### PR TITLE
research(seeker): replenish pool with 7 diverse verified-parent OQ children

### DIFF
--- a/research/problems/cramers-rule-oq-06/problem.md
+++ b/research/problems/cramers-rule-oq-06/problem.md
@@ -1,0 +1,139 @@
+# Problem: The Adjugate Algebra - Multiplicative and Conjugation Identities Behind Cramer's Rule
+
+**Slug**: cramers-rule-oq-06
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: cramers-rule
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\mathrm{adj}(AB)=\mathrm{adj}(B)\,\mathrm{adj}(A),\quad
+\mathrm{adj}(A^k)=\mathrm{adj}(A)^k,\quad
+\det(\mathrm{adj}\,A)=(\det A)^{n-1},\quad
+\mathrm{adj}(\mathrm{adj}\,A)=(\det A)^{n-2}A\ (n\neq 1),
+$$
+and the original corollary $\mathrm{adj}(UAU^{-1}) = \mathrm{adj}(U)^{-1}\,\mathrm{adj}(A)\,\mathrm{adj}(U)$: similar matrices have similar adjugates.
+
+### Plain Language
+
+Cramer's rule rests on the single adjugate identity $A\cdot\mathrm{adj}(A)=\det(A)I$. This
+child studies the adjugate as an operation in its own right, proving its *compositional*
+algebra: it is an anti-homomorphism on products, commutes with transpose and powers,
+scales its determinant by $(\det A)^{n-1}$, and is an involution up to a determinant factor.
+As an original corollary, the adjugate of a conjugate is the conjugate of the adjugate — so
+the adjugate descends to conjugacy classes.
+
+### Why This Matters
+
+The parent proves Cramer's rule from $A\cdot\mathrm{adj}(A)=\det(A)I$. This child assembles
+the adjugate's algebraic laws and proves two original results (units have invertible
+adjugates that respect inversion; similar matrices have similar adjugates) not present in
+Mathlib and distinct from siblings oq-04 (two-sided identity, singular case) and oq-05
+(det/trace/charpoly conjugation invariance).
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `cramers-rule` is verified (0-axiom).
+- Mathlib has `Matrix.adjugate_mul_distrib`, `adjugate_pow`, `det_adjugate`,
+  `adjugate_adjugate`, `adjugate_one`.
+
+### What's Still Open
+
+- The target theorems below (currently `sorry`), including the two original conjugation
+  results.
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child. Category: **companion / corollary**.
+
+## Target Lean Sketch
+
+```lean
+open Matrix
+variable {n R : Type*} [Fintype n] [DecidableEq n] [CommRing R]
+
+theorem adjugate_anti_mul (A B : Matrix n n R) :
+    (A * B).adjugate = B.adjugate * A.adjugate := by
+  sorry -- Matrix.adjugate_mul_distrib
+
+theorem det_adjugate' (A : Matrix n n R) :
+    A.adjugate.det = A.det ^ (Fintype.card n - 1) := by
+  sorry -- Matrix.det_adjugate
+
+theorem adjugate_adjugate' (A : Matrix n n R) (h : Fintype.card n ≠ 1) :
+    A.adjugate.adjugate = A.det ^ (Fintype.card n - 2) • A := by
+  sorry -- Matrix.adjugate_adjugate
+
+/-- ORIGINAL: adj sends mutually-inverse pairs to mutually-inverse pairs. -/
+theorem adjugate_mul_adjugate_inv {A B : Matrix n n R} (h : A * B = 1) (h' : B * A = 1) :
+    A.adjugate * B.adjugate = 1 ∧ B.adjugate * A.adjugate = 1 := by
+  sorry -- ← adjugate_mul_distrib; simp [h, h', adjugate_one]
+
+/-- ORIGINAL corollary: similar matrices have similar adjugates. -/
+theorem adjugate_conj (A U Uinv : Matrix n n R)
+    (h : U * Uinv = 1) (h' : Uinv * U = 1) :
+    (U * A * Uinv).adjugate = Uinv.adjugate * A.adjugate * U.adjugate := by
+  sorry -- adjugate_mul_distrib twice + reassociate
+```
+
+Plus a concrete `Fin 2` example via `adjugate_fin_two_of`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `cramers-rule` | Parent: Cramer's rule | adjugate, determinants |
+| `cramers-rule-oq-04` | Sibling: two-sided adjugate identity, singular case | adjugate |
+| `cayley-hamilton` | Uses adjugate / characteristic polynomial | matrix algebra |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 5/10  |  **Tractability**: 9/10  |  **Tier**: B
+
+**Justification**: Most content is curated Mathlib wrappers plus two short original lemmas
+(~5 lines each) built by chaining `adjugate_mul_distrib`. No hard tactic work; stays
+`verified`, `axiomCount: 0`.
+
+### Suggested First Steps
+
+1. Wrap `adjugate_mul_distrib`, `adjugate_pow`, `det_adjugate`, `adjugate_adjugate` as the
+   named identities.
+2. Prove `adjugate_mul_adjugate_inv` using `← adjugate_mul_distrib` and `adjugate_one`.
+3. Prove `adjugate_conj` by chaining `adjugate_mul_distrib` twice; add the `Fin 2` example.
+
+## References
+
+### Mathlib
+
+- `Matrix.adjugate_mul_distrib`, `adjugate_pow`, `adjugate_transpose` — LinearAlgebra/Matrix/Adjugate.lean
+- `Matrix.det_adjugate`, `adjugate_adjugate`, `adjugate_one`, `adjugate_fin_two_of` — LinearAlgebra/Matrix/Adjugate.lean
+- `Matrix.mul_adjugate` — LinearAlgebra/Matrix/Adjugate.lean (ties back to parent)
+
+### Literature
+
+- Standard linear-algebra treatments of the adjugate/classical adjoint.
+
+## Metadata
+
+```yaml
+tags:
+  - linear-algebra
+  - adjugate
+  - cramers-rule
+  - determinants
+related_proofs:
+  - cramers-rule
+  - cramers-rule-oq-04
+  - cayley-hamilton
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/de-moivre-oq-06/problem.md
+++ b/research/problems/de-moivre-oq-06/problem.md
@@ -1,0 +1,129 @@
+# Problem: Finite Geometric Sum of Complex Exponentials and the Lagrange Trigonometric Identity
+
+**Slug**: de-moivre-oq-06
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: de-moivre
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\sum_{k=0}^{n-1} e^{ik\theta} = \frac{e^{in\theta}-1}{e^{i\theta}-1}
+\quad(e^{i\theta}\neq 1),
+\qquad
+\sum_{k=0}^{n-1}\cos(k\theta) = \tfrac12 + \frac{\sin\!\big((n-\tfrac12)\theta\big)}{2\sin(\theta/2)}.
+$$
+
+### Plain Language
+
+By De Moivre's theorem each term $(\cos\theta + i\sin\theta)^k = e^{ik\theta}$, so the
+partial sums $\sum_{k=0}^{n-1} e^{ik\theta}$ form a **finite geometric series**. Summing it
+in closed form and taking real/imaginary parts yields Lagrange's classical trigonometric
+identities — the Dirichlet-kernel closed forms for $\sum\cos(k\theta)$ and
+$\sum\sin(k\theta)$. This packages De Moivre's theorem with the finite geometric series to
+expose the analytic engine behind Fourier partial sums.
+
+### Why This Matters
+
+No sibling addresses this: oq-05 ("roots of unity sum to zero") is the degenerate special
+case $\theta = 2\pi/n$ where the numerator $e^{in\theta}-1$ vanishes. Mathlib has no
+Dirichlet-kernel / Lagrange trig-identity result, so this is a genuine gap that composes
+two verified gallery pieces (De Moivre + geometric series).
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `de-moivre` is verified (0-axiom).
+- Mathlib has `geom_sum_eq`, `Complex.exp_nat_mul`, and `Complex.exp_ofReal_mul_I_re/_im`.
+
+### What's Still Open
+
+- The target theorems below (currently `sorry`).
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child. Category: **composition /
+specialization**.
+
+## Target Lean Sketch
+
+```lean
+open Complex Real Finset
+
+/-- Geometric sum of complex exponentials (De Moivre + geom_sum_eq). -/
+theorem geom_sum_exp (θ : ℝ) (n : ℕ) (h : Complex.exp (θ * I) ≠ 1) :
+    ∑ k ∈ range n, Complex.exp (k * θ * I)
+      = (Complex.exp (n * θ * I) - 1) / (Complex.exp (θ * I) - 1) := by
+  sorry -- exp(k*θ*I) = exp(θ*I)^k via Complex.exp_nat_mul, then geom_sum_eq
+
+/-- Cosine partial sum as the real part of the closed form. -/
+theorem sum_cos_eq_re (θ : ℝ) (n : ℕ) (h : Complex.exp (θ * I) ≠ 1) :
+    ∑ k ∈ range n, Real.cos (k * θ)
+      = ((Complex.exp (n * θ * I) - 1) / (Complex.exp (θ * I) - 1)).re := by
+  sorry -- push .re through the finite sum; Complex.exp_ofReal_mul_I_re
+
+/-- Lagrange / Dirichlet-kernel closed form (sin(θ/2) ≠ 0). -/
+theorem lagrange_sum_cos (θ : ℝ) (n : ℕ) (h : Real.sin (θ/2) ≠ 0) :
+    ∑ k ∈ range n, Real.cos (k * θ)
+      = 1/2 + Real.sin ((n - 1/2) * θ) / (2 * Real.sin (θ/2)) := by
+  sorry -- half-angle: multiply by e^{-iθ/2}, take real part, field_simp/ring
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `de-moivre` | Parent: De Moivre's theorem | complex exponentials |
+| `de-moivre-oq-05` | Sibling: roots of unity sum to zero (degenerate case) | roots of unity |
+| `geometric-series` | Provides the finite-sum engine | geometric series |
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Significance**: 6/10  |  **Tractability**: 7/10  |  **Tier**: B
+
+**Justification**: Parts 1-2 are short mechanical compositions (De Moivre + `geom_sum_eq`,
+push `.re` through the sum). The Lagrange capstone needs half-angle bookkeeping (rewrite
+$e^{i\theta}-1 = e^{i\theta/2}(e^{i\theta/2}-e^{-i\theta/2})$) closed with `field_simp`/`ring`.
+
+### Suggested First Steps
+
+1. Prove `geom_sum_exp` via `Complex.exp_nat_mul` then `geom_sum_eq h n`.
+2. Prove `sum_cos_eq_re` by pushing `.re` through `Finset.sum` and evaluating each term
+   with `Complex.exp_ofReal_mul_I_re`.
+3. Prove the Lagrange form by the half-angle multiplication and real-part extraction.
+
+## References
+
+### Mathlib
+
+- `geom_sum_eq` — Algebra/Field/GeomSum.lean
+- `Complex.exp_nat_mul` — Analysis/Complex/Exponential.lean
+- `Complex.exp_mul_I`, `Complex.exp_ofReal_mul_I_re`, `Complex.exp_ofReal_mul_I_im` — Analysis/Complex/Trigonometric.lean
+
+### Literature
+
+- Lagrange's trigonometric identity; Dirichlet kernel in Fourier analysis.
+
+## Metadata
+
+```yaml
+tags:
+  - complex-analysis
+  - trigonometry
+  - de-moivre
+  - fourier-analysis
+  - geometric-series
+related_proofs:
+  - de-moivre
+  - de-moivre-oq-05
+  - geometric-series
+difficulty: medium
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/geometric-series-oq-11/problem.md
+++ b/research/problems/geometric-series-oq-11/problem.md
@@ -1,0 +1,137 @@
+# Problem: The Negative Binomial Series - sum of C(n+k,k) r^n = 1/(1-r)^(k+1)
+
+**Slug**: geometric-series-oq-11
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: geometric-series
+
+## Problem Statement
+
+### Formal Statement
+
+For a fixed $k \in \mathbb{N}$ and $|r| < 1$:
+$$
+\sum_{n=0}^{\infty} \binom{n+k}{k} r^n = \frac{1}{(1-r)^{k+1}}.
+$$
+
+### Plain Language
+
+The geometric series $1/(1-r)$ is the $k=0$ case of an entire family. For a fixed
+nonnegative integer $k$ and real ratio $|r| < 1$, the generating function of the binomial
+coefficients along a diagonal satisfies the closed form $\sum_{n\ge 0}\binom{n+k}{k}r^n =
+1/(1-r)^{k+1}$. This is Newton's generalized binomial theorem specialized to the negative
+integer exponent $-(k+1)$. Unlike the moment siblings (coefficients polynomial in $n$ via
+differentiation), here the coefficients are binomial coefficients and the identity comes
+from iterated Cauchy self-convolution of the geometric series.
+
+### Why This Matters
+
+Distinct from all 9 siblings: oq-06/07/10 are polynomial moments (differentiation), oq-09
+is parity splitting, oq-08 is a finite-tail defect, oq-04 is q-analog finite sums. None
+treats binomial-coefficient (negative-binomial) generating functions. The $k=0$ case
+recovers the parent geometric series, and the derivation gives a **combinatorial** route to
+the first moment $\sum n\,r^n = r/(1-r)^2$ (distinct from oq-06's differentiation).
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `geometric-series` is verified (0-axiom).
+- Mathlib has `tsum_choose_mul_geometric_of_norm_lt_one` and
+  `summable_choose_mul_geometric_of_norm_lt_one`.
+
+### What's Still Open
+
+- The target theorems below (currently `sorry`).
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child. Category: **generalization**.
+
+## Target Lean Sketch
+
+```lean
+namespace GeometricSeriesNegBinom
+open scoped BigOperators
+
+/-- The negative binomial / diagonal generating-function identity. -/
+theorem negBinom_series (k : ℕ) (r : ℝ) (hr : |r| < 1) :
+    ∑' n : ℕ, ((n + k).choose k : ℝ) * r ^ n = 1 / (1 - r) ^ (k + 1) := by
+  sorry -- tsum_choose_mul_geometric_of_norm_lt_one (Real.norm_eq_abs)
+
+theorem recover_parent (r : ℝ) (hr : |r| < 1) :
+    ∑' n : ℕ, r ^ n = 1 / (1 - r) := by
+  sorry -- simpa using negBinom_series 0 r hr
+
+theorem sum_succ_mul (r : ℝ) (hr : |r| < 1) :
+    ∑' n : ℕ, ((n : ℝ) + 1) * r ^ n = 1 / (1 - r) ^ 2 := by
+  sorry -- negBinom_series 1 with Nat.choose_one_right
+
+/-- Combinatorial derivation of the first moment (distinct from differentiation). -/
+theorem first_moment_via_negBinom (r : ℝ) (hr : |r| < 1) :
+    ∑' n : ℕ, (n : ℝ) * r ^ n = r / (1 - r) ^ 2 := by
+  sorry -- ∑ (n+1) r^n − ∑ r^n via Summable.tsum_sub, then field_simp/ring
+
+end GeometricSeriesNegBinom
+```
+
+Plus concrete instances, e.g. $\sum_n (n+1)/2^n = 4$ and $\sum_n \binom{n+2}{2}/2^n = 8$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `geometric-series` | Parent: geometric series | infinite sums |
+| `geometric-series-oq-06` | Sibling: first moment via differentiation | power series |
+| `binomial-theorem` | Newton generalized binomial (α = -1 case) | binomial coefficients |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 6/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: The core identity is a direct wrapper of Mathlib's
+`tsum_choose_mul_geometric_of_norm_lt_one`; the added value (k=0/k=1 specializations, the
+combinatorial first-moment derivation via `Summable.tsum_sub`, numeric examples) is
+standard `simp [Nat.choose_one_right]` / `field_simp` / `ring` work.
+
+### Suggested First Steps
+
+1. Prove `negBinom_series` by converting `|r| < 1` to `‖r‖ < 1` (`Real.norm_eq_abs`) and
+   applying `tsum_choose_mul_geometric_of_norm_lt_one`.
+2. Specialize to $k=0$ (recover parent) and $k=1$ (`Nat.choose_one_right`).
+3. Derive the first moment by `Summable.tsum_sub` of the $k=1$ and $k=0$ series, then
+   `field_simp`/`ring`; add numeric examples.
+
+## References
+
+### Mathlib
+
+- `tsum_choose_mul_geometric_of_norm_lt_one`, `summable_choose_mul_geometric_of_norm_lt_one`, `hasSum_choose_mul_geometric_of_norm_lt_one` — Analysis/SpecificLimits/Normed.lean
+- `hasSum_geom_series_inverse` — Analysis/SpecificLimits/Normed.lean
+- `Nat.choose_one_right` — Data/Nat/Choose/Basic.lean
+- `Summable.tsum_sub` — Topology/Algebra/InfiniteSum
+
+### Literature
+
+- Newton's generalized binomial theorem; negative binomial series / generating functions.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - geometric-series
+  - generating-functions
+  - binomial-coefficients
+  - infinite-series
+related_proofs:
+  - geometric-series
+  - geometric-series-oq-06
+  - binomial-theorem
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/konigsberg-oq-05/problem.md
+++ b/research/problems/konigsberg-oq-05/problem.md
@@ -1,0 +1,140 @@
+# Problem: Endpoints of an Eulerian Trail Are Exactly the Odd-Degree Vertices
+
+**Slug**: konigsberg-oq-05
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: konigsberg
+
+## Problem Statement
+
+### Formal Statement
+
+For an Eulerian trail $p$ from $u$ to $v$ in a finite simple graph $G$:
+$$
+u = v \Rightarrow \forall x,\ \text{Even}(\deg x); \qquad
+u \neq v \Rightarrow \big(\text{Odd}(\deg x) \iff x \in \{u,v\}\big).
+$$
+Hence any finite graph with $\ge 3$ odd-degree vertices admits no Eulerian trail with any
+endpoints.
+
+### Plain Language
+
+Euler's theorem (used in the Königsberg parent) says an Eulerian trail forces the number
+of odd-degree vertices to be 0 or 2, but not *which* vertices those are. This child
+sharpens the necessity direction: a closed trail ($u=v$) forces every degree even, and an
+open trail ($u \neq v$) makes the odd-degree set **exactly** the two endpoints $\{u,v\}$.
+Combined with the handshaking lemma this yields a strengthened Königsberg impossibility:
+$\ge 3$ odd-degree vertices $\Rightarrow$ no Eulerian trail at all.
+
+### Why This Matters
+
+Siblings cover concrete families / odd-regular graphs (oq-01), directed graphs (oq-02),
+hypergraphs/infinite graphs (oq-03), and Eulerian-circuit counting/BEST (oq-04). None
+establishes the *exact identity* of the odd-degree set with the trail's endpoints, nor the
+"$\ge 3$ odd $\Rightarrow$ no trail" strengthening. This is a pure necessity-direction
+result, so it verifies with 0 axioms (unlike siblings that axiomatize Hierholzer
+sufficiency).
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `konigsberg` is verified.
+- Mathlib has `SimpleGraph.Walk.IsEulerian.even_degree_iff`,
+  `IsEulerian.card_filter_odd_degree`, and the handshaking lemma
+  `SimpleGraph.even_card_odd_degree_vertices`.
+
+### What's Still Open
+
+- The target theorems below (currently `sorry`).
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child. Category: **specialization
+(necessity direction)**.
+
+## Target Lean Sketch
+
+```lean
+open SimpleGraph SimpleGraph.Walk
+variable {V : Type*} (G : SimpleGraph V) [Fintype V] [DecidableRel G.Adj] [DecidableEq V]
+
+/-- Open-trail endpoints have odd degree. -/
+theorem euler_open_endpoint_odd {u v : V} {p : G.Walk u v}
+    (h : p.IsEulerian) (hn : u ≠ v) : Odd (G.degree u) ∧ Odd (G.degree v) := by
+  sorry -- from IsEulerian.even_degree_iff at u and v; Nat.not_even_iff_odd
+
+/-- The odd-degree set of an OPEN trail is exactly {u, v}. -/
+theorem euler_open_odd_set {u v : V} {p : G.Walk u v}
+    (h : p.IsEulerian) (hn : u ≠ v) :
+    ∀ x, Odd (G.degree x) ↔ (x = u ∨ x = v) := by
+  sorry -- negate even_degree_iff; ¬(x ≠ u ∧ x ≠ v) ↔ x = u ∨ x = v
+
+/-- A CLOSED trail forces every degree even. -/
+theorem euler_circuit_all_even {u : V} {p : G.Walk u u}
+    (h : p.IsEulerian) : ∀ x, Even (G.degree x) := by
+  sorry -- even_degree_iff with u = v makes RHS vacuously true
+
+/-- Strengthened Königsberg: ≥ 3 odd vertices ⇒ no Eulerian trail. -/
+theorem no_euler_trail_of_three_odd
+    (h3 : 3 ≤ (Finset.univ.filter (fun x => Odd (G.degree x))).card) :
+    ∀ (u v : V) (p : G.Walk u v), ¬ p.IsEulerian := by
+  sorry -- IsEulerian.card_filter_odd_degree gives ∈ {0,2}; omega
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `konigsberg` | Parent: Seven Bridges / Euler trails | degree parity |
+| `konigsberg-oq-04` | Sibling: Eulerian-circuit counting (BEST) | Eulerian circuits |
+| `konigsberg-oq-01` | Sibling: concrete families / odd-regular | degree conditions |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 6/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: Every theorem is a short (3-12 line) consequence of
+`IsEulerian.even_degree_iff` plus `card_filter_odd_degree`. No new graph construction, no
+Hierholzer sufficiency needed — pure necessity, fully 0-axiom.
+
+### Suggested First Steps
+
+1. Instantiate `IsEulerian.even_degree_iff` at `u` and `v` to get endpoint oddness.
+2. Negate it to characterize the odd-degree set as `{u,v}` in the open case; use
+   `even_degree_iff` with `u = v` for the closed case.
+3. Use `IsEulerian.card_filter_odd_degree` (card ∈ {0,2}) and `omega` for the ≥3
+   strengthening; optionally cross-check with `even_card_odd_degree_vertices`.
+
+## References
+
+### Mathlib
+
+- `SimpleGraph.Walk.IsEulerian.even_degree_iff` — Combinatorics/SimpleGraph/Trails.lean
+- `SimpleGraph.Walk.IsEulerian.card_filter_odd_degree`, `IsEulerian.card_odd_degree` — Combinatorics/SimpleGraph/Trails.lean
+- `SimpleGraph.even_card_odd_degree_vertices`, `sum_degrees_eq_twice_card_edges` — Combinatorics/SimpleGraph/DegreeSum.lean
+- `Nat.not_even_iff_odd`, `Finset.card_pair` — core
+
+### Literature
+
+- Euler (1736); standard graph-theory treatments of Eulerian trails.
+
+## Metadata
+
+```yaml
+tags:
+  - graph-theory
+  - eulerian-trails
+  - konigsberg
+  - degree-parity
+related_proofs:
+  - konigsberg
+  - konigsberg-oq-04
+  - konigsberg-oq-01
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/lagrange-theorem-oq-10/problem.md
+++ b/research/problems/lagrange-theorem-oq-10/problem.md
@@ -1,0 +1,132 @@
+# Problem: Coprime-Order Subgroups Intersect Trivially - the Gcd Refinement of Lagrange
+
+**Slug**: lagrange-theorem-oq-10
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: lagrange-theorem
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+|H \cap K| \mid \gcd(|H|,|K|), \qquad
+\gcd(|H|,|K|)=1 \Rightarrow H \cap K = \{1\},
+$$
+and if additionally $|H|\cdot|K| = |G|$ then $G$ is the internal direct product of $H$ and $K$.
+
+### Plain Language
+
+Lagrange's theorem forces $|H|$ to divide $|G|$ for every subgroup. Applied to
+$H \cap K \le H$ and $H \cap K \le K$ it yields the sharp refinement that $|H \cap K|$
+divides $\gcd(|H|,|K|)$. Consequently, subgroups of coprime order meet only in the
+identity, and when their orders additionally multiply to $|G|$ they form an internal
+direct product $G \cong H \times K$. This coprimality corollary is the algebraic backbone
+of Sylow decomposition and the CRT-style splitting of finite abelian groups.
+
+### Why This Matters
+
+Mathlib states only the coprime special case (`Subgroup.inf_eq_bot_of_coprime`); the
+gcd-divisibility general form `|H ⊓ K| ∣ gcd(|H|,|K|)` is not stated. It is distinct from
+every existing sibling (Sylow, orbit-stabilizer, tower law, exponent, Cauchy, pq-center):
+those describe a single subgroup's order, not the arithmetic of subgroup **intersections**.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `lagrange-theorem` is verified (0-axiom).
+- Mathlib has `Subgroup.card_dvd_of_le`, `Subgroup.inf_eq_bot_of_coprime`,
+  `Subgroup.isComplement'_of_coprime`.
+
+### What's Still Open
+
+- The target theorems below (currently `sorry`), especially the gcd-divisibility core.
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child. Category: **generalization /
+corollary**.
+
+## Target Lean Sketch
+
+```lean
+variable {G : Type*} [Group G] [Finite G] (H K : Subgroup G)
+
+/-- New core: intersection order divides the gcd of the orders. -/
+theorem card_inf_dvd_gcd :
+    Nat.card (H ⊓ K : Subgroup G) ∣ Nat.gcd (Nat.card H) (Nat.card K) := by
+  sorry -- Nat.dvd_gcd (card_dvd_of_le inf_le_left) (card_dvd_of_le inf_le_right)
+
+/-- Coprime orders force trivial intersection (reproved from the gcd core). -/
+theorem inf_eq_bot_of_coprime_card
+    (h : Nat.Coprime (Nat.card H) (Nat.card K)) : H ⊓ K = ⊥ := by
+  sorry -- Subgroup.card_eq_one + card_inf_dvd_gcd
+
+/-- With matching product of orders, H and K complement: internal direct product. -/
+theorem isComplement'_of_coprime_card
+    (hmul : Nat.card H * Nat.card K = Nat.card G)
+    (hcop : Nat.Coprime (Nat.card H) (Nat.card K)) : H.IsComplement' K := by
+  sorry -- Subgroup.isComplement'_of_coprime
+```
+
+Plus `eq_one_of_mem_both` (a common element is the identity) and a concrete instance for
+two subgroups of coprime prime orders $p \neq q$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `lagrange-theorem` | Parent: Lagrange's theorem | coset counting |
+| `lagrange-theorem-oq-06` | Sibling: tower law (chain of subgroups) | index multiplicativity |
+| `sylow-theorem` | Uses coprime-order splitting | p-groups |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 6/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: Everything descends from `Subgroup.card_dvd_of_le` (Lagrange on the
+sublattice) plus elementary Nat gcd/coprime facts. One honest new derivation
+(`card_inf_dvd_gcd`); the rest wrap confirmed Mathlib lemmas. No custom definitions or
+decidability.
+
+### Suggested First Steps
+
+1. Prove `card_inf_dvd_gcd` via `Nat.dvd_gcd` and `Subgroup.card_dvd_of_le` on both
+   `inf_le_left` and `inf_le_right`.
+2. Derive `inf_eq_bot_of_coprime_card` from the gcd core plus `Subgroup.card_eq_one`.
+3. Wrap `Subgroup.isComplement'_of_coprime` for the internal-direct-product form; add the
+   coprime-prime-order instance.
+
+## References
+
+### Mathlib
+
+- `Subgroup.card_dvd_of_le` — GroupTheory/Coset/Card.lean
+- `Subgroup.card_subgroup_dvd_card` — GroupTheory/Coset/Card.lean (core Lagrange)
+- `Subgroup.card_eq_one`, `Subgroup.inf_eq_bot_of_coprime` — GroupTheory/Index.lean
+- `Subgroup.isComplement'_of_coprime`, `Subgroup.IsComplement'.QuotientMulEquiv` — GroupTheory/Complement.lean
+
+### Literature
+
+- Any first-course algebra text: Lagrange's theorem and internal direct products.
+
+## Metadata
+
+```yaml
+tags:
+  - group-theory
+  - lagrange-theorem
+  - subgroups
+  - direct-products
+related_proofs:
+  - lagrange-theorem
+  - lagrange-theorem-oq-06
+  - sylow-theorem
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/law-of-cosines-oq-09/problem.md
+++ b/research/problems/law-of-cosines-oq-09/problem.md
@@ -1,0 +1,134 @@
+# Problem: Acute-Right-Obtuse Trichotomy from the Law of Cosines (Euclid II.12 and II.13)
+
+**Slug**: law-of-cosines-oq-09
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: law-of-cosines
+
+## Problem Statement
+
+### Formal Statement
+
+For the angle $C$ opposite side $c$ in a triangle with sides $a,b,c$:
+$$
+C < \tfrac{\pi}{2} \iff a^2+b^2 > c^2,\qquad
+C = \tfrac{\pi}{2} \iff a^2+b^2 = c^2,\qquad
+C > \tfrac{\pi}{2} \iff a^2+b^2 < c^2.
+$$
+Coordinate-free: the unoriented angle between vectors $x,y$ is $<,=,>\ \tfrac{\pi}{2}$
+exactly as $\langle x,y\rangle$ is $>,=,<\ 0$.
+
+### Plain Language
+
+The Law of Cosines $c^2 = a^2+b^2-2ab\cos C$ makes classifying a triangle's angle a purely
+algebraic test on side lengths: the angle opposite $c$ is acute, right, or obtuse exactly
+as $a^2+b^2$ exceeds, equals, or falls short of $c^2$. This is precisely Euclid's case
+split in *Elements* Book II Propositions 12 (obtuse) and 13 (acute), which the parent
+entry's history discusses but does not formalize. We prove the coordinate-free trichotomy
+in any real inner-product space and derive the triangle-side form from Mathlib's `law_cos`.
+
+### Why This Matters
+
+Siblings cover spherical (oq-01), hyperbolic (oq-03), Stewart/median (oq-04), Apollonius/
+parallelogram (oq-07), and the triangle inequality (oq-08). None formalizes the acute/
+right/obtuse sign trichotomy, and Mathlib has no direct "angle vs π/2 iff inner sign"
+lemma (only the right-angle equality case), so this is a genuine gap.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `law-of-cosines` is verified (0-axiom).
+- Mathlib has `InnerProductGeometry.cos_angle_mul_norm_mul_norm`, `angle_nonneg`,
+  `angle_le_pi`, `Real.strictAntiOn_cos`, `EuclideanGeometry.law_cos`.
+
+### What's Still Open
+
+- The target theorems below (currently `sorry`).
+
+### Our Goal
+
+Prove the sketch below as a verified (0-axiom) child. Category: **specialization /
+characterization**.
+
+## Target Lean Sketch
+
+```lean
+open InnerProductGeometry Real
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+theorem angle_lt_pi_div_two_iff_inner_pos {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) :
+    angle x y < π / 2 ↔ 0 < ⟪x, y⟫_ℝ := by
+  sorry -- cos_angle_mul_norm_mul_norm + strictAntiOn_cos on [0,π] + cos_pi_div_two
+
+theorem pi_div_two_lt_angle_iff_inner_neg {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) :
+    π / 2 < angle x y ↔ ⟪x, y⟫_ℝ < 0 := by
+  sorry -- symmetric to the above
+
+-- Affine (triangle-side) form, Euclid II.12 / II.13:
+theorem angle_obtuse_iff_dist_sq_lt {P : Type*} [MetricSpace P] [NormedAddTorsor V P]
+    {p₁ p₂ p₃ : P} (h12 : p₁ ≠ p₂) (h32 : p₃ ≠ p₂) :
+    π / 2 < ∠ p₁ p₂ p₃ ↔ dist p₁ p₂ ^ 2 + dist p₃ p₂ ^ 2 < dist p₁ p₃ ^ 2 := by
+  sorry -- law_cos expresses dist p₁ p₃ ^2 via cos ∠; nlinarith on positive factor
+```
+
+Plus the acute (`<`) and right (`=`) affine companions and worked examples (3-4-5 right
+triangle; an obtuse triangle) checked by `norm_num`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `law-of-cosines` | Parent: Law of Cosines | inner products, angles |
+| `law-of-cosines-oq-08` | Sibling: triangle inequality | angle/norm bounds |
+| `pythagorean-theorem` | Right-angle special case | inner products |
+
+## Tractability Assessment
+
+**Difficulty**: Low-Medium
+
+**Significance**: 6/10  |  **Tractability**: 7/10  |  **Tier**: B
+
+**Justification**: Every step is a named Mathlib lemma plus `linarith`/`nlinarith` sign
+arithmetic; no analysis or new definitions. The angle lies in $[0,\pi]$ where $\cos$ is
+strictly decreasing, so cos-sign converts to angle-vs-$\pi/2$ directly.
+
+### Suggested First Steps
+
+1. Use `cos_angle_mul_norm_mul_norm` to reduce inner-product sign to $\cos(\text{angle})$
+   sign (the norm product is positive for nonzero vectors).
+2. Apply `Real.strictAntiOn_cos` on `[0,π]` with `cos_pi_div_two = 0` to convert to the
+   angle comparison; reuse `inner_eq_zero_iff_angle_eq_pi_div_two` for the right case.
+3. For the affine form, apply `law_cos` and transfer the cos-sign via `nlinarith` using the
+   positive factor `2 * dist p₁ p₂ * dist p₃ p₂`.
+
+## References
+
+### Mathlib
+
+- `InnerProductGeometry.cos_angle_mul_norm_mul_norm`, `angle_nonneg`, `angle_le_pi`, `inner_eq_zero_iff_angle_eq_pi_div_two` — Geometry/Euclidean/Angle/Unoriented/Basic.lean
+- `Real.strictAntiOn_cos`, `Real.cos_pi_div_two` — Analysis/SpecialFunctions/Trigonometric/Basic.lean
+- `EuclideanGeometry.law_cos` — Geometry/Euclidean/Triangle.lean
+
+### Literature
+
+- Euclid, *Elements*, Book II, Propositions 12 and 13.
+
+## Metadata
+
+```yaml
+tags:
+  - geometry
+  - euclidean-geometry
+  - law-of-cosines
+  - inner-product-spaces
+  - angles
+related_proofs:
+  - law-of-cosines
+  - law-of-cosines-oq-08
+  - pythagorean-theorem
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/pell-equation-oq-08/problem.md
+++ b/research/problems/pell-equation-oq-08/problem.md
@@ -1,0 +1,131 @@
+# Problem: Negative Pell x^2 - D y^2 = -1 Is Unsolvable When a Prime p = 3 (mod 4) Divides D
+
+**Slug**: pell-equation-oq-08
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: pell-equation
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{If a prime } p \equiv 3 \pmod 4 \text{ divides } D, \text{ then } x^2 - D\,y^2 = -1 \text{ has no integer solution.}
+$$
+
+Equivalently, a solution of the negative Pell equation forces $-1$ to be a quadratic
+residue modulo every divisor of $D$, but $-1$ is a nonresidue modulo any prime
+$p \equiv 3 \pmod 4$.
+
+### Plain Language
+
+The classical Pell equation $x^2 - D y^2 = 1$ is always solvable (parent entry), but the
+**negative** Pell equation $x^2 - D y^2 = -1$ is not always solvable. This child proves a
+clean local obstruction: if $D$ has any prime factor $p \equiv 3 \pmod 4$, then no integer
+solution exists. This immediately gives the elementary corollary $D \equiv 3 \pmod 4
+\Rightarrow$ unsolvable, and it also catches cases the mod-4 test alone misses — e.g.
+$D = 21 \equiv 1 \pmod 4$ is still unsolvable because $3 \mid 21$ — contrasted with the
+solvable $D = 2$ (1,1) and $D = 5$ (2,1).
+
+### Why This Matters
+
+The parent gallery entry and its subtree treat solutions that **exist** (regulator, size
+bounds, norm forms, recurrences, the $D=2$ negative case). None addresses *when the
+negative Pell equation is unsolvable for general D* — a thread flagged by sibling oq-02.
+Mathlib's `Pell` library only handles the norm-$+1$ equation, so no named result covers
+this. The proof is a short reduction to `ZMod` quadratic-residue facts.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `pell-equation` is verified (0-axiom).
+- Mathlib has `ZMod.exists_sq_eq_neg_one_iff` and `ZMod.isSquare_neg_one_of_dvd`.
+
+### What's Still Open
+
+- The target theorems below (currently `sorry`).
+
+### Our Goal
+
+Prove the sketch below as a self-contained verified (0-axiom) child. Category:
+**specialization / obstruction**.
+
+## Target Lean Sketch
+
+```lean
+open scoped Classical
+
+/-- A negative-Pell solution makes `-1` a square mod `D`. -/
+theorem negPell_isSquare_neg_one {D : ℕ}
+    (h : ∃ x y : ℤ, x ^ 2 - (D : ℤ) * y ^ 2 = -1) :
+    IsSquare (-1 : ZMod D) := by
+  sorry -- push through Int.cast : ℤ → ZMod D; (D : ZMod D) = 0 via ZMod.natCast_self
+
+/-- A prime factor `p ≡ 3 (mod 4)` obstructs solvability. -/
+theorem negPell_no_sol_of_prime_factor {D p : ℕ}
+    (hp : p.Prime) (hp3 : p % 4 = 3) (hpD : p ∣ D) :
+    ¬ ∃ x y : ℤ, x ^ 2 - (D : ℤ) * y ^ 2 = -1 := by
+  sorry -- descend IsSquare(-1) mod D to mod p, contradict exists_sq_eq_neg_one_iff
+```
+
+Plus the corollary `negPell_no_sol_of_three_mod_four (hD : D % 4 = 3)`, and worked
+`example`s: solvable $D = 2, 5$; unsolvable $D = 3, 7, 21$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `pell-equation` | Parent: Pell's equation | continued fractions, fundamental solution |
+| `pell-equation-oq-02` | Sibling: solvability questions | number theory |
+| `fermat-two-squares` | Uses `-1` quadratic residue mod primes | quadratic residues |
+
+## Tractability Assessment
+
+**Difficulty**: Low-Medium
+
+**Significance**: 6/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: Three short lemmas — a cast/reduction (`push_cast` + `ZMod.natCast_self`),
+one library descent lemma, and one library iff. No induction or `Solution₁` machinery. Main
+risk is minor `Int.cast` bookkeeping.
+
+### Suggested First Steps
+
+1. Prove `negPell_isSquare_neg_one` by casting the equation into `ZMod D` (`push_cast`,
+   `ZMod.natCast_self`) so `x^2 = -1`.
+2. Descend to `ZMod p` via `ZMod.isSquare_neg_one_of_dvd hpD`, then contradict with
+   `ZMod.exists_sq_eq_neg_one_iff.mp` given `p % 4 = 3` (needs `Fact p.Prime`).
+3. Derive the `D ≡ 3 (mod 4)` corollary and add `norm_num` / `decide` worked examples.
+
+## References
+
+### Mathlib
+
+- `ZMod.exists_sq_eq_neg_one_iff` — NumberTheory/LegendreSymbol/Basic.lean (`IsSquare (-1) ↔ p % 4 ≠ 3`)
+- `ZMod.isSquare_neg_one_of_dvd` — NumberTheory/SumTwoSquares.lean (divisor descent)
+- `ZMod.natCast_self`, `ZMod.intCast_zmod_eq_zero_iff_dvd` — Data/ZMod/Basic.lean
+- `ZMod.isSquare_neg_one_iff'` — NumberTheory/SumTwoSquares.lean (squarefree full criterion, optional)
+
+### Literature
+
+- Continued fractions and the negative Pell equation; solvability criteria (e.g. via
+  the class group / genus theory). The $p \equiv 3 \pmod 4$ obstruction is classical.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - pell-equation
+  - quadratic-residues
+  - diophantine-equations
+related_proofs:
+  - pell-equation
+  - pell-equation-oq-02
+  - fermat-two-squares
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```


### PR DESCRIPTION
## Summary

The candidate pool's **effective** availability was 1 (nominal 57 "available", but 56 already have research/gallery directories = claimed) — below the seeker's 15-problem threshold. This PR adds **7 new tractable open-question children**, one per math domain, each crafted off a **verified 0-axiom classic parent**.

Each child was drafted by a dedicated per-parent subagent that (a) read the parent's meta + Lean source + existing siblings to ensure distinctness, (b) crafted a genuinely new tractable theorem, and (c) **grepped the local Mathlib checkout to confirm the key lemma names actually exist** before seeding.

| Slug | Domain | Result |
|------|--------|--------|
| `pell-equation-oq-08` | number theory | Negative Pell x²−Dy²=−1 unsolvable when a prime p≡3 (mod 4) divides D |
| `de-moivre-oq-06` | complex analysis | Finite geometric sum of complex exponentials → Lagrange/Dirichlet trig identity |
| `lagrange-theorem-oq-10` | group theory | \|H∩K\| divides gcd(\|H\|,\|K\|); coprime-order subgroups meet trivially |
| `konigsberg-oq-05` | graph theory | Eulerian-trail endpoints are exactly the odd-degree vertices; ≥3 odd ⇒ no trail |
| `cramers-rule-oq-06` | linear algebra | Adjugate algebra: anti-multiplicativity, det, involution, conjugation invariance |
| `law-of-cosines-oq-09` | geometry | Acute/right/obtuse trichotomy (Euclid II.12/II.13) |
| `geometric-series-oq-11` | analysis | Negative binomial series ∑C(n+k,k)rⁿ = 1/(1−r)^(k+1) |

All 7 target parents are verified 0-axiom; all children are expected to be verifiable 0-axiom (necessity/wrapper/composition results built on confirmed Mathlib lemmas). Fresh domains chosen to avoid overlap with recent cycles.

## Registration
- Inserted into `research/db/knowledge.db` (local/gitignored)
- Regenerated `research/candidate-pool.json` + surgically appended to `.lean/state/candidate-pool.json` (the pool researchers read)
- All 7 pass `validate-seeker-stubs.ts` (no template placeholders)
- Stats updated via `update-stats.sh problem-selected`

**PR deliverable** = the 7 `research/problems/<slug>/problem.md` stubs only (DB + pool JSONs are local/gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)