### PR TITLE
research(randomized-maxcut-oq-05): Max-Cut saturates the edge bound exactly on bipartite graphs [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/RandomizedMaxCutOQ05.lean
+++ b/proofs/Proofs/RandomizedMaxCutOQ05.lean
@@ -1,0 +1,162 @@
+import Proofs.RandomizedMaxCut
+import Mathlib.Combinatorics.SimpleGraph.Coloring
+import Mathlib.Combinatorics.SimpleGraph.DegreeSum
+
+/-!
+# Max-Cut Saturates the Edge Bound Exactly on Bipartite Graphs
+
+The base entry `randomized-maxcut` proves the universal upper bound
+`maxCutValue G ≤ |E(G)|` (`maxCut_le_edges`): no cut can cross more edges than
+the graph has.  This entry pins down **exactly when that bound is attained**.
+
+## Main results
+
+* `maxCut_eq_edges_of_coloring` — if `G` admits a `Bool`-coloring (i.e. `G` is
+  bipartite), then `maxCutValue G = |E(G)|`: the bipartition crosses *every*
+  edge, so the trivial upper bound is met.
+* `coloring_of_maxCut_eq_edges` — conversely, if the max cut crosses every edge
+  then the optimal partition is a proper `2`-coloring, so `G` is bipartite.
+* `maxCut_eq_edges_iff_colorable` — the **rigidity characterization**:
+  `maxCutValue G = |E(G)| ↔ Nonempty (G.Coloring Bool)`.  Max-Cut saturates the
+  edge bound *iff* the graph is bipartite.
+* `maxCut_completeBipartiteGraph` — the headline corollary:
+  `maxCutValue (completeBipartiteGraph V W) = card V * card W`.  For `K_{m,n}`
+  the maximum cut is the entire edge set, of size `m * n`.
+
+The forward direction is the easy "witness" half; the reverse direction is the
+extremal content — a rigidity statement in the spirit of "the averaging bound is
+tight only in the degenerate (here: bipartite) case".
+-/
+
+open Finset SimpleGraph
+
+namespace RandomizedMaxCutOQ05
+
+variable {V : Type*} [DecidableEq V] [Fintype V]
+
+/-- Under the cut coming from an assignment `c : V → Bool`, an edge `s(u, v)` is
+crossed **iff** its endpoints receive different colours. -/
+lemma edgeInCut_ofAssignment {G : SimpleGraph V} (c : V → Bool) (u v : V) :
+    (Cut.ofAssignment (G := G) c).edgeInCut s(u, v) = (c u != c v) := by
+  simp only [Cut.edgeInCut, Cut.ofAssignment, Sym2.lift_mk, mem_filter, mem_univ, true_and]
+  cases c u <;> cases c v <;> decide
+
+/-- If every edge of `G` is crossed by the cut of an assignment `c`, then that
+cut has size `|E(G)|`. -/
+lemma size_ofAssignment_eq_card_edges {G : SimpleGraph V} [DecidableRel G.Adj]
+    (c : V → Bool) (h : ∀ e ∈ G.edgeFinset, (Cut.ofAssignment (G := G) c).edgeInCut e) :
+    (Cut.ofAssignment (G := G) c).size = G.edgeFinset.card := by
+  unfold Cut.size
+  rw [Finset.filter_true_of_mem h]
+
+/-- **Bipartite ⟹ Max-Cut is the whole edge set.**  A `Bool`-coloring of `G`
+crosses every edge, so its partition is an optimal cut of size `|E(G)|`. -/
+theorem maxCut_eq_edges_of_coloring {G : SimpleGraph V} [DecidableRel G.Adj]
+    (C : G.Coloring Bool) : maxCutValue G = G.edgeFinset.card := by
+  refine le_antisymm (maxCut_le_edges G) ?_
+  set c : V → Bool := fun v => C v with hc
+  have hcross : ∀ e ∈ G.edgeFinset, (Cut.ofAssignment (G := G) c).edgeInCut e := by
+    intro e
+    induction e using Sym2.ind with
+    | _ u v =>
+      intro he
+      rw [SimpleGraph.mem_edgeFinset, SimpleGraph.mem_edgeSet] at he
+      rw [edgeInCut_ofAssignment]
+      have hne : C u ≠ C v := C.valid he
+      simpa [hc, bne_iff_ne] using hne
+  have hsize : (Cut.ofAssignment (G := G) c).size = G.edgeFinset.card :=
+    size_ofAssignment_eq_card_edges c hcross
+  calc G.edgeFinset.card = (Cut.ofAssignment (G := G) c).size := hsize.symm
+    _ ≤ maxCutValue G := by
+        rw [maxCutValue]
+        exact Finset.le_sup (f := fun f : V → Bool => (Cut.ofAssignment (G := G) f).size)
+          (Finset.mem_univ c)
+
+/-- **Max-Cut is the whole edge set ⟹ bipartite.**  If the optimal cut crosses
+every edge, the assignment attaining it is a proper `2`-coloring. -/
+theorem coloring_of_maxCut_eq_edges {G : SimpleGraph V} [DecidableRel G.Adj]
+    (h : maxCutValue G = G.edgeFinset.card) : Nonempty (G.Coloring Bool) := by
+  have hne : (Finset.univ : Finset (V → Bool)).Nonempty := Finset.univ_nonempty
+  obtain ⟨f, _, hf⟩ :=
+    Finset.exists_mem_eq_sup' hne (fun f : V → Bool => (Cut.ofAssignment (G := G) f).size)
+  have hsup : maxCutValue G = (Cut.ofAssignment (G := G) f).size := by
+    rw [maxCutValue, ← Finset.sup'_eq_sup hne, hf]
+  have hsize : (Cut.ofAssignment (G := G) f).size = G.edgeFinset.card := by
+    rw [← hsup, h]
+  have hfilter :
+      G.edgeFinset.filter (fun e => (Cut.ofAssignment (G := G) f).edgeInCut e)
+        = G.edgeFinset := by
+    apply Finset.eq_of_subset_of_card_le (Finset.filter_subset _ _)
+    exact le_of_eq hsize.symm
+  have hcross : ∀ e ∈ G.edgeFinset, (Cut.ofAssignment (G := G) f).edgeInCut e :=
+    (Finset.filter_eq_self).1 hfilter
+  refine ⟨Coloring.mk f ?_⟩
+  intro u v huv
+  have hmem : s(u, v) ∈ G.edgeFinset := by
+    rw [SimpleGraph.mem_edgeFinset, SimpleGraph.mem_edgeSet]; exact huv
+  have hc := hcross _ hmem
+  rw [edgeInCut_ofAssignment] at hc
+  simpa [bne_iff_ne] using hc
+
+/-- **Rigidity characterization.**  The maximum cut saturates the universal edge
+bound `maxCutValue G ≤ |E(G)|` **iff** `G` is bipartite (`Bool`-colorable). -/
+theorem maxCut_eq_edges_iff_colorable {G : SimpleGraph V} [DecidableRel G.Adj] :
+    maxCutValue G = G.edgeFinset.card ↔ Nonempty (G.Coloring Bool) :=
+  ⟨coloring_of_maxCut_eq_edges, fun ⟨C⟩ => maxCut_eq_edges_of_coloring C⟩
+
+/-! ## The complete bipartite graph `K_{m,n}` -/
+
+section CompleteBipartite
+
+variable (V W : Type*) [DecidableEq V] [Fintype V] [DecidableEq W] [Fintype W]
+
+instance : DecidableRel (completeBipartiteGraph V W).Adj := by
+  intro u v
+  unfold completeBipartiteGraph
+  infer_instance
+
+/-- Degree of a left vertex in `K_{m,n}` is `|W| = n`. -/
+lemma degree_inl (a : V) :
+    (completeBipartiteGraph V W).degree (Sum.inl a) = Fintype.card W := by
+  have hset : (completeBipartiteGraph V W).neighborFinset (Sum.inl a)
+      = Finset.univ.map ⟨Sum.inr, Sum.inr_injective⟩ := by
+    ext x
+    simp only [SimpleGraph.mem_neighborFinset, Finset.mem_map, Finset.mem_univ,
+      Function.Embedding.coeFn_mk, true_and]
+    cases x with
+    | inl b => simp [completeBipartiteGraph]
+    | inr w => simp [completeBipartiteGraph]
+  rw [SimpleGraph.degree, hset, Finset.card_map, Finset.card_univ]
+
+/-- Degree of a right vertex in `K_{m,n}` is `|V| = m`. -/
+lemma degree_inr (b : W) :
+    (completeBipartiteGraph V W).degree (Sum.inr b) = Fintype.card V := by
+  have hset : (completeBipartiteGraph V W).neighborFinset (Sum.inr b)
+      = Finset.univ.map ⟨Sum.inl, Sum.inl_injective⟩ := by
+    ext x
+    simp only [SimpleGraph.mem_neighborFinset, Finset.mem_map, Finset.mem_univ,
+      Function.Embedding.coeFn_mk, true_and]
+    cases x with
+    | inl a => simp [completeBipartiteGraph]
+    | inr w => simp [completeBipartiteGraph]
+  rw [SimpleGraph.degree, hset, Finset.card_map, Finset.card_univ]
+
+/-- The number of edges of `K_{m,n}` is `m * n`. -/
+lemma card_edgeFinset_completeBipartiteGraph :
+    (completeBipartiteGraph V W).edgeFinset.card = Fintype.card V * Fintype.card W := by
+  have h := (completeBipartiteGraph V W).sum_degrees_eq_twice_card_edges
+  rw [Fintype.sum_sum_type] at h
+  simp only [degree_inl, degree_inr, Finset.sum_const, Finset.card_univ, smul_eq_mul] at h
+  rw [Nat.mul_comm (Fintype.card W) (Fintype.card V)] at h
+  omega
+
+/-- **Headline corollary.**  The maximum cut of the complete bipartite graph
+`K_{m,n}` crosses *every* edge, so it equals `|E| = m * n`. -/
+theorem maxCut_completeBipartiteGraph :
+    maxCutValue (completeBipartiteGraph V W) = Fintype.card V * Fintype.card W := by
+  rw [maxCut_eq_edges_of_coloring (CompleteBipartiteGraph.bicoloring V W),
+    card_edgeFinset_completeBipartiteGraph]
+
+end CompleteBipartite
+
+end RandomizedMaxCutOQ05

--- a/src/data/proofs/randomized-maxcut-oq-05/annotations.json
+++ b/src/data/proofs/randomized-maxcut-oq-05/annotations.json
@@ -1,0 +1,174 @@
+[
+  {
+    "id": "ann-edge-in-cut",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 39,
+      "endLine": 42
+    },
+    "type": "lemma",
+    "title": "An Edge Is Crossed iff Its Endpoints Differ",
+    "content": "The bridge between graph structure and the Boolean assignment. The cut Cut.ofAssignment c sends vertices with c v = true to side A and the rest to side B. An edge s(u,v) is 'in the cut' exactly when one endpoint is in A and the other in B — that is, when c u ≠ c v. Reducing edgeInCut to the two-symbol inequality c u != c v lets every later argument reason purely about colours.",
+    "mathContext": "$\\text{edgeInCut}(\\text{Cut.ofAssignment } c)\\, s(u,v) = (c\\,u \\mathbin{\\text{!=}} c\\,v)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "graph cut",
+      "Boolean assignment",
+      "Sym2 lift"
+    ],
+    "prerequisites": [
+      "Sym2",
+      "Finset membership"
+    ]
+  },
+  {
+    "id": "ann-size-eq-card",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 46,
+      "endLine": 50
+    },
+    "type": "lemma",
+    "title": "A Cut Crossing Every Edge Has Size |E|",
+    "content": "If the assignment c crosses every edge of G, then filtering the edge set by the crossing predicate leaves it unchanged, so the cut size — defined as the cardinality of that filter — equals the total edge count. This is the numerical heart of the forward direction.",
+    "mathContext": "$(\\forall e \\in E,\\ \\text{edgeInCut } e) \\Rightarrow |\\text{Cut.ofAssignment } c| = |E(G)|$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Finset.filter_true_of_mem",
+      "cut size"
+    ],
+    "prerequisites": [
+      "Finset.filter"
+    ]
+  },
+  {
+    "id": "ann-forward",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 52,
+      "endLine": 71
+    },
+    "type": "theorem",
+    "title": "Bipartite ⟹ Max-Cut = |E|",
+    "content": "The easy 'witness' direction. Given a Bool-coloring C, its validity (C u ≠ C v for every adjacent pair) means the induced assignment crosses every edge, so the corresponding cut has size |E|. Since maxCutValue is the supremum over all assignments, it is at least this cut's size; combined with the universal upper bound maxCut_le_edges from the base entry, equality follows.",
+    "mathContext": "$C : G.\\text{Coloring } \\text{Bool} \\Rightarrow \\text{maxCutValue } G = |E(G)|$",
+    "significance": "key",
+    "relatedConcepts": [
+      "graph coloring",
+      "Finset.le_sup",
+      "maxCut_le_edges"
+    ],
+    "prerequisites": [
+      "SimpleGraph.Coloring",
+      "Finset.sup"
+    ]
+  },
+  {
+    "id": "ann-reverse",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 73,
+      "endLine": 97
+    },
+    "type": "theorem",
+    "title": "Max-Cut = |E| ⟹ Bipartite",
+    "content": "The extremal direction, where a numerical equality must yield combinatorial structure. Because the supremum defining maxCutValue is taken over the finite nonempty type V → Bool, it is attained by some assignment f. If maxCut = |E| then f's cut has size |E|, forcing the filter of crossed edges to be the entire edge set — so f crosses every edge. Reading f off as colours gives a proper 2-coloring, i.e. a Bool-coloring of G, witnessing that G is bipartite.",
+    "mathContext": "$\\text{maxCutValue } G = |E(G)| \\Rightarrow \\text{Nonempty}(G.\\text{Coloring } \\text{Bool})$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.exists_mem_eq_sup'",
+      "Finset.eq_of_subset_of_card_le",
+      "Coloring.mk"
+    ],
+    "prerequisites": [
+      "supremum attainment",
+      "SimpleGraph.Coloring"
+    ]
+  },
+  {
+    "id": "ann-rigidity",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 99,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "Rigidity Characterization of Max-Cut Saturation",
+    "content": "The headline theorem: the maximum cut saturates the universal edge bound maxCut(G) ≤ |E(G)| if and only if G is bipartite (admits a Bool-coloring). Assembles the two preceding directions into a single iff, characterizing exactly the graphs whose Max-Cut is trivial to compute.",
+    "mathContext": "$\\text{maxCutValue } G = |E(G)| \\iff \\text{Nonempty}(G.\\text{Coloring } \\text{Bool})$",
+    "significance": "key",
+    "relatedConcepts": [
+      "bipartite graphs",
+      "extremal characterization",
+      "rigidity"
+    ],
+    "prerequisites": [
+      "the two directions above"
+    ]
+  },
+  {
+    "id": "ann-degrees",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 116,
+      "endLine": 140
+    },
+    "type": "lemma",
+    "title": "Degrees in the Complete Bipartite Graph",
+    "content": "In K_{m,n} = completeBipartiteGraph V W, a left vertex inl a is adjacent to every right vertex and to no left vertex, so its neighbor set is the image of Sum.inr and its degree is |W| = n. Symmetrically a right vertex has degree |V| = m. These are proved by identifying the neighbor Finset with a mapped copy of univ.",
+    "mathContext": "$\\deg(\\text{inl } a) = |W| = n, \\qquad \\deg(\\text{inr } b) = |V| = m$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "neighborFinset",
+      "Finset.map",
+      "vertex degree"
+    ],
+    "prerequisites": [
+      "completeBipartiteGraph",
+      "Sum type"
+    ]
+  },
+  {
+    "id": "ann-edge-count",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 142,
+      "endLine": 149
+    },
+    "type": "lemma",
+    "title": "K_{m,n} Has m·n Edges (Handshake Lemma)",
+    "content": "Summing degrees over all vertices via Fintype.sum_sum_type splits into the left and right sides, giving n·m + m·n = 2mn. By the handshake lemma sum_degrees_eq_twice_card_edges this equals 2|E|, so |E(K_{m,n})| = m·n.",
+    "mathContext": "$2|E| = \\sum_v \\deg v = m\\,n + n\\,m \\Rightarrow |E(K_{m,n})| = m\\,n$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "handshake lemma",
+      "Fintype.sum_sum_type",
+      "degree sum formula"
+    ],
+    "prerequisites": [
+      "sum_degrees_eq_twice_card_edges"
+    ]
+  },
+  {
+    "id": "ann-maxcut-kmn",
+    "proofId": "randomized-maxcut-oq-05",
+    "range": {
+      "startLine": 151,
+      "endLine": 156
+    },
+    "type": "theorem",
+    "title": "Max-Cut of K_{m,n} Equals m·n",
+    "content": "The headline corollary. K_{m,n} is bipartite — witnessed by Mathlib's CompleteBipartiteGraph.bicoloring — so the forward direction gives maxCut = |E|, and the handshake edge count gives |E| = m·n. The complete bipartite graph's optimal cut crosses every single edge.",
+    "mathContext": "$\\text{maxCutValue}(K_{m,n}) = |E| = m \\cdot n$",
+    "significance": "key",
+    "relatedConcepts": [
+      "complete bipartite graph",
+      "CompleteBipartiteGraph.bicoloring",
+      "optimal cut"
+    ],
+    "prerequisites": [
+      "the rigidity characterization",
+      "edge count of K_{m,n}"
+    ]
+  }
+]

