### PR TITLE
research(derangements-convergence-oq-07): fixed-point convolution n! = Σ C(n,k)·D(n−k) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ07.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ07.lean
@@ -1,0 +1,121 @@
+/-
+  Derangements: the fixed-point convolution identity
+      n! = Σ_{k=0}^{n} C(n,k) · D(n−k)
+  Open question: derangements-convergence-oq-07
+
+  ## Context
+
+  The parent file `DerangementsConvergence.lean` studies the derangement numbers
+  `D(n) = numDerangements n` analytically (the ratio `D(n)/n! → 1/e`).  A separate,
+  purely combinatorial fact underlies the whole subject: the number of permutations
+  of an `n`-element set, sorted by the *size of their fixed-point set*, reconstructs
+  `n!` as a binomial convolution with the derangement numbers.
+
+  ## What this file adds
+
+  We prove, for any finite type `α` (and hence for `Fin n`), the **fixed-point
+  convolution identity**
+
+      |α|! = Σ_{k=0}^{|α|} C(|α|, k) · D(|α| − k).
+
+  The proof is the classical bijective one, made fully formal:
+
+  * `card_fixedPointFinset_fiber` — permutations whose set of fixed points is exactly
+    a given subset `S` are in bijection with the derangements of the complement of `S`,
+    so there are `D(|α| − |S|)` of them.  This is obtained from Mathlib's
+    `derangements.subtypeEquiv`.
+  * `card_perm_eq_sum_choose_mul_numDerangements` — summing the fibers over all subsets
+    `S`, grouped by `|S| = k` (there are `C(|α|, k)` such subsets), and using
+    `Fintype.card_perm` for the left-hand side, yields the identity.
+  * `factorial_eq_sum_choose_mul_numDerangements` — the specialization to `α = Fin n`,
+    stated purely in terms of `n : ℕ`.
+
+  Mathlib contains the analytic and recursive theory of `numDerangements`
+  (`numDerangements_sum`, the `D(n)/n! → 1/e` limit) but **not** this convolution
+  identity, so it is a genuine addition rather than a wrapper.
+
+  ## Main results
+  - `card_fixedPointFinset_fiber`                    : fiber count = `D(|α| − |S|)`
+  - `card_perm_eq_sum_choose_mul_numDerangements`    : `|α|! = Σ C(|α|,k)·D(|α|−k)`
+  - `factorial_eq_sum_choose_mul_numDerangements`    : `n! = Σ_{k≤n} C(n,k)·D(n−k)`
+-/
+import Mathlib.Combinatorics.Derangements.Finite
+import Mathlib.Combinatorics.Derangements.Basic
+import Mathlib.Tactic
+
+open Equiv Function Finset Nat
+open scoped BigOperators
+
+namespace DerangementsConvolution
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-- Permutations of `α` whose set of fixed points is **exactly** `S` are in bijection
+with the derangements of the complement of `S`.  Hence there are
+`numDerangements (|α| − |S|)` of them. -/
+theorem card_fixedPointFinset_fiber (S : Finset α) :
+    (univ.filter (fun σ : Perm α => univ.filter (fun x => σ x = x) = S)).card
+      = numDerangements (Fintype.card α - S.card) := by
+  classical
+  -- Rewrite the filter-cardinality as the cardinality of a subtype.
+  have hb : (univ.filter (fun σ : Perm α => univ.filter (fun x => σ x = x) = S)).card
+      = Fintype.card {σ : Perm α // univ.filter (fun x => σ x = x) = S} := by
+    simp [Fintype.card_subtype]
+  -- The subtype `{σ // fixedFinset σ = S}` matches the RHS of `derangements.subtypeEquiv`
+  -- with predicate `(· ∉ S)`.
+  have e1 : {σ : Perm α // univ.filter (fun x => σ x = x) = S}
+      ≃ {σ : Perm α // ∀ a, ¬ (a ∉ S) ↔ a ∈ fixedPoints σ} :=
+    Equiv.subtypeEquivRight (fun σ => by
+      rw [Finset.ext_iff]
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and, not_not,
+        Function.mem_fixedPoints, Function.IsFixedPt]
+      exact ⟨fun h a => (h a).symm, fun h a => (h a).symm⟩)
+  have e2 : derangements (Subtype (fun a : α => a ∉ S))
+      ≃ {σ : Perm α // ∀ a, ¬ (a ∉ S) ↔ a ∈ fixedPoints σ} :=
+    derangements.subtypeEquiv (fun a : α => a ∉ S)
+  rw [hb, Fintype.card_congr e1, ← Fintype.card_congr e2,
+    card_derangements_eq_numDerangements, Fintype.card_subtype_compl, Fintype.card_coe]
+
+/-- **Fixed-point convolution identity.**  For any finite type `α`,
+`|α|! = Σ_{k=0}^{|α|} C(|α|, k) · D(|α| − k)`, where `D = numDerangements`.
+
+Both sides count `Perm α`: the left by `Fintype.card_perm`, the right by partitioning
+permutations according to the size `k` of their fixed-point set (there are `C(|α|, k)`
+choices of that set, and the remaining `|α| − k` points are deranged). -/
+theorem card_perm_eq_sum_choose_mul_numDerangements :
+    (Fintype.card α)! =
+      ∑ k ∈ range (Fintype.card α + 1),
+        (Fintype.card α).choose k * numDerangements (Fintype.card α - k) := by
+  classical
+  -- Left side is the number of permutations of `α`.
+  rw [← Fintype.card_perm, ← Finset.card_univ]
+  -- Partition permutations by their fixed-point finset.
+  rw [Finset.card_eq_sum_card_fiberwise
+        (t := (univ : Finset α).powerset)
+        (f := fun σ : Perm α => univ.filter (fun x => σ x = x))
+        (fun σ _ => Finset.mem_powerset.mpr (Finset.subset_univ _))]
+  -- Each fiber has `D(|α| − |S|)` elements.
+  rw [Finset.sum_congr rfl (fun S _ => card_fixedPointFinset_fiber S)]
+  -- Group subsets `S` of `univ` by their cardinality `k`.
+  rw [Finset.powerset_card_disjiUnion, Finset.sum_disjiUnion, Finset.card_univ]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  -- Inside the block of `k`-subsets, `|S| = i` is constant.
+  rw [Finset.sum_congr rfl (fun S hS => by rw [(Finset.mem_powersetCard.mp hS).2] :
+        ∀ S ∈ powersetCard i univ,
+          numDerangements (Fintype.card α - S.card)
+            = numDerangements (Fintype.card α - i))]
+  rw [Finset.sum_const, Finset.card_powersetCard, Finset.card_univ, smul_eq_mul]
+
+/-- **Fixed-point convolution identity over `ℕ`.**  For every `n`,
+`n! = Σ_{k=0}^{n} C(n, k) · D(n − k)`. -/
+theorem factorial_eq_sum_choose_mul_numDerangements (n : ℕ) :
+    n ! = ∑ k ∈ range (n + 1), n.choose k * numDerangements (n - k) := by
+  have h := card_perm_eq_sum_choose_mul_numDerangements (α := Fin n)
+  simpa [Fintype.card_fin] using h
+
+/-- Concrete instance `4! = 24 = 9 + 8 + 6 + 0 + 1`. -/
+example :
+    (4 : ℕ)! = ∑ k ∈ range 5, (4).choose k * numDerangements (4 - k) :=
+  factorial_eq_sum_choose_mul_numDerangements 4
+
+end DerangementsConvolution

--- a/src/data/proofs/derangements-convergence-oq-07/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-07/annotations.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "ann-dcoq07-header",
+    "proofId": "derangements-convergence-oq-07",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "concept",
+    "title": "Module Overview: The Fixed-Point Convolution Identity",
+    "content": "This module proves the classical binomial convolution n! = Σ_{k=0}^{n} C(n,k)·D(n−k), where D = numDerangements. Both sides count the permutations of an n-element set: the left directly, the right by sorting permutations by the size k of their fixed-point set. The docstring lays out the three-step bijective proof and notes that Mathlib records the analytic theory of numDerangements (the D(n)/n! → 1/e limit, numDerangements_sum) but not this convolution, so the file is a genuine addition rather than a wrapper. Imports are narrow — only Mathlib.Combinatorics.Derangements.Finite/Basic and Mathlib.Tactic — with opens Equiv, Function, Finset, Nat (the last brings the `!` factorial notation and numDerangements into scope).",
+    "mathContext": "The identity is the exact finite counterpart of the asymptotic $D(n)/n! \\to e^{-1}$. In exponential-generating-function form it is the coefficient extraction from $\\frac{1}{1-x} = e^x \\cdot \\frac{e^{-x}}{1-x}$: the EGF of $n!$ factors as (EGF of the all-ones sequence) × (EGF $\\sum_n D(n)x^n/n! = e^{-x}/(1-x)$ of the derangement numbers).",
+    "significance": "key",
+    "relatedConcepts": [
+      "numDerangements",
+      "binomial convolution",
+      "exponential generating functions",
+      "fixed points of a permutation",
+      "derangements.subtypeEquiv"
+    ],
+    "prerequisites": [
+      "Mathlib.Combinatorics.Derangements (Basic and Finite)",
+      "Fintype.card_perm: |Perm α| = |α|!",
+      "Finset powerset / powersetCard API"
+    ]
+  },
+  {
+    "id": "ann-dcoq07-fiber",
+    "proofId": "derangements-convergence-oq-07",
+    "range": { "startLine": 53, "endLine": 77 },
+    "type": "theorem",
+    "title": "Fiber Count: Permutations With a Prescribed Fixed-Point Set",
+    "content": "card_fixedPointFinset_fiber shows that the permutations σ of α whose fixed-point set is exactly S number numDerangements(|α| − |S|). The proof first rewrites the filter-cardinality as the cardinality of the subtype {σ // fixedFinset σ = S} (via Fintype.card_subtype). It then transports along Equiv.subtypeEquivRight to the predicate form '∀ a, ¬(a ∉ S) ↔ a ∈ fixedPoints σ', matching the shape of Mathlib's derangements.subtypeEquiv (· ∉ S). The double-negation bridge ¬(a ∉ S) ↔ a ∈ S is discharged by a pointwise Finset.ext_iff rewrite. Finally card_derangements_eq_numDerangements, Fintype.card_subtype_compl and Fintype.card_coe turn the derangement subtype count into numDerangements(|α| − |S|).",
+    "mathContext": "A permutation fixing exactly the points of $S$ acts on the complement $\\alpha \\setminus S$ (of size $|\\alpha| - |S|$) with no fixed points — i.e. as a derangement of the complement. Mathlib's `derangements.subtypeEquiv p` realizes precisely this bijection for the predicate $p = (\\cdot \\notin S)$, so the fiber size is $D(|\\alpha| - |S|)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "derangements.subtypeEquiv",
+      "Equiv.subtypeEquivRight",
+      "card_derangements_eq_numDerangements",
+      "Fintype.card_subtype_compl",
+      "fixedPoints"
+    ],
+    "prerequisites": [
+      "The equivalence derangements.subtypeEquiv from Mathlib",
+      "Fintype.card_subtype and Fintype.card_congr",
+      "Function.mem_fixedPoints / IsFixedPt"
+    ]
+  },
+  {
+    "id": "ann-dcoq07-convolution",
+    "proofId": "derangements-convergence-oq-07",
+    "range": { "startLine": 79, "endLine": 107 },
+    "type": "theorem",
+    "title": "The Convolution Identity Over a Finite Type",
+    "content": "card_perm_eq_sum_choose_mul_numDerangements assembles the fibers into |α|! = Σ_{k=0}^{|α|} C(|α|,k)·D(|α|−k). It rewrites |α|! = |Perm α| = |univ| (Fintype.card_perm), then partitions Perm α by the fixed-point-set map using Finset.card_eq_sum_card_fiberwise over the powerset of univ. Substituting the per-fiber count card_fixedPointFinset_fiber gives Σ_{S ⊆ univ} D(|α|−|S|). Regrouping the powerset by cardinality with powerset_card_disjiUnion + sum_disjiUnion turns this into a double sum over sizes k; on each k-block the derangement factor D(|α|−k) is constant (since |S| = k there), so Finset.sum_const + card_powersetCard collapse the block to C(|α|,k)·D(|α|−k).",
+    "mathContext": "This is double counting of $\\mathrm{Perm}\\,\\alpha$: the left side by $|\\mathrm{Perm}\\,\\alpha| = |\\alpha|!$, the right by summing the $D(|\\alpha|-k)$ permutations with a given $k$-element fixed set over the $\\binom{|\\alpha|}{k}$ choices of that set. The regrouping $\\sum_{S \\subseteq \\mathrm{univ}} = \\sum_k \\sum_{|S|=k}$ is exactly the disjoint-union decomposition of the powerset into its cardinality strata.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.card_eq_sum_card_fiberwise",
+      "Finset.powerset_card_disjiUnion",
+      "Finset.card_powersetCard",
+      "Fintype.card_perm",
+      "double counting"
+    ],
+    "prerequisites": [
+      "Fiberwise cardinality partition of a Finset",
+      "powersetCard and its cardinality C(n,k)",
+      "The fiber-count lemma card_fixedPointFinset_fiber"
+    ]
+  },
+  {
+    "id": "ann-dcoq07-nat",
+    "proofId": "derangements-convergence-oq-07",
+    "range": { "startLine": 109, "endLine": 121 },
+    "type": "theorem",
+    "title": "ℕ Specialization and Concrete Instance",
+    "content": "factorial_eq_sum_choose_mul_numDerangements specializes the finite-type identity to α = Fin n, giving n! = Σ_{k∈range(n+1)} C(n,k)·D(n−k) purely over ℕ; the reduction is a single simpa with Fintype.card_fin. A concrete example checks the identity at n = 4: 4! = 24 = C(4,0)·9 + C(4,1)·2 + C(4,2)·1 + C(4,3)·0 + C(4,4)·1 = 9 + 8 + 6 + 0 + 1, exercising the statement on a nontrivial instance (D(4)=9, D(3)=2, D(2)=1, D(1)=0, D(0)=1).",
+    "mathContext": "Instantiating the abstract statement at the canonical $n$-element type $\\mathrm{Fin}\\,n$ yields the familiar number-theoretic identity. The concrete $n=4$ check confirms the convolution numerically and doubles as a regression test on the derangement values.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Fintype.card_fin",
+      "numDerangements small values",
+      "Nat.choose"
+    ],
+    "prerequisites": [
+      "The finite-type convolution card_perm_eq_sum_choose_mul_numDerangements",
+      "Fintype.card_fin: |Fin n| = n"
+    ]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-07/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-07/meta.json
@@ -1,0 +1,224 @@
+{
+  "id": "derangements-convergence-oq-07",
+  "title": "Fixed-point convolution identity: n! = Σ C(n,k)·D(n−k)",
+  "slug": "derangements-convergence-oq-07",
+  "description": "Proves the classical fixed-point convolution identity n! = Σ_{k=0}^{n} C(n,k)·D(n−k), where D = numDerangements. Both sides count the permutations of an n-element set; the right side partitions them by the size k of their fixed-point set (choose the fixed set in C(n,k) ways, derange the remaining n−k points). The bijective heart is that permutations with fixed-point set exactly S correspond to derangements of the complement of S, extracted from Mathlib's derangements.subtypeEquiv. Mathlib records the analytic theory of numDerangements (the D(n)/n! → 1/e limit and the recurrence numDerangements_sum) but not this convolution, so it is a genuine addition rather than a wrapper.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ07.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "permutations",
+      "binomial-convolution",
+      "bijective-proof",
+      "fixed-points",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. The theorem is fully machine-checked (0 sorries, 0 axioms). The fiber count delegates to Mathlib's derangements.subtypeEquiv (permutations with a prescribed fixed-point set biject with derangements of the complement) and card_derangements_eq_numDerangements; the summation uses Finset.card_eq_sum_card_fiberwise and powerset_card_disjiUnion.",
+    "dateAdded": "2026-07-01",
+    "lineCount": 121,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "card_fixedPointFinset_fiber (PROVED): permutations of α whose fixed-point set is exactly S number numDerangements(|α| − |S|), via derangements.subtypeEquiv with predicate (· ∉ S)",
+      "card_perm_eq_sum_choose_mul_numDerangements (PROVED): |α|! = Σ_{k=0}^{|α|} C(|α|,k)·D(|α|−k) by fiberwise partition of Perm α over the fixed-point-set map, regrouped by cardinality",
+      "factorial_eq_sum_choose_mul_numDerangements (PROVED): the ℕ specialization n! = Σ_{k=0}^{n} C(n,k)·D(n−k), obtained from the α = Fin n instance via Fintype.card_fin"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "derangements.subtypeEquiv",
+        "description": "Permutations σ with (∀ a, ¬p a ↔ a ∈ fixedPoints σ) biject with derangements of the subtype {a // p a}; used with p = (· ∉ S)",
+        "module": "Mathlib.Combinatorics.Derangements.Basic"
+      },
+      {
+        "theorem": "card_derangements_eq_numDerangements",
+        "description": "Fintype.card (derangements (Fin n)) = numDerangements n — bridges the equiv count to numDerangements",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "Finset.card_eq_sum_card_fiberwise",
+        "description": "Partitions |univ (Perm α)| as the sum over fixed-point sets S of the fiber cardinalities",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.powerset_card_disjiUnion",
+        "description": "The powerset of univ is the disjoint union over k of the k-element subsets (powersetCard k), regrouping the sum by |S| = k",
+        "module": "Mathlib.Combinatorics.SetFamily.Powerset"
+      },
+      {
+        "theorem": "Fintype.card_perm",
+        "description": "Fintype.card (Perm α) = (Fintype.card α)! — the left-hand side of the identity",
+        "module": "Mathlib.GroupTheory.Perm.Fintype"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Derangements — permutations with no fixed points — were first analyzed by Pierre de Montmort (1708) in his study of the card game 'Jeu du Treize' and independently by Euler (1751). The convolution identity n! = Σ_{k=0}^{n} C(n,k)·D(n−k) is the bookkeeping fact that organizes all permutations by how many points they fix: a permutation with exactly k fixed points is determined by choosing which k points are fixed (C(n,k) ways) and deranging the remaining n−k. Summing over k recovers every permutation exactly once, giving n!. Equivalently, in exponential-generating-function language this is the product identity 1/(1−x) = e^x · (e^{−x}/(1−x)), i.e. the EGF of n! is the product of the EGF of 1 (all subsets) and the EGF e^{−x}/(1−x) of the derangement numbers. The identity is the finite, exact counterpart of the analytic limit D(n)/n! → e^{−1} studied in the parent entry: it expresses n! as a binomial convolution of the derangement sequence with the constant sequence.",
+    "problemStatement": "**OQ-07 of derangements-convergence**\n\nProve the fixed-point convolution identity: for every n,\n\n  n! = Σ_{k=0}^{n} C(n,k) · D(n−k),\n\nwhere D(m) = numDerangements m is the number of fixed-point-free permutations of an m-element set. State it both for an arbitrary finite type α (|α|! = Σ C(|α|,k)·D(|α|−k)) and over ℕ.",
+    "text": "For every n : ℕ, n! = Σ_{k ∈ range (n+1)} C(n,k) · numDerangements (n−k).",
+    "proofStrategy": "**Bijective / double-counting proof in three steps:**\n1. **Fiber count** (`card_fixedPointFinset_fiber`): fix a subset S ⊆ α and count the permutations whose fixed-point set is *exactly* S. Rewrite the filter cardinality as a subtype cardinality, transport it along `Equiv.subtypeEquivRight` to the predicate form (∀ a, ¬(a ∉ S) ↔ a ∈ fixedPoints σ), then apply `derangements.subtypeEquiv (· ∉ S)` and `card_derangements_eq_numDerangements`. Since the complement of S has |α| − |S| elements, the fiber has numDerangements(|α| − |S|) permutations.\n2. **Fiberwise partition** (`card_perm_eq_sum_choose_mul_numDerangements`): write |Perm α| = |α|! via `Fintype.card_perm`, then partition Perm α by the fixed-point-set map using `Finset.card_eq_sum_card_fiberwise` over the powerset of univ. Substitute the fiber counts, regroup the powerset by cardinality with `powerset_card_disjiUnion`/`sum_disjiUnion`, and on each block (S with |S| = i, of which there are C(|α|,i)) the summand numDerangements(|α| − i) is constant; `sum_const` + `card_powersetCard` finish the block.\n3. **Specialize to ℕ** (`factorial_eq_sum_choose_mul_numDerangements`): instantiate α = Fin n and rewrite Fintype.card (Fin n) = n via `Fintype.card_fin`.",
+    "keyInsights": [
+      "The proof is a fully formal rendering of the standard bijective argument: the only genuinely combinatorial input is that permutations with a *prescribed* fixed-point set S biject with derangements of the complement — everything else is bookkeeping (fiberwise partition + regroup by cardinality).",
+      "Mathlib's `derangements.subtypeEquiv` is stated for the predicate form 'σ fixes exactly the points where ¬p holds'. Matching it to 'fixed-point finset = S' requires the double-negation bridge ¬(a ∉ S) ↔ a ∈ S, handled by `Equiv.subtypeEquivRight` with a pointwise `Finset.ext_iff` rewrite.",
+      "Regrouping Σ_{S ⊆ univ} by |S| = k is exactly `powerset_card_disjiUnion`: the powerset is the disjoint union of the powersetCard blocks. On each block the derangement factor is constant, so `Finset.sum_const` turns the inner sum into (block size) • (constant) = C(n,k) · D(n−k).",
+      "The identity is the exact finite shadow of the analytic limit D(n)/n! → 1/e proved in the parent: dividing by n! gives 1 = Σ_{k} [C(n,k)/n!]·D(n−k) = Σ_k D(n−k)/(k!(n−k)!), the partial-sum form of the e^{−x}/(1−x) generating function.",
+      "Generating-function view: the identity is the coefficient extraction from 1/(1−x) = e^x · e^{−x}/(1−x). The e^x factor is the EGF of the all-ones sequence (any subset can be the fixed set) and e^{−x}/(1−x) is the EGF of the derangement numbers; their Cauchy product is the binomial convolution proved here.",
+      "The concrete check 4! = 24 = C(4,0)·9 + C(4,1)·2 + C(4,2)·1 + C(4,3)·0 + C(4,4)·1 = 9 + 8 + 6 + 0 + 1 is included as an `example`, exercising the ℕ statement on a nontrivial instance."
+    ],
+    "prerequisites": [
+      "derangements.subtypeEquiv and card_derangements_eq_numDerangements from Mathlib.Combinatorics.Derangements",
+      "Finset.card_eq_sum_card_fiberwise for fiberwise partition of a Finset",
+      "powerset_card_disjiUnion / card_powersetCard for regrouping subsets by size",
+      "Fintype.card_perm (|Perm α| = |α|!) and Fintype.card_fin"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring stating the fixed-point convolution identity n! = Σ C(n,k)·D(n−k), the bijective proof outline, and the note that Mathlib lacks this convolution. Imports Mathlib.Combinatorics.Derangements.Finite/Basic and Mathlib.Tactic; opens Equiv, Function, Finset. Namespace DerangementsConvolution with variable {α} [Fintype α] [DecidableEq α].",
+      "mathContext": "The two Derangements imports supply `derangements.subtypeEquiv` (the fixed-set ↔ complement-derangement bijection) and `card_derangements_eq_numDerangements` (the count bridge)."
+    },
+    {
+      "id": "sec-fiber",
+      "title": "Fiber count: permutations with a prescribed fixed-point set",
+      "startLine": 53,
+      "endLine": 77,
+      "summary": "Theorem card_fixedPointFinset_fiber: the permutations σ of α with univ.filter (σ x = x) = S number numDerangements (|α| − |S|). Rewrites the filter cardinality as Fintype.card of a subtype, transports along Equiv.subtypeEquivRight to the (∀ a, ¬(a∉S) ↔ a ∈ fixedPoints σ) form, applies derangements.subtypeEquiv (· ∉ S), then card_derangements_eq_numDerangements, Fintype.card_subtype_compl, Fintype.card_coe.",
+      "mathContext": "Permutations fixing exactly S are, on the complement of S, fixed-point-free — i.e. derangements of a set of size |α| − |S|. Hence the fiber size is D(|α| − |S|)."
+    },
+    {
+      "id": "sec-convolution",
+      "title": "The convolution identity over a finite type",
+      "startLine": 79,
+      "endLine": 107,
+      "summary": "Theorem card_perm_eq_sum_choose_mul_numDerangements: |α|! = Σ_{k=0}^{|α|} C(|α|,k)·D(|α|−k). Rewrites |α|! = |Perm α| = |univ|, partitions via Finset.card_eq_sum_card_fiberwise over the powerset by the fixed-point-set map, substitutes the fiber counts, regroups by cardinality with powerset_card_disjiUnion + sum_disjiUnion, and collapses each constant block with sum_const + card_powersetCard.",
+      "mathContext": "Double counting Perm α: LHS by Fintype.card_perm, RHS by summing the D(|α|−k) fibers over the C(|α|,k) subsets of each size k."
+    },
+    {
+      "id": "sec-nat",
+      "title": "ℕ specialization and concrete instance",
+      "startLine": 109,
+      "endLine": 121,
+      "summary": "Theorem factorial_eq_sum_choose_mul_numDerangements (n : ℕ): n! = Σ_{k∈range(n+1)} C(n,k)·D(n−k), from the α = Fin n instance via Fintype.card_fin. Followed by the concrete example 4! = 24 = 9+8+6+0+1.",
+      "mathContext": "Instantiating α = Fin n turns the abstract finite-type identity into the familiar number-theoretic statement over ℕ."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "parent",
+      "description": "Parent entry: studies numDerangements analytically (D(n)/n! → 1/e). This entry supplies the exact finite convolution n! = Σ C(n,k)·D(n−k) underlying that limit."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "related",
+      "description": "Root derangements entry: D(n) = n!·Σ(−1)^k/k! and the inclusion–exclusion foundations of numDerangements."
+    },
+    {
+      "targetId": "derangements-convergence-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling: P(X_n = k) → e⁻¹/k! (Poisson(1) fixed-point marginals). The convolution here is the deterministic identity whose k-th block, divided by n!, is the finite-n fixed-point probability."
+    },
+    {
+      "targetId": "derangements-convergence-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling: the rounding characterisation D(n) = round(n!/e). Both refine the parent's D(n)/n! → 1/e limit — oq-03 with a metric bound, this entry with an exact convolution."
+    },
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "foundational",
+      "description": "numDerangements is defined via inclusion–exclusion; the convolution identity re-derives n! by summing the deranged complements over all fixed-point sets."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified (0 sorries, 0 axioms): for every finite type α and every n : ℕ, n! = Σ_{k=0}^{n} C(n,k)·numDerangements(n−k). The proof is the classical bijective one — permutations with a prescribed fixed-point set S biject with derangements of the complement — carried out with Mathlib's derangements.subtypeEquiv and a fiberwise partition of Perm α regrouped by subset cardinality.",
+    "implications": "**Exact vs. asymptotic**: the identity is the precise finite counterpart of the parent's D(n)/n! → 1/e; dividing through by n! exhibits the fixed-point distribution of a uniform random permutation as a binomial convolution.\\n\\n**Generating functions**: it is the coefficient form of 1/(1−x) = e^x · e^{−x}/(1−x), a clean instance of the exponential formula relating a structure (permutations) to its connected/derangement part.\\n\\n**Reusability**: card_fixedPointFinset_fiber is a self-contained lemma (fiber = D(|α|−|S|)) that could seed further fixed-point-statistics results, e.g. counting permutations with exactly r fixed points.",
+    "openQuestions": [
+      "Prove the exactly-r-fixed-points count as a direct corollary: the number of permutations of an n-set with exactly r fixed points is C(n,r)·D(n−r) (this is a single block of the convolution). It follows immediately from card_fixedPointFinset_fiber summed over |S| = r.",
+      "Invert the convolution: express D(n) = Σ_{k=0}^{n} (−1)^k C(n,k) (n−k)! by Möbius inversion of n! = Σ C(n,k) D(n−k), recovering the inclusion–exclusion formula for derangements from the convolution direction.",
+      "Formalize the exponential-generating-function statement Σ_n n! x^n/n! = (Σ_n x^n/n!)·(Σ_n D(n) x^n/n!) at the level of Mathlib's PowerSeries, making the 1/(1−x) = e^x·e^{−x}/(1−x) factorization explicit.",
+      "Generalize to the two-variable rencontres numbers: n! = Σ_{r} (number of permutations with exactly r fixed points), and prove Σ_r r·(#fixing r) = n! (expected number of fixed points is 1), linking to the sibling Poisson(1) entry."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "factorial_eq_sum_choose_mul_numDerangements",
+      "type": "core",
+      "description": "For every n : ℕ, n! = Σ_{k=0}^{n} C(n,k)·numDerangements(n−k)",
+      "leanType": "(n : ℕ) → n ! = ∑ k ∈ Finset.range (n + 1), n.choose k * numDerangements (n - k)"
+    },
+    {
+      "name": "card_perm_eq_sum_choose_mul_numDerangements",
+      "type": "core",
+      "description": "For any finite type α, |α|! = Σ_{k=0}^{|α|} C(|α|,k)·numDerangements(|α|−k)",
+      "leanType": "[Fintype α] [DecidableEq α] → (Fintype.card α)! = ∑ k ∈ Finset.range (Fintype.card α + 1), (Fintype.card α).choose k * numDerangements (Fintype.card α - k)"
+    },
+    {
+      "name": "card_fixedPointFinset_fiber",
+      "type": "supporting",
+      "description": "Permutations of α whose fixed-point set is exactly S number numDerangements(|α| − |S|)",
+      "leanType": "[Fintype α] [DecidableEq α] → (S : Finset α) → (univ.filter (fun σ : Perm α => univ.filter (fun x => σ x = x) = S)).card = numDerangements (Fintype.card α - S.card)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Derangements.Finite",
+      "Mathlib.Combinatorics.Derangements.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Equiv",
+      "Function",
+      "Finset"
+    ],
+    "namespace": "DerangementsConvolution",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "substantiveTheoremCount": 3,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ07.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pierre de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris: Jacque Quillau (2nd ed. 1713)",
+      "note": "First derivation of the derangement numbers via the 'Jeu du Treize'. The fixed-point convolution organizing all permutations by their number of fixed points is implicit in Montmort's rencontres analysis."
+    },
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "Probability-theoretic treatment of derangements and the limit D(n)/n! → e^{−1}, the asymptotic counterpart of the exact convolution proved here."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "venue": "Cambridge Studies in Advanced Mathematics 49, 2nd edition, §2.2",
+      "note": "Exponential-generating-function treatment: Σ D(n) x^n/n! = e^{−x}/(1−x). The identity n! = Σ C(n,k) D(n−k) is the coefficient form of 1/(1−x) = e^x · e^{−x}/(1−x)."
+    },
+    {
+      "authors": "Riordan, John",
+      "title": "An Introduction to Combinatorial Analysis",
+      "year": "1958",
+      "venue": "Wiley, Chapter 3 'Permutations with Restricted Position'",
+      "note": "Classic textbook derivation of the rencontres/derangement recurrences, including the partition of permutations by number of fixed points that gives the binomial convolution with the derangement numbers."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the classical **fixed-point convolution identity** for derangement numbers:

$$n! = \sum_{k=0}^{n} \binom{n}{k} \, D(n-k), \qquad D = \texttt{numDerangements}.$$

Both sides count the permutations of an $n$-element set. The right side partitions them by the size $k$ of their fixed-point set: choose the fixed set in $\binom{n}{k}$ ways, then derange the remaining $n-k$ points.

## What's new (Mathlib gap)

Mathlib records the *analytic* theory of `numDerangements` — the limit $D(n)/n! \to 1/e$ and the recurrence `numDerangements_sum` — but **not** this convolution. It is a genuine addition rather than a wrapper.

## Theorems (`Proofs/DerangementsConvergenceOQ07.lean`, namespace `DerangementsConvolution`)

- `card_fixedPointFinset_fiber` — permutations of `α` whose fixed-point set is *exactly* `S` number `numDerangements(|α| − |S|)`, via Mathlib's `derangements.subtypeEquiv (· ∉ S)`.
- `card_perm_eq_sum_choose_mul_numDerangements` — `|α|! = Σ C(|α|,k)·D(|α|−k)` for any finite type, by fiberwise partition of `Perm α` over the fixed-point-set map (`Finset.card_eq_sum_card_fiberwise`) regrouped by cardinality (`powerset_card_disjiUnion`).
- `factorial_eq_sum_choose_mul_numDerangements` — the `ℕ` specialization via `Fintype.card_fin`.
- Concrete `example`: `4! = 24 = C(4,0)·9 + C(4,1)·2 + C(4,2)·1 + C(4,3)·0 + C(4,4)·1 = 9+8+6+0+1`.

## Verification

- 0 sorries. `#print axioms` on both main theorems lists only `propext`, `Classical.choice`, `Quot.sound` — **0-axiom** by project convention (no `sorryAx`, no `Lean.ofReduceBool`).
- Compiled against Mathlib (toolchain `v4.26.0`); narrow imports (`Mathlib.Combinatorics.Derangements.Finite/Basic`, `Mathlib.Tactic`).
- Gallery entry added: `src/data/proofs/derangements-convergence-oq-07/{meta.json,annotations.json}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)