### PR TITLE
Enrich Feuerbach / triangle-geometry OQ-children cluster: add references (19 entries)

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -102,15 +102,6 @@
       "mathContext": "triangle_345_OH_sq rewrites the parent's circumcenter (3/2,2) and orthocenter (0,0) then norm_num; triangle_345_euler_metric substitutes R = 5/2 and sides 5,4,3."
     }
   ],
-  "conclusion": {
-    "summary": "Supplies the metric capstone of the orthocenter sub-line: OH² = 9R² − (a²+b²+c²), together with Euler's inequality precursor a²+b²+c² ≤ 9R², the metric Euler-line ratio OG : GH : OH = 1 : 2 : 3, the centroid identity OG² = R² − (a²+b²+c²)/9, and a 3-4-5 worked example. 8 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
-    "implications": "**Quantitative completion**: the orthocenter is now characterized metrically (its exact distance to the circumcenter) and not only qualitatively (concurrency, reflections), and the development can now state inequalities — a²+b²+c² ≤ 9R² — that the earlier entries could not reach.\n\n**Euler line as metric**: the collinearity recorded by the grandparent is upgraded to the exact 1:2:3 distance ratio among O, G, H, the standard metric statement of the Euler line.",
-    "openQuestions": [
-      "Prove Euler's theorem OI² = R² − 2Rr (distance between circumcenter and incenter) and deduce Euler's inequality R ≥ 2r — the direct path to the Feuerbach tangency the umbrella theorem targets.",
-      "Sharpen a²+b²+c² ≤ 9R² to the equality case, showing OH = 0 (and hence equality) holds exactly for the equilateral triangle.",
-      "Reformulate OH² = 9R² − (a²+b²+c²) and the metric Euler line in Mathlib's EuclideanGeometry API (dist, EuclideanGeometry.orthocenter, circumradius) for a possible upstream contribution."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01",
@@ -128,9 +119,50 @@
       "description": "upgrades the qualitative Euler line (G = (2O+H)/3) recorded in FeuerbachsTheoremDefs.lean to the exact metric ratio OG : GH : OH = 1 : 2 : 3"
     }
   ],
+  "conclusion": {
+    "summary": "Supplies the metric capstone of the orthocenter sub-line: OH² = 9R² − (a²+b²+c²), together with Euler's inequality precursor a²+b²+c² ≤ 9R², the metric Euler-line ratio OG : GH : OH = 1 : 2 : 3, the centroid identity OG² = R² − (a²+b²+c²)/9, and a 3-4-5 worked example. 8 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "**Quantitative completion**: the orthocenter is now characterized metrically (its exact distance to the circumcenter) and not only qualitatively (concurrency, reflections), and the development can now state inequalities — a²+b²+c² ≤ 9R² — that the earlier entries could not reach.\n\n**Euler line as metric**: the collinearity recorded by the grandparent is upgraded to the exact 1:2:3 distance ratio among O, G, H, the standard metric statement of the Euler line.",
+    "openQuestions": [
+      "Prove Euler's theorem OI² = R² − 2Rr (distance between circumcenter and incenter) and deduce Euler's inequality R ≥ 2r — the direct path to the Feuerbach tangency the umbrella theorem targets.",
+      "Sharpen a²+b²+c² ≤ 9R² to the equality case, showing OH = 0 (and hence equality) holds exactly for the equilateral triangle.",
+      "Reformulate OH² = 9R² − (a²+b²+c²) and the metric Euler line in Mathlib's EuclideanGeometry API (dist, EuclideanGeometry.orthocenter, circumradius) for a possible upstream contribution."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "Solutio facilis problematum quorundam geometricorum difficillimorum",
+      "year": "1765",
+      "venue": "Novi Commentarii Academiae Scientiarum Petropolitanae 11, 103–123",
+      "note": "The Euler line and the distance formula OI² = R² − 2Rr."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01",
     "lineCount": 229,
     "axiomCount": 0,
@@ -142,6 +174,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "orthocenter_circumcenter_dist_classical",
@@ -173,6 +206,5 @@
       "description": "Metric Euler line (2:3 leg): 4·OH² = 9·GH², so OG : GH : OH = 1 : 2 : 3.",
       "leanType": "∀ T : Triangle, 4 * dist2_sq T.circumcenter T.orthocenter = 9 * dist2_sq T.centroid T.orthocenter"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -120,14 +120,6 @@
       "mathContext": "altitude_A_perp_BC collapses to equidistB − equidistC; circumcenter_midpoint_sum_sq is linarith over the three midpoint identities; the 3-4-5 theorems rewrite triangle_345_circumcenter then norm_num."
     }
   ],
-  "conclusion": {
-    "summary": "Supplies the segment relation AH = 2·OM_a of the orthocenter sub-line: the exact affine vector identity A − H = 2(O − M_a) (circle-free), the squared form AH² = 4·OM_a², the circumcenter–midpoint distance 4·OM_a² = 4R² − a² (OM_a² = R² − (a/2)²), an independent re-derivation of AH² = 4R² − a², the true-distance AH = 2·OM_a, the altitude perpendicularity (A−H)·(C−B) = 0, the sum 4(OM_a²+OM_b²+OM_c²) = 12R² − (a²+b²+c²), and a 3-4-5 worked example. 20 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
-    "implications": "**Structural source of AH² = 4R² − a²**: the parent measured AH directly; here the factor of 2 is exhibited as the literal coefficient of an affine identity A − H = 2(O − M_a), separating the part true for any triangle (the parallel segments) from the part that uses the circumscribed circle (OM_a² = R² − (a/2)²).\n\n**Toward the angle form and the medial homothety**: OM_a = R·cos A makes AH = 2·OM_a the same statement as AH = 2R·cos A; and the vector identity is exactly the homothety (centroid, ratio −2) sending the medial triangle's circumcenter picture to the orthocenter, the standard bridge to the Euler line and the nine-point circle of the Feuerbach umbrella.",
-    "openQuestions": [
-      "Promote the affine identity A − H = 2(O − M_a) to a clean statement of the homothety h(G, −2) carrying each side midpoint M_a to the opposite vertex A and the circumcenter O to the orthocenter H, deriving the Euler-line collinearity O, G, H with HG = 2·GO as a corollary.",
-      "Combine OM_a = R·cos A with the obtuse/acute dichotomy to determine the sign of cos A geometrically and hence whether the foot of the perpendicular from O lands inside segment BC, locating the orthocenter inside or outside the triangle."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
@@ -150,9 +142,49 @@
       "description": "adds the vertex–orthocenter / circumcenter–midpoint segment relation AH = 2·OM_a, a quantity the nine-point-circle and Euler-line development in FeuerbachsTheoremDefs.lean never measures"
     }
   ],
+  "conclusion": {
+    "summary": "Supplies the segment relation AH = 2·OM_a of the orthocenter sub-line: the exact affine vector identity A − H = 2(O − M_a) (circle-free), the squared form AH² = 4·OM_a², the circumcenter–midpoint distance 4·OM_a² = 4R² − a² (OM_a² = R² − (a/2)²), an independent re-derivation of AH² = 4R² − a², the true-distance AH = 2·OM_a, the altitude perpendicularity (A−H)·(C−B) = 0, the sum 4(OM_a²+OM_b²+OM_c²) = 12R² − (a²+b²+c²), and a 3-4-5 worked example. 20 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "**Structural source of AH² = 4R² − a²**: the parent measured AH directly; here the factor of 2 is exhibited as the literal coefficient of an affine identity A − H = 2(O − M_a), separating the part true for any triangle (the parallel segments) from the part that uses the circumscribed circle (OM_a² = R² − (a/2)²).\n\n**Toward the angle form and the medial homothety**: OM_a = R·cos A makes AH = 2·OM_a the same statement as AH = 2R·cos A; and the vector identity is exactly the homothety (centroid, ratio −2) sending the medial triangle's circumcenter picture to the orthocenter, the standard bridge to the Euler line and the nine-point circle of the Feuerbach umbrella.",
+    "openQuestions": [
+      "Promote the affine identity A − H = 2(O − M_a) to a clean statement of the homothety h(G, −2) carrying each side midpoint M_a to the opposite vertex A and the circumcenter O to the orthocenter H, deriving the Euler-line collinearity O, G, H with HG = 2·GO as a corollary.",
+      "Combine OM_a = R·cos A with the obtuse/acute dichotomy to determine the sign of cos A geometrically and hence whether the foot of the perpendicular from O lands inside segment BC, locating the orthocenter inside or outside the triangle."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01",
     "lineCount": 347,
     "axiomCount": 0,
@@ -164,6 +196,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "vertexA_orthocenter_vec",
@@ -201,6 +234,5 @@
       "description": "4·(OM_a² + OM_b² + OM_c²) = 12R² − (a² + b² + c²), hence OM_a² + OM_b² + OM_c² = ¼(AH² + BH² + CH²).",
       "leanType": "∀ T : Triangle, 4 * (dist2_sq T.circumcenter T.midpoint_a + dist2_sq T.circumcenter T.midpoint_b + dist2_sq T.circumcenter T.midpoint_c) = 12 * dist2_sq T.circumcenter T.A - (dist2_sq T.B T.C + dist2_sq T.C T.A + dist2_sq T.A T.B)"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -100,15 +100,6 @@
       "mathContext": "orthocenter_vertex_le_diameter_sq uses the classical identity and sq_nonneg; triangle_345_AH_sq / triangle_345_vertex_A_metric / triangle_345_vertex_sum rewrite the parent's orthocenter (0,0) and side/circumradius values then norm_num."
     }
   ],
