### PR TITLE
Enrich carnot-theorem OQ-children cluster: add references (8 entries)

### DIFF
--- a/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-01/meta.json
@@ -74,6 +74,28 @@
     "theoremCount": 8,
     "definitionCount": 7
   },
+  "overview": {
+    "historicalContext": "Carnot's theorem (Lazare Carnot, 1803) states that the sum of the signed distances from the circumcenter of a triangle to its three sides equals R + r, the sum of the circumradius and the inradius — with a side's contribution counted negative when the circumcenter lies on the far side of that side, as happens at an obtuse angle. The parent gallery entries formalize only the equivalent angle identity cos A + cos B + cos C = 1 + r/R, living in a bespoke trigonometric encoding with no actual triangle, circumcenter, or distances. The parent explicitly left open whether the genuinely metric statement — with an explicit circumcenter and real perpendicular distances over EuclideanSpace ℝ (Fin 2) — could be formalized. This entry does exactly that.",
+    "problemStatement": "Realize a triangle with circumradius R > 0 and angles A, B, C > 0 (A + B + C = π) concretely in EuclideanSpace ℝ (Fin 2): place the circumcenter at an explicit point and the vertices on the circle of radius R about it. Define the signed perpendicular distances from the circumcenter to the three sides (with the orientation convention that makes obtuse contributions negative) and prove that they sum to R + r, where r is the inradius.",
+    "text": "Place the circumcenter at the origin O = (0,0) and the vertices on the radius-R circle. The signed perpendicular distance from O to each side is exactly R cos of the opposite angle, and the three sum to R + r.",
+    "proofStrategy": "Place the circumcenter at O = (0,0) and the vertices Pa, Pb, Pc on the circle of radius R, at position angles chosen by the inscribed-angle convention (side BC subtends central angle 2A, etc.). For a chord, the foot of the perpendicular from the center is its midpoint, whose direction is the chord's midangle μ; the inward unit normal to that side is therefore −(cos μ, sin μ). Taking Mathlib's signedDist (= ⟪normalize v, q −ᵥ p⟫) from O along this normal, the normalize drops once the normal is shown to be a unit vector (sin² + cos² = 1), and the inner product collapses by cos(x − y) to exactly R cos of the opposite angle — negative precisely in the obtuse case, with no manual case split. Each normal is independently certified perpendicular to its side, and O is certified equidistant (= R) from the three vertices, so it genuinely is the circumcenter. Summing the three signed distances gives R(cos A + cos B + cos C), and the parent angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), scaled by R, turns this into R + r.",
+    "keyInsights": [
+      "**Center-to-chord = midpoint, so the inward unit normal is −(cos μ, sin μ)**: the perpendicular foot from the circumcenter to a chord is the chord's midpoint, whose direction is the chord's midangle μ; this makes every side normal an explicit unit vector and the signed distance a one-line inner product",
+      "**Mathlib's signedDist carries the obtuse sign for free**: writing the distance as ⟪normalize v, O −ᵥ p⟫ with v the inward normal yields exactly R cos of the opposite angle, whose sign already flips for obtuse triangles — the orientation bookkeeping that makes the metric form hard is handled by the cosine itself",
+      "**The metric statement is the angle statement scaled by R**: each signed distance is R cos(angle), so the whole theorem reduces to the parent identity multiplied by R — the geometric content is entirely in the dA_eq/dB_eq/dC_eq distance computations",
+      "**An explicit, certified circumcenter**: O = (0,0) is not assumed to be the circumcenter — it is proved equidistant from the three explicitly-placed vertices, anchoring the construction in genuine Euclidean geometry rather than a coordinate fiction"
+    ],
+    "prerequisites": [
+      "Euclidean plane EuclideanSpace ℝ (Fin 2): norms, inner products, and the !₂[·,·] coordinate notation",
+      "Mathlib's signedDist (trilinear signed distance) and normalize",
+      "Trigonometric identities cos(x ± y) and sin² + cos² = 1, plus the inscribed-angle convention relating central and inscribed angles",
+      "The parent Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)"
+    ],
+    "openQuestions": [
+      "Can the construction be repackaged through Mathlib's Affine.Simplex.circumcenter / circumradius API so the circumcenter is derived from the triangle rather than placed by hand, recovering the same R + r identity?",
+      "Does the same explicit signed-distance technique extend to the excircles, giving the signed-distance forms d_a − d_b − d_c = R − r_A for the exradii?"
+    ]
+  },
   "sections": [
     {
       "title": "Module header",
@@ -132,36 +154,6 @@
       "id": "main-theorem"
     }
   ],
-  "overview": {
-    "historicalContext": "Carnot's theorem (Lazare Carnot, 1803) states that the sum of the signed distances from the circumcenter of a triangle to its three sides equals R + r, the sum of the circumradius and the inradius — with a side's contribution counted negative when the circumcenter lies on the far side of that side, as happens at an obtuse angle. The parent gallery entries formalize only the equivalent angle identity cos A + cos B + cos C = 1 + r/R, living in a bespoke trigonometric encoding with no actual triangle, circumcenter, or distances. The parent explicitly left open whether the genuinely metric statement — with an explicit circumcenter and real perpendicular distances over EuclideanSpace ℝ (Fin 2) — could be formalized. This entry does exactly that.",
-    "problemStatement": "Realize a triangle with circumradius R > 0 and angles A, B, C > 0 (A + B + C = π) concretely in EuclideanSpace ℝ (Fin 2): place the circumcenter at an explicit point and the vertices on the circle of radius R about it. Define the signed perpendicular distances from the circumcenter to the three sides (with the orientation convention that makes obtuse contributions negative) and prove that they sum to R + r, where r is the inradius.",
-    "text": "Place the circumcenter at the origin O = (0,0) and the vertices on the radius-R circle. The signed perpendicular distance from O to each side is exactly R cos of the opposite angle, and the three sum to R + r.",
-    "proofStrategy": "Place the circumcenter at O = (0,0) and the vertices Pa, Pb, Pc on the circle of radius R, at position angles chosen by the inscribed-angle convention (side BC subtends central angle 2A, etc.). For a chord, the foot of the perpendicular from the center is its midpoint, whose direction is the chord's midangle μ; the inward unit normal to that side is therefore −(cos μ, sin μ). Taking Mathlib's signedDist (= ⟪normalize v, q −ᵥ p⟫) from O along this normal, the normalize drops once the normal is shown to be a unit vector (sin² + cos² = 1), and the inner product collapses by cos(x − y) to exactly R cos of the opposite angle — negative precisely in the obtuse case, with no manual case split. Each normal is independently certified perpendicular to its side, and O is certified equidistant (= R) from the three vertices, so it genuinely is the circumcenter. Summing the three signed distances gives R(cos A + cos B + cos C), and the parent angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), scaled by R, turns this into R + r.",
-    "keyInsights": [
-      "**Center-to-chord = midpoint, so the inward unit normal is −(cos μ, sin μ)**: the perpendicular foot from the circumcenter to a chord is the chord's midpoint, whose direction is the chord's midangle μ; this makes every side normal an explicit unit vector and the signed distance a one-line inner product",
-      "**Mathlib's signedDist carries the obtuse sign for free**: writing the distance as ⟪normalize v, O −ᵥ p⟫ with v the inward normal yields exactly R cos of the opposite angle, whose sign already flips for obtuse triangles — the orientation bookkeeping that makes the metric form hard is handled by the cosine itself",
-      "**The metric statement is the angle statement scaled by R**: each signed distance is R cos(angle), so the whole theorem reduces to the parent identity multiplied by R — the geometric content is entirely in the dA_eq/dB_eq/dC_eq distance computations",
-      "**An explicit, certified circumcenter**: O = (0,0) is not assumed to be the circumcenter — it is proved equidistant from the three explicitly-placed vertices, anchoring the construction in genuine Euclidean geometry rather than a coordinate fiction"
-    ],
-    "prerequisites": [
-      "Euclidean plane EuclideanSpace ℝ (Fin 2): norms, inner products, and the !₂[·,·] coordinate notation",
-      "Mathlib's signedDist (trilinear signed distance) and normalize",
-      "Trigonometric identities cos(x ± y) and sin² + cos² = 1, plus the inscribed-angle convention relating central and inscribed angles",
-      "The parent Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)"
-    ],
-    "openQuestions": [
-      "Can the construction be repackaged through Mathlib's Affine.Simplex.circumcenter / circumradius API so the circumcenter is derived from the triangle rather than placed by hand, recovering the same R + r identity?",
-      "Does the same explicit signed-distance technique extend to the excircles, giving the signed-distance forms d_a − d_b − d_c = R − r_A for the exradii?"
-    ]
-  },
-  "conclusion": {
-    "summary": "Carnot's theorem is formalized in genuinely metric form over EuclideanSpace ℝ (Fin 2): with the circumcenter placed at the explicit point O = (0,0) and the vertices on the radius-R circle (O certified equidistant from all three), each signed perpendicular distance from O to a side equals R cos of the opposite angle, and the three sum to R + r. The obtuse-case sign is carried automatically by Mathlib's signedDist. This answers the parent entry's open question. Axiom- and sorry-free.",
-    "implications": "**Theoretical Significance**: The entry closes the gap between the parent's analytic angle identity and the classical metric statement of Carnot's theorem, showing that the much-feared orientation bookkeeping (a side's distance flipping sign at an obtuse angle) needs no case analysis once the signed distance is taken along the inward unit normal: the cosine supplies the sign. It anchors Carnot's theorem in Mathlib's signedDist / EuclideanSpace API, making it composable with other Euclidean-geometry formalizations.",
-    "openQuestions": [
-      "Repackage through Mathlib's Affine.Simplex.circumcenter API so the circumcenter is derived rather than placed by hand.",
-      "Extend the signed-distance technique to the excircles (exradius forms d_a − d_b − d_c = R − r_A)."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "carnot-theorem-oq-01-oq-01",
@@ -174,7 +166,43 @@
       "description": "The root Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), scaled by R, is what turns the sum of signed distances R(cos A + cos B + cos C) into R + r."
     }
   ],
