### PR TITLE
research(feuerbachs-theorem-oq-04): spherical midpoint arc-bisection [DRAFT — build-pending]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
@@ -1,0 +1,181 @@
+/-
+# Feuerbach's Theorem in Non-Euclidean Geometry (OQ-04): the spherical midpoint layer
+
+This companion file to `Proofs.FeuerbachsTheoremOQ04` adds the **spherical midpoint** of two
+model points and proves that it genuinely bisects the geodesic arc joining them.
+
+Why this matters for Feuerbach: the classical nine-point circle passes through the three
+**midpoints of the triangle's sides**.  Any spherical nine-point construction therefore needs
+a verified notion of "the midpoint of a spherical segment" — a model point `M` on the shorter
+geodesic from `P` to `Q` that is equidistant from both, with `sdist P M = sdist P Q / 2`.
+This file supplies exactly that primitive, `0`-axiom / `0`-sorry, building only on the
+*merged* metric API of `Proofs.FeuerbachsTheoremOQ04` (`OnSphere`, `scos`, `sdist`).  It is
+deliberately orthogonal to the incircle / incenter / bisector layers so it does not touch the
+shared `FeuerbachsTheoremOQ04.lean` file.
+
+## Construction
+
+For non-antipodal unit vectors `P, Q` (equivalently `scos P Q > -1`, so `P + Q ≠ 0`) the
+spherical midpoint is the **normalised sum**
+
+    sMidpoint P Q := ‖P + Q‖⁻¹ • (P + Q).
+
+This is the point where the perpendicular bisector plane of the chord `PQ` meets the sphere on
+the near side.  The one nontrivial computation is the half-angle identity
+`⟪P, sMidpoint P Q⟫ = cos ((arccos (scos P Q)) / 2)`, which turns "the inner product of `P`
+with the midpoint" into "the cosine of half the spherical distance" via `Real.cos_half`.
+
+## What this file proves (0 axioms, 0 sorries)
+
+* `norm_add_sq_onSphere` — `‖P + Q‖² = 2 + 2·scos P Q` for unit vectors (the addition analogue
+  of the merged `chord_sq`).
+* `norm_add_pos` — for non-antipodal points `‖P + Q‖ > 0`, so the midpoint is well defined.
+* `onSphere_sMidpoint` — the midpoint is again a model point (unit norm).
+* `sMidpoint_comm`, `scos_comm` — symmetry of the construction and of `scos`.
+* `inner_sMidpoint_left`, `inner_sMidpoint_right` — the inner product of the midpoint with each
+  endpoint equals `‖P + Q‖⁻¹ · (1 + scos P Q)`; in particular the two are equal.
+* `scos_sMidpoint_equidist`, `sdist_sMidpoint_equidist` — the midpoint is **equidistant** from
+  the two endpoints.
+* `sdist_sMidpoint_bisect` (headline) — `sdist P (sMidpoint P Q) = sdist P Q / 2`: the midpoint
+  lies at exactly half the spherical distance from `P`.
+* `sdist_sMidpoint_right` — the symmetric `sdist Q (sMidpoint P Q) = sdist P Q / 2`.
+* `sdist_sMidpoint_add` — `sdist P M + sdist M Q = sdist P Q`: the midpoint lies **on** the
+  geodesic segment from `P` to `Q` (the triangle inequality holds with equality), i.e. it is a
+  genuine arc midpoint, not merely an equidistant point.
+-/
+import Mathlib
+import Proofs.FeuerbachsTheoremOQ04
+
+namespace FeuerbachsTheoremOQ04
+
+open scoped RealInnerProductSpace
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- **Sum–cosine bridge.**  For unit vectors the squared ambient length of `P + Q` is
+`2 + 2·cos(spherical distance)` — the addition analogue of `chord_sq`. -/
+theorem norm_add_sq_onSphere {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) :
+    ‖P + Q‖ ^ 2 = 2 + 2 * scos P Q := by
+  have expand : ⟪P + Q, P + Q⟫ = ‖P‖ ^ 2 + 2 * ⟪P, Q⟫ + ‖Q‖ ^ 2 := by
+    rw [inner_add_left, inner_add_right, inner_add_right,
+      real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq, real_inner_comm Q P]
+    ring
+  rw [← real_inner_self_eq_norm_sq, expand, hP, hQ, scos]
+  ring
+
+/-- Spherical cosine is symmetric (the inner product is). -/
+theorem scos_comm (P Q : E) : scos P Q = scos Q P := by
+  unfold scos; exact real_inner_comm P Q
+
+/-- For **non-antipodal** model points (`scos P Q > -1`) the sum `P + Q` is nonzero, so the
+normalised sum below is well defined. -/
+theorem norm_add_pos {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q)
+    (hlt : (-1 : ℝ) < scos P Q) : 0 < ‖P + Q‖ := by
+  have hsq : ‖P + Q‖ ^ 2 = 2 + 2 * scos P Q := norm_add_sq_onSphere hP hQ
+  have hpos : (0 : ℝ) < ‖P + Q‖ ^ 2 := by rw [hsq]; linarith
+  nlinarith [norm_nonneg (P + Q), hpos]
+
+/-- The **spherical midpoint** of two model points: the renormalised sum.  For non-antipodal
+`P, Q` this is the point of the sphere on the perpendicular bisector plane of the chord `PQ`
+that lies on the shorter geodesic between them. -/
+noncomputable def sMidpoint (P Q : E) : E := (‖P + Q‖)⁻¹ • (P + Q)
+
+/-- The spherical midpoint is symmetric in its two endpoints. -/
+theorem sMidpoint_comm (P Q : E) : sMidpoint P Q = sMidpoint Q P := by
+  unfold sMidpoint; rw [add_comm P Q]
+
+/-- The spherical midpoint of two model points is again a model point (unit norm). -/
+theorem onSphere_sMidpoint {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q)
+    (hlt : (-1 : ℝ) < scos P Q) : OnSphere (sMidpoint P Q) := by
+  have hpos := norm_add_pos hP hQ hlt
+  unfold OnSphere sMidpoint
+  rw [norm_smul, norm_inv, norm_norm, inv_mul_cancel₀ (ne_of_gt hpos)]
+
+/-- Inner product of the midpoint with the **first** endpoint: `‖P + Q‖⁻¹ · (1 + scos P Q)`. -/
+theorem inner_sMidpoint_left {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) :
+    (⟪sMidpoint P Q, P⟫ : ℝ) = (‖P + Q‖)⁻¹ * (1 + scos P Q) := by
+  unfold sMidpoint
+  rw [real_inner_smul_left, inner_add_left, real_inner_self_eq_norm_sq, hP, real_inner_comm Q P]
+  simp only [scos]
+  ring
+
+/-- Inner product of the midpoint with the **second** endpoint: `‖P + Q‖⁻¹ · (scos P Q + 1)`. -/
+theorem inner_sMidpoint_right {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) :
+    (⟪sMidpoint P Q, Q⟫ : ℝ) = (‖P + Q‖)⁻¹ * (scos P Q + 1) := by
+  unfold sMidpoint
+  rw [real_inner_smul_left, inner_add_left, real_inner_self_eq_norm_sq, hQ]
+  simp only [scos]
+  ring
+
+/-- The midpoint has the **same spherical cosine** with each endpoint — the algebraic form of
+"equidistant from both". -/
+theorem scos_sMidpoint_equidist {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) :
+    scos (sMidpoint P Q) P = scos (sMidpoint P Q) Q := by
+  rw [scos, scos, inner_sMidpoint_left hP hQ, inner_sMidpoint_right hP hQ]
+  ring
+
+/-- The midpoint is **equidistant** from the two endpoints (in spherical distance). -/
+theorem sdist_sMidpoint_equidist {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) :
+    sdist (sMidpoint P Q) P = sdist (sMidpoint P Q) Q := by
+  unfold sdist
+  rw [inner_sMidpoint_left hP hQ, inner_sMidpoint_right hP hQ]
+  congr 1
+  ring
+
+/-- **Headline: the spherical midpoint bisects the geodesic arc.**  For non-antipodal model
+points the spherical distance from `P` to `sMidpoint P Q` is exactly half the spherical
+distance from `P` to `Q`.
+
+The engine is the half-angle identity `⟪P, sMidpoint P Q⟫ = cos ((arccos (scos P Q)) / 2)`:
+the inner product of `P` with the midpoint equals the cosine of half the angle `∠POQ`. -/
+theorem sdist_sMidpoint_bisect {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q)
+    (hlt : (-1 : ℝ) < scos P Q) :
+    sdist P (sMidpoint P Q) = sdist P Q / 2 := by
+  have hs_hi : scos P Q ≤ 1 := scos_le_one P Q hP hQ
+  have hpos := norm_add_pos hP hQ hlt
+  have h1s : (0 : ℝ) < 1 + scos P Q := by linarith
+  -- inner product of `P` with the midpoint
+  have hIM : (⟪P, sMidpoint P Q⟫ : ℝ) = (‖P + Q‖)⁻¹ * (1 + scos P Q) := by
+    rw [real_inner_comm P (sMidpoint P Q), inner_sMidpoint_left hP hQ]
+  have hnn : 0 ≤ (⟪P, sMidpoint P Q⟫ : ℝ) := by
+    rw [hIM]
+    exact mul_nonneg (inv_nonneg.mpr (norm_nonneg _)) (by linarith)
+  have hns : ‖P + Q‖ ^ 2 = 2 + 2 * scos P Q := norm_add_sq_onSphere hP hQ
+  have h1s' : (1 + scos P Q) ≠ 0 := ne_of_gt h1s
+  -- the square of that inner product is `(1 + scos P Q) / 2`
+  have hsq : (⟪P, sMidpoint P Q⟫ : ℝ) ^ 2 = (1 + scos P Q) / 2 := by
+    rw [hIM, mul_pow, inv_pow, hns,
+      show (2 : ℝ) + 2 * scos P Q = 2 * (1 + scos P Q) from by ring]
+    field_simp
+    ring
+  -- half-angle identity: the inner product is `cos ((arccos (scos P Q)) / 2)`
+  have hval : (⟪P, sMidpoint P Q⟫ : ℝ) = Real.cos (Real.arccos (scos P Q) / 2) := by
+    rw [Real.cos_half (by linarith [Real.arccos_nonneg (scos P Q), Real.pi_pos])
+        (Real.arccos_le_pi (scos P Q)),
+      Real.cos_arccos (le_of_lt hlt) hs_hi, ← Real.sqrt_sq hnn, hsq]
+  -- assemble: `sdist P M = arccos (cos (arccos (scos P Q) / 2)) = arccos (scos P Q) / 2`
+  have hsdM : sdist P (sMidpoint P Q) = Real.arccos (⟪P, sMidpoint P Q⟫) := rfl
+  have hsdPQ : sdist P Q = Real.arccos (scos P Q) := rfl
+  rw [hsdM, hval,
+    Real.arccos_cos (by linarith [Real.arccos_nonneg (scos P Q)])
+      (by linarith [Real.arccos_le_pi (scos P Q), Real.pi_pos]),
+    hsdPQ]
+
+/-- Symmetric form of the bisection: the midpoint is also at half the distance from `Q`. -/
+theorem sdist_sMidpoint_right {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q)
+    (hlt : (-1 : ℝ) < scos P Q) :
+    sdist Q (sMidpoint P Q) = sdist P Q / 2 := by
+  have hlt' : (-1 : ℝ) < scos Q P := by rw [scos_comm Q P]; exact hlt
+  rw [sMidpoint_comm, sdist_sMidpoint_bisect hQ hP hlt', sdist_comm Q P]
+
+/-- **The midpoint lies on the geodesic segment.**  Its two half-distances add back to the full
+spherical distance, so the triangle inequality holds with equality — `sMidpoint P Q` is a
+genuine arc midpoint, not merely an equidistant point off the geodesic. -/
+theorem sdist_sMidpoint_add {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q)
+    (hlt : (-1 : ℝ) < scos P Q) :
+    sdist P (sMidpoint P Q) + sdist (sMidpoint P Q) Q = sdist P Q := by
+  rw [sdist_sMidpoint_bisect hP hQ hlt, sdist_comm (sMidpoint P Q) Q,
+    sdist_sMidpoint_right hP hQ hlt]
+  ring
+
+end FeuerbachsTheoremOQ04

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -1,5 +1,22 @@
 # feuerbachs-theorem-oq-04 — Feuerbach's Theorem in Non-Euclidean Geometry
 
+## Session 2026-07-01 (researcher-11): re-confirm midpoint build-block; freed disk [BUILD-PENDING]
+
+**Mode**: REVISIT (own draft PR #32127). Re-attempted verification of
+`FeuerbachsTheoremOQ04Midpoint.lean` (181 L, 12 thm/1 def, **0 sorry / 0 axiom by
+construction**). Non-destructive typecheck `lake env lean <file>` from repo-root cache failed
+again, but the failure is a **moving cache-corruption target** — successive retries hit
+different torn blobs (`Finset/Sort.ir` → `Batteries List/Basic.olean.private` →
+`Batteries RBMap/Basic.olean.server`), i.e. concurrent agents tearing oleans on a disk pinned
+at 100%. Not this file's code. Freed ~3.5 G by removing two of my own superseded worktrees
+(negbinom oq-06-oq-02 = merged #32574; vieta oq-05 = merged #32213) — disk 826 Mi → 2.2 Gi.
+Cache blobs remain corrupt on host; a full `cache get` would be immediately re-torn and is not
+worth the churn. File left as **draft, verified-by-construction only** (mirrors ~20 merged
+sibling PRs on the identical `OnSphere/scos/sdist` API + standard `Real.cos_half/cos_arccos/
+arccos_cos/sqrt_sq` lemmas confirmed present). **NEXT AGENT / deployer**: once host disk clears
+and the mathlib cache is healthy, run `docker-build.sh Proofs.FeuerbachsTheoremOQ04Midpoint`;
+if green, flip PR #32127 to ready and mark VERIFIED.
+
 ## Session 2026-06-28 (researcher-4): antipodal-pole layer — two-pole description of a spherical circle [BUILD-PENDING: Docker outage]
 
 **Mode**: ACT (CONTINUE). The metric layer (`sdist_isMetric`, point separation, triangle

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -464,3 +464,63 @@ refinement.
 REMAINING: (1) uniqueness / interior-incenter refinement; (2) spherical nine-point circle;
 (3) the Feuerbach tangency itself (nine-point circle tangent to the incircle). The hard
 existence-of-incenter obstacle is now cleared.
+
+## Session 2026-07-01 (researcher-11): spherical MIDPOINT layer — arc bisection [BUILD-BLOCKED: mathlib cache corruption]
+
+**Mode**: ACT (CONTINUE). Attacks remaining item **(2) spherical nine-point circle**: the
+classical nine-point circle passes through the three *midpoints of the triangle's sides*, so a
+spherical nine-point construction first needs a verified **midpoint of a spherical segment**.
+This session builds that primitive in a **collision-free companion file**
+`proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean` (new file, auto-discovered by lake globs,
+imports `Proofs.FeuerbachsTheoremOQ04`), so it does **not** touch the shared
+`FeuerbachsTheoremOQ04.lean` and cannot clobber the in-flight incenter/bisector work.
+
+**Outcome**: CODE COMPLETE (10 declarations, ~181 L), **but build verification is BLOCKED by a
+mathlib cache-blob corruption affecting all Docker builds on the host** — see below. NOT claimed
+verified per integrity policy. Committed + pushed (branch `research/feuerbach-oq04-midpoint`).
+
+### Delivered (`FeuerbachsTheoremOQ04Midpoint.lean`)
+- **`sMidpoint P Q := ‖P + Q‖⁻¹ • (P + Q)`** — the normalised sum (perpendicular-bisector-plane
+  point on the near side), for non-antipodal `P, Q` (`scos P Q > -1` ⟺ `P + Q ≠ 0`).
+- **`norm_add_sq_onSphere`** : `‖P + Q‖² = 2 + 2·scos P Q` (addition analogue of merged `chord_sq`).
+- **`norm_add_pos`** : non-antipodal ⇒ `‖P + Q‖ > 0` (well-definedness).
+- **`onSphere_sMidpoint`** : the midpoint is a unit vector (`norm_smul`/`norm_inv`/`inv_mul_cancel₀`).
+- **`inner_sMidpoint_left`/`_right`** : `⟪M,P⟫ = ⟪M,Q⟫ = ‖P+Q‖⁻¹·(1 + scos P Q)` (equidistant, algebraic).
+- **`scos_sMidpoint_equidist`, `sdist_sMidpoint_equidist`** : the midpoint is equidistant from both endpoints.
+- **`sdist_sMidpoint_bisect`** (headline) : `sdist P (sMidpoint P Q) = sdist P Q / 2`. ENGINE:
+  the half-angle identity `⟪P,M⟫ = cos((arccos (scos P Q))/2)` via `Real.cos_half` +
+  `Real.cos_arccos`, combined with `⟪P,M⟫ ≥ 0` and `⟪P,M⟫² = (1+scos)/2` (so `⟪P,M⟫ = √((1+scos)/2)`),
+  then `Real.arccos_cos` on `[0,π]`.
+- **`sdist_sMidpoint_right`** : symmetric `sdist Q (sMidpoint P Q) = sdist P Q / 2` (via `sMidpoint_comm`).
+- **`sdist_sMidpoint_add`** : `sdist P M + sdist M Q = sdist P Q` — triangle inequality holds with
+  equality, so `M` lies ON the geodesic segment (a genuine arc midpoint, not merely equidistant).
+
+### RECIPES (for reuse)
+- Half-distance from a normalised-sum point: `Real.cos_half {x} (hl : -π ≤ x) (hr : x ≤ π) :
+  cos (x/2) = √((1 + cos x)/2)`, instantiated at `x = arccos (scos P Q)` (∈ `[0,π]` always);
+  recover the inner product as `√(·²)` via `Real.sqrt_sq` on the nonneg inner product.
+- `‖P+Q‖² = 2 + 2⟪P,Q⟫` mirrors merged `chord_sq` (`‖P−Q‖² = 2 − 2·scos`); `inner_add_*` + `ring`.
+- `arccos x ≤ π/2 ↔ 0 ≤ x` is `Real.arccos_le_pi_div_two` (found but not needed — the `[0,π]`
+  bound on `arccos (scos)/2` suffices for `Real.arccos_cos`).
+
+### BUILD BLOCKER (infrastructure, NOT a code error — file elaborates up to `import Mathlib`)
+Docker was freshly restarted this session (daemon was down; brought up via `open -a Docker`).
+Every subsequent build fails in the **Mathlib cache stage**, not on this file's Lean code:
+`lake exe cache get` downloads all 7727 blobs, but `f0b4cfbf7f287672.ltar` is *consistently*
+flagged `removing corrupted file`, so `Mathlib/RingTheory/Kaehler/Basic.olean.server` is absent
+and `import Mathlib` fails with `failed to open file '…/Kaehler/Basic.olean.server'` — at
+`FeuerbachsTheoremOQ04.lean:53` (the dependency's import) and at this file's line 46. This
+affects **all** concurrent agent builds (8 `lean-build-*` containers were running), i.e. the
+shared `lean-mathlib-cache` blob is corrupt upstream/on-host. Did NOT restart Docker again
+(would kill 8 concurrent builds). The Lean proofs use only `ring`/`linarith`/`nlinarith`/
+`field_simp` + named `Real.cos_half`/`cos_arccos`/`arccos_cos`/`sqrt_sq` (all verified to exist
+in `proofs/.lake/…/Trigonometric/{Basic,Inverse}.lean`), so correctness is highly likely; per
+policy it is **not** claimed VERIFIED until a clean docker build. **NEXT AGENT**: re-run
+`docker-build.sh Proofs.FeuerbachsTheoremOQ04Midpoint` once the cache blob is healthy; if green,
+flip PR to ready and mark VERIFIED.
+
+### Next steps (unchanged direction)
+1. Verify this file once the mathlib cache recovers.
+2. Spherical nine-point circle: the circle through the three side midpoints (`sMidpoint` of each
+   pair of triangle vertices) — needs a "circle through 3 spherical points" existence lemma.
+3. Then the spherical Feuerbach tangency (nine-point circle tangent to the incircle).


### PR DESCRIPTION
## Summary

Adds a **collision-free companion file** `proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean` for the spherical Feuerbach programme: the **spherical midpoint** of two model points and the proof that it **bisects the geodesic arc** between them.

This is the side-midpoint primitive a **spherical nine-point circle** needs (the classical nine-point circle passes through the three side midpoints). It is orthogonal to the merged incircle / incenter / bisector layers and does **not** touch the shared `FeuerbachsTheoremOQ04.lean`.

### Contents (10 declarations, ~181 L, imports `Proofs.FeuerbachsTheoremOQ04`)
- `sMidpoint P Q := ‖P + Q‖⁻¹ • (P + Q)` — normalised sum (well defined for non-antipodal `P,Q`, i.e. `scos P Q > -1`).
- `norm_add_sq_onSphere` : `‖P+Q‖² = 2 + 2·scos P Q` (addition analogue of merged `chord_sq`).
- `norm_add_pos`, `onSphere_sMidpoint` — well-definedness and unit-norm.
- `inner_sMidpoint_left`/`_right`, `scos_sMidpoint_equidist`, `sdist_sMidpoint_equidist` — the midpoint is equidistant from both endpoints.
- **`sdist_sMidpoint_bisect`** (headline) : `sdist P (sMidpoint P Q) = sdist P Q / 2` — via the half-angle identity `⟪P,M⟫ = cos((arccos (scos P Q))/2)` (`Real.cos_half`).
- `sdist_sMidpoint_right`, and `sdist_sMidpoint_add` : `sdist P M + sdist M Q = sdist P Q` (the midpoint lies **on** the geodesic segment — triangle inequality with equality).

## ⚠️ Build status: NOT YET VERIFIED (DRAFT)

Build verification is blocked by a **host-wide mathlib cache-blob corruption**, not by this file's code. Across 4 Docker build attempts this session, `lake exe cache get` consistently flags `f0b4cfbf7f287672.ltar` as corrupt, so `Mathlib/RingTheory/Kaehler/Basic.olean.server` is missing and **`import Mathlib` fails for all builds on the host** (8 concurrent `lean-build-*` containers were running). The file elaborates up to the import; the proofs use only `ring`/`linarith`/`nlinarith`/`field_simp` + named `Real` trig lemmas confirmed present in the vendored Mathlib.

Per the axiom-integrity policy this is **left as a draft and not claimed verified**. Once the cache blob is healthy, re-run `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremOQ04Midpoint`; if green, flip to ready and mark VERIFIED. Session notes are in `research/problems/feuerbachs-theorem-oq-04/knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)