### PR TITLE
Enrich Fibonacci Linear Sums (fibonacci-identities-oq-06): add Lucas partial-sum crossRef

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-06/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06/meta.json
@@ -102,6 +102,11 @@
       "targetId": "fibonacci-identities-oq-05",
       "relationship": "relatedTo",
       "description": "The oq-05 entry establishes the bilinear product sum ∑ Fₖ·Fₖ₊₁ (parity governed via Cassini); this entry handles the strictly simpler linear sums ∑ Fₖ and ∑ k·Fₖ, which telescope or reduce to a single linear combination of the induction hypothesis with no parity split."
+    },
+    {
+      "targetId": "lucas-sum-oq-01",
+      "relationship": "relatedTo",
+      "description": "The Lucas analogue of this entry's fib_sum: the partial sum ∑_{k=1}^{n} Lₖ = Lₙ₊₂ − 3 telescopes exactly as F₀ + ⋯ + Fₙ = Fₙ₊₂ − 1 does here, differing only in the constant (3 vs 1) fixed by the initial conditions L₀ = 2, L₁ = 1 rather than F₀ = 0, F₁ = 1. It realizes, at degree zero, the general Gibonacci partial-sum question raised in this entry's open problems and shares the same subtraction-free-in-ℕ + omega proof recipe."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-06` (fresh entry, 0 prior passes, quality 89).

The entry was already exceptionally well-curated: 13.6 KB (well under the 60 KB cap), 4 high-quality annotations covering the full 70-line Lean file end-to-end, 4 keyInsights, a complete conclusion, and 3 references. Per the size guardrails I did **not** pad the shallowest field. Instead I added the one genuinely-missing cross-reference.

## Change
- **crossReferences 2 → 3** (cap 20): added `lucas-sum-oq-01`, the exact **Lucas analogue** of this entry's `fib_sum`. The Lucas partial sum ∑_{k=1}^{n} Lₖ = Lₙ₊₂ − 3 telescopes identically to the Fibonacci partial sum F₀ + ⋯ + Fₙ = Fₙ₊₂ − 1 proved here, differing only in the constant (3 vs 1) set by the initial conditions. This directly realizes, at degree zero, the Gibonacci partial-sum open question already raised in this entry's `openQuestions`, and shares the same subtraction-free-in-ℕ + `omega` proof recipe.

## Verification
- meta.json valid JSON; crossReference targetIds unique (no dups); `lucas-sum-oq-01` exists on origin/main (link resolves).
- Defect scan (dup crossRefs / dup section summaries / bare openQuestions string / dangling targetIds): clean.
- Single-file diff (+5 lines).