### PR TITLE
research(prob-method-second-moment-oq-01-oq-03): measure-theoretic Paley-Zygmund [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ProbMethodSecondMomentOQ01OQ03.lean
+++ b/proofs/Proofs/ProbMethodSecondMomentOQ01OQ03.lean
@@ -1,0 +1,134 @@
+/-
+Paley–Zygmund inequality in Mathlib's measure-theoretic framework
+(prob-method-second-moment-oq-01-oq-03).
+
+The parent entry `prob-method-second-moment` proves the Paley–Zygmund inequality
+in a *finite* (`Finset`) setting.  This file lifts it to Mathlib's general
+`MeasureTheory` / `ProbabilityTheory` framework: for a non-negative random
+variable `Z ∈ L²` on a probability space and `0 ≤ θ ≤ 1`,
+
+      (1 - θ)² · E[Z]²  ≤  P(Z > θ·E[Z]) · E[Z²].
+
+Dividing through by `E[Z²]` (when positive) recovers the classical ratio form
+`P(Z > θ E[Z]) ≥ (1-θ)² E[Z]²/E[Z²]`.
+
+Mathlib has Hölder's inequality for integrals (`integral_mul_le_Lp_mul_Lq_of_nonneg`)
+and the Chebyshev/Markov machinery, but **no** packaged measure-theoretic
+Paley–Zygmund inequality.  This file supplies it.
+
+## Proof
+
+Write `m = E[Z]` and `A = {Z > θ m}`.  The pointwise truncation bound
+
+      Z ω ≤ θ m + Z ω · 𝟙_A(ω)          (for every ω)
+
+integrates (using `μ` a probability measure) to `m ≤ θ m + E[Z · 𝟙_A]`, i.e.
+`(1-θ) m ≤ E[Z · 𝟙_A]`.  Cauchy–Schwarz (Hölder with `p = q = 2`) gives
+`E[Z · 𝟙_A] ≤ √(E[Z²]) · √(μ A)`.  Squaring the resulting non-negative
+inequality yields `(1-θ)² m² ≤ μ(A) · E[Z²]`.
+
+## Main result
+
+* `paley_zygmund_measure` — the measure-theoretic Paley–Zygmund inequality.
+-/
+import Mathlib.MeasureTheory.Integral.Bochner.Set
+import Mathlib.MeasureTheory.Function.LpSpace.Basic
+import Mathlib.Data.Real.ConjExponents
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace ProbMethodSecondMomentOQ01OQ03
+
+variable {Ω : Type*} {m0 : MeasurableSpace Ω} {μ : Measure Ω}
+
+/-- Helper: for `0 ≤ x`, squaring the real square root cancels: `(x ^ (1/2))² = x`. -/
+private lemma rpow_half_sq {x : ℝ} (hx : 0 ≤ x) : (x ^ (1/2 : ℝ)) ^ 2 = x := by
+  rw [← Real.rpow_natCast (x ^ (1/2 : ℝ)) 2, ← Real.rpow_mul hx]
+  norm_num
+
+/-- **Paley–Zygmund inequality (measure-theoretic form).**
+
+For a probability measure `μ`, a measurable non-negative random variable
+`Z ∈ L²(μ)`, and `0 ≤ θ ≤ 1`,
+`(1 - θ)² · E[Z]² ≤ P(Z > θ·E[Z]) · E[Z²]`. -/
+theorem paley_zygmund_measure
+    [IsProbabilityMeasure μ] {Z : Ω → ℝ}
+    (hZmeas : Measurable Z) (hZ : 0 ≤ᵐ[μ] Z) (hL2 : MemLp Z 2 μ)
+    {θ : ℝ} (hθ0 : 0 ≤ θ) (hθ1 : θ ≤ 1) :
+    (1 - θ) ^ 2 * (∫ ω, Z ω ∂μ) ^ 2
+      ≤ (μ {ω | θ * (∫ ω, Z ω ∂μ) < Z ω}).toReal * (∫ ω, (Z ω) ^ 2 ∂μ) := by
+  set m : ℝ := ∫ ω, Z ω ∂μ with hm_def
+  -- Basic facts.
+  have hm0 : 0 ≤ m := integral_nonneg_of_ae hZ
+  have hθm0 : 0 ≤ θ * m := mul_nonneg hθ0 hm0
+  have hZint : Integrable Z μ := hL2.integrable one_le_two
+  -- The threshold set and its indicator.
+  set A : Set Ω := {ω | θ * m < Z ω} with hA_def
+  have hA : MeasurableSet A := hZmeas measurableSet_Ioi
+  set g : Ω → ℝ := A.indicator (fun _ => (1 : ℝ)) with hg_def
+  have hg_nonneg : 0 ≤ᵐ[μ] g :=
+    Filter.Eventually.of_forall fun ω => Set.indicator_nonneg (fun _ _ => zero_le_one) ω
+  -- `Z · g = 𝟙_A · Z`, hence integrable.
+  have hZg_eq : (fun ω => Z ω * g ω) = A.indicator Z := by
+    funext ω
+    by_cases h : ω ∈ A
+    · simp [hg_def, Set.indicator_of_mem h]
+    · simp [hg_def, Set.indicator_of_notMem h]
+  have hZg_int : Integrable (fun ω => Z ω * g ω) μ := by
+    rw [hZg_eq]; exact hZint.indicator hA
+  -- Pointwise truncation bound: `Z ω ≤ θ m + Z ω · g ω`.
+  have hbound : ∀ ω, Z ω ≤ θ * m + Z ω * g ω := by
+    intro ω
+    by_cases h : θ * m < Z ω
+    · have hmem : ω ∈ A := h
+      simp only [hg_def, Set.indicator_of_mem hmem, mul_one]
+      linarith
+    · have hmem : ω ∉ A := h
+      simp only [hg_def, Set.indicator_of_notMem hmem, mul_zero, add_zero]
+      linarith
+  -- Integrate the bound.
+  have hconst_int : Integrable (fun _ : Ω => θ * m) μ := integrable_const _
+  have hrhs_int : Integrable (fun ω => θ * m + Z ω * g ω) μ := hconst_int.add hZg_int
+  have hint_le : m ≤ θ * m + ∫ ω, Z ω * g ω ∂μ := by
+    have h1 : m ≤ ∫ ω, (θ * m + Z ω * g ω) ∂μ :=
+      integral_mono_ae hZint hrhs_int (Filter.Eventually.of_forall hbound)
+    rwa [integral_add hconst_int hZg_int, integral_const, measureReal_def, measure_univ,
+      ENNReal.toReal_one, one_smul] at h1
+  have hstep1 : (1 - θ) * m ≤ ∫ ω, Z ω * g ω ∂μ := by linarith
+  -- Cauchy–Schwarz (Hölder, p = q = 2).
+  have hpq : (2 : ℝ).HolderConjugate 2 := Real.holderConjugate_iff.mpr ⟨one_lt_two, by norm_num⟩
+  have hL2' : MemLp Z (ENNReal.ofReal 2) μ := by rw [ENNReal.ofReal_ofNat]; exact hL2
+  have hgL2' : MemLp g (ENNReal.ofReal 2) μ := (memLp_const (1 : ℝ)).indicator hA
+  have hCS := integral_mul_le_Lp_mul_Lq_of_nonneg hpq hZ hg_nonneg hL2' hgL2'
+  -- Rewrite the rpow exponents `^ (2:ℝ)` back to `^ (2:ℕ)`.
+  have hexp : ∀ y : ℝ, y ^ (2 : ℝ) = y ^ 2 := by
+    intro y; rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, Real.rpow_natCast]
+  simp only [hexp] at hCS
+  -- `∫ g² = ∫ g = μ(A).toReal`.
+  have hg_sq : (fun ω => g ω ^ 2) = g := by
+    funext ω
+    by_cases h : ω ∈ A
+    · simp [hg_def, Set.indicator_of_mem h]
+    · simp [hg_def, Set.indicator_of_notMem h]
+  have hg_int_eq : ∫ ω, g ω ^ 2 ∂μ = (μ A).toReal := by
+    rw [hg_sq, hg_def, integral_indicator_const _ hA, smul_eq_mul, mul_one, measureReal_def]
+  rw [hg_int_eq] at hCS
+  -- Abbreviations for the two non-negative quantities.
+  set S : ℝ := ∫ ω, Z ω ^ 2 ∂μ with hS_def
+  set T : ℝ := (μ A).toReal with hT_def
+  have hS0 : 0 ≤ S := integral_nonneg fun ω => sq_nonneg _
+  have hT0 : 0 ≤ T := ENNReal.toReal_nonneg
+  -- Now `hCS : ∫ Z·g ≤ S ^ (1/2) * T ^ (1/2)`.
+  have hstep2 : (1 - θ) * m ≤ S ^ (1/2 : ℝ) * T ^ (1/2 : ℝ) := le_trans hstep1 hCS
+  have hlhs0 : 0 ≤ (1 - θ) * m := mul_nonneg (by linarith) hm0
+  -- Square both sides.
+  have hrhs : (S ^ (1/2 : ℝ) * T ^ (1/2 : ℝ)) ^ 2 = S * T := by
+    rw [mul_pow, rpow_half_sq hS0, rpow_half_sq hT0]
+  have hsq := pow_le_pow_left₀ hlhs0 hstep2 2
+  rw [hrhs] at hsq
+  -- `((1-θ) m)² = (1-θ)² m²` and conclude.
+  calc (1 - θ) ^ 2 * m ^ 2 = ((1 - θ) * m) ^ 2 := by rw [mul_pow]
+    _ ≤ S * T := hsq
+    _ = T * S := mul_comm S T

