### PR TITLE
research(vietas-formulas-oq-05): Vieta in general degree — sum & product of roots of a monic split polynomial [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/VietasFormulasOQ05.lean
+++ b/proofs/Proofs/VietasFormulasOQ05.lean
@@ -116,6 +116,7 @@ theorem card_roots_eq_natDegree (hsplit : p.Splits) :
     Multiset.card p.roots = p.natDegree :=
   splits_iff_card_roots.mp hsplit
 
+omit [IsDomain R] in
 /-- **Forward (constructive) Vieta.** For any multiset `s` of prescribed roots,
 the monic polynomial `∏ (X - rᵢ)` has coefficients given by the elementary
 symmetric functions of `s`: the coefficient in position `k` is

--- a/proofs/Proofs/VietasFormulasOQ05.lean
+++ b/proofs/Proofs/VietasFormulasOQ05.lean
@@ -1,0 +1,129 @@
+/-
+# Vieta's Formulas in General Degree: Sum and Product of Roots of a Monic Split Polynomial
+
+For a *monic* polynomial `p` of degree `n` over an integral domain that *splits*
+(factors into linear factors, equivalently has `n` roots counted with
+multiplicity), Vieta's formulas express every coefficient of `p` as an
+elementary symmetric function of the roots:
+
+  `p.coeff (n - j) = (-1)^j * (elementary symmetric function of degree j in the roots)`.
+
+The two most famous instances are the boundary cases:
+
+* `j = 1` -- the **sum of the roots** equals `-p.coeff (n-1)`;
+* `j = n` -- the **product of the roots** equals `(-1)^n * p.coeff 0`.
+
+The sibling files `VietasFormulasOQ02`/`OQ03`/`OQ03OQ01` develop Newton's
+identities (power sums vs. elementary symmetric functions), and `OQ04`/`OQ03OQ05`
+treat the discriminant and quartic resolvent. This file is the complementary
+*general-degree* statement: the full elementary-symmetric coefficient
+dictionary for an arbitrary monic split polynomial, with the sum and product of
+roots unified as its two boundary cases and cross-checked against Mathlib's
+`Splits.coeff_zero_eq_prod_roots_of_monic` and
+`Splits.nextCoeff_eq_neg_sum_roots_of_monic`.
+
+## Main results
+
+* `Multiset.esymm_one` / `Multiset.esymm_self` -- boundary values of the
+  elementary symmetric functions of a multiset (`esymm 1 = sum`,
+  `esymm (card s) = prod`).
+* `Vieta.coeff_eq_esymm_of_monic` -- the general coefficient dictionary:
+  `p.coeff (n - j) = (-1)^j * p.roots.esymm j` for `j ≤ n`.
+* `Vieta.coeff_natDegree_sub_one` -- sum of roots: `p.coeff (n-1) = -p.roots.sum`.
+* `Vieta.coeff_zero_eq_prod` -- product of roots: `p.coeff 0 = (-1)^n * p.roots.prod`.
+* `Vieta.eq_prod_roots` -- the reconstruction `p = ∏ (X - rᵢ)`.
+* `Vieta.build_coeff` -- the forward (constructive) coefficient dictionary for a
+  monic polynomial built from a prescribed multiset of roots.
+
+## References
+
+- Mathlib.RingTheory.Polynomial.Vieta (`Polynomial.coeff_eq_esymm_roots_of_card`)
+- Mathlib.Algebra.Polynomial.Factors (`Polynomial.Splits`, split root formulas)
+-/
+
+import Mathlib.RingTheory.Polynomial.Vieta
+import Mathlib.Algebra.Polynomial.Factors
+
+open Polynomial Multiset
+
+namespace Multiset
+
+variable {R : Type*} [CommRing R]
+
+/-- The degree-`1` elementary symmetric function of a multiset is its sum. -/
+theorem esymm_one (s : Multiset R) : s.esymm 1 = s.sum := by
+  simp [esymm, powersetCard_one, Multiset.map_map, Function.comp]
+
+/-- The top elementary symmetric function of a multiset (degree equal to its
+cardinality) is its product. -/
+theorem esymm_self (s : Multiset R) : s.esymm (Multiset.card s) = s.prod := by
+  have hmem : s ∈ Multiset.powersetCard (Multiset.card s) s :=
+    Multiset.mem_powersetCard.mpr ⟨le_refl s, rfl⟩
+  have hcard : Multiset.card (Multiset.powersetCard (Multiset.card s) s) = 1 := by
+    rw [Multiset.card_powersetCard, Nat.choose_self]
+  obtain ⟨a, ha⟩ := Multiset.card_eq_one.mp hcard
+  rw [ha, Multiset.mem_singleton] at hmem
+  rw [esymm, ha, Multiset.map_singleton, Multiset.sum_singleton, ← hmem]
+
+end Multiset
+
+namespace Vieta
+
+variable {R : Type*} [CommRing R] [IsDomain R] {p : R[X]}
+
+/-- **Vieta's formula, general degree.** For a monic polynomial that splits over
+an integral domain, the coefficient in position `n - j` (where `n = natDegree p`)
+is `(-1)^j` times the degree-`j` elementary symmetric function of the roots. -/
+theorem coeff_eq_esymm_of_monic (hp : p.Monic) (hsplit : p.Splits) {j : ℕ}
+    (hj : j ≤ p.natDegree) :
+    p.coeff (p.natDegree - j) = (-1) ^ j * p.roots.esymm j := by
+  have hcard : Multiset.card p.roots = p.natDegree := splits_iff_card_roots.mp hsplit
+  have hk : p.natDegree - j ≤ p.natDegree := Nat.sub_le _ _
+  have h := Polynomial.coeff_eq_esymm_roots_of_card hcard (k := p.natDegree - j) hk
+  rwa [hp.leadingCoeff, one_mul, Nat.sub_sub_self hj] at h
+
+/-- **Sum of the roots.** For a monic split polynomial of positive degree, the
+sub-leading coefficient equals the negative of the sum of the roots. -/
+theorem coeff_natDegree_sub_one (hp : p.Monic) (hsplit : p.Splits)
+    (hn : 1 ≤ p.natDegree) :
+    p.coeff (p.natDegree - 1) = - p.roots.sum := by
+  have h := coeff_eq_esymm_of_monic hp hsplit hn
+  rwa [pow_one, Multiset.esymm_one, neg_one_mul] at h
+
+/-- **Product of the roots.** For a monic split polynomial the constant
+coefficient equals `(-1)^n` times the product of the roots (`n = natDegree p`).
+Derived here from the general dictionary at the top elementary symmetric
+function; it agrees with `Splits.coeff_zero_eq_prod_roots_of_monic`. -/
+theorem coeff_zero_eq_prod (hp : p.Monic) (hsplit : p.Splits) :
+    p.coeff 0 = (-1) ^ p.natDegree * p.roots.prod := by
+  have hcard : Multiset.card p.roots = p.natDegree := splits_iff_card_roots.mp hsplit
+  have h := coeff_eq_esymm_of_monic hp hsplit (le_refl p.natDegree)
+  rw [Nat.sub_self] at h
+  have hesymm : p.roots.esymm p.natDegree = p.roots.prod := by
+    rw [← hcard, Multiset.esymm_self]
+  rwa [hesymm] at h
+
+/-- **Root factorization.** A monic split polynomial is the product of the
+linear factors `X - rᵢ` over its roots. This is the geometric content behind
+Vieta's formulas: expanding this product recovers the coefficient dictionary. -/
+theorem eq_prod_roots (hp : p.Monic) (hsplit : p.Splits) :
+    p = (p.roots.map fun r => X - C r).prod :=
+  hsplit.eq_prod_roots_of_monic hp
+
+/-- The number of roots (with multiplicity) of a monic split polynomial equals
+its degree. -/
+theorem card_roots_eq_natDegree (hsplit : p.Splits) :
+    Multiset.card p.roots = p.natDegree :=
+  splits_iff_card_roots.mp hsplit
+
+/-- **Forward (constructive) Vieta.** For any multiset `s` of prescribed roots,
+the monic polynomial `∏ (X - rᵢ)` has coefficients given by the elementary
+symmetric functions of `s`: the coefficient in position `k` is
+`(-1)^(m - k)` times `esymm (m - k)`, where `m = card s`. This is the converse
+direction to `coeff_eq_esymm_of_monic`. -/
+theorem build_coeff (s : Multiset R) {k : ℕ} (hk : k ≤ Multiset.card s) :
+    (s.map fun r => X - C r).prod.coeff k =
+      (-1) ^ (Multiset.card s - k) * s.esymm (Multiset.card s - k) :=
+  Multiset.prod_X_sub_C_coeff s hk
+
+end Vieta

--- a/src/data/proofs/vietas-formulas-oq-05/annotations.json
+++ b/src/data/proofs/vietas-formulas-oq-05/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-vf-oq05-esymm-boundary",
+    "proofId": "vietas-formulas-oq-05",
+    "range": {
+      "startLine": 54,
+      "endLine": 66
+    },
+    "type": "lemma",
+    "title": "Boundary Values: esymm 1 = sum and esymm (card s) = prod",
+    "content": "Two degenerate layers of the elementary symmetric functions of a multiset. `esymm_one` unfolds e₁(s) via `powersetCard_one`: the 1-element sub-multisets of s are exactly the singletons {a}, whose products are the elements a, so the sum over them is s.sum. `esymm_self` handles the top layer e_{card s}(s): the sub-multisets of s with cardinality card s number (card s).choose(card s) = 1, and s itself is one of them (s ≤ s), so the top layer is the single element {s}; its only product is s.prod. These are precisely the two symmetric functions that become the sum and the product of the roots.",
+    "mathContext": "e_1(s) = Σ_{a∈s} a via powersetCard 1 s = s.map singleton; e_{|s|}(s) = Π_{a∈s} a because powersetCard (card s) s = {s} (cardinality (card s).choose(card s) = 1, and s ≤ s).",
+    "significance": "important",
+    "relatedConcepts": [
+      "elementary symmetric functions",
+      "multiset powerset",
+      "binomial coefficient choose_self"
+    ],
+    "prerequisites": [
+      "Multiset.powersetCard",
+      "Multiset.card_eq_one"
+    ]
+  },
+  {
+    "id": "ann-vf-oq05-general-dictionary",
+    "proofId": "vietas-formulas-oq-05",
+    "range": {
+      "startLine": 77,
+      "endLine": 85
+    },
+    "type": "theorem",
+    "title": "coeff_eq_esymm_of_monic: the General-Degree Vieta Dictionary",
+    "content": "The centerpiece. For a monic polynomial p over an integral domain that splits, the coefficient in position n − j is (−1)ʲ times the j-th elementary symmetric function of the roots, for every j ≤ n. The proof stitches together three facts about a monic split polynomial: (1) `splits_iff_card_roots` turns the `Splits` hypothesis into card(roots) = natDegree, exactly the hypothesis Mathlib's `coeff_eq_esymm_roots_of_card` needs; (2) that lemma applied at k = n − j gives coeff(n−j) = leadingCoeff · (−1)^(n−(n−j)) · esymm(n−(n−j)); (3) `Monic.leadingCoeff` collapses the leading factor to 1 and `Nat.sub_sub_self hj` (valid since j ≤ n) reflects n − (n − j) back to j. The result is the clean textbook form with the signs and elementary symmetric functions exposed.",
+    "mathContext": "coeff(n − j) = 1 · (−1)^(n−(n−j)) · esymm(n−(n−j)) = (−1)ʲ · e_j(roots), using n − (n − j) = j for j ≤ n.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "elementary symmetric functions",
+      "split polynomial",
+      "monic polynomial"
+    ],
+    "prerequisites": [
+      "Polynomial.coeff_eq_esymm_roots_of_card",
+      "Polynomial.splits_iff_card_roots",
+      "Polynomial.Monic.leadingCoeff",
+      "Nat.sub_sub_self"
+    ]
+  },
+  {
+    "id": "ann-vf-oq05-sum-roots",
+    "proofId": "vietas-formulas-oq-05",
+    "range": {
+      "startLine": 87,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "coeff_natDegree_sub_one: Sum of the Roots (j = 1)",
+    "content": "The sum-of-roots law as the j = 1 instance of the dictionary. For a monic split polynomial of positive degree, coeff(n − 1) = −(sum of roots). The proof feeds j = 1 into coeff_eq_esymm_of_monic, giving coeff(n−1) = (−1)¹ · esymm 1(roots), then rewrites esymm 1 = sum (esymm_one) and (−1)·x = −x (neg_one_mul). The positive-degree hypothesis 1 ≤ n is exactly what makes j = 1 a legal index and n − 1 the genuine sub-leading position.",
+    "mathContext": "coeff(n−1) = (−1)^1 · e_1(roots) = −(Σ roots). The familiar 'sum of roots = minus the coefficient one below the top'.",
+    "significance": "important",
+    "relatedConcepts": [
+      "sum of roots",
+      "Vieta's formulas",
+      "sub-leading coefficient"
+    ],
+    "prerequisites": [
+      "coeff_eq_esymm_of_monic",
+      "Multiset.esymm_one"
+    ]
+  },
+  {
+    "id": "ann-vf-oq05-prod-roots",
+    "proofId": "vietas-formulas-oq-05",
+    "range": {
+      "startLine": 97,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "coeff_zero_eq_prod: Product of the Roots (j = n)",
+    "content": "The product-of-roots law as the j = n instance of the same dictionary — so the sum and product are not proved by separate arguments but read off the two ends of one relation. Feeding j = n gives coeff(n − n) = coeff 0 = (−1)ⁿ · esymm n(roots); since card(roots) = n, esymm n(roots) = esymm (card roots)(roots) = product of roots by esymm_self. The statement coincides with Mathlib's Splits.coeff_zero_eq_prod_roots_of_monic, but here it is a corollary of the general dictionary rather than an independent lemma.",
+    "mathContext": "coeff 0 = (−1)^n · e_n(roots) = (−1)^n · (Π roots), using e_n = e_{card roots} = prod.",
+    "significance": "important",
+    "relatedConcepts": [
+      "product of roots",
+      "Vieta's formulas",
+      "constant coefficient"
+    ],
+    "prerequisites": [
+      "coeff_eq_esymm_of_monic",
+      "Multiset.esymm_self"
+    ]
+  },
+  {
+    "id": "ann-vf-oq05-build-coeff",
+    "proofId": "vietas-formulas-oq-05",
+    "range": {
+      "startLine": 119,
+      "endLine": 129
+    },
+    "type": "theorem",
+    "title": "build_coeff: the Converse Constructive Direction",
+    "content": "The inverse of the dictionary. Instead of reading coefficients off a given split polynomial, this builds a monic polynomial ∏(X − rᵢ) from a prescribed multiset s of roots and reads its coefficients back as the elementary symmetric functions of s: coeff k = (−1)^(m−k) · e_{m−k}(s) with m = card s. It is a direct application of Mathlib's Multiset.prod_X_sub_C_coeff and needs only a commutative ring, so `IsDomain` is omitted at the site. Together with coeff_eq_esymm_of_monic it says that expanding a product of linear factors and factoring a split polynomial are inverse coefficient computations.",
+    "mathContext": "(∏_{r∈s}(X − r)).coeff k = (−1)^(m−k) · e_{m−k}(s), m = card s — the forward map from roots to coefficients.",
+    "significance": "important",
+    "relatedConcepts": [
+      "constructive Vieta",
+      "product of linear factors",
+      "elementary symmetric functions"
+    ],
+    "prerequisites": [
+      "Multiset.prod_X_sub_C_coeff"
+    ]
+  }
+]

--- a/src/data/proofs/vietas-formulas-oq-05/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-05/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "vietas-formulas-oq-05",
+  "title": "Vieta in General Degree: Sum and Product of Roots of a Monic Split Polynomial",
+  "slug": "vietas-formulas-oq-05",
+  "description": "For a monic polynomial of degree n over an integral domain that splits into linear factors, every coefficient is an elementary symmetric function of the roots: coeff(n − j) = (−1)^j · e_j(roots). The two famous boundary cases fall out of this single dictionary — the sum of the roots equals −coeff(n−1) (j = 1) and their product equals (−1)^n · coeff 0 (j = n) — unifying the small-degree Vieta relations of the parent and sibling entries into one general-degree statement. Includes the root factorization p = ∏(X − rᵢ) and the converse constructive direction.",
+  "meta": {
+    "author": "Francois Viete (1615); formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Vieta%27s_formulas",
+    "date": "1615",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VietasFormulasOQ05.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "vietas-formulas",
+      "elementary-symmetric-functions",
+      "roots",
+      "research",
+      "ring-theory"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "defCount": 0,
+    "lineCount": 130,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.coeff_eq_esymm_roots_of_card",
+        "description": "Vieta's formula for a polynomial over an integral domain with as many roots as its degree: coeff k = leadingCoeff · (−1)^(n−k) · esymm(n−k) of the roots. The engine behind the general dictionary.",
+        "module": "Mathlib.RingTheory.Polynomial.Vieta"
+      },
+      {
+        "theorem": "Multiset.prod_X_sub_C_coeff",
+        "description": "Coefficient of ∏(X − tᵢ) over a multiset s: coeff k = (−1)^(card s − k) · esymm(card s − k). Powers the constructive (forward) direction.",
+        "module": "Mathlib.RingTheory.Polynomial.Vieta"
+      },
+      {
+        "theorem": "Polynomial.splits_iff_card_roots",
+        "description": "A polynomial over a domain splits iff its root multiset has cardinality equal to its degree; converts the Splits hypothesis into the card hypothesis the Vieta engine needs.",
+        "module": "Mathlib.Algebra.Polynomial.Factors"
+      },
+      {
+        "theorem": "Polynomial.Splits.eq_prod_roots_of_monic",
+        "description": "A monic split polynomial equals the product of its linear factors ∏(X − rᵢ) — the geometric content of Vieta's formulas.",
+        "module": "Mathlib.Algebra.Polynomial.Factors"
+      }
+    ],
+    "originalContributions": [
+      "coeff_eq_esymm_of_monic: the general-degree Vieta dictionary specialized to a monic split polynomial — coeff(n − j) = (−1)^j · esymm_j(roots), with the leading coefficient dropped and the index reflected to the textbook form",
+      "Multiset.esymm_one and Multiset.esymm_self: the boundary values of the elementary symmetric functions of a multiset (esymm 1 = sum, esymm (card s) = prod), the latter proved via the singleton top layer of powersetCard",
+      "coeff_natDegree_sub_one: the sum-of-roots law coeff(n−1) = −(sum of roots), obtained as the j = 1 case of the dictionary",
+      "coeff_zero_eq_prod: the product-of-roots law coeff 0 = (−1)^n · (product of roots), obtained as the j = n case of the same dictionary (so sum and product are unified rather than proved separately)",
+      "build_coeff: the converse constructive direction — the coefficients of ∏(X − rᵢ) built from a prescribed multiset of roots are exactly the elementary symmetric functions of that multiset"
+    ],
+    "dateAdded": "2026-07-01",
+    "prerequisites": [
+      "Vieta's formulas for small degree (parent and sibling entries)",
+      "Elementary symmetric functions of a multiset",
+      "Splitting of polynomials and the root multiset over an integral domain",
+      "Monic polynomials and leading coefficients"
+    ],
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Vieta's formulas (Francois Viete, 1615) relate the coefficients of a polynomial to the elementary symmetric functions of its roots. For a monic polynomial ∏(X − rᵢ) = Xⁿ − e₁Xⁿ⁻¹ + e₂Xⁿ⁻² − ⋯ + (−1)ⁿeₙ, the coefficient of Xⁿ⁻ʲ is (−1)ʲ times the j-th elementary symmetric function of the roots. The two best-known instances — the sum of the roots is minus the sub-leading coefficient, and the product of the roots is ±the constant term — are the j = 1 and j = n endpoints of this single dictionary.",
+    "problemStatement": "For a monic polynomial p of degree n over an integral domain that splits into linear factors, prove the general Vieta relation p.coeff(n − j) = (−1)ʲ · e_j(roots) for every j ≤ n, and derive from it the sum-of-roots law p.coeff(n−1) = −∑ roots and the product-of-roots law p.coeff 0 = (−1)ⁿ · ∏ roots. Also record the root factorization p = ∏(X − rᵢ) and the converse constructive direction.",
+    "text": "Establishes the general-degree Vieta coefficient dictionary for a monic split polynomial and derives the sum and product of the roots as its two boundary cases, complementing the small-degree and Newton-identity siblings with the arbitrary-degree statement.",
+    "proofStrategy": "The engine is Mathlib's Polynomial.coeff_eq_esymm_roots_of_card, which for a polynomial with card(roots) = natDegree gives coeff k = leadingCoeff · (−1)^(n−k) · esymm(n−k). Specializing to a monic split polynomial contributes two simplifications: the Splits hypothesis is converted to the card hypothesis via splits_iff_card_roots, and Monic.leadingCoeff collapses the leading factor to 1. Re-indexing k = n − j and using Nat.sub_sub_self (valid because j ≤ n) yields the textbook form coeff(n − j) = (−1)ʲ · esymm_j(roots).\n\nThe sum and product then require only the boundary values of the elementary symmetric functions of a multiset. esymm 1 = sum follows from powersetCard_one (the 1-element sub-multisets are the singletons). esymm(card s) = prod follows because the top layer powersetCard(card s) s is a single element, {s}: its cardinality is (card s).choose(card s) = 1 and it contains s, so it equals {s}. Feeding j = 1 and j = n into the dictionary gives the sum and product laws — one derivation, two named consequences.\n\nThe root factorization p = ∏(X − rᵢ) is Splits.eq_prod_roots_of_monic; the converse build_coeff is Multiset.prod_X_sub_C_coeff, showing the two directions of Vieta are inverse.",
+    "keyInsights": [
+      "**One dictionary, both endpoints**: The sum-of-roots and product-of-roots laws are not independent theorems but the j = 1 and j = n cases of the single relation coeff(n − j) = (−1)ʲ · e_j(roots). Proving the dictionary once makes both classical formulas fall out, unifying what the small-degree siblings state case by case.",
+      "**Monic + split is exactly the right hypothesis**: `Splits` supplies card(roots) = natDegree (so every coefficient is captured, none lost to missing roots) and `Monic` kills the leading-coefficient factor, turning Mathlib's general leadingCoeff·(−1)^(n−k)·esymm into the clean textbook signed elementary symmetric functions.",
+      "**The boundary values of esymm are geometry, not computation**: esymm 1 = sum and esymm(card s) = prod are the degenerate layers of the powerset — the singletons and the whole multiset. The top layer is forced to be a single element by a cardinality count ((card s).choose(card s) = 1), which is why the product of the roots is a single elementary symmetric function rather than a sum of many.",
+      "**Both directions of Vieta**: coeff_eq_esymm_of_monic reads coefficients off a given split polynomial; build_coeff builds a polynomial from prescribed roots and reads the same elementary symmetric functions back. Together they express that expanding ∏(X − rᵢ) and factoring a split polynomial are inverse operations at the level of coefficients."
+    ],
+    "prerequisites": [
+      "Vieta's formulas for small degree",
+      "Elementary symmetric functions of a multiset",
+      "Polynomial splitting and the root multiset",
+      "Monic polynomials"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "The Open Question: General-Degree Sum and Product of Roots",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Frames the follow-up to the parent Vieta entry: move from fixed small degrees to arbitrary degree n. States the general dictionary coeff(n − j) = (−1)ʲ · e_j(roots) for a monic split polynomial and identifies the sum (j = 1) and product (j = n) of the roots as its two boundary cases. Imports Mathlib's Vieta and Factors modules and declares 0 axioms.",
+      "mathContext": "$p.\\mathrm{coeff}(n-j) = (-1)^j\\, e_j(\\text{roots}),\\quad e_1 = \\textstyle\\sum r_i,\\ e_n = \\textstyle\\prod r_i.$"
+    },
+    {
+      "id": "esymm-boundary",
+      "title": "Boundary values of the elementary symmetric functions",
+      "startLine": 49,
+      "endLine": 68,
+      "summary": "Multiset.esymm_one proves e₁(s) = ∑ s from powersetCard_one (the 1-element sub-multisets are the singletons). Multiset.esymm_self proves e_{card s}(s) = ∏ s: the top powerset layer powersetCard(card s) s has cardinality (card s).choose(card s) = 1 and contains s, hence equals {s}, whose product is s.prod. These are the two degenerate layers that become the sum and product of roots.",
+      "mathContext": "$e_1(s) = \\sum_{a\\in s} a,\\qquad e_{|s|}(s) = \\prod_{a\\in s} a.$"
+    },
+    {
+      "id": "general-dictionary",
+      "title": "coeff_eq_esymm_of_monic: the general-degree Vieta dictionary",
+      "startLine": 70,
+      "endLine": 85,
+      "summary": "The centerpiece. For a monic split polynomial over an integral domain, coeff(n − j) = (−1)ʲ · e_j(roots) for every j ≤ n. Converts Splits to card(roots) = natDegree via splits_iff_card_roots, applies Mathlib's coeff_eq_esymm_roots_of_card at k = n − j, kills the leading coefficient with Monic.leadingCoeff, and reflects the index via Nat.sub_sub_self.",
+      "mathContext": "$p\\ \\text{monic, splits},\\ j\\le n \\;\\Rightarrow\\; p.\\mathrm{coeff}(n-j) = (-1)^j\\, e_j(\\text{roots}).$"
+    },
+    {
+      "id": "sum-and-product",
+      "title": "Sum and product of the roots as boundary cases",
+      "startLine": 87,
+      "endLine": 107,
+      "summary": "coeff_natDegree_sub_one instantiates the dictionary at j = 1 and applies esymm_one to give coeff(n−1) = −(sum of roots) for a monic split polynomial of positive degree. coeff_zero_eq_prod instantiates at j = n (so n − n = 0) and applies esymm_self to give coeff 0 = (−1)ⁿ · (product of roots), agreeing with Mathlib's Splits.coeff_zero_eq_prod_roots_of_monic but derived from the same general dictionary.",
+      "mathContext": "$p.\\mathrm{coeff}(n-1) = -\\!\\textstyle\\sum r_i,\\qquad p.\\mathrm{coeff}\\,0 = (-1)^n\\!\\textstyle\\prod r_i.$"
+    },
+    {
+      "id": "factorization",
+      "title": "Root factorization and the degree–root count",
+      "startLine": 109,
+      "endLine": 117,
+      "summary": "eq_prod_roots records the geometric content — a monic split polynomial is the product ∏(X − rᵢ) of its linear factors (Splits.eq_prod_roots_of_monic). card_roots_eq_natDegree states the accompanying count: a split polynomial has exactly as many roots (with multiplicity) as its degree.",
+      "mathContext": "$p = \\prod_{r\\in\\text{roots}} (X - r),\\qquad |\\text{roots}(p)| = \\deg p.$"
+    },
+    {
+      "id": "forward-construction",
+      "title": "build_coeff: the converse constructive direction",
+      "startLine": 119,
+      "endLine": 130,
+      "summary": "The inverse of the dictionary. For any prescribed multiset s of roots, the monic polynomial ∏(X − rᵢ) has coeff k = (−1)^(m−k) · e_{m−k}(s) with m = card s (Multiset.prod_X_sub_C_coeff). This needs only a commutative ring — IsDomain is omitted at the site — showing that expanding a product of linear factors and factoring a split polynomial are inverse coefficient computations.",
+      "mathContext": "$\\Big(\\prod_{r\\in s}(X-r)\\Big).\\mathrm{coeff}\\,k = (-1)^{m-k}\\, e_{m-k}(s),\\quad m = |s|.$"
+    }
+  ],
+  "conclusion": {
+    "summary": "For a monic polynomial of degree n over an integral domain that splits, every coefficient is a signed elementary symmetric function of the roots: coeff(n − j) = (−1)ʲ · e_j(roots). The sum of the roots (−coeff(n−1)) and their product ((−1)ⁿ·coeff 0) are the j = 1 and j = n cases of this one dictionary, and the constructive direction shows the coefficients of ∏(X − rᵢ) are the elementary symmetric functions of the chosen roots. 8 theorems, 0 sorries, 0 axioms.",
+    "implications": "The general-degree dictionary subsumes the case-by-case Vieta relations of the parent quadratic/cubic entries and the sibling Newton-identity files into a single arbitrary-degree statement, and it pairs the read-off direction with its constructive inverse. Because it rests on the elementary symmetric functions of the root multiset, it connects directly to the Newton-identity siblings (which relate power sums to these same e_j) and to the discriminant sibling (the squared Vandermonde of the roots).",
+    "openQuestions": [
+      "Combine this dictionary with the Newton-identity siblings to express the power sums p_k of the roots of a monic split polynomial directly in terms of its coefficients.",
+      "Drop the monic hypothesis: state the general Vieta relations for an arbitrary split polynomial by carrying the leading coefficient, recovering the a·(sum), a·(product) form of the non-monic quadratic sibling.",
+      "Specialize the dictionary to a splitting field to obtain Vieta's formulas for an arbitrary polynomial over a field via its roots in the algebraic closure."
+    ]
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Viete, Francois",
+      "title": "De aequationum recognitione et emendatione",
+      "year": "1615",
+      "venue": "",
+      "note": "Origin of the coefficient-root relations now called Vieta's formulas"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "extends",
+      "description": "Generalizes the small-degree sum/product-of-roots relations of the parent entry to arbitrary degree via the elementary symmetric functions of the root multiset."
+    },
+    {
+      "targetId": "vietas-formulas-oq-03-oq-01",
+      "relationship": "complements",
+      "description": "The Newton-identity sibling relates power sums to elementary symmetric functions; this entry relates the coefficients to those same elementary symmetric functions of the roots."
+    },
+    {
+      "targetId": "vietas-formulas-oq-04",
+      "relationship": "complements",
+      "description": "The discriminant sibling is the squared root-gap (Vandermonde) of the roots; both entries read invariants of a polynomial off its root multiset."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Polynomial.Vieta",
+      "Mathlib.Algebra.Polynomial.Factors"
+    ],
+    "opens": [
+      "Polynomial",
+      "Multiset"
+    ],
+    "namespace": "Vieta",
+    "lineCount": 130,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/VietasFormulasOQ05.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes **vietas-formulas-oq-05** (Seeker-selected OQ child, tractability 9): the **general-degree** Vieta relations for a monic polynomial that splits over an integral domain, with the **sum** and **product** of the roots derived as the two boundary cases of a single coefficient dictionary.

