### PR TITLE
research(niven-theorem-oq-01-oq-02): Vieta–Lucas monic recurrence from scratch [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/NivenTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/NivenTheoremOQ01OQ02.lean
@@ -1,0 +1,169 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Tactic
+
+/-
+# Niven's Theorem, OQ-01-OQ-02: the Vieta–Lucas monic recurrence, from scratch
+
+## What This Proves
+
+The parent entry `niven-theorem-oq-01` proves Niven's theorem but discharges its
+deep half — "`2·cos θ` is an algebraic integer whenever `θ` is a rational multiple
+of `π`" — by *citing* the Mathlib black box `Real.isIntegral_two_mul_cos_rat_mul_pi`
+(proved internally via roots of unity).
+
+This file replaces that citation with the classical, explicit mechanism: the
+**Vieta–Lucas** (normalized Chebyshev-of-the-first-kind) polynomials
+
+    C₀(x) = 2,   C₁(x) = x,   C_{n+2}(x) = x·C_{n+1}(x) − C_n(x)
+
+are **monic integer** polynomials satisfying the fundamental identity
+
+    2·cos(n θ) = C_n(2·cos θ)          for all n ∈ ℕ, θ ∈ ℝ.
+
+Because each `C_n` (n ≥ 1) is monic with integer coefficients, and because
+`2·cos(n θ) = ±2 ∈ ℤ` when `θ = (k/n)·π`, the number `2·cos θ` is a root of the
+monic integer polynomial `C_n(X) − 2·cos(n θ) ∈ ℤ[X]`, hence an algebraic integer.
+
+## Main results
+
+* `C`                    — the Vieta–Lucas polynomials in `ℤ[X]`.
+* `C_monic`              — `C (n+1)` is monic (of degree `n+1`).
+* `C_eval_two_cos`       — `2·cos(n θ) = aeval (2·cos θ) (C n)`, by two-step induction
+                           on the cosine addition formula. *This is the mathematical core.*
+* `isIntegral_two_mul_cos`     — the explicit-witness replacement for
+                                 `Real.isIntegral_two_mul_cos_rat_mul_pi`.
+* `isIntegral_two_mul_cos_rat` — the same in the familiar `θ = (m/n)·π` form.
+
+Everything is verified from scratch: no `sorry`, no `axiom`, and no appeal to the
+Mathlib Niven lemma or to `Polynomial.Chebyshev`.
+-/
+
+open Polynomial Real
+
+namespace NivenOQ0102
+
+/-- The Vieta–Lucas polynomials `C n ∈ ℤ[X]`:
+`C₀ = 2`, `C₁ = X`, `C_{n+2} = X·C_{n+1} − C_n`.
+These are the monic normalization of the Chebyshev polynomials of the first kind:
+`C_n(2 cos θ) = 2 cos(n θ)`. -/
+noncomputable def C : ℕ → Polynomial ℤ
+  | 0 => 2
+  | 1 => Polynomial.X
+  | (n + 2) => Polynomial.X * C (n + 1) - C n
+
+@[simp] lemma C_zero : C 0 = 2 := rfl
+@[simp] lemma C_one : C 1 = Polynomial.X := rfl
+
+/-- Defining recurrence, as a rewrite lemma. -/
+lemma C_succ_succ (n : ℕ) : C (n + 2) = Polynomial.X * C (n + 1) - C n := rfl
+
+/-- `C 2 = X² − 2` (so `2 cos 2θ = (2 cos θ)² − 2`). -/
+example : C 2 = Polynomial.X ^ 2 - 2 := by
+  rw [C_succ_succ, C_one, C_zero]; ring
+
+/-- `C 3 = X³ − 3X` (so `2 cos 3θ = (2 cos θ)³ − 3(2 cos θ)`). -/
+example : C 3 = Polynomial.X ^ 3 - 3 * Polynomial.X := by
+  rw [C_succ_succ, C_succ_succ, C_one, C_zero]; ring
+
+/-- Both facts we need about the shape of `C`, proved together by two-step induction:
+for every `n ≥ 1`, `C n` is monic of degree exactly `n`. Stated with the index shifted
+to `n + 1` so that only the monic polynomials `C 1, C 2, …` are involved. -/
+lemma C_monic_natDegree :
+    ∀ n : ℕ, Monic (C (n + 1)) ∧ (C (n + 1)).natDegree = n + 1 := by
+  -- Prove the statement together with its successor, so the two-step recurrence closes.
+  have H : ∀ n : ℕ,
+      (Monic (C (n + 1)) ∧ (C (n + 1)).natDegree = n + 1) ∧
+      (Monic (C (n + 2)) ∧ (C (n + 2)).natDegree = n + 2) := by
+    intro n
+    induction n with
+    | zero =>
+      -- Base: handle C 1 = X and C 2 = X·X − 2 explicitly.
+      have hm1 : Monic (C 1) := by rw [C_one]; exact monic_X
+      have hd1 : (C 1).natDegree = 1 := by simp [C_one]
+      have hmul : Monic (Polynomial.X * C 1) := monic_X.mul hm1
+      have hmuld : (Polynomial.X * C 1).natDegree = 2 := by
+        rw [Monic.natDegree_mul monic_X hm1, natDegree_X, hd1]
+      have hd0 : (C 0).natDegree = 0 := by simp [C_zero]
+      have hlt : (C 0).natDegree < (Polynomial.X * C 1).natDegree := by rw [hmuld, hd0]; omega
+      refine ⟨⟨hm1, hd1⟩, ?_, ?_⟩
+      · rw [C_succ_succ 0]; exact hmul.sub_of_left (degree_lt_degree hlt)
+      · rw [C_succ_succ 0, natDegree_sub_eq_left_of_natDegree_lt hlt, hmuld]
+    | succ k ih =>
+      obtain ⟨h1, h2⟩ := ih          -- h1: about C (k+1);  h2: about C (k+2)
+      refine ⟨h2, ?_⟩
+      -- Now prove the claim for C (k+3) = X·C (k+2) − C (k+1).
+      have hmul : Monic (Polynomial.X * C (k + 2)) := monic_X.mul h2.1
+      have hmuld : (Polynomial.X * C (k + 2)).natDegree = k + 3 := by
+        rw [Monic.natDegree_mul monic_X h2.1, natDegree_X, h2.2]; omega
+      have hlt : (C (k + 1)).natDegree < (Polynomial.X * C (k + 2)).natDegree := by
+        rw [hmuld, h1.2]; omega
+      refine ⟨?_, ?_⟩
+      · rw [C_succ_succ (k + 1)]; exact hmul.sub_of_left (degree_lt_degree hlt)
+      · rw [C_succ_succ (k + 1), natDegree_sub_eq_left_of_natDegree_lt hlt, hmuld]
+  exact fun n => (H n).1
+
+/-- `C (n+1)` is monic. -/
+lemma C_monic (n : ℕ) : Monic (C (n + 1)) := (C_monic_natDegree n).1
+
+/-- `C (n+1)` has degree `n+1`. -/
+lemma C_natDegree (n : ℕ) : (C (n + 1)).natDegree = n + 1 := (C_monic_natDegree n).2
+
+/-- **The fundamental identity.** Evaluating the Vieta–Lucas polynomial at `2 cos θ`
+returns `2 cos(n θ)`. Proved by two-step induction: the step *is* the cosine
+addition/product-to-sum formula
+`2 cos((n+2)θ) = (2 cos θ)·(2 cos((n+1)θ)) − 2 cos(n θ)`. -/
+lemma C_eval_two_cos (θ : ℝ) :
+    ∀ n : ℕ, (2 : ℝ) * Real.cos (n * θ) = Polynomial.aeval (2 * Real.cos θ) (C n) := by
+  intro n
+  induction n using Nat.twoStepInduction with
+  | zero => simp [map_ofNat]
+  | one => simp [C_one]
+  | more n ih1 ih2 =>
+    rw [C_succ_succ, map_sub, map_mul, aeval_X, ← ih1, ← ih2]
+    -- Goal: 2·cos((n+2)θ) = (2 cos θ)·(2 cos((n+1)θ)) − 2 cos(n θ)
+    push_cast
+    rw [show ((n : ℝ) + 2) * θ = ((n : ℝ) + 1) * θ + θ by ring,
+        show (n : ℝ) * θ = ((n : ℝ) + 1) * θ - θ by ring,
+        Real.cos_add, Real.cos_sub]
+    ring
+
+/-- **Algebraic-integer core (explicit witness).**
+If `θ` is a rational multiple of `π` — witnessed by `n·θ = k·π` with `n ≥ 1` — then
+`2·cos θ` is a root of the monic integer polynomial `C n − 2·cos(n θ)`, hence an
+algebraic integer. This is the from-scratch replacement for
+`Real.isIntegral_two_mul_cos_rat_mul_pi`. -/
+theorem isIntegral_two_mul_cos (θ : ℝ) (n : ℕ) (hn : 1 ≤ n) (k : ℤ)
+    (hθ : (n : ℝ) * θ = k * π) : IsIntegral ℤ (2 * Real.cos θ) := by
+  obtain ⟨j, rfl⟩ : ∃ j, n = j + 1 := ⟨n - 1, by omega⟩
+  -- `2 cos((j+1)θ) = 2 cos(kπ) = ±2` is an integer; name that integer `z`.
+  obtain ⟨z, hz⟩ : ∃ z : ℤ, (z : ℝ) = 2 * Real.cos (((j + 1 : ℕ) : ℝ) * θ) := by
+    rcases Int.even_or_odd k with hk | hk
+    · exact ⟨2, by rw [hθ, Real.cos_int_mul_pi, hk.neg_one_zpow]; norm_num⟩
+    · exact ⟨-2, by rw [hθ, Real.cos_int_mul_pi, hk.neg_one_zpow]; norm_num⟩
+  -- Witness polynomial:  C (j+1) − z.
+  refine ⟨C (j + 1) - Polynomial.C z, ?_, ?_⟩
+  · -- Monic: subtracting a constant does not disturb the leading term of the degree-(j+1) poly.
+    refine (C_monic j).sub_of_left ?_
+    have hne : C (j + 1) ≠ 0 := (C_monic j).ne_zero
+    rw [degree_eq_natDegree hne, C_natDegree j]
+    exact lt_of_le_of_lt degree_C_le (by exact_mod_cast Nat.succ_pos j)
+  · -- Root: aeval (2 cos θ) (C (j+1)) = 2 cos((j+1)θ) = z.
+    rw [← aeval_def, map_sub, ← C_eval_two_cos, aeval_C, algebraMap_int_eq, eq_intCast, hz]
+    ring
+
+/-- **Familiar form.** For `θ = (m/n)·π` with `n ≥ 1`, `2·cos θ` is an algebraic
+integer. This is exactly the fact the parent Niven entry cited from Mathlib. -/
+theorem isIntegral_two_mul_cos_rat (m : ℤ) (n : ℕ) (hn : 1 ≤ n) :
+    IsIntegral ℤ (2 * Real.cos (((m : ℝ) / n) * π)) := by
+  refine isIntegral_two_mul_cos _ n hn m ?_
+  have hn0 : (n : ℝ) ≠ 0 := by
+    exact_mod_cast (by omega : n ≠ 0)
+  field_simp
+
+/-- Sanity example: `2·cos(π/5)` (the golden ratio `(1+√5)/2`) is an algebraic integer. -/
+example : IsIntegral ℤ (2 * Real.cos (π / 5)) := by
+  have h : π / 5 = ((1 : ℝ) / (5 : ℕ)) * π := by push_cast; ring
+  rw [h]
+  simpa using isIntegral_two_mul_cos_rat 1 5 (by norm_num)
+
+end NivenOQ0102

--- a/src/data/proofs/niven-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/niven-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-def-vieta-lucas",
+    "proofId": "niven-theorem-oq-01-oq-02",
+    "range": { "startLine": 45, "endLine": 58 },
+    "type": "definition",
+    "title": "The Vieta–Lucas Polynomials C_n in ℤ[X]",
+    "content": "Defines C : ℕ → ℤ[X] by the three-term recurrence C₀ = 2, C₁ = X, C_{n+2} = X·C_{n+1} − C_n, together with @[simp] base lemmas C_zero, C_one and the rewrite lemma C_succ_succ (all provable by rfl). These are the monic normalization of the Chebyshev polynomials of the first kind: C_n(x) = 2·T_n(x/2), designed so that C_n(2·cos θ) = 2·cos(n θ). The recurrence deliberately mirrors the cosine recurrence 2cos((n+2)θ) = 2cosθ·2cos((n+1)θ) − 2cos(nθ).",
+    "mathContext": "$C_0 = 2,\\quad C_1 = X,\\quad C_{n+2} = X\\,C_{n+1} - C_n$",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Vieta–Lucas polynomials",
+      "Chebyshev polynomials of the first kind",
+      "linear recurrence over ℤ[X]"
+    ],
+    "prerequisites": ["Polynomial ℤ", "structural recursion on ℕ"]
+  },
+  {
+    "id": "ann-examples-c2-c3",
+    "proofId": "niven-theorem-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 66 },
+    "type": "example",
+    "title": "First Cases: C₂ = X² − 2 and C₃ = X³ − 3X",
+    "content": "Two examples unfold the recurrence at small indices: C₂ = X·C₁ − C₀ = X² − 2 and C₃ = X·C₂ − C₁ = X³ − 3X, each closed by rewriting with C_succ_succ / C_one / C_zero and ring. These are exactly the polynomials behind the familiar identities 2cos(2θ) = (2cosθ)² − 2 and 2cos(3θ) = (2cosθ)³ − 3(2cosθ), making the abstract recurrence concrete.",
+    "mathContext": "$C_2(x) = x^2 - 2,\\qquad C_3(x) = x^3 - 3x$",
+    "significance": "illustrative",
+    "relatedConcepts": ["double-angle formula", "triple-angle formula"],
+    "prerequisites": ["ring", "the recurrence lemma C_succ_succ"]
+  },
+  {
+    "id": "ann-monic-natdegree",
+    "proofId": "niven-theorem-oq-01-oq-02",
+    "range": { "startLine": 68, "endLine": 109 },
+    "type": "theorem",
+    "title": "C_{n+1} is Monic of Degree n+1 (Two-Step Induction)",
+    "content": "C_monic_natDegree proves, in one induction, that for every n ≥ 1 the polynomial C_n is monic and has natDegree exactly n. The statement is phrased at the shifted index n+1 because C₀ = 2 is the constant 2 — NOT monic. To make the two-step recurrence close, the proof carries the pair (claim at n+1, claim at n+2) through a single ℕ-induction. In the step, X·C_{n+1} is monic of degree n+2 (Monic.mul, Monic.natDegree_mul), and since the subtracted C_n has degree only n, Monic.sub_of_left and natDegree_sub_eq_left_of_natDegree_lt show the leading term survives — so C_{n+2} is monic of degree n+2.",
+    "mathContext": "$\\deg C_n = n,\\quad \\operatorname{lead}(C_n) = 1 \\quad (n \\ge 1)$",
+    "significance": "essential",
+    "relatedConcepts": [
+      "Monic.sub_of_left",
+      "Monic.natDegree_mul",
+      "Nat.twoStepInduction",
+      "leading coefficient stability under lower-degree perturbation"
+    ],
+    "prerequisites": ["Polynomial.Monic", "degree_lt_degree", "natDegree_sub_eq_left_of_natDegree_lt"]
+  },
+  {
+    "id": "ann-eval-identity",
+    "proofId": "niven-theorem-oq-01-oq-02",
+    "range": { "startLine": 111, "endLine": 128 },
+    "type": "theorem",
+    "title": "The Fundamental Identity 2cos(nθ) = C_n(2cosθ)",
+    "content": "C_eval_two_cos proves 2·cos(n θ) = aeval(2·cos θ)(C n) by two-step induction — the mathematical heart of the entry. The base cases n=0,1 are immediate. In the step, map_sub / map_mul / aeval_X push aeval through C_{n+2} = X·C_{n+1} − C_n, turning the right side into (2cosθ)·(2cos((n+1)θ)) − 2cos(nθ) after applying the two inductive hypotheses. Rewriting (n+2)θ = (n+1)θ + θ and nθ = (n+1)θ − θ and applying Real.cos_add and Real.cos_sub reduces the whole goal to a ring identity: this step IS the product-to-sum formula 4cosθ·cos((n+1)θ) = 2cos((n+2)θ) + 2cos(nθ). This replaces Mathlib's internal roots-of-unity proof of integrality with the classical trigonometric recurrence.",
+    "mathContext": "$2\\cos(n\\theta) = C_n(2\\cos\\theta),\\qquad 2\\cos((n{+}2)\\theta) = (2\\cos\\theta)(2\\cos((n{+}1)\\theta)) - 2\\cos(n\\theta)$",
+    "significance": "essential",
+    "relatedConcepts": [
+      "cosine addition formula",
+      "product-to-sum identity",
+      "Polynomial.aeval as a ring homomorphism",
+      "two-step induction"
+    ],
+    "prerequisites": ["Real.cos_add", "Real.cos_sub", "aeval_X", "map_mul", "map_sub"]
+  },
+  {
+    "id": "ann-isintegral-core",
+    "proofId": "niven-theorem-oq-01-oq-02",
+    "range": { "startLine": 130, "endLine": 152 },
+    "type": "theorem",
+    "title": "Algebraic-Integer Core: the Explicit Monic Witness",
+    "content": "isIntegral_two_mul_cos proves IsIntegral ℤ (2·cos θ) whenever n·θ = k·π (n ≥ 1). Since cos(n θ) = cos(k π) = (−1)^k, the value 2·cos(n θ) is the integer ±2, chosen concretely by casing on the parity of k (Int.even_or_odd with Even/Odd.neg_one_zpow) to avoid any ℤ-valued (−1)^k. The witness polynomial is C(j+1) − Polynomial.C z: it is monic because subtracting the constant z (degree ≤ 0, via degree_C_le) cannot disturb the degree-(j+1) leading term of the monic C(j+1) (Monic.sub_of_left), and 2·cos θ is a root because, after rewriting eval₂ as aeval (aeval_def), the evaluation identity gives aeval(2cosθ)(C(j+1)) = 2cos((j+1)θ) = z. This is the direct, from-scratch replacement for Real.isIntegral_two_mul_cos_rat_mul_pi.",
+    "mathContext": "$n\\theta = k\\pi \\;\\Rightarrow\\; 2\\cos\\theta \\text{ is a root of } C_n(X) - 2\\cos(n\\theta) \\in \\mathbb{Z}[X],\\ \\text{monic}$",
+    "significance": "essential",
+    "relatedConcepts": [
+      "IsIntegral as root of a monic integer polynomial",
+      "Real.cos_int_mul_pi",
+      "parity of the exponent",
+      "algebraic integers"
+    ],
+    "prerequisites": ["IsIntegral", "aeval_def", "degree_C_le", "Even.neg_one_zpow", "Odd.neg_one_zpow"]
+  },
+  {
+    "id": "ann-rational-form",
+    "proofId": "niven-theorem-oq-01-oq-02",
+    "range": { "startLine": 154, "endLine": 169 },
+    "type": "theorem",
+    "title": "Familiar Form and the 2cos(π/5) Example",
+    "content": "isIntegral_two_mul_cos_rat restates the core in the shape the parent Niven entry cited: for θ = (m/n)·π with n ≥ 1, 2·cos θ is an algebraic integer, obtained by feeding n·((m/n)·π) = m·π (cleared by field_simp) into isIntegral_two_mul_cos. A closing example specializes to θ = π/5, exhibiting 2·cos(π/5) — the golden ratio (1+√5)/2 — as an algebraic integer via C₅, a concrete sanity check that the whole pipeline fires.",
+    "mathContext": "$\\theta = \\tfrac{m}{n}\\pi \\;\\Rightarrow\\; \\mathrm{IsIntegral}\\ \\mathbb{Z}\\ (2\\cos\\theta);\\qquad 2\\cos\\tfrac{\\pi}{5} = \\tfrac{1+\\sqrt5}{2}$",
+    "significance": "illustrative",
+    "relatedConcepts": ["rational multiples of π", "golden ratio", "field_simp"],
+    "prerequisites": ["isIntegral_two_mul_cos"]
+  }
+]

