### PR TITLE
Enrich solution-of-cubic OQ cluster: add references to 5 entries

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01-oq-04/meta.json
@@ -18,6 +18,26 @@
     "path": "Proofs/SolutionOfCubicOQ03OQ01OQ04.lean",
     "sorries": 0
   },
+  "references": [
+    {
+      "authors": [
+        "Cox, D.A."
+      ],
+      "title": "Galois Theory",
+      "year": "2012",
+      "venue": "2nd ed., Pure and Applied Mathematics, Wiley",
+      "note": "Modern treatment of the cubic and quartic — depressed forms, discriminants, resolvent cubic and the Cardano/Ferrari methods."
+    },
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "The discriminant as a root-separation product and Vieta's formulas via symmetric functions."
+    }
+  ],
   "conclusion": {
     "summary": "The discriminant of the general monic cubic x³ + ax² + bx + c equals the same root-separation product (x₁−x₂)²(x₁−x₃)²(x₂−x₃)² that the parent established only for the depressed cubic, with 0 sorries and 0 axioms. The parent's formula −4p³ − 27q² is recovered exactly as the a = 0 specialization. The discriminant is proved invariant under a common translation of the roots — the depression substitution x ↦ x + t — so depressing a cubic never changes its discriminant. Finally, over any integral domain the discriminant vanishes iff two roots coincide, a characteristic-free separability criterion that strengthens the parent's real-sign analysis (no ordering required).",
     "implications": "The root-form identity and the translation-invariance lemma justify the standard practice of computing a cubic's discriminant from its depressed form: the depression step is discriminant-preserving. The integral-domain criterion Δ ≠ 0 ⟺ distinct roots is the squarefree/separability test underlying Galois-theoretic arguments about cubic field extensions, and being characteristic-free it applies over ℚ, finite fields (away from characteristic obstructions to depression), and polynomial rings alike.",

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
@@ -84,6 +84,26 @@
       "summary": "Two theorems over ℝ: `distinct_roots_of_pos_discriminant` (Δ>0 → all roots distinct, proved by simp+contradiction) and `repeated_root_of_zero_discriminant` (Δ=0 → some roots coincide, proved by positivity+linarith)."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Cox, D.A."
+      ],
+      "title": "Galois Theory",
+      "year": "2012",
+      "venue": "2nd ed., Pure and Applied Mathematics, Wiley",
+      "note": "Modern treatment of the cubic and quartic — depressed forms, discriminants, resolvent cubic and the Cardano/Ferrari methods."
+    },
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "The discriminant as a root-separation product and Vieta's formulas via symmetric functions."
+    }
+  ],
   "conclusion": {
     "summary": "A concise 89-line fully verified formalization proving that Δ = -4p³-27q² equals the squared Vandermonde product (x₁-x₂)²(x₁-x₃)²(x₂-x₃)² for the depressed cubic, with sign-based theorems for root nature. The main identity proof is a clean ring calculation; the sign theorems use positivity and linarith elegantly.",
     "implications": "The discriminant connects algebra, geometry, and topology. In algebraic geometry, the discriminant locus {(p,q) : Δ(p,q) = 0} is a curve in parameter space where the cubic has a repeated root (a bifurcation set in dynamical systems). In Galois theory, the discriminant determines whether the Galois group of the polynomial is contained in the alternating group: for cubics over ℚ, Gal(f) ⊆ A₃ (cyclic order 3) iff Δ is a perfect square in ℚ.",

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05-oq-01/meta.json
@@ -145,6 +145,27 @@
       "mathContext": "cubic_coeff_two applies prod_linear_sub_one at cardinality 3; cubic_coeff_zero reads off the constant term via coeff 0 = eval 0. Together they show the general degree-n machinery subsumes the hand-expanded cubic Vieta of the parent."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "The discriminant as a root-separation product and Vieta's formulas via symmetric functions."
+    },
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Vieta's formulas via elementary symmetric polynomials and the discriminant over a commutative ring."
+    }
+  ],
   "conclusion": {
     "summary": "Vieta's formulas are established for arbitrary degree n over any integral domain (and field), with 0 sorries and 0 axioms. The classical named relations — sum of roots, product of roots, second symmetric function, and their field-division forms — are extracted from the single Mathlib coefficient formula, and the parent's cubic relations are recovered as the cardinality-3 instance. This affirmatively answers the parent's open question: Mathlib's Polynomial.roots / Multiset.esymm machinery fully covers the general case.",
     "implications": "The named relations provide ready-to-use lemmas for any argument relating a split polynomial's coefficients to symmetric functions of its roots — trace and determinant of a matrix from its characteristic polynomial, Newton's identities, discriminants, and the Galois-theoretic fact that coefficients are the symmetric (invariant) functions of the roots.",

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
@@ -121,6 +121,27 @@
       "mathContext": "`root_satisfies (h : X^3 + C a * X^2 + C b * X + C c = (X - C r₁) * (X - C r₂) * (X - C r₃)) : Polynomial.eval r₁ (X^3 + C a * X^2 + C b * X + C c) = 0`. Proof: `rw [h]; simp [Polynomial.eval_mul, Polynomial.eval_sub, sub_self]` — evaluating $(r_1 - r_1) = 0$ kills the first factor. This is the reverse direction of the factor theorem: $p(r_i) = 0$ iff $(X - r_i) \\mid p$. Here we prove it directly from the factored form, avoiding the general factor theorem. In Lean, `Polynomial.eval r₁ (X - C r₁) = r₁ - r₁ = 0` by `simp`."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Prasolov, V.V."
+      ],
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "The discriminant as a root-separation product and Vieta's formulas via symmetric functions."
+    },
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Vieta's formulas via elementary symmetric polynomials and the discriminant over a commutative ring."
+    }
+  ],
   "conclusion": {
     "summary": "Vieta's formulas for the general cubic are fully machine-verified over any commutative ring, with no axioms and no sorries. The proof by coefficient extraction from the factored form is clean and generalizes immediately to polynomials of any degree.",
     "implications": "These formulas connect the roots of a cubic to its coefficients and are the foundation for: (1) the discriminant Δ = 18abcd - 4b³d + b²c² - 4ac³ - 27a²d² expressed in terms of roots; (2) the resolvent cubic in Galois theory; (3) Newton's identities relating power sums to elementary symmetric polynomials. In Lean, they provide the formal basis for any proof that needs to relate polynomial coefficients to roots.",

--- a/src/data/proofs/solution-of-cubic-oq-05/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-05/meta.json
@@ -187,6 +187,26 @@
       "mathContext": "For $p=0$: no Tschirnhaus shift, $P_r = 0$, $Q_r = -q^2/8$. For $p=-1$: shift $= -5/6$, $P_r = -1/12$, $Q_r = 1/108$. The identity evaluations confirm both sides match on concrete inputs."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Cardano, G."
+      ],
+      "title": "Ars Magna (The Great Art, or the Rules of Algebra)",
+      "year": "1545",
+      "venue": "Nuremberg",
+      "note": "The original published solution of the cubic and (via Ferrari) the quartic by radicals."
+    },
+    {
+      "authors": [
+        "Cox, D.A."
+      ],
+      "title": "Galois Theory",
+      "year": "2012",
+      "venue": "2nd ed., Pure and Applied Mathematics, Wiley",
+      "note": "Modern treatment of the cubic and quartic — depressed forms, discriminants, resolvent cubic and the Cardano/Ferrari methods."
+    }
+  ],
   "conclusion": {
     "summary": "Fully verified (0 sorries, 0 axioms) proof that Ferrari's resolvent cubic reduces to a depressed cubic via the Tschirnhaus substitution m = t − 5p/6, and that Cardano's formula directly provides the required resolvent root. Eight theorems in 183 lines, including the key polynomial identity (proved by ring), the main Cardano-Ferrari connection, FTA-based existence results, and concrete numerical checks.",
     "implications": "This file completes the chain connecting Wiedijk #37 (Cardano's cubic) and Wiedijk #46 (Ferrari's quartic) in a fully machine-verified way. The Tschirnhaus reduction shows that solving the quartic ultimately reduces to the cubic, which in turn reduces to the depressed cubic via another Tschirnhaus substitution. This chain — quartic → resolvent cubic → depressed cubic → Cardano's formula — is now fully formalized in Lean 4 with zero gaps.",


### PR DESCRIPTION
Adds a top-level `references` array to 5 open-question descendants of **solution-of-cubic** that previously had none.

## Coverage
The discriminant of the depressed and general cubic (as the root-separation product (x₁−x₂)²(x₁−x₃)²(x₂−x₃)², with depression invariance), Vieta's formulas for the general cubic and for arbitrary degree n, and the resolvent-cubic bridge between Cardano's cubic formula and Ferrari's quartic method.

## Method
Cited to Cardano's *Ars Magna* (1545), Cox (*Galois Theory*), Prasolov (*Polynomials*) and Dummit–Foote for the symmetric-function / discriminant theory. 2 references per entry.

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`.