### PR TITLE
research(seeker): replenish pool with 7 diverse OQ children (verified 0-axiom parents)

### DIFF
--- a/research/problems/fibonacci-identities-oq-07/problem.md
+++ b/research/problems/fibonacci-identities-oq-07/problem.md
@@ -1,0 +1,139 @@
+# Problem: Fibonacci Divisibility Characterization F_m ∣ F_n ⟺ m ∣ n
+
+**Slug**: fibonacci-identities-oq-07
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: fibonacci-identities
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{For } m \ge 3:\qquad F_m \mid F_n \iff m \mid n.
+$$
+
+with the corollary that if $F_n$ is prime then $n = 4$ or $n$ is prime.
+
+### Plain Language
+
+Mathlib proves the *forward* divisibility `Nat.fib_dvd : m ∣ n → fib m ∣ fib n`, and the
+beautiful gcd identity `Nat.fib_gcd : fib (gcd m n) = gcd (fib m) (fib n)`. It does **not**
+package the *converse*, so it lacks the full **biconditional** `F_m ∣ F_n ⟺ m ∣ n`. This
+child supplies the converse and assembles the clean iff (for indices `m ≥ 3`, which avoids
+the degenerate `F_1 = F_2 = 1`), then derives the classic corollary that Fibonacci primes
+sit at prime indices (or the exceptional index `4`, where `F_4 = 3`).
+
+### Why This Matters
+
+The converse is the mathematically interesting half — it says Fibonacci divisibility *sees*
+index divisibility exactly. The proof is a short, elegant reduction through `fib_gcd`:
+`F_m ∣ F_n ⟹ gcd(F_m, F_n) = F_m ⟹ F_{gcd(m,n)} = F_m ⟹ gcd(m,n) = m` (using strict
+monotonicity of `fib` on `[2,∞)`), i.e. `m ∣ n`. It showcases how a single gcd identity
+plus monotonicity yields a divisibility characterization.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `fibonacci-identities` is verified (0-axiom).
+- Mathlib: `Nat.fib_gcd (m n) : fib (gcd m n) = gcd (fib m) (fib n)`,
+  `Nat.fib_dvd (m n) (h : m ∣ n) : fib m ∣ fib n`,
+  `Nat.fib_strictMonoOn : StrictMonoOn fib (Set.Ici 2)`,
+  `Nat.fib_lt_fib (hm : 2 ≤ m) : fib m < fib n ↔ m < n`,
+  `Nat.fib_coprime_fib_succ`.
+
+### What's Still Open
+
+- The biconditional and its corollary below (currently `sorry`). Mathlib has only the
+  forward direction `Nat.fib_dvd`.
+
+### Our Goal
+
+Prove the sketch below as a self-contained verified (0-axiom) child. Category:
+**characterization / completion**.
+
+## Target Lean Sketch
+
+```lean
+open Nat
+
+/-- Fibonacci divisibility mirrors index divisibility (for indices `≥ 3`). -/
+theorem fib_dvd_iff {m n : ℕ} (hm : 3 ≤ m) : fib m ∣ fib n ↔ m ∣ n := by
+  constructor
+  · intro h
+    -- fib m ∣ fib n  ⟹  gcd (fib m) (fib n) = fib m
+    -- rewrite with `Nat.fib_gcd`:  fib (gcd m n) = fib m
+    -- gcd m n ∣ m and (m ≥ 3) so both indices are in `Set.Ici 2`;
+    -- `fib_strictMonoOn` injectivity forces gcd m n = m, i.e. m ∣ n.
+    sorry
+  · intro h
+    exact fib_dvd m n h
+
+/-- Fibonacci primes occur at index 4 or at prime indices. -/
+theorem index_prime_of_fib_prime {n : ℕ} (hn : (fib n).Prime) : n = 4 ∨ n.Prime := by
+  sorry
+  -- If n is composite with a proper divisor d (2 ≤ d < n), then fib d ∣ fib n with
+  -- 1 < fib d < fib n, contradicting primality — except the boundary case n = 4.
+```
+
+Add worked `example`s: `F_6 = 8`, `F_3 = 2 ∣ 8` and `3 ∣ 6`; `F_5 = 5` prime, `5` prime;
+`F_4 = 3` prime, index `4` composite (the lone exception); `F_7 = 13` prime, `7` prime.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `fibonacci-identities` | Parent: Fibonacci identities | recurrences, induction |
+| `fibonacci-identities-oq-02` | Sibling: divisibility/gcd threads | number theory |
+| `gcd-algorithm` | gcd machinery underlying `fib_gcd` | Euclidean algorithm |
+
+## Tractability Assessment
+
+**Difficulty**: Low-Medium
+
+**Significance**: 6/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: The converse is a three-line chain: `dvd → gcd_eq → fib_gcd rewrite →
+monotone injectivity`. The only care needed is the small-index boundary (`m ≥ 3`) and the
+`n = 4` exception in the corollary. All primitives (`fib_gcd`, `fib_strictMonoOn`,
+`fib_dvd`) are in Mathlib.
+
+### Suggested First Steps
+
+1. Prove the converse: from `fib m ∣ fib n` get `Nat.gcd (fib m) (fib n) = fib m`
+   (`Nat.gcd_eq_left`), rewrite via `Nat.fib_gcd`, then apply injectivity of
+   `fib_strictMonoOn` on `Set.Ici 2` to conclude `gcd m n = m`.
+2. Combine with `Nat.fib_dvd` for the reverse to close `fib_dvd_iff`.
+3. Derive `index_prime_of_fib_prime` by contradiction on a proper divisor of `n`, handling
+   `n = 4` separately; add `decide` worked examples.
+
+## References
+
+### Mathlib
+
+- `Nat.fib_gcd` — Data/Nat/Fib/Basic.lean
+- `Nat.fib_dvd` — Data/Nat/Fib/Basic.lean
+- `Nat.fib_strictMonoOn`, `Nat.fib_lt_fib` — Data/Nat/Fib/Basic.lean
+
+### Literature
+
+- The identity `gcd(F_m, F_n) = F_{gcd(m,n)}` and its divisibility corollary are classical
+  (Lucas). The Fibonacci-prime index result is a standard consequence.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - fibonacci
+  - divisibility
+  - integer-sequences
+related_proofs:
+  - fibonacci-identities
+  - gcd-algorithm
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/intermediate-value-theorem-oq-04/problem.md
+++ b/research/problems/intermediate-value-theorem-oq-04/problem.md
@@ -1,0 +1,133 @@
+# Problem: Bolzano — Every Odd-Degree Real Polynomial Has a Real Root
+
+**Slug**: intermediate-value-theorem-oq-04
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: intermediate-value-theorem
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+p \in \mathbb{R}[X],\ \deg p \text{ odd} \implies \exists x \in \mathbb{R},\ p(x) = 0.
+$$
+
+### Plain Language
+
+The parent `intermediate-value-theorem` proves the IVT for continuous real functions. Its
+most famous corollary is **Bolzano's theorem**: every real polynomial of *odd* degree has a
+real root. The reason is that an odd-degree polynomial takes arbitrarily large positive and
+arbitrarily large negative values (its two "ends" point opposite ways), so it must cross
+zero. This child formalizes that corollary end-to-end.
+
+### Why This Matters
+
+This is the canonical application of the IVT to algebra and the elementary reason `ℝ` is not
+algebraically closed only "by one dimension" (odd-degree polynomials always factor off a real
+root). Mathlib has the IVT (`intermediate_value_Icc`), polynomial continuity, and the precise
+end-behavior lemmas (`tendsto_atTop_of_leadingCoeff_nonneg`,
+`tendsto_atBot_of_leadingCoeff_nonpos`), but there is **no named lemma** assembling them into
+"odd degree ⟹ real root." The proof is a clean, instructive assembly.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `intermediate-value-theorem` is verified (0-axiom).
+- Mathlib: `intermediate_value_Icc (hab : a ≤ b) (hf : ContinuousOn f (Set.Icc a b)) :
+  Set.Icc (f a) (f b) ⊆ f '' Set.Icc a b`;
+  `Polynomial.continuous`;
+  `Polynomial.tendsto_atTop_of_leadingCoeff_nonneg (hdeg : 0 < P.degree) (0 ≤ leadingCoeff)`;
+  `Polynomial.tendsto_atBot_of_leadingCoeff_nonpos (hdeg : 0 < P.degree) (leadingCoeff ≤ 0)`.
+
+### What's Still Open
+
+- The target theorem below (currently `sorry`). No Mathlib lemma states "odd real degree ⟹
+  a real root exists."
+
+### Our Goal
+
+Prove the sketch below as a self-contained verified (0-axiom) child. Category:
+**application / corollary of IVT**.
+
+## Target Lean Sketch
+
+```lean
+open Polynomial Filter Topology
+
+/-- Bolzano: an odd-degree real polynomial has a real root. -/
+theorem exists_root_of_odd_natDegree (p : ℝ[X]) (hodd : Odd p.natDegree) :
+    ∃ x : ℝ, p.eval x = 0 := by
+  sorry
+  -- WLOG `0 < p.leadingCoeff` (else replace p by -p; roots are the same).
+  -- `0 < p.degree` since odd natDegree ⟹ natDegree ≥ 1.
+  -- As x → +∞, `eval x p → +∞` (tendsto_atTop_of_leadingCoeff_nonneg) ⟹ pick b with p b > 0.
+  -- As x → -∞, `eval x p → -∞` (odd degree flips the sign; tendsto_atBot_of_leadingCoeff_nonpos
+  --   applied to `p.comp (-X)`, whose leadingCoeff is `-p.leadingCoeff`) ⟹ pick a < b with p a < 0.
+  -- `Polynomial.continuous p` is continuous on [a,b]; `intermediate_value_Icc` puts 0 ∈ image,
+  --   giving `∃ x ∈ Icc a b, p.eval x = 0`.
+```
+
+Add worked `example`s: `p = X^3 - X` (roots `-1,0,1`); `p = X^3 + X + 1` (one real root, no
+rational one); confirm an *even*-degree counterexample to the hypothesis (`X^2 + 1` has no
+real root) to motivate the odd-degree condition.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `intermediate-value-theorem` | Parent: IVT | continuity, connectedness |
+| `fundamental-theorem-algebra` | Complex roots exist for all degrees | complex analysis |
+| `solution-of-cubic` | Real cubics always have a real root | Cardano, algebra |
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Significance**: 7/10  |  **Tractability**: 7/10  |  **Tier**: B
+
+**Justification**: All ingredients are in Mathlib; the work is the bookkeeping of (i) the
+sign-normalization WLOG, (ii) extracting a positive and a negative value from the two
+end-behavior `Tendsto` facts (`Filter.eventually` + `Filter.Eventually.exists`), and (iii)
+one `intermediate_value_Icc` application. The `p.comp (-X)` leading-coefficient computation
+for the `atBot` end is the main fiddly step.
+
+### Suggested First Steps
+
+1. Reduce to `0 < p.leadingCoeff` and note `0 < p.degree` from `Odd p.natDegree`.
+2. From `tendsto_atTop_of_leadingCoeff_nonneg`, extract `b` with `0 < p.eval b`; from the
+   `atBot` end (odd-degree sign flip), extract `a < b` with `p.eval a < 0`.
+3. Apply `intermediate_value_Icc` (with `Polynomial.continuous`) to land `0` in the image.
+
+## References
+
+### Mathlib
+
+- `intermediate_value_Icc` — Topology/Order/IntermediateValue.lean
+- `Polynomial.continuous` — Topology/Algebra/Polynomial.lean
+- `Polynomial.tendsto_atTop_of_leadingCoeff_nonneg`,
+  `Polynomial.tendsto_atBot_of_leadingCoeff_nonpos` — Analysis/Polynomial/Basic.lean
+
+### Literature
+
+- Bolzano (1817); the odd-degree real-root theorem is the standard first corollary of the
+  intermediate value theorem in every analysis text.
+
+## Metadata
+
+```yaml
+tags:
+  - real-analysis
+  - intermediate-value-theorem
+  - polynomials
+  - bolzano
+related_proofs:
+  - intermediate-value-theorem
+  - fundamental-theorem-algebra
+  - solution-of-cubic
+difficulty: medium
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/markov-equation-oq-06/problem.md
+++ b/research/problems/markov-equation-oq-06/problem.md
@@ -1,0 +1,129 @@
+# Problem: Vieta Jumping on the Markov Equation Generates New Solutions
+
+**Slug**: markov-equation-oq-06
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: markov-equation
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+a^2 + b^2 + c^2 = 3abc \implies a^2 + b^2 + (3ab - c)^2 = 3ab\,(3ab - c).
+$$
+
+That is, the **Vieta jump** `c ↦ 3ab − c` maps Markov triples to Markov triples; the two
+values `c` and `c' = 3ab − c` are the two roots of `x² − 3ab·x + (a² + b²) = 0`, so
+`c + c' = 3ab` and `c·c' = a² + b²`.
+
+### Plain Language
+
+The Markov equation `a² + b² + c² = 3abc` is the seed of *Vieta jumping*, the technique that
+generated the whole "Markov tree" of solutions and famously appears in olympiad number
+theory. This child formalizes the fundamental step: **fixing two coordinates and replacing
+the third by its Vieta conjugate keeps you on the Markov surface.** From `(1,1,1)` this
+single move already reaches `(1,1,2)`, then `(1,2,5)`, `(2,5,29)`, … — the entire tree of
+Markov numbers.
+
+### Why This Matters
+
+Vieta jumping is a landmark proof technique with no formal counterpart in Mathlib — there is
+**no Markov-equation development at all**. The core jump is a pure polynomial identity
+(provable by `linear_combination` off the hypothesis), so it is fully verifiable and
+0-axiom, yet it opens a genuinely rich thread (the branching structure, positivity/descent,
+unicity conjecture) for later children. This is a high-leverage, low-cost seed.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `markov-equation` is verified (0-axiom).
+- Mathlib has **no** Markov-equation or Vieta-jumping API (confirmed by source search); the
+  jump is proved by `ring`/`linear_combination` only.
+
+### What's Still Open
+
+- The Vieta-jump theorems below (currently `sorry`), and the observation that the jump on a
+  positive triple stays in the positive integers (`c' = (a²+b²)/c > 0`).
+
+### Our Goal
+
+Prove the sketch below as a self-contained verified (0-axiom) child. Category:
+**technique / generative identity**.
+
+## Target Lean Sketch
+
+```lean
+/-- The Vieta jump `c ↦ 3ab - c` preserves the Markov equation. -/
+theorem markov_vieta_jump (a b c : ℤ) (h : a ^ 2 + b ^ 2 + c ^ 2 = 3 * a * b * c) :
+    a ^ 2 + b ^ 2 + (3 * a * b - c) ^ 2 = 3 * a * b * (3 * a * b - c) := by
+  linear_combination h
+  -- Key identity: (a² + b² + c'² - 3ab·c') - (a² + b² + c² - 3ab·c) = 0 for c' = 3ab - c,
+  -- so the new equation holds iff the old one does.
+
+/-- Vieta's relations for the two roots `c`, `c' = 3ab - c` of `x² - 3ab·x + (a²+b²)`. -/
+theorem markov_roots_sum_prod (a b c : ℤ) (h : a ^ 2 + b ^ 2 + c ^ 2 = 3 * a * b * c) :
+    c + (3 * a * b - c) = 3 * a * b ∧ c * (3 * a * b - c) = a ^ 2 + b ^ 2 := by
+  refine ⟨by ring, ?_⟩
+  linear_combination h
+```
+
+Add worked `example`s tracing the tree: `(1,1,1)` (`3 = 3`), jump `c` → `(1,1,2)` (`6 = 6`),
+jump `b` on `(1,1,2)` → `(1,5,2)` i.e. the triple `(1,2,5)` (`30 = 30`), and one more step to
+`(2,5,29)`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `markov-equation` | Parent: the Markov equation | Diophantine analysis |
+| `vietas-formulas` | Sum/product-of-roots identity used by the jump | polynomial roots |
+| `pell-equation` | Recurrence-generated solution families | Diophantine equations |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 7/10  |  **Tractability**: 9/10  |  **Tier**: B
+
+**Justification**: The jump is a single `linear_combination h`; the Vieta relations are `ring`
++ `linear_combination`. It is a genuine Mathlib gap (no Markov content) with an unambiguous
+0-axiom proof, and it seeds a much larger structural thread (positivity, descent, the tree).
+
+### Suggested First Steps
+
+1. Prove `markov_vieta_jump` with `linear_combination h` (verify the coefficient is `1`; if
+   `ring_nf` leaves a residual, use `nlinarith [h]`).
+2. Prove `markov_roots_sum_prod` (sum by `ring`, product by `linear_combination h`).
+3. Add the tree-tracing `example`s from `(1,1,1)` outward via `decide`/`norm_num`.
+
+## References
+
+### Mathlib
+
+- No Markov-equation API exists; proofs use `linear_combination`, `ring`, `nlinarith`.
+- `Polynomial.Splits.nextCoeff_eq_neg_sum_roots_of_monic` (for the conceptual Vieta framing).
+
+### Literature
+
+- A. A. Markov (1879–1880) on the minima of binary quadratic forms; Vieta jumping and the
+  Markov tree of solutions. See also the Markov uniqueness conjecture.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - markov-equation
+  - vieta-jumping
+  - diophantine-equations
+related_proofs:
+  - markov-equation
+  - vietas-formulas
+  - pell-equation
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/prob-method-expectation-oq-05/problem.md
+++ b/research/problems/prob-method-expectation-oq-05/problem.md
@@ -1,0 +1,140 @@
+# Problem: The First-Moment Principle — Some Outcome Meets the Average
+
+**Slug**: prob-method-expectation-oq-05
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: prob-method-expectation
+
+## Problem Statement
+
+### Formal Statement
+
+For a finite nonempty index set `s` and `f : ι → ℝ`,
+
+$$
+\exists\, i \in s,\ \frac{1}{|s|}\sum_{j \in s} f(j) \le f(i)
+\qquad\text{and}\qquad
+\exists\, j \in s,\ f(j) \le \frac{1}{|s|}\sum_{j \in s} f(j).
+$$
+
+Equivalently (integral form): if `X` is integrable, then `∃ ω, X ω ≥ 𝔼[X]` and
+`∃ ω, X ω ≤ 𝔼[X]`.
+
+### Plain Language
+
+The parent `prob-method-expectation` develops linearity of expectation and its use in the
+probabilistic method. The **first-moment principle** is the engine underneath: *some outcome
+is at least as good as the average, and some outcome is at most the average.* This is what
+lets a probabilistic argument conclude "an object with property P exists" from "the expected
+number of P-objects is positive." This child states and proves the principle in both the
+finite-average and the integral (expectation) forms.
+
+### Why This Matters
+
+This is the single most-used deduction in the probabilistic method, yet it is usually left
+implicit. Mathlib has the finite building blocks (`Finset.exists_le_of_sum_le`,
+`Finset.card_nsmul_le_sum`) and the measure-theoretic pair (`MeasureTheory.exists_le_integral`,
+`exists_integral_le`), but not a clean, citable "∃ outcome ≥ mean" statement. This child packages
+it as a reusable lemma with both faces.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `prob-method-expectation` is verified (0-axiom).
+- Mathlib: `Finset.exists_le_of_sum_le (hs : s.Nonempty) (h : ∑ i ∈ s, f i ≤ ∑ i ∈ s, g i) :
+  ∃ i ∈ s, f i ≤ g i`; `Finset.card_nsmul_le_sum (h : ∀ x ∈ s, a ≤ f x) : #s • a ≤ ∑ i ∈ s, f i`;
+  `MeasureTheory.exists_le_integral (hf : Integrable f μ) : ∃ x, f x ≤ ∫ a, f a ∂μ`;
+  `MeasureTheory.exists_integral_le`.
+
+### What's Still Open
+
+- The packaged first-moment statements below (currently `sorry`). No single Mathlib lemma
+  states "∃ element ≥ average."
+
+### Our Goal
+
+Prove the sketch below as a self-contained verified (0-axiom) child. Category:
+**principle / completion**.
+
+## Target Lean Sketch
+
+```lean
+open Finset
+
+/-- Some element attains at least the average value (finite form). -/
+theorem exists_ge_average {ι : Type*} {s : Finset ι} (hs : s.Nonempty) (f : ι → ℝ) :
+    ∃ i ∈ s, (∑ j ∈ s, f j) ≤ s.card • f i := by
+  -- Apply `exists_le_of_sum_le` with `g := fun _ => (∑ j ∈ s, f j)` scaled appropriately,
+  -- or: by_contra ⟹ f i < average for all i ⟹ ∑ f < #s • average = ∑ f (card_nsmul_le_sum).
+  sorry
+
+/-- Dual: some element is at most the average. -/
+theorem exists_le_average {ι : Type*} {s : Finset ι} (hs : s.Nonempty) (f : ι → ℝ) :
+    ∃ i ∈ s, s.card • f i ≤ (∑ j ∈ s, f j) := by
+  sorry
+
+/-- Expectation form (probabilistic method): an outcome beats the mean. -/
+theorem exists_ge_expectation {α : Type*} {m : MeasurableSpace α} {μ : MeasureTheory.Measure α}
+    {X : α → ℝ} (hX : MeasureTheory.Integrable X μ) : ∃ ω, ∫ a, X a ∂μ ≤ X ω := by
+  exact MeasureTheory.exists_le_integral hX
+```
+
+Add worked `example`s: a finite `f` on `{0,1,2}` with values `1,4,7` — the average is `4`
+and index `2` beats it; a Bernoulli-style random variable whose positive expectation forces a
+successful outcome.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `prob-method-expectation` | Parent: linearity of expectation | probabilistic method |
+| `prob-method-first-moment` (if present) | First-moment method applications | expectation bounds |
+| `randomized-maxcut` | Uses "≥ expectation" existence | probabilistic method |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 6/10  |  **Tractability**: 9/10  |  **Tier**: B
+
+**Justification**: The finite forms are one `by_contra` + `card_nsmul_le_sum`, or a direct
+`exists_le_of_sum_le` with a constant comparison function. The expectation form is a direct
+application of `MeasureTheory.exists_le_integral`. No new machinery.
+
+### Suggested First Steps
+
+1. Prove `exists_ge_average` via `Finset.exists_le_of_sum_le` with `g := const (∑ f)` and
+   `f := fun i => s.card • f i`, using `Finset.sum_const` to match totals.
+2. Prove the dual by swapping the comparison direction.
+3. Discharge the expectation form directly from `MeasureTheory.exists_le_integral`; add the
+   worked finite and Bernoulli examples.
+
+## References
+
+### Mathlib
+
+- `Finset.exists_le_of_sum_le`, `Finset.exists_lt_of_sum_lt` — Algebra/Order/BigOperators/Group/Finset.lean
+- `Finset.card_nsmul_le_sum` — Algebra/Order/BigOperators/Group/Finset.lean
+- `MeasureTheory.exists_le_integral`, `MeasureTheory.exists_integral_le` — MeasureTheory/Integral/Average.lean
+
+### Literature
+
+- Alon & Spencer, *The Probabilistic Method* — the first-moment / averaging principle.
+
+## Metadata
+
+```yaml
+tags:
+  - probability
+  - probabilistic-method
+  - expectation
+  - averaging
+related_proofs:
+  - prob-method-expectation
+  - randomized-maxcut
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/triangle-inequality-oq-06/problem.md
+++ b/research/problems/triangle-inequality-oq-06/problem.md
@@ -1,0 +1,142 @@
+# Problem: The Reverse Triangle Inequality Family and 1-Lipschitz Distance
+
+**Slug**: triangle-inequality-oq-06
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: triangle-inequality
+
+## Problem Statement
+
+### Formal Statement
+
+In a pseudometric space and a seminormed group:
+
+$$
+|\,d(x,z) - d(y,z)\,| \le d(x,y),\qquad
+|\,d(x,y) - d(x',y')\,| \le d(x,x') + d(y,y'),\qquad
+\big|\,\|a\| - \|b\|\,\big| \le \|a - b\|,
+$$
+
+and the distance function is `1`-Lipschitz in each argument.
+
+### Plain Language
+
+The parent `triangle-inequality` proves the forward inequality `d(x,z) ≤ d(x,y) + d(y,z)`.
+This child collects its *reverse* companions into one coherent verified narrative: the
+**reverse (second) triangle inequality** (distance changes by at most the step you take), its
+**quadrilateral** strengthening (moving both endpoints), the **norm** version, and the
+consequence that `d(x, ·)` is `1`-Lipschitz — hence continuous. Together these are the tools
+that make metric geometry "stable under small perturbations."
+
+### Why This Matters
+
+The reverse inequalities are used constantly (continuity of the metric, well-definedness of
+limits, stability estimates), but they are rarely presented as a unit. Mathlib has each piece
+(`abs_dist_sub_le`, `dist_dist_dist_le`, `abs_norm_sub_norm_le`, `LipschitzWith.dist_right`),
+so the value here is a curated, cross-referenced gallery entry that states the family, proves
+the quadrilateral form as the headline, and derives continuity of the metric as a corollary.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `triangle-inequality` is verified (0-axiom).
+- Mathlib: `abs_dist_sub_le (x y z) : |dist x z - dist y z| ≤ dist x y`;
+  `dist_dist_dist_le (x y x' y') : dist (dist x y) (dist x' y') ≤ dist x x' + dist y y'`;
+  `abs_norm_sub_norm_le (a b) : |‖a‖ - ‖b‖| ≤ ‖a - b‖`;
+  `norm_sub_norm_le`;
+  `LipschitzWith.dist_right (x) : LipschitzWith 1 (dist x)`;
+  `LipschitzWith.dist_left`.
+
+### What's Still Open
+
+- The packaged family + the metric-continuity corollary below (currently `sorry` where a
+  short assembly is needed; the atomic inequalities discharge by the cited lemmas).
+
+### Our Goal
+
+Prove the sketch below as a self-contained verified (0-axiom) child. Category:
+**restatement / curated bundle with corollary**.
+
+## Target Lean Sketch
+
+```lean
+variable {α : Type*} [PseudoMetricSpace α]
+
+/-- Reverse triangle inequality. -/
+theorem reverse_triangle (x y z : α) : |dist x z - dist y z| ≤ dist x y :=
+  abs_dist_sub_le x y z
+
+/-- Quadrilateral reverse inequality (move both endpoints). -/
+theorem reverse_triangle_quad (x y x' y' : α) :
+    |dist x y - dist x' y'| ≤ dist x x' + dist y y' := by
+  -- `dist_dist_dist_le` gives `dist (dist x y) (dist x' y') ≤ dist x x' + dist y y'`,
+  -- and on ℝ `dist a b = |a - b|`.
+  simpa [Real.dist_eq] using dist_dist_dist_le x y x' y'
+
+/-- Norm reverse triangle inequality. -/
+theorem reverse_triangle_norm {E : Type*} [SeminormedAddGroup E] (a b : E) :
+    |‖a‖ - ‖b‖| ≤ ‖a - b‖ := abs_norm_sub_norm_le a b
+
+/-- The metric is 1-Lipschitz, hence continuous, in its right argument. -/
+theorem dist_lipschitz (x : α) : LipschitzWith 1 (dist x) := LipschitzWith.dist_right x
+
+example (x : α) : Continuous (dist x) := (dist_lipschitz x).continuous
+```
+
+Add worked `example`s in `ℝ` (`|(|x| - |y|)| ≤ |x - y|`) and a two-point perturbation showing
+the quadrilateral bound is tight.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `triangle-inequality` | Parent: forward triangle inequality | metric spaces |
+| `cauchy-schwarz` | Underlies the norm triangle inequality | inner products |
+| `minkowski-theorem` | `L^p` triangle inequality context | normed spaces |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 5/10  |  **Tractability**: 9/10  |  **Tier**: B
+
+**Justification**: The atomic inequalities are direct Mathlib lemmas; the only assembly is
+the quadrilateral form (`dist_dist_dist_le` + `Real.dist_eq`) and the continuity corollary
+(`LipschitzWith.continuous`). A clean, fully verifiable bundle.
+
+### Suggested First Steps
+
+1. Restate `abs_dist_sub_le` and `abs_norm_sub_norm_le` as the reverse forms.
+2. Derive the quadrilateral inequality from `dist_dist_dist_le` via `Real.dist_eq`.
+3. Package `LipschitzWith.dist_right` and derive `Continuous (dist x)`; add ℝ examples.
+
+## References
+
+### Mathlib
+
+- `abs_dist_sub_le`, `dist_dist_dist_le` — Topology/MetricSpace/Pseudo/Defs.lean
+- `abs_norm_sub_norm_le`, `norm_sub_norm_le` — Analysis/Normed/Group/Basic.lean
+- `LipschitzWith.dist_right`, `LipschitzWith.dist_left` — Topology/MetricSpace/Lipschitz.lean
+
+### Literature
+
+- The reverse (second) triangle inequality; standard in any metric-space / normed-space text.
+
+## Metadata
+
+```yaml
+tags:
+  - metric-spaces
+  - triangle-inequality
+  - lipschitz
+  - normed-groups
+related_proofs:
+  - triangle-inequality
+  - cauchy-schwarz
+  - minkowski-theorem
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/vietas-formulas-oq-05/problem.md
+++ b/research/problems/vietas-formulas-oq-05/problem.md
@@ -1,0 +1,139 @@
+# Problem: Vieta — Sum and Product of Roots of a Monic Split Polynomial
+
+**Slug**: vietas-formulas-oq-05
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: vietas-formulas
+
+## Problem Statement
+
+### Formal Statement
+
+For a monic polynomial `p` over a field `K` that **splits** over `K`,
+
+$$
+\prod_{r \in \text{roots}(p)} r = (-1)^{\deg p}\, p_0,
+\qquad
+\sum_{r \in \text{roots}(p)} r = -\,[\text{next coefficient of } p],
+$$
+
+where `p_0 = p.coeff 0` and the *next coefficient* is the coefficient of `X^{deg p - 1}`.
+
+### Plain Language
+
+The parent `vietas-formulas` states Vieta's relations. This child pins down the two
+headline cases as clean, reusable lemmas over `Polynomial.roots`: the **product of all roots
+(with multiplicity)** equals `(-1)^n` times the constant term, and the **sum of all roots**
+equals the negative of the `X^{n-1}` coefficient — for any monic split polynomial, in one
+statement, with a fully worked cubic.
+
+### Why This Matters
+
+Mathlib's current API states these through `Polynomial.Splits.coeff_zero_eq_prod_roots_of_monic`
+and `Polynomial.Splits.nextCoeff_eq_neg_sum_roots_of_monic` (the older
+`prod_roots_eq_coeff_zero_of_monic_of_splits` spellings are now deprecated). This child gives
+the *root-side* orientation (`roots.prod = …`, `roots.sum = …`) that matches how Vieta is
+taught and used, and demonstrates it on a concrete cubic — a small but genuinely useful
+curated packaging on top of a recently-renamed API.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `vietas-formulas` is verified (0-axiom).
+- Mathlib (current, non-deprecated):
+  `Polynomial.Splits.coeff_zero_eq_prod_roots_of_monic (hf : Splits f) (hm : Monic f) :
+   coeff f 0 = (-1) ^ f.natDegree * f.roots.prod`;
+  `Polynomial.Splits.nextCoeff_eq_neg_sum_roots_of_monic (hf : Splits f) (hm : Monic f) :
+   f.nextCoeff = -f.roots.sum`;
+  `Polynomial.Splits.eq_prod_roots_of_monic`.
+
+### What's Still Open
+
+- The root-oriented restatements and the worked cubic below (currently `sorry`).
+
+### Our Goal
+
+Prove the sketch below as a self-contained verified (0-axiom) child. Category:
+**restatement / worked corollary**.
+
+## Target Lean Sketch
+
+```lean
+open Polynomial
+
+variable {K : Type*} [Field K] {p : K[X]}
+
+/-- Product of the roots of a monic split polynomial. -/
+theorem prod_roots_of_monic (hm : p.Monic) (hsp : p.Splits (RingHom.id K)) :
+    p.roots.prod = (-1) ^ p.natDegree * p.coeff 0 := by
+  -- from `Splits.coeff_zero_eq_prod_roots_of_monic`: coeff 0 = (-1)^n * roots.prod;
+  -- multiply both sides by (-1)^n and use `(-1)^n * (-1)^n = 1`.
+  sorry
+
+/-- Sum of the roots of a monic split polynomial. -/
+theorem sum_roots_of_monic (hm : p.Monic) (hsp : p.Splits (RingHom.id K)) :
+    p.roots.sum = - p.nextCoeff := by
+  -- immediate from `Splits.nextCoeff_eq_neg_sum_roots_of_monic` + `neg_neg`.
+  sorry
+```
+
+Add a fully worked `example` over `ℝ` or `ℂ`: `p = (X - 1) * (X - 2) * (X - 3)
+= X^3 - 6 X^2 + 11 X - 6`, verifying `roots.sum = 6 = -(-6)` and
+`roots.prod = 6 = (-1)^3 * (-6)`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `vietas-formulas` | Parent: Vieta's relations | symmetric functions, roots |
+| `fundamental-theorem-algebra` | Splitting over `ℂ` guarantees roots | complex analysis |
+| `solution-of-cubic` | Concrete cubic root relations | Cardano |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 5/10  |  **Tractability**: 9/10  |  **Tier**: B
+
+**Justification**: Both statements are short rearrangements of existing (current, un-deprecated)
+Mathlib lemmas; the sign bookkeeping `(-1)^n * (-1)^n = 1` and `neg_neg` is routine. The worked
+cubic is `norm_num`/`decide`-friendly after computing `roots`.
+
+### Suggested First Steps
+
+1. Prove `sum_roots_of_monic` directly from `Splits.nextCoeff_eq_neg_sum_roots_of_monic`.
+2. Prove `prod_roots_of_monic` by isolating `roots.prod` in
+   `Splits.coeff_zero_eq_prod_roots_of_monic` (multiply by `(-1)^n`, simplify with `Even`/`pow`
+   lemmas).
+3. Build the worked cubic: compute `roots` of `(X-1)(X-2)(X-3)` and check both relations.
+
+## References
+
+### Mathlib
+
+- `Polynomial.Splits.coeff_zero_eq_prod_roots_of_monic` — Algebra/Polynomial/Factors.lean
+- `Polynomial.Splits.nextCoeff_eq_neg_sum_roots_of_monic` — Algebra/Polynomial/Factors.lean
+- `Polynomial.Splits.eq_prod_roots_of_monic` — Algebra/Polynomial/Factors.lean
+
+### Literature
+
+- Vieta's formulas relating coefficients to elementary symmetric functions of the roots.
+
+## Metadata
+
+```yaml
+tags:
+  - algebra
+  - polynomials
+  - vietas-formulas
+  - roots
+related_proofs:
+  - vietas-formulas
+  - fundamental-theorem-algebra
+  - solution-of-cubic
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```

