### PR TITLE
Enrich borsuk-ulam OQ cluster: add references to 6 entries

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -106,6 +106,26 @@
       "summary": "Discussion of the strict inclusion CRT axiom ⊊ formula conjecture (CRT fails for prime powers p^k). A trivial theorem `crt_axiom_vs_formula_conjecture` serves as a Lean anchor. The closing docstring summarizes all 10 theorems, 1 axiom, and 0 sorries, and explains why the CRT axiom is the minimal assumption for the semiprime case."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Matoušek, J."
+      ],
+      "title": "Using the Borsuk-Ulam Theorem: Lectures on Topological Methods in Combinatorics and Geometry",
+      "year": "2003",
+      "venue": "Universitext, Springer",
+      "note": "Standard reference for the Borsuk-Ulam theorem, Z/2 and G-indices, and Dold's theorem."
+    },
+    {
+      "authors": [
+        "tom Dieck, T."
+      ],
+      "title": "Transformation Groups",
+      "year": "1987",
+      "venue": "De Gruyter Studies in Mathematics 8, Walter de Gruyter",
+      "note": "Free G-actions, representation spheres and equivariant index theory."
+    }
+  ],
   "conclusion": {
     "summary": "This file establishes $\\text{buDim}(pq, d) = \\max(\\text{buDim}(p,d), \\text{buDim}(q,d))$ for distinct primes $p, q$ using one axiom (CRT compatibility) and zero sorries. The lower bound is proved axiom-free from monotonicity. The CRT compatibility axiom is the minimal new assumption for the semiprime case, strictly weaker than the full formula conjecture. Ten theorems cover lower bounds, the equality, the formula conjecture for semiprimes, non-existence of exotic representations, and concrete cases for $n = 6, 10, 15$.",
     "implications": "The result clarifies the axiomatic structure of the BU dimension formula for cyclic groups. For the semiprime case, the CRT decomposition is the right tool — not the full machinery of Smith theory. This suggests a hierarchical proof strategy: prove the CRT axiom for semiprimes first, handle prime powers via Smith theory separately, and then combine for general squarefree $n$. The absence of exotic representations for $\\mathbb{Z}/pq\\mathbb{Z}$ suggests that if exotic behavior exists at all in the BU dimension framework, it must arise from prime power cyclic groups rather than from products of distinct primes.",

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-02/meta.json
@@ -53,6 +53,26 @@
       "Equivariant Borsuk–Ulam lower bounds (background motivation)"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "tom Dieck, T."
+      ],
+      "title": "Transformation Groups",
+      "year": "1987",
+      "venue": "De Gruyter Studies in Mathematics 8, Walter de Gruyter",
+      "note": "Free G-actions, representation spheres and equivariant index theory."
+    },
+    {
+      "authors": [
+        "Matoušek, J."
+      ],
+      "title": "Using the Borsuk-Ulam Theorem: Lectures on Topological Methods in Combinatorics and Geometry",
+      "year": "2003",
+      "venue": "Universitext, Springer",
+      "note": "Standard reference for the Borsuk-Ulam theorem, Z/2 and G-indices, and Dold's theorem."
+    }
+  ],
   "conclusion": {
     "summary": "In the free-action regime the exotic-representation question is settled negatively and axiom-free: a complex Z/n-representation is free iff each prime-order subgroup acts freely (isFreeRep_iff_forall_prime), so freeness — and the equivariant lower bounds it produces — is governed entirely by the prime divisors of n. 7 theorems, 2 definitions, 144 lines, 0 axioms.",
     "implications": "This isolates the structural reason composite cyclic groups cannot outperform their prime subgroups via free representations, and does so without the parent's axiomatized buDim. It reframes a topological conjecture as a transparent number-theoretic localization, and supplies the concrete free-action criterion that any honest computation of cyclic equivariant indices must use.",

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-03/meta.json
@@ -116,6 +116,26 @@
       "mathContext": "The axioms can be proved from singular cohomology + Borel construction + transfer maps. Mathlib currently lacks all three, but they are constructible."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Dold, A."
+      ],
+      "title": "Simple proofs of some Borsuk-Ulam results",
+      "year": "1983",
+      "venue": "Contemporary Mathematics 19, pp. 65–69",
+      "note": "Dold's numerical index for free G-spaces on spheres."
+    },
+    {
+      "authors": [
+        "Matoušek, J."
+      ],
+      "title": "Using the Borsuk-Ulam Theorem: Lectures on Topological Methods in Combinatorics and Geometry",
+      "year": "2003",
+      "venue": "Universitext, Springer",
+      "note": "Standard reference for the Borsuk-Ulam theorem, Z/2 and G-indices, and Dold's theorem."
+    }
+  ],
   "conclusion": {
     "summary": "The formalization axiomatizes Dold's 1983 cohomological index framework with 5 axioms and derives 11 machine-verified theorems: classical Borsuk-Ulam, Yang-Borsuk, lower bounds for Z/4, Z/6, Z/pq, and a unification showing the OQ02OQ01 buDim framework is a reparametrization of the Dold index.",
     "implications": "Dold's framework is the conceptual engine behind modern combinatorial topology applications of Borsuk-Ulam — including topological proofs of the Lovász-Kneser theorem (chromatic number of Kneser graphs), Schrijver's theorem, and the Necklace Splitting theorem. Full Lean formalization would provide machine-verified foundations for these combinatorial results. The gap analysis reveals transfer maps as the most leveraged Mathlib contribution: 200 lines unlocking one axiom that drives all composite-group bounds.",

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-04/meta.json
@@ -110,6 +110,27 @@
       "mathContext": "With a Borel-cohomology layer, idx_localization is a 1-line consequence of the retraction X -> {x0} -> X. Everything else here is order arithmetic on WithTop Nat."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Fadell, E.",
+        "Husseini, S."
+      ],
+      "title": "An ideal-valued cohomological index theory with applications to Borsuk-Ulam and Bourgin-Yang theorems",
+      "year": "1988",
+      "venue": "Ergodic Theory and Dynamical Systems 8*, pp. 73–85",
+      "note": "The Fadell-Husseini equivariant cohomological index and Borel-localization behaviour for non-free actions."
+    },
+    {
+      "authors": [
+        "tom Dieck, T."
+      ],
+      "title": "Transformation Groups",
+      "year": "1987",
+      "venue": "De Gruyter Studies in Mathematics 8, Walter de Gruyter",
+      "note": "Free G-actions, representation spheres and equivariant index theory."
+    }
+  ],
   "conclusion": {
     "summary": "The formalization resolves the open question OQ-02-OQ-04 in the negative: for non-free Z/p actions the equivariant cohomological index does NOT control vanishing. From 10 axioms (modelling the index in WithTop Nat with TOP = +infinity, plus monotonicity, the localization collapse, and the test-map scheme) we derive 11 machine-verified theorems. The free regime recovers the classical finite, dimension-sensitive Borsuk-Ulam obstruction; the non-free regime collapses to the constant +infinity, forbids equivariant maps to free spheres, and forces vanishing trivially via the fixed point -- so the genuine control passes to the (nonempty) fixed-point set.",
     "implications": "The dichotomy explains why combinatorial applications of Borsuk-Ulam (Kneser, Schrijver, Necklace Splitting) insist on FREE actions: freeness is exactly what keeps the index finite and discriminating. For non-free configuration spaces one must instead analyze the fixed-point stratum directly, as in equivariant obstruction theory. The formalization isolates the localization splitting H*(BG) -> H*_G(X) as the single highest-value Mathlib target: with it, the collapse is a one-line corollary.",

--- a/src/data/proofs/borsuk-ulam-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04/meta.json
@@ -115,6 +115,26 @@
       "summary": "Generalizes GCovering_z2_involutive to arbitrary cyclic deck groups ZMod p. The bridge lemma `GCovering.act_one_iterate` shows `(C.act 1)^[k] x = C.act ((k : ZMod p)) x` via induction (using `Function.iterate_succ_apply'` and `act_add`). The main result `GCovering_zmod_p_periodic` then follows from `ZMod.natCast_self : (p : ZMod p) = 0` and `act_zero`: iterating the generator p times yields the identity. `GCovering_zmod_p_periodic_two` recovers the original p = 2 involutivity statement, confirming the generalization is conservative. This is the algebraic backbone for lens-space coverings S^{2n-1} → L^{2n-1}(p) and the Yang-Borsuk theorem."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Borsuk, K."
+      ],
+      "title": "Drei Sätze über die n-dimensionale euklidische Sphäre",
+      "year": "1933",
+      "venue": "Fundamenta Mathematicae 20, pp. 177–190",
+      "note": "Original antipodal (Borsuk-Ulam) theorem."
+    },
+    {
+      "authors": [
+        "Matoušek, J."
+      ],
+      "title": "Using the Borsuk-Ulam Theorem: Lectures on Topological Methods in Combinatorics and Geometry",
+      "year": "2003",
+      "venue": "Universitext, Springer",
+      "note": "Standard reference for the Borsuk-Ulam theorem, Z/2 and G-indices, and Dold's theorem."
+    }
+  ],
   "conclusion": {
     "summary": "This formalization makes the covering space argument in the Borsuk-Ulam proof fully explicit and algebraically transparent. The descent of odd maps — from $\\mathbb{R}^{n+1}$ to projective spaces — is identified as the key algebraic step and proved without sorries. The CoveringType abstraction isolates the essential categorical structure (projection, deck transformation, involutivity, fiber compatibility) needed for both classical and higher generalizations.",
     "implications": "The CoveringType framework demonstrates that the Borsuk-Ulam covering space argument decomposes into a purely algebraic component (descent, fully formalized here) and a topological component (the obstruction axiom). This separation suggests that higher categorical generalizations should similarly factor: the $\\infty$-categorical descent theory (well-developed via Lurie's work) paired with higher obstruction theory. The formalization connects to active research in equivariant stable homotopy theory, where the Hill-Hopkins-Ravenel norm machinery extends $\\mathbb{Z}/2$-equivariance to $\\mathbb{Z}/p$ and beyond. As Lean's algebraic topology library grows to include homotopy groups, fibration sequences, and spectral sequences, this CoveringType framework could serve as the foundation for machine-checked proofs of higher Borsuk-Ulam results.",


### PR DESCRIPTION
Adds a top-level `references` array to 6 open-question descendants of **borsuk-ulam** that previously had none.

## Coverage
Equivariant Borsuk–Ulam theory: Borsuk–Ulam dimension for semiprime cyclic groups via CRT, the absence of exotic free representations, Dold's cohomological index for free G-spaces, the Borel-localization collapse of the index for non-free ℤ/p actions, quantitative 1D antipodal-pair bounds, and higher-categorical covering-space arguments.

## Method
Cited to Matoušek (*Using the Borsuk-Ulam Theorem*), Borsuk's 1933 paper, tom Dieck (*Transformation Groups*), Dold (1983), and Fadell–Husseini (1988). 2 references per entry, matched to each `description`.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.