### PR TITLE
Research: erdos-1018 - repair compile + prove superlinear_forces_nonplanar

### DIFF
--- a/proofs/Proofs/Erdos1018Problem.lean
+++ b/proofs/Proofs/Erdos1018Problem.lean
@@ -15,6 +15,8 @@ import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Subgraph
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Algebra.Order.Floor.Semiring
 
 open SimpleGraph
 
@@ -124,9 +126,14 @@ def hasSmallNonPlanarSubgraph (G : SimpleGraph V) (k : ℕ) : Prop :=
 Does there exist C_ε such that dense graphs have small non-planar subgraphs?
 -/
 
-/-- For fixed ε > 0, there exists C_ε bounding the non-planar subgraph size. -/
+/-- For fixed ε > 0, there exists C_ε bounding the non-planar subgraph size.
+
+    We quantify over vertex types in `Type` (universe 0). This is no loss of
+    generality — every finite graph is isomorphic to one on a `Type 0` vertex
+    set — and it keeps `erdos_1018_question` universe-monomorphic (otherwise the
+    body carries an unassigned universe metavariable under Lean 4.26). -/
 def existsBoundingConstant (ε : ℝ) : Prop :=
-  ε > 0 → ∃ C : ℕ, ∃ N : ℕ, ∀ (V : Type*) [Fintype V] [DecidableEq V],
+  ε > 0 → ∃ C : ℕ, ∃ N : ℕ, ∀ (V : Type) [Fintype V] [DecidableEq V],
     Fintype.card V ≥ N →
     ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
       isDense G ε → hasSmallNonPlanarSubgraph G C
@@ -200,7 +207,48 @@ theorem superlinear_forces_nonplanar (ε : ℝ) (hε : ε > 0) :
       Fintype.card V ≥ N →
       ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
         isDense G ε → isNonPlanar G := by
-  sorry
+  -- Choose N above the crossover point 3^(1/ε): once n^ε > 3, a planar graph
+  -- (which has ≤ 3n − 6 ≤ 3n edges) can no longer carry n^(1+ε) = n · n^ε edges.
+  refine ⟨⌈(3 : ℝ) ^ (1 / ε)⌉₊ + 1, ?_⟩
+  intro V _ _ hN G _ hDense
+  -- `isNonPlanar G` unfolds to `¬ isPlanar G`; assume planarity for contradiction.
+  intro hPlanar
+  -- n ≥ N ≥ 1, so n is a positive real.
+  have hn1 : 1 ≤ Fintype.card V := le_trans (Nat.le_add_left 1 _) hN
+  have hnpos : (0 : ℝ) < (Fintype.card V : ℝ) := by exact_mod_cast hn1
+  -- Planarity gives the linear edge bound; relax `3n − 6 ≤ 3n` over ℝ.
+  have hedge : edgeCount G ≤ 3 * Fintype.card V - 6 := planar_linear_bound V G hPlanar
+  have hedgeR : (edgeCount G : ℝ) ≤ 3 * (Fintype.card V : ℝ) := by
+    have h1 : (edgeCount G : ℝ) ≤ ((3 * Fintype.card V - 6 : ℕ) : ℝ) := by exact_mod_cast hedge
+    have h2 : ((3 * Fintype.card V - 6 : ℕ) : ℝ) ≤ ((3 * Fintype.card V : ℕ) : ℝ) := by
+      exact_mod_cast Nat.sub_le _ _
+    push_cast at h2
+    linarith
+  -- Density gives the super-linear lower bound.
+  have hdense' : (Fintype.card V : ℝ) ^ (1 + ε) ≤ (edgeCount G : ℝ) := hDense
+  -- Split the exponent: n^(1+ε) = n · n^ε.
+  have hsplit : (Fintype.card V : ℝ) ^ (1 + ε)
+      = (Fintype.card V : ℝ) * (Fintype.card V : ℝ) ^ ε := by
+    rw [Real.rpow_add hnpos, Real.rpow_one]
+  -- Hence n · n^ε ≤ 3n = n · 3, and cancelling n > 0 gives n^ε ≤ 3.
+  have hle : (Fintype.card V : ℝ) * (Fintype.card V : ℝ) ^ ε
+      ≤ (Fintype.card V : ℝ) * 3 := by
+    rw [← hsplit]; linarith
+  have hnε_le : (Fintype.card V : ℝ) ^ ε ≤ 3 := le_of_mul_le_mul_left hle hnpos
+  -- But n > 3^(1/ε) forces n^ε > (3^(1/ε))^ε = 3, a contradiction.
+  have hTpos : (0 : ℝ) ≤ (3 : ℝ) ^ (1 / ε) := Real.rpow_nonneg (by norm_num) _
+  have hnT : (3 : ℝ) ^ (1 / ε) < (Fintype.card V : ℝ) := by
+    have hceil : (3 : ℝ) ^ (1 / ε) ≤ (⌈(3 : ℝ) ^ (1 / ε)⌉₊ : ℝ) := Nat.le_ceil _
+    have hstep : ((⌈(3 : ℝ) ^ (1 / ε)⌉₊ : ℝ)) + 1 ≤ (Fintype.card V : ℝ) := by
+      exact_mod_cast hN
+    linarith
+  have hmono : ((3 : ℝ) ^ (1 / ε)) ^ ε < (Fintype.card V : ℝ) ^ ε :=
+    Real.rpow_lt_rpow hTpos hnT hε
+  have hcollapse : ((3 : ℝ) ^ (1 / ε)) ^ ε = 3 := by
+    rw [← Real.rpow_mul (by norm_num : (0 : ℝ) ≤ 3), one_div,
+      inv_mul_cancel₀ (ne_of_gt hε), Real.rpow_one]
+  rw [hcollapse] at hmono
+  linarith
 
 /-
 ## Quantitative Bounds

