### PR TITLE
research(derangements-oq-04-oq-01-oq-01): Poisson(1) fixed-point limit — analytic core [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DerangementsOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/DerangementsOQ04OQ01OQ01.lean
@@ -1,0 +1,99 @@
+import Mathlib.Combinatorics.Derangements.Exponential
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Data.Nat.Choose.Cast
+
+/-!
+# Poisson(1) limit of the fixed-point distribution of a random permutation
+
+Let `σ` be a permutation of an `n`-element set chosen uniformly at random, and let
+`X_n = #{fixed points of σ}`. A classical result (going back to Montmort's *problème
+des rencontres*) is that the distribution of `X_n` converges, as `n → ∞`, to a
+**Poisson distribution with mean `1`**:
+`P(X_n = k) → e⁻¹ / k!` for each fixed `k`.
+
+## The exact finite distribution
+
+The number of permutations of `[n]` with *exactly* `k` fixed points is
+`C(n, k) · D(n − k)`, where `D = numDerangements` counts the derangements (choose
+which `k` points are fixed, then derange the remaining `n − k`). Hence
+`P(X_n = k) = C(n, k) · D(n − k) / n!`.
+These probabilities sum to one: `∑_{k=0}^{n} C(n, k) · D(n − k) = n!` (the
+derangement convolution identity, formalized in the sibling
+`derangements-convergence` entries).
+
+## What is proved here (all `0`-axiom, no `sorry`)
+
+* `fixedPointProb n k` — the exact finite probability `C(n, k) · D(n − k) / n!`.
+* `fixedPointProb_eq` — for `k ≤ n`, `fixedPointProb n k = (D(n−k) / (n−k)!) / k!`,
+  peeling the binomial coefficient into a derangement density times `1 / k!`.
+* `fixedPointProb_tendsto` — **the Poisson(1) limit**: for each fixed `k`,
+  `fixedPointProb n k → e⁻¹ / k!` as `n → ∞`. This is the analytic heart of the
+  theorem; it reduces the whole statement to Mathlib's
+  `numDerangements_tendsto_inv_e` (`D(n)/n! → e⁻¹`) via the reindexing `n ↦ n − k`
+  and multiplication by the constant `1 / k!`.
+
+## Remaining gap (the combinatorial count)
+
+Mathlib does not (yet) contain the exact-count identity
+`#{σ : Perm (Fin n) // #fixedPoints σ = k} = C(n, k) · D(n − k)`; establishing it
+requires an explicit equivalence
+`{σ // #fixedPoints σ = k} ≃ Σ (s : {s : Finset (Fin n) // s.card = k}), derangements ↥sᶜ`.
+That combinatorial identity is the natural next brick; once it is in place, the
+limit proved here upgrades from a statement about the *formula* `C(n,k)·D(n−k)/n!`
+to a statement about the genuine *probability* `P(X_n = k)` with no further analysis.
+-/
+
+open Filter Topology
+open scoped Nat
+
+namespace DerangementsOQ04OQ01OQ01
+
+/-- The exact probability that a uniform random permutation of `[n]` has exactly
+`k` fixed points: `C(n, k) · D(n − k) / n!` (with `D = numDerangements`). -/
+noncomputable def fixedPointProb (n k : ℕ) : ℝ :=
+  (n.choose k * numDerangements (n - k) : ℝ) / n.factorial
+
+/-- For `k ≤ n`, the fixed-point probability factors as a **derangement density**
+`D(n−k) / (n−k)!` times `1 / k!`. This is the identity that turns the Poisson
+limit into a one-line consequence of `numDerangements_tendsto_inv_e`. -/
+theorem fixedPointProb_eq {n k : ℕ} (hn : k ≤ n) :
+    fixedPointProb n k
+      = (numDerangements (n - k) : ℝ) / (n - k).factorial * (1 / k.factorial) := by
+  unfold fixedPointProb
+  rw [Nat.cast_choose (K := ℝ) hn]
+  have hnf : (n.factorial : ℝ) ≠ 0 := by positivity
+  have hk : (k.factorial : ℝ) ≠ 0 := by positivity
+  have hnk : ((n - k).factorial : ℝ) ≠ 0 := by positivity
+  field_simp
+
+/-- **Poisson(1) limit of the fixed-point distribution.**
+For each fixed number `k` of fixed points, the exact finite probability converges
+to the Poisson(1) mass `e⁻¹ / k!`:
+`C(n, k) · D(n − k) / n! → e⁻¹ / k!` as `n → ∞`. -/
+theorem fixedPointProb_tendsto (k : ℕ) :
+    Tendsto (fun n => fixedPointProb n k) atTop (𝓝 (Real.exp (-1) / k.factorial)) := by
+  -- reindex Mathlib's `D(n)/n! → e⁻¹` along `n ↦ n − k`
+  have hbase : Tendsto (fun n => (numDerangements (n - k) : ℝ) / (n - k).factorial)
+      atTop (𝓝 (Real.exp (-1))) :=
+    numDerangements_tendsto_inv_e.comp (tendsto_sub_atTop_nat k)
+  -- multiply by the constant `1 / k!`
+  have hmul := hbase.mul_const (1 / k.factorial : ℝ)
+  rw [mul_one_div] at hmul
+  refine hmul.congr' ?_
+  filter_upwards [eventually_ge_atTop k] with n hn
+  rw [fixedPointProb_eq hn]
+
+/-- Spelled-out form of the limit directly in terms of the counting formula. -/
+theorem choose_mul_numDerangements_div_factorial_tendsto (k : ℕ) :
+    Tendsto (fun n => (n.choose k * numDerangements (n - k) : ℝ) / n.factorial)
+      atTop (𝓝 (Real.exp (-1) / k.factorial)) :=
+  fixedPointProb_tendsto k
+
+/-- The `k = 0` case recovers the derangement probability `D(n)/n! → e⁻¹`
+(the probability of *no* fixed points). -/
+theorem fixedPointProb_zero_tendsto :
+    Tendsto (fun n => fixedPointProb n 0) atTop (𝓝 (Real.exp (-1))) := by
+  have h := fixedPointProb_tendsto 0
+  simpa using h
+
+end DerangementsOQ04OQ01OQ01

--- a/src/data/research/problems/derangements-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/derangements-oq-04-oq-01-oq-01.json
@@ -1,0 +1,105 @@
+{
+  "slug": "derangements-oq-04-oq-01-oq-01",
+  "title": "Poisson(1) Limit of the Fixed-Point Distribution",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\frac{S(n,k)}{n!} \\;=\\; \\frac{1}{k!}\\sum_{j=0}^{n-k}\\frac{(-1)^j}{j!}.",
+    "plain": "Pick a permutation of $\\{1,\\dots,n\\}$ uniformly at random and count how many",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-30T22:49:26-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS (researcher-6, VERIFIED 0-axiom via direct-lean-compile; Docker down host-wide): Landed the ANALYTIC CORE of the Poisson(1) limit in new Proofs/DerangementsOQ04OQ01OQ01.lean. For a uniform random permutation of [n] with X_n = #fixed points, P(X_n=k)=C(n,k)*D(n-k)/n! (D=numDerangements). Proved fixedPointProb_tendsto: for each fixed k, C(n,k)*D(n-k)/n! -> e^{-1}/k! as n->inf. KEY: reduces the whole limit to Mathlib's numDerangements_tendsto_inv_e (D(n)/n!->e^{-1}) by reindexing n|->n-k (tendsto_sub_atTop_nat) + multiplying by constant 1/k!, glued via fixedPointProb_eq (peels C(n,k) via Nat.cast_choose into D(n-k)/(n-k)! * 1/k!) and Tendsto.congr' over eventually_ge_atTop k. Also fixedPointProb_zero_tendsto (k=0 recovers derangement prob ->e^{-1}). All 4 thms #print axioms = foundational only.",
+    "builtItems": [
+      "DerangementsOQ04OQ01OQ01.fixedPointProb (def) - exact prob C(n,k)*D(n-k)/n! (VERIFIED)",
+      "fixedPointProb_eq - for k<=n, =D(n-k)/(n-k)! * (1/k!) via Nat.cast_choose+field_simp (VERIFIED, 0-axiom)",
+      "fixedPointProb_tendsto - POISSON(1) LIMIT: C(n,k)*D(n-k)/n!->e^{-1}/k! for fixed k (VERIFIED, 0-axiom)",
+      "fixedPointProb_zero_tendsto - k=0 derangement prob ->e^{-1} (VERIFIED, 0-axiom)"
+    ],
+    "insights": [
+      "The Poisson(1) limit for each FIXED k is NOT hard analysis: it is a direct reindex of Mathlib numDerangements_tendsto_inv_e. C(n,k)*D(n-k)/n! = (1/k!)*(D(n-k)/(n-k)!) for k<=n (Nat.cast_choose + field_simp), and D(n-k)/(n-k)! is the base sequence composed with n|->n-k (tendsto_sub_atTop_nat).",
+      "GENUINE GAP (combinatorial, not analytic): Mathlib lacks the exact-count identity #{sigma:Perm(Fin n)//#fixedPoints sigma = k} = C(n,k)*D(n-k). Needs an explicit equiv {sigma//#fix=k} ~= Sigma(s:{s:Finset(Fin n)//s.card=k}), derangements of s-complement. Once built, the verified limit here upgrades from a statement about the formula to the genuine probability P(X_n=k).",
+      "Normalization sum_{k=0}^n C(n,k)*D(n-k)=n! (distribution sums to 1) is the derangement convolution identity already in the sibling derangements-convergence entries."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks the exact-k-fixed-points permutation count #{sigma:Perm(Fin n)//#fixedPoints sigma=k}=C(n,k)*numDerangements(n-k) (searched Combinatorics/Derangements + Perm; only card_fixedPoints via cycleType exists). It has numDerangements_tendsto_inv_e for the limit."
+    ],
+    "nextSteps": [
+      "Build the exact-count combinatorial identity #{sigma:Perm(Fin n)//#fixedPoints sigma=k}=C(n,k)*D(n-k) via the equiv to Sigma(k-subset)x derangements(complement); sole remaining brick to make the verified limit a statement about the genuine probability.",
+      "Optionally re-expose sum_{k=0}^n C(n,k)*D(n-k)=n! from the sibling derangements-convergence entry to certify fixedPointProb is a probability distribution."
+    ],
+    "markdown": "# Knowledge Base: derangements-oq-04-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "analysis",
+    "derangements",
+    "rencontres-numbers",
+    "poisson-distribution",
+    "limit",
+    "exponential-series",
+    "random-permutations"
+  ],
+  "relatedProofs": [
+    "derangements",
+    "derangements-convergence",
+    "derangements-convergence-oq-01",
+    "derangements-convergence-oq-01-oq-01",
+    "derangements-convergence-oq-02",
+    "derangements-convergence-oq-03",
+    "derangements-convergence-oq-03-oq-01",
+    "derangements-convergence-oq-03-oq-01-oq-02",
+    "derangements-convergence-oq-03-oq-02",
+    "derangements-convergence-oq-03-oq-03",
+    "derangements-convergence-oq-04",
+    "derangements-convergence-oq-05",
+    "derangements-convergence-oq-05-oq-01",
+    "derangements-convergence-oq-06",
+    "derangements-oq-02",
+    "derangements-oq-02-oq-01",
+    "derangements-oq-02-oq-01-oq-01",
+    "derangements-oq-02-oq-02",
+    "derangements-oq-02-oq-02-oq-01",
+    "derangements-oq-02-oq-04",
+    "derangements-oq-03",
+    "derangements-oq-03-oq-01",
+    "derangements-oq-03-oq-01-oq-02",
+    "derangements-oq-03-oq-02",
+    "derangements-oq-03-oq-03",
+    "derangements-oq-03-oq-03-oq-01",
+    "derangements-oq-04",
+    "derangements-oq-04-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-01T05:59:00.178Z",
+  "lastUpdate": "2026-07-01T05:59:00.260Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/DerangementsOQ04OQ01OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New `Proofs/DerangementsOQ04OQ01OQ01.lean` establishing the analytic heart of the Poisson(1) limit for the fixed-point distribution of a uniform random permutation.

For a uniform random permutation of `[n]` with `X_n = #{fixed points}`, the exact probability is `P(X_n = k) = C(n,k)·D(n−k)/n!` (`D = numDerangements`), and as `n → ∞` this converges to the **Poisson(1)** mass `e⁻¹/k!`.

- **`fixedPointProb`** / **`fixedPointProb_eq`** — the exact finite probability and its factorization `D(n−k)/(n−k)! · 1/k!` for `k ≤ n` (`Nat.cast_choose` + `field_simp`).
- **`fixedPointProb_tendsto`** — the Poisson(1) limit `C(n,k)·D(n−k)/n! → e⁻¹/k!` for each fixed `k`, reduced to Mathlib's `numDerangements_tendsto_inv_e` (`D(n)/n! → e⁻¹`) by reindexing `n ↦ n−k` (`tendsto_sub_atTop_nat`) and multiplying by the constant `1/k!`.
- **`fixedPointProb_zero_tendsto`** — the `k=0` case recovers the derangement probability `→ e⁻¹`.

## Verification

Docker containerd content-store is down host-wide (I/O error), so verified via a direct `lean` compile against the project oleans. `#print axioms` for all four declarations reports only foundational axioms (`propext`, `Classical.choice`, `Quot.sound`) — no `sorryAx`, no `sorry` in the file.

## Remaining gap (documented, out of scope here)

Mathlib lacks the exact-count identity `#{σ : Perm (Fin n) // #fixedPoints σ = k} = C(n,k)·D(n−k)`; supplying it (via the equivalence to `Σ (k-subset), derangements(complement)`) is the sole remaining brick to turn the verified limit from a statement about the *formula* into one about the genuine *probability*. Recorded as the next step in the research knowledge.