### PR TITLE
audit(bertrands-postulate-oq-05): CLEAN — verified badge honest, 0-axiom

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26455,6 +26455,12 @@
       "issues": [],
       "result": "clean",
       "lastAudited": "2026-07-01T12:19:41Z"
+    },
+    "bertrands-postulate-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T13:17:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `bertrands-postulate-oq-05` (first audit)
**Verdict**: CLEAN — records `auditCount: 1, result: clean` in the tracker.

### Checks (meta.json vs Lean source)

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| theorems | 6 | 6 | ✅ |
| sorries | 0 | 0 | ✅ |
| axiom decls | 0 | 0 | ✅ |
| native_decide | none | 0 | ✅ |
| True stubs | — | 0 | ✅ |
| lineCount | 112 | 112 | ✅ |

### Narrative integrity

- **No delegation opacity**: Bertrand (`Nat.exists_prime_lt_and_le_two_mul`) and Legendre (`padicValNat_factorial`) are transparently credited — the `description` opens "Applying Bertrand's postulate…", both appear in `mathlibDependencies`, and `originalContributions` scope exactly the bridge lemmas that are independently derived.
- **Not a Mathlib wrapper**: the headline results — `factorization_factorial_eq_one` (v_p(n!) = 1 for the Bertrand prime) and `factorial_not_isSquare` (n! is never a perfect square for n ≥ 2) — are genuinely derived from Bertrand + Legendre, not imported. Badge `verified` is defensible.
- **No hidden assumptions**: no structures/typeclasses encode assumptions; `assumptions` field honest ("0 axioms beyond foundational, no native_decide").

Only `src/data/proofs/audit-tracker.json` is modified.

---
Discovered during autonomous gallery integrity audit.