### PR TITLE
Fix: remove false fabry_implies_fejer lemma in Erdős #516

### DIFF
--- a/proofs/Proofs/Erdos516Problem.lean
+++ b/proofs/Proofs/Erdos516Problem.lean
@@ -45,17 +45,13 @@ def HasFabryGaps (n : ℕ → ℕ) : Prop :=
   Tendsto (fun k => (n k : ℝ) / k) atTop atTop
 
 /-- The Fejér gap condition: Σ 1/nₖ < ∞.
-    A weaker condition than Fabry gaps. -/
+    A distinct gap condition from Fabry gaps: in general neither implies
+    the other. For increasing (nₖ), Σ 1/nₖ < ∞ forces nₖ/k → ∞ (so Fejér
+    gaps imply Fabry gaps), but the converse fails — e.g. nₖ = k⌊log k⌋
+    satisfies nₖ/k → ∞ while Σ 1/nₖ = Σ 1/(k⌊log k⌋) diverges. Hence there
+    is no `fabry_implies_fejer` implication. -/
 def HasFejerGaps (n : ℕ → ℕ) : Prop :=
   Summable (fun k => (1 : ℝ) / n k)
-
-/-- Fabry gaps are stronger than Fejér gaps.
-    If nₖ/k → ∞, then nₖ grows superlinearly, so 1/nₖ is summable. -/
-theorem fabry_implies_fejer (n : ℕ → ℕ) (hn : HasFabryGaps n) :
-    HasFejerGaps n := by
-  -- This follows from the comparison test: if nₖ/k → ∞ then
-  -- eventually nₖ > k², so Σ 1/nₖ < Σ 1/k² < ∞
-  sorry
 
 /-
 ## Entire Functions of Finite Order

--- a/src/data/proofs/erdos-516/annotations.json
+++ b/src/data/proofs/erdos-516/annotations.json
@@ -76,7 +76,7 @@
     },
     "type": "definition",
     "title": "Fejér Gap Condition",
-    "content": "**HasFejerGaps(n)**: The series Σ 1/nₖ converges.\n\n```lean\ndef HasFejerGaps (n : ℕ → ℕ) : Prop :=\n  Summable (fun k => (1 : ℝ) / n k)\n```\n\nThis is weaker than Fabry gaps. It remains open whether this suffices for the minimum modulus result.",
+    "content": "**HasFejerGaps(n)**: The series Σ 1/nₖ converges.\n\n```lean\ndef HasFejerGaps (n : ℕ → ℕ) : Prop :=\n  Summable (fun k => (1 : ℝ) / n k)\n```\n\nDistinct from Fabry gaps: in general neither implies the other. It remains open whether Σ 1/nₖ < ∞ suffices for the minimum modulus result on arbitrary entire functions.",
     "mathContext": "Named after Lipót Fejér. This condition appears in Macintyre's optimality result: if Σ 1/nₖ = ∞, counterexamples to the minimum modulus result exist.",
     "significance": "key",
     "relatedConcepts": [
@@ -93,13 +93,13 @@
     "id": "ann-e516-fabry-implies-fejer",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 52,
-      "endLine": 58
+      "startLine": 47,
+      "endLine": 54
     },
     "type": "concept",
-    "title": "Fabry Implies Fejér",
-    "content": "**Theorem**: Fabry gaps imply Fejér gaps.\n\nIf nₖ/k → ∞, then eventually nₖ > k², so Σ 1/nₖ < Σ 1/k² < ∞.\n\nThis shows Fabry is a strictly stronger condition.",
-    "mathContext": "The proof uses the comparison test: superlinear growth of nₖ gives superlinear decay of 1/nₖ, which is summable.",
+    "title": "Fabry vs. Fejér Gaps",
+    "content": "**Relationship**: Fabry gaps (nₖ/k → ∞) and Fejér gaps (Σ 1/nₖ < ∞) are distinct — in general neither implies the other.\n\nFor *increasing* (nₖ), Σ 1/nₖ < ∞ forces k/nₖ → 0 (decreasing summable terms), i.e. nₖ/k → ∞, so **Fejér gaps imply Fabry gaps** and Fejér is the stronger condition.\n\nThe converse **fails**: nₖ = k⌊log k⌋ satisfies nₖ/k = ⌊log k⌋ → ∞ (Fabry) while Σ 1/nₖ = Σ 1/(k⌊log k⌋) diverges (not Fejér). So there is no `fabry_implies_fejer` implication.",
+    "mathContext": "A common pitfall is to claim nₖ/k → ∞ forces nₖ > k² eventually — false, since nₖ may grow only slightly faster than linear (e.g. k log k). The correct direction uses that a decreasing summable sequence 1/nₖ satisfies k/nₖ → 0.",
     "significance": "supporting",
     "relatedConcepts": [
       "comparison-test",
@@ -115,8 +115,8 @@
     "id": "ann-e516-finite-order",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 67,
-      "endLine": 70
+      "startLine": 63,
+      "endLine": 66
     },
     "type": "definition",
     "title": "Finite Order Entire Functions",
