### PR TITLE
research(herons-formula-oq-07): Weitzenböck's inequality a²+b²+c² ≥ 4√3·Area [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/HeronsFormulaOQ07.lean
+++ b/proofs/Proofs/HeronsFormulaOQ07.lean
@@ -1,0 +1,188 @@
+/-
+  Weitzenböck's Inequality from Heron's Formula
+
+  For any nondegenerate triangle with side lengths a, b, c and area
+  Area = √(s(s-a)(s-b)(s-c)) (s = (a+b+c)/2 the semi-perimeter),
+
+      a² + b² + c² ≥ 4·√3·Area,
+
+  with equality if and only if the triangle is equilateral (a = b = c).
+
+  This is a child of the Heron's formula gallery entry (oq-07). Squaring both
+  sides turns the statement into a polynomial inequality in a, b, c, because
+  (4√3)² = 48 and Area² = s(s-a)(s-b)(s-c):
+
+      (a² + b² + c²)² ≥ 48·s(s-a)(s-b)(s-c).
+
+  The mathematical heart is the sum-of-squares certificate
+
+      (a²+b²+c²)² - 48·s(s-a)(s-b)(s-c)
+          = 2·((a²-b²)² + (b²-c²)² + (c²-a²)²)  ≥ 0,
+
+  which holds for ALL reals a, b, c (no triangle inequality needed). The
+  triangle inequalities enter only to make Area² ≥ 0, so that Area = √(Area²)
+  is real and the squaring step is reversible. Equality forces each square to
+  vanish, i.e. a² = b² = c², which for positive sides means a = b = c.
+
+  Axioms: 0
+  Sorries: 0
+-/
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Tactic
+
+namespace WeitzenbockHeronOQ07
+
+open Real
+
+-- ════════════════════════════════════════════════════════════════
+-- PART I: Triangle data — semi-perimeter, Heron product, area
+-- ════════════════════════════════════════════════════════════════
+
+/-- Semi-perimeter. -/
+noncomputable def semiperimeter (a b c : ℝ) : ℝ := (a + b + c) / 2
+
+/-- Heron's product `s(s-a)(s-b)(s-c)`; the squared area. -/
+noncomputable def heronProduct (a b c : ℝ) : ℝ :=
+  semiperimeter a b c * (semiperimeter a b c - a)
+    * (semiperimeter a b c - b) * (semiperimeter a b c - c)
+
+/-- Heron's area `√(s(s-a)(s-b)(s-c))`. -/
+noncomputable def area (a b c : ℝ) : ℝ := sqrt (heronProduct a b c)
+
+/-- For a nondegenerate triangle, Heron's product is non-negative. -/
+theorem heronProduct_nonneg {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    0 ≤ heronProduct a b c := by
+  unfold heronProduct semiperimeter
+  apply mul_nonneg
+  apply mul_nonneg
+  apply mul_nonneg
+  all_goals linarith
+
+-- ════════════════════════════════════════════════════════════════
+-- PART II: The algebraic core — a sum-of-squares certificate
+-- ════════════════════════════════════════════════════════════════
+
+/-- **The Weitzenböck SOS identity.** For all reals,
+
+    `(a²+b²+c²)² - 48·heronProduct a b c = 2·((a²-b²)²+(b²-c²)²+(c²-a²)²)`.
+
+This is the exact certificate behind the squared inequality; being an identity,
+it also supplies the equality case. -/
+theorem sq_sum_sub_heron (a b c : ℝ) :
+    (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 - 48 * heronProduct a b c
+      = 2 * ((a ^ 2 - b ^ 2) ^ 2 + (b ^ 2 - c ^ 2) ^ 2 + (c ^ 2 - a ^ 2) ^ 2) := by
+  unfold heronProduct semiperimeter
+  ring
+
+/-- **The squared Weitzenböck inequality** (holds for all reals, no triangle
+condition): `48·heronProduct a b c ≤ (a²+b²+c²)²`. -/
+theorem weitzenbock_sq (a b c : ℝ) :
+    48 * heronProduct a b c ≤ (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 := by
+  nlinarith [sq_nonneg (a ^ 2 - b ^ 2), sq_nonneg (b ^ 2 - c ^ 2),
+             sq_nonneg (c ^ 2 - a ^ 2), sq_sum_sub_heron a b c]
+
+/-- Equality in the squared inequality forces `a² = b²` and `b² = c²`. -/
+theorem weitzenbock_sq_eq_iff (a b c : ℝ) :
+    (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 = 48 * heronProduct a b c ↔
+      a ^ 2 = b ^ 2 ∧ b ^ 2 = c ^ 2 := by
+  constructor
+  · intro h
+    have hsos : (a ^ 2 - b ^ 2) ^ 2 + (b ^ 2 - c ^ 2) ^ 2 + (c ^ 2 - a ^ 2) ^ 2 = 0 := by
+      have := sq_sum_sub_heron a b c; linarith
+    have t1 : 0 ≤ (a ^ 2 - b ^ 2) ^ 2 := sq_nonneg _
+    have t2 : 0 ≤ (b ^ 2 - c ^ 2) ^ 2 := sq_nonneg _
+    have t3 : 0 ≤ (c ^ 2 - a ^ 2) ^ 2 := sq_nonneg _
+    have e1 : (a ^ 2 - b ^ 2) ^ 2 = 0 := by linarith
+    have e2 : (b ^ 2 - c ^ 2) ^ 2 = 0 := by linarith
+    exact ⟨by nlinarith [sq_eq_zero_iff.mp e1], by nlinarith [sq_eq_zero_iff.mp e2]⟩
+  · rintro ⟨h1, h2⟩
+    have := sq_sum_sub_heron a b c
+    nlinarith [this, h1, h2]
+
+-- ════════════════════════════════════════════════════════════════
+-- PART III: Weitzenböck's inequality
+-- ════════════════════════════════════════════════════════════════
+
+/-- **Weitzenböck's inequality.** For a nondegenerate triangle,
+
+    `4·√3·Area ≤ a² + b² + c²`.
+
+The area is `√(heronProduct a b c)`; both sides are non-negative, so the claim
+is equivalent to the squared inequality `weitzenbock_sq`, upgraded through
+`Real.sqrt` monotonicity. -/
+theorem weitzenbock {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    4 * Real.sqrt 3 * area a b c ≤ a ^ 2 + b ^ 2 + c ^ 2 := by
+  have hp : 0 ≤ heronProduct a b c := heronProduct_nonneg ha hb hc hab hbc hca
+  set A : ℝ := area a b c with hA
+  have hA2 : A ^ 2 = heronProduct a b c := by rw [hA, area]; exact Real.sq_sqrt hp
+  have hA0 : 0 ≤ A := by rw [hA, area]; exact Real.sqrt_nonneg _
+  set s3 : ℝ := Real.sqrt 3 with hs3
+  have hs32 : s3 ^ 2 = 3 := by rw [hs3]; exact Real.sq_sqrt (by norm_num)
+  have hs30 : 0 ≤ s3 := by rw [hs3]; exact Real.sqrt_nonneg _
+  -- the squared inequality, phrased for Y = 4·s3·A and X = a²+b²+c²
+  have hYsq : (4 * s3 * A) ^ 2 = 48 * heronProduct a b c := by
+    have : (4 * s3 * A) ^ 2 = 16 * s3 ^ 2 * A ^ 2 := by ring
+    rw [this, hs32, hA2]; ring
+  have hsq : (4 * s3 * A) ^ 2 ≤ (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 := by
+    rw [hYsq]; exact weitzenbock_sq a b c
+  have hY0 : 0 ≤ 4 * s3 * A := by positivity
+  have hX0 : 0 ≤ a ^ 2 + b ^ 2 + c ^ 2 := by positivity
+  have h := Real.sqrt_le_sqrt hsq
+  rwa [Real.sqrt_sq hY0, Real.sqrt_sq hX0] at h
+
+/-- **Equality in Weitzenböck's inequality holds iff the triangle is
+equilateral.** -/
+theorem weitzenbock_eq_iff {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    4 * Real.sqrt 3 * area a b c = a ^ 2 + b ^ 2 + c ^ 2 ↔ a = b ∧ b = c := by
+  have hp : 0 ≤ heronProduct a b c := heronProduct_nonneg ha hb hc hab hbc hca
+  have hA2 : area a b c ^ 2 = heronProduct a b c := by rw [area]; exact Real.sq_sqrt hp
+  have hA0 : 0 ≤ area a b c := by rw [area]; exact Real.sqrt_nonneg _
+  have hs32 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have hs30 : 0 ≤ Real.sqrt 3 := Real.sqrt_nonneg _
+  have hYsq : (4 * Real.sqrt 3 * area a b c) ^ 2 = 48 * heronProduct a b c := by
+    have : (4 * Real.sqrt 3 * area a b c) ^ 2
+        = 16 * Real.sqrt 3 ^ 2 * area a b c ^ 2 := by ring
+    rw [this, hs32, hA2]; ring
+  have hY0 : 0 ≤ 4 * Real.sqrt 3 * area a b c := by positivity
+  have hX0 : 0 ≤ a ^ 2 + b ^ 2 + c ^ 2 := by positivity
+  constructor
+  · intro h
+    -- equality of nonneg values ⇒ equality of squares ⇒ SOS = 0
+    have hsqeq : (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 = 48 * heronProduct a b c := by
+      rw [← hYsq, h]
+    obtain ⟨hab2, hbc2⟩ := (weitzenbock_sq_eq_iff a b c).mp hsqeq
+    have hab' : a = b := by
+      have hs : (0 : ℝ) < a + b := by linarith
+      have : (a - b) * (a + b) = 0 := by nlinarith [hab2]
+      rcases mul_eq_zero.mp this with h0 | h0
+      · linarith
+      · linarith
+    have hbc' : b = c := by
+      have hs : (0 : ℝ) < b + c := by linarith
+      have : (b - c) * (b + c) = 0 := by nlinarith [hbc2]
+      rcases mul_eq_zero.mp this with h0 | h0
+      · linarith
+      · linarith
+    exact ⟨hab', hbc'⟩
+  · rintro ⟨hab', hbc'⟩
+    subst hab'; subst hbc'
+    -- reduce to the squared identity: both sides nonneg with equal squares
+    have hsqeq : (a ^ 2 + a ^ 2 + a ^ 2) ^ 2 = (4 * Real.sqrt 3 * area a a a) ^ 2 := by
+      rw [hYsq]
+      have := sq_sum_sub_heron a a a
+      nlinarith [this]
+    have h := Real.sqrt_le_sqrt (le_of_eq hsqeq)
+    have h' := Real.sqrt_le_sqrt (le_of_eq hsqeq.symm)
+    have hX0' : 0 ≤ a ^ 2 + a ^ 2 + a ^ 2 := by positivity
+    have hY0' : 0 ≤ 4 * Real.sqrt 3 * area a a a := by positivity
+    rw [Real.sqrt_sq hX0', Real.sqrt_sq hY0'] at h
+    rw [Real.sqrt_sq hY0', Real.sqrt_sq hX0'] at h'
+    linarith
+
+end WeitzenbockHeronOQ07

--- a/research/problems/herons-formula-oq-07/knowledge.md
+++ b/research/problems/herons-formula-oq-07/knowledge.md
@@ -1,0 +1,31 @@
+# herons-formula-oq-07 — Weitzenböck's Inequality
+
+## Session 2026-07-01 (researcher-7): Weitzenböck's inequality a²+b²+c² ≥ 4√3·Area [VERIFIED, SOLVED]
+
+**Mode**: ACT (fresh EMPTY problem). **Outcome**: SOLVED — new file
+`proofs/Proofs/HeronsFormulaOQ07.lean` (188 L, 3 defs / 6 theorems), plus gallery entry
+`src/data/proofs/herons-formula-oq-07/` (meta.json + annotations.json). **Docker build
+VERIFIED** (`docker-build.sh Proofs.HeronsFormulaOQ07`, `✔ [3058/3058]`); **0-sorry,
+0-axiom**, no native_decide.
+
+### What was delivered (namespace `WeitzenbockHeronOQ07`)
+- defs `semiperimeter`, `heronProduct` (= Area²), `area` (self-contained, mirrors OQ06 style).
+- `heronProduct_nonneg` — Heron product ≥ 0 for a nondegenerate triangle.
+- **`sq_sum_sub_heron`** (SOS identity, the core) : `(a²+b²+c²)² − 48·heronProduct =
+  2((a²−b²)²+(b²−c²)²+(c²−a²)²)`, closed by `unfold; ring`.
+- **`weitzenbock_sq`** : `48·heronProduct ≤ (a²+b²+c²)²` — holds for ALL reals (no triangle
+  hypothesis), via `nlinarith` on the three `sq_nonneg` + the identity.
+- `weitzenbock_sq_eq_iff` : squared equality ⇔ a²=b² ∧ b²=c².
+- **`weitzenbock`** (headline) : `4·√3·area ≤ a²+b²+c²` for a nondegenerate triangle.
+- **`weitzenbock_eq_iff`** : equality ⇔ a=b ∧ b=c (equilateral).
+
+### Recipe / gotchas
+- Squaring trick: both sides ≥0, so `4√3·Area ≤ X ⇔ (4√3·Area)² ≤ X²`. Compute
+  `(4·√3·A)² = 16·(√3)²·A² = 48·heronProduct` using `Real.sq_sqrt` for (√3)²=3 and A²=hp.
+  Upgrade squared→linear with `Real.sqrt_le_sqrt` then `Real.sqrt_sq` (both sides ≥0).
+- SOS identity verified numerically first (3-4-5: 2500−1728=772=2·386 ✓; equilateral: 0 ✓).
+- (4√3)² = 48 is the magic constant. `48·hp = 3·(a+b+c)(−a+b+c)(a−b+c)(a+b−c)`.
+- Equality: a²=b², a,b>0 ⇒ a=b via factoring (a−b)(a+b)=0 with a+b>0.
+
+### Follow-up directions (for Seeker, depth-1 → allowed)
+- Finsler–Hadwiger: a²+b²+c² ≥ 4√3·Area + (a−b)²+(b−c)²+(c−a)² — same SOS technique, sharper.

--- a/src/data/proofs/herons-formula-oq-07/annotations.json
+++ b/src/data/proofs/herons-formula-oq-07/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-weitzenbock-context",
+    "proofId": "herons-formula-oq-07",
+    "range": {
+      "startLine": 1,
+      "endLine": 31
+    },
+    "type": "concept",
+    "title": "Weitzenböck's Inequality",
+    "content": "Weitzenböck's inequality (Roland Weitzenböck, 1919; IMO 1961, Problem 2) states that for any triangle with side lengths a, b, c and area, a² + b² + c² ≥ 4√3·Area, with equality exactly for the equilateral triangle. Equivalently, among all triangles with a fixed sum of squared sides the equilateral one has the largest area. It is the leading term of the sharper Finsler–Hadwiger inequality. This formalization avoids any coordinate or trigonometric construction and works directly from Heron's area, reducing the statement to a polynomial inequality settled by a sum-of-squares certificate."
+  },
+  {
+    "id": "ann-triangle-data",
+    "proofId": "herons-formula-oq-07",
+    "range": {
+      "startLine": 42,
+      "endLine": 61
+    },
+    "type": "concept",
+    "title": "Square-root-free triangle data",
+    "content": "The semi-perimeter s = (a+b+c)/2, Heron's product heronProduct = s(s-a)(s-b)(s-c) (the squared area), and area = √(heronProduct) are defined so that the entire proof stays polynomial in a, b, c except for the single definitional square root. `heronProduct_nonneg` shows the product is ≥ 0 for a nondegenerate triangle by splitting the product with `mul_nonneg` and discharging each factor with `linarith` from the strict triangle inequalities."
+  },
+  {
+    "id": "ann-sos-identity",
+    "proofId": "herons-formula-oq-07",
+    "range": {
+      "startLine": 66,
+      "endLine": 85
+    },
+    "type": "tactic",
+    "title": "The Sum-of-Squares Certificate",
+    "content": "The heart of the proof is the identity (a²+b²+c²)² - 48·heronProduct = 2((a²-b²)²+(b²-c²)²+(c²-a²)²), an identity in the squared side lengths that `ring` closes after unfolding heronProduct and the semi-perimeter. Its right-hand side is a sum of squares, so the squared inequality 48·heronProduct ≤ (a²+b²+c²)² follows by `nlinarith` fed the three `sq_nonneg` terms and the identity. Crucially this squared inequality needs no triangle hypothesis — it holds for all real a, b, c."
+  },
+  {
+    "id": "ann-sqrt-upgrade",
+    "proofId": "herons-formula-oq-07",
+    "range": {
+      "startLine": 115,
+      "endLine": 137
+    },
+    "type": "tactic",
+    "title": "Upgrading the squared inequality via sqrt monotonicity",
+    "content": "Both sides of a²+b²+c² ≥ 4√3·Area are non-negative, so the linear inequality is equivalent to the squared one. Writing Y = 4·√3·Area and X = a²+b²+c², one computes Y² = 16·(√3)²·Area² = 48·heronProduct (using `Real.sq_sqrt` for both (√3)²=3 and Area²=heronProduct), so `weitzenbock_sq` gives Y² ≤ X². Then `Real.sqrt_le_sqrt` together with `Real.sqrt_sq` (both X, Y ≥ 0) recovers Y ≤ X. This is the only analytic step in the entire development."
+  },
+  {
+    "id": "ann-equality",
+    "proofId": "herons-formula-oq-07",
+    "range": {
+      "startLine": 138,
+      "endLine": 188
+    },
+    "type": "insight",
+    "title": "The equality case comes for free",
+    "content": "Equality 4√3·Area = a²+b²+c² forces Y² = X², hence (a²+b²+c²)² = 48·heronProduct, so the SOS sum vanishes and each square (a²-b²)², (b²-c²)², (c²-a²)² is zero. Thus a² = b² = c², and since the sides are positive, factoring (a-b)(a+b) = 0 with a+b > 0 gives a = b (similarly b = c) — the triangle is equilateral. The converse is a direct computation. A single sum-of-squares identity therefore proves both Weitzenböck's inequality and its sharpness."
+  }
+]

--- a/src/data/proofs/herons-formula-oq-07/meta.json
+++ b/src/data/proofs/herons-formula-oq-07/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "herons-formula-oq-07",
+  "slug": "herons-formula-oq-07",
+  "title": "Weitzenböck's Inequality from Heron's Formula",
+  "description": "For any nondegenerate triangle with side lengths a, b, c and area Area = √(s(s-a)(s-b)(s-c)) (s = (a+b+c)/2), Weitzenböck's inequality states a² + b² + c² ≥ 4√3·Area, with equality iff the triangle is equilateral. Squaring both sides (using (4√3)² = 48 and Area² = s(s-a)(s-b)(s-c)) reduces it to the polynomial inequality (a²+b²+c²)² ≥ 48·s(s-a)(s-b)(s-c), which follows from the sum-of-squares identity (a²+b²+c²)² - 48·s(s-a)(s-b)(s-c) = 2((a²-b²)²+(b²-c²)²+(c²-a²)²).",
+  "conclusion": {
+    "summary": "A complete, axiom-free formalization of Weitzenböck's inequality a² + b² + c² ≥ 4√3·Area together with its equality characterization (equilateral). The inequality is reduced to a polynomial statement in the side lengths and settled by an explicit sum-of-squares identity in the squared side lengths a², b², c².",
+    "implications": "Weitzenböck's inequality (1919) is the base case of the Finsler–Hadwiger inequality and a classical benchmark for symmetric triangle inequalities. The sum-of-squares certificate proved here yields the sharp equality case for free: equality holds exactly for the equilateral triangle. The squared, square-root-free core (a²+b²+c²)² ≥ 48·heronProduct is a reusable polynomial fact for other triangle extremal problems.",
+    "openQuestions": [
+      "Can the sharper Finsler–Hadwiger inequality a² + b² + c² ≥ 4√3·Area + (a-b)² + (b-c)² + (c-a)² be formalized by the same SOS technique?",
+      "Does the pedal/Weitzenböck generalization to the sum of squares of a cevian-triangle's sides admit an analogous sum-of-squares proof?"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Weitzenböck's inequality was published by Roland Weitzenböck in 1919 and famously reappeared as Problem 2 of the 1961 International Mathematical Olympiad. It bounds the area of a triangle below by a symmetric function of its side lengths: 4√3·Area ≤ a² + b² + c², with equality only for the equilateral triangle (which maximizes area for a fixed sum of squared sides). It is the first term of the stronger Finsler–Hadwiger inequality and a standard example of a triangle inequality provable by a sum-of-squares certificate.",
+    "problemStatement": "For a triangle with side lengths a, b, c (satisfying the strict triangle inequalities), let s = (a+b+c)/2 and Area = √(s(s-a)(s-b)(s-c)) (Heron). Prove a² + b² + c² ≥ 4√3·Area, with equality iff a = b = c.",
+    "proofStrategy": "Both sides of a² + b² + c² ≥ 4√3·Area are non-negative, so the inequality is equivalent to its square. Squaring and using (4√3)² = 48 and Area² = s(s-a)(s-b)(s-c) turns the goal into the polynomial inequality (a²+b²+c²)² ≥ 48·s(s-a)(s-b)(s-c). This is proved from the explicit identity (a²+b²+c²)² - 48·s(s-a)(s-b)(s-c) = 2((a²-b²)²+(b²-c²)²+(c²-a²)²), whose right-hand side is manifestly ≥ 0. The squared inequality holds for all real a, b, c; the triangle inequalities are used only to guarantee Area² ≥ 0 so that Area = √(Area²) is real and the squaring is reversible (via Real.sqrt monotonicity). Equality forces each square to vanish, i.e. a² = b² = c², hence a = b = c for positive sides.",
+    "keyInsights": [
+      "Squaring reduces the √3- and Area-containing statement to a pure polynomial inequality in a, b, c, avoiding all analysis except one Real.sqrt monotonicity step.",
+      "The certificate (a²+b²+c²)² - 48·heronProduct = 2((a²-b²)²+(b²-c²)²+(c²-a²)²) is an identity in the squared side lengths, closed by ring, and simultaneously proves the inequality and its equality case.",
+      "The squared inequality (a²+b²+c²)² ≥ 48·heronProduct needs no triangle hypothesis; nondegeneracy enters only to keep Area real.",
+      "Equality holds iff each summand vanishes, i.e. a² = b² = c², which for positive sides means the triangle is equilateral — so one SOS identity proves both the inequality and its sharpness."
+    ],
+    "prerequisites": [
+      "Heron's formula Area² = s(s-a)(s-b)(s-c)",
+      "Sum-of-squares positivity / nlinarith",
+      "Real.sqrt monotonicity (Real.sqrt_le_sqrt, Real.sqrt_sq)"
+    ],
+    "text": "This entry formalizes Weitzenböck's inequality a² + b² + c² ≥ 4√3·Area for triangles as an algebraic consequence of Heron's formula. Because both sides are non-negative, the inequality is equivalent to its square, which — using (4√3)² = 48 and Heron's Area² = s(s-a)(s-b)(s-c) — becomes (a²+b²+c²)² ≥ 48·s(s-a)(s-b)(s-c). This polynomial inequality is proved from an explicit sum-of-squares identity in the squared side lengths, which also delivers the equality case. Both the inequality and the equality characterization (equilateral) are machine-checked with 0 axioms and 0 sorries."
+  },
+  "mainTheorems": [
+    {
+      "name": "sq_sum_sub_heron",
+      "type": "supporting",
+      "description": "The Weitzenböck sum-of-squares identity: (a²+b²+c²)² - 48·heronProduct = 2((a²-b²)²+(b²-c²)²+(c²-a²)²), an identity for all reals.",
+      "leanType": "(a^2 + b^2 + c^2)^2 - 48 * heronProduct a b c = 2 * ((a^2 - b^2)^2 + (b^2 - c^2)^2 + (c^2 - a^2)^2)"
+    },
+    {
+      "name": "weitzenbock_sq",
+      "type": "supporting",
+      "description": "The squared Weitzenböck inequality (all reals, no triangle condition): 48·heronProduct ≤ (a²+b²+c²)².",
+      "leanType": "48 * heronProduct a b c ≤ (a^2 + b^2 + c^2)^2"
+    },
+    {
+      "name": "weitzenbock",
+      "type": "main",
+      "description": "Weitzenböck's inequality: for any nondegenerate triangle, 4√3·Area ≤ a² + b² + c².",
+      "leanType": "4 * Real.sqrt 3 * area a b c ≤ a^2 + b^2 + c^2"
+    },
+    {
+      "name": "weitzenbock_eq_iff",
+      "type": "main",
+      "description": "Equality case: 4√3·Area = a² + b² + c² holds iff the triangle is equilateral (a = b = c).",
+      "leanType": "4 * Real.sqrt 3 * area a b c = a^2 + b^2 + c^2 ↔ a = b ∧ b = c"
+    }
+  ],
+  "sections": [
+    {
+      "id": "triangle-data",
+      "title": "Triangle Data — semi-perimeter, Heron product, area",
+      "startLine": 37,
+      "endLine": 61,
+      "summary": "Defines the semi-perimeter s = (a+b+c)/2, Heron's product heronProduct = s(s-a)(s-b)(s-c) (the squared area), and area = √(heronProduct). Proves heronProduct ≥ 0 for a nondegenerate triangle.",
+      "mathContext": "The square-root-free data underlying the inequality. Working with heronProduct = Area² keeps the whole argument polynomial except for one final Real.sqrt step."
+    },
+    {
+      "id": "sos-core",
+      "title": "The Algebraic Core — a sum-of-squares certificate",
+      "startLine": 63,
+      "endLine": 102,
+      "summary": "Establishes the identity (a²+b²+c²)² - 48·heronProduct = 2((a²-b²)²+(b²-c²)²+(c²-a²)²), the squared inequality 48·heronProduct ≤ (a²+b²+c²)², and the equality condition a² = b² = c².",
+      "mathContext": "The mathematical heart of Weitzenböck's inequality, independent of any square roots. The SOS identity gives both the inequality (nlinarith on nonnegative squares) and the equality case (each square vanishes)."
+    },
+    {
+      "id": "weitzenbock",
+      "title": "Weitzenböck's Inequality and its Equality Case",
+      "startLine": 104,
+      "endLine": 188,
+      "summary": "Upgrades the squared inequality to a² + b² + c² ≥ 4√3·Area via Real.sqrt monotonicity (both sides non-negative), and characterizes equality as the equilateral case a = b = c.",
+      "mathContext": "The geometric statement. The only analytic input is Real.sqrt_le_sqrt / Real.sqrt_sq applied to the squared inequality; everything else is the polynomial SOS core."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "herons-formula",
+      "relationship": "extends",
+      "description": "Uses Heron's formula Area² = s(s-a)(s-b)(s-c) to eliminate the area and reduce Weitzenböck's inequality to a polynomial inequality in the side lengths."
+    },
+    {
+      "targetId": "herons-formula-oq-06",
+      "relationship": "related",
+      "description": "A sibling triangle inequality from Heron's formula (Euler's R ≥ 2r); both reduce a geometric inequality to a symmetric polynomial inequality with an explicit sum-of-squares certificate and full equality characterization."
+    }
+  ],
+  "references": [
+    {
+      "title": "Weitzenböck's inequality (Wikipedia)",
+      "url": "https://en.wikipedia.org/wiki/Weitzenb%C3%B6ck%27s_inequality"
+    },
+    {
+      "title": "Finsler–Hadwiger inequality (Wikipedia)",
+      "url": "https://en.wikipedia.org/wiki/Finsler%E2%80%93Hadwiger_inequality"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "WeitzenbockHeronOQ07",
+    "lineCount": 188,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/HeronsFormulaOQ07.lean",
+    "theoremCount": 6,
+    "definitionCount": 3
+  },
+  "meta": {
+    "author": "Classical result (Weitzenböck, 1919; IMO 1961), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Weitzenb%C3%B6ck%27s_inequality",
+    "date": "1919",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HeronsFormulaOQ07.lean",
+    "tags": [
+      "geometry",
+      "weitzenbock-inequality",
+      "triangle",
+      "area",
+      "sum-of-squares",
+      "heron",
+      "imo",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only propext, Classical.choice, Quot.sound).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "sqrt(x)^2 = x for x ≥ 0; used to obtain Area² = heronProduct and (√3)² = 3.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.sqrt_le_sqrt",
+        "description": "monotonicity of sqrt; upgrades the squared inequality to the linear one.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Real.sqrt_sq",
+        "description": "sqrt(a^2) = a for a ≥ 0; recovers each side from its square.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      }
+    ],
+    "originalContributions": [
+      "Weitzenböck's inequality a² + b² + c² ≥ 4√3·Area formalized directly from Heron's area, with no coordinate construction.",
+      "Equality characterization (equilateral) obtained from the sum-of-squares equality case.",
+      "Explicit SOS identity (a²+b²+c²)² - 48·heronProduct = 2((a²-b²)²+(b²-c²)²+(c²-a²)²), an identity in the squared side lengths closed by ring.",
+      "Square-root-free core: the squared inequality holds for all reals; only one Real.sqrt monotonicity step recovers the geometric statement."
+    ],
+    "prerequisites": [
+      "Heron's formula",
+      "sum-of-squares positivity",
+      "Real.sqrt monotonicity"
+    ],
+    "difficulty": "intermediate",
+    "category": "geometry",
+    "parentSlug": "herons-formula",
+    "dateAdded": "2026-07-01",
+    "lineCount": 188,
+    "theoremCount": 6,
+    "definitionCount": 3,
+    "mathlib_version": "v4.26"
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry formalizing **Weitzenböck's inequality** (Roland Weitzenböck, 1919; IMO 1961, Problem 2): for any nondegenerate triangle with side lengths `a, b, c` and area `Area = √(s(s-a)(s-b)(s-c))`,

$$a^2 + b^2 + c^2 \ge 4\sqrt{3}\cdot\text{Area},$$

with equality **iff the triangle is equilateral**. Child of the `herons-formula` gallery entry (oq-07).

## Proof idea

Both sides are non-negative, so the inequality is equivalent to its square. Using `(4√3)² = 48` and `Area² = s(s-a)(s-b)(s-c)`, the goal becomes the polynomial inequality `(a²+b²+c²)² ≥ 48·s(s-a)(s-b)(s-c)`, settled by the sum-of-squares identity

$$(a^2+b^2+c^2)^2 - 48\,s(s-a)(s-b)(s-c) = 2\big((a^2-b^2)^2+(b^2-c^2)^2+(c^2-a^2)^2\big),$$

which `ring` closes. The identity gives both the inequality (`nlinarith` on the three squares) and the equality case. The squared inequality holds for **all reals** — the triangle inequalities enter only to keep `Area` real, and a single `Real.sqrt` monotonicity step recovers the geometric statement.

## Contents

- `proofs/Proofs/HeronsFormulaOQ07.lean` — namespace `WeitzenbockHeronOQ07`, 3 defs + 6 theorems (188 L). Headlines: `weitzenbock`, `weitzenbock_eq_iff`; core `sq_sum_sub_heron`, `weitzenbock_sq`.
- `src/data/proofs/herons-formula-oq-07/` — gallery `meta.json` + `annotations.json`.

## Verification

- **Docker build VERIFIED**: `docker-build.sh Proofs.HeronsFormulaOQ07` → `✔ [3058/3058]`
- **0-sorry, 0-axiom**, no `native_decide`. `status: verified`, `badge: original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)