### PR TITLE
Enrich abel-ruffini OQ cluster: add references to 9 entries

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/meta.json
@@ -104,6 +104,27 @@
       "summary": "isSimpleGroup_quotient and of_isSimpleGroup_quotient: each implication as a reusable dot-notation lemma."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "Galois Theory",
+      "year": "1998",
+      "venue": "2nd ed., Universitext, Springer",
+      "note": "Jordan–Hölder theory and the simple-quotient / maximal-normal-subgroup correspondence."
+    },
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Solvable groups, the Galois correspondence, and the group-theoretic core of the Abel–Ruffini theorem."
+    }
+  ],
   "conclusion": {
     "summary": "The combinatorial maximality predicate IsMaxNorm and the categorical simplicity predicate IsSimpleGroup of the quotient are equivalent, for K = ⊤: G ⧸ N is simple iff N is a maximal normal subgroup. The forward direction pushes a normal M ⊇ N into the quotient (it must be ⊥ or ⊤, giving M = N or M = ⊤); the reverse pulls a normal subgroup of G ⧸ N back through mk' and uses injectivity of the correspondence map. This is the bridge the parent entry asserted but did not prove.",
     "implications": [

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-02/meta.json
@@ -60,6 +60,27 @@
       "Cayley's theorem (G ↪ Sym(G)) and the permutation action of a symmetric group on a rational function field, for the universal-realizability remark in the docstring."
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Serre, J.-P."
+      ],
+      "title": "Topics in Galois Theory",
+      "year": "2008",
+      "venue": "2nd ed., Research Notes in Mathematics 1, A K Peters",
+      "note": "Artin's realizability results and the framework of the inverse Galois problem."
+    },
+    {
+      "authors": [
+        "Malle, G.",
+        "Matzat, B.H."
+      ],
+      "title": "Inverse Galois Theory",
+      "year": "2018",
+      "venue": "2nd ed., Springer Monographs in Mathematics, Springer",
+      "note": "Comprehensive account of the inverse Galois problem, including the Shafarevich theorem."
+    }
+  ],
   "conclusion": {
     "summary": "Artin's fixed-field theorem is packaged as a verified, axiom-free realizability statement: a finite group acting faithfully on a field F is the Galois group of F over its fixed field F^G, with F/F^G Galois and [F : F^G] = |G| (artin_realizability, realizable_over_some_subfield). The structural half F/F^G Galois holds for any finite action (extension_isGalois). All results are 0-axiom (propext, Classical.choice, Quot.sound only); the Shafarevich axiom is not used. 4 theorems, 1 definition, 97 lines.",
     "implications": "Together with the parent entry this draws the precise line in the inverse Galois problem: the realization of finite groups as Galois groups is elementary over an auxiliary base field (Artin, verified here) and becomes deep only when the base is forced to be ℚ (Shafarevich, axiomatized in the parent; general case open). The Artin lemmas are reusable for any concrete faithful field action; supplying the Cayley/permutation action on a rational function field would upgrade realizable_over_some_subfield to the unconditional 'every finite group is a Galois group over some field'.",

--- a/src/data/proofs/abel-ruffini-obstruction-oq-06/meta.json
+++ b/src/data/proofs/abel-ruffini-obstruction-oq-06/meta.json
@@ -85,6 +85,36 @@
       "summary": "not_solvableByRad_of_not_solvable_gal: a root of an irreducible q with non-solvable Galois group is not solvable by radicals — the contrapositive of Mathlib's solvableByRad.isSolvable'. solvable_gal_of_solvableByRad re-exposes the forward direction. Together they are the Galois bridge from the symmetric-group obstruction to actual polynomial equations."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Abel, N.H."
+      ],
+      "title": "Démonstration de l'impossibilité de la résolution algébrique des équations générales qui passent le quatrième degré",
+      "year": "1826",
+      "venue": "Journal für die reine und angewandte Mathematik 1, pp. 65–84",
+      "note": "Abel's proof of the unsolvability of the general quintic by radicals."
+    },
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Solvable groups, the Galois correspondence, and the group-theoretic core of the Abel–Ruffini theorem."
+    },
+    {
+      "authors": [
+        "Stewart, I."
+      ],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "4th ed., Chapman & Hall/CRC",
+      "note": "Insolvability of the quintic, transitive Galois groups, and radical solvability."
+    }
+  ],
   "conclusion": {
     "summary": "This 121-line, axiom-free, sorry-free file isolates the group-theoretic heart of Abel–Ruffini and makes it directly usable. It proves the symmetric group Sₙ is not solvable for every n ≥ 5 (symmetricGroup_not_solvable, a uniform-in-n generalization of Mathlib's Fin-5-only instance), that S₂ is solvable, and packages both endpoints in symmetric_threshold. It then states the Abel–Ruffini criterion not_solvableByRad_of_not_solvable_gal — non-solvable Galois group implies a root not expressible by radicals — as the contrapositive of Mathlib's solvableByRad.isSolvable', with the converse re-exposed alongside it.",
     "implications": "The criterion is the reusable engine for certifying concrete unsolvable polynomials: any irreducible degree-n polynomial (n ≥ 5) whose Galois group contains a non-solvable symmetric group has roots provably not expressible by radicals. Combined with a route that pins a specific polynomial's Galois group to S₅ — such as the discriminant/Jordan argument for X⁵ − X − 1 — it yields a fully formal proof that a named quintic has no radical solution. The uniform n ≥ 5 statement also means no per-degree re-proof is ever needed downstream.",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/meta.json
@@ -108,6 +108,27 @@
       "summary": "natDegree_dvd_card: p.natDegree ∣ Nat.card p.Gal for irreducible p over a characteristic-zero field, generalizing prime_degree_dvd_card; primality is replaced by Irreducible.natDegree_pos."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Solvable groups, the Galois correspondence, and the group-theoretic core of the Abel–Ruffini theorem."
+    },
+    {
+      "authors": [
+        "Stewart, I."
+      ],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "4th ed., Chapman & Hall/CRC",
+      "note": "Insolvability of the quintic, transitive Galois groups, and radical solvability."
+    }
+  ],
   "conclusion": {
     "summary": "For an irreducible polynomial p that splits in E, the Galois group Gal p embeds via galActionHom as a transitive subgroup of Equiv.Perm (rootSet p E) (galActionHom_range_isPretransitive), is isomorphic to that subgroup (galMulEquivRange), and — in characteristic zero — has order divisible by p.natDegree for every degree, not only prime degree (natDegree_dvd_card).",
     "significance": "Supplies the Galois-theoretic foundation under the concrete-quintic chain: it is the reason a Galois-group computation may begin 'the group is a transitive subgroup of S_n', exactly the transitivity hypothesis the sibling 'transitive + transposition ⟹ S_p' lemma takes for granted, and it generalizes Mathlib's prime-degree divisibility to all degrees.",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04-oq-01/meta.json
@@ -53,6 +53,27 @@
       "summary": "not_isSolvable_top: S_α is not solvable for 5 ≤ card α (transported across Subgroup.topEquiv from Equiv.Perm.not_solvable). not_isSolvable_of_isPretransitive_of_mem_isSwap: a transitive subgroup of S_p with a transposition and p ≥ 5 is not solvable."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Solvable groups, the Galois correspondence, and the group-theoretic core of the Abel–Ruffini theorem."
+    },
+    {
+      "authors": [
+        "Stewart, I."
+      ],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "4th ed., Chapman & Hall/CRC",
+      "note": "Insolvability of the quintic, transitive Galois groups, and radical solvability."
+    }
+  ],
   "conclusion": {
     "summary": "A transitive subgroup of S_p (p prime, p ≥ 5) containing a transposition equals the full symmetric group and is therefore not solvable — the Abel–Ruffini obstruction. The Key Lemma forces G = ⊤; non-solvability of ⊤ follows from Mathlib's Equiv.Perm.not_solvable transported across Subgroup.topEquiv. Fully machine-checked, 0 axioms, 0 sorries.",
     "implications": "This converts the parent's structural Key Lemma into the group-theoretic heart of Abel–Ruffini: via the Galois correspondence, any polynomial of prime degree p ≥ 5 whose Galois group is transitive and contains a transposition is unsolvable by radicals. It is the reusable abstract obstruction behind every concrete unsolvable quintic such as x⁵ − 4x + 2.",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04/meta.json
@@ -114,6 +114,27 @@
       "summary": "closure_prime_cycle_swap gives ⟨g,τ⟩ = ⊤; both generators lie in G, so G = ⊤."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Solvable groups, the Galois correspondence, and the group-theoretic core of the Abel–Ruffini theorem."
+    },
+    {
+      "authors": [
+        "Stewart, I."
+      ],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "4th ed., Chapman & Hall/CRC",
+      "note": "Insolvability of the quintic, transitive Galois groups, and radical solvability."
+    }
+  ],
   "conclusion": {
     "summary": "A transitive subgroup G of S_p (p prime) containing a transposition is all of S_p. Transitivity forces p | |G| (orbit–stabilizer); Cauchy yields an element σ of order p, which on a p-element set is a full-support p-cycle; with the given transposition τ, closure_prime_cycle_swap gives ⟨σ,τ⟩ = ⊤; since σ,τ ∈ G, we get G = ⊤.",
     "significance": "This is the classical lemma (transitive + transposition ⟹ full symmetric, prime degree) that powers Galois-group computations such as Gal(x^5-4x+2) ≅ S_5. Formalizing it replaces the parent's ad-hoc Sylow case-elimination with the general result.",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03-oq-01/meta.json
@@ -107,6 +107,26 @@
       "summary": "OrderTwoPrimes p q G captures the pᵃqᵇ hypothesis and is inherited by subgroups and quotients. burnside_reduces_to_nonsimplicity then performs strong induction on |G|: abelian groups are solvable; otherwise the supplied non-simplicity hypothesis yields a proper nontrivial normal N, the induction hypothesis applies to the strictly smaller N and G ⧸ N, and solvable_of_normal_extension reassembles G. Fully verified modulo the explicit non-simplicity hypothesis."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Burnside, W."
+      ],
+      "title": "On groups of order pᵃqᵇ",
+      "year": "1904",
+      "venue": "Proceedings of the London Mathematical Society (2) 1, pp. 388–392",
+      "note": "Burnside's theorem: every group of order pᵃqᵇ is solvable (character-theoretic proof)."
+    },
+    {
+      "authors": [
+        "Isaacs, I.M."
+      ],
+      "title": "Character Theory of Finite Groups",
+      "year": "2006",
+      "venue": "AMS Chelsea Publishing",
+      "note": "Character-theoretic proof of Burnside's pᵃqᵇ theorem via non-simplicity."
+    }
+  ],
   "conclusion": {
     "summary": "This entry formalizes, with zero sorries and zero axioms, the complete outer structure of the classical proof of Burnside's pᵃqᵇ theorem: the prime-power base case, the solvable-extension inductive engine, and a verified strong induction that reduces the full theorem to the single group-theoretic statement that a finite nonabelian group of order pᵃqᵇ is not simple. It does not claim the unconditional theorem.",
     "implications": "The reduction pinpoints precisely the representation theory Mathlib still needs to close the gap — irreducible character degrees dividing |G|, Burnside's vanishing lemma, and the count of irreducibles by conjugacy classes — and provides the verified scaffolding into which a future formalization of that character theory can be plugged to obtain Burnside's theorem unconditionally.",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-07-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07-oq-02/meta.json
@@ -118,6 +118,26 @@
       "summary": "gal_not_solvable_of_iso_S5 transports non-solvability of S₅ across Gal ≃* S₅; the capstone bringRadical_not_solvableByRad_of_iso_S5 concludes from irreducibility plus the S₅ iso."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Abel, N.H."
+      ],
+      "title": "Démonstration de l'impossibilité de la résolution algébrique des équations générales qui passent le quatrième degré",
+      "year": "1826",
+      "venue": "Journal für die reine und angewandte Mathematik 1, pp. 65–84",
+      "note": "Abel's proof of the unsolvability of the general quintic by radicals."
+    },
+    {
+      "authors": [
+        "Stewart, I."
+      ],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "4th ed., Chapman & Hall/CRC",
+      "note": "Insolvability of the quintic, transitive Galois groups, and radical solvability."
+    }
+  ],
   "conclusion": {
     "summary": "The degenerate placeholder axiom bringRadical_not_in_radicals is replaced by a correct, machine-checked conditional theorem: the analytically-defined Bring radical BR(↑t) is a genuine root of the rational quintic X⁵+X+C t (new bridge bringRadical_aeval), and Mathlib's Abel-Ruffini theorem then shows that irreducibility plus a non-solvable Galois group (equivalently Gal ≃ S₅) makes BR(↑t) not solvable by radicals over ℚ. All five results are 0-axiom, 0-sorry.",
     "significance": "Converts a false/degenerate axiom into the genuine Abel-Ruffini statement for the Bring radical, reduced to exactly the open Galois-group input shared by the whole Abel-Ruffini family. It is the first formal link between the parent's analytically-constructed Bring radical and Mathlib's algebraic radical-solvability machinery.",

--- a/src/data/proofs/abel-ruffini-oq-06-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-06-oq-01/meta.json
@@ -115,6 +115,27 @@
       "summary": "Proves isSolvable_perm_fin_iff. Forward: contraposition through Equiv.Perm.not_solvable for n ≥ 5 (using #(Fin n) = n). Backward: interval_cases on n ≤ 4 — S₀, S₁ subsingleton (infer_instance), S₂, S₃ from the parent, S₄ from permFinFour_isSolvable. Packages the full Abel–Ruffini group-theoretic dichotomy as one biconditional."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Solvable groups, the Galois correspondence, and the group-theoretic core of the Abel–Ruffini theorem."
+    },
+    {
+      "authors": [
+        "Stewart, I."
+      ],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "4th ed., Chapman & Hall/CRC",
+      "note": "Insolvability of the quintic, transitive Galois groups, and radical solvability."
+    }
+  ],
   "conclusion": {
     "summary": "Closed the last open case of the symmetric-group threshold by proving A₄ solvable through its metabelian structure A₄ ⊳ V₄ ⊳ 1 (Klein-four commutator subgroup, abelian quotient), lifted it to S₄ solvable via the parent reduction, and packaged the complete dichotomy IsSolvable (Equiv.Perm (Fin n)) ⟺ n ≤ 4 as a single biconditional. This is the exact group-theoretic threshold underlying Abel–Ruffini: the general degree-n polynomial is solvable by radicals iff Sₙ is solvable iff n ≤ 4. 3 theorems, 0 sorries, 0 axioms.",
     "implications": "Completes the solvable-side program of the parent chain: every degree's solvability status is now decided, and the full equivalence is a reusable single theorem. The A₄ argument is a clean, self-contained model of how solvability flows through a short exact sequence with abelian kernel and abelian quotient — directly reusable for other metabelian extensions. Together with Mathlib's n ≥ 5 non-solvability, this gives the formal group-theoretic foundation for the radical-solvability dichotomy of the general polynomial.",


### PR DESCRIPTION
Adds a top-level `references` array to 9 open-question descendants across the **abel-ruffini** family (`abel-ruffini-*`, `-obstruction-*`, `-galois-extensions-*`) that previously had none.

## Coverage
The Abel–Ruffini theorem and surrounding Galois/solvability theory: Sₙ unsolvable for n ≥ 5, the S₄ threshold (A₄ solvable, Sₙ solvable ⟺ n ≤ 4), transitive Galois groups of irreducible polynomials, the key S_p-with-a-transposition lemma, the Bring radical, the Jordan–Hölder simple-quotient / maximal-normal bridge, Artin realizability / the inverse Galois problem, and Burnside's pᵃqᵇ theorem.

## Method
Cited to Dummit–Foote, Stewart and Rotman (Galois theory), Abel (1826), Burnside (1904) with Isaacs (character theory), and Serre / Malle–Matzat (inverse Galois theory). 2–3 references per entry, matched to each `description`.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.