### PR TITLE
Enrich divisibility-rules OQ cluster: add references to 6 entries

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-02/meta.json
@@ -127,6 +127,29 @@
       "description": "Grandparent: existence of a decimal digit-block rule for every d coprime to 10."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Wright, E.M."
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "6th ed., Oxford University Press",
+      "note": "Congruences, Euler's theorem and the theory behind digit-sum and alternating-digit divisibility tests."
+    },
+    {
+      "authors": [
+        "Niven, I.",
+        "Zuckerman, H.S.",
+        "Montgomery, H.L."
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1991",
+      "venue": "5th ed., Wiley",
+      "note": "Modular arithmetic and the order of the base mod d underlying base-b divisibility rules."
+    }
+  ],
   "conclusion": {
     "summary": "A complete, base-independent proof that every d > 1 coprime to a base b ≥ 2 admits a base-b^k digit-sum divisibility rule, with k = φ(d) as a universal witness. The base-10 parent is the b = 10 corollary. 0 sorries, 0 axioms.",
     "implications": "Unifies all positional digit-sum divisibility tests under a single Euler-theorem mechanism, independent of the choice of numeral base.",

--- a/src/data/proofs/divisibility-rules-oq-01-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-01/meta.json
@@ -132,6 +132,27 @@
       "description": "Original divisibility rules gallery (specific cases)"
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Wright, E.M."
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "6th ed., Oxford University Press",
+      "note": "Congruences, Euler's theorem and the theory behind digit-sum and alternating-digit divisibility tests."
+    },
+    {
+      "authors": [
+        "Burton, D.M."
+      ],
+      "title": "Elementary Number Theory",
+      "year": "2010",
+      "venue": "7th ed., McGraw-Hill",
+      "note": "Divisibility tests, casting out nines, and block/truncation rules for 7, 11, 13."
+    }
+  ],
   "conclusion": {
     "summary": "A complete proof that every d > 1 coprime to 10 admits a digit-block divisibility rule, with k = φ(d) as an explicit universal witness. 0 sorries, 0 axioms.",
     "implications": "Provides the theoretical foundation for algorithmic divisibility testing of any number coprime to 10 using positional digit sums.",

--- a/src/data/proofs/divisibility-rules-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-02-oq-01/meta.json
@@ -50,6 +50,29 @@
       "Basic cyclic-group reasoning: order divides φ(d), coprimality of an odd number with 2"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Wright, E.M."
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "6th ed., Oxford University Press",
+      "note": "Congruences, Euler's theorem and the theory behind digit-sum and alternating-digit divisibility tests."
+    },
+    {
+      "authors": [
+        "Niven, I.",
+        "Zuckerman, H.S.",
+        "Montgomery, H.L."
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1991",
+      "venue": "5th ed., Wiley",
+      "note": "Modular arithmetic and the order of the base mod d underlying base-b divisibility rules."
+    }
+  ],
   "conclusion": {
     "summary": "Thirteen theorems establish a genuine per-base iff for the alternating digit-sum rule (it holds for base 10^k iff 10^k ≡ -1 mod d), and the sharp solvability criterion that a power-of-10 alternating rule exists for d > 2 coprime to 10 iff ord_d(10) is even and 10^{ord_d(10)/2} ≡ -1 (mod d). Positive instances (11, 7, 13) and negative instances (3, 37) illustrate the dichotomy.",
     "implications": "This is the alternating counterpart to the parent's universal digit-sum theorem and completes its open question. Where the digit-sum rule exists for every modulus coprime to 10, the alternating rule exists only for the 'even-order' moduli, with the witness base 10^{ord_d(10)/2} explicitly identified. The proof is 0-axiom and native_decide-free.",

--- a/src/data/proofs/divisibility-rules-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-02/meta.json
@@ -52,6 +52,27 @@
       "Multiplicative order in a monoid (orderOf, orderOf_dvd_iff_pow_eq_one) and ZMod d casts"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Wright, E.M."
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "6th ed., Oxford University Press",
+      "note": "Congruences, Euler's theorem and the theory behind digit-sum and alternating-digit divisibility tests."
+    },
+    {
+      "authors": [
+        "Burton, D.M."
+      ],
+      "title": "Elementary Number Theory",
+      "year": "2010",
+      "venue": "7th ed., McGraw-Hill",
+      "note": "Divisibility tests, casting out nines, and block/truncation rules for 7, 11, 13."
+    }
+  ],
   "conclusion": {
     "summary": "Twelve theorems establish that a power-of-10 digit-sum base exists for every modulus coprime to 10, identify the valid exponents as the multiples of the multiplicative order of 10, and pin the minimal working base at 10^{ord_d(10)}. Five concrete instances (3, 7, 13, 27, 37) are recovered as corollaries, including new base-10^6 rules for 7 and 13.",
     "implications": "This upgrades the parent's list of individually proved rules to a universal existence-and-sharpness statement: the question 'which moduli have a power-of-10 digit-sum rule?' is answered completely (all d coprime to 10) and the optimal base is characterized. The 0-axiom, native_decide-free proof also tightens the parent's Lean.ofReduceBool dependency.",

--- a/src/data/proofs/divisibility-rules-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01/meta.json
@@ -53,6 +53,26 @@
       "Nat.Coprime for natural number coprimality"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Burton, D.M."
+      ],
+      "title": "Elementary Number Theory",
+      "year": "2010",
+      "venue": "7th ed., McGraw-Hill",
+      "note": "Divisibility tests, casting out nines, and block/truncation rules for 7, 11, 13."
+    },
+    {
+      "authors": [
+        "Dickson, L.E."
+      ],
+      "title": "History of the Theory of Numbers, Volume I: Divisibility and Primality",
+      "year": "1919",
+      "venue": "Carnegie Institution of Washington",
+      "note": "Historical account of casting out nines and classical divisibility criteria."
+    }
+  ],
   "conclusion": {
     "summary": "This OQ-01 extension proves 41 theorems extending the base divisibility rules collection. The general dvd_iff_dvd_mod theorem provides a unified foundation for all last-k-digit rules, while the alternating sum and truncation methods cover divisibility by 7, 11, and 13. The casting out nines module provides both the arithmetic preservation theorems and a practical error-detection theorem.",
     "implications": "The generalization of last-k-digit rules to a single theorem demonstrates the power of modular arithmetic abstraction. The simultaneous coverage of divisibility by 7, 11, and 13 through the truncation/alternating-sum methods reflects the algebraic unity behind these seemingly disparate rules — all exploiting coprimality of 10 with the target divisor.",

--- a/src/data/proofs/divisibility-rules-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-02/meta.json
@@ -101,6 +101,27 @@
       "mathContext": "Concrete examples verified by `native_decide`: $7 \\mid 1001$ (altDigitSum$(1000, 1001) = 1 + 1 = 2$... wait, $1001 = 1 \\cdot 1000 + 1$, so altDigitSum $= 1 - 1 = 0$, $7 \\mid 0$ ✓). **Classical instances**: `eleven_dvd_iff_altDigitSum`: $b = 10$, since $10 \\equiv -1 \\pmod{11}$; the alternating 1-digit sum rule (alternating digit sum divisible by 11). `hundredone_dvd_iff_altDigitSum`: $b = 100$, since $100 \\equiv -1 \\pmod{101}$; the 2-digit block alternating sum rule for 101. These show the general framework covers all classical alternating divisibility rules, unified by $b \\equiv -1 \\pmod{d}$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Wright, E.M."
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "6th ed., Oxford University Press",
+      "note": "Congruences, Euler's theorem and the theory behind digit-sum and alternating-digit divisibility tests."
+    },
+    {
+      "authors": [
+        "Burton, D.M."
+      ],
+      "title": "Elementary Number Theory",
+      "year": "2010",
+      "venue": "7th ed., McGraw-Hill",
+      "note": "Divisibility tests, casting out nines, and block/truncation rules for 7, 11, 13."
+    }
+  ],
   "conclusion": {
     "summary": "Proves a general alternating block divisibility test: for any d and base b with b ≡ -1 (mod d), divisibility by d is equivalent to divisibility of the alternating sum of b-ary blocks. Instantiated for d ∈ {7, 11, 13, 101} with respective bases b ∈ {1000, 10, 1000, 100}.",
     "implications": "The framework shows that divisibility rules for 7, 11, 13, and 101 are all instances of a single pattern determined by the congruence b ≡ -1 (mod d). More generally, b^k ≡ -1 (mod d) yields a k-digit alternating block sum rule. This unification suggests a complete classification of 'alternating sum' divisibility rules for all d.",


### PR DESCRIPTION
Adds a top-level `references` array to 6 open-question descendants of **divisibility-rules** that previously had none.

## Coverage
Generalizations of elementary digit divisibility tests: the base-b digit-sum rule for moduli coprime to the base (via the multiplicative order of the base / Euler's theorem), the existence of a power-of-10 digit-sum base for every modulus coprime to 10, the characterization of which moduli admit an alternating-digit-sum rule, and the alternating 3-digit-block rules for 7, 11 and 13 together with casting out nines.

## Method
Cited to Hardy–Wright, Niven–Zuckerman–Montgomery and Burton (elementary number theory), plus Dickson's *History of the Theory of Numbers* for the classical criteria. 2 references per entry.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.