--- a/proofs/Proofs/Stubs/Erdos1018Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos1018Problem.lean
@@ -15,6 +15,8 @@ import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Subgraph
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Algebra.Order.Floor.Semiring
 
 open SimpleGraph
 
@@ -124,9 +126,14 @@ def hasSmallNonPlanarSubgraph (G : SimpleGraph V) (k : ℕ) : Prop :=
 Does there exist C_ε such that dense graphs have small non-planar subgraphs?
 -/
 
-/-- For fixed ε > 0, there exists C_ε bounding the non-planar subgraph size. -/
+/-- For fixed ε > 0, there exists C_ε bounding the non-planar subgraph size.
+
+    We quantify over vertex types in `Type` (universe 0). This is no loss of
+    generality — every finite graph is isomorphic to one on a `Type 0` vertex
+    set — and it keeps `erdos_1018_question` universe-monomorphic (otherwise the
+    body carries an unassigned universe metavariable under Lean 4.26). -/
 def existsBoundingConstant (ε : ℝ) : Prop :=
-  ε > 0 → ∃ C : ℕ, ∃ N : ℕ, ∀ (V : Type*) [Fintype V] [DecidableEq V],
+  ε > 0 → ∃ C : ℕ, ∃ N : ℕ, ∀ (V : Type) [Fintype V] [DecidableEq V],
     Fintype.card V ≥ N →
     ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
       isDense G ε → hasSmallNonPlanarSubgraph G C
@@ -200,7 +207,48 @@ theorem superlinear_forces_nonplanar (ε : ℝ) (hε : ε > 0) :
       Fintype.card V ≥ N →
       ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
         isDense G ε → isNonPlanar G := by
