### PR TITLE
research(erdos-381): eliminate all 3 sorries — Nicolas disproof fully derived

### DIFF
--- a/proofs/Proofs/Erdos381Problem.lean
+++ b/proofs/Proofs/Erdos381Problem.lean
@@ -25,9 +25,9 @@ Related: OEIS A002182, Ramanujan's highly composite numbers
 -/
 
 import Mathlib.Data.Nat.Basic
-import Mathlib.Algebra.Order.Ring.Lemmas
-import Mathlib.Order.Filter.AtTopBot
+import Mathlib.Order.Filter.AtTopBot.Field
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
 
 open Filter
 
@@ -86,7 +86,7 @@ theorem two_highly_composite : IsHighlyComposite 2 := by
   · omega
   · intro m hm hmlt
     interval_cases m
-    · simp [tau]
+    decide
 
 /--
 **4 is highly composite:**
@@ -96,7 +96,7 @@ theorem four_highly_composite : IsHighlyComposite 4 := by
   constructor
   · omega
   · intro m hm hmlt
-    interval_cases m <;> simp [tau]
+    interval_cases m <;> decide
 
 /--
 **6 is highly composite:**
@@ -106,7 +106,7 @@ theorem six_highly_composite : IsHighlyComposite 6 := by
   constructor
   · omega
   · intro m hm hmlt
-    interval_cases m <;> simp [tau]
+    interval_cases m <;> decide
 
 /--
 **12 is highly composite:**
@@ -116,21 +116,21 @@ theorem twelve_highly_composite : IsHighlyComposite 12 := by
   constructor
   · omega
   · intro m hm hmlt
-    interval_cases m <;> simp [tau]
+    interval_cases m <;> decide
 
 /--
 **Divisor counts for small numbers:**
 Computational verification of τ values.
 -/
-example : tau 1 = 1 := by native_decide
-example : tau 2 = 2 := by native_decide
-example : tau 3 = 2 := by native_decide
-example : tau 4 = 3 := by native_decide
-example : tau 5 = 2 := by native_decide
-example : tau 6 = 4 := by native_decide
-example : tau 12 = 6 := by native_decide
-example : tau 24 = 8 := by native_decide
-example : tau 36 = 9 := by native_decide
+example : tau 1 = 1 := by decide
+example : tau 2 = 2 := by decide
+example : tau 3 = 2 := by decide
+example : tau 4 = 3 := by decide
+example : tau 5 = 2 := by decide
+example : tau 6 = 4 := by decide
+example : tau 12 = 6 := by decide
+example : tau 24 = 8 := by decide
+example : tau 36 = 9 := by decide
 
 /--
 **First several highly composite numbers:**
@@ -205,17 +205,73 @@ theorem nicolas_exponent_pos : nicolas_exponent > 0 :=
   (Classical.choose_spec nicolas_upper_bound).1
 
 /--
