### PR TITLE
Enrich British Flag Theorem (british-flag-theorem-oq-01): P-cancellation insight

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/annotations.json
@@ -73,7 +73,7 @@
     },
     "type": "theorem",
     "title": "The British Flag Identity",
-    "content": "The core theorem `british_flag`. After substituting the parallelogram closure C = B + D − A, the goal expands to a polynomial identity in the coordinates. Writing u = B − A and v = D − A, the key cancellation is\n\n(PA² + PC²) − (PB² + PD²) = 2 (u.1·v.1 + u.2·v.2) = 2 (u ⬝ v).\n\nThe right-hand side is exactly twice the orthogonality hypothesis, so a single `linear_combination (2 : ℝ) * hperp` closes the goal. The theorem is therefore a metric restatement of the right angle at A: the squared-distance identity holds precisely because the edges are perpendicular.",
+    "content": "The core theorem `british_flag`. After substituting the parallelogram closure C = B + D − A, the goal expands to a polynomial identity in the coordinates. Writing u = B − A and v = D − A, the key cancellation is\n\n(PA² + PC²) − (PB² + PD²) = 2 (u.1·v.1 + u.2·v.2) = 2 (u ⬝ v).\n\nThe right-hand side is exactly twice the orthogonality hypothesis, so a single `linear_combination (2 : ℝ) * hperp` closes the goal. The theorem is therefore a metric restatement of the right angle at A: the squared-distance identity holds precisely because the edges are perpendicular.\n\nNotice that P never survives to the right-hand side: its quadratic terms cancel automatically, and its linear terms cancel because the parallelogram closure makes the coefficient (A + C) − (B + D) equal to zero. So although P appears in all four distances, the identity is really a fact about the vertices.",
     "mathContext": "$(PA^2+PC^2)-(PB^2+PD^2) = 2(u_1 v_1 + u_2 v_2)$ with $u = B-A$, $v = D-A$; this vanishes by $u \\cdot v = 0$.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/british-flag-theorem-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/meta.json
@@ -54,7 +54,8 @@
       "The British Flag theorem is the orthogonality condition in disguise: the metric identity holds exactly when the edge vectors at A are perpendicular",
       "Encoding 'rectangle' as parallelogram-closure plus a single right angle is enough — the remaining three right angles follow and are not needed for the identity",
       "The whole content reduces to one algebraic fact: (PA² + PC²) − (PB² + PD²) = 2 (u ⬝ v), where u, v are the edge vectors at A",
-      "Because the identity is an exact cancellation, the proof needs no square roots and no irrational arithmetic — it is a single ring/linear_combination identity over ℝ"
+      "Because the identity is an exact cancellation, the proof needs no square roots and no irrational arithmetic — it is a single ring/linear_combination identity over ℝ",
+      "The arbitrary point P drops out completely: both its quadratic terms and — thanks to the parallelogram closure making the coefficient (A + C) − (B + D) vanish — its linear terms cancel, so despite appearing in all four distances the identity is ultimately a statement about the vertices alone, not about P"
     ],
     "prerequisites": [
       "Coordinate geometry of points in the plane",


### PR DESCRIPTION
Enrichment pass on `british-flag-theorem-oq-01` (quality 89, passes 0).

The entry was already well-curated (5 full annotations, complete conclusion). This pass adds the one genuinely deep observation that was missing:

- **New 5th keyInsight**: The arbitrary point P drops out of the identity completely — its quadratic terms cancel automatically, and its linear terms cancel because the parallelogram closure `C = B + D − A` makes the coefficient `(A + C) − (B + D)` vanish. So despite appearing in all four distances, the theorem is ultimately a statement about the vertices, not P.
- **Deepened `ann-main`** annotation with the same observation, since it explains *why* the proof collapses to a single `linear_combination`.

Verified against `proofs/Proofs/BritishFlagTheorem.lean`. JSON valid; meta.json 8.2 KB (well under the 60 KB cap); status/badge/axiomCount unchanged (verified, 0 axioms, 0 sorries).