### PR TITLE
Enrich fibonacci-divisibility-oq-07: index.ts, conclusion, schema fixes

### DIFF
--- a/src/data/proofs/fibonacci-divisibility-oq-07/annotations.json
+++ b/src/data/proofs/fibonacci-divisibility-oq-07/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-fibdivoq07-1",
     "proofId": "fibonacci-divisibility-oq-07",
-    "range": { "startLine": 3, "endLine": 26 },
+    "range": {
+      "startLine": 3,
+      "endLine": 26
+    },
     "type": "concept",
     "title": "What Mathlib Has, and the m = 2 Wrinkle",
     "content": "**Framing.** Mathlib records the *forward* divisibility law $\\mathtt{Nat.fib\\_dvd}: m \\mid n \\to F_m \\mid F_n$ and the strong-divisibility identity $\\mathtt{Nat.fib\\_gcd}: F_{\\gcd(m,n)} = \\gcd(F_m, F_n)$, but neither the converse nor the biconditional. The naive iff $F_m \\mid F_n \\Leftrightarrow m \\mid n$ is **false** at exactly one index: because $F_1 = F_2 = 1$ and $1$ divides everything, $F_2 \\mid F_n$ holds for all $n$ while $2 \\mid n$ fails at $n = 1$. This file supplies the converse and pins $m = 2$ as the unique exception.",
@@ -17,12 +20,20 @@
       "The 0-indexed Fibonacci sequence Nat.fib",
       "Divisibility and gcd over ℕ"
     ],
-    "tags": ["module-header", "framing", "fibonacci", "divisibility"]
+    "tags": [
+      "module-header",
+      "framing",
+      "fibonacci",
+      "divisibility"
+    ]
   },
   {
     "id": "ann-fibdivoq07-2",
     "proofId": "fibonacci-divisibility-oq-07",
-    "range": { "startLine": 31, "endLine": 57 },
+    "range": {
+      "startLine": 33,
+      "endLine": 59
+    },
     "type": "proof-step",
     "title": "The Converse: from fib_gcd to Injectivity on [2, ∞)",
     "content": "**The mathematical heart of the entry.** For $m \\ge 3$, assume $F_m \\mid F_n$. By $\\mathtt{fib\\_gcd}$, $\\gcd(F_m, F_n) = F_{\\gcd(m,n)}$, and $\\mathtt{gcd\\_eq\\_left}$ collapses the left side to $F_m$ under the hypothesis, giving $F_{\\gcd(m,n)} = F_m$. Now $F_m \\ge F_3 = 2$ (monotonicity), so $\\gcd(m,n)$ is neither $0$ (where $F = 0$) nor $1$ (where $F = 1$); hence $\\gcd(m,n) \\ge 2$. On $[2,\\infty)$ the sequence $F$ is strictly monotone, so **injective**, and $F_{\\gcd(m,n)} = F_m$ upgrades to $\\gcd(m,n) = m$. Therefore $m = \\gcd(m,n) \\mid n$.",
@@ -37,12 +48,20 @@
       "fib (gcd m n) = gcd (fib m) (fib n)",
       "Strict monotonicity of fib on [2, ∞)"
     ],
-    "tags": ["converse", "gcd", "injectivity", "critical"]
+    "tags": [
+      "converse",
+      "gcd",
+      "injectivity",
+      "critical"
+    ]
   },
   {
     "id": "ann-fibdivoq07-3",
     "proofId": "fibonacci-divisibility-oq-07",
-    "range": { "startLine": 59, "endLine": 88 },
+    "range": {
+      "startLine": 61,
+      "endLine": 90
+    },
     "type": "theorem",
     "title": "The Biconditional and its Sharp Global Form",
     "content": "**$\\mathtt{fib\\_dvd\\_iff}$** packages the converse with Mathlib's forward $\\mathtt{Nat.fib\\_dvd}$ to give $F_m \\mid F_n \\Leftrightarrow m \\mid n$ for $m \\ge 3$. **$\\mathtt{fib\\_dvd\\_iff\\_forall}$** is the sharp statement: for a fixed $m$, the per-$n$ biconditional holds for *every* $n$ iff $m \\ne 2$. The exceptional direction instantiates $n = 1$ at $m = 2$ to derive $2 \\mid 1$; the converse direction splits $m \\ne 2$ into $m = 0$ (both sides $\\Leftrightarrow n = 0$), $m = 1$ (both sides vacuously true), and $m = k+3$.",
@@ -57,12 +76,20 @@
       "The converse dvd_of_fib_dvd_fib",
       "Mathlib's forward Nat.fib_dvd"
     ],
-    "tags": ["biconditional", "sharp", "characterization", "critical"]
+    "tags": [
+      "biconditional",
+      "sharp",
+      "characterization",
+      "critical"
+    ]
   },
   {
     "id": "ann-fibdivoq07-4",
     "proofId": "fibonacci-divisibility-oq-07",
-    "range": { "startLine": 90, "endLine": 105 },
+    "range": {
+      "startLine": 92,
+      "endLine": 108
+    },
     "type": "concept",
     "title": "Arithmetic Corollaries and the Sharpness Witness",
     "content": "Specializing the biconditional at $m = 3$ (with $F_3 = 2$) gives **$\\mathtt{two\\_dvd\\_fib\\_iff}$**: $F_n$ is even $\\Leftrightarrow 3 \\mid n$ — the exact 'every third Fibonacci number is even'. At $m = 4$ (with $F_4 = 3$), **$\\mathtt{three\\_dvd\\_fib\\_iff}$**: $3 \\mid F_n \\Leftrightarrow 4 \\mid n$. Finally **$\\mathtt{fib\\_two\\_exception}$** exhibits the concrete failure at the exceptional index: $F_2 \\mid F_1$ holds yet $2 \\nmid 1$, confirming that $m = 2$ genuinely must be excluded.",
@@ -77,6 +104,11 @@
       "The biconditional fib_dvd_iff",
       "fib 3 = 2 and fib 4 = 3"
     ],
-    "tags": ["corollary", "parity", "sharpness", "fibonacci"]
+    "tags": [
+      "corollary",
+      "parity",
+      "sharpness",
+      "fibonacci"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `fibonacci-divisibility-oq-07`.

## Fixes
- **Added the missing `index.ts`** — without it the proof isn't discoverable by Vite's `import.meta.glob` and the page renders 'proof not found'.
- **Fixed `sections` to the `ProofSection` schema.** The existing sections used a `content` field and had no line ranges; `ProofSection` requires `startLine`/`endLine`/`summary`. Rewrote each with accurate line ranges (from the 108-line Lean file), `summary`, and `mathContext`.
- **Converted `crossReferences` from a bare string array to `CrossReference` objects** (`proofId`/`relationship`/`description`) — the string form doesn't match the type consumed by `index.ts`.
- **Added a `conclusion`** (summary, implications, 3 openQuestions) — previously absent.
- Aligned the 4 annotation line ranges to the actual theorem boundaries.

meta.json is 13.9 KB (under the 60 KB cap). Content (overview, keyInsights, references framing) was already strong and is preserved. Verified with `pnpm build`.