### PR TITLE
Add IVT OQ-04: Bolzano's theorem for odd-degree polynomials (VERIFIED)

### DIFF
--- a/proofs/Proofs/IntermediateValueTheoremOQ04.lean
+++ b/proofs/Proofs/IntermediateValueTheoremOQ04.lean
@@ -134,7 +134,9 @@ theorem not_irreducible_of_odd_natDegree_ge_three (P : ℝ[X])
 /-- A concrete instance: the cubic `X³ - X - 1` has a real root (odd degree `3`). -/
 example : ∃ x : ℝ, (X ^ 3 - X - 1 : ℝ[X]).eval x = 0 := by
   apply exists_root_of_odd_natDegree
-  compute_degree!
+  have h : (X ^ 3 - X - 1 : ℝ[X]).natDegree = 3 := by compute_degree!
+  rw [h]
+  exact ⟨1, rfl⟩
 
 #check @exists_root_of_odd_natDegree
 #check @not_irreducible_of_odd_natDegree_ge_three

--- a/proofs/Proofs/IntermediateValueTheoremOQ04.lean
+++ b/proofs/Proofs/IntermediateValueTheoremOQ04.lean
@@ -1,0 +1,142 @@
+import Mathlib
+
+/-
+# IVT — OQ-04: Bolzano's Theorem for Polynomials
+
+## Research Problem: intermediate-value-theorem-oq-04
+
+**Statement.** Every real polynomial of odd degree has a real root:
+`P : ℝ[X]`, `Odd P.natDegree` ⟹ `∃ x, P.eval x = 0`.
+
+This is the classical corollary of the Intermediate Value Theorem that is usually
+stated informally as "an odd-degree curve must cross the axis". The parent gallery
+entry `intermediate-value-theorem` states a *placeholder* version
+`odd_degree_poly_has_root` for a generic continuous function that is *assumed* to take
+both a negative and a positive value; it explicitly punts the polynomial case
+("specific polynomial case follows from this"). The genuine mathematical content — the
+part that is NOT a hypothesis — is precisely showing that an odd-degree polynomial
+actually *attains both signs*. That is what this entry proves.
+
+## Why the sign-attainment is the real theorem
+
+A real polynomial `P` of odd degree behaves at the two ends of the real line like its
+leading term `c·xⁿ` with `n` odd: as `x → +∞` it runs off to `+∞` (if `c > 0`) and as
+`x → -∞` it runs off to `-∞`, because `(-x)ⁿ = -xⁿ` for odd `n`. So `P` takes arbitrarily
+large positive and arbitrarily large negative values, and the IVT then forces a zero.
+Mathlib supplies the two asymptotic facts
+(`Polynomial.tendsto_atTop_of_leadingCoeff_nonneg`,
+`Polynomial.tendsto_atBot_of_leadingCoeff_nonpos`); the odd-degree sign flip at `-∞` is
+realised here by composing with `-X` (which negates the leading coefficient exactly when
+the degree is odd) rather than by any hypothesis.
+
+## Results
+- `exists_neg_and_pos_of_pos_leadingCoeff` — an odd-degree polynomial with positive leading
+  coefficient attains a negative value and a positive value (the sign-attainment lemma).
+- `exists_root_of_both_signs` — IVT wrapper: a value `≤ 0` and a value `≥ 0` force a root.
+- `exists_root_of_odd_natDegree` — **Bolzano.** Every odd-degree real polynomial has a root.
+- `not_irreducible_of_odd_natDegree_ge_three` — structural corollary: no real polynomial of
+  odd degree `≥ 3` is irreducible (it splits off a linear factor at the root).
+
+All results are `sorry`-free and axiom-free (no `native_decide`).
+
+Tags: analysis, ivt, bolzano, polynomials, real-roots, irreducibility
+-/
+
+open Polynomial Filter Topology
+
+namespace IntermediateValueTheoremOQ04
+
+/-- **Sign-attainment lemma.** A real polynomial of *odd* degree with *positive* leading
+coefficient attains both a strictly negative value and a strictly positive value.
+
+The positive value comes from `P(x) → +∞` as `x → +∞`. The negative value comes from
+`P(x) → -∞` as `x → -∞`: we realise the left end by composing with `-X`, whose leading
+coefficient `(-1)^{deg P} = -1` (odd degree) makes `P.comp (-X)` a polynomial with negative
+leading coefficient, hence running off to `-∞` at `+∞`. -/
+theorem exists_neg_and_pos_of_pos_leadingCoeff (P : ℝ[X]) (hodd : Odd P.natDegree)
+    (hlc : 0 < P.leadingCoeff) :
+    (∃ a : ℝ, P.eval a < 0) ∧ (∃ b : ℝ, 0 < P.eval b) := by
+  have hpos_nd : 0 < P.natDegree := by rcases hodd with ⟨m, hm⟩; omega
+  have hdeg : 0 < P.degree := natDegree_pos_iff_degree_pos.mp hpos_nd
+  refine ⟨?_, ?_⟩
+  · -- negative value: study `R = P.comp (-X)`, which has negative leading coefficient.
+    set R := P.comp (-X) with hR
+    have hne : (-X : ℝ[X]).natDegree ≠ 0 := by rw [natDegree_neg, natDegree_X]; exact one_ne_zero
+    have hndR : R.natDegree = P.natDegree := by
+      rw [hR, natDegree_comp, natDegree_neg, natDegree_X, mul_one]
+    have hdegR : 0 < R.degree :=
+      natDegree_pos_iff_degree_pos.mp (by rw [hndR]; exact hpos_nd)
+    have hlcR : R.leadingCoeff ≤ 0 := by
+      rw [hR, leadingCoeff_comp hne, leadingCoeff_neg, leadingCoeff_X, Odd.neg_one_pow hodd,
+        mul_neg_one]
+      linarith
+    have htend : Tendsto (fun x => R.eval x) atTop atBot :=
+      R.tendsto_atBot_of_leadingCoeff_nonpos hdegR hlcR
+    obtain ⟨c, hc⟩ := (htend.eventually (eventually_lt_atBot 0)).exists
+    refine ⟨-c, ?_⟩
+    have hval : R.eval c = P.eval (-c) := by rw [hR, eval_comp, eval_neg, eval_X]
+    rwa [hval] at hc
+  · -- positive value: `P(x) → +∞` as `x → +∞`.
+    have htend : Tendsto (fun x => P.eval x) atTop atTop :=
+      P.tendsto_atTop_of_leadingCoeff_nonneg hdeg hlc.le
+    exact (htend.eventually (eventually_gt_atTop 0)).exists
+
+/-- IVT wrapper: if a real polynomial takes a value `≤ 0` and a value `≥ 0`, it has a root.
+Immediate from `intermediate_value_univ₂` applied to `P.eval` and the zero function on the
+(pre)connected space `ℝ`. -/
+theorem exists_root_of_both_signs (P : ℝ[X]) {a b : ℝ}
+    (ha : P.eval a ≤ 0) (hb : 0 ≤ P.eval b) : ∃ x : ℝ, P.eval x = 0 := by
+  have h := intermediate_value_univ₂ (a := a) (b := b) P.continuous continuous_const ha hb
+  simpa using h
+
+/-- **Bolzano's theorem for polynomials.** Every real polynomial of odd degree has a real
+root. The odd degree guarantees the leading term dominates with opposite signs at `±∞`, so
+the polynomial attains both signs and the IVT delivers a zero. -/
+theorem exists_root_of_odd_natDegree (P : ℝ[X]) (hodd : Odd P.natDegree) :
+    ∃ x : ℝ, P.eval x = 0 := by
+  have hP : P ≠ 0 := by
+    rintro rfl; rw [natDegree_zero] at hodd; rcases hodd with ⟨m, hm⟩; omega
+  rcases lt_trichotomy P.leadingCoeff 0 with hlc | hlc | hlc
+  · -- negative leading coefficient: run the lemma on `-P` (same roots) and swap signs.
+    have hodd' : Odd (-P).natDegree := by rwa [natDegree_neg]
+    have hlc' : 0 < (-P).leadingCoeff := by rw [leadingCoeff_neg]; linarith
+    obtain ⟨⟨a, ha⟩, ⟨b, hb⟩⟩ := exists_neg_and_pos_of_pos_leadingCoeff (-P) hodd' hlc'
+    rw [eval_neg] at ha hb
+    -- `ha : -P.eval a < 0` (so `P.eval a > 0`), `hb : 0 < -P.eval b` (so `P.eval b < 0`)
+    exact exists_root_of_both_signs P (show P.eval b ≤ 0 by linarith)
+      (show (0 : ℝ) ≤ P.eval a by linarith)
+  · exact absurd hlc (leadingCoeff_ne_zero.mpr hP)
+  · obtain ⟨⟨a, ha⟩, ⟨b, hb⟩⟩ := exists_neg_and_pos_of_pos_leadingCoeff P hodd hlc
+    exact exists_root_of_both_signs P ha.le hb.le
+
+/-- **Structural corollary.** No real polynomial of odd degree `≥ 3` is irreducible: it has a
+real root by Bolzano, hence splits off a linear factor `X - C a`, leaving a cofactor of
+degree `≥ 2`; neither factor is a unit, contradicting irreducibility. (Together with the
+degree-2 case this is the odd half of "irreducible real polynomials have degree `≤ 2`".) -/
+theorem not_irreducible_of_odd_natDegree_ge_three (P : ℝ[X])
+    (hodd : Odd P.natDegree) (h3 : 3 ≤ P.natDegree) : ¬ Irreducible P := by
+  obtain ⟨a, ha⟩ := exists_root_of_odd_natDegree P hodd
+  intro hirr
+  obtain ⟨Q, hQ⟩ := dvd_iff_isRoot.mpr ha
+  rcases hirr.isUnit_or_isUnit hQ with hu | hu
+  · -- `X - C a` cannot be a unit: it has degree `1`.
+    have h := natDegree_eq_zero_of_isUnit hu
+    rw [natDegree_X_sub_C] at h
+    exact one_ne_zero h
+  · -- `Q` a unit forces `natDegree P = 1`, contradicting `3 ≤ natDegree P`.
+    have hQ0 : Q ≠ 0 := hu.ne_zero
+    have hXne : (X - C a : ℝ[X]) ≠ 0 := X_sub_C_ne_zero a
+    have hnd : P.natDegree = (X - C a).natDegree + Q.natDegree := by
+      rw [hQ, natDegree_mul hXne hQ0]
+    rw [natDegree_X_sub_C, natDegree_eq_zero_of_isUnit hu] at hnd
+    omega
+
+/-- A concrete instance: the cubic `X³ - X - 1` has a real root (odd degree `3`). -/
+example : ∃ x : ℝ, (X ^ 3 - X - 1 : ℝ[X]).eval x = 0 := by
+  apply exists_root_of_odd_natDegree
+  compute_degree!
+
+#check @exists_root_of_odd_natDegree
+#check @not_irreducible_of_odd_natDegree_ge_three
+
+end IntermediateValueTheoremOQ04

