### PR TITLE
Enrich erdos-357-oq-04 cluster: 3 reciprocal crossRef back-links

### DIFF
--- a/src/data/proofs/erdos-1003-oq-03/meta.json
+++ b/src/data/proofs/erdos-1003-oq-03/meta.json
@@ -149,6 +149,11 @@
       "targetId": "erdos-1003-oq-02",
       "relationship": "related",
       "description": "Sibling: the nested-chain reduction of the infinitude family. The bridge theorem here connects density-unboundedness to the infinitude OQ-02 studies."
+    },
+    {
+      "targetId": "erdos-357-oq-04",
+      "relationship": "related",
+      "description": "The little-o ⇔ ratio-limit ⇔ ε–N trichotomy (Erdős #357 generalization) is the interchangeable menu of density-zero formulations that the Density Layer catalogued here can draw on: a genuine asymptotic-density answer can be phrased as a ratio limit, a little-o statement, or the concrete ε–N form ∀ε>0 eventually #{k | A k ≤ n} ≤ ε·n, whichever is most convenient to attack."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-31-primes-density/meta.json
+++ b/src/data/proofs/erdos-31-primes-density/meta.json
@@ -122,6 +122,11 @@
       "targetId": "bounded-prime-gaps",
       "relationship": "related",
       "description": "Bounded Prime Gaps (Zhang/Maynard-Tao/Polymath 8b) studies how closely primes can cluster despite their global thinning. Density zero established here is the baseline 'primes are sparse' fact; the bounded-gaps theory shows that sparsity nonetheless permits infinitely many pairs within distance 246, a striking tension between average density and local clustering."
+    },
+    {
+      "targetId": "erdos-357-oq-04",
+      "relationship": "generalized-by",
+      "description": "π(N)/N → 0 established here is a worked instance of the little-o ⇔ ratio-limit ⇔ ε–N trichotomy stated for arbitrary sequences in the Erdős #357 generalization: π(N)/N → 0 is the ratio-limit face, π(N) =o[atTop] N the little-o face, and 'eventually π(N) ≤ ε·N' the ε–N face, all supplied at once by density_zero_iff_littleO / density_zero_iff_eventually_le for the counting function #{p prime | p ≤ N}."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/szemeredi-full-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-full-oq-02/meta.json
@@ -146,6 +146,11 @@
       "targetId": "furstenberg-correspondence",
       "relationship": "related",
       "description": "The Furstenberg correspondence principle — translates the combinatorial density statement of Szemerédi's theorem into a measure-theoretic recurrence problem. The density formulation proved here (k-AP-free sets have |A|/N → 0) is the negation of the condition triggering recurrence under Furstenberg's correspondence: positive upper density implies return times."
+    },
+    {
+      "targetId": "erdos-357-oq-04",
+      "relationship": "shares-technique",
+      "description": "The little-o ⇔ ratio-limit Equivalence (Erdős #357) isolates the same Asymptotics.isLittleO_iff_tendsto bridge used here to move between the little-o and ratio-limit forms of the density bound |A|/N → 0, but for an arbitrary sequence, and additionally supplies the ε–N face ∀ε>0 eventually u(n) ≤ ε·n that density arguments like this k-AP-free bound are actually written in."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The little-o ⇔ ratio-limit Equivalence entry (`erdos-357-oq-04`) references three sibling gallery proofs, but none of them linked back — a one-way crossReference gap. This PR adds the missing reciprocal `crossReferences`, closing the bidirectional links across the cluster.

The parent link (`erdos-357` ↔ `erdos-357-oq-04`) was already made bidirectional in #32226; this completes the remaining three edges.

## Back-links added
| Target | Relationship | Rationale |
|--------|--------------|-----------|
| `szemeredi-full-oq-02` | `shares-technique` | Both use `Asymptotics.isLittleO_iff_tendsto` to move between the little-o and ratio-limit forms of a density bound; oq-04 isolates the bridge for arbitrary sequences + supplies the ε–N face. |
| `erdos-31-primes-density` | `generalized-by` | π(N)/N → 0 is a worked instance of oq-04's little-o ⇔ ratio-limit ⇔ ε–N trichotomy. |
| `erdos-1003-oq-03` | `related` | oq-04's trichotomy is the interchangeable menu of density-zero formulations the #1003 Density Layer catalogues. |

## Verification
- Purely additive diff: 3 files, 15 insertions, 0 deletions (targeted JSON insertion, no reformatting of existing content).
- All three `meta.json` files validated as parseable JSON.
- Each reciprocal description mirrors the mathematically-accurate forward description already present in `erdos-357-oq-04`.