-  "conclusion": {
-    "summary": "Supplies the orthocenter–vertex distances of the orthocenter sub-line: AH² = 4R² − a², BH² = 4R² − b², CH² = 4R² − c², their sum AH² + BH² + CH² = 12R² − (a²+b²+c²), the link AH² + BH² + CH² = OH² + 3R² to Euler's metric identity, the diameter bound AH² ≤ 4R², and a 3-4-5 worked example. 13 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
-    "implications": "**Metric completion**: together with the sibling entry's OH² = 9R² − (a²+b²+c²), the orthocenter is now fully characterized metrically — its distance to the circumcenter and to each vertex — and not only qualitatively (concurrency, reflections).\n\n**Bridge to angle form**: AH² = 4R² − a² is the squared, coordinate-free statement of AH = 2R·cos A, the natural entry point to a trigonometric treatment of the orthocenter and the pedal triangle.",
-    "openQuestions": [
-      "Prove the angle form AH = 2R·cos A directly, recovering the sign of cos A (and hence whether H lies inside or outside the triangle) from the obtuse/acute dichotomy.",
-      "Use AH² = 4R² − a² together with the reflection entry to compute the side lengths of the orthic (pedal) triangle, a²·(…)-type identities feeding the nine-point circle's tangency in the Feuerbach umbrella.",
-      "Reformulate AH² = 4R² − a² and the vertex-distance sum in Mathlib's EuclideanGeometry API (dist, EuclideanGeometry.orthocenter, circumradius) for a possible upstream contribution."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
@@ -131,9 +122,50 @@
       "description": "adds the vertex distances of the orthocenter, a metric quantity the nine-point-circle development in FeuerbachsTheoremDefs.lean never measures"
     }
   ],
+  "conclusion": {
+    "summary": "Supplies the orthocenter–vertex distances of the orthocenter sub-line: AH² = 4R² − a², BH² = 4R² − b², CH² = 4R² − c², their sum AH² + BH² + CH² = 12R² − (a²+b²+c²), the link AH² + BH² + CH² = OH² + 3R² to Euler's metric identity, the diameter bound AH² ≤ 4R², and a 3-4-5 worked example. 13 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "**Metric completion**: together with the sibling entry's OH² = 9R² − (a²+b²+c²), the orthocenter is now fully characterized metrically — its distance to the circumcenter and to each vertex — and not only qualitatively (concurrency, reflections).\n\n**Bridge to angle form**: AH² = 4R² − a² is the squared, coordinate-free statement of AH = 2R·cos A, the natural entry point to a trigonometric treatment of the orthocenter and the pedal triangle.",
+    "openQuestions": [
+      "Prove the angle form AH = 2R·cos A directly, recovering the sign of cos A (and hence whether H lies inside or outside the triangle) from the obtuse/acute dichotomy.",
+      "Use AH² = 4R² − a² together with the reflection entry to compute the side lengths of the orthic (pedal) triangle, a²·(…)-type identities feeding the nine-point circle's tangency in the Feuerbach umbrella.",
+      "Reformulate AH² = 4R² − a² and the vertex-distance sum in Mathlib's EuclideanGeometry API (dist, EuclideanGeometry.orthocenter, circumradius) for a possible upstream contribution."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02",
     "lineCount": 272,
     "axiomCount": 0,
@@ -145,6 +177,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "orthocenter_vertex_A_dist_classical",
@@ -176,6 +209,5 @@
       "description": "Diameter bound: AH² ≤ 4R², a vertex is never farther from the orthocenter than the diameter of the circumcircle (immediate from AH² = 4R² − a² and a² ≥ 0).",
       "leanType": "∀ T : Triangle, dist2_sq T.A T.orthocenter ≤ 4 * T.circumradius ^ 2"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01/meta.json
@@ -127,15 +127,6 @@
       "mathContext": "triangle_345_reflectOrthoMidBC: rw [triangle_345_orthocenter] then norm_num, using the parent's orthocenter computation."
     }
   ],
-  "conclusion": {
-    "summary": "Establishes the classical orthocentric-configuration fact missing from the nine-point-circle development: reflecting the orthocenter across any side lands on the circumcircle, so the three reflections are concyclic with the vertices, and reflecting across any side midpoint gives the antipode of the opposite vertex. 10 theorems and 6 lemmas, 5 definitions, 0 axioms, 0 sorries.",
-    "implications": "**Foundational grounding**: the coordinate orthocenter is now shown to obey the reflection property that characterizes it within the circumcircle, complementing the altitude-concurrency characterization of the sibling entry.\n\n**Reusable geometry**: reflectOverLine (mirror across an arbitrary line) and reflectOverLine_orthocenter_dist_sq (a denominator-clearing distance lemma with an explicit ideal-membership certificate) are reusable tools for downstream R^2 Euclidean-geometry proofs.",
-    "openQuestions": [
-      "Show the reflections of the orthocenter across the three sides are precisely the antipodes-after-rotation of the vertices, i.e. identify each reflected orthocenter with a specific point of the circumcircle rather than only proving it lies on the circle.",
-      "Prove that the circle through the three reflected orthocenters coincides with the circumcircle as sets (not just that each reflection lies on it), and deduce the reflection of the circumcircle over a side passes through H.",
-      "Reformulate the reflection-onto-circumcircle property in Mathlib's EuclideanGeometry API (EuclideanGeometry.reflection and Sphere) to enable an upstream contribution."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-01-oq-01",
@@ -153,9 +144,50 @@
       "description": "uses the orthocenter defined by the Euler formula H = A + B + C - 2O and the circumcenter coordinate API from FeuerbachsTheoremDefs.lean"
     }
   ],
+  "conclusion": {
+    "summary": "Establishes the classical orthocentric-configuration fact missing from the nine-point-circle development: reflecting the orthocenter across any side lands on the circumcircle, so the three reflections are concyclic with the vertices, and reflecting across any side midpoint gives the antipode of the opposite vertex. 10 theorems and 6 lemmas, 5 definitions, 0 axioms, 0 sorries.",
+    "implications": "**Foundational grounding**: the coordinate orthocenter is now shown to obey the reflection property that characterizes it within the circumcircle, complementing the altitude-concurrency characterization of the sibling entry.\n\n**Reusable geometry**: reflectOverLine (mirror across an arbitrary line) and reflectOverLine_orthocenter_dist_sq (a denominator-clearing distance lemma with an explicit ideal-membership certificate) are reusable tools for downstream R^2 Euclidean-geometry proofs.",
+    "openQuestions": [
+      "Show the reflections of the orthocenter across the three sides are precisely the antipodes-after-rotation of the vertices, i.e. identify each reflected orthocenter with a specific point of the circumcircle rather than only proving it lies on the circle.",
+      "Prove that the circle through the three reflected orthocenters coincides with the circumcircle as sets (not just that each reflection lies on it), and deduce the reflection of the circumcircle over a side passes through H.",
+      "Reformulate the reflection-onto-circumcircle property in Mathlib's EuclideanGeometry API (EuclideanGeometry.reflection and Sphere) to enable an upstream contribution."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachsTheoremDefsOQ01OQ01OQ01",
     "lineCount": 296,
     "axiomCount": 0,
@@ -167,6 +199,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "orthocenter_reflections_concyclic",
@@ -192,6 +225,5 @@
       "description": "Generic: the reflection of H = V + P + Q - 2O over line PQ is at distance |V - O| from O when O is equidistant from V, P, Q.",
       "leanType": "dist2_sq (ox,oy) (reflectOverLine (hx,hy) (px,py) (qx,qy)) = dist2_sq (ox,oy) (vx,vy)"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-02/meta.json
@@ -120,15 +120,6 @@
       "mathContext": "An acute configuration keeps all four points distinct, unlike the degenerate 3-4-5 right triangle where H coincides with the right-angle vertex."
     }
   ],
-  "conclusion": {
-    "summary": "Establishes the orthocentric system that the concurrency, metric, and reflection strands of the orthocenter sub-line left implicit: the four-point set {A, B, C, H} is symmetric, each point being the orthocenter of the triangle on the other three. The deep-looking symmetry reduces entirely to the three perpendicular-bisector relations of the circumcenter — one linear_combination per perpendicularity — and a 2×2 Cramer argument upgrades the memberships to a uniqueness statement identifying THE orthocenter. As a structural consequence the six connector midpoints of the system share one nine-point circle, and an acute worked example exhibits a genuine, non-collapsed configuration.",
-    "significance": "Completes the conceptual picture of the orthocenter begun by the concurrency entry: beyond existing and being measured, the orthocenter is the fourth point of a symmetric four-point system, which is the natural home of the nine-point circle and the reflection facts proved earlier in the strand.",
-    "futureDirections": [
-      "Identify the common nine-point centre N as the circumcenter of the medial-type configuration shared by all four triangles of the system, and prove the four circumcircles are congruent (all radius R).",
-      "Show the de Longchamps point (reflection of H over O) is the orthocenter of the anticomplementary triangle, extending the system outward.",
-      "Formalize that the four triangles of an orthocentric system have a common nine-point circle as an equality of circles, not just a shared six-point incidence."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-01-oq-01",
@@ -146,9 +137,50 @@
       "description": "uses the grandparent's coordinate orthocenter, circumcenter and nine-point circle theorems to state and prove the orthocentric system"
     }
   ],
