### PR TITLE
research(prob-method-expectation-oq-05): first-moment rigidity — the averaging inequality saturates only for constants [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ProbMethodExpectationOQ05.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ05.lean
@@ -1,0 +1,143 @@
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Algebra.BigOperators.Field
+import Mathlib.Algebra.Order.Field.Basic
+
+/-
+# OQ-05: First-Moment Rigidity — the averaging inequality is an equality only for constants
+
+The parent entry `prob-method-expectation` and its siblings establish the **existence**
+side of the first-moment method: over a nonempty finite set some element meets or beats
+the average `mean s f = (∑ a ∈ s, f a) / |s|` (and, dually, some element is at most the
+average). This entry supplies the **rigidity** side that the family leaves open: the
+first-moment inequality *saturates* — i.e. every element attains the mean — exactly when
+`f` is constant on `s`.
+
+## Why this is the missing piece
+
+`exists_ge_average` says `∃ a ∈ s, mean s f ≤ f a`. That element could sit strictly above
+the mean while others sit below. The natural sharpening asks: when is there **no slack** at
+all — when does *every* element sit on the mean? The answer is the equality case of the
+averaging inequality, and it is a genuine dichotomy, not a mere existence statement:
+
+> If every element is on one side of the mean (`∀ a ∈ s, f a ≤ mean s f`), then in fact
+> every element equals the mean. Consequently, if a single element strictly beats the mean,
+> some other element must strictly fall below it — the first moment is *conserved*.
+
+## Main results
+
+* `sum_sub_mean_eq_zero` — the conservation law `∑ a ∈ s, (f a − mean s f) = 0`.
+* `eq_mean_of_forall_le` / `eq_mean_of_forall_ge` — **rigidity**: one-sided domination forces
+  equality everywhere.
+* `forall_eq_mean_iff_forall_le` / `forall_eq_mean_iff_forall_ge` — the equality case packaged
+  as an iff.
+* `exists_lt_mean_of_exists_gt_mean` / `exists_gt_mean_of_exists_lt_mean` — **strict
+  compensation**: a single element above the mean forces another strictly below (and dually).
+* `variance_pos_of_exists_ne` — the quantitative form: non-constant data has strictly
+  positive spread `∑ (f a − mean)² > 0`.
+
+Everything is over an arbitrary linearly ordered field and is fully machine-checked with no
+`sorry`, no `axiom`, and no `native_decide`.
+-/
+
+namespace ProbMethodExpectationOQ05
+
+open Finset
+
+variable {α : Type*} {𝕜 : Type*} [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]
+variable {s : Finset α} {f : α → 𝕜}
+
+/-- The **mean** (empirical first moment) of `f` over a finite set `s`:
+`mean s f = (∑ a ∈ s, f a) / |s|`. -/
+noncomputable def mean (s : Finset α) (f : α → 𝕜) : 𝕜 :=
+  (∑ a ∈ s, f a) / s.card
+
+/-- Multiplying the mean back out recovers the sum, on a nonempty set. -/
+theorem card_mul_mean (hs : s.Nonempty) :
+    (s.card : 𝕜) * mean s f = ∑ a ∈ s, f a := by
+  have hc : (s.card : 𝕜) ≠ 0 := by
+    exact_mod_cast hs.card_pos.ne'
+  rw [mean, mul_div_cancel₀ _ hc]
+
+/-- **Conservation of the first moment.** The signed deviations from the mean sum to zero:
+`∑ a ∈ s, (f a − mean s f) = 0`. This is the algebraic identity underlying every rigidity
+statement below. -/
+theorem sum_sub_mean_eq_zero (hs : s.Nonempty) :
+    ∑ a ∈ s, (f a - mean s f) = 0 := by
+  rw [Finset.sum_sub_distrib, Finset.sum_const, nsmul_eq_mul, card_mul_mean hs, sub_self]
+
+/-- **Rigidity (≤ side).** If every element is at most the mean, then every element *equals*
+the mean: there is no room for any element to sit strictly below when none sits above. -/
+theorem eq_mean_of_forall_le (hs : s.Nonempty) (h : ∀ a ∈ s, f a ≤ mean s f) :
+    ∀ a ∈ s, f a = mean s f := by
+  have hnn : ∀ a ∈ s, 0 ≤ mean s f - f a := fun a ha => sub_nonneg.mpr (h a ha)
+  have hsum : ∑ a ∈ s, (mean s f - f a) = 0 := by
+    have h0 := sum_sub_mean_eq_zero (f := f) hs
+    rw [← neg_eq_zero, ← Finset.sum_neg_distrib] at h0
+    simpa [neg_sub] using h0
+  intro a ha
+  have hz := (Finset.sum_eq_zero_iff_of_nonneg hnn).1 hsum a ha
+  exact (sub_eq_zero.1 hz).symm
+
+/-- **Rigidity (≥ side).** If every element is at least the mean, then every element equals
+the mean. Dual of `eq_mean_of_forall_le`. -/
+theorem eq_mean_of_forall_ge (hs : s.Nonempty) (h : ∀ a ∈ s, mean s f ≤ f a) :
+    ∀ a ∈ s, f a = mean s f := by
+  have hnn : ∀ a ∈ s, 0 ≤ f a - mean s f := fun a ha => sub_nonneg.mpr (h a ha)
+  have hsum : ∑ a ∈ s, (f a - mean s f) = 0 := sum_sub_mean_eq_zero hs
+  intro a ha
+  have hz := (Finset.sum_eq_zero_iff_of_nonneg hnn).1 hsum a ha
+  exact sub_eq_zero.1 hz
+
+/-- **Equality case (≤), packaged.** On a nonempty set, all elements equal the mean iff all
+are at most the mean. -/
+theorem forall_eq_mean_iff_forall_le (hs : s.Nonempty) :
+    (∀ a ∈ s, f a = mean s f) ↔ (∀ a ∈ s, f a ≤ mean s f) :=
+  ⟨fun h a ha => (h a ha).le, eq_mean_of_forall_le hs⟩
+
+/-- **Equality case (≥), packaged.** All elements equal the mean iff all are at least the
+mean. -/
+theorem forall_eq_mean_iff_forall_ge (hs : s.Nonempty) :
+    (∀ a ∈ s, f a = mean s f) ↔ (∀ a ∈ s, mean s f ≤ f a) :=
+  ⟨fun h a ha => (h a ha).ge, eq_mean_of_forall_ge hs⟩
+
+/-- **Strict compensation (above forces below).** If some element strictly exceeds the mean,
+then some element strictly falls below it: the first moment being conserved, an excess in one
+place must be paid for by a deficit elsewhere. -/
+theorem exists_lt_mean_of_exists_gt_mean (hs : s.Nonempty)
+    (hb : ∃ b ∈ s, mean s f < f b) : ∃ a ∈ s, f a < mean s f := by
+  obtain ⟨b, hb_mem, hb_lt⟩ := hb
+  by_contra hcon
+  have hall : ∀ a ∈ s, mean s f ≤ f a := fun a ha =>
+    not_lt.1 (fun hlt => hcon ⟨a, ha, hlt⟩)
+  exact absurd (eq_mean_of_forall_ge hs hall b hb_mem) (ne_of_gt hb_lt)
+
+/-- **Strict compensation (below forces above).** Dual of `exists_lt_mean_of_exists_gt_mean`:
+a single element strictly below the mean forces another strictly above. -/
+theorem exists_gt_mean_of_exists_lt_mean (hs : s.Nonempty)
+    (hb : ∃ b ∈ s, f b < mean s f) : ∃ a ∈ s, mean s f < f a := by
+  obtain ⟨b, hb_mem, hb_lt⟩ := hb
+  by_contra hcon
+  have hall : ∀ a ∈ s, f a ≤ mean s f := fun a ha =>
+    not_lt.1 (fun hlt => hcon ⟨a, ha, hlt⟩)
+  exact absurd (eq_mean_of_forall_le hs hall b hb_mem) (ne_of_lt hb_lt)
+
+/-- **Non-constant data has strictly positive spread.** If two elements of `s` disagree, the
+sum of squared deviations from the mean is strictly positive: `0 < ∑ a ∈ s, (f a − mean s f)²`.
+This is the quantitative form of rigidity — zero spread is equivalent to constancy. -/
+theorem variance_pos_of_exists_ne
+    (hne : ∃ a ∈ s, ∃ b ∈ s, f a ≠ f b) :
+    0 < ∑ a ∈ s, (f a - mean s f) ^ 2 := by
+  have hnn : ∀ a ∈ s, 0 ≤ (f a - mean s f) ^ 2 := fun a _ => sq_nonneg _
+  rcases (Finset.sum_nonneg hnn).lt_or_eq with hlt | heq
+  · exact hlt
+  · -- If the spread were zero every deviation vanishes, so `f` is constant `= mean`,
+    -- contradicting the two disagreeing elements.
+    exfalso
+    have hz : ∀ a ∈ s, (f a - mean s f) ^ 2 = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg hnn).1 heq.symm
+    obtain ⟨a, ha, b, hb, hab⟩ := hne
+    have hea : f a = mean s f := sub_eq_zero.1 (by simpa using hz a ha)
+    have heb : f b = mean s f := sub_eq_zero.1 (by simpa using hz b hb)
+    exact hab (hea.trans heb.symm)
+
+end ProbMethodExpectationOQ05

