### PR TITLE
research(wilsons-theorem-oq-08): Wilson criterion over ℕ + composite factorial congruence [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/WilsonsTheoremOQ08.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ08.lean
@@ -1,0 +1,149 @@
+import Mathlib
+
+/-!
+# Wilson's Theorem OQ-08: Primality Criterion over ℕ and the Composite Factorial Congruence
+
+The parent gallery entry states Wilson's theorem as the `ZMod n`-biconditional
+`Nat.Prime n ↔ ((n-1)! : ZMod n) = -1`.  This follow-up sharpens the picture in
+two elementary directions that live entirely in `ℕ`:
+
+1. **Primality criterion over ℕ.**  For `n ≥ 2`,
+   `Nat.Prime n ↔ n ∣ (n-1)! + 1`.
+   This is Wilson's criterion in its classical arithmetic (divisibility) form,
+   with no reference to `ZMod` or additive inverses.
+
+2. **Composite factorial congruence.**  For a *composite* `n > 4`,
+   `n ∣ (n-1)!`, i.e. `(n-1)! ≡ 0 (mod n)`.
+   The single exception among composites is `n = 4`, where `3! = 6 ≡ 2 (mod 4)`.
+
+Combining the two gives the sharp dichotomy for `n > 4`:
+`Nat.Prime n ↔ ¬ n ∣ (n-1)!`.
+
+The composite congruence is *not* in Mathlib; we build it from the elementary
+combinatorial fact that two **distinct** nonzero naturals `≤ N` have product
+dividing `N!` (they appear as separate factors of `N!`).  The perfect-square
+subcase `n = p²` is handled by using the distinct factors `p` and `2p`, which
+both lie below `n` precisely when `p ≥ 3` (equivalently `n > 4`).
+
+All results are fully machine-checked with no additional axioms.
+-/
+
+namespace WilsonsTheoremOQ08
+
+open Nat Finset
+
+/-! ## Combinatorial core: distinct factors multiply into the factorial -/
+
+/-- If `a` and `b` are distinct positive naturals, each at most `N`, then their
+product divides `N !`.  They occur as two *separate* factors of the product
+`N ! = ∏_{i=1}^{N} i`, so their product divides the whole product. -/
+theorem mul_dvd_factorial_of_distinct {a b N : ℕ} (ha : 1 ≤ a) (hb : 1 ≤ b)
+    (haN : a ≤ N) (hbN : b ≤ N) (hab : a ≠ b) : a * b ∣ N ! := by
+  have hsub : ({a, b} : Finset ℕ) ⊆ Finset.Ico 1 (N + 1) := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    simp only [Finset.mem_Ico]
+    rcases hx with rfl | rfl <;> omega
+  have hdvd := Finset.prod_dvd_prod_of_subset ({a, b} : Finset ℕ)
+    (Finset.Ico 1 (N + 1)) (fun i => i) hsub
+  rw [Finset.prod_Ico_id_eq_factorial] at hdvd
+  rwa [Finset.prod_pair hab] at hdvd
+
+/-! ## Composite factorial congruence -/
+
+/-- **Composite factorial congruence.**  For composite `n > 4`, `n ∣ (n-1)!`.
+
+Write `n = m * k` with `2 ≤ m ≤ k < n` (via the least prime factor).  If `m ≠ k`
+they are distinct factors below `n`, so `n = m*k ∣ (n-1)!`.  If `m = k` then
+`n = m²` with `m ≥ 3` (as `n > 4`), and the distinct factors `m`, `2m` both lie
+below `n`, giving `n ∣ m*(2m) ∣ (n-1)!`. -/
+theorem composite_dvd_factorial_pred {n : ℕ} (hn : 4 < n) (hcomp : ¬ Nat.Prime n) :
+    n ∣ (n - 1)! := by
+  have hn2 : 2 ≤ n := by omega
+  obtain ⟨m, hmdvd, hm2, hmn⟩ := Nat.exists_dvd_of_not_prime2 hn2 hcomp
+  obtain ⟨k, hk⟩ := hmdvd          -- `n = m * k`
+  have hk2 : 2 ≤ k := by
+    rcases Nat.lt_or_ge k 2 with h | h
+    · interval_cases k <;> omega
+    · exact h
+  rcases eq_or_ne m k with hmk | hmk
+  · -- perfect-square case `n = m * m`
+    rw [← hmk] at hk                -- `hk : n = m * m`
+    have hm3 : 3 ≤ m := by
+      rcases Nat.lt_or_ge m 3 with h | h
+      · interval_cases m
+        omega
+      · exact h
+    have hmlt : m < n := by rw [hk]; nlinarith [hm3]
+    have h2mlt : 2 * m < n := by rw [hk]; nlinarith [hm3]
+    have hmle : m ≤ n - 1 := by omega
+    have h2m : 2 * m ≤ n - 1 := by omega
+    have key : m * (2 * m) ∣ (n - 1)! :=
+      mul_dvd_factorial_of_distinct (by omega) (by omega) hmle h2m (by omega)
+    have hndvd : n ∣ m * (2 * m) := ⟨2, by rw [hk]; ring⟩
+    exact dvd_trans hndvd key
+  · -- distinct proper factors `m ≠ k`
+    have hkn : k < n := by rw [hk]; nlinarith [hm2, hk2]
+    have hmle : m ≤ n - 1 := by omega
+    have hkle : k ≤ n - 1 := by omega
+    have key : m * k ∣ (n - 1)! :=
+      mul_dvd_factorial_of_distinct (by omega) (by omega) hmle hkle hmk
+    rwa [← hk] at key
+
+/-- The composite congruence stated in `ZMod n`: for composite `n > 4`,
+`(n-1)! ≡ 0 (mod n)`. -/
+theorem composite_factorial_zmod {n : ℕ} (hn : 4 < n) (hcomp : ¬ Nat.Prime n) :
+    ((n - 1)! : ZMod n) = 0 :=
+  (ZMod.natCast_eq_zero_iff _ _).mpr (composite_dvd_factorial_pred hn hcomp)
+
+/-- The exceptional composite `n = 4`: `3! = 6 ≡ 2 (mod 4)`, so `4 ∤ 3!`. -/
+theorem four_factorial_pred_mod : (4 - 1)! % 4 = 2 := by decide
+
+theorem four_not_dvd_factorial_pred : ¬ (4 ∣ (4 - 1)!) := by decide
+
+/-! ## Wilson's primality criterion over ℕ -/
+
+/-- **Wilson's criterion over ℕ.**  For `n ≥ 2`, `n` is prime iff `n ∣ (n-1)! + 1`.
+This is the purely arithmetic form of Wilson's theorem, obtained from the
+`ZMod`-biconditional by rewriting `(n-1)! ≡ -1` as `(n-1)! + 1 ≡ 0`. -/
+theorem prime_iff_dvd_factorial_succ {n : ℕ} (hn : 2 ≤ n) :
+    Nat.Prime n ↔ n ∣ ((n - 1)! + 1) := by
+  rw [Nat.prime_iff_fac_equiv_neg_one (by omega : n ≠ 1)]
+  constructor
+  · intro h
+    have hz : (((n - 1)! + 1 : ℕ) : ZMod n) = 0 := by push_cast; rw [h]; ring
+    exact (ZMod.natCast_eq_zero_iff _ _).mp hz
+  · intro h
+    have hz : (((n - 1)! + 1 : ℕ) : ZMod n) = 0 := (ZMod.natCast_eq_zero_iff _ _).mpr h
+    have h2 : ((n - 1)! : ZMod n) + 1 = 0 := by push_cast at hz; exact hz
+    exact eq_neg_of_add_eq_zero_left h2
+
+/-! ## The sharp dichotomy for `n > 4` -/
+
+/-- **Sharp dichotomy.**  For `n > 4`, `n` is prime iff `n` does *not* divide
+`(n-1)!`.  Primes fail to divide (Wilson: `(n-1)! ≡ -1`), composites divide
+(the composite congruence).  The bound `n > 4` excludes only the exceptional
+composite `n = 4`. -/
+theorem prime_iff_not_dvd_factorial_pred {n : ℕ} (hn : 4 < n) :
+    Nat.Prime n ↔ ¬ n ∣ (n - 1)! := by
+  constructor
+  · intro hp hcontra
+    have h1 : n ∣ (n - 1)! + 1 := (prime_iff_dvd_factorial_succ (by omega)).mp hp
+    have hone : n ∣ 1 := by simpa using Nat.dvd_sub h1 hcontra
+    exact absurd (Nat.le_of_dvd one_pos hone) (by omega)
+  · intro h
+    by_contra hcomp
+    exact h (composite_dvd_factorial_pred hn hcomp)
+
+/-! ## Sanity checks -/
+
+-- `n = 7` (prime): `6! = 720 = 7·103 - 1`, so `7 ∣ 6! + 1`.
+example : (7 : ℕ) ∣ ((7 - 1)! + 1) := by decide
+
+-- `n = 9` (composite): `8! = 40320 = 9 · 4480`, so `9 ∣ 8!`.
+example : (9 : ℕ) ∣ (9 - 1)! := by decide
+
+-- `n = 4`: the lone composite exception, `4 ∤ 3!`.
+example : ¬ (4 : ℕ) ∣ (4 - 1)! := by decide
+
+end WilsonsTheoremOQ08

--- a/src/data/proofs/wilsons-theorem-oq-08/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-08/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "wilson08-overview",
+    "proofId": "wilsons-theorem-oq-08",
+    "range": { "startLine": 3, "endLine": 29 },
+    "type": "concept",
+    "title": "Wilson over ℕ, and completing the composite side",
+    "content": "The parent states Wilson's theorem as the ZMod biconditional `Nat.Prime n ↔ ((n−1)! : ZMod n) = −1`. This entry gives the two elementary refinements that make Wilson a genuine primality *test*: the arithmetic criterion `Nat.Prime n ↔ n ∣ (n−1)!+1` over ℕ, and the composite congruence `(n−1)! ≡ 0 (mod n)` for every composite n > 4 (the sole exception being 3! ≡ 2 mod 4). Together: for n > 4, `Nat.Prime n ↔ ¬ n ∣ (n−1)!`.",
+    "mathContext": "$n \\text{ prime} \\iff n \\mid (n-1)!+1; \\quad n \\text{ composite},\\, n>4 \\implies n \\mid (n-1)!$",
+    "significance": "key",
+    "relatedConcepts": ["Wilson's theorem", "primality criterion", "composite modulus", "factorial", "divisibility"],
+    "prerequisites": ["modular arithmetic", "factorials", "prime factorization"]
+  },
+  {
+    "id": "wilson08-core",
+    "proofId": "wilsons-theorem-oq-08",
+    "range": { "startLine": 35, "endLine": 51 },
+    "type": "theorem",
+    "title": "Combinatorial core: distinct factors divide N!",
+    "content": "`mul_dvd_factorial_of_distinct`: if a ≠ b are positive and both ≤ N, then a·b ∣ N!. Proof: {a,b} ⊆ Ico 1 (N+1); `Finset.prod_pair` gives ∏_{{a,b}} i = a·b, and `Finset.prod_dvd_prod_of_subset` makes this divide ∏_{Ico 1 (N+1)} i = N! (`Finset.prod_Ico_id_eq_factorial`). Intuitively, a and b sit as two *separate* terms of the product 1·2···N, so their product divides it. This is the engine of the composite congruence.",
+    "mathContext": "$a \\ne b,\\ 1 \\le a,b \\le N \\implies ab \\mid N!$",
+    "significance": "fundamental",
+    "relatedConcepts": ["Finset product", "subproduct divisibility", "factorial"],
+    "prerequisites": ["Finset.prod_dvd_prod_of_subset", "Finset.prod_Ico_id_eq_factorial"]
+  },
+  {
+    "id": "wilson08-composite",
+    "proofId": "wilsons-theorem-oq-08",
+    "range": { "startLine": 52, "endLine": 93 },
+    "type": "theorem",
+    "title": "The composite factorial congruence n ∣ (n−1)!",
+    "content": "`composite_dvd_factorial_pred`: for composite n > 4, n ∣ (n−1)!. Factor n = m·k with 2 ≤ m ≤ k < n (m the least prime factor, via `Nat.exists_dvd_of_not_prime2`). If m ≠ k, then m and k are distinct factors below n, so n = m·k ∣ (n−1)! by the core lemma. If m = k, then n = m² with m ≥ 3 (else n = 4, excluded); the distinct factors m and 2m both lie below n (2m ≤ m²−1 ⟺ m ≥ 3), so m·(2m) ∣ (n−1)!, and n = m² ∣ m·(2m) = 2m² finishes it.",
+    "mathContext": "$n = m^2,\\ m \\ge 3:\\quad n = m^2 \\mid m\\cdot 2m \\mid (n-1)!$",
+    "significance": "key",
+    "relatedConcepts": ["composite numbers", "least prime factor", "perfect square exception", "factorial divisibility"],
+    "prerequisites": ["Nat.exists_dvd_of_not_prime2", "mul_dvd_factorial_of_distinct"]
+  },
+  {
+    "id": "wilson08-exception",
+    "proofId": "wilsons-theorem-oq-08",
+    "range": { "startLine": 95, "endLine": 102 },
+    "type": "observation",
+    "title": "The lone exception n = 4",
+    "content": "`composite_factorial_zmod` restates the congruence as (n−1)! ≡ 0 in ZMod n. `four_factorial_pred_mod` / `four_not_dvd_factorial_pred`: the single composite where n ∤ (n−1)! is n = 4, since 3! = 6 ≡ 2 (mod 4). This is exactly where the square-case bound 2m ≤ m²−1 fails (m = 2). Certified by ordinary kernel `decide` — no native_decide, no Lean.ofReduceBool.",
+    "mathContext": "$3! = 6 \\equiv 2 \\pmod 4$",
+    "significance": "supporting",
+    "relatedConcepts": ["exceptional case", "kernel decide", "axiom-free certificate"],
+    "prerequisites": ["decidability of divisibility on ℕ"]
+  },
+  {
+    "id": "wilson08-criterion",
+    "proofId": "wilsons-theorem-oq-08",
+    "range": { "startLine": 104, "endLine": 120 },
+    "type": "theorem",
+    "title": "Wilson's criterion over ℕ",
+    "content": "`prime_iff_dvd_factorial_succ`: for n ≥ 2, Nat.Prime n ↔ n ∣ (n−1)!+1. This is Wilson's theorem as a divisibility statement with no ZMod cast in the conclusion. Obtained from `Nat.prime_iff_fac_equiv_neg_one` by moving between (n−1)! ≡ −1 and (n−1)!+1 ≡ 0 (push_cast, `eq_neg_of_add_eq_zero_left`) and applying `ZMod.natCast_eq_zero_iff` to translate the ZMod-zero into ℕ-divisibility.",
+    "mathContext": "$n \\ge 2:\\quad n \\text{ prime} \\iff n \\mid (n-1)!+1$",
+    "significance": "key",
+    "relatedConcepts": ["Wilson primality criterion", "ZMod-to-ℕ bridge", "divisibility"],
+    "prerequisites": ["Nat.prime_iff_fac_equiv_neg_one", "ZMod.natCast_eq_zero_iff"]
+  },
+  {
+    "id": "wilson08-dichotomy",
+    "proofId": "wilsons-theorem-oq-08",
+    "range": { "startLine": 121, "endLine": 137 },
+    "type": "theorem",
+    "title": "The sharp dichotomy for n > 4",
+    "content": "`prime_iff_not_dvd_factorial_pred`: for n > 4, Nat.Prime n ↔ ¬ n ∣ (n−1)!. Forward: if a prime n divided (n−1)!, it would also divide (n−1)!+1 (the criterion), hence divide their difference 1 (`Nat.dvd_sub`, `Nat.le_of_dvd`) — impossible for n > 4. Backward: the contrapositive is precisely the composite congruence. The bound n > 4 excludes only the exceptional composite n = 4.",
+    "mathContext": "$n > 4:\\quad n \\text{ prime} \\iff n \\nmid (n-1)!$",
+    "significance": "key",
+    "relatedConcepts": ["primality test", "prime vs composite", "contrapositive"],
+    "prerequisites": ["prime_iff_dvd_factorial_succ", "composite_dvd_factorial_pred"]
+  },
+  {
+    "id": "wilson08-sanity",
+    "proofId": "wilsons-theorem-oq-08",
+    "range": { "startLine": 138, "endLine": 148 },
+    "type": "observation",
+    "title": "Numeric sanity checks",
+    "content": "Kernel-`decide` certificates illustrating the trichotomy: n = 7 prime with 7 ∣ 6!+1; n = 9 composite with 9 ∣ 8!; and n = 4 the lone composite with 4 ∤ 3!. All use ordinary kernel decide, so #print axioms reports only propext / Classical.choice / Quot.sound.",
+    "mathContext": "$7 \\mid 6!+1,\\quad 9 \\mid 8!,\\quad 4 \\nmid 3!$",
+    "significance": "supporting",
+    "relatedConcepts": ["worked instances", "kernel decide"],
+    "prerequisites": ["decidability of divisibility on ℕ"]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-08/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-08/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "wilsons-theorem-oq-08",
+  "title": "Wilson's Primality Criterion over $\\mathbb{N}$ and the Composite Factorial Congruence",
+  "slug": "wilsons-theorem-oq-08",
+  "description": "Answers an open question on the `wilsons-theorem` gallery family. The parent states Wilson's theorem as the ZMod biconditional Nat.Prime n ↔ ((n−1)! : ZMod n) = −1. This entry sharpens the picture in two elementary directions that live entirely in ℕ. (1) The PRIMALITY CRITERION OVER ℕ: for n ≥ 2, Nat.Prime n ↔ n ∣ (n−1)! + 1 (`prime_iff_dvd_factorial_succ`) — Wilson's criterion in classical divisibility form, with no ZMod cast or additive inverse. (2) The COMPOSITE FACTORIAL CONGRUENCE: for a composite n > 4, n ∣ (n−1)!, i.e. (n−1)! ≡ 0 (mod n) (`composite_dvd_factorial_pred`), with the lone composite exception n = 4 where 3! = 6 ≡ 2 (mod 4) (`four_factorial_pred_mod`, `four_not_dvd_factorial_pred`). Combined they yield the sharp dichotomy for n > 4: Nat.Prime n ↔ ¬ n ∣ (n−1)! (`prime_iff_not_dvd_factorial_pred`). The composite congruence is NOT in Mathlib and is built here from the combinatorial core `mul_dvd_factorial_of_distinct`: two DISTINCT nonzero naturals ≤ N occur as separate factors of N!, so their product divides N!. The perfect-square subcase n = p² is handled by the distinct factors p and 2p, which both lie below n precisely when p ≥ 3 (equivalently n > 4); n = 2² = 4 is exactly the excluded exception since 2p = 4 = n is not < n. Fully machine-checked: 0 sorries, 0 axioms (only foundational propext, Classical.choice, Quot.sound; the small-case `decide` certificates are ordinary kernel decide, so #print axioms confirms no Lean.ofReduceBool).",
+  "meta": {
+    "author": "Wilson/Lagrange (1771); the composite congruence (n−1)! ≡ 0 (mod n) for composite n ≠ 4 is classical; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Wilson%27s_theorem",
+    "date": "1771",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ08.lean",
+    "tags": [
+      "number-theory",
+      "wilsons-theorem",
+      "primality-criterion",
+      "factorial",
+      "composite-numbers",
+      "modular-arithmetic",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 149,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Rests on Mathlib's `Nat.prime_iff_fac_equiv_neg_one` (the ZMod form of Wilson's theorem, from which the ℕ divisibility criterion is derived), `ZMod.natCast_eq_zero_iff` (n ∣ a ↔ (a : ZMod n) = 0), `Nat.exists_dvd_of_not_prime2` (a composite n ≥ 2 has a divisor 2 ≤ m < n), `Finset.prod_Ico_id_eq_factorial` (∏_{1≤i≤N} i = N!), `Finset.prod_dvd_prod_of_subset`, `Finset.prod_pair`, and `Nat.dvd_sub`/`Nat.le_of_dvd`. The four numeric/exception certificates (n = 4, 7, 9) are discharged by ordinary kernel `decide` (NOT `native_decide`), so the proof does not depend on `Lean.ofReduceBool`. The only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.prime_iff_fac_equiv_neg_one",
+        "description": "`n ≠ 1 → (Nat.Prime n ↔ ((n−1)! : ZMod n) = -1)`, the ZMod biconditional form of Wilson's theorem. The ℕ divisibility criterion `n ∣ (n−1)!+1` is derived from it by rewriting `(n−1)! ≡ −1` as `(n−1)!+1 ≡ 0`.",
+        "module": "Mathlib.NumberTheory.Wilson"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "`(a : ZMod b) = 0 ↔ b ∣ a`. Bridges the ZMod congruence and the ℕ divisibility statements in both the primality criterion and the composite congruence.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.exists_dvd_of_not_prime2",
+        "description": "`2 ≤ n → ¬Prime n → ∃ m, m ∣ n ∧ 2 ≤ m ∧ m < n`. Supplies the proper divisor m (least prime factor) used to factor a composite n = m·k with 2 ≤ m ≤ k < n.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Finset.prod_Ico_id_eq_factorial",
+        "description": "`∏ x ∈ Ico 1 (N+1), x = N!`. Identifies the factorial with the product over {1,…,N}, so that any subproduct of distinct factors divides N!.",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.prod_dvd_prod_of_subset",
+        "description": "`s ⊆ t → (∏ i ∈ s, f i) ∣ ∏ i ∈ t, f i`. With s = {a,b} ⊆ Ico 1 (N+1), gives a·b ∣ N! — the combinatorial core of the composite congruence.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      }
+    ],
+    "originalContributions": [
+      "`mul_dvd_factorial_of_distinct`: the combinatorial core — two distinct positive naturals a ≠ b, each ≤ N, satisfy a·b ∣ N!, because {a,b} ⊆ {1,…,N} makes a·b a subproduct of N! (via Finset.prod_pair and Finset.prod_dvd_prod_of_subset).",
+      "`composite_dvd_factorial_pred`: the composite factorial congruence — for composite n > 4, n ∣ (n−1)!. Factor n = m·k with 2 ≤ m ≤ k < n; if m ≠ k use the distinct factors m, k, and if m = k (so n = m², m ≥ 3) use the distinct factors m, 2m with n = m² ∣ m·(2m).",
+      "`composite_factorial_zmod`: the ZMod restatement (n−1)! ≡ 0 (mod n) for composite n > 4.",
+      "`prime_iff_dvd_factorial_succ`: Wilson's primality criterion in purely arithmetic form over ℕ — for n ≥ 2, Nat.Prime n ↔ n ∣ (n−1)!+1, with no ZMod cast in the statement.",
+      "`prime_iff_not_dvd_factorial_pred`: the sharp dichotomy — for n > 4, Nat.Prime n ↔ ¬ n ∣ (n−1)!, cleanly separating primes (which never divide) from composites (which always do), with n = 4 the single excluded exception.",
+      "`four_factorial_pred_mod` / `four_not_dvd_factorial_pred`: the exceptional composite n = 4 (3! ≡ 2 mod 4), certified by ordinary kernel `decide` (no native_decide, hence no Lean.ofReduceBool)."
+    ],
+    "prerequisites": [
+      "Wilson's theorem in ZMod form (Nat.prime_iff_fac_equiv_neg_one)",
+      "The bridge n ∣ a ↔ (a : ZMod n) = 0 (ZMod.natCast_eq_zero_iff)",
+      "Factorization of composites via a proper divisor (Nat.exists_dvd_of_not_prime2)",
+      "Factorials as products over intervals and subproduct divisibility"
+    ],
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "wilsons-theorem",
+        "relationship": "Parent: the gallery's Wilson's theorem entry supplies the ZMod biconditional Nat.Prime n ↔ ((n−1)! : ZMod n) = −1. This entry recasts it as the ℕ divisibility criterion n ∣ (n−1)!+1 and complements it with the composite congruence (n−1)! ≡ 0 (mod n) for composite n > 4, giving the full residue behaviour of (n−1)! mod n."
+      },
+      {
+        "id": "wilsons-theorem-oq-06",
+        "relationship": "Sibling: oq-06 studies the Wilson quotient ((p−1)!+1)/p for primes p. This entry works the complementary composite side, showing (n−1)!+1 is NOT divisible by composite n > 4 (equivalently n ∣ (n−1)!); both keep small-case computations axiom-free via kernel `decide`."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Wilson's theorem (Ibn al-Haytham c. 1000; stated by John Wilson; first proved by Lagrange in 1771) says p is prime iff (p−1)! ≡ −1 (mod p). The converse observation is equally classical and is what makes Wilson a genuine primality *test*: for a composite modulus n the factorial (n−1)! collapses to 0 modulo n — every composite except n = 4 satisfies n ∣ (n−1)!. The reason is elementary: a composite n has two factors that both appear, as distinct terms, inside the product (n−1)! = 1·2···(n−1); the only obstruction is n = 4, whose only nontrivial factorization 2·2 repeats a factor that appears just once below 4. Together, the prime case (≡ −1) and the composite case (≡ 0, bar n = 4) give a complete description of (n−1)! mod n and the sharp criterion Prime n ↔ n ∤ (n−1)! for n > 4.",
+    "problemStatement": "**Open Question (wilsons-theorem-oq-08):** state Wilson's criterion purely over ℕ and complete the composite side. Formalize (i) the arithmetic biconditional Nat.Prime n ↔ n ∣ (n−1)!+1 for n ≥ 2, without reference to ZMod or −1; (ii) the composite factorial congruence n ∣ (n−1)! for every composite n > 4, together with the exceptional value 3! ≡ 2 (mod 4); and (iii) the resulting sharp dichotomy Nat.Prime n ↔ ¬ n ∣ (n−1)! for n > 4.",
+    "text": "For the ℕ criterion, rewrite Wilson's ZMod statement (n−1)! ≡ −1 as (n−1)!+1 ≡ 0, which is exactly n ∣ (n−1)!+1 via ZMod.natCast_eq_zero_iff. For the composite congruence, write a composite n as n = m·k with 2 ≤ m ≤ k < n (m the least prime factor). If m ≠ k, then m and k are distinct elements of {1,…,n−1}, so m·k = n divides (n−1)!. If m = k, then n = m² with m ≥ 3 (as n > 4); now m and 2m are distinct elements of {1,…,n−1} (2m ≤ m²−1 ⟺ m ≥ 3), and n = m² divides m·(2m) = 2m², which divides (n−1)!. The dichotomy follows: composites (n > 4) divide (n−1)!, while primes cannot, since a prime dividing both (n−1)! and (n−1)!+1 would divide 1.",
+    "proofStrategy": "The combinatorial lemma `mul_dvd_factorial_of_distinct` shows a·b ∣ N! for distinct positive a,b ≤ N: the pair {a,b} is a subset of Ico 1 (N+1), so `Finset.prod_pair` and `Finset.prod_dvd_prod_of_subset` give a·b = ∏_{{a,b}} i ∣ ∏_{Ico 1 (N+1)} i = N! (`Finset.prod_Ico_id_eq_factorial`). `composite_dvd_factorial_pred` obtains a proper divisor m via `Nat.exists_dvd_of_not_prime2`, writes n = m·k, derives 2 ≤ k and k < n by omega/nlinarith, and case-splits on m = k. In the square case n = m² it proves 3 ≤ m (else n = 4 contradicts n > 4), bounds m and 2m below n by nlinarith, applies the core lemma to get m·(2m) ∣ (n−1)!, and finishes with n = m² ∣ m·(2m). `prime_iff_dvd_factorial_succ` rewrites with `Nat.prime_iff_fac_equiv_neg_one` and moves between (n−1)! ≡ −1 and (n−1)!+1 ≡ 0 by push_cast + `eq_neg_of_add_eq_zero_left` and `ZMod.natCast_eq_zero_iff`. `prime_iff_not_dvd_factorial_pred` combines the two: forward uses that a prime dividing (n−1)! and (n−1)!+1 divides 1 (`Nat.dvd_sub`, `Nat.le_of_dvd`); backward is the contrapositive of the composite congruence.",
+    "keyInsights": [
+      "**Distinct factors are the whole mechanism.** A composite n > 4 always exposes two *distinct* factors below n whose product is a multiple of n; they sit as separate terms of (n−1)! = 1·2···(n−1), so their product — hence n — divides (n−1)!.",
+      "**n = 4 is the unique exception, and one sees exactly why.** The only composite whose factorization forces a repeated factor (2·2) with that factor appearing just once below n is 4. The square-case bound 2m ≤ m²−1 fails precisely at m = 2, pinpointing the exception.",
+      "**Wilson over ℕ needs no −1.** Rewriting (n−1)! ≡ −1 as (n−1)!+1 ≡ 0 turns the criterion into a divisibility statement n ∣ (n−1)!+1 that is stated and used entirely in ℕ — the form in which Wilson is a primality test.",
+      "**The dichotomy is a one-line consequence of two divisibilities.** For n > 4, a prime cannot divide (n−1)! (it would then divide both (n−1)! and (n−1)!+1, hence 1), while a composite must — giving Prime n ↔ ¬ n ∣ (n−1)! with no further computation.",
+      "**Axiom-free exception check via kernel decide.** The values 3! ≡ 2 (mod 4), 7 ∣ 6!+1, and 9 ∣ 8! are small enough for ordinary kernel `decide`, so the entry never touches native_decide / Lean.ofReduceBool."
+    ],
+    "prerequisites": [
+      "Wilson's theorem in ZMod form (Nat.prime_iff_fac_equiv_neg_one)",
+      "The bridge n ∣ a ↔ (a : ZMod n) = 0",
+      "Factorization of a composite via its least prime factor",
+      "Factorials as interval products and subproduct divisibility"
+    ]
+  },
+  "sections": [
+    {
+      "id": "combinatorial-core",
+      "title": "Combinatorial Core: Distinct Factors Multiply into the Factorial",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring stating the two directions (ℕ primality criterion and composite congruence) and the sharp dichotomy. The core lemma `mul_dvd_factorial_of_distinct`: distinct positive a ≠ b with a,b ≤ N satisfy a·b ∣ N!, proved by embedding {a,b} in Ico 1 (N+1) and combining Finset.prod_pair with Finset.prod_dvd_prod_of_subset and Finset.prod_Ico_id_eq_factorial."
+    },
+    {
+      "id": "composite-congruence",
+      "title": "The Composite Factorial Congruence",
+      "startLine": 52,
+      "endLine": 102,
+      "summary": "`composite_dvd_factorial_pred`: for composite n > 4, n ∣ (n−1)!. Factor n = m·k (Nat.exists_dvd_of_not_prime2) with 2 ≤ m ≤ k < n; distinct-factor case m ≠ k uses m,k directly, and the perfect-square case m = k (n = m², m ≥ 3) uses the distinct factors m, 2m with n = m² ∣ m·(2m). `composite_factorial_zmod` restates it in ZMod n. `four_factorial_pred_mod` and `four_not_dvd_factorial_pred` certify the lone exception 3! ≡ 2 (mod 4) by kernel decide."
+    },
+    {
+      "id": "primality-criterion-over-N",
+      "title": "Wilson's Primality Criterion over ℕ",
+      "startLine": 104,
+      "endLine": 120,
+      "summary": "`prime_iff_dvd_factorial_succ`: for n ≥ 2, Nat.Prime n ↔ n ∣ (n−1)!+1. Rewrites Wilson's ZMod biconditional and converts between (n−1)! ≡ −1 and (n−1)!+1 ≡ 0 via push_cast, eq_neg_of_add_eq_zero_left, and ZMod.natCast_eq_zero_iff — a fully arithmetic statement over ℕ."
+    },
+    {
+      "id": "sharp-dichotomy",
+      "title": "The Sharp Dichotomy for n > 4",
+      "startLine": 121,
+      "endLine": 137,
+      "summary": "`prime_iff_not_dvd_factorial_pred`: for n > 4, Nat.Prime n ↔ ¬ n ∣ (n−1)!. Forward: a prime dividing (n−1)! would also divide (n−1)!+1 (criterion) and hence 1 — impossible. Backward: the contrapositive is exactly the composite congruence."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Numeric Sanity Checks",
+      "startLine": 138,
+      "endLine": 149,
+      "summary": "Kernel-`decide` certificates: n = 7 prime (7 ∣ 6!+1), n = 9 composite (9 ∣ 8!), and n = 4 the lone composite exception (4 ∤ 3!) — all without native_decide."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent Wilson biconditional is recast over ℕ as the divisibility criterion Nat.Prime n ↔ n ∣ (n−1)!+1 (n ≥ 2) and completed on the composite side by n ∣ (n−1)! for every composite n > 4, with the unique exception 3! ≡ 2 (mod 4). Together they give the sharp dichotomy Nat.Prime n ↔ ¬ n ∣ (n−1)! for n > 4. The composite congruence, absent from Mathlib, is built from the combinatorial fact that distinct factors ≤ N multiply into N!. 7 theorems, 0 definitions, 149 lines, 0 sorries, 0 axioms (no native_decide, no Lean.ofReduceBool).",
+    "implications": "Completes the arithmetic picture of (n−1)! mod n: −1 for primes, 0 for composites other than 4, and 2 for n = 4. This is precisely the content that makes Wilson's theorem a primality *criterion* rather than a one-way congruence. The core lemma `mul_dvd_factorial_of_distinct` (distinct factors ≤ N divide N!) is a reusable elementary tool for factorial-divisibility arguments.",
+    "openQuestions": [
+      "Package the results into a decidable Wilson primality test on ℕ and compare its (astronomical) cost with trial division, quantifying the exponential blow-up of (n−1)! that makes the criterion beautiful but impractical.",
+      "Characterize (n−1)! mod n² and the higher-power residues: for composite n the factorial is divisible by n but by which power of each prime factor exactly? (Legendre-formula bookkeeping on the interval {1,…,n−1}.)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "wilsons-theorem",
+      "title": "Wilson's Theorem",
+      "relationship": "Parent — supplies the ZMod biconditional (n−1)! ≡ −1; this entry recasts it over ℕ and adds the composite congruence (n−1)! ≡ 0 for composite n > 4."
+    },
+    {
+      "proofId": "wilsons-theorem-oq-06",
+      "title": "The Wilson Quotient and Wilson Primes",
+      "relationship": "Sibling — studies ((p−1)!+1)/p for primes; this entry handles the complementary composite side, where n ∣ (n−1)! for composite n > 4."
+    }
+  ],
+  "mainTheorems": "none",
+  "sorries": 0,
+  "leanFile": {
+    "lineCount": 149,
+    "path": "Proofs/WilsonsTheoremOQ08.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 7
+  },
+  "references": [
+    {
+      "authors": "G. H. Hardy, E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press",
+      "note": "Wilson's theorem and its converse for composite moduli."
+    },
+    {
+      "authors": "K. Ireland, M. Rosen",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": 1990,
+      "venue": "Springer",
+      "note": "Wilson's theorem as a primality criterion."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.prime_iff_fac_equiv_neg_one, ZMod.natCast_eq_zero_iff, and the Nat/Finset arithmetic API underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **wilsons-theorem-oq-08** (Seeker-selected OQ child off the verified 0-axiom `wilsons-theorem` parent). The parent states Wilson's theorem as the ZMod biconditional `Nat.Prime n ↔ ((n-1)! : ZMod n) = -1`. This entry sharpens it in two elementary directions living entirely in `ℕ`, and completes the composite side.

### Results (7 theorems, 0 def, 149 lines, 0 sorries, **0 axioms**)

1. **Primality criterion over ℕ** — `prime_iff_dvd_factorial_succ`: for `n ≥ 2`, `Nat.Prime n ↔ n ∣ (n-1)!+1`. Wilson's criterion in classical divisibility form, no `ZMod` cast or `-1` in the statement.
2. **Composite factorial congruence** — `composite_dvd_factorial_pred`: for composite `n > 4`, `n ∣ (n-1)!` (i.e. `(n-1)! ≡ 0 mod n`). Not in Mathlib.
3. **The lone exception** — `four_factorial_pred_mod` / `four_not_dvd_factorial_pred`: `3! = 6 ≡ 2 (mod 4)`, so `n = 4` is the unique composite with `n ∤ (n-1)!`.
4. **Sharp dichotomy** — `prime_iff_not_dvd_factorial_pred`: for `n > 4`, `Nat.Prime n ↔ ¬ n ∣ (n-1)!`.

### How the composite congruence is built

The combinatorial core `mul_dvd_factorial_of_distinct` shows that two **distinct** positive naturals `a ≠ b`, each `≤ N`, satisfy `a·b ∣ N!` (they are separate factors of `N! = 1·2···N`). For composite `n = m·k` (`2 ≤ m ≤ k < n`, least prime factor):
- `m ≠ k`: distinct factors `m, k` below `n` give `n = m·k ∣ (n-1)!`.
- `m = k` (so `n = m²`, `m ≥ 3` as `n > 4`): distinct factors `m, 2m` below `n` give `n = m² ∣ m·(2m) ∣ (n-1)!`.

The square-case bound `2m ≤ m²-1 ⟺ m ≥ 3` is exactly why `n = 2² = 4` is the sole exception.

### Verification

- `#print axioms` on all main theorems reports only `propext`, `Classical.choice`, `Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`. Small-case checks (`n = 4, 7, 9`) use **ordinary kernel `decide`**, not `native_decide`.
- Compiled clean (0 errors, 0 warnings) with Lean 4.26.0 + Mathlib via targeted-import compile (`import Mathlib` umbrella olean was locally corrupt; repaired via `lake exe cache get`).

Gallery entry: `src/data/proofs/wilsons-theorem-oq-08/` (meta.json + annotations.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)