--- a/src/data/proofs/intermediate-value-theorem-oq-04/annotations.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-04/annotations.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "intermediate-value-theorem-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Preamble: Discharging the IVT Hypothesis for Polynomials",
+    "content": "The module docstring frames the target — every real polynomial of odd degree has a real root — and pinpoints what makes it a theorem rather than a restatement of the IVT. The parent entry `intermediate-value-theorem` proves a placeholder `odd_degree_poly_has_root` for a generic continuous function that is *assumed* to take both a negative and a positive value, and explicitly punts the polynomial case. The real content, supplied here, is the sign-attainment step: an odd-degree polynomial genuinely attains both signs, so the IVT hypothesis is discharged. The docstring also previews the mechanism — the leading term c·xⁿ with n odd dominates at both ends of ℝ with opposite signs — and the four results in the file.",
+    "mathContext": "For $P \\in \\mathbb{R}[X]$ with $\\deg P = n$ odd and leading coefficient $c$: $P(x) \\sim c x^n$ as $|x| \\to \\infty$. Since $(-x)^n = -x^n$ for odd $n$, the two ends carry opposite signs. With $c > 0$: $P(x) \\to +\\infty$ at $+\\infty$ and $P(x) \\to -\\infty$ at $-\\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Intermediate Value Theorem",
+      "Bolzano's theorem",
+      "leading term dominance",
+      "Fundamental Theorem of Algebra (real analogue)"
+    ],
+    "prerequisites": [
+      "polynomials over ℝ",
+      "degree and leading coefficient",
+      "continuity of polynomial evaluation"
+    ]
+  },
+  {
+    "id": "ann-sign-attainment",
+    "proofId": "intermediate-value-theorem-oq-04",
+    "range": {
+      "startLine": 49,
+      "endLine": 82
+    },
+    "type": "insight",
+    "title": "Sign Attainment via Reflection Through -X",
+    "content": "This is the mathematical heart of the entry. For P of odd degree with positive leading coefficient c, the positive value is easy: P(x) → +∞ as x → +∞ (`tendsto_atTop_of_leadingCoeff_nonneg`), so eventually P(x) > 0. The negative value is subtler because Mathlib provides asymptotics only at the +∞ end. The trick is to reflect: set R = P.comp(-X), so R(y) = P(-y). Then natDegree R = natDegree P (via `natDegree_comp`, since -X has degree 1) and, crucially, leadingCoeff R = c · leadingCoeff(-X)^n = c · (-1)^n = -c, which is negative exactly because n is odd (`Odd.neg_one_pow`). Now R has negative leading coefficient, so R(y) → -∞ as y → +∞ (`tendsto_atBot_of_leadingCoeff_nonpos`), giving y₀ with R(y₀) = P(-y₀) < 0. The negative value of P is attained at -y₀. No separate 'limit at -∞' lemma is needed — reflection converts the left end into the right end.",
+    "mathContext": "$\\operatorname{lc}(P.\\mathrm{comp}(-X)) = \\operatorname{lc}(P)\\cdot \\operatorname{lc}(-X)^{\\deg P} = c\\cdot(-1)^{n} = -c$. Filter argument: `htend.eventually (eventually_lt_atBot 0)).exists` extracts a point where the reflected polynomial is negative; `eval_comp`/`eval_neg`/`eval_X` translate $R(y_0)$ back to $P(-y_0)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polynomial composition",
+      "leadingCoeff_comp",
+      "end behavior / asymptotics",
+      "parity of degree",
+      "filter eventually / Tendsto"
+    ],
+    "prerequisites": [
+      "Polynomial.tendsto_atTop_of_leadingCoeff_nonneg",
+      "Polynomial.tendsto_atBot_of_leadingCoeff_nonpos",
+      "natDegree_comp and leadingCoeff_comp",
+      "Odd.neg_one_pow"
+    ]
+  },
+  {
+    "id": "ann-ivt-wrapper",
+    "proofId": "intermediate-value-theorem-oq-04",
+    "range": {
+      "startLine": 84,
+      "endLine": 90
+    },
+    "type": "concept",
+    "title": "The IVT Wrapper on the Connected Real Line",
+    "content": "Once both signs are attained, the root is delivered by a single Mathlib call: `intermediate_value_univ₂` applied to the two continuous functions P.eval and the constant zero. It states that on a preconnected space, if f a ≤ g a and g b ≤ f b then f and g agree somewhere — here f = P.eval, g = 0, so P.eval a ≤ 0 ≤ P.eval b yields a point where P.eval equals 0. Using the `univ₂` form over all of ℝ (rather than an Icc) sidesteps any need to order a and b or manage interval endpoints; the connectedness of ℝ does the work.",
+    "mathContext": "`intermediate_value_univ₂ (P.continuous) (continuous_const) ha hb` with $P(a) \\leq 0$ and $0 \\leq P(b)$ produces $x$ with $P(x) = 0$. Continuity of $P.\\mathrm{eval}$ is `Polynomial.continuous`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "intermediate value theorem",
+      "preconnected space",
+      "continuity of polynomials"
+    ],
+    "prerequisites": [
+      "intermediate_value_univ₂",
+      "Polynomial.continuous",
+      "connectedness of ℝ"
+    ]
+  },
+  {
+    "id": "ann-bolzano-main",
+    "proofId": "intermediate-value-theorem-oq-04",
+    "range": {
+      "startLine": 92,
+      "endLine": 110
+    },
+    "type": "concept",
+    "title": "Bolzano via Leading-Coefficient Trichotomy",
+    "content": "The main theorem assembles the pieces. First, an odd-degree polynomial is nonzero (the zero polynomial has natDegree 0, which is even). Then trichotomy on the leading coefficient: if it is positive, the sign-attainment lemma and the IVT wrapper close the goal directly; if it is negative, apply the lemma to -P — which has the same roots, the same odd degree, and positive leading coefficient — then translate the attained signs back through eval_neg and swap the inequalities; the zero case contradicts nonzero-ness via `leadingCoeff_ne_zero`. The reduction to -P is the clean way to avoid duplicating the asymptotic analysis for both signs.",
+    "mathContext": "$P \\neq 0$ because $\\operatorname{natDegree}(0) = 0$ is even. For $\\operatorname{lc}(P) < 0$: $\\operatorname{natDegree}(-P) = \\operatorname{natDegree}(P)$ and $\\operatorname{lc}(-P) = -\\operatorname{lc}(P) > 0$; a value where $-P < 0$ is a value where $P > 0$, and vice versa.",
+    "significance": "key",
+    "relatedConcepts": [
+      "case analysis / trichotomy",
+      "root-preserving transformations",
+      "leadingCoeff_neg, natDegree_neg",
+      "sign symmetry P ↔ -P"
+    ],
+    "prerequisites": [
+      "lt_trichotomy",
+      "leadingCoeff_ne_zero",
+      "natDegree_neg and leadingCoeff_neg"
+    ]
+  },
+  {
+    "id": "ann-irreducibility",
+    "proofId": "intermediate-value-theorem-oq-04",
+    "range": {
+      "startLine": 112,
+      "endLine": 144
+    },
+    "type": "insight",
+    "title": "From a Root to Reducibility, and a Concrete Cubic",
+    "content": "The structural corollary turns the analytic existence statement into an algebraic one: no real polynomial of odd degree ≥ 3 is irreducible. Bolzano supplies a root a, so X - C a divides P (`dvd_iff_isRoot`); write P = (X - C a)·Q. Irreducibility would force one factor to be a unit, but X - C a has degree 1 (`natDegree_X_sub_C`) so it is not a unit, and if Q were a unit the degree equation natDegree P = 1 + natDegree Q would give natDegree P = 1, contradicting natDegree P ≥ 3. This is exactly the odd half of the classification 'irreducible real polynomials have degree ≤ 2'. The file closes with a concrete instance: the depressed cubic X³ − X − 1 (odd degree 3) has a real root, with `compute_degree!` discharging the parity hypothesis automatically.",
+    "mathContext": "$(X - C\\,a) \\mid P \\Rightarrow P = (X - C\\,a)Q$. `Irreducible.isUnit_or_isUnit` ⇒ one factor a unit. $\\operatorname{natDegree}(X - C\\,a) = 1 \\neq 0$ rules out the first; a unit $Q$ forces $\\operatorname{natDegree} P = 1$, contradicting $\\geq 3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "irreducible polynomials over ℝ",
+      "linear factors and roots",
+      "classification of ℝ-irreducibles (degree ≤ 2)",
+      "dvd_iff_isRoot"
+    ],
+    "prerequisites": [
+      "dvd_iff_isRoot",
+      "Irreducible.isUnit_or_isUnit",
+      "natDegree_X_sub_C, natDegree_mul",
+      "compute_degree!"
+    ]
+  }
+]

