### PR TITLE
research(de-moivre-oq-06): Lagrange trigonometric identities [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DeMoivreOQ06.lean
+++ b/proofs/Proofs/DeMoivreOQ06.lean
@@ -30,7 +30,10 @@ supplies them, together with the underlying complex closed form
 * `lagrange_sin_sum` — **Lagrange's sine identity** (the conjugate Dirichlet kernel).
 -/
 
-import Mathlib
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.Complex.Exponential
+import Mathlib.Algebra.Field.GeomSum
+import Mathlib.Tactic
 
 open Finset
 
@@ -81,15 +84,14 @@ theorem lagrange_cos_key (θ : ℝ) (n : ℕ) :
       = Real.sin (((n : ℝ) + 1 / 2) * θ) + Real.sin (θ / 2) := by
   induction n with
   | zero =>
-      simp only [Finset.sum_range_one, Nat.cast_zero, zero_mul, Real.cos_zero, mul_one]
-      rw [show ((0 : ℝ) + 1 / 2) * θ = θ / 2 by ring]
+      rw [Finset.sum_range_one, Nat.cast_zero, zero_mul, Real.cos_zero, mul_one,
+          show ((0 : ℝ) + 1 / 2) * θ = θ / 2 by ring]
       ring
   | succ n ih =>
       rw [Finset.sum_range_succ, mul_add, ih, two_sin_half_mul_cos]
       have e1 : ((↑(n + 1) : ℝ) + 1 / 2) * θ = ((n : ℝ) + 1 + 1 / 2) * θ := by push_cast; ring
       have e2 : ((↑(n + 1) : ℝ) - 1 / 2) * θ = ((n : ℝ) + 1 / 2) * θ := by push_cast; ring
       rw [e1, e2]
-      push_cast
       ring
 
 /-- Telescoped (denominator-cleared) Lagrange sine identity:
@@ -99,15 +101,14 @@ theorem lagrange_sin_key (θ : ℝ) (n : ℕ) :
       = Real.cos (θ / 2) - Real.cos (((n : ℝ) + 1 / 2) * θ) := by
   induction n with
   | zero =>
-      simp only [Finset.sum_range_one, Nat.cast_zero, zero_mul, Real.sin_zero, mul_zero]
-      rw [show ((0 : ℝ) + 1 / 2) * θ = θ / 2 by ring]
+      rw [Finset.sum_range_one, Nat.cast_zero, zero_mul, Real.sin_zero, mul_zero,
+          show ((0 : ℝ) + 1 / 2) * θ = θ / 2 by ring]
       ring
   | succ n ih =>
       rw [Finset.sum_range_succ, mul_add, ih, two_sin_half_mul_sin]
       have e1 : ((↑(n + 1) : ℝ) + 1 / 2) * θ = ((n : ℝ) + 1 + 1 / 2) * θ := by push_cast; ring
       have e2 : ((↑(n + 1) : ℝ) - 1 / 2) * θ = ((n : ℝ) + 1 / 2) * θ := by push_cast; ring
       rw [e1, e2]
-      push_cast
       ring
 
 /-- **Lagrange's cosine identity (Dirichlet kernel).**

--- a/proofs/Proofs/DeMoivreOQ06.lean
+++ b/proofs/Proofs/DeMoivreOQ06.lean
@@ -1,0 +1,141 @@
+/-
+Finite geometric sum of complex exponentials and the Lagrange trigonometric identities
+
+Source: Open question from the de-moivre gallery family (de-moivre-oq-06)
+Status: VERIFIED (0 axioms, 0 sorries)
+
+De Moivre's theorem turns a geometric sum of unit-modulus complex numbers into a
+closed form.  Summing the ratio `z = e^{iθ}` and taking real / imaginary parts
+yields the two classical *Lagrange trigonometric identities* (the Dirichlet
+kernel and its conjugate):
+
+      ∑_{k=0}^{n} cos(kθ) = 1/2 + sin((n+1/2)θ) / (2 sin(θ/2))
+      ∑_{k=0}^{n} sin(kθ) = (cos(θ/2) − cos((n+1/2)θ)) / (2 sin(θ/2))
+
+valid whenever `sin(θ/2) ≠ 0` (i.e. `θ` is not an integer multiple of `2π`).
+
+Mathlib records the *infinite* power series `Complex.cos_eq_tsum` and the raw
+geometric-series identity `geom_sum_eq`, but it does **not** record these
+closed forms for the *finite partial sums* of `cos(kθ)` and `sin(kθ)`.  This file
+supplies them, together with the underlying complex closed form
+
+      ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ} − 1)/(e^{iθ} − 1)      (e^{iθ} ≠ 1).
+
+## Main results
+
+* `geom_exp_partial_sum` — the finite geometric sum of complex exponentials.
+* `two_sin_half_mul_cos`, `two_sin_half_mul_sin` — product-to-sum telescoping steps.
+* `lagrange_cos_key`, `lagrange_sin_key` — the telescoped (denominator-cleared) identities.
+* `lagrange_cos_sum` — **Lagrange's cosine identity** (real part of the Dirichlet kernel).
+* `lagrange_sin_sum` — **Lagrange's sine identity** (the conjugate Dirichlet kernel).
+-/
+
+import Mathlib
+
+open Finset
+
+namespace DeMoivreOQ06
+
+/-- **Finite geometric sum of complex exponentials.**
+For `e^{iθ} ≠ 1`,
+`∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ} − 1)/(e^{iθ} − 1)`. -/
+theorem geom_exp_partial_sum (θ : ℝ) (h : Complex.exp (θ * Complex.I) ≠ 1) (n : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), Complex.exp ((k : ℂ) * (θ * Complex.I))
+      = (Complex.exp (((n : ℂ) + 1) * (θ * Complex.I)) - 1) /
+          (Complex.exp (θ * Complex.I) - 1) := by
+  have hx : ∀ k : ℕ, Complex.exp ((k : ℂ) * (θ * Complex.I))
+      = Complex.exp (θ * Complex.I) ^ k := fun k => Complex.exp_nat_mul (θ * Complex.I) k
+  simp_rw [hx]
+  rw [geom_sum_eq h (n + 1)]
+  have hnum : Complex.exp (θ * Complex.I) ^ (n + 1)
+      = Complex.exp (((n : ℂ) + 1) * (θ * Complex.I)) := by
+    rw [← Complex.exp_nat_mul]
+    push_cast
+    ring_nf
+  rw [hnum]
+
+/-- Product-to-sum telescoping step for cosines:
+`2 sin(θ/2) cos(mθ) = sin((m+1/2)θ) − sin((m−1/2)θ)`. -/
+theorem two_sin_half_mul_cos (θ m : ℝ) :
+    2 * Real.sin (θ / 2) * Real.cos (m * θ)
+      = Real.sin ((m + 1 / 2) * θ) - Real.sin ((m - 1 / 2) * θ) := by
+  have h1 : (m + 1 / 2) * θ = m * θ + θ / 2 := by ring
+  have h2 : (m - 1 / 2) * θ = m * θ - θ / 2 := by ring
+  rw [h1, h2, Real.sin_add, Real.sin_sub]
+  ring
+
+/-- Product-to-sum telescoping step for sines:
+`2 sin(θ/2) sin(mθ) = cos((m−1/2)θ) − cos((m+1/2)θ)`. -/
+theorem two_sin_half_mul_sin (θ m : ℝ) :
+    2 * Real.sin (θ / 2) * Real.sin (m * θ)
+      = Real.cos ((m - 1 / 2) * θ) - Real.cos ((m + 1 / 2) * θ) := by
+  have h1 : (m + 1 / 2) * θ = m * θ + θ / 2 := by ring
+  have h2 : (m - 1 / 2) * θ = m * θ - θ / 2 := by ring
+  rw [h1, h2, Real.cos_add, Real.cos_sub]
+  ring
+
+/-- Telescoped (denominator-cleared) Lagrange cosine identity:
+`2 sin(θ/2) · ∑_{k=0}^{n} cos(kθ) = sin((n+1/2)θ) + sin(θ/2)`. -/
+theorem lagrange_cos_key (θ : ℝ) (n : ℕ) :
+    2 * Real.sin (θ / 2) * (∑ k ∈ Finset.range (n + 1), Real.cos (k * θ))
+      = Real.sin (((n : ℝ) + 1 / 2) * θ) + Real.sin (θ / 2) := by
+  induction n with
+  | zero =>
+      simp only [Finset.sum_range_one, Nat.cast_zero, zero_mul, Real.cos_zero, mul_one]
+      rw [show ((0 : ℝ) + 1 / 2) * θ = θ / 2 by ring]
+      ring
+  | succ n ih =>
+      rw [Finset.sum_range_succ, mul_add, ih, two_sin_half_mul_cos]
+      have e1 : ((↑(n + 1) : ℝ) + 1 / 2) * θ = ((n : ℝ) + 1 + 1 / 2) * θ := by push_cast; ring
+      have e2 : ((↑(n + 1) : ℝ) - 1 / 2) * θ = ((n : ℝ) + 1 / 2) * θ := by push_cast; ring
+      rw [e1, e2]
+      push_cast
+      ring
+
+/-- Telescoped (denominator-cleared) Lagrange sine identity:
+`2 sin(θ/2) · ∑_{k=0}^{n} sin(kθ) = cos(θ/2) − cos((n+1/2)θ)`. -/
+theorem lagrange_sin_key (θ : ℝ) (n : ℕ) :
+    2 * Real.sin (θ / 2) * (∑ k ∈ Finset.range (n + 1), Real.sin (k * θ))
+      = Real.cos (θ / 2) - Real.cos (((n : ℝ) + 1 / 2) * θ) := by
+  induction n with
+  | zero =>
+      simp only [Finset.sum_range_one, Nat.cast_zero, zero_mul, Real.sin_zero, mul_zero]
+      rw [show ((0 : ℝ) + 1 / 2) * θ = θ / 2 by ring]
+      ring
+  | succ n ih =>
+      rw [Finset.sum_range_succ, mul_add, ih, two_sin_half_mul_sin]
+      have e1 : ((↑(n + 1) : ℝ) + 1 / 2) * θ = ((n : ℝ) + 1 + 1 / 2) * θ := by push_cast; ring
+      have e2 : ((↑(n + 1) : ℝ) - 1 / 2) * θ = ((n : ℝ) + 1 / 2) * θ := by push_cast; ring
+      rw [e1, e2]
+      push_cast
+      ring
+
+/-- **Lagrange's cosine identity (Dirichlet kernel).**
+For `sin(θ/2) ≠ 0`,
+`∑_{k=0}^{n} cos(kθ) = 1/2 + sin((n+1/2)θ) / (2 sin(θ/2))`. -/
+theorem lagrange_cos_sum (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (n : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), Real.cos (k * θ)
+      = 1 / 2 + Real.sin (((n : ℝ) + 1 / 2) * θ) / (2 * Real.sin (θ / 2)) := by
+  have hk := lagrange_cos_key θ n
+  have hden : (2 : ℝ) * Real.sin (θ / 2) ≠ 0 := mul_ne_zero two_ne_zero hθ
+  have hS : ∑ k ∈ Finset.range (n + 1), Real.cos (k * θ)
+      = (Real.sin (((n : ℝ) + 1 / 2) * θ) + Real.sin (θ / 2)) / (2 * Real.sin (θ / 2)) := by
+    rw [eq_div_iff hden]
+    linear_combination hk
+  have hhalf : Real.sin (θ / 2) / (2 * Real.sin (θ / 2)) = 1 / 2 := by
+    rw [div_eq_iff hden]; ring
+  rw [hS, add_div, hhalf]
+  ring
+
+/-- **Lagrange's sine identity (conjugate Dirichlet kernel).**
+For `sin(θ/2) ≠ 0`,
+`∑_{k=0}^{n} sin(kθ) = (cos(θ/2) − cos((n+1/2)θ)) / (2 sin(θ/2))`. -/
+theorem lagrange_sin_sum (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (n : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), Real.sin (k * θ)
+      = (Real.cos (θ / 2) - Real.cos (((n : ℝ) + 1 / 2) * θ)) / (2 * Real.sin (θ / 2)) := by
+  have hk := lagrange_sin_key θ n
+  have hden : (2 : ℝ) * Real.sin (θ / 2) ≠ 0 := mul_ne_zero two_ne_zero hθ
+  rw [eq_div_iff hden]
+  linear_combination hk
+
+end DeMoivreOQ06

--- a/src/data/proofs/de-moivre-oq-06/annotations.json
+++ b/src/data/proofs/de-moivre-oq-06/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-dm06-docstring",
+    "proofId": "de-moivre-oq-06",
+    "range": {
+      "startLine": 1,
+      "endLine": 31
+    },
+    "type": "concept",
+    "title": "Partial Sums from De Moivre: the Lagrange Identities",
+    "content": "The docstring frames the goal: closed forms for the finite partial sums $\\sum_{k=0}^{n} e^{ik\\theta}$, $\\sum_{k=0}^{n}\\cos(k\\theta)$, and $\\sum_{k=0}^{n}\\sin(k\\theta)$. De Moivre's theorem writes each term $e^{ik\\theta}=(e^{i\\theta})^k$, so the exponential sum is a geometric series with ratio $e^{i\\theta}$; its real and imaginary parts are the two classical Lagrange trigonometric identities — the Dirichlet kernel and its conjugate. It pinpoints the Mathlib gap: the library records the raw geometric series and the *infinite* trigonometric power series, but not these *finite partial-sum* closed forms for a general angle $\\theta$.",
+    "mathContext": "$\\sum_{k=0}^{n} e^{ik\\theta} = \\frac{e^{i(n+1)\\theta}-1}{e^{i\\theta}-1}$; real/imaginary parts give $\\sum\\cos(k\\theta)$ and $\\sum\\sin(k\\theta)$ in closed form for $\\sin(\\theta/2)\\ne 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "De Moivre's theorem",
+      "geometric series",
+      "Dirichlet kernel",
+      "Fourier analysis"
+    ],
+    "prerequisites": [
+      "complex exponential",
+      "Euler's formula",
+      "finite geometric series"
+    ]
+  },
+  {
+    "id": "ann-dm06-geom-exp",
+    "proofId": "de-moivre-oq-06",
+    "range": {
+      "startLine": 45,
+      "endLine": 60
+    },
+    "type": "technique",
+    "title": "The Complex Geometric Sum of Exponentials",
+    "content": "`geom_exp_partial_sum` proves $\\sum_{k=0}^{n} e^{ik\\theta} = \\frac{e^{i(n+1)\\theta}-1}{e^{i\\theta}-1}$ for $e^{i\\theta}\\ne 1$. The proof is three moves: (1) rewrite every summand $e^{ik\\theta}=(e^{i\\theta})^k$ using `Complex.exp_nat_mul` (the exponential power law), under the sum binder via `simp_rw`; (2) apply Mathlib's `geom_sum_eq`, whose hypothesis $e^{i\\theta}\\ne 1$ is exactly the given `h`; (3) re-express the top power $(e^{i\\theta})^{n+1}=e^{i(n+1)\\theta}$ by running the exponential power law backwards and normalising the cast $\\uparrow(n+1)=n+1$. No analysis beyond the exponential functional equation is needed.",
+    "mathContext": "$\\sum_{k=0}^{n}(e^{i\\theta})^k = \\frac{(e^{i\\theta})^{n+1}-1}{e^{i\\theta}-1}$, with $(e^{i\\theta})^{n+1}=e^{i(n+1)\\theta}$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "geometric series",
+      "complex exponential",
+      "exponential functional equation"
+    ],
+    "prerequisites": [
+      "geom_sum_eq",
+      "Complex.exp_nat_mul"
+    ]
+  },
+  {
+    "id": "ann-dm06-product-to-sum",
+    "proofId": "de-moivre-oq-06",
+    "range": {
+      "startLine": 62,
+      "endLine": 80
+    },
+    "type": "technique",
+    "title": "The Product-to-Sum Telescoping Step",
+    "content": "`two_sin_half_mul_cos` and `two_sin_half_mul_sin` establish the integrating-factor identities $2\\sin(\\theta/2)\\cos(m\\theta)=\\sin((m+\\tfrac12)\\theta)-\\sin((m-\\tfrac12)\\theta)$ and $2\\sin(\\theta/2)\\sin(m\\theta)=\\cos((m-\\tfrac12)\\theta)-\\cos((m+\\tfrac12)\\theta)$. Each is proved by rewriting the half-integer-shifted arguments $(m\\pm\\tfrac12)\\theta = m\\theta\\pm\\theta/2$, expanding with the angle-addition formulas `Real.sin_add`/`Real.sin_sub` (resp. `Real.cos_add`/`Real.cos_sub`), and closing with `ring`. Multiplying a summand by the factor $2\\sin(\\theta/2)$ turns it into a difference of consecutive terms — the algebraic heart of the telescope.",
+    "mathContext": "$2\\sin(\\theta/2)\\cos(m\\theta)=\\sin((m+\\tfrac12)\\theta)-\\sin((m-\\tfrac12)\\theta)$; sine analogue with cosines. Both are the addition formulas $\\sin(a\\pm b)$, $\\cos(a\\pm b)$ specialised at $b=\\theta/2$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "product-to-sum identities",
+      "angle-addition formulas",
+      "telescoping sums"
+    ],
+    "prerequisites": [
+      "Real.sin_add",
+      "Real.cos_add"
+    ]
+  },
+  {
+    "id": "ann-dm06-telescope",
+    "proofId": "de-moivre-oq-06",
+    "range": {
+      "startLine": 82,
+      "endLine": 115
+    },
+    "type": "key_step",
+    "title": "Collapsing the Sum by Telescoping Induction",
+    "content": "`lagrange_cos_key` and `lagrange_sin_key` prove the denominator-cleared identities $2\\sin(\\theta/2)\\sum_{k=0}^{n}\\cos(k\\theta)=\\sin((n+\\tfrac12)\\theta)+\\sin(\\theta/2)$ and $2\\sin(\\theta/2)\\sum_{k=0}^{n}\\sin(k\\theta)=\\cos(\\theta/2)-\\cos((n+\\tfrac12)\\theta)$. The proof is induction on $n$: `Finset.sum_range_succ` peels the top term, the inductive hypothesis handles the head, and the peeled term is rewritten by the matching product-to-sum step. Casting $\\uparrow(n+1)=n+1$ and cancelling the two half-integer-shifted sines (which coincide, since $(n+1-\\tfrac12)\\theta=(n+\\tfrac12)\\theta$) leaves exactly the endpoint terms — the telescope collapses, closed by `ring`.",
+    "mathContext": "Endpoints: $\\sum_{k=0}^{n} 2\\sin(\\theta/2)\\cos(k\\theta) = \\sin((n+\\tfrac12)\\theta)-\\sin(-\\theta/2) = \\sin((n+\\tfrac12)\\theta)+\\sin(\\theta/2)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "telescoping sums",
+      "induction",
+      "Finset.sum_range_succ"
+    ],
+    "prerequisites": [
+      "mathematical induction",
+      "product-to-sum identities"
+    ]
+  },
+  {
+    "id": "ann-dm06-lagrange",
+    "proofId": "de-moivre-oq-06",
+    "range": {
+      "startLine": 117,
+      "endLine": 142
+    },
+    "type": "key_step",
+    "title": "The Lagrange Identities and the Dirichlet Kernel",
+    "content": "`lagrange_cos_sum` and `lagrange_sin_sum` divide the telescoped identities by $2\\sin(\\theta/2)\\ne 0$ to reach the closed forms $\\sum_{k=0}^{n}\\cos(k\\theta)=\\tfrac12+\\frac{\\sin((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}$ and $\\sum_{k=0}^{n}\\sin(k\\theta)=\\frac{\\cos(\\theta/2)-\\cos((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}$. The cosine form is exactly the **Dirichlet kernel** $D_n(\\theta)$ governing Fourier-series convergence; the sine form is its conjugate. The hypothesis $\\sin(\\theta/2)\\ne 0$ ($\\theta\\notin 2\\pi\\mathbb{Z}$) is the removable singularity of the kernel: at $\\theta=0$ every term is $1$ and the sum is $n+1=D_n(0)$, while the closed form's denominator vanishes.",
+    "mathContext": "$D_n(\\theta)=\\tfrac12+\\frac{\\sin((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}$, the Dirichlet kernel; division uses `eq_div_iff` and `linear_combination` against the telescoped key.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Dirichlet kernel",
+      "Fourier series convergence",
+      "Lagrange trigonometric identities"
+    ],
+    "prerequisites": [
+      "field division lemmas",
+      "telescoped key identities"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-06/meta.json
+++ b/src/data/proofs/de-moivre-oq-06/meta.json
@@ -1,0 +1,207 @@
+{
+  "id": "de-moivre-oq-06",
+  "title": "De Moivre OQ-06: Finite Geometric Sum of Complex Exponentials and the Lagrange Trigonometric Identities",
+  "slug": "de-moivre-oq-06",
+  "description": "Closed forms for the finite partial sums ∑ e^{ikθ}, ∑ cos(kθ), and ∑ sin(kθ). De Moivre's geometric sum of the ratio e^{iθ} gives ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1), whose real and imaginary parts are the two Lagrange trigonometric identities (the Dirichlet kernel and its conjugate), proved directly by a product-to-sum telescoping.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ06.lean",
+    "tags": [
+      "complex-analysis",
+      "trigonometry",
+      "geometric-sum",
+      "dirichlet-kernel",
+      "fourier-analysis",
+      "de-moivre"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "geom_sum_eq",
+        "description": "For x ≠ 1, ∑ i ∈ range n, x^i = (x^n − 1)/(x − 1)",
+        "module": "Mathlib.Algebra.Field.GeomSum"
+      },
+      {
+        "theorem": "Complex.exp_nat_mul",
+        "description": "exp(n·x) = exp(x)^n for a natural number n, identifying e^{ikθ} with (e^{iθ})^k",
+        "module": "Mathlib.Analysis.Complex.Exponential"
+      },
+      {
+        "theorem": "Real.sin_add",
+        "description": "sin(x + y) = sin x cos y + cos x sin y, the angle-addition formula behind the product-to-sum step",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.cos_add",
+        "description": "cos(x + y) = cos x cos y − sin x sin y, the angle-addition formula behind the conjugate product-to-sum step",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peeling the top term ∑_{k∈range(n+1)} f k = ∑_{k∈range n} f k + f n, the engine of the telescoping induction",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "geom_exp_partial_sum: the finite geometric sum of complex exponentials ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1) for e^{iθ} ≠ 1 — the partial-sum companion to Mathlib's roots-of-unity geometric series, absent from Mathlib for a general angle θ",
+      "two_sin_half_mul_cos / two_sin_half_mul_sin: the product-to-sum identities 2 sin(θ/2) cos(mθ) = sin((m+½)θ) − sin((m−½)θ) and 2 sin(θ/2) sin(mθ) = cos((m−½)θ) − cos((m+½)θ), the telescoping steps",
+      "lagrange_cos_sum: Lagrange's cosine identity ∑_{k=0}^{n} cos(kθ) = ½ + sin((n+½)θ)/(2 sin(θ/2)) — the real Dirichlet kernel, proved by telescoping without passing through complex numbers",
+      "lagrange_sin_sum: Lagrange's sine identity ∑_{k=0}^{n} sin(kθ) = (cos(θ/2) − cos((n+½)θ))/(2 sin(θ/2)) — the conjugate Dirichlet kernel"
+    ],
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 142,
+    "assumptions": "0 axioms, 0 sorries. Mathlib supplies the raw geometric series (geom_sum_eq), the exponential power law (Complex.exp_nat_mul), and the angle-addition formulas; the finite closed forms for ∑ e^{ikθ}, ∑ cos(kθ), ∑ sin(kθ) and the telescoping product-to-sum steps are supplied here. The real identities require sin(θ/2) ≠ 0 (θ not an integer multiple of 2π); the complex identity requires e^{iθ} ≠ 1.",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The identity $\\sum_{k=0}^{n} e^{ik\\theta} = \\frac{e^{i(n+1)\\theta}-1}{e^{i\\theta}-1}$ is the finite-geometric-series face of De Moivre's theorem: the partial sums of the equally-spaced phases $e^{ik\\theta}$ trace a regular polygonal path on the unit circle. Taking real and imaginary parts gives the two *Lagrange trigonometric identities*, named for Joseph-Louis Lagrange, who used them in his study of trigonometric series. The cosine form $\\tfrac12 + \\tfrac{\\sin((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}$ is exactly the **Dirichlet kernel** $D_n(\\theta)$ that governs the convergence of Fourier series; its conjugate is the sine form. These closed forms are the workhorses behind partial-sum estimates in classical harmonic analysis, the Dirichlet test for convergence, and the summation of trigonometric series.",
+    "problemStatement": "**Open Question**: Find closed forms for the finite partial sums $\\sum_{k=0}^{n} e^{ik\\theta}$, $\\sum_{k=0}^{n}\\cos(k\\theta)$, and $\\sum_{k=0}^{n}\\sin(k\\theta)$.\n\n**Answer**: Summing the geometric series with ratio $z=e^{i\\theta}\\ne 1$ gives $\\sum_{k=0}^{n} e^{ik\\theta} = \\dfrac{e^{i(n+1)\\theta}-1}{e^{i\\theta}-1}$. Its real and imaginary parts are Lagrange's identities: for $\\sin(\\theta/2)\\ne 0$,\n$$\\sum_{k=0}^{n}\\cos(k\\theta) = \\tfrac12 + \\dfrac{\\sin\\big((n+\\tfrac12)\\theta\\big)}{2\\sin(\\theta/2)},\\qquad \\sum_{k=0}^{n}\\sin(k\\theta) = \\dfrac{\\cos(\\theta/2)-\\cos\\big((n+\\tfrac12)\\theta\\big)}{2\\sin(\\theta/2)}.$$",
+    "text": "Closed forms for the finite partial sums of complex exponentials and of cosines and sines of arithmetic-progression angles: the complex geometric sum ∑ e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1) and its real/imaginary parts, the Lagrange trigonometric identities (the Dirichlet kernel and its conjugate).",
+    "proofStrategy": "Two independent routes are formalized.\n1. **Complex geometric sum**: recognise $e^{ik\\theta} = (e^{i\\theta})^k$ via `Complex.exp_nat_mul`, apply `geom_sum_eq` (valid since $e^{i\\theta}\\ne 1$), and re-express the top power $e^{i(n+1)\\theta}$.\n2. **Real telescoping**: rather than extracting real/imaginary parts (which needs $\\mathrm{Re}/\\mathrm{Im}$ of a quotient of complex numbers), the two real identities are proved *directly*. Multiplying a single term by $2\\sin(\\theta/2)$ and using the angle-addition formulas gives the product-to-sum steps $2\\sin(\\theta/2)\\cos(k\\theta)=\\sin((k+\\tfrac12)\\theta)-\\sin((k-\\tfrac12)\\theta)$ (and its sine analogue). Summed over $k$ these telescope: an induction on $n$ using `Finset.sum_range_succ` collapses the sum to the endpoints, yielding $2\\sin(\\theta/2)\\sum\\cos(k\\theta)=\\sin((n+\\tfrac12)\\theta)+\\sin(\\theta/2)$. Dividing by $2\\sin(\\theta/2)\\ne 0$ gives the stated identity.",
+    "keyInsights": [
+      "The telescoping route sidesteps complex real/imaginary-part bookkeeping entirely: the real identities follow from a single product-to-sum identity plus induction, so the only analytic inputs are the angle-addition formulas",
+      "$2\\sin(\\theta/2)$ is the natural integrating factor: the product-to-sum step $2\\sin(\\theta/2)\\cos(k\\theta)=\\sin((k+\\tfrac12)\\theta)-\\sin((k-\\tfrac12)\\theta)$ writes each summand as a difference of consecutive half-integer-shifted sines, which is exactly a telescope",
+      "The cosine identity is the **Dirichlet kernel** $D_n(\\theta)=\\tfrac12+\\tfrac{\\sin((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}$, the fundamental object controlling pointwise convergence of Fourier partial sums",
+      "The hypothesis $\\sin(\\theta/2)\\ne 0$ is essential and geometric: at $\\theta\\in 2\\pi\\mathbb{Z}$ every term is $1$ and the sum is $n+1$, while the closed form's denominator vanishes — the removable singularity of the Dirichlet kernel where $D_n(0)=n+\\tfrac12$",
+      "Mathlib records the geometric series and the *infinite* trig power series, but not these *finite partial-sum* closed forms for a general angle; supplying them fills a concrete gap on the road to a Mathlib Dirichlet kernel"
+    ],
+    "prerequisites": [
+      "Complex exponential and Euler's formula e^{iθ} = cos θ + i sin θ",
+      "Finite geometric series",
+      "Angle-addition (product-to-sum) trigonometric identities",
+      "Telescoping sums and induction over Finset.range"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: closed forms for ∑ e^{ikθ}, ∑ cos(kθ), ∑ sin(kθ); the Dirichlet kernel connection, what Mathlib does and does not record, and the six results proved",
+      "startLine": 1,
+      "endLine": 43,
+      "mathContext": "**Goal**: ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1), and its real/imaginary parts the Lagrange identities."
+    },
+    {
+      "id": "complex-geometric-sum",
+      "title": "Part I: Finite Geometric Sum of Complex Exponentials",
+      "summary": "geom_exp_partial_sum: ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1) for e^{iθ} ≠ 1, via exp(kθi) = (exp(θi))^k and geom_sum_eq",
+      "startLine": 45,
+      "endLine": 60,
+      "mathContext": "$\\sum_{k=0}^{n}(e^{i\\theta})^k = \\frac{(e^{i\\theta})^{n+1}-1}{e^{i\\theta}-1}$, with $(e^{i\\theta})^{n+1}=e^{i(n+1)\\theta}$."
+    },
+    {
+      "id": "product-to-sum",
+      "title": "Part II: Product-to-Sum Telescoping Steps",
+      "summary": "two_sin_half_mul_cos and two_sin_half_mul_sin: 2 sin(θ/2) cos(mθ) = sin((m+½)θ) − sin((m−½)θ) and 2 sin(θ/2) sin(mθ) = cos((m−½)θ) − cos((m+½)θ), from the angle-addition formulas",
+      "startLine": 62,
+      "endLine": 80,
+      "mathContext": "Writing each summand as a difference of half-integer-shifted sines/cosines makes the sum telescope."
+    },
+    {
+      "id": "telescoped-keys",
+      "title": "Part III: Telescoped (Denominator-Cleared) Identities",
+      "summary": "lagrange_cos_key and lagrange_sin_key: 2 sin(θ/2)·∑ cos(kθ) = sin((n+½)θ) + sin(θ/2) and 2 sin(θ/2)·∑ sin(kθ) = cos(θ/2) − cos((n+½)θ), by induction with Finset.sum_range_succ",
+      "startLine": 82,
+      "endLine": 115,
+      "mathContext": "The telescope collapses $\\sum_{k=0}^{n}$ to its endpoints; the induction step is exactly the product-to-sum identity."
+    },
+    {
+      "id": "lagrange-identities",
+      "title": "Part IV: The Lagrange Trigonometric Identities",
+      "summary": "lagrange_cos_sum and lagrange_sin_sum: the closed forms ∑ cos(kθ) = ½ + sin((n+½)θ)/(2 sin(θ/2)) and ∑ sin(kθ) = (cos(θ/2) − cos((n+½)θ))/(2 sin(θ/2)) for sin(θ/2) ≠ 0",
+      "startLine": 117,
+      "endLine": 142,
+      "mathContext": "Dividing the telescoped identities by $2\\sin(\\theta/2)\\ne 0$ yields the Dirichlet kernel and its conjugate."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization supplies the finite partial-sum closed forms that De Moivre's theorem produces: the complex geometric sum ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1), and its real and imaginary parts, the two Lagrange trigonometric identities. The real identities are proved directly by a product-to-sum telescoping induction, avoiding complex real/imaginary-part extraction. All six theorems are fully proved with zero sorries and zero axioms.",
+    "implications": "The cosine identity is the Dirichlet kernel D_n(θ), the object at the heart of Fourier-series convergence; its conjugate is the sine form. These closed forms underpin partial-sum estimates in harmonic analysis, the Dirichlet convergence test, and the evaluation of trigonometric series. Together with OQ-05 (the roots-of-unity vanishing sum, the θ = 2π/n special case where the full period cancels) they complete the De Moivre geometric-sum picture.",
+    "openQuestions": [
+      "Extract the Lagrange identities as the genuine real/imaginary parts of geom_exp_partial_sum, giving a second proof and a Complex.re/Complex.im bridge",
+      "Bound the Dirichlet kernel |D_n(θ)| ≤ 1/(2|sin(θ/2)|) and derive the classical L¹ growth ‖D_n‖₁ ∼ (4/π²) log n",
+      "The Fejér kernel as the Cesàro average of the Dirichlet kernels, and its nonnegativity"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-05",
+      "relationship": "OQ-05 sums the n-th roots of unity to zero — the θ = 2π/n, k = 0..n−1 special case where a full period of the exponential sum cancels; OQ-06 gives the closed form for the general partial sum and angle"
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "Base theorem: De Moivre's formula (e^{iθ})^k = e^{ikθ}, the identity that turns the exponential sum into a geometric series"
+    },
+    {
+      "id": "geometric-series",
+      "relationship": "The complex closed form is the geometric series ∑ z^k = (z^{n+1}−1)/(z−1) specialised to z = e^{iθ}"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.Complex.Exponential",
+      "Mathlib.Algebra.Field.GeomSum",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "DeMoivreOQ06",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ06.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Abraham De Moivre",
+      "title": "Original theorem for integer exponents",
+      "year": "1707",
+      "venue": "Philosophical Transactions"
+    },
+    {
+      "authors": "Joseph-Louis Lagrange",
+      "title": "Trigonometric identities for sums of cosines and sines (the Lagrange identities)",
+      "year": "1770",
+      "venue": "Classical analysis"
+    },
+    {
+      "authors": "Peter Gustav Lejeune Dirichlet",
+      "title": "Sur la convergence des séries trigonométriques (the Dirichlet kernel)",
+      "year": "1829",
+      "venue": "Journal für die reine und angewandte Mathematik"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-05",
+      "relationship": "sibling",
+      "description": "OQ-05 is the full-period special case (∑ over one period of e^{2πik/n} = 0); OQ-06 gives the general finite partial sum and its real/imaginary Lagrange forms."
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "extends",
+      "description": "Parent formalization; De Moivre's (e^{iθ})^k = e^{ikθ} is what makes ∑ e^{ikθ} a geometric series."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "foundational",
+      "description": "The complex closed form is the finite geometric series ∑_{k=0}^{n} z^k = (z^{n+1}−1)/(z−1) with ratio z = e^{iθ}."
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's e^{iθ} = cos θ + i sin θ is what links the complex geometric sum to the real cosine and sine partial sums."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **de-moivre-oq-06**: closed forms for the finite partial sums that De Moivre's theorem produces.

- **Complex geometric sum**: $\sum_{k=0}^{n} e^{ik\theta} = \dfrac{e^{i(n+1)\theta}-1}{e^{i\theta}-1}$ for $e^{i\theta}\ne 1$.
- **Lagrange cosine identity (Dirichlet kernel)**: for $\sin(\theta/2)\ne 0$, $\ \sum_{k=0}^{n}\cos(k\theta)=\tfrac12+\dfrac{\sin((n+\tfrac12)\theta)}{2\sin(\theta/2)}$.
- **Lagrange sine identity (conjugate kernel)**: $\ \sum_{k=0}^{n}\sin(k\theta)=\dfrac{\cos(\theta/2)-\cos((n+\tfrac12)\theta)}{2\sin(\theta/2)}$.

Mathlib records the raw geometric series and the *infinite* trig power series, but not these *finite partial-sum* closed forms for a general angle. The real identities are proved directly by a product-to-sum telescoping induction (integrating factor $2\sin(\theta/2)$), avoiding real/imaginary-part extraction.

## Status

- **6 theorems, 0 definitions, 0 sorries, 0 axioms** (`#print axioms` → only `propext`, `Classical.choice`, `Quot.sound`).
- Badge: `original`, status: `verified`.
- Built with Lean v4.26.0 / Mathlib 4.26.0: **0 errors, 0 warnings**.

## Notes

The initial WIP used `import Mathlib`; this PR narrows it to the four modules actually used and replaces two brittle `simp only` base cases with deterministic `rw` chains so the file compiles standalone and warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)