### PR TITLE
research(binary-gcd-oq-01-oq-01): total bit-operation cost model for Stein's GCD [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ01.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ01.lean
@@ -1,0 +1,170 @@
+/-
+  Binary GCD OQ-01-OQ-01: Total bit-operation cost model for Stein's algorithm.
+
+  The parent file `BinaryGcdOQ01` counts the *number of reduction steps*
+  (`binaryGcdSteps`) and bounds it by `2*(log₂ a + log₂ b) + 2` (a Lamé-style
+  bound). That is a *unit-cost* model: every step is charged one unit,
+  regardless of how large the operands are.
+
+  This file supplies the missing *total cost model* asked for by the open
+  question. A single reduction step of the binary GCD — halving an even
+  operand, subtracting the smaller odd operand from the larger, or the
+  parity/comparison test that selects the branch — touches every bit of the
+  current pair `(a, b)`. Its honest bit-operation cost is therefore
+  `Nat.size a + Nat.size b`, the combined bit-length of the two operands.
+  Accumulating this over the whole recursion gives `binaryGcdCost`.
+
+  Worked example (a = 12, b = 8), following the five reductions of
+  `binaryGcdSteps 12 8 = 5`:
+
+      (12,8) both even   cost size 12 + size 8 = 4+4 = 8 → (6,4)
+      (6,4)  both even   cost size 6  + size 4 = 3+3 = 6 → (3,2)
+      (3,2)  odd/even    cost size 3  + size 2 = 2+2 = 4 → (3,1)
+      (3,1)  odd/odd     cost size 3  + size 1 = 2+1 = 3 → (1,1)
+      (1,1)  odd/odd     cost size 1  + size 1 = 1+1 = 2 → (1,0)
+
+  so `binaryGcdCost 12 8 = 8+6+4+3+2 = 23`, well under the step count 5 times
+  the initial bit-length 8 (= 40), and under the quadratic bound below.
+
+  Main results.
+
+  * `binaryGcdCost_le_steps_mul_size`
+        binaryGcdCost a b ≤ binaryGcdSteps a b * (Nat.size a + Nat.size b)
+    Neither operand ever grows along the recursion (each step halves or
+    subtracts), so every step is at least as cheap as the first. The total
+    cost is thus bounded by the step count times the *initial* bit-length.
+
+  * `binaryGcdCost_le_quadratic`
+        binaryGcdCost a b
+          ≤ (2*(log₂ a + log₂ b) + 2) * (log₂ a + log₂ b + 2)
+    Composing with the parent's step bound yields the classical
+    O((log N)²) total bit-complexity of the binary GCD (Brent 1976,
+    Knuth TAOCP 4.5.2).
+
+  All results are axiom-free (only the foundational
+  propext / Classical.choice / Quot.sound), 0 sorries, no `native_decide`.
+
+  References:
+  - Stein (1967), Binary GCD Algorithm
+  - Brent (1976), analysis of the binary GCD
+  - Knuth, TAOCP 4.5.2
+  - BinaryGcdOQ01.lean (step count `binaryGcdSteps` + Lamé-style bound)
+-/
+import Mathlib
+import Proofs.BinaryGcdOQ01
+
+namespace BinaryGcdOQ01OQ01
+
+open Nat BinaryGcdOQ01
+
+/-- Total bit-operation cost of Stein's binary GCD: each reduction step on the
+    current pair `(a, b)` costs `Nat.size a + Nat.size b` bit operations. The
+    branch structure mirrors `binaryGcdSteps` exactly. -/
+def binaryGcdCost (a b : ℕ) : ℕ :=
+  match a, b with
+  | 0, _ => 0
+  | _, 0 => 0
+  | a' + 1, b' + 1 =>
+      (Nat.size (a' + 1) + Nat.size (b' + 1)) +
+      (if (a' + 1) % 2 = 0 then
+          if (b' + 1) % 2 = 0 then
+            binaryGcdCost ((a' + 1) / 2) ((b' + 1) / 2)
+          else
+            binaryGcdCost ((a' + 1) / 2) (b' + 1)
+        else if (b' + 1) % 2 = 0 then
+          binaryGcdCost (a' + 1) ((b' + 1) / 2)
+        else if a' + 1 > b' + 1 then
+          binaryGcdCost ((a' + 1 - (b' + 1)) / 2) (b' + 1)
+        else
+          binaryGcdCost (a' + 1) ((b' + 1 - (a' + 1)) / 2))
+  termination_by a + b
+  decreasing_by all_goals omega
+
+@[simp] theorem binaryGcdCost_zero_left (b : ℕ) : binaryGcdCost 0 b = 0 :=
+  binaryGcdCost.eq_1 b
+
+@[simp] theorem binaryGcdCost_zero_right (a : ℕ) : binaryGcdCost a 0 = 0 := by
+  cases a with
+  | zero => exact binaryGcdCost.eq_1 0
+  | succ a' => exact binaryGcdCost.eq_2 _ (by omega)
+
+/-! ## The core cost bound
+
+Total cost ≤ (step count) × (initial bit-length). The engine is a fuelled
+strong induction on `a + b`; in every branch the recursive operands are ≤ the
+current operands, so `Nat.size` (monotone) cannot increase, making each step no
+more expensive than the first. -/
+
+private theorem binaryGcdCost_le_aux :
+    ∀ n a b : ℕ, a + b ≤ n →
+      binaryGcdCost a b ≤ binaryGcdSteps a b * (Nat.size a + Nat.size b) := by
+  intro n
+  induction n with
+  | zero =>
+    intro a b h
+    obtain ⟨rfl, rfl⟩ : a = 0 ∧ b = 0 := ⟨by omega, by omega⟩
+    simp
+  | succ n ih =>
+    intro a b h
+    rcases a with _ | a'
+    · simp
+    rcases b with _ | b'
+    · simp
+    rw [binaryGcdCost.eq_3, binaryGcdSteps.eq_3]
+    set S := Nat.size (a' + 1) + Nat.size (b' + 1) with hS
+    -- Generic closer for one branch: reduced operands `ra rb` with proofs that
+    -- they are ≤ the current operands.
+    have close : ∀ ra rb : ℕ, ra + rb ≤ n →
+        ra ≤ a' + 1 → rb ≤ b' + 1 →
+        S + binaryGcdCost ra rb ≤ (1 + binaryGcdSteps ra rb) * S := by
+      intro ra rb hfuel hra hrb
+      have ihb := ih ra rb hfuel
+      have hmono : Nat.size ra + Nat.size rb ≤ S := by
+        have e1 : Nat.size ra ≤ Nat.size (a' + 1) := Nat.size_le_size hra
+        have e2 : Nat.size rb ≤ Nat.size (b' + 1) := Nat.size_le_size hrb
+        omega
+      have step2 : binaryGcdSteps ra rb * (Nat.size ra + Nat.size rb)
+          ≤ binaryGcdSteps ra rb * S := by gcongr
+      have hexp : (1 + binaryGcdSteps ra rb) * S = S + binaryGcdSteps ra rb * S := by ring
+      omega
+    split_ifs with h1 h2 h3 h4
+    · exact close ((a' + 1) / 2) ((b' + 1) / 2) (by omega)
+        (Nat.div_le_self _ _) (Nat.div_le_self _ _)
+    · exact close ((a' + 1) / 2) (b' + 1) (by omega)
+        (Nat.div_le_self _ _) le_rfl
+    · exact close (a' + 1) ((b' + 1) / 2) (by omega)
+        le_rfl (Nat.div_le_self _ _)
+    · exact close ((a' + 1 - (b' + 1)) / 2) (b' + 1) (by omega)
+        (le_trans (Nat.div_le_self _ _) (Nat.sub_le _ _)) le_rfl
+    · exact close (a' + 1) ((b' + 1 - (a' + 1)) / 2) (by omega)
+        le_rfl (le_trans (Nat.div_le_self _ _) (Nat.sub_le _ _))
+
+/-- **Total cost model.** The total bit-operation cost of Stein's binary GCD is
+    bounded by the number of reduction steps times the initial combined
+    bit-length `Nat.size a + Nat.size b`. -/
+theorem binaryGcdCost_le_steps_mul_size (a b : ℕ) :
+    binaryGcdCost a b ≤ binaryGcdSteps a b * (Nat.size a + Nat.size b) :=
+  binaryGcdCost_le_aux (a + b) a b le_rfl
+
+/-- **Quadratic total bit-complexity.** For positive inputs the total
+    bit-operation cost of the binary GCD is `O((log₂ a + log₂ b)²)`: it is
+    bounded by `(2·(log₂ a + log₂ b) + 2) · (log₂ a + log₂ b + 2)`. This is the
+    classical `O((log N)²)` bit complexity (Brent 1976, Knuth TAOCP 4.5.2),
+    now derived from the step bound plus the per-step bit cost. -/
+theorem binaryGcdCost_le_quadratic (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
+    binaryGcdCost a b ≤
+      (2 * (Nat.log 2 a + Nat.log 2 b) + 2) * (Nat.log 2 a + Nat.log 2 b + 2) := by
+  have hsteps := binaryGcdSteps_le_log a b ha hb
+  have hsize : Nat.size a + Nat.size b ≤ Nat.log 2 a + Nat.log 2 b + 2 := by
+    have e1 : Nat.size a ≤ Nat.log 2 a + 1 := by
+      rw [Nat.size_le]; exact Nat.lt_pow_succ_log_self (by norm_num) a
+    have e2 : Nat.size b ≤ Nat.log 2 b + 1 := by
+      rw [Nat.size_le]; exact Nat.lt_pow_succ_log_self (by norm_num) b
+    omega
+  calc binaryGcdCost a b
+      ≤ binaryGcdSteps a b * (Nat.size a + Nat.size b) :=
+        binaryGcdCost_le_steps_mul_size a b
+    _ ≤ (2 * (Nat.log 2 a + Nat.log 2 b) + 2) * (Nat.log 2 a + Nat.log 2 b + 2) := by
+        gcongr
+
+end BinaryGcdOQ01OQ01

--- a/research/problems/binary-gcd-oq-01-oq-01/knowledge.md
+++ b/research/problems/binary-gcd-oq-01-oq-01/knowledge.md
@@ -1,21 +1,34 @@
 # Knowledge Base: binary-gcd-oq-01-oq-01
 
-Insights accumulated during research on this problem.
-
----
-
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent `binary-gcd-oq-01` formalises the *step count* `binaryGcdSteps` of
+Stein's Binary GCD under a UNIT-COST model and bounds it by
+`2*(log₂ a + log₂ b) + 2` (Lamé-style). That is not the running time: each
+reduction step touches every bit of the operands. The open question OQ-01 asks
+for the TOTAL COST MODEL — an honest bit-operation count.
 
----
+## Insights (SOLVED, 2026-07-01, researcher-5)
 
-## Insights
-
-[Insights from research attempts will be accumulated here]
-
----
+- **Cost model**: `binaryGcdCost a b` mirrors the 5-branch `binaryGcdSteps`
+  recursion but charges `Nat.size a + Nat.size b` (combined bit-length) per
+  step instead of 1. Well-founded on `a + b`.
+- **Per-step bound** `binaryGcdCost_le_steps_mul_size`:
+    `binaryGcdCost a b ≤ binaryGcdSteps a b * (Nat.size a + Nat.size b)`.
+  KEY STRUCTURAL FACT: neither operand ever grows along the recursion (halving
+  or subtract-smaller keeps values ≤ original), so `Nat.size` (monotone via
+  `Nat.size_le_size`) never increases → every step ≤ the first. Proof: fuelled
+  strong induction on `a+b`, unfold cost & step recursions in LOCKSTEP, single
+  `split_ifs` aligns identical if-trees, one reusable per-branch closer.
+  Algebra: `(1 + steps) * S = S + steps * S`.
+- **Quadratic bound** `binaryGcdCost_le_quadratic` (a,b>0):
+    `binaryGcdCost a b ≤ (2*(log₂a+log₂b)+2) * (log₂a+log₂b+2)`.
+  = classical O((log N)²) bit-complexity (Brent 1976, Knuth 4.5.2).
+  Bridge: `Nat.size a ≤ log₂ a + 1` via `Nat.size_le` + `Nat.lt_pow_succ_log_self`;
+  compose with parent `binaryGcdSteps_le_log`; multiply monotone factors by `gcongr`.
+- Worked example: `binaryGcdCost 12 8 = 8+6+4+3+2 = 23` (symbolic, no native_decide).
+- VERIFIED 0-axiom, 0 sorries, no native_decide. File `Proofs/BinaryGcdOQ01OQ01.lean`.
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Did NOT need the sharp equality `Nat.size a = log₂ a + 1`; the ≤ bound suffices.

--- a/src/data/proofs/binary-gcd-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-bgcost-1",
+    "proofId": "binary-gcd-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "Unit-Cost Steps vs. an Honest Bit-Operation Cost",
+    "content": "**Framing.** The parent `binary-gcd-oq-01` counts *steps* of Stein's Binary GCD ($\\mathtt{binaryGcdSteps}$) under a **unit-cost** model — one unit per reduction, regardless of operand size — and bounds it by $2(\\log_2 a + \\log_2 b) + 2$. That is not the running time: each reduction (a shift, a subtraction, or the parity/comparison test that selects the branch) actually touches *every bit* of the current pair $(a,b)$. This entry supplies the missing **total cost model**: charge each step its honest bit cost $\\mathtt{Nat.size}\\,a + \\mathtt{Nat.size}\\,b$ (the combined bit-length), accumulate over the recursion as $\\mathtt{binaryGcdCost}$, and recover the classical $O((\\log N)^2)$ bit-complexity (Brent 1976, Knuth TAOCP 4.5.2).",
+    "mathContext": "Worked trace for $(12,8)$, following the five reductions of $\\mathtt{binaryGcdSteps}\\,12\\,8 = 5$: $8+6+4+3+2 = 23 = \\mathtt{binaryGcdCost}\\,12\\,8$, recorded symbolically (no $\\mathtt{native\\_decide}$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Unit-cost vs. bit-cost complexity models",
+      "Nat.size (bit-length)",
+      "O((log N)^2) bit-complexity of the Binary GCD"
+    ],
+    "prerequisites": [
+      "Stein's Binary GCD reduction rules",
+      "The parent step count binaryGcdSteps and its Lame-style bound"
+    ],
+    "tags": [
+      "module-header",
+      "framing",
+      "cost-model",
+      "binary-gcd"
+    ]
+  },
+  {
+    "id": "ann-bgcost-2",
+    "proofId": "binary-gcd-oq-01-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 89
+    },
+    "type": "definition",
+    "title": "The Cost Recursion: Bit-Length per Step",
+    "content": "**The cost model.** $\\mathtt{binaryGcdCost}$ mirrors the five-branch recursion of $\\mathtt{binaryGcdSteps}$ *exactly* — even/even halves both, even/odd halves one, odd/odd subtracts the smaller from the larger and halves the difference — but instead of adding $1$ per step it adds $\\mathtt{Nat.size}(a) + \\mathtt{Nat.size}(b)$, the combined bit-length of the operands *at that step*. It is well-founded on $a+b$ (each branch strictly shrinks the sum, discharged by `decreasing_by omega`), with a finished computation ($a=0$ or $b=0$) costing $0$ (the two `@[simp]` boundary lemmas).",
+    "mathContext": "Charging bit-length per step is faithful because every Stein primitive — a right shift, a subtraction, or a parity/comparison test — is $\\Theta(\\text{bit-length})$ bit operations.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Well-founded recursion on a + b",
+      "Mirroring the binaryGcdSteps branch structure",
+      "Nat.size as per-step weight"
+    ],
+    "prerequisites": [
+      "binaryGcdSteps definition (parent)",
+      "Nat.size and termination via a decreasing measure"
+    ],
+    "tags": [
+      "definition",
+      "cost-model",
+      "recursion"
+    ]
+  },
+  {
+    "id": "ann-bgcost-3",
+    "proofId": "binary-gcd-oq-01-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 147
+    },
+    "type": "proof-step",
+    "title": "Operands Never Grow: Cost ≤ Steps × Initial Bit-Length",
+    "content": "**The mathematical heart.** `binaryGcdCost_le_steps_mul_size`: $\\mathtt{binaryGcdCost}\\,a\\,b \\le \\mathtt{binaryGcdSteps}\\,a\\,b \\cdot (\\mathtt{Nat.size}\\,a + \\mathtt{Nat.size}\\,b)$. A fuelled strong induction on $a+b$ (`binaryGcdCost_le_aux`). In the $(a'{+}1, b'{+}1)$ branch the cost recursion and the step recursion are unfolded **in lockstep** (`binaryGcdCost.eq_3`, `binaryGcdSteps.eq_3`) so a single `split_ifs` aligns their identical five-way if-trees. One reusable closer discharges every leaf: the reduced operands satisfy $r_a \\le a'{+}1$, $r_b \\le b'{+}1$ (each `Nat.div_le_self` / `Nat.sub_le`), so by **monotonicity of $\\mathtt{Nat.size}$** ($\\mathtt{Nat.size\\_le\\_size}$) $\\mathtt{size}\\,r_a + \\mathtt{size}\\,r_b \\le S$; the induction hypothesis bounds the recursive cost by $(\\text{recursive steps})\\cdot(\\mathtt{size}\\,r_a + \\mathtt{size}\\,r_b) \\le (\\text{recursive steps})\\cdot S$; and $(1+\\text{steps})\\cdot S = S + \\text{steps}\\cdot S$ closes the leaf.",
+    "mathContext": "Because neither operand ever grows, every step is at most as expensive as the first: the leading $S$ pays the current step, and $\\text{steps}\\cdot S$ dominates the rest via the IH. Hence total cost $\\le$ (step count) $\\times$ (initial bit-length).",
+    "significance": "core",
+    "relatedConcepts": [
+      "Monotonicity of the operand pair along the recursion",
+      "Nat.size_le_size (bit-length monotonicity)",
+      "Lockstep unfolding + split_ifs of two aligned recursions",
+      "Fuelled strong induction on a + b"
+    ],
+    "prerequisites": [
+      "binaryGcdSteps.eq_3 (parent equation lemma)",
+      "Nat.div_le_self, Nat.sub_le",
+      "The identity (1 + s) * S = S + s * S"
+    ],
+    "tags": [
+      "proof-step",
+      "induction",
+      "monotonicity",
+      "core-result"
+    ]
+  },
+  {
+    "id": "ann-bgcost-4",
+    "proofId": "binary-gcd-oq-01-oq-01",
+    "range": {
+      "startLine": 149,
+      "endLine": 168
+    },
+    "type": "proof-step",
+    "title": "The Classical O((log N)²) Total Bit-Complexity",
+    "content": "**Composition.** `binaryGcdCost_le_quadratic`: for $a,b>0$, $\\mathtt{binaryGcdCost}\\,a\\,b \\le (2(\\log_2 a + \\log_2 b) + 2)\\,(\\log_2 a + \\log_2 b + 2)$. Two $O(\\log)$ factors multiplied: the parent $\\mathtt{binaryGcdSteps\\_le\\_log}$ bounds the step count by $2(\\log_2 a + \\log_2 b)+2$, and the size/log bridge $\\mathtt{Nat.size}\\,a \\le \\log_2 a + 1$ — from $\\mathtt{Nat.size\\_le}$ and $\\mathtt{Nat.lt\\_pow\\_succ\\_log\\_self}$ (the witness $a < 2^{\\log_2 a + 1}$) — bounds the initial bit-length $S \\le \\log_2 a + \\log_2 b + 2$. `gcongr` multiplies the two monotone bounds.",
+    "mathContext": "$O(\\log N)$ steps each costing $O(\\log N)$ bits gives the textbook $O((\\log N)^2)$ bit-complexity of the Binary GCD (Brent 1976, Knuth TAOCP 4.5.2), now derived formally from the step bound plus the per-step bit cost.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Nat.size a ≤ log₂ a + 1",
+      "Nat.lt_pow_succ_log_self",
+      "gcongr for products of monotone bounds",
+      "Composing with the parent step bound binaryGcdSteps_le_log"
+    ],
+    "prerequisites": [
+      "binaryGcdSteps_le_log (parent Lame-style step bound)",
+      "Nat.size_le and Nat.lt_pow_succ_log_self",
+      "The per-step bound binaryGcdCost_le_steps_mul_size"
+    ],
+    "tags": [
+      "proof-step",
+      "bit-complexity",
+      "composition",
+      "core-result"
+    ]
+  }
+]

--- a/src/data/proofs/binary-gcd-oq-01-oq-01/index.ts
+++ b/src/data/proofs/binary-gcd-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BinaryGcdOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const binaryGcdOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const binaryGcdOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const binaryGcdOq01Oq01Data: ProofData = {
+  proof: binaryGcdOq01Oq01Proof,
+  annotations: binaryGcdOq01Oq01Annotations,
+}

--- a/src/data/proofs/binary-gcd-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-01/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "binary-gcd-oq-01-oq-01",
+  "title": "Binary GCD: Total Bit-Operation Cost Model",
+  "slug": "binary-gcd-oq-01-oq-01",
+  "description": "Open question OQ-01 of binary-gcd-oq-01. The parent file counts the number of reduction steps of Stein's Binary GCD (binaryGcdSteps) under a unit-cost model and bounds it by 2*(log2 a + log2 b) + 2. This entry supplies the missing total cost model: a single reduction step on the current pair (a, b) — halving an even operand, subtracting the smaller odd operand from the larger, or the parity/comparison test selecting the branch — touches every bit of both operands, so its honest bit-operation cost is Nat.size a + Nat.size b, the combined bit-length. Accumulating this over the recursion defines binaryGcdCost. Two results are proved, both axiom-free and with no native_decide: (1) binaryGcdCost a b <= binaryGcdSteps a b * (Nat.size a + Nat.size b) — the operands never grow along the recursion, so every step is at least as cheap as the first and the total cost is bounded by the step count times the initial bit-length; and (2) composing with the parent's Lame-style step bound, binaryGcdCost a b <= (2*(log2 a + log2 b) + 2) * (log2 a + log2 b + 2) for positive inputs — the classical O((log N)^2) total bit-complexity of the Binary GCD (Brent 1976, Knuth TAOCP 4.5.2).",
+  "meta": {
+    "author": "researcher-5",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
+    "date": "2026-07-01",
+    "status": "verified",
+    "tags": [
+      "algorithms",
+      "number-theory",
+      "gcd",
+      "complexity",
+      "cost-model",
+      "bit-complexity",
+      "bit-length",
+      "open-question",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/BinaryGcdOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 170,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.size_le_size",
+        "description": "Monotonicity of the bit-length: m <= n implies Nat.size m <= Nat.size n. Applied to each recursive operand, which is <= the current operand, to show the per-step bit cost never increases.",
+        "module": "Mathlib.Data.Nat.Size"
+      },
+      {
+        "theorem": "Nat.size_le",
+        "description": "Nat.size m <= n iff m < 2 ^ n. Used to bound Nat.size a by log2 a + 1 when converting the size-based cost bound into the log-based quadratic form.",
+        "module": "Mathlib.Data.Nat.Size"
+      },
+      {
+        "theorem": "Nat.lt_pow_succ_log_self",
+        "description": "For base b > 1, n < b ^ (Nat.log b n + 1). Supplies the witness a < 2 ^ (log2 a + 1) that gives Nat.size a <= log2 a + 1.",
+        "module": "Mathlib.Data.Nat.Log"
+      },
+      {
+        "theorem": "binaryGcdSteps.eq_3",
+        "description": "Equation lemma for the (a'+1, b'+1) branch of Stein's step recursion; unfolded in lockstep with the cost recursion so split_ifs aligns their identical branch structure.",
+        "module": "Proofs.BinaryGcdOQ01"
+      },
+      {
+        "theorem": "binaryGcdSteps_le_log",
+        "description": "Parent Lame-style bound binaryGcdSteps a b <= 2*(log2 a + log2 b) + 2, composed with the per-step cost bound to yield the quadratic total-cost result.",
+        "module": "Proofs.BinaryGcdOQ01"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Stein's Binary GCD algorithm (1967) replaces Euclidean division by shifts, subtractions, and parity tests. Its classical complexity analysis (Brent 1976; Knuth, TAOCP 4.5.2) charges each reduction step a bit-operation cost proportional to the bit-length of the operands, giving a total running time of O((log N)^2) bit operations on inputs below N. The parent binary-gcd-oq-01 formalised only the step *count* (binaryGcdSteps) and a Lame-style bound of O(log N) steps — a unit-cost model that deliberately ignores the per-step bit work. This entry closes that gap on the cost side: it defines the honest total bit-operation cost binaryGcdCost, in which each step is charged Nat.size a + Nat.size b (the combined bit-length of the current operands), and derives the quadratic total-cost bound that the step count alone cannot express.",
+    "problemStatement": "**OQ-01 of binary-gcd-oq-01 (total cost model).** Move beyond the unit-cost step count of Stein's Binary GCD to an honest total bit-operation cost. Define binaryGcdCost a b that charges each reduction step the combined bit-length Nat.size a + Nat.size b of its operands, and (1) bound the total cost by the step count times the initial bit-length, then (2) compose with the step bound to obtain the classical O((log N)^2) total bit-complexity.",
+    "proofStrategy": "**Cost model (definition).** binaryGcdCost mirrors the five-branch recursion of binaryGcdSteps exactly, but instead of adding 1 per step it adds Nat.size a + Nat.size b. Well-founded on a + b (each branch strictly shrinks the sum), with the two zero cases costing 0.\n\n**Per-step bound (binaryGcdCost_le_steps_mul_size).** A fuelled strong induction on a + b. After reducing to the (a'+1, b'+1) branch, the cost recursion and the step recursion are unfolded in lockstep (binaryGcdCost.eq_3, binaryGcdSteps.eq_3) and split_ifs aligns their identical if-trees into five leaves. A single reusable closer handles every leaf: for reduced operands ra <= a'+1 and rb <= b'+1, monotonicity of Nat.size (Nat.size_le_size) gives Nat.size ra + Nat.size rb <= S := Nat.size (a'+1) + Nat.size (b'+1); the induction hypothesis bounds the recursive cost by (recursive steps) * (Nat.size ra + Nat.size rb) <= (recursive steps) * S; and (1 + steps) * S = S + steps * S closes the goal. The operand-monotonicity facts ((a'+1)/2 <= a'+1, (a'+1 - (b'+1))/2 <= a'+1, etc.) are Nat.div_le_self / Nat.sub_le.\n\n**Quadratic bound (binaryGcdCost_le_quadratic).** For a, b > 0: Nat.size a <= log2 a + 1 via Nat.size_le and Nat.lt_pow_succ_log_self, so the initial bit-length S <= log2 a + log2 b + 2; the parent binaryGcdSteps_le_log bounds the step count by 2*(log2 a + log2 b) + 2; gcongr multiplies the two monotone factors to give the quadratic bound.\n\n**No decide / native_decide anywhere** — the worked example (binaryGcdCost 12 8 = 23) is recorded symbolically in the header comment, so the file rests only on the foundational axioms.",
+    "keyInsights": [
+      "The step count is a unit-cost model; the honest running time of Stein's algorithm is a *bit* count. Charging each step the combined bit-length Nat.size a + Nat.size b of its current operands is the minimal faithful cost model, and it is exactly what turns the O(log N) step bound into the classical O((log N)^2) bit-complexity.",
+      "The whole per-step bound rests on one structural monotonicity fact: neither operand ever grows along the recursion (every branch halves an operand or replaces the larger by a difference that is smaller than it). Hence Nat.size, being monotone, never increases, and every step is at least as cheap as the first.",
+      "Unfolding the cost recursion and the step recursion in lockstep lets a single split_ifs align their identical five-branch if-trees, so one reusable per-branch closer — parameterised only by the reduced operands and the proofs that they are <= the current operands — discharges all five cases uniformly.",
+      "The algebraic core of each leaf is the identity (1 + steps) * S = S + steps * S: the leading S pays for the current step's bit cost and the remaining steps * S dominates the recursive cost via the induction hypothesis and Nat.size monotonicity.",
+      "Nat.size (bit-length) is the right currency: Nat.size a <= log2 a + 1 (from Nat.lt_pow_succ_log_self) converts the exact size-based bound into the log-based quadratic form without ever needing the sharper Nat.size a = log2 a + 1 equality.",
+      "Keeping the numeric cross-check symbolic (the header trace binaryGcdCost 12 8 = 8+6+4+3+2 = 23) means the file incurs no Lean.ofReduceBool: the total cost model is fully verified on the foundational axioms alone."
+    ],
+    "prerequisites": [
+      "binary-gcd-oq-01 — the binaryGcdSteps definition, its equation lemma binaryGcdSteps.eq_3, and the Lame-style step bound binaryGcdSteps_le_log",
+      "Nat.size (bit-length) and its monotonicity Nat.size_le_size; the size/log bridge Nat.size_le with Nat.lt_pow_succ_log_self",
+      "Strong induction on ℕ via an explicit a + b fuel parameter, for recursion without discharging termination in the proof",
+      "Stein's Binary GCD reduction rules (even/even, even/odd, odd/odd subtract-smaller) and their asymptotic bit-complexity (Brent 1976, Knuth TAOCP 4.5.2)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "cost-definition",
+      "title": "The total bit-operation cost model",
+      "startLine": 59,
+      "endLine": 89,
+      "summary": "binaryGcdCost a b: mirrors the five-branch recursion of binaryGcdSteps but charges each step Nat.size a + Nat.size b (the combined bit-length of the current operands) instead of 1. Well-founded on a + b. The two boundary simp lemmas binaryGcdCost_zero_left/right record the zero cost of a finished computation.",
+      "mathContext": "Each Stein reduction — a shift (halving an even operand), a subtraction of the smaller odd operand from the larger, or the parity/comparison test — is linear in the bit-length of the operands, so Nat.size a + Nat.size b is the faithful per-step bit cost. binaryGcdCost is the sum of these costs over the whole reduction sequence."
+    },
+    {
+      "id": "per-step-bound",
+      "title": "Total cost bounded by steps times initial bit-length",
+      "startLine": 91,
+      "endLine": 147,
+      "summary": "binaryGcdCost_le_steps_mul_size: binaryGcdCost a b <= binaryGcdSteps a b * (Nat.size a + Nat.size b). A fuelled strong induction on a + b (binaryGcdCost_le_aux); the cost and step recursions are unfolded in lockstep and split_ifs aligns the identical if-trees; a single reusable closer uses Nat.size monotonicity (operands never grow) plus the induction hypothesis to bound each branch.",
+      "mathContext": "In every branch the reduced operands are <= the current ones, so Nat.size ra + Nat.size rb <= S. With (1 + steps) * S = S + steps * S, the leading S pays the current step and steps * S dominates the recursive cost. Thus every step costs at most the initial combined bit-length, and the total is at most (step count) * (initial bit-length)."
+    },
+    {
+      "id": "quadratic-bound",
+      "title": "Quadratic O((log N)^2) total bit-complexity",
+      "startLine": 149,
+      "endLine": 168,
+      "summary": "binaryGcdCost_le_quadratic: for a, b > 0, binaryGcdCost a b <= (2*(log2 a + log2 b) + 2) * (log2 a + log2 b + 2). Combines the per-step bound with the parent binaryGcdSteps_le_log and the size/log bridge Nat.size a <= log2 a + 1 (via Nat.size_le and Nat.lt_pow_succ_log_self), multiplied by gcongr.",
+      "mathContext": "The step count is O(log N) and the initial bit-length is O(log N), so their product is the classical O((log N)^2) total bit-complexity of the Binary GCD (Brent 1976, Knuth TAOCP 4.5.2)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binary-gcd-oq-01",
+      "relationship": "extends",
+      "description": "Parent. It formalised the step count binaryGcdSteps and the Lame-style bound binaryGcdSteps_le_log under a unit-cost model; this file adds the honest total bit-operation cost binaryGcdCost and derives the quadratic total-cost bound by composing with that step bound."
+    },
+    {
+      "targetId": "binary-gcd",
+      "relationship": "depends-on",
+      "description": "Underlying Stein Binary GCD algorithm whose bit-operation cost is the object of study."
+    },
+    {
+      "targetId": "binary-gcd-oq-01-oq-04-oq-02",
+      "relationship": "related",
+      "description": "Sibling analysis of the same binaryGcdSteps count (its symmetry and axis slices). That work refines the unit-cost step count; this work lifts it to a bit-operation cost."
+    }
+  ],
+  "conclusion": {
+    "summary": "Supplies the total cost model for Stein's Binary GCD: binaryGcdCost charges each reduction step its honest bit-operation cost Nat.size a + Nat.size b. Two axiom-free results (no native_decide): the total cost is bounded by the step count times the initial bit-length, and — composing with the parent's O(log N) step bound — by (2*(log2 a + log2 b) + 2) * (log2 a + log2 b + 2), the classical O((log N)^2) total bit-complexity.",
+    "implications": "Turns the parent's unit-cost step count into a faithful running-time bound: the quadratic total-cost result is the formal counterpart of the textbook O((log N)^2) bit-complexity of the Binary GCD. The reusable lockstep-recursion + Nat.size-monotonicity pattern applies to any cost model whose per-step weight is monotone in the operands.",
+    "openQuestions": [
+      "A matching lower bound: exhibit an input family for which binaryGcdCost is Omega((log N)^2), showing the quadratic bound is tight and not merely an over-estimate.",
+      "A sharper leading constant: the bound step-count * initial-bit-length double-counts, since later operands are strictly smaller; a telescoping sum over the actual per-step bit-lengths should give a smaller constant.",
+      "An average-case cost (rather than worst-case) matching Knuth's analysis of the Binary GCD, integrating the per-step bit cost against the distribution of operand sizes."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BinaryGcdOQ01"
+    ],
+    "opens": [
+      "Nat",
+      "BinaryGcdOQ01"
+    ],
+    "namespace": "BinaryGcdOQ01OQ01",
+    "lineCount": 170,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 3,
+    "definitionCount": 1,
+    "path": "Proofs/BinaryGcdOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Stein, J.",
+      "title": "Computational problems associated with Racah algebra",
+      "year": "1967",
+      "note": "Journal of Computational Physics 1(3), 397-405. Original Binary GCD algorithm."
+    },
+    {
+      "authors": "Brent, R.P.",
+      "title": "Analysis of the binary Euclidean algorithm",
+      "year": "1976",
+      "note": "In Algorithms and Complexity (J.F. Traub, ed.), Academic Press, 321-355. Bit-complexity analysis of the Binary GCD."
+    },
+    {
+      "authors": "Knuth, D.E.",
+      "title": "The Art of Computer Programming, Vol. 2: Seminumerical Algorithms",
+      "year": "1998",
+      "note": "Section 4.5.2. Analysis of GCD algorithms, including the Binary GCD running time."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "binaryGcdCost_le_steps_mul_size",
+      "type": "core",
+      "description": "Total bit-operation cost is bounded by the step count times the initial combined bit-length: every step is at most as expensive as the first because the operands never grow.",
+      "leanType": "(a b : ℕ) → binaryGcdCost a b ≤ binaryGcdSteps a b * (Nat.size a + Nat.size b)"
+    },
+    {
+      "name": "binaryGcdCost_le_quadratic",
+      "type": "core",
+      "description": "Classical O((log N)^2) total bit-complexity of the Binary GCD, from the per-step bound composed with the parent's O(log N) step bound.",
+      "leanType": "(a b : ℕ) → 0 < a → 0 < b → binaryGcdCost a b ≤ (2 * (Nat.log 2 a + Nat.log 2 b) + 2) * (Nat.log 2 a + Nat.log 2 b + 2)"
+    },
+    {
+      "name": "binaryGcdCost",
+      "type": "definition",
+      "description": "Total bit-operation cost of Stein's Binary GCD: mirrors the binaryGcdSteps recursion but charges each step Nat.size a + Nat.size b instead of 1.",
+      "leanType": "ℕ → ℕ → ℕ"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Supplies the missing **total cost model** for Stein's Binary GCD (open question OQ-01 of `binary-gcd-oq-01`). The parent formalises only the *step count* `binaryGcdSteps` under a **unit-cost** model (one unit per reduction) and bounds it by `2·(log₂ a + log₂ b) + 2`. That is not the running time: each reduction touches every bit of the operands. This entry charges each step its honest bit cost and recovers the classical O((log N)²) bit-complexity.

## Results (all VERIFIED, 0-axiom, 0 sorries, no `native_decide`)

- **`def binaryGcdCost`** — mirrors the five-branch `binaryGcdSteps` recursion but adds `Nat.size a + Nat.size b` (combined bit-length of the current operands) per step instead of `1`.
- **`binaryGcdCost_le_steps_mul_size`** — `binaryGcdCost a b ≤ binaryGcdSteps a b * (Nat.size a + Nat.size b)`. Core structural fact: **neither operand ever grows** along the recursion (each branch halves an operand or replaces the larger by a strictly smaller difference), so `Nat.size` — being monotone (`Nat.size_le_size`) — never increases, and every step is at most as expensive as the first. Proof is a fuelled strong induction on `a+b`: the cost and step recursions are unfolded in **lockstep**, one `split_ifs` aligns their identical if-trees, and a single reusable per-branch closer discharges all five leaves via the identity `(1 + steps)·S = S + steps·S`.
- **`binaryGcdCost_le_quadratic`** — for `a,b > 0`, `binaryGcdCost a b ≤ (2·(log₂ a + log₂ b) + 2)·(log₂ a + log₂ b + 2)`. Composing the per-step bound with the parent's Lamé-style step bound `binaryGcdSteps_le_log` and the size/log bridge `Nat.size a ≤ log₂ a + 1` (`Nat.size_le` + `Nat.lt_pow_succ_log_self`), multiplied by `gcongr`. This is the textbook **O((log N)²)** total bit-complexity of the Binary GCD (Brent 1976, Knuth TAOCP 4.5.2), now derived formally from the step bound plus the per-step bit cost.

Worked check (symbolic, in the header comment): `binaryGcdCost 12 8 = 8+6+4+3+2 = 23`.

## Files

- `proofs/Proofs/BinaryGcdOQ01OQ01.lean` (170 lines) — builds cleanly via docker wrapper.
- `src/data/proofs/binary-gcd-oq-01-oq-01/{meta.json,index.ts,annotations.json}` — gallery entry (status `verified`, badge `original`, axiomCount 0).
- `research/problems/binary-gcd-oq-01-oq-01/knowledge.md` — solution record.

## Verification

`./proofs/scripts/docker-build.sh Proofs.BinaryGcdOQ01OQ01` → **Build completed successfully**. No `axiom`/`sorry`/`native_decide` in the file; all lemmas used depend only on the foundational `propext`/`Classical.choice`/`Quot.sound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)