### PR TITLE
Enrich Erdős #191 axiom-elimination (erdos-191-incomplete-01): 5th keyInsight on divergence rate

### DIFF
--- a/src/data/proofs/erdos-191-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-191-incomplete-01/meta.json
@@ -50,7 +50,8 @@
       "**Not every axiom in a solved-problem file is deep.** Three of erdos-191's axioms encode genuine research theorems (Rödl, Conlon–Fox–Sudakov); tripleLog_unbounded merely says a triple logarithm diverges — provable in a few lines.",
       "**Divergence composes.** log preserves atTop, so any finite tower log(log(…log n…)) diverges; the proof is just `Real.tendsto_log_atTop.comp` applied threefold over the cast.",
       "**Tendsto ⇒ ε–N.** The filter statement Tendsto f atTop atTop is strictly stronger than and immediately yields the quantifier form ∀ M ∃ N ∀ n ≥ N, f n > M, so the axiom is fully discharged.",
-      "**Axiom reduction is real progress.** Replacing tripleLog_unbounded by a theorem lowers the genuine assumption count of erdos-191 from 4 to 3, leaving only the deep results assumed."
+      "**Axiom reduction is real progress.** Replacing tripleLog_unbounded by a theorem lowers the genuine assumption count of erdos-191 from 4 to 3, leaving only the deep results assumed.",
+      "**Divergence, but astronomically slow.** The Tendsto proof is qualitative: it certifies tripleLog n → ∞ without any rate. Quantitatively the threshold is a tower — log(log(log n)) > M ⟺ n > exp(exp(exp M)) — so the N guaranteed by tripleLog_unbounded grows like a triple exponential in M. This is exactly why the parent's Θ(log log log n) bound, though unbounded, is so weak: reaching ∑ 1/log x ≥ M over {2,…,n} needs n triply-exponential in M."
     ]
   },
   "sections": [


### PR DESCRIPTION
## Enrichment pass

Adds one substantive `keyInsight` to `erdos-191-incomplete-01`, the entry that discharges the elementary `tripleLog_unbounded` axiom (log log log n → ∞) from the parent erdos-191 formalization.

### What changed
- **New keyInsight (4→5):** the `Tendsto` proof is purely *qualitative* — it certifies divergence with no rate. Quantitatively `log(log(log n)) > M ⟺ n > exp(exp(exp M))`, so the `N` guaranteed by `tripleLog_unbounded` is a **triple-exponential tower in M**. This explains why the parent's Θ(log log log n) bound, though unbounded, is so weak, and it complements the existing openQuestion asking for an explicit N(M).

### Why this and nothing more
The entry already meets every quality minimum (4 annotations covering the full 62-line file, complete conclusion, 4 crossRefs, adequate historicalContext). The enrichment scorer's remaining gap was keyInsights (4/5); rather than pad annotations onto trivial `namespace`/`open` lines (which would game the scorer), this adds the single genuinely new mathematical point the entry was missing — the divergence *rate*.

meta.json grows 9.8 → 10.3 KB, comfortably under all size caps.