### PR TITLE
research(bertrands-postulate-oq-05): a large prime factor of n! and non-squareness of factorials [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BertrandsPostulateOQ05.lean
+++ b/proofs/Proofs/BertrandsPostulateOQ05.lean
@@ -1,0 +1,112 @@
+import Mathlib.NumberTheory.Bertrand
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Data.Nat.Log
+import Mathlib.Tactic
+
+/-
+# Bertrand's Postulate, oq-05: A Large Prime Factor of `n!`, and the Non-Squareness of Factorials
+
+## Open question (`bertrands-postulate-oq-05`)
+
+Bertrand's postulate guarantees a prime in every interval `(m, 2m]`. Applying it to
+`m = ⌊n/2⌋` produces a prime `p` with `n/2 < p ≤ n`. Two structural facts follow, and
+together they upgrade Bertrand from an *existence-of-primes* statement into a statement
+about the arithmetic of the factorial itself:
+
+* **A large prime factor.** Since `p ≤ n`, the prime divides `n!`. So every `n ≥ 2`
+  satisfies `∃ prime p, n < 2p ∧ p ∣ n!` — the factorial always has a prime factor
+  exceeding `n/2`.
+
+* **The prime is *unramified* in `n!`.** Because `p ≤ n < 2p` we have `⌊n/p⌋ = 1`, and
+  because `p² > n` every higher Legendre term `⌊n/pᵏ⌋` (`k ≥ 2`) vanishes. Hence
+  Legendre's formula gives the exact `p`-adic valuation `vₚ(n!) = 1`: the prime divides
+  `n!` but `p²` does not.
+
+* **`n!` is never a perfect square for `n ≥ 2`.** If `n! = k²`, the prime `p` above would
+  divide `k`, forcing `p² ∣ k² = n!` — contradicting `vₚ(n!) = 1`. This is the classical
+  Erdős-style corollary of Bertrand's postulate.
+
+Everything is assembled from Mathlib primitives: `Nat.exists_prime_lt_and_le_two_mul`
+(Bertrand), `Nat.dvd_factorial`, Legendre's theorem `padicValNat_factorial`, and
+`Nat.Prime.pow_dvd_iff_le_factorization`. Fully machine-checked; no axioms beyond
+Mathlib's foundations.
+-/
+
+namespace BertrandsPostulateOQ05
+
+open Nat
+
+/-- **Bertrand in the lower half.** For `n ≥ 2` there is a prime `p` with `n/2 < p ≤ n`,
+phrased as `n < 2p` (i.e. `p > n/2`) together with `p ≤ n`. Obtained by applying
+Bertrand's postulate to `⌊n/2⌋`. -/
+theorem exists_prime_gt_half_le {n : ℕ} (hn : 2 ≤ n) :
+    ∃ p, p.Prime ∧ n < 2 * p ∧ p ≤ n := by
+  obtain ⟨p, hp, hlt, hle⟩ := Nat.exists_prime_lt_and_le_two_mul (n / 2) (by omega)
+  -- `hlt : n / 2 < p`, `hle : p ≤ 2 * (n / 2)`; `omega` knows the floor-division facts.
+  exact ⟨p, hp, by omega, by omega⟩
+
+/-- **Legendre valuation of the large prime is exactly one.** For a prime `p` with
+`p ≤ n < 2p`, the `p`-adic valuation of `n!` equals `1`: only the first Legendre term
+`⌊n/p⌋ = 1` survives, since `p² > n`. -/
+theorem factorization_factorial_eq_one {n p : ℕ} (hp : p.Prime)
+    (h2p : n < 2 * p) (hpn : p ≤ n) : (n !).factorization p = 1 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  -- `p² > n`, so the base-`p` logarithm of `n` is below `2`.
+  have hp2 : n < p ^ 2 := by
+    have h2 : 2 ≤ p := hp.two_le
+    calc n < 2 * p := h2p
+      _ ≤ p * p := by nlinarith
+      _ = p ^ 2 := (pow_two p).symm
+  have hlog : Nat.log p n < 2 :=
+    (Nat.log_lt_iff_lt_pow hp.one_lt (by have := hp.pos; omega)).2 hp2
+  -- Legendre's formula collapses to the single term `⌊n / p⌋ = 1`.
+  rw [Nat.factorization_def _ hp, padicValNat_factorial hlog]
+  have hset : (Finset.Ico 1 2) = {1} := by decide
+  rw [hset, Finset.sum_singleton, pow_one]
+  exact Nat.div_eq_of_lt_le (by omega) (by omega)
+
+/-- The large prime `p` from Bertrand appears in `n!` **to the first power only**:
+`p² ∤ n!`. Immediate from `vₚ(n!) = 1`. -/
+theorem not_prime_sq_dvd_factorial {n p : ℕ} (hp : p.Prime)
+    (h2p : n < 2 * p) (hpn : p ≤ n) : ¬ p ^ 2 ∣ n ! := by
+  rw [Nat.Prime.pow_dvd_iff_le_factorization hp (Nat.factorial_ne_zero n),
+      factorization_factorial_eq_one hp h2p hpn]
+  omega
+
+/-- **A prime factor exceeding `n/2`.** Every factorial `n!` with `n ≥ 2` has a prime
+factor `p` with `n < 2p`, equivalently `p > n/2`. -/
+theorem exists_large_prime_factor {n : ℕ} (hn : 2 ≤ n) :
+    ∃ p, p.Prime ∧ n < 2 * p ∧ p ∣ n ! := by
+  obtain ⟨p, hp, h2p, hpn⟩ := exists_prime_gt_half_le hn
+  exact ⟨p, hp, h2p, Nat.dvd_factorial hp.pos hpn⟩
+
+/-- **`n!` is never a perfect square for `n ≥ 2`.** The Bertrand prime `p` with
+`n/2 < p ≤ n` divides `n!` exactly once, so `n!` cannot be a square. -/
+theorem factorial_not_isSquare {n : ℕ} (hn : 2 ≤ n) : ¬ IsSquare (n !) := by
+  obtain ⟨p, hp, h2p, hpn⟩ := exists_prime_gt_half_le hn
+  have hdvd : p ∣ n ! := Nat.dvd_factorial hp.pos hpn
+  have hnsq : ¬ p ^ 2 ∣ n ! := not_prime_sq_dvd_factorial hp h2p hpn
+  rintro ⟨k, hk⟩
+  -- `hk : n ! = k * k`.
+  apply hnsq
+  have hpk : p ∣ k := by
+    have hmul : p ∣ k * k := hk ▸ hdvd
+    rcases (hp.dvd_mul).1 hmul with h | h <;> exact h
+  rw [hk, pow_two]
+  exact mul_dvd_mul hpk hpk
+
+/-- **Capstone.** For every `n ≥ 2` there is a prime `p` with `n < 2p` that divides `n!`
+exactly once (`p ∣ n!` but `p² ∤ n!`); consequently `n!` is not a perfect square. -/
+theorem bertrand_factorial_summary {n : ℕ} (hn : 2 ≤ n) :
+    (∃ p, p.Prime ∧ n < 2 * p ∧ p ∣ n ! ∧ ¬ p ^ 2 ∣ n !) ∧ ¬ IsSquare (n !) := by
+  obtain ⟨p, hp, h2p, hpn⟩ := exists_prime_gt_half_le hn
+  refine ⟨⟨p, hp, h2p, Nat.dvd_factorial hp.pos hpn,
+    not_prime_sq_dvd_factorial hp h2p hpn⟩, factorial_not_isSquare hn⟩
+
+-- Sanity checks on small factorials.
+example : ¬ IsSquare (5 !) := factorial_not_isSquare (by norm_num)
+example : ¬ IsSquare (10 !) := factorial_not_isSquare (by norm_num)
+
+end BertrandsPostulateOQ05

--- a/src/data/proofs/bertrands-postulate-oq-05/annotations.json
+++ b/src/data/proofs/bertrands-postulate-oq-05/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-bp-oq05-01-header",
+    "proofId": "bertrands-postulate-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "concept",
+    "title": "From Bertrand's Postulate to the Arithmetic of n!",
+    "content": "The file imports the targeted Mathlib modules (Bertrand, PadicVal, Factorization, Log, Tactic) and works in ℕ (open Nat). The header lays out the plan: apply Bertrand's postulate at ⌊n/2⌋ to obtain a prime p with n/2 < p ≤ n, then extract two consequences — p divides n! exactly once (v_p(n!) = 1), so n! has a prime factor exceeding n/2 and n! is never a perfect square for n ≥ 2. Everything is assembled from Mathlib primitives with no axioms and no sorries.",
+    "mathContext": "Bertrand: a prime lies in $(m, 2m]$ for every $m \\geq 1$. Taken at $m = \\lfloor n/2 \\rfloor$, the prime lands in $(n/2, n]$ — the window where it both divides $n!$ and appears unramified.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bertrand's postulate",
+      "Legendre's formula",
+      "p-adic valuation",
+      "perfect squares"
+    ],
+    "prerequisites": [
+      "prime number theory",
+      "factorials",
+      "Lean 4 Mathlib"
+    ]
+  },
+  {
+    "id": "ann-bp-oq05-02-half",
+    "proofId": "bertrands-postulate-oq-05",
+    "range": {
+      "startLine": 44,
+      "endLine": 48
+    },
+    "type": "theorem",
+    "title": "exists_prime_gt_half_le: a Prime Strictly Above n/2",
+    "content": "Applies Nat.exists_prime_lt_and_le_two_mul to ⌊n/2⌋ (nonzero since n ≥ 2), yielding a prime p with ⌊n/2⌋ < p ≤ 2⌊n/2⌋. The tactic omega discharges both repackaged inequalities: n < 2p (from ⌊n/2⌋ < p, using n ≤ 2⌊n/2⌋+1) and p ≤ n (from p ≤ 2⌊n/2⌋ ≤ n). omega natively understands floor division by the literal 2.",
+    "mathContext": "The conclusion $n < 2p \\wedge p \\leq n$ is exactly $n/2 < p \\leq n$; the first half will give the valuation bound, the second half divisibility.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bertrand's postulate",
+      "floor division",
+      "omega"
+    ],
+    "prerequisites": [
+      "Nat.exists_prime_lt_and_le_two_mul"
+    ]
+  },
+  {
+    "id": "ann-bp-oq05-03-valuation",
+    "proofId": "bertrands-postulate-oq-05",
+    "range": {
+      "startLine": 53,
+      "endLine": 70
+    },
+    "type": "theorem",
+    "title": "factorization_factorial_eq_one: Legendre's Sum Collapses to 1",
+    "content": "The mathematical core. First p² > n is established from p ≥ 2 and n < 2p (p² ≥ 2p > n) via a short calc + nlinarith. This gives log_p n < 2 through Nat.log_lt_iff_lt_pow. Rewriting (n!).factorization p with Nat.factorization_def and Legendre's padicValNat_factorial turns the goal into a sum over Finset.Ico 1 2; that set is {1} (by decide), so the sum is the single term n/p^1 = n/p, evaluated to 1 by Nat.div_eq_of_lt_le since p ≤ n < 2p.",
+    "mathContext": "Legendre: $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$. With $p^2 > n$ every term $i \\geq 2$ vanishes, leaving $\\lfloor n/p \\rfloor = 1$, so $v_p(n!) = 1$ exactly.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Legendre's formula",
+      "p-adic valuation of factorial",
+      "Nat.log",
+      "floor division"
+    ],
+    "prerequisites": [
+      "padicValNat_factorial",
+      "Nat.factorization_def",
+      "Nat.log_lt_iff_lt_pow",
+      "Nat.div_eq_of_lt_le"
+    ]
+  },
+  {
+    "id": "ann-bp-oq05-04-unramified",
+    "proofId": "bertrands-postulate-oq-05",
+    "range": {
+      "startLine": 72,
+      "endLine": 76
+    },
+    "type": "theorem",
+    "title": "not_prime_sq_dvd_factorial: p² ∤ n!",
+    "content": "Reads the valuation off as a divisibility statement. Nat.Prime.pow_dvd_iff_le_factorization rewrites p² ∣ n! to 2 ≤ (n!).factorization p; substituting the previous lemma's value 1 leaves the false goal 2 ≤ 1, closed by omega.",
+    "mathContext": "$p^k \\mid m \\iff k \\leq v_p(m)$; with $v_p(n!) = 1$, the prime $p$ divides $n!$ but $p^2$ does not.",
+    "significance": "key",
+    "relatedConcepts": [
+      "p-adic valuation",
+      "prime power divisibility"
+    ],
+    "prerequisites": [
+      "Nat.Prime.pow_dvd_iff_le_factorization",
+      "factorization_factorial_eq_one"
+    ]
+  },
+  {
+    "id": "ann-bp-oq05-05-corollaries",
+    "proofId": "bertrands-postulate-oq-05",
+    "range": {
+      "startLine": 78,
+      "endLine": 110
+    },
+    "type": "theorem",
+    "title": "Corollaries: Large Prime Factor and n! Non-Square",
+    "content": "exists_large_prime_factor pairs p ∣ n! (from Nat.dvd_factorial) with n < 2p. factorial_not_isSquare destructs IsSquare (n!) as n! = k·k; primality of p gives p ∣ k (via Nat.Prime.dvd_mul), so p·p ∣ k·k = n!, contradicting not_prime_sq_dvd_factorial. bertrand_factorial_summary bundles the unramified large prime factor with non-squareness, and two examples verify 5! and 10! are non-squares.",
+    "mathContext": "A perfect square has even exponent at every prime; a single prime of exponent 1 (the Bertrand prime) rules out squareness — the classical Erdős corollary of Bertrand's postulate.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "perfect square obstruction",
+      "Bertrand's postulate",
+      "Erdős"
+    ],
+    "prerequisites": [
+      "Nat.dvd_factorial",
+      "Nat.Prime.dvd_mul",
+      "mul_dvd_mul"
+    ]
+  }
+]

