### PR TITLE
research(erdos-357-oq-04): little-o ⇔ ratio-limit equivalence, generalized [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos357OQ04.lean
+++ b/proofs/Proofs/Erdos357OQ04.lean
@@ -126,6 +126,6 @@ conjecture.
 theorem density_zero_iff_eventually_le (A : ℕ → ℕ) :
     Tendsto (fun n => (countLE A n : ℝ) / n) atTop (𝓝 0) ↔
       ∀ ε, 0 < ε → ∀ᶠ n in atTop, (countLE A n : ℝ) ≤ ε * n :=
-  sublinear_tfae _ (fun n => Nat.cast_nonneg _)
+  sublinear_tfae _ (fun _ => Nat.cast_nonneg _)
 
 end Erdos357OQ04

--- a/proofs/Proofs/Erdos357OQ04.lean
+++ b/proofs/Proofs/Erdos357OQ04.lean
@@ -1,0 +1,131 @@
+/-
+  Erdős Problem #357 — OQ-04
+  The little-o ⇔ ratio-limit equivalence, generalized (via the Mathlib asymptotic API).
+
+  Context. The parent gallery entry (Proofs/Erdos357Problem.lean) states the main
+  Erdős #357 conjecture in two equivalent forms and proves their equivalence in
+  `conjecture_equiv`:
+
+      Erdos357Conjecture     :  (fun n ↦ (f n : ℝ)) =o[atTop] (fun n ↦ (n : ℝ))
+      Erdos357ConjectureAlt  :  Tendsto (fun n ↦ (f n : ℝ) / n) atTop (𝓝 0)
+
+  That proof is a one-off: it is stated for the specific counting function `f` and
+  unfolds `isLittleO_iff_tendsto'` inline with the ad-hoc side condition that the
+  denominator `n` is eventually nonzero.
+
+  This file isolates the reusable content behind that argument. The only fact used
+  is that `(n : ℝ)` is eventually nonzero along `atTop`, so the vacuous side
+  condition of `Asymptotics.isLittleO_iff_tendsto'` is discharged once and for all,
+  for an ARBITRARY sequence `u : ℕ → ℝ` (Section 1). We then record two consequences
+  that the parent file's own OPEN conjectures need but do not have:
+
+  * an ε–N characterization of `u =o[atTop] id` for nonnegative `u`
+    (`littleO_natCast_iff_eventually_le`), which turns the asymptotic statement into
+    the concrete "eventually `u n ≤ ε·n`" form that density arguments are phrased in;
+
+  * the resulting dual formulation of the parent's OPEN infinite-set density-zero
+    conjecture (`InfiniteDensityZeroConjecture`), giving that conjecture the same
+    little-o ⇔ ratio-limit ⇔ ε–N trichotomy that `conjecture_equiv` gave the finite
+    function `f` (Section 2).
+
+  Nothing here re-proves `conjecture_equiv`; it generalizes the mechanism and applies
+  it to the density side, which the parent left only in ratio-limit form.
+
+  Fully machine-checked: 0 axioms, 0 sorries, no `native_decide`.
+-/
+import Mathlib
+
+open Filter Asymptotics
+
+namespace Erdos357OQ04
+
+/- ## Section 1: The general equivalence -/
+
+/--
+**General little-o ⇔ ratio-limit equivalence.**
+
+For *any* sequence `u : ℕ → ℝ`, comparison against the identity `n` in the
+little-o sense is equivalent to the normalized ratio tending to `0`:
+
+  `u =o[atTop] (fun n ↦ (n : ℝ))  ↔  Tendsto (fun n ↦ u n / n) atTop (𝓝 0)`.
+
+This is `Asymptotics.isLittleO_iff_tendsto'` specialized to the identity denominator,
+with its side condition discharged by the fact that `(n : ℝ)` is eventually nonzero
+along `atTop`. The parent file proves exactly this statement for `u = f`; here it is
+stated once for all `u`, so downstream growth/density questions can cite it directly.
+-/
+theorem littleO_natCast_iff_ratio_tendsto (u : ℕ → ℝ) :
+    (u =o[atTop] fun n => (n : ℝ)) ↔
+      Tendsto (fun n => u n / n) atTop (𝓝 0) := by
+  have h : ∀ᶠ n : ℕ in atTop, (n : ℝ) = 0 → u n = 0 := by
+    filter_upwards [eventually_gt_atTop 0] with n hn h0
+    rw [Nat.cast_eq_zero] at h0
+    omega
+  exact isLittleO_iff_tendsto' h
+
+/--
+**ε–N characterization of sublinear growth.**
+
+For a *nonnegative* sequence `u`, being little-o of the identity is equivalent to the
+concrete ε–N statement: for every `ε > 0`, eventually `u n ≤ ε · n`. This is the form
+in which "density tends to `0`" is usually attacked, so it is the practically useful
+face of the little-o statement.
+-/
+theorem littleO_natCast_iff_eventually_le (u : ℕ → ℝ) (hu : ∀ n, 0 ≤ u n) :
+    (u =o[atTop] fun n => (n : ℝ)) ↔
+      ∀ ε, 0 < ε → ∀ᶠ n in atTop, u n ≤ ε * n := by
+  rw [isLittleO_iff]
+  refine ⟨fun h ε hε => ?_, fun h c hc => ?_⟩
+  · filter_upwards [h hε] with n hn
+    rwa [Real.norm_of_nonneg (hu n), Real.norm_of_nonneg (Nat.cast_nonneg n)] at hn
+  · filter_upwards [h c hc] with n hn
+    rwa [Real.norm_of_nonneg (hu n), Real.norm_of_nonneg (Nat.cast_nonneg n)]
+
+/--
+The full trichotomy for a nonnegative sequence: little-o, ratio-limit, and ε–N forms
+all coincide. Combines the two lemmas above.
+-/
+theorem sublinear_tfae (u : ℕ → ℝ) (hu : ∀ n, 0 ≤ u n) :
+    (Tendsto (fun n => u n / n) atTop (𝓝 0)) ↔
+      ∀ ε, 0 < ε → ∀ᶠ n in atTop, u n ≤ ε * n := by
+  rw [← littleO_natCast_iff_ratio_tendsto]
+  exact littleO_natCast_iff_eventually_le u hu
+
+/- ## Section 2: Application to the Erdős #357 density conjecture
+
+The parent file states the OPEN "infinite-set density-zero" conjecture only in
+ratio-limit form:
+
+    InfiniteDensityZeroConjecture :
+      ∀ A, StrictMono A → HasDistinctSums A →
+        Tendsto (fun n ↦ #{k | A k ≤ n} / (n : ℝ)) atTop (𝓝 0)
+
+We reconstruct its counting function locally (as `countLE`) and give it the same
+little-o ⇔ ratio-limit ⇔ ε–N formulations that `conjecture_equiv` provides for the
+finite function `f`. -/
+
+/-- The counting function `#{k | A k ≤ n}` of a sequence `A`, matching the parent
+file's density statement. -/
+noncomputable def countLE (A : ℕ → ℕ) (n : ℕ) : ℕ := Nat.card {k | A k ≤ n}
+
+/--
+**Density-zero ⇔ little-o** for the counting function of any sequence `A`.
+The dual of `conjecture_equiv`, on the density side.
+-/
+theorem density_zero_iff_littleO (A : ℕ → ℕ) :
+    Tendsto (fun n => (countLE A n : ℝ) / n) atTop (𝓝 0) ↔
+      (fun n => (countLE A n : ℝ)) =o[atTop] fun n => (n : ℝ) :=
+  (littleO_natCast_iff_ratio_tendsto _).symm
+
+/--
+**Density-zero ⇔ ε–N** for the counting function: the OPEN conjecture that the
+density tends to `0` is *exactly* the statement that for every `ε > 0` the count is
+eventually below `ε · n`. This is the concrete handle for attacking the density
+conjecture.
+-/
+theorem density_zero_iff_eventually_le (A : ℕ → ℕ) :
+    Tendsto (fun n => (countLE A n : ℝ) / n) atTop (𝓝 0) ↔
+      ∀ ε, 0 < ε → ∀ᶠ n in atTop, (countLE A n : ℝ) ≤ ε * n :=
+  sublinear_tfae _ (fun n => Nat.cast_nonneg _)
+
+end Erdos357OQ04

--- a/proofs/Proofs/Erdos357OQ04.lean
+++ b/proofs/Proofs/Erdos357OQ04.lean
@@ -35,7 +35,7 @@
 -/
 import Mathlib
 
-open Filter Asymptotics
+open Filter Asymptotics Topology
 
 namespace Erdos357OQ04
 

--- a/src/data/proofs/erdos-357-oq-04/annotations.json
+++ b/src/data/proofs/erdos-357-oq-04/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-e357oq04-framing",
+    "proofId": "erdos-357-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 40
+    },
+    "type": "concept",
+    "title": "From a One-Off Equivalence to a Reusable Bridge",
+    "content": "**Framing.** The parent Erdős #357 entry proves `conjecture_equiv`: the little-o form $(f\\,n) =o[atTop] n$ and the ratio form $f(n)/n \\to 0$ of the main conjecture are equivalent. That proof is stated for the *specific* function $f$ and unfolds `Asymptotics.isLittleO_iff_tendsto'` inline with the ad-hoc observation that the denominator $n$ is eventually nonzero. This file extracts the reusable content: the equivalence holds for an **arbitrary** sequence $u : \\mathbb{N} \\to \\mathbb{R}$, plus an ε–N reformulation, and it is then applied to the parent's OPEN density-zero conjecture (which the parent stated only as a ratio limit).",
+    "mathContext": "$u =o[atTop] n \\iff \\lim_{n} u(n)/n = 0$; the side condition of `isLittleO_iff_tendsto'` is vacuous along $atTop$ since $n$ is eventually nonzero.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Landau little-o notation",
+      "Filter.atTop and eventually",
+      "Asymptotics.isLittleO_iff_tendsto'"
+    ],
+    "prerequisites": [
+      "Erdős #357 conjecture_equiv (parent entry)",
+      "The little-o relation f =o[l] g"
+    ],
+    "tags": [
+      "module-header",
+      "framing",
+      "asymptotics",
+      "erdos-357"
+    ]
+  },
+  {
+    "id": "ann-e357oq04-general-equiv",
+    "proofId": "erdos-357-oq-04",
+    "range": {
+      "startLine": 42,
+      "endLine": 72
+    },
+    "type": "theorem",
+    "title": "The General little-o ⇔ ratio-limit Equivalence",
+    "content": "**`littleO_natCast_iff_ratio_tendsto`.** For any $u : \\mathbb{N} \\to \\mathbb{R}$, $u =o[atTop] (\\lambda n.\\,n) \\iff \\mathrm{Tendsto}\\ (\\lambda n.\\,u(n)/n)\\ atTop\\ (\\mathcal{N}\\,0)$. The proof supplies the side condition $\\forall^{\\!f} n,\\ (n:\\mathbb{R}) = 0 \\to u(n) = 0$ of `Asymptotics.isLittleO_iff_tendsto'`; via `eventually_gt_atTop 0` we have $n > 0$ eventually, so $(n:\\mathbb{R}) = 0$ is impossible and the implication is vacuously true. This generalizes the parent's `conjecture_equiv`, whose only use of $f$ was that it is a sequence with eventually-nonzero denominator $n$.",
+    "mathContext": "`isLittleO_iff_tendsto' : (∀ᶠ x in l, g x = 0 → f x = 0) → (f =o[l] g ↔ Tendsto (fun x => f x / g x) l (𝓝 0))`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Asymptotics.isLittleO_iff_tendsto'",
+      "eventually_gt_atTop",
+      "Vacuous side conditions"
+    ],
+    "prerequisites": [
+      "Filter.Eventually and filter_upwards",
+      "Division-limit characterization of little-o"
+    ],
+    "tags": [
+      "theorem",
+      "general-lemma",
+      "asymptotics",
+      "reusable"
+    ]
+  },
+  {
+    "id": "ann-e357oq04-epsilon-n",
+    "proofId": "erdos-357-oq-04",
+    "range": {
+      "startLine": 73,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "ε–N Characterization of Sublinear Growth",
+    "content": "**`littleO_natCast_iff_eventually_le`.** For a *nonnegative* sequence $u$, $u =o[atTop] n$ is equivalent to $\\forall \\varepsilon > 0,\\ \\forall^{\\!f} n,\\ u(n) \\le \\varepsilon\\, n$. The proof rewrites the little-o relation via `Asymptotics.isLittleO_iff` into $\\forall c > 0,\\ \\forall^{\\!f} n,\\ \\lVert u(n)\\rVert \\le c\\,\\lVert n\\rVert$ and erases both norms with `Real.norm_of_nonneg` ($\\lVert u(n)\\rVert = u(n)$ since $u \\ge 0$, and $\\lVert(n:\\mathbb{R})\\rVert = n$). `sublinear_tfae` then packages the little-o, ratio-limit, and ε–N forms into one equivalence. This ε–N form is the operational shape density estimates are written in.",
+    "mathContext": "`isLittleO_iff : f =o[l] g ↔ ∀ ⦃c⦄, 0 < c → ∀ᶠ x in l, ‖f x‖ ≤ c * ‖g x‖`; for $u \\ge 0$ and $n \\ge 0$ the norms drop.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Asymptotics.isLittleO_iff",
+      "Real.norm_of_nonneg",
+      "ε–N definition of a limit"
+    ],
+    "prerequisites": [
+      "Norm on ℝ and Real.norm_of_nonneg",
+      "The IsLittleO unfolding"
+    ],
+    "tags": [
+      "theorem",
+      "epsilon-n",
+      "asymptotics",
+      "nonnegative"
+    ]
+  },
+  {
+    "id": "ann-e357oq04-density",
+    "proofId": "erdos-357-oq-04",
+    "range": {
+      "startLine": 94,
+      "endLine": 131
+    },
+    "type": "theorem",
+    "title": "Application: The Density-Zero Conjecture in Three Forms",
+    "content": "**`countLE`, `density_zero_iff_littleO`, `density_zero_iff_eventually_le`.** Reconstructing the parent's counting function $\\mathrm{countLE}\\,A\\,n := \\#\\{k \\mid A_k \\le n\\}$ (as `Nat.card`), the general results specialize to give the parent's OPEN `InfiniteDensityZeroConjecture` — stated there only as $\\#\\{k \\mid A_k \\le n\\}/n \\to 0$ — its little-o form and its ε–N form. In particular density $\\to 0$ is *exactly* $\\forall \\varepsilon > 0,\\ \\forall^{\\!f} n,\\ \\#\\{k \\mid A_k \\le n\\} \\le \\varepsilon\\,n$. This mirrors, on the density side, what `conjecture_equiv` does for the finite function $f$.",
+    "mathContext": "$\\#\\{k : A_k \\le n\\}/n \\to 0 \\iff \\#\\{k : A_k \\le n\\} =o[atTop] n \\iff \\forall\\varepsilon>0\\ \\text{eventually}\\ \\#\\{k : A_k \\le n\\} \\le \\varepsilon n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.card counting function",
+      "InfiniteDensityZeroConjecture (parent)",
+      "Natural density"
+    ],
+    "prerequisites": [
+      "The general equivalence and ε–N lemma above",
+      "The parent's density-zero conjecture"
+    ],
+    "tags": [
+      "theorem",
+      "density",
+      "application",
+      "erdos-357"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-357-oq-04/meta.json
+++ b/src/data/proofs/erdos-357-oq-04/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "erdos-357-oq-04",
+  "title": "The little-o ⇔ ratio-limit Equivalence, Generalized (Erdős #357)",
+  "slug": "erdos-357-oq-04",
+  "description": "The parent Erdős #357 entry proves conjecture_equiv — that the little-o form (f n) =o[atTop] n and the ratio form f n / n → 0 of the main conjecture coincide — but only for its specific counting function f, unfolding Asymptotics.isLittleO_iff_tendsto' inline. This entry isolates the reusable mechanism: the sole ingredient is that (n : ℝ) is eventually nonzero along atTop, discharging the vacuous side condition of isLittleO_iff_tendsto' once and for all for an ARBITRARY sequence u : ℕ → ℝ (littleO_natCast_iff_ratio_tendsto). It then supplies two things the parent's OPEN infinite-set density-zero conjecture lacks: an ε–N characterization of sublinear growth for nonnegative sequences (littleO_natCast_iff_eventually_le), turning the asymptotic statement into the concrete 'eventually count ≤ ε·n' form density arguments are phrased in, and the resulting little-o ⇔ ratio-limit ⇔ ε–N trichotomy for the density counting function #{k | A k ≤ n} (density_zero_iff_littleO, density_zero_iff_eventually_le). Nothing re-proves conjecture_equiv; the mechanism is generalized and applied to the density side, which the parent left only in ratio-limit form.",
+  "leanFile": {
+    "path": "Proofs/Erdos357OQ04.lean",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "sorryCount": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius (generalization + density application); mechanism from Mathlib (Asymptotics.isLittleO_iff_tendsto')",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos357OQ04.lean",
+    "tags": [
+      "analysis",
+      "asymptotics",
+      "little-o",
+      "filters",
+      "density",
+      "erdos-357",
+      "mathlib-api",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-01",
+    "lineCount": 131,
+    "originalContributions": [
+      "littleO_natCast_iff_ratio_tendsto: for ANY u : ℕ → ℝ, (u =o[atTop] fun n => (n:ℝ)) ↔ Tendsto (fun n => u n / n) atTop (𝓝 0). Generalizes the parent's conjecture_equiv (stated only for the specific function f) by discharging the side condition of Asymptotics.isLittleO_iff_tendsto' — that (n:ℝ) is eventually nonzero along atTop — once for all sequences.",
+      "littleO_natCast_iff_eventually_le: for nonnegative u, sublinear growth u =o[atTop] id is equivalent to the ε–N statement ∀ ε > 0, ∀ᶠ n, u n ≤ ε·n. Proved by unfolding Asymptotics.isLittleO_iff and simplifying the norms via Real.norm_of_nonneg (‖u n‖ = u n and ‖(n:ℝ)‖ = n). This is the concrete face of the asymptotic statement used in density arguments.",
+      "sublinear_tfae: combines the two into the little-o ⇔ ratio-limit ⇔ ε–N trichotomy for nonnegative sequences.",
+      "countLE + density_zero_iff_littleO / density_zero_iff_eventually_le: applies the trichotomy to the counting function #{k | A k ≤ n}, giving the parent's OPEN InfiniteDensityZeroConjecture the same dual/triple formulation that conjecture_equiv gives the finite function f — in particular that density → 0 is EXACTLY ∀ ε > 0, ∀ᶠ n, #{k | A k ≤ n} ≤ ε·n."
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms (only Mathlib's asymptotic API and standard tactics; no axiom depends on native_decide/decide, so no Lean.ofReduceBool), 0 sorries. The proofs use Asymptotics.isLittleO_iff_tendsto', Asymptotics.isLittleO_iff, filter_upwards / eventually_gt_atTop, Real.norm_of_nonneg, Nat.cast_nonneg, and omega. Ordinary foundational axioms (propext, Classical.choice, Quot.sound) do not count as assumptions.",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-357",
+      "relationship": "extends",
+      "description": "The parent entry proves conjecture_equiv for its specific function f, unfolding isLittleO_iff_tendsto' inline. This entry generalizes that argument to an arbitrary sequence u : ℕ → ℝ, adds an ε–N characterization, and applies the result to the parent's OPEN infinite-set density-zero conjecture, which the parent stated only in ratio-limit form."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Erdős Problem #357 asks whether the maximal length f(n) of a strictly increasing sequence in [1,n] with all distinct consecutive sums grows sublinearly, f(n) = o(n). The natural statement lives in two dialects: the Landau little-o form (f n) =o[atTop] n, and the analyst's ratio-limit form f(n)/n → 0. Mathlib's Asymptotics.isLittleO_iff_tendsto' bridges the two, but with a side condition (the denominator must vanish only where the numerator does), which along atTop with denominator n is vacuous because n is eventually nonzero. The parent formalization discharges this inline for its concrete f. The same bridge, and its ε–N reformulation, apply verbatim to every sublinear-growth question in the #357 circle — notably the infinite-set density-zero conjecture — so it is worth stating once in reusable form.",
+    "problemStatement": "Extract the reusable content of the parent's conjecture_equiv: state the little-o ⇔ ratio-limit equivalence for an arbitrary sequence u : ℕ → ℝ, add the ε–N characterization of sublinear growth for nonnegative sequences, and apply both to the counting function #{k | A k ≤ n} so that the parent's OPEN density-zero conjecture acquires the same little-o ⇔ ratio-limit ⇔ ε–N formulations.",
+    "proofStrategy": "For the general equivalence, invoke Asymptotics.isLittleO_iff_tendsto' with denominator (n : ℝ); its side condition ∀ᶠ n, (n:ℝ) = 0 → u n = 0 is discharged by eventually_gt_atTop 0 (n > 0 ⇒ (n:ℝ) ≠ 0), so the implication is vacuous. For the ε–N form, unfold Asymptotics.isLittleO_iff to ∀ c > 0, ∀ᶠ n, ‖u n‖ ≤ c·‖n‖ and simplify both norms with Real.norm_of_nonneg (using u ≥ 0 and n ≥ 0). The trichotomy and the density corollaries are direct combinations/instantiations, with the counting function countLE A n := Nat.card {k | A k ≤ n} matching the parent's density statement.",
+    "keyInsights": [
+      "The parent's conjecture_equiv is a one-off specialization: the ONLY property of f it uses is that the numerator is a sequence and the denominator n is eventually nonzero. Abstracting to arbitrary u : ℕ → ℝ loses nothing and makes the bridge reusable.",
+      "Along atTop the side condition of isLittleO_iff_tendsto' is vacuous — n is eventually positive, hence nonzero — so the little-o and ratio-limit forms are unconditionally equivalent for every sequence.",
+      "For nonnegative sequences the little-o statement is literally the ε–N definition of sublinear growth: ∀ ε > 0, eventually u n ≤ ε·n. This is the operational form for density work, obtained by erasing the norms via Real.norm_of_nonneg.",
+      "The parent states its infinite-set density-zero conjecture only as a ratio limit; the same trichotomy gives it the little-o and ε–N faces for free, so any attack on that OPEN conjecture can pick whichever form is most convenient."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Context",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Explains that the parent's conjecture_equiv proves the little-o ⇔ ratio-limit equivalence only for its specific f, and that this file isolates the reusable mechanism (denominator eventually nonzero) plus an ε–N characterization and a density application.",
+      "mathContext": "Erdős #357: is f(n) = o(n)? The little-o form $(f\\,n) =o[atTop] n$ and ratio form $f(n)/n \\to 0$ are the two dialects bridged here."
+    },
+    {
+      "id": "general-equivalence",
+      "title": "Section 1: The General Equivalence and ε–N Form",
+      "startLine": 42,
+      "endLine": 92,
+      "summary": "littleO_natCast_iff_ratio_tendsto generalizes conjecture_equiv to any u : ℕ → ℝ via isLittleO_iff_tendsto' with the vacuous side condition. littleO_natCast_iff_eventually_le rewrites sublinear growth of a nonnegative u as the ε–N statement ∀ ε > 0, ∀ᶠ n, u n ≤ ε·n. sublinear_tfae combines them.",
+      "mathContext": "$u =o[atTop] n \\iff \\lim u(n)/n = 0 \\iff \\forall \\varepsilon>0,\\ \\text{eventually } u(n) \\le \\varepsilon n$ (last for $u \\ge 0$)."
+    },
+    {
+      "id": "density-application",
+      "title": "Section 2: Application to the Density-Zero Conjecture",
+      "startLine": 94,
+      "endLine": 131,
+      "summary": "countLE A n := Nat.card {k | A k ≤ n} reconstructs the parent's density counting function. density_zero_iff_littleO and density_zero_iff_eventually_le give the parent's OPEN InfiniteDensityZeroConjecture the little-o and ε–N reformulations, in particular that density → 0 is exactly ∀ ε > 0, eventually #{k | A k ≤ n} ≤ ε·n.",
+      "mathContext": "For $A : \\mathbb{N} \\to \\mathbb{N}$, $\\#\\{k : A_k \\le n\\}/n \\to 0 \\iff \\#\\{k : A_k \\le n\\} =o[atTop] n \\iff \\forall\\varepsilon>0$ eventually $\\#\\{k : A_k \\le n\\} \\le \\varepsilon n$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 131-line file (0 sorries, 0 axioms, no native_decide) generalizes the parent Erdős #357 entry's conjecture_equiv from its specific counting function f to an arbitrary sequence u : ℕ → ℝ, proving the little-o ⇔ ratio-limit equivalence via Mathlib's Asymptotics.isLittleO_iff_tendsto' with its side condition discharged once (the denominator n is eventually nonzero along atTop). It adds an ε–N characterization of sublinear growth for nonnegative sequences and combines the two into a little-o ⇔ ratio-limit ⇔ ε–N trichotomy, then applies it to the density counting function #{k | A k ≤ n} to give the parent's OPEN infinite-set density-zero conjecture the same triple formulation.",
+    "implications": "The reusable equivalence and its ε–N face apply to every sublinear-growth question in the Erdős #357 circle without re-deriving the eventually-nonzero-denominator bookkeeping. In particular the OPEN density-zero conjecture can now be attacked in whichever of the three equivalent forms is most convenient; the ε–N form ∀ ε > 0, eventually #{k | A k ≤ n} ≤ ε·n is the natural target for density estimates.",
+    "openQuestions": [
+      "The infinite-set density-zero conjecture itself (that every strictly increasing sequence with distinct consecutive sums has density 0) remains OPEN; this entry only supplies its equivalent formulations.",
+      "Relate the finite function f and the density counting function quantitatively — e.g. transfer a proof of f(n) = o(n) to the density statement for the corresponding extremal sequences."
+    ]
+  },
+  "references": [
+    {
+      "authors": "P. Erdős",
+      "title": "Problems and results in additive number theory",
+      "year": 1956,
+      "venue": "Colloque sur la Théorie des Nombres",
+      "note": "Source of the distinct-consecutive-sums growth problem (#357)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Asymptotics.isLittleO_iff_tendsto' and isLittleO_iff, the asymptotic API on which the equivalences rest."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Isolates the reusable content behind the parent Erdős #357 entry's `conjecture_equiv`, which proves the little-o ⇔ ratio-limit equivalence only for its specific counting function `f` (unfolding `Asymptotics.isLittleO_iff_tendsto'` inline). This entry:

- **`littleO_natCast_iff_ratio_tendsto`** — for *any* `u : ℕ → ℝ`, `u =o[atTop] (fun n ↦ (n:ℝ))  ↔  Tendsto (fun n ↦ u n / n) atTop (𝓝 0)`. The side condition of `isLittleO_iff_tendsto'` is discharged once and for all by `eventually_gt_atTop 0` (the denominator `n` is eventually nonzero along `atTop`).
- **`littleO_natCast_iff_eventually_le`** — for nonnegative `u`, sublinear growth is equivalent to the ε–N statement `∀ ε > 0, ∀ᶠ n, u n ≤ ε·n` (norms erased via `Real.norm_of_nonneg`). This is the concrete face density arguments are phrased in.
- **`sublinear_tfae`** — combines them into the little-o ⇔ ratio-limit ⇔ ε–N trichotomy.
- **`countLE` + `density_zero_iff_littleO` / `density_zero_iff_eventually_le`** — applies the trichotomy to the counting function `#{k | A k ≤ n}`, giving the parent's **OPEN** infinite-set density-zero conjecture the same dual/triple formulation `conjecture_equiv` gives the finite function `f`.

Nothing re-proves `conjecture_equiv`; the mechanism is generalized and applied to the density side, which the parent left only in ratio-limit form.

## Verification

- **0 axioms, 0 sorries, no `native_decide`.** `#print axioms` on all five theorems reports only `[propext, Classical.choice, Quot.sound]` (ordinary foundational axioms — no `Lean.ofReduceBool`, no `sorryAx`).
- Docker build clean (`Built Proofs.Erdos357OQ04`, no warnings).
- 5 theorems, 1 definition, 131 lines. Status: **verified**.

## Files

- `proofs/Proofs/Erdos357OQ04.lean` — the formalization
- `src/data/proofs/erdos-357-oq-04/{meta.json,annotations.json}` — gallery integration (cross-referenced to parent `erdos-357`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)