### PR TITLE
Enrich golden ratio badly approximable (dirichlet-approximation-theorem-oq-05): 5th annotation

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-05/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-05/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-header-sharpness-duality",
+    "proofId": "dirichlet-approximation-theorem-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "context",
+    "title": "The Dual of Dirichlet: Sharpness Instead of Existence",
+    "content": "The header frames what makes this entry distinctive within the gallery. The parent `dirichlet-approximation-theorem` and its siblings all prove EXISTENCE — every real α has infinitely many p/q with |α − p/q| < 1/q² (oq-01 counts them, oq-03 re-derives via Minkowski). This file proves the opposite, SHARPNESS direction, which appears nowhere else in the gallery: the exponent 2 cannot be improved for the golden ratio φ = (1+√5)/2. φ is the prototypical badly approximable number — the worst-approximable real, together with its GL₂(ℤ)-orbit — the bottom of the Lagrange/Markov spectrum. The proof is deliberately elementary (norm form of ℤ[φ], no continued fractions), and it is built on Mathlib's `Real.goldenRatio` API: goldenRatio_add_goldenConj (φ+ψ=1), goldenRatio_mul_goldenConj (φψ=−1), goldenRatio_sub_goldenConj (φ−ψ=√5), and the irrationality lemmas goldenRatio_irrational / goldenConj_irrational — the four inputs the three theorems below consume.",
+    "mathContext": "Dirichlet (existence): $\\exists^\\infty\\, p/q,\\ |\\alpha - p/q| < 1/q^2$. Here (sharpness): $\\exists c>0,\\ \\forall p,q>0,\\ c/q^2 \\le |\\varphi - p/q|$.",
+    "significance": "context",
+    "relatedConcepts": ["badly approximable numbers", "Lagrange/Markov spectrum", "Real.goldenRatio API", "continued fractions", "Diophantine approximation"],
+    "prerequisites": ["Dirichlet's approximation theorem (parent)", "the golden ratio and its conjugate", "Mathlib goldenRatio lemmas"]
+  },
+  {
     "id": "ann-norm-form-identity",
     "proofId": "dirichlet-approximation-theorem-oq-05",
     "range": {
@@ -85,6 +100,6 @@
       "Hurwitz's theorem",
       "irrationality measure"
     ],
-    "significance": "supporting"
+    "significance": "key"
   }
 ]


### PR DESCRIPTION
Enrichment pass for `dirichlet-approximation-theorem-oq-05` (0 passes, quality 89).

**Changes**
- Added `ann-header-sharpness-duality` covering the previously unannotated header (lines 1–52): frames this entry as the SHARPNESS dual of the parent's existence results — a direction that appears nowhere else in the gallery — with φ as the worst-approximable real (bottom of the Lagrange–Markov spectrum), and documents the Mathlib `Real.goldenRatio` API (the φ+ψ=1, φψ=−1, φ−ψ=√5, and irrationality lemmas) that the three theorems consume.
- Bumped the headline `goldenRatio_badly_approximable` annotation from `supporting` to `key` — it was the main result yet the only annotations were all `supporting`, leaving no key/critical marker.

**Not changed**: meta.json already comprehensive (13.5 KB, under cap). Curation, not accretion.

Vetted: no open PR; recent commits on this entry are historical merges (#32056 references, #31502 normalize).

Validated: annotations.json + meta.json parse; check-meta-size passes.