### PR TITLE
Enrich Riemann Hypothesis (riemann-hypothesis): dedupe prime-number-theorem crossRef

### DIFF
--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -335,11 +335,6 @@
       "targetId": "fundamental-theorem-algebra",
       "relationship": "foundational",
       "description": "FTA proves every polynomial splits over C; the Hadamard product formula for entire functions generalizes this to the Riemann zeta function, expressing zeta(s) as a product over its non-trivial zeros — the zeros that RH asks about living on the critical line Re(s)=1/2"
-    },
-    {
-      "targetId": "prime-number-theorem",
-      "relationship": "strengthens",
-      "description": "PNT gives pi(x) ~ x/ln(x); RH would sharpen the error term to the optimal O(sqrt(x) * log(x)), connecting the distribution of primes to the positions of zeta zeros on the critical line"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Defect

The `crossReferences` array in `riemann-hypothesis/meta.json` linked `prime-number-theorem` **twice**:
- **idx 2** — `extends`: "RH implies the strongest form of PNT: π(x) = Li(x) + O(√x log x)..." (precise LaTeX)
- **idx 17** — `strengthens`: "PNT gives pi(x) ~ x/ln(x); RH would sharpen the error term to the optimal O(sqrt(x) * log(x))..." (ASCII restatement of the same error-term point)

This renders two gallery cards pointing at the same proof page. The `strengthens` entry adds no information the `extends` entry doesn't already carry (both assert RH sharpens the PNT error term to O(√x log x)).

## Fix

Removed the redundant idx-17 duplicate, keeping the more precise `extends` entry. crossReferences: **18 → 17**, now all targeting distinct proofs.

Verifiable: `jq '[.crossReferences[].targetId] | length == (unique | length)' meta.json` → `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)