### PR TITLE
research(hurwitz-oq-03-oq-01): sharpness of the commutative Hurwitz bound [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/HurwitzCommSharp.lean
+++ b/proofs/Proofs/HurwitzCommSharp.lean
@@ -1,0 +1,79 @@
+/-
+  Hurwitz's Theorem (Erdős/gallery #357 circle) — OQ-03-OQ-01, incomplete-01
+  Sharpness of the commutative Hurwitz bound.
+
+  Context. The parent entry `Proofs/HurwitzOnlyIf.lean` (gallery
+  `hurwitz-theorem-oq-03-oq-01`) proves the "only-if" direction of Hurwitz's theorem
+  in the COMMUTATIVE (field) case via the Gelfand–Mazur theorem:
+
+      hurwitz_field_case :
+        (F : normed field over ℝ) → finrank ℝ F ∈ {1, 2, 4, 8}
+
+  obtained from the sharper `finrank ℝ F = 1 ∨ finrank ℝ F = 2`. That is an UPPER
+  bound only: it shows no commutative real normed division algebra can have dimension
+  outside {1, 2}. The parent leaves the non-commutative division-ring case as a `sorry`
+  (Clifford algebras / Radon–Hurwitz numbers, not yet in Mathlib).
+
+  This companion supplies the missing REALIZABILITY / lower direction for the
+  commutative case: both admissible values are actually attained —
+
+      finrank ℝ ℝ = 1        (ℝ realizes dimension 1)
+      finrank ℝ ℂ = 2        (ℂ realizes dimension 2)
+
+  — so the bound {1, 2} is SHARP: the set of ℝ-dimensions realized by commutative real
+  normed division algebras is *exactly* {1, 2}, not merely a subset. This upgrades the
+  parent's one-sided bound for the commutative case to an exact characterization.
+  Nothing here touches the parent's hard non-commutative `sorry`.
+
+  Fully machine-checked: 0 axioms, 0 sorries, no `native_decide`.
+-/
+import Mathlib
+
+open Module
+
+namespace HurwitzCommSharp
+
+/-- The admissible dimensions {1, 2, 4, 8} for normed division algebras over ℝ,
+    matching `HurwitzOnlyIf.admissibleDimensions` in the parent file. -/
+def admissibleDimensions : Set ℕ := {1, 2, 4, 8}
+
+/-- **Upper bound (Gelfand–Mazur).** Any normed field over ℝ has `finrank ℝ F` equal to
+    `1` or `2`. This is the commutative case of Hurwitz's only-if direction, reproduced
+    from the parent file so this entry is self-contained; ℝ and ℂ are the only options. -/
+theorem finrank_normed_field_eq_one_or_two (F : Type*) [NormedField F] [NormedAlgebra ℝ F] :
+    finrank ℝ F = 1 ∨ finrank ℝ F = 2 := by
+  obtain h | h := NormedAlgebra.Real.nonempty_algEquiv_or F
+  · obtain ⟨e⟩ := h
+    exact Or.inl (e.toLinearEquiv.finrank_eq.trans (CommSemiring.finrank_self ℝ))
+  · obtain ⟨e⟩ := h
+    exact Or.inr (e.toLinearEquiv.finrank_eq.trans Complex.finrank_real_complex)
+
+/-- Every normed field over ℝ has admissible finrank (commutative Hurwitz, upper bound). -/
+theorem finrank_normed_field_admissible (F : Type*) [NormedField F] [NormedAlgebra ℝ F] :
+    finrank ℝ F ∈ admissibleDimensions := by
+  simp only [admissibleDimensions, Set.mem_insert_iff, Set.mem_singleton_iff]
+  rcases finrank_normed_field_eq_one_or_two F with h | h <;> omega
+
+/-- **Realizability of dimension 1.** ℝ is a commutative real normed division algebra of
+    dimension `1`, so the value `1` in the Hurwitz bound is attained. -/
+theorem finrank_real_self : finrank ℝ ℝ = 1 := CommSemiring.finrank_self ℝ
+
+/-- **Realizability of dimension 2.** ℂ is a commutative real normed division algebra of
+    dimension `2`, so the value `2` in the Hurwitz bound is attained. -/
+theorem finrank_complex : finrank ℝ ℂ = 2 := Complex.finrank_real_complex
+
+/-- **Sharpness of the commutative Hurwitz bound.**
+
+    The upper bound `finrank ℝ F ∈ {1, 2}` for commutative real normed division algebras
+    is sharp: both endpoints are realized (ℝ gives `1`, ℂ gives `2`) and no such algebra
+    attains any other dimension. Equivalently, the set of ℝ-dimensions of commutative real
+    normed division algebras is *exactly* `{1, 2}`. This is the realizability direction the
+    parent's one-sided bound lacks. -/
+theorem comm_bound_sharp :
+    finrank ℝ ℝ = 1 ∧ finrank ℝ ℂ = 2 ∧
+      ∀ (F : Type) [NormedField F] [NormedAlgebra ℝ F], finrank ℝ F = 1 ∨ finrank ℝ F = 2 := by
+  refine ⟨finrank_real_self, finrank_complex, ?_⟩
+  intro F _ _
+  exact finrank_normed_field_eq_one_or_two F
+
+end HurwitzCommSharp

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/annotations.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "ann-hcs-framing",
+    "proofId": "hurwitz-theorem-oq-03-oq-01-incomplete-01",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "From an upper bound to an exact characterization",
+    "content": "Hurwitz's only-if theorem says a finite-dimensional real normed division algebra has dimension in {1,2,4,8}. The parent entry (HurwitzOnlyIf.lean) proves the COMMUTATIVE case as a one-sided upper bound — any normed field over ℝ has finrank 1 or 2, by Gelfand-Mazur — and leaves the non-commutative division-ring case as a sorry. A dimension bound alone is not a classification: one must also exhibit algebras realizing each allowed value. This file adds that realizability direction for the commutative case, making the bound {1,2} exact.",
+    "mathContext": "Commutative real normed division algebra = normed field over ℝ; Gelfand-Mazur ⇒ it is ℝ or ℂ.",
+    "significance": "Separates 'no dimension outside {1,2}' (parent) from 'exactly {1,2} occur' (this file). The latter is the complete commutative classification.",
+    "relatedConcepts": ["Hurwitz's theorem", "normed division algebra", "Gelfand-Mazur theorem", "Frobenius theorem"],
+    "prerequisites": ["normed field", "finrank", "ℝ-algebra"],
+    "tags": ["hurwitz", "classification", "sharpness"]
+  },
+  {
+    "id": "ann-hcs-upper-bound",
+    "proofId": "hurwitz-theorem-oq-03-oq-01-incomplete-01",
+    "range": { "startLine": 43, "endLine": 64 },
+    "type": "theorem",
+    "title": "Gelfand–Mazur upper bound (reproduced)",
+    "content": "finrank_normed_field_eq_one_or_two reproduces the parent's argument: NormedAlgebra.Real.nonempty_algEquiv_or gives an ℝ-algebra isomorphism F ≅ ℝ or F ≅ ℂ; transporting finrank across the induced linear equivalence (LinearEquiv.finrank_eq) with CommSemiring.finrank_self ℝ (=1) or Complex.finrank_real_complex (=2) yields finrank ℝ F ∈ {1,2}. finrank_normed_field_admissible then packages this into the admissible set {1,2,4,8} via omega.",
+    "mathContext": "$F \\cong_{\\mathbb R\\text{-alg}} \\mathbb R$ or $\\mathbb C \\Rightarrow \\operatorname{finrank}_{\\mathbb R}F \\in \\{1,2\\}$.",
+    "significance": "Supplies the 'no other value' half of the sharpness statement, self-contained so the entry stands alone.",
+    "relatedConcepts": ["Gelfand-Mazur theorem", "algebra isomorphism", "finrank of a linear equivalence"],
+    "prerequisites": ["NormedAlgebra ℝ F", "AlgEquiv", "LinearEquiv.finrank_eq"],
+    "tags": ["gelfand-mazur", "upper-bound"]
+  },
+  {
+    "id": "ann-hcs-sharpness",
+    "proofId": "hurwitz-theorem-oq-03-oq-01-incomplete-01",
+    "range": { "startLine": 66, "endLine": 79 },
+    "type": "theorem",
+    "title": "Realizability and sharpness of {1,2}",
+    "content": "finrank_real_self (finrank ℝ ℝ = 1) and finrank_complex (finrank ℝ ℂ = 2) exhibit commutative real normed division algebras of each admissible dimension. comm_bound_sharp bundles both endpoints with the upper bound: both 1 and 2 are attained and no commutative real normed division algebra has any other dimension, so the set of realized dimensions is EXACTLY {1,2}. This is the realizability/lower direction the parent's impossibility bound lacked.",
+    "mathContext": "$\\operatorname{finrank}_{\\mathbb R}\\mathbb R=1$, $\\operatorname{finrank}_{\\mathbb R}\\mathbb C=2$, and these are the only values $\\Rightarrow$ realized set $=\\{1,2\\}$.",
+    "significance": "Completes the commutative half of the {1,2,4,8} classification; the non-commutative case (dim 4, 8; Clifford/Radon-Hurwitz) remains the parent's open sorry.",
+    "relatedConcepts": ["realizability", "sharp bound", "complex numbers as ℝ-algebra"],
+    "prerequisites": ["finrank ℝ ℝ", "Complex.finrank_real_complex"],
+    "tags": ["sharpness", "realizability", "hurwitz"]
+  }
+]

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "hurwitz-theorem-oq-03-oq-01-incomplete-01",
+  "title": "Sharpness of the Commutative Hurwitz Bound: dim ∈ {1,2} is Exact",
+  "slug": "hurwitz-theorem-oq-03-oq-01-incomplete-01",
+  "description": "The parent entry hurwitz-theorem-oq-03-oq-01 (HurwitzOnlyIf.lean) proves the commutative (field) case of Hurwitz's only-if theorem via Gelfand-Mazur: any normed field over ℝ has finrank ℝ F = 1 or 2, hence in {1,2,4,8}. That is a one-sided UPPER bound — it rules out dimensions outside {1,2} but does not show those values occur. This entry supplies the missing REALIZABILITY direction for the commutative case: dimension 1 is attained by ℝ (finrank_real_self: finrank ℝ ℝ = 1) and dimension 2 by ℂ (finrank_complex: finrank ℝ ℂ = 2). Combined with the reproduced upper bound (finrank_normed_field_eq_one_or_two, finrank_normed_field_admissible), this yields comm_bound_sharp: both endpoints are realized and no other dimension occurs, so the set of ℝ-dimensions of commutative real normed division algebras is EXACTLY {1,2}. The parent's hard non-commutative (division ring) case, requiring Clifford algebras / Radon-Hurwitz numbers, is untouched and remains open.",
+  "leanFile": {
+    "path": "Proofs/HurwitzCommSharp.lean",
+    "namespace": "HurwitzCommSharp",
+    "lineCount": 79,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "sorryCount": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius (realizability/sharpness direction); upper bound reproduced from parent HurwitzOnlyIf.lean; Gelfand-Mazur from Mathlib",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HurwitzCommSharp.lean",
+    "tags": [
+      "algebra",
+      "normed-division-algebra",
+      "hurwitz-theorem",
+      "gelfand-mazur",
+      "finrank",
+      "field-theory",
+      "mathlib-api",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-01",
+    "lineCount": 79,
+    "originalContributions": [
+      "finrank_real_self / finrank_complex: the realizability endpoints — ℝ is a commutative real normed division algebra of dimension 1 (finrank ℝ ℝ = 1) and ℂ of dimension 2 (finrank ℝ ℂ = 2). The parent only bounds the dimension from above; these witness that both admissible values actually occur.",
+      "comm_bound_sharp: the parent's commutative bound finrank ℝ F ∈ {1,2} is SHARP — both endpoints are realized (by ℝ and ℂ) and no commutative real normed division algebra attains any other dimension. Equivalently, the set of ℝ-dimensions of commutative real normed division algebras is exactly {1,2}, upgrading the parent's one-sided bound to an exact characterization.",
+      "finrank_normed_field_eq_one_or_two / finrank_normed_field_admissible: the Gelfand-Mazur upper bound, reproduced self-contained so this entry stands alone; used as the 'no other value' half of comm_bound_sharp."
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. #print axioms reports only propext, Classical.choice, Quot.sound for all results — no Lean.ofReduceBool, no sorryAx. Proofs use NormedAlgebra.Real.nonempty_algEquiv_or (Gelfand-Mazur), CommSemiring.finrank_self, Complex.finrank_real_complex, LinearEquiv.finrank_eq, and omega. Ordinary foundational axioms (propext, Classical.choice, Quot.sound) do not count as assumptions. This entry does NOT resolve the parent's non-commutative division-ring sorry (Clifford/Radon-Hurwitz), which stays open.",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "hurwitz-theorem-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry (HurwitzOnlyIf.lean) proves the commutative case of Hurwitz's only-if theorem as an UPPER bound: finrank ℝ F ∈ {1,2} via Gelfand-Mazur, leaving the non-commutative case as a sorry. This entry adds the realizability/lower direction — ℝ and ℂ attain dimensions 1 and 2 — making the commutative bound exact ({1,2} realized, sharp)."
+    },
+    {
+      "targetId": "hurwitz-theorem",
+      "relationship": "extends",
+      "description": "The top-level Hurwitz entry states the {1,2,4,8} classification. This entry certifies exactness of the commutative subcase {1,2}."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Hurwitz's theorem (1898) classifies the finite-dimensional real normed division algebras: their dimension must lie in {1,2,4,8}, realized by ℝ, ℂ, the quaternions ℍ, and the octonions 𝕆. The 'only-if' (impossibility) direction is the hard part. In the commutative case A is a field, and the Gelfand-Mazur theorem (any normed ℝ-algebra that is a field is ℝ or ℂ) settles it: dim ∈ {1,2}. Mathlib formalized Gelfand-Mazur, letting the parent entry discharge the commutative upper bound. But a bound is only half a classification — one must also exhibit algebras realizing each allowed dimension. ℝ and ℂ do exactly that for {1,2}.",
+    "problemStatement": "The parent proves finrank ℝ F ∈ {1,2} for every commutative real normed division algebra F (upper bound). Show this bound is sharp: exhibit commutative real normed division algebras of each dimension 1 and 2, so that the set of realized dimensions is exactly {1,2}.",
+    "proofStrategy": "Realizability: ℝ is a real normed field with finrank ℝ ℝ = 1 (CommSemiring.finrank_self); ℂ is a real normed field with finrank ℝ ℂ = 2 (Complex.finrank_real_complex). Upper bound: reproduce the parent's Gelfand-Mazur argument — NormedAlgebra.Real.nonempty_algEquiv_or gives an ℝ-algebra isomorphism F ≅ ℝ or F ≅ ℂ, and transporting finrank across the induced linear equivalence yields 1 or 2. Bundle the two endpoints and the upper bound into comm_bound_sharp.",
+    "keyInsights": [
+      "A dimension bound and a classification are different claims: the parent proves finrank ℝ F ≤-in-{1,2}, but sharpness additionally requires witnesses for each value. ℝ and ℂ are those witnesses.",
+      "Gelfand-Mazur makes the commutative case an exact ℝ-or-ℂ dichotomy, so {1,2} is not just an upper bound but the precise set of achievable dimensions once realizability is added.",
+      "The realizability endpoints are elementary (finrank of ℝ over ℝ and of ℂ over ℝ) yet are exactly what turns the parent's one-sided bound into a complete characterization of the commutative case.",
+      "None of this touches the non-commutative division-ring case (ℍ at dim 4, and the non-associative octonions at dim 8), which needs Clifford-algebra / Radon-Hurwitz machinery and remains the parent's open sorry."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Context",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Explains that the parent proves only the commutative UPPER bound finrank ℝ F ∈ {1,2} via Gelfand-Mazur and leaves the non-commutative case as a sorry; this file adds the realizability/sharpness direction so the commutative bound becomes exact.",
+      "mathContext": "Hurwitz: real normed division algebras have dimension in $\\{1,2,4,8\\}$. Commutative case: Gelfand-Mazur $\\Rightarrow \\dim \\in \\{1,2\\}$."
+    },
+    {
+      "id": "upper-bound",
+      "title": "The Gelfand–Mazur Upper Bound",
+      "startLine": 43,
+      "endLine": 64,
+      "summary": "admissibleDimensions := {1,2,4,8}. finrank_normed_field_eq_one_or_two reproduces the parent's Gelfand-Mazur argument (F ≅ ℝ or ℂ ⇒ finrank 1 or 2); finrank_normed_field_admissible packages it into {1,2,4,8}.",
+      "mathContext": "$F$ normed field over $\\mathbb{R} \\Rightarrow \\operatorname{finrank}_{\\mathbb R} F \\in \\{1,2\\} \\subseteq \\{1,2,4,8\\}$."
+    },
+    {
+      "id": "sharpness",
+      "title": "Realizability and Sharpness",
+      "startLine": 66,
+      "endLine": 79,
+      "summary": "finrank_real_self (finrank ℝ ℝ = 1) and finrank_complex (finrank ℝ ℂ = 2) exhibit the endpoint algebras; comm_bound_sharp combines them with the upper bound to conclude the set of realized dimensions is exactly {1,2}.",
+      "mathContext": "$\\operatorname{finrank}_{\\mathbb R}\\mathbb R = 1$, $\\operatorname{finrank}_{\\mathbb R}\\mathbb C = 2$; both attained, none other $\\Rightarrow$ realized set $= \\{1,2\\}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 79-line file (0 sorries, 0 axioms, no native_decide) upgrades the commutative case of Hurwitz's only-if theorem from the parent's one-sided upper bound (finrank ℝ F ∈ {1,2} via Gelfand-Mazur) to an exact characterization: dimension 1 is realized by ℝ and dimension 2 by ℂ, so the set of ℝ-dimensions of commutative real normed division algebras is exactly {1,2} (comm_bound_sharp).",
+    "implications": "Sharpness confirms that the commutative half of the {1,2,4,8} classification is complete — the bound {1,2} is achieved, not merely respected. This is the realizability counterpart the parent's impossibility bound lacked.",
+    "openQuestions": [
+      "The non-commutative division-ring case (the parent's hurwitz_only_if_ring sorry) remains OPEN: proving no real normed division ring has dimension outside {1,2,4,8} needs Clifford-algebra / Radon-Hurwitz theory not yet in Mathlib.",
+      "Realizability of dimensions 4 and 8 (quaternions ℍ and octonions 𝕆) as normed division algebras — the non-commutative/non-associative endpoints — is a natural companion to complete the sharpness of the full {1,2,4,8} bound."
+    ]
+  },
+  "references": [
+    {
+      "authors": "A. Hurwitz",
+      "title": "Über die Komposition der quadratischen Formen",
+      "year": 1922,
+      "venue": "Mathematische Annalen",
+      "note": "Origin of the {1,2,4,8} classification of normed division algebras."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides the Gelfand-Mazur theorem (NormedAlgebra.Real.nonempty_algEquiv_or) and Complex.finrank_real_complex used here."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The parent entry [`hurwitz-theorem-oq-03-oq-01`](../tree/main/src/data/proofs/hurwitz-theorem-oq-03-oq-01) (`HurwitzOnlyIf.lean`) proves the **commutative** case of Hurwitz's only-if theorem as a one-sided **upper bound** — any normed field over ℝ has `finrank ℝ F ∈ {1,2}` via Gelfand–Mazur — and leaves the non-commutative division-ring case as a `sorry` (Clifford algebras / Radon–Hurwitz numbers, not yet in Mathlib).

A bound is only half a classification. This entry adds the missing **realizability / sharpness** direction for the commutative case:

- **`finrank_real_self`** — `finrank ℝ ℝ = 1` (ℝ realizes dimension 1).
- **`finrank_complex`** — `finrank ℝ ℂ = 2` (ℂ realizes dimension 2).
- **`finrank_normed_field_eq_one_or_two` / `finrank_normed_field_admissible`** — the Gelfand–Mazur upper bound, reproduced self-contained.
- **`comm_bound_sharp`** — combines them: both endpoints are attained and no commutative real normed division algebra has any other dimension, so the set of realized ℝ-dimensions is **exactly `{1,2}`**. This upgrades the parent's one-sided bound to an exact characterization of the commutative case.

The parent's hard non-commutative `sorry` (dimensions 4, 8 via ℍ/𝕆) is **untouched and remains open**.

## Verification

- **0 axioms, 0 sorries, no `native_decide`.** `#print axioms` on all results reports only `[propext, Classical.choice, Quot.sound]` (foundational — no `Lean.ofReduceBool`, no `sorryAx`).
- Docker build clean (`Built Proofs.HurwitzCommSharp`, no warnings).
- 5 theorems, 1 definition, 79 lines. Status: **verified**.

## Files

- `proofs/Proofs/HurwitzCommSharp.lean` — the formalization
- `src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/{meta.json,annotations.json}` — gallery integration (cross-referenced to `hurwitz-theorem-oq-03-oq-01` and `hurwitz-theorem`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)