### PR TITLE
research(konigsberg-oq-05): Eulerian trail endpoints = odd-degree vertices [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/KonigsbergOQ05.lean
+++ b/proofs/Proofs/KonigsbergOQ05.lean
@@ -1,0 +1,111 @@
+import Mathlib.Combinatorics.SimpleGraph.Trails
+import Mathlib.Tactic
+
+/-
+# Königsberg OQ-05: Endpoints of an Eulerian Trail Are Exactly the Odd-Degree Vertices
+
+An *Eulerian trail* is a walk that traverses every edge of a graph exactly once
+(`SimpleGraph.Walk.IsEulerian`).  Euler's original analysis of the Königsberg
+bridges rests on a parity observation: as the trail passes *through* an interior
+vertex it consumes edges two at a time (one to arrive, one to leave), so every
+vertex other than the two endpoints must have even degree, while each endpoint
+carries one unmatched edge and is therefore odd.
+
+Mathlib already records the *cardinality* half of this story:
+`SimpleGraph.Walk.IsEulerian.even_degree_iff` characterises even degree, and
+`IsEulerian.card_odd_degree` shows the number of odd-degree vertices is `0` or `2`.
+This entry sharpens the statement from "*how many*" to "*which*": it identifies the
+odd-degree vertices **explicitly** as the trail's two endpoints.
+
+Main results (all machine-checked, `0` axioms beyond Mathlib's foundational core):
+
+* `oddDegree_iff_endpoint` — for an open trail (`u ≠ v`), a vertex has odd degree
+  iff it equals `u` or `v`.
+* `oddDegreeVerts_eq_pair` — the odd-degree vertex set is exactly `{u, v}`.
+* `card_oddDegreeVerts` — hence there are exactly two odd-degree vertices
+  (the sharp form of `card_odd_degree` for the open case).
+* `endpoint_left_odd`, `endpoint_right_odd` — each endpoint has odd degree.
+* `circuit_all_even` / `circuit_no_odd` — a closed trail (`u = v`, an Eulerian
+  circuit) forces *every* vertex to have even degree, so there are no odd vertices.
+* `no_eulerian_of_card_odd_gt_two` — the parity obstruction: a graph with three or
+  more odd-degree vertices admits no Eulerian trail at all.  The Königsberg
+  multigraph has four odd vertices, which is precisely why the bridges cannot be
+  walked.
+
+Parent: `Konigsberg.lean` (the seven-bridges problem).
+-/
+
+namespace KonigsbergOQ05
+
+open SimpleGraph SimpleGraph.Walk Finset
+
+variable {V : Type*} [Fintype V] [DecidableEq V] {G : SimpleGraph V} [DecidableRel G.Adj]
+
+/-! ## The open case: `u ≠ v` -/
+
+/-- **Odd degree ⟺ endpoint.**  Along an open Eulerian trail from `u` to `v`
+(`u ≠ v`), a vertex has odd degree precisely when it is one of the two endpoints.
+This is the vertex-level sharpening of `IsEulerian.even_degree_iff`. -/
+theorem oddDegree_iff_endpoint {u v x : V} {p : G.Walk u v} (hp : p.IsEulerian)
+    (huv : u ≠ v) : Odd (G.degree x) ↔ x = u ∨ x = v := by
+  have key : Even (G.degree x) ↔ x ≠ u ∧ x ≠ v :=
+    hp.even_degree_iff.trans ⟨fun f => f huv, fun a _ => a⟩
+  rw [← Nat.not_even_iff_odd, key, not_and_or, not_not, not_not]
+
+/-- The set of odd-degree vertices of a graph carrying an open Eulerian trail is
+*exactly* the two-element set of endpoints `{u, v}`. -/
+theorem oddDegreeVerts_eq_pair {u v : V} {p : G.Walk u v} (hp : p.IsEulerian)
+    (huv : u ≠ v) : (univ.filter fun x => Odd (G.degree x)) = {u, v} := by
+  ext x
+  simp only [mem_filter, mem_univ, true_and, mem_insert, mem_singleton]
+  exact oddDegree_iff_endpoint hp huv
+
+/-- **Exactly two odd vertices.**  For an open Eulerian trail the odd-degree vertex
+count is exactly `2`.  This is the sharp form of `IsEulerian.card_odd_degree`
+(which only gives `0 ∨ 2`): here we pin down the value in the open case and, via
+`oddDegreeVerts_eq_pair`, name the two vertices. -/
+theorem card_oddDegreeVerts {u v : V} {p : G.Walk u v} (hp : p.IsEulerian)
+    (huv : u ≠ v) : (univ.filter fun x => Odd (G.degree x)).card = 2 := by
+  rw [oddDegreeVerts_eq_pair hp huv, card_insert_of_notMem (by simpa using huv),
+    card_singleton]
+
+/-- The left endpoint of an open Eulerian trail has odd degree. -/
+theorem endpoint_left_odd {u v : V} {p : G.Walk u v} (hp : p.IsEulerian) (huv : u ≠ v) :
+    Odd (G.degree u) := (oddDegree_iff_endpoint hp huv).mpr (Or.inl rfl)
+
+/-- The right endpoint of an open Eulerian trail has odd degree. -/
+theorem endpoint_right_odd {u v : V} {p : G.Walk u v} (hp : p.IsEulerian) (huv : u ≠ v) :
+    Odd (G.degree v) := (oddDegree_iff_endpoint hp huv).mpr (Or.inr rfl)
+
+/-! ## The closed case: `u = v` (Eulerian circuit) -/
+
+/-- **Closed trail ⟹ all even.**  Every vertex of a graph carrying an Eulerian
+*circuit* (a closed Eulerian trail) has even degree: the trail leaves each vertex
+exactly as often as it enters, endpoints included. -/
+theorem circuit_all_even {u : V} {p : G.Walk u u} (hp : p.IsEulerian) (x : V) :
+    Even (G.degree x) := hp.even_degree_iff.mpr (fun h => absurd rfl h)
+
+/-- An Eulerian circuit leaves no odd-degree vertices. -/
+theorem circuit_no_odd {u : V} {p : G.Walk u u} (hp : p.IsEulerian) :
+    (univ.filter fun x => Odd (G.degree x)) = ∅ := by
+  ext x
+  simp only [mem_filter, mem_univ, true_and, notMem_empty, iff_false]
+  exact fun h => (Nat.not_even_iff_odd.mpr h) (circuit_all_even hp x)
+
+/-! ## The parity obstruction -/
+
+/-- **Königsberg's obstruction.**  A graph with three or more odd-degree vertices
+carries no Eulerian trail whatsoever — neither open nor closed.  An open trail
+allows exactly two odd vertices (`card_oddDegreeVerts`) and a closed one allows
+none (`circuit_no_odd`), so more than two odd vertices is incompatible with any
+Eulerian trail.  The Königsberg bridge multigraph has four odd-degree vertices,
+which is exactly why no walk crosses each bridge once. -/
+theorem no_eulerian_of_card_odd_gt_two
+    (h : 2 < (univ.filter fun x => Odd (G.degree x)).card) :
+    ¬ ∃ (u v : V) (p : G.Walk u v), p.IsEulerian := by
+  rintro ⟨u, v, p, hp⟩
+  rcases eq_or_ne u v with rfl | huv
+  · rw [circuit_no_odd hp] at h; simp at h
+  · rw [card_oddDegreeVerts hp huv] at h; norm_num at h
+
+end KonigsbergOQ05

--- a/src/data/proofs/konigsberg-oq-05/annotations.json
+++ b/src/data/proofs/konigsberg-oq-05/annotations.json
@@ -1,0 +1,135 @@
+[
+  {
+    "id": "ann-oddDegree-iff-endpoint",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 49,
+      "endLine": 55
+    },
+    "type": "theorem",
+    "title": "Odd Degree ⟺ Endpoint (Open Trail)",
+    "content": "The central result. For an open Eulerian trail from $u$ to $v$ (with $u \\neq v$), a vertex $x$ has odd degree exactly when it is one of the two endpoints. The proof specializes Mathlib's `IsEulerian.even_degree_iff` — which reads Even (G.degree x) ↔ (u ≠ v → x ≠ u ∧ x ≠ v) — at the known hypothesis $u \\neq v$, collapsing the implication to $x \\neq u \\wedge x \\neq v$, then negates both sides with `Nat.not_even_iff_odd` and De Morgan (`not_and_or`, `not_not`).",
+    "mathContext": "$\\text{Odd}(\\deg_G x) \\iff (x = u \\vee x = v)$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Eulerian trail",
+      "vertex degree parity",
+      "IsEulerian.even_degree_iff",
+      "De Morgan's laws"
+    ],
+    "prerequisites": [
+      "SimpleGraph.degree",
+      "SimpleGraph.Walk.IsEulerian",
+      "parity of natural numbers"
+    ]
+  },
+  {
+    "id": "ann-oddDegreeVerts-eq-pair",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 57,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "Odd-Degree Vertex Set = {u, v}",
+    "content": "Recasts the pointwise characterization as a Finset identity: the set of odd-degree vertices of a graph carrying an open Eulerian trail is exactly the two-element endpoint set $\\{u, v\\}$. Proved by Finset extensionality, reducing membership to `oddDegree_iff_endpoint`. This is the explicit content that Mathlib's `card_odd_degree` (a cardinality-only statement) leaves implicit.",
+    "mathContext": "$\\{x \\mid \\text{Odd}(\\deg_G x)\\} = \\{u, v\\}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset extensionality",
+      "odd-degree vertices",
+      "IsEulerian.card_odd_degree"
+    ],
+    "prerequisites": [
+      "Finset.filter",
+      "Finset.ext"
+    ]
+  },
+  {
+    "id": "ann-card-oddDegreeVerts",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 67,
+      "endLine": 71
+    },
+    "type": "theorem",
+    "title": "Exactly Two Odd-Degree Vertices",
+    "content": "For an open Eulerian trail the odd-degree vertex count is exactly $2$, sharpening Mathlib's `IsEulerian.card_odd_degree` (which gives only $0 \\vee 2$). Follows from the set equality $\\{u, v\\}$ together with $u \\neq v$, so the pair genuinely has two distinct elements.",
+    "mathContext": "$\\#\\{x \\mid \\text{Odd}(\\deg_G x)\\} = 2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.card",
+      "card_insert_of_notMem",
+      "cardinality of a pair"
+    ],
+    "prerequisites": [
+      "Finset.card",
+      "distinctness"
+    ]
+  },
+  {
+    "id": "ann-endpoints-odd",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 73,
+      "endLine": 78
+    },
+    "type": "theorem",
+    "title": "Each Endpoint Has Odd Degree",
+    "content": "The two-line corollaries `endpoint_left_odd` and `endpoint_right_odd`: each endpoint $u$, $v$ of an open Eulerian trail has odd degree, obtained by feeding `Or.inl rfl` / `Or.inr rfl` into the mpr direction of the endpoint characterization. This is the fact usually stated as the 'interesting half' of Euler's criterion.",
+    "mathContext": "$\\text{Odd}(\\deg_G u) \\wedge \\text{Odd}(\\deg_G v)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Eulerian trail endpoints",
+      "odd degree"
+    ],
+    "prerequisites": [
+      "biconditional elimination"
+    ]
+  },
+  {
+    "id": "ann-circuit-all-even",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 85,
+      "endLine": 94
+    },
+    "type": "theorem",
+    "title": "Eulerian Circuit ⟹ All Even",
+    "content": "For a closed Eulerian trail ($u = v$, an Eulerian circuit), every vertex has even degree (`circuit_all_even`), hence the odd-degree vertex set is empty (`circuit_no_odd`). Here the antecedent $u \\neq v$ of `even_degree_iff` is false, so the biconditional yields Even for all vertices with no side conditions.",
+    "mathContext": "$u = v \\implies \\forall x,\\ \\text{Even}(\\deg_G x)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Eulerian circuit",
+      "even degree",
+      "vacuous implication"
+    ],
+    "prerequisites": [
+      "SimpleGraph.Walk.IsEulerian",
+      "even/odd parity"
+    ]
+  },
+  {
+    "id": "ann-parity-obstruction",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 103,
+      "endLine": 110
+    },
+    "type": "theorem",
+    "title": "Königsberg Parity Obstruction",
+    "content": "A graph with three or more odd-degree vertices admits no Eulerian trail — open or closed. An open trail permits exactly two odd vertices (`card_oddDegreeVerts`) and a closed trail permits none (`circuit_no_odd`), so a count exceeding two is incompatible with any Eulerian trail. This is precisely why the Seven Bridges of Königsberg cannot be walked: its four landmasses all have odd degree, and $4 > 2$.",
+    "mathContext": "$\\#\\{x \\mid \\text{Odd}(\\deg_G x)\\} > 2 \\implies \\neg\\, \\exists\\, (u\\, v)\\, (p : G.\\text{Walk}\\ u\\ v),\\ p.\\text{IsEulerian}$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Seven Bridges of Königsberg",
+      "Euler's theorem",
+      "parity obstruction",
+      "non-existence of Eulerian trails"
+    ],
+    "prerequisites": [
+      "case analysis on u = v",
+      "Finset cardinality"
+    ]
+  }
+]

