### PR TITLE
Enrich Hermite's Floor Identity: add companion/generalization crossRefs

### DIFF
--- a/src/data/proofs/hermite-floor-identity/meta.json
+++ b/src/data/proofs/hermite-floor-identity/meta.json
@@ -84,6 +84,16 @@
   },
   "crossReferences": [
     {
+      "targetId": "hermite-sawtooth-identity",
+      "relationship": "companion",
+      "description": "The fractional-part twin of this floor identity: ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n-1)/2 for the sawtooth {y} = y − ⌊y⌋. Since {y} = y − ⌊y⌋, the two identities together give the complete floor + fractional decomposition of the uniformly sampled sum ∑_{k<n}(x + k/n) = n·x + (n-1)/2. That sawtooth entry cross-references this one as its parent; the openQuestions here name exactly that companion identity."
+    },
+    {
+      "targetId": "hermite-sawtooth-identity-oq-01",
+      "relationship": "generalized-by",
+      "description": "The Raabe (Hurwitz) multiplication theorem for Bernoulli polynomials, ∑_{k=0}^{n-1} Bₘ(x + k/n) = n^{1-m}·Bₘ(nx), subsumes both this floor identity and the companion sawtooth identity as low-order faces: the sawtooth ∑{x+k/n} is the m = 1 Bernoulli case, and the floor sum is its integer-part complement. That entry proves Raabe at orders m = 0, 1, 2."
+    },
+    {
       "targetId": "hermite-lindemann",
       "relationship": "related",
       "description": "Shares only the name 'Hermite': HermiteLindemann is the transcendence theorem (e and π transcendental), an entirely different result. This entry is the elementary floor-function identity; the cross-reference exists to disambiguate the two."


### PR DESCRIPTION
Enrichment pass for `hermite-floor-identity` (quality 89, pass 0).

## Change
crossReferences **1 → 3** — all target IDs verified present on `origin/main`:

| target | relationship | why |
|--------|-------------|-----|
| `hermite-sawtooth-identity` | companion | The fractional-part twin (∑{x+k/n} = {nx}+(n-1)/2). That entry already back-links here as its parent; this adds the missing **forward** link, making the floor + fractional decomposition navigable both ways. |
| `hermite-sawtooth-identity-oq-01` | generalized-by | The Raabe/Hurwitz Bernoulli-polynomial multiplication formula ∑Bₘ(x+k/n)=n^{1-m}Bₘ(nx) that subsumes both the floor and sawtooth identities as low-order faces. |
| `hermite-lindemann` | related | Existing disambiguation link, preserved. |

## Rationale
The entry's own `openQuestions` already name "the companion sawtooth/fractional-part identity ∑{x+k/n} = {nx}+(n-1)/2" — but there was no cross-reference wiring it up. This closes the bidirectional gap and links the Raabe generalization.

## Validation
- JSON parses; `check-meta-size` passes (well under 60 KB cap).
- Gallery enrichment prebuild processed the entry with no errors.
- Pure JSON metadata change; no Lean/axiom/status fields touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)