### PR TITLE
Enrich Weitzenböck inequality (herons-formula-oq-07): annotation depth

### DIFF
--- a/src/data/proofs/herons-formula-oq-07/annotations.json
+++ b/src/data/proofs/herons-formula-oq-07/annotations.json
@@ -8,7 +8,19 @@
     },
     "type": "concept",
     "title": "Weitzenböck's Inequality",
-    "content": "Weitzenböck's inequality (Roland Weitzenböck, 1919; IMO 1961, Problem 2) states that for any triangle with side lengths a, b, c and area, a² + b² + c² ≥ 4√3·Area, with equality exactly for the equilateral triangle. Equivalently, among all triangles with a fixed sum of squared sides the equilateral one has the largest area. It is the leading term of the sharper Finsler–Hadwiger inequality. This formalization avoids any coordinate or trigonometric construction and works directly from Heron's area, reducing the statement to a polynomial inequality settled by a sum-of-squares certificate."
+    "content": "Weitzenböck's inequality (Roland Weitzenböck, 1919; IMO 1961, Problem 2) states that for any triangle with side lengths a, b, c and area, a² + b² + c² ≥ 4√3·Area, with equality exactly for the equilateral triangle. Equivalently, among all triangles with a fixed sum of squared sides the equilateral one has the largest area. It is the leading term of the sharper Finsler–Hadwiger inequality. This formalization avoids any coordinate or trigonometric construction and works directly from Heron's area, reducing the statement to a polynomial inequality settled by a sum-of-squares certificate.",
+    "mathContext": "$a^2 + b^2 + c^2 \\ge 4\\sqrt{3}\\,\\mathrm{Area}$, with equality iff $a=b=c$. The constant $4\\sqrt{3}$ is sharp: for the equilateral triangle of side $a$ one has $\\mathrm{Area} = \\tfrac{\\sqrt{3}}{4}a^2$, so $4\\sqrt{3}\\,\\mathrm{Area} = 3a^2 = a^2+a^2+a^2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Weitzenböck's inequality",
+      "Finsler–Hadwiger inequality",
+      "isoperimetric-type extremal problems",
+      "IMO 1961 Problem 2"
+    ],
+    "prerequisites": [
+      "triangle area",
+      "elementary symmetric inequalities"
+    ]
   },
   {
     "id": "ann-triangle-data",
@@ -19,7 +31,19 @@
     },
     "type": "concept",
     "title": "Square-root-free triangle data",
-    "content": "The semi-perimeter s = (a+b+c)/2, Heron's product heronProduct = s(s-a)(s-b)(s-c) (the squared area), and area = √(heronProduct) are defined so that the entire proof stays polynomial in a, b, c except for the single definitional square root. `heronProduct_nonneg` shows the product is ≥ 0 for a nondegenerate triangle by splitting the product with `mul_nonneg` and discharging each factor with `linarith` from the strict triangle inequalities."
+    "content": "The semi-perimeter s = (a+b+c)/2, Heron's product heronProduct = s(s-a)(s-b)(s-c) (the squared area), and area = √(heronProduct) are defined so that the entire proof stays polynomial in a, b, c except for the single definitional square root. `heronProduct_nonneg` shows the product is ≥ 0 for a nondegenerate triangle by splitting the product with `mul_nonneg` and discharging each factor with `linarith` from the strict triangle inequalities.",
+    "mathContext": "$s = \\tfrac{a+b+c}{2}$, $\\;\\mathrm{heronProduct} = s(s-a)(s-b)(s-c) = \\mathrm{Area}^2$, $\\;\\mathrm{area} = \\sqrt{\\mathrm{heronProduct}}$. The triangle inequalities $a<b+c$, $b<a+c$, $c<a+b$ are exactly $s-a>0$, $s-b>0$, $s-c>0$, so each of the four factors is positive and $\\mathrm{heronProduct} \\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Heron's formula",
+      "semi-perimeter",
+      "triangle inequality",
+      "nonnegativity of a product"
+    ],
+    "prerequisites": [
+      "Heron's formula Area² = s(s-a)(s-b)(s-c)",
+      "strict triangle inequalities"
+    ]
   },
   {
     "id": "ann-sos-identity",
@@ -30,7 +54,19 @@
     },
     "type": "tactic",
     "title": "The Sum-of-Squares Certificate",
-    "content": "The heart of the proof is the identity (a²+b²+c²)² - 48·heronProduct = 2((a²-b²)²+(b²-c²)²+(c²-a²)²), an identity in the squared side lengths that `ring` closes after unfolding heronProduct and the semi-perimeter. Its right-hand side is a sum of squares, so the squared inequality 48·heronProduct ≤ (a²+b²+c²)² follows by `nlinarith` fed the three `sq_nonneg` terms and the identity. Crucially this squared inequality needs no triangle hypothesis — it holds for all real a, b, c."
+    "content": "The heart of the proof is the identity (a²+b²+c²)² - 48·heronProduct = 2((a²-b²)²+(b²-c²)²+(c²-a²)²), an identity in the squared side lengths that `ring` closes after unfolding heronProduct and the semi-perimeter. Its right-hand side is a sum of squares, so the squared inequality 48·heronProduct ≤ (a²+b²+c²)² follows by `nlinarith` fed the three `sq_nonneg` terms and the identity. Crucially this squared inequality needs no triangle hypothesis — it holds for all real a, b, c.",
+    "mathContext": "$(a^2+b^2+c^2)^2 - 48\\cdot\\mathrm{heronProduct} = 2\\big((a^2-b^2)^2 + (b^2-c^2)^2 + (c^2-a^2)^2\\big) \\ge 0$. This exhibits the difference as a sum of squares in the variables $a^2, b^2, c^2$, so $48\\cdot\\mathrm{heronProduct} \\le (a^2+b^2+c^2)^2$ holds for all reals. A sum-of-squares (SOS) certificate is the constructive witness that a polynomial is nonnegative.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum-of-squares decomposition",
+      "Positivstellensatz / SOS certificates",
+      "polynomial (ring) identities",
+      "nlinarith / sq_nonneg"
+    ],
+    "prerequisites": [
+      "sum-of-squares positivity",
+      "polynomial identities closed by `ring`"
+    ]
   },
   {
     "id": "ann-sqrt-upgrade",
@@ -41,7 +77,18 @@
     },
     "type": "tactic",
     "title": "Upgrading the squared inequality via sqrt monotonicity",