+  "conclusion": {
+    "summary": "Establishes the orthocentric system that the concurrency, metric, and reflection strands of the orthocenter sub-line left implicit: the four-point set {A, B, C, H} is symmetric, each point being the orthocenter of the triangle on the other three. The deep-looking symmetry reduces entirely to the three perpendicular-bisector relations of the circumcenter — one linear_combination per perpendicularity — and a 2×2 Cramer argument upgrades the memberships to a uniqueness statement identifying THE orthocenter. As a structural consequence the six connector midpoints of the system share one nine-point circle, and an acute worked example exhibits a genuine, non-collapsed configuration.",
+    "significance": "Completes the conceptual picture of the orthocenter begun by the concurrency entry: beyond existing and being measured, the orthocenter is the fourth point of a symmetric four-point system, which is the natural home of the nine-point circle and the reflection facts proved earlier in the strand.",
+    "futureDirections": [
+      "Identify the common nine-point centre N as the circumcenter of the medial-type configuration shared by all four triangles of the system, and prove the four circumcircles are congruent (all radius R).",
+      "Show the de Longchamps point (reflection of H over O) is the orthocenter of the anticomplementary triangle, extending the system outward.",
+      "Formalize that the four triangles of an orthocentric system have a common nine-point circle as an equality of circles, not just a shared six-point incidence."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachsTheoremDefsOQ01OQ01OQ02",
     "lineCount": 344,
     "axiomCount": 0,
@@ -156,8 +188,11 @@
     "definitionCount": 2,
     "path": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ02.lean",
     "sorries": 0,
-    "additionalFiles": ["Proofs/FeuerbachsTheoremDefs.lean"]
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
   },
+  "sorries": [],
   "mainTheorems": [
     {
       "name": "orthocentric_system",
@@ -183,6 +218,5 @@
       "description": "The midpoints of all six connectors of {A, B, C, H} — three sides and three cevian segments — lie on one nine-point circle of centre N and radius R/2.",
       "leanType": "∀ T : Triangle, dist(N, M_a) = R/2 ∧ … ∧ dist(N, M_CH) = R/2"
     }
-  ],
-  "sorries": []
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01/meta.json
@@ -108,15 +108,6 @@
       "mathContext": "triangle_345_orthocenter_eq_A: rw [triangle_345_orthocenter]; rfl, using the parent's computation that the orthocenter is (0,0) = A."
     }
   ],
-  "conclusion": {
-    "summary": "Supplies the defining characterization of the orthocenter underlying the nine-point circle: it lies on all three altitudes (concurrency), is collinear with each vertex and its altitude foot, and is the unique common point of any two altitudes. 9 public theorems and 5 supporting lemmas, 0 axioms, 0 sorries.",
-    "implications": "**Foundational grounding**: the parent's formula-defined orthocenter is now verified to be the genuine concurrency point of the altitudes, completing the altitude-feet characterization of the sibling entry.\n\n**Reusable geometry**: cross_eq_zero_of_perp_perp (perpendicular-to-common-vector implies parallel) and the Cramer-rule uniqueness pattern are standard tools for downstream R^2 Euclidean-geometry proofs.",
-    "openQuestions": [
-      "Show the reflection of the orthocenter across each side lies on the circumcircle, a classical consequence of the altitude-foot and concurrency configuration.",
-      "Prove the Euler line collinearity O, G, H with the 2:1 ratio directly from the concurrency characterization rather than from the coordinate formula.",
-      "Reformulate concurrency of the altitudes in Mathlib's EuclideanGeometry API (orthocenter / affine subspaces) to enable an upstream contribution."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-01",
@@ -134,9 +125,50 @@
       "description": "the full Feuerbach theorem whose nine-point circle passes through the altitude feet on these altitudes"
     }
   ],
+  "conclusion": {
+    "summary": "Supplies the defining characterization of the orthocenter underlying the nine-point circle: it lies on all three altitudes (concurrency), is collinear with each vertex and its altitude foot, and is the unique common point of any two altitudes. 9 public theorems and 5 supporting lemmas, 0 axioms, 0 sorries.",
+    "implications": "**Foundational grounding**: the parent's formula-defined orthocenter is now verified to be the genuine concurrency point of the altitudes, completing the altitude-feet characterization of the sibling entry.\n\n**Reusable geometry**: cross_eq_zero_of_perp_perp (perpendicular-to-common-vector implies parallel) and the Cramer-rule uniqueness pattern are standard tools for downstream R^2 Euclidean-geometry proofs.",
+    "openQuestions": [
+      "Show the reflection of the orthocenter across each side lies on the circumcircle, a classical consequence of the altitude-foot and concurrency configuration.",
+      "Prove the Euler line collinearity O, G, H with the 2:1 ratio directly from the concurrency characterization rather than from the coordinate formula.",
+      "Reformulate concurrency of the altitudes in Mathlib's EuclideanGeometry API (orthocenter / affine subspaces) to enable an upstream contribution."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachsTheoremDefsOQ01OQ01",
     "lineCount": 282,
     "axiomCount": 0,
@@ -148,6 +180,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "altitudes_concurrent",
@@ -167,6 +200,5 @@
       "description": "The orthocenter is collinear with vertex A and the altitude foot from A.",
       "leanType": "(foot_a - A) × (H - A) = 0"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-02/meta.json
@@ -97,15 +97,6 @@
       "mathContext": "triangle_345_altitude_a_sq: |A Hₐ|² = 144/25 (h_a = 12/5) by norm_num. triangle_345_altitude_law: (144/25)·25 = 144 = (2·6)², the law instantiated."
     }
   ],
-  "conclusion": {
-    "summary": "Supplies the metric content of the altitude feet: a Lagrange-identity altitude-length law for each of the three altitudes, its restatement through the area function, and a base-independence capstone proving (2·Area)² is the common value of every (altitude length)²·(base length)² product. 10 theorems, 0 axioms, 0 sorries.",
-    "implications": "**Completes the foot API**: alongside the OQ01 collinearity/perpendicularity/Pythagoras lemmas, the altitude lengths are now available, so downstream proofs can use Area = ½·base·height directly.\n\n**Base-independence of area**: the file gives a fully verified coordinate proof that the three base-times-height computations of the triangle's area agree, grounding the area function used throughout the Feuerbach development.",
-    "openQuestions": [
-      "Derive the inradius relation Area = r·s and the circumradius relation Area = abc/(4R) from the altitude lengths, linking this file to the incenter/circumcenter API.",
-      "Express the altitude lengths via the side lengths (h_a = 2·Area/a) once Real.sqrt side lengths are related to dist2_sq, bridging to the metric side_a/b/c definitions.",
-      "Lift the altitude-length law to Mathlib's EuclideanGeometry.orthogonalProjection and the area form to MeasureTheory volume for a possible upstream contribution."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-01",
@@ -123,9 +114,50 @@
       "description": "the full Feuerbach theorem whose nine-point circle the altitude feet lie on"
     }
   ],
+  "conclusion": {
+    "summary": "Supplies the metric content of the altitude feet: a Lagrange-identity altitude-length law for each of the three altitudes, its restatement through the area function, and a base-independence capstone proving (2·Area)² is the common value of every (altitude length)²·(base length)² product. 10 theorems, 0 axioms, 0 sorries.",
+    "implications": "**Completes the foot API**: alongside the OQ01 collinearity/perpendicularity/Pythagoras lemmas, the altitude lengths are now available, so downstream proofs can use Area = ½·base·height directly.\n\n**Base-independence of area**: the file gives a fully verified coordinate proof that the three base-times-height computations of the triangle's area agree, grounding the area function used throughout the Feuerbach development.",
+    "openQuestions": [
+      "Derive the inradius relation Area = r·s and the circumradius relation Area = abc/(4R) from the altitude lengths, linking this file to the incenter/circumcenter API.",
+      "Express the altitude lengths via the side lengths (h_a = 2·Area/a) once Real.sqrt side lengths are related to dist2_sq, bridging to the metric side_a/b/c definitions.",
+      "Lift the altitude-length law to Mathlib's EuclideanGeometry.orthogonalProjection and the area form to MeasureTheory volume for a possible upstream contribution."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachsTheoremDefsOQ01OQ02",
     "lineCount": 171,
     "axiomCount": 0,
@@ -137,6 +169,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "altitude_length_base_independent",
@@ -156,6 +189,5 @@
       "description": "The squared signed area Δ² equals (2·Area)², bridging the area function to the polynomial identity.",
       "leanType": "(2 · Area)² = ((B−A)×(C−A))²"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01/meta.json
@@ -106,15 +106,6 @@
       "mathContext": "altitude_feet_characterization is the conjunction of the six core lemmas; triangle_345_foot_a computes Hₐ = (48/25, 36/25) for A=(0,0), B=(3,0), C=(0,4) by norm_num."
     }
   ],
-  "conclusion": {
-    "summary": "Supplies the defining geometric lemmas for the three altitude feet of the nine-point circle: collinearity with the opposite side, perpendicularity of each altitude, a Pythagorean split at each foot, and uniqueness of the foot as the perpendicular's base point. 12 theorems, 0 axioms, 0 sorries.",
-    "implications": "**Foundational grounding**: the parent's on-circle membership theorems now rest on a verified characterization of the feet as genuine orthogonal projections, not just on an opaque coordinate formula.\n\n**Reusable foot API**: collinearity, perpendicularity, and the Pythagorean split are the standard facts downstream Euclidean-geometry proofs need about altitude feet, available here for import.",
-    "openQuestions": [
-      "Prove the orthocenter is the common intersection of the three altitude lines (each altitude passes through its foot and is perpendicular to its side), using the perpendicularity lemmas of this file.",
-      "Show the reflection of the orthocenter across each side lies on the circumcircle, a classical consequence of the altitude-foot configuration.",
-      "Reformulate the altitude-foot characterization in Mathlib's EuclideanGeometry.orthogonalProjection API to enable an upstream contribution."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs",
@@ -132,9 +123,50 @@
       "description": "the full Feuerbach theorem whose nine-point circle the altitude feet lie on"
     }
   ],
