### PR TITLE
Add Markov OQ-06: Vieta ascent proves infinitely many Markov triples (VERIFIED)

### DIFF
--- a/proofs/Proofs/MarkovEquationOQ06.lean
+++ b/proofs/Proofs/MarkovEquationOQ06.lean
@@ -1,0 +1,146 @@
+/-
+# Markov Equation — Vieta Ascent Generates Infinitely Many Solutions (OQ-06)
+
+The parent development (`Proofs.MarkovEquation`) runs the Markov tree **downward**:
+every positive Markov triple descends, by Vieta-jumping the *largest* coordinate,
+back to the root `(1,1,1)` (`markov_classification`). The descent strictly
+*decreases* the coordinate sum (`markov_vieta_lt`).
+
+This file runs the tree the other way — **upward** — and draws the structural
+consequence the descent theorem does not give: there are **infinitely many**
+Markov triples.
+
+The engine is the *ascent* move. Given a sorted triple `a ≤ b ≤ c`, Vieta-jump the
+**smallest** coordinate `a ↦ 3bc − a`. The parent's third-coordinate jump,
+conjugated by transpositions, shows the result `(b, c, 3bc − a)` is again a Markov
+triple; and because `a ≤ c` while `b ≥ 1`, the new top coordinate satisfies
+
+  `3bc − a ≥ 3bc − c = c(3b − 1) ≥ 2c > c`,
+
+so the ascent **strictly increases** the maximal coordinate. Iterating from the
+root produces the strictly growing sequence
+
+  `(1,1,1) → (1,1,2) → (1,2,5) → (2,5,29) → ⋯`
+
+of pairwise-distinct Markov triples. Injectivity of this sequence (its top
+coordinate is strictly monotone) forces the solution set to be infinite.
+
+We prove, all axiom-free and over `ℤ`:
+
+* `markov_vieta_fst`   — Vieta-jumping the *first* coordinate preserves Markov;
+* `markov_ascent_isMarkov` — the sorted ascent move `(a,b,c) ↦ (b,c,3bc−a)` lands
+                          in the solution set;
+* `ascent_spec`        — one ascent step keeps a sorted triple sorted and strictly
+                          increases the top coordinate;
+* `seq`                — the canonical ascent sequence rooted at `(1,1,1)`;
+* `seq_zero … seq_three` — it reproduces the classical head `(1,1,1),(1,1,2),
+                          (1,2,5),(2,5,29)`;
+* `seq_top_strictMono` — its top coordinate is strictly monotone, hence `seq` is
+                          injective (`seq_injective`);
+* `markov_infinite`    — **the Markov solution set is infinite.**
+
+Mathlib has no Markov-equation development, so none of this is available there;
+it builds directly on the parent file.
+-/
+import Mathlib
+import Proofs.MarkovEquation
+
+namespace MarkovEquationOQ06
+
+open MarkovEquation
+
+/-! ## The ascent move
+
+Vieta-jumping the *first* coordinate is the parent's third-coordinate jump
+`markov_vieta` conjugated by the two transpositions `markov_swap12`,
+`markov_swap23`. -/
+
+/-- **Vieta jump on the first coordinate.** Replacing `x` by its conjugate root
+`3yz − x` sends a Markov triple to a Markov triple. -/
+theorem markov_vieta_fst {x y z : ℤ} (h : IsMarkov x y z) :
+    IsMarkov (3 * y * z - x) y z :=
+  markov_swap12 (markov_swap23 (markov_vieta (markov_swap23 (markov_swap12 h))))
+
+/-- **The sorted ascent move lands in the solution set.** From a triple `(a,b,c)`
+the move `(a,b,c) ↦ (b, c, 3bc − a)` (Vieta-jump the first coordinate, then keep
+the natural sorted order) again yields a Markov triple. -/
+theorem markov_ascent_isMarkov {a b c : ℤ} (h : IsMarkov a b c) :
+    IsMarkov b c (3 * b * c - a) :=
+  markov_vieta (markov_swap23 (markov_swap12 h))
+
+/-- **One ascent step.** Applied to a *sorted* Markov triple `1 ≤ a ≤ b ≤ c`, the
+ascent move returns a sorted Markov triple `b ≤ c ≤ 3bc − a` whose top coordinate
+is *strictly larger* than the previous top: `c < 3bc − a`. -/
+theorem ascent_spec {a b c : ℤ} (hM : IsMarkov a b c) (h1 : 1 ≤ a)
+    (hab : a ≤ b) (hbc : b ≤ c) :
+    IsMarkov b c (3 * b * c - a) ∧ 1 ≤ b ∧ b ≤ c ∧
+      c ≤ 3 * b * c - a ∧ c < 3 * b * c - a := by
+  have hac : a ≤ c := le_trans hab hbc
+  have hc1 : (1 : ℤ) ≤ c := le_trans h1 hac
+  -- `c·(3b − 2) = 3bc − 2c > 0`, the arithmetic core of the strict growth.
+  have hprod : (0 : ℤ) < c * (3 * b - 2) := mul_pos (by linarith) (by linarith)
+  refine ⟨markov_ascent_isMarkov hM, le_trans h1 hab, hbc, ?_, ?_⟩
+  · nlinarith [hprod, hac]
+  · nlinarith [hprod, hac]
+
+/-! ## The canonical ascent sequence -/
+
+/-- The ascent map on raw triples: `(a,b,c) ↦ (b, c, 3bc − a)`. -/
+def ascent (p : ℤ × ℤ × ℤ) : ℤ × ℤ × ℤ := (p.2.1, p.2.2, 3 * p.2.1 * p.2.2 - p.1)
+
+/-- The canonical ascent sequence of Markov triples rooted at `(1,1,1)`. -/
+def seq : ℕ → ℤ × ℤ × ℤ
+  | 0 => (1, 1, 1)
+  | (n + 1) => ascent (seq n)
+
+theorem seq_zero : seq 0 = (1, 1, 1) := rfl
+theorem seq_one : seq 1 = (1, 1, 2) := by decide
+theorem seq_two : seq 2 = (1, 2, 5) := by decide
+theorem seq_three : seq 3 = (2, 5, 29) := by decide
+
+/-- **Invariant.** Every term of the ascent sequence is a sorted Markov triple
+`1 ≤ a ≤ b ≤ c`. -/
+theorem seq_spec (n : ℕ) :
+    IsMarkov (seq n).1 (seq n).2.1 (seq n).2.2 ∧
+      1 ≤ (seq n).1 ∧ (seq n).1 ≤ (seq n).2.1 ∧ (seq n).2.1 ≤ (seq n).2.2 := by
+  induction n with
+  | zero => exact ⟨markov_one, le_refl _, le_refl _, le_refl _⟩
+  | succ n ih =>
+    obtain ⟨hM, h1, hab, hbc⟩ := ih
+    obtain ⟨hM', hb1, hbc', hc', _⟩ := ascent_spec hM h1 hab hbc
+    simp only [seq, ascent]
+    exact ⟨hM', hb1, hbc', hc'⟩
+
+/-- Every term of the sequence is a Markov triple. -/
+theorem seq_mem_markov (n : ℕ) :
+    IsMarkov (seq n).1 (seq n).2.1 (seq n).2.2 := (seq_spec n).1
+
+/-- **Strict growth.** The top coordinate of the ascent sequence is strictly
+monotone. -/
+theorem seq_top_strictMono : StrictMono (fun n => (seq n).2.2) := by
+  apply strictMono_nat_of_lt_succ
+  intro n
+  obtain ⟨hM, h1, hab, hbc⟩ := seq_spec n
+  obtain ⟨_, _, _, _, hlt⟩ := ascent_spec hM h1 hab hbc
+  simpa [seq, ascent] using hlt
+
+/-- The ascent sequence is injective: distinct indices give distinct triples,
+since their top coordinates already differ. -/
+theorem seq_injective : Function.Injective seq := by
+  intro n m h
+  exact seq_top_strictMono.injective (by rw [h])
+
+/-! ## Infinitude of the Markov solution set -/
+
+/-- **Infinitely many Markov triples.** The Vieta ascent generates a strictly
+increasing sequence of pairwise-distinct Markov triples, so the solution set of
+the Markov equation `x² + y² + z² = 3xyz` over the positive integers is infinite.
+
+This is the structural counterpart to the parent's descent theorem
+(`MarkovEquation.markov_classification`): descent shows *every* triple reaches the
+root; ascent shows the tree never terminates upward. -/
+theorem markov_infinite :
+    {p : ℤ × ℤ × ℤ | IsMarkov p.1 p.2.1 p.2.2}.Infinite :=
+  Set.infinite_of_injective_forall_mem seq_injective (fun n => seq_mem_markov n)
+
+end MarkovEquationOQ06

