### PR TITLE
Enrich hilbert-10 OQ-children cluster: add references (6 entries)

### DIFF
--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/meta.json
@@ -161,5 +161,36 @@
       "Can the bridge vecGcd = Finset.gcd be generalized from ℤ to an arbitrary Euclidean domain (or Bézout domain), recovering both the explicit witness and the abstract criterion uniformly?",
       "What is the bit-complexity of the constructive solver relative to computing Finset.gcd, and does the normalized identification suggest a fused algorithm that returns both the gcd and the Bézout vector in one pass?"
     ]
-  }
+  },
+  "references": [
+    {
+      "authors": [
+        "Ivan Niven",
+        "Herbert S. Zuckerman",
+        "Hugh L. Montgomery"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 1991,
+      "venue": "Wiley (5th ed.)",
+      "note": "Linear Diophantine equations, the gcd/Bézout solvability criterion, and explicit solution construction."
+    },
+    {
+      "authors": [
+        "Henri Cohen"
+      ],
+      "title": "A Course in Computational Algebraic Number Theory",
+      "year": 1993,
+      "venue": "Springer, Graduate Texts in Mathematics 138",
+      "note": "Algorithms for the Hermite and Smith normal forms and constructive solution of linear Diophantine systems."
+    },
+    {
+      "authors": [
+        "Serge Lang"
+      ],
+      "title": "Algebra",
+      "year": 2002,
+      "venue": "Springer, Graduate Texts in Mathematics 211 (3rd ed.)",
+      "note": "gcd in PIDs and the abstract Finset.gcd reconciled with recursive fold definitions."
+    }
+  ]
 }

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01/meta.json
@@ -199,5 +199,36 @@
       "relationship": "extends",
       "description": "Makes the forward direction of the grandparent's linear_bezout_n criterion constructive, exhibiting the solution rather than only asserting it exists."
     }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Ivan Niven",
+        "Herbert S. Zuckerman",
+        "Hugh L. Montgomery"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 1991,
+      "venue": "Wiley (5th ed.)",
+      "note": "Linear Diophantine equations, the gcd/Bézout solvability criterion, and explicit solution construction."
+    },
+    {
+      "authors": [
+        "Henri Cohen"
+      ],
+      "title": "A Course in Computational Algebraic Number Theory",
+      "year": 1993,
+      "venue": "Springer, Graduate Texts in Mathematics 138",
+      "note": "Algorithms for the Hermite and Smith normal forms and constructive solution of linear Diophantine systems."
+    },
+    {
+      "authors": [
+        "Alexander Schrijver"
+      ],
+      "title": "Theory of Linear and Integer Programming",
+      "year": 1986,
+      "venue": "Wiley",
+      "note": "Constructive extended-Euclidean solvers producing explicit witnesses for linear Diophantine equations."
+    }
   ]
 }

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02-oq-01/meta.json
@@ -152,5 +152,34 @@
     "definitionCount": 1,
     "axiomCount": 0,
     "sorries": 0
-  }
+  },
+  "references": [
+    {
+      "authors": [
+        "Henry J. S. Smith"
+      ],
+      "title": "On Systems of Linear Indeterminate Equations and Congruences",
+      "year": 1861,
+      "venue": "Philosophical Transactions of the Royal Society of London 151, 293–326",
+      "note": "Original derivation of the invariant-factor (Smith) normal form for integer matrices."
+    },
+    {
+      "authors": [
+        "Morris Newman"
+      ],
+      "title": "Integral Matrices",
+      "year": 1972,
+      "venue": "Academic Press (Pure and Applied Mathematics 45)",
+      "note": "Smith normal form and the theory of integer matrices underlying decidability of linear Diophantine systems."
+    },
+    {
+      "authors": [
+        "Henri Cohen"
+      ],
+      "title": "A Course in Computational Algebraic Number Theory",
+      "year": 1993,
+      "venue": "Springer, Graduate Texts in Mathematics 138",
+      "note": "Algorithms for the Hermite and Smith normal forms and constructive solution of linear Diophantine systems."
+    }
+  ]
 }

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02/meta.json
@@ -136,5 +136,34 @@
     "definitionCount": 0,
     "axiomCount": 0,
     "sorries": 0
