### PR TITLE
research(sperner-ndim-oq-02): per-cell door set/count in Kuhn-increment form [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -2299,4 +2299,59 @@ theorem boundary_faces_card (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d) :
   · rw [if_pos hcond, if_pos hcond, Finset.card_singleton]
   · rw [if_neg hcond, if_neg hcond, Finset.card_empty]
 
+/-!
+## Per-cell door count in Kuhn-increment form
+
+`boundary_faces_eq`/`boundary_faces_card` express each cell's contribution to the
+last-face door count through the *geometric* top-facet condition
+`∀ j ≠ Fin.last d, (verts j).coords (Fin.last d) = 0`.  A Phase-2 door-parity
+induction, however, does not accumulate over that geometric predicate directly: it
+runs along the **Kuhn chains**, whose data is the increment directions `s.incDir` and
+the base vertex `s.verts 0`.  `last_boundary_face_iff` is exactly the translation
+between the two — the top facet is a geometric `∂Δ_N` door iff the *final* Kuhn step
+(`c.val = d - 1`) increments the top coordinate (`s.incDir c = Fin.last d`) and that
+coordinate starts at zero on the base.  This section restates the exact per-cell door
+set (`boundary_faces_eq_incDir`) and count (`boundary_faces_card_incDir`) through that
+Kuhn-increment predicate, so the global door sum can be reorganized along Kuhn chains
+without ever re-deriving the geometric condition.  All 0-sorry, 0-axiom (builds only
+on `boundary_faces_eq`/`boundary_faces_card` + `last_boundary_face_iff`). -/
+
+/-- **Per-cell boundary-door set, in Kuhn-increment form.**  The finset of geometric
+`∂Δ_N` boundary doors of a Freudenthal cell equals the singleton `{Fin.last d}`
+exactly when the final Kuhn step increments the top coordinate
+(`∃ c, s.incDir c = Fin.last d ∧ c.val = d - 1`) and that coordinate starts at zero on
+the base vertex, and `∅` otherwise.  The `boundary_faces_eq` set re-expressed through
+the Kuhn-increment data a dimensional induction runs over (via
+`last_boundary_face_iff`). -/
+theorem boundary_faces_eq_incDir (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d) :
+    (Finset.univ.filter
+      (fun k : Fin (d + 1) =>
+        ∀ j : Fin (d + 1), j ≠ k → (s.verts j).coords k = 0)) =
+    if ((∃ c : Fin d, s.incDir c = Fin.last d ∧ c.val = d - 1) ∧
+        (s.verts 0).coords (Fin.last d) = 0)
+      then {Fin.last d} else ∅ := by
+  rw [boundary_faces_eq s hd]
+  by_cases hcond :
+      (∀ j : Fin (d + 1), j ≠ Fin.last d → (s.verts j).coords (Fin.last d) = 0)
+  · rw [if_pos hcond, if_pos ((last_boundary_face_iff s hd).mp hcond)]
+  · rw [if_neg hcond, if_neg (fun hk => hcond ((last_boundary_face_iff s hd).mpr hk))]
+
+/-- **Per-cell boundary-door count, in Kuhn-increment form.**  The number of geometric
+`∂Δ_N` boundary doors of a Freudenthal cell is `1` when the final Kuhn step increments
+the top coordinate and that coordinate starts at zero on the base, and `0` otherwise.
+The `boundary_faces_card` term re-expressed through the Kuhn-increment data — the exact
+`0/1` summand a Phase-2 door-parity induction over Kuhn chains accumulates. -/
+theorem boundary_faces_card_incDir (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d) :
+    (Finset.univ.filter
+      (fun k : Fin (d + 1) =>
+        ∀ j : Fin (d + 1), j ≠ k → (s.verts j).coords k = 0)).card =
+    if ((∃ c : Fin d, s.incDir c = Fin.last d ∧ c.val = d - 1) ∧
+        (s.verts 0).coords (Fin.last d) = 0)
+      then 1 else 0 := by
+  rw [boundary_faces_card s hd]
+  by_cases hcond :
+      (∀ j : Fin (d + 1), j ≠ Fin.last d → (s.verts j).coords (Fin.last d) = 0)
+  · rw [if_pos hcond, if_pos ((last_boundary_face_iff s hd).mp hcond)]
+  · rw [if_neg hcond, if_neg (fun hk => hcond ((last_boundary_face_iff s hd).mpr hk))]
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/state.md
+++ b/research/problems/sperner-ndim-oq-02/state.md
@@ -4,8 +4,11 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-23T00:00:00Z
-**Iteration**: 12
+**Iteration**: 13
 
+> **Session 13 (2026-07-01, researcher-5): per-cell door set/count restated in Kuhn-increment form (VERIFIED 0-axiom, docker-build 7745 jobs exit 0).** Added 2 theorems to `SpernerNDimOQ02.lean` bridging the two most recent sessions:
+> - `boundary_faces_eq_incDir` / `boundary_faces_card_incDir` — the exact per-cell door set (`boundary_faces_eq`, researcher-1) and count (`boundary_faces_card`, researcher-1) re-expressed through the *Kuhn-increment* predicate `(∃ c, incDir c = Fin.last d ∧ c.val = d-1) ∧ (verts 0).coords (Fin.last d) = 0` — via `last_boundary_face_iff` (researcher-11, S12). The per-cell `0/1` door term now reads off the increment directions + base vertex, the data a Phase-2 door-parity induction over Kuhn chains actually accumulates over (rather than the raw geometric top-facet condition). Pure `rw`/`by_cases`/`if_pos`/`if_neg` over already-0-axiom lemmas; no `native_decide`. **Frontier UNCHANGED**: the cross-chain gluing adjacency (facet-0 partner) is untouched. File 2302 → 2362 L.
+>
 > **Session 12 (2026-07-01, researcher-11): top-facet boundary door FULLY CHARACTERIZED + facet-0 frontier CERTIFIED as a theorem (PR #32085, VERIFIED 0-axiom, docker-build 7745 jobs exit 0, `#print axioms` = [propext, Classical.choice, Quot.sound]).** Added 5 theorems to `SpernerNDimOQ02.lean` sharpening the *geometric* `boundary_face` analysis:
 > - `last_boundary_face_of_incDir_last` / `last_boundary_face_imp_incDir_last` / `last_boundary_face_iff` — the exact converse-refinement of `boundary_face_imp_last`: facet `Fin.last d` is a genuine ∂Δ_N door **iff** the final Kuhn step (`c.val = d-1`) increases the top coordinate (`incDir c = Fin.last d`) **and** that coordinate is 0 on the base vertex. Pins down exactly which Freudenthal cells the last-face door count visits. Proofs use only `coord_incDir_at` + `incDir_surj_complement` + `miss_coord_pos_of_ne_last`.
 > - `gridVertices_zero_not_boundary_face` — carrier/`onFace` restatement of `zero_not_boundary_face` (the shape `SpernerTriangulation.boundary_face` consumes).


### PR DESCRIPTION
## Summary

Two new theorems in `proofs/Proofs/SpernerNDimOQ02.lean` that bridge the two most recent sessions on the n-dim Sperner boundary-door problem:

- **`boundary_faces_eq_incDir`** — the exact per-cell geometric `∂Δ_N` door **set** equals `{Fin.last d}` (else `∅`) exactly when the *Kuhn-increment* predicate holds:
  `(∃ c, s.incDir c = Fin.last d ∧ c.val = d-1) ∧ (s.verts 0).coords (Fin.last d) = 0`
- **`boundary_faces_card_incDir`** — the corresponding per-cell door **count** is `1`/`0` under that same predicate.

## Why

Prior sessions delivered two complementary per-cell facts:
- `boundary_faces_eq` / `boundary_faces_card` (researcher-1, #32159) — the exact `0/1` door contribution, stated through the **geometric** top-facet condition `∀ j ≠ Fin.last d, (verts j).coords (Fin.last d) = 0`.
- `last_boundary_face_iff` (researcher-11, S12, #32085) — that geometric condition ⟺ the **Kuhn-increment** data (final step increments the top coordinate; base starts at 0 there).

A Phase-2 door-parity induction runs along **Kuhn chains** and accumulates over the increment directions `incDir` + base vertex, not the raw geometric predicate. These lemmas hand it the per-cell summand already in that form, so the global door sum can be reorganized along chains without re-deriving the geometry each time.

## Verification

- **docker-build**: `docker-build.sh Proofs.SpernerNDimOQ02` → `Built Proofs.SpernerNDimOQ02`, **7745 jobs, exit 0**.
- **0-axiom**: pure `rw` / `by_cases` / `if_pos` / `if_neg` over already-0-axiom lemmas (`boundary_faces_eq`, `boundary_faces_card`, `last_boundary_face_iff`) with decidable-instance `if`s; **no `native_decide`/`decide`**, no new `axiom` declarations, 0 sorries. Foundational deps only (`propext`/`Classical.choice`/`Quot.sound`).

## Scope / honesty

Modest but genuinely useful reformulation. **Frontier UNCHANGED**: the cross-chain gluing adjacency (the facet-0 cross-Kuhn partner / `SpernerTriangulation` instance) remains the open blocker, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)