--- a/src/data/proofs/bertrands-postulate-oq-05/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-05/meta.json
@@ -1,0 +1,206 @@
+{
+  "id": "bertrands-postulate-oq-05",
+  "title": "A Large Prime Factor of n! — and Why Factorials Are Never Perfect Squares",
+  "slug": "bertrands-postulate-oq-05",
+  "description": "Applying Bertrand's postulate to ⌊n/2⌋ yields a prime p with n/2 < p ≤ n. Since p ≤ n it divides n!, and since p ≤ n < 2p (so ⌊n/p⌋ = 1) and p² > n, Legendre's formula pins the p-adic valuation of n! at exactly 1. That single unramified prime forces n! to have a prime factor exceeding n/2 and, as the classical Erdős corollary, makes n! a non-square for every n ≥ 2.",
+  "meta": {
+    "author": "Joseph Bertrand (1845), Pafnuty Chebyshev (1852), Paul Erdős (1932); Adrien-Marie Legendre (valuation formula, 1808)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bertrand%27s_postulate",
+    "date": "1845",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BertrandsPostulateOQ05.lean",
+    "tags": [
+      "number-theory",
+      "prime-numbers",
+      "bertrands-postulate",
+      "factorial",
+      "legendre-formula",
+      "p-adic-valuation",
+      "perfect-square",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.exists_prime_lt_and_le_two_mul",
+        "description": "Bertrand's postulate: for m ≠ 0 there is a prime p with m < p ≤ 2m",
+        "module": "Mathlib.NumberTheory.Bertrand"
+      },
+      {
+        "theorem": "Nat.dvd_factorial",
+        "description": "0 < m → m ≤ n → m ∣ n! — every positive integer at most n divides n!",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "padicValNat_factorial",
+        "description": "Legendre's theorem: v_p(n!) = Σ_{i≥1} ⌊n/p^i⌋ over Ico 1 b for any b > log_p n",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.pow_dvd_iff_le_factorization",
+        "description": "For prime p and n ≠ 0: p^k ∣ n ↔ k ≤ n.factorization p",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.log_lt_iff_lt_pow",
+        "description": "For 1 < b and y ≠ 0: log b y < x ↔ y < b^x — used to bound log_p n < 2 from n < p²",
+        "module": "Mathlib.Data.Nat.Log"
+      },
+      {
+        "theorem": "Nat.div_eq_of_lt_le",
+        "description": "k·n ≤ m < (k+1)·n → m / n = k — collapses ⌊n/p⌋ to 1",
+        "module": "Init.Data.Nat.Div.Basic"
+      }
+    ],
+    "originalContributions": [
+      "exists_prime_gt_half_le: repackages Bertrand at ⌊n/2⌋ into a prime p with n < 2p and p ≤ n (a prime strictly above n/2 and at most n) for every n ≥ 2",
+      "factorization_factorial_eq_one: proves v_p(n!) = 1 for such p by collapsing Legendre's sum to the single surviving term ⌊n/p⌋ = 1 (bounding log_p n < 2 via p² > n)",
+      "not_prime_sq_dvd_factorial: p² ∤ n! — the Bertrand prime is unramified in the factorial",
+      "exists_large_prime_factor: every n! (n ≥ 2) has a prime factor exceeding n/2",
+      "factorial_not_isSquare: n! is never a perfect square for n ≥ 2, via the p ∣ k ⇒ p² ∣ k² = n! contradiction (the classical Erdős argument)",
+      "bertrand_factorial_summary: capstone bundling the unramified large prime factor with the non-squareness conclusion"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 112,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axioms beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). No native_decide.",
+    "mathlib_version": "4.26.0",
+    "relatedProblems": [
+      {
+        "id": "bertrands-postulate",
+        "relationship": "Parent entry proving Bertrand's postulate; this OQ-05 turns the existence-of-primes statement into arithmetic facts about n!"
+      },
+      {
+        "id": "bertrands-postulate-oq-03",
+        "relationship": "Sibling: iterates Bertrand for prime-density lower bounds; this entry instead extracts a single unramified prime factor of n!"
+      }
+    ],
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Bertrand's postulate — a prime in every interval $(m, 2m]$ — was conjectured by Joseph Bertrand in 1845, verified empirically to $m = 3{,}000{,}000$, first proved by Chebyshev in 1852, and given its famous elementary proof by the 19-year-old Paul Erdős in 1932. Among Erdős's favourite applications was the observation that $n!$ is never a perfect square for $n \\geq 2$: Bertrand supplies a prime $p$ with $n/2 < p \\leq n$, this prime divides $n!$ exactly once, and a lone prime of odd exponent obstructs squareness. The exact exponent count rests on Legendre's 1808 formula $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$.",
+    "problemStatement": "Bertrand's postulate is an existence statement about primes in intervals. What does it say about the *factorial* itself? Applying it to $\\lfloor n/2 \\rfloor$ produces a prime $p$ with $n/2 < p \\leq n$. Does this prime divide $n!$? To what power? And what obstruction to squareness does it create?",
+    "proofStrategy": "Apply Mathlib's `Nat.exists_prime_lt_and_le_two_mul` to $\\lfloor n/2 \\rfloor$ to obtain a prime $p$ with $n < 2p$ and $p \\leq n$ (floor-division arithmetic discharged by `omega`). Since $p \\leq n$, `Nat.dvd_factorial` gives $p \\mid n!$. For the valuation: $p \\geq 2$ and $n < 2p$ force $p^2 > n$, hence $\\log_p n < 2$, so Legendre's formula `padicValNat_factorial` reduces to the single term $\\lfloor n/p \\rfloor$, which equals $1$ because $p \\leq n < 2p$. Thus $v_p(n!) = 1$ and $p^2 \\nmid n!$. Finally, if $n! = k^2$ then $p \\mid k^2 \\Rightarrow p \\mid k \\Rightarrow p^2 \\mid k^2 = n!$, contradicting $p^2 \\nmid n!$.",
+    "keyInsights": [
+      "Bertrand applied to ⌊n/2⌋ (not n) is what lands the prime in the half-open window (n/2, n] where it both divides n! and stays unramified",
+      "The window p ≤ n < 2p does double duty: p ≤ n gives divisibility p ∣ n!, while n < 2p gives ⌊n/p⌋ = 1 (valuation exactly one)",
+      "p² > n follows from p ≥ 2 and n < 2p (p² ≥ 2p > n), which kills every higher Legendre term and pins v_p(n!) = 1",
+      "A single prime of exponent 1 is enough to rule out squareness — no need to analyse the full factorization of n!",
+      "The non-squareness proof never computes the valuation as a number in the final step: it only needs the qualitative p ∣ n! ∧ p² ∤ n!"
+    ],
+    "prerequisites": [
+      "Bertrand's postulate",
+      "Legendre's formula for the p-adic valuation of a factorial",
+      "prime factorization and p-adic valuation in ℕ",
+      "perfect squares and even exponents"
+    ],
+    "text": "A 112-line, fully verified (0 sorries, 0 axioms) formalization that upgrades Bertrand's postulate from an existence-of-primes statement into two arithmetic facts about the factorial. `exists_prime_gt_half_le` applies Bertrand at ⌊n/2⌋ to produce a prime p with n < 2p and p ≤ n. `factorization_factorial_eq_one` computes the exact p-adic valuation v_p(n!) = 1 by collapsing Legendre's sum to its single surviving term. `not_prime_sq_dvd_factorial` reads off p² ∤ n!. Two headline corollaries follow: `exists_large_prime_factor` (every n! with n ≥ 2 has a prime factor exceeding n/2) and `factorial_not_isSquare` (n! is never a perfect square for n ≥ 2). A capstone `bertrand_factorial_summary` bundles the unramified large prime factor with the non-squareness conclusion."
+  },
+  "sections": [
+    {
+      "id": "sec-bertrand-half",
+      "title": "Bertrand in the Lower Half: a Prime in (n/2, n]",
+      "startLine": 41,
+      "endLine": 48,
+      "summary": "Applies Nat.exists_prime_lt_and_le_two_mul to ⌊n/2⌋ and repackages the result as a prime p with n < 2p and p ≤ n. The floor-division bookkeeping (n ≤ 2⌊n/2⌋+1, etc.) is fully automated by omega.",
+      "mathContext": "Bertrand gives a prime in (m, 2m]; taking m = ⌊n/2⌋ places the prime strictly above n/2 and at most n, the exact window needed for both divisibility and unramifiedness."
+    },
+    {
+      "id": "sec-valuation-one",
+      "title": "Legendre's Formula Collapses: v_p(n!) = 1",
+      "startLine": 50,
+      "endLine": 70,
+      "summary": "Shows p² > n (from p ≥ 2 and n < 2p), deduces log_p n < 2 via Nat.log_lt_iff_lt_pow, and rewrites (n!).factorization p through Nat.factorization_def and padicValNat_factorial. The Legendre sum over Ico 1 2 reduces to the single term ⌊n/p⌋, evaluated to 1 by Nat.div_eq_of_lt_le.",
+      "mathContext": "v_p(n!) = Σ_{i≥1} ⌊n/p^i⌋ = ⌊n/p⌋ + ⌊n/p²⌋ + ⋯; here ⌊n/p⌋ = 1 and every ⌊n/p^i⌋ for i ≥ 2 vanishes since p² > n."
+    },
+    {
+      "id": "sec-unramified",
+      "title": "The Bertrand Prime Is Unramified: p² ∤ n!",
+      "startLine": 72,
+      "endLine": 76,
+      "summary": "Combines the valuation with Nat.Prime.pow_dvd_iff_le_factorization: p² ∣ n! would require 2 ≤ (n!).factorization p = 1, which omega refutes.",
+      "mathContext": "p² ∣ n! ⟺ 2 ≤ v_p(n!); since v_p(n!) = 1 the prime divides n! to the first power only."
+    },
+    {
+      "id": "sec-corollaries",
+      "title": "Corollaries: Large Prime Factor and Non-Squareness of n!",
+      "startLine": 78,
+      "endLine": 110,
+      "summary": "exists_large_prime_factor packages p ∣ n! with n < 2p. factorial_not_isSquare argues that n! = k² would give p ∣ k hence p² ∣ k² = n!, contradicting p² ∤ n!. bertrand_factorial_summary bundles both, and two examples confirm 5! and 10! are non-squares.",
+      "mathContext": "A prime of odd (here unit) exponent is a squareness obstruction: perfect squares have even exponents at every prime, so a single exponent-1 prime forces non-squareness."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) formalization that promotes Bertrand's postulate into arithmetic statements about n!. The mathematical heart is factorization_factorial_eq_one: the Bertrand prime p ∈ (n/2, n] satisfies v_p(n!) = 1 exactly. From this single unramified prime follow two classical corollaries — n! always has a prime factor exceeding n/2, and n! is never a perfect square for n ≥ 2.",
+    "implications": "**Theoretical significance**: The result is the cleanest bridge from Bertrand's postulate to the multiplicative structure of factorials. The same unramified-prime idea underlies Erdős's proof that no product of consecutive integers with more than one term is a perfect power, and the observation that the squarefree part of n! is 'large'. The proof is deliberately valuation-light in its final step: it isolates exactly the qualitative fact (p ∣ n! ∧ p² ∤ n!) needed to defeat squareness, which is why it transfers verbatim to 'n! is not a perfect k-th power' once a prime of exponent coprime to k is available.",
+    "openQuestions": [
+      "Does the same window (n/2, n] furnish enough exponent-1 primes to show n! is never a non-trivial perfect power (k ≥ 2)? Bertrand alone gives one prime; a quantitative prime-counting bound would give the general statement.",
+      "Can the valuation-collapse lemma be generalized to v_p(n!) = ⌊n/p⌋ whenever p² > n (a prime in (√n, n]), giving a reusable 'unramified prime' API for factorials in Mathlib?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "extends",
+      "description": "Turns the parent's existence-of-a-prime-in-(n,2n] statement into arithmetic facts about n! by applying it at ⌊n/2⌋."
+    },
+    {
+      "targetId": "bertrands-postulate-oq-03",
+      "relationship": "related",
+      "description": "Sibling that iterates Bertrand for a logarithmic prime-density lower bound; this entry instead extracts one unramified prime factor and its squareness consequence."
+    }
+  ],
+  "references": [
+    {
+      "authors": "J. Bertrand",
+      "title": "Mémoire sur le nombre de valeurs que peut prendre une fonction",
+      "year": "1845",
+      "venue": "J. École Roy. Polytech.",
+      "note": "Original conjecture of the postulate"
+    },
+    {
+      "authors": "P. Chebyshev",
+      "title": "Mémoire sur les nombres premiers",
+      "year": "1852",
+      "venue": "J. Math. Pures Appl.",
+      "note": "First proof of Bertrand's postulate"
+    },
+    {
+      "authors": "P. Erdős",
+      "title": "Beweis eines Satzes von Tschebyschef",
+      "year": "1932",
+      "venue": "Acta Sci. Math. (Szeged)",
+      "note": "Elementary proof; the non-squareness of n! is a signature corollary"
+    },
+    {
+      "authors": "A.-M. Legendre",
+      "title": "Essai sur la théorie des nombres",
+      "year": "1808",
+      "venue": "",
+      "note": "Formula for the p-adic valuation of n!"
+    }
+  ],
+  "sorries": [],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Bertrand",
+      "Mathlib.NumberTheory.Padics.PadicVal.Basic",
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Data.Nat.Factorial.Basic",
+      "Mathlib.Data.Nat.Log",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "BertrandsPostulateOQ05",
+    "lineCount": 112,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BertrandsPostulateOQ05.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Turns **Bertrand's postulate** into two arithmetic statements about the factorial, fully machine-checked with **0 sorries and 0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`; no `native_decide`).