--- a/src/data/proofs/markov-equation-oq-06/annotations.json
+++ b/src/data/proofs/markov-equation-oq-06/annotations.json
@@ -1,0 +1,135 @@
+[
+  {
+    "id": "markov-oq06-ann-header",
+    "proofId": "markov-equation-oq-06",
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "Running the Markov Tree Upward",
+    "content": "The parent Proofs.MarkovEquation runs the Markov tree downward: every positive solution of x² + y² + z² = 3xyz descends, by Vieta-jumping its largest coordinate, to the root (1,1,1). This file runs the tree the other way and draws the consequence the descent theorem does not give — there are infinitely many Markov triples. The engine is the ascent move: on a sorted triple a ≤ b ≤ c, Vieta-jump the smallest coordinate, a ↦ 3bc − a. The result (b, c, 3bc − a) is again Markov, and because a ≤ c while b ≥ 1 its top coordinate strictly grows. Iterating from the root gives the strictly increasing sequence (1,1,1) → (1,1,2) → (1,2,5) → (2,5,29) → ⋯ of distinct solutions.",
+    "mathContext": "$3bc - a \\ge 3bc - c = c(3b-1) \\ge 2c > c, \\qquad \\{p : \\mathrm{IsMarkov}\\;p_1\\,p_2\\,p_3\\}\\ \\text{is infinite}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Markov equation",
+      "Vieta jumping",
+      "Markov tree",
+      "infinite descent"
+    ],
+    "prerequisites": [
+      "Diophantine equations",
+      "strict monotonicity and injectivity",
+      "Set.Infinite"
+    ]
+  },
+  {
+    "id": "markov-oq06-ann-vieta-fst",
+    "proofId": "markov-equation-oq-06",
+    "range": {
+      "startLine": 58,
+      "endLine": 69
+    },
+    "type": "technique",
+    "title": "Jumping the First Coordinate by Conjugation",
+    "content": "The parent only jumps the third coordinate (markov_vieta: z ↦ 3xy − z). To jump the first coordinate instead, conjugate by transpositions: swap the target coordinate into third position, jump it, and swap back. markov_vieta_fst does x ↦ 3yz − x as markov_swap12 ∘ markov_swap23 ∘ markov_vieta ∘ markov_swap23 ∘ markov_swap12. markov_ascent_isMarkov is the same idea packaged for the sorted move (a,b,c) ↦ (b, c, 3bc − a): swap a to the end, jump it, and the natural output order is already b ≤ c ≤ 3bc − a. No new arithmetic is needed — the symmetry lemmas of the parent do all the work.",
+    "mathContext": "$\\mathrm{IsMarkov}\\,x\\,y\\,z \\Rightarrow \\mathrm{IsMarkov}\\,(3yz-x)\\,y\\,z, \\qquad \\mathrm{IsMarkov}\\,a\\,b\\,c \\Rightarrow \\mathrm{IsMarkov}\\,b\\,c\\,(3bc-a).$",
+    "significance": "important",
+    "relatedConcepts": [
+      "Vieta jumping",
+      "coordinate symmetry",
+      "conjugation by transpositions"
+    ],
+    "prerequisites": [
+      "the parent's markov_vieta, markov_swap12, markov_swap23"
+    ]
+  },
+  {
+    "id": "markov-oq06-ann-ascent-spec",
+    "proofId": "markov-equation-oq-06",
+    "range": {
+      "startLine": 71,
+      "endLine": 84
+    },
+    "type": "key-step",
+    "title": "One Ascent Step Strictly Grows the Maximum",
+    "content": "ascent_spec is the heart of the argument. Starting from a sorted Markov triple 1 ≤ a ≤ b ≤ c, the move produces (b, c, 3bc − a) which is again sorted (b ≤ c ≤ 3bc − a) and Markov, and — crucially — its top coordinate is strictly larger: c < 3bc − a. The whole inequality rests on one positive product: c·(3b − 2) = 3bc − 2c > 0, valid because b ≥ 1 gives 3b − 2 ≥ 1 and c ≥ 1 > 0. Adding a ≤ c then yields 3bc − a − c ≥ c(3b − 2) + (c − a) > 0. A single nlinarith call with the product hint discharges both the non-strict bound c ≤ 3bc − a and the strict growth c < 3bc − a.",
+    "mathContext": "$c\\,(3b-2) = 3bc - 2c > 0 \\ \\wedge\\ a \\le c \\ \\Rightarrow\\ 0 < (3bc - 2c) + (c - a) = 3bc - a - c.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "strict growth",
+      "nlinarith",
+      "sorted triples"
+    ],
+    "prerequisites": [
+      "positivity of products",
+      "linear arithmetic over ℤ"
+    ]
+  },
+  {
+    "id": "markov-oq06-ann-sequence",
+    "proofId": "markov-equation-oq-06",
+    "range": {
+      "startLine": 88,
+      "endLine": 112
+    },
+    "type": "technique",
+    "title": "The Canonical Ascent Sequence and Its Invariant",
+    "content": "ascent is the raw map (a,b,c) ↦ (b, c, 3bc − a) on triples, and seq iterates it from (1,1,1). Its first four terms, checked by the axiom-free decide, are exactly the classical head of the Markov tree: (1,1,1), (1,1,2), (1,2,5), (2,5,29). seq_spec is the load-bearing invariant: by induction, using ascent_spec at the successor step, every term is a sorted Markov triple 1 ≤ a ≤ b ≤ c. This is what lets the sequence keep ascending forever — each term satisfies the hypotheses needed to take the next step.",
+    "mathContext": "$\\mathrm{seq}\\,0 = (1,1,1), \\quad \\mathrm{seq}\\,(n{+}1) = \\mathrm{ascent}(\\mathrm{seq}\\,n), \\quad \\mathrm{seq}\\,3 = (2,5,29).$",
+    "significance": "important",
+    "relatedConcepts": [
+      "iteration",
+      "loop invariant",
+      "induction on ℕ"
+    ],
+    "prerequisites": [
+      "structural recursion",
+      "the decide tactic"
+    ]
+  },
+  {
+    "id": "markov-oq06-ann-mono-inj",
+    "proofId": "markov-equation-oq-06",
+    "range": {
+      "startLine": 118,
+      "endLine": 131
+    },
+    "type": "key-step",
+    "title": "Strict Monotonicity Gives Injectivity for Free",
+    "content": "seq_top_strictMono shows the top coordinate n ↦ (seq n).2.2 is strictly monotone: each ascent step strictly increases it (the c < 3bc − a from ascent_spec), and strictMono_nat_of_lt_succ upgrades one-step growth to full strict monotonicity. Injectivity of the whole sequence is then immediate — StrictMono.injective on the top-coordinate map means distinct indices already give triples that differ in that coordinate, so seq_injective needs no separate distinctness computation.",
+    "mathContext": "$m \\ne n \\Rightarrow (\\mathrm{seq}\\,m).2.2 \\ne (\\mathrm{seq}\\,n).2.2 \\Rightarrow \\mathrm{seq}\\,m \\ne \\mathrm{seq}\\,n.$",
+    "significance": "important",
+    "relatedConcepts": [
+      "StrictMono",
+      "injectivity",
+      "strictMono_nat_of_lt_succ"
+    ],
+    "prerequisites": [
+      "monotone sequences",
+      "Function.Injective"
+    ]
+  },
+  {
+    "id": "markov-oq06-ann-infinite",
+    "proofId": "markov-equation-oq-06",
+    "range": {
+      "startLine": 133,
+      "endLine": 146
+    },
+    "type": "concept",
+    "title": "From an Injection to Set.Infinite",
+    "content": "markov_infinite is the payoff. We have an injective map seq : ℕ → ℤ×ℤ×ℤ (seq_injective) all of whose values lie in the Markov solution set (seq_mem_markov). Set.infinite_of_injective_forall_mem turns exactly this data — an injection from the infinite type ℕ into a set — into Set.Infinite. So the Markov equation x² + y² + z² = 3xyz has infinitely many positive-integer solutions. This is the structural complement of the parent's descent theorem: descent shows every triple reaches the root, ascent shows the tree is infinite.",
+    "mathContext": "$\\text{injective } \\mathrm{seq} : \\mathbb{N} \\to S \\ \\Rightarrow\\ S = \\{p : \\mathrm{IsMarkov}\\;p_1\\,p_2\\,p_3\\} \\text{ is infinite}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Set.Infinite",
+      "Set.infinite_of_injective_forall_mem",
+      "Markov tree"
+    ],
+    "prerequisites": [
+      "cardinality of sets",
+      "injections from ℕ"
+    ]
+  }
+]

