### PR TITLE
Enrich 'Second Moment & Variance of Composition Parts' (composition-parts-choose-oq-01-oq-01-oq-01): index.ts + header annotation

### DIFF
--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-compparts-header",
+    "proofId": "composition-parts-choose-oq-01-oq-01-oq-01",
+    "range": { "startLine": 5, "endLine": 62 },
+    "type": "concept",
+    "title": "From First Moment to Variance via the Gap Bijection",
+    "content": "The docstring places this leaf in its lineage and lays out the whole mechanism. A composition of n is an ordered tuple of positive integers summing to n; its part-count is c.length. The family already knows: 2^(n−1) compositions of n (grandparent), C(n−1,k−1) with exactly k parts (parent), and the FIRST moment (n+1)·2^(n−2), mean (n+1)/2 (parent). This entry computes the SECOND moment 4·∑ c.length² = n(n+3)2^(n−1) and hence the variance (n−1)/4. The engine is the same gap bijection gapsEquiv : Composition n ≃ Finset (Fin (n−1)) (a composition IS the set of internal gaps it cuts) plus length = |gaps|+1: transporting sums across it reduces everything to subset sums over an (n−1)-set, where (|s|+1)² = |s|² + 2|s| + 1 splits into the new second-moment subset sum, the parent's first moment, and the plain count. The probabilistic punchline — variance (n−1)/4 is exactly that of 1 + Binomial(n−1, ½) — emerges with no probability theory invoked. Mathlib has ∑ C(m,k) = 2^m but none of the weighted sums or the part-count distribution.",
+    "mathContext": "$X(c) = c.\\mathrm{length}$; $\\;4\\sum_c X^2 = n(n{+}3)2^{n-1}$ and $\\mathrm{Var}(X) = \\frac{n-1}{4}$, the variance of $1 + \\mathrm{Binomial}(n{-}1, \\tfrac12)$.",
+    "significance": "context",
+    "relatedConcepts": ["compositions of an integer", "gap bijection", "moments and variance", "binomial distribution", "family lineage"],
+    "prerequisites": ["Mathlib's Composition n", "the gap bijection and first moment from parent entries", "moments of a distribution"]
+  },
+  {
     "id": "ann-sum-choose-mul-sq",
     "proofId": "composition-parts-choose-oq-01-oq-01-oq-01",
     "range": { "startLine": 71, "endLine": 105 },

--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CompositionPartsChooseOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const compositionPartsChooseOq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const compositionPartsChooseOq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const compositionPartsChooseOq01Oq01Oq01Data: ProofData = {
+  proof: compositionPartsChooseOq01Oq01Oq01Proof,
+  annotations: compositionPartsChooseOq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `composition-parts-choose-oq-01-oq-01-oq-01`.

**Critical fix:**
- **Added missing `index.ts`** — without it the page rendered 'proof not found' on the live site despite appearing in the gallery listing.

**Enrichment:**
- Added `ann-compparts-header` (lines 5–62) covering the module docstring: the first-moment → second-moment → variance arc via the gap bijection `Composition n ≃ Finset (Fin (n−1))`, and the punchline that the variance (n−1)/4 is exactly that of `1 + Binomial(n−1, ½)`. Annotations 4 → 5.

meta.json unchanged (16 KB, within caps). JSON validates.