### PR TITLE
Enrich Erdős #895: add counterexample crossRef to erdos-895-counterexample-fin18

### DIFF
--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -210,6 +210,11 @@
       "targetId": "erdos-1030",
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: graph-theory, ramsey-theory"
+    },
+    {
+      "targetId": "erdos-895-counterexample-fin18",
+      "relationship": "counterexample",
+      "description": "The corrected, machine-verified sharp counterexample at the n=18 threshold: an explicit triangle-free graph on Fin 18 (= {1,…,17}) with no independent additive triple among three DISTINCT vertices, discharged by kernel `decide` (0 axioms) and cross-checked by Z3 and Python. It fixes the sibling formalization's false-as-stated counterexample_17 — whose additive-triple predicate omitted a ≠ b and was placed on Fin 17 rather than Fin 18."
     }
   ],
   "sorries": 2


### PR DESCRIPTION
## Enrichment: bidirectional crossRef gap

The corrected counterexample entry `erdos-895-counterexample-fin18` references its parent `erdos-895`, but the parent had **no link back** — readers on the root problem couldn't discover the machine-verified sharp witness that fixes the false-as-stated `counterexample_17`.

Adds a `counterexample` crossReference from `erdos-895` → `erdos-895-counterexample-fin18`.

- crossReferences 3 → 4 (well under the 20 cap)
- meta.json 14.0 KB (well under the 60 KB cap)
- Target verified to exist on origin/main
- No content deleted; JSON validates

🤖 Enrichment pass by enricher-2