--- a/src/data/proofs/konigsberg-oq-05/meta.json
+++ b/src/data/proofs/konigsberg-oq-05/meta.json
@@ -1,0 +1,117 @@
+{
+  "id": "konigsberg-oq-05",
+  "title": "Endpoints of an Eulerian Trail Are Exactly the Odd-Degree Vertices",
+  "slug": "konigsberg-oq-05",
+  "description": "Sharpens Mathlib's cardinality-only Eulerian degree result from 'how many' to 'which': for an open Eulerian trail the odd-degree vertices are exactly the two endpoints {u, v}, an Eulerian circuit forces every vertex to be even, and three or more odd vertices rule out any Eulerian trail — the Königsberg parity obstruction.",
+  "meta": {
+    "author": "Leonhard Euler (1736); formalization by Lean Genius researcher",
+    "date": "1736",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KonigsbergOQ05.lean",
+    "tags": [
+      "graph-theory",
+      "eulerian-trail",
+      "parity",
+      "vertex-degree",
+      "konigsberg"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked; depends only on the foundational axioms propext, Classical.choice, Quot.sound (no sorry, no axiom declarations, no native_decide).",
+    "lineCount": 111,
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Euler's 1736 solution of the Seven Bridges of Königsberg is regarded as the birth of graph theory. Euler observed that a walk crossing every bridge exactly once — an Eulerian trail — must, at every vertex it merely passes through, use edges in matched pairs (arrive, leave). Only the two endpoints of the walk escape this pairing. Consequently every vertex except possibly the start and finish has even degree, and the Königsberg graph, whose four landmasses all have odd degree, admits no such walk. Mathlib formalizes the Eulerian-trail predicate `SimpleGraph.Walk.IsEulerian` and records the cardinality half of Euler's observation: `IsEulerian.card_odd_degree` shows the number of odd-degree vertices is 0 or 2. What Mathlib leaves implicit is the identity of those vertices. This entry makes it explicit: the odd-degree vertices are precisely the trail's endpoints.",
+    "problemStatement": "Given a finite simple graph G with an Eulerian trail p from u to v, characterize the odd-degree vertices of G. Prove that for an open trail (u ≠ v) a vertex has odd degree iff it equals u or v (so the odd-degree set is exactly {u, v} and has cardinality 2), that for a closed trail (u = v, an Eulerian circuit) every vertex has even degree, and that a graph with more than two odd-degree vertices admits no Eulerian trail at all.",
+    "proofStrategy": "The whole development is driven by Mathlib's `SimpleGraph.Walk.IsEulerian.even_degree_iff`, which states Even (G.degree x) ↔ (u ≠ v → x ≠ u ∧ x ≠ v). (1) In the open case, specializing the hypothesis u ≠ v collapses the implication to `x ≠ u ∧ x ≠ v`; negating both sides via `Nat.not_even_iff_odd` and De Morgan (`not_and_or`, `not_not`) yields Odd (G.degree x) ↔ x = u ∨ x = v. (2) Turning this into a Finset extensionality gives the odd-degree set = {u, v}, whose cardinality is 2 since u ≠ v. (3) In the closed case, the implication's hypothesis u ≠ u is false, so `even_degree_iff` gives Even for every vertex, hence the odd-degree set is empty. (4) The parity obstruction combines the two: an Eulerian trail forces the odd-degree count to be exactly 0 (closed) or exactly 2 (open), so a count exceeding 2 is impossible.",
+    "keyInsights": [
+      "Mathlib's IsEulerian.card_odd_degree only tells you the odd-degree vertices number 0 or 2; the sharp content is WHICH vertices — this entry pins them down as the trail's endpoints.",
+      "The entire open-case characterization is one rewrite: specialize even_degree_iff at the known hypothesis u ≠ v, then negate through Nat.not_even_iff_odd and De Morgan. No induction is needed because the parity bookkeeping already lives inside Mathlib's IsTrail.even_countP_edges_iff.",
+      "The endpoints being odd (each of u, v has odd degree) is a two-line corollary — the mpr direction applied to Or.inl rfl / Or.inr rfl — yet it is the fact most textbooks state as the 'interesting' half of Euler's criterion.",
+      "The closed/open dichotomy is governed entirely by whether the antecedent u ≠ v is true: a circuit makes it false and kills every odd vertex; an open trail makes it true and produces exactly the pair {u, v}.",
+      "The parity obstruction (>2 odd vertices ⟹ no Eulerian trail) is exactly why Königsberg is unwalkable: its four landmasses all have odd degree, and 4 > 2."
+    ]
+  },
+  "sections": [
+    {
+      "id": "open-case",
+      "title": "Open Trail: Odd Degree ⟺ Endpoint",
+      "startLine": 44,
+      "endLine": 78,
+      "summary": "For an open Eulerian trail (u ≠ v): a vertex has odd degree iff it is u or v (oddDegree_iff_endpoint); the odd-degree vertex set equals {u, v} (oddDegreeVerts_eq_pair) and hence has cardinality exactly 2 (card_oddDegreeVerts); each endpoint has odd degree (endpoint_left_odd, endpoint_right_odd)."
+    },
+    {
+      "id": "closed-case",
+      "title": "Closed Trail (Eulerian Circuit): All Even",
+      "startLine": 80,
+      "endLine": 94,
+      "summary": "For a closed Eulerian trail (u = v): every vertex has even degree (circuit_all_even), so there are no odd-degree vertices (circuit_no_odd)."
+    },
+    {
+      "id": "obstruction",
+      "title": "The Königsberg Parity Obstruction",
+      "startLine": 95,
+      "endLine": 111,
+      "summary": "A graph with three or more odd-degree vertices admits no Eulerian trail whatsoever (no_eulerian_of_card_odd_gt_two): an open trail permits exactly two odd vertices and a closed trail none. The Königsberg multigraph has four odd vertices."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry sharpens the degree-parity content of Euler's Eulerian-trail criterion from a cardinality statement to a vertex-level identification. Building on Mathlib's IsEulerian.even_degree_iff, it proves that the odd-degree vertices of a graph carrying an open Eulerian trail are exactly its two endpoints {u, v}, that an Eulerian circuit forces all vertices to be even, and that more than two odd-degree vertices obstruct any Eulerian trail. All eight results are fully machine-checked with no additional axioms.",
+    "implications": "The endpoint characterization is the 'necessity' half of Euler's theorem in its sharpest form: it not only counts odd vertices but names them. The parity obstruction is the direct explanation of why the Seven Bridges of Königsberg cannot be walked — the four landmasses all have odd degree. The results are stated for arbitrary finite simple graphs and plug directly into Mathlib's SimpleGraph API.",
+    "openQuestions": [
+      "Can the sufficiency direction (a connected graph with 0 or 2 odd-degree vertices admits an Eulerian trail) be formalized in Mathlib to complete the biconditional, e.g. via Hierholzer's algorithm?",
+      "Does the endpoint characterization extend cleanly to multigraphs, where the Königsberg bridges genuinely live (parallel edges)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "konigsberg",
+      "relationship": "extends",
+      "description": "Root: the Seven Bridges of Königsberg and Euler's theorem. This entry supplies the degree-parity heart of that argument — the odd-degree vertices of a graph with an Eulerian trail are exactly its endpoints — and states the obstruction (four odd landmasses) that makes Königsberg unwalkable."
+    },
+    {
+      "targetId": "konigsberg-oq-02",
+      "relationship": "complementary",
+      "description": "Proves the directed Euler theorem (Eulerian circuit iff every vertex balanced; Eulerian path iff exactly one vertex has out−in = 1). This entry is the undirected companion, working with SimpleGraph.degree parity rather than in/out-degree balance."
+    },
+    {
+      "targetId": "konigsberg-oq-04",
+      "relationship": "complementary",
+      "description": "Counts directed Eulerian circuits via the BEST theorem. This entry addresses the undirected existence obstruction: which vertices are odd, and why more than two odd vertices forbid any Eulerian trail."
+    }
+  ],
+  "leanFile": {
+    "namespace": "KonigsbergOQ05",
+    "lineCount": 111,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/KonigsbergOQ05.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Leonhard Euler"
+      ],
+      "title": "Solutio problematis ad geometriam situs pertinentis",
+      "year": 1736,
+      "venue": "Commentarii Academiae Scientiarum Imperialis Petropolitanae 8, 128–140",
+      "note": "The Seven Bridges of Königsberg: the degree-parity obstruction to an Eulerian trail."
+    },
+    {
+      "authors": [
+        "Reinhard Diestel"
+      ],
+      "title": "Graph Theory",
+      "year": 2017,
+      "venue": "Graduate Texts in Mathematics 173, Springer (5th ed.)",
+      "note": "Euler's theorem: a connected graph has an Eulerian trail iff it has 0 or 2 odd-degree vertices, the latter being the endpoints."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

**Problem:** konigsberg-oq-05 — *Endpoints of an Eulerian Trail Are Exactly the Odd-Degree Vertices* (tractability 8, significance 6, number-theory/graph-theory OQ child off the verified Königsberg parent).

Mathlib's `SimpleGraph.Walk.IsEulerian.card_odd_degree` records only *how many* odd-degree vertices a graph with an Eulerian trail has (0 or 2). This entry sharpens that to *which* vertices — they are exactly the trail's endpoints.

## Results (8 theorems, 0 defs, 111 lines)

**Open case (`u ≠ v`):**
- `oddDegree_iff_endpoint` — `Odd (G.degree x) ↔ x = u ∨ x = v`
- `oddDegreeVerts_eq_pair` — odd-degree vertex set `= {u, v}`
- `card_oddDegreeVerts` — exactly `2` odd-degree vertices (sharp form of `card_odd_degree`)
- `endpoint_left_odd` / `endpoint_right_odd` — each endpoint has odd degree

**Closed case (`u = v`, Eulerian circuit):**
- `circuit_all_even` — every vertex has even degree
- `circuit_no_odd` — no odd-degree vertices

**Obstruction:**
- `no_eulerian_of_card_odd_gt_two` — three or more odd vertices ⟹ no Eulerian trail at all. This is exactly why the Seven Bridges of Königsberg (four odd landmasses) cannot be walked.

## Method

Everything is driven by Mathlib's `IsEulerian.even_degree_iff : Even (G.degree x) ↔ (u ≠ v → x ≠ u ∧ x ≠ v)`. Specializing at the known hypothesis `u ≠ v` and negating through `Nat.not_even_iff_odd` + De Morgan yields the endpoint characterization; the closed case is the vacuous-antecedent branch.

## Verification

Compiled with `lake env lean` (Lean 4.26.0 / Mathlib). All 8 theorems:
```
depends on axioms: [propext, Classical.choice, Quot.sound]
```
No `sorry`, no `axiom` declarations, no `native_decide` — **VERIFIED, 0-axiom**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)