+**Exponent comparison from two-sided bounds.**
+If `Q x` is eventually at least `a · (log x)^α` (with `a > 0`) and eventually at most
+`b · (log x)^β`, then the lower exponent cannot exceed the upper one: `α ≤ β`.
+
+This is the analytic core behind Nicolas's disproof: a slower-growing power of
+`log x` can never dominate a faster-growing one on `atTop`, since their ratio
+`a · (log x)^(α-β)` would tend to infinity while remaining `≤ b`.
+-/
+theorem exponent_le_of_bounds {a b α β : ℝ} (ha : 0 < a)
+    (hlow : ∀ᶠ x : ℕ in atTop, a * (Real.log x) ^ α ≤ (Q x : ℝ))
+    (hup : ∀ᶠ x : ℕ in atTop, (Q x : ℝ) ≤ b * (Real.log x) ^ β) :
+    α ≤ β := by
+  by_contra hlt
+  push_neg at hlt
+  have hd : 0 < α - β := by linarith
+  have hlogtop : Tendsto (fun x : ℕ => Real.log x) atTop atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  have hlog1 : ∀ᶠ x : ℕ in atTop, (1 : ℝ) ≤ Real.log x :=
+    hlogtop.eventually_ge_atTop 1
+  -- Combining both bounds, `a · (log x)^(α-β) ≤ b` eventually.
+  have key : ∀ᶠ x : ℕ in atTop, a * (Real.log x) ^ (α - β) ≤ b := by
+    filter_upwards [hlow, hup, hlog1] with x hx_low hx_up hx_log1
+    have hpos : (0 : ℝ) < Real.log x := lt_of_lt_of_le one_pos hx_log1
+    have hβpos : (0 : ℝ) < (Real.log x) ^ β := Real.rpow_pos_of_pos hpos β
+    have hab : a * (Real.log x) ^ α ≤ b * (Real.log x) ^ β := le_trans hx_low hx_up
+    have hsplit : (Real.log x) ^ α = (Real.log x) ^ β * (Real.log x) ^ (α - β) := by
+      rw [← Real.rpow_add hpos]; congr 1; ring
+    rw [hsplit] at hab
+    have hab2 : (a * (Real.log x) ^ (α - β)) * (Real.log x) ^ β
+        ≤ b * (Real.log x) ^ β := by
+      have e : (a * (Real.log x) ^ (α - β)) * (Real.log x) ^ β
+          = a * ((Real.log x) ^ β * (Real.log x) ^ (α - β)) := by ring
+      rw [e]; exact hab
+    exact le_of_mul_le_mul_right hab2 hβpos
+  -- But `a · (log x)^(α-β) → ∞`, contradicting the eventual bound `≤ b`.
+  have hrtop : Tendsto (fun x : ℕ => (Real.log x) ^ (α - β)) atTop atTop :=
+    (tendsto_rpow_atTop hd).comp hlogtop
+  have htop : Tendsto (fun x : ℕ => a * (Real.log x) ^ (α - β)) atTop atTop :=
+    Filter.Tendsto.const_mul_atTop ha hrtop
+  have hgt : ∀ᶠ x : ℕ in atTop, b < a * (Real.log x) ^ (α - β) :=
+    htop.eventually_gt_atTop b
+  have hfalse : ∀ᶠ x : ℕ in atTop, False := by
+    filter_upwards [key, hgt] with x h1 h2; linarith
+  rcases hfalse.exists with ⟨_, h⟩
+  exact h
+
+/--
 **Corollary: The answer is NO:**
-The Erdős question is false - there exists k such that Q(x) is NOT ≫ (log x)^k.
+The Erdős question is false — there exists `k` such that `Q(x)` is NOT `≫ (log x)^k`.
 -/
 theorem erdos_question_false : ¬erdos_question := by
   intro h
-  -- Take k larger than Nicolas's exponent
-  obtain ⟨C, hC, K, hK, hbound⟩ := nicolas_upper_bound
-  -- If question were true, Q(x) ≥ c(log x)^k for k > C
-  -- But nicolas says Q(x) ≤ K(log x)^C
-  -- Contradiction for large x when k > C
-  sorry
+  -- Nicolas: Q(x) ≤ K (log x)^C eventually, for some real exponent C > 0.
+  obtain ⟨C, _hC, K, _hK, hup⟩ := nicolas_upper_bound
+  -- Instantiate the (false) hypothesis at a natural exponent strictly above C.
+  obtain ⟨c, hc, hlow⟩ := h (⌈C⌉₊ + 1) (by omega)
+  have hNge : C < ((⌈C⌉₊ + 1 : ℕ) : ℝ) := by
+    have h1 : C ≤ (⌈C⌉₊ : ℝ) := Nat.le_ceil C
+    push_cast; linarith
+  -- Rewrite the natural-power lower bound as an `rpow` bound.
+  have hlow' : ∀ᶠ x : ℕ in atTop,
+      c * (Real.log x) ^ ((⌈C⌉₊ + 1 : ℕ) : ℝ) ≤ (Q x : ℝ) := by
+    filter_upwards [hlow] with x hx
+    rw [Real.rpow_natCast]; exact hx
+  -- The comparison lemma forces `⌈C⌉₊ + 1 ≤ C`, contradicting `hNge`.
+  have := exponent_le_of_bounds hc hlow' hup
+  linarith
 
 /- ## Part VI: Tight Bounds -/
 
@@ -227,9 +283,16 @@ where c > 0 is Erdős's constant and C is Nicolas's exponent.
 theorem Q_bounds :
     ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ c < C ∧
     (∃ K₁ K₂ : ℝ, K₁ > 0 ∧ K₂ > 0 ∧
-     ∀ᶠ x in atTop, K₁ * (Real.log x)^(1 + c) ≤ (Q x : ℝ) ∧
+     ∀ᶠ x : ℕ in atTop, K₁ * (Real.log x)^(1 + c) ≤ (Q x : ℝ) ∧
                     (Q x : ℝ) ≤ K₂ * (Real.log x)^C) := by
