### PR TITLE
Enrich 'Two-Sided Central Binomial Bound' (chebyshev-bounds-oq-06): index.ts + header annotation

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-06/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-chebo06-header",
+    "proofId": "chebyshev-bounds-oq-06",
+    "range": { "startLine": 4, "endLine": 31 },
+    "type": "concept",
+    "title": "The Workhorse Sandwich Behind Chebyshev Prime-Counting",
+    "content": "The docstring frames this file as a routine but load-bearing assembly: the two-sided bound 4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ is the estimate that drives Chebyshev-type prime-counting inequalities. The UPPER bound feeds the O(n) bound on θ(n) = ∑_{p≤n} log p (each prime p in (n,2n] divides C(2n,n), so ∏ p ≤ C(2n,n) ≤ 4ⁿ ⟹ θ-type upper bound); the LOWER bound forces enough prime factors into C(2n,n) to drive the lower estimate on π(n). Neither inequality is new — the lower is Mathlib's Nat.four_pow_le_two_mul_add_one_mul_central_binom (from (1+1)^{2n} = ∑ C(2n,m) with the central term largest), the upper a one-line corollary of Nat.choose_le_two_pow — but Mathlib records the even-row upper bound C(2n,n) ≤ 4ⁿ nowhere, and the packaged sandwich (ℕ, quotient, and real-valued forms) is the reusable, axiom-free building block this entry contributes to the axiomatized parent chebyshev-bounds.",
+    "mathContext": "$\\frac{4^n}{2n+1} \\le \\binom{2n}{n} \\le 4^n$ — the central term dominates its row ($\\ge$ average $4^n/(2n+1)$) yet is bounded by the full row sum $2^{2n} = 4^n$.",
+    "significance": "context",
+    "relatedConcepts": ["central binomial coefficient", "Chebyshev prime-counting bounds", "row sum of Pascal's triangle", "axiom-free building block"],
+    "prerequisites": ["binomial coefficients", "Chebyshev θ and π functions", "central term is the row maximum"]
+  },
+  {
     "id": "ann-upper-bound",
     "proofId": "chebyshev-bounds-oq-06",
     "range": { "startLine": 38, "endLine": 45 },

--- a/src/data/proofs/chebyshev-bounds-oq-06/index.ts
+++ b/src/data/proofs/chebyshev-bounds-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevBoundsOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevBoundsOq06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevBoundsOq06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevBoundsOq06Data: ProofData = {
+  proof: chebyshevBoundsOq06Proof,
+  annotations: chebyshevBoundsOq06Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `chebyshev-bounds-oq-06`.

**Critical fix:**
- **Added missing `index.ts`** — without it the page rendered 'proof not found' on the live site despite appearing in the gallery listing.

**Enrichment:**
- Added `ann-chebo06-header` (lines 4–31) covering the module docstring: the workhorse sandwich `4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ` behind Chebyshev prime-counting bounds (upper → θ(n), lower → π(n)), assembled axiom-free from Mathlib primitives. Annotations 4 → 5.

meta.json unchanged (12 KB, within caps). JSON validates.