--- a/src/data/proofs/intermediate-value-theorem-oq-04/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-04/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "intermediate-value-theorem-oq-04",
+  "title": "Bolzano's Theorem for Polynomials: Odd Degree Forces a Real Root",
+  "slug": "intermediate-value-theorem-oq-04",
+  "description": "Proves the classical corollary of the Intermediate Value Theorem that every real polynomial of odd degree has a real root. The genuine content is the sign-attainment step — showing an odd-degree polynomial actually takes both a negative and a positive value — realised via the ±∞ asymptotics of the leading term and the odd-degree sign flip at -∞ (composition with -X). A structural corollary follows: no real polynomial of odd degree ≥ 3 is irreducible.",
+  "meta": {
+    "author": "Classical analysis (Bolzano 1817); Lean formalization original",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/IntermediateValueTheoremOQ04.lean",
+    "tags": [
+      "analysis",
+      "ivt",
+      "bolzano",
+      "polynomials",
+      "real-roots",
+      "irreducibility",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 144,
+    "assumptions": "None. Fully machine-checked with 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions, and no native_decide. Depends only on Mathlib.",
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Bolzano's theorem for polynomials: `Odd P.natDegree → ∃ x, P.eval x = 0`, over ℝ — not present in Mathlib",
+      "Sign-attainment lemma: an odd-degree polynomial with positive leading coefficient attains both a strictly negative and a strictly positive value, with the -∞ end realised by composing with -X (which negates the leading coefficient exactly when the degree is odd)",
+      "Structural corollary: no real polynomial of odd degree ≥ 3 is irreducible (the odd half of 'irreducible real polynomials have degree ≤ 2')"
+    ],
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "IntermediateValueTheoremOQ04",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/IntermediateValueTheoremOQ04.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The **Intermediate Value Theorem** was stated by Bernard Bolzano in 1817 in his memoir *Rein analytischer Beweis*, precisely in order to prove — rigorously and without geometric hand-waving — that a continuous function changing sign must have a zero. Bolzano's motivating application was exactly this corollary: **every polynomial of odd degree has a real root.** Before Bolzano and Cauchy (1821), this fact was 'obvious from the graph', and Gauss's 1799 dissertation on the Fundamental Theorem of Algebra had already leaned on such intuitive continuity arguments. The odd-degree root theorem is the real-analytic shadow of the Fundamental Theorem of Algebra: while ℂ is algebraically closed, ℝ is not, and the *only* degrees for which a real polynomial is guaranteed a real root are the odd ones.\n\nThe theorem is also the crux of the classification of irreducible real polynomials: a polynomial irreducible over ℝ has degree 1 or 2. The odd-degree case of that classification is an immediate consequence — an odd-degree polynomial of degree ≥ 3 has a real root, hence a linear factor, hence is reducible.\n\nHistorical milestones:\n- **1799**: Gauss's first proof of the Fundamental Theorem of Algebra uses intuitive continuity/curve-crossing.\n- **1817**: Bolzano gives an analytic proof of the IVT, explicitly to justify the odd-degree root fact.\n- **1821**: Cauchy's *Cours d'analyse* provides a rigorous ε-based treatment.\n- **Modern**: The result is the standard textbook illustration that ℝ, unlike ℂ, is a *real closed* field only in the precise algebraic sense (every odd-degree polynomial has a root and every positive element is a square).",
+    "problemStatement": "**OQ-04**: Prove Bolzano's corollary for polynomials as a genuine theorem — not as a hypothesis-laden placeholder.\n\n**Statement.** For a real polynomial $P \\in \\mathbb{R}[X]$ with $\\deg P$ odd, there exists $x \\in \\mathbb{R}$ with $P(x) = 0$.\n\nThe parent entry `intermediate-value-theorem` states a placeholder `odd_degree_poly_has_root` for a generic continuous function that is *assumed* to attain both signs; it explicitly defers the polynomial case. The mathematical substance omitted there — and supplied here — is the **sign-attainment step**: showing that an odd-degree polynomial genuinely takes both a negative and a positive value, so the IVT hypothesis is *discharged*, not assumed.",
+    "proofStrategy": "**Step 1 — Sign attainment (positive leading coefficient).** Let $P$ have odd natDegree $n \\geq 1$ and leading coefficient $c > 0$. As $x \\to +\\infty$, $P(x) \\to +\\infty$ (`Polynomial.tendsto_atTop_of_leadingCoeff_nonneg`), so $P$ attains a strictly positive value. For the left end, set $R := P \\circ (-X)$, so $R(y) = P(-y)$. Then $\\deg R = \\deg P = n$ and $\\operatorname{lc}(R) = c \\cdot (-1)^n = -c < 0$ (odd $n$). Hence $R(y) \\to -\\infty$ as $y \\to +\\infty$ (`Polynomial.tendsto_atBot_of_leadingCoeff_nonpos`), giving $y_0$ with $R(y_0) = P(-y_0) < 0$. So $P$ attains a strictly negative value at $-y_0$.\n\n**Step 2 — IVT wrapper.** If $P(a) \\leq 0 \\leq P(b)$ then $P$ has a root, by `intermediate_value_univ₂` applied to the continuous functions $P.\\mathrm{eval}$ and the constant $0$ on the connected space $\\mathbb{R}$.\n\n**Step 3 — Bolzano.** Trichotomy on $\\operatorname{lc}(P)$: if $c > 0$, apply Steps 1–2 directly; if $c < 0$, apply Step 1 to $-P$ (same roots, positive leading coefficient) and swap the sign inequalities; $c = 0$ is impossible for a nonzero polynomial (odd degree $\\Rightarrow P \\neq 0$).\n\n**Step 4 — Irreducibility corollary.** A root $a$ gives $(X - C\\,a) \\mid P$; write $P = (X - C\\,a)\\,Q$. If $P$ were irreducible, one factor is a unit — but $X - C\\,a$ has degree $1$ (not a unit), and if $Q$ is a unit then $\\deg P = 1$, contradicting $\\deg P \\geq 3$.",
+    "keyInsights": [
+      "The IVT hypothesis 'f attains both signs' is not free for polynomials — it is a *theorem* about the leading term. Parity of the degree is exactly what makes the two ends of the real line disagree in sign: for odd n, (-x)^n = -x^n, so the leading term flips sign between +∞ and -∞. This is the entire reason odd degree (and not even degree) forces a root.",
+      "The -∞ asymptotic is obtained without a separate 'tendsto at -∞' lemma. Composing with -X reflects the polynomial: P.comp(-X) evaluates to P(-y), turns the left end into a right end, and negates the leading coefficient precisely when the degree is odd (leadingCoeff_comp gives lc(P)·lc(-X)^n = c·(-1)^n). This reduces the missing half to the same atTop machinery Mathlib already provides.",
+      "Reducing to positive leading coefficient via -P is a clean symmetry: P and -P have the same roots, the same (odd) degree, and opposite-sign leading coefficients. It halves the case analysis to a single application of the sign-attainment lemma.",
+      "This theorem is the real-analytic complement to the Fundamental Theorem of Algebra. Over ℂ every non-constant polynomial has a root; over ℝ the guarantee holds exactly for odd degrees. The even-degree obstruction is genuine — x² + 1 has no real root — which is why the parity hypothesis cannot be dropped.",
+      "The irreducibility corollary shows the analytic fact has algebraic teeth: it forces the odd half of the classification of ℝ-irreducible polynomials (degree ≤ 2). No degree-3-or-higher real polynomial is irreducible, because Bolzano hands it a linear factor."
+    ],
+    "prerequisites": [
+      "Intermediate Value Theorem (intermediate_value_univ₂ for continuous functions on ℝ)",
+      "Polynomial asymptotics: tendsto_atTop_of_leadingCoeff_nonneg and tendsto_atBot_of_leadingCoeff_nonpos",
+      "Polynomial composition: natDegree_comp and leadingCoeff_comp",
+      "Continuity of polynomial evaluation (Polynomial.continuous)",
+      "Divisibility and roots: dvd_iff_isRoot, X_sub_C factorization, Irreducible.isUnit_or_isUnit"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Introduction: Bolzano's Corollary as a Theorem",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module header stating the target — every odd-degree real polynomial has a real root — and explaining why the sign-attainment step (not the IVT itself) is the genuine mathematical content the parent entry defers.",
+      "mathContext": "Target: $P \\in \\mathbb{R}[X]$, $\\deg P$ odd $\\Rightarrow \\exists x,\\ P(x) = 0$. The leading term $c x^n$ with $n$ odd dominates at both ends: $\\to +\\infty$ at $+\\infty$ and $\\to -\\infty$ at $-\\infty$ (for $c>0$), so $P$ attains both signs and the IVT delivers a zero."
+    },
+    {
+      "id": "sign-attainment",
+      "title": "Sign-Attainment Lemma",
+      "startLine": 49,
+      "endLine": 82,
+      "summary": "An odd-degree polynomial with positive leading coefficient attains a strictly negative and a strictly positive value. The positive value is from P(x)→+∞ at +∞; the negative value is from the reflected polynomial R = P.comp(-X), whose leading coefficient is negated by the odd degree, running to -∞ at +∞.",
+      "mathContext": "$\\operatorname{lc}(P.\\mathrm{comp}(-X)) = \\operatorname{lc}(P)\\cdot(-1)^{\\deg P} = -c$ for odd degree. `tendsto_atBot_of_leadingCoeff_nonpos` then yields $y_0$ with $P(-y_0) < 0$; `tendsto_atTop_of_leadingCoeff_nonneg` yields $b$ with $P(b) > 0$."
+    },
+    {
+      "id": "ivt-wrapper",
+      "title": "IVT Wrapper: Two Signs Force a Root",
+      "startLine": 84,
+      "endLine": 90,
+      "summary": "If a polynomial takes a value ≤ 0 and a value ≥ 0, it has a root — a direct application of intermediate_value_univ₂ to P.eval and the constant zero on the connected real line.",
+      "mathContext": "$P(a) \\leq 0 \\leq P(b)$ with $P.\\mathrm{eval}$ continuous and $\\mathbb{R}$ preconnected $\\Rightarrow 0 \\in \\operatorname{range}(P.\\mathrm{eval})$."
+    },
+    {
+      "id": "bolzano",
+      "title": "Bolzano's Theorem for Polynomials",
+      "startLine": 92,
+      "endLine": 110,
+      "summary": "The main theorem. Trichotomy on the leading coefficient: positive uses the sign-attainment lemma directly; negative applies it to -P (same roots) and swaps signs; zero is impossible for the nonzero odd-degree polynomial.",
+      "mathContext": "$P \\neq 0$ since $\\deg P$ odd. For $\\operatorname{lc}(P) < 0$, use that $-P$ has the same roots, odd degree, and positive leading coefficient."
+    },
+    {
+      "id": "irreducibility",
+      "title": "Structural Corollary: No Odd Degree ≥ 3 Is Irreducible",
+      "startLine": 112,
+      "endLine": 132,
+      "summary": "A real polynomial of odd degree ≥ 3 is reducible: Bolzano gives a root a, hence a factor X - C a; neither X - C a (degree 1) nor the cofactor Q (which would force degree 1) can be a unit, contradicting irreducibility.",
+      "mathContext": "$(X - C\\,a) \\mid P$ from $P(a)=0$; `Irreducible.isUnit_or_isUnit` forces a unit factor, but $\\deg(X - C\\,a) = 1$ and a unit $Q$ gives $\\deg P = 1 < 3$."
+    },
+    {
+      "id": "concrete-example",
+      "title": "Concrete Instance: X³ − X − 1",
+      "startLine": 134,
+      "endLine": 144,
+      "summary": "The depressed cubic X³ − X − 1 (odd degree 3) has a real root, dispatched by the main theorem with compute_degree! verifying the odd-degree hypothesis.",
+      "mathContext": "$X^3 - X - 1$ has natDegree $3$ (odd); the theorem applies with no case-specific work."
+    }
+  ],
+  "conclusion": {
+    "summary": "Every real polynomial of odd degree has a real root, proved from the Intermediate Value Theorem by discharging — rather than assuming — the sign-attainment hypothesis. The two-sided asymptotics of the leading term supply a negative and a positive value; the odd-degree sign flip at -∞ is captured by composing with -X. A structural corollary follows immediately: no real polynomial of odd degree ≥ 3 is irreducible.",
+    "implications": "This is the real-analytic shadow of the Fundamental Theorem of Algebra. ℂ is algebraically closed, but ℝ is not; the odd-degree root theorem pins down exactly which real polynomials are *forced* to have real roots by continuity alone, and the parity hypothesis is essential (x² + 1 witnesses the even-degree failure).\n\nThe irreducibility corollary connects the analytic statement to the algebraic classification of ℝ-irreducible polynomials: every irreducible real polynomial has degree ≤ 2. Combined with the degree-2 discriminant analysis, this is the structural backbone of real polynomial factorization, partial-fraction decomposition, and the real Jordan/rational canonical form.\n\nFor formalization, the file shows that a textbook 'obvious from the graph' fact becomes a short, fully verified proof once the correct Mathlib asymptotic lemmas are located and the -∞ end is handled by reflection rather than a bespoke limit.",
+    "openQuestions": [
+      "Can the full classification of ℝ-irreducible polynomials (degree ≤ 2, with the degree-2 case governed by the discriminant) be assembled from this odd-degree half plus a negative-discriminant analysis?",
+      "Does the same reflection technique (compose with -X) give clean formal proofs of related end-behavior facts, e.g. that an even-degree polynomial with negative leading coefficient and a positive value has at least two real roots (counted by sign changes)?",
+      "How does this relate to a Lean formalization of real closed fields? The two axioms defining a real closed field are 'every positive element is a square' and 'every odd-degree polynomial has a root' — this entry formalizes the second for ℝ concretely.",
+      "Can an effective/constructive version bound the location of a root (e.g. within [-(1+‖coeffs‖), 1+‖coeffs‖] via Cauchy's bound), turning the existence proof into a bracketing suitable for the bisection entries in this IVT family?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Bolzano, Bernard",
+      "title": "Rein analytischer Beweis des Lehrsatzes, dass zwischen je zwey Werthen, die ein entgegengesetztes Resultat gewähren, wenigstens eine reelle Wurzel der Gleichung liege",
+      "year": "1817",
+      "venue": "Gottlieb Haase, Prague",
+      "note": "The memoir introducing an analytic proof of the Intermediate Value Theorem, motivated precisely by the odd-degree real-root theorem for polynomials."
+    },
+    {
+      "authors": "Cauchy, Augustin-Louis",
+      "title": "Cours d'analyse de l'École Royale Polytechnique",
+      "year": "1821",
+      "venue": "Imprimerie Royale, Paris",
+      "note": "Provides a rigorous ε-treatment of continuity and the IVT, consolidating Bolzano's approach."
+    },
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Demonstratio nova theorematis omnem functionem algebraicam rationalem integram unius variabilis in factores reales primi vel secundi gradus resolvi posse",
+      "year": "1799",
+      "venue": "Doctoral dissertation, University of Helmstedt",
+      "note": "First proof of the Fundamental Theorem of Algebra; leans on intuitive continuity/curve-crossing arguments of the kind Bolzano later made rigorous. The title asserts the real factorization into degree-1 and degree-2 factors implied by the odd-degree corollary."
+    }
+  ]
+}

