### PR TITLE
Enrich harmonic-divergence-oq-06-oq-02: add missing index.ts + finer annotations

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-06-oq-02/annotations.json
@@ -53,22 +53,68 @@
     "proofId": "harmonic-divergence-oq-06-oq-02",
     "range": {
       "startLine": 63,
-      "endLine": 95
+      "endLine": 73
     },
     "type": "theorem",
-    "title": "Unified b ≥ 0 Statement and Corollaries",
-    "content": "not_summable_one_div_arith' (a b : ℝ) (ha : 0 < a) (hb : 0 ≤ b): ¬ Summable (fun n => 1/(a·n+b)). The proof splits 0 ≤ b into b > 0 (dispatched to the parent not_summable_one_div_arith) and b = 0 (dispatched to not_summable_one_div_scaled after simplifying a·n+0 = a·n). Three corollaries follow: not_summable_one_div_multiples (reciprocals of positive multiples of a, index-shifted); not_summable_harmonic (a = 1, b = 0 recovers Σ 1/n); and tendsto_sum_one_div_scaled_atTop (partial sums Σ_{i<n} 1/(a·(i+1)) → +∞ via not_summable_iff_tendsto_nat_atTop_of_nonneg).",
-    "mathContext": "A single case split unifies the family $a>0,\\ b\\ge 0$; the endpoint $b=0$ is the pure 'multiples of $a$' series, and $a=1,b=0$ is the raw harmonic series.",
+    "title": "Unified b ≥ 0 Statement",
+    "content": "not_summable_one_div_arith' (a b : ℝ) (ha : 0 < a) (hb : 0 ≤ b): ¬ Summable (fun n => 1/(a·n+b)). The proof splits 0 ≤ b (via hb.lt_or_eq) into b > 0 — dispatched verbatim to the parent not_summable_one_div_arith — and b = 0, where subst reduces the goal to Σ 1/(a·n+0); simpa collapses a·n+0 = a·n and hands off to not_summable_one_div_scaled. A single theorem now subsumes the parent (b > 0) and the endpoint (b = 0) across the whole family a > 0, b ≥ 0.",
+    "mathContext": "A single case split unifies the family $a>0,\\ b\\ge 0$: the interior $b>0$ is the parent's comparison argument, the boundary $b=0$ is the pure 'multiples of $a$' series.",
     "significance": "standard",
     "relatedConcepts": [
       "case split",
       "arithmetic progression",
-      "partial sums",
-      "divergence to infinity"
+      "endpoint / boundary case",
+      "theorem unification"
     ],
     "prerequisites": [
       "not_summable_one_div_arith (parent)",
-      "not_summable_iff_tendsto_nat_atTop_of_nonneg"
+      "LE.le.lt_or_eq (trichotomy on 0 ≤ b)"
+    ]
+  },
+  {
+    "id": "ann-hdoq06oq02-corollaries",
+    "proofId": "harmonic-divergence-oq-06-oq-02",
+    "range": {
+      "startLine": 75,
+      "endLine": 86
+    },
+    "type": "theorem",
+    "title": "Corollaries: Positive Multiples and the Raw Harmonic Series",
+    "content": "Two immediate consequences of the b = 0 core. not_summable_one_div_multiples (a : ℝ) (ha : 0 < a): ¬ Summable (fun n => 1/(a·(n+1))) — the reciprocals of the positive multiples of a, indexed so the first term is 1/a; proved by shifting back to Σ 1/(a·n) with summable_nat_add_iff and applying not_summable_one_div_scaled. not_summable_harmonic: ¬ Summable (fun n => 1/n) — the raw harmonic series recovered as the a = 1, b = 0 instance, via simpa on not_summable_one_div_scaled 1.",
+    "mathContext": "$\\sum_{n\\ge 0} 1/(a(n+1)) = (1/a)\\sum_{k\\ge 1} 1/k$; setting $a=1$ gives back $\\sum 1/n$, the series everything reduces to.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "index shift",
+      "positive multiples of a",
+      "harmonic series",
+      "specialization"
+    ],
+    "prerequisites": [
+      "not_summable_one_div_scaled",
+      "summable_nat_add_iff"
+    ]
+  },
+  {
+    "id": "ann-hdoq06oq02-tendsto",
+    "proofId": "harmonic-divergence-oq-06-oq-02",
+    "range": {
+      "startLine": 88,
+      "endLine": 95
+    },
+    "type": "technique",
+    "title": "Explicit Divergence: Partial Sums Tend to +∞",
+    "content": "tendsto_sum_one_div_scaled_atTop (a : ℝ) (ha : 0 < a): the partial sums Σ_{i<n} 1/(a·(i+1)) tend to atTop. Because the terms are nonnegative (positivity discharges 0 ≤ 1/(a·(i+1))), not_summable_iff_tendsto_nat_atTop_of_nonneg converts non-summability into an honest limit statement; the non-summability itself is not_summable_one_div_multiples. This is the concrete 'the running total blows up' form of the abstract ¬ Summable claim.",
+    "mathContext": "For nonnegative terms, $\\neg\\,\\text{Summable}\\,f \\iff \\sum_{i<n} f(i) \\to +\\infty$; here $f(i) = 1/(a(i+1)) \\ge 0$, so the partial sums diverge to $+\\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "partial sums",
+      "divergence to infinity",
+      "nonnegative terms",
+      "monotone convergence"
+    ],
+    "prerequisites": [
+      "not_summable_iff_tendsto_nat_atTop_of_nonneg",
+      "not_summable_one_div_multiples"
     ]
   }
 ]

--- a/src/data/proofs/harmonic-divergence-oq-06-oq-02/index.ts
+++ b/src/data/proofs/harmonic-divergence-oq-06-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HarmonicDivergenceOQ06OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const harmonicDivergenceOq06Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const harmonicDivergenceOq06Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const harmonicDivergenceOq06Oq02Data: ProofData = {
+  proof: harmonicDivergenceOq06Oq02Proof,
+  annotations: harmonicDivergenceOq06Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `harmonic-divergence-oq-06-oq-02`.

## Critical fix
- **Added the missing `index.ts`.** Without it, Vite's `import.meta.glob` cannot discover the proof and the page renders 'proof not found' on the live site despite the entry appearing in the gallery listing.

## Annotation improvements
- Split the single broad annotation covering lines 63–95 into three targeted blocks:
  1. **Unified b ≥ 0 statement** (`not_summable_one_div_arith'`) — case split on `hb.lt_or_eq`.
  2. **Corollaries** — positive multiples (`not_summable_one_div_multiples`) and the raw harmonic series (`not_summable_harmonic`).
  3. **Explicit divergence** — `tendsto_sum_one_div_scaled_atTop`, partial sums → +∞.
- Coverage now 5 annotation blocks, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

meta.json was already rich (13.9 KB) and is left intact.

> Note: this redoes enrichment that was lost when PR #32067's branch (`feature/enricher-1`) was force-updated to a later target before the deployer merged it — #32067 ended up merging the *erdos-895* commit under a harmonic-divergence title. This PR is on a distinct branch. Verified with `pnpm build`.