### PR TITLE
Fix 68 crossRefs rendering /proof/undefined (id->proofId field name)

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -5,8 +5,14 @@
   "sorries": 0,
   "description": "Generalizes the parent's André reflection bijection from barrier height −1 to arbitrary depth −k. A monotone n-up lattice path (encoded by its up-step position set S : Finset (Fin (2n))) reaches depth −k when some prefix has k more downs than ups, i.e. j = 2·preUps S j + k. The same reflection — complement every step from the first descent to −k — is an explicit bijection between depth-k 'bad' n-up paths and ALL (n−k)-up paths, giving #BadPathsK = C(2n,n+k); hence the generalized ballot number, the count of n-up paths staying strictly above −k, is exactly C(2n,n) − C(2n,n+k). At k = 1 this recovers the parent's #GoodPaths = catalan n. Reuses the parent's barrier-independent infrastructure (preUps, reflect, card_reflect_add) verbatim. Fully verified, 0 axioms, no native_decide.",
   "leanFile": {
-    "imports": ["Mathlib", "Proofs.CatalanAndreReflection"],
-    "opens": ["Finset", "CatalanAndreReflection"],
+    "imports": [
+      "Mathlib",
+      "Proofs.CatalanAndreReflection"
+    ],
+    "opens": [
+      "Finset",
+      "CatalanAndreReflection"
+    ],
     "namespace": "CatalanGeneralizedBallot",
     "lineCount": 259,
     "axiomCount": 0,
@@ -105,11 +111,11 @@
   },
   "crossReferences": [
     {
-      "id": "catalan-numbers-oq-01-oq-01-oq-01",
+      "proofId": "catalan-numbers-oq-01-oq-01-oq-01",
       "reason": "The parent entry: André's reflection bijection at barrier −1 (catalan n = C(2n,n) − C(2n,n+1)). This entry imports it and reuses preUps, reflect, card_reflect_add, preUps_reflect_eq and card_goodPaths_eq_catalan, generalizing the barrier to depth −k."
     },
     {
-      "id": "catalan-numbers-oq-01-oq-01",
+      "proofId": "catalan-numbers-oq-01-oq-01",
       "reason": "Grandparent: the arithmetic Catalan reflection form, of which the generalized ballot count C(2n,n) − C(2n,n+k) is the k-parameter family."
     }
   ],

--- a/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-01/meta.json
@@ -5,8 +5,12 @@
   "sorries": 0,
   "description": "Upgrades the arithmetic Catalan reflection form catalan n = C(2n,n) − C(2n,n+1) to a genuine combinatorial bijection. Monotone lattice paths with 2n steps are encoded as up-step position sets S : Finset (Fin (2n)); a path is 'bad' when some prefix dips to height −1. André's reflection — complement every step from the first descent onward — is built as an explicit involution on the encoding and shown to be a bijection between bad n-up paths and ALL (n−1)-up paths, whence #BadPaths = C(2n,n+1) and the number of Dyck (good) paths is exactly catalan n. Fully verified, 0 axioms, no native_decide.",
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Finset"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
     "namespace": "CatalanAndreReflection",
     "lineCount": 360,
     "axiomCount": 0,
@@ -34,7 +38,7 @@
       "Nat.sInf and first-passage (least-witness) arguments"
     ]
   },
-  "sections":   [
+  "sections": [
     {
       "id": "setup-reflection",
       "title": "Setup: Lattice Paths and André's Reflection",
@@ -98,11 +102,11 @@
   },
   "crossReferences": [
     {
-      "id": "catalan-numbers-oq-01-oq-01",
+      "proofId": "catalan-numbers-oq-01-oq-01",
       "reason": "The parent entry: the arithmetic reflection form catalan n = C(2n,n) − C(2n,n+1). This entry supplies the explicit bijection that the arithmetic identity only asserts the cardinality of."
     },
     {
-      "id": "catalan-numbers-oq-01",
+      "proofId": "catalan-numbers-oq-01",
       "reason": "Grandparent: the central-binomial bridge (n+1)*catalan n = C(2n,n) reused here (succ_mul_catalan_eq_centralBinom) to reprove the additive partition inline."
     }
   ],

--- a/src/data/proofs/catalan-numbers-oq-01-oq-03/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-03/meta.json
@@ -114,7 +114,7 @@
   ],
   "crossReferences": [
     {
-      "id": "catalan-numbers-oq-01",
+      "proofId": "catalan-numbers-oq-01",
       "relationship": "Parent open question: proved the first-order linear recurrence for the Catalan numbers and asked for the analogous holonomic structure of Delannoy/Motzkin/Schröder numbers; this entry addresses the Schröder growth rate and sets up the Schröder order-two recurrence."
     }
   ],

--- a/src/data/proofs/dini-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-01/meta.json
@@ -145,7 +145,7 @@
   ],
   "crossReferences": [
     {
-      "id": "dini-theorem-oq-01",
+      "proofId": "dini-theorem-oq-01",
       "relationship": "Parent entry: re-exports Dini's theorem and proves the necessity of continuity-of-limit and compactness; this entry answers its open question on the necessity of monotonicity."
     }
   ],

--- a/src/data/proofs/dirichlets-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-01-oq-01/meta.json
@@ -25,7 +25,14 @@
       "deuring_heilbronn_repulsion: Deuring-Heilbronn repulsion (from DirichletsTheoremOQ01)",
       "tatuzawa_theorem: Tatuzawa single-exception theorem (from DirichletsTheoremOQ01)"
     ],
-    "tags": ["dirichlet", "l-functions", "siegel-zeros", "linnik", "analytic-number-theory", "open-question"],
+    "tags": [
+      "dirichlet",
+      "l-functions",
+      "siegel-zeros",
+      "linnik",
+      "analytic-number-theory",
+      "open-question"
+    ],
     "sorries": 0,
     "lineCount": 335,
     "definitionCount": 1
@@ -37,7 +44,14 @@
       "Proofs.DirichletsTheoremOQ01",
       "Mathlib.Tactic"
     ],
-    "opens": ["Nat", "Real", "Filter", "DirichletCharacter", "Topology", "DirichletsTheoremOQ01"],
+    "opens": [
+      "Nat",
+      "Real",
+      "Filter",
+      "DirichletCharacter",
+      "Topology",
+      "DirichletsTheoremOQ01"
+    ],
     "lineCount": 335,
     "axiomCount": 2,
     "theoremCount": 20,
@@ -114,12 +128,12 @@
   },
   "crossReferences": [
     {
-      "id": "dirichlets-theorem-oq-01",
+      "proofId": "dirichlets-theorem-oq-01",
       "relationship": "parent",
       "description": "Parent file establishing Siegel zeros framework, IsSiegelZero definition, and the five key axioms (Siegel's theorem, GRH conditional, Landau-Page, Deuring-Heilbronn, Tatuzawa)"
     },
     {
-      "id": "dirichlets-theorem-oq-02-oq-01",
+      "proofId": "dirichlets-theorem-oq-02-oq-01",
       "relationship": "sibling",
       "description": "GRH for Dirichlet L-functions — the hypothesis that would imply SiegelZeroConjecture via grh_implies_no_siegel_zeros_standard"
     }

--- a/src/data/proofs/dyck-catalan-count-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dyck-catalan-count-oq-01-oq-01/meta.json
@@ -137,11 +137,11 @@
   ],
   "crossReferences": [
     {
-      "id": "dyck-catalan-count-oq-01",
+      "proofId": "dyck-catalan-count-oq-01",
       "relationship": "Parent entry: counts Dyck words of semilength n by catalan n and poses the open question this entry answers; supplies the Dyck-word side of the bijection."
     },
     {
-      "id": "catalan-numbers-oq-01",
+      "proofId": "catalan-numbers-oq-01",
       "relationship": "Companion Catalan entry on the arithmetic linear recurrence of the abstract sequence; disjoint from this entry's bijective enumeration of a new Catalan family."
     }
   ],

--- a/src/data/proofs/dyck-catalan-count-oq-01/meta.json
+++ b/src/data/proofs/dyck-catalan-count-oq-01/meta.json
@@ -134,7 +134,7 @@
   ],
   "crossReferences": [
     {
-      "id": "catalan-numbers-oq-01",
+      "proofId": "catalan-numbers-oq-01",
       "relationship": "Companion Catalan entry covering the arithmetic side — the first-order (holonomic) linear recurrence of the abstract sequence — disjoint from this entry's combinatorial enumeration."
     }
   ],

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-01/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-01/meta.json
@@ -135,11 +135,6 @@
       "proofId": "eisenstein-criterion-oq-01-oq-03",
       "relationship": "related",
       "description": "Sibling entry that reached irreducibility over ℚ via Gauss's lemma and explicitly listed 'irreducibility of Φ_p by applying Eisenstein to Φ_p(X+1)' as an open question. This entry realizes that step, reusing the same ℤ-to-ℚ upgrade."
-    },
-    {
-      "proofId": "cyclotomic-polynomials-oq-01",
-      "relationship": "related",
-      "description": "Companion cyclotomic-polynomial entry. The prime-case irreducibility proved here is the foundational fact behind the structure of cyclotomic extensions (degree p−1, Galois group (ℤ/p)ˣ)."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-03/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-03/meta.json
@@ -133,11 +133,6 @@
       "proofId": "eisenstein-criterion-oq-01",
       "relationship": "extends",
       "description": "Parent entry. It states the abstract Eisenstein criterion and proves Xⁿ − p irreducible over ℤ. This entry answers its third open question: general Eisenstein-at-p polynomials with arbitrary lower coefficients (the family Xⁿ + p·g), and irreducibility over ℚ via Gauss's lemma."
-    },
-    {
-      "proofId": "cyclotomic-polynomials-oq-01",
-      "relationship": "related",
-      "description": "Irreducibility of the p-th cyclotomic polynomial Φ_p is the other classical Eisenstein application (after X ↦ X + 1); the irreducibility-over-ℚ machinery developed here is exactly what such arguments conclude with."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/eisenstein-criterion-oq-01/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01/meta.json
@@ -103,13 +103,7 @@
       "mathContext": "$X^2-2,\\ X^3-2,\\ X^5-3$ irreducible over $\\mathbb{Z}$."
     }
   ],
-  "crossReferences": [
-    {
-      "proofId": "cyclotomic-polynomials-oq-01",
-      "relationship": "related",
-      "description": "The irreducibility of the p-th cyclotomic polynomial Φ_p is the other classical application of Eisenstein's criterion (after the substitution X ↦ X + 1). This entry establishes the criterion and the companion Xⁿ − p family; the cyclotomic entry studies Φ_n's degree and divisor-product structure."
-    }
-  ],
+  "crossReferences": [],
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-305-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-305-incomplete-01/meta.json
@@ -121,7 +121,7 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-305",
+      "proofId": "erdos-305",
       "title": "Erdős #305: Maximum Denominator in Egyptian Fraction Representations",
       "relationship": "Parent / target — this entry discharges that file's `axiom egyptian_representation_exists`, leaving its deep asymptotic sorry out of scope."
     }

--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-895-oq-01",
   "title": "Hajnal's Independent Hindman Set Conjecture",
   "slug": "erdos-895-oq-01",
-  "description": "Hajnal's open generalization of Erd\u0151s #895: every large triangle-free graph on {1,...,n} contains an independent Hindman set \u2014 a base B with all finite sub-sums forming a mutually non-adjacent set.",
+  "description": "Hajnal's open generalization of Erdős #895: every large triangle-free graph on {1,...,n} contains an independent Hindman set — a base B with all finite sub-sums forming a mutually non-adjacent set.",
   "meta": {
-    "author": "Erd\u0151s-Hajnal (conjectured)",
+    "author": "Erdős-Hajnal (conjectured)",
     "sourceUrl": "https://erdosproblems.com/895",
     "date": "1995",
     "status": "axiomatized",
@@ -46,8 +46,8 @@
       "Monotonicity and structural lemmas for hindmanSet (sorry-free)",
       "Axiomatization of Hajnal's conjecture as an open problem",
       "Proof that Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple",
-      "Proved Case 1 of \u03b1(G) \u2265 \u221an bound: high-degree vertex N(v) is independent",
-      "Full proof of \u03b1(G) \u2265 \u221an via two-case greedy argument: Case 1 (high-degree vertex N(v)), Case 2 (greedy induction on candidate set cardinality)",
+      "Proved Case 1 of α(G) ≥ √n bound: high-degree vertex N(v) is independent",
+      "Full proof of α(G) ≥ √n via two-case greedy argument: Case 1 (high-degree vertex N(v)), Case 2 (greedy induction on candidate set cardinality)",
       "triangleFree_indep_pair: for n >= 4, a triangle-free graph on Fin n has an independent set of card >= 2 (corollary of the alpha(G) >= sqrt(n) bound via sqrt(n) >= 2 = Nat.sqrt 4); yields an independent pair as a first step toward an independent Hindman base of card >= 2 (sorry-free)"
     ],
     "assumptions": "1 axiom: hajnal_conjecture (Hajnal's open conjecture, unsolved as of 2026). 0 sorries: all structural lemmas and the greedy independence bound are fully proved.",
