### PR TITLE
Enrich Fibonacci linear-sums cluster: reciprocal crossRefs + fix unrendered relation fields

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-05/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-05/meta.json
@@ -126,6 +126,11 @@
       "targetId": "fibonacci-identities-oq-04",
       "relationship": "relatedTo",
       "description": "The oq-04 entry formalizes Cassini's identity over Int.fib as a corollary of Vajda's identity; here Cassini is reproved directly over Nat.fib and used as the engine of a summation identity rather than as a product identity in its own right."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-06",
+      "relationship": "relatedTo",
+      "description": "The oq-06 entry handles the strictly simpler linear sums ∑ Fₖ and ∑ k·Fₖ, which telescope or reduce to a single linear combination of the induction hypothesis with no parity split — a useful contrast to this entry's bilinear product sum ∑ FₖFₖ₊₁, whose closed form is parity-governed and requires Cassini's identity rather than mere telescoping."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/fibonacci-identities/meta.json
+++ b/src/data/proofs/fibonacci-identities/meta.json
@@ -142,6 +142,11 @@
       "proofId": "combinations-formula-oq-08-oq-01",
       "relationship": "Source of the recurrence",
       "description": "combinations-formula-oq-08-oq-01 derives the Fibonacci recurrence Fₙ₊₂ = Fₙ₊₁ + Fₙ itself from Pascal's rule on the shallow-diagonal binomial sums. That recurrence is the single fact all three summation identities here reduce to, so this entry can be read as the summation-level consequences of the recurrence that entry establishes combinatorially."
+    },
+    {
+      "proofId": "fibonacci-identities-oq-06",
+      "relationship": "Linear-sum descendant",
+      "description": "fibonacci-identities-oq-06 supplies the two un-filtered linear summation identities this entry left open: the full partial sum ∑Fᵢ = Fₙ₊₂ − 1 and the index-weighted first moment ∑ i·Fᵢ = n·Fₙ₊₂ − Fₙ₊₃ + 2 — directly answering the '∑ i·Fᵢ' weighted-sum open question posed below. Together they are the degree-zero and degree-one companions to this entry's degree-two sum of squares ∑Fᵢ² = Fₙ·Fₙ₊₁."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/lucas-sum-oq-01/meta.json
+++ b/src/data/proofs/lucas-sum-oq-01/meta.json
@@ -79,11 +79,18 @@
   "crossReferences": [
     {
       "proofId": "factorial-telescoping-sum-oq-01",
-      "relation": "Shares the ℕ subtraction-free telescoping technique (prove (∑)+c = boundary first)."
+      "relationship": "Shared technique",
+      "description": "Shares the ℕ subtraction-free telescoping technique (prove (∑)+c = boundary first)."
     },
     {
       "proofId": "fibonacci-identities",
-      "relation": "Fibonacci analogue ∑_{k=1}^{n} F_k = F_{n+2} − 1; the bridge L_{n+1} = F_n + F_{n+2} connects the two."
+      "relationship": "Fibonacci analogue",
+      "description": "Fibonacci analogue ∑_{k=1}^{n} F_k = F_{n+2} − 1; the bridge L_{n+1} = F_n + F_{n+2} connects the two."
+    },
+    {
+      "proofId": "fibonacci-identities-oq-06",
+      "relationship": "Fibonacci analogue",
+      "description": "fibonacci-identities-oq-06 proves the precise Fibonacci counterpart of this entry's Lucas partial sum: ∑_{i≤n} F_i = F_{n+2} − 1, telescoping exactly as ∑_{k=1}^{n} L_k = L_{n+2} − 3 does here and differing only in the constant (1 vs 3) fixed by the initial conditions F₀=0, F₁=1 rather than L₀=2, L₁=1. Both use the same subtraction-free-in-ℕ + omega recipe; oq-06 additionally supplies the index-weighted first moment ∑ i·F_i."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Closes the **bidirectional crossReference gap** around `fibonacci-identities-oq-06` (the linear partial-sum + first-moment entry) and fixes a **rendering defect** in `lucas-sum-oq-01`.

`fibonacci-identities-oq-06` links to 3 siblings (parent + oq-05 + lucas-sum-oq-01), but none linked back. This PR adds the reciprocal back-links so the cluster navigates both ways.

## Changes

- **`fibonacci-identities` (parent)**: add back-link to `oq-06`. The parent's *own* `openQuestions` asks whether "the weighted sum ∑ i·Fᵢ" can be added — oq-06 answers exactly that, so the link is doubly warranted.
- **`fibonacci-identities-oq-05`**: add back-link to `oq-06` (linear sums vs this entry's parity-governed bilinear product sum).
- **`lucas-sum-oq-01`**: add back-link to `oq-06` (its `fib_sum` is the direct Fibonacci analogue of the Lucas partial sum), **and fix a defect** — its 2 existing crossRefs used an unrecognized `relation` field. The renderer (`ProofOverview.tsx:376`) reads `ref.description ?? ref.relationship ?? ''`, so `relation` was rendering as **empty** descriptive text. Converted to `relationship` + `description`.

## Verification

- All 3 meta.json files validate as JSON; enrichment prebuild parsed all 2512 entries clean.
- All files well under size caps (≤15 KB vs 60 KB cap) and crossRef caps (≤4 items vs 20 cap).
- All crossRef targets confirmed to exist (no dangling links / 404s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)