### PR TITLE
audit(de-moivre-oq-06): correct theoremCount 6→7 to match Lean source

### DIFF
--- a/src/data/proofs/de-moivre-oq-06/meta.json
+++ b/src/data/proofs/de-moivre-oq-06/meta.json
@@ -56,7 +56,7 @@
     "axiomCount": 0,
     "lineCount": 142,
     "assumptions": "0 axioms, 0 sorries. Mathlib supplies the raw geometric series (geom_sum_eq), the exponential power law (Complex.exp_nat_mul), and the angle-addition formulas; the finite closed forms for ∑ e^{ikθ}, ∑ cos(kθ), ∑ sin(kθ) and the telescoping product-to-sum steps are supplied here. The real identities require sin(θ/2) ≠ 0 (θ not an integer multiple of 2π); the complex identity requires e^{iθ} ≠ 1.",
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0
   },
   "overview": {
@@ -121,7 +121,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization supplies the finite partial-sum closed forms that De Moivre's theorem produces: the complex geometric sum ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1), and its real and imaginary parts, the two Lagrange trigonometric identities. The real identities are proved directly by a product-to-sum telescoping induction, avoiding complex real/imaginary-part extraction. All six theorems are fully proved with zero sorries and zero axioms.",
+    "summary": "This formalization supplies the finite partial-sum closed forms that De Moivre's theorem produces: the complex geometric sum ∑_{k=0}^{n} e^{ikθ} = (e^{i(n+1)θ}−1)/(e^{iθ}−1), and its real and imaginary parts, the two Lagrange trigonometric identities. The real identities are proved directly by a product-to-sum telescoping induction, avoiding complex real/imaginary-part extraction. All seven theorems are fully proved with zero sorries and zero axioms.",
     "implications": "The cosine identity is the Dirichlet kernel D_n(θ), the object at the heart of Fourier-series convergence; its conjugate is the sine form. These closed forms underpin partial-sum estimates in harmonic analysis, the Dirichlet convergence test, and the evaluation of trigonometric series. Together with OQ-05 (the roots-of-unity vanishing sum, the θ = 2π/n special case where the full period cancels) they complete the De Moivre geometric-sum picture.",
     "openQuestions": [
       "Extract the Lagrange identities as the genuine real/imaginary parts of geom_exp_partial_sum, giving a second proof and a Complex.re/Complex.im bridge",
@@ -156,7 +156,7 @@
     "namespace": "DeMoivreOQ06",
     "lineCount": 142,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/DeMoivreOQ06.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `de-moivre-oq-06`
**Problem**: `theoremCount` undercounted — meta.json claims **6** theorems, Lean source has **7**.

## Evidence

`proofs/Proofs/DeMoivreOQ06.lean` contains 7 `theorem` declarations:
`geom_exp_partial_sum`, `two_sin_half_mul_cos`, `two_sin_half_mul_sin`, `lagrange_cos_key`, `lagrange_sin_key`, `lagrange_cos_sum`, `lagrange_sin_sum`.

meta.json stated `theoremCount: 6` in both `meta.theoremCount` and `leanFile.theoremCount`, and the conclusion summary said "All six theorems are fully proved".

## Fix

- `meta.theoremCount`: 6 → 7
- `leanFile.theoremCount`: 6 → 7
- conclusion summary: "All six theorems" → "All seven theorems"

## All other claims verified accurate

- 0 sorries (matches source), 0 axioms, no `native_decide`, no `True` stubs
- status `verified` and badge `original` are legitimate: the Lagrange identities are independently proved by product-to-sum telescoping (not extracted from Mathlib); `geom_sum_eq` and the angle-addition formulas are standard building blocks, honestly disclosed in `assumptions` and `mathlibDependencies`.

Low-severity undercount (not an overclaim), but a real meta.json↔source mismatch.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)