Applying `Nat.exists_prime_lt_and_le_two_mul` at `⌊n/2⌋` gives a prime `p` with `n < 2p` and `p ≤ n` (a prime in the window `(n/2, n]`). That single prime does double duty:

- `p ≤ n` ⟹ `p ∣ n!` (via `Nat.dvd_factorial`);
- `p ≤ n < 2p` ⟹ `⌊n/p⌋ = 1`, and `p ≥ 2, n < 2p` ⟹ `p² > n`, so **Legendre's formula** (`padicValNat_factorial`) collapses to a single term giving `v_p(n!) = 1` **exactly** — hence `p² ∤ n!`.

### Headline results
- `exists_large_prime_factor` — every `n!` with `n ≥ 2` has a prime factor exceeding `n/2`.
- `factorial_not_isSquare` — `n!` is **never a perfect square** for `n ≥ 2` (the classical Erdős corollary: `n! = k²` would force `p ∣ k`, hence `p² ∣ k² = n!`).
- `factorization_factorial_eq_one` — the mathematical core: `v_p(n!) = 1` for the Bertrand prime.
- `bertrand_factorial_summary` — capstone bundling the unramified large prime factor with non-squareness.

### Details
- **File**: `proofs/Proofs/BertrandsPostulateOQ05.lean` — 6 theorems, 112 lines, 0 defs.
- **Gallery**: `src/data/proofs/bertrands-postulate-oq-05/` (meta.json + annotations.json).
- **Not a duplicate**: the sibling `bertrands-postulate-oq-03` iterates Bertrand for prime-density bounds; this entry instead extracts one *unramified* prime and its squareness consequence. Grep confirmed no existing gallery file proves the factorial non-square result.
- **Status**: `verified` / badge `verified`. Verified against Mathlib 4.26.0; `#print axioms` on the main theorems shows only the three foundational axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)