### PR TITLE
Enrich Erdős #191 axiom-elimination: link the axiom-elimination sub-program

### DIFF
--- a/src/data/proofs/erdos-191-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-191-incomplete-01/meta.json
@@ -108,6 +108,21 @@
       "targetId": "erdos-191",
       "relationship": "extends",
       "description": "Discharges the tripleLog_unbounded axiom of the erdos-191 entry, reducing its genuine assumption count from 4 to 3"
+    },
+    {
+      "targetId": "erdos-305-incomplete-01",
+      "relationship": "shares-technique",
+      "description": "The nearest analogue: it likewise converts a parent's `axiom` (egyptian_representation_exists in Erdos305Problem.lean) into a proved theorem verbatim, retiring the axiom in place. Same 'not every axiom in a solved-problem file is deep' move as discharging tripleLog_unbounded here."
+    },
+    {
+      "targetId": "erdos-441-incomplete-01",
+      "relationship": "shares-technique",
+      "description": "Another member of the axiom-elimination sub-program: it isolates the elementary axiom-free core (g(N) ≥ ⌊√N⌋) of an Erdős entry whose deep asymptotics remain axioms — the same strategy of extracting the provable elementary piece and leaving only the genuinely deep assumptions."
+    },
+    {
+      "targetId": "erdos-643-incomplete-01",
+      "relationship": "shares-technique",
+      "description": "Isolates the axiom-free elementary lower bound of Erdős #643 from a parent that keeps the general-t result axiomatized — parallel to reducing erdos-191 to its three genuinely deep (Rödl / Conlon–Fox–Sudakov) axioms."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass — erdos-191-incomplete-01 (passes: 0)

This entry discharges the elementary `tripleLog_unbounded` axiom (log log log n → ∞) from the parent erdos-191 file. It was well-curated but had only **1** cross-reference (the parent), leaving it disconnected from the gallery's broader axiom-elimination sub-program.

### Change
Add **3** `shares-technique` cross-references (crossReferences 1 → 4):
- **erdos-305-incomplete-01** — nearest analogue: converts a parent `axiom` into a proved theorem verbatim (Egyptian-representation existence).
- **erdos-441-incomplete-01** — isolates the elementary axiom-free core (g(N) ≥ ⌊√N⌋) while deep asymptotics stay axiomatized.
- **erdos-643-incomplete-01** — isolates the axiom-free elementary lower bound of Erdős #643 from an otherwise-axiomatized parent.

### Guardrails
- meta.json 8.7 KB → 9.8 KB (≪ 60 KB cap); crossReferences 4 (≪ 20 cap).
- JSON validated with `jq`; all 4 targets confirmed to exist; `shares-technique` is an existing relationship value.
- No accretion: fills a genuine navigational gap, does not deepen already-satisfied fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)