### PR TITLE
Enrich 'Weyl Eigenvalue Stability Bound' (cauchy-interlacing-oq-03-oq-01): index.ts + header annotation

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-stability-oq0301-header",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
+    "range": { "startLine": 4, "endLine": 42 },
+    "type": "concept",
+    "title": "The Open Question: Quantitative Stability from Qualitative Monotonicity",
+    "content": "The module docstring frames the deliverable: this file answers the lead open question of the parent entry cauchy-interlacing-theorem-oq-03 — derive the operator-norm eigenvalue stability bound |μ(k) − ν(k)| ≤ ‖T − U‖ (Weyl's perturbation theorem, eigenvalues are 1-Lipschitz in the operator norm) purely from the already-proven Weyl MONOTONICITY theorem weyl_monotone, itself a 0-sorry/0-axiom corollary of the Courant–Fischer keystone (#25063). The strategy is the Loewner sandwich: with δ = ‖T − U‖, the elementary Rayleigh bound re⟪(T−U)x,x⟫ ≤ δ‖x‖² yields U − δ·I ⪯ T ⪯ U + δ·I; the shifted operators U ± δ·I reuse U's eigenbasis with eigenvalues ν ± δ, and feeding both inequalities into weyl_monotone brackets μ(k) between ν(k) − δ and ν(k) + δ. No new spectral theory is introduced — the qualitative monotonicity result already contains the quantitative Lipschitz bound.",
+    "mathContext": "Answers parent oq-03: from $weyl\\_monotone$ obtain $|\\mu_k - \\nu_k| \\le \\|T-U\\|$ via $U - \\|T-U\\| I \\preceq T \\preceq U + \\|T-U\\| I$.",
+    "significance": "context",
+    "relatedConcepts": ["Weyl perturbation theorem", "Loewner sandwich", "Courant–Fischer keystone", "open question resolution"],
+    "prerequisites": ["Weyl monotonicity", "operator norm", "Loewner order"]
+  },
+  {
     "id": "ann-stability-oq0301-setup",
     "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
     "range": { "startLine": 44, "endLine": 50 },

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/index.ts
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchyInterlacingOQ030101Stability.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchyInterlacingTheoremOq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchyInterlacingTheoremOq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchyInterlacingTheoremOq03Oq01Data: ProofData = {
+  proof: cauchyInterlacingTheoremOq03Oq01Proof,
+  annotations: cauchyInterlacingTheoremOq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-03-oq-01`.

**Critical fix:**
- **Added missing `index.ts`** — without it the page rendered 'proof not found' on the live site despite appearing in the gallery listing.

**Enrichment:**
- Added `ann-stability-oq0301-header` (lines 4–42) covering the module docstring / open-question framing (derive the quantitative Lipschitz bound |μ_k − ν_k| ≤ ‖T−U‖ from qualitative `weyl_monotone` via the Loewner sandwich) — the one uncovered region above the four per-lemma annotations. Coverage 4 → 5.

meta.json unchanged (already richly enriched, 16.5 KB, within caps). JSON validates.