### PR TITLE
Enrich Cauchy Interlacing eigenvalue corollary: 5th annotation

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-eigenvalues-finrank-congr",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 63, "endLine": 72 },
+    "type": "technique",
+    "title": "Eigenvalues Are Independent of the Dimension Proof",
+    "content": "`LinearMap.IsSymmetric.eigenvalues` is indexed by `Fin m` through a *proof* `finrank 𝕜 E = m`, so the operator statement (using `finrank_euclideanSpace_fin`) and the literal `eigenvalues₀` statement (using `finrank_euclideanSpace`) name the same list against two different indexings. `eigenvalues_finrank_congr` discharges this once: since both `m` and `m'` equal `finrank 𝕜 E`, the equality `m = m'` is forced, and after `obtain rfl` the reindexing `Fin.cast` collapses to the identity (`Fin.cast_eq_self`). This single lemma is the only bridge needed between the abstract-operator proof and Mathlib's `Matrix.IsHermitian.eigenvalues₀` indexing.",
+    "mathContext": "The eigenvalue list of a symmetric operator on an $m$-dimensional space is canonical; two proofs of $\\dim E = m$ yield the same list up to the forced identity $\\mathrm{Fin}\\,m \\simeq \\mathrm{Fin}\\,m'$.",
+    "significance": "technical",
+    "relatedConcepts": ["proof irrelevance", "Fin.cast", "dependent indexing", "eigenvalues₀"],
+    "prerequisites": ["Fin.cast and dependent types", "LinearMap.IsSymmetric.eigenvalues"]
+  },
+  {
     "id": "ann-interlacing-of-intertwine",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
     "range": { "startLine": 87, "endLine": 111 },


### PR DESCRIPTION
## Enrichment pass — `cauchy-interlacing-theorem-oq-01-oq-01-oq-02`

Adds the 5th annotation (`ann-eigenvalues-finrank-congr`, type `technique`) covering `eigenvalues_finrank_congr` at lines 63–72, previously uncovered. This is the dimension-proof-irrelevance bookkeeping lemma that bridges the abstract operator-eigenvalue statement to Mathlib's `Matrix.IsHermitian.eigenvalues₀` indexing.

- Coverage: 4 → 5 annotations (reaches the minimum), all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.
- meta.json already rich (16 KB, well under the 60 KB cap; check-meta-size passes) — left untouched.
- No `index.ts` added: the post-#20993 loader fetches by slug via listings.json/data-manifest.json and no longer imports per-proof shims, so index.ts is dead cruft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)