### PR TITLE
research(sperner-ndim-oq-02): geometric ∂Δ_N boundary faces localized to top facet; facet 0 unconditionally interior

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -2404,4 +2404,111 @@ theorem boundary_faces_card_lastStep (s : SpernerGrid.GridSimplex d N) (hd : 2 �
   · rw [if_neg hstep,
       if_neg (fun h => hstep ⟨(exists_incDir_last_iff s hd).mpr h.1, h.2⟩)]
 
+
+-- ============================================================
+-- SECTION: Geometric ∂Δ_N boundary faces over ALL coordinates
+-- ============================================================
+-- The `boundary_face k` predicate used above tests the SINGLE
+-- coordinate whose index matches the dropped facet index `k`
+-- (`(verts j).coords k = 0`), because that is the obligation a
+-- `gridNeighbor`-`none` facet discharges.  But the genuine
+-- *geometric* question — "does facet `k` lie on `∂Δ_N`?" — is
+-- whether the `d` vertices of the facet share a common vanishing
+-- coordinate `i`, for ANY `i : Fin (d+1)`, not necessarily `i = k`.
+--
+-- This section proves that the geometric boundary condition is no
+-- weaker: a facet lies on `∂Δ_N` (any coordinate hyperplane) ONLY
+-- for the top facet `k = Fin.last d`.  In particular facet `0` lies
+-- on NO coordinate hyperplane — it is ALWAYS strictly interior to
+-- `Δ_N`.  This settles the Phase-1 frontier dichotomy: the option
+-- "route facet `0` to `∂Δ_N` so `adj = none` is sound" is
+-- impossible, so the cross-`miss` partner construction for facet `0`
+-- is unavoidable.  All 0-sorry, 0-axiom (builds only on
+-- `coord_incDir_at`, `miss_coord_pos_of_ne_last`, and
+-- `incDir_surj_complement`).
+
+/-- **Geometric boundary faces are localized to the top facet.**
+If some coordinate `i` vanishes at every vertex of facet `k`
+(every `j ≠ k`), then `k = Fin.last d`.  Generalizes
+`boundary_face_imp_last` from the index-matched coordinate `i = k`
+to an ARBITRARY coordinate `i`: no matter which hyperplane the
+facet is tested against, only the top facet can lie on it.
+
+The `miss` coordinate is excluded because it is positive at every
+non-top vertex (`miss_coord_pos_of_ne_last`), and a facet with
+`2 ≤ d` contains at least one non-top vertex `≠ k`.  An
+increase-direction coordinate `incDir c` is excluded unless the top
+vertex is the dropped one, since at `Fin.last d` its value is
+`base + 1 ≥ 1 > 0` (`coord_incDir_at`, as `c.val < d`). -/
+theorem geom_boundary_face_imp_last (s : SpernerGrid.GridSimplex d N)
+    (hd : 2 ≤ d) (k : Fin (d + 1))
+    (h : ∃ i : Fin (d + 1), ∀ j : Fin (d + 1), j ≠ k →
+      (s.verts j).coords i = 0) :
+    k = Fin.last d := by
+  obtain ⟨i, hi⟩ := h
+  by_cases hmiss : i = s.miss
+  · -- `i = miss`: impossible outright.  Pick a vertex `j ≠ k` with
+    -- `j ≠ Fin.last d` (available since `d ≥ 2` gives `≥ 3` indices);
+    -- its `miss` coordinate is positive, contradicting `hi j`.
+    subst hmiss
+    exfalso
+    have hlast0 : (0 : Fin (d + 1)) ≠ Fin.last d := by
+      rw [Ne, Fin.ext_iff]; simp only [Fin.val_zero, Fin.val_last]; omega
+    have hlast1 : (⟨1, by omega⟩ : Fin (d + 1)) ≠ Fin.last d := by
+      rw [Ne, Fin.ext_iff]; simp only [Fin.val_last]; omega
+    by_cases hk0 : (0 : Fin (d + 1)) = k
+    · -- `k = 0`, so use `j = 1`.
+      have hne : (⟨1, by omega⟩ : Fin (d + 1)) ≠ k := by
+        rw [← hk0, Ne, Fin.ext_iff]; simp
+      have hz := hi ⟨1, by omega⟩ hne
+      have hpos := miss_coord_pos_of_ne_last s ⟨1, by omega⟩ hlast1
+      omega
+    · -- `k ≠ 0`, so use `j = 0`.
+      have hz := hi 0 hk0
+      have hpos := miss_coord_pos_of_ne_last s 0 hlast0
+      omega
+  · -- `i = incDir c` for some `c` (surjectivity onto the miss
+    -- complement).  If `k ≠ Fin.last d`, apply `hi` at the top
+    -- vertex `Fin.last d`; `coord_incDir_at` makes that coordinate
+    -- `base + 1`, contradicting `= 0`.
+    obtain ⟨c, hc⟩ := s.incDir_surj_complement i hmiss
+    subst hc
+    by_contra hk
+    have hne : (Fin.last d) ≠ k := fun h => hk h.symm
+    have hz := hi (Fin.last d) hne
+    rw [s.coord_incDir_at c (Fin.last d)] at hz
+    have hcd : c.val < (Fin.last d).val := by
+      simp only [Fin.val_last]; exact c.isLt
+    simp only [hcd, if_true] at hz
+    omega
+
+/-- Carrier (`SpernerNDim.onFace`) form of
+`geom_boundary_face_imp_last`. -/
+theorem gridVertices_geom_boundary_face_imp_last
+    (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d) (k : Fin (d + 1))
+    (h : ∃ i : Fin (d + 1), ∀ j : Fin (d + 1), j ≠ k →
+      SpernerNDim.onFace (gridVertices s j) i) :
+    k = Fin.last d := by
+  apply geom_boundary_face_imp_last s hd k
+  obtain ⟨i, hi⟩ := h
+  exact ⟨i, fun j hj => (gridVertices_onFace_iff s j i).mp (hi j hj)⟩
+
+/-- **Facet `0` is always strictly interior to `Δ_N`.**  No
+coordinate hyperplane contains all of facet `0`'s vertices
+`{verts 1, …, verts d}`.  Immediate from
+`geom_boundary_face_imp_last` (facet `0` on `∂Δ_N` would force
+`0 = Fin.last d`, false for `d ≥ 2`).  Consequence for Phase-1:
+facet `0` has NO geometric escape to `∂Δ_N`, so a total triangulation
+`adj` cannot legitimately send it to `none` — the cross-`miss`
+partner cell for facet `0` must be constructed. -/
+theorem zero_facet_not_on_boundary (s : SpernerGrid.GridSimplex d N)
+    (hd : 2 ≤ d) :
+    ¬ ∃ i : Fin (d + 1), ∀ j : Fin (d + 1), j ≠ 0 →
+      (s.verts j).coords i = 0 := by
+  intro h
+  have hk := geom_boundary_face_imp_last s hd 0 h
+  rw [Fin.ext_iff] at hk
+  simp only [Fin.val_zero, Fin.val_last] at hk
+  omega
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -2169,3 +2169,76 @@ identified as the sole non-top facet without a within-chain partner) — or prov
 2. Define a total `adj` with geometric none-fibre exactly `{Fin.last d}` on interior cells; then
    `boundary_face` via `gridVertices_boundary_face_imp_last`.
 3. Assemble `SpernerTriangulation`; Phase 2 door oddness induction on `d`; apply `sperner_ndim`.