--- a/src/data/research/problems/intermediate-value-theorem-oq-04.json
+++ b/src/data/research/problems/intermediate-value-theorem-oq-04.json
@@ -1,0 +1,98 @@
+{
+  "slug": "intermediate-value-theorem-oq-04",
+  "title": "Bolzano's Theorem for Polynomials: Odd Degree Forces a Real Root",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\forall P \\in \\mathbb{R}[X],\\ \\text{Odd}(\\deg P) \\Rightarrow \\exists x \\in \\mathbb{R},\\ P(x) = 0",
+    "plain": "Every real polynomial of odd degree has a real root. This is the classical corollary of the Intermediate Value Theorem; the genuine content is showing that an odd-degree polynomial actually attains both a negative and a positive value, which discharges the IVT hypothesis rather than assuming it.",
+    "whyMatters": [
+      "Real-analytic analogue of the Fundamental Theorem of Algebra: pins down exactly which real polynomials are forced to have real roots by continuity (odd degrees only).",
+      "Forces the odd half of the classification of ℝ-irreducible polynomials (degree ≤ 2)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "exists_neg_and_pos_of_pos_leadingCoeff — sign-attainment lemma",
+      "exists_root_of_both_signs — IVT wrapper",
+      "exists_root_of_odd_natDegree — Bolzano for polynomials",
+      "not_irreducible_of_odd_natDegree_ge_three — irreducibility corollary"
+    ],
+    "open": [],
+    "goal": "Prove odd-degree real polynomials have a real root, VERIFIED and axiom-free."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-01",
+    "iteration": 1,
+    "focus": "Completed: verified 0-axiom proof plus gallery integration.",
+    "blockers": [],
+    "nextAction": "None — shipped.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: VERIFIED 0-axiom proof of Bolzano for polynomials (4 theorems) with gallery integration.",
+    "builtItems": [
+      "exists_neg_and_pos_of_pos_leadingCoeff in Proofs/IntermediateValueTheoremOQ04.lean",
+      "exists_root_of_both_signs in Proofs/IntermediateValueTheoremOQ04.lean",
+      "exists_root_of_odd_natDegree in Proofs/IntermediateValueTheoremOQ04.lean",
+      "not_irreducible_of_odd_natDegree_ge_three in Proofs/IntermediateValueTheoremOQ04.lean"
+    ],
+    "insights": [
+      "Mathlib provides polynomial end-behavior only at +∞ (tendsto_atTop/atBot with the atTop input filter). The -∞ end is obtained by reflection: compose with -X so P.comp(-X)(y) = P(-y); leadingCoeff_comp negates the leading coefficient exactly when the degree is odd (c·(-1)^n).",
+      "intermediate_value_univ₂ over all of ℝ avoids ordering the two sign-change points a, b or managing an Icc.",
+      "Reducing to positive leading coefficient via -P (same roots, same odd degree) halves the case analysis."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no 'odd-degree real polynomial has a root' lemma, nor a 'tendsto at atBot input filter' polynomial asymptotic; the reflection workaround fills the latter."
+    ],
+    "nextSteps": [
+      "Optional follow-up: assemble the full ℝ-irreducible classification (degree ≤ 2) by combining this odd-degree half with a degree-2 discriminant analysis.",
+      "Optional follow-up: Cauchy root bound to turn existence into an explicit bracketing for the bisection entries in this IVT family."
+    ],
+    "markdown": "# Knowledge Base: intermediate-value-theorem-oq-04\n\n## Problem\nEvery real polynomial of odd degree has a real root (Bolzano's corollary of the IVT).\n\n## Result (COMPLETE, VERIFIED, 0-axiom)\nFour theorems in `Proofs/IntermediateValueTheoremOQ04.lean`:\n- `exists_neg_and_pos_of_pos_leadingCoeff` — sign attainment.\n- `exists_root_of_both_signs` — IVT wrapper via `intermediate_value_univ₂`.\n- `exists_root_of_odd_natDegree` — the main theorem.\n- `not_irreducible_of_odd_natDegree_ge_three` — structural corollary.\n\n## Key technique\nThe missing -∞ asymptotic is realised by composing with `-X`: `P.comp(-X)(y) = P(-y)` and `leadingCoeff (P.comp(-X)) = leadingCoeff P · (-1)^{deg P} = -c` for odd degree, so the reflected polynomial runs to -∞ at +∞ and supplies a negative value of P.\n\n## Mathlib lemmas used\n`tendsto_atTop_of_leadingCoeff_nonneg`, `tendsto_atBot_of_leadingCoeff_nonpos`, `natDegree_comp`, `leadingCoeff_comp`, `Odd.neg_one_pow`, `intermediate_value_univ₂`, `Polynomial.continuous`, `dvd_iff_isRoot`, `Irreducible.isUnit_or_isUnit`, `natDegree_X_sub_C`.\n"
+  },
+  "tags": [
+    "analysis",
+    "ivt",
+    "bolzano",
+    "polynomials",
+    "real-roots",
+    "irreducibility"
+  ],
+  "relatedProofs": [
+    "intermediate-value-theorem",
+    "intermediate-value-theorem-oq-01",
+    "intermediate-value-theorem-oq-02",
+    "intermediate-value-theorem-oq-03"
+  ],
+  "references": {
+    "papers": [
+      "Bolzano (1817), Rein analytischer Beweis"
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Analysis.Polynomial.Basic",
+      "Mathlib.Topology.Order.IntermediateValue"
+    ]
+  },
+  "started": "2026-07-01",
+  "lastUpdate": "2026-07-01",
+  "leanFiles": [
+    {
+      "path": "Proofs/IntermediateValueTheoremOQ04.lean",
+      "filename": "IntermediateValueTheoremOQ04.lean",
+      "lineCount": 144,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes **Bolzano's theorem for polynomials**: every real polynomial of odd degree has a real root. `intermediate-value-theorem-oq-04`.

The parent gallery entry `intermediate-value-theorem` states a *placeholder* `odd_degree_poly_has_root` for a generic continuous function that is *assumed* to attain both signs. The genuine mathematical content — discharging that hypothesis for odd-degree polynomials — is exactly what this entry proves.

## Results (all `sorry`-free, axiom-free, no `native_decide`)

- `exists_neg_and_pos_of_pos_leadingCoeff` — sign-attainment lemma. Uses the ±∞ asymptotics of the leading term; the -∞ end is realised by composing with `-X`, which negates the leading coefficient exactly when the degree is odd, reducing the missing half to the same `atTop` machinery Mathlib already provides.
- `exists_root_of_both_signs` — IVT wrapper via `intermediate_value_univ₂`.
- `exists_root_of_odd_natDegree` — **Bolzano.** Trichotomy on the leading coefficient; the negative case runs the lemma on `-P`.
- `not_irreducible_of_odd_natDegree_ge_three` — structural corollary: no real polynomial of odd degree ≥ 3 is irreducible (the odd half of the classification of ℝ-irreducible polynomials).

## Verification

Docker build passes: `./proofs/scripts/docker-build.sh Proofs.IntermediateValueTheoremOQ04` (7743 jobs, built successfully). status `verified`, badge `original`, 0 sorries / 0 axioms.

## Gallery

Adds `src/data/proofs/intermediate-value-theorem-oq-04/` (meta.json + annotations.json) and the research problem entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)