+  "conclusion": {
+    "summary": "Supplies the defining geometric lemmas for the three altitude feet of the nine-point circle: collinearity with the opposite side, perpendicularity of each altitude, a Pythagorean split at each foot, and uniqueness of the foot as the perpendicular's base point. 12 theorems, 0 axioms, 0 sorries.",
+    "implications": "**Foundational grounding**: the parent's on-circle membership theorems now rest on a verified characterization of the feet as genuine orthogonal projections, not just on an opaque coordinate formula.\n\n**Reusable foot API**: collinearity, perpendicularity, and the Pythagorean split are the standard facts downstream Euclidean-geometry proofs need about altitude feet, available here for import.",
+    "openQuestions": [
+      "Prove the orthocenter is the common intersection of the three altitude lines (each altitude passes through its foot and is perpendicular to its side), using the perpendicularity lemmas of this file.",
+      "Show the reflection of the orthocenter across each side lies on the circumcircle, a classical consequence of the altitude-foot configuration.",
+      "Reformulate the altitude-foot characterization in Mathlib's EuclideanGeometry.orthogonalProjection API to enable an upstream contribution."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachsTheoremDefsOQ01",
     "lineCount": 204,
     "axiomCount": 0,
@@ -146,6 +178,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "altitude_feet_characterization",
@@ -165,6 +198,5 @@
       "description": "Pythagorean split at the foot from A.",
       "leanType": "dist2_sq A foot_a + dist2_sq foot_a B = dist2_sq A B"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -110,14 +110,6 @@
       "mathContext": "Instantiates the general perpendicularity at the integer-sided 3-4-5 triangle, where all side lengths and centers are rational so the dot products evaluate by norm_num."
     }
   ],
-  "conclusion": {
-    "summary": "Proves directly that the incenter I is the orthocenter of the excentral triangle IₐI_bI_c: the three lines joining I to the excenters are the altitudes of the excentral triangle, perpendicular to the opposite sides (⟨Iₐ−I, I_c−I_b⟩ = ⟨I_b−I, I_c−Iₐ⟩ = ⟨I_c−I, I_b−Iₐ⟩ = 0), so they concur at I and {I, Iₐ, I_b, I_c} is an orthocentric system. Answers the first open question of the circumradius-2R entry. 8 theorems (plus 13 supporting lemmas), 0 axioms, 0 sorries.",
-    "implications": "**The dot-product foundation of the tritangent picture**: this perpendicularity fact is the geometric reason behind both the affine centroid law I+Iₐ+I_b+I_c = 4O and the metric circumradius-2R law O' = 2O−I; the sibling entries cite 'I is the excentral orthocenter' to call O the nine-point center, and this entry finally proves it.\n\n**Orthocentric system as gallery infrastructure**: the three perpendicularity identities (and their bundle) are reusable across the triangle-geometry strand wherever the orthocentric structure of the tritangent centers is needed — for instance to identify the excentral nine-point circle with the circumcircle of ABC.\n\n**A bisector-only proof technique**: the clearing-to-|u|²−|v|² mechanism shows that internal/external-bisector perpendicularity is forced by the side-length weights alone, a method that transfers to other angle-bisector configurations in the same coordinate framework.",
-    "openQuestions": [
-      "Show that each excenter is the orthocenter of the triangle formed by the incenter and the other two excenters (e.g. ⟨I−Iₐ, I_b−I_c⟩ = 0 read from Iₐ's vertex), making the full orthocentric-system symmetry of {I, Iₐ, I_b, I_c} explicit rather than implicit in the three shared perpendicularities.",
-      "Combine this orthocenter fact with the circumradius-2R entry to prove the excentral nine-point circle is the circumcircle of ABC as a circle-tangency statement, closing the loop toward the Feuerbach tangency of the nine-point circle to the incircle and excircles."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01",
@@ -145,6 +137,42 @@
       "description": "the full Feuerbach theorem, whose nine-point circle is tangent to the incircle and all three excircles whose centers form the excentral triangle studied here"
     }
   ],
+  "conclusion": {
+    "summary": "Proves directly that the incenter I is the orthocenter of the excentral triangle IₐI_bI_c: the three lines joining I to the excenters are the altitudes of the excentral triangle, perpendicular to the opposite sides (⟨Iₐ−I, I_c−I_b⟩ = ⟨I_b−I, I_c−Iₐ⟩ = ⟨I_c−I, I_b−Iₐ⟩ = 0), so they concur at I and {I, Iₐ, I_b, I_c} is an orthocentric system. Answers the first open question of the circumradius-2R entry. 8 theorems (plus 13 supporting lemmas), 0 axioms, 0 sorries.",
+    "implications": "**The dot-product foundation of the tritangent picture**: this perpendicularity fact is the geometric reason behind both the affine centroid law I+Iₐ+I_b+I_c = 4O and the metric circumradius-2R law O' = 2O−I; the sibling entries cite 'I is the excentral orthocenter' to call O the nine-point center, and this entry finally proves it.\n\n**Orthocentric system as gallery infrastructure**: the three perpendicularity identities (and their bundle) are reusable across the triangle-geometry strand wherever the orthocentric structure of the tritangent centers is needed — for instance to identify the excentral nine-point circle with the circumcircle of ABC.\n\n**A bisector-only proof technique**: the clearing-to-|u|²−|v|² mechanism shows that internal/external-bisector perpendicularity is forced by the side-length weights alone, a method that transfers to other angle-bisector configurations in the same coordinate framework.",
+    "openQuestions": [
+      "Show that each excenter is the orthocenter of the triangle formed by the incenter and the other two excenters (e.g. ⟨I−Iₐ, I_b−I_c⟩ = 0 read from Iₐ's vertex), making the full orthocentric-system symmetry of {I, Iₐ, I_b, I_c} explicit rather than implicit in the three shared perpendicularities.",
+      "Combine this orthocenter fact with the circumradius-2R entry to prove the excentral nine-point circle is the circumcircle of ABC as a circle-tangency statement, closing the loop toward the Feuerbach tangency of the nine-point circle to the incircle and excircles."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Proofs.FeuerbachsTheoremDefs"
@@ -163,6 +191,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "incenter_is_excentral_orthocenter",
@@ -200,6 +229,5 @@
       "description": "The A-excenter of the 3-4-5 right triangle is (6, 6).",
       "leanType": "triangle_345.excenter_a = (6, 6)"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -119,15 +119,6 @@
       "mathContext": "dist = √(dist²) = √(4R²) = 2R since R ≥ 0 (Real.sqrt_sq); the midpoint relation is immediate from O' = 2O − I, and the example instantiates at triangle_345 via the general theorem and triangle_345_circumradius."
     }
   ],
-  "conclusion": {
-    "summary": "Proves directly that the excentral triangle IₐI_bI_c has circumradius 2R and circumcenter O' = 2O − I, by showing the single point O' = 2O − I is equidistant (distance 2R, squared distance 4R²) from all three excenters, for an arbitrary non-degenerate triangle. Establishes also that O is the midpoint of I and O' — the nine-point center of the excentral triangle — completing the orthocentric-system picture whose centroid the sibling entry placed at O. Answers the first open question of the centroid (4O) entry. 9 theorems (plus 25 supporting lemmas and 1 definition), 0 axioms, 0 sorries.",
-    "implications": "**The metric half of the tritangent picture**: together with the sibling's affine law I+Iₐ+I_b+I_c = 4O and the square-distance law OI²+OIₐ²+OI_b²+OI_c² = 12R², this completes the analytic description of the orthocentric system {I, Iₐ, I_b, I_c} — its common nine-point circle is the circumcircle of ABC (center O, radius R), and the excentral circumcircle (center O' = 2O − I, radius 2R) is its double.\n\n**A named triangle-center as gallery infrastructure**: Triangle.excentralCircumcenter = 2O − I is supplied as a 0-axiom coordinate definition together with its defining property (equidistant 2R from the excenters), reusable across the triangle-geometry strand.\n\n**The reflection mechanism**: the proof technique — reflecting a known center and verifying equidistance via the weighted-norm identity — generalizes to other circumcircle/incircle reflection problems in the same coordinate framework.",
-    "openQuestions": [
-      "Prove the incenter I is the orthocenter of the excentral triangle IₐI_bI_c directly (each tritangent center is the orthocenter of the other three): show ⟨Iₐ − I, I_b − I_c⟩ = 0 and cyclically, the dot-product fact underlying the orthocentric system and hence both the 4O centroid and the 2R circumradius laws.",
-      "Establish the excentral nine-point radius is R and identify the excentral nine-point center with O as a circle-tangency statement, closing the loop with the Feuerbach tangency of the nine-point circle to the incircle and excircles.",
-      "Compute the side lengths of the excentral triangle (IₐI_b, etc.) in terms of R and the angles, and verify the law of sines IₐI_b = 2·(2R)·sin(∠) consistent with the excentral circumradius 2R proved here."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
@@ -155,6 +146,43 @@
       "description": "the full Feuerbach theorem, whose nine-point circle is tangent to the incircle and all three excircles whose centers form the excentral triangle studied here"
     }
   ],
