### PR TITLE
Enrich shannon-channel-coding OQ-children cluster: add references (9 entries)

### DIFF
--- a/src/data/proofs/shannon-channel-coding-bec-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-01/meta.json
@@ -1,190 +1,220 @@
 {
-    "id": "shannon-channel-coding-bec-oq-01",
-    "title": "q-ary Erasure Channel Capacity (C = (1 − p) log q)",
-    "slug": "shannon-channel-coding-bec-oq-01",
-    "description": "Generalizes the parent binary erasure channel to an arbitrary input alphabet of size q. The q-ary erasure channel QEC(p) over a finite input type α (with Fintype.card α = q) and output Option α (none = erasure) has capacity C(QEC(p)) = (1 − p) · log q, proven from first principles (0 axioms, 0 sorries). The derivation is the exact generalization of the binary case with Bool replaced by α: the erasure identity H(X|Y) = p · H(X) holds for any input distribution (the some-y conditional terms vanish because an un-erased symbol determines the input, and the none term carries the full input entropy scaled by p), the chain rule gives I(X;Y) = (1 − p) · H(X), the converse follows from H(X) ≤ log|α| = log q, and the uniform input achieves H(X) = log q via the entropy-of-uniform theorem. The binary erasure channel is recovered as the q = 2 case: the QEC transition kernel over Bool coincides on the nose with the parent's bec (qec_eq_bec, by rfl) and the capacity specializes to (1 − p) · log 2 (= 1 − p bits). The erasure decomposition uses nothing about q; the only alphabet-specific ingredient is the maximum-entropy value log q.",
-    "meta": {
-        "author": "Claude Shannon (1948), formalized in Lean 4",
-        "sourceUrl": "https://en.wikipedia.org/wiki/Erasure_channel",
-        "date": "1948",
-        "status": "verified",
-        "proofRepoPath": "Proofs/ShannonChannelCodingBECOQ01.lean",
-        "tags": [
-            "information-theory",
-            "probability",
-            "coding-theory",
-            "channel-capacity",
-            "entropy",
-            "erasure-channel",
-            "advanced"
-        ],
-        "badge": "original",
-        "sorries": 0,
-        "mathlibDependencies": [
-            {
-                "theorem": "Fintype.sum_option",
-                "description": "Splits a sum over Option α into the none term plus the sum over α, used for the channel's sum_one and the collapse of the conditional-entropy inner sum",
-                "module": "Mathlib.Algebra.BigOperators.Fin"
-            },
-            {
-                "theorem": "Real.log_one / Real.log_nonneg",
-                "description": "log 1 = 0 (un-erased conditional probability is 1, contributing zero entropy) and log q ≥ 0 for the capacity non-negativity",
-                "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
-            },
-            {
-                "theorem": "Finset.sum_ite_eq / Finset.sum_eq_single",
-                "description": "Collapse of the indicator sums in the channel normalization and the un-erased output marginal",
-                "module": "Mathlib.Algebra.BigOperators.Basic"
-            }
-        ],
-        "originalContributions": [
-            "qec: the q-ary erasure channel over any finite input type α with output Option α — a single DMChannel definition that recovers the parent bec as its Bool instance",
-            "qec_conditional_entropy: the erasure identity H(X|Y) = p · H(X) for any input distribution on α, the q-independent engine of the capacity (direct generalization of the binary bec_conditional_entropy)",
-            "qec_mi_eq: I(X;Y) = (1 − p) · H(X) for any input, via the chain rule",
-            "qec_capacity: the capacity C(QEC(p)) = (1 − p) · log|α| assembled axiom-free — converse via H(X) ≤ log|α|, achievability via the uniform input and entropy_of_uniform_eq_log_card",
-            "qec_capacity_card: the capacity as (1 − p) · log q when |α| = q",
-            "qec_eq_bec: the QEC kernel over Bool equals the parent bec kernel on the nose (by rfl), and qec_capacity_bool / qec_capacity_bool_bits recover the binary capacity (1 − p) log 2 = 1 − p bits"
-        ],
-        "assumptions": "0 axioms, 0 sorries. The file imports ShannonChannelCoding, ShannonEntropy, and ShannonChannelCodingBEC (all 0 axioms, 0 sorries) and reuses the general finite-alphabet channel API (DMChannel, InputDist, jointDist, channelMI, channelCapacity, chain_rule, channelMI_le_log_card) together with the entropy theorems entropy_le_log_card and entropy_of_uniform_eq_log_card; none lies on a path to any sorry. SCOPE: this entry formalizes the discrete capacity for the q-ary erasure channel exactly as stated — the conditional-entropy identity, the mutual-information identity, the converse bound, and the achievability by the uniform input are all proven. The mutual information and channel capacity are the file's grounded discrete quantities (mutualInformation / channelCapacity from the parent scaffold); the operational coding theorem (achievable rates via random codebooks and a Fano converse) is not formalized here, consistent with the parent BEC/BSC entries.",
-        "dateAdded": "2026-06-18",
-        "axiomCount": 0,
-        "lineCount": 276,
-        "prerequisites": [
-            "The binary erasure channel capacity C(BEC(p)) = (1 − p) log 2 (ShannonChannelCodingBEC.lean) — the q = 2 special case",
-            "Discrete memoryless channels, mutual information, and channel capacity (ShannonChannelCoding.lean)",
-            "Shannon entropy, the chain rule, the maximum-entropy bound H(X) ≤ log|α|, and the entropy of the uniform distribution (ShannonEntropy.lean)"
-        ],
-        "mathlib_version": "4.26.0",
-        "theoremCount": 14,
-        "definitionCount": 2
-    },
-    "overview": {
-        "historicalContext": "The erasure channel models a receiver that always knows which symbols were lost: each transmitted symbol either arrives intact or is replaced by a special erasure mark, with the positions of erasures known to the decoder. It is the canonical abstraction of packet-loss networks and the test bed for capacity-achieving codes — Reed–Solomon, fountain (LT/Raptor) codes, and rateless schemes are all designed against the erasure model. The binary case (q = 2) is the parent gallery entry; the q-ary generalization replaces the bit alphabet by an alphabet of size q (e.g. a packet, a finite field symbol).\n\nThe capacity is intuitive: a fraction 1 − p of the symbols get through cleanly, and each carries log q nats of information (the entropy of a uniform symbol over q values), so C = (1 − p) log q. The information-theoretic content is the erasure identity H(X|Y) = p · H(X): when the symbol is received (probability 1 − p) it pins down the input exactly, contributing zero residual entropy, and when it is erased (probability p) the full input entropy survives.",
-        "problemStatement": "**q-ary Erasure Channel Capacity**: For the q-ary erasure channel with input alphabet α of size q = |α|, output Option α (none = erasure), each symbol erased independently with probability p and otherwise received intact, the capacity is\n$$C(\\mathrm{QEC}(p)) = (1 - p)\\,\\log q,$$\nmaximized by the uniform input. The binary erasure channel C(BEC(p)) = (1 − p) log 2 is the q = 2 case.",
-        "text": "Generalizes the binary erasure channel to alphabet size q: the q-ary erasure channel has capacity (1 − p) log q, proven axiom-free by the same erasure identity H(X|Y) = p·H(X), with the uniform input as the capacity-achieving distribution and the BEC recovered at q = 2.",
-        "proofStrategy": "The capacity is built by generalizing the binary proof, replacing Bool by an arbitrary finite type α:\n\n1. **The channel** (qec): a DMChannel α (Option α) with W x none = p and W x (some y) = if x = y then 1 − p else 0; normalization is the indicator-sum collapse p + (1 − p) = 1.\n\n2. **Output marginals** (qec_ymarg_none, qec_ymarg_some): the erasure marginal is p for every input; the un-erased marginal of symbol y is inp.p y · (1 − p).\n\n3. **Erasure identity** (qec_conditional_entropy): H(X|Y) = p · H(X). The some-y conditional terms vanish (an un-erased symbol determines the input, log 1 = 0), and the none term reduces to p · (per-symbol entropy), summing to p · H(X).\n\n4. **Mutual information** (qec_mi_eq): the chain rule I = H(X) − H(X|Y) gives I(X;Y) = (1 − p) · H(X) for every input.\n\n5. **Capacity** (qec_capacity): the converse I ≤ (1 − p) log|α| follows from entropy_le_log_card; achievability from the uniform input, whose entropy is log|α| by entropy_of_uniform_eq_log_card. The supremum over inputs is therefore (1 − p) log|α|.\n\n6. **BEC recovery** (qec_eq_bec, qec_capacity_bool): over Bool the kernel is definitionally the parent bec, and the capacity specializes to (1 − p) log 2 = 1 − p bits.",
-        "keyInsights": [
-            "The erasure decomposition H(X|Y) = p · H(X) uses nothing about the alphabet size: the q-ary proof is the binary proof with Bool replaced by a finite type α, because the conditional-entropy collapse is per-symbol.",
-            "The only place q enters is the maximum entropy value: H(X) ≤ log|α| (converse) with equality for the uniform input (achievability), both already general theorems in ShannonEntropy.lean.",
-            "The parent finite-alphabet channel scaffold (DMChannel, channelMI, channelCapacity, chain_rule, channelMI_le_log_card) was already polymorphic in the alphabet — the BEC entry only happened to instantiate it at Bool, so the generalization required no new information-theory infrastructure.",
-            "The binary erasure channel is literally the q = 2 instance: qec over Bool has the same transition kernel as the parent bec on the nose (qec_eq_bec holds by rfl), so the BEC capacity is a corollary of the q-ary result.",
-            "Capacity in bits is recovered by dividing by log 2: over Bool this gives the clean C = 1 − p bits, matching the parent bec_capacity_bits."
-        ]
-    },
-    "sections": [
-        {
-            "id": "qec-channel-def",
-            "title": "The q-ary Erasure Channel",
-            "startLine": 59,
-            "endLine": 84,
-            "description": "Defines qec p : DMChannel α (Option α) with W x none = p and W x (some y) = if x = y then 1 − p else 0, with normalization via the indicator-sum collapse, plus the simp lemmas qec_W_none and qec_W_some.",
-            "summary": "The QEC kernel over a finite input type α with output Option α."
-        },
-        {
-            "id": "output-marginals",
-            "title": "Output Marginals",
-            "startLine": 86,
-            "endLine": 108,
-            "description": "qec_ymarg_none: the erasure output marginal is p regardless of the input. qec_ymarg_some: the un-erased marginal of symbol y is inp.p y · (1 − p).",
-            "summary": "Erasure marginal p; un-erased marginal inp.p y · (1 − p)."
-        },
-        {
-            "id": "erasure-identity",
-            "title": "The Erasure Identity H(X|Y) = p · H(X)",
-            "startLine": 111,
-            "endLine": 176,
-            "description": "qec_conditional_entropy: for any input distribution, the conditional entropy of the input given the output equals p · H(X). The un-erased (some y) terms vanish because the input is determined exactly (log 1 = 0); the erasure (none) term carries the full input entropy scaled by p.",
-            "summary": "H(X|Y) = p · H(X) for any input — the q-independent engine of the capacity."
-        },
-        {
-            "id": "mutual-information",
-            "title": "Mutual Information I(X;Y) = (1 − p) · H(X)",
-            "startLine": 178,
-            "endLine": 195,
-            "description": "qec_mi_eq: combining the chain rule I = H(X) − H(X|Y) with the erasure identity gives I(X;Y) = (1 − p) · H(X) for every input distribution.",
-            "summary": "I(X;Y) = (1 − p) · H(X) via the chain rule."
-        },
-        {
-            "id": "capacity",
-            "title": "Capacity = (1 − p) · log q",
-            "startLine": 197,
-            "endLine": 259,
-            "description": "uniformInput (the 1/|α| distribution), qec_uniform_mi (uniform achieves (1 − p) log|α|), qec_mi_le (converse via entropy_le_log_card), qec_capacity (the capacity = (1 − p) log|α|), qec_capacity_card (= (1 − p) log q when |α| = q), and qec_capacity_nonneg.",
-            "summary": "The capacity (1 − p) log q: converse from H(X) ≤ log q, achievability from the uniform input."
-        },
-        {
-            "id": "bec-recovery",
-            "title": "The Binary Erasure Channel as q = 2",
-            "startLine": 261,
-            "endLine": 276,
-            "description": "qec_eq_bec: the QEC kernel over Bool equals the parent bec kernel on the nose (by rfl). qec_capacity_bool: the capacity specializes to (1 − p) log 2. qec_capacity_bool_bits: in bits, C = 1 − p, matching the parent bec_capacity_bits.",
-            "summary": "The BEC is the q = 2 instance: kernel equality by rfl, capacity (1 − p) log 2 = 1 − p bits."
-        }
+  "id": "shannon-channel-coding-bec-oq-01",
+  "title": "q-ary Erasure Channel Capacity (C = (1 − p) log q)",
+  "slug": "shannon-channel-coding-bec-oq-01",
+  "description": "Generalizes the parent binary erasure channel to an arbitrary input alphabet of size q. The q-ary erasure channel QEC(p) over a finite input type α (with Fintype.card α = q) and output Option α (none = erasure) has capacity C(QEC(p)) = (1 − p) · log q, proven from first principles (0 axioms, 0 sorries). The derivation is the exact generalization of the binary case with Bool replaced by α: the erasure identity H(X|Y) = p · H(X) holds for any input distribution (the some-y conditional terms vanish because an un-erased symbol determines the input, and the none term carries the full input entropy scaled by p), the chain rule gives I(X;Y) = (1 − p) · H(X), the converse follows from H(X) ≤ log|α| = log q, and the uniform input achieves H(X) = log q via the entropy-of-uniform theorem. The binary erasure channel is recovered as the q = 2 case: the QEC transition kernel over Bool coincides on the nose with the parent's bec (qec_eq_bec, by rfl) and the capacity specializes to (1 − p) · log 2 (= 1 − p bits). The erasure decomposition uses nothing about q; the only alphabet-specific ingredient is the maximum-entropy value log q.",
+  "meta": {
+    "author": "Claude Shannon (1948), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Erasure_channel",
+    "date": "1948",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonChannelCodingBECOQ01.lean",
+    "tags": [
+      "information-theory",
+      "probability",
+      "coding-theory",
+      "channel-capacity",
+      "entropy",
+      "erasure-channel",
+      "advanced"
     ],
-    "crossReferences": [
-        {
-            "targetId": "shannon-channel-coding-bec",
-            "relationship": "extends",
-            "description": "The parent: the binary erasure channel C(BEC(p)) = (1 − p) log 2. This entry generalizes it to alphabet size q, recovering the parent as the q = 2 case (qec_eq_bec holds by rfl)."
-        },
-        {
-            "targetId": "shannon-channel-coding-awgn",
-            "relationship": "sibling",
-            "description": "Companion concrete-capacity proof for the additive white Gaussian noise channel C = ½ log(1 + P/N). Together with the BSC and the erasure channels these are the named channels of the Shannon channel-coding goal."
-        },
-        {
-            "targetId": "shannon-channel-coding-oq-02",
-            "relationship": "sibling",
-            "description": "Companion concrete-capacity proof for the binary symmetric channel C(BSC(p)) = log 2 − h(p)."
-        },
-        {
-            "targetId": "shannon-entropy",
-            "relationship": "uses",
-            "description": "Built on its general entropy theorems: entropy_le_log_card (H(X) ≤ log|α|, the converse) and entropy_of_uniform_eq_log_card (the uniform input achieves H(X) = log|α|, achievability)."
-        }
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.sum_option",
+        "description": "Splits a sum over Option α into the none term plus the sum over α, used for the channel's sum_one and the collapse of the conditional-entropy inner sum",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      },
+      {
+        "theorem": "Real.log_one / Real.log_nonneg",
+        "description": "log 1 = 0 (un-erased conditional probability is 1, contributing zero entropy) and log q ≥ 0 for the capacity non-negativity",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Finset.sum_ite_eq / Finset.sum_eq_single",
+        "description": "Collapse of the indicator sums in the channel normalization and the un-erased output marginal",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
     ],
-    "conclusion": {
-        "summary": "This formalization generalizes the binary erasure channel to an arbitrary input alphabet of size q, proving the q-ary erasure channel capacity C(QEC(p)) = (1 − p) · log q axiom-free, with 0 sorries. The capacity rests on the erasure identity H(X|Y) = p · H(X) — proven for any input distribution on a finite type α — whence the chain rule gives I(X;Y) = (1 − p) · H(X); the converse is the maximum-entropy bound H(X) ≤ log q and achievability is the uniform input, whose entropy is exactly log q. The binary erasure channel is recovered as the q = 2 instance: the QEC transition kernel over Bool is definitionally the parent's bec, so C = (1 − p) log 2 = 1 − p bits is a corollary.",
-        "implications": "Generalizing the formalized BEC argument to arbitrary alphabet size broadens the gallery's information-theory coverage from the Boolean special case to the model used for packet-loss networks and capacity-achieving erasure codes (Reed–Solomon, fountain codes). The proof demonstrates that the parent finite-alphabet channel scaffold was already alphabet-polymorphic: the only q-specific ingredient is the maximum-entropy value log q, so the entire erasure-identity engine transfers verbatim from Bool to any finite type.",
-        "openQuestions": [
-            "Formalize the operational coding theorem for the erasure channel (achievable rates via random codebooks, a Fano-inequality converse), connecting the information capacity proved here to achievable communication rates.",
-            "Specialize α to a finite field GF(q) and connect the capacity to the rate of maximum-distance-separable (Reed–Solomon) erasure codes.",
-            "Extend to erasure channels with feedback or to the q-ary symmetric channel (errors rather than erasures), whose capacity log q − h(p) − p log(q − 1) is the q-ary generalization of the BSC."
-        ]
-    },
-    "mainTheorems": [
-        {
-            "name": "qec_capacity",
-            "type": "core",
-            "description": "The q-ary erasure channel over a finite input type α has capacity (1 − p) · log|α|, assembled axiom-free: every input gives I(X;Y) = (1 − p)·H(X) ≤ (1 − p)·log|α|, and the uniform input achieves the bound.",
-            "leanType": "channelCapacity (qec p hp0.le hp1.le) = (1 - p) * Real.log (Fintype.card α)"
-        },
-        {
-            "name": "qec_conditional_entropy",
-            "type": "core",
-            "description": "The erasure identity: for any input distribution, H(X|Y) = p · H(X). The q-independent engine of the capacity.",
-            "leanType": "conditionalEntropy (jointDist (qec p hp0.le hp1.le) inp) = p * shannonEntropy inp.p"
-        },
-        {
-            "name": "qec_mi_eq",
-            "type": "supporting",
-            "description": "Mutual information I(X;Y) = (1 − p) · H(X) for any input, via the chain rule.",
-            "leanType": "channelMI (qec p hp0.le hp1.le) inp = (1 - p) * shannonEntropy inp.p"
-        },
-        {
-            "name": "qec_eq_bec",
-            "type": "corollary",
-            "description": "The QEC kernel over Bool coincides on the nose with the parent binary erasure channel bec — the BEC is the q = 2 case.",
-            "leanType": "(qec (α := Bool) p hp0 hp1).W = (BEC.bec p hp0 hp1).W"
-        }
+    "originalContributions": [
+      "qec: the q-ary erasure channel over any finite input type α with output Option α — a single DMChannel definition that recovers the parent bec as its Bool instance",
+      "qec_conditional_entropy: the erasure identity H(X|Y) = p · H(X) for any input distribution on α, the q-independent engine of the capacity (direct generalization of the binary bec_conditional_entropy)",
+      "qec_mi_eq: I(X;Y) = (1 − p) · H(X) for any input, via the chain rule",
+      "qec_capacity: the capacity C(QEC(p)) = (1 − p) · log|α| assembled axiom-free — converse via H(X) ≤ log|α|, achievability via the uniform input and entropy_of_uniform_eq_log_card",
+      "qec_capacity_card: the capacity as (1 − p) · log q when |α| = q",
+      "qec_eq_bec: the QEC kernel over Bool equals the parent bec kernel on the nose (by rfl), and qec_capacity_bool / qec_capacity_bool_bits recover the binary capacity (1 − p) log 2 = 1 − p bits"
     ],
-    "leanFile": {
-        "axiomCount": 0,
-        "lineCount": 276,
-        "path": "Proofs/ShannonChannelCodingBECOQ01.lean",
-        "sorries": 0,
-        "definitionCount": 2,
-        "theoremCount": 14
+    "assumptions": "0 axioms, 0 sorries. The file imports ShannonChannelCoding, ShannonEntropy, and ShannonChannelCodingBEC (all 0 axioms, 0 sorries) and reuses the general finite-alphabet channel API (DMChannel, InputDist, jointDist, channelMI, channelCapacity, chain_rule, channelMI_le_log_card) together with the entropy theorems entropy_le_log_card and entropy_of_uniform_eq_log_card; none lies on a path to any sorry. SCOPE: this entry formalizes the discrete capacity for the q-ary erasure channel exactly as stated — the conditional-entropy identity, the mutual-information identity, the converse bound, and the achievability by the uniform input are all proven. The mutual information and channel capacity are the file's grounded discrete quantities (mutualInformation / channelCapacity from the parent scaffold); the operational coding theorem (achievable rates via random codebooks and a Fano converse) is not formalized here, consistent with the parent BEC/BSC entries.",
+    "dateAdded": "2026-06-18",
+    "axiomCount": 0,
+    "lineCount": 276,
+    "prerequisites": [
+      "The binary erasure channel capacity C(BEC(p)) = (1 − p) log 2 (ShannonChannelCodingBEC.lean) — the q = 2 special case",
+      "Discrete memoryless channels, mutual information, and channel capacity (ShannonChannelCoding.lean)",
+      "Shannon entropy, the chain rule, the maximum-entropy bound H(X) ≤ log|α|, and the entropy of the uniform distribution (ShannonEntropy.lean)"
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 14,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The erasure channel models a receiver that always knows which symbols were lost: each transmitted symbol either arrives intact or is replaced by a special erasure mark, with the positions of erasures known to the decoder. It is the canonical abstraction of packet-loss networks and the test bed for capacity-achieving codes — Reed–Solomon, fountain (LT/Raptor) codes, and rateless schemes are all designed against the erasure model. The binary case (q = 2) is the parent gallery entry; the q-ary generalization replaces the bit alphabet by an alphabet of size q (e.g. a packet, a finite field symbol).\n\nThe capacity is intuitive: a fraction 1 − p of the symbols get through cleanly, and each carries log q nats of information (the entropy of a uniform symbol over q values), so C = (1 − p) log q. The information-theoretic content is the erasure identity H(X|Y) = p · H(X): when the symbol is received (probability 1 − p) it pins down the input exactly, contributing zero residual entropy, and when it is erased (probability p) the full input entropy survives.",
+    "problemStatement": "**q-ary Erasure Channel Capacity**: For the q-ary erasure channel with input alphabet α of size q = |α|, output Option α (none = erasure), each symbol erased independently with probability p and otherwise received intact, the capacity is\n$$C(\\mathrm{QEC}(p)) = (1 - p)\\,\\log q,$$\nmaximized by the uniform input. The binary erasure channel C(BEC(p)) = (1 − p) log 2 is the q = 2 case.",
+    "text": "Generalizes the binary erasure channel to alphabet size q: the q-ary erasure channel has capacity (1 − p) log q, proven axiom-free by the same erasure identity H(X|Y) = p·H(X), with the uniform input as the capacity-achieving distribution and the BEC recovered at q = 2.",
+    "proofStrategy": "The capacity is built by generalizing the binary proof, replacing Bool by an arbitrary finite type α:\n\n1. **The channel** (qec): a DMChannel α (Option α) with W x none = p and W x (some y) = if x = y then 1 − p else 0; normalization is the indicator-sum collapse p + (1 − p) = 1.\n\n2. **Output marginals** (qec_ymarg_none, qec_ymarg_some): the erasure marginal is p for every input; the un-erased marginal of symbol y is inp.p y · (1 − p).\n\n3. **Erasure identity** (qec_conditional_entropy): H(X|Y) = p · H(X). The some-y conditional terms vanish (an un-erased symbol determines the input, log 1 = 0), and the none term reduces to p · (per-symbol entropy), summing to p · H(X).\n\n4. **Mutual information** (qec_mi_eq): the chain rule I = H(X) − H(X|Y) gives I(X;Y) = (1 − p) · H(X) for every input.\n\n5. **Capacity** (qec_capacity): the converse I ≤ (1 − p) log|α| follows from entropy_le_log_card; achievability from the uniform input, whose entropy is log|α| by entropy_of_uniform_eq_log_card. The supremum over inputs is therefore (1 − p) log|α|.\n\n6. **BEC recovery** (qec_eq_bec, qec_capacity_bool): over Bool the kernel is definitionally the parent bec, and the capacity specializes to (1 − p) log 2 = 1 − p bits.",
+    "keyInsights": [
+      "The erasure decomposition H(X|Y) = p · H(X) uses nothing about the alphabet size: the q-ary proof is the binary proof with Bool replaced by a finite type α, because the conditional-entropy collapse is per-symbol.",
+      "The only place q enters is the maximum entropy value: H(X) ≤ log|α| (converse) with equality for the uniform input (achievability), both already general theorems in ShannonEntropy.lean.",
+      "The parent finite-alphabet channel scaffold (DMChannel, channelMI, channelCapacity, chain_rule, channelMI_le_log_card) was already polymorphic in the alphabet — the BEC entry only happened to instantiate it at Bool, so the generalization required no new information-theory infrastructure.",
+      "The binary erasure channel is literally the q = 2 instance: qec over Bool has the same transition kernel as the parent bec on the nose (qec_eq_bec holds by rfl), so the BEC capacity is a corollary of the q-ary result.",
+      "Capacity in bits is recovered by dividing by log 2: over Bool this gives the clean C = 1 − p bits, matching the parent bec_capacity_bits."
+    ]
+  },
+  "sections": [
+    {
+      "id": "qec-channel-def",
+      "title": "The q-ary Erasure Channel",
+      "startLine": 59,
+      "endLine": 84,
+      "description": "Defines qec p : DMChannel α (Option α) with W x none = p and W x (some y) = if x = y then 1 − p else 0, with normalization via the indicator-sum collapse, plus the simp lemmas qec_W_none and qec_W_some.",
+      "summary": "The QEC kernel over a finite input type α with output Option α."
     },
-    "sorries": 0
+    {
+      "id": "output-marginals",
+      "title": "Output Marginals",
+      "startLine": 86,
+      "endLine": 108,
+      "description": "qec_ymarg_none: the erasure output marginal is p regardless of the input. qec_ymarg_some: the un-erased marginal of symbol y is inp.p y · (1 − p).",
+      "summary": "Erasure marginal p; un-erased marginal inp.p y · (1 − p)."
+    },
+    {
+      "id": "erasure-identity",
+      "title": "The Erasure Identity H(X|Y) = p · H(X)",
+      "startLine": 111,
+      "endLine": 176,
+      "description": "qec_conditional_entropy: for any input distribution, the conditional entropy of the input given the output equals p · H(X). The un-erased (some y) terms vanish because the input is determined exactly (log 1 = 0); the erasure (none) term carries the full input entropy scaled by p.",
+      "summary": "H(X|Y) = p · H(X) for any input — the q-independent engine of the capacity."
+    },
+    {
+      "id": "mutual-information",
+      "title": "Mutual Information I(X;Y) = (1 − p) · H(X)",
+      "startLine": 178,
+      "endLine": 195,
+      "description": "qec_mi_eq: combining the chain rule I = H(X) − H(X|Y) with the erasure identity gives I(X;Y) = (1 − p) · H(X) for every input distribution.",
+      "summary": "I(X;Y) = (1 − p) · H(X) via the chain rule."
+    },
+    {
+      "id": "capacity",
+      "title": "Capacity = (1 − p) · log q",
+      "startLine": 197,
+      "endLine": 259,
+      "description": "uniformInput (the 1/|α| distribution), qec_uniform_mi (uniform achieves (1 − p) log|α|), qec_mi_le (converse via entropy_le_log_card), qec_capacity (the capacity = (1 − p) log|α|), qec_capacity_card (= (1 − p) log q when |α| = q), and qec_capacity_nonneg.",
+      "summary": "The capacity (1 − p) log q: converse from H(X) ≤ log q, achievability from the uniform input."
+    },
+    {
+      "id": "bec-recovery",
+      "title": "The Binary Erasure Channel as q = 2",
+      "startLine": 261,
+      "endLine": 276,
+      "description": "qec_eq_bec: the QEC kernel over Bool equals the parent bec kernel on the nose (by rfl). qec_capacity_bool: the capacity specializes to (1 − p) log 2. qec_capacity_bool_bits: in bits, C = 1 − p, matching the parent bec_capacity_bits.",
+      "summary": "The BEC is the q = 2 instance: kernel equality by rfl, capacity (1 − p) log 2 = 1 − p bits."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding-bec",
+      "relationship": "extends",
+      "description": "The parent: the binary erasure channel C(BEC(p)) = (1 − p) log 2. This entry generalizes it to alphabet size q, recovering the parent as the q = 2 case (qec_eq_bec holds by rfl)."
+    },
+    {
+      "targetId": "shannon-channel-coding-awgn",
+      "relationship": "sibling",
+      "description": "Companion concrete-capacity proof for the additive white Gaussian noise channel C = ½ log(1 + P/N). Together with the BSC and the erasure channels these are the named channels of the Shannon channel-coding goal."
+    },
+    {
+      "targetId": "shannon-channel-coding-oq-02",
+      "relationship": "sibling",
+      "description": "Companion concrete-capacity proof for the binary symmetric channel C(BSC(p)) = log 2 − h(p)."
+    },
+    {
+      "targetId": "shannon-entropy",
+      "relationship": "uses",
+      "description": "Built on its general entropy theorems: entropy_le_log_card (H(X) ≤ log|α|, the converse) and entropy_of_uniform_eq_log_card (the uniform input achieves H(X) = log|α|, achievability)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization generalizes the binary erasure channel to an arbitrary input alphabet of size q, proving the q-ary erasure channel capacity C(QEC(p)) = (1 − p) · log q axiom-free, with 0 sorries. The capacity rests on the erasure identity H(X|Y) = p · H(X) — proven for any input distribution on a finite type α — whence the chain rule gives I(X;Y) = (1 − p) · H(X); the converse is the maximum-entropy bound H(X) ≤ log q and achievability is the uniform input, whose entropy is exactly log q. The binary erasure channel is recovered as the q = 2 instance: the QEC transition kernel over Bool is definitionally the parent's bec, so C = (1 − p) log 2 = 1 − p bits is a corollary.",
+    "implications": "Generalizing the formalized BEC argument to arbitrary alphabet size broadens the gallery's information-theory coverage from the Boolean special case to the model used for packet-loss networks and capacity-achieving erasure codes (Reed–Solomon, fountain codes). The proof demonstrates that the parent finite-alphabet channel scaffold was already alphabet-polymorphic: the only q-specific ingredient is the maximum-entropy value log q, so the entire erasure-identity engine transfers verbatim from Bool to any finite type.",
+    "openQuestions": [
+      "Formalize the operational coding theorem for the erasure channel (achievable rates via random codebooks, a Fano-inequality converse), connecting the information capacity proved here to achievable communication rates.",
+      "Specialize α to a finite field GF(q) and connect the capacity to the rate of maximum-distance-separable (Reed–Solomon) erasure codes.",
+      "Extend to erasure channels with feedback or to the q-ary symmetric channel (errors rather than erasures), whose capacity log q − h(p) − p log(q − 1) is the q-ary generalization of the BSC."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "qec_capacity",
+      "type": "core",
+      "description": "The q-ary erasure channel over a finite input type α has capacity (1 − p) · log|α|, assembled axiom-free: every input gives I(X;Y) = (1 − p)·H(X) ≤ (1 − p)·log|α|, and the uniform input achieves the bound.",
+      "leanType": "channelCapacity (qec p hp0.le hp1.le) = (1 - p) * Real.log (Fintype.card α)"
+    },
+    {
+      "name": "qec_conditional_entropy",
+      "type": "core",
+      "description": "The erasure identity: for any input distribution, H(X|Y) = p · H(X). The q-independent engine of the capacity.",
+      "leanType": "conditionalEntropy (jointDist (qec p hp0.le hp1.le) inp) = p * shannonEntropy inp.p"
+    },
+    {
+      "name": "qec_mi_eq",
+      "type": "supporting",
+      "description": "Mutual information I(X;Y) = (1 − p) · H(X) for any input, via the chain rule.",
+      "leanType": "channelMI (qec p hp0.le hp1.le) inp = (1 - p) * shannonEntropy inp.p"
+    },
+    {
+      "name": "qec_eq_bec",
+      "type": "corollary",
+      "description": "The QEC kernel over Bool coincides on the nose with the parent binary erasure channel bec — the BEC is the q = 2 case.",
+      "leanType": "(qec (α := Bool) p hp0 hp1).W = (BEC.bec p hp0 hp1).W"
+    }
+  ],
+  "leanFile": {
+    "axiomCount": 0,
+    "lineCount": 276,
+    "path": "Proofs/ShannonChannelCodingBECOQ01.lean",
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 14
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "Standard textbook: mutual information, channel capacity, Fano's inequality, and the coding theorem with its converse."
+    },
+    {
+      "authors": [
+        "Claude E. Shannon"
+      ],
+      "title": "A Mathematical Theory of Communication",
+      "year": 1948,
+      "venue": "Bell System Technical Journal 27, 379–423 & 623–656",
+      "note": "Founding paper of information theory: channel capacity, the channel coding theorem, and the entropy of discrete sources."
+    },
+    {
+      "authors": [
+        "David J. C. MacKay"
+      ],
+      "title": "Information Theory, Inference, and Learning Algorithms",
+      "year": 2003,
+      "venue": "Cambridge University Press",
+      "note": "Accessible treatment of erasure/symmetric channels, capacity, and binary entropy."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding-bec-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-02/meta.json
@@ -1,139 +1,169 @@
 {
-    "id": "shannon-channel-coding-bec-oq-02",
-    "title": "Operational Coding Theorem for the Binary Erasure Channel",
-    "slug": "shannon-channel-coding-bec-oq-02",
-    "description": "Bridges the binary erasure channel's information-theoretic capacity C(BEC(p)) = (1 - p) · log 2 (proved axiom-free in the parent entry) to the operational coding layer. Specialising the gallery's abstract channel-coding theorems channel_coding_achievability and channel_coding_converse to the concrete bec : DMChannel Bool (Option Bool), and discharging the capacity hypothesis with the proved value via bec_capacity, yields the BEC operational coding theorem with an explicit numerical threshold: every rate 0 < R < (1 - p) log 2 nats (equivalently every bit-rate 0 < R₂ < 1 - p) is achievable by block codes whose average error vanishes, while every rate above the threshold is bounded away from zero error. The two abstract operational theorems are axioms of the channel-coding framework, so the BEC operational theorem is honestly axiomatized (2 inherited axioms); no new axioms or sorries are introduced.",
-    "leanFile": {
-        "axiomCount": 0,
-        "lineCount": 134,
-        "path": "Proofs/ShannonChannelCodingBECOQ02.lean",
-        "sorries": 0,
-        "definitionCount": 0,
-        "theoremCount": 4
-    },
+  "id": "shannon-channel-coding-bec-oq-02",
+  "title": "Operational Coding Theorem for the Binary Erasure Channel",
+  "slug": "shannon-channel-coding-bec-oq-02",
+  "description": "Bridges the binary erasure channel's information-theoretic capacity C(BEC(p)) = (1 - p) · log 2 (proved axiom-free in the parent entry) to the operational coding layer. Specialising the gallery's abstract channel-coding theorems channel_coding_achievability and channel_coding_converse to the concrete bec : DMChannel Bool (Option Bool), and discharging the capacity hypothesis with the proved value via bec_capacity, yields the BEC operational coding theorem with an explicit numerical threshold: every rate 0 < R < (1 - p) log 2 nats (equivalently every bit-rate 0 < R₂ < 1 - p) is achievable by block codes whose average error vanishes, while every rate above the threshold is bounded away from zero error. The two abstract operational theorems are axioms of the channel-coding framework, so the BEC operational theorem is honestly axiomatized (2 inherited axioms); no new axioms or sorries are introduced.",
+  "leanFile": {
+    "axiomCount": 0,
+    "lineCount": 134,
+    "path": "Proofs/ShannonChannelCodingBECOQ02.lean",
     "sorries": 0,
-    "meta": {
-        "author": "Claude Shannon (1948), formalized in Lean 4",
-        "sourceUrl": "https://en.wikipedia.org/wiki/Binary_erasure_channel",
-        "date": "1948",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/ShannonChannelCodingBECOQ02.lean",
-        "tags": [
-            "information-theory",
-            "probability",
-            "coding-theory",
-            "channel-capacity",
-            "erasure-channel",
-            "channel-coding-theorem",
-            "advanced"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "mathlibDependencies": [
-            {
-                "theorem": "Real.log_pos",
-                "description": "log 2 > 0, used to transport the rate threshold between nats and bits (R₂ < 1 - p ⟺ R₂ · log 2 < (1 - p) · log 2)",
-                "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
-            },
-            {
-                "theorem": "mul_lt_mul_of_pos_right",
-                "description": "Monotonicity of multiplication by the positive constant log 2, the single algebraic step in the bit-rate forms",
-                "module": "Mathlib.Algebra.Order.Ring.Lemmas"
-            },
-            {
-                "theorem": "Filter.Eventually / Filter.atTop",
-                "description": "The 'for all sufficiently long block lengths' quantifier in the achievability statement, inherited verbatim from the abstract channel_coding_achievability",
-                "module": "Mathlib.Order.Filter.AtTopBot"
-            }
-        ],
-        "originalContributions": [
-            "bec_coding_achievability: every nat-rate 0 < R < (1 - p) · log 2 is achievable on the BEC — for each ε > 0, all sufficiently long block lengths admit a code of rate ≥ R with average error < ε. The abstract channel_coding_achievability applied to bec, with the capacity hypothesis discharged by the proved value bec_capacity.",
-            "bec_coding_converse: every nat-rate R > (1 - p) · log 2 is unachievable — a fixed δ > 0 lower-bounds the average error of every code of rate ≥ R, at every length. The abstract channel_coding_converse specialised to bec.",
-            "bec_coding_achievability_bits: the textbook headline 'the BEC achieves rate 1 - p bits' — every bit-rate 0 < R₂ < 1 - p is achievable, obtained from the nat-rate form by the log-2 change of units.",
-            "bec_coding_converse_bits: the bit-rate converse — no bit-rate R₂ > 1 - p is achievable.",
-            "Together these pin the BEC's operational capacity to exactly its information-theoretic capacity (1 - p) log 2, answering the open question raised by the sibling entry shannon-channel-coding-bec-oq-01 ('connecting the information capacity proved here to achievable communication rates')."
-        ],
-        "assumptions": "2 axioms, on the critical path: channel_coding_achievability and channel_coding_converse, the gallery's abstract statements of Shannon's two operational coding theorems for an arbitrary DMChannel (the deep random-coding and Fano arguments are taken as given at the abstract level in ShannonChannelCoding.lean). #print axioms confirms the achievability results depend on channel_coding_achievability and the converse results on channel_coding_converse, in each case plus only the ordinary propext / Classical.choice / Quot.sound. The BEC capacity value itself, bec_capacity : channelCapacity (bec p) = (1 - p) · log 2, is proved axiom-free in the parent and supplies the explicit numerical threshold. 0 sorries, no native_decide. leanFile.axiomCount is 0 because the file declares no literal 'axiom'; the assumptions are the two inherited framework axioms, hence meta axiomCount = 2 and status = axiomatized. SCOPE: this entry takes the abstract operational theorems as black boxes and specialises them to the concrete BEC; it does not reprove Shannon's random-coding achievability or Fano converse from scratch (those remain the framework's axioms).",
-        "dateAdded": "2026-06-27",
-        "axiomCount": 2,
-        "lineCount": 134,
-        "prerequisites": [
-            "The binary erasure channel capacity C(BEC(p)) = (1 - p) log 2 (ShannonChannelCodingBEC.lean), supplying the threshold via bec_capacity",
-            "Discrete memoryless channels, block codes, code rate, and channel capacity (ShannonChannelCoding.lean)",
-            "The abstract operational coding theorems channel_coding_achievability / channel_coding_converse (ShannonChannelCoding.lean)"
-        ],
-        "mathlib_version": "4.26.0",
-        "theoremCount": 4,
-        "definitionCount": 0
-    },
-    "overview": {
-        "historicalContext": "Shannon's 1948 channel coding theorem is the foundational result of information theory: it identifies the channel capacity C — an information-theoretic quantity defined as a supremum of mutual informations — with the operational threshold separating achievable from unachievable communication rates. Achievability (rates below C admit codes with vanishing error) is proved by the random-coding method; the converse (rates above C cannot be reliable) is proved via Fano's inequality. For the binary erasure channel, where each transmitted bit is either received correctly or replaced by a known erasure, the capacity is the especially transparent C = 1 - p bits: the surviving fraction of transmissions, each carrying one bit.\n\nThe parent gallery entry proves the BEC's *information* capacity (1 - p) log 2 from first principles. This entry closes the loop to the *operational* meaning by feeding that capacity value through the framework's abstract achievability and converse theorems, producing the BEC operational coding theorem with an explicit numerical threshold.",
-        "problemStatement": "**BEC Operational Coding Theorem**: For a binary erasure channel with erasure probability $0 < p < 1$, the operational capacity equals the information capacity $(1-p)\\log 2$ nats $= 1 - p$ bits. Concretely:\n- **Achievability**: for every rate $0 < R < (1-p)\\log 2$ and every $\\varepsilon > 0$, all sufficiently long block lengths $n$ admit a code of rate $\\ge R$ with average error probability $< \\varepsilon$.\n- **Converse**: for every rate $R > (1-p)\\log 2$ there is a fixed $\\delta > 0$ lower-bounding the average error of every code of rate $\\ge R$.",
-        "text": "Specialises the abstract channel-coding theorems to the BEC, pinning its operational capacity to the proved value (1 - p) log 2.",
-        "proofStrategy": "Each result is a one-step specialisation:\n\n1. **Achievability** (`bec_coding_achievability`): apply `channel_coding_achievability` to `ch := bec p`. Its capacity hypothesis `R < channelCapacity (bec p)` is rewritten by `bec_capacity hp0 hp1` to the explicit `R < (1 - p) · log 2`, which is the stated hypothesis.\n\n2. **Converse** (`bec_coding_converse`): identically, apply `channel_coding_converse` to `bec p` and rewrite the capacity hypothesis with `bec_capacity`.\n\n3. **Bit-rate forms** (`*_bits`): from a bit-rate hypothesis `R₂ < 1 - p` (resp. `1 - p < R₂`) and `log 2 > 0`, `mul_lt_mul_of_pos_right` gives the nat-rate hypothesis `R₂ · log 2 < (1 - p) · log 2`, and the nat-rate theorem applies. The conclusion's rate guarantee `R₂ · log 2 ≤ rate_of_code` says the code's bit-rate `rate_of_code / log 2` is at least `R₂`.",
-        "keyInsights": [
-            "The capacity proved by the parent is an information-theoretic supremum; on its own it says nothing about codes. The operational theorem is what turns it into a statement about achievable communication, and that is precisely Shannon's channel coding theorem.",
-            "The gallery already states the abstract operational theorems (for any DMChannel, in terms of channelCapacity); the only channel-specific input needed to instantiate them for the BEC is the numerical capacity value (1 - p) log 2 — supplied axiom-free by bec_capacity.",
-            "Honesty: because the abstract operational theorems are axioms here, the BEC operational theorem is axiomatized, not verified. #print axioms confirms exactly the two intended axioms are on the critical path (achievability ← channel_coding_achievability, converse ← channel_coding_converse).",
-            "The bit-rate forms are the textbook headline 'the BEC achieves rate 1 - p': the nat/bit conversion is a single multiplication by the positive constant log 2.",
-            "This directly answers an open question logged by the sibling entry bec-oq-01, which asked to connect the proved information capacity to achievable communication rates via the operational coding theorem."
-        ]
-    },
-    "conclusion": {
-        "summary": "Specialises the gallery's abstract channel-coding theorems to the binary erasure channel, establishing the BEC operational coding theorem: every rate below the capacity (1 - p) log 2 nats (every bit-rate below 1 - p) is achievable by block codes with vanishing average error, and every rate above is bounded away from zero error. The capacity value is supplied by the parent's axiom-free bec_capacity, so the threshold is explicit and numerical; the achievability and converse content are inherited from the framework's abstract operational theorems, which are axioms, making this entry honestly axiomatized (2 axioms, 0 sorries).",
-        "implications": "Completes the BEC strand of the Shannon channel-coding development from information capacity to operational capacity, the form in which capacity is actually used in coding theory. The specialisation pattern is reusable: any concrete DMChannel with a proved channelCapacity value (the BSC and AWGN entries also have one) can be turned into an operational coding theorem with an explicit threshold by the same two-line instantiation, so this entry doubles as a template for the sibling channels.",
-        "openQuestions": [
-            "Discharge the framework axioms channel_coding_achievability and channel_coding_converse themselves — formalize Shannon's random-coding achievability and the Fano-inequality converse for general discrete memoryless channels — which would upgrade this entry (and the BSC/AWGN operational statements) from axiomatized to verified.",
-            "Give a BEC-specific constructive achievability via random linear codes and the peeling (belief-propagation) decoder, whose erasure-correction threshold matches 1 - p, replacing the abstract random-coding axiom with an explicit code family for this channel.",
-            "Strengthen the converse to the strong converse (error → 1, not merely bounded below, above capacity) and quantify the finite-blocklength rate penalty (dispersion) for the BEC."
-        ]
-    },
-    "crossReferences": [
-        {
-            "targetId": "shannon-channel-coding-bec",
-            "relationship": "extends",
-            "description": "The parent: the binary erasure channel information capacity C(BEC(p)) = (1 - p) log 2, proved axiom-free. This entry feeds that value through the abstract operational theorems to obtain the BEC operational coding theorem."
-        },
-        {
-            "targetId": "shannon-channel-coding-bec-oq-01",
-            "relationship": "sibling",
-            "description": "The q-ary erasure channel capacity generalization, whose logged open question — 'connecting the information capacity proved here to achievable communication rates' via the operational coding theorem — this entry answers for the binary case."
-        },
-        {
-            "targetId": "shannon-channel-coding",
-            "relationship": "uses",
-            "description": "Supplies the abstract operational coding theorems channel_coding_achievability and channel_coding_converse (specialised here to the BEC) together with the BlockCode / rate_of_code / channelCapacity scaffold."
-        },
-        {
-            "targetId": "shannon-channel-coding-awgn",
-            "relationship": "sibling",
-            "description": "Companion concrete-capacity channel C = ½ log(1 + P/N); the same instantiation pattern would yield its operational coding theorem from its proved capacity value."
-        }
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Claude Shannon (1948), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_erasure_channel",
+    "date": "1948",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/ShannonChannelCodingBECOQ02.lean",
+    "tags": [
+      "information-theory",
+      "probability",
+      "coding-theory",
+      "channel-capacity",
+      "erasure-channel",
+      "channel-coding-theorem",
+      "advanced"
     ],
-    "mainTheorems": [
-        {
-            "name": "bec_coding_achievability",
-            "type": "core",
-            "description": "Every nat-rate 0 < R < (1 - p) · log 2 is achievable on the BEC: for each ε > 0, all sufficiently long block lengths admit a code of rate ≥ R with average error < ε. The abstract achievability theorem specialised to bec, with the capacity hypothesis discharged by bec_capacity.",
-            "leanType": "R < (1 - p) * Real.log 2 → ∀ ε, 0 < ε → ∀ᶠ n in Filter.atTop, ∀ (hn : 0 < n), ∃ code decoder, R ≤ rate_of_code hn code ∧ (avg error) < ε"
-        },
-        {
-            "name": "bec_coding_converse",
-            "type": "core",
-            "description": "Every nat-rate R > (1 - p) · log 2 is unachievable: a fixed δ > 0 lower-bounds the average error of every code of rate ≥ R. The abstract converse specialised to bec.",
-            "leanType": "(1 - p) * Real.log 2 < R → ∃ δ, 0 < δ ∧ ∀ n hn code decoder, R ≤ rate_of_code hn code → δ ≤ (avg error)"
-        },
-        {
-            "name": "bec_coding_achievability_bits",
-            "type": "corollary",
-            "description": "Bit-rate headline form: every bit-rate 0 < R₂ < 1 - p is achievable on the BEC, via the log-2 change of units from the nat-rate achievability theorem.",
-            "leanType": "R₂ < 1 - p → ∀ ε, 0 < ε → ∀ᶠ n in Filter.atTop, ∀ (hn : 0 < n), ∃ code decoder, R₂ * Real.log 2 ≤ rate_of_code hn code ∧ (avg error) < ε"
-        },
-        {
-            "name": "bec_coding_converse_bits",
-            "type": "corollary",
-            "description": "Bit-rate converse: no bit-rate R₂ > 1 - p is achievable on the BEC.",
-            "leanType": "1 - p < R₂ → ∃ δ, 0 < δ ∧ ∀ n hn code decoder, R₂ * Real.log 2 ≤ rate_of_code hn code → δ ≤ (avg error)"
-        }
+    "badge": "axiom",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.log_pos",
+        "description": "log 2 > 0, used to transport the rate threshold between nats and bits (R₂ < 1 - p ⟺ R₂ · log 2 < (1 - p) · log 2)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "mul_lt_mul_of_pos_right",
+        "description": "Monotonicity of multiplication by the positive constant log 2, the single algebraic step in the bit-rate forms",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "Filter.Eventually / Filter.atTop",
+        "description": "The 'for all sufficiently long block lengths' quantifier in the achievability statement, inherited verbatim from the abstract channel_coding_achievability",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      }
+    ],
+    "originalContributions": [
+      "bec_coding_achievability: every nat-rate 0 < R < (1 - p) · log 2 is achievable on the BEC — for each ε > 0, all sufficiently long block lengths admit a code of rate ≥ R with average error < ε. The abstract channel_coding_achievability applied to bec, with the capacity hypothesis discharged by the proved value bec_capacity.",
+      "bec_coding_converse: every nat-rate R > (1 - p) · log 2 is unachievable — a fixed δ > 0 lower-bounds the average error of every code of rate ≥ R, at every length. The abstract channel_coding_converse specialised to bec.",
+      "bec_coding_achievability_bits: the textbook headline 'the BEC achieves rate 1 - p bits' — every bit-rate 0 < R₂ < 1 - p is achievable, obtained from the nat-rate form by the log-2 change of units.",
+      "bec_coding_converse_bits: the bit-rate converse — no bit-rate R₂ > 1 - p is achievable.",
+      "Together these pin the BEC's operational capacity to exactly its information-theoretic capacity (1 - p) log 2, answering the open question raised by the sibling entry shannon-channel-coding-bec-oq-01 ('connecting the information capacity proved here to achievable communication rates')."
+    ],
+    "assumptions": "2 axioms, on the critical path: channel_coding_achievability and channel_coding_converse, the gallery's abstract statements of Shannon's two operational coding theorems for an arbitrary DMChannel (the deep random-coding and Fano arguments are taken as given at the abstract level in ShannonChannelCoding.lean). #print axioms confirms the achievability results depend on channel_coding_achievability and the converse results on channel_coding_converse, in each case plus only the ordinary propext / Classical.choice / Quot.sound. The BEC capacity value itself, bec_capacity : channelCapacity (bec p) = (1 - p) · log 2, is proved axiom-free in the parent and supplies the explicit numerical threshold. 0 sorries, no native_decide. leanFile.axiomCount is 0 because the file declares no literal 'axiom'; the assumptions are the two inherited framework axioms, hence meta axiomCount = 2 and status = axiomatized. SCOPE: this entry takes the abstract operational theorems as black boxes and specialises them to the concrete BEC; it does not reprove Shannon's random-coding achievability or Fano converse from scratch (those remain the framework's axioms).",
+    "dateAdded": "2026-06-27",
+    "axiomCount": 2,
+    "lineCount": 134,
+    "prerequisites": [
+      "The binary erasure channel capacity C(BEC(p)) = (1 - p) log 2 (ShannonChannelCodingBEC.lean), supplying the threshold via bec_capacity",
+      "Discrete memoryless channels, block codes, code rate, and channel capacity (ShannonChannelCoding.lean)",
+      "The abstract operational coding theorems channel_coding_achievability / channel_coding_converse (ShannonChannelCoding.lean)"
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Shannon's 1948 channel coding theorem is the foundational result of information theory: it identifies the channel capacity C — an information-theoretic quantity defined as a supremum of mutual informations — with the operational threshold separating achievable from unachievable communication rates. Achievability (rates below C admit codes with vanishing error) is proved by the random-coding method; the converse (rates above C cannot be reliable) is proved via Fano's inequality. For the binary erasure channel, where each transmitted bit is either received correctly or replaced by a known erasure, the capacity is the especially transparent C = 1 - p bits: the surviving fraction of transmissions, each carrying one bit.\n\nThe parent gallery entry proves the BEC's *information* capacity (1 - p) log 2 from first principles. This entry closes the loop to the *operational* meaning by feeding that capacity value through the framework's abstract achievability and converse theorems, producing the BEC operational coding theorem with an explicit numerical threshold.",
+    "problemStatement": "**BEC Operational Coding Theorem**: For a binary erasure channel with erasure probability $0 < p < 1$, the operational capacity equals the information capacity $(1-p)\\log 2$ nats $= 1 - p$ bits. Concretely:\n- **Achievability**: for every rate $0 < R < (1-p)\\log 2$ and every $\\varepsilon > 0$, all sufficiently long block lengths $n$ admit a code of rate $\\ge R$ with average error probability $< \\varepsilon$.\n- **Converse**: for every rate $R > (1-p)\\log 2$ there is a fixed $\\delta > 0$ lower-bounding the average error of every code of rate $\\ge R$.",
+    "text": "Specialises the abstract channel-coding theorems to the BEC, pinning its operational capacity to the proved value (1 - p) log 2.",
+    "proofStrategy": "Each result is a one-step specialisation:\n\n1. **Achievability** (`bec_coding_achievability`): apply `channel_coding_achievability` to `ch := bec p`. Its capacity hypothesis `R < channelCapacity (bec p)` is rewritten by `bec_capacity hp0 hp1` to the explicit `R < (1 - p) · log 2`, which is the stated hypothesis.\n\n2. **Converse** (`bec_coding_converse`): identically, apply `channel_coding_converse` to `bec p` and rewrite the capacity hypothesis with `bec_capacity`.\n\n3. **Bit-rate forms** (`*_bits`): from a bit-rate hypothesis `R₂ < 1 - p` (resp. `1 - p < R₂`) and `log 2 > 0`, `mul_lt_mul_of_pos_right` gives the nat-rate hypothesis `R₂ · log 2 < (1 - p) · log 2`, and the nat-rate theorem applies. The conclusion's rate guarantee `R₂ · log 2 ≤ rate_of_code` says the code's bit-rate `rate_of_code / log 2` is at least `R₂`.",
+    "keyInsights": [
+      "The capacity proved by the parent is an information-theoretic supremum; on its own it says nothing about codes. The operational theorem is what turns it into a statement about achievable communication, and that is precisely Shannon's channel coding theorem.",
+      "The gallery already states the abstract operational theorems (for any DMChannel, in terms of channelCapacity); the only channel-specific input needed to instantiate them for the BEC is the numerical capacity value (1 - p) log 2 — supplied axiom-free by bec_capacity.",
+      "Honesty: because the abstract operational theorems are axioms here, the BEC operational theorem is axiomatized, not verified. #print axioms confirms exactly the two intended axioms are on the critical path (achievability ← channel_coding_achievability, converse ← channel_coding_converse).",
+      "The bit-rate forms are the textbook headline 'the BEC achieves rate 1 - p': the nat/bit conversion is a single multiplication by the positive constant log 2.",
+      "This directly answers an open question logged by the sibling entry bec-oq-01, which asked to connect the proved information capacity to achievable communication rates via the operational coding theorem."
     ]
+  },
+  "conclusion": {
+    "summary": "Specialises the gallery's abstract channel-coding theorems to the binary erasure channel, establishing the BEC operational coding theorem: every rate below the capacity (1 - p) log 2 nats (every bit-rate below 1 - p) is achievable by block codes with vanishing average error, and every rate above is bounded away from zero error. The capacity value is supplied by the parent's axiom-free bec_capacity, so the threshold is explicit and numerical; the achievability and converse content are inherited from the framework's abstract operational theorems, which are axioms, making this entry honestly axiomatized (2 axioms, 0 sorries).",
+    "implications": "Completes the BEC strand of the Shannon channel-coding development from information capacity to operational capacity, the form in which capacity is actually used in coding theory. The specialisation pattern is reusable: any concrete DMChannel with a proved channelCapacity value (the BSC and AWGN entries also have one) can be turned into an operational coding theorem with an explicit threshold by the same two-line instantiation, so this entry doubles as a template for the sibling channels.",
+    "openQuestions": [
+      "Discharge the framework axioms channel_coding_achievability and channel_coding_converse themselves — formalize Shannon's random-coding achievability and the Fano-inequality converse for general discrete memoryless channels — which would upgrade this entry (and the BSC/AWGN operational statements) from axiomatized to verified.",
+      "Give a BEC-specific constructive achievability via random linear codes and the peeling (belief-propagation) decoder, whose erasure-correction threshold matches 1 - p, replacing the abstract random-coding axiom with an explicit code family for this channel.",
+      "Strengthen the converse to the strong converse (error → 1, not merely bounded below, above capacity) and quantify the finite-blocklength rate penalty (dispersion) for the BEC."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding-bec",
+      "relationship": "extends",
+      "description": "The parent: the binary erasure channel information capacity C(BEC(p)) = (1 - p) log 2, proved axiom-free. This entry feeds that value through the abstract operational theorems to obtain the BEC operational coding theorem."
+    },
+    {
+      "targetId": "shannon-channel-coding-bec-oq-01",
+      "relationship": "sibling",
+      "description": "The q-ary erasure channel capacity generalization, whose logged open question — 'connecting the information capacity proved here to achievable communication rates' via the operational coding theorem — this entry answers for the binary case."
+    },
+    {
+      "targetId": "shannon-channel-coding",
+      "relationship": "uses",
+      "description": "Supplies the abstract operational coding theorems channel_coding_achievability and channel_coding_converse (specialised here to the BEC) together with the BlockCode / rate_of_code / channelCapacity scaffold."
+    },
+    {
+      "targetId": "shannon-channel-coding-awgn",
+      "relationship": "sibling",
+      "description": "Companion concrete-capacity channel C = ½ log(1 + P/N); the same instantiation pattern would yield its operational coding theorem from its proved capacity value."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "bec_coding_achievability",
+      "type": "core",
+      "description": "Every nat-rate 0 < R < (1 - p) · log 2 is achievable on the BEC: for each ε > 0, all sufficiently long block lengths admit a code of rate ≥ R with average error < ε. The abstract achievability theorem specialised to bec, with the capacity hypothesis discharged by bec_capacity.",
+      "leanType": "R < (1 - p) * Real.log 2 → ∀ ε, 0 < ε → ∀ᶠ n in Filter.atTop, ∀ (hn : 0 < n), ∃ code decoder, R ≤ rate_of_code hn code ∧ (avg error) < ε"
+    },
+    {
+      "name": "bec_coding_converse",
+      "type": "core",
+      "description": "Every nat-rate R > (1 - p) · log 2 is unachievable: a fixed δ > 0 lower-bounds the average error of every code of rate ≥ R. The abstract converse specialised to bec.",
+      "leanType": "(1 - p) * Real.log 2 < R → ∃ δ, 0 < δ ∧ ∀ n hn code decoder, R ≤ rate_of_code hn code → δ ≤ (avg error)"
+    },
+    {
+      "name": "bec_coding_achievability_bits",
+      "type": "corollary",
+      "description": "Bit-rate headline form: every bit-rate 0 < R₂ < 1 - p is achievable on the BEC, via the log-2 change of units from the nat-rate achievability theorem.",
+      "leanType": "R₂ < 1 - p → ∀ ε, 0 < ε → ∀ᶠ n in Filter.atTop, ∀ (hn : 0 < n), ∃ code decoder, R₂ * Real.log 2 ≤ rate_of_code hn code ∧ (avg error) < ε"
+    },
+    {
+      "name": "bec_coding_converse_bits",
+      "type": "corollary",
+      "description": "Bit-rate converse: no bit-rate R₂ > 1 - p is achievable on the BEC.",
+      "leanType": "1 - p < R₂ → ∃ δ, 0 < δ ∧ ∀ n hn code decoder, R₂ * Real.log 2 ≤ rate_of_code hn code → δ ≤ (avg error)"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "Standard textbook: mutual information, channel capacity, Fano's inequality, and the coding theorem with its converse."
+    },
+    {
+      "authors": [
+        "Robert G. Gallager"
+      ],
+      "title": "Information Theory and Reliable Communication",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Random-coding achievability, the converse, and capacity of discrete memoryless channels."
+    },
+    {
+      "authors": [
+        "David J. C. MacKay"
+      ],
+      "title": "Information Theory, Inference, and Learning Algorithms",
+      "year": 2003,
+      "venue": "Cambridge University Press",
+      "note": "Accessible treatment of erasure/symmetric channels, capacity, and binary entropy."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-01/meta.json
@@ -144,5 +144,35 @@
     "definitionCount": 2,
     "theoremCount": 5
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "Standard textbook: mutual information, channel capacity, Fano's inequality, and the coding theorem with its converse."
+    },
+    {
+      "authors": [
+        "Claude E. Shannon"
+      ],
+      "title": "A Mathematical Theory of Communication",
+      "year": 1948,
+      "venue": "Bell System Technical Journal 27, 379–423 & 623–656",
+      "note": "Founding paper of information theory: channel capacity, the channel coding theorem, and the entropy of discrete sources."
+    },
+    {
+      "authors": [
+        "Robert G. Gallager"
+      ],
+      "title": "Information Theory and Reliable Communication",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Random-coding achievability, the converse, and capacity of discrete memoryless channels."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -171,5 +171,36 @@
       "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Robert M. Fano"
+      ],
+      "title": "Transmission of Information: A Statistical Theory of Communications",
+      "year": 1961,
+      "venue": "MIT Press",
+      "note": "Original source of Fano's inequality relating conditional entropy to error probability."
+    },
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "Standard textbook: mutual information, channel capacity, Fano's inequality, and the coding theorem with its converse."
+    },
+    {
+      "authors": [
+        "Imre Csiszár",
+        "János Körner"
+      ],
+      "title": "Information Theory: Coding Theorems for Discrete Memoryless Systems",
+      "year": 2011,
+      "venue": "Cambridge University Press (2nd ed.)",
+      "note": "Rigorous coding theorems and converses for discrete memoryless channels."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
@@ -170,5 +170,36 @@
     "definitionCount": 1,
     "theoremCount": 5
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "Standard textbook: mutual information, channel capacity, Fano's inequality, and the coding theorem with its converse."
+    },
+    {
+      "authors": [
+        "Imre Csiszár",
+        "János Körner"
+      ],
+      "title": "Information Theory: Coding Theorems for Discrete Memoryless Systems",
+      "year": 2011,
+      "venue": "Cambridge University Press (2nd ed.)",
+      "note": "Rigorous coding theorems and converses for discrete memoryless channels."
+    },
+    {
+      "authors": [
+        "Robert G. Gallager"
+      ],
+      "title": "Information Theory and Reliable Communication",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Random-coding achievability, the converse, and capacity of discrete memoryless channels."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-04/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "shannon-channel-coding-oq-02-oq-04",
   "title": "Symmetric Channel Capacity: Generalization Beyond BSC",
   "slug": "shannon-channel-coding-oq-02-oq-04",
-  "description": "Generalizes the BSC capacity proof to arbitrary symmetric channels. Proves that for a channel where all rows have the same entropy sum C and uniform input produces uniform output (doubly balanced), the capacity equals log|\u03b2| + C = log|\u03b2| - H(row). Recovers the BSC result as a special case.",
+  "description": "Generalizes the BSC capacity proof to arbitrary symmetric channels. Proves that for a channel where all rows have the same entropy sum C and uniform input produces uniform output (doubly balanced), the capacity equals log|β| + C = log|β| - H(row). Recovers the BSC result as a special case.",
   "meta": {
     "author": "Claude Shannon (1948), formalized in Lean 4",
     "date": "1948",
@@ -25,26 +25,26 @@
     "definitionCount": 1,
     "originalContributions": [
       "uniformDist: uniform distribution on any nonempty Fintype as an InputDist",
-      "entropy_uniform_fintype: H(uniform on \u03b1) = log|\u03b1| (generalizes entropy_uniform_bool)",
+      "entropy_uniform_fintype: H(uniform on α) = log|α| (generalizes entropy_uniform_bool)",
       "sym_conditional_output_entropy: H(Y|X) = -C for row-symmetric channels, any input distribution",
-      "sym_uniform_ymarg: doubly balanced + uniform input \u2192 uniform output",
-      "sym_uniform_mi: achievability MI = log|\u03b2| + C for uniform input",
-      "sym_mi_le: converse MI \u2264 log|\u03b2| + C for all inputs (via chain rule)",
-      "sym_channel_capacity: capacity = log|\u03b2| + C (main theorem)",
+      "sym_uniform_ymarg: doubly balanced + uniform input → uniform output",
+      "sym_uniform_mi: achievability MI = log|β| + C for uniform input",
+      "sym_mi_le: converse MI ≤ log|β| + C for all inputs (via chain rule)",
+      "sym_channel_capacity: capacity = log|β| + C (main theorem)",
       "BSC verification: bsc_row_symmetric, bsc_doubly_balanced, bsc_capacity_from_symmetric"
     ]
   },
   "overview": {
-    "historicalContext": "Shannon (1948) identified symmetric channels as a natural class for which the capacity formula has a closed form. A channel is symmetric (in the relevant sense) when all rows of the transition matrix are permutations of each other (ensuring H(Y|X) is constant) and all columns are proportional (ensuring uniform input maximizes H(Y)). Shannon showed the capacity is C = log|\u03b2| - H(row), achieved by the uniform input distribution. The BSC is the simplest example: \u03b1 = \u03b2 = {0,1}, rows [p, 1-p] and [1-p, p], giving C = log 2 - h(p).",
-    "problemStatement": "**Symmetric Channel Capacity**: For a DMChannel W : \u03b1 \u2192 \u03b2 where:\n(1) Row symmetry: \u2203 C, \u2200 x, \u2211_y W(x,y)\u00b7log(W(x,y)) = C\n(2) Doubly balanced: \u2200 y, \u2211_x W(x,y) = |\u03b1|/|\u03b2|\n(3) Positive: W(x,y) > 0 for all x, y\n\nThe channel capacity equals $C(W) = \\log|\\beta| + C = \\log|\\beta| - H(\\text{row})$.",
-    "text": "**Answer**: The capacity formula `channelCapacity ch = log|\u03b2| + C` holds for symmetric channels satisfying the three conditions.\n\n**Proof structure**:\n1. **Achievability**: Uniform input gives H(Y) = log|\u03b2| (by doubly balanced condition) and H(Y|X) = -C (by row symmetry). So MI(uniform) = H(Y) - H(Y|X) = log|\u03b2| + C.\n\n2. **Converse**: For any input distribution, MI = H(Y) - H(Y|X) = H(Y) + C \u2264 log|\u03b2| + C (since H(Y) \u2264 log|\u03b2|).\n\n3. **Capacity**: The supremum equals the maximum achieved value log|\u03b2| + C.\n\n**BSC recovery**: Setting \u03b1 = \u03b2 = Bool, C = p\u00b7log(p) + (1-p)\u00b7log(1-p) = -h(p), we recover C(BSC(p)) = log 2 - h(p).",
-    "proofStrategy": "1. Prove H(Y|X) = -C for any input distribution using the row symmetry hypothesis.\n   Key step: each conditional entropy term simplifies to inp.p(x)\u00b7(ch.W(x,y)\u00b7log(ch.W(x,y))), and summing over x gives C.\n2. Prove uniform input \u2192 uniform output via the doubly balanced condition.\n3. Compute MI(uniform) = H(Y) - H(Y|X) = log|\u03b2| - (-C) = log|\u03b2| + C.\n4. Bound MI \u2264 log|\u03b2| + C for all inputs via the chain rule and entropy maximality.\n5. Conclude capacity = log|\u03b2| + C.",
+    "historicalContext": "Shannon (1948) identified symmetric channels as a natural class for which the capacity formula has a closed form. A channel is symmetric (in the relevant sense) when all rows of the transition matrix are permutations of each other (ensuring H(Y|X) is constant) and all columns are proportional (ensuring uniform input maximizes H(Y)). Shannon showed the capacity is C = log|β| - H(row), achieved by the uniform input distribution. The BSC is the simplest example: α = β = {0,1}, rows [p, 1-p] and [1-p, p], giving C = log 2 - h(p).",
+    "problemStatement": "**Symmetric Channel Capacity**: For a DMChannel W : α → β where:\n(1) Row symmetry: ∃ C, ∀ x, ∑_y W(x,y)·log(W(x,y)) = C\n(2) Doubly balanced: ∀ y, ∑_x W(x,y) = |α|/|β|\n(3) Positive: W(x,y) > 0 for all x, y\n\nThe channel capacity equals $C(W) = \\log|\\beta| + C = \\log|\\beta| - H(\\text{row})$.",
+    "text": "**Answer**: The capacity formula `channelCapacity ch = log|β| + C` holds for symmetric channels satisfying the three conditions.\n\n**Proof structure**:\n1. **Achievability**: Uniform input gives H(Y) = log|β| (by doubly balanced condition) and H(Y|X) = -C (by row symmetry). So MI(uniform) = H(Y) - H(Y|X) = log|β| + C.\n\n2. **Converse**: For any input distribution, MI = H(Y) - H(Y|X) = H(Y) + C ≤ log|β| + C (since H(Y) ≤ log|β|).\n\n3. **Capacity**: The supremum equals the maximum achieved value log|β| + C.\n\n**BSC recovery**: Setting α = β = Bool, C = p·log(p) + (1-p)·log(1-p) = -h(p), we recover C(BSC(p)) = log 2 - h(p).",
+    "proofStrategy": "1. Prove H(Y|X) = -C for any input distribution using the row symmetry hypothesis.\n   Key step: each conditional entropy term simplifies to inp.p(x)·(ch.W(x,y)·log(ch.W(x,y))), and summing over x gives C.\n2. Prove uniform input → uniform output via the doubly balanced condition.\n3. Compute MI(uniform) = H(Y) - H(Y|X) = log|β| - (-C) = log|β| + C.\n4. Bound MI ≤ log|β| + C for all inputs via the chain rule and entropy maximality.\n5. Conclude capacity = log|β| + C.",
     "keyInsights": [
       "H(Y|X) = -C holds for ALL input distributions (not just positive ones), because zero-probability input terms contribute 0 to the conditional entropy.",
-      "The row symmetry condition is minimal: it only requires that all rows have the same entropy sum C = \u2211_y W(x,y)\u00b7log(W(x,y)), not that rows are permutations of each other.",
-      "The doubly balanced condition \u2211_x W(x,y) = |\u03b1|/|\u03b2| ensures uniform input \u2192 uniform output, giving H(Y) = log|\u03b2|.",
-      "BSC is doubly stochastic (column sums = 1 = |Bool|/|Bool|), satisfying the doubly balanced condition with |\u03b1|/|\u03b2| = 2/2 = 1.",
-      "The capacity formula log|\u03b2| + C generalizes to BSC as log 2 + (p\u00b7log p + (1-p)\u00b7log(1-p)) = log 2 - h(p)."
+      "The row symmetry condition is minimal: it only requires that all rows have the same entropy sum C = ∑_y W(x,y)·log(W(x,y)), not that rows are permutations of each other.",
+      "The doubly balanced condition ∑_x W(x,y) = |α|/|β| ensures uniform input → uniform output, giving H(Y) = log|β|.",
+      "BSC is doubly stochastic (column sums = 1 = |Bool|/|Bool|), satisfying the doubly balanced condition with |α|/|β| = 2/2 = 1.",
+      "The capacity formula log|β| + C generalizes to BSC as log 2 + (p·log p + (1-p)·log(1-p)) = log 2 - h(p)."
     ],
     "prerequisites": [
       "BSC Capacity Proof (ShannonChannelCodingOQ02): parent proof providing the chain rule and BSC infrastructure",
@@ -65,14 +65,14 @@
       "title": "Uniform Distribution on General Fintype",
       "startLine": 61,
       "endLine": 73,
-      "summary": "uniformDist: InputDist with p(x) = 1/|\u03b1| for all x. Proves positivity."
+      "summary": "uniformDist: InputDist with p(x) = 1/|α| for all x. Proves positivity."
     },
     {
       "id": "uniform-entropy",
-      "title": "Entropy of Uniform Distribution = log|\u03b1|",
+      "title": "Entropy of Uniform Distribution = log|α|",
       "startLine": 75,
       "endLine": 89,
-      "summary": "entropy_uniform_fintype: H(uniform on \u03b1) = log|\u03b1|. Generalizes entropy_uniform_bool from the BSC proof."
+      "summary": "entropy_uniform_fintype: H(uniform on α) = log|α|. Generalizes entropy_uniform_bool from the BSC proof."
     },
     {
       "id": "conditional-entropy",
@@ -83,31 +83,31 @@
     },
     {
       "id": "uniform-ymarg",
-      "title": "Doubly Balanced: Uniform \u2192 Uniform Output",
+      "title": "Doubly Balanced: Uniform → Uniform Output",
       "startLine": 129,
       "endLine": 141,
-      "summary": "sym_uniform_ymarg: Doubly balanced condition implies uniform input gives 1/|\u03b2| output marginal."
+      "summary": "sym_uniform_ymarg: Doubly balanced condition implies uniform input gives 1/|β| output marginal."
     },
     {
       "id": "achievability",
-      "title": "Achievability: Uniform MI = log|\u03b2| + C",
+      "title": "Achievability: Uniform MI = log|β| + C",
       "startLine": 143,
       "endLine": 168,
-      "summary": "sym_uniform_mi: The uniform input distribution achieves mutual information = log|\u03b2| + C."
+      "summary": "sym_uniform_mi: The uniform input distribution achieves mutual information = log|β| + C."
     },
     {
       "id": "converse",
-      "title": "Converse: All MI \u2264 log|\u03b2| + C",
+      "title": "Converse: All MI ≤ log|β| + C",
       "startLine": 170,
       "endLine": 190,
-      "summary": "sym_mi_le: For all input distributions, MI \u2264 log|\u03b2| + C via chain rule + entropy bound."
+      "summary": "sym_mi_le: For all input distributions, MI ≤ log|β| + C via chain rule + entropy bound."
     },
     {
       "id": "capacity",
       "title": "Symmetric Channel Capacity Theorem",
       "startLine": 192,
       "endLine": 220,
-      "summary": "sym_channel_capacity: capacity = log|\u03b2| + C. Follows from achievability and converse."
+      "summary": "sym_channel_capacity: capacity = log|β| + C. Follows from achievability and converse."
     },
     {
       "id": "bsc-verification",
@@ -118,12 +118,12 @@
     }
   ],
   "conclusion": {
-    "summary": "The symmetric channel capacity formula C(W) = log|\u03b2| - H(row) is proved from first principles for channels satisfying row symmetry and the doubly balanced condition. The BSC is verified as a special case, recovering log 2 - h(p). This closes OQ 4 from the BSC capacity proof.",
+    "summary": "The symmetric channel capacity formula C(W) = log|β| - H(row) is proved from first principles for channels satisfying row symmetry and the doubly balanced condition. The BSC is verified as a special case, recovering log 2 - h(p). This closes OQ 4 from the BSC capacity proof.",
     "implications": "The proof demonstrates that the key structural properties of BSC (constant row entropy and doubly balanced columns) are the mathematical essence behind the capacity formula, not the binary alphabet. The same technique applies to q-ary symmetric channels, erasure channels over larger alphabets, and other structured channels.",
     "openQuestions": [
       "Remove the positivity assumption W(x,y) > 0: can the theorem extend to channels with zero-probability transitions?",
       "Extend to the general case without the doubly balanced condition: characterize capacity for channels where only row symmetry holds.",
-      "Formalize the q-ary symmetric channel (|\u03b1| = |\u03b2| = q, each off-diagonal entry = p/(q-1)) as a concrete example of the general theorem.",
+      "Formalize the q-ary symmetric channel (|α| = |β| = q, each off-diagonal entry = p/(q-1)) as a concrete example of the general theorem.",
       "Connect to the Blahut-Arimoto algorithm: show it converges to the uniform distribution for symmetric channels."
     ]
   },
@@ -148,5 +148,36 @@
     "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "Standard textbook: mutual information, channel capacity, Fano's inequality, and the coding theorem with its converse."
+    },
+    {
+      "authors": [
+        "Robert G. Gallager"
+      ],
+      "title": "Information Theory and Reliable Communication",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Random-coding achievability, the converse, and capacity of discrete memoryless channels."
+    },
+    {
+      "authors": [
+        "Imre Csiszár",
+        "János Körner"
+      ],
+      "title": "Information Theory: Coding Theorems for Discrete Memoryless Systems",
+      "year": 2011,
+      "venue": "Cambridge University Press (2nd ed.)",
+      "note": "Rigorous coding theorems and converses for discrete memoryless channels."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02/meta.json
@@ -183,5 +183,35 @@
     "definitionCount": 1,
     "theoremCount": 13
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Claude E. Shannon"
+      ],
+      "title": "A Mathematical Theory of Communication",
+      "year": 1948,
+      "venue": "Bell System Technical Journal 27, 379–423 & 623–656",
+      "note": "Founding paper of information theory: channel capacity, the channel coding theorem, and the entropy of discrete sources."
+    },
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "Standard textbook: mutual information, channel capacity, Fano's inequality, and the coding theorem with its converse."
+    },
+    {
+      "authors": [
+        "Robert G. Gallager"
+      ],
+      "title": "Information Theory and Reliable Communication",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Random-coding achievability, the converse, and capacity of discrete memoryless channels."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-04-oq-01-oq-01/meta.json
@@ -144,5 +144,37 @@
       "mathContext": "$h_2(p) = h(p)/\\log 2 = 1 \\iff h(p) = \\log 2 \\iff p = 1/2$. BSC capacity $C = 1 - h_2(p)$ achieves minimum 0 uniquely at $p = 1/2$."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "Standard textbook: mutual information, channel capacity, Fano's inequality, and the coding theorem with its converse."
+    },
+    {
+      "authors": [
+        "David J. C. MacKay"
+      ],
+      "title": "Information Theory, Inference, and Learning Algorithms",
+      "year": 2003,
+      "venue": "Cambridge University Press",
+      "note": "Accessible treatment of erasure/symmetric channels, capacity, and binary entropy."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "J. E. Littlewood",
+        "G. Pólya"
+      ],
+      "title": "Inequalities",
+      "year": 1952,
+      "venue": "Cambridge University Press (2nd ed.)",
+      "note": "Concavity of the entropy function and Jensen's inequality underlying its unique maximum."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding-oq-04-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-04-oq-01/meta.json
@@ -122,5 +122,37 @@
       "summary": "Applies strictConcaveOn_of_deriv2_neg: verifies ContinuousOn and negative second derivative using EventuallyEq.deriv_eq to chain the two derivative lemmas."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "Standard textbook: mutual information, channel capacity, Fano's inequality, and the coding theorem with its converse."
+    },
+    {
+      "authors": [
+        "David J. C. MacKay"
+      ],
+      "title": "Information Theory, Inference, and Learning Algorithms",
+      "year": 2003,
+      "venue": "Cambridge University Press",
+      "note": "Accessible treatment of erasure/symmetric channels, capacity, and binary entropy."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "J. E. Littlewood",
+        "G. Pólya"
+      ],
+      "title": "Inequalities",
+      "year": 1952,
+      "venue": "Cambridge University Press (2nd ed.)",
+      "note": "Concavity of the entropy function and Jensen's inequality underlying its unique maximum."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass: adds bibliographic `references` to 9 empty-reference OQ-children of the **shannon-channel-coding** base (including the `-bec-` erasure-channel subfamily).

| Entry | Topic |
|-------|-------|
| bec-oq-01 | q-ary erasure channel capacity |
| bec-oq-02 | Operational coding theorem for the BEC |
| oq-01 | Additive-channel decomposition I(X;Y)=h(Y)−h(Z) |
| oq-02 | BSC capacity and random coding |
| oq-02-oq-01 | Fano's inequality via conditional entropy |
| oq-02-oq-03 | Channel coding converse via Fano |
| oq-02-oq-04 | Symmetric channel capacity beyond BSC |
| oq-04-oq-01 | Binary entropy strict concavity |
| oq-04-oq-01-oq-01 | Binary entropy unique maximum |

References drawn from canonical sources (Shannon 1948, Cover–Thomas, Gallager, MacKay, Csiszár–Körner, Fano 1961, Hardy–Littlewood–Pólya) matched to each child's topic. Only the top-level `references` field is added; all other keys byte-verified identical to origin/main.