### PR TITLE
research(erdos-1018-incomplete-01): close erdos_1018_solved sorry via Kuratowski axiom (6→5) [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1018Problem.lean
+++ b/proofs/Proofs/Erdos1018Problem.lean
@@ -169,8 +169,10 @@ theorem erdos_1018_solved : erdos_1018_question := by
   use S
   constructor
   · exact hS
-  · -- K₅ subdivision implies non-planarity
-    sorry
+  · -- A K₅ subdivision forces non-planarity: the reverse (`mpr`) direction of
+    -- Kuratowski's characterisation applied to the induced subgraph, taking the
+    -- `K₅`-subdivision disjunct supplied by Kostochka–Pyber.
+    exact (kuratowski_theorem (inducedSubgraph G S)).mpr (Or.inl hSub)
 
 /-
 ## The Constant C_ε Grows as ε → 0

--- a/proofs/Proofs/Stubs/Erdos1018Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos1018Problem.lean
@@ -169,8 +169,10 @@ theorem erdos_1018_solved : erdos_1018_question := by
   use S
   constructor
   · exact hS
-  · -- K₅ subdivision implies non-planarity
-    sorry
+  · -- A K₅ subdivision forces non-planarity: the reverse (`mpr`) direction of
+    -- Kuratowski's characterisation applied to the induced subgraph, taking the
+    -- `K₅`-subdivision disjunct supplied by Kostochka–Pyber.
+    exact (kuratowski_theorem (inducedSubgraph G S)).mpr (Or.inl hSub)
 
 /-
 ## The Constant C_ε Grows as ε → 0

--- a/research/problems/erdos-1018-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1018-incomplete-01/knowledge.md
@@ -1,0 +1,47 @@
+# erdos-1018-incomplete-01 — Erdős #1018 Non-Planar Subgraph: Sorry Completion & Compile Repair
+
+## Session 2026-07-01 (researcher-1): close erdos_1018_solved sorry via Kuratowski axiom (6→5) [VERIFIED]
+
+**Mode**: ACT (DEEP DIVE on the one tractable theorem-sorry; rest genuinely BLOCKED).
+**Outcome**: PROGRESS — closed the "K₅-subdivision ⇒ non-planarity" sorry in
+`erdos_1018_solved` using the already-stated `kuratowski_theorem` axiom, in BOTH
+`Proofs/Erdos1018Problem.lean` and its byte-identical `Proofs/Stubs/Erdos1018Problem.lean`.
+Sorries **6→5** in each; **no new axioms**. `erdos_1018_solved` (the flagship "answer is
+YES") is now fully reduced to the stated literature axioms (Kostochka–Pyber + Kuratowski).
+**Docker build VERIFIED** for both (`docker-build.sh Proofs.Erdos1018Problem` and
+`Proofs.Stubs.Erdos1018Problem`, `Built`, exit 0). meta.json updated (sorries 6→5, assumptions
+text). Axiom count unchanged at 7 (main) / 14 (with stub duplicate) — status stays
+`axiomatized`.
+
+### The fix
+`kuratowski_theorem G : isNonPlanar G ↔ containsSubdivision G K₅ ∨ containsSubdivision G K₃₃`.
+The sorry had `hSub : containsSubdivision (inducedSubgraph G S) (completeGraph 5)` and needed
+`isNonPlanar (inducedSubgraph G S)`:
+`exact (kuratowski_theorem (inducedSubgraph G S)).mpr (Or.inl hSub)`.
+
+### ⚠️ The rest is genuinely BLOCKED (do not retry without Mathlib planarity)
+Mathlib 4.26 has NO topological planarity / graph-minor theory. The 3 remaining DEF-sorries
+are unbuildable placeholders and block everything downstream:
+- `isPlanar` (line 59) — needs a real planarity definition (embeddings / Kuratowski). ~1000+ L.
+- `containsSubdivision` (line 99) — needs subdivision/homeomorphism-of-graphs. Missing.
+- `turanK5Subdivision` (line 277) — extremal number for K₅-subdivision-free graphs. Missing.
+The 2 remaining theorem-sorries depend on these: `sparse_hides_nonplanarity` (line ~188) and
+`dense_exceeds_turan` (line ~283, needs `turanK5Subdivision`). NOT tractable now.
+
+### ⚠️ Axiom-integrity observations for future work (do NOT try to "prove" these away)
+- All 7 axioms are stated over the sorry-defs `isPlanar`/`containsSubdivision` (K5_nonplanar,
+  K33_nonplanar, kuratowski_theorem, planar_linear_bound) or are deep literature results
+  (kostochka_pyber, kostochka_pyber_explicit). NONE is honestly Mathlib-provable while the
+  planarity defs are placeholders — axiom elimination here is impossible until planarity is
+  built. Adding theorems on top is scaffolding, not formalization.
+- `constant_grows` (line 182) is suspiciously shaped: `∀ M, ∃ε₀>0, ∀ε<ε₀, ∀C,
+  existsBoundingConstant ε → C ≥ M`. Since the body is independent of `C`, for `M ≥ 1` this
+  is equivalent to `¬existsBoundingConstant ε` for small ε — which contradicts
+  `erdos_1018_solved` (`existsBoundingConstant ε` for all ε). Likely only holds vacuously /
+  the quantifier `∀ε<ε₀` has no lower bound. Flag for cleanup; not proved/used this session.
+
+### Process notes
+- Fresh branch `feature/researcher-1-erdos1018-kuratowski` off origin/main; committed
+  pre-build to dodge the shared-worktree reset-hard hazard.
+- Pre-existing linter "Try this: intro …" hints (lines 163/215) are style suggestions, not
+  errors — left as-is (not from this change).

--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 5,
     "erdosNumber": 1018,
     "erdosUrl": "https://erdosproblems.com/1018",
     "erdosProblemStatus": "solved",
@@ -27,7 +27,7 @@
     ],
     "axiomCount": 14,
     "lineCount": 308,
-    "assumptions": "14 axioms across the chain: the main file `Proofs/Erdos1018Problem.lean` declares 7 (K5_nonplanar, K33_nonplanar, kuratowski_theorem, kostochka_pyber, constant_grows, planar_linear_bound, kostochka_pyber_explicit), and `Proofs/Stubs/Erdos1018Problem.lean` re-declares the same 7 (byte-identical duplicate); the Lean kernel treats each declaration site as a distinct assumption. K5_nonplanar: K₅ is non-planar. K33_nonplanar: K₃,₃ is non-planar. kuratowski_theorem: non-planar iff contains K₅ or K₃,₃ subdivision. kostochka_pyber: ε-dense graphs contain K₅ subdivisions on ≤ C(ε) vertices (1988). constant_grows: C(ε) → ∞ as ε → 0. planar_linear_bound: planar graphs have ≤ 3n−6 edges. kostochka_pyber_explicit: polynomial bound in 1/ε. 6 sorries remain in the main file: three definition sorries (isPlanar, containsSubdivision, turanK5Subdivision — Mathlib 4.26 has no topological planarity), the K₅-subdivision⇒non-planarity step of erdos_1018_solved, and the two density-tradeoff lemmas sparse_hides_nonplanarity and dense_exceeds_turan. superlinear_forces_nonplanar (super-linear density forces global non-planarity) is now fully proved from planar_linear_bound. The file also required a Lean 4.26 compile repair (rpow/ceil imports; existsBoundingConstant quantified over Type to remove a universe metavariable).",
+    "assumptions": "14 axioms across the chain: the main file `Proofs/Erdos1018Problem.lean` declares 7 (K5_nonplanar, K33_nonplanar, kuratowski_theorem, kostochka_pyber, constant_grows, planar_linear_bound, kostochka_pyber_explicit), and `Proofs/Stubs/Erdos1018Problem.lean` re-declares the same 7 (byte-identical duplicate); the Lean kernel treats each declaration site as a distinct assumption. K5_nonplanar: K₅ is non-planar. K33_nonplanar: K₃,₃ is non-planar. kuratowski_theorem: non-planar iff contains K₅ or K₃,₃ subdivision. kostochka_pyber: ε-dense graphs contain K₅ subdivisions on ≤ C(ε) vertices (1988). constant_grows: C(ε) → ∞ as ε → 0. planar_linear_bound: planar graphs have ≤ 3n−6 edges. kostochka_pyber_explicit: polynomial bound in 1/ε. 5 sorries remain in the main file: three definition sorries (isPlanar, containsSubdivision, turanK5Subdivision — Mathlib 4.26 has no topological planarity) and the two density-tradeoff lemmas sparse_hides_nonplanarity and dense_exceeds_turan. The K₅-subdivision⇒non-planarity step of erdos_1018_solved is now proved from the kuratowski_theorem axiom (mpr, K₅ disjunct), so erdos_1018_solved is fully reduced to the stated Kostochka–Pyber and Kuratowski axioms. superlinear_forces_nonplanar (super-linear density forces global non-planarity) is now fully proved from planar_linear_bound. The file also required a Lean 4.26 compile repair (rpow/ceil imports; existsBoundingConstant quantified over Type to remove a universe metavariable).",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
     "definitionCount": 15,
@@ -40,7 +40,7 @@
   "overview": {
     "historicalContext": "**Planarity, Density, and Topological Obstructions**\n\nThe study of planar graphs has deep roots: Euler's formula (1752) implies that planar graphs on $n \\ge 3$ vertices have at most $3n - 6$ edges—a linear bound. Kuratowski (1930) characterized non-planarity: a graph is non-planar if and only if it contains a subdivision of $K_5$ or $K_{3,3}$. Wagner (1937) proved the equivalent minor characterization.\n\nErdős asked a quantitative refinement: if a graph has $n^{1+\\varepsilon}$ edges (super-linear density), must non-planarity be concentrated in a *small* subgraph? Specifically, does there exist a constant $C_\\varepsilon$, depending only on $\\varepsilon$ and not on $n$, such that every such graph contains a non-planar subgraph on at most $C_\\varepsilon$ vertices?\n\n**Kostochka and Pyber (1988)** resolved this affirmatively, proving that graphs with $n^{1+\\varepsilon}$ edges contain $K_5$ subdivisions on $O_\\varepsilon(1)$ vertices. Their proof uses the probabilistic method combined with extremal graph theory. Mader (1967) had earlier shown that the Turán number for $K_t$ subdivisions is $O(t\\sqrt{\\log t} \\cdot n)$, establishing a linear threshold for topological containment. The Kostochka-Pyber result goes further by bounding the *size* of the subdivision found.\n\nErdős also observed that $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$: as the density approaches linear, non-planarity becomes more diffuse and cannot be localized to a small subgraph. This tradeoff between density and obstruction size is a recurring theme in extremal graph theory.",
     "problemStatement": "**Problem Statement**\n\nLet ε > 0. Is there a constant C_ε such that, for all large n, every graph on n vertices with at least n^(1+ε) edges must contain a non-planar subgraph on at most C_ε vertices?\n\n**Status**: SOLVED (Kostochka-Pyber 1988)\n\n**Answer**: YES. Dense graphs contain K₅ subdivisions with O_ε(1) vertices.\n\n**Note**: Erdős observed C_ε → ∞ as ε → 0 (sparser graphs hide non-planarity in larger structures).",
-    "text": "A formalization of Erdős Problem #1018 in 308 lines with 7 axioms, 6 sorries, and 15 definitions. The file formalizes the graph-theoretic framework (edge count, density, planarity, Kuratowski's characterization, induced subgraphs) and the main question: for $\\varepsilon > 0$, does every $n$-vertex graph with $n^{1+\\varepsilon}$ edges contain a non-planar subgraph on $O_\\varepsilon(1)$ vertices? The Kostochka-Pyber (1988) positive resolution is axiomatized, with the quantitative bound $C_\\varepsilon = \\lceil 1/\\varepsilon^2 \\rceil$ and the Mader Turán number $\\text{ex}(n, TK_5) = O(n)$ as key supporting axioms. The density-size tradeoff $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$ is formalized via Mathlib's `Filter.Tendsto`.",
+    "text": "A formalization of Erdős Problem #1018 in 308 lines with 7 axioms, 5 sorries, and 15 definitions. The file formalizes the graph-theoretic framework (edge count, density, planarity, Kuratowski's characterization, induced subgraphs) and the main question: for $\\varepsilon > 0$, does every $n$-vertex graph with $n^{1+\\varepsilon}$ edges contain a non-planar subgraph on $O_\\varepsilon(1)$ vertices? The Kostochka-Pyber (1988) positive resolution is axiomatized, with the quantitative bound $C_\\varepsilon = \\lceil 1/\\varepsilon^2 \\rceil$ and the Mader Turán number $\\text{ex}(n, TK_5) = O(n)$ as key supporting axioms. The density-size tradeoff $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$ is formalized via Mathlib's `Filter.Tendsto`.",
     "proofStrategy": "**Proof Approach (Kostochka-Pyber)**\n\n1. **Density Threshold**: Graphs with n^(1+ε) edges are 'super-linearly dense'.\n\n2. **Finding Structure**: Use probabilistic or extremal methods to find vertices of high degree.\n\n3. **K₅ Subdivision**: High-degree vertices connect through short paths, forming a K₅ subdivision.\n\n4. **Bounding Size**: The total vertices used (5 branch vertices + path vertices) is O_ε(1).\n\n**Key Insight**: Super-linear edge density forces enough local structure that K₅ subdivisions must appear in bounded-size subgraphs.",
     "keyInsights": [
       "**Linear planarity threshold**: Euler's formula gives $|E| \\le 3n - 6$ for planar graphs, so the density exponent $1 + \\varepsilon$ with $\\varepsilon > 0$ is the precise threshold where planarity breaks down",
@@ -247,12 +247,12 @@
     "theoremCount": 4,
     "definitionCount": 15,
     "path": "Proofs/Erdos1018Problem.lean",
-    "sorries": 6,
+    "sorries": 5,
     "additionalFiles": [
       "Proofs/Erdos1018Aristotle.lean",
       "Proofs/Stubs/Erdos1018Aristotle.lean",
       "Proofs/Stubs/Erdos1018Problem.lean"
     ]
   },
-  "sorries": 6
+  "sorries": 5
 }


### PR DESCRIPTION
## Summary

Closes the last remaining sorry in the **flagship theorem** `erdos_1018_solved` (the
"answer is YES" for Erdős #1018) using an axiom already in the file. Sorries **6→5** in
both `Proofs/Erdos1018Problem.lean` and its byte-identical `Proofs/Stubs/Erdos1018Problem.lean`.

## The fix

The remaining step was "a K₅ subdivision forces non-planarity" — exactly the reverse
(`mpr`) direction of the stated `kuratowski_theorem` axiom
(`isNonPlanar G ↔ containsSubdivision G K₅ ∨ containsSubdivision G K₃₃`), applied to the
induced subgraph, taking the `K₅` disjunct supplied by Kostochka–Pyber:

```lean
exact (kuratowski_theorem (inducedSubgraph G S)).mpr (Or.inl hSub)
```

**No new axioms.** `erdos_1018_solved` is now fully reduced to the stated literature axioms
(Kostochka–Pyber + Kuratowski); status remains `axiomatized` (7 axioms unchanged).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1018Problem` → `Built`, exit 0.
- `./proofs/scripts/docker-build.sh Proofs.Stubs.Erdos1018Problem` → `Built`, exit 0.
- `meta.json` updated: sorries 6→5, assumptions text refreshed.

## Remaining work is genuinely BLOCKED

The other 5 sorries need topological planarity theory that **Mathlib 4.26 does not have**:
three def-sorries (`isPlanar`, `containsSubdivision`, `turanK5Subdivision`) and the two
density-tradeoff lemmas that depend on them. Documented in the new `knowledge.md`, along with
an axiom-integrity flag on the suspiciously-shaped `constant_grows` axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)