### PR TITLE
research(pell-equation-oq-03): operations-vs-output-size obstruction to polynomial-time Pell [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PellEquationOQ03.lean
+++ b/proofs/Proofs/PellEquationOQ03.lean
@@ -1,0 +1,189 @@
+/-
+Pell Equation — Open Question 03: Can Pell equations be solved in polynomial time?
+
+## Research Question
+Is there a deterministic classical algorithm that, given a non-square `D`, outputs a
+representation of the fundamental Pell solution in time polynomial in `log D`?
+The best known classical algorithms are only *sub-exponential* (Lenstra 1980,
+Buchmann–Williams), while Hallgren (2002) gives a *quantum* polynomial-time algorithm.
+The classical question is OPEN and is believed to be at least as hard as computing the
+regulator of the real quadratic field ℚ(√D).
+
+## What This File Contributes
+A full formalisation of the *concrete algorithmic obstruction* that forces every
+"generate the solutions" method to be at best exponential in the number of arithmetic
+operations. The key tension is between two facts:
+
+  (A) The `2^k`-th Pell solution is reachable by **`k` repeated squarings** — a
+      *linear* number of group operations in `k` (fast exponentiation / addition
+      chains).  This is the algorithmic content that makes powers cheap to *compose*.
+
+  (B) The `2^k`-th Pell solution has an `x`-coordinate of size at least `2^(2^k)`,
+      i.e. its bit-length is `≥ 2^k` — **exponential in `k`**, the number of
+      operations performed.
+
+So the map (number of operations `k`) ↦ (bit-size of the output) is exponential: you
+cannot even *write down* the reached solution in time polynomial in the number of ring
+multiplications.  This is precisely why naive solution-enumeration is sub-exponential,
+and it isolates — in fully verified, axiom-free Lean — the growth phenomenon at the
+heart of the open complexity question.
+
+The complexity-class statement itself (does a `poly(log D)` classical algorithm exist?)
+is *not* formalised here: Mathlib has no bit-complexity model, no `TIME(f)` predicate,
+and no complexity class `P`.  We formalise the underlying mathematics that any such
+formalisation would rest on.
+
+## Main Results
+* `pellDouble` — the squaring (doubling) map `a ↦ a * a` on `Solution₁ d`.
+* `x_double`, `y_double` — explicit Brahmagupta doubling formulas
+  `x₂ₙ = 2xₙ² − 1`, `y₂ₙ = 2 xₙ yₙ`.
+* `iterate_double_eq_pow` — `k` doublings compute the `2^k`-th power
+  (repeated-squaring correctness).
+* `x_pow_add`, `y_pow_add` — the index-addition (Brahmagupta composition) laws
+  `x_{m+n} = xₘxₙ + D yₘyₙ`, `y_{m+n} = xₘyₙ + yₘxₙ`, the step of binary exponentiation.
+* `x_double_ge`, `x_iterate_double_ge` — the doubly-exponential lower bound
+  `2^(2^k) ≤ x_{2^k}` on the reached coordinate.
+* `operations_vs_size` — the capstone tying (A) and (B) together.
+
+## Status: axiom-free formalisation of the growth obstruction.
+The open question (classical polynomial-time solvability) itself remains OPEN.
+
+Reference: Lenstra, "Solving the Pell Equation", Notices AMS 49 (2002) 182–192.
+-/
+
+import Mathlib.NumberTheory.Pell
+import Mathlib.Tactic
+
+open Pell
+
+namespace PellEquationOQ03
+
+variable {d : ℤ}
+
+/-! ## Part 1: The doubling (squaring) map -/
+
+/-- The **doubling map** on Pell solutions: `a ↦ a * a`.  In the multiplicative
+group `Solution₁ d` this is squaring, and it is the elementary step of the
+repeated-squaring ("fast exponentiation") algorithm for reaching high powers of the
+fundamental solution. -/
+def pellDouble (a : Solution₁ d) : Solution₁ d := a * a
+
+@[simp] theorem pellDouble_eq_sq (a : Solution₁ d) : pellDouble a = a ^ 2 := by
+  rw [pellDouble, sq]
+
+/-- **Brahmagupta doubling formula for the `x`-coordinate**: `x₂ₙ = 2 xₙ² − 1`.
+Uses the defining Pell relation `xₙ² − D yₙ² = 1` to eliminate `D yₙ²`. -/
+theorem x_double (a : Solution₁ d) : (pellDouble a).x = 2 * a.x ^ 2 - 1 := by
+  have hp := a.prop
+  show (a * a).x = 2 * a.x ^ 2 - 1
+  rw [Solution₁.x_mul]
+  linear_combination -hp
+
+/-- **Brahmagupta doubling formula for the `y`-coordinate**: `y₂ₙ = 2 xₙ yₙ`. -/
+theorem y_double (a : Solution₁ d) : (pellDouble a).y = 2 * a.x * a.y := by
+  show (a * a).y = 2 * a.x * a.y
+  rw [Solution₁.y_mul]
+  ring
+
+/-! ## Part 2: Repeated squaring computes high powers
+
+`k` applications of `pellDouble` compute the `2^k`-th power of a solution.  This is
+the correctness statement of the fast-exponentiation loop: reaching an
+exponentially-indexed solution costs only linearly-many group operations in `k`. -/
+
+/-- **Repeated-squaring correctness**: iterating the doubling map `k` times yields the
+`2^k`-th power.  Hence `2^k`-indexed Pell solutions are reachable in `k` operations. -/
+theorem iterate_double_eq_pow (a : Solution₁ d) :
+    ∀ k : ℕ, (pellDouble)^[k] a = a ^ (2 ^ k) := by
+  intro k
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    rw [Function.iterate_succ_apply', ih, pellDouble_eq_sq, ← pow_mul, pow_succ]
+
+/-! ## Part 3: The index-addition (Brahmagupta composition) laws
+
+The step of binary exponentiation combines two already-computed powers.  In coordinates
+this is Brahmagupta's identity applied to `a^m` and `a^n`. -/
+
+/-- **Index-addition law for `x`** (Brahmagupta composition of powers):
+`x_{m+n} = xₘ xₙ + D yₘ yₙ`. -/
+theorem x_pow_add (a : Solution₁ d) (m n : ℕ) :
+    (a ^ (m + n)).x = (a ^ m).x * (a ^ n).x + d * ((a ^ m).y * (a ^ n).y) := by
+  rw [pow_add, Solution₁.x_mul]
+
+/-- **Index-addition law for `y`** (Brahmagupta composition of powers):
+`y_{m+n} = xₘ yₙ + yₘ xₙ`. -/
+theorem y_pow_add (a : Solution₁ d) (m n : ℕ) :
+    (a ^ (m + n)).y = (a ^ m).x * (a ^ n).y + (a ^ m).y * (a ^ n).x := by
+  rw [pow_add, Solution₁.y_mul]
+
+/-! ## Part 4: Exponential lower bound on the reached coordinate
+
+While the *computation* of the `2^k`-th solution costs only `k` operations, the *output*
+is doubly-exponentially large. -/
+
+/-- One doubling at least squares the `x`-coordinate (for `x ≥ 1`):
+`xₙ² ≤ x₂ₙ`.  From `x₂ₙ = 2xₙ² − 1` and `xₙ² ≥ 1`. -/
+theorem x_double_ge {a : Solution₁ d} (ha : 1 ≤ a.x) : a.x ^ 2 ≤ (pellDouble a).x := by
+  rw [x_double]
+  nlinarith [ha]
+
+/-- **Doubly-exponential lower bound**: if the seed has `x ≥ 2`, then after `k`
+doublings the `x`-coordinate is at least `2^(2^k)`.  Equivalently the bit-length of the
+`2^k`-th solution is `≥ 2^k`, exponential in the number `k` of operations performed. -/
+theorem x_iterate_double_ge {a : Solution₁ d} (ha : 2 ≤ a.x) :
+    ∀ k : ℕ, (2 : ℤ) ^ (2 ^ k) ≤ ((pellDouble)^[k] a).x := by
+  intro k
+  induction k with
+  | zero => simpa only [pow_zero, pow_one, Function.iterate_zero_apply] using ha
+  | succ k ih =>
+    rw [Function.iterate_succ_apply', x_double]
+    have h0 : (0 : ℤ) < (2 : ℤ) ^ (2 ^ k) := by positivity
+    have hx1 : (1 : ℤ) ≤ ((pellDouble)^[k] a).x := by omega
+    have hsq : ((2 : ℤ) ^ (2 ^ k)) ^ 2 ≤ ((pellDouble)^[k] a).x ^ 2 :=
+      pow_le_pow_left₀ (le_of_lt h0) ih 2
+    calc (2 : ℤ) ^ (2 ^ (k + 1))
+        = ((2 : ℤ) ^ (2 ^ k)) ^ 2 := by rw [← pow_mul, ← pow_succ]
+      _ ≤ ((pellDouble)^[k] a).x ^ 2 := hsq
+      _ ≤ 2 * ((pellDouble)^[k] a).x ^ 2 - 1 := by nlinarith [hx1]
+
+/-! ## Part 5: Capstone — operations versus output size -/
+
+/-- **Operations versus output size.**  Starting from a solution with `x ≥ 2`, performing
+`k` doubling operations produces exactly the `2^k`-th power (part A), whose `x`-coordinate
+is at least `2^(2^k)` (part B).  The number of arithmetic operations is `k`, yet the size
+of the result is exponential in `k`: no algorithm of this "compose the solutions" shape can
+write its output in time polynomial in the number of ring operations.  This is the concrete
+growth obstruction underlying the open question of classical polynomial-time solvability. -/
+theorem operations_vs_size {a : Solution₁ d} (ha : 2 ≤ a.x) (k : ℕ) :
+    (pellDouble)^[k] a = a ^ (2 ^ k) ∧ (2 : ℤ) ^ (2 ^ k) ≤ (a ^ (2 ^ k)).x := by
+  refine ⟨iterate_double_eq_pow a k, ?_⟩
+  have h := x_iterate_double_ge ha k
+  rwa [iterate_double_eq_pow a k] at h
+
+/-! ## Part 6: A concrete instance (D = 2, fundamental solution (3, 2))
+
+The fundamental solution of `x² − 2y² = 1` is `(3, 2)`.  Repeated squaring reproduces the
+classical chain `(3,2) → (17,12) → (577,408) → …`, each step roughly doubling the number
+of digits. -/
+
+/-- The fundamental solution `(3, 2)` of `x² − 2y² = 1`. -/
+def sol2 : Solution₁ (2 : ℤ) := Solution₁.mk 3 2 (by norm_num)
+
+theorem sol2_x : sol2.x = 3 := by simp only [sol2, Solution₁.x_mk]
+theorem sol2_y : sol2.y = 2 := by simp only [sol2, Solution₁.y_mk]
+
+/-- One doubling: `(3, 2) → (17, 12)`. -/
+theorem double_sol2 : (pellDouble sol2).x = 17 ∧ (pellDouble sol2).y = 12 := by
+  rw [x_double, y_double, sol2_x, sol2_y]
+  norm_num
+
+/-- Two doublings: `(3, 2) → (17, 12) → (577, 408)`, i.e. the 4-th power `sol2 ^ (2²)`
+(see `iterate_double_eq_pow`).  Each step roughly doubles the number of digits. -/
+theorem double_double_sol2 :
+    (pellDouble (pellDouble sol2)).x = 577 ∧ (pellDouble (pellDouble sol2)).y = 408 := by
+  rw [x_double, y_double, double_sol2.1, double_sol2.2]
+  norm_num
+
+end PellEquationOQ03

--- a/src/data/proofs/pell-equation-oq-03/annotations.json
+++ b/src/data/proofs/pell-equation-oq-03/annotations.json
@@ -1,0 +1,178 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "pell-equation-oq-03",
+    "range": { "startLine": 1, "endLine": 61 },
+    "type": "concept",
+    "title": "Why the Open Question Is Not Literally Formalizable — and What Is",
+    "content": "The gallery question is *can Pell's equation be solved in classical polynomial time in $\\log D$?* This cannot be stated inside Lean: Mathlib has no bit-complexity model, no predicate $\\mathrm{TIME}(f)$, and no complexity class $\\mathsf{P}$. Rather than axiomatize a complexity class, this entry formalizes — fully verified and axiom-free — the concrete growth phenomenon that makes every 'compose the known solutions' method sub-exponential. Two facts are in tension: **(A)** the $2^k$-th Pell solution is reachable by $k$ repeated squarings (a *linear* number of operations in $k$); **(B)** that solution has $x$-coordinate $\\geq 2^{2^k}$, i.e. bit-length $\\geq 2^k$ (*exponential* in $k$). So you cannot even write the answer down in time polynomial in the number of ring operations performed.",
+    "mathContext": "Reaching index $2^k$ costs $k$ operations; the output there has size $\\geq 2^{2^k}$. The complexity class statement itself is left OPEN.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "polynomial time",
+      "Pell's equation",
+      "sub-exponential algorithms",
+      "compact representation"
+    ],
+    "prerequisites": [
+      "Pell's equation",
+      "computational complexity (informal)",
+      "bit-length of integers"
+    ]
+  },
+  {
+    "id": "ann-doubling-map",
+    "proofId": "pell-equation-oq-03",
+    "range": { "startLine": 63, "endLine": 74 },
+    "type": "definition",
+    "title": "The Doubling Map: Squaring in the Pell Group",
+    "content": "Mathlib models the solutions of $x^2 - dy^2 = 1$ as a commutative group `Solution₁ d`, with the fundamental solution generating all others by powers. The **doubling map** `pellDouble a = a * a` is squaring in that group; `pellDouble_eq_sq` records `pellDouble a = a ^ 2`. It is the elementary step of the repeated-squaring ('fast exponentiation') loop: applying it $k$ times will land on the $2^k$-th power, which is exactly why exponentially-indexed solutions are cheap to *reach*.",
+    "mathContext": "$\\texttt{pellDouble}(a) = a\\cdot a = a^2$ in the group $\\mathrm{Solution}_1(d)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicative group of Pell solutions",
+      "squaring map",
+      "fast exponentiation"
+    ],
+    "prerequisites": [
+      "monoid / group powers",
+      "Pell.Solution₁"
+    ]
+  },
+  {
+    "id": "ann-doubling-formulas",
+    "proofId": "pell-equation-oq-03",
+    "range": { "startLine": 75, "endLine": 87 },
+    "type": "tactic",
+    "title": "The Brahmagupta Doubling Formulas",
+    "content": "In coordinates, squaring is Brahmagupta's identity applied to $a$ with itself. The `x`-formula `x_double` reads $x_{2n} = 2x_n^2 - 1$: from `Solution₁.x_mul`, $(a\\cdot a).x = x_n^2 + d\\,y_n^2$, and the defining Pell relation $x_n^2 - d\\,y_n^2 = 1$ lets us eliminate $d\\,y_n^2 = x_n^2 - 1$, giving $2x_n^2 - 1$ (discharged by `linear_combination`). The `y`-formula `y_double` is $y_{2n} = 2x_ny_n$, immediate from `Solution₁.y_mul` and `ring`. The '$-1$' and the elimination of $d\\,y_n^2$ both come straight from the Pell relation.",
+    "mathContext": "$x_{2n} = 2x_n^2 - 1$, $y_{2n} = 2x_ny_n$, using $x_n^2 - dy_n^2 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Brahmagupta identity",
+      "Pell relation",
+      "doubling formulas"
+    ],
+    "prerequisites": [
+      "Solution₁.x_mul / y_mul",
+      "the defining Pell relation"
+    ]
+  },
+  {
+    "id": "ann-repeated-squaring",
+    "proofId": "pell-equation-oq-03",
+    "range": { "startLine": 88, "endLine": 103 },
+    "type": "key-step",
+    "title": "Repeated Squaring Reaches Index 2^k in k Steps",
+    "content": "`iterate_double_eq_pow` proves $(\\texttt{pellDouble})^{[k]}(a) = a^{2^k}$ by induction on $k$. The step uses `Function.iterate_succ_apply'` ($f^{[k+1]}x = f(f^{[k]}x)$), the inductive hypothesis, `pellDouble_eq_sq`, and the exponent law $(a^{2^k})^2 = a^{2^k\\cdot 2} = a^{2^{k+1}}$ (`pow_mul`, `pow_succ`). This is the **(A)** side of the obstruction: the same addition-chain principle behind fast modular exponentiation makes an exponentially-indexed Pell solution reachable in only $k$ group multiplications.",
+    "mathContext": "$(\\texttt{double})^{[k]}(a) = a^{2^k}$: $k$ squarings reach the $2^k$-th power.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "repeated squaring",
+      "addition chains",
+      "fast exponentiation",
+      "function iteration"
+    ],
+    "prerequisites": [
+      "induction",
+      "Function.iterate",
+      "laws of exponents"
+    ]
+  },
+  {
+    "id": "ann-addition-laws",
+    "proofId": "pell-equation-oq-03",
+    "range": { "startLine": 104, "endLine": 120 },
+    "type": "key-step",
+    "title": "The Index-Addition (Composition) Laws",
+    "content": "Binary exponentiation also needs a *combine* step: given $a^m$ and $a^n$, form $a^{m+n}$. In coordinates this is Brahmagupta composition, obtained for free from $a^{m+n} = a^m\\cdot a^n$ (`pow_add`) and `Solution₁.x_mul` / `y_mul`. `x_pow_add`: $x_{m+n} = x_mx_n + d\\,y_my_n$; `y_pow_add`: $y_{m+n} = x_my_n + y_mx_n$. Together with the doubling formulas these are the two primitives of a fast-exponentiation algorithm on Pell solutions.",
+    "mathContext": "$x_{m+n} = x_mx_n + d\\,y_my_n$, $y_{m+n} = x_my_n + y_mx_n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Brahmagupta composition",
+      "binary exponentiation",
+      "group law in coordinates"
+    ],
+    "prerequisites": [
+      "pow_add",
+      "Solution₁.x_mul / y_mul"
+    ]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "pell-equation-oq-03",
+    "range": { "startLine": 121, "endLine": 150 },
+    "type": "key-step",
+    "title": "Doubly-Exponential Lower Bound on the Coordinate",
+    "content": "`x_double_ge` observes that one doubling at least squares the coordinate: $x_n^2 \\leq x_{2n} = 2x_n^2 - 1$ once $x_n^2 \\geq 1$. Iterating, `x_iterate_double_ge` proves $2^{2^k} \\leq x_{2^k}$ for any seed with $x \\geq 2$, by induction: from $2^{2^k} \\leq x_n$ (with $x_n \\geq 1$ via `omega`) and `pow_le_pow_left₀`, get $(2^{2^k})^2 \\leq x_n^2 \\leq 2x_n^2 - 1$, and $(2^{2^k})^2 = 2^{2^{k+1}}$. This is the **(B)** side: after $k$ operations the coordinate has at least $2^k$ bits.",
+    "mathContext": "$2^{2^k} \\leq x_{2^k}$: the output size is exponential in the operation count $k$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "exponential growth",
+      "monotonicity of powers",
+      "bit-length lower bound"
+    ],
+    "prerequisites": [
+      "induction",
+      "pow_le_pow_left₀",
+      "nlinarith / omega"
+    ]
+  },
+  {
+    "id": "ann-capstone",
+    "proofId": "pell-equation-oq-03",
+    "range": { "startLine": 151, "endLine": 164 },
+    "type": "key-step",
+    "title": "Capstone: Operations versus Output Size",
+    "content": "`operations_vs_size` packages the two sides: for a seed with $x \\geq 2$, performing $k$ doublings produces *exactly* $a^{2^k}$ (part A, `iterate_double_eq_pow`) whose $x$-coordinate is *at least* $2^{2^k}$ (part B, `x_iterate_double_ge`). The number of arithmetic operations is $k$, but the size of the result is exponential in $k$. No algorithm of this 'compose the solutions' shape can write its output in time polynomial in the number of ring operations — the concrete growth obstruction behind the open complexity question.",
+    "mathContext": "$k$ operations $\\Rightarrow$ output $= a^{2^k}$ with $x \\geq 2^{2^k}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "time-space tradeoff",
+      "output-size lower bound",
+      "polynomial time"
+    ],
+    "prerequisites": [
+      "iterate_double_eq_pow",
+      "x_iterate_double_ge"
+    ]
+  },
+  {
+    "id": "ann-regulator-bridge",
+    "proofId": "pell-equation-oq-03",
+    "range": { "startLine": 151, "endLine": 164 },
+    "type": "concept",
+    "title": "How the Regulator Reconciles the Two Rates",
+    "content": "The tension between $k$ operations and $2^{2^k}$-size output is resolved by the **regulator** $R = \\log(x + y\\sqrt D)$, developed in the sibling entries `pell-equation-oq-01` and the `oq-01-oq-04` lineage. Because $R$ is a logarithm, doubling becomes addition: $R(a^{2^k}) = 2^k\\,R(a)$, which is only *linear* in $k$ — matching the operation count. The coordinate $x = \\exp(R)$ is then exponential in $k$. The whole difficulty of *classical* Pell is to manipulate the exponential-size regulator through a polynomial-size proxy; the sub-exponential (Lenstra) and quantum-polynomial (Hallgren) algorithms both work with $R$ rather than the coordinates, which is precisely why they escape the obstruction proved here.",
+    "mathContext": "$R(a^{2^k}) = 2^k R(a)$ (linear in $k$) while $x_{2^k} = \\exp(R) \\geq 2^{2^k}$ (exponential in $k$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "regulator of a real quadratic field",
+      "logarithm of the fundamental unit",
+      "Hallgren's quantum algorithm"
+    ],
+    "prerequisites": [
+      "logarithms",
+      "the Pell regulator (oq-01)"
+    ]
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "pell-equation-oq-03",
+    "range": { "startLine": 165, "endLine": 189 },
+    "type": "example",
+    "title": "The Concrete Chain for D = 2",
+    "content": "The fundamental solution of $x^2 - 2y^2 = 1$ is $(3,2)$ (`sol2`). Applying the doubling formulas: $(3,2) \\to (2\\cdot 3^2 - 1,\\ 2\\cdot 3\\cdot 2) = (17,12)$, then $(17,12) \\to (2\\cdot 17^2 - 1,\\ 2\\cdot 17\\cdot 12) = (577,408)$ — the 4-th power $\\texttt{sol2}^{2^2}$ reached in two squarings (`double_double_sol2`). The digit count roughly doubles at each step ($1 \\to 2 \\to 3$ digits here, exponentially thereafter): a small, explicit witness of the operations-vs-size gap. Verified by `norm_num` on concrete integers (no `native_decide`).",
+    "mathContext": "$(3,2)\\to(17,12)\\to(577,408)$; $577^2 - 2\\cdot 408^2 = 332929 - 332928 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "fundamental solution",
+      "Pell chain",
+      "continued fraction convergents of √2"
+    ],
+    "prerequisites": [
+      "the doubling formulas",
+      "Solution₁.mk"
+    ]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-03/index.ts
+++ b/src/data/proofs/pell-equation-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PellEquationOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pellEquationOQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pellEquationOQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pellEquationOQ03Data: ProofData = {
+  proof: pellEquationOQ03Proof,
+  annotations: pellEquationOQ03Annotations,
+}

