### PR TITLE
research(prob-method-expectation-oq-05): weighted first moment principle [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ProbMethodExpectationOQ05.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ05.lean
@@ -1,0 +1,201 @@
+/-
+  First Moment Method — OQ-05: the WEIGHTED (non-uniform) first moment principle
+
+  The gallery entry `ProbMethodExpectation` and its child `…OQ04` both work with the
+  *uniform* average `(∑ f)/|s|`: every outcome is weighted equally.  The genuine
+  probabilistic setting, however, attaches an arbitrary finite probability
+  distribution (or, more generally, a nonnegative weighting) to the outcomes, and
+  the expectation is the weighted sum `E_w[X] = ∑ w a · f a`.  This file proves the
+  first moment principle in that general form.  The uniform results are recovered as
+  the special case `w ≡ 1` (see `weighted_generalizes_uniform`), so this strictly
+  subsumes the parent.
+
+  Setup: `w : α → ℚ` with `w a ≥ 0` on `s`, total weight `W := ∑_{a∈s} w a`.  The
+  weighted mean is `(∑ w·f)/W` when `W > 0`.
+
+  Results:
+  * `weighted_first_moment_gt` / `_lt` — strict:  if the weighted mean beats `t`,
+    some *supported* outcome (`w a > 0`) beats `t`.  Getting `w a > 0` on the witness
+    is strictly stronger than the uniform statement — zero-weight outcomes are
+    genuinely irrelevant.
+  * `weighted_first_moment_ge` / `_le` — non-strict threshold forms `E_w ≥ t ⟹
+    ∃ a, w a > 0 ∧ f a ≥ t`.
+  * `exists_ge_weighted_mean` / `exists_le_weighted_mean` — the titular statement:
+    *some outcome meets the weighted average* — with the sharper conclusion that the
+    witness carries positive weight.
+  * `weighted_mean_mem_Icc` — the weighted mean lies between the min and max of the
+    supported values (sandwich form).
+  * `weighted_generalizes_uniform` — with all weights `1`, `E_w = (∑ f)/|s|`, so the
+    uniform first-moment results are the `w ≡ 1` instance.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Spencer, *The Probabilistic Method*, Ch. 2 (first moment / linearity
+  of expectation for general finite distributions).
+-/
+
+import Mathlib
+
+namespace ProbMethod.ExpectationOQ05
+
+open Finset BigOperators
+
+variable {α : Type*} {s : Finset α} {w f : α → ℚ} {t : ℚ}
+
+/-- The total weight of a nonnegatively-weighted set is nonnegative. -/
+theorem totalWeight_nonneg (hw : ∀ a ∈ s, 0 ≤ w a) : 0 ≤ s.sum w :=
+  Finset.sum_nonneg hw
+
+/-- **Weighted first moment (strict, ≥).**  If the weighted mean exceeds `t`, then
+    some *supported* outcome (positive weight) exceeds `t`.  Equivalent hypothesis
+    `∑ w·f > t · W` avoids dividing by the total weight `W`. -/
+theorem weighted_first_moment_gt (hw : ∀ a ∈ s, 0 ≤ w a)
+    (h : t * s.sum w < s.sum (fun a => w a * f a)) :
+    ∃ a ∈ s, 0 < w a ∧ t < f a := by
+  by_contra hc
+  push_neg at hc
+  -- On every outcome, `w a * f a ≤ w a * t`: either `w a = 0`, or `w a > 0` forces
+  -- `f a ≤ t` by `hc`.
+  have hpoint : ∀ a ∈ s, w a * f a ≤ w a * t := by
+    intro a ha
+    rcases eq_or_lt_of_le (hw a ha) with hwa | hwa
+    · simp [← hwa]
+    · exact mul_le_mul_of_nonneg_left (hc a ha hwa) (le_of_lt hwa)
+  have hsum : s.sum (fun a => w a * f a) ≤ s.sum (fun a => w a * t) :=
+    Finset.sum_le_sum hpoint
+  have : s.sum (fun a => w a * t) = s.sum w * t := by
+    rw [← Finset.sum_mul]
+  rw [this] at hsum
+  nlinarith [hsum]
+
+/-- **Weighted first moment (strict, ≤ / dual).**  If the weighted mean is below `t`,
+    some supported outcome is below `t`. -/
+theorem weighted_first_moment_lt (hw : ∀ a ∈ s, 0 ≤ w a)
+    (h : s.sum (fun a => w a * f a) < t * s.sum w) :
+    ∃ a ∈ s, 0 < w a ∧ f a < t := by
+  by_contra hc
+  push_neg at hc
+  have hpoint : ∀ a ∈ s, w a * t ≤ w a * f a := by
+    intro a ha
+    rcases eq_or_lt_of_le (hw a ha) with hwa | hwa
+    · simp [← hwa]
+    · exact mul_le_mul_of_nonneg_left (hc a ha hwa) (le_of_lt hwa)
+  have hsum : s.sum (fun a => w a * t) ≤ s.sum (fun a => w a * f a) :=
+    Finset.sum_le_sum hpoint
+  have : s.sum (fun a => w a * t) = s.sum w * t := by
+    rw [← Finset.sum_mul]
+  rw [this] at hsum
+  nlinarith [hsum]
+
+/-- **Weighted first moment (non-strict, ≥).**  If the weighted mean is at least `t`
+    over a set of positive total weight, then some supported outcome is `≥ t`. -/
+theorem weighted_first_moment_ge (hw : ∀ a ∈ s, 0 ≤ w a) (hW : 0 < s.sum w)
+    (h : t * s.sum w ≤ s.sum (fun a => w a * f a)) :
+    ∃ a ∈ s, 0 < w a ∧ t ≤ f a := by
+  by_contra hc
+  push_neg at hc
+  -- Every supported outcome has `f a < t`, so weighted sum is *strictly* below `t·W`.
+  have hpoint : ∀ a ∈ s, w a * f a ≤ w a * t := by
+    intro a ha
+    rcases eq_or_lt_of_le (hw a ha) with hwa | hwa
+    · simp [← hwa]
+    · exact mul_le_mul_of_nonneg_left (le_of_lt (hc a ha hwa)) (le_of_lt hwa)
+  -- Since `W > 0`, at least one outcome carries positive weight; there the point
+  -- inequality is strict, upgrading the sum bound to strict.
+  have hex : ∃ a ∈ s, 0 < w a := by
+    by_contra hnone
+    push_neg at hnone
+    have : s.sum w = 0 :=
+      Finset.sum_eq_zero (fun a ha => le_antisymm (hnone a ha) (hw a ha))
+    rw [this] at hW; exact lt_irrefl _ hW
+  obtain ⟨b, hb, hwb⟩ := hex
+  have hstrict : s.sum (fun a => w a * f a) < s.sum (fun a => w a * t) :=
+    Finset.sum_lt_sum hpoint ⟨b, hb, by
+      exact mul_lt_mul_of_pos_left (hc b hb hwb) hwb⟩
+  have : s.sum (fun a => w a * t) = s.sum w * t := by
+    rw [← Finset.sum_mul]
+  rw [this] at hstrict
+  nlinarith [hstrict]
+
+/-- **Weighted first moment (non-strict, ≤ / dual).** -/
+theorem weighted_first_moment_le (hw : ∀ a ∈ s, 0 ≤ w a) (hW : 0 < s.sum w)
+    (h : s.sum (fun a => w a * f a) ≤ t * s.sum w) :
+    ∃ a ∈ s, 0 < w a ∧ f a ≤ t := by
+  by_contra hc
+  push_neg at hc
+  have hpoint : ∀ a ∈ s, w a * t ≤ w a * f a := by
+    intro a ha
+    rcases eq_or_lt_of_le (hw a ha) with hwa | hwa
+    · simp [← hwa]
+    · exact mul_le_mul_of_nonneg_left (le_of_lt (hc a ha hwa)) (le_of_lt hwa)
+  have hex : ∃ a ∈ s, 0 < w a := by
+    by_contra hnone
+    push_neg at hnone
+    have : s.sum w = 0 :=
+      Finset.sum_eq_zero (fun a ha => le_antisymm (hnone a ha) (hw a ha))
+    rw [this] at hW; exact lt_irrefl _ hW
+  obtain ⟨b, hb, hwb⟩ := hex
+  have hstrict : s.sum (fun a => w a * t) < s.sum (fun a => w a * f a) :=
+    Finset.sum_lt_sum hpoint ⟨b, hb, by
+      exact mul_lt_mul_of_pos_left (hc b hb hwb) hwb⟩
+  have : s.sum (fun a => w a * t) = s.sum w * t := by
+    rw [← Finset.sum_mul]
+  rw [this] at hstrict
+  nlinarith [hstrict]
+
+/-- **Some outcome meets the weighted average (≥).**  There is a supported outcome
+    whose value is at least the weighted mean `(∑ w·f)/W`.  This is the pigeonhole
+    core of the first moment method in the general (non-uniform) setting. -/
+theorem exists_ge_weighted_mean (hw : ∀ a ∈ s, 0 ≤ w a) (hW : 0 < s.sum w) :
+    ∃ a ∈ s, 0 < w a ∧ (s.sum (fun a => w a * f a)) / s.sum w ≤ f a := by
+  obtain ⟨a, ha, hwa, hle⟩ :=
+    weighted_first_moment_ge (t := (s.sum (fun a => w a * f a)) / s.sum w) hw hW
+      (by rw [div_mul_cancel₀ _ (ne_of_gt hW)])
+  exact ⟨a, ha, hwa, hle⟩
+
+/-- **Some outcome meets the weighted average (≤ / dual).** -/
+theorem exists_le_weighted_mean (hw : ∀ a ∈ s, 0 ≤ w a) (hW : 0 < s.sum w) :
+    ∃ a ∈ s, 0 < w a ∧ f a ≤ (s.sum (fun a => w a * f a)) / s.sum w := by
+  obtain ⟨a, ha, hwa, hle⟩ :=
+    weighted_first_moment_le (t := (s.sum (fun a => w a * f a)) / s.sum w) hw hW
+      (by rw [div_mul_cancel₀ _ (ne_of_gt hW)])
+  exact ⟨a, ha, hwa, hle⟩
+
+/-- **Sandwich: the weighted mean lies between the extreme supported values.**
+    If every supported outcome satisfies `lo ≤ f a ≤ hi`, then the weighted mean is
+    itself in `[lo, hi]`.  (A convex combination stays within the range of its
+    inputs.) -/
+theorem weighted_mean_mem_Icc {lo hi : ℚ} (hw : ∀ a ∈ s, 0 ≤ w a) (hW : 0 < s.sum w)
+    (hlo : ∀ a ∈ s, 0 < w a → lo ≤ f a) (hhi : ∀ a ∈ s, 0 < w a → f a ≤ hi) :
+    lo ≤ (s.sum (fun a => w a * f a)) / s.sum w ∧
+      (s.sum (fun a => w a * f a)) / s.sum w ≤ hi := by
+  have hpoint_lo : ∀ a ∈ s, w a * lo ≤ w a * f a := by
+    intro a ha
+    rcases eq_or_lt_of_le (hw a ha) with hwa | hwa
+    · simp [← hwa]
+    · exact mul_le_mul_of_nonneg_left (hlo a ha hwa) (le_of_lt hwa)
+  have hpoint_hi : ∀ a ∈ s, w a * f a ≤ w a * hi := by
+    intro a ha
+    rcases eq_or_lt_of_le (hw a ha) with hwa | hwa
+    · simp [← hwa]
+    · exact mul_le_mul_of_nonneg_left (hhi a ha hwa) (le_of_lt hwa)
+  have hsum_lo : s.sum w * lo ≤ s.sum (fun a => w a * f a) := by
+    have := Finset.sum_le_sum hpoint_lo
+    rwa [← Finset.sum_mul] at this
+  have hsum_hi : s.sum (fun a => w a * f a) ≤ s.sum w * hi := by
+    have := Finset.sum_le_sum hpoint_hi
+    rwa [← Finset.sum_mul] at this
+  constructor
+  · rw [le_div_iff₀ hW, mul_comm]; exact hsum_lo
+  · rw [div_le_iff₀ hW, mul_comm]; exact hsum_hi
+
+/-- **Weighted mean generalizes the uniform average.**  Taking every weight equal to
+    `1`, the weighted sum `∑ (1 · f a)` is the plain sum and the total weight is the
+    cardinality, so `E_w = (∑ f)/|s|`.  The uniform first-moment results of the parent
+    are therefore the `w ≡ 1` instance of the weighted ones. -/
+theorem weighted_generalizes_uniform :
+    s.sum (fun a => (1 : ℚ) * f a) = s.sum f ∧ s.sum (fun _ : α => (1 : ℚ)) = s.card := by
+  refine ⟨by simp, ?_⟩
+  rw [Finset.sum_const, nsmul_eq_mul, mul_one]
+
+end ProbMethod.ExpectationOQ05

--- a/src/data/proofs/prob-method-expectation-oq-05/annotations.json
+++ b/src/data/proofs/prob-method-expectation-oq-05/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-pmeoq05-strict-gt",
+    "proofId": "prob-method-expectation-oq-05",
+    "range": {
+      "startLine": 52,
+      "endLine": 71
+    },
+    "type": "theorem",
+    "title": "weighted_first_moment_gt: Strict Weighted First Moment",
+    "content": "`weighted_first_moment_gt` proves: for a nonnegative weighting `w` on `s`, if `t * (Σ w) < Σ (w·f)` then there exists `a ∈ s` with `0 < w a ∧ t < f a`. The hypothesis is the division-free form of 'the weighted mean beats t'. The conclusion sharpens the uniform first-moment principle by producing a *supported* witness (`w a > 0`) — zero-weight outcomes carry no information about a weighted expectation. Proof is by contradiction: `push_neg` yields `∀ a ∈ s, 0 < w a → f a ≤ t`; a pointwise case split on `w a = 0` vs `w a > 0` gives `w a * f a ≤ w a * t` everywhere; `Finset.sum_le_sum` then `Finset.sum_mul` factor `Σ w·t = (Σ w)·t`, and `nlinarith` closes against the hypothesis.",
+    "mathContext": "This is the weighted analogue of the parent's `first_moment_principle`. Writing $W = \\sum_{a} w(a)$ and the weighted mean $E_w[f] = \\frac{\\sum_a w(a) f(a)}{W}$, the hypothesis $t\\cdot W < \\sum_a w(a) f(a)$ says $E_w[f] > t$ (when $W>0$), and the conclusion extracts an outcome of positive weight exceeding $t$. The case split on $w(a)=0$ is essential: at zero-weight points $w(a)f(a) \\le w(a)t$ holds trivially ($0 \\le 0$), so no assumption on $f$ there is needed."
+  },
+  {
+    "id": "ann-pmeoq05-nonstrict-ge",
+    "proofId": "prob-method-expectation-oq-05",
+    "range": {
+      "startLine": 92,
+      "endLine": 119
+    },
+    "type": "theorem",
+    "title": "weighted_first_moment_ge: Non-strict Threshold Form",
+    "content": "`weighted_first_moment_ge` proves: with `w ≥ 0` on `s` and total weight `0 < Σ w`, if `t * (Σ w) ≤ Σ (w·f)` then some supported outcome satisfies `t ≤ f a`. The positivity of the total weight `W` is what makes the non-strict hypothesis usable: it guarantees at least one outcome `b` with `w b > 0` (else `Finset.sum_eq_zero` forces `W = 0`), and at that outcome the pointwise inequality is *strict*, so `Finset.sum_lt_sum` upgrades `Σ w·f < Σ w·t = W·t`, contradicting `t·W ≤ Σ w·f`.",
+    "mathContext": "The strict principle cannot conclude anything at the boundary $E_w[f] = t$; the non-strict form fills that gap, matching how the method is actually invoked ('some outcome is at least the mean'). The hypothesis $W>0$ is not cosmetic: for an all-zero weighting the support is empty and the statement is false, so the existence of a positive-weight witness is precisely the ingredient that revives the strict step `Finset.sum_lt_sum`."
+  },
+  {
+    "id": "ann-pmeoq05-meets-mean",
+    "proofId": "prob-method-expectation-oq-05",
+    "range": {
+      "startLine": 148,
+      "endLine": 166
+    },
+    "type": "theorem",
+    "title": "exists_ge_weighted_mean / exists_le_weighted_mean: Some Outcome Meets the Weighted Average",
+    "content": "`exists_ge_weighted_mean` proves: with `w ≥ 0` and `0 < Σ w`, there exists `a ∈ s` with `0 < w a ∧ (Σ w·f)/(Σ w) ≤ f a`; `exists_le_weighted_mean` is the dual. These are the titular results — 'some outcome meets the weighted average' — obtained by instantiating the threshold forms at `t = (Σ w·f)/(Σ w)`. The side goal `t·W ≤ Σ w·f` becomes an equality discharged by `div_mul_cancel₀ _ (ne_of_gt hW)`.",
+    "mathContext": "This is the pigeonhole core of the first moment method in the non-uniform setting: at least one supported outcome sits at or above the weighted mean, and (dually) at or below it. In the uniform case $w\\equiv 1$ these reduce to 'some value is at least the average $(\\sum f)/|s|$', the statement in the sibling OQ-04 — here proved for arbitrary finite distributions with the additional guarantee that the witnessing outcome carries positive weight."
+  },
+  {
+    "id": "ann-pmeoq05-sandwich",
+    "proofId": "prob-method-expectation-oq-05",
+    "range": {
+      "startLine": 167,
+      "endLine": 195
+    },
+    "type": "theorem",
+    "title": "weighted_mean_mem_Icc: Weighted Mean Between the Extremes",
+    "content": "`weighted_mean_mem_Icc` proves: if `w ≥ 0`, `0 < Σ w`, and every supported outcome satisfies `lo ≤ f a ≤ hi`, then `lo ≤ (Σ w·f)/(Σ w) ≤ hi`. Two pointwise chains `w a * lo ≤ w a * f a ≤ w a * hi` sum (via `Finset.sum_mul`) to `W·lo ≤ Σ w·f ≤ W·hi`; then `le_div_iff₀` and `div_le_iff₀` (both needing `W > 0`) turn these into the mean bounds.",
+    "mathContext": "This is the convexity fact underlying the whole method: a convex combination of values never escapes their range, so $E_w[f] \\in [\\min_{\\text{supp}} f, \\max_{\\text{supp}} f]$. It is what lets a first-moment argument read off a usable bound purely from the extreme observed values, without knowing the distribution in detail."
+  },
+  {
+    "id": "ann-pmeoq05-generalizes",
+    "proofId": "prob-method-expectation-oq-05",
+    "range": {
+      "startLine": 196,
+      "endLine": 201
+    },
+    "type": "theorem",
+    "title": "weighted_generalizes_uniform: Recovering the Uniform Case",
+    "content": "`weighted_generalizes_uniform` proves the two reductions `Σ_{a∈s} (1·f a) = Σ_{a∈s} f a` (by `simp`) and `Σ_{a∈s} 1 = s.card` (by `Finset.sum_const, nsmul_eq_mul, mul_one`). Setting every weight to 1 turns the weighted sum into the plain sum and the total weight into the cardinality, so the weighted mean `(Σ w·f)/W` becomes the uniform average `(Σ f)/|s|`.",
+    "mathContext": "This certifies that the file strictly subsumes the parent entry: every uniform first-moment statement (`first_moment_principle` and the OQ-04 averaging lemmas) is the $w \\equiv 1$ specialization of a weighted theorem proved here. Generalization without loss — the classical case is a corollary, not a separate development."
+  }
+]

