### PR TITLE
research(napoleons-theorem-oq-04): Napoleon's area theorem (outer + inner = original) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/NapoleonAreaOQ04.lean
+++ b/proofs/Proofs/NapoleonAreaOQ04.lean
@@ -1,0 +1,121 @@
+import Mathlib
+
+/-!
+# Napoleon's area theorem (outer + inner = original), signed form — napoleons-theorem-oq-04
+
+The parent entry `napoleons-theorem` proves the outer Napoleon triangle is equilateral.
+This child proves the classical *area* companion: the difference between the areas of the
+outer and inner Napoleon triangles equals the area of the original triangle.
+
+## Signs and the centroid formula (two corrections to the seeker sketch)
+
+The problem's Lean sketch contained two inaccuracies that make the *literal* statement
+false; this file states and proves the correct identity.
+
+1. **Centroid, not apex.** The Napoleon triangle is built from the **centroids** of the
+   equilateral triangles on the sides, not their apices. The centroid of the equilateral
+   triangle on side `pq` sits at perpendicular offset `|q-p|·√3/6` from the midpoint
+   (the apex is at `√3/2`); the sketch's `√3/2` is the apex distance and does not satisfy
+   the area identity. We use the centroid, coefficient `√3/6`.
+
+2. **Orientation.** With the *signed* area `triArea a b c = ½ Im((b-a) · conj (c-a))`
+   (the sketch's own code convention) and the **same** cyclic vertex ordering for both
+   Napoleon triangles, the inner triangle is oppositely oriented, so its signed area is the
+   negative of its unsigned area. The clean signed identity is therefore an **addition**
+   `triArea(outer) + triArea(inner) = triArea(original)` (`napoleon_area_signed`), which is
+   exactly the classical *unsigned* statement `|outer| − |inner| = |original|`. Listing the
+   inner triangle's vertices in the opposite (natural) order recovers the literal
+   subtraction form `triArea(outer) − triArea(inner) = triArea(original)`
+   (`napoleon_area_difference`).
+
+The core is a finite complex-algebra cancellation: expand the three signed areas into real
+coordinates, substitute the centroid formulas, and observe that the `√3`-linear terms cancel
+between the outer and inner triangles while `√3² = 3` closes the rest. Verified 0-axiom.
+-/
+
+open Complex ComplexConjugate
+
+namespace NapoleonArea
+
+/-- Signed area of the triangle `a b c`, `½ Im((b-a) · conj (c-a))` (sketch code convention;
+counterclockwise triples get positive area up to this orientation choice). -/
+noncomputable def triArea (a b c : ℂ) : ℝ := (((b - a) * conj (c - a)).im) / 2
+
+/-- Real-coordinate expansion of the signed area (a cross product of the two edge vectors). -/
+theorem triArea_eq (a b c : ℂ) :
+    triArea a b c =
+      ((b.im - a.im) * (c.re - a.re) - (b.re - a.re) * (c.im - a.im)) / 2 := by
+  simp only [triArea, Complex.mul_im, Complex.sub_re, Complex.sub_im, Complex.conj_re,
+    Complex.conj_im]
+  ring
+
+/-- Centroid of the equilateral triangle erected on side `pq`, on the `r`-side
+(`r = 1` outward, `r = -1` inward). This is the geometric centroid
+`(p+q)/2 + (q-p)·(I · r · √3/6)`; note the coefficient is `√3/6` (centroid), *not* `√3/2`
+(apex). -/
+noncomputable def napCentroid (p q : ℂ) (r : ℝ) : ℂ :=
+  (p + q) * Complex.ofReal (1 / 2)
+    + (q - p) * (Complex.I * Complex.ofReal (r * Real.sqrt 3 / 6))
+
+theorem napCentroid_re (p q : ℂ) (r : ℝ) :
+    (napCentroid p q r).re =
+      (p.re + q.re) / 2 - r * Real.sqrt 3 / 6 * (q.im - p.im) := by
+  simp only [napCentroid, Complex.add_re, Complex.add_im, Complex.sub_re, Complex.sub_im,
+    Complex.mul_re, Complex.mul_im, Complex.I_re, Complex.I_im, Complex.ofReal_re,
+    Complex.ofReal_im]
+  ring
+
+theorem napCentroid_im (p q : ℂ) (r : ℝ) :
+    (napCentroid p q r).im =
+      (p.im + q.im) / 2 + r * Real.sqrt 3 / 6 * (q.re - p.re) := by
+  simp only [napCentroid, Complex.add_re, Complex.add_im, Complex.sub_re, Complex.sub_im,
+    Complex.mul_re, Complex.mul_im, Complex.I_re, Complex.I_im, Complex.ofReal_re,
+    Complex.ofReal_im]
+  ring
+
+/-- **Napoleon's area theorem (signed form).** For any triangle `z₁ z₂ z₃`, the signed area
+of the outward Napoleon triangle plus the signed area of the inward Napoleon triangle
+(both with the same cyclic vertex ordering) equals the signed area of `z₁ z₂ z₃`.
+
+Because the inward triangle is oppositely oriented, its signed area is the negative of its
+unsigned area, so this is the classical `|outer| − |inner| = |original|`.
+
+Proof: expand via `triArea_eq` and the centroid formulas; the `√3`-linear contributions of
+the two Napoleon triangles cancel, and the residual is closed by `√3² = 3`. -/
+theorem napoleon_area_signed (z₁ z₂ z₃ : ℂ) :
+    triArea (napCentroid z₂ z₃ 1) (napCentroid z₃ z₁ 1) (napCentroid z₁ z₂ 1)
+      + triArea (napCentroid z₂ z₃ (-1)) (napCentroid z₃ z₁ (-1)) (napCentroid z₁ z₂ (-1))
+      = triArea z₁ z₂ z₃ := by
+  have hs : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  simp only [triArea_eq, napCentroid_re, napCentroid_im]
+  linear_combination
+    (-z₁.re * z₂.im + z₁.re * z₃.im + z₂.re * z₁.im - z₂.re * z₃.im
+      - z₃.re * z₁.im + z₃.re * z₂.im) / 12 * hs
+
+/-- **Napoleon's area theorem (difference form).** Listing the inner Napoleon triangle's
+vertices in its natural (opposite) orientation turns the signed identity into the literal
+classical statement: the outer Napoleon area *minus* the inner Napoleon area equals the
+original area. -/
+theorem napoleon_area_difference (z₁ z₂ z₃ : ℂ) :
+    triArea (napCentroid z₂ z₃ 1) (napCentroid z₃ z₁ 1) (napCentroid z₁ z₂ 1)
+      - triArea (napCentroid z₂ z₃ (-1)) (napCentroid z₁ z₂ (-1)) (napCentroid z₃ z₁ (-1))
+      = triArea z₁ z₂ z₃ := by
+  have h := napoleon_area_signed z₁ z₂ z₃
+  have e : triArea (napCentroid z₂ z₃ (-1)) (napCentroid z₁ z₂ (-1)) (napCentroid z₃ z₁ (-1))
+      = -triArea (napCentroid z₂ z₃ (-1)) (napCentroid z₃ z₁ (-1)) (napCentroid z₁ z₂ (-1)) := by
+    simp only [triArea_eq]; ring
+  rw [e]; linarith
+
+/-! ### Worked examples -/
+
+/-- A degenerate triangle with two coincident vertices has zero area. -/
+example (a b : ℂ) : triArea a b b = 0 := by rw [triArea_eq]; ring
+
+/-- Signed area of the unit right triangle `0, 1, i` is `-1/2` in this orientation
+convention. -/
+example : triArea 0 1 Complex.I = -1 / 2 := by
+  simp only [triArea_eq, Complex.zero_re, Complex.zero_im, Complex.one_re, Complex.one_im,
+    Complex.I_re, Complex.I_im]
+  norm_num
+
+end NapoleonArea

--- a/research/problems/napoleons-theorem-oq-04/knowledge.md
+++ b/research/problems/napoleons-theorem-oq-04/knowledge.md
@@ -1,0 +1,61 @@
+# Knowledge: Napoleon's Area Theorem (napoleons-theorem-oq-04)
+
+## Goal
+
+Formalize the area half of Napoleon's theorem: for any triangle `z₁z₂z₃`, the outer
+Napoleon triangle area minus the inner Napoleon triangle area equals the area of `z₁z₂z₃`.
+
+## Session 1 (researcher-8, 2026-07-01): SOLVED (VERIFIED 0-axiom)
+
+`proofs/Proofs/NapoleonAreaOQ04.lean` — 5 theorems, 2 defs, 121 lines, 0 axioms.
+
+### The math (and why the seeker sketch was false as written)
+
+The classical result: with side lengths `a,b,c` and area `S`,
+`Area(outer Napoleon) = (√3/24)(a²+b²+c²) + S/2`,
+`Area(inner Napoleon) = (√3/24)(a²+b²+c²) − S/2`, difference `= S`.
+
+The provided sketch had two errors, both confirmed by brute-force numerics:
+
+1. **Centroid vs apex.** The Napoleon triangle is formed by the **centroids** of the
+   equilateral triangles on the sides. The centroid offset from a side's midpoint is
+   `|q-p|·√3/6`, one third of the apex offset `|q-p|·√3/2`. The sketch used `√3/2`
+   (apex) → identity fails. Correct: `napCentroid p q r = (p+q)/2 + (q-p)(i·r·√3/6)`.
+
+2. **Sign / orientation.** With signed area `triArea a b c = ½ Im((b-a) conj(c-a))`
+   (the sketch's own code convention) and the **same** cyclic vertex order for both
+   Napoleon triangles, the inner triangle is oppositely oriented, so its signed area is
+   the negative of its unsigned area. Exhaustive search over {apex, centroid} ×
+   {outer sign} × {inner vertex permutation} shows the ONLY true signed identity is
+   `centroid, outer +, inner −, inner-vertices reversed`, i.e.
+   `triArea(outer) + triArea(inner, same order) = triArea(original)`.
+
+### Verified statements
+
+- `napoleon_area_signed` : `triArea(G_out z₂z₃, G_out z₃z₁, G_out z₁z₂)
+  + triArea(G_in z₂z₃, G_in z₃z₁, G_in z₁z₂) = triArea(z₁,z₂,z₃)`.
+- `napoleon_area_difference` : `triArea(outer) − triArea(inner, reversed) = triArea(original)`
+  (the literal classical subtraction, inner in natural opposite orientation).
+
+### Key Lean recipe (reusable for √3 planar-geometry identities)
+
+- **Route complex signed areas through real coordinates.** Prove once
+  `triArea_eq : triArea a b c = ((b.im-a.im)(c.re-a.re) − (b.re-a.re)(c.im-a.im))/2`
+  (via `Complex.mul_im`, `Complex.sub_re/im`, `Complex.conj_re/im`, then `ring`).
+- **Define points with `Complex.ofReal` scalars, not ℂ-division.** Writing the midpoint as
+  `(p+q) * Complex.ofReal (1/2)` and the rotation as `I * Complex.ofReal (r*√3/6)` lets
+  `.re`/`.im` expand with only `Complex.{add,sub,mul}_{re,im}`, `Complex.I_{re,im}`,
+  `Complex.ofReal_{re,im}` + `ring` — **no** `Complex.div_re`/`normSq` mess.
+- **One `linear_combination` for the √3-cancellation.** Set `hs : Real.sqrt 3 ^ 2 = 3 :=
+  Real.sq_sqrt (by norm_num)`; after expansion the goal is `LHS = RHS` polynomial in the
+  coords and `√3` with `√3` only to power ≤ 2 and the odd part structurally zero, so
+  `LHS − RHS = k·(√3² − 3)`. **Compute `k` with sympy** (the `s²` coefficient) and pass
+  `linear_combination k * hs`. Here `k = (−z₁.re·z₂.im + z₁.re·z₃.im + z₂.re·z₁.im
+  − z₂.re·z₃.im − z₃.re·z₁.im + z₃.re·z₂.im)/12` = original signed area ÷ 12. One-shot.
+- **Orientation flip as a lemma:** `triArea a b c = −triArea a c b` by `simp [triArea_eq]; ring`
+  converts the signed-addition form to the literal subtraction form.
+
+### Gallery
+
+New entry `napoleons-theorem-oq-04` (badge original, status verified, 0 axioms).
+Parent `napoleons-theorem` (equilaterality) unchanged.

--- a/research/problems/napoleons-theorem-oq-04/state.md
+++ b/research/problems/napoleons-theorem-oq-04/state.md
@@ -1,0 +1,50 @@
+# Current State
+
+**Phase**: SOLVED (verified 0-axiom gallery entry)
+**Since**: 2026-07-01
+**Iteration**: 1
+
+## Current Focus
+
+Prove the area companion to Napoleon's theorem: the difference of the outer and
+inner Napoleon triangle areas equals the area of the original triangle.
+
+## Result
+
+`proofs/Proofs/NapoleonAreaOQ04.lean` (VERIFIED 0-axiom): defines the complex
+signed area `triArea a b c = ½ Im((b-a) conj(c-a))` and the Napoleon centroid
+`napCentroid p q r = (p+q)/2 + (q-p)(i·r·√3/6)` (r=±1 outer/inner), and proves:
+
+- `napoleon_area_signed` : `triArea(outer) + triArea(inner) = triArea(original)`
+  (the signed form; equals the classical unsigned `|outer| − |inner| = |original|`);
+- `napoleon_area_difference` : the literal `triArea(outer) − triArea(inner) = original`
+  with the inner triangle in its natural opposite orientation.
+
+Both depend only on `[propext, Classical.choice, Quot.sound]`.
+
+## Two corrections to the seeker sketch
+
+1. **Centroid, not apex.** The sketch's `Gouter/Ginner` used offset `√3/2` (the apex);
+   the Napoleon triangle uses the **centroid**, offset `√3/6`. The identity is false for
+   apex points (verified numerically) and true for centroids.
+2. **Addition, not subtraction (signed).** With a fixed signed-area convention and the
+   same cyclic vertex order, the inner Napoleon triangle is oppositely oriented, so its
+   signed area is negative. The clean signed identity is `outer + inner = original`.
+
+## Proof technique
+
+Expand both Napoleon areas in real coordinates via `triArea_eq` + `napCentroid_re/im`.
+Each area is quadratic in `√3/6`; the `√3`-linear terms flip sign between outer (r=1) and
+inner (r=-1) and cancel in the sum, while `√3² = 3` (`Real.sq_sqrt`) closes the rest. One
+`linear_combination`, multiplier = original signed area ÷ 12.
+
+## Next Action
+
+Complete. Optional follow-ups: formalize the separate `(√3/24)Σside² ± S/2` area formulas;
+connect to the parent's equilaterality result; Petr–Douglas–Neumann n-gon generalization.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (complex signed-area cancellation)

--- a/src/data/proofs/napoleons-theorem-oq-04/annotations.json
+++ b/src/data/proofs/napoleons-theorem-oq-04/annotations.json
@@ -1,0 +1,70 @@
+[
+  {
+    "id": "napoleon-oq04-ann-overview",
+    "proofId": "napoleons-theorem-oq-04",
+    "range": { "startLine": 3, "endLine": 34 },
+    "type": "concept",
+    "title": "The Area Half of Napoleon's Theorem",
+    "content": "Napoleon's theorem has two halves: the outer Napoleon triangle is equilateral (the parent entry), and the difference of the outer and inner Napoleon areas equals the area of the original triangle (this entry). In side-length terms the outer area is (√3/24)(a²+b²+c²) + S/2 and the inner is (√3/24)(a²+b²+c²) − S/2, so their difference is exactly S. This file formalizes that identity with complex signed areas. Two corrections to the original problem sketch are needed to make the statement true: the Napoleon triangle uses the centroid offset √3/6 (not the apex √3/2), and with signed areas the correct relation is an addition, because the inner triangle is oppositely oriented.",
+    "mathContext": "Outer $=\\tfrac{\\sqrt3}{24}(a^2+b^2+c^2)+\\tfrac S2$, inner $=\\tfrac{\\sqrt3}{24}(a^2+b^2+c^2)-\\tfrac S2$, difference $=S$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Napoleon's theorem",
+      "signed area",
+      "triangle centroid",
+      "complex plane geometry"
+    ],
+    "prerequisites": [
+      "complex plane geometry",
+      "signed area of a triangle"
+    ]
+  },
+  {
+    "id": "napoleon-oq04-ann-signed-area",
+    "proofId": "napoleons-theorem-oq-04",
+    "range": { "startLine": 40, "endLine": 50 },
+    "type": "definition",
+    "title": "Signed Area as an Edge Cross-Product",
+    "content": "The signed area triArea a b c = ½ Im((b-a) conj(c-a)) is half the 2D cross product of the two edge vectors b-a and c-a. The lemma triArea_eq rewrites it into ½((b.im-a.im)(c.re-a.re) − (b.re-a.re)(c.im-a.im)), a polynomial in the six real coordinates. Doing this once means every subsequent area computation is ordinary real algebra, and the final cancellation is a `ring` fact rather than a statement about complex numbers.",
+    "mathContext": "$\\operatorname{triArea}(a,b,c)=\\tfrac12\\operatorname{Im}\\big((b-a)\\overline{(c-a)}\\big)=\\tfrac12\\big((b_y-a_y)(c_x-a_x)-(b_x-a_x)(c_y-a_y)\\big)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["cross product", "imaginary part", "complex conjugate"],
+    "prerequisites": ["Complex.mul_im", "Complex.conj_im"]
+  },
+  {
+    "id": "napoleon-oq04-ann-centroid",
+    "proofId": "napoleons-theorem-oq-04",
+    "range": { "startLine": 52, "endLine": 74 },
+    "type": "definition",
+    "title": "Centroid, Not Apex: Offset √3/6",
+    "content": "napCentroid p q r = (p+q)/2 + (q-p)(i·r·√3/6) is the centroid of the equilateral triangle erected on side pq, with r=1 outward and r=-1 inward. The perpendicular offset from the midpoint is |q-p|·√3/6 — one third of the apex offset √3/2. This is the decisive correction to the problem's sketch, which used √3/2 (the apex) and hence did not satisfy the area identity. Because the coefficient is a real scalar times i, the real and imaginary parts (napCentroid_re, napCentroid_im) are affine in the input coordinates.",
+    "mathContext": "$G(p,q,r)=\\tfrac{p+q}{2}+ (q-p)\\,\\tfrac{i\\,r\\sqrt3}{6}$, so $G_{\\mathrm{re}}=\\tfrac{p_x+q_x}{2}-\\tfrac{r\\sqrt3}{6}(q_y-p_y)$ and $G_{\\mathrm{im}}=\\tfrac{p_y+q_y}{2}+\\tfrac{r\\sqrt3}{6}(q_x-p_x)$.",
+    "significance": "key",
+    "relatedConcepts": ["centroid", "equilateral triangle", "60° rotation", "affine map"],
+    "prerequisites": ["complex arithmetic", "roots of unity"]
+  },
+  {
+    "id": "napoleon-oq04-ann-theorem",
+    "proofId": "napoleons-theorem-oq-04",
+    "range": { "startLine": 76, "endLine": 107 },
+    "type": "theorem",
+    "title": "outer + inner = original (One √3-Cancellation)",
+    "content": "napoleon_area_signed states triArea(outer) + triArea(inner) = triArea(original). Substituting the centroids, each Napoleon area is quadratic in √3/6: a constant part Q₀, a √3-linear part ±Q₁, and a √3²-part Q₂. The linear part flips sign between outer (r=1) and inner (r=-1) and cancels in the sum; √3² is replaced by 3 via Real.sq_sqrt. What remains is a polynomial identity in z₁,z₂,z₃, closed by a single linear_combination whose multiplier is exactly the original signed area over 12. napoleon_area_difference then reverses the inner triangle's vertex order — which negates its signed area since it is oppositely oriented — to give the literal classical statement outer − inner = original.",
+    "mathContext": "$\\operatorname{area}(r)=Q_0+r\\,Q_1\\tfrac{\\sqrt3}{6}+Q_2(\\tfrac{\\sqrt3}{6})^2$; the sum $r{=}1$ plus $r{=}-1$ is $2Q_0+2Q_2\\cdot\\tfrac{3}{36}$, free of $\\sqrt3$, and equals $\\operatorname{triArea}(z_1,z_2,z_3)$.",
+    "significance": "key",
+    "relatedConcepts": ["linear_combination tactic", "Real.sq_sqrt", "orientation", "signed area"],
+    "prerequisites": ["triArea_eq", "napCentroid_re", "napCentroid_im", "√3² = 3"]
+  },
+  {
+    "id": "napoleon-oq04-ann-examples",
+    "proofId": "napoleons-theorem-oq-04",
+    "range": { "startLine": 109, "endLine": 119 },
+    "type": "concept",
+    "title": "Sanity Checks",
+    "content": "Two worked examples fix the conventions: a triangle with two coincident vertices has zero area (closed by ring after triArea_eq), and the unit right triangle 0,1,i has signed area −1/2 in the chosen orientation convention. The latter pins down the sign of the ½ Im((b-a) conj(c-a)) definition used throughout.",
+    "mathContext": "$\\operatorname{triArea}(a,b,b)=0$ and $\\operatorname{triArea}(0,1,i)=-\\tfrac12$.",
+    "significance": "supporting",
+    "relatedConcepts": ["degenerate triangle", "orientation convention"],
+    "prerequisites": ["triArea_eq"]
+  }
+]

--- a/src/data/proofs/napoleons-theorem-oq-04/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-04/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "napoleons-theorem-oq-04",
+  "title": "Napoleon's Area Theorem: Outer + Inner = Original",
+  "slug": "napoleons-theorem-oq-04",
+  "description": "The signed-area companion to Napoleon's theorem. For any triangle z₁z₂z₃, the signed area of the outer Napoleon triangle plus that of the inner Napoleon triangle equals the area of the original — the classical 'outer minus inner (unsigned) = original', where the sign flip encodes the inner triangle's opposite orientation. Proven by a single √3-cancellation: expanding both Napoleon areas in real coordinates, the √3-linear terms cancel between outer and inner and √3²=3 closes the rest.",
+  "meta": {
+    "author": "Lean Genius Researcher (2026)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Napoleon%27s_theorem",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NapoleonAreaOQ04.lean",
+    "tags": [
+      "geometry",
+      "napoleon",
+      "complex-numbers",
+      "area",
+      "signed-area",
+      "triangle"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "√3² = 3 for the nonnegative real square root; the sole non-ring fact behind the cancellation",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "Complex.mul_im",
+        "description": "Imaginary part of a complex product, used to expand the signed-area cross product",
+        "module": "Mathlib.Data.Complex.Basic"
+      },
+      {
+        "theorem": "Complex.conj_im",
+        "description": "(conj z).im = -z.im, used to expand the signed area ½ Im((b-a) conj(c-a))",
+        "module": "Mathlib.Data.Complex.Basic"
+      }
+    ],
+    "originalContributions": [
+      "triArea_eq: real-coordinate (edge cross-product) expansion of the complex signed area ½ Im((b-a) conj(c-a))",
+      "napCentroid_re / napCentroid_im: the real and imaginary parts of the Napoleon centroid (p+q)/2 + (q-p)(i·r·√3/6), r=±1 for outer/inner",
+      "napoleon_area_signed: signed form — triArea(outer) + triArea(inner) = triArea(original); the √3-linear terms cancel between the two Napoleon triangles and √3²=3 closes the rest (one linear_combination)",
+      "napoleon_area_difference: the literal classical statement — triArea(outer) − triArea(inner, natural orientation) = triArea(original)",
+      "Two corrections to the seeker sketch: the Napoleon triangle uses the centroid offset √3/6 (not the apex √3/2), and the correct signed relation is an addition (the inner triangle is oppositely oriented)"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 121,
+    "assumptions": "0 axioms, 0 sorries. Fully verified (#print axioms reports only propext, Classical.choice, Quot.sound). Self-contained: defines its own signed-area function and Napoleon centroid. The only non-ring input is √3²=3 (Real.sq_sqrt); the identity then follows from a single deterministic linear_combination whose multiplier is the original triangle's signed area.",
+    "mathlib_version": "4.26.0",
+    "parentProof": "napoleons-theorem",
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "sections": [
+    {
+      "title": "Signed Area and its Real Expansion",
+      "startLine": 40,
+      "endLine": 50,
+      "description": "Define the complex signed area triArea a b c = ½ Im((b-a) conj(c-a)) and prove triArea_eq, its expansion into the real edge cross-product ½((b.im-a.im)(c.re-a.re) - (b.re-a.re)(c.im-a.im)).",
+      "summary": "Complex signed area = real edge cross-product",
+      "id": "signed-area",
+      "mathContext": "The signed area is half the imaginary part of $(b-a)\\overline{(c-a)}$, i.e. half the 2D cross product of the edge vectors $b-a$ and $c-a$. Expanding via `Complex.mul_im` and `Complex.conj_im/re` turns every area into a polynomial in the six real coordinates — the form in which the final cancellation is a `ring` fact."
+    },
+    {
+      "title": "The Napoleon Centroid",
+      "startLine": 52,
+      "endLine": 74,
+      "description": "Define napCentroid p q r = (p+q)/2 + (q-p)(I·r·√3/6), the centroid of the equilateral triangle on side pq (r=1 outward, r=-1 inward), and compute its real and imaginary parts (napCentroid_re, napCentroid_im).",
+      "summary": "Centroid formula (offset √3/6, not apex √3/2) and its re/im",
+      "id": "centroid",
+      "mathContext": "The centroid of the equilateral triangle on side $pq$ lies at perpendicular offset $|q-p|\\sqrt3/6$ from the midpoint — one third of the way to the apex (which is at $\\sqrt3/2$). Writing the offset as multiplication by $i\\cdot r\\cdot\\sqrt3/6$ makes the real and imaginary parts $\\tfrac{p+q}{2}\\mp\\tfrac{r\\sqrt3}{6}\\,\\Delta$ affine in the coordinates."
+    },
+    {
+      "title": "Napoleon's Area Theorem",
+      "startLine": 76,
+      "endLine": 107,
+      "description": "napoleon_area_signed: triArea(outer) + triArea(inner) = triArea(original), closed by one linear_combination with multiplier the original signed area (÷12) times √3²=3. napoleon_area_difference: the literal outer-minus-inner form, obtained by reversing the inner triangle's orientation.",
+      "summary": "outer + inner = original (signed); outer − inner = original (difference)",
+      "id": "area-theorem",
+      "mathContext": "Each Napoleon area expands as $Q_0 \\pm Q_1\\sqrt3/6 + Q_2(\\sqrt3/6)^2$; the odd term flips sign between outer ($r=1$) and inner ($r=-1$), so their sum is $2Q_0 + Q_2/6$ — free of $\\sqrt3$ — and equals the original area. The single `linear_combination` multiplier is exactly the $\\sqrt3^2$-coefficient, the original triangle's signed area over 12."
+    },
+    {
+      "title": "Worked Examples",
+      "startLine": 109,
+      "endLine": 119,
+      "description": "A degenerate triangle with two coincident vertices has zero area (by ring); the unit right triangle 0,1,i has signed area -1/2 in this orientation convention.",
+      "summary": "Degenerate and unit-right-triangle sanity checks",
+      "id": "examples",
+      "mathContext": "Sanity checks fixing the orientation convention: coincident vertices annihilate the cross product, and $\\text{triArea}(0,1,i)=-1/2$ pins down the sign of the chosen $\\tfrac12\\operatorname{Im}((b-a)\\overline{(c-a)})$ convention."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Napoleon's theorem — the centers of equilateral triangles erected on the sides of any triangle form an equilateral triangle — has a less-quoted second half concerning areas: both the outer and inner Napoleon triangles are equilateral, and the difference of their areas equals the area of the original triangle. In terms of the side lengths a,b,c and area S, the outer Napoleon area is (√3/24)(a²+b²+c²) + S/2 and the inner is (√3/24)(a²+b²+c²) − S/2, so their difference is exactly S. This entry formalizes that area identity in complex coordinates, complementing the parent napoleons-theorem (equilaterality) and the sibling spectral entries.",
+    "problemStatement": "For a triangle z₁,z₂,z₃ ∈ ℂ, let the outer and inner Napoleon triangles be formed by the centroids of the outward/inward equilateral triangles on the three sides. Using the signed area ½ Im((b-a) conj(c-a)), prove that the outer Napoleon area plus the inner Napoleon area equals the area of z₁z₂z₃ (equivalently, |outer| − |inner| = |original|).",
+    "text": "The outer and inner Napoleon triangles straddle the original in area: their signed areas add up to the original's, which is the classical statement that the excess of the outer over the inner equals the triangle you started with.",
+    "proofStrategy": "A finite complex-algebra cancellation, deliberately routed through real coordinates so the finish is a `ring` fact modulo one square-root identity.\n\n1. **Signed area as a cross product**: triArea_eq rewrites ½ Im((b-a) conj(c-a)) into ½((b.im-a.im)(c.re-a.re) − (b.re-a.re)(c.im-a.im)), a polynomial in the six real coordinates.\n\n2. **Centroid coordinates**: napCentroid_re/im give the affine real/imaginary parts of the centroid (p+q)/2 + (q-p)(i·r·√3/6). Crucially the offset is √3/6 (centroid), not √3/2 (apex).\n\n3. **√3 cancellation**: substituting the centroids, each Napoleon area is quadratic in √3/6; the √3-linear part flips sign between outer (r=1) and inner (r=-1) and cancels in the sum, while √3² is replaced by 3 via Real.sq_sqrt. The residual is a polynomial identity in z₁,z₂,z₃, closed by a single `linear_combination` whose multiplier is the original signed area (÷12).\n\n4. **Difference form**: reversing the inner triangle's vertex order negates its signed area (it is oppositely oriented), turning the addition into the literal outer-minus-inner statement.",
+    "keyInsights": [
+      "**Centroid, not apex**: the Napoleon triangle is built from centroids; the perpendicular offset is √3/6 of the base, one third of the apex offset √3/2. The area identity fails for apex points — a correction to the problem's original sketch.",
+      "**Addition, not subtraction (signed)**: with a fixed signed-area convention and the same cyclic vertex order, the inner Napoleon triangle is oppositely oriented, so its signed area is negative. The clean signed identity is outer + inner = original; the classical 'outer − inner' refers to unsigned areas.",
+      "**√3 cancels for free**: the √3-linear terms of the two Napoleon areas are equal and opposite, so the sum contains no √3 once √3²=3 is applied — the whole theorem is a single linear_combination.",
+      "**The multiplier is the answer**: the linear_combination coefficient needed is precisely (original signed area)/12·... — the √3²-coefficient of the expansion equals a twelfth of the original area, so the identity is self-referential in a pleasing way."
+    ],
+    "prerequisites": [
+      "Complex numbers and arithmetic in ℂ",
+      "Signed area of a triangle as an imaginary-part / cross product",
+      "The Napoleon centroid formula (60° rotation = multiplication by e^{iπ/3})"
+    ],
+    "openQuestions": [
+      "Formalize the individual Napoleon areas (√3/24)(a²+b²+c²) ± S/2, not just their difference.",
+      "Connect to the parent's equilaterality result to recover both halves of Napoleon's theorem in one file.",
+      "Generalize to the Petr–Douglas–Neumann area relations for n-gons."
+    ]
+  },
+  "conclusion": {
+    "summary": "For any triangle, the signed area of the outer Napoleon triangle plus that of the inner Napoleon triangle equals the area of the original; equivalently the outer exceeds the inner (in unsigned area) by exactly the original area. The proof expands both Napoleon areas in real coordinates, cancels the √3-linear terms between outer and inner, and closes with √3²=3 in a single linear_combination.",
+    "implications": "This supplies the area half of the classical Napoleon package, complementing the parent's equilaterality theorem. The routing through a real cross-product plus one square-root identity is a robust, search-free proof architecture for √3-laden planar-geometry identities.",
+    "openQuestions": [
+      "Formalize the separate outer and inner area formulas (√3/24)Σside² ± S/2.",
+      "Petr–Douglas–Neumann area generalization to n-gons."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "napoleons-theorem",
+      "relationship": "parent",
+      "description": "Proves the outer Napoleon triangle is equilateral; this entry supplies the complementary area identity, the second half of the classical Napoleon package."
+    },
+    {
+      "targetId": "napoleons-theorem-oq-03",
+      "relationship": "related",
+      "description": "The spectral (DFT filter) sibling; shares the centroid displacement coefficient i√3/6 whose square −1/12 also drives that entry's collapses."
+    },
+    {
+      "targetId": "herons-formula",
+      "relationship": "related",
+      "description": "An alternative route to triangle area (from side lengths); the Napoleon area identity here is stated instead via the complex signed-area cross product."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America, §3.3",
+      "note": "States Napoleon's theorem together with the outer-minus-inner area relation formalized in this entry."
+    },
+    {
+      "authors": "Wetzel, John E.",
+      "title": "Converses of Napoleon's Theorem",
+      "year": "1992",
+      "venue": "The American Mathematical Monthly, vol. 99, no. 4, pp. 339–351",
+      "note": "Comprehensive treatment of Napoleon's theorem, the complex-number proof strategy, and the area relations."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Complex",
+      "ComplexConjugate"
+    ],
+    "namespace": "NapoleonArea",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "sorries": 0,
+    "path": "Proofs/NapoleonAreaOQ04.lean",
+    "definitionCount": 2
+  }
+}


### PR DESCRIPTION
## Summary

New verified (0-axiom) gallery entry `proofs/Proofs/NapoleonAreaOQ04.lean` — the **signed-area companion** to Napoleon's theorem (parent `napoleons-theorem` proves equilaterality). For any triangle `z₁z₂z₃`, the outer Napoleon triangle area plus the inner Napoleon triangle area equals the original area.

- **`napoleon_area_signed`** : `triArea(outer) + triArea(inner) = triArea(original)` — the classical `|outer| − |inner| = |original|` in signed form.
- **`napoleon_area_difference`** : the literal `triArea(outer) − triArea(inner) = triArea(original)`, with the inner triangle in its natural (opposite) orientation.

## Two corrections to the problem's original sketch

The seeker sketch was **false as literally written** (confirmed by brute-force numerics over 20 000 random triangles):

1. **Centroid, not apex.** The Napoleon triangle is built from the **centroids** of the equilateral triangles on the sides — perpendicular offset `√3/6`, one third of the apex offset `√3/2` the sketch used. The identity fails for apex points.
2. **Addition, not subtraction (signed).** With a fixed signed-area convention and the same cyclic vertex order, the inner Napoleon triangle is oppositely oriented, so its *signed* area is negative; the clean signed identity is an addition. Reversing the inner vertices recovers the literal subtraction form.

## Technique

Expand both Napoleon areas into real coordinates (`triArea_eq` + `napCentroid_re/im`). Each area is quadratic in `√3/6`; the `√3`-linear terms flip sign between outer (`r=1`) and inner (`r=-1`) and **cancel in the sum**, while `√3² = 3` (`Real.sq_sqrt`) closes the rest — one `linear_combination`, multiplier = original signed area ÷ 12 (computed symbolically).

## Verification

`./proofs/scripts/docker-build.sh Proofs.NapoleonAreaOQ04` — **build succeeded**. `#print axioms` on `napoleon_area_signed` and `napoleon_area_difference` reports only `[propext, Classical.choice, Quot.sound]`: 0 `sorry`, 0 `native_decide`, 0 `axiom`.

Files: Lean proof + gallery `meta.json`/`annotations.json` + research `state.md`/`knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)