--- a/src/data/proofs/pell-equation-oq-03/meta.json
+++ b/src/data/proofs/pell-equation-oq-03/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "pell-equation-oq-03",
+  "title": "Pell's Equation and Polynomial Time: The Operations-vs-Output-Size Obstruction",
+  "slug": "pell-equation-oq-03",
+  "description": "The open question 'can Pell's equation be solved in classical polynomial time (in log D)?' cannot be stated inside Lean — Mathlib has no bit-complexity model, no TIME(f), no class P. This entry instead formalizes, axiom-free, the concrete growth phenomenon that makes every 'compose the solutions' method sub-exponential. Two facts stand in tension. (A) Reachability is cheap: k applications of the doubling map a ↦ a·a compute the 2^k-th power of a Pell solution (iterate_double_eq_pow) — an exponentially-indexed solution reached in a LINEAR number k of group operations, the correctness of repeated squaring / fast exponentiation. (B) The output is huge: starting from a seed with x ≥ 2, the x-coordinate after k doublings satisfies 2^(2^k) ≤ x_{2^k} (x_iterate_double_ge), so its bit-length is ≥ 2^k — EXPONENTIAL in the number k of operations. The capstone operations_vs_size packages (A) and (B): you cannot even write down the reached solution in time polynomial in the number of ring multiplications. Supporting results give the explicit Brahmagupta doubling formulas x₂ₙ = 2xₙ²−1, y₂ₙ = 2xₙyₙ, the index-addition (composition) laws x_{m+n} = xₘxₙ + D yₘyₙ / y_{m+n} = xₘyₙ + yₘxₙ that drive binary exponentiation, and a concrete D=2 instance reproducing the classical chain (3,2) → (17,12) → (577,408).",
+  "meta": {
+    "author": "Lean Genius (operations-vs-output-size formulation of the Pell polynomial-time obstruction, doubling map on Solution₁); classical algorithmic number theory (Lenstra, Hallgren)",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ03.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "pell-equation",
+      "computational-complexity",
+      "polynomial-time",
+      "fast-exponentiation",
+      "repeated-squaring",
+      "brahmagupta",
+      "exponential-growth",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-01",
+    "lineCount": 189,
+    "originalContributions": [
+      "operations_vs_size : THE HEADLINE — starting from a Pell solution with x ≥ 2, performing k doubling operations produces exactly the 2^k-th power whose x-coordinate is ≥ 2^(2^k); the number of arithmetic operations is k yet the output size is exponential in k. This is the concrete obstruction that makes 'generate the solutions' algorithms sub-exponential and underlies the open question of classical polynomial-time solvability.",
+      "iterate_double_eq_pow : repeated-squaring correctness — iterating the doubling map a ↦ a·a exactly k times yields the 2^k-th power a^(2^k). The (A) side: exponentially-indexed solutions are reachable in a linear number of group operations.",
+      "x_iterate_double_ge : the doubly-exponential lower bound 2^(2^k) ≤ x_{2^k} on the reached coordinate (seed x ≥ 2), proved by induction using x₂ₙ = 2xₙ²−1. The (B) side: the output has ≥ 2^k bits.",
+      "x_double / y_double : the explicit Brahmagupta doubling formulas x₂ₙ = 2xₙ²−1 (eliminating D yₙ² via the Pell relation) and y₂ₙ = 2xₙyₙ — the coordinate action of the squaring step.",
+      "x_pow_add / y_pow_add : the index-addition (Brahmagupta composition) laws x_{m+n} = xₘxₙ + D yₘyₙ and y_{m+n} = xₘyₙ + yₘxₙ, the combine step of binary exponentiation, read off from a^(m+n) = a^m·a^n and Solution₁.x_mul / y_mul.",
+      "x_double_ge : one doubling at least squares the x-coordinate, xₙ² ≤ x₂ₙ, the inductive engine of the exponential lower bound.",
+      "double_sol2 / double_double_sol2 : the concrete D = 2 chain (3,2) → (17,12) → (577,408) (the 4-th power sol2^(2²)), each step roughly doubling the digit count — an explicit witness of the operations-vs-size gap."
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Built only on Mathlib's Pell.Solution₁ CommGroup API (Solution₁.x_mul, y_mul, prop, x_mk, y_mk) and standard ordered-ring lemmas (pow_le_pow_left₀, pow_mul, pow_succ). The concrete instance uses norm_num on integer values, not native_decide. The complexity-class statement itself (existence of a poly(log D)-time classical algorithm) is NOT formalized — Mathlib has no bit-complexity model — and remains OPEN; this entry formalizes the underlying growth mathematics only.",
+    "theoremCount": 13,
+    "definitionCount": 2
+  },
+  "crossReferences": [
+    {
+      "targetId": "pell-equation-oq-01",
+      "relationship": "extends",
+      "description": "The oq-01 sibling defines the Pell regulator R(D) = log(x₁ + y₁√D) and states the polynomial-time question (PellPolynomialTime) and the size heuristic R(D) = O(√D log D) as Props. This entry supplies the elementary, verified counterpart on the algorithmic side: the coordinate itself grows doubly-exponentially in the number of squaring operations, so R(a^(2^k)) = 2^k · R(a) — the regulator (a log) is linear in k while the coordinate is exponential in k."
+    },
+    {
+      "targetId": "pell-equation-oq-02",
+      "relationship": "extends",
+      "description": "The oq-02 sibling proves the lower bound x² ≥ D + 1 on the size of the fundamental solution. This entry is about the size of the HIGH powers rather than the fundamental one: x_{2^k} ≥ 2^(2^k), the exponential blow-up under iteration that the fundamental-solution bound seeds."
+    },
+    {
+      "targetId": "pell-equation-oq-07",
+      "relationship": "related",
+      "description": "The oq-07 sibling gives the Cayley–Hamilton linear recurrence uₙ₊₂ = 2x₁·uₙ₊₁ − uₙ for the coordinate sequences — the additive step from one solution to the NEXT. This entry uses the multiplicative doubling step instead (index n ↦ 2n), the operation that makes repeated squaring reach index 2^k in k steps rather than 2^k steps."
+    },
+    {
+      "targetId": "pell-equation-oq-01-oq-04",
+      "relationship": "related",
+      "description": "The oq-01-oq-04 lineage develops the regulator as a homomorphism with R(a^n) = n·R(a) (regulator additivity). This entry is the complexity-facing shadow of that additivity: because R is a logarithm, R(a^(2^k)) = 2^k·R(a) grows linearly in k while the coordinate x_{2^k} = exp(R) grows exponentially, which is exactly why writing the solution down is expensive."
+    },
+    {
+      "targetId": "pell-equation",
+      "relationship": "related",
+      "description": "The classical Pell equation x² − Dy² = 1, modeled in Mathlib by Pell.Solution₁ as a multiplicative group generated by the fundamental solution. The doubling map studied here is squaring in that group, and the chain (3,2) → (17,12) → (577,408) is the powers of the fundamental solution for D = 2."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Solving Pell's equation means finding the fundamental solution of x² − Dy² = 1 for a non-square D. Lagrange's continued-fraction algorithm always works but is exponential in log D in the worst case, because the fundamental solution can itself be exponentially large (Fermat's D = 61 has x₁ = 1766319049). Lenstra (1980) and Buchmann–Williams gave sub-exponential L_D(1/2) classical algorithms via regulator/class-group computation, and Hallgren (2002) gave a quantum polynomial-time algorithm by reducing to period finding. Whether a classical polynomial-time (in log D) algorithm exists is OPEN and widely believed to be at least as hard as integer factoring; Pell is a canonical example of a problem thought to lie in BQP but not P. The obstruction to naive approaches is elementary: the solutions grow so fast that they cannot be written down in polynomial time. This entry formalizes exactly that elementary obstruction.",
+    "problemStatement": "Can Pell's equation be solved in polynomial time in log D on a classical deterministic machine? The literal question is not expressible in Lean (no bit-complexity model, no class P). The formalizable core is the growth obstruction behind it: how does the cost of REACHING the n-th Pell solution (number of ring operations) compare to the SIZE of that solution (bit-length)? Concretely, can an algorithm that composes known solutions ever produce its output in time polynomial in the number of arithmetic operations it performs?",
+    "proofStrategy": "Work in Mathlib's multiplicative group Solution₁ d of solutions to x² − dy² = 1. Define the doubling map pellDouble a = a·a (= a²) and prove the coordinate formulas x_double: x₂ₙ = 2xₙ²−1 (using the Pell relation xₙ²−dyₙ²=1 to eliminate d yₙ²) and y_double: y₂ₙ = 2xₙyₙ. Prove iterate_double_eq_pow by induction: (pellDouble)^[k] a = a^(2^k), so k doublings reach index 2^k (repeated squaring). For the size lower bound x_iterate_double_ge, induct on k: from x₂ₙ = 2xₙ²−1 ≥ xₙ² and the hypothesis 2^(2^k) ≤ xₙ, get 2^(2^(k+1)) = (2^(2^k))² ≤ xₙ² ≤ x₂ₙ. Combine both in operations_vs_size. Add the index-addition laws x_pow_add / y_pow_add (the binary-exponentiation combine step) from a^(m+n) = a^m·a^n and Solution₁.x_mul / y_mul, and a concrete D = 2 instance chaining the doubling formulas.",
+    "keyInsights": [
+      "The crux of Pell's algorithmic hardness is a mismatch of two rates. Number of operations to reach the 2^k-th solution by repeated squaring: k (linear). Bit-size of that solution: ≥ 2^k (exponential). So the output cannot be written in time polynomial in the operation count — 'compose the solutions' algorithms are intrinsically sub-exponential in the worst case.",
+      "Repeated squaring is provably correct on the Pell group: (pellDouble)^[k] a = a^(2^k). This is the same addition-chain principle that makes modular exponentiation fast; here it makes exponentially-indexed solutions cheap to REACH even though they are expensive to WRITE.",
+      "The doubling formula x₂ₙ = 2xₙ²−1 is what forces the doubly-exponential blow-up: each squaring at least squares the coordinate (once x ≥ 1), so k squarings from a seed x ≥ 2 give x ≥ 2^(2^k). The '−1' and the elimination of D yₙ² both come straight from the defining Pell relation.",
+      "The regulator reconciles the two rates: R = log(x + y√D) turns the multiplicative doubling into addition, R(a^(2^k)) = 2^k·R(a), which is linear in k — matching the operation count. The coordinate x = exp(R) is then exponential in k. The whole difficulty of classical Pell is packing the exponential-size regulator into a poly-size representation, which this entry makes concrete on the coordinate side.",
+      "None of this proves the open question either way: it isolates the obstruction to the naive family of algorithms without formalizing a complexity class. The sub-exponential and quantum-polynomial algorithms sidestep the obstruction by working with the regulator (a log-size object) rather than the coordinates."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Research Context",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Frames the open question (classical polynomial-time solvability of Pell), explains why it is not literally expressible in Lean (no bit-complexity model), and states what is formalized instead: the operations-vs-output-size growth obstruction, axiom-free.",
+      "mathContext": "Reaching the $2^k$-th solution costs $k$ operations; its size is $\\geq 2^{2^k}$ bits."
+    },
+    {
+      "id": "doubling",
+      "title": "The Doubling (Squaring) Map",
+      "startLine": 63,
+      "endLine": 87,
+      "summary": "Defines pellDouble a = a·a on Solution₁ d, identifies it with a², and proves the Brahmagupta doubling formulas x_double (x₂ₙ = 2xₙ²−1, via the Pell relation) and y_double (y₂ₙ = 2xₙyₙ).",
+      "mathContext": "$x_{2n}=2x_n^2-1$, $y_{2n}=2x_ny_n$, from $x_n^2-dy_n^2=1$."
+    },
+    {
+      "id": "repeated-squaring",
+      "title": "Repeated Squaring Computes High Powers",
+      "startLine": 88,
+      "endLine": 103,
+      "summary": "iterate_double_eq_pow: iterating the doubling map k times yields the 2^k-th power, (pellDouble)^[k] a = a^(2^k) — the correctness of fast exponentiation, so 2^k-indexed solutions are reachable in k operations.",
+      "mathContext": "$(\\mathrm{double})^{[k]}(a)=a^{2^k}$: $k$ squarings reach index $2^k$."
+    },
+    {
+      "id": "addition-laws",
+      "title": "The Index-Addition (Brahmagupta Composition) Laws",
+      "startLine": 104,
+      "endLine": 120,
+      "summary": "x_pow_add and y_pow_add: the composition laws x_{m+n} = xₘxₙ + D yₘyₙ and y_{m+n} = xₘyₙ + yₘxₙ, the combine step of binary exponentiation, from a^(m+n) = a^m·a^n and Solution₁.x_mul / y_mul.",
+      "mathContext": "$x_{m+n}=x_mx_n+Dy_my_n$, $y_{m+n}=x_my_n+y_mx_n$."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Exponential Lower Bound on the Reached Coordinate",
+      "startLine": 121,
+      "endLine": 150,
+      "summary": "x_double_ge (xₙ² ≤ x₂ₙ for x ≥ 1) and the doubly-exponential lower bound x_iterate_double_ge: 2^(2^k) ≤ x_{2^k} for a seed with x ≥ 2, so the 2^k-th solution has bit-length ≥ 2^k.",
+      "mathContext": "$2^{2^k}\\leq x_{2^k}$: output size exponential in the operation count $k$."
+    },
+    {
+      "id": "capstone",
+      "title": "Capstone: Operations versus Output Size",
+      "startLine": 151,
+      "endLine": 164,
+      "summary": "operations_vs_size: k doublings produce exactly a^(2^k) (part A) whose x-coordinate is ≥ 2^(2^k) (part B) — the reached solution cannot be written in time polynomial in the number of ring operations.",
+      "mathContext": "$k$ operations $\\Rightarrow$ output $\\geq 2^{2^k}$: the polynomial-time obstruction."
+    },
+    {
+      "id": "concrete",
+      "title": "A Concrete Instance (D = 2)",
+      "startLine": 165,
+      "endLine": 189,
+      "summary": "The fundamental solution sol2 = (3,2) of x² − 2y² = 1 and the doubling chain (3,2) → (17,12) → (577,408) (the 4-th power), each step roughly doubling the digit count — an explicit witness of the operations-vs-size gap.",
+      "mathContext": "$(3,2)\\to(17,12)\\to(577,408)$: $\\mathtt{sol2}^{2^2}$ in two squarings."
+    }
+  ],
+  "conclusion": {
+    "summary": "Because the open question — is Pell solvable in classical polynomial time in log D? — has no Lean-expressible form (Mathlib lacks a bit-complexity model, TIME(f), and the class P), this entry formalizes the elementary growth obstruction that underlies it. In Mathlib's Pell solution group it defines the doubling map a ↦ a·a, proves the Brahmagupta doubling formulas x₂ₙ = 2xₙ²−1 and y₂ₙ = 2xₙyₙ, shows that k iterations of doubling compute the 2^k-th power (repeated-squaring correctness), and proves the doubly-exponential lower bound 2^(2^k) ≤ x_{2^k} on the reached coordinate. The capstone operations_vs_size combines these: reaching the 2^k-th solution costs k operations but yields an output of ≥ 2^k bits. All results are sorry-free and axiom-free (no native_decide).",
+    "implications": "The entry pinpoints, in verified Lean, why the naive family of Pell algorithms is sub-exponential: the map from operation count to output size is exponential, so the answer cannot even be written down in polynomial time. This is the classical explanation for why efficient methods (Lenstra's sub-exponential algorithm, Hallgren's quantum algorithm) must work with the regulator R = log(x + y√D) — a logarithmic-size proxy — rather than the coordinates themselves; the regulator turns the doubling into addition, R(a^(2^k)) = 2^k·R(a), which is only linear in k. It complements the regulator lineage (oq-01, oq-01-oq-04) on the coordinate side and the recurrence siblings (oq-07) by using the multiplicative (index-doubling) step rather than the additive (next-solution) one.",
+    "openQuestions": [
+      "The headline complexity question is untouched: does a deterministic classical algorithm output a compact representation of the fundamental Pell solution in time poly(log D)? This is genuinely OPEN and believed at least as hard as factoring.",
+      "Can the addition-chain cost be formalized as a genuine complexity bound — e.g. defining a cost model on Solution₁ operations and proving that a^n is computable in O(log n) multiplications (binary exponentiation), using x_pow_add / y_pow_add as the combine step?",
+      "Can the regulator lineage be connected to this coordinate bound to prove R(a^(2^k)) = 2^k·R(a) and x_{2^k} = exp(R(a^(2^k))), making the log-vs-exponential reconciliation explicit and verified?",
+      "Would formalizing even a toy bit-complexity model (e.g. Mathlib's TuringMachine with a step counter) suffice to state and prove that continued-fraction Pell solving is sub-exponential, giving a first Lean statement of an algorithmic complexity bound in number theory?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "H. W. Lenstra Jr.",
+      "title": "Solving the Pell Equation",
+      "year": 2002,
+      "venue": "Notices of the AMS 49(2), 182–192",
+      "note": "Survey of algorithmic Pell: continued fractions, the regulator, sub-exponential and quantum algorithms, and the compact-representation issue central to this entry."
+    },
+    {
+      "authors": "S. Hallgren",
+      "title": "Polynomial-time quantum algorithms for Pell's equation and the principal ideal problem",
+      "year": 2007,
+      "venue": "Journal of the ACM 54(1)",
+      "note": "Proves Pell ∈ BQP by reducing to period finding; the quantum algorithm sidesteps the coordinate blow-up by computing the regulator."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides the Pell.Solution₁ CommGroup (x_mul, y_mul, prop, x_mk, y_mk) on which the doubling map and all growth bounds are built."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry for **`pell-equation-oq-03`** — *Can Pell equations be solved in polynomial time?*

The literal open question is **not expressible in Lean** (Mathlib has no bit-complexity model, no `TIME(f)`, no class `P`). Instead this entry formalizes — fully verified, axiom-free — the concrete growth obstruction that makes every "compose the known solutions" algorithm sub-exponential.

Two facts in tension, both proved in Mathlib's `Solution₁ d` group:

- **(A) Reaching is cheap.** `iterate_double_eq_pow`: `k` applications of the doubling map `a ↦ a·a` compute the `2^k`-th power — an exponentially-indexed solution reached in a **linear** number `k` of group operations (repeated squaring / fast exponentiation).
- **(B) The output is huge.** `x_iterate_double_ge`: from a seed with `x ≥ 2`, the `x`-coordinate after `k` doublings satisfies `2^(2^k) ≤ x_{2^k}`, so its bit-length is `≥ 2^k` — **exponential** in the number of operations.

**Capstone** `operations_vs_size` packages both: `k` operations produce exactly `a^(2^k)`, whose coordinate is `≥ 2^(2^k)`. You cannot even *write down* the reached solution in time polynomial in the number of ring multiplications — the classical explanation for why efficient methods (Lenstra sub-exponential, Hallgren quantum) work with the log-size **regulator** instead of the coordinates.

## Contents (`proofs/Proofs/PellEquationOQ03.lean`, 189 lines, 13 thm / 2 def)

- `pellDouble`, `x_double` (`x₂ₙ = 2xₙ²−1`, via the Pell relation), `y_double` (`y₂ₙ = 2xₙyₙ`)
- `iterate_double_eq_pow`, `x_double_ge`, `x_iterate_double_ge`, `operations_vs_size`
- `x_pow_add` / `y_pow_add`: Brahmagupta index-addition (composition) laws — the binary-exponentiation combine step
- Concrete `D = 2` chain `(3,2) → (17,12) → (577,408)` (`sol2`, `double_sol2`, `double_double_sol2`)

## Verification

- **Docker build succeeds** (`✔ Built Proofs.PellEquationOQ03`).
- **0 axioms, 0 sorries, no `native_decide`** — only `Solution₁` CommGroup API + standard ordered-ring lemmas, `linear_combination`/`nlinarith`/`omega`/`norm_num`/`positivity`. `status: verified`, `badge: verified`, `axiomCount: 0`.
- The complexity-class statement itself remains **OPEN**; this entry formalizes the underlying growth mathematics only, and states the open direction in `openQuestions`.

Distinct from the regulator lineage (`oq-01`, `oq-01-oq-04`) and the additive recurrence sibling (`oq-07`): those describe the analytic/algebraic structure; this isolates the *algorithmic* index-doubling step and the operations-vs-size gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)