+  "conclusion": {
+    "summary": "Proves directly that the excentral triangle IₐI_bI_c has circumradius 2R and circumcenter O' = 2O − I, by showing the single point O' = 2O − I is equidistant (distance 2R, squared distance 4R²) from all three excenters, for an arbitrary non-degenerate triangle. Establishes also that O is the midpoint of I and O' — the nine-point center of the excentral triangle — completing the orthocentric-system picture whose centroid the sibling entry placed at O. Answers the first open question of the centroid (4O) entry. 9 theorems (plus 25 supporting lemmas and 1 definition), 0 axioms, 0 sorries.",
+    "implications": "**The metric half of the tritangent picture**: together with the sibling's affine law I+Iₐ+I_b+I_c = 4O and the square-distance law OI²+OIₐ²+OI_b²+OI_c² = 12R², this completes the analytic description of the orthocentric system {I, Iₐ, I_b, I_c} — its common nine-point circle is the circumcircle of ABC (center O, radius R), and the excentral circumcircle (center O' = 2O − I, radius 2R) is its double.\n\n**A named triangle-center as gallery infrastructure**: Triangle.excentralCircumcenter = 2O − I is supplied as a 0-axiom coordinate definition together with its defining property (equidistant 2R from the excenters), reusable across the triangle-geometry strand.\n\n**The reflection mechanism**: the proof technique — reflecting a known center and verifying equidistance via the weighted-norm identity — generalizes to other circumcircle/incircle reflection problems in the same coordinate framework.",
+    "openQuestions": [
+      "Prove the incenter I is the orthocenter of the excentral triangle IₐI_bI_c directly (each tritangent center is the orthocenter of the other three): show ⟨Iₐ − I, I_b − I_c⟩ = 0 and cyclically, the dot-product fact underlying the orthocentric system and hence both the 4O centroid and the 2R circumradius laws.",
+      "Establish the excentral nine-point radius is R and identify the excentral nine-point center with O as a circle-tangency statement, closing the loop with the Feuerbach tangency of the nine-point circle to the incircle and excircles.",
+      "Compute the side lengths of the excentral triangle (IₐI_b, etc.) in terms of R and the angles, and verify the law of sines IₐI_b = 2·(2R)·sin(∠) consistent with the excentral circumradius 2R proved here."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Proofs.FeuerbachsTheoremDefs"
@@ -173,6 +201,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "excentral_circumradius_eq_two_R",
@@ -210,6 +239,5 @@
       "description": "Worked example: for the 3-4-5 right triangle, O' = 2O − I = (2,3) and the squared distance to each excenter is 25 = 4·(5/2)² = 4R².",
       "leanType": "dist2_sq triangle_345.excentralCircumcenter triangle_345.excenter_a = 25 ∧ dist2_sq triangle_345.excentralCircumcenter triangle_345.excenter_b = 25 ∧ dist2_sq triangle_345.excentralCircumcenter triangle_345.excenter_c = 25"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -119,15 +119,6 @@
       "mathContext": "Instantiates the identity at the parent's triangle_345 (A=(0,0), B=(3,0), C=(0,4)); norm_num evaluates the weighted barycentric coordinates with the known side lengths a=5, b=4, c=3."
     }
   ],
-  "conclusion": {
-    "summary": "Proves the affine identity I + Iₐ + I_b + I_c = 4O — the circumcenter is the centroid of the four classical tritangent centers — for an arbitrary non-degenerate triangle, the affine companion of the sibling's metric law OI² + OIₐ² + OI_b² + OI_c² = 12R² and the second open question that entry posed. The proof clears all denominators against the Heron product (shown equal to the squared circumcenter determinant), telescopes the tritangent sum into the circumcenter's barycentric numerator, and cancels. 4 theorems (plus 21 supporting lemmas), 0 axioms, 0 sorries.",
-    "implications": "**The affine half of the tritangent conservation law**: together with the 12R² square-distance sum, this completes Leibniz's parallel-axis decomposition Σ OX² = 4·OG² + Σ GX² for the four tritangent centers — the centroid G is the circumcenter O, so the 12R² constant is exactly the moment of inertia of the four centers about O.\n\n**The excentral triangle's nine-point circle is the circumcircle of ABC**: the identity I+Iₐ+I_b+I_c = 4O is the arithmetic form of the classical fact that the four tritangent centers form an orthocentric system whose common nine-point center is O (and whose excentral circumradius is 2R).\n\n**The circumcenter's barycentric coordinates as gallery infrastructure**: circ_bary_x/y supply the standard unnormalized barycentrics a²(b²+c²−a²) : b²(c²+a²−b²) : c²(a²+b²−c²) of O as 0-axiom coordinate identities, reusable across the triangle-geometry strand.",
-    "openQuestions": [
-      "Prove the excentral circumradius is 2R directly: show the circumradius of the excentral triangle IₐI_bI_c equals twice that of ABC, completing the orthocentric-system picture whose nine-point center this entry locates at O.",
-      "Establish that the incenter I is the orthocenter of the excentral triangle IₐI_bI_c (each tritangent center is the orthocenter of the other three), the structural fact underlying the orthocentric system and hence the 4O centroid identity.",
-      "Generalize the barycentric telescoping: for which vertex-weight schemes does a signed combination of weighted barycentric centers (incenter, excenters, and beyond) again land on a named triangle center, and which centers arise as such averages?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01",
@@ -150,9 +141,49 @@
       "description": "the full Feuerbach theorem, whose nine-point circle is tangent to the incircle and all three excircles whose centers form the orthocentric system studied here"
     }
   ],
+  "conclusion": {
+    "summary": "Proves the affine identity I + Iₐ + I_b + I_c = 4O — the circumcenter is the centroid of the four classical tritangent centers — for an arbitrary non-degenerate triangle, the affine companion of the sibling's metric law OI² + OIₐ² + OI_b² + OI_c² = 12R² and the second open question that entry posed. The proof clears all denominators against the Heron product (shown equal to the squared circumcenter determinant), telescopes the tritangent sum into the circumcenter's barycentric numerator, and cancels. 4 theorems (plus 21 supporting lemmas), 0 axioms, 0 sorries.",
+    "implications": "**The affine half of the tritangent conservation law**: together with the 12R² square-distance sum, this completes Leibniz's parallel-axis decomposition Σ OX² = 4·OG² + Σ GX² for the four tritangent centers — the centroid G is the circumcenter O, so the 12R² constant is exactly the moment of inertia of the four centers about O.\n\n**The excentral triangle's nine-point circle is the circumcircle of ABC**: the identity I+Iₐ+I_b+I_c = 4O is the arithmetic form of the classical fact that the four tritangent centers form an orthocentric system whose common nine-point center is O (and whose excentral circumradius is 2R).\n\n**The circumcenter's barycentric coordinates as gallery infrastructure**: circ_bary_x/y supply the standard unnormalized barycentrics a²(b²+c²−a²) : b²(c²+a²−b²) : c²(a²+b²−c²) of O as 0-axiom coordinate identities, reusable across the triangle-geometry strand.",
+    "openQuestions": [
+      "Prove the excentral circumradius is 2R directly: show the circumradius of the excentral triangle IₐI_bI_c equals twice that of ABC, completing the orthocentric-system picture whose nine-point center this entry locates at O.",
+      "Establish that the incenter I is the orthocenter of the excentral triangle IₐI_bI_c (each tritangent center is the orthocenter of the other three), the structural fact underlying the orthocentric system and hence the 4O centroid identity.",
+      "Generalize the barycentric telescoping: for which vertex-weight schemes does a signed combination of weighted barycentric centers (incenter, excenters, and beyond) again land on a named triangle center, and which centers arise as such averages?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "Kimberling, Clark",
+      "title": "Triangle Centers and Central Triangles",
+      "year": "1998",
+      "venue": "Congressus Numerantium 129, Utilitas Mathematica"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachTritangentCentroid",
     "lineCount": 447,
     "axiomCount": 0,
@@ -164,6 +195,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "circumcenter_eq_tritangent_centroid",
@@ -201,6 +233,5 @@
       "description": "Worked example: for the 3-4-5 right triangle the incenter (1,1) and excenters (6,6), (−3,3), (2,−2) sum to (6,8) = 4·(3/2,2) = 4·O.",
       "leanType": "(triangle_345.incenter.1 + triangle_345.excenter_a.1 + triangle_345.excenter_b.1 + triangle_345.excenter_c.1 = 4 * triangle_345.circumcenter.1) ∧ (triangle_345.incenter.2 + triangle_345.excenter_a.2 + triangle_345.excenter_b.2 + triangle_345.excenter_c.2 = 4 * triangle_345.circumcenter.2)"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01/meta.json
@@ -127,15 +127,6 @@
       "mathContext": "Instantiates the main theorem at the parent's triangle_345 and uses its circumradius 5/2; norm_num evaluates 12·(5/2)² = 75."
     }
   ],
-  "conclusion": {
-    "summary": "Proves the shape-independent conservation law OI² + OIₐ² + OI_b² + OI_c² = 12R² summing Euler's incenter and three excenter formulas over the four tritangent centers, together with the classical exradius identity rₐ + r_b + r_c − r = 4R that drives the collapse, both resting on a from-scratch proof of Heron's identity. Answers the first open question of the excenter entry. 3 theorems (plus 16 supporting lemmas), 0 axioms, 0 sorries.",
-    "implications": "**A conservation law on Euler's pair**: the sibling entries gave OI² = R² − 2Rr and OIₐ² = R² + 2Rrₐ; summing all four centers cancels every shape-dependent term and leaves the pure constant 12R², a fact more rigid than either Euler formula alone.\n\n**The exradius identity made explicit**: rₐ + r_b + r_c − r = 4R is supplied as a standalone theorem, a classical companion of Euler's formula useful wherever exradii and the circumradius interact.\n\n**Heron's identity as gallery infrastructure**: 16·Area² = (a+b+c)(−a+b+c)(a−b+c)(a+b−c) is proved coordinate-free of trigonometry and is reusable for any side-length/area relation in the triangle-geometry strand.",
-    "openQuestions": [
-      "Establish the incenter–excenter distance IIₐ² = 4R·rₐ (so IIₐ = 2√(R rₐ)) and the excenter–excenter distances IₐI_b, completing the metric table of the four tritangent centers and recovering their pairwise sum.",
-      "Show that I, Iₐ, I_b, I_c form an orthocentric system with common nine-point circle the circumcircle of ABC, so that 12R² also equals the analogous square-distance sum from the centroid of the four centers, linking back to the Feuerbach configuration.",
-      "Generalize to weighted tritangent sums: determine for which weights wₐ,w_b,w_c,w₀ the combination w₀·OI² + wₐ·OIₐ² + w_b·OI_b² + w_c·OI_c² is shape-independent, and characterize the resulting constants."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-02-oq-01",
@@ -158,9 +149,52 @@
       "description": "the full Feuerbach theorem, whose nine-point circle is tangent to the incircle and all three excircles whose centers appear here"
     }
   ],
