### PR TITLE
Enrich 'n-th Root of a Prime Is Irrational' (cube-root-2-irrational-oq-05): index.ts + header annotation

### DIFF
--- a/src/data/proofs/cube-root-2-irrational-oq-05/annotations.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-nrtprime-oq05-header",
+    "proofId": "cube-root-2-irrational-oq-05",
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "concept",
+    "title": "One Theorem Subsuming √2, ∛2, and Every Prime Root",
+    "content": "The docstring states the open question: generalize the irrationality of ∛2 (and √2) to the full two-parameter family — for every prime p and every degree n ≥ 2, the real n-th root p^(1/n) is irrational. The base entry handled only p=2, n=3; this entry proves all cases at once. The single engine is Mathlib's irrational_nrt_of_n_not_dvd_multiplicity: if x^n = m ∈ ℤ and n ∤ multiplicity p m then x is irrational. Instantiate x = p^(1/n), m = p: then x^n = p^(n⁻¹·n) = p by rpow composition (p ≥ 0), and multiplicity p p = 1 (multiplicity_self) with 1 % n = 1 ≠ 0 for n ≥ 2, so n never divides the multiplicity. Specializing recovers everything — n=3 gives ∛p (in particular the base ∛2), n=2 recovers Nat.Prime.irrational_sqrt, and p=2 gives every n-th root of 2 irrational. Mathlib has only the square-root case; this fills the n-th-root gap.",
+    "mathContext": "For $p$ prime, $n \\ge 2$: $\\;p^{1/n} \\notin \\mathbb{Q}$, since $(p^{1/n})^n = p$ and $n \\nmid \\mathrm{mult}_p(p) = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["irrationality", "n-th roots", "p-adic multiplicity", "unique factorization"],
+    "prerequisites": ["irrational_nrt_of_n_not_dvd_multiplicity", "real rpow", "prime multiplicity"]
+  },
+  {
     "id": "ann-nrtprime-oq05-main",
     "proofId": "cube-root-2-irrational-oq-05",
     "range": { "startLine": 31, "endLine": 53 },

--- a/src/data/proofs/cube-root-2-irrational-oq-05/index.ts
+++ b/src/data/proofs/cube-root-2-irrational-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CubeRoot2IrrationalOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cubeRoot2IrrationalOq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cubeRoot2IrrationalOq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cubeRoot2IrrationalOq05Data: ProofData = {
+  proof: cubeRoot2IrrationalOq05Proof,
+  annotations: cubeRoot2IrrationalOq05Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cube-root-2-irrational-oq-05`.

**Critical fix:**
- **Added missing `index.ts`** — without it the page rendered 'proof not found' on the live site despite appearing in the gallery listing.

**Enrichment:**
- Added `ann-nrtprime-oq05-header` (lines 1–25) covering the module docstring: the single theorem subsuming √2, ∛2 and every prime n-th root via `irrational_nrt_of_n_not_dvd_multiplicity` (multiplicity_self = 1, n ∤ 1 for n ≥ 2). Annotations 4 → 5.

meta.json unchanged (10 KB, within caps). JSON validates.