### PR TITLE
Enrich lagrange-theorem OQ cluster: add references to 9 entries

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json
@@ -97,6 +97,27 @@
       "summary": "Four concrete existence witnesses derived from the main theorem: exists_noncyclic_of_order_6 (DihedralGroup 3 ≅ S₃), exists_noncyclic_of_order_10 (DihedralGroup 5), exists_noncyclic_of_order_14 (DihedralGroup 7), exists_noncyclic_of_order_22 (DihedralGroup 11). Each instantiates with norm_num for the primality and inequality hypotheses."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Standard reference for the Sylow theorems, groups of order pq, the class equation, and A₄ as a counterexample to Lagrange's converse."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "note": "Detailed development of Sylow theory, p-group structure, and small-order classification."
+    }
+  ],
   "conclusion": {
     "summary": "This file proves 6 theorems with 0 sorries and 0 axioms, supplying explicit non-cyclic witnesses of order 2q for every odd prime q. The main theorem exists_noncyclic_of_order_two_mul_odd_prime, the divisibility certificate two_dvd_sub_one_of_odd_prime, and four concrete corollaries (orders 6, 10, 14, 22) complete the p = 2 specialization of the OQ.",
     "implications": "Combined with the parent pq-classification (LagrangeTheoremOQ01OQ01), this gives a complete two-sided picture in the p = 2 regime: when 2 ∤ (q-1) — i.e., q = 2 — only the cyclic group ℤ/4 and Klein four exist (handled separately because p < q is required); when 2 | (q-1) — i.e., q odd prime — both ℤ/(2q) and DihedralGroup q exist, and they are non-isomorphic (cyclic vs not cyclic). The Approach B generalization to arbitrary p with p | (q-1) is deferred and requires the SemidirectProduct construction.",

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
@@ -144,6 +144,27 @@
       "summary": "semidirectProduct_trivial_isCyclic: a trivial action over coprime cyclic factors collapses N ⋊[1] Γ to the cyclic direct product N × Γ (SemidirectProduct.mulEquivProd + Group.isCyclic_prod_iff). action_ne_one_of_not_isCyclic: contrapositive — a non-cyclic such product has nontrivial action. pq_noncyclic_iso (CAPSTONE): any two non-cyclic groups of order pq (p < q) are isomorphic — both are internally Q ⋊ P with nontrivial action, bridged by transporting one action onto the other's factors (SemidirectProduct.congr', mulEquivOfCyclicCardEq) and Part VII's capstone, valid since MulAut Q ≅ (ZMod q)ˣ is cyclic for prime q (IsCyclic.mulAutMulEquiv, ZMod.isCyclic_units_prime)."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Standard reference for the Sylow theorems, groups of order pq, the class equation, and A₄ as a counterexample to Lagrange's converse."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "note": "Detailed development of Sylow theory, p-group structure, and small-order classification."
+    }
+  ],
   "conclusion": {
     "summary": "This file proves 25 theorems and 2 definitions with 0 sorries and 0 axioms (kernel-verified: standard [propext, Classical.choice, Quot.sound] triple only, no native_decide). It resolves, up to MulEquiv, ALL THREE isomorphism classes of order pq: (a) the abelian class (every abelian group of order pq is cyclic ≅ ℤ/pq, any distinct primes); (b) the full cyclic branch (when ¬p∣(q-1) and ¬q∣(p-1), every group of order pq is cyclic, so any two are isomorphic — e.g. all groups of order 15 and 35); and (c) the NON-ABELIAN branch — pq_noncyclic_iso shows any two non-cyclic groups of order pq (p < q) are isomorphic. The non-abelian proof chains Part VI (iso type of N ⋊[φ] G depends only on φ.range), Part VII (common range of nontrivial prime-order actions into a cyclic Aut), Part VIII (internal recognition G ≃* Q ⋊ P), and Part IX (a trivial action forces the cyclic direct product Q × P, so a non-cyclic group has nontrivial action), bridging two arbitrary non-cyclic groups by transporting actions across their isomorphic Sylow factors (SemidirectProduct.congr').",
     "implications": "Together with the parent (counting) and sibling oq-01-oq-01-oq-01 (explicit non-cyclic witnesses), the ENTIRE order-pq classification now has genuine isomorphisms, not just a class count — covering the cyclic AND non-abelian branches, and crucially without assuming commutativity, rebuilt directly from Mathlib's Sylow/Z-group/SemidirectProduct API rather than the parent's non-compiling Sylow file. The previously-flagged Mathlib gaps (internal semidirect recognition; common range) are both discharged, and the last residual mathematical input — nontriviality of the action in the non-cyclic case — is proved via the trivial-action-collapses-to-direct-product lemma. The one remaining open direction is constructive existence of the non-abelian class exactly when p ∣ (q-1).",

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01/meta.json
@@ -1,7 +1,6 @@
 {
   "id": "lagrange-theorem-oq-01-oq-01",
   "title": "pq-Groups: Classification of Groups of Order pq via Sylow Theory",
-  "id": "lagrange-theorem-oq-01-oq-01",
   "description": "Formal proof classifying all finite groups of order pq (p < q distinct primes): the Sylow q-subgroup is always unique and normal; when p ∤ (q-1) the group is cyclic; when p | (q-1) two groups exist.",
   "meta": {
     "author": "Lean Genius",
@@ -93,6 +92,36 @@
       "startLine": 143,
       "endLine": 169,
       "summary": "Six concrete examples: order_15_cyclic, order_35_cyclic, order_77_cyclic (all via pq_cyclic_classification with norm_num/omega); order_6_non_unique (2 | 2), order_21_non_unique (3 | 6), order_55_non_unique (5 | 10). The cyclic theorems are machine-verified; the non-unique cases prove the divisibility condition confirming two groups exist."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Sylow, L."
+      ],
+      "title": "Théorèmes sur les groupes de substitutions",
+      "year": "1872",
+      "venue": "Mathematische Annalen 5, pp. 584–594",
+      "note": "Original source of the Sylow theorems, the partial converse to Lagrange's theorem."
+    },
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Standard reference for the Sylow theorems, groups of order pq, the class equation, and A₄ as a counterexample to Lagrange's converse."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "note": "Detailed development of Sylow theory, p-group structure, and small-order classification."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-02/meta.json
@@ -34,8 +34,13 @@
   "leanFile": {
     "path": "Proofs/LagrangeTheoremOQ01OQ02.lean",
     "namespace": "LagrangeOQ01OQ02",
-    "imports": ["Mathlib"],
-    "opens": ["Subgroup", "Fintype"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Subgroup",
+      "Fintype"
+    ],
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 121,
@@ -101,6 +106,27 @@
       "endLine": 121,
       "summary": "A4_no_index2_subgroup: no index-2 subgroup of A₄ (since an index-2 subgroup would have order 6). lagrange_converse_fails: the precise counterexample statement — 6 divides |A₄| but no subgroup of order 6 exists.",
       "mathContext": "Index-2 corollary: $[A_4:H]=2 \\Rightarrow |H|=6$ (from $|H| \\cdot [A_4:H] = |A_4| = 12$). Then `A4_no_subgroup_order6` gives contradiction. Formal counterexample: $6 \\mid 12$ (witnessed by $6 \\times 2 = 12$) and $\\forall H \\leq A_4,\\, |H| \\neq 6$."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Standard reference for the Sylow theorems, groups of order pq, the class equation, and A₄ as a counterexample to Lagrange's converse."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "note": "Detailed development of Sylow theory, p-group structure, and small-order classification."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
@@ -82,6 +82,36 @@
     }
   ],
   "parentId": "lagrange-theorem-oq-01",
