### PR TITLE
Enrich chebyshev-pnt-bridge OQ-children cluster: add references (6 entries)

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-02/meta.json
@@ -156,5 +156,34 @@
     "path": "Proofs/ChebyshevPNTBridgeOQ01OQ02.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Melvyn B. Nathanson"
+      ],
+      "title": "Elementary Methods in Number Theory",
+      "year": 2000,
+      "venue": "Springer (Graduate Texts in Mathematics 195)",
+      "note": "Erdős-style central-binomial-coefficient proof of Chebyshev's bounds."
+    },
+    {
+      "authors": [
+        "Pafnuty L. Chebyshev"
+      ],
+      "title": "Mémoire sur les nombres premiers",
+      "year": 1852,
+      "venue": "Journal de Mathématiques Pures et Appliquées 17, 366–390",
+      "note": "Original elementary bounds c₁ x/log x ≤ π(x) ≤ c₂ x/log x on the prime-counting function."
+    },
+    {
+      "authors": [
+        "Tom M. Apostol"
+      ],
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer (Undergraduate Texts in Mathematics)",
+      "note": "Chebyshev's theorems, the von Mangoldt function, Abel summation, and Mertens' theorems."
+    }
+  ]
 }

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-04/meta.json
@@ -157,5 +157,34 @@
     "path": "Proofs/ChebyshevPNTBridgeOQ04.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Franz Mertens"
+      ],
+      "title": "Ein Beitrag zur analytischen Zahlentheorie",
+      "year": 1874,
+      "venue": "Journal für die reine und angewandte Mathematik 78, 46–62",
+      "note": "Original derivation of Mertens' theorems, including Σ_{p≤x}(log p)/p = log x + O(1)."
+    },
+    {
+      "authors": [
+        "Tom M. Apostol"
+      ],
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer (Undergraduate Texts in Mathematics)",
+      "note": "Chebyshev's theorems, the von Mangoldt function, Abel summation, and Mertens' theorems."
+    },
+    {
+      "authors": [
+        "Gérald Tenenbaum"
+      ],
+      "title": "Introduction to Analytic and Probabilistic Number Theory",
+      "year": 2015,
+      "venue": "American Mathematical Society (Graduate Studies in Mathematics 163, 3rd ed.)",
+      "note": "Chebyshev sandwich, Mertens' formulas, and asymptotics of prime sums."
+    }
+  ]
 }

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/meta.json
@@ -166,5 +166,35 @@
     "path": "Proofs/ChebyshevPNTBridgeOQ05OQ01.lean",
     "sorries": 0
   },
-  "sorries": []
+  "sorries": [],
+  "references": [
+    {
+      "authors": [
+        "Pafnuty L. Chebyshev"
+      ],
+      "title": "Mémoire sur les nombres premiers",
+      "year": 1852,
+      "venue": "Journal de Mathématiques Pures et Appliquées 17, 366–390",
+      "note": "Original elementary bounds c₁ x/log x ≤ π(x) ≤ c₂ x/log x on the prime-counting function."
+    },
+    {
+      "authors": [
+        "Tom M. Apostol"
+      ],
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer (Undergraduate Texts in Mathematics)",
+      "note": "Chebyshev's theorems, the von Mangoldt function, Abel summation, and Mertens' theorems."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed.)",
+      "note": "Elementary prime-counting estimates and bounds on the n-th prime."
+    }
+  ]
 }

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-05/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-05/meta.json
@@ -143,5 +143,34 @@
     "path": "Proofs/ChebyshevPNTBridgeOQ05.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Pafnuty L. Chebyshev"
+      ],
+      "title": "Mémoire sur les nombres premiers",
+      "year": 1852,
+      "venue": "Journal de Mathématiques Pures et Appliquées 17, 366–390",
+      "note": "Original elementary bounds c₁ x/log x ≤ π(x) ≤ c₂ x/log x on the prime-counting function."
+    },
+    {
+      "authors": [
+        "Melvyn B. Nathanson"
+      ],
+      "title": "Elementary Methods in Number Theory",
+      "year": 2000,
+      "venue": "Springer (Graduate Texts in Mathematics 195)",
+      "note": "Erdős-style central-binomial-coefficient proof of Chebyshev's bounds."
+    },
+    {
+      "authors": [
+        "Tom M. Apostol"
+      ],
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer (Undergraduate Texts in Mathematics)",
+      "note": "Chebyshev's theorems, the von Mangoldt function, Abel summation, and Mertens' theorems."
+    }
+  ]
 }

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/meta.json
@@ -157,5 +157,35 @@
     "path": "Proofs/ChebyshevPNTBridgeOQ06OQ01.lean",
     "sorries": 0
   },
-  "sorries": []
+  "sorries": [],
+  "references": [
+    {
+      "authors": [
+        "Tom M. Apostol"
+      ],
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer (Undergraduate Texts in Mathematics)",
+      "note": "Chebyshev's theorems, the von Mangoldt function, Abel summation, and Mertens' theorems."
+    },
+    {
+      "authors": [
+        "Gérald Tenenbaum"
+      ],
+      "title": "Introduction to Analytic and Probabilistic Number Theory",
+      "year": 2015,
+      "venue": "American Mathematical Society (Graduate Studies in Mathematics 163, 3rd ed.)",
+      "note": "Chebyshev sandwich, Mertens' formulas, and asymptotics of prime sums."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed.)",
+      "note": "Elementary prime-counting estimates and bounds on the n-th prime."
+    }
+  ]
 }

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/meta.json
@@ -172,5 +172,35 @@
     "path": "Proofs/ChebyshevPNTBridgeOQ06OQ02.lean",
     "sorries": 0
   },
-  "sorries": []
+  "sorries": [],
+  "references": [
+    {
+      "authors": [
+        "Tom M. Apostol"
+      ],
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer (Undergraduate Texts in Mathematics)",
+      "note": "Chebyshev's theorems, the von Mangoldt function, Abel summation, and Mertens' theorems."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed.)",
+      "note": "Elementary prime-counting estimates and bounds on the n-th prime."
+    },
+    {
+      "authors": [
+        "Gérald Tenenbaum"
+      ],
+      "title": "Introduction to Analytic and Probabilistic Number Theory",
+      "year": 2015,
+      "venue": "American Mathematical Society (Graduate Studies in Mathematics 163, 3rd ed.)",
+      "note": "Chebyshev sandwich, Mertens' formulas, and asymptotics of prime sums."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass: adds bibliographic `references` to 6 empty-reference OQ-children of the **chebyshev-pnt-bridge** base.

| Entry | Topic |
|-------|-------|
| oq-01-oq-02 | Chebyshev bound via central-binomial factorization |
| oq-04 | Mertens' first theorem / von Mangoldt floor identity |
| oq-05 | Chebyshev lower density for all m |
| oq-05-oq-01 | Two-sided bound π(x)=Θ(x/log x) |
| oq-06-oq-01 | Nat.sqrt log bracket and Chebyshev sandwich |
| oq-06-oq-02 | n·log n lower bound on the n-th prime |

References drawn from canonical sources (Chebyshev 1852, Mertens 1874, Apostol, Hardy–Wright, Tenenbaum, Nathanson) matched to each child's topic. Only the top-level `references` field is added; all other keys byte-verified identical to origin/main.