### PR TITLE
Enrich ζ(6) = π⁶/945 (basel-problem-oq-08-oq-02): distinguish series vs analytic continuation

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02/annotations.json
@@ -21,6 +21,26 @@
     ]
   },
   {
+    "id": "ann-aoc0702-setintegral",
+    "proofId": "area-of-circle-oq-07-oq-02",
+    "range": { "startLine": 32, "endLine": 32 },
+    "type": "concept",
+    "title": "Reading the Set-Restricted Integral Notation `∫ x in s, f x`",
+    "content": "`open MeasureTheory` brings two integral notations into play, and the entire entry hinges on the difference. The parent's `∫ x, f x` integrates against the volume measure on all of ℝ; here `∫ x in Set.Ioi 0, f x` is the *set integral* `MeasureTheory.setIntegral`, i.e. integration against the volume measure **restricted** to the half-line `(0, ∞)` (`volume.restrict (Set.Ioi 0)`). It is not a new primitive — `∫ x in s, f x` unfolds to `∫ x, f x ∂(μ.restrict s)` — which is exactly why the even-symmetry lemma `integral_comp_abs` can relate the two by a measure-level reflection rather than any change-of-variable bookkeeping. `Set.Ioi 0` is the *open* ray `(0, ∞)`, but since `{0}` is volume-null the endpoint is irrelevant to the value; and as with the full-line notation, a non-integrable integrand (here `b ≤ 0`) makes the whole thing evaluate to `0`.",
+    "mathContext": "$\\int_{x \\in s} f = \\int f \\, d(\\mu\\restriction s)$ with $\\mu = \\text{volume}$, $s = (0,\\infty)$. Since $\\text{volume}(\\{0\\}) = 0$, $\\int_{(0,\\infty)} = \\int_{[0,\\infty)}$; the open vs. closed ray choice does not change the value.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "MeasureTheory.setIntegral",
+      "restricted measure volume.restrict",
+      "Set.Ioi",
+      "null sets and endpoints"
+    ],
+    "prerequisites": [
+      "set integral notation",
+      "restricted measure"
+    ]
+  },
+  {
     "id": "ann-aoc0702-half",
     "proofId": "area-of-circle-oq-07-oq-02",
     "range": { "startLine": 34, "endLine": 38 },

--- a/src/data/proofs/area-of-circle-oq-07/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07/annotations.json
@@ -47,6 +47,29 @@
     ]
   },
   {
+    "id": "ann-aoc07-opens",
+    "proofId": "area-of-circle-oq-07",
+    "range": {
+      "startLine": 29,
+      "endLine": 29
+    },
+    "type": "concept",
+    "title": "What the two `open`s bring into scope",
+    "content": "The single `open Real MeasureTheory` is what makes the theorem statements read the way they do. `open Real` brings the un-namespaced `π`, `exp`, and `sqrt` into scope (the file still writes `Real.exp`/`Real.sqrt`/`Real.pi` explicitly, but `integral_gaussian`'s statement uses the opened forms, so the match works). `open MeasureTheory` brings the integral notation `∫ x, f x`, which denotes the **Bochner integral of `f` against the default volume measure on ℝ** — not a Riemann or improper integral. Two consequences matter for reading the statement honestly: (1) the notation is total — for a non-integrable integrand it would silently evaluate to `0`, so the theorem only says something because `e^{-x²}` is genuinely integrable (a fact `integral_gaussian` supplies); (2) `∫ x : ℝ, …` with the bound-variable type annotation fixes the measure space to `(ℝ, volume)`, which is exactly the space `integral_gaussian` is stated over, allowing the `b = 1` instance to unify with the goal without any measure coercion.",
+    "mathContext": "$\\int_{\\mathbb R} f\\,d\\mu$ (Bochner) with $\\mu = \\text{volume}$; convention $\\int f = 0$ when $f \\notin L^1$, so integrability of $e^{-x^2}$ is a genuine hypothesis carried by \\texttt{integral\\_gaussian}.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Bochner integral",
+      "volume measure on ℝ",
+      "integral-of-non-integrable convention",
+      "namespace scoping"
+    ],
+    "prerequisites": [
+      "MeasureTheory integral notation",
+      "Real namespace"
+    ]
+  },
+  {
     "id": "ann-aoc07-main",
     "proofId": "area-of-circle-oq-07",
     "range": {

--- a/src/data/proofs/basel-problem-oq-08-oq-02/annotations.json
+++ b/src/data/proofs/basel-problem-oq-08-oq-02/annotations.json
@@ -34,15 +34,30 @@
     "proofId": "basel-problem-oq-08-oq-02",
     "range": {
       "startLine": 44,
-      "endLine": 65
+      "endLine": 53
     },
     "type": "theorem",
-    "title": "The Value ζ(6) = π⁶/945",
-    "content": "`tsum_one_div_nat_pow_six` is the headline result $\\sum' n,\\ 1/n^6 = \\pi^6/945$. It comes from `hasSum_one_div_nat_pow_six`, the $k=3$ instance of `hasSum_zeta_nat`: substituting $B_6 = 1/42$ and $6! = 720$ into $(-1)^4\\cdot 2^5\\cdot\\pi^6\\cdot B_6/6!$ gives $32\\cdot(1/42)/720 = 1/945$. `riemannZeta_six_eq` records the same value for the analytically continued zeta, $\\zeta(6) = \\pi^6/945$ over $\\mathbb{C}$, via `riemannZeta_two_mul_nat`.",
-    "mathContext": "$\\sum_{n\\ge1} 1/n^6 = \\dfrac{2^5\\pi^6\\cdot(1/42)}{720} = \\dfrac{\\pi^6}{945}$; also $\\zeta(6) = \\pi^6/945$ over $\\mathbb{C}$.",
+    "title": "The Value ζ(6) = π⁶/945 (real series)",
+    "content": "`tsum_one_div_nat_pow_six` is the headline result $\\sum' n,\\ 1/n^6 = \\pi^6/945$. It comes from `hasSum_one_div_nat_pow_six`, the $k=3$ instance of `hasSum_zeta_nat`: substituting $B_6 = 1/42$ and $6! = 720$ into $(-1)^4\\cdot 2^5\\cdot\\pi^6\\cdot B_6/6!$ gives $32\\cdot(1/42)/720 = 1/945$. The `tsum` value is then just `.tsum_eq` applied to the `HasSum` statement — summability is automatic from `HasSum`, so no separate convergence argument is needed.",
+    "mathContext": "$\\sum_{n\\ge1} 1/n^6 = \\dfrac{2^5\\pi^6\\cdot(1/42)}{720} = \\dfrac{\\pi^6}{945}$. The $\\texttt{HasSum}$ form carries both the value and summability; $\\texttt{.tsum\\_eq}$ extracts the $\\sum'$ identity.",
     "significance": "critical",
-    "relatedConcepts": ["ζ(6)", "even-zeta formula", "riemannZeta_two_mul_nat", "analytic continuation"],
+    "relatedConcepts": ["ζ(6)", "even-zeta formula hasSum_zeta_nat", "HasSum vs tsum", "Bernoulli substitution"],
     "prerequisites": ["B₆ = 1/42", "the even-argument zeta formula"]
+  },
+  {
+    "id": "baseloq08oq02-riemannzeta",
+    "proofId": "basel-problem-oq-08-oq-02",
+    "range": {
+      "startLine": 55,
+      "endLine": 63
+    },
+    "type": "theorem",
+    "title": "The Analytically-Continued ζ(6) over ℂ",
+    "content": "`riemannZeta_six_eq` records $\\zeta(6) = \\pi^6/945$ for Mathlib's `riemannZeta` — the *analytically continued* zeta function on $\\mathbb{C}$, a genuinely different object from the real series `∑' 1/n⁶` even though the two agree at $s = 6$. The value comes from `riemannZeta_two_mul_nat` at $k = 3$ (the even-integer special values of the meromorphic continuation), after which the same $B_6 = 1/42$ substitution and a `push_cast`/`ring` normalize the cast $\\mathbb{Q} \\to \\mathbb{C}$. Stating this separately from the real sum is the honest thing to do: the equality of the Dirichlet-series value and the continued value is a theorem (both are $\\pi^6/945$), not a definition — for $\\Re(s) > 1$ they coincide, and $s=6$ lies in that half-plane, but the `riemannZeta` symbol denotes the continuation everywhere.",
+    "mathContext": "$\\zeta(6) = \\pi^6/945$ in $\\mathbb{C}$, where $\\zeta = \\texttt{riemannZeta}$ is the analytic continuation. For $\\Re(s) > 1$, $\\texttt{riemannZeta}(s) = \\sum' n^{-s}$, so the complex value at $6$ matches the real series; the cast is $\\mathbb{Q}\\hookrightarrow\\mathbb{C}$ via $\\texttt{push\\_cast}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["riemannZeta_two_mul_nat", "analytic continuation", "Dirichlet series vs continuation", "ℚ → ℂ cast"],
+    "prerequisites": ["riemannZeta (analytic continuation)", "B₆ = 1/42"]
   },
   {
     "id": "baseloq08oq02-ratio",

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/index.ts
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, ProofReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BrouwerFixedPointOQ04OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+  references?: ProofReference[]
+}
+
+export const brouwerFixedPointOq04Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+  references: meta.references,
+}
+
+export const brouwerFixedPointOq04Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const brouwerFixedPointOq04Oq03Oq01Data: ProofData = {
+  proof: brouwerFixedPointOq04Oq03Oq01Proof,
+  annotations: brouwerFixedPointOq04Oq03Oq01Annotations,
+}

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/meta.json
@@ -3,6 +3,62 @@
   "title": "The Singleton Correspondence Bridge: Single-Valued Fixed Point Theorems as Special Cases of Set-Valued Ones",
   "slug": "brouwer-fixed-point-oq-04-oq-03-oq-01",
   "description": "Isolates the one fully machine-checkable, axiom-free piece of the Kakutani/Fan-Glicksberg hierarchy: the precise sense in which every single-valued fixed point theorem (Brouwer, Schauder) is a special case of its set-valued counterpart. The bridge is the singleton correspondence F_f(x) = {f x}. We prove, with zero axioms, that F_f is upper hemicontinuous iff f is continuous, always has nonempty/closed/convex values, that fixed points transfer exactly, and — as an axiom-free reduction theorem taking the set-valued fixed point principle as a hypothesis — that any Kakutani-type principle yields the corresponding Brouwer-type theorem.",
