### PR TITLE
Enrich Singleton Correspondence Bridge (brouwer-fixed-point-oq-04-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/annotations.json
@@ -3,7 +3,7 @@
     "id": "ann-bridge-set-valued-vocab",
     "proofId": "brouwer-fixed-point-oq-04-oq-03-oq-01",
     "range": {
-      "startLine": 49,
+      "startLine": 53,
       "endLine": 81
     },
     "type": "concept",
@@ -114,7 +114,7 @@
     "id": "ann-bridge-reduction-theorem",
     "proofId": "brouwer-fixed-point-oq-04-oq-03-oq-01",
     "range": {
-      "startLine": 150,
+      "startLine": 151,
       "endLine": 183
     },
     "type": "key-step",


### PR DESCRIPTION
Enrichment pass for `brouwer-fixed-point-oq-04-oq-03-oq-01` (quality 41, pass 0 — the lowest-quality *tracked* gallery entry).

## Highest-impact fix: missing `index.ts`
The entry had **no `index.ts`**, so `import.meta.glob` could not discover it and the live page showed "proof not found". Created it from the standard template (Lean source `Proofs/BrouwerFixedPointOQ04OQ03OQ01.lean`, exports `brouwerFixedPointOq04Oq03Oq01{Proof,Annotations,Data}`).

## Made buried content visible
meta.json carried `historicalContext`/`problemStatement`/`proofStrategy`/`keyInsights` nested under `meta.*`, where the page's Overview/Conclusion/Sections tabs never read them. Added:
- top-level **`overview`** (surfacing the 5 existing keyInsights + context, with LaTeX),
- a 6-item **`sections`** array covering all 184 lines (Parts I–VI),
- a **`conclusion`** with summary, implications, and 3 openQuestions.

## Annotation cleanup
Realigned two annotation ranges off comment banners onto their Lean docstrings (`ann-bridge-set-valued-vocab` 49→53, `ann-bridge-reduction-theorem` 150→151), clearing the `annotations:build` "No Lean construct found" warnings for this entry.

## Guardrails / integrity
- meta.json 9.3 → 18 KB; `check-meta-size` passes (≤ 60 KB cap); keyInsights 5.
- Axiom integrity unchanged: `verified`, 0 axioms — `brouwer_from_kakutani_principle` takes the Kakutani principle as an explicit hypothesis, not an axiom.
- `gallery:check-size`, `annotations:build`, `research:build`, `research:enrich` pass. (`tsc`/`vite` not run: this worktree's `node_modules` fails to build `better-sqlite3` under node v26 — environmental, unrelated to this JSON/TS-data change.)