### PR TITLE
Enrich Burnside p^a q^b (abel-ruffini-galois-extensions-oq-07): merge duplicate sibling crossRef

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -282,7 +282,7 @@
     {
       "targetId": "abel-ruffini-oq-04-oq-02-oq-03",
       "relationship": "uses",
-      "description": "Reuses the `IsPGroup → IsNilpotent → IsSolvable` chain (`pGroup_isSolvable`-style packaging) established in this gallery entry, which classifies …"
+      "description": "Reuses the `IsPGroup → IsNilpotent → IsSolvable` chain (`pGroup_isSolvable`-style packaging) established in this gallery entry. That entry is also the *quantitative* sharpness companion to this file's *qualitative* Burnside sharpness: it proves every finite group of order $< 60$ is solvable."
     },
     {
       "targetId": "abel-ruffini",
@@ -298,11 +298,6 @@
       "targetId": "abel-ruffini-galois-extensions-oq-04",
       "relationship": "complementary",
       "description": "Jordan-Hölder uniqueness theorem (sister sub-entry) provides the *uniqueness* counterpart to Burnside's *existence* statement: Burnside guarantees …"
-    },
-    {
-      "targetId": "abel-ruffini-oq-04-oq-02-oq-03",
-      "relationship": "complementary",
-      "description": "Finite groups of order $< 60$ are solvable — the *quantitative* sharpness companion to this file's *qualitative* Burnside sharpness."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Defect

`crossReferences` linked the sibling `abel-ruffini-oq-04-oq-02-oq-03` **twice** — as `uses` (reuses the `IsPGroup → IsNilpotent → IsSolvable` chain) and as `complementary` (order-<60 quantitative sharpness companion). Two cards pointed to the same proof. The `uses` description was also truncated (ended in `which classifies …`).

## Fix

Merged the quantitative-sharpness note into the primary `uses` entry and repaired the trailing `…` truncation. **6 → 5** crossReferences, all targeting distinct proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)