### PR TITLE
research(minkowski-theorem-oq-04-oq-02): covolume-threshold Blichfeldt & Minkowski for an arbitrary lattice [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/MinkowskiTheoremOQ04OQ02.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ04OQ02.lean
@@ -1,0 +1,211 @@
+import Mathlib.Algebra.Module.ZLattice.Covolume
+import Proofs.MinkowskiTheoremOQ04
+import Mathlib.Tactic
+
+/-
+# Blichfeldt & Minkowski for an arbitrary full-rank lattice — covolume threshold
+
+Child of `minkowski-theorem-oq-04` (`Proofs/MinkowskiTheoremOQ04.lean`).
+
+The parent already proves, verified and axiom-free, the lattice-parametric Blichfeldt
+pigeonhole `BlichfeldtTheorem.blichfeldt_general_lattice`: for a basis
+`b : Module.Basis (Fin n) ℝ (Fin n → ℝ)` and a measurable `s` with
+`(k : ℝ≥0∞) * volume (ZSpan.fundamentalDomain b) < volume s`, there are `k + 1`
+distinct points of `s` whose pairwise differences lie in `Submodule.span ℤ (Set.range b)`.
+
+What the parent does *not* provide, and what this child adds, is the geometry-of-numbers
+**covolume-threshold** form — the statement as it appears in Cassels / Siegel, phrased with
+`ZLattice.covolume` (a real number, `= (volume of a fundamental domain).toReal`) rather than
+the raw `ℝ≥0∞`-valued `volume (ZSpan.fundamentalDomain b)`. This is the shape used in
+essentially every number-theoretic application (Diophantine approximation, ideal-lattice
+bounds via the Minkowski embedding, whose covolume is `2^{-r₂}√|d_K|`).
+
+## Main results
+
+* `covolume_eq_toReal_volume_fundamentalDomain` — the bridge
+  `ZLattice.covolume (span ℤ (range b)) volume = (volume (ZSpan.fundamentalDomain b)).toReal`.
+* `blichfeldt_general_lattice_covolume` — Blichfeldt with threshold
+  `ENNReal.ofReal (k · covol(Λ)) < volume s`.
+* `blichfeldt_basic_lattice`, `blichfeldt_basic_lattice_covolume` — the `k = 1` corollaries.
+* `minkowski_lattice` — Minkowski's convex-body theorem for an arbitrary full-rank lattice:
+  a measurable, convex, centrally-symmetric `s` with
+  `2ⁿ · volume (ZSpan.fundamentalDomain b) < volume s` contains a nonzero lattice point.
+* `minkowski_lattice_covolume` — the same with the covolume threshold
+  `ENNReal.ofReal (2ⁿ · covol(Λ)) < volume s`.
+
+All results are reduced to the parent's verified engine plus the Mathlib `ZLattice.covolume`
+API; no new axioms are introduced.
+
+References: Blichfeldt (1914); Cassels, *Geometry of Numbers*, Ch. III;
+Siegel, *Lectures on the Geometry of Numbers*.
+-/
+
+open MeasureTheory Set Pointwise
+
+namespace BlichfeldtTheorem
+
+variable {n : ℕ} [NeZero n]
+
+omit [NeZero n] in
+/-- The volume of a lattice fundamental domain is finite (it is a bounded set). -/
+theorem volume_fundamentalDomain_ne_top (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) :
+    volume (ZSpan.fundamentalDomain b) ≠ ⊤ :=
+  (Bornology.IsBounded.measure_lt_top (ZSpan.fundamentalDomain_isBounded b)).ne
+
+omit [NeZero n] in
+/-- **Covolume bridge.** For the lattice `Λ = span ℤ (range b)`, the real-valued
+`ZLattice.covolume` is exactly the `toReal` of the (`ℝ≥0∞`-valued) volume of the
+half-open fundamental parallelepiped `ZSpan.fundamentalDomain b`. -/
+theorem covolume_eq_toReal_volume_fundamentalDomain
+    (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) :
+    ZLattice.covolume (Submodule.span ℤ (Set.range b)) volume
+      = (volume (ZSpan.fundamentalDomain b)).toReal := by
+  rw [ZLattice.covolume_eq_measure_fundamentalDomain _ volume
+        (ZSpan.isAddFundamentalDomain b volume), measureReal_def]
+
+omit [NeZero n] in
+/-- `(k : ℝ≥0∞) · volume F = ENNReal.ofReal (k · covol Λ)`, the arithmetic bridge that
+turns the parent's `ℝ≥0∞`-threshold into the covolume threshold. -/
+theorem natCast_mul_volume_fundamentalDomain
+    (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) (k : ℕ) :
+    (k : ENNReal) * volume (ZSpan.fundamentalDomain b)
+      = ENNReal.ofReal ((k : ℝ) * ZLattice.covolume (Submodule.span ℤ (Set.range b)) volume) := by
+  rw [covolume_eq_toReal_volume_fundamentalDomain, ENNReal.ofReal_mul (Nat.cast_nonneg k),
+      ENNReal.ofReal_natCast, ENNReal.ofReal_toReal (volume_fundamentalDomain_ne_top b)]
+
+/-- **Blichfeldt's theorem for an arbitrary full-rank lattice, covolume form.**
+
+For a basis `b` (hence lattice `Λ = span ℤ (range b)`) and measurable `s` with
+`vol(S) > k · covol(Λ)`, there exist `k + 1` distinct points of `S` whose pairwise
+differences all lie in `Λ`. Covolume restatement of the parent's
+`blichfeldt_general_lattice`. -/
+theorem blichfeldt_general_lattice_covolume
+    (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) (k : ℕ) (s : Set (Fin n → ℝ))
+    (h_meas : MeasurableSet s)
+    (h_vol : ENNReal.ofReal ((k : ℝ) * ZLattice.covolume (Submodule.span ℤ (Set.range b)) volume)
+              < volume s) :
+    ∃ pts : Fin (k + 1) → Fin n → ℝ,
+      Function.Injective pts ∧ (∀ i, pts i ∈ s) ∧
+      ∀ i j, pts i - pts j ∈
+        (Submodule.span ℤ (Set.range b) : Set (Fin n → ℝ)) := by
+  refine blichfeldt_general_lattice b k s h_meas ?_
+  rw [natCast_mul_volume_fundamentalDomain]
+  exact h_vol
+
+/-- **Blichfeldt at `k = 1` for an arbitrary lattice** (fundamental-domain-volume form):
+a measurable `s` with `volume s > volume (ZSpan.fundamentalDomain b)` contains two distinct
+points differing by a lattice vector. -/
+theorem blichfeldt_basic_lattice
+    (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) (s : Set (Fin n → ℝ))
+    (h_meas : MeasurableSet s)
+    (h_vol : volume (ZSpan.fundamentalDomain b) < volume s) :
+    ∃ x y : Fin n → ℝ, x ∈ s ∧ y ∈ s ∧ x ≠ y ∧
+      x - y ∈ (Submodule.span ℤ (Set.range b) : Set (Fin n → ℝ)) := by
+  obtain ⟨pts, hinj, hmem, hcong⟩ :=
+    blichfeldt_general_lattice b 1 s h_meas (by rw [Nat.cast_one, one_mul]; exact h_vol)
+  exact ⟨pts 0, pts 1, hmem 0, hmem 1, fun heq => absurd (hinj heq) (by decide), hcong 0 1⟩
+
+/-- **Blichfeldt at `k = 1` for an arbitrary lattice**, covolume form:
+`volume s > covol(Λ)` forces a lattice-related pair. -/
+theorem blichfeldt_basic_lattice_covolume
+    (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) (s : Set (Fin n → ℝ))
+    (h_meas : MeasurableSet s)
+    (h_vol : ENNReal.ofReal (ZLattice.covolume (Submodule.span ℤ (Set.range b)) volume)
+              < volume s) :
+    ∃ x y : Fin n → ℝ, x ∈ s ∧ y ∈ s ∧ x ≠ y ∧
+      x - y ∈ (Submodule.span ℤ (Set.range b) : Set (Fin n → ℝ)) := by
+  refine blichfeldt_basic_lattice b s h_meas ?_
+  have h1 : ENNReal.ofReal (ZLattice.covolume (Submodule.span ℤ (Set.range b)) volume)
+      = volume (ZSpan.fundamentalDomain b) := by
+    rw [covolume_eq_toReal_volume_fundamentalDomain,
+        ENNReal.ofReal_toReal (volume_fundamentalDomain_ne_top b)]
+  rwa [h1] at h_vol
+
+/-- **Minkowski's convex-body theorem for an arbitrary full-rank lattice.**
+
+A measurable, convex, centrally-symmetric set `s ⊆ ℝⁿ` with
+`volume s > 2ⁿ · volume (ZSpan.fundamentalDomain b)` contains a nonzero point of the
+lattice `Λ = span ℤ (range b)`.
+
+Half-scaling reduces it to `blichfeldt_basic_lattice` on `T = (1/2) • s`, exactly mirroring
+the parent's `minkowski_from_blichfeldt` with the constant `1` (= covolume of `ℤⁿ`) replaced
+by `volume (ZSpan.fundamentalDomain b)`. -/
+theorem minkowski_lattice
+    (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) (s : Set (Fin n → ℝ))
+    (h_meas : MeasurableSet s) (h_symm : ∀ x ∈ s, -x ∈ s) (h_conv : Convex ℝ s)
+    (h_vol : (2 : ENNReal) ^ n * volume (ZSpan.fundamentalDomain b) < volume s) :
+    ∃ p : (Submodule.span ℤ (Set.range b)).toAddSubgroup, p ≠ 0 ∧ (p : Fin n → ℝ) ∈ s := by
+  let T := (fun x : Fin n → ℝ => (2 : ℝ)⁻¹ • x) '' s
+  have h_T_eq : T = (2 : ℝ)⁻¹ • s := rfl
+  have h2_ne : (2 : ℝ) ≠ 0 := by norm_num
+  -- Measurability of `T` (same argument as `minkowski_from_blichfeldt`).
+  have h_meas_T : MeasurableSet T := by
+    have h_pre : (2 : ℝ)⁻¹ • s = ((2 : ℝ) • · : (Fin n → ℝ) → (Fin n → ℝ)) ⁻¹' s := by
+      ext y
+      simp only [Set.mem_smul_set, Set.mem_preimage]
+      refine ⟨?_, ?_⟩
+      · rintro ⟨a, has, rfl⟩
+        rwa [smul_smul, mul_inv_cancel₀ h2_ne, one_smul]
+      · intro h
+        exact ⟨(2 : ℝ) • y, h, by rw [smul_smul, inv_mul_cancel₀ h2_ne, one_smul]⟩
+    rw [h_T_eq, h_pre]
+    exact h_meas.preimage (measurable_const_smul (2 : ℝ))
+  -- Volume identity: `vol T = (1/2)ⁿ · vol s > vol F` since `vol s > 2ⁿ · vol F`.
+  have h_vol_T : volume (ZSpan.fundamentalDomain b) < volume T := by
+    rw [h_T_eq, MeasureTheory.Measure.addHaar_smul volume ((2 : ℝ)⁻¹) s,
+        Module.finrank_fin_fun, abs_pow, ENNReal.ofReal_pow (abs_nonneg _)]
+    rw [show |((2 : ℝ)⁻¹)| = (2 : ℝ)⁻¹ by norm_num]
+    have h_ofReal : ENNReal.ofReal ((2 : ℝ)⁻¹) = (2 : ENNReal)⁻¹ := by
+      rw [show ((2 : ℝ)⁻¹) = 1 / 2 by ring,
+          ENNReal.ofReal_div_of_pos (by norm_num : (0 : ℝ) < 2)]
+      simp
+    rw [h_ofReal]
+    have h2iz : (2 : ENNReal)⁻¹ ≠ 0 := ENNReal.inv_ne_zero.mpr (by norm_num)
+    have h2it : (2 : ENNReal)⁻¹ ≠ ⊤ := ENNReal.inv_ne_top.mpr (by norm_num)
+    have hz : ((2 : ENNReal)⁻¹) ^ n ≠ 0 := pow_ne_zero _ h2iz
+    have ht : ((2 : ENNReal)⁻¹) ^ n ≠ ⊤ := by
+      intro hc; rw [ENNReal.pow_eq_top_iff] at hc; exact h2it hc.1
+    have h_step := ENNReal.mul_lt_mul_right hz ht h_vol
+    have h_eq_one : ((2 : ENNReal)⁻¹) ^ n * (2 : ENNReal) ^ n = 1 := by
+      rw [← mul_pow,
+          ENNReal.inv_mul_cancel (by norm_num : (2 : ENNReal) ≠ 0)
+            (by norm_num : (2 : ENNReal) ≠ ⊤), one_pow]
+    rw [← mul_assoc, h_eq_one, one_mul] at h_step
+    exact h_step
+  obtain ⟨a, c, haT, hcT, hac_ne, hac_diff⟩ := blichfeldt_basic_lattice b T h_meas_T h_vol_T
+  obtain ⟨x₀, hx₀s, rfl⟩ := haT
+  obtain ⟨y₀, hy₀s, rfl⟩ := hcT
+  have hp_in_s : (2 : ℝ)⁻¹ • x₀ - (2 : ℝ)⁻¹ • y₀ ∈ s := by
+    have key : (2 : ℝ)⁻¹ • x₀ + (2 : ℝ)⁻¹ • (-y₀) ∈ s :=
+      h_conv hx₀s (h_symm y₀ hy₀s) (by norm_num) (by norm_num) (by norm_num)
+    rwa [smul_neg, ← sub_eq_add_neg] at key
+  -- `x ∈ (N : Set _)` and `x ∈ N.toAddSubgroup` are definitionally equal
+  -- (`Submodule.mem_toAddSubgroup` is `Iff.rfl`), so `hac_diff` transfers directly.
+  have hp_mem : (2 : ℝ)⁻¹ • x₀ - (2 : ℝ)⁻¹ • y₀
+      ∈ (Submodule.span ℤ (Set.range b)).toAddSubgroup :=
+    hac_diff
+  exact ⟨⟨_, hp_mem⟩, fun h => (sub_ne_zero.mpr hac_ne) (congrArg Subtype.val h), hp_in_s⟩
+
+/-- **Minkowski's convex-body theorem for an arbitrary lattice**, covolume form:
+a measurable convex centrally-symmetric `s` with `volume s > 2ⁿ · covol(Λ)` contains a
+nonzero lattice point. This is the classical geometry-of-numbers statement (Cassels III.2). -/
+theorem minkowski_lattice_covolume
+    (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) (s : Set (Fin n → ℝ))
+    (h_meas : MeasurableSet s) (h_symm : ∀ x ∈ s, -x ∈ s) (h_conv : Convex ℝ s)
+    (h_vol : ENNReal.ofReal
+        ((2 : ℝ) ^ n * ZLattice.covolume (Submodule.span ℤ (Set.range b)) volume)
+              < volume s) :
+    ∃ p : (Submodule.span ℤ (Set.range b)).toAddSubgroup, p ≠ 0 ∧ (p : Fin n → ℝ) ∈ s := by
+  refine minkowski_lattice b s h_meas h_symm h_conv ?_
+  have hbridge : (2 : ENNReal) ^ n * volume (ZSpan.fundamentalDomain b)
+      = ENNReal.ofReal
+          ((2 : ℝ) ^ n * ZLattice.covolume (Submodule.span ℤ (Set.range b)) volume) := by
+    rw [ENNReal.ofReal_mul (by positivity : (0 : ℝ) ≤ (2 : ℝ) ^ n),
+        ENNReal.ofReal_pow (by norm_num : (0 : ℝ) ≤ 2),
+        covolume_eq_toReal_volume_fundamentalDomain,
+        ENNReal.ofReal_toReal (volume_fundamentalDomain_ne_top b)]
+    norm_num
+  rw [hbridge]
+  exact h_vol
+
+end BlichfeldtTheorem

--- a/research/problems/minkowski-theorem-oq-04-oq-02/knowledge.md
+++ b/research/problems/minkowski-theorem-oq-04-oq-02/knowledge.md
@@ -6,16 +6,52 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Goal: Blichfeldt's theorem for an arbitrary full-rank ℤ-lattice Λ ⊆ ℝⁿ with the covolume
+threshold vol(S) > k·covol(Λ), and the corresponding general-lattice Minkowski convex body
+theorem.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **The parent already contains the lattice-parametric engine.**
+  `Proofs/MinkowskiTheoremOQ04.lean` proves `blichfeldt_general_lattice` (verified, 0-axiom):
+  for a basis `b`, `(k:ℝ≥0∞) * volume (ZSpan.fundamentalDomain b) < volume s` yields k+1
+  points with pairwise differences in `span ℤ (range b)`. The hard analytic step (the
+  covering-count integral identity `volume_eq_setLIntegral_indicator_tsum_lattice`) is also
+  already general. So the "open" child theorem, in its raw ℝ≥0∞ form, was in fact done.
+
+- **The genuine gap = the covolume-facing statement.** The parent's threshold uses the raw
+  ℝ≥0∞ fundamental-domain volume; the geometry-of-numbers standard (Cassels/Siegel) uses the
+  real covolume `ZLattice.covolume`. Bridging them is the new content, plus the general-lattice
+  Minkowski convex body theorem (parent has Minkowski only for ℤⁿ).
+
+- **Covolume bridge (Mathlib v4.26.0).**
+  `ZLattice.covolume L μ = μ.real F` (`ZLattice.covolume_eq_measure_fundamentalDomain`) for any
+  `IsAddFundamentalDomain L F μ`. For `L = span ℤ (range b)` use `ZSpan.isAddFundamentalDomain b
+  volume` (note: the *Submodule* version, not the `.toAddSubgroup` primed one, matches
+  covolume's `L : Submodule ℤ E`). `μ.real F = (μ F).toReal` is `measureReal_def`. Instances
+  `DiscreteTopology (span ℤ (range b))` and `IsZLattice ℝ (span ℤ (range b))`
+  (`instIsZLatticeRealSpan`) are found automatically for `[Finite ι]`.
+
+- **Finiteness of the fundamental-domain volume** is the one analytic fact needed:
+  `(Bornology.IsBounded.measure_lt_top (ZSpan.fundamentalDomain_isBounded b)).ne`. It makes
+  `ENNReal.ofReal ∘ toReal` the identity on `volume F`, giving
+  `(k:ℝ≥0∞)·volume F = ENNReal.ofReal (k·covol Λ)`.
+
+- **Threshold phrasing.** Stating the hypothesis as `ENNReal.ofReal (k·covol Λ) < volume s`
+  (rather than a real inequality with `(volume s).toReal`) is robust: when `volume s = ⊤` the
+  hypothesis is automatically satisfied and the theorem still holds, with no extra finiteness
+  assumption on S.
+
+- **Minkowski half-scaling is lattice-agnostic.** Scaling `T = (1/2)·S` acts on S, not Λ, so
+  the parent's ℤⁿ proof (`minkowski_from_blichfeldt`) transfers verbatim: measurability via the
+  doubling-map preimage, `Measure.addHaar_smul` + `(2⁻¹)ⁿ·2ⁿ = 1` ENNReal arithmetic, with the
+  constant `1` (= covol ℤⁿ) replaced by `volume (ZSpan.fundamentalDomain b)`.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Approach 2 (pull back to ℤⁿ via the basis linear map + Jacobian) was unnecessary: the parent's
+  already-general Move A made the direct covolume bridge far cheaper.

--- a/research/problems/minkowski-theorem-oq-04-oq-02/state.md
+++ b/research/problems/minkowski-theorem-oq-04-oq-02/state.md
@@ -1,25 +1,39 @@
 # Research State: minkowski-theorem-oq-04-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETE
 **Path**: full
-**Since**: 2026-06-30T22:21:47-07:00
-**Iteration**: 1
+**Since**: 2026-07-01
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Delivered the covolume-threshold forms of Blichfeldt and Minkowski for an arbitrary
+full-rank lattice. Verified, 0-axiom, 0-sorry.
 
 ## Active Approach
-None yet.
+Approach 1 (re-parametrize the parent's Path A) — but discovered the parent ALREADY
+contains the lattice-parametric engine `blichfeldt_general_lattice` (verified, 0-axiom,
+threshold in raw ℝ≥0∞ fundamental-domain volume). The genuine gap was the covolume-facing
+restatement + the general-lattice Minkowski convex body theorem. Built those as a child
+file importing the parent.
+
+## Deliverables (Proofs/MinkowskiTheoremOQ04OQ02.lean, 8 theorems / 206 lines)
+- `covolume_eq_toReal_volume_fundamentalDomain` — covol Λ = (volume F).toReal bridge
+- `natCast_mul_volume_fundamentalDomain` — (k:ℝ≥0∞)·volume F = ofReal(k·covol Λ)
+- `blichfeldt_general_lattice_covolume` — Blichfeldt, vol(S) > k·covol(Λ)
+- `blichfeldt_basic_lattice`, `blichfeldt_basic_lattice_covolume` — k=1 corollaries
+- `minkowski_lattice` — general-lattice Minkowski, threshold 2ⁿ·volume F
+- `minkowski_lattice_covolume` — general-lattice Minkowski, threshold 2ⁿ·covol(Λ)
+
+Directly answers open question #2 of parent minkowski-theorem-oq-04.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Complete: PR opened, gallery entry added. Release claim.

--- a/src/data/proofs/minkowski-theorem-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-mk04oq02-header",
+    "proofId": "minkowski-theorem-oq-04-oq-02",
+    "range": { "startLine": 5, "endLine": 46 },
+    "type": "concept",
+    "title": "Covolume-Threshold Geometry of Numbers",
+    "content": "The parent entry proves Blichfeldt's pigeonhole for a general lattice, but only with the threshold stated in the raw ℝ≥0∞-valued volume of the fundamental domain ZSpan.fundamentalDomain b. The geometry-of-numbers literature (Cassels, Siegel) instead states the threshold via the covolume covol(Λ) — the real number equal to the volume of one fundamental cell. This entry supplies that covolume form for both Blichfeldt (vol(S) > k·covol(Λ)) and Minkowski (vol(S) > 2ⁿ·covol(Λ)), and adds the general-lattice Minkowski convex body theorem the parent gives only for ℤⁿ. It directly answers open question #2 of the parent entry.",
+    "mathContext": "For Λ = span_ℤ(range b): **Blichfeldt** $\\mathrm{vol}(S) > k\\cdot\\mathrm{covol}(\\Lambda) \\Rightarrow k{+}1$ points of $S$ pairwise congruent mod $\\Lambda$; **Minkowski** $S$ convex + symmetric, $\\mathrm{vol}(S) > 2^n\\cdot\\mathrm{covol}(\\Lambda) \\Rightarrow$ a nonzero point of $\\Lambda$ in $S$.",
+    "significance": "key",
+    "relatedConcepts": ["geometry of numbers", "covolume", "ℤ-lattice", "Minkowski's convex body theorem", "Blichfeldt's theorem"],
+    "prerequisites": ["full-rank ℤ-lattices in ℝⁿ", "covolume of a lattice", "the parent Blichfeldt engine"]
+  },
+  {
+    "id": "ann-mk04oq02-bridge",
+    "proofId": "minkowski-theorem-oq-04-oq-02",
+    "range": { "startLine": 49, "endLine": 76 },
+    "type": "technique",
+    "title": "The ℝ≥0∞ ↔ ℝ Covolume Bridge",
+    "content": "ZLattice.covolume is a real number (a .toReal), while the parent's analytic argument lives in ℝ≥0∞. covolume_eq_toReal_volume_fundamentalDomain identifies covol(Λ) with (volume F).toReal via ZLattice.covolume_eq_measure_fundamentalDomain applied to ZSpan.isAddFundamentalDomain. Because the fundamental domain is bounded (ZSpan.fundamentalDomain_isBounded), its volume is finite, so ENNReal.ofReal and toReal are mutually inverse there — giving the arithmetic identity (k:ℝ≥0∞)·volume F = ENNReal.ofReal (k·covol(Λ)) in natCast_mul_volume_fundamentalDomain.",
+    "mathContext": "$\\mathrm{covol}(\\Lambda) = (\\mathrm{vol}\\,F).\\mathrm{toReal}$ and, since $\\mathrm{vol}\\,F < \\infty$, $(k:\\mathbb{R}_{\\ge 0}^\\infty)\\cdot\\mathrm{vol}\\,F = \\mathrm{ofReal}(k\\cdot\\mathrm{covol}\\,\\Lambda)$.",
+    "significance": "important",
+    "relatedConcepts": ["ZLattice.covolume", "ENNReal.ofReal", "fundamental domain volume", "boundedness"],
+    "prerequisites": ["ℝ≥0∞ arithmetic", "finiteness of bounded-set volume"]
+  },
+  {
+    "id": "ann-mk04oq02-blichfeldt",
+    "proofId": "minkowski-theorem-oq-04-oq-02",
+    "range": { "startLine": 79, "endLine": 128 },
+    "type": "theorem",
+    "title": "Blichfeldt in Covolume Form",
+    "content": "blichfeldt_general_lattice_covolume states Blichfeldt's theorem for an arbitrary full-rank lattice with the covolume threshold, and reduces in three lines to the parent's verified blichfeldt_general_lattice by rewriting the hypothesis through the covolume bridge. The k=1 corollaries blichfeldt_basic_lattice (fundamental-domain-volume form) and blichfeldt_basic_lattice_covolume extract a single lattice-related pair.",
+    "mathContext": "$\\mathrm{vol}(S) > k\\cdot\\mathrm{covol}(\\Lambda) \\Rightarrow \\exists\\,\\mathrm{pts}:\\mathrm{Fin}(k{+}1)\\hookrightarrow S,\\ \\forall i,j,\\ \\mathrm{pts}\\,i-\\mathrm{pts}\\,j\\in\\Lambda$.",
+    "significance": "key",
+    "relatedConcepts": ["Blichfeldt's theorem", "covolume", "pigeonhole principle"],
+    "prerequisites": ["parent blichfeldt_general_lattice", "covolume bridge"]
+  },
+  {
+    "id": "ann-mk04oq02-minkowski",
+    "proofId": "minkowski-theorem-oq-04-oq-02",
+    "range": { "startLine": 129, "endLine": 205 },
+    "type": "theorem",
+    "title": "Minkowski's Convex Body Theorem for a General Lattice",
+    "content": "minkowski_lattice proves the classical Minkowski convex body theorem for an arbitrary full-rank lattice via the half-scaling T = (1/2)·S: measurability of T comes from the doubling-map preimage, and vol(T) = (1/2)ⁿ·vol(S) from Measure.addHaar_smul, so the hypothesis 2ⁿ·volume F < vol(S) becomes volume F < vol(T); blichfeldt_basic_lattice then yields a ≠ b ∈ T with a − b ∈ Λ, and central symmetry + convexity place a − b in S. minkowski_lattice_covolume restates the threshold as vol(S) > 2ⁿ·covol(Λ), the classical Cassels III.2 form. The half-scaling is lattice-agnostic: it acts on S, not Λ, so the ℤⁿ arithmetic (2⁻¹)ⁿ·2ⁿ = 1 carries over verbatim with the constant 1 replaced by volume F.",
+    "mathContext": "$S$ convex, centrally symmetric, $\\mathrm{vol}(S) > 2^n\\cdot\\mathrm{covol}(\\Lambda) \\Rightarrow \\exists\\, p\\in S\\cap\\Lambda,\\ p\\ne 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Minkowski's convex body theorem", "half-scaling", "central symmetry", "convexity", "covolume"],
+    "prerequisites": ["blichfeldt_basic_lattice", "Measure.addHaar_smul", "convexity + central symmetry"]
+  }
+]

