### PR TITLE
research(leibniz-pi-oq-04): Euler's two-term Machin identity π/4 = arctan(1/2)+arctan(1/3) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LeibnizPiOQ04.lean
+++ b/proofs/Proofs/LeibnizPiOQ04.lean
@@ -1,0 +1,118 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan
+import Mathlib.Tactic
+
+/-!
+# Euler's Two-Term Machin-Like Identity: π/4 = arctan(1/2) + arctan(1/3)
+
+## What This Proves
+Euler's classical decomposition of the quarter-turn angle into two arctangents of
+unit fractions:
+
+  π/4 = arctan(1/2) + arctan(1/3)
+
+This is the simplest nontrivial *Machin-like* identity: it writes the angle whose
+tangent is `1` (namely `arctan 1 = π/4`, the endpoint of the Leibniz/Gregory series
+`π/4 = 1 - 1/3 + 1/5 - ⋯`) as a sum of two arctangents of *smaller* arguments, whose
+own arctangent series converge geometrically faster.
+
+## The General Characterization
+Rather than verify the single numerical identity, we prove the underlying
+**characterization theorem**. For positive reals `x, y`,
+
+  arctan x + arctan y = π/4   ⟺   x + y + x·y = 1   ⟺   (1 + x)(1 + y) = 2.
+
+Euler's identity is then the instance `x = 1/2, y = 1/3`, checked by the arithmetic
+`1/2 + 1/3 + 1/6 = 1` (equivalently `(3/2)(4/3) = 2`).
+
+The characterization exposes the whole one-parameter *family* of two-term π/4
+identities: any `x ∈ (0, 1)` pairs with the unique `y = (1 - x)/(1 + x) > 0`.
+Euler's `(1/2, 1/3)` is the value `x = 1/2`.
+
+## Approach
+- `Real.arctan_add : x*y < 1 → arctan x + arctan y = arctan ((x+y)/(1-x*y))` is the
+  tangent addition formula transported through `arctan`.
+- The forward direction needs `x < 1` and `y < 1` (hence `x*y < 1`), obtained from
+  strict monotonicity of `arctan`: if `arctan x + arctan y = π/4` with `y > 0` then
+  `arctan x < π/4 = arctan 1`.
+- `Real.arctan_eq_pi_div_four : arctan x = π/4 ↔ x = 1` closes both directions.
+
+## Status
+- [x] Complete proof, 0 sorries, 0 axioms (foundational axioms only).
+- [x] Parent: `leibniz-pi` (π/4 = arctan 1). This OQ splits that angle.
+
+## Parent
+Open question `leibniz-pi-oq-04` off the verified 0-axiom `leibniz-pi` entry.
+-/
+
+namespace LeibnizPiOQ04
+
+open Real
+
+/-- **Two-term π/4 characterization.** For positive reals `x` and `y`,
+`arctan x + arctan y = π/4` holds exactly when `x + y + x·y = 1`. -/
+theorem arctan_add_eq_pi_div_four_iff {x y : ℝ} (hx : 0 < x) (hy : 0 < y) :
+    arctan x + arctan y = π / 4 ↔ x + y + x * y = 1 := by
+  constructor
+  · -- Forward: from the angle sum, deduce x < 1, y < 1, then invert arctan_add.
+    intro h
+    -- `arctan y > 0` since `y > 0`, so `arctan x < π/4 = arctan 1`, giving `x < 1`.
+    have hay : 0 < arctan y := arctan_pos.mpr hy
+    have hax : 0 < arctan x := arctan_pos.mpr hx
+    have hx1 : x < 1 := by
+      have : arctan x < arctan 1 := by
+        rw [arctan_one]; linarith
+      exact (arctan_lt_arctan_iff).mp this
+    have hy1 : y < 1 := by
+      have : arctan y < arctan 1 := by
+        rw [arctan_one]; linarith
+      exact (arctan_lt_arctan_iff).mp this
+    have hxy : x * y < 1 := by nlinarith
+    -- Rewrite the sum through `arctan_add`, then peel off `arctan`.
+    rw [arctan_add hxy] at h
+    have hden : (1 - x * y) ≠ 0 := by nlinarith
+    have hone := (arctan_eq_pi_div_four).mp h        -- (x + y)/(1 - x*y) = 1
+    field_simp [hden] at hone
+    nlinarith [hone]
+  · -- Backward: `x + y + x*y = 1` forces the argument of `arctan_add` to be `1`.
+    intro h
+    have hxy : x * y < 1 := by nlinarith
+    rw [arctan_add hxy]
+    have hden : (1 - x * y) ≠ 0 := by nlinarith
+    have harg : (x + y) / (1 - x * y) = 1 := by
+      field_simp [hden]
+      linarith
+    rw [harg, arctan_one]
+
+/-- **Product form of the characterization.** For positive reals,
+`arctan x + arctan y = π/4` holds exactly when `(1 + x)(1 + y) = 2`. -/
+theorem arctan_add_eq_pi_div_four_iff_prod {x y : ℝ} (hx : 0 < x) (hy : 0 < y) :
+    arctan x + arctan y = π / 4 ↔ (1 + x) * (1 + y) = 2 := by
+  rw [arctan_add_eq_pi_div_four_iff hx hy]
+  constructor <;> intro h <;> nlinarith [h]
+
+/-- **Euler's identity.** `π/4 = arctan(1/2) + arctan(1/3)`, the simplest
+two-term Machin-like decomposition of the quarter angle. -/
+theorem euler_arctan_half_add_third :
+    arctan (1 / 2) + arctan (1 / 3) = π / 4 := by
+  rw [arctan_add_eq_pi_div_four_iff (by norm_num) (by norm_num)]
+  norm_num
+
+/-- Restatement splitting `arctan 1 = π/4` (the Leibniz endpoint) into two faster
+arctangent series. -/
+theorem arctan_one_eq_half_add_third :
+    arctan 1 = arctan (1 / 2) + arctan (1 / 3) := by
+  rw [arctan_one, euler_arctan_half_add_third]
+
+/-- The pairing partner is explicit: any `x ∈ (0,1)` matches the unique
+`y = (1 - x)/(1 + x) > 0`, exhibiting the whole family of two-term π/4 identities.
+Euler's identity is the case `x = 1/2`, where `y = 1/3`. -/
+theorem arctan_add_partner_eq_pi_div_four {x : ℝ} (hx0 : 0 < x) (hx1 : x < 1) :
+    arctan x + arctan ((1 - x) / (1 + x)) = π / 4 := by
+  have hy : 0 < (1 - x) / (1 + x) := by
+    apply div_pos <;> linarith
+  have h1x : (1 + x) ≠ 0 := ne_of_gt (by linarith)
+  rw [arctan_add_eq_pi_div_four_iff hx0 hy]
+  field_simp [h1x]
+  ring
+
+end LeibnizPiOQ04

