### PR TITLE
Enrich cauchy-group-theorem OQ cluster: add references (9 entries)

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01/meta.json
@@ -3,6 +3,29 @@
   "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
   "title": "The exponent governs the power map: range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) in every group",
   "description": "The parent showed that in a finite group of order m the power map x ↦ xⁿ has the same kernel as x ↦ x^gcd(n,m), but could only prove the corresponding image equality in the cyclic case, where the order m and the counting identity #range · #ker = m do the work. Its first open question asked for the image equality in a general finite abelian group and for the right partition analogue. This entry answers it by changing the invariant: the controlling number is not the order m = |G| but the exponent e = exp G. Against the exponent the image equality range(x ↦ xⁿ) = range(x ↦ x^gcd(n,e)) holds in EVERY group — no commutativity, no finiteness — because the hard inclusion is a single Bézout identity. Writing gcd(n,e) = n·A + e·B over ℤ and using x^e = 1 (Monoid.pow_exponent_eq_one) exhibits x^gcd(n,e) = (x^A)ⁿ, so every gcd(n,e)-th power is already an n-th power; the reverse inclusion is the elementary gcd(n,e) ∣ n. The kernel equality xⁿ = 1 ↔ x^gcd(n,e) = 1 is likewise upgraded from gcd-with-order to gcd-with-exponent (orderOf x ∣ exp G always), again with no finiteness. For a finite abelian group these specialize to subgroup equalities of ker and range of powMonoidHom, and the partition identity becomes #range · #ker = |G| via the first isomorphism theorem — the constant fibre size #ker replaces the cyclic value gcd(n, m), with which it agrees exactly when G is cyclic.",
