### PR TITLE
Enrich Fibonacci linear sums (fibonacci-identities-oq-06): fix overlapping annotation range

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-06/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-06/annotations.json
@@ -62,7 +62,7 @@
   {
     "id": "ann-fiboq06-4",
     "proofId": "fibonacci-identities-oq-06",
-    "range": { "startLine": 33, "endLine": 68 },
+    "range": { "startLine": 29, "endLine": 32 },
     "type": "insight",
     "title": "Two Rungs of the Fibonacci Moment Ladder",
     "content": "**Synthesis.** Read together, `fib_sum` and `fib_weighted_sum` are the $k=0$ and $k=1$ rungs of the *moment ladder* $S_k(n) = \\sum_{i\\le n} i^k F_i$. The zeroth moment is a single Fibonacci value ($F_{n+2}-1$); the first moment is a Fibonacci value scaled by $n$ minus a higher-index correction ($n F_{n+2} - F_{n+3} + 2$). The pattern continues: each higher moment $S_k$ has a closed form that is a $\\mathbb{Z}[n]$-combination of $O(k)$ shifted Fibonacci numbers, and — crucially — every rung is provable by the *same* two-ingredient recipe used here: peel the last term with `Finset.sum_range_succ`, reduce all shifted $F_{n+j}$ to the atoms $F_{n+1}, F_{n+2}$ via `Nat.fib_add_two`, then close by `omega` (when the summand is linear in the $F$'s, as for $k=0$) or `zify` + `linear_combination` (when an index coefficient introduces a nonlinear cross term, as for $k=1$). This is why the open second-moment $\\sum i^2 F_i$ is expected to be mechanically reachable rather than to require new ideas — it is the next rung of the same ladder, and connects to differentiating the generating function $x/(1-x-x^2)$ twice.",


### PR DESCRIPTION
Enrichment/repair pass on `fibonacci-identities-oq-06` (the linear Fibonacci summation identities).

The moment-ladder synthesis annotation (`ann-fiboq06-4`) had range **33–68**, which fully overlapped *both* theorem annotations (`fib_sum` at 33–44 and `fib_weighted_sum` at 46–68) — a double-cover that renders ambiguously.

- **Re-anchored** `ann-fiboq06-4` to the previously-uncovered code-body-start region (29–32, `namespace`/`open Finset`), where a file-wide synthesis naturally belongs. Content unchanged.

Result: 4 sharp, **non-overlapping** annotations spanning the 70-line/2-theorem file (header · fib_sum · fib_weighted_sum · moment-ladder synthesis) — complete coverage without padding. All annotations retain `mathContext`/`significance`/`relatedConcepts`/`prerequisites`. JSON valid; meta.json within caps; status unchanged (verified, 0 axioms, 0 sorries).