### PR TITLE
research(stars-and-bars-oq-05): marginal weak-composition count with fixed first part [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/StarsAndBarsWeakCompositionsOQ05.lean
+++ b/proofs/Proofs/StarsAndBarsWeakCompositionsOQ05.lean
@@ -1,0 +1,181 @@
+import Mathlib.Data.Sym.Card
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Tactic
+import Proofs.StarsAndBarsWeakCompositions
+
+/-
+# Stars and Bars, marginal count: weak compositions with a fixed first part
+
+## What This Proves
+
+The parent entry `StarsAndBarsWeakCompositions` proves the master count
+
+  Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} = (n + k - 1).choose n,
+
+the number of *weak compositions* of `n` into `k` parts (functions `Fin k → ℕ`
+summing to `n`). This child proves the natural **conditional refinement**: if we
+*fix the first part* to a value `d ≤ n`, the number of such weak compositions is
+the stars-and-bars count one dimension down,
+
+  Nat.card {f : Fin k → ℕ // (∑ i, f i = n) ∧ f 0 = d} = (n - d + (k - 1) - 1).choose (n - d),
+
+i.e. the number of weak compositions of `n - d` into `k - 1` parts. Summing this
+marginal over `d = 0 … n` recovers the parent's total — a hockey-stick / Zhu Shijie
+consistency check.
+
+## The engine
+
+The single idea is the **drop-the-first-coordinate bijection**
+
+  f  ↦  Fin.tail f       (forward: forget `f 0`, keep the tail)
+  g  ↦  Fin.cons d g      (inverse: prepend the fixed value `d`)
+
+between weak compositions of `n` into `k = m+1` parts with `f 0 = d` and weak
+compositions of `n - d` into `m` parts. `Fin.sum_univ_succ` splits the sum as
+`f 0 + ∑ tail`, so fixing `f 0 = d` turns `∑ f = n` into `∑ tail = n - d`
+(using `d ≤ n`). Transporting cardinality across this equiv with `Nat.card_congr`
+and invoking the parent master count on the smaller instance gives the marginal
+count; the summation identity then follows from Mathlib's hockey-stick lemma
+`Nat.sum_range_add_choose`.
+
+## What Mathlib has — and what this adds
+
+Mathlib counts weak compositions/multisets via `Sym` and `Nat.multichoose`, and it
+has the hockey-stick identity `Nat.sum_range_add_choose`, but it has **no** lemma
+for a weak-composition count *conditioned on one coordinate's value*. The bijection
+is short but genuinely new content and must be composed with the parent's master
+count.
+
+## Note on the source sketch
+
+The problem sketch's worked example ("marginals `15,10,6,3,1` summing to `35`") is
+incorrect: the total number of weak compositions of `4` into `3` parts is
+`C(6,2) = 15`, not `35`, and the correct marginals are `5,4,3,2,1` (the count with
+`f 0 = d` is `C(5-d, 4-d) = 5-d`). The verified `example`s below record the correct
+values.
+-/
+
+open Finset
+
+namespace StarsAndBarsMarginal
+
+/-- **Drop-the-first-coordinate bijection.** Weak compositions of `n` into `m + 1`
+parts whose first part is exactly `d` (with `d ≤ n`) biject with weak compositions
+of `n - d` into `m` parts: forget `f 0` and keep `Fin.tail f`; conversely prepend
+the fixed value `d` with `Fin.cons d g`. -/
+def dropFirstEquiv (m n d : ℕ) (hd : d ≤ n) :
+    {f : Fin (m + 1) → ℕ // (∑ i, f i = n) ∧ f 0 = d} ≃
+      {g : Fin m → ℕ // ∑ i, g i = n - d} where
+  toFun f := ⟨Fin.tail f.1, by
+    have hsum := f.2.1
+    rw [Fin.sum_univ_succ, f.2.2] at hsum
+    -- hsum : d + ∑ i, f.1 i.succ = n ; goal : ∑ i, Fin.tail f.1 i = n - d
+    show ∑ i : Fin m, f.1 i.succ = n - d
+    omega⟩
+  invFun g := ⟨Fin.cons d g.1, by
+    refine ⟨?_, ?_⟩
+    · rw [Fin.sum_univ_succ, Fin.cons_zero]
+      simp only [Fin.cons_succ]
+      rw [g.2]
+      omega
+    · rw [Fin.cons_zero]⟩
+  left_inv := by
+    rintro ⟨f, hsum, hf0⟩
+    apply Subtype.ext
+    show Fin.cons d (Fin.tail f) = f
+    rw [← hf0]
+    exact Fin.cons_self_tail f
+  right_inv := by
+    rintro ⟨g, hg⟩
+    apply Subtype.ext
+    funext i
+    simp [Fin.tail, Fin.cons_succ]
+
+/-- **Marginal count.** Fixing the first part of a weak composition to `d ≤ n`
+gives a `(k-1)`-part stars-and-bars number: the number of weak compositions of `n`
+into `k ≥ 1` parts with `f 0 = d` equals `(n - d + (k-1) - 1).choose (n - d)`,
+the number of weak compositions of `n - d` into `k - 1` parts. -/
+theorem card_weakComposition_first_eq (k n d : ℕ) [NeZero k] (hd : d ≤ n) :
+    Nat.card {f : Fin k → ℕ // (∑ i, f i = n) ∧ f 0 = d}
+      = (n - d + (k - 1) - 1).choose (n - d) := by
+  obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by have := NeZero.pos k; omega⟩
+  simp only [Nat.add_sub_cancel]
+  rw [Nat.card_congr (dropFirstEquiv m n d hd), Nat.card_eq_fintype_card]
+  exact StarsAndBars.card_weakComposition m (n - d)
+
+/-- **Consistency (hockey stick).** Summing the marginal count over all admissible
+first parts `d = 0 … n` recovers the parent's total count of weak compositions of
+`n` into `k` parts, `(n + k - 1).choose (k - 1)`. -/
+theorem sum_marginals_eq_total (k n : ℕ) [NeZero k] :
+    (∑ d ∈ range (n + 1),
+        Nat.card {f : Fin k → ℕ // (∑ i, f i = n) ∧ f 0 = d})
+      = (n + k - 1).choose (k - 1) := by
+  obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by have := NeZero.pos k; omega⟩
+  -- Rewrite each summand by the marginal count.
+  have hstep : (∑ d ∈ range (n + 1),
+        Nat.card {f : Fin (m + 1) → ℕ // (∑ i, f i = n) ∧ f 0 = d})
+      = ∑ d ∈ range (n + 1), (n - d + m - 1).choose (n - d) := by
+    refine Finset.sum_congr rfl ?_
+    intro d hd
+    have hdn : d ≤ n := by simpa [Nat.lt_succ_iff] using (Finset.mem_range.mp hd)
+    rw [card_weakComposition_first_eq (m + 1) n d hdn]
+    simp only [Nat.add_sub_cancel]
+  rw [hstep]
+  -- Split on whether there is any remaining part after the first.
+  rcases Nat.eq_zero_or_pos m with hm | hm
+  · -- k = 1: only the `d = n` term survives, contributing `1`.
+    subst hm
+    have hzero : ∀ d ∈ range (n + 1), d ≠ n → (n - d + 0 - 1).choose (n - d) = 0 := by
+      intro d hd hne
+      have hlt : d < n := by have := Finset.mem_range.mp hd; omega
+      exact Nat.choose_eq_zero_of_lt (by omega)
+    rw [Finset.sum_eq_single n hzero
+        (by intro h; exact absurd (Finset.self_mem_range_succ n) h)]
+    simp
+  · -- k = m + 1 with m ≥ 1: genuine hockey stick (Zhu Shijie).
+    obtain ⟨p, rfl⟩ : ∃ p, m = p + 1 := ⟨m - 1, by omega⟩
+    -- Normalise the RHS to `(n + p + 1).choose (p + 1)`.
+    have hR : (n + (p + 1 + 1) - 1).choose (p + 1 + 1 - 1) = (n + p + 1).choose (p + 1) := by
+      have h1 : n + (p + 1 + 1) - 1 = n + p + 1 := by omega
+      have h2 : p + 1 + 1 - 1 = p + 1 := by omega
+      rw [h1, h2]
+    rw [hR, ← Nat.sum_range_add_choose n p,
+        ← Finset.sum_range_reflect (fun i => (i + p).choose p) (n + 1)]
+    -- Match the reflected summand with the marginal-count summand termwise.
+    refine Finset.sum_congr rfl ?_
+    intro d _
+    have e1 : n - d + (p + 1) - 1 = (n - d) + p := by omega
+    have e2 : n + 1 - 1 - d = n - d := by omega
+    rw [e1, e2, ← Nat.choose_symm (Nat.le_add_left p (n - d))]
+    congr 1
+    omega
+
+/-! ### Worked examples (`k = 3`, `n = 4`)
+
+The number of weak compositions of `4` into `3` parts with first part `d` is
+`C(5 - d, 4 - d) = 5 - d`, so the marginals are `5, 4, 3, 2, 1`; they sum to
+`15 = C(6, 2)`, the parent's total. (This corrects the source sketch, which listed
+`15, 10, 6, 3, 1` summing to `35`.) -/
+
+-- Fixing the first part to `0` leaves `5` weak compositions of `4` into `3` parts.
+example : Nat.card {f : Fin 3 → ℕ // (∑ i, f i = 4) ∧ f 0 = 0} = 5 := by
+  rw [card_weakComposition_first_eq 3 4 0 (by norm_num)]
+  decide
+
+-- The boundary case `d = n = 4` leaves the single composition `(4, 0, 0)`.
+example : Nat.card {f : Fin 3 → ℕ // (∑ i, f i = 4) ∧ f 0 = 4} = 1 := by
+  rw [card_weakComposition_first_eq 3 4 4 (by norm_num)]
+  decide
+
+-- Marginal for `d = 2`: `C(3, 2) = 3` compositions.
+example : Nat.card {f : Fin 3 → ℕ // (∑ i, f i = 4) ∧ f 0 = 2} = 3 := by
+  rw [card_weakComposition_first_eq 3 4 2 (by norm_num)]
+  decide
+
+-- Summing the marginals over `d = 0 … 4` recovers the parent total `C(6, 2) = 15`.
+example :
+    (∑ d ∈ range 5, Nat.card {f : Fin 3 → ℕ // (∑ i, f i = 4) ∧ f 0 = d}) = 15 := by
+  rw [sum_marginals_eq_total 3 4]
+  decide
+
+end StarsAndBarsMarginal

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-05/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-05/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "stars-and-bars-weak-compositions-oq-05",
+    "range": {
+      "startLine": 5,
+      "endLine": 60
+    },
+    "type": "concept",
+    "title": "The marginal refinement and what it adds over the parent",
+    "content": "The parent stars-and-bars-weak-compositions counts weak compositions of n into k parts — functions f : Fin k → ℕ with ∑ f = n — as C(n+k−1, n). This entry conditions that count on the value of the first coordinate: how many such compositions have f(0) = d? The answer is the stars-and-bars number one dimension down, counting weak compositions of n − d into k − 1 parts. The single engine is the drop-the-first-coordinate bijection: forget f(0) to get the tail, or prepend the fixed value d to reconstruct f. Mathlib counts weak compositions via Sym and Nat.multichoose but has no lemma for a count conditioned on one coordinate's value.",
+    "mathContext": "$\\#\\{f : \\mathrm{Fin}\\,k\\to\\mathbb N \\mid (\\sum_i f_i = n)\\wedge f_0 = d\\} = \\binom{(n-d)+(k-1)-1}{n-d}$ for $k\\ge1,\\ d\\le n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "weak composition",
+      "marginal count",
+      "stars and bars",
+      "bijective proof"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "finite cardinality via bijection"
+    ]
+  },
+  {
+    "id": "ann-drop-first-equiv",
+    "proofId": "stars-and-bars-weak-compositions-oq-05",
+    "range": {
+      "startLine": 62,
+      "endLine": 92
+    },
+    "type": "definition",
+    "title": "The drop-the-first-coordinate bijection",
+    "content": "dropFirstEquiv is the explicit Equiv between weak compositions of n into m+1 parts with first part d and weak compositions of n − d into m parts. The forward map is f ↦ Fin.tail f (Fin.tail f i = f i.succ, i.e. drop the first coordinate). Its sum obligation ∑ tail = n − d is discharged by rewriting ∑ f with Fin.sum_univ_succ (which splits it as f(0) + ∑ tail) and the hypothesis f(0) = d to get d + ∑ tail = n, after which omega — treating the tail sum as an opaque natural — closes the goal. The inverse is g ↦ Fin.cons d g (prepend d); its sum obligation d + ∑ g = n uses Fin.cons_zero/Fin.cons_succ and d ≤ n, and the first-part obligation is Fin.cons_zero. The two round-trips are exactly Mathlib's Fin.cons_self_tail (cons (f 0) (tail f) = f, after rewriting d back to f 0) and Fin.tail_cons (tail (cons d g) = g).",
+    "mathContext": "Forward $f \\mapsto (i \\mapsto f(i^+))$; inverse $g \\mapsto \\mathrm{cons}\\,d\\,g$. $\\sum_i f_i = f_0 + \\sum_i f_{i^+}$ splits the constraint.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fin.cons",
+      "Fin.tail",
+      "Fin.sum_univ_succ",
+      "Equiv"
+    ],
+    "prerequisites": [
+      "Fin tuple API",
+      "truncated natural subtraction"
+    ]
+  },
+  {
+    "id": "ann-marginal-count",
+    "proofId": "stars-and-bars-weak-compositions-oq-05",
+    "range": {
+      "startLine": 94,
+      "endLine": 104
+    },
+    "type": "theorem",
+    "title": "The marginal count via Nat.card transport",
+    "content": "card_weakComposition_first_eq destructures k = m + 1 (legal since k ≥ 1), transports the count across dropFirstEquiv with Nat.card_congr — which needs no Fintype instance on the conditioned subtype — and only then converts Nat.card to Fintype.card with Nat.card_eq_fintype_card, landing on the parent's subtype {g : Fin m → ℕ // ∑ g = n − d}, which does carry the parent's Fintype instance. The parent master count card_weakComposition m (n − d) closes it. Using Nat.card rather than Fintype.card throughout is what avoids having to manufacture a Fintype instance for the conditioned subtype at statement time.",
+    "mathContext": "$\\mathrm{Nat.card}\\,\\{f \\mid (\\sum f = n)\\wedge f_0 = d\\} = \\mathrm{Nat.card}\\,\\{g : \\mathrm{Fin}\\,m \\mid \\sum g = n-d\\} = \\binom{(n-d)+m-1}{n-d}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.card_congr",
+      "Nat.card_eq_fintype_card",
+      "card_weakComposition"
+    ],
+    "prerequisites": [
+      "cardinality transport across an equivalence",
+      "Fintype instances on subtypes"
+    ]
+  },
+  {
+    "id": "ann-hockey-stick",
+    "proofId": "stars-and-bars-weak-compositions-oq-05",
+    "range": {
+      "startLine": 106,
+      "endLine": 151
+    },
+    "type": "theorem",
+    "title": "The hockey-stick consistency check",
+    "content": "sum_marginals_eq_total sums the marginal over all admissible first parts d = 0 … n and recovers the parent total C(n+k−1, k−1). After rewriting each summand by the marginal count, the proof splits on the number of parts. When k = 1 (no coordinates remain after the first), only the d = n term is nonzero: Finset.sum_eq_single isolates it, the other terms vanishing by Nat.choose_eq_zero_of_lt. When k = m + 2 the sum is genuinely a hockey stick: the RHS is rewritten backwards through Mathlib's Nat.sum_range_add_choose into ∑ (i+p).choose p, the index is reflected d ↦ n − d with Finset.sum_range_reflect, and each term is converted to the (i+p).choose p shape via binomial symmetry Nat.choose_symm — matching termwise.",
+    "mathContext": "$\\sum_{d=0}^{n} \\binom{(n-d)+p}{n-d} = \\sum_{i=0}^{n}\\binom{i+p}{p} = \\binom{n+p+1}{p+1}$, the Zhu Shijie identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "hockey-stick identity",
+      "Nat.sum_range_add_choose",
+      "Finset.sum_range_reflect",
+      "Nat.choose_symm"
+    ],
+    "prerequisites": [
+      "reindexing a finite sum",
+      "binomial coefficient symmetry"
+    ]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "stars-and-bars-weak-compositions-oq-05",
+    "range": {
+      "startLine": 153,
+      "endLine": 180
+    },
+    "type": "concept",
+    "title": "Worked examples and a correction to the source sketch",
+    "content": "The four examples instantiate the theorems at k = 3, n = 4, where the total is C(6,2) = 15 and the marginals are C(5−d, 4−d) = 5 − d: namely 5 (d=0), 3 (d=2), 1 (the boundary d=n=4), and their sum 15. The numeric goals are closed by kernel evaluation of Nat.choose on literals (decide), not native_decide, so they add no axioms. These values correct the source problem sketch, which erroneously listed the marginals as 15,10,6,3,1 summing to 35 (the total is 15, not 35).",
+    "mathContext": "$C(5,4)=5,\\ C(3,2)=3,\\ C(1,0)=1$; $\\sum_{d=0}^{4}(5-d)=15=C(6,2)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked example",
+      "kernel decision procedure"
+    ],
+    "prerequisites": [
+      "Nat.choose evaluation"
+    ]
+  }
+]

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-05/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-05/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "stars-and-bars-weak-compositions-oq-05",
+  "title": "Marginal Count of Weak Compositions with a Fixed First Part, and the Hockey-Stick Consistency Check",
+  "slug": "stars-and-bars-weak-compositions-oq-05",
+  "description": "The parent entry stars-and-bars-weak-compositions proves the master count #{f : Fin k → ℕ // ∑ᵢ f(i) = n} = C(n+k−1, n) for weak compositions of n into k parts. This child proves the conditional refinement: fixing the first part to a value d ≤ n leaves exactly C(n−d+k−2, n−d) weak compositions — the stars-and-bars number one dimension down, counting weak compositions of n−d into k−1 parts (card_weakComposition_first_eq). The single engine is the drop-the-first-coordinate bijection dropFirstEquiv: forward it sends f to its tail Fin.tail f (forgetting f 0), and backward it prepends the fixed value via Fin.cons d g; Fin.sum_univ_succ splits ∑ f as f(0) + ∑ tail, so the constraint f(0) = d turns ∑ f = n into ∑ tail = n − d (using d ≤ n). Cardinality is transported across the equivalence with Nat.card_congr and the parent master count is applied to the smaller instance. Summing the marginal over all admissible first parts d = 0 … n recovers the parent's total C(n+k−1, k−1) — a hockey-stick / Zhu Shijie consistency check (sum_marginals_eq_total), proved by reindexing d ↦ n−d with Finset.sum_range_reflect and invoking Mathlib's Nat.sum_range_add_choose. Mathlib counts weak compositions/multisets via Sym and Nat.multichoose and records the hockey-stick identity, but has no lemma for a weak-composition count conditioned on one coordinate's value; the marginal bijection and its composition with the master count are new here, fully machine-checked and axiom-free. (The source problem sketch's worked example was numerically wrong — it listed marginals 15,10,6,3,1 summing to 35 for k=3,n=4, whereas the true marginals are 5,4,3,2,1 summing to 15 = C(6,2); the verified examples record the correct values.)",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Sym.Card",
+      "Mathlib.Data.Nat.Choose.Sum",
+      "Mathlib.Tactic",
+      "Proofs.StarsAndBarsWeakCompositions"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "StarsAndBarsMarginal",
+    "lineCount": 181,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "path": "Proofs/StarsAndBarsWeakCompositionsOQ05.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Composition_(combinatorics)#Number_of_compositions",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StarsAndBarsWeakCompositionsOQ05.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "stars-and-bars",
+      "weak-compositions",
+      "bijective-proof",
+      "marginal-count",
+      "hockey-stick-identity",
+      "binomial-coefficients"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "stars-and-bars-weak-compositions",
+        "relationship": "Direct parent. The parent proves the master count card_weakComposition : #{f : Fin k → ℕ // ∑ f = n} = C(n+k−1, n) via the multiset bijection weakCompositionEquivSym. This entry conditions that count on the value of the first coordinate: dropFirstEquiv reduces a weak composition of n into k parts with f 0 = d to a weak composition of n − d into k − 1 parts, and card_weakComposition is applied verbatim to the smaller instance to give the marginal count. Summing the marginals reproves the parent total."
+      },
+      {
+        "id": "stars-and-bars-weak-compositions-oq-04",
+        "relationship": "Sibling. OQ-04 records the additive/recursive layer of the same counts — the Pascal recurrence, its telescoped partial sum, and the negative-binomial hockey-stick identity ∑_{m≤n} C(m+k−1, m) = C(n+k, n). This entry's summation consistency sum_marginals_eq_total is the marginal/refinement counterpart of that hockey stick: it partitions the master count by the first part rather than telescoping the last."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 176,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. Both named theorems (card_weakComposition_first_eq, sum_marginals_eq_total) and the bijection dropFirstEquiv were verified to depend only on the foundational propext / Classical.choice / Quot.sound. The marginal count card_weakComposition_first_eq holds for every k ≥ 1 and d ≤ n; the d ≤ n hypothesis is essential, since for d > n the set is empty (count 0) while the closed form would read C(n−d+k−2, 0) = 1. The summation consistency sum_marginals_eq_total holds for all k ≥ 1, with the k = 1 (single-part) boundary handled separately: only the d = n term survives. The worked examples are discharged by kernel evaluation of Nat.choose on literals (decide), not native_decide.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Stars and bars counts weak compositions of n into k parts — functions Fin k → ℕ summing to n — as the negative-binomial coefficient C(n+k−1, n). A basic refinement asks for the marginal distribution of a single part: how many of these compositions have their first part equal to a prescribed value d? Fixing one coordinate drops the problem by one dimension, and the marginals are again stars-and-bars numbers. Summing them over d must return the total, which is exactly the hockey-stick (Zhu Shijie) identity read on the negative-binomial table. These marginals are the combinatorial content behind the negative-hypergeometric distribution and are the building blocks of generating-function proofs.",
+    "problemStatement": "Prove the conditional refinement of the stars-and-bars count. For k ≥ 1 and d ≤ n, show that the number of weak compositions f : Fin k → ℕ of n whose first part f(0) equals d is\n\n$$\\#\\{f : \\textstyle\\sum_i f_i = n,\\ f_0 = d\\} = \\binom{(n-d)+(k-1)-1}{n-d},$$\n\nthe stars-and-bars count of weak compositions of n − d into k − 1 parts, and verify the consistency check that summing over d = 0 … n recovers the parent total C(n+k−1, k−1).",
+    "text": "The whole result rests on a single bijection. Writing k = m + 1, a weak composition of n into m+1 parts with first part d is exactly the data of its tail — a weak composition of n − d into m parts — together with the fixed value d prepended. Forward the map forgets the first coordinate (Fin.tail); backward it prepends d (Fin.cons d). That Fin.sum_univ_succ splits the total as f(0) + ∑ tail is what turns the linear constraint into the smaller one, and d ≤ n is what makes n − d honest. Everything else is transport of cardinality (Nat.card_congr) and one application of the parent master count.",
+    "proofStrategy": "dropFirstEquiv is the explicit Equiv {f : Fin (m+1) → ℕ // (∑ f = n) ∧ f 0 = d} ≃ {g : Fin m → ℕ // ∑ g = n − d}. Its forward map is f ↦ Fin.tail f: the sum condition is discharged by rewriting ∑ f with Fin.sum_univ_succ and the hypothesis f 0 = d to get d + ∑ tail = n, then omega. Its inverse is g ↦ Fin.cons d g: the sum condition uses Fin.cons_zero / Fin.cons_succ and omega with d ≤ n, and the first-part condition is Fin.cons_zero. The two round-trips are Fin.cons_self_tail and Fin.tail_cons. card_weakComposition_first_eq then destructures k = m + 1, transports the count across dropFirstEquiv with Nat.card_congr, converts to Fintype.card via the parent's Fintype instance, and closes with card_weakComposition m (n − d). sum_marginals_eq_total rewrites each summand by card_weakComposition_first_eq, splits on k = 1 (only the d = n term is nonzero) versus k = m + 2, and for the generic case reindexes d ↦ n − d with Finset.sum_range_reflect and Nat.choose_symm before matching Mathlib's Nat.sum_range_add_choose (the range form of the hockey-stick identity).",
+    "keyInsights": [
+      "**Fixing one coordinate is a genuine dimension drop.** The map f ↦ Fin.tail f / g ↦ Fin.cons d g is a bijection, not just an injection: a weak composition with prescribed first part carries exactly the information of its tail. The count therefore reduces cleanly to the parent formula on k − 1 parts with total n − d.",
+      "**The linear constraint splits, so no subtraction bookkeeping is needed inside the proof of the bijection.** Fin.sum_univ_succ writes ∑ f = f(0) + ∑ tail; substituting f(0) = d and using d ≤ n lets omega finish both directions without ever reasoning about truncated subtraction inside a Finset.sum.",
+      "**Nat.card sidesteps the finiteness obstacle.** The conditioned subtype has no canonical Fintype instance available at statement time, but Nat.card is defined for every type and Nat.card_congr transports it across the bijection with no instance argument; only after landing on the parent's subtype (which does carry a Fintype instance) is the cardinality converted with Nat.card_eq_fintype_card.",
+      "**The summation check is the hockey stick, from the other end.** Summing the marginals over the first part d partitions the master count and must return C(n+k−1, k−1); after the reflection d ↦ n − d this is precisely Mathlib's Nat.sum_range_add_choose, the negative-binomial hockey-stick identity — here obtained by refining on the first coordinate rather than telescoping the last (cf. sibling OQ-04)."
+    ],
+    "prerequisites": [
+      "The Fin tuple API: Fin.cons, Fin.tail, Fin.cons_zero, Fin.cons_succ, Fin.tail_cons, Fin.cons_self_tail, and Fin.sum_univ_succ",
+      "Cardinality transport with Nat.card_congr and Nat.card_eq_fintype_card, and the parent's Fintype instance on the weak-composition subtype",
+      "The parent stars-and-bars count card_weakComposition : #{f : Fin k → ℕ // ∑ f = n} = C(n+k−1, n)",
+      "Mathlib's hockey-stick identity Nat.sum_range_add_choose, the reindexing lemma Finset.sum_range_reflect, and binomial symmetry Nat.choose_symm"
+    ]
+  },
+  "sections": [
+    {
+      "id": "drop-first-bijection",
+      "title": "The Drop-the-First-Coordinate Bijection",
+      "startLine": 62,
+      "endLine": 95,
+      "mathContext": "$\\{f : \\mathrm{Fin}\\,(m{+}1)\\to\\mathbb N \\mid (\\sum f = n)\\wedge f_0 = d\\} \\simeq \\{g : \\mathrm{Fin}\\,m\\to\\mathbb N \\mid \\sum g = n-d\\}$ for $d \\le n$.",
+      "summary": "dropFirstEquiv builds the explicit equivalence: forward is f ↦ Fin.tail f (forget the first part), inverse is g ↦ Fin.cons d g (prepend the fixed value d). The forward sum condition follows from Fin.sum_univ_succ and f 0 = d giving d + ∑ tail = n, then omega; the inverse sum condition uses Fin.cons_zero/Fin.cons_succ and d ≤ n. The round-trips are Fin.cons_self_tail and Fin.tail_cons."
+    },
+    {
+      "id": "marginal-count",
+      "title": "The Marginal Count",
+      "startLine": 97,
+      "endLine": 106,
+      "mathContext": "$\\#\\{f \\mid (\\sum f = n)\\wedge f_0 = d\\} = \\binom{(n-d)+(k-1)-1}{n-d}$ for $k \\ge 1,\\ d \\le n$.",
+      "summary": "card_weakComposition_first_eq destructures k = m + 1, transports the count across dropFirstEquiv with Nat.card_congr, converts Nat.card to Fintype.card via the parent's instance, and applies the parent master count card_weakComposition m (n − d). The result is the stars-and-bars number one dimension down."
+    },
+    {
+      "id": "hockey-stick-consistency",
+      "title": "The Hockey-Stick Consistency Check",
+      "startLine": 108,
+      "endLine": 155,
+      "mathContext": "$\\sum_{d=0}^{n} \\#\\{f \\mid (\\sum f = n)\\wedge f_0 = d\\} = \\binom{n+k-1}{k-1}$.",
+      "summary": "sum_marginals_eq_total rewrites each summand by the marginal count, then splits on the number of parts. For k = 1 only the d = n term survives (Finset.sum_eq_single, with the other terms zero by Nat.choose_eq_zero_of_lt). For k = m + 2 the sum is reindexed d ↦ n − d via Finset.sum_range_reflect and each term is put in (i+p).choose p form via Nat.choose_symm, matching Mathlib's Nat.sum_range_add_choose — the range form of the hockey-stick identity — which returns the parent total C(n+k−1, k−1)."
+    },
+    {
+      "id": "worked-examples",
+      "title": "Worked Examples (k = 3, n = 4)",
+      "startLine": 157,
+      "endLine": 175,
+      "mathContext": "Marginals of $C(6,2)=15$: fixing $f_0=d$ gives $C(5-d,4-d)=5-d$, i.e. $5,4,3,2,1$, summing to $15$.",
+      "summary": "Four verified examples instantiate the theorems at k = 3, n = 4: the marginal at d = 0 is 5, the boundary d = n = 4 is 1, the middle d = 2 is 3, and the marginals sum to 15 = C(6,2). These correct the source problem sketch, which erroneously listed 15,10,6,3,1 summing to 35."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fixing the first part of a weak composition to d ≤ n is a clean dimension drop: the drop-the-first-coordinate bijection dropFirstEquiv identifies such compositions of n into k parts with weak compositions of n − d into k − 1 parts, so the marginal count is the stars-and-bars number C(n−d+k−2, n−d) (card_weakComposition_first_eq). Summing these marginals over all admissible first parts recovers the parent total C(n+k−1, k−1) via Mathlib's hockey-stick identity (sum_marginals_eq_total). Everything is axiom-free and reuses the parent's master count verbatim.",
+    "implications": "The marginal count is the combinatorial content of the negative-hypergeometric distribution and the building block of generating-function proofs of stars and bars. Together with sibling OQ-04 (additive/recursive Pascal + hockey-stick layer) and OQ-01 (generating function), the gallery now records the refinement/marginal layer of the stars-and-bars circle: the same total C(n+k−1, k−1) partitioned by a single coordinate. The Nat.card + Nat.card_congr technique for a subtype without a canonical Fintype instance is reusable for other conditioned counts.",
+    "openQuestions": [
+      "Refine the marginal to a joint distribution: count weak compositions with the first r parts fixed to (d₁,…,d_r), giving iterated drop-first bijections and the multivariate negative-hypergeometric count C(n−Σd_i + (k−r) − 1, n−Σd_i).",
+      "Upgrade the summation consistency from a cardinality identity to an explicit fiberwise Equiv {f : Fin k → ℕ // ∑ f = n} ≃ Σ d ∈ range (n+1), {f // (∑ f = n) ∧ f 0 = d}, exhibiting the partition-by-first-part bijection whose cardinality is sum_marginals_eq_total."
+    ]
+  },
+  "crossReferences": [
+    "stars-and-bars-weak-compositions",
+    "stars-and-bars-weak-compositions-oq-04"
+  ]
+}


### PR DESCRIPTION
## Summary

Child of `stars-and-bars-weak-compositions`. The parent proves the master count `#{f : Fin k → ℕ // ∑ f = n} = C(n+k−1, n)`. This entry proves the **conditional refinement**: fixing the first part to `d ≤ n` leaves exactly `C(n−d+k−2, n−d)` weak compositions — the stars-and-bars number one dimension down.

## Results (all VERIFIED, 0-axiom, no native_decide)

- `dropFirstEquiv` — the explicit **drop-the-first-coordinate bijection** `{f : Fin (m+1) → ℕ // (∑ f = n) ∧ f 0 = d} ≃ {g : Fin m → ℕ // ∑ g = n − d}`: forward `f ↦ Fin.tail f`, inverse `g ↦ Fin.cons d g`; round-trips are `Fin.cons_self_tail` / `Fin.tail_cons`.
- `card_weakComposition_first_eq` — the **marginal count**: transports cardinality across `dropFirstEquiv` with `Nat.card_congr` and applies the parent master count to the smaller instance.
- `sum_marginals_eq_total` — **hockey-stick consistency**: summing the marginals over `d = 0 … n` recovers the parent total `C(n+k−1, k−1)`, via reindexing `d ↦ n−d` (`Finset.sum_range_reflect`, `Nat.choose_symm`) and Mathlib's `Nat.sum_range_add_choose`. The single-part `k = 1` boundary is handled separately.

## Verification

`./proofs/scripts/docker-build.sh Proofs.StarsAndBarsWeakCompositionsOQ05` → succeeds, 0 errors / 0 warnings. 2 theorems, 1 def, 0 sorries, 0 `axiom` declarations, no `native_decide`; worked examples discharged by kernel `decide` on `Nat.choose` literals.

Note: the source sketch's worked example (marginals 15,10,6,3,1 summing to 35 for k=3,n=4) is numerically wrong; the true marginals are 5,4,3,2,1 summing to 15 = C(6,2), recorded in the verified examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)