--- a/src/data/proofs/prob-method-expectation-oq-05/annotations.json
+++ b/src/data/proofs/prob-method-expectation-oq-05/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-pmeoq05-0",
+    "proofId": "prob-method-expectation-oq-05",
+    "range": {
+      "startLine": 49,
+      "endLine": 69
+    },
+    "type": "definition",
+    "title": "The Mean and the Conservation Law",
+    "content": "The finitary setup for the whole entry. `mean s f := (∑ a ∈ s, f a) / s.card` is the empirical first moment over a nonempty finite set, defined over an arbitrary linearly ordered field. `card_mul_mean` records that multiplying the mean back by the cardinality recovers the sum (`mul_div_cancel₀` on `|s| ≠ 0`). The keystone is `sum_sub_mean_eq_zero`: the signed deviations from the mean cancel, `∑ a ∈ s, (f a − mean s f) = 0`. It expands via `Finset.sum_sub_distrib`, `Finset.sum_const`/`nsmul_eq_mul`, and `card_mul_mean`. Every rigidity and compensation statement downstream is a corollary of this one identity.",
+    "mathContext": "$\\mathrm{mean}\\,s\\,f = \\tfrac{1}{|s|}\\sum_{a\\in s} f(a)$ and $\\sum_{a\\in s}(f(a) - \\mathrm{mean}\\,s\\,f) = 0$: the first moment of the deviations vanishes.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Empirical mean / first moment",
+      "Conservation of deviations",
+      "Finite sums over a field"
+    ],
+    "prerequisites": [
+      "Finset.sum over a field",
+      "mul_div_cancel₀",
+      "Finset.sum_sub_distrib"
+    ],
+    "tags": [
+      "definition",
+      "setup",
+      "key-identity"
+    ]
+  },
+  {
+    "id": "ann-pmeoq05-1",
+    "proofId": "prob-method-expectation-oq-05",
+    "range": {
+      "startLine": 70,
+      "endLine": 104
+    },
+    "type": "theorem",
+    "title": "Rigidity: One-Sided Domination Forces Equality",
+    "content": "The heart of the entry, and the piece the first-moment family leaves open. `eq_mean_of_forall_le`: if every element is at most the mean, then every element *equals* the mean. The proof turns the constant-signed deviations `mean s f − f a` (all ≥ 0) into a sum equal to zero (from the conservation law), then invokes `Finset.sum_eq_zero_iff_of_nonneg` to force each deviation to vanish, so `f a = mean s f` via `sub_eq_zero`. `eq_mean_of_forall_ge` is the dual. `forall_eq_mean_iff_forall_le` and `forall_eq_mean_iff_forall_ge` package the equality case as clean iffs on a nonempty set.",
+    "mathContext": "$(\\forall a\\in s,\\ f(a) \\le \\mathrm{mean}) \\Rightarrow (\\forall a\\in s,\\ f(a) = \\mathrm{mean})$: no slack on one side means no slack anywhere.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Equality case of the averaging inequality",
+      "Sum of nonnegative terms equal to zero",
+      "Rigidity / uniqueness of extremizers"
+    ],
+    "prerequisites": [
+      "Finset.sum_eq_zero_iff_of_nonneg",
+      "sub_nonneg",
+      "sub_eq_zero"
+    ],
+    "tags": [
+      "theorem",
+      "rigidity",
+      "main-result"
+    ]
+  },
+  {
+    "id": "ann-pmeoq05-2",
+    "proofId": "prob-method-expectation-oq-05",
+    "range": {
+      "startLine": 105,
+      "endLine": 143
+    },
+    "type": "theorem",
+    "title": "Strict Compensation and Positive Spread",
+    "content": "The consequences of rigidity. `exists_lt_mean_of_exists_gt_mean`: if some element strictly exceeds the mean, some element strictly falls below it — an excess in one place must be paid for by a deficit elsewhere, because the first moment is conserved. It is proved by contraposition: if no element fell below, all would be ≥ the mean, hence (by rigidity) all equal it, contradicting the strict excess. `exists_gt_mean_of_exists_lt_mean` is the dual. Finally `variance_pos_of_exists_ne` gives the quantitative face: two disagreeing elements force `0 < ∑ a ∈ s, (f a − mean s f)²`, since the sum of squared deviations vanishes exactly when the data is constant.",
+    "mathContext": "$(\\exists b,\\ \\mathrm{mean} < f(b)) \\Rightarrow (\\exists a,\\ f(a) < \\mathrm{mean})$; and $f$ non-constant $\\Rightarrow 0 < \\sum_{a\\in s}(f(a)-\\mathrm{mean})^2$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Compensation / smoothing arguments",
+      "Sum of squared deviations (variance)",
+      "Zero spread ⇔ constancy"
+    ],
+    "prerequisites": [
+      "Contraposition via the rigidity theorems",
+      "not_lt",
+      "sq_nonneg, Finset.sum_nonneg"
+    ],
+    "tags": [
+      "theorem",
+      "compensation",
+      "variance"
+    ]
+  }
+]

