### PR TITLE
research(feuerbachs-theorem-oq-04): complete pairwise-distinctness matrix for the four tritangent circles [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -1168,4 +1168,97 @@ theorem incircle_excircleAB_distinct {Na Nb Nc O : E} {ρ : ℝ}
   rw [h0] at hpos
   exact lt_irrefl 0 hpos
 
+/-! ### Completing the pairwise-distinctness matrix
+
+`incircle_excircleAB_distinct` above handles the incircle against excircles A and B (both
+flip the `a`–`b` relation). Feuerbach's "tangent to all four" presupposes that *all four*
+tritangent circles are pairwise distinct, i.e. every one of the six pairs is genuinely
+different. The remaining pairs — incircle vs. excircle C, and the three excircle–excircle
+pairs — are certified here. Each reduces to one of three sign-exclusivity engines
+(`a`–`b`, `b`–`c`, `a`–`c`), so on a nondegenerate radius (`0 < ρ < π`, `sin ρ > 0`) no
+single tangent centre can carry both circles' returned sign relations.
+
+Recall the sign patterns each existence theorem returns (writing `sᵢ = ⟪O, Nᵢ⟫`, so
+`|sₐ| = |s_b| = |s_c| = sin ρ`):
+
+* incircle  `sphericalIncircle_exists`  : `sₐ =  s_b`, `s_b =  s_c`   (all equal)
+* excircle A `sphericalExcircleA_exists` : `sₐ = -s_b`, `s_b =  s_c`   (`a` flipped)
+* excircle B `sphericalExcircleB_exists` : `sₐ = -s_b`, `sₐ =  s_c`   (`b` flipped)
+* excircle C `sphericalExcircleC_exists` : `sₐ =  s_b`, `s_b = -s_c`   (`c` flipped)
+-/
+
+/-- **`a`–`c` sign exclusivity.**  Companion to `incircle_excircleAB_signs_exclusive`
+(the `a`–`b` engine) and `incircle_excircleC_signs_exclusive` (the `b`–`c` engine): a
+tangent centre carrying both the equal relation `⟪O,Na⟫ = ⟪O,Nc⟫` and the flipped relation
+`⟪O,Na⟫ = -⟪O,Nc⟫` has degenerate radius `sin ρ = 0` (its `c`-side tangency vanishes). -/
+theorem incircle_excircle_ac_signs_exclusive {Na Nb Nc O : E} {ρ : ℝ}
+    (hinc : SphericalIncircle Na Nb Nc O ρ)
+    (hIn : (⟪O, Na⟫ : ℝ) = ⟪O, Nc⟫)
+    (hEx : (⟪O, Na⟫ : ℝ) = -⟪O, Nc⟫) :
+    Real.sin ρ = 0 :=
+  tangent_signs_opposite_imp_sin_zero hinc.2.2 hIn hEx
+
+/-- **Incircle vs. excircle C are genuinely distinct.**  The incircle has `⟪O,Nb⟫ = ⟪O,Nc⟫`
+while excircle C flips this to `⟪O,Nb⟫ = -⟪O,Nc⟫`.  On a nondegenerate radius no centre can
+satisfy both, so the incircle and excircle C are different circles.  (The `b`–`c` analogue
+of `incircle_excircleAB_distinct`.) -/
+theorem incircle_excircleC_distinct {Na Nb Nc O : E} {ρ : ℝ}
+    (hinc : SphericalIncircle Na Nb Nc O ρ)
+    (hρpos : 0 < ρ) (hρlt : ρ < Real.pi)
+    (hIn : (⟪O, Nb⟫ : ℝ) = ⟪O, Nc⟫)
+    (hEx : (⟪O, Nb⟫ : ℝ) = -⟪O, Nc⟫) :
+    False := by
+  have h0 : Real.sin ρ = 0 := incircle_excircleC_signs_exclusive hinc hIn hEx
+  have hpos : 0 < Real.sin ρ := Real.sin_pos_of_pos_of_lt_pi hρpos hρlt
+  rw [h0] at hpos
+  exact lt_irrefl 0 hpos
+
+/-- **Excircles A and B are genuinely distinct.**  Both flip the `a`–`b` relation, so they
+must be told apart on the `b`–`c` relation: excircle A returns `⟪O,Nb⟫ = ⟪O,Nc⟫`, whereas
+excircle B's pair `⟪O,Na⟫ = -⟪O,Nb⟫`, `⟪O,Na⟫ = ⟪O,Nc⟫` forces `⟪O,Nb⟫ = -⟪O,Nc⟫`.  On a
+nondegenerate radius these are incompatible, so excircles A and B are different circles. -/
+theorem excircleA_excircleB_distinct {Na Nb Nc O : E} {ρ : ℝ}
+    (hinc : SphericalIncircle Na Nb Nc O ρ)
+    (hρpos : 0 < ρ) (hρlt : ρ < Real.pi)
+    (hA_bc : (⟪O, Nb⟫ : ℝ) = ⟪O, Nc⟫)
+    (hB_ab : (⟪O, Na⟫ : ℝ) = -⟪O, Nb⟫)
+    (hB_ac : (⟪O, Na⟫ : ℝ) = ⟪O, Nc⟫) :
+    False := by
+  have hB_bc : (⟪O, Nb⟫ : ℝ) = -⟪O, Nc⟫ := by linarith
+  have h0 : Real.sin ρ = 0 := incircle_excircleC_signs_exclusive hinc hA_bc hB_bc
+  have hpos : 0 < Real.sin ρ := Real.sin_pos_of_pos_of_lt_pi hρpos hρlt
+  rw [h0] at hpos
+  exact lt_irrefl 0 hpos
+
+/-- **Excircles A and C are genuinely distinct.**  Excircle A flips the `a`–`b` relation
+(`⟪O,Na⟫ = -⟪O,Nb⟫`) while excircle C keeps it equal (`⟪O,Na⟫ = ⟪O,Nb⟫`).  On a nondegenerate
+radius these are incompatible, so excircles A and C are different circles. -/
+theorem excircleA_excircleC_distinct {Na Nb Nc O : E} {ρ : ℝ}
+    (hinc : SphericalIncircle Na Nb Nc O ρ)
+    (hρpos : 0 < ρ) (hρlt : ρ < Real.pi)
+    (hC_ab : (⟪O, Na⟫ : ℝ) = ⟪O, Nb⟫)
+    (hA_ab : (⟪O, Na⟫ : ℝ) = -⟪O, Nb⟫) :
+    False := by
+  have h0 : Real.sin ρ = 0 := incircle_excircleAB_signs_exclusive hinc hC_ab hA_ab
+  have hpos : 0 < Real.sin ρ := Real.sin_pos_of_pos_of_lt_pi hρpos hρlt
+  rw [h0] at hpos
+  exact lt_irrefl 0 hpos
+
+/-- **Excircles B and C are genuinely distinct.**  They agree on the `b`–`c` relation, so
+they are told apart on the `a`–`c` relation: excircle B returns `⟪O,Na⟫ = ⟪O,Nc⟫`, whereas
+excircle C's pair `⟪O,Na⟫ = ⟪O,Nb⟫`, `⟪O,Nb⟫ = -⟪O,Nc⟫` forces `⟪O,Na⟫ = -⟪O,Nc⟫`.  On a
+nondegenerate radius these are incompatible, so excircles B and C are different circles. -/
+theorem excircleB_excircleC_distinct {Na Nb Nc O : E} {ρ : ℝ}
+    (hinc : SphericalIncircle Na Nb Nc O ρ)
+    (hρpos : 0 < ρ) (hρlt : ρ < Real.pi)
+    (hB_ac : (⟪O, Na⟫ : ℝ) = ⟪O, Nc⟫)
+    (hC_ab : (⟪O, Na⟫ : ℝ) = ⟪O, Nb⟫)
+    (hC_bc : (⟪O, Nb⟫ : ℝ) = -⟪O, Nc⟫) :
+    False := by
+  have hC_ac : (⟪O, Na⟫ : ℝ) = -⟪O, Nc⟫ := by linarith
+  have h0 : Real.sin ρ = 0 := incircle_excircle_ac_signs_exclusive hinc hB_ac hC_ac
+  have hpos : 0 < Real.sin ρ := Real.sin_pos_of_pos_of_lt_pi hρpos hρlt
+  rw [h0] at hpos
+  exact lt_irrefl 0 hpos
+
 end FeuerbachsTheoremOQ04

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -1,5 +1,39 @@
 # feuerbachs-theorem-oq-04 — Feuerbach's Theorem in Non-Euclidean Geometry
 
+## Session 2026-07-01 (researcher-7): completed the pairwise-distinctness matrix [VERIFIED]
+
+**Mode**: ACT (CONTINUE). The prior session (researcher-1) proved only `incircle_excircleAB_distinct`
+— 1 of the 6 pairs of the four tritangent circles (incircle + 3 excircles). Feuerbach's "tangent to
+all four" presupposes ALL four are pairwise distinct (6 pairs). **Outcome**: PROGRESS — completed the
+matrix: +5 theorems (~75 L) to `FeuerbachsTheoremOQ04.lean`. **Docker build VERIFIED**
+(`docker-build.sh Proofs.FeuerbachsTheoremOQ04`, `✔ [7743/7743] Built`, exit 0); **0-sorry, 0-axiom**,
+no native_decide (only `linarith`, existing signs-exclusivity engines, `Real.sin_pos_of_pos_of_lt_pi`,
+`lt_irrefl`).
+
+### Sign patterns (sᵢ = ⟪O,Nᵢ⟫, |sₐ|=|s_b|=|s_c|=sin ρ), from the existence theorems
+- incircle: sₐ=s_b, s_b=s_c (EEE on a-b/b-c/a-c) ; excircle A: sₐ=-s_b, s_b=s_c (OEO) ;
+  excircle B: sₐ=-s_b, sₐ=s_c (OOE) ; excircle C: sₐ=s_b, s_b=-s_c (EOO). Every pair differs.
+
+### What was delivered (appended after `incircle_excircleAB_distinct`)
+- **`incircle_excircle_ac_signs_exclusive`** (new engine): a-c analogue of the existing a-b/b-c
+  sign-exclusivity lemmas — `⟪O,Na⟫=⟪O,Nc⟫` ∧ `⟪O,Na⟫=-⟪O,Nc⟫` ⟹ sin ρ=0 (via `hinc.2.2`).
+- **`incircle_excircleC_distinct`** (I vs C, b-c pair): the missing b-c mirror of AB_distinct.
+- **`excircleA_excircleB_distinct`** (A vs B): both flip a-b, so distinguished on b-c — B's pair
+  `sₐ=-s_b, sₐ=s_c` forces `s_b=-s_c` (linarith), conflicts with A's `s_b=s_c`.
+- **`excircleA_excircleC_distinct`** (A vs C, a-b pair): A flips a-b, C keeps it equal — direct.
+- **`excircleB_excircleC_distinct`** (B vs C): agree on b-c, distinguished on a-c — C's pair forces
+  `sₐ=-s_c` (linarith), conflicts with B's `sₐ=s_c`; uses the new a-c engine.
+
+### Why this matters
+All four tritangent circles share the predicate `SphericalIncircle`; distinctness is not automatic
+and is a stated prerequisite for spherical Feuerbach. The matrix is now complete: all 6 pairs are
+certified different on any nondegenerate radius (`0<ρ<π`).
+
+### Frontier UNCHANGED (genuinely hard, not attempted)
+1. **Spherical nine-point circle** (needs side midpoints — in-flight DRAFT PR #32127
+   `research/feuerbach-oq04-midpoint`). Did NOT touch to avoid collision.
+2. **The Feuerbach tangency** (nine-point circle tangent to all four). Genuinely hard.
+
 ## Session 2026-07-01 (researcher-1): the four tritangent circles are genuinely distinct [VERIFIED]
 
 **Mode**: ACT (CONTINUE). researcher-7 (same day) produced all four tritangent circles


### PR DESCRIPTION
## Summary

Completes the **pairwise-distinctness matrix** of the four spherical tritangent circles (incircle + three excircles) in `FeuerbachsTheoremOQ04.lean`.

Prior work (`incircle_excircleAB_distinct`) certified only **1 of the 6 pairs** — incircle vs. excircles A/B. But Feuerbach's theorem asserts the spherical nine-point circle is *tangent to all four*, which is only meaningful if all four are **genuinely distinct** circles. All four satisfy the same predicate `SphericalIncircle` and are distinguished solely by the sign relations `⟪O,Nᵢ⟫ = ±⟪O,Nⱼ⟫` their existence theorems return, so distinctness is not automatic.

This PR adds the remaining 5 pairs' worth of infrastructure (+5 theorems, ~75 L), certifying that **every** one of the 6 pairs is a different circle on any nondegenerate radius (`0 < ρ < π`, `sin ρ > 0`).

## Sign patterns (from the existence theorems)

With `sᵢ = ⟪O, Nᵢ⟫` and `|sₐ| = |s_b| = |s_c| = sin ρ`:

| circle | relations returned | pattern (a-b, b-c, a-c) |
|--------|--------------------|--------------------------|
| incircle | `sₐ=s_b`, `s_b=s_c` | E, E, E |
| excircle A | `sₐ=-s_b`, `s_b=s_c` | O, E, O |
| excircle B | `sₐ=-s_b`, `sₐ=s_c` | O, O, E |
| excircle C | `sₐ=s_b`, `s_b=-s_c` | E, O, O |

Every pair differs in at least one relation, and each such difference is certified incompatible by a sign-exclusivity engine.

## Theorems added

- **`incircle_excircle_ac_signs_exclusive`** — the `a`–`c` sign-exclusivity engine, companion to the existing `a`–`b` (`incircle_excircleAB_signs_exclusive`) and `b`–`c` (`incircle_excircleC_signs_exclusive`) engines.
- **`incircle_excircleC_distinct`** — incircle vs. excircle C (`b`–`c`); the missing mirror of `incircle_excircleAB_distinct`.
- **`excircleA_excircleB_distinct`** — excircles A vs. B; both flip `a`–`b`, so distinguished on `b`–`c` (B's pair forces `s_b = -s_c`).
- **`excircleA_excircleC_distinct`** — excircles A vs. C (`a`–`b`).
- **`excircleB_excircleC_distinct`** — excircles B vs. C; agree on `b`–`c`, distinguished on `a`–`c` (C's pair forces `sₐ = -s_c`).

All reuse the existing `tangent_signs_opposite_imp_sin_zero` core plus `linarith`.

## Verification

- **Docker build VERIFIED**: `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremOQ04` → `✔ [7743/7743] Built`, exit 0.
- **0-sorry, 0-axiom**, no `native_decide`.

## Scope note

Does **not** touch the spherical nine-point-circle / midpoint direction (in-flight DRAFT #32127) or the Feuerbach tangency itself — those remain the genuinely hard frontier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)