--- a/src/data/proofs/niven-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/niven-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "niven-theorem-oq-01-oq-02",
+  "title": "Niven's Algebraic-Integer Step, Unfolded: the Vieta–Lucas Monic Recurrence from Scratch",
+  "slug": "niven-theorem-oq-01-oq-02",
+  "description": "Answers the parent entry's open question — replace the delegated Mathlib black box Real.isIntegral_two_mul_cos_rat_mul_pi with the explicit classical mechanism. Builds the Vieta–Lucas (normalized Chebyshev-of-the-first-kind) polynomials C₀=2, C₁=X, C_{n+2}=X·C_{n+1}−C_n directly in ℤ[X], proves each C_{n+1} is monic of degree n+1 by two-step induction, and proves the fundamental identity 2·cos(nθ)=aeval(2cosθ)(C n) — whose induction step is exactly the cosine product-to-sum formula 2cos((n+2)θ)=(2cosθ)(2cos((n+1)θ))−2cos(nθ). Assembling the monic witness C n − 2cos(nθ) with 2cos(nθ)=±2∈ℤ gives IsIntegral ℤ (2cosθ) for every rational multiple of π, from scratch. 9 theorems, 1 definition, 0 sorries, 0 axioms, 169 lines.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NivenTheoremOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "algebraic-integers",
+      "chebyshev-polynomials",
+      "vieta-lucas-polynomials",
+      "trigonometry",
+      "rational-multiples-of-pi",
+      "monic-polynomials",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified over Mathlib's polynomial and trigonometric API; no new axioms and no native_decide. The parent's appeal to Real.isIntegral_two_mul_cos_rat_mul_pi is eliminated and re-derived by hand.",
+    "lineCount": 169,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "originalContributions": [
+      "C: the Vieta–Lucas polynomials defined directly in ℤ[X] by C₀=2, C₁=X, C_{n+2}=X·C_{n+1}−C_n",
+      "C_monic_natDegree: a single two-step induction proving C_{n+1} is monic AND has natDegree exactly n+1, with the base case handling the non-monic constant C₀=2 explicitly",
+      "C_eval_two_cos: the fundamental identity 2·cos(nθ)=aeval(2cosθ)(C n), whose two-step induction step is the cosine product-to-sum formula — the mathematical heart replacing Mathlib's roots-of-unity argument",
+      "isIntegral_two_mul_cos: the explicit-witness replacement for Real.isIntegral_two_mul_cos_rat_mul_pi — 2cosθ is a root of the monic integer polynomial C n − 2cos(nθ) whenever n·θ = k·π"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Niven's theorem (Ivan Niven, Irrational Numbers, 1956) states that the only rational values of cos θ at rational multiples of π are 0, ±1/2, ±1. Its deep half rests on the classical fact that 2·cos θ is an algebraic integer whenever θ is a rational multiple of π. The mechanism is the family of monic integer polynomials V_n with V_n(2cos θ) = 2cos(n θ) — the Vieta–Lucas polynomials, going back to François Viète's Ad angulares sectiones and appearing as the monic normalization C_n(x) = 2·T_n(x/2) of the Chebyshev polynomials of the first kind. The parent gallery entry (niven-theorem-oq-01) presents Niven's theorem but discharges this algebraic-integer step by citing a single packaged Mathlib lemma, Real.isIntegral_two_mul_cos_rat_mul_pi, which is proved internally via roots of unity — hiding the classical recurrence that is the real reason the theorem is true. This entry answers the parent's open question by building that recurrence explicitly and re-deriving integrality from scratch.",
+    "problemStatement": "Construct the monic integer Vieta–Lucas polynomials C_n directly, prove the identity 2·cos(n θ) = C_n(2·cos θ) by induction on the cosine addition formula, and use it to prove IsIntegral ℤ (2·cos θ) for every rational multiple of π — eliminating the parent entry's appeal to Real.isIntegral_two_mul_cos_rat_mul_pi.",
+    "text": "Define C : ℕ → ℤ[X] by C₀ = 2, C₁ = X, C_{n+2} = X·C_{n+1} − C_n. Two structural facts drive the proof. (1) Shape: for n ≥ 1, C_n is monic of degree exactly n. This is a two-step induction — X·C_{n+1} is monic of degree n+2 (product of monics), and subtracting the lower-degree C_n leaves the top coefficient untouched (Monic.sub_of_left). The base case is handled explicitly because C₀ = 2 is the constant 2, which is NOT monic, so the induction is phrased with the index shifted to n+1. (2) Evaluation: 2·cos(n θ) = aeval(2·cos θ)(C_n), again by two-step induction. The step unfolds C_{n+2} into X·C_{n+1} − C_n under aeval, giving (2cos θ)·(2cos((n+1)θ)) − 2cos(n θ); rewriting (n+2)θ = (n+1)θ + θ and nθ = (n+1)θ − θ and applying cos_add and cos_sub reduces the goal to a pure ring identity — this step IS the product-to-sum formula 4cos θ·cos((n+1)θ) = 2cos((n+2)θ) + 2cos(n θ). Finally, when n·θ = k·π (i.e. θ is the rational multiple (k/n)·π), cos(n θ) = cos(k π) = (−1)^k, so 2·cos(n θ) = ±2 ∈ ℤ. The polynomial C_n(X) − 2·cos(n θ) is then a monic integer polynomial (subtracting a constant from a degree-n≥1 monic) with 2·cos θ as a root, exhibiting 2·cos θ as an algebraic integer.",
+    "proofStrategy": "Everything is derived from elementary Mathlib API only. The monic/degree induction uses Monic.mul, Monic.natDegree_mul, Monic.sub_of_left, natDegree_sub_eq_left_of_natDegree_lt, and degree_lt_degree, driven by Nat.twoStepInduction. The evaluation identity is a Nat.twoStepInduction whose step calls map_sub / map_mul / aeval_X to push aeval through the recurrence, then Real.cos_add and Real.cos_sub with a ring closer. The integrality assembly names the integer value ±2 by casing on the parity of k (Int.even_or_odd, Even/Odd.neg_one_zpow, Real.cos_int_mul_pi), builds the witness C (j+1) − Polynomial.C z, proves it monic via degree_C_le versus the degree-(j+1) leading term, and discharges the root condition by rewriting eval₂ as aeval (aeval_def) and applying the evaluation identity. No native_decide, no roots-of-unity black box, no Polynomial.Chebyshev import.",
+    "keyInsights": [
+      "The induction step for 2cos(nθ)=C_n(2cosθ) is LITERALLY the cosine product-to-sum formula: writing (n+2)θ=(n+1)θ+θ and nθ=(n+1)θ−θ, cos_add and cos_sub collapse the polynomial recurrence into the trigonometric one, so the same three-term recurrence governs the polynomials and the cosines. This is why the Vieta–Lucas polynomials exist at all.",
+      "C₀ = 2 is the constant 2, which is NOT monic (its leading coefficient is 2, not 1). Monicity holds only from C₁ onward, so the whole shape induction is phrased at the shifted index n+1 — a small but essential bookkeeping choice that keeps every polynomial in the induction genuinely monic.",
+      "Degree bookkeeping makes the recurrence self-sustaining: X·C_{n+1} has degree n+2 while C_n has degree n, so the subtraction can never cancel the leading term. Monic.sub_of_left packages exactly this 'lower-degree perturbation preserves the leading coefficient' principle.",
+      "Integrality needs only that 2cos(nθ) is SOME integer, not its exact value: casing on the parity of k turns cos(kπ)=(−1)^k into the concrete witness ±2, avoiding any ℤ-valued (−1)^k (which would demand a zpow instance ℤ does not carry) by working with the real zpow and its parity lemmas.",
+      "The Bézout-free, roots-of-unity-free route shows the classical Niven argument is elementary end to end: a monic recurrence plus the addition formula plus ℤ being integrally closed in ℚ. The Mathlib lemma the parent cited is convenient but conceals this mechanism."
+    ],
+    "prerequisites": [
+      "Polynomials over ℤ: Polynomial.Monic, Monic.mul, Monic.natDegree_mul, Monic.sub_of_left, natDegree_sub_eq_left_of_natDegree_lt, degree_lt_degree, degree_C_le",
+      "Algebra evaluation: Polynomial.aeval, aeval_X, aeval_C, aeval_def, map_sub, map_mul",
+      "Trigonometry: Real.cos_add, Real.cos_sub, Real.cos_int_mul_pi (cos(kπ)=(−1)^k)",
+      "Parity and casts: Int.even_or_odd, Even.neg_one_zpow / Odd.neg_one_zpow, algebraMap_int_eq, eq_intCast",
+      "Integrality: IsIntegral ℤ as 'root of a monic integer polynomial'; Nat.twoStepInduction"
+    ]
+  },
+  "conclusion": {
+    "summary": "The algebraic-integer step of Niven's theorem is re-derived from scratch: the Vieta–Lucas polynomials C₀=2, C₁=X, C_{n+2}=X·C_{n+1}−C_n are monic integer polynomials with 2·cos(nθ)=C_n(2·cos θ), so 2·cos θ is a root of the monic integer polynomial C_n−2·cos(nθ) whenever θ is a rational multiple of π. This replaces the parent entry's citation of Real.isIntegral_two_mul_cos_rat_mul_pi. 9 theorems, 1 definition, 0 sorries, 0 axioms, 169 lines.",
+    "implications": "The parent Niven entry no longer rests on a Mathlib black box for its deep half — the whole argument is now elementary and self-contained: a monic three-term recurrence, the cosine addition formula, and ℤ integrally closed in ℚ. The explicit polynomials and the identity 2cos(nθ)=C_n(2cosθ) are reusable machinery for sibling cyclotomic/irrationality results (e.g. irrationality of cos(2π/n) for most n) and for minimal-polynomial computations of 2cos(2π/n).",
+    "openQuestions": [
+      "Prove the bridge C_n(X) = 2·T_n(X/2) to Mathlib's Chebyshev polynomials Polynomial.Chebyshev.T, reconciling the monic normalization (leading coefficient 1) with T_n's leading coefficient 2^{n-1}.",
+      "Compute the minimal polynomial of 2·cos(2π/n) explicitly from the C_n family (the 'minimal polynomial of 2cos(2π/n)' / Ψ_n polynomials), sharpening 'algebraic integer' to its exact degree φ(n)."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "C_eval_two_cos",
+      "type": "core",
+      "description": "The fundamental identity 2·cos(n θ) = aeval(2·cos θ)(C n), proved by two-step induction. The induction step pushes aeval through the recurrence C_{n+2}=X·C_{n+1}−C_n and reduces to the cosine product-to-sum formula via Real.cos_add and Real.cos_sub — the mathematical core replacing Mathlib's roots-of-unity argument."
+    },
+    {
+      "name": "isIntegral_two_mul_cos",
+      "type": "core",
+      "description": "If n·θ = k·π with n ≥ 1, then 2·cos θ is a root of the monic integer polynomial C n − 2·cos(n θ) (with 2·cos(n θ)=±2∈ℤ), hence IsIntegral ℤ (2·cos θ). The from-scratch, explicit-witness replacement for Real.isIntegral_two_mul_cos_rat_mul_pi."
+    },
+    {
+      "name": "isIntegral_two_mul_cos_rat",
+      "type": "core",
+      "description": "The familiar form: for θ = (m/n)·π with n ≥ 1, 2·cos θ is an algebraic integer — exactly the fact the parent Niven entry cited from Mathlib, now supplied by the Vieta–Lucas construction."
+    },
+    {
+      "name": "C_monic_natDegree",
+      "type": "supporting",
+      "description": "A single two-step induction proving that for every n ≥ 1, C_{n+1} is monic AND has natDegree exactly n+1. The base case treats the non-monic constant C₀=2 explicitly; the step uses that X·C_{n+1} (degree n+2) dominates the subtracted C_n (degree n)."
+    },
+    {
+      "name": "C",
+      "type": "supporting",
+      "description": "The Vieta–Lucas polynomials in ℤ[X]: C₀=2, C₁=X, C_{n+2}=X·C_{n+1}−C_n. The monic normalization of the Chebyshev polynomials of the first kind, with C_2=X²−2 and C_3=X³−3X exhibited as sanity examples."
+    }
+  ],
+  "leanFile": {
+    "namespace": "NivenOQ0102",
+    "lineCount": 169,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/NivenTheoremOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "niven-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Presents Niven's theorem but discharges its algebraic-integer step by citing the Mathlib lemma Real.isIntegral_two_mul_cos_rat_mul_pi. This entry answers its open question by unfolding that step into the explicit Vieta–Lucas monic recurrence."
+    },
+    {
+      "targetId": "nth-root-irrational-oq-01-oq-01",
+      "relationship": "related",
+      "description": "A sibling cyclotomic/Niven result resting on the same '2·cos(qπ) is an algebraic integer' fact; the explicit C_n polynomials and the identity 2cos(nθ)=C_n(2cosθ) are the reusable machinery behind such minimal-polynomial arguments."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Statement of Goal",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module documentation explains that the parent entry delegates its algebraic-integer step to Mathlib's Real.isIntegral_two_mul_cos_rat_mul_pi and states the plan: build the Vieta–Lucas polynomials C₀=2, C₁=X, C_{n+2}=X·C_{n+1}−C_n, prove 2cos(nθ)=C_n(2cosθ), and re-derive IsIntegral ℤ (2cosθ) from scratch."
+    },
+    {
+      "id": "sec-def",
+      "title": "Definition: the Vieta–Lucas Polynomials",
+      "startLine": 45,
+      "endLine": 65,
+      "summary": "Defines C : ℕ → ℤ[X] by the three-term recurrence, with @[simp] base lemmas C_zero, C_one and the rewrite lemma C_succ_succ. Two examples record C_2 = X²−2 and C_3 = X³−3X, the polynomials behind 2cos2θ=(2cosθ)²−2 and 2cos3θ=(2cosθ)³−3(2cosθ)."
+    },
+    {
+      "id": "sec-monic",
+      "title": "Shape: C_{n+1} is Monic of Degree n+1",
+      "startLine": 68,
+      "endLine": 109,
+      "summary": "C_monic_natDegree proves, by a single Nat-indexed two-step induction (carrying the statement together with its successor), that C_{n+1} is monic and has natDegree exactly n+1. The base case handles C₁=X and C₂ explicitly (C₀=2 is not monic); the step uses Monic.mul, Monic.natDegree_mul, and Monic.sub_of_left since X·C_{n+1} of degree n+2 dominates C_n of degree n. C_monic and C_natDegree expose the two components."
+    },
+    {
+      "id": "sec-eval",
+      "title": "The Fundamental Identity: 2cos(nθ) = C_n(2cosθ)",
+      "startLine": 111,
+      "endLine": 128,
+      "summary": "C_eval_two_cos proves the evaluation identity by two-step induction. The step rewrites C_{n+2} under aeval into (2cosθ)·(2cos((n+1)θ))−2cos(nθ), then rewrites (n+2)θ=(n+1)θ+θ and nθ=(n+1)θ−θ and applies Real.cos_add and Real.cos_sub, reducing the goal to a ring identity — the cosine product-to-sum formula."
+    },
+    {
+      "id": "sec-integral",
+      "title": "Algebraic-Integer Core: the Explicit Monic Witness",
+      "startLine": 130,
+      "endLine": 161,
+      "summary": "isIntegral_two_mul_cos assembles the witness C(j+1) − Polynomial.C z where z=±2 is chosen by parity of k so that (z:ℝ)=2cos((j+1)θ). Monicity follows from degree_C_le against the degree-(j+1) leading term; the root condition follows from the evaluation identity after rewriting eval₂ as aeval. isIntegral_two_mul_cos_rat restates it in the θ=(m/n)·π form the parent cited."
+    },
+    {
+      "id": "sec-example",
+      "title": "Sanity Example: 2cos(π/5) is an Algebraic Integer",
+      "startLine": 163,
+      "endLine": 169,
+      "summary": "Specializes the rational-multiple form to θ=π/5, exhibiting 2cos(π/5) — the golden ratio (1+√5)/2 — as an algebraic integer via C_5."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry **niven-theorem-oq-01**'s open question: replace its delegated Mathlib black box `Real.isIntegral_two_mul_cos_rat_mul_pi` (proved internally via roots of unity) with the **explicit classical mechanism** — the Vieta–Lucas monic recurrence — built entirely from scratch.

## What's proved

- **`C : ℕ → ℤ[X]`** — the Vieta–Lucas polynomials `C₀ = 2`, `C₁ = X`, `C_{n+2} = X·C_{n+1} − C_n` (monic normalization of the Chebyshev polynomials of the first kind). Sanity: `C₂ = X²−2`, `C₃ = X³−3X`.
- **`C_monic_natDegree`** — for `n ≥ 1`, `C_n` is monic of degree exactly `n`, by a single two-step induction (the non-monic constant `C₀ = 2` is handled explicitly by shifting the index to `n+1`).
- **`C_eval_two_cos`** — the fundamental identity `2·cos(nθ) = aeval(2·cos θ)(C n)`, by two-step induction. *The induction step is literally the cosine product-to-sum formula* `2cos((n+2)θ) = (2cosθ)(2cos((n+1)θ)) − 2cos(nθ)`, discharged by `Real.cos_add`/`Real.cos_sub` + `ring`.
- **`isIntegral_two_mul_cos`** — the explicit-witness replacement: if `n·θ = k·π` (`n ≥ 1`), then `2·cos θ` is a root of the monic integer polynomial `C n − 2cos(nθ)` (with `2cos(nθ) = ±2 ∈ ℤ`), hence `IsIntegral ℤ (2·cos θ)`.
- **`isIntegral_two_mul_cos_rat`** — the familiar `θ = (m/n)·π` form the parent cited; plus a `2·cos(π/5)` example (the golden ratio).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.NivenTheoremOQ01OQ02` → **`✔ [3058/3058] Built`**, build completed successfully.
- **0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions, no `native_decide`.** Genuinely verified. 9 theorems, 1 definition, 169 lines.
- No appeal to Mathlib's Niven lemma or to `Polynomial.Chebyshev` — the whole argument (monic recurrence + cosine addition formula + ℤ integrally closed in ℚ) is elementary and self-contained.

## Gallery

Adds `src/data/proofs/niven-theorem-oq-01-oq-02/{meta.json,annotations.json}` with full overview, key insights, section map, cross-references to the parent (`niven-theorem-oq-01`) and sibling (`nth-root-irrational-oq-01-oq-01`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)