### PR TITLE
research(randomized-maxcut-oq-05): max-cut of complete bipartite graph = |E| = card V · card W [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/RandomizedMaxCutOQ05.lean
+++ b/proofs/Proofs/RandomizedMaxCutOQ05.lean
@@ -1,0 +1,126 @@
+import Proofs.RandomizedMaxCut
+import Mathlib.Combinatorics.SimpleGraph.Basic
+
+/-
+# Max-Cut of a Complete Bipartite Graph Equals the Full Edge Count
+
+## What This Proves
+
+For the complete bipartite graph `K_{V,W}` (Mathlib's `completeBipartiteGraph V W`
+on the vertex type `V ⊕ W`), the maximum cut value equals the total number of
+edges:
+
+  `maxCutValue (completeBipartiteGraph V W) = |E|`,
+
+and this common value is the product of the two side sizes:
+
+  `|E| = card V * card W`.
+
+## Why This Is Interesting
+
+The parent entry (`randomized-maxcut`) proves the *general* upper bound
+`maxCutValue G ≤ |E|` and the `1/2`-approximation guarantee of the randomized
+algorithm.  A complete bipartite graph is the extremal case where that upper
+bound is *attained*: the natural left/right partition is itself a cut, and it
+crosses **every** edge.  So the greedy/optimal cut recovers all of `|E|`, and
+the randomized `1/2`-approximation is, in the worst case, off by exactly a
+factor of two here.
+
+## Proof Strategy
+
+1. `bipartiteAssignment_size_eq_edges`: the assignment `fun x => x.isLeft`
+   (left vertices → side `A`, right vertices → side `B`) has cut size `|E|`,
+   because in `K_{V,W}` every edge joins a left vertex to a right vertex, so
+   `Cut.edgeInCut` is `true` on all of `edgeFinset` (`Finset.filter_true_of_mem`).
+2. `maxCut_completeBipartite_eq_edges`: combine `Finset.le_sup` (the supremum
+   dominates any single assignment) with the parent's `maxCut_le_edges`.
+3. `completeBipartite_edgeFinset_card`: the edges biject with `V × W` via
+   `(a, b) ↦ s(inl a, inr b)`, so `|E| = card V * card W` (`Fintype.card_prod`).
+-/
+
+open Finset SimpleGraph
+
+namespace RandomizedMaxCutOQ05
+
+variable {V W : Type*} [Fintype V] [Fintype W] [DecidableEq V] [DecidableEq W]
+
+/-- Adjacency in the complete bipartite graph is decidable. -/
+instance : DecidableRel (completeBipartiteGraph V W).Adj := fun v w => by
+  rw [completeBipartiteGraph_adj]; infer_instance
+
+/-- **Step 1.** The "left/right" assignment cuts *every* edge of `K_{V,W}`.
+Sending each left vertex to side `A` and each right vertex to side `B` produces
+a cut whose size is the full edge count, since every edge of a complete
+bipartite graph joins the two sides. -/
+theorem bipartiteAssignment_size_eq_edges :
+    (Cut.ofAssignment (G := completeBipartiteGraph V W) (fun x => x.isLeft)).size
+      = (completeBipartiteGraph V W).edgeFinset.card := by
+  unfold Cut.size
+  refine congrArg Finset.card (Finset.filter_true_of_mem ?_)
+  intro e he
+  rw [mem_edgeFinset] at he
+  induction e using Sym2.ind with
+  | _ u v =>
+    rw [mem_edgeSet, completeBipartiteGraph_adj] at he
+    unfold Cut.edgeInCut Cut.ofAssignment
+    simp only [Sym2.lift_mk, Finset.mem_filter, Finset.mem_univ, true_and,
+      decide_eq_true_eq]
+    cases u <;> cases v <;> simp_all
+
+/-- **Step 2 (main result).** The max-cut value of a complete bipartite graph is
+exactly its number of edges. -/
+theorem maxCut_completeBipartite_eq_edges :
+    maxCutValue (completeBipartiteGraph V W) = (completeBipartiteGraph V W).edgeFinset.card := by
+  refine le_antisymm (maxCut_le_edges _) ?_
+  calc (completeBipartiteGraph V W).edgeFinset.card
+      = (Cut.ofAssignment (G := completeBipartiteGraph V W) (fun x => x.isLeft)).size :=
+        (bipartiteAssignment_size_eq_edges).symm
+    _ ≤ maxCutValue (completeBipartiteGraph V W) := by
+        unfold maxCutValue
+        exact Finset.le_sup
+          (f := fun f => (Cut.ofAssignment (G := completeBipartiteGraph V W) f).size)
+          (Finset.mem_univ (fun x : V ⊕ W => x.isLeft))
+
+/-- **Step 3.** The edges of `K_{V,W}` biject with `V × W`, so the edge count is
+the product of the side sizes. -/
+theorem completeBipartite_edgeFinset_card :
+    (completeBipartiteGraph V W).edgeFinset.card = Fintype.card V * Fintype.card W := by
+  have himg : (completeBipartiteGraph V W).edgeFinset
+      = (Finset.univ : Finset (V × W)).image (fun p => s(Sum.inl p.1, Sum.inr p.2)) := by
+    ext e
+    induction e using Sym2.ind with
+    | _ x y =>
+      simp only [mem_edgeFinset, mem_edgeSet, completeBipartiteGraph_adj, Finset.mem_image,
+        Finset.mem_univ, true_and]
+      constructor
+      · rintro (⟨hx, hy⟩ | ⟨hx, hy⟩)
+        · cases x with
+          | inr _ => simp at hx
+          | inl a =>
+            cases y with
+            | inl _ => simp at hy
+            | inr b => exact ⟨(a, b), rfl⟩
+        · cases x with
+          | inl _ => simp at hx
+          | inr b =>
+            cases y with
+            | inr _ => simp at hy
+            | inl a => exact ⟨(a, b), Sym2.eq_swap⟩
+      · rintro ⟨⟨a, b⟩, heq⟩
+        rw [Sym2.eq_iff] at heq
+        rcases heq with ⟨hx, hy⟩ | ⟨hx, hy⟩
+        · subst hx; subst hy; simp
+        · subst hx; subst hy; simp
+  rw [himg, Finset.card_image_of_injective, Finset.card_univ, Fintype.card_prod]
+  intro p q hpq
+  simp only [Sym2.eq_iff] at hpq
+  rcases hpq with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exact Prod.ext (Sum.inl.inj h1) (Sum.inr.inj h2)
+  · exact absurd h1 (by simp)
+
+/-- **Corollary.** The max-cut value of `K_{V,W}` equals `card V * card W`. -/
+theorem maxCut_completeBipartite_eq_mul :
+    maxCutValue (completeBipartiteGraph V W) = Fintype.card V * Fintype.card W := by
+  rw [maxCut_completeBipartite_eq_edges, completeBipartite_edgeFinset_card]
+
+end RandomizedMaxCutOQ05

--- a/src/data/proofs/randomized-maxcut-oq-05/annotations.json
+++ b/src/data/proofs/randomized-maxcut-oq-05/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-decidable-adj",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 47,
+      "endLine": 49
+    },
+    "type": "definition",
+    "title": "Decidable Adjacency for the Complete Bipartite Graph",
+    "content": "Mathlib's `completeBipartiteGraph V W` lives on the sum type `V ⊕ W`, with two vertices adjacent iff they lie on opposite sides. The parent MaxCut framework (`Cut.size`, `maxCutValue`) requires `DecidableRel G.Adj` to filter the edge set, so we supply the instance by rewriting adjacency into the decidable predicate `(v.isLeft ∧ w.isRight) ∨ (v.isRight ∧ w.isLeft)`.",
+    "mathContext": "$v \\sim w \\iff (\\text{isLeft } v \\wedge \\text{isRight } w) \\vee (\\text{isRight } v \\wedge \\text{isLeft } w)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "complete bipartite graph",
+      "decidable relation",
+      "sum type"
+    ],
+    "prerequisites": [
+      "SimpleGraph.Adj",
+      "Decidable instances"
+    ]
+  },
+  {
+    "id": "ann-witness-cut",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 51,
+      "endLine": 68
+    },
+    "type": "theorem",
+    "title": "The Left/Right Cut Crosses Every Edge",
+    "content": "The witness assignment `fun x => x.isLeft` sends every left vertex (`Sum.inl`) to side $A$ and every right vertex (`Sum.inr`) to side $B$. Because every edge of a complete bipartite graph joins a left vertex to a right vertex, `Cut.edgeInCut` returns `true` on all of `edgeFinset`. Hence `Finset.filter_true_of_mem` collapses the filter to the whole edge set, and the cut size equals $|E|$. The edge is destructured with `Sym2.ind` and the two adjacency cases are discharged by `cases u <;> cases v <;> simp_all`.",
+    "mathContext": "$\\text{size}(\\text{ofAssignment}(\\lambda x.\\ \\text{isLeft } x)) = |E|$",
+    "significance": "key",
+    "relatedConcepts": [
+      "cut",
+      "edge crossing",
+      "Finset.filter_true_of_mem",
+      "Sym2 induction"
+    ],
+    "prerequisites": [
+      "Cut.ofAssignment",
+      "Cut.edgeInCut",
+      "edgeFinset"
+    ]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 70,
+      "endLine": 82
+    },
+    "type": "theorem",
+    "title": "Max-Cut Equals the Full Edge Count",
+    "content": "The main result. `maxCutValue` is the supremum of cut sizes over all boolean assignments, so `Finset.le_sup` applied to the left/right witness gives `maxCutValue ≥ |E|`. The parent entry's general bound `maxCut_le_edges` gives `maxCutValue ≤ |E|`. Antisymmetry yields equality: the complete bipartite graph is exactly the extremal instance where the MaxCut upper bound is attained.",
+    "mathContext": "$\\text{maxCutValue}(K_{V,W}) = |E|$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "max-cut",
+      "supremum",
+      "extremal case",
+      "Finset.le_sup"
+    ],
+    "prerequisites": [
+      "maxCutValue",
+      "maxCut_le_edges",
+      "le_antisymm"
+    ]
+  },
+  {
+    "id": "ann-edge-count",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 84,
+      "endLine": 119
+    },
+    "type": "theorem",
+    "title": "Edge Count via the V × W Bijection",
+    "content": "The edges of $K_{V,W}$ are exactly the unordered pairs $\\{\\text{inl } a, \\text{inr } b\\}$, which biject with ordered pairs $(a, b) \\in V \\times W$ via `(a, b) ↦ s(inl a, inr b)`. We show `edgeFinset` is the image of `univ : V × W` under this map (each direction destructures with `Sym2.ind` / `Sym2.eq_iff`), and that the map is injective (the crossed case `inl a = inr b` is impossible since `Sum.inl ≠ Sum.inr`). Then `Finset.card_image_of_injective` and `Fintype.card_prod` give $|E| = \\text{card } V \\cdot \\text{card } W$.",
+    "mathContext": "$|E(K_{V,W})| = \\text{card } V \\cdot \\text{card } W$",
+    "significance": "key",
+    "relatedConcepts": [
+      "bijection",
+      "Sym2.eq_iff",
+      "Finset.card_image_of_injective",
+      "Fintype.card_prod"
+    ],
+    "prerequisites": [
+      "edgeFinset",
+      "Sym2",
+      "Finset.image"
+    ]
+  },
+  {
+    "id": "ann-corollary",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 121,
+      "endLine": 124
+    },
+    "type": "theorem",
+    "title": "Closed Form for the Max-Cut",
+    "content": "Chaining the two main results gives the fully explicit value `maxCutValue (completeBipartiteGraph V W) = card V · card W`. For $K_{m,n}$ this is the familiar $m \\cdot n$.",
+    "mathContext": "$\\text{maxCutValue}(K_{V,W}) = \\text{card } V \\cdot \\text{card } W$",
+    "significance": "key",
+    "relatedConcepts": [
+      "closed form",
+      "complete bipartite graph"
+    ],
+    "prerequisites": [
+      "maxCut_completeBipartite_eq_edges",
+      "completeBipartite_edgeFinset_card"
+    ]
+  }
+]