-  sorry
+  -- Choose N above the crossover point 3^(1/ε): once n^ε > 3, a planar graph
+  -- (which has ≤ 3n − 6 ≤ 3n edges) can no longer carry n^(1+ε) = n · n^ε edges.
+  refine ⟨⌈(3 : ℝ) ^ (1 / ε)⌉₊ + 1, ?_⟩
+  intro V _ _ hN G _ hDense
+  -- `isNonPlanar G` unfolds to `¬ isPlanar G`; assume planarity for contradiction.
+  intro hPlanar
+  -- n ≥ N ≥ 1, so n is a positive real.
+  have hn1 : 1 ≤ Fintype.card V := le_trans (Nat.le_add_left 1 _) hN
+  have hnpos : (0 : ℝ) < (Fintype.card V : ℝ) := by exact_mod_cast hn1
+  -- Planarity gives the linear edge bound; relax `3n − 6 ≤ 3n` over ℝ.
+  have hedge : edgeCount G ≤ 3 * Fintype.card V - 6 := planar_linear_bound V G hPlanar
+  have hedgeR : (edgeCount G : ℝ) ≤ 3 * (Fintype.card V : ℝ) := by
+    have h1 : (edgeCount G : ℝ) ≤ ((3 * Fintype.card V - 6 : ℕ) : ℝ) := by exact_mod_cast hedge
+    have h2 : ((3 * Fintype.card V - 6 : ℕ) : ℝ) ≤ ((3 * Fintype.card V : ℕ) : ℝ) := by
+      exact_mod_cast Nat.sub_le _ _
+    push_cast at h2
+    linarith
+  -- Density gives the super-linear lower bound.
+  have hdense' : (Fintype.card V : ℝ) ^ (1 + ε) ≤ (edgeCount G : ℝ) := hDense
+  -- Split the exponent: n^(1+ε) = n · n^ε.
+  have hsplit : (Fintype.card V : ℝ) ^ (1 + ε)
+      = (Fintype.card V : ℝ) * (Fintype.card V : ℝ) ^ ε := by
+    rw [Real.rpow_add hnpos, Real.rpow_one]
+  -- Hence n · n^ε ≤ 3n = n · 3, and cancelling n > 0 gives n^ε ≤ 3.
+  have hle : (Fintype.card V : ℝ) * (Fintype.card V : ℝ) ^ ε
+      ≤ (Fintype.card V : ℝ) * 3 := by
+    rw [← hsplit]; linarith
+  have hnε_le : (Fintype.card V : ℝ) ^ ε ≤ 3 := le_of_mul_le_mul_left hle hnpos
+  -- But n > 3^(1/ε) forces n^ε > (3^(1/ε))^ε = 3, a contradiction.
+  have hTpos : (0 : ℝ) ≤ (3 : ℝ) ^ (1 / ε) := Real.rpow_nonneg (by norm_num) _
+  have hnT : (3 : ℝ) ^ (1 / ε) < (Fintype.card V : ℝ) := by
+    have hceil : (3 : ℝ) ^ (1 / ε) ≤ (⌈(3 : ℝ) ^ (1 / ε)⌉₊ : ℝ) := Nat.le_ceil _
+    have hstep : ((⌈(3 : ℝ) ^ (1 / ε)⌉₊ : ℝ)) + 1 ≤ (Fintype.card V : ℝ) := by
+      exact_mod_cast hN
+    linarith
+  have hmono : ((3 : ℝ) ^ (1 / ε)) ^ ε < (Fintype.card V : ℝ) ^ ε :=
+    Real.rpow_lt_rpow hTpos hnT hε
+  have hcollapse : ((3 : ℝ) ^ (1 / ε)) ^ ε = 3 := by
+    rw [← Real.rpow_mul (by norm_num : (0 : ℝ) ≤ 3), one_div,
+      inv_mul_cancel₀ (ne_of_gt hε), Real.rpow_one]
+  rw [hcollapse] at hmono
+  linarith
 
 /-
 ## Quantitative Bounds

--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 6,
     "erdosNumber": 1018,
     "erdosUrl": "https://erdosproblems.com/1018",
     "erdosProblemStatus": "solved",
@@ -26,8 +26,8 @@
       "erdos-945"
     ],
     "axiomCount": 14,