+  "conclusion": {
+    "summary": "Proves the shape-independent conservation law OI² + OIₐ² + OI_b² + OI_c² = 12R² summing Euler's incenter and three excenter formulas over the four tritangent centers, together with the classical exradius identity rₐ + r_b + r_c − r = 4R that drives the collapse, both resting on a from-scratch proof of Heron's identity. Answers the first open question of the excenter entry. 3 theorems (plus 16 supporting lemmas), 0 axioms, 0 sorries.",
+    "implications": "**A conservation law on Euler's pair**: the sibling entries gave OI² = R² − 2Rr and OIₐ² = R² + 2Rrₐ; summing all four centers cancels every shape-dependent term and leaves the pure constant 12R², a fact more rigid than either Euler formula alone.\n\n**The exradius identity made explicit**: rₐ + r_b + r_c − r = 4R is supplied as a standalone theorem, a classical companion of Euler's formula useful wherever exradii and the circumradius interact.\n\n**Heron's identity as gallery infrastructure**: 16·Area² = (a+b+c)(−a+b+c)(a−b+c)(a+b−c) is proved coordinate-free of trigonometry and is reusable for any side-length/area relation in the triangle-geometry strand.",
+    "openQuestions": [
+      "Establish the incenter–excenter distance IIₐ² = 4R·rₐ (so IIₐ = 2√(R rₐ)) and the excenter–excenter distances IₐI_b, completing the metric table of the four tritangent centers and recovering their pairwise sum.",
+      "Show that I, Iₐ, I_b, I_c form an orthocentric system with common nine-point circle the circumcircle of ABC, so that 12R² also equals the analogous square-distance sum from the centroid of the four centers, linking back to the Feuerbach configuration.",
+      "Generalize to weighted tritangent sums: determine for which weights wₐ,w_b,w_c,w₀ the combination w₀·OI² + wₐ·OIₐ² + w_b·OI_b² + w_c·OI_c² is shape-independent, and characterize the resulting constants."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "Solutio facilis problematum quorundam geometricorum difficillimorum",
+      "year": "1765",
+      "venue": "Novi Commentarii Academiae Scientiarum Petropolitanae 11, 103–123",
+      "note": "The Euler line and the distance formula OI² = R² − 2Rr."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefsOQ02OQ01"],
-    "opens": ["FeuerbachsTheorem", "FeuerbachEulerOI", "FeuerbachExcenterEuler"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefsOQ02OQ01"
+    ],
+    "opens": [
+      "FeuerbachsTheorem",
+      "FeuerbachEulerOI",
+      "FeuerbachExcenterEuler"
+    ],
     "namespace": "FeuerbachSumOISq",
     "lineCount": 330,
     "axiomCount": 0,
@@ -174,6 +208,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "sum_OI_sq_eq_twelve_R_sq",
@@ -205,6 +240,5 @@
       "description": "Worked example: for the 3-4-5 right triangle the four squared distances sum to 75 = 12·(5/2)².",
       "leanType": "dist2_sq triangle_345.circumcenter triangle_345.incenter + dist2_sq triangle_345.circumcenter triangle_345.excenter_a + dist2_sq triangle_345.circumcenter triangle_345.excenter_b + dist2_sq triangle_345.circumcenter triangle_345.excenter_c = 75"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01/meta.json
@@ -144,15 +144,6 @@
       "mathContext": "Uses the parent's computed circumcenter (3/2, 2), circumradius 5/2 and side lengths 5, 4, 3."
     }
   ],
-  "conclusion": {
-    "summary": "Establishes Euler's circumcenter–excenter formula OIₐ² = R² + 2Rrₐ for all three excenters, the sign-flipped companion of the incenter law OI² = R² − 2Rr, and derives the strict consequence R < OIₐ. Along the way it proves the strict triangle inequality for the Euclidean side lengths from the 2-D Lagrange identity. 15 theorems (plus supporting lemmas), 0 axioms, 0 sorries.",
-    "implications": "**Euler's pair completed**: the sibling entry gave OI² = R² − 2Rr; this entry gives OIₐ² = R² + 2Rrₐ, so the gallery now records both of Euler's 1765 center-distance laws.\n\n**Opposite inclusions**: the incenter law's minus sign yields OI < R (incenter inside the circumcircle); the excenter law's plus sign yields OIₐ > R (circumcenter farther from any excenter than R). One sign captures the geometric dichotomy.\n\n**Reusable triangle inequality**: strict_tri_ineq_a/b/c prove a < b+c for the coordinate side lengths via a Lagrange identity, a fact useful wherever escribed circles or barycentric coordinates with signed weights appear.",
-    "openQuestions": [
-      "Prove the excentral identity OIₐ² + OI_b² + OI_c² = 3R² + 2R(rₐ + r_b + r_c) and combine with the incenter law to obtain OI² + OIₐ² + OI_b² + OI_c² in closed form.",
-      "Establish the distance between the incenter and an excenter, IIₐ² = 4R·rₐ (so IIₐ = 2√(R rₐ)), and the excenter–excenter distances, completing the metric table of the four tritangent centers.",
-      "Show that the four points I, Iₐ, I_b, I_c form an orthocentric system whose nine-point circle is the circumcircle of ABC, linking these distances back to the Feuerbach configuration."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-02",
@@ -170,9 +161,50 @@
       "description": "the full Feuerbach theorem, whose nine-point circle is tangent to each of the three excircles whose centers appear here"
     }
   ],
+  "conclusion": {
+    "summary": "Establishes Euler's circumcenter–excenter formula OIₐ² = R² + 2Rrₐ for all three excenters, the sign-flipped companion of the incenter law OI² = R² − 2Rr, and derives the strict consequence R < OIₐ. Along the way it proves the strict triangle inequality for the Euclidean side lengths from the 2-D Lagrange identity. 15 theorems (plus supporting lemmas), 0 axioms, 0 sorries.",
+    "implications": "**Euler's pair completed**: the sibling entry gave OI² = R² − 2Rr; this entry gives OIₐ² = R² + 2Rrₐ, so the gallery now records both of Euler's 1765 center-distance laws.\n\n**Opposite inclusions**: the incenter law's minus sign yields OI < R (incenter inside the circumcircle); the excenter law's plus sign yields OIₐ > R (circumcenter farther from any excenter than R). One sign captures the geometric dichotomy.\n\n**Reusable triangle inequality**: strict_tri_ineq_a/b/c prove a < b+c for the coordinate side lengths via a Lagrange identity, a fact useful wherever escribed circles or barycentric coordinates with signed weights appear.",
+    "openQuestions": [
+      "Prove the excentral identity OIₐ² + OI_b² + OI_c² = 3R² + 2R(rₐ + r_b + r_c) and combine with the incenter law to obtain OI² + OIₐ² + OI_b² + OI_c² in closed form.",
+      "Establish the distance between the incenter and an excenter, IIₐ² = 4R·rₐ (so IIₐ = 2√(R rₐ)), and the excenter–excenter distances, completing the metric table of the four tritangent centers.",
+      "Show that the four points I, Iₐ, I_b, I_c form an orthocentric system whose nine-point circle is the circumcircle of ABC, linking these distances back to the Feuerbach configuration."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "Solutio facilis problematum quorundam geometricorum difficillimorum",
+      "year": "1765",
+      "venue": "Novi Commentarii Academiae Scientiarum Petropolitanae 11, 103–123",
+      "note": "The Euler line and the distance formula OI² = R² − 2Rr."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Proofs.FeuerbachsTheoremDefsOQ02"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefsOQ02"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachExcenterEuler",
     "lineCount": 594,
     "axiomCount": 0,
@@ -185,6 +217,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "euler_OI_a_formula",
@@ -216,6 +249,5 @@
       "description": "Reusable weighted-norm master identity for arbitrary weights, specializing to the incenter and all three excenters.",
       "leanType": "∀ (T : Triangle) (wa wb wc : ℝ), |wa(A−O)+wb(B−O)+wc(C−O)|² = |A−O|²(wa+wb+wc)² − (wa·wb·c²+wb·wc·a²+wc·wa·b²)"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-04-oq-03/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-04-oq-03/meta.json
@@ -97,15 +97,6 @@
       "mathContext": "Each conjunct is discharged by Metric.mem_sphere + dist_comm and the corresponding distance lemma; the radius is R/2 with R the common circumradius."
     }
   ],
