### PR TITLE
Enrich Generalized Non-Negativity of Squares (sqrt2-examples-oq-01): add cross-references

### DIFF
--- a/src/data/proofs/sqrt2-examples-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-examples-oq-01/meta.json
@@ -104,7 +104,22 @@
     {
       "targetId": "sqrt2-examples",
       "relationship": "extends",
-      "description": "Parent file with the original ℤ-specific proof"
+      "description": "Parent file with the original ℤ-specific proof of square_nonneg that this entry generalizes to any LinearOrderedSemiring"
+    },
+    {
+      "targetId": "sqrt2-examples-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Child entry that answers this entry's first open question: it shows totality of the order is essential (the Artin–Schreier obstruction), constructing formally real fields where a merely partial order admits elements with x² < 0"
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "This entry's Part IV proves the 2-variable AM-GM inequality ab ≤ (a²+b²)/2 from (a-b)² ≥ 0; the full AM-GM entry establishes the n-variable form"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "The (a-b)² ≥ 0 trick used for am_gm_sq is the elementary shadow of the sum-of-squares argument behind the Cauchy-Schwarz inequality"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `sqrt2-examples-oq-01`.

## Assessment
The entry was already solid on annotation depth (5 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`), `historicalContext` (~1KB, Artin–Schreier context), 5 keyInsights, and a full `conclusion`. The one clear gap was **crossReferences: only 1** (parent) against the cap of 20 — the entry was under-connected to the gallery.

## Changes
- **crossReferences 1 → 4** (well under the 20 cap):
  - `sqrt2-examples-oq-01-oq-01` — the child entry that directly **answers this entry's first open question** (is totality of the order essential? the Artin–Schreier obstruction).
  - `amgm-inequality` — this entry's Part IV proves the 2-variable AM-GM; the full entry gives the n-variable form.
  - `cauchy-schwarz` — the `(a-b)² ≥ 0` trick behind `am_gm_sq` is the elementary shadow of the Cauchy-Schwarz sum-of-squares argument.
- Tightened the existing parent cross-reference description.

All target IDs verified to exist in the gallery (no dangling links). `meta.json` 7.6 KB → 8.6 KB (far under the 60 KB cap). No content removed. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)