+  "references": [
+    {
+      "authors": [
+        "Hall, P."
+      ],
+      "title": "A note on soluble groups",
+      "year": "1928",
+      "venue": "Journal of the London Mathematical Society 3 (2), pp. 98–105",
+      "note": "Hall's theorem on the existence of Hall subgroups in finite solvable groups."
+    },
+    {
+      "authors": [
+        "Isaacs, I.M."
+      ],
+      "title": "Finite Group Theory",
+      "year": "2008",
+      "venue": "Graduate Studies in Mathematics 92, American Mathematical Society",
+      "note": "Hall subgroups and the characterization of finite solvable groups."
+    },
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Standard reference for the Sylow theorems, groups of order pq, the class equation, and A₄ as a counterexample to Lagrange's converse."
+    }
+  ],
   "conclusion": {
     "summary": "This entry formalizes the combinatorial and algebraic heart of Hall's theorem in Lean 4, providing machine-checked proofs for the trivial, prime, and cyclic cases, and a mathematically complete axiom-with-sketch for the general solvable case. The 14 theorems and 2 definitions establish a rigorous framework for Hall divisors, Hall subgroups, and their relationship to solvability.",
     "implications": "Hall's theorem is a foundational result in finite group theory with far-reaching implications. It provides the theoretical basis for the structure of solvable groups: every solvable group has a rich supply of subgroups whose orders cover all Hall divisors. This is used in the Schur–Zassenhaus theory of group extensions, in the classification of groups of squarefree order, and in the study of Frobenius groups. The biconditional characterization of solvability also shows that Hall's theorem is not merely a generalization of Sylow theory but a fundamentally deeper result — one that connects the prime factorization structure of the group order to the global topology of the subgroup lattice.",

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -93,6 +93,36 @@
       "summary": "Proves partial_converse_lagrange: p^k | |G| implies ∃ H : Subgroup G with |H| = p^k, via Sylow.exists_subgroup_card_pow_prime. Proves cauchy_theorem: p prime, p | |G| implies ∃ g with orderOf g = p, via exists_prime_orderOf_dvd_card. Both are one-line delegations to Mathlib"
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Sylow, L."
+      ],
+      "title": "Théorèmes sur les groupes de substitutions",
+      "year": "1872",
+      "venue": "Mathematische Annalen 5, pp. 584–594",
+      "note": "Original source of the Sylow theorems, the partial converse to Lagrange's theorem."
+    },
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Standard reference for the Sylow theorems, groups of order pq, the class equation, and A₄ as a counterexample to Lagrange's converse."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "note": "Detailed development of Sylow theory, p-group structure, and small-order classification."
+    }
+  ],
   "conclusion": {
     "summary": "This file proves 11 theorems with 0 sorries and 0 axioms, all sourced from Mathlib, covering Lagrange's theorem, all three Sylow theorems, and Cauchy's theorem, within the namespace LagrangeOQ01.",
     "implications": "The Sylow theorems are among the most important results in finite group theory, enabling the classification of groups of small order and underpinning the structure theory of finite groups. Having them formally verified and contextualized relative to Lagrange's theorem completes the classical picture. Mathlib's implementation represents decades of development: the proof of the third Sylow theorem (n_p ≡ 1 mod p) uses the orbit-counting lemma (Burnside's lemma) applied to the action of P on the set of Sylow p-subgroups by conjugation — all formalized in `Mathlib.GroupTheory.Sylow`.",

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-02/meta.json
@@ -51,6 +51,27 @@
       "The class equation and the center of a group"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Standard reference for the Sylow theorems, groups of order pq, the class equation, and A₄ as a counterexample to Lagrange's converse."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "note": "Detailed development of Sylow theory, p-group structure, and small-order classification."
+    }
+  ],
   "conclusion": {
     "summary": "Fully machine-verified packaging of the p-group fixed-point congruence and its central consequence: a p-group action satisfies |α| ≡ |fixed points| (mod p), and applied to conjugation this forces the center of a nontrivial finite p-group to be nontrivial, with p dividing |Z(G)|. Zero axioms, zero sorries.",
     "implications": "Nontriviality of the center is the inductive lever of p-group theory: quotienting by Z(G) repeatedly shows every finite p-group is nilpotent and possesses a normal subgroup of each order dividing |G|. The underlying fixed-point congruence also yields Cauchy's theorem (a prime dividing |G| produces an element of that order) and, via actions on coset spaces, the three Sylow theorems that govern the local structure of every finite group. The result is therefore a hinge between elementary counting (Lagrange) and the deep classification machinery of finite groups.",

--- a/src/data/proofs/lagrange-theorem-oq-08/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-08/meta.json
@@ -99,6 +99,36 @@
       "summary": "card_perm_fin_three computes |S₃| = 3! = 6 (Nat.card_perm), and two examples extract a 3-cycle (order 3, by Cauchy) and a transposition (order 2, by the involution corollary) from it."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "McKay, J.H."
+      ],
+      "title": "Another proof of Cauchy's group theorem",
+      "year": "1959",
+      "venue": "American Mathematical Monthly 66 (2), p. 119",
+      "note": "The short orbit-counting proof of Cauchy's theorem."
+    },
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Standard reference for the Sylow theorems, groups of order pq, the class equation, and A₄ as a counterexample to Lagrange's converse."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "note": "Detailed development of Sylow theory, p-group structure, and small-order classification."
+    }
+  ],
   "conclusion": {
     "summary": "Restated Cauchy's theorem and assembled the sharp prime-divisor converse to Lagrange: a prime p divides |G| iff G has an element of order p iff G has a cyclic subgroup of order p iff p divides exp(G). This yields the equality of prime-factor sets primeFactors(|G|) = primeFactors(exp(G)), and specializes at p = 2 to 'even order ⟺ contains an involution', witnessed concretely in S₃. 179 lines, 9 theorems, 0 sorries, 0 axioms.",
     "implications": "Cauchy is the exact boundary of the converse to Lagrange: for prime divisors it holds unconditionally, while the A₄ counterexample shows the composite case fails. The exponent formulation records that |G| and exp(G) share prime factors, and the involution corollary is the algebraic backbone of results like 'a group of even order has a non-identity element equal to its own inverse'. The prime-order cyclic subgroup produced here is also the first step toward Sylow theory, which extends Cauchy from primes to prime powers.",

--- a/src/data/proofs/lagrange-theorem-oq-09/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-09/meta.json
@@ -89,6 +89,27 @@
       "summary": "center_trivial_of_nonabelian: a nonabelian group of order pq has |Z(G)| = 1. center_eq_bot_or_top: the dichotomy as a subgroup statement Z(G) = ⊥ ∨ Z(G) = ⊤."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Standard reference for the Sylow theorems, groups of order pq, the class equation, and A₄ as a counterexample to Lagrange's converse."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "note": "Detailed development of Sylow theory, p-group structure, and small-order classification."
+    }
+  ],
   "conclusion": {
     "summary": "Proved that the center of a finite group of order pq (p ≠ q prime) has order exactly 1 or pq — the intermediate divisors p and q are impossible — together with the subgroup-level restatement Z(G) = ⊥ ∨ Z(G) = ⊤ and the corollary that a nonabelian group of order pq has trivial center. 160 lines, 6 theorems, 0 sorries, 0 axioms.",
     "implications": "The center is the sharpest single invariant separating the two isomorphism types of order-pq groups: abelian ⟺ Z(G) = G, nonabelian ⟺ Z(G) = 1, with no middle ground. This is the structural starting point for the semidirect-product description of the nonabelian case and complements the sibling Sylow classification, which counts Sylow subgroups but never inspects the center.",


### PR DESCRIPTION
Adds a top-level `references` array to 9 open-question descendants of **lagrange-theorem** that previously had none.

## Coverage
The converse theory of Lagrange's theorem — the Sylow theorems, classification of groups of order pq (dihedral non-cyclic witnesses, MulEquiv isomorphism uniqueness, center dichotomy), A₄ having no subgroup of order 6 (the canonical counterexample), Cauchy's theorem for prime divisors, Hall's theorem for finite solvable groups, and the class-equation / nontrivial-center structure of p-groups.

## Method
Cited to the standard group-theory texts Dummit–Foote and Rotman, Isaacs (*Finite Group Theory*) for Hall subgroups, and the primary sources Sylow (1872), Hall (1928), and McKay's short proof of Cauchy's theorem (1959). 2–3 references per entry, matched to each `description`.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.