--- a/src/data/proofs/markov-equation-oq-06/index.ts
+++ b/src/data/proofs/markov-equation-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MarkovEquationOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const markovEquationOQ06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const markovEquationOQ06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const markovEquationOQ06Data: ProofData = {
+  proof: markovEquationOQ06Proof,
+  annotations: markovEquationOQ06Annotations,
+}

--- a/src/data/proofs/markov-equation-oq-06/meta.json
+++ b/src/data/proofs/markov-equation-oq-06/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "markov-equation-oq-06",
+  "title": "Vieta Ascent Generates Infinitely Many Markov Triples",
+  "slug": "markov-equation-oq-06",
+  "description": "An axiom-free proof that the Markov equation x² + y² + z² = 3xyz has infinitely many positive-integer solutions, obtained by running the Markov tree upward. The parent Proofs.MarkovEquation runs the tree downward: every positive triple descends, by Vieta-jumping the largest coordinate, to the root (1,1,1). This entry supplies the ascent direction and its structural consequence. Given a sorted triple a ≤ b ≤ c, Vieta-jumping the smallest coordinate a ↦ 3bc − a yields another Markov triple (b, c, 3bc − a) whose top coordinate strictly increases: since a ≤ c and b ≥ 1, 3bc − a ≥ 3bc − c = c(3b − 1) ≥ 2c > c. Iterating from the root produces the strictly growing sequence (1,1,1) → (1,1,2) → (1,2,5) → (2,5,29) → ⋯ of pairwise-distinct triples; strict monotonicity of the top coordinate makes the sequence injective, so the solution set {p | IsMarkov p.1 p.2.1 p.2.2} is infinite. This is the structural counterpart to the parent's descent theorem markov_classification: descent shows every triple reaches the root; ascent shows the tree never terminates upward.",
+  "meta": {
+    "author": "Markov theory (classical); formalization original to Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MarkovEquationOQ06.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "markov-equation",
+      "vieta-jumping",
+      "markov-tree",
+      "infinite-descent",
+      "infinitude"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-01",
+    "lineCount": 146,
+    "originalContributions": [
+      "markov_vieta_fst: Vieta-jumping the first coordinate, x ↦ 3yz − x, preserves Markov triples — the parent's third-coordinate jump markov_vieta conjugated by the two transpositions markov_swap12, markov_swap23",
+      "markov_ascent_isMarkov: the sorted ascent move (a,b,c) ↦ (b, c, 3bc − a) lands in the Markov solution set",
+      "ascent_spec: one ascent step keeps a sorted triple 1 ≤ a ≤ b ≤ c sorted (b ≤ c ≤ 3bc − a) and strictly increases the top coordinate (c < 3bc − a), via the arithmetic core c·(3b − 2) = 3bc − 2c > 0",
+      "seq: the canonical ascent sequence of Markov triples rooted at (1,1,1) (ascent iterated), with seq_zero/seq_one/seq_two/seq_three reproducing the classical head (1,1,1), (1,1,2), (1,2,5), (2,5,29)",
+      "seq_spec: the invariant that every term of the sequence is a sorted Markov triple, proved by induction using ascent_spec",
+      "seq_top_strictMono: the top coordinate of the sequence is strictly monotone, hence seq_injective: the sequence is injective",
+      "markov_infinite: the Markov solution set {p | IsMarkov p.1 p.2.1 p.2.2} is infinite (Set.Infinite), via Set.infinite_of_injective_forall_mem applied to the injective ascent sequence"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms markov_infinite reports only the foundational propext / Classical.choice / Quot.sound. No native_decide is used (the small concrete triples seq_one/seq_two/seq_three are checked with the axiom-free decide). The proof imports the verified parent entry Proofs/MarkovEquation.lean (reusing IsMarkov, markov_one, markov_swap12, markov_swap23, markov_vieta).",
+    "theoremCount": 12,
+    "definitionCount": 2
+  },
+  "crossReferences": [
+    {
+      "targetId": "markov-equation",
+      "relationship": "extends",
+      "description": "The structural counterpart to the parent's descent theorem. The parent (markov_classification) shows every positive Markov triple descends to the root (1,1,1) by Vieta-jumping the largest coordinate; this entry runs the tree upward — jumping the smallest coordinate strictly increases the maximum — and concludes there are infinitely many Markov triples. It reuses the parent's markov_vieta and the two transposition lemmas to build the ascent move."
+    },
+    {
+      "targetId": "markov-equation-oq-05",
+      "relationship": "related",
+      "description": "OQ-05 pins each fixed-pair fiber to the doubleton {z, 3xy − z} (the neighbor is the unique alternative); this entry uses the neighbor in the ascending direction to generate a strictly growing, hence infinite, family of solutions."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The positive solutions of the Markov equation x² + y² + z² = 3xyz form the Markov tree, rooted at the singular triple (1,1,1), with every triple reachable from every other by Vieta-jumping moves and coordinate permutations. The parent Lean development proves the descent half of this picture: sorting a triple and Vieta-jumping its largest coordinate strictly decreases the coordinate sum, so every triple reduces to the root. The complementary fact — that the tree is infinite, i.e. the equation has infinitely many solutions — is the ascent half: from any triple one can jump the smallest coordinate to reach a strictly larger one. Classically this is how the tree (1,1,1), (1,1,2), (1,2,5), (2,5,29), … is grown, and it is the first input to Zagier's (1982) asymptotic count of Markov numbers.",
+    "problemStatement": "Show that the Markov equation x² + y² + z² = 3xyz has infinitely many positive-integer solutions. Concretely: exhibit the Vieta ascent move on sorted triples, prove it produces a sorted Markov triple with a strictly larger maximal coordinate, iterate it from the root to obtain an injective sequence of Markov triples, and conclude the solution set is infinite.",
+    "proofStrategy": "Build one ascent step, iterate it, and read off injectivity from strict growth. (1) markov_vieta_fst: conjugate the parent's third-coordinate jump markov_vieta by the transpositions markov_swap12/markov_swap23 to jump the first coordinate. (2) ascent_spec: for a sorted triple 1 ≤ a ≤ b ≤ c, the move (a,b,c) ↦ (b, c, 3bc − a) is Markov and sorted, and c < 3bc − a because c·(3b − 2) = 3bc − 2c > 0 (using a ≤ c, b ≥ 1, c ≥ 1) — the single nlinarith arithmetic core. (3) seq: iterate ascent from (1,1,1); seq_spec proves by induction that every term is a sorted Markov triple. (4) seq_top_strictMono: the third coordinate strictly increases at each step, so by strictMono_nat_of_lt_succ the top-coordinate map is strictly monotone, hence seq is injective (seq_injective). (5) markov_infinite: feed the injective sequence, all of whose values are Markov triples, to Set.infinite_of_injective_forall_mem.",
+    "keyInsights": [
+      "Descent and ascent are the same Vieta move applied at opposite ends of a sorted triple. The parent jumps the largest coordinate to shrink the sum; jumping the smallest coordinate instead grows it. Both are the single lemma markov_vieta, conjugated by transpositions — so infinitude needs no new arithmetic beyond one sign inequality.",
+      "Strict growth reduces to one elementary factorization. On a sorted triple, 3bc − a − c ≥ c(3b − 2) > 0 because b ≥ 1 makes 3b − 2 ≥ 1 and c ≥ 1; this single positive product is the entire engine of the infinitude, discharged by nlinarith.",
+      "Infinitude follows from injectivity, and injectivity follows for free from strict monotonicity of a single coordinate. Because the top coordinate strictly increases along the ascent sequence, distinct indices give triples that already differ in that coordinate — StrictMono.injective delivers injectivity with no separate distinctness argument.",
+      "The abstract Set.Infinite conclusion is obtained not by a cardinality computation but by producing an explicit injection ℕ ↪ (solution set): the concrete ascent sequence rooted at (1,1,1), whose first four terms are exactly the textbook triples (1,1,1), (1,1,2), (1,2,5), (2,5,29)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-ascent",
+      "title": "The Ascent Move",
+      "startLine": 52,
+      "endLine": 84,
+      "summary": "markov_vieta_fst jumps the first coordinate, x ↦ 3yz − x, by conjugating the parent's markov_vieta with the two transpositions. markov_ascent_isMarkov packages the sorted ascent move (a,b,c) ↦ (b, c, 3bc − a) as landing in the solution set. ascent_spec proves that on a sorted triple 1 ≤ a ≤ b ≤ c the move stays sorted and strictly increases the top coordinate, c < 3bc − a, via the positive product c·(3b − 2) = 3bc − 2c."
+    },
+    {
+      "id": "sec-sequence",
+      "title": "The Canonical Ascent Sequence",
+      "startLine": 86,
+      "endLine": 131,
+      "summary": "ascent and seq define the raw ascent map and its iteration from (1,1,1); seq_zero/seq_one/seq_two/seq_three evaluate the first four terms to the classical triples (1,1,1), (1,1,2), (1,2,5), (2,5,29). seq_spec establishes by induction (using ascent_spec) that every term is a sorted Markov triple, seq_top_strictMono shows the top coordinate is strictly monotone, and seq_injective concludes the sequence is injective."
+    },
+    {
+      "id": "sec-infinite",
+      "title": "Infinitude of the Markov Solution Set",
+      "startLine": 133,
+      "endLine": 146,
+      "summary": "markov_infinite assembles the pieces: the ascent sequence is injective (seq_injective) and every term lies in the Markov solution set (seq_mem_markov), so Set.infinite_of_injective_forall_mem yields that {p | IsMarkov p.1 p.2.1 p.2.2} is infinite — the Markov equation has infinitely many positive-integer solutions."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 0-axiom, 0-sorry formalization (146 lines, 12 theorems, 2 definitions) proving that the Markov equation x² + y² + z² = 3xyz has infinitely many positive-integer solutions. Vieta-jumping the smallest coordinate of a sorted triple strictly increases its maximum; iterating from (1,1,1) yields an injective sequence of Markov triples, and Set.infinite_of_injective_forall_mem converts that injection into Set.Infinite.",
+    "implications": "This completes the qualitative picture the parent development began: descent (markov_classification) shows the tree is connected down to the root, and ascent shows it is infinite upward. The explicit injective ascent sequence — reproducing the textbook head (1,1,1), (1,1,2), (1,2,5), (2,5,29) — is the elementary, axiom-free input underlying quantitative results such as Zagier's asymptotic count M(N) ∼ C(log N)² of Markov numbers below a bound. The template (conjugate a known jump to move a chosen coordinate, prove one sign inequality, iterate, read injectivity off strict monotonicity) transfers to other Vieta-jumping Diophantine families such as x² + y² + z² = kxyz.",
+    "openQuestions": [
+      "Quantify the growth: prove the top coordinate of the ascent sequence grows at least geometrically (each step more than doubles it, cf. the parent's markov_two_mul_mid_lt_top), giving an explicit lower bound seq n ≥ 2^n and hence a counting lower bound on Markov numbers.",
+      "Extend infinitude to the generalized Hurwitz equation x² + y² + z² = kxyz for k ≥ 1: does the same ascent argument produce an injective sequence, and how does the base of the tree depend on k?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Markov, Andrey A.",
+      "title": "Sur les formes quadratiques binaires indéfinies",
+      "year": "1880",
+      "venue": "Mathematische Annalen 17, 379–399",
+      "note": "The founding work: the equation x²+y²+z²=3xyz and its infinite tree of solutions arise from Markov's study of minima of indefinite binary quadratic forms and the Markov spectrum."
+    },
+    {
+      "authors": "Aigner, Martin",
+      "title": "Markov's Theorem and 100 Years of the Uniqueness Conjecture",
+      "year": "2013",
+      "venue": "Springer",
+      "note": "Modern monograph on Markov triples and the Markov tree; describes how Vieta jumping in the ascending direction generates all solutions from (1,1,1), the construction formalized here as an injective sequence."
+    },
+    {
+      "authors": "Zagier, Don",
+      "title": "On the number of Markoff numbers below a given bound",
+      "year": "1982",
+      "venue": "Mathematics of Computation 39(160), 709–723",
+      "note": "Asymptotic count M(N) ∼ C(log N)² of Markov numbers, built on the tree generated by the ascending Vieta-jumping moves whose solution-generating property (infinitely many triples) is the content of this entry."
+    },
+    {
+      "authors": "Engel, Arthur",
+      "title": "Problem-Solving Strategies, Ch. 6 (Vieta jumping / infinite descent)",
+      "year": "1998",
+      "venue": "Springer",
+      "note": "Standard exposition of Vieta jumping — fixing all but one variable and using the conjugate root of the resulting monic quadratic — used here in the ascending direction to generate infinitely many solutions."
+    },
+    {
+      "authors": "Cassels, J. W. S.",
+      "title": "An Introduction to Diophantine Approximation, Ch. II",
+      "year": "1957",
+      "venue": "Cambridge University Press",
+      "note": "Classical account connecting the Markov equation to Diophantine approximation and the Lagrange/Markov spectrum, providing the number-theoretic backdrop for the infinite tree of solutions."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 146,
+    "axiomCount": 0,
+    "path": "Proofs/MarkovEquationOQ06.lean",
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 12
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New **verified, 0-axiom** gallery entry `markov-equation-oq-06`: the Markov equation x² + y² + z² = 3xyz has **infinitely many** positive-integer solutions, proved by running the Markov tree *upward* via Vieta ascent.

The parent `Proofs.MarkovEquation` runs the tree **downward** (`markov_classification`: every triple descends to the root (1,1,1) by jumping the largest coordinate). This entry supplies the complementary **ascent** direction and its consequence — infinitude — which the descent theorem does not give.

## Mathematical content

- `markov_vieta_fst` — Vieta-jumping the *first* coordinate (x ↦ 3yz − x) preserves Markov triples, via the parent's `markov_vieta` conjugated by the two transposition lemmas.
- `ascent_spec` — on a sorted triple 1 ≤ a ≤ b ≤ c, the move (a,b,c) ↦ (b, c, 3bc − a) stays sorted and **strictly increases** the top coordinate: c < 3bc − a. Whole engine is one positive product c·(3b − 2) = 3bc − 2c > 0.
- `seq` — iterate the ascent from (1,1,1); `seq_zero…seq_three` reproduce the classical head (1,1,1), (1,1,2), (1,2,5), (2,5,29).
- `seq_top_strictMono` → `seq_injective` — strict monotonicity of the top coordinate gives injectivity for free.
- `markov_infinite` — `Set.infinite_of_injective_forall_mem` turns the injective ascent sequence into `Set.Infinite`.

## Verification

- Built successfully with `./proofs/scripts/docker-build.sh Proofs.MarkovEquationOQ06` (`✔ Built Proofs.MarkovEquationOQ06`).
- 0 sorries, 0 `axiom` declarations, no `native_decide` (small triples use axiom-free `decide`). Status `verified`, badge `original`.
- 146 lines, 12 theorems, 2 definitions. Imports the verified parent entry.

## Files

- `proofs/Proofs/MarkovEquationOQ06.lean`
- `src/data/proofs/markov-equation-oq-06/` (meta.json, annotations.json, index.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)