--- a/src/data/proofs/minkowski-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-02/meta.json
@@ -1,0 +1,258 @@
+{
+  "id": "minkowski-theorem-oq-04-oq-02",
+  "title": "Blichfeldt & Minkowski for an Arbitrary Lattice: the Covolume Threshold",
+  "slug": "minkowski-theorem-oq-04-oq-02",
+  "description": "Covolume-threshold form of Blichfeldt's theorem and Minkowski's convex body theorem for an arbitrary full-rank ℤ-lattice Λ = span_ℤ(range b) ⊆ ℝⁿ. Blichfeldt: vol(S) > k·covol(Λ) ⇒ k+1 points of S with pairwise differences in Λ. Minkowski: a convex, centrally-symmetric S with vol(S) > 2ⁿ·covol(Λ) contains a nonzero lattice point. This is the geometry-of-numbers (Cassels/Siegel) form used in number-theoretic applications; it directly answers open question #2 of the parent entry minkowski-theorem-oq-04.",
+  "meta": {
+    "id": "minkowski-theorem-oq-04-oq-02",
+    "title": "Blichfeldt & Minkowski for an Arbitrary Lattice: the Covolume Threshold",
+    "slug": "minkowski-theorem-oq-04-oq-02",
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Blichfeldt%27s_theorem",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MinkowskiTheoremOQ04OQ02.lean",
+    "tags": [
+      "number-theory",
+      "geometry",
+      "lattice",
+      "geometry-of-numbers",
+      "measure-theory",
+      "blichfeldt",
+      "minkowski",
+      "covolume"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 206,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "assumptions": "None. The file is textually 0-axiom (no `axiom` declarations, no structure-encoded assumptions) and 0-sorry, and uses no `native_decide`. It reduces to the parent entry's verified engine `BlichfeldtTheorem.blichfeldt_general_lattice` (already proved lattice-parametrically) plus the Mathlib `ZLattice.covolume` API. Docker build verified clean against Lean 4.26.0 / Mathlib 4.26.0.",
+    "dateAdded": "2026-07-01",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZLattice.covolume",
+        "description": "The covolume of a ℤ-lattice as a real number: (volume of a fundamental domain).toReal",
+        "module": "Mathlib.Algebra.Module.ZLattice.Covolume"
+      },
+      {
+        "theorem": "ZLattice.covolume_eq_measure_fundamentalDomain",
+        "description": "covolume L μ = μ.real F for any additive fundamental domain F of L — the bridge from covolume to the fundamental-domain volume",
+        "module": "Mathlib.Algebra.Module.ZLattice.Covolume"
+      },
+      {
+        "theorem": "ZSpan.isAddFundamentalDomain",
+        "description": "The half-open parallelepiped ZSpan.fundamentalDomain b is an additive fundamental domain for span ℤ (range b)",
+        "module": "Mathlib.Algebra.Module.ZLattice.Basic"
+      },
+      {
+        "theorem": "ZSpan.fundamentalDomain_isBounded",
+        "description": "The lattice fundamental domain is bounded, hence has finite volume — needed to bridge ℝ≥0∞ volume and ℝ covolume",
+        "module": "Mathlib.Algebra.Module.ZLattice.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.Measure.addHaar_smul",
+        "description": "Scaling law volume(c • s) = |c|^n · volume s for the Lebesgue measure — the half-scaling step in the Minkowski reduction",
+        "module": "Mathlib.MeasureTheory.Measure.Haar.Basic"
+      },
+      {
+        "theorem": "BlichfeldtTheorem.blichfeldt_general_lattice",
+        "description": "The parent's verified lattice-parametric Blichfeldt engine (threshold in raw ℝ≥0∞ fundamental-domain volume), reused as a black box",
+        "module": "Proofs.MinkowskiTheoremOQ04"
+      }
+    ],
+    "originalContributions": [
+      "covolume_eq_toReal_volume_fundamentalDomain: the bridge ZLattice.covolume (span ℤ (range b)) volume = (volume (ZSpan.fundamentalDomain b)).toReal, via ZLattice.covolume_eq_measure_fundamentalDomain applied to ZSpan.isAddFundamentalDomain and measureReal_def.",
+      "natCast_mul_volume_fundamentalDomain: the arithmetic identity (k : ℝ≥0∞) · volume F = ENNReal.ofReal (k · covol Λ), bridging the parent's ℝ≥0∞ threshold to the real covolume threshold using finiteness of the fundamental-domain volume (volume_fundamentalDomain_ne_top).",
+      "blichfeldt_general_lattice_covolume: Blichfeldt's theorem for an arbitrary full-rank lattice in the covolume form vol(S) > k · covol(Λ) ⇒ k+1 points with pairwise differences in Λ. Reduces to the parent's blichfeldt_general_lattice via the arithmetic bridge.",
+      "blichfeldt_basic_lattice and blichfeldt_basic_lattice_covolume: the k = 1 corollaries (fundamental-domain-volume form and covolume form), extracting a single lattice-related pair.",
+      "minkowski_lattice: Minkowski's convex body theorem for an arbitrary full-rank lattice — a measurable, convex, centrally-symmetric S with vol(S) > 2ⁿ · volume(ZSpan.fundamentalDomain b) contains a nonzero lattice point. Proved by half-scaling T = (1/2)·S and applying blichfeldt_basic_lattice, mirroring the parent's minkowski_from_blichfeldt with the covolume-1 constant replaced by the general fundamental-domain volume.",
+      "minkowski_lattice_covolume: the covolume-threshold form vol(S) > 2ⁿ · covol(Λ) — the classical geometry-of-numbers statement (Cassels III.2) used in number-theoretic applications (ideal-lattice bounds via the Minkowski embedding, whose covolume is 2^{-r₂}√|d_K|).",
+      "Directly resolves open question #2 of the parent entry minkowski-theorem-oq-04: 'Can the statement extend from ℤⁿ to an arbitrary full-rank ℤ-lattice Λ with covolume V, replacing the threshold vol(S) > k with vol(S) > k·V?'"
+    ],
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "Full-rank ℤ-lattices in ℝⁿ and their fundamental domains (ZSpan.fundamentalDomain)",
+      "The covolume of a lattice (ZLattice.covolume) as the volume of a fundamental domain",
+      "Lebesgue measure on ℝⁿ and its scaling law (Measure.addHaar_smul)",
+      "Blichfeldt's theorem for ℤⁿ and its lattice-parametric form (parent entry minkowski-theorem-oq-04)"
+    ],
+    "relatedProofs": [
+      "minkowski-theorem-oq-04",
+      "minkowski-fundamental-theorem",
+      "minkowski-theorem-oq-02"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The geometry-of-numbers literature (Blichfeldt 1914; Cassels 1959, ch. III; Siegel 1989) always states Blichfeldt's and Minkowski's theorems for a general lattice Λ rather than only the standard integer lattice ℤⁿ, because the applications — simultaneous Diophantine approximation, transference theorems, and above all bounds for ideal lattices in algebraic number theory via the Minkowski embedding of a ring of integers (whose covolume is 2^{-r₂}√|d_K|) — require lattices that are not ℤⁿ. The natural threshold for the general statement replaces the unit volume of the ℤⁿ-cube by the covolume V = covol(Λ) of the (skewed) fundamental parallelepiped.",
+    "problemStatement": "For a full-rank ℤ-lattice Λ = span_ℤ(range b) ⊆ ℝⁿ with covolume V:\n\n**Blichfeldt (covolume form):** if S ⊆ ℝⁿ is measurable with vol(S) > k·V, then S contains k+1 distinct points whose pairwise differences all lie in Λ.\n\n**Minkowski (covolume form):** if S is additionally convex and centrally symmetric with vol(S) > 2ⁿ·V, then S contains a nonzero point of Λ.",
+    "text": "A verified, 0-axiom child of minkowski-theorem-oq-04. The parent already proves the lattice-parametric Blichfeldt pigeonhole blichfeldt_general_lattice, but only with the threshold stated in the raw ℝ≥0∞-valued volume of ZSpan.fundamentalDomain b. This entry supplies the geometry-of-numbers covolume-threshold form (using Mathlib's ZLattice.covolume) and the general-lattice Minkowski convex body theorem, which the parent provides only for ℤⁿ. The mathematically substantive work — the covering-count integral identity and the contrapose pigeonhole — is inherited from the parent; the new content is the ℝ≥0∞ ↔ ℝ covolume bridge and the half-scaling Minkowski reduction re-run over a general fundamental domain.",
+    "proofStrategy": "**Covolume bridge.** ZLattice.covolume (span ℤ (range b)) volume equals (volume (ZSpan.fundamentalDomain b)).toReal by ZLattice.covolume_eq_measure_fundamentalDomain applied to the fundamental-domain property ZSpan.isAddFundamentalDomain. Since the fundamental domain is bounded (ZSpan.fundamentalDomain_isBounded) its volume is finite, so ENNReal.ofReal and toReal are mutually inverse there, giving (k : ℝ≥0∞) · volume F = ENNReal.ofReal (k · covol Λ).\n\n**Blichfeldt (covolume).** Feed the bridge into the parent's blichfeldt_general_lattice: the covolume hypothesis ENNReal.ofReal (k · covol Λ) < vol(S) rewrites to the parent's (k : ℝ≥0∞) · volume F < vol(S).\n\n**Minkowski (covolume).** Half-scale T = (1/2)·S: measurability via the doubling-map preimage, and vol(T) = (1/2)ⁿ·vol(S) via Measure.addHaar_smul. The hypothesis 2ⁿ·volume F < vol(S) becomes volume F < vol(T), so blichfeldt_basic_lattice yields a ≠ b ∈ T with a − b ∈ Λ; central symmetry and convexity of S place a − b = (x₀ − y₀)/2 in S, giving a nonzero lattice point. Finally the covolume bridge converts the threshold to 2ⁿ·covol(Λ).",
+    "keyInsights": [
+      "The mathematically hard step — the covering-count integral identity ∫_F Σ'_g 1_S((g:ℝⁿ)+x) dx = vol(S) for a general basis — was already proved in the parent (volume_eq_setLIntegral_indicator_tsum_lattice), so generalizing from ℤⁿ to Λ costs essentially only the ℝ≥0∞ ↔ ℝ covolume bookkeeping.",
+      "covolume lives in ℝ (it is a .toReal) while the analytic argument lives in ℝ≥0∞; the clean way to state the threshold is ENNReal.ofReal (k · covol Λ) < vol(S), which is robust even when vol(S) = ∞ and needs no separate finiteness hypothesis on S.",
+      "Finiteness of the fundamental-domain volume (from boundedness) is the one genuine analytic fact the covolume bridge needs: it makes ENNReal.ofReal ∘ toReal the identity on volume F.",
+      "The Minkowski half-scaling trick is lattice-agnostic: scaling acts on the set S, not the lattice, so the same (2⁻¹)ⁿ·2ⁿ = 1 ENNReal arithmetic that recovers Minkowski for ℤⁿ recovers it verbatim for a general Λ once the threshold constant 1 is replaced by volume F."
+    ],
+    "prerequisites": [
+      "ℤ-lattices span_ℤ(range b) ⊆ ℝⁿ and the fundamental domain ZSpan.fundamentalDomain b",
+      "ZLattice.covolume and its identity with the fundamental-domain volume",
+      "Lebesgue measure, its scaling law, and ℝ≥0∞/ℝ conversions (ENNReal.ofReal, toReal)",
+      "The parent's Blichfeldt engine blichfeldt_general_lattice"
+    ]
+  },
+  "sections": [
+    {
+      "id": "covolume-bridge",
+      "title": "The Covolume Bridge",
+      "startLine": 49,
+      "endLine": 76,
+      "summary": "volume_fundamentalDomain_ne_top (finiteness of the fundamental-domain volume, from boundedness), covolume_eq_toReal_volume_fundamentalDomain (covol Λ = (volume F).toReal), and natCast_mul_volume_fundamentalDomain ((k:ℝ≥0∞)·volume F = ENNReal.ofReal (k·covol Λ)) — the three lemmas that translate between the parent's ℝ≥0∞ threshold and the real covolume threshold.",
+      "mathContext": "ZLattice.covolume L μ is defined as (addCovolume L E μ).toReal and equals μ.real F for any fundamental domain F. For F = ZSpan.fundamentalDomain b (bounded, hence finite volume) this makes covolume the honest real volume of the parallelepiped, and ENNReal.ofReal ∘ toReal the identity there."
+    },
+    {
+      "id": "blichfeldt-covolume",
+      "title": "Blichfeldt in Covolume Form",
+      "startLine": 77,
+      "endLine": 128,
+      "summary": "blichfeldt_general_lattice_covolume (vol(S) > k·covol(Λ) ⇒ k+1 points with pairwise differences in Λ) and the k=1 corollaries blichfeldt_basic_lattice and blichfeldt_basic_lattice_covolume. Each reduces to the parent's blichfeldt_general_lattice through the covolume bridge.",
+      "mathContext": "This is the geometry-of-numbers statement of Blichfeldt's pigeonhole for an arbitrary full-rank lattice: the volume threshold is k times the covolume, the volume of one fundamental cell."
+    },
+    {
+      "id": "minkowski-covolume",
+      "title": "Minkowski's Convex Body Theorem for a General Lattice",
+      "startLine": 129,
+      "endLine": 205,
+      "summary": "minkowski_lattice (convex, centrally-symmetric S with vol(S) > 2ⁿ·volume F ⇒ nonzero lattice point) via half-scaling T = (1/2)·S and blichfeldt_basic_lattice, and minkowski_lattice_covolume (the covolume-threshold restatement vol(S) > 2ⁿ·covol(Λ)).",
+      "mathContext": "Minkowski's classical convex body theorem in its general-lattice form (Cassels III.2): the sharp volume threshold for forcing a nonzero lattice point in a symmetric convex body is 2ⁿ times the covolume. The half-scaling reduction to Blichfeldt is identical to the ℤⁿ case, with the covolume replacing 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "A verified, 0-axiom, 0-sorry Lean 4 formalization (8 theorems, 206 lines) giving the covolume-threshold forms of Blichfeldt's theorem and Minkowski's convex body theorem for an arbitrary full-rank ℤ-lattice Λ = span_ℤ(range b) ⊆ ℝⁿ. It reuses the parent entry's verified lattice-parametric Blichfeldt engine and the Mathlib ZLattice.covolume API, contributing (i) the ℝ≥0∞ ↔ ℝ covolume bridge, (ii) Blichfeldt in the form vol(S) > k·covol(Λ), (iii) the k=1 corollaries, and (iv) Minkowski's convex body theorem for a general lattice with threshold vol(S) > 2ⁿ·covol(Λ). This directly answers open question #2 of the parent entry.",
+    "implications": "The covolume-threshold Minkowski theorem is the exact building block used across analytic and algebraic number theory: bounding the shortest vector of an ideal lattice (via the Minkowski embedding, covolume 2^{-r₂}√|d_K|), proving the finiteness of the class group, and Diophantine transference theorems. Having it in verified form for an arbitrary lattice removes the ℤⁿ-normalization that the parent entry imposed.",
+    "openQuestions": [
+      "Can the k+1-point Minkowski form (k · 2ⁿ · covol threshold) and the pairwise-nonzero / Finset repackagings — all present for ℤⁿ in the parent — be lifted to the general lattice as cheap corollaries of blichfeldt_general_lattice_covolume?",
+      "Can the covolume threshold be phrased and proved directly over an abstract IsZLattice L (via Free.chooseBasis) rather than over an explicitly chosen basis b, so the statement no longer mentions a basis at all?",
+      "Does the covolume form specialize back to the parent's ℤⁿ statement by b := stdBasis n with covol = 1, giving a machine-checked consistency link between the two entries?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "minkowski-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry. Provides the verified lattice-parametric engine blichfeldt_general_lattice (and volume_eq_setLIntegral_indicator_tsum_lattice). This child adds the covolume-threshold restatement and the general-lattice Minkowski convex body theorem, answering the parent's open question #2."
+    },
+    {
+      "targetId": "minkowski-fundamental-theorem",
+      "relationship": "related",
+      "description": "Source of the standard-lattice covolume-1 fundamental domain; the covolume form here specializes to it at b := stdBasis n."
+    },
+    {
+      "targetId": "minkowski-theorem-oq-02",
+      "relationship": "related",
+      "description": "Sibling Minkowski OQ (Dirichlet approximation); a consumer of covolume-parametric Minkowski for lattices other than ℤⁿ."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/MinkowskiTheoremOQ04OQ02.lean",
+    "imports": [
+      "Mathlib.Algebra.Module.ZLattice.Covolume",
+      "Proofs.MinkowskiTheoremOQ04",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "BlichfeldtTheorem",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 206,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "blichfeldt_general_lattice_covolume",
+        "type": "proved",
+        "description": "Blichfeldt for an arbitrary full-rank lattice, covolume form: vol(S) > k·covol(Λ) ⇒ k+1 distinct points of S with all pairwise differences in Λ = span ℤ (range b).",
+        "leanType": "{n : ℕ} [NeZero n] (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) (k : ℕ) (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s) (h_vol : ENNReal.ofReal ((k:ℝ) * ZLattice.covolume (Submodule.span ℤ (Set.range b)) volume) < volume s) → ∃ pts : Fin (k+1) → Fin n → ℝ, Function.Injective pts ∧ (∀ i, pts i ∈ s) ∧ ∀ i j, pts i - pts j ∈ (Submodule.span ℤ (Set.range b) : Set (Fin n → ℝ))"
+      },
+      {
+        "name": "covolume_eq_toReal_volume_fundamentalDomain",
+        "type": "proved",
+        "description": "Covolume bridge: ZLattice.covolume (span ℤ (range b)) volume = (volume (ZSpan.fundamentalDomain b)).toReal.",
+        "leanType": "{n : ℕ} [NeZero n] (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) → ZLattice.covolume (Submodule.span ℤ (Set.range b)) volume = (volume (ZSpan.fundamentalDomain b)).toReal"
+      },
+      {
+        "name": "blichfeldt_basic_lattice",
+        "type": "proved",
+        "description": "k=1 Blichfeldt for an arbitrary lattice: volume(ZSpan.fundamentalDomain b) < vol(S) ⇒ two distinct points of S differing by a lattice vector.",
+        "leanType": "{n : ℕ} [NeZero n] (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s) (h_vol : volume (ZSpan.fundamentalDomain b) < volume s) → ∃ x y, x ∈ s ∧ y ∈ s ∧ x ≠ y ∧ x - y ∈ (Submodule.span ℤ (Set.range b) : Set (Fin n → ℝ))"
+      },
+      {
+        "name": "minkowski_lattice",
+        "type": "proved",
+        "description": "Minkowski's convex body theorem for an arbitrary full-rank lattice: a measurable, convex, centrally-symmetric S with vol(S) > 2ⁿ·volume(ZSpan.fundamentalDomain b) contains a nonzero lattice point.",
+        "leanType": "{n : ℕ} [NeZero n] (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s) (h_symm : ∀ x ∈ s, -x ∈ s) (h_conv : Convex ℝ s) (h_vol : (2:ENNReal)^n * volume (ZSpan.fundamentalDomain b) < volume s) → ∃ p : (Submodule.span ℤ (Set.range b)).toAddSubgroup, p ≠ 0 ∧ (p : Fin n → ℝ) ∈ s"
+      },
+      {
+        "name": "minkowski_lattice_covolume",
+        "type": "proved",
+        "description": "Minkowski's convex body theorem for an arbitrary lattice, covolume form: vol(S) > 2ⁿ·covol(Λ) ⇒ nonzero lattice point (the classical Cassels III.2 statement).",
+        "leanType": "{n : ℕ} [NeZero n] (b : Module.Basis (Fin n) ℝ (Fin n → ℝ)) (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s) (h_symm : ∀ x ∈ s, -x ∈ s) (h_conv : Convex ℝ s) (h_vol : ENNReal.ofReal ((2:ℝ)^n * ZLattice.covolume (Submodule.span ℤ (Set.range b)) volume) < volume s) → ∃ p : (Submodule.span ℤ (Set.range b)).toAddSubgroup, p ≠ 0 ∧ (p : Fin n → ℝ) ∈ s"
+      }
+    ],
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiTheoremOQ04OQ02.lean"
+  },
+  "references": [
+    {
+      "authors": "Blichfeldt, Hans Frederik",
+      "title": "A new principle in the geometry of numbers, with some applications",
+      "year": "1914",
+      "venue": "Transactions of the American Mathematical Society 15(3), pp. 227–235",
+      "note": "Original publication, stated for a general lattice"
+    },
+    {
+      "authors": "Cassels, J. W. S.",
+      "title": "An Introduction to the Geometry of Numbers",
+      "year": "1959",
+      "venue": "Springer, Grundlehren der mathematischen Wissenschaften 99",
+      "note": "Chapter III: general-lattice Blichfeldt and Minkowski, covolume threshold"
+    },
+    {
+      "authors": "Siegel, Carl Ludwig",
+      "title": "Lectures on the Geometry of Numbers",
+      "year": "1989",
+      "venue": "Springer",
+      "note": "Covolume / fundamental-domain formulation"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "blichfeldt_general_lattice_covolume",
+      "type": "core",
+      "statement": "$\\mathrm{vol}(S) > k \\cdot \\mathrm{covol}(\\Lambda) \\Rightarrow \\exists\\, \\mathrm{pts} : \\mathrm{Fin}(k{+}1) \\hookrightarrow S,\\;\\; \\forall i,j,\\; \\mathrm{pts}\\,i - \\mathrm{pts}\\,j \\in \\Lambda$",
+      "significance": "Blichfeldt's theorem for an arbitrary full-rank lattice in the geometry-of-numbers covolume form. Answers open question #2 of the parent entry. Reduces to the parent's verified blichfeldt_general_lattice through the covolume bridge natCast_mul_volume_fundamentalDomain.",
+      "description": "Covolume-threshold Blichfeldt for a general lattice Λ = span_ℤ(range b)."
+    },
+    {
+      "name": "minkowski_lattice_covolume",
+      "type": "core",
+      "statement": "$S$ convex, centrally symmetric, $\\mathrm{vol}(S) > 2^n \\cdot \\mathrm{covol}(\\Lambda) \\Rightarrow \\exists\\, p \\in S \\cap \\Lambda,\\; p \\ne 0$",
+      "significance": "Minkowski's convex body theorem for an arbitrary full-rank lattice — the classical Cassels III.2 statement and the workhorse of algebraic-number-theory lattice bounds. The parent proves this only for ℤⁿ (covolume 1).",
+      "description": "Covolume-threshold Minkowski convex body theorem for a general lattice."
+    },
+    {
+      "name": "covolume_eq_toReal_volume_fundamentalDomain",
+      "type": "supporting",
+      "statement": "$\\mathrm{covol}(\\Lambda) = (\\mathrm{vol}(\\mathrm{ZSpan.fundamentalDomain}\\,b)).\\mathrm{toReal}$",
+      "significance": "The bridge lemma identifying Mathlib's real-valued ZLattice.covolume with the toReal of the ℝ≥0∞-valued fundamental-domain volume that the parent's threshold uses. Requires finiteness of the fundamental-domain volume (boundedness).",
+      "description": "Identifies covolume with the toReal of the fundamental-domain volume."
+    },
+    {
+      "name": "minkowski_lattice",
+      "type": "core",
+      "statement": "$S$ convex, centrally symmetric, $\\mathrm{vol}(S) > 2^n \\cdot \\mathrm{vol}(F) \\Rightarrow \\exists\\, p \\in S \\cap \\Lambda,\\; p \\ne 0$",
+      "significance": "Minkowski's convex body theorem for a general lattice, fundamental-domain-volume form. Proved by half-scaling T = (1/2)·S and blichfeldt_basic_lattice, mirroring the parent's ℤⁿ reduction with the constant 1 replaced by volume F.",
+      "description": "General-lattice Minkowski via half-scaling to Blichfeldt."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New **verified, 0-axiom** child of `minkowski-theorem-oq-04`, directly answering that entry's **open question #2**: extending Blichfeldt's theorem (and Minkowski's convex body theorem) from the standard lattice ℤⁿ to an arbitrary full-rank ℤ-lattice `Λ = span_ℤ(range b) ⊆ ℝⁿ` with the **covolume threshold** `vol(S) > k · covol(Λ)`.

`Proofs/MinkowskiTheoremOQ04OQ02.lean` — 8 theorems / 206 lines, 0 sorries, 0 `axiom` declarations, no `native_decide`. `#print axioms` on all four main results shows only `propext`, `Classical.choice`, `Quot.sound`.

## What's new vs. the parent

The parent already proves the lattice-parametric Blichfeldt engine `blichfeldt_general_lattice`, but only with the threshold stated in the raw ℝ≥0∞-valued volume of `ZSpan.fundamentalDomain b`. This child adds the geometry-of-numbers **covolume** form (Cassels/Siegel) and the general-lattice **Minkowski convex body theorem** (the parent gives Minkowski only for ℤⁿ):

- `covolume_eq_toReal_volume_fundamentalDomain` — the bridge `ZLattice.covolume Λ = (volume F).toReal`
- `natCast_mul_volume_fundamentalDomain` — `(k:ℝ≥0∞)·volume F = ENNReal.ofReal (k·covol Λ)`
- `blichfeldt_general_lattice_covolume` — `vol(S) > k·covol(Λ) ⇒ k+1` points of S with pairwise differences in Λ
- `blichfeldt_basic_lattice`, `blichfeldt_basic_lattice_covolume` — the `k = 1` corollaries
- `minkowski_lattice` — Minkowski's convex body theorem for a general lattice (threshold `2ⁿ·volume F`)
- `minkowski_lattice_covolume` — the same with threshold `2ⁿ·covol(Λ)` (classical Cassels III.2 form)

## Proof approach

Reduces to the parent's verified engine plus the Mathlib `ZLattice.covolume` API. The only genuinely new analytic fact is finiteness of the (bounded) fundamental-domain volume, which makes `ENNReal.ofReal ∘ toReal` the identity there and bridges the ℝ≥0∞ threshold to the real covolume. The Minkowski half-scaling `T = (1/2)·S` is lattice-agnostic and mirrors the parent's ℤⁿ reduction with the covolume-1 constant replaced by `volume(ZSpan.fundamentalDomain b)`.

## Verification

Docker build clean against Lean 4.26.0 / Mathlib 4.26.0 (`✔ Built Proofs.MinkowskiTheoremOQ04OQ02`, 3085 jobs, no warnings/errors in the new file). Axiom check confirms 0 substantive axioms.

Includes the gallery entry (`meta.json` + `annotations.json`) and research notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
