### PR TITLE
research(inverse-galois-oq-04): mod-7 factorization keystone for A5 quintic [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/InverseGaloisA5DedekindMod7.lean
+++ b/proofs/Proofs/InverseGaloisA5DedekindMod7.lean
@@ -1,0 +1,110 @@
+import Mathlib
+import Proofs.InverseGaloisA5
+
+/-
+# The mod-7 factorization keystone for the A₅ quintic (Inverse-Galois OQ-04)
+
+`InverseGaloisA5` realizes `A₅` as a Galois group over `ℚ` using the quintic
+
+```
+q = X⁵ − 5X⁴ + 10X³ − 10X² + 25X − 5,
+```
+
+but its last input is the `axiom three_dvd_gal_card : 3 ∣ |q.Gal|`. The abstract
+Dedekind–Frobenius bridge `DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn`
+(0 axioms) reduces that axiom to the single concrete number-theoretic fact
+
+```
+3 ∣ Ideal.inertiaDegIn (7) (𝓞 q.SplittingField),
+```
+
+and `InverseGaloisA5DedekindInstantiation.three_dvd_gal_card_of_bridge` shows this fact
+suffices. The residual inertia computation goes, via Kummer–Dedekind, through the
+factorization of `q` modulo `7`. This file supplies that **concrete arithmetic keystone**,
+fully verified with `0` axioms and `0` sorries:
+
+```
+q ≡ (X − 5)(X − 6)(X³ + 6X² + 4X + 1)   (mod 7),   the cubic irreducible over 𝔽₇.
+```
+
+That is exactly Dedekind's "Frobenius cycle type `(1, 1, 3)` at `p = 7`" datum: the
+irreducible cubic factor is the one whose associated prime of `𝓞 ℚ(α)` has inertia degree
+`3`, feeding `3 ∣ inertiaDegIn (7)`.
+
+This file does **not** by itself remove `three_dvd_gal_card`: bridging "`q` has an
+irreducible cubic factor mod `7`" to "`3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)`" still
+needs the Kummer–Dedekind conductor step
+(`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply`, using `7 ∤ disc q = 32000²`)
+plus the inertia-tower and `inertiaDegIn_eq_inertiaDeg` (Galois) identities. It pins down and
+verifies the arithmetic input those steps consume.
+-/
+
+open Polynomial
+
+namespace InverseGaloisA5DedekindMod7
+
+/-- `7` is prime, so `ZMod 7` is a field (needed for the degree-`≤ 3` irreducibility test). -/
+instance : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+
+/-- The integer model of `q` (same coefficients as `InverseGaloisA5.q`, over `ℤ`). -/
+noncomputable def qInt : ℤ[X] :=
+  X ^ 5 - 5 * X ^ 4 + 10 * X ^ 3 - 10 * X ^ 2 + 25 * X - 5
+
+/-- `qInt` is the integer model of the rational quintic `q`: casting `ℤ → ℚ` recovers `q`. -/
+theorem qInt_map_rat :
+    qInt.map (Int.castRingHom ℚ) = InverseGaloisA5.q := by
+  simp only [qInt, InverseGaloisA5.q, Polynomial.map_sub, Polynomial.map_add,
+    Polynomial.map_mul, Polynomial.map_pow, Polynomial.map_X, Polynomial.map_ofNat,
+    map_ofNat]
+
+/-- The cubic factor of `q mod 7`, `X³ + 6X² + 4X + 1` over `𝔽₇ = ZMod 7`. -/
+noncomputable def cubic7 : (ZMod 7)[X] :=
+  X ^ 3 + 6 * X ^ 2 + 4 * X + 1
+
+/-- Integer identity underlying the mod-`7` reduction: `q = (X−5)(X−6)(cubic) + 7 · R`
+(all coefficients of `q − (X−5)(X−6)(cubic)` are divisible by `7`). Pure `ℤ[X]`
+arithmetic, closed by `ring`. -/
+theorem qInt_eq_factor_add_seven :
+    qInt = (X - 5) * (X - 6) * (X ^ 3 + 6 * X ^ 2 + 4 * X + 1)
+             + 7 * (6 * X ^ 3 - 21 * X ^ 2 - 12 * X - 5) := by
+  simp only [qInt]; ring
+
+/-- **Mod-7 factorization of `q`.** Reducing `q` modulo `7` splits it as a product of two
+distinct linear factors and the cubic `cubic7`:
+`q ≡ (X − 5)(X − 6)(X³ + 6X² + 4X + 1) (mod 7)`. -/
+theorem qInt_map_zmod7 :
+    qInt.map (Int.castRingHom (ZMod 7)) = (X - 5) * (X - 6) * cubic7 := by
+  -- In `(ZMod 7)[X]` the numeral `7` is `0` (characteristic 7), so the `7 · R` term dies.
+  have h70 : (7 : (ZMod 7)[X]) = 0 := by
+    have h := CharP.cast_eq_zero (ZMod 7)[X] 7
+    rwa [Nat.cast_ofNat] at h
+  rw [qInt_eq_factor_add_seven, Polynomial.map_add]
+  simp only [cubic7, Polynomial.map_mul, Polynomial.map_sub, Polynomial.map_add,
+    Polynomial.map_pow, Polynomial.map_X, Polynomial.map_ofNat, Polynomial.map_one,
+    h70, zero_mul, add_zero]
+
+/-- `cubic7` has degree `3`. -/
+theorem cubic7_natDegree : cubic7.natDegree = 3 := by
+  unfold cubic7; compute_degree!
+
+/-- `cubic7` has no root in `𝔽₇`: `x³ + 6x² + 4x + 1 ≠ 0` for every `x ∈ ZMod 7`
+(checked exhaustively over the `7` residues). -/
+theorem cubic7_no_root : ∀ x : ZMod 7, cubic7.eval x ≠ 0 := by
+  intro x
+  simp only [cubic7, eval_add, eval_mul, eval_pow, eval_X, eval_ofNat, eval_one]
+  revert x; decide
+
+/-- **The cubic factor is irreducible over `𝔽₇`.** A degree-`3` polynomial over a field is
+irreducible iff it has no root; `cubic7` has none. Together with `qInt_map_zmod7` this is
+Dedekind's cycle-type-`(1, 1, 3)` datum for `q` at the prime `7`. -/
+theorem cubic7_irreducible : Irreducible cubic7 :=
+  irreducible_of_degree_le_three_of_not_isRoot
+    (by rw [Finset.mem_Icc, cubic7_natDegree]; exact ⟨by norm_num, le_refl 3⟩)
+    (fun x => cubic7_no_root x)
+
+-- Axiom audit: only the three standard foundational axioms; no `sorryAx`, no
+-- `Lean.ofReduceBool` (`decide` is kernel-checked, not `native_decide`).
+#print axioms qInt_map_zmod7
+#print axioms cubic7_irreducible
+
+end InverseGaloisA5DedekindMod7

--- a/research/problems/inverse-galois-oq-04/knowledge.md
+++ b/research/problems/inverse-galois-oq-04/knowledge.md
@@ -92,3 +92,48 @@ verifiable in isolation — q mod 7 = X⁵+2X⁴+3X³+4X²+4X+2 over 𝔽₇ spl
 ZMod 7" (degree 3), which is `decide`-able. But this fact cannot be connected to
 |Gal| without the missing Frobenius/Dedekind bridge, so on its own it does not
 advance OQ-04. Recommend deprioritize until that bridge lands in Mathlib.
+
+## Session 3 (researcher-8, 2026-07-01): FORMALIZED the arithmetic keystone (VERIFIED 0-axiom)
+
+Acted on Session 2's note: the mod-7 factorization datum Dedekind consumes is now
+machine-checked in `proofs/Proofs/InverseGaloisA5DedekindMod7.lean` (0 axioms — only
+`propext` / `Classical.choice` / `Quot.sound`; no `sorry`, no `native_decide`).
+
+Contents:
+- `qInt` : the ℤ model of `q` (same coefficients), with `qInt_map_rat` proving it
+  casts to `InverseGaloisA5.q` over ℚ.
+- `qInt_eq_factor_add_seven` : the ℤ[X] identity
+  `qInt = (X−5)(X−6)(X³+6X²+4X+1) + 7·(6X³−21X²−12X−5)` (closed by `ring`).
+- `qInt_map_zmod7` : **`q ≡ (X−5)(X−6)·cubic7 (mod 7)`** — obtained by mapping the
+  ℤ identity to `ZMod 7`; the `7·R` term dies because `(7 : (ZMod 7)[X]) = 0`
+  (`CharP.cast_eq_zero` via `Polynomial.instCharP`).
+- `cubic7_irreducible` : `X³ + 6X² + 4X + 1` is irreducible over `𝔽₇`, via
+  `Polynomial.irreducible_of_degree_le_three_of_not_isRoot` + `cubic7_no_root`
+  (an exhaustive `decide` over the 7 residues; `cubic7_natDegree` via `compute_degree!`).
+
+So Frobenius cycle type `(1, 1, 3)` at `p = 7` is now a verified fact rather than a
+hand computation.
+
+### Key Lean recipes (reusable)
+- **Factorization mod p, robustly**: prove the identity over `ℤ[X]` as
+  `poly = factors + p · R` (fully closed by `ring`, no characteristic reasoning), then
+  `Polynomial.map` to `ZMod p`; the `p · R` term vanishes via
+  `(p : (ZMod p)[X]) = 0` = `CharP.cast_eq_zero _ p` (needs `Nat.cast_ofNat` to align
+  the `OfNat` numeral) + `Polynomial.instCharP`. Avoids all `ring`-in-char-p pitfalls.
+- **Cubic irreducibility over a finite field**: `irreducible_of_degree_le_three_of_not_isRoot`
+  (`Mathlib/Algebra/Polynomial/SpecificDegree.lean`) with `natDegree ∈ Finset.Icc 1 3`
+  and `∀ x, ¬ IsRoot`; discharge no-roots by `simp only [def, eval_add, eval_mul,
+  eval_pow, eval_X, eval_ofNat, eval_one]` then `revert x; decide` (kernel `decide`,
+  not `native_decide`, so axiom-clean).
+- `C n` ↔ numeral: `Polynomial.C_ofNat` / `map_ofNat` in the simp set.
+
+### Residual gap (unchanged in size, but the arithmetic input is now closed)
+Still needs, over `𝓞 q.SplittingField`:
+`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply` (KummerDedekind; conductor
+coprime to 7 since `7 ∤ disc q = 32000²`) → inertia degree 3 at the cubic's prime →
+inertia-tower multiplicativity → `inertiaDegIn_eq_inertiaDeg` (Galois) →
+`3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)` → feed
+`InverseGaloisA5DedekindInstantiation.three_dvd_gal_card_of_bridge`. This file does
+**not** remove `three_dvd_gal_card`; it verifies and pins the arithmetic datum the
+remaining ~hundreds-of-lines KummerDedekind bridge will consume. Gallery entry
+`inverse-galois-a5` remains correctly `axiomatized` (axiomCount 1) — no gallery change.

--- a/research/problems/inverse-galois-oq-04/state.md
+++ b/research/problems/inverse-galois-oq-04/state.md
@@ -1,35 +1,53 @@
 # Current State
 
-**Phase**: BLOCKED
-**Since**: 2026-06-28
-**Iteration**: 1
+**Phase**: PARTIAL (arithmetic keystone formalized; residual = inertia-degree bridge)
+**Since**: 2026-07-01
+**Iteration**: 3
 
 ## Current Focus
 
 Eliminate `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` in InverseGaloisA5.lean
-via Dedekind's theorem at p = 7.
+via Dedekind's theorem at p = 7. The abstract Dedekind–Frobenius bridge and its
+A₅ instantiation already exist (0-axiom); what remains is a concrete inertia
+computation over `𝓞 q.SplittingField`.
 
 ## Active Approach
 
-None viable in-session. The 3 ∣ |Gal| fact requires either Dedekind's theorem
-(mod-7 factorization → 3-cycle) or Dummit's resolvent correspondence; both are
-absent from Mathlib and there is no computational/axiom-free shortcut.
+`InverseGaloisA5DedekindMod7.lean` (this session, VERIFIED 0-axiom): formalized
+the concrete arithmetic keystone Dedekind consumes at `p = 7`:
+
+```
+q ≡ (X − 5)(X − 6)(X³ + 6X² + 4X + 1)   (mod 7),   cubic irreducible over 𝔽₇.
+```
+
+i.e. Frobenius cycle type `(1, 1, 3)`. Proof route: an integer identity
+`qInt = (X−5)(X−6)(cubic) + 7·R` (closed by `ring`), mapped to `ZMod 7` (the `7·R`
+term vanishes since `char (ZMod 7)[X] = 7`); cubic irreducibility from
+`irreducible_of_degree_le_three_of_not_isRoot` + an exhaustive `decide` over the 7
+residues.
 
 ## Blockers
 
-Dedekind's theorem (factorization type mod p = cycle type of Frobenius in Gal)
-is absent from Mathlib 4.26.0; no Frobenius-as-Galois-permutation primitive.
-Estimated 800–1500 lines of foundational number theory to build. See
-`knowledge.md` for the concrete Mathlib bridge plan (KummerDedekind +
-RamificationInertia/Galois + galActionHom + cycleType).
+The remaining gap is **not** Dedekind's theorem in the abstract (that bridge,
+`DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn`, is proved 0-axiom).
+It is the concrete number-field inertia fact
+`3 ∣ Ideal.inertiaDegIn (7) (𝓞 q.SplittingField)`, which still needs the
+Kummer–Dedekind conductor step
+(`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply`, using `7 ∤ disc q =
+32000²`), the inertia-tower multiplicativity, and `inertiaDegIn_eq_inertiaDeg`
+(Galois). This is the `~800–1500`-line multi-session bridge; the arithmetic input
+it consumes is now machine-checked.
 
 ## Next Action
 
