### PR TITLE
research(lagrange-theorem-oq-10): gcd refinement of Lagrange for subgroup intersections [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ10.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ10.lean
@@ -1,0 +1,91 @@
+/-
+  The Gcd Refinement of Lagrange: Subgroup Intersections (lagrange-theorem-oq-10)
+
+  This answers OQ-10 from Lagrange's Theorem: the arithmetic of the order of an
+  intersection of two subgroups.
+
+  **Open Question**: How is the order of `H ⊓ K` constrained by the orders of
+  `H` and `K`?
+
+  **Answer**: `|H ⊓ K|` divides `gcd(|H|, |K|)`. This is the sharp refinement of
+  Lagrange applied on the subgroup lattice: `H ⊓ K ≤ H` and `H ⊓ K ≤ K` give
+  `|H ⊓ K| ∣ |H|` and `|H ⊓ K| ∣ |K|` respectively, and the two divisibilities
+  combine through the universal property of the gcd.
+
+  **Consequences**:
+  * Subgroups of coprime order meet only in the identity (`H ⊓ K = ⊥`).
+  * Hence any element lying in two coprime-order subgroups is the identity.
+  * When the orders additionally multiply to `|G|`, `H` and `K` are complementary
+    (`H.IsComplement' K`): the internal direct-product situation behind
+    CRT-style splitting of finite (abelian) groups and Sylow decomposition.
+  * A concrete instance: two subgroups of distinct prime orders intersect
+    trivially.
+
+  Mathlib states only the coprime special case `Subgroup.inf_eq_bot_of_coprime`
+  and its proof passes through `Nat.eq_one_of_dvd_coprimes`; the explicit
+  gcd-divisibility statement `|H ⊓ K| ∣ gcd(|H|,|K|)` is the honest new core here,
+  from which the coprime corollary is re-derived.
+
+  Verified, 0 axioms (beyond Lean's foundational propext/Classical.choice/Quot.sound).
+-/
+import Mathlib.GroupTheory.Coset.Card
+import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.Complement
+import Mathlib.Algebra.Group.Subgroup.Finite
+import Mathlib.Tactic
+
+namespace LagrangeTheoremOQ10
+
+open Subgroup
+
+variable {G : Type*} [Group G] (H K : Subgroup G)
+
+/-! ## The gcd-divisibility core -/
+
+/-- **Core refinement of Lagrange.** The order of the intersection of two
+subgroups divides the gcd of their orders. Both `H ⊓ K ≤ H` and `H ⊓ K ≤ K`
+give a Lagrange divisibility, and `Nat.dvd_gcd` combines them. -/
+theorem card_inf_dvd_gcd :
+    Nat.card (H ⊓ K : Subgroup G) ∣ Nat.gcd (Nat.card H) (Nat.card K) :=
+  Nat.dvd_gcd (card_dvd_of_le inf_le_left) (card_dvd_of_le inf_le_right)
+
+/-! ## Coprime orders force a trivial intersection -/
+
+/-- Subgroups whose orders are coprime intersect trivially, re-derived from the
+gcd core: `|H ⊓ K|` divides `gcd(|H|,|K|) = 1`, so it equals `1`. -/
+theorem inf_eq_bot_of_coprime_card
+    (h : Nat.Coprime (Nat.card H) (Nat.card K)) : H ⊓ K = ⊥ := by
+  rw [← Subgroup.card_eq_one]
+  have hg : Nat.gcd (Nat.card H) (Nat.card K) = 1 := h
+  have hd := card_inf_dvd_gcd H K
+  rw [hg] at hd
+  exact Nat.dvd_one.mp hd
+
+/-- An element lying in two coprime-order subgroups must be the identity. -/
+theorem eq_one_of_mem_both
+    (h : Nat.Coprime (Nat.card H) (Nat.card K)) {g : G} (hH : g ∈ H) (hK : g ∈ K) :
+    g = 1 := by
+  have hmem : g ∈ H ⊓ K := Subgroup.mem_inf.mpr ⟨hH, hK⟩
+  rw [inf_eq_bot_of_coprime_card H K h] at hmem
+  exact Subgroup.mem_bot.mp hmem
+
+/-! ## The internal direct product -/
+
+/-- With coprime orders whose product is `|G|`, `H` and `K` complement each other
+in `G`: the internal direct-product situation. Wraps
+`Subgroup.isComplement'_of_coprime`. -/
+theorem isComplement'_of_coprime_card [Finite G]
+    (hmul : Nat.card H * Nat.card K = Nat.card G)
+    (hcop : Nat.Coprime (Nat.card H) (Nat.card K)) : H.IsComplement' K :=
+  Subgroup.isComplement'_of_coprime hmul hcop
+
+/-! ## Concrete instance: distinct prime orders -/
+
+/-- Two subgroups of distinct prime orders intersect trivially: the coprimality
+of `p ≠ q` feeds directly into `inf_eq_bot_of_coprime_card`. -/
+theorem inf_eq_bot_of_prime_orders {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (hH : Nat.card H = p) (hK : Nat.card K = q) : H ⊓ K = ⊥ :=
+  inf_eq_bot_of_coprime_card H K (by
+    rw [hH, hK]; exact (Nat.coprime_primes hp hq).mpr hpq)
+
+end LagrangeTheoremOQ10

--- a/src/data/proofs/lagrange-theorem-oq-10/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-10/annotations.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "ann-oq10-gcd-core",
+    "proofId": "lagrange-theorem-oq-10",
+    "range": { "startLine": 45, "endLine": 51 },
+    "type": "insight",
+    "title": "The Gcd Bound from Two Lagrange Divisibilities",
+    "content": "The core is Lagrange applied twice on the subgroup lattice. Both inf_le_left : H ⊓ K ≤ H and inf_le_right : H ⊓ K ≤ K hold, and Subgroup.card_dvd_of_le turns each containment into a divisibility |H ⊓ K| ∣ |H| and |H ⊓ K| ∣ |K|. The universal property of the gcd (Nat.dvd_gcd) merges them into a single divisibility |H ⊓ K| ∣ gcd(|H|, |K|). No coset counting beyond the parent's Lagrange is required — the bound is inherited purely from the lattice containments.",
+    "mathContext": "$H\\cap K\\le H,\\ H\\cap K\\le K \\Rightarrow |H\\cap K|\\mid |H|,\\ |H\\cap K|\\mid |K| \\Rightarrow |H\\cap K|\\mid \\gcd(|H|,|K|)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Subgroup.card_dvd_of_le",
+      "inf_le_left",
+      "inf_le_right",
+      "Nat.dvd_gcd"
+    ],
+    "prerequisites": ["Lagrange's theorem", "greatest common divisor"]
+  },
+  {
+    "id": "ann-oq10-coprime-trivial",
+    "proofId": "lagrange-theorem-oq-10",
+    "range": { "startLine": 54, "endLine": 63 },
+    "type": "insight",
+    "title": "Coprime Orders Collapse the Intersection to the Identity",
+    "content": "When gcd(|H|,|K|) = 1 the core bound reads |H ⊓ K| ∣ 1, so |H ⊓ K| = 1 and hence H ⊓ K = ⊥ (Subgroup.card_eq_one). This is the coprime independence principle: subgroups of coprime order overlap only in the identity. Mathlib reaches the same conclusion via Nat.eq_one_of_dvd_coprimes; here it is re-derived transparently from the explicit gcd-divisibility statement, exposing that coprimality is exactly the case where the gcd bound is small enough to kill the intersection.",
+    "mathContext": "$\\gcd(|H|,|K|)=1 \\Rightarrow |H\\cap K|\\mid 1 \\Rightarrow |H\\cap K|=1 \\Rightarrow H\\cap K=\\{1\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Subgroup.card_eq_one",
+      "Nat.dvd_one",
+      "Nat.Coprime"
+    ],
+    "prerequisites": ["coprimality", "trivial subgroup"]
+  },
+  {
+    "id": "ann-oq10-mem-both",
+    "proofId": "lagrange-theorem-oq-10",
+    "range": { "startLine": 64, "endLine": 71 },
+    "type": "observation",
+    "title": "A Shared Element of Coprime-Order Subgroups Is Trivial",
+    "content": "The pointwise reading of trivial intersection: if g lies in both H and K, then g ∈ H ⊓ K = ⊥ (via Subgroup.mem_inf and mem_bot), so g = 1. This is the form most often used in practice — e.g. showing that generators of coprime-order cyclic subgroups commute freely, or that a coprime-order element outside a subgroup cannot be captured by it.",
+    "mathContext": "$g\\in H,\\ g\\in K,\\ \\gcd(|H|,|K|)=1 \\Rightarrow g\\in H\\cap K=\\{1\\} \\Rightarrow g=1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Subgroup.mem_inf",
+      "Subgroup.mem_bot"
+    ],
+    "prerequisites": ["subgroup membership"]
+  },
+  {
+    "id": "ann-oq10-complement",
+    "proofId": "lagrange-theorem-oq-10",
+    "range": { "startLine": 73, "endLine": 81 },
+    "type": "insight",
+    "title": "Coprime Orders Filling |G| Give an Internal Direct Product",
+    "content": "When the coprime orders additionally multiply to |G| (and G is finite), H and K complement each other: H.IsComplement' K, meaning every element of G factors uniquely as a product from H and K. This is the internal direct-product situation and the elementary form of the coprime splitting behind CRT-style decompositions of finite abelian groups and Sylow theory. The statement wraps Mathlib's Subgroup.isComplement'_of_coprime, whose hypotheses are exactly coprimality plus the order product.",
+    "mathContext": "$\\gcd(|H|,|K|)=1$ and $|H|\\,|K|=|G| \\Rightarrow H\\,K = G$ with $H\\cap K=\\{1\\}$, i.e. $G$ is the internal direct product of $H$ and $K$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Subgroup.isComplement'_of_coprime",
+      "Subgroup.IsComplement'"
+    ],
+    "prerequisites": ["complement subgroups", "internal direct product"]
+  },
+  {
+    "id": "ann-oq10-prime-instance",
+    "proofId": "lagrange-theorem-oq-10",
+    "range": { "startLine": 82, "endLine": 91 },
+    "type": "observation",
+    "title": "Distinct Prime Orders Intersect Trivially",
+    "content": "The cleanest concrete instance: subgroups of orders p and q with p ≠ q prime intersect trivially. Distinct primes are coprime (Nat.coprime_primes), so this is an immediate specialization of inf_eq_bot_of_coprime_card. It is the fact underlying the independence of distinct Sylow subgroups and the building block of the pq-group analysis in the sibling entry.",
+    "mathContext": "$p\\neq q$ prime $\\Rightarrow \\gcd(p,q)=1$; with $|H|=p,\\ |K|=q$ this gives $H\\cap K=\\{1\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.coprime_primes",
+      "Nat.Prime"
+    ],
+    "prerequisites": ["prime numbers", "coprimality"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-10/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-10/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "lagrange-theorem-oq-10",
+  "title": "The Gcd Refinement of Lagrange: Subgroup Intersections",
+  "slug": "lagrange-theorem-oq-10",
+  "description": "The order of an intersection of two subgroups is not just constrained by each order separately — it divides their gcd. Applying Lagrange on the subgroup lattice, H ⊓ K ≤ H and H ⊓ K ≤ K give |H ⊓ K| ∣ |H| and |H ⊓ K| ∣ |K|, which combine through the universal property of the gcd to |H ⊓ K| ∣ gcd(|H|, |K|). Consequences: coprime-order subgroups intersect trivially, any element in two coprime-order subgroups is the identity, coprime orders multiplying to |G| make H and K complementary (internal direct product), and two subgroups of distinct prime orders meet only in 1.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ10.lean",
+    "tags": [
+      "group-theory",
+      "lagrange-theorem",
+      "subgroups",
+      "intersection",
+      "gcd",
+      "direct-products",
+      "coprime-order"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 91,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-verified from Mathlib (depends only on the foundational axioms propext, Classical.choice, Quot.sound).",
+    "originalContributions": [
+      "card_inf_dvd_gcd: the honest new core — |H ⊓ K| divides gcd(|H|, |K|), obtained by combining the two Lagrange divisibilities from H ⊓ K ≤ H and H ⊓ K ≤ K via Nat.dvd_gcd. Mathlib states only the coprime special case (inf_eq_bot_of_coprime), never this gcd-divisibility statement",
+      "inf_eq_bot_of_coprime_card: coprime orders force H ⊓ K = ⊥, re-derived cleanly from the gcd core (|H ⊓ K| ∣ gcd = 1) rather than from Nat.eq_one_of_dvd_coprimes",
+      "eq_one_of_mem_both: any element lying in two coprime-order subgroups equals the identity",
+      "isComplement'_of_coprime_card: coprime orders multiplying to |G| make H and K complementary — the internal direct-product situation — wrapping Subgroup.isComplement'_of_coprime",
+      "inf_eq_bot_of_prime_orders: the concrete instance — two subgroups of distinct prime orders p ≠ q intersect trivially, feeding coprimality of distinct primes into the general result"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Lagrange's theorem — that the order of a subgroup divides the order of the group — is usually stated for a single subgroup. But its most useful working corollaries come from applying it on the lattice of subgroups. The order of an intersection H ⊓ K sits below both |H| and |K|, so it divides each; the sharp consequence is that it divides their gcd. This gcd refinement is the arithmetic backbone of the internal direct-product decompositions taught in every first algebra course: coprime-order pieces overlap only in the identity, and when their orders fill out the whole group they assemble it as a product. Mathlib records the coprime endpoint (inf_eq_bot_of_coprime) directly through Nat.eq_one_of_dvd_coprimes, but leaves the underlying divisibility |H ⊓ K| ∣ gcd(|H|,|K|) unstated as a lemma.",
+    "problemStatement": "Let G be a group and H, K ≤ G subgroups. How is the order of H ⊓ K constrained by |H| and |K|? Claim: |H ⊓ K| divides gcd(|H|, |K|). Corollaries: if gcd(|H|,|K|) = 1 then H ⊓ K = ⊥; any element in both H and K is the identity; if additionally |H|·|K| = |G| (G finite) then H.IsComplement' K; and two subgroups of distinct prime orders intersect trivially.",
+    "proofStrategy": "**Core.** Both inf_le_left : H ⊓ K ≤ H and inf_le_right : H ⊓ K ≤ K hold in the subgroup lattice. Lagrange (Subgroup.card_dvd_of_le) turns each containment into a divisibility of orders: |H ⊓ K| ∣ |H| and |H ⊓ K| ∣ |K|. The universal property of the gcd (Nat.dvd_gcd) packages the two into |H ⊓ K| ∣ gcd(|H|, |K|).\n\n**Coprime corollary.** If gcd(|H|,|K|) = 1 the core gives |H ⊓ K| ∣ 1, so |H ⊓ K| = 1, i.e. H ⊓ K = ⊥ (Subgroup.card_eq_one). Membership version: g ∈ H and g ∈ K put g ∈ H ⊓ K = ⊥, so g = 1.\n\n**Complement.** Coprimality plus |H|·|K| = |G| is exactly the hypothesis of Subgroup.isComplement'_of_coprime, giving H.IsComplement' K.\n\n**Prime instance.** For distinct primes p ≠ q, Nat.coprime_primes gives Nat.Coprime p q, so subgroups of orders p and q are coprime and intersect trivially.",
+    "keyInsights": [
+      "The whole result is Lagrange applied twice on the subgroup lattice plus one fact about gcd. No coset counting beyond the parent's Lagrange is needed — the divisibility is inherited from the two containments H ⊓ K ≤ H, K.",
+      "Stating the gcd-divisibility explicitly is the value added: Mathlib jumps straight to the coprime case via Nat.eq_one_of_dvd_coprimes, so the general |H ⊓ K| ∣ gcd(|H|,|K|) is not available as a named lemma.",
+      "The coprime corollary is the seed of internal direct products and the CRT-style splitting of finite abelian groups: coprime-order subgroups are 'independent' precisely because their intersection is forced to be trivial.",
+      "Coprimality is exactly the boundary case where the gcd bound (1) is small enough to kill the intersection; when the orders share a prime the intersection may be nontrivial, so the gcd is the sharp constraint."
+    ],
+    "prerequisites": [
+      "Subgroup.card_dvd_of_le: Lagrange's theorem on the lattice — H ≤ K implies |H| divides |K| (via Nat.card)",
+      "inf_le_left, inf_le_right: the intersection lies below each subgroup",
+      "Nat.dvd_gcd: n ∣ a and n ∣ b imply n ∣ gcd(a, b) (universal property of the gcd)",
+      "Subgroup.card_eq_one: |H| = 1 if and only if H = ⊥",
+      "Subgroup.isComplement'_of_coprime: coprime orders summing (multiplying) to |G| give a complement",
+      "Nat.coprime_primes: distinct primes are coprime",
+      "Lagrange's Theorem (parent)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring explaining the gcd refinement |H ⊓ K| ∣ gcd(|H|,|K|) and its corollaries. Imports Lagrange (Coset.Card), index, and complement theory from Mathlib; opens the Subgroup namespace and fixes G, H, K."
+    },
+    {
+      "id": "gcd-core",
+      "title": "The Gcd-Divisibility Core",
+      "startLine": 43,
+      "endLine": 51,
+      "summary": "card_inf_dvd_gcd: |H ⊓ K| divides gcd(|H|, |K|). Nat.dvd_gcd combines the two Lagrange divisibilities card_dvd_of_le inf_le_left and card_dvd_of_le inf_le_right."
+    },
+    {
+      "id": "coprime-trivial",
+      "title": "Coprime Orders Force a Trivial Intersection",
+      "startLine": 52,
+      "endLine": 71,
+      "summary": "inf_eq_bot_of_coprime_card: coprime |H|, |K| give H ⊓ K = ⊥ (the core divisibility collapses |H ⊓ K| ∣ 1). eq_one_of_mem_both: a shared element of two coprime-order subgroups is the identity."
+    },
+    {
+      "id": "complement",
+      "title": "The Internal Direct Product",
+      "startLine": 72,
+      "endLine": 81,
+      "summary": "isComplement'_of_coprime_card: with G finite, coprime orders whose product is |G| make H and K complementary (H.IsComplement' K), wrapping Subgroup.isComplement'_of_coprime."
+    },
+    {
+      "id": "prime-instance",
+      "title": "Concrete Instance: Distinct Prime Orders",
+      "startLine": 82,
+      "endLine": 91,
+      "summary": "inf_eq_bot_of_prime_orders: two subgroups of distinct prime orders p ≠ q intersect trivially, via Nat.coprime_primes feeding inf_eq_bot_of_coprime_card."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Standard reference for Lagrange's theorem, internal direct products, and the coprime-order intersection principle."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "note": "Develops subgroup lattices, complements, and direct-product decompositions of finite groups."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proved the gcd refinement of Lagrange: |H ⊓ K| divides gcd(|H|, |K|) for subgroups H, K of a group G. Derived the coprime corollaries (coprime orders force H ⊓ K = ⊥; a shared element is the identity), the internal direct-product form (coprime orders multiplying to |G| give H.IsComplement' K), and the concrete distinct-prime-order instance. 91 lines, 5 theorems, 0 sorries, 0 axioms.",
+    "implications": "The gcd bound is the precise arithmetic constraint on subgroup intersections and the reason coprime-order subgroups are independent. It is the working lemma behind internal direct products, the CRT-style splitting of finite abelian groups, and the coprime-order complementarity used in Sylow decomposition. The explicit statement fills a small gap: Mathlib only records the coprime endpoint, not the underlying divisibility.",
+    "openQuestions": [
+      "Sharpen in the other direction: for which pairs (H, K) is |H ⊓ K| equal to gcd(|H|,|K|) rather than merely dividing it — e.g. when is the bound attained for subgroups of a finite abelian group?",
+      "Extend to a family H₁, …, Hₙ of pairwise-coprime-order subgroups: show they generate their internal direct product and that |⟨H₁,…,Hₙ⟩| = ∏|Hᵢ| when the orders multiply to |G|."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "extends",
+      "description": "Parent. Lagrange's theorem (|H| divides |G|) applied to H ⊓ K ≤ H and H ⊓ K ≤ K supplies the two divisibilities that combine into the gcd bound."
+    },
+    {
+      "targetId": "lagrange-theorem-oq-09",
+      "relationship": "related",
+      "description": "Sibling. Uses Lagrange's divisibility to constrain the order of the center of an order-pq group; this entry constrains the order of a subgroup intersection."
+    },
+    {
+      "targetId": "sylow-theorem",
+      "relationship": "related",
+      "description": "The coprime-order complementarity proved here (H.IsComplement' K) is the elementary form of the coprime splitting used in Sylow-based decompositions."
+    }
+  ],
+  "leanFile": {
+    "namespace": "LagrangeTheoremOQ10",
+    "lineCount": 91,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/LagrangeTheoremOQ10.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified (0-axiom) child of **lagrange-theorem**. Answers OQ-10: how the order of a subgroup intersection `H ⊓ K` is constrained by `|H|` and `|K|`.

**Core (honest new result):** `card_inf_dvd_gcd : |H ⊓ K| ∣ gcd(|H|, |K|)` — Lagrange applied on the subgroup lattice (`H ⊓ K ≤ H` and `H ⊓ K ≤ K`) combined via `Nat.dvd_gcd`. Mathlib records only the coprime endpoint (`Subgroup.inf_eq_bot_of_coprime`, proved through `Nat.eq_one_of_dvd_coprimes`); the explicit gcd-divisibility statement is not in Mathlib.

## Contents (5 theorems, 0 defs, 91 lines, 0 axioms)

- `card_inf_dvd_gcd` — the gcd-divisibility core
- `inf_eq_bot_of_coprime_card` — coprime orders ⇒ `H ⊓ K = ⊥`, re-derived from the core
- `eq_one_of_mem_both` — an element of two coprime-order subgroups is the identity
- `isComplement'_of_coprime_card` — coprime orders with product `|G|` ⇒ internal direct product (wraps `Subgroup.isComplement'_of_coprime`)
- `inf_eq_bot_of_prime_orders` — distinct prime orders `p ≠ q` intersect trivially

## Verification

Docker build `Proofs.LagrangeTheoremOQ10` compiles cleanly (3058 jobs, 0 errors, 0 sorries). Depends only on foundational axioms (propext / Classical.choice / Quot.sound).

Gallery data added: `meta.json` (status verified, badge original) + `annotations.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)