--- a/src/data/proofs/leibniz-pi-oq-04/annotations.json
+++ b/src/data/proofs/leibniz-pi-oq-04/annotations.json
@@ -1,0 +1,111 @@
+[
+  {
+    "id": "ann-leibniz-oq04-01-overview",
+    "proofId": "leibniz-pi-oq-04",
+    "range": {
+      "startLine": 4,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "Problem Overview: Euler's Two-Term Machin-Like Identity",
+    "content": "This file proves Euler's decomposition $\\pi/4 = \\arctan(1/2) + \\arctan(1/3)$ — but instead of verifying the single numerical identity, it establishes the general characterization behind it: for positive reals $x, y$, the angle sum $\\arctan x + \\arctan y$ equals $\\pi/4$ exactly when $x + y + xy = 1$. Euler's pair $(1/2, 1/3)$ is one rational point on a continuous one-parameter family of such identities. This is the simplest genuinely two-term Machin-like formula, splitting the quarter angle $\\arctan 1 = \\pi/4$ (the Leibniz-series endpoint) into two arctangents of smaller arguments whose Gregory–Leibniz series converge geometrically faster.",
+    "mathContext": "$$\\arctan x + \\arctan y = \\frac{\\pi}{4} \\iff x + y + xy = 1 \\iff (1+x)(1+y) = 2$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Machin-like formula",
+      "arctangent addition",
+      "convergence acceleration"
+    ],
+    "prerequisites": [
+      "arctangent function",
+      "tangent addition formula",
+      "arctan 1 = pi/4"
+    ]
+  },
+  {
+    "id": "ann-leibniz-oq04-02-characterization",
+    "proofId": "leibniz-pi-oq-04",
+    "range": {
+      "startLine": 51,
+      "endLine": 84
+    },
+    "type": "theorem",
+    "title": "The Characterization Theorem and Its Forward Subtlety",
+    "content": "The core theorem `arctan_add_eq_pi_div_four_iff` is an iff. The backward direction is a direct computation: $x + y + xy = 1$ forces the argument $(x+y)/(1-xy)$ of `Real.arctan_add` to equal $1$, and $\\arctan 1 = \\pi/4$. The forward direction is subtler: to apply `arctan_add` at all we need $xy < 1$, which is *not* assumed. It is earned from strict monotonicity of arctan — since $y > 0$ gives $\\arctan y > 0$, the hypothesis forces $\\arctan x < \\pi/4 = \\arctan 1$, hence $x < 1$ (symmetrically $y < 1$), so $xy < 1$. Only then does rewriting through `arctan_add` and peeling off arctan via `arctan_eq_pi_div_four` reduce the goal to the algebraic identity.",
+    "mathContext": "Forward: $\\arctan y > 0 \\Rightarrow \\arctan x < \\arctan 1 \\Rightarrow x < 1$, giving $xy < 1$; then $\\frac{x+y}{1-xy} = 1 \\Leftrightarrow x + y + xy = 1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "arctangent addition formula",
+      "strict monotonicity",
+      "side conditions"
+    ],
+    "prerequisites": [
+      "Real.arctan_add",
+      "Real.arctan_lt_arctan_iff",
+      "Real.arctan_eq_pi_div_four"
+    ]
+  },
+  {
+    "id": "ann-leibniz-oq04-03-product-form",
+    "proofId": "leibniz-pi-oq-04",
+    "range": {
+      "startLine": 86,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "Product Form: A Clean Multiplicative Test",
+    "content": "The additive criterion $x + y + xy = 1$ factors as $(1+x)(1+y) = 2$. This `arctan_add_eq_pi_div_four_iff_prod` restatement turns the test into a single multiplication: a positive pair gives a two-term $\\pi/4$ identity iff the product of $(1+x)$ and $(1+y)$ is exactly $2$. Euler's pair makes this transparent: $(1 + 1/2)(1 + 1/3) = (3/2)(4/3) = 2$.",
+    "mathContext": "$x + y + xy = 1 \\iff (1+x)(1+y) = 2$; Euler: $(3/2)(4/3) = 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "factorization",
+      "multiplicative criterion"
+    ],
+    "prerequisites": [
+      "algebraic manipulation"
+    ]
+  },
+  {
+    "id": "ann-leibniz-oq04-04-euler-identity",
+    "proofId": "leibniz-pi-oq-04",
+    "range": {
+      "startLine": 93,
+      "endLine": 104
+    },
+    "type": "theorem",
+    "title": "Euler's Identity and the Leibniz-Endpoint Split",
+    "content": "With the characterization in hand, `euler_arctan_half_add_third` proves $\\arctan(1/2) + \\arctan(1/3) = \\pi/4$ by discharging the arithmetic $1/2 + 1/3 + 1/6 = 1$. The companion `arctan_one_eq_half_add_third` restates it as $\\arctan 1 = \\arctan(1/2) + \\arctan(1/3)$: the quarter angle whose slow Gregory–Leibniz series is the parent entry's subject is split into two arctangents of arguments $1/2$ and $1/3$, whose own series (ratios $\\le 1/4$ and $1/9$ per term) converge geometrically faster.",
+    "mathContext": "$\\arctan\\tfrac12 + \\arctan\\tfrac13 = \\pi/4$ from $\\tfrac12+\\tfrac13+\\tfrac16 = 1$; equivalently $\\arctan 1 = \\arctan\\tfrac12 + \\arctan\\tfrac13$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's identity",
+      "Machin-like decomposition",
+      "convergence acceleration"
+    ],
+    "prerequisites": [
+      "the characterization theorem",
+      "arctan 1 = pi/4"
+    ]
+  },
+  {
+    "id": "ann-leibniz-oq04-05-partner-family",
+    "proofId": "leibniz-pi-oq-04",
+    "range": {
+      "startLine": 106,
+      "endLine": 116
+    },
+    "type": "theorem",
+    "title": "The One-Parameter Partner Family",
+    "content": "Euler's identity is not isolated: `arctan_add_partner_eq_pi_div_four` exhibits it as one value of a continuous family. For any $x \\in (0,1)$, the unique partner $y = (1-x)/(1+x) > 0$ satisfies $\\arctan x + \\arctan y = \\pi/4$ — checked by plugging into the characterization and simplifying. Euler's $(1/2, 1/3)$ is the case $x = 1/2$. The partner map $x \\mapsto (1-x)/(1+x)$ is an involution on $(-1,1)$ fixing $0$, so the family is symmetric under swapping the two arctangents.",
+    "mathContext": "For $x \\in (0,1)$: $\\arctan x + \\arctan\\frac{1-x}{1+x} = \\pi/4$; at $x = 1/2$, $y = 1/3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "one-parameter family",
+      "involution",
+      "Möbius map"
+    ],
+    "prerequisites": [
+      "the characterization theorem"
+    ]
+  }
+]

