### PR TITLE
Enrich Vajda's identity (cassini-identity-oq-01-oq-01-oq-01): sanity-check annotation + index.ts

### DIFF
--- a/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/annotations.json
@@ -71,5 +71,24 @@
       "Specialization",
       "Fibonacci recurrence"
     ]
+  },
+  {
+    "id": "ann-vajda-sanity",
+    "proofId": "cassini-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 138,
+      "endLine": 153
+    },
+    "type": "theorem",
+    "title": "Numerical sanity checks against the master identity",
+    "content": "Two concrete instances discharge the abstract theorem against integer arithmetic. `vajda_2_1_3` checks the off-diagonal case $n=2, i=1, j=3$: $F_3 F_5 - F_2 F_6 = 2\\cdot 5 - 1\\cdot 8 = 2 = (-1)^2 F_1 F_3$. `vajda_3_2_2` checks the diagonal (Catalan) case $n=3, i=j=2$: $F_5^2 - F_3 F_7 = 25 - 2\\cdot 13 = -1 = (-1)^3 F_2^2$. Each specializes `vajda` and closes with `norm_num`, confirming the sign and the $F_i F_j$ factor evaluate correctly on distinct offsets and on both parities of $n$.",
+    "mathContext": "$n=2$: $F_3 F_5 - F_2 F_6 = 2$; $n=3$: $F_5^2 - F_3 F_7 = -1$. The two parities exercise both signs of $(-1)^n$, and the first exercises a genuinely bilinear $i \\neq j$ instance the diagonal cases never reach.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Numerical verification",
+      "norm_num",
+      "Bilinear off-diagonal case",
+      "Parity of the Cassini sign"
+    ]
   }
 ]

--- a/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CassiniIdentityOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cassiniIdentityOq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cassiniIdentityOq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cassiniIdentityOq01Oq01Oq01Data: ProofData = {
+  proof: cassiniIdentityOq01Oq01Oq01Proof,
+  annotations: cassiniIdentityOq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass on cassini-identity-oq-01-oq-01-oq-01 (Vajda's identity).

- Add a 5th annotation (`ann-vajda-sanity`) covering the numerical sanity checks `vajda_2_1_3` and `vajda_3_2_2`, previously uncovered (lines 138–153). Documents the off-diagonal $i\neq j$ instance and the diagonal Catalan instance, and notes both parities of the Cassini sign are exercised.
- Add the missing `index.ts` shim (matching sibling entries).

meta.json unchanged and within size caps. annotations.json valid (5 entries). Data-generation build step passes; JSON validated.