-  "conclusion": {
-    "summary": "Establishes the nine-point circle theorem in full generality: for any triangle in any real inner product space with a common circumcenter, the nine classical points lie on one Metric.sphere of radius R/2. This removes the coordinate (ℝ×ℝ) restriction of the gallery's earlier Feuerbach formalisations and provides Mathlib-ready infrastructure, since Mathlib currently has no nine-point circle. 14 theorems, 4 definitions, 0 axioms, 0 sorries.",
-    "implications": "Coordinate-free formulation: the result holds in EuclideanSpace ℝ (Fin 2), ℝ³, or any abstract Hilbert space, making it a direct candidate for upstreaming to Mathlib's EuclideanGeometry. The translation-and-rotation proof skeleton (normalise circumcenter to origin, reduce to a single core lemma) is reusable for the remaining open questions — incircle/excircle tangency (Feuerbach's tangency theorem proper) and the affine-space (EuclideanGeometry.sphere) reformulation.",
-    "openQuestions": [
-      "Prove the Feuerbach tangency itself in this abstract setting: the nine-point sphere is internally tangent to the incircle and externally tangent to the three excircles, i.e. dist between centres equals the difference/sum of radii.",
-      "Recast the construction in Mathlib's affine EuclideanGeometry framework (AffineSpace, EuclideanGeometry.sphere, Affine.Simplex.circumcenter / orthocenter) so that O is recovered as the genuine circumcenter rather than supplied as a hypothesis.",
-      "Show the nine-point centre lies on the Euler line and equals the circumcentre of the medial triangle, in the same coordinate-free language."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs-oq-04",
@@ -116,6 +107,43 @@
       "targetId": "feuerbachs-theorem-defs",
       "relationship": "related",
       "description": "the coordinate (Point = ℝ × ℝ) nine-point circle proofs that this file abstracts away from"
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes the nine-point circle theorem in full generality: for any triangle in any real inner product space with a common circumcenter, the nine classical points lie on one Metric.sphere of radius R/2. This removes the coordinate (ℝ×ℝ) restriction of the gallery's earlier Feuerbach formalisations and provides Mathlib-ready infrastructure, since Mathlib currently has no nine-point circle. 14 theorems, 4 definitions, 0 axioms, 0 sorries.",
+    "implications": "Coordinate-free formulation: the result holds in EuclideanSpace ℝ (Fin 2), ℝ³, or any abstract Hilbert space, making it a direct candidate for upstreaming to Mathlib's EuclideanGeometry. The translation-and-rotation proof skeleton (normalise circumcenter to origin, reduce to a single core lemma) is reusable for the remaining open questions — incircle/excircle tangency (Feuerbach's tangency theorem proper) and the affine-space (EuclideanGeometry.sphere) reformulation.",
+    "openQuestions": [
+      "Prove the Feuerbach tangency itself in this abstract setting: the nine-point sphere is internally tangent to the incircle and externally tangent to the three excircles, i.e. dist between centres equals the difference/sum of radii.",
+      "Recast the construction in Mathlib's affine EuclideanGeometry framework (AffineSpace, EuclideanGeometry.sphere, Affine.Simplex.circumcenter / orthocenter) so that O is recovered as the genuine circumcenter rather than supplied as a hypothesis.",
+      "Show the nine-point centre lies on the Euler line and equals the circumcentre of the medial triangle, in the same coordinate-free language."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Feuerbach, Karl Wilhelm",
+      "title": "Eigenschaften einiger merkwürdigen Punkte des geradlinigen Dreiecks",
+      "year": "1822",
+      "venue": "Riegel und Wießner, Nürnberg",
+      "note": "Nine-point circle and its tangency to the incircle and excircles (Feuerbach's theorem)."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
@@ -98,15 +98,6 @@
       "mathContext": "The `end FeuerbachsTheoremDefsOQ04` and `end` close the namespace and noncomputable section, making all 12 theorems available under the `FeuerbachsTheoremDefsOQ04` prefix for import by downstream proofs."
     }
   ],
-  "conclusion": {
-    "summary": "Successfully bridges the gallery's coordinate-based Feuerbach formalization to Mathlib's abstract EuclideanSpace and Metric.sphere types. The 155-line file provides 12 theorems (1 bridge lemma + 9 individual memberships + 1 combined + 1 corollary), all with 0 sorries, showing full compatibility between the two formulations.",
-    "implications": "**Mathlib alignment**: The reformulation expresses the nine-point circle theorem using Mathlib's preferred geometry types, making it a candidate for Mathlib contribution after appropriate abstraction.\n\n**API bridge pattern**: The `toEuclidean` + bridge lemma approach can be applied to other gallery proofs using the custom coordinate API (FeuerbachsTheorem.lean, FeuerbachsTheoremOQ01.lean, etc.).\n\n**Incircle tangency**: The next step is to reformulate the incircle tangency (`feuerbach_incircle_distance`) using Mathlib's tangent sphere condition, which would complete the Mathlib reformulation of the full Feuerbach theorem.",
-    "openQuestions": [
-      "Reformulate the incircle tangency theorem using Mathlib's sphere tangency: `Metric.sphere (toEuclidean N) R₉ ∩ Metric.sphere (toEuclidean I) r = {toEuclidean F}` where F is the Feuerbach point.",
-      "Prove the result using Mathlib's EuclideanGeometry.sphere type (the affine geometry version) rather than Metric.sphere, enabling connection to Mathlib's incircle/circumcircle formalism.",
-      "Contribute the nine-point circle theorem to Mathlib using this Mathlib-compatible formulation as the starting point."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs",
@@ -119,9 +110,53 @@
       "description": "the full Feuerbach theorem including incircle tangency, which this bridge enables reformulating"
     }
   ],
+  "conclusion": {
+    "summary": "Successfully bridges the gallery's coordinate-based Feuerbach formalization to Mathlib's abstract EuclideanSpace and Metric.sphere types. The 155-line file provides 12 theorems (1 bridge lemma + 9 individual memberships + 1 combined + 1 corollary), all with 0 sorries, showing full compatibility between the two formulations.",
+    "implications": "**Mathlib alignment**: The reformulation expresses the nine-point circle theorem using Mathlib's preferred geometry types, making it a candidate for Mathlib contribution after appropriate abstraction.\n\n**API bridge pattern**: The `toEuclidean` + bridge lemma approach can be applied to other gallery proofs using the custom coordinate API (FeuerbachsTheorem.lean, FeuerbachsTheoremOQ01.lean, etc.).\n\n**Incircle tangency**: The next step is to reformulate the incircle tangency (`feuerbach_incircle_distance`) using Mathlib's tangent sphere condition, which would complete the Mathlib reformulation of the full Feuerbach theorem.",
+    "openQuestions": [
+      "Reformulate the incircle tangency theorem using Mathlib's sphere tangency: `Metric.sphere (toEuclidean N) R₉ ∩ Metric.sphere (toEuclidean I) r = {toEuclidean F}` where F is the Feuerbach point.",
+      "Prove the result using Mathlib's EuclideanGeometry.sphere type (the affine geometry version) rather than Metric.sphere, enabling connection to Mathlib's incircle/circumcircle formalism.",
+      "Contribute the nine-point circle theorem to Mathlib using this Mathlib-compatible formulation as the starting point."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Feuerbach, Karl Wilhelm",
+      "title": "Eigenschaften einiger merkwürdigen Punkte des geradlinigen Dreiecks",
+      "year": "1822",
+      "venue": "Riegel und Wießner, Nürnberg",
+      "note": "Nine-point circle and its tangency to the incircle and excircles (Feuerbach's theorem)."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Mathlib", "Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem", "Real", "EuclideanGeometry"],
+    "imports": [
+      "Mathlib",
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem",
+      "Real",
+      "EuclideanGeometry"
+    ],
     "namespace": "FeuerbachsTheoremDefsOQ04",
     "lineCount": 190,
     "axiomCount": 0,
@@ -133,6 +168,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "toEuclidean_dist",
@@ -146,6 +182,5 @@
       "description": "All 9 nine-point circle points lie on a Mathlib Metric.sphere",
       "leanType": "∀ p ∈ [nine points], p ∈ Metric.sphere (toEuclidean T.ninePointCenter) T.ninePointRadius"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-05/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-05/meta.json
@@ -105,15 +105,6 @@
       "mathContext": "Specializes ninePointCircle_unique to triangle_345 and rewrites with the parent's computed ninePointCenter and ninePointRadius."
     }
   ],
-  "conclusion": {
-    "summary": "Establishes that the nine-point circle is the unique circle through the nine special points of a non-degenerate triangle. The 184-line file proves uniqueness of an equidistant centre (the linear-algebra core), non-collinearity of the three side midpoints (a 1/4-multiple of the triangle's non-degeneracy determinant), and assembles them with the parent's membership theorems into ninePointCircle_unique. 6 theorems, 0 axioms, 0 sorries.",
-    "implications": "**Completes the definitional picture**: with both membership (parent) and uniqueness (this file), 'the nine-point circle' is now a canonically determined object in the gallery's coordinate framework, not merely 'a circle through these points'.\n\n**Reusable circle-uniqueness lemma**: equidistant_center_unique is stated for arbitrary points and can be reused for circumcircle uniqueness or any 'three non-collinear points determine a circle' argument in the coordinate API.\n\n**Minimal hypotheses**: uniqueness consumes only the three side-midpoint memberships, making explicit that three of the nine points suffice.",
-    "openQuestions": [
-      "Transport ninePointCircle_unique across the toEuclidean bridge of feuerbachs-theorem-defs-oq-04 to obtain uniqueness for Mathlib's Metric.sphere formulation.",
-      "Prove that the nine-point centre N is the unique point equidistant from any three of the nine points (not just the side midpoints), e.g. from the three altitude feet.",
-      "Derive a general 'three non-collinear points determine a unique circle' theorem in the coordinate API from equidistant_center_unique and apply it to the circumcircle."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem-defs",
@@ -131,9 +122,51 @@
       "description": "uniqueness of the Feuerbach (tangency) point, a companion uniqueness result for the same configuration"
     }
   ],
+  "conclusion": {
+    "summary": "Establishes that the nine-point circle is the unique circle through the nine special points of a non-degenerate triangle. The 184-line file proves uniqueness of an equidistant centre (the linear-algebra core), non-collinearity of the three side midpoints (a 1/4-multiple of the triangle's non-degeneracy determinant), and assembles them with the parent's membership theorems into ninePointCircle_unique. 6 theorems, 0 axioms, 0 sorries.",
+    "implications": "**Completes the definitional picture**: with both membership (parent) and uniqueness (this file), 'the nine-point circle' is now a canonically determined object in the gallery's coordinate framework, not merely 'a circle through these points'.\n\n**Reusable circle-uniqueness lemma**: equidistant_center_unique is stated for arbitrary points and can be reused for circumcircle uniqueness or any 'three non-collinear points determine a circle' argument in the coordinate API.\n\n**Minimal hypotheses**: uniqueness consumes only the three side-midpoint memberships, making explicit that three of the nine points suffice.",
+    "openQuestions": [
+      "Transport ninePointCircle_unique across the toEuclidean bridge of feuerbachs-theorem-defs-oq-04 to obtain uniqueness for Mathlib's Metric.sphere formulation.",
+      "Prove that the nine-point centre N is the unique point equidistant from any three of the nine points (not just the side midpoints), e.g. from the three altitude feet.",
+      "Derive a general 'three non-collinear points determine a unique circle' theorem in the coordinate API from equidistant_center_unique and apply it to the circumcircle."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Feuerbach, Karl Wilhelm",
+      "title": "Eigenschaften einiger merkwürdigen Punkte des geradlinigen Dreiecks",
+      "year": "1822",
+      "venue": "Riegel und Wießner, Nürnberg",
+      "note": "Nine-point circle and its tangency to the incircle and excircles (Feuerbach's theorem)."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
-    "imports": ["Mathlib", "Proofs.FeuerbachsTheoremDefs"],
-    "opens": ["FeuerbachsTheorem"],
+    "imports": [
+      "Mathlib",
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
     "namespace": "FeuerbachNinePointUniqueness",
     "lineCount": 184,
     "axiomCount": 0,
@@ -145,6 +178,7 @@
       "Proofs/FeuerbachsTheoremDefs.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "ninePointCircle_unique",
@@ -164,6 +198,5 @@
       "description": "The three side midpoints of a non-degenerate triangle are non-collinear",
       "leanType": "(M_b.1-M_a.1)*(M_c.2-M_a.2) - (M_c.1-M_a.1)*(M_b.2-M_a.2) != 0"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-oq-02-murakami/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02-murakami/meta.json
@@ -128,6 +128,35 @@
       "Relate the rational centre Θ to a canonical tetrahedron centre (the analogue of the nine-point centre)."
     ]
   },
+  "references": [
+    {
+      "authors": "Grace, John Hilton",
+      "title": "Tetrahedra in relation to spheres and quadrics",
+      "year": "1917",
+      "venue": "Proceedings of the London Mathematical Society s2-17, 259–271",
+      "note": "Sphere tangencies for tetrahedra (3D Feuerbach-type results)."
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"
@@ -150,6 +179,7 @@
     "sorries": 0,
     "additionalFiles": []
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "grace_feuerbach_trirectangular",
@@ -157,6 +187,5 @@
       "description": "For the trirectangular tetrahedron with legs a,b,c>0, the sphere of centre Θ=((a+b)(a+c),(a+b)(b+c),(a+c)(b+c))/(2σ) and radius R=(a²+b²+c²+ab+bc+ca)/(2σ) passes through A=(a,0,0), B=(0,b,0), C=(0,0,c) and is internally tangent to both the insphere (radius ρin=(ab+bc+ca−t)/(2σ)) and the D-exsphere (radius ρex=(ab+bc+ca+t)/(2σ)), where t=√(a²b²+b²c²+c²a²). Proved by field_simp;ring (incidence) and field_simp;linear_combination 2*ht (tangency).",
       "leanType": "(a b c t : ℝ) → 0 < a → 0 < b → 0 < c → t^2 = a^2*b^2+b^2*c^2+c^2*a^2 → 0 ≤ t → (qx qy qz R ρin ρex : ℝ) → … → (incidence A ∧ incidence B ∧ incidence C ∧ tangent insphere ∧ tangent D-exsphere)"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -221,6 +221,34 @@
       "Investigate the analogue for n-dimensional simplices."
     ]
   },
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "Altshiller-Court, Nathan",
+      "title": "College Geometry (2nd ed.)",
+      "year": "1952",
+      "venue": "Barnes & Noble",
+      "note": "Orthocentric system, excentral triangle, and tritangent circles."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Real.Sqrt",
@@ -243,6 +271,7 @@
       "Proofs/FeuerbachsTheoremOQ02Aristotle.lean"
     ]
   },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "orthocentric_third_perp",
