### PR TITLE
Enrich Weyl eigenvalue stability bound (cauchy-interlacing-oq-03-oq-01): 5th annotation

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/annotations.json
@@ -53,9 +53,31 @@
     ]
   },
   {
+    "id": "ann-stability-oq0301-statement",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
+    "range": { "startLine": 104, "endLine": 112 },
+    "type": "definition",
+    "title": "The Theorem Interface: Spectral Presentation as Input",
+    "content": "The signature encodes the design choice that keeps the whole family variational. Rather than reconstructing spectra internally, `weyl_eigenvalue_stability` receives each operator together with its spectral data: T with an orthonormal eigenbasis `b`, an antitone (descending) eigenvalue enumeration `μ : Fin n → ℝ`, and the eigen-equations `hbT : ∀ i, T (b i) = (μ i) • b i`; U symmetrically with `c`, `ν`, `hcU`. `[FiniteDimensional 𝕜 E]` guarantees such an enumeration is a genuine finite descending list (so index `k : Fin n` and the max–min keystone underneath make sense), while the operators being continuous (`E →L[𝕜] E`) makes `‖T − U‖` the true operator norm. Because the presentation is taken as a hypothesis — always available for a symmetric operator by the spectral theorem — the file needs no self-adjointness machinery and reuses `weyl_monotone` verbatim; the conclusion `|μ k − ν k| ≤ ‖T − U‖` is the pointwise Lipschitz bound for each fixed coordinate `k`.",
+    "mathContext": "$$T(b_i)=\\mu_i\\,b_i,\\ \\ U(c_i)=\\nu_i\\,c_i,\\quad \\mu,\\nu\\ \\text{antitone};\\qquad \\forall k,\\ |\\mu_k-\\nu_k|\\le\\|T-U\\|.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "spectral theorem presentation",
+      "orthonormal eigenbasis",
+      "antitone eigenvalue enumeration",
+      "finite-dimensional inner product space",
+      "operator norm"
+    ],
+    "prerequisites": [
+      "the spectral theorem for symmetric operators",
+      "OrthonormalBasis and Fin n indexing",
+      "continuous linear maps E →L[𝕜] E"
+    ]
+  },
+  {
     "id": "ann-stability-oq0301-sandwich",
     "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
-    "range": { "startLine": 103, "endLine": 156 },
+    "range": { "startLine": 113, "endLine": 156 },
     "type": "insight",
     "title": "The Loewner Sandwich Lipschitz Bound",
     "content": "weyl_eigenvalue_stability is the classical Weyl perturbation theorem |μ(k) − ν(k)| ≤ ‖T − U‖ — eigenvalues are 1-Lipschitz in the operator norm. The proof needs no new spectral theory: with δ = ‖T − U‖, the Rayleigh bound gives the two Loewner inequalities U − δ·I ⪯ T ⪯ U + δ·I. Feeding T ⪯ U + δ·I into the parent's weyl_monotone (with the shifted operator's eigenvalues ν + δ) yields μ(k) ≤ ν(k) + δ; feeding U − δ·I ⪯ T (using ‖U − T‖ = ‖T − U‖ via norm_sub_rev) yields ν(k) − δ ≤ μ(k). The two one-sided bounds combine through abs_le into |μ(k) − ν(k)| ≤ δ. This is the structural point: the qualitative monotonicity of the parent already contains the quantitative stability bound — bracket and apply twice.",


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-03-oq-01` (0 passes, quality 89 — arrived rich from research but below the 5-annotation minimum).

**Changes**
- Added a 5th annotation `ann-stability-oq0301-statement` covering the theorem *interface*: why the spectral presentation (orthonormal eigenbasis + antitone eigenvalue enumeration) is taken as input for both T and U, the role of `[FiniteDimensional 𝕜 E]`, and why continuous operators make `‖T − U‖` the genuine operator norm. Full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.
- Tightened the existing `sandwich` annotation range to the proof body (113–156) so statement (104–112) and body coverage are disjoint.

**Not changed**: meta.json is already comprehensive (16.5 KB, well under the 60 KB cap; rich historicalContext, 4 keyInsights, conclusion with implications + 2 open questions, crossReferences to parent/grandparent). No deepening needed — curation, not accretion.

No `index.ts` added: proof loading moved to build-generated `listings.json`/`data-manifest.json` (issue #20993); per-proof `index.ts` is legacy and not required for discoverability.

Validated: annotations.json + meta.json parse; check-meta-size passes (within all caps).