--- a/src/data/proofs/prob-method-expectation-oq-05/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-05/meta.json
@@ -1,0 +1,130 @@
+{
+  "id": "prob-method-expectation-oq-05",
+  "title": "Weighted First Moment Principle: Some Outcome Meets the Average",
+  "slug": "prob-method-expectation-oq-05",
+  "description": "Generalizes the first moment method from uniform averages to arbitrary finite probability weightings: if the weighted mean E_w[X] = Σ w·f beats a threshold, some positive-weight outcome beats it too. The uniform gallery results are recovered as the w ≡ 1 instance.",
+  "meta": {
+    "author": "Alon-Spencer (probabilistic method), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
+    "date": "2000",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodExpectationOQ05.lean",
+    "tags": [
+      "probability",
+      "probabilistic-method",
+      "combinatorics",
+      "expectation",
+      "intermediate"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 201,
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-expectation",
+      "relationship": "extends",
+      "description": "Generalizes the parent's uniform first moment principle E[X] = (Σ f)/|s| to the weighted expectation E_w[X] = Σ w·f for an arbitrary nonnegative weighting; the parent is the w ≡ 1 instance (weighted_generalizes_uniform)."
+    },
+    {
+      "targetId": "prob-method-expectation-oq-04",
+      "relationship": "sibling",
+      "description": "OQ-04 supplies the non-strict uniform averaging lemmas (some outcome meets the mean under uniform weights); this file lifts the same statements to non-uniform weightings and sharpens the witness to carry positive weight."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The first moment method is the simplest incarnation of Erdős's probabilistic method: to show an object with a property exists, exhibit a random one whose expected 'badness' is small. In its textbook form (Alon–Spencer, The Probabilistic Method, Ch. 2) the underlying distribution is rarely uniform — one weights outcomes by their probabilities. The gallery's parent entry and its OQ-04 child both formalize only the uniform case, where the expectation is the plain average (Σ f)/|s|. This entry closes that gap by formalizing the general finite-distribution statement: the expectation is the weighted sum Σ w(a)·f(a) against a nonnegative weighting w, and the first moment principle continues to hold. Weighting by an arbitrary nonnegative measure — not just the counting measure — is exactly what makes the method applicable to biased random constructions, importance sampling, and Chernoff-style tilted distributions.",
+    "problemStatement": "Let s be a finite set, f : s → ℚ an observable, and w : s → ℚ a nonnegative weighting with total weight W = Σ_{a∈s} w(a). Define the weighted mean E_w[f] = (Σ w·f)/W. Does the first moment principle survive the passage from uniform to weighted averages? Concretely: if E_w[f] > t, must some *supported* outcome (w(a) > 0) satisfy f(a) > t? And is the uniform gallery result the special case w ≡ 1?",
+    "proofStrategy": "Every statement is proved by contradiction against the division-free inequality t·W ≤ Σ w·f (or its reverse), avoiding any division until the final mean forms. The engine is a single pointwise bound: for each outcome, w(a)·f(a) ≤ w(a)·t, split on whether w(a) = 0 (contributes nothing) or w(a) > 0 (where the assumed f(a) ≤ t applies with a nonnegative multiplier). Summing via Finset.sum_le_sum and factoring Σ w·t = W·t via Finset.sum_mul closes the strict cases with nlinarith. The non-strict forms additionally extract a positive-weight witness from W > 0 (else the whole sum is zero) and upgrade the sum bound to strict via Finset.sum_lt_sum. The titular 'meets the average' lemmas instantiate t at the weighted mean using div_mul_cancel₀. A sandwich lemma shows the weighted mean stays in [lo, hi] whenever every supported value does, and weighted_generalizes_uniform certifies that w ≡ 1 reduces Σ (1·f) to Σ f and W to |s|.",
+    "keyInsights": [
+      "Sharper witness than the uniform case: the conclusion delivers a *supported* outcome (w(a) > 0), not merely an index. Zero-weight outcomes are genuinely irrelevant to a weighted expectation, and the proof makes that precise by handling w(a) = 0 as the trivial branch of a case split.",
+      "The division-free hypotheses t·W ≤ Σ w·f are the shape lower-bound arguments actually use — one never wants to divide by the total weight W when chasing an existence witness. The mean forms (exists_ge_weighted_mean) are then one div_mul_cancel₀ away.",
+      "Positivity of the total weight W does real work in the non-strict forms: it guarantees at least one supported outcome, which is exactly the point where Finset.sum_lt_sum needs a strict inequality to fire. Without W > 0 the statement is false (an all-zero weighting has an empty support).",
+      "The sandwich lemma weighted_mean_mem_Icc is the convexity fact behind the method: a convex combination never escapes the range of its inputs, so E_w[f] ∈ [min f, max f] over the support. This is what lets first-moment bounds be read off from extreme values.",
+      "weighted_generalizes_uniform certifies this file strictly subsumes the parent: setting w ≡ 1 turns Σ (1·f) into Σ f and W into |s|, so every uniform first-moment statement is the w ≡ 1 specialization of a weighted one here."
+    ],
+    "prerequisites": [
+      "Finite sums over Finsets (Finset.sum) and their monotonicity lemmas",
+      "Expectation as a weighted average against a probability distribution",
+      "The first moment method (uniform case) from the parent entry",
+      "Convex combinations and the range of a weighted average",
+      "Proof by contradiction with ordered-field arithmetic (nlinarith)"
+    ],
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: From Uniform to Weighted Averages",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Frames the gap: the parent and OQ-04 work with the uniform mean (Σ f)/|s|, while the genuine probabilistic setting weights outcomes by a finite distribution. Sets up the weighting w, total weight W, and the weighted mean (Σ w·f)/W.",
+      "mathContext": "Setup over ℚ: a Finset s, observable f : α → ℚ, weighting w : α → ℚ with w(a) ≥ 0 on s, total weight W = Σ_{a∈s} w(a). The weighted mean is E_w[f] = (Σ w·f)/W when W > 0. The uniform case of the parent is w ≡ 1, giving W = |s| and E_w[f] = (Σ f)/|s|."
+    },
+    {
+      "id": "strict",
+      "title": "Part I: Strict Weighted First Moment (both directions)",
+      "startLine": 45,
+      "endLine": 91,
+      "summary": "totalWeight_nonneg (W ≥ 0), then weighted_first_moment_gt and its dual weighted_first_moment_lt: if the weighted mean strictly beats t, some positive-weight outcome strictly beats t. Division-free hypotheses t·W < Σ w·f.",
+      "mathContext": "weighted_first_moment_gt: given w ≥ 0 on s and t·W < Σ w·f, there is a ∈ s with w(a) > 0 and f(a) > t. Contradiction: if every supported a had f(a) ≤ t then pointwise w(a)·f(a) ≤ w(a)·t (trivial when w(a) = 0), so Σ w·f ≤ Σ w·t = W·t, contradicting the hypothesis. The dual weighted_first_moment_lt reverses all inequalities."
+    },
+    {
+      "id": "nonstrict",
+      "title": "Part II: Non-strict Threshold Forms",
+      "startLine": 92,
+      "endLine": 147,
+      "summary": "weighted_first_moment_ge and weighted_first_moment_le: with W > 0, if the weighted mean is at least (resp. at most) t, some supported outcome is ≥ t (resp. ≤ t). Positivity of W supplies the supported witness that makes Finset.sum_lt_sum strict.",
+      "mathContext": "weighted_first_moment_ge: w ≥ 0, W > 0, t·W ≤ Σ w·f ⟹ ∃ a ∈ s, w(a) > 0 ∧ t ≤ f(a). If instead every supported a had f(a) < t, then since W > 0 some outcome b has w(b) > 0 where the pointwise bound is strict, so Σ w·f < Σ w·t = W·t by Finset.sum_lt_sum, contradicting t·W ≤ Σ w·f. The ≤ dual is symmetric."
+    },
+    {
+      "id": "meets-mean",
+      "title": "Part III: Some Outcome Meets the Weighted Average",
+      "startLine": 148,
+      "endLine": 166,
+      "summary": "exists_ge_weighted_mean and exists_le_weighted_mean: the titular statement. There is a positive-weight outcome whose value is at least (resp. at most) the weighted mean (Σ w·f)/W. Obtained by instantiating the threshold forms at t = mean via div_mul_cancel₀.",
+      "mathContext": "exists_ge_weighted_mean: with w ≥ 0 and W > 0, ∃ a ∈ s, w(a) > 0 ∧ (Σ w·f)/W ≤ f(a). Apply weighted_first_moment_ge with t = (Σ w·f)/W; the hypothesis t·W ≤ Σ w·f is an equality, div_mul_cancel₀ _ (W ≠ 0). This is the pigeonhole core of the first moment method for non-uniform distributions."
+    },
+    {
+      "id": "sandwich",
+      "title": "Part IV: Weighted Mean Sandwiched by Extremes",
+      "startLine": 167,
+      "endLine": 195,
+      "summary": "weighted_mean_mem_Icc: if every supported outcome lies in [lo, hi], the weighted mean lies in [lo, hi] too — the convexity fact that a weighted average never escapes the range of its inputs.",
+      "mathContext": "weighted_mean_mem_Icc: w ≥ 0, W > 0, and lo ≤ f(a) ≤ hi for every supported a ⟹ lo ≤ (Σ w·f)/W ≤ hi. Pointwise w(a)·lo ≤ w(a)·f(a) ≤ w(a)·hi sums to W·lo ≤ Σ w·f ≤ W·hi (via Finset.sum_mul), then le_div_iff₀ / div_le_iff₀ with W > 0 give the mean bounds."
+    },
+    {
+      "id": "generalizes",
+      "title": "Part V: Recovering the Uniform Case",
+      "startLine": 196,
+      "endLine": 201,
+      "summary": "weighted_generalizes_uniform: with all weights equal to 1, Σ (1·f) = Σ f and the total weight Σ 1 = |s|, so E_w reduces to the uniform mean (Σ f)/|s|. Certifies this file subsumes the parent.",
+      "mathContext": "weighted_generalizes_uniform: Σ_{a∈s} (1·f(a)) = Σ_{a∈s} f(a) and Σ_{a∈s} 1 = |s| (Finset.sum_const, nsmul_eq_mul). Hence the uniform first-moment results of the parent are exactly the w ≡ 1 instance of the weighted theorems above."
+    }
+  ],
+  "conclusion": {
+    "summary": "This 201-line fully verified (0 sorries, 0 axioms) file lifts the first moment method from uniform averages to arbitrary nonnegative finite weightings. Nine theorems cover the strict principle in both directions, its non-strict threshold forms, the titular 'some outcome meets the weighted average' statements (with a positive-weight witness), a convexity sandwich placing the weighted mean between the extreme supported values, and a reduction certifying that the uniform gallery results are the w ≡ 1 special case.",
+    "implications": "Weighting outcomes by an arbitrary distribution is what makes the probabilistic method practical: biased random constructions, importance sampling, and tilted (Chernoff) distributions all replace the uniform measure with a weighted one. Formalizing the first moment principle at this generality means existence arguments over non-uniform random structures can cite these lemmas directly, rather than re-deriving the averaging step each time.",
+    "openQuestions": [
+      "Can the weighted second moment method (weighted Paley–Zygmund) be formalized similarly, replacing the uniform variance with a w-weighted variance?",
+      "Does an equality-characterization hold — is E_w[f] = max_support f iff f is w-a.e. constant on the support, mirroring the uniform equality case?",
+      "Can these ℚ-valued weighted statements be transported to ℝ≥0∞-valued measures to connect with the MeasureTheory bridge of OQ-01?"
+    ]
+  },
+  "leanFile": {
+    "axiomCount": 0,
+    "lineCount": 201,
+    "path": "Proofs/ProbMethodExpectationOQ05.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 9
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Weighted First Moment Principle — Some Outcome Meets the (Weighted) Average

**Problem** `prob-method-expectation-oq-05` (Seeker-selected OQ child, tractability 9). Verified, 0-axiom, 0-sorry.

### Gap closed
The parent `prob-method-expectation` and sibling `…OQ04` formalize the first moment method only for the **uniform** average `(Σ f)/|s|`. The genuine probabilistic setting weights outcomes by an arbitrary finite distribution and takes the expectation as the **weighted sum** `E_w[f] = Σ w·f`. This entry proves the first moment principle at that generality; the uniform results are the `w ≡ 1` instance.

### Contents (9 theorems, 201 lines)
- `weighted_first_moment_gt` / `_lt` — strict principle, both directions, delivering a **supported** witness (`w a > 0`), which is sharper than the uniform statement (zero-weight outcomes are irrelevant to a weighted mean).
- `weighted_first_moment_ge` / `_le` — non-strict threshold forms; positivity of total weight `W` supplies the supported witness that makes `Finset.sum_lt_sum` fire.
- `exists_ge_weighted_mean` / `exists_le_weighted_mean` — the titular "some outcome meets the weighted average", instantiating the threshold at the mean via `div_mul_cancel₀`.
- `weighted_mean_mem_Icc` — convexity sandwich: the weighted mean stays in `[lo, hi]` whenever every supported value does.
- `weighted_generalizes_uniform` — `w ≡ 1` reduces `Σ (1·f)` to `Σ f` and `W` to `|s|`, certifying the parent/OQ-04 uniform results are a special case.

### Proof engine
Contradiction against the division-free inequality `t·W ≤ Σ w·f`, with a single pointwise bound `w a · f a ≤ w a · t` split on `w a = 0` vs `w a > 0`, summed via `Finset.sum_le_sum` / `sum_lt_sum` and factored with `Finset.sum_mul`, closed by `nlinarith`.

### Verification
`#print axioms` shows only `propext, Classical.choice, Quot.sound` (the standard foundational trio; not counted). Verified locally by direct `lean` compile against the host Mathlib oleans — Docker containerd content-store I/O corruption persists host-wide, so the sanctioned `docker-build.sh` is unavailable this session. The committed file keeps `import Mathlib` (a superset of the targeted imports used for local verification); docker/CI has a complete Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)