### PR TITLE
research(divisibility-by-3-oq-01-oq-02): uniform computable osculator for truncation divisibility [VERIFIED, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/DivisibilityBy3OQ01OQ02.lean
+++ b/proofs/Proofs/DivisibilityBy3OQ01OQ02.lean
@@ -1,0 +1,145 @@
+/-
+Uniform Osculator Function for Truncation Divisibility
+(Open Question: divisibility-by-3-oq-01-oq-02)
+Date: 2026-07-01
+Research: divisibility-by-3-oq-01-oq-02
+
+The parent entry `DivisibilityTruncationGeneral.lean` proves two parametric
+osculator theorems (`truncation_pos`, `truncation_neg`) and instantiates them
+by hand for each divisor coprime to 10 (7, 11, 13, 17, 19, 23, 29, 31, 37, 41,
+43, …). Each instance requires the human to SUPPLY the osculator constant `c`
+and a witness `d ∣ 10c ± 1`.
+
+This file removes that per-divisor hand-work. We give a single **computable**
+osculator function
+
+    osculator d := Int.gcdA 10 d      -- a Bézout coefficient of 10 modulo d
+
+and prove, once and for all, that it satisfies the positive-osculator relation
+`d ∣ 10 · osculator d − 1` for every `d` coprime to 10. Consequently
+
+    truncation_uniform : IsCoprime (d:ℤ) 10 →
+      (d ∣ n ↔ d ∣ (n/10 + osculator d · (n%10)))
+
+covers EVERY divisor coprime to 10 with no supplied constant — the only side
+goal at a concrete divisor is `IsCoprime (d:ℤ) 10`, discharged by `decide`.
+
+This subsumes the hand-written coverage extension (23, 29, 31, 37, 41, 43) of
+the parent OQ: those primes, and all others, are now instances of one theorem
+whose osculator is produced automatically from Bézout's identity.
+-/
+
+import Proofs.DivisibilityTruncationGeneral
+import Mathlib.Tactic
+
+open Nat
+
+namespace DivisibilityBy3OQ01OQ02
+
+open DivisibilityTruncationGeneral
+
+/-
+## The Computable Osculator
+-/
+
+/-- The (positive) **osculator** of `d`: a Bézout coefficient of `10` modulo `d`.
+    For any `d` coprime to `10` this is an inverse of `10` mod `d`, so it
+    satisfies `d ∣ 10 · osculator d − 1` (see `osculator_spec`). Unlike the
+    hand-supplied constants in the parent file, this is a total computable
+    function of `d`. -/
+def osculator (d : ℕ) : ℤ := Int.gcdA 10 (d : ℤ)
+
+/-- **Correctness of the osculator.** For every `d` coprime to `10`, the
+    computed osculator satisfies the positive-osculator relation
+    `d ∣ 10 · osculator d − 1`. This is exactly the hypothesis that the
+    parametric `truncation_pos` theorem needs, now discharged automatically
+    from Bézout's identity rather than by a supplied witness. -/
+theorem osculator_spec (d : ℕ) (hcop : IsCoprime (d : ℤ) 10) :
+    (d : ℤ) ∣ 10 * osculator d - 1 := by
+  -- Bézout: (gcd 10 d : ℤ) = 10 * gcdA 10 d + d * gcdB 10 d
+  have hbez := Int.gcd_eq_gcd_ab (10 : ℤ) (d : ℤ)
+  -- Coprimality collapses the gcd to 1.
+  have hg : Int.gcd (10 : ℤ) (d : ℤ) = 1 := by
+    rw [Int.gcd_comm]
+    exact (Int.isCoprime_iff_gcd_eq_one).mp hcop
+  rw [hg] at hbez
+  -- Now  1 = 10 * osculator d + d * gcdB 10 d, so 10 * osculator d - 1 = d * (-gcdB).
+  refine ⟨-Int.gcdB (10 : ℤ) (d : ℤ), ?_⟩
+  simp only [osculator]
+  push_cast at hbez
+  linear_combination -hbez
+
+/-
+## The Uniform Truncation Rule
+-/
+
+/-- **Uniform Truncation Rule.** For *every* `d` coprime to `10`, the truncation
+    test holds with the automatically computed osculator:
+
+      d ∣ n  ↔  d ∣ (n/10 + osculator d · (n%10)).
+
+    No osculator constant needs to be supplied: the only hypothesis is
+    `IsCoprime (d:ℤ) 10`, which at any concrete divisor is decidable. -/
+theorem truncation_uniform (d : ℕ) (n : ℕ) (hcop : IsCoprime (d : ℤ) 10) :
+    (d : ℤ) ∣ n ↔ (d : ℤ) ∣ (↑(n / 10) + osculator d * ↑(n % 10)) :=
+  truncation_pos d (osculator d) n hcop (osculator_spec d hcop)
+
+/-
+## Coverage With Zero Supplied Constants
+
+Every divisor coprime to 10 is now a one-liner: the osculator is produced by
+`osculator`, and the sole side goal `IsCoprime (d:ℤ) 10` is closed by `decide`.
+Contrast with the parent file, where each of these required a hand-computed
+constant and a `⟨k, by norm_num⟩` divisibility witness.
+-/
+
+theorem seven_uniform (n : ℕ) :
+    (7 : ℤ) ∣ n ↔ (7 : ℤ) ∣ (↑(n / 10) + osculator 7 * ↑(n % 10)) :=
+  truncation_uniform 7 n (by decide)
+
+theorem thirteen_uniform (n : ℕ) :
+    (13 : ℤ) ∣ n ↔ (13 : ℤ) ∣ (↑(n / 10) + osculator 13 * ↑(n % 10)) :=
+  truncation_uniform 13 n (by decide)
+
+theorem nineteen_uniform (n : ℕ) :
+    (19 : ℤ) ∣ n ↔ (19 : ℤ) ∣ (↑(n / 10) + osculator 19 * ↑(n % 10)) :=
+  truncation_uniform 19 n (by decide)
+
+/-- **Extended coverage, uniformly.** The six primes of the parent OQ
+    (23, 29, 31, 37, 41, 43) — and indeed every divisor coprime to 10 — are
+    covered by a single theorem, with the osculator computed rather than
+    supplied. This is the structural upgrade of `extended_truncation_coverage`:
+    the parent bundled six hand-crafted instances; here they are six evaluations
+    of one uniform rule. -/
+theorem extended_coverage_uniform :
+    (∀ n : ℕ, (23 : ℤ) ∣ n ↔ (23 : ℤ) ∣ (↑(n / 10) + osculator 23 * ↑(n % 10))) ∧
+    (∀ n : ℕ, (29 : ℤ) ∣ n ↔ (29 : ℤ) ∣ (↑(n / 10) + osculator 29 * ↑(n % 10))) ∧
+    (∀ n : ℕ, (31 : ℤ) ∣ n ↔ (31 : ℤ) ∣ (↑(n / 10) + osculator 31 * ↑(n % 10))) ∧
+    (∀ n : ℕ, (37 : ℤ) ∣ n ↔ (37 : ℤ) ∣ (↑(n / 10) + osculator 37 * ↑(n % 10))) ∧
+    (∀ n : ℕ, (41 : ℤ) ∣ n ↔ (41 : ℤ) ∣ (↑(n / 10) + osculator 41 * ↑(n % 10))) ∧
+    (∀ n : ℕ, (43 : ℤ) ∣ n ↔ (43 : ℤ) ∣ (↑(n / 10) + osculator 43 * ↑(n % 10))) :=
+  ⟨fun n => truncation_uniform 23 n (by decide),
+   fun n => truncation_uniform 29 n (by decide),
+   fun n => truncation_uniform 31 n (by decide),
+   fun n => truncation_uniform 37 n (by decide),
+   fun n => truncation_uniform 41 n (by decide),
+   fun n => truncation_uniform 43 n (by decide)⟩
+
+/-
+## Sanity Checks: the computed osculator gives a correct test
+
+We verify on concrete numbers that reducing `n` via the *computed* osculator
+preserves divisibility. `osculator 7 = Int.gcdA 10 7`; whatever value it takes,
+`truncation_uniform` guarantees the equivalence, and these examples confirm the
+end-to-end computation is sound.
+-/
+
+-- 7 ∣ 91:  the uniform rule reduces the test to 7 ∣ (9 + osculator 7 · 1).
+example : (7 : ℤ) ∣ 91 ↔ (7 : ℤ) ∣ (↑(91 / 10) + osculator 7 * ↑(91 % 10)) :=
+  seven_uniform 91
+
+-- 13 ∣ 169 via the computed osculator.
+example : (13 : ℤ) ∣ 169 ↔ (13 : ℤ) ∣ (↑(169 / 10) + osculator 13 * ↑(169 % 10)) :=
+  thirteen_uniform 169
+
+end DivisibilityBy3OQ01OQ02

--- a/src/data/proofs/divisibility-by-3-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/divisibility-by-3-oq-01-oq-02/annotations.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "divisibility-by-3-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "From Hand-Supplied Constants to a Computed Osculator",
+    "content": "The parent framework `DivisibilityTruncationGeneral` proves two parametric truncation theorems, `truncation_pos` and `truncation_neg`, but every concrete divisibility test still requires a human to *supply* the osculator constant $c$ together with a witness that $d \\mid 10c \\pm 1$.\n\nThis file removes that per-divisor hand-work. We give a single computable function $\\mathrm{osculator}(d) = \\mathtt{Int.gcdA}\\,10\\,d$ (a Bézout coefficient of $10$ modulo $d$) and prove once and for all that it satisfies the positive-osculator relation for every $d$ coprime to $10$. The truncation rule then becomes *uniform*: at any concrete divisor the only remaining side goal is decidable coprimality.",
+    "mathContext": "For $\\gcd(d,10)=1$, Bézout gives integers with $10 a + d b = 1$; taking $c = a = \\mathtt{gcdA}\\,10\\,d$ yields $10c - 1 = -db$, i.e. $d \\mid 10c - 1$.",
+    "significance": "central",
+    "prerequisites": [
+      "divisibility-truncation-general entry",
+      "Bézout's identity over the integers"
+    ],
+    "relatedConcepts": [
+      "osculator theory",
+      "modular inverse",
+      "Bézout coefficients"
+    ]
+  },
+  {
+    "id": "ann-osculator-def",
+    "proofId": "divisibility-by-3-oq-01-oq-02",
+    "range": { "startLine": 52, "endLine": 60 },
+    "type": "definition",
+    "title": "The Computable Osculator osculator(d) = Int.gcdA 10 d",
+    "content": "`osculator d` is defined as `Int.gcdA 10 (d : ℤ)`, the first Bézout coefficient of $10$ and $d$. It is a *total* computable function of $d$: no coprimality hypothesis is needed to define it, only to prove it behaves as an inverse. For $d$ coprime to $10$ it is an inverse of $10$ modulo $d$; for other $d$ it is still well-defined but the truncation rule need not apply.",
+    "mathContext": "$\\mathrm{osculator}(d) := \\mathtt{Int.gcdA}\\,10\\,d$; when $\\gcd(d,10)=1$ this is $10^{-1} \\bmod d$ (up to sign/representative).",
+    "significance": "central",
+    "prerequisites": ["extended Euclidean algorithm"],
+    "relatedConcepts": ["modular inverse", "extended Euclidean algorithm"]
+  },
+  {
+    "id": "ann-osculator-spec",
+    "proofId": "divisibility-by-3-oq-01-oq-02",
+    "range": { "startLine": 62, "endLine": 82 },
+    "type": "theorem",
+    "title": "osculator_spec: Correctness from Bézout's Identity",
+    "content": "`osculator_spec` proves that for every $d$ coprime to $10$, the computed osculator satisfies $d \\mid 10\\cdot\\mathrm{osculator}(d) - 1$ — exactly the hypothesis `truncation_pos` requires. The proof invokes `Int.gcd_eq_gcd_ab` (Bézout: $\\gcd(10,d) = 10\\,\\mathtt{gcdA} + d\\,\\mathtt{gcdB}$), collapses $\\gcd(10,d)$ to $1$ using `Int.isCoprime_iff_gcd_eq_one`, and exhibits $-\\mathtt{gcdB}$ as the witness for the divisibility, closing with `linear_combination`.\n\nThis is the crux: it converts a fact previously discharged by a *supplied* numeric witness into one *derived* from the structure of Bézout's identity.",
+    "mathContext": "$\\gcd(10,d)=1 \\Rightarrow 1 = 10c + d\\,b$ with $c=\\mathrm{osculator}(d)$, so $10c-1 = d(-b)$ and $d \\mid 10c-1$.",
+    "significance": "central",
+    "prerequisites": ["Bézout's identity", "IsCoprime <-> gcd = 1"],
+    "relatedConcepts": ["Bézout coefficients", "coprimality"]
+  },
+  {
+    "id": "ann-truncation-uniform",
+    "proofId": "divisibility-by-3-oq-01-oq-02",
+    "range": { "startLine": 88, "endLine": 100 },
+    "type": "theorem",
+    "title": "truncation_uniform: One Rule for All Divisors Coprime to 10",
+    "content": "`truncation_uniform` combines `truncation_pos` with `osculator_spec` to obtain, for *every* $d$ coprime to $10$,\n$$ d \\mid n \\iff d \\mid \\left(\\lfloor n/10\\rfloor + \\mathrm{osculator}(d)\\cdot(n \\bmod 10)\\right). $$\nThe osculator is no longer an input: it is computed from $d$. The only hypothesis is `IsCoprime (d:ℤ) 10`, which at any concrete numeral is decidable.",
+    "mathContext": "Instantiates the parametric positive-osculator rule at $c = \\mathrm{osculator}(d)$, with the osculator relation supplied by `osculator_spec`.",
+    "significance": "central",
+    "prerequisites": ["truncation_pos", "osculator_spec"],
+    "relatedConcepts": ["truncation divisibility test", "uniformity"]
+  },
+  {
+    "id": "ann-coverage",
+    "proofId": "divisibility-by-3-oq-01-oq-02",
+    "range": { "startLine": 102, "endLine": 137 },
+    "type": "theorem",
+    "title": "Extended Coverage as Evaluations of One Rule",
+    "content": "`seven_uniform`, `thirteen_uniform`, `nineteen_uniform`, and the bundling theorem `extended_coverage_uniform` recover the parent OQ's target primes (23, 29, 31, 37, 41, 43) — and any other divisor coprime to 10 — as one-line instances of `truncation_uniform`. The sole side goal in each is `IsCoprime (d:ℤ) 10`, closed by `decide`. Contrast the parent's `extended_truncation_coverage`, where each prime needed a hand-computed constant and a `⟨k, by norm_num⟩` divisibility witness. Two concrete `example`s confirm the end-to-end computation on $7 \\mid 91$ and $13 \\mid 169$.",
+    "mathContext": "Each prime $p \\in \\{23,29,31,37,41,43\\}$: `truncation_uniform p n (by decide)`; the osculator constant is computed, not supplied.",
+    "significance": "supporting",
+    "prerequisites": ["truncation_uniform"],
+    "relatedConcepts": ["divisibility rules", "decidability"]
+  }
+]

