### PR TITLE
Enrich mixed-dimension Sperner (sperner-simplicial-bridge-oq-01): merge duplicate parent crossRef

### DIFF
--- a/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
@@ -118,11 +118,7 @@
   "crossReferences": [
     {
       "targetId": "sperner-simplicial-bridge",
-      "description": "OQ-01 strictly generalises the pure pseudomanifold case to mixed-dimension complexes. `MixedPseudomanifold.of_pure` proves the embedding of pure data into the mixed framework."
-    },
-    {
-      "targetId": "sperner-simplicial-bridge",
-      "description": "The per-stratum proof is a single application of the parent's `exists_panchromatic` on the chosen stratum after packaging per-stratum `hcard`, `hpseudo`, and `hbdry`."
+      "description": "OQ-01 strictly generalises the parent's pure pseudomanifold case to mixed-dimension complexes: `MixedPseudomanifold.of_pure` embeds pure data into the mixed framework, and the per-stratum proof is a single application of the parent's `exists_panchromatic` on the chosen stratum after packaging per-stratum `hcard`, `hpseudo`, and `hbdry`."
     },
     {
       "targetId": "sperner-simplicial-instance",


### PR DESCRIPTION
## Defect

`crossReferences` listed the parent `sperner-simplicial-bridge` **twice** — both entries with no `relationship` field, differing only in description (one about `MixedPseudomanifold.of_pure`, one about the per-stratum `exists_panchromatic` application). Two gallery cards linked to the same proof page.

## Fix

Merged the two complementary descriptions into a single crossReference. **6 → 5** crossReferences, now all targeting distinct proofs. No content lost — both the `of_pure` embedding and the per-stratum application are preserved in the merged description.

Verifiable: `jq '[.crossReferences[].targetId] | length == (unique|length)' meta.json` → `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)