### PR TITLE
Enrich konigsberg OQ cluster: add references to 6 entries

### DIFF
--- a/src/data/proofs/konigsberg-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-01/meta.json
@@ -115,6 +115,26 @@
       "mathContext": "Epilogue; no new declarations. #checks confirm sqCircuit_isEulerian, pentCircuit_isEulerian, k4_not_eulerian, and regular_odd_no_euler typecheck."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Euler, L."
+      ],
+      "title": "Solutio problematis ad geometriam situs pertinentis",
+      "year": "1736",
+      "venue": "Commentarii Academiae Scientiarum Petropolitanae 8, pp. 128–140",
+      "note": "The Seven Bridges of Königsberg, founding paper of graph theory; the even-degree criterion for Eulerian circuits."
+    },
+    {
+      "authors": [
+        "West, D.B."
+      ],
+      "title": "Introduction to Graph Theory",
+      "year": "2001",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Textbook treatment of Eulerian circuits/paths in undirected and directed graphs."
+    }
+  ],
   "conclusion": {
     "summary": "Verifies Eulerian circuit existence for $C_4$ (explicit 4-edge circuit) and $C_5$ (explicit 5-edge circuit), and non-existence for $K_4$ (4 odd-degree vertices) and all odd-regular graphs with $|V| \\geq 3$. Proves general necessary conditions: Eulerian circuits require all-even degrees; Eulerian paths require $\\leq 2$ odd-degree vertices. 24 theorems, 8 definitions, 404 lines, no mathematical axioms in the main file (the concrete native_decide theorems depend on `Lean.ofReduceBool` via the compiler's kernel reduction). The companion HierholzerAlgorithm.lean axiomatizes the sufficiency direction (2 axioms) pending Hierholzer's algorithm formalization.",
     "implications": "This provides machine-verified concrete examples for Euler's theorem — the foundational result of graph theory. The combination of explicit circuit constructions (positive examples) with odd-degree counting arguments (negative examples) demonstrates both directions of the degree criterion. The `Walk.IsEulerian.card_odd_degree` lemma from Mathlib is the key bridge between the combinatorial structure and the algebraic degree counts.",

--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "konigsberg-oq-02-oq-01",
-  "title": "Hierholzer's Algorithm \u2014 Directed Eulerian Circuit (Corrected)",
+  "title": "Hierholzer's Algorithm — Directed Eulerian Circuit (Corrected)",
   "slug": "konigsberg-oq-02-oq-01",
   "description": "Fully formalizes Hierholzer's algorithm for directed Eulerian circuits, correcting a bug in KonigsbergOQ02 where `directed_euler_circuit_sufficient` was missing the strong connectivity hypothesis. Complete proof with 0 sorries: maximal trail sub-lemma, Walk.splice, removeArcList infrastructure, and WF induction on arcCount.",
   "meta": {
@@ -31,36 +31,56 @@
     "originalContributions": [
       "Bug fix: directed_euler_circuit_sufficient in KonigsbergOQ02 missing isStronglyConnected hypothesis",
       "Digraph.isStronglyConnected: definition of the missing hypothesis with counterexample documentation",
-      "maximal_balanced_trail_is_circuit: proved (0 sorries) \u2014 key Hierholzer sub-lemma",
-      "fst_count_eq_outDegree_stuck: proved \u2014 count of out-arcs equals outDegree at stuck vertex",
-      "snd_count_le_inDegree: proved \u2014 count of in-arcs is at most inDegree for Nodup trails",
-      "Walk.splice: proved (0 sorries) \u2014 concatenate two walks at a shared vertex",
-      "Walk.splice_nodup: proved \u2014 arc-disjoint splice yields Nodup walk",
-      "removeArcList: definition \u2014 residual digraph removing an arc list",
-      "removeArcList_arcCount: proved (0 sorries) \u2014 residual arcCount = D.arcCount - removed",
-      "removeArcList_balanced: proved (0 sorries) \u2014 removing a circuit preserves balance",
-      "walk_split_at: proved (0 sorries) \u2014 split a circuit at an interior vertex using take/drop",
-      "nodup_circuit_exists_of_outDeg_pos: proved (0 sorries) \u2014 WF induction building Nodup circuit",
-      "walk_closed: proved \u2014 digraph closure forces walks to stay in closed sets",
-      "vertex_with_unused_arc: proved (0 sorries) \u2014 strong connectivity provides extension vertex",
-      "directed_euler_circuit_sufficient_corrected: proved (0 sorries) \u2014 full Hierholzer algorithm via WF induction on arcCount"
+      "maximal_balanced_trail_is_circuit: proved (0 sorries) — key Hierholzer sub-lemma",
+      "fst_count_eq_outDegree_stuck: proved — count of out-arcs equals outDegree at stuck vertex",
+      "snd_count_le_inDegree: proved — count of in-arcs is at most inDegree for Nodup trails",
+      "Walk.splice: proved (0 sorries) — concatenate two walks at a shared vertex",
+      "Walk.splice_nodup: proved — arc-disjoint splice yields Nodup walk",
+      "removeArcList: definition — residual digraph removing an arc list",
+      "removeArcList_arcCount: proved (0 sorries) — residual arcCount = D.arcCount - removed",
+      "removeArcList_balanced: proved (0 sorries) — removing a circuit preserves balance",
+      "walk_split_at: proved (0 sorries) — split a circuit at an interior vertex using take/drop",
+      "nodup_circuit_exists_of_outDeg_pos: proved (0 sorries) — WF induction building Nodup circuit",
+      "walk_closed: proved — digraph closure forces walks to stay in closed sets",
+      "vertex_with_unused_arc: proved (0 sorries) — strong connectivity provides extension vertex",
+      "directed_euler_circuit_sufficient_corrected: proved (0 sorries) — full Hierholzer algorithm via WF induction on arcCount"
     ]
   },
   "overview": {
-    "historicalContext": "Carl Hierholzer (1840\u20131871) published his algorithm for directed Eulerian circuits posthumously in 1873. Euler had characterized Eulerian paths in 1736 (the K\u00f6nigsberg bridges problem), but the constructive algorithm \u2014 greedily extending trails until stuck, then splicing sub-circuits \u2014 was Hierholzer's contribution, running in O(E) time.\n\nFor directed graphs, balance alone (indeg = outdeg) is necessary but not sufficient. Two disjoint directed triangles satisfy balance but have no Eulerian circuit spanning both components. **Strong connectivity** is the missing ingredient. This file fixes a bug in the parent proof (KonigsbergOQ02) where the sufficiency axiom omitted this hypothesis.\n\nThis entry formalizes the key Hierholzer sub-lemma \u2014 that any maximal Nodup trail in a balanced digraph must close into a circuit \u2014 using a counting argument on the balance condition.",
-    "problemStatement": "**Corrected Directed Eulerian Circuit Sufficiency** (Hierholzer, 1873):\n\nLet $D = (V, A)$ be a finite directed graph where:\n1. $D$ is **strongly connected**: $\\forall u, v \\in V$, there exists a directed walk from $u$ to $v$\n2. Every vertex satisfies $\\mathrm{indeg}(v) = \\mathrm{outdeg}(v)$ (**balance**)\n\nThen $\\exists v_0 \\in V$ and a closed walk $W$ from $v_0$ to $v_0$ traversing every arc exactly once (an **Eulerian circuit**).\n\n**Bug in KonigsbergOQ02**: `directed_euler_circuit_sufficient` omitted hypothesis (1). Counterexample: two disjoint directed triangles \u2014 balanced, but no single trail spans both components.",
-    "proofStrategy": "Hierholzer's algorithm:\n1. Build maximal Nodup trail from v\u2080 (greedy edge following)\n2. By `maximal_balanced_trail_is_circuit`: maximal trail must be a closed circuit C\n3. If C is Eulerian: done\n4. If not: some vertex u on C has unused out-arcs (by strong connectivity + balance)\n5. Build new circuit C' from u in the residual subgraph D' = D.removeArcList C.arcs\n6. D' is balanced (by removeArcList_balanced)\n7. Splice C' into C at vertex u (by Walk.splice)\n8. Repeat (WF induction on D.arcCount - current circuit length)",
+    "historicalContext": "Carl Hierholzer (1840–1871) published his algorithm for directed Eulerian circuits posthumously in 1873. Euler had characterized Eulerian paths in 1736 (the Königsberg bridges problem), but the constructive algorithm — greedily extending trails until stuck, then splicing sub-circuits — was Hierholzer's contribution, running in O(E) time.\n\nFor directed graphs, balance alone (indeg = outdeg) is necessary but not sufficient. Two disjoint directed triangles satisfy balance but have no Eulerian circuit spanning both components. **Strong connectivity** is the missing ingredient. This file fixes a bug in the parent proof (KonigsbergOQ02) where the sufficiency axiom omitted this hypothesis.\n\nThis entry formalizes the key Hierholzer sub-lemma — that any maximal Nodup trail in a balanced digraph must close into a circuit — using a counting argument on the balance condition.",
+    "problemStatement": "**Corrected Directed Eulerian Circuit Sufficiency** (Hierholzer, 1873):\n\nLet $D = (V, A)$ be a finite directed graph where:\n1. $D$ is **strongly connected**: $\\forall u, v \\in V$, there exists a directed walk from $u$ to $v$\n2. Every vertex satisfies $\\mathrm{indeg}(v) = \\mathrm{outdeg}(v)$ (**balance**)\n\nThen $\\exists v_0 \\in V$ and a closed walk $W$ from $v_0$ to $v_0$ traversing every arc exactly once (an **Eulerian circuit**).\n\n**Bug in KonigsbergOQ02**: `directed_euler_circuit_sufficient` omitted hypothesis (1). Counterexample: two disjoint directed triangles — balanced, but no single trail spans both components.",
+    "proofStrategy": "Hierholzer's algorithm:\n1. Build maximal Nodup trail from v₀ (greedy edge following)\n2. By `maximal_balanced_trail_is_circuit`: maximal trail must be a closed circuit C\n3. If C is Eulerian: done\n4. If not: some vertex u on C has unused out-arcs (by strong connectivity + balance)\n5. Build new circuit C' from u in the residual subgraph D' = D.removeArcList C.arcs\n6. D' is balanced (by removeArcList_balanced)\n7. Splice C' into C at vertex u (by Walk.splice)\n8. Repeat (WF induction on D.arcCount - current circuit length)",
     "keyInsights": [
-      "**Strong connectivity is necessary**: Two disjoint balanced directed triangles satisfy balance but have no Eulerian circuit \u2014 any trail stays within one component. The original axiom in KonigsbergOQ02 was unsound without this hypothesis.",
+      "**Strong connectivity is necessary**: Two disjoint balanced directed triangles satisfy balance but have no Eulerian circuit — any trail stays within one component. The original axiom in KonigsbergOQ02 was unsound without this hypothesis.",
       "**Balance counting forces circuit closure**: The proof uses the path equation $[u] \\mathbin{++} \\mathrm{map\\ snd}(arcs) = \\mathrm{map\\ fst}(arcs) \\mathbin{++} [v_0]$. Counting occurrences of $v_0$ with the stuck condition ($fst\\text{-}count = outDeg$) and the Nodup bound ($snd\\text{-}count \\leq inDeg = outDeg$) forces $u = v_0$.",
       "**Nodup is essential**: Without the Nodup condition, repeated arcs could inflate counts and break the degree bound inequality needed for the counting argument.",
-      "**path_fst_snd_eq vs circuit_fst_perm_snd**: For circuits (start = end), fst and snd multisets are equal. For paths, they differ by exactly the endpoints \u2014 the reproved path equation exploits this difference.",
-      "**Formal verification catches axiom bugs**: Attempting to prove the corrected theorem revealed that the original axiom was missing a hypothesis \u2014 a subtle error that informal mathematical intuition might overlook.",
-      "**removeArcList preserves balance**: Removing a directed circuit C from digraph D yields a balanced residual \u2014 because circuit_fst_perm_snd ensures each vertex loses exactly one in-arc and one out-arc per circuit traversal, maintaining inDeg = outDeg.",
+      "**path_fst_snd_eq vs circuit_fst_perm_snd**: For circuits (start = end), fst and snd multisets are equal. For paths, they differ by exactly the endpoints — the reproved path equation exploits this difference.",
+      "**Formal verification catches axiom bugs**: Attempting to prove the corrected theorem revealed that the original axiom was missing a hypothesis — a subtle error that informal mathematical intuition might overlook.",
+      "**removeArcList preserves balance**: Removing a directed circuit C from digraph D yields a balanced residual — because circuit_fst_perm_snd ensures each vertex loses exactly one in-arc and one out-arc per circuit traversal, maintaining inDeg = outDeg.",
       "**WF induction on arcCount**: nodup_circuit_exists_of_outDeg_pos uses Nat.lt_wfRel on the residual arcCount. Each recursive call produces a strictly smaller residual (removeArcList_arcCount), ensuring termination regardless of graph connectivity.",
-      "**walk_split_at enables circuit splicing**: Splitting a circuit W at an interior vertex u via List.take/drop produces two walks W\u2081 and W\u2082; Walk.splice then recombines them with an inserted sub-circuit, extending coverage without revisiting arcs."
+      "**walk_split_at enables circuit splicing**: Splitting a circuit W at an interior vertex u via List.take/drop produces two walks W₁ and W₂; Walk.splice then recombines them with an inserted sub-circuit, extending coverage without revisiting arcs."
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Hierholzer, C."
+      ],
+      "title": "Über die Möglichkeit, einen Linienzug ohne Wiederholung und ohne Unterbrechung zu umfahren",
+      "year": "1873",
+      "venue": "Mathematische Annalen 6 (1), pp. 30–32",
+      "note": "Hierholzer's constructive algorithm for Eulerian circuits."
+    },
+    {
+      "authors": [
+        "West, D.B."
+      ],
+      "title": "Introduction to Graph Theory",
+      "year": "2001",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Textbook treatment of Eulerian circuits/paths in undirected and directed graphs."
+    }
+  ],
   "conclusion": {
     "summary": "Complete Hierholzer algorithm formalized with 0 sorries: corrects missing isStronglyConnected hypothesis in KonigsbergOQ02, proves all supporting lemmas (maximal trail circuit, Walk.splice, removeArcList balance/count, walk_split_at, vertex_with_unused_arc), and closes the main theorem via WF induction on arcCount.",
     "implications": [
@@ -105,14 +125,14 @@
       "title": "Part I: Auxiliary List Lemmas",
       "startLine": 39,
       "endLine": 79,
-      "summary": "chain_tail_fst_eq_dropLast_snd and path_fst_snd_eq \u2014 reproved since private in OQ02"
+      "summary": "chain_tail_fst_eq_dropLast_snd and path_fst_snd_eq — reproved since private in OQ02"
     },
     {
       "id": "sec-strong-connectivity",
       "title": "Part II: Strong Connectivity",
       "startLine": 80,
       "endLine": 94,
-      "summary": "Digraph.isStronglyConnected \u2014 the hypothesis missing from directed_euler_circuit_sufficient"
+      "summary": "Digraph.isStronglyConnected — the hypothesis missing from directed_euler_circuit_sufficient"
     },
     {
       "id": "sec-counting",
@@ -126,7 +146,7 @@
       "title": "Part IV: Maximal Trail is a Circuit",
       "startLine": 156,
       "endLine": 214,
-      "summary": "maximal_balanced_trail_is_circuit \u2014 proved with 0 sorries; the key Hierholzer sub-lemma"
+      "summary": "maximal_balanced_trail_is_circuit — proved with 0 sorries; the key Hierholzer sub-lemma"
     },
     {
       "id": "sec-walk-splice",
@@ -147,14 +167,14 @@
       "title": "Part VII: Nodup Circuit Sub-Lemmas",
       "startLine": 481,
       "endLine": 715,
-      "summary": "nodup_arcs_length_le, isEulerian_of_length_eq, nodup_circuit_exists_of_outDeg_pos \u2014 WF induction on residual arcCount builds Nodup circuit from any vertex with positive outDegree"
+      "summary": "nodup_arcs_length_le, isEulerian_of_length_eq, nodup_circuit_exists_of_outDeg_pos — WF induction on residual arcCount builds Nodup circuit from any vertex with positive outDegree"
     },
     {
       "id": "sec-walk-split-hierholzer",
       "title": "Part VIII: walk_split_at and Full Hierholzer Assembly",
       "startLine": 716,
       "endLine": 954,
-      "summary": "walk_closed, vertex_with_unused_arc, walk_split_at (List.take/drop), circuit splicing machinery, and directed_euler_circuit_sufficient_corrected \u2014 final Hierholzer algorithm via WF induction on arcCount"
+      "summary": "walk_closed, vertex_with_unused_arc, walk_split_at (List.take/drop), circuit splicing machinery, and directed_euler_circuit_sufficient_corrected — final Hierholzer algorithm via WF induction on arcCount"
     }
   ],
   "crossReferences": [
@@ -166,7 +186,7 @@
     {
       "targetId": "konigsberg",
       "relationship": "ancestor",
-      "description": "Original K\u00f6nigsberg bridges undirected case"
+      "description": "Original Königsberg bridges undirected case"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/konigsberg-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-02/meta.json
@@ -52,6 +52,36 @@
       "Euler's theorem for undirected graphs (Wiedijk #53)"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Euler, L."
+      ],
+      "title": "Solutio problematis ad geometriam situs pertinentis",
+      "year": "1736",
+      "venue": "Commentarii Academiae Scientiarum Petropolitanae 8, pp. 128–140",
+      "note": "The Seven Bridges of Königsberg, founding paper of graph theory; the even-degree criterion for Eulerian circuits."
+    },
+    {
+      "authors": [
+        "Bondy, J.A.",
+        "Murty, U.S.R."
+      ],
+      "title": "Graph Theory",
+      "year": "2008",
+      "venue": "Graduate Texts in Mathematics 244, Springer",
+      "note": "Eulerian graphs, the in-degree/out-degree characterization and the BEST theorem."
+    },
+    {
+      "authors": [
+        "West, D.B."
+      ],
+      "title": "Introduction to Graph Theory",
+      "year": "2001",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Textbook treatment of Eulerian circuits/paths in undirected and directed graphs."
+    }
+  ],
   "conclusion": {
     "summary": "The directed Euler theorem is formalized with 2 axioms for the sufficiency directions. Necessity (balanced degrees → needed for Eulerian circuit/path) is fully proved. 35 theorems, 8 definitions, 813 lines.",
     "implications": "Directed Eulerian path theory is used in computational linguistics (de Bruijn sequences), bioinformatics (genome assembly via de Bruijn graphs), and Chinese Postman Problem algorithms. The formal characterization enables verified routing and traversal algorithms.",

--- a/src/data/proofs/konigsberg-oq-03-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-03-oq-01/meta.json
@@ -103,6 +103,28 @@
       "summary": "Recap table of the two verified instances and an explicit statement that the general theorem remains open and unaxiomatized. #check commands documenting the public results."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Erdős, P.",
+        "Grünwald, T.",
+        "Weiszfeld, E."
+      ],
+      "title": "On Euler lines of infinite graphs (Hungarian)",
+      "year": "1938",
+      "venue": "Matematikai és Fizikai Lapok 43, pp. 129–140",
+      "note": "The Erdős–Grünwald–Weiszfeld characterization of Euler lines in infinite graphs."
+    },
+    {
+      "authors": [
+        "Diestel, R."
+      ],
+      "title": "Graph Theory",
+      "year": "2017",
+      "venue": "5th ed., Graduate Texts in Mathematics 173, Springer",
+      "note": "Infinite graphs and Eulerian tours via compactness/König's lemma."
+    }
+  ],
   "conclusion": {
     "summary": "For each of the two canonical locally finite graphs — the one-way ray on ℕ and the bi-infinite line on ℤ — both Erdős–Grünwald–Weiszfeld hypotheses (local finiteness + the degree-parity profile) and the EGW conclusion (an explicit Euler walk traversing every edge exactly once) are verified with 0 axioms and 0 sorries. A general lemma makes 'exactly once' precise: every edge is traversed at a unique step index.",
     "implications": "This pins down the verifiable core of the EGW theorem and exhibits, concretely, the two shapes an infinite Euler object can take (path vs. circuit) together with their classical parity signatures. It builds directly on the InfiniteWalk semantics of konigsberg-oq-03-oq-02, demonstrating that those definitions support genuine theorems and not just stubs. The local-finiteness and degree API is reusable for any future attack on the general theorem.",

--- a/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
@@ -98,6 +98,28 @@
       "summary": "Module summary comment recapping design choices. #check commands documenting the public API: InfiniteWalk, IsEulerWalk, HasOneWayInfiniteEulerPath, BiInfiniteWalk, step_ne."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Diestel, R."
+      ],
+      "title": "Graph Theory",
+      "year": "2017",
+      "venue": "5th ed., Graduate Texts in Mathematics 173, Springer",
+      "note": "Infinite graphs and Eulerian tours via compactness/König's lemma."
+    },
+    {
+      "authors": [
+        "Erdős, P.",
+        "Grünwald, T.",
+        "Weiszfeld, E."
+      ],
+      "title": "On Euler lines of infinite graphs (Hungarian)",
+      "year": "1938",
+      "venue": "Matematikai és Fizikai Lapok 43, pp. 129–140",
+      "note": "The Erdős–Grünwald–Weiszfeld characterization of Euler lines in infinite graphs."
+    }
+  ],
   "conclusion": {
     "summary": "The ℕ-indexed InfiniteWalk provides a clean, sorry-free foundation for infinite Euler paths in Lean 4. The definitions are ready for use in the Erdős-Grünwald-Weiszfeld theorem formalization. Key simplifications: ℕ over Stream', split Euler condition, undirected edges via sameEdge without Sym2.",
     "implications": "These definitions serve as the semantic foundation for formalizing the Erdős-Grünwald-Weiszfeld theorem in infinite graph theory, which characterizes exactly when an infinite (locally finite, connected) graph has a one-way infinite Euler path. The BiInfiniteWalk (ℤ-indexed) extends this to two-way Euler paths, and the sameEdge approach provides a cleaner formalization than Sym2 for undirected graphs in Lean 4. The N-indexed approach over Stream' is a principled design choice: it is computationally transparent, avoids coinductive types, and aligns with Mathlib's finset-based summation over ℕ.",

--- a/src/data/proofs/konigsberg-oq-04/meta.json
+++ b/src/data/proofs/konigsberg-oq-04/meta.json
@@ -73,6 +73,28 @@
       "summary": "Formalizes decidability of Eulerian circuit existence via balance checking, and documents the directed/undirected counting complexity gap."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "van Aardenne-Ehrenfest, T.",
+        "de Bruijn, N.G."
+      ],
+      "title": "Circuits and trees in oriented linear graphs",
+      "year": "1951",
+      "venue": "Simon Stevin 28, pp. 203–217",
+      "note": "With Smith and Tutte (1941), the BEST theorem counting directed Eulerian circuits via arborescences."
+    },
+    {
+      "authors": [
+        "Bondy, J.A.",
+        "Murty, U.S.R."
+      ],
+      "title": "Graph Theory",
+      "year": "2008",
+      "venue": "Graduate Texts in Mathematics 244, Springer",
+      "note": "Eulerian graphs, the in-degree/out-degree characterization and the BEST theorem."
+    }
+  ],
   "conclusion": {
     "summary": "This formalization establishes the BEST theorem framework in Lean 4 for counting directed Eulerian circuits. The theorem is axiomatized (requiring the Matrix Tree Theorem for a full proof) and verified on two concrete examples: $C_3$ (unique circuit) and bidirectional $K_3$ (6 circuits). The cycle exclusion argument for arborescence completeness on $K_3$ is a notable proof. The decision-vs-counting complexity gap is documented.",
     "implications": "The BEST theorem demonstrates that directed Eulerian circuit counting is polynomial, contrasting with the #P-completeness of undirected counting. This is one of the sharpest known complexity separations between directed and undirected graph problems. A full formalization would require the Matrix Tree Theorem, connecting to Kirchhoff's work and algebraic graph theory.",


### PR DESCRIPTION
Adds a top-level `references` array to 6 open-question descendants of **konigsberg** that previously had none.

## Coverage
Eulerian path/circuit theory: Eulerian circuits in concrete graph families, the directed in-degree/out-degree characterization, Hierholzer's constructive algorithm, the BEST theorem for counting directed Eulerian circuits, and the infinite-graph (Erdős–Grünwald–Weiszfeld) setting.

## Method
Cited to Euler's founding 1736 paper, Hierholzer (1873), the van Aardenne-Ehrenfest–de Bruijn BEST paper (1951), Erdős–Grünwald–Weiszfeld (1938), and the standard texts West, Bondy–Murty and Diestel. 2–3 references per entry.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.