+
+## Session 2026-07-01 (researcher-1) — Geometric ∂Δ_N boundary over ALL coordinates; facet 0 is unconditionally interior
+
+**Mode**: ACT (CONTINUE Phase-1). **Outcome**: PROGRESS — sharpens the frontier
+dichotomy with a genuine negative result; does NOT close it. **+3 theorems, ~108 L**
+(file 2407 → 2515 L). **0-sorry, 0-axiom by construction** (new decls use only
+`coord_incDir_at`, `miss_coord_pos_of_ne_last`, `incDir_surj_complement`,
+`gridVertices_onFace_iff`, `omega`, `rw`, `simp only`, `by_cases`, `by_contra` — no
+`native_decide`/`decide`).
+
+### What was delivered (`SpernerNDimOQ02.lean`, appended before `end`)
+All prior boundary lemmas (`boundary_face_imp_last`, `zero_not_boundary_face`, …) test
+the SINGLE coordinate whose index matches the dropped facet index `k`
+(`(verts j).coords k = 0`) — that is the obligation a `gridNeighbor`-`none` facet
+discharges. But the genuine *geometric* question "does facet `k` lie on `∂Δ_N`?" tests
+whether the `d` facet vertices share a common vanishing coordinate `i`, over ANY
+`i : Fin (d+1)`, not just `i = k`.
+
+- **`geom_boundary_face_imp_last (s) (hd : 2 ≤ d) (k)`** :
+  `(∃ i, ∀ j ≠ k, (verts j).coords i = 0) → k = Fin.last d`. Generalizes
+  `boundary_face_imp_last` from the index-matched coordinate to an ARBITRARY coordinate.
+  Proof splits `i` via `incDir_surj_complement`: the `miss` case is impossible (some
+  non-top vertex `≠ k` has positive `miss`-coord, since `d ≥ 2` leaves `≥ 3` indices);
+  an `incDir c` coordinate at `Fin.last d` is `base + 1 > 0` unless the top vertex is
+  the dropped one (`coord_incDir_at`, `c.val < d`).
+- **`gridVertices_geom_boundary_face_imp_last`** — carrier (`SpernerNDim.onFace`) form.
+- **`zero_facet_not_on_boundary (s) (hd : 2 ≤ d)`** :
+  `¬ ∃ i, ∀ j ≠ 0, (verts j).coords i = 0`. Facet `0` lies on NO coordinate hyperplane
+  — it is UNCONDITIONALLY strictly interior to `Δ_N`.
+
+### Why this matters (sharpens the frontier — a negative result)
+Prior session (r1, 06-30) localized the geometric `none`-fibre to `⊆ {Fin.last d}` using
+the index-matched tests, and identified facet `0` as the sole non-top facet lacking a
+within-chain pivot partner — but left open whether facet `0` might still escape to
+`∂Δ_N` (frontier-option (b): "prove facet 0 of a Δ_N-boundary cell lies on ∂Δ_N, so
+`adj = none` is sound"). **This session closes option (b): facet `0` is interior against
+EVERY coordinate hyperplane, never on `∂Δ_N`.** Therefore a total triangulation `adj`
+CANNOT legitimately send facet `0` to `none`; the cross-`miss` partner construction for
+facet `0` is *unavoidable* (only frontier-option (a) survives). This does not build that
+construction — it proves it is the sole remaining path.
+
+### ⚠️ Frontier UNCHANGED (the genuine blocker — same as all prior sessions)
+Still the **cross-chain gluing**: construct the cross-`miss` partner cell for facet `0`
+(now proved to be the ONLY option, no `∂Δ_N` escape). ≳ several hundred lines, untouched.
+
+### ⚠️ INFRA NOTE (full machine-verification blocked — host-level, not code)
+BOTH channels down this session:
+- **Direct `lean`/`lake env lean`**: host Mathlib olean cache is missing exactly ONE
+  data file — `Mathlib/RingTheory/Kaehler/Basic.olean.server` (stale Jun-30 olean; all
+  7375 other modules' `.server` files regenerated Jul-01 05:53). Any file transitively
+  under `import Mathlib` fails at the import line with `missing data file for module
+  Mathlib.RingTheory.Kaehler.Basic`. Regenerating it correctly requires lake's exact
+  build options (an ad-hoc `lean -Dexperimental.module=true` recompile diverges into
+  synthesis errors + `sorry`), and mutating the shared cache would risk hash-mismatch
+  for other agents — so NOT attempted.
+- **Docker (`docker-build.sh`)**: containerd blob I/O error — `docker image inspect
+  lean4-arm64:v4.26.0` and `docker images` both fail reading the image blob (corrupted
+  `/var/lib/desktop-containerd`). Cannot start a fresh build container.
+
+**Mitigation**: the non-obvious tactic bookkeeping (the `Fin`/`omega` steps: picking a
+non-top vertex `≠ k`, the `incDir` `base+1>0` contradiction, the `0 = Fin.last d`
+refutation) was machine-verified in an ISOLATED file importing only `Mathlib.Data.Fin.Basic`
+(avoids the Kaehler-poisoned aggregate) with the Sperner lemmas replaced by abstract
+hypotheses of identical shape — **compiles exit 0**. That check CAUGHT A REAL BUG
+(`hi 0 (fun h => hk0 h.symm)` had the wrong argument order; `hk0 : ¬(0 = k)` already has
+type `0 ≠ k`, so it must be `hi 0 hk0`) which was fixed before commit. All cited lemma
+signatures were read from source and match the abstract stand-ins exactly.
+
+### Next steps (unchanged crux)
+1. **(crux)** Cross-`miss` partner cell for facet `0` — now the SOLE path (option (b)
+   formally eliminated by `zero_facet_not_on_boundary`).
+2. Define total `adj` with geometric none-fibre exactly `{Fin.last d}` on interior cells.
+3. Assemble `SpernerTriangulation`; Phase-2 door oddness induction on `d`.


### PR DESCRIPTION
## Summary

Advances Phase-1 of **sperner-ndim-oq-02** (Boundary-Door Oddness by Dimensional Induction) with a genuine **negative result** that sharpens the long-standing frontier dichotomy. **+3 theorems (~108 L)**, `SpernerNDimOQ02.lean` 2407 → 2515 L. **0-sorry, 0-axiom by construction.**

### The gap this closes
All prior boundary lemmas (`boundary_face_imp_last`, `zero_not_boundary_face`, …) test the **single** coordinate whose index matches the dropped facet index `k` — because that is the obligation a `gridNeighbor`-`none` facet discharges. But the genuine *geometric* question "does facet `k` lie on `∂Δ_N`?" tests whether the `d` facet vertices share a common vanishing coordinate `i`, over **any** `i : Fin (d+1)`, not just `i = k`.

### New theorems
- **`geom_boundary_face_imp_last`** — `(∃ i, ∀ j ≠ k, (verts j).coords i = 0) → k = Fin.last d`. Generalizes `boundary_face_imp_last` from the index-matched coordinate to an arbitrary coordinate. (`miss` case impossible via `miss_coord_pos_of_ne_last`; `incDir c` case is `base+1>0` at the top vertex via `coord_incDir_at`.)
- **`gridVertices_geom_boundary_face_imp_last`** — carrier (`SpernerNDim.onFace`) form.
- **`zero_facet_not_on_boundary`** — facet `0` lies on **no** coordinate hyperplane; it is **unconditionally strictly interior** to `Δ_N`.

### Why it matters
The prior session localized the geometric `none`-fibre to `⊆ {Fin.last d}` and flagged facet `0` as the sole non-top facet without a within-chain pivot partner, but left open whether facet `0` could still escape to `∂Δ_N` (frontier-option (b)). **This PR eliminates option (b): facet `0` is interior against every coordinate hyperplane.** So a total triangulation `adj` can never legitimately send facet `0` to `none` — the cross-`miss` partner construction is the *sole remaining path*. This does not build that construction (the frontier is unchanged), but it formally rules out the alternative.

## Verification
⚠️ **Full end-to-end machine-check was infra-blocked this session** (documented fleet-wide):
- Direct `lean`/`lake env lean`: host Mathlib olean cache is missing exactly one data file, `Mathlib/RingTheory/Kaehler/Basic.olean.server` — every `import Mathlib` closure fails at the import line. Regenerating it correctly needs lake's exact build options; mutating the shared cache would risk hash-mismatch for other agents, so not attempted.
- Docker `docker-build.sh`: containerd blob I/O error — the `lean4-arm64:v4.26.0` image blob is unreadable, so no fresh build container can start.

**Mitigation (better than trust-me):** the non-obvious `Fin`/`omega` tactic bookkeeping was **machine-verified in isolation** (a standalone file importing only `Mathlib.Data.Fin.Basic`, avoiding the Kaehler-poisoned aggregate, with the Sperner lemmas replaced by abstract hypotheses of identical shape) — **compiles exit 0**. That isolated check **caught and fixed a real argument-order bug** before commit (`hi 0 (fun h => hk0 h.symm)` → `hi 0 hk0`). All cited lemma signatures (`miss_coord_pos_of_ne_last`, `coord_incDir_at`, `incDir_surj_complement`, `gridVertices_onFace_iff`) were read from source and match the stand-ins exactly.

A re-run of `./proofs/scripts/docker-build.sh Proofs.SpernerNDimOQ02` once the host olean cache / docker are healthy will confirm the full file.

## Honesty note
This is **PROGRESS, not a closure**: a decision-relevant negative result narrowing future work to the cross-chain gluing construction. The main OQ (n-dim door oddness) remains open.