@@ -138,8 +138,8 @@
     "id": "ann-e516-order-def",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 72,
-      "endLine": 74
+      "startLine": 68,
+      "endLine": 70
     },
     "type": "definition",
     "title": "Order of an Entire Function",
@@ -160,8 +160,8 @@
     "id": "ann-e516-max-modulus",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 82,
-      "endLine": 84
+      "startLine": 78,
+      "endLine": 80
     },
     "type": "definition",
     "title": "Maximum Modulus",
@@ -183,8 +183,8 @@
     "id": "ann-e516-min-modulus",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 86,
-      "endLine": 88
+      "startLine": 82,
+      "endLine": 84
     },
     "type": "definition",
     "title": "Minimum Modulus",
@@ -206,8 +206,8 @@
     "id": "ann-e516-ratio",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 90,
-      "endLine": 92
+      "startLine": 86,
+      "endLine": 88
     },
     "type": "definition",
     "title": "Modulus Ratio",
@@ -229,8 +229,8 @@
     "id": "ann-e516-fuchs",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 101,
-      "endLine": 117
+      "startLine": 97,
+      "endLine": 113
     },
     "type": "concept",
     "title": "Fuchs's Theorem (1963)",
@@ -252,8 +252,8 @@
     "id": "ann-e516-wiman",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 125,
-      "endLine": 135
+      "startLine": 121,
+      "endLine": 131
     },
     "type": "concept",
     "title": "Wiman's Theorem (1914)",
@@ -274,8 +274,8 @@
     "id": "ann-e516-erdos-macintyre",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 137,
-      "endLine": 147
+      "startLine": 133,
+      "endLine": 143
     },
     "type": "concept",
     "title": "Erdős-Macintyre Theorem (1954)",
@@ -296,8 +296,8 @@
     "id": "ann-e516-kovari",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 156,
-      "endLine": 167
+      "startLine": 152,
+      "endLine": 163
     },
     "type": "concept",
     "title": "Kovári's Theorem (1965)",
@@ -318,8 +318,8 @@
     "id": "ann-e516-fejer-conj",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 176,
-      "endLine": 190
+      "startLine": 172,
+      "endLine": 186
     },
     "type": "definition",
     "title": "Fejér Gap Conjecture (Open)",
@@ -340,8 +340,8 @@
     "id": "ann-e516-macintyre-counter",
     "proofId": "erdos-516",
     "range": {
-      "startLine": 192,
-      "endLine": 196
+      "startLine": 188,
+      "endLine": 192
     },
     "type": "concept",
     "title": "Macintyre's Counterexample (1952)",

--- a/src/data/proofs/erdos-516/meta.json
+++ b/src/data/proofs/erdos-516/meta.json
@@ -18,7 +18,7 @@
       "minimum-modulus"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 516,
     "erdosUrl": "https://erdosproblems.com/516",
     "erdosProblemStatus": "proved",
@@ -58,21 +58,21 @@
       "Formalization of the remaining open conjecture (Fejér gaps)"
     ],
     "axiomCount": 1,
