### PR TITLE
research(fermat-two-squares-oq-08): prime-factorization criterion for sums of two squares [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FermatTwoSquaresOQ08.lean
+++ b/proofs/Proofs/FermatTwoSquaresOQ08.lean
@@ -1,0 +1,155 @@
+/-
+  Sum of Two Squares for All Naturals — the Prime-Factorization Criterion
+  Open Question: fermat-two-squares-oq-08
+
+  The parent entry `fermat-two-squares` and sibling `fermat-two-squares-oq-05`
+  characterize which PRIMES are sums of two squares (p = x² + y² ⟺ p ≢ 3 mod 4).
+  This file promotes that prime-only statement to the full multiplicative
+  characterization for EVERY natural number:
+
+        n = x² + y²  for some x, y ∈ ℕ
+          ⟺  every prime q ≡ 3 (mod 4) divides n to an EVEN power.
+
+  Examples: 45 = 3²·5 = 6² + 3² is representable (the 3-mod-4 prime 3 occurs to
+  the even power 2), while 21 = 3·7 is not (both 3 and 7 are ≡ 3 mod 4 with the
+  odd exponent 1).
+
+  The headline biconditional is exactly Mathlib's `Nat.eq_sq_add_sq_iff`. The
+  contribution of this file is (i) to present it as the composite/all-naturals
+  characterization the parent left open, (ii) to DERIVE the prime case back out
+  of the general criterion — showing the two statements are one theorem, not two
+  — and (iii) to exercise the criterion on concrete composite witnesses.
+
+  References:
+  - Fermat (1640): two-squares characterization for primes
+  - FermatTwoSquares.lean: parent prime characterization
+  - FermatTwoSquaresOQ05.lean: sibling mod-4 obstruction (necessity)
+  - FermatTwoSquaresOQ06.lean: sibling Brahmagupta multiplicativity identity
+-/
+
+import Mathlib.NumberTheory.SumTwoSquares
+import Mathlib.Tactic
+
+namespace FermatTwoSquaresOQ08
+
+-- ============================================================================
+-- Part I: The Headline Criterion (all naturals)
+-- ============================================================================
+
+/-- **Sum-of-two-squares criterion for every natural number.**
+
+A natural number `n` is a sum of two squares if and only if, in its prime
+factorization, every prime `q ≡ 3 (mod 4)` occurs to an even power
+`padicValNat q n`. This is the composite/all-naturals characterization that the
+parent entry states as its open question; the prime case (below) is the special
+case `n = p`.
+
+This is Mathlib's `Nat.eq_sq_add_sq_iff`; we restate it here as the headline of
+the entry and build the prime-case bridge on top of it. -/
+theorem sum_two_squares_iff_even_padicVal (n : ℕ) :
+    (∃ x y : ℕ, n = x ^ 2 + y ^ 2) ↔
+      ∀ q ∈ n.primeFactors, q % 4 = 3 → Even (padicValNat q n) :=
+  Nat.eq_sq_add_sq_iff
+
+-- ============================================================================
+-- Part II: Recovering the Prime Case from the General Criterion
+-- ============================================================================
+
+/-- **The prime case is a corollary of the general criterion.**
+
+For a prime `p`, the only prime factor is `p` itself, occurring to the power
+`padicValNat p p = 1`, which is odd. So the criterion of Part I collapses: the
+even-exponent condition can only be met by having NO prime factor `≡ 3 (mod 4)`,
+i.e. `p % 4 ≠ 3`. This reproduces Fermat's prime classification without invoking
+`Nat.Prime.sq_add_sq` — it falls straight out of the all-naturals theorem. -/
+theorem prime_sum_two_squares_iff {p : ℕ} (hp : p.Prime) :
+    (∃ x y : ℕ, p = x ^ 2 + y ^ 2) ↔ p % 4 ≠ 3 := by
+  rw [sum_two_squares_iff_even_padicVal, hp.primeFactors]
+  simp only [Finset.mem_singleton, forall_eq]
+  constructor
+  · -- If representable, the even-exponent condition forces `p % 4 ≠ 3`,
+    -- because `padicValNat p p = 1` is odd.
+    intro h hp3
+    have hev : Even (padicValNat p p) := h hp3
+    rw [padicValNat.self hp.one_lt] at hev
+    exact Nat.not_even_one hev
+  · -- Conversely, if `p % 4 ≠ 3` the hypothesis `p % 4 = 3` is vacuous.
+    intro hp4 hp3
+    exact absurd hp3 hp4
+
+/-- **Fermat's classical form for odd primes.** For an odd prime `p`, being a sum
+of two squares is equivalent to `p ≡ 1 (mod 4)`. Obtained from
+`prime_sum_two_squares_iff` by noting an odd prime has residue `1` or `3` mod 4. -/
+theorem odd_prime_sum_two_squares_iff {p : ℕ} (hp : p.Prime) (hodd : Odd p) :
+    (∃ x y : ℕ, p = x ^ 2 + y ^ 2) ↔ p % 4 = 1 := by
+  rw [prime_sum_two_squares_iff hp]
+  rcases hodd with ⟨k, hk⟩
+  omega
+
+-- ============================================================================
+-- Part III: A Divisibility Obstruction at the Prime 3
+-- ============================================================================
+-- The mod-4 obstruction (oq-05) only rules out `n ≡ 3 (mod 4)`. It says nothing
+-- about composites like `21 ≡ 1 (mod 4)` that fail the criterion because a
+-- 3-mod-4 prime divides them to an ODD power. We isolate the smallest such case
+-- (`q = 3`) with a self-contained argument: since the only squares in ZMod 3 are
+-- `{0, 1}`, a sum of two squares vanishes mod 3 only when BOTH summands do, so
+-- `3 ∣ x² + y²` forces `3 ∣ x` and `3 ∣ y`, hence `9 ∣ x² + y²`.
+
+/-- **Core fact mod 3.** In `ZMod 3`, a sum of two squares is `0` only when both
+squares are `0`. Exhaustive kernel check over the 9 pairs. -/
+theorem zmod_three_sq_add_sq_eq_zero (a b : ZMod 3) (h : a ^ 2 + b ^ 2 = 0) :
+    a = 0 ∧ b = 0 := by
+  revert a b; decide
+
+/-- **The odd-power-of-3 obstruction.** If `3 ∣ n` but `9 ∤ n` (i.e. `3` divides
+`n` to an odd power `1`), then `n` is not a sum of two squares. This is the
+instance of the general criterion for the prime `q = 3`, proved directly: a
+representation would push `3 ∣ x` and `3 ∣ y`, forcing `9 ∣ n`. -/
+theorem not_sq_add_sq_of_three_dvd_not_nine_dvd {n : ℕ} (h3 : 3 ∣ n)
+    (h9 : ¬ (9 ∣ n)) : ¬ ∃ x y : ℕ, n = x ^ 2 + y ^ 2 := by
+  rintro ⟨x, y, rfl⟩
+  apply h9
+  -- `x² + y² ≡ 0 (mod 3)`, transported to `ZMod 3`.
+  have hz : ((x ^ 2 + y ^ 2 : ℕ) : ZMod 3) = 0 :=
+    (ZMod.natCast_eq_zero_iff _ 3).mpr h3
+  push_cast at hz
+  obtain ⟨hx, hy⟩ := zmod_three_sq_add_sq_eq_zero _ _ hz
+  -- Both `x` and `y` are divisible by 3.
+  rw [ZMod.natCast_eq_zero_iff] at hx hy
+  obtain ⟨a, rfl⟩ := hx
+  obtain ⟨b, rfl⟩ := hy
+  -- Then `(3a)² + (3b)² = 9(a² + b²)`.
+  exact ⟨a ^ 2 + b ^ 2, by ring⟩
+
+-- ============================================================================
+-- Part IV: Concrete Witnesses
+-- ============================================================================
+
+/-- `45 = 3²·5` is a sum of two squares: the 3-mod-4 prime `3` occurs to the even
+power `2`. Explicit witness `45 = 6² + 3²`. -/
+theorem fortyfive_is_sq_add_sq : ∃ x y : ℕ, (45 : ℕ) = x ^ 2 + y ^ 2 :=
+  ⟨6, 3, by norm_num⟩
+
+/-- `50 = 2·5²` is a sum of two squares (no prime `≡ 3 mod 4` divides it at all):
+`50 = 5² + 5²`. -/
+theorem fifty_is_sq_add_sq : ∃ x y : ℕ, (50 : ℕ) = x ^ 2 + y ^ 2 :=
+  ⟨5, 5, by norm_num⟩
+
+/-- `21 = 3·7` is NOT a sum of two squares — even though `21 ≡ 1 (mod 4)`, so the
+mod-4 obstruction is silent. The prime `3` divides `21` to the odd power `1`. -/
+theorem twentyone_not_sq_add_sq : ¬ ∃ x y : ℕ, (21 : ℕ) = x ^ 2 + y ^ 2 :=
+  not_sq_add_sq_of_three_dvd_not_nine_dvd (by norm_num) (by norm_num)
+
+/-- `33 = 3·11` is NOT a sum of two squares: the prime `3` occurs to the odd
+power `1` (and `33 ≡ 1 (mod 4)`, so again the mod-4 test alone does not detect it). -/
+theorem thirtythree_not_sq_add_sq : ¬ ∃ x y : ℕ, (33 : ℕ) = x ^ 2 + y ^ 2 :=
+  not_sq_add_sq_of_three_dvd_not_nine_dvd (by norm_num) (by norm_num)
+
+/-- The prime `7 ≡ 3 (mod 4)` is not a sum of two squares — the prime case,
+now read off `prime_sum_two_squares_iff` rather than a bespoke obstruction. -/
+theorem seven_not_sq_add_sq : ¬ ∃ x y : ℕ, (7 : ℕ) = x ^ 2 + y ^ 2 := by
+  rw [prime_sum_two_squares_iff (by norm_num)]
+  norm_num
+
+end FermatTwoSquaresOQ08

--- a/src/data/proofs/fermat-two-squares-oq-08/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-08/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "ann-headline-criterion",
+    "proofId": "fermat-two-squares-oq-08",
+    "range": {
+      "startLine": 49,
+      "endLine": 52
+    },
+    "type": "concept",
+    "title": "The All-Naturals Criterion",
+    "content": "The headline `sum_two_squares_iff_even_padicVal` states that a natural number n is a sum of two squares iff every prime q ≡ 3 (mod 4) occurs to an even power in n. This is exactly Mathlib's `Nat.eq_sq_add_sq_iff`, so the theorem is a one-line `:= Nat.eq_sq_add_sq_iff`. The value of the entry is not this restatement but its framing (the composite promotion of the prime theorem) and the corollaries built on it below. The criterion is genuinely multiplicative: no single modulus decides representability of a general n, unlike the prime case.",
+    "mathContext": "$n = x^2+y^2 \\iff \\forall q \\in n.\\mathrm{primeFactors},\\ q \\equiv 3 \\pmod 4 \\Rightarrow 2 \\mid \\nu_q(n)$, where $\\nu_q$ is the $q$-adic valuation `padicValNat q n`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum of two squares",
+      "prime factorization",
+      "p-adic valuation",
+      "Gaussian integers norm form"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "p-adic valuation",
+      "quadratic residues"
+    ]
+  },
+  {
+    "id": "ann-prime-corollary",
+    "proofId": "fermat-two-squares-oq-08",
+    "range": {
+      "startLine": 65,
+      "endLine": 78
+    },
+    "type": "proof-technique",
+    "title": "Deriving the Prime Case from the General Criterion",
+    "content": "`prime_sum_two_squares_iff` recovers Fermat's prime classification (∃ a b, p = a²+b² ↔ p % 4 ≠ 3) as a corollary of the general criterion — NOT by re-citing Mathlib's Nat.Prime.sq_add_sq. The mechanism: `Nat.Prime.primeFactors` rewrites p.primeFactors to the singleton {p}, and `simp [Finset.mem_singleton, forall_eq]` collapses the bounded quantifier to a single implication about p. Then `padicValNat.self hp.one_lt` gives padicValNat p p = 1, and `Nat.not_even_one` refutes Even 1. So the even-exponent condition can only be met when p ≢ 3 (mod 4). The prime and composite statements are thus one theorem instantiated twice.",
+    "mathContext": "For prime $p$: $p.\\mathrm{primeFactors} = \\{p\\}$ and $\\nu_p(p) = 1$ (odd). The criterion collapses to $p \\not\\equiv 3 \\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "specialization",
+      "singleton prime factors",
+      "p-adic valuation of a prime",
+      "parity"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "Finset membership",
+      "p-adic valuation"
+    ]
+  },
+  {
+    "id": "ann-zmod-three-core",
+    "proofId": "fermat-two-squares-oq-08",
+    "range": {
+      "startLine": 99,
+      "endLine": 103
+    },
+    "type": "concept",
+    "title": "Squares Mod 3: a Sum Vanishes Only When Both Do",
+    "content": "The squares in ZMod 3 are 0²=0, 1²=1, 2²=1, i.e. {0,1}. So a²+b² ∈ {0,1,2}, and it equals 0 only when a²=0 and b²=0, forcing a=0 and b=0. The lemma `zmod_three_sq_add_sq_eq_zero` proves this by `revert a b; decide`, an exhaustive kernel check over the 9 pairs. This is the arithmetic seed of the q=3 divisibility obstruction that follows.",
+    "mathContext": "In $\\mathbb{Z}/3$, $a^2 \\in \\{0,1\\}$, so $a^2+b^2 = 0 \\Rightarrow a = b = 0$ — checked by `decide` over all $9$ pairs (kernel reduction, axiom-free).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "quadratic residues mod 3",
+      "ZMod",
+      "decide tactic"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "quadratic residues",
+      "decidability"
+    ]
+  },
+  {
+    "id": "ann-three-obstruction",
+    "proofId": "fermat-two-squares-oq-08",
+    "range": {
+      "startLine": 105,
+      "endLine": 123
+    },
+    "type": "proof-technique",
+    "title": "The q=3 Divisibility Obstruction",
+    "content": "`not_sq_add_sq_of_three_dvd_not_nine_dvd` proves that 3 ∣ n with 9 ∤ n forbids n = x²+y². From a representation, `ZMod.natCast_eq_zero_iff` turns 3 ∣ x²+y² into (x²+y² : ZMod 3) = 0; `push_cast` exposes (x)²+(y)², and the core lemma forces (x : ZMod 3) = 0 and (y : ZMod 3) = 0. Casting back gives 3 ∣ x and 3 ∣ y, so x = 3a, y = 3b and x²+y² = 9(a²+b²), i.e. 9 ∣ n — contradicting 9 ∤ n. This is the smallest concrete instance of the general criterion (the prime q=3 to an odd power), proved with no reference to padicValNat, and crucially it detects failures the mod-4 obstruction cannot.",
+    "mathContext": "$3 \\mid x^2+y^2 \\Rightarrow 3\\mid x \\wedge 3\\mid y \\Rightarrow 9 \\mid x^2+y^2$. Contrapositive: $3\\mid n,\\ 9\\nmid n \\Rightarrow n \\ne x^2+y^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "local obstruction",
+      "ZMod casts",
+      "divisibility",
+      "sum of two squares"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "ZMod casts",
+      "divisibility"
+    ]
+  },
+  {
+    "id": "ann-witnesses",
+    "proofId": "fermat-two-squares-oq-08",
+    "range": {
+      "startLine": 125,
+      "endLine": 155
+    },
+    "type": "concept",
+    "title": "Witnesses: Why 21 and 33 Fail",
+    "content": "45 = 3²·5 = 6²+3² and 50 = 2·5² = 5²+5² are representable (explicit witnesses; no 3-mod-4 prime to an odd power). By contrast 21 = 3·7 and 33 = 3·11 are NOT sums of two squares — and both are ≡ 1 (mod 4), so the sibling mod-4 obstruction (oq-05) says nothing about them. They fail solely because 3 divides them to the odd power 1, which the q=3 obstruction detects. The prime 7 ≡ 3 (mod 4) is dispatched by the derived prime criterion. These examples make concrete why the composite theory needs the full factorization criterion, not just a congruence.",
+    "mathContext": "$45 = 6^2+3^2$, $50 = 5^2+5^2$; $21 = 3\\cdot 7$ and $33 = 3\\cdot 11$ are $\\equiv 1 \\pmod 4$ yet not sums of two squares, ruled out by $3 \\parallel n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked examples",
+      "mod-4 obstruction insufficiency",
+      "sum of two squares"
+    ],
+    "prerequisites": [
+      "sum of two squares",
+      "divisibility"
+    ]
+  }
+]

