### PR TITLE
research(automorphic-number-oq-01-oq-02-oq-01): idempotents of ZMod(m^k) count 2^ω(m) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AutomorphicNumberOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/AutomorphicNumberOQ01OQ02OQ01.lean
@@ -1,0 +1,142 @@
+import Mathlib
+import Proofs.AutomorphicNumberOQ01
+
+/-!
+# Idempotents of `ZMod (m ^ k)`: the count is `2 ^ ω(m)`
+
+## What This Proves
+
+The parent entry `automorphic-number-oq-01-oq-02` pins down the idempotents of
+`ZMod (10 ^ k)` — the automorphic residues `n² ≡ n (mod 10^k)` — showing there are
+exactly **four**, split into two complementary pairs.  The first follow-up
+(`AutomorphicNumberOQ01`) reframed that count as `2 ^ ω(10) = 2²` and proved, for a
+single prime power, that `ZMod (p ^ a)` has exactly two idempotents.
+
+This entry removes the base `10` entirely and settles the count for an **arbitrary**
+modulus `m ≥ 2`:
+
+```
+card_idempotents_eq_two_pow_omega :
+  Fintype.card {e : ZMod (m ^ k) // e * e = e} = 2 ^ m.primeFactors.card
+```
+
+Here `m.primeFactors.card = ω(m)` is the number of distinct prime divisors of `m`.
+The exponent `k ≥ 1` never appears on the right — the count depends only on `ω(m)`.
+So `ZMod (12 ^ k)` (`12 = 2²·3`, two primes) has `4` idempotents, `ZMod (30 ^ k)`
+(`30 = 2·3·5`, three primes) has `8`, and `ZMod (p ^ k)` for a prime power has only the
+trivial two.
+
+## Strategy
+
+The proof is the structural statement of which the parent's `10^k` computation is a
+shadow, assembled from three reusable pieces:
+
+* **Local factors have two idempotents.**  `AutomorphicNumberOQ01.idem_card_prime_pow`
+  already proves `Fintype.card {a : ZMod (p^a) // a*a=a} = 2` for prime `p`, `a ≥ 1`
+  (a prime-power ring is local, so `a*(a-1)=0` forces `a ∈ {0,1}`).
+* **Chinese Remainder over all primes.**  `ZMod.equivPi` gives the ring isomorphism
+  `ZMod (m^k) ≃+* Π p ∈ (m^k).primeFactors, ZMod (p ^ v_p(m^k))`.
+* **Idempotents of a product are families of idempotents.**  `idemPi` (below, the
+  dependent-product analogue of the parent's binary `idemProd`) turns the idempotent
+  subtype of a `Π`-ring into the product of the factors' idempotent subtypes, so the
+  count multiplies: `∏_{p} 2 = 2 ^ #primeFactors(m^k) = 2 ^ ω(m)`.
+
+The complementation involution `e ↦ 1 - e` (Mathlib's `HasCompl`/`compl_compl` on the
+idempotent subtype) is recorded as `compl_involutive`.
+
+## Status
+
+Fully machine-checked: `0` sorries, `0` axioms.
+-/
+
+namespace AutomorphicNumberOQ01OQ02OQ01
+
+open Finset AutomorphicNumberOQ01
+
+/-- An idempotent of a dependent product ring is exactly a family of idempotents of the
+factors.  This is the `Π`-type analogue of the parent's binary `idemProd`. -/
+def idemPi {ι : Type*} {R : ι → Type*} [∀ i, Mul (R i)] :
+    {e : (∀ i, R i) // e * e = e} ≃ (∀ i, {a : R i // a * a = a}) where
+  toFun e i := ⟨e.1 i, by have h := congrFun e.2 i; rwa [Pi.mul_apply] at h⟩
+  invFun f := ⟨fun i => (f i).1, funext fun i => by rw [Pi.mul_apply]; exact (f i).2⟩
+  left_inv e := by ext i; rfl
+  right_inv f := by ext i; rfl
+
+/-- **Main theorem.**  For a nonzero modulus `m` (the interesting range is `m ≥ 2`) and
+`k ≥ 1`, the ring `ZMod (m ^ k)` has exactly `2 ^ ω(m)` idempotents, where
+`ω(m) = m.primeFactors.card` is the number of distinct primes dividing `m`.  The exponent
+`k` does not affect the count.  (`[NeZero m]` is required so that `ZMod (m ^ k)` is a finite
+type; it holds automatically for any concrete `m ≥ 1`.) -/
+theorem card_idempotents_eq_two_pow_omega (m k : ℕ) [NeZero m] (hk : 1 ≤ k) :
+    Fintype.card {e : ZMod (m ^ k) // e * e = e} = 2 ^ m.primeFactors.card := by
+  have hk0 : k ≠ 0 := by omega
+  have hn : m ^ k ≠ 0 := pow_ne_zero k (NeZero.ne m)
+  -- Each prime-power factor is a nonzero (hence finite) ring.
+  haveI hNZ : ∀ p : (m ^ k).primeFactors,
+      NeZero ((p : ℕ) ^ ((m ^ k).factorization (p : ℕ))) :=
+    fun p => ⟨pow_ne_zero _ (Nat.prime_of_mem_primeFactors p.2).pos.ne'⟩
+  -- Transport idempotents across the Chinese-Remainder product decomposition
+  -- (`ZMod.equivPi`), then split them componentwise (`idemPi`).
+  rw [Fintype.card_congr ((idemCongr (ZMod.equivPi (m ^ k) hn).toMulEquiv).trans idemPi),
+      Fintype.card_pi]
+  -- Every local factor contributes exactly two idempotents.
+  have hfac : ∀ p : (m ^ k).primeFactors,
+      Fintype.card {a : ZMod ((p : ℕ) ^ ((m ^ k).factorization (p : ℕ))) // a * a = a} = 2 := by
+    intro p
+    haveI : Fact ((p : ℕ).Prime) := ⟨Nat.prime_of_mem_primeFactors p.2⟩
+    have hpos : 0 < (m ^ k).factorization (p : ℕ) := by
+      obtain ⟨hp, hdvd, -⟩ := Nat.mem_primeFactors.mp p.2
+      exact hp.factorization_pos_of_dvd hn hdvd
+    exact idem_card_prime_pow hpos
+  simp only [hfac]
+  rw [Finset.prod_const, Finset.card_univ, Fintype.card_coe, Nat.primeFactors_pow m hk0]
+
+/-- **Complementation involution.**  On the idempotents of `ZMod (m ^ k)` the orthogonal
+complement `e ↦ 1 - e` (Mathlib's `HasCompl` on the idempotent subtype) is an involution;
+it pairs the `2 ^ ω(m)` idempotents by `e ↔ 1 - e`. -/
+theorem compl_involutive (m k : ℕ) :
+    Function.Involutive
+      (fun e : {e : ZMod (m ^ k) // IsIdempotentElem e} => eᶜ) :=
+  fun e => compl_compl e
+
+/-! ## Sanity checks
+
+The count `2 ^ ω(m)` reproduces the known small cases. -/
+
+/-- Base `10 = 2·5` has `ω = 2`, giving `4` idempotents mod `10 ^ k` — the parent's count. -/
+example (k : ℕ) (hk : 1 ≤ k) :
+    Fintype.card {e : ZMod (10 ^ k) // e * e = e} = 4 := by
+  have h : (10 : ℕ).primeFactors.card = 2 := by
+    rw [show (10 : ℕ) = 2 * 5 from rfl, Nat.primeFactors_mul (by norm_num) (by norm_num),
+        Nat.Prime.primeFactors (by norm_num), Nat.Prime.primeFactors (by norm_num)]
+    decide
+  have key := card_idempotents_eq_two_pow_omega 10 k hk
+  rw [h] at key
+  exact key
+
+/-- A prime power `m = 3²` still has `ω = 1`, so only the trivial two idempotents. -/
+example (k : ℕ) (hk : 1 ≤ k) :
+    Fintype.card {e : ZMod (9 ^ k) // e * e = e} = 2 := by
+  have h : (9 : ℕ).primeFactors.card = 1 := by
+    rw [show (9 : ℕ) = 3 * 3 from rfl, Nat.primeFactors_mul (by norm_num) (by norm_num),
+        Nat.Prime.primeFactors (by norm_num)]
+    decide
+  have key := card_idempotents_eq_two_pow_omega 9 k hk
+  rw [h] at key
+  exact key
+
+/-- `30 = 2·3·5` has `ω = 3`, giving `8` idempotents mod `30 ^ k`. -/
+example (k : ℕ) (hk : 1 ≤ k) :
+    Fintype.card {e : ZMod (30 ^ k) // e * e = e} = 8 := by
+  have h : (30 : ℕ).primeFactors.card = 3 := by
+    rw [show (30 : ℕ) = 2 * (3 * 5) from rfl,
+        Nat.primeFactors_mul (by norm_num) (by norm_num),
+        Nat.primeFactors_mul (by norm_num) (by norm_num),
+        Nat.Prime.primeFactors (by norm_num), Nat.Prime.primeFactors (by norm_num),
+        Nat.Prime.primeFactors (by norm_num)]
+    decide
+  have key := card_idempotents_eq_two_pow_omega 30 k hk
+  rw [h] at key
+  exact key
+
+end AutomorphicNumberOQ01OQ02OQ01

--- a/src/data/proofs/automorphic-number-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-autonum-oq010201-context",
+    "proofId": "automorphic-number-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "concept",
+    "title": "From base 10 to arbitrary m: idempotents of ℤ/mᵏ and the count 2^ω(m)",
+    "content": "The parent tower studies the automorphic residues mod 10^k — the idempotents e²=e of ZMod (10^k) — counting four of them and pairing them as {0,1} and the classic {…5,…6}. The base 10 is incidental: 10 = 2·5 has two distinct primes, and THAT is why there are 4 = 2² idempotents. This entry proves the general statement: for any modulus m ≥ 2 and exponent k ≥ 1, ZMod (m^k) has exactly 2^ω(m) idempotents, where ω(m) = m.primeFactors.card counts the distinct primes of m. The exponent k never appears. The mechanism is the Chinese Remainder Theorem, which splits ZMod (m^k) into a product of local prime-power rings ZMod (p^a), each of which has exactly the two trivial idempotents 0 and 1; the idempotents of the product are the tuples of these choices, a Boolean cube of dimension ω(m).",
+    "mathContext": "An idempotent of $\\mathbb{Z}/m^k$ is a solution of $x^2\\equiv x$; by CRT these correspond to tuples of idempotents of the local factors $\\mathbb{Z}/p^{a}$, giving $2^{\\omega(m)}$ in total.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "idempotents",
+      "Chinese Remainder Theorem",
+      "local rings",
+      "distinct prime factors ω(m)",
+      "Boolean algebra of idempotents"
+    ],
+    "prerequisites": [
+      "idempotents in a commutative ring",
+      "ZMod (m^k) and the CRT"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq010201-idempi",
+    "proofId": "automorphic-number-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 68
+    },
+    "type": "technique",
+    "title": "idemPi: idempotents of a product ring are families of idempotents",
+    "content": "The equivalence idemPi says an idempotent of a dependent product ring Π i, R i is exactly a family assigning to each index an idempotent of that factor. Idempotency in a Π-ring is pointwise — (e·e) i = e i · e i by Pi.mul_apply — so e²=e holds iff every component is idempotent. This is the Π-type analogue of the parent sibling's binary idemProd, and it is the combinatorial hinge of the whole count: composed with the CRT isomorphism it lets Fintype.card_pi turn the idempotent count of ZMod (m^k) into the product of the per-factor counts.",
+    "mathContext": "For a product ring $\\prod_i R_i$, the idempotents are exactly $\\prod_i \\{\\text{idempotents of }R_i\\}$; cardinality is therefore multiplicative across the factors.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "product ring",
+      "pointwise multiplication",
+      "Fintype.card_pi",
+      "multiplicativity of counts"
+    ],
+    "prerequisites": [
+      "dependent function types",
+      "Pi.mul_apply"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq010201-maincount",
+    "proofId": "automorphic-number-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 65,
+      "endLine": 95
+    },
+    "type": "proof-step",
+    "title": "The count 2^ω(m): CRT decomposition, then multiply the local factors",
+    "content": "The main theorem chains three moves. First, idemCongr (ZMod.equivPi hn).toMulEquiv transports the idempotent subtype of ZMod (m^k) across the finite-product CRT isomorphism into the idempotent subtype of ∏ p ∈ (m^k).primeFactors, ZMod (p^v_p(m^k)); idemPi then splits that into ∏ p, (idempotents of the factor). Fintype.card_pi turns the cardinality into a product over the primes. Each factor exponent is positive — p ∈ (m^k).primeFactors means (m^k).factorization p ≠ 0 via Nat.support_factorization — so the verified sibling's idem_card_prime_pow gives exactly 2 idempotents per prime. Finally Finset.prod_const collapses ∏ 2 to 2^(#primeFactors), Fintype.card_coe converts the coe-Fintype card to the Finset card, and Nat.primeFactors_pow rewrites (m^k).primeFactors = m.primeFactors, dropping the exponent k to land on 2^ω(m).",
+    "mathContext": "$\\mathbb{Z}/m^k\\cong\\prod_{p\\mid m}\\mathbb{Z}/p^{k\\,v_p(m)}$, each factor local with two idempotents, so the count is $\\prod_{p\\mid m}2 = 2^{\\omega(m)}$, independent of $k$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "ZMod.equivPi",
+      "Fintype.card_pi",
+      "Finset.prod_const",
+      "Nat.primeFactors_pow",
+      "local prime-power rings"
+    ],
+    "prerequisites": [
+      "Chinese Remainder Theorem (finite product form)",
+      "cardinality of dependent products",
+      "prime factorization support"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq010201-involution",
+    "proofId": "automorphic-number-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 104
+    },
+    "type": "concept",
+    "title": "The complementation involution",
+    "content": "compl_involutive records that the orthogonal complement e ↦ 1 − e is an involution on the idempotents of ZMod (m^k): applying it twice returns e, by Mathlib's compl_compl on the idempotent subtype. This generalizes the parent's pairing e ↔ 1 − e of the four residues mod 10^k to the full 2^ω(m) idempotents. (The headline count is stated with the elementary condition e·e=e, which is definitionally Mathlib's IsIdempotentElem, so it plugs directly into the library's idempotent API.)",
+    "mathContext": "On the idempotents of any commutative ring, $e\\mapsto 1-e$ is the Boolean complement — an involution pairing $e$ with its orthogonal complement $1-e$ ($e+(1-e)=1$, $e(1-e)=0$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IsIdempotentElem",
+      "orthogonal complement",
+      "involution",
+      "Boolean complement"
+    ],
+    "prerequisites": [
+      "Mathlib idempotent HasCompl instance"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq010201-sanity",
+    "proofId": "automorphic-number-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 107,
+      "endLine": 142
+    },
+    "type": "example",
+    "title": "Sanity checks: 10 → 4, 9 → 2, 30 → 8",
+    "content": "Three examples instantiate the general count and reproduce the known cases. For m = 10 = 2·5 (two primes, ω = 2) the count is 2² = 4 — exactly the parent's four automorphic residues mod 10^k. For m = 9 = 3² (one prime, ω = 1) it is 2¹ = 2, only the trivial idempotents 0 and 1. For m = 30 = 2·3·5 (three primes, ω = 3) it is 2³ = 8. Each example computes m.primeFactors.card by rewriting the modulus as a product of primes (Nat.primeFactors_mul, Nat.Prime.primeFactors) and finishing with a decide on the resulting concrete finite set — deliberately avoiding any reduction of the well-founded primeFactors recursion.",
+    "mathContext": "The formula $2^{\\omega(m)}$ recovers four for a two-prime modulus, two for a prime power, and eight for a three-prime modulus.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ω(m) = number of distinct primes",
+      "Nat.primeFactors_mul",
+      "prime-power modulus"
+    ],
+    "prerequisites": [
+      "prime factorization of small integers"
+    ]
+  }
+]

--- a/src/data/proofs/automorphic-number-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "automorphic-number-oq-01-oq-02-oq-01",
+  "slug": "automorphic-number-oq-01-oq-02-oq-01",
+  "title": "Idempotents of ℤ/mᵏ: the Count is 2^ω(m) for Every Modulus",
+  "description": "The parent entry describes the four automorphic residues mod 10^k — the idempotents of ZMod (10^k) — and asks, as its first open question, to remove the base 10 entirely: for an arbitrary modulus m ≥ 2, how many idempotents does ZMod (m^k) have? This entry answers it. The count is exactly 2^ω(m), where ω(m) = m.primeFactors.card is the number of DISTINCT prime divisors of m — and the exponent k never appears. So ZMod (12^k) (12 = 2²·3, two primes) has 4 idempotents just like ZMod (10^k), ZMod (30^k) (30 = 2·3·5, three primes) has 8, and ZMod (p^k) for a prime power has only the trivial two, 0 and 1. The proof is the structural statement of which the parent's concrete {0,1,…5,…6} computation is a shadow. Three reusable pieces assemble it: (1) a prime-power ring ZMod (p^a) is local, so its only idempotents are 0 and 1 — exactly two (reused from the verified sibling AutomorphicNumberOQ01 via idem_card_prime_pow); (2) the Chinese Remainder Theorem in its finite-product form ZMod.equivPi splits ZMod (m^k) ≃+* ∏ p ∈ (m^k).primeFactors, ZMod (p^v_p(m^k)); (3) an idempotent of a dependent product ring is precisely a family of idempotents of the factors (idemPi, the Π-type analogue of the parent's binary idemProd), so the counts multiply: ∏ over the primeFactors of 2 = 2^(#primeFactors(m^k)) = 2^ω(m), using that (m^k).primeFactors = m.primeFactors for k ≥ 1. The complementation involution e ↦ 1 - e on the idempotent subtype is recorded as compl_involutive. The result is machine-checked with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AutomorphicNumberOQ01OQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "automorphic-numbers",
+      "idempotents",
+      "zmod",
+      "chinese-remainder-theorem",
+      "prime-factorization",
+      "local-ring",
+      "arithmetic-functions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 142,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. The three `decide` calls in the sanity examples are kernel decisions on concrete finite Finset data (the cardinalities of {2,5}, {3}, {2,3,5} as prime-factor sets), reached only after rewriting each modulus via Nat.primeFactors_mul / Nat.Prime.primeFactors — no well-founded recursion is reduced. Results depend only on the standard foundational axioms propext / Classical.choice / Quot.sound. Builds on the verified sibling AutomorphicNumberOQ01.lean, reusing its idem_card_prime_pow (each prime-power factor has exactly two idempotents) and idemCongr (idempotents transport across a ring isomorphism).",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.equivPi",
+        "description": "The finite-product form of the Chinese Remainder Theorem: ZMod n ≃+* Π p ∈ n.primeFactors, ZMod (p ^ n.factorization p) for n ≠ 0; applied at n = m^k it decomposes ZMod (m^k) into its local prime-power factors",
+        "module": "Mathlib.Data.ZMod.QuotientRing"
+      },
+      {
+        "theorem": "Fintype.card_pi",
+        "description": "The cardinality of a dependent function type is the product of the factor cardinalities; turns the idempotents of the product ring into ∏ (idempotents per factor)",
+        "module": "Mathlib.Data.Fintype.BigOperators"
+      },
+      {
+        "theorem": "Nat.primeFactors_pow",
+        "description": "(n ^ k).primeFactors = n.primeFactors for k ≠ 0; the fact that makes the count depend only on ω(m) and not on the exponent k",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Nat.support_factorization",
+        "description": "(factorization n).support = n.primeFactors; used to show every prime in (m^k).primeFactors has positive exponent, so each factor ZMod (p^a) has a ≥ 1 and is a nontrivial local ring",
+        "module": "Mathlib.Data.Nat.Factorization.Defs"
+      },
+      {
+        "theorem": "Nat.prime_of_mem_primeFactors",
+        "description": "Membership in n.primeFactors gives primality; supplies the Fact p.Prime instance for each factor's two-idempotent count",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01.idem_card_prime_pow",
+        "description": "The verified sibling result that ZMod (p^k) has exactly two idempotents for prime p and k ≥ 1; the per-prime factor of the product count",
+        "module": "Proofs.AutomorphicNumberOQ01"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01.idemCongr",
+        "description": "Idempotents transport across a multiplicative isomorphism; used with (ZMod.equivPi _).toMulEquiv to move the count into the product ring",
+        "module": "Proofs.AutomorphicNumberOQ01"
+      },
+      {
+        "theorem": "IsIdempotentElem.compl_compl",
+        "description": "Double orthogonal complement is the identity on the idempotent subtype; gives the complementation involution e ↦ 1 - e",
+        "module": "Mathlib.Algebra.Ring.Idempotent"
+      }
+    ],
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AutomorphicNumberOQ01"
+    ],
+    "opens": [
+      "Finset",
+      "AutomorphicNumberOQ01"
+    ],
+    "namespace": "AutomorphicNumberOQ01OQ02OQ01",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "path": "Proofs/AutomorphicNumberOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "card_idempotents_eq_two_pow_omega",
+      "type": "headline",
+      "statement": "[NeZero m] → 1 ≤ k → Fintype.card {e : ZMod (m ^ k) // e * e = e} = 2 ^ m.primeFactors.card",
+      "description": "For every modulus m ≥ 2 and exponent k ≥ 1, the ring ZMod (m^k) has exactly 2^ω(m) idempotents, where ω(m) = m.primeFactors.card is the number of distinct primes dividing m. The exponent k does not affect the count.",
+      "significance": "Removes the base 10 from the parent's count of four, exhibiting 2^ω(m) as the correct level of generality: the number of automorphic-type idempotents is governed entirely by the count of distinct prime factors of the modulus, a consequence of the Chinese Remainder Theorem and the locality of prime-power rings."
+    },
+    {
+      "name": "compl_involutive",
+      "type": "supporting",
+      "statement": "Function.Involutive (fun e : {e : ZMod (m ^ k) // IsIdempotentElem e} => eᶜ)",
+      "description": "The orthogonal complement e ↦ 1 - e is an involution on the idempotents of ZMod (m^k); it pairs the 2^ω(m) idempotents by e ↔ 1 - e, generalizing the parent's complementary-pairing of the four residues mod 10^k.",
+      "significance": "The first structural refinement beyond the count: complementation is a fixed-point-free-in-pairs involution (except for no fixed points when 2 is invertible), the Boolean-complement operation on the idempotents."
+    },
+    {
+      "name": "idemPi",
+      "type": "supporting",
+      "statement": "{e : (∀ i, R i) // e * e = e} ≃ (∀ i, {a : R i // a * a = a})",
+      "description": "An idempotent of a dependent product ring is exactly a family of idempotents of the factors — the Π-type analogue of the parent sibling's binary idemProd. This is the equivalence that makes the idempotent count multiplicative across the CRT decomposition.",
+      "significance": "The combinatorial heart of the multiplicativity: it converts the idempotent subtype of ∏ R_i into ∏ (idempotent subtype of R_i), so Fintype.card_pi turns the count into a product of the per-factor counts."
+    }
+  ],
+  "sections": [
+    {
+      "id": "product-idempotents",
+      "title": "Part I: Idempotents of a product ring",
+      "startLine": 56,
+      "endLine": 68,
+      "summary": "idemPi: the idempotent subtype of a dependent product Π i, R i is equivalent to the product Π i, (idempotent subtype of R i). Idempotency in a Π-ring is pointwise (Pi.mul_apply), so an idempotent is exactly a family of componentwise idempotents.",
+      "mathContext": "Idempotents of a product of rings are the tuples of idempotents of the factors; this is the ring-theoretic fact that makes the count multiplicative and, structurally, exhibits the idempotents as a product of two-element sets — a Boolean cube."
+    },
+    {
+      "id": "main-count",
+      "title": "Part II: The count 2^ω(m) via the Chinese Remainder Theorem",
+      "startLine": 65,
+      "endLine": 95,
+      "summary": "card_idempotents_eq_two_pow_omega: transport idempotents across ZMod.equivPi (CRT), split them by idemPi, and apply Fintype.card_pi to get ∏ p ∈ (m^k).primeFactors, (count of idempotents of ZMod (p^v_p)). Each factor exponent is positive (Nat.support_factorization) so idem_card_prime_pow gives 2 per prime; Finset.prod_const collapses ∏ 2 to 2^#primeFactors, and Nat.primeFactors_pow drops the exponent k.",
+      "mathContext": "ZMod (m^k) ≅ ∏ ZMod (p^{k·v_p(m)}) over the distinct primes of m; each factor is a local ring with exactly two idempotents, so the total is 2 raised to the number of distinct primes, independent of k."
+    },
+    {
+      "id": "complementation-involution",
+      "title": "Part III: The complementation involution",
+      "startLine": 92,
+      "endLine": 104,
+      "summary": "compl_involutive records that the orthogonal complement e ↦ 1 - e (Mathlib's HasCompl on the idempotent subtype) is an involution via compl_compl, generalizing the parent's e ↔ 1-e pairing to all 2^ω(m) idempotents. (The headline count is stated with the elementary condition e*e=e, which is definitionally Mathlib's IsIdempotentElem.)",
+      "mathContext": "Beyond the count, the idempotents carry a Boolean-complement involution; on ZMod (m^k) it pairs the 2^ω(m) idempotents, matching the {0,1}/{…5,…6} pairing the parent found for 10^k."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Part IV: Sanity checks against known cases",
+      "startLine": 107,
+      "endLine": 142,
+      "summary": "Three examples instantiate the count: 10 = 2·5 (ω=2) gives 4 (the parent's number), 9 = 3² (ω=1) gives 2 (trivial idempotents only), 30 = 2·3·5 (ω=3) gives 8. Each computes m.primeFactors.card by Nat.primeFactors_mul / Nat.Prime.primeFactors, avoiding any reduction of the well-founded primeFactors recursion.",
+      "mathContext": "The formula reproduces the parent's four idempotents mod 10^k, collapses to two for a prime power, and predicts eight for a three-prime modulus."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Automorphic numbers — whose squares end in the number itself (5²=25, 76²=5776) — are an old piece of recreational number theory whose modern framing is ring-theoretic: an automorphic residue mod 10^k is exactly an idempotent of ℤ/10^k, a fixed point of squaring. The parent tower formalized this base-10 story: the count of four idempotents, its reading as 2^ω(10)=2², and the complementary pairing of the four residues into {0,1} and the classic {…5,…6}. But the base 10 is incidental. The Chinese Remainder Theorem writes ℤ/m^k as a product of local rings ℤ/p^{a} over the distinct primes p of m, and a finite local ring has only the two trivial idempotents 0 and 1; so the idempotents of ℤ/m^k are the tuples of 0/1 choices across the primes — a Boolean cube of dimension ω(m), with 2^ω(m) vertices. This entry formalizes that structural count for arbitrary m, exactly the generalization the parent posed as its first open question.",
+    "problemStatement": "For an arbitrary modulus m ≥ 2 and exponent k ≥ 1, count the idempotents of ℤ/m^k — equivalently, the number of solutions of x² ≡ x (mod m^k). Show the count is 2^ω(m), where ω(m) is the number of distinct prime divisors of m, and that it is independent of k; record the orthogonal-complement involution e ↦ 1 − e on the idempotents.",
+    "proofStrategy": "Three reusable pieces. (1) Local factors: a prime-power ring ℤ/p^a is local, so its only idempotents are 0 and 1 — exactly two (the verified sibling's idem_card_prime_pow, itself proved from p^a ∣ n(n−1) with gcd(n,n−1)=1). (2) Chinese Remainder in finite-product form (ZMod.equivPi): ℤ/m^k ≅ ∏ over the distinct primes p of m of ℤ/p^{k·v_p(m)}. (3) Product idempotents (idemPi): an idempotent of ∏ R_i is a family of idempotents, so Fintype.card_pi makes the count multiply: ∏ 2 = 2^#primeFactors. Since (m^k).primeFactors = m.primeFactors (Nat.primeFactors_pow) and every listed prime has positive exponent (Nat.support_factorization), the product is 2^ω(m) with no dependence on k. The complement involution is Mathlib's compl_compl on the idempotent subtype.",
+    "keyInsights": [
+      "**ω(m), not the modulus, controls the count**: the number of idempotents of ℤ/m^k is 2 to the number of DISTINCT primes of m — so 10, 12, and any two-prime modulus all give four, while a prime power gives only two.",
+      "**The exponent k is irrelevant**: raising the exponent keeps each local factor ℤ/p^a nontrivial (a ≥ 1) with exactly two idempotents, so k cancels out of 2^ω(m) — proved via Nat.primeFactors_pow.",
+      "**Idempotents of a product multiply**: idemPi turns the idempotent subtype of a Π-ring into a product of the factors' idempotent subtypes, the exact fact that Fintype.card_pi needs to convert the CRT decomposition into 2^ω(m).",
+      "**Local rings are the atoms**: each prime-power factor ℤ/p^a contributes the two trivial idempotents 0 and 1, so the global idempotents are a Boolean cube of 0/1 choices across the primes.",
+      "**Structural, not computational**: the parent's four residues {0,1,…5,…6} mod 10^k are the (0,0),(1,1),(1,0),(0,1) corners of the 2-prime cube; this entry proves that picture for every m."
+    ],
+    "prerequisites": [
+      "Idempotents in a commutative ring (e² = e) and the Boolean algebra they form",
+      "The ring ℤ/nℤ and the Chinese Remainder Theorem for ℤ/m^k as a product over prime powers",
+      "Local rings and the fact that a prime-power ring ℤ/p^a has only trivial idempotents",
+      "The arithmetic function ω(m) = number of distinct prime divisors (m.primeFactors.card)",
+      "Cardinality of dependent function types (Fintype.card_pi)"
+    ]
+  },
+  "conclusion": {
+    "summary": "For every modulus m ≥ 2 and exponent k ≥ 1, the ring ℤ/m^k has exactly 2^ω(m) idempotents, where ω(m) counts the distinct primes of m — and the exponent k plays no role. The proof decomposes ℤ/m^k by the Chinese Remainder Theorem into local prime-power factors, each contributing exactly the two trivial idempotents 0 and 1, and multiplies the counts with the product-ring idempotent equivalence idemPi. The orthogonal complement e ↦ 1 − e is recorded as an involution. Everything is machine-checked with no axioms and no sorries, reusing the verified sibling's per-prime count.",
+    "implications": "This settles the first open question of the parent entry: the automorphic-number phenomenon is base-independent, and its count is the arithmetic function 2^ω(m). The idempotents of ℤ/m^k form a Boolean cube of dimension ω(m), of which the parent's four residues mod 10^k are the 2-dimensional case. The product-idempotent equivalence idemPi and the CRT-multiplicativity template are reusable for counting other ring-theoretic invariants factor by factor (units, nilpotents, zero-divisors).",
+    "openQuestions": [
+      "Upgrade the count to a full BooleanAlgebra isomorphism between the idempotents of ℤ/m^k and the power set 𝒫(primeFactors m), realizing meet = e·f, join = e+f−ef, complement = 1−e explicitly and identifying the involution e ↦ 1−e with set-complementation.",
+      "Describe the idempotents of ℤ/n for a general (non prime-power-exponent) modulus n directly in terms of the unitary divisors of n, and give an effective enumeration matching the 2^ω(n) count.",
+      "Formalize the p-adic limit: the nontrivial idempotents of ℤ/m^k stabilize digit by digit into the idempotents of the profinite ring ∏ ℤ_p over the primes of m, connecting the finite count to the idempotents of the p-adic integers."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "automorphic-number-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Direct parent: this entry answers the parent's first open question, generalizing its count of four idempotents mod 10^k to 2^ω(m) idempotents mod m^k for arbitrary m, and generalizing the complementary pairing to the involution e ↦ 1 − e."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes the automorphic-number tower from base 10 to an **arbitrary modulus**: for `m` with `NeZero m` (interesting range `m ≥ 2`) and `k ≥ 1`,
```
Fintype.card {e : ZMod (m ^ k) // e * e = e} = 2 ^ m.primeFactors.card
```
i.e. `ZMod (m^k)` has exactly `2^ω(m)` idempotents, where `ω(m)` is the number of **distinct** prime divisors of `m`. The exponent `k` never appears. This directly answers the parent entry `automorphic-number-oq-01-oq-02`'s first open question (the parent proved the `m=10` case gives four).

## Proof

Three reusable pieces:
1. **Local factors have two idempotents** — reuses the verified sibling `AutomorphicNumberOQ01.idem_card_prime_pow` (a prime-power ring `ZMod (p^a)` is local, so `0,1` are its only idempotents).
2. **CRT over all primes** — `ZMod.equivPi` splits `ZMod (m^k) ≃+* ∏ p ∈ (m^k).primeFactors, ZMod (p^v_p(m^k))`.
3. **Idempotents of a product multiply** — a new equivalence `idemPi` (the Π-type analogue of the sibling's binary `idemProd`) turns the idempotent subtype of a product ring into a product of the factors' idempotent subtypes, so `Fintype.card_pi` gives `∏ 2 = 2^#primeFactors = 2^ω(m)` (using `Nat.primeFactors_pow` to drop `k`).

Also records the complementation involution `e ↦ 1 - e` (`compl_involutive`) and sanity checks (`10 → 4`, `9 → 2`, `30 → 8`).

## Verification

- `✔ Built Proofs.AutomorphicNumberOQ01OQ02OQ01` via `docker-build.sh`
- **0 sorries, 0 axioms** (no `native_decide`; the 3 `decide` calls are kernel decisions on concrete finite Finsets)
- 2 theorems, 1 definition, 3 examples, 142 lines
- Gallery data: `meta.json` + `annotations.json` with crossReference to the parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)