-  }
+  },
+  "references": [
+    {
+      "authors": [
+        "Morris Newman"
+      ],
+      "title": "Integral Matrices",
+      "year": 1972,
+      "venue": "Academic Press (Pure and Applied Mathematics 45)",
+      "note": "Smith normal form and the theory of integer matrices underlying decidability of linear Diophantine systems."
+    },
+    {
+      "authors": [
+        "Henry J. S. Smith"
+      ],
+      "title": "On Systems of Linear Indeterminate Equations and Congruences",
+      "year": 1861,
+      "venue": "Philosophical Transactions of the Royal Society of London 151, 293–326",
+      "note": "Original derivation of the invariant-factor (Smith) normal form for integer matrices."
+    },
+    {
+      "authors": [
+        "Alexander Schrijver"
+      ],
+      "title": "Theory of Linear and Integer Programming",
+      "year": 1986,
+      "venue": "Wiley",
+      "note": "Column-lattice (integer span) membership and its decision via normal forms."
+    }
+  ]
 }

--- a/src/data/proofs/hilbert-10-oq-04-oq-03/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03/meta.json
@@ -169,5 +169,36 @@
     "definitionCount": 4,
     "axiomCount": 0,
     "sorries": 0
-  }
+  },
+  "references": [
+    {
+      "authors": [
+        "Ivan Niven",
+        "Herbert S. Zuckerman",
+        "Hugh L. Montgomery"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 1991,
+      "venue": "Wiley (5th ed.)",
+      "note": "Linear Diophantine equations, the gcd/Bézout solvability criterion, and explicit solution construction."
+    },
+    {
+      "authors": [
+        "Martin Davis"
+      ],
+      "title": "Hilbert's Tenth Problem is Unsolvable",
+      "year": 1973,
+      "venue": "American Mathematical Monthly 80(3), 233–269",
+      "note": "Expository proof that Diophantine sets coincide with recursively enumerable sets."
+    },
+    {
+      "authors": [
+        "Alexander Schrijver"
+      ],
+      "title": "Theory of Linear and Integer Programming",
+      "year": 1986,
+      "venue": "Wiley",
+      "note": "Decidability of linear Diophantine solvability via the gcd divisibility criterion."
+    }
+  ]
 }

--- a/src/data/proofs/hilbert-10-oq-04/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04/meta.json
@@ -176,5 +176,34 @@
     "definitionCount": 7,
     "axiomCount": 4,
     "sorries": 0
-  }
+  },
+  "references": [
+    {
+      "authors": [
+        "Yuri V. Matiyasevich"
+      ],
+      "title": "Hilbert's Tenth Problem",
+      "year": 1993,
+      "venue": "MIT Press",
+      "note": "Definitive account of the unsolvability of Hilbert's tenth problem (the MRDP theorem)."
+    },
+    {
+      "authors": [
+        "Martin Davis"
+      ],
+      "title": "Hilbert's Tenth Problem is Unsolvable",
+      "year": 1973,
+      "venue": "American Mathematical Monthly 80(3), 233–269",
+      "note": "Expository proof that Diophantine sets coincide with recursively enumerable sets."
+    },
+    {
+      "authors": [
+        "James P. Jones"
+      ],
+      "title": "Universal Diophantine Equation",
+      "year": 1982,
+      "venue": "Journal of Symbolic Logic 47(3), 549–571",
+      "note": "Establishes the 9-unknowns upper bound for universal (undecidable) Diophantine equations."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass: adds bibliographic `references` to 6 empty-reference OQ-children of the **hilbert-10** base.

| Entry | Topic |
|-------|-------|
| oq-04 | Simplest undecidable Diophantine equation (MRDP, 9-var bound) |
| oq-04-oq-03 | Linear Diophantine solvability is decidable (gcd criterion) |
| oq-04-oq-03-oq-01 | Constructive Bézout solver |
| oq-04-oq-03-oq-01-oq-01 | vecGcd = Finset.gcd bridge |
| oq-04-oq-03-oq-02 | Systems reduce to column-lattice membership |
| oq-04-oq-03-oq-02-oq-01 | Deciding linear systems via Smith normal form |

References drawn from canonical sources (Matiyasevich, Davis, Jones, Niven–Zuckerman–Montgomery, Smith 1861, Newman, Cohen, Schrijver, Lang) matched to each child's topic. Only the top-level `references` field is added; all other keys byte-verified identical to origin/main.