@@ -286,6 +315,5 @@
       "description": "Volume = inradius × surface area / 3",
       "leanType": "(T : Tetrahedron) → (hS : T.surfaceArea > 0) → T.volume = T.inradius * T.surfaceArea / 3"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-oq-05/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-05/meta.json
@@ -93,15 +93,6 @@
       "summary": "Closing comment cataloging the 12 theorems proved in this file with their geometric meaning, and explaining the overall inversive proof strategy connecting to the excircle tangency (the next step not formalized here)"
     }
   ],
-  "conclusion": {
-    "summary": "This file proves 12 theorems plus 2 auxiliary lemmas (12 total) with 0 sorries and 0 axioms, formalizing the inversive geometry framework. The Feuerbach point is defined and shown to lie on both circles; the Circle-to-Line theorem is proved; and the parallel-image-lines result establishes the core geometric content of the inversive proof strategy.",
-    "implications": "The inversive framework established here is the foundation for the full proof that excircles are also tangent to the nine-point circle. The parallel line result — that inversion at F maps both circles to parallel lines — means any circle tangent to both original circles maps to a circle between the two parallel lines, automatically tangent to both lines and hence to both original circles. This reduces the excircle tangency to the simpler problem of finding circles between two parallel lines. The `circle_to_line` theorem and `invertPoint` definition are reusable for other inversive geometry arguments.",
-    "openQuestions": [
-      "Complete the inversive proof by showing each excircle maps under inversion at $F$ to a circle between the two parallel lines, establishing external tangency of each excircle to the nine-point circle",
-      "Formalize Feuerbach's theorem using Mathlib's projective geometry or complex plane approach (where inversion is Möbius transformation and the computation is more algebraically streamlined via complex multiplication)",
-      "Extend the framework to other tangency results in triangle geometry: the Soddy circles, mixtilinear incircles, or the Apollonius circle — all of which use inversive methods"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "feuerbachs-theorem",
@@ -124,6 +115,53 @@
       "description": "Ptolemy's theorem is proved via inversive geometry — inversion maps circles to lines in both theorems; the technique is the same"
     }
   ],
+  "conclusion": {
+    "summary": "This file proves 12 theorems plus 2 auxiliary lemmas (12 total) with 0 sorries and 0 axioms, formalizing the inversive geometry framework. The Feuerbach point is defined and shown to lie on both circles; the Circle-to-Line theorem is proved; and the parallel-image-lines result establishes the core geometric content of the inversive proof strategy.",
+    "implications": "The inversive framework established here is the foundation for the full proof that excircles are also tangent to the nine-point circle. The parallel line result — that inversion at F maps both circles to parallel lines — means any circle tangent to both original circles maps to a circle between the two parallel lines, automatically tangent to both lines and hence to both original circles. This reduces the excircle tangency to the simpler problem of finding circles between two parallel lines. The `circle_to_line` theorem and `invertPoint` definition are reusable for other inversive geometry arguments.",
+    "openQuestions": [
+      "Complete the inversive proof by showing each excircle maps under inversion at $F$ to a circle between the two parallel lines, establishing external tangency of each excircle to the nine-point circle",
+      "Formalize Feuerbach's theorem using Mathlib's projective geometry or complex plane approach (where inversion is Möbius transformation and the computation is more algebraically streamlined via complex multiplication)",
+      "Extend the framework to other tangency results in triangle geometry: the Soddy circles, mixtilinear incircles, or the Apollonius circle — all of which use inversive methods"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Feuerbach, Karl Wilhelm",
+      "title": "Eigenschaften einiger merkwürdigen Punkte des geradlinigen Dreiecks",
+      "year": "1822",
+      "venue": "Riegel und Wießner, Nürnberg",
+      "note": "Nine-point circle and its tangency to the incircle and excircles (Feuerbach's theorem)."
+    },
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Euler line, nine-point circle and Feuerbach's theorem."
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": "1929",
+      "venue": "Houghton Mifflin"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "EuclideanGeometry, Sphere, EuclideanSpace inner-product and affine-combination API (Mathlib.Geometry.Euclidean)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "namespace": "FeuerbachsTheoremOQ05",
+    "lineCount": 266,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/FeuerbachsTheoremOQ05.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "feuerbach_inversive_parallel_lines",
@@ -140,15 +178,5 @@
       "type": "supporting",
       "description": "The Feuerbach point lies on the nine-point circle (dist2(N,F) = R₉), proved from the explicit coordinate definition F = N + (R₉/d)·(I-N) where d = R₉ - r."
     }
-  ],
-  "leanFile": {
-    "namespace": "FeuerbachsTheoremOQ05",
-    "lineCount": 266,
-    "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 2,
-    "path": "Proofs/FeuerbachsTheoremOQ05.lean",
-    "sorries": 0
-  },
-  "sorries": 0
+  ]
 }


### PR DESCRIPTION
## Enrichment pass — cluster

19 verified `feuerbachs-theorem(-defs)-oq-*` descendants (nine-point circle, Euler line, orthocenter, excentral triangle, Feuerbach's theorem, 3D analogues) had **no references**. Added 4 references to each, matched to its content:

- **Orthocenter distances / Euler OH² identity / reflections / orthocentric system** — Euler (1765), Coxeter–Greitzer, Johnson, Altshiller-Court, mathlib
- **Altitude concurrency + altitude-length law** — Coxeter–Greitzer, Johnson, Altshiller-Court, mathlib
- **Excentral triangle (circumradius 2R, incenter-as-orthocenter, tritangent centroid)** — Johnson, Altshiller-Court, Kimberling, mathlib
- **Euler circumcenter–excenter OIₐ² = R² + 2Rrₐ and OI² sums** — Euler (1765), Coxeter–Greitzer, Johnson, mathlib
- **Nine-point circle** (abstract inner-product space, Mathlib sphere form, uniqueness, inversive) — Feuerbach (1822), Coxeter–Greitzer, Johnson, mathlib
- **3D analogues for tetrahedra incl. Grace's theorem** — Grace (1917), Altshiller-Court, Coxeter–Greitzer, mathlib

All meta.json within size caps. No Lean source changed.