### PR TITLE
Audit fix: de-moivre-oq-06 theoremCount 6→7

### DIFF
--- a/src/data/proofs/de-moivre-oq-06/meta.json
+++ b/src/data/proofs/de-moivre-oq-06/meta.json
@@ -56,7 +56,7 @@
     "axiomCount": 0,
     "lineCount": 142,
     "assumptions": "0 axioms, 0 sorries. Mathlib supplies the raw geometric series (geom_sum_eq), the exponential power law (Complex.exp_nat_mul), and the angle-addition formulas; the finite closed forms for ∑ e^{ikθ}, ∑ cos(kθ), ∑ sin(kθ) and the telescoping product-to-sum steps are supplied here. The real identities require sin(θ/2) ≠ 0 (θ not an integer multiple of 2π); the complex identity requires e^{iθ} ≠ 1.",
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0
   },
   "overview": {
@@ -82,7 +82,7 @@
     {
       "id": "preamble",
       "title": "Preamble and Problem Statement",
-      "summary": "Module docstring: closed forms for ∑ e^{ikθ}, ∑ cos(kθ), ∑ sin(kθ); the Dirichlet kernel connection, what Mathlib does and does not record, and the six results proved",
+      "summary": "Module docstring: closed forms for ∑ e^{ikθ}, ∑ cos(kθ), ∑ sin(kθ); the Dirichlet kernel connection, what Mathlib does and does not record, and the seven results proved",
       "startLine": 1,
       "endLine": 43,
       "mathContext": "**Goal**: ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1), and its real/imaginary parts the Lagrange identities."
@@ -121,7 +121,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization supplies the finite partial-sum closed forms that De Moivre's theorem produces: the complex geometric sum ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1), and its real and imaginary parts, the two Lagrange trigonometric identities. The real identities are proved directly by a product-to-sum telescoping induction, avoiding complex real/imaginary-part extraction. All six theorems are fully proved with zero sorries and zero axioms.",
+    "summary": "This formalization supplies the finite partial-sum closed forms that De Moivre's theorem produces: the complex geometric sum ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1), and its real and imaginary parts, the two Lagrange trigonometric identities. The real identities are proved directly by a product-to-sum telescoping induction, avoiding complex real/imaginary-part extraction. All seven theorems are fully proved with zero sorries and zero axioms.",
     "implications": "The cosine identity is the Dirichlet kernel D_n(θ), the object at the heart of Fourier-series convergence; its conjugate is the sine form. These closed forms underpin partial-sum estimates in harmonic analysis, the Dirichlet convergence test, and the evaluation of trigonometric series. Together with OQ-05 (the roots-of-unity vanishing sum, the θ = 2π/n special case where the full period cancels) they complete the De Moivre geometric-sum picture.",
     "openQuestions": [
       "Extract the Lagrange identities as the genuine real/imaginary parts of geom_exp_partial_sum, giving a second proof and a Complex.re/Complex.im bridge",
@@ -156,7 +156,7 @@
     "namespace": "DeMoivreOQ06",
     "lineCount": 142,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/DeMoivreOQ06.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `de-moivre-oq-06`
**Severity**: LOW (count mismatch — not a status/verification overclaim)

## Evidence

**meta.json claimed**: `theoremCount: 6` (in both `meta` and `leanFile` blocks); narrative said "the six results proved" / "All six theorems are fully proved".

**Lean source (`proofs/Proofs/DeMoivreOQ06.lean`) shows 7 theorems**:
1. `geom_exp_partial_sum`
2. `two_sin_half_mul_cos`
3. `two_sin_half_mul_sin`
4. `lagrange_cos_key`
5. `lagrange_sin_key`
6. `lagrange_cos_sum`
7. `lagrange_sin_sum`

## Fix

- `theoremCount` 6 → 7 in both the `meta` and `leanFile` blocks
- Two narrative "six" → "seven" mentions (preamble section summary + conclusion)

## Other checks (all PASS)

- sorries: 0 claimed / 0 in source ✅
- axiomCount: 0 claimed / 0 in source ✅
- True stubs: 0 ✅
- lineCount: 142 claimed / 142 actual ✅
- status `verified` / badge `original`: defensible — headline Lagrange identities proved directly by telescoping induction; Mathlib dependencies (`geom_sum_eq`, `Complex.exp_nat_mul`, angle-addition) honestly credited.

---
Discovered during gallery integrity audit.