-    "lineCount": 196,
-    "assumptions": "1 axiom: fuchs_theorem. 1 sorry.",
-    "theoremCount": 2,
+    "lineCount": 192,
+    "assumptions": "1 axiom: fuchs_theorem (deep complex analysis — Nevanlinna theory / Phragmén-Lindelöf — beyond current Mathlib). 0 sorries.",
+    "theoremCount": 1,
     "definitionCount": 8
   },
   "overview": {
     "historicalContext": "This problem was originally posed by Pólya in 1929. It asks about the relationship between the maximum and minimum modulus of entire functions with gap power series.\n\nA gap series f(z) = Σ aₖzⁿᵏ has many zero coefficients. The sequence (nₖ) records positions of nonzero terms. The Fabry gap condition nₖ/k → ∞ means gaps grow superlinearly.\n\nWiman (1914) proved a strong result under (nₖ₊₁ - nₖ)² > nₖ. Erdős and Macintyre (1954) weakened this to Σ 1/(nₖ₊₁ - nₖ) < ∞. Finally, Fuchs (1963) gave the complete solution for Fabry gaps.\n\nKovári (1965) extended the result to entire functions of infinite order under nₖ > k(log k)^{2+c}. The question of whether Fejér gaps (Σ 1/nₖ < ∞) suffice for arbitrary entire functions remains open.",
     "problemStatement": "Let $f(z) = \\sum_{k \\geq 1} a_k z^{n_k}$ be an entire function of finite order such that $n_k/k \\to \\infty$ (Fabry gaps).\n\nLet $M(r) = \\max_{|z|=r} |f(z)|$ and $m(r) = \\min_{|z|=r} |f(z)|$.\n\nIs it true that $\\limsup \\frac{\\log m(r)}{\\log M(r)} = 1$?\n\n**Answer**: YES (Fuchs 1963)\n\nMore precisely, for any ε > 0, log m(r) > (1-ε) log M(r) holds outside a set of logarithmic density 0.\n\n**Status**: SOLVED for finite order + Fabry gaps. OPEN for Fejér gaps.",
     "text": "For entire functions with Fabry gaps (nₖ/k → ∞), is lim sup (log m(r))/(log M(r)) = 1? YES - proved by Fuchs (1963).",
-    "proofStrategy": "We formalize the problem through several key definitions:\n\n1. **Gap conditions**: Define Fabry gaps (nₖ/k → ∞) and Fejér gaps (Σ 1/nₖ < ∞), and prove Fabry implies Fejér.\n\n2. **Entire functions of finite order**: Functions f with |f(z)| ≤ c·exp(|z|^a) for some constants c, a.\n\n3. **Modulus functions**: M(r) = max_{|z|=r} |f(z)| and m(r) = min_{|z|=r} |f(z)|.\n\n4. **Main theorems**: State Fuchs's theorem as an axiom (requires Nevanlinna theory beyond current Mathlib).\n\n5. **Historical results**: Include Wiman, Erdős-Macintyre, and Kovári theorems.\n\n6. **Open conjecture**: Formalize the remaining question about Fejér gaps.",
+    "proofStrategy": "We formalize the problem through several key definitions:\n\n1. **Gap conditions**: Define Fabry gaps (nₖ/k → ∞) and Fejér gaps (Σ 1/nₖ < ∞). These are distinct: in general neither implies the other (e.g. nₖ = k⌊log k⌋ is Fabry but not Fejér).\n\n2. **Entire functions of finite order**: Functions f with |f(z)| ≤ c·exp(|z|^a) for some constants c, a.\n\n3. **Modulus functions**: M(r) = max_{|z|=r} |f(z)| and m(r) = min_{|z|=r} |f(z)|.\n\n4. **Main theorems**: State Fuchs's theorem as an axiom (requires Nevanlinna theory beyond current Mathlib).\n\n5. **Historical results**: Include Wiman, Erdős-Macintyre, and Kovári theorems.\n\n6. **Open conjecture**: Formalize the remaining question about Fejér gaps.",
     "keyInsights": [
       "**Fabry gaps**: The condition nₖ/k → ∞ means nonzero terms become increasingly sparse. This forces the function to behave 'lacunary' - large gaps between terms.",
       "**Maximum vs Minimum modulus**: For most entire functions, m(r) can be much smaller than M(r). Gap series are special: the ratio of logarithms approaches 1.",
       "**Why logarithms?**: Wiman's original result had m(r)/M(r) → 1 under strong gaps. For weaker gaps, we only get (log m)/(log M) → 1.",
-      "**Fejér gaps**: The weaker condition Σ 1/nₖ < ∞ is conjectured to suffice. Macintyre showed this would be optimal - counterexamples exist when Σ 1/nₖ = ∞.",
+      "**Fejér gaps**: The condition Σ 1/nₖ < ∞ is conjectured to suffice for arbitrary entire functions. Macintyre showed this would be optimal - counterexamples exist when Σ 1/nₖ = ∞.",
       "**Nevanlinna theory**: Fuchs's proof uses deep results from value distribution theory, which is not yet formalized in Mathlib."
     ],
     "prerequisites": [
@@ -85,55 +85,55 @@
       "id": "gap-defs",
       "title": "Gap Series Definitions",
       "startLine": 35,
-      "endLine": 59,
+      "endLine": 55,
       "summary": "Fabry gaps (nₖ/k → ∞), Fejér gaps (Σ 1/nₖ < ∞), and their relationship.",
       "mathContext": "Fabry gaps (nₖ/k $\\to$ ∞), Fejér gaps ($\\sum$ 1/nₖ < ∞), and their relationship."
     },
     {
       "id": "finite-order",
       "title": "Entire Functions of Finite Order",
-      "startLine": 60,
-      "endLine": 75,
+      "startLine": 56,
+      "endLine": 71,
       "summary": "Definition of finite order entire functions with growth bound.",
       "mathContext": "Formal definition: Definition of finite order entire functions with growth bound."
     },
     {
       "id": "modulus",
       "title": "Maximum and Minimum Modulus",
-      "startLine": 76,
-      "endLine": 93,
+      "startLine": 72,
+      "endLine": 89,
       "summary": "M(r), m(r), and the modulus ratio log m(r)/log M(r).",
       "mathContext": "Mathematical content: M(r), m(r), and the modulus ratio log m(r)/log M(r)."
     },
     {
       "id": "fuchs",
       "title": "Fuchs's Theorem",
-      "startLine": 94,
-      "endLine": 118,
+      "startLine": 90,
+      "endLine": 114,
       "summary": "The main result solving Erdős #516 for Fabry gaps + finite order.",
       "mathContext": "Mathematical content: The main result solving Erdős #516 for Fabry gaps + finite order."
     },
     {
       "id": "historical",
       "title": "Historical Results",
-      "startLine": 119,
-      "endLine": 148,
+      "startLine": 115,
+      "endLine": 131,
       "summary": "Wiman (1914) and Erdős-Macintyre (1954) under stronger conditions.",
       "mathContext": "Mathematical content: Wiman (1914) and Erdős-Macintyre (1954) under stronger conditions."
     },
     {
       "id": "kovari",
       "title": "Kovári's Extension",
-      "startLine": 149,
-      "endLine": 168,
+      "startLine": 132,
+      "endLine": 144,
       "summary": "Extension to infinite order under nₖ > k(log k)^{2+c}.",
       "mathContext": "Mathematical content: Extension to infinite order under nₖ > k(log k)^{2+c}."
     },
     {
       "id": "open",
       "title": "The Open Conjecture",
-      "startLine": 169,
-      "endLine": 196,
+      "startLine": 145,
+      "endLine": 192,
       "summary": "Fejér gap conjecture and Macintyre's counterexample.",
       "mathContext": "Mathematical content: Fejér gap conjecture and Macintyre's counterexample."
     }
@@ -166,12 +166,12 @@
       "Topology"
     ],
     "namespace": "Erdos516",