-  sorry
+  obtain ⟨c, hc, K₁, hK₁, hlow⟩ := erdos_lower_bound
+  obtain ⟨C, hC, K₂, hK₂, hup⟩ := nicolas_upper_bound
+  -- The lower exponent `1 + c` cannot exceed the upper exponent `C`, so `c < C`.
+  have hlow' : ∀ᶠ x : ℕ in atTop, K₁ * (Real.log x) ^ (1 + c) ≤ (Q x : ℝ) := hlow
+  have hexp : (1 + c) ≤ C := exponent_le_of_bounds hK₁ hlow' hup
+  refine ⟨c, C, hc, hC, by linarith, K₁, K₂, hK₁, hK₂, ?_⟩
+  filter_upwards [hlow, hup] with x h1 h2
+  exact ⟨h1, h2⟩
 
 /-
 **Q(x) has polynomial growth in log x:**
@@ -314,10 +377,19 @@ Q(x) does NOT grow faster than every power of log x.
 theorem erdos_381_answer_no :
     ∃ k : ℕ, k ≥ 1 ∧ ¬(∃ C : ℝ, C > 0 ∧
     ∀ᶠ x in atTop, (Q x : ℝ) ≥ C * (Real.log x)^k) := by
-  -- Take k = ⌈nicolas_exponent⌉ + 1
-  -- Nicolas's bound gives Q(x) ≤ K(log x)^C
-  -- So Q(x) is not ≥ c(log x)^k for k > C
-  sorry
+  -- Take k = ⌈C⌉₊ + 1 where C is Nicolas's exponent; then k > C.
+  obtain ⟨C, _hC, K, _hK, hup⟩ := nicolas_upper_bound
+  refine ⟨⌈C⌉₊ + 1, by omega, ?_⟩
+  rintro ⟨c, hc, hlow⟩
+  have hNge : C < ((⌈C⌉₊ + 1 : ℕ) : ℝ) := by
+    have h1 : C ≤ (⌈C⌉₊ : ℝ) := Nat.le_ceil C
+    push_cast; linarith
+  have hlow' : ∀ᶠ x : ℕ in atTop,
+      c * (Real.log x) ^ ((⌈C⌉₊ + 1 : ℕ) : ℝ) ≤ (Q x : ℝ) := by
+    filter_upwards [hlow] with x hx
+    rw [Real.rpow_natCast]; exact hx
+  have := exponent_le_of_bounds hc hlow' hup
+  linarith
 
 /--
 **Summary of erdos_381:**

--- a/proofs/Proofs/Erdos381ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos381ProblemAristotle.lean
@@ -1,83 +1,60 @@
 /-
   Aristotle targets for Erdős Problem #381: Counting Highly Composite Numbers
-  Routine supporting lemmas for automated proof search.
-  See Erdos381Problem.lean for the main formalization.
+  Supporting lemmas for the main formalization in Erdos381Problem.lean.
 
-  Criteria for inclusion:
-  - NOT open conjectures (the problem is DISPROVED — Nicolas 1971)
-  - All theorems follow from axioms already in Erdos381Problem.lean
-  - No definition sorries, no axiom declarations, no True placeholders
-  - Use only block comments, not module docstrings
+  STATUS (2026-07-01): All three targets below are now PROVED in
+  Erdos381Problem.lean and the wrappers here simply delegate to them.
+  They are retained as a record of the Aristotle target set; there are no
+  remaining sorries.
 
   Background:
   - erdos_lower_bound (axiom): Q(x) ≥ K(log x)^{1+c} for some c > 0
   - nicolas_upper_bound (axiom): Q(x) ≤ K(log x)^C for some C > 0
-  - These two axioms together disprove erdos_question
+  - These two axioms together disprove erdos_question. The disproof and the
+    combined two-sided bounds are all deduced from the analytic comparison
+    lemma Erdos381.exponent_le_of_bounds.
 -/
 import Proofs.Erdos381Problem
-import Mathlib
 
 namespace Erdos381Aristotle
 
 open Erdos381 Filter Real
 
-/-
-## Target 1: Q_bounds
+/- ## Target 1: Q_bounds
 
 Combining erdos_lower_bound and nicolas_upper_bound gives explicit two-sided bounds.