--- a/src/data/proofs/fermat-two-squares-oq-08/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-08/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "fermat-two-squares-oq-08",
+  "title": "Sum of Two Squares for All Naturals: the Prime-Factorization Criterion",
+  "slug": "fermat-two-squares-oq-08",
+  "description": "The full multiplicative characterization: a natural number n is a sum of two squares iff every prime q ≡ 3 (mod 4) divides n to an even power. This promotes Fermat's prime-only theorem to every natural number, and the prime case is recovered as a one-line corollary of the general criterion.",
+  "meta": {
+    "author": "Fermat / Euler (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sum_of_two_squares_theorem",
+    "date": "1749",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "sum-of-two-squares",
+      "prime-factorization",
+      "fermat",
+      "modular-arithmetic",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FermatTwoSquaresOQ08.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.eq_sq_add_sq_iff",
+        "description": "The all-naturals biconditional: n is a sum of two squares iff every prime q ≡ 3 (mod 4) has even exponent in n",
+        "module": "Mathlib.NumberTheory.SumTwoSquares"
+      },
+      {
+        "theorem": "padicValNat.self",
+        "description": "For 1 < p, padicValNat p p = 1 — the exponent of a prime in itself is 1 (odd)",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.primeFactors",
+        "description": "A prime's set of prime factors is the singleton {p}",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod b) = 0 iff b ∣ a — the bridge between divisibility in ℕ and vanishing in ZMod b",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "sum_two_squares_iff_even_padicVal: the headline all-naturals criterion, presented as the composite/all-naturals characterization the parent entry left open (via Nat.eq_sq_add_sq_iff)",
+      "prime_sum_two_squares_iff: the prime case DERIVED from the general criterion (padicValNat p p = 1 is odd, so a 3-mod-4 prime factor is forbidden), NOT re-cited from Nat.Prime.sq_add_sq — showing the prime and composite statements are one theorem",
+      "odd_prime_sum_two_squares_iff: Fermat's classical odd-prime form p = x²+y² ↔ p ≡ 1 (mod 4), read off the derived prime criterion",
+      "zmod_three_sq_add_sq_eq_zero: in ZMod 3 a sum of two squares vanishes only when both squares do (exhaustive decide over 9 pairs)",
+      "not_sq_add_sq_of_three_dvd_not_nine_dvd: a self-contained divisibility obstruction — 3 ∣ n and 9 ∤ n implies n is not a sum of two squares — the q=3 instance of the criterion, proved without padicValNat",
+      "Concrete witnesses: 45 = 6²+3² and 50 = 5²+5² are representable; 21 = 3·7 and 33 = 3·11 are not, both ≡ 1 (mod 4) so invisible to the mod-4 obstruction alone; 7 not representable via the derived prime criterion"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 155,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms on every theorem — no sorryAx, no Lean.ofReduceBool). The headline biconditional is Mathlib's Nat.eq_sq_add_sq_iff; the prime-case derivation, the mod-3 divisibility obstruction, and the worked witnesses are original.",
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Fermat's 1640 letter to Mersenne classified which odd PRIMES are sums of two squares: exactly those with p ≡ 1 (mod 4). Euler supplied the first proof (1749). But the natural question is which arbitrary natural numbers are sums of two squares, and the answer is genuinely multiplicative rather than a single congruence: n is a sum of two squares iff, in the prime factorization of n, every prime q ≡ 3 (mod 4) occurs to an EVEN power. The 'only if' direction rests on the norm form of the Gaussian integers ℤ[i] being multiplicative (Brahmagupta–Fibonacci), together with the prime case; the 'if' direction assembles a representation from the prime pieces.\n\nThis all-naturals criterion is the composite generalization the parent gallery entry `fermat-two-squares` explicitly flagged as open. It is strictly stronger than the mod-4 obstruction (sibling oq-05): numbers like 21 = 3·7 are ≡ 1 (mod 4) yet still not sums of two squares, because a 3-mod-4 prime divides them to an odd power. The congruence test alone cannot see this; the factorization criterion can.",
+    "problemStatement": "**Open question (fermat-two-squares-oq-08)**: Promote Fermat's prime-only two-squares theorem to the full characterization for every natural number, and recover the prime case as a special case.\n\n**Result**: A fully verified (0 sorries, 0 axioms) development. The headline is\n\n  (∃ x y, n = x² + y²)  ↔  ∀ q ∈ n.primeFactors, q % 4 = 3 → Even (padicValNat q n),\n\nMathlib's `Nat.eq_sq_add_sq_iff`. From it the prime characterization ∃ a b, p = a²+b² ↔ p % 4 ≠ 3 is derived (using padicValNat p p = 1), and a self-contained q=3 divisibility obstruction (3 ∣ n, 9 ∤ n ⇒ not representable) is proved via ZMod 3 and applied to 21 and 33.",
+    "text": "A natural number n is a sum of two squares iff every prime q ≡ 3 (mod 4) in its factorization occurs to an even power. The prime case p ≡ 1 (mod 4) is the special case n = p, recovered here as a corollary of the general criterion.",
+    "proofStrategy": "**Proof Strategy:**\n\n1. **Headline (Part I)**: State the all-naturals criterion as `sum_two_squares_iff_even_padicVal`, which is exactly `Nat.eq_sq_add_sq_iff` from Mathlib.\n\n2. **Prime case from the general criterion (Part II)**: For a prime p, `Nat.Prime.primeFactors` collapses the quantifier to the single factor p, and `padicValNat.self` gives padicValNat p p = 1. Since Even 1 is false, the even-exponent condition can only hold if p ≢ 3 (mod 4). This yields ∃ a b, p = a²+b² ↔ p % 4 ≠ 3 WITHOUT citing Mathlib's Nat.Prime.sq_add_sq — the prime statement is a genuine corollary of the composite one. The odd-prime iff p ≡ 1 (mod 4) follows by `omega`.\n\n3. **A q=3 divisibility obstruction (Part III)**: The mod-4 test is silent on n ≡ 1 (mod 4). To exhibit the criterion's extra strength, prove directly that 3 ∣ n with 9 ∤ n forbids representation: in ZMod 3 the squares are {0,1}, so a²+b²=0 forces a=b=0 (decide over 9 pairs), hence 3 ∣ x and 3 ∣ y, hence 9 ∣ x²+y². Contrapositive gives the obstruction.\n\n4. **Witnesses (Part IV)**: 45 = 6²+3² and 50 = 5²+5² by explicit witness; 21 = 3·7 and 33 = 3·11 not representable via the q=3 obstruction (both ≡ 1 mod 4); 7 not representable via the derived prime criterion."
+    ,
+    "keyInsights": [
+      "**The criterion is multiplicative, not a single congruence**: Unlike the prime case, no fixed modulus decides representability of a general n. The obstruction lives prime-by-prime: each q ≡ 3 (mod 4) must appear to an even power. This is why 21 ≡ 1 (mod 4) still fails — the mod-4 test cannot detect an odd power of a 3-mod-4 prime hidden in a composite.",
+      "**The prime case is a corollary, not a companion**: Specializing the general criterion to n = p (one prime factor, exponent 1, which is odd) reproduces Fermat's prime classification directly. This file derives it that way, so the prime and composite theorems are literally one theorem instantiated twice — not two separate results glued together.",
+      "**padicValNat p p = 1 is the whole prime argument**: The exponent of a prime in itself is 1, and 1 is odd. That single fact, fed into the even-exponent criterion, is exactly what forbids a 3-mod-4 prime from being a sum of two squares. No descent, no Gaussian integers appear at the prime-specialization step.",
+      "**A local obstruction at q = 3 detects what mod 4 cannot**: The self-contained argument (squares mod 3 are {0,1}, so 3 ∣ a²+b² ⇒ 3∣a ∧ 3∣b ⇒ 9 ∣ a²+b²) is the smallest visible case of the criterion's teeth. It rules out 21 and 33 — both ≡ 1 (mod 4) — which the sibling mod-4 obstruction (oq-05) is powerless against.",
+      "**ZMod is the bridge in both directions**: `ZMod.natCast_eq_zero_iff` turns 3 ∣ m into (m : ZMod 3) = 0 and back, letting a finite `decide` over ZMod 3 carry an argument about arbitrary integers x, y."
+    ],
+    "prerequisites": [
+      "Prime factorization and p-adic valuations (padicValNat)",
+      "Modular arithmetic and the ring ZMod n",
+      "Quadratic residues (squares modulo small moduli)",
+      "Fermat's two-squares theorem for primes (parent entry)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "File header positioning the entry as the composite/all-naturals promotion of the prime two-squares theorem. Imports SumTwoSquares and Tactic; opens the FermatTwoSquaresOQ08 namespace.",
+      "mathContext": "The parent and sibling oq-05 classify primes; this file gives the multiplicative criterion for every natural number and recovers the prime case from it."
+    },
+    {
+      "id": "headline",
+      "title": "The Headline Criterion (all naturals)",
+      "startLine": 35,
+      "endLine": 52,
+      "summary": "States sum_two_squares_iff_even_padicVal: n is a sum of two squares iff every prime q ≡ 3 (mod 4) occurs to an even power. This is Mathlib's Nat.eq_sq_add_sq_iff.",
+      "mathContext": "n = x²+y² ⟺ ∀ q ∈ n.primeFactors, q % 4 = 3 → Even (padicValNat q n). The multiplicative characterization, resting on the multiplicativity of the ℤ[i] norm form plus the prime case."
+    },
+    {
+      "id": "prime-case",
+      "title": "Recovering the Prime Case",
+      "startLine": 54,
+      "endLine": 87,
+      "summary": "Derives ∃ a b, p = a²+b² ↔ p % 4 ≠ 3 from the general criterion via Nat.Prime.primeFactors and padicValNat.self, then Fermat's odd-prime iff p ≡ 1 (mod 4).",
+      "mathContext": "For prime p the quantifier collapses to the single factor p with exponent padicValNat p p = 1 (odd); Even 1 is false, so a 3-mod-4 prime is forbidden. The prime classification is thus a corollary of the composite one."
+    },
+    {
+      "id": "mod-three-obstruction",
+      "title": "A Divisibility Obstruction at the Prime 3",
+      "startLine": 89,
+      "endLine": 123,
+      "summary": "Proves the core ZMod 3 fact (a²+b²=0 ⇒ a=b=0) by decide, and the obstruction: 3 ∣ n with 9 ∤ n implies n is not a sum of two squares.",
+      "mathContext": "Squares mod 3 are {0,1}, so 3 ∣ x²+y² forces 3∣x and 3∣y, hence 9 ∣ x²+y². This is the q=3 instance of the criterion, detecting failures the mod-4 test cannot."
+    },
+    {
+      "id": "witnesses",
+      "title": "Concrete Witnesses",
+      "startLine": 125,
+      "endLine": 155,
+      "summary": "45 = 6²+3² and 50 = 5²+5² representable (explicit witnesses); 21 = 3·7 and 33 = 3·11 not (q=3 obstruction); 7 not representable via the derived prime criterion.",
+      "mathContext": "21 and 33 are ≡ 1 (mod 4), so the mod-4 obstruction is silent — they fail only because 3 divides them to an odd power, exactly what the factorization criterion sees."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "extends",
+      "description": "Promotes the parent's prime-only characterization to the full multiplicative criterion for every natural number — the composite generalization the parent flagged as its open question."
+    },
+    {
+      "targetId": "fermat-two-squares-oq-05",
+      "relationship": "extends",
+      "description": "Strictly strengthens the sibling mod-4 obstruction: numbers like 21 ≡ 1 (mod 4) are invisible to the congruence test but ruled out by the factorization criterion (a 3-mod-4 prime to an odd power)."
+    },
+    {
+      "targetId": "fermat-two-squares-oq-06",
+      "relationship": "related",
+      "description": "The 'only if' direction of the criterion rests on the multiplicativity of the sum-of-two-squares form (Brahmagupta–Fibonacci), which the sibling oq-06 formalizes."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) formalization of the prime-factorization criterion for sums of two squares: n = x²+y² iff every prime q ≡ 3 (mod 4) occurs to an even power in n. The headline is Mathlib's Nat.eq_sq_add_sq_iff; the entry's contribution is to present it as the composite/all-naturals promotion of the parent prime theorem, to DERIVE the prime case as a corollary (via padicValNat p p = 1), and to supply a self-contained q=3 divisibility obstruction that detects composite non-representables (21, 33) which the sibling mod-4 obstruction misses.",
+    "implications": "**Theoretical Significance**: The criterion is the two-dimensional face of the local–global principle for quadratic forms: representability by x²+y² is controlled prime-by-prime, with the ramified/inert primes (q ≡ 3 mod 4) contributing the only obstructions and only through the parity of their exponents. The multiplicative structure — rather than a single congruence — is what distinguishes the composite theory from the prime theory, and is exactly why the four-squares theorem (no obstruction) and the three-squares theorem (a mod-8 obstruction) sit differently in the hierarchy.",
+    "openQuestions": [
+      "Can the q=3 divisibility obstruction be generalized to every prime q ≡ 3 (mod 4) with an odd exponent, giving a Mathlib-independent proof of the necessary direction of the full criterion via -1 not being a quadratic residue mod q?",
+      "Does an analogous factorization criterion hold for representability by x² + 2y² or x² + 3y², and can it be assembled in Lean from the corresponding norm-form multiplicativity?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.SumTwoSquares",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "FermatTwoSquaresOQ08",
+    "lineCount": 155,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/FermatTwoSquaresOQ08.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "P. de Fermat",
+      "title": "Letter to Mersenne (1640)",
+      "year": "1640",
+      "venue": "",
+      "note": "Two-squares characterization for odd primes"
+    },
+    {
+      "authors": "L. Euler",
+      "title": "De numeris qui sunt aggregata duorum quadratorum",
+      "year": "1749",
+      "venue": "Novi Commentarii Academiae Scientiarum Petropolitanae",
+      "note": "First proof of the prime case; the multiplicative extension to all naturals follows from the norm-form identity"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **fermat-two-squares-oq-08**, the composite/all-naturals promotion of Fermat's prime two-squares theorem, as a **VERIFIED, 0-axiom** child of `fermat-two-squares`.

**Headline criterion** (`sum_two_squares_iff_even_padicVal`, = Mathlib's `Nat.eq_sq_add_sq_iff`):
$$n = x^2+y^2 \iff \forall q \in n.\text{primeFactors},\ q \equiv 3 \pmod 4 \Rightarrow 2 \mid \nu_q(n).$$

## Contributions beyond the restatement

- **`prime_sum_two_squares_iff`** — the prime case ($\exists a\,b,\ p = a^2+b^2 \iff p \not\equiv 3 \bmod 4$) **derived from the general criterion** via `Nat.Prime.primeFactors` + `padicValNat.self` (the exponent of a prime in itself is $1$, odd). Not re-cited from `Nat.Prime.sq_add_sq` — the prime and composite statements are one theorem.
- **`odd_prime_sum_two_squares_iff`** — Fermat's classical form $p = x^2+y^2 \iff p \equiv 1 \pmod 4$.
- **`not_sq_add_sq_of_three_dvd_not_nine_dvd`** — a self-contained $q=3$ divisibility obstruction ($3 \mid n$, $9 \nmid n \Rightarrow n \ne x^2+y^2$) via `ZMod 3`, detecting composite failures like $21 = 3\cdot 7$ and $33 = 3\cdot 11$ that are $\equiv 1 \pmod 4$ and thus **invisible to the sibling mod-4 obstruction (oq-05)**.
- **Worked witnesses**: $45 = 6^2+3^2$, $50 = 5^2+5^2$ representable; $21, 33, 7$ not.

## Verification

- 10 theorems, 0 definitions, **0 axioms, 0 sorries**, 155 lines.
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.FermatTwoSquaresOQ08`.
- `#print axioms` on every theorem reports only `propext, Classical.choice, Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`** (uses kernel `decide`, not `native_decide`).

Gallery data: `src/data/proofs/fermat-two-squares-oq-08/{meta.json,annotations.json}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)