### PR TITLE
audit(roth-theorem): re-audit CLEAN — mathlib badge & 2 disclosed axioms verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14476,8 +14476,8 @@
       "issues": []
     },
     "roth-theorem": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-04T12:57:15Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-01T12:32:35Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Gallery Integrity Re-Audit

**Proof**: roth-theorem — *Roth's Theorem: AP-Free Sets Have Density o(1)*
**Result**: CLEAN (auditCount 1→2)

Queue is drained (4263/4263 audited, 0 issues), so this is a re-audit of a high-risk famous-name entry.

### Findings
- **Main file** `Proofs/RothTheorem.lean`: 0 axioms, 0 sorries, 42 theorems. Main result `roth_density_bound` delegates to Mathlib's `roth_3ap_theorem_nat` — **credited explicitly in `assumptions`**, so no delegation opacity. Badge `mathlib` correct (Tier B).
- **Companion** `Proofs/RothTheoremOQ02.lean`: exactly 2 axioms (`rothNumberNat_bloom_sisask`, `rothNumberNat_kelley_meka`), matching `axiomCount: 2`. Both are state-of-the-art quantitative refinements (Bloom–Sisask 2020 arXiv:2007.03528; Kelley–Meka 2023) not yet in Mathlib, fully disclosed. The single `sorry` grep hit is a docstring comment (line 42), not a real declaration.
- `status: axiomatized` + `badge: mathlib` is the honestly harder-scoped choice — no overclaim.

No integrity issues. Only the audit tracker is updated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)