### PR TITLE
Enrich 'ℵ₀-Closure of the Rationals' (denumerability-rationals-oq-05): index.ts + header annotation

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-05/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-05/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-denum-oq05-header",
+    "proofId": "denumerability-rationals-oq-05",
+    "range": { "startLine": 1, "endLine": 23 },
+    "type": "concept",
+    "title": "Which Constructions Preserve ℵ₀ — and Where It Breaks",
+    "content": "The docstring states the open question sharply: pin down exactly which constructions preserve the denumerability (cardinality ℵ₀) of ℚ. The answer is a clean dichotomy driven by the absorption laws of ℵ₀. Every FINITE operation stays at ℵ₀ — finite products #(ℚ×ℚ) = ℵ₀·ℵ₀ = ℵ₀ (aleph0_mul_aleph0), finite sequences #(List ℚ) = ℵ₀ (mk_list_eq_aleph0), finite subsets #(Finset ℚ) = ℵ₀ (mk_finset_of_infinite) — but the countably-infinite POWER escapes: #(ℕ → ℚ) = ℵ₀^ℵ₀ = 𝔠 (aleph0_power_aleph0), the continuum. The contrast is the whole point: ℵ₀ absorbs every finite operation yet a single countable power already reaches 𝔠. This is the ℵ₀-level shadow of the continuum arithmetic 𝔠·𝔠 = 𝔠, 𝔠^ℵ₀ = 𝔠, and it sharpens the gallery's ℵ₀ < 𝔠 gap by locating precisely where the jump happens.",
+    "mathContext": "$\\aleph_0$ absorbs finite operations ($\\aleph_0 \\cdot \\aleph_0 = \\aleph_0$) but $\\aleph_0^{\\aleph_0} = \\mathfrak{c}$: the countable power is the boundary between denumerable and continuum.",
+    "significance": "context",
+    "relatedConcepts": ["aleph-null absorption", "continuum", "cardinal exponentiation", "denumerability of ℚ"],
+    "prerequisites": ["cardinal arithmetic", "#ℚ = ℵ₀", "ℵ₀ < 𝔠"]
+  },
+  {
     "id": "ann-denum-oq05-engine",
     "proofId": "denumerability-rationals-oq-05",
     "range": { "startLine": 30, "endLine": 33 },

--- a/src/data/proofs/denumerability-rationals-oq-05/index.ts
+++ b/src/data/proofs/denumerability-rationals-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DenumerabilityRationalsOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const denumerabilityRationalsOq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const denumerabilityRationalsOq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const denumerabilityRationalsOq05Data: ProofData = {
+  proof: denumerabilityRationalsOq05Proof,
+  annotations: denumerabilityRationalsOq05Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `denumerability-rationals-oq-05`.

**Critical fix:**
- **Added missing `index.ts`** — without it the page rendered 'proof not found' on the live site despite appearing in the gallery listing.

**Enrichment:**
- Added `ann-denum-oq05-header` (lines 1–23) covering the module docstring: the dichotomy that finite operations preserve ℵ₀ (products, lists, finsets) while the countable power `ℕ → ℚ` jumps to the continuum 𝔠 = ℵ₀^ℵ₀. Annotations 4 → 5.

meta.json unchanged (11 KB, within caps). JSON validates.