### PR TITLE
Enrich mantel-theorem OQ cluster: add references to 7 entries

### DIFF
--- a/src/data/proofs/mantel-theorem-oq-01/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-01/meta.json
@@ -57,6 +57,38 @@
       "The 2n/5 threshold is sharp, and the balanced blow-up of the 5-cycle C₅ is the single example that certifies it: it is triangle-free, non-bipartite, and 2n/5-regular, so it simultaneously shows the AES hypothesis cannot be relaxed below 2n/5 and pins down the exact constant the degree-cleaning step must clear before invoking the lemma."
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Andrásfai, B.",
+        "Erdős, P.",
+        "Sós, V.T."
+      ],
+      "title": "On the connection between chromatic number, maximal clique and minimal degree of a graph",
+      "year": "1974",
+      "venue": "Discrete Mathematics 8 (3), pp. 205–218",
+      "note": "The minimum-degree threshold for triangle-free graphs (Andrásfai–Erdős–Sós)."
+    },
+    {
+      "authors": [
+        "Erdős, P.",
+        "Simonovits, M."
+      ],
+      "title": "A limit theorem in graph theory",
+      "year": "1966",
+      "venue": "Studia Scientiarum Mathematicarum Hungarica 1, pp. 51–57",
+      "note": "The Erdős–Simonovits stability theorem for extremal graphs."
+    },
+    {
+      "authors": [
+        "Bollobás, B."
+      ],
+      "title": "Extremal Graph Theory",
+      "year": "1978",
+      "venue": "London Mathematical Society Monographs 11, Academic Press",
+      "note": "Standard reference for Mantel's and Turán's theorems and the Erdős–Simonovits stability theory."
+    }
+  ],
   "conclusion": {
     "summary": "This entry formalizes, with no axioms or sorries, the Andrásfai–Erdős–Sós min-degree ingredient underlying Erdős–Simonovits stability for triangle-free graphs: a triangle-free graph with minimum degree > 2n/5 is bipartite (the r = 2 case of Mathlib's colorable_of_cliqueFree_lt_minDegree), together with its contrapositive sparse-vertex form. It is a verified partial result, not the full stability theorem.",
     "implications": "Isolates the precise Mathlib lemma that supplies the structural half of the stability argument and packages it in the exact shape the degree-cleaning proof consumes, lowering the barrier to a future full formalization. The remaining work is a self-contained counting problem (bounding the edges lost when low-degree vertices are deleted) plus an edit-distance accounting step.",

--- a/src/data/proofs/mantel-theorem-oq-02/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-02/meta.json
@@ -62,6 +62,35 @@
       "Mantel's ⌊n²/4⌋ bound is not re-proved here from triangle-free arithmetic but recovered as the literal r = 2 instance of the general theorem (simpa collapses 2·2 to 4), giving a formal proof that Mantel is a corollary of Turán inside the gallery."
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Turán, P."
+      ],
+      "title": "On an extremal problem in graph theory (Hungarian)",
+      "year": "1941",
+      "venue": "Matematikai és Fizikai Lapok 48, pp. 436–452",
+      "note": "Turán's theorem, the K_{r+1}-free edge bound generalizing Mantel."
+    },
+    {
+      "authors": [
+        "Bollobás, B."
+      ],
+      "title": "Extremal Graph Theory",
+      "year": "1978",
+      "venue": "London Mathematical Society Monographs 11, Academic Press",
+      "note": "Standard reference for Mantel's and Turán's theorems and the Erdős–Simonovits stability theory."
+    },
+    {
+      "authors": [
+        "West, D.B."
+      ],
+      "title": "Introduction to Graph Theory",
+      "year": "2001",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Textbook development of Mantel/Turán extremal bounds and the Turán graph."
+    }
+  ],
   "conclusion": {
     "summary": "This entry assembles, with no axioms or sorries, the clean closed-form Turán bound for an arbitrary K_{r+1}-free graph — 2r·e(G) ≤ (r−1)·n² and the rational e(G) ≤ (1 − 1/r)·n²/2 — by composing Mathlib's exact arbitrary-graph bound with its clean Turán-graph bound. It certifies sharpness via the Turán graph and recovers the gallery's Mantel ⌊n²/4⌋ bound as the literal r = 2 corollary.",
     "implications": "Supplies the 'textbook' statement of Turán's theorem that Mathlib leaves implicit, in a form directly reusable wherever an extremal edge bound is needed, and formally ties the mantel-theorem entry to its r-fold generalization.",

--- a/src/data/proofs/mantel-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-03-oq-01/meta.json
@@ -79,6 +79,26 @@
       "The maximum-degree value ⌈n/2⌉ is genuinely not uniform across n (it fails for n = 1, where the single isolated vertex has degree 0): only the minimum-degree statement — the one the sharpness question asks about — holds for every n ≥ 1, so the entry states the universally-true minimum and the safe degree upper bound turanTwo_degree_le."
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Mantel, W."
+      ],
+      "title": "Problem 28",
+      "year": "1907",
+      "venue": "Wiskundige Opgaven 10, pp. 60–61",
+      "note": "Original statement: a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges, attained by the balanced complete bipartite graph."
+    },
+    {
+      "authors": [
+        "Bollobás, B."
+      ],
+      "title": "Extremal Graph Theory",
+      "year": "1978",
+      "venue": "London Mathematical Society Monographs 11, Academic Press",
+      "note": "Standard reference for Mantel's and Turán's theorems and the Erdős–Simonovits stability theory."
+    }
+  ],
   "conclusion": {
     "summary": "A complete, axiom-free and sorry-free certificate that Mantel's minimum-degree bound ⌊n/2⌋ is sharp: the r = 2 Turán graph turanGraph n 2 (the balanced complete bipartite graph) is triangle-free and, for every n ≥ 1, has minimum degree exactly ⌊n/2⌋. The exact degree sequence (⌊n/2⌋ at even vertices, ⌈n/2⌉ at odd vertices) is computed along the way, together with reusable residue-counting lemmas.",
     "implications": "Closes the loop on the parent minimum-degree corollary: the inequality exists_degree_le_card_div_two is now known to be attained, so ⌊n/2⌋ is the exact extremal minimum degree of a triangle-free graph. The bridge card_fin_filter_val and the closed forms count_mod_two_eq_zero/one are reusable for any parity-counting argument over Fin n.",

--- a/src/data/proofs/mantel-theorem-oq-03/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-03/meta.json
@@ -65,6 +65,35 @@
       "Read contrapositively the result is a Turán-type forcing principle — minimum degree > n/2 guarantees a triangle — which is the local analogue of 'too many edges force a triangle'."
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Mantel, W."
+      ],
+      "title": "Problem 28",
+      "year": "1907",
+      "venue": "Wiskundige Opgaven 10, pp. 60–61",
+      "note": "Original statement: a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges, attained by the balanced complete bipartite graph."
+    },
+    {
+      "authors": [
+        "Bollobás, B."
+      ],
+      "title": "Extremal Graph Theory",
+      "year": "1978",
+      "venue": "London Mathematical Society Monographs 11, Academic Press",
+      "note": "Standard reference for Mantel's and Turán's theorems and the Erdős–Simonovits stability theory."
+    },
+    {
+      "authors": [
+        "West, D.B."
+      ],
+      "title": "Introduction to Graph Theory",
+      "year": "2001",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Textbook development of Mantel/Turán extremal bounds and the Turán graph."
+    }
+  ],
   "conclusion": {
     "summary": "A complete, axiom-free and sorry-free formalization of the minimum-degree corollary of Mantel's theorem: every triangle-free simple graph on a nonempty vertex set has a vertex of degree at most ⌊n/2⌋, together with the supporting neighbourhood-disjointness and degree-sum lemmas and the Turán-type contrapositive (large minimum degree forces a triangle).",
     "implications": "Provides the reusable local ingredients — disjoint neighbourhoods of adjacent vertices and the deg u + deg v ≤ n edge inequality — that underlie inductive proofs of Mantel's theorem and several degree-cleaning arguments in extremal graph theory, all packaged independently of the global edge bound.",

--- a/src/data/proofs/mantel-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-04-oq-01/meta.json
@@ -71,6 +71,26 @@
       "omega treats the products k·r and r·k as distinct opaque atoms because both factors are variables; supplying the commutativity equation by hand (Nat.mul_comm) is the small but essential step that lets the linear divmod bounds go through."
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Turán, P."
+      ],
+      "title": "On an extremal problem in graph theory (Hungarian)",
+      "year": "1941",
+      "venue": "Matematikai és Fizikai Lapok 48, pp. 436–452",
+      "note": "Turán's theorem, the K_{r+1}-free edge bound generalizing Mantel."
+    },
+    {
+      "authors": [
+        "Bollobás, B."
+      ],
+      "title": "Extremal Graph Theory",
+      "year": "1978",
+      "venue": "London Mathematical Society Monographs 11, Academic Press",
+      "note": "Standard reference for Mantel's and Turán's theorems and the Erdős–Simonovits stability theory."
+    }
+  ],
   "conclusion": {
     "summary": "A complete, axiom-free and sorry-free realization of Mathlib's Turán graph turanGraph n r as a genuine complete r-partite graph for arbitrary n: the parts are the r residue classes mod r, the graph is shown to be complete multipartite, and the exact balanced part sizes (n+r−1−j)/r = ⌈(n−j)/r⌉ are computed and verified to sum to n. This answers the general-r open question posed by mantel-theorem-oq-04, of which the r = 2 complete-bipartite case was the special instance.",
     "implications": "Provides a reusable bridge between Mathlib's residue-based turanGraph and the structural completeMultipartiteGraph / IsCompleteMultipartite API for every r and every n — a strict generalization of the equipartite-only completeEquipartiteGraph.turanGraph. The sigmaFiberEquiv-of-a-colouring pattern (parts as colour fibres) is a clean, HEq-free template for identifying any vertex-coloured graph with a complete multipartite graph; the constructive fibre enumeration gives a model for computing balanced residue-class cardinalities without a dedicated counting lemma.",

--- a/src/data/proofs/mantel-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-04-oq-02/meta.json
@@ -69,6 +69,26 @@
       "Triangle-freeness of the extremal graph needs no combinatorics — it is bipartite, hence 2-colourable (the parity colouring), and any 2-colourable graph is K₃-free by Colorable.cliqueFree."
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Mantel, W."
+      ],
+      "title": "Problem 28",
+      "year": "1907",
+      "venue": "Wiskundige Opgaven 10, pp. 60–61",
+      "note": "Original statement: a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges, attained by the balanced complete bipartite graph."
+    },
+    {
+      "authors": [
+        "Bollobás, B."
+      ],
+      "title": "Extremal Graph Theory",
+      "year": "1978",
+      "venue": "London Mathematical Society Monographs 11, Academic Press",
+      "note": "Standard reference for Mantel's and Turán's theorems and the Erdős–Simonovits stability theory."
+    }
+  ],
   "conclusion": {
     "summary": "A complete, axiom-free and sorry-free proof that Mantel's bound is sharp: the complete bipartite edge-count formula #E(K_{V,W}) = |V|·|W|, the identity ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋, and their combination #E(turanGraph n 2) = ⌊n²/4⌋, packaged with triangle-freeness into mantel_bound_attained. This is the existence/tightness direction missing from the equality characterizations of the sibling entries.",
     "implications": "card_edgeFinset_completeBipartiteGraph is a reusable Mathlib-gap lemma (the bipartite analogue of card_edgeFinset_completeEquipartiteGraph) good for any extremal-graph edge count. Together with the upper bound mantel_card_edgeFinset_le it certifies that ⌊n²/4⌋ is the exact extremal number of edges, not merely an upper bound.",

--- a/src/data/proofs/mantel-theorem-oq-04/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-04/meta.json
@@ -64,6 +64,35 @@
       "Every arithmetic obligation in the bijection (2k < n, v/2 bounds, round trips, parity of 2k and 2k+1) is linear in n, k, v once the parities are exposed, so omega discharges all of them after simp normalizes the Fin coercions."
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Mantel, W."
+      ],
+      "title": "Problem 28",
+      "year": "1907",
+      "venue": "Wiskundige Opgaven 10, pp. 60–61",
+      "note": "Original statement: a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges, attained by the balanced complete bipartite graph."
+    },
+    {
+      "authors": [
+        "Bollobás, B."
+      ],
+      "title": "Extremal Graph Theory",
+      "year": "1978",
+      "venue": "London Mathematical Society Monographs 11, Academic Press",
+      "note": "Standard reference for Mantel's and Turán's theorems and the Erdős–Simonovits stability theory."
+    },
+    {
+      "authors": [
+        "West, D.B."
+      ],
+      "title": "Introduction to Graph Theory",
+      "year": "2001",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Textbook development of Mantel/Turán extremal bounds and the Turán graph."
+    }
+  ],
   "conclusion": {
     "summary": "A complete, axiom-free and sorry-free identification of Mantel's extremal graph with the balanced complete bipartite graph: turanGraph n 2 ≃g K_{⌈n/2⌉,⌊n/2⌋} for all n, together with the resulting complete-bipartite form of the Mantel equality characterization. This upgrades the abstract Turán-graph statement of mantel-theorem-oq-02 to the classical textbook phrasing with the unique extremal graph named explicitly.",
     "implications": "Supplies a reusable bridge between Mathlib's residue-based turanGraph (at r = 2) and the complete bipartite graph, valid for arbitrary, possibly odd, n with unequal parts — a strict generalization of the equipartite-only completeEquipartiteGraph.turanGraph. The interleaved parity bijection and the transport pattern are directly reusable for analogous identifications of turanGraph n r with complete r-partite graphs.",


### PR DESCRIPTION
Adds a top-level `references` array to 7 open-question descendants of **mantel-theorem** that previously had none.

## Coverage
Extremal graph theory around Mantel's triangle-free edge bound ⌊n²/4⌋: Turán's K_{r+1}-free generalization, the minimum-degree corollary and its sharpness via the Turán graph, the identification of the Turán graph as a complete r-partite graph, the unique extremal balanced complete bipartite graph, and the Andrásfai–Erdős–Sós / Erdős–Simonovits stability ingredient.

## Method
Cited to Bollobás (*Extremal Graph Theory*) and West, plus the primary sources Mantel (1907), Turán (1941), Erdős–Simonovits (1966) and Andrásfai–Erdős–Sós (1974). 2–3 references per entry, matched to each `description`.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.