### PR TITLE
Enrich Two-Term Error Trapping for the Alternating Series Test

### DIFF
--- a/src/data/proofs/alternating-series-test-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-01/annotations.json
@@ -26,7 +26,7 @@
   {
     "id": "ast-oq0101-ann-trap",
     "proofId": "alternating-series-test-oq-01-oq-01",
-    "range": { "startLine": 71, "endLine": 136 },
+    "range": { "startLine": 71, "endLine": 124 },
     "type": "theorem",
     "title": "The Two-Sided Two-Term Trap",
     "content": "abs_partialSum_sub_limit_trapped proves f(N) − f(N+1) ≤ |S_N − l| ≤ f(N). The proof splits on the parity of N. For even N = 2k: Mathlib's alternating_series_le_tendsto / tendsto_le_alternating_series give S_{2k} ≤ l ≤ S_{2k+1}, so S_N − l ≤ 0; the one-step S_{N+1} = S_N + f(N) gives the upper bound and the two-step S_{N+2} = S_N + (f(N) − f(N+1)) ≤ l gives the lower bound, both via linarith on abs_of_nonpos. The odd case is symmetric with abs_of_nonneg. The two halves are extracted as abs_partialSum_sub_limit_le (Leibniz) and sub_le_abs_partialSum_sub_limit (sharpness).",
@@ -34,6 +34,18 @@
     "significance": "key",
     "relatedConcepts": ["nested partial sums", "alternating_series_le_tendsto", "case split on parity", "abs_of_nonpos"],
     "prerequisites": ["the recurrences above", "order limits of partial sums"]
+  },
+  {
+    "id": "ast-oq0101-ann-extracted",
+    "proofId": "alternating-series-test-oq-01-oq-01",
+    "range": { "startLine": 126, "endLine": 136 },
+    "type": "theorem",
+    "title": "One-Sided Lemmas Extracted from the Trap",
+    "content": "The conjunction abs_partialSum_sub_limit_trapped is split into its two directed halves for downstream reuse. abs_partialSum_sub_limit_le projects the second component, recovering the classical Leibniz bound |S_N − l| ≤ f(N) verbatim — this is exactly the parent entry's statement, now a corollary. sub_le_abs_partialSum_sub_limit projects the first component, the sharpness bound f(N) − f(N+1) ≤ |S_N − l|, which is the new content and is what the harmonic capstone invokes. Both are one-line `.2` / `.1` projections carrying the same three hypotheses (antitone, f → 0, S_N → l), so no argument is re-proved; the split is purely an API convenience that lets callers cite the direction they need without destructuring the pair.",
+    "mathContext": "$|S_N - l| \\le f(N)$ (Leibniz) and $f(N) - f(N+1) \\le |S_N - l|$ (sharpness)",
+    "significance": "supporting",
+    "relatedConcepts": ["projection of a conjunction", "Leibniz bound", "sharpness bound", "lemma API design"],
+    "prerequisites": ["the two-sided trap"]
   },
   {
     "id": "ast-oq0101-ann-harmonic",

--- a/src/data/proofs/alternating-series-test-oq-01-oq-01/meta.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-01/meta.json
@@ -66,7 +66,8 @@
       "The limit lies between EVERY consecutive pair of partial sums, not just (S_N, S_{N+1}); using the next pair (S_{N+1}, S_{N+2}) yields the matching lower bound",
       "The two-step displacement S_{N+2} − S_N = (-1)^N (f N − f (N+1)) is exactly the consecutive-term gap, which is what bounds the error from below",
       "The Leibniz upper bound is therefore sharp to within one term: for strictly decreasing terms the error has a guaranteed nonzero size",
-      "For the alternating harmonic series the lower bound telescopes to 1/((N+1)(N+2)), pinning the convergence to log 2 as exactly first-order"
+      "For the alternating harmonic series the lower bound telescopes to 1/((N+1)(N+2)), pinning the convergence to log 2 as exactly first-order",
+      "Both bounds are purely order-theoretic — they depend only on the bracketing of l by the partial sums, never on the limit value itself (log 2 for the harmonic case is irrelevant to either estimate)"
     ],
     "prerequisites": [
       "Convergence of sequences and series in ℝ",


### PR DESCRIPTION
Enrichment pass for `alternating-series-test-oq-01-oq-01` (pass 0, quality 89).

**Changes:**
- Added a 5th annotation (`ast-oq0101-ann-extracted`) calling out the two extracted one-sided lemmas — `abs_partialSum_sub_limit_le` (Leibniz bound as a corollary) and `sub_le_abs_partialSum_sub_limit` (the new sharpness bound) — reaching the 5-annotation quality target. Narrowed the trap annotation range (71–124) so coverage is non-overlapping.
- Added a keyInsight: both bounds are purely order-theoretic, depending only on the bracketing of the limit by the partial sums, never on the limit value itself (log 2 is irrelevant to either estimate).

meta.json stays well under the size cap (10.5 KB). JSON validated via gallery:check-size / annotations:build; `tsc -b` typecheck passes clean.