--- a/src/data/proofs/randomized-maxcut-oq-05/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-05/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "randomized-maxcut-oq-05",
+  "title": "Max-Cut of a Complete Bipartite Graph Equals the Full Edge Count",
+  "slug": "randomized-maxcut-oq-05",
+  "description": "For the complete bipartite graph K_{V,W} on the vertex type V ⊕ W, the maximum cut value equals the total number of edges, and this common value is the product card V · card W. The natural left/right partition is a cut crossing every edge, attaining the parent entry's general upper bound maxCut ≤ |E|.",
+  "meta": {
+    "author": "Formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "extremal-combinatorics",
+      "max-cut"
+    ],
+    "proofRepoPath": "Proofs/RandomizedMaxCutOQ05.lean",
+    "badge": "original",
+    "sorries": 0,
+    "originalContributions": [
+      "bipartiteAssignment_size_eq_edges: the left/right assignment cuts every edge of K_{V,W}, so its cut size is the full edge count (via Finset.filter_true_of_mem)",
+      "maxCut_completeBipartite_eq_edges: maxCutValue (completeBipartiteGraph V W) = |E| — the extremal case attaining the parent's maxCut ≤ |E| bound",
+      "completeBipartite_edgeFinset_card: |E(K_{V,W})| = card V · card W via the edge ≃ V × W bijection (a,b) ↦ s(inl a, inr b)",
+      "maxCut_completeBipartite_eq_mul: the closed form maxCutValue = card V · card W"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 126,
+    "assumptions": "No remaining sorries and no axioms beyond Lean/Mathlib foundations (propext, Classical.choice, Quot.sound). Builds on the parent randomized-maxcut Cut/maxCutValue framework and Mathlib's completeBipartiteGraph.",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Max-Cut asks for a vertex bipartition maximizing the number of crossing edges; it is one of Karp's 21 NP-complete problems (1972). The parent formalization (randomized-maxcut) proves the general upper bound maxCut ≤ |E| and Erdős's probabilistic 1/2-approximation. Complete bipartite graphs K_{m,n} are the canonical extremal instances where the max-cut equals the entire edge set: the graph is already bipartite, so its defining bipartition cuts everything. This is precisely the worst case for the randomized algorithm, where the 1/2-approximation is off by exactly a factor of two.",
+    "problemStatement": "Show that for the complete bipartite graph K_{V,W}, the maximum cut value equals |E|, and that |E| = card V · card W.",
+    "proofStrategy": "The assignment sending each left vertex (Sum.inl) to side A and each right vertex (Sum.inr) to side B produces a cut. Every edge of K_{V,W} joins a left to a right vertex, so Cut.edgeInCut is true on all of edgeFinset; Finset.filter_true_of_mem gives cut size = |E|. Since maxCutValue is a supremum over assignments, Finset.le_sup yields maxCut ≥ |E|, and the parent's maxCut_le_edges gives ≤, hence equality. Separately, the edges biject with V × W via (a,b) ↦ s(inl a, inr b) (injectivity from Sym2.eq_iff and Sum.inl ≠ Sum.inr), so |E| = card V · card W by Fintype.card_prod.",
+    "keyInsights": [
+      "A complete bipartite graph is the extremal case of the MaxCut upper bound maxCut ≤ |E|: its natural bipartition is a cut that crosses every single edge, so no edge is wasted.",
+      "The proof reduces the supremum-over-all-assignments maxCutValue to a single explicit witness assignment (fun x => x.isLeft) via Finset.le_sup, then squeezes with the parent bound.",
+      "Counting the edges is a clean Sym2 bijection: each unordered edge {inl a, inr b} corresponds to exactly one ordered pair (a, b), giving |E| = card V · card W with no double counting since the two endpoints live on different sides.",
+      "This is exactly the worst case for the randomized 1/2-approximation: the optimum recovers all of |E| while a random cut recovers only |E|/2 in expectation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "decidability",
+      "title": "Decidable Adjacency",
+      "startLine": 47,
+      "endLine": 49,
+      "summary": "Provides the DecidableRel instance for completeBipartiteGraph adjacency needed by the parent's maxCutValue and Cut.size definitions.",
+      "mathContext": "Adjacency v ~ w ⟺ (v.isLeft ∧ w.isRight) ∨ (v.isRight ∧ w.isLeft), a decidable predicate."
+    },
+    {
+      "id": "witness-cut",
+      "title": "Step 1: The Left/Right Cut Crosses Every Edge",
+      "startLine": 51,
+      "endLine": 68,
+      "summary": "bipartiteAssignment_size_eq_edges: the assignment fun x => x.isLeft yields a cut whose size equals |E|, because every edge crosses between the two sides.",
+      "mathContext": "size(ofAssignment (·.isLeft)) = |E|, since Cut.edgeInCut is true on all e ∈ edgeFinset."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Step 2: Max-Cut Equals the Edge Count",
+      "startLine": 70,
+      "endLine": 82,
+      "summary": "maxCut_completeBipartite_eq_edges: combines Finset.le_sup on the witness cut with the parent's maxCut_le_edges to conclude maxCutValue = |E|.",
+      "mathContext": "maxCutValue (completeBipartiteGraph V W) = |E|."
+    },
+    {
+      "id": "edge-count",
+      "title": "Step 3: The Edge Count Is card V · card W",
+      "startLine": 84,
+      "endLine": 119,
+      "summary": "completeBipartite_edgeFinset_card: edgeFinset is the image of univ : V × W under (a,b) ↦ s(inl a, inr b), an injection, so |E| = card V · card W.",
+      "mathContext": "|E(K_{V,W})| = card V · card W via edges ≃ V × W."
+    },
+    {
+      "id": "corollary",
+      "title": "Corollary: Closed Form for the Max-Cut",
+      "startLine": 121,
+      "endLine": 124,
+      "summary": "maxCut_completeBipartite_eq_mul: chains the two main results to give maxCutValue = card V · card W.",
+      "mathContext": "maxCutValue (completeBipartiteGraph V W) = card V · card W."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "randomized-maxcut",
+      "relationship": "extends",
+      "description": "Instantiates the parent's Cut/maxCutValue framework and its general bound maxCut_le_edges at the extremal complete bipartite graph, where the bound is attained."
+    },
+    {
+      "targetId": "randomized-maxcut-oq-04",
+      "relationship": "related",
+      "description": "The derandomized greedy 1/2-approximation; K_{n,n} is the tight worst case where a random cut recovers only half of the |E| edges attained here."
+    },
+    {
+      "targetId": "randomized-maxcut-oq-01",
+      "relationship": "related",
+      "description": "The Goemans-Williamson SDP approximation, whose analysis is also driven by bipartite-like extremal instances."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) in 126 lines. Proves that the max-cut of a complete bipartite graph K_{V,W} equals its full edge count |E|, and that |E| = card V · card W. The extremal witness is the graph's own left/right bipartition, which crosses every edge.",
+    "implications": "This pins down the tight extremal case of the general MaxCut upper bound maxCut ≤ |E| from the parent formalization, and simultaneously exhibits the worst case for the randomized 1/2-approximation (a factor-of-two gap on K_{n,n}). The edge ≃ V × W Sym2 bijection is a reusable pattern for counting edges of bipartite graphs.",
+    "openQuestions": [
+      "Which graph families beyond complete bipartite graphs also attain maxCut = |E| (equivalently, which finite graphs are bipartite)?",
+      "Can the exact max-cut of the complete graph K_n (⌊n/2⌋·⌈n/2⌉) be formalized in the same framework?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.RandomizedMaxCut",
+      "Mathlib.Combinatorics.SimpleGraph.Basic"
+    ],
+    "namespace": "RandomizedMaxCutOQ05",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/RandomizedMaxCutOQ05.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "maxCut_completeBipartite_eq_edges",
+      "type": "core",
+      "description": "maxCutValue (completeBipartiteGraph V W) = edgeFinset.card: the max-cut equals the full edge count."
+    },
+    {
+      "name": "maxCut_completeBipartite_eq_mul",
+      "type": "core",
+      "description": "maxCutValue (completeBipartiteGraph V W) = card V · card W: the closed form."
+    },
+    {
+      "name": "bipartiteAssignment_size_eq_edges",
+      "type": "supporting",
+      "description": "The left/right assignment produces a cut of size |E|, crossing every edge."
+    },
+    {
+      "name": "completeBipartite_edgeFinset_card",
+      "type": "supporting",
+      "description": "|E(K_{V,W})| = card V · card W via the edge ≃ V × W bijection."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the open question **randomized-maxcut-oq-05**: *Max-Cut of a Complete Bipartite Graph Equals the Full Edge Count.*

For Mathlib's `completeBipartiteGraph V W` (on `V ⊕ W`), this proves:

- **`maxCut_completeBipartite_eq_edges`**: `maxCutValue (completeBipartiteGraph V W) = edgeFinset.card` — the max-cut attains the parent's general upper bound `maxCut ≤ |E|`.
- **`maxCut_completeBipartite_eq_mul`**: `maxCutValue = Fintype.card V * Fintype.card W` — the closed form (for `K_{m,n}`, this is `m·n`).

## Approach

1. **`bipartiteAssignment_size_eq_edges`** — the assignment `fun x => x.isLeft` sends left vertices to side `A`, right vertices to side `B`. Every edge of a complete bipartite graph crosses, so `Cut.edgeInCut` is `true` on all of `edgeFinset` and `Finset.filter_true_of_mem` gives cut size `= |E|`.
2. **Main theorem** — `maxCutValue` is a `Finset.sup` over assignments, so `Finset.le_sup` on the witness gives `≥ |E|`; the parent's `maxCut_le_edges` gives `≤ |E|`; `le_antisymm` closes it.
3. **`completeBipartite_edgeFinset_card`** — edges biject with `V × W` via `(a,b) ↦ s(inl a, inr b)` (injectivity from `Sym2.eq_iff` and `Sum.inl ≠ Sum.inr`), so `Fintype.card_prod` gives `|E| = card V · card W`.

This is the extremal instance of the parent MaxCut bound and the tight worst case for the randomized 1/2-approximation (a factor-of-two gap on `K_{n,n}`).

## Verification

- **0 sorries, 0 added axioms.** `#print axioms` on all three main theorems lists only `propext`, `Classical.choice`, `Quot.sound`.
- 4 theorems, 1 instance, 126 lines.
- Built with the project toolchain (`lean4:v4.26.0`) against the repo's Mathlib oleans plus the parent `Proofs.RandomizedMaxCut` (Docker wrapper unavailable; verified via direct `lean` compile with reconstructed `LEAN_PATH`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)