### PR TITLE
Enrich Algebraic Numbers ARE an Algebraic Closure of ℚ: 5th annotation

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-03/annotations.json
@@ -70,6 +70,29 @@
     ]
   },
   {
+    "id": "anoq03-ann-commutes",
+    "proofId": "algebraic-numbers-countable-oq-01-oq-03",
+    "range": {
+      "startLine": 97,
+      "endLine": 102
+    },
+    "type": "technique",
+    "title": "The identification is canonical over ℚ, not just an abstract bijection",
+    "content": "Steinitz uniqueness is famously non-canonical — the isomorphism of two algebraic closures depends on a choice of lift and is not unique. What `algebraicNumbersEquivAlgebraicClosure_commutes` records is the one piece of canonicity that survives: because the map is a `ℚ`-algebra equivalence (`≃ₐ[ℚ]`), it necessarily fixes the base field pointwise, sending `algebraMap ℚ algebraicNumbersField q` to `algebraMap ℚ (AlgebraicClosure ℚ) q` for every rational `q`. This is exactly `AlgEquiv.commutes`, and it is what makes the identification a bridge *over* `ℚ` rather than a bare bijection of sets — the transported structure (and later the cardinality) is compatible with the rational subfield common to both.",
+    "mathContext": "For an $R$-algebra isomorphism $\\varphi : A \\simeq_{\\mathrm{alg}[R]} B$, the defining triangle $\\varphi \\circ \\mathrm{algebraMap}_R^A = \\mathrm{algebraMap}_R^B$ holds; here $R = \\mathbb{Q}$, so $\\varphi$ restricts to the identity on the rationals despite the non-canonical choice underlying Steinitz uniqueness.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "AlgEquiv.commutes",
+      "algebra structure map",
+      "non-canonical isomorphism",
+      "naturality over the base field"
+    ],
+    "prerequisites": [
+      "algebra homomorphisms",
+      "the structure map algebraMap"
+    ]
+  },
+  {
     "id": "anoq03-ann-cardinality",
     "proofId": "algebraic-numbers-countable-oq-01-oq-03",
     "range": {


### PR DESCRIPTION
## Enrichment pass — `algebraic-numbers-countable-oq-01-oq-03`

Adds a 5th annotation (`anoq03-ann-commutes`, type `technique`) on `algebraicNumbersEquivAlgebraicClosure_commutes` (lines 97–102).

Steinitz uniqueness is famously non-canonical, but as a `≃ₐ[ℚ]` map the identification necessarily fixes ℚ pointwise (`AlgEquiv.commutes`) — making it a bridge *over* ℚ rather than a bare set bijection, which is what makes the downstream cardinality transport structurally meaningful.

- Coverage: 4 → 5 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.
- meta.json already rich (18 KB, under the 60 KB cap; check-meta-size passes) — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)