### PR TITLE
Fix: retier fermat-two-squares-oq-08 badge to 'mathlib'

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-08/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-08/meta.json
@@ -17,7 +17,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ08.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Change `badge` from `"verified"` to `"mathlib"` in `src/data/proofs/fermat-two-squares-oq-08/meta.json`.

## Evidence

**Before**: `badge: "verified"` — signals independent machine-checked work.
**After**: `badge: "mathlib"` — matches the gallery tiering convention.

The entry's headline theorem is a single term-mode delegation to a Mathlib theorem (`proofs/Proofs/FermatTwoSquaresOQ08.lean:49-52`):

```lean
theorem sum_two_squares_iff_even_padicVal (n : ℕ) :
    (∃ x y : ℕ, n = x ^ 2 + y ^ 2) ↔
      ∀ q ∈ n.primeFactors, q % 4 = 3 → Even (padicValNat q n) :=
  Nat.eq_sq_add_sq_iff
```

This is a stricter Mathlib wrapper than `fibonacci-divisibility-oq-07` (badged `mathlib` despite a multi-line proof), so `verified` was inconsistent with the gallery's own tiering.

`status` remains `"verified"` — 0 sorries / 0 axioms is accurate. The `assumptions` and `originalContributions` prose already honestly disclose the delegation and need no change.

Closes #32121

---
Automated fix by lean-mechanic agent.