@@ -57,48 +57,48 @@
     "lineCount": 319
   },
   "overview": {
-    "historicalContext": "**Hajnal's Generalization of Erd\u0151s Problem #895**\n\nThe parent problem, Erd\u0151s #895, was solved by Ben Barber (2015) using SAT verification: every triangle-free graph on $\\{1,\\ldots,n\\}$ for $n \\geq 18$ contains three mutually non-adjacent vertices $a$, $b$, $a+b$. This is the $k=2$ base case of a more ambitious conjecture by Andr\u00e1s Hajnal.\n\nHajnal asks: does every sufficiently large triangle-free graph contain an **independent Hindman set** \u2014 a base $B = \\{a_1, \\ldots, a_k\\}$ with $k \\geq 2$ such that ALL finite nonempty sub-sums of $B$ form a mutually non-adjacent set in the graph?\n\nThe $k=2$ case gives FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$, which is exactly Barber's result. The challenge for $k \\geq 3$ is that sums can grow (possibly exceeding $n$) while graph independence must be maintained for all sub-sums simultaneously.\n\n**Connection to Hindman's Theorem (1974):** Hindman proved that for any finite coloring of $\\mathbb{N}$, there exists an infinite Hindman set that is monochromatic. Hajnal's conjecture replaces 'monochromatic' with 'graph-independent' and works in the finite setting \u2014 a fundamentally different kind of constraint.",
-    "problemStatement": "Let $G$ be a triangle-free graph with vertex set $\\{1, 2, \\ldots, n\\}$.\n\n**Conjecture (Hajnal):** For sufficiently large $n$, there exists a base $B \\subseteq \\{1,\\ldots,n\\}$ with $|B| \\geq 2$ such that the finite sums set FS$(B) = \\{\\sum_{i \\in T} a_i \\mid T \\subseteq B, T \\neq \\emptyset\\}$ forms an independent set in $G$.\n\n**Special case $k=2$:** FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$ \u2014 proved by Barber for $n \\geq 18$.\n\n**Status:** OPEN for base size $k \\geq 3$. No counterexample or proof is known.",
-    "text": "Hajnal's open generalization of Erd\u0151s #895: does every large triangle-free graph contain an independent Hindman set?",
-    "proofStrategy": "This file:\n1. Defines `hindmanSet base` as all finite nonempty sub-sums of `base`\n2. Proves structural properties of hindmanSet (monotonicity, pair lemmas)\n3. States `hajnalConjecture` and axiomatizes it (OPEN)\n4. Proves `hajnal_k2_gives_additive_triple`: k=2 Hajnal base \u2192 independent additive triple\n5. Proves `triangleFree_independence_bound` (\u03b1 \u2265 \u221an) via two-case greedy argument (0 sorries)",
+    "historicalContext": "**Hajnal's Generalization of Erdős Problem #895**\n\nThe parent problem, Erdős #895, was solved by Ben Barber (2015) using SAT verification: every triangle-free graph on $\\{1,\\ldots,n\\}$ for $n \\geq 18$ contains three mutually non-adjacent vertices $a$, $b$, $a+b$. This is the $k=2$ base case of a more ambitious conjecture by András Hajnal.\n\nHajnal asks: does every sufficiently large triangle-free graph contain an **independent Hindman set** — a base $B = \\{a_1, \\ldots, a_k\\}$ with $k \\geq 2$ such that ALL finite nonempty sub-sums of $B$ form a mutually non-adjacent set in the graph?\n\nThe $k=2$ case gives FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$, which is exactly Barber's result. The challenge for $k \\geq 3$ is that sums can grow (possibly exceeding $n$) while graph independence must be maintained for all sub-sums simultaneously.\n\n**Connection to Hindman's Theorem (1974):** Hindman proved that for any finite coloring of $\\mathbb{N}$, there exists an infinite Hindman set that is monochromatic. Hajnal's conjecture replaces 'monochromatic' with 'graph-independent' and works in the finite setting — a fundamentally different kind of constraint.",
+    "problemStatement": "Let $G$ be a triangle-free graph with vertex set $\\{1, 2, \\ldots, n\\}$.\n\n**Conjecture (Hajnal):** For sufficiently large $n$, there exists a base $B \\subseteq \\{1,\\ldots,n\\}$ with $|B| \\geq 2$ such that the finite sums set FS$(B) = \\{\\sum_{i \\in T} a_i \\mid T \\subseteq B, T \\neq \\emptyset\\}$ forms an independent set in $G$.\n\n**Special case $k=2$:** FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$ — proved by Barber for $n \\geq 18$.\n\n**Status:** OPEN for base size $k \\geq 3$. No counterexample or proof is known.",
+    "text": "Hajnal's open generalization of Erdős #895: does every large triangle-free graph contain an independent Hindman set?",
+    "proofStrategy": "This file:\n1. Defines `hindmanSet base` as all finite nonempty sub-sums of `base`\n2. Proves structural properties of hindmanSet (monotonicity, pair lemmas)\n3. States `hajnalConjecture` and axiomatizes it (OPEN)\n4. Proves `hajnal_k2_gives_additive_triple`: k=2 Hajnal base → independent additive triple\n5. Proves `triangleFree_independence_bound` (α ≥ √n) via two-case greedy argument (0 sorries)",
     "keyInsights": [
-      "**Hierarchy of Hindman strength:** Hajnal's conjecture strictly generalizes Erd\u0151s #895 \u2014 the k=2 base case IS the Barber theorem. Each additional base element adds exponentially more sum-independence requirements: $|\\mathrm{FS}(B)|$ can be as large as $2^{|B|} - 1$, so the constraint count grows from 3 (at $k=2$) to 7 (at $k=3$) to 15 (at $k=4$).",
-      "**hindmanSet monotonicity:** Larger bases produce larger sum sets. This allows reducing from a full Hajnal base to a 2-element sub-base to recover the Erd\u0151s-Barber structure.",
-      "**Independence number bound:** Triangle-free graphs satisfy \u03b1(G) \u2265 \u221an. Case 1 (high-degree vertex) is proved here via N(v) being independent; Case 2 (greedy algorithm) reduces to a bounded-degree independence number bound.",
-      "**k=2 reduction:** If the Hajnal base {a,b} has a+b < n (in-range sum), then a, b, a+b are all in FS({a,b}) and are mutually non-adjacent \u2014 giving exactly the Erd\u0151s-Barber structure. This is `hajnal_k2_gives_additive_triple`.",
-      "**Open territory:** The gap between k=2 (computationally verified by Barber's SAT proof) and k\u22653 (unknown) mirrors the gap between Schur's theorem (1916) and Hindman's theorem (1974) in pure additive combinatorics.",
-      "**Sharpness of the \u221an bound:** The elementary $\\alpha(G) \\geq \\sqrt{n}$ proved here is essentially tight in form \u2014 Kim (1995) showed the Ramsey number $R(3,t)$ has order $t^2/\\log t$, so the true bound is $\\alpha(G) = \\Omega(\\sqrt{n \\log n})$. The Lean proof captures the elementary half; the logarithmic improvement is a deep probabilistic argument (Lov\u00e1sz Local Lemma + nibble) not yet formalized."
+      "**Hierarchy of Hindman strength:** Hajnal's conjecture strictly generalizes Erdős #895 — the k=2 base case IS the Barber theorem. Each additional base element adds exponentially more sum-independence requirements: $|\\mathrm{FS}(B)|$ can be as large as $2^{|B|} - 1$, so the constraint count grows from 3 (at $k=2$) to 7 (at $k=3$) to 15 (at $k=4$).",
+      "**hindmanSet monotonicity:** Larger bases produce larger sum sets. This allows reducing from a full Hajnal base to a 2-element sub-base to recover the Erdős-Barber structure.",
+      "**Independence number bound:** Triangle-free graphs satisfy α(G) ≥ √n. Case 1 (high-degree vertex) is proved here via N(v) being independent; Case 2 (greedy algorithm) reduces to a bounded-degree independence number bound.",
+      "**k=2 reduction:** If the Hajnal base {a,b} has a+b < n (in-range sum), then a, b, a+b are all in FS({a,b}) and are mutually non-adjacent — giving exactly the Erdős-Barber structure. This is `hajnal_k2_gives_additive_triple`.",
+      "**Open territory:** The gap between k=2 (computationally verified by Barber's SAT proof) and k≥3 (unknown) mirrors the gap between Schur's theorem (1916) and Hindman's theorem (1974) in pure additive combinatorics.",
+      "**Sharpness of the √n bound:** The elementary $\\alpha(G) \\geq \\sqrt{n}$ proved here is essentially tight in form — Kim (1995) showed the Ramsey number $R(3,t)$ has order $t^2/\\log t$, so the true bound is $\\alpha(G) = \\Omega(\\sqrt{n \\log n})$. The Lean proof captures the elementary half; the logarithmic improvement is a deep probabilistic argument (Lovász Local Lemma + nibble) not yet formalized."
     ],
     "prerequisites": [
       "Graph theory: triangle-free graphs, independent sets, neighborhood sets",
       "Additive combinatorics: sumsets, Schur triples, Hindman sets",
       "Ramsey theory: R(3,3)=6, triangle-free graph structure",
-      "Parent result: Erd\u0151s #895 (Barber 2015)"
+      "Parent result: Erdős #895 (Barber 2015)"
     ],
     "mainTheorems": [
       {
         "name": "hajnal_conjecture",
-        "statement": "\u2203 N : \u2115, \u2200 n \u2265 N, \u2200 G : GraphOnInterval n, IsTriangleFree G \u2192 \u2203 base : Finset (Fin n), base.card \u2265 2 \u2227 \u2200 s t : Fin n, s.val \u2208 hindmanSet (base.image (\u00b7.val)) \u2192 t.val \u2208 hindmanSet (base.image (\u00b7.val)) \u2192 s \u2260 t \u2192 \u00acG.Adj s t",
-        "description": "Hajnal's open conjecture: every sufficiently large triangle-free graph on {1,\u2026,n} contains an independent Hindman set. AXIOM (open as of 2026)."
+        "statement": "∃ N : ℕ, ∀ n ≥ N, ∀ G : GraphOnInterval n, IsTriangleFree G → ∃ base : Finset (Fin n), base.card ≥ 2 ∧ ∀ s t : Fin n, s.val ∈ hindmanSet (base.image (·.val)) → t.val ∈ hindmanSet (base.image (·.val)) → s ≠ t → ¬G.Adj s t",
+        "description": "Hajnal's open conjecture: every sufficiently large triangle-free graph on {1,…,n} contains an independent Hindman set. AXIOM (open as of 2026)."
       },
       {
         "name": "hajnal_k2_gives_additive_triple",
-        "statement": "\u2200 {n} (G : GraphOnInterval n) (a b : Fin n), a \u2260 b \u2192 a.val > 0 \u2192 b.val > 0 \u2192 a.val + b.val < n \u2192 (\u2200 s t, s.val \u2208 hindmanSet \u2026 \u2192 t.val \u2208 hindmanSet \u2026 \u2192 s \u2260 t \u2192 \u00acG.Adj s t) \u2192 HasIndependentAdditiveTriple G",
-        "description": "Hajnal at base size k=2 directly recovers Erd\u0151s-Barber: a Hajnal base {a,b} with in-range sum a+b<n yields the additive triple (a, b, a+b) being mutually non-adjacent. Sorry-free."
+        "statement": "∀ {n} (G : GraphOnInterval n) (a b : Fin n), a ≠ b → a.val > 0 → b.val > 0 → a.val + b.val < n → (∀ s t, s.val ∈ hindmanSet … → t.val ∈ hindmanSet … → s ≠ t → ¬G.Adj s t) → HasIndependentAdditiveTriple G",
+        "description": "Hajnal at base size k=2 directly recovers Erdős-Barber: a Hajnal base {a,b} with in-range sum a+b<n yields the additive triple (a, b, a+b) being mutually non-adjacent. Sorry-free."
       },
       {
         "name": "triangleFree_independence_bound",
-        "statement": "\u2200 {n} (G : GraphOnInterval n) [DecidableRel G.Adj], IsTriangleFree G \u2192 \u2203 S : Finset (Fin n), S.card \u2265 Nat.sqrt n \u2227 \u2200 a b, a \u2208 S \u2192 b \u2208 S \u2192 a \u2260 b \u2192 \u00acG.Adj a b",
-        "description": "Independence number bound \u03b1(G) \u2265 \u221an for any triangle-free graph on n vertices, proved by a two-case argument (high-degree vertex N(v) or greedy on bounded-degree). Sorry-free, no axiom dependency."
+        "statement": "∀ {n} (G : GraphOnInterval n) [DecidableRel G.Adj], IsTriangleFree G → ∃ S : Finset (Fin n), S.card ≥ Nat.sqrt n ∧ ∀ a b, a ∈ S → b ∈ S → a ≠ b → ¬G.Adj a b",
+        "description": "Independence number bound α(G) ≥ √n for any triangle-free graph on n vertices, proved by a two-case argument (high-degree vertex N(v) or greedy on bounded-degree). Sorry-free, no axiom dependency."
       },
       {
         "name": "triangleFree_nbhd_independent",
-        "statement": "\u2200 {n} (G : GraphOnInterval n), IsTriangleFree G \u2192 \u2200 v u w : Fin n, G.Adj v u \u2192 G.Adj v w \u2192 \u00acG.Adj u w",
-        "description": "Defining structural lemma: in a triangle-free graph, any two distinct neighbors of v are non-adjacent (would close the triangle vuw). Underlies Case 1 of the \u221an bound."
+        "statement": "∀ {n} (G : GraphOnInterval n), IsTriangleFree G → ∀ v u w : Fin n, G.Adj v u → G.Adj v w → ¬G.Adj u w",
+        "description": "Defining structural lemma: in a triangle-free graph, any two distinct neighbors of v are non-adjacent (would close the triangle vuw). Underlies Case 1 of the √n bound."
       },
       {
         "name": "hindmanSet_pair_sum",
-        "statement": "\u2200 a b : \u2115, a \u2260 b \u2192 a + b \u2208 hindmanSet ({a, b} : Finset \u2115)",
+        "statement": "∀ a b : ℕ, a ≠ b → a + b ∈ hindmanSet ({a, b} : Finset ℕ)",
         "description": "Witnesses that the pair-sum a+b is in FS({a,b}); together with `hindmanSet_pair_left/right` gives the three k=2 elements {a, b, a+b}."
       }
     ]
@@ -110,7 +110,7 @@
       "summary": "Graph-on-interval, triangle-free predicate, additive triple, and the hindmanSet (Hindman finite-sums set FS(B)).",
       "startLine": 35,
       "endLine": 52,
-      "mathContext": "Sets up $G$ on vertices $\\{0,\\ldots,n-1\\}$ via `Fin n`, defines triangle-freeness ($\\nexists$ three mutually adjacent vertices), additive triples ($a + b = c$ with $a,b > 0$), and $\\mathrm{FS}(B) = \\{\\sum_{i \\in T} a_i : \\emptyset \\neq T \\subseteq B\\}$ as a `Set \u2115`."
+      "mathContext": "Sets up $G$ on vertices $\\{0,\\ldots,n-1\\}$ via `Fin n`, defines triangle-freeness ($\\nexists$ three mutually adjacent vertices), additive triples ($a + b = c$ with $a,b > 0$), and $\\mathrm{FS}(B) = \\{\\sum_{i \\in T} a_i : \\emptyset \\neq T \\subseteq B\\}$ as a `Set ℕ`."
     },
     {
       "id": "hindman-structure",
@@ -123,7 +123,7 @@
     {
       "id": "hajnal-conjecture",
       "title": "Hajnal's Conjecture",
-      "summary": "Formal statement of Hajnal's generalization of Erd\u0151s #895 and its axiomatization as an open problem.",
+      "summary": "Formal statement of Hajnal's generalization of Erdős #895 and its axiomatization as an open problem.",
       "startLine": 111,
       "endLine": 124,
       "mathContext": "$\\exists N, \\forall n \\geq N, \\forall G$ triangle-free on `Fin n`, $\\exists B \\subseteq V$ with $|B| \\geq 2$ such that $\\mathrm{FS}(B.\\mathrm{image}\\,(\\cdot.\\mathrm{val}))$ is a graph-independent set. Asserted via `axiom hajnal_conjecture` (OPEN as of 2026)."
@@ -131,10 +131,10 @@
     {
       "id": "k2-reduction",
       "title": "The k=2 Reduction",
-      "summary": "Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple (a, b, a+b) \u2014 recovers Erd\u0151s-Barber.",
+      "summary": "Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple (a, b, a+b) — recovers Erdős-Barber.",
       "startLine": 125,
       "endLine": 162,
-      "mathContext": "Theorem `hajnal_k2_gives_additive_triple`: given `hindep` for the 2-element base and the in-range condition $a.\\mathrm{val} + b.\\mathrm{val} < n$, the witness $d := \\langle a + b, \\text{hsum}\\rangle$ together with `hindmanSet_pair_*` lemmas produces an independent triple. This is the formal sense in which Hajnal $\\Rightarrow$ Erd\u0151s-Barber on the $k=2$ slice."
+      "mathContext": "Theorem `hajnal_k2_gives_additive_triple`: given `hindep` for the 2-element base and the in-range condition $a.\\mathrm{val} + b.\\mathrm{val} < n$, the witness $d := \\langle a + b, \\text{hsum}\\rangle$ together with `hindmanSet_pair_*` lemmas produces an independent triple. This is the formal sense in which Hajnal $\\Rightarrow$ Erdős-Barber on the $k=2$ slice."
     },
     {
       "id": "triangle-free-neighborhoods",
@@ -147,113 +147,135 @@
     {
       "id": "greedy-bounded-degree",
       "title": "Greedy Independent Set on Bounded-Degree Subgraphs",
-      "summary": "Strong induction on candidate-set cardinality: greedy removal of v and N(v) gives \u03b1 \u2265 |C|/(\u0394+1).",
+      "summary": "Strong induction on candidate-set cardinality: greedy removal of v and N(v) gives α ≥ |C|/(Δ+1).",
       "startLine": 182,
       "endLine": 279,
       "mathContext": "Private lemma `greedy_indep_of_bounded_deg`: if $\\Delta(G[C]) \\leq \\Delta$, greedy step removes $\\leq \\Delta + 1$ vertices and recurses, yielding $|C| \\leq |S|(\\Delta+1)$. Wrapper `indep_from_bounded_deg` specializes to $C = V$."
     },
     {
       "id": "independence-bound",
-      "title": "Independence Number Bound \u03b1(G) \u2265 \u221an",
-      "summary": "Two-case proof: high-degree vertex (Case 1) or all-low-degree (Case 2 via greedy) yields an independent set of size \u2265 \u221an.",
+      "title": "Independence Number Bound α(G) ≥ √n",
+      "summary": "Two-case proof: high-degree vertex (Case 1) or all-low-degree (Case 2 via greedy) yields an independent set of size ≥ √n.",
       "startLine": 280,
       "endLine": 319,
       "mathContext": "`triangleFree_independence_bound`: split on $\\exists v$ with $\\deg(v) \\geq \\sqrt{n}$. Case 1 reuses `triangleFree_indep_high_deg`. Case 2: all $\\deg \\leq \\sqrt{n} - 1$, so greedy gives $n \\leq |S| \\cdot \\sqrt{n}$; combined with `Nat.sqrt_le'` ($\\lfloor\\sqrt{n}\\rfloor^2 \\leq n$) and `Nat.le_of_mul_le_mul_right` we conclude $|S| \\geq \\sqrt{n}$."
     }
   ],
   "conclusion": {
-    "summary": "This formalization axiomatizes Hajnal's open generalization of Erd\u0151s #895 and proves all available structural components: hindmanSet properties (4 lemmas, sorry-free), the k=2 reduction (Hajnal base of size 2 implies Erd\u0151s-Barber structure), and the independence number bound \u03b1(G) \u2265 \u221an for triangle-free graphs via a complete two-case greedy argument (0 sorries, 1 axiom for the conjecture itself).",
-    "implications": "The independence bound \u03b1(G) \u2265 \u221an for triangle-free graphs is tight \u2014 Paley graphs and polarity graphs show the bound cannot be improved to \u03c9(\u221an) in general. Hajnal's conjecture, if true, would give a structural reason for the additive richness of large independent sets in triangle-free graphs: not only do large independent sets exist (by the \u221an bound), they contain sets that are closed under addition (FS-sets). This would bridge graph Ramsey theory and additive Ramsey theory (Hindman's theorem). The greedy bound \u03b1 \u2265 n/(\u0394+1) proved here is also useful beyond the \u221an application: for triangle-free graphs with bounded maximum degree \u0394 \u226a \u221an, it gives the tighter bound \u03b1 \u2265 n/\u0394.",
+    "summary": "This formalization axiomatizes Hajnal's open generalization of Erdős #895 and proves all available structural components: hindmanSet properties (4 lemmas, sorry-free), the k=2 reduction (Hajnal base of size 2 implies Erdős-Barber structure), and the independence number bound α(G) ≥ √n for triangle-free graphs via a complete two-case greedy argument (0 sorries, 1 axiom for the conjecture itself).",
+    "implications": "The independence bound α(G) ≥ √n for triangle-free graphs is tight — Paley graphs and polarity graphs show the bound cannot be improved to ω(√n) in general. Hajnal's conjecture, if true, would give a structural reason for the additive richness of large independent sets in triangle-free graphs: not only do large independent sets exist (by the √n bound), they contain sets that are closed under addition (FS-sets). This would bridge graph Ramsey theory and additive Ramsey theory (Hindman's theorem). The greedy bound α ≥ n/(Δ+1) proved here is also useful beyond the √n application: for triangle-free graphs with bounded maximum degree Δ ≪ √n, it gives the tighter bound α ≥ n/Δ.",
     "openQuestions": [
-      "Hajnal's conjecture for k=3: does every large triangle-free graph on {1,...,n} contain an independent FS({a,b,c}) = {a,b,c,a+b,a+c,b+c,a+b+c}? The 7 elements must all be in {1,...,n} and mutually non-adjacent \u2014 a substantially harder combinatorial constraint than the k=2 case.",
-      "Can the independence bound \u03b1(G) \u2265 \u221an be proved using the Bonferroni/Lov\u00e1sz Local Lemma approach (probabilistic method) rather than the greedy algorithm? A probabilistic proof might give tighter constants or extend to hypergraphs.",
-      "The parent result (Erd\u0151s #895, Barber 2015) was proved by SAT verification. Can the Lean 4 formalization be extended to verify Barber's argument \u2014 that n \u2265 18 is sufficient for the k=2 case \u2014 without using the axiom?"
+      "Hajnal's conjecture for k=3: does every large triangle-free graph on {1,...,n} contain an independent FS({a,b,c}) = {a,b,c,a+b,a+c,b+c,a+b+c}? The 7 elements must all be in {1,...,n} and mutually non-adjacent — a substantially harder combinatorial constraint than the k=2 case.",
+      "Can the independence bound α(G) ≥ √n be proved using the Bonferroni/Lovász Local Lemma approach (probabilistic method) rather than the greedy algorithm? A probabilistic proof might give tighter constants or extend to hypergraphs.",
+      "The parent result (Erdős #895, Barber 2015) was proved by SAT verification. Can the Lean 4 formalization be extended to verify Barber's argument — that n ≥ 18 is sufficient for the k=2 case — without using the axiom?"
     ]
   },
   "crossReferences": [
     {
-      "id": "erdos-895",
-      "title": "Erd\u0151s Problem #895 \u2014 Independent Additive Triples",
-      "relationship": "Parent: proves the k=2 case of Hajnal's conjecture (Barber 2015: every triangle-free graph on {1,...,n} for n \u2265 18 contains independent a, b, a+b). This entry extends the question to larger Hindman bases."
+      "proofId": "erdos-895",
+      "title": "Erdős Problem #895 — Independent Additive Triples",
+      "relationship": "Parent: proves the k=2 case of Hajnal's conjecture (Barber 2015: every triangle-free graph on {1,...,n} for n ≥ 18 contains independent a, b, a+b). This entry extends the question to larger Hindman bases."
     },
     {
-      "id": "ramseys-theorem",
+      "proofId": "ramseys-theorem",
       "title": "Ramsey's Theorem",
-      "relationship": "Thematic sibling: Ramsey theory studies structure in large combinatorial objects. Hajnal's conjecture is a hybrid of graph Ramsey theory (triangle-free = K\u2083-free) and additive Ramsey theory (Hindman sets)."
+      "relationship": "Thematic sibling: Ramsey theory studies structure in large combinatorial objects. Hajnal's conjecture is a hybrid of graph Ramsey theory (triangle-free = K₃-free) and additive Ramsey theory (Hindman sets)."
     },
     {
-      "id": "ramsey-r4k",
+      "proofId": "ramsey-r4k",
       "title": "Ramsey R(4,k) Bounds",
-      "relationship": "Related combinatorial result in the Ramsey family. The independence bound \u03b1(G) \u2265 \u221an proved here is related to Ramsey-multiplicity and diagonal Ramsey bounds."
+      "relationship": "Related combinatorial result in the Ramsey family. The independence bound α(G) ≥ √n proved here is related to Ramsey-multiplicity and diagonal Ramsey bounds."
     }
   ],
   "references": [
     {
-      "authors": ["Neil Hindman"],
+      "authors": [
+        "Neil Hindman"
+      ],
       "title": "Finite sums from sequences within cells of a partition of N",
       "year": 1974,
       "venue": "Journal of Combinatorial Theory, Series A",
       "volume": "17",
-      "pages": "1\u201311",
+      "pages": "1–11",
       "doi": "10.1016/0097-3165(74)90023-5",
-      "note": "Original Hindman's theorem: for any finite coloring of \u2115, there is an infinite set whose finite sums are monochromatic. Hajnal's conjecture is the graph-Ramsey analogue in the finite setting."
+      "note": "Original Hindman's theorem: for any finite coloring of ℕ, there is an infinite set whose finite sums are monochromatic. Hajnal's conjecture is the graph-Ramsey analogue in the finite setting."
     },
     {
-      "authors": ["Ben Barber"],
+      "authors": [
+        "Ben Barber"
+      ],
       "title": "Independent sets in graphs with an excluded clique minor",
       "year": 2015,
       "venue": "preprint / arXiv",
       "arxiv": "1502.05015",
-      "note": "Resolves Erd\u0151s #895 (the k=2 base case of this conjecture) for n \u2265 18 via SAT-assisted case analysis."
+      "note": "Resolves Erdős #895 (the k=2 base case of this conjecture) for n ≥ 18 via SAT-assisted case analysis."
     },
     {
-      "authors": ["Andr\u00e1s Hajnal"],
+      "authors": [
+        "András Hajnal"
+      ],
       "title": "Open problems on combinatorics and graph theory",
       "year": "1995",
       "venue": "Combinatorica / talk notes",
-      "note": "Hajnal's original posing of the FS-independence conjecture, generalizing Erd\u0151s #895 from k=2 to arbitrary base size."
+      "note": "Hajnal's original posing of the FS-independence conjecture, generalizing Erdős #895 from k=2 to arbitrary base size."
     },
     {
-      "authors": ["Paul Erd\u0151s", "Andr\u00e1s Hajnal", "Joel Spencer"],
+      "authors": [
+        "Paul Erdős",
+        "András Hajnal",
+        "Joel Spencer"
+      ],
       "title": "Graphs without large complete subgraphs of given chromatic number",
       "year": 1985,
       "venue": "Combinatorica",
-      "note": "Foundational Erd\u0151s-Hajnal collaboration on triangle-free / clique-free graph structure underpinning the conjecture."
+      "note": "Foundational Erdős-Hajnal collaboration on triangle-free / clique-free graph structure underpinning the conjecture."
     },
     {
-      "authors": ["Issai Schur"],
-      "title": "\u00dcber die Kongruenz $x^m + y^m \\equiv z^m \\pmod{p}$",
+      "authors": [
+        "Issai Schur"
+      ],
+      "title": "Über die Kongruenz $x^m + y^m \\equiv z^m \\pmod{p}$",
       "year": 1916,
       "venue": "Jahresbericht der Deutschen Mathematiker-Vereinigung",
       "volume": "25",
-      "pages": "114\u2013117",
-      "note": "Schur's theorem on monochromatic additive triples (a, b, a+b) \u2014 historical antecedent to Erd\u0151s-Barber and Hajnal's generalization."
+      "pages": "114–117",
+      "note": "Schur's theorem on monochromatic additive triples (a, b, a+b) — historical antecedent to Erdős-Barber and Hajnal's generalization."
     },
     {
-      "authors": ["Paul Erd\u0151s", "George Szekeres"],
+      "authors": [
+        "Paul Erdős",
+        "George Szekeres"
+      ],
       "title": "A combinatorial problem in geometry",
       "year": 1935,
       "venue": "Compositio Mathematica",
       "volume": "2",
-      "pages": "463\u2013470",
-      "note": "Origin of finite Ramsey theory, providing the framework in which the \u03b1(G) \u2265 \u221an bound for triangle-free graphs (proved here) lives."
+      "pages": "463–470",
+      "note": "Origin of finite Ramsey theory, providing the framework in which the α(G) ≥ √n bound for triangle-free graphs (proved here) lives."
     },
     {
-      "authors": ["Jeong Han Kim"],
+      "authors": [
+        "Jeong Han Kim"
+      ],
       "title": "The Ramsey number R(3, t) has order of magnitude $t^2/\\log t$",
       "year": 1995,
       "venue": "Random Structures & Algorithms",
       "volume": "7",
-      "pages": "173\u2013207",
+      "pages": "173–207",
       "doi": "10.1002/rsa.3240070302",
-      "note": "Tight asymptotics for the independence number of triangle-free graphs \u2014 shows the elementary \u221an bound proved here is off by only a $\\sqrt{\\log n}$ factor."
+      "note": "Tight asymptotics for the independence number of triangle-free graphs — shows the elementary √n bound proved here is off by only a $\\sqrt{\\log n}$ factor."
     }
   ],
   "leanFile": {
     "path": "Proofs/Erdos895OQ01Problem.lean",
     "namespace": "Erdos895OQ01Problem",
-    "imports": ["Mathlib"],
-    "opens": ["Finset", "SimpleGraph"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "SimpleGraph"
+    ],
     "lineCount": 319,
     "theoremCount": 15,
     "definitionCount": 6,

--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -106,7 +106,11 @@
       "startLine": 56,
       "endLine": 67,
       "summary": "Proves circleMap t = ↑(Circle.exp t), identifying the gallery construction with Mathlib's canonical circle exponential, the object carrying the smooth Lie group structure.",
-      "concepts": ["complex exponential", "Circle.exp", "identification"]
+      "concepts": [
+        "complex exponential",
+        "Circle.exp",
+        "identification"
+      ]
     },
     {
       "id": "sec-smoothness",
@@ -114,7 +118,12 @@
       "startLine": 69,
       "endLine": 81,
       "summary": "States contMDiff_circleExp_packaged: Circle.exp is ContMDiff of every order m, so C∞ (m = ∞) and analytic (m = ω), within Mathlib's LieGroup framework.",
-      "concepts": ["ContMDiff", "C∞ smoothness", "analytic Lie group", "manifold model"]
+      "concepts": [
+        "ContMDiff",
+        "C∞ smoothness",
+        "analytic Lie group",
+        "manifold model"
+      ]
     },
     {
       "id": "sec-homomorphism",
@@ -122,7 +131,11 @@
       "startLine": 83,
       "endLine": 96,
       "summary": "Proves circleExp_homomorphism (Circle.exp_add) and circleHom_coe_eq_circleExp, relating the parent's circleHom into ℂˣ to Mathlib's Circle.exp.",
-      "concepts": ["group homomorphism", "Circle.expHom", "compatibility"]
+      "concepts": [
+        "group homomorphism",
+        "Circle.expHom",
+        "compatibility"
+      ]
     },
     {
       "id": "sec-lie-algebra",
@@ -130,7 +143,12 @@
       "startLine": 98,
       "endLine": 126,
       "summary": "Proves the defining ODE γ'(t) = γ(t)·I (hasDerivAt_circleExp), the velocity at the identity γ'(0) = I (hasDerivAt_circleExp_zero), and that the generator lies on the imaginary axis (generator_mem_imaginary_axis).",
-      "concepts": ["Lie algebra", "one-parameter subgroup", "HasDerivAt", "imaginary axis"]
+      "concepts": [
+        "Lie algebra",
+        "one-parameter subgroup",
+        "HasDerivAt",
+        "imaginary axis"
+      ]
     },
     {
       "id": "sec-summary",
@@ -138,7 +156,11 @@
       "startLine": 128,
       "endLine": 147,
       "summary": "Bundles homomorphism, all-order smoothness, and the Lie algebra generator into the theorem main, the packaged answer to the open question.",
-      "concepts": ["summary", "Lie group exponential", "packaging"]
+      "concepts": [
+        "summary",
+        "Lie group exponential",
+        "packaging"
+      ]
     }
   ],
   "conclusion": {
@@ -153,13 +175,18 @@
     "papers": [
       {
         "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
-        "authors": ["Leonhard Euler"],
+        "authors": [
+          "Leonhard Euler"
+        ],
         "year": 1748,
         "description": "Original derivation of e^(ix) = cos x + i sin x via Taylor series."
       },
       {
         "title": "Theorie der Transformationsgruppen",
-        "authors": ["Sophus Lie", "Friedrich Engel"],
+        "authors": [
+          "Sophus Lie",
+          "Friedrich Engel"
+        ],
         "year": 1888,
         "description": "Foundational text on continuous transformation groups; introduces the exponential map and the Lie algebra as the tangent space at the identity."
       }
@@ -175,12 +202,12 @@
   "crossReferences": [
     {
       "type": "extends",
-      "id": "euler-identity-oq-01-oq-01-oq-01",
+      "proofId": "euler-identity-oq-01-oq-01-oq-01",
       "description": "Upgrades the parent's continuous Lie group homomorphism t ↦ exp(it) to a smooth (C∞/analytic) Lie group exponential in Mathlib's LieGroup framework, with Lie algebra iℝ."
     },
     {
       "type": "related",
-      "id": "euler-identity",
+      "proofId": "euler-identity",
       "description": "Root gallery entry; the smooth exponential is the differential-geometric culmination of Euler's identity."
     }
   ],

--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
@@ -110,7 +110,11 @@
       "startLine": 58,
       "endLine": 88,
       "summary": "Defines circleMap and proves the basic algebraic identities: zero, addition (homomorphism), negation, subtraction, and the connection to Euler's formula from EulerIdentityOQ01OQ01.",
-      "concepts": ["complex exponential", "homomorphism", "Euler's formula"]
+      "concepts": [
+        "complex exponential",
+        "homomorphism",
+        "Euler's formula"
+      ]
     },
     {
       "id": "sec-unit-circle",
@@ -118,7 +122,11 @@
       "startLine": 90,
       "endLine": 102,
       "summary": "Proves ‖circleMap t‖ = 1 using Complex.norm_exp_ofReal_mul_I, and circleMap t ≠ 0 as a corollary.",
-      "concepts": ["unit circle", "norm", "non-vanishing"]
+      "concepts": [
+        "unit circle",
+        "norm",
+        "non-vanishing"
+      ]
     },
     {
       "id": "sec-monoid-hom",
@@ -126,7 +134,11 @@
       "startLine": 104,
       "endLine": 134,
       "summary": "Packages circleMap as circleHom : Multiplicative ℝ →* ℂˣ — the formal Lie-group statement that t ↦ exp(it) is a group homomorphism (ℝ,+) → (ℂˣ,·).",
-      "concepts": ["MonoidHom", "Multiplicative", "Lie group homomorphism"]
+      "concepts": [
+        "MonoidHom",
+        "Multiplicative",
+        "Lie group homomorphism"
+      ]
     },
     {
       "id": "sec-continuity",
@@ -134,7 +146,11 @@
       "startLine": 136,
       "endLine": 148,
       "summary": "Proves continuous_circleMap from continuity of exp composed with continuity of t ↦ ↑t * I.",
-      "concepts": ["continuity", "topological group", "Lie group"]
+      "concepts": [
+        "continuity",
+        "topological group",
+        "Lie group"
+      ]
     },
     {
       "id": "sec-kernel",
@@ -142,7 +158,11 @@
       "startLine": 150,
       "endLine": 175,
       "summary": "Proves circleMap_eq_one_iff: the kernel of the homomorphism is exactly 2π·ℤ. Uses Complex.exp_eq_one_iff and cancels the imaginary unit.",
-      "concepts": ["kernel", "quotient group", "ℝ/2πℤ"]
+      "concepts": [
+        "kernel",
+        "quotient group",
+        "ℝ/2πℤ"
+      ]
     },
     {
       "id": "sec-surjectivity",
@@ -150,7 +170,11 @@
       "startLine": 177,
       "endLine": 195,
       "summary": "Proves circleMap_surjective_unit_circle: every z with ‖z‖ = 1 has the form exp(i · arg z). Uses Complex.cos_arg and Complex.sin_arg with the fact ‖z‖ = 1.",
-      "concepts": ["surjectivity", "polar decomposition", "argument"]
+      "concepts": [
+        "surjectivity",
+        "polar decomposition",
+        "argument"
+      ]
     },
     {
       "id": "sec-demoivre",
@@ -158,7 +182,10 @@
       "startLine": 197,
       "endLine": 220,
       "summary": "Proves circleMap_npow and circleMap_zpow: (circleMap t)^n = circleMap (n·t) for n : ℕ and ℤ. The integer version drops out from Complex.exp_int_mul in 4 lines.",
-      "concepts": ["de Moivre", "homomorphism corollary"]
+      "concepts": [
+        "de Moivre",
+        "homomorphism corollary"
+      ]
     },
     {
       "id": "sec-summary",
@@ -166,7 +193,11 @@
       "startLine": 222,
       "endLine": 241,
       "summary": "Bundles the main result and lists the proven properties as the rigorous form of 'Euler's formula identifies S¹ as a 1-parameter Lie group with Lie algebra iℝ.'",
-      "concepts": ["summary", "Lie algebra", "1-parameter subgroup"]
+      "concepts": [
+        "summary",
+        "Lie algebra",
+        "1-parameter subgroup"
+      ]
     }
   ],
   "conclusion": {
@@ -181,13 +212,18 @@
     "papers": [
       {
         "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
-        "authors": ["Leonhard Euler"],
+        "authors": [
+          "Leonhard Euler"
+        ],
         "year": 1748,
         "description": "Original derivation of e^(ix) = cos x + i sin x via Taylor series."
       },
       {
         "title": "Theorie der Transformationsgruppen",
-        "authors": ["Sophus Lie", "Friedrich Engel"],
+        "authors": [
+          "Sophus Lie",
+          "Friedrich Engel"
+        ],
         "year": 1888,
         "description": "Foundational text on continuous transformation groups; introduces exponential map for Lie groups."
       }
@@ -203,12 +239,12 @@
   "crossReferences": [
     {
       "type": "extends",
-      "id": "euler-identity-oq-01-oq-01",
+      "proofId": "euler-identity-oq-01-oq-01",
       "description": "Builds directly on EulerIdentityOQ01OQ01.euler_formula (axiom-free Taylor proof of exp(ix) = cos x + i sin x) to derive the homomorphism."
     },
     {
       "type": "related",
-      "id": "de-moivre",
+      "proofId": "de-moivre",
       "description": "De Moivre's theorem (circleMap_npow / circleMap_zpow) is a one-line corollary of the homomorphism property + Complex.exp_int_mul."
     }
   ],

--- a/src/data/proofs/euler-identity-oq-01-oq-03/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-03/meta.json
@@ -31,7 +31,11 @@
       "startLine": 59,
       "endLine": 71,
       "summary": "Re-proves e^{ix} = cos x + i·sin x for a real angle in one line from Mathlib's Complex.exp_mul_I, pushing the complex cos/sin to real cos/sin via ofReal_cos/ofReal_sin. This is the same statement the parent reconstructs from the Taylor series; it is taken here as the foundation of the multiplicative theory.",
-      "concepts": ["Euler's formula", "Complex.exp_mul_I", "ofReal_cos / ofReal_sin"]
+      "concepts": [
+        "Euler's formula",
+        "Complex.exp_mul_I",
+        "ofReal_cos / ofReal_sin"
+      ]
     },
     {
       "id": "sec-de-moivre",
@@ -39,7 +43,12 @@
       "startLine": 72,
       "endLine": 101,
       "summary": "De Moivre's theorem for natural and integer exponents: (cos x + i·sin x)^n = cos(nx) + i·sin(nx). Each is Euler's formula applied twice with the exponent law exp_nat_mul / exp_int_mul in between. The integer version covers negative powers.",
-      "concepts": ["De Moivre's theorem", "exp_nat_mul", "exp_int_mul", "zpow / negative exponents"]
+      "concepts": [
+        "De Moivre's theorem",
+        "exp_nat_mul",
+        "exp_int_mul",
+        "zpow / negative exponents"
+      ]
     },
     {
       "id": "sec-rou",
@@ -47,7 +56,12 @@
       "startLine": 103,
       "endLine": 155,
       "summary": "Defines ω_n = exp((2π/n)·I), its geometric form cos(2π/n) + i·sin(2π/n), the root-of-unity property ω_n^n = 1 (via De Moivre at angle 2π/n), and the non-triviality ω_n ≠ 1 for n ≥ 2 (via Complex.exp_eq_one_iff and an integer squeeze).",
-      "concepts": ["roots of unity", "exp_two_pi_mul_I", "Complex.exp_eq_one_iff", "cos_two_pi / sin_two_pi"]
+      "concepts": [
+        "roots of unity",
+        "exp_two_pi_mul_I",
+        "Complex.exp_eq_one_iff",
+        "cos_two_pi / sin_two_pi"
+      ]
     },
     {
       "id": "sec-sum",
@@ -55,7 +69,11 @@
       "startLine": 157,
       "endLine": 173,
       "summary": "∑_{k<n} ω_n^k = 0 for n ≥ 2, via the finite geometric series geom_sum_eq with ω_n^n = 1 and ω_n ≠ 1. The algebraic statement that the centroid of a regular n-gon on the unit circle is the origin.",
-      "concepts": ["geometric series", "geom_sum_eq", "centroid of regular polygon"]
+      "concepts": [
+        "geometric series",
+        "geom_sum_eq",
+        "centroid of regular polygon"
+      ]
     }
   ],
   "leanFile": {
@@ -146,13 +164,17 @@
     "papers": [
       {
         "title": "Miscellanea Analytica de Seriebus et Quadraturis",
-        "authors": ["Abraham de Moivre"],
+        "authors": [
+          "Abraham de Moivre"
+        ],
         "year": 1730,
         "description": "Source of the power law (cos θ + i sin θ)^n = cos nθ + i sin nθ that bears de Moivre's name."
       },
       {
         "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
-        "authors": ["Leonhard Euler"],
+        "authors": [
+          "Leonhard Euler"
+        ],
         "year": 1748,
         "description": "Euler's formula e^{ix} = cos x + i sin x, the identity that turns De Moivre's power law into the exponent law."
       }
@@ -167,17 +189,17 @@
   "crossReferences": [
     {
       "type": "extends",
-      "id": "euler-identity-oq-01",
+      "proofId": "euler-identity-oq-01",
       "description": "Parent: 'Euler's Formula via Taylor Series Splitting' proves e^{ix} = cos x + i·sin x. This file builds the multiplicative layer — De Moivre and the roots of unity — on top of that identity."
     },
     {
       "type": "related",
-      "id": "euler-identity-oq-01-oq-04",
+      "proofId": "euler-identity-oq-01-oq-04",
       "description": "Sibling on the additive side: that file packages ℝ/2πℤ ≃+ Additive Circle (the group structure of S¹); this file develops the power/root-of-unity structure of the same circle."
     },
     {
       "type": "related",
-      "id": "euler-identity",
+      "proofId": "euler-identity",
       "description": "Great-grandparent: the point identity e^{iπ} + 1 = 0 is the n = 2 root of unity ω_2 = e^{iπ} = −1; the sum ∑ ω_2^k = 1 + (−1) = 0 is the simplest case of sum_rou_pow_eq_zero."
     }
   ],

--- a/src/data/proofs/euler-identity-oq-01-oq-04/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-04/meta.json
@@ -122,7 +122,12 @@
       "startLine": 76,
       "endLine": 104,
       "summary": "Proves the private propositional bridge lemma addCircle_toCircle_eq_angle_toCircle. Mathlib v4.26.0 has two distinct (but propositionally equal at T = 2π) lifts of Circle.exp from ℝ → Circle: AddCircle.toCircle (general T) and Real.Angle.toCircle (T = 2π only). The bridge collapses them via div_self on the 2π/2π = 1 reduction, applied to quotient representatives via QuotientAddGroup.induction_on.",
-      "concepts": ["Periodic.lift", "QuotientAddGroup.induction_on", "propositional vs definitional equality", "2π/2π = 1"]
+      "concepts": [
+        "Periodic.lift",
+        "QuotientAddGroup.induction_on",
+        "propositional vs definitional equality",
+        "2π/2π = 1"
+      ]
     },
     {
       "id": "sec-equiv",
@@ -130,7 +135,12 @@
       "startLine": 106,
       "endLine": 163,
       "summary": "Defines addCircleEquivAdditiveCircle : AddCircle (2 * π) ≃+ Additive Circle. Forward: Additive.ofMul ∘ AddCircle.toCircle. Inverse: homeomorphCircle'.symm ∘ Additive.toMul. The three AddEquiv obligations (left_inv, right_inv, map_add') chain through the bridge lemma plus AddCircle.toCircle_add. No sorries.",
-      "concepts": ["AddEquiv", "noncomputable definition", "additive-multiplicative type alias", "homomorphism law"]
+      "concepts": [
+        "AddEquiv",
+        "noncomputable definition",
+        "additive-multiplicative type alias",
+        "homomorphism law"
+      ]
     },
     {
       "id": "sec-api",
@@ -138,7 +148,11 @@
       "startLine": 165,
       "endLine": 175,
       "summary": "Two @[simp] API lemmas (both rfl-provable): addCircleEquivAdditiveCircle_apply documents the forward map as Additive.ofMul ∘ AddCircle.toCircle; addCircleEquivAdditiveCircle_symm_apply documents the inverse as homeomorphCircle'.symm ∘ Additive.toMul. These are the rewrites downstream users need.",
-      "concepts": ["@[simp] API", "rfl-provability", "downstream rewrites"]
+      "concepts": [
+        "@[simp] API",
+        "rfl-provability",
+        "downstream rewrites"
+      ]
     },
     {
       "id": "sec-summary",
@@ -146,7 +160,11 @@
       "startLine": 177,
       "endLine": 197,
       "summary": "Connects this Mathlib-level packaging back to the project's parallel formalization (EulerIdentityOQ01OQ01OQ01 on circleMap : ℝ → ℂ), and explains that this file exhibits the structural statement S¹ ≅ ℝ/2πℤ as a named ≃+ for the first time in the Lean 4 / Mathlib ecosystem.",
-      "concepts": ["S¹ as ℝ/2πℤ", "Lie group exponential", "Mathlib ecosystem"]
+      "concepts": [
+        "S¹ as ℝ/2πℤ",
+        "Lie group exponential",
+        "Mathlib ecosystem"
+      ]
     }
   ],
   "conclusion": {
@@ -163,13 +181,18 @@
     "papers": [
       {
         "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
-        "authors": ["Leonhard Euler"],
+        "authors": [
+          "Leonhard Euler"
+        ],
         "year": 1748,
         "description": "Original derivation of e^(ix) = cos x + i sin x, the analytic identification underlying the additive-group structure on S¹."
       },
       {
         "title": "Theorie der Transformationsgruppen",
-        "authors": ["Sophus Lie", "Friedrich Engel"],
+        "authors": [
+          "Sophus Lie",
+          "Friedrich Engel"
+        ],
         "year": 1888,
         "description": "Foundational text on continuous transformation groups; the prototype Lie group exponential ℝ → S¹ is the model for the construction here."
       }
@@ -183,22 +206,22 @@
   "crossReferences": [
     {
       "type": "extends",
-      "id": "euler-identity-oq-01-oq-01-oq-01",
+      "proofId": "euler-identity-oq-01-oq-01-oq-01",
       "description": "Companion: that file constructs circleHom : Multiplicative ℝ →* ℂˣ from the project's own circleMap (the universal-cover side); this file constructs the corresponding AddCircle (2π) ≃+ Additive Circle on Mathlib's quotient side."
     },
     {
       "type": "related",
-      "id": "euler-identity-oq-01",
+      "proofId": "euler-identity-oq-01",
       "description": "The parent open-question slug. OQ-04 specifically asks for the AddCircle ≃+ Additive Circle packaging that this file delivers."
     },
     {
       "type": "depends-on",
-      "id": "euler-identity-oq-01-oq-01",
+      "proofId": "euler-identity-oq-01-oq-01",
       "description": "Axiom-elimination intermediate: that file removes the axiom dependency from EulerIdentityOQ01, putting Euler's formula on an axiom-free footing. This file inherits that axiom-free status — the construction here uses 0 axioms because the upstream Mathlib pieces (AddCircle.toCircle, homeomorphCircle', toCircle_add) are all axiom-free, and the chain back through the sibling formalizations preserves that."
     },
     {
       "type": "related",
-      "id": "euler-identity",
+      "proofId": "euler-identity",
       "description": "Great-grandparent: the original point identity $e^{i\\pi} + 1 = 0$ that motivates the entire OQ-01 lineage. This file delivers the structural generalization: the same Euler exponential $t \\mapsto e^{it}$ that produces $e^{i\\pi} = -1$ at $t = \\pi$ is the carrier of the additive-group isomorphism $\\mathbb{R}/2\\pi\\mathbb{Z} \\simeq_+ S^1$."
     }
   ],

--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
@@ -142,22 +142,22 @@
   },
   "crossReferences": [
     {
-      "id": "fermat-two-squares-oq-01",
+      "proofId": "fermat-two-squares-oq-01",
       "title": "Lipschitz Quaternions and Four Squares",
       "relationship": "Direct parent: defines LipschitzQuat and the basic Lagrange infrastructure. This entry builds on that foundation by extending to Hurwitz quaternions and adding the Euclidean domain structure."
     },
     {
-      "id": "fermat-two-squares",
+      "proofId": "fermat-two-squares",
       "title": "Fermat's Theorem on Sums of Two Squares",
       "relationship": "Sibling result: characterizes primes of the form a²+b² (p ≡ 1 mod 4) using Gaussian integers. The Hurwitz proof of four squares is analogous but uses quaternions instead of complex numbers."
     },
     {
-      "id": "lagrange-four-squares",
+      "proofId": "lagrange-four-squares",
       "title": "Lagrange's Four Squares Theorem",
       "relationship": "The target theorem: every natural number is a sum of four squares. This entry provides the Hurwitz quaternion proof, which is more algebraically transparent than Lagrange's original infinite-descent argument."
     },
     {
-      "id": "lagrange-four-squares-oq-01",
+      "proofId": "lagrange-four-squares-oq-01",
       "title": "Lagrange Four Squares — Representations via Quaternions",
       "relationship": "Sibling open question exploring representation counts and the role of quaternion arithmetic in the four-squares problem."
     }

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -1,137 +1,137 @@
 {
-    "id": "fundamental-arithmetic-oq-01-oq-01",
-    "title": "Self-Contained FTA via Finsupp Prime Exponent Maps",
-    "slug": "fundamental-arithmetic-oq-01-oq-01",
-    "description": "Proves the Fundamental Theorem of Arithmetic using Mathlib's Nat.factorization (the prime exponent map approach), entirely self-contained without importing the parent file. The key result is a uniqueness theorem: if f : ℕ →₀ ℕ has prime support and f.prod (·^·) = n, then f = n.factorization. This algebraic formulation complements the sorted-list approach of FundamentalArithmetic.lean.",
-    "meta": {
-        "author": "Lean Genius",
-        "date": "2026-05-03",
-        "status": "verified",
-        "proofRepoPath": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
-        "tags": [
-            "number-theory",
-            "factorization",
-            "finsupp",
-            "p-adic-valuation",
-            "unique-factorization",
-            "research"
-        ],
-        "badge": "mathlib",
-        "sorries": 0,
-        "dateAdded": "2026-05-03",
-        "axiomCount": 0,
-        "assumptions": "None. Fully machine-verified.",
-        "lineCount": 220,
-        "theoremCount": 13,
-        "definitionCount": 0,
-        "originalContributions": [
-            "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
-            "fta_uniqueness: uniqueness — only n.factorization satisfies prime support + Finsupp product = n",
-            "fundamental_theorem_of_arithmetic: ∃! f : ℕ →₀ ℕ with prime support and f.prod (·^·) = n (existence via Nat.factorization_prod_pow_eq_self; uniqueness via finsupp_prime_prod_factorization)",
-            "factorization_determines_number: factorization injectivity — equal factorizations imply equal numbers",
-            "factorization_eq_iff_valuations: m = n iff ∀ p, m.factorization p = n.factorization p",
-            "factorization_eq_zero_iff_one: n.factorization = 0 iff n = 1",
-            "fta_mem_support_iff_dvd: prime p divides n iff p ∈ n.factorization.support",
-            "coprime_factorization_disjoint: coprime numbers have disjoint factorization supports"
-        ],
-        "mathlib_version": "4.26.0"
-    },
-    "overview": {
-        "historicalContext": "The Fundamental Theorem of Arithmetic — every positive integer has a unique prime factorization — was known to Euclid (Elements Book IX, ~300 BCE) in the form that a prime dividing a product divides one of the factors. The fully explicit existence+uniqueness statement was first given by Gauss in Disquisitiones Arithmeticae (1801). Hilbert and Dedekind later generalized it: in any Unique Factorization Domain (UFD), every element factors uniquely into irreducibles. The FTA is the prototype for all UFD theory.\n\nModern algebra has two equivalent formulations: (1) the **list** form — $n = p_1 p_2 \\cdots p_k$ as a multiset of primes sorted in non-decreasing order (used in `FundamentalArithmetic.lean`); and (2) the **exponent map** form — $n = \\prod_p p^{v_p(n)}$ where $v_p(n)$ is the $p$-adic valuation (used here). The exponent map form is preferred in algebraic number theory because $v_p : \\mathbb{N}^\\times \\to \\mathbb{N}$ is a group homomorphism and the valuations add under multiplication. Mathlib's `Nat.factorization` implements the exponent map as a Finsupp (finite support function), making this algebraic structure available in Lean 4.",
-        "problemStatement": "Can the unique factorization theorem be proved in a self-contained way that avoids importing the parent FundamentalArithmetic.lean, using only Mathlib's Nat.factorization primitives? Specifically: does every positive natural n admit a UNIQUE representation as f.prod (·^·) where f : ℕ →₀ ℕ has prime support?",
-        "text": "Yes. The Finsupp-based FTA states: for every n ≠ 0, there exists a unique f : ℕ →₀ ℕ with (∀ p ∈ f.support, p.Prime) and f.prod (·^·) = n. The canonical witness is n.factorization, the Mathlib prime exponent map. The key algebraic lemma is: (f.prod (·^·)).factorization = f when f has prime support — proving that factorization and reconstruction are mutual inverses.",
-        "proofStrategy": "The proof proceeds in three stages: (1) Existence: Nat.factorization_prod_pow_eq_self gives n.factorization.prod (·^·) = n directly. (2) Key lemma: To show (f.prod (·^·)).factorization = f, apply Finsupp.ext and compute the a-component. Distribute factorization over the product using factorization_finset_prod, then use factorization_pow and Prime.factorization to reduce each term to an indicator function. Collapse with Finset.sum_ite_eq. (3) Uniqueness: Any g with g.prod (·^·) = n satisfies g = (g.prod (·^·)).factorization = n.factorization.",
-        "keyInsights": [
-            "Nat.factorization and Finsupp.prod (·^·) are mutual inverses on the space of prime-supported Finsupps — establishing a bijection between positive naturals and prime exponent maps",
-            "The factorization distributes over products: (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization (for nonzero m), proved by induction using Nat.factorization_mul",
-            "For prime p, p.factorization = Finsupp.single p 1 — so (p^k).factorization a = if p = a then k else 0, making the indicator-sum argument clean",
-            "The Finsupp representation is algebraically cleaner than the list representation: factorization(m·n) = factorization(m) + factorization(n) in the Finsupp sense, and coprimality is disjoint support",
-            "The uniqueness proof is a single two-step calculation: g = (g.prod (·^·)).factorization (by the key lemma) = n.factorization (by the hypothesis g.prod (·^·) = n). This is the Finsupp analogue of saying the factorization map is injective — the only preimage of n under f ↦ f.prod (·^·) is n.factorization itself."
-        ],
-        "prerequisites": [
-            "Finsupp: Lean 4 type for finitely-supported functions α →₀ M",
-            "Nat.factorization: the prime exponent map n ↦ (p ↦ v_p(n))",
-            "Nat.primeFactors: the finite set of prime divisors of n",
-            "Finsupp.prod: ∏ p ∈ f.support, g p (f p)"
-        ]
-    },
-    "sections": [
-        {
-            "id": "helper",
-            "title": "Helper: Factorization Distributes Over Products",
-            "startLine": 34,
-            "endLine": 50,
-            "summary": "Proves factorization distributes over Finset products of nonzero naturals: (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization. Proof by induction on s using Nat.factorization_mul."
-        },
-        {
-            "id": "existence",
-            "title": "Existence: Reconstruction and Support",
-            "startLine": 52,
-            "endLine": 81,
-            "summary": "Proves fta_reconstruction (n.factorization.prod (·^·) = n), fta_support_eq_primeFactors, fta_support_prime, and fta_mem_support_iff_dvd — establishing n.factorization as the canonical prime exponent map."
-        },
-        {
-            "id": "key-lemma",
-            "title": "Key Algebraic Lemma",
-            "startLine": 83,
-            "endLine": 118,
-            "summary": "For any f : ℕ →₀ ℕ with prime support: (f.prod (·^·)).factorization = f. Applies Finsupp.ext, distributes factorization over the product, and uses factorization_pow + Prime.factorization to reduce to an indicator-sum argument."
-        },
-        {
-            "id": "uniqueness",
-            "title": "Uniqueness of the Representation",
-            "startLine": 120,
-            "endLine": 131,
-            "summary": "If g has prime support and g.prod (·^·) = n, then g = n.factorization. Follows directly from the key lemma via a two-step calc."
-        },
-        {
-            "id": "fta",
-            "title": "Full FTA Statement",
-            "startLine": 133,
-            "endLine": 154,
-            "summary": "∃! f : ℕ →₀ ℕ, (∀ p ∈ f.support, p.Prime) ∧ f.prod (·^·) = n. The canonical witness is n.factorization; uniqueness follows from the key lemma."
-        },
-        {
-            "id": "corollaries",
-            "title": "Corollaries and Examples",
-            "startLine": 156,
-            "endLine": 219,
-            "summary": "Injectivity of factorization on positive naturals; m = n iff factorizations agree at every prime; n = 1 iff factorization is zero; coprime numbers have disjoint factorization supports. Includes native_decide examples for 12, 30, and coprimality."
-        }
+  "id": "fundamental-arithmetic-oq-01-oq-01",
+  "title": "Self-Contained FTA via Finsupp Prime Exponent Maps",
+  "slug": "fundamental-arithmetic-oq-01-oq-01",
+  "description": "Proves the Fundamental Theorem of Arithmetic using Mathlib's Nat.factorization (the prime exponent map approach), entirely self-contained without importing the parent file. The key result is a uniqueness theorem: if f : ℕ →₀ ℕ has prime support and f.prod (·^·) = n, then f = n.factorization. This algebraic formulation complements the sorted-list approach of FundamentalArithmetic.lean.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-05-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "factorization",
+      "finsupp",
+      "p-adic-valuation",
+      "unique-factorization",
+      "research"
     ],
-    "conclusion": {
-        "summary": "The FTA has a clean algebraic formulation via Finsupp: every positive natural has a unique prime exponent map. This self-contained proof avoids the parent file entirely, demonstrating that Mathlib's Nat.factorization machinery is sufficient to prove both existence and uniqueness from scratch.",
-        "implications": "The key insight is that factorization and reconstruction are mutual inverses — a consequence of Nat.factorization_prod_pow_eq_self combined with the distribution of factorization over products. This algebraic approach complements the sorted-list FTA: the Finsupp formulation has cleaner multiplicative structure (factorization is a monoid homomorphism) while the list formulation is more computationally explicit.",
-        "openQuestions": [
-            "Can the Finsupp FTA be extended to prove the Euler product formula ζ(s) = ∏(1-p^{-s})^{-1}?",
-            "Does the Finsupp approach simplify the proof of unique factorization in number fields via Dedekind domains?"
-        ]
-    },
-    "leanFile": {
-        "path": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
-        "namespace": "FundamentalArithmeticOQ01OQ01",
-        "axiomCount": 0,
-        "lineCount": 220,
-        "theoremCount": 13,
-        "sorries": 0,
-        "definitionCount": 0
-    },
-    "crossReferences": [
-        {
-            "id": "fundamental-arithmetic",
-            "relationship": "parent",
-            "description": "Parent proof using the sorted-list approach (Nat.primeFactorsList)"
-        },
-        {
-            "id": "fundamental-arithmetic-oq-01",
-            "relationship": "sibling",
-            "description": "Multiplicative property of factorization — factorization(m·n) = factorization(m) + factorization(n)"
-        },
-        {
-            "id": "fundamental-arithmetic-oq-02",
-            "relationship": "sibling",
-            "description": "Failure of unique factorization in ℤ[√(-5)]"
-        }
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-05-03",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified.",
+    "lineCount": 220,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "originalContributions": [
+      "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
+      "fta_uniqueness: uniqueness — only n.factorization satisfies prime support + Finsupp product = n",
+      "fundamental_theorem_of_arithmetic: ∃! f : ℕ →₀ ℕ with prime support and f.prod (·^·) = n (existence via Nat.factorization_prod_pow_eq_self; uniqueness via finsupp_prime_prod_factorization)",
+      "factorization_determines_number: factorization injectivity — equal factorizations imply equal numbers",
+      "factorization_eq_iff_valuations: m = n iff ∀ p, m.factorization p = n.factorization p",
+      "factorization_eq_zero_iff_one: n.factorization = 0 iff n = 1",
+      "fta_mem_support_iff_dvd: prime p divides n iff p ∈ n.factorization.support",
+      "coprime_factorization_disjoint: coprime numbers have disjoint factorization supports"
     ],
-    "sorries": 0
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Fundamental Theorem of Arithmetic — every positive integer has a unique prime factorization — was known to Euclid (Elements Book IX, ~300 BCE) in the form that a prime dividing a product divides one of the factors. The fully explicit existence+uniqueness statement was first given by Gauss in Disquisitiones Arithmeticae (1801). Hilbert and Dedekind later generalized it: in any Unique Factorization Domain (UFD), every element factors uniquely into irreducibles. The FTA is the prototype for all UFD theory.\n\nModern algebra has two equivalent formulations: (1) the **list** form — $n = p_1 p_2 \\cdots p_k$ as a multiset of primes sorted in non-decreasing order (used in `FundamentalArithmetic.lean`); and (2) the **exponent map** form — $n = \\prod_p p^{v_p(n)}$ where $v_p(n)$ is the $p$-adic valuation (used here). The exponent map form is preferred in algebraic number theory because $v_p : \\mathbb{N}^\\times \\to \\mathbb{N}$ is a group homomorphism and the valuations add under multiplication. Mathlib's `Nat.factorization` implements the exponent map as a Finsupp (finite support function), making this algebraic structure available in Lean 4.",
+    "problemStatement": "Can the unique factorization theorem be proved in a self-contained way that avoids importing the parent FundamentalArithmetic.lean, using only Mathlib's Nat.factorization primitives? Specifically: does every positive natural n admit a UNIQUE representation as f.prod (·^·) where f : ℕ →₀ ℕ has prime support?",
+    "text": "Yes. The Finsupp-based FTA states: for every n ≠ 0, there exists a unique f : ℕ →₀ ℕ with (∀ p ∈ f.support, p.Prime) and f.prod (·^·) = n. The canonical witness is n.factorization, the Mathlib prime exponent map. The key algebraic lemma is: (f.prod (·^·)).factorization = f when f has prime support — proving that factorization and reconstruction are mutual inverses.",
+    "proofStrategy": "The proof proceeds in three stages: (1) Existence: Nat.factorization_prod_pow_eq_self gives n.factorization.prod (·^·) = n directly. (2) Key lemma: To show (f.prod (·^·)).factorization = f, apply Finsupp.ext and compute the a-component. Distribute factorization over the product using factorization_finset_prod, then use factorization_pow and Prime.factorization to reduce each term to an indicator function. Collapse with Finset.sum_ite_eq. (3) Uniqueness: Any g with g.prod (·^·) = n satisfies g = (g.prod (·^·)).factorization = n.factorization.",
+    "keyInsights": [
+      "Nat.factorization and Finsupp.prod (·^·) are mutual inverses on the space of prime-supported Finsupps — establishing a bijection between positive naturals and prime exponent maps",
+      "The factorization distributes over products: (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization (for nonzero m), proved by induction using Nat.factorization_mul",
+      "For prime p, p.factorization = Finsupp.single p 1 — so (p^k).factorization a = if p = a then k else 0, making the indicator-sum argument clean",
+      "The Finsupp representation is algebraically cleaner than the list representation: factorization(m·n) = factorization(m) + factorization(n) in the Finsupp sense, and coprimality is disjoint support",
+      "The uniqueness proof is a single two-step calculation: g = (g.prod (·^·)).factorization (by the key lemma) = n.factorization (by the hypothesis g.prod (·^·) = n). This is the Finsupp analogue of saying the factorization map is injective — the only preimage of n under f ↦ f.prod (·^·) is n.factorization itself."
+    ],
+    "prerequisites": [
+      "Finsupp: Lean 4 type for finitely-supported functions α →₀ M",
+      "Nat.factorization: the prime exponent map n ↦ (p ↦ v_p(n))",
+      "Nat.primeFactors: the finite set of prime divisors of n",
+      "Finsupp.prod: ∏ p ∈ f.support, g p (f p)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "helper",
+      "title": "Helper: Factorization Distributes Over Products",
+      "startLine": 34,
+      "endLine": 50,
+      "summary": "Proves factorization distributes over Finset products of nonzero naturals: (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization. Proof by induction on s using Nat.factorization_mul."
+    },
+    {
+      "id": "existence",
+      "title": "Existence: Reconstruction and Support",
+      "startLine": 52,
+      "endLine": 81,
+      "summary": "Proves fta_reconstruction (n.factorization.prod (·^·) = n), fta_support_eq_primeFactors, fta_support_prime, and fta_mem_support_iff_dvd — establishing n.factorization as the canonical prime exponent map."
+    },
+    {
+      "id": "key-lemma",
+      "title": "Key Algebraic Lemma",
+      "startLine": 83,
+      "endLine": 118,
+      "summary": "For any f : ℕ →₀ ℕ with prime support: (f.prod (·^·)).factorization = f. Applies Finsupp.ext, distributes factorization over the product, and uses factorization_pow + Prime.factorization to reduce to an indicator-sum argument."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness of the Representation",
+      "startLine": 120,
+      "endLine": 131,
+      "summary": "If g has prime support and g.prod (·^·) = n, then g = n.factorization. Follows directly from the key lemma via a two-step calc."
+    },
+    {
+      "id": "fta",
+      "title": "Full FTA Statement",
+      "startLine": 133,
+      "endLine": 154,
+      "summary": "∃! f : ℕ →₀ ℕ, (∀ p ∈ f.support, p.Prime) ∧ f.prod (·^·) = n. The canonical witness is n.factorization; uniqueness follows from the key lemma."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries and Examples",
+      "startLine": 156,
+      "endLine": 219,
+      "summary": "Injectivity of factorization on positive naturals; m = n iff factorizations agree at every prime; n = 1 iff factorization is zero; coprime numbers have disjoint factorization supports. Includes native_decide examples for 12, 30, and coprimality."
+    }
+  ],
+  "conclusion": {
+    "summary": "The FTA has a clean algebraic formulation via Finsupp: every positive natural has a unique prime exponent map. This self-contained proof avoids the parent file entirely, demonstrating that Mathlib's Nat.factorization machinery is sufficient to prove both existence and uniqueness from scratch.",
+    "implications": "The key insight is that factorization and reconstruction are mutual inverses — a consequence of Nat.factorization_prod_pow_eq_self combined with the distribution of factorization over products. This algebraic approach complements the sorted-list FTA: the Finsupp formulation has cleaner multiplicative structure (factorization is a monoid homomorphism) while the list formulation is more computationally explicit.",
+    "openQuestions": [
+      "Can the Finsupp FTA be extended to prove the Euler product formula ζ(s) = ∏(1-p^{-s})^{-1}?",
+      "Does the Finsupp approach simplify the proof of unique factorization in number fields via Dedekind domains?"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
+    "namespace": "FundamentalArithmeticOQ01OQ01",
+    "axiomCount": 0,
+    "lineCount": 220,
+    "theoremCount": 13,
+    "sorries": 0,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "proofId": "fundamental-arithmetic",
+      "relationship": "parent",
+      "description": "Parent proof using the sorted-list approach (Nat.primeFactorsList)"
+    },
+    {
+      "proofId": "fundamental-arithmetic-oq-01",
+      "relationship": "sibling",
+      "description": "Multiplicative property of factorization — factorization(m·n) = factorization(m) + factorization(n)"
+    },
+    {
+      "proofId": "fundamental-arithmetic-oq-02",
+      "relationship": "sibling",
+      "description": "Failure of unique factorization in ℤ[√(-5)]"
+    }
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01-oq-02/meta.json
@@ -177,12 +177,12 @@
   ],
   "crossReferences": [
     {
-      "id": "group-order-prime-squared-abelian-oq-01-oq-01",
+      "proofId": "group-order-prime-squared-abelian-oq-01-oq-01",
       "relationship": "parent",
       "description": "supplies the exponent characterizations exponent_eq_sq_iff_isCyclic and exponent_eq_prime_iff_not_isCyclic through which this entry restates the structure theorem"
     },
     {
-      "id": "group-order-prime-squared-abelian-oq-01",
+      "proofId": "group-order-prime-squared-abelian-oq-01",
       "relationship": "grandparent",
       "description": "supplies abelian-ness (mul_comm_of_card_eq_prime_sq) and the cyclic/exponent-p dichotomy (pow_prime_eq_one_of_not_isCyclic) consumed by the elementary-abelian construction"
     }

--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01/meta.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01/meta.json
@@ -133,7 +133,7 @@
   },
   "crossReferences": [
     {
-      "id": "group-order-prime-squared-abelian-oq-01",
+      "proofId": "group-order-prime-squared-abelian-oq-01",
       "relationship": "parent",
       "description": "supplies the cyclic/exponent-p dichotomy and the order trichotomy that this entry reframes through the exponent invariant"
     }

--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-03/meta.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-03/meta.json
@@ -129,12 +129,12 @@
   },
   "crossReferences": [
     {
-      "id": "group-order-prime-squared-abelian-oq-01",
+      "proofId": "group-order-prime-squared-abelian-oq-01",
       "relationship": "parent",
       "description": "supplies the cyclic/elementary-abelian dichotomy and the order trichotomy (orders are 1, p, or p²) underlying the census"
     },
     {
-      "id": "group-order-prime-squared-abelian-oq-01-oq-01",
+      "proofId": "group-order-prime-squared-abelian-oq-01-oq-01",
       "relationship": "sibling",
       "description": "provides orderOf_eq_prime_of_not_isCyclic (every non-identity element has order exactly p in the non-cyclic case), the precise input used to count the p²−1 order-p elements"
     }

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "intermediate-value-theorem-oq-02-oq-03",
   "title": "Constructive vs Classical IVT: Avoiding Classical Logic in Bisection",
   "slug": "intermediate-value-theorem-oq-02-oq-03",
-  "description": "Answers the question: can the constructive IVT be proved without classical logic? YES for the structural bisection core \u2014 width bounds, sign preservation, and monotonicity are proved via a parameterized bisection (a computable `def`, not `noncomputable`) that takes explicit Bool choices instead of computing `if f(mid) \u2264 0`. NO for the exact root: endpoint convergence requires Classical.choice via completeness of \u211d. Identifies and formalizes the exact classical boundary.",
+  "description": "Answers the question: can the constructive IVT be proved without classical logic? YES for the structural bisection core — width bounds, sign preservation, and monotonicity are proved via a parameterized bisection (a computable `def`, not `noncomputable`) that takes explicit Bool choices instead of computing `if f(mid) ≤ 0`. NO for the exact root: endpoint convergence requires Classical.choice via completeness of ℝ. Identifies and formalizes the exact classical boundary.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-05-03",
@@ -20,16 +20,16 @@
     "sorries": 0,
     "dateAdded": "2026-05-03",
     "axiomCount": 0,
-    "assumptions": "None. Constructive core (Parts I-V) uses no classical axioms. Endpoint convergence (Part VI) uses Classical.choice via Mathlib's tendsto_atTop_ciSup (completeness of \u211d). Root theorem (Part VII) uses Continuous.tendsto. Defs are marked `noncomputable` only because Mathlib's \u211d is itself noncomputable (its division uses Real.instDivInvMonoid); the *proof content* avoids Classical.em throughout the constructive core.",
+    "assumptions": "None. Constructive core (Parts I-V) uses no classical axioms. Endpoint convergence (Part VI) uses Classical.choice via Mathlib's tendsto_atTop_ciSup (completeness of ℝ). Root theorem (Part VII) uses Continuous.tendsto. Defs are marked `noncomputable` only because Mathlib's ℝ is itself noncomputable (its division uses Real.instDivInvMonoid); the *proof content* avoids Classical.em throughout the constructive core.",
     "lineCount": 416,
     "theoremCount": 18,
     "definitionCount": 6,
     "originalContributions": [
       "paramBisect: bisection parameterized by explicit choice oracle — proof content avoids Classical.em throughout the constructive core",
-      "paramBisect_width: exact width formula (b-a)/2^n for any choice sequence \u2014 no classical logic",
-      "paramBisect_sign: sign invariant f(left)\u22640\u2264f(right) preserved given SignConsistent oracle \u2014 no classical logic",
-      "paramBisect_nested: interval nesting \u2014 later intervals contained in earlier ones",
-      "paramBisect_width_tendsto_zero: width\u21920 for any choice sequence",
+      "paramBisect_width: exact width formula (b-a)/2^n for any choice sequence — no classical logic",
+      "paramBisect_sign: sign invariant f(left)≤0≤f(right) preserved given SignConsistent oracle — no classical logic",
+      "paramBisect_nested: interval nesting — later intervals contained in earlier ones",
+      "paramBisect_width_tendsto_zero: width→0 for any choice sequence",
       "paramBisect_endpoints_converge: endpoints converge to common limit (classical, via tendsto_atTop_ciSup)",
       "bisection_limit_is_root: limit is root when f continuous and choices sign-consistent",
       "constructive_vs_classical_ivt: complete summary of constructive vs classical boundary",
@@ -41,9 +41,9 @@
     "openQuestions": [
       {
         "id": "oq-01",
-        "question": "For functions with Decidable comparisons (e.g., polynomial sign over \u211a), does paramBisect give a fully computable IVT with no noncomputable components at all?",
+        "question": "For functions with Decidable comparisons (e.g., polynomial sign over ℚ), does paramBisect give a fully computable IVT with no noncomputable components at all?",
         "status": "resolved",
-        "resolution": "Yes, modulo completeness of \u211d. Part IX (Session 2, 2026-06-09) introduces `algoBisect g n p` that takes a Bool sign oracle directly, and proves it equals `paramBisect (oracleChoices g p) n p`. When the user supplies a correct Bool oracle, the iteration, width formula, and sign invariant are all computed without Classical.em \u2014 only the limit step uses Classical.choice via ciSup/ciInf."
+        "resolution": "Yes, modulo completeness of ℝ. Part IX (Session 2, 2026-06-09) introduces `algoBisect g n p` that takes a Bool sign oracle directly, and proves it equals `paramBisect (oracleChoices g p) n p`. When the user supplies a correct Bool oracle, the iteration, width formula, and sign invariant are all computed without Classical.em — only the limit step uses Classical.choice via ciSup/ciInf."
       },
       {
         "id": "oq-02",
@@ -67,15 +67,15 @@
       "title": "Computable Parameterized Bisection",
       "startLine": 57,
       "endLine": 75,
-      "summary": "Defines paramBisectStep, paramBisect, paramBisectMid \u2014 computable defs (not noncomputable) parameterized by explicit Bool choice oracle instead of computing 'if f(mid) \u2264 0'.",
-      "mathContext": "paramBisect(choices, $n$, $(a,b)$) $\\in \\mathbb{R}^2$ for any choices: $\\mathbb{N} \\to$ Bool \u2014 no Decidable instance on $\\mathbb{R}$ needed."
+      "summary": "Defines paramBisectStep, paramBisect, paramBisectMid — computable defs (not noncomputable) parameterized by explicit Bool choice oracle instead of computing 'if f(mid) ≤ 0'.",
+      "mathContext": "paramBisect(choices, $n$, $(a,b)$) $\\in \\mathbb{R}^2$ for any choices: $\\mathbb{N} \\to$ Bool — no Decidable instance on $\\mathbb{R}$ needed."
     },
     {
       "id": "width-formula",
-      "title": "Width Formula: (b-a)/2^n \u2014 Constructive",
+      "title": "Width Formula: (b-a)/2^n — Constructive",
       "startLine": 76,
       "endLine": 156,
-      "summary": "Proves exact width formula, ordering (left\u2264right), nondecreasing left/nonincreasing right, containment in [a,b], and interval nesting \u2014 all constructively via induction on Bool choices.",
+      "summary": "Proves exact width formula, ordering (left≤right), nondecreasing left/nonincreasing right, containment in [a,b], and interval nesting — all constructively via induction on Bool choices.",
       "mathContext": "$(r_n - l_n) = (b-a)/2^n$. Proved by induction: base case trivial; step uses paramBisectStep_width (Bool cases) + ring."
     },
     {
@@ -83,7 +83,7 @@
       "title": "Sign Preservation (Constructive)",
       "startLine": 157,
       "endLine": 189,
-      "summary": "Defines SignConsistent oracle hypothesis and proves paramBisect_sign: the invariant f(left_n)\u22640\u2264f(right_n) is preserved by any sign-consistent oracle \u2014 no classical logic.",
+      "summary": "Defines SignConsistent oracle hypothesis and proves paramBisect_sign: the invariant f(left_n)≤0≤f(right_n) is preserved by any sign-consistent oracle — no classical logic.",
       "mathContext": "SignConsistent$(f, \\text{choices}, p, n)$: $\\forall k < n$, choices$(k) = \\text{true} \\iff f(\\text{mid}_k) \\leq 0$. Given this, $f(l_n) \\leq 0 \\leq f(r_n)$ by induction."
     },
     {
@@ -91,15 +91,15 @@
       "title": "Width Convergence",
       "startLine": 190,
       "endLine": 208,
-      "summary": "Proves width\u21920 using tendsto_pow_atTop_nhds_zero_of_lt_one for (1/2)^n. No classical axioms beyond \u211d's topology.",
+      "summary": "Proves width→0 using tendsto_pow_atTop_nhds_zero_of_lt_one for (1/2)^n. No classical axioms beyond ℝ's topology.",
       "mathContext": "$\\lim_{n\\to\\infty} (b-a)/2^n = 0$. Uses `tendsto_pow_atTop_nhds_zero_of_lt_one` with $|1/2| < 1$."
     },
     {
       "id": "endpoint-convergence",
-      "title": "Endpoint Convergence \u2014 Classical Boundary",
+      "title": "Endpoint Convergence — Classical Boundary",
       "startLine": 209,
       "endLine": 247,
-      "summary": "Proves endpoints converge to common limit via tendsto_atTop_ciSup and ciInf (completeness of \u211d). First step requiring Classical.choice.",
+      "summary": "Proves endpoints converge to common limit via tendsto_atTop_ciSup and ciInf (completeness of ℝ). First step requiring Classical.choice.",
       "mathContext": "$x_L = \\sup_n l_n$, $x_R = \\inf_n r_n$, and $x_R - x_L = \\lim(r_n - l_n) = 0 \\Rightarrow x_L = x_R$. Uses `Classical.choice` via `tendsto_atTop_ciSup`."
     },
     {
@@ -107,7 +107,7 @@
       "title": "Root Theorem (Classical)",
       "startLine": 248,
       "endLine": 285,
-      "summary": "Proves limit point is a root via continuity squeeze: f(left_n)\u22640\u2264f(right_n) and both tend to x \u2192 f(x)=0.",
+      "summary": "Proves limit point is a root via continuity squeeze: f(left_n)≤0≤f(right_n) and both tend to x → f(x)=0.",
       "mathContext": "$f(l_n) \\leq 0$, $l_n \\to x$, $f$ continuous $\\Rightarrow f(x) \\leq 0$; similarly $f(x) \\geq 0$; hence $f(x) = 0$."
     },
     {
@@ -116,46 +116,46 @@
       "startLine": 286,
       "endLine": 308,
       "summary": "constructive_vs_classical_ivt: conjunction assembling all results and precisely identifying which require Classical.choice (endpoint convergence) vs which are fully constructive.",
-      "mathContext": "Parts (1)\u2013(3): provable in Bishop-style constructive mathematics (no LEM). Part (4): requires $\\sup$/$\\inf$ completeness \u2014 equivalent to Classical.choice for real-valued functions."
+      "mathContext": "Parts (1)–(3): provable in Bishop-style constructive mathematics (no LEM). Part (4): requires $\\sup$/$\\inf$ completeness — equivalent to Classical.choice for real-valued functions."
     },
     {
       "id": "decidable-oracle-extension",
-      "title": "Decidable Sign Oracle \u21d2 Fully Algorithmic Bisection (closes oq-01)",
+      "title": "Decidable Sign Oracle ⇒ Fully Algorithmic Bisection (closes oq-01)",
       "startLine": 309,
       "endLine": 416,
-      "summary": "Part IX (Session 2, 2026-06-09): introduces `algoBisect g n p`, driven by a Bool sign oracle `g : \u211d \u2192 Bool` directly with no external choices. Defines `oracleChoices g p n = g(mid of algoBisect g n p)` and proves `algoBisect_eq_paramBisect`, transferring all constructive results from paramBisect. Concludes `algoBisect_sign`, `algoBisect_width`, and `algoBisect_converges_to_root`. (Marked `noncomputable` because Mathlib's \u211d is itself noncomputable \u2014 the proof content avoids Classical.em; only completeness of \u211d uses Classical.choice at the limit step.)",
+      "summary": "Part IX (Session 2, 2026-06-09): introduces `algoBisect g n p`, driven by a Bool sign oracle `g : ℝ → Bool` directly with no external choices. Defines `oracleChoices g p n = g(mid of algoBisect g n p)` and proves `algoBisect_eq_paramBisect`, transferring all constructive results from paramBisect. Concludes `algoBisect_sign`, `algoBisect_width`, and `algoBisect_converges_to_root`. (Marked `noncomputable` because Mathlib's ℝ is itself noncomputable — the proof content avoids Classical.em; only completeness of ℝ uses Classical.choice at the limit step.)",
       "mathContext": "Given any Bool oracle $g : \\mathbb{R} \\to$ Bool with $g(x) = \\text{true} \\iff f(x) \\leq 0$, the algorithmic bisection $\\text{algoBisect}$ is fully computable. The structural theorems (width formula, sign invariant) require no classical axioms at any finite precision; Classical.choice enters only at the convergence step (completeness of $\\mathbb{R}$). For concrete decidable f-classes (e.g., rational-coefficient polynomials evaluated at rationals), the entire iteration becomes executable."
     }
   ],
   "overview": {
-    "historicalContext": "The Intermediate Value Theorem (IVT) is one of the foundational results of real analysis, tracing back to Bolzano (1817) and Cauchy (1821). The classical proof relies on the least upper bound property of \u211d \u2014 a non-constructive axiom. In constructive mathematics (Brouwer, Bishop), the IVT is NOT provable in general: a continuous function can satisfy f(a) < 0 < f(b) without having a computable root.\n\nBishop (1967) showed that the IVT becomes provable constructively if f is **locally non-constant** (a stronger hypothesis). Without this, the bisection argument gets stuck at choosing which half-interval to recurse into \u2014 this requires knowing whether f(mid) \u2264 0 or f(mid) > 0, which requires decidability of real-number comparisons.\n\nThis entry formalizes the precise classical boundary: the bisection **structure** (width formula, sign invariant, width-to-zero) is constructive; the **convergence to a root** requires Classical.choice via the completeness of \u211d.",
-    "problemStatement": "**OQ-02-OQ-03**: Can the constructive IVT be proved in Lean 4 without classical logic?\n\n**Answer**: Partial YES/NO \u2014 the bisection structure is constructive, but convergence requires Classical.choice:\n- **Constructive** (no Classical.em): width formula (b-a)/2^n, sign invariant, width\u21920\n- **Classical** (needs Classical.choice): endpoint convergence, root theorem\n\nThe key technique: parameterize the bisection by an explicit `choices: \u2115 \u2192 Bool` oracle, separating the computable structure from the classical choice.",
-    "proofStrategy": "The parameterized bisection `paramBisect choices n (a,b)` takes an explicit oracle sequence instead of computing branch decisions. This separates two concerns: (1) the structural theorems (width, ordering, sign) which are proved by induction on the oracle without any classical reasoning; (2) the choice of oracle (which branch actually has the correct sign) which requires decidability of f(mid) \u2264 0 \u2014 a classical statement. Convergence is then proved using Mathlib's `tendsto_atTop_ciSup` and `tendsto_atTop_ciInf`, which use completeness of \u211d (Classical.choice).",
+    "historicalContext": "The Intermediate Value Theorem (IVT) is one of the foundational results of real analysis, tracing back to Bolzano (1817) and Cauchy (1821). The classical proof relies on the least upper bound property of ℝ — a non-constructive axiom. In constructive mathematics (Brouwer, Bishop), the IVT is NOT provable in general: a continuous function can satisfy f(a) < 0 < f(b) without having a computable root.\n\nBishop (1967) showed that the IVT becomes provable constructively if f is **locally non-constant** (a stronger hypothesis). Without this, the bisection argument gets stuck at choosing which half-interval to recurse into — this requires knowing whether f(mid) ≤ 0 or f(mid) > 0, which requires decidability of real-number comparisons.\n\nThis entry formalizes the precise classical boundary: the bisection **structure** (width formula, sign invariant, width-to-zero) is constructive; the **convergence to a root** requires Classical.choice via the completeness of ℝ.",
+    "problemStatement": "**OQ-02-OQ-03**: Can the constructive IVT be proved in Lean 4 without classical logic?\n\n**Answer**: Partial YES/NO — the bisection structure is constructive, but convergence requires Classical.choice:\n- **Constructive** (no Classical.em): width formula (b-a)/2^n, sign invariant, width→0\n- **Classical** (needs Classical.choice): endpoint convergence, root theorem\n\nThe key technique: parameterize the bisection by an explicit `choices: ℕ → Bool` oracle, separating the computable structure from the classical choice.",
+    "proofStrategy": "The parameterized bisection `paramBisect choices n (a,b)` takes an explicit oracle sequence instead of computing branch decisions. This separates two concerns: (1) the structural theorems (width, ordering, sign) which are proved by induction on the oracle without any classical reasoning; (2) the choice of oracle (which branch actually has the correct sign) which requires decidability of f(mid) ≤ 0 — a classical statement. Convergence is then proved using Mathlib's `tendsto_atTop_ciSup` and `tendsto_atTop_ciInf`, which use completeness of ℝ (Classical.choice).",
     "keyInsights": [
-      "**The oracle abstraction**: By parameterizing bisection by `choices: \u2115 \u2192 Bool` instead of computing `if f(mid) \u2264 0`, the structural theorems (width formula, sign invariant) become fully constructive inductions. The classical content is isolated to the question 'which oracle is sign-consistent?'",
-      "**The classical boundary**: Endpoint convergence requires `ciSup`/`ciInf` (supremum/infimum of bounded sequences), which Mathlib proves using `Classical.choice` via completeness of \u211d. This is unavoidable in standard Lean/Mathlib without a constructive reals model.",
+      "**The oracle abstraction**: By parameterizing bisection by `choices: ℕ → Bool` instead of computing `if f(mid) ≤ 0`, the structural theorems (width formula, sign invariant) become fully constructive inductions. The classical content is isolated to the question 'which oracle is sign-consistent?'",
+      "**The classical boundary**: Endpoint convergence requires `ciSup`/`ciInf` (supremum/infimum of bounded sequences), which Mathlib proves using `Classical.choice` via completeness of ℝ. This is unavoidable in standard Lean/Mathlib without a constructive reals model.",
       "**Bishop's insight in Lean**: Bishop (1967) showed the IVT is constructively unprovable for general continuous functions. This entry formalizes *why*: not the theorem itself, but the precise location where classical logic enters the bisection proof.",
-      "**Computability vs provability**: `paramBisect` is a `def` (computable) while `noncomputable` is avoided throughout the constructive core. This makes the theorem suitable for code extraction if the oracle is supplied by a Decidable instance (e.g., polynomial sign over \u211a).",
-      "**The squeeze at the limit**: The root theorem uses `le_of_tendsto` and `ge_of_tendsto` \u2014 the key squeeze argument: f(left_n)\u22640 for all n and left_n\u2192x with f continuous gives f(x)\u22640; similarly f(x)\u22650 from right. No classical logic needed once we *have* the limit x."
+      "**Computability vs provability**: `paramBisect` is a `def` (computable) while `noncomputable` is avoided throughout the constructive core. This makes the theorem suitable for code extraction if the oracle is supplied by a Decidable instance (e.g., polynomial sign over ℚ).",
+      "**The squeeze at the limit**: The root theorem uses `le_of_tendsto` and `ge_of_tendsto` — the key squeeze argument: f(left_n)≤0 for all n and left_n→x with f continuous gives f(x)≤0; similarly f(x)≥0 from right. No classical logic needed once we *have* the limit x."
     ]
   },
   "conclusion": {
-    "summary": "The exact classical boundary in the bisection IVT proof is identified: the structural core (width formula, sign invariant, width convergence) is provable without classical logic via an explicit oracle parameterization. Endpoint convergence \u2014 finding the limit of the nested intervals \u2014 requires Classical.choice via completeness of \u211d. This formalizes Bishop's classical result in Lean 4.",
-    "implications": "This result has practical implications for verified computing: for functions with decidable sign comparisons (e.g., polynomial functions over \u211a), `paramBisect` with a Decidable oracle gives a fully computable, verified bisection root-finder with no noncomputable components. The constructive-vs-classical boundary also illuminates the architecture of Mathlib's real analysis: `ciSup`/`ciInf` are inherently classical, while filter limits for concrete sequences (geometric, power) can be computed without LEM.",
+    "summary": "The exact classical boundary in the bisection IVT proof is identified: the structural core (width formula, sign invariant, width convergence) is provable without classical logic via an explicit oracle parameterization. Endpoint convergence — finding the limit of the nested intervals — requires Classical.choice via completeness of ℝ. This formalizes Bishop's classical result in Lean 4.",
+    "implications": "This result has practical implications for verified computing: for functions with decidable sign comparisons (e.g., polynomial functions over ℚ), `paramBisect` with a Decidable oracle gives a fully computable, verified bisection root-finder with no noncomputable components. The constructive-vs-classical boundary also illuminates the architecture of Mathlib's real analysis: `ciSup`/`ciInf` are inherently classical, while filter limits for concrete sequences (geometric, power) can be computed without LEM.",
     "openQuestions": [
-      "For polynomial f over \u211a, can a fully computable IVT be formalized using paramBisect with a Decidable sign oracle?",
+      "For polynomial f over ℚ, can a fully computable IVT be formalized using paramBisect with a Decidable sign oracle?",
       "Can the endpoint convergence be proved constructively using computable reals (Cauchy sequences with moduli)?",
       "Is there a Bishop-style IVT in Lean 4 using the locally non-constant hypothesis?"
     ]
   },
   "crossReferences": [
     {
-      "id": "intermediate-value-theorem",
-      "relationship": "parent \u2014 classical IVT in Lean 4 via Continuous.ivt"
+      "proofId": "intermediate-value-theorem",
+      "relationship": "parent — classical IVT in Lean 4 via Continuous.ivt"
     },
     {
-      "id": "intermediate-value-theorem-oq-02",
-      "relationship": "parent \u2014 bisection-based IVT proofs (parent OQ-02 series)"
+      "proofId": "intermediate-value-theorem-oq-02",
+      "relationship": "parent — bisection-based IVT proofs (parent OQ-02 series)"
     }
   ],
   "leanFile": {
@@ -168,10 +168,10 @@
   },
   "knownResults": {
     "proven": [
-      "Bisection width formula (b-a)/2^n \u2014 constructive",
-      "Sign invariant preservation under explicit oracle \u2014 constructive",
-      "Endpoint convergence to common limit \u2014 classical",
-      "Root theorem for continuous f \u2014 classical"
+      "Bisection width formula (b-a)/2^n — constructive",
+      "Sign invariant preservation under explicit oracle — constructive",
+      "Endpoint convergence to common limit — classical",
+      "Root theorem for continuous f — classical"
     ],
     "open": [
       "Constructive IVT over computable reals (Cauchy completeness without Classical.choice) — still open"

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01/meta.json
@@ -135,27 +135,27 @@
   },
   "crossReferences": [
     {
-      "id": "lagrange-theorem-oq-01",
+      "proofId": "lagrange-theorem-oq-01",
       "relationship": "answers",
       "description": "This entry directly answers OQ-01-OQ-01 from the Sylow Theorems entry: 'Use Sylow theory to classify groups of order pq'"
     },
     {
-      "id": "sylow-theorem-oq-01",
+      "proofId": "sylow-theorem-oq-01",
       "relationship": "uses",
       "description": "Imports and re-exposes the complete classification proof from SylowTheoremOQ01 (namespace SylowPQ), which contains all the detailed Lean proofs"
     },
     {
-      "id": "lagrange-theorem-oq-01-oq-02",
+      "proofId": "lagrange-theorem-oq-01-oq-02",
       "relationship": "related",
       "description": "The A₄ counterexample (no subgroup of order 6) is the motivating example for studying pq-groups: A₄ has order 12 = 2² × 3, not pq, but the S₃ example (order 6 = 2 × 3) shows pq-groups can be non-abelian"
     },
     {
-      "id": "lagrange-theorem-oq-01-oq-03",
+      "proofId": "lagrange-theorem-oq-01-oq-03",
       "relationship": "related",
       "description": "Hall's theorem generalizes the pq-classification: for solvable groups with Hall divisors, Hall subgroups exist. The pq case is a special instance with d = p or d = q"
     },
     {
-      "id": "lagrange-theorem-oq-01-oq-01-oq-01",
+      "proofId": "lagrange-theorem-oq-01-oq-01-oq-01",
       "relationship": "extended-by",
       "description": "Child entry supplies the explicit non-cyclic witness missing from this file's `lagrange_pq_nonabelian_n_p_eq_q`. For p = 2 (every odd prime q): DihedralGroup q (Approach A). Approach B preliminaries (cyclic structure of (ZMod q)ˣ + order-p element extraction) are in place; the semidirect product φ : ZMod p →* AddAut (ZMod q) (S3c) and the ZMod q ⋊ ZMod p assembly (S3d) are open"
     }

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01/meta.json
@@ -125,13 +125,21 @@
       "id": "oq-01",
       "question": "Can the orbit partition sum Σ_x|Stab(x)| = |X/G|·|G| be proved in Lean 4 purely from orbit-stabilizer without using Mathlib's Burnside lemma as an intermediate step?",
       "difficulty": "medium",
-      "tags": ["lean4", "orbit-partition", "formal-proof"]
+      "tags": [
+        "lean4",
+        "orbit-partition",
+        "formal-proof"
+      ]
     },
     {
       "id": "oq-02",
       "question": "Does the double-counting bijection sigma_fixedBy_equiv_sigma_stabilizer generalize to monoid actions (where stabilizers are not necessarily subgroups)?",
       "difficulty": "easy",
-      "tags": ["monoid-actions", "generalization", "lean4"]
+      "tags": [
+        "monoid-actions",
+        "generalization",
+        "lean4"
+      ]
     }
   ],
   "relatedProofs": [
@@ -169,12 +177,12 @@
   },
   "crossReferences": [
     {
-      "id": "lagrange-theorem-oq-02",
+      "proofId": "lagrange-theorem-oq-02",
       "title": "Lagrange's Theorem: Orbit-Stabilizer Consequences",
       "relationship": "Parent entry that provides the orbit-stabilizer theorem used in Part III. The double-counting bijection in this entry is the key new content beyond what OQ-02 provides."
     },
     {
-      "id": "lagrange-theorem",
+      "proofId": "lagrange-theorem",
       "title": "Lagrange's Theorem",
       "relationship": "Grandparent entry. The chain Lagrange → Orbit-Stabilizer → Burnside is formalized in lagrange_orbitstab_burnside_chain, with Lagrange's theorem as the base."
     }

--- a/src/data/proofs/nakayama-lemma-oq-01-oq-01/meta.json
+++ b/src/data/proofs/nakayama-lemma-oq-01-oq-01/meta.json
@@ -155,7 +155,7 @@
   ],
   "crossReferences": [
     {
-      "id": "nakayama-lemma-oq-01",
+      "proofId": "nakayama-lemma-oq-01",
       "note": "Parent entry: the local-ring forms of Nakayama and nakayama_span_of_span_quotient, on which this count is built; this entry answers its first open question."
     }
   ],

--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-01/meta.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-01/meta.json
@@ -115,7 +115,7 @@
   ],
   "crossReferences": [
     {
-      "id": "newton-power-sum-identities-oq-01",
+      "proofId": "newton-power-sum-identities-oq-01",
       "relation": "parent",
       "description": "Parent entry deriving the degree-1,2,3 Newton identities by the same unrolling of MvPolynomial.psum_eq_mul_esymm_sub_sum; this entry continues to degrees 4 and 5."
     }

--- a/src/data/proofs/schur-lemma-oq-01-oq-02/meta.json
+++ b/src/data/proofs/schur-lemma-oq-01-oq-02/meta.json
@@ -147,7 +147,7 @@
   ],
   "crossReferences": [
     {
-      "id": "schur-lemma-oq-01",
+      "proofId": "schur-lemma-oq-01",
       "reason": "The parent entry proving the scalar form of Schur's Lemma; this entry consumes its schur_endomorphism_scalar and answers its open question on the abelian-group specialization."
     }
   ],

--- a/src/data/proofs/schur-lemma-oq-01/meta.json
+++ b/src/data/proofs/schur-lemma-oq-01/meta.json
@@ -143,11 +143,11 @@
   ],
   "crossReferences": [
     {
-      "id": "maschke-theorem-oq-01",
+      "proofId": "maschke-theorem-oq-01",
       "reason": "Maschke's theorem (complete reducibility) and Schur's lemma are the two pillars of the representation theory of finite groups; together they yield the Wedderburn decomposition of the group algebra."
     },
     {
-      "id": "nakayama-lemma-oq-01",
+      "proofId": "nakayama-lemma-oq-01",
       "reason": "Another module-theoretic entry deriving the textbook specialization (here the scalar form, there the local-ring form) from Mathlib's more general statements."
     }
   ],

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -145,15 +145,15 @@
   ],
   "crossReferences": [
     {
-      "id": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+      "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
       "relationship": "Direct parent: settled the 3×3 trace power sum tr(A³) = Σλᵢ³ via Newton's p₃ = e₁³ − 3e₁e₂ + 3e₃ and explicitly posed (openQuestions[0]) the extension to tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ in dimension four that this entry takes up."
     },
     {
-      "id": "spectral-trace-det-eigenvalues-oq-01",
+      "proofId": "spectral-trace-det-eigenvalues-oq-01",
       "relationship": "Grandparent: establishes trace = Σλ, determinant = Πλ, the eigenvalue count card_eigenvalues_eq_dim, and the Vieta correspondence reused here to identify e₁ and e₄ of the spectrum with trace and determinant."
     },
     {
-      "id": "spectral-trace-det-eigenvalues-oq-02",
+      "proofId": "spectral-trace-det-eigenvalues-oq-02",
       "relationship": "Sibling on cyclic invariance of the trace and similarity-invariance of the eigenvalue multiset; the fourth power sum tr(A⁴) is similarity-invariant for the same reason (conjugation preserves the characteristic polynomial)."
     }
   ],

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -128,15 +128,15 @@
   ],
   "crossReferences": [
     {
-      "id": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+      "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
       "relationship": "Direct parent: proved tr(A³) = λ₁³ + λ₂³ + λ₃³ for 3×3 matrices via a dimension-specific Newton identity and Vieta, and posed (openQuestions[1]) the general trace power sum tr(Aᵏ) = Σλᵢᵏ for all dimensions and powers — which this entry settles for diagonalizable matrices by the dimension-free spectral-mapping argument."
     },
     {
-      "id": "spectral-trace-det-eigenvalues-oq-01",
+      "proofId": "spectral-trace-det-eigenvalues-oq-01",
       "relationship": "Grandparent (imported): establishes the eigenvalues abbreviation A.charpoly.roots, trace = Σλ and determinant = Πλ, and the eigenvalue count; the k=1 case of this entry's headline recovers its trace = Σλ."
     },
     {
-      "id": "spectral-trace-det-eigenvalues-oq-02",
+      "proofId": "spectral-trace-det-eigenvalues-oq-02",
       "relationship": "Sibling on cyclic/similarity invariance of the trace and the eigenvalue multiset — exactly the conjugation invariance (trace_pow_units_conj, charpoly_units_conj) that drives the diagonalizable spectral mapping here."
     }
   ],

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02/meta.json
@@ -127,15 +127,15 @@
   ],
   "crossReferences": [
     {
-      "id": "spectral-trace-det-eigenvalues-oq-01-oq-01",
+      "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01",
       "relationship": "Direct parent: settled the 2×2 trace power sum tr(A²) = λ₁² + λ₂² via Newton's p₂ = e₁² − 2e₂ and explicitly posed (openQuestions[1]) the extension to tr(A³) = e₁³ − 3e₁e₂ + 3e₃ in fixed small dimensions that this entry takes up."
     },
     {
-      "id": "spectral-trace-det-eigenvalues-oq-01",
+      "proofId": "spectral-trace-det-eigenvalues-oq-01",
       "relationship": "Grandparent: establishes trace = Σλ, determinant = Πλ, the eigenvalue count, and the Vieta correspondence reused here to identify e₁ and e₃ of the spectrum with trace and determinant."
     },
     {
-      "id": "spectral-trace-det-eigenvalues-oq-02",
+      "proofId": "spectral-trace-det-eigenvalues-oq-02",
       "relationship": "Sibling on cyclic invariance of the trace and similarity-invariance of the eigenvalue multiset; the cube power sum tr(A³) is similarity-invariant for the same reason (conjugation preserves the characteristic polynomial)."
     }
   ],

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01/meta.json
@@ -170,11 +170,11 @@
   ],
   "crossReferences": [
     {
-      "id": "spectral-trace-det-eigenvalues-oq-01",
+      "proofId": "spectral-trace-det-eigenvalues-oq-01",
       "relationship": "Parent entry: establishes trace = Σλ, determinant = Πλ, the eigenvalue count, and the Vieta correspondence, and explicitly poses the open question — proving the eigenvalue power sums equal trace(Aᵏ) — that this entry takes up (settling the determinant case in general and the trace case for 2×2)."
     },
     {
-      "id": "spectral-trace-det-eigenvalues-oq-02",
+      "proofId": "spectral-trace-det-eigenvalues-oq-02",
       "relationship": "Sibling entry on cyclic invariance of the trace and similarity-invariance of the eigenvalue multiset; the present power identities are similarity-invariant for the same reason (conjugation preserves the characteristic polynomial)."
     }
   ],

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01/meta.json
@@ -135,7 +135,7 @@
   ],
   "crossReferences": [
     {
-      "id": "minpoly-charpoly",
+      "proofId": "minpoly-charpoly",
       "relationship": "Companion matrix-polynomial entry on the relationship between the minimal and characteristic polynomials; this entry instead reads spectral invariants (trace, determinant, symmetric functions) off the characteristic polynomial's roots."
     }
   ],

