### PR TITLE
Enrich Erdős #660 convex-independence (erdos-660-oq-01): setup/generality annotation

### DIFF
--- a/src/data/proofs/erdos-660-oq-01/annotations.json
+++ b/src/data/proofs/erdos-660-oq-01/annotations.json
@@ -24,6 +24,29 @@
     ]
   },
   {
+    "id": "erdos-660-oq-01-ann-setup",
+    "proofId": "erdos-660-oq-01",
+    "range": {
+      "startLine": 31,
+      "endLine": 38
+    },
+    "type": "context",
+    "title": "Ordered-field generality and the drop-in `_root_` name",
+    "content": "The setup fixes the assumptions at exactly the generality Mathlib uses for both notions: `variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E]`. Nothing in the three-line proof uses ℝ-specific structure — only that $\\Bbbk$ is a linearly ordered field and $E$ a module over it — so the lemma holds over any such $\\Bbbk$, not just the reals, matching `AffineIndependent`/`ConvexIndependent`'s own generality. `open scoped Affine` brings the affine-span notation into scope.\n\nA deliberate naming choice makes the result a literal drop-in for the Mathlib gap: the main theorem (line 49) is declared `theorem _root_.AffineIndependent.convexIndependent`, i.e. in the *root* namespace under `AffineIndependent.` rather than inside `Erdos660`. This is what lets a caller write `hp.convexIndependent` in Mathlib's dotted-notation style — exactly the name the TODO asks for — even though the file lives outside Mathlib.",
+    "mathContext": "Assumptions: $\\Bbbk$ a linearly ordered field (`Field`, `LinearOrder`, `IsStrictOrderedRing`), $E$ a $\\Bbbk$-module. The `_root_.AffineIndependent.convexIndependent` name enables `hp.convexIndependent` dot-notation.",
+    "significance": "technical",
+    "prerequisites": [
+      "Lean typeclass variables and instance assumptions",
+      "the `_root_` namespace escape and dot-notation resolution"
+    ],
+    "relatedConcepts": [
+      "linearly ordered field",
+      "generality of a lemma",
+      "root namespace",
+      "dot notation"
+    ]
+  },
+  {
     "id": "erdos-660-oq-01-ann-main",
     "proofId": "erdos-660-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass on `erdos-660-oq-01` (AffineIndependent.convexIndependent — a Mathlib TODO).

The entry was already excellent (4 deep keyInsights, complete conclusion with an honest 'does not touch the open conjecture' caveat, 3 theorems/sections). It had 4 annotations — the role targets ≥5, and the import/typeclass setup block (lines 31–38) was uncovered.

- **New annotation `ann-setup`** (lines 31–38, type context): explains (1) why the lemma holds over any linearly ordered field, not just ℝ — the proof uses only `Field`/`LinearOrder`/`IsStrictOrderedRing` + module structure, matching Mathlib's own generality for both notions; and (2) the `_root_.AffineIndependent.convexIndependent` drop-in naming that enables Mathlib-style `hp.convexIndependent` dot-notation from outside Mathlib.

Now 5 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`. Verified against `proofs/Proofs/Erdos660Convexity.lean`; JSON valid; meta.json within caps; status/badge/axiomCount unchanged (verified, 0 axioms, 0 sorries).