### PR TITLE
Enrich Uniform Osculator Function for Truncation Divisibility

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-01-oq-02/meta.json
@@ -59,5 +59,165 @@
     "theoremCount": 6,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Builds on the parent's truncation_pos (also 0-axiom).",
     "mathlib_version": "4.26.0"
-  }
+  },
+  "overview": {
+    "historicalContext": "Osculator divisibility tests — multiply the last digit by a fixed constant and add it to the truncated number — were systematized by V. Ramaswami Aiyar in 1907 and popularized for a general audience by Martin Gardner in Scientific American (1962). Classically, each divisor comes with its own memorized osculator: 5 for 7, 4 for 13, 2 for 19, and so on. Textbooks and recreational columns present these as a table of magic numbers to be looked up. But the osculator of $d$ is nothing mysterious: it is the multiplicative inverse of $10$ modulo $d$, which exists precisely when $\\gcd(10, d) = 1$ and is produced constructively by the extended Euclidean algorithm through Bezout's identity $10s + dt = 1$. The parent formalization (divisibility-truncation-general) captured the parametric theorems but still required a human to supply the constant $c$ and a proof that $d \\mid 10c \\pm 1$ for each individual divisor, reproducing the classical table by hand. This entry closes the loop: it replaces the lookup table with the algorithm that generates it, defining $\\mathrm{osculator}(d) = \\mathtt{Int.gcdA}\\,10\\,d$ and proving that this single computable function is a correct osculator for every $d$ coprime to $10$ at once.",
+    "problemStatement": "The parent OQ instantiates the parametric truncation theorems by hand for each divisor coprime to 10 (7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, ...), supplying both the osculator constant $c$ and a witness for $d \\mid 10c \\pm 1$ each time.\n\n**Question: can the osculator be computed once, uniformly, so that no per-divisor constant is ever supplied?**\n\n**Answer: YES.** Define $\\mathrm{osculator}(d) := \\mathtt{Int.gcdA}\\,10\\,d$, a Bezout coefficient of 10 modulo d. Then for every $d$ coprime to 10, $d \\mid 10\\cdot\\mathrm{osculator}(d) - 1$, and the truncation rule\n\n  d | n  <->  d | (n/10 + osculator(d) * (n%10))\n\nholds with the osculator computed from d. The sole side goal at a concrete divisor is `IsCoprime (d:Z) 10`, which is decidable.",
+    "text": "A 145-line entry (1 definition, 6 theorems, 0 axioms, 0 sorries) that turns the classical osculator lookup table into a single computable function. Where the parent (divisibility-truncation-general) proves parametric rules and the sibling (divisibility-truncation-general-oq-01) merges the positive and negative cases into a signed constant, this file supplies the osculator itself. The definition $\\mathrm{osculator}(d) = \\mathtt{Int.gcdA}\\,10\\,d$ is total and computable for all $d$; the correctness lemma `osculator_spec` proves $d \\mid 10\\cdot\\mathrm{osculator}(d) - 1$ for every $d$ coprime to 10, extracting the witness directly from Bezout's identity ($\\gcd(10,d) = 10\\,\\mathtt{gcdA} + d\\,\\mathtt{gcdB} = 1$) rather than from a supplied constant. Feeding this into the parent's `truncation_pos` yields `truncation_uniform`, one rule for all divisors coprime to 10. The parent's six hand-crafted extension primes (23, 29, 31, 37, 41, 43) then collapse to six evaluations of a single theorem, each closed by `by decide` on the coprimality side goal.",
+    "proofStrategy": "The argument is a three-step reduction from 'supply a constant' to 'compute a constant':\n\n1. **Define** $\\mathrm{osculator}(d) = \\mathtt{Int.gcdA}\\,10\\,d$. This is total — no coprimality hypothesis is needed to write it down — so it is a genuine computable function of $d$.\n\n2. **Prove correctness once** (`osculator_spec`). Start from Bezout's identity `Int.gcd_eq_gcd_ab`: $\\gcd(10,d) = 10\\,\\mathtt{gcdA}\\,10\\,d + d\\,\\mathtt{gcdB}\\,10\\,d$. Coprimality collapses the left side to 1 via `Int.isCoprime_iff_gcd_eq_one` (after `Int.gcd_comm`). Rearranging gives $10\\cdot\\mathrm{osculator}(d) - 1 = d \\cdot (-\\mathtt{gcdB}\\,10\\,d)$, so $-\\mathtt{gcdB}\\,10\\,d$ is an explicit divisibility witness; `linear_combination -hbez` closes it.\n\n3. **Instantiate uniformly** (`truncation_uniform`). This is a one-line application of the parent's `truncation_pos` with $c := \\mathrm{osculator}(d)$ and the osculator hypothesis supplied by `osculator_spec`. Every concrete divisor now reduces to discharging `IsCoprime (d:Z) 10` by `decide`.",
+    "keyInsights": [
+      "The osculator of d is exactly the multiplicative inverse of 10 mod d, so 'supplying a magic constant' and 'running the extended Euclidean algorithm' are the same operation — this file makes Lean run the algorithm.",
+      "Int.gcdA 10 d is a total computable function: it is defined for every d without any coprimality hypothesis, which is what lets a single definition serve all divisors.",
+      "Correctness is proved once for all d coprime to 10, converting a fact previously discharged by a per-divisor supplied witness into one derived from the structure of Bezout's identity.",
+      "The divisibility witness for d | 10*osculator(d) - 1 is not guessed but read off Bezout: it is -gcdB 10 d, the second Bezout coefficient.",
+      "Because the osculator is computed, the only remaining obstacle at a concrete divisor is decidable coprimality (`by decide`) — no norm_num arithmetic on a hand-chosen constant.",
+      "The parent's hand-written six-prime extension (23, 29, 31, 37, 41, 43) is subsumed: it becomes six evaluations of one theorem, demonstrating that the coverage was never really about those specific primes.",
+      "The rule applies to divisors sharing no factor with 10; multiples of 2 or 5 are exactly the divisors for which gcd(10,d) != 1 and the inverse (hence the osculator) fails to exist."
+    ],
+    "prerequisites": [
+      "Bezout's identity over the integers: $\\gcd(a,b) = a\\,s + b\\,t$ for computable coefficients $s = \\mathtt{gcdA}$, $t = \\mathtt{gcdB}$",
+      "Modular multiplicative inverses: $10c \\equiv 1 \\pmod d$ has a solution iff $\\gcd(10,d) = 1$",
+      "Coprimality in Lean: the equivalence `IsCoprime (a:Z) b <-> Int.gcd a b = 1`",
+      "The parent truncation framework: the parametric `truncation_pos` theorem this file instantiates",
+      "Division algorithm and digit extraction: $n = 10\\lfloor n/10\\rfloor + (n \\bmod 10)$"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Motivation: From Supplied Constants to a Computed Osculator",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "The header docstring frames the upgrade over the parent: the parent's truncation_pos/truncation_neg require a human to supply the osculator c and a witness d | 10c +/- 1 for each divisor. This file defines a single computable osculator and proves it correct once. Imports the parent framework (Proofs.DivisibilityTruncationGeneral) and Mathlib.Tactic; opens the DivisibilityTruncationGeneral namespace.",
+      "mathContext": "Goal: replace the per-divisor pair (constant $c$, witness $d \\mid 10c \\pm 1$) with one function $\\mathrm{osculator}(d)$ and one correctness proof valid for all $d$ coprime to 10."
+    },
+    {
+      "id": "osculator-def",
+      "title": "The Computable Osculator",
+      "startLine": 41,
+      "endLine": 50,
+      "summary": "Defines osculator(d) := Int.gcdA 10 (d : Z), the first Bezout coefficient of 10 and d. It is total: no coprimality hypothesis is needed to define it, only to prove it behaves as an inverse. For d coprime to 10 it is an inverse of 10 mod d.",
+      "mathContext": "$\\mathrm{osculator}(d) := \\mathtt{Int.gcdA}\\,10\\,d$. When $\\gcd(10,d)=1$ this represents $10^{-1} \\bmod d$; for other $d$ it is still well-defined but the truncation rule need not apply."
+    },
+    {
+      "id": "osculator-spec",
+      "title": "Correctness of the Osculator from Bezout's Identity",
+      "startLine": 52,
+      "endLine": 70,
+      "summary": "osculator_spec proves d | 10*osculator(d) - 1 for every d coprime to 10 — exactly the hypothesis truncation_pos needs. Uses Int.gcd_eq_gcd_ab (Bezout), collapses gcd(10,d) to 1 via Int.gcd_comm and Int.isCoprime_iff_gcd_eq_one, exhibits -gcdB 10 d as the divisibility witness, and closes with linear_combination -hbez after push_cast.",
+      "mathContext": "$\\gcd(10,d)=1 \\Rightarrow 1 = 10\\,\\mathrm{osculator}(d) + d\\,\\mathtt{gcdB}\\,10\\,d$, so $10\\,\\mathrm{osculator}(d) - 1 = d\\,(-\\mathtt{gcdB}\\,10\\,d)$ and $d \\mid 10\\,\\mathrm{osculator}(d) - 1$."
+    },
+    {
+      "id": "truncation-uniform",
+      "title": "The Uniform Truncation Rule",
+      "startLine": 72,
+      "endLine": 85,
+      "summary": "truncation_uniform combines the parent's truncation_pos with osculator_spec to obtain, for every d coprime to 10, d | n <-> d | (n/10 + osculator(d)*(n%10)). The osculator is no longer an input — it is computed from d. The only hypothesis is IsCoprime (d:Z) 10, decidable at any concrete numeral.",
+      "mathContext": "Instantiates the parametric positive-osculator rule at $c = \\mathrm{osculator}(d)$, with the osculator relation supplied by `osculator_spec`: $d \\mid n \\iff d \\mid (\\lfloor n/10\\rfloor + \\mathrm{osculator}(d)\\cdot(n \\bmod 10))$."
+    },
+    {
+      "id": "coverage",
+      "title": "Coverage With Zero Supplied Constants",
+      "startLine": 87,
+      "endLine": 126,
+      "summary": "seven_uniform, thirteen_uniform, nineteen_uniform, and the bundling theorem extended_coverage_uniform recover the parent OQ's target primes (23, 29, 31, 37, 41, 43) — and any divisor coprime to 10 — as one-line instances of truncation_uniform. The sole side goal in each is IsCoprime (d:Z) 10, closed by decide. Contrast the parent's extended_truncation_coverage, where each prime needed a hand-computed constant and a divisibility witness.",
+      "mathContext": "Each prime $p \\in \\{7,13,19,23,29,31,37,41,43\\}$: `truncation_uniform p n (by decide)`; the osculator constant is computed, not supplied."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Sanity Checks on Concrete Numbers",
+      "startLine": 128,
+      "endLine": 145,
+      "summary": "Two example theorems confirm the end-to-end computation on 7 | 91 and 13 | 169, applying seven_uniform 91 and thirteen_uniform 169. Whatever value the computed osculator takes, truncation_uniform guarantees the equivalence, and these examples confirm the reduction is sound.",
+      "mathContext": "$7 \\mid 91 \\iff 7 \\mid (9 + \\mathrm{osculator}(7)\\cdot 1)$ and $13 \\mid 169 \\iff 13 \\mid (16 + \\mathrm{osculator}(13)\\cdot 9)$, both instances of the uniform rule."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "divisibility-truncation-general",
+      "relationship": "extends",
+      "description": "Grandparent framework: provides the parametric truncation_pos theorem. This file supplies the osculator argument automatically via osculator_spec, so every hand-crafted instance in the parent's extended_truncation_coverage becomes a one-line evaluation of truncation_uniform"
+    },
+    {
+      "targetId": "divisibility-truncation-general-oq-01",
+      "relationship": "related",
+      "description": "Sibling extension that unifies the positive and negative osculator theorems into a single signed constant c in Z. This file is orthogonal: instead of unifying the two cases, it computes the (positive) osculator from d, so the two extensions compose — one could compute the signed osculator uniformly"
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "foundational",
+      "description": "Bezout's identity 10s + dt = gcd(10,d) is the engine of the whole entry: when gcd(10,d)=1 it yields 10s + dt = 1, so s = gcdA 10 d = osculator(d) is the inverse of 10 mod d and -t = -gcdB 10 d is the explicit divisibility witness used in osculator_spec"
+    },
+    {
+      "targetId": "divisibility-by-three-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Companion divisibility entry (digital-root approach to divisibility by three). Distinct slug and proof technique: that entry iterates the digit-sum rule, whereas this one computes a general single-step osculator; together they illustrate two formalization styles for base-10 divisibility tests"
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient counts invertible residues mod d. The osculator is the inverse of 10 in (Z/dZ)*, which exists iff gcd(10,d)=1 — the same coprimality condition, with Euler's theorem 10^{phi(d)} = 1 (mod d) giving an alternative (non-constructive) route to the same inverse"
+    },
+    {
+      "targetId": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "For composite d = d1*d2 with coprime factors, CRT reconstructs the osculator of d from those of d1 and d2, an alternative to computing gcdA 10 d directly; both routes produce the same inverse of 10 mod d"
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique factorization underlies the coprimality condition gcd(10,d)=1: divisors sharing a factor with 10 (multiples of 2 or 5) are exactly those for which no osculator exists, delimiting the scope of the uniform rule"
+    }
+  ],
+  "conclusion": {
+    "summary": "The classical per-divisor osculator table is replaced by a single computable function osculator(d) = Int.gcdA 10 d, proved correct once for all d coprime to 10. The truncation test becomes uniform: d | n <-> d | (n/10 + osculator(d)*(n%10)), with the osculator computed from d and the only side goal at a concrete divisor being decidable coprimality. The parent OQ's six hand-crafted extension primes (23, 29, 31, 37, 41, 43) are recovered as six evaluations of one theorem, each closed by `by decide`.",
+    "implications": "This computation-over-lookup upgrade:\n- **Eliminates hand-work**: no osculator constant and no divisibility witness are ever supplied per divisor; the extended Euclidean algorithm produces both.\n- **Isolates the real obligation**: the sole remaining side goal is decidable coprimality, not arithmetic on a chosen constant.\n- **Reveals the structure**: the parent's coverage was never about specific primes — every divisor coprime to 10 is a single instance of one rule.\n- **Composes with the sibling**: pairing this computed osculator with the signed-osculator unification (oq-01) would give a uniform rule covering both positive and negative osculators.\n- **Generalizes by base**: replacing 10 by an arbitrary base b gives the same construction, osculator_b(d) = gcdA b d, valid for all d coprime to b.",
+    "openQuestions": [
+      "Can the uniform rule be extended to divisors sharing a factor with 10 by combining the computed osculator with a last-k-digits framework for the 2- and 5-parts of d?",
+      "Does composing this computed osculator with the signed-osculator unification (divisibility-truncation-general-oq-01) yield a single uniform rule covering both the positive and negative osculator tests?",
+      "What is the relationship between osculator(d) = gcdA 10 d and the continued-fraction expansion of 1/d, and does it predict the size of the osculator?",
+      "Can multi-digit truncation (removing k digits at a time, using the inverse of 10^k mod d) be given the same uniform computable treatment?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.DivisibilityTruncationGeneral",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "DivisibilityTruncationGeneral"
+    ],
+    "namespace": "DivisibilityBy3OQ01OQ02",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/DivisibilityBy3OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Ramaswami Aiyar, V.",
+      "title": "The Osculator",
+      "year": "1907",
+      "venue": "The Journal of the Indian Mathematical Club, vol. 1",
+      "note": "Early systematic study of osculator divisibility rules, framing digit-based tests in terms of modular multiplicative inverses — the constants this entry now computes automatically"
+    },
+    {
+      "authors": "Gardner, Martin",
+      "title": "Mathematical Games: Tests for divisibility by 7 and the other digits",
+      "year": "1962",
+      "venue": "Scientific American, vol. 207, September 1962",
+      "note": "Popularized the per-divisor osculator table (5 for 7, 4 for 13, 2 for 19, ...) that this proof replaces with a single computable function osculator(d) = gcdA 10 d"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "Standard reference for the extended Euclidean algorithm and Bezout's identity, which produce the osculator as the Bezout coefficient gcdA 10 d, and for modular multiplicative inverses"
+    }
+  ],
+  "sorries": 0
 }


