### PR TITLE
research(feuerbachs-theorem-oq-04): spherical excircles — the three other tritangent circles [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -1017,4 +1017,91 @@ theorem sphericalIncircle_exists [FiniteDimensional ℝ E] (Na Nb Nc : E)
   · show |(⟪O, Nc⟫ : ℝ)| = Real.sin (Real.arcsin |⟪O, Na⟫|)
     rw [Real.sin_arcsin (by linarith [abs_nonneg (⟪O, Na⟫ : ℝ)]) hbound, ← hbc', ← hab']
 
+/-! ## Spherical excircles — the other three tritangent circles
+
+`sphericalIncircle_exists` produced *one* circle tangent to all three sides, from intersecting
+the two **internal** bisectors (poles `Na − Nb`, `Nb − Nc`), giving a centre with
+`⟪O,Na⟫ = ⟪O,Nb⟫ = ⟪O,Nc⟫` — the incircle.  Replacing an internal bisector by the matching
+**external** one (pole `Na + Nb` in place of `Na − Nb`) flips the sign of the inner product
+against one pole, producing a centre still equidistant from all three sides but on the far
+side of one of them: an **excircle**.  There are three such choices, one per vertex, so a
+spherical triangle carries the same four tritangent circles (incircle + three excircles) as
+its Euclidean counterpart — exactly the four circles the spherical nine-point circle must be
+tangent to in Feuerbach's theorem.  The tangency criterion `|⟪O,N⟫| = sin ρ` is
+sign-insensitive, so all four share the definition `SphericalIncircle`; the returned sign
+relations `⟪O,Nᵢ⟫ = ±⟪O,Nⱼ⟫` are what tell the four circles apart. -/
+
+/-- **Tritangent circles from equal side-distances.**  If a unit centre `O` is equidistant
+from the three side great circles in the strong sense `|⟪O,Na⟫| = |⟪O,Nb⟫| = |⟪O,Nc⟫|`, then
+`sCircle O (arcsin |⟪O,Na⟫|)` is tangent to all three sides.  This packages the common tail of
+the incircle and excircle existence proofs. -/
+theorem sphericalIncircle_of_abs_eq {Na Nb Nc O : E}
+    (hO : OnSphere O) (hNa : OnSphere Na)
+    (hab : |(⟪O, Na⟫ : ℝ)| = |⟪O, Nb⟫|) (hac : |(⟪O, Na⟫ : ℝ)| = |⟪O, Nc⟫|) :
+    SphericalIncircle Na Nb Nc O (Real.arcsin |⟪O, Na⟫|) := by
+  have hbound : |(⟪O, Na⟫ : ℝ)| ≤ 1 := by
+    have h := abs_real_inner_le_norm O Na; rw [hO, hNa, mul_one] at h; exact h
+  have key : |(⟪O, Na⟫ : ℝ)| = Real.sin (Real.arcsin |⟪O, Na⟫|) :=
+    (Real.sin_arcsin (by linarith [abs_nonneg (⟪O, Na⟫ : ℝ)]) hbound).symm
+  refine ⟨?_, ?_, ?_⟩
+  · show |(⟪O, Na⟫ : ℝ)| = Real.sin (Real.arcsin |⟪O, Na⟫|); exact key
+  · show |(⟪O, Nb⟫ : ℝ)| = Real.sin (Real.arcsin |⟪O, Na⟫|); rw [← hab]; exact key
+  · show |(⟪O, Nc⟫ : ℝ)| = Real.sin (Real.arcsin |⟪O, Na⟫|); rw [← hac]; exact key
+
+/-- **Existence of the spherical excircle opposite the first vertex.**  Intersecting the
+*external* bisector of the `(Na, Nb)` pair (pole `Na + Nb`) with the *internal* bisector of
+`(Nb, Nc)` (pole `Nb − Nc`) yields a centre `O` with `⟪O,Na⟫ = −⟪O,Nb⟫ = −⟪O,Nc⟫`: a circle
+tangent to all three sides but on the far side of the first, an excircle.  The returned sign
+relations record which tritangent circle this is, distinguishing it from the incircle
+(`⟪O,Na⟫ = ⟪O,Nb⟫ = ⟪O,Nc⟫`). -/
+theorem sphericalExcircleA_exists [FiniteDimensional ℝ E] (Na Nb Nc : E)
+    (hNa : OnSphere Na) (hdim : 2 < Module.finrank ℝ E) :
+    ∃ (O : E) (ρ : ℝ), SphericalIncircle Na Nb Nc O ρ ∧
+      (⟪O, Na⟫ : ℝ) = -⟪O, Nb⟫ ∧ (⟪O, Nb⟫ : ℝ) = ⟪O, Nc⟫ := by
+  obtain ⟨O, hOon, -, ⟨-, hab⟩, ⟨-, hbc⟩, -, -⟩ :=
+    greatCircles_inter (Na + Nb) (Nb - Nc) hdim
+  have hab' : (⟪O, Na⟫ : ℝ) = -⟪O, Nb⟫ := by
+    have := hab; rw [inner_add_right] at this; linarith
+  have hbc' : (⟪O, Nb⟫ : ℝ) = ⟪O, Nc⟫ := by
+    have := hbc; rw [inner_sub_right] at this; linarith
+  have hAB : |(⟪O, Na⟫ : ℝ)| = |⟪O, Nb⟫| := by rw [hab', abs_neg]
+  have hAC : |(⟪O, Na⟫ : ℝ)| = |⟪O, Nc⟫| := by rw [hab', abs_neg, hbc']
+  exact ⟨O, _, sphericalIncircle_of_abs_eq hOon hNa hAB hAC, hab', hbc'⟩
+
+/-- **Existence of the spherical excircle opposite the second vertex.**  Uses the external
+bisector of `(Na, Nb)` (pole `Na + Nb`) and the internal bisector of `(Na, Nc)` (pole
+`Na − Nc`), yielding `⟪O,Na⟫ = −⟪O,Nb⟫` and `⟪O,Na⟫ = ⟪O,Nc⟫`; the sign of the second pole is
+the one flipped. -/
+theorem sphericalExcircleB_exists [FiniteDimensional ℝ E] (Na Nb Nc : E)
+    (hNa : OnSphere Na) (hdim : 2 < Module.finrank ℝ E) :
+    ∃ (O : E) (ρ : ℝ), SphericalIncircle Na Nb Nc O ρ ∧
+      (⟪O, Na⟫ : ℝ) = -⟪O, Nb⟫ ∧ (⟪O, Na⟫ : ℝ) = ⟪O, Nc⟫ := by
+  obtain ⟨O, hOon, -, ⟨-, hab⟩, ⟨-, hac⟩, -, -⟩ :=
+    greatCircles_inter (Na + Nb) (Na - Nc) hdim
+  have hab' : (⟪O, Na⟫ : ℝ) = -⟪O, Nb⟫ := by
+    have := hab; rw [inner_add_right] at this; linarith
+  have hac' : (⟪O, Na⟫ : ℝ) = ⟪O, Nc⟫ := by
+    have := hac; rw [inner_sub_right] at this; linarith
+  have hAB : |(⟪O, Na⟫ : ℝ)| = |⟪O, Nb⟫| := by rw [hab', abs_neg]
+  have hAC : |(⟪O, Na⟫ : ℝ)| = |⟪O, Nc⟫| := by rw [hac']
+  exact ⟨O, _, sphericalIncircle_of_abs_eq hOon hNa hAB hAC, hab', hac'⟩
+
+/-- **Existence of the spherical excircle opposite the third vertex.**  Uses the internal
+bisector of `(Na, Nb)` (pole `Na − Nb`) and the external bisector of `(Nb, Nc)` (pole
+`Nb + Nc`), yielding `⟪O,Na⟫ = ⟪O,Nb⟫` and `⟪O,Nb⟫ = −⟪O,Nc⟫`; the sign of the third pole is
+the one flipped. -/
+theorem sphericalExcircleC_exists [FiniteDimensional ℝ E] (Na Nb Nc : E)
+    (hNa : OnSphere Na) (hdim : 2 < Module.finrank ℝ E) :
+    ∃ (O : E) (ρ : ℝ), SphericalIncircle Na Nb Nc O ρ ∧
+      (⟪O, Na⟫ : ℝ) = ⟪O, Nb⟫ ∧ (⟪O, Nb⟫ : ℝ) = -⟪O, Nc⟫ := by
+  obtain ⟨O, hOon, -, ⟨-, hab⟩, ⟨-, hbc⟩, -, -⟩ :=
+    greatCircles_inter (Na - Nb) (Nb + Nc) hdim
+  have hab' : (⟪O, Na⟫ : ℝ) = ⟪O, Nb⟫ := by
+    have := hab; rw [inner_sub_right] at this; linarith
+  have hbc' : (⟪O, Nb⟫ : ℝ) = -⟪O, Nc⟫ := by
+    have := hbc; rw [inner_add_right] at this; linarith
+  have hAB : |(⟪O, Na⟫ : ℝ)| = |⟪O, Nb⟫| := by rw [hab']
+  have hAC : |(⟪O, Na⟫ : ℝ)| = |⟪O, Nc⟫| := by rw [hab', hbc', abs_neg]
+  exact ⟨O, _, sphericalIncircle_of_abs_eq hOon hNa hAB hAC, hab', hbc'⟩
+
 end FeuerbachsTheoremOQ04

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -1,5 +1,45 @@
 # feuerbachs-theorem-oq-04 — Feuerbach's Theorem in Non-Euclidean Geometry
 
+## Session 2026-07-01 (researcher-7): spherical excircles — the other three tritangent circles [VERIFIED]
+
+**Mode**: ACT (CONTINUE). `sphericalIncircle_exists` (already on main) produced *one*
+tritangent circle from intersecting the two internal angle bisectors. Feuerbach's theorem
+requires the nine-point circle to be tangent to the incircle **and the three excircles**, so
+the missing existence ingredient was the other three tritangent circles. **Outcome**:
+PROGRESS — added 4 declarations (~70 L) to `FeuerbachsTheoremOQ04.lean`. **Docker build
+VERIFIED** (`docker-build.sh Proofs.FeuerbachsTheoremOQ04`, `✔ [7743/7743]`); **0-sorry,
+0-axiom**, no native_decide.
+
+### What was delivered (appended after `sphericalIncircle_exists`)
+- **`sphericalIncircle_of_abs_eq`** (shared tail) : a unit centre `O` with `|⟪O,Na⟫| =
+  |⟪O,Nb⟫| = |⟪O,Nc⟫|` gives a circle `sCircle O (arcsin|⟪O,Na⟫|)` tangent to all three sides.
+  Factors the common end of the incircle/excircle proofs (`Real.sin_arcsin` + the
+  Cauchy–Schwarz bound `|⟪O,Na⟫| ≤ 1`).
+- **`sphericalExcircleA_exists`** : excircle opposite the first vertex, from
+  `greatCircles_inter (Na + Nb) (Nb − Nc)` — external bisector of `(Na,Nb)` × internal
+  bisector of `(Nb,Nc)`. Returns `⟪O,Na⟫ = −⟪O,Nb⟫ = −⟪O,Nc⟫` (sign of pole a flipped).
+- **`sphericalExcircleB_exists`** : from `greatCircles_inter (Na + Nb) (Na − Nc)`, returns
+  `⟪O,Na⟫ = −⟪O,Nb⟫`, `⟪O,Na⟫ = ⟪O,Nc⟫` (pole b flipped).
+- **`sphericalExcircleC_exists`** : from `greatCircles_inter (Na − Nb) (Nb + Nc)`, returns
+  `⟪O,Na⟫ = ⟪O,Nb⟫`, `⟪O,Nb⟫ = −⟪O,Nc⟫` (pole c flipped).
+
+Together with the incircle (all-same-sign), this establishes existence of the full family of
+**four tritangent circles** of a spherical triangle — exactly the circles the spherical
+nine-point circle must touch in Feuerbach's theorem. The tangency criterion `|⟪O,N⟫| = sin ρ`
+is sign-insensitive, so all four satisfy the single `SphericalIncircle` predicate; the
+returned sign relations `⟪O,Nᵢ⟫ = ±⟪O,Nⱼ⟫` are what distinguish the four.
+
+GOTCHA: `greatCircles_inter` returns membership `⟪O, N⟫ = 0` for the *pole* `N` (robust to the
+`P` vs `−P` antipodal ambiguity — both give inner product `0`), so the sign *relations*
+between `⟪O,Na⟫, ⟪O,Nb⟫, ⟪O,Nc⟫` are well-defined and provable; the individual signs are not
+(they flip under `O ↦ −O`). Excircle vs incircle is therefore characterised by relative signs.
+
+### Next steps (unchanged direction)
+1. **Spherical nine-point circle** for a spherical triangle (needs side midpoints — see the
+   in-flight midpoint arc-bisection work, branch `research/feuerbach-oq04-midpoint`).
+2. The Feuerbach tangency itself: nine-point circle internally tangent to the incircle and
+   externally tangent to the three excircles. This is the genuinely hard remaining step.
+
 ## Session 2026-06-28 (researcher-4): antipodal-pole layer — two-pole description of a spherical circle [BUILD-PENDING: Docker outage]
 
 **Mode**: ACT (CONTINUE). The metric layer (`sdist_isMetric`, point separation, triangle


### PR DESCRIPTION
## Summary

Feuerbach's theorem states the nine-point circle is tangent to the incircle **and the three excircles**. On `main`, `sphericalIncircle_exists` already produced *one* tritangent circle of a spherical triangle (from intersecting the two internal angle bisectors). This PR adds the remaining three, completing the existence of the full **four tritangent circles** — exactly the circles the spherical nine-point circle must touch.

## What's added (`proofs/Proofs/FeuerbachsTheoremOQ04.lean`, +4 decls, ~70 L)

- **`sphericalIncircle_of_abs_eq`** — shared tail: a unit centre `O` with `|⟪O,Na⟫| = |⟪O,Nb⟫| = |⟪O,Nc⟫|` yields a circle `sCircle O (arcsin|⟪O,Na⟫|)` tangent to all three sides.
- **`sphericalExcircleA_exists`** — excircle opposite vertex A, from `greatCircles_inter (Na + Nb) (Nb − Nc)` (external bisector of `(Na,Nb)` × internal bisector of `(Nb,Nc)`); returns `⟪O,Na⟫ = −⟪O,Nb⟫ = −⟪O,Nc⟫`.
- **`sphericalExcircleB_exists`** — pole b flipped, from `greatCircles_inter (Na + Nb) (Na − Nc)`.
- **`sphericalExcircleC_exists`** — pole c flipped, from `greatCircles_inter (Na − Nb) (Nb + Nc)`.

The tangency criterion `|⟪O,N⟫| = sin ρ` is sign-insensitive, so all four tritangent circles satisfy the single `SphericalIncircle` predicate; the returned sign relations `⟪O,Nᵢ⟫ = ±⟪O,Nⱼ⟫` are what distinguish incircle from the three excircles. These relations are robust to the antipodal (`P` vs `−P`) ambiguity of `greatCircles_inter`, since great-circle membership fixes `⟪O,N⟫ = 0` for the pole.

## Verification

- **Docker build VERIFIED**: `docker-build.sh Proofs.FeuerbachsTheoremOQ04` → `✔ [7743/7743]`
- **0-sorry, 0-axiom**, no `native_decide`.

## Remaining hard step

Spherical nine-point circle + the Feuerbach tangency itself (nine-point circle internally tangent to the incircle, externally tangent to the three excircles). Side-midpoint machinery is in-flight on `research/feuerbach-oq04-midpoint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)