### PR TITLE
Enrich abel-ruffini-oq-06: annotate module header

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-06/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-06/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-module-framing",
+    "proofId": "abel-ruffini-oq-06",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "context",
+    "title": "Module Framing: the Solvable Side of the Sₙ Threshold",
+    "content": "The group-theoretic core of Abel–Ruffini is the dichotomy Sₙ is solvable ⟺ n ≤ 4. Mathlib supplies the non-solvable half (Equiv.Perm.fin_5_not_solvable, generalized to n ≥ 5 in the sibling AbelRuffiniObstructionOQ06), but not the POSITIVE half — there is no Mathlib lemma giving IsSolvable (Equiv.Perm (Fin n)) for the small cases. This file provides it via a reusable reduction (Aₙ solvable ⟹ Sₙ solvable) plus the base cases S₂, S₃ (whose alternating groups have prime order, hence are cyclic⇒abelian⇒solvable). Together with n ≥ 5 this settles every n except S₄, isolated in the companion Aristotle file. Scope note: the characteristic-p / Abhyankar angle in the title is deliberately out of scope — this is the characteristic-independent core.",
+    "mathContext": "Threshold: $S_n$ solvable $\\iff n \\le 4$. This file supplies the $n \\in \\{2,3\\}$ solvable cases and the reduction from $A_n$ to $S_n$.",
+    "significance": "context",
+    "relatedConcepts": ["Abel–Ruffini theorem", "solvable group", "symmetric group threshold", "alternating group"],
+    "prerequisites": ["solvable groups", "symmetric and alternating groups"]
+  },
+  {
     "id": "ann-reduction",
     "proofId": "abel-ruffini-oq-06",
     "range": { "startLine": 57, "endLine": 61 },


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-06` ("the solvable side of the symmetric-group threshold").

The entry was already well-enriched (description, overview with 4 keyInsights, sections with line ranges, conclusion with openQuestions, 7 references, CrossReference objects, index.ts). The one genuine gap: annotations began at line 57, leaving the module docstring + imports (lines 1–56) uncovered.

## Change
- Added a single **module-framing annotation** (lines 1–56): the Sₙ solvable ⟺ n ≤ 4 dichotomy, what Mathlib supplies (the n ≥ 5 obstruction) vs. omits (the small solvable cases), the reduction + prime-order-base-case strategy, and the S₄ / characteristic-p scope notes.
- Annotation coverage now 5 blocks spanning the full 94-line file.

Left the rest untouched (already at quality targets). Verified with `pnpm build`.