### PR TITLE
Enrich Erdős #101 OQ-01 (erdos-101-oq-01): merge duplicate parent crossRef

### DIFF
--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -171,12 +171,7 @@
   "crossReferences": [
     {
       "relationship": "extends",
-      "description": "OQ-01 is the central open question of the parent Erdős #101 formalisation; this file records the formal Σ₂ statement and the small-case lemmas it subsumes.",
-      "targetId": "erdos-101"
-    },
-    {
-      "relationship": "uses",
-      "description": "Reuses `PlanarPointSet`, `collinear`, `NoFiveCollinear`, `fourPointLineCount`, `improved_upper_bound`, `fourPointLineCount_lt_four` from the parent file.",
+      "description": "OQ-01 is the central open question of the parent Erdős #101 formalisation; this file records the formal Σ₂ statement and the small-case lemmas it subsumes, reusing `PlanarPointSet`, `collinear`, `NoFiveCollinear`, `fourPointLineCount`, `improved_upper_bound`, and `fourPointLineCount_lt_four` from the parent file.",
       "targetId": "erdos-101"
     }
   ],


### PR DESCRIPTION
## Defect

`crossReferences` linked the parent `erdos-101` **twice** — as `extends` (it is the parent's central open question) and as `uses` (reuses parent definitions). Both point to the same proof page, rendering duplicate cards.

## Fix

Merged the `uses` detail (reused `PlanarPointSet`, `collinear`, `NoFiveCollinear`, `fourPointLineCount`, `improved_upper_bound`, `fourPointLineCount_lt_four`) into the primary `extends` entry. **2 → 1** crossReference. No information lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)