-The constants c and C come directly from the two axioms.
+Since a slower-growing power of `log x` cannot dominate a faster-growing one on
+`atTop`, the lower exponent `1 + c` cannot exceed the upper exponent `C`, hence
+`c < C`. -/
 
-Strategy: Take c from erdos_lower_bound (so Q(x) ≥ K₁(log x)^{1+c}).
-Take C from nicolas_upper_bound (so Q(x) ≤ K₂(log x)^C).
-For c < C: if C ≤ c, the upper bound O((log x)^C) contradicts the lower bound
-Ω((log x)^{1+c}) for large x. Hence C > 1 + c > c.
--/
-
-/-- Combined bounds: (log x)^{1+c} ≪ Q(x) ≪ (log x)^C.
-
-  Follows from erdos_lower_bound (Q ≥ K₁(log x)^{1+c}) and nicolas_upper_bound
-  (Q ≤ K₂(log x)^C). Since both hold for large x, we must have 1 + c ≤ C.
-  In particular c < C. -/
+/-- Combined bounds: (log x)^{1+c} ≪ Q(x) ≪ (log x)^C. Proved in the main file
+  as `Erdos381.Q_bounds`. -/
 theorem Q_bounds_ari :
     ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ c < C ∧
     (∃ K₁ K₂ : ℝ, K₁ > 0 ∧ K₂ > 0 ∧
-     ∀ᶠ x in atTop, K₁ * (Real.log x)^(1 + c) ≤ (Q x : ℝ) ∧
-                    (Q x : ℝ) ≤ K₂ * (Real.log x)^C) := by
-  sorry
+     ∀ᶠ x : ℕ in atTop, K₁ * (Real.log x)^(1 + c) ≤ (Q x : ℝ) ∧
+                    (Q x : ℝ) ≤ K₂ * (Real.log x)^C) :=
+  Erdos381.Q_bounds
 
-/-
-## Target 2: erdos_question_false
+/- ## Target 2: erdos_question_false
 
 Nicolas (1971) showed Q(x) ≪ (log x)^C, disproving Erdős's question that
-Q(x) ≫_k (log x)^k for every k. If the question were true, for k > C we would
-have Q(x) ≥ c(log x)^k for large x, contradicting Q(x) ≤ K(log x)^C.
--/
+Q(x) ≫_k (log x)^k for every k. -/
 
-/-- The Erdős question is FALSE.
+/-- The Erdős question is FALSE. Proved in the main file as
+  `Erdos381.erdos_question_false`. -/
+theorem erdos_question_false_ari : ¬erdos_question :=
+  Erdos381.erdos_question_false
 
-  Proof: Assume erdos_question holds. Get C and K from nicolas_upper_bound.
-  Apply the hypothesis to k := ⌈C⌉.toNat + 1 (which satisfies k ≥ 1 and k > C).
-  Get c' > 0 such that eventually Q(x) ≥ c'(log x)^k.
-  Combined with Q(x) ≤ K(log x)^C, this gives c'(log x)^(k-C) ≤ K for large x.
-  But (log x)^(k-C) → ∞ since k > C and log x → ∞, contradiction. -/
-theorem erdos_question_false_ari : ¬erdos_question := by
-  sorry
+/- ## Target 3: erdos_381_answer_no
 
-/-
-## Target 3: erdos_381_answer_no
+A concrete k for which Q(x) does NOT grow as fast as (log x)^k. -/
 
-A concrete k for which Q(x) does NOT grow as fast as (log x)^k:
-take k = ⌈nicolas_exponent⌉.toNat + 1.
--/
-
-/-- There exists k ≥ 1 such that Q(x) ≁ (log x)^k.
-
-  Take k = ⌈nicolas_exponent⌉.toNat + 1. Since k > nicolas_exponent,
-  and nicolas_upper_bound gives Q(x) ≤ K(log x)^{nicolas_exponent},
-  any lower bound Q(x) ≥ c(log x)^k would exceed the upper bound for large x. -/
+/-- There exists k ≥ 1 such that Q(x) is not eventually ≥ c(log x)^k for any c > 0.
+  Proved in the main file as `Erdos381.erdos_381_answer_no`. -/
 theorem erdos_381_answer_no_ari :
     ∃ k : ℕ, k ≥ 1 ∧ ¬(∃ C : ℝ, C > 0 ∧
-    ∀ᶠ x in atTop, (Q x : ℝ) ≥ C * (Real.log x)^k) := by
-  sorry
+    ∀ᶠ x in atTop, (Q x : ℝ) ≥ C * (Real.log x)^k) :=
+  Erdos381.erdos_381_answer_no
 
 end Erdos381Aristotle

