### PR TITLE
research(seeker): replenish pool with 7 diverse OQ children [verified 0-axiom parents]

### DIFF
--- a/research/problems/derangements-convergence-oq-07/problem.md
+++ b/research/problems/derangements-convergence-oq-07/problem.md
@@ -1,0 +1,124 @@
+# Problem: Binomial Convolution Identity n! = Σ C(n,k)·D(n−k)
+
+**Slug**: derangements-convergence-oq-07
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: derangements-convergence
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+n! = \sum_{k=0}^{n} \binom{n}{k}\, D(n-k),\qquad D = \text{numDerangements}
+$$
+
+### Plain Language
+
+Prove that the factorial equals the binomial convolution of derangement numbers.
+Combinatorially, every permutation of an $n$-element set is uniquely determined by its
+fixed-point set (of size $k$, chosen in $\binom{n}{k}$ ways) together with a derangement
+of the remaining $n-k$ elements. Algebraically this is the **inverse binomial transform**
+of the inclusion–exclusion formula $D(n) = \sum_k (-1)^k n!/k!$ — the dual direction to the
+parent's analytic $D(n)/n! \to e^{-1}$ story.
+
+### Why This Matters
+
+All 12 existing siblings concern the *analytic* side (convergence rate, round/floor/ceiling
+$n!/e$ formulas, sign/two-sided sandwiches, the one-term recurrence and its congruences,
+the Poisson(1) fixed-point distribution). None states the binomial **convolution** identity,
+which is purely combinatorial and absent from Mathlib. It is the counting identity that
+*defines* the relationship between permutations and derangements.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `derangements-convergence` is verified (0-axiom) and supplies
+  `numDerangements_eq_factorial_mul_altSum` ($D(n) = n!\sum_{k\le n}(-1)^k/k!$).
+- Mathlib has `numDerangements`, `numDerangements_sum`, `numDerangements_succ`,
+  `numDerangements_add_two`.
+
+### What's Still Open
+
+- The target identity below (currently `sorry`).
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child of `derangements-convergence`.
+Category: **connection**.
+
+## Target Lean Sketch
+
+```lean
+open Finset
+
+/-- The factorial is the binomial convolution of derangement numbers. -/
+theorem numDerangements_binomial_convolution (n : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), n.choose k * numDerangements (n - k) = n.factorial := by
+  sorry
+```
+
+Two routes:
+- **Double-sum route**: cast to ℝ, expand `D(n−k)` via the parent identity and
+  `C(n,k)·(n−k)! = n!/k!`, swap summation order with `Finset.sum_comm`, and collapse the
+  inner alternating binomial sum with `Int.alternating_sum_range_choose`.
+- **Induction route** (lower risk): strong induction on `n` using `numDerangements_add_two`
+  and Pascal's rule `Nat.choose_succ_succ`; base cases `n = 0, 1` by `decide`, step by
+  `push_cast; ring`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `derangements-convergence` | Parent: D(n)/n! → e⁻¹ | inclusion–exclusion, alternating sum |
+| `derangements-convergence-oq-05` | Sibling: fixed-point distribution (analytic) | Poisson limit |
+
+## Tractability Assessment
+
+**Difficulty**: Moderate
+
+**Significance**: 7/10  |  **Tractability**: 6/10  |  **Tier**: B
+
+**Justification**: All ingredients exist in Mathlib, but the double-sum reindexing (or the
+induction bookkeeping with mixed ℕ/ℤ casts) requires some care. The induction route is a
+reliable fallback.
+
+### Suggested First Steps
+
+1. Reduce to ℝ (or ℤ): rewrite `D(n−k)` using the parent identity and
+   `Nat.choose_mul_factorial_mul_factorial` / `Nat.cast_choose`.
+2. Swap the order of summation with `Finset.sum_comm`; collapse the inner alternating
+   binomial sum with `Int.alternating_sum_range_choose`.
+3. If the swap is fiddly, prove by strong induction on `n` via `numDerangements_add_two`
+   + `Nat.choose_succ_succ`, closing the step with `ring` after `push_cast`.
+
+## References
+
+### Mathlib
+
+- `Nat.choose_mul_factorial_mul_factorial` — Data/Nat/Choose/Basic.lean
+- `Nat.cast_choose` — Data/Nat/Choose/Cast.lean
+- `Int.alternating_sum_range_choose` — Data/Nat/Choose/Sum.lean
+- `numDerangements_sum` — Combinatorics/Derangements/Finite.lean
+- `numDerangements_succ`, `numDerangements_add_two` — Combinatorics/Derangements/Finite.lean
+- `Finset.sum_comm` — Algebra/BigOperators/Basic.lean
+- Parent lemma `numDerangements_eq_factorial_mul_altSum` — proofs/Proofs/DerangementsConvergence.lean
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - derangements
+  - binomial-transform
+  - convolution-identity
+  - inclusion-exclusion
+related_proofs:
+  - derangements-convergence
+  - derangements-convergence-oq-05
+difficulty: moderate
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/fermat-two-squares-oq-08/problem.md
+++ b/research/problems/fermat-two-squares-oq-08/problem.md
@@ -1,0 +1,120 @@
+# Problem: Sum of Two Squares for All Naturals — the Prime-Factorization Criterion
+
+**Slug**: fermat-two-squares-oq-08
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: fermat-two-squares
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+n = x^2 + y^2 \ \text{ for some } x,y \in \mathbb{N}
+\iff \forall\, q \mid n,\ q \equiv 3 \pmod 4 \Rightarrow 2 \mid \nu_q(n)
+$$
+
+### Plain Language
+
+A natural number $n$ is a sum of two squares iff, in its prime factorization, every prime
+$q \equiv 3 \pmod 4$ occurs to an even power. This promotes Fermat's prime-only theorem
+($p$ is a sum of two squares iff $p \ne 3 \bmod 4$) to the full multiplicative
+characterization for **every** natural number. Examples: $45 = 3^2\cdot 5 = 6^2 + 3^2$
+is representable (the 3-mod-4 prime 3 has even exponent 2), while $21 = 3\cdot 7$ is not
+(both 3 and 7 are $\equiv 3 \bmod 4$ with odd exponent 1).
+
+### Why This Matters
+
+This is exactly the parent's stated open question: the composite/all-naturals
+characterization. No sibling states it — oq-05 proves only the necessary mod-4 obstruction
+for a single residue, oq-04 counts representations via the Jacobi divisor-character sum,
+and oq-06/oq-07 formalize the Brahmagupta multiplicativity identities but not the
+factorization criterion. It rests on the multiplicativity of the norm form plus the prime
+case, both already in the gallery/Mathlib.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `fermat-two-squares` is verified (0-axiom).
+- Mathlib contains the exact biconditional `Nat.eq_sq_add_sq_iff`, plus
+  `Nat.Prime.sq_add_sq`, `Nat.sq_add_sq_mul` (Brahmagupta–Fibonacci), and a `Decidable`
+  instance for `∃ x y, n = x^2 + y^2`.
+
+### What's Still Open
+
+- The headline below (currently `sorry`) and its worked corollaries.
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child of `fermat-two-squares`.
+Category: **generalization**.
+
+## Target Lean Sketch
+
+```lean
+theorem sum_two_squares_iff_even_padicVal (n : ℕ) :
+    (∃ x y : ℕ, n = x ^ 2 + y ^ 2) ↔
+      ∀ q ∈ n.primeFactors, q % 4 = 3 → Even (padicValNat q n) := by
+  sorry -- exact Nat.eq_sq_add_sq_iff (modulo namespace/statement shape)
+
+-- worked corollaries, closed by `decide` via the Mathlib Decidable instance:
+example : ∃ x y : ℕ, 45 = x ^ 2 + y ^ 2 := by decide   -- 6² + 3²
+example : ¬ ∃ x y : ℕ, 21 = x ^ 2 + y ^ 2 := by decide  -- 3·7, both 3 mod 4
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `fermat-two-squares` | Parent: prime p ≡ 1 mod 4 ⇒ p = x²+y² | descent / ZMod |
+| `fermat-two-squares-oq-05` | Sibling: mod-4 obstruction (necessity only) | ZMod 4 |
+| `fermat-two-squares-oq-06` | Sibling: Brahmagupta multiplicativity | norm identity |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 7/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: The headline is essentially `Nat.eq_sq_add_sq_iff`; the value of the
+entry is in wrapping it with a pedagogical framing (prime case as a special case) and
+concrete `decide`-checked worked examples using the Mathlib decidability instance.
+
+### Suggested First Steps
+
+1. Prove the headline via `Nat.eq_sq_add_sq_iff`, wrapping it with a docstring tying it to
+   the parent prime case.
+2. Add worked corollaries closed by `decide`: 45, 50 representable; 21, 33 not.
+3. Optionally expose the squarefree-part form `Nat.eq_sq_add_sq_iff_eq_sq_mul` and connect
+   $-1$'s squareness to `ZMod.exists_sq_eq_neg_one_iff` for a second proof route.
+
+## References
+
+### Mathlib
+
+- `Nat.eq_sq_add_sq_iff` — NumberTheory/SumTwoSquares.lean (the exact biconditional)
+- `Nat.eq_sq_add_sq_iff_eq_sq_mul` — NumberTheory/SumTwoSquares.lean
+- `Nat.Prime.sq_add_sq` — NumberTheory/SumTwoSquares.lean (parent prime case)
+- `Nat.sq_add_sq_mul` — NumberTheory/SumTwoSquares.lean (Brahmagupta–Fibonacci over ℕ)
+- `ZMod.exists_sq_eq_neg_one_iff` — NumberTheory/LegendreSymbol/Basic.lean
+- `Decidable (∃ x y, n = x ^ 2 + y ^ 2)` instance — NumberTheory/SumTwoSquares.lean
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - sum-of-two-squares
+  - prime-factorization
+  - fermat
+  - gaussian-integers
+related_proofs:
+  - fermat-two-squares
+  - fermat-two-squares-oq-05
+  - fermat-two-squares-oq-06
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/herons-formula-oq-07/problem.md
+++ b/research/problems/herons-formula-oq-07/problem.md
@@ -1,0 +1,121 @@
+# Problem: Weitzenböck's Inequality from Heron's Formula
+
+**Slug**: herons-formula-oq-07
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: herons-formula
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+a^2 + b^2 + c^2 \ge 4\sqrt{3}\cdot \text{Area},\qquad
+\text{Area} = \sqrt{s(s-a)(s-b)(s-c)},\ \ s = \tfrac{a+b+c}{2}
+$$
+
+with equality iff the triangle is equilateral (IMO 1961, Problem 2).
+
+### Plain Language
+
+For any nondegenerate triangle with side lengths $a, b, c$, the sum of the squares of the
+sides bounds the area from above: $a^2 + b^2 + c^2 \ge 4\sqrt{3}\,\text{Area}$, where Area
+is Heron's formula. The proof squares both sides — reducing to $48\,\text{Area}^2 \le
+(a^2+b^2+c^2)^2$ — expands $16\,\text{Area}^2 = 2a^2b^2 + 2b^2c^2 + 2c^2a^2 - a^4 - b^4 - c^4$
+by `ring`, and finishes with the sum-of-squares fact
+$a^4 + b^4 + c^4 \ge a^2b^2 + b^2c^2 + c^2a^2$, i.e.
+$\tfrac12((a^2-b^2)^2 + (b^2-c^2)^2 + (c^2-a^2)^2) \ge 0$.
+
+### Why This Matters
+
+Weitzenböck's inequality is a distinct classical named result (IMO 1961) relating the
+**sum of squared sides** to area. The eight siblings cover Brahmagupta (oq-01), Kahan
+stability (oq-03), the isoperimetric max-area result (oq-04), Cayley–Menger (oq-05,
+oq-05-oq-03), and the circum/inradius family (oq-06 branch) — none is Weitzenböck.
+It exercises a different SOS mechanism than the perimeter-fixing AM-GM of oq-04 and
+touches neither $R$ nor $r$.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `herons-formula` is verified (0-axiom) and supplies the area formula.
+- The `Real.sqrt` lemmas below are grep-confirmed in `Mathlib/Data/Real/Sqrt.lean`.
+
+### What's Still Open
+
+- The target inequality below (currently `sorry`).
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child of `herons-formula`.
+Category: **extension** (geometric inequality).
+
+## Target Lean Sketch
+
+```lean
+open Real
+
+theorem weitzenboeck (a b c : ℝ) (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    4 * Real.sqrt 3 *
+        Real.sqrt ((a + b + c) / 2 * ((a + b + c) / 2 - a) *
+          ((a + b + c) / 2 - b) * ((a + b + c) / 2 - c))
+      ≤ a ^ 2 + b ^ 2 + c ^ 2 := by
+  sorry
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `herons-formula` | Parent: Area = √(s(s−a)(s−b)(s−c)) | Heron's formula |
+| `herons-formula-oq-04` | Sibling: isoperimetric max area (fixes perimeter) | AM-GM |
+| `herons-formula-oq-05` | Sibling: Cayley–Menger determinant | determinant area |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 7/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: Both sides are nonnegative, so squaring reduces the goal to a polynomial
+inequality dischargeable by `nlinarith` with three explicit SOS hints. Only three `Real.sqrt`
+rewrite lemmas are needed.
+
+### Suggested First Steps
+
+1. State with Area = `Real.sqrt` of the explicit Heron product; note both sides nonneg.
+2. Rewrite `4·√3·√(hp) = √(48·hp)` via `Real.sqrt_mul`, and `a²+b²+c² = √((a²+b²+c²)²)`
+   via `Real.sqrt_sq`; then apply `Real.sqrt_le_sqrt`.
+3. Discharge `48·hp ≤ (a²+b²+c²)²` by `ring_nf` +
+   `nlinarith [sq_nonneg (a^2-b^2), sq_nonneg (b^2-c^2), sq_nonneg (c^2-a^2)]`.
+
+## References
+
+### Mathlib
+
+- `Real.sqrt_mul` — Data/Real/Sqrt.lean (√(x·y) = √x·√y for 0 ≤ x)
+- `Real.sqrt_sq` — Data/Real/Sqrt.lean (√(x²) = x for 0 ≤ x)
+- `Real.sqrt_le_sqrt` — Data/Real/Sqrt.lean
+- `Real.sqrt_nonneg` — Data/Real/Sqrt.lean
+- `sq_nonneg` — Mathlib (SOS hints for `nlinarith`)
+
+## Metadata
+
+```yaml
+tags:
+  - geometry
+  - triangle-inequality
+  - weitzenboeck
+  - sum-of-squares
+  - imo
+related_proofs:
+  - herons-formula
+  - herons-formula-oq-04
+  - herons-formula-oq-05
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/kummer-theorem-oq-05/problem.md
+++ b/research/problems/kummer-theorem-oq-05/problem.md
@@ -1,0 +1,129 @@
+# Problem: Kummer's Digit-Sum Divisibility Criterion for Binomial Coefficients
+
+**Slug**: kummer-theorem-oq-05
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: kummer-theorem
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+(p-1)\cdot \nu_p\!\binom{n}{k} = S_p(k) + S_p(n-k) - S_p(n),\qquad
+p \nmid \binom{n}{k} \iff S_p(k) + S_p(n-k) = S_p(n)
+$$
+
+where $S_p(\cdot)$ is the base-$p$ digit sum and $k \le n$.
+
+### Plain Language
+
+Complete the binomial (as opposed to factorial) side of the Legendre/Kummer digit-sum
+theory. For a prime $p$ and $k \le n$, the $p$-adic valuation of $\binom{n}{k}$ is
+$(S_p(k) + S_p(n-k) - S_p(n))/(p-1)$. Consequently $p \nmid \binom{n}{k}$ exactly when
+the base-$p$ digits of $k$ and $n-k$ add with no digit loss (equivalently, no carries
+occur when adding $k$ and $n-k$ in base $p$) — the criterion form of Kummer's theorem.
+
+### Why This Matters
+
+The parent Lean file states the identity $(p-1)\nu_p\binom{n}{k} = S_p(k)+S_p(n-k)-S_p(n)$
+in prose but only proves the **factorial** Legendre case. This child completes the
+binomial identity and derives the clean "no digit loss ⟺ not divisible" criterion —
+a form no sibling covers (oq-01 does multinomial carry counts, oq-03 characterizes
+divisibility mod $p^m$ via carry counts, the oq-04 branch specializes to the 2-adic
+valuation of the central binomial / Catalan via popcount).
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `kummer-theorem` is verified (0-axiom) and supplies the base theory.
+- Mathlib already contains the master identity `padicValNat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits`.
+
+### What's Still Open
+
+- The target theorems below (currently `sorry`).
+
+### Our Goal
+
+Prove the sketch below as a self-contained verified (0-axiom) child of `kummer-theorem`.
+Category: **completion**.
+
+## Target Lean Sketch
+
+```lean
+open Nat
+
+/-- Kummer's identity for the binomial `p`-adic valuation. -/
+theorem kummer_choose_digit_sum {p n k : ℕ} [hp : Fact p.Prime] (h : k ≤ n) :
+    (p - 1) * padicValNat p (Nat.choose n k)
+      = (p.digits k).sum + (p.digits (n - k)).sum - (p.digits n).sum := by
+  sorry -- wrapper of padicValNat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits
+
+/-- Divisibility criterion: no digit loss ⟺ `p ∤ C(n,k)`. -/
+theorem kummer_digit_sum_dvd_iff {p n k : ℕ} [hp : Fact p.Prime] (h : k ≤ n) :
+    ¬ p ∣ Nat.choose n k ↔
+      (p.digits k).sum + (p.digits (n - k)).sum = (p.digits n).sum := by
+  sorry -- via dvd_iff_padicValNat_ne_zero + the identity + Nat.sub_eq_zero_iff_le
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `kummer-theorem` | Parent: Kummer's theorem (carries) | p-adic valuation, base-p digits |
+| `kummer-theorem-oq-03` | Sibling: divisibility mod p^m via carry counts | carry counting |
+| `kummer-theorem-oq-01` | Sibling: multinomial carry counts | multinomial coefficients |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 6/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: The core identity is a direct Mathlib lemma; the criterion follows by
+rewriting the valuation-nonzero condition and using `Nat.sub_eq_zero_iff_le` with the
+digit-sum bound. Mostly assembly of named lemmas.
+
+### Suggested First Steps
+
+1. Prove `kummer_choose_digit_sum` as a thin wrapper of
+   `padicValNat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits` (convert
+   multiplicity/factorization to `padicValNat` as the parent does).
+2. Prove `kummer_digit_sum_dvd_iff`: rewrite via `dvd_iff_padicValNat_ne_zero`
+   (using `Nat.choose_ne_zero` from `k ≤ n`), reduce `(p-1)*v = 0 ↔ v = 0`
+   (`p-1 > 0`), substitute the identity, and close with `Nat.sub_eq_zero_iff_le`
+   plus `Nat.digit_sum_le`.
+3. Add the explicit valuation corollary and `native_decide` worked examples
+   (e.g. `C(10,4)`, `C(6,3)`) cross-checking digit sums against the parent's
+   carry-count examples.
+
+## References
+
+### Mathlib
+
+- `padicValNat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits` — NumberTheory/Padics/PadicVal/Basic.lean (the master identity)
+- `padicValNat.dvd_iff_padicValNat_ne_zero` — NumberTheory/Padics/PadicVal/Basic.lean
+- `padicValNat_choose` — NumberTheory/Padics/PadicVal/Basic.lean (Kummer carry-count form)
+- `Nat.digit_sum_le` — Data/Nat/Digits/Defs.lean
+- `Nat.sub_one_mul_factorization_factorial` — Data/Nat/Choose/Factorization.lean (parent's proven factorial case, for cross-checking)
+- `Nat.choose_pos`, `Nat.choose_ne_zero` — Data/Nat/Choose/Basic.lean
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - p-adic-valuation
+  - binomial-coefficients
+  - kummers-theorem
+  - digit-sum
+related_proofs:
+  - kummer-theorem
+  - kummer-theorem-oq-03
+  - kummer-theorem-oq-01
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/mean-value-theorem-oq-06/problem.md
+++ b/research/problems/mean-value-theorem-oq-06/problem.md
@@ -1,0 +1,119 @@
+# Problem: Two-Sided Derivative Bounds Sandwich the Increment
+
+**Slug**: mean-value-theorem-oq-06
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: mean-value-theorem
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+m \le f'(x) \le M \ \forall x \in (a,b)
+\ \Rightarrow\
+m\,(b-a) \le f(b) - f(a) \le M\,(b-a)
+$$
+
+### Plain Language
+
+If $f$ is continuous on $[a,b]$ ($a \le b$) and differentiable on $(a,b)$ with derivative
+bounded between constants $m \le f'(x) \le M$, then the total increment is sandwiched:
+$m(b-a) \le f(b) - f(a) \le M(b-a)$. This is the signed, two-sided quantitative form of the
+Mean Value Theorem — it turns pointwise upper *and* lower derivative bounds into global
+lower and upper bounds on the finite difference. It specializes: $m > 0$ gives a strict
+increase gap, $M < 0$ a strict decrease, and $m = -M = C$ recovers the scalar Lipschitz
+bound $|f(b) - f(a)| \le C(b-a)$.
+
+### Why This Matters
+
+Sibling oq-03 (Vector-Valued Mean Value Inequality) proves only the *absolute* upper bound
+$\|f(b)-f(a)\| \le C(b-a)$ — a one-sided magnitude bound that discards sign and gives no
+lower bound. This child proves the **signed, two-sided** sandwich for scalar $f$, capturing
+the lower bound and direction (oq-03's norm inequality is the $m = -M$ special case). It is
+also distinct from oq-02 (Taylor/Lagrange remainder), oq-04 (FTC), oq-04-oq-03 (trapezoidal
+rule), and oq-05 (Darboux). No sibling formalizes the increment sandwich.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `mean-value-theorem` is verified (0-axiom).
+- Mathlib supplies `Convex.mul_sub_le_image_sub_of_le_deriv` and
+  `Convex.image_sub_le_mul_sub_of_deriv_le`, both built on the core MVT.
+
+### What's Still Open
+
+- The target theorem below (currently `sorry`) plus a monotonicity/Lipschitz corollary.
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child of `mean-value-theorem`.
+Category: **extension** (real analysis).
+
+## Target Lean Sketch
+
+```lean
+open Set
+
+theorem deriv_bounds_imply_increment_bounds {a b m M : ℝ} (hab : a ≤ b) {f : ℝ → ℝ}
+    (hfc : ContinuousOn f (Set.Icc a b))
+    (hfd : DifferentiableOn ℝ f (Set.Ioo a b))
+    (hm : ∀ x ∈ Set.Ioo a b, m ≤ deriv f x)
+    (hM : ∀ x ∈ Set.Ioo a b, deriv f x ≤ M) :
+    m * (b - a) ≤ f b - f a ∧ f b - f a ≤ M * (b - a) := by
+  sorry
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `mean-value-theorem` | Parent: MVT / Rolle | mean value theorem |
+| `mean-value-theorem-oq-03` | Sibling: vector-valued MVT inequality (absolute, one-sided) | norm bound |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 5/10  |  **Tractability**: 9/10  |  **Tier**: C
+
+**Justification**: Both bounds are direct applications of named Mathlib `Convex.*` lemmas
+after rewriting `Ioo a b = interior (Icc a b)`. Assembly-level.
+
+### Suggested First Steps
+
+1. `rw [← interior_Icc] at hfd hm hM` so the `Convex.*` lemmas apply directly.
+2. Split with `refine ⟨?_, ?_⟩`; discharge the lower bound with
+   `(convex_Icc a b).mul_sub_le_image_sub_of_le_deriv hfc hfd hm ...` and the upper bound
+   with `(convex_Icc a b).image_sub_le_mul_sub_of_deriv_le hfc hfd hM ...`.
+3. Add a corollary: quantitative strict monotonicity ($m > 0 \Rightarrow f a < f b$) or
+   recover $|f(b)-f(a)| \le C(b-a)$ from $m = -C, M = C$ via `abs_le`.
+
+## References
+
+### Mathlib
+
+- `Convex.mul_sub_le_image_sub_of_le_deriv` — Analysis/Calculus/Deriv/MeanValue.lean
+- `Convex.image_sub_le_mul_sub_of_deriv_le` — Analysis/Calculus/Deriv/MeanValue.lean
+- `convex_Icc` — Analysis/Convex/Basic.lean
+- `interior_Icc` — Topology/Order/DenselyOrdered.lean
+- `exists_deriv_eq_slope` — Analysis/Calculus/Deriv/MeanValue.lean (core MVT engine)
+
+## Metadata
+
+```yaml
+tags:
+  - calculus
+  - real-analysis
+  - mean-value-theorem
+  - derivative-bounds
+  - monotonicity
+related_proofs:
+  - mean-value-theorem
+  - mean-value-theorem-oq-03
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/schroeder-bernstein-oq-05/problem.md
+++ b/research/problems/schroeder-bernstein-oq-05/problem.md
@@ -1,0 +1,121 @@
+# Problem: Dual Schröder–Bernstein — Mutual Surjections Imply Equinumerosity
+
+**Slug**: schroeder-bernstein-oq-05
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: schroeder-bernstein
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+(\exists\, f : A \twoheadrightarrow B)\ \wedge\ (\exists\, g : B \twoheadrightarrow A)
+\ \Rightarrow\ \exists\, h : A \xrightarrow{\ \sim\ } B
+$$
+
+### Plain Language
+
+If there exist surjections $f : A \to B$ and $g : B \to A$, then $A$ and $B$ are
+equinumerous. This is the **dual** Schröder–Bernstein theorem. Unlike the injective form
+(which holds in ZF), the surjective form genuinely requires the axiom of choice: each
+surjection is turned into an injection the other way by choosing a section (right inverse),
+after which the ordinary Schröder–Bernstein theorem applies. The entry pinpoints exactly
+where choice enters (the two section choices).
+
+### Why This Matters
+
+This answers the parent's explicitly listed unanswered open question #4 (the surjective /
+dual formulation). All existing siblings treat the injective input case: oq-01 (categorical
+SBP), oq-02 (Knaster–Tarski fixed-point proofs), oq-03 (Myhill computable isomorphism),
+oq-04 (constructive/decidability content). The dual is a distinct theorem with a distinct
+foundational subtlety — its dependence on choice.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `schroeder-bernstein` is verified (0-axiom).
+- Mathlib supplies `Function.Embedding.schroeder_bernstein` (mutual injections ⇒ bijection),
+  `Function.Surjective.hasRightInverse`, and `Function.RightInverse.injective`.
+
+### What's Still Open
+
+- The target theorem below (currently `sorry`), plus the Equiv/Cardinal corollary.
+
+### Our Goal
+
+Prove the sketch below as a verified child of `schroeder-bernstein` (note: the result is a
+theorem *of ZFC* — its proof legitimately uses `Classical.choice`; the entry documents this
+rather than claiming choice-freeness). Category: **extension**.
+
+## Target Lean Sketch
+
+```lean
+open Function
+
+theorem dual_schroeder_bernstein {α β : Type*} {f : α → β} {g : β → α}
+    (hf : Function.Surjective f) (hg : Function.Surjective g) :
+    ∃ h : α → β, Function.Bijective h := by
+  obtain ⟨f', hf'⟩ := hf.hasRightInverse   -- f' : β → α, section of f, injective
+  obtain ⟨g', hg'⟩ := hg.hasRightInverse   -- g' : α → β, section of g, injective
+  exact Function.Embedding.schroeder_bernstein hg'.injective hf'.injective
+
+-- corollary: bundled equinumerosity
+theorem dual_schroeder_bernstein_equiv {α β : Type*} {f : α → β} {g : β → α}
+    (hf : Function.Surjective f) (hg : Function.Surjective g) :
+    Nonempty (α ≃ β) := by sorry -- via Function.Embedding.antisymm on the two embeddings
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `schroeder-bernstein` | Parent: mutual injections ⇒ bijection | fixed-point / orbit analysis |
+| `schroeder-bernstein-oq-02` | Sibling: Knaster–Tarski fixed-point proof | lattice fixed points |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 6/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: The headline is a three-line composition of named Mathlib lemmas; the
+mathematical content is the *framing* (dual statement, isolating the two `Classical.choice`
+invocations that make the dual choice-dependent).
+
+### Suggested First Steps
+
+1. State for arbitrary `Type*` α, β with two surjections; obtain sections via
+   `hf.hasRightInverse` / `hg.hasRightInverse`.
+2. Convert each section to an injection with `.injective`, then feed into
+   `Function.Embedding.schroeder_bernstein`.
+3. Add the `Nonempty (α ≃ β)` corollary via `Function.Embedding.antisymm`, plus a docstring
+   note isolating the two `Classical.choice` uses.
+
+## References
+
+### Mathlib
+
+- `Function.Surjective.hasRightInverse` — Logic/Function/Basic.lean (the choice step)
+- `Function.RightInverse.injective` — Logic/Function/Basic.lean
+- `Function.Embedding.schroeder_bernstein` — SetTheory/Cardinal/SchroederBernstein.lean
+- `Function.Embedding.antisymm` — SetTheory/Cardinal/SchroederBernstein.lean
+
+## Metadata
+
+```yaml
+tags:
+  - set-theory
+  - cardinality
+  - schroeder-bernstein
+  - axiom-of-choice
+  - surjections
+related_proofs:
+  - schroeder-bernstein
+  - schroeder-bernstein-oq-02
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/sylow-theorem-oq-05/problem.md
+++ b/research/problems/sylow-theorem-oq-05/problem.md
@@ -1,0 +1,118 @@
+# Problem: Groups of Order p² are Abelian
+
+**Slug**: sylow-theorem-oq-05
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: sylow-theorem
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+|G| = p^2,\ p \text{ prime}\ \Rightarrow\ \forall\, a,b \in G,\ ab = ba
+$$
+
+### Plain Language
+
+Let $p$ be a prime and $G$ a group of order exactly $p^2$. Then $G$ is abelian; consequently
+$G \cong \mathbb{Z}/p^2$ or $G \cong \mathbb{Z}/p \times \mathbb{Z}/p$. The proof rests on the
+fact that a nontrivial finite $p$-group has nontrivial center: $|Z(G)| \in \{p, p^2\}$. If
+$|Z(G)| = p^2$ then $G$ is abelian directly; if $|Z(G)| = p$ then $G/Z(G)$ has order $p$,
+hence is cyclic, and a group whose central quotient is cyclic is itself abelian — forcing
+$|Z(G)| = p^2$, a contradiction. Either way $G$ is commutative.
+
+### Why This Matters
+
+This is the prime-square case of small-group classification and complements the sibling
+entries that classify groups of order $pq$: it handles the one remaining two-prime-power
+order type. None of the 9 existing siblings treat prime-square order (oq-01 and oq-03-oq-02
+do order $pq$ with *distinct* primes; the oq-02 branch covers orbit counting / nilpotency /
+characteristic Sylow subgroups; oq-03/oq-03-oq-01 are Schur–Zassenhaus; oq-04 is simplicity
+of $A_5$).
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `sylow-theorem` is verified (0-axiom).
+- Mathlib supplies `IsPGroup.commutative_of_card_eq_prime_sq` — the exact result — requiring
+  only `[Group G] [Fact p.Prime]` and `Nat.card G = p^2` (finiteness derived internally).
+
+### What's Still Open
+
+- The headline below (currently `sorry`) plus its unfolded pedagogical proof and corollaries.
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child of `sylow-theorem`.
+Category: **extension** (finite-group classification).
+
+## Target Lean Sketch
+
+```lean
+theorem group_of_prime_sq_abelian (G : Type*) [Group G] (p : ℕ) [Fact p.Prime]
+    (hG : Nat.card G = p ^ 2) : ∀ a b : G, a * b = b * a :=
+  IsPGroup.commutative_of_card_eq_prime_sq hG
+
+-- substance beyond the re-export: center is everything, plus small examples
+theorem center_eq_top_of_prime_sq (G : Type*) [Group G] (p : ℕ) [Fact p.Prime]
+    (hG : Nat.card G = p ^ 2) : Subgroup.center G = ⊤ := by sorry
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `sylow-theorem` | Parent: Sylow's theorems | p-groups, group actions |
+| `sylow-theorem-oq-01` | Sibling: groups of order pq | Sylow counting |
+| `sylow-theorem-oq-04` | Sibling: simplicity of A₅ | conjugacy classes |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 6/10  |  **Tractability**: 9/10  |  **Tier**: B
+
+**Justification**: The headline closes in one line with a Mathlib lemma; the entry's value
+is a pedagogically unfolded proof (center dichotomy) and concrete instantiations (order 4,
+order 9).
+
+### Suggested First Steps
+
+1. Close `group_of_prime_sq_abelian` with `IsPGroup.commutative_of_card_eq_prime_sq hG`.
+2. Add `center_eq_top_of_prime_sq` and small `example`s at `p = 2` (order 4), `p = 3`
+   (order 9).
+3. Write an unfolded proof sketch in the docstring using `center_nontrivial`,
+   `card_center_eq_prime_pow`, `cyclic_center_quotient_of_card_eq_prime_sq`,
+   `commutative_of_cyclic_center_quotient` — explaining the $|Z(G)| \in \{p, p^2\}$ dichotomy.
+
+## References
+
+### Mathlib
+
+- `IsPGroup.commutative_of_card_eq_prime_sq` — GroupTheory/PGroup.lean (the exact result)
+- `IsPGroup.commGroupOfCardEqPrimeSq` — GroupTheory/PGroup.lean (CommGroup instance)
+- `IsPGroup.cyclic_center_quotient_of_card_eq_prime_sq` — GroupTheory/PGroup.lean
+- `IsPGroup.center_nontrivial` — GroupTheory/PGroup.lean
+- `IsPGroup.card_center_eq_prime_pow` — GroupTheory/PGroup.lean
+- `commutative_of_cyclic_center_quotient` — GroupTheory/SpecificGroups/Cyclic.lean
+
+## Metadata
+
+```yaml
+tags:
+  - group-theory
+  - sylow
+  - p-groups
+  - finite-group-classification
+  - abelian-groups
+related_proofs:
+  - sylow-theorem
+  - sylow-theorem-oq-01
+  - sylow-theorem-oq-04
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```


### PR DESCRIPTION
## Summary

Seeker replenishment cycle. The **effective** free pool had dropped to **1** — 44 of the 45 nominally "available" candidates already have research dirs (i.e. claimed/in-flight). This PR seeds **7 new tractable open-question children**, one per mathematical domain, each spawned from a **verified 0-axiom classic parent**.

## Selected problems

| Slug | Domain | Statement | Tract | Sig |
|------|--------|-----------|:-----:|:---:|
| `kummer-theorem-oq-05` | number theory (p-adic) | binomial digit-sum divisibility criterion: p∤C(n,k) ⇔ S_p(k)+S_p(n−k)=S_p(n) | 8 | 6 |
| `derangements-convergence-oq-07` | combinatorics | n! = Σ C(n,k)·D(n−k) (inverse binomial transform) | 6 | 7 |
| `herons-formula-oq-07` | geometry | Weitzenböck's inequality a²+b²+c² ≥ 4√3·Area (IMO 1961) | 8 | 7 |
| `fermat-two-squares-oq-08` | number theory | n=x²+y² ⇔ every q≡3 mod 4 has even exponent | 8 | 7 |
| `schroeder-bernstein-oq-05` | set theory | dual SB: mutual surjections ⇒ equinumerosity (needs choice) | 8 | 6 |
| `sylow-theorem-oq-05` | group theory | groups of order p² are abelian | 9 | 6 |
| `mean-value-theorem-oq-06` | real analysis | two-sided derivative bounds sandwich the increment | 9 | 5 |

## Quality gates

- **Diversity**: 7 distinct domains (avoided domains used in recent cycles — taylor/basel/binomial/abel-ruffini/cauchy-interlacing/shapley/halting).
- **OQ guardrails**: every child is depth-1 (`-oq-` appears once), no repeated `-oq-NN` index, and confirmed non-duplicate vs existing siblings.
- **Mathlib support**: each proposal's key lemmas were grep-confirmed to exist in the pinned Mathlib by an independent verification pass before seeding (e.g. `padicValNat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits`, `numDerangements_sum`, `Real.sqrt_mul`, `Nat.eq_sq_add_sq_iff`, `Function.Embedding.schroeder_bernstein`, `IsPGroup.commutative_of_card_eq_prime_sq`, `Convex.mul_sub_le_image_sub_of_le_deriv`).
- **Validation**: all 7 pass `validate-seeker-stubs.ts` (no template placeholders).

Database + candidate-pool.json updated locally (gitignored); this PR carries the git-tracked `problem.md` stubs for the Researcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
