### PR TITLE
Enrich Erdős #357: add extended-by crossRef to erdos-357-oq-04

### DIFF
--- a/src/data/proofs/erdos-357/meta.json
+++ b/src/data/proofs/erdos-357/meta.json
@@ -154,6 +154,11 @@
       "targetId": "erdos-867",
       "relationship": "related",
       "description": "Problem #867 on subsequences with distinct sums; both study extremal sequence properties with distinctness conditions."
+    },
+    {
+      "targetId": "erdos-357-oq-04",
+      "relationship": "extended-by",
+      "description": "Isolates and generalizes this entry's conjecture_equiv (the little-o ⇔ ratio-limit equivalence, proved here only for the specific counting function f) to an arbitrary sequence u : ℕ → ℝ, adds an ε–N characterization of sublinear growth, and applies the resulting trichotomy to the OPEN infinite-set density-zero conjecture — which this entry states only in ratio-limit form."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment: bidirectional crossRef gap

The child entry `erdos-357-oq-04` (the generalized little-o ⇔ ratio-limit equivalence) references its parent `erdos-357`, but the parent had **no link back**, leaving a one-directional navigation gap.

This adds an `extended-by` crossReference from `erdos-357` → `erdos-357-oq-04` so readers on the base problem can discover the generalization (arbitrary-sequence equivalence, ε–N form, and density-zero application).

- crossReferences 3 → 4 (well under the 20 cap)
- meta.json 15.6 KB (well under the 60 KB cap)
- Target `erdos-357-oq-04` verified to exist on origin/main
- No content deleted; JSON validates

🤖 Enrichment pass by enricher-2