-    "lineCount": 196,
+    "lineCount": 192,
     "axiomCount": 1,
-    "theoremCount": 2,
+    "theoremCount": 1,
     "definitionCount": 8,
     "path": "Proofs/Erdos516Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -190,5 +190,5 @@
       "description": "Related Erdős problem sharing themes: complex-analysis, entire-functions"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Removes the mathematically **false** (and unused) `fabry_implies_fejer` lemma in `Erdos516Problem.lean`, and corrects the backwards Fabry/Fejér relationship claims propagated through the gallery entry.

## Evidence

**Before**: `theorem fabry_implies_fejer` claimed Fabry gaps (nₖ/k → ∞) imply Fejér gaps (Σ 1/nₖ < ∞), justified by "nₖ/k → ∞ ⟹ nₖ > k² eventually". Both are false:
- Counterexample: nₖ = k⌊log k⌋ gives nₖ/k = ⌊log k⌋ → ∞ (Fabry holds) while Σ 1/(k⌊log k⌋) **diverges** (Fejér fails).
- The true implication is the *reverse*: for increasing nₖ, Σ 1/nₖ < ∞ ⟹ nₖ/k → ∞ (Fejér ⟹ Fabry).

The lemma was carried as a `sorry` and was **unused** — `erdos_516_solved` derives the result from the `fuchs_theorem` axiom, not from this lemma.

**After**:
- Removed the false theorem and its `sorry`.
- Corrected the Lean doc-comment, and the `proofStrategy` / `keyInsights` / two annotations in the gallery data (`meta.json`, `annotations.json`) that repeated the false "Fabry is stronger / implies Fejér" claim.
- Updated counts: `sorries` 1→0, `theoremCount` 2→1, `lineCount` 196→192; shifted section and annotation line ranges (−4).

Status stays `axiomatized` / badge `axiom` (the `fuchs_theorem` axiom remains).

Validated: gallery `annotations:build` line-range check passes for erdos-516; the Lean change is a pure deletion of an unused `sorry`-bearing theorem plus comment edits (no impact on remaining declarations).

---
Automated fix by lean-mechanic agent.