### PR TITLE
Enrich bernoulli-inequality-oq-01: add index.ts + annotate module header

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "module-framing",
+    "proofId": "bernoulli-inequality-oq-01",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "Module Framing: the Sharp Strict Bernoulli Inequality",
+    "content": "Bernoulli's inequality is 1 + n·a ≤ (1+a)ⁿ for a ≥ -1; the weak integer-power form is Mathlib's one_add_mul_le_pow. The discarded quadratic term C(n,2)·a² is strictly positive exactly when a ≠ 0 and n ≥ 2, which is what makes the STRICT form sharper. This file proves the complete sharp picture over the full domain a > -1: the strict inequality one_add_mul_lt_pow (including the harder negative subrange -1 < a < 0, where 1 + n·a can be negative), and the two-sided characterizations one_add_mul_lt_pow_iff (strict ⟺ a ≠ 0 ∧ 2 ≤ n) and one_add_mul_eq_pow_iff (equality ⟺ a = 0 ∨ n ≤ 1). Mathlib has only the weak integer form and an rpow strict form; the gallery's binomial-theorem-oq-05 covers only a > 0 — the extension to a > -1 with the iff characterizations is new.",
+    "mathContext": "$1 + na < (1+a)^n$ for $a>-1,\\ a\\ne 0,\\ n\\ge 2$; equality $\\iff a=0 \\vee n\\le 1$. The gap is the binomial remainder $\\binom{n}{2}a^2 + \\cdots > 0$.",
+    "significance": "context",
+    "relatedConcepts": ["Bernoulli's inequality", "strict vs weak inequality", "equality characterization", "binomial theorem"],
+    "prerequisites": ["real exponentiation with natural powers", "binomial expansion"]
+  },
+  {
     "id": "strict",
     "proofId": "bernoulli-inequality-oq-01",
     "range": { "startLine": 36, "endLine": 64 },

--- a/src/data/proofs/bernoulli-inequality-oq-01/index.ts
+++ b/src/data/proofs/bernoulli-inequality-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BernoulliInequalityOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const bernoulliInequalityOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bernoulliInequalityOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bernoulliInequalityOq01Data: ProofData = {
+  proof: bernoulliInequalityOq01Proof,
+  annotations: bernoulliInequalityOq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `bernoulli-inequality-oq-01` ("the sharp strict form and its equality characterization").

## Fixes
- **Added the missing `index.ts`** — without it the proof isn't discoverable by Vite's `import.meta.glob` and the page renders 'proof not found'.
- **Added a module-framing annotation** (lines 1–35), covering the previously-unannotated docstring/imports: the sharp strict Bernoulli picture over the full domain a > -1, the strictness/equality `iff` characterizations, and how the result goes beyond Mathlib (weak form only) and the gallery's `binomial-theorem-oq-05` (a > 0 only). Coverage now 5 annotation blocks spanning the full 108-line file.

The rest was already fully enriched (description, overview, sections with line ranges + mathContext, conclusion with openQuestions, references, CrossReference objects). Verified with `pnpm build`.