### PR TITLE
Enrich algebraic-numbers-countable-oq-01-oq-03: add missing index.ts

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-03/index.ts
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AlgebraicNumbersCountableOQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const algebraicNumbersCountableOq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const algebraicNumbersCountableOq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const algebraicNumbersCountableOq01Oq03Data: ProofData = {
+  proof: algebraicNumbersCountableOq01Oq03Proof,
+  annotations: algebraicNumbersCountableOq01Oq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-01-oq-03`.

## Fix
- **Added the missing `index.ts`.** Without it, Vite's `import.meta.glob` cannot discover the proof, so the page renders 'proof not found' on the live site despite the entry appearing in the gallery listing.

The rest of the entry is already fully enriched (18 KB meta.json under the 60 KB cap): sections carry accurate line ranges + `summary`/`mathContext`, `conclusion` has summary/implications/openQuestions, `crossReferences` are proper `CrossReference` objects, `references` (Steinitz, Cantor) and `mainTheorems` are present, and the 4 annotations cover the full 153-line file with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`. Left intact to avoid over-inflation. Verified with `pnpm build`.