### PR TITLE
Enrich Gerretsen's inequality (herons-formula-oq-06-oq-02): 4th keyInsight on equality case

### DIFF
--- a/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
+++ b/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
@@ -18,7 +18,8 @@
     "keyInsights": [
       "Only Area² (not Area) appears throughout — the cross term 4Rr = abc/s is area-free — so a single Heron substitution removes every square root and reduces the geometric inequality to an area-free polynomial inequality.",
       "gerretsenPoly admits the certificate Σ x⁴(y-z)² + 2[x²(y-z)²(xy+xz-yz) + y²z²(x-y)(x-z)]. The bracket is Schur-type: it is negative for some signed inputs, so unlike the parent's pure AM-GM core, positivity of x,y,z is mathematically essential.",
-      "Under a WLOG ordering z ≤ y ≤ x the Schur term becomes manifestly nonnegative because xy+xz-yz = y² + (x-y)(y+z) ≥ 0 and (x-y)(x-z) ≥ 0; symmetry of gerretsenPoly closes the six orderings."
+      "Under a WLOG ordering z ≤ y ≤ x the Schur term becomes manifestly nonnegative because xy+xz-yz = y² + (x-y)(y+z) ≥ 0 and (x-y)(x-z) ≥ 0; symmetry of gerretsenPoly closes the six orderings.",
+      "The slack is a single quotient, so the equality case falls out for free. The identity (4R²+4Rr+3r²) - s² = gerretsenPoly(s-a,s-b,s-c)/(4·Area²) writes the entire gap as one nonnegative numerator over the positive denominator 4·Area². Equality therefore holds exactly when gerretsenPoly(x,y,z) = 0, i.e. x = y = z, i.e. s-a = s-b = s-c — the equilateral triangle — so the sharpness of Gerretsen's bound is read straight off the certificate with no separate extremal argument."
     ],
     "prerequisites": [
       "Heron's formula Area² = s(s-a)(s-b)(s-c)",


### PR DESCRIPTION
Enrichment pass for `herons-formula-oq-06-oq-02` (Gerretsen's inequality s² ≤ 4R²+4Rr+3r²).

**Gap addressed:** the entry had only 3 `overview.keyInsights`, below the documented minimum of 4.

**Change:** adds one substantive keyInsight (distinct from the existing three) explaining that the slack (4R²+4Rr+3r²) − s² = gerretsenPoly(s−a,s−b,s−c)/(4·Area²) is a single nonnegative quotient, so equality holds exactly when the numerator vanishes (x = y = z ⟺ equilateral). This reads the sharpness of the bound directly off the certificate with no separate extremal analysis.

- keyInsights 3 → 4
- meta.json 11.7 KB → 12.2 KB (well under the 60 KB cap)
- JSON validated with jq; no other fields touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)