### PR TITLE
Enrich Raabe Multiplication Formula: link to Hermite floor identity

### DIFF
--- a/src/data/proofs/hermite-sawtooth-identity-oq-01/meta.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-01/meta.json
@@ -103,6 +103,11 @@
       "proofId": "hermite-sawtooth-identity",
       "relationship": "parent",
       "description": "Parent entry: the fractional-part sawtooth identity ∑_{k<n} {x+k/n} = {nx} + (n-1)/2, the m = 1 face of the Raabe multiplication theorem. This entry answers its open question oq-01 by proving the Bernoulli-polynomial multiplication formula at orders m = 0, 1, 2."
+    },
+    {
+      "proofId": "hermite-floor-identity",
+      "relationship": "related",
+      "description": "The integer-part complement of the sawtooth face of this formula. Raabe at order m = 1 recovers the sawtooth identity ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n-1)/2; subtracting that from the trivial ∑_{k<n}(x + k/n) = n·x + (n-1)/2 yields Hermite's floor identity ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋. The floor entry lists this Raabe formula as its generalization."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `hermite-sawtooth-identity-oq-01` (Raabe/Hurwitz multiplication formula, quality 89).

## Change
crossReferences **1 → 2** — adds `hermite-floor-identity` (relationship `related`, target verified on `origin/main`).

## Rationale
Reciprocal of PR #32216. Raabe at order m=1 recovers the sawtooth identity ∑{x+k/n} = {nx}+(n-1)/2; its integer-part complement is Hermite's floor identity ∑⌊x+k/n⌋ = ⌊nx⌋. The floor entry now lists this Raabe formula as its `generalized-by` reference, so this closes the cluster's cross-linking symmetrically.

## Validation
- JSON parses; entry ~11 KB (well under 60 KB cap).
- Uses the entry's existing `proofId` key convention.
- Pure JSON metadata change; no Lean/axiom/status fields touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)