### PR TITLE
research(kummer-theorem-oq-05): binomial digit-sum criterion [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/KummerTheoremOQ05.lean
+++ b/proofs/Proofs/KummerTheoremOQ05.lean
@@ -1,0 +1,144 @@
+import Mathlib
+
+/-
+# Kummer's digit-sum criterion for binomial coefficients
+
+The companion gallery entry `kummer-theorem` records Legendre's factorial
+identity in digit-sum form,
+
+  `(p - 1) * ν_p(n!) = n - S_p(n)`            (`legendre_digit_sum`),
+
+where `S_p(m) = (p.digits m).sum` is the sum of the base-`p` digits of `m`, but
+leaves the **binomial** side as a docstring remark.  This file completes it.
+
+The starting point is the elementary factorization
+`C(n,k) · k! · (n-k)! = n!` (`Nat.choose_mul_factorial_mul_factorial`).  Taking
+`p`-adic valuations turns the product into a sum,
+
+  `ν_p C(n,k) + ν_p(k!) + ν_p((n-k)!) = ν_p(n!)`,
+
+and multiplying by `(p - 1)` and substituting Legendre three times gives, after
+cancelling `k + (n-k) = n`, the exact (untruncated) identity
+
+  `S_p(n) + (p - 1) · ν_p C(n,k) = S_p(k) + S_p(n-k)`   (`digit_sum_padicValNat_choose`).
+
+From this single equation everything else drops out by linear arithmetic:
+
+* the classical **Kummer digit-sum formula**
+  `(p - 1) · ν_p C(n,k) = S_p(k) + S_p(n-k) - S_p(n)` (`sub_one_mul_padicValNat_choose`);
+* the **subadditivity of digit sums** across a split `n = k + (n-k)`,
+  `S_p(n) ≤ S_p(k) + S_p(n-k)` (`digit_sum_add_le`), a fact interesting in its own
+  right (the digit sum can only *decrease* under carries); and
+* the **divisibility criterion** `p ∤ C(n,k) ↔ S_p(k) + S_p(n-k) = S_p(n)`
+  (`not_dvd_choose_iff_digit_sum_add`): a prime fails to divide `C(n,k)` exactly
+  when adding `k` and `n-k` in base `p` produces no carries (each carry costs the
+  digit sum `p-1` and forces one factor of `p`).
+
+The central valuation identity `(p-1)·ν_p C(n,k) = S_p(k)+S_p(n-k)-S_p(n)` is
+already available in Mathlib as `sub_one_mul_padicValNat_choose_eq_sub_sum_digits`;
+the contribution here is the untruncated ordered form, the subadditivity corollary,
+and the clean divisibility criterion, all assembled over the parent's Legendre
+identity.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open Nat
+
+namespace KummerTheorem
+
+/-- **Exact (untruncated) Kummer digit-sum identity.**  For `k ≤ n` and a prime
+`p`, the base-`p` digit sums of `k`, `n - k`, and `n` are linked to the `p`-adic
+valuation of the binomial coefficient by
+
+  `S_p(n) + (p - 1) · ν_p C(n,k) = S_p(k) + S_p(n-k)`.
+
+This is the binomial companion of the parent's `legendre_digit_sum`.  It is stated
+without truncated subtraction, so both the classical formula and the subadditivity
+of digit sums follow from it by `omega`.
+
+Proof: `C(n,k)·k!·(n-k)! = n!`, so `ν_p` is additive across the three factors;
+multiplying by `p - 1` and substituting Legendre's factorial identity three times
+cancels `k + (n-k) = n`. -/
+theorem digit_sum_padicValNat_choose {p n k : ℕ} [Fact p.Prime] (h : k ≤ n) :
+    (p.digits n).sum + (p - 1) * padicValNat p (n.choose k)
+      = (p.digits k).sum + (p.digits (n - k)).sum := by
+  -- `C(n,k)·k!·(n-k)! = n!`, with all three factors nonzero.
+  have hCne : n.choose k ≠ 0 := (Nat.choose_pos h).ne'
+  have hkf : (k ! : ℕ) ≠ 0 := Nat.factorial_ne_zero k
+  have hnkf : ((n - k)! : ℕ) ≠ 0 := Nat.factorial_ne_zero (n - k)
+  have hprod : n.choose k * k ! * (n - k)! = n ! :=
+    Nat.choose_mul_factorial_mul_factorial h
+  -- Additivity of `padicValNat` across the product.
+  have hadd : padicValNat p (n.choose k) + padicValNat p (k !)
+        + padicValNat p ((n - k)!) = padicValNat p (n !) := by
+    rw [← hprod, padicValNat.mul (mul_ne_zero hCne hkf) hnkf, padicValNat.mul hCne hkf]
+  -- Multiply the additive relation by `(p - 1)` and distribute.
+  have hmul : (p - 1) * padicValNat p (n.choose k)
+        + (p - 1) * padicValNat p (k !)
+        + (p - 1) * padicValNat p ((n - k)!)
+      = (p - 1) * padicValNat p (n !) := by
+    have h2 : (p - 1) * (padicValNat p (n.choose k) + padicValNat p (k !)
+        + padicValNat p ((n - k)!)) = (p - 1) * padicValNat p (n !) := by rw [hadd]
+    simpa [mul_add] using h2
+  -- Legendre's factorial identity (digit-sum form) for each factorial.
+  have leg_k := sub_one_mul_padicValNat_factorial (p := p) k
+  have leg_nk := sub_one_mul_padicValNat_factorial (p := p) (n - k)
+  have leg_n := sub_one_mul_padicValNat_factorial (p := p) n
+  -- Digit sums never exceed their number, so the truncated subtractions are honest.
+  have hbk : (p.digits k).sum ≤ k := Nat.digit_sum_le p k
+  have hbnk : (p.digits (n - k)).sum ≤ n - k := Nat.digit_sum_le p (n - k)
+  have hbn : (p.digits n).sum ≤ n := Nat.digit_sum_le p n
+  omega
+
+/-- **Kummer's digit-sum formula** (classical, truncated form).  For `k ≤ n`,
+
+  `(p - 1) · ν_p C(n,k) = S_p(k) + S_p(n-k) - S_p(n)`.
+
+Equivalently `ν_p C(n,k)` is the number of carries when adding `k` and `n - k` in
+base `p`, since each carry lowers the digit sum by exactly `p - 1`.  (Matches
+Mathlib's `sub_one_mul_padicValNat_choose_eq_sub_sum_digits`.) -/
+theorem sub_one_mul_padicValNat_choose {p n k : ℕ} [Fact p.Prime] (h : k ≤ n) :
+    (p - 1) * padicValNat p (n.choose k)
+      = (p.digits k).sum + (p.digits (n - k)).sum - (p.digits n).sum := by
+  have key := digit_sum_padicValNat_choose (p := p) h
+  omega
+
+/-- **Subadditivity of digit sums across a split.**  For `k ≤ n` and prime `p`,
+
+  `S_p(n) ≤ S_p(k) + S_p(n-k)`.
+
+Writing `n = k + (n-k)`, the base-`p` digit sum of the whole never exceeds the sum
+of the digit sums of the parts: carries can only decrease it.  Immediate from the
+untruncated identity, since `(p - 1) · ν_p C(n,k) ≥ 0`. -/
+theorem digit_sum_add_le {p n k : ℕ} [Fact p.Prime] (h : k ≤ n) :
+    (p.digits n).sum ≤ (p.digits k).sum + (p.digits (n - k)).sum := by
+  have key := digit_sum_padicValNat_choose (p := p) h
+  omega
+
+/-- **Kummer's divisibility criterion.**  For `k ≤ n` and a prime `p`,
+
+  `p ∤ C(n,k) ↔ S_p(k) + S_p(n-k) = S_p(n)`.
+
+A prime `p` fails to divide `C(n,k)` exactly when adding `k` and `n - k` in base
+`p` produces no carries — equivalently, when the digit sums add without loss.  This
+is the binomial (Lucas-type) sharpening of the digit-sum identity: divisibility is
+detected purely by comparing digit sums. -/
+theorem not_dvd_choose_iff_digit_sum_add {p n k : ℕ} [Fact p.Prime] (h : k ≤ n) :
+    ¬ p ∣ n.choose k ↔
+      (p.digits k).sum + (p.digits (n - k)).sum = (p.digits n).sum := by
+  have key := digit_sum_padicValNat_choose (p := p) h
+  have hCne : n.choose k ≠ 0 := (Nat.choose_pos h).ne'
+  have hp2 : 2 ≤ p := (Fact.out : p.Prime).two_le
+  rw [dvd_iff_padicValNat_ne_zero hCne, not_not]
+  constructor
+  · intro h0
+    have hz : (p - 1) * padicValNat p (n.choose k) = 0 := by rw [h0, Nat.mul_zero]
+    omega
+  · intro heq
+    have hz : (p - 1) * padicValNat p (n.choose k) = 0 := by omega
+    rcases Nat.mul_eq_zero.mp hz with h1 | h2
+    · omega
+    · exact h2
+
+end KummerTheorem

--- a/src/data/proofs/kummer-theorem-oq-05/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-05/annotations.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "ann-kummer-oq05-untruncated-identity",
+    "proofId": "kummer-theorem-oq-05",
+    "range": {
+      "startLine": 63,
+      "endLine": 98
+    },
+    "type": "insight",
+    "title": "The Exact, Untruncated Kummer Digit-Sum Identity",
+    "content": "`digit_sum_padicValNat_choose` proves the binomial companion of the parent's factorial Legendre identity in a subtraction-free form: $s_p(n) + (p-1)\\,v_p\\binom{n}{k} = s_p(k) + s_p(n-k)$ for $k \\le n$. The proof takes `Nat.choose_mul_factorial_mul_factorial h : C(n,k)·k!·(n-k)! = n!`, applies `padicValNat.mul` twice to get $v_p C(n,k) + v_p(k!) + v_p((n-k)!) = v_p(n!)$, multiplies through by $p-1$ (distributing with `mul_add`), substitutes `sub_one_mul_padicValNat_factorial` for each factorial, and closes with `omega`. The `Nat.digit_sum_le` bounds $s_p(m) \\le m$ make every ℕ-truncated subtraction honest, so `omega` can cancel $k + (n-k) = n$.",
+    "mathContext": "Legendre's formula $(p-1)v_p(m!) = m - s_p(m)$ turns the additive relation among $v_p(n!), v_p(k!), v_p((n-k)!)$ into $(n - s_p(n)) = (p-1)v_p C(n,k) + (k - s_p(k)) + ((n-k) - s_p(n-k))$. Because $k + (n-k) = n$, the bare integers cancel and only the digit sums and the binomial valuation remain.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Legendre's formula",
+      "p-adic valuation multiplicativity",
+      "base-p digit sum",
+      "Kummer's theorem"
+    ],
+    "prerequisites": [
+      "sub_one_mul_padicValNat_factorial",
+      "padicValNat.mul",
+      "Nat.choose_mul_factorial_mul_factorial",
+      "Nat.digit_sum_le"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq05-classical-formula",
+    "proofId": "kummer-theorem-oq-05",
+    "range": {
+      "startLine": 101,
+      "endLine": 112
+    },
+    "type": "observation",
+    "title": "The Classical Digit-Sum Formula",
+    "content": "`sub_one_mul_padicValNat_choose` recovers the usual (truncated) statement $(p-1)\\,v_p\\binom{n}{k} = s_p(k) + s_p(n-k) - s_p(n)$ as a one-line `omega` consequence of the untruncated identity. This matches Mathlib's `sub_one_mul_padicValNat_choose_eq_sub_sum_digits`; here it is presented as a corollary of the ordered form so the divisibility criterion below can be read off without truncation artifacts.",
+    "mathContext": "$v_p\\binom{n}{k}$ is the number of carries when adding $k$ and $n-k$ in base $p$; each carry decreases the total digit sum by exactly $p-1$, which is precisely what this formula measures.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Kummer carry count",
+      "base-p digit sum"
+    ],
+    "prerequisites": [
+      "digit_sum_padicValNat_choose"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq05-digit-sum-subadditivity",
+    "proofId": "kummer-theorem-oq-05",
+    "range": {
+      "startLine": 114,
+      "endLine": 124
+    },
+    "type": "insight",
+    "title": "Digit Sums Are Subadditive Across a Split",
+    "content": "`digit_sum_add_le` gives $s_p(n) \\le s_p(k) + s_p(n-k)$ for $k \\le n$, a reusable arithmetic fact obtained as an immediate byproduct: since $(p-1)\\,v_p\\binom{n}{k} \\ge 0$, the untruncated identity forces $s_p(n)$ below $s_p(k) + s_p(n-k)$. Writing $n = k + (n-k)$, the base-$p$ digit sum of the whole never exceeds the sum of the digit sums of the parts.",
+    "mathContext": "Adding two numbers in base $p$ can only trigger carries, and each carry replaces a local digit sum of $p$ by a carried $1$ — a net loss of $p-1$ in the digit sum. Hence $s_p(a+b) \\le s_p(a) + s_p(b)$, with equality exactly when the addition is carry-free.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "digit sum subadditivity",
+      "carries in base-p addition"
+    ],
+    "prerequisites": [
+      "digit_sum_padicValNat_choose"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq05-divisibility-criterion",
+    "proofId": "kummer-theorem-oq-05",
+    "range": {
+      "startLine": 127,
+      "endLine": 142
+    },
+    "type": "insight",
+    "title": "Kummer's Divisibility Criterion: No Carries ⟺ Not Divisible",
+    "content": "`not_dvd_choose_iff_digit_sum_add` proves $p \\nmid \\binom{n}{k} \\iff s_p(k) + s_p(n-k) = s_p(n)$ for $k \\le n$. Via `dvd_iff_padicValNat_ne_zero` (using $\\binom{n}{k} \\ne 0$) the goal becomes $v_p\\binom{n}{k} = 0 \\iff s_p(k)+s_p(n-k) = s_p(n)$; the untruncated identity makes both directions `omega`, with `Nat.mul_eq_zero` and the primality bound $2 \\le p$ discharging $(p-1)\\,v_p = 0 \\Rightarrow v_p = 0$.",
+    "mathContext": "A prime $p$ fails to divide $\\binom{n}{k}$ precisely when adding $k$ and $n-k$ in base $p$ produces no carries. This is the binomial, Lucas-type sharpening of Kummer's theorem: divisibility is decided by comparing digit sums alone.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kummer's theorem",
+      "Lucas' theorem",
+      "carry-free addition",
+      "p-adic valuation"
+    ],
+    "prerequisites": [
+      "digit_sum_padicValNat_choose",
+      "dvd_iff_padicValNat_ne_zero",
+      "Nat.mul_eq_zero"
+    ]
+  }
+]

--- a/src/data/proofs/kummer-theorem-oq-05/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-05/meta.json
@@ -1,0 +1,124 @@
+{
+  "slug": "kummer-theorem-oq-05",
+  "title": "Kummer's Theorem OQ-05: The Digit-Sum Divisibility Criterion for Binomial Coefficients",
+  "id": "kummer-theorem-oq-05",
+  "description": "Completes the binomial side of the Legendre/Kummer digit-sum identity begun in the parent's factorial-only legendre_digit_sum. From C(n,k)·k!·(n-k)! = n! it derives the exact untruncated identity S_p(n) + (p-1)·v_p(C(n,k)) = S_p(k) + S_p(n-k), and reads off three consequences: the classical formula (p-1)·v_p(C(n,k)) = S_p(k)+S_p(n-k)-S_p(n), the subadditivity of base-p digit sums S_p(n) ≤ S_p(k)+S_p(n-k), and the divisibility criterion p ∤ C(n,k) ⟺ S_p(k)+S_p(n-k) = S_p(n) (no carries).",
+  "overview": {
+    "historicalContext": "Kummer's theorem (1852) identifies the $p$-adic valuation $v_p\\binom{n}{k}$ with the number of carries when adding $k$ and $n-k$ in base $p$. Legendre's factorial formula $(p-1)\\,v_p(m!) = m - s_p(m)$ (where $s_p$ is the base-$p$ digit sum) is its additive engine. The parent gallery entry records the factorial side of this bridge; the binomial side — the identity $(p-1)\\,v_p\\binom{n}{k} = s_p(k) + s_p(n-k) - s_p(n)$ and the resulting no-carry divisibility test — is the classical statement usually quoted as 'Kummer's theorem' in number theory. It is the tool behind the study of Pascal's triangle mod $p$ (Lucas' theorem, the Sierpiński gasket for $p=2$), divisibility of Catalan and central binomial numbers, and Erdős-type elementary estimates.",
+    "problemStatement": "Complete the binomial (as opposed to factorial) side of the Legendre/Kummer digit-sum bridge: express $(p-1)\\,v_p\\binom{n}{k}$ through base-$p$ digit sums, and characterise exactly when a prime $p$ fails to divide $\\binom{n}{k}$ in terms of those digit sums.",
+    "text": "From C(n,k)·k!·(n-k)! = n!, the p-adic valuation is additive across the three factors; multiplying by (p-1) and substituting Legendre three times cancels k + (n-k) = n and yields the exact digit-sum identity, from which the classical formula, digit-sum subadditivity, and the no-carry divisibility criterion all follow by linear arithmetic.",
+    "proofStrategy": "The single computational core is `digit_sum_padicValNat_choose`. Start from `Nat.choose_mul_factorial_mul_factorial : k ≤ n → C(n,k)·k!·(n-k)! = n!`. Applying `padicValNat.mul` twice turns the valuation of the product into `v_p C(n,k) + v_p(k!) + v_p((n-k)!) = v_p(n!)`. Multiply through by `p-1` (distributing with `mul_add`) and substitute `sub_one_mul_padicValNat_factorial` for each of the four factorials. Since `Nat.digit_sum_le` guarantees `s_p(m) ≤ m`, every truncated ℕ-subtraction is honest and `omega` cancels `k + (n-k) = n` to give the exact identity `s_p(n) + (p-1)·v_p C(n,k) = s_p(k) + s_p(n-k)`. Stating it without truncation is the key move: the classical formula (`sub_one_mul_padicValNat_choose`), digit-sum subadditivity (`digit_sum_add_le`), and the criterion (`not_dvd_choose_iff_digit_sum_add`, via `dvd_iff_padicValNat_ne_zero`) are then each a one-line `omega` consequence.",
+    "keyInsights": [
+      "**State the identity without truncation.** The classical form `(p-1)·v_p = s_p(k)+s_p(n-k)-s_p(n)` uses truncated ℕ subtraction and hides information. Rearranged to `s_p(n) + (p-1)·v_p C(n,k) = s_p(k) + s_p(n-k)`, no subtraction appears, and every corollary becomes a linear-arithmetic triviality for `omega`.",
+      "**Multiplicativity does the real work.** The whole bridge rests on `v_p(a·b) = v_p a + v_p b` applied to `C(n,k)·k!·(n-k)! = n!`. No carry-counting is needed: Legendre's factorial identity supplies the digit sums and the binomial identity supplies the additivity.",
+      "**Digit-sum subadditivity falls out for free.** Because `(p-1)·v_p C(n,k) ≥ 0`, the untruncated identity immediately gives `s_p(n) ≤ s_p(k) + s_p(n-k)` for any split `n = k + (n-k)`: base-$p$ digit sums can only drop under carries. This subadditivity is a genuinely reusable arithmetic fact, obtained here as a byproduct.",
+      "**Divisibility is a digit-sum equality.** `dvd_iff_padicValNat_ne_zero` turns `p ∤ C(n,k)` into `v_p C(n,k) = 0`; the untruncated identity then makes this exactly `s_p(k)+s_p(n-k) = s_p(n)`. A prime misses `C(n,k)` precisely when adding `k` and `n-k` in base $p$ carries nowhere — each carry costs the digit sum $p-1$ and one factor of $p$."
+    ],
+    "prerequisites": [
+      "Legendre's factorial formula in digit-sum form: sub_one_mul_padicValNat_factorial, (p-1)·v_p(m!) = m - s_p(m)",
+      "Multiplicativity of the p-adic valuation: padicValNat.mul",
+      "The factorial identity C(n,k)·k!·(n-k)! = n! (Nat.choose_mul_factorial_mul_factorial)",
+      "The valuation/divisibility bridge dvd_iff_padicValNat_ne_zero and the digit-sum bound Nat.digit_sum_le"
+    ]
+  },
+  "conclusion": {
+    "summary": "A complete, 0-axiom, 0-sorry Lean 4 formalization completing the binomial side of the Kummer/Legendre digit-sum bridge. A single untruncated identity s_p(n) + (p-1)·v_p(C(n,k)) = s_p(k) + s_p(n-k), proved from valuation-multiplicativity plus Legendre's factorial formula, yields the classical digit-sum formula, the subadditivity of base-p digit sums, and the no-carry divisibility criterion p ∤ C(n,k) ⟺ s_p(k)+s_p(n-k) = s_p(n).",
+    "implications": "Supplies the gallery with the binomial companion of the parent's factorial-only Legendre identity, plus a clean statement of Kummer's divisibility criterion and a reusable digit-sum subadditivity lemma. These underpin Pascal-triangle-mod-p questions (Lucas' theorem, the Sierpiński gasket), divisibility of central binomial and Catalan numbers, and elementary prime-power estimates.",
+    "openQuestions": [
+      "Quantify the divisibility deficit: express the exact power v_p(C(n,k)) = (s_p(k)+s_p(n-k)-s_p(n))/(p-1) as a carry count and relate it to Lucas' digit-wise product.",
+      "Extend the untruncated identity to multinomial coefficients n!/(k_1!···k_r!) and a several-summand digit-sum subadditivity.",
+      "Characterise the pairs (n,k) with s_p(k)+s_p(n-k) = s_p(n) (carry-free additions) and count them within a fixed digit-width."
+    ]
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KummerTheoremOQ05.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "kummer-theorem",
+      "p-adic-valuation",
+      "binomial-coefficients",
+      "digit-sum",
+      "legendre-formula"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 144,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. 0 axioms, 0 sorries. #print axioms reports only [propext, Classical.choice, Quot.sound] (no sorryAx, no Lean.ofReduceBool). All results are derived from Mathlib's factorial Legendre identity (sub_one_mul_padicValNat_factorial), valuation multiplicativity (padicValNat.mul), and the digit-sum bound (Nat.digit_sum_le). The central valuation identity (p-1)·v_p(C(n,k)) = s_p(k)+s_p(n-k)-s_p(n) is also available in Mathlib as sub_one_mul_padicValNat_choose_eq_sub_sum_digits; the contribution here is the untruncated ordered form, the digit-sum subadditivity corollary, and the clean divisibility criterion, assembled over the parent's factorial-side identity.",
+    "originalContributions": [
+      "digit_sum_padicValNat_choose: the exact, untruncated Kummer digit-sum identity s_p(n) + (p-1)·v_p(C(n,k)) = s_p(k) + s_p(n-k) for k ≤ n. Stating it without ℕ-truncated subtraction is the enabling move that makes every downstream corollary a one-line omega. Proved from C(n,k)·k!·(n-k)! = n! by valuation multiplicativity plus Legendre's factorial formula three times.",
+      "sub_one_mul_padicValNat_choose: the classical (truncated) digit-sum formula (p-1)·v_p(C(n,k)) = s_p(k) + s_p(n-k) - s_p(n), recovered from the untruncated identity (matches Mathlib's sub_one_mul_padicValNat_choose_eq_sub_sum_digits).",
+      "digit_sum_add_le: subadditivity of base-p digit sums across a split, s_p(n) ≤ s_p(k) + s_p(n-k) for k ≤ n — a reusable arithmetic fact obtained as a byproduct, expressing that carries can only decrease the digit sum.",
+      "not_dvd_choose_iff_digit_sum_add: Kummer's divisibility criterion p ∤ C(n,k) ⟺ s_p(k) + s_p(n-k) = s_p(n), i.e. a prime misses the binomial coefficient exactly when adding k and n-k in base p is carry-free."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "sub_one_mul_padicValNat_factorial",
+        "description": "Legendre's formula, digit-sum form: (p-1)·v_p(m!) = m - s_p(m) — substituted for each of n!, k!, (n-k)! to convert the valuation additivity into a digit-sum identity",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "padicValNat.mul",
+        "description": "v_p(a·b) = v_p(a) + v_p(b) for a, b ≠ 0 — turns the valuation of C(n,k)·k!·(n-k)! into the sum of the three valuations",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "k ≤ n → C(n,k)·k!·(n-k)! = n! — the elementary factorization supplying the multiplicative relation among the factorials",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "dvd_iff_padicValNat_ne_zero",
+        "description": "for n ≠ 0, p ∣ n ↔ v_p(n) ≠ 0 — converts the divisibility criterion into a statement about the valuation, hence about digit sums",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.digit_sum_le",
+        "description": "s_p(m) ≤ m — guarantees the truncated ℕ-subtractions m - s_p(m) are honest so omega can cancel them",
+        "module": "Mathlib.Data.Nat.Digits.Defs"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "KummerTheorem",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/KummerTheoremOQ05.lean",
+    "sorries": 0
+  },
+  "sections": 4,
+  "crossReferences": [
+    {
+      "targetId": "kummer-theorem",
+      "relationship": "extends",
+      "description": "Parent proof of Kummer's theorem. The parent records Legendre's factorial identity in digit-sum form (legendre_digit_sum) but leaves the binomial side as a docstring remark; this file completes it and derives the divisibility criterion."
+    },
+    {
+      "targetId": "kummer-theorem-oq-04",
+      "relationship": "sibling",
+      "description": "Sibling OQ that specialises the digit-sum form of Kummer's theorem to p=2 on the diagonal C(2n,n) to get v₂(C(2n,n)) = s₂(n); this file supplies the general-p untruncated identity and criterion behind that specialisation."
+    },
+    {
+      "targetId": "kummer-theorem-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling OQ on divisibility patterns in Pascal's triangle via carry counts; the no-carry criterion here is the exact boundary between divisibility and non-divisibility it studies."
+    }
+  ]
+}


### PR DESCRIPTION
## Kummer's digit-sum divisibility criterion for binomial coefficients

Completes the **binomial** side of the Legendre/Kummer digit-sum bridge (the companion gallery entry `kummer-theorem` records only the factorial side, `legendre_digit_sum`).

### Core identity
From `Nat.choose_mul_factorial_mul_factorial : C(n,k)·k!·(n-k)! = n!` and valuation multiplicativity (`padicValNat.mul`), plus Legendre's factorial identity (`sub_one_mul_padicValNat_factorial`) three times, the proof cancels `k + (n-k) = n` via `omega` to get the exact, **untruncated** identity:

```
S_p(n) + (p-1)·v_p(C(n,k)) = S_p(k) + S_p(n-k)      -- digit_sum_padicValNat_choose
```

Stating it subtraction-free is the enabling move: every corollary is then a one-line `omega`.

### Corollaries (4 theorems total)
- `sub_one_mul_padicValNat_choose` — classical formula `(p-1)·v_p(C(n,k)) = S_p(k)+S_p(n-k)-S_p(n)`
- `digit_sum_add_le` — subadditivity of base-p digit sums: `S_p(n) ≤ S_p(k)+S_p(n-k)` (carries only decrease the digit sum)
- `not_dvd_choose_iff_digit_sum_add` — **Kummer's divisibility criterion** `p ∤ C(n,k) ⟺ S_p(k)+S_p(n-k) = S_p(n)` (a prime misses C(n,k) exactly when adding k and n-k in base p is carry-free)

### Verification
- Docker build clean (`Proofs.KummerTheoremOQ05`)
- `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` — **0 sorries, 0 axioms, no native_decide**
- 144 lines, standalone against Mathlib. The parent `KummerTheorem.lean` was referenced only in prose, so its import was dropped (the parent has pre-existing Mathlib `multiplicity`-refactor API drift, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)