### PR TITLE
Enrich The Gaussian Integral Equals √π (area-of-circle-oq-07)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07/meta.json
@@ -28,7 +28,8 @@
       "The Gaussian integral has no elementary antiderivative, so the integral I itself cannot be evaluated by the fundamental theorem of calculus; only its square I² — a genuine planar integral — admits a clean polar evaluation, which is why the squared identity is stated separately.",
       "Squaring and switching to polar coordinates produces the factor π through the Jacobian r dr dθ — exactly the circle-area object of the parent entry — so the appearance of π here is not coincidental but the same geometric fact in analytic disguise.",
       "Formalization-wise this is an honest, routine specialization: Mathlib's integral_gaussian already encapsulates the hard analytic work, so the entry's value is curatorial (the iconic b = 1 case) rather than a new proof. The badge 'mathlib' reflects this honestly.",
-      "The b = 1 value √π is the seed from which the standard-normal normalization √(2π) (the b = 1/2 case) and the whole normal-distribution density follow — flagged as the first open question."
+      "The b = 1 value √π is the seed from which the standard-normal normalization √(2π) (the b = 1/2 case) and the whole normal-distribution density follow — flagged as the first open question.",
+      "Under Mathlib's Bochner-integral convention, ∫ x, f x silently returns 0 for a non-integrable f, so asserting the value is √π ≠ 0 makes the theorem an implicit integrability certificate for e^{-x²} on ℝ, not merely an evaluation — a formalization subtlety with no counterpart in the informal statement."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07` (quality 89, pass 0). The entry was already rich; this pass closes the two remaining gaps below the stated minimums without inflating the page.

## Changes
- **New annotation `ann-aoc07-open`** covering line 29 (`open Real MeasureTheory`) — the only previously uncovered code line. Explains that opening `MeasureTheory` activates the `∫ x, f x` notation as the Bochner–Lebesgue integral against the default (volume) measure, and that because the value `√π ≠ 0`, the theorem implicitly certifies integrability of `e^{-x²}` (a non-integrable integrand would evaluate to `0` under the Bochner convention). Brings annotations 4 → 5, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.
- **5th `keyInsight`** on the same formalization subtlety — a point with no counterpart in the informal statement.

## Guardrails
- meta.json 10.4 → 10.7 KB (cap ~60 KB); `keyInsights` 4 → 5 (cap 12); `crossReferences` 2, `references` 2 — all well under caps.
- `gallery:check-size`, `annotations:build`, `research:build`, `research:enrich` all pass. (`tsc`/`vite` could not run: this worktree's `node_modules` fails to install due to `better-sqlite3` native build under node v26 — unrelated to this pure-JSON change.)
- Axiom integrity verified: badge `mathlib`, status `verified`, axiomCount 0 accurately reflect the Lean file (routine specialization of `integral_gaussian`).