### PR DESCRIPTION
## Enrichment pass — divisibility-by-3-oq-01-oq-02

This freshly-merged research entry (`divisibility-by-3-oq-01-oq-02`, quality 55, 0 passes) had a **bare meta.json** (3 KB): a research `meta` block and description, but no `overview`, `sections`, `conclusion`, `crossReferences`, `references`, or `leanFile`. Its 5 annotations were already strong and were left untouched.

### Added
- **`overview`**: `historicalContext` (Ramaswami Aiyar 1907, Gardner 1962, osculator = 10⁻¹ mod d), `problemStatement`, `text`, three-step `proofStrategy`, **7 `keyInsights`**, and `prerequisites`.
- **`sections`**: 6 sections mapped to the 145-line Lean file (header, osculator def, osculator_spec, truncation_uniform, coverage, sanity checks) with per-section `mathContext`.
- **`crossReferences`**: 7 links (parent `divisibility-truncation-general` *extends*; sibling `-oq-01`; `bezout-identity`, `euler-totient`, `chinese-remainder-constructive`, `fundamental-arithmetic`, companion `divisibility-by-three-oq-01-oq-02`) — all verified to exist in the gallery.
- **`conclusion`**: `summary`, `implications`, 4 `openQuestions`.
- **`leanFile`** block and 3 **`references`**.

### Size / guardrails
- meta.json: 3.1 KB → **19.9 KB**, well under the 60 KB cap (`check-meta-size.ts`: within caps). In line with sibling entries (~12–15 KB).
- keyInsights 7 (≤12), crossReferences 7 (≤20), references 3 (≤25), openQuestions 4 (≤15).
- No existing content deleted; annotations unchanged.

Verified with `pnpm build` (clean). Math-agent PR — no `loom:review-requested`.