--- a/src/data/proofs/leibniz-pi-oq-04/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-04/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "leibniz-pi-oq-04",
+  "title": "Euler's Two-Term Machin-Like Identity: π/4 = arctan(1/2) + arctan(1/3)",
+  "slug": "leibniz-pi-oq-04",
+  "description": "The general characterization arctan x + arctan y = π/4 ⟺ x + y + xy = 1 ⟺ (1+x)(1+y) = 2 for positive reals, with Euler's identity π/4 = arctan(1/2) + arctan(1/3) as the instance x = 1/2, y = 1/3, and the full one-parameter partner family.",
+  "meta": {
+    "author": "Euler (formalized in Lean 4)",
+    "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.html",
+    "date": "1738 (Euler)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LeibnizPiOQ04.lean",
+    "tags": [
+      "analysis",
+      "arctangent",
+      "machin-formula",
+      "pi",
+      "real-analysis",
+      "leibniz-pi"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.arctan_add",
+        "description": "Tangent addition formula transported through arctan: x*y < 1 → arctan x + arctan y = arctan ((x+y)/(1-x*y))",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan"
+      },
+      {
+        "theorem": "Real.arctan_eq_pi_div_four",
+        "description": "arctan x = π/4 ↔ x = 1, closing both directions of the characterization",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan"
+      },
+      {
+        "theorem": "Real.arctan_lt_arctan_iff",
+        "description": "Strict monotonicity of arctan, used to derive x < 1 and y < 1 from the angle sum",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan"
+      }
+    ],
+    "originalContributions": [
+      "General characterization: arctan x + arctan y = π/4 ⟺ x + y + x·y = 1 for positive reals x, y",
+      "Product form of the criterion: (1 + x)(1 + y) = 2, a clean multiplicative test",
+      "Euler's identity π/4 = arctan(1/2) + arctan(1/3) as the instance x = 1/2, y = 1/3",
+      "The one-parameter partner family: any x ∈ (0,1) pairs with the unique y = (1−x)/(1+x)",
+      "Restatement splitting arctan 1 = π/4 (the Leibniz endpoint) into two faster arctangent series"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 118,
+    "prerequisites": [
+      "The arctangent function and its range (−π/2, π/2)",
+      "Tangent addition formula tan(a+b) = (tan a + tan b)/(1 − tan a tan b)",
+      "Strict monotonicity of arctan",
+      "arctan 1 = π/4"
+    ],
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Machin-like formulas express π/4 (equivalently arctan 1) as an integer combination of arctangents of smaller arguments, whose Gregory–Leibniz series converge geometrically faster than the boundary-case series for arctan 1 itself. The prototype is John Machin's 1706 formula π/4 = 4·arctan(1/5) − arctan(1/239), which he used to compute 100 digits of π. Euler contributed the simplest genuinely two-term decomposition, π/4 = arctan(1/2) + arctan(1/3), in the course of his work on arctangent identities (c. 1738). It is the smallest nontrivial member of an infinite family: rather than a numerical coincidence, it is one rational point on a continuous one-parameter curve of two-term π/4 identities.",
+    "problemStatement": "**Open-question extension of Leibniz's series (leibniz-pi-oq-04).** Prove Euler's decomposition\n\n$$\\frac{\\pi}{4} = \\arctan\\tfrac{1}{2} + \\arctan\\tfrac{1}{3}$$\n\nnot as an isolated numerical identity but through the underlying **characterization theorem**: for positive reals $x, y$,\n\n$$\\arctan x + \\arctan y = \\frac{\\pi}{4} \\iff x + y + xy = 1 \\iff (1+x)(1+y) = 2.$$",
+    "text": "The general two-term characterization arctan x + arctan y = π/4 ⟺ x + y + xy = 1, with Euler's π/4 = arctan(1/2) + arctan(1/3) as one instance and the full partner family y = (1−x)/(1+x).",
+    "proofStrategy": "The engine is Mathlib's `Real.arctan_add`, the tangent addition formula transported through arctan, valid when `x*y < 1`. The subtlety is the forward direction: to apply `arctan_add` we must first know `x*y < 1`. This is not assumed — it is derived from strict monotonicity of arctan. From `arctan x + arctan y = π/4` with `y > 0` we get `arctan y > 0`, hence `arctan x < π/4 = arctan 1`, hence `x < 1` (and symmetrically `y < 1`), so `x*y < 1`. Rewriting through `arctan_add` and peeling off arctan with `arctan_eq_pi_div_four` reduces the identity to the algebraic condition `(x+y)/(1−xy) = 1`, i.e. `x + y + xy = 1`. The backward direction runs the same computation forward. Euler's identity is then the arithmetic check `1/2 + 1/3 + 1/6 = 1`, equivalently `(3/2)(4/3) = 2`.",
+    "keyInsights": [
+      "**Characterize, don't just verify**: proving the iff `arctan x + arctan y = π/4 ⟺ x + y + xy = 1` subsumes Euler's identity and every other two-term π/4 decomposition in a single theorem, rather than checking one rational pair.",
+      "**The `x*y < 1` side condition is earned, not assumed**: the forward direction obtains `x < 1` and `y < 1` from strict monotonicity of arctan (`arctan y > 0 ⟹ arctan x < arctan 1 ⟹ x < 1`), which is exactly what makes `Real.arctan_add` applicable.",
+      "**A clean multiplicative test**: the additive criterion `x + y + xy = 1` factors as `(1+x)(1+y) = 2`. Euler's pair is `(3/2)(4/3) = 2` — the identity becomes a one-line arithmetic fact.",
+      "**A curve, not a point**: Euler's `(1/2, 1/3)` is the value `x = 1/2` of the one-parameter family `y = (1−x)/(1+x)`, `x ∈ (0,1)`. The partner map is an involution on `(−1,1)` fixing `0`.",
+      "**No infrastructure gaps**: `Real.arctan_add`, `arctan_one`, `arctan_eq_pi_div_four`, `arctan_pos`, and `arctan_lt_arctan_iff` are all already in Mathlib; the contribution is the characterization and family, assembled from them."
+    ],
+    "prerequisites": [
+      "The arctangent function and its range (−π/2, π/2)",
+      "Tangent addition formula tan(a+b) = (tan a + tan b)/(1 − tan a tan b)",
+      "Strict monotonicity of arctan",
+      "arctan 1 = π/4"
+    ]
+  },
+  "sections": [
+    {
+      "id": "characterization",
+      "title": "Two-Term π/4 Characterization",
+      "startLine": 51,
+      "endLine": 84,
+      "summary": "For positive reals x, y, arctan x + arctan y = π/4 holds exactly when x + y + xy = 1. The forward direction derives x, y < 1 from monotonicity of arctan before applying the addition formula.",
+      "mathContext": "$\\arctan x + \\arctan y = \\pi/4 \\iff x + y + xy = 1$. Forward: $\\arctan y > 0 \\Rightarrow \\arctan x < \\arctan 1 \\Rightarrow x < 1$, so $xy < 1$ and `arctan_add` applies."
+    },
+    {
+      "id": "product-form",
+      "title": "Product Form of the Criterion",
+      "startLine": 86,
+      "endLine": 91,
+      "summary": "The additive condition x + y + xy = 1 is equivalent to the multiplicative (1 + x)(1 + y) = 2.",
+      "mathContext": "$x + y + xy = 1 \\iff (1+x)(1+y) = 2$. Euler's pair: $(3/2)(4/3) = 2$."
+    },
+    {
+      "id": "euler-identity",
+      "title": "Euler's Identity",
+      "startLine": 93,
+      "endLine": 104,
+      "summary": "π/4 = arctan(1/2) + arctan(1/3) as the instance x = 1/2, y = 1/3, plus the restatement splitting arctan 1 into two faster-converging arctangent series.",
+      "mathContext": "$\\arctan\\tfrac12 + \\arctan\\tfrac13 = \\pi/4$ since $\\tfrac12 + \\tfrac13 + \\tfrac16 = 1$. Restated: $\\arctan 1 = \\arctan\\tfrac12 + \\arctan\\tfrac13$."
+    },
+    {
+      "id": "partner-family",
+      "title": "The One-Parameter Partner Family",
+      "startLine": 106,
+      "endLine": 116,
+      "summary": "Every x ∈ (0,1) pairs with the unique y = (1−x)/(1+x) > 0 to give a two-term π/4 identity; Euler's is the case x = 1/2.",
+      "mathContext": "For $x \\in (0,1)$, $\\arctan x + \\arctan\\frac{1-x}{1+x} = \\pi/4$. The partner map $x \\mapsto (1-x)/(1+x)$ is an involution on $(-1,1)$ fixing $0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "leibniz-pi",
+      "relationship": "extends",
+      "description": "The parent entry proves π/4 = arctan 1 via the Leibniz series. This open-question extension splits that same quarter angle into arctan(1/2) + arctan(1/3), whose arctangent series converge geometrically faster than the boundary-case series for arctan 1."
+    },
+    {
+      "targetId": "leibniz-pi-oq-01",
+      "relationship": "related",
+      "description": "The sibling extension pins the Leibniz series convergence rate at the sharp |π/4 − S_N| ≤ 1/(2N+1) (Θ(1/N)); this entry supplies the Machin-like acceleration that motivates that comparison — arctan(1/2), arctan(1/3) series converge exponentially faster."
+    },
+    {
+      "targetId": "taylor-theorem",
+      "relationship": "foundational",
+      "description": "Each term arctan(1/2), arctan(1/3) is evaluated via its Taylor series arctan t = t − t³/3 + t⁵/5 − ⋯; the smaller arguments 1/2, 1/3 (vs 1) give geometric convergence, which is the practical payoff of the decomposition."
+    },
+    {
+      "targetId": "pi-transcendental",
+      "relationship": "related",
+      "description": "π is transcendental (Lindemann 1882); Machin-like identities such as π/4 = arctan(1/2) + arctan(1/3) are the classical route to computing many digits of this non-algebraic constant."
+    }
+  ],
+  "conclusion": {
+    "summary": "Euler's identity π/4 = arctan(1/2) + arctan(1/3) is proved as one instance of the general characterization arctan x + arctan y = π/4 ⟺ x + y + xy = 1 ⟺ (1+x)(1+y) = 2 for positive reals. The characterization exposes the entire one-parameter family of two-term π/4 decompositions, of which Euler's rational pair is a single point. Fully machine-checked with 0 axioms and 0 sorries.",
+    "implications": "**1. From identity to theory.** Verifying a single numerical identity gives one fact; proving the characterization gives every two-term π/4 identity at once and the family that organizes them.\n\n**2. The side condition is structural.** The `x·y < 1` needed by the tangent addition formula is derived from monotonicity of arctan, not assumed — showing why Euler's pair, with both arguments below 1, is exactly the admissible regime.\n\n**3. Machin-like acceleration.** Replacing the single slow series for arctan 1 by two series for arctan(1/2), arctan(1/3) is the elementary prototype of the acceleration Machin's π/4 = 4·arctan(1/5) − arctan(1/239) exploits at scale.",
+    "openQuestions": [
+      "Three-term extension: characterize arctan x + arctan y + arctan z = π/4 (Størmer / cotangent-sum theory), e.g. π/4 = arctan(1/3) + arctan(1/4) + arctan(2/9).",
+      "Integer-combination Machin formulas: formalize π/4 = 4·arctan(1/5) − arctan(1/239) and quantify the convergence-acceleration gain over the two-term identity."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "LeibnizPiOQ04",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/LeibnizPiOQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "De variis modis circuli quadraturam numeris proxime exprimendi",
+      "year": "1738",
+      "venue": "Commentarii academiae scientiarum Petropolitanae",
+      "note": "Euler's arctangent identities, including two-term decompositions of π/4 of the form arctan(1/p) + arctan(1/q)"
+    },
+    {
+      "authors": "Machin, John",
+      "title": "Machin's formula (as reported by William Jones)",
+      "year": "1706",
+      "venue": "Synopsis Palmariorum Matheseos (Jones, 1706)",
+      "note": "π/4 = 4·arctan(1/5) − arctan(1/239), the prototype Machin-like formula for fast computation of π"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "arctan_add_eq_pi_div_four_iff",
+      "type": "core",
+      "description": "For positive reals x, y: arctan x + arctan y = π/4 ⟺ x + y + x·y = 1",
+      "leanType": "0 < x → 0 < y → (arctan x + arctan y = π/4 ↔ x + y + x*y = 1)"
+    },
+    {
+      "name": "euler_arctan_half_add_third",
+      "type": "core",
+      "description": "Euler's identity: arctan(1/2) + arctan(1/3) = π/4",
+      "leanType": "arctan (1/2) + arctan (1/3) = π/4"
+    },
+    {
+      "name": "arctan_add_partner_eq_pi_div_four",
+      "type": "supporting",
+      "description": "The partner family: for x ∈ (0,1), arctan x + arctan((1−x)/(1+x)) = π/4",
+      "leanType": "0 < x → x < 1 → arctan x + arctan ((1-x)/(1+x)) = π/4"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **Euler's two-term Machin-like identity** `π/4 = arctan(1/2) + arctan(1/3)` — not as an isolated numerical check but via the underlying **characterization theorem**:

> For positive reals `x, y`:  `arctan x + arctan y = π/4  ⟺  x + y + x·y = 1  ⟺  (1+x)(1+y) = 2`.

Euler's identity is the instance `x = 1/2, y = 1/3` (arithmetic: `1/2 + 1/3 + 1/6 = 1`, equivalently `(3/2)(4/3) = 2`). The entry also exhibits the whole **one-parameter partner family** `y = (1−x)/(1+x)` for `x ∈ (0,1)`, of which Euler's rational pair is a single point.

This is the parent `leibniz-pi` open-question **oq-04**: it splits the quarter angle `arctan 1 = π/4` (the Leibniz-series endpoint) into two arctangents of smaller arguments whose Gregory–Leibniz series converge geometrically faster.

## Contents

`proofs/Proofs/LeibnizPiOQ04.lean` — 5 theorems, 0 definitions, 118 lines:
- `arctan_add_eq_pi_div_four_iff` — the core `⟺ x+y+xy=1` characterization
- `arctan_add_eq_pi_div_four_iff_prod` — product form `(1+x)(1+y)=2`
- `euler_arctan_half_add_third` — `arctan(1/2)+arctan(1/3) = π/4`
- `arctan_one_eq_half_add_third` — `arctan 1 = arctan(1/2)+arctan(1/3)`
- `arctan_add_partner_eq_pi_div_four` — the family `y=(1−x)/(1+x)`

Plus the gallery entry (`meta.json` + `annotations.json`).

## Key point

The forward direction *earns* the `x·y < 1` side condition required by `Real.arctan_add`: from `arctan y > 0` it derives `arctan x < arctan 1`, hence `x < 1` (symmetrically `y < 1`) via strict monotonicity — the condition is not assumed.

## Verification

- Compiles under **Lean 4.26.0 / Mathlib** (`import Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan`).
- `#print axioms` on all five theorems reports only `propext`, `Classical.choice`, `Quot.sound`.
- **0 axioms, 0 sorries** → `status: verified`, `badge: original`, `axiomCount: 0`.

Built with an explicit-`LEAN_PATH` compile against the host Mathlib olean cache (the shared Docker cache volume was hitting concurrent-build I/O errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)