--- a/src/data/proofs/prob-method-expectation-oq-05/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-05/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "prob-method-expectation-oq-05",
+  "title": "First-Moment Rigidity: The Averaging Inequality Saturates Only for Constants",
+  "slug": "prob-method-expectation-oq-05",
+  "description": "The rigidity (equality) side of the first-moment method, which the prob-method-expectation family leaves open. Its siblings prove existence — some element meets or beats the average mean s f = (∑ f)/|s|. This entry proves the dichotomy behind that: if every element lies on one side of the mean (∀ a ∈ s, f a ≤ mean, or all ≥), then every element in fact equals the mean. Consequently the first moment is conserved — a single element strictly above the mean forces another strictly below (strict compensation) — and non-constant data has strictly positive spread ∑ (f a − mean)² > 0. Everything is over an arbitrary linearly ordered field.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodExpectationOQ05.lean",
+    "tags": [
+      "probability",
+      "probabilistic-method",
+      "first-moment-method",
+      "combinatorics",
+      "rigidity",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_eq_zero_iff_of_nonneg",
+        "description": "A sum of nonnegative terms is zero iff every term is zero — the engine of both rigidity theorems and the variance positivity",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_sub_distrib",
+        "description": "Distributes a finite sum over subtraction, used to expand ∑ (f a − mean) = ∑ f − |s|·mean",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_const / nsmul_eq_mul",
+        "description": "∑ a ∈ s, c = |s| • c = (|s| : 𝕜) · c, giving the constant-term bookkeeping for the mean",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "mul_div_cancel₀",
+        "description": "Cancels the cardinality in (|s| : 𝕜) · ((∑ f)/|s|) = ∑ f on a nonempty set, where |s| ≠ 0",
+        "module": "Mathlib.Algebra.Group.Basic"
+      },
+      {
+        "theorem": "Finset.sum_nonneg",
+        "description": "A sum of nonnegative terms is nonnegative; combined with lt_or_eq to split the variance into positive or zero",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "sub_eq_zero / sub_nonneg",
+        "description": "x − y = 0 ↔ x = y and 0 ≤ x − y ↔ y ≤ x, converting deviation identities into the equalities and inequalities of the rigidity statements",
+        "module": "Mathlib.Algebra.Order.Group.Defs"
+      }
+    ],
+    "originalContributions": [
+      "mean s f: the empirical first moment (∑ a ∈ s, f a)/|s| over a linearly ordered field, with card_mul_mean recovering the sum on a nonempty set",
+      "sum_sub_mean_eq_zero: the conservation law ∑ a ∈ s, (f a − mean s f) = 0 — the algebraic identity underlying every rigidity result",
+      "eq_mean_of_forall_le / eq_mean_of_forall_ge: the rigidity theorems — one-sided domination (all ≤ mean, or all ≥ mean) forces equality everywhere, proved by writing the (constant-signed) deviations as a sum of nonnegative terms equal to zero",
+      "forall_eq_mean_iff_forall_le / forall_eq_mean_iff_forall_ge: the equality case packaged as an iff on a nonempty set",
+      "exists_lt_mean_of_exists_gt_mean / exists_gt_mean_of_exists_lt_mean: strict compensation — a single element strictly beating the mean forces another strictly below it, and dually",
+      "variance_pos_of_exists_ne: the quantitative rigidity — two disagreeing elements force strictly positive spread 0 < ∑ (f a − mean s f)²"
+    ],
+    "dateAdded": "2026-07-01",
+    "prerequisites": [
+      "The first-moment method and the empirical mean over a finite set",
+      "Sum of nonnegative terms is zero iff each term is zero (Finset.sum_eq_zero_iff_of_nonneg)",
+      "Deviation algebra: sub_eq_zero, sub_nonneg, sum_sub_distrib",
+      "Squares are nonnegative and vanish only at zero"
+    ],
+    "relatedProblems": [
+      {
+        "id": "prob-method-expectation",
+        "relationship": "Parent: proves the existence side of the first-moment method (some element meets/beats the average); this entry supplies the rigidity/equality side"
+      },
+      {
+        "id": "prob-method-expectation-oq-01",
+        "relationship": "Sibling: measure-theoretic (integral) formulation of the first-moment method"
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 143,
+    "assumptions": "0 axioms, 0 sorries. #print axioms reports only [propext, Classical.choice, Quot.sound] for all nine theorems. Results are over an arbitrary linearly ordered field ([Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]); the rigidity and compensation theorems assume s is nonempty (the variance positivity needs only two disagreeing elements). No probability-space or measure-theoretic machinery is used — the mean is the purely finitary (∑ f)/|s|.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The first-moment (or averaging) method underlies the probabilistic method: since the average of a random variable is attained, some outcome is at least the average and some is at most. The parent entry and its siblings formalize this existence principle over ℚ, ℕ, and in a measure-theoretic setting. But existence is only half of the averaging inequality; its equality case — when does every value coincide with the mean — is the rigidity statement that pins down constancy and powers 'smoothing' or 'compensation' arguments throughout combinatorics and analysis (e.g. an extremal configuration with no slack must be uniform). This entry isolates that equality case as a clean dichotomy over an arbitrary ordered field.",
+    "problemStatement": "Prove the rigidity side of the first-moment method: if every element of a nonempty finite set is on one side of the mean, then all equal the mean; deduce strict compensation and the strict positivity of the spread for non-constant data.",
+    "text": "Write mean s f = (∑ a ∈ s, f a)/|s|. The identity ∑ a ∈ s, (f a − mean s f) = 0 (conservation of the first moment) is the crux: if additionally f a ≤ mean s f for all a, then each summand mean s f − f a is ≥ 0 and they sum to 0, so each is 0 and f a = mean s f. The dual gives the ≥ case. Strict compensation and the variance bound 0 < ∑ (f a − mean s f)² follow by contraposition and the same sum-of-nonnegatives argument on squares.",
+    "proofStrategy": "Everything reduces to the conservation law sum_sub_mean_eq_zero, obtained from Finset.sum_sub_distrib, Finset.sum_const/nsmul_eq_mul, and card_mul_mean (which cancels |s| via mul_div_cancel₀ on a nonempty set). Rigidity then applies Finset.sum_eq_zero_iff_of_nonneg to the constant-signed deviations, converting the zero-sum into pointwise vanishing via sub_eq_zero. Strict compensation is the contrapositive of rigidity (if no element falls strictly below, all are ≥ mean, hence all equal it, contradicting a strict excess). The variance positivity splits Finset.sum_nonneg's ≤ into < or =, ruling out equality because two disagreeing elements cannot both equal the mean.",
+    "keyInsights": [
+      "The whole family reduces to one conservation identity: ∑ (f a − mean) = 0",
+      "A sum of nonnegative terms equal to zero forces each term to vanish — this single lemma yields both rigidity directions and the variance bound",
+      "Rigidity is exactly the equality case of the averaging inequality: no slack on one side means no slack anywhere",
+      "Strict compensation is the contrapositive: an excess above the mean must be paid for by a deficit below it, because the first moment is conserved",
+      "Zero spread ⇔ constancy, so non-constant data has strictly positive sum of squared deviations — the quantitative face of rigidity"
+    ],
+    "prerequisites": [
+      "The first-moment method and the empirical mean over a finite set",
+      "Sum of nonnegative terms is zero iff each term is zero",
+      "Deviation algebra (sub_eq_zero, sub_nonneg, sum_sub_distrib)",
+      "Squares are nonnegative and vanish only at zero"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "The Mean and the Conservation Law",
+      "startLine": 1,
+      "endLine": 69,
+      "summary": "Header motivating the rigidity side, setup over a linearly ordered field, the definition mean s f = (∑ f)/|s|, card_mul_mean recovering the sum on a nonempty set, and the conservation identity sum_sub_mean_eq_zero: ∑ (f a − mean s f) = 0.",
+      "mathContext": "The signed deviations from the mean sum to zero; every rigidity statement is a corollary of this single algebraic identity."
+    },
+    {
+      "id": "rigidity",
+      "title": "Rigidity: One-Sided Domination Forces Equality",
+      "startLine": 70,
+      "endLine": 104,
+      "summary": "eq_mean_of_forall_le and eq_mean_of_forall_ge: if all elements are ≤ mean (resp. ≥ mean) then all equal the mean; forall_eq_mean_iff_forall_le / _ge package these as iffs.",
+      "mathContext": "The constant-signed deviations are nonnegative and sum to zero, so each vanishes (Finset.sum_eq_zero_iff_of_nonneg), giving f a = mean s f pointwise."
+    },
+    {
+      "id": "compensation",
+      "title": "Strict Compensation and Positive Spread",
+      "startLine": 105,
+      "endLine": 143,
+      "summary": "exists_lt_mean_of_exists_gt_mean / exists_gt_mean_of_exists_lt_mean: a single element strictly beating the mean forces another strictly below (and dually); variance_pos_of_exists_ne: two disagreeing elements force 0 < ∑ (f a − mean s f)².",
+      "mathContext": "By contraposition of rigidity an excess above the mean must be compensated below it; the sum of squared deviations is zero exactly when the data is constant, so disagreement makes it strictly positive."
+    }
+  ],
+  "conclusion": {
+    "summary": "The first-moment method's rigidity side: on a nonempty finite set, one-sided domination by the mean forces every element to equal the mean, the first moment is conserved (so an excess above the mean is compensated by a deficit below), and non-constant data has strictly positive spread. All 9 theorems and 1 definition are fully verified over an arbitrary linearly ordered field with 0 sorries and 0 axioms.",
+    "implications": "Rigidity is the equality case that the existence-focused parent and siblings leave open, and it is the workhorse of smoothing/compensation arguments: an extremal configuration with no slack on one side of its average must be uniform. The variance formulation connects the first-moment method to the second moment, foreshadowing Chebyshev-style concentration.",
+    "openQuestions": [
+      "Quantitative rigidity: bound how far the data can deviate from constant in terms of the spread ∑ (f a − mean)², a stability/robust version of the equality case.",
+      "Extend the rigidity dichotomy to weighted means (probability weights summing to one) and to the measure-theoretic first moment of the sibling entry."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Order.BigOperators.Group.Finset",
+      "Mathlib.Algebra.BigOperators.Field",
+      "Mathlib.Algebra.Order.Field.Basic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ProbMethodExpectationOQ05",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/ProbMethodExpectationOQ05.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-expectation",
+      "relationship": "extends",
+      "description": "Supplies the rigidity (equality) side of the first-moment method whose existence side the parent proves."
+    },
+    {
+      "targetId": "prob-method-expectation-oq-01",
+      "relationship": "related",
+      "description": "Sibling giving the measure-theoretic formulation of the first-moment method; this entry stays purely finitary and focuses on the equality case."
+    }
+  ],
+  "references": [
+    {
+      "key": "AS16",
+      "citation": "Alon, N. and Spencer, J.H., The Probabilistic Method, 4th ed., Wiley (2016), Chapter 2: The first moment method.",
+      "type": "book"
+    },
+    {
+      "key": "HLP52",
+      "citation": "Hardy, G.H., Littlewood, J.E. and Pólya, G., Inequalities, 2nd ed., Cambridge University Press (1952), Chapter 2: the equality case of the arithmetic-mean inequality.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Supplies the **rigidity (equality) side** of the first-moment method — the piece the `prob-method-expectation` family leaves open. Its siblings prove *existence* (some element meets/beats the average `mean s f = (∑ f)/|s|`); this entry proves the dichotomy behind it, over an arbitrary linearly ordered field.

> If every element lies on one side of the mean (`∀ a ∈ s, f a ≤ mean`, or all `≥`), then **every element equals the mean**. Hence the first moment is conserved: a single element strictly above the mean forces another strictly below it.

## Main results (9 theorems + 1 definition)

- `mean` / `card_mul_mean` — the empirical first moment `(∑ f)/|s|`.
- `sum_sub_mean_eq_zero` — **conservation**: `∑ a ∈ s, (f a − mean s f) = 0`.
- `eq_mean_of_forall_le` / `eq_mean_of_forall_ge` — **rigidity**: one-sided domination forces equality everywhere.
- `forall_eq_mean_iff_forall_le` / `_ge` — the equality case as an iff.
- `exists_lt_mean_of_exists_gt_mean` / `exists_gt_mean_of_exists_lt_mean` — **strict compensation**.
- `variance_pos_of_exists_ne` — non-constant data has strictly positive spread `0 < ∑ (f a − mean)²`.

## Method

Everything reduces to the conservation identity: a sum of constant-signed deviations that is `≥ 0` termwise and sums to `0` must vanish termwise (`Finset.sum_eq_zero_iff_of_nonneg`), giving `f a = mean` pointwise. Strict compensation is the contrapositive; the variance bound splits `Finset.sum_nonneg` into `<` or `=` and rules out `=` via two disagreeing elements.

## Verification

- **Machine-checked** against Mathlib v4.26.0 (`lake env lean`, clean compile).
- **0 axioms**: `#print axioms` on all nine theorems shows only `propext / Classical.choice / Quot.sound`. No `sorryAx`, no `native_decide`.
- 0 sorries, 0 `axiom` declarations. Targeted imports.

Status `verified`, badge `original`, `axiomCount: 0`. Purely finitary — no probability-space machinery; the mean is `(∑ f)/|s|`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)