### PR TITLE
Enrich dirichlet-approximation-theorem OQ-children cluster: add references (6 entries)

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-01/meta.json
@@ -166,5 +166,35 @@
     "definitionCount": 0,
     "theoremCount": 4
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Adolf Hurwitz"
+      ],
+      "title": "Über die angenäherte Darstellung der Irrationalzahlen durch rationale Brüche",
+      "year": 1891,
+      "venue": "Mathematische Annalen 39, 279–284",
+      "note": "Original proof that |α−p/q|<1/(√5·q²) has infinitely many solutions and that √5 is best possible."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed., rev. Heath-Brown & Silverman)",
+      "note": "Comprehensive treatment of Dirichlet's and Hurwitz's approximation theorems, continued fractions, and badly approximable numbers."
+    },
+    {
+      "authors": [
+        "Aleksandr Ya. Khinchin"
+      ],
+      "title": "Continued Fractions",
+      "year": 1964,
+      "venue": "University of Chicago Press",
+      "note": "Continued-fraction approach to Hurwitz's theorem and the extremal role of the golden ratio."
+    }
+  ]
 }

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01/meta.json
@@ -185,5 +185,35 @@
     "definitionCount": 0,
     "theoremCount": 8
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed., rev. Heath-Brown & Silverman)",
+      "note": "Comprehensive treatment of Dirichlet's and Hurwitz's approximation theorems, continued fractions, and badly approximable numbers."
+    },
+    {
+      "authors": [
+        "Aleksandr Ya. Khinchin"
+      ],
+      "title": "Continued Fractions",
+      "year": 1964,
+      "venue": "University of Chicago Press",
+      "note": "Continued-fraction approach to Hurwitz's theorem and the extremal role of the golden ratio."
+    },
+    {
+      "authors": [
+        "J. W. S. Cassels"
+      ],
+      "title": "An Introduction to Diophantine Approximation",
+      "year": 1957,
+      "venue": "Cambridge University Press (Cambridge Tracts in Mathematics 45)",
+      "note": "Simultaneous approximation and the metric theory of Diophantine approximation."
+    }
+  ]
 }

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-02/meta.json
@@ -169,5 +169,35 @@
     "definitionCount": 0,
     "theoremCount": 1
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "J. W. S. Cassels"
+      ],
+      "title": "An Introduction to Diophantine Approximation",
+      "year": 1957,
+      "venue": "Cambridge University Press (Cambridge Tracts in Mathematics 45)",
+      "note": "Simultaneous approximation and the metric theory of Diophantine approximation."
+    },
+    {
+      "authors": [
+        "Wolfgang M. Schmidt"
+      ],
+      "title": "Diophantine Approximation",
+      "year": 1980,
+      "venue": "Springer (Lecture Notes in Mathematics 785)",
+      "note": "Modern account of simultaneous approximation and Dirichlet's theorem in higher dimensions."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed., rev. Heath-Brown & Silverman)",
+      "note": "Comprehensive treatment of Dirichlet's and Hurwitz's approximation theorems, continued fractions, and badly approximable numbers."
+    }
+  ]
 }

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-03/meta.json
@@ -182,5 +182,35 @@
     "definitionCount": 3,
     "theoremCount": 15
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Hermann Minkowski"
+      ],
+      "title": "Geometrie der Zahlen",
+      "year": 1896,
+      "venue": "Teubner, Leipzig",
+      "note": "Founding text of the geometry of numbers; the convex-body theorem used to re-derive Dirichlet's bound."
+    },
+    {
+      "authors": [
+        "J. W. S. Cassels"
+      ],
+      "title": "An Introduction to the Geometry of Numbers",
+      "year": 1959,
+      "venue": "Springer (Grundlehren 99)",
+      "note": "Minkowski's convex-body theorem and its application to Diophantine approximation."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed., rev. Heath-Brown & Silverman)",
+      "note": "Comprehensive treatment of Dirichlet's and Hurwitz's approximation theorems, continued fractions, and badly approximable numbers."
+    }
+  ]
 }

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04/meta.json
@@ -148,5 +148,35 @@
       "relationship": "sibling",
       "description": "The dual SHARPNESS lower bound (the golden ratio is badly approximable). OQ-04 shows every irrational's multiples come arbitrarily close to integers; OQ-05 shows that for φ they cannot come too close too fast — bounding the irrational rotation's orbit from both qualitative and quantitative sides."
     }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Leopold Kronecker"
+      ],
+      "title": "Näherungsweise ganzzahlige Auflösung linearer Gleichungen",
+      "year": 1884,
+      "venue": "Sitzungsberichte der Preußischen Akademie der Wissenschaften, 1179–1193, 1271–1299",
+      "note": "Original statement of Kronecker's density/approximation theorem."
+    },
+    {
+      "authors": [
+        "Hermann Weyl"
+      ],
+      "title": "Über die Gleichverteilung von Zahlen mod. Eins",
+      "year": 1916,
+      "venue": "Mathematische Annalen 77, 313–352",
+      "note": "Equidistribution of {nα} for irrational α, strengthening Kronecker's density theorem."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed., rev. Heath-Brown & Silverman)",
+      "note": "Comprehensive treatment of Dirichlet's and Hurwitz's approximation theorems, continued fractions, and badly approximable numbers."
+    }
   ]
 }

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-05/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-05/meta.json
@@ -110,5 +110,35 @@
     "dirichlet-approximation-theorem",
     "dirichlet-approximation-theorem-oq-01",
     "dirichlet-approximation-theorem-oq-03"
+  ],
+  "references": [
+    {
+      "authors": [
+        "Aleksandr Ya. Khinchin"
+      ],
+      "title": "Continued Fractions",
+      "year": 1964,
+      "venue": "University of Chicago Press",
+      "note": "Continued-fraction approach to Hurwitz's theorem and the extremal role of the golden ratio."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed., rev. Heath-Brown & Silverman)",
+      "note": "Comprehensive treatment of Dirichlet's and Hurwitz's approximation theorems, continued fractions, and badly approximable numbers."
+    },
+    {
+      "authors": [
+        "Adolf Hurwitz"
+      ],
+      "title": "Über die angenäherte Darstellung der Irrationalzahlen durch rationale Brüche",
+      "year": 1891,
+      "venue": "Mathematische Annalen 39, 279–284",
+      "note": "Original proof that |α−p/q|<1/(√5·q²) has infinitely many solutions and that √5 is best possible."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass: adds bibliographic `references` to 6 empty-reference OQ-children of the **dirichlet-approximation-theorem** base.

| Entry | Topic |
|-------|-------|
| oq-01 | Infinitude of good rational approximations |
| oq-01-oq-01 | Optimality of the Hurwitz constant √5 |
| oq-02 | Simultaneous (higher-dimensional) approximation |
| oq-03 | Minkowski geometry-of-numbers re-derivation |
| oq-04 | Kronecker's density theorem |
| oq-05 | The golden ratio is badly approximable |

References drawn from canonical sources (Hardy–Wright, Khinchin, Hurwitz 1891, Cassels, Schmidt, Minkowski, Kronecker 1884, Weyl) matched to each child's topic. Only the top-level `references` field is added; all other keys byte-verified identical to origin/main.