### PR TITLE
Enrich alternating-series-test-oq-01-oq-01: add missing index.ts

### DIFF
--- a/src/data/proofs/alternating-series-test-oq-01-oq-01/index.ts
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AlternatingSeriesTestOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const alternatingSeriesTestOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const alternatingSeriesTestOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const alternatingSeriesTestOq01Oq01Data: ProofData = {
+  proof: alternatingSeriesTestOq01Oq01Proof,
+  annotations: alternatingSeriesTestOq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `alternating-series-test-oq-01-oq-01`.

## Fix
- **Added the missing `index.ts`.** Without it, Vite's `import.meta.glob` cannot discover the proof and the page renders 'proof not found' despite the entry appearing in the gallery listing.

The rest of the entry is already fully enriched (10.3 KB meta.json): sections carry line ranges + `summary`/`mathContext`, `conclusion` has summary/implications/openQuestions, `crossReferences` is a proper `CrossReference` object, `references` (Leibniz, Rudin) present, and the 4 annotations cover the full 186-line file with all required fields. Left intact to avoid over-inflation. Verified with `pnpm build`.