### PR TITLE
research(cramers-rule-oq-06): the adjugate algebra — multiplicative & conjugation identities [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CramersRuleOQ06.lean
+++ b/proofs/Proofs/CramersRuleOQ06.lean
@@ -1,0 +1,114 @@
+import Mathlib.LinearAlgebra.Matrix.Adjugate
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import Mathlib.Tactic
+
+/-
+# The Adjugate Algebra (cramers-rule-oq-06)
+
+The parent `cramers-rule` derives Cramer's rule from the single adjugate identity
+`A * adj(A) = det(A) • I`.  This child studies the adjugate as an *operation in its own
+right* and assembles its compositional algebra:
+
+  * `adj` is an **anti-homomorphism** on products: `adj(A * B) = adj(B) * adj(A)`;
+  * it commutes with **powers** and **transpose**: `adj(Aᵏ) = adj(A)ᵏ`, `adj(Aᵀ) = adj(A)ᵀ`;
+  * it scales its **determinant**: `det(adj A) = (det A) ^ (n - 1)`;
+  * it is an **involution up to a determinant factor**: `adj(adj A) = (det A) ^ (n - 2) • A`
+    for `n ≠ 1`.
+
+Two results are stated as *original corollaries* of the anti-homomorphism law, neither
+present in Mathlib:
+
+  * **Units have invertible adjugates that respect inversion** — if `A` and `B` are mutually
+    inverse then so are `adj A` and `adj B` (`adjugate_mul_adjugate_inv`).
+  * **Similar matrices have similar adjugates** — the adjugate of a conjugate is the
+    conjugate of the adjugate, so `adj` descends to conjugacy classes (`adjugate_conj`).
+
+Everything reduces to curated Mathlib lemmas chained together; the file stays
+`verified`, `0` axioms, `0` sorries.
+-/
+
+namespace CramersRuleOQ06
+
+open Matrix BigOperators
+
+variable {n : Type*} [DecidableEq n] [Fintype n]
+variable {R : Type*} [CommRing R]
+
+-- ============================================================================
+-- Part I: The multiplicative / structural laws of the adjugate
+-- ============================================================================
+
+/-- The adjugate is an **anti-homomorphism** on products:
+    `adj(A * B) = adj(B) * adj(A)`. -/
+theorem adjugate_anti_mul (A B : Matrix n n R) :
+    (A * B).adjugate = B.adjugate * A.adjugate :=
+  Matrix.adjugate_mul_distrib A B
+
+/-- The adjugate of the identity is the identity. -/
+theorem adjugate_one' : (1 : Matrix n n R).adjugate = 1 :=
+  Matrix.adjugate_one
+
+/-- The adjugate commutes with **powers**: `adj(Aᵏ) = adj(A)ᵏ`. -/
+theorem adjugate_pow' (A : Matrix n n R) (k : ℕ) :
+    (A ^ k).adjugate = A.adjugate ^ k :=
+  Matrix.adjugate_pow A k
+
+/-- The adjugate commutes with **transpose**: `adj(Aᵀ) = adj(A)ᵀ`. -/
+theorem adjugate_transpose' (A : Matrix n n R) :
+    Aᵀ.adjugate = A.adjugateᵀ :=
+  (Matrix.adjugate_transpose A).symm
+
+/-- The determinant of the adjugate: `det(adj A) = (det A) ^ (n - 1)`. -/
+theorem det_adjugate' (A : Matrix n n R) :
+    A.adjugate.det = A.det ^ (Fintype.card n - 1) :=
+  Matrix.det_adjugate A
+
+/-- The adjugate is an **involution up to a determinant factor**:
+    `adj(adj A) = (det A) ^ (n - 2) • A` when `n ≠ 1`. -/
+theorem adjugate_adjugate' (A : Matrix n n R) (h : Fintype.card n ≠ 1) :
+    A.adjugate.adjugate = A.det ^ (Fintype.card n - 2) • A :=
+  Matrix.adjugate_adjugate A h
+
+-- ============================================================================
+-- Part II: Original corollaries of the anti-homomorphism law
+-- ============================================================================
+
+/-- **ORIGINAL.** The adjugate sends mutually-inverse pairs to mutually-inverse pairs:
+    if `A * B = 1` and `B * A = 1` then `adj A` and `adj B` are mutually inverse.
+    In particular the adjugate of a unit is again a unit.  Proof: apply the
+    anti-homomorphism law to `B * A` and `A * B` and simplify with `adjugate_one`. -/
+theorem adjugate_mul_adjugate_inv {A B : Matrix n n R} (h : A * B = 1) (h' : B * A = 1) :
+    A.adjugate * B.adjugate = 1 ∧ B.adjugate * A.adjugate = 1 := by
+  refine ⟨?_, ?_⟩
+  · rw [← Matrix.adjugate_mul_distrib B A, h', Matrix.adjugate_one]
+  · rw [← Matrix.adjugate_mul_distrib A B, h, Matrix.adjugate_one]
+
+/-- **ORIGINAL.** *Similar matrices have similar adjugates.*  For a conjugating pair
+    `U`, `Uinv` (with `U * Uinv = 1` and `Uinv * U = 1`), the adjugate of the conjugate
+    `U * A * Uinv` is the conjugate of the adjugate, `adj(Uinv) * adj(A) * adj(U)`, and the
+    conjugating factors `adj U`, `adj Uinv` are themselves mutually inverse — so `adj`
+    descends to conjugacy classes.  Proof: chain the anti-homomorphism law twice, then use
+    `adjugate_mul_adjugate_inv`. -/
+theorem adjugate_conj (A U Uinv : Matrix n n R)
+    (h : U * Uinv = 1) (h' : Uinv * U = 1) :
+    (U * A * Uinv).adjugate = Uinv.adjugate * A.adjugate * U.adjugate ∧
+      U.adjugate * Uinv.adjugate = 1 ∧ Uinv.adjugate * U.adjugate = 1 := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [Matrix.adjugate_mul_distrib, Matrix.adjugate_mul_distrib, ← Matrix.mul_assoc]
+  · rw [← Matrix.adjugate_mul_distrib Uinv U, h', Matrix.adjugate_one]
+  · rw [← Matrix.adjugate_mul_distrib U Uinv, h, Matrix.adjugate_one]
+
+-- ============================================================================
+-- Part III: A concrete `Fin 2` witness
+-- ============================================================================
+
+/-- Concrete `Fin 2` computation: `adj !![1,2;3,4] = !![4,-2;-3,1]`. -/
+example : (!![(1 : ℤ), 2; 3, 4]).adjugate = !![4, -2; -3, 1] := by
+  rw [Matrix.adjugate_fin_two_of]
+
+/-- The anti-homomorphism law, checked on a concrete `Fin 2` product. -/
+example (A B : Matrix (Fin 2) (Fin 2) ℤ) :
+    (A * B).adjugate = B.adjugate * A.adjugate :=
+  adjugate_anti_mul A B
+
+end CramersRuleOQ06

--- a/src/data/proofs/cramers-rule-oq-06/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-06/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-cro06-setup",
+    "proofId": "cramers-rule-oq-06",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "Setup: The Adjugate over a Commutative Ring",
+    "content": "The file imports Mathlib's adjugate and nonsingular-inverse libraries and fixes a finite decidable index type n and a commutative ring R. Every identity in the file descends from the universal cofactor identity A·adj(A) = adj(A)·A = det(A)·I, which holds over any commutative ring. Working over CommRing (rather than a field) means the adjugate's algebra is available over ℤ and polynomial rings, where the adjugate appears in resultants, discriminants, and Cayley–Hamilton.",
+    "mathContext": "Work over a commutative ring $R$ and finite index type $n$; $\\mathrm{adj}(A)$ is the transpose of the cofactor matrix and satisfies $A\\,\\mathrm{adj}(A)=\\mathrm{adj}(A)\\,A=\\det(A)\\,I$.",
+    "significance": "supporting",
+    "relatedConcepts": ["adjugate / classical adjoint", "cofactor expansion", "commutative ring", "determinant"],
+    "prerequisites": ["matrices over a ring", "determinant and cofactors"]
+  },
+  {
+    "id": "ann-cro06-anti-mul",
+    "proofId": "cramers-rule-oq-06",
+    "range": { "startLine": 41, "endLine": 50 },
+    "type": "tactic",
+    "title": "The Anti-Homomorphism Law",
+    "content": "adjugate_anti_mul states adj(A·B) = adj(B)·adj(A): the adjugate reverses the order of a product, exactly like transpose and inversion. This single law is the engine of the file — every subsequent identity, including both original corollaries, is obtained by applying it and simplifying. It is Mathlib's Matrix.adjugate_mul_distrib, packaged under a descriptive name.",
+    "mathContext": "$\\mathrm{adj}(AB) = \\mathrm{adj}(B)\\,\\mathrm{adj}(A)$. The adjugate is an anti-homomorphism of the multiplicative monoid of $\\mathrm{Mat}_n(R)$.",
+    "significance": "key",
+    "relatedConcepts": ["anti-homomorphism", "order reversal", "transpose", "matrix inverse"],
+    "prerequisites": ["adjugate identity A·adj(A)=det(A)·I", "determinant multiplicativity"]
+  },
+  {
+    "id": "ann-cro06-structural",
+    "proofId": "cramers-rule-oq-06",
+    "range": { "startLine": 51, "endLine": 80 },
+    "type": "tactic",
+    "title": "Powers, Transpose, Determinant, and the Involution Law",
+    "content": "Four further structural laws: adjugate_pow' gives adj(Aᵏ) = adj(A)ᵏ (iterate the anti-homomorphism law); adjugate_transpose' gives adj(Aᵀ) = adj(A)ᵀ (adj commutes with transpose); det_adjugate' gives det(adj A) = (det A)^(n-1); and adjugate_adjugate' gives adj(adj A) = (det A)^(n-2)·A for n≠1 — the adjugate is an involution up to a determinant factor. Each wraps a Mathlib lemma, together forming a named API for the adjugate's compositional algebra.",
+    "mathContext": "$\\mathrm{adj}(A^k)=\\mathrm{adj}(A)^k$, $\\mathrm{adj}(A^\\top)=\\mathrm{adj}(A)^\\top$, $\\det(\\mathrm{adj}\\,A)=(\\det A)^{n-1}$, and $\\mathrm{adj}(\\mathrm{adj}\\,A)=(\\det A)^{n-2}A$ for $n\\ne 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["adjugate of a power", "transpose", "determinant of the adjugate", "involution up to scalar"],
+    "prerequisites": ["anti-homomorphism law", "det(adj A) formula"]
+  },
+  {
+    "id": "ann-cro06-inv",
+    "proofId": "cramers-rule-oq-06",
+    "range": { "startLine": 81, "endLine": 91 },
+    "type": "tactic",
+    "title": "ORIGINAL: Adjugates Preserve Mutual Inverses",
+    "content": "adjugate_mul_adjugate_inv shows that if A·B = 1 and B·A = 1 then adj(A)·adj(B) = 1 and adj(B)·adj(A) = 1. The proof rewrites adj(A)·adj(B) as adj(B·A) using the anti-homomorphism law backwards, substitutes B·A = 1, and applies adj(1) = 1; the other equality is symmetric. No determinant division is used, so the adjugate of a unit is again a unit — an inverse-preservation property that holds even where det A is not a unit.",
+    "mathContext": "If $AB=BA=I$ then $\\mathrm{adj}(A)\\,\\mathrm{adj}(B)=\\mathrm{adj}(BA)=\\mathrm{adj}(I)=I$ and symmetrically, so $\\mathrm{adj}$ maps units to units and respects inversion.",
+    "significance": "key",
+    "relatedConcepts": ["units of the matrix ring", "inverse preservation", "adj(1)=1", "anti-homomorphism"],
+    "prerequisites": ["anti-homomorphism law", "adjugate_one"]
+  },
+  {
+    "id": "ann-cro06-conj",
+    "proofId": "cramers-rule-oq-06",
+    "range": { "startLine": 92, "endLine": 103 },
+    "type": "tactic",
+    "title": "ORIGINAL: Similar Matrices Have Similar Adjugates",
+    "content": "adjugate_conj shows that for a conjugating pair U, U⁻¹ (with U·U⁻¹ = 1 and U⁻¹·U = 1) the adjugate of the conjugate U·A·U⁻¹ equals adj(U⁻¹)·adj(A)·adj(U), and the conjugating factors adj(U), adj(U⁻¹) are themselves mutually inverse. The first part chains the anti-homomorphism law twice and reassociates; the inverse-preservation of the factors reuses the previous argument. Consequently the adjugate carries conjugation to conjugation, so similarity of matrices is respected and adj descends to conjugacy classes.",
+    "mathContext": "$\\mathrm{adj}(UAU^{-1}) = \\mathrm{adj}(U^{-1})\\,\\mathrm{adj}(A)\\,\\mathrm{adj}(U)$ with $\\mathrm{adj}(U)$, $\\mathrm{adj}(U^{-1})$ mutually inverse — so $A \\sim A'$ implies $\\mathrm{adj}(A) \\sim \\mathrm{adj}(A')$.",
+    "significance": "key",
+    "relatedConcepts": ["similarity / conjugation", "conjugacy classes", "change of basis", "inverse preservation"],
+    "prerequisites": ["anti-homomorphism law", "adjugate_mul_adjugate_inv", "matrix associativity"]
+  },
+  {
+    "id": "ann-cro06-witness",
+    "proofId": "cramers-rule-oq-06",
+    "range": { "startLine": 104, "endLine": 114 },
+    "type": "concept",
+    "title": "A Concrete Fin 2 Witness",
+    "content": "The closing examples ground the abstract laws: adj !![1,2;3,4] = !![4,-2;-3,1] via Mathlib's adjugate_fin_two_of (which sends !![a,b;c,d] to !![d,-b;-c,a]), and the anti-homomorphism law checked on a concrete Fin 2 product. These confirm the packaged identities compute as expected on explicit matrices.",
+    "mathContext": "$\\mathrm{adj}\\begin{pmatrix}1&2\\\\3&4\\end{pmatrix} = \\begin{pmatrix}4&-2\\\\-3&1\\end{pmatrix}$, matching the $2\\times2$ formula $\\mathrm{adj}\\begin{pmatrix}a&b\\\\c&d\\end{pmatrix}=\\begin{pmatrix}d&-b\\\\-c&a\\end{pmatrix}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["2×2 adjugate formula", "explicit computation", "matrix notation"],
+    "prerequisites": ["adjugate_fin_two_of", "matrix literal notation !![...]"]
+  }
+]

--- a/src/data/proofs/cramers-rule-oq-06/meta.json
+++ b/src/data/proofs/cramers-rule-oq-06/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "cramers-rule-oq-06",
+  "title": "Cramer's Rule OQ-06: The Adjugate Algebra — Multiplicative and Conjugation Identities",
+  "slug": "cramers-rule-oq-06",
+  "description": "Studies the adjugate as an operation in its own right. Assembles its compositional algebra — anti-homomorphism on products adj(A·B)=adj(B)·adj(A), commuting with powers and transpose, det(adj A)=(det A)^(n-1), and the involution-up-to-a-determinant adj(adj A)=(det A)^(n-2)·A for n≠1 — and proves two original corollaries of the anti-homomorphism law: mutually inverse matrices have mutually inverse adjugates, and similar matrices have similar adjugates (adj descends to conjugacy classes). 8 theorems, 2 examples, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CramersRuleOQ06.lean",
+    "tags": [
+      "linear-algebra",
+      "adjugate",
+      "cramers-rule",
+      "determinants",
+      "matrix-conjugation",
+      "anti-homomorphism"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using Mathlib's Matrix.adjugate_mul_distrib, adjugate_pow, adjugate_transpose, det_adjugate, adjugate_adjugate, adjugate_one, and adjugate_fin_two_of. Depends only on propext, Classical.choice, and Quot.sound.",
+    "lineCount": 114,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "originalContributions": [
+      "adjugate_mul_adjugate_inv: mutually-inverse matrices have mutually-inverse adjugates, so the adjugate of a unit is again a unit and respects inversion — proved by applying the anti-homomorphism law to B·A and A·B and simplifying with adjugate_one",
+      "adjugate_conj: similar matrices have similar adjugates — adj(U·A·U⁻¹)=adj(U⁻¹)·adj(A)·adj(U) with the conjugating factors adj(U), adj(U⁻¹) themselves mutually inverse, so adj descends to conjugacy classes",
+      "adjugate_anti_mul / adjugate_pow' / adjugate_transpose' / det_adjugate' / adjugate_adjugate': the adjugate's structural laws packaged as a single named API for the compositional algebra of the adjugate"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The adjugate (classical adjoint) of a square matrix — the transpose of its cofactor matrix — is the 19th-century device behind Cramer's rule and the explicit inverse formula A⁻¹ = adj(A)/det(A). Cauchy, Jacobi, and Sylvester developed the theory of minors and cofactors from which the adjugate emerges; the single identity A·adj(A) = det(A)·I encapsulates the cofactor expansion of the determinant along every row and column at once. Beyond the inverse formula, the adjugate carries a rich algebra of its own: it reverses products (an anti-homomorphism), commutes with transpose and powers, and is an involution up to a determinant factor. These laws, systematized in modern linear algebra, show that the adjugate is a well-behaved operation on the whole matrix ring, not merely a tool for inverting nonsingular matrices.",
+    "problemStatement": "Assemble the compositional algebra of the adjugate over a commutative ring: prove that adj is an anti-homomorphism on products, commutes with powers and transpose, satisfies det(adj A) = (det A)^(n-1) and adj(adj A) = (det A)^(n-2)·A for n≠1, and derive the original corollaries that adj preserves mutual inverses and sends similar matrices to similar matrices.",
+    "text": "Write adj(A) for the adjugate of a square matrix A over a commutative ring R. The defining identity is A·adj(A) = adj(A)·A = det(A)·I. From it Mathlib derives the structural laws collected here. The crucial one is the anti-homomorphism law adj(A·B) = adj(B)·adj(A): the adjugate reverses the order of a product, exactly like transpose or inversion. Iterating gives adj(Aᵏ) = adj(A)ᵏ, and a short calculation gives adj(Aᵀ) = adj(A)ᵀ, det(adj A) = (det A)^(n-1), and adj(adj A) = (det A)^(n-2)·A when n≠1 (the adjugate is an involution up to a scalar). Two consequences are original to this entry. First, if A·B = 1 and B·A = 1 then applying the anti-homomorphism law to B·A and A·B and using adj(1) = 1 shows adj(A)·adj(B) = 1 and adj(B)·adj(A) = 1 — mutually inverse matrices have mutually inverse adjugates, so the adjugate of a unit is again a unit. Second, for a conjugating pair U, U⁻¹ the anti-homomorphism law applied twice gives adj(U·A·U⁻¹) = adj(U⁻¹)·adj(A)·adj(U), and the same inverse-preservation shows adj(U), adj(U⁻¹) are mutually inverse — so similar matrices have similar adjugates and the adjugate descends to conjugacy classes.",
+    "proofStrategy": "Wrap Mathlib's adjugate_mul_distrib, adjugate_pow, adjugate_transpose, det_adjugate, adjugate_adjugate, and adjugate_one as the named structural identities. Prove adjugate_mul_adjugate_inv by rewriting adj(A)·adj(B) as adj(B·A) via the anti-homomorphism law (backwards), substituting B·A = 1, and applying adjugate_one; symmetrically for adj(B)·adj(A). Prove adjugate_conj by chaining the anti-homomorphism law twice on U·A·U⁻¹ and reassociating, then reusing the inverse-preservation argument on the conjugating factors. Close with a concrete Fin 2 witness via adjugate_fin_two_of.",
+    "keyInsights": [
+      "The adjugate is an anti-homomorphism: adj(A·B) = adj(B)·adj(A) reverses order like transpose and inversion, and this single law drives every other identity in the file",
+      "All laws hold over an arbitrary commutative ring — no field or invertibility is required — because they descend from the universal identity A·adj(A) = det(A)·I",
+      "Inverse-preservation is immediate from the anti-homomorphism law plus adj(1)=1: no determinant division is needed, so it works even where det A is not invertible",
+      "Because adj preserves both products (with reversal) and inverses, it carries conjugation to conjugation, so similarity of matrices is respected and adj is well-defined on conjugacy classes"
+    ],
+    "prerequisites": [
+      "Adjugate (classical adjoint) and the identity A·adj(A) = det(A)·I",
+      "Determinant multiplicativity over a commutative ring",
+      "The anti-homomorphism law adj(A·B) = adj(B)·adj(A) (Matrix.adjugate_mul_distrib)",
+      "Matrix ring structure over a commutative ring"
+    ]
+  },
+  "conclusion": {
+    "summary": "Fully machine-verified assembly of the adjugate's compositional algebra over a commutative ring: anti-homomorphism on products, commutation with powers and transpose, det(adj A) = (det A)^(n-1), and adj(adj A) = (det A)^(n-2)·A for n≠1, plus two original corollaries — mutually inverse matrices have mutually inverse adjugates, and similar matrices have similar adjugates. Zero axioms, zero sorries.",
+    "implications": "Treating the adjugate as an operation in its own right rather than a step toward the inverse turns a scattered collection of cofactor identities into a coherent algebra: adj is an order-reversing, transpose- and power-respecting, inverse-preserving map on the matrix ring that descends to conjugacy classes. The inverse-preservation and conjugation results make adj a functor-like operation on units and on similarity classes, which is the right setting for questions about how adjugates behave under change of basis. Because everything is stated over a commutative ring, the API applies over ℤ and polynomial rings, where the adjugate features in resultants, discriminants, and the Cayley–Hamilton theorem.",
+    "openQuestions": [
+      "Characterize the image of the adjugate map and the fibers of adj on singular matrices (rank drop from n to at most 1)",
+      "Formalize adj as respecting the group structure on GLₙ, exhibiting it as an anti-automorphism up to the det^(n-2) twist",
+      "Connect det(adj A) = (det A)^(n-1) and adj(adj A) = (det A)^(n-2)·A to the compound-matrix / exterior-power interpretation of the adjugate",
+      "Relate the conjugation identity to the sibling oq-05 similarity invariants: adj(U A U⁻¹) similar to adj A recovers that det, trace, and charpoly of the adjugate are similarity invariants"
+    ]
+  },
+  "leanFile": {
+    "namespace": "CramersRuleOQ06",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/CramersRuleOQ06.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cramers-rule",
+      "relationship": "extends",
+      "description": "The parent derives Cramer's rule from A·adj(A) = det(A)·I. This entry studies the adjugate itself as an operation, assembling its multiplicative and conjugation algebra on top of that identity."
+    },
+    {
+      "targetId": "cramers-rule-oq-04",
+      "relationship": "related",
+      "description": "Sibling oq-04 treats the two-sided adjugate identity and the singular case (adjugate as generalized inverse); this entry instead develops the adjugate's compositional laws and its behaviour under products and conjugation."
+    },
+    {
+      "targetId": "cramers-rule-oq-05",
+      "relationship": "related",
+      "description": "Sibling oq-05 proves det, trace, and charpoly are similarity invariants. The conjugation identity here shows the adjugate itself respects similarity, so those invariants of adj A are again similarity invariants."
+    }
+  ],
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Imports and Variable Setup",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Imports Mathlib's adjugate and nonsingular-inverse libraries. Declares universe-polymorphic variables: n (finite decidable index type) and R (commutative ring). Working over a commutative ring means every identity holds without assuming a field or invertibility."
+    },
+    {
+      "id": "structural-laws",
+      "title": "Part I: The multiplicative / structural laws",
+      "startLine": 41,
+      "endLine": 80,
+      "summary": "Packages Mathlib's adjugate_mul_distrib, adjugate_one, adjugate_pow, adjugate_transpose, det_adjugate, and adjugate_adjugate as the named identities adjugate_anti_mul, adjugate_one', adjugate_pow', adjugate_transpose', det_adjugate', and adjugate_adjugate': the adjugate is an anti-homomorphism, commutes with powers and transpose, scales its determinant by (det A)^(n-1), and is an involution up to a determinant factor."
+    },
+    {
+      "id": "originals",
+      "title": "Part II: Original corollaries of the anti-homomorphism law",
+      "startLine": 81,
+      "endLine": 103,
+      "summary": "Proves adjugate_mul_adjugate_inv — mutually-inverse matrices have mutually-inverse adjugates — by rewriting adj(A)·adj(B) as adj(B·A), substituting B·A=1, and applying adjugate_one. Proves adjugate_conj — similar matrices have similar adjugates — by chaining the anti-homomorphism law twice and reusing the inverse-preservation argument on the conjugating factors."
+    },
+    {
+      "id": "witness",
+      "title": "Part III: A concrete Fin 2 witness",
+      "startLine": 104,
+      "endLine": 114,
+      "summary": "Checks adj !![1,2;3,4] = !![4,-2;-3,1] via adjugate_fin_two_of and confirms the anti-homomorphism law on a concrete Fin 2 product."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **cramers-rule-oq-06** ("The Adjugate Algebra"). The parent `cramers-rule`
derives Cramer's rule from the single adjugate identity `A * adj(A) = det(A) • I`; this
child studies the adjugate as an *operation in its own right* and assembles its
compositional algebra.

## What is proven (`proofs/Proofs/CramersRuleOQ06.lean`, 114 L, 8 theorems)

**Part I — structural laws**
- `adjugate_anti_mul` : `adj(A*B) = adj(B)*adj(A)` (anti-homomorphism on products)
- `adjugate_pow'` / `adjugate_transpose'` : commutes with powers and transpose
- `det_adjugate'` : `det(adj A) = (det A)^(n-1)`
- `adjugate_adjugate'` : involution up to a determinant factor, `adj(adj A) = (det A)^(n-2) • A` for `n ≠ 1`

**Part II — original corollaries of the anti-homomorphism law** (neither in Mathlib)
- `adjugate_mul_adjugate_inv` : the adjugate sends mutually-inverse pairs to mutually-inverse pairs (adjugate of a unit is a unit)
- `adjugate_conj` : *similar matrices have similar adjugates* — `adj` descends to conjugacy classes

**Part III** — a concrete `Fin 2` witness (`adj !![1,2;3,4] = !![4,-2;-3,1]`).

## Verification

- Docker build: `✔ [3058/3058] Built Proofs.CramersRuleOQ06 (39s)`, exit 0
- **0 sorries, 0 axioms**, no `native_decide`
- `status: verified`, `badge: mathlib`, `axiomCount: 0`, `theoremCount: 8`

Everything reduces to curated Mathlib adjugate lemmas chained together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)