-Park until Mathlib gains Dedekind's theorem, or commit a dedicated multi-session
-bridge effort.
+Multi-session: connect `qInt_map_zmod7` / `cubic7_irreducible` to
+`3 ∣ inertiaDegIn (7)` via KummerDedekind, then feed
+`InverseGaloisA5DedekindInstantiation.three_dvd_gal_card_of_bridge`. Alternatively
+park the residual bridge until Mathlib exposes Dedekind's factorization–inertia
+correspondence directly.
 
 ## Attempt Counts
 
-- Total attempts: 1
+- Total attempts: 3
 - Current approach attempts: 1
-- Approaches tried: 1 (assess-and-document)
+- Approaches tried: 2 (assess-and-document; arithmetic-keystone formalization)

--- a/src/data/research/problems/inverse-galois-oq-04.json
+++ b/src/data/research/problems/inverse-galois-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "inverse-galois-oq-04",
   "title": "Dedekind Theorem to Eliminate A5 Axiom",
-  "phase": "BLOCKED",
+  "phase": "PARTIAL",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,24 +16,28 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "BLOCKED",
-    "since": "2026-06-28T00:00:00.000Z",
-    "iteration": 1,
-    "focus": "Eliminate three_dvd_gal_card via Dedekind's theorem at p=7.",
+    "phase": "PARTIAL",
+    "since": "2026-07-01T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Arithmetic keystone formalized (q mod 7 = (X-5)(X-6)(irred cubic), 0-axiom); residual = KummerDedekind inertia-degree bridge to 3 | inertiaDegIn(7).",
     "blockers": [
       "Dedekind's theorem (factorization type mod p = cycle type of Frobenius in Gal) is absent from Mathlib 4.26.0; no Frobenius-as-Galois-permutation primitive. Estimated 800-1500 lines of foundational number theory to build."
     ],
