### PR TITLE
research(fibonacci-divisibility-oq-07): F_m ∣ F_n ⟺ m ∣ n, sharp at m=2 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FibonacciDivisibilityOQ07.lean
+++ b/proofs/Proofs/FibonacciDivisibilityOQ07.lean
@@ -1,0 +1,108 @@
+import Mathlib
+
+/-
+# Fibonacci Divisibility Characterization: `Fₘ ∣ Fₙ ↔ m ∣ n`, with the sharp exception at m = 2
+
+Mathlib records the *forward* half of the classical divisibility property of the
+Fibonacci sequence — `Nat.fib_dvd : m ∣ n → fib m ∣ fib n` — together with the
+strong-divisibility identity `Nat.fib_gcd : fib (gcd m n) = gcd (fib m) (fib n)`.
+It does **not** record the converse, nor the full biconditional.
+
+This file supplies the converse and packages the complete characterization.  The
+subtlety that makes the naive biconditional *false* is the coincidence
+`F₁ = F₂ = 1`: since `fib 2 = 1` divides every Fibonacci number, `fib 2 ∣ fib n`
+holds for all `n`, yet `2 ∣ n` does not.  Index `m = 2` is therefore the *unique*
+exception, and the sharp statement is
+
+  `(∀ n, fib m ∣ fib n ↔ m ∣ n) ↔ m ≠ 2`.
+
+The converse `fib m ∣ fib n → m ∣ n` for `m ≥ 3` runs through `fib_gcd`: the
+hypothesis forces `fib (gcd m n) = fib m`, and strict monotonicity of `fib` on
+`[2, ∞)` upgrades this to `gcd m n = m`, i.e. `m ∣ n`.
+
+Fully verified: 0 sorries, 0 axioms, no `native_decide`.  `decide` appears only
+to evaluate the closed numerals `fib 2 = 1`, `fib 3 = 2`, `fib 4 = 3` and the
+ground fact `¬ (2 ∣ 1)` — these reduce in the kernel (`fib_zero/one/two` are
+`rfl`) and introduce no `Lean.ofReduceBool`.
+-/
+
+namespace FibonacciDivisibilityOQ07
+
+open Nat
+
+/-- **Converse of `Nat.fib_dvd` for indices `m ≥ 3`.**  If `fib m ∣ fib n` then
+`m ∣ n`.
+
+Proof: by `Nat.fib_gcd`, `fib m ∣ fib n` gives `fib (gcd m n) = fib m`.  Since
+`m ≥ 3` we have `fib m ≥ fib 3 = 2`, so `gcd m n` can be neither `0` (where
+`fib = 0`) nor `1` (where `fib = 1`); hence `gcd m n ≥ 2`.  Strict monotonicity of
+`fib` on `[2, ∞)` is injective there, so `fib (gcd m n) = fib m` forces
+`gcd m n = m`, and `gcd m n ∣ n` finishes. -/
+theorem dvd_of_fib_dvd_fib {m n : ℕ} (hm : 3 ≤ m) (h : fib m ∣ fib n) : m ∣ n := by
+  -- `fib` of the gcd collapses to `fib m` because `fib m ∣ fib n`.
+  have hg : fib (Nat.gcd m n) = fib m := by
+    rw [Nat.fib_gcd]; exact Nat.gcd_eq_left h
+  -- `fib m ≥ 2` from monotonicity and `fib 3 = 2`.
+  have hfm : 2 ≤ fib m := by
+    have h3 : fib 3 = 2 := by decide
+    have : fib 3 ≤ fib m := fib_mono hm
+    omega
+  -- The gcd is neither 0 nor 1, hence `≥ 2`.
+  have hne0 : Nat.gcd m n ≠ 0 := by
+    intro h0; rw [h0, Nat.fib_zero] at hg; omega
+  have hne1 : Nat.gcd m n ≠ 1 := by
+    intro h1; rw [h1, Nat.fib_one] at hg; omega
+  have h2 : 2 ≤ Nat.gcd m n := by omega
+  -- Injectivity of `fib` on `[2, ∞)` turns `fib (gcd m n) = fib m` into equality.
+  have heq : Nat.gcd m n = m :=
+    fib_strictMonoOn.injOn (Set.mem_Ici.mpr h2) (Set.mem_Ici.mpr (by omega : (2 : ℕ) ≤ m)) hg
+  rw [← heq]; exact Nat.gcd_dvd_right m n
+
+/-- **Divisibility characterization for `m ≥ 3`:** `fib m ∣ fib n ↔ m ∣ n`.
+
+The forward implication is Mathlib's `Nat.fib_dvd`; the converse is
+`dvd_of_fib_dvd_fib`. -/
+theorem fib_dvd_iff {m : ℕ} (hm : 3 ≤ m) (n : ℕ) : fib m ∣ fib n ↔ m ∣ n :=
+  ⟨dvd_of_fib_dvd_fib hm, Nat.fib_dvd m n⟩
+
+/-- **The sharp global characterization.**  For a fixed index `m`, the divisibility
+biconditional `fib m ∣ fib n ↔ m ∣ n` holds for *every* `n` if and only if
+`m ≠ 2`.
+
+The exceptional index is exactly `m = 2`, because `fib 2 = 1` divides every
+Fibonacci number while `2 ∣ n` fails for odd `n` (take `n = 1`).  The indices
+`m = 0` (`fib 0 = 0`, so both sides say `n = 0`) and `m = 1` (`fib 1 = 1`, so both
+sides are vacuously true) are *not* exceptions. -/
+theorem fib_dvd_iff_forall (m : ℕ) : (∀ n, fib m ∣ fib n ↔ m ∣ n) ↔ m ≠ 2 := by
+  constructor
+  · -- If the biconditional held at `m = 2` for `n = 1` we would get `2 ∣ 1`.
+    intro h hm2
+    subst hm2
+    have hd : fib 2 ∣ fib 1 := by decide
+    have : (2 : ℕ) ∣ 1 := (h 1).mp hd
+    omega
+  · -- Conversely, `m ≠ 2` splits into `0`, `1`, and `≥ 3`, each handled above.
+    intro hm n
+    rcases m with _ | _ | _ | k
+    · simp [zero_dvd_iff, Nat.fib_eq_zero]        -- m = 0 : `fib n = 0 ↔ n = 0`
+    · simp                                         -- m = 1 : both sides always hold
+    · exact absurd rfl hm                          -- m = 2 : excluded
+    · exact fib_dvd_iff (by omega) n              -- m = k + 3
+
+/-- **Corollary — parity of Fibonacci numbers.**  `fib n` is even iff `3 ∣ n`.
+Immediate from `fib_dvd_iff` at `m = 3`, since `fib 3 = 2`. -/
+theorem two_dvd_fib_iff (n : ℕ) : 2 ∣ fib n ↔ 3 ∣ n := by
+  have h3 : Nat.fib 3 = 2 := by decide
+  rw [← h3]; exact fib_dvd_iff (by norm_num) n
+
+/-- **Corollary — divisibility by 3.**  `3 ∣ fib n` iff `4 ∣ n`, since `fib 4 = 3`. -/
+theorem three_dvd_fib_iff (n : ℕ) : 3 ∣ fib n ↔ 4 ∣ n := by
+  have h4 : Nat.fib 4 = 3 := by decide
+  rw [← h4]; exact fib_dvd_iff (by norm_num) n
+
+/-- **Sharpness witness.**  At the exceptional index `m = 2` the biconditional
+fails concretely: `fib 2 ∣ fib 1` holds while `2 ∣ 1` does not. -/
+theorem fib_two_exception : fib 2 ∣ fib 1 ∧ ¬ (2 ∣ 1) := by
+  refine ⟨by decide, by decide⟩
+
+end FibonacciDivisibilityOQ07

