### PR TITLE
Enrich Pascal-row log-concavity (combinations-formula-oq-04): ratio-rewrite technique annotation

### DIFF
--- a/src/data/proofs/combinations-formula-oq-04/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-04/annotations.json
@@ -57,6 +57,27 @@
     ]
   },
   {
+    "id": "ann-ratio-rewrite",
+    "proofId": "combinations-formula-oq-04",
+    "range": { "startLine": 61, "endLine": 66 },
+    "type": "technique",
+    "title": "Rewriting choose_succ_right_eq to Kill Truncated Subtraction",
+    "content": "The two `have R1`/`R2` blocks are the technical linchpin. Mathlib's `Nat.choose_succ_right_eq n k` states C(n,k+1)·(k+1) = C(n,k)·(n−k), where the factor n−k is ℕ *truncated* subtraction. Specializing at n = k+2+t, the proof needs n−k to appear as the honest t+2 so the downstream algebra (ring, nlinarith) can see it. The idiom `simpa [show (k + 2 + t) - k = t + 2 by omega] using this` does exactly that: `omega` discharges the arithmetic identity (k+2+t)−k = t+2, and `simpa` rewrites the hypothesis with it before closing the goal. R2 applies the same relation one index higher (at k+1), giving c·(k+2) = b·(t+1). These are the two equalities that multiply into the log-concavity bound.",
+    "mathContext": "$C(n,k{+}1)(k{+}1)=C(n,k)(n{-}k)$; at $n=k{+}2{+}t$, $n-k = t+2$ (by `omega`), so $b(k{+}1)=a(t{+}2)$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Nat.choose_succ_right_eq",
+      "truncated subtraction",
+      "omega",
+      "simpa with rewrite"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_right_eq",
+      "ℕ truncated subtraction",
+      "the omega decision procedure"
+    ]
+  },
+  {
     "id": "ann-centered",
     "proofId": "combinations-formula-oq-04",
     "range": { "startLine": 109, "endLine": 114 },


### PR DESCRIPTION
Enrichment pass on `combinations-formula-oq-04` (Log-Concavity of a Pascal Row).

The entry was already rich (deep keyInsights, complete conclusion, full mathlibDependencies) but had only 4 annotations — the role targets ≥5, and the proof's key Lean technique was uncovered at the tactic level.

- **New annotation `ann-ratio-rewrite`** (lines 61–66): explains the `R1`/`R2` linchpin. Mathlib's `Nat.choose_succ_right_eq` carries a truncated ℕ subtraction `n − k`; the proof rewrites it to the honest `t + 2` via `simpa [show (k + 2 + t) - k = t + 2 by omega] using this`. This is what lets the whole argument stay in ℕ with no division, and it was previously unannotated.

Now 5 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`. Verified against `proofs/Proofs/CombinationsFormulaOQ04.lean`; JSON valid; meta.json within caps; status/badge/axiomCount unchanged (verified, 0 axioms, 0 sorries).