### PR TITLE
research(amgm-inequality-oq-02-oq-04): Newton inequalities & Maclaurin chain for n=3 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ04.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ04.lean
@@ -1,0 +1,179 @@
+/-
+  Newton's Inequalities for Three Variables — the n=3 Maclaurin Chain, Axiom-Free
+  Open Question: amgm-inequality-oq-02-oq-04
+
+  Parent: amgm-inequality-oq-02 (Maclaurin's Inequalities via Elementary Symmetric
+  Polynomials), which proves the k=1 Newton inequality from scratch but AXIOMATIZES
+  the general `newton_log_concavity` (Newton's inequalities) and, through it, the
+  full Maclaurin chain Mₖ ≥ Mₖ₊₁.
+
+  This file DISCHARGES that axiom completely for n = 3: both Newton inequalities and
+  the full three-variable Maclaurin chain M₁ ≥ M₂ ≥ M₃ are proved with zero axioms
+  (no `sorry`, no `newton_log_concavity`). The engine is exactly Maclaurin's own
+  "equal-variable symmetrization", which for three variables is an explicit
+  sum-of-squares identity — see oq-02-oq-04.
+
+  Elementary symmetric polynomials of x, y, z:
+    e₁ = x + y + z,   e₂ = xy + yz + zx,   e₃ = xyz.
+  Normalized Maclaurin means:
+    M₁ = e₁/3,   M₂ = √(e₂/3),   M₃ = (e₃)^(1/3).
+
+  Newton's inequalities (n = 3):
+    (N1)  p₁² ≥ p₀·p₂   ⟺   e₁² ≥ 3·e₂
+    (N2)  p₂² ≥ p₁·p₃   ⟺   e₂² ≥ 3·e₁·e₃
+  where pₖ = eₖ/C(3,k). Both are exact sum-of-squares statements:
+    e₁² − 3e₂ = ½·[(x−y)² + (y−z)² + (z−x)²]           (holds for all reals)
+    e₂² − 3e₁e₃ = ½·[(xy−yz)² + (yz−zx)² + (zx−xy)²]    (holds for all reals)
+
+  Maclaurin chain steps (non-negative x, y, z):
+    (M12)  M₁ ≥ M₂   ⟺   e₁² ≥ 3·e₂                    (= N1)
+    (M23)  M₂ ≥ M₃   ⟺   e₂³ ≥ 27·e₃²                  (AM–GM on xy, yz, zx)
+
+  References:
+  - Maclaurin, C. (1729): A Second Letter to Martin Folkes, Esq.
+  - Hardy–Littlewood–Pólya, "Inequalities" (1934) §2.22
+  - Newton, I. (1707): Arithmetica Universalis
+-/
+
+import Mathlib
+
+open Real
+
+namespace AmgmOQ02OQ04
+
+/-! ## Part I: Newton's inequalities for n = 3 (sum-of-squares, all reals)
+
+Both Newton inequalities for three variables are unconditional polynomial
+identities up to a manifestly non-negative remainder, so they hold for ALL real
+inputs, not merely non-negative ones. The remainders are the equal-variable
+symmetrization sums of squares. -/
+
+/-- **Newton's inequality N1 for n = 3.** `e₁² ≥ 3·e₂`, i.e.
+    `(x+y+z)² ≥ 3(xy+yz+zx)`. Exact remainder `½·∑ (x−y)²`. Holds for all reals. -/
+theorem newton_n3_k1 (x y z : ℝ) :
+    (x + y + z) ^ 2 ≥ 3 * (x * y + y * z + z * x) := by
+  nlinarith [sq_nonneg (x - y), sq_nonneg (y - z), sq_nonneg (z - x)]
+
+/-- **Newton's inequality N2 for n = 3.** `e₂² ≥ 3·e₁·e₃`, i.e.
+    `(xy+yz+zx)² ≥ 3(x+y+z)·xyz`. Exact remainder `½·∑ (xy−yz)²`.
+    Holds for all reals (no non-negativity needed). -/
+theorem newton_n3_k2 (x y z : ℝ) :
+    (x * y + y * z + z * x) ^ 2 ≥ 3 * (x + y + z) * (x * y * z) := by
+  nlinarith [sq_nonneg (x * y - y * z), sq_nonneg (y * z - z * x),
+    sq_nonneg (z * x - x * y)]
+
+/-- The exact SOS identity behind `newton_n3_k1`: the gap is `½·∑(x−y)²`. -/
+theorem newton_n3_k1_identity (x y z : ℝ) :
+    (x + y + z) ^ 2 - 3 * (x * y + y * z + z * x)
+      = ((x - y) ^ 2 + (y - z) ^ 2 + (z - x) ^ 2) / 2 := by
+  ring
+
+/-- The exact SOS identity behind `newton_n3_k2`: the gap is `½·∑(xy−yz)²`. -/
+theorem newton_n3_k2_identity (x y z : ℝ) :
+    (x * y + y * z + z * x) ^ 2 - 3 * (x + y + z) * (x * y * z)
+      = ((x * y - y * z) ^ 2 + (y * z - z * x) ^ 2 + (z * x - x * y) ^ 2) / 2 := by
+  ring
+
+/-! ## Part II: The Maclaurin chain in polynomial (radical-free) form
+
+The chain `M₁ ≥ M₂ ≥ M₃` is equivalent, after clearing the radicals, to two
+polynomial inequalities. `M12` is exactly `newton_n3_k1`. `M23` is AM–GM applied
+to the three products `xy, yz, zx`. -/
+
+/-- Three-variable AM–GM in cubed form: for non-negative `a, b, c`,
+    `(a+b+c)³ ≥ 27·a·b·c`. Base lemma for the `M₂ ≥ M₃` step. -/
+theorem amgm3_cubed (a b c : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) :
+    (a + b + c) ^ 3 ≥ 27 * (a * b * c) := by
+  nlinarith [mul_nonneg ha (sq_nonneg (b - c)), mul_nonneg hb (sq_nonneg (a - c)),
+    mul_nonneg hc (sq_nonneg (a - b)), mul_nonneg (mul_nonneg ha hb) hc,
+    mul_nonneg ha hb, mul_nonneg hb hc, mul_nonneg ha hc,
+    sq_nonneg (a - b), sq_nonneg (b - c), sq_nonneg (a - c)]
+
+/-- **Maclaurin step M₁ ≥ M₂, polynomial form.** `e₁² ≥ 3·e₂`
+    (this is precisely Newton N1; squaring `M₁ ≥ M₂` clears the `√`). -/
+theorem maclaurin_n3_12_poly (x y z : ℝ) :
+    (x + y + z) ^ 2 ≥ 3 * (x * y + y * z + z * x) :=
+  newton_n3_k1 x y z
+
+/-- **Maclaurin step M₂ ≥ M₃, polynomial form.** For non-negative `x, y, z`,
+    `e₂³ ≥ 27·e₃²`, i.e. `(xy+yz+zx)³ ≥ 27·(xyz)²`. Obtained from `amgm3_cubed`
+    with `a=xy, b=yz, c=zx` (note `a·b·c = (xyz)²`). -/
+theorem maclaurin_n3_23_poly (x y z : ℝ) (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    (x * y + y * z + z * x) ^ 3 ≥ 27 * (x * y * z) ^ 2 := by
+  have h := amgm3_cubed (x * y) (y * z) (z * x)
+    (mul_nonneg hx hy) (mul_nonneg hy hz) (mul_nonneg hz hx)
+  -- a·b·c = (xy)(yz)(zx) = (xyz)²
+  nlinarith [h]
+
+/-! ## Part III: The Maclaurin chain in radical (mean) form
+
+We now state the chain for the honest Maclaurin means using `Real.sqrt` and
+`Real.rpow`. Everything below is derived from the polynomial forms above; there
+are no new axioms. -/
+
+/-- First Maclaurin mean `M₁ = e₁/3`. -/
+noncomputable def M1 (x y z : ℝ) : ℝ := (x + y + z) / 3
+
+/-- Second Maclaurin mean `M₂ = √(e₂/3)`. -/
+noncomputable def M2 (x y z : ℝ) : ℝ := Real.sqrt ((x * y + y * z + z * x) / 3)
+
+/-- Third Maclaurin mean `M₃ = (e₃)^(1/3)`. -/
+noncomputable def M3 (x y z : ℝ) : ℝ := (x * y * z) ^ ((1 : ℝ) / 3)
+
+/-- **Maclaurin chain, step 1 → 2 (mean form).** `M₁ ≥ M₂` for non-negative inputs. -/
+theorem maclaurin_n3_M1_ge_M2 (x y z : ℝ) (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    M1 x y z ≥ M2 x y z := by
+  unfold M1 M2
+  have hsum : 0 ≤ x + y + z := by positivity
+  -- √(e₂/3) ≤ √((e₁/3)²) = e₁/3, using e₂/3 ≤ (e₁/3)² from Newton N1.
+  have hkey : (x * y + y * z + z * x) / 3 ≤ ((x + y + z) / 3) ^ 2 := by
+    nlinarith [newton_n3_k1 x y z]
+  calc Real.sqrt ((x * y + y * z + z * x) / 3)
+      ≤ Real.sqrt (((x + y + z) / 3) ^ 2) := Real.sqrt_le_sqrt hkey
+    _ = (x + y + z) / 3 := by
+        rw [Real.sqrt_sq (by positivity)]
+
+/-- **Maclaurin chain, step 2 → 3 (mean form).** `M₂ ≥ M₃` for non-negative inputs.
+
+    Both means are rewritten as the `1/6`-power of a non-negative quantity:
+    `M₂ = ((e₂/3)³)^(1/6)` and `M₃ = (e₃²)^(1/6)`. The comparison then follows
+    from `maclaurin_n3_23_poly` (`(e₂/3)³ ≥ e₃²`) by monotonicity of `rpow`. -/
+theorem maclaurin_n3_M2_ge_M3 (x y z : ℝ) (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    M2 x y z ≥ M3 x y z := by
+  unfold M2 M3
+  have he2n : 0 ≤ (x * y + y * z + z * x) / 3 := by positivity
+  have he3n : 0 ≤ x * y * z := by positivity
+  -- (e₂/3)³ ≥ (e₃)² , the polynomial Maclaurin step, rescaled by 27.
+  have hpoly : ((x * y + y * z + z * x) / 3) ^ 3 ≥ (x * y * z) ^ 2 := by
+    have h := maclaurin_n3_23_poly x y z hx hy hz
+    nlinarith [h]
+  -- M₃ = (e₃²)^(1/6)
+  have hM3 : (x * y * z) ^ ((1 : ℝ) / 3)
+      = ((x * y * z) ^ 2) ^ ((1 : ℝ) / 6) := by
+    rw [← Real.rpow_natCast (x * y * z) 2, ← Real.rpow_mul he3n]
+    norm_num
+  -- M₂ = √(e₂/3) = ((e₂/3)³)^(1/6)
+  have hM2 : Real.sqrt ((x * y + y * z + z * x) / 3)
+      = (((x * y + y * z + z * x) / 3) ^ 3) ^ ((1 : ℝ) / 6) := by
+    rw [Real.sqrt_eq_rpow, ← Real.rpow_natCast ((x * y + y * z + z * x) / 3) 3,
+      ← Real.rpow_mul he2n]
+    norm_num
+  rw [hM3, hM2]
+  exact Real.rpow_le_rpow (by positivity) hpoly (by norm_num)
+
+/-- **The full three-variable Maclaurin chain, axiom-free.**
+    `M₁ ≥ M₂ ≥ M₃` for non-negative `x, y, z`. Together with `newton_n3_k1`,
+    `newton_n3_k2` this discharges — for `n = 3` — the `newton_log_concavity`
+    axiom and the Maclaurin chain assumed in the parent entry. -/
+theorem maclaurin_n3_chain (x y z : ℝ) (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    M1 x y z ≥ M2 x y z ∧ M2 x y z ≥ M3 x y z :=
+  ⟨maclaurin_n3_M1_ge_M2 x y z hx hy hz, maclaurin_n3_M2_ge_M3 x y z hx hy hz⟩
+
+/-- **AM ≥ GM as the endpoints of the chain.** `M₁ ≥ M₃`, i.e.
+    `(x+y+z)/3 ≥ (xyz)^(1/3)` for non-negative `x, y, z` — the classical AM–GM
+    inequality recovered as the transitive closure of the Maclaurin chain. -/
+theorem maclaurin_n3_am_ge_gm (x y z : ℝ) (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    M1 x y z ≥ M3 x y z :=
+  le_trans (maclaurin_n3_M2_ge_M3 x y z hx hy hz) (maclaurin_n3_M1_ge_M2 x y z hx hy hz)
+
+end AmgmOQ02OQ04

--- a/src/data/proofs/amgm-inequality-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-04/annotations.json
@@ -1,0 +1,88 @@
+[
+  {
+    "id": "ann-amgmoq0204-0",
+    "proofId": "amgm-inequality-oq-02-oq-04",
+    "range": {
+      "startLine": 44,
+      "endLine": 76
+    },
+    "type": "theorem",
+    "title": "Newton's Inequalities for n=3 as Sums of Squares",
+    "content": "The two Newton inequalities for three variables. `newton_n3_k1` gives `(x+y+z)² ≥ 3(xy+yz+zx)` and `newton_n3_k2` gives `(xy+yz+zx)² ≥ 3(x+y+z)·xyz`; both are discharged by `nlinarith` supplied with the three squared differences. Because each is an exact symmetrization identity — recorded by `ring` in `newton_n3_k1_identity` (gap `½∑(x−y)²`) and `newton_n3_k2_identity` (gap `½∑(xy−yz)²`) — they hold for ALL real inputs, not just nonnegative ones. This is precisely the n=3 case of the parent entry's axiomatized `newton_log_concavity`, now proved outright.",
+    "mathContext": "$e_1^2 - 3e_2 = \\tfrac12\\sum(x-y)^2 \\ge 0$ and $e_2^2 - 3e_1e_3 = \\tfrac12\\sum(xy-yz)^2 \\ge 0$, where $e_1=x+y+z,\\ e_2=xy+yz+zx,\\ e_3=xyz$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Newton's inequalities / log-concavity",
+      "Elementary symmetric polynomials",
+      "Sum-of-squares certificates"
+    ],
+    "prerequisites": [
+      "nlinarith with squared-difference hints",
+      "sq_nonneg",
+      "Equal-variable symmetrization"
+    ],
+    "tags": [
+      "theorem",
+      "newton-inequalities",
+      "sum-of-squares",
+      "key-result"
+    ]
+  },
+  {
+    "id": "ann-amgmoq0204-1",
+    "proofId": "amgm-inequality-oq-02-oq-04",
+    "range": {
+      "startLine": 77,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "The Chain in Radical-Free Polynomial Form",
+    "content": "Clearing radicals turns the Maclaurin chain into two polynomial facts. `amgm3_cubed` is three-variable AM–GM in cubed form, `(a+b+c)³ ≥ 27abc` for nonnegative `a,b,c` (nlinarith with Schur-type products). `maclaurin_n3_12_poly` is `e₁² ≥ 3e₂` (just Newton N1). `maclaurin_n3_23_poly` is `e₂³ ≥ 27e₃²`, obtained from `amgm3_cubed` at `a=xy, b=yz, c=zx` (whose product is `(xyz)²`). These are exactly the squared/cubed forms of `M₁ ≥ M₂` and `M₂ ≥ M₃`.",
+    "mathContext": "$M_1\\ge M_2 \\iff e_1^2\\ge 3e_2$ and $M_2\\ge M_3 \\iff e_2^3\\ge 27e_3^2$; the latter is AM–GM on the pairwise products $xy,yz,zx$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "AM–GM inequality",
+      "Radical-free reformulation",
+      "Pairwise-product substitution"
+    ],
+    "prerequisites": [
+      "Three-variable AM–GM",
+      "nlinarith",
+      "Substitution a=xy, b=yz, c=zx"
+    ],
+    "tags": [
+      "theorem",
+      "am-gm",
+      "polynomial-form"
+    ]
+  },
+  {
+    "id": "ann-amgmoq0204-2",
+    "proofId": "amgm-inequality-oq-02-oq-04",
+    "range": {
+      "startLine": 108,
+      "endLine": 179
+    },
+    "type": "theorem",
+    "title": "The Maclaurin Chain for the Radical Means and AM ≥ GM",
+    "content": "The honest means `M₁ = (x+y+z)/3`, `M₂ = √((xy+yz+zx)/3)`, `M₃ = (xyz)^(1/3)`. `maclaurin_n3_M1_ge_M2` uses square-root monotonicity (`Real.sqrt_le_sqrt`, `Real.sqrt_sq`) on Newton N1. `maclaurin_n3_M2_ge_M3` rewrites both means as common 1/6-powers — `M₂ = ((e₂/3)³)^(1/6)`, `M₃ = (e₃²)^(1/6)` via `Real.sqrt_eq_rpow`, `Real.rpow_natCast`, `Real.rpow_mul` — and applies `Real.rpow_le_rpow` to `(e₂/3)³ ≥ e₃²`. `maclaurin_n3_chain` packages the full chain and `maclaurin_n3_am_ge_gm` recovers AM ≥ GM as its endpoints. Zero axioms remain (`#print axioms`: only propext/Classical.choice/Quot.sound).",
+    "mathContext": "$\\tfrac{x+y+z}{3} \\ge \\sqrt{\\tfrac{xy+yz+zx}{3}} \\ge (xyz)^{1/3}$ for $x,y,z\\ge 0$, with equality iff $x=y=z$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Maclaurin means",
+      "rpow monotonicity",
+      "Arithmetic–geometric mean inequality"
+    ],
+    "prerequisites": [
+      "Real.sqrt and Real.rpow monotonicity",
+      "Common-exponent comparison",
+      "Transitivity of ≥"
+    ],
+    "tags": [
+      "theorem",
+      "maclaurin-chain",
+      "am-gm",
+      "key-result"
+    ]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-04/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "amgm-inequality-oq-02-oq-04",
+  "title": "Newton's Inequalities for Three Variables: the n=3 Maclaurin Chain, Axiom-Free",
+  "slug": "amgm-inequality-oq-02-oq-04",
+  "description": "The parent Maclaurin entry (amgm-inequality-oq-02) proves the k=1 Newton inequality from scratch but AXIOMATIZES the general Newton log-concavity (newton_log_concavity) and, through it, the full Maclaurin chain. This follow-up discharges that axiom completely for n=3: via Maclaurin's own equal-variable symmetrization — which for three variables is an explicit sum-of-squares identity — it proves both Newton inequalities e₁² ≥ 3e₂ and e₂² ≥ 3e₁e₃ (each an exact SOS, valid for ALL reals), and derives the entire three-variable Maclaurin chain M₁ ≥ M₂ ≥ M₃ for the honest radical means, recovering AM ≥ GM as the endpoints. Zero axioms, zero sorries.",
+  "meta": {
+    "author": "Colin Maclaurin (1729), Isaac Newton (1707); formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Maclaurin%27s_inequality",
+    "date": "1729",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ04.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "mean-inequalities",
+      "elementary-symmetric-polynomials",
+      "sum-of-squares",
+      "newton-inequalities",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sqrt_le_sqrt",
+        "description": "Monotonicity of the square root, used to pass from e₂/3 ≤ (e₁/3)² to √(e₂/3) ≤ e₁/3 in the M₁ ≥ M₂ step",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Real.sqrt_sq",
+        "description": "For x ≥ 0, √(x²) = x, collapsing √((e₁/3)²) to e₁/3",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Real.sqrt_eq_rpow",
+        "description": "√x = x^(1/2), rewriting M₂ as a real power so both M₂ and M₃ can be compared as 1/6-powers",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      },
+      {
+        "theorem": "Real.rpow_natCast",
+        "description": "x^(n : ℝ) = x^n, bridging natural powers of the symmetric functions and their real (rpow) powers",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_mul",
+        "description": "For x ≥ 0, x^(y·z) = (x^y)^z, used to fold (e₃²)^(1/6) = e₃^(1/3) and ((e₂/3)³)^(1/6) = √(e₂/3)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "Monotonicity of rpow in the base for a fixed nonnegative exponent, delivering M₂ ≥ M₃ from (e₂/3)³ ≥ e₃²",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "sq_nonneg",
+        "description": "x² ≥ 0, the raw material of every sum-of-squares certificate for the Newton inequalities and AM–GM",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "newton_n3_k1: Newton's inequality N1 for n=3, (x+y+z)² ≥ 3(xy+yz+zx), proved by nlinarith on the three squared differences — valid for all reals",
+      "newton_n3_k2: Newton's inequality N2 for n=3, (xy+yz+zx)² ≥ 3(x+y+z)·xyz, proved by nlinarith on (xy−yz)², (yz−zx)², (zx−xy)² — also valid for all reals, no non-negativity needed",
+      "newton_n3_k1_identity / newton_n3_k2_identity: the exact equal-variable symmetrization identities exhibiting each Newton gap as ½·∑(x−y)² and ½·∑(xy−yz)², proved by ring",
+      "amgm3_cubed: three-variable AM–GM in cubed form (a+b+c)³ ≥ 27abc for nonnegative a,b,c",
+      "maclaurin_n3_12_poly / maclaurin_n3_23_poly: the radical-free Maclaurin chain steps e₁² ≥ 3e₂ and e₂³ ≥ 27e₃² (the latter from amgm3_cubed on xy, yz, zx)",
+      "M1, M2, M3: the honest Maclaurin means (x+y+z)/3, √((xy+yz+zx)/3), (xyz)^(1/3)",
+      "maclaurin_n3_M1_ge_M2: M₁ ≥ M₂ via sqrt monotonicity from Newton N1",
+      "maclaurin_n3_M2_ge_M3: M₂ ≥ M₃ by rewriting both as 1/6-powers and applying rpow monotonicity to (e₂/3)³ ≥ e₃²",
+      "maclaurin_n3_chain: the full chain M₁ ≥ M₂ ≥ M₃, discharging (for n=3) the parent's newton_log_concavity axiom and its Maclaurin step",
+      "maclaurin_n3_am_ge_gm: AM ≥ GM, (x+y+z)/3 ≥ (xyz)^(1/3), recovered as the transitive endpoints of the chain"
+    ],
+    "dateAdded": "2026-07-01",
+    "prerequisites": [
+      "Elementary symmetric polynomials e₁, e₂, e₃ of three variables",
+      "Sum-of-squares (SOS) certificates and nlinarith",
+      "Three-variable AM–GM and its cubed (radical-free) form",
+      "Real powers: Real.sqrt, Real.rpow and their monotonicity"
+    ],
+    "relatedProblems": [
+      {
+        "id": "amgm-inequality-oq-02",
+        "relationship": "Parent: proves Newton k=1 and axiomatizes the general Newton log-concavity plus the Maclaurin chain; this entry discharges that axiom in full for n=3."
+      },
+      {
+        "id": "amgm-inequality",
+        "relationship": "Ancestor: the AM–GM inequality, recovered here as the endpoints M₁ ≥ M₃ of the three-variable Maclaurin chain."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 179,
+    "assumptions": "0 axioms, 0 sorries. #print axioms reports only [propext, Classical.choice, Quot.sound] for newton_n3_k1, newton_n3_k2, maclaurin_n3_chain, and maclaurin_n3_am_ge_gm. Crucially, the parent's newton_log_concavity axiom is NOT used — both Newton inequalities for n=3 are proved directly from sum-of-squares certificates (and are in fact valid for all real inputs, not merely nonnegative ones). The Maclaurin chain M₁ ≥ M₂ ≥ M₃ is over the honest radical means for nonnegative x, y, z. Verified with Lean toolchain 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Newton (Arithmetica Universalis, 1707) observed that the normalized elementary symmetric means pₖ = eₖ/C(n,k) of a real-rooted polynomial are log-concave: pₖ² ≥ pₖ₋₁pₖ₊₁. Maclaurin (1729) deduced from this the chain of mean inequalities M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ, with AM ≥ GM as the extreme case. The general Newton inequalities require the real-rootedness / Rolle machinery and are still absent from Mathlib — the parent entry therefore assumes them as newton_log_concavity. For three variables, however, Newton's inequalities are elementary sum-of-squares identities, so the whole chain can be made unconditional.",
+    "problemStatement": "For n=3, discharge the parent's newton_log_concavity axiom: prove both Newton inequalities and the complete Maclaurin chain M₁ ≥ M₂ ≥ M₃ (hence AM ≥ GM) with no axioms.",
+    "text": "Writing e₁ = x+y+z, e₂ = xy+yz+zx, e₃ = xyz, the two Newton inequalities are e₁² ≥ 3e₂ and e₂² ≥ 3e₁e₃. Each is an exact symmetrization identity: e₁² − 3e₂ = ½[(x−y)²+(y−z)²+(z−x)²] and e₂² − 3e₁e₃ = ½[(xy−yz)²+(yz−zx)²+(zx−xy)²], so both hold for all reals. The Maclaurin chain follows after clearing radicals: M₁ ≥ M₂ is exactly e₁² ≥ 3e₂, and M₂ ≥ M₃ is e₂³ ≥ 27e₃², i.e. AM–GM on the three products xy, yz, zx.",
+    "proofStrategy": "The Newton inequalities are discharged by nlinarith fed the relevant squared differences (equivalently the ring identities newton_n3_k1_identity, newton_n3_k2_identity). For the radical means, M₁ ≥ M₂ uses monotonicity of √ (Real.sqrt_le_sqrt then Real.sqrt_sq). M₂ ≥ M₃ is obtained by rewriting M₂ = ((e₂/3)³)^(1/6) and M₃ = (e₃²)^(1/6) — via Real.sqrt_eq_rpow, Real.rpow_natCast, Real.rpow_mul — and applying Real.rpow_le_rpow to the polynomial step e₂³ ≥ 27e₃² (proved from the cubed AM–GM amgm3_cubed). Transitivity gives AM ≥ GM.",
+    "keyInsights": [
+      "For three variables the Newton inequalities are exact sums of squares, so no real-rootedness machinery (and no axiom) is needed",
+      "Both Newton inequalities in fact hold for ALL real x, y, z — non-negativity is only required to interpret the radical means",
+      "The full Maclaurin chain reduces to two polynomial facts: e₁² ≥ 3e₂ (Newton N1) and e₂³ ≥ 27e₃² (AM–GM on the pairwise products)",
+      "Comparing M₂ = √(e₂/3) and M₃ = (e₃)^(1/3) as common 1/6-powers turns the radical inequality into the single polynomial inequality (e₂/3)³ ≥ e₃²",
+      "AM ≥ GM emerges for free as the transitive endpoints M₁ ≥ M₃ of the chain"
+    ],
+    "prerequisites": [
+      "Elementary symmetric polynomials of three variables",
+      "Sum-of-squares certificates and nlinarith",
+      "Three-variable AM–GM in cubed form",
+      "Real powers (Real.sqrt, Real.rpow) and their monotonicity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "newton",
+      "title": "Newton's Inequalities for n=3 (Sum-of-Squares)",
+      "startLine": 44,
+      "endLine": 76,
+      "summary": "newton_n3_k1 and newton_n3_k2: the two Newton inequalities e₁² ≥ 3e₂ and e₂² ≥ 3e₁e₃, each proved by nlinarith on the squared differences and valid for all reals; newton_n3_k1_identity / newton_n3_k2_identity exhibit the exact SOS remainders ½∑(x−y)² and ½∑(xy−yz)².",
+      "mathContext": "For three variables Newton's log-concavity is an unconditional sum-of-squares identity, so it needs no real-rootedness machinery — this is exactly the n=3 case the parent left axiomatized."
+    },
+    {
+      "id": "poly-chain",
+      "title": "The Maclaurin Chain in Radical-Free Form",
+      "startLine": 77,
+      "endLine": 107,
+      "summary": "amgm3_cubed: (a+b+c)³ ≥ 27abc for nonnegative a,b,c; maclaurin_n3_12_poly (e₁² ≥ 3e₂, = Newton N1) and maclaurin_n3_23_poly (e₂³ ≥ 27e₃², via AM–GM on xy, yz, zx) are the two polynomial steps of the chain after clearing radicals.",
+      "mathContext": "Squaring/cubing the mean inequalities converts M₁ ≥ M₂ ≥ M₃ into polynomial statements provable by SOS and AM–GM."
+    },
+    {
+      "id": "mean-chain",
+      "title": "The Maclaurin Chain for the Radical Means",
+      "startLine": 108,
+      "endLine": 179,
+      "summary": "The honest means M₁ = (x+y+z)/3, M₂ = √((xy+yz+zx)/3), M₃ = (xyz)^(1/3); maclaurin_n3_M1_ge_M2 (√-monotonicity), maclaurin_n3_M2_ge_M3 (rpow 1/6-power comparison), the packaged chain maclaurin_n3_chain, and maclaurin_n3_am_ge_gm recovering AM ≥ GM.",
+      "mathContext": "Comparing the radical means as common 1/6-powers reduces each step to the polynomial inequalities above; transitivity yields the arithmetic-geometric mean inequality."
+    }
+  ],
+  "conclusion": {
+    "summary": "For three variables, both Newton inequalities and the entire Maclaurin chain M₁ ≥ M₂ ≥ M₃ are proved with zero axioms and zero sorries, discharging the parent entry's newton_log_concavity assumption in this case. The Newton inequalities are exact sums of squares (valid for all reals); the chain for the radical means follows by square-root and rpow monotonicity, and AM ≥ GM drops out as the endpoints.",
+    "implications": "This pins down the elementary, axiom-free core of Maclaurin's theorem at n=3: the deep real-rootedness input is only needed to push past three variables. The sum-of-squares certificates are constructive and quantitative, giving explicit slack (the symmetrization remainders) that vanishes exactly at x=y=z.",
+    "openQuestions": [
+      "Prove the n=4 Newton inequalities (e₂² ≥ e₁e₃ type at C(4,k) normalization) axiom-free by an explicit SOS/Schur certificate, extending the chain to four variables.",
+      "Quantify the slack: express M₁ − M₃ (or M₁² − M₂²) in terms of the symmetrization sums of squares to get a stability version of AM–GM for three variables."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "AmgmOQ02OQ04",
+    "lineCount": 179,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "path": "Proofs/AmgmInequalityOQ02OQ04.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "extends",
+      "description": "Discharges, for n=3, the parent's axiomatized Newton log-concavity and its Maclaurin chain step, using explicit sum-of-squares certificates."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "Recovers the AM–GM inequality as the endpoints M₁ ≥ M₃ of the three-variable Maclaurin chain."
+    }
+  ],
+  "references": [
+    {
+      "key": "Maclaurin1729",
+      "citation": "Maclaurin, C., A Second Letter to Martin Folkes, Esq.; concerning the Roots of Equations, with the Demonstration of other Rules in Algebra, Phil. Trans. 36 (1729), 59–96.",
+      "type": "article"
+    },
+    {
+      "key": "HLP52",
+      "citation": "Hardy, G.H., Littlewood, J.E. and Pólya, G., Inequalities, 2nd ed., Cambridge University Press (1952), §2.22 (Newton's and Maclaurin's inequalities).",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Discharges — for **n = 3** — the axiom `newton_log_concavity` (and the Maclaurin chain step it powers) that the parent entry **amgm-inequality-oq-02** leaves assumed. The engine is Maclaurin's own *equal-variable symmetrization*, which for three variables is an explicit **sum-of-squares** identity.

**Answers OQ** `amgm-inequality-oq-02-oq-04`: "Connect to Maclaurin's original 1729 proof via equal-variable symmetrization."

## What is proved (0 axioms, 0 sorries)

Elementary symmetric polynomials `e₁ = x+y+z`, `e₂ = xy+yz+zx`, `e₃ = xyz`.

- **Newton's inequalities (n=3), as exact SOS — valid for all reals:**
  - `newton_n3_k1`: `e₁² ≥ 3e₂`, remainder `½∑(x−y)²`
  - `newton_n3_k2`: `e₂² ≥ 3e₁e₃`, remainder `½∑(xy−yz)²`
  - `newton_n3_k1_identity` / `newton_n3_k2_identity`: the `ring`-checked symmetrization identities
- **Radical-free chain steps:** `amgm3_cubed` (`(a+b+c)³ ≥ 27abc`), `maclaurin_n3_12_poly` (`e₁² ≥ 3e₂`), `maclaurin_n3_23_poly` (`e₂³ ≥ 27e₃²`)
- **Radical-mean chain:** `M₁ = (x+y+z)/3`, `M₂ = √(e₂/3)`, `M₃ = (e₃)^(1/3)`; `maclaurin_n3_M1_ge_M2`, `maclaurin_n3_M2_ge_M3`, `maclaurin_n3_chain` (`M₁ ≥ M₂ ≥ M₃`), and `maclaurin_n3_am_ge_gm` recovering **AM ≥ GM** as the endpoints

## Verification

- `#print axioms` on the headline theorems reports only `[propext, Classical.choice, Quot.sound]` — **status: verified, badge: original, axiomCount 0**.
- Compiled with Lean toolchain `v4.26.0` (Docker unavailable — containerd meta.db I/O error; verified via direct-lean over the repo's package oleans with the pinned toolchain).
- 11 theorems, 3 definitions, 179 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)