### PR TITLE
Enrich lagrange-four-squares-waring-g2-oq-03-oq-06: annotate module header

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "module-framing",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-06",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "context",
+    "title": "Module Framing: the Unconditional Half of the Rational Characterization",
+    "content": "The docstring situates the file against three gallery pillars it imports: Proofs.ThreeSquares (Legendre necessity axiom-free — 4^a(8b+7) is never a sum of three INTEGER squares — with sufficiency isolated as one axiom), Proofs.ThreeSquaresDavenportCassels (the axiom-free descent: rational representability ⟹ integral), and Proofs.ThreeSquaresRationalBridge (the still-open Hasse–Minkowski solvability hypothesis). This file records exactly what the first two give UNCONDITIONALLY once combined — the rational=integral Iff, rational necessity, and square-class invariance — deferring only the genuinely open sufficiency over ℚ, so that the closing full characterization is conditional on a single named hypothesis. No axiom, no sorry, no native_decide.",
+    "mathContext": "The three-square problem over $\\mathbb Q$ splits into a necessity half (2-adic obstruction, proved here unconditionally) and a sufficiency half (Hasse–Minkowski, the one remaining hypothesis).",
+    "significance": "context",
+    "relatedConcepts": ["Legendre three-square theorem", "Davenport–Cassels descent", "Hasse–Minkowski principle", "axiom accounting"],
+    "prerequisites": ["ternary quadratic forms", "local-global principle for quadratic forms"]
+  },
+  {
     "id": "rat-iff-int",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-06",
     "range": { "startLine": 44, "endLine": 54 },


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-06` ("Rational Three Squares: the Unconditional Half via Davenport–Cassels").

The entry was already well-enriched (description, full overview with 5 keyInsights, sections with line ranges, conclusion, top-level openQuestions, CrossReference objects, references, index.ts). The one genuine gap: annotations started at line 44, leaving the module docstring + imports (lines 1–43) uncovered.

## Change
- Added a single **module-framing annotation** (lines 1–43) explaining how the file combines its three imported gallery pillars (ThreeSquares necessity, the Davenport–Cassels descent, the RationalBridge Hasse–Minkowski hypothesis) into the unconditional half of the rational three-square characterization, plus the axiom accounting.
- Annotation coverage now 5 blocks spanning the full 115-line file.

Deliberately left the rest untouched (already at quality targets — avoiding over-inflation per the size guardrails). Verified with `pnpm build`.