### PR TITLE
Enrich summation-by-parts OQ cluster: add references to 7 entries

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -56,6 +56,28 @@
       "mathContext": "Instantiate discrete_taylor_abel at D=1, simp away Function.iterate_zero / iterate_one and the range-one sum, then ring."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Finite calculus: summation by parts (Abel transform), difference/antidifference operators, and arithmetico-geometric sums."
+    },
+    {
+      "authors": [
+        "Knuth, D.E."
+      ],
+      "title": "The Art of Computer Programming, Volume 1: Fundamental Algorithms",
+      "year": "1997",
+      "venue": "3rd ed., Addison-Wesley",
+      "note": "Summation by parts and closed forms for weighted geometric sums via the finite-calculus operators."
+    }
+  ],
   "conclusion": {
     "summary": "This entry proves the finite Taylor–Abel expansion: iterating the parent's single-step discrete Abel transform D times along a tower of antidifferences G (linked by G(d+1)(k+1) − G(d+1)(k) = G(d)(k+1)) yields ∑_{k<n} f(k)·G(0)(k+1) = ∑_{d<D} (−1)ᵈ(Δᵈf(n)·G(d+1)(n) − Δᵈf(0)·G(d+1)(0)) + (−1)ᴰ ∑_{k<n} Δᴰf(k)·G(D)(k+1), over any commutative ring with no further hypotheses. It records the single-layer recurrence (step), the terminating case for discrete polynomials (Δᴰf = 0), and the depth-1 recovery of the parent transform. Answers the parent entry's first open question.",
     "implications": "(T) is the discrete, finite analogue of repeated integration by parts producing a Taylor-with-remainder series ∫ f dG = ∑ (−1)ᵈ [f⁽ᵈ⁾ G₍d+1₎] ± ∫ f⁽ᴰ⁾ G₍D₎. Because it carries no side hypotheses beyond the antidifference tower and lives over an arbitrary commutative ring, it is reusable infrastructure for finite-difference calculus: Newton's forward-difference formula, discrete Euler–Maclaurin skeletons, and Abel/Euler summation all specialise from it by choosing the tower G. The terminating case is the discrete finite Taylor formula for polynomial sequences.",

--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -47,6 +47,28 @@
       "mathContext": "Each specialisation is a one-line `have … ; simpa` off taylor_abel_iterate / taylor_abel_biadditive: smulAddHom_apply for the module form, AddMonoidHom.mul_apply for the ring form, and a sum_range_succ/pow unfolding for the order-two form. f and the weight tower live in genuinely different objects in the module case, exhibiting the bimodule pairing."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Finite calculus: summation by parts (Abel transform), difference/antidifference operators, and arithmetico-geometric sums."
+    },
+    {
+      "authors": [
+        "Knuth, D.E."
+      ],
+      "title": "The Art of Computer Programming, Volume 1: Fundamental Algorithms",
+      "year": "1997",
+      "venue": "3rd ed., Addison-Wesley",
+      "note": "Summation by parts and closed forms for weighted geometric sums via the finite-calculus operators."
+    }
+  ],
   "conclusion": {
     "summary": "This entry proves the finite Taylor–Abel expansion: iterating the parent's single-step biadditive Abel transform D times turns ∑_{k<n} p(F 0 k)(H 0 (k+1)) into a finite alternating sum of D boundary terms plus a remainder (−1)ᴰ ∑_{k<n} p(F D k)(H D (k+1)) pairing the D-th forward difference of the left tower against the D-th antidifference of the right tower, for any biadditive pairing p : A →+ B →+ M between abelian groups. Specialising the left tower to the genuine iterated forward difference Δʲf and the pairing to the scalar action / ring multiplication yields the module-valued and arbitrary-ring forms; D=2 gives the explicit second-order expansion. It answers the parent entry's first open question.",
     "implications": "The expansion is the discrete, module-valued analogue of the Taylor formula obtained from iterated integration by parts — the finite boundary sum is the Taylor polynomial and the last sum the order-D remainder. Because only biadditivity is used, it applies verbatim to vector-, matrix-, and operator-valued sums and to any bilinear pairing with a fixed argument order, and it underlies discrete Taylor remainders, Euler–Maclaurin-style estimates, and Abel/Dirichlet convergence tests over general modules. The abstract-tower formulation isolates the one structural choice that makes iteration uniform: a shifted antidifference at each order.",

--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -39,6 +39,28 @@
       "mathContext": "Proved by the same induction with smul_sub and sub_smul replacing map_sub, then abel. f and G live in genuinely different objects (the ring R and the module M), with the scalar action playing the role of the biadditive pairing."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Finite calculus: summation by parts (Abel transform), difference/antidifference operators, and arithmetico-geometric sums."
+    },
+    {
+      "authors": [
+        "Knuth, D.E."
+      ],
+      "title": "The Art of Computer Programming, Volume 1: Fundamental Algorithms",
+      "year": "1997",
+      "venue": "3rd ed., Addison-Wesley",
+      "note": "Summation by parts and closed forms for weighted geometric sums via the finite-calculus operators."
+    }
+  ],
   "conclusion": {
     "summary": "This entry proves the discrete Abel summation by parts in maximal generality: for any biadditive pairing p : A →+ B →+ M between abelian groups, ∑_{k<n} p(f k)(G(k+1)−G k) = p(f n)(G n) − p(f 0)(G 0) − ∑_{k<n} p(f(k+1)−f k)(G(k+1)), with no commutativity, associativity, or ring structure on the value group. It recovers the parent's identity over an ARBITRARY ring (p = multiplication, commutativity dropped) and the module-valued transform (p = scalar action). It answers the parent entry's second open question: the Abel mechanism uses only biadditivity, so it survives both the loss of commutativity and the move to a bimodule-valued pairing.",
     "implications": "Isolating biadditivity as the sole hypothesis makes the transform reusable for sequences valued in modules — vector-, matrix-, or operator-valued sums against a scalar weight, and any bilinear pairing with a fixed argument order. The non-commutative ring version (abel_summation_ring) is a drop-in strengthening of the parent: any future use over a ring no longer needs commutativity. The proof is the parent's induction verbatim with `ring` replaced by `map_sub` + `abel`, demonstrating concretely which algebraic axioms the identity actually consumes.",

--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -47,6 +47,37 @@
       "mathContext": "After mul_sum and rewriting (r−1)·(f(k)·rᵏ) = f(k)·(r^{k+1} − rᵏ) via pow_succ + ring, the goal matches (A) instantiated at G(k)=rᵏ with G(0)=r⁰=1; rw closes it."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Abel, N.H."
+      ],
+      "title": "Untersuchungen über die Reihe 1 + (m/1)x + m(m−1)/(1·2)x² + …",
+      "year": "1826",
+      "venue": "Journal für die reine und angewandte Mathematik 1, pp. 311–339",
+      "note": "Origin of Abel's summation-by-parts identity."
+    },
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Finite calculus: summation by parts (Abel transform), difference/antidifference operators, and arithmetico-geometric sums."
+    },
+    {
+      "authors": [
+        "Apostol, T.M."
+      ],
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Undergraduate Texts in Mathematics, Springer",
+      "note": "Abel (partial) summation as a standard tool for evaluating and estimating weighted sums."
+    }
+  ],
   "conclusion": {
     "summary": "This entry proves the general discrete Abel transform ∑_{k<n} f(k)·(G(k+1)−G(k)) = f(n)·G(n) − f(0)·G(0) − ∑_{k<n} (f(k+1)−f(k))·G(k+1), valid for any two sequences f, G over any commutative ring with no hypotheses, and reads off both pure telescoping (f ≡ 1) and the parent's geometric recursion (G(k) = rᵏ) as instances. It answers the parent entry's second open question: the hypothesis-free Abel mechanism is not special to a geometric base — it holds for an arbitrary antidifference G, packaged for reuse over a commutative ring.",
     "implications": "The transform is the discrete, finite analogue of integration by parts ∫ f dG = fG − ∫ G df, and subsumes the parent's geometric recursion (hence the whole ∑ kᵐ rᵏ ladder) as the case G(k) = rᵏ. Because it carries no hypotheses and lives over any commutative ring with an arbitrary antidifference, it is reusable infrastructure for any future entry needing a closed form for a sum against a sequence with a known antidifference — q-analogues, falling-factorial weights, or any g = ΔG.",

--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01/meta.json
@@ -47,6 +47,28 @@
       "mathContext": "Each corollary instantiates f in geom_weighted_recursion and simplifies the forward difference via push_cast + ring; the second-order case reproduces, as a one-line corollary, the degree-lowering step the parent entry summation-by-parts-oq-01-oq-01 established by a dedicated summation-by-parts computation."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Finite calculus: summation by parts (Abel transform), difference/antidifference operators, and arithmetico-geometric sums."
+    },
+    {
+      "authors": [
+        "Knuth, D.E."
+      ],
+      "title": "The Art of Computer Programming, Volume 1: Fundamental Algorithms",
+      "year": "1997",
+      "venue": "3rd ed., Addison-Wesley",
+      "note": "Summation by parts and closed forms for weighted geometric sums via the finite-calculus operators."
+    }
+  ],
   "conclusion": {
     "summary": "This entry proves the single hypothesis-free identity (r−1)·∑_{k<n} f(k)·rᵏ = f(n)·rⁿ − f(0) − ∑_{k<n} (f(k+1)−f(k))·r^{k+1}, valid for every sequence f over every commutative ring, and reads the geometric series and the first- and second-order arithmetico-geometric sums off it as corollaries. It answers the parent entry's first open question: the uniform mechanism behind every ∑ kᵐ·rᵏ closed form is the forward-difference recursion f ↦ Δf with explicit boundary term.",
     "implications": "The recursion is the discrete, finite analogue of integration by parts against dv = rᵏ, and it makes the degree-lowering ladder ∑ kᵐ rᵏ ↝ ∑ kᵐ⁻¹ rᵏ ↝ … ↝ ∑ rᵏ explicit and machine-checked. Because it carries no hypotheses and lives over any commutative ring, it is reusable infrastructure for any future entry that needs a closed form for a geometrically-weighted sum.",

--- a/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/meta.json
@@ -124,6 +124,28 @@
       "leanType": "∀ {K : Type*} [Field K] (r : K) (n : ℕ), ∑ k ∈ Finset.range n, (k : K) ^ 2 * r ^ k = (↑(n - 1) : K) ^ 2 * (∑ i ∈ Finset.range n, r ^ i) - ∑ i ∈ Finset.range (n - 1), (2 * (i : K) + 1) * (∑ j ∈ Finset.range (i + 1), r ^ j)"
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Finite calculus: summation by parts (Abel transform), difference/antidifference operators, and arithmetico-geometric sums."
+    },
+    {
+      "authors": [
+        "Knuth, D.E."
+      ],
+      "title": "The Art of Computer Programming, Volume 1: Fundamental Algorithms",
+      "year": "1997",
+      "venue": "3rd ed., Addison-Wesley",
+      "note": "Summation by parts and closed forms for weighted geometric sums via the finite-calculus operators."
+    }
+  ],
   "conclusion": {
     "summary": "This entry returns the finite second-moment identity ∑_{k<n} k²·rᵏ to its natural algebraic generality (any field, not just ℝ) and supplies the genuine Abel summation-by-parts derivation its ℝ-only sibling omitted. It adds the second falling-factorial closed form ∑ k(k−1)·rᵏ and the term-by-term decomposition k²=k(k−1)+k, tying the degree-≤2 weighted geometric sums into one family.",
     "implications": "Over any field the closed form is a polynomial-over-(r−1)³ identity with no analytic content. The summation-by-parts derivation makes explicit that the order of the discrete derivative (constant vs. linear forward differences) governs the shape of the correction term — the structural lever for the general ∑ P(k)·rᵏ.",

--- a/src/data/proofs/summation-by-parts-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01/meta.json
@@ -88,6 +88,28 @@
       "leanType": "∀ {K : Type*} [Field K] (r : K) (n : ℕ), ∑ k ∈ Finset.range n, (k : K) * r ^ k = (↑(n - 1) : K) * (∑ i ∈ Finset.range n, r ^ i) - ∑ i ∈ Finset.range (n - 1), (∑ j ∈ Finset.range (i + 1), r ^ j)"
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Graham, R.L.",
+        "Knuth, D.E.",
+        "Patashnik, O."
+      ],
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Finite calculus: summation by parts (Abel transform), difference/antidifference operators, and arithmetico-geometric sums."
+    },
+    {
+      "authors": [
+        "Knuth, D.E."
+      ],
+      "title": "The Art of Computer Programming, Volume 1: Fundamental Algorithms",
+      "year": "1997",
+      "venue": "3rd ed., Addison-Wesley",
+      "note": "Summation by parts and closed forms for weighted geometric sums via the finite-calculus operators."
+    }
+  ],
   "conclusion": {
     "summary": "This entry supplies the exact finite arithmetico-geometric identity ∑_{k<n} k·rᵏ = (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)² over any field, both by induction and via Abel's summation by parts — the finite refinement underpinning the gallery's infinite ∑ k·rᵏ = r/(1−r)².",
     "implications": "The closed form is the workhorse of discrete calculus and generating-function manipulation; the summation-by-parts derivation exhibits the discrete analogue of integration by parts as the structural source of the formula.",


### PR DESCRIPTION
Adds a top-level `references` array to 7 open-question descendants of **summation-by-parts** that previously had none.

## Coverage
Abel's discrete summation by parts over general rings and modules: the general discrete Abel transform, its biadditive-pairing generalization, iterated (finite Taylor–Abel) expansions, the degree-lowering recursion for geometric-weighted sums, and closed forms for the arithmetico-geometric sums ∑ k·rᵏ and ∑ k²·rᵏ.

## Method
Cited to Graham–Knuth–Patashnik (*Concrete Mathematics*) and Knuth (*TAOCP* Vol. 1) for finite calculus, plus Abel (1826) and Apostol for the classical partial-summation identity. 2–3 references per entry.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.