### PR TITLE
Enrich 'Sharpness of the Commutative Hurwitz Bound': add index.ts + annotations (3→5)

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/annotations.json
@@ -13,9 +13,22 @@
     "tags": ["hurwitz", "classification", "sharpness"]
   },
   {
+    "id": "ann-hcs-admissible-def",
+    "proofId": "hurwitz-theorem-oq-03-oq-01-incomplete-01",
+    "range": { "startLine": 36, "endLine": 38 },
+    "type": "definition",
+    "title": "The admissible dimension set {1,2,4,8}",
+    "content": "admissibleDimensions : Set ℕ := {1, 2, 4, 8} is the target set of Hurwitz's classification, defined identically to HurwitzOnlyIf.admissibleDimensions in the parent so the two files' statements line up literally. As a Set ℕ it is the union of singletons {1} ∪ {2} ∪ {4} ∪ {8}; membership unfolds via Set.mem_insert_iff / Set.mem_singleton_iff to a finite disjunction that omega discharges. Reproducing the definition (rather than importing the parent) keeps this companion self-contained.",
+    "mathContext": "$\\{1,2,4,8\\}$ — the dimensions of $\\mathbb R, \\mathbb C, \\mathbb H, \\mathbb O$, the only real normed division algebras.",
+    "significance": "The shared vocabulary in which both the upper bound and the sharpness statement are phrased.",
+    "relatedConcepts": ["normed division algebra", "Hurwitz classification", "Set membership in ℕ"],
+    "prerequisites": ["Set ℕ", "finite set membership"],
+    "tags": ["hurwitz", "definition"]
+  },
+  {
     "id": "ann-hcs-upper-bound",
     "proofId": "hurwitz-theorem-oq-03-oq-01-incomplete-01",
-    "range": { "startLine": 43, "endLine": 64 },
+    "range": { "startLine": 40, "endLine": 55 },
     "type": "theorem",
     "title": "Gelfand–Mazur upper bound (reproduced)",
     "content": "finrank_normed_field_eq_one_or_two reproduces the parent's argument: NormedAlgebra.Real.nonempty_algEquiv_or gives an ℝ-algebra isomorphism F ≅ ℝ or F ≅ ℂ; transporting finrank across the induced linear equivalence (LinearEquiv.finrank_eq) with CommSemiring.finrank_self ℝ (=1) or Complex.finrank_real_complex (=2) yields finrank ℝ F ∈ {1,2}. finrank_normed_field_admissible then packages this into the admissible set {1,2,4,8} via omega.",
@@ -26,16 +39,29 @@
     "tags": ["gelfand-mazur", "upper-bound"]
   },
   {
+    "id": "ann-hcs-realizability-endpoints",
+    "proofId": "hurwitz-theorem-oq-03-oq-01-incomplete-01",
+    "range": { "startLine": 57, "endLine": 63 },
+    "type": "theorem",
+    "title": "The endpoint witnesses: ℝ realizes 1, ℂ realizes 2",
+    "content": "finrank_real_self : finrank ℝ ℝ = 1 (from CommSemiring.finrank_self ℝ, since ℝ is 1-dimensional over itself) and finrank_complex : finrank ℝ ℂ = 2 (from Complex.finrank_real_complex, ℂ = ℝ ⊕ ℝi) are the concrete realizability witnesses. They are one-line term-mode delegations to Mathlib, but their role is decisive: an upper bound {1,2} is only a classification once each value is exhibited by an actual algebra. ℝ and ℂ are those algebras — both commutative real normed division algebras — so no admissible commutative dimension is vacuous.",
+    "mathContext": "$\\operatorname{finrank}_{\\mathbb R}\\mathbb R = 1$ and $\\operatorname{finrank}_{\\mathbb R}\\mathbb C = 2$: the two endpoints of $\\{1,2\\}$ are attained.",
+    "significance": "The realizability/lower direction the parent's impossibility bound lacked; without these, {1,2} is only an upper bound.",
+    "relatedConcepts": ["realizability", "complex numbers as ℝ-algebra", "finrank of the base field"],
+    "prerequisites": ["CommSemiring.finrank_self", "Complex.finrank_real_complex"],
+    "tags": ["realizability", "hurwitz"]
+  },
+  {
     "id": "ann-hcs-sharpness",
     "proofId": "hurwitz-theorem-oq-03-oq-01-incomplete-01",
-    "range": { "startLine": 66, "endLine": 79 },
+    "range": { "startLine": 65, "endLine": 79 },
     "type": "theorem",
-    "title": "Realizability and sharpness of {1,2}",
-    "content": "finrank_real_self (finrank ℝ ℝ = 1) and finrank_complex (finrank ℝ ℂ = 2) exhibit commutative real normed division algebras of each admissible dimension. comm_bound_sharp bundles both endpoints with the upper bound: both 1 and 2 are attained and no commutative real normed division algebra has any other dimension, so the set of realized dimensions is EXACTLY {1,2}. This is the realizability/lower direction the parent's impossibility bound lacked.",
-    "mathContext": "$\\operatorname{finrank}_{\\mathbb R}\\mathbb R=1$, $\\operatorname{finrank}_{\\mathbb R}\\mathbb C=2$, and these are the only values $\\Rightarrow$ realized set $=\\{1,2\\}$.",
+    "title": "Sharpness: the realized dimension set is exactly {1,2}",
+    "content": "comm_bound_sharp bundles the two endpoints with the upper bound into a single statement: finrank ℝ ℝ = 1 ∧ finrank ℝ ℂ = 2 ∧ (∀ commutative real normed field F, finrank ℝ F = 1 ∨ finrank ℝ F = 2). The first two conjuncts are the realizability witnesses; the third is Gelfand–Mazur ruling out every other value. Together they say the set of ℝ-dimensions realized by commutative real normed division algebras is EXACTLY {1,2}, not merely a subset — upgrading the parent's one-sided bound to a complete characterization of the commutative case.",
+    "mathContext": "Both endpoints attained ($1$ by $\\mathbb R$, $2$ by $\\mathbb C$) and no other value occurs $\\Rightarrow$ realized set $=\\{1,2\\}$.",
     "significance": "Completes the commutative half of the {1,2,4,8} classification; the non-commutative case (dim 4, 8; Clifford/Radon-Hurwitz) remains the parent's open sorry.",
-    "relatedConcepts": ["realizability", "sharp bound", "complex numbers as ℝ-algebra"],
-    "prerequisites": ["finrank ℝ ℝ", "Complex.finrank_real_complex"],
-    "tags": ["sharpness", "realizability", "hurwitz"]
+    "relatedConcepts": ["sharp bound", "exact characterization", "Gelfand-Mazur theorem"],
+    "prerequisites": ["the endpoint and upper-bound lemmas above"],
+    "tags": ["sharpness", "hurwitz"]
   }
 ]

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/index.ts
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HurwitzCommSharp.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hurwitzTheoremOq03Oq01Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hurwitzTheoremOq03Oq01Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hurwitzTheoremOq03Oq01Incomplete01Data: ProofData = {
+  proof: hurwitzTheoremOq03Oq01Incomplete01Proof,
+  annotations: hurwitzTheoremOq03Oq01Incomplete01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `hurwitz-theorem-oq-03-oq-01-incomplete-01`.

**Critical fix:**
- **Added missing `index.ts`** — without it, Vite's `import.meta.glob` cannot discover the proof, so the page rendered 'proof not found' on the live site despite appearing in the gallery listing.

**Enrichment (annotations 3 → 5, with corrected ranges):**
- The previous upper-bound annotation (lines 43–64) mis-ranged over the realizability endpoint theorems at 57–63. Ranges now non-overlapping and accurate.
- Added `ann-hcs-admissible-def` — the `admissibleDimensions := {1,2,4,8}` definition (36–38).
- Added `ann-hcs-realizability-endpoints` — the endpoint witnesses `finrank ℝ ℝ = 1`, `finrank ℝ ℂ = 2` (57–63).
- Narrowed `ann-hcs-upper-bound` to 40–55 and `ann-hcs-sharpness` to 65–79.

JSON validates; meta.json within all size caps (10 KB). Status/badge/axiom fields unchanged and consistent with the verified 0-sorry Lean file.