### PR TITLE
research(brouwer-fixed-point-oq-04-oq-03-oq-01): singleton correspondence bridge [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ04OQ03OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ04OQ03OQ01.lean
@@ -1,0 +1,184 @@
+/-
+  Brouwer Fixed Point OQ-04-OQ-03-OQ-01:
+  The Singleton Correspondence Bridge — Single-Valued Fixed Point Theorems
+  as Special Cases of Set-Valued Ones
+
+  Context (parent chain):
+  - OQ-04       : Kakutani Fixed Point Theorem (set-valued, finite-dim)
+  - OQ-04-OQ-03 : Fan-Glicksberg extension to locally convex spaces
+                  (both stated as axioms — genuine open/hard formalizations)
+
+  This child isolates the ONE piece of that hierarchy that is fully
+  machine-checkable with zero axioms: the precise sense in which every
+  single-valued fixed point theorem (Brouwer, Schauder) is a special case
+  of its set-valued counterpart (Kakutani, Fan-Glicksberg).
+
+  The bridge is the "singleton correspondence"
+        F_f (x) := { f x }.
+  We prove, with no axioms:
+
+    1. F_f is upper hemicontinuous  ⟺  f is continuous
+    2. F_f always has nonempty values
+    3. F_f has closed values         (in a T1 space)
+    4. F_f has convex values         (in a real vector space)
+    5. x is a fixed point of F_f     ⟺  f x = x
+    6. Reduction theorem: any set-valued fixed point principle satisfying
+       Kakutani's hypotheses yields the corresponding single-valued
+       (Brouwer-type) fixed point theorem — stated axiom-free, taking the
+       set-valued principle as a hypothesis rather than an axiom.
+
+  Together these say: single-valued fixed point theory embeds faithfully
+  into set-valued fixed point theory, and the embedding preserves exactly
+  the hypotheses (continuity ↦ upper hemicontinuity + nonempty/closed/convex
+  values) and conclusions (fixed points).
+
+  All results are `verified`, 0-axiom, 0-sorry.
+
+  References:
+  - Kakutani, "A generalization of Brouwer's fixed point theorem" (1941)
+  - Border, "Fixed Point Theorems with Applications to Economics and
+    Game Theory" (1985), Ch. 15 (singleton correspondences)
+-/
+
+import Mathlib
+
+namespace BrouwerOQ04OQ03OQ01
+
+open Set
+
+-- ============================================================
+-- PART I: Set-valued maps (mirrors the parent OQ-04-OQ-03 file)
+-- ============================================================
+
+/-- A set-valued map (correspondence) from `X` to `Y`. -/
+def SetValuedMap (X Y : Type*) := X → Set Y
+
+/-- Upper hemicontinuity: the "upper preimage" of every open set is open.
+    Equivalently, for every open `U ⊇ F x` there is a neighbourhood `V` of
+    `x` with `F y ⊆ U` for all `y ∈ V`. -/
+def IsUpperHemicontinuous {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    (F : SetValuedMap X Y) : Prop :=
+  ∀ U : Set Y, IsOpen U → IsOpen {x | F x ⊆ U}
+
+/-- A set-valued map has nonempty values. -/
+def HasNonemptyValues {X Y : Type*} (F : SetValuedMap X Y) : Prop :=
+  ∀ x, (F x).Nonempty
+
+/-- A set-valued map has closed values. -/
+def HasClosedValues {X Y : Type*} [TopologicalSpace Y] (F : SetValuedMap X Y) : Prop :=
+  ∀ x, IsClosed (F x)
+
+/-- A set-valued map has convex values (in a real vector space). -/
+def HasConvexValues {X Y : Type*} [AddCommMonoid Y] [Module ℝ Y]
+    (F : SetValuedMap X Y) : Prop :=
+  ∀ x, Convex ℝ (F x)
+
+/-- `x` is a fixed point of a self-correspondence: `x ∈ F x`. -/
+def IsFixedPoint {X : Type*} (F : SetValuedMap X X) (x : X) : Prop :=
+  x ∈ F x
+
+/-- The singleton correspondence attached to a single-valued map `f`. -/
+def singletonMap {X Y : Type*} (f : X → Y) : SetValuedMap X Y := fun x => {f x}
+
+-- ============================================================
+-- PART II: The key set identity
+-- ============================================================
+
+/-- The upper preimage of `U` under the singleton correspondence of `f`
+    is exactly the ordinary preimage `f ⁻¹' U`. This is the computational
+    core of every result below. -/
+theorem upperPreimage_singletonMap {X Y : Type*} (f : X → Y) (U : Set Y) :
+    {x | singletonMap f x ⊆ U} = f ⁻¹' U := by
+  ext x
+  simp only [singletonMap, mem_setOf_eq, singleton_subset_iff, mem_preimage]
+
+-- ============================================================
+-- PART III: Continuity ⟺ upper hemicontinuity for singletons
+-- ============================================================
+
+/-- **Bridge (topology).** The singleton correspondence `F_f (x) = {f x}` is
+    upper hemicontinuous if and only if `f` is continuous. This is precisely
+    why Brouwer's continuous-map hypothesis matches Kakutani's upper
+    hemicontinuity hypothesis. -/
+theorem singleton_uhc_iff_continuous
+    {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] (f : X → Y) :
+    IsUpperHemicontinuous (singletonMap f) ↔ Continuous f := by
+  rw [continuous_def]
+  constructor
+  · intro h U hU
+    have := h U hU
+    rwa [upperPreimage_singletonMap] at this
+  · intro h U hU
+    have := h U hU
+    rw [upperPreimage_singletonMap]
+    exact this
+
+-- ============================================================
+-- PART IV: The remaining Kakutani hypotheses for singletons
+-- ============================================================
+
+/-- Singleton values are always nonempty. -/
+theorem singleton_hasNonemptyValues {X Y : Type*} (f : X → Y) :
+    HasNonemptyValues (singletonMap f) :=
+  fun x => ⟨f x, rfl⟩
+
+/-- Singleton values are closed in a T1 space. -/
+theorem singleton_hasClosedValues {X Y : Type*} [TopologicalSpace Y] [T1Space Y]
+    (f : X → Y) : HasClosedValues (singletonMap f) :=
+  fun _ => isClosed_singleton
+
+/-- Singleton values are convex in a real vector space. -/
+theorem singleton_hasConvexValues {X Y : Type*} [AddCommMonoid Y] [Module ℝ Y]
+    (f : X → Y) : HasConvexValues (singletonMap f) :=
+  fun _ => convex_singleton _
+
+-- ============================================================
+-- PART V: Fixed points transfer exactly
+-- ============================================================
+
+/-- **Bridge (fixed points).** `x` is a fixed point of the singleton
+    correspondence of `f` iff `x` is an ordinary fixed point `f x = x`. -/
+theorem singleton_isFixedPoint_iff {X : Type*} (f : X → X) (x : X) :
+    IsFixedPoint (singletonMap f) x ↔ f x = x := by
+  unfold IsFixedPoint singletonMap
+  rw [mem_singleton_iff]
+  exact eq_comm
+
+-- ============================================================
+-- PART VI: Reduction theorem (axiom-free)
+-- ============================================================
+
+/-- **Brouwer reduces to Kakutani.** Suppose we are handed *any* set-valued
+    fixed point principle `kakutani`: on a fixed nonempty compact convex
+    domain `K ⊆ Y`, every self-correspondence with nonempty, closed, convex
+    values that is upper hemicontinuous and maps `K` into itself has a fixed
+    point in `K`. Then every continuous single-valued self-map `f` of `K`
+    has an ordinary fixed point in `K`.
+
+    This is stated with the set-valued principle as a *hypothesis*, so the
+    theorem itself is fully verified and axiom-free: it is the rigorous
+    content of "single-valued ⊆ set-valued". Instantiating `kakutani` with
+    the actual Kakutani/Fan-Glicksberg theorem recovers the classical
+    Brouwer/Schauder fixed point theorem on `K`. -/
+theorem brouwer_from_kakutani_principle
+    {Y : Type*} [TopologicalSpace Y] [T1Space Y] [AddCommMonoid Y] [Module ℝ Y]
+    (K : Set Y)
+    (kakutani : ∀ F : SetValuedMap Y Y,
+      (∀ x ∈ K, F x ⊆ K) →
+      IsUpperHemicontinuous F →
+      HasNonemptyValues F →
+      HasClosedValues F →
+      HasConvexValues F →
+      ∃ x ∈ K, IsFixedPoint F x)
+    (f : Y → Y) (hf : ∀ x ∈ K, f x ∈ K) (hcont : Continuous f) :
+    ∃ x ∈ K, f x = x := by
+  obtain ⟨x, hxK, hx⟩ := kakutani (singletonMap f)
+    (fun x hx => by
+      simp only [singletonMap, singleton_subset_iff]; exact hf x hx)
+    ((singleton_uhc_iff_continuous f).mpr hcont)
+    (singleton_hasNonemptyValues f)
+    (singleton_hasClosedValues f)
+    (singleton_hasConvexValues f)
+  exact ⟨x, hxK, (singleton_isFixedPoint_iff f x).mp hx⟩
+
+end BrouwerOQ04OQ03OQ01

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-bridge-set-valued-vocab",
+    "proofId": "brouwer-fixed-point-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 81
+    },
+    "type": "concept",
+    "title": "The Set-Valued Vocabulary and the Singleton Correspondence",
+    "content": "Part I mirrors the parent Kakutani file's definitions: a `SetValuedMap X Y` is a function `X → Set Y`; upper hemicontinuity (`IsUpperHemicontinuous`) is the open-preimage condition '{x | F x ⊆ U} is open for every open U'; and `HasNonemptyValues`, `HasClosedValues`, `HasConvexValues`, `IsFixedPoint` capture the remaining Kakutani data. The new definition is `singletonMap f := fun x => {f x}` — the correspondence attached to a single-valued map. Everything downstream studies how this one construction interacts with the set-valued vocabulary.",
+    "mathContext": "For $f : X \\to Y$ the singleton correspondence is $F_f(x) = \\{f(x)\\}$. A fixed point of a self-correspondence $F$ is a point with $x \\in F(x)$; for $F_f$ this reads $x \\in \\{f(x)\\}$, i.e. $f(x) = x$. Upper hemicontinuity is stated globally: $F$ is UHC iff $\\{x \\mid F(x) \\subseteq U\\}$ is open for every open $U$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "correspondence",
+      "upper hemicontinuity",
+      "set-valued analysis",
+      "singleton set"
+    ],
+    "prerequisites": [
+      "Set.Nonempty",
+      "IsOpen",
+      "IsClosed",
+      "Convex"
+    ]
+  },
+  {
+    "id": "ann-bridge-upper-preimage-identity",
+    "proofId": "brouwer-fixed-point-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 87,
+      "endLine": 93
+    },
+    "type": "key-step",
+    "title": "The Computational Core: Upper Preimage = Ordinary Preimage",
+    "content": "`upperPreimage_singletonMap` proves the single identity on which the entire bridge rests: {x | singletonMap f x ⊆ U} = f⁻¹' U. The proof is one `ext` followed by `simp` with `singleton_subset_iff` (the fact that {a} ⊆ U ↔ a ∈ U). This is the reason the embedding of single-valued into set-valued theory is faithful: the upper-hemicontinuity preimage of the correspondence carries exactly the same information as the ordinary preimage of the function, so no continuity data is gained or lost.",
+    "mathContext": "$\\{x \\mid \\{f(x)\\} \\subseteq U\\} = \\{x \\mid f(x) \\in U\\} = f^{-1}(U)$, using $\\{a\\} \\subseteq U \\iff a \\in U$. Because the UHC preimage of $F_f$ literally is $f^{-1}(U)$, openness of one is openness of the other.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "preimage",
+      "singleton_subset_iff",
+      "upper hemicontinuity"
+    ],
+    "prerequisites": [
+      "Set.preimage",
+      "Set.singleton_subset_iff"
+    ]
+  },
+  {
+    "id": "ann-bridge-uhc-iff-continuous",
+    "proofId": "brouwer-fixed-point-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 99,
+      "endLine": 114
+    },
+    "type": "key-step",
+    "title": "UHC of the Singleton Correspondence ⟺ Continuity of f",
+    "content": "`singleton_uhc_iff_continuous` upgrades the preimage identity into a full equivalence: `IsUpperHemicontinuous (singletonMap f) ↔ Continuous f`. After rewriting with `continuous_def` (continuity = openness of preimages of opens), both directions are immediate rewrites by the core identity. That this is an *iff*, not merely 'continuity ⟹ UHC', is the precise justification for why Kakutani's upper-hemicontinuity hypothesis is the correct set-valued analogue of Brouwer's continuity hypothesis — they coincide exactly on singleton correspondences.",
+    "mathContext": "By $\\text{continuous } f \\iff \\forall U \\text{ open}, f^{-1}(U) \\text{ open}$ and the identity $\\{x \\mid F_f(x)\\subseteq U\\}=f^{-1}(U)$, upper hemicontinuity of $F_f$ and continuity of $f$ are the same statement. UHC is thus the faithful generalization of continuity to correspondences.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "continuous_def",
+      "upper hemicontinuity",
+      "continuity"
+    ],
+    "prerequisites": [
+      "continuous_def"
+    ]
+  },
+  {
+    "id": "ann-bridge-value-conditions",
+    "proofId": "brouwer-fixed-point-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 120,
+      "endLine": 133
+    },
+    "type": "technique",
+    "title": "Singletons Satisfy the Remaining Kakutani Value-Conditions",
+    "content": "Part IV discharges the other three Kakutani hypotheses for singleton correspondences, each pointwise and each under the minimal ambient typeclass: values are nonempty always (`⟨f x, rfl⟩`), closed in a T1 space (`isClosed_singleton`), and convex in a real vector space (`convex_singleton`). Making the hypotheses explicit — T1 for closedness, a real module for convexity — is part of the contribution: it names exactly what ambient structure the transfer of each Kakutani condition requires.",
+    "mathContext": "A singleton $\\{f(x)\\}$ is always nonempty; it is closed precisely because points are closed in a $T_1$ space ($\\texttt{isClosed\\_singleton}$); and it is convex in any real vector space ($\\texttt{convex\\_singleton}$). These are the three non-continuity Kakutani hypotheses, so $F_f$ satisfies all four whenever $f$ is continuous.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "T1Space",
+      "isClosed_singleton",
+      "convex_singleton",
+      "Kakutani hypotheses"
+    ],
+    "prerequisites": [
+      "T1Space",
+      "Convex"
+    ]
+  },
+  {
+    "id": "ann-bridge-fixed-point-transfer",
+    "proofId": "brouwer-fixed-point-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 139,
+      "endLine": 145
+    },
+    "type": "key-step",
+    "title": "Fixed Points Transfer Exactly",
+    "content": "`singleton_isFixedPoint_iff` shows the set-valued fixed-point equation specializes exactly to the scalar one: `IsFixedPoint (singletonMap f) x ↔ f x = x`. After unfolding, `mem_singleton_iff` turns `x ∈ {f x}` into `x = f x`, and `eq_comm` flips it to `f x = x`. The embedding therefore neither invents nor destroys fixed points — the correspondence has exactly the fixed points of the original map.",
+    "mathContext": "$x \\in F_f(x) = \\{f(x)\\} \\iff x = f(x) \\iff f(x) = x$. The conclusion of Kakutani's theorem (a set-valued fixed point) specializes to the conclusion of Brouwer's theorem (an ordinary fixed point) with no loss.",
+    "significance": "important",
+    "relatedConcepts": [
+      "fixed point",
+      "mem_singleton_iff"
+    ],
+    "prerequisites": [
+      "Set.mem_singleton_iff"
+    ]
+  },
+  {
+    "id": "ann-bridge-reduction-theorem",
+    "proofId": "brouwer-fixed-point-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 150,
+      "endLine": 183
+    },
+    "type": "key-step",
+    "title": "Axiom-Free Reduction: Kakutani-Type Principle ⟹ Brouwer-Type Theorem",
+    "content": "`brouwer_from_kakutani_principle` assembles the whole file into one reduction. It takes, as an explicit hypothesis `kakutani`, any set-valued fixed point principle on a domain K (every UHC self-correspondence with nonempty/closed/convex values mapping K into itself has a fixed point in K), and concludes that every continuous self-map f of K has an ordinary fixed point in K. The proof feeds `singletonMap f` to the principle, discharging its five obligations with the earlier lemmas, then reads off `f x = x` via `singleton_isFixedPoint_iff`. Because the deep theorem is a *hypothesis*, not an `axiom`, the whole result is unconditionally verified and 0-axiom; instantiating `kakutani` with the actual Kakutani/Fan-Glicksberg theorem recovers classical Brouwer/Schauder on K.",
+    "mathContext": "Statement: for $K \\subseteq Y$ (with $Y$ a $T_1$ real vector space), if every UHC, nonempty/closed/convex-valued self-correspondence $F$ with $F(K) \\subseteq K$ has a fixed point in $K$, then every continuous $f : Y \\to Y$ with $f(K) \\subseteq K$ has $x \\in K$ with $f(x) = x$. Quantifying over the principle keeps the theorem axiom-free while faithfully encoding 'Kakutani $\\Rightarrow$ Brouwer'.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Kakutani fixed point theorem",
+      "Brouwer fixed point theorem",
+      "reduction",
+      "proof-relevant hypothesis"
+    ],
+    "prerequisites": [
+      "singleton_subset_iff",
+      "T1Space",
+      "Module"
+    ]
+  }
+]

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "brouwer-fixed-point-oq-04-oq-03-oq-01",
+  "title": "The Singleton Correspondence Bridge: Single-Valued Fixed Point Theorems as Special Cases of Set-Valued Ones",
+  "slug": "brouwer-fixed-point-oq-04-oq-03-oq-01",
+  "description": "Isolates the one fully machine-checkable, axiom-free piece of the Kakutani/Fan-Glicksberg hierarchy: the precise sense in which every single-valued fixed point theorem (Brouwer, Schauder) is a special case of its set-valued counterpart. The bridge is the singleton correspondence F_f(x) = {f x}. We prove, with zero axioms, that F_f is upper hemicontinuous iff f is continuous, always has nonempty/closed/convex values, that fixed points transfer exactly, and — as an axiom-free reduction theorem taking the set-valued fixed point principle as a hypothesis — that any Kakutani-type principle yields the corresponding Brouwer-type theorem.",
+  "meta": {
+    "author": "Robb Walters (formalization); classical (Kakutani 1941, Border 1985 Ch. 15)",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BrouwerFixedPointOQ04OQ03OQ01.lean",
+    "tags": [
+      "topology",
+      "fixed-point-theory",
+      "set-valued-analysis",
+      "correspondences"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 184,
+    "theoremCount": 7,
+    "definitionCount": 7,
+    "assumptions": "None. Fully machine-checked, 0 axioms, 0 sorries. The reduction theorem `brouwer_from_kakutani_principle` takes the set-valued fixed point principle as an explicit hypothesis rather than an axiom, so the theorem itself is unconditionally verified; instantiating that hypothesis with the actual Kakutani/Fan-Glicksberg theorem recovers classical Brouwer/Schauder.",
+    "historicalContext": "The parent hierarchy (OQ-04: Kakutani 1941; OQ-04-OQ-03: Fan-Glicksberg 1952) states its two headline theorems as axioms, because their proofs need degree theory or Schauder's theorem and are not packaged in Mathlib. This child extracts the part of that hierarchy that requires no such machinery: the embedding of single-valued fixed point theory into set-valued fixed point theory via the singleton correspondence F_f(x) = {f x}. This embedding is folklore in the mathematical-economics literature (Border, Fixed Point Theorems with Applications to Economics and Game Theory, 1985, Ch. 15), where it justifies why Kakutani's theorem is stated as the strict generalization of Brouwer's. Here it is made fully formal and axiom-free.",
+    "problemStatement": "In what precise sense is every single-valued fixed point theorem a special case of a set-valued one? Concretely: given a single-valued map f : X → Y, form its singleton correspondence F_f(x) := {f x}. Which of Kakutani's hypotheses (upper hemicontinuity, nonempty/closed/convex values) does F_f satisfy, and how do they relate to hypotheses on f? And does a fixed point of F_f coincide with an ordinary fixed point of f?",
+    "proofStrategy": "The computational core is a single set identity: the upper preimage {x | F_f(x) ⊆ U} equals the ordinary preimage f⁻¹(U) (`upperPreimage_singletonMap`, by `singleton_subset_iff`). From it, upper hemicontinuity of F_f unfolds — via `continuous_def` — to exactly the continuity of f (`singleton_uhc_iff_continuous`, an iff). The three remaining Kakutani value-conditions are discharged pointwise: nonempty (`⟨f x, rfl⟩`), closed in a T1 space (`isClosed_singleton`), convex in a real vector space (`convex_singleton`). Fixed points transfer by `mem_singleton_iff` plus `eq_comm` (`singleton_isFixedPoint_iff`). Finally `brouwer_from_kakutani_principle` assembles these: given any set-valued principle guaranteeing a fixed point for UHC nonempty/closed/convex self-correspondences on a domain K, feeding it F_f produces an ordinary fixed point of any continuous self-map f of K — the rigorous content of 'single-valued ⊆ set-valued', stated with the principle as a hypothesis so the whole theorem is verified.",
+    "keyInsights": [
+      "The entire bridge rests on one set identity: {x | {f x} ⊆ U} = f⁻¹(U). Every downstream result is a one- or two-line consequence, which is exactly why the embedding is 'faithful' — no information is lost passing from f to F_f.",
+      "Upper hemicontinuity of the singleton correspondence is not merely implied by continuity of f — it is *equivalent* to it (`singleton_uhc_iff_continuous` is a genuine iff). This pins down UHC as the correct set-valued generalization of continuity.",
+      "The reduction theorem is stated with the Kakutani/Fan-Glicksberg principle as an explicit hypothesis, not an axiom. This keeps the entry honestly 0-axiom while still expressing the full logical content 'Kakutani ⟹ Brouwer': the hard theorem is quantified over, not assumed globally.",
+      "The four hypotheses map cleanly: continuity ↦ upper hemicontinuity, and 'single value' ↦ nonempty + closed (T1) + convex values. The T1 assumption is exactly what closedness of singletons needs; convexity needs a real module structure. Naming these minimal ambient hypotheses is part of the contribution.",
+      "Fixed points transfer as an iff (`singleton_isFixedPoint_iff`): x ∈ {f x} ⟺ f x = x. The set-valued fixed-point equation x ∈ F(x) genuinely specializes to the scalar equation f x = x, so no spurious or missing fixed points are introduced by the embedding."
+    ],
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "A fully axiom-free Lean formalization of the singleton-correspondence embedding of single-valued into set-valued fixed point theory.",
+      "`singleton_uhc_iff_continuous`: the equivalence (not just implication) of upper hemicontinuity of F_f with continuity of f.",
+      "`brouwer_from_kakutani_principle`: an axiom-free reduction theorem that takes an abstract Kakutani-type fixed point principle as a hypothesis and derives the corresponding single-valued (Brouwer-type) theorem, isolating exactly which ambient hypotheses (T1, real module) the transfer needs.",
+      "Explicit identification of the minimal typeclass hypotheses under which each Kakutani value-condition holds for singletons."
+    ],
+    "definitionCount_note": "7 definitions: SetValuedMap, IsUpperHemicontinuous, HasNonemptyValues, HasClosedValues, HasConvexValues, IsFixedPoint, singletonMap."
+  },
+  "references": [
+    {
+      "authors": "Kakutani, Shizuo",
+      "title": "A generalization of Brouwer's fixed point theorem",
+      "year": "1941",
+      "venue": "Duke Mathematical Journal 8(3), 457–459"
+    },
+    {
+      "authors": "Border, Kim C.",
+      "title": "Fixed Point Theorems with Applications to Economics and Game Theory",
+      "year": "1985",
+      "venue": "Cambridge University Press, Ch. 15 (singleton correspondences)"
+    },
+    {
+      "authors": "Brouwer, L. E. J.",
+      "title": "Über Abbildung von Mannigfaltigkeiten",
+      "year": "1911",
+      "venue": "Mathematische Annalen 71(1), 97–115"
+    }
+  ],
+  "leanFile": {
+    "namespace": "BrouwerOQ04OQ03OQ01",
+    "lineCount": 184,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 7,
+    "mainTheorems": [
+      {
+        "name": "upperPreimage_singletonMap",
+        "status": "proved",
+        "description": "The upper preimage {x | {f x} ⊆ U} equals the ordinary preimage f⁻¹(U) — the computational core."
+      },
+      {
+        "name": "singleton_uhc_iff_continuous",
+        "status": "proved",
+        "description": "The singleton correspondence F_f is upper hemicontinuous iff f is continuous."
+      },
+      {
+        "name": "singleton_isFixedPoint_iff",
+        "status": "proved",
+        "description": "x is a fixed point of F_f iff f x = x."
+      },
+      {
+        "name": "brouwer_from_kakutani_principle",
+        "status": "proved",
+        "description": "Axiom-free reduction: any set-valued fixed point principle satisfying Kakutani's hypotheses yields the corresponding single-valued (Brouwer-type) fixed point theorem."
+      }
+    ],
+    "path": "Proofs/BrouwerFixedPointOQ04OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "brouwer-fixed-point-oq-04-oq-03",
+      "relationship": "ancestor",
+      "description": "Direct parent: the (axiomatized) infinite-dimensional Kakutani / Fan-Glicksberg theorem. This child extracts the one axiom-free component of that development — the singleton-correspondence bridge — and proves it unconditionally, with the set-valued principle taken as an explicit hypothesis rather than an axiom."
+    },
+    {
+      "targetId": "brouwer-fixed-point-oq-04",
+      "relationship": "ancestor",
+      "description": "Grandparent: the original Kakutani fixed point theorem. The bridge formalizes exactly why Kakutani is stated as a strict generalization of Brouwer — single-valued maps embed as singleton correspondences preserving all four Kakutani hypotheses."
+    },
+    {
+      "targetId": "brouwer-fixed-point",
+      "relationship": "related",
+      "description": "The single-valued endpoint of the bridge: instantiating the reduction theorem's Kakutani hypothesis with the actual theorem recovers classical Brouwer on a compact convex domain."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified, **0-axiom** child of `brouwer-fixed-point-oq-04-oq-03` (whose parent states Kakutani and Fan-Glicksberg as axioms). This entry isolates the one part of that hierarchy that is fully machine-checkable without degree theory or Schauder's theorem: the **singleton correspondence bridge**

$$F_f(x) := \{f(x)\}$$

embedding single-valued fixed point theory (Brouwer, Schauder) faithfully into set-valued fixed point theory (Kakutani, Fan-Glicksberg).

## What is proved (0 axioms, 0 sorries, 7 theorems, 7 definitions, 184 lines)

- **`upperPreimage_singletonMap`** — the computational core: $\{x \mid \{f x\} \subseteq U\} = f^{-1}(U)$.
- **`singleton_uhc_iff_continuous`** — $F_f$ is upper hemicontinuous **iff** $f$ is continuous (a genuine equivalence; pins UHC as the correct set-valued generalization of continuity).
- **`singleton_hasNonemptyValues` / `singleton_hasClosedValues` (T1) / `singleton_hasConvexValues` (real module)** — the three remaining Kakutani value-conditions, each under its minimal ambient typeclass.
- **`singleton_isFixedPoint_iff`** — $x \in \{f x\} \iff f x = x$; fixed points transfer exactly (none invented or destroyed).
- **`brouwer_from_kakutani_principle`** — an axiom-free reduction theorem: taking *any* Kakutani-type fixed point principle as an explicit **hypothesis** (not an axiom), it derives the corresponding single-valued Brouwer-type theorem. Instantiating the hypothesis with the actual Kakutani/Fan-Glicksberg theorem recovers classical Brouwer/Schauder on $K$.

The reduction is stated with the deep theorem quantified over rather than assumed globally, so the whole file is honestly **0-axiom** while still expressing the full logical content "Kakutani ⟹ Brouwer".

## Verification

Built with `./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ04OQ03OQ01` — compiles cleanly, 0 axioms, 0 sorries, no warnings.

## Files
- `proofs/Proofs/BrouwerFixedPointOQ04OQ03OQ01.lean`
- `src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/{meta.json,annotations.json}`

References: Kakutani (1941); Border, *Fixed Point Theorems with Applications to Economics and Game Theory* (1985), Ch. 15; Brouwer (1911).

🤖 Generated with [Claude Code](https://claude.com/claude-code)