+  "references": [
+    {
+      "authors": "Hall, Marshall, Jr.",
+      "title": "The Theory of Groups",
+      "year": "1959",
+      "venue": "Macmillan",
+      "note": "Classical treatment of power maps and coprime automorphisms: x ↦ x^n is bijective when gcd(n, |G|) = 1, and regular / fixed-point-free actions on finite groups."
+    },
+    {
+      "authors": "Isaacs, I. Martin",
+      "title": "Finite Group Theory",
+      "year": "2008",
+      "venue": "American Mathematical Society, Graduate Studies in Mathematics 92",
+      "note": "Modern text covering Cauchy/Sylow theory and counting arguments for element orders and power maps in finite groups."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.GroupTheory (exists_prime_orderOf_dvd_card, Sylow, IsCyclic.card_pow_eq_one_le, powCoprime)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides Cauchy's theorem, the Sylow API, the coprime power-map equivalence, and the one-sided solution-count bound that this entry sharpens to an exact equality."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Tactic"

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02/meta.json
@@ -2,12 +2,37 @@
   "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02",
   "title": "Fibre sizes of the power map are constant: on any finite abelian group #(fibre) = #{xⁿ=1}, and on a product of cyclics this is ∏ gcd(n, mᵢ)",
   "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02",
+  "references": [
+    {
+      "authors": "Frobenius, Ferdinand Georg",
+      "title": "Über einen Fundamentalsatz der Gruppentheorie",
+      "year": "1895",
+      "venue": "Sitzungsberichte der Preußischen Akademie der Wissenschaften, 981–993",
+      "note": "Frobenius's theorem: if n divides |G|, the number of solutions of x^n = 1 in a finite group is a multiple of n — the divisibility underlying the exact solution counts formalized here."
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": "2004",
+      "venue": "John Wiley & Sons",
+      "note": "Standard graduate reference for Cauchy's theorem, the Sylow theorems, and the structure theorem for finite abelian groups invoked here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.GroupTheory (exists_prime_orderOf_dvd_card, Sylow, IsCyclic.card_pow_eq_one_le, powCoprime)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides Cauchy's theorem, the Sylow API, the coprime power-map equivalence, and the one-sided solution-count bound that this entry sharpens to an exact equality."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Tactic",
       "Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02"
     ],
-    "opens": ["Finset"],
+    "opens": [
+      "Finset"
+    ],
     "namespace": "CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ02",
     "lineCount": 202,
     "axiomCount": 0,

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/meta.json
@@ -2,12 +2,37 @@
   "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02",
   "title": "gcd(n,m) recovers the power map: same kernel, same image, fibre partition #(n-th powers)·gcd(n,m) = m",
   "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02",
+  "references": [
+    {
+      "authors": "Frobenius, Ferdinand Georg",
+      "title": "Über einen Fundamentalsatz der Gruppentheorie",
+      "year": "1895",
+      "venue": "Sitzungsberichte der Preußischen Akademie der Wissenschaften, 981–993",
+      "note": "Frobenius's theorem: if n divides |G|, the number of solutions of x^n = 1 in a finite group is a multiple of n — the divisibility underlying the exact solution counts formalized here."
+    },
+    {
+      "authors": "Hall, Marshall, Jr.",
+      "title": "The Theory of Groups",
+      "year": "1959",
+      "venue": "Macmillan",
+      "note": "Classical treatment of power maps and coprime automorphisms: x ↦ x^n is bijective when gcd(n, |G|) = 1, and regular / fixed-point-free actions on finite groups."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.GroupTheory (exists_prime_orderOf_dvd_card, Sylow, IsCyclic.card_pow_eq_one_le, powCoprime)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides Cauchy's theorem, the Sylow API, the coprime power-map equivalence, and the one-sided solution-count bound that this entry sharpens to an exact equality."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Tactic",
       "Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03"
     ],
-    "opens": ["Finset"],
+    "opens": [
+      "Finset"
+    ],
     "namespace": "CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02",
     "lineCount": 165,
     "axiomCount": 0,

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -2,12 +2,37 @@
   "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
   "title": "Counting solutions of xⁿ = g: gcd(n, |G|) when g is an n-th power, else 0",
   "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
+  "references": [
+    {
+      "authors": "Frobenius, Ferdinand Georg",
+      "title": "Über einen Fundamentalsatz der Gruppentheorie",
+      "year": "1895",
+      "venue": "Sitzungsberichte der Preußischen Akademie der Wissenschaften, 981–993",
+      "note": "Frobenius's theorem: if n divides |G|, the number of solutions of x^n = 1 in a finite group is a multiple of n — the divisibility underlying the exact solution counts formalized here."
+    },
+    {
+      "authors": "Isaacs, I. Martin",
+      "title": "Finite Group Theory",
+      "year": "2008",
+      "venue": "American Mathematical Society, Graduate Studies in Mathematics 92",
+      "note": "Modern text covering Cauchy/Sylow theory and counting arguments for element orders and power maps in finite groups."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.GroupTheory (exists_prime_orderOf_dvd_card, Sylow, IsCyclic.card_pow_eq_one_le, powCoprime)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides Cauchy's theorem, the Sylow API, the coprime power-map equivalence, and the one-sided solution-count bound that this entry sharpens to an exact equality."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Tactic",
       "Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01"
     ],
-    "opens": ["Finset"],
+    "opens": [
+      "Finset"
+    ],
     "namespace": "CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03",
     "lineCount": 188,
     "axiomCount": 0,

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -2,13 +2,41 @@
   "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01",
   "title": "Counting solutions to xⁿ = 1 in a cyclic group: exactly gcd(n, |G|)",
   "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01",
+  "references": [
+    {
+      "authors": "Frobenius, Ferdinand Georg",
+      "title": "Über einen Fundamentalsatz der Gruppentheorie",
+      "year": "1895",
+      "venue": "Sitzungsberichte der Preußischen Akademie der Wissenschaften, 981–993",
+      "note": "Frobenius's theorem: if n divides |G|, the number of solutions of x^n = 1 in a finite group is a multiple of n — the divisibility underlying the exact solution counts formalized here."
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": "2004",
+      "venue": "John Wiley & Sons",
+      "note": "Standard graduate reference for Cauchy's theorem, the Sylow theorems, and the structure theorem for finite abelian groups invoked here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.GroupTheory (exists_prime_orderOf_dvd_card, Sylow, IsCyclic.card_pow_eq_one_le, powCoprime)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides Cauchy's theorem, the Sylow API, the coprime power-map equivalence, and the one-sided solution-count bound that this entry sharpens to an exact equality."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.GroupTheory.SpecificGroups.Cyclic",
       "Mathlib.GroupTheory.OrderOfElement",
       "Mathlib.Tactic"
     ],
-    "opens": ["Finset", "Subgroup", "Submonoid", "Function"],
+    "opens": [
+      "Finset",
+      "Subgroup",
+      "Submonoid",
+      "Function"
+    ],
     "namespace": "CauchyGroupTheoremOQ01OQ01OQ01OQ01",
     "lineCount": 165,
     "axiomCount": 0,

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/meta.json
@@ -2,6 +2,36 @@
   "id": "cauchy-group-theorem-oq-01-oq-01-oq-01",
   "title": "The power-map dichotomy: x ↦ xⁿ is a bijection iff gcd(n, |G|) = 1",
   "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+  "references": [
+    {
+      "authors": "Hall, Marshall, Jr.",
+      "title": "The Theory of Groups",
+      "year": "1959",
+      "venue": "Macmillan",
+      "note": "Classical treatment of power maps and coprime automorphisms: x ↦ x^n is bijective when gcd(n, |G|) = 1, and regular / fixed-point-free actions on finite groups."
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": "2004",
+      "venue": "John Wiley & Sons",
+      "note": "Standard graduate reference for Cauchy's theorem, the Sylow theorems, and the structure theorem for finite abelian groups invoked here."
+    },
+    {
+      "authors": "Cauchy, Augustin-Louis",
+      "title": "Mémoire sur les arrangements que l'on peut former avec des lettres données",
+      "year": "1845",
+      "venue": "Exercices d'analyse et de physique mathématique, Vol. 3, 151–252",
+      "note": "The origin of Cauchy's theorem: a finite group whose order is divisible by a prime p contains an element of order p."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.GroupTheory (exists_prime_orderOf_dvd_card, Sylow, IsCyclic.card_pow_eq_one_le, powCoprime)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides Cauchy's theorem, the Sylow API, the coprime power-map equivalence, and the one-sided solution-count bound that this entry sharpens to an exact equality."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.GroupTheory.OrderOfElement",
@@ -10,7 +40,9 @@
       "Mathlib.Data.ZMod.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": ["Function"],
+    "opens": [
+      "Function"
+    ],
     "namespace": "CauchyGroupTheoremOQ01OQ01OQ01",
     "lineCount": 160,
     "axiomCount": 0,

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
@@ -2,6 +2,36 @@
   "id": "cauchy-group-theorem-oq-01-oq-01",
   "title": "The odd-order boundary of Cauchy's theorem: squaring is a bijection",
   "slug": "cauchy-group-theorem-oq-01-oq-01",
+  "references": [
+    {
+      "authors": "Cauchy, Augustin-Louis",
+      "title": "Mémoire sur les arrangements que l'on peut former avec des lettres données",
+      "year": "1845",
+      "venue": "Exercices d'analyse et de physique mathématique, Vol. 3, 151–252",
+      "note": "The origin of Cauchy's theorem: a finite group whose order is divisible by a prime p contains an element of order p."
+    },
+    {
+      "authors": "McKay, James H.",
+      "title": "Another proof of Cauchy's group theorem",
+      "year": "1959",
+      "venue": "American Mathematical Monthly 66(2), 119",
+      "note": "The slick orbit-counting proof: p divides the number of p-tuples (x_1,…,x_p) with product 1, and the p-element cyclic action fixes exactly the constant tuples, forcing a nontrivial element of order p."
+    },
+    {
+      "authors": "Isaacs, I. Martin",
+      "title": "Finite Group Theory",
+      "year": "2008",
+      "venue": "American Mathematical Society, Graduate Studies in Mathematics 92",
+      "note": "Modern text covering Cauchy/Sylow theory and counting arguments for element orders and power maps in finite groups."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.GroupTheory (exists_prime_orderOf_dvd_card, Sylow, IsCyclic.card_pow_eq_one_le, powCoprime)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides Cauchy's theorem, the Sylow API, the coprime power-map equivalence, and the one-sided solution-count bound that this entry sharpens to an exact equality."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.GroupTheory.OrderOfElement",

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-02-oq-03/meta.json
@@ -2,6 +2,36 @@
   "id": "cauchy-group-theorem-oq-01-oq-02-oq-03",
   "title": "Squarefree group order forces every Sylow subgroup cyclic of prime order",
   "slug": "cauchy-group-theorem-oq-01-oq-02-oq-03",
+  "references": [
+    {
+      "authors": "Hölder, Otto",
+      "title": "Die Gruppen mit quadratfreier Ordnungszahl",
+      "year": "1895",
+      "venue": "Nachrichten von der Gesellschaft der Wissenschaften zu Göttingen, 211–229",
+      "note": "Classification of groups of squarefree order: all are metacyclic and every Sylow subgroup is cyclic of prime order — the structural endpoint this entry formalizes."
+    },
+    {
+      "authors": "Sylow, Ludwig",
+      "title": "Théorèmes sur les groupes de substitutions",
+      "year": "1872",
+      "venue": "Mathematische Annalen 5, 584–594",
+      "note": "The Sylow theorems, extending Cauchy's element of order p to the existence, conjugacy and count of maximal p-power subgroups."
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": "2004",
+      "venue": "John Wiley & Sons",
+      "note": "Standard graduate reference for Cauchy's theorem, the Sylow theorems, and the structure theorem for finite abelian groups invoked here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.GroupTheory (exists_prime_orderOf_dvd_card, Sylow, IsCyclic.card_pow_eq_one_le, powCoprime)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides Cauchy's theorem, the Sylow API, the coprime power-map equivalence, and the one-sided solution-count bound that this entry sharpens to an exact equality."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.GroupTheory.Sylow",

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-02/meta.json
@@ -2,6 +2,36 @@
   "id": "cauchy-group-theorem-oq-01-oq-02",
   "title": "From Cauchy to Sylow: the maximal p-power subgroup as a named corollary",
   "slug": "cauchy-group-theorem-oq-01-oq-02",
+  "references": [
+    {
+      "authors": "Sylow, Ludwig",
+      "title": "Théorèmes sur les groupes de substitutions",
+      "year": "1872",
+      "venue": "Mathematische Annalen 5, 584–594",
+      "note": "The Sylow theorems, extending Cauchy's element of order p to the existence, conjugacy and count of maximal p-power subgroups."
+    },
+    {
+      "authors": "Cauchy, Augustin-Louis",
+      "title": "Mémoire sur les arrangements que l'on peut former avec des lettres données",
+      "year": "1845",
+      "venue": "Exercices d'analyse et de physique mathématique, Vol. 3, 151–252",
+      "note": "The origin of Cauchy's theorem: a finite group whose order is divisible by a prime p contains an element of order p."
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": "2004",
+      "venue": "John Wiley & Sons",
+      "note": "Standard graduate reference for Cauchy's theorem, the Sylow theorems, and the structure theorem for finite abelian groups invoked here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.GroupTheory (exists_prime_orderOf_dvd_card, Sylow, IsCyclic.card_pow_eq_one_le, powCoprime)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides Cauchy's theorem, the Sylow API, the coprime power-map equivalence, and the one-sided solution-count bound that this entry sharpens to an exact equality."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.GroupTheory.Sylow",


### PR DESCRIPTION
Enrichment pass adding a `references` array to **9 `cauchy-group-theorem` OQ-children** that previously had none.

The cluster spans a coherent arc — Cauchy's theorem (element of order p), the power map $x\mapsto x^n$ and when it is a bijection, exact solution counts of $x^n=1$ and $x^n=g$, fibre structure of the power map, and the climb from Cauchy to the Sylow theorems (including squarefree-order groups).

**Method (cluster references pass):** shared base references — Cauchy (1845), Sylow (1872), Dummit–Foote, Isaacs, and the Mathlib group-theory modules — plus 1 angle-specific citation per entry read from its `description`:
- **Frobenius (1895)** — $x^n=1$ solution-count divisibility — for the counting entries.
- **McKay (1959)** — the orbit-counting proof of Cauchy's theorem.
- **Hall (1959)** — coprime power maps / $\gcd(n,|G|)=1$.
- **Hölder (1895)** — groups of squarefree order (all Sylow subgroups cyclic of prime order).

**Scope:** `meta.json` only; each change verified to add *only* the `references` key (rest byte-identical). No per-proof `index.ts` (dead code since #20993). `pnpm build` passes; all files remain well under the 60 KB cap.