### PR TITLE
Enrich Σ 1/(a·n+b) divergence at b=0 (oq-06-oq-02): add missing index.ts

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-06-oq-02/index.ts
+++ b/src/data/proofs/harmonic-divergence-oq-06-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HarmonicDivergenceOQ06OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const harmonicDivergenceOq06Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const harmonicDivergenceOq06Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const harmonicDivergenceOq06Oq02Data: ProofData = {
+  proof: harmonicDivergenceOq06Oq02Proof,
+  annotations: harmonicDivergenceOq06Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `harmonic-divergence-oq-06-oq-02`.

The entry already had a complete, high-quality `meta.json` (overview, sections with line ranges, crossReferences, conclusion, references, mainTheorems) and full `annotations.json`, but was **missing `index.ts`** — so Vite's `import.meta.glob` could not discover it and the page rendered *"proof not found"* on the live site.

This PR adds the single missing Vite entry point. No other changes (the entry is already at target quality; per the size guardrails I did not deepen further). The Lean source `Proofs/HarmonicDivergenceOQ06OQ02.lean` is committed and verified on main (0 sorries, 0 axioms). `pnpm build` passes.