--- a/src/data/proofs/erdos-381/meta.json
+++ b/src/data/proofs/erdos-381/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 381,
     "erdosUrl": "https://erdosproblems.com/381",
     "erdosProblemStatus": "disproved",
@@ -39,6 +39,16 @@
         "theorem": "Real.log",
         "description": "Natural logarithm",
         "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "tendsto_rpow_atTop",
+        "description": "x ^ y → ∞ as x → ∞ for y > 0 (real power growth)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics"
+      },
+      {
+        "theorem": "Real.rpow_add",
+        "description": "Additivity of the real power exponent",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       }
     ],
     "originalContributions": [
@@ -48,17 +58,19 @@
       "erdos_question formalization",
       "erdos_lower_bound axiom (1944)",
       "nicolas_upper_bound axiom (1971)",
-      "erdos_question_false theorem: disproof",
-      "Q_bounds combined asymptotic bounds",
+      "exponent_le_of_bounds: analytic comparison lemma (a slower-growing power of log x cannot dominate a faster-growing one on atTop); the shared core of the disproof",
+      "erdos_question_false theorem: disproof (fully proved from nicolas_upper_bound, no sorry)",
+      "Q_bounds combined asymptotic bounds (fully proved, deriving c < C from the two axioms)",
+      "erdos_381_answer_no: concrete exponent k = ⌈C⌉₊ + 1 with no matching lower bound (fully proved)",
       "IsSuperiorHighlyComposite definition",
       "erdos_381_summary: combines lower bound, upper bound, and disproof",
       "Proofs: one_highly_composite, two_highly_composite, four_highly_composite, six_highly_composite, twelve_highly_composite",
-      "Computational verification: tau values for small n via native_decide"
+      "Computational verification: tau values for small n via decide (kernel-checked, no ofReduceBool)"
     ],
     "axiomCount": 2,
-    "lineCount": 335,
-    "assumptions": "2 axioms: erdos_lower_bound, nicolas_upper_bound. 3 sorries.",
-    "theoremCount": 12,
+    "lineCount": 407,
+    "assumptions": "2 axioms: erdos_lower_bound (Erdős 1944) and nicolas_upper_bound (Nicolas 1971), both deep analytic results not available in Mathlib. 0 sorries: all consequences (erdos_question_false, Q_bounds, erdos_381_answer_no) are fully derived from these two axioms via the comparison lemma exponent_le_of_bounds.",
+    "theoremCount": 13,
     "definitionCount": 11,
     "additionalFiles": [
       "Proofs/Erdos381ProblemAristotle.lean"
@@ -117,41 +129,41 @@
     {
       "id": "nicolas",
       "title": "Nicolas's Disproof (1971)",
-      "summary": "Q(x) ≪ (log x)^C disproves the conjecture",
+      "summary": "Q(x) ≪ (log x)^C disproves the conjecture; exponent_le_of_bounds and erdos_question_false",
       "startLine": 184,
-      "endLine": 219,
+      "endLine": 275,
       "mathContext": "Verified: Q(x) ≪ (log x)^C disproves the conjecture"
     },
     {
       "id": "bounds",
       "title": "Tight Bounds",
       "summary": "(log x)^{1+c} ≪ Q(x) ≪ (log x)^C",
-      "startLine": 220,
-      "endLine": 237,
+      "startLine": 276,
+      "endLine": 300,
       "mathContext": "Mathematical content: (log x)^{1+c} ≪ Q(x) ≪ (log x)^C"
     },
     {
       "id": "structure",
       "title": "Structure of HC Numbers",
       "summary": "Prime factorization properties, Ramanujan characterization, superior HC numbers",
-      "startLine": 238,
-      "endLine": 260,
+      "startLine": 301,
+      "endLine": 323,
       "mathContext": "Mathematical content: Prime factorization properties, Ramanujan characterization, superior HC numbers"
     },
     {
       "id": "comparison",
       "title": "Comparison with Other Sequences",
       "summary": "HC vs primes (Q(x)/π(x) → 0), highly abundant numbers",
-      "startLine": 261,
-      "endLine": 278,
+      "startLine": 324,
+      "endLine": 341,
       "mathContext": "HC vs primes (Q(x)/π(x) $\\to$ 0), highly abundant numbers"
     },
     {
       "id": "summary",
       "title": "Summary and Main Results",
       "summary": "erdos_381 theorem: the conjecture is FALSE; erdos_381_summary combines all key results",
-      "startLine": 279,
-      "endLine": 335,
+      "startLine": 342,
+      "endLine": 407,
       "mathContext": "Verified: erdos_381 theorem: the conjecture is FALSE; erdos_381_summary combines all key results"
     }
   ],