-    "content": "Both sides of a²+b²+c² ≥ 4√3·Area are non-negative, so the linear inequality is equivalent to the squared one. Writing Y = 4·√3·Area and X = a²+b²+c², one computes Y² = 16·(√3)²·Area² = 48·heronProduct (using `Real.sq_sqrt` for both (√3)²=3 and Area²=heronProduct), so `weitzenbock_sq` gives Y² ≤ X². Then `Real.sqrt_le_sqrt` together with `Real.sqrt_sq` (both X, Y ≥ 0) recovers Y ≤ X. This is the only analytic step in the entire development."
+    "content": "Both sides of a²+b²+c² ≥ 4√3·Area are non-negative, so the linear inequality is equivalent to the squared one. Writing Y = 4·√3·Area and X = a²+b²+c², one computes Y² = 16·(√3)²·Area² = 48·heronProduct (using `Real.sq_sqrt` for both (√3)²=3 and Area²=heronProduct), so `weitzenbock_sq` gives Y² ≤ X². Then `Real.sqrt_le_sqrt` together with `Real.sqrt_sq` (both X, Y ≥ 0) recovers Y ≤ X. This is the only analytic step in the entire development.",
+    "mathContext": "For $X, Y \\ge 0$, $\\;Y^2 \\le X^2 \\Rightarrow Y \\le X$ because $t \\mapsto \\sqrt{t}$ is monotone and $\\sqrt{Y^2} = Y$, $\\sqrt{X^2} = X$. Here $Y = 4\\sqrt{3}\\,\\mathrm{Area}$, $X = a^2+b^2+c^2$, and $Y^2 = 16\\cdot(\\sqrt3)^2\\cdot\\mathrm{Area}^2 = 48\\cdot\\mathrm{heronProduct}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotonicity of the square root",
+      "order-reflecting maps",
+      "Real.sqrt_le_sqrt / Real.sqrt_sq"
+    ],
+    "prerequisites": [
+      "Real.sqrt monotonicity",
+      "√(x²) = x for x ≥ 0"
+    ]
   },
   {
     "id": "ann-equality",
@@ -52,6 +99,18 @@
     },
     "type": "insight",
     "title": "The equality case comes for free",
-    "content": "Equality 4√3·Area = a²+b²+c² forces Y² = X², hence (a²+b²+c²)² = 48·heronProduct, so the SOS sum vanishes and each square (a²-b²)², (b²-c²)², (c²-a²)² is zero. Thus a² = b² = c², and since the sides are positive, factoring (a-b)(a+b) = 0 with a+b > 0 gives a = b (similarly b = c) — the triangle is equilateral. The converse is a direct computation. A single sum-of-squares identity therefore proves both Weitzenböck's inequality and its sharpness."
+    "content": "Equality 4√3·Area = a²+b²+c² forces Y² = X², hence (a²+b²+c²)² = 48·heronProduct, so the SOS sum vanishes and each square (a²-b²)², (b²-c²)², (c²-a²)² is zero. Thus a² = b² = c², and since the sides are positive, factoring (a-b)(a+b) = 0 with a+b > 0 gives a = b (similarly b = c) — the triangle is equilateral. The converse is a direct computation. A single sum-of-squares identity therefore proves both Weitzenböck's inequality and its sharpness.",
+    "mathContext": "Equality $\\Rightarrow (a^2-b^2)^2+(b^2-c^2)^2+(c^2-a^2)^2 = 0 \\Rightarrow a^2=b^2=c^2$. Since $a+b>0$, $\\;a^2=b^2$ factors as $(a-b)(a+b)=0 \\Rightarrow a=b$; likewise $b=c$. The equality case is read off the *same* SOS identity that proves the inequality — no separate optimization argument is needed.",
+    "significance": "key",
+    "relatedConcepts": [
+      "equality cases of inequalities",
+      "vanishing sum of squares",
+      "zero-product property",
+      "sharpness / extremal configuration"
+    ],
+    "prerequisites": [
+      "a sum of squares is zero iff each term is zero",
+      "zero-product property"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass on `herons-formula-oq-07` (Weitzenböck's inequality from Heron's formula).

**Gap addressed:** all 5 annotations had solid `content` but lacked the annotation-depth fields. This pass adds `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation, matching the enricher quality target (≥5 annotations with mathContext/significance/relatedConcepts).

- Existing `content` preserved verbatim; only additive.
- `meta.json` untouched (already rich at 11.4 KB, well under the 60 KB cap; overview/conclusion/sections/crossRefs already complete).
- LaTeX `mathContext` verified against the Lean source `Proofs/HeronsFormulaOQ07.lean` (SOS identity, sqrt-monotonicity upgrade, equality case).
- JSON validated; `check-meta-size` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)