### PR TITLE
Enrich André-reflection Catalan bijection: add sections array (catalan-numbers-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-01/meta.json
@@ -34,6 +34,56 @@
       "Nat.sInf and first-passage (least-witness) arguments"
     ]
   },
+  "sections":   [
+    {
+      "id": "setup-reflection",
+      "title": "Setup: Lattice Paths and André's Reflection",
+      "startLine": 1,
+      "endLine": 104,
+      "summary": "Encodes a monotone lattice path as the Finset of up-step positions in Fin (2n). Defines preUps (up-steps among the first j positions), hitsAt / Reaches (the path drops to height -1 at some prefix), and reflect S t (André's reflection: flip every step from position t onward). The key cardinality identity card_reflect_add shows reflecting at cut point t sends an n-up path to an (n-1)-up path, the numeric heart of the bijection.",
+      "mathContext": "A path is $S \\subseteq \\mathrm{Fin}(2n)$ (up-step positions); reflecting after the first descent turns an $n$-up path that dips below the axis into an $(n-1)$-up path: $\\#\\mathrm{reflect}(S,t) + \\#S = \\ldots$ shifts the up-count by one."
+    },
+    {
+      "id": "prefix-recurrence",
+      "title": "Prefix-Count Recurrence and Basic Bounds",
+      "startLine": 105,
+      "endLine": 146,
+      "summary": "preUps_succ (stepping the prefix length adds the 0-or-1 up-steps at position j), preUps_zero, preUps_le_card, and preUps_eq_card (beyond the last position the prefix count equals the full up-count). The elementary monotonicity/boundary facts that drive the discrete IVT.",
+      "mathContext": "$\\mathrm{preUps}(S,j{+}1) = \\mathrm{preUps}(S,j) + [\\,j \\in S\\,]$, with $\\mathrm{preUps}(S,0)=0$ and $\\mathrm{preUps}(S,j)=\\#S$ for $j \\ge 2n$."
+    },
+    {
+      "id": "discrete-ivt",
+      "title": "Discrete Intermediate Value: A Deficient Path Reaches -1",
+      "startLine": 147,
+      "endLine": 177,
+      "summary": "reaches_of_card_lt: a path with fewer than n up-steps (hence ending below height 0) must reach height -1 at some prefix. The discrete analogue of the IVT: a walk that ends below the axis and moves in unit steps cannot avoid crossing -1.",
+      "mathContext": "$\\#S < n \\Rightarrow \\mathrm{Reaches}(S)$: an $\\pm1$ walk ending below 0 must hit $-1$ - the combinatorial intermediate value step."
+    },
+    {
+      "id": "involution",
+      "title": "The Reflection Is an Involution Fixing the First Descent",
+      "startLine": 178,
+      "endLine": 210,
+      "summary": "reflect_involutive (reflecting twice at the same cut is the identity), preUps_reflect_eq (the prefix up-count is unchanged below the cut), and hitsAt_reflect_iff (hitsAt agrees between S and reflect S t at every prefix up to t). These make reflection a well-defined involution once the cut point is chosen canonically.",
+      "mathContext": "$\\mathrm{reflect}(\\mathrm{reflect}(S,t),t) = S$ and the two paths agree on all prefixes $\\le t$ - so reflection is an involution that leaves the initial descent intact."
+    },
+    {
+      "id": "cut-point",
+      "title": "The First-Descent Cut Point",
+      "startLine": 211,
+      "endLine": 256,
+      "summary": "Defines cut S (the first prefix length at which the path reaches -1) and proves cut_hits, cut_min, cut_le, reaches_reflect (reflecting a bad path at its own cut keeps it bad), cut_reflect (the cut point is preserved by reflecting there), and card_reflect_cut (subtraction-free cardinality after cutting). This canonical, reflection-invariant cut point is what makes the involution a genuine bijection.",
+      "mathContext": "$\\mathrm{cut}(S) = \\min\\{ j : \\mathrm{hitsAt}(S,j) \\}$ is invariant under reflection there, so $S \\mapsto \\mathrm{reflect}(S,\\mathrm{cut}\\,S)$ is a well-defined involution on bad paths."
+    },
+    {
+      "id": "bijection-catalan",
+      "title": "The Reflection Bijection and the Catalan Count",
+      "startLine": 257,
+      "endLine": 360,
+      "summary": "Defines BadPaths (n-up paths that dip below the axis), LowPaths (all (n-1)-up paths), and GoodPaths (Dyck paths). card_badPaths establishes the reflection bijection #BadPaths = #LowPaths for n >= 1; card_badPaths_eq evaluates it to C(2n, n+1); the partition C(2n,n) = catalan n + C(2n,n+1) then yields the main theorem card_goodPaths_eq_catalan: the number of Dyck paths of length 2n is the Catalan number catalan n.",
+      "mathContext": "$\\#\\mathrm{Bad} = \\#\\mathrm{Low} = \\binom{2n}{n+1}$, and $\\binom{2n}{n} = C_n + \\binom{2n}{n+1}$ gives $\\#\\mathrm{Good} = \\binom{2n}{n} - \\binom{2n}{n+1} = C_n$."
+    }
+  ],
   "conclusion": {
     "summary": "André's reflection is formalized as an explicit involution reflect S (cut S) on up-step position sets, fixing the first descent and dropping the up-count by exactly one. This gives a Finset bijection between bad n-up paths and all (n−1)-up paths, proving #BadPaths = C(2n,n+1) and hence #GoodPaths = C(2n,n) − C(2n,n+1) = catalan n — the bijective upgrade of the arithmetic reflection form. Verified, 0 axioms, 0 sorries, no native_decide.",
     "implications": [


### PR DESCRIPTION
## Enrichment — catalan-numbers-oq-01-oq-01-oq-01

"André's reflection as an explicit bijection for the Catalan count" had `overview`, `conclusion`, `crossReferences`, and `references`, but **no `sections` array**.

### Added
- **`sections`**: 6 sections following the 360-line Lean file's own `/-! ### -/` markers:
  1. Setup: lattice paths and André's reflection (1–104)
  2. Prefix-count recurrence and basic bounds (105–146)
  3. Discrete intermediate value: a deficient path reaches −1 (147–177)
  4. The reflection is an involution fixing the first descent (178–210)
  5. The first-descent cut point (211–256)
  6. The reflection bijection and the Catalan count (`card_goodPaths_eq_catalan`, 257–360)
  Each with `summary` + `mathContext`.

### Guardrails
- meta.json ~13 KB → 16.4 KB, under the 60 KB cap (`check-meta-size`: within caps).
- No existing content modified.

Math-agent PR — no `loom:review-requested`.