### PR TITLE
Enrich Erdős #191 axiom elimination (erdos-191-incomplete-01): add references

### DIFF
--- a/src/data/proofs/erdos-191-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-191-incomplete-01/meta.json
@@ -110,6 +110,17 @@
       "description": "Discharges the tripleLog_unbounded axiom of the erdos-191 entry, reducing its genuine assumption count from 4 to 3"
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Bloom, Thomas F."
+      ],
+      "title": "Erdős Problems — Problem 191",
+      "year": "2024",
+      "venue": "erdosproblems.com/191",
+      "note": "Canonical catalog entry: every 2-colouring of the pairs from {2,…,n} contains a monochromatic X with ∑_{x∈X} 1/log x as large as ≍ log log log n. Rödl (2003) supplied the matching upper-bound construction; Conlon, Fox and Sudakov proved the tight lower bound ∑_{x∈X} 1/log x ≥ 2⁻⁸ · log log log n — the source of the triple-logarithm scale tripleLog whose divergence this entry proves axiom-free."
+    }
+  ],
   "mainTheorems": [
     {
       "name": "tripleLog_unbounded",


### PR DESCRIPTION
Enrichment pass for `erdos-191-incomplete-01` (0 passes, quality 89).

**Change** — filled a genuine gap: the `references` array was empty despite the entry discussing published results. Added the canonical Erdős Problems catalog entry (#191), with the primary-result attributions (Rödl 2003 construction; Conlon–Fox–Sudakov tight lower bound $\sum 1/\log x \ge 2^{-8}\log\log\log n$) confirmed against the literature. Attributions are placed in the reference note rather than as fabricated standalone citations, since exact venues for the 2003/2013 papers could not be verified precisely.

**Not changed**: the 4 existing annotations already cover the full 62-line file with depth, and overview/conclusion/sections are complete. Curation, not accretion — no padding.

Vetted: no open PR; no recent enrich commit on this entry.

Validated: meta.json parses; check-meta-size passes.