--- a/src/data/proofs/fibonacci-divisibility-oq-07/annotations.json
+++ b/src/data/proofs/fibonacci-divisibility-oq-07/annotations.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "ann-fibdivoq07-1",
+    "proofId": "fibonacci-divisibility-oq-07",
+    "range": { "startLine": 3, "endLine": 26 },
+    "type": "concept",
+    "title": "What Mathlib Has, and the m = 2 Wrinkle",
+    "content": "**Framing.** Mathlib records the *forward* divisibility law $\\mathtt{Nat.fib\\_dvd}: m \\mid n \\to F_m \\mid F_n$ and the strong-divisibility identity $\\mathtt{Nat.fib\\_gcd}: F_{\\gcd(m,n)} = \\gcd(F_m, F_n)$, but neither the converse nor the biconditional. The naive iff $F_m \\mid F_n \\Leftrightarrow m \\mid n$ is **false** at exactly one index: because $F_1 = F_2 = 1$ and $1$ divides everything, $F_2 \\mid F_n$ holds for all $n$ while $2 \\mid n$ fails at $n = 1$. This file supplies the converse and pins $m = 2$ as the unique exception.",
+    "mathContext": "$F_0 = 0,\\ F_1 = 1,\\ F_2 = 1,\\ F_3 = 2,\\ F_4 = 3,\\dots$ (0-indexed $\\mathtt{Nat.fib}$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Strong divisibility sequences",
+      "Nat.fib_dvd (forward direction, in Mathlib)",
+      "The coincidence F₁ = F₂ = 1"
+    ],
+    "prerequisites": [
+      "The 0-indexed Fibonacci sequence Nat.fib",
+      "Divisibility and gcd over ℕ"
+    ],
+    "tags": ["module-header", "framing", "fibonacci", "divisibility"]
+  },
+  {
+    "id": "ann-fibdivoq07-2",
+    "proofId": "fibonacci-divisibility-oq-07",
+    "range": { "startLine": 31, "endLine": 57 },
+    "type": "proof-step",
+    "title": "The Converse: from fib_gcd to Injectivity on [2, ∞)",
+    "content": "**The mathematical heart of the entry.** For $m \\ge 3$, assume $F_m \\mid F_n$. By $\\mathtt{fib\\_gcd}$, $\\gcd(F_m, F_n) = F_{\\gcd(m,n)}$, and $\\mathtt{gcd\\_eq\\_left}$ collapses the left side to $F_m$ under the hypothesis, giving $F_{\\gcd(m,n)} = F_m$. Now $F_m \\ge F_3 = 2$ (monotonicity), so $\\gcd(m,n)$ is neither $0$ (where $F = 0$) nor $1$ (where $F = 1$); hence $\\gcd(m,n) \\ge 2$. On $[2,\\infty)$ the sequence $F$ is strictly monotone, so **injective**, and $F_{\\gcd(m,n)} = F_m$ upgrades to $\\gcd(m,n) = m$. Therefore $m = \\gcd(m,n) \\mid n$.",
+    "mathContext": "$F_m \\mid F_n \\Rightarrow F_{\\gcd(m,n)} = F_m \\xRightarrow{\\text{inj on }[2,\\infty)} \\gcd(m,n) = m \\Rightarrow m \\mid n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.fib_gcd (strong divisibility)",
+      "Nat.fib_strictMonoOn and injectivity on [2, ∞)",
+      "Lower-bounding the gcd by ruling out 0 and 1"
+    ],
+    "prerequisites": [
+      "fib (gcd m n) = gcd (fib m) (fib n)",
+      "Strict monotonicity of fib on [2, ∞)"
+    ],
+    "tags": ["converse", "gcd", "injectivity", "critical"]
+  },
+  {
+    "id": "ann-fibdivoq07-3",
+    "proofId": "fibonacci-divisibility-oq-07",
+    "range": { "startLine": 59, "endLine": 88 },
+    "type": "theorem",
+    "title": "The Biconditional and its Sharp Global Form",
+    "content": "**$\\mathtt{fib\\_dvd\\_iff}$** packages the converse with Mathlib's forward $\\mathtt{Nat.fib\\_dvd}$ to give $F_m \\mid F_n \\Leftrightarrow m \\mid n$ for $m \\ge 3$. **$\\mathtt{fib\\_dvd\\_iff\\_forall}$** is the sharp statement: for a fixed $m$, the per-$n$ biconditional holds for *every* $n$ iff $m \\ne 2$. The exceptional direction instantiates $n = 1$ at $m = 2$ to derive $2 \\mid 1$; the converse direction splits $m \\ne 2$ into $m = 0$ (both sides $\\Leftrightarrow n = 0$), $m = 1$ (both sides vacuously true), and $m = k+3$.",
+    "mathContext": "$(\\forall n,\\ F_m \\mid F_n \\leftrightarrow m \\mid n) \\leftrightarrow m \\ne 2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Sharp boundary / exceptional-index phenomena",
+      "Case split by rcases on m = 0, 1, 2, k+3",
+      "Nat.fib_eq_zero and zero_dvd_iff for the m = 0 branch"
+    ],
+    "prerequisites": [
+      "The converse dvd_of_fib_dvd_fib",
+      "Mathlib's forward Nat.fib_dvd"
+    ],
+    "tags": ["biconditional", "sharp", "characterization", "critical"]
+  },
+  {
+    "id": "ann-fibdivoq07-4",
+    "proofId": "fibonacci-divisibility-oq-07",
+    "range": { "startLine": 90, "endLine": 105 },
+    "type": "concept",
+    "title": "Arithmetic Corollaries and the Sharpness Witness",
+    "content": "Specializing the biconditional at $m = 3$ (with $F_3 = 2$) gives **$\\mathtt{two\\_dvd\\_fib\\_iff}$**: $F_n$ is even $\\Leftrightarrow 3 \\mid n$ — the exact 'every third Fibonacci number is even'. At $m = 4$ (with $F_4 = 3$), **$\\mathtt{three\\_dvd\\_fib\\_iff}$**: $3 \\mid F_n \\Leftrightarrow 4 \\mid n$. Finally **$\\mathtt{fib\\_two\\_exception}$** exhibits the concrete failure at the exceptional index: $F_2 \\mid F_1$ holds yet $2 \\nmid 1$, confirming that $m = 2$ genuinely must be excluded.",
+    "mathContext": "$2 \\mid F_n \\Leftrightarrow 3 \\mid n$;\\quad $3 \\mid F_n \\Leftrightarrow 4 \\mid n$;\\quad $F_2 \\mid F_1 \\wedge \\neg(2 \\mid 1)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Periodicity of Fibonacci residues (Pisano-style)",
+      "Divisibility-blindness of the value 1",
+      "Sharpness witnesses"
+    ],
+    "prerequisites": [
+      "The biconditional fib_dvd_iff",
+      "fib 3 = 2 and fib 4 = 3"
+    ],
+    "tags": ["corollary", "parity", "sharpness", "fibonacci"]
+  }
+]

