### PR TITLE
Enrich descartes-rule-of-signs OQ cluster: add references to 10 entries

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-02/meta.json
@@ -114,6 +114,46 @@
       "mathContext": "Honest scoping: the whole-line case is proved; the finite-interval generalization is the natural next step and reuses this file's backbone."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Budan de Boislaurent, F.D."
+      ],
+      "title": "Nouvelle méthode pour la résolution des équations numériques",
+      "year": "1807",
+      "venue": "Paris",
+      "note": "Budan's theorem bounding real roots in an interval by the drop in sign variations."
+    },
+    {
+      "authors": [
+        "Fourier, J.B.J."
+      ],
+      "title": "Analyse des équations déterminées",
+      "year": "1831",
+      "venue": "Firmin Didot, Paris (posthumous)",
+      "note": "The Fourier (iterated-derivative) sign-variation sequence underlying the Budan–Fourier theorem."
+    },
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference covering Descartes' rule, the Budan–Fourier theorem, Sturm's theorem and root-localization bounds."
+    },
+    {
+      "authors": [
+        "Basu, S.",
+        "Pollack, R.",
+        "Roy, M.-F."
+      ],
+      "title": "Algorithms in Real Algebraic Geometry",
+      "year": "2006",
+      "venue": "Algorithms and Computation in Mathematics 10, 2nd ed., Springer",
+      "note": "Standard algorithmic reference for sign variations, Sturm sequences, and real-root isolation (Vincent/VAS/VCA)."
+    }
+  ],
   "conclusion": {
     "summary": "YES — a Budan–Fourier formalization can be built on the parent's framework. This entry formalizes the endpoint backbone (the Fourier sequence's leading-coefficient law and the sign-variation counts V(+∞)=0, V(−∞)=n) and proves the whole-line identity V(−∞) − V(+∞) = deg p, which recovers the parent's parity result as the interval-(−∞,+∞) case of Budan–Fourier. All 11 theorems are machine-checked with 0 sorries and 0 axioms.",
     "implications": "The descending-factorial leading-coefficient law (leadingCoeff_iterate_derivative) and the sign-variation counter (sv) are reusable infrastructure for the full finite-interval Budan–Fourier theorem and for Sturm-sequence formalizations. The whole-line result makes explicit the precise sense in which Descartes/parity is the endpoint case of Budan–Fourier, complementing the parent file's complex-conjugate-pairing explanation of the same parity fact.",

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-03/meta.json
@@ -116,6 +116,27 @@
       "mathContext": "$\\#\\{z: \\Im z\\ne 0\\}$ even $\\Rightarrow \\#\\{z: \\Im z=0\\} \\equiv \\deg p \\pmod 2$ (counts with multiplicity, using $\\#\\mathrm{roots}=\\deg p$ over $\\mathbb{C}$)."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference covering Descartes' rule, the Budan–Fourier theorem, Sturm's theorem and root-localization bounds."
+    },
+    {
+      "authors": [
+        "Rahman, Q.I.",
+        "Schmeisser, G."
+      ],
+      "title": "Analytic Theory of Polynomials",
+      "year": "2002",
+      "venue": "London Mathematical Society Monographs 26, Oxford University Press",
+      "note": "Comprehensive treatment of root distribution, sign variations and conjugate-root structure."
+    }
+  ],
   "conclusion": {
     "summary": "For a real polynomial viewed over ℂ, a root and its conjugate occur with equal multiplicity in the root multiset; therefore the non-real roots counted with multiplicity are even in number and the real roots counted with multiplicity are congruent to the degree modulo 2. This refines the parent entry's set-level pairing to the level of multiplicities, answering its open question.",
     "implications": "The multiplicity-aware pairing is the natural home for the parity behind Descartes' rule of signs and is the right foundation for a multiplicity-correct treatment of Budan–Fourier-type root counts.",
@@ -126,8 +147,12 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Polynomial"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
     "namespace": "DescartesRuleComplexMult",
     "lineCount": 147,
     "axiomCount": 0,

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
@@ -103,6 +103,27 @@
       "mathContext": "Cubic (3 = r + 2k): r ∈ {1,3}. Quartic (4 = r + 2k): r ∈ {0,2,4}. Assessment: complex approach is pedagogically valuable (explains WHY) but factoring approach is more direct in Lean."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference covering Descartes' rule, the Budan–Fourier theorem, Sturm's theorem and root-localization bounds."
+    },
+    {
+      "authors": [
+        "Rahman, Q.I.",
+        "Schmeisser, G."
+      ],
+      "title": "Analytic Theory of Polynomials",
+      "year": "2002",
+      "venue": "London Mathematical Society Monographs 26, Oxford University Press",
+      "note": "Comprehensive treatment of root distribution, sign variations and conjugate-root structure."
+    }
+  ],
   "conclusion": {
     "summary": "YES, the complex root theory approach can prove the Descartes parity result. The formalization proves eval_conj_eq_conj_eval (via polynomial induction), the conjugate root theorem, and the parity arithmetic framework. The approach is more pedagogically informative than the factoring proof but less direct in Lean.",
     "implications": "The comparative analysis — showing that two proof approaches are valid but differ in directness — models best practice in formal mathematics: understanding not just what can be proved but how different methods compare. The conjugate root approach generalizes immediately to other complex number fields and provides structural insight into why parity holds. The parity framework (parity_of_real_roots) is reusable for any polynomial degree.",

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/meta.json
@@ -117,6 +117,26 @@
       "description": "The classical Descartes Rule of Signs at the root of the OQ chain"
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Descartes, R."
+      ],
+      "title": "La Géométrie",
+      "year": "1637",
+      "venue": "Appendix to Discours de la méthode, Leiden",
+      "note": "Original statement of the rule of signs."
+    },
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference covering Descartes' rule, the Budan–Fourier theorem, Sturm's theorem and root-localization bounds."
+    }
+  ],
   "conclusion": {
     "summary": "In the boundary cases the exact positive-root count is recovered without the parity refinement: signVariations = 0 gives 0 roots from Descartes' bound, and signVariations = 1 gives exactly one root from the bound (≤ 1) together with the Intermediate Value Theorem (≥ 1). The IVT existence argument — deflate by Xᵐ, then cross zero between the trailing sign at 0 and the leading sign at +∞ — is fully machine-checked with 0 sorries and 0 axioms. The only non-analytic input, that one sign variation forces opposite leading/trailing signs, is taken as an explicit combinatorial hypothesis.",
     "implications": "Shows the boundary cases of Descartes' Rule are strictly easier than the general parity refinement: they require only existence of a sign-change root, a completeness/IVT phenomenon, not the odd-multiplicity FTA argument the gallery has consistently left open. The deflate-then-IVT pattern (P = Xᵐ·Q with nonzero constant term, sign at 0 vs sign at +∞) is reusable for other sign-change root-existence facts. Reduces the open unconditional boundary count to a single, analysis-free combinatorial lemma about List.destutter.",

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/meta.json
@@ -130,6 +130,38 @@
       "description": "The classical Descartes rule of signs — root of the OQ chain studied here."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Basu, S.",
+        "Pollack, R.",
+        "Roy, M.-F."
+      ],
+      "title": "Algorithms in Real Algebraic Geometry",
+      "year": "2006",
+      "venue": "Algorithms and Computation in Mathematics 10, 2nd ed., Springer",
+      "note": "Standard algorithmic reference for sign variations, Sturm sequences, and real-root isolation (Vincent/VAS/VCA)."
+    },
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference covering Descartes' rule, the Budan–Fourier theorem, Sturm's theorem and root-localization bounds."
+    },
+    {
+      "authors": [
+        "The mathlib community"
+      ],
+      "title": "Mathlib.Analysis.SpecialFunctions.Polynomials / Polynomial.signVariations",
+      "year": "2020",
+      "venue": "Mathlib4, Lean 4 mathematical library",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/",
+      "note": "Mathlib's abstract signVariations and roots API that these entries bridge to a computable form."
+    }
+  ],
   "conclusion": {
     "summary": "YES: the computable sign-variation count generalizes verbatim to any ordered field with decidable order, with the rfl bridge intact, because Mathlib's signVariations already lives at that generality and the count is purely combinatorial on signs. The substantive new result is that signVariations is invariant under any strictly monotone ring homomorphism (signVariations_map) — a fact not in Mathlib. Specializing to ℚ ↪ ℝ shows the kernel-reducible rational count equals the real polynomial's count, so it bounds the positive REAL roots, repairing the gap left by the parent (whose bound only constrained rational roots). All with 0 axioms; examples by kernel decide.",
     "implications": "Map-invariance of signVariations is reusable infrastructure: it lets any computable subfield (ℚ, computable algebraic reals) certify sign-variation facts about polynomials over a larger ordered field by pushing forward along an order embedding. It is also exactly the lemma needed to make the constructive Descartes bound a statement about real roots rather than coefficient-field roots. The trichotomy proof that a strict-mono ring hom preserves SignType.sign is a small lemma of independent use for any sign-driven polynomial invariant.",

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04/meta.json
@@ -122,6 +122,39 @@
       "description": "Sibling OQ exploring the complex-root-theory route to the parity result; this file instead pursues constructivity"
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Collins, G.E.",
+        "Akritas, A.G."
+      ],
+      "title": "Polynomial real root isolation using Descartes' rule of signs",
+      "year": "1976",
+      "venue": "Proc. ACM Symposium on Symbolic and Algebraic Computation (SYMSAC), pp. 272–275",
+      "note": "The Descartes/Vincent-based real-root isolation algorithm behind the computable sign-variation count."
+    },
+    {
+      "authors": [
+        "Basu, S.",
+        "Pollack, R.",
+        "Roy, M.-F."
+      ],
+      "title": "Algorithms in Real Algebraic Geometry",
+      "year": "2006",
+      "venue": "Algorithms and Computation in Mathematics 10, 2nd ed., Springer",
+      "note": "Standard algorithmic reference for sign variations, Sturm sequences, and real-root isolation (Vincent/VAS/VCA)."
+    },
+    {
+      "authors": [
+        "The mathlib community"
+      ],
+      "title": "Mathlib.Analysis.SpecialFunctions.Polynomials / Polynomial.signVariations",
+      "year": "2020",
+      "venue": "Mathlib4, Lean 4 mathematical library",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/",
+      "note": "Mathlib's abstract signVariations and roots API that these entries bridge to a computable form."
+    }
+  ],
   "conclusion": {
     "summary": "YES, the bound side of Descartes' Rule can be made constructive. Mathlib's signVariations is noncomputable as a function of the polynomial, but its combinatorial core is a computable function on the coefficient list. This file builds that function (signVarList over ℚ), proves by rfl that it agrees with the abstract count, transports Descartes' upper bound to it, and extracts a decidable sound certificate of no positive roots — all with 0 axioms, examples checked by kernel decide.",
     "implications": "Separates the genuinely algorithmic part of Descartes' Rule (counting sign variations) from the genuinely noncomputable part (locating real roots, which needs Sturm). The signVarList / signVarList_coeffList pattern — a computable list mirror certified by rfl against a noncomputable polynomial-level definition — is reusable for other coefficient-driven polynomial invariants. The decidable no-positive-roots certificate is a small but genuinely constructive decision procedure: sound, terminating, and checkable.",

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -341,6 +341,37 @@
       "tactics": []
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Sturm, C."
+      ],
+      "title": "Mémoire sur la résolution des équations numériques",
+      "year": "1835",
+      "venue": "Mémoires présentés par divers savants 6, pp. 271–318 (announced 1829)",
+      "note": "Sturm's theorem: the exact count of distinct real roots in an interval via sign changes in the Sturm sequence."
+    },
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference covering Descartes' rule, the Budan–Fourier theorem, Sturm's theorem and root-localization bounds."
+    },
+    {
+      "authors": [
+        "Basu, S.",
+        "Pollack, R.",
+        "Roy, M.-F."
+      ],
+      "title": "Algorithms in Real Algebraic Geometry",
+      "year": "2006",
+      "venue": "Algorithms and Computation in Mathematics 10, 2nd ed., Springer",
+      "note": "Standard algorithmic reference for sign variations, Sturm sequences, and real-root isolation (Vincent/VAS/VCA)."
+    }
+  ],
   "conclusion": {
     "summary": "This file provides a complete formalization of Sturm's theorem for the Lean Genius gallery. The Sturm sequence is defined constructively via fuel-based GCD recursion, the sign-variation count is defined rigorously, and the main theorem is axiomatized with 1 axiom. Ten supporting theorems are fully proved, including the fundamental algebraic identity (mod_eval_at_root), the structural sign property, four corollaries from the exact count, and explicit verification for linear polynomials.",
     "implications": "Sturm's theorem has three major algorithmic consequences: (1) Real root isolation — bisect any interval until the Sturm count difference equals 0 or 1, giving provably correct root isolation in finite time; (2) Root count decision — for any polynomial, compute the total number of real roots in (-M, M] for large M in O(n²) time using polynomial GCD; (3) Isolation certificates — each isolated interval with Sturm count 1 is a certificate that exactly one root exists there, usable for constructive analysis.",

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03/meta.json
@@ -169,6 +169,38 @@
       ]
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Vincent, A.J.H."
+      ],
+      "title": "Sur la résolution des équations numériques",
+      "year": "1836",
+      "venue": "Journal de Mathématiques Pures et Appliquées 1, pp. 341–372",
+      "note": "Vincent's continued-fraction / bisection theorem underlying modern real-root isolation."
+    },
+    {
+      "authors": [
+        "Collins, G.E.",
+        "Akritas, A.G."
+      ],
+      "title": "Polynomial real root isolation using Descartes' rule of signs",
+      "year": "1976",
+      "venue": "Proc. ACM Symposium on Symbolic and Algebraic Computation (SYMSAC), pp. 272–275",
+      "note": "The Descartes/Vincent-based real-root isolation algorithm behind the computable sign-variation count."
+    },
+    {
+      "authors": [
+        "Basu, S.",
+        "Pollack, R.",
+        "Roy, M.-F."
+      ],
+      "title": "Algorithms in Real Algebraic Geometry",
+      "year": "2006",
+      "venue": "Algorithms and Computation in Mathematics 10, 2nd ed., Springer",
+      "note": "Standard algorithmic reference for sign variations, Sturm sequences, and real-root isolation (Vincent/VAS/VCA)."
+    }
+  ],
   "conclusion": {
     "summary": "This file gives a fully machine-checked proof (0 axioms, 0 sorries; only propext / Classical.choice / Quot.sound) of the termination core of Vincent's bisection theorem: bisection subdivision of an interval must eventually isolate the real roots of a polynomial, because the roots form a finite separated set and halving drives every subinterval below the separation distance. The eight theorems build from the minimum-gap definition through the narrow-interval subsingleton bound to the headline existence of an isolating bisection level, uniform across all dyadic subintervals.",
     "implications": "Termination is the part of real-root isolation that is easy to state and easy to get wrong informally; pinning it down formally provides a verified foundation for the VAS/VCA algorithms used throughout computer algebra. The metric formulation (any finite separated set) is reusable beyond polynomials — e.g. for isolating eigenvalues or sampled signals. Combined with the separately-tracked Descartes sign-test step (0 or 1 sign variations on an isolated interval), it would yield a complete verified root-isolation pipeline atop the Budan/Descartes lineage.",

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -176,6 +176,35 @@
       ]
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Budan de Boislaurent, F.D."
+      ],
+      "title": "Nouvelle méthode pour la résolution des équations numériques",
+      "year": "1807",
+      "venue": "Paris",
+      "note": "Budan's theorem bounding real roots in an interval by the drop in sign variations."
+    },
+    {
+      "authors": [
+        "Fourier, J.B.J."
+      ],
+      "title": "Analyse des équations déterminées",
+      "year": "1831",
+      "venue": "Firmin Didot, Paris (posthumous)",
+      "note": "The Fourier (iterated-derivative) sign-variation sequence underlying the Budan–Fourier theorem."
+    },
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference covering Descartes' rule, the Budan–Fourier theorem, Sturm's theorem and root-localization bounds."
+    }
+  ],
   "conclusion": {
     "summary": "This file establishes the foundational building blocks for Budan's upper bound theorem: constant and linear polynomial bounds (proved), Rolle's theorem for polynomials (proved), IVT-based root existence (proved), and documented placeholders for the sign-change accounting and inductive step. The three proved theorems are sound; the two placeholder theorems prove `True` to document proof architecture without introducing unsound assumptions.",
     "implications": "Budan's theorem is the algorithmic heart of real root isolation: computer algebra systems use V_p(a) - V_p(b) as a quick upper bound on roots in (a,b] to bisect intervals. The theorem also implies Descartes' Rule (sign changes in coefficients = upper bound on positive roots) as a corollary. A complete Lean formalization would: (1) give a verified foundation for root isolation algorithms, (2) enable formal proofs of Sturm's theorem as a tighter cousin, and (3) contribute to Mathlib's polynomial root-counting infrastructure.",

--- a/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
@@ -51,6 +51,36 @@
       "Cauchy bound: Mathlib.Analysis.Polynomial.CauchyBound"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Cauchy, A.-L."
+      ],
+      "title": "Exercices de mathématiques, IV",
+      "year": "1829",
+      "venue": "De Bure, Paris",
+      "note": "Source of the Cauchy bound localizing all roots of a polynomial."
+    },
+    {
+      "authors": [
+        "Rahman, Q.I.",
+        "Schmeisser, G."
+      ],
+      "title": "Analytic Theory of Polynomials",
+      "year": "2002",
+      "venue": "London Mathematical Society Monographs 26, Oxford University Press",
+      "note": "Comprehensive treatment of root distribution, sign variations and conjugate-root structure."
+    },
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference covering Descartes' rule, the Budan–Fourier theorem, Sturm's theorem and root-localization bounds."
+    }
+  ],
   "conclusion": {
     "summary": "Fully machine-verified constructive root localization: 24 theorems combining Descartes' Rule of Signs (signVariations) with the Cauchy bound to confine all roots to a computable interval. Includes the Lagrange alternative bound, negative root reduction, intermediate value root existence, and a RootCertificate structure for verified root isolation. 440 lines, 0 axioms, 0 sorries.",
     "implications": "Constructive root bounds are the foundation for certified numerical algorithms. Root isolation (determining intervals containing exactly one root) is a subroutine in all real algebraic geometry software; the Descartes-Cauchy combination gives the first-pass interval before applying Sturm sequences or bisection. The formalization in Lean 4 makes these bounds available for verified algorithm analysis: any Lean 4 program that calls a root finder can carry a machine-checked certificate that its output lies in the correct interval. This connects formal mathematics to practical computer algebra, an active research area (certified CAS, computational real algebraic geometry).",


### PR DESCRIPTION
Adds a top-level `references` array to the 10 open-question descendants of **descartes-rule-of-signs** that previously had none.

## Coverage
Real-root counting for polynomials — Descartes' rule and its parity refinements (via complex conjugate roots and multiplicity), the Budan–Fourier theorem and its endpoint sign-variation backbone, Sturm's exact-count theorem, Vincent's bisection/root-isolation theorem, constructive/computable sign-variation counts, and Cauchy/Lagrange root-localization bounds.

## Method
Each entry cited to the standard modern references — Prasolov, *Polynomials*; Rahman–Schmeisser, *Analytic Theory of Polynomials*; Basu–Pollack–Roy, *Algorithms in Real Algebraic Geometry* — plus the matching primary sources (Descartes 1637, Budan 1807, Fourier 1831, Sturm 1835, Vincent 1836, Cauchy 1829, Collins–Akritas 1976). 2–4 references per entry, matched to each `description`.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.