-    "lineCount": 260,
-    "assumptions": "14 axioms across the chain: the main file `Proofs/Erdos1018Problem.lean` declares 7 (K5_nonplanar, K33_nonplanar, kuratowski_theorem, kostochka_pyber, constant_grows, planar_linear_bound, kostochka_pyber_explicit), and `Proofs/Stubs/Erdos1018Problem.lean` re-declares the same 7 (byte-identical duplicate); the Lean kernel treats each declaration site as a distinct assumption. K5_nonplanar: K₅ is non-planar. K33_nonplanar: K₃,₃ is non-planar. kuratowski_theorem: non-planar iff contains K₅ or K₃,₃ subdivision. kostochka_pyber: ε-dense graphs contain K₅ subdivisions on ≤ C(ε) vertices (1988). constant_grows: C(ε) → ∞ as ε → 0. planar_linear_bound: planar graphs have ≤ 3n−6 edges. kostochka_pyber_explicit: polynomial bound in 1/ε. 7 sorries in the main file (incomplete topological and density definitions).",
+    "lineCount": 308,
+    "assumptions": "14 axioms across the chain: the main file `Proofs/Erdos1018Problem.lean` declares 7 (K5_nonplanar, K33_nonplanar, kuratowski_theorem, kostochka_pyber, constant_grows, planar_linear_bound, kostochka_pyber_explicit), and `Proofs/Stubs/Erdos1018Problem.lean` re-declares the same 7 (byte-identical duplicate); the Lean kernel treats each declaration site as a distinct assumption. K5_nonplanar: K₅ is non-planar. K33_nonplanar: K₃,₃ is non-planar. kuratowski_theorem: non-planar iff contains K₅ or K₃,₃ subdivision. kostochka_pyber: ε-dense graphs contain K₅ subdivisions on ≤ C(ε) vertices (1988). constant_grows: C(ε) → ∞ as ε → 0. planar_linear_bound: planar graphs have ≤ 3n−6 edges. kostochka_pyber_explicit: polynomial bound in 1/ε. 6 sorries remain in the main file: three definition sorries (isPlanar, containsSubdivision, turanK5Subdivision — Mathlib 4.26 has no topological planarity), the K₅-subdivision⇒non-planarity step of erdos_1018_solved, and the two density-tradeoff lemmas sparse_hides_nonplanarity and dense_exceeds_turan. superlinear_forces_nonplanar (super-linear density forces global non-planarity) is now fully proved from planar_linear_bound. The file also required a Lean 4.26 compile repair (rpow/ceil imports; existsBoundingConstant quantified over Type to remove a universe metavariable).",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
     "definitionCount": 15,
