### PR TITLE
research(cauchy-schwarz-integral-lp-duality-synthesis): S19 — split localization_existence Step A1 → gseq_norm_bound + drift fixes (Incomplete01 63→55) [VERIFIED, axiom not eliminated]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -381,7 +381,8 @@ theorem gseq_norm_bound
           exact measure_spanningSets_lt_top μ n }
     -- ‖extZ f‖ = ‖f‖ (isometry), hence ‖extZ‖ ≤ 1
     have hextZ_le : ∀ f : Lp ℝ p μₙ, ‖extZ f‖ ≤ ‖f‖ := fun f => by
-      simp only [extZ, extByZeroCLM, LinearMap.mkContinuous_apply, Lp.norm_def]
+      simp only [extZ, extByZeroCLM, LinearMap.mkContinuous_apply, LinearMap.coe_mk,
+        AddHom.coe_mk, Lp.norm_def]
       have hh := memLp_indicator_of_restrict_loc hS hp0 hptop (Lp.memLp f)
       conv_lhs => rw [eLpNorm_congr_ae hh.coeFn_toLp]
       rw [eLpNorm_indicator_eq_restrict_loc hS _ hp0 hptop]
@@ -413,13 +414,14 @@ theorem gseq_norm_bound
           measurable_const.aestronglyMeasurable
       have hgk_int : Integrable g_k μₙ := by
         rw [← memLp_one_iff_integrable]
-        exact MemLp.of_bound (k : ℝ) hgk_asm
+        exact MemLp.of_bound hgk_asm (k : ℝ)
           (ae_of_all μₙ fun a => by
             simp only [Real.norm_eq_abs]; exact hgk_bound a)
       -- h_k is bounded and in Lp
       have hhk_bound : ∀ᵐ a ∂μₙ, ‖h_k a‖ ≤ (k : ℝ) ^ (q.toReal - 1) :=
         ae_of_all μₙ fun a => by
           simp only [h_k, Real.norm_eq_abs, abs_mul]
+          rw [abs_of_nonneg (Real.rpow_nonneg (abs_nonneg (g_k a)) (q.toReal - 1))]
           calc |Real.sign (g_k a)| * |g_k a| ^ (q.toReal - 1)
               ≤ 1 * |g_k a| ^ (q.toReal - 1) :=
                   mul_le_mul_of_nonneg_right
@@ -437,7 +439,7 @@ theorem gseq_norm_bound
             continuous_id.rpow_const fun _ => Or.inr (by linarith [hpq.symm.lt])
           exact hrpow.comp_aestronglyMeasurable hgk_asm.norm
       have hhk_memLp : MemLp h_k p μₙ :=
-        MemLp.of_bound ((k : ℝ) ^ (q.toReal - 1)) hhk_meas hhk_bound
+        MemLp.of_bound hhk_meas ((k : ℝ) ^ (q.toReal - 1)) hhk_bound
       -- φₙ(h_k) = ∫ h_k * g ∂μₙ (direct from hrep)
       have hphi_hk : (φ.comp extZ) (hhk_memLp.toLp h_k) = ∫ a, h_k a * g a ∂μₙ := by
         rw [hrep (hhk_memLp.toLp h_k)]
@@ -480,9 +482,9 @@ theorem gseq_norm_bound
         have hpw2 : ∀ a, h_k a * g_k a = |g_k a| ^ q.toReal := fun a => by
           simp only [h_k]
           have hsign : Real.sign (g_k a) * g_k a = |g_k a| := by
-            rcases lt_trichotomy (g_k a) 0 with ha | rfl | ha
+            rcases lt_trichotomy (g_k a) 0 with ha | ha | ha
             · simp [Real.sign_of_neg ha, abs_of_neg ha]
