### PR TITLE
research(inverse-galois-oq-04): inertia-tower + Galois-uniformity brick [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DedekindInertiaTower.lean
+++ b/proofs/Proofs/DedekindInertiaTower.lean
@@ -1,0 +1,85 @@
+import Mathlib
+
+/-!
+# Tower + Galois-uniformity brick for inertia degrees (inverse-Galois A₅, OQ-04)
+
+This file isolates one abstract, reusable, `0`-axiom step in the ongoing effort to
+discharge the last assumption of `Proofs.InverseGaloisA5`,
+
+```
+axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal     -- InverseGaloisA5.lean:309
+```
+
+The companion file `Proofs.InverseGaloisA5DedekindInstantiation` already reduces that
+axiom to the single sharp arithmetic fact
+
+```
+3 ∣ Ideal.inertiaDegIn (Q.under ℤ) (𝓞 q.SplittingField)
+```
+
+at an unramified prime `Q` over `7`, and its "residual gap" note spells out a three-step
+route to prove it:
+
+1. **Kummer–Dedekind** (`NumberField.Ideal.inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply`):
+   the prime of `𝓞 ℚ(α)` matching the *irreducible cubic factor* of `q mod 7` has inertia
+   degree `3`;
+2. **inertia-degree multiplicativity in a tower** (`Ideal.inertiaDeg_algebra_tower`, which
+   needs **no** Galois hypothesis on the non-normal middle field `ℚ(α)`): a prime `Q` of
+   `𝓞 q.SplittingField` over that cubic prime has `3 ∣ inertiaDeg(Q ∣ 7)`;
+3. **Galois uniformity** (`Ideal.inertiaDegIn_eq_inertiaDeg`): all primes of the *splitting
+   field* over `7` share this inertia degree, so `3 ∣ inertiaDegIn (7)`.
+
+This file packages steps **2 and 3** as a single divisibility statement,
+`inertiaDeg_dvd_inertiaDegIn`, in full generality (an arbitrary tower `R ⊆ S ⊆ T` with
+`T / R` Galois via a group `G`, `S` possibly non-normal). It thereby reduces the residual
+gap to producing *one* intermediate prime `P` with `d ∣ inertiaDeg p P`, which is exactly
+what the Kummer–Dedekind step of (1) supplies. Only ordinary foundational axioms
+(`propext`, `Classical.choice`, `Quot.sound`) are used — no `sorry`, no new `axiom`.
+-/
+
+open Ideal
+
+namespace DedekindInertiaTower
+
+variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
+  [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
+  (G : Type*) [Group G] [Finite G] [MulSemiringAction G T] [IsGaloisGroup G R T]
+  (p : Ideal R) [p.IsMaximal] (P : Ideal S) [P.IsMaximal] (Q : Ideal T) [Q.IsMaximal]
+  [P.LiesOver p] [Q.LiesOver P]
+
+-- `G` and `Q` (with their instances) do not appear in the theorem *statements* below,
+-- only in their proofs, so Lean would otherwise omit them from the contexts. Force their
+-- inclusion so the intermediate prime `Q` and Galois group `G` are quantified arguments.
+include G Q
+
+/-- **Tower + Galois-uniformity brick.** Let `R ⊆ S ⊆ T` be a tower of commutative rings
+with `T / R` Galois (Galois group `G`). If `p` is a maximal ideal of `R`, `P` a maximal
+ideal of the (possibly non-normal) intermediate ring `S` lying over `p`, and `Q` a maximal
+ideal of `T` lying over `P`, then the intermediate inertia degree `inertiaDeg p P` divides
+the Galois-invariant inertia degree `inertiaDegIn p T`.
+
+Proof: `inertiaDeg_algebra_tower` gives `inertiaDeg p Q = inertiaDeg p P * inertiaDeg P Q`
+(no Galois hypothesis needed on the middle field `S`), and `inertiaDegIn_eq_inertiaDeg`
+identifies `inertiaDegIn p T` with `inertiaDeg p Q` because `T / R` is Galois. Hence
+`inertiaDeg p P` is a factor of `inertiaDegIn p T`. -/
+theorem inertiaDeg_dvd_inertiaDegIn : inertiaDeg p P ∣ inertiaDegIn p T := by
+  haveI : Q.LiesOver p := LiesOver.trans Q P p
+  have htower : inertiaDeg p Q = inertiaDeg p P * inertiaDeg P Q :=
+    inertiaDeg_algebra_tower p P Q
+  have huniform : inertiaDegIn p T = inertiaDeg p Q :=
+    inertiaDegIn_eq_inertiaDeg p Q G
+  rw [huniform, htower]
+  exact dvd_mul_right _ _
+
+/-- **Reduction form.** To prove that a natural number `d` divides the Galois-invariant
+inertia degree `inertiaDegIn p T` of the top field, it suffices to exhibit *one*
+intermediate prime `P` (over `p`, below a chosen prime `Q` of `T`) with
+`d ∣ inertiaDeg p P`. This is the shape consumed by the A₅ inverse-Galois argument: the
+Kummer–Dedekind factorization of `q mod 7` yields a prime `P` of `𝓞 ℚ(α)` with
+`inertiaDeg (7) P = 3`, and this lemma promotes `3 ∣ inertiaDeg (7) P` to
+`3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)`. -/
+theorem dvd_inertiaDegIn_of_dvd_inertiaDeg {d : ℕ} (hd : d ∣ inertiaDeg p P) :
+    d ∣ inertiaDegIn p T :=
+  hd.trans (inertiaDeg_dvd_inertiaDegIn G p P Q)
+
+end DedekindInertiaTower

--- a/research/problems/inverse-galois-oq-04/knowledge.md
+++ b/research/problems/inverse-galois-oq-04/knowledge.md
@@ -137,3 +137,49 @@ inertia-tower multiplicativity → `inertiaDegIn_eq_inertiaDeg` (Galois) →
 **not** remove `three_dvd_gal_card`; it verifies and pins the arithmetic datum the
 remaining ~hundreds-of-lines KummerDedekind bridge will consume. Gallery entry
 `inverse-galois-a5` remains correctly `axiomatized` (axiomCount 1) — no gallery change.
+
+## Session 4 (researcher-8, 2026-07-01): PACKAGED the inertia-tower + Galois-uniformity brick (VERIFIED 0-axiom)
+
+New file `proofs/Proofs/DedekindInertiaTower.lean` isolates **steps 2 and 3** of the
+Session-3 residual gap as a single abstract, reusable, 0-axiom lemma (only
+`propext` / `Classical.choice` / `Quot.sound`; no `sorry`, no `native_decide`).
+
+- `DedekindInertiaTower.inertiaDeg_dvd_inertiaDegIn` : in a tower of commutative rings
+  `R ⊆ S ⊆ T` with `T / R` Galois (Galois group `G`, `[IsGaloisGroup G R T]`), for
+  maximal ideals `p ◁ R`, `P ◁ S` over `p`, `Q ◁ T` over `P`,
+  `Ideal.inertiaDeg p P ∣ Ideal.inertiaDegIn p T`.
+- `DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg` : reduction form — to get
+  `d ∣ inertiaDegIn p T` it suffices to exhibit *one* intermediate prime `P` with
+  `d ∣ inertiaDeg p P`. This is exactly the shape the A₅ argument consumes.
+
+Proof packages two existing Mathlib facts:
+- `Ideal.inertiaDeg_algebra_tower p P Q : inertiaDeg p Q = inertiaDeg p P * inertiaDeg P Q`
+  — multiplicativity in the tower, needing **no** Galois hypothesis on the non-normal
+  middle field `S = ℚ(α)`;
+- `Ideal.inertiaDegIn_eq_inertiaDeg p Q G : inertiaDegIn p T = inertiaDeg p Q`
+  — Galois uniformity: all primes of the top field `T` over `p` share one inertia degree.
+Then `inertiaDeg p P ∣ inertiaDeg p P * inertiaDeg P Q = inertiaDeg p Q = inertiaDegIn p T`.
+The transitivity instance `Q.LiesOver p` is supplied by `Ideal.LiesOver.trans Q P p`.
+
+### Effect on the residual gap
+Applied with `R = ℤ`, `S = 𝓞 ℚ(α)`, `T = 𝓞 q.SplittingField`, `G = q.Gal`, `p = (7)`,
+`d = 3`, this collapses the three-step route to a **single** remaining obligation:
+
+> **(Step 1, KummerDedekind only)** exhibit one prime `P` of `𝓞 ℚ(α)` over `(7)` with
+> `3 ∣ Ideal.inertiaDeg (7) P` — i.e. the prime matching the irreducible cubic factor
+> `cubic7` of `q mod 7` (Session 3), whose inertia degree is its degree, `3`.
+
+Steps 2 (inertia-tower multiplicativity) and 3 (Galois uniformity) are now machine-checked
+and packaged; only the KummerDedekind conductor step
+(`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply`, using `7 ∤ disc q = 32000²`)
+still stands between the verified arithmetic datum and `3 ∣ inertiaDegIn (7)`. This file
+does **not** remove `three_dvd_gal_card`; gallery entry `inverse-galois-a5` stays
+correctly `axiomatized` (axiomCount 1) — no gallery change.
+
+### Key Lean recipe (reusable)
+- **Tower inertia divisibility, abstractly**: for `d ∣ inertiaDegIn` reductions, use
+  `Ideal.inertiaDeg_algebra_tower` (multiplicativity, no Galois needed on the middle
+  ring) composed with `Ideal.inertiaDegIn_eq_inertiaDeg _ _ G` (Galois uniformity on the
+  top ring), stated over an `[IsGaloisGroup G R T]` tower with `[IsScalarTower R S T]`
+  and `LiesOver` instances chained by `Ideal.LiesOver.trans`. Keeps the middle field
+  non-normal — the whole point for `ℚ(α) ⊂ splitting field`.

--- a/research/problems/inverse-galois-oq-04/state.md
+++ b/research/problems/inverse-galois-oq-04/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: PARTIAL (arithmetic keystone formalized; residual = inertia-degree bridge)
+**Phase**: PARTIAL (arithmetic keystone + inertia-tower brick formalized; residual = KummerDedekind conductor step)
 **Since**: 2026-07-01
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
 
@@ -26,28 +26,39 @@ term vanishes since `char (ZMod 7)[X] = 7`); cubic irreducibility from
 `irreducible_of_degree_le_three_of_not_isRoot` + an exhaustive `decide` over the 7
 residues.
 
+## Session 4 addition (researcher-8, VERIFIED 0-axiom)
+
+`DedekindInertiaTower.lean`: packaged the abstract inertia-tower + Galois-uniformity
+step as `inertiaDeg_dvd_inertiaDegIn` (over a tower `R ⊆ S ⊆ T`, `T/R` Galois:
+`inertiaDeg p P ∣ inertiaDegIn p T`) plus its reduction form
+`dvd_inertiaDegIn_of_dvd_inertiaDeg`. Combines `Ideal.inertiaDeg_algebra_tower`
+(multiplicativity, no Galois on the non-normal middle ring) and
+`Ideal.inertiaDegIn_eq_inertiaDeg` (Galois uniformity). This covers **steps 2 & 3**
+of the residual route below.
+
 ## Blockers
 
 The remaining gap is **not** Dedekind's theorem in the abstract (that bridge,
-`DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn`, is proved 0-axiom).
-It is the concrete number-field inertia fact
-`3 ∣ Ideal.inertiaDegIn (7) (𝓞 q.SplittingField)`, which still needs the
-Kummer–Dedekind conductor step
-(`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply`, using `7 ∤ disc q =
-32000²`), the inertia-tower multiplicativity, and `inertiaDegIn_eq_inertiaDeg`
-(Galois). This is the `~800–1500`-line multi-session bridge; the arithmetic input
-it consumes is now machine-checked.
+`DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn`, is proved 0-axiom), and
+is **no longer** the inertia-tower multiplicativity / Galois-uniformity steps (packaged
+this session, 0-axiom). What remains is the single Kummer–Dedekind conductor step:
+exhibit one prime `P` of `𝓞 ℚ(α)` over `(7)` with `3 ∣ inertiaDeg (7) P` — the prime
+matching the irreducible cubic factor of `q mod 7` — via
+`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply` (conductor coprime to 7 since
+`7 ∤ disc q = 32000²`). Feeding that prime into
+`DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg` then yields
+`3 ∣ Ideal.inertiaDegIn (7) (𝓞 q.SplittingField)`.
 
 ## Next Action
 