--- a/src/data/proofs/prob-method-second-moment-oq-01-oq-03/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01-oq-03/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "prob-method-second-moment-oq-01-oq-03",
+  "title": "Paley-Zygmund Inequality in Mathlib's Measure-Theoretic Framework",
+  "slug": "prob-method-second-moment-oq-01-oq-03",
+  "description": "Lifts the Paley-Zygmund inequality from the parent's finite (Finset) setting to Mathlib's general MeasureTheory/ProbabilityTheory framework: for a measurable non-negative random variable Z ∈ L²(μ) on a probability space and 0 ≤ θ ≤ 1, (1-θ)²·E[Z]² ≤ P(Z > θ·E[Z])·E[Z²]. Dividing by E[Z²] recovers the classical ratio form P(Z > θE[Z]) ≥ (1-θ)²E[Z]²/E[Z²].",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodSecondMomentOQ01OQ03.lean",
+    "tags": [
+      "probability",
+      "measure-theory",
+      "second-moment-method",
+      "paley-zygmund",
+      "holder-inequality"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 134,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "assumptions": "None beyond the stated hypotheses. 0 axioms, 0 sorries; the theorem depends only on Lean's standard foundational axioms (propext, Classical.choice, Quot.sound). Hypotheses: μ is a probability measure, Z is measurable, 0 ≤ Z a.e., Z ∈ L²(μ), and 0 ≤ θ ≤ 1. The measurability hypothesis (Measurable Z) is standard for a random variable and is what makes the threshold event {Z > θ·E[Z]} a measurable set; it is a mild strengthening of the MemLp-only sketch in the parent's open question.",
+    "originalContributions": [
+      "paley_zygmund_measure: the Paley-Zygmund inequality over a general probability space (∫/measure framework), not the finite Finset setting — (1-θ)²·(∫Z)² ≤ μ{Z > θ·∫Z}.toReal · ∫Z²",
+      "Answers the parent oq-01's explicit open question: 'Can this be generalized to the measure-theoretic MeasureTheory.Lp setting?'",
+      "rpow_half_sq: helper cancelling (x^(1/2))² = x for x ≥ 0, bridging Hölder's rpow output to the squared bound"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.integral_mul_le_Lp_mul_Lq_of_nonneg",
+        "description": "Hölder's inequality for integrals; specialized to p = q = 2 it is the Cauchy-Schwarz step ∫ Z·𝟙_A ≤ (∫Z²)^(1/2)·(∫𝟙_A²)^(1/2)",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.integral_mono_ae",
+        "description": "Monotonicity of the Bochner integral, used to integrate the pointwise truncation bound Z ≤ θ·E[Z] + Z·𝟙_A",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.integral_indicator_const",
+        "description": "∫ 𝟙_A·c = μ(A).toReal · c, evaluating the second-moment weight ∫ 𝟙_A² = μ(A).toReal",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Set"
+      },
+      {
+        "theorem": "MeasureTheory.MemLp.integrable",
+        "description": "L² membership on a finite measure implies integrability, giving Integrable Z",
+        "module": "Mathlib.MeasureTheory.Function.L1Space.Integrable"
+      },
+      {
+        "theorem": "Real.holderConjugate_iff",
+        "description": "Characterizes Hölder-conjugate exponents; used to certify that 2 and 2 are conjugate",
+        "module": "Mathlib.Data.Real.ConjExponents"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Paley-Zygmund inequality was proved by Raymond Paley and Antoni Zygmund in 1932 during their study of lacunary trigonometric series. It gives a quantitative lower bound on the probability that a non-negative random variable exceeds a fraction θ of its mean, strengthening the qualitative second moment method. In its native form it is a measure-theoretic statement about random variables on a probability space. The parent gallery entry `prob-method-second-moment-oq-01` formalizes it in a finite, discrete (Finset over ℚ) setting to keep the proof elementary and explicitly leaves as an open question whether it generalizes to Mathlib's measure-theoretic Lᵖ framework. This entry answers that question affirmatively.",
+    "problemStatement": "For a probability measure μ, a measurable non-negative random variable Z with Z ∈ L²(μ), and a threshold 0 ≤ θ ≤ 1, prove (1-θ)²·(∫ Z dμ)² ≤ μ{ω : θ·∫Z dμ < Z ω}.toReal · ∫ Z² dμ. Dividing by ∫Z² (when positive) yields the classical ratio form P(Z > θE[Z]) ≥ (1-θ)²E[Z]²/E[Z²].",
+    "text": "Establishes the measure-theoretic Paley-Zygmund inequality directly over Mathlib's Bochner integral and measure framework, complementing the parent's finite-sum formalization. The proof is the classical one: a pointwise truncation bound, integration against a probability measure, and Cauchy-Schwarz (Hölder with p = q = 2).",
+    "proofStrategy": "Let m = E[Z] and A = {Z > θm}. The pointwise bound Z ω ≤ θm + Z ω·𝟙_A(ω) holds for every ω (case split on whether Z ω exceeds θm, using θm ≥ 0). Integrating against the probability measure μ (so ∫ θm = θm) gives m ≤ θm + E[Z·𝟙_A], i.e. (1-θ)m ≤ E[Z·𝟙_A]. Cauchy-Schwarz (integral Hölder with p = q = 2) bounds E[Z·𝟙_A] ≤ (∫Z²)^(1/2)·(∫𝟙_A²)^(1/2) = √(E[Z²])·√(μ A). Since (1-θ)m ≥ 0, squaring the inequality yields (1-θ)²m² ≤ μ(A)·E[Z²].",
+    "keyInsights": [
+      "**Truncation bound needs no measurability or a.e. reasoning**: The inequality Z ω ≤ θ·E[Z] + Z ω·𝟙_A(ω) holds for every single ω by a two-case argument (Z ω > θm gives RHS = θm + Z ω ≥ Z ω; Z ω ≤ θm gives RHS = θm ≥ Z ω). This everywhere-true bound is what lets the whole proof avoid delicate almost-everywhere bookkeeping until the final integration.",
+      "**Probability measure collapses the constant integral**: ∫ θ·E[Z] dμ = μ(univ).toReal · θ·E[Z] = θ·E[Z] precisely because μ is a probability measure. This is the single place the total-mass-one hypothesis is used, and it is exactly what turns the additive split into (1-θ)·E[Z] ≤ E[Z·𝟙_A].",
+      "**Cauchy-Schwarz = Hölder at p = q = 2, with the indicator as second factor**: Taking the second function to be the indicator 𝟙_A makes ∫𝟙_A² = ∫𝟙_A = μ(A).toReal, so Hölder's inequality directly relates the first moment on A to the global second moment and the measure of A. Mathlib's `integral_mul_le_Lp_mul_Lq_of_nonneg` supplies this once the exponents are certified conjugate.",
+      "**Measurability of Z, not just L², is the honest hypothesis**: The threshold event {Z > θ·E[Z]} must be a genuine measurable set for its measure to appear on the right. MemLp only gives AE-strong-measurability, so this formalization takes the standard `Measurable Z` hypothesis — a mild and customary strengthening of the parent's MemLp-only sketch that keeps the statement clean and avoids null-measurable-set technicalities.",
+      "**Measure-theoretic vs finite formalization**: Unlike the parent (Finset sums over ℚ), this version quantifies over an arbitrary probability space and uses the Bochner integral, so it applies to continuous and mixed distributions. It is the form actually invoked in probability and analysis, and it plugs directly into Mathlib's ProbabilityTheory API."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "File header stating the measure-theoretic Paley-Zygmund inequality and its proof outline. Notes that the parent formalizes the finite case and this file lifts it to the MeasureTheory framework. Uses narrow Mathlib imports (Bochner integral, Lp spaces, conjugate exponents, real rpow) rather than the full `import Mathlib`."
+    },
+    {
+      "id": "rpow-half-sq",
+      "title": "Square-Root Cancellation Helper",
+      "startLine": 46,
+      "endLine": 49,
+      "summary": "Private lemma rpow_half_sq: for 0 ≤ x, (x^(1/2))² = x. Bridges the rpow output of Hölder's inequality to the squared first-moment bound.",
+      "mathContext": "$(x^{1/2})^2 = x$ for $x \\ge 0$, via $x^{(1/2)\\cdot 2} = x^1$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Measure-Theoretic Paley-Zygmund Inequality",
+      "startLine": 51,
+      "endLine": 134,
+      "summary": "paley_zygmund_measure: the full proof — everywhere-true truncation bound Z ≤ θE[Z] + Z·𝟙_A, integration using the probability-measure normalization to get (1-θ)E[Z] ≤ E[Z·𝟙_A], Cauchy-Schwarz (Hölder p=q=2) to bound E[Z·𝟙_A] ≤ √(E[Z²])·√(μ A), and squaring the non-negative inequality.",
+      "mathContext": "$(1-\\theta)^2(\\int Z)^2 \\le \\mu\\{Z > \\theta\\int Z\\}\\cdot\\int Z^2$."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Paley, R.E.A.C.",
+        "Zygmund, A."
+      ],
+      "title": "On some series of functions",
+      "year": "1932",
+      "venue": "Proceedings of the Cambridge Philosophical Society 26, pp. 337-357",
+      "note": "Original Paley-Zygmund inequality in the context of lacunary trigonometric series"
+    },
+    {
+      "authors": [
+        "Alon, N.",
+        "Spencer, J.H."
+      ],
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "Second moment method and Paley-Zygmund inequality; measure-theoretic and combinatorial forms"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "prob-method-second-moment-oq-01",
+      "relationship": "extends",
+      "description": "Parent quantitative Paley-Zygmund over finite sets; this entry answers its stated open question by lifting the inequality to Mathlib's measure-theoretic Lᵖ framework."
+    },
+    {
+      "targetId": "prob-method-second-moment",
+      "relationship": "foundational",
+      "description": "Root second-moment-method entry; the θ=0 case of this inequality gives the qualitative principle P(Z>0) ≥ E[Z]²/E[Z²]."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "Cauchy-Schwarz (Hölder with p=q=2) is the analytic core, applied here to Z and the indicator 𝟙_A over the Bochner integral."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, 0-axiom Lean 4 formalization of the Paley-Zygmund inequality in Mathlib's measure-theoretic framework, over an arbitrary probability space and the Bochner integral. The proof is the classical truncation-plus-Cauchy-Schwarz argument and depends only on Lean's standard foundational axioms.",
+    "implications": "Provides the general-probability form of Paley-Zygmund that the parent finite formalization explicitly left open, applicable to continuous and mixed distributions and directly compatible with Mathlib's ProbabilityTheory API. This is the form used in analysis and probability (anticoncentration, random series, threshold phenomena).",
+    "openQuestions": [
+      "Can the equality/near-equality case be characterized in the measure-theoretic setting?",
+      "Does the argument extend to Lᵖ for the reversed-Hölder generalizations of Paley-Zygmund?",
+      "Is this a suitable candidate for upstreaming to Mathlib's ProbabilityTheory library?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the **Paley–Zygmund inequality in Mathlib's measure-theoretic framework**, answering the parent entry `prob-method-second-moment-oq-01`'s explicit open question: *"Can this be generalized to the measure-theoretic MeasureTheory.Lp setting?"*

The parent proves Paley–Zygmund over finite `Finset` sums (ℚ-valued). This entry lifts it to an **arbitrary probability space** with the Bochner integral:

```
paley_zygmund_measure :
  (1 - θ)^2 * (∫ ω, Z ω ∂μ)^2
    ≤ (μ {ω | θ * (∫ ω, Z ω ∂μ) < Z ω}).toReal * (∫ ω, (Z ω)^2 ∂μ)
```

for a probability measure `μ`, measurable non-negative `Z ∈ L²(μ)`, and `0 ≤ θ ≤ 1`. Dividing by `E[Z²]` recovers the classical ratio form `P(Z > θE[Z]) ≥ (1-θ)²E[Z]²/E[Z²]`.

## Proof

1. **Truncation bound** (everywhere-true, no a.e.): `Z ω ≤ θ·E[Z] + Z ω·𝟙_A(ω)` where `A = {Z > θ·E[Z]}`.
2. **Integrate** using the probability normalization `∫ const = const`: `(1-θ)·E[Z] ≤ E[Z·𝟙_A]`.
3. **Cauchy–Schwarz** (integral Hölder at `p = q = 2`, indicator as second factor so `∫𝟙_A² = μ(A).toReal`): `E[Z·𝟙_A] ≤ √(E[Z²])·√(μ A)`.
4. **Square** the non-negative inequality.

## Verification

- **134 lines, 2 theorems (1 helper), 0 defs, 0 sorries, 0 axioms**
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only → genuinely 0-axiom / verified
- Narrow Mathlib imports (Bochner integral, Lp, conjugate exponents, rpow) — avoids full `import Mathlib`
- Compiled against Mathlib 4.26.0

## Honesty note

Adds an explicit `Measurable Z` hypothesis beyond the parent's `MemLp`-only sketch. This is standard for a random variable and is what makes the threshold event `{Z > θE[Z]}` a genuine measurable set (MemLp gives only AE-strong-measurability). Disclosed in `assumptions` and `keyInsights`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)