@@ -167,20 +179,20 @@
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Basic",
-      "Mathlib.Algebra.Order.Ring.Lemmas",
-      "Mathlib.Order.Filter.AtTopBot",
-      "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      "Mathlib.Order.Filter.AtTopBot.Field",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics"
     ],
     "opens": [
       "Filter"
     ],
     "namespace": "Erdos381",
-    "lineCount": 335,
+    "lineCount": 407,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 11,
     "path": "Proofs/Erdos381Problem.lean",
-    "sorries": 3,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos381ProblemAristotle.lean"
     ]
@@ -202,5 +214,5 @@
       "description": "Related Erdős problem sharing themes: divisor-functions, number-theory"
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Erdős Problem **#381** asks whether `Q(x)` — the count of highly composite numbers `≤ x` — grows faster than *every* power of `log x`. Nicolas (1971) answered **NO**. The gallery file kept the two deep analytic results as axioms (`erdos_lower_bound`, `nicolas_upper_bound`) but left the three *derivations* from them as `sorry`. **This PR proves all three**, taking the entry from 3 sorries → 0 (still `axiomatized`, still exactly 2 deep axioms).

## What changed

**New shared lemma `exponent_le_of_bounds` (0-axiom):** if `Q x` is eventually `≥ a·(log x)^α` and eventually `≤ b·(log x)^β` with `a > 0`, then `α ≤ β`. A slower-growing power of `log x` cannot dominate a faster one on `atTop` — their ratio `a·(log x)^(α−β)` tends to `∞` while remaining `≤ b`.

Discharged from it:
- **`erdos_question_false`** — instantiate the (false) hypothesis at `k = ⌈C⌉₊ + 1 > C`; the lemma forces `k ≤ C`, contradiction.
- **`erdos_381_answer_no`** — same argument, exhibiting the concrete failing exponent.
- **`Q_bounds`** — the lemma gives `1 + c ≤ C`, hence `c < C`, so the two-sided bound is stated honestly rather than assumed.

The Aristotle companion now delegates its three targets to the main-file theorems (0 sorries there too).

## Incidental fixes (needed to compile against Mathlib v4.26.0)
- `import Mathlib.Algebra.Order.Ring.Lemmas` no longer exists in this rev → imports replaced with `AtTopBot.Field` + `Pow.Asymptotics` (rpow growth lemmas).
- Pinned the `Q_bounds` binder to `x : ℕ` — `Real.log x` preceded `Q x`, so `x` had been inferred as `ℝ` and the statement was ill-typed under current elaboration.
- Small-number theorems: `simp [tau]` → `decide` (simp now rewrites to `Nat.divisors` and stalls under the broader imports). Also converted the `tau` `example`s from `native_decide` → `decide`, removing the `Lean.ofReduceBool` dependency.

## Verification
Built with the pinned toolchain (`leanprover/lean4:v4.26.0`) against the repo's Mathlib snapshot. Both files compile with **0 errors, 0 warnings, 0 sorries**.

Axiom audit:
- `erdos_381` → `[propext, Classical.choice, nicolas_upper_bound, Quot.sound]`
- `erdos_381_answer_no` → `[propext, Classical.choice, nicolas_upper_bound, Quot.sound]`
- `Q_bounds` → `[propext, Classical.choice, erdos_lower_bound, nicolas_upper_bound, Quot.sound]`
- `exponent_le_of_bounds` → `[propext, Classical.choice, Quot.sound]`

No `sorryAx`, no `Lean.ofReduceBool`. `axiomCount` stays **2**; `sorries` **3 → 0**. meta.json line/section/theorem counts updated accordingly.