### PR TITLE
Enrich Euler four-square identity (euler-identity-oq-05): sharpness-section annotation

### DIFF
--- a/src/data/proofs/euler-identity-oq-05/annotations.json
+++ b/src/data/proofs/euler-identity-oq-05/annotations.json
@@ -89,5 +89,30 @@
       "worked representation"
     ],
     "significance": "supporting"
+  },
+  {
+    "id": "ann-sharpness-three-squares",
+    "proofId": "euler-identity-oq-05",
+    "range": {
+      "startLine": 146,
+      "endLine": 198
+    },
+    "type": "insight",
+    "title": "Sharpness of Four: Three Squares Are Not Multiplicatively Closed",
+    "content": "This section proves that four is *minimal*: the analogous closure fails for sums of three squares. The obstruction is the classical mod-8 invariant. `sq_zmod_eight` establishes that every square in ℤ/8ℤ lies in {0,1,4} (a finite check by `decide +revert`), and `sum_three_sq_ne_fifteen_zmod_eight` checks over all 8³ = 512 residue triples that no three of those values sum to 15 ≡ 7 (mod 8). Lifting through the ring map ℤ → ℤ/8ℤ, `fifteen_not_isSumThreeSq` concludes 15 is not a sum of three integer squares — the residue 7 (mod 8) excluded by the Legendre–Gauss three-square theorem, obtained here without invoking that theorem. Since 3 = 1²+1²+1² and 5 = 0²+1²+2² are each sums of three squares but 3·5 = 15 is not, `not_isSumThreeSq_mul_closed` exhibits the failure of closure. Together with `IsSumFourSq.mul` this pins four as the least square-count for which Euler-style multiplicativity holds — the quaternion norm has no three-dimensional analogue (there is no real division algebra of dimension 3).",
+    "mathContext": "Squares mod 8 lie in $\\{0,1,4\\}$, so no sum of three is $\\equiv 7\\pmod 8$; hence $15=3\\cdot 5\\not\\in$ sums of three squares though $3,5$ are — closure fails at three.",
+    "significance": "key",
+    "prerequisites": [
+      "Modular arithmetic and quadratic residues mod 8",
+      "The `decide` decision procedure over finite types (ZMod 8)",
+      "The Legendre–Gauss three-square theorem (conceptual background)"
+    ],
+    "relatedConcepts": [
+      "sharpness / minimality",
+      "sum of three squares",
+      "mod-8 obstruction",
+      "quaternions and division algebras",
+      "decide over ZMod"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass on `euler-identity-oq-05` (Euler's four-square identity + multiplicative closure).

The entry had 4 annotations, but the file's **entire sharpness section (lines 146–198)** — proving that sums of *three* squares are not multiplicatively closed — was completely unannotated, despite being the most interesting mathematical content.

- **New annotation `ann-sharpness-three-squares`** (type insight): explains the mod-8 obstruction (squares ≡ 0,1,4 mod 8, so no sum of three is ≡ 7), the self-contained `decide +revert` checks over `ZMod 8` (the 8³ = 512 residue triples), why 15 = 3·5 witnesses the failure, and how this pins four as the minimal square-count for Euler-style multiplicativity (tied to the nonexistence of a 3-dimensional real division algebra).

Now 5 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`. Verified against `proofs/Proofs/EulerIdentityOQ05.lean`. Note the file uses `decide` (not `native_decide`), so the verified/0-axiom status is correct. JSON valid; meta.json within caps.