--- a/src/data/proofs/fibonacci-divisibility-oq-07/meta.json
+++ b/src/data/proofs/fibonacci-divisibility-oq-07/meta.json
@@ -1,0 +1,109 @@
+{
+  "id": "fibonacci-divisibility-oq-07",
+  "title": "Fibonacci Divisibility Characterization: Fₘ ∣ Fₙ ⟺ m ∣ n, Sharp at m = 2",
+  "slug": "fibonacci-divisibility-oq-07",
+  "description": "Mathlib records only the forward half of the classical divisibility law of the Fibonacci sequence — Nat.fib_dvd: m ∣ n → fib m ∣ fib n — together with the strong-divisibility identity Nat.fib_gcd: fib (gcd m n) = gcd (fib m) (fib n). This entry supplies the missing converse and packages the complete biconditional. The obstruction to a naive iff is the coincidence F₁ = F₂ = 1: because fib 2 = 1 divides every Fibonacci number, fib 2 ∣ fib n holds for all n, yet 2 ∣ n fails at n = 1. Index m = 2 is therefore the unique exception, and the sharp statement is fib_dvd_iff_forall: (∀ n, fib m ∣ fib n ↔ m ∣ n) ↔ m ≠ 2. The converse dvd_of_fib_dvd_fib (for m ≥ 3) runs through fib_gcd: fib m ∣ fib n forces fib (gcd m n) = fib m; since fib m ≥ fib 3 = 2 the gcd is neither 0 nor 1, so it lies in [2, ∞) where fib is strictly monotone and hence injective, upgrading the equality of fib-values to gcd m n = m, i.e. m ∣ n. Two arithmetic corollaries fall out: fib n is even ⟺ 3 ∣ n (fib 3 = 2) and 3 ∣ fib n ⟺ 4 ∣ n (fib 4 = 3). Fully verified: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Lucas, 1878; É. Lucas, Théorie des nombres); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Divisibility_properties",
+    "date": "1878",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "divisibility",
+      "strong-divisibility-sequence",
+      "gcd",
+      "sharp-boundary",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciDivisibilityOQ07.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_gcd",
+        "description": "fib (gcd m n) = gcd (fib m) (fib n) — the strong-divisibility identity; the engine of the converse, turning fib m ∣ fib n into fib (gcd m n) = fib m",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_dvd",
+        "description": "m ∣ n → fib m ∣ fib n — the forward implication of the biconditional, the only half Mathlib records",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_strictMonoOn",
+        "description": "StrictMonoOn fib (Set.Ici 2) — strict monotonicity of fib on [2, ∞); its .injOn gives the injectivity that upgrades fib (gcd m n) = fib m to gcd m n = m",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.gcd_eq_left",
+        "description": "m ∣ n → gcd m n = m — collapses gcd (fib m) (fib n) to fib m under the divisibility hypothesis",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.fib_mono / Nat.fib_zero / Nat.fib_one / Nat.fib_eq_zero",
+        "description": "monotonicity and small values of fib — used to force gcd m n ≥ 2 and to discharge the m = 0 edge case (fib n = 0 ↔ n = 0)",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ],
+    "originalContributions": [
+      "dvd_of_fib_dvd_fib: ∀ {m n}, 3 ≤ m → fib m ∣ fib n → m ∣ n — the converse of Nat.fib_dvd, absent from Mathlib, proved via fib_gcd and injectivity of fib on [2, ∞)",
+      "fib_dvd_iff: ∀ {m}, 3 ≤ m → ∀ n, (fib m ∣ fib n ↔ m ∣ n) — the full divisibility biconditional for non-degenerate indices",
+      "fib_dvd_iff_forall: ∀ m, (∀ n, fib m ∣ fib n ↔ m ∣ n) ↔ m ≠ 2 — the sharp global characterization identifying m = 2 as the unique exceptional index",
+      "two_dvd_fib_iff: ∀ n, 2 ∣ fib n ↔ 3 ∣ n — corollary: fib n is even iff 3 ∣ n",
+      "three_dvd_fib_iff: ∀ n, 3 ∣ fib n ↔ 4 ∣ n — corollary from fib 4 = 3",
+      "fib_two_exception: fib 2 ∣ fib 1 ∧ ¬ (2 ∣ 1) — the concrete sharpness witness at m = 2"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 106,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). The tactic `decide` is used only to evaluate the closed numerals fib 2 = 1, fib 3 = 2, fib 4 = 3 and the ground fact ¬(2 ∣ 1); these reduce in the kernel (fib_zero/one/two are rfl) and introduce no `Lean.ofReduceBool` — no `native_decide` appears.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That consecutive Fibonacci numbers are coprime, and more generally that gcd(Fₘ, Fₙ) = F_gcd(m,n), was established by Édouard Lucas in the 1870s; the sequence Fₙ is the archetypal 'strong divisibility sequence'. An immediate consequence is the divisibility law Fₘ ∣ Fₙ ⟺ m ∣ n — one of the most quoted facts about the Fibonacci numbers. The one wrinkle, invisible in the 1-indexed classical presentation but explicit in Mathlib's 0-indexed Nat.fib, is the coincidence F₁ = F₂ = 1: the value 1 divides everything, so the index m = 2 (like the trivial m = 1) cannot be recovered from divisibility of fib-values. This entry pins down that the biconditional survives at every index except m = 2.",
+    "problemStatement": "**Open Question (fibonacci-divisibility-oq-07)**: Establish the full divisibility characterization Fₘ ∣ Fₙ ⟺ m ∣ n for the Fibonacci sequence, supplying the converse that Mathlib omits, and determine the exact indices for which the biconditional holds.\n\n**Result**: fib_dvd_iff (the biconditional for m ≥ 3) and the sharp global form fib_dvd_iff_forall: the per-n biconditional holds for all n iff m ≠ 2.",
+    "text": "Using Mathlib's 0-indexed Nat.fib (F₀ = 0, F₁ = 1, F₂ = 1, F₃ = 2, …): for m ≥ 3 one has fib m ∣ fib n ⟺ m ∣ n. Fixing m, the equivalence holds for every n precisely when m ≠ 2 — the indices m = 0 and m = 1 are not exceptions (both sides collapse to n = 0, resp. to True), whereas m = 2 fails because fib 2 = 1 divides fib 1 = 1 while 2 ∤ 1.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Converse via the gcd (`dvd_of_fib_dvd_fib`, m ≥ 3).** From fib m ∣ fib n and Nat.fib_gcd, gcd(fib m, fib n) = fib m gives fib (gcd m n) = fib m. Because m ≥ 3, fib m ≥ fib 3 = 2 (Nat.fib_mono), so gcd m n cannot be 0 (fib 0 = 0) or 1 (fib 1 = 1); hence gcd m n ≥ 2. On [2, ∞) fib is strictly monotone (Nat.fib_strictMonoOn), hence injective, so fib (gcd m n) = fib m forces gcd m n = m. Then m = gcd m n ∣ n.\n2. **Biconditional (`fib_dvd_iff`).** Package step 1 with Mathlib's forward Nat.fib_dvd.\n3. **Sharp global form (`fib_dvd_iff_forall`).** The exceptional direction: if the biconditional held at m = 2 then instantiating n = 1 gives 2 ∣ 1, a contradiction (fib 2 ∣ fib 1 by decide). Conversely, m ≠ 2 splits by rcases into m = 0 (both sides ⇔ n = 0 via fib_eq_zero and zero_dvd_iff), m = 1 (both sides always true), and m = k + 3 (step 2).\n4. **Corollaries.** Instantiating fib_dvd_iff at m = 3 and m = 4, and rewriting fib 3 = 2 and fib 4 = 3, yields the arithmetic progressions of even Fibonacci numbers (2 ∣ fib n ⟺ 3 ∣ n) and multiples of 3 (3 ∣ fib n ⟺ 4 ∣ n).",
+    "keyInsights": [
+      "**The converse is the content; Mathlib supplies only the forward half.** Nat.fib_dvd (m ∣ n → fib m ∣ fib n) is standard, but the reverse implication — recovering the index divisibility from divisibility of the values — is exactly what a *strong* divisibility sequence buys you, and it is not in Mathlib.",
+      "**fib_gcd converts a divisibility hypothesis into an equation of fib-values.** The whole converse hinges on reading fib m ∣ fib n as gcd(fib m, fib n) = fib m and then as fib (gcd m n) = fib m; injectivity of fib on [2, ∞) does the rest.",
+      "**m = 2 is a genuine, unique exception — the sharpest possible statement.** Because F₁ = F₂ = 1, the value 1 is divisibility-blind to its index. The theorem fib_dvd_iff_forall makes this precise: the biconditional holds for all n iff m ≠ 2, and no weaker hypothesis (e.g. m ≥ 1) would be correct.",
+      "**Even Fibonacci numbers sit on an arithmetic progression.** The corollary 2 ∣ fib n ⟺ 3 ∣ n (from fib 3 = 2) recovers the familiar 'every third Fibonacci number is even', now as an exact iff rather than a one-directional divisibility."
+    ],
+    "prerequisites": [
+      "The 0-indexed Fibonacci sequence Nat.fib and its recurrence",
+      "The strong-divisibility identity fib (gcd m n) = gcd (fib m) (fib n)",
+      "Strict monotonicity/injectivity of fib on [2, ∞) and basic gcd facts"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Framing",
+      "content": "The file opens by situating itself against Mathlib: Nat.fib_dvd and Nat.fib_gcd are present, but the converse and the full biconditional are not. It flags the F₁ = F₂ = 1 coincidence as the source of the single exceptional index m = 2."
+    },
+    {
+      "id": "converse",
+      "title": "The Converse dvd_of_fib_dvd_fib",
+      "content": "For m ≥ 3, fib m ∣ fib n ⟹ m ∣ n. The proof turns the divisibility hypothesis into fib (gcd m n) = fib m via fib_gcd, bounds the gcd below by 2 using fib m ≥ 2, and applies injectivity of fib on [2, ∞) to conclude gcd m n = m."
+    },
+    {
+      "id": "characterization",
+      "title": "Biconditional and Sharp Global Form",
+      "content": "fib_dvd_iff packages the converse with Mathlib's forward direction for m ≥ 3. fib_dvd_iff_forall proves the sharp statement (∀ n, fib m ∣ fib n ↔ m ∣ n) ↔ m ≠ 2, isolating m = 2 as the unique exceptional index."
+    },
+    {
+      "id": "corollaries",
+      "title": "Arithmetic Corollaries and Sharpness Witness",
+      "content": "two_dvd_fib_iff (fib n even ⟺ 3 ∣ n) and three_dvd_fib_iff (3 ∣ fib n ⟺ 4 ∣ n) specialize the biconditional at m = 3, 4. fib_two_exception exhibits the concrete failure at m = 2: fib 2 ∣ fib 1 while ¬(2 ∣ 1)."
+    }
+  ],
+  "crossReferences": [
+    "fibonacci-identities",
+    "fibonacci-identities-oq-05"
+  ]
+}


