### PR TITLE
Enrich 'Positivity & Spectral Range of Compressions' (cauchy-interlacing-oq-01-oq-02-oq-02): index.ts + 5th annotation

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/annotations.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "ann-poincare-hypothesis-bundle",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 80, "endLine": 92 },
+    "type": "technique",
+    "title": "The Shared Poincaré Hypothesis Bundle and `include`",
+    "content": "The three eigenvalue corollaries all consume the *same* elaborate setup, so it is factored into a single section `variable` block rather than repeated per theorem: the operator `T` with an eigenbasis `b` and descending spectrum `lam` (`hT`, `hlam`), a codimension data `H` of dimension `n` (`hHdim`), the compression `TH` with its own eigenbasis `bH`, spectrum `mu` (`hTH`, `hmu`), and the crucial Rayleigh-agreement hypothesis `hRayleigh` linking the two quotients. Because Lean 4 only auto-includes `variable`s that appear in a theorem's *statement*, hypotheses used solely inside proof bodies (here the whole Poincaré package feeding `poincare_separation`) would be silently dropped; the explicit `include T b hT hlam hHdim TH bH hTH hmu hRayleigh` forces them into every theorem in the section. This is the same `include`-or-vanish pitfall that silently breaks proofs when a hypothesis is named but never referenced in the goal.",
+    "mathContext": "All corollaries are stated for a fixed $(T, b, \\lambda)$ and its compression $(T_H, b_H, \\mu)$ satisfying the Poincaré interlacing hypotheses; the bundle is shared rather than re-declared.",
+    "significance": "technical",
+    "relatedConcepts": ["section variables", "include directive", "Poincaré separation hypotheses", "Rayleigh quotient agreement"]
+  },
+  {
     "id": "ann-compress-isPositive",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02",
     "range": { "startLine": 68, "endLine": 75 },

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/index.ts
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchyInterlacingMajorizationPositivity.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchyInterlacingTheoremOq01Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchyInterlacingTheoremOq01Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchyInterlacingTheoremOq01Oq02Oq02Data: ProofData = {
+  proof: cauchyInterlacingTheoremOq01Oq02Oq02Proof,
+  annotations: cauchyInterlacingTheoremOq01Oq02Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-02-oq-02`.

**Critical fix:**
- **Added missing `index.ts`** — without it, Vite's `import.meta.glob` cannot discover the proof, so the page rendered 'proof not found' on the live site despite appearing in the gallery listing.

**Enrichment:**
- Added `ann-poincare-hypothesis-bundle` (lines 80–92) covering the shared section `variable` block and the load-bearing `include` directive — the Lean-4 'include-or-vanish' pitfall for hypotheses referenced only inside proof bodies. This was the one uncovered structural region between the four per-theorem annotations. Annotation coverage 4 → 5.

meta.json unchanged (already richly enriched, 16.9 KB, within caps). JSON validates.