### PR TITLE
research(geometric-series-oq-11): negative binomial series ∑ (n+k choose k) rⁿ = 1/(1-r)^{k+1} [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ11.lean
+++ b/proofs/Proofs/GeometricSeriesOQ11.lean
@@ -1,0 +1,150 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Data.Nat.Choose.Cast
+import Mathlib.Data.Nat.Choose.Basic
+import Mathlib.Tactic
+
+/-
+# The Negative Binomial Series: ∑ (n+k choose k) rⁿ = 1/(1-r)^{k+1}
+
+## What This Proves
+
+For a real ratio `r` with `‖r‖ < 1` and any fixed order `k : ℕ`,
+
+  ∑_{n=0}^{∞} (n+k choose k) · rⁿ  =  1 / (1-r)^{k+1}.
+
+This is the **negative binomial series** (also called the *generalized geometric
+series* or the *(k+1)-fold self-convolution* of the geometric series).  It is the
+common parent of the whole geometric-moment family already in the gallery:
+
+  k = 0 : ∑ rⁿ              = 1/(1-r)     (the geometric series itself)
+  k = 1 : ∑ (n+1) rⁿ        = 1/(1-r)²
+  k = 2 : ∑ (n+2 choose 2) rⁿ = 1/(1-r)³
+  ...
+
+Differentiating `1/(1-r)` term-by-term `k` times, or convolving the geometric
+series with itself `k+1` times, produces exactly these coefficients.  The
+individual moments `∑ nᵐ rⁿ` (`GeometricSeriesOQ07`, `GeometricSeriesOQ10`) are
+finite linear combinations of these members.
+
+## Why This Is Worth Formalising
+
+Mathlib packages the core analytic fact as
+`hasSum_choose_mul_geometric_of_norm_lt_one`.  The contribution of this file is to
+present that member as the **negative binomial series** and to expose the three
+faces of its coefficient `(n+k choose k)` that make it more than a single lemma:
+
+1. **Symmetric form** `(n+k choose k) = (n+k choose n)` — the two conventions in
+   which the series appears in the literature.
+2. **Stars-and-bars / multichoose form**
+   `(n+k choose k) = multichoose (k+1) n`, i.e. the coefficient of `rⁿ` counts the
+   monomials of degree `n` in `k+1` variables (equivalently, size-`n` multisets
+   from a `(k+1)`-element set).  This is the combinatorial reason a
+   `(k+1)`-fold product of geometric series has these coefficients: expanding
+   `(∑ rⁿ)^{k+1}` and collecting the degree-`n` term counts weak compositions of
+   `n` into `k+1` parts, of which there are `multichoose (k+1) n`.
+3. **Moment-family bridges** to `k = 0` (recovering the geometric series) and
+   `k = 1` (the first-moment-style series `∑ (n+1) rⁿ = 1/(1-r)²`).
+
+## Status: 0 sorries, 0 axioms
+-/
+
+open Filter Topology
+
+namespace GeometricSeriesOQ11
+
+variable {r : ℝ}
+
+/-! ## The negative binomial series -/
+
+/-- **Negative binomial series** (`HasSum` form): for `‖r‖ < 1`,
+`∑ (n+k choose k) rⁿ = 1/(1-r)^{k+1}`.
+
+This is Mathlib's `hasSum_choose_mul_geometric_of_norm_lt_one`, specialised to `ℝ`
+and named for the identity it expresses. -/
+theorem hasSum_negBinomial (k : ℕ) (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => ((n + k).choose k : ℝ) * r ^ n) (1 / (1 - r) ^ (k + 1)) :=
+  hasSum_choose_mul_geometric_of_norm_lt_one k hr
+
+/-- **Negative binomial series** (`tsum` form). -/
+theorem tsum_negBinomial (k : ℕ) (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, ((n + k).choose k : ℝ) * r ^ n = 1 / (1 - r) ^ (k + 1) :=
+  (hasSum_negBinomial k hr).tsum_eq
+
+/-- The negative binomial series is summable. -/
+theorem summable_negBinomial (k : ℕ) (hr : ‖r‖ < 1) :
+    Summable (fun n : ℕ => ((n + k).choose k : ℝ) * r ^ n) :=
+  (hasSum_negBinomial k hr).summable
+
+/-- Restatement with the real-analysis hypothesis `|r| < 1` (equivalent to `‖r‖ < 1`
+over `ℝ`), the form in which the series is usually quoted. -/
+theorem hasSum_negBinomial_of_abs_lt_one (k : ℕ) (hr : |r| < 1) :
+    HasSum (fun n : ℕ => ((n + k).choose k : ℝ) * r ^ n) (1 / (1 - r) ^ (k + 1)) :=
+  hasSum_negBinomial k (by rwa [Real.norm_eq_abs])
+
+/-! ## Symmetric coefficient form -/
+
+/-- Pascal symmetry across the two standard conventions:
+`(n+k choose n) = (n+k choose k)`. -/
+lemma choose_symm_add (n k : ℕ) : (n + k).choose n = (n + k).choose k := by
+  have h : k ≤ n + k := Nat.le_add_left k n
+  rw [← Nat.choose_symm h, Nat.add_sub_cancel]
+
+/-- **Symmetric form** of the series: `∑ (n+k choose n) rⁿ = 1/(1-r)^{k+1}`. -/
+theorem hasSum_negBinomial' (k : ℕ) (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => ((n + k).choose n : ℝ) * r ^ n) (1 / (1 - r) ^ (k + 1)) := by
+  have hfun : (fun n : ℕ => ((n + k).choose n : ℝ) * r ^ n)
+      = (fun n : ℕ => ((n + k).choose k : ℝ) * r ^ n) := by
+    funext n; rw [choose_symm_add]
+  rw [hfun]; exact hasSum_negBinomial k hr
+
+/-! ## Stars-and-bars (multichoose) form -/
+
+/-- The coefficient equals a multiset coefficient:
+`(n+k choose k) = multichoose (k+1) n`, the number of size-`n` multisets drawn from
+a `(k+1)`-element set (equivalently, monomials of degree `n` in `k+1` variables). -/
+lemma choose_add_eq_multichoose (n k : ℕ) :
+    (n + k).choose k = Nat.multichoose (k + 1) n := by
+  rw [Nat.multichoose_eq, show k + 1 + n - 1 = n + k by omega]
+  exact (choose_symm_add n k).symm
+
+/-- **Stars-and-bars form**: `∑ (multichoose (k+1) n) rⁿ = 1/(1-r)^{k+1}`.
+
+Read the right-hand side as `(∑ rⁿ)^{k+1}`: the degree-`n` coefficient of the
+`(k+1)`-fold product of the geometric series counts weak compositions of `n` into
+`k+1` parts, of which there are `multichoose (k+1) n`. -/
+theorem hasSum_multichoose (k : ℕ) (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => (Nat.multichoose (k + 1) n : ℝ) * r ^ n) (1 / (1 - r) ^ (k + 1)) := by
+  have hfun : (fun n : ℕ => (Nat.multichoose (k + 1) n : ℝ) * r ^ n)
+      = (fun n : ℕ => ((n + k).choose k : ℝ) * r ^ n) := by
+    funext n; rw [← choose_add_eq_multichoose]
+  rw [hfun]; exact hasSum_negBinomial k hr
+
+/-! ## Bridges to the geometric-moment family -/
+
+/-- **`k = 0` bridge**: the negative binomial series specialises to the geometric
+series `∑ rⁿ = 1/(1-r)`. -/
+theorem hasSum_geometric (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => r ^ n) (1 / (1 - r)) := by
+  have h := hasSum_negBinomial 0 hr
+  simpa using h
+
+/-- **`k = 1` bridge**: `∑ (n+1) rⁿ = 1/(1-r)²`. -/
+theorem hasSum_succ_mul_geometric (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => ((n : ℝ) + 1) * r ^ n) (1 / (1 - r) ^ 2) := by
+  have h := hasSum_negBinomial 1 hr
+  have hfun : (fun n : ℕ => ((n + 1).choose 1 : ℝ) * r ^ n)
+      = (fun n : ℕ => ((n : ℝ) + 1) * r ^ n) := by
+    funext n; rw [Nat.choose_one_right]; push_cast; ring
+  rw [hfun] at h
+  rw [show (1 : ℕ) + 1 = 2 from rfl] at h
+  exact h
+
+/-! ## A concrete value -/
+
+/-- Sanity check at `r = 1/2`, order `k = 2`: `∑ (n+2 choose 2)/2ⁿ = 8`.
+(`1/(1-1/2)³ = 1/(1/2)³ = 8`.) -/
+example : ∑' n : ℕ, ((n + 2).choose 2 : ℝ) * (1 / 2 : ℝ) ^ n = 8 := by
+  rw [tsum_negBinomial 2 (by norm_num : ‖(1 / 2 : ℝ)‖ < 1)]
+  norm_num
+
+end GeometricSeriesOQ11

--- a/src/data/proofs/geometric-series-oq-11/annotations.json
+++ b/src/data/proofs/geometric-series-oq-11/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-overview-negbinomial",
+    "proofId": "geometric-series-oq-11",
+    "range": { "startLine": 6, "endLine": 51 },
+    "type": "concept",
+    "title": "The Negative Binomial Series and the Moment Family",
+    "content": "The identity 1/(1−r)^{k+1} = ∑ (n+k choose k) rⁿ is the negative binomial (generalized geometric) series — the Newton binomial theorem at exponent −(k+1), equivalently the k-th derivative or (k+1)-fold self-convolution of ∑ rⁿ = 1/(1−r). It is the common parent of the gallery's geometric-moment family: k=0 is the geometric series, and each ∑ nᵐ rⁿ (oq-07, oq-10) is a finite linear combination of these members. Mathlib packages the analytic core as hasSum_choose_mul_geometric_of_norm_lt_one; this entry names it as the negative binomial series and exposes the combinatorial meaning of its coefficient.",
+    "mathContext": "$\\sum_{n\\ge0}\\binom{n+k}{k}r^n=\\dfrac{1}{(1-r)^{k+1}}$, $\\|r\\|<1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["negative binomial series", "generalized binomial theorem", "geometric moments", "self-convolution"],
+    "prerequisites": ["geometric series", "infinite sums"]
+  },
+  {
+    "id": "ann-hassum-negbinomial",
+    "proofId": "geometric-series-oq-11",
+    "range": { "startLine": 57, "endLine": 82 },
+    "type": "theorem",
+    "title": "The Negative Binomial Series",
+    "content": "`hasSum_negBinomial`: ∑ (n+k choose k) rⁿ = 1/(1−r)^{k+1} for ‖r‖ < 1, Mathlib's hasSum_choose_mul_geometric_of_norm_lt_one specialised to ℝ and named for the identity it expresses. Companion `tsum_negBinomial` and `summable_negBinomial` give the tsum and summability forms, and `hasSum_negBinomial_of_abs_lt_one` restates it under the equivalent real-analysis hypothesis |r| < 1 (Real.norm_eq_abs).",
+    "mathContext": "$\\sum_{n\\ge0}\\binom{n+k}{k}r^n=\\dfrac{1}{(1-r)^{k+1}}$.",
+    "significance": "key",
+    "relatedConcepts": ["HasSum", "tsum", "summability", "power series"],
+    "prerequisites": ["infinite series", "binomial coefficients"]
+  },
+  {
+    "id": "ann-symmetric-form",
+    "proofId": "geometric-series-oq-11",
+    "range": { "startLine": 84, "endLine": 98 },
+    "type": "theorem",
+    "title": "Symmetric Coefficient Form",
+    "content": "`choose_symm_add`: (n+k choose n) = (n+k choose k), Pascal symmetry via Nat.choose_symm (with Nat.add_sub_cancel to identify (n+k)−k = n). `hasSum_negBinomial'` then restates the series with the second literature convention ∑ (n+k choose n) rⁿ = 1/(1−r)^{k+1}, obtained by a funext rewrite of the coefficient and transport along hasSum_negBinomial.",
+    "mathContext": "$\\binom{n+k}{n}=\\binom{n+k}{k}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Pascal symmetry", "Nat.choose_symm", "binomial coefficient"],
+    "prerequisites": ["binomial coefficients"]
+  },
+  {
+    "id": "ann-multichoose-form",
+    "proofId": "geometric-series-oq-11",
+    "range": { "startLine": 100, "endLine": 120 },
+    "type": "theorem",
+    "title": "Stars-and-Bars (Multichoose) Form",
+    "content": "`choose_add_eq_multichoose`: (n+k choose k) = multichoose (k+1) n, from Nat.multichoose_eq (multichoose a b = (a+b−1 choose b)) and the Pascal symmetry above. `hasSum_multichoose` restates the series as ∑ multichoose (k+1) n · rⁿ = 1/(1−r)^{k+1}. The coefficient counts size-n multisets from k+1 symbols — degree-n monomials in k+1 variables — which is exactly why the (k+1)-fold product (∑ rⁿ)^{k+1} produces these coefficients: collecting the degree-n term counts weak compositions of n into k+1 parts.",
+    "mathContext": "$\\binom{n+k}{k}=\\left(\\!\\!\\binom{k+1}{n}\\!\\!\\right)$; degree-$n$ monomials in $k+1$ variables.",
+    "significance": "key",
+    "relatedConcepts": ["stars and bars", "multiset coefficient", "Nat.multichoose", "weak compositions", "monomials"],
+    "prerequisites": ["binomial coefficients", "combinatorics"]
+  },
+  {
+    "id": "ann-moment-bridges",
+    "proofId": "geometric-series-oq-11",
+    "range": { "startLine": 122, "endLine": 140 },
+    "type": "theorem",
+    "title": "Bridges to the Geometric-Moment Family",
+    "content": "`hasSum_geometric` specializes k=0, collapsing (n+0 choose 0)=1 and (1−r)^{0+1}=1−r to recover the parent geometric series ∑ rⁿ = 1/(1−r). `hasSum_succ_mul_geometric` specializes k=1, rewriting (n+1 choose 1)=n+1 (Nat.choose_one_right) to give ∑ (n+1) rⁿ = 1/(1−r)² — the first member beyond the geometric series and the derivative form d/dr[1/(1−r)]. These anchor the family at its low-order members.",
+    "mathContext": "$k=0:\\ \\sum r^n=\\frac{1}{1-r}$;\\ $k=1:\\ \\sum (n+1)r^n=\\frac{1}{(1-r)^2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["geometric series", "term-by-term differentiation", "specialization"],
+    "prerequisites": ["geometric series", "infinite sums"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-11/meta.json
+++ b/src/data/proofs/geometric-series-oq-11/meta.json
@@ -1,0 +1,184 @@
+{
+  "id": "geometric-series-oq-11",
+  "slug": "geometric-series-oq-11",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Data.Nat.Choose.Cast",
+      "Mathlib.Data.Nat.Choose.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "GeometricSeriesOQ11",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ11.lean",
+    "sorries": 0
+  },
+  "title": "The Negative Binomial Series: ∑ (n+k choose k) rⁿ = 1/(1−r)^{k+1}",
+  "description": "The negative binomial series (generalized geometric series): for ‖r‖ < 1 over ℝ and any fixed order k, ∑_{n≥0} (n+k choose k)·rⁿ = 1/(1−r)^{k+1}. This is the common parent of the whole geometric-moment family in the gallery — k=0 is the geometric series 1/(1−r), k=1 gives 1/(1−r)², and each moment ∑ nᵐ·rⁿ (oq-07, oq-10) is a finite linear combination of these members. The core analytic fact is Mathlib's hasSum_choose_mul_geometric_of_norm_lt_one; the contribution here is to present it AS the negative binomial series and expose the three faces of its coefficient (n+k choose k): the symmetric convention (n+k choose n), the stars-and-bars / multichoose form (n+k choose k) = multichoose (k+1) n (counting degree-n monomials in k+1 variables — the combinatorial reason a (k+1)-fold product of geometric series has these coefficients), and explicit k=0 (geometric) and k=1 bridges into the moment family.",
+  "overview": {
+    "historicalContext": "The identity 1/(1−r)^{k+1} = ∑_{n≥0} (n+k choose k) rⁿ is the negative binomial series, obtained by the Newton generalized binomial theorem with exponent −(k+1), or equivalently by differentiating the geometric series 1/(1−r) exactly k times (up to the k! factor), or by convolving the geometric series with itself k+1 times. Its coefficient (n+k choose k) is the multiset coefficient of stars-and-bars: it counts the weak compositions of n into k+1 nonnegative parts, which is precisely how the degree-n term of (∑ rⁿ)^{k+1} is assembled. Mathlib packages the analytic statement as the rising-binomial geometric sum hasSum_choose_mul_geometric_of_norm_lt_one; the gallery's geometric-moment entries (oq-07 second moment, oq-10 third moment) already invoke it member-by-member. This entry names and frames the family itself.",
+    "problemStatement": "Prove the negative binomial series ∑_{n≥0} (n+k choose k)·rⁿ = 1/(1−r)^{k+1} for ‖r‖ < 1 over ℝ (in HasSum, tsum, summability, and |r|<1 forms), together with the symmetric-coefficient form ∑ (n+k choose n) rⁿ, the stars-and-bars form ∑ multichoose (k+1) n · rⁿ, and the k=0 (geometric series) and k=1 (∑ (n+1) rⁿ = 1/(1−r)²) specializations. Verify the concrete value ∑ (n+2 choose 2)/2ⁿ = 8.",
+    "proofStrategy": "The analytic core hasSum_negBinomial is Mathlib's hasSum_choose_mul_geometric_of_norm_lt_one specialised to ℝ; tsum, summability, and the |r|<1 restatement follow immediately. The value-add lemmas are elementary but non-cosmetic: choose_symm_add proves the Pascal symmetry (n+k choose n) = (n+k choose k) via Nat.choose_symm; choose_add_eq_multichoose proves (n+k choose k) = multichoose (k+1) n from Nat.multichoose_eq (multichoose a b = (a+b−1 choose b)) and the symmetry, giving the stars-and-bars reading. The two moment bridges rewrite the coefficient: k=0 collapses (n+0 choose 0) = 1 to recover ∑ rⁿ = 1/(1−r); k=1 rewrites (n+1 choose 1) = n+1 (Nat.choose_one_right) to give ∑ (n+1) rⁿ = 1/(1−r)². Each series form is obtained by a funext rewrite of the coefficient followed by transport along the named base theorem.",
+    "keyInsights": [
+      "The negative binomial series 1/(1−r)^{k+1} = ∑ (n+k choose k) rⁿ is the single parent from which the whole geometric-moment family descends: k=0 is the geometric series, and every ∑ nᵐ rⁿ is a finite linear combination of the members {∑ (n+j choose j) rⁿ : j ≤ m}.",
+      "The coefficient (n+k choose k) has a purely combinatorial meaning: (n+k choose k) = multichoose (k+1) n counts size-n multisets from k+1 symbols, i.e. degree-n monomials in k+1 variables — exactly the terms produced when the (k+1)-fold product (∑ rⁿ)^{k+1} is expanded and the degree-n coefficient is collected.",
+      "The two literature conventions (n+k choose k) and (n+k choose n) are the same coefficient by Pascal symmetry, so the series admits both standard statements.",
+      "Because the coefficient is a fixed polynomial in n of degree k, the series is genuinely a member of the geometric-moment hierarchy and not a fresh convergence problem; summability is inherited from the base HasSum.",
+      "Specializing k pins down the low-order family concretely: k=0 recovers 1/(1−r), k=1 gives ∑ (n+1) rⁿ = 1/(1−r)², matching the derivative/convolution picture."
+    ]
+  },
+  "sections": [
+    {
+      "id": "negative-binomial-series",
+      "title": "The Negative Binomial Series",
+      "startLine": 57,
+      "endLine": 82,
+      "summary": "hasSum_negBinomial states ∑ (n+k choose k) rⁿ = 1/(1−r)^{k+1} for ‖r‖ < 1 (Mathlib's hasSum_choose_mul_geometric_of_norm_lt_one, named for the identity it expresses), with tsum_negBinomial, summable_negBinomial, and the real-analysis restatement hasSum_negBinomial_of_abs_lt_one under the equivalent hypothesis |r| < 1.",
+      "mathContext": "$\\sum_{n\\ge0}\\binom{n+k}{k}r^n=\\dfrac{1}{(1-r)^{k+1}}$ for $\\|r\\|<1$."
+    },
+    {
+      "id": "symmetric-form",
+      "title": "Symmetric Coefficient Form",
+      "startLine": 84,
+      "endLine": 98,
+      "summary": "choose_symm_add proves the Pascal symmetry (n+k choose n) = (n+k choose k) via Nat.choose_symm; hasSum_negBinomial' restates the series with the second standard convention ∑ (n+k choose n) rⁿ = 1/(1−r)^{k+1}.",
+      "mathContext": "$\\binom{n+k}{n}=\\binom{n+k}{k}$."
+    },
+    {
+      "id": "multichoose-form",
+      "title": "Stars-and-Bars (Multichoose) Form",
+      "startLine": 100,
+      "endLine": 120,
+      "summary": "choose_add_eq_multichoose proves (n+k choose k) = multichoose (k+1) n from Nat.multichoose_eq and the symmetry; hasSum_multichoose restates the series as ∑ multichoose (k+1) n · rⁿ = 1/(1−r)^{k+1}, reading the right side as (∑ rⁿ)^{k+1} whose degree-n coefficient counts weak compositions of n into k+1 parts.",
+      "mathContext": "$\\binom{n+k}{k}=\\left(\\!\\!\\binom{k+1}{n}\\!\\!\\right)$, the number of degree-$n$ monomials in $k+1$ variables."
+    },
+    {
+      "id": "moment-bridges",
+      "title": "Bridges to the Geometric-Moment Family",
+      "startLine": 122,
+      "endLine": 140,
+      "summary": "hasSum_geometric specializes k=0 (collapsing (n+0 choose 0)=1) to recover the geometric series ∑ rⁿ = 1/(1−r); hasSum_succ_mul_geometric specializes k=1 (rewriting (n+1 choose 1)=n+1) to ∑ (n+1) rⁿ = 1/(1−r)², the first member beyond the geometric series.",
+      "mathContext": "$k=0:\\ \\sum r^n=\\frac{1}{1-r}$;\\quad $k=1:\\ \\sum (n+1)r^n=\\frac{1}{(1-r)^2}$."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ11.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "infinite-series",
+      "power-series",
+      "negative-binomial",
+      "combinatorics",
+      "stars-and-bars",
+      "summability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 150,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hasSum_negBinomial / tsum_negBinomial: the negative binomial series ∑_{n≥0} (n+k choose k)·rⁿ = 1/(1−r)^{k+1} for ‖r‖ < 1 over ℝ, presented and named as the generalized geometric series — the common parent of the gallery's geometric-moment family (k=0 geometric series, oq-07 second moment, oq-10 third moment)",
+      "choose_add_eq_multichoose + hasSum_multichoose: the stars-and-bars reading (n+k choose k) = multichoose (k+1) n, restating the series as ∑ multichoose (k+1) n · rⁿ = 1/(1−r)^{k+1}; the coefficient counts degree-n monomials in k+1 variables, the combinatorial reason (∑ rⁿ)^{k+1} has these coefficients",
+      "choose_symm_add + hasSum_negBinomial': the symmetric-convention form ∑ (n+k choose n) rⁿ = 1/(1−r)^{k+1}, matching the second standard statement in the literature via Pascal symmetry",
+      "hasSum_geometric and hasSum_succ_mul_geometric: explicit k=0 and k=1 bridges recovering ∑ rⁿ = 1/(1−r) and ∑ (n+1) rⁿ = 1/(1−r)², anchoring the family at its low-order members",
+      "hasSum_negBinomial_of_abs_lt_one and summable_negBinomial: the |r|<1 real-analysis restatement and summability, plus a concrete evaluation ∑ (n+2 choose 2)/2ⁿ = 8"
+    ],
+    "prerequisites": [
+      "Mathlib's rising-binomial geometric sum hasSum_choose_mul_geometric_of_norm_lt_one (∑ (n+k choose k) rⁿ = 1/(1−r)^{k+1})",
+      "Nat.multichoose_eq: multichoose a b = (a+b−1 choose b), the multiset-coefficient identity",
+      "Nat.choose_symm: the Pascal symmetry n.choose (n−k) = n.choose k",
+      "Nat.choose_one_right and Nat.choose_zero_right: the column-1 and column-0 binomial values",
+      "HasSum arithmetic (HasSum.tsum_eq, HasSum.summable)",
+      "Parent: geometric-series (∑ rⁿ = 1/(1−r)); siblings: geometric-series-oq-07, geometric-series-oq-10 (moments assembled from this family)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_choose_mul_geometric_of_norm_lt_one",
+        "description": "∑_n (n+k choose k) · rⁿ = 1/(1−r)^{k+1} for ‖r‖ < 1. The analytic core, named here as the negative binomial series.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Nat.multichoose_eq",
+        "description": "multichoose a b = (a+b−1 choose b). Combined with Pascal symmetry to prove (n+k choose k) = multichoose (k+1) n, the stars-and-bars form of the coefficient.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "n.choose (n−k) = n.choose k. Yields (n+k choose n) = (n+k choose k), the symmetric-convention form of the series.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_one_right",
+        "description": "(n+1 choose 1) = n+1. Used in the k=1 bridge to obtain ∑ (n+1) rⁿ = 1/(1−r)².",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-11-oq-01",
+      "question": "Prove the negative binomial series directly as the (k+1)-fold Cauchy product of the geometric series, ∑ (n+k choose k) rⁿ = (∑ rⁿ)^{k+1}, by induction on k using HasSum.mul_eq / the Cauchy product on ℝ, so that the coefficient identity (n+k choose k) = multichoose (k+1) n emerges from stars-and-bars rather than being imported from Mathlib's induction on k.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-11-oq-02",
+      "question": "Extend the series to negative real (or complex) order via the Newton generalized binomial theorem: for a real exponent s and |r|<1, ∑_n (s+n−1 choose n) rⁿ = 1/(1−r)^s with the generalized binomial coefficient, recovering the natural-order case here at s = k+1.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series",
+      "relationship": "extends",
+      "description": "Parent. The base entry proves the geometric series ∑ rⁿ = 1/(1−r), which is exactly the k=0 member of this family (hasSum_geometric recovers it here). This entry generalizes it to all orders k."
+    },
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "related",
+      "description": "Sibling. oq-07's second moment ∑ n² rⁿ = r(1+r)/(1−r)³ is assembled as a finite linear combination of the members of this negative binomial family (the rising-binomial sums at k=0,1,2). This entry names and frames that family."
+    },
+    {
+      "targetId": "geometric-series-oq-10",
+      "relationship": "related",
+      "description": "Sibling. oq-10's third moment ∑ n³ rⁿ = r(1+4r+r²)/(1−r)⁴ is likewise a linear combination 6·h₃ − 12·h₂ + 7·h₁ − 1·h₀ of the members of this family at k=0,1,2,3. This entry provides the parent series those moments draw on."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the rising-binomial geometric sum hasSum_choose_mul_geometric_of_norm_lt_one, the analytic core of the negative binomial series."
+    },
+    {
+      "title": "Concrete Mathematics (negative binomial / generalized binomial series; multiset coefficients)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the negative binomial series 1/(1−r)^{k+1} = ∑ (n+k choose k) rⁿ and the multiset (stars-and-bars) interpretation of its coefficients."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For ‖r‖ < 1 over ℝ and any order k, the negative binomial series is ∑_{n≥0} (n+k choose k)·rⁿ = 1/(1−r)^{k+1}. This is the common parent of the gallery's geometric-moment family: hasSum_geometric recovers the geometric series at k=0, hasSum_succ_mul_geometric gives ∑ (n+1) rⁿ = 1/(1−r)² at k=1, and the moments of oq-07 and oq-10 are finite linear combinations of these members. Beyond the analytic core (Mathlib's hasSum_choose_mul_geometric_of_norm_lt_one), the file exposes the coefficient's two combinatorial faces: the symmetric convention (n+k choose n) = (n+k choose k) (hasSum_negBinomial') and the stars-and-bars form (n+k choose k) = multichoose (k+1) n (hasSum_multichoose), which counts the degree-n monomials in k+1 variables. HasSum, tsum, summability, and |r|<1 forms are given, with a concrete check ∑ (n+2 choose 2)/2ⁿ = 8. 150 lines, 10 theorems/lemmas, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Framing the rising-binomial sum as the negative binomial series makes explicit why the gallery's geometric moments are not independent results: they all live inside the finite span of these members, so each ∑ nᵐ rⁿ is a linear combination rather than a fresh convergence argument. The stars-and-bars identity (n+k choose k) = multichoose (k+1) n gives the combinatorial reason the (k+1)-fold self-convolution of the geometric series has exactly these coefficients, connecting the analytic closed form to the counting of monomials. The k=0 and k=1 bridges anchor the family at the geometric series and its first derivative.",
+    "openQuestions": [
+      "Prove the series directly as the (k+1)-fold Cauchy product (∑ rⁿ)^{k+1}, so that (n+k choose k) = multichoose (k+1) n emerges from stars-and-bars.",
+      "Extend to real/complex order via the Newton generalized binomial theorem: ∑ (s+n−1 choose n) rⁿ = 1/(1−r)^s."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **geometric-series-oq-11** — the **negative binomial series** (generalized geometric series):

> For `‖r‖ < 1` over ℝ and any order `k : ℕ`,  ∑_{n≥0} (n+k choose k)·rⁿ = 1/(1−r)^{k+1}.

This is the common **parent** of the gallery's geometric-moment family: `k=0` is the geometric series itself, `k=1` gives `1/(1−r)²`, and each moment `∑ nᵐ rⁿ` (siblings oq-07, oq-10) is a finite linear combination of these members.

## What's original

The analytic core is Mathlib's `hasSum_choose_mul_geometric_of_norm_lt_one`. The contribution is to name it **as** the negative binomial series and expose the three faces of the coefficient `(n+k choose k)`:

- **Symmetric convention** `(n+k choose n) = (n+k choose k)` (Pascal symmetry) → `hasSum_negBinomial'`.
- **Stars-and-bars form** `(n+k choose k) = multichoose (k+1) n` → `hasSum_multichoose`. The coefficient counts degree-`n` monomials in `k+1` variables — the combinatorial reason the `(k+1)`-fold product `(∑ rⁿ)^{k+1}` has these coefficients.
- **Moment bridges**: `hasSum_geometric` (k=0, recovers `∑ rⁿ = 1/(1−r)`) and `hasSum_succ_mul_geometric` (k=1, `∑ (n+1) rⁿ = 1/(1−r)²`).

Plus `HasSum` / `tsum` / summability / `|r|<1` forms and a concrete check `∑ (n+2 choose 2)/2ⁿ = 8`.

## Verification

- **150 lines, 10 theorems/lemmas, 0 definitions, 0 axioms, 0 sorries.**
- `#print axioms` on the main results: only `propext, Classical.choice, Quot.sound` — **0-axiom / VERIFIED** (no `sorryAx`, no `Lean.ofReduceBool`).
- Compiled with Lean v4.26.0 against the repo's Mathlib oleans (direct-lean compile; Docker builder corrupted this session, narrow imports used — not the broken `import Mathlib` umbrella).

## Files

- `proofs/Proofs/GeometricSeriesOQ11.lean`
- `src/data/proofs/geometric-series-oq-11/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)