--- a/src/data/proofs/divisibility-by-3-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-01-oq-02/meta.json
@@ -1,0 +1,63 @@
+{
+  "id": "divisibility-by-3-oq-01-oq-02",
+  "title": "Uniform Osculator Function for Truncation Divisibility",
+  "slug": "divisibility-by-3-oq-01-oq-02",
+  "description": "Replaces the parent's hand-supplied per-divisor osculator constants with a single computable osculator function osculator(d) = Int.gcdA 10 d (a Bezout coefficient of 10 mod d). Proves once and for all that it satisfies the positive-osculator relation d | 10*osculator(d) - 1 for every d coprime to 10, yielding a uniform truncation rule d | n <-> d | (n/10 + osculator(d)*(n%10)) whose only side goal at a concrete divisor is decidable coprimality. This subsumes the parent's hand-written coverage extension (23, 29, 31, 37, 41, 43): those primes and all others are now instances of one theorem whose osculator is produced automatically from Bezout's identity.",
+  "meta": {
+    "author": "Extension of General Truncation Divisibility Rule",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Divisibility_rule",
+    "date": "2026-07-01",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "modular-arithmetic",
+      "bezout",
+      "computable",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DivisibilityBy3OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.gcd_eq_gcd_ab",
+        "description": "Bezout's identity: (gcd x y : Z) = x * gcdA x y + y * gcdB x y",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.isCoprime_iff_gcd_eq_one",
+        "description": "IsCoprime a b <-> Int.gcd a b = 1 over the integers",
+        "module": "Mathlib.RingTheory.Int.Basic"
+      },
+      {
+        "theorem": "Int.gcd_comm",
+        "description": "Int.gcd is symmetric",
+        "module": "Mathlib.Data.Int.GCD"
+      }
+    ],
+    "originalContributions": [
+      "Computable osculator function osculator(d) = Int.gcdA 10 d, total on all d",
+      "osculator_spec: for every d coprime to 10, d | 10*osculator(d) - 1, discharged from Bezout's identity rather than a supplied witness",
+      "truncation_uniform: a single truncation rule covering every d coprime to 10 with no supplied osculator constant",
+      "extended_coverage_uniform: the parent's six primes (23,29,31,37,41,43) recovered as evaluations of one uniform rule (side goal = decidable coprimality only)"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "relatedProblems": [
+      {
+        "id": "divisibility-truncation-general",
+        "relationship": "Grandparent: parametric truncation_pos/truncation_neg theorems this file instantiates uniformly"
+      },
+      {
+        "id": "divisibility-truncation-general-oq-01",
+        "relationship": "Sibling: unifies positive/negative osculator into a signed constant; this file instead computes the osculator"
+      }
+    ],
+    "lineCount": 145,
+    "definitionCount": 1,
+    "theoremCount": 6,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Builds on the parent's truncation_pos (also 0-axiom).",
+    "mathlib_version": "4.26.0"
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **divisibility-by-3-oq-01-oq-02** — a uniform, computable osculator function that removes the per-divisor hand-work of the parent truncation-divisibility framework.

The parent `DivisibilityTruncationGeneral` proves parametric osculator theorems (`truncation_pos`/`truncation_neg`) but every concrete divisor requires a human to *supply* the osculator constant `c` and a witness `d ∣ 10c ± 1`. This file gives a single **computable** osculator

    osculator d := Int.gcdA 10 d      -- Bézout coefficient of 10 mod d

and proves once and for all (`osculator_spec`) that it satisfies `d ∣ 10·osculator d − 1` for every `d` coprime to 10, derived from Bézout's identity rather than a supplied witness. Consequently `truncation_uniform` covers **every** divisor coprime to 10 with the sole side goal being decidable coprimality.

## Contributions (1 def, 6 theorems, 145 lines)

- `osculator` — total computable osculator `Int.gcdA 10 d`
- `osculator_spec` — correctness from Bézout (`Int.gcd_eq_gcd_ab` + `Int.isCoprime_iff_gcd_eq_one`)
- `truncation_uniform` — one truncation rule for all `d` coprime to 10, no supplied constant
- `extended_coverage_uniform` — parent's six primes (23,29,31,37,41,43) recovered as one-line evaluations, each side goal closed by `decide`
- `seven_uniform`/`thirteen_uniform`/`nineteen_uniform` + two concrete `example`s (7∣91, 13∣169)

## Verification

- Docker build: `Built Proofs.DivisibilityBy3OQ01OQ02` ✓ (3059 jobs, 0 errors)
- **0 axioms, 0 sorries** — `status: verified`, `badge: original`
- Builds on the parent's `truncation_pos` (also 0-axiom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)