### PR TITLE
Enrich birthday-problem OQ cluster: add references to 8 entries

### DIFF
--- a/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
@@ -156,6 +156,27 @@
       "mathContext": "$\\text{Var}(X) = \\binom{n}{2}(d-1)/d^2 \\leq \\binom{n}{2}/d = E[X]$ when $d \\geq 1$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Feller, W."
+      ],
+      "title": "An Introduction to Probability Theory and Its Applications, Volume I",
+      "year": "1968",
+      "venue": "3rd ed., Wiley",
+      "note": "Classic treatment of the birthday problem and occupancy / collision distributions."
+    },
+    {
+      "authors": [
+        "Motwani, R.",
+        "Raghavan, P."
+      ],
+      "title": "Randomized Algorithms",
+      "year": "1995",
+      "venue": "Cambridge University Press",
+      "note": "The birthday paradox and collision bounds in the algorithmic setting."
+    }
+  ],
   "conclusion": {
     "summary": "This file provides a complete Lean formalization of X = number of birthday collision pairs, going far beyond the classic question of whether X=0. It proves X=0 ↔ injective, counts zero-collision assignments via an Equiv chain, gives Pr(X=0) = descFactorial(d,n)/d^n, decomposes X as a sum of indicators, bounds X ≤ C(n,2), and proves E[X] = C(n,2)/d assuming three intermediate lemmas. The variance bound Var(X) ≤ E[X] is imported from BirthdayProblemOQ01.lean, completing a comprehensive distributional portrait of X.",
     "implications": "The indicator decomposition X = Σ I_{ij} and the double-counting argument Σ_f X(f) = C(n,2)·d^{n-1} constitute a formal proof of E[X] = C(n,2)/d by a method entirely independent of linearity of expectation. The two approaches — top-down via linearity (BirthdayProblemOQ01.lean) and bottom-up via double counting (this file) — formally agree, providing mutual verification. The sub-Poisson variance bound Var(X) ≤ E[X] formalizes the intuition that collision indicators I_{ij} are negatively correlated. The unification theorem zero_collision_fraction shows that injection counting (BirthdayProblem.lean) and collision-count-zero counting (this file) yield identical probabilities, connecting the two main formalizations in the gallery.",

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -74,6 +74,30 @@
       "summary": "uniformAveraging_mem_doublyStochastic: the all-1/d matrix is doubly stochastic. one_div_card_le_sum_sq: 1/d ≤ ∑ qᵢ² for probability vectors, obtained by applying the global inequality to the all-1/d matrix whose output is the uniform vector."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Marshall, A.W.",
+        "Olkin, I.",
+        "Arnold, B.C."
+      ],
+      "title": "Inequalities: Theory of Majorization and Its Applications",
+      "year": "2011",
+      "venue": "2nd ed., Springer Series in Statistics",
+      "note": "Standard reference for Schur-convexity, majorization and doubly-stochastic smoothing."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "Majorization and the doubly-stochastic characterization underlying Schur-convexity."
+    }
+  ],
   "conclusion": {
     "summary": "Globalized the parent's local smoothing transfer into the full Schur-convexity of the collision probability in doubly-stochastic (Hardy–Littlewood–Pólya) form: for every doubly stochastic matrix D, ∑ᵢ (Dq)ᵢ² ≤ ∑ᵢ qᵢ². The proof is per-row Jensen for x² (each output coordinate is a convex combination via row-stochasticity) followed by a column-stochastic collapse of the double sum. As a corollary the uniform distribution minimizes collision (1/d ≤ ∑ qᵢ²), recovering the parent chain's sharp lower endpoint as the bottom of the majorization order. 135 lines, 3 theorems, 0 sorries, 0 axioms.",
     "implications": "Passing a vector through any averaging (doubly stochastic) operator can only decrease its sum of squares — the operator form of Schur-convexity of ∑ xᵢ². Via Birkhoff–von Neumann and the HLP theorem this is exactly the majorization statement p ≺ q ⟹ ∑ pᵢ² ≤ ∑ qᵢ², so the parent's two extremal endpoints (uniform minimum, concentration maximum) sit at the two ends of a single monotone order rather than being isolated bounds. The uniform-minimizer corollary shows the bottom endpoint falling out as one instance at the all-1/d matrix.",

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -90,6 +90,29 @@
       "summary": "smoothing_sum_sq_le: replacing the values at two distinct coordinates by their average weakly decreases ∑ f². The sum difference collapses (off {i,j} the values are unchanged) to the smoothing atom evaluated at the two coordinates."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Marshall, A.W.",
+        "Olkin, I.",
+        "Arnold, B.C."
+      ],
+      "title": "Inequalities: Theory of Majorization and Its Applications",
+      "year": "2011",
+      "venue": "2nd ed., Springer Series in Statistics",
+      "note": "Standard reference for Schur-convexity, majorization and doubly-stochastic smoothing."
+    },
+    {
+      "authors": [
+        "Klamkin, M.S.",
+        "Newman, D.J."
+      ],
+      "title": "Extensions of the birthday surprise",
+      "year": "1967",
+      "venue": "Journal of Combinatorial Theory 3 (3), pp. 279–282",
+      "note": "Extremality of the uniform distribution for multi-coincidence birthday problems."
+    }
+  ],
   "conclusion": {
     "summary": "Proved the complementary half of the two-draw collision extremality: the sharp upper bound ∑ᵢ pᵢ² ≤ maxᵢ pᵢ with equality iff the distribution is supported on equal-mass atoms (pᵢ ∈ {0, M}); the two-sided bound 1/d ≤ ∑ pᵢ² ≤ maxᵢ pᵢ (lower bound re-derived self-contained); and the smoothing/transfer atom showing that equalizing two coordinates weakly decreases collision, strictly unless they were equal. 189 lines, 9 theorems, 0 sorries, 0 axioms.",
     "implications": "Collision probability lives in [1/d, maxᵢ pᵢ] on the simplex, with the two endpoints realized by the two opposite extremes — global uniformity (minimum) and concentration on equal-mass atoms (maximum). The smoothing inequality identifies the exact local move that decreases collision: any 'Robin Hood' transfer that equalizes two outcomes. Iterating it is the majorization proof that uniform is the unique minimizer, so this entry supplies the Schur-convexity mechanism behind the parent's result rather than re-stating the bound.",

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02/meta.json
@@ -92,6 +92,38 @@
       "summary": "no_collision_le: 1 − ∑ pᵢ² ≤ 1 − 1/d. no_collision_eq_iff: equality iff uniform. Restates the collision bound in complementary (no-collision) form."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Munford, A.G."
+      ],
+      "title": "A note on the uniformity assumption in the birthday problem",
+      "year": "1977",
+      "venue": "The American Statistician 31 (3), p. 119",
+      "note": "Shows the uniform distribution minimizes birthday-collision probability."
+    },
+    {
+      "authors": [
+        "Klamkin, M.S.",
+        "Newman, D.J."
+      ],
+      "title": "Extensions of the birthday surprise",
+      "year": "1967",
+      "venue": "Journal of Combinatorial Theory 3 (3), pp. 279–282",
+      "note": "Extremality of the uniform distribution for multi-coincidence birthday problems."
+    },
+    {
+      "authors": [
+        "Marshall, A.W.",
+        "Olkin, I.",
+        "Arnold, B.C."
+      ],
+      "title": "Inequalities: Theory of Majorization and Its Applications",
+      "year": "2011",
+      "venue": "2nd ed., Springer Series in Statistics",
+      "note": "Standard reference for Schur-convexity, majorization and doubly-stochastic smoothing."
+    }
+  ],
   "conclusion": {
     "summary": "Proved that the uniform distribution minimizes the two-draw collision probability: ∑ᵢ pᵢ² ≥ 1/d for every probability vector p on d outcomes, with equality iff p is uniform. The complementary no-collision probability 1 − ∑ pᵢ² is correspondingly maximized at uniform. 140 lines, 7 theorems, 0 sorries, 0 axioms — the proof rests entirely on the variance identity ∑ pᵢ² − 1/d = ∑ (pᵢ − 1/d)².",
     "implications": "This is the n = 2 instance of the Munford/Klamkin–Newman non-uniform birthday extremality: among all birthday distributions on d days, uniform is the least likely to produce a shared birthday. Practically, any real-world seasonal bias *increases* the probability of a coincidence, so the textbook uniform calculation is a conservative (lower) bound on the true collision probability. The variance-identity proof also yields the exact minimizer characterization, not just the bound.",

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/meta.json
@@ -103,6 +103,27 @@
       "summary": "collisionProb_one: collisionProb 1 d = 0 (no collision with a single person). collisionProb_nonneg / collisionProb_le_one: 0 ≤ collisionProb k d ≤ 1 for k ≤ d+1."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Feller, W."
+      ],
+      "title": "An Introduction to Probability Theory and Its Applications, Volume I",
+      "year": "1968",
+      "venue": "3rd ed., Wiley",
+      "note": "Classic treatment of the birthday problem and occupancy / collision distributions."
+    },
+    {
+      "authors": [
+        "Motwani, R.",
+        "Raghavan, P."
+      ],
+      "title": "Randomized Algorithms",
+      "year": "1995",
+      "venue": "Cambridge University Press",
+      "note": "The birthday paradox and collision bounds in the algorithmic setting."
+    }
+  ],
   "conclusion": {
     "summary": "This file formalizes the qualitative heart of the birthday paradox: the collision probability collisionProb(k,d) = 1 − ∏_{i<k}(1 − i/d) is non-decreasing in the number of people k for 1 ≤ k ≤ d (collisionProb_monotone), so growing the group can only make a shared birthday more likely. The proof rests on a single product recurrence P(k+1) = P(k)·(1 − k/d) and the elementary fact that each conditional avoidance factor lies in [0,1]; Nat.le_induction lifts the one-step bound to the global antitone statement, and taking complements yields the headline. Companion lemmas certify collisionProb is a genuine probability (collisionProb 1 d = 0 and 0 ≤ collisionProb ≤ 1). Everything is machine-checked with 0 axioms and 0 sorries.",
     "implications": [

--- a/src/data/proofs/birthday-problem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01/meta.json
@@ -88,6 +88,27 @@
       "endLine": 229
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Feller, W."
+      ],
+      "title": "An Introduction to Probability Theory and Its Applications, Volume I",
+      "year": "1968",
+      "venue": "3rd ed., Wiley",
+      "note": "Classic treatment of the birthday problem and occupancy / collision distributions."
+    },
+    {
+      "authors": [
+        "Motwani, R.",
+        "Raghavan, P."
+      ],
+      "title": "Randomized Algorithms",
+      "year": "1995",
+      "venue": "Cambridge University Press",
+      "note": "The birthday paradox and collision bounds in the algorithmic setting."
+    }
+  ],
   "conclusion": {
     "summary": "Proved ∏(1-i/d) ≥ exp(-k(k-1)/(2d) - k²(k-1)²/(4d²)) under 2(k-1) ≤ d. Combined with OQ-02's upper bound, this gives a two-sided exponential approximation for the birthday probability. 229 lines, 8 theorems, 0 sorries, 0 axioms.",
     "implications": "The two-sided bound exp(-k(k-1)/(2d) - k²(k-1)²/(4d²)) ≤ P(k,d) ≤ exp(-k(k-1)/(2d)) shows that the birthday probability is asymptotically exp(-k(k-1)/(2d)) in the standard regime k ~ √d. The error term k²(k-1)²/(4d²) is O(k⁴/d²) = O(1) when k = O(d^{1/2}), confirming the classical approximation.",

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
@@ -151,6 +151,27 @@
       "mathContext": "native_decide confirms n=12 despite the loose asymptotic prediction n≈7.5 — asymptotics are inaccurate at small d."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "McKinney, E.H."
+      ],
+      "title": "Generalized birthday problem",
+      "year": "1966",
+      "venue": "American Mathematical Monthly 73 (4), pp. 385–387",
+      "note": "The generalized (k-coincidence) birthday problem and its counting recurrences."
+    },
+    {
+      "authors": [
+        "Diaconis, P.",
+        "Mosteller, F."
+      ],
+      "title": "Methods for studying coincidences",
+      "year": "1989",
+      "venue": "Journal of the American Statistical Association 84 (408), pp. 853–861",
+      "note": "Asymptotics of k-fold birthday coincidences, including the (k=3) threshold scaling."
+    }
+  ],
   "conclusion": {
     "summary": "The slot-based recurrence reduces birthday counting from O(d^n) to O(n²). The definition is computable, the capacity theorem and polynomial bound are proved, the general n=3 formula birthdayCount3 3 d = d³ - d is proved, and thresholds for d=3,4,5,7,10,365 are all machine-verified by decide/native_decide. Fully verified: 0 axioms, 0 sorries.",
     "implications": "The slot-based recurrence R(n, e, s) is the Lean formalization of the standard dynamic programming approach to birthday counting. The O(n²) state space is optimal: by the capacity theorem, states with n > 2e+s are unreachable, and the remaining states form a triangular region of size O(n²). This framework extends to k-way coincidences for general k by tracking a k-level histogram instead of just (e, s).",

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -61,6 +61,27 @@
       "Parent proof: birthday-problem-oq-03-oq-01 (extension-counting framework)"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Diaconis, P.",
+        "Mosteller, F."
+      ],
+      "title": "Methods for studying coincidences",
+      "year": "1989",
+      "venue": "Journal of the American Statistical Association 84 (408), pp. 853–861",
+      "note": "Asymptotics of k-fold birthday coincidences, including the (k=3) threshold scaling."
+    },
+    {
+      "authors": [
+        "McKinney, E.H."
+      ],
+      "title": "Generalized birthday problem",
+      "year": "1966",
+      "venue": "American Mathematical Monthly 73 (4), pp. 385–387",
+      "note": "The generalized (k-coincidence) birthday problem and its counting recurrences."
+    }
+  ],
   "conclusion": {
     "summary": "This file formalizes the k=3 birthday threshold asymptotics in Lean 4. The key result is asympThreshold(d) = (6d² ln 2)^{1/3}, proved from the expected-triples formula E(n,d) = C(n,3)/d². The exact scaling ratio, order bounds, numerical bounds for d=365, and comparison with the k=2 threshold are all fully proved. The Poisson approximation (connecting the asymptotic to the actual probability) is axiomatized.",
     "implications": "**Connection to parent proofs**: The parent (birthday-problem-oq-03-oq-01) provides the extension-counting framework and exact threshold n*(365) = 88. This file shows the asymptotic ≈ 82–84 differs by ~7% from the exact value, illustrating the error in the leading-term Poisson approximation.\\n\\n**General k-way scaling**: The method generalizes: for k-way coincidences, E(n,d) = C(n,k)/d^{k-1} ≈ n^k/(k! d^{k-1}), giving threshold n*(d) ~ (k! d^{k-1} ln 2)^{1/k} with exponent (k-1)/k. This is proved in general_threshold_exponent.\\n\\n**Resolving the Poisson sorry**: The Chen-Stein method (Arratia-Goldstein-Gordon 1989) gives total variation bounds between the triple-coincidence count and a Poisson(C(n,3)/d²) variable. The main missing ingredient in Lean is a formalization of the Chen-Stein lemma for positively associated indicator random variables.",


### PR DESCRIPTION
Adds a top-level `references` array to 8 open-question descendants of **birthday-problem** that previously had none.

## Coverage
The collision-count distribution X and its expectation, two-sided exponential bounds and monotonicity of the collision probability, the non-uniform extremality results (uniform distribution minimizes collisions; Schur-convexity of C(p)=∑pᵢ² via doubly-stochastic smoothing), and the k=3 multi-coincidence slot-recurrence and threshold asymptotics n*(d) ~ (6d² ln 2)^{1/3}.

## Method
Cited to Feller and Motwani–Raghavan (birthday/occupancy), Marshall–Olkin–Arnold and Hardy–Littlewood–Pólya (majorization / Schur-convexity), Munford (1977) and Klamkin–Newman (1967) (non-uniform extremality), and Diaconis–Mosteller (1989) / McKinney (1966) (k-coincidence asymptotics). 2–3 references per entry, matched to each `description`.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.