### PR TITLE
Enrich cayley-hamilton-minpoly OQ cluster: add references to 10 entries

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
@@ -127,6 +127,27 @@
       "summary": "Summary theorem consolidating the three properties: universal divisibility, degree inequality, and the iff characterization. Documents the zero-map failure example explicitly in the docstring."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Lang, S."
+      ],
+      "title": "Algebra",
+      "year": "2002",
+      "venue": "3rd ed., Graduate Texts in Mathematics 211, Springer",
+      "note": "Structure theorem for finitely generated modules over a PID and primary decomposition, underlying the module-theoretic cyclic-vector arguments."
+    },
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Rational canonical form via the structure theorem for modules over a PID, invariant factors and Smith normal form."
+    }
+  ],
   "conclusion": {
     "summary": "This proof provides the definitive characterization of minpoly invariance under non-injective K-algebra homomorphisms: minpoly K (f a) = minpoly K a iff Polynomial.aeval a (minpoly K (f a)) = 0. The result is fully verified in Lean 4 with 0 axioms and 0 sorries, relying only on Mathlib's minpoly.dvd, minpoly.aeval_algHom, associated_of_dvd_dvd, and eq_of_monic_of_associated.",
     "implications": "The characterization is practically useful: instead of requiring f to be injective, one only needs to check a single polynomial evaluation. This has applications in field extension theory (when can a map between field extensions preserve algebraic relations?), matrix theory (when does a linear map preserve the minimal polynomial of an operator?), and module theory (when does a module homomorphism preserve the annihilator polynomial?). The proof also clarifies why injectivity is sufficient but not necessary: injective maps automatically satisfy the criterion, but the criterion is strictly weaker.",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/meta.json
@@ -85,6 +85,37 @@
       "summary": "Catalogues Mathlib's current coverage (charpoly, Cayley-Hamilton, minpoly, conjugation invariance) and identifies the three missing ingredients for full RCF: Smith normal form for $F[x]$-matrices (~800 lines), companion matrix construction (~200 lines), and block diagonal assembly + the full RCF existence/uniqueness theorem (~800 lines). Total estimated effort: ~1800 lines."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Rational canonical form via the structure theorem for modules over a PID, invariant factors and Smith normal form."
+    },
+    {
+      "authors": [
+        "Hoffman, K.",
+        "Kunze, R."
+      ],
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Classic development of minimal and characteristic polynomials, cyclic vectors, the cyclic decomposition theorem and rational canonical form."
+    },
+    {
+      "authors": [
+        "Roman, S."
+      ],
+      "title": "Advanced Linear Algebra",
+      "year": "2008",
+      "venue": "3rd ed., Graduate Texts in Mathematics 135, Springer",
+      "note": "Cyclic/companion decomposition and the equivalence between nonderogatory matrices and cyclic vectors."
+    }
+  ],
   "conclusion": {
     "summary": "This entry proves that similar matrices have identical characteristic and minimal polynomials, delegating to Mathlib's verified conjugation lemmas. It defines the key auxiliary structures (`InvariantFactorsEqual`, `CompanionMatrixProp`) and provides a detailed roadmap showing that the full Rational Canonical Form theorem requires approximately 1800 additional lines of Lean, with Smith normal form for polynomial matrices as the central missing piece.",
     "implications": "The Rational Canonical Form is the correct substitute for Jordan form when working over non-algebraically-closed fields. It classifies all finitely generated torsion modules over PIDs, making it central to abstract algebra. In Lean 4, a complete formalization would require extending Mathlib's PID module theory to $F[x]$-matrices and constructively computing Smith normal form — a substantial but well-defined project. The similarity invariance results proved here are the first and most accessible steps, already available as one-liners in Mathlib.",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01/meta.json
@@ -97,6 +97,27 @@
       "mathContext": "#{v | cyclic} = #({0}ᶜ) = qⁿ − 1."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hoffman, K.",
+        "Kunze, R."
+      ],
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Classic development of minimal and characteristic polynomials, cyclic vectors, the cyclic decomposition theorem and rational canonical form."
+    },
+    {
+      "authors": [
+        "Roman, S."
+      ],
+      "title": "Advanced Linear Algebra",
+      "year": "2008",
+      "venue": "3rd ed., Graduate Texts in Mathematics 135, Springer",
+      "note": "Cyclic/companion decomposition and the equivalence between nonderogatory matrices and cyclic vectors."
+    }
+  ],
   "conclusion": {
     "summary": "Sharpens the parent's one-directional result into a complete characterization: for a matrix with irreducible minimal polynomial of full degree n, a vector is cyclic iff it is nonzero, so the cyclic locus is exactly {0}ᶜ and, over a finite field with q elements, has exactly qⁿ − 1 points. 4 theorems, 0 axioms, 0 sorries.",
     "implications": "The characterization shows such matrices are 'uniformly cyclic' (maximal cyclic locus), and the finite-field count gives a concrete enumerative invariant. The result reuses the verified parent unchanged.",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01/meta.json
@@ -94,6 +94,27 @@
       "mathContext": "IsNonderogatory ⟹ deg μ = n; any nonzero v then cyclic; such v exists for n>0."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hoffman, K.",
+        "Kunze, R."
+      ],
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Classic development of minimal and characteristic polynomials, cyclic vectors, the cyclic decomposition theorem and rational canonical form."
+    },
+    {
+      "authors": [
+        "Gantmacher, F.R."
+      ],
+      "title": "The Theory of Matrices, Vol. I",
+      "year": "1959",
+      "venue": "Chelsea Publishing",
+      "note": "Nonderogatory matrices, companion matrices and the minimal polynomial."
+    }
+  ],
   "conclusion": {
     "summary": "For a matrix whose minimal polynomial is irreducible of degree n, every nonzero vector is cyclic — proved by a gcd/Bézout argument with no factorization machinery, sidestepping the import conflict that left the parent's general theorem as a sorry. This removes the parent's cyclic-vector axiom for all nonderogatory matrices with irreducible minimal polynomial. Self-contained, 4 theorems, 0 axioms, 0 sorries.",
     "implications": "The irreducible case covers companion matrices of irreducible polynomials and matrices with irreducible characteristic polynomial — a natural and substantial subclass — and isolates exactly where the general proof's difficulty lies (the multi-factor union-avoidance argument). It also documents, and works around, the parent file's bit-rot against the current Mathlib toolchain.",
@@ -151,21 +172,28 @@
         "content": "IsCyclicVector, IsNonderogatory, gcd_aeval_mulVec_eq_zero.",
         "startLine": 57,
         "endLine": 90,
-        "theorems": ["gcd_aeval_mulVec_eq_zero"]
+        "theorems": [
+          "gcd_aeval_mulVec_eq_zero"
+        ]
       },
       {
         "title": "Core Theorem",
         "content": "cyclic_of_irreducible_minpoly.",
         "startLine": 92,
         "endLine": 130,
-        "theorems": ["cyclic_of_irreducible_minpoly"]
+        "theorems": [
+          "cyclic_of_irreducible_minpoly"
+        ]
       },
       {
         "title": "Corollaries",
         "content": "nonderogatory_irreducible_cyclic, exists_cyclic_of_nonderogatory_irreducible.",
         "startLine": 132,
         "endLine": 153,
-        "theorems": ["nonderogatory_irreducible_cyclic", "exists_cyclic_of_nonderogatory_irreducible"]
+        "theorems": [
+          "nonderogatory_irreducible_cyclic",
+          "exists_cyclic_of_nonderogatory_irreducible"
+        ]
       }
     ],
     "mathContext": {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/meta.json
@@ -60,41 +60,57 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "A square matrix is nonderogatory when its minimal and characteristic polynomials coincide, equivalently (Frobenius) when it admits a cyclic vector — a single vector whose iterated images under the matrix span the whole space. This is the linear-algebra backbone of rational canonical form. The easy direction (a cyclic vector forces minpoly = charpoly) is elementary; the converse — every nonderogatory matrix has a cyclic vector — is classically proved via the structure theorem for modules over a PID or rational canonical form, machinery that is heavy to formalize and, in some routes, implicitly assumes an infinite field. This entry isolates the one case where the converse is fully constructive and field-agnostic: the single nilpotent Jordan block N with Nⁿ = 0 and Nⁿ⁻¹ ≠ 0.",
-    "problemStatement": "Prove the converse of the cyclic-vector / nonderogatory equivalence for the maximal-nilpotent case over an ARBITRARY field: if N satisfies Nⁿ = 0 and Nⁿ⁻¹ ≠ 0 then N has a cyclic vector. Also characterize this hypothesis arithmetically as minpoly K N = Xⁿ.",
-    "proofStrategy": "Constructive. Since Nⁿ⁻¹ ≠ 0, some standard basis vector v has Nⁿ⁻¹v ≠ 0 (exists_mulVec_ne_zero). The Krylov vectors {v, Nv, …, Nⁿ⁻¹v} are then linearly independent: apply Nⁿ⁻¹⁻ʲ to a vanishing linear combination — terms above degree j die by nilpotency, terms below by descending induction — leaving cⱼ Nⁿ⁻¹v = 0, hence cⱼ = 0 (nilpotent_krylov_independent). Linear independence of the power orbit is exactly cyclicity (isCyclicVector_of_linearIndependent, via aeval_eq_sum_range'). Separately, minpoly K N = Xⁿ is obtained from Nⁿ = 0 (so minpoly ∣ Xⁿ), primeness of X (minpoly = Xⁱ), and Nⁿ⁻¹ ≠ 0 (forcing i = n).",
+    "historicalContext": "The notion of a cyclic (or generating) vector and the equivalence 'nonderogatory ⟺ has a cyclic vector' are classical, going back to the theory of the rational canonical form developed by Frobenius and refined in Hoffman & Kunze's and Roman's textbooks (§7.1–7.2 and §10.4 respectively). A matrix is nonderogatory precisely when its minimal and characteristic polynomials coincide — equivalently, when its rational canonical form is a single companion block. The single nilpotent Jordan block Jₙ(0), whose minimal polynomial is Xⁿ, is the prototypical nonderogatory matrix; over any field a vector outside ker Nⁿ⁻¹ cyclically generates the whole space. This entry formalizes exactly that prototype, deliberately avoiding the genericity and factorization tools that the general converse needs.",
+    "problemStatement": "Over an arbitrary field K, prove the converse direction of the cyclic-vector characterization for maximal-nilpotent matrices: if N ∈ Mₙ(K) satisfies Nⁿ = 0 and Nⁿ⁻¹ ≠ 0 then N has a cyclic vector. Additionally characterize this class arithmetically by minpoly K N = Xⁿ and record natDegree(minpoly K N) = n.",
+    "proofStrategy": "Construct the cyclic vector explicitly. Since Nⁿ⁻¹ ≠ 0 there is a v with Nⁿ⁻¹v ≠ 0 (exists_mulVec_ne_zero). Its Krylov vectors {v, Nv, …, Nⁿ⁻¹v} are linearly independent: apply Nⁿ⁻¹⁻ʲ to any relation ∑ cₖ Nᵏv = 0; terms with exponent ≥ n vanish by Nⁿ = 0, terms below index j vanish by a descending strong induction, leaving cⱼ Nⁿ⁻¹v = 0 and hence cⱼ = 0. Independence of the full power basis upgrades to cyclicity via aeval_eq_sum_range'. The arithmetic side uses that Nⁿ = 0 forces minpoly K N ∣ Xⁿ; since X is prime, the minimal polynomial is a monic associate of some Xⁱ, hence equals Xⁱ, and i = n is forced because Nⁿ⁻¹ ≠ 0.",
     "keyInsights": [
-      "**The nilpotent case needs no infinite field.** The general converse routes through rational canonical form or PID module theory; for a single Jordan block the cyclic vector is built by hand, so the result holds over finite fields too — exactly the gap the infinite-field sibling cannot cover.",
-      "**Cyclicity = Krylov linear independence.** A vector is cyclic iff its power orbit {v, Nv, …, Nⁿ⁻¹v} is linearly independent; the proof expands p(N)v over this power basis (aeval_eq_sum_range') so that no nonzero low-degree polynomial annihilates v.",
-      "**Nilpotency peels coefficients one at a time.** Applying the right power of N to a linear relation kills high-degree terms outright and, with descending induction, isolates each coefficient against the nonzero Nⁿ⁻¹v — an elementary substitute for module-theoretic generators.",
-      "**minpoly = Xⁿ is the clean restatement.** The maximal-nilpotent hypothesis Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0 is exactly minpoly K N = Xⁿ (X prime ⟹ minpoly is a power of X; the nonvanishing pins the exponent), tying the construction to the degree-n (nonderogatory) framing of the parent.",
-      "**Honest scope.** This discharges the parent's axiomatized converse only for the maximal-nilpotent case; the general nonderogatory converse remains axiomatized, and the infinite-field sibling's full assembly still carries a `sorry`."
-    ],
-    "prerequisites": [
-      "Minimal and characteristic polynomials; nonderogatory matrices and cyclic vectors",
-      "Krylov / power-orbit linear independence and aeval over a power basis",
-      "Nilpotent matrices and the single Jordan block; primeness of X in K[X]"
+      "The maximal-nilpotent case is the unique slice of the nonderogatory converse that is purely constructive: no infinite-field genericity and no rational-canonical-form factorization are needed, so it holds over finite fields that the infinite-field sibling cannot reach.",
+      "Linear independence of the Krylov vectors is proved by peeling: applying the descending powers Nⁿ⁻¹, Nⁿ⁻², … to a single relation isolates one coefficient at a time, with nilpotency killing the high-index tail and induction the low-index head.",
+      "Primality of X in K[X] does all the factorization work: minpoly ∣ Xⁿ plus prime_X plus equality of monic associates pins minpoly to Xⁱ, and Nⁿ⁻¹ ≠ 0 selects i = n — a one-line route to minpoly = Xⁿ that never mentions eigenvalues.",
+      "The equivalence minpoly K N = Xⁿ ⟺ (Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0) is the polynomial signature of a single Jordan block at 0, translating a geometric/structural hypothesis into a clean arithmetic one and back.",
+      "Because natDegree(minpoly K N) = n = natDegree(charpoly N) here, the construction closes precisely the nonderogatory ⟹ cyclic gap that the parent entry had axiomatized — for this case, over every field."
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Hoffman, K.",
+        "Kunze, R."
+      ],
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Classic development of minimal and characteristic polynomials, cyclic vectors, the cyclic decomposition theorem and rational canonical form."
+    },
+    {
+      "authors": [
+        "Gantmacher, F.R."
+      ],
+      "title": "The Theory of Matrices, Vol. I",
+      "year": "1959",
+      "venue": "Chelsea Publishing",
+      "note": "Nonderogatory matrices, companion matrices and the minimal polynomial."
+    }
+  ],
   "conclusion": {
-    "summary": "A self-contained, 0-axiom, 0-sorry formalization (238 lines, 9 theorems, 1 definition) of the constructive converse of the cyclic-vector / nonderogatory equivalence for maximal-nilpotent matrices over an arbitrary field: if Nⁿ = 0 and Nⁿ⁻¹ ≠ 0 then N has an explicit cyclic vector. It also gives the arithmetic characterization minpoly K N = Xⁿ ⟺ (Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0) and natDegree(minpoly K N) = n.",
-    "implications": "Discharges the parent entry's axiomatized converse for the nilpotent single-Jordan-block case — and crucially over finite fields, which the infinite-field sibling cannot reach — by an explicit Krylov construction needing no rational-canonical-form or PID machinery. The reproved Krylov-independence helpers are reusable infrastructure for cyclic-vector arguments elsewhere in the Cayley–Hamilton / minimal-polynomial family.",
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (238 lines, 9 theorems, 1 definition) proving the constructive converse of the cyclic-vector characterization for maximal-nilpotent matrices N (Nⁿ = 0, Nⁿ⁻¹ ≠ 0) over an arbitrary field, including finite fields. It builds an explicit cyclic vector from the Krylov sequence of any v ∉ ker Nⁿ⁻¹, and characterizes the class arithmetically by minpoly K N = Xⁿ with natDegree(minpoly) = n.",
+    "implications": "This discharges the parent entry's axiomatized converse for the single-Jordan-block case without the infinite-field assumption or factorization machinery that the OQ04Backward sibling required (and which left that sibling with a `sorry`). The inline Krylov-independence helpers are reusable infrastructure for any cyclic-vector argument, and the minpoly = Xⁿ characterization is the base case from which a general nilpotent (multiple-block) or general nonderogatory converse could be assembled.",
     "openQuestions": [
-      "Extend the constructive converse from a single nilpotent Jordan block to a general nilpotent matrix (direct sum of blocks), and then to arbitrary nonderogatory matrices over any field, fully discharging the parent's axiom.",
-      "Repair the infinite-field sibling (CayleyHamiltonMinpolyOQ04Backward) whose downstream assembly carries a `sorry` and a bit-rotted `ring` step under Mathlib 4.26.0.",
-      "Connect the explicit cyclic vector to a constructive rational canonical form over finite fields, where genericity arguments are unavailable."
+      "General nonderogatory converse over any field: extend the construction from a single Jordan block to an arbitrary matrix whose minimal polynomial equals its characteristic polynomial, discharging the parent's full axiom without the infinite-field hypothesis.",
+      "Multiple nilpotent blocks: characterize and construct cyclic vectors (or prove their absence) for nilpotent matrices with minpoly Xᵐ but m < n, where no cyclic vector exists — making precise the boundary the maximal-nilpotent hypothesis sits on.",
+      "Repair vs. replace: determine whether the OQ04Backward sibling's `normalizedFactors`/`DecidableEq` import clash can be fixed against current Mathlib so the infinite-field and finite-field cases unify into one converse theorem."
     ]
   },
   "crossReferences": [
     {
       "targetId": "cayley-hamilton-minpoly-oq-04",
       "relationship": "extends",
-      "description": "Parent entry: proves cyclic ⟹ nonderogatory and axiomatizes the converse. This entry discharges the converse for the maximal-nilpotent (single Jordan block) case over an arbitrary field, by an explicit cyclic-vector construction."
+      "description": "The parent proves the easy direction (a cyclic vector ⟹ nonderogatory) and axiomatizes the converse nonderogatory_has_cyclic_vector. This entry discharges that converse constructively for the maximal-nilpotent case (minpoly = Xⁿ) over any field, and connects to the parent via natDegree(minpoly K N) = n."
     },
     {
-      "targetId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
-      "relationship": "complements",
-      "description": "Sibling that proves the converse for infinite fields but leaves its main assembly as a `sorry`. This entry handles the orthogonal case that needs neither an infinite field nor factorization machinery (finite fields included), reproving the shared Krylov-independence helpers inline."
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "Cayley–Hamilton (charpoly N annihilates N) underlies the nonderogatory notion: a matrix is nonderogatory exactly when its minimal polynomial reaches the full degree of the characteristic polynomial guaranteed by Cayley–Hamilton. Here that full degree n is realized by the single nilpotent block whose minpoly is Xⁿ."
     }
   ],
   "leanFile": {
@@ -153,39 +169,6 @@
       "statement": "0 < n → minpoly K N = Xⁿ → ∃ v, IsCyclicVector N v",
       "description": "Cyclic-vector existence stated directly from the minimal-polynomial hypothesis minpoly K N = Xⁿ.",
       "significance": "Convenience form combining the characterization with the constructive headline."
-    }
-  ],
-  "overview": {
-    "historicalContext": "The notion of a cyclic (or generating) vector and the equivalence 'nonderogatory ⟺ has a cyclic vector' are classical, going back to the theory of the rational canonical form developed by Frobenius and refined in Hoffman & Kunze's and Roman's textbooks (§7.1–7.2 and §10.4 respectively). A matrix is nonderogatory precisely when its minimal and characteristic polynomials coincide — equivalently, when its rational canonical form is a single companion block. The single nilpotent Jordan block Jₙ(0), whose minimal polynomial is Xⁿ, is the prototypical nonderogatory matrix; over any field a vector outside ker Nⁿ⁻¹ cyclically generates the whole space. This entry formalizes exactly that prototype, deliberately avoiding the genericity and factorization tools that the general converse needs.",
-    "problemStatement": "Over an arbitrary field K, prove the converse direction of the cyclic-vector characterization for maximal-nilpotent matrices: if N ∈ Mₙ(K) satisfies Nⁿ = 0 and Nⁿ⁻¹ ≠ 0 then N has a cyclic vector. Additionally characterize this class arithmetically by minpoly K N = Xⁿ and record natDegree(minpoly K N) = n.",
-    "proofStrategy": "Construct the cyclic vector explicitly. Since Nⁿ⁻¹ ≠ 0 there is a v with Nⁿ⁻¹v ≠ 0 (exists_mulVec_ne_zero). Its Krylov vectors {v, Nv, …, Nⁿ⁻¹v} are linearly independent: apply Nⁿ⁻¹⁻ʲ to any relation ∑ cₖ Nᵏv = 0; terms with exponent ≥ n vanish by Nⁿ = 0, terms below index j vanish by a descending strong induction, leaving cⱼ Nⁿ⁻¹v = 0 and hence cⱼ = 0. Independence of the full power basis upgrades to cyclicity via aeval_eq_sum_range'. The arithmetic side uses that Nⁿ = 0 forces minpoly K N ∣ Xⁿ; since X is prime, the minimal polynomial is a monic associate of some Xⁱ, hence equals Xⁱ, and i = n is forced because Nⁿ⁻¹ ≠ 0.",
-    "keyInsights": [
-      "The maximal-nilpotent case is the unique slice of the nonderogatory converse that is purely constructive: no infinite-field genericity and no rational-canonical-form factorization are needed, so it holds over finite fields that the infinite-field sibling cannot reach.",
-      "Linear independence of the Krylov vectors is proved by peeling: applying the descending powers Nⁿ⁻¹, Nⁿ⁻², … to a single relation isolates one coefficient at a time, with nilpotency killing the high-index tail and induction the low-index head.",
-      "Primality of X in K[X] does all the factorization work: minpoly ∣ Xⁿ plus prime_X plus equality of monic associates pins minpoly to Xⁱ, and Nⁿ⁻¹ ≠ 0 selects i = n — a one-line route to minpoly = Xⁿ that never mentions eigenvalues.",
-      "The equivalence minpoly K N = Xⁿ ⟺ (Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0) is the polynomial signature of a single Jordan block at 0, translating a geometric/structural hypothesis into a clean arithmetic one and back.",
-      "Because natDegree(minpoly K N) = n = natDegree(charpoly N) here, the construction closes precisely the nonderogatory ⟹ cyclic gap that the parent entry had axiomatized — for this case, over every field."
-    ]
-  },
-  "conclusion": {
-    "summary": "A self-contained, 0-axiom, 0-sorry formalization (238 lines, 9 theorems, 1 definition) proving the constructive converse of the cyclic-vector characterization for maximal-nilpotent matrices N (Nⁿ = 0, Nⁿ⁻¹ ≠ 0) over an arbitrary field, including finite fields. It builds an explicit cyclic vector from the Krylov sequence of any v ∉ ker Nⁿ⁻¹, and characterizes the class arithmetically by minpoly K N = Xⁿ with natDegree(minpoly) = n.",
-    "implications": "This discharges the parent entry's axiomatized converse for the single-Jordan-block case without the infinite-field assumption or factorization machinery that the OQ04Backward sibling required (and which left that sibling with a `sorry`). The inline Krylov-independence helpers are reusable infrastructure for any cyclic-vector argument, and the minpoly = Xⁿ characterization is the base case from which a general nilpotent (multiple-block) or general nonderogatory converse could be assembled.",
-    "openQuestions": [
-      "General nonderogatory converse over any field: extend the construction from a single Jordan block to an arbitrary matrix whose minimal polynomial equals its characteristic polynomial, discharging the parent's full axiom without the infinite-field hypothesis.",
-      "Multiple nilpotent blocks: characterize and construct cyclic vectors (or prove their absence) for nilpotent matrices with minpoly Xᵐ but m < n, where no cyclic vector exists — making precise the boundary the maximal-nilpotent hypothesis sits on.",
-      "Repair vs. replace: determine whether the OQ04Backward sibling's `normalizedFactors`/`DecidableEq` import clash can be fixed against current Mathlib so the infinite-field and finite-field cases unify into one converse theorem."
-    ]
-  },
-  "crossReferences": [
-    {
-      "targetId": "cayley-hamilton-minpoly-oq-04",
-      "relationship": "extends",
-      "description": "The parent proves the easy direction (a cyclic vector ⟹ nonderogatory) and axiomatizes the converse nonderogatory_has_cyclic_vector. This entry discharges that converse constructively for the maximal-nilpotent case (minpoly = Xⁿ) over any field, and connects to the parent via natDegree(minpoly K N) = n."
-    },
-    {
-      "targetId": "cayley-hamilton",
-      "relationship": "related",
-      "description": "Cayley–Hamilton (charpoly N annihilates N) underlies the nonderogatory notion: a matrix is nonderogatory exactly when its minimal polynomial reaches the full degree of the characteristic polynomial guaranteed by Cayley–Hamilton. Here that full degree n is realized by the single nilpotent block whose minpoly is Xⁿ."
     }
   ],
   "sections": [

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
@@ -57,6 +57,36 @@
       "Rational canonical form: companion matrices and cyclic decomposition"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Hoffman, K.",
+        "Kunze, R."
+      ],
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Classic development of minimal and characteristic polynomials, cyclic vectors, the cyclic decomposition theorem and rational canonical form."
+    },
+    {
+      "authors": [
+        "Gantmacher, F.R."
+      ],
+      "title": "The Theory of Matrices, Vol. I",
+      "year": "1959",
+      "venue": "Chelsea Publishing",
+      "note": "Nonderogatory matrices, companion matrices and the minimal polynomial."
+    },
+    {
+      "authors": [
+        "Roman, S."
+      ],
+      "title": "Advanced Linear Algebra",
+      "year": "2008",
+      "venue": "3rd ed., Graduate Texts in Mathematics 135, Springer",
+      "note": "Cyclic/companion decomposition and the equivalence between nonderogatory matrices and cyclic vectors."
+    }
+  ],
   "conclusion": {
     "summary": "Nonderogatory matrices characterized via cyclic vectors: forward direction (cyclic → minpoly = charpoly) fully proved via degree bridge lemma, converse axiomatized (requires PID structure theorem). Equivalent natDegree characterizations proved. 8 theorems, 316 lines, 1 axiom.",
     "implications": "The cyclic vector characterization is central to systems theory: a linear dynamical system is controllable from a single input iff its state matrix is nonderogatory. The bridge lemma (equal-degree monic polynomials where one divides the other are equal) is a reusable algebraic tool. Completing the converse would give a fully verified characterization useful in both pure and applied linear algebra.",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-01/meta.json
@@ -86,6 +86,27 @@
       "mathContext": "Divisibility chain: $d \\mid \\mu$, $\\mu = d \\cdot s$; pick irreducible $q' \\mid s$ (via exists_mem_normalizedFactors_of_dvd); then $\\mu = q' \\cdot (d \\cdot t)$ so $\\mu/q' = d \\cdot t$; thus $(\\mu/q')(M)v = t(M) \\cdot d(M)v = 0$, placing $v \\in S(q')$, contradicting $v \\notin S(q')$ from Phase 3."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hoffman, K.",
+        "Kunze, R."
+      ],
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Classic development of minimal and characteristic polynomials, cyclic vectors, the cyclic decomposition theorem and rational canonical form."
+    },
+    {
+      "authors": [
+        "Gantmacher, F.R."
+      ],
+      "title": "The Theory of Matrices, Vol. I",
+      "year": "1959",
+      "venue": "Chelsea Publishing",
+      "note": "Nonderogatory matrices, companion matrices and the minimal polynomial."
+    }
+  ],
   "conclusion": {
     "summary": "The nonderogatory → cyclic vector theorem is proved for fields with $|K| > n$, strictly weakening the [Infinite K] hypothesis of the parent proof. The proof is complete with 0 axioms and 0 sorries, using the finite union avoidance lemma with explicit cardinality control.",
     "implications": "This formalization gives the tightest known purely combinatorial condition for the existence of cyclic vectors over finite fields. The sharp bound $|K| > n$ matches the number of irreducible factors of $\\mu_M$, and the proof technique (line argument + counting) is adaptable to other union avoidance applications in computational algebra and coding theory. Together with the infinite field version (OQ-05-OQ-01), this completes a two-case analysis covering all fields.",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
@@ -125,6 +125,26 @@
       "mathContext": "For n > 0: companionMat(charpoly M) has e0 as a cyclic vector (Section IV); M is similar to it (axiom); similarity transfers cyclic vectors (Section V). Therefore M has a cyclic vector. The finite-field corollary removes the [Infinite K] hypothesis from the parent file's approach."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Gantmacher, F.R."
+      ],
+      "title": "The Theory of Matrices, Vol. I",
+      "year": "1959",
+      "venue": "Chelsea Publishing",
+      "note": "Nonderogatory matrices, companion matrices and the minimal polynomial."
+    },
+    {
+      "authors": [
+        "Roman, S."
+      ],
+      "title": "Advanced Linear Algebra",
+      "year": "2008",
+      "venue": "3rd ed., Graduate Texts in Mathematics 135, Springer",
+      "note": "Cyclic/companion decomposition and the equivalence between nonderogatory matrices and cyclic vectors."
+    }
+  ],
   "conclusion": {
     "summary": "This file makes concrete progress on the nonderogatory cyclic vector theorem. The companion matrix cyclic vector (companionMat_e0_cyclic) is fully proved via the Krylov orbit argument. The remaining sorry is precisely stated as an axiom: nonderogatory matrices are similar to their companion matrices. This decomposes the original vague sorry into a proved part and a precisely-located mathematical gap.",
     "implications": "The orbit argument C^k e0 = e_k is now formally verified in Lean 4, establishing a concrete constructive fact about companion matrices. The similarity transfer theorem is also verified. The only remaining mathematical content is the rational canonical form / PID structure theorem, which is a known Mathlib gap. This decomposition makes the remaining work modular: once the similarity axiom is proved, the entire chain completes automatically.",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04/meta.json
@@ -124,6 +124,27 @@
       "mathContext": "The remaining work to obtain the fully unconditional `nonderogatory_has_cyclic_vector_any_field` is producing the prime power decomposition data from `IsNonderogatory M` automatically, via UniqueFactorizationMonoid on K[X]."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Rational canonical form via the structure theorem for modules over a PID, invariant factors and Smith normal form."
+    },
+    {
+      "authors": [
+        "Lang, S."
+      ],
+      "title": "Algebra",
+      "year": "2002",
+      "venue": "3rd ed., Graduate Texts in Mathematics 211, Springer",
+      "note": "Structure theorem for finitely generated modules over a PID and primary decomposition, underlying the module-theoretic cyclic-vector arguments."
+    }
+  ],
   "conclusion": {
     "summary": "WIP04 proves the nonderogatory cyclic vector theorem for general k-fold prime power factorizations, axiom-free and sorry-free, using primary decomposition via Bezout projections. The construction avoids the PID module structure theorem (not in Mathlib 4.26) and eliminates the rational canonical form axiom from WIP01. The single remaining gap is producing the prime power factorization of minpoly K M from a Mathlib UFD instance.",
     "implications": "Combined with WIP02 (squarefree case) and WIP03 (single prime power case), this completes the family-of-cases proof of the nonderogatory cyclic vector theorem under a factored-form hypothesis. The technique — primary vectors v_i = F_i(M) w_i plus CRT projections plus prime power divisibility — is a self-contained alternative to the PID structure theorem and could plausibly be ported to Mathlib as a lemma about cyclic K[X]-modules without first formalizing the full structure theorem.",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -120,6 +120,37 @@
       "mathContext": "The 3 nonzero vectors of $\\mathbb{F}_2^2$ are $(1,0)$, $(0,1)$, $(1,1)$. Each 1-dimensional subspace over $\\mathbb{F}_2$ contains exactly 1 nonzero vector. So $\\mathbb{F}_2^2 \\setminus \\{0\\}$ is covered by 3 proper subspaces. For union avoidance, one needs $|K| > n$ (here $|K| = 2 \\leq 2 = n$), so the argument fails. Yet every nonderogatory $2 \\times 2$ matrix over $\\mathbb{F}_2$ still has a cyclic vector."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Rational canonical form via the structure theorem for modules over a PID, invariant factors and Smith normal form."
+    },
+    {
+      "authors": [
+        "Lang, S."
+      ],
+      "title": "Algebra",
+      "year": "2002",
+      "venue": "3rd ed., Graduate Texts in Mathematics 211, Springer",
+      "note": "Structure theorem for finitely generated modules over a PID and primary decomposition, underlying the module-theoretic cyclic-vector arguments."
+    },
+    {
+      "authors": [
+        "Hoffman, K.",
+        "Kunze, R."
+      ],
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Classic development of minimal and characteristic polynomials, cyclic vectors, the cyclic decomposition theorem and rational canonical form."
+    }
+  ],
   "conclusion": {
     "summary": "This formalization establishes the cyclic vector theorem over ANY field (finite or infinite, regardless of size relative to n) for every nonderogatory matrix. The previously-isolated sorry on the PID structure theorem has been removed: the main theorem is closed by delegating to WIP05, which combines WIP04's Bezout/CRT primary-decomposition argument with UFD factorization of the minimal polynomial. The file is 0 axioms, 0 sorries.",
     "implications": "The Bezout/CRT projection approach demonstrates that the cyclic vector theorem does not require the full PID structure theorem (rational canonical form) — only the algebraic facts that K[X] is a UFD and that distinct monic irreducibles are coprime. This significantly lowers the Mathlib bar for related results and provides a constructive route avoiding the module-theoretic structure theorem.",


### PR DESCRIPTION
Adds a top-level `references` array to the 10 open-question descendants of **cayley-hamilton-minpoly** that previously had none.

## Coverage
Minimal and characteristic polynomials, nonderogatory matrices ⇔ cyclic vectors, companion matrices / Krylov orbits, and rational canonical form (similarity invariance, invariant factors, primary decomposition) over infinite, finite, and arbitrary fields.

## Method
Cited to the standard linear-algebra references — Hoffman–Kunze (cyclic decomposition, RCF), Gantmacher (nonderogatory matrices), Roman's *Advanced Linear Algebra*, and Dummit–Foote / Lang (structure theorem for modules over a PID, primary decomposition) — matched to each `description`. 2–3 references per entry.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.