-  "sorries": 0,
+  "conclusion": {
+    "summary": "Carnot's theorem is formalized in genuinely metric form over EuclideanSpace ℝ (Fin 2): with the circumcenter placed at the explicit point O = (0,0) and the vertices on the radius-R circle (O certified equidistant from all three), each signed perpendicular distance from O to a side equals R cos of the opposite angle, and the three sum to R + r. The obtuse-case sign is carried automatically by Mathlib's signedDist. This answers the parent entry's open question. Axiom- and sorry-free.",
+    "implications": "**Theoretical Significance**: The entry closes the gap between the parent's analytic angle identity and the classical metric statement of Carnot's theorem, showing that the much-feared orientation bookkeeping (a side's distance flipping sign at an obtuse angle) needs no case analysis once the signed distance is taken along the inward unit normal: the cosine supplies the sign. It anchors Carnot's theorem in Mathlib's signedDist / EuclideanSpace API, making it composable with other Euclidean-geometry formalizations.",
+    "openQuestions": [
+      "Repackage through Mathlib's Affine.Simplex.circumcenter API so the circumcenter is derived rather than placed by hand.",
+      "Extend the signed-distance technique to the excircles (exradius forms d_a − d_b − d_c = R − r_A)."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Carnot, Lazare N. M.",
+      "title": "Géométrie de position",
+      "year": "1803",
+      "venue": "J. B. M. Duprat, Paris",
+      "note": "Origin of Carnot's theorem on signed distances from the circumcenter to the sides."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Carnot's theorem, circumradius/inradius relations, and triangle trigonometry."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin",
+      "note": "Comprehensive classical triangle geometry."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry circumradius/inradius, Real.cos/sin identities and inner-product-space triangle API (Mathlib.Geometry.Euclidean / Mathlib.Analysis.SpecialFunctions.Trigonometric)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -192,5 +220,6 @@
     "definitionCount": 7,
     "sorries": 0,
     "path": "Proofs/CarnotTheoremOQ01OQ01OQ01.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-02/meta.json
@@ -75,6 +75,27 @@
     "theoremCount": 5,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "Carnot's theorem on the inradius and circumradius has as its analytic core the angle identity cos A + cos B + cos C = 1 + r/R and the fundamental polynomial identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1. The sibling entries extract the linear cosine-sum range (1, 3/2] and the acute/right/obtuse trichotomy of the squared sum against 1. What those leave open is the sharp lower extremum of the squared cosine sum — the smallest value it can take over all triangles. This entry supplies it: cos²A + cos²B + cos²C ≥ 3/4, with equality exactly at the equilateral triangle, equivalent to the classical inequality cos A cos B cos C ≤ 1/8.",
+    "problemStatement": "For a triangle with angles A, B, C > 0 and A + B + C = π, prove the sharp bound cos A cos B cos C ≤ 1/8 (equivalently cos²A + cos²B + cos²C ≥ 3/4) with equality if and only if the triangle is equilateral.",
+    "text": "The product of a triangle's angle cosines never exceeds 1/8, and its squared cosine sum never drops below 3/4 — both extremes hit only by the equilateral triangle.",
+    "proofStrategy": "Write the product-to-sum form cos A cos B = ½(cos(A-B) + cos(A+B)) and use A + B = π - C, so cos(A+B) = -cos C and cos A cos B = ½(cos(A-B) - cos C). Substituting and completing the square against cos²(A-B) + sin²(A-B) = 1 yields the single identity\n\n  1 - 8 cos A cos B cos C = (2 cos C - cos(A-B))² + sin²(A-B).\n\n1. **Product bound**: the right-hand side is a sum of two squares, hence ≥ 0, so cos A cos B cos C ≤ 1/8. This uses only A + B + C = π — no acute/obtuse case split.\n2. **Squared-sum bound**: the sibling identity cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C turns the product bound into cos²A + cos²B + cos²C ≥ 1 - 2(1/8) = 3/4.\n3. **Equality**: cos A cos B cos C = 1/8 makes the right-hand side zero, forcing both squares to vanish. sin(A-B) = 0 with |A-B| < π gives A = B; then cos(A-B) = 1 and 2 cos C = 1, so cos C = 1/2 and C = π/3 by injectivity of cosine on [0, π]; the angle sum then forces A = B = π/3.",
+    "keyInsights": [
+      "**One sum-of-squares identity does everything**: 1 - 8 cos A cos B cos C = (2 cos C - cos(A-B))² + sin²(A-B), so the bound cos A cos B cos C ≤ 1/8 is a single nonnegativity statement",
+      "**The bound is sign-agnostic**: it holds for every real triple summing to π, never splitting on whether the triangle is acute or obtuse — positivity of the angles enters only to pin the equality case",
+      "**The genuine lower extremum of the squared cosine sum is 3/4**: where the sibling entry compares cos²A + cos²B + cos²C only to the threshold 1, this entry gives its sharp minimum, attained at the equilateral triangle",
+      "**Equality is rigid**: vanishing of the two squares forces A = B (from sin(A-B) = 0) and C = π/3 (from 2 cos C = cos(A-B) = 1), i.e. the equilateral triangle"
+    ],
+    "prerequisites": [
+      "Real trigonometric functions cos, sin, the addition formulas, and the pythagorean identity",
+      "The sibling rearranged identity cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C",
+      "Injectivity of cosine on [0, π] and the zero set of sine on (-π, π)"
+    ],
+    "openQuestions": [
+      "Does the companion sharp bound sin A sin B sin C ≤ 3√3/8 (equivalently a sharp upper bound on the squared sine sum) admit the same one-identity sum-of-squares treatment?",
+      "Can the product bound be promoted to the full equilateral extremality statement for the elementary symmetric functions of the angle cosines, unifying the linear, quadratic, and cubic cases proved across these sibling entries?"
+    ]
+  },
   "sections": [
     {
       "title": "Module header",
@@ -125,35 +146,6 @@
       "id": "sqsum-equality"
     }
   ],
-  "overview": {
-    "historicalContext": "Carnot's theorem on the inradius and circumradius has as its analytic core the angle identity cos A + cos B + cos C = 1 + r/R and the fundamental polynomial identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1. The sibling entries extract the linear cosine-sum range (1, 3/2] and the acute/right/obtuse trichotomy of the squared sum against 1. What those leave open is the sharp lower extremum of the squared cosine sum — the smallest value it can take over all triangles. This entry supplies it: cos²A + cos²B + cos²C ≥ 3/4, with equality exactly at the equilateral triangle, equivalent to the classical inequality cos A cos B cos C ≤ 1/8.",
-    "problemStatement": "For a triangle with angles A, B, C > 0 and A + B + C = π, prove the sharp bound cos A cos B cos C ≤ 1/8 (equivalently cos²A + cos²B + cos²C ≥ 3/4) with equality if and only if the triangle is equilateral.",
-    "text": "The product of a triangle's angle cosines never exceeds 1/8, and its squared cosine sum never drops below 3/4 — both extremes hit only by the equilateral triangle.",
-    "proofStrategy": "Write the product-to-sum form cos A cos B = ½(cos(A-B) + cos(A+B)) and use A + B = π - C, so cos(A+B) = -cos C and cos A cos B = ½(cos(A-B) - cos C). Substituting and completing the square against cos²(A-B) + sin²(A-B) = 1 yields the single identity\n\n  1 - 8 cos A cos B cos C = (2 cos C - cos(A-B))² + sin²(A-B).\n\n1. **Product bound**: the right-hand side is a sum of two squares, hence ≥ 0, so cos A cos B cos C ≤ 1/8. This uses only A + B + C = π — no acute/obtuse case split.\n2. **Squared-sum bound**: the sibling identity cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C turns the product bound into cos²A + cos²B + cos²C ≥ 1 - 2(1/8) = 3/4.\n3. **Equality**: cos A cos B cos C = 1/8 makes the right-hand side zero, forcing both squares to vanish. sin(A-B) = 0 with |A-B| < π gives A = B; then cos(A-B) = 1 and 2 cos C = 1, so cos C = 1/2 and C = π/3 by injectivity of cosine on [0, π]; the angle sum then forces A = B = π/3.",
-    "keyInsights": [
-      "**One sum-of-squares identity does everything**: 1 - 8 cos A cos B cos C = (2 cos C - cos(A-B))² + sin²(A-B), so the bound cos A cos B cos C ≤ 1/8 is a single nonnegativity statement",
-      "**The bound is sign-agnostic**: it holds for every real triple summing to π, never splitting on whether the triangle is acute or obtuse — positivity of the angles enters only to pin the equality case",
-      "**The genuine lower extremum of the squared cosine sum is 3/4**: where the sibling entry compares cos²A + cos²B + cos²C only to the threshold 1, this entry gives its sharp minimum, attained at the equilateral triangle",
-      "**Equality is rigid**: vanishing of the two squares forces A = B (from sin(A-B) = 0) and C = π/3 (from 2 cos C = cos(A-B) = 1), i.e. the equilateral triangle"
-    ],
-    "prerequisites": [
-      "Real trigonometric functions cos, sin, the addition formulas, and the pythagorean identity",
-      "The sibling rearranged identity cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C",
-      "Injectivity of cosine on [0, π] and the zero set of sine on (-π, π)"
-    ],
-    "openQuestions": [
-      "Does the companion sharp bound sin A sin B sin C ≤ 3√3/8 (equivalently a sharp upper bound on the squared sine sum) admit the same one-identity sum-of-squares treatment?",
-      "Can the product bound be promoted to the full equilateral extremality statement for the elementary symmetric functions of the angle cosines, unifying the linear, quadratic, and cubic cases proved across these sibling entries?"
-    ]
-  },
-  "conclusion": {
-    "summary": "For a triangle the product of the angle cosines satisfies cos A cos B cos C ≤ 1/8 and the squared cosine sum satisfies cos²A + cos²B + cos²C ≥ 3/4, each with equality exactly at the equilateral triangle. The proof rests on one sum-of-squares identity, 1 - 8 cos A cos B cos C = (2 cos C - cos(A-B))² + sin²(A-B), which is sign-agnostic; the equality case is identified using only the positivity of the angles. All results are axiom- and sorry-free.",
-    "implications": "**Theoretical Significance**: The entry supplies the sharp lower extremum of the squared cosine sum that the sibling trichotomy leaves open, exhibiting the cubic symmetric form cos A cos B cos C as the analytic partner of the linear and quadratic forms already formalized. Together the three follow-ups bound the elementary symmetric functions of a triangle's angle cosines, each extremized by the equilateral triangle.",
-    "openQuestions": [
-      "A one-identity sum-of-squares proof of the companion product-of-sines bound sin A sin B sin C ≤ 3√3/8?",
-      "A unified equilateral-extremality statement for all elementary symmetric functions of the angle cosines?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "carnot-theorem-oq-01-oq-01",
@@ -166,7 +158,43 @@
       "description": "The squared-sum sibling supplies the identity cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C used here to convert the product bound into the sharp lower bound 3/4, and classifies the squared sum against 1 where this entry gives its minimum."
     }
   ],
-  "sorries": 0,
+  "conclusion": {
+    "summary": "For a triangle the product of the angle cosines satisfies cos A cos B cos C ≤ 1/8 and the squared cosine sum satisfies cos²A + cos²B + cos²C ≥ 3/4, each with equality exactly at the equilateral triangle. The proof rests on one sum-of-squares identity, 1 - 8 cos A cos B cos C = (2 cos C - cos(A-B))² + sin²(A-B), which is sign-agnostic; the equality case is identified using only the positivity of the angles. All results are axiom- and sorry-free.",
+    "implications": "**Theoretical Significance**: The entry supplies the sharp lower extremum of the squared cosine sum that the sibling trichotomy leaves open, exhibiting the cubic symmetric form cos A cos B cos C as the analytic partner of the linear and quadratic forms already formalized. Together the three follow-ups bound the elementary symmetric functions of a triangle's angle cosines, each extremized by the equilateral triangle.",
+    "openQuestions": [
+      "A one-identity sum-of-squares proof of the companion product-of-sines bound sin A sin B sin C ≤ 3√3/8?",
+      "A unified equilateral-extremality statement for all elementary symmetric functions of the angle cosines?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Mitrinović, D. S.; Pečarić, J. E.; Volenec, V.",
+      "title": "Recent Advances in Geometric Inequalities",
+      "year": "1989",
+      "venue": "Kluwer Academic",
+      "note": "Sharp bounds for triangle cosine and sine sums."
+    },
+    {
+      "authors": "Andreescu, Titu and Andrica, Dorin",
+      "title": "Complex Numbers from A to ...Z, and triangle trigonometric identities",
+      "year": "2006",
+      "venue": "Birkhäuser",
+      "note": "Triangle trigonometric identities and extremal angle-sum inequalities."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Carnot's theorem, circumradius/inradius relations, and triangle trigonometry."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry circumradius/inradius, Real.cos/sin identities and inner-product-space triangle API (Mathlib.Geometry.Euclidean / Mathlib.Analysis.SpecialFunctions.Trigonometric)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -183,5 +211,6 @@
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/CarnotTheoremOQ01OQ01OQ02.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/carnot-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-01/meta.json
@@ -76,6 +76,28 @@
     "theoremCount": 6,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "Euler's inequality r ≤ R/2 — the inradius of a triangle is at most half its circumradius, with equality only for the equilateral triangle — was published by Leonhard Euler in 1765, though it had been stated earlier by William Chapple (1746). It is one of the most classical of all triangle inequalities. This entry derives it as a corollary of the parent file's angle form of Carnot's theorem, cos A + cos B + cos C = 1 + r/R: since r/R = 4 sin(A/2) sin(B/2) sin(C/2), bounding the cosine sum above by 3/2 is exactly the statement r/R ≤ 1/2. The cosine sum itself ranges over (1, 3/2] for an actual triangle, the lower endpoint approached by degenerate triangles and the upper endpoint attained by the equilateral one.",
+    "problemStatement": "For a triangle with angles A, B, C > 0 and A + B + C = π, prove the sharp bounds\n\n  1 < cos A + cos B + cos C ≤ 3/2,\n\nwith equality at 3/2 if and only if the triangle is equilateral, and deduce Euler's inequality 4 sin(A/2) sin(B/2) sin(C/2) ≤ 1/2 (equivalently r ≤ R/2).",
+    "text": "The sum of the cosines of a triangle's angles lies in (1, 3/2], maximized by the equilateral triangle; equivalently the inradius is at most half the circumradius (Euler's inequality).",
+    "proofStrategy": "Everything rests on one algebraic decomposition obtained from the sum-to-product identity. Writing cos A + cos B = 2 cos((A+B)/2) cos((A-B)/2) and using (A+B)/2 = π/2 - C/2 (so the leading cosine becomes sin(C/2)) together with cos C = 1 - 2 sin²(C/2) gives\n\n  cos A + cos B + cos C = 1 + 2 sin(C/2) cos((A-B)/2) - 2 sin²(C/2).\n\nCompleting the square rewrites the gap to 3/2 as a sum of two manifestly nonnegative terms:\n\n  3/2 - (cos A + cos B + cos C) = 2(sin(C/2) - 1/2)² + 2 sin(C/2)(1 - cos((A-B)/2)).\n\n1. **Upper bound**: both terms are ≥ 0 (sin(C/2) ≥ 0, cos((A-B)/2) ≤ 1), so the sum is ≤ 3/2.\n2. **Equality**: the two terms vanish simultaneously iff sin(C/2) = 1/2 and cos((A-B)/2) = 1, i.e. C = π/3 and A = B, forcing the equilateral triangle.\n3. **Lower bound**: through the parent identity the sum is 1 + 4 sin(A/2) sin(B/2) sin(C/2), and the three half-angle sines are positive on (0, π/2), so the sum exceeds 1.\n4. **Euler's inequality**: the upper bound 1 + 4 sin(A/2) sin(B/2) sin(C/2) ≤ 3/2 rearranges to 4 sin(A/2) sin(B/2) sin(C/2) ≤ 1/2, i.e. r ≤ R/2.\n\nThe argument never splits on acute/obtuse — it uses only A, B, C > 0 and A + B + C = π.",
+    "keyInsights": [
+      "**The gap to 3/2 is a perfect square plus a nonnegative product**: cos A + cos B + cos C = 3/2 - 2(sin(C/2) - 1/2)² - 2 sin(C/2)(1 - cos((A-B)/2)), so the bound, its equality case, and the equilateral extremizer all fall out of one decomposition",
+      "**Range correspondence**: through the parent identity cos sum = 1 + r/R, the analytic range (1, 3/2] of the cosine sum is exactly the geometric range (0, 1/2] of r/R — Euler's inequality is the upper bound restated",
+      "**Sign-agnostic**: the proof uses only A, B, C > 0 and A + B + C = π, avoiding the acute/obtuse case split that the metric signed-distance form of Carnot's theorem requires",
+      "**Two simple endpoint facts pin the extremizer**: sin(C/2) = 1/2 (via injectivity of sin near 0) gives C = π/3, and cos((A-B)/2) = 1 (via cos x = 1 ⟺ x = 0) gives A = B — together the equilateral triangle"
+    ],
+    "prerequisites": [
+      "Real trigonometric functions sin and cos",
+      "Sum-to-product and double-angle identities",
+      "Monotonicity/injectivity of sin near 0 and the characterization cos x = 1 ⟺ x = 0",
+      "The parent Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)"
+    ],
+    "openQuestions": [
+      "Can the originally-scoped metric signed-distance form of Carnot's theorem (sum of signed circumcenter-to-side distances = R + r) be formalized directly over EuclideanSpace ℝ (Fin 2) with an explicit circumcenter? This remains open; the present entry is a tractable analytic follow-up.",
+      "Is there a spherical or hyperbolic analogue of the cosine-sum range and the corresponding Euler-type inequality?"
+    ]
+  },
   "sections": [
     {
       "title": "Module header",
@@ -126,28 +148,13 @@
       "id": "equality-case"
     }
   ],
-  "overview": {
-    "historicalContext": "Euler's inequality r ≤ R/2 — the inradius of a triangle is at most half its circumradius, with equality only for the equilateral triangle — was published by Leonhard Euler in 1765, though it had been stated earlier by William Chapple (1746). It is one of the most classical of all triangle inequalities. This entry derives it as a corollary of the parent file's angle form of Carnot's theorem, cos A + cos B + cos C = 1 + r/R: since r/R = 4 sin(A/2) sin(B/2) sin(C/2), bounding the cosine sum above by 3/2 is exactly the statement r/R ≤ 1/2. The cosine sum itself ranges over (1, 3/2] for an actual triangle, the lower endpoint approached by degenerate triangles and the upper endpoint attained by the equilateral one.",
-    "problemStatement": "For a triangle with angles A, B, C > 0 and A + B + C = π, prove the sharp bounds\n\n  1 < cos A + cos B + cos C ≤ 3/2,\n\nwith equality at 3/2 if and only if the triangle is equilateral, and deduce Euler's inequality 4 sin(A/2) sin(B/2) sin(C/2) ≤ 1/2 (equivalently r ≤ R/2).",
-    "text": "The sum of the cosines of a triangle's angles lies in (1, 3/2], maximized by the equilateral triangle; equivalently the inradius is at most half the circumradius (Euler's inequality).",
-    "proofStrategy": "Everything rests on one algebraic decomposition obtained from the sum-to-product identity. Writing cos A + cos B = 2 cos((A+B)/2) cos((A-B)/2) and using (A+B)/2 = π/2 - C/2 (so the leading cosine becomes sin(C/2)) together with cos C = 1 - 2 sin²(C/2) gives\n\n  cos A + cos B + cos C = 1 + 2 sin(C/2) cos((A-B)/2) - 2 sin²(C/2).\n\nCompleting the square rewrites the gap to 3/2 as a sum of two manifestly nonnegative terms:\n\n  3/2 - (cos A + cos B + cos C) = 2(sin(C/2) - 1/2)² + 2 sin(C/2)(1 - cos((A-B)/2)).\n\n1. **Upper bound**: both terms are ≥ 0 (sin(C/2) ≥ 0, cos((A-B)/2) ≤ 1), so the sum is ≤ 3/2.\n2. **Equality**: the two terms vanish simultaneously iff sin(C/2) = 1/2 and cos((A-B)/2) = 1, i.e. C = π/3 and A = B, forcing the equilateral triangle.\n3. **Lower bound**: through the parent identity the sum is 1 + 4 sin(A/2) sin(B/2) sin(C/2), and the three half-angle sines are positive on (0, π/2), so the sum exceeds 1.\n4. **Euler's inequality**: the upper bound 1 + 4 sin(A/2) sin(B/2) sin(C/2) ≤ 3/2 rearranges to 4 sin(A/2) sin(B/2) sin(C/2) ≤ 1/2, i.e. r ≤ R/2.\n\nThe argument never splits on acute/obtuse — it uses only A, B, C > 0 and A + B + C = π.",
-    "keyInsights": [
-      "**The gap to 3/2 is a perfect square plus a nonnegative product**: cos A + cos B + cos C = 3/2 - 2(sin(C/2) - 1/2)² - 2 sin(C/2)(1 - cos((A-B)/2)), so the bound, its equality case, and the equilateral extremizer all fall out of one decomposition",
-      "**Range correspondence**: through the parent identity cos sum = 1 + r/R, the analytic range (1, 3/2] of the cosine sum is exactly the geometric range (0, 1/2] of r/R — Euler's inequality is the upper bound restated",
-      "**Sign-agnostic**: the proof uses only A, B, C > 0 and A + B + C = π, avoiding the acute/obtuse case split that the metric signed-distance form of Carnot's theorem requires",
-      "**Two simple endpoint facts pin the extremizer**: sin(C/2) = 1/2 (via injectivity of sin near 0) gives C = π/3, and cos((A-B)/2) = 1 (via cos x = 1 ⟺ x = 0) gives A = B — together the equilateral triangle"
-    ],
-    "prerequisites": [
-      "Real trigonometric functions sin and cos",
-      "Sum-to-product and double-angle identities",
-      "Monotonicity/injectivity of sin near 0 and the characterization cos x = 1 ⟺ x = 0",
-      "The parent Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)"
-    ],
-    "openQuestions": [
-      "Can the originally-scoped metric signed-distance form of Carnot's theorem (sum of signed circumcenter-to-side distances = R + r) be formalized directly over EuclideanSpace ℝ (Fin 2) with an explicit circumcenter? This remains open; the present entry is a tractable analytic follow-up.",
-      "Is there a spherical or hyperbolic analogue of the cosine-sum range and the corresponding Euler-type inequality?"
-    ]
-  },
+  "crossReferences": [
+    {
+      "targetId": "carnot-theorem-oq-01",
+      "relationship": "parent",
+      "description": "The parent angle form cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2) is used directly: the lower bound and Euler's inequality are read off it, and the upper bound 3/2 on the cosine sum is the inequality r/R ≤ 1/2."
+    }
+  ],
   "conclusion": {
     "summary": "For a triangle the cosine sum cos A + cos B + cos C lies in the sharp range (1, 3/2], with the maximum 3/2 attained exactly by the equilateral triangle. The upper bound is Euler's inequality r ≤ R/2 restated through the parent Carnot angle identity. All four headline results are axiom- and sorry-free, resting on a single completing-the-square decomposition.",
     "implications": "**Theoretical Significance**: The entry shows that Euler's classical inradius/circumradius inequality and the sharp triangle cosine-sum range are two faces of one elementary algebraic decomposition, derived without any acute/obtuse case analysis. It complements the parent angle form of Carnot's theorem by exhibiting the exact range of the quantity that the parent identity computes.",
@@ -156,14 +163,35 @@
       "Spherical/hyperbolic analogue of the cosine-sum range?"
     ]
   },
-  "crossReferences": [
+  "references": [
     {
-      "targetId": "carnot-theorem-oq-01",
-      "relationship": "parent",
-      "description": "The parent angle form cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2) is used directly: the lower bound and Euler's inequality are read off it, and the upper bound 3/2 on the cosine sum is the inequality r/R ≤ 1/2."
+      "authors": "Mitrinović, D. S.; Pečarić, J. E.; Volenec, V.",
+      "title": "Recent Advances in Geometric Inequalities",
+      "year": "1989",
+      "venue": "Kluwer Academic",
+      "note": "Sharp bounds for triangle cosine and sine sums."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Carnot's theorem, circumradius/inradius relations, and triangle trigonometry."
+    },
+    {
+      "authors": "Andreescu, Titu and Andrica, Dorin",
+      "title": "Complex Numbers from A to ...Z, and triangle trigonometric identities",
+      "year": "2006",
+      "venue": "Birkhäuser",
+      "note": "Triangle trigonometric identities and extremal angle-sum inequalities."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry circumradius/inradius, Real.cos/sin identities and inner-product-space triangle API (Mathlib.Geometry.Euclidean / Mathlib.Analysis.SpecialFunctions.Trigonometric)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ],
-  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -179,5 +207,6 @@
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/CarnotTheoremOQ01OQ01.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/carnot-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-02/meta.json
@@ -60,6 +60,27 @@
     "theoremCount": 7,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "Carnot's theorem on the inradius and circumradius states that the sum of the signed distances from the circumcenter of a triangle to its three sides equals R + r. Its analytic core is the pair of identities proved in the parent file: the angle form cos A + cos B + cos C = 1 + r/R and the fundamental polynomial identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1. This entry exploits the second one. Written as cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C, it shows that the value of the squared cosine sum relative to 1 is a pure read-off of the sign of the product of cosines — and for a genuine triangle that sign is exactly the classical acute/right/obtuse dichotomy.",
+    "problemStatement": "For a triangle with angles A, B, C > 0 and A + B + C = π, prove that cos²A + cos²B + cos²C < 1 if and only if the triangle is acute, equals 1 if and only if it is right, and exceeds 1 if and only if it is obtuse — all from the parent fundamental identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1.",
+    "text": "The squared cosine sum of a triangle's angles compares to 1 exactly as the triangle is acute, right, or obtuse — a trichotomy that falls straight out of the sign of cos A cos B cos C.",
+    "proofStrategy": "Rearranging the parent identity gives cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C, so the whole question reduces to the sign of P := cos A cos B cos C. The key elementary fact is that at most one angle of a triangle can be ≥ π/2, because if two were, their sum alone would reach π and the third positive angle would push the total past π.\n\n1. **Acute** (all angles < π/2): each cosine is positive (cos is positive on (0, π/2)), so P > 0 and the squared sum is < 1.\n2. **Right** (one angle = π/2): that cosine is 0, so P = 0 and the squared sum is exactly 1.\n3. **Obtuse** (one angle > π/2): that cosine is negative; the other two angles are forced below π/2 (they sum to less than π/2), so their cosines are positive and P < 0, making the squared sum > 1.\n4. **Trichotomy iff**: the backward direction of cos²A + cos²B + cos²C < 1 ⇔ acute is the acute case; the forward direction is its contrapositive — if some angle is ≥ π/2 then a non-strict version of the obtuse argument gives the squared sum ≥ 1. Symmetry across the three angles is handled by applying the same lemma with each angle placed first.\n\nNo metric data and no completing-the-square is needed; the argument is purely about cosine signs.",
+    "keyInsights": [
+      "**The squared cosine sum is 1 minus twice the product of cosines**: cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C, so everything about its position relative to 1 is encoded in the sign of cos A cos B cos C",
+      "**Sign of the product = triangle type**: at most one angle can reach π/2, so the product of cosines is positive (acute), zero (right), or negative (obtuse) — exactly tracking the classical classification",
+      "**A classification theorem with no metric input**: the acute/right/obtuse split is recovered from only A, B, C > 0, the angle sum, and the sign of cos on (0, π/2) and (π/2, π)",
+      "**Complements the linear cosine-sum range**: where the sibling entry pins the range (1, 3/2] of cos A + cos B + cos C, this one reads the *squared* sum against the single threshold 1"
+    ],
+    "prerequisites": [
+      "Real trigonometric function cos and its sign on (0, π/2), at π/2, and on (π/2, π)",
+      "The parent Carnot fundamental identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1",
+      "The elementary fact that at most one angle of a triangle is ≥ π/2"
+    ],
+    "openQuestions": [
+      "Does an analogous product-sign trichotomy hold for the polynomial cos²A + cos²B + cos²C - 2 cos A cos B cos C, or for higher symmetric functions of the angle cosines?",
+      "Can the metric signed-distance form of Carnot's theorem (signed circumcenter-to-side distances summing to R + r) be formalized over EuclideanSpace ℝ (Fin 2), making the acute/obtuse sign of each signed distance match the cosine-sign trichotomy proved here?"
+    ]
+  },
   "sections": [
     {
       "title": "Module header",
@@ -110,35 +131,6 @@
       "id": "trichotomy-iff"
     }
   ],
-  "overview": {
-    "historicalContext": "Carnot's theorem on the inradius and circumradius states that the sum of the signed distances from the circumcenter of a triangle to its three sides equals R + r. Its analytic core is the pair of identities proved in the parent file: the angle form cos A + cos B + cos C = 1 + r/R and the fundamental polynomial identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1. This entry exploits the second one. Written as cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C, it shows that the value of the squared cosine sum relative to 1 is a pure read-off of the sign of the product of cosines — and for a genuine triangle that sign is exactly the classical acute/right/obtuse dichotomy.",
-    "problemStatement": "For a triangle with angles A, B, C > 0 and A + B + C = π, prove that cos²A + cos²B + cos²C < 1 if and only if the triangle is acute, equals 1 if and only if it is right, and exceeds 1 if and only if it is obtuse — all from the parent fundamental identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1.",
-    "text": "The squared cosine sum of a triangle's angles compares to 1 exactly as the triangle is acute, right, or obtuse — a trichotomy that falls straight out of the sign of cos A cos B cos C.",
-    "proofStrategy": "Rearranging the parent identity gives cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C, so the whole question reduces to the sign of P := cos A cos B cos C. The key elementary fact is that at most one angle of a triangle can be ≥ π/2, because if two were, their sum alone would reach π and the third positive angle would push the total past π.\n\n1. **Acute** (all angles < π/2): each cosine is positive (cos is positive on (0, π/2)), so P > 0 and the squared sum is < 1.\n2. **Right** (one angle = π/2): that cosine is 0, so P = 0 and the squared sum is exactly 1.\n3. **Obtuse** (one angle > π/2): that cosine is negative; the other two angles are forced below π/2 (they sum to less than π/2), so their cosines are positive and P < 0, making the squared sum > 1.\n4. **Trichotomy iff**: the backward direction of cos²A + cos²B + cos²C < 1 ⇔ acute is the acute case; the forward direction is its contrapositive — if some angle is ≥ π/2 then a non-strict version of the obtuse argument gives the squared sum ≥ 1. Symmetry across the three angles is handled by applying the same lemma with each angle placed first.\n\nNo metric data and no completing-the-square is needed; the argument is purely about cosine signs.",
-    "keyInsights": [
-      "**The squared cosine sum is 1 minus twice the product of cosines**: cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C, so everything about its position relative to 1 is encoded in the sign of cos A cos B cos C",
-      "**Sign of the product = triangle type**: at most one angle can reach π/2, so the product of cosines is positive (acute), zero (right), or negative (obtuse) — exactly tracking the classical classification",
-      "**A classification theorem with no metric input**: the acute/right/obtuse split is recovered from only A, B, C > 0, the angle sum, and the sign of cos on (0, π/2) and (π/2, π)",
-      "**Complements the linear cosine-sum range**: where the sibling entry pins the range (1, 3/2] of cos A + cos B + cos C, this one reads the *squared* sum against the single threshold 1"
-    ],
-    "prerequisites": [
-      "Real trigonometric function cos and its sign on (0, π/2), at π/2, and on (π/2, π)",
-      "The parent Carnot fundamental identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1",
-      "The elementary fact that at most one angle of a triangle is ≥ π/2"
-    ],
-    "openQuestions": [
-      "Does an analogous product-sign trichotomy hold for the polynomial cos²A + cos²B + cos²C - 2 cos A cos B cos C, or for higher symmetric functions of the angle cosines?",
-      "Can the metric signed-distance form of Carnot's theorem (signed circumcenter-to-side distances summing to R + r) be formalized over EuclideanSpace ℝ (Fin 2), making the acute/obtuse sign of each signed distance match the cosine-sign trichotomy proved here?"
-    ]
-  },
-  "conclusion": {
-    "summary": "For a triangle the squared cosine sum cos²A + cos²B + cos²C compares to 1 exactly as the triangle is acute (< 1), right (= 1), or obtuse (> 1). The proof rearranges the parent fundamental identity to cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C and reads off the sign of the product of cosines, which the triangle's type fixes since at most one angle can reach π/2. All results are axiom- and sorry-free.",
-    "implications": "**Theoretical Significance**: The entry turns Carnot's fundamental polynomial identity into a classification theorem, showing that the acute/right/obtuse type of a triangle is a single sign — that of cos A cos B cos C — and complements the sibling entry's range result for the linear cosine sum. Together the two follow-ups exhibit the linear and quadratic symmetric forms of the angle cosines as the analytic content of Carnot's theorem.",
-    "openQuestions": [
-      "A product-sign trichotomy for related cosine polynomials or higher symmetric functions?",
-      "A direct metric formalization over EuclideanSpace ℝ (Fin 2) matching signed-distance signs to the cosine-sign trichotomy?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "carnot-theorem-oq-01",
@@ -151,7 +143,43 @@
       "description": "The sibling entry pins the sharp range (1, 3/2] of the linear cosine sum cos A + cos B + cos C; this entry classifies the squared cosine sum against the single threshold 1, the quadratic counterpart of the same Carnot identities."
     }
   ],
-  "sorries": 0,
+  "conclusion": {
+    "summary": "For a triangle the squared cosine sum cos²A + cos²B + cos²C compares to 1 exactly as the triangle is acute (< 1), right (= 1), or obtuse (> 1). The proof rearranges the parent fundamental identity to cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C and reads off the sign of the product of cosines, which the triangle's type fixes since at most one angle can reach π/2. All results are axiom- and sorry-free.",
+    "implications": "**Theoretical Significance**: The entry turns Carnot's fundamental polynomial identity into a classification theorem, showing that the acute/right/obtuse type of a triangle is a single sign — that of cos A cos B cos C — and complements the sibling entry's range result for the linear cosine sum. Together the two follow-ups exhibit the linear and quadratic symmetric forms of the angle cosines as the analytic content of Carnot's theorem.",
+    "openQuestions": [
+      "A product-sign trichotomy for related cosine polynomials or higher symmetric functions?",
+      "A direct metric formalization over EuclideanSpace ℝ (Fin 2) matching signed-distance signs to the cosine-sign trichotomy?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Carnot, Lazare N. M.",
+      "title": "Géométrie de position",
+      "year": "1803",
+      "venue": "J. B. M. Duprat, Paris",
+      "note": "Origin of Carnot's theorem on signed distances from the circumcenter to the sides."
+    },
+    {
+      "authors": "Mitrinović, D. S.; Pečarić, J. E.; Volenec, V.",
+      "title": "Recent Advances in Geometric Inequalities",
+      "year": "1989",
+      "venue": "Kluwer Academic",
+      "note": "Sharp bounds for triangle cosine and sine sums."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Carnot's theorem, circumradius/inradius relations, and triangle trigonometry."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry circumradius/inradius, Real.cos/sin identities and inner-product-space triangle API (Mathlib.Geometry.Euclidean / Mathlib.Analysis.SpecialFunctions.Trigonometric)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -167,5 +195,6 @@
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/CarnotTheoremOQ01OQ02.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-01/meta.json
@@ -51,6 +51,27 @@
     "theoremCount": 2,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "The parent companion-sine entry proves the sharp perimeter bound sin A + sin B + sin C ≤ 3√3/2 — by the law of sines (a = 2R sin A) the sine sum is the perimeter of a triangle inscribed in a fixed circle measured in units of the circumdiameter, so the bound is the classical statement that the equilateral triangle has the largest such perimeter. That entry exhibits the equilateral triangle as one maximiser but, using only ordinary concavity of sin, cannot show it is the only one. This entry supplies the missing uniqueness: strict concavity of sin on [0, π] forces any maximiser to be equilateral, so 3√3/2 is attained at exactly one configuration of angles.",
+    "problemStatement": "For reals A, B, C with A + B + C = π and A, B, C ∈ [0, π], characterise equality in the sharp bound sin A + sin B + sin C ≤ 3√3/2: show the maximum is attained if and only if A = B = C = π/3.",
+    "text": "Strict concavity of sin upgrades the parent's one-directional perimeter bound to a uniqueness statement: sin A + sin B + sin C = 3√3/2 exactly when the triangle is equilateral.",
+    "proofStrategy": "1. **Strict-Jensen equality lemma.** For x ≠ y in [0, π] and positive weights a + b = 1, strict concavity gives a·sin x + b·sin y < sin(a·x + b·y). Contrapositively, if this two-point Jensen inequality is an *equality* then x = y.\n\n2. **Forward direction.** Reproduce the parent's two ordinary Jensen steps: first average B and C at equal weights to the midpoint M = (B+C)/2, giving (sin B + sin C)/2 ≤ sin M; then combine A (weight 1/3) with M (weight 2/3), landing the argument at (A + B + C)/3 = π/3 where sin = √3/2. These chain to sin A + sin B + sin C ≤ 3√3/2. Writing the two non-negative slacks s₁, s₂ of the two steps, a single linear balance gives 2·s₁ + 3·s₂ = 3√3/2 − (sin A + sin B + sin C). Saturating the bound forces s₁ = s₂ = 0, i.e. *both* Jensen steps are equalities.\n\n3. **Read off the angles.** Tightness of the first step is a saturated two-point Jensen for B, C, so by the lemma B = C; tightness of the second is a saturated two-point Jensen for A, M, so A = M = (B+C)/2 = C. Hence A = B = C, and A + B + C = π forces each to π/3.\n\n4. **Backward direction.** For A = B = C = π/3 the sum is 3·sin(π/3) = 3√3/2.",
+    "keyInsights": [
+      "**Strict concavity is exactly the uniqueness ingredient**: ordinary concavity (used by the parent) gives the bound but allows the chord to touch the graph off the barycentre; the strict version forbids this, so a saturated Jensen step *forces its two points equal*",
+      "**The maximiser is unique, not just exhibited**: equality in sin A + sin B + sin C ≤ 3√3/2 holds at exactly one angle configuration A = B = C = π/3, the strongest form of the extremal-perimeter statement",
+      "**Two tight steps decode to two equalities**: saturating the global bound makes both Jensen averaging steps simultaneously tight (their slacks are non-negative and sum to zero), and each tightness decodes — via the strict-Jensen lemma — to one coincidence (B = C, then A = M), which the angle-sum closes to the equilateral triangle",
+      "**The strict-Jensen equality lemma is reusable**: a saturated two-point Jensen for any strictly concave function forces its sample points equal — the generic mechanism behind 'the symmetric point is the unique optimiser' in symmetric extremal problems"
+    ],
+    "prerequisites": [
+      "Real trigonometric function sin and its value sin(π/3) = √3/2",
+      "Strict concavity of sin on [0, π] and the two-point form of Jensen's inequality",
+      "The contrapositive reading of a strict inequality: equality in a strict-concavity bound forces the sample points to coincide"
+    ],
+    "openQuestions": [
+      "Does the same strict-concavity mechanism give a uniqueness/equality-iff statement for the sibling cosine-sum range, characterising when cos A + cos B + cos C attains its bounds?",
+      "Can the uniqueness be lifted, via the law-of-sines bridge over EuclideanSpace ℝ (Fin 2), to the geometric statement that the equilateral triangle is the unique perimeter-maximiser among triangles inscribed in a fixed circle?"
+    ]
+  },
   "sections": [
     {
       "title": "Module header",
@@ -77,35 +98,6 @@
       "id": "uniqueness"
     }
   ],
-  "overview": {
-    "historicalContext": "The parent companion-sine entry proves the sharp perimeter bound sin A + sin B + sin C ≤ 3√3/2 — by the law of sines (a = 2R sin A) the sine sum is the perimeter of a triangle inscribed in a fixed circle measured in units of the circumdiameter, so the bound is the classical statement that the equilateral triangle has the largest such perimeter. That entry exhibits the equilateral triangle as one maximiser but, using only ordinary concavity of sin, cannot show it is the only one. This entry supplies the missing uniqueness: strict concavity of sin on [0, π] forces any maximiser to be equilateral, so 3√3/2 is attained at exactly one configuration of angles.",
-    "problemStatement": "For reals A, B, C with A + B + C = π and A, B, C ∈ [0, π], characterise equality in the sharp bound sin A + sin B + sin C ≤ 3√3/2: show the maximum is attained if and only if A = B = C = π/3.",
-    "text": "Strict concavity of sin upgrades the parent's one-directional perimeter bound to a uniqueness statement: sin A + sin B + sin C = 3√3/2 exactly when the triangle is equilateral.",
-    "proofStrategy": "1. **Strict-Jensen equality lemma.** For x ≠ y in [0, π] and positive weights a + b = 1, strict concavity gives a·sin x + b·sin y < sin(a·x + b·y). Contrapositively, if this two-point Jensen inequality is an *equality* then x = y.\n\n2. **Forward direction.** Reproduce the parent's two ordinary Jensen steps: first average B and C at equal weights to the midpoint M = (B+C)/2, giving (sin B + sin C)/2 ≤ sin M; then combine A (weight 1/3) with M (weight 2/3), landing the argument at (A + B + C)/3 = π/3 where sin = √3/2. These chain to sin A + sin B + sin C ≤ 3√3/2. Writing the two non-negative slacks s₁, s₂ of the two steps, a single linear balance gives 2·s₁ + 3·s₂ = 3√3/2 − (sin A + sin B + sin C). Saturating the bound forces s₁ = s₂ = 0, i.e. *both* Jensen steps are equalities.\n\n3. **Read off the angles.** Tightness of the first step is a saturated two-point Jensen for B, C, so by the lemma B = C; tightness of the second is a saturated two-point Jensen for A, M, so A = M = (B+C)/2 = C. Hence A = B = C, and A + B + C = π forces each to π/3.\n\n4. **Backward direction.** For A = B = C = π/3 the sum is 3·sin(π/3) = 3√3/2.",
-    "keyInsights": [
-      "**Strict concavity is exactly the uniqueness ingredient**: ordinary concavity (used by the parent) gives the bound but allows the chord to touch the graph off the barycentre; the strict version forbids this, so a saturated Jensen step *forces its two points equal*",
-      "**The maximiser is unique, not just exhibited**: equality in sin A + sin B + sin C ≤ 3√3/2 holds at exactly one angle configuration A = B = C = π/3, the strongest form of the extremal-perimeter statement",
-      "**Two tight steps decode to two equalities**: saturating the global bound makes both Jensen averaging steps simultaneously tight (their slacks are non-negative and sum to zero), and each tightness decodes — via the strict-Jensen lemma — to one coincidence (B = C, then A = M), which the angle-sum closes to the equilateral triangle",
-      "**The strict-Jensen equality lemma is reusable**: a saturated two-point Jensen for any strictly concave function forces its sample points equal — the generic mechanism behind 'the symmetric point is the unique optimiser' in symmetric extremal problems"
-    ],
-    "prerequisites": [
-      "Real trigonometric function sin and its value sin(π/3) = √3/2",
-      "Strict concavity of sin on [0, π] and the two-point form of Jensen's inequality",
-      "The contrapositive reading of a strict inequality: equality in a strict-concavity bound forces the sample points to coincide"
-    ],
-    "openQuestions": [
-      "Does the same strict-concavity mechanism give a uniqueness/equality-iff statement for the sibling cosine-sum range, characterising when cos A + cos B + cos C attains its bounds?",
-      "Can the uniqueness be lifted, via the law-of-sines bridge over EuclideanSpace ℝ (Fin 2), to the geometric statement that the equilateral triangle is the unique perimeter-maximiser among triangles inscribed in a fixed circle?"
-    ]
-  },
-  "conclusion": {
-    "summary": "Strict concavity of sin upgrades the parent's sharp bound to a uniqueness characterisation: sin A + sin B + sin C = 3√3/2 holds if and only if A = B = C = π/3. The forward direction saturates two Jensen steps and decodes each tightness — via a reusable strict-Jensen equality lemma — to B = C and A = (B+C)/2, with the angle-sum pinning each angle to π/3; the backward direction evaluates the sum at the equilateral triangle. Axiom- and sorry-free.",
-    "implications": "**Theoretical Significance**: Completes the extremal story of the triangle's sine sum begun by the parent: not only is 3√3/2 the maximum (parent), it is attained at a *unique* triangle (this entry). The proof isolates the generic mechanism — a saturated two-point Jensen for a strictly concave function forces its sample points equal — as a standalone lemma, the same engine that makes the symmetric point the unique optimiser in symmetric extremal problems. Geometrically: among triangles inscribed in a fixed circle, the equilateral one is the *unique* triangle of maximal perimeter, the sharp form of the parent's perimeter bound.",
-    "openQuestions": [
-      "Apply the same strict-concavity uniqueness mechanism to characterise the extremal triangles for the sibling cosine-sum range (1, 3/2].",
-      "Lift the uniqueness, via the law-of-sines bridge over EuclideanSpace ℝ (Fin 2), to the geometric statement that the equilateral triangle is the unique perimeter-maximiser among inscribed triangles."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "carnot-theorem-oq-01-oq-03",
@@ -123,7 +115,43 @@
       "description": "The cosine form of Carnot's theorem cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2) is the analytic root of this family; the present entry is its sine-side extremal-uniqueness descendant."
     }
   ],
-  "sorries": 0,
+  "conclusion": {
+    "summary": "Strict concavity of sin upgrades the parent's sharp bound to a uniqueness characterisation: sin A + sin B + sin C = 3√3/2 holds if and only if A = B = C = π/3. The forward direction saturates two Jensen steps and decodes each tightness — via a reusable strict-Jensen equality lemma — to B = C and A = (B+C)/2, with the angle-sum pinning each angle to π/3; the backward direction evaluates the sum at the equilateral triangle. Axiom- and sorry-free.",
+    "implications": "**Theoretical Significance**: Completes the extremal story of the triangle's sine sum begun by the parent: not only is 3√3/2 the maximum (parent), it is attained at a *unique* triangle (this entry). The proof isolates the generic mechanism — a saturated two-point Jensen for a strictly concave function forces its sample points equal — as a standalone lemma, the same engine that makes the symmetric point the unique optimiser in symmetric extremal problems. Geometrically: among triangles inscribed in a fixed circle, the equilateral one is the *unique* triangle of maximal perimeter, the sharp form of the parent's perimeter bound.",
+    "openQuestions": [
+      "Apply the same strict-concavity uniqueness mechanism to characterise the extremal triangles for the sibling cosine-sum range (1, 3/2].",
+      "Lift the uniqueness, via the law-of-sines bridge over EuclideanSpace ℝ (Fin 2), to the geometric statement that the equilateral triangle is the unique perimeter-maximiser among inscribed triangles."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Mitrinović, D. S.; Pečarić, J. E.; Volenec, V.",
+      "title": "Recent Advances in Geometric Inequalities",
+      "year": "1989",
+      "venue": "Kluwer Academic",
+      "note": "Sharp bounds for triangle cosine and sine sums."
+    },
+    {
+      "authors": "Andreescu, Titu and Andrica, Dorin",
+      "title": "Complex Numbers from A to ...Z, and triangle trigonometric identities",
+      "year": "2006",
+      "venue": "Birkhäuser",
+      "note": "Triangle trigonometric identities and extremal angle-sum inequalities."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Carnot's theorem, circumradius/inradius relations, and triangle trigonometry."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry circumradius/inradius, Real.cos/sin identities and inner-product-space triangle API (Mathlib.Geometry.Euclidean / Mathlib.Analysis.SpecialFunctions.Trigonometric)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -139,5 +167,6 @@
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/CarnotTheoremOQ01OQ03OQ01.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-02/meta.json
@@ -63,6 +63,28 @@
     "theoremCount": 4,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "Carnot's circle-of-results connects a triangle's angles, side lengths, inradius r and circumradius R. The law of sines a = 2R sin A (here in Mathlib's extended form for an Affine.Triangle) is the classical hinge between the angle picture and the metric picture: it turns any symmetric inequality in the angles into a statement about side lengths and the circumradius. The family's earlier entries proved the angle-level facts sin A + sin B + sin C ≤ 3√3/2 (sharp bound) and its equality characterisation A = B = C = π/3 (uniqueness) purely as statements about reals summing to π. This entry crosses the hinge: it lifts both to honest geometry, recovering the textbook theorem that among all triangles inscribed in a fixed circle the equilateral one has the greatest perimeter — and is the unique such maximiser.",
+    "problemStatement": "Formalise the law-of-sines bridge from the angle-level sine bound to an explicit perimeter inequality over a Euclidean space: for a triangle t : Affine.Triangle ℝ P with circumradius R, show perimeter t ≤ 3√3·R, with equality exactly when t is equilateral.",
+    "text": "The extended law of sines turns the angle-level bound sin A + sin B + sin C ≤ 3√3/2 into the geometric perimeter inequality perimeter ≤ 3√3·R, with equality iff the inscribed triangle is equilateral.",
+    "proofStrategy": "1. **Each side as 2R·sin(opposite angle).** Mathlib's extended law of sines gives dist(points i₁)(points i₃)/sin(∠ at i₂) = 2·circumradius. To clear the denominator, note the triangle's affine independence makes the three vertices non-collinear (affineIndependent_iff_not_collinear_of_ne), so the interior angle lies strictly in (0, π) (angle_pos_of_not_collinear, angle_lt_pi_of_not_collinear) and its sine is nonzero; div_eq_iff then yields the multiplicative form dist = 2R·sin.\n\n2. **Angle sum.** EuclideanGeometry.angle_add_angle_add_angle_eq_pi gives A + B + C = π (the two-vertices-distinct hypothesis comes from the injective points map).\n\n3. **Perimeter bound.** Summing the three side equations, the perimeter is 2R·(sin A + sin B + sin C). The companion bound sin A + sin B + sin C ≤ 3√3/2 (with the angle sum and the automatic [0, π] membership) and R ≥ 0 give perimeter ≤ 2R·(3√3/2) = 3√3·R.\n\n4. **Equality characterisation.** The circumradius of a genuine triangle is positive, so the factor 2R cancels (mul_right_inj'): the perimeter equation 2R·(sum) = 3√3·R = 2R·(3√3/2) is equivalent to sin A + sin B + sin C = 3√3/2, which the companion uniqueness result sin_sum_eq_iff_equilateral characterises as A = B = C = π/3.",
+    "keyInsights": [
+      "**The law of sines is the hinge between angles and metric**: dist = 2R·sin(opposite angle) converts the whole angle-level extremal story (bound + uniqueness) into a metric one (perimeter vs circumradius) with no new analysis — the geometry and the trigonometry stay cleanly separated",
+      "**Affine independence is exactly the non-degeneracy needed**: it is what makes each interior angle lie in the open interval (0, π), so its sine is nonzero and the law-of-sines quotient can be cleared — the same hypothesis that makes the circumradius positive and the equality cancellation legitimate",
+      "**Equality transfers losslessly through the bridge**: because 2R > 0, the geometric perimeter equation is equivalent (not merely implied) to the angle-level sine equation, so the angle-level uniqueness A = B = C = π/3 lifts verbatim to 'the equilateral triangle is the unique inscribed perimeter-maximiser'",
+      "**Stated over a general inner-product space**: the result is proved for any Affine.Triangle ℝ P with the inner-product/torsor instances — a triangle lives in its 2-dimensional affine span regardless of ambient dimension — so it specialises immediately to EuclideanSpace ℝ (Fin 2)"
+    ],
+    "prerequisites": [
+      "Mathlib's Affine.Triangle ℝ P and its circumradius (Affine.Simplex.circumradius)",
+      "The extended law of sines dist/sin = 2R and the Euclidean angle sum for a triangle",
+      "Affine independence ⇔ non-collinearity for three points, and the resulting (0, π) range of each interior angle",
+      "The companion angle-level results: the sharp bound sin A + sin B + sin C ≤ 3√3/2 and its equality characterisation A = B = C = π/3"
+    ],
+    "openQuestions": [
+      "Can the equality side be restated purely metrically — equality iff the three side lengths dist p₀ p₁, dist p₁ p₂, dist p₂ p₀ are all equal — by proving the converse 'equal sides ⇒ equal angles' (which, unlike the angle direction, must contend with sin's non-injectivity on (0, π))?",
+      "Does the dual cosine identity cos A + cos B + cos C = 1 + r/R bridge similarly to a sharp inradius/circumradius (Euler) inequality r ≤ R/2 with equality iff equilateral, over the same Affine.Triangle ℝ P?"
+    ]
+  },
   "sections": [
     {
       "title": "Module header",
@@ -105,36 +127,6 @@
       "id": "equality-iff"
     }
   ],
-  "overview": {
-    "historicalContext": "Carnot's circle-of-results connects a triangle's angles, side lengths, inradius r and circumradius R. The law of sines a = 2R sin A (here in Mathlib's extended form for an Affine.Triangle) is the classical hinge between the angle picture and the metric picture: it turns any symmetric inequality in the angles into a statement about side lengths and the circumradius. The family's earlier entries proved the angle-level facts sin A + sin B + sin C ≤ 3√3/2 (sharp bound) and its equality characterisation A = B = C = π/3 (uniqueness) purely as statements about reals summing to π. This entry crosses the hinge: it lifts both to honest geometry, recovering the textbook theorem that among all triangles inscribed in a fixed circle the equilateral one has the greatest perimeter — and is the unique such maximiser.",
-    "problemStatement": "Formalise the law-of-sines bridge from the angle-level sine bound to an explicit perimeter inequality over a Euclidean space: for a triangle t : Affine.Triangle ℝ P with circumradius R, show perimeter t ≤ 3√3·R, with equality exactly when t is equilateral.",
-    "text": "The extended law of sines turns the angle-level bound sin A + sin B + sin C ≤ 3√3/2 into the geometric perimeter inequality perimeter ≤ 3√3·R, with equality iff the inscribed triangle is equilateral.",
-    "proofStrategy": "1. **Each side as 2R·sin(opposite angle).** Mathlib's extended law of sines gives dist(points i₁)(points i₃)/sin(∠ at i₂) = 2·circumradius. To clear the denominator, note the triangle's affine independence makes the three vertices non-collinear (affineIndependent_iff_not_collinear_of_ne), so the interior angle lies strictly in (0, π) (angle_pos_of_not_collinear, angle_lt_pi_of_not_collinear) and its sine is nonzero; div_eq_iff then yields the multiplicative form dist = 2R·sin.\n\n2. **Angle sum.** EuclideanGeometry.angle_add_angle_add_angle_eq_pi gives A + B + C = π (the two-vertices-distinct hypothesis comes from the injective points map).\n\n3. **Perimeter bound.** Summing the three side equations, the perimeter is 2R·(sin A + sin B + sin C). The companion bound sin A + sin B + sin C ≤ 3√3/2 (with the angle sum and the automatic [0, π] membership) and R ≥ 0 give perimeter ≤ 2R·(3√3/2) = 3√3·R.\n\n4. **Equality characterisation.** The circumradius of a genuine triangle is positive, so the factor 2R cancels (mul_right_inj'): the perimeter equation 2R·(sum) = 3√3·R = 2R·(3√3/2) is equivalent to sin A + sin B + sin C = 3√3/2, which the companion uniqueness result sin_sum_eq_iff_equilateral characterises as A = B = C = π/3.",
-    "keyInsights": [
-      "**The law of sines is the hinge between angles and metric**: dist = 2R·sin(opposite angle) converts the whole angle-level extremal story (bound + uniqueness) into a metric one (perimeter vs circumradius) with no new analysis — the geometry and the trigonometry stay cleanly separated",
-      "**Affine independence is exactly the non-degeneracy needed**: it is what makes each interior angle lie in the open interval (0, π), so its sine is nonzero and the law-of-sines quotient can be cleared — the same hypothesis that makes the circumradius positive and the equality cancellation legitimate",
-      "**Equality transfers losslessly through the bridge**: because 2R > 0, the geometric perimeter equation is equivalent (not merely implied) to the angle-level sine equation, so the angle-level uniqueness A = B = C = π/3 lifts verbatim to 'the equilateral triangle is the unique inscribed perimeter-maximiser'",
-      "**Stated over a general inner-product space**: the result is proved for any Affine.Triangle ℝ P with the inner-product/torsor instances — a triangle lives in its 2-dimensional affine span regardless of ambient dimension — so it specialises immediately to EuclideanSpace ℝ (Fin 2)"
-    ],
-    "prerequisites": [
-      "Mathlib's Affine.Triangle ℝ P and its circumradius (Affine.Simplex.circumradius)",
-      "The extended law of sines dist/sin = 2R and the Euclidean angle sum for a triangle",
-      "Affine independence ⇔ non-collinearity for three points, and the resulting (0, π) range of each interior angle",
-      "The companion angle-level results: the sharp bound sin A + sin B + sin C ≤ 3√3/2 and its equality characterisation A = B = C = π/3"
-    ],
-    "openQuestions": [
-      "Can the equality side be restated purely metrically — equality iff the three side lengths dist p₀ p₁, dist p₁ p₂, dist p₂ p₀ are all equal — by proving the converse 'equal sides ⇒ equal angles' (which, unlike the angle direction, must contend with sin's non-injectivity on (0, π))?",
-      "Does the dual cosine identity cos A + cos B + cos C = 1 + r/R bridge similarly to a sharp inradius/circumradius (Euler) inequality r ≤ R/2 with equality iff equilateral, over the same Affine.Triangle ℝ P?"
-    ]
-  },
-  "conclusion": {
-    "summary": "The extended law of sines lifts the family's angle-level sine results to honest Euclidean geometry. Writing each side of an Affine.Triangle ℝ P as 2R·sin(opposite angle) — legitimate because affine independence forces every interior angle into (0, π), so its sine is nonzero — makes the perimeter equal to 2R·(sin A + sin B + sin C). The companion bound then gives perimeter ≤ 3√3·R, and (cancelling the positive factor 2R) the companion uniqueness result gives equality iff the triangle is equilateral. Axiom- and sorry-free.",
-    "implications": "**Theoretical Significance**: Completes the Carnot sine-sum thread by crossing from angles to metric geometry: the abstract bound 3√3/2 and its unique angle-maximiser become the textbook theorem that the equilateral triangle is the greatest-perimeter triangle inscribed in a fixed circle, and the unique one. The proof cleanly isolates the geometric content (law of sines, angle sum, non-degeneracy, positive circumradius) from the analytic content (Jensen / strict concavity) reused unchanged from the companion entries, demonstrating how Mathlib's Euclidean-geometry layer turns angle-level extremal facts into metric ones with no additional trigonometry.",
-    "openQuestions": [
-      "Prove the metric form of the equality case — equality iff all three side lengths are equal — which requires the converse 'equal sides ⇒ equal angles' and so must handle the non-injectivity of sin on (0, π).",
-      "Bridge the dual cosine identity cos A + cos B + cos C = 1 + r/R to a sharp Euler inequality r ≤ R/2 over the same Affine.Triangle ℝ P, with equality iff equilateral."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "carnot-theorem-oq-01-oq-03-oq-01",
@@ -152,7 +144,43 @@
       "description": "The cosine form of Carnot's theorem cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2) is the analytic root of the family; the present entry is its metric-geometry descendant on the sine side, expressing the bound through the circumradius."
     }
   ],
-  "sorries": 0,
+  "conclusion": {
+    "summary": "The extended law of sines lifts the family's angle-level sine results to honest Euclidean geometry. Writing each side of an Affine.Triangle ℝ P as 2R·sin(opposite angle) — legitimate because affine independence forces every interior angle into (0, π), so its sine is nonzero — makes the perimeter equal to 2R·(sin A + sin B + sin C). The companion bound then gives perimeter ≤ 3√3·R, and (cancelling the positive factor 2R) the companion uniqueness result gives equality iff the triangle is equilateral. Axiom- and sorry-free.",
+    "implications": "**Theoretical Significance**: Completes the Carnot sine-sum thread by crossing from angles to metric geometry: the abstract bound 3√3/2 and its unique angle-maximiser become the textbook theorem that the equilateral triangle is the greatest-perimeter triangle inscribed in a fixed circle, and the unique one. The proof cleanly isolates the geometric content (law of sines, angle sum, non-degeneracy, positive circumradius) from the analytic content (Jensen / strict concavity) reused unchanged from the companion entries, demonstrating how Mathlib's Euclidean-geometry layer turns angle-level extremal facts into metric ones with no additional trigonometry.",
+    "openQuestions": [
+      "Prove the metric form of the equality case — equality iff all three side lengths are equal — which requires the converse 'equal sides ⇒ equal angles' and so must handle the non-injectivity of sin on (0, π).",
+      "Bridge the dual cosine identity cos A + cos B + cos C = 1 + r/R to a sharp Euler inequality r ≤ R/2 over the same Affine.Triangle ℝ P, with equality iff equilateral."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Carnot's theorem, circumradius/inradius relations, and triangle trigonometry."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin",
+      "note": "Comprehensive classical triangle geometry."
+    },
+    {
+      "authors": "Mitrinović, D. S.; Pečarić, J. E.; Volenec, V.",
+      "title": "Recent Advances in Geometric Inequalities",
+      "year": "1989",
+      "venue": "Kluwer Academic",
+      "note": "Sharp bounds for triangle cosine and sine sums."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry circumradius/inradius, Real.cos/sin identities and inner-product-space triangle API (Mathlib.Geometry.Euclidean / Mathlib.Analysis.SpecialFunctions.Trigonometric)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -170,5 +198,6 @@
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/CarnotTheoremOQ01OQ03OQ02.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/carnot-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-03/meta.json
@@ -80,6 +80,27 @@
     "theoremCount": 4,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "Carnot's theorem on the inradius and circumradius has as its analytic core a pair of trigonometric identities for the angles of a triangle. The parent entries develop the cosine form cos A + cos B + cos C = 1 + r/R and the fundamental polynomial identity. This entry develops the dual sine form sin A + sin B + sin C = 4 cos(A/2) cos(B/2) cos(C/2). Through the law of sines (a = 2R sin A) the sine sum is the triangle's perimeter measured in units of the circumdiameter 2R, and the product 4 cos(A/2) cos(B/2) cos(C/2) equals s/R with s the semiperimeter. The sharp maximum 3√3/2 is the classical statement that, among all triangles inscribed in a fixed circle, the equilateral one has the greatest perimeter.",
+    "problemStatement": "For reals A, B, C with A + B + C = π, prove the product-form identity sin A + sin B + sin C = 4 cos(A/2) cos(B/2) cos(C/2); and for the angles of a triangle prove the sine sum is positive and bounded above by 3√3/2, with equality at the equilateral triangle.",
+    "text": "The companion sine identity factorises sin A + sin B + sin C into half-angle cosines, and concavity of sin pins its maximum at 3√3/2 — the equilateral triangle maximises the perimeter inscribed in a fixed circle.",
+    "proofStrategy": "1. **Identity.** Write each sine in double-angle form 2 sin(·/2) cos(·/2). The constraint A + B + C = π gives C/2 = π/2 - (A/2 + B/2), so sin(C/2) = cos(A/2 + B/2) and cos(C/2) = sin(A/2 + B/2) by the complementary-angle identities. Expanding with the addition formulas turns the goal into a polynomial identity in sin(A/2), cos(A/2), sin(B/2), cos(B/2) that closes by linear_combination of the two Pythagorean relations.\n\n2. **Positivity.** For a genuine triangle each angle is in (0, π) (e.g. A = π - B - C < π since B, C > 0), so each sine is positive and the sum is positive.\n\n3. **Sharp maximum.** sin is concave on [0, π]. Apply the two-point concavity inequality first to B and C at equal weights, obtaining (sin B + sin C)/2 ≤ sin((B+C)/2); then combine A (weight 1/3) with the midpoint M = (B+C)/2 (weight 2/3). The convex combination (1/3)A + (2/3)M equals (A + B + C)/3 = π/3, where sin = √3/2. A single linear arithmetic step (three times the second inequality plus twice the first, cancelling sin M) gives sin A + sin B + sin C ≤ 3√3/2.\n\n4. **Sharpness.** The equilateral triangle A = B = C = π/3 makes the sum 3 sin(π/3) = 3√3/2, so the bound is attained.",
+    "keyInsights": [
+      "**Sine sum factorises through half-angle cosines**: sin A + sin B + sin C = 4 cos(A/2) cos(B/2) cos(C/2), the exact dual of the parent's cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)",
+      "**The sine sum is the normalised perimeter**: by the law of sines a + b + c = 2R (sin A + sin B + sin C), so bounding the sine sum bounds the perimeter of triangles inscribed in a fixed circle",
+      "**Concavity gives the sharp bound**: sin is concave on [0, π], so Jensen at the barycentre π/3 yields the maximum 3√3/2 with no calculus beyond Mathlib's concavity lemma",
+      "**Equilateral is extremal**: equality holds exactly for A = B = C = π/3, the largest-perimeter triangle in a fixed circumcircle — the dual extremal statement to Euler's inequality (which the sibling range entry encodes)"
+    ],
+    "prerequisites": [
+      "Real trigonometric functions sin, cos and the double-angle, addition, and complementary-angle identities",
+      "The Pythagorean identity sin²x + cos²x = 1",
+      "Concavity of sin on [0, π] and the two-point form of Jensen's inequality"
+    ],
+    "openQuestions": [
+      "Does the strict concavity of sin upgrade the maximum to a uniqueness statement (equality in sin A + sin B + sin C ≤ 3√3/2 forces A = B = C = π/3)?",
+      "Can the law-of-sines bridge a + b + c = 2R (sin A + sin B + sin C) be formalised over EuclideanSpace ℝ (Fin 2), turning the 3√3/2 bound into the explicit perimeter inequality for inscribed triangles?"
+    ]
+  },
   "sections": [
     {
       "title": "Module header",
@@ -122,35 +143,6 @@
       "id": "witness"
     }
   ],
-  "overview": {
-    "historicalContext": "Carnot's theorem on the inradius and circumradius has as its analytic core a pair of trigonometric identities for the angles of a triangle. The parent entries develop the cosine form cos A + cos B + cos C = 1 + r/R and the fundamental polynomial identity. This entry develops the dual sine form sin A + sin B + sin C = 4 cos(A/2) cos(B/2) cos(C/2). Through the law of sines (a = 2R sin A) the sine sum is the triangle's perimeter measured in units of the circumdiameter 2R, and the product 4 cos(A/2) cos(B/2) cos(C/2) equals s/R with s the semiperimeter. The sharp maximum 3√3/2 is the classical statement that, among all triangles inscribed in a fixed circle, the equilateral one has the greatest perimeter.",
-    "problemStatement": "For reals A, B, C with A + B + C = π, prove the product-form identity sin A + sin B + sin C = 4 cos(A/2) cos(B/2) cos(C/2); and for the angles of a triangle prove the sine sum is positive and bounded above by 3√3/2, with equality at the equilateral triangle.",
-    "text": "The companion sine identity factorises sin A + sin B + sin C into half-angle cosines, and concavity of sin pins its maximum at 3√3/2 — the equilateral triangle maximises the perimeter inscribed in a fixed circle.",
-    "proofStrategy": "1. **Identity.** Write each sine in double-angle form 2 sin(·/2) cos(·/2). The constraint A + B + C = π gives C/2 = π/2 - (A/2 + B/2), so sin(C/2) = cos(A/2 + B/2) and cos(C/2) = sin(A/2 + B/2) by the complementary-angle identities. Expanding with the addition formulas turns the goal into a polynomial identity in sin(A/2), cos(A/2), sin(B/2), cos(B/2) that closes by linear_combination of the two Pythagorean relations.\n\n2. **Positivity.** For a genuine triangle each angle is in (0, π) (e.g. A = π - B - C < π since B, C > 0), so each sine is positive and the sum is positive.\n\n3. **Sharp maximum.** sin is concave on [0, π]. Apply the two-point concavity inequality first to B and C at equal weights, obtaining (sin B + sin C)/2 ≤ sin((B+C)/2); then combine A (weight 1/3) with the midpoint M = (B+C)/2 (weight 2/3). The convex combination (1/3)A + (2/3)M equals (A + B + C)/3 = π/3, where sin = √3/2. A single linear arithmetic step (three times the second inequality plus twice the first, cancelling sin M) gives sin A + sin B + sin C ≤ 3√3/2.\n\n4. **Sharpness.** The equilateral triangle A = B = C = π/3 makes the sum 3 sin(π/3) = 3√3/2, so the bound is attained.",
-    "keyInsights": [
-      "**Sine sum factorises through half-angle cosines**: sin A + sin B + sin C = 4 cos(A/2) cos(B/2) cos(C/2), the exact dual of the parent's cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)",
-      "**The sine sum is the normalised perimeter**: by the law of sines a + b + c = 2R (sin A + sin B + sin C), so bounding the sine sum bounds the perimeter of triangles inscribed in a fixed circle",
-      "**Concavity gives the sharp bound**: sin is concave on [0, π], so Jensen at the barycentre π/3 yields the maximum 3√3/2 with no calculus beyond Mathlib's concavity lemma",
-      "**Equilateral is extremal**: equality holds exactly for A = B = C = π/3, the largest-perimeter triangle in a fixed circumcircle — the dual extremal statement to Euler's inequality (which the sibling range entry encodes)"
-    ],
-    "prerequisites": [
-      "Real trigonometric functions sin, cos and the double-angle, addition, and complementary-angle identities",
-      "The Pythagorean identity sin²x + cos²x = 1",
-      "Concavity of sin on [0, π] and the two-point form of Jensen's inequality"
-    ],
-    "openQuestions": [
-      "Does the strict concavity of sin upgrade the maximum to a uniqueness statement (equality in sin A + sin B + sin C ≤ 3√3/2 forces A = B = C = π/3)?",
-      "Can the law-of-sines bridge a + b + c = 2R (sin A + sin B + sin C) be formalised over EuclideanSpace ℝ (Fin 2), turning the 3√3/2 bound into the explicit perimeter inequality for inscribed triangles?"
-    ]
-  },
-  "conclusion": {
-    "summary": "The companion sine form of Carnot's theorem, sin A + sin B + sin C = 4 cos(A/2) cos(B/2) cos(C/2), is proved from scratch in half-angle form, together with positivity of the sine sum for a triangle and the sharp maximum sin A + sin B + sin C ≤ 3√3/2 (via concavity of sin and Jensen at π/3), attained at the equilateral triangle. All results are axiom- and sorry-free.",
-    "implications": "**Theoretical Significance**: The entry completes the linear symmetric picture of the triangle's angle trigonometry begun by the cosine-sum entries: the sibling pins the range (1, 3/2] of cos A + cos B + cos C (encoding Euler's inequality r ≤ R/2), while this entry pins the maximum 3√3/2 of sin A + sin B + sin C (the extremal-perimeter statement). Together they exhibit both linear symmetric functions of the angles as sharp triangle invariants.",
-    "openQuestions": [
-      "Upgrade the maximum to a uniqueness/equality-iff statement using strict concavity of sin?",
-      "Formalise the law-of-sines bridge to express the bound as an explicit perimeter inequality over EuclideanSpace ℝ (Fin 2)?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "carnot-theorem-oq-01",
@@ -168,7 +160,43 @@
       "description": "The squared-cosine sibling classifies cos²A + cos²B + cos²C against 1; together with this sine entry the family covers the linear and quadratic symmetric functions of the triangle's angle trigonometric values."
     }
   ],
-  "sorries": 0,
+  "conclusion": {
+    "summary": "The companion sine form of Carnot's theorem, sin A + sin B + sin C = 4 cos(A/2) cos(B/2) cos(C/2), is proved from scratch in half-angle form, together with positivity of the sine sum for a triangle and the sharp maximum sin A + sin B + sin C ≤ 3√3/2 (via concavity of sin and Jensen at π/3), attained at the equilateral triangle. All results are axiom- and sorry-free.",
+    "implications": "**Theoretical Significance**: The entry completes the linear symmetric picture of the triangle's angle trigonometry begun by the cosine-sum entries: the sibling pins the range (1, 3/2] of cos A + cos B + cos C (encoding Euler's inequality r ≤ R/2), while this entry pins the maximum 3√3/2 of sin A + sin B + sin C (the extremal-perimeter statement). Together they exhibit both linear symmetric functions of the angles as sharp triangle invariants.",
+    "openQuestions": [
+      "Upgrade the maximum to a uniqueness/equality-iff statement using strict concavity of sin?",
+      "Formalise the law-of-sines bridge to express the bound as an explicit perimeter inequality over EuclideanSpace ℝ (Fin 2)?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Mitrinović, D. S.; Pečarić, J. E.; Volenec, V.",
+      "title": "Recent Advances in Geometric Inequalities",
+      "year": "1989",
+      "venue": "Kluwer Academic",
+      "note": "Sharp bounds for triangle cosine and sine sums."
+    },
+    {
+      "authors": "Andreescu, Titu and Andrica, Dorin",
+      "title": "Complex Numbers from A to ...Z, and triangle trigonometric identities",
+      "year": "2006",
+      "venue": "Birkhäuser",
+      "note": "Triangle trigonometric identities and extremal angle-sum inequalities."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Carnot's theorem, circumradius/inradius relations, and triangle trigonometry."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry circumradius/inradius, Real.cos/sin identities and inner-product-space triangle API (Mathlib.Geometry.Euclidean / Mathlib.Analysis.SpecialFunctions.Trigonometric)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -184,5 +212,6 @@
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/CarnotTheoremOQ01OQ03.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/carnot-theorem-oq-01/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01/meta.json
@@ -59,6 +59,29 @@
     "theoremCount": 3,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "Carnot's theorem on the inradius and circumradius is due to Lazare Carnot (1753–1823), the French mathematician, engineer, and politician known as the 'Organizer of Victory' during the French Revolution. It appears in his 1803 work on the geometry of position. The theorem states that, for a triangle with circumradius R and inradius r, the sum of the signed distances from the circumcenter O to the three sides equals R + r. The sign convention is essential: a distance is counted negative when the circumcenter lies on the opposite side of an edge from the triangle's interior, which happens precisely for the side opposite an obtuse angle. With this convention the identity holds for every triangle, acute or obtuse.\n\nDividing the signed-distance form by R, and using that the signed distance from the circumcenter to the side opposite angle θ equals R cos θ (the central angle subtending that side is 2θ), Carnot's theorem becomes the compact trigonometric statement cos A + cos B + cos C = 1 + r/R. Combined with Euler's inradius formula r = 4R sin(A/2) sin(B/2) sin(C/2), the analytic heart of the theorem is the pure identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), which holds for any real angles summing to π.",
+    "problemStatement": "**Carnot's theorem (angle form)**: For any reals A, B, C with A + B + C = π, prove\n\n  cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2).\n\nThis is equivalent to the classical statement that the signed distances from the circumcenter to the three sides of a triangle sum to R + r, since cos A + cos B + cos C = 1 + r/R and r/R = 4 sin(A/2) sin(B/2) sin(C/2).",
+    "text": "For a triangle with circumradius R and inradius r, the signed distances from the circumcenter to the three sides sum to R + r; equivalently cos A + cos B + cos C = 1 + r/R.",
+    "proofStrategy": "The proof works entirely with the angle relation A + B + C = π and reduces to a polynomial identity.\n\n1. **Half angles**: Set a = A/2, b = B/2, c = C/2, so a + b + c = π/2 and c = π/2 - (a + b). Then sin(C/2) = sin(π/2 - (a+b)) = cos(a + b) = cos a cos b - sin a sin b, expressing the third half-angle sine through A/2 and B/2.\n\n2. **Cosine reduction**: Rewrite each full-angle cosine as cos(2·) and apply the double-angle identity cos(2x) = 1 - 2 sin²x. The left side becomes 3 - 2(sin²(A/2) + sin²(B/2) + sin²(C/2)).\n\n3. **Polynomial closure**: After substituting sin(C/2), the goal is a polynomial identity in sin(A/2), cos(A/2), sin(B/2), cos(B/2). It is closed by a single linear_combination of the Pythagorean identities sin²(A/2) + cos²(A/2) = 1 and sin²(B/2) + cos²(B/2) = 1.\n\nThe companion identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1 is proved the same way, using cos C = -cos(A + B) and a linear_combination of the Pythagorean identities for A and B.",
+    "keyInsights": [
+      "**Half-angle linearization**: writing c = π/2 - (a + b) turns sin(C/2) into a polynomial in the sines and cosines of A/2 and B/2, removing the third angle entirely",
+      "**cos(2x) = 1 - 2 sin²x**: the sin-form double angle matches the half-angle products on the right-hand side, so both sides become polynomials in the same four quantities",
+      "**One linear_combination closes it**: modulo the two Pythagorean identities the whole theorem is a single algebraic identity — no case analysis on acute/obtuse is needed because the angle form is sign-agnostic",
+      "**r/R = 4 sin(A/2) sin(B/2) sin(C/2)**: Euler's inradius formula is what connects the proved trigonometric identity to the geometric R + r statement",
+      "**Two algebraic faces of one hypothesis**: the angle form (linear in the half-angle sine products) and the companion cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1 (quadratic in the full-angle cosines) are both polynomial consequences of the single relation A + B + C = π, each closed by a `linear_combination` of two Pythagorean identities in a different coordinate system"
+    ],
+    "prerequisites": [
+      "Real trigonometric functions sin and cos",
+      "Double-angle and angle-addition identities",
+      "The Pythagorean identity sin²x + cos²x = 1",
+      "The angle-sum relation A + B + C = π for a triangle"
+    ],
+    "openQuestions": [
+      "Can the signed-distance form (sum of circumcenter-to-side distances = R + r) be formalized directly over EuclideanSpace ℝ (Fin 2) with an explicit circumcenter and inradius?",
+      "Can Euler's inradius formula r = 4R sin(A/2) sin(B/2) sin(C/2) be formalized to bridge the angle form to the metric form?"
+    ]
+  },
   "sections": [
     {
       "title": "Module header",
@@ -101,37 +124,6 @@
       "id": "fundamental-triangle-cosine-identity"
     }
   ],
-  "overview": {
-    "historicalContext": "Carnot's theorem on the inradius and circumradius is due to Lazare Carnot (1753–1823), the French mathematician, engineer, and politician known as the 'Organizer of Victory' during the French Revolution. It appears in his 1803 work on the geometry of position. The theorem states that, for a triangle with circumradius R and inradius r, the sum of the signed distances from the circumcenter O to the three sides equals R + r. The sign convention is essential: a distance is counted negative when the circumcenter lies on the opposite side of an edge from the triangle's interior, which happens precisely for the side opposite an obtuse angle. With this convention the identity holds for every triangle, acute or obtuse.\n\nDividing the signed-distance form by R, and using that the signed distance from the circumcenter to the side opposite angle θ equals R cos θ (the central angle subtending that side is 2θ), Carnot's theorem becomes the compact trigonometric statement cos A + cos B + cos C = 1 + r/R. Combined with Euler's inradius formula r = 4R sin(A/2) sin(B/2) sin(C/2), the analytic heart of the theorem is the pure identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), which holds for any real angles summing to π.",
-    "problemStatement": "**Carnot's theorem (angle form)**: For any reals A, B, C with A + B + C = π, prove\n\n  cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2).\n\nThis is equivalent to the classical statement that the signed distances from the circumcenter to the three sides of a triangle sum to R + r, since cos A + cos B + cos C = 1 + r/R and r/R = 4 sin(A/2) sin(B/2) sin(C/2).",
-    "text": "For a triangle with circumradius R and inradius r, the signed distances from the circumcenter to the three sides sum to R + r; equivalently cos A + cos B + cos C = 1 + r/R.",
-    "proofStrategy": "The proof works entirely with the angle relation A + B + C = π and reduces to a polynomial identity.\n\n1. **Half angles**: Set a = A/2, b = B/2, c = C/2, so a + b + c = π/2 and c = π/2 - (a + b). Then sin(C/2) = sin(π/2 - (a+b)) = cos(a + b) = cos a cos b - sin a sin b, expressing the third half-angle sine through A/2 and B/2.\n\n2. **Cosine reduction**: Rewrite each full-angle cosine as cos(2·) and apply the double-angle identity cos(2x) = 1 - 2 sin²x. The left side becomes 3 - 2(sin²(A/2) + sin²(B/2) + sin²(C/2)).\n\n3. **Polynomial closure**: After substituting sin(C/2), the goal is a polynomial identity in sin(A/2), cos(A/2), sin(B/2), cos(B/2). It is closed by a single linear_combination of the Pythagorean identities sin²(A/2) + cos²(A/2) = 1 and sin²(B/2) + cos²(B/2) = 1.\n\nThe companion identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1 is proved the same way, using cos C = -cos(A + B) and a linear_combination of the Pythagorean identities for A and B.",
-    "keyInsights": [
-      "**Half-angle linearization**: writing c = π/2 - (a + b) turns sin(C/2) into a polynomial in the sines and cosines of A/2 and B/2, removing the third angle entirely",
-      "**cos(2x) = 1 - 2 sin²x**: the sin-form double angle matches the half-angle products on the right-hand side, so both sides become polynomials in the same four quantities",
-      "**One linear_combination closes it**: modulo the two Pythagorean identities the whole theorem is a single algebraic identity — no case analysis on acute/obtuse is needed because the angle form is sign-agnostic",
-      "**r/R = 4 sin(A/2) sin(B/2) sin(C/2)**: Euler's inradius formula is what connects the proved trigonometric identity to the geometric R + r statement",
-      "**Two algebraic faces of one hypothesis**: the angle form (linear in the half-angle sine products) and the companion cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1 (quadratic in the full-angle cosines) are both polynomial consequences of the single relation A + B + C = π, each closed by a `linear_combination` of two Pythagorean identities in a different coordinate system"
-    ],
-    "prerequisites": [
-      "Real trigonometric functions sin and cos",
-      "Double-angle and angle-addition identities",
-      "The Pythagorean identity sin²x + cos²x = 1",
-      "The angle-sum relation A + B + C = π for a triangle"
-    ],
-    "openQuestions": [
-      "Can the signed-distance form (sum of circumcenter-to-side distances = R + r) be formalized directly over EuclideanSpace ℝ (Fin 2) with an explicit circumcenter and inradius?",
-      "Can Euler's inradius formula r = 4R sin(A/2) sin(B/2) sin(C/2) be formalized to bridge the angle form to the metric form?"
-    ]
-  },
-  "conclusion": {
-    "summary": "Carnot's theorem is formalized in its angle form, cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), for any reals summing to π. A half-angle substitution linearizes the third angle and a single linear_combination modulo the Pythagorean identities closes the proof. The companion fundamental cosine identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1 is also established.",
-    "implications": "**Theoretical Significance**: The proof shows that the analytic content of Carnot's theorem is a polynomial identity, independent of the acute/obtuse case split that the signed-distance form requires geometrically. The same half-angle linearization technique applies to the broad family of triangle identities relating cos A + cos B + cos C, the half-angle products, and r/R.",
-    "openQuestions": [
-      "Can the signed-distance form be formalized directly with an explicit circumcenter over EuclideanSpace ℝ (Fin 2)?",
-      "Can Euler's inradius formula r = 4R sin(A/2) sin(B/2) sin(C/2) be formalized to bridge the two forms?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "law-of-cosines",
@@ -144,7 +136,43 @@
       "description": "Both reduce a classical triangle theorem to an algebraic identity — Napoleon via complex coordinates and a rotation identity, Carnot via half-angle substitution and a Pythagorean linear_combination."
     }
   ],
-  "sorries": 0,
+  "conclusion": {
+    "summary": "Carnot's theorem is formalized in its angle form, cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), for any reals summing to π. A half-angle substitution linearizes the third angle and a single linear_combination modulo the Pythagorean identities closes the proof. The companion fundamental cosine identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1 is also established.",
+    "implications": "**Theoretical Significance**: The proof shows that the analytic content of Carnot's theorem is a polynomial identity, independent of the acute/obtuse case split that the signed-distance form requires geometrically. The same half-angle linearization technique applies to the broad family of triangle identities relating cos A + cos B + cos C, the half-angle products, and r/R.",
+    "openQuestions": [
+      "Can the signed-distance form be formalized directly with an explicit circumcenter over EuclideanSpace ℝ (Fin 2)?",
+      "Can Euler's inradius formula r = 4R sin(A/2) sin(B/2) sin(C/2) be formalized to bridge the two forms?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Carnot, Lazare N. M.",
+      "title": "Géométrie de position",
+      "year": "1803",
+      "venue": "J. B. M. Duprat, Paris",
+      "note": "Origin of Carnot's theorem on signed distances from the circumcenter to the sides."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Carnot's theorem, circumradius/inradius relations, and triangle trigonometry."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin",
+      "note": "Comprehensive classical triangle geometry."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry circumradius/inradius, Real.cos/sin identities and inner-product-space triangle API (Mathlib.Geometry.Euclidean / Mathlib.Analysis.SpecialFunctions.Trigonometric)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"
@@ -159,5 +187,6 @@
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/CarnotTheorem.lean"
-  }
+  },
+  "sorries": 0
 }


### PR DESCRIPTION
## Enrichment pass — cluster

8 verified `carnot-theorem-oq-*` descendants had **no references**. Added 4 references to each, matched to its content:

- **Angle / metric signed-distance form** (Σ signed distances = R + r) — Carnot *Géométrie de position* (1803), Coxeter–Greitzer, Johnson, mathlib
- **Sharp cosine-sum range (1, 3/2] and cosine-product bound** — Mitrinović–Pečarić–Volenec, Coxeter–Greitzer, Andreescu–Andrica, mathlib
- **Squared cosine identity** — Carnot (1803), Mitrinović et al., Coxeter–Greitzer, mathlib
- **Companion sine sum / equilateral maximizer / law-of-sines bridge** — Mitrinović et al., Andreescu–Andrica, Coxeter–Greitzer/Johnson, mathlib

All meta.json within size caps. No Lean source changed.