### PR TITLE
Enrich Paley-Zygmund (measure-theoretic): add annotations.json

### DIFF
--- a/src/data/proofs/prob-method-second-moment-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01-oq-03/annotations.json
@@ -1,0 +1,141 @@
+[
+  {
+    "id": "ann-pzm-header",
+    "proofId": "prob-method-second-moment-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 40
+    },
+    "type": "context",
+    "title": "Lifting Paley-Zygmund to the Measure-Theoretic Framework",
+    "content": "The header frames this file as the answer to the open question left by the parent `prob-method-second-moment-oq-01`, which proves Paley-Zygmund only over finite Finsets with ℚ-valued functions. Here the statement is upgraded to Mathlib's general `MeasureTheory`/`ProbabilityTheory` setting: an arbitrary probability space, the Bochner integral for expectation, and honest measures of threshold events. The imports are deliberately narrow — the Bochner integral over sets, Lᵖ spaces, conjugate exponents, and real `rpow` — rather than the umbrella `import Mathlib`, keeping the dependency footprint explicit. Mathlib already has Hölder for integrals and Markov/Chebyshev, but no packaged measure-theoretic Paley-Zygmund; this file supplies exactly that missing piece.",
+    "mathContext": "Target: $(1-\\theta)^2\\,(\\mathbb{E}[Z])^2 \\le \\mathbb{P}(Z > \\theta\\,\\mathbb{E}[Z])\\cdot\\mathbb{E}[Z^2]$ on a probability space, versus the parent's finite form $(1-\\theta)^2(\\sum f)^2 \\le |\\{f>\\theta\\mu\\}|\\cdot\\sum f^2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "second moment method",
+      "Paley-Zygmund 1932",
+      "Bochner integral",
+      "ProbabilityTheory API"
+    ],
+    "prerequisites": [
+      "measure theory",
+      "Lᵖ spaces",
+      "expectation as integral"
+    ]
+  },
+  {
+    "id": "ann-pzm-rpow-half-sq",
+    "proofId": "prob-method-second-moment-oq-01-oq-03",
+    "range": {
+      "startLine": 46,
+      "endLine": 49
+    },
+    "type": "technique",
+    "title": "Square-Root Cancellation Helper: (x^(1/2))² = x",
+    "content": "The private lemma `rpow_half_sq` cancels a square against a real one-half power: for $0 \\le x$, $(x^{1/2})^2 = x$. It is proved by rewriting the outer natural-number square as an `rpow` (`Real.rpow_natCast`), then merging the two exponents with `Real.rpow_mul` (which needs the base non-negative) so that $x^{(1/2)\\cdot 2} = x^1$, closed by `norm_num`. This tiny bridge is essential because Mathlib's integral Hölder inequality delivers its bound with `rpow` exponents ($S^{1/2}\\cdot T^{1/2}$), whereas the final Paley-Zygmund statement is phrased with an ordinary square; the lemma lets the proof square the Hölder output cleanly.",
+    "mathContext": "$(x^{1/2})^2 = x^{(1/2)\\cdot 2} = x^1 = x$ for $x \\ge 0$. Non-negativity is required: $\\mathrm{rpow}$ merging $x^{a}\\!\\cdot\\!{}^{b}=x^{ab}$ fails for negative bases.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "real rpow",
+      "Real.rpow_mul",
+      "exponent arithmetic"
+    ],
+    "prerequisites": [
+      "real power functions",
+      "rpow vs npow"
+    ]
+  },
+  {
+    "id": "ann-pzm-truncation-bound",
+    "proofId": "prob-method-second-moment-oq-01-oq-03",
+    "range": {
+      "startLine": 82,
+      "endLine": 90
+    },
+    "type": "insight",
+    "title": "Everywhere-True Truncation Bound",
+    "content": "The heart of the argument is the pointwise inequality `Z ω ≤ θ·m + Z ω · 𝟙_A(ω)`, established for *every* ω by a two-case split on whether `Z ω > θ·m` (the defining predicate of `A`). If ω ∈ A the indicator is 1 and the bound reads `Z ω ≤ θ·m + Z ω`, which follows from `θ·m ≥ 0`; if ω ∉ A the indicator is 0 and the bound reads `Z ω ≤ θ·m`, which is exactly the failure of the threshold. Both cases close with `linarith`. Crucially this bound is *everywhere* true, not merely almost-everywhere — so the proof avoids delicate a.e. bookkeeping and can integrate the inequality directly. The non-negativity `0 ≤ θ·m` (from `hθ0` and `integral_nonneg_of_ae hZ`) is the only hypothesis the case split consumes.",
+    "mathContext": "For all $\\omega$: $Z(\\omega) \\le \\theta m + Z(\\omega)\\mathbf{1}_A(\\omega)$ where $A=\\{Z>\\theta m\\}$. On $A$: $Z\\le\\theta m+Z$ since $\\theta m\\ge0$. Off $A$: $Z\\le\\theta m$ by definition of $A^c$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "truncation",
+      "indicator function",
+      "case analysis",
+      "pointwise vs a.e. bounds"
+    ],
+    "prerequisites": [
+      "Set.indicator",
+      "threshold events"
+    ]
+  },
+  {
+    "id": "ann-pzm-probability-normalization",
+    "proofId": "prob-method-second-moment-oq-01-oq-03",
+    "range": {
+      "startLine": 91,
+      "endLine": 99
+    },
+    "type": "technique",
+    "title": "Integrating the Bound: Where Total Mass One Is Used",
+    "content": "Integrating the everywhere-true truncation bound against μ via `integral_mono_ae` gives `m ≤ ∫(θ·m + Z·g)`. Splitting the integral with `integral_add` and evaluating the constant piece via `integral_const` produces `μ(univ).toReal · (θ·m)`. This is the single point where `IsProbabilityMeasure μ` is used: `measure_univ` rewrites `μ(univ) = 1`, `ENNReal.toReal_one` makes it the scalar 1, and `one_smul` collapses the constant integral to exactly `θ·m`. The result `m ≤ θ·m + E[Z·𝟙_A]` rearranges (via `linarith`) to `hstep1 : (1-θ)·m ≤ E[Z·𝟙_A]`. Over a non-probability measure this step would carry an extra `μ(univ)` factor and the classical constant would be wrong.",
+    "mathContext": "$m \\le \\int(\\theta m + Z\\mathbf{1}_A)\\,d\\mu = \\mu(\\Omega)\\,\\theta m + \\mathbb{E}[Z\\mathbf{1}_A] = \\theta m + \\mathbb{E}[Z\\mathbf{1}_A]$ using $\\mu(\\Omega)=1$; hence $(1-\\theta)m \\le \\mathbb{E}[Z\\mathbf{1}_A]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bochner integral",
+      "integral_mono_ae",
+      "probability measure normalization",
+      "linearity of expectation"
+    ],
+    "prerequisites": [
+      "IsProbabilityMeasure",
+      "integral of a constant",
+      "monotonicity of the integral"
+    ]
+  },
+  {
+    "id": "ann-pzm-cauchy-schwarz",
+    "proofId": "prob-method-second-moment-oq-01-oq-03",
+    "range": {
+      "startLine": 100,
+      "endLine": 117
+    },
+    "type": "insight",
+    "title": "Cauchy-Schwarz as Hölder at p = q = 2",
+    "content": "The first moment on A is controlled by the global second moment via integral Hölder (`integral_mul_le_Lp_mul_Lq_of_nonneg`) with the conjugate pair p = q = 2, certified by `Real.holderConjugate_iff` (using `1 < 2` and `1/2 + 1/2 = 1`). Applied to Z and the indicator g = 𝟙_A it yields `∫ Z·g ≤ (∫Z²)^(1/2)·(∫g²)^(1/2)`. Two clean-ups follow: `hexp` rewrites the `rpow` exponents `^(2:ℝ)` back to natural `^2`, and the key simplification `hg_sq : g² = g` (an indicator is idempotent) lets `integral_indicator_const` evaluate `∫g² = ∫g = μ(A).toReal`. So the indicator collapses the second Hölder factor to exactly the square root of the measure of the threshold event — the quantity that must appear on the right-hand side of Paley-Zygmund.",
+    "mathContext": "$\\mathbb{E}[Z\\mathbf{1}_A] \\le (\\mathbb{E}[Z^2])^{1/2}(\\mathbb{E}[\\mathbf{1}_A^2])^{1/2} = \\sqrt{\\mathbb{E}[Z^2]}\\cdot\\sqrt{\\mu(A)}$, since $\\mathbf{1}_A^2=\\mathbf{1}_A$ gives $\\mathbb{E}[\\mathbf{1}_A^2]=\\mu(A)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy-Schwarz",
+      "Hölder inequality",
+      "conjugate exponents",
+      "indicator idempotence"
+    ],
+    "prerequisites": [
+      "Hölder for integrals",
+      "MemLp membership",
+      "integral_indicator_const"
+    ]
+  },
+  {
+    "id": "ann-pzm-square-and-conclude",
+    "proofId": "prob-method-second-moment-oq-01-oq-03",
+    "range": {
+      "startLine": 118,
+      "endLine": 134
+    },
+    "type": "technique",
+    "title": "Squaring the Non-Negative Inequality",
+    "content": "With `S = ∫Z²` and `T = μ(A).toReal` (both non-negative), the chain `hstep1` and Hölder give `hstep2 : (1-θ)·m ≤ S^(1/2)·T^(1/2)`. Because the left side is non-negative (`hlhs0`, needing `θ ≤ 1` and `m ≥ 0`), the inequality survives squaring monotonically: `pow_le_pow_left₀` yields `((1-θ)m)² ≤ (S^(1/2)T^(1/2))²`, and `rpow_half_sq` on each factor (via `hrhs`) simplifies the right side to `S·T`. A final `calc` distributes the square — `(1-θ)²·m² = ((1-θ)·m)²` — and commutes `S·T` to `T·S`, matching the goal `(1-θ)²·(∫Z)² ≤ μ(A).toReal·∫Z²`. The non-negativity of the left side is essential: squaring is monotone only for non-negative quantities.",
+    "mathContext": "From $0\\le(1-\\theta)m\\le\\sqrt{S}\\sqrt{T}$ square to get $(1-\\theta)^2 m^2 \\le S\\,T = \\mu(A)\\,\\mathbb{E}[Z^2]$, the Paley-Zygmund bound.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotone squaring",
+      "pow_le_pow_left",
+      "calc proof"
+    ],
+    "prerequisites": [
+      "monotonicity of x↦x² on [0,∞)",
+      "algebraic rearrangement"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `prob-method-second-moment-oq-01-oq-03` (quality 41, passes 0).

This fresh research entry (merged in #32222) had a rich `meta.json` but **no `annotations.json`**, so the proof page had no inline commentary. Added 6 substantive annotations mapped to the Lean source:

1. **Header / framing** — lifting Paley-Zygmund from the parent's finite Finset form to Mathlib's measure-theoretic framework
2. **`rpow_half_sq`** — the $(x^{1/2})^2=x$ helper bridging Hölder's rpow output to the squared bound
3. **Everywhere-true truncation bound** — $Z \le \theta m + Z\,\mathbf{1}_A$ for every $\omega$ (the key insight avoiding a.e. bookkeeping)
4. **Probability-measure normalization** — the single point where total mass one collapses the constant integral to $\theta m$
5. **Cauchy-Schwarz = Hölder at p=q=2** — indicator idempotence makes $\int\mathbf{1}_A^2=\mu(A)$
6. **Monotone squaring** — concluding via non-negativity of $(1-\theta)m$

Each annotation includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. No changes to `meta.json` (already within all size caps). JSON validated; gallery data-generation build passed.