--- a/research/problems/wilsons-theorem-oq-08/problem.md
+++ b/research/problems/wilsons-theorem-oq-08/problem.md
@@ -1,0 +1,137 @@
+# Problem: Wilson's Primality Criterion over ℕ and the Composite Factorial Congruence
+
+**Slug**: wilsons-theorem-oq-08
+**Created**: 2026-07-01
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: wilsons-theorem
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{For } n \ge 2:\quad n \text{ is prime} \iff n \mid (n-1)! + 1,
+\qquad\text{and}\qquad
+n > 4 \text{ composite} \implies n \mid (n-1)!.
+$$
+
+### Plain Language
+
+The parent entry `wilsons-theorem` proves Wilson's congruence in the ring `ZMod n`:
+`((n-1)! : ZMod n) = -1` exactly when `n` is prime. This child pulls that statement back
+to a **decision criterion stated entirely over ℕ** — `n` is prime iff `n` divides
+`(n-1)! + 1` — and proves the complementary **composite** fact that Mathlib does *not*
+package: for every composite `n > 4`, `n` already divides `(n-1)!` (so `(n-1)! ≡ 0`, not
+`-1`). Together these give a clean, self-contained primality test and a sharp contrast
+between the prime case (`≡ -1`) and the composite case (`≡ 0`).
+
+### Why This Matters
+
+Mathlib's `Nat.prime_iff_fac_equiv_neg_one` lives in `ZMod n` and says nothing about the
+composite residue. The elementary composite statement `n ∣ (n-1)!` for composite `n > 4` is
+a classic exercise (the only exception is `n = 4`, where `3! = 6 ≡ 2`), yet there is **no
+named Mathlib lemma** for it, and no ℕ-level `n ∣ (n-1)! + 1 ↔ n.Prime` criterion. This
+child fills both gaps with short reductions.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `wilsons-theorem` is verified (0-axiom).
+- Mathlib: `Nat.prime_iff_fac_equiv_neg_one (h : n ≠ 1) : Prime n ↔ ((n-1)! : ZMod n) = -1`
+  and `ZMod.wilsons_lemma [Fact p.Prime] : ((p-1)! : ZMod p) = -1`, plus
+  `Nat.prime_of_fac_equiv_neg_one`.
+
+### What's Still Open
+
+- The target theorems below (currently `sorry`). Mathlib has **no** composite factorial
+  congruence lemma and **no** ℕ-level `n ∣ (n-1)!+1` primality criterion.
+
+### Our Goal
+
+Prove the sketch below as a self-contained verified (0-axiom) child. Category:
+**characterization / completion**.
+
+## Target Lean Sketch
+
+```lean
+open Nat
+
+/-- ℕ-level Wilson primality criterion: `n` is prime iff `n ∣ (n-1)! + 1`. -/
+theorem prime_iff_dvd_factorial_succ {n : ℕ} (hn : 2 ≤ n) :
+    n.Prime ↔ n ∣ (n - 1)! + 1 := by
+  sorry
+  -- Bridge to ZMod n: `(↑((n-1)! + 1) : ZMod n) = 0 ↔ n ∣ (n-1)!+1`
+  -- (ZMod.natCast_zmod_eq_zero_iff_dvd), and `(↑((n-1)!+1)) = 0 ↔ ((n-1)! : ZMod n) = -1`
+  -- (push_cast + `eq_neg_iff_add_eq_zero`), then `Nat.prime_iff_fac_equiv_neg_one`.
+
+/-- The complementary composite congruence: a composite `n > 4` divides `(n-1)!`. -/
+theorem composite_dvd_factorial {n : ℕ} (h4 : 4 < n) (hc : ¬ n.Prime) :
+    n ∣ (n - 1)! := by
+  sorry
+  -- Write n = a * b with 1 < a ≤ b < n (n composite). If a ≠ b, both a and b are distinct
+  -- factors ≤ n-1, so a*b ∣ (n-1)! via `Nat.dvd_factorial`-style product. If a = b (n = a²),
+  -- then a and 2a are distinct and ≤ n-1 for a ≥ 3 (uses 4 < n), giving a² ∣ a*(2a) ∣ (n-1)!.
+```
+
+Add worked `example`s: `n = 5, 7, 11` prime (`n ∣ (n-1)!+1`); `n = 4` the lone exception
+(`3! = 6`, `4 ∤ 6`, `4 ∤ 7`); `n = 6, 8, 9` composite with `n ∣ (n-1)!`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `wilsons-theorem` | Parent: Wilson's congruence in `ZMod n` | finite fields, `ZMod` |
+| `wilsons-theorem-oq-04` | Sibling on Wilson variants | number theory |
+| `infinitude-primes` | Uses factorial divisibility arguments | elementary number theory |
+
+## Tractability Assessment
+
+**Difficulty**: Low-Medium
+
+**Significance**: 6/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: The forward criterion is a `ZMod`/cast reduction onto an existing iff. The
+composite congruence is a short factor-pairing argument (`Nat.dvd_factorial`, case split on
+whether `n` is a perfect square). No deep machinery.
+
+### Suggested First Steps
+
+1. Prove `prime_iff_dvd_factorial_succ` by rewriting `n ∣ (n-1)!+1` as
+   `(↑((n-1)!+1) : ZMod n) = 0`, simplifying to `((n-1)! : ZMod n) = -1`, and applying
+   `Nat.prime_iff_fac_equiv_neg_one`.
+2. For `composite_dvd_factorial`, obtain a nontrivial factorization of `n`; split on
+   `a = b` vs `a ≠ b`; use `Nat.dvd_factorial` for each distinct factor `≤ n-1`.
+3. Add the `n = 4` exception and `decide`/`norm_num` worked examples.
+
+## References
+
+### Mathlib
+
+- `Nat.prime_iff_fac_equiv_neg_one` — NumberTheory/Wilson.lean
+- `ZMod.wilsons_lemma`, `Nat.prime_of_fac_equiv_neg_one` — NumberTheory/Wilson.lean
+- `ZMod.natCast_zmod_eq_zero_iff_dvd` — Data/ZMod/Basic.lean
+- `Nat.dvd_factorial` — Data/Nat/Factorial/Basic.lean
+
+### Literature
+
+- Wilson's theorem and its converse; the composite factorial congruence with the single
+  exception `n = 4` is a standard elementary-number-theory result.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - wilsons-theorem
+  - primality
+  - factorials
+related_proofs:
+  - wilsons-theorem
+  - wilsons-theorem-oq-04
+  - infinitude-primes
+difficulty: low
+source: proof-suggestion
+created: 2026-07-01
+```


### PR DESCRIPTION
## Summary

Effective free candidate pool was **0** (nominal 57 available all had active research dirs), below the 15 threshold. This adds **7 new tractable open-question children**, one per domain, each crafted off a **verified 0-axiom classic parent**. A per-parent verification pass grepped the local mathlib checkout to confirm every cited lemma name before seeding.

Three children are **genuine Mathlib gaps**; four are curated packagings of existing API into gallery-worthy named results.

| Slug | Domain | Result | Status |
|------|--------|--------|--------|
| `wilsons-theorem-oq-08` | number theory | ℕ-level Wilson criterion `n ∣ (n-1)!+1 ↔ prime` + composite `n>4 ⇒ n ∣ (n-1)!` | **gap** |
| `fibonacci-identities-oq-07` | integer sequences | `F_m ∣ F_n ⟺ m ∣ n` (converse via `fib_gcd` + monotonicity) | **gap (converse)** |
| `intermediate-value-theorem-oq-04` | real analysis | Bolzano: odd-degree real polynomial has a real root | **gap** |
| `prob-method-expectation-oq-05` | probability | first-moment principle — some outcome meets the average (finite + integral) | curated |
| `vietas-formulas-oq-05` | polynomial algebra | sum & product of roots of a monic split polynomial | curated |
| `triangle-inequality-oq-06` | metric spaces | reverse triangle family + quadrilateral form + 1-Lipschitz distance | curated |
| `markov-equation-oq-06` | Diophantine | Vieta jumping `c ↦ 3ab−c` preserves the Markov equation; seeds the Markov tree | **gap (no Markov API)** |

Domains are fresh vs. cycles 6–9 (pell/de-moivre/lagrange/konigsberg/cramers/law-of-cosines/geometric-series, kummer/derangements/herons/fermat/schroeder-bernstein/sylow/MVT, taylor/basel/…).

## OQ-chain guardrails

All 7 slugs are depth-1 top-level children (single `-oq-NN`), no repeated indices, no sibling content duplication. Two initial picks (IVT 1-D fixed point = `exists_mem_Icc_isFixedPt_of_mapsTo`; Ptolemy inequality = `mul_dist_le_mul_dist_add_mul_dist`) were dropped after verification revealed they are already single Mathlib lemmas (trivial wrappers), and reframed/replaced with genuine gaps.

## Registration

DB insert → `sync_pool.py` → surgical append to `.lean/state/candidate-pool.json` → `validate-seeker-stubs.ts` (all 7 **PASS**) → `update-stats.sh problem-selected` ×7. Note: `prob-method-expectation-oq-03` was a completed phantom in the DB, so the probability child uses the free index `-oq-05`.

Only the 7 `problem.md` stubs are in this PR (DB and pool JSONs are gitignored/local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