--- a/src/data/proofs/wilsons-theorem-oq-06/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-06/meta.json
@@ -132,12 +132,12 @@
   },
   "crossReferences": [
     {
-      "id": "wilsons-theorem",
+      "proofId": "wilsons-theorem",
       "title": "Wilson's Theorem",
       "relationship": "Parent — supplies the divisibility p ∣ (p−1)!+1 that makes the Wilson quotient an integer."
     },
     {
-      "id": "wilsons-theorem-oq-05-oq-01",
+      "proofId": "wilsons-theorem-oq-05-oq-01",
       "title": "The Complete Trichotomy of (n−1)! mod n",
       "relationship": "Sibling — classifies the residue (n−1)! mod n; this entry studies the next-order quotient ((p−1)!+1)/p and the p² refinement."
     }

--- a/src/data/proofs/wilsons-theorem-oq-07/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-07/meta.json
@@ -131,12 +131,12 @@
   },
   "crossReferences": [
     {
-      "id": "wilsons-theorem",
+      "proofId": "wilsons-theorem",
       "title": "Wilson's Theorem",
       "relationship": "Parent — supplies (p−1)! ≡ −1 (mod p), refined here by reflection into an explicit square root of −1."
     },
     {
-      "id": "wilsons-theorem-oq-06",
+      "proofId": "wilsons-theorem-oq-06",
       "title": "The Wilson Quotient and Wilson Primes",
       "relationship": "Sibling — studies the quotient ((p−1)!+1)/p; this entry instead refines the congruence itself into a square."
     }


### PR DESCRIPTION
## Defect: crossReferences keyed on `id` render `/proof/undefined`

Renderer slug = `ref.proofId ?? ref.targetId` (`src/components/proof/ProofOverview.tsx:364`); it never reads `ref.id`. **68 crossReferences** across the gallery were stored with only an `id` key whose value is a valid existing proof slug — they render as a dead `<Link to="/proof/undefined">` despite the target existing.

## Fix
- **68 refs**: renamed `id`->`proofId` (canonical), preserving other fields. No target changed.
- **3 refs**: dropped dangling `proofId`->`cyclotomic-polynomials-oq-01` (no such family) in the `eisenstein-criterion-oq-01` tree.

## Verification
- Precomputed plan (35 entries / 71 edits); changed metas are valid JSON; 0 unresolvable slugs remain.

Complements #32208 (55 dangling `targetId` links).