### PR TITLE
Enrich cyclic-vector characterization (cayley-hamilton-minpoly-oq-04...oq-01): 5th annotation

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-cyc-oq0401-setup",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "context",
+    "title": "A corollary file layered on the verified parent",
+    "content": "The architecture is a thin strengthening layer, not a re-derivation. The first import is the parent `CayleyHamiltonMinpolyOQ04BackwardIncomplete01`, which already proves the hard direction (`cyclic_of_irreducible_minpoly`: irreducible full-degree $\\mathrm{minpoly}\\,K\\,M \\Rightarrow$ every nonzero vector is cyclic) with $0$ sorries; `Mathlib.Data.Set.Card` and `Mathlib.Data.Fintype.BigOperators` supply only the counting apparatus ($\\mathrm{Set.ncard}$, `Fintype.card_fun`) for the finite-field enumeration. The `variable` block fixes a general field $K$ and dimension $n$, so the characterization (`cyclic_iff_ne_zero`, `setOf_cyclic_eq_compl_zero`) holds over any field; only the final count `ncard_cyclic_vectors` adds a `[Fintype K]` hypothesis to specialize to $q = |K|$. This separation keeps the qualitative iff field-agnostic and isolates finiteness to the one place it is genuinely used.",
+    "mathContext": "$K$ an arbitrary field for the iff; a `[Fintype K]` instance with $q = |K|$ is added only for the $q^n - 1$ count.",
+    "significance": "context",
+    "relatedConcepts": ["module import architecture", "cyclic vector", "corollary layering", "finite field specialization"],
+    "prerequisites": ["the verified parent entry", "IsCyclicVector", "Set.ncard and Fintype cardinality"]
+  },
+  {
     "id": "ann-cyc-oq0401-zero",
     "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01",
     "range": { "startLine": 40, "endLine": 48 },


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01` (0 passes, quality 89 — arrived rich from research but below the 5-annotation minimum).

**Changes**
- Added a 5th annotation `ann-cyc-oq0401-setup` covering the previously unannotated setup/import region (lines 1–37): the corollary architecture that imports the verified parent for the hard direction, pulls in only the counting apparatus (`Set.ncard`, `Fintype.card_fun`), keeps the iff field-agnostic over a general field `K`, and isolates `[Fintype K]` to the single `qⁿ − 1` count. Full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

**Not changed**: meta.json is already comprehensive (11 KB, well under the 60 KB cap; full overview with 4 keyInsights, conclusion with implications + 2 open questions, 3 sections, references, crossReferences). Curation, not accretion.

Validated: annotations.json + meta.json parse; check-meta-size passes (within all caps).