### PR TITLE
research(schroeder-bernstein-oq-03): formalize Σ₁ obstruction — range g is REPred [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -52,6 +52,9 @@ computable via Partrec.rfind. The orbit type is determined by bounded search.
 - fwdOrbit_eq_iterate: proved (forward orbit = iteration of g∘f; forward direction is computable)
 - isGFree_iff_not_mem_range: proved — pins down WHY the naive orbit classification is
   not computable: `isGFree` is Π₁ (complement of the c.e. set `range g`), hence undecidable
+- partialInverse_dom_iff: proved — the domain of `partialInverse g` is *exactly* `range g`
+- range_rePred: proved — `range g` is `REPred` (Σ₁ / computably enumerable) for computable g;
+  machine-checked form of the obstruction (its complement `isGFree` is thus Π₁)
 - decidableIsGFree: proved — the Π₁ obstruction becomes decidable once `range g` is decidable
 - totalInverse_{mem,right,left,computable}: proved — a surjective computable injection has a
   total, computable two-sided inverse (partialInverse becomes everywhere-defined)
@@ -142,6 +145,23 @@ theorem partialInverse_dom {g : ℕ → ℕ} {m : ℕ} (hm : ∃ k, g k = m) :
   rw [partialInverse, Nat.rfind_dom']
   exact ⟨k, by simp [hk], fun _ => trivial⟩
 
+/-- The partial inverse is **defined at `m` exactly when `m ∈ range g`**. This is
+    the sharp form of `partialInverse_dom`: the domain of the partial-recursive
+    `partialInverse g` is *precisely* the range of `g` (no injectivity needed).
+    Combined with `partialInverse_partrec`, it exhibits `Set.range g` as the domain
+    of a computable partial function — i.e. as a `Σ₁` (computably enumerable) set;
+    see `range_rePred`. -/
+theorem partialInverse_dom_iff {g : ℕ → ℕ} (m : ℕ) :
+    (partialInverse g m).Dom ↔ m ∈ Set.range g := by
+  constructor
+  · intro h
+    -- The value returned by `rfind` is a genuine preimage, so `m` is in the range.
+    have hmem : (partialInverse g m).get h ∈ partialInverse g m := Part.get_mem h
+    have hspec := Nat.rfind_spec hmem
+    exact ⟨_, by simpa using hspec⟩
+  · rintro ⟨k, hk⟩
+    exact partialInverse_dom ⟨k, hk⟩
+
 /-- The partial inverse is **single-valued** under an injective `g`: any two
     values returned for the same `m` coincide. This is the bijectivity fact the
     back-and-forth construction needs — extending the partial map by a `g`-edge
@@ -200,6 +220,20 @@ def isGFree (g : ℕ → ℕ) (n : ℕ) : Prop := ∀ k, g k ≠ n
 theorem isGFree_iff_not_mem_range (g : ℕ → ℕ) (n : ℕ) :
     isGFree g n ↔ n ∉ Set.range g := by
   simp only [isGFree, Set.mem_range, not_exists, ne_eq]
+
+/-- **`Set.range g` is computably enumerable** (`Σ₁`) for any computable `g`.
+
+    This is the machine-checked form of the prose obstruction on
+    `isGFree_iff_not_mem_range`: `range g` is exactly the domain of the
+    partial-recursive function `partialInverse g` (`partialInverse_dom_iff`), and the
+    domain of a partial-recursive function is an `REPred` by `Partrec.dom_re`. Hence
+    `range g` is `Σ₁`. Its complement `isGFree g` is therefore `Π₁`, which — for a
+    merely computable (non-surjective) `g` whose range is not decidable — is in
+    general **undecidable**. This is the precise reason the classical orbit
+    classification is not computable, previously only asserted informally. -/
+theorem range_rePred {g : ℕ → ℕ} (hgc : Computable g) :
+    REPred (fun m => m ∈ Set.range g) :=
+  ((partialInverse_partrec hgc).dom_re).of_eq fun m => partialInverse_dom_iff m
 
 /-!
 ## Section 4b: Isolating the Π₁ obstruction — the fully computable case

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -41,10 +41,40 @@ two computable injections yield a *computable* permutation — is the OPEN targe
   computable (difficulty is entirely backward).
 - `isGFree_iff_not_mem_range` — the Π₁ obstruction lemma (see above).
 
+## Session 2026-07-01 (researcher-2): formalize the Σ₁ obstruction [VERIFIED, 0-axiom]
+
+**Mode**: STUCK strategy → *decompose*, not broaden. The lone remaining sorry is the
+full hard-direction back-and-forth (research-level ~200 L, open across 3+ sessions).
+Rather than scaffold or spin Aristotle on an open construction, turned the prose
+obstruction into machine-checked theorems.
+
+**Added (both proved, file compiles clean via `lake env lean`; docker containerd I/O
+still broken):**
+- `partialInverse_dom_iff : (partialInverse g m).Dom ↔ m ∈ Set.range g` — the domain
+  of the partial-recursive `partialInverse g` is *exactly* `range g` (no injectivity
+  needed; sharpens `partialInverse_dom` to an iff).
+- `range_rePred : Computable g → REPred (fun m => m ∈ Set.range g)` — **`range g` is
+  computably enumerable (Σ₁)** for computable `g`. Proof: `range g` = domain of the
+  partrec `partialInverse g` (`partialInverse_dom_iff`) + `Partrec.dom_re` (Mathlib:
+  domain of a partrec function is `REPred`). This is the machine-checked form of what
+  `isGFree_iff_not_mem_range` only asserted in prose: `isGFree g` is the complement of
+  a Σ₁ set, hence Π₁ and (for non-decidable-range `g`) undecidable — the precise reason
+  the classical orbit classification is non-computable.
+
+**Key Mathlib facts discovered**: `REPred` and `Partrec.dom_re` live in
+`Mathlib/Computability/Halting.lean`, reachable because `Computability.Reduce`
+`public import`s `Halting`. No `RePred` (note capitalization: it is `REPred`).
+
+**Gallery**: meta leanFile lineCount 269→430 (was stale — prior sessions added ~130 L
+without updating), theoremCount 14→16; added curated `range_rePred` theorem entry;
+realigned all 7 annotation ranges (were calibrated to the 269-L version) + added an
+`ann-myhill-obstruction` annotation covering Sections 4/4b.
+
 ## Dead Ends
 
 - Reading the computable bijection off the classical SB orbit decomposition:
-  blocked by the Π₁ undecidability of `isGFree`/`range g` membership.
+  blocked by the Π₁ undecidability of `isGFree`/`range g` membership (now made precise
+  by `range_rePred`: the complement of a genuinely Σ₁ set).
 
 ## Next Steps
 

--- a/src/data/proofs/schroeder-bernstein-oq-03/annotations.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/annotations.json
@@ -4,11 +4,11 @@
     "proofId": "schroeder-bernstein-oq-03",
     "range": {
       "startLine": 1,
-      "endLine": 62
+      "endLine": 70
     },
     "type": "concept",
-    "title": "Myhill's Isomorphism Theorem: Computable Analogue of Schr\u00f6der-Bernstein",
-    "content": "The module docstring presents Myhill's 1955 theorem as the computable version of Cantor-Schr\u00f6der-Bernstein: classical CBS gives any bijection from two injections; Myhill's theorem gives a computable bijection from two computable injections. The key distinction is between many-one reducibility (\u2264\u2098, function need not be injective) and one-one reducibility (\u2264\u2081, function must be injective). The back-and-forth construction classifies each n by its backward orbit type (A: chain exits range(g), B: chain exits range(f), C: infinite). References to Myhill (1955, creative sets), Rogers (1967, \u00a77.4), and Soare (2016, Chapter 3) establish the classical literature context.",
+    "title": "Myhill's Isomorphism Theorem: Computable Analogue of Schröder-Bernstein",
+    "content": "The module docstring presents Myhill's 1955 theorem as the computable version of Cantor-Schröder-Bernstein: classical CBS gives any bijection from two injections; Myhill's theorem gives a computable bijection from two computable injections. The key distinction is between many-one reducibility (≤ₘ, function need not be injective) and one-one reducibility (≤₁, function must be injective). The back-and-forth construction classifies each n by its backward orbit type (A: chain exits range(g), B: chain exits range(f), C: infinite). References to Myhill (1955, creative sets), Rogers (1967, §7.4), and Soare (2016, Chapter 3) establish the classical literature context.",
     "mathContext": "One-one reducibility: $p \\leq_1 q$ iff $\\exists$ computable injective $f$ with $\\forall n, p(n) \\leftrightarrow q(f(n))$. One-one equivalence: $p \\equiv_1 q$ iff $p \\leq_1 q$ and $q \\leq_1 p$. Myhill: $p \\equiv_1 q \\iff \\exists$ computable permutation $e : \\mathbb{N} \\simeq \\mathbb{N}$ with $\\forall n, p(n) \\leftrightarrow q(e(n))$. Back-and-forth: orbit $n \\leftarrow g^{-1}(n) \\leftarrow f^{-1}(g^{-1}(n)) \\leftarrow \\cdots$ determines which injection to use for $\\sigma(n)$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -16,7 +16,7 @@
       "many-one reducibility",
       "creative sets",
       "back-and-forth argument",
-      "Cantor-Schr\u00f6der-Bernstein"
+      "Cantor-Schröder-Bernstein"
     ],
     "prerequisites": [
       "computability theory basics",
@@ -28,8 +28,8 @@
     "id": "ann-myhill-corresponds",
     "proofId": "schroeder-bernstein-oq-03",
     "range": {
-      "startLine": 64,
-      "endLine": 70
+      "startLine": 76,
+      "endLine": 82
     },
     "type": "definition",
     "title": "Corresponds: Predicate Mapping Under a Permutation",
@@ -51,12 +51,12 @@
     "id": "ann-myhill-easy",
     "proofId": "schroeder-bernstein-oq-03",
     "range": {
-      "startLine": 73,
-      "endLine": 94
+      "startLine": 84,
+      "endLine": 106
     },
     "type": "insight",
     "title": "Easy Direction: Computable Bijection Implies One-One Equivalence",
-    "content": "The easy direction is fully proved. Given a computable bijection e with Corresponds p e q, construct: (1) e witnesses p \u2264\u2081 q \u2014 e is computable (he.1), injective (e.injective), and maps p to q (hpq). (2) e.symm witnesses q \u2264\u2081 p \u2014 e.symm is computable (he.2), injective, and the iff q n \u2194 p (e.symm n) follows by applying hpq at e.symm(n) and using e(e.symm(n)) = n. The simp/Equiv.apply_symm_apply lemma handles the cancellation. The variant one_one_equiv_of_computable_perm takes explicit Computable hypotheses rather than e.Computable.",
+    "content": "The easy direction is fully proved. Given a computable bijection e with Corresponds p e q, construct: (1) e witnesses p ≤₁ q — e is computable (he.1), injective (e.injective), and maps p to q (hpq). (2) e.symm witnesses q ≤₁ p — e.symm is computable (he.2), injective, and the iff q n ↔ p (e.symm n) follows by applying hpq at e.symm(n) and using e(e.symm(n)) = n. The simp/Equiv.apply_symm_apply lemma handles the cancellation. The variant one_one_equiv_of_computable_perm takes explicit Computable hypotheses rather than e.Computable.",
     "mathContext": "Proof of $q(n) \\leftrightarrow p(e^{-1}(n))$: by hypothesis, $p(e^{-1}(n)) \\leftrightarrow q(e(e^{-1}(n))) = q(n)$. So the iff holds by symmetry. This uses the key identity $e \\circ e^{-1} = \\text{id}$, i.e., $e(e^{-1}(n)) = n$ for all $n$.",
     "significance": "key",
     "relatedConcepts": [
@@ -75,12 +75,12 @@
     "id": "ann-myhill-partial-inverse",
     "proofId": "schroeder-bernstein-oq-03",
     "range": {
-      "startLine": 97,
-      "endLine": 134
+      "startLine": 108,
+      "endLine": 172
     },
     "type": "concept",
-    "title": "Partial Inverse via Nat.rfind \u2014 Infrastructure for the Hard Direction",
-    "content": "The partial inverse partialInverse(g)(m) = Nat.rfind(n \u21a6 decide(g(n) = m)) searches for a preimage of m under g using unbounded search. Three key lemmas are stated (with sorry): (1) partialInverse_partrec: if g is computable, the partial inverse is Partrec. (2) partialInverse_spec: if n \u2208 partialInverse(g)(m), then g(n) = m. (3) partialInverse_dom: elements in range(g) have a defined partial inverse. The forward orbit fwdOrbit(f,g,n,k) = (g\u2218f)^k(n) is defined by recursion. isGFree(g)(n) captures that n \u2209 range(g), the condition for Type A orbit classification.",
+    "title": "Partial Inverse via Nat.rfind — Infrastructure for the Hard Direction",
+    "content": "The partial inverse partialInverse(g)(m) = Nat.rfind(n ↦ decide(g(n) = m)) searches for a preimage of m under g using unbounded search. Three key lemmas are stated (with sorry): (1) partialInverse_partrec: if g is computable, the partial inverse is Partrec. (2) partialInverse_spec: if n ∈ partialInverse(g)(m), then g(n) = m. (3) partialInverse_dom: elements in range(g) have a defined partial inverse. The forward orbit fwdOrbit(f,g,n,k) = (g∘f)^k(n) is defined by recursion. isGFree(g)(n) captures that n ∉ range(g), the condition for Type A orbit classification.",
     "mathContext": "Partial inverse: $g^{-1}(m) := \\mu n[g(n) = m]$ (least $n$ with $g(n) = m$ if one exists, undefined otherwise). By `Nat.rfind_mem`: $n \\in \\text{Nat.rfind}(P) \\iff P(n) = \\text{true} \\wedge \\forall m < n, P(m) = \\text{false}$. `Partrec.rfind` states: if $P : \\mathbb{N} \\to \\mathbb{N}$ is partial recursive, then $\\mu n[P(n) = 0]$ is partial recursive. Applied here: $(m, n) \\mapsto \\text{decide}(g(n) = m)$ is computable (as $g$ is computable), so $g^{-1}$ is `Partrec`.",
     "significance": "key",
     "relatedConcepts": [
@@ -97,15 +97,39 @@
     ]
   },
   {
+    "id": "ann-myhill-obstruction",
+    "proofId": "schroeder-bernstein-oq-03",
+    "range": {
+      "startLine": 174,
+      "endLine": 315
+    },
+    "type": "concept",
+    "title": "The Π₁ Obstruction: Why the Classical Orbit Construction Isn't Computable",
+    "content": "For a merely computable injection g, the set range g is computably enumerable (Σ₁) — proved machine-checked as range_rePred, since range g is exactly the domain of the partial-recursive partialInverse g (partialInverse_dom_iff) and domains of partial-recursive functions are REPred (Partrec.dom_re). Its complement isGFree g (= · ∉ range g, via isGFree_iff_not_mem_range) is therefore Π₁ and in general undecidable. The classical Schröder–Bernstein orbit classification must decide whether a backward chain leaves range g, i.e. it must evaluate isGFree — so it does not yield a computable bijection. This is precisely why Myhill's theorem cannot be read off the classical proof and needs the stage-wise bounded back-and-forth. The obstruction vanishes when range g is decidable (decidableIsGFree) or when g is already a bijection (computable_bijection_isComputablePerm).",
+    "mathContext": "Arithmetical hierarchy: Σ₁ (c.e.) vs Π₁ (co-c.e.); recursively enumerable sets as domains of partial recursive functions.",
+    "significance": "Isolates the exact computability barrier and formalizes it as a theorem (range_rePred) rather than prose, complementing the fully-computable special cases.",
+    "relatedConcepts": [
+      "recursively enumerable set",
+      "arithmetical hierarchy",
+      "partial recursive function",
+      "Schröder–Bernstein theorem"
+    ],
+    "prerequisites": [
+      "computably enumerable sets",
+      "partial recursive functions",
+      "Nat.rfind"
+    ]
+  },
+  {
     "id": "ann-myhill-main-theorem",
     "proofId": "schroeder-bernstein-oq-03",
     "range": {
-      "startLine": 136,
-      "endLine": 183
+      "startLine": 316,
+      "endLine": 356
     },
     "type": "insight",
-    "title": "Myhill's Isomorphism Theorem \u2014 Full Statement with Hard Direction (sorry'd)",
-    "content": "The main theorem myhill_isomorphism states the full biconditional. The easy direction (\u2190) immediately applies myhill_easy. The hard direction (\u2192) is sorry'd with a detailed comment explaining the back-and-forth construction: at stage 2k, ensure k \u2208 dom(\u03c3); at stage 2k+1, ensure k \u2208 range(\u03c3). The priority argument uses: (a) each stage terminates by injectivity of f and g; (b) domain/range exhaustion covers all of \u2115; (c) the membership condition p(n) \u2194 q(\u03c3(n)) is preserved; (d) computability from partialInverse_partrec. The sorry covers approximately 200 lines of Partrec-based formalization.",
+    "title": "Myhill's Isomorphism Theorem — Full Statement with Hard Direction (sorry'd)",
+    "content": "The main theorem myhill_isomorphism states the full biconditional. The easy direction (←) immediately applies myhill_easy. The hard direction (→) is sorry'd with a detailed comment explaining the back-and-forth construction: at stage 2k, ensure k ∈ dom(σ); at stage 2k+1, ensure k ∈ range(σ). The priority argument uses: (a) each stage terminates by injectivity of f and g; (b) domain/range exhaustion covers all of ℕ; (c) the membership condition p(n) ↔ q(σ(n)) is preserved; (d) computability from partialInverse_partrec. The sorry covers approximately 200 lines of Partrec-based formalization.",
     "mathContext": "Hard direction strategy: define $\\sigma$ via stage-by-stage extension. At each stage, either extend $\\sigma$'s domain (using $f$) or ensure an element is in $\\sigma$'s range (using $g^{-1}$). Orbit classification: for $n$, let $n_0 = n$, $n_1 = g^{-1}(n_0)$, $n_2 = f^{-1}(n_1)$, $n_3 = g^{-1}(n_2), \\ldots$ If the chain terminates because $n_k \\notin \\text{range}(g)$ (Type A) or $n_k \\notin \\text{range}(f)$ (Type B), or runs forever (Type C): use $\\sigma(n) = f(n)$ for Type A and C, $\\sigma(n) = g^{-1}(n)$ for Type B.",
     "significance": "key",
     "relatedConcepts": [
@@ -126,13 +150,13 @@
     "id": "ann-myhill-equivalence-relation",
     "proofId": "schroeder-bernstein-oq-03",
     "range": {
-      "startLine": 186,
-      "endLine": 234
+      "startLine": 357,
+      "endLine": 408
     },
     "type": "insight",
     "title": "Computable Isomorphism is an Equivalence Relation",
-    "content": "Six theorems establish the equivalence-relation structure. myhill_self: use the identity permutation (Equiv.refl \u2115, trivially computable, trivially maps p to p). myhill_symm: if e witnesses p \u2243_c q, then e.symm witnesses q \u2243_c p (using the same Computable pair with .symm). myhill_trans: if e\u2081 witnesses p \u2243_c q and e\u2082 witnesses q \u2243_c r, then e\u2081.trans e\u2082 witnesses p \u2243_c r (using Computable.trans, and (hpq n).trans (hqr (e\u2081 n)) for the correspondence). computable_iso_is_equivalence packages these into the Mathlib Equivalence structure.",
-    "mathContext": "Reflexivity: $e = \\text{id}$, $p(n) \\leftrightarrow p(\\text{id}(n)) = p(n)$ by `Iff.rfl`. Symmetry: $p(n) \\leftrightarrow q(e(n)) \\Rightarrow q(m) \\leftrightarrow p(e^{-1}(m))$ by substituting $n = e^{-1}(m)$. Transitivity: $p(n) \\leftrightarrow q(e_1(n)) \\leftrightarrow r(e_2(e_1(n))) = r((e_1 \\circ e_2)(n))$ using `Iff.trans`. Composition of computable functions is computable: `he\u2081.trans he\u2082`.",
+    "content": "Six theorems establish the equivalence-relation structure. myhill_self: use the identity permutation (Equiv.refl ℕ, trivially computable, trivially maps p to p). myhill_symm: if e witnesses p ≃_c q, then e.symm witnesses q ≃_c p (using the same Computable pair with .symm). myhill_trans: if e₁ witnesses p ≃_c q and e₂ witnesses q ≃_c r, then e₁.trans e₂ witnesses p ≃_c r (using Computable.trans, and (hpq n).trans (hqr (e₁ n)) for the correspondence). computable_iso_is_equivalence packages these into the Mathlib Equivalence structure.",
+    "mathContext": "Reflexivity: $e = \\text{id}$, $p(n) \\leftrightarrow p(\\text{id}(n)) = p(n)$ by `Iff.rfl`. Symmetry: $p(n) \\leftrightarrow q(e(n)) \\Rightarrow q(m) \\leftrightarrow p(e^{-1}(m))$ by substituting $n = e^{-1}(m)$. Transitivity: $p(n) \\leftrightarrow q(e_1(n)) \\leftrightarrow r(e_2(e_1(n))) = r((e_1 \\circ e_2)(n))$ using `Iff.trans`. Composition of computable functions is computable: `he₁.trans he₂`.",
     "significance": "supporting",
     "relatedConcepts": [
       "Equivalence in Lean 4",
@@ -151,12 +175,12 @@
     "id": "ann-myhill-special-cases",
     "proofId": "schroeder-bernstein-oq-03",
     "range": {
-      "startLine": 238,
-      "endLine": 257
+      "startLine": 409,
+      "endLine": 430
     },
     "type": "insight",
-    "title": "Fixed Points: \u2205 and \u2115 Are the Extreme One-One Degree Classes",
-    "content": "The empty predicate (\u22a5) and universal predicate (\u22a4) are fixed points of computable isomorphism: any computable permutation maps \u2205 to \u2205 and \u2115 to \u2115. Proof for \u2205: if e maps \u22a5 to p (meaning False \u2194 p(e(n)) for all n), then for any m, surjectivity gives m = e(k) for some k, so p(m) = p(e(k)) \u2194 False is False. Proof for \u22a4: dual argument. These are the minimum and maximum in the one-one degree hierarchy, and they cannot be computably isomorphic to any other predicate.",
+    "title": "Fixed Points: ∅ and ℕ Are the Extreme One-One Degree Classes",
+    "content": "The empty predicate (⊥) and universal predicate (⊤) are fixed points of computable isomorphism: any computable permutation maps ∅ to ∅ and ℕ to ℕ. Proof for ∅: if e maps ⊥ to p (meaning False ↔ p(e(n)) for all n), then for any m, surjectivity gives m = e(k) for some k, so p(m) = p(e(k)) ↔ False is False. Proof for ⊤: dual argument. These are the minimum and maximum in the one-one degree hierarchy, and they cannot be computably isomorphic to any other predicate.",
     "mathContext": "Surjectivity of $e : \\mathbb{N} \\simeq \\mathbb{N}$: $\\forall m, \\exists k, e(k) = m$ (used as `e.surjective`). For the empty case: $\\text{False} \\leftrightarrow p(e(k))$ means $p(e(k)) = \\text{False}$; with $e(k) = m$ arbitrary, $p(m) = \\text{False}$. The one-one degrees form a partially ordered set (under $\\leq_1$) with $[\\emptyset]_1$ as minimum and $[\\mathbb{N}]_1$ as maximum.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -203,6 +203,12 @@
       "description": "Full Myhill theorem: easy direction proved, hard direction sorry'd"
     },
     {
+      "name": "range_rePred",
+      "statement": "Computable g → REPred (fun m => m ∈ Set.range g)",
+      "status": "proved",
+      "description": "range g is computably enumerable (Σ₁) for computable g — machine-checked form of the Π₁ obstruction: its complement isGFree is co-c.e., so the classical orbit classification is not computable."
+    },
+    {
       "name": "myhill_self",
       "statement": "∃ e : ℕ ≃ ℕ, e.Computable ∧ ∀ n, p n ↔ p (e n)",
       "status": "proved",
@@ -241,9 +247,9 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 269,
+    "lineCount": 430,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 4,
     "sorries": 1,
     "path": "Proofs/SchroederBernsteinOQ03.lean",


### PR DESCRIPTION
## Summary

Advances the **Myhill Isomorphism Theorem** entry (OQ-03) by turning the previously
prose-only computability obstruction into **machine-checked theorems**. The hard
direction (`myhill_isomorphism`, the stage-wise back-and-forth construction) remains a
single open `sorry` — genuinely research-level (~200 L), worked across 3+ prior
sessions. Per the STUCK strategy, this session **decomposes** rather than broadens: it
formalizes *why* the classical construction fails.

## New theorems (both VERIFIED, 0 new axioms, 0 new sorries)

- **`partialInverse_dom_iff`** — `(partialInverse g m).Dom ↔ m ∈ Set.range g`. The
  domain of the partial-recursive `partialInverse g` is *exactly* `range g` (sharpens
  `partialInverse_dom` to an iff; needs no injectivity).
- **`range_rePred`** — `Computable g → REPred (fun m => m ∈ Set.range g)`: **`range g`
  is computably enumerable (Σ₁)** for computable `g`. Proof: `range g` is the domain of
  the partrec `partialInverse g` (`partialInverse_dom_iff`), and domains of partial
  recursive functions are `REPred` (`Partrec.dom_re`, Mathlib). Hence its complement
  `isGFree g` (via `isGFree_iff_not_mem_range`) is **Π₁** and, for a merely-computable
  non-decidable-range `g`, undecidable — the exact reason the classical Schröder–Bernstein
  orbit classification is not computable. This was previously only asserted in prose.

## Verification

- Compiles clean via `lake env lean Proofs/SchroederBernsteinOQ03.lean` (exit 0; only the
  pre-existing hard-direction `sorry` warning + pre-existing style warnings). Docker
  build wrapper currently hits a containerd `meta.db` I/O error, so direct-lean was used.
- 0 axioms, 1 sorry (unchanged — the open hard direction).

## Gallery bookkeeping

- `leanFile`: `lineCount` 269→430 (prior sessions had drifted the count), `theoremCount`
  14→16; added a curated `range_rePred` theorem entry.
- Realigned all 7 annotation ranges (were calibrated to the stale 269-line version) and
  added `ann-myhill-obstruction` covering the Σ₁/Π₁ obstruction (Sections 4/4b).
- Knowledge base updated with the session and the `REPred`/`Partrec.dom_re` location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)