### PR TITLE
Enrich arithmetic-series OQ cluster: add references to 10 entries

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -50,6 +50,38 @@
       "Finset.sum_range_reflect (reflection involution on a finite range)"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Andrews, G.E."
+      ],
+      "title": "The Theory of Partitions",
+      "year": "1998",
+      "venue": "Cambridge Mathematical Library, Cambridge University Press",
+      "note": "q-series, Gaussian (q-)binomial coefficients and the q-Vandermonde / q-Chu–Vandermonde identity."
+    },
+    {
+      "authors": [
+        "Kac, V.",
+        "Cheung, P."
+      ],
+      "title": "Quantum Calculus",
+      "year": "2002",
+      "venue": "Universitext, Springer",
+      "note": "Gaussian binomial coefficients, the q-Pascal recurrence and q-analogs of classical identities."
+    },
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Standard reference for binomial identities — Vandermonde's convolution, the hockey-stick identity, and rising/falling factorials."
+    }
+  ],
   "conclusion": {
     "summary": "The q-Vandermonde convolution is recast under the two involutions m↔n and k↦r−k, and the resulting dual / reflected sums are proved equal to the original as ring elements. Four theorems, all corollaries of the parent qVandermonde via Nat.add_comm and Finset.sum_range_reflect. Fully verified: 0 axioms, 0 sorries.",
     "implications": "Records, as machine-checked identities, the hidden symmetry of the q-exponent k(m+k−r): different-looking q-weighted convolution sums compute the same Gaussian binomial. This is the symmetry that becomes manifest at q=1 (classical Vandermonde) but is obscured by the q-deformation, and it underlies the standard combinatorial (subspace-counting) interpretation where exchanging the two factor spaces or complementing the chosen dimension leaves the count invariant.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01-oq-03/meta.json
@@ -103,6 +103,28 @@
       "mathContext": "1-D recovers the classical hockey stick generating function; 3-D gives $1/(1-z)^{a+b+c+3}$, whose coefficients $\\binom{n+a+b+c+2}{a+b+c+2}$ count weighted lattice points in a tetrahedron."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Stanley, R.P."
+      ],
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge Studies in Advanced Mathematics 49, Cambridge University Press",
+      "note": "Comprehensive treatment of generating functions, convolution identities and q-analogs."
+    },
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Standard reference for binomial identities — Vandermonde's convolution, the hockey-stick identity, and rising/falling factorials."
+    }
+  ],
   "conclusion": {
     "summary": "The multivariate generating-function identity ∏_j (∑_i C(a_j+i,a_j) z^i) = 1/(1-z)^{∑a_j+k} is proved in Lean's PowerSeries ring, answering the parent's third open question. The one-variable factor is Mathlib's invOneSubPow S (a+1); the whole identity is a one-line list induction whose engine is the exponent-additivity law invOneSubPow_add. The k=2 Cauchy product recovers the parent's parallel Vandermonde convolution with no induction. 13 theorems, 1 definition, 0 axioms, 0 sorries, fully machine-checked (only propext / Classical.choice / Quot.sound).",
     "implications": "The entry makes precise the textbook slogan that 'convolution of sequences is multiplication of generating functions.' Where the parent file performs a dimension-by-dimension induction driven by parallel Vandermonde, this file performs no numerical induction at all: the dimension count is a list length, the weight offset is a list sum, and folding the simplex is multiplication of inverse powers of (1-z). Reusing Mathlib's invOneSubPow unit means the proof's mathematical content reduces to a single additivity lemma, illustrating how the right algebraic abstraction (the group of units of a power series ring) can compress a combinatorial induction into a homomorphism computation.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
@@ -94,6 +94,28 @@
       "mathContext": "$C(m+k, k) \\leq C(n+k, k)$ when $m \\leq n$ (monotone in top argument). `Nat.choose_le_choose` takes `h : m ≤ n` and derives `C(m+k, k) ≤ C(n+k, k)`. Positivity: $C(n+k, k) \\geq 1$ for all $n,k \\geq 0$ since $n+k \\geq k$ always holds for naturals."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Standard reference for binomial identities — Vandermonde's convolution, the hockey-stick identity, and rising/falling factorials."
+    },
+    {
+      "authors": [
+        "Stanley, R.P."
+      ],
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge Studies in Advanced Mathematics 49, Cambridge University Press",
+      "note": "Comprehensive treatment of generating functions, convolution identities and q-analogs."
+    }
+  ],
   "conclusion": {
     "summary": "The k-dimensional hockey stick identity is proved by list induction with parallel Vandermonde as the induction engine. The parameter list encoding (length = dimension $k$, sum = offset $\\sum a_j$) makes the inductive step a clean one-application-of-convolution argument. Concrete checks confirm $C(5,3)=10$ (3-simplex at $n=2$) and $C(6,3)=20$. 8 theorems, 0 axioms, 165 lines.",
     "implications": "This formalization demonstrates that multi-dimensional combinatorial identities often reduce to repeated 1D convolutions. The list induction structure is a clean architectural choice: it makes the $k$-dimensional case literally a consequence of the $(k-1)$-dimensional case plus one Vandermonde step. The parallel between the algebraic structure (list sum + length) and the combinatorial content (weight offset + dimension) is the insight that makes the proof work.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -154,6 +154,26 @@
       ]
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Pólya, G."
+      ],
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "venue": "Acta Mathematica 68, pp. 145–254",
+      "note": "Pólya's enumeration theorem (with Burnside's lemma) for counting under group actions, e.g. bead necklaces."
+    },
+    {
+      "authors": [
+        "Stanley, R.P."
+      ],
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge Studies in Advanced Mathematics 49, Cambridge University Press",
+      "note": "Comprehensive treatment of generating functions, convolution identities and q-analogs."
+    }
+  ],
   "conclusion": {
     "summary": "Formalization proving 30 theorems (0 sorries). Burnside's lemma is used to count necklaces; the Pólya divisor-sum formula is verified for small n and proved in general via Burnside + cycle structure (from BurnsideCountingOQ03) + totient grouping. The concrete fixed-point/totient/necklace-count values are discharged by native_decide (relies on Lean.ofReduceBool); the general theorems are native_decide-free.",
     "implications": "Pólya's enumeration theorem is the foundational tool for counting combinatorial objects up to symmetry. The formalization demonstrates that Burnside's lemma from Mathlib is powerful enough to count necklaces concretely, and that ZMod-indexed colorings provide a particularly clean Lean 4 approach. The cycle structure theorem (each rotation by r has gcd(r,n) orbits on n positions) is the key missing ingredient for the general theorem — it connects the abstract Burnside sum to the totient-weighted divisor sum. The sequence [2,3,4,6,8,14] (binary necklaces for n=1–6) appears in OEIS A000029 and has applications in chemistry (molecular isomers), music theory (necklace rhythms), and coding theory (cyclic codes).",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
@@ -109,6 +109,28 @@
       "summary": "Verifies f-vectors for specific simplices (triangle: {3,3,1}, tetrahedron: {4,6,4,1}) via native_decide."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Stanley, R.P."
+      ],
+      "title": "Combinatorics and Commutative Algebra",
+      "year": "1996",
+      "venue": "2nd ed., Progress in Mathematics 41, Birkhäuser",
+      "note": "f-vectors and face counts of simplicial complexes."
+    },
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Standard reference for binomial identities — Vandermonde's convolution, the hockey-stick identity, and rising/falling factorials."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified formalization (0 axioms, 0 sorries) connects simplicial numbers $S_k(n) = \\binom{n+k}{k}$ to the combinatorial topology of simplicial complexes. The f-vector of the standard $k$-simplex is expressed in terms of simplicial numbers, and the Euler characteristic relation $\\chi(\\Delta^k) = 1$ is proved.",
     "implications": "The connection between simplicial numbers and face counts provides a bridge between the arithmetic of binomial coefficients (studied in the parent file) and algebraic topology. This perspective suggests formalizing the full f-vector theory including the Dehn-Sommerville relations for simplicial polytopes.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -85,6 +85,28 @@
       "endLine": 220
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Standard reference for binomial identities — Vandermonde's convolution, the hockey-stick identity, and rising/falling factorials."
+    },
+    {
+      "authors": [
+        "Stanley, R.P."
+      ],
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge Studies in Advanced Mathematics 49, Cambridge University Press",
+      "note": "Comprehensive treatment of generating functions, convolution identities and q-analogs."
+    }
+  ],
   "conclusion": {
     "summary": "Proved that rising factorials form a sequence of binomial type: (x+y)^{(k)} = Σ_{m=0}^{k} C(k,m)·x^{(m)}·y^{(k-m)} over any commutative semiring via Mathlib's ascPochhammer, plus its ℕ Chu–Vandermonde specialization for Nat.ascFactorial and structural corollaries. 222 lines, 8 theorems, 0 sorries, 0 axioms, no native_decide. Answers open questions #2 (multiset/Chu–Vandermonde in rising-factorial form) and #3 (ascPochhammer over a commutative ring, ℕ as specialization) of the parent multiset-coefficient entry.",
     "implications": "The headline is the additive (Vandermonde) companion to Mathlib's multiplicative ascPochhammer_mul and could be upstreamed. As a binomial-type statement it is the umbral binomial theorem for rising factorials, the bridge from elementary consecutive-integer products to Pochhammer symbols, hypergeometric series, and the Sheffer/binomial-type sequence machinery of umbral calculus.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01/meta.json
@@ -82,6 +82,28 @@
       "endLine": 149
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Standard reference for binomial identities — Vandermonde's convolution, the hockey-stick identity, and rising/falling factorials."
+    },
+    {
+      "authors": [
+        "Stanley, R.P."
+      ],
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge Studies in Advanced Mathematics 49, Cambridge University Press",
+      "note": "Comprehensive treatment of generating functions, convolution identities and q-analogs."
+    }
+  ],
   "conclusion": {
     "summary": "Proved the multiset-coefficient (rising factorial) identity C(n+k-1,k)·k! = ∏ i in range k, (n+i) and 8 consequences. 149 lines, 11 theorems, 0 sorries, 0 axioms, no native_decide. Completes the descending/ascending/multiset family of ordered-selection identities on the arithmetic-series branch. As part of this change, the grandparent ArithmeticSeriesOQ02OQ04.lean was repaired for Mathlib v4.26.0 (∏-binder syntax, numeric-literal factorial) and its concrete checks moved from native_decide to decide.",
     "implications": "With the descending (parent) and ascending (grandparent) forms, the multiset form completes the natural triad of consecutive-integer products attached to binomial and multiset coefficients. The rising-factorial form is the bridge to Pochhammer symbols and hypergeometric series.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
@@ -190,6 +190,26 @@
       "mathContext": "$$\\mathrm{qtMultichoose}(q,t,2,2) = \\mathrm{qMultichoose}(q,2,2) \\quad (1 - q^2 t \\neq 0,\\ 1 - q \\neq 0)$$"
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Macdonald, I.G."
+      ],
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "2nd ed., Oxford Mathematical Monographs, Oxford University Press",
+      "note": "Macdonald (q,t)-symmetric functions, the source of the (q,t)-deformations formalized here."
+    },
+    {
+      "authors": [
+        "Andrews, G.E."
+      ],
+      "title": "The Theory of Partitions",
+      "year": "1998",
+      "venue": "Cambridge Mathematical Library, Cambridge University Press",
+      "note": "q-series, Gaussian (q-)binomial coefficients and the q-Vandermonde / q-Chu–Vandermonde identity."
+    }
+  ],
   "conclusion": {
     "summary": "The Macdonald (q,t)-binomial, evaluated at the multichoose index shift N = n+k-1, yields a (q,t)-multichoose coefficient that is well-typed over a Field R and recovers the parent's qMultichoose at t=1 on the open dense set where q is not a low-order root of unity (Path A). The (q,t)-multichoose is t-independent precisely on the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)}, and every point there is bridged to the parent's qNumber/qBinom/qMultichoose. The file is sorry-free and axiom-free (21 machine-checked theorems), but the open question is only partially resolved.",
     "implications": "This is the gallery's first contact with Macdonald (q,t)-binomial theory, an area entirely absent from Mathlib v4.26.0 (no Macdonald polynomials, Hall-Littlewood functions, or DAHA). The k-direction multiplicative recurrence and its ratio form give clean Lean handles on the Macdonald binomial that future work can reuse. The explicit formalization of the Field-R 0/0 trap is a reusable cautionary pattern for any rational-function specialization under Lean's 0/0 = 0 convention.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
@@ -145,6 +145,27 @@
       "mathContext": "At $R = \\mathbb{Z}$: $\\text{qMultichoose}(1, n, k) = \\text{multichoose}(n, k) \\in \\mathbb{Z}$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Andrews, G.E."
+      ],
+      "title": "The Theory of Partitions",
+      "year": "1998",
+      "venue": "Cambridge Mathematical Library, Cambridge University Press",
+      "note": "q-series, Gaussian (q-)binomial coefficients and the q-Vandermonde / q-Chu–Vandermonde identity."
+    },
+    {
+      "authors": [
+        "Kac, V.",
+        "Cheung, P."
+      ],
+      "title": "Quantum Calculus",
+      "year": "2002",
+      "venue": "Universitext, Springer",
+      "note": "Gaussian binomial coefficients, the q-Pascal recurrence and q-analogs of classical identities."
+    }
+  ],
   "conclusion": {
     "summary": "The Gaussian binomial coefficient $\\binom{n+k-1}{k}_q$ is the canonical q-analog of the multiset coefficient $\\text{multichoose}(n,k)$, proved via: a clean definition (one line), four boundary cases, a q-Pascal recurrence, and double induction establishing recovery at q=1 over any CommRing.",
     "implications": "This result enables q-deformation of the entire multiset combinatorics toolkit: the multiset Vandermonde identity (parent entry) has a q-analog via qMultichoose, the q-analog of stars-and-bars has a vector-space interpretation (subspace counting over 𝔽_q), and the formal power series identity ∑_k multichoose(n,k) x^k = (1-x)^{-n} has a q-analog as a basic hypergeometric series. The Lean formalization over an arbitrary CommRing (not just ℤ or ℝ) enables application to polynomial rings, formal power series, and representation rings.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
@@ -96,6 +96,28 @@
       "endLine": 169
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Standard reference for binomial identities — Vandermonde's convolution, the hockey-stick identity, and rising/falling factorials."
+    },
+    {
+      "authors": [
+        "Stanley, R.P."
+      ],
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge Studies in Advanced Mathematics 49, Cambridge University Press",
+      "note": "Comprehensive treatment of generating functions, convolution identities and q-analogs."
+    }
+  ],
   "conclusion": {
     "summary": "Proved the descending factorial identity C(n,k)·k! = n.descFactorial(k) and 10 consequences. 169 lines, 12 theorems, 0 sorries, 0 axioms. Dual to the ascending factorial identity in ArithmeticSeriesOQ02OQ04.",
     "implications": "Together with the ascending factorial result, this completes the symmetry between rising and falling factorials in the context of arithmetic series and binomial coefficients. Both forms are useful in combinatorics: the descending form appears in falling factorial polynomials (basis for umbral calculus) and the ascending form in rising factorial polynomials (Pochhammer symbols).",


### PR DESCRIPTION
Adds a top-level `references` array to 10 open-question descendants of **arithmetic-series** that previously had none.

## Coverage
A combinatorics tree: Vandermonde / Chu–Vandermonde convolution and its q-analog (dual and reflected forms), the k-dimensional hockey-stick identity (convolution and multivariate generating-function proofs), rising/falling-factorial and multiset-coefficient identities, Gaussian (q-)binomial coefficients and their Macdonald (q,t)-deformation, Pólya/Burnside enumeration of bead necklaces, and simplicial numbers as face counts.

## Method
Cited to the standard combinatorics references — Graham–Knuth–Patashnik (*Concrete Mathematics*), Stanley (*Enumerative Combinatorics*; *Combinatorics and Commutative Algebra*), Andrews (*The Theory of Partitions*), Kac–Cheung (*Quantum Calculus*), Macdonald (*Symmetric Functions and Hall Polynomials*), and Pólya (1937) — matched to each `description`. 2–3 references per entry.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.