### PR TITLE
Enrich cevas-theorem OQ cluster: add references to 11 entries

### DIFF
--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01-oq-01/meta.json
@@ -91,6 +91,27 @@
       "summary": "Recap: SignedMeasure abstraction, the unified theorem and its algebraic cores, the oddness/coherence lemmas, the three instances, and the domain characterization (0 sorries, 0 axioms)."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Coxeter, H.S.M.",
+        "Greitzer, S.L."
+      ],
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "New Mathematical Library 19, Mathematical Association of America",
+      "note": "Classical treatment of Ceva's and Menelaus' theorems, mass points and the special triangle centers."
+    },
+    {
+      "authors": [
+        "Todhunter, I."
+      ],
+      "title": "Spherical Trigonometry, for the Use of Colleges and Schools",
+      "year": "1886",
+      "venue": "5th ed., Macmillan",
+      "note": "The spherical (great-circle) forms of the Ceva and Menelaus theorems."
+    }
+  ],
   "conclusion": {
     "summary": "The three classical Menelaus theorems are unified into a single result parametrized by an odd measure function. unified_menelaus holds for any SignedMeasure, and Euclidean/spherical/hyperbolic Menelaus are one-line instances via id/sin/sinh. The proof separates the function-free algebraic core from the role of oddness, which is shown to be exactly the property providing signed-arc (Ceva ↔ Menelaus) coherence. 0 sorries, 0 axioms.",
     "implications": "Identifying oddness as the operative hypothesis suggests the 'real' object is a signed arc-measure on an oriented geodesic, with the three geometries as special cases of a one-parameter family. The Ceva/Menelaus toggle under reversal is a Z/2 grading on configurations.",

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
@@ -115,6 +115,27 @@
       "summary": "Recap of the 6 core results + 4 sin-property lemmas (0 sorries, 0 axioms), the shared algebraic core with OQ02's sinh version, and the completed Euclidean/spherical/hyperbolic × Ceva/Menelaus 2×2 matrix."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Todhunter, I."
+      ],
+      "title": "Spherical Trigonometry, for the Use of Colleges and Schools",
+      "year": "1886",
+      "venue": "5th ed., Macmillan",
+      "note": "The spherical (great-circle) forms of the Ceva and Menelaus theorems."
+    },
+    {
+      "authors": [
+        "Coxeter, H.S.M.",
+        "Greitzer, S.L."
+      ],
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "New Mathematical Library 19, Mathematical Association of America",
+      "note": "Classical treatment of Ceva's and Menelaus' theorems, mass points and the special triangle centers."
+    }
+  ],
   "conclusion": {
     "summary": "This formalization proves the spherical Menelaus theorem with 0 sorries and 0 axioms. The proof is a 2-line consequence of a reusable algebraic core, demonstrating that all three geometries (Euclidean, spherical, hyperbolic) share identical algebraic structure — only the measure function changes.",
     "implications": "The completion of the 2×2 matrix (Ceva/Menelaus × Euclidean/Spherical/Hyperbolic) suggests a natural next question: is there a unified statement parametrized by the measure function? The pattern f(-x) = -f(x) (odd function) is the key property, suggesting the real claim is: for any odd function f with f(x) ≠ 0 in the relevant domain, the f-Menelaus theorem holds with the same algebraic core.",

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02/meta.json
@@ -112,6 +112,36 @@
       "mathContext": "Architectural pattern: GeneralizedMenelausConfig (algebraic core) → toGeneralized conversion (measure function swap: $\\text{id} \\to \\sinh$) → HyperbolicMenelausConfig (hyperbolic Menelaus). The algebraic biconditional is proved once and reused for all geometries."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Coxeter, H.S.M.",
+        "Greitzer, S.L."
+      ],
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "New Mathematical Library 19, Mathematical Association of America",
+      "note": "Classical treatment of Ceva's and Menelaus' theorems, mass points and the special triangle centers."
+    },
+    {
+      "authors": [
+        "Todhunter, I."
+      ],
+      "title": "Spherical Trigonometry, for the Use of Colleges and Schools",
+      "year": "1886",
+      "venue": "5th ed., Macmillan",
+      "note": "The spherical (great-circle) forms of the Ceva and Menelaus theorems."
+    },
+    {
+      "authors": [
+        "Ratcliffe, J.G."
+      ],
+      "title": "Foundations of Hyperbolic Manifolds",
+      "year": "2019",
+      "venue": "3rd ed., Graduate Texts in Mathematics 149, Springer",
+      "note": "Hyperboloid model and hyperbolic (sinh-ratio) trigonometry for the hyperbolic Ceva/Menelaus laws."
+    }
+  ],
   "conclusion": {
     "summary": "This formalization now covers Menelaus' theorem in all three constant-curvature geometries (Euclidean, Spherical, Hyperbolic), completing the Ceva-Menelaus trichotomy. All results are fully verified (0 sorries, 0 axioms) using a single generalized algebraic core.",
     "implications": "The unified Ceva-Menelaus framework confirms that the same algebraic biconditional governs all three geometries — only the measure function changes. This pattern could extend to other triangle theorems (Stewart's, trigonometric Ceva) in non-Euclidean settings.",

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02/meta.json
@@ -53,6 +53,26 @@
       "Hyperbolic geometry: hyperboloid model, sinh distance function"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Ratcliffe, J.G."
+      ],
+      "title": "Foundations of Hyperbolic Manifolds",
+      "year": "2019",
+      "venue": "3rd ed., Graduate Texts in Mathematics 149, Springer",
+      "note": "Hyperboloid model and hyperbolic (sinh-ratio) trigonometry for the hyperbolic Ceva/Menelaus laws."
+    },
+    {
+      "authors": [
+        "Coxeter, H.S.M."
+      ],
+      "title": "Introduction to Geometry",
+      "year": "1969",
+      "venue": "2nd ed., Wiley",
+      "note": "Affine and projective ratios underlying Ceva/Menelaus and their higher-dimensional analogues."
+    }
+  ],
   "conclusion": {
     "summary": "Hyperbolic Ceva's theorem is proved via weight parameters in the hyperboloid model: sinh(d(B,D))/sinh(d(D,C)) = β/α by algebraic cancellation, and the triple product equals 1 iff αD·αE·αF = βD·βE·βF. This unifies with Euclidean and spherical cases. 13 theorems, 4 definitions, 301 lines, 0 axioms.",
     "implications": "The universality result confirms that Ceva's theorem is fundamentally a theorem of projective/barycentric geometry. The weight parameters (α:β) encode projective cross-ratios on each edge, and the concurrency condition is a projective invariant. This perspective unifies Euclidean, spherical, and hyperbolic cases under the Klein model (where hyperbolic geometry IS projective geometry on the disk).",

--- a/src/data/proofs/cevas-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-02/meta.json
@@ -177,6 +177,27 @@
       "mathContext": "Translates the weight ratios $\\beta_i/\\alpha_i$ into products of trigonometric angle ratios, recovering the spherical Ceva formulation."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Todhunter, I."
+      ],
+      "title": "Spherical Trigonometry, for the Use of Colleges and Schools",
+      "year": "1886",
+      "venue": "5th ed., Macmillan",
+      "note": "The spherical (great-circle) forms of the Ceva and Menelaus theorems."
+    },
+    {
+      "authors": [
+        "Coxeter, H.S.M.",
+        "Greitzer, S.L."
+      ],
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "New Mathematical Library 19, Mathematical Association of America",
+      "note": "Classical treatment of Ceva's and Menelaus' theorems, mass points and the special triangle centers."
+    }
+  ],
   "conclusion": {
     "summary": "This formalization fully answers OQ-02-OQ-02: YES, the spherical Ceva theorem generalizes from triangles to arbitrary convex n-gons. The concurrency condition ∏αᵢ = ∏βᵢ (where αᵢ, βᵢ are weight parameters for cevian points on each side) is a clean algebraic criterion. All 17 theorems are proved with 0 sorries.",
     "implications": "**Mathematical Significance**:\n\n**1. New Quadrilateral Ceva**: The condition α₁α₂α₃α₄ = β₁β₂β₃β₄ for spherical quadrilateral concurrency is a concrete new result not commonly found in textbooks.\n\n**2. Unified Framework**: The PolygonCevaConfig structure and Fin n indexing provide a single framework for all polygon sizes, avoiding case-by-case arguments.\n\n**3. Scaling Invariance**: The proof that the Ceva condition depends only on weight ratios (not absolute values) shows the underlying projective nature of the concurrency condition.\n\n**4. Polygon Menelaus Duality**: The sign-flip theorem extends the classical Ceva-Menelaus duality to polygons, with the Menelaus sign being (-1)ⁿ.",

--- a/src/data/proofs/cevas-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-04-oq-01/meta.json
@@ -154,6 +154,26 @@
       "mathContext": "Specialization to ι = Fin 4 makes the content concrete: the tetrahedron's triangular faces carry signed product -1 while its 4-vertex cycle returns +1, illustrating the $(-1)^L$ law."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Richter-Gebert, J."
+      ],
+      "title": "Perspectives on Projective Geometry",
+      "year": "2011",
+      "venue": "Springer",
+      "note": "Cocycle / determinant criteria for incidence and concurrency in higher dimensions."
+    },
+    {
+      "authors": [
+        "Coxeter, H.S.M."
+      ],
+      "title": "Introduction to Geometry",
+      "year": "1969",
+      "venue": "2nd ed., Wiley",
+      "note": "Affine and projective ratios underlying Ceva/Menelaus and their higher-dimensional analogues."
+    }
+  ],
   "conclusion": {
     "summary": "Menelaus's theorem is Ceva's with a sign. A hyperplane crossing an n-simplex assigns signed edge ratios m(i,j) = -a_i/a_j that satisfy a TWISTED cocycle m(i,j)·m(j,k) = -m(i,k) and multiply to -1 around every triangular 2-face — the exact negation of the parent's Ceva +1 for concurrent cevians. A transversal hyperplane realizing a nonzero signed assignment exists precisely when the Menelaus product equals -1 on every 2-face, and the hyperplane is reconstructed explicitly as a_i = 1/m(b,i). The closed-walk product (-1)^L unifies the triangle's -1 with the even cycles' +1. All results are fully machine-checked with 0 axioms and 0 sorries.",
     "implications": "This completes the Ceva/Menelaus dual at the algebraic level of the parent's higher-dimensional Ceva entry: concurrency (an honest 1-cocycle, +1) and transversality (a twisted cocycle, -1) are revealed as one identity up to a single orientation-reversing sign on each crossed edge. The signed reformulation extends the classical planar Menelaus equation to every triangular 2-face of an n-simplex and shows realizability is reconstruction — a signed assignment comes from a genuine hyperplane exactly when it is a twisted coboundary m(i,j) = -a_i/a_j. The cube relation m(i,i)³ = -1 over ℝ is the lone nonlinear ingredient that makes the 2-face conditions sufficient.",

--- a/src/data/proofs/cevas-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-04/meta.json
@@ -142,6 +142,26 @@
       "mathContext": "Specialization to ι = Fin 4 makes the higher-dimensional content concrete: the tetrahedron's faces and full vertex cycle all carry edge-ratio product 1."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Richter-Gebert, J."
+      ],
+      "title": "Perspectives on Projective Geometry",
+      "year": "2011",
+      "venue": "Springer",
+      "note": "Cocycle / determinant criteria for incidence and concurrency in higher dimensions."
+    },
+    {
+      "authors": [
+        "Coxeter, H.S.M."
+      ],
+      "title": "Introduction to Geometry",
+      "year": "1969",
+      "venue": "2nd ed., Wiley",
+      "note": "Affine and projective ratios underlying Ceva/Menelaus and their higher-dimensional analogues."
+    }
+  ],
   "conclusion": {
     "summary": "The planar Ceva equation BD/DC·CE/EA·AF/FB = 1 is identified as the n = 2 instance of a 1-cocycle condition on a simplex's edge ratios. In every dimension, cevians of an n-simplex concur precisely when the edge ratios form a cocycle, equivalently when the classical Ceva product equals 1 on every triangular 2-face; the concurrency point is reconstructed explicitly from any base vertex as w_i = r(b,i). The full three-way equivalence is machine-checked with 0 axioms and 0 sorries.",
     "implications": "This answers open question 4 of cevas-theorem-oq-02 — when do hypersurfaces bisect a simplex concurrently? — at the algebraic level shared by all the gallery's Ceva/Menelaus entries. By recasting concurrency as the solvability of a coboundary equation r(i,j) = w_j/w_i, the result both unifies the planar Ceva product with its higher-dimensional and closed-walk generalizations and makes the criterion constructive: the concurrency point's barycentric coordinates are produced explicitly rather than merely shown to exist.",

--- a/src/data/proofs/cevas-theorem-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-01-oq-01/meta.json
@@ -97,6 +97,27 @@
       "Elementary real arithmetic"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Coxeter, H.S.M.",
+        "Greitzer, S.L."
+      ],
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "New Mathematical Library 19, Mathematical Association of America",
+      "note": "Classical treatment of Ceva's and Menelaus' theorems, mass points and the special triangle centers."
+    },
+    {
+      "authors": [
+        "Honsberger, R."
+      ],
+      "title": "Episodes in Nineteenth and Twentieth Century Euclidean Geometry",
+      "year": "1995",
+      "venue": "New Mathematical Library 37, Mathematical Association of America",
+      "note": "The Nagel and Gergonne points, excenters and mass-point constructions."
+    }
+  ],
   "conclusion": {
     "summary": "The necessary conditions for an n-simplex complement-fraction profile — each r i < 1 and Σ r i = n — are also sufficient: the explicit masses mass i = 1 - r i realise any such profile, with total mass 1, and these normalised masses are uniquely determined by the profile. This closes the converse direction of the parent's n-dimensional mass-point Ceva identity. Fully verified, 0 axioms, 0 sorries.",
     "implications": "Together with the parent's forward identity (masses → ratios with Σ ratio i = n), this gives a complete characterisation of realisable complement-fraction profiles on an n-simplex and pins down the normalised mass representative of each. It is the n-dim analogue of recovering vertex masses from a triangle Ceva ratio (masses_from_ceva). The remaining open directions are geometric: bridging to the parent's edge-split parametrization and to Mathlib.LinearAlgebra.AffineSpace.Ceva for cevian concurrency.",

--- a/src/data/proofs/cevas-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-01/meta.json
@@ -99,6 +99,27 @@
       "Elementary real arithmetic"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Coxeter, H.S.M.",
+        "Greitzer, S.L."
+      ],
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "New Mathematical Library 19, Mathematical Association of America",
+      "note": "Classical treatment of Ceva's and Menelaus' theorems, mass points and the special triangle centers."
+    },
+    {
+      "authors": [
+        "Honsberger, R."
+      ],
+      "title": "Episodes in Nineteenth and Twentieth Century Euclidean Geometry",
+      "year": "1995",
+      "venue": "New Mathematical Library 37, Mathematical Association of America",
+      "note": "The Nagel and Gergonne points, excenters and mass-point constructions."
+    }
+  ],
   "conclusion": {
     "summary": "The triangle mass-point structure of the parent entry generalizes to an n-simplex: with n+1 positive vertex masses, each complement fraction ratio i = (Σ_{j≠i} mass j)/total lies in (0,1) and the fractions sum to exactly n. The uniform mass point gives ratio i = n/(n+1) (the centroid), and the n = 2 case recovers the triangle sum of 2. Fully verified, 0 axioms, 0 sorries.",
     "implications": "This establishes the algebraic skeleton of n-dimensional mass-point geometry, the affine setting for cevian concurrency in a simplex. It resolves the parent's generalization question at the level of the mass/ratio identities; connecting these to geometric concurrency via Mathlib.LinearAlgebra.AffineSpace.Ceva, and bridging to the parent's edge-split parametrization, are the natural next steps.",

--- a/src/data/proofs/cevas-theorem-oq-04-oq-04-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-04-oq-02/meta.json
@@ -10,7 +10,9 @@
   "leanFile": {
     "path": "Proofs/CevasTheoremOQ04OQ04OQ02.lean",
     "namespace": "MassPointCeva.Excenters",
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "opens": [],
     "axiomCount": 0,
     "sorries": 0,
@@ -88,6 +90,27 @@
       "endLine": 223,
       "summary": "excenterA_on_bisector_A proves the A-excenter (signed mass −a at A) lies on the internal A-bisector through footBisectorA — the same foot as the incenter (incenter_on_bisector_A, for comparison). excenterB_on_bisector_B gives the B-excenter on its own internal bisector. Weight-sum-one lemmas accompany each.",
       "mathContext": "A-excenter = (−(y+z)/2x)A + ((2x+y+z)/2x)·footBisectorA, weights summing to 1 even though the apex weight is negative."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Honsberger, R."
+      ],
+      "title": "Episodes in Nineteenth and Twentieth Century Euclidean Geometry",
+      "year": "1995",
+      "venue": "New Mathematical Library 37, Mathematical Association of America",
+      "note": "The Nagel and Gergonne points, excenters and mass-point constructions."
+    },
+    {
+      "authors": [
+        "Coxeter, H.S.M.",
+        "Greitzer, S.L."
+      ],
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "New Mathematical Library 19, Mathematical Association of America",
+      "note": "Classical treatment of Ceva's and Menelaus' theorems, mass points and the special triangle centers."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/cevas-theorem-oq-04-oq-04/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-04/meta.json
@@ -91,6 +91,27 @@
       "Affine combinations and lines in a vector space"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Coxeter, H.S.M.",
+        "Greitzer, S.L."
+      ],
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "New Mathematical Library 19, Mathematical Association of America",
+      "note": "Classical treatment of Ceva's and Menelaus' theorems, mass points and the special triangle centers."
+    },
+    {
+      "authors": [
+        "Honsberger, R."
+      ],
+      "title": "Episodes in Nineteenth and Twentieth Century Euclidean Geometry",
+      "year": "1995",
+      "venue": "New Mathematical Library 37, Mathematical Association of America",
+      "note": "The Nagel and Gergonne points, excenters and mass-point constructions."
+    }
+  ],
   "conclusion": {
     "summary": "Assigning vertex masses equal to the opposite side lengths realises the three angle bisectors of a triangle within the parent's mass-point framework: the induced division ratios are exactly the angle-bisector theorem ratios c/b, a/c, b/a, whose Ceva product is 1. The bisectors are concurrent at the incenter I = (a·A + b·B + c·C)/(a+b+c), proved constructively by placing I on each bisector as an affine combination of a vertex and the opposite foot (and as AffineMap.lineMap). Fully verified, 0 axioms, 0 sorries.",
     "implications": "This is the canonical angle-bisector / incenter worked example of mass-point geometry, made into a checked theorem. Beyond the parent's ratio identity it provides an explicit geometric concurrency witness (the incenter on all three cevians) valid in any real vector space, and identifies the incenter's barycentric coordinates as (a : b : c).",


### PR DESCRIPTION
Adds a top-level `references` array to 11 open-question descendants across the **cevas-theorem** family (including `-non-euclidean-*`) that previously had none.

## Coverage
Ceva's and Menelaus' theorems across the three constant-curvature geometries (Euclidean, spherical, hyperbolic), their weight-parameter and higher-dimensional cocycle criteria for simplex concurrency, and the mass-point / barycentric treatment of triangle centers — the incenter via angle bisectors, and the excenters, Nagel and Gergonne points.

## Method
Cited to Coxeter–Greitzer (*Geometry Revisited*), Coxeter (*Introduction to Geometry*), Todhunter (spherical trigonometry), Ratcliffe (hyperbolic geometry), Richter-Gebert (projective / higher-dimensional) and Honsberger (triangle centers). 2–3 references per entry, matched to each `description`.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.