### PR TITLE
research(pell-equation-oq-08): congruence obstructions to negative Pell x²−Dy²=−1 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PellEquationOQ08.lean
+++ b/proofs/Proofs/PellEquationOQ08.lean
@@ -1,0 +1,121 @@
+/-
+Pell's Equation OQ-08: Obstructions to the Negative Pell Equation x² − D y² = −1
+
+The classical Pell equation x² − Dy² = 1 always has infinitely many integer
+solutions for non-square D > 0 (the rank-1 case of Dirichlet's unit theorem). The
+*negative* Pell equation
+
+    x² − D y² = −1
+
+is far more delicate: for many D it has **no** integer solution at all. Sibling
+entry `PellEquationOQ06` builds the infinite solution chain for the smallest
+solvable instance D = 2. This entry proves the complementary **non-existence**
+(obstruction) side: congruence conditions on D that rule out any solution.
+
+The key observation is purely local (mod p): a solution of `x² − D y² = −1`
+forces `x² ≡ −1` in every residue ring where `D ≡ 0`. Since `−1` is a quadratic
+residue mod an odd prime `p` iff `p ≢ 3 (mod 4)` (Mathlib's
+`ZMod.mod_four_ne_three_of_sq_eq_neg_one`), a prime factor `p ≡ 3 (mod 4)` of `D`
+is a fatal obstruction. A separate elementary `mod 4` count rules out every
+`D ≡ 3 (mod 4)`.
+
+Main results:
+  • `neg_pell_no_sol_of_D_three_mod_four`
+        — if D ≡ 3 (mod 4) then x² − D y² = −1 has no integer solution (mod-4 count).
+  • `neg_pell_no_sol_of_prime_factor_three_mod_four`
+        — if a prime p ≡ 3 (mod 4) divides D then x² − D y² = −1 has no solution.
+  • `neg_pell_solvable_imp_no_prime_factor_three_mod_four`
+        — solvability forces every prime factor of D to avoid the residue 3 (mod 4).
+  • `neg_pell_three_no_sol`, `neg_pell_seven_no_sol`
+        — the classical concrete obstructions D = 3 and D = 7.
+  • `neg_pell_two_example`
+        — D = 2 solves (contrast: 2 is not ≡ 3 mod 4), so the obstruction is sharp.
+
+All proofs are `sorry`-free and axiom-free (no `native_decide`).
+
+References:
+- Parent entry: `pell-equation` (the norm `+1`, real-quadratic special case).
+- Sibling: `PellEquationOQ06` (existence of the D = 2 solution chain).
+- Mathlib `ZMod.exists_sq_eq_neg_one_iff` / `ZMod.mod_four_ne_three_of_sq_eq_neg_one`.
+-/
+
+import Mathlib
+
+namespace PellEquationOQ08
+
+/-
+## The mod-4 obstruction
+-/
+
+/-- **`D ≡ 3 (mod 4)` obstruction.** If `D ≡ 3 (mod 4)`, the negative Pell
+    equation `x² − D y² = −1` has no integer solution. Mod 4 the equation reads
+    `x² + y² ≡ 3`, but `x² + y² ∈ {0, 1, 2}` mod 4, never `3`. -/
+theorem neg_pell_no_sol_of_D_three_mod_four
+    {D : ℤ} (hD : D % 4 = 3) (x y : ℤ) : x ^ 2 - D * y ^ 2 ≠ -1 := by
+  intro h
+  -- reduce the equation to `ZMod 4`
+  have h4 : (x : ZMod 4) ^ 2 - (D : ZMod 4) * (y : ZMod 4) ^ 2 = -1 := by
+    have h' : ((x ^ 2 - D * y ^ 2 : ℤ) : ZMod 4) = ((-1 : ℤ) : ZMod 4) := by rw [h]
+    push_cast at h'
+    exact h'
+  -- `D ≡ 3 (mod 4)` becomes `(D : ZMod 4) = 3`
+  have hD4 : (D : ZMod 4) = 3 := by
+    have hmod : D ≡ 3 [ZMOD 4] := by show D % 4 = 3 % 4; omega
+    have := (ZMod.intCast_eq_intCast_iff D 3 4).mpr hmod
+    simpa using this
+  rw [hD4] at h4
+  -- exhaustive check over `ZMod 4`
+  have hfin : ∀ a b : ZMod 4, a ^ 2 - 3 * b ^ 2 ≠ -1 := by decide
+  exact hfin _ _ h4
+
+/-
+## The prime-factor obstruction
+-/
+
+/-- **Prime-factor obstruction.** If a prime `p ≡ 3 (mod 4)` divides `D`, then
+    `x² − D y² = −1` has no integer solution: reducing mod `p` gives `x² ≡ −1`,
+    but `−1` is not a square mod a prime `≡ 3 (mod 4)`. -/
+theorem neg_pell_no_sol_of_prime_factor_three_mod_four
+    {D : ℤ} {p : ℕ} (hp : p.Prime) (hp3 : p % 4 = 3) (hpD : (p : ℤ) ∣ D)
+    (x y : ℤ) : x ^ 2 - D * y ^ 2 ≠ -1 := by
+  intro h
+  haveI : Fact p.Prime := ⟨hp⟩
+  -- `p ∣ D` kills the `D`-term mod `p`
+  have hD0 : (D : ZMod p) = 0 := (ZMod.intCast_zmod_eq_zero_iff_dvd D p).mpr hpD
+  -- reduce the equation mod `p` to `x² = −1`
+  have hx2 : (x : ZMod p) ^ 2 = -1 := by
+    have h' : ((x ^ 2 - D * y ^ 2 : ℤ) : ZMod p) = ((-1 : ℤ) : ZMod p) := by rw [h]
+    push_cast at h'
+    rw [hD0] at h'
+    simpa using h'
+  -- `−1` a square mod `p` forces `p ≢ 3 (mod 4)`, contradiction
+  exact ZMod.mod_four_ne_three_of_sq_eq_neg_one hx2 hp3
+
+/-- **Necessary condition for solvability.** If `x² − D y² = −1` has a solution,
+    then no prime factor of `D` is congruent to `3 (mod 4)`. -/
+theorem neg_pell_solvable_imp_no_prime_factor_three_mod_four
+    {D : ℤ} (hsol : ∃ x y : ℤ, x ^ 2 - D * y ^ 2 = -1)
+    {p : ℕ} (hp : p.Prime) (hpD : (p : ℤ) ∣ D) : p % 4 ≠ 3 := by
+  intro hp3
+  obtain ⟨x, y, h⟩ := hsol
+  exact neg_pell_no_sol_of_prime_factor_three_mod_four hp hp3 hpD x y h
+
+/-
+## Concrete instances
+-/
+
+/-- The classical obstruction `x² − 3y² = −1` has no integer solution
+    (`3 ≡ 3 mod 4`). -/
+theorem neg_pell_three_no_sol (x y : ℤ) : x ^ 2 - 3 * y ^ 2 ≠ -1 :=
+  neg_pell_no_sol_of_D_three_mod_four (by norm_num) x y
+
+/-- The obstruction `x² − 7y² = −1` has no integer solution (`7 ≡ 3 mod 4`). -/
+theorem neg_pell_seven_no_sol (x y : ℤ) : x ^ 2 - 7 * y ^ 2 ≠ -1 :=
+  neg_pell_no_sol_of_D_three_mod_four (by norm_num) x y
+
+/-- **Sharpness.** For `D = 2` (which is *not* `≡ 3 mod 4`) the equation *does*
+    solve, e.g. `(x, y) = (1, 1)`: `1 − 2 = −1`. The obstructions above are
+    therefore genuinely about the residue class of `D`, not vacuous. -/
+theorem neg_pell_two_example : (1 : ℤ) ^ 2 - 2 * 1 ^ 2 = -1 := by norm_num
+
+end PellEquationOQ08

--- a/src/data/proofs/pell-equation-oq-08/annotations.json
+++ b/src/data/proofs/pell-equation-oq-08/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-pelloq08-framing",
+    "proofId": "pell-equation-oq-08",
+    "range": {
+      "startLine": 1,
+      "endLine": 44
+    },
+    "type": "concept",
+    "title": "The Negative Pell Equation and Its Congruence Obstructions",
+    "content": "**Framing.** The norm-$(+1)$ equation $x^2 - Dy^2 = 1$ always has nontrivial solutions for non-square $D > 0$ (the root entry). The *negative* equation $x^2 - Dy^2 = -1$ is far more delicate: it asks for a unit of $\\mathbb{Z}[\\sqrt D]$ of norm $-1$, which exists only when the fundamental unit has norm $-1$ (equivalently, the continued-fraction period of $\\sqrt D$ is odd). Sibling `pell-equation-oq-06` constructs the solution chain for the smallest solvable case $D = 2$. This entry proves the complementary **non-existence** side via two elementary congruence obstructions.",
+    "mathContext": "A solution is $\\alpha = x + y\\sqrt D \\in \\mathbb{Z}[\\sqrt D]$ with $N(\\alpha) = x^2 - Dy^2 = -1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Norm form of ℤ[√D]",
+      "Fundamental unit of norm −1",
+      "Continued-fraction period parity"
+    ],
+    "prerequisites": [
+      "Pell's equation x² − Dy² = 1",
+      "Quadratic residues modulo a prime"
+    ],
+    "tags": [
+      "module-header",
+      "framing",
+      "negative-pell",
+      "number-theory"
+    ]
+  },
+  {
+    "id": "ann-pelloq08-mod4",
+    "proofId": "pell-equation-oq-08",
+    "range": {
+      "startLine": 50,
+      "endLine": 69
+    },
+    "type": "theorem",
+    "title": "The mod-4 Obstruction: D ≡ 3 (mod 4) is Unsolvable",
+    "content": "**`neg_pell_no_sol_of_D_three_mod_four`.** If $D \\equiv 3 \\pmod 4$, then $x^2 - Dy^2 = -1$ has no integer solution. Reducing into $\\mathbb{Z}/4$ (via `push_cast`) and rewriting $(D : \\mathrm{ZMod}\\ 4) = 3$ — obtained from $D \\% 4 = 3$ through `Int.ModEq` and `ZMod.intCast_eq_intCast_iff` — the equation becomes $a^2 - 3b^2 = -1$ over the finite ring $\\mathbb{Z}/4$. A kernel `decide` checks all $16$ pairs and finds none: since squares are $0$ or $1$ mod $4$, $x^2 + y^2 \\in \\{0,1,2\\}$, never $3 \\equiv -1$.",
+    "mathContext": "Mod $4$: $-1 \\equiv 3$ and $-3 \\equiv 1$, so $x^2 - Dy^2 \\equiv x^2 + y^2 \\in \\{0,1,2\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Squares modulo 4",
+      "Kernel `decide` over finite ZMod",
+      "Int.ModEq and ZMod.intCast_eq_intCast_iff"
+    ],
+    "prerequisites": [
+      "Casting integer equations into ZMod n",
+      "The residues of squares mod 4"
+    ],
+    "tags": [
+      "mod-4",
+      "decide",
+      "obstruction",
+      "negative-pell"
+    ]
+  },
+  {
+    "id": "ann-pelloq08-primefactor",
+    "proofId": "pell-equation-oq-08",
+    "range": {
+      "startLine": 75,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "The Prime-Factor Obstruction via Quadratic Residues of −1",
+    "content": "**`neg_pell_no_sol_of_prime_factor_three_mod_four`.** If a prime $p \\equiv 3 \\pmod 4$ divides $D$, then $x^2 - Dy^2 = -1$ has no integer solution. Casting the equation into $\\mathrm{ZMod}\\ p$ and killing the $D$-term with `ZMod.intCast_zmod_eq_zero_iff_dvd` (since $p \\mid D$) yields $(x : \\mathrm{ZMod}\\ p)^2 = -1$, exhibiting $-1$ as a square mod $p$. But `ZMod.mod_four_ne_three_of_sq_eq_neg_one` says any $y$ with $y^2 = -1$ forces $p \\% 4 \\neq 3$ — contradicting $p \\equiv 3 \\pmod 4$. This is the local heart of the classical solvability criterion.",
+    "mathContext": "$-1$ is a quadratic residue mod an odd prime $p$ iff $p \\equiv 1 \\pmod 4$ (Euler's criterion / first supplement).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Quadratic residue of −1",
+      "ZMod.mod_four_ne_three_of_sq_eq_neg_one",
+      "Reduction of Diophantine equations mod p"
+    ],
+    "prerequisites": [
+      "Legendre symbol and the first supplementary law",
+      "ZMod.intCast_zmod_eq_zero_iff_dvd"
+    ],
+    "tags": [
+      "quadratic-residues",
+      "legendre-symbol",
+      "obstruction",
+      "negative-pell"
+    ]
+  },
+  {
+    "id": "ann-pelloq08-necessary-and-concrete",
+    "proofId": "pell-equation-oq-08",
+    "range": {
+      "startLine": 94,
+      "endLine": 119
+    },
+    "type": "proof-step",
+    "title": "Necessary Condition, Classical Cases, and Sharpness",
+    "content": "**Packaging.** `neg_pell_solvable_imp_no_prime_factor_three_mod_four` is the contrapositive: if $x^2 - Dy^2 = -1$ is solvable, every prime factor of $D$ satisfies $p \\% 4 \\neq 3$ — the classical necessary condition. `neg_pell_three_no_sol` and `neg_pell_seven_no_sol` instantiate the mod-4 obstruction at the textbook unsolvable cases $D = 3, 7$. Finally `neg_pell_two_example` exhibits $(1,1)$ solving $x^2 - 2y^2 = -1$: $D = 2 \\not\\equiv 3 \\pmod 4$ is solvable, so the obstructions genuinely depend on $D$'s residue class and are not vacuous.",
+    "mathContext": "Necessary but not sufficient: e.g. $D = 34 = 2\\cdot 17$ passes both tests yet $x^2 - 34y^2 = -1$ is unsolvable.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Contrapositive necessary conditions",
+      "Sharpness witnesses",
+      "Necessary vs. sufficient congruence criteria"
+    ],
+    "prerequisites": [
+      "The two obstruction theorems above",
+      "Concrete instantiation with norm_num"
+    ],
+    "tags": [
+      "necessary-condition",
+      "concrete-instances",
+      "sharpness",
+      "negative-pell"
+    ]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-08/meta.json
+++ b/src/data/proofs/pell-equation-oq-08/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "pell-equation-oq-08",
+  "title": "Congruence Obstructions to the Negative Pell Equation x² − D y² = −1",
+  "slug": "pell-equation-oq-08",
+  "description": "The root entry establishes that x² − Dy² = 1 always has infinitely many solutions for non-square D > 0, and sibling pell-equation-oq-06 builds the infinite solution chain for the smallest solvable negative instance D = 2. This entry proves the complementary non-existence side: congruence conditions on D that make x² − D y² = −1 unsolvable over ℤ. The mechanism is purely local. A solution forces x² ≡ −1 in ZMod p for every prime p ∣ D, and −1 is a quadratic residue modulo an odd prime p exactly when p ≢ 3 (mod 4) (Mathlib's ZMod.mod_four_ne_three_of_sq_eq_neg_one). Hence a prime factor p ≡ 3 (mod 4) of D is a fatal obstruction, and an elementary mod-4 count independently rules out every D ≡ 3 (mod 4). Together these give the classical necessary condition for negative-Pell solvability and recover the textbook facts that x² − 3y² = −1 and x² − 7y² = −1 have no solutions, contrasted with the solvable D = 2.",
+  "leanFile": {
+    "path": "Proofs/PellEquationOQ08.lean",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "sorryCount": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius (local congruence obstructions); classical (Legendre, Lagrange, Dirichlet: negative Pell solvability)",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ08.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "pell-equation",
+      "negative-pell",
+      "quadratic-residues",
+      "legendre-symbol",
+      "congruences",
+      "zmod",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-01",
+    "lineCount": 121,
+    "originalContributions": [
+      "neg_pell_no_sol_of_D_three_mod_four: if D ≡ 3 (mod 4) then x² − D y² = −1 has no integer solution — the equation reduced to ZMod 4 reads x² + y² ≡ 3, but a kernel `decide` over ZMod 4 shows a² − 3b² never equals −1; the residue (D : ZMod 4) = 3 is obtained from D % 4 = 3 via ZMod.intCast_eq_intCast_iff and Int.ModEq",
+      "neg_pell_no_sol_of_prime_factor_three_mod_four: if a prime p ≡ 3 (mod 4) divides D then x² − D y² = −1 has no integer solution — casting the equation to ZMod p and killing the D-term with ZMod.intCast_zmod_eq_zero_iff_dvd gives (x : ZMod p)² = −1, contradicting ZMod.mod_four_ne_three_of_sq_eq_neg_one",
+      "neg_pell_solvable_imp_no_prime_factor_three_mod_four: the necessary condition — if x² − D y² = −1 is solvable then every prime factor of D satisfies p % 4 ≠ 3 (contrapositive packaging of the prime-factor obstruction)",
+      "neg_pell_three_no_sol / neg_pell_seven_no_sol: the classical concrete non-existence results for D = 3 and D = 7 (both ≡ 3 mod 4), instantiating the mod-4 obstruction",
+      "neg_pell_two_example: the sharpness witness (1, 1) solving x² − 2y² = −1, showing D = 2 (not ≡ 3 mod 4) is solvable and the obstructions are about the residue class of D, not vacuous"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms (verified via #print axioms — all theorems depend only on propext, Classical.choice, Quot.sound), 0 sorries, no native_decide (the single `decide` is kernel `decide` over the finite type ZMod 4, not native_decide, so no Lean.ofReduceBool). Uses only Mathlib's ZMod / Legendre-symbol API (ZMod.mod_four_ne_three_of_sq_eq_neg_one, ZMod.intCast_zmod_eq_zero_iff_dvd, ZMod.intCast_eq_intCast_iff) and standard tactics (push_cast, omega, simpa, decide, norm_num).",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pell-equation",
+      "relationship": "extends",
+      "description": "The root entry proves x² − Dy² = 1 always has infinitely many solutions for non-square D > 0. This entry treats the negative form x² − Dy² = −1, which is far more restrictive, and proves congruence obstructions (D ≢ 3 mod 4; no prime factor ≡ 3 mod 4) that must hold for any solution to exist."
+    },
+    {
+      "targetId": "pell-equation-oq-06",
+      "relationship": "complements",
+      "description": "The sibling builds the infinite solution chain (1,1) → (7,5) → (41,29) → … for the solvable negative-Pell instance D = 2. This entry provides the opposite side: the local (mod p and mod 4) reasons that make the negative Pell equation unsolvable for many other D, e.g. D = 3 and D = 7. Together they frame negative-Pell solvability as a congruence-constrained phenomenon."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The negative Pell equation x² − Dy² = −1 is the norm-(−1) equation for the ring ℤ[√D]: a solution is an element of norm −1, i.e. a unit of ℤ[√D] whose norm is −1. Unlike the norm-(+1) equation, which always has nontrivial solutions for non-square D > 0, the norm-(−1) equation is solvable only for special D — those for which the continued-fraction expansion of √D has odd period, equivalently for which the fundamental unit has norm −1. A classical necessary condition, going back to Legendre, is that D can have no prime factor ≡ 3 (mod 4) and cannot itself be ≡ 3 (mod 4): otherwise reducing x² − Dy² = −1 modulo such a prime (or modulo 4) exhibits −1 as a quadratic residue where it is not one. This obstruction is the elementary half of the full solvability criterion; the sufficiency direction is genuinely deeper (it is not implied by these congruences alone).",
+    "problemStatement": "For which D does the negative Pell equation x² − Dy² = −1 fail to have integer solutions, and can the failure be certified by an elementary congruence obstruction? Concretely: does a prime factor p ≡ 3 (mod 4) of D, or the condition D ≡ 3 (mod 4), rule out all solutions — and do the classical cases D = 3, D = 7 follow, in contrast to the solvable D = 2?",
+    "proofStrategy": "Two independent local obstructions. (1) Mod 4: cast x² − Dy² = −1 into ZMod 4 with push_cast; convert D % 4 = 3 to (D : ZMod 4) = 3 through Int.ModEq and ZMod.intCast_eq_intCast_iff; then a finite kernel `decide` over ZMod 4 shows ∀ a b, a² − 3b² ≠ −1, a contradiction. (2) Mod p: given a prime p ≡ 3 (mod 4) dividing D, cast the equation into ZMod p, use ZMod.intCast_zmod_eq_zero_iff_dvd to set (D : ZMod p) = 0, obtain (x : ZMod p)² = −1, and apply ZMod.mod_four_ne_three_of_sq_eq_neg_one to contradict p % 4 = 3. The necessary-condition corollary is the contrapositive of (2); the concrete D = 3, 7 results instantiate (1); the D = 2 example is a direct norm_num computation showing the obstructions are sharp.",
+    "keyInsights": [
+      "A single reduction mod p converts the global Diophantine non-existence into a local quadratic-residue statement: x² − Dy² = −1 with p ∣ D forces x² ≡ −1 (mod p), so −1 must be a square mod p.",
+      "The quadratic-residue character of −1 is governed entirely by p mod 4: −1 is a square in ZMod p iff p ≢ 3 (mod 4) (ZMod.mod_four_ne_three_of_sq_eq_neg_one). A single prime factor ≡ 3 (mod 4) of D therefore kills all solutions.",
+      "The mod-4 obstruction is even more elementary and needs no primality: mod 4 the equation is x² + y² ≡ 3, impossible because squares are 0 or 1 mod 4, so x² + y² ∈ {0,1,2}. A finite `decide` over ZMod 4 discharges it kernel-cleanly.",
+      "These conditions are necessary but not sufficient: D = 34 = 2·17 has no prime factor ≡ 3 (mod 4) and is ≢ 3 (mod 4), yet x² − 34y² = −1 is unsolvable — full solvability is the odd-period / fundamental-unit-norm condition. The entry proves exactly the elementary necessary half, and neg_pell_two_example certifies it is non-vacuous."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Research Context",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "States the negative Pell equation x² − D y² = −1, contrasts its delicate solvability with the always-solvable norm-(+1) case, and outlines the two local obstructions (mod p via quadratic residues of −1, and an elementary mod-4 count) proved in the file.",
+      "mathContext": "A solution of $x^2 - Dy^2 = -1$ is a norm-$(-1)$ element of $\\mathbb{Z}[\\sqrt D]$; solvability requires the fundamental unit to have norm $-1$."
+    },
+    {
+      "id": "mod-4-obstruction",
+      "title": "The mod-4 Obstruction: D ≡ 3 (mod 4)",
+      "startLine": 46,
+      "endLine": 69,
+      "summary": "neg_pell_no_sol_of_D_three_mod_four: if D ≡ 3 (mod 4) there is no solution. The equation is cast into ZMod 4, the residue (D : ZMod 4) = 3 is obtained from D % 4 = 3 via Int.ModEq and ZMod.intCast_eq_intCast_iff, and a kernel `decide` over ZMod 4 shows a² − 3b² ≠ −1 for all a, b.",
+      "mathContext": "Mod $4$: $x^2 + y^2 \\equiv 3$ is impossible since $x^2, y^2 \\in \\{0,1\\}$, so $x^2+y^2 \\in \\{0,1,2\\}$."
+    },
+    {
+      "id": "prime-factor-obstruction",
+      "title": "The Prime-Factor Obstruction: p ≡ 3 (mod 4), p ∣ D",
+      "startLine": 71,
+      "endLine": 101,
+      "summary": "neg_pell_no_sol_of_prime_factor_three_mod_four reduces the equation mod a prime p ∣ D (killing the D-term via ZMod.intCast_zmod_eq_zero_iff_dvd) to get (x : ZMod p)² = −1, contradicting ZMod.mod_four_ne_three_of_sq_eq_neg_one when p ≡ 3 (mod 4). neg_pell_solvable_imp_no_prime_factor_three_mod_four packages the contrapositive as the classical necessary condition.",
+      "mathContext": "$-1$ is a quadratic residue mod an odd prime $p$ iff $p \\equiv 1 \\pmod 4$; a factor $p \\equiv 3 \\pmod 4$ of $D$ blocks $x^2 \\equiv -1 \\pmod p$."
+    },
+    {
+      "id": "concrete-instances",
+      "title": "Concrete Instances and Sharpness",
+      "startLine": 103,
+      "endLine": 121,
+      "summary": "neg_pell_three_no_sol and neg_pell_seven_no_sol instantiate the mod-4 obstruction for the classical unsolvable D = 3 and D = 7; neg_pell_two_example exhibits (1,1) solving x² − 2y² = −1, showing the solvable D = 2 (not ≡ 3 mod 4) and confirming the obstructions depend on D's residue class.",
+      "mathContext": "$D=3,7 \\equiv 3 \\pmod 4$ are unsolvable; $D=2$ is solvable with fundamental solution $(1,1)$ ($1 - 2 = -1$)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 121-line file (0 sorries, 0 axioms confirmed by #print axioms, no native_decide) proves the elementary congruence obstructions to the negative Pell equation x² − D y² = −1, complementing sibling pell-equation-oq-06's existence chain for D = 2. Two independent local arguments — reduction mod a prime factor p ≡ 3 (mod 4) using the quadratic-residue character of −1, and an elementary mod-4 count — establish non-solvability, packaged as the classical necessary condition that a solvable D has no prime factor ≡ 3 (mod 4). The concrete unsolvable cases D = 3, D = 7 and the solvable witness D = 2 illustrate sharpness.",
+    "implications": "The result isolates the elementary, decidable half of negative-Pell solvability: a purely local certificate of non-existence obtained by reducing modulo a single prime. The same reduce-mod-p / quadratic-residue template certifies unsolvability of many norm-form equations x² − Dy² = N whenever N is a non-residue modulo a prime factor of D. It sits below the deeper analytic criterion (odd continued-fraction period / fundamental unit of norm −1), which is necessary and sufficient but not captured by congruences alone.",
+    "openQuestions": [
+      "Formalize the mod-4 sharpening D ≡ 3 (mod 4) ⟹ unsolvable directly from the prime-factor obstruction, using that a number ≡ 3 (mod 4) has an odd number (hence at least one) of prime factors ≡ 3 (mod 4) counted with multiplicity.",
+      "Prove the negative counterpart to the D = 2 chain in general: whenever the fundamental unit of ℤ[√D] has norm −1, the negative Pell equation has infinitely many solutions, linking this obstruction file to a full solvability characterization.",
+      "Exhibit an unsolvable D that passes both obstructions (e.g. D = 34) to formalize that the congruence conditions are necessary but not sufficient, pinning down the gap to the continued-fraction period parity."
+    ]
+  },
+  "references": [
+    {
+      "authors": "E. J. Barbeau",
+      "title": "Pell's Equation",
+      "year": 2003,
+      "venue": "Springer",
+      "note": "Treats the negative Pell equation and the continued-fraction period-parity solvability criterion."
+    },
+    {
+      "authors": "K. H. Rosen",
+      "title": "Elementary Number Theory and Its Applications",
+      "year": 2011,
+      "venue": "Pearson",
+      "note": "Quadratic residues of −1 modulo primes and the congruence obstructions to x² − Dy² = −1."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides ZMod.mod_four_ne_three_of_sq_eq_neg_one and the ZMod / Legendre-symbol API used in the obstruction proofs."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New verified, **0-axiom** OQ child of `pell-equation`. Proves the elementary **congruence obstructions** to the negative Pell equation `x² − D y² = −1` — the complementary *non-existence* side to sibling `pell-equation-oq-06`, which builds the infinite solution chain for the solvable case D = 2.

`proofs/Proofs/PellEquationOQ08.lean` (121 lines, 6 theorems, 0 defs, 0 sorries, 0 axioms).

## Mathematical content

Two independent **local** obstructions:

1. **mod-4** (`neg_pell_no_sol_of_D_three_mod_four`): if `D ≡ 3 (mod 4)` there is no solution. Mod 4 the equation is `x² + y² ≡ 3`, impossible since squares are `0/1` mod 4. Discharged by a kernel `decide` over `ZMod 4`.
2. **prime-factor** (`neg_pell_no_sol_of_prime_factor_three_mod_four`): if a prime `p ≡ 3 (mod 4)` divides `D`, reducing mod `p` gives `(x : ZMod p)² = −1`, but `−1` is not a square mod such `p` (`ZMod.mod_four_ne_three_of_sq_eq_neg_one`).

Plus the classical necessary condition (`neg_pell_solvable_imp_no_prime_factor_three_mod_four`), the textbook unsolvable cases `D = 3, 7`, and the sharpness witness `(1,1)` solving `x² − 2y² = −1`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.PellEquationOQ08` — builds successfully.
- `#print axioms` on all three main theorems: `[propext, Classical.choice, Quot.sound]` only — no `Lean.ofReduceBool`, no `sorryAx`. The single `decide` is kernel `decide` over the finite type `ZMod 4` (not `native_decide`).
- `pnpm gallery:check-size` — passes (meta.json 13 KB « 60 KB cap).

## Files

- `proofs/Proofs/PellEquationOQ08.lean`
- `src/data/proofs/pell-equation-oq-08/meta.json`
- `src/data/proofs/pell-equation-oq-08/annotations.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)