-            · simp
+            · simp [ha]
             · simp [Real.sign_of_pos ha, abs_of_pos ha]
           rw [show Real.sign (g_k a) * |g_k a| ^ (q.toReal - 1) * g_k a =
               |g_k a| ^ (q.toReal - 1) * (Real.sign (g_k a) * g_k a) from by ring,
@@ -492,12 +494,12 @@ theorem gseq_norm_bound
         simp_rw [hpw2]
         have hpw3 : ∀ a, |g_k a| ^ q.toReal =
             ((‖g_k a‖₊ : ℝ≥0∞) ^ q.toReal).toReal := fun a => by
-          rw [ENNReal.coe_rpow_of_nonneg (le_of_lt hq_pos'), ENNReal.coe_toReal, NNReal.coe_rpow]
+          rw [ENNReal.coe_rpow_of_nonneg _ (le_of_lt hq_pos'), ENNReal.coe_toReal, NNReal.coe_rpow]
           simp [Real.norm_eq_abs]
         simp_rw [hpw3]
         have hf_ne_top : ∀ᵐ a ∂μₙ, (‖g_k a‖₊ : ℝ≥0∞) ^ q.toReal ≠ ⊤ :=
           ae_of_all μₙ fun a => by
-            rw [ENNReal.coe_rpow_of_nonneg (le_of_lt hq_pos')]; exact ENNReal.coe_ne_top
+            rw [ENNReal.coe_rpow_of_nonneg _ (le_of_lt hq_pos')]; exact ENNReal.coe_ne_top
         rw [integral_toReal (hgk_asm.enorm.pow_const q.toReal) hf_ne_top]
         congr 1
         rw [eLpNorm_eq_lintegral_rpow_enorm hq0' hqtop', ← ENNReal.rpow_mul,
@@ -523,8 +525,8 @@ theorem gseq_norm_bound
             congr 1; nlinarith [hpq_prod]
         have hpw_enn : ∀ a, (‖h_k a‖₊ : ℝ≥0∞) ^ p.toReal =
             (‖g_k a‖₊ : ℝ≥0∞) ^ q.toReal := fun a => by
-          rw [ENNReal.coe_rpow_of_nonneg (le_of_lt hp_pos'),
-              ENNReal.coe_rpow_of_nonneg (le_of_lt hq_pos')]
+          rw [ENNReal.coe_rpow_of_nonneg _ (le_of_lt hp_pos'),
+              ENNReal.coe_rpow_of_nonneg _ (le_of_lt hq_pos')]
           norm_cast; apply NNReal.coe_injective
           simp only [NNReal.coe_rpow, NNReal.coe_nnnorm, Real.norm_eq_abs]
           exact hpw_real a

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -347,117 +347,26 @@ noncomputable def extByZeroCLM {S : Set α} (hS : MeasurableSet S)
 -- § 5. Localization step (Step A — proved)
 -- ============================================================================
 
-/-- **Step A**: constructs g ∈ Lq(μ) with indicator agreement on finite-measure sets.
-
-    Proof outline (Folland §6.2):
-    1. For each n, μ.restrict(Sₙ) is finite. Build φₙ = φ ∘ extByZeroCLM.
-    2. Apply `RieszLpSurjectivity.riesz_lp_surjective_from_rn` to get gₙ ∈ Lq(μₙ).
-    3. Consistency: gₙ₊₁ = gₙ a.e. on Sₙ (Lq uniqueness).
-    4. MCT + uniform bound ‖gₙ‖_{Lq(μₙ)} ≤ ‖φₙ‖ ≤ ‖φ‖ gives g ∈ Lq(μ).
-    5. Indicator agreement via continuity of φ and DCT.
-    Infrastructure (extByZeroCLM, finite-measure application) is proved above.
-    All steps proved below; 0 sorries. -/
-theorem localization_existence
+/-- **Step A1 of `localization_existence`, extracted.** For a single spanning set
+`Sₙ`, the finite-measure Riesz representer `g` on `μ.restrict Sₙ` satisfies the
+converse-Hölder norm bound `‖g‖_{Lq(μ|Sₙ)} ≤ ‖φ‖`.  Split out of the monolithic
+`localization_existence` (S18: the 600-line theorem exceeded the 40min/32GB build
+envelope once further drift fixes let elaboration proceed) so each piece
+elaborates independently and within budget. -/
+theorem gseq_norm_bound
     (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (hpq : p.toReal.HolderConjugate q.toReal)
     [SigmaFinite μ] [Fact (1 ≤ p)]
-    (φ : Lp ℝ p μ →L[ℝ] ℝ) :
-    ∃ g : α → ℝ, MemLp g q μ ∧
-      eLpNorm g q μ ≤ ENNReal.ofReal ‖φ‖ ∧
-      ∀ (E : Set α) (hE : MeasurableSet E) (hfin : μ E ≠ ⊤),
-        φ ((memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _) =
-        ∫ a in E, g a ∂μ := by
-  have hp0 : p ≠ 0 := ne_of_gt (lt_of_lt_of_le zero_lt_one (le_of_lt hp1))
-  -- For each n, finite-measure Riesz on μ.restrict(Sₙ) via φₙ = φ ∘ extByZeroCLM
-  have hriesz_n : ∀ n, ∃ gₙ : α → ℝ,
-      MemLp gₙ q (μ.restrict (spanningSets μ n)) ∧
-      ∀ f : Lp ℝ p (μ.restrict (spanningSets μ n)),
+    (φ : Lp ℝ p μ →L[ℝ] ℝ) (n : ℕ) (hp0 : p ≠ 0)
+    (g : α → ℝ)
+    (hg : MemLp g q (μ.restrict (spanningSets μ n)))
+    (hgrep : ∀ f : Lp ℝ p (μ.restrict (spanningSets μ n)),
         φ (extByZeroCLM (measurableSet_spanningSets μ n) hp0 hptop f) =
-        ∫ a, (f : α → ℝ) a * gₙ a ∂(μ.restrict (spanningSets μ n)) := by
-    intro n
-    haveI hfin_n : IsFiniteMeasure (μ.restrict (spanningSets μ n)) :=
-      { measure_univ_lt_top := by
-          have : (μ.restrict (spanningSets μ n)) Set.univ =
-              μ (spanningSets μ n) := by
-            rw [Measure.restrict_apply MeasurableSet.univ, Set.inter_univ]
-          rw [this]; exact measure_spanningSets_lt_top μ n }
-    haveI : SigmaFinite (μ.restrict (spanningSets μ n)) := inferInstance
-    let φₙ : Lp ℝ p (μ.restrict (spanningSets μ n)) →L[ℝ] ℝ :=
-      φ.comp (extByZeroCLM (measurableSet_spanningSets μ n) hp0 hptop)
-    obtain ⟨gₙ, hgₙ, hgₙ_rep⟩ :=
-      RieszLpSurjectivity.riesz_lp_surjective_from_rn p q hp1 hptop hpq φₙ
-    exact ⟨gₙ, hgₙ, hgₙ_rep⟩
-  -- Extract the gₙ family
-  choose g_seq hg_seq_mem hg_seq_rep using hriesz_n
-  -- Key: extByZeroCLM(Sₙ)(1_E^Lp(μₙ)) = 1_E^Lp(μ), for E ⊆ Sₙ
-  -- (Both have representative E.indicator 1 a.e. w.r.t. μ)
-  have hext_ind : ∀ n (E : Set α) (hE : MeasurableSet E) (hEn : E ⊆ spanningSets μ n)
-      (hfin : μ E ≠ ⊤),
-      extByZeroCLM (measurableSet_spanningSets μ n) hp0 hptop
-        ((memLp_indicator_const p hE 1 (Or.inr (show (μ.restrict (spanningSets μ n)) E ≠ ⊤ from by
-            rw [Measure.restrict_apply hE, Set.inter_eq_left.mpr hEn]; exact hfin))).toLp _) =
-      (memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _ := by
-    intro n E hE hEn hfin
-    have hfin_n : (μ.restrict (spanningSets μ n)) E ≠ ⊤ := by
-      rw [Measure.restrict_apply hE, Set.inter_eq_left.mpr hEn]; exact hfin
-    rw [Lp.ext_iff]
-    -- Show both cofunctions are a.e. E.indicator 1 under μ
-    have hlhs : (extByZeroCLM (measurableSet_spanningSets μ n) hp0 hptop
-        ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _) : α → ℝ) =ᵐ[μ]
-        (spanningSets μ n).indicator
-          ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ : α → ℝ) :=
-      (memLp_indicator_of_restrict_loc (measurableSet_spanningSets μ n) hp0 hptop
-        (Lp.memLp _)).coeFn_toLp
-    have hrhs : ((memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _ : α → ℝ) =ᵐ[μ]
-        E.indicator 1 :=
-      (memLp_indicator_const p hE 1 (Or.inr hfin)).coeFn_toLp
-    -- Sₙ.indicator (coeFn of 1_E^Lp(μₙ)) =ᵐ[μ] E.indicator 1
-    -- coeFn_toLp gives =ᵐ[μ.restrict Sₙ]; convert to =ᵐ[μ] via ae_restrict_iff'
-    have hkey : (spanningSets μ n).indicator
-        ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ : α → ℝ) =ᵐ[μ]
-        E.indicator 1 := by
-      have hcoe_restrict : ∀ᵐ a ∂μ, a ∈ spanningSets μ n →
-          (memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ a = E.indicator 1 a :=
-        (ae_restrict_iff' (measurableSet_spanningSets μ n)).mp
-          (memLp_indicator_const p hE 1 (Or.inr hfin_n)).coeFn_toLp
-      filter_upwards [hcoe_restrict] with a ha
-      simp only [Set.indicator_apply]
-      by_cases hn : a ∈ spanningSets μ n
-      · simp only [hn, ite_true]; exact ha hn
-      · simp only [hn, ite_false, Set.indicator_apply, if_neg (fun he => hn (hEn he))]
-    exact hlhs.trans hkey |>.trans hrhs.symm
-  -- For E ⊆ Sₙ with μ(E) < ∞: φ(1_E^Lp(μ)) = ∫_E g_seq n dμ
-  have hagree_n : ∀ n (E : Set α) (hE : MeasurableSet E) (hEn : E ⊆ spanningSets μ n)
-      (hfin : μ E ≠ ⊤),
-      φ ((memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _) =
-      ∫ a in E, g_seq n a ∂μ := by
-    intro n E hE hEn hfin
-    have hfin_n : (μ.restrict (spanningSets μ n)) E ≠ ⊤ := by
-      rw [Measure.restrict_apply hE, Set.inter_eq_left.mpr hEn]; exact hfin
-    -- φ(1_E) = φ(extByZeroCLM(1_E^Lp(μₙ))) = ∫ 1_E * g_seq n ∂μₙ = ∫_E g_seq n ∂μ
-    rw [← hext_ind n E hE hEn hfin]
-    rw [hg_seq_rep n]
-    -- ∫ (coeFn of 1_E^Lp(μₙ)) * g_seq n ∂(μ.restrict Sₙ) = ∫_E g_seq n ∂μ
-    have hcoe : ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ : α → ℝ) =ᵐ[μ.restrict (spanningSets μ n)]
-        E.indicator 1 :=
-      (memLp_indicator_const p hE 1 (Or.inr hfin_n)).coeFn_toLp
-    rw [integral_congr_ae (EventuallyEq.mul_right hcoe _)]
-    simp_rw [Set.indicator_apply, Pi.one_apply, ite_mul, one_mul, zero_mul]
-    rw [integral_indicator hE, Measure.restrict_restrict hE,
-      Set.inter_comm, Set.inter_eq_left.mpr hEn]
-  -- ── Step A1: Norm bound ─────────────────────────────────────────────────────
-  -- Hölder-extremizer norm bound: ‖g_seq n‖_{Lq(μ.restrict Sₙ)} ≤ ‖φ‖
-  -- Proof sketch: let φₙ := φ ∘ extByZeroCLM(Sₙ); then ‖φₙ‖ ≤ ‖φ‖.
-  -- riesz_lp_surjective_from_rn gives g_seq n with ‖g_seq n‖_Lq = ‖φₙ‖ ≤ ‖φ‖.
-  -- The equality uses the Hölder extremizer (cf. holder_extremizer_lq_bound in parent).
-  have hgnorm : ∀ n, eLpNorm (g_seq n) q (μ.restrict (spanningSets μ n)) ≤
-      ENNReal.ofReal ‖φ‖ := by
-    intro n
+        ∫ a, (f : α → ℝ) a * g a ∂(μ.restrict (spanningSets μ n))) :
+    eLpNorm g q (μ.restrict (spanningSets μ n)) ≤ ENNReal.ofReal ‖φ‖ := by
     set μₙ := μ.restrict (spanningSets μ n)
     set hS := measurableSet_spanningSets μ n
     set extZ := extByZeroCLM hS hp0 hptop
-    have hg := hg_seq_mem n
-    set g := g_seq n
     -- Derived constants
     have hqtop' : q ≠ ⊤ := by
       intro h; rw [h, ENNReal.toReal_top] at hpq; linarith [hpq.symm.pos]
@@ -484,7 +393,7 @@ theorem localization_existence
         (mul_le_of_le_one_right (norm_nonneg _) hextZ_norm)
     -- hrep: (φ ∘ extZ) f = ∫ f * g ∂μₙ for all f ∈ Lp(μₙ)
     have hrep : ∀ f : Lp ℝ p μₙ, (φ.comp extZ) f = ∫ a, (f : α → ℝ) a * g a ∂μₙ := by
-      intro f; simp only [ContinuousLinearMap.comp_apply]; exact hg_seq_rep n f
+      intro f; simp only [ContinuousLinearMap.comp_apply]; exact hgrep f
     -- For each truncation g_k := clamp(g, -k, k), prove ‖g_k‖_q ≤ ‖φ ∘ extZ‖
     have htrunc : ∀ k : ℕ,
         eLpNorm (fun a => max (min (g a) (k : ℝ)) (-(k : ℝ))) q μₙ ≤
@@ -725,6 +634,113 @@ theorem localization_existence
             rw [hMCT]; exact iSup_le hgn_lint
       _ = ENNReal.ofReal ‖φ.comp extZ‖ := by
             rw [← ENNReal.rpow_mul, mul_one_div_cancel hq_pos'.ne', ENNReal.rpow_one]
+
+/-- **Step A**: constructs g ∈ Lq(μ) with indicator agreement on finite-measure sets.
+
+    Proof outline (Folland §6.2):
+    1. For each n, μ.restrict(Sₙ) is finite. Build φₙ = φ ∘ extByZeroCLM.
+    2. Apply `RieszLpSurjectivity.riesz_lp_surjective_from_rn` to get gₙ ∈ Lq(μₙ).
+    3. Consistency: gₙ₊₁ = gₙ a.e. on Sₙ (Lq uniqueness).
+    4. MCT + uniform bound ‖gₙ‖_{Lq(μₙ)} ≤ ‖φₙ‖ ≤ ‖φ‖ gives g ∈ Lq(μ).
+    5. Indicator agreement via continuity of φ and DCT.
+    Infrastructure (extByZeroCLM, finite-measure application) is proved above.
+    All steps proved below; 0 sorries. -/
+theorem localization_existence
+    (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
+    (hpq : p.toReal.HolderConjugate q.toReal)
+    [SigmaFinite μ] [Fact (1 ≤ p)]
+    (φ : Lp ℝ p μ →L[ℝ] ℝ) :
+    ∃ g : α → ℝ, MemLp g q μ ∧
+      eLpNorm g q μ ≤ ENNReal.ofReal ‖φ‖ ∧
+      ∀ (E : Set α) (hE : MeasurableSet E) (hfin : μ E ≠ ⊤),
+        φ ((memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _) =
+        ∫ a in E, g a ∂μ := by
+  have hp0 : p ≠ 0 := ne_of_gt (lt_of_lt_of_le zero_lt_one (le_of_lt hp1))
+  -- For each n, finite-measure Riesz on μ.restrict(Sₙ) via φₙ = φ ∘ extByZeroCLM
+  have hriesz_n : ∀ n, ∃ gₙ : α → ℝ,
+      MemLp gₙ q (μ.restrict (spanningSets μ n)) ∧
+      ∀ f : Lp ℝ p (μ.restrict (spanningSets μ n)),
+        φ (extByZeroCLM (measurableSet_spanningSets μ n) hp0 hptop f) =
+        ∫ a, (f : α → ℝ) a * gₙ a ∂(μ.restrict (spanningSets μ n)) := by
+    intro n
+    haveI hfin_n : IsFiniteMeasure (μ.restrict (spanningSets μ n)) :=
+      { measure_univ_lt_top := by
+          have : (μ.restrict (spanningSets μ n)) Set.univ =
+              μ (spanningSets μ n) := by
+            rw [Measure.restrict_apply MeasurableSet.univ, Set.inter_univ]
+          rw [this]; exact measure_spanningSets_lt_top μ n }
+    haveI : SigmaFinite (μ.restrict (spanningSets μ n)) := inferInstance
+    let φₙ : Lp ℝ p (μ.restrict (spanningSets μ n)) →L[ℝ] ℝ :=
+      φ.comp (extByZeroCLM (measurableSet_spanningSets μ n) hp0 hptop)
+    obtain ⟨gₙ, hgₙ, hgₙ_rep⟩ :=
+      RieszLpSurjectivity.riesz_lp_surjective_from_rn p q hp1 hptop hpq φₙ
+    exact ⟨gₙ, hgₙ, hgₙ_rep⟩
+  -- Extract the gₙ family
+  choose g_seq hg_seq_mem hg_seq_rep using hriesz_n
+  -- Key: extByZeroCLM(Sₙ)(1_E^Lp(μₙ)) = 1_E^Lp(μ), for E ⊆ Sₙ
+  -- (Both have representative E.indicator 1 a.e. w.r.t. μ)
+  have hext_ind : ∀ n (E : Set α) (hE : MeasurableSet E) (hEn : E ⊆ spanningSets μ n)
+      (hfin : μ E ≠ ⊤),
+      extByZeroCLM (measurableSet_spanningSets μ n) hp0 hptop
+        ((memLp_indicator_const p hE 1 (Or.inr (show (μ.restrict (spanningSets μ n)) E ≠ ⊤ from by
+            rw [Measure.restrict_apply hE, Set.inter_eq_left.mpr hEn]; exact hfin))).toLp _) =
+      (memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _ := by
+    intro n E hE hEn hfin
+    have hfin_n : (μ.restrict (spanningSets μ n)) E ≠ ⊤ := by
+      rw [Measure.restrict_apply hE, Set.inter_eq_left.mpr hEn]; exact hfin
+    rw [Lp.ext_iff]
+    -- Show both cofunctions are a.e. E.indicator 1 under μ
+    have hlhs : (extByZeroCLM (measurableSet_spanningSets μ n) hp0 hptop
+        ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _) : α → ℝ) =ᵐ[μ]
+        (spanningSets μ n).indicator
+          ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ : α → ℝ) :=
+      (memLp_indicator_of_restrict_loc (measurableSet_spanningSets μ n) hp0 hptop
+        (Lp.memLp _)).coeFn_toLp
+    have hrhs : ((memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _ : α → ℝ) =ᵐ[μ]
+        E.indicator 1 :=
+      (memLp_indicator_const p hE 1 (Or.inr hfin)).coeFn_toLp
+    -- Sₙ.indicator (coeFn of 1_E^Lp(μₙ)) =ᵐ[μ] E.indicator 1
+    -- coeFn_toLp gives =ᵐ[μ.restrict Sₙ]; convert to =ᵐ[μ] via ae_restrict_iff'
+    have hkey : (spanningSets μ n).indicator
+        ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ : α → ℝ) =ᵐ[μ]
+        E.indicator 1 := by
+      have hcoe_restrict : ∀ᵐ a ∂μ, a ∈ spanningSets μ n →
+          (memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ a = E.indicator 1 a :=
+        (ae_restrict_iff' (measurableSet_spanningSets μ n)).mp
+          (memLp_indicator_const p hE 1 (Or.inr hfin_n)).coeFn_toLp
+      filter_upwards [hcoe_restrict] with a ha
+      simp only [Set.indicator_apply]
+      by_cases hn : a ∈ spanningSets μ n
+      · simp only [hn, ite_true]; exact ha hn
+      · simp only [hn, ite_false, Set.indicator_apply, if_neg (fun he => hn (hEn he))]
+    exact hlhs.trans hkey |>.trans hrhs.symm
+  -- For E ⊆ Sₙ with μ(E) < ∞: φ(1_E^Lp(μ)) = ∫_E g_seq n dμ
+  have hagree_n : ∀ n (E : Set α) (hE : MeasurableSet E) (hEn : E ⊆ spanningSets μ n)
+      (hfin : μ E ≠ ⊤),
+      φ ((memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _) =
+      ∫ a in E, g_seq n a ∂μ := by
+    intro n E hE hEn hfin
+    have hfin_n : (μ.restrict (spanningSets μ n)) E ≠ ⊤ := by
+      rw [Measure.restrict_apply hE, Set.inter_eq_left.mpr hEn]; exact hfin
+    -- φ(1_E) = φ(extByZeroCLM(1_E^Lp(μₙ))) = ∫ 1_E * g_seq n ∂μₙ = ∫_E g_seq n ∂μ
+    rw [← hext_ind n E hE hEn hfin]
+    rw [hg_seq_rep n]
+    -- ∫ (coeFn of 1_E^Lp(μₙ)) * g_seq n ∂(μ.restrict Sₙ) = ∫_E g_seq n ∂μ
+    have hcoe : ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ : α → ℝ) =ᵐ[μ.restrict (spanningSets μ n)]
+        E.indicator 1 :=
+      (memLp_indicator_const p hE 1 (Or.inr hfin_n)).coeFn_toLp
+    rw [integral_congr_ae (EventuallyEq.mul_right hcoe _)]
+    simp_rw [Set.indicator_apply, Pi.one_apply, ite_mul, one_mul, zero_mul]
+    rw [integral_indicator hE, Measure.restrict_restrict hE,
+      Set.inter_comm, Set.inter_eq_left.mpr hEn]
+  -- ── Step A1: Norm bound ─────────────────────────────────────────────────────
+  -- Hölder-extremizer norm bound: ‖g_seq n‖_{Lq(μ.restrict Sₙ)} ≤ ‖φ‖
+  -- Proof sketch: let φₙ := φ ∘ extByZeroCLM(Sₙ); then ‖φₙ‖ ≤ ‖φ‖.
+  -- riesz_lp_surjective_from_rn gives g_seq n with ‖g_seq n‖_Lq = ‖φₙ‖ ≤ ‖φ‖.
+  -- The equality uses the Hölder extremizer (cf. holder_extremizer_lq_bound in parent).
+  have hgnorm : ∀ n, eLpNorm (g_seq n) q (μ.restrict (spanningSets μ n)) ≤
+      ENNReal.ofReal ‖φ‖ := fun n =>
+    gseq_norm_bound p q hp1 hptop hpq φ n hp0 (g_seq n) (hg_seq_mem n) (hg_seq_rep n)
   -- ── Step A2: Consistency ────────────────────────────────────────────────────
   -- g_seq m =ᵐ[μ.restrict Sₘ] g_seq n for m ≤ n, via set-integral uniqueness.
   -- Key: ∫_s gₘ ∂(μ.restrict Sₘ) = ∫_{s∩Sₘ} gₘ ∂μ = φ(1_{s∩Sₘ}) = ∫_{s∩Sₘ} gₙ ∂μ

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -1033,3 +1033,73 @@ measurability (234+ — `AEMeasurable`/`Measurable` + `‖·‖ₑ`/`↑‖·‖
 path is unchanged from S16/S17 (repair chain → surface σ-finite norm bound → discharge synthesis
 `sorry` → swap axiom), but this session pins the true blocker on step 1: **the repair is now
 mechanical + source-verifiable, but the monolithic theorem must be split to be buildable.**
+
+### 2026-07-01 (Session 19, researcher-5) — S18 SPLIT EXECUTED: Step A1 extracted to gseq_norm_bound (build-verified faithful); + 8 drift fixes, Incomplete01 63→55 [VERIFIED, no regressions]
+
+**Mode:** REVISIT (executes S18's pinned mandate "NEXT SESSION MUST SPLIT localization_existence").
+Two verified deliverables this session; axiom untouched.
+
+**1. SPLIT DONE + build-verified faithful (commit 9be62d50c3b).** Extracted Step A1 (the
+~275-line `hgnorm` block, the converse-Hölder norm bound `eLpNorm gₙ q (μ|Sₙ) ≤ ‖φ‖`) out of
+the 600-line monolith `localization_existence` into a standalone top-level theorem
+`gseq_norm_bound` (Incomplete01 line ~356, before localization_existence). It takes the fixed
+`n`, `hp0`, the representer `g`, its `MemLp`, and the `extByZeroCLM`-form representation `hgrep`
+as explicit params; `localization_existence` now calls it via a one-liner
+(`fun n => gseq_norm_bound p q hp1 hptop hpq φ n hp0 (g_seq n) (hg_seq_mem n) (hg_seq_rep n)`).
+Docker build confirmed the split is **error-neutral: 63→63, downstream error set identical**
+(pure structural move, no new/lost errors). This is the S18 step-1 unblock: the monolith is now
+splittable/measurable and the isolated Step A1 drift is repairable independently.
+**Extraction recipe** (reap-safe, no hand-retyping 275 lines): Python script that (a) copies the
+inner tactic block keeping its 4-space indent (valid under a col-0 `theorem … := by`), dropping
+the `have hg :=`/`set g :=` setup lines (now params) and swapping `exact hg_seq_rep n f`→`exact
+hgrep f`; (b) inserts the new theorem before the localization_existence docstring; (c) replaces
+the old `have hgnorm := by …` block with the one-liner. Proof-irrelevance handles the `hp0` term
+in `hgrep` (explicit param avoids relying on it).
+
+**2. 8 root drift fixes in gseq_norm_bound, Docker-verified 63→55 (-8), ZERO downstream
+regression (commit c66b2b8c130).** Diffed the two builds' error-line sets: all downstream lines
+identical (shifted +2), all 8 cleared errors were inside gseq_norm_bound (24→16). **NEW drift
+NOT in S17/S18's dictionary — add to it:**
+- `MemLp.of_bound`: signature is now `(hf : AEStronglyMeasurable f μ) (C : ℝ) (hfC)` — the
+  **measurability hypothesis comes FIRST**, then the bound `C`. (Was `C` first.) 2 sites.
+- `ENNReal.coe_rpow_of_nonneg (x : ℝ≥0) {y} (h : 0 ≤ y)`: the **base `x` is now an explicit
+  first argument** → write `ENNReal.coe_rpow_of_nonneg _ (le_of_lt h…)` (insert `_`). 4 sites.
+- `hextZ_le`: `simp only [extZ, extByZeroCLM, LinearMap.mkContinuous_apply, Lp.norm_def]` no longer
+  reduces the `LinearMap.mkContinuous`-anon-ctor application `({toFun:=…} f)` → add
+  `LinearMap.coe_mk, AddHom.coe_mk` to the simp set so `{toFun:=t,…} f ↝ t f`.
+- `hhk_bound` calc: after `simp only […, abs_mul]` the LHS gains an inner abs
+  `|sign|*||g_k a|^(q-1)|` → `rw [abs_of_nonneg (Real.rpow_nonneg (abs_nonneg (g_k a)) (q.toReal-1))]`
+  before the calc.
+- `hsign` (in hpw2): `rcases lt_trichotomy (g_k a) 0 with ha | rfl | ha` — the `rfl` subst on the
+  **non-variable** `g_k a` fails now → use `… | ha | ha` with middle case `simp [ha]`.
+
+**Remaining 16 gseq_norm_bound errors = the fragile rpow-arithmetic chain** (Incomplete01 new
+line nums, all cascade through hint_hkgk→hgk_memLq→hchain→hx_le so gseq stays red until cleared):
+- `hpw2` (≈492) & `hpw_real` (≈515,528): `Real.rpow_add` now requires **`hx : 0 < x`** (was
+  `0 ≤ x`); base `|g_k a|` can be 0 → must case-split `g_k a = 0` (use `Real.zero_rpow hq_pos'.ne'`)
+  and in the nonzero branch use `Real.rpow_add habs …` with `habs : 0 < |g_k a|`, or
+  `Real.rpow_add' (abs_nonneg _) (h : y+z ≠ 0)`. Avoid the global `rw [show |g_k a|=|g_k a|^1]`
+  (it rewrites the exponent-base too) — use a calc `_ = |g_k a|^(q-1) * |g_k a|^1 := by rw
+  [Real.rpow_one] _ = |g_k a|^((q-1)+1) := (Real.rpow_add habs _ _).symm _ = |g_k a|^q := by
+  congr 1; ring`.
+- `460` unsolved goals / failed to synthesize (hgk_memLq eLpNorm_mono_ae area).
+- `503` app type mismatch (`integral_toReal` measurability arg — enorm.pow_const form).
+- `535` hn_eLpNorm final rw (eLpNorm_eq_lintegral_rpow_enorm enorm/nnnorm).
+- `556` `rw [x]` invalid — `x` is a value not an eq (the `set x := …` rewrite target drifted).
+- `593` unsolved (hchain).
+- `615` `iSup (min x) = x` vs `⨆ k, min x ↑k` (sup_min — Nat.cast coe mismatch).
+- `620/625/629` OrderIso.map_iSup type mismatch + `AEMeasurable.pow_const`/`.min`/`.enorm` form.
+Also warning `614`: unused simp arg.
+
+**Recommended next ACT:** clear the ~16 rpow-chain errors in gseq_norm_bound (all mechanical/
+source-verifiable per above; a fast-iteration or Aristotle pass is ideal since each Docker verify
+is ~17 min). Once gseq_norm_bound is green, apply S18's staged `s18-batch3-drift-fixes.patch`
+(targets integrationCLM_sf / hagree_n / Step A4 / Step A5 — all OUTSIDE gseq, patch line numbers
+now shifted by the split so apply by content not `git apply`) to clear the downstream ~40, then
+Incomplete01 greens → surfaces the σ-finite norm bound → discharges synthesis `sorry` → eliminates
+the parent axiom. **The split means each piece now elaborates independently within budget.**
+**INFRA:** Docker builds work (~17 min/iteration incl. dep-clone+cache; the split file compiles
+Lean-side much longer than S18's "180s" figure but well under the 60min envelope). **Worktree got
+reaped mid-session once** (killed an in-flight build; branch survived) — commit before every
+Docker build; recreate via `git worktree add .loom/worktrees/researcher-5 feature/researcher-5`
+then `git reset --hard origin/main`.


### PR DESCRIPTION
## Summary

Continues the multi-session repair of the Lp-duality chain that gates elimination of
`axiom riesz_lp_surjective`. Executes **S18's pinned mandate**: split the 600-line
`localization_existence` monolith (which exceeded the 40min/32GB build envelope once further
drift fixes let elaboration proceed) into independently-elaborating pieces.

Two Docker-verified deliverables (axiom **not** eliminated — this is critical-path infra):

### 1. Split Step A1 → standalone `gseq_norm_bound` (build-verified faithful)
Extracted the ~275-line `hgnorm` block (converse-Hölder norm bound
`eLpNorm gₙ q (μ|Sₙ) ≤ ‖φ‖`) out of `localization_existence` into a top-level theorem taking
the representer + representation as explicit params; `localization_existence` now applies it via
a one-liner. Docker build confirmed **error-neutral (63→63), downstream error set identical** — a
pure structural move that isolates Step A1's drift for independent repair.

### 2. 8 root drift fixes in `gseq_norm_bound` → Incomplete01 **63 → 55 errors (−8), zero regression**
Diffed both builds' error-line sets: all 8 cleared errors are inside `gseq_norm_bound`; downstream
set is identical. Includes **two newly-discovered Mathlib drift patterns** (not in the S17/S18
dictionary):
- `MemLp.of_bound` — measurability hypothesis is now the **first** argument (then `C : ℝ`). 2 sites.
- `ENNReal.coe_rpow_of_nonneg` — base `x : ℝ≥0` is now an **explicit first** argument. 4 sites.

Plus: `hextZ_le` (`LinearMap.coe_mk`/`AddHom.coe_mk` to reduce the `mkContinuous` anon-ctor),
`hhk_bound` inner-abs strip, and `hpw2`'s `rfl`-subst-on-non-variable fix.

## Status
`status: formalized` (unchanged) — Incomplete01 is not in `build-safe-subset.sh`; strand metas
remain honestly `formalized`. Remaining 16 `gseq_norm_bound` errors are a fragile rpow-arithmetic
chain (documented in the problem's `knowledge.md` S19 notes with fix recipes) left for a
fast-iteration/Aristotle pass. Splitting means each piece now elaborates within budget, unblocking
S18's staged batch-3 fixes for the downstream ~40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)