@@ -40,7 +40,7 @@
   "overview": {
     "historicalContext": "**Planarity, Density, and Topological Obstructions**\n\nThe study of planar graphs has deep roots: Euler's formula (1752) implies that planar graphs on $n \\ge 3$ vertices have at most $3n - 6$ edges—a linear bound. Kuratowski (1930) characterized non-planarity: a graph is non-planar if and only if it contains a subdivision of $K_5$ or $K_{3,3}$. Wagner (1937) proved the equivalent minor characterization.\n\nErdős asked a quantitative refinement: if a graph has $n^{1+\\varepsilon}$ edges (super-linear density), must non-planarity be concentrated in a *small* subgraph? Specifically, does there exist a constant $C_\\varepsilon$, depending only on $\\varepsilon$ and not on $n$, such that every such graph contains a non-planar subgraph on at most $C_\\varepsilon$ vertices?\n\n**Kostochka and Pyber (1988)** resolved this affirmatively, proving that graphs with $n^{1+\\varepsilon}$ edges contain $K_5$ subdivisions on $O_\\varepsilon(1)$ vertices. Their proof uses the probabilistic method combined with extremal graph theory. Mader (1967) had earlier shown that the Turán number for $K_t$ subdivisions is $O(t\\sqrt{\\log t} \\cdot n)$, establishing a linear threshold for topological containment. The Kostochka-Pyber result goes further by bounding the *size* of the subdivision found.\n\nErdős also observed that $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$: as the density approaches linear, non-planarity becomes more diffuse and cannot be localized to a small subgraph. This tradeoff between density and obstruction size is a recurring theme in extremal graph theory.",
     "problemStatement": "**Problem Statement**\n\nLet ε > 0. Is there a constant C_ε such that, for all large n, every graph on n vertices with at least n^(1+ε) edges must contain a non-planar subgraph on at most C_ε vertices?\n\n**Status**: SOLVED (Kostochka-Pyber 1988)\n\n**Answer**: YES. Dense graphs contain K₅ subdivisions with O_ε(1) vertices.\n\n**Note**: Erdős observed C_ε → ∞ as ε → 0 (sparser graphs hide non-planarity in larger structures).",
-    "text": "A formalization of Erdős Problem #1018 in 261 lines with 7 axioms, 7 sorries, and 15 definitions. The file formalizes the graph-theoretic framework (edge count, density, planarity, Kuratowski's characterization, induced subgraphs) and the main question: for $\\varepsilon > 0$, does every $n$-vertex graph with $n^{1+\\varepsilon}$ edges contain a non-planar subgraph on $O_\\varepsilon(1)$ vertices? The Kostochka-Pyber (1988) positive resolution is axiomatized, with the quantitative bound $C_\\varepsilon = \\lceil 1/\\varepsilon^2 \\rceil$ and the Mader Turán number $\\text{ex}(n, TK_5) = O(n)$ as key supporting axioms. The density-size tradeoff $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$ is formalized via Mathlib's `Filter.Tendsto`.",
+    "text": "A formalization of Erdős Problem #1018 in 308 lines with 7 axioms, 6 sorries, and 15 definitions. The file formalizes the graph-theoretic framework (edge count, density, planarity, Kuratowski's characterization, induced subgraphs) and the main question: for $\\varepsilon > 0$, does every $n$-vertex graph with $n^{1+\\varepsilon}$ edges contain a non-planar subgraph on $O_\\varepsilon(1)$ vertices? The Kostochka-Pyber (1988) positive resolution is axiomatized, with the quantitative bound $C_\\varepsilon = \\lceil 1/\\varepsilon^2 \\rceil$ and the Mader Turán number $\\text{ex}(n, TK_5) = O(n)$ as key supporting axioms. The density-size tradeoff $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$ is formalized via Mathlib's `Filter.Tendsto`.",
     "proofStrategy": "**Proof Approach (Kostochka-Pyber)**\n\n1. **Density Threshold**: Graphs with n^(1+ε) edges are 'super-linearly dense'.\n\n2. **Finding Structure**: Use probabilistic or extremal methods to find vertices of high degree.\n\n3. **K₅ Subdivision**: High-degree vertices connect through short paths, forming a K₅ subdivision.\n\n4. **Bounding Size**: The total vertices used (5 branch vertices + path vertices) is O_ε(1).\n\n**Key Insight**: Super-linear edge density forces enough local structure that K₅ subdivisions must appear in bounded-size subgraphs.",
     "keyInsights": [
       "**Linear planarity threshold**: Euler's formula gives $|E| \\le 3n - 6$ for planar graphs, so the density exponent $1 + \\varepsilon$ with $\\varepsilon > 0$ is the precise threshold where planarity breaks down",
@@ -234,23 +234,25 @@
       "Mathlib.Combinatorics.SimpleGraph.Basic",
       "Mathlib.Combinatorics.SimpleGraph.Subgraph",
       "Mathlib.Data.Real.Basic",
-      "Mathlib.Data.Fintype.Basic"
+      "Mathlib.Data.Fintype.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Algebra.Order.Floor.Semiring"
     ],
     "opens": [
       "SimpleGraph"
     ],
     "namespace": "Erdos1018",
-    "lineCount": 260,
+    "lineCount": 308,
     "axiomCount": 7,
     "theoremCount": 4,
     "definitionCount": 15,
     "path": "Proofs/Erdos1018Problem.lean",
-    "sorries": 7,
+    "sorries": 6,
     "additionalFiles": [
       "Proofs/Erdos1018Aristotle.lean",
       "Proofs/Stubs/Erdos1018Aristotle.lean",
       "Proofs/Stubs/Erdos1018Problem.lean"
     ]
   },
