### PR TITLE
Enrich area-of-circle-oq-07-oq-02: add index.ts + missing description

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-02/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq07Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq07Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq07Oq02Data: ProofData = {
+  proof: areaOfCircleOq07Oq02Proof,
+  annotations: areaOfCircleOq07Oq02Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-07-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02/meta.json
@@ -19,6 +19,7 @@
     "sorries": 0
   },
   "title": "The Half-Line Gaussian Integral",
+  "description": "Evaluates the Gaussian integral over the positive half-line, ∫_{0}^{∞} e^{-b x²} dx = √(π/b)/2 — exactly half the full-line value — directly from Mathlib's integral_gaussian_Ioi. It then proves the even-symmetry bridge ∫_ℝ e^{-x²} = 2·∫_{(0,∞)} e^{-x²} (via integral_comp_abs and |x|² = x²) and composes it with the b = 1 half-line value √π/2 to re-derive the parent's ∫_ℝ e^{-x²} = √π along an independent route through Set.Ioi 0. 64 lines, 4 theorems, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-02`.

## Fixes
- **Added the missing `index.ts`** — without it the proof isn't discoverable by Vite's `import.meta.glob` and the page renders 'proof not found'.
- **Added the missing top-level `description`** — the meta.json had no `description` field, so the gallery card and proof header had no summary text. Added a concise LaTeX-bearing summary consistent with the overview/conclusion.

The rest is already fully enriched (sections with line ranges, `conclusion`, `CrossReference` objects, `references`, 4 annotations covering the whole 64-line file). Verified with `pnpm build`.