### PR TITLE
Enrich picks-theorem OQ cluster: add references to 9 entries

### DIFF
--- a/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
@@ -32,12 +32,12 @@
     ]
   },
   "overview": {
-    "historicalContext": "Georg Alexander Pick (1859\u20131942) discovered his eponymous formula in 1899: for a lattice polygon (vertices at integer points), Area = I + B/2 - 1, where I is the number of interior lattice points and B the number of boundary lattice points. The formula is elegant and elementary but its proof requires connecting area to lattice point counts. One clean approach, due to the Euclidean algorithm tradition, triangulates any lattice polygon into primitive triangles (area 1/2, the smallest non-degenerate lattice triangles) and uses that each has exactly one interior lattice point's worth of area. The key step \u2014 that any lattice triangle decomposes into exactly |det| primitive triangles \u2014 is essentially the theory of the Smith normal form for 2\u00d72 integer matrices. Pick's theorem has applications in toric algebraic geometry (where it controls the number of lattice points in polygons) and in computational geometry (efficient area computation for integer-coordinate polygons).",
+    "historicalContext": "Georg Alexander Pick (1859–1942) discovered his eponymous formula in 1899: for a lattice polygon (vertices at integer points), Area = I + B/2 - 1, where I is the number of interior lattice points and B the number of boundary lattice points. The formula is elegant and elementary but its proof requires connecting area to lattice point counts. One clean approach, due to the Euclidean algorithm tradition, triangulates any lattice polygon into primitive triangles (area 1/2, the smallest non-degenerate lattice triangles) and uses that each has exactly one interior lattice point's worth of area. The key step — that any lattice triangle decomposes into exactly |det| primitive triangles — is essentially the theory of the Smith normal form for 2×2 integer matrices. Pick's theorem has applications in toric algebraic geometry (where it controls the number of lattice points in polygons) and in computational geometry (efficient area computation for integer-coordinate polygons).",
     "problemStatement": "Let $T$ be a lattice triangle with vertices $v_1, v_2, v_3 \\in \\mathbb{Z}^2$. Define $\\det(T) = (v_2 - v_1) \\times (v_3 - v_1)$ (the 2D cross product, equal to twice the signed area). $T$ is called *primitive* if $|\\det(T)| = 1$ (area $= 1/2$). The theorem states: if $T$ is non-degenerate ($\\det(T) \\neq 0$), then $T$ can be triangulated into exactly $|\\det(T)|$ primitive triangles.",
-    "proofStrategy": "The proof uses strong induction on $|\\det(T)|$. Base case: $|\\det(T)| = 1$ \u2014 $T$ is already primitive, triangulated by itself. Inductive step: if $|\\det(T)| > 1$, the reduction lemma `exists_reduction` finds an edge vector $(v_j - v_i)$ with $\\gcd > 1$: taking $M = v_i + (v_j - v_i)/g$ where $g = \\gcd(v_j - v_i)$ gives a midpoint that splits $T$ into two sub-triangles with $|\\det(L)| + |\\det(R)| = |\\det(T)|$ and both $|\\det(L)|, |\\det(R)| < |\\det(T)|$. By induction, each sub-triangle has a primitive triangulation, and their concatenation gives the full triangulation. The GCD existence step mirrors the Euclidean algorithm: if no edge has $\\gcd > 1$, then $|\\det(T)| = 1$, contradicting $|\\det(T)| > 1$.",
+    "proofStrategy": "The proof uses strong induction on $|\\det(T)|$. Base case: $|\\det(T)| = 1$ — $T$ is already primitive, triangulated by itself. Inductive step: if $|\\det(T)| > 1$, the reduction lemma `exists_reduction` finds an edge vector $(v_j - v_i)$ with $\\gcd > 1$: taking $M = v_i + (v_j - v_i)/g$ where $g = \\gcd(v_j - v_i)$ gives a midpoint that splits $T$ into two sub-triangles with $|\\det(L)| + |\\det(R)| = |\\det(T)|$ and both $|\\det(L)|, |\\det(R)| < |\\det(T)|$. By induction, each sub-triangle has a primitive triangulation, and their concatenation gives the full triangulation. The GCD existence step mirrors the Euclidean algorithm: if no edge has $\\gcd > 1$, then $|\\det(T)| = 1$, contradicting $|\\det(T)| > 1$.",
     "keyInsights": [
       "The determinant $\\det(T) = (v_2-v_1)\\times(v_3-v_1)$ is exactly the 2D cross product: it measures twice the signed area in integer arithmetic. Primitivity ($|\\det|=1$) means the triangle has the minimum possible non-zero lattice area.",
-      "The GCD condition drives the reduction: if $g = \\gcd(v_j - v_i) > 1$, the midpoint $M = v_i + (v_j-v_i)/g$ is a lattice point on the edge. Splitting there creates two triangles whose determinants sum to the original \u2014 a strict reduction in each piece.",
+      "The GCD condition drives the reduction: if $g = \\gcd(v_j - v_i) > 1$, the midpoint $M = v_i + (v_j-v_i)/g$ is a lattice point on the edge. Splitting there creates two triangles whose determinants sum to the original — a strict reduction in each piece.",
       "The proof uses `List` (not `Finset`) for the triangulation, because List concatenation naturally represents the union of two triangulations without needing to prove disjointness. The inductive structure directly mirrors the recursive concatenation.",
       "The reduction step relies on the fact that if $|\\det(T)| > 1$, then NOT all edges can have $\\gcd = 1$ simultaneously: if all three edge GCDs were 1, the determinant formula forces $|\\det| = 1$. This is the key number-theoretic content.",
       "The concrete examples (det=2 split, det=12 needing multiple splits) serve as proof-of-concept for the algorithmic nature of the decomposition: the splitting process terminates and produces the right count."
@@ -56,7 +56,7 @@
       "title": "Lattice Triangle Definitions",
       "startLine": 30,
       "endLine": 82,
-      "summary": "Defines LatticeTriangle (structure with v1, v2, v3 : \u2124\u00d7\u2124), LatticeTriangle.det (signed 2D cross product), IsPrimitive (|det|=1), NonDegenerate (det\u22600), splitLeft and splitRight (sub-triangles after edge split). Proves unit triangle examples and IsPrimitive.nonDegenerate."
+      "summary": "Defines LatticeTriangle (structure with v1, v2, v3 : ℤ×ℤ), LatticeTriangle.det (signed 2D cross product), IsPrimitive (|det|=1), NonDegenerate (det≠0), splitLeft and splitRight (sub-triangles after edge split). Proves unit triangle examples and IsPrimitive.nonDegenerate."
     },
     {
       "id": "det-additivity",
@@ -85,6 +85,27 @@
       "startLine": 194,
       "endLine": 215,
       "summary": "Machine-checked examples: det2_split_correct (det=2 triangle splits into 2 primitives), det12_two_splits (det=12 example), det_add_example. These serve as sanity checks and illustrate the splitting algorithm."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Beck, M.",
+        "Robins, S."
+      ],
+      "title": "Computing the Continuous Discretely: Integer-Point Enumeration in Polyhedra",
+      "year": "2015",
+      "venue": "2nd ed., Undergraduate Texts in Mathematics, Springer",
+      "note": "Standard modern reference for Pick's theorem, Ehrhart polynomials, Ehrhart–Macdonald reciprocity and h*-vectors."
+    },
+    {
+      "authors": [
+        "Pick, G."
+      ],
+      "title": "Geometrisches zur Zahlenlehre",
+      "year": "1899",
+      "venue": "Sitzungsberichte des deutschen naturwissenschaftlich-medicinischen Vereines für Böhmen \"Lotos\" 19, pp. 311–319",
+      "note": "Original statement of Pick's area formula for lattice polygons."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
@@ -98,6 +98,27 @@
       "mathContext": "$\\sum_{t \\geq 0} L(P,t) z^t = \\frac{h_0^* + h_1^* z + h_2^* z^2}{(1-z)^3}$, where $h_i^* \\geq 0$ (Stanley's theorem)."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Beck, M.",
+        "Robins, S."
+      ],
+      "title": "Computing the Continuous Discretely: Integer-Point Enumeration in Polyhedra",
+      "year": "2015",
+      "venue": "2nd ed., Undergraduate Texts in Mathematics, Springer",
+      "note": "Standard modern reference for Pick's theorem, Ehrhart polynomials, Ehrhart–Macdonald reciprocity and h*-vectors."
+    },
+    {
+      "authors": [
+        "Ehrhart, E."
+      ],
+      "title": "Sur les polyèdres rationnels homothétiques à n dimensions",
+      "year": "1962",
+      "venue": "Comptes Rendus de l'Académie des Sciences (Paris) 254, pp. 616–618",
+      "note": "Introduces the Ehrhart polynomial counting lattice points in dilates of a lattice polytope."
+    }
+  ],
   "conclusion": {
     "summary": "The 2D Ehrhart polynomial L(P,t) = A·t² + (B/2)·t + 1 is machine-verified via three independent proof routes: combinatorial (rectangles and triangles via Finset), algebraic (from Pick's theorem and scaling axioms). The interior count formula and h*-vector non-negativity are derived as immediate consequences. 25 theorems, 7 definitions, 324 lines.",
     "implications": "This formalization establishes the 2D Ehrhart polynomial as a direct corollary of Pick's theorem when combined with the geometric scaling laws. The cross-framework consistency result (rectangle_frameworks_agree) validates that the axiomatic and combinatorial approaches agree. The h*-vector formulation opens the path to Stanley's non-negativity theorem in higher dimensions.",

--- a/src/data/proofs/picks-theorem-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01/meta.json
@@ -127,6 +127,27 @@
       "summary": "Documents the remaining gap (primitive triangulation requires computational geometry) and proves `picks_from_triangulation`: given n primitive triangles and Pick's formula for the composite, the formula holds. This is the tautological conclusion that makes the inductive hypothesis explicit."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Pick, G."
+      ],
+      "title": "Geometrisches zur Zahlenlehre",
+      "year": "1899",
+      "venue": "Sitzungsberichte des deutschen naturwissenschaftlich-medicinischen Vereines für Böhmen \"Lotos\" 19, pp. 311–319",
+      "note": "Original statement of Pick's area formula for lattice polygons."
+    },
+    {
+      "authors": [
+        "Beck, M.",
+        "Robins, S."
+      ],
+      "title": "Computing the Continuous Discretely: Integer-Point Enumeration in Polyhedra",
+      "year": "2015",
+      "venue": "2nd ed., Undergraduate Texts in Mathematics, Springer",
+      "note": "Standard modern reference for Pick's theorem, Ehrhart polynomials, Ehrhart–Macdonald reciprocity and h*-vectors."
+    }
+  ],
   "conclusion": {
     "summary": "This 206-line fully verified file (0 sorries, 0 axioms) establishes the algebraic core of the constructive proof of Pick's theorem via triangulation. The base case (primitive triangles have area 1/2), the shoelace formula, Pick's formula for rectangles, and the additivity lemma are all machine-checked. The only gap is the triangulation existence theorem, which requires computational geometry infrastructure not yet in Mathlib.",
     "implications": "Pick's theorem connects to several deep mathematical areas: the theory of lattice polytopes (Ehrhart polynomials generalize Pick to higher dimensions), algebraic K-theory (the unimodularity condition is the SL₂(ℤ) orbit), and toric geometry (the Newton polytope of a polynomial's lattice structure). The formalization here demonstrates that the algebraic content of the classical proof is entirely straightforward; the difficulty lies in the combinatorial geometry of triangulation.",

--- a/src/data/proofs/picks-theorem-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-02/meta.json
@@ -103,6 +103,29 @@
       "mathContext": "$B = \\sum_i \\gcd(|\\Delta x_i|, |\\Delta y_i|)$, with each edge contributing $\\text{card} - 1 = \\gcd(a,b)$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Beck, M.",
+        "Robins, S."
+      ],
+      "title": "Computing the Continuous Discretely: Integer-Point Enumeration in Polyhedra",
+      "year": "2015",
+      "venue": "2nd ed., Undergraduate Texts in Mathematics, Springer",
+      "note": "Standard modern reference for Pick's theorem, Ehrhart polynomials, Ehrhart–Macdonald reciprocity and h*-vectors."
+    },
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Elementary gcd / lattice-point counting on a segment."
+    }
+  ],
   "conclusion": {
     "summary": "Fully proves the GCD boundary formula for lattice points on a segment: card(segmentPoints(a,b)) = gcd(a,b)+1. The proof is machine-verified with 0 axioms and 0 sorries. Key techniques: Finset.card_image_of_injective for the cardinality, Nat.coprime_div_gcd_div_gcd + Nat.Coprime.dvd_of_dvd_mul_right for completeness. 13 theorems, 2 definitions, 245 lines.",
     "implications": "This formula is the foundation of the boundary count B in Pick's theorem. A polygon with n edges, each going from (xᵢ,yᵢ) to (xᵢ₊₁,yᵢ₊₁), has boundary count B = Σ gcd(|Δxᵢ|, |Δyᵢ|). With this formula formalized, a constructive proof of Pick's theorem (as opposed to the axiomatized version) requires formalizing triangulation of lattice polygons.",

--- a/src/data/proofs/picks-theorem-oq-03-cross-poly/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-cross-poly/meta.json
@@ -192,6 +192,27 @@
       ]
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Beck, M.",
+        "Robins, S."
+      ],
+      "title": "Computing the Continuous Discretely: Integer-Point Enumeration in Polyhedra",
+      "year": "2015",
+      "venue": "2nd ed., Undergraduate Texts in Mathematics, Springer",
+      "note": "Standard modern reference for Pick's theorem, Ehrhart polynomials, Ehrhart–Macdonald reciprocity and h*-vectors."
+    },
+    {
+      "authors": [
+        "Stanley, R.P."
+      ],
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge Studies in Advanced Mathematics 49, Cambridge University Press",
+      "note": "Ehrhart theory, h*-vectors and the algebra of lattice-point generating functions."
+    }
+  ],
   "conclusion": {
     "summary": "Cross-polytope Ehrhart theory fully formalized: 69 theorems, 0 sorries, 0 axioms. Ehrhart polynomials, reciprocity, palindromic h*-vectors, duality with hypercube, and the identity h*(z) = (1+z)^d all proved.",
     "implications": "The identity h*(z) = (1+z)^d is a hallmark of the cross-polytope's combinatorial regularity. The palindromic h*-vector characterizes reflexive polytopes, placing β_d in the same family as simplices and hypercubes.",

--- a/src/data/proofs/picks-theorem-oq-03-ext-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-ext-oq-02/meta.json
@@ -73,6 +73,27 @@
       "mathContext": "The octahedron (3D cross-polytope) is reflexive; its h*-vector $(1,3,3,1)$ is palindromic, recovered here as an instance of the general theorem."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hibi, T."
+      ],
+      "title": "Dual polytopes of rational convex polytopes",
+      "year": "1992",
+      "venue": "Combinatorica 12 (2), pp. 237–240",
+      "note": "Hibi's palindromy criterion characterizing reflexive polytopes by self-reciprocal h*-polynomials."
+    },
+    {
+      "authors": [
+        "Beck, M.",
+        "Robins, S."
+      ],
+      "title": "Computing the Continuous Discretely: Integer-Point Enumeration in Polyhedra",
+      "year": "2015",
+      "venue": "2nd ed., Undergraduate Texts in Mathematics, Springer",
+      "note": "Standard modern reference for Pick's theorem, Ehrhart polynomials, Ehrhart–Macdonald reciprocity and h*-vectors."
+    }
+  ],
   "conclusion": {
     "summary": "Hibi's palindromy phenomenon — that reflexive lattice polytopes have symmetric h*-vectors — is reduced here to a single dimension-free algebraic identity: the h*-vector (h_0,…,h_d) is palindromic iff its h*-polynomial H(X) = ∑ h_i X^i is self-reciprocal, reflect d H = H. The equivalence reflect_eq_iff_palindromic, the reflexive⇒palindromic reduction reflexive_hStar_palindromic, the normalization h_0 = h_d, and the octahedron (1,3,3,1) corollary are all fully machine-checked over an arbitrary commutative semiring (0 sorries, 0 axioms).",
     "implications": "Recasting a combinatorial symmetry as the polynomial equation reflect d H = H makes it uniform across all dimensions and polytopes and directly reusable: any future Mathlib Ehrhart generating-series infrastructure need only supply self-reciprocity — the H(t) = t^d H(1/t) consequence of Ehrhart–Macdonald reciprocity — to obtain palindromy as an immediate corollary. The development also pinpoints the exact missing piece, generating-series reciprocity, that currently separates the proved algebraic core from a from-first-principles geometric proof of Hibi's theorem.",

--- a/src/data/proofs/picks-theorem-oq-03-ext/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-ext/meta.json
@@ -87,6 +87,27 @@
       "mathContext": "$\\sum_i h^*_i = d! \\cdot \\text{Vol}(P)$. Euler: $L(0) + (-1)^d L^*(0) = 0$ for odd $d$. Binomial: $L_{\\text{cube}}(n) = n^3 + 3n^2 + 3n + 1 = \\sum_k \\binom{3}{k} n^k$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Macdonald, I.G."
+      ],
+      "title": "Polynomials associated with finite cell-complexes",
+      "year": "1971",
+      "venue": "Journal of the London Mathematical Society 4 (1), pp. 181–192",
+      "note": "Ehrhart–Macdonald reciprocity relating the Ehrhart polynomial of a polytope to that of its interior."
+    },
+    {
+      "authors": [
+        "Beck, M.",
+        "Robins, S."
+      ],
+      "title": "Computing the Continuous Discretely: Integer-Point Enumeration in Polyhedra",
+      "year": "2015",
+      "venue": "2nd ed., Undergraduate Texts in Mathematics, Springer",
+      "note": "Standard modern reference for Pick's theorem, Ehrhart polynomials, Ehrhart–Macdonald reciprocity and h*-vectors."
+    }
+  ],
   "conclusion": {
     "summary": "Ehrhart extension theory fully formalized: 30 theorems, 0 sorries, 0 axioms. h*-palindromy examples, reciprocity consequences, and interpolation uniqueness all proved.",
     "implications": "These results clarify the relationship between reflexivity, palindromy, and reciprocity in Ehrhart theory. The interpolation uniqueness theorem confirms that Ehrhart polynomials are canonically determined by their evaluations.",

--- a/src/data/proofs/picks-theorem-oq-03-product/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-product/meta.json
@@ -159,6 +159,27 @@
       "mathContext": "Consolidates the 57 theorems: product formula and its reciprocity/interior variants, valuation, quasipolynomial examples, zonotope and simplex-product identities, and the Eulerian $h^*$-vector computations."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Beck, M.",
+        "Robins, S."
+      ],
+      "title": "Computing the Continuous Discretely: Integer-Point Enumeration in Polyhedra",
+      "year": "2015",
+      "venue": "2nd ed., Undergraduate Texts in Mathematics, Springer",
+      "note": "Standard modern reference for Pick's theorem, Ehrhart polynomials, Ehrhart–Macdonald reciprocity and h*-vectors."
+    },
+    {
+      "authors": [
+        "Stanley, R.P."
+      ],
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge Studies in Advanced Mathematics 49, Cambridge University Press",
+      "note": "Ehrhart theory, h*-vectors and the algebra of lattice-point generating functions."
+    }
+  ],
   "conclusion": {
     "summary": "Ehrhart product theory fully formalized: 57 theorems, 0 sorries, 0 axioms. Product formula, quasipolynomials, valuation property, zonotopes all proved.",
     "implications": "These results show Ehrhart's counting function is a valuation on the lattice of polytopes, opening the door to inclusion-exclusion arguments in lattice point counting. The product formula enables counting in multi-dimensional product spaces efficiently.",

--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -200,6 +200,27 @@
       "mathContext": "Complete Ehrhart theory for the cross-polytope (hyperoctahedron) family β_d in dimensions 1-3."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Ehrhart, E."
+      ],
+      "title": "Sur les polyèdres rationnels homothétiques à n dimensions",
+      "year": "1962",
+      "venue": "Comptes Rendus de l'Académie des Sciences (Paris) 254, pp. 616–618",
+      "note": "Introduces the Ehrhart polynomial counting lattice points in dilates of a lattice polytope."
+    },
+    {
+      "authors": [
+        "Beck, M.",
+        "Robins, S."
+      ],
+      "title": "Computing the Continuous Discretely: Integer-Point Enumeration in Polyhedra",
+      "year": "2015",
+      "venue": "2nd ed., Undergraduate Texts in Mathematics, Springer",
+      "note": "Standard modern reference for Pick's theorem, Ehrhart polynomials, Ehrhart–Macdonald reciprocity and h*-vectors."
+    }
+  ],
   "conclusion": {
     "summary": "Ehrhart theory is formalized with an axiomatized LatticePolytope structure, concrete polynomial verifications for cubes, simplices, and octahedra, and a derivation of Pick's theorem as the d=2 specialization. The h*-vector framework provides an alternative combinatorial encoding with Stanley's nonnegativity theorem.",
     "implications": "This formalization provides the natural framework for higher-dimensional discrete geometry in Lean. The Ehrhart-Macdonald reciprocity and h*-vector theory open paths toward formalizing deeper results in enumerative combinatorics and toric geometry.",


### PR DESCRIPTION
Adds a top-level `references` array to 9 open-question descendants of **picks-theorem** that previously had none.

## Coverage
Lattice-point enumeration: primitive triangulation of lattice triangles, the 2D Ehrhart polynomial derived via Pick's theorem, the gcd boundary formula for lattice points on a segment, and higher-dimensional Ehrhart theory — cross-polytopes, product formulas, quasipolynomials, Ehrhart–Macdonald reciprocity, and palindromic h*-vectors / reflexive polytopes via Hibi's algebraic criterion.

## Method
Cited to Beck–Robins (*Computing the Continuous Discretely*, the standard modern reference), the primary sources Pick (1899), Ehrhart (1962), Macdonald (1971) and Hibi (1992), and Stanley's *Enumerative Combinatorics*. 2 references per entry, matched to each `description`.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.