### PR TITLE
Enrich 'Cyclic Vectors: Full Characterization & Count' (cayley-hamilton-oq-04-...-oq-01): index.ts + header annotation

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-cyc-oq0401-header",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01",
+    "range": { "startLine": 6, "endLine": 32 },
+    "type": "concept",
+    "title": "Closing a One-Directional Result into an Exact Characterization",
+    "content": "The module docstring states the research goal: the parent file proved only the ONE-DIRECTIONAL result that if minpoly K M is irreducible of degree n then every NONZERO vector is cyclic for M. This file closes the gap into an iff and extracts the enumerative consequence the parent left unstated. The arc is four steps: (1) zero_not_cyclic supplies the single missing obstruction (0 is never cyclic); (2) cyclic_iff_ne_zero combines it with the parent to get 'cyclic ⟺ nonzero'; (3) setOf_cyclic_eq_compl_zero repackages this geometrically as the punctured space {0}ᶜ; (4) ncard_cyclic_vectors counts the cyclic locus over a finite field as exactly qⁿ − 1. The theme is sharpness: such a matrix is 'uniformly cyclic', its cyclic locus as large as possible — the whole space minus the one unavoidable excluded point.",
+    "mathContext": "Parent: $\\mathrm{minpoly}\\,K\\,M$ irreducible of degree $n \\Rightarrow$ every $v \\ne 0$ is cyclic. Here: cyclic $\\iff v \\ne 0$, and over finite $K$ the count is $q^n - 1$.",
+    "significance": "context",
+    "relatedConcepts": ["cyclic vector", "irreducible minimal polynomial", "uniform cyclicity", "enumerative sharpening"],
+    "prerequisites": ["the parent one-directional theorem", "cyclic vectors", "minimal polynomial of a matrix"]
+  },
+  {
     "id": "ann-cyc-oq0401-zero",
     "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01",
     "range": { "startLine": 40, "endLine": 48 },

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01/index.ts
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cayleyHamiltonMinpolyOq04BackwardIncomplete01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cayleyHamiltonMinpolyOq04BackwardIncomplete01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cayleyHamiltonMinpolyOq04BackwardIncomplete01Oq01Data: ProofData = {
+  proof: cayleyHamiltonMinpolyOq04BackwardIncomplete01Oq01Proof,
+  annotations: cayleyHamiltonMinpolyOq04BackwardIncomplete01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01`.

**Critical fix:**
- **Added missing `index.ts`** — without it the page rendered 'proof not found' on the live site despite appearing in the gallery listing.

**Enrichment:**
- Added `ann-cyc-oq0401-header` (lines 6–32) covering the module docstring / research-problem framing (closing the parent's one-directional 'nonzero ⟹ cyclic' into the iff 'cyclic ⟺ nonzero', then the finite-field count qⁿ − 1). The one uncovered region above the four per-theorem annotations; coverage 4 → 5.

meta.json unchanged (11 KB, within caps). JSON validates.