**Core result** (`Vieta.coeff_eq_esymm_of_monic`): for monic split `p` of degree `n`, for every `j ≤ n`,
```
p.coeff (n - j) = (-1)^j * p.roots.esymm j
```
The two famous instances fall out as endpoints:
- **Sum of roots** (`coeff_natDegree_sub_one`, `j = 1`): `p.coeff (n-1) = -p.roots.sum`
- **Product of roots** (`coeff_zero_eq_prod`, `j = n`): `p.coeff 0 = (-1)^n * p.roots.prod`

So sum and product are not separate theorems but the `j = 1` / `j = n` cases of one relation — unifying the case-by-case small-degree Vieta of the parent/sibling entries into an arbitrary-degree statement.

## What's new vs. Mathlib / siblings

- Mathlib has the *engine* (`coeff_eq_esymm_roots_of_card`, with a leading-coefficient factor and `n-k` indexing) and the isolated extreme-coefficient results. This entry specializes to **monic + split**, drops the leading factor, reflects the index to the textbook `coeff(n-j) = (-1)^j e_j` form, and derives sum & product uniformly from it.
- Proves the two `Multiset.esymm` boundary values (`esymm_one = sum`, `esymm_self = prod`) not present as standalone Mathlib lemmas.
- Distinct from siblings: OQ02/OQ03/OQ03OQ01 are Newton identities (power sums ↔ e_j), OQ04/OQ03OQ05 are discriminant/quartic. This is the general-degree coefficient↔roots dictionary.
- Includes the root factorization `p = ∏(X - rᵢ)` and the **converse constructive direction** `build_coeff` (coefficients of `∏(X - rᵢ)` are the e_j of the chosen roots).

## Verification

- **8 theorems, 0 defs, 130 lines, 0 sorries, 0 axioms.**
- `#print axioms` on every result: only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- Docker build infra was down (containerd I/O errors); verified via **direct `lean` compile against the local olean cache** — exit 0, clean, no warnings.

## Files

- `proofs/Proofs/VietasFormulasOQ05.lean`
- `src/data/proofs/vietas-formulas-oq-05/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)