### PR TITLE
research(erdos-729-oq-04): multinomial Legendre/Kummer identity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos729LegendreMultinomial.lean
+++ b/proofs/Proofs/Erdos729LegendreMultinomial.lean
@@ -1,0 +1,156 @@
+/-
+  Erdős Problem #729 — OQ-04 follow-up: the MULTINOMIAL analogue of Legendre.
+
+  Companion to `Erdos729Problem.lean` and `Erdos729LegendreGeneral.lean`.
+
+  ## The question (OQ-04)
+
+  The parent problem and its OQ-02 general Legendre companion study the base-`p`
+  valuation of *binomial* coefficients `n!/(a!b!)` via Legendre's identity
+  `v_p(n!) = (n - s_p(n))/(p-1)`. The parent entry lists as an open question:
+
+      Is there an analogue for the *multinomial* coefficients
+      `n! / (a₁! ⋯ a_k!)` with `k > 2`?
+
+  There is, and it is the natural generalisation of Kummer's theorem. If
+  `N = a₁ + ⋯ + a_k` and `s_p(m) = (p.digits m).sum` is the base-`p` digit sum,
+  then for every prime `p`
+
+        (p - 1) · v_p( N! / (a₁!⋯a_k!) )  =  (Σᵢ s_p(aᵢ)) − s_p(N).                (★)
+
+  Equivalently `v_p(multinomial) = (Σᵢ s_p(aᵢ) − s_p(N)) / (p − 1)`, and this
+  common value is exactly the number of carries produced when the `aᵢ` are added
+  together in base `p` (the multinomial Kummer theorem). The parent's binomial
+  bound argument (`v_p(a!) + v_p(b!) ≤ v_p(n!)`) is the two-part special case.
+
+  ## What this file proves (0 axioms / 0 sorries)
+
+  * `padicValNat_prod_factorial` — `v_p` distributes over a finite product of
+    factorials (each factor is nonzero, so `padicValNat.mul` applies termwise).
+  * `legendre_add` — the subtraction-free additive form of Legendre,
+    `(p-1)·v_p(n!) + s_p(n) = n`, obtained from Mathlib's multiplied form
+    `sub_one_mul_padicValNat_factorial` plus `Nat.digit_sum_le`.
+  * `sub_one_mul_padicValNat_multinomial` — the identity (★) in additive,
+    subtraction-free form, over an arbitrary `Finset` index set (any `k`).
+  * `padicValNat_multinomial_eq_div` — the classical division form
+    `v_p = (Σ s_p(aᵢ) − s_p(N)) / (p−1)`.
+  * `sub_one_mul_padicValNat_multinomial_fin` — the same for `k` parts indexed by
+    `Fin k`, directly answering the "`k > 2`" phrasing of OQ-04.
+  * `prime_dvd_multinomial_iff` — the multinomial Kummer divisibility criterion:
+    `p ∣ multinomial ↔ s_p(N) < Σᵢ s_p(aᵢ)` (i.e. adding the `aᵢ` in base `p`
+    produces at least one carry).
+
+  Bearer lemmas verified against the Mathlib pin `v4.26.0` (sibling checkout):
+  `Nat.multinomial_spec` (Data/Nat/Choose/Multinomial.lean:50),
+  `Nat.multinomial_pos` (:46),
+  `sub_one_mul_padicValNat_factorial` (Padics/PadicVal/Basic.lean:587),
+  `padicValNat.mul` (:402), `dvd_iff_padicValNat_ne_zero` (:220),
+  `Nat.digit_sum_le` (Data/Nat/Digits/Defs.lean:432), `Finset.mul_sum`,
+  `Finset.sum_add_distrib`, `Finset.prod_ne_zero_iff`, `mul_pos_iff_of_pos_left`,
+  `Nat.mul_div_cancel_left`.
+-/
+
+import Mathlib
+
+namespace Erdos729Multinomial
+
+open Nat Finset
+
+/-- `p`-adic valuation distributes over a finite product of factorials.
+Each factorial is nonzero, so `padicValNat.mul` applies at every step. -/
+theorem padicValNat_prod_factorial {α : Type*} (p : ℕ) [Fact p.Prime]
+    (s : Finset α) (f : α → ℕ) :
+    padicValNat p (∏ i ∈ s, (f i)!) = ∑ i ∈ s, padicValNat p ((f i)!) := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp
+  | insert a s ha ih =>
+    have hprod : (∏ i ∈ s, (f i)!) ≠ 0 :=
+      Finset.prod_ne_zero_iff.mpr fun i _ => Nat.factorial_ne_zero _
+    rw [Finset.prod_insert ha, Finset.sum_insert ha,
+      padicValNat.mul (Nat.factorial_ne_zero _) hprod, ih]
+
+/-- **Additive (subtraction-free) form of Legendre's identity.**
+For a prime `p`, `(p-1)·v_p(n!) + s_p(n) = n`, where `s_p(n) = (p.digits n).sum`.
+Derived from Mathlib's `sub_one_mul_padicValNat_factorial` together with the
+bound `Nat.digit_sum_le`. -/
+theorem legendre_add (p : ℕ) [Fact p.Prime] (n : ℕ) :
+    (p - 1) * padicValNat p (n !) + (p.digits n).sum = n := by
+  have h := sub_one_mul_padicValNat_factorial (p := p) n
+  have hle : (p.digits n).sum ≤ n := Nat.digit_sum_le p n
+  omega
+
+/-- **The multinomial Legendre/Kummer identity (★), additive form.**
+
+For any prime `p`, any finite index set `s`, and any parts `f : α → ℕ`,
+
+    (p - 1) · v_p(multinomial s f) + s_p(Σᵢ f i)  =  Σᵢ s_p(f i),
+
+with `s_p(m) = (p.digits m).sum`. This is the exact analogue, for `k = |s|`
+parts, of the classical binomial statement, and holds with no subtraction. -/
+theorem sub_one_mul_padicValNat_multinomial {α : Type*} (p : ℕ) [Fact p.Prime]
+    (s : Finset α) (f : α → ℕ) :
+    (p - 1) * padicValNat p (Nat.multinomial s f)
+        + (p.digits (∑ i ∈ s, f i)).sum
+      = ∑ i ∈ s, (p.digits (f i)).sum := by
+  -- v_p of the multinomial in terms of v_p of the factorials, via `multinomial_spec`.
+  have hne : (∏ i ∈ s, (f i)!) ≠ 0 :=
+    Finset.prod_ne_zero_iff.mpr fun i _ => Nat.factorial_ne_zero _
+  have hM : Nat.multinomial s f ≠ 0 := (Nat.multinomial_pos s f).ne'
+  have hB : padicValNat p ((∑ i ∈ s, f i)!)
+      = (∑ i ∈ s, padicValNat p ((f i)!)) + padicValNat p (Nat.multinomial s f) := by
+    calc padicValNat p ((∑ i ∈ s, f i)!)
+        = padicValNat p ((∏ i ∈ s, (f i)!) * Nat.multinomial s f) := by
+          rw [Nat.multinomial_spec]
+      _ = padicValNat p (∏ i ∈ s, (f i)!) + padicValNat p (Nat.multinomial s f) :=
+          padicValNat.mul hne hM
+      _ = (∑ i ∈ s, padicValNat p ((f i)!)) + padicValNat p (Nat.multinomial s f) := by
+          rw [padicValNat_prod_factorial]
+  -- Summing the additive Legendre identity over the parts.
+  have hC : (p - 1) * (∑ i ∈ s, padicValNat p ((f i)!))
+        + (∑ i ∈ s, (p.digits (f i)).sum) = ∑ i ∈ s, f i := by
+    rw [Finset.mul_sum, ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun i _ => legendre_add p (f i)
+  -- Additive Legendre for the total `N = Σᵢ f i`, expanded through `hB`.
+  have hAN := legendre_add p (∑ i ∈ s, f i)
+  rw [hB, Nat.mul_add] at hAN
+  omega
+
+/-- **The multinomial Legendre identity, classical division form.**
+
+`v_p(multinomial s f) = (Σᵢ s_p(f i) − s_p(Σᵢ f i)) / (p − 1)`. -/
+theorem padicValNat_multinomial_eq_div {α : Type*} (p : ℕ) [Fact p.Prime]
+    (s : Finset α) (f : α → ℕ) :
+    padicValNat p (Nat.multinomial s f)
+      = ((∑ i ∈ s, (p.digits (f i)).sum) - (p.digits (∑ i ∈ s, f i)).sum) / (p - 1) := by
+  have hp1 : 0 < p - 1 := by have := (Fact.out : p.Prime).two_le; omega
+  have hmain := sub_one_mul_padicValNat_multinomial p s f
+  have hstep : (p - 1) * padicValNat p (Nat.multinomial s f)
+      = (∑ i ∈ s, (p.digits (f i)).sum) - (p.digits (∑ i ∈ s, f i)).sum := by omega
+  rw [← hstep, Nat.mul_div_cancel_left _ hp1]
+
+/-- **OQ-04, `k`-part form.** The multinomial Legendre/Kummer identity for `k`
+parts indexed by `Fin k` — the literal "`n!/(a₁!⋯a_k!)` with `k > 2`" analogue. -/
+theorem sub_one_mul_padicValNat_multinomial_fin (p : ℕ) [Fact p.Prime]
+    (k : ℕ) (a : Fin k → ℕ) :
+    (p - 1) * padicValNat p (Nat.multinomial Finset.univ a)
+        + (p.digits (∑ i, a i)).sum
+      = ∑ i, (p.digits (a i)).sum :=
+  sub_one_mul_padicValNat_multinomial p Finset.univ a
+
+/-- **Multinomial Kummer divisibility criterion.** A prime `p` divides the
+multinomial coefficient `multinomial s f` iff the base-`p` digit sum of the total
+is strictly smaller than the sum of the digit sums of the parts — equivalently,
+iff adding the parts in base `p` produces at least one carry. -/
+theorem prime_dvd_multinomial_iff {α : Type*} (p : ℕ) [Fact p.Prime]
+    (s : Finset α) (f : α → ℕ) :
+    p ∣ Nat.multinomial s f
+      ↔ (p.digits (∑ i ∈ s, f i)).sum < ∑ i ∈ s, (p.digits (f i)).sum := by
+  have hM : Nat.multinomial s f ≠ 0 := (Nat.multinomial_pos s f).ne'
+  have hq : 0 < p - 1 := by have := (Fact.out : p.Prime).two_le; omega
+  have hmain := sub_one_mul_padicValNat_multinomial p s f
+  rw [dvd_iff_padicValNat_ne_zero hM, ← Nat.pos_iff_ne_zero,
+    ← mul_pos_iff_of_pos_left hq]
+  omega
+
+end Erdos729Multinomial

--- a/src/data/proofs/erdos-729-oq-04/meta.json
+++ b/src/data/proofs/erdos-729-oq-04/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "erdos-729-oq-04",
+  "title": "Erdős #729 OQ-04: The Multinomial Legendre/Kummer Identity, Axiom-Free",
+  "slug": "erdos-729-oq-04",
+  "description": "The parent problem #729 controls the base-p valuation of binomial coefficients n!/(a!b!) through Legendre's identity v_p(n!) = (n - s_p(n))/(p-1), and lists as an open question whether there is an analogue for multinomial coefficients n!/(a₁!⋯a_k!) with k > 2. There is: the multinomial Kummer theorem. Over an arbitrary finite index set this file proves, with zero axioms and zero sorries, that (p-1)·v_p(multinomial s f) + s_p(Σf i) = Σ s_p(f i) — equivalently v_p = (Σ s_p(f i) − s_p(Σ f i))/(p-1), the number of carries when the parts are added in base p. It also derives the division form, the Fin-k form directly matching the 'k > 2' phrasing, and the divisibility criterion p ∣ multinomial ↔ s_p(N) < Σ s_p(a_i).",
+  "meta": {
+    "author": "Legendre (1808), Kummer (1852); formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://erdosproblems.com/729",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos729LegendreMultinomial.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "multinomials",
+      "valuation",
+      "legendre-formula",
+      "kummer-theorem",
+      "digit-sum",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.multinomial_spec",
+        "description": "(∏ i ∈ s, (f i)!) · multinomial s f = (∑ i ∈ s, f i)!, the defining relation that lets v_p of the multinomial be extracted from v_p of the factorials",
+        "module": "Mathlib.Data.Nat.Choose.Multinomial"
+      },
+      {
+        "theorem": "Nat.multinomial_pos",
+        "description": "0 < multinomial s f, giving multinomial s f ≠ 0 so padicValNat is well behaved and divisibility ↔ nonzero valuation applies",
+        "module": "Mathlib.Data.Nat.Choose.Multinomial"
+      },
+      {
+        "theorem": "sub_one_mul_padicValNat_factorial",
+        "description": "Legendre's identity in multiplied form (p-1)·v_p(n!) = n − s_p(n); the engine behind the additive form legendre_add and the whole multinomial identity",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "padicValNat.mul",
+        "description": "v_p(a·b) = v_p(a) + v_p(b) for a,b ≠ 0, used to split v_p over the factorial product and (via induction) over the finite product ∏ (f i)!",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "dvd_iff_padicValNat_ne_zero",
+        "description": "For n ≠ 0 and prime p, p ∣ n ↔ padicValNat p n ≠ 0; converts the divisibility criterion to a statement about the valuation",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.digit_sum_le",
+        "description": "(p.digits n).sum ≤ n, the bound that turns Legendre's subtraction form into the subtraction-free additive identity via omega",
+        "module": "Mathlib.Data.Nat.Digits.Defs"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "b·∑ = ∑ b·, distributing (p-1) across the per-part sum when aggregating the additive Legendre identities",
+        "module": "Mathlib.Algebra.BigOperators.Ring.Finset"
+      },
+      {
+        "theorem": "mul_pos_iff_of_pos_left",
+        "description": "For 0 < a, 0 < a·b ↔ 0 < b; lets the carry criterion 0 < v_p be read off the multiplied identity (p-1)·v_p + s_p(N) = Σ s_p",
+        "module": "Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic"
+      }
+    ],
+    "originalContributions": [
+      "sub_one_mul_padicValNat_multinomial: the multinomial Legendre/Kummer identity (p-1)·v_p(multinomial s f) + s_p(Σ f i) = Σ s_p(f i), over an ARBITRARY finite index set s (any number of parts k = |s|), proved with zero axioms and no natural-number subtraction",
+      "padicValNat_prod_factorial: v_p distributes over a finite product of factorials, padicValNat p (∏ (f i)!) = ∑ padicValNat p (f i)!, by Finset induction using padicValNat.mul on nonzero factorials",
+      "legendre_add: the subtraction-free additive form of Legendre, (p-1)·v_p(n!) + s_p(n) = n, obtained from Mathlib's multiplied form plus Nat.digit_sum_le",
+      "padicValNat_multinomial_eq_div: the classical division form v_p(multinomial s f) = (Σ s_p(f i) − s_p(Σ f i))/(p-1)",
+      "sub_one_mul_padicValNat_multinomial_fin: the identity specialized to k parts indexed by Fin k, the literal answer to the parent's 'n!/(a₁!⋯a_k!) with k > 2' open question",
+      "prime_dvd_multinomial_iff: the multinomial Kummer divisibility criterion p ∣ multinomial s f ↔ s_p(Σ f i) < Σ s_p(f i), i.e. adding the parts in base p produces at least one carry"
+    ],
+    "dateAdded": "2026-07-01",
+    "prerequisites": [
+      "p-adic valuation padicValNat and Legendre's formula for factorials",
+      "Base-p digit sums (Nat.digits) and Kummer's carry theorem",
+      "Multinomial coefficients Nat.multinomial and the relation ∏(a_i!)·multinomial = (Σ a_i)!",
+      "Finset big operators and induction"
+    ],
+    "relatedProblems": [
+      {
+        "id": "erdos-729",
+        "relationship": "Parent: problem #729 studies binomial factorial divisibility via Legendre's formula and asks (open question) for the multinomial analogue with k > 2, which this entry supplies."
+      },
+      {
+        "id": "kummer-theorem",
+        "relationship": "Generalizes: the binomial Kummer theorem (v_p of a binomial coefficient = number of base-p carries) is the two-part special case s = {a, b} of the multinomial identity proved here."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 156,
+    "assumptions": "0 axioms, 0 sorries. #print axioms reports only [propext, Classical.choice, Quot.sound] for sub_one_mul_padicValNat_multinomial, padicValNat_multinomial_eq_div, prime_dvd_multinomial_iff, and sub_one_mul_padicValNat_multinomial_fin — no sorryAx and no Lean.ofReduceBool. The identity holds for every prime p and an arbitrary finite index set (any k). Verified with Lean toolchain 4.26.0 against the pinned Mathlib.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Legendre (1808) gave the p-adic valuation of a factorial, v_p(n!) = (n − s_p(n))/(p−1) where s_p is the base-p digit sum; Kummer (1852) reinterpreted the valuation of a binomial coefficient C(n,a) as the number of carries when a and n−a are added in base p. Erdős's Problem #729 exploits exactly this binomial machinery: from a!b! ∣ n! one gets v_p(a!) + v_p(b!) ≤ v_p(n!) for every prime p, and the p = 2 digit-sum identity already forces a + b ≤ n + O(log n). The parent gallery entry records, as an open question, whether the same story runs for the multinomial coefficients n!/(a₁!⋯a_k!) with k > 2. It does — the multinomial coefficient is again an integer whose p-adic valuation counts carries — and this file makes that precise and fully machine-checked.",
+    "problemStatement": "Is there an analogue of Legendre's factorial valuation identity for the multinomial coefficients n!/(a₁!⋯a_k!) with k > 2, and what is the resulting divisibility criterion?",
+    "text": "For a prime p, a finite index set s and parts f : α → ℕ with total N = Σ_{i∈s} f i, the multinomial coefficient N!/∏(f i)! satisfies (p−1)·v_p(multinomial s f) = Σ_i s_p(f i) − s_p(N), where s_p(m) = (p.digits m).sum. Equivalently v_p = (Σ_i s_p(f i) − s_p(N))/(p−1), the number of carries in adding the parts in base p; and p divides the multinomial coefficient iff s_p(N) < Σ_i s_p(f i).",
+    "proofStrategy": "First recast Legendre in additive, subtraction-free form legendre_add: (p−1)·v_p(n!) + s_p(n) = n, using Mathlib's sub_one_mul_padicValNat_factorial and the digit-sum bound Nat.digit_sum_le, discharged by omega. From Nat.multinomial_spec, ∏(f i)!·multinomial = N!, and padicValNat.mul (all factors nonzero) together with the inductive lemma padicValNat_prod_factorial give v_p(N!) = Σ_i v_p(f i!) + v_p(multinomial). Summing legendre_add over the parts and expanding legendre_add for N through this identity yields two expressions equal to N sharing the common atom (p−1)·Σ v_p(f i!); omega cancels it to leave (p−1)·v_p(multinomial) + s_p(N) = Σ_i s_p(f i). The division form follows by Nat.mul_div_cancel_left, the Fin-k form by specializing s = univ, and the divisibility criterion by dvd_iff_padicValNat_ne_zero together with mul_pos_iff_of_pos_left.",
+    "keyInsights": [
+      "The multinomial coefficient's valuation is governed by the same digit-sum bookkeeping as the binomial one; the binomial statement is the two-part case s = {a, b}",
+      "Keeping Legendre in additive form (p−1)·v_p(n!) + s_p(n) = n avoids all natural-number subtraction, so the whole derivation closes by omega on shared nonlinear atoms",
+      "Splitting v_p over the factorial product needs only that each factorial is nonzero — no prime-by-prime analysis — via padicValNat.mul and a one-line Finset induction",
+      "Σ_i s_p(a_i) − s_p(Σ a_i), divided by p−1, is the number of carries when the a_i are added in base p: the multinomial Kummer theorem",
+      "Divisibility p ∣ multinomial is exactly the presence of a carry, read directly off the multiplied identity via mul_pos_iff_of_pos_left"
+    ],
+    "prerequisites": [
+      "p-adic valuation and Legendre's factorial formula",
+      "Base-p digit sums and Kummer's carry interpretation",
+      "Multinomial coefficients and Nat.multinomial_spec",
+      "Finset big operators and induction"
+    ]
+  },
+  "sections": [
+    {
+      "id": "prod-and-legendre",
+      "title": "Valuation of a Factorial Product and Additive Legendre",
+      "startLine": 61,
+      "endLine": 90,
+      "summary": "padicValNat_prod_factorial: v_p(∏ (f i)!) = ∑ v_p((f i)!) by Finset induction using padicValNat.mul on nonzero factorials. legendre_add: the subtraction-free form (p−1)·v_p(n!) + s_p(n) = n from Mathlib's sub_one_mul_padicValNat_factorial and Nat.digit_sum_le.",
+      "mathContext": "Both building blocks are unconditional: the product splits because every factorial is nonzero, and the digit-sum bound turns Legendre's subtraction into an addition closed by omega."
+    },
+    {
+      "id": "multinomial-identity",
+      "title": "The Multinomial Legendre/Kummer Identity",
+      "startLine": 91,
+      "endLine": 133,
+      "summary": "sub_one_mul_padicValNat_multinomial: (p−1)·v_p(multinomial s f) + s_p(Σ f i) = Σ s_p(f i), over an arbitrary finite index set. Proved by extracting v_p(N!) = Σ v_p(f i!) + v_p(multinomial) from Nat.multinomial_spec, then combining the per-part and total additive Legendre identities via omega. padicValNat_multinomial_eq_div gives the division form.",
+      "mathContext": "The core generalization: the multinomial coefficient's valuation is Σ s_p(a_i) − s_p(N) over p−1, the number of base-p carries."
+    },
+    {
+      "id": "fin-and-divisibility",
+      "title": "The k-Part Form and the Kummer Divisibility Criterion",
+      "startLine": 134,
+      "endLine": 156,
+      "summary": "sub_one_mul_padicValNat_multinomial_fin: the identity for k parts indexed by Fin k, matching the parent's 'k > 2' phrasing. prime_dvd_multinomial_iff: p ∣ multinomial s f ↔ s_p(Σ f i) < Σ s_p(f i), via dvd_iff_padicValNat_ne_zero and mul_pos_iff_of_pos_left.",
+      "mathContext": "The Fin-k specialization is the literal multinomial n!/(a₁!⋯a_k!); the divisibility criterion is the multinomial Kummer theorem (a prime divides iff adding the parts in base p carries)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős #729's open question about the multinomial analogue is answered affirmatively and axiom-free: for every prime p and any number of parts, (p−1)·v_p(n!/(a₁!⋯a_k!)) = Σ_i s_p(a_i) − s_p(N), equivalently the multinomial coefficient's p-adic valuation is the number of carries when the parts are added in base p, and p divides it exactly when a carry occurs.",
+    "implications": "This is the correct generalization of the p = 2 digit-sum identity that drives the parent's bound: the multinomial valuation is again controlled by all primes collectively through their digit sums. The subtraction-free additive formulation is convenient for downstream bounds on Σ_i a_i in terms of N, the multinomial version of the a + b ≤ n + O(log n) rigidity.",
+    "openQuestions": [
+      "Use the additive identity to bound Σ_i a_i − N in terms of the total base-p digit excess Σ_i s_p(a_i) − s_p(N), the multinomial analogue of the Erdős a + b ≤ n + O(log n) constraint.",
+      "Formalize the carry-counting statement literally: exhibit v_p(multinomial) as the count of positions where the running base-p addition of the parts overflows."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "Erdos729Multinomial",
+    "lineCount": 156,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos729LegendreMultinomial.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-729",
+      "relationship": "extends",
+      "description": "Answers the parent problem's open question by generalizing its binomial Legendre machinery to multinomial coefficients n!/(a₁!⋯a_k!) for any k."
+    },
+    {
+      "targetId": "kummer-theorem",
+      "relationship": "generalizes",
+      "description": "The multinomial Kummer identity: v_p of a multinomial coefficient counts base-p carries; the binomial Kummer theorem is the two-part special case."
+    }
+  ],
+  "references": [
+    {
+      "key": "Legendre1808",
+      "citation": "Legendre, A.-M., Essai sur la théorie des nombres, 2nd ed., Paris (1808). (Formula for the exponent of a prime in n!.)",
+      "type": "book"
+    },
+    {
+      "key": "Kummer1852",
+      "citation": "Kummer, E.E., Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen, J. Reine Angew. Math. 44 (1852), 93–146.",
+      "type": "article"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/erdos-729/meta.json
+++ b/src/data/proofs/erdos-729/meta.json
@@ -175,6 +175,11 @@
       "targetId": "prime-number-theorem",
       "relationship": "related",
       "description": "The distribution of primes underlies the O(log n) bound via digit sum estimates"
+    },
+    {
+      "targetId": "erdos-729-oq-04",
+      "relationship": "extended-by",
+      "description": "OQ-04 answers this entry's open question about a multinomial analogue: the axiom-free multinomial Legendre/Kummer identity (p-1)·v_p(n!/(a₁!⋯a_k!)) = Σ s_p(a_i) − s_p(N) for any number of parts."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Answers the open question recorded in the **Erdős #729** gallery entry —
*"Is there an analogue for the multinomial coefficients n!/(a₁!⋯a_k!) with k > 2?"*
— with the multinomial Legendre/Kummer identity, formalized **VERIFIED, 0-axiom / 0-sorry**.

For any prime `p`, finite index set `s`, and parts `f` with total `N = Σᵢ f i`:

```
(p - 1) · v_p(multinomial s f) + s_p(N)  =  Σᵢ s_p(f i)          -- s_p = base-p digit sum
```

equivalently `v_p(n!/(a₁!⋯a_k!)) = (Σᵢ s_p(aᵢ) − s_p(N)) / (p − 1)`, the number of
carries when the parts are added in base `p`. The parent's binomial argument
(`v_p(a!) + v_p(b!) ≤ v_p(n!)`) is the two-part special case.

## Theorems (`Proofs/Erdos729LegendreMultinomial.lean`, 156 lines, namespace `Erdos729Multinomial`)

- `padicValNat_prod_factorial` — `v_p` distributes over a finite product of factorials.
- `legendre_add` — subtraction-free Legendre `(p-1)·v_p(n!) + s_p(n) = n`.
- `sub_one_mul_padicValNat_multinomial` — the main identity (★), any number of parts.
- `padicValNat_multinomial_eq_div` — the classical division form.
- `sub_one_mul_padicValNat_multinomial_fin` — the `Fin k` form (literal "k > 2").
- `prime_dvd_multinomial_iff` — Kummer divisibility: `p ∣ multinomial ↔ s_p(N) < Σᵢ s_p(aᵢ)`.

## Verification

- Compiles cleanly under Lean toolchain `4.26.0` against the pinned Mathlib.
- `#print axioms` on all four end results reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely axiom-free.

Built on Mathlib's `Nat.multinomial_spec`, `sub_one_mul_padicValNat_factorial`,
`padicValNat.mul`, and `Nat.digit_sum_le`; no new axioms or definitions.

## Gallery

- New entry `src/data/proofs/erdos-729-oq-04/meta.json` (`status: verified`, `badge: original`, `axiomCount: 0`).
- Reciprocal `extended-by` cross-reference added to the parent `erdos-729` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)