--- a/src/data/proofs/randomized-maxcut-oq-05/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-05/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "randomized-maxcut-oq-05",
+  "title": "Max-Cut Saturates the Edge Bound Exactly on Bipartite Graphs",
+  "slug": "randomized-maxcut-oq-05",
+  "description": "Characterizes exactly when the universal bound maxCut(G) ≤ |E(G)| is attained: the maximum cut equals the whole edge set if and only if G is bipartite (Bool-colorable). As a corollary, the max cut of the complete bipartite graph K_{m,n} is |E| = m·n. Reuses the Cut / maxCutValue framework of the base randomized-maxcut entry.",
+  "meta": {
+    "author": "Classical (folklore); formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "graph-theory",
+      "combinatorics",
+      "extremal-combinatorics",
+      "max-cut",
+      "bipartite",
+      "rigidity"
+    ],
+    "proofRepoPath": "Proofs/RandomizedMaxCutOQ05.lean",
+    "badge": "original",
+    "sorries": 0,
+    "originalContributions": [
+      "maxCut_eq_edges_iff_colorable: the rigidity characterization maxCut(G) = |E(G)| ↔ Nonempty (G.Coloring Bool)",
+      "maxCut_eq_edges_of_coloring: a Bool-coloring makes the bipartition an optimal cut of size |E|",
+      "coloring_of_maxCut_eq_edges: extracting a proper 2-coloring from an optimal edge-saturating cut",
+      "edgeInCut_ofAssignment: an edge is crossed iff its endpoints get different colours (c u != c v)",
+      "card_edgeFinset_completeBipartiteGraph: |E(K_{m,n})| = m·n via the handshake lemma",
+      "maxCut_completeBipartiteGraph: maxCut(K_{m,n}) = m·n"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 162,
+    "assumptions": "No remaining sorries and no axioms beyond Lean/Mathlib foundations (propext, Classical.choice, Quot.sound). All results fully machine-checked.",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Max-Cut problem — partition a graph's vertices into two sides to maximize the number of crossing edges — is one of Karp's 21 NP-complete problems (1972). Trivially the cut can never exceed the total edge count, maxCut(G) ≤ |E(G)|, and the base randomized-maxcut entry formalizes exactly this bound. A cut that crosses *every* edge is the extreme case: it exists precisely when the two sides are independent sets, i.e. when the graph is bipartite. This is the graph-theoretic content of König's classical theory of bipartite graphs (1936) and the equivalence 'bipartite ⇔ 2-colorable ⇔ no odd cycle'. The concrete extremal instance is the complete bipartite graph K_{m,n}, whose bipartition cuts all m·n edges.",
+    "problemStatement": "Determine exactly when the universal Max-Cut bound maxCutValue G ≤ G.edgeFinset.card is attained, and compute the maximum cut of the complete bipartite graph K_{m,n}.",
+    "proofStrategy": "Work inside the Cut / maxCutValue framework of the base entry, where maxCutValue G = univ.sup (fun f : V → Bool => (Cut.ofAssignment f).size). First prove edgeInCut_ofAssignment: under the cut from an assignment c, the edge s(u,v) is crossed iff c u ≠ c v. Forward direction: a Bool-coloring C is an assignment whose validity guarantees every edge is crossed, so its cut has size |E|; combined with maxCut_le_edges this gives equality. Reverse direction: since the sup over the finite nonempty set of assignments is attained, some assignment f cuts all edges; the filter of crossed edges is then all of edgeFinset, and reading off f gives a proper 2-coloring. The iff is the conjunction. For K_{m,n}, Mathlib's CompleteBipartiteGraph.bicoloring supplies the coloring, and the edge count |E| = m·n follows from the handshake lemma with degree m or n on the two sides.",
+    "keyInsights": [
+      "The bound maxCut(G) ≤ |E(G)| is saturated iff G is bipartite — a rigidity/equality statement: the averaging bound is tight only in the 'degenerate' (2-colorable) case, mirroring first-moment rigidity elsewhere in the gallery.",
+      "The two directions have very different flavors: forward is an easy witness (a coloring cuts every edge), while reverse is extremal — it must *extract* combinatorial structure (a 2-coloring) from a numerical equality.",
+      "The bridge lemma edgeInCut_ofAssignment reduces all graph reasoning to a two-symbol comparison c u != c v, so both directions hinge on the same Boolean fact.",
+      "Attainment of the sup over the finite type V → Bool (Finset.exists_mem_eq_sup') is what lets a purely numerical hypothesis maxCut = |E| produce an explicit optimal assignment.",
+      "The K_{m,n} edge count m·n falls out of the handshake lemma: every left vertex has degree n, every right vertex degree m, so 2|E| = m·n + n·m."
+    ]
+  },
+  "sections": [
+    {
+      "id": "edge-crossing",
+      "title": "Part I: When an Edge Is Crossed",
+      "startLine": 37,
+      "endLine": 50,
+      "summary": "Proves edgeInCut_ofAssignment — under the cut induced by an assignment c, the edge s(u,v) is crossed iff c u ≠ c v — and size_ofAssignment_eq_card_edges, that a cut crossing every edge has size |E|.",
+      "mathContext": "$\\text{edgeInCut}(s(u,v)) = (c\\,u \\ne c\\,v)$; if all edges are crossed then $|\\text{cut}| = |E(G)|$."
+    },
+    {
+      "id": "forward",
+      "title": "Part II: Bipartite ⟹ Max-Cut = |E|",
+      "startLine": 52,
+      "endLine": 72,
+      "summary": "maxCut_eq_edges_of_coloring: a Bool-coloring C crosses every edge (by validity), so its partition is a cut of size |E|; with maxCut_le_edges this forces maxCutValue G = |E(G)|.",
+      "mathContext": "$C : G.\\text{Coloring } \\text{Bool} \\;\\Rightarrow\\; \\text{maxCutValue } G = |E(G)|$."
+    },
+    {
+      "id": "reverse",
+      "title": "Part III: Max-Cut = |E| ⟹ Bipartite",
+      "startLine": 73,
+      "endLine": 97,
+      "summary": "coloring_of_maxCut_eq_edges: the sup is attained by some assignment f; if it equals |E| then the filter of crossed edges is all of edgeFinset, so f crosses every edge and hence is a proper 2-coloring.",
+      "mathContext": "$\\text{maxCutValue } G = |E(G)| \\;\\Rightarrow\\; \\exists\\, C : G.\\text{Coloring } \\text{Bool}$."
+    },
+    {
+      "id": "rigidity",
+      "title": "Part IV: The Rigidity Characterization",
+      "startLine": 99,
+      "endLine": 103,
+      "summary": "maxCut_eq_edges_iff_colorable assembles the two directions: Max-Cut saturates the edge bound iff the graph is bipartite.",
+      "mathContext": "$\\text{maxCutValue } G = |E(G)| \\iff \\text{Nonempty}(G.\\text{Coloring } \\text{Bool})$."
+    },
+    {
+      "id": "complete-bipartite",
+      "title": "Part V: The Complete Bipartite Graph K_{m,n}",
+      "startLine": 105,
+      "endLine": 160,
+      "summary": "Computes vertex degrees (degree_inl = n, degree_inr = m), derives |E(K_{m,n})| = m·n via the handshake lemma, and concludes maxCut_completeBipartiteGraph: the max cut of K_{m,n} is m·n.",
+      "mathContext": "$\\deg(\\text{inl}) = n,\\ \\deg(\\text{inr}) = m \\Rightarrow |E| = m\\,n \\Rightarrow \\text{maxCutValue}(K_{m,n}) = m\\,n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "randomized-maxcut",
+      "relationship": "extends",
+      "description": "Reuses the Cut, Cut.ofAssignment, Cut.size, and maxCutValue framework and sharpens the base entry's upper bound maxCut_le_edges into an exact characterization of when it is attained."
+    },
+    {
+      "targetId": "randomized-maxcut-oq-04",
+      "relationship": "related",
+      "description": "The derandomized greedy 1/2-approximation; both entries analyze the extremal behavior of the Max-Cut value, here at the opposite (edge-saturating) extreme."
+    },
+    {
+      "targetId": "randomized-maxcut-oq-01",
+      "relationship": "related",
+      "description": "The Goemans-Williamson 0.878-approximation; on bipartite graphs the exact optimum |E| computed here is achieved, illustrating the gap between worst-case and bipartite instances."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) in 162 lines. Proves the rigidity characterization maxCutValue G = |E(G)| ↔ G is bipartite (Bool-colorable), and the headline corollary that the complete bipartite graph K_{m,n} has maximum cut m·n. Built on the Cut / maxCutValue framework of the base randomized-maxcut entry.",
+    "implications": "The result sharpens the trivial Max-Cut upper bound into an exact equality condition, tying the algorithmic quantity maxCut(G) to the structural property of bipartiteness. The bridge lemma edgeInCut_ofAssignment (an edge is cut iff its endpoints differ) and the sup-attainment extraction are reusable for other extremal cut arguments. On bipartite inputs Max-Cut is polynomial-time exact, which this formalization makes precise.",
+    "openQuestions": [
+      "Can the odd-cycle obstruction be formalized, giving maxCut(G) < |E(G)| whenever G contains an odd cycle?",
+      "What is the largest maxCut/|E| ratio attainable by non-bipartite graphs, and can the extremal (near-bipartite) families be characterized in Lean?",
+      "Does the framework extend to weighted graphs, characterizing when the maximum weighted cut equals the total edge weight?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.RandomizedMaxCut",
+      "Mathlib.Combinatorics.SimpleGraph.Coloring",
+      "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
+    ],
+    "namespace": "RandomizedMaxCutOQ05",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/RandomizedMaxCutOQ05.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "maxCut_eq_edges_iff_colorable",
+      "type": "core",
+      "description": "Rigidity characterization: maxCutValue G = |E(G)| ↔ Nonempty (G.Coloring Bool). Max-Cut saturates the edge bound iff G is bipartite."
+    },
+    {
+      "name": "maxCut_completeBipartiteGraph",
+      "type": "core",
+      "description": "The maximum cut of the complete bipartite graph K_{m,n} equals |E| = m·n."
+    },
+    {
+      "name": "maxCut_eq_edges_of_coloring",
+      "type": "supporting",
+      "description": "A Bool-coloring of G makes its bipartition an optimal cut of size |E(G)|."
+    },
+    {
+      "name": "coloring_of_maxCut_eq_edges",
+      "type": "supporting",
+      "description": "An edge-saturating optimal cut yields a proper 2-coloring, so G is bipartite."
+    },
+    {
+      "name": "edgeInCut_ofAssignment",
+      "type": "supporting",
+      "description": "Under the cut from an assignment c, the edge s(u,v) is crossed iff c u ≠ c v."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/randomized-maxcut-oq-05.json
+++ b/src/data/research/problems/randomized-maxcut-oq-05.json
@@ -1,0 +1,82 @@
+{
+  "slug": "randomized-maxcut-oq-05",
+  "title": "Max-Cut of a Complete Bipartite Graph Equals the Full Edge Count",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{For any bipartite graph } G=(A\\sqcup B,E):\\quad \\mathrm{maxcut}(G)=|E|,\n\\qquad\\text{and in particular}\\qquad\n\\mathrm{maxcut}(K_{m,n}) = m\\cdot n .",
+    "plain": "The parent entry `randomized-maxcut` proves the probabilistic lower bound: a *uniformly",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-01T08:33:00.688Z",
+    "iteration": 1,
+    "focus": "",
+    "blockers": [],
+    "nextAction": "Shipped: RandomizedMaxCutOQ05.lean, PR pending.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "graph-theory",
+    "randomized-maxcut",
+    "extremal-combinatorics",
+    "probabilistic-method"
+  ],
+  "relatedProofs": [
+    "randomized-maxcut",
+    "randomized-maxcut-oq-02",
+    "randomized-maxcut-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-01T08:33:00.688Z",
+  "lastUpdate": "2026-07-01T08:33:00.688Z",
+  "significance": 5,
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/RandomizedMaxcutOQ02.lean",
+      "filename": "RandomizedMaxcutOQ02.lean",
+      "lineCount": 128,
+      "theoremCount": 3,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RandomizedMaxcutOQ02.lean"
+    },
+    {
+      "path": "Proofs/RandomizedMaxcutOQ04.lean",
+      "filename": "RandomizedMaxcutOQ04.lean",
+      "lineCount": 402,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RandomizedMaxcutOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Sharpens the base `randomized-maxcut` universal bound `maxCut(G) ≤ |E(G)|` (`maxCut_le_edges`) into an **exact rigidity characterization** of when it is attained, and computes the extremal instance `K_{m,n}`.

**Status:** VERIFIED, 0-axiom (`#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`).

## Main results

`Proofs/RandomizedMaxCutOQ05.lean` — 9 theorems/lemmas + 1 instance, 162 lines:

- **`maxCut_eq_edges_iff_colorable`** (headline): `maxCutValue G = G.edgeFinset.card ↔ Nonempty (G.Coloring Bool)`. The maximum cut equals the whole edge set **iff** `G` is bipartite.
- `maxCut_eq_edges_of_coloring` (forward, witness): a `Bool`-coloring crosses every edge, so its bipartition is an optimal cut of size `|E|`.
- `coloring_of_maxCut_eq_edges` (reverse, extremal): since the sup over `V → Bool` is attained, an edge-saturating optimal cut yields a proper 2-coloring.
- `edgeInCut_ofAssignment` (bridge): an edge `s(u,v)` is crossed iff `c u ≠ c v`.
- `maxCut_completeBipartiteGraph`: `maxCut(K_{m,n}) = |E| = m·n`, via the handshake edge count and Mathlib's `CompleteBipartiteGraph.bicoloring`.

## Why it's non-redundant

The base entry and its children (`oq-01` SDP, `oq-02` weighted, `oq-04` derandomization) prove *lower* bounds / approximation ratios. This entry characterizes the *upper* extreme (edge saturation) and its exact structural condition (bipartiteness) — a first-moment/rigidity flavored result, reusing the base `Cut` / `maxCutValue` framework.

## Build

Verified with direct `lake env lean` (Docker containerd meta.db is corrupt in this environment). Imports `Proofs.RandomizedMaxCut` + `Mathlib.Combinatorics.SimpleGraph.{Coloring,DegreeSum}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)