-    "nextAction": "Park until Mathlib gains Dedekind's theorem / Frobenius-as-Galois-automorphism, or commit a dedicated multi-session bridge effort.",
+    "nextAction": "Connect qInt_map_zmod7/cubic7_irreducible to 3 | inertiaDegIn(7) via KummerDedekind, then feed three_dvd_gal_card_of_bridge; or park residual bridge until Mathlib exposes Dedekind factorization-inertia directly.",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 2
     }
   },
   "knowledge": {
     "progressSummary": "Assessed (researcher-3, 2026-06-28). InverseGaloisA5.lean has exactly 1 axiom, three_dvd_gal_card (3 | |Gal(q)|), encoding Dedekind's theorem at p=7. All other inputs to |Gal|=60 are proved (5|Gal, Gal|60 via discriminant, no order-15/30 subgroup). The 3|Gal step has no axiom-free or computational shortcut: distinguishing D5 from A5 requires detecting an order-3 element, i.e. Dedekind's theorem (mod-7 cycle type) or Dummit's resolvent correspondence -- both absent from Mathlib.",
-    "builtItems": [],
-    "insights": [],
+    "builtItems": [
+      "InverseGaloisA5DedekindMod7.lean (VERIFIED 0-axiom): q mod 7 = (X-5)(X-6)(X^3+6X^2+4X+1) over F_7 with the cubic irreducible (Frobenius cycle type (1,1,3) at p=7). qInt_map_zmod7, cubic7_irreducible, qInt_map_rat, qInt_eq_factor_add_seven, cubic7_natDegree, cubic7_no_root."
+    ],
+    "insights": [
+      "Robust mod-p factorization recipe: prove poly = factors + p*R over Z[X] (ring closes it), map to ZMod p, kill the p*R term via (p:(ZMod p)[X])=0 (CharP.cast_eq_zero + Polynomial.instCharP). Cubic irreducibility over a finite field via irreducible_of_degree_le_three_of_not_isRoot + decide (kernel, axiom-clean)."
+    ],
     "mathlibGaps": [
       "Dedekind's theorem: factorization type of f mod p (p not dividing disc) = cycle type of Frobenius in Gal on roots. Entirely absent.",
       "Frobenius element as a Galois automorphism / permutation of roots: no primitive.",


### PR DESCRIPTION
## Summary

Formalizes the concrete arithmetic datum that **Dedekind's theorem consumes at p = 7**
for the A₅ quintic `q = X⁵ − 5X⁴ + 10X³ − 10X² + 25X − 5`, fully machine-checked:

```
q ≡ (X − 5)(X − 6)(X³ + 6X² + 4X + 1)   (mod 7),   the cubic irreducible over 𝔽₇.
```

i.e. **Frobenius cycle type (1, 1, 3)** at `p = 7` — the input to `3 ∣ |q.Gal|`.

New file `proofs/Proofs/InverseGaloisA5DedekindMod7.lean` (6 theorems):
- `qInt_map_rat` — `qInt` (ℤ model) casts to `InverseGaloisA5.q` over ℚ.
- `qInt_eq_factor_add_seven` — the ℤ[X] identity `qInt = (X−5)(X−6)(cubic) + 7·R` (`ring`).
- `qInt_map_zmod7` — the mod-7 factorization (map to `ZMod 7`; `7·R` dies since `char = 7`).
- `cubic7_natDegree`, `cubic7_no_root`, `cubic7_irreducible` — the cubic is irreducible over 𝔽₇
  (`irreducible_of_degree_le_three_of_not_isRoot` + exhaustive kernel `decide`).

## Verification

Docker build succeeds. `#print axioms` on `qInt_map_zmod7` and `cubic7_irreducible` lists
only `[propext, Classical.choice, Quot.sound]` — **0 axioms, 0 sorries, no `native_decide`**
(kernel `decide` only).

## Scope / honesty note

This does **not** remove the `three_dvd_gal_card` axiom in `InverseGaloisA5`. It complements
the already-landed 0-axiom abstract bridge
(`DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn`) and its A₅ instantiation
(`three_dvd_gal_card_of_bridge`), verifying and pinning the arithmetic input the remaining
KummerDedekind inertia bridge (`3 ∣ inertiaDegIn(7)(𝓞 q.SplittingField)`) will consume.
The `inverse-galois-a5` gallery entry remains correctly `axiomatized` (axiomCount 1) — no
gallery change. Research problem `inverse-galois-oq-04` moves BLOCKED → PARTIAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)