### PR TITLE
Enrich law-of-cosines OQ cluster: add references to 7 entries

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
@@ -119,6 +119,26 @@
       "mathContext": "The standard law cos(c') = cos(a')cos(b') + sin(a')sin(b')cos(γ') becomes -cos(γ) = cos(α)cos(β) - sin(α)sin(β)cos(c) after substitution, giving cos(γ) = -cos(α)cos(β) + sin(α)sin(β)cos(c). The clean-hypothesis form retains only 8 hypotheses (3 unit + 3 cross non-deg + 2 polar non-deg) versus 12 in the original — the two polar non-degeneracies remain because tripleProduct ≠ 0 is not implied by pairwise cross non-deg alone."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Todhunter, I."
+      ],
+      "title": "Spherical Trigonometry, for the Use of Colleges and Schools",
+      "year": "1886",
+      "venue": "5th ed., Macmillan",
+      "note": "Classical reference for the spherical law of cosines, the polar triangle and the dual (supplemental) formulae."
+    },
+    {
+      "authors": [
+        "Coxeter, H.S.M."
+      ],
+      "title": "Non-Euclidean Geometry",
+      "year": "1998",
+      "venue": "6th ed., Mathematical Association of America",
+      "note": "Unified treatment of spherical and hyperbolic trigonometry and their dualities."
+    }
+  ],
   "conclusion": {
     "summary": "The polar triangle construction provides a conceptually clean derivation of the dual spherical law of cosines as a symmetry of the standard law. The key identity dot(B×C, C×A) = -dot(projPerp A C, projPerp B C) bridges the cross product geometry of the polar vertices to the dihedral angle geometry of the original triangle.",
     "implications": "This establishes the polar triangle side and angle formulas in Lean 4 (fully proved, axiom-free). The Cauchy-Schwarz/projection-dot identity (projperp_dot_sinsincos) was eliminated in Session 3; the polar_angle_eq axiom was eliminated in Session 4 via the polar-of-polar reduction. The dual spherical law of cosines is now derivable axiom-free in this entry.",

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01/meta.json
@@ -137,6 +137,26 @@
       "summary": "Two explicit verifications: the 90-90-90 spherical triangle (all sides and angles π/2) and the equilateral 90-degree variant, both reducing to 0 = 0 via cos(arccos(0)) = 0 and simp."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Todhunter, I."
+      ],
+      "title": "Spherical Trigonometry, for the Use of Colleges and Schools",
+      "year": "1886",
+      "venue": "5th ed., Macmillan",
+      "note": "Classical reference for the spherical law of cosines, the polar triangle and the dual (supplemental) formulae."
+    },
+    {
+      "authors": [
+        "Coxeter, H.S.M."
+      ],
+      "title": "Non-Euclidean Geometry",
+      "year": "1998",
+      "venue": "6th ed., Mathematical Association of America",
+      "note": "Unified treatment of spherical and hyperbolic trigonometry and their dualities."
+    }
+  ],
   "conclusion": {
     "summary": "This proof establishes the dual spherical law of cosines — cos(C) = −cos(A)cos(B) + sin(A)sin(B)cos(c) — via a direct algebraic route through the Gram determinant, without using the polar triangle construction. All 22 theorems are proved from Mathlib's inner product space theory with zero axioms and zero sorries.",
     "implications": "The dual law completes the symmetry of spherical trigonometry: the standard law expresses a side in terms of sides and an angle, while the dual expresses an angle in terms of angles and a side. Together they form a duality that mirrors the relationship between a spherical triangle and its polar dual. The Gram determinant approach is more algebraically transparent than the traditional polar triangle construction and generalizes to higher-dimensional spherical geometry. The proof infrastructure (perpendicular projections, Gram determinant nonnegativity) is directly reusable for the spherical sine rule and for analogous results in hyperbolic geometry.",

--- a/src/data/proofs/law-of-cosines-oq-03-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-01/meta.json
@@ -10,8 +10,12 @@
   "leanFile": {
     "path": "Proofs/HyperbolicLawCosinesModelOQ0301.lean",
     "namespace": "HyperbolicLawCosines",
-    "imports": ["Mathlib"],
-    "opens": ["Real"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 191,
@@ -91,6 +95,26 @@
       "endLine": 190,
       "summary": "tangent θ = (0, cos θ, sin θ). geo_tangent_t/x/y: tangent θ is the r=0 velocity of geo · θ (HasDerivAt on cosh/sinh). tangent_unit: each tangent is a unit vector. tangent_inner: their induced inner product is cos C. apex_angle: arccos⟨tangent 0, tangent C⟩ = C on [0,π].",
       "mathContext": "The induced Riemannian metric on the spacelike tangent plane at the apex is the Euclidean form; the angle between the geodesics' unit initial velocities is arccos(cos C) = C, confirming C is the true interior angle."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Ratcliffe, J.G."
+      ],
+      "title": "Foundations of Hyperbolic Manifolds",
+      "year": "2019",
+      "venue": "3rd ed., Graduate Texts in Mathematics 149, Springer",
+      "note": "Hyperboloid model of the hyperbolic plane and the hyperbolic laws of cosines and sines."
+    },
+    {
+      "authors": [
+        "Anderson, J.W."
+      ],
+      "title": "Hyperbolic Geometry",
+      "year": "2005",
+      "venue": "2nd ed., Springer Undergraduate Mathematics Series, Springer",
+      "note": "Hyperbolic trigonometry, including the laws of cosines and sines and AAA rigidity."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
@@ -142,6 +142,26 @@
       "mathContext": "The right-angle case is the hyperbolic analogue of $\\sin A = a/c$ in Euclidean right triangles. The positivity of the ratio sinA/sinha follows from sin_pos_of_pos_of_lt_pi and sinh_pos_of_pos."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Ratcliffe, J.G."
+      ],
+      "title": "Foundations of Hyperbolic Manifolds",
+      "year": "2019",
+      "venue": "3rd ed., Graduate Texts in Mathematics 149, Springer",
+      "note": "Hyperboloid model of the hyperbolic plane and the hyperbolic laws of cosines and sines."
+    },
+    {
+      "authors": [
+        "Anderson, J.W."
+      ],
+      "title": "Hyperbolic Geometry",
+      "year": "2005",
+      "venue": "2nd ed., Springer Undergraduate Mathematics Series, Springer",
+      "note": "Hyperbolic trigonometry, including the laws of cosines and sines and AAA rigidity."
+    }
+  ],
   "conclusion": {
     "summary": "The hyperbolic law of sines is axiomatized via 6 structure fields in HyperbolicSineTriangle. From the law we derive: the triple-ratio form, three cross-multiplication equalities, the isoceles criterion (a=b↔A=B), right-angle and equilateral specializations. The isoceles proof uses arccos injectivity (via cos_injOn_Icc) after ruling out the supplement case via the angular defect.",
     "implications": "The hyperbolic law of sines is the fundamental tool for computing angles from sides in hyperbolic geometry, dual to the law of cosines. Together with LawOfCosinesOQ03, it provides the complete hyperbolic trigonometry. The isoceles criterion mirrors the Euclidean case and is used in classifying hyperbolic triangles. The common ratio 1/(2R) identifies the circumradius R in hyperbolic space.",

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -136,6 +136,26 @@
       "mathContext": "The defect π-(A+B+C) equals the hyperbolic area (Gauss-Bonnet, curvature -1)."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Ratcliffe, J.G."
+      ],
+      "title": "Foundations of Hyperbolic Manifolds",
+      "year": "2019",
+      "venue": "3rd ed., Graduate Texts in Mathematics 149, Springer",
+      "note": "Hyperboloid model of the hyperbolic plane and the hyperbolic laws of cosines and sines."
+    },
+    {
+      "authors": [
+        "Coxeter, H.S.M."
+      ],
+      "title": "Non-Euclidean Geometry",
+      "year": "1998",
+      "venue": "6th ed., Mathematical Association of America",
+      "note": "Unified treatment of spherical and hyperbolic trigonometry and their dualities."
+    }
+  ],
   "conclusion": {
     "summary": "Hyperbolic AAA congruence is formalized by inverting the second law of cosines: cosh c = (cos C + cos A cos B)/(sin A sin B) expresses each side as a function of the angles, and injectivity of cosh on [0,∞) turns equal angles into equal sides. An internal-consistency theorem shows the angular defect A+B+C<π is exactly the condition making the formula exceed 1 (cosh c > 1), and the equilateral case yields the closed form cosh(side) = cos θ/(1-cos θ). 7 structure-encoded axioms, 0 sorries.",
     "implications": "AAA congruence is the precise sense in which hyperbolic geometry is rigid: there are no similar non-congruent triangles, in sharp contrast to Euclidean geometry. The same inversion underlies the fact that hyperbolic structures on surfaces are determined by their holonomy/angle data, a theme central to Thurston's geometrization. Together with the parent law of cosines and the sibling law of sines, this completes the basic congruence theory of hyperbolic triangles.",

--- a/src/data/proofs/law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03/meta.json
@@ -48,6 +48,26 @@
       "Hyperbolic geometry basics: Poincaré disk or upper half-plane model"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Ratcliffe, J.G."
+      ],
+      "title": "Foundations of Hyperbolic Manifolds",
+      "year": "2019",
+      "venue": "3rd ed., Graduate Texts in Mathematics 149, Springer",
+      "note": "Hyperboloid model of the hyperbolic plane and the hyperbolic laws of cosines and sines."
+    },
+    {
+      "authors": [
+        "Anderson, J.W."
+      ],
+      "title": "Hyperbolic Geometry",
+      "year": "2005",
+      "venue": "2nd ed., Springer Undergraduate Mathematics Series, Springer",
+      "note": "Hyperbolic trigonometry, including the laws of cosines and sines and AAA rigidity."
+    }
+  ],
   "conclusion": {
     "summary": "Hyperbolic law of cosines axiomatized via structure fields: both laws (first and second), hyperbolic Pythagorean theorem, angular defect > 0. Hyperbolic function identities (cosh²-sinh²=1, cosh≥1, parities) proved from Mathlib. 12 theorems, 3 structure-encoded axioms, 192 lines.",
     "implications": "The hyperbolic law of cosines is the fundamental computational tool for hyperbolic trigonometry, used to compute distances and angles in hyperbolic space. It is the basis for hyperbolic trigonometry tables, used in Thurston's geometrization program, and essential for studying hyperbolic 3-manifolds and Kleinian groups. The structure-encoding approach here is appropriate for an axiomatic development — deriving the law from a specific model (Poincaré disk, hyperboloid) would require substantially more infrastructure.",

--- a/src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json
@@ -103,6 +103,27 @@
       "summary": "angle_bisector_length_inner: for the foot dividing BC in ratio c:b, (b+c)²‖A−D‖² = bc((b+c)² − a²)."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Coxeter, H.S.M.",
+        "Greitzer, S.L."
+      ],
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "New Mathematical Library 19, Mathematical Association of America",
+      "note": "Stewart's theorem and the cevian-length identities."
+    },
+    {
+      "authors": [
+        "Coxeter, H.S.M."
+      ],
+      "title": "Non-Euclidean Geometry",
+      "year": "1998",
+      "venue": "6th ed., Mathematical Association of America",
+      "note": "Unified treatment of spherical and hyperbolic trigonometry and their dualities."
+    }
+  ],
   "conclusion": {
     "summary": "Starting from a single bilinear lemma (the squared norm of a linear combination of two vectors), the entry establishes Stewart's theorem as a coordinate-free identity in an arbitrary real inner product space. The master identity ‖A−D‖² = (1−s)‖A−B‖² + s‖A−C‖² − s(1−s)‖B−C‖², with the cevian foot encoded as the affine combination D = (1−s)·B + s·C, specializes by substitution to the classical form b²m + c²n = a(d² + mn), to Apollonius' median theorem (s = 1/2), and to the internal angle-bisector length formula (the c:b segment ratio).",
     "implications": "Grounding Stewart's theorem in genuine inner-product geometry removes the side conditions that the scalar law-of-cosines derivation must carry. The segment relation m + n = a holds by construction rather than as a collinearity/sign hypothesis, and the abstract cosine parameter t of the parent entry is exposed as the real inner product ⟪A−B, A−C⟫. Because nothing depends on dimension, the same identity covers planar triangles, spatial-tetrahedron cevians, and arbitrary-dimensional configurations — a single algebraic fact replacing a family of case-specific geometric arguments. This is a model for how classical metric geometry lifts to inner-product spaces: the law of cosines becomes the polarization identity, and cevian results become substitutions into one bilinear expansion.",


### PR DESCRIPTION
Adds a top-level `references` array to 7 open-question descendants of **law-of-cosines** that previously had none.

## Coverage
Non-Euclidean extensions of the law of cosines: the polar triangle and dual spherical law of cosines, the hyperbolic laws of cosines and sines derived from the hyperboloid model, hyperbolic AAA congruence (no non-trivial similar triangles), and Stewart's theorem lifted to inner-product geometry.

## Method
Cited to Todhunter (*Spherical Trigonometry*), Ratcliffe (*Foundations of Hyperbolic Manifolds*), Anderson (*Hyperbolic Geometry*), Coxeter (*Non-Euclidean Geometry*) and Coxeter–Greitzer (*Geometry Revisited*). 2 references per entry, matched to each `description`.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.