### PR TITLE
research(schroeder-bernstein-oq-03): fully computable easy-case Myhill [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -52,6 +52,11 @@ computable via Partrec.rfind. The orbit type is determined by bounded search.
 - fwdOrbit_eq_iterate: proved (forward orbit = iteration of g∘f; forward direction is computable)
 - isGFree_iff_not_mem_range: proved — pins down WHY the naive orbit classification is
   not computable: `isGFree` is Π₁ (complement of the c.e. set `range g`), hence undecidable
+- decidableIsGFree: proved — the Π₁ obstruction becomes decidable once `range g` is decidable
+- totalInverse_{mem,right,left,computable}: proved — a surjective computable injection has a
+  total, computable two-sided inverse (partialInverse becomes everywhere-defined)
+- computable_bijection_isComputablePerm / oneOneEquiv_of_computable_bijection: proved — the
+  fully computable easy case (Myhill when the reductions are already bijections)
 - myhill_isomorphism: hard direction has sorry (open: stage-wise back-and-forth construction)
 
 ## References
@@ -195,6 +200,84 @@ def isGFree (g : ℕ → ℕ) (n : ℕ) : Prop := ∀ k, g k ≠ n
 theorem isGFree_iff_not_mem_range (g : ℕ → ℕ) (n : ℕ) :
     isGFree g n ↔ n ∉ Set.range g := by
   simp only [isGFree, Set.mem_range, not_exists, ne_eq]
+
+/-!
+## Section 4b: Isolating the Π₁ obstruction — the fully computable case
+
+The insight `isGFree_iff_not_mem_range` shows the *only* obstruction to reading a
+computable bijection off the classical Schröder–Bernstein construction is that
+`isGFree g` (equivalently `· ∉ Set.range g`) is `Π₁`. Here we make that precise
+in two ways:
+
+* `decidableIsGFree` — as soon as `Set.range g` is *decidable*, the obstruction
+  disappears and `isGFree g` is a decidable predicate.
+* `computable_bijection_isComputablePerm` — the fully computable special case:
+  a computable **bijection** of ℕ is automatically a computable permutation, i.e.
+  its inverse is computable too. (This is Myhill's theorem in the degenerate case
+  where the two one-one reductions are already bijections, so no back-and-forth is
+  needed.) The inverse is obtained from the partial-recursive `partialInverse`,
+  which becomes total because `g` is surjective.
+-/
+
+/-- If `Set.range g` is decidable then the `Π₁` obstruction predicate `isGFree g`
+    is itself decidable — the range-decidability hypothesis is exactly what the
+    general (merely-computable) case lacks. -/
+def decidableIsGFree (g : ℕ → ℕ) [DecidablePred (· ∈ Set.range g)] :
+    DecidablePred (isGFree g) :=
+  fun n => decidable_of_iff _ (isGFree_iff_not_mem_range g n).symm
+
+/-- Under a surjective `g`, the partial inverse (Section 3) is defined everywhere,
+    so it yields a genuine total function `ℕ → ℕ`. -/
+def totalInverse (g : ℕ → ℕ) (hg : Surjective g) : ℕ → ℕ :=
+  fun m => (partialInverse g m).get (partialInverse_dom (hg m))
+
+/-- The total inverse is always a valid `partialInverse` value. -/
+theorem totalInverse_mem {g : ℕ → ℕ} (hg : Surjective g) (m : ℕ) :
+    totalInverse g hg m ∈ partialInverse g m :=
+  Part.get_mem _
+
+/-- `totalInverse` is a right inverse of `g` (needs only surjectivity). -/
+theorem totalInverse_right {g : ℕ → ℕ} (hg : Surjective g) (m : ℕ) :
+    g (totalInverse g hg m) = m := by
+  have h := Nat.rfind_spec (totalInverse_mem hg m)
+  simpa using h
+
+/-- `totalInverse` is a left inverse of `g` (needs injectivity too). -/
+theorem totalInverse_left {g : ℕ → ℕ} (hg_inj : Injective g) (hg : Surjective g)
+    (n : ℕ) : totalInverse g hg (g n) = n :=
+  hg_inj (totalInverse_right hg (g n))
+
+/-- When `g` is a computable injection **and** surjective, its total inverse is
+    computable: `partialInverse` is partial recursive and here everywhere defined,
+    so it coincides with the total function `totalInverse`. -/
+theorem totalInverse_computable {g : ℕ → ℕ} (hgc : Computable g) (hg : Surjective g) :
+    Computable (totalInverse g hg) :=
+  (partialInverse_partrec hgc).of_eq (fun _ => (Part.some_get _).symm)
+
+/-- **Computable easy-case Schröder–Bernstein / Myhill.** A computable *bijection*
+    of ℕ is a computable permutation: both it and its inverse are computable. This
+    is the special case where the two one-one reductions are already bijections, so
+    the back-and-forth priority construction is unnecessary and the `Π₁` `isGFree`
+    obstruction never arises. -/
+theorem computable_bijection_isComputablePerm {g : ℕ → ℕ}
+    (hgc : Computable g) (hg : Bijective g) :
+    (Equiv.ofBijective g hg).Computable := by
+  refine ⟨hgc, ?_⟩
+  have hsymm : ⇑(Equiv.ofBijective g hg).symm = totalInverse g hg.surjective := by
+    funext m
+    apply hg.injective
+    rw [totalInverse_right hg.surjective]
+    exact (Equiv.ofBijective g hg).apply_symm_apply m
+  rw [hsymm]
+  exact totalInverse_computable hgc hg.surjective
+
+/-- Consequently, a computable bijection `g` with `p n ↔ q (g n)` computably
+    witnesses `OneOneEquiv p q` — the fully computable instance of Myhill's
+    theorem, discharged without the open back-and-forth construction. -/
+theorem oneOneEquiv_of_computable_bijection {p q : ℕ → Prop} {g : ℕ → ℕ}
+    (hgc : Computable g) (hg : Bijective g) (hpq : ∀ n, p n ↔ q (g n)) :
+    OneOneEquiv p q :=
+  myhill_easy (Equiv.ofBijective g hg) (computable_bijection_isComputablePerm hgc hg) hpq
 
 /-!
 ## Section 5: The Myhill Isomorphism Theorem

--- a/src/data/research/problems/schroeder-bernstein-oq-03.json
+++ b/src/data/research/problems/schroeder-bernstein-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "schroeder-bernstein-oq-03",
   "title": "Myhill Isomorphism Theorem (Computable Schroeder-Bernstein)",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -39,11 +39,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: hard direction (OneOneEquiv → computable permutation) still OPEN. Confirmed Mathlib lacks Myhill's isomorphism theorem (only MyhillNerode, unrelated). Added 3 proved lemmas decomposing toward the construction and identified the core obstruction: isGFree (= n ∉ range g) is Π₁/undecidable, so the file's orbit-classification sketch is NOT computable; Myhill genuinely requires the stage-wise bounded back-and-forth.",
+    "progressSummary": "PROGRESS (researcher-6, VERIFIED 0-axiom via direct-lean-compile; Docker down host-wide): Landed the flagged TRACTABLE PARTIAL WIN — the fully computable easy case. Added to SchroederBernsteinOQ03.lean: (1) decidableIsGFree — the Π₁ obstruction isGFree g becomes DECIDABLE once Set.range g is decidable (via isGFree_iff_not_mem_range), making explicit that range-decidability is exactly what the general merely-computable case lacks; (2) totalInverse + totalInverse_{mem,right,left,computable} — a surjective computable injection's partialInverse is everywhere-defined, giving a total COMPUTABLE two-sided inverse (Part.some_get + Partrec.of_eq); (3) computable_bijection_isComputablePerm — a computable BIJECTION of ℕ is a computable permutation (Equiv.ofBijective g hg).Computable, both g and g⁻¹ computable; (4) oneOneEquiv_of_computable_bijection — Myhill's easy case discharged with no back-and-forth. All 6 new decls #print axioms = only foundational (no sorryAx). The HARD direction (myhill_isomorphism, arbitrary computable injections → computable permutation) remains OPEN: still needs the stage-wise bounded back-and-forth/priority construction; the isGFree Π₁ obstruction blocks the naive orbit classification.",
     "builtItems": [
       "partialInverse_unique in Proofs/SchroederBernsteinOQ03.lean (single-valued partial inverse)",
       "fwdOrbit_eq_iterate in Proofs/SchroederBernsteinOQ03.lean (orbit = Function.iterate of g∘f)",
-      "isGFree_iff_not_mem_range in Proofs/SchroederBernsteinOQ03.lean (Π₁ obstruction lemma)"
+      "isGFree_iff_not_mem_range in Proofs/SchroederBernsteinOQ03.lean (Π₁ obstruction lemma)",
+      "decidableIsGFree in Proofs/SchroederBernsteinOQ03.lean — DecidablePred (isGFree g) given DecidablePred (·∈range g); isolates the Π₁ obstruction (VERIFIED, 0-axiom)",
+      "totalInverse + totalInverse_{mem,right,left} — total two-sided inverse of a surjective (injective) g from the everywhere-defined partialInverse (VERIFIED, 0-axiom)",
+      "totalInverse_computable — Computable (totalInverse g hg) for computable surjective g, via Partrec.of_eq + Part.some_get (VERIFIED, 0-axiom)",
+      "computable_bijection_isComputablePerm — a computable bijection of ℕ is a computable permutation (Equiv.ofBijective g hg).Computable (VERIFIED, 0-axiom)",
+      "oneOneEquiv_of_computable_bijection — fully computable easy-case Myhill: computable bijection g with p n↔q(g n) ⟹ OneOneEquiv p q (VERIFIED, 0-axiom)"
     ],
     "insights": [
       "Mathlib has OneOneReducible/OneOneEquiv/ManyOneEquiv (Computability.Reduce) but NOT Myhill's isomorphism theorem — genuine gap.",
@@ -57,6 +62,7 @@
       "Mathlib lacks Myhill isomorphism theorem (OneOneEquiv → computable permutation)."
     ],
     "nextSteps": [
+      "DONE (researcher-6): the 'tractable partial win' (classical/computable SB is computable when ranges decidable / when g is a bijection) is now formalized as computable_bijection_isComputablePerm + decidableIsGFree. Remaining frontier is unchanged: the stage-wise back-and-forth for arbitrary computable injections.",
       "Formalize the stage-wise partial-bijection builder (List (ℕ×ℕ) by recursion on stage) using f for domain-side and partialInverse g for range-side extensions.",
       "Prove the stage invariants: injectivity (via partialInverse_unique + f injective), correspondence p↔q preserved, and domain/range exhaustion (n covered by stage 2n+1).",
       "Derive computability of the resulting permutation from computability of the stage builder + bounded search for the entering stage.",


### PR DESCRIPTION
## Summary

Lands the flagged **tractable partial win** for the Myhill Isomorphism Theorem (computable Schröder–Bernstein). The hard direction (arbitrary computable injections → computable permutation) stays open, but this formalizes the fully-computable special case and pins down the obstruction, in `Proofs/SchroederBernsteinOQ03.lean`:

- **`decidableIsGFree`** — the `Π₁` obstruction `isGFree g` becomes *decidable* once `Set.range g` is decidable (via the existing `isGFree_iff_not_mem_range`), making explicit that range-decidability is exactly what the general merely-computable case lacks.
- **`totalInverse`** (+ `_mem`/`_right`/`_left`/`_computable`) — a surjective computable injection's `partialInverse` is everywhere defined, so it yields a total **computable** two-sided inverse (`Part.some_get` + `Partrec.of_eq`).
- **`computable_bijection_isComputablePerm`** — a computable *bijection* of ℕ is a computable permutation: `(Equiv.ofBijective g hg).Computable`.
- **`oneOneEquiv_of_computable_bijection`** — Myhill's easy case discharged with no back-and-forth.

## Verification

Docker containerd content-store is down host-wide (I/O error), so verified via a direct `lean` compile against the project oleans. `#print axioms` for all six new declarations reports only foundational axioms (`propext`, `Classical.choice`, `Quot.sound`; `decidableIsGFree` only `propext`) — no `sorryAx`. The file's sole `sorry` remains the pre-existing open hard direction of `myhill_isomorphism`.

## Status

Problem stays open (`ACT`): the frontier is the stage-wise bounded back-and-forth / priority construction for arbitrary computable injections.