### PR TITLE
Enrich Cauchy interlacing compression↔principal submatrix: annotate finrank proof

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01/annotations.json
@@ -46,5 +46,17 @@
     "significance": "key",
     "relatedConcepts": ["principal submatrix", "compression", "Cauchy interlacing"],
     "prerequisites": ["Matrix.submatrix", "the two ingredient lemmas above"]
+  },
+  {
+    "id": "ann-finrank-hyperplane",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
+    "range": { "startLine": 132, "endLine": 141 },
+    "type": "theorem",
+    "title": "The Hyperplane Really Is n-Dimensional",
+    "content": "`finrank_coordinateHyperplane`: `Module.finrank 𝕜 (coordinateHyperplane j) = n`. Interlacing via `cauchy_interlacing_compression` only applies to a genuine codimension-one subspace, so this dimension count is not bookkeeping — it certifies the hypothesis. The argument is a clean chain: `EuclideanSpace.orthonormal_single` gives that the full standard basis `(e_a)_{a : Fin (n+1)}` is orthonormal; `Orthonormal.comp` along the *injective* deletion map `Fin.succAbove_right_injective` restricts it to the orthonormal sub-family `(e_{j.succAbove i})_{i : Fin n}`; `Orthonormal.linearIndependent` upgrades orthonormality to linear independence; and `finrank_span_eq_card` reads the dimension of the span off the cardinality `Fintype.card (Fin n) = n`. Injectivity of `succAbove` is load-bearing — orthonormality is preserved under composition only with an injection, and it is exactly what keeps the deleted index `j` from collapsing the family.",
+    "mathContext": "An orthonormal sub-family of size n spans an n-dimensional subspace: dim span{e_{j◁i} : i ∈ Fin n} = |Fin n| = n.",
+    "significance": "supporting",
+    "relatedConcepts": ["orthonormal family", "linear independence", "finrank of a span", "Fin.succAbove injectivity"],
+    "prerequisites": ["Orthonormal.comp and Orthonormal.linearIndependent", "finrank_span_eq_card"]
   }
 ]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchyInterlacingOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchyInterlacingTheoremOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchyInterlacingTheoremOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchyInterlacingTheoremOq01Oq01Data: ProofData = {
+  proof: cauchyInterlacingTheoremOq01Oq01Proof,
+  annotations: cauchyInterlacingTheoremOq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-01` (The Orthogonal Compression to a Coordinate Hyperplane Is the Principal Submatrix).

**Critical fix:**
- **Added missing `index.ts`** — without it, Vite's `import.meta.glob` cannot discover the proof, so the page rendered 'proof not found' on the live site despite appearing in the gallery listing.

**Enrichment:**
- Added a 5th annotation (`ann-finrank-hyperplane`) covering `finrank_coordinateHyperplane`, the previously uncovered dimension-count theorem (orthonormal sub-family ⟹ linearly independent ⟹ `finrank = card = n`), highlighting that injectivity of `Fin.succAbove` is load-bearing.

meta.json unchanged (already richly enriched, 12.8 KB, well within caps). JSON validates; entry type-checks clean.