### PR TITLE
audit(gallery): re-audit algebraic-numbers-countable-oq-05 CLEAN [queue drained 4263/4263]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -91,9 +91,9 @@
       "result": "clean"
     },
     "algebraic-numbers-countable-oq-05": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-07-01T12:27:37Z",
       "result": "clean"
     },
     "amgm-inequality": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Target**: `algebraic-numbers-countable-oq-05` — *Cantor's 1874 Height Function Proof of Algebraic Number Countability*
**Result**: CLEAN (re-audit, auditCount 2→3). Queue remains drained **4263/4263**, 0 issues / 0 critical.

### Verification
- Lean source (`Proofs/AlgebraicNumbersCountableOQ05.lean`): 0 sorry, 0 `native_decide`, 0 `admit`, 0 `axiom`, 0 `True`/`trivial` stubs (comment-stripped).
- Headline theorem `algebraic_reals_countable_via_height` is an **independent** formalization of Cantor's height-stratification argument: countability derived from `algebraic_reals_eq_iUnion_height` (proved via `IsLocalization.integerNormalization`) plus `Set.countable_iUnion` over finite height strata (each stratum finite via injection into a Fintype). Not a Mathlib countability wrapper.
- The one Mathlib-delegated theorem (`card_algebraic_reals_eq_aleph0` via `Algebraic.cardinalMk_of_countable_of_charZero`) is a secondary cardinality corollary, honestly worded, not the featured claim.
- Badge `original` + status `verified` — defensible.

Only `src/data/proofs/audit-tracker.json` is modified (auditCount bump). Deployer merges directly; no Judge review requested.

---
Discovered during autonomous gallery integrity audit.