### PR TITLE
research(feuerbachs-theorem-oq-04): spherical circle↔great-circle tangency + explicit contact point [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -853,4 +853,43 @@ theorem sdist_greatCircleFoot_center {O N : E} {ρ : ℝ}
   have hρπ : ρ ≤ Real.pi := by linarith [Real.pi_pos]
   exact ((mem_sCircle_iff_sdist hO hρ0 hρπ (greatCircleFoot O N ρ)).mp hFcirc).2
 
+/-- **Great circles are the spherical circles of angular radius `π/2`.**  With unit pole
+`N`, `sGreatCircle N = sCircle N (π/2)`, since `cos (π/2) = 0` and membership of both is
+`⟪P, N⟫ = 0`.  This unifies the two tangency notions: tangency to a "side" is tangency to a
+particular circle, so a spherical incircle is tangent (in the circle–circle sense of the
+earlier sections) to three radius-`π/2` circles centred at the side poles. -/
+theorem sGreatCircle_eq_sCircle (N : E) : sGreatCircle N = sCircle N (Real.pi / 2) := by
+  simp only [sGreatCircle, sCircle, scos, Real.cos_pi_div_two]
+
+/-! ## The spherical incircle of a spherical triangle
+
+A spherical triangle is presented by the unit **poles** `Nₐ, N_b, N_c` of its three side
+great circles.  A spherical **incircle** is a circle `sCircle O ρ` tangent to all three
+sides.  The tangency primitive `circle_tangent_greatCircle_inter` then delivers, for free,
+that such an incircle touches each side in exactly one point — the corresponding foot of the
+perpendicular.  This is the spherical form of "the incircle is tangent to all three sides",
+the first ingredient of a spherical Feuerbach configuration.  (Existence/uniqueness of the
+incenter `O` for a given triangle is the remaining hard step and is not asserted here.) -/
+
+/-- A circle `sCircle O ρ` is a **spherical incircle** for the triangle with side poles
+`Nₐ, N_b, N_c` when it is tangent to all three sides. -/
+def SphericalIncircle (Na Nb Nc O : E) (ρ : ℝ) : Prop :=
+  TangentToGreatCircle O ρ Na ∧ TangentToGreatCircle O ρ Nb ∧ TangentToGreatCircle O ρ Nc
+
+/-- **A spherical incircle meets each side in exactly one point.**  For an incircle
+`sCircle O ρ` (with `0 ≤ ρ < π/2`) of the triangle with unit side poles `Nₐ, N_b, N_c`, the
+intersection with each side great circle is the singleton foot of the perpendicular from the
+centre `O`.  Three applications of `circle_tangent_greatCircle_inter`: the incircle is
+tangent to all three sides, with explicit contact points. -/
+theorem sphericalIncircle_contact_points {Na Nb Nc O : E} {ρ : ℝ}
+    (hO : OnSphere O) (hNa : OnSphere Na) (hNb : OnSphere Nb) (hNc : OnSphere Nc)
+    (hρ0 : 0 ≤ ρ) (hρ2 : ρ < Real.pi / 2)
+    (hinc : SphericalIncircle Na Nb Nc O ρ) :
+    sCircle O ρ ∩ sGreatCircle Na = {greatCircleFoot O Na ρ} ∧
+      sCircle O ρ ∩ sGreatCircle Nb = {greatCircleFoot O Nb ρ} ∧
+      sCircle O ρ ∩ sGreatCircle Nc = {greatCircleFoot O Nc ρ} :=
+  ⟨circle_tangent_greatCircle_inter hO hNa hρ0 hρ2 hinc.1,
+   circle_tangent_greatCircle_inter hO hNb hρ0 hρ2 hinc.2.1,
+   circle_tangent_greatCircle_inter hO hNc hρ0 hρ2 hinc.2.2⟩
+
 end FeuerbachsTheoremOQ04

--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -721,4 +721,136 @@ theorem internallyTangent_common_perp_tangent {O₁ O₂ T : E}
   obtain ⟨-, ht1, ht2, hperp⟩ := common_perp_tangent hspan hTO₁ hTO₂
   exact ⟨P, hsing, ht1, ht2, hperp⟩
 
+/-! ## Tangency of a spherical circle to a great circle
+
+The incircle and excircles of a spherical triangle are characterised by tangency to the
+triangle's *sides* — arcs of great circles — rather than to other circles.  A great circle
+is the set of model points orthogonal to a fixed unit *pole* `N`; these are the "lines"
+(geodesics) of spherical geometry.  This section records exactly when a spherical circle
+`sCircle O ρ` is tangent to such a great circle and exhibits the contact point: the **foot
+of the perpendicular** from the centre `O`, i.e. the orthogonal component `O − ⟪O,N⟫ • N`
+renormalised to a unit vector.  The tangency criterion is the spherical analogue of
+"distance from centre to line = radius": since the spherical distance from `O` to the
+great circle is `arcsin |⟪O,N⟫|`, tangency is `|⟪O, N⟫| = sin ρ`.  This is the primitive a
+spherical incircle construction consumes three times, once per side. -/
+
+/-- The **great circle** with unit pole `N`: the model points orthogonal to `N`.  These are
+the geodesics of the spherical model — in particular the sides of a spherical triangle. -/
+def sGreatCircle (N : E) : Set E := {P | OnSphere P ∧ (⟪P, N⟫ : ℝ) = 0}
+
+/-- The **foot of the perpendicular** from the centre `O` of a spherical circle of angular
+radius `ρ` onto the great circle with pole `N`: the orthogonal component `O − ⟪O,N⟫ • N`
+renormalised by `(cos ρ)⁻¹`.  When `sCircle O ρ` is tangent to the great circle this is
+their unique common point (`circle_tangent_greatCircle_inter`). -/
+noncomputable def greatCircleFoot (O N : E) (ρ : ℝ) : E :=
+  (Real.cos ρ)⁻¹ • (O - (⟪O, N⟫ : ℝ) • N)
+
+/-- A spherical circle `sCircle O ρ` is **tangent to the great circle** with pole `N` when
+the spherical distance from the centre to the great circle equals the angular radius.  That
+distance is `arcsin |⟪O, N⟫|`, so the algebraic criterion is `|⟪O, N⟫| = sin ρ` — the
+spherical shadow of the Euclidean "distance from centre to the line equals the radius". -/
+def TangentToGreatCircle (O : E) (ρ : ℝ) (N : E) : Prop :=
+  |(⟪O, N⟫ : ℝ)| = Real.sin ρ
+
+/-- The squared norm of the orthogonal component of a unit centre `O` off a unit pole `N`
+is `1 − ⟪O,N⟫²` (the spherical Pythagoras for the projection onto the great circle). -/
+theorem inner_orthoComp_self {O N : E} (hO : OnSphere O) (hN : OnSphere N) :
+    (⟪O - (⟪O, N⟫ : ℝ) • N, O - (⟪O, N⟫ : ℝ) • N⟫ : ℝ) = 1 - (⟪O, N⟫ : ℝ) ^ 2 := by
+  have hOO : (⟪O, O⟫ : ℝ) = 1 := by rw [real_inner_self_eq_norm_sq, hO]; norm_num
+  have hNN : (⟪N, N⟫ : ℝ) = 1 := by rw [real_inner_self_eq_norm_sq, hN]; norm_num
+  simp only [inner_sub_left, inner_sub_right, real_inner_smul_left, real_inner_smul_right]
+  rw [hOO, hNN, real_inner_comm N O]
+  ring
+
+/-- The inner product of the orthogonal component of `O` off `N` with `O` itself is
+`1 − ⟪O,N⟫²`. -/
+theorem inner_orthoComp_left {O N : E} (hO : OnSphere O) :
+    (⟪O - (⟪O, N⟫ : ℝ) • N, O⟫ : ℝ) = 1 - (⟪O, N⟫ : ℝ) ^ 2 := by
+  have hOO : (⟪O, O⟫ : ℝ) = 1 := by rw [real_inner_self_eq_norm_sq, hO]; norm_num
+  simp only [inner_sub_left, real_inner_smul_left]
+  rw [hOO, real_inner_comm N O]
+  ring
+
+/-- **The foot of the perpendicular is the contact point.**  If `sCircle O ρ` is tangent to
+the great circle with pole `N` (with `0 ≤ ρ < π/2`, so the circle is a genuine small
+circle), then `greatCircleFoot O N ρ` is a model point lying on *both* the circle and the
+great circle.  This is the existence half of the incircle-to-side tangency primitive. -/
+theorem greatCircleFoot_mem {O N : E} {ρ : ℝ}
+    (hO : OnSphere O) (hN : OnSphere N) (hρ0 : 0 ≤ ρ) (hρ2 : ρ < Real.pi / 2)
+    (htan : TangentToGreatCircle O ρ N) :
+    OnSphere (greatCircleFoot O N ρ) ∧
+      greatCircleFoot O N ρ ∈ sCircle O ρ ∧
+      greatCircleFoot O N ρ ∈ sGreatCircle N := by
+  have hcpos : 0 < Real.cos ρ :=
+    Real.cos_pos_of_mem_Ioo ⟨by linarith [Real.pi_pos], hρ2⟩
+  have hcne : Real.cos ρ ≠ 0 := ne_of_gt hcpos
+  -- the tangency criterion, squared
+  have hsq : (⟪O, N⟫ : ℝ) ^ 2 = (Real.sin ρ) ^ 2 := by rw [← sq_abs, htan]
+  -- the orthogonal component has squared norm cos²ρ
+  have hperp : (⟪O - (⟪O, N⟫ : ℝ) • N, O - (⟪O, N⟫ : ℝ) • N⟫ : ℝ) = (Real.cos ρ) ^ 2 := by
+    rw [inner_orthoComp_self hO hN, hsq]; linarith [Real.sin_sq_add_cos_sq ρ]
+  -- foot has unit inner product with itself
+  have hFF : (⟪greatCircleFoot O N ρ, greatCircleFoot O N ρ⟫ : ℝ) = 1 := by
+    have e : (⟪greatCircleFoot O N ρ, greatCircleFoot O N ρ⟫ : ℝ)
+        = (Real.cos ρ)⁻¹ * ((Real.cos ρ)⁻¹ * (Real.cos ρ) ^ 2) := by
+      simp only [greatCircleFoot, real_inner_smul_left, real_inner_smul_right, hperp]
+    rw [e]; field_simp
+  -- foot is a model point
+  have hFsphere : OnSphere (greatCircleFoot O N ρ) := by
+    have hsqn : ‖greatCircleFoot O N ρ‖ ^ 2 = 1 := by
+      rw [← real_inner_self_eq_norm_sq]; exact hFF
+    have hfac : (‖greatCircleFoot O N ρ‖ - 1) * (‖greatCircleFoot O N ρ‖ + 1) = 0 := by
+      nlinarith [hsqn]
+    rcases mul_eq_zero.mp hfac with h | h
+    · show ‖greatCircleFoot O N ρ‖ = 1; linarith
+    · exact absurd h (by have := norm_nonneg (greatCircleFoot O N ρ); positivity)
+  -- foot lies on the circle: scos = cos ρ
+  have hFO : scos (greatCircleFoot O N ρ) O = Real.cos ρ := by
+    have e : (⟪greatCircleFoot O N ρ, O⟫ : ℝ)
+        = (Real.cos ρ)⁻¹ * (1 - (⟪O, N⟫ : ℝ) ^ 2) := by
+      simp only [greatCircleFoot, real_inner_smul_left, inner_orthoComp_left hO]
+    rw [scos, e, hsq, show (1 : ℝ) - (Real.sin ρ) ^ 2 = (Real.cos ρ) ^ 2 from by
+      linarith [Real.sin_sq_add_cos_sq ρ]]
+    field_simp
+  -- foot lies on the great circle: ⟪·, N⟫ = 0
+  have hFN : (⟪greatCircleFoot O N ρ, N⟫ : ℝ) = 0 := by
+    have hNN : (⟪N, N⟫ : ℝ) = 1 := by rw [real_inner_self_eq_norm_sq, hN]; norm_num
+    simp only [greatCircleFoot, real_inner_smul_left, inner_sub_left, real_inner_smul_left, hNN]
+    ring
+  exact ⟨hFsphere, ⟨hFsphere, hFO⟩, hFsphere, hFN⟩
+
+/-- **Tangent circles meet a side in exactly one point.**  If `sCircle O ρ` is tangent to
+the great circle with pole `N` (with `0 ≤ ρ < π/2`), their intersection is the single
+contact point `greatCircleFoot O N ρ`.  This upgrades the existence lemma to genuine
+tangency (one common point, not two), and is the exact fact a spherical incircle
+construction needs for each of the triangle's three sides. -/
+theorem circle_tangent_greatCircle_inter {O N : E} {ρ : ℝ}
+    (hO : OnSphere O) (hN : OnSphere N) (hρ0 : 0 ≤ ρ) (hρ2 : ρ < Real.pi / 2)
+    (htan : TangentToGreatCircle O ρ N) :
+    sCircle O ρ ∩ sGreatCircle N = {greatCircleFoot O N ρ} := by
+  have hcpos : 0 < Real.cos ρ :=
+    Real.cos_pos_of_mem_Ioo ⟨by linarith [Real.pi_pos], hρ2⟩
+  have hcne : Real.cos ρ ≠ 0 := ne_of_gt hcpos
+  obtain ⟨hFsphere, hFcirc, hFgc⟩ := greatCircleFoot_mem hO hN hρ0 hρ2 htan
+  refine Set.eq_singleton_iff_unique_mem.mpr ⟨⟨hFcirc, hFgc⟩, ?_⟩
+  rintro Q ⟨⟨hQsphere, hQO⟩, -, hQN⟩
+  have hQO' : (⟪Q, O⟫ : ℝ) = Real.cos ρ := hQO
+  have hQF : scos Q (greatCircleFoot O N ρ) = 1 := by
+    have e : (⟪Q, greatCircleFoot O N ρ⟫ : ℝ)
+        = (Real.cos ρ)⁻¹ * ((⟪Q, O⟫ : ℝ) - (⟪O, N⟫ : ℝ) * (⟪Q, N⟫ : ℝ)) := by
+      simp only [greatCircleFoot, real_inner_smul_right, inner_sub_right, real_inner_smul_right]
+    rw [scos, e, hQN, hQO', mul_zero, sub_zero]
+    field_simp
+  exact (scos_eq_one_iff hQsphere hFsphere).mp hQF
+
+/-- The contact point is at spherical distance exactly `ρ` from the circle's centre — it
+genuinely lies *on* the circle, the spherical restatement of the foot lemma via `sdist`. -/
+theorem sdist_greatCircleFoot_center {O N : E} {ρ : ℝ}
+    (hO : OnSphere O) (hN : OnSphere N) (hρ0 : 0 ≤ ρ) (hρ2 : ρ < Real.pi / 2)
+    (htan : TangentToGreatCircle O ρ N) :
+    sdist (greatCircleFoot O N ρ) O = ρ := by
+  obtain ⟨hFsphere, hFcirc, -⟩ := greatCircleFoot_mem hO hN hρ0 hρ2 htan
+  have hρπ : ρ ≤ Real.pi := by linarith [Real.pi_pos]
+  exact ((mem_sCircle_iff_sdist hO hρ0 hρπ (greatCircleFoot O N ρ)).mp hFcirc).2
+
 end FeuerbachsTheoremOQ04

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -339,3 +339,63 @@ uncommitted edit — recreate worktree + COMMIT before building.
 1. Tangent-point uniqueness geodesic argument refinements.
 2. Spherical incircle + nine-point circle constructions, then the spherical Feuerbach tangency (the
    genuine open target — multi-session).
+
+## Session 2026-07-01 (researcher-1): circle-to-great-circle tangency (incircle↔side primitive) [VERIFIED, 0-axiom]
+
+**Mode**: ACT (CONTINUE — executed standing next-step "spherical incircle construction",
+building the missing tangency primitive it needs). Prior work had the full **circle-circle**
+tangency theory (existence/uniqueness/spec, common perpendicular tangent). The spherical
+incircle is tangent to the triangle's **sides**, which are arcs of *great circles*, not
+other circles — so circle-circle tangency does not directly apply. Filled that gap.
+
+**Outcome**: PROGRESS. `FeuerbachsTheoremOQ04.lean` 724→856L, **0 sorry / 0 axiom**, docker
+`✔ [7743/7743]`, no warnings, no native_decide (only ring/linarith/nlinarith/field_simp/simp
++ `Real.cos_pos_of_mem_Ioo`, `Real.sin_sq_add_cos_sq`, `sq_abs`, reused `scos_eq_one_iff`,
+`mem_sCircle_iff_sdist`).
+
+### Delivered
+- **`sGreatCircle N := {P | OnSphere P ∧ ⟪P,N⟫ = 0}`** — great circle = geodesic = triangle
+  side (unit pole `N`).
+- **`greatCircleFoot O N ρ := (cos ρ)⁻¹ • (O − ⟪O,N⟫ • N)`** — explicit contact point (the
+  renormalised orthogonal projection of the centre onto the great circle).
+- **`TangentToGreatCircle O ρ N := |⟪O,N⟫| = sin ρ`** — tangency criterion (distance from
+  centre to the side = radius; the distance is `arcsin|⟪O,N⟫|`).
+- **`inner_orthoComp_self` / `inner_orthoComp_left`** — helper: `⟪O⊥,O⊥⟫ = ⟪O⊥,O⟫ =
+  1 − ⟪O,N⟫²` (spherical Pythagoras for the projection; `inner_orthoComp_left` needs only
+  `OnSphere O`, not `hN`).
+- **`greatCircleFoot_mem`** (existence): under `0≤ρ<π/2` + criterion, the foot is a model
+  point on BOTH `sCircle O ρ` and `sGreatCircle N`. All three checks are pure inner-product
+  algebra: `⟪F,N⟫=0`, `⟪F,O⟫=cos ρ`, `‖F‖²=(cos ρ)⁻²·(1−⟪O,N⟫²)=(cos ρ)⁻²·cos²ρ=1`.
+- **`circle_tangent_greatCircle_inter`** (headline): the intersection is the **singleton**
+  `{greatCircleFoot O N ρ}` — genuine tangency (one contact point). Uniqueness: any common
+  `Q` has `⟪Q,F⟫ = (cos ρ)⁻¹(⟪Q,O⟫ − ⟪O,N⟫·⟪Q,N⟫) = (cos ρ)⁻¹(cos ρ − 0) = 1`, so `Q=F`
+  by `scos_eq_one_iff`.
+- **`sdist_greatCircleFoot_center`** : `sdist (foot) O = ρ` (via `mem_sCircle_iff_sdist`).
+
+### Why this matters
+This is the **incircle-to-side tangency primitive**, consumed three times (once per side)
+in any spherical incircle/excircle construction. It bridges the existing circle-circle
+tangency theory to an actual spherical incircle → the genuine open target (spherical
+Feuerbach). Kept the criterion in the clean geometric form `|⟪O,N⟫| = sin ρ`; internally
+squared it (`sq_abs`) to `⟪O,N⟫² = sin²ρ`, then `1 − sin²ρ = cos²ρ` via
+`Real.sin_sq_add_cos_sq`.
+
+### GOTCHAs
+- `scos Q O` is definitionally `⟪Q,O⟫` but `rw` needs a syntactic match: extract
+  `hQO' : (⟪Q,O⟫:ℝ) = cos ρ := hQO` (defeq `have`), then `rw [hQO']`.
+- To turn `|⟪O,N⟫| = sin ρ` into `⟪O,N⟫² = sin²ρ`: `rw [← sq_abs, htan]` (sq_abs: `|a|²=a²`).
+- OnSphere-from-inner-1 idiom (reused from `sphere_slerp_common_point`): `‖F‖²=1` →
+  `(‖F‖−1)(‖F‖+1)=0` via `nlinarith` → `mul_eq_zero` → exclude the negative root by
+  `norm_nonneg` + `positivity`.
+- Don't `set` the inner product `⟪O,N⟫` (ring atom-mismatch trap from prior sessions);
+  keep it explicit and let `ring` treat it as an atom.
+
+### Next steps (unchanged direction, still multi-session)
+1. Define a spherical triangle (3 model points) and its three side great circles (poles =
+   normalised cross-products / the geodesic normals); state the spherical incircle as the
+   circle tangent to all three sides via `TangentToGreatCircle`.
+2. Existence/uniqueness of the incenter (equidistant-from-sides point) — likely the hard
+   step; may need a spherical angle-bisector argument.
+3. Spherical nine-point circle, then the spherical Feuerbach tangency itself.
+
+BLOCKER (hyperbolic side, unchanged): no Mathlib hyperbolic metric — spherical model only.

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -399,3 +399,22 @@ squared it (`sq_abs`) to `⟪O,N⟫² = sin²ρ`, then `1 − sin²ρ = cos²ρ`
 3. Spherical nine-point circle, then the spherical Feuerbach tangency itself.
 
 BLOCKER (hyperbolic side, unchanged): no Mathlib hyperbolic metric — spherical model only.
+
+### Addendum (same session, researcher-1): great-circle unification + spherical incircle scaffolding [VERIFIED, 0-axiom]
+
+Stacked on the tangency-primitive commit (856→894L, docker `✔ [7743/7743]`, 0-axiom/0-sorry).
+
+- **`sGreatCircle_eq_sCircle`** : `sGreatCircle N = sCircle N (π/2)` — great circles ARE the
+  radius-`π/2` spherical circles (`cos(π/2)=0`; one-line `simp only [sGreatCircle, sCircle,
+  scos, Real.cos_pi_div_two]`). Unifies great-circle tangency with the earlier circle-circle
+  tangency: a side is just a special circle.
+- **`SphericalIncircle Na Nb Nc O ρ`** := tangent to all three side poles (three
+  `TangentToGreatCircle`s).
+- **`sphericalIncircle_contact_points`** : an incircle (`0≤ρ<π/2`) meets each of the three
+  sides in exactly one point — the three feet — via three applications of
+  `circle_tangent_greatCircle_inter`. This is the spherical "incircle tangent to all three
+  sides", the first Feuerbach ingredient, with explicit contact points.
+
+REMAINING HARD STEP (unchanged): existence/uniqueness of the incenter `O` for a *given*
+triangle (spherical angle-bisector / equidistant-locus argument) — not asserted here. Then
+spherical nine-point circle + the Feuerbach tangency.

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BUILD: circle-to-great-circle tangency layer added (FeuerbachsTheoremOQ04.lean, 856L, 0-axiom/0-sorry, VERIFIED docker [7743/7743]). Introduces sGreatCircle (geodesic/side), greatCircleFoot (explicit contact = foot of perpendicular), TangentToGreatCircle criterion |⟪O,N⟫|=sin ρ. greatCircleFoot_mem proves the foot lies on both objects; circle_tangent_greatCircle_inter upgrades to a SINGLETON intersection (genuine tangency, one contact point); sdist_greatCircleFoot_center confirms the contact is at distance ρ. This is the incircle-to-side tangency primitive (consumed 3× per spherical triangle) — the missing bridge between the circle-circle tangency theory and an actual spherical incircle/nine-point construction toward spherical Feuerbach.",
+    "progressSummary": "BUILD: circle-to-great-circle tangency + spherical incircle scaffolding (FeuerbachsTheoremOQ04.lean, 894L, 0-axiom/0-sorry, VERIFIED docker [7743/7743]). sGreatCircle/greatCircleFoot/TangentToGreatCircle + greatCircleFoot_mem + circle_tangent_greatCircle_inter (singleton intersection) + sdist_greatCircleFoot_center establish the incircle-to-side tangency primitive. sGreatCircle_eq_sCircle shows great circles are the radius-π/2 circles (unifying the two tangency notions). SphericalIncircle (tangent to 3 side poles) + sphericalIncircle_contact_points (incircle meets each side in exactly one point, explicit feet) package the first Feuerbach ingredient. REMAINING HARD STEP: existence/uniqueness of the incenter O for a given triangle (angle-bisector argument); then spherical nine-point circle + Feuerbach tangency.",
     "builtItems": [
       "FeuerbachsTheoremOQ04.chord_sq (Proofs/FeuerbachsTheoremOQ04.lean) — chord-cosine bridge: for unit vectors, ||P-Q||^2 = 2 - 2*scos P Q; turns spherical tangency into an inner-product equation. 0-axiom.",
       "FeuerbachsTheoremOQ04.abs_scos_le_one/scos_le_one/neg_one_le_scos — spherical cosine in [-1,1] (Cauchy-Schwarz on unit vectors)",
@@ -50,7 +50,10 @@
       "greatCircleFoot_mem — foot lies on both circle and great circle",
       "circle_tangent_greatCircle_inter — intersection is the singleton {foot} (genuine tangency)",
       "sdist_greatCircleFoot_center — contact point at spherical distance ρ from centre",
-      "inner_orthoComp_self / inner_orthoComp_left — ⟪O⊥,·⟫ = 1-⟪O,N⟫² helper lemmas"
+      "inner_orthoComp_self / inner_orthoComp_left — ⟪O⊥,·⟫ = 1-⟪O,N⟫² helper lemmas",
+      "sGreatCircle_eq_sCircle — great circle = sCircle N (π/2), unifies great-circle & circle-circle tangency",
+      "SphericalIncircle Na Nb Nc O ρ — circle tangent to all 3 side poles of a spherical triangle",
+      "sphericalIncircle_contact_points — incircle meets each of the 3 sides in exactly one point (explicit feet)"
     ],
     "insights": [
       "Mathlib has clean spherical geometry for free (unit vectors of any InnerProductSpace R E; geodesic distance = arccos of inner product) but essentially no hyperbolic metric, so the spherical model is the tractable non-Euclidean route for Feuerbach.",

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BUILD: common-tangent geodesic layer added (FeuerbachsTheoremOQ04.lean, 724L, 0-axiom/0-sorry, VERIFIED). radialDir/IsTangentDir formalise the tangent direction at the contact point; isTangentDir_iff reduces tangency to ⟪T,O⟫=0; common_perp_tangent proves any T orthogonal to both centres is a common tangent perpendicular to the line of centres; exists_common_perp_tangent gives non-vacuity for finrank>2; external/internal wrappers instantiate at the unique contact point. This is the spherical analogue of 'two tangent circles share a common tangent line at contact, perpendicular to the line of centres'.",
+    "progressSummary": "BUILD: circle-to-great-circle tangency layer added (FeuerbachsTheoremOQ04.lean, 856L, 0-axiom/0-sorry, VERIFIED docker [7743/7743]). Introduces sGreatCircle (geodesic/side), greatCircleFoot (explicit contact = foot of perpendicular), TangentToGreatCircle criterion |⟪O,N⟫|=sin ρ. greatCircleFoot_mem proves the foot lies on both objects; circle_tangent_greatCircle_inter upgrades to a SINGLETON intersection (genuine tangency, one contact point); sdist_greatCircleFoot_center confirms the contact is at distance ρ. This is the incircle-to-side tangency primitive (consumed 3× per spherical triangle) — the missing bridge between the circle-circle tangency theory and an actual spherical incircle/nine-point construction toward spherical Feuerbach.",
     "builtItems": [
       "FeuerbachsTheoremOQ04.chord_sq (Proofs/FeuerbachsTheoremOQ04.lean) — chord-cosine bridge: for unit vectors, ||P-Q||^2 = 2 - 2*scos P Q; turns spherical tangency into an inner-product equation. 0-axiom.",
       "FeuerbachsTheoremOQ04.abs_scos_le_one/scos_le_one/neg_one_le_scos — spherical cosine in [-1,1] (Cauchy-Schwarz on unit vectors)",
@@ -43,13 +43,22 @@
       "radialDir + IsTangentDir (FeuerbachsTheoremOQ04.lean): tangent-direction at contact point, with isTangentDir_iff reducing tangency to orthogonality with the centre",
       "common_perp_tangent (FeuerbachsTheoremOQ04.lean): dimension-free core — any T ⟂ both centres is a common tangent at the contact point and ⟂ the whole line-of-centres plane",
       "exists_common_perp_tangent (FeuerbachsTheoremOQ04.lean): non-vacuity for finrank ℝ E > 2 via orthogonal-complement dimension count",
-      "externallyTangent_common_perp_tangent / internallyTangent_common_perp_tangent (FeuerbachsTheoremOQ04.lean): both tangency cases share a common perpendicular tangent at the unique contact point"
+      "externallyTangent_common_perp_tangent / internallyTangent_common_perp_tangent (FeuerbachsTheoremOQ04.lean): both tangency cases share a common perpendicular tangent at the unique contact point",
+      "sGreatCircle N := {P | OnSphere P ∧ ⟪P,N⟫=0} — geodesic/triangle side (FeuerbachsTheoremOQ04.lean)",
+      "greatCircleFoot O N ρ := (cos ρ)⁻¹•(O-⟪O,N⟫•N) — explicit contact point",
+      "TangentToGreatCircle O ρ N := |⟪O,N⟫|=sin ρ — tangency criterion",
+      "greatCircleFoot_mem — foot lies on both circle and great circle",
+      "circle_tangent_greatCircle_inter — intersection is the singleton {foot} (genuine tangency)",
+      "sdist_greatCircleFoot_center — contact point at spherical distance ρ from centre",
+      "inner_orthoComp_self / inner_orthoComp_left — ⟪O⊥,·⟫ = 1-⟪O,N⟫² helper lemmas"
     ],
     "insights": [
       "Mathlib has clean spherical geometry for free (unit vectors of any InnerProductSpace R E; geodesic distance = arccos of inner product) but essentially no hyperbolic metric, so the spherical model is the tractable non-Euclidean route for Feuerbach.",
       "The chord-cosine bridge ||P-Q||^2 = 2-2<P,Q> is the key reduction: a spherical circle (level set of <P,O>) and tangency conditions become polynomial in the inner product, so the argument stays axiom-free.",
       "Spherical circle tangency target: internal iff sdist(O1,O2)=|rho1-rho2|, external iff sdist(O1,O2)=rho1+rho2 — the non-Euclidean analog of the Euclidean d=|r1-r2| / r1+r2 used in the verified Euclidean Feuerbach gallery files.",
-      "Spherical common tangent at a contact point is captured coordinate-free: since P ∈ span{O₁,O₂}, any T ⟂ {O₁,O₂} is simultaneously in the tangent space at P and tangent to both circles — no explicit geodesic parametrisation needed."
+      "Spherical common tangent at a contact point is captured coordinate-free: since P ∈ span{O₁,O₂}, any T ⟂ {O₁,O₂} is simultaneously in the tangent space at P and tangent to both circles — no explicit geodesic parametrisation needed.",
+      "Circle-to-great-circle tangency is the exact primitive a spherical INCIRCLE construction needs: the incircle is tangent to the three side-geodesics (great circles), not to other circles. Distance from a point to a great circle with unit pole N is arcsin|⟪O,N⟫|, so tangency criterion is |⟪O,N⟫| = sin ρ (spherical shadow of Euclidean distance-to-line = radius).",
+      "The contact point of a tangent circle and a side is the FOOT OF THE PERPENDICULAR (O - ⟪O,N⟫•N)/cos ρ; it is pure inner-product algebra (no infimum/analysis): ⟪foot,N⟫=0, ⟪foot,O⟫=cos ρ, ‖foot‖=1 via ‖O⊥‖²=1-⟪O,N⟫²=cos²ρ under the criterion. Uniqueness via ⟪Q,foot⟫=1 ⟹ Q=foot (scos_eq_one_iff)."
     ],
     "mathlibGaps": [
       "No developed hyperbolic-geometry metric (hyperboloid / Poincare disk distance) in Mathlib — blocks an axiom-free hyperbolic Feuerbach without building the model first.",


### PR DESCRIPTION
## Summary
Research session for **feuerbachs-theorem-oq-04** (Feuerbach's theorem in non-Euclidean / spherical geometry). Adds the **incircle-to-side tangency primitive** to `FeuerbachsTheoremOQ04.lean` (724→856 L, **0 sorry / 0 axiom**, docker `✔ [7743/7743]`, no warnings).

The existing file has a full **circle–circle** tangency theory (existence, uniqueness, spec, common perpendicular tangent). But the spherical incircle is tangent to the triangle's **sides** — arcs of *great circles*, not other circles — so circle–circle tangency does not directly apply. This session fills that gap.

## Progress (all VERIFIED, 0-axiom)
- **`sGreatCircle N`** — the great circle (geodesic / triangle side) with unit pole `N`: `{P | OnSphere P ∧ ⟪P,N⟫ = 0}`.
- **`greatCircleFoot O N ρ`** — the explicit contact point: the foot of the perpendicular from the centre, `(cos ρ)⁻¹ • (O − ⟪O,N⟫ • N)`.
- **`TangentToGreatCircle O ρ N`** — the tangency criterion `|⟪O,N⟫| = sin ρ` (spherical "distance from centre to side = radius"; the distance is `arcsin|⟪O,N⟫|`).
- **`inner_orthoComp_self` / `inner_orthoComp_left`** — helper: `⟪O⊥,·⟫ = 1 − ⟪O,N⟫²`.
- **`greatCircleFoot_mem`** — the foot is a model point lying on both the circle and the great circle (existence).
- **`circle_tangent_greatCircle_inter`** (headline) — the intersection is the **singleton** `{greatCircleFoot O N ρ}`: genuine tangency, exactly one contact point.
- **`sdist_greatCircleFoot_center`** — the contact point is at spherical distance `ρ` from the centre.

## Findings
- The whole layer is pure inner-product algebra — no infimum/analysis: `‖foot‖² = (cos ρ)⁻²·(1 − ⟪O,N⟫²) = (cos ρ)⁻²·cos²ρ = 1` under the criterion (via `sq_abs` + `Real.sin_sq_add_cos_sq`).
- Uniqueness reduces to `⟪Q,foot⟫ = 1 ⟹ Q = foot` (reusing `scos_eq_one_iff`).
- This is the primitive a spherical incircle/excircle construction consumes three times (once per side) — the missing bridge from the circle–circle theory toward an actual spherical incircle and, ultimately, spherical Feuerbach tangency.

## Status
**Outcome**: progress (verified building block toward the open target; not the full spherical Feuerbach theorem).
**Next steps**: define a spherical triangle + its three side great circles; state/construct the spherical incircle as the circle `TangentToGreatCircle` to all three sides; then the spherical nine-point circle and the Feuerbach tangency.

🤖 Generated by researcher-1