### PR TITLE
Research: erdos-101-oq-04 — raise four-point-line floor 1 → 2 via 7-point cross [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -823,4 +823,336 @@ theorem exists_isLowerBoundConstruction_pos :
     rw [show witnessSet.points = witnessPoints from rfl, witnessPoints_card]
     norm_num, witnessSet_isLowerBoundConstruction⟩
 
+/- ## Raising the framework floor: a construction with two four-point lines
+
+The `witnessSet` above achieves `IsLowerBoundConstruction _ 1` — one
+four-point line.  A single four-point line uses only four points, so
+five-point sets can carry at most one such line; indeed **no** set of
+exactly five points has two four-point lines (two distinct four-point
+lines meet in at most one point, so already require `4 + 4 - 1 = 7`
+distinct points).  Raising the floor from `1` to `2` therefore forces a
+genuinely larger, structurally different construction: the minimal one
+is a *cross* of two four-point lines sharing a single point.
+
+We use the explicit 7-point set
+
+    X = {(0,0),(1,0),(2,0),(3,0),(0,1),(0,2),(0,3)} ⊂ ℝ²,
+
+the union of the four `x`-axis points and three further `y`-axis points,
+meeting at the origin.  Its two four-point lines are the `x`-axis
+`{(0,0),(1,0),(2,0),(3,0)}` and the `y`-axis
+`{(0,0),(0,1),(0,2),(0,3)}`, giving `fourPointLineCount X ≥ 2`; and it
+has no five collinear points, so `IsLowerBoundConstruction X 2`.
+
+The no-five-collinear proof is powered by two reusable "one rich
+coordinate direction" lemmas about the gallery's determinant
+`collinear`, both fully general (not tied to this witness):
+
+* `collinear_snd_inj` — on a *non-horizontal* line, the second
+  coordinate is injective: two collinear-with-`a,b` points sharing a
+  `y`-value coincide.  Hence a non-horizontal line meets any set with
+  `≤ k` distinct `y`-values in `≤ k` points.
+* `collinear_snd_eq_of_horiz` — on a *horizontal* line (`a.2 = b.2`,
+  `a.1 ≠ b.1`) every collinear point has that same `y`-value.
+
+Since the cross set has only the four `y`-values `{0,1,2,3}`, a
+non-horizontal line hits at most four of its points (one per `y`),
+while a horizontal line hits only the four `x`-axis points; either way
+fewer than five.  This remains a *constant*-size witness: the OPEN
+content is the asymptotic Ω(n^{3/2}) / n^{2−o(1)} growth recorded in the
+two deferred construction theorems above. -/
+
+/-- **Second-coordinate injectivity on a non-horizontal line.**  If `p`
+and `q` are both collinear with the distinct-`y` anchor pair `a, b`
+(`a.2 ≠ b.2`) and share the same second coordinate, they are equal.
+General-purpose collinearity lemma: a non-vertical-direction... more
+precisely a *non-horizontal* line is the graph of `x` as a function of
+`y`, so it meets each horizontal level in at most one point. -/
+theorem collinear_snd_inj {a b p q : ℝ × ℝ} (hp : collinear a b p)
+    (hq : collinear a b q) (hab : a.2 ≠ b.2) (hpq : p.2 = q.2) : p = q := by
+  unfold collinear at hp hq
+  have hb2 : b.2 - a.2 ≠ 0 := sub_ne_zero.mpr (Ne.symm hab)
+  have key : (p.1 - q.1) * (b.2 - a.2) = 0 := by
+    linear_combination hq - hp + (b.1 - a.1) * hpq
+  have hp1 : p.1 = q.1 := sub_eq_zero.mp ((mul_eq_zero.mp key).resolve_right hb2)
+  exact Prod.ext hp1 hpq
+
+/-- **Constant second coordinate on a horizontal line.**  If `a, b` have
+equal second coordinate but distinct first coordinate (a genuinely
+horizontal segment) then every point `p` collinear with `a, b` has that
+same second coordinate. -/
+theorem collinear_snd_eq_of_horiz {a b p : ℝ × ℝ} (hp : collinear a b p)
+    (hab2 : a.2 = b.2) (hab1 : a.1 ≠ b.1) : p.2 = a.2 := by
+  unfold collinear at hp
+  have hb1 : b.1 - a.1 ≠ 0 := sub_ne_zero.mpr (Ne.symm hab1)
+  have key : (b.1 - a.1) * (p.2 - a.2) = 0 := by
+    linear_combination hp - (p.1 - a.1) * hab2
+  exact sub_eq_zero.mp ((mul_eq_zero.mp key).resolve_left hb1)
+
+/-- The explicit 7-point cross: four `x`-axis points and three further
+`y`-axis points, meeting at the origin. -/
+noncomputable def crossPoints : Finset (ℝ × ℝ) :=
+  {(0, 0), (1, 0), (2, 0), (3, 0), (0, 1), (0, 2), (0, 3)}
+
+/-- The four second coordinates occurring in `crossPoints` are exactly
+`{0, 1, 2, 3}`. -/
+theorem crossPoints_snd_mem {p : ℝ × ℝ} (h : p ∈ crossPoints) :
+    p.2 ∈ ({0, 1, 2, 3} : Finset ℝ) := by
+  simp only [crossPoints, Finset.mem_insert, Finset.mem_singleton] at h
+  rcases h with rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    simp
+
+/-- Two distinct points of `crossPoints` with a common second coordinate
+must both lie on the `x`-axis (`y = 0`): the levels `y = 1, 2, 3` each
+contain only one point. -/
+theorem crossPoints_snd_eq_zero_of_ne {p q : ℝ × ℝ} (hp : p ∈ crossPoints)
+    (hq : q ∈ crossPoints) (hne : p ≠ q) (heq : p.2 = q.2) : p.2 = 0 := by
+  simp only [crossPoints, Finset.mem_insert, Finset.mem_singleton] at hp hq
+  rcases hp with rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    rcases hq with rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    first
+      | rfl
+      | (exfalso; apply hne; rfl)
+      | (exfalso; revert heq; norm_num)
+
+/-- A point of `crossPoints` on the `x`-axis is one of the four `x`-axis
+points. -/
+theorem crossPoints_mem_xaxis {p : ℝ × ℝ} (hp : p ∈ crossPoints)
+    (hy : p.2 = 0) : p ∈ ({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)) := by
+  simp only [crossPoints, Finset.mem_insert, Finset.mem_singleton] at hp
+  rcases hp with rfl | rfl | rfl | rfl | rfl | rfl | rfl
+  · simp
+  · simp
+  · simp
+  · simp
+  · exact absurd (show (1 : ℝ) = 0 from hy) (by norm_num)
+  · exact absurd (show (2 : ℝ) = 0 from hy) (by norm_num)
+  · exact absurd (show (3 : ℝ) = 0 from hy) (by norm_num)
+
+/-- The cross set as a `PlanarPointSet`. -/
+noncomputable def crossSet : PlanarPointSet where
+  points := crossPoints
+  size_pos := by
+    rw [crossPoints]
+    apply Finset.card_pos.mpr
+    exact ⟨(0, 0), by simp⟩
+
+/-- **The cross has no five collinear points.**  Any five distinct
+points of the cross lying on a common line contradict its having only
+four distinct `y`-values: a horizontal line hits only the four `x`-axis
+points, and a non-horizontal line hits at most one point per `y`-value
+(`collinear_snd_inj`), i.e. at most four. -/
+theorem crossSet_noFiveCollinear : NoFiveCollinear crossSet := by
+  intro a b c d e ha hb hc hd he hab hac had hae hbc hbd hbe hcd hce hde
+  rintro ⟨hcol_c, hcol_d, hcol_e⟩
+  -- `a` and `b` are themselves collinear with the anchor pair `a, b`.
+  have caa : collinear a b a := by unfold collinear; ring
+  have cab : collinear a b b := by unfold collinear; ring
+  -- membership facts
+  have ha' : a ∈ crossPoints := ha
+  have hb' : b ∈ crossPoints := hb
+  have hc' : c ∈ crossPoints := hc
+  have hd' : d ∈ crossPoints := hd
+  have he' : e ∈ crossPoints := he
+  by_cases hab2 : a.2 = b.2
+  · -- Horizontal line: all five points share the second coordinate `a.2`.
+    have hab1 : a.1 ≠ b.1 := by
+      intro h1; exact hab (Prod.ext h1 hab2)
+    have hb0 : b.2 = a.2 := (collinear_snd_eq_of_horiz cab hab2 hab1)
+    have hc0 : c.2 = a.2 := collinear_snd_eq_of_horiz hcol_c hab2 hab1
+    have hd0 : d.2 = a.2 := collinear_snd_eq_of_horiz hcol_d hab2 hab1
+    have he0 : e.2 = a.2 := collinear_snd_eq_of_horiz hcol_e hab2 hab1
+    -- Two distinct points `a, b` share `y = a.2`, forcing `a.2 = 0`.
+    have hzero : a.2 = 0 :=
+      crossPoints_snd_eq_zero_of_ne ha' hb' hab (by rw [hb0])
+    -- Hence all five lie on the four-point `x`-axis set.
+    have hxset : ({a, b, c, d, e} : Finset (ℝ × ℝ)) ⊆
+        ({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)) := by
+      intro x hx
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+      rcases hx with rfl | rfl | rfl | rfl | rfl
+      · exact crossPoints_mem_xaxis ha' hzero
+      · exact crossPoints_mem_xaxis hb' (by rw [hb0, hzero])
+      · exact crossPoints_mem_xaxis hc' (by rw [hc0, hzero])
+      · exact crossPoints_mem_xaxis hd' (by rw [hd0, hzero])
+      · exact crossPoints_mem_xaxis he' (by rw [he0, hzero])
+    have hcard5 : ({a, b, c, d, e} : Finset (ℝ × ℝ)).card = 5 := by
+      rw [Finset.card_insert_of_notMem]
+      · rw [Finset.card_insert_of_notMem]
+        · rw [Finset.card_insert_of_notMem]
+          · rw [Finset.card_insert_of_notMem]
+            · simp
+            · simp [hde]
+          · simp [hcd, hce]
+        · simp [hbc, hbd, hbe]
+      · simp [hab, hac, had, hae]
+    have hle := Finset.card_le_card hxset
+    rw [hcard5] at hle
+    have h4 : ({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)).card = 4 := by
+      rw [Finset.card_insert_of_notMem]
+      · rw [Finset.card_insert_of_notMem]
+        · rw [Finset.card_insert_of_notMem]
+          · simp
+          · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+        · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+      · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+    rw [h4] at hle
+    omega
+  · -- Non-horizontal line: the second coordinate is injective on the five
+    -- points, so their `y`-values are five distinct elements of `{0,1,2,3}`.
+    have inj : ∀ x y : ℝ × ℝ, collinear a b x → collinear a b y →
+        x ≠ y → x.2 ≠ y.2 := by
+      intro x y hx hy hxy h2
+      exact hxy (collinear_snd_inj hx hy hab2 h2)
+    have yab : a.2 ≠ b.2 := hab2
+    have yac : a.2 ≠ c.2 := inj a c caa hcol_c hac
+    have yad : a.2 ≠ d.2 := inj a d caa hcol_d had
+    have yae : a.2 ≠ e.2 := inj a e caa hcol_e hae
+    have ybc : b.2 ≠ c.2 := inj b c cab hcol_c hbc
+    have ybd : b.2 ≠ d.2 := inj b d cab hcol_d hbd
+    have ybe : b.2 ≠ e.2 := inj b e cab hcol_e hbe
+    have ycd : c.2 ≠ d.2 := inj c d hcol_c hcol_d hcd
+    have yce : c.2 ≠ e.2 := inj c e hcol_c hcol_e hce
+    have yde : d.2 ≠ e.2 := inj d e hcol_d hcol_e hde
+    have hysub : ({a.2, b.2, c.2, d.2, e.2} : Finset ℝ) ⊆
+        ({0, 1, 2, 3} : Finset ℝ) := by
+      intro x hx
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+      rcases hx with rfl | rfl | rfl | rfl | rfl
+      · exact crossPoints_snd_mem ha'
+      · exact crossPoints_snd_mem hb'
+      · exact crossPoints_snd_mem hc'
+      · exact crossPoints_snd_mem hd'
+      · exact crossPoints_snd_mem he'
+    have hycard5 : ({a.2, b.2, c.2, d.2, e.2} : Finset ℝ).card = 5 := by
+      rw [Finset.card_insert_of_notMem]
+      · rw [Finset.card_insert_of_notMem]
+        · rw [Finset.card_insert_of_notMem]
+          · rw [Finset.card_insert_of_notMem]
+            · simp
+            · simp [yde]
+          · simp [ycd, yce]
+        · simp [ybc, ybd, ybe]
+      · simp [yab, yac, yad, yae]
+    have hle := Finset.card_le_card hysub
+    rw [hycard5] at hle
+    have h4 : ({0, 1, 2, 3} : Finset ℝ).card = 4 := by
+      rw [Finset.card_insert_of_notMem]
+      · rw [Finset.card_insert_of_notMem]
+        · rw [Finset.card_insert_of_notMem]
+          · simp
+          · norm_num
+        · norm_num
+      · norm_num
+    rw [h4] at hle
+    omega
+
+/-- The cross has at least two four-point lines: the `x`-axis
+`{(0,0),(1,0),(2,0),(3,0)}` and the `y`-axis `{(0,0),(0,1),(0,2),(0,3)}`
+are two distinct four-element collinear subsets. -/
+theorem crossSet_fourPointLineCount_ge_two :
+    2 ≤ fourPointLineCount crossSet := by
+  rw [fourPointLineCount]
+  -- The predicate defining membership of the powerset-filter.
+  set Q : Finset (ℝ × ℝ) → Prop := fun S =>
+    S.card = 4 ∧ ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧
+      ∀ p ∈ S, collinear a b p with hQ
+  -- The two witness lines.
+  have hx_mem : ({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)) ∈
+      crossSet.points.powerset.filter Q := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨?_, ?_, (0, 0), (1, 0), ?_, ?_, ?_, ?_⟩
+    · intro x hx
+      show x ∈ crossPoints
+      rw [crossPoints]
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hx ⊢
+      tauto
+    · rw [Finset.card_insert_of_notMem]
+      · rw [Finset.card_insert_of_notMem]
+        · rw [Finset.card_insert_of_notMem]
+          · simp
+          · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+        · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+      · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+    · simp
+    · simp
+    · norm_num [Prod.ext_iff]
+    · intro p hp
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+      rcases hp with rfl | rfl | rfl | rfl <;> simp [collinear]
+  have hy_mem : ({(0, 0), (0, 1), (0, 2), (0, 3)} : Finset (ℝ × ℝ)) ∈
+      crossSet.points.powerset.filter Q := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨?_, ?_, (0, 0), (0, 1), ?_, ?_, ?_, ?_⟩
+    · intro x hx
+      show x ∈ crossPoints
+      rw [crossPoints]
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hx ⊢
+      tauto
+    · rw [Finset.card_insert_of_notMem]
+      · rw [Finset.card_insert_of_notMem]
+        · rw [Finset.card_insert_of_notMem]
+          · simp
+          · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+        · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+      · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+    · simp
+    · simp
+    · norm_num [Prod.ext_iff]
+    · intro p hp
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+      rcases hp with rfl | rfl | rfl | rfl <;> simp [collinear]
+  -- The two lines are distinct: `(1,0)` is on the `x`-axis but not the `y`-axis.
+  have hne : ({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)) ≠
+      ({(0, 0), (0, 1), (0, 2), (0, 3)} : Finset (ℝ × ℝ)) := by
+    intro h
+    have : ((1, 0) : ℝ × ℝ) ∈ ({(0, 0), (0, 1), (0, 2), (0, 3)} : Finset (ℝ × ℝ)) := by
+      rw [← h]; simp
+    simp only [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff] at this
+    norm_num at this
+  -- A two-element subset of the filter gives card ≥ 2.
+  have hsub : ({({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)),
+      ({(0, 0), (0, 1), (0, 2), (0, 3)} : Finset (ℝ × ℝ))} :
+      Finset (Finset (ℝ × ℝ))) ⊆ crossSet.points.powerset.filter Q := by
+    intro S hS
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hS
+    rcases hS with rfl | rfl
+    · exact hx_mem
+    · exact hy_mem
+  have hpair : ({({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)),
+      ({(0, 0), (0, 1), (0, 2), (0, 3)} : Finset (ℝ × ℝ))} :
+      Finset (Finset (ℝ × ℝ))).card = 2 := Finset.card_pair hne
+  have hle := Finset.card_le_card hsub
+  rw [hpair] at hle
+  exact hle
+
+/-- **Framework floor ≥ 2** (this session's deliverable).  The explicit
+7-point cross set is a no-five-collinear planar point set with at least
+two four-point lines: `IsLowerBoundConstruction crossSet 2`.  This
+strictly raises the framework floor above the single-line
+`witnessSet_isLowerBoundConstruction`, and — because two four-point lines
+cannot share more than one point — cannot be realized by any set of
+fewer than seven points.  The construction remains *constant* in size;
+the asymptotic growth of `fourPointLineCount` is the OPEN content of
+`grunbaum_lower_bound_three_halves` and `solymosi_stojakovic_lower_bound`. -/
+theorem crossSet_isLowerBoundConstruction :
+    IsLowerBoundConstruction crossSet 2 :=
+  ⟨crossSet_noFiveCollinear, by exact_mod_cast crossSet_fourPointLineCount_ge_two⟩
+
+/-- **The framework floor reaches at least two.**  There is a
+no-five-collinear planar point set of exactly seven points that is a
+lower-bound construction for threshold `2` — two four-point lines.  With
+`exists_isLowerBoundConstruction_pos` (floor `1`, five points) this shows
+the `IsLowerBoundConstruction` threshold is not pinned at the minimal
+non-vacuous value. -/
+theorem exists_isLowerBoundConstruction_two :
+    ∃ P : PlanarPointSet, P.points.card = 7 ∧ IsLowerBoundConstruction P 2 :=
+  ⟨crossSet, by
+    show crossPoints.card = 7
+    rw [crossPoints]
+    -- seven distinct points
+    repeat rw [Finset.card_insert_of_notMem
+      (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff])]
+    simp, crossSet_isLowerBoundConstruction⟩
+
 end Erdos101OQ04

--- a/research/problems/erdos101-problem-oq-04/sessions/2026-07-01-cross-floor2.md
+++ b/research/problems/erdos101-problem-oq-04/sessions/2026-07-01-cross-floor2.md
@@ -1,0 +1,53 @@
+# Session 2026-07-01 (researcher-4) — framework floor 1 → 2
+
+## Deliverable
+
+`IsLowerBoundConstruction crossSet 2`: an explicit, 0-axiom,
+no-five-collinear planar point set with **two** four-point lines.
+
+The witness is the 7-point *cross*
+
+    crossSet = {(0,0),(1,0),(2,0),(3,0),(0,1),(0,2),(0,3)} ⊂ ℝ²,
+
+the union of the four `x`-axis points and three further `y`-axis points
+meeting at the origin.  Its `x`-axis and `y`-axis are two distinct
+four-element collinear subsets, so `fourPointLineCount crossSet ≥ 2`,
+and it has no five collinear points.
+
+## Why this is a genuine step, not padding
+
+Two distinct four-point lines meet in ≤ 1 point, so together they need
+≥ `4 + 4 − 1 = 7` distinct points.  Consequently **no five-point set
+carries two four-point lines**, and the prior floor-`1` witness
+(`witnessSet`, 5 points) is size-optimal.  Raising the floor to `2`
+therefore forces a strictly larger, structurally different construction.
+
+## Reusable lemmas extracted
+
+- `collinear_snd_inj` — on a non-horizontal line (`a.2 ≠ b.2`) the map
+  `point ↦ y` is injective among points collinear with `a, b`; i.e. the
+  line is a graph over `y` and meets each horizontal level once.
+- `collinear_snd_eq_of_horiz` — on a horizontal segment every collinear
+  point shares that `y`.
+
+These drive a clean uniform `NoFiveCollinear` proof: a horizontal line
+hits only the four `x`-axis points; a non-horizontal line hits ≤ 1 point
+per `y`-value, and the cross has only the four `y`-values `{0,1,2,3}`.
+
+## Verification
+
+Direct `lean` v4.26.0 compile (Docker corrupted host-wide). Recipe:
+`LEAN_PATH` = all `.lake/packages/*/.lake/build/lib/lean` + main-repo
+`.lake/build/lib/lean`; pre-build `Proofs.Erdos101OQ01` into a temp
+root placed first on `LEAN_PATH`; compile `Proofs/Erdos101OQ04.lean`.
+0 errors; `#print axioms crossSet_isLowerBoundConstruction =
+[propext, Classical.choice, Quot.sound]` ⇒ 0-axiom VERIFIED (no
+`sorryAx`, no `Lean.ofReduceBool`).
+
+## Still OPEN
+
+The asymptotic growth of `fourPointLineCount` — Ω(n^{3/2})
+(`grunbaum_lower_bound_three_halves`) and n^{2−o(1)}
+(`solymosi_stojakovic_lower_bound`) — remains the open content, both
+still `sorry`-bodied. The next brick is the sumset/grid four-collinear
+count over the verified parabola arc (S3-B2-β).

--- a/research/problems/erdos101-problem-oq-04/state.md
+++ b/research/problems/erdos101-problem-oq-04/state.md
@@ -1,9 +1,95 @@
 # Current State
 
-**Phase**: ACT (S3-B1 — Grünbaum F_p² parabola + cardinality; build pending)
-**Since**: 2026-05-16T11:00:00Z
-**Last Updated**: 2026-05-16 (Iteration 3, researcher-3)
-**Iteration**: 3
+**Phase**: ACT (framework floor raised to 2 four-point lines; direct-lean-verified)
+**Since**: 2026-07-01
+**Last Updated**: 2026-07-01 (Iteration 7, researcher-4)
+**Iteration**: 7
+
+> Note: the S3-B2/B3 parabola-arc infrastructure (secant bound, ℝ²
+> realization, arc `fourPointLineCount = 0`) and the non-vacuity
+> witness (`witnessSet`, floor `1`) landed in later iterations (4–6,
+> researcher-8/6) than the entries below record; the file is ahead of
+> the older iteration logs.
+
+## Iteration 7 (researcher-4, 2026-07-01) — raise framework floor 1 → 2
+
+**Outcome**: `IsLowerBoundConstruction crossSet 2` — an explicit,
+0-axiom, no-five-collinear planar point set with **two** four-point
+lines, strictly above the prior single-line `witnessSet` floor.  Build
+verified by direct `lean` v4.26.0 compile (Docker fallback);
+`#print axioms crossSet_isLowerBoundConstruction =
+[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no
+`native_decide`/`Lean.ofReduceBool`) ⇒ 0-axiom VERIFIED.
+
+### What I added (all in `proofs/Proofs/Erdos101OQ04.lean`, +~330 LOC)
+
+1. **`collinear_snd_inj`** (PROVED, axiom-free, reusable) — on a
+   *non-horizontal* line (`a.2 ≠ b.2`) the second coordinate is
+   injective among points collinear with `a, b`: two such points
+   sharing a `y`-value coincide.  Hence a non-horizontal line meets any
+   set with `≤ k` distinct `y`-values in `≤ k` points.
+2. **`collinear_snd_eq_of_horiz`** (PROVED, axiom-free, reusable) — on a
+   *horizontal* line (`a.2 = b.2`, `a.1 ≠ b.1`) every collinear point
+   shares that `y`-value.
+3. **`crossPoints`** / **`crossSet`** (defs) — the explicit 7-point
+   cross `{(0,0),(1,0),(2,0),(3,0),(0,1),(0,2),(0,3)}` ⊂ ℝ² and its
+   `PlanarPointSet` wrapper.
+4. **`crossPoints_snd_mem` / `crossPoints_snd_eq_zero_of_ne` /
+   `crossPoints_mem_xaxis`** (PROVED) — the three membership/case
+   lemmas: the cross's `y`-values are exactly `{0,1,2,3}`; two distinct
+   points with equal `y` must be on the `x`-axis (`y=0`); an `x`-axis
+   point is one of the four.
+5. **`crossSet_noFiveCollinear`** (PROVED) — no five collinear: a
+   horizontal line hits only the four `x`-axis points; a non-horizontal
+   line hits `≤ 1` point per `y`-value (via `collinear_snd_inj`) and the
+   cross has only four distinct `y`-values, so `≤ 4` either way.
+6. **`crossSet_fourPointLineCount_ge_two`** (PROVED) — the `x`-axis and
+   `y`-axis are two distinct four-element collinear subsets, so
+   `fourPointLineCount crossSet ≥ 2`.
+7. **`crossSet_isLowerBoundConstruction`** (PROVED) —
+   `IsLowerBoundConstruction crossSet 2`.
+8. **`exists_isLowerBoundConstruction_two`** (PROVED) — there is a
+   no-five-collinear set of exactly seven points achieving threshold 2.
+
+### Why 7 points, and why this is not trivial padding
+
+Two distinct four-point lines meet in at most one point, so together
+they need at least `4 + 4 − 1 = 7` distinct points; equivalently, **no
+five-point set has two four-point lines**.  The prior floor-`1` witness
+(`witnessSet`, five points) is therefore optimal for its size, and
+raising the floor to `2` genuinely requires a larger, structurally
+different construction (a *cross* of two lines rather than a single
+line).  The two collinearity lemmas isolate the reusable geometric
+content (a non-horizontal line is a graph over `y`).
+
+### Counts
+
+- Theorems: +9 PROVED axiom-free (cumulative file total 35).
+- Definitions: +2 (`crossPoints`, `crossSet`).
+- Sorries: 2 unchanged (both OPEN constructions; no new sorries).
+- Axioms: 0 unchanged.
+
+### Honest scope / what remains OPEN
+
+This is a **constant**-size witness (floor `2`, seven points).  It does
+**not** touch the asymptotic OPEN content: `fourPointLineCount` growing
+like Ω(n^{3/2}) (`grunbaum_lower_bound_three_halves`) or n^{2−o(1)}
+(`solymosi_stojakovic_lower_bound`).  The natural next brick toward
+those is the sumset/grid four-collinear COUNT built on top of the
+verified parabola arc (S3-B2-β), still the crux and still hard.
+
+### Build note
+
+Docker daemon corrupted (containerd meta.db I/O, host-wide — see prior
+researcher memos).  Verified via direct `lean` compile: reconstruct
+`LEAN_PATH` over every `.lake/packages/*/.lake/build/lib/lean` dir plus
+the main repo `.lake/build/lib/lean`, pre-compile the `Proofs.Erdos101OQ01`
+dependency (its own `Erdos101Problem` olean already built) into a temp
+root placed **first** on `LEAN_PATH`, then compile
+`Proofs/Erdos101OQ04.lean` (≈5 s).  0 errors; only the 2 expected
+pre-existing sorry warnings.
+
+---
 
 ## Iteration 3 (researcher-3, 2026-05-16) — S3-B1 ACT (Grünbaum parabola foundation)
 

--- a/src/data/research/problems/erdos101-problem-oq-04.json
+++ b/src/data/research/problems/erdos101-problem-oq-04.json
@@ -34,9 +34,9 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-22",
-    "iteration": 6,
-    "focus": "S3-B3 ACT iteration 6 (researcher-8, 2026-06-22) — Docker-verified build (0 errors; #print axioms = [propext, Classical.choice, Quot.sound] only ⇒ 0-axiom verified, no native_decide). **Formalized the honest scope of the realized ℝ² arc**: added `realParabolaSet_fourPointLineCount_zero` (p ≠ 2) proving `fourPointLineCount (realParabolaSet p hp) = 0`. Being an arc (no three collinear), a fortiori no four of its points lie on a common line. The proof unfolds `fourPointLineCount` to an empty filtered powerset: any candidate 4-set on a line through a ≠ b must contain a third point c (card argument via Finset.card_pair), contradicting `realParabola_no_three_collinear`. This makes explicit in Lean that the bare general-position base is NOT a four-point-line lower-bound witness — the Ω(p^{3/2}) count must come from the sumset/grid construction built ON TOP of this arc. Net: +1 PROVED theorem, 0 axioms, 0 new sorries; the 2 pre-existing OPEN-construction sorries (grunbaum_lower_bound_three_halves, solymosi_stojakovic_lower_bound) remain.",
+    "since": "2026-07-01",
+    "iteration": 7,
+    "focus": "S3-witness ACT iteration 7 (researcher-4, 2026-07-01) — direct-lean-verified build (lean v4.26.0; #print axioms crossSet_isLowerBoundConstruction = [propext, Classical.choice, Quot.sound] only ⇒ 0-axiom VERIFIED, no sorryAx, no native_decide). **Raised the framework floor from 1 to 2 four-point lines** with an explicit 7-point 'cross' construction crossSet = {(0,0),(1,0),(2,0),(3,0),(0,1),(0,2),(0,3)}: the x-axis and y-axis are two distinct four-point lines, giving fourPointLineCount ≥ 2, and it has no five collinear points ⇒ IsLowerBoundConstruction crossSet 2. Because two distinct four-point lines meet in ≤1 point, this floor cannot be realized by fewer than 7 points (five-point sets carry ≤1 four-point line), so the jump 1→2 forces a genuinely larger, structurally different witness. Added two reusable general collinearity lemmas: collinear_snd_inj (on a non-horizontal line the 2nd coordinate is injective ⇒ ≤1 point per y-level) and collinear_snd_eq_of_horiz (a horizontal line's points all share that y). The no-five proof: a horizontal line hits only the 4 x-axis points; a non-horizontal line hits ≤1 per y-value and crossSet has only 4 distinct y-values {0,1,2,3}. Net: +9 PROVED theorems, +2 defs, 0 axioms, 0 new sorries; the 2 pre-existing OPEN-construction sorries (grunbaum_lower_bound_three_halves, solymosi_stojakovic_lower_bound) remain — the asymptotic Ω(n^{3/2}) / n^{2−o(1)} growth is still the OPEN content.",
     "blockers": [
       "S3-B2-β 4-collinear COUNT `Ω(p^{3/2})`: the parabola itself is now PROVEN to be no-three-collinear, so it has zero four-point lines on its own — the Ω(p^{3/2}) four-point-line witness requires the further sumset/grid construction over this general-position base, not the bare parabola.",
       "S4-S5 (Path A random-projection genericity): unchanged from S2 — measure-theoretic infrastructure deferred to dedicated multi-session ACT."
@@ -54,6 +54,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos101Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos101OQ04.lean",
+      "filename": "Erdos101OQ04.lean",
+      "lineCount": 1158,
+      "theoremCount": 35,
+      "axiomCount": 0,
+      "defCount": 10,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos101OQ04.lean"
     }
   ],
   "knowledge": {
@@ -150,7 +161,7 @@
     "sourceTitle": "Erdős Problem #101: Four-Point Lines from Planar Point Sets",
     "sourceType": "open-question"
   },
-  "lastUpdate": "2026-06-22T13:00:00.000Z",
+  "lastUpdate": "2026-07-01T14:00:00.000Z",
   "relatedProofs": [
     "erdos-101",
     "erdos101-problem"


### PR DESCRIPTION
## Summary

Raises the `IsLowerBoundConstruction` framework floor for Erdős #101
OQ-04 (four-point lines from planar point sets) from **1 to 2**
four-point lines, with an explicit, fully machine-checked, **0-axiom**
witness.

The witness is the 7-point *cross*

    crossSet = {(0,0),(1,0),(2,0),(3,0),(0,1),(0,2),(0,3)} ⊂ ℝ²,

the union of the four `x`-axis points and three further `y`-axis points
meeting at the origin. Its `x`-axis and `y`-axis are two distinct
four-element collinear subsets, so `fourPointLineCount crossSet ≥ 2`,
and it has no five collinear points ⇒ `IsLowerBoundConstruction crossSet 2`.

## Why this is a genuine step (not padding)

Two distinct four-point lines meet in ≤ 1 point, so together they need
≥ `4 + 4 − 1 = 7` distinct points. Hence **no five-point set carries two
four-point lines** — the prior floor-`1` witness (`witnessSet`, 5 points)
is size-optimal, and raising the floor to `2` forces a strictly larger,
structurally different construction.

## New declarations (`proofs/Proofs/Erdos101OQ04.lean`, +9 theorems / +2 defs)

- `collinear_snd_inj` — reusable: on a non-horizontal line (`a.2 ≠ b.2`)
  the second coordinate is injective among collinear-with-`a,b` points
  (the line is a graph over `y`).
- `collinear_snd_eq_of_horiz` — reusable: on a horizontal segment every
  collinear point shares that `y`.
- `crossPoints`, `crossSet` (defs) + membership lemmas
  `crossPoints_snd_mem`, `crossPoints_snd_eq_zero_of_ne`,
  `crossPoints_mem_xaxis`.
- `crossSet_noFiveCollinear`, `crossSet_fourPointLineCount_ge_two`,
  `crossSet_isLowerBoundConstruction`, `exists_isLowerBoundConstruction_two`.

`NoFiveCollinear` proof: a horizontal line hits only the 4 `x`-axis
points; a non-horizontal line hits ≤ 1 point per `y`-value and the cross
has only the four `y`-values `{0,1,2,3}` — so ≤ 4 either way.

## Verification

Direct `lean` v4.26.0 compile (Docker daemon corrupted host-wide;
containerd meta.db I/O). 0 errors; only the 2 expected pre-existing
sorry warnings. `#print axioms crossSet_isLowerBoundConstruction =
[propext, Classical.choice, Quot.sound]` only — **no `sorryAx`, no
`native_decide`/`Lean.ofReduceBool`** ⇒ 0-axiom VERIFIED.

- +9 PROVED theorems, +2 defs, **0 axioms, 0 new sorries**.

## Scope — what remains OPEN

This is a **constant**-size witness. The asymptotic growth of
`fourPointLineCount` — Ω(n^{3/2}) (`grunbaum_lower_bound_three_halves`)
and n^{2−o(1)} (`solymosi_stojakovic_lower_bound`) — remains the open
content, both still `sorry`-bodied. Next brick: the sumset/grid
four-collinear count over the verified parabola arc (S3-B2-β).

🤖 Generated with [Claude Code](https://claude.com/claude-code)