### PR TITLE
Research: cauchy-schwarz-integral-lp-duality-synthesis — verified AESM gluing helper across σ-finite exhaustion [0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySpanning.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySpanning.lean
@@ -1,0 +1,67 @@
+/-
+# AE-strong-measurability across the σ-finite exhaustion
+(cauchy-schwarz-integral-lp-duality-synthesis)
+
+## What this file provides
+
+The σ-finite Riesz-representation chain for `Lᵖ` (file `…OQ01OQ01Incomplete01.lean`)
+builds, inside its 600-line `localization_existence` theorem, a single global representer
+`g : α → ℝ` out of the per-piece representers `g_n` living on the σ-finite exhaustion
+`spanningSets μ n`.  A recurring obstruction there was the step
+
+    (∀ n, AEStronglyMeasurable g (μ.restrict (spanningSets μ n)))  ⟹  AEStronglyMeasurable g μ,
+
+for which the knowledge base recorded a helper
+`aestronglyMeasurable_of_restrict_spanningSets` that "exists NOWHERE (Mathlib or local)"
+and would have to be constructed.  In fact it is a two-line consequence of two standard
+Mathlib facts once they are lined up:
+
+* `aestronglyMeasurable_iUnion_iff` — a.e.-strong-measurability on `μ.restrict (⋃ i, sᵢ)`
+  is equivalent to a.e.-strong-measurability on each `μ.restrict sᵢ` (for a **countable**
+  index; here `ι = ℕ`), and
+* `MeasureTheory.iUnion_spanningSets` — the σ-finite exhaustion covers the space,
+  `⋃ n, spanningSets μ n = univ`, together with `Measure.restrict_univ : μ.restrict univ = μ`.
+
+This file packages the helper as a standalone, **Mathlib-only, kernel-verified** lemma so
+the eventual repair/assembly of the σ-finite chain can `import` it directly rather than
+re-deriving it inline.  It does *not* touch the build-broken chain
+(`…Incomplete01.lean`), and eliminates no axiom by itself — it is a reusable building
+block for the critical path (Session 16 roadmap, step 1: build the global representer `g`).
+
+## Honesty note
+
+This is elementary once the right Mathlib lemmas are located; the only "work" was
+recognizing that the supposedly missing helper reduces to `aestronglyMeasurable_iUnion_iff`
+applied along `iUnion_spanningSets`.  Fully verified, 0 axioms, 0 sorries.
+-/
+
+import Mathlib.MeasureTheory.Function.StronglyMeasurable.AEStronglyMeasurable
+import Mathlib.MeasureTheory.Measure.Typeclasses.SFinite
+import Mathlib.MeasureTheory.Measure.Restrict
+import Mathlib.Topology.Metrizable.Basic
+
+noncomputable section
+
+open MeasureTheory TopologicalSpace
+
+namespace RieszLpDualitySpanning
+
+variable {α β : Type*} [MeasurableSpace α] {μ : Measure α}
+  [TopologicalSpace β] [PseudoMetrizableSpace β] {f : α → β}
+
+/-- **AE-strong-measurability glues across the σ-finite exhaustion.**
+If `f` is a.e.-strongly-measurable on each restriction `μ.restrict (spanningSets μ n)`
+of the σ-finite exhaustion, then it is a.e.-strongly-measurable for `μ` itself.
+
+Reduces to `aestronglyMeasurable_iUnion_iff` (the index `ℕ` is countable) applied along
+`iUnion_spanningSets μ : ⋃ n, spanningSets μ n = univ` and `Measure.restrict_univ`. -/
+theorem aestronglyMeasurable_of_restrict_spanningSets [SigmaFinite μ]
+    (h : ∀ n, AEStronglyMeasurable f (μ.restrict (spanningSets μ n))) :
+    AEStronglyMeasurable f μ := by
+  have hcov : AEStronglyMeasurable f (μ.restrict (⋃ n, spanningSets μ n)) :=
+    aestronglyMeasurable_iUnion_iff.mpr h
+  rwa [iUnion_spanningSets μ, Measure.restrict_univ] at hcov
+
+end RieszLpDualitySpanning
+
+end


### PR DESCRIPTION
## Summary

Supplies a **verified, 0-axiom** helper the σ-finite Riesz-representation chain needs but the knowledge base had flagged as *"exists NOWHERE (Mathlib or local), must be constructed"*:

```
aestronglyMeasurable_of_restrict_spanningSets :
  (∀ n, AEStronglyMeasurable f (μ.restrict (spanningSets μ n))) → AEStronglyMeasurable f μ
```

It turns out **not** to need construction from scratch — it is a 3-line consequence of existing Mathlib:
`aestronglyMeasurable_iUnion_iff.mpr` (the index `ℕ` is countable) applied along `MeasureTheory.iUnion_spanningSets μ : ⋃ n, spanningSets μ n = univ` and `Measure.restrict_univ`.

## Progress

- New standalone **Mathlib-only** file `proofs/Proofs/CauchySchwarzIntegralLpDualitySpanning.lean` (1 theorem, 0 sorries, 0 axioms).
- Does not touch the build-broken σ-finite chain (`…Incomplete01.lean`); it is decoupled infrastructure (same pattern as the sibling `Extension`/`Gluing` files).
- Pool JSON (`src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json`) updated with the unblock discovery and the drop-in next step.

## Verification

Built with `./proofs/scripts/docker-build.sh Proofs.CauchySchwarzIntegralLpDualitySpanning` — **succeeded** (1744 jobs). 0 sorries, 0 `axiom`, no `native_decide`.

*(Build note: the blanket `import Mathlib` repeatedly hit `.olean.private`/`.olean.server` permission-denied races on the shared main-repo `.lake` under heavy concurrent-agent load; switching to targeted imports both sped the build and dodged the poisoned CategoryTheory/Kaehler oleans.)*

## Status

**Outcome**: progress — verified critical-path infrastructure. This unblocks the global-representer `g` construction inside `localization_existence` (`Incomplete01` ~line 804), the documented key to collapsing the `hg_eq_n`/`hg_lq`/`hg_norm` cascade. The parent axiom `riesz_lp_surjective` is **not** eliminated (still gated on the σ-finite chain repair + the Folland-6.16 maximality lemma); `axiomCount` unchanged.

🤖 Generated by researcher-6