### PR TITLE
research(schroeder-bernstein-oq-03): prove fwdOrbit_computable [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -145,6 +145,25 @@ def fwdOrbit (f g : ℕ → ℕ) (n : ℕ) : ℕ → ℕ
   | 0 => n
   | k + 1 => g (f (fwdOrbit f g n k))
 
+/-- The forward orbit `(n, k) ↦ (g∘f)^k(n)` is computable when `f` and `g` are.
+    This discharges the "orbit structure is effective" requirement (step (d) of the
+    back-and-forth construction): the orbit is a primitive recursion in `k` whose step
+    `IH ↦ g (f IH)` is a composition of computable functions, so `Computable.nat_rec`
+    applies. Fully verified, 0 axioms — infrastructure for the hard direction. -/
+theorem fwdOrbit_computable {f g : ℕ → ℕ} (hf : Computable f) (hg : Computable g) :
+    Computable (fun nk : ℕ × ℕ => fwdOrbit f g nk.1 nk.2) := by
+  have hstep : Computable₂ (fun (_ : ℕ × ℕ) (p : ℕ × ℕ) => g (f p.2)) :=
+    (hg.comp (hf.comp (Computable.snd.comp Computable.snd))).to₂
+  have key := Computable.nat_rec (σ := ℕ) (α := ℕ × ℕ)
+    (f := fun nk : ℕ × ℕ => nk.2) (g := fun nk : ℕ × ℕ => nk.1)
+    (h := fun _ p => g (f p.2)) Computable.snd Computable.fst hstep
+  refine key.of_eq ?_
+  rintro ⟨n, k⟩
+  simp only
+  induction k with
+  | zero => rfl
+  | succ k ih => simp only [fwdOrbit, ih]
+
 /-- The back-and-forth strategy: an element n is "f-type" if its backward chain
     under alternating g⁻¹, f⁻¹ terminates outside range(g) (i.e., not a g-image).
     These are exactly the elements where σ(n) := f(n) is the right choice.

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 269,
+    "lineCount": 288,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",
@@ -47,12 +47,13 @@
       "Clean proof of the easy direction: computable bijection implies one-one equivalence",
       "Fully proved partial-inverse infrastructure via Nat.rfind: partialInverse_partrec (Partrec), partialInverse_spec (recovers input under injection), partialInverse_dom (defined on range)",
       "Proof that computable isomorphism is an equivalence relation (reflexive, symmetric, transitive)",
-      "Forward orbit definition: (g∘f)^k(n) for the back-and-forth construction"
+      "Forward orbit definition: (g∘f)^k(n) for the back-and-forth construction",
+      "Fully proved fwdOrbit_computable: the forward orbit (n,k) ↦ (g∘f)^k(n) is Computable when f, g are (via Computable.nat_rec) — verifies the 'orbit structure is effective' requirement (step (d)) of the hard-direction construction"
     ],
     "openProblems": [
       "Hard direction of Myhill's theorem: construct computable bijection from computable injections via back-and-forth priority argument (~200 lines of Partrec-based formalization)"
     ],
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 4,
     "additionalFiles": [
       "Proofs/SchroederBernsteinOQ03Aristotle.lean"


### PR DESCRIPTION
## Summary

Adds and **fully proves** \`fwdOrbit_computable\` in \`Proofs/SchroederBernsteinOQ03.lean\` (Myhill's Isomorphism Theorem):

> The forward orbit \`(n, k) ↦ (g∘f)^k(n)\` is \`Computable\` whenever \`f\` and \`g\` are computable.

Proof: the orbit is a primitive recursion in \`k\` whose step \`IH ↦ g (f IH)\` is a composition of computable functions, so \`Computable.nat_rec\` applies; \`of_eq\` + induction relate it to the existing \`fwdOrbit\` equation lemmas.

## Why this matters (honest scope)

This verifies the **"orbit structure is effective"** requirement (step (d)) of the still-open hard-direction back-and-forth construction. It is an **incremental verified brick**, not a discharge of the main theorem.

The main theorem \`myhill_isomorphism\` **retains its single \`sorry\`** — the ~200-line Partrec priority argument for the → direction is unchanged. No new sorries, no axioms introduced.

## Verification
- Built via \`./proofs/scripts/docker-build.sh Proofs.SchroederBernsteinOQ03\` — succeeds; only the pre-existing sorry warning (line ~200) and two pre-existing unused-variable linter warnings remain.
- 0 \`axiom\` declarations, 0 structure-encoded assumptions.

## Meta
- theoremCount 14 → 15, lineCount 269 → 288, sorries unchanged (1), axiomCount 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)