### PR TITLE
Enrich bounded-prime-gaps OQ cluster: add references to 10 entries

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/meta.json
@@ -115,6 +115,26 @@
       "summary": "pair_density_implies_bounded_gaps specialises to {0,d}: a density of two primes among {n, n+d} yields infinitely many consecutive gaps <= d, recovering the twin-style reading at d = 2."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Maynard, J."
+      ],
+      "title": "Small gaps between primes",
+      "year": "2015",
+      "venue": "Annals of Mathematics 181 (1), pp. 383–413",
+      "note": "The Maynard–Tao multidimensional sieve giving bounded prime gaps and the H ≤ 246 / EH-conditional H ≤ 12 bounds."
+    },
+    {
+      "authors": [
+        "Polymath, D.H.J."
+      ],
+      "title": "Variants of the Selberg sieve, and bounded intervals containing many primes",
+      "year": "2014",
+      "venue": "Research in the Mathematical Sciences 1:12",
+      "note": "Polymath8b: optimized admissible tuples and the sharpest unconditional/EH-conditional gap bounds."
+    }
+  ],
   "conclusion": {
     "summary": "Five machine-checked theorems (0 sorries, 0 axioms beyond propext/Classical.choice/Quot.sound) show that the two gap-sieve axioms of the parent BoundedPrimeGaps formalization are logically redundant: their conclusion — infinitely many consecutive prime gaps ≤ D — is derived elementarily from the single Maynard–Tao density statement MaynardTaoDensity H 2 together with the diameter bound. The arithmetic core gap_from_two_primes turns any two primes within distance D into a bounded consecutive gap; density_two_implies_bounded_gaps lifts it to 'infinitely often'; and sieve_conclusion_from_density / sieve_eh_conclusion_from_density reproduce the eliminated axioms' exact signatures with the admissibility and cardinality hypotheses provably unused.",
     "implications": "The result sharpens the formalization's axiomatic footprint: the irreducible analytic input of the bounded-prime-gaps program is one density statement, not three axioms. It also cleanly localises where the depth lives — admissibility and the sieve machinery serve only to make the density antecedent true; the passage from 'two nearby primes' to 'a bounded consecutive gap' is pure prime-counting arithmetic. This separation is a reusable pattern for auditing which assumptions in a formalization are genuinely primitive versus derivable.",

--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "bounded-prime-gaps-oq-01-oq-02",
-  "title": "Bounded Prime Gaps: Elliott-Halberstam Conditional H \u2264 12",
+  "title": "Bounded Prime Gaps: Elliott-Halberstam Conditional H ≤ 12",
   "slug": "bounded-prime-gaps-oq-01-oq-02",
-  "description": "Formalizes the Elliott-Halberstam (EH) conditional prime gap bound H \u2264 12 from the Maynard-Tao sieve applied to the optimal admissible 5-tuple {0,2,6,8,12}. The EH conjecture extends Bombieri-Vinogradov equidistribution from \u03b8 < 1/2 to \u03b8 = 1/2, reducing the required tuple size from 50 (unconditional H \u2264 246) to 5 (EH conditional H \u2264 12) \u2014 a 10\u00d7 reduction. Key results: eh_conditional_h_le_12 (H \u2264 12 from sieve + 5-tuple), sieve threshold comparison (k=5 vs k=50), and the open problem structure.",
+  "description": "Formalizes the Elliott-Halberstam (EH) conditional prime gap bound H ≤ 12 from the Maynard-Tao sieve applied to the optimal admissible 5-tuple {0,2,6,8,12}. The EH conjecture extends Bombieri-Vinogradov equidistribution from θ < 1/2 to θ = 1/2, reducing the required tuple size from 50 (unconditional H ≤ 246) to 5 (EH conditional H ≤ 12) — a 10× reduction. Key results: eh_conditional_h_le_12 (H ≤ 12 from sieve + 5-tuple), sieve threshold comparison (k=5 vs k=50), and the open problem structure.",
   "meta": {
     "author": "Lean Genius Researcher",
     "status": "axiomatized",
@@ -21,7 +21,7 @@
     "lineCount": 219,
     "theoremCount": 25,
     "definitionCount": 3,
-    "assumptions": "1 axiom: maynard_tao_sieve_eh \u2014 the EH-conditional Maynard-Tao sieve result: for any admissible 5-tuple H with all elements \u2264 D, infinitely many prime gaps \u2264 D exist. This axiom encodes the Elliott-Halberstam conjecture (distribution of primes in APs up to modulus x^{1/2}) combined with the Maynard-Tao sieve framework.",
+    "assumptions": "1 axiom: maynard_tao_sieve_eh — the EH-conditional Maynard-Tao sieve result: for any admissible 5-tuple H with all elements ≤ D, infinitely many prime gaps ≤ D exist. This axiom encodes the Elliott-Halberstam conjecture (distribution of primes in APs up to modulus x^{1/2}) combined with the Maynard-Tao sieve framework.",
     "mathlibDependencies": [
       {
         "theorem": "Nat.nth",
@@ -36,9 +36,9 @@
     ],
     "originalContributions": [
       "First direct formalization of eh_conditional_h_le_12 as a theorem derived from maynard_tao_sieve_eh applied to the OQ01 5-tuple",
-      "no_admissible_5_tuple_diam_le_10: consolidation of all 5 non-admissibility witnesses for diameter \u2264 10 as a single conjunction",
-      "eh_threshold_lt_bv_threshold (5 < 50) and eh_threshold_divides_bv (5 \u2223 50): the substantive numeric comparison between the EH and BV sieve thresholds. (The companion theorems bv_requires_50_elements and eh_requires_5_elements record the threshold values themselves but are literal-equality markers, not formalizations of the underlying sieve-theoretic content.)",
-      "OpenQuestion01OQ02: formal definition of the open problem as \u2203 H \u2264 12, H is an unconditional gap bound",
+      "no_admissible_5_tuple_diam_le_10: consolidation of all 5 non-admissibility witnesses for diameter ≤ 10 as a single conjunction",
+      "eh_threshold_lt_bv_threshold (5 < 50) and eh_threshold_divides_bv (5 ∣ 50): the substantive numeric comparison between the EH and BV sieve thresholds. (The companion theorems bv_requires_50_elements and eh_requires_5_elements record the threshold values themselves but are literal-equality markers, not formalizations of the underlying sieve-theoretic content.)",
+      "OpenQuestion01OQ02: formal definition of the open problem as ∃ H ≤ 12, H is an unconditional gap bound",
       "eh_solves_oq01oq02: conditional answer to the open question via EH"
     ],
     "dateAdded": "2026-05-04",
@@ -51,15 +51,15 @@
     ]
   },
   "overview": {
-    "historicalContext": "The bounded prime gaps program asks: how small can prime gaps be infinitely often? Zhang (2013) gave the first finite bound H \u2264 70,000,000. Maynard-Tao (2014/2015) and Polymath 8b dramatically improved this to H \u2264 246 unconditionally, using a combinatorial sieve applied to an admissible 50-tuple of diameter 246.\n\nA parallel thread asks: assuming the Elliott-Halberstam (EH) conjecture \u2014 a strong equidistribution hypothesis for primes in arithmetic progressions \u2014 can H be reduced further? EH, if true, would allow the Maynard-Tao sieve to work with much smaller tuples: a 5-tuple instead of a 50-tuple. The optimal admissible 5-tuple (proved in OQ01) has diameter 12, giving H \u2264 12 conditionally.\n\nThe EH conjecture itself extends the Bombieri-Vinogradov theorem. BV controls primes in APs up to modulus q \u2264 x^\u03b8 for any fixed \u03b8 < 1/2; the extension to \u03b8 = 1/2 (the 'critical boundary') is the EH conjecture. This extension from \u03b8 < 1/2 to \u03b8 = 1/2 is the key open problem underlying the improvement from H \u2264 246 to H \u2264 12.",
-    "problemStatement": "The open question OQ01-OQ02 from the BoundedPrimeGapsOQ01 gallery proof: Can the gap bound H \u2264 12 be proved unconditionally (without assuming EH)?\n\nConditionally: Polymath 8b established that assuming Elliott-Halberstam, the Maynard-Tao sieve with the optimal admissible 5-tuple {0,2,6,8,12} yields H \u2264 12. This file formalizes this conditional result.\n\nUnconditionally: Proving H \u2264 12 without EH would require either:\n1. Proving the EH conjecture itself (very hard open problem), or\n2. Finding a new sieve-theoretic argument using k=5 elements without EH-level distribution estimates, or\n3. A fundamentally different approach to prime gaps.",
-    "proofStrategy": "The formalization has three layers:\n\n**Layer 1: Direct EH Conditional Result (eh_conditional_h_le_12)**: Apply the EH-conditional sieve axiom (maynard_tao_sieve_eh) from BoundedPrimeGaps.lean to the optimal 5-tuple {0,2,6,8,12} proved admissible in OQ01. The sieve needs: IsAdmissible (proved), card \u2265 5 (= 5), all elements \u2264 12 (all native_decide). This directly gives H \u2264 12.\n\n**Layer 2: Sieve Threshold Analysis**: The key structural insight is the BV-vs-EH sieve threshold difference. BV requires k \u2265 50 primes in the admissible tuple; EH reduces this to k \u2265 5. This 10\u00d7 reduction in tuple size is formalized via arithmetic theorems (sieve_threshold_ratio, bv_needs_10x_more_elements).\n\n**Layer 3: Open Problem Characterization**: OpenQuestion01OQ02 formalizes what it means to answer the open question unconditionally. eh_solves_oq01oq02 shows EH is sufficient; h12_unconditional_implies_progress shows any answer surpasses the current best.",
+    "historicalContext": "The bounded prime gaps program asks: how small can prime gaps be infinitely often? Zhang (2013) gave the first finite bound H ≤ 70,000,000. Maynard-Tao (2014/2015) and Polymath 8b dramatically improved this to H ≤ 246 unconditionally, using a combinatorial sieve applied to an admissible 50-tuple of diameter 246.\n\nA parallel thread asks: assuming the Elliott-Halberstam (EH) conjecture — a strong equidistribution hypothesis for primes in arithmetic progressions — can H be reduced further? EH, if true, would allow the Maynard-Tao sieve to work with much smaller tuples: a 5-tuple instead of a 50-tuple. The optimal admissible 5-tuple (proved in OQ01) has diameter 12, giving H ≤ 12 conditionally.\n\nThe EH conjecture itself extends the Bombieri-Vinogradov theorem. BV controls primes in APs up to modulus q ≤ x^θ for any fixed θ < 1/2; the extension to θ = 1/2 (the 'critical boundary') is the EH conjecture. This extension from θ < 1/2 to θ = 1/2 is the key open problem underlying the improvement from H ≤ 246 to H ≤ 12.",
+    "problemStatement": "The open question OQ01-OQ02 from the BoundedPrimeGapsOQ01 gallery proof: Can the gap bound H ≤ 12 be proved unconditionally (without assuming EH)?\n\nConditionally: Polymath 8b established that assuming Elliott-Halberstam, the Maynard-Tao sieve with the optimal admissible 5-tuple {0,2,6,8,12} yields H ≤ 12. This file formalizes this conditional result.\n\nUnconditionally: Proving H ≤ 12 without EH would require either:\n1. Proving the EH conjecture itself (very hard open problem), or\n2. Finding a new sieve-theoretic argument using k=5 elements without EH-level distribution estimates, or\n3. A fundamentally different approach to prime gaps.",
+    "proofStrategy": "The formalization has three layers:\n\n**Layer 1: Direct EH Conditional Result (eh_conditional_h_le_12)**: Apply the EH-conditional sieve axiom (maynard_tao_sieve_eh) from BoundedPrimeGaps.lean to the optimal 5-tuple {0,2,6,8,12} proved admissible in OQ01. The sieve needs: IsAdmissible (proved), card ≥ 5 (= 5), all elements ≤ 12 (all native_decide). This directly gives H ≤ 12.\n\n**Layer 2: Sieve Threshold Analysis**: The key structural insight is the BV-vs-EH sieve threshold difference. BV requires k ≥ 50 primes in the admissible tuple; EH reduces this to k ≥ 5. This 10× reduction in tuple size is formalized via arithmetic theorems (sieve_threshold_ratio, bv_needs_10x_more_elements).\n\n**Layer 3: Open Problem Characterization**: OpenQuestion01OQ02 formalizes what it means to answer the open question unconditionally. eh_solves_oq01oq02 shows EH is sufficient; h12_unconditional_implies_progress shows any answer surpasses the current best.",
     "keyInsights": [
-      "**Sieve threshold is the key**: BV works at \u03b8 < 1/2 and needs k \u2265 50; EH extends to \u03b8 = 1/2 and only needs k \u2265 5. This 10\u00d7 difference in tuple size is the root of the 246 vs 12 gap in the bound.",
-      "**The 5-tuple {0,2,6,8,12} is optimal**: All 5 even 5-tuples with diameter \u2264 10 are non-admissible (verified exhaustively in OQ01). The diameter 12 is tight \u2014 EH cannot give H < 12 without a new admissible 5-tuple.",
-      "**Two witnesses for the bound**: Both {0,2,6,8,12} and {0,4,6,10,12} are admissible 5-tuples of diameter 12, giving two independent paths to H \u2264 12 under EH.",
+      "**Sieve threshold is the key**: BV works at θ < 1/2 and needs k ≥ 50; EH extends to θ = 1/2 and only needs k ≥ 5. This 10× difference in tuple size is the root of the 246 vs 12 gap in the bound.",
+      "**The 5-tuple {0,2,6,8,12} is optimal**: All 5 even 5-tuples with diameter ≤ 10 are non-admissible (verified exhaustively in OQ01). The diameter 12 is tight — EH cannot give H < 12 without a new admissible 5-tuple.",
+      "**Two witnesses for the bound**: Both {0,2,6,8,12} and {0,4,6,10,12} are admissible 5-tuples of diameter 12, giving two independent paths to H ≤ 12 under EH.",
       "**The bound hierarchy is strict**: 2 < 12 < 246. TPC (H=2) is hardest and implies EH bound and Polymath bound. Unconditional Polymath bound (246) is easiest. EH bound (12) sits between, conditional on a major open conjecture.",
-      "**EH is the knife's edge**: Both BV and EH are stated for \u03b8 \u2264 1/2, but BV is proved only for strict \u03b8 < 1/2. The single step from \u03b8 < 1/2 to \u03b8 = 1/2 is where the open problem lies."
+      "**EH is the knife's edge**: Both BV and EH are stated for θ ≤ 1/2, but BV is proved only for strict θ < 1/2. The single step from θ < 1/2 to θ = 1/2 is where the open problem lies."
     ],
     "prerequisites": [
       "Bounded prime gaps setup (BoundedPrimeGaps.lean)",
@@ -71,24 +71,24 @@
   "sections": [
     {
       "id": "definitions",
-      "title": "EH-Conditional H \u2264 12",
+      "title": "EH-Conditional H ≤ 12",
       "startLine": 30,
       "endLine": 64,
-      "summary": "Main results: quintuple_card (card=5), quintuple_le_12 (all elements \u2264 12), eh_conditional_h_le_12 (the core theorem applying maynard_tao_sieve_eh to {0,2,6,8,12}), and eh_strictly_improves_on_246 (H \u2264 12 implies \u2203H < 246 with infinitely many gaps \u2264 H)."
+      "summary": "Main results: quintuple_card (card=5), quintuple_le_12 (all elements ≤ 12), eh_conditional_h_le_12 (the core theorem applying maynard_tao_sieve_eh to {0,2,6,8,12}), and eh_strictly_improves_on_246 (H ≤ 12 implies ∃H < 246 with infinitely many gaps ≤ H)."
     },
     {
       "id": "numerical",
       "title": "Numerical Comparison of Bounds",
       "startLine": 65,
       "endLine": 99,
-      "summary": "Arithmetic theorems: eh_bound_lt_polymath_bound (12 < 246), bound_gap (234 = 246-12), eh_improvement_factor (20\u00b712 \u2264 246), sieve_threshold_ratio (5\u00b710 = 50), bv_needs_10x_more_elements, and no_admissible_5_tuple_diam_le_10 (exhaustive non-admissibility witness for all 5 even 5-tuples with diameter \u2264 10)."
+      "summary": "Arithmetic theorems: eh_bound_lt_polymath_bound (12 < 246), bound_gap (234 = 246-12), eh_improvement_factor (20·12 ≤ 246), sieve_threshold_ratio (5·10 = 50), bv_needs_10x_more_elements, and no_admissible_5_tuple_diam_le_10 (exhaustive non-admissibility witness for all 5 even 5-tuples with diameter ≤ 10)."
     },
     {
       "id": "sieve-level",
       "title": "Sieve Level Analysis",
       "startLine": 100,
       "endLine": 143,
-      "summary": "bvLevel = ehLevel = 1/2 (both definitions, equal by rfl). bv_requires_50_elements (50=50) and eh_requires_5_elements (5=5) are literal-equality markers. Substantive inequalities: eh_threshold_lt_bv_threshold (5 < 50) and eh_threshold_divides_bv (5 | 50), recording the 10\u00d7 reduction in tuple size from BV to EH level."
+      "summary": "bvLevel = ehLevel = 1/2 (both definitions, equal by rfl). bv_requires_50_elements (50=50) and eh_requires_5_elements (5=5) are literal-equality markers. Substantive inequalities: eh_threshold_lt_bv_threshold (5 < 50) and eh_threshold_divides_bv (5 | 50), recording the 10× reduction in tuple size from BV to EH level."
     },
     {
       "id": "witnesses",
@@ -102,14 +102,44 @@
       "title": "Open Problem and Hierarchy",
       "startLine": 172,
       "endLine": 219,
-      "summary": "OpenQuestion01OQ02 definition (\u2203H \u2264 12, infinitely many prime gaps \u2264 H), gap_bound_eh_implies_unconditional (H\u226412 \u2192 H\u2264246) and gap_bound_tpc_implies_eh (TPC \u2192 EH bound), eh_conditional_range (2 \u2264 H_opt \u2264 12 under EH), eh_solves_oq01oq02 (EH proves OpenQuestion01OQ02), and h12_unconditional_implies_progress (any unconditional H\u226412 surpasses state of art)."
+      "summary": "OpenQuestion01OQ02 definition (∃H ≤ 12, infinitely many prime gaps ≤ H), gap_bound_eh_implies_unconditional (H≤12 → H≤246) and gap_bound_tpc_implies_eh (TPC → EH bound), eh_conditional_range (2 ≤ H_opt ≤ 12 under EH), eh_solves_oq01oq02 (EH proves OpenQuestion01OQ02), and h12_unconditional_implies_progress (any unconditional H≤12 surpasses state of art)."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Maynard, J."
+      ],
+      "title": "Small gaps between primes",
+      "year": "2015",
+      "venue": "Annals of Mathematics 181 (1), pp. 383–413",
+      "note": "The Maynard–Tao multidimensional sieve giving bounded prime gaps and the H ≤ 246 / EH-conditional H ≤ 12 bounds."
+    },
+    {
+      "authors": [
+        "Elliott, P.D.T.A.",
+        "Halberstam, H."
+      ],
+      "title": "A conjecture in prime number theory",
+      "year": "1970",
+      "venue": "Symposia Mathematica 4, pp. 59–72",
+      "note": "The Elliott–Halberstam conjecture on the distribution of primes in arithmetic progressions."
+    },
+    {
+      "authors": [
+        "Polymath, D.H.J."
+      ],
+      "title": "Variants of the Selberg sieve, and bounded intervals containing many primes",
+      "year": "2014",
+      "venue": "Research in the Mathematical Sciences 1:12",
+      "note": "Polymath8b: optimized admissible tuples and the sharpest unconditional/EH-conditional gap bounds."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the Elliott-Halberstam conditional improvement from H \u2264 246 (unconditional Polymath 8b) to H \u2264 12. With 25 proved theorems, 0 sorries, and 1 axiom (maynard_tao_sieve_eh), the file gives a complete structural picture: the 10\u00d7 reduction in sieve threshold (k=50 \u2192 k=5) traces back to the single step from strict \u03b8 < 1/2 to equality \u03b8 = 1/2 in the distribution estimate for primes in APs, and the optimal admissible 5-tuple {0,2,6,8,12} of diameter 12 gives the best possible EH-conditional bound.",
-    "implications": "The EH conditional bound H \u2264 12 represents the current frontier between what is conditionally achievable and what the Twin Prime Conjecture predicts (H=2). Proving EH unconditionally \u2014 or finding a sieve argument that requires only k=5 without EH-level estimates \u2014 would be a major breakthrough in analytic number theory, yielding H \u2264 12 as a theorem. The formal definition of OpenQuestion01OQ02 makes this milestone machine-checkable: any proof of that proposition constitutes progress beyond Polymath 8b. The formalization also illustrates how conditional improvements in number theory can be precisely organized around distribution estimates (BV vs EH) and their sieve-theoretic consequences.",
+    "summary": "This formalization captures the Elliott-Halberstam conditional improvement from H ≤ 246 (unconditional Polymath 8b) to H ≤ 12. With 25 proved theorems, 0 sorries, and 1 axiom (maynard_tao_sieve_eh), the file gives a complete structural picture: the 10× reduction in sieve threshold (k=50 → k=5) traces back to the single step from strict θ < 1/2 to equality θ = 1/2 in the distribution estimate for primes in APs, and the optimal admissible 5-tuple {0,2,6,8,12} of diameter 12 gives the best possible EH-conditional bound.",
+    "implications": "The EH conditional bound H ≤ 12 represents the current frontier between what is conditionally achievable and what the Twin Prime Conjecture predicts (H=2). Proving EH unconditionally — or finding a sieve argument that requires only k=5 without EH-level estimates — would be a major breakthrough in analytic number theory, yielding H ≤ 12 as a theorem. The formal definition of OpenQuestion01OQ02 makes this milestone machine-checkable: any proof of that proposition constitutes progress beyond Polymath 8b. The formalization also illustrates how conditional improvements in number theory can be precisely organized around distribution estimates (BV vs EH) and their sieve-theoretic consequences.",
     "openQuestions": [
-      "Can H \u2264 12 be proved unconditionally \u2014 i.e., can the EH conjecture be proved, or can its hypothesis be avoided by a new sieve argument?",
+      "Can H ≤ 12 be proved unconditionally — i.e., can the EH conjecture be proved, or can its hypothesis be avoided by a new sieve argument?",
       "Does a new sieve technique exist that achieves the k=5 threshold without full EH-level primes-in-APs distribution?",
       "Can the Maynard-Tao sieve framework be formalized in Lean 4 / Mathlib, eliminating the maynard_tao_sieve_eh axiom entirely?"
     ]
@@ -117,15 +147,15 @@
   "crossReferences": [
     {
       "targetId": "bounded-prime-gaps",
-      "relationship": "grandparent \u2014 defines IsAdmissible, primeGap, maynard_tao_sieve, maynard_tao_sieve_eh"
+      "relationship": "grandparent — defines IsAdmissible, primeGap, maynard_tao_sieve, maynard_tao_sieve_eh"
     },
     {
       "targetId": "bounded-prime-gaps-oq-01",
-      "relationship": "parent \u2014 proves admissibility of {0,2,6,8,12}, non-admissibility of diameter \u2264 10 tuples"
+      "relationship": "parent — proves admissibility of {0,2,6,8,12}, non-admissibility of diameter ≤ 10 tuples"
     },
     {
       "targetId": "bounded-prime-gaps-oq-03",
-      "relationship": "sibling \u2014 explores other extensions of bounded prime gaps"
+      "relationship": "sibling — explores other extensions of bounded prime gaps"
     }
   ],
   "sorries": 0,

--- a/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
@@ -55,6 +55,36 @@
       "Combinatorics: admissible k-tuples, Dickson's conjecture"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Maynard, J."
+      ],
+      "title": "Small gaps between primes",
+      "year": "2015",
+      "venue": "Annals of Mathematics 181 (1), pp. 383–413",
+      "note": "The Maynard–Tao multidimensional sieve giving bounded prime gaps and the H ≤ 246 / EH-conditional H ≤ 12 bounds."
+    },
+    {
+      "authors": [
+        "Polymath, D.H.J."
+      ],
+      "title": "Variants of the Selberg sieve, and bounded intervals containing many primes",
+      "year": "2014",
+      "venue": "Research in the Mathematical Sciences 1:12",
+      "note": "Polymath8b: optimized admissible tuples and the sharpest unconditional/EH-conditional gap bounds."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E."
+      ],
+      "title": "Some problems of 'Partitio numerorum'; III: On the expression of a number as a sum of primes",
+      "year": "1923",
+      "venue": "Acta Mathematica 44, pp. 1–70",
+      "note": "Origin of the prime k-tuples conjecture and the notion of an admissible tuple."
+    }
+  ],
   "conclusion": {
     "summary": "A complete formalization of the admissible tuple theory underlying the bounded prime gaps theorem. Proves minimum diameter theorems for k=2,3,5 and the gap bound hierarchy (H≤246 unconditionally, H≤12 conditional). 26 theorems, 0 sorries; the H≤246 bound inherits the maynard_tao_sieve axiom from BoundedPrimeGaps.lean.",
     "implications": "This formalization establishes the combinatorial foundation for future work on improving the prime gap bound. The non-admissibility proofs demonstrate how decidable computations (via Lean's native_decide or decide) can verify specific tuple failures at explicit primes. The gap hierarchy is a roadmap for the open problem of reducing H toward 2.",

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -101,6 +101,36 @@
       "summary": "minAdmissibleDiameter_6 = 16 via le_antisymm, mirroring minAdmissibleDiameter_5: upper bound from the admissible witness {0,4,6,10,12,16} via csInf_le; lower bound from admissible_6tuple_diam_ge_16 via le_csInf."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E."
+      ],
+      "title": "Some problems of 'Partitio numerorum'; III: On the expression of a number as a sum of primes",
+      "year": "1923",
+      "venue": "Acta Mathematica 44, pp. 1–70",
+      "note": "Origin of the prime k-tuples conjecture and the notion of an admissible tuple."
+    },
+    {
+      "authors": [
+        "Polymath, D.H.J."
+      ],
+      "title": "Variants of the Selberg sieve, and bounded intervals containing many primes",
+      "year": "2014",
+      "venue": "Research in the Mathematical Sciences 1:12",
+      "note": "Polymath8b: optimized admissible tuples and the sharpest unconditional/EH-conditional gap bounds."
+    },
+    {
+      "authors": [
+        "Maynard, J."
+      ],
+      "title": "Small gaps between primes",
+      "year": "2015",
+      "venue": "Annals of Mathematics 181 (1), pp. 383–413",
+      "note": "The Maynard–Tao multidimensional sieve giving bounded prime gaps and the H ≤ 246 / EH-conditional H ≤ 12 bounds."
+    }
+  ],
   "conclusion": {
     "summary": "Proved $D(6)=16$: every admissible 6-tuple has diameter $\\geq 16$, witnessed by $\\{0,4,6,10,12,16\\}$. The lower bound is fully symbolic (native_decide-free), interrogating $p \\in \\{2,3,5\\}$ via a parity filter, a mod-3 grouping that pins the tuple to a unique candidate, and a mod-5 obstruction that kills it. The witness diameter is computed without native_decide, so the whole entry is axiom-free. 254 lines, 4 theorems, 0 sorries, 0 axioms.",
     "implications": "With $D(2)=2$, $D(3)=6$, $D(4)=8$, $D(5)=12$, and now $D(6)=16$ all machine-verified, the smallest six prime-constellation diameters are formally established in Lean 4. $D(6)$ is the first rung whose lower bound provably needs three residue layers ($p=2,3,5$), illustrating how the obstruction structure of $D(k)$ grows. The technique — parity filtration, residue-group pinning via cardinality, and a final residue-cover obstruction — extends toward $D(7)=20$, where the mod-5 and mod-7 layers will both be needed.",

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
@@ -86,6 +86,36 @@
       "summary": "minAdmissibleDiameter_5 = 12 via le_antisymm, exactly mirroring minAdmissibleDiameter_3: upper bound from the admissible witness {0,2,6,8,12} via csInf_le (witness diameter discharged by fsDiameter_0_2_6_8_12); lower bound from admissible_5tuple_diam_ge_12 via le_csInf. No native_decide anywhere."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E."
+      ],
+      "title": "Some problems of 'Partitio numerorum'; III: On the expression of a number as a sum of primes",
+      "year": "1923",
+      "venue": "Acta Mathematica 44, pp. 1–70",
+      "note": "Origin of the prime k-tuples conjecture and the notion of an admissible tuple."
+    },
+    {
+      "authors": [
+        "Polymath, D.H.J."
+      ],
+      "title": "Variants of the Selberg sieve, and bounded intervals containing many primes",
+      "year": "2014",
+      "venue": "Research in the Mathematical Sciences 1:12",
+      "note": "Polymath8b: optimized admissible tuples and the sharpest unconditional/EH-conditional gap bounds."
+    },
+    {
+      "authors": [
+        "Maynard, J."
+      ],
+      "title": "Small gaps between primes",
+      "year": "2015",
+      "venue": "Annals of Mathematics 181 (1), pp. 383–413",
+      "note": "The Maynard–Tao multidimensional sieve giving bounded prime gaps and the H ≤ 246 / EH-conditional H ≤ 12 bounds."
+    }
+  ],
   "conclusion": {
     "summary": "Proved $D(5)=12$: every admissible 5-tuple has diameter $\\geq 12$, witnessed by $\\{0,2,6,8,12\\}$. Both bounds are fully symbolic (native_decide-free): the lower bound interrogates only $p \\in \\{2,3\\}$ via a parity filter plus a two-mod-3-complete-triple counting argument, and the upper-bound witness diameter is computed symbolically by `fsDiameter_0_2_6_8_12`. The result carries no `Lean.ofReduceBool` axiom and is fully kernel-verified. 232 lines, 4 theorems, 0 sorries, 0 axioms.",
     "implications": "With $D(2)=2$, $D(3)=6$, $D(4)=8$, and now $D(5)=12$ all machine-verified, the smallest five prime-constellation diameters are formally established in Lean 4. The two-triple counting argument is the natural successor to the single-AP obstruction used for $D(4)$ and extends the reusable proof infrastructure (parity filtration, residue-complete-block counting) toward $D(6)=16$ and beyond. Under the Elliott–Halberstam conjecture, $D(5)=12$ is the exact predicted span for prime quintuples $n, n+2, n+6, n+8, n+12$.",

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
@@ -86,6 +86,27 @@
       "summary": "Proves D2_lt_D3_lt_D4 (strictly increasing chain 2 < 6 < 8), D4_achieved_by_0268, D4_minus_D3 = 2, and prime_quadruple_span_ge_8 (universal lower bound on admissible 4-tuple diameters)."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E."
+      ],
+      "title": "Some problems of 'Partitio numerorum'; III: On the expression of a number as a sum of primes",
+      "year": "1923",
+      "venue": "Acta Mathematica 44, pp. 1–70",
+      "note": "Origin of the prime k-tuples conjecture and the notion of an admissible tuple."
+    },
+    {
+      "authors": [
+        "Polymath, D.H.J."
+      ],
+      "title": "Variants of the Selberg sieve, and bounded intervals containing many primes",
+      "year": "2014",
+      "venue": "Research in the Mathematical Sciences 1:12",
+      "note": "Polymath8b: optimized admissible tuples and the sharpest unconditional/EH-conditional gap bounds."
+    }
+  ],
   "conclusion": {
     "summary": "Proved $D(4)=8$: every admissible 4-tuple has diameter $\\geq 8$, witnessed by $\\{0,2,6,8\\}$. The proof uses the parity constraint + forced AP structure argument, reducing to the non-admissible triple result proved in the parent file. 187 lines, 7 theorems, 0 sorries, 0 axioms. Also repaired pre-existing Mathlib API issues in BoundedPrimeGapsOQ03OQ01.",
     "implications": "With $D(2)=2$, $D(3)=6$, $D(4)=8$ now all machine-verified, the smallest prime constellation diameters are formally established in Lean 4. The proof infrastructure — parity filtration, subset contamination, forced-AP structure — is reusable for $D(5)=12$ and beyond. Under the Elliott–Halberstam conjecture, these $D(k)$ values give exact predicted gaps for prime $k$-tuples: the prime quadruple conjecture predicts infinitely many $n$ with $n,n+2,n+6,n+8$ all prime.",

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01/meta.json
@@ -77,6 +77,27 @@
       "mathContext": "$2\\|\\theta\\| \\leq |\\sin(\\pi\\theta)|$, hence $1/|\\sin(\\pi\\theta)| \\leq 1/(2\\|\\theta\\|)$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Montgomery, H.L.",
+        "Vaughan, R.C."
+      ],
+      "title": "Multiplicative Number Theory I: Classical Theory",
+      "year": "2007",
+      "venue": "Cambridge Studies in Advanced Mathematics 97, Cambridge University Press",
+      "note": "Modern treatment of the large sieve, the Pólya–Vinogradov inequality and related character-sum bounds."
+    },
+    {
+      "authors": [
+        "Davenport, H."
+      ],
+      "title": "Multiplicative Number Theory",
+      "year": "2000",
+      "venue": "3rd ed., Graduate Texts in Mathematics 74, Springer",
+      "note": "Standard reference for character sums, Pólya–Vinogradov and Bombieri–Vinogradov."
+    }
+  ],
   "conclusion": {
     "summary": "The cosecant→distance conversion |sin(πθ)| ≥ 2‖θ‖ (and its reciprocal form) is fully formalized, supplying the bridge that puts the sibling's geometric exponential sum bound into the standard 1/(2‖θ‖) form used throughout Pólya–Vinogradov. 4 theorems, 0 sorries, 0 axioms.",
     "implications": "Together with BoundedPrimeGapsOQ04OQ01WIP01's geometric sum bound, this gives |∑_{n=M+1}^{M+N} e^{2πiθn}| ≤ 1/(2‖θ‖), the exact input the Pólya–Vinogradov cotangent aggregation consumes. It is the second self-contained classical ingredient of that inequality.",

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
@@ -84,6 +84,36 @@
       "summary": "Detailed four-phase proof plan (~700 lines total): Gauss sum bound (~300 lines), geometric series (~100 lines), cotangent sum (~200 lines), assembly (~100 lines). Lists Mathlib infrastructure required."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Pólya, G."
+      ],
+      "title": "Über die Verteilung der quadratischen Reste und Nichtreste",
+      "year": "1918",
+      "venue": "Nachrichten von der Gesellschaft der Wissenschaften zu Göttingen, pp. 21–29",
+      "note": "One of the two independent origins of the Pólya–Vinogradov character-sum inequality."
+    },
+    {
+      "authors": [
+        "Vinogradov, I.M."
+      ],
+      "title": "Sur la distribution des résidus et non-résidus des puissances",
+      "year": "1918",
+      "venue": "Journal of the Physico-Mathematical Society of Perm 1, pp. 94–98",
+      "note": "Independent origin of the Pólya–Vinogradov inequality."
+    },
+    {
+      "authors": [
+        "Montgomery, H.L.",
+        "Vaughan, R.C."
+      ],
+      "title": "Multiplicative Number Theory I: Classical Theory",
+      "year": "2007",
+      "venue": "Cambridge Studies in Advanced Mathematics 97, Cambridge University Press",
+      "note": "Modern treatment of the large sieve, the Pólya–Vinogradov inequality and related character-sum bounds."
+    }
+  ],
   "conclusion": {
     "summary": "This formalization precisely states all components of the Pólya-Vinogradov inequality in Lean 4 with a detailed four-phase proof roadmap. All five sorries correspond to well-understood mathematical arguments; the formalization is complete at the statement level and is structured to support incremental completion of each phase.",
     "implications": "Completing this formalization would unlock the Bombieri-Vinogradov theorem (the parent goal), which is the key analytic ingredient in the bounded prime gap problem. The Pólya-Vinogradov inequality also has independent significance as the sharpest unconditional bound on character sums over intervals, with applications throughout analytic number theory including zero-free regions for L-functions and exponential sum bounds in cryptography.",

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
@@ -119,6 +119,36 @@
       "mathContext": "The key identity $\\tau(\\chi)\\overline{\\tau(\\chi)} = \\chi(-1) q$ for primitive $\\chi \\bmod q$ is proved by substituting $u = t - s$ and applying character orthogonality: $\\sum_s \\chi(u+s)\\bar{\\chi}(s) = \\chi(u)\\varphi(q)$ for $\\gcd(u,q) = 1$ (and 0 otherwise by primitivity). This yields $|\\tau(\\chi)|^2 = q$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Bombieri, E."
+      ],
+      "title": "On the large sieve",
+      "year": "1965",
+      "venue": "Mathematika 12, pp. 201–225",
+      "note": "The Bombieri–Vinogradov theorem on the average distribution of primes in arithmetic progressions."
+    },
+    {
+      "authors": [
+        "Davenport, H."
+      ],
+      "title": "Multiplicative Number Theory",
+      "year": "2000",
+      "venue": "3rd ed., Graduate Texts in Mathematics 74, Springer",
+      "note": "Standard reference for character sums, Pólya–Vinogradov and Bombieri–Vinogradov."
+    },
+    {
+      "authors": [
+        "Montgomery, H.L.",
+        "Vaughan, R.C."
+      ],
+      "title": "Multiplicative Number Theory I: Classical Theory",
+      "year": "2007",
+      "venue": "Cambridge Studies in Advanced Mathematics 97, Cambridge University Press",
+      "note": "Modern treatment of the large sieve, the Pólya–Vinogradov inequality and related character-sum bounds."
+    }
+  ],
   "conclusion": {
     "summary": "The minimal set for Bombieri-Vinogradov is 6 additions totaling ~5500 lines. The most tractable entry point is gaussSumBound (~300 lines, HIGH tractability: builds on ZMod.gaussSum and character orthogonality in Mathlib). Parallel development of vaughanIdentity (~400 lines, HIGH tractability: algebraic Möbius identity) would let two Mathlib PRs proceed simultaneously. Once these two are in, polyaVinogradov follows directly.",
     "implications": "Proving all 6 additions would reduce BoundedPrimeGaps.lean from 3 axioms to 2 (eliminating bombieriVinogradov), making the Maynard-Tao bounded prime gaps proof closer to axiom-free. Beyond BV, the same additions unlock the Barban-Davenport-Halberstam theorem, Linnik's theorem on least primes in APs, the GPY sieve, and Chen's theorem approach to Goldbach.",

--- a/src/data/proofs/bounded-prime-gaps-oq-05/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-05/meta.json
@@ -75,6 +75,26 @@
       "summary": "Defines nthPrime = Nat.nth Nat.Prime and the three prime formulations FiroozbakhtRoot / FiroozbakhtRpow / FiroozbakhtIntPow, proves the three pairwise equivalences by chaining the pointwise lemmas with core_real_iff_nat and nthPrime_pos, and packages them as firoozbakht_forms_tfae (List.TFAE)."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Ribenboim, P."
+      ],
+      "title": "The Little Book of Bigger Primes",
+      "year": "2004",
+      "venue": "2nd ed., Springer",
+      "note": "Standard survey source for Firoozbakht's conjecture and related prime-gap conjectures."
+    },
+    {
+      "authors": [
+        "Kourbatov, A."
+      ],
+      "title": "Upper bounds for prime gaps related to Firoozbakht's conjecture",
+      "year": "2015",
+      "venue": "Journal of Integer Sequences 18, Article 15.11.2",
+      "note": "Analysis of the equivalent formulations and consequences of Firoozbakht's conjecture."
+    }
+  ],
   "conclusion": {
     "summary": "Proved, unconditionally and axiom-free, that the three standard formulations of Firoozbakht's conjecture — the original root form $p_{n+1}^{1/(n+1)} < p_n^{1/n}$, the rpow form $p_{n+1} < p_n^{1+1/n}$, and the integer-power form $p_{n+1}^n < p_n^{n+1}$ — are equivalent. The core mechanism is a pointwise reduction of each inequality (for positive reals) to the single inequality $a^n < b^{n+1}$ via strict monotonicity of real rpow, followed by a bridge to the natural-number statement. 150 lines, 8 theorems, 4 definitions, 0 sorries, 0 axioms.",
     "implications": "This connects the gallery's RPOW formalization (BoundedPrimeGaps.lean's FireoozbakhtConjecture) to the original 1982 root statement and to the elementary integer-power statement, so a result proved against any one form transfers to the others. The pointwise lemmas root_lt_iff / rpow_lt_iff are reusable for any strictly-monotone comparison of $a^{1/(n+1)}$ and $b^{1/n}$. Establishing the equivalence is the prerequisite for any future formal work that would, e.g., verify the conjecture for an initial range of primes via the elementary integer-power form (the cheapest to decide) and conclude the analytic forms.",


### PR DESCRIPTION
Adds a top-level `references` array to the 10 open-question descendants of **bounded-prime-gaps** that previously had none.

## Coverage
The Maynard–Tao / Polymath multidimensional sieve and admissible k-tuples (minimum diameters D(4)=8, D(5)=12, D(6)=16), the Elliott–Halberstam conditional gap bound H ≤ 12, the Pólya–Vinogradov inequality and its cosecant→distance ingredient, the minimal-Mathlib-additions catalog for Bombieri–Vinogradov, and the three equivalent formulations of Firoozbakht's conjecture.

## Method
Cited to the primary sources — Maynard (2015), Polymath8b (2014), Hardy–Littlewood (1923), Elliott–Halberstam (1970), Bombieri (1965), Pólya / Vinogradov (1918), and Firoozbakht via Ribenboim / Kourbatov — plus the standard texts Davenport, *Multiplicative Number Theory* and Montgomery–Vaughan. 2–3 references per entry, matched to each `description`.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.