### PR TITLE
research(sperner-ndim-oq-02): exact per-cell boundary-door set and count [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -2214,4 +2214,89 @@ theorem boundary_faces_card_le_one (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤
   simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hk₁ hk₂
   exact boundary_face_subsingleton s hd hk₁ hk₂
 
+/-!
+## Exact per-cell boundary-door set and count
+
+`boundary_faces_card_le_one` bounds each cell's contribution to the last-face door
+count by one.  This section computes that contribution *exactly*.  Localization
+(`boundary_face_imp_last`) confines the door-facet finset to `{Fin.last d}`, and the
+top-facet characterization (`last_boundary_face_iff`) says precisely when that facet
+is a door.  Together they collapse the per-cell door set to a single decidable
+alternative: the singleton `{Fin.last d}` when the top facet is a door, otherwise
+`∅`.  The corresponding cardinality is the `0/1` summand a Phase-2 door-parity
+(oddness) induction accumulates over all cells — this is the exact per-cell term that
+sum runs over.  All 0-sorry, 0-axiom (builds only on `boundary_face_imp_last`). -/
+
+/-- **Boundary-door facets are contained in `{Fin.last d}`.**  Sharpens
+`boundary_faces_card_le_one` from a cardinality bound to a concrete containment: the
+only facet index that can be a geometric `∂Δ_N` door is the top facet.  Immediate from
+`boundary_face_imp_last`. -/
+theorem boundary_faces_subset_last (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d) :
+    (Finset.univ.filter
+      (fun k : Fin (d + 1) =>
+        ∀ j : Fin (d + 1), j ≠ k → (s.verts j).coords k = 0)) ⊆ {Fin.last d} := by
+  intro k hk
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hk
+  rw [Finset.mem_singleton]
+  exact boundary_face_imp_last s hd k hk
+
+/-- **Membership in the boundary-door set.**  A facet `k` is a geometric `∂Δ_N` door of
+the cell iff it is the top facet `Fin.last d` *and* the top-facet boundary condition
+holds there.  The `∈`-form combining `boundary_face_imp_last` (only `Fin.last d`
+qualifies) with the defining filter predicate. -/
+theorem mem_boundary_faces_iff (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d)
+    (k : Fin (d + 1)) :
+    (k ∈ Finset.univ.filter
+      (fun k : Fin (d + 1) =>
+        ∀ j : Fin (d + 1), j ≠ k → (s.verts j).coords k = 0)) ↔
+    k = Fin.last d ∧
+      (∀ j : Fin (d + 1), j ≠ Fin.last d → (s.verts j).coords (Fin.last d) = 0) := by
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  constructor
+  · intro h
+    have hk : k = Fin.last d := boundary_face_imp_last s hd k h
+    subst hk
+    exact ⟨rfl, h⟩
+  · rintro ⟨hk, h⟩
+    subst hk
+    exact h
+
+/-- **Exact per-cell boundary-door set.**  The finset of geometric `∂Δ_N` boundary
+doors of a Freudenthal cell equals the singleton `{Fin.last d}` when the top-facet
+door condition holds, and `∅` otherwise.  Pins the per-cell contribution to a single
+decidable boolean — exactly the summand a Phase-2 door-parity induction accumulates. -/
+theorem boundary_faces_eq (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d) :
+    (Finset.univ.filter
+      (fun k : Fin (d + 1) =>
+        ∀ j : Fin (d + 1), j ≠ k → (s.verts j).coords k = 0)) =
+    if (∀ j : Fin (d + 1), j ≠ Fin.last d → (s.verts j).coords (Fin.last d) = 0)
+      then {Fin.last d} else ∅ := by
+  by_cases hcond :
+      (∀ j : Fin (d + 1), j ≠ Fin.last d → (s.verts j).coords (Fin.last d) = 0)
+  · rw [if_pos hcond]
+    apply Finset.ext
+    intro k
+    rw [mem_boundary_faces_iff s hd, Finset.mem_singleton]
+    exact ⟨fun h => h.1, fun h => ⟨h, hcond⟩⟩
+  · rw [if_neg hcond, Finset.eq_empty_iff_forall_not_mem]
+    intro k hk
+    rw [mem_boundary_faces_iff s hd] at hk
+    exact hcond hk.2
+
+/-- **Exact per-cell boundary-door count.**  The number of geometric `∂Δ_N` boundary
+doors of a Freudenthal cell is `1` when its top facet is a door and `0` otherwise.
+This is the exact `0/1` per-cell term the last-face door-parity sum accumulates,
+strengthening `boundary_faces_card_le_one` from `≤ 1` to a decidable equality. -/
+theorem boundary_faces_card (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d) :
+    (Finset.univ.filter
+      (fun k : Fin (d + 1) =>
+        ∀ j : Fin (d + 1), j ≠ k → (s.verts j).coords k = 0)).card =
+    if (∀ j : Fin (d + 1), j ≠ Fin.last d → (s.verts j).coords (Fin.last d) = 0)
+      then 1 else 0 := by
+  rw [boundary_faces_eq s hd]
+  by_cases hcond :
+      (∀ j : Fin (d + 1), j ≠ Fin.last d → (s.verts j).coords (Fin.last d) = 0)
+  · rw [if_pos hcond, if_pos hcond, Finset.card_singleton]
+  · rw [if_neg hcond, if_neg hcond, Finset.card_empty]
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,5 +1,69 @@
 # sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
 
+## Session 2026-07-01 (researcher-1) — Exact per-cell boundary-door set and count
+
+**Mode**: ACT (SOLVED-in-parts; frontier still the hard cross-chain gluing, so did NOT
+attempt it — instead extended the per-cell door-counting toolkit, the tractable Phase-2
+prep). **Outcome**: PROGRESS — added an "Exact per-cell boundary-door set and count"
+section to `SpernerNDimOQ02.lean` (+4 theorems, ~85 L). **Docker build VERIFIED**
+(`docker-build.sh Proofs.SpernerNDimOQ02`, `Built Proofs.SpernerNDimOQ02`, 7745 jobs,
+exit 0); file stays 0-sorry, 0-axiom. (`#print axioms` unobtainable this session — host
+Mathlib olean cache has multiple corrupt files `*.olean.private`/`*.olean.server`
+"invalid header" even after `lake exe cache get`; the `lake env lean` single-file
+channel is therefore down. Docker is the authoritative check. The new decls use only
+`boundary_face_imp_last` (already verified `[propext, Classical.choice, Quot.sound]` in
+prior sessions) + pure Finset/logic lemmas — no `native_decide`/`decide`/`sorry` — so
+genuinely 0-axiom by construction.)
+
+### What was delivered (`SpernerNDimOQ02.lean`, after `boundary_faces_card_le_one`)
+Prior sessions bounded each cell's door contribution by one (`boundary_faces_card_le_one`,
+`≤ 1`). This session computes it **exactly**, turning the bound into a decidable `0/1`
+summand — the precise per-cell term a Phase-2 door-parity (oddness) sum accumulates.
+
+- **`boundary_faces_subset_last (s) (hd : 2 ≤ d)`** `: (univ.filter boundaryCond) ⊆
+  {Fin.last d}` — the door-facet finset is contained in the top-facet singleton (from
+  `boundary_face_imp_last`; sharpens the cardinality bound to a concrete containment).
+- **`mem_boundary_faces_iff (s) (hd) (k)`** `: k ∈ filter ↔ k = Fin.last d ∧
+  (top-facet boundary condition)` — membership splits into "is the top facet" ∧ "the top
+  facet is a door". Combines `boundary_face_imp_last` (only `Fin.last d` qualifies) with
+  the filter predicate.
+- **`boundary_faces_eq (s) (hd)`** `: (univ.filter boundaryCond) = if (top-facet door
+  condition) then {Fin.last d} else ∅` — the **exact per-cell door SET** as a single
+  decidable alternative.
+- **`boundary_faces_card (s) (hd)`** `: (univ.filter boundaryCond).card = if (top-facet
+  door condition) then 1 else 0` — the **exact per-cell door COUNT**; the `0/1` summand
+  the last-face door-parity induction runs over. Strengthens `boundary_faces_card_le_one`
+  (`≤ 1`) to an equality.
+
+### Why this matters (Phase-2 prep)
+The Phase-2 argument counts last-face boundary doors and shows the total is odd by
+induction on `d`. That sum is `∑ over cells, (door count of cell)`. This session pins each
+summand to an exact decidable `0/1` (`boundary_faces_card`), governed by the clean chain
+condition of `last_boundary_face_iff`. So the door-count sum is now fully reduced to summing
+a decidable indicator over Freudenthal cells — no residual `≤`/existence bookkeeping per
+cell.
+
+### ⚠️ Frontier UNCHANGED (the genuine blocker — same as all prior sessions)
+Still the **cross-chain gluing**: assembling the total `adj` / `SpernerTriangulation`
+instance needs the cross-`miss` partner for facet `0` interior to `Δ_N` (or a proof it lies
+on `∂Δ_N`), ≳ several hundred lines. NOT attempted — genuinely hard and stuck across
+r1/r2/r4/r5/r7. The door-counting toolkit (this session + prior) is complete for the
+Phase-2 side; the missing piece remains purely the Phase-1 gluing geometry.
+
+### Process notes
+- **Concurrency hazard hit again**: mid-session the shared worktree was `reset --hard` by a
+  concurrent process, silently reverting my working `.lean` to the stale HEAD version (1878
+  L) and wiping my edits from disk AFTER a successful docker build. Recovery: `git checkout
+  origin/main -- <file>` to restore the correct 2217-L base, then re-applied the 4 lemmas
+  from the edit history, and **committed immediately**. Lesson reconfirmed: commit each file
+  change the instant it builds; never leave edits uncommitted on this hot problem. Also:
+  HEAD `92828fa3ef2` was NOT an ancestor of `origin/main`'s file (squash-merges) — based the
+  branch on `origin/main`, not HEAD.
+- Docker host is UP; `lake env lean` fallback unusable (corrupt Mathlib oleans, not fixed by
+  `cache get`).
+- GOTCHA: `rw [Finset.not_mem_empty]` fails — it's a proof of `False`, not an eq/iff. For
+  "filter is empty" use `Finset.eq_empty_iff_forall_not_mem` then contradict membership.
+
 ## Session 2026-06-28 (researcher-4) — Per-vertex evaluation of the reduced boundary-coordinate condition
 
 **Mode**: ACT (CONTINUE Phase-1, next-step "boundary_face geometric half"). **Outcome**:


### PR DESCRIPTION
## Summary

Sharpens the per-cell boundary-door counting toolkit for the n-dimensional Sperner
program from a **bound** (`boundary_faces_card_le_one`, `≤ 1`) to an **exact decidable
`0/1` contribution** — the precise summand a Phase-2 door-parity (oddness) induction
accumulates over Freudenthal cells.

## What's new (`proofs/Proofs/SpernerNDimOQ02.lean`, +4 theorems, ~85 L)

- `boundary_faces_subset_last` — the geometric `∂Δ_N` door-facet finset of a cell is
  contained in `{Fin.last d}` (concrete containment, from `boundary_face_imp_last`).
- `mem_boundary_faces_iff` — `k ∈ door set ↔ k = Fin.last d ∧ (top-facet door condition)`.
- `boundary_faces_eq` — the **exact per-cell door SET**: `if top-facet-door then
  {Fin.last d} else ∅`.
- `boundary_faces_card` — the **exact per-cell door COUNT**: `if top-facet-door then 1
  else 0`, strengthening `boundary_faces_card_le_one` (`≤ 1`) to a decidable equality.

## Why it matters

The Phase-2 finish (`SpernerNDim.sperner_ndim`) counts last-face boundary doors and
proves the total is odd by induction on `d`. That total is `∑ over cells, (door count)`.
This session reduces each summand to a decidable `0/1` indicator governed by the clean
chain condition of the existing `last_boundary_face_iff` — removing all per-cell
`≤`/existence bookkeeping from the eventual door-parity sum.

The genuine frontier (cross-chain gluing for the total `adj` / `SpernerTriangulation`
instance) is **unchanged and not attempted** — it remains the hard blocker.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.SpernerNDimOQ02` → `Built Proofs.SpernerNDimOQ02`,
  7745 jobs, exit 0. File remains **0-sorry, 0-axiom**.
- The new declarations use only `boundary_face_imp_last` (already verified
  `[propext, Classical.choice, Quot.sound]` in prior sessions) plus pure `Finset`/logic
  lemmas — no `native_decide`/`decide`/`sorry` — so genuinely 0-axiom by construction.
  (`#print axioms` via `lake env lean` was unavailable this session due to a corrupt host
  Mathlib olean cache; docker is the authoritative check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)