-Multi-session: connect `qInt_map_zmod7` / `cubic7_irreducible` to
-`3 ∣ inertiaDegIn (7)` via KummerDedekind, then feed
-`InverseGaloisA5DedekindInstantiation.three_dvd_gal_card_of_bridge`. Alternatively
-park the residual bridge until Mathlib exposes Dedekind's factorization–inertia
-correspondence directly.
+Multi-session: prove Step 1 (KummerDedekind conductor step) to produce the intermediate
+prime `P` with `3 ∣ inertiaDeg (7) P`, feed it through
+`DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg`, then into
+`InverseGaloisA5DedekindInstantiation.three_dvd_gal_card_of_bridge`. Alternatively park
+the residual step until Mathlib exposes the factorization–inertia correspondence directly.
 
 ## Attempt Counts
 
-- Total attempts: 3
-- Current approach attempts: 1
-- Approaches tried: 2 (assess-and-document; arithmetic-keystone formalization)
+- Total attempts: 4
+- Current approach attempts: 2
+- Approaches tried: 3 (assess-and-document; arithmetic-keystone formalization; inertia-tower brick)

--- a/src/data/research/problems/inverse-galois-oq-04.json
+++ b/src/data/research/problems/inverse-galois-oq-04.json
@@ -31,12 +31,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Assessed (researcher-3, 2026-06-28). InverseGaloisA5.lean has exactly 1 axiom, three_dvd_gal_card (3 | |Gal(q)|), encoding Dedekind's theorem at p=7. All other inputs to |Gal|=60 are proved (5|Gal, Gal|60 via discriminant, no order-15/30 subgroup). The 3|Gal step has no axiom-free or computational shortcut: distinguishing D5 from A5 requires detecting an order-3 element, i.e. Dedekind's theorem (mod-7 cycle type) or Dummit's resolvent correspondence -- both absent from Mathlib.",
+    "progressSummary": "Session 4 (researcher-8, 2026-07-01): packaged the inertia-tower + Galois-uniformity brick (DedekindInertiaTower.lean, VERIFIED 0-axiom) — inertiaDeg_dvd_inertiaDegIn reduces 3 ∣ inertiaDegIn(7)(𝓞 splitting field) to exhibiting one intermediate prime of 𝓞ℚ(α) over 7 with inertia degree divisible by 3. Combined with Session 3's verified mod-7 factorization (cubic irreducible ⇒ that prime has inertiaDeg 3), the ONLY remaining obligation to discharge three_dvd_gal_card is the single KummerDedekind conductor step (inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply; 7 ∤ disc q = 32000²). Steps 2-3 (tower multiplicativity, Galois uniformity) now machine-checked. Gallery entry inverse-galois-a5 stays axiomatized (axiomCount 1) — no gallery change.",
     "builtItems": [
-      "InverseGaloisA5DedekindMod7.lean (VERIFIED 0-axiom): q mod 7 = (X-5)(X-6)(X^3+6X^2+4X+1) over F_7 with the cubic irreducible (Frobenius cycle type (1,1,3) at p=7). qInt_map_zmod7, cubic7_irreducible, qInt_map_rat, qInt_eq_factor_add_seven, cubic7_natDegree, cubic7_no_root."
+      "InverseGaloisA5DedekindMod7.lean (VERIFIED 0-axiom): q mod 7 = (X-5)(X-6)(X^3+6X^2+4X+1) over F_7 with the cubic irreducible (Frobenius cycle type (1,1,3) at p=7). qInt_map_zmod7, cubic7_irreducible, qInt_map_rat, qInt_eq_factor_add_seven, cubic7_natDegree, cubic7_no_root.",
+      "DedekindInertiaTower.lean (VERIFIED 0-axiom): abstract inertia-tower + Galois-uniformity brick. inertiaDeg_dvd_inertiaDegIn: in a tower R⊆S⊆T with T/R Galois, inertiaDeg p P ∣ inertiaDegIn p T; plus reduction form dvd_inertiaDegIn_of_dvd_inertiaDeg. Packages Ideal.inertiaDeg_algebra_tower + Ideal.inertiaDegIn_eq_inertiaDeg. Covers steps 2-3 of the residual gap; leaves only the KummerDedekind conductor step (step 1)."
     ],
     "insights": [
-      "Robust mod-p factorization recipe: prove poly = factors + p*R over Z[X] (ring closes it), map to ZMod p, kill the p*R term via (p:(ZMod p)[X])=0 (CharP.cast_eq_zero + Polynomial.instCharP). Cubic irreducibility over a finite field via irreducible_of_degree_le_three_of_not_isRoot + decide (kernel, axiom-clean)."
+      "Robust mod-p factorization recipe: prove poly = factors + p*R over Z[X] (ring closes it), map to ZMod p, kill the p*R term via (p:(ZMod p)[X])=0 (CharP.cast_eq_zero + Polynomial.instCharP). Cubic irreducibility over a finite field via irreducible_of_degree_le_three_of_not_isRoot + decide (kernel, axiom-clean).",
+      "Tower inertia divisibility abstractly: compose Ideal.inertiaDeg_algebra_tower (multiplicativity, no Galois needed on non-normal middle ring) with Ideal.inertiaDegIn_eq_inertiaDeg _ _ G (Galois uniformity on top ring) over an [IsGaloisGroup G R T] tower; chain LiesOver via Ideal.LiesOver.trans. Reduces d ∣ inertiaDegIn to exhibiting one intermediate prime P with d ∣ inertiaDeg p P."
     ],
     "mathlibGaps": [
       "Dedekind's theorem: factorization type of f mod p (p not dividing disc) = cycle type of Frobenius in Gal on roots. Entirely absent.",
@@ -44,8 +46,9 @@
       "Building blocks present: KummerDedekind.normalizedFactorsMapEquivNormalizedFactorsMinPolyMk; Ideal.inertiaDeg/ramificationIdx + RamificationInertia/Galois identities; Polynomial.Gal.galActionHom; Equiv.Perm.cycleType."
     ],
     "nextSteps": [
-      "If pursued: define Frobenius automorphism at an unramified prime P|(7), show it induces residue-field Frobenius, prove its cycle type on roots = inertia-degree multiset = mod-7 factorization degrees. ~800-1500 lines.",
-      "Alternatively formalize Dummit's resolvent-sextic correspondence (resolvent_no_*_root evidence already in file)."
+      "Prove Step 1 (KummerDedekind): exhibit prime P of 𝓞ℚ(α) over (7) with 3 ∣ inertiaDeg(7) P from the irreducible cubic factor, via inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply.",
+      "Feed P through DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg to get 3 ∣ inertiaDegIn(7), then into InverseGaloisA5DedekindInstantiation.three_dvd_gal_card_of_bridge.",
+      "Alternatively park until Mathlib exposes the factorization–inertia correspondence directly."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Adds `proofs/Proofs/DedekindInertiaTower.lean` (VERIFIED, 0-axiom): an abstract, reusable brick for the ongoing effort to discharge the last axiom of `Proofs.InverseGaloisA5` (`three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`, encoding Dedekind's theorem at p = 7).

Two theorems, in full generality over a tower `R ⊆ S ⊆ T` with `T/R` Galois (group `G`, possibly non-normal middle ring `S`):

- **`inertiaDeg_dvd_inertiaDegIn`** : `Ideal.inertiaDeg p P ∣ Ideal.inertiaDegIn p T` for `p ◁ R`, `P ◁ S` over `p`, `Q ◁ T` over `P`.
- **`dvd_inertiaDegIn_of_dvd_inertiaDeg`** : reduction form — `d ∣ inertiaDegIn p T` follows from exhibiting one intermediate prime `P` with `d ∣ inertiaDeg p P`.

The proof composes two existing Mathlib facts:
- `Ideal.inertiaDeg_algebra_tower` (inertia-degree multiplicativity in the tower — **no** Galois hypothesis on the non-normal middle ring `ℚ(α)`);
- `Ideal.inertiaDegIn_eq_inertiaDeg` (Galois uniformity: all primes of the top ring over `p` share one inertia degree).

## Effect on inverse-galois-oq-04

This packages **steps 2 and 3** of the Session-3 residual route. Combined with the verified mod-7 factorization (Session 3, `InverseGaloisA5DedekindMod7.lean`: `q ≡ (X−5)(X−6)·(irred. cubic) mod 7`), the only remaining obligation to discharge `three_dvd_gal_card` is the **single KummerDedekind conductor step** (step 1): exhibit the prime of `𝓞 ℚ(α)` over `(7)` matching the cubic factor, with inertia degree `3`.

Applied with `R = ℤ`, `S = 𝓞 ℚ(α)`, `T = 𝓞 q.SplittingField`, `G = q.Gal`, `p = (7)`, `d = 3`, `dvd_inertiaDegIn_of_dvd_inertiaDeg` then yields `3 ∣ inertiaDegIn (7)`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.DedekindInertiaTower` — **build succeeded**. `#print axioms` on both theorems reports only `[propext, Classical.choice, Quot.sound]`: 0 `sorry`, 0 `native_decide`, 0 new `axiom`.

This does **not** remove `three_dvd_gal_card`; gallery entry `inverse-galois-a5` stays `axiomatized` (axiomCount 1) — no gallery change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)