### PR TITLE
Enrich Gaussian Integral (area-of-circle-oq-07): 5th annotation

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07/annotations.json
@@ -47,6 +47,29 @@
     ]
   },
   {
+    "id": "ann-aoc07-opens",
+    "proofId": "area-of-circle-oq-07",
+    "range": {
+      "startLine": 29,
+      "endLine": 29
+    },
+    "type": "concept",
+    "title": "What the two `open`s bring into scope",
+    "content": "The single `open Real MeasureTheory` is what makes the theorem statements read the way they do. `open Real` brings the un-namespaced `π`, `exp`, and `sqrt` into scope (the file still writes `Real.exp`/`Real.sqrt`/`Real.pi` explicitly, but `integral_gaussian`'s statement uses the opened forms, so the match works). `open MeasureTheory` brings the integral notation `∫ x, f x`, which denotes the **Bochner integral of `f` against the default volume measure on ℝ** — not a Riemann or improper integral. Two consequences matter for reading the statement honestly: (1) the notation is total — for a non-integrable integrand it would silently evaluate to `0`, so the theorem only says something because `e^{-x²}` is genuinely integrable (a fact `integral_gaussian` supplies); (2) `∫ x : ℝ, …` with the bound-variable type annotation fixes the measure space to `(ℝ, volume)`, which is exactly the space `integral_gaussian` is stated over, allowing the `b = 1` instance to unify with the goal without any measure coercion.",
+    "mathContext": "$\\int_{\\mathbb R} f\\,d\\mu$ (Bochner) with $\\mu = \\text{volume}$; convention $\\int f = 0$ when $f \\notin L^1$, so integrability of $e^{-x^2}$ is a genuine hypothesis carried by \\texttt{integral\\_gaussian}.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Bochner integral",
+      "volume measure on ℝ",
+      "integral-of-non-integrable convention",
+      "namespace scoping"
+    ],
+    "prerequisites": [
+      "MeasureTheory integral notation",
+      "Real namespace"
+    ]
+  },
+  {
     "id": "ann-aoc07-main",
     "proofId": "area-of-circle-oq-07",
     "range": {


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07` (pass 0, quality 89).

**Change:** added a 5th annotation (`ann-aoc07-opens`) on `open Real MeasureTheory` — the previously-uncovered line 29. It explains that the `∫ x, f x` notation is the Bochner integral against the volume measure on ℝ, that the total-notation convention silently returns 0 for non-integrable integrands (so integrability of e^{-x²} is a genuine hypothesis supplied by `integral_gaussian`), and that the bound-variable type annotation fixes the (ℝ, volume) space enabling unification with the b=1 instance. This brings the entry to the 5-annotation quality target.

Validated: JSON parses, size within caps (meta 10.4 KB), `tsc -b` clean.