### PR DESCRIPTION
## Summary

New verified, 0-axiom gallery entry: the **complete divisibility characterization of the Fibonacci sequence**, `Fₘ ∣ Fₙ ⟺ m ∣ n`, supplying the converse that Mathlib omits and pinning down **m = 2 as the unique exceptional index**.

Mathlib records only the forward half (`Nat.fib_dvd : m ∣ n → fib m ∣ fib n`) plus the strong-divisibility identity `Nat.fib_gcd`. It has neither the converse nor the biconditional. The obstruction to a naive iff is the coincidence `F₁ = F₂ = 1`: since `fib 2 = 1` divides every Fibonacci number, `fib 2 ∣ fib n` holds for all `n`, yet `2 ∣ n` fails at `n = 1`.

## Results (`proofs/Proofs/FibonacciDivisibilityOQ07.lean`)

- **`dvd_of_fib_dvd_fib`** (`m ≥ 3`): `fib m ∣ fib n → m ∣ n` — the converse, absent from Mathlib. Proof: `fib_gcd` turns the hypothesis into `fib (gcd m n) = fib m`; `fib m ≥ fib 3 = 2` forces `gcd m n ≥ 2`; injectivity of `fib` on `[2, ∞)` (`fib_strictMonoOn`) upgrades to `gcd m n = m`.
- **`fib_dvd_iff`** (`m ≥ 3`): the biconditional `fib m ∣ fib n ↔ m ∣ n`.
- **`fib_dvd_iff_forall`**: the sharp global form `(∀ n, fib m ∣ fib n ↔ m ∣ n) ↔ m ≠ 2`. Indices `m = 0` (both sides ⇔ `n = 0`) and `m = 1` (both sides vacuously true) are **not** exceptions; `m = 2` is the only one.
- **`two_dvd_fib_iff`**: `Fₙ` even `⟺ 3 ∣ n` (from `fib 3 = 2`).
- **`three_dvd_fib_iff`**: `3 ∣ Fₙ ⟺ 4 ∣ n` (from `fib 4 = 3`).
- **`fib_two_exception`**: concrete sharpness witness `fib 2 ∣ fib 1 ∧ ¬(2 ∣ 1)`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.FibonacciDivisibilityOQ07` → `✔ [7743/7743] Built`.
**0 sorries, 0 axioms, no `native_decide`.** `decide` is used only to evaluate closed numerals (`fib 3 = 2`, etc.), which reduce in the kernel and introduce no `Lean.ofReduceBool`. 6 theorems, 0 definitions, 106 lines.

## Gallery

- `src/data/proofs/fibonacci-divisibility-oq-07/{meta.json,annotations.json}` (badge `mathlib`, status `verified`, 4 annotations, cross-refs to `fibonacci-identities` and `fibonacci-identities-oq-05`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