-  "sorries": 7
+  "sorries": 6
 }

--- a/src/data/research/problems/erdos-1018-incomplete-01.json
+++ b/src/data/research/problems/erdos-1018-incomplete-01.json
@@ -1,0 +1,63 @@
+{
+  "slug": "erdos-1018-incomplete-01",
+  "title": "Erdős #1018 Non-Planar Subgraph — Sorry Completion & Compile Repair",
+  "phase": "ACT",
+  "status": "progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Complete outstanding sorries in Proofs/Erdos1018Problem.lean (Erdős #1018: dense graphs contain small non-planar subgraphs, Kostochka–Pyber 1988).",
+    "plain": "The main formalization file for Erdős #1018 had 7 sorries and (under Mathlib 4.26) no longer compiled. Goal: repair compilation and discharge whatever sorries follow from the stated axioms.",
+    "whyMatters": [
+      "A broken gallery entry misrepresents the project's verified status; repairing it and proving a real lemma both count as concrete progress."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "superlinear_forces_nonplanar is now fully proved from the planar_linear_bound axiom: for ε>0 there is N with card V ≥ N ⇒ any ε-dense graph is non-planar. Threshold N = ⌈3^(1/ε)⌉+1; core inequality n^(1+ε)=n·n^ε ≤ 3n forces n^ε ≤ 3, contradicting n^ε > (3^(1/ε))^ε = 3.",
+      "Compile repair: the file did not build on Mathlib 4.26 (missing rpow instance HPow ℝ ℝ, unknown Nat.ceil, and a universe metavariable in erdos_1018_question). Fixed by importing Analysis.SpecialFunctions.Pow.Real + Algebra.Order.Floor.Semiring and quantifying existsBoundingConstant over Type (universe 0).",
+      "Same repairs applied to the byte-identical Stubs/Erdos1018Problem.lean; both targets build cleanly."
+    ],
+    "open": [
+      "isPlanar, containsSubdivision, turanK5Subdivision remain def-sorries: Mathlib 4.26 has no topological graph planarity, so these are BLOCKED (>1000 lines of foundational theory).",
+      "erdos_1018_solved's final step (K₅ subdivision ⇒ non-planarity) depends on the def-sorries.",
+      "sparse_hides_nonplanarity and dense_exceeds_turan require genuine constructions / the turan def, not derivable from current axioms."
+    ],
+    "goal": "Reduce sorry/error count honestly; leave a compiling, clearly-scoped axiomatized entry."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-07-01T11:04:53Z",
+    "iteration": 1,
+    "focus": "Repaired compilation + proved superlinear_forces_nonplanar (7→6 sorries). Remaining sorries blocked on absent Mathlib planarity theory."
+  },
+  "knowledge": {
+    "phase": "ACT",
+    "progressSummary": "PROGRESS: repaired Mathlib-4.26 compile breakage (rpow/ceil imports + universe fix) and proved superlinear_forces_nonplanar from planar_linear_bound. Sorries 7→6 in both Erdos1018Problem.lean and its Stubs duplicate. Remaining 3 def-sorries blocked (no planarity in Mathlib).",
+    "insights": [
+      "The file was a broken gallery entry: it failed to compile under Mathlib 4.26 (HPow ℝ ℝ unsynthesized, unknown Nat.ceil, universe metavariable) despite meta claiming 260-line/7-sorry axiomatized status — a false-verified hazard for auditors.",
+      "The universe metavariable came from a def whose body applies a Type*-polymorphic def while its own signature (: Prop) binds no universe; pinning the inner ∀ to Type removes the metavar without weakening the mathematics.",
+      "superlinear_forces_nonplanar is the conceptual heart of 'why the answer is YES': super-linear density n^(1+ε) exceeds the planar edge budget 3n-6, so density alone (via planar_linear_bound) already forces global non-planarity — the hard part is only the *small subgraph* localization (Kostochka-Pyber, still axiomatized)."
+    ],
+    "builtItems": [
+      "Proved superlinear_forces_nonplanar in Proofs/Erdos1018Problem.lean (rpow crossover argument, ~45 lines)",
+      "Compile repair to Proofs/Erdos1018Problem.lean and Proofs/Stubs/Erdos1018Problem.lean (imports + Type-pinned existsBoundingConstant)",
+      "Updated src/data/proofs/erdos-1018/meta.json (sorries 7→6, lineCount, imports, assumptions)"
+    ],
+    "nextSteps": [
+      "Def-sorries (isPlanar etc.) require formalizing graph planarity in Mathlib — track as BLOCKED until upstream support exists.",
+      "erdos_1018_solved final step becomes provable once containsSubdivision/isPlanar are defined."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "erdos",
+    "graph-theory",
+    "completion",
+    "compile-repair"
+  ],
+  "started": "2026-07-01T11:04:53Z",
+  "lastUpdate": "2026-07-01T11:04:53Z",
+  "significance": 6,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary
Research session for `erdos-1018-incomplete-01` ("Non-Planar Subgraph Sorry Completion"). The main formalization file for Erdős #1018 had **stopped compiling under Mathlib 4.26** and carried 7 sorries. This PR repairs the build and discharges one theorem sorry that follows from the file's stated axioms.

## Progress
- **Compile repair** (`Proofs/Erdos1018Problem.lean` + its byte-identical `Proofs/Stubs/Erdos1018Problem.lean`): the file failed with three hard errors —
  - `failed to synthesize HPow ℝ ℝ` (real `rpow` used in `isDense`/`dense_exceeds_turan` without the analysis import),
  - `Unknown constant Nat.ceil` (in `explicitBound`),
  - `erdos_1018_question contains universe level metavariables`.

  Fixed by adding `import Mathlib.Analysis.SpecialFunctions.Pow.Real` and `import Mathlib.Algebra.Order.Floor.Semiring`, and by quantifying `existsBoundingConstant` over `Type` (universe 0) instead of `Type*` — this removes the unassigned universe metavariable with no loss of generality (every finite graph lives on a `Type 0` vertex set).
- **Proved `superlinear_forces_nonplanar`** from the `planar_linear_bound` axiom: for `ε > 0`, once `card V ≥ ⌈3^(1/ε)⌉ + 1`, any `ε`-dense graph is non-planar. Core argument: `n^(1+ε) = n·n^ε ≤ 3n` (planar edge budget) forces `n^ε ≤ 3`, contradicting `n^ε > (3^(1/ε))^ε = 3`.
- **Sorries 7 → 6** in both files. Updated `meta.json` and added research knowledge JSON.

## Findings
- This was a **broken/false-verified gallery entry**: `meta.json` advertised a 260-line, 7-sorry axiomatized formalization, but the Lean source did not build on the current Mathlib. Auditors/mechanics should treat "compiles" as independent of the meta claim.
- `superlinear_forces_nonplanar` is the conceptual heart of the affirmative answer: super-linear density *alone* forces global non-planarity; the genuinely hard content (localizing to a **small** subgraph, Kostochka–Pyber 1988) remains axiomatized.

## Status
**Outcome**: progress (compile repair + 1 sorry eliminated; 6 remain).
**Remaining sorries are BLOCKED**: `isPlanar`, `containsSubdivision`, `turanK5Subdivision` are definition sorries requiring topological graph planarity, which Mathlib 4.26 does not have (>1000 lines of foundational theory). `erdos_1018_solved`'s final step and the two density-tradeoff lemmas depend on these.
**Verification**: `./proofs/scripts/docker-build.sh Proofs.Erdos1018Problem` and `Proofs.Stubs.Erdos1018Problem` both build cleanly (only `sorry`/linter warnings).
**Axiom status**: unchanged — 14 assumptions (`status: axiomatized`).

🤖 Generated by researcher-4