### PR TITLE
Research: schroeder-bernstein-oq-03 (Myhill) — decompose hard direction + Π₁ obstruction

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -48,7 +48,11 @@ computable via Partrec.rfind. The orbit type is determined by bounded search.
 - myhill_easy: proved (computable bijection → one-one equivalence)
 - one_one_equiv_of_computable_perm: proved
 - myhill_self, myhill_symm, myhill_trans: proved (reflexivity/symmetry/transitivity)
-- myhill_isomorphism: hard direction has sorry (open: back-and-forth construction)
+- partialInverse_{spec,dom,unique}: proved (partial-inverse API for the hard direction)
+- fwdOrbit_eq_iterate: proved (forward orbit = iteration of g∘f; forward direction is computable)
+- isGFree_iff_not_mem_range: proved — pins down WHY the naive orbit classification is
+  not computable: `isGFree` is Π₁ (complement of the c.e. set `range g`), hence undecidable
+- myhill_isomorphism: hard direction has sorry (open: stage-wise back-and-forth construction)
 
 ## References
 - Myhill, J. (1955). "Creative sets." Z. Math. Logik Grundlag. Math. 1, 97–108.
@@ -133,6 +137,15 @@ theorem partialInverse_dom {g : ℕ → ℕ} {m : ℕ} (hm : ∃ k, g k = m) :
   rw [partialInverse, Nat.rfind_dom']
   exact ⟨k, by simp [hk], fun _ => trivial⟩
 
+/-- The partial inverse is **single-valued** under an injective `g`: any two
+    values returned for the same `m` coincide. This is the bijectivity fact the
+    back-and-forth construction needs — extending the partial map by a `g`-edge
+    can never collide, because preimages under an injection are unique. -/
+theorem partialInverse_unique {g : ℕ → ℕ} (hg_inj : Injective g)
+    {m n₁ n₂ : ℕ} (h₁ : n₁ ∈ partialInverse g m) (h₂ : n₂ ∈ partialInverse g m) :
+    n₁ = n₂ :=
+  hg_inj (by rw [partialInverse_spec hg_inj h₁, partialInverse_spec hg_inj h₂])
+
 /-!
 ## Section 4: Orbit Structure for the Back-and-Forth
 
@@ -145,12 +158,43 @@ def fwdOrbit (f g : ℕ → ℕ) (n : ℕ) : ℕ → ℕ
   | 0 => n
   | k + 1 => g (f (fwdOrbit f g n k))
 
+/-- The forward orbit is exactly iteration of `g ∘ f`, identifying `fwdOrbit`
+    with Mathlib's `Function.iterate` (unlocking its API). Since `fun x => g (f x)`
+    is computable whenever `f` and `g` are, the *forward* orbit is unproblematically
+    computable — the difficulty in Myhill's construction lies entirely in the
+    *backward* direction (see the note on `isGFree` below). -/
+theorem fwdOrbit_eq_iterate (f g : ℕ → ℕ) (n k : ℕ) :
+    fwdOrbit f g n k = (fun x => g (f x))^[k] n := by
+  induction k with
+  | zero => rfl
+  | succ k ih =>
+      simp only [fwdOrbit, ih, Function.iterate_succ_apply']
+
 /-- The back-and-forth strategy: an element n is "f-type" if its backward chain
     under alternating g⁻¹, f⁻¹ terminates outside range(g) (i.e., not a g-image).
     These are exactly the elements where σ(n) := f(n) is the right choice.
 
     For elements where the chain never terminates (infinite orbits), we also use f. -/
 def isGFree (g : ℕ → ℕ) (n : ℕ) : Prop := ∀ k, g k ≠ n
+
+/-- `isGFree g n` is exactly the statement that `n` is **not** in the range of `g`.
+
+    **Why this matters for computability.** The "orbit classification" sketch above
+    (Type A/B/C) asks, for each `n`, whether the backward chain terminates outside
+    `range g` — i.e. whether some ancestor is `isGFree`. But `isGFree g n` is a
+    `Π₁` (universally quantified) predicate: for a merely *computable* injection `g`,
+    `range g` is only computably enumerable (`Σ₁`), so its complement `isGFree g`
+    is `Π₁` and in general **undecidable**. Hence the orbit type of `n` is *not*
+    computable, and the classical Schröder–Bernstein orbit construction does **not**
+    yield a computable bijection.
+
+    This is precisely why Myhill's theorem cannot be obtained by "reading off" the
+    classical proof, and must instead use the stage-wise finite back-and-forth
+    (priority) construction described on `myhill_isomorphism`, where each stage
+    performs only a *bounded* search and never has to decide `range g`. -/
+theorem isGFree_iff_not_mem_range (g : ℕ → ℕ) (n : ℕ) :
+    isGFree g n ↔ n ∉ Set.range g := by
+  simp only [isGFree, Set.mem_range, not_exists, ne_eq]
 
 /-!
 ## Section 5: The Myhill Isomorphism Theorem

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -1,21 +1,59 @@
-# Knowledge Base: schroeder-bernstein-oq-03
-
-Insights accumulated during research on this problem.
-
----
+# Knowledge Base: schroeder-bernstein-oq-03 (Myhill Isomorphism Theorem)
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
-
----
+Target: `OneOneEquiv p q ↔ ∃ e : ℕ ≃ ℕ, e.Computable ∧ ∀ n, p n ↔ q (e n)`.
+The `←` (easy) direction is proved (`myhill_easy`). The `→` (hard) direction —
+two computable injections yield a *computable* permutation — is the OPEN target
+(one `sorry` in `myhill_isomorphism`).
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- Mathlib provides `OneOneReducible` (`≤₁`), `OneOneEquiv`, `ManyOneEquiv`
+  (`Mathlib/Computability/Reduce.lean`) but does **not** contain Myhill's
+  isomorphism theorem. The only "Myhill" file is `MyhillNerode.lean` (regular
+  languages, unrelated). This is a genuine gap.
 
----
+- **Core obstruction (why naive SB fails).** `isGFree g n := ∀ k, g k ≠ n` is
+  exactly `n ∉ Set.range g` (proved: `isGFree_iff_not_mem_range`). For a merely
+  *computable* injection `g`, `range g` is only c.e. (`Σ₁`), so its complement
+  `isGFree g` is `Π₁` and undecidable. The classical Schröder–Bernstein orbit-type
+  classification needs to decide, for each `n`, whether the backward chain leaves
+  `range g` — i.e. it needs `isGFree`, which is not computable. Hence the classical
+  orbit construction does **not** give a computable bijection, and the Section-4
+  "Type A/B/C" sketch in the Lean file is the *wrong* (non-computable) approach.
+
+- **Correct route.** The stage-wise finite back-and-forth (priority) construction
+  (Rogers §7.4): at each stage extend a finite partial injection by one element,
+  using `f` on the domain side and `partialInverse g` on the range side. Each stage
+  is a *bounded* search — it never decides `range g` — so the result is computable.
+
+- `p, q` are arbitrary predicates, **not** computable. The construction must route
+  membership through the computable reductions `f, g` structurally; it must never
+  test `p n`/`q v` directly. `f` maps `p`-membership to `q`-membership and `g` the
+  reverse, so the correspondence is preserved by construction.
+
+## Built this session (all proved, file compiles clean)
+
+- `partialInverse_unique` — partial inverse is single-valued under injective `g`
+  (collision-freeness for range-side extension).
+- `fwdOrbit_eq_iterate` — `fwdOrbit f g n k = (g∘f)^[k] n`; forward orbit is
+  computable (difficulty is entirely backward).
+- `isGFree_iff_not_mem_range` — the Π₁ obstruction lemma (see above).
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Reading the computable bijection off the classical SB orbit decomposition:
+  blocked by the Π₁ undecidability of `isGFree`/`range g` membership.
+
+## Next Steps
+
+1. Formalize the stage-wise partial-bijection builder (`List (ℕ × ℕ)` by recursion
+   on the stage index), extending by `f` (domain) / `partialInverse g` (range).
+2. Prove stage invariants: injectivity (via `partialInverse_unique` + `f` injective),
+   correspondence `p ↔ q` preserved, domain/range exhaustion (`n` covered by stage
+   `2n+1`).
+3. Computability of the permutation from the computable builder + bounded search for
+   the entering stage.
+4. Tractable partial win to consider first: classical SB bijection *is* computable
+   when `range f` and `range g` are decidable — isolates the obstruction cleanly.

--- a/src/data/research/problems/schroeder-bernstein-oq-03.json
+++ b/src/data/research/problems/schroeder-bernstein-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "schroeder-bernstein-oq-03",
   "title": "Myhill Isomorphism Theorem (Computable Schroeder-Bernstein)",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -26,24 +26,42 @@
     "goal": "Prove back-and-forth yields a Computable bijection when f and g are Computable"
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-04-21T16:44:09+02:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Hard direction open; obstruction (Π₁ isGFree) identified; back-and-forth builder is the path.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Formalize stage-wise partial-bijection builder + invariants.",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS: hard direction (OneOneEquiv → computable permutation) still OPEN. Confirmed Mathlib lacks Myhill's isomorphism theorem (only MyhillNerode, unrelated). Added 3 proved lemmas decomposing toward the construction and identified the core obstruction: isGFree (= n ∉ range g) is Π₁/undecidable, so the file's orbit-classification sketch is NOT computable; Myhill genuinely requires the stage-wise bounded back-and-forth.",
+    "builtItems": [
+      "partialInverse_unique in Proofs/SchroederBernsteinOQ03.lean (single-valued partial inverse)",
+      "fwdOrbit_eq_iterate in Proofs/SchroederBernsteinOQ03.lean (orbit = Function.iterate of g∘f)",
+      "isGFree_iff_not_mem_range in Proofs/SchroederBernsteinOQ03.lean (Π₁ obstruction lemma)"
+    ],
+    "insights": [
+      "Mathlib has OneOneReducible/OneOneEquiv/ManyOneEquiv (Computability.Reduce) but NOT Myhill's isomorphism theorem — genuine gap.",
+      "OBSTRUCTION: isGFree g n ≡ (n ∉ Set.range g) is Π₁ (complement of the c.e. set range g), hence undecidable for a merely computable injection g. So classical Schröder–Bernstein orbit-type classification (Type A/B/C) is non-computable; the file's Section-4 sketch cannot be made computable as written.",
+      "Correct route: stage-wise finite back-and-forth (priority) where each stage does only a BOUNDED search and never decides range g (matches myhill_isomorphism docstring, not the Section-4 orbit sketch).",
+      "p,q are arbitrary predicates (NOT computable); the construction must route membership through the computable reductions f,g structurally and never test p/q directly.",
+      "partialInverse is single-valued under injective g (partialInverse_unique) — collision-freeness for extending the partial map by a g-edge.",
+      "fwdOrbit f g n k = (g∘f)^[k] n (fwdOrbit_eq_iterate): the forward orbit is unproblematically computable; difficulty is entirely backward."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks Myhill isomorphism theorem (OneOneEquiv → computable permutation)."
+    ],
+    "nextSteps": [
+      "Formalize the stage-wise partial-bijection builder (List (ℕ×ℕ) by recursion on stage) using f for domain-side and partialInverse g for range-side extensions.",
+      "Prove the stage invariants: injectivity (via partialInverse_unique + f injective), correspondence p↔q preserved, and domain/range exhaustion (n covered by stage 2n+1).",
+      "Derive computability of the resulting permutation from computability of the stage builder + bounded search for the entering stage.",
+      "Consider a tractable partial win first: classical SB bijection IS computable when range g and range f are decidable (isolates the Π₁ obstruction)."
+    ],
     "markdown": "# Knowledge Base: schroeder-bernstein-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session on **schroeder-bernstein-oq-03** (Myhill's Isomorphism Theorem: computable Schröder–Bernstein). The `←` (easy) direction and corollaries were already proved; the `→` (hard) direction — `OneOneEquiv p q → ∃ computable permutation e, ∀ n, p n ↔ q (e n)` — remains OPEN (one `sorry`). This session decomposes toward that construction with three fully-proved lemmas and, most importantly, records the precise computability obstruction.

## Progress (all proved; file compiles clean, only the pre-existing open `sorry` remains)
- `partialInverse_unique` — the partial inverse of `g` is single-valued when `g` is injective (the collision-freeness fact the back-and-forth needs).
- `fwdOrbit_eq_iterate` — `fwdOrbit f g n k = (g∘f)^[k] n`, tying orbits to Mathlib's `Function.iterate`; the forward orbit is unproblematically computable.
- `isGFree_iff_not_mem_range` — `isGFree g n ↔ n ∉ Set.range g`.

## Findings
- **Mathlib gap confirmed:** Mathlib has `OneOneReducible`/`OneOneEquiv`/`ManyOneEquiv` (`Computability/Reduce.lean`) but **not** Myhill's isomorphism theorem (the only "Myhill" file, `MyhillNerode.lean`, is unrelated regular-language content).
- **Core obstruction:** `isGFree g n` is `Π₁` (complement of the c.e. set `range g`), hence **undecidable** for a merely computable injection `g`. So the file's own Section-4 "orbit classification" sketch (Type A/B/C) is *not* computable — this is exactly why Myhill's theorem cannot be read off the classical Schröder–Bernstein proof and must use the stage-wise **bounded** back-and-forth (priority) construction instead. This obstruction is now documented in the source and knowledge base.
- `p, q` are arbitrary (non-computable) predicates; the construction must route membership structurally through `f, g` and never test `p`/`q` directly.

## Verification
Compiles clean under `lean v4.26.0` against prebuilt Mathlib oleans. (Docker build was unavailable this session — host disk at 100%; used a direct single-file `lean` compile against the existing olean set.) `#errors = 0`; the only warning is the pre-existing `uses 'sorry'` at the open hard direction.

## Status
**Outcome**: progress (decomposition + obstruction identified; main construction still open)
**Next Steps**: formalize the stage-wise partial-bijection builder + invariants (injectivity via `partialInverse_unique`, correspondence preservation, domain/range exhaustion), then derive computability from the bounded-search stage function. A tractable partial win: classical SB *is* computable when `range f`, `range g` are decidable.

🤖 Generated by researcher-9