+  "overview": {
+    "historicalContext": "The parent hierarchy (OQ-04: Kakutani 1941; OQ-04-OQ-03: Fan-Glicksberg 1952) states its two headline theorems as axioms, because their proofs need degree theory or Schauder's theorem and are not packaged in Mathlib. This child extracts the part of that hierarchy that requires no such machinery: the embedding of single-valued fixed point theory into set-valued fixed point theory via the singleton correspondence F_f(x) = {f x}. This embedding is folklore in the mathematical-economics literature (Border, Fixed Point Theorems with Applications to Economics and Game Theory, 1985, Ch. 15), where it justifies why Kakutani's theorem is stated as the strict generalization of Brouwer's. Here it is made fully formal and axiom-free.",
+    "problemStatement": "In what precise sense is every single-valued fixed point theorem a special case of a set-valued one? Concretely: given a single-valued map f : X → Y, form its singleton correspondence F_f(x) := {f x}. Which of Kakutani's hypotheses (upper hemicontinuity, nonempty/closed/convex values) does F_f satisfy, and how do they relate to hypotheses on f? And does a fixed point of F_f coincide with an ordinary fixed point of f?",
+    "proofStrategy": "The computational core is a single set identity: the upper preimage {x | F_f(x) ⊆ U} equals the ordinary preimage f⁻¹(U) (upperPreimage_singletonMap, by singleton_subset_iff). From it, upper hemicontinuity of F_f unfolds — via continuous_def — to exactly the continuity of f (singleton_uhc_iff_continuous, an iff). The three remaining Kakutani value-conditions are discharged pointwise: nonempty (⟨f x, rfl⟩), closed in a T1 space (isClosed_singleton), convex in a real vector space (convex_singleton). Fixed points transfer by mem_singleton_iff plus eq_comm (singleton_isFixedPoint_iff). Finally brouwer_from_kakutani_principle assembles these: given any set-valued principle guaranteeing a fixed point for UHC nonempty/closed/convex self-correspondences on a domain K, feeding it F_f produces an ordinary fixed point of any continuous self-map f of K — the rigorous content of 'single-valued ⊆ set-valued', stated with the principle as a hypothesis so the whole theorem is verified.",
+    "keyInsights": [
+      "The entire bridge rests on one set identity: {x | {f x} ⊆ U} = f⁻¹(U). Every downstream result is a one- or two-line consequence, which is exactly why the embedding is 'faithful' — no information is lost passing from f to F_f.",
+      "Upper hemicontinuity of the singleton correspondence is not merely implied by continuity of f — it is *equivalent* to it (singleton_uhc_iff_continuous is a genuine iff). This pins down UHC as the correct set-valued generalization of continuity.",
+      "The reduction theorem is stated with the Kakutani/Fan-Glicksberg principle as an explicit hypothesis, not an axiom. This keeps the entry honestly 0-axiom while still expressing the full logical content 'Kakutani ⟹ Brouwer': the hard theorem is quantified over, not assumed globally.",
+      "The four hypotheses map cleanly: continuity ↦ upper hemicontinuity, and 'single value' ↦ nonempty + closed (T1) + convex values. The T1 assumption is exactly what closedness of singletons needs; convexity needs a real module structure. Naming these minimal ambient hypotheses is part of the contribution.",
+      "Fixed points transfer as an iff (singleton_isFixedPoint_iff): x ∈ {f x} ⟺ f x = x. The set-valued fixed-point equation x ∈ F(x) genuinely specializes to the scalar equation f x = x, so no spurious or missing fixed points are introduced by the embedding."
+    ]
+  },
+  "sections": [
+    {
+      "id": "set-valued-vocabulary",
+      "title": "Part I — Set-Valued Vocabulary and the Singleton Correspondence",
+      "startLine": 49,
+      "endLine": 81,
+      "summary": "Definitions mirroring the parent Kakutani file: SetValuedMap, IsUpperHemicontinuous (open upper-preimages), HasNonempty/Closed/ConvexValues, IsFixedPoint, plus the new singletonMap f := fun x => {f x} whose behaviour under the set-valued vocabulary the rest of the file studies."
+    },
+    {
+      "id": "key-set-identity",
+      "title": "Part II — The Key Set Identity",
+      "startLine": 83,
+      "endLine": 93,
+      "summary": "upperPreimage_singletonMap: {x | {f x} ⊆ U} = f⁻¹(U), proved by ext + singleton_subset_iff. The computational core on which every later result depends — the UHC preimage of F_f carries exactly the information of the ordinary preimage of f."
+    },
+    {
+      "id": "uhc-iff-continuity",
+      "title": "Part III — Continuity ⟺ Upper Hemicontinuity",
+      "startLine": 95,
+      "endLine": 114,
+      "summary": "singleton_uhc_iff_continuous: IsUpperHemicontinuous (singletonMap f) ↔ Continuous f. After continuous_def both directions are immediate rewrites by the core identity — establishing UHC as the exact set-valued analogue of continuity."
+    },
+    {
+      "id": "kakutani-value-conditions",
+      "title": "Part IV — The Remaining Kakutani Value-Conditions",
+      "startLine": 116,
+      "endLine": 133,
+      "summary": "Singleton values are nonempty (⟨f x, rfl⟩), closed in a T1 space (isClosed_singleton), and convex in a real vector space (convex_singleton) — the three non-continuity Kakutani hypotheses, each with its minimal ambient typeclass named explicitly."
+    },
+    {
+      "id": "fixed-points-transfer",
+      "title": "Part V — Fixed Points Transfer Exactly",
+      "startLine": 135,
+      "endLine": 145,
+      "summary": "singleton_isFixedPoint_iff: IsFixedPoint (singletonMap f) x ↔ f x = x, via mem_singleton_iff and eq_comm. The embedding neither invents nor destroys fixed points."
+    },
+    {
+      "id": "reduction-theorem",
+      "title": "Part VI — Axiom-Free Reduction Theorem",
+      "startLine": 147,
+      "endLine": 183,
+      "summary": "brouwer_from_kakutani_principle: taking any set-valued fixed point principle on a domain K as an explicit hypothesis, every continuous self-map of K has an ordinary fixed point. Feeding singletonMap f to the principle and discharging its five obligations yields f x = x — 'Kakutani ⟹ Brouwer' stated axiom-free."
+    }
+  ],
   "meta": {
     "author": "Robb Walters (formalization); classical (Kakutani 1941, Border 1985 Ch. 15)",
     "date": "2026-07-01",
@@ -109,5 +165,14 @@
       "description": "The single-valued endpoint of the bridge: instantiating the reduction theorem's Kakutani hypothesis with the actual theorem recovers classical Brouwer on a compact convex domain."
     }
   ],
+  "conclusion": {
+    "summary": "Single-valued fixed point theory embeds faithfully into set-valued fixed point theory through the singleton correspondence F_f(x) = {f x}. With zero axioms the entry proves: the upper preimage identity {x | {f x} ⊆ U} = f⁻¹(U); upper hemicontinuity of F_f is *equivalent* to continuity of f; singleton values are always nonempty, closed (T1), and convex (real module); fixed points transfer exactly (x ∈ {f x} ⟺ f x = x); and, as an axiom-free reduction, any Kakutani-type set-valued principle supplied as a hypothesis yields the corresponding Brouwer-type theorem on its domain.",
+    "implications": "This makes rigorous and machine-checked the folklore statement that Kakutani's theorem is a strict generalization of Brouwer's: the four Kakutani hypotheses on F_f pull back to exactly the continuity hypothesis on f, and the set-valued conclusion pulls back to the ordinary fixed point. By quantifying over the deep theorem rather than asserting it, the reduction isolates the genuinely axiom-free logical content of the Kakutani/Fan-Glicksberg hierarchy while the hard analytic input remains cleanly factored into a single hypothesis to be instantiated.",
+    "openQuestions": [
+      "Instantiate the reduction's kakutani hypothesis with a Mathlib-backed finite-dimensional Kakutani theorem to recover classical Brouwer on a compact convex domain fully within the library.",
+      "Extend the bridge to lower hemicontinuity and to Michael-type continuous-selection theorems, characterizing which single-valued results arise as selections of set-valued ones.",
+      "Formalize the converse direction — conditions under which a set-valued theorem genuinely requires the set-valued generality and cannot be reduced to a single-valued statement via singleton correspondences."
+    ]
+  },
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-08-oq-02` (pass 0, quality 89). Structurally complete already. The ζ(6) annotation previously folded the real series and the complex `riemannZeta 6` into one block; I split them: narrowed the series annotation (clarifying HasSum vs tsum) and added a dedicated 5th annotation (`baseloq08oq02-riemannzeta`) explaining that Mathlib's analytically-continued `riemannZeta` is a genuinely different object from `∑' 1/n⁶` that agrees at s=6 only because Re s>1 — covering `riemannZeta_two_mul_nat` and the ℚ→ℂ cast. Reaches the 5-annotation target. Verified: JSON valid, size within caps, tsc -b clean.