### PR TITLE
research(angle-trisection-oq-02-oq-03-oq-03): 17-gon via Gauss — primitive-root ordering, Gaussian periods, index-2 tower [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ03OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ03OQ03.lean
@@ -1,0 +1,285 @@
+/-
+  Angle Trisection OQ02-OQ03-OQ03:
+  The 17-gon via Gauss: the arithmetic backbone of the 1796 construction.
+
+  Parent (OQ02-OQ03, `heptadecagon_constructible`) proves *abstractly* that the
+  regular 17-gon is constructible because φ(17) = 16 is a power of two.  That
+  statement is silent about *how* Gauss actually did it.  This file formalizes the
+  concrete combinatorial data underlying Gauss's construction — the piece a reader
+  of "the 17-gon is constructible" still wants to see:
+
+    1. `3` is a primitive root modulo 17: its powers cycle through all sixteen
+       nonzero residues.  This is the ordering Gauss used to label the vertices.
+    2. That ordering, listed explicitly:
+         [1, 3, 9, 10, 13, 5, 15, 11, 16, 14, 8, 7, 4, 12, 2, 6].
+    3. The two eight-term **Gaussian periods**: the quadratic residues (even powers
+       of 3) and the non-residues (odd powers), which partition the vertices and
+       are exactly the squares / non-squares mod 17.
+    4. The descending **period tower** of the cyclic group (ℤ/17ℤ)ˣ:
+         ⟨3⟩ ⊃ ⟨9⟩ ⊃ ⟨13⟩ ⊃ ⟨16⟩ ⊃ ⟨1⟩,   orders 16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1,
+       each of index 2 in the previous.  This chain of index-2 subgroups is precisely
+       the Galois-theoretic backbone: by the fixed-field correspondence it mirrors a
+       tower ℚ ⊂ K₁ ⊂ K₂ ⊂ K₃ ⊂ K₄ = ℚ(ζ₁₇) of four quadratic extensions.  The four
+       square roots those steps introduce (starting with √17) are what Gauss's nested
+       radicals express, and what makes the 17-gon straightedge-and-compass
+       constructible.
+
+  Everything here is a finite, decidable statement about (ℤ/17ℤ)ˣ, so the file is
+  fully machine-checked: 0 sorries, 0 axioms.
+
+  Mathematically distinct from the family: no sibling formalizes the primitive-root
+  ordering, the Gaussian-period partition, or the explicit index-2 subgroup tower
+  for n = 17 — this is the number-theoretic content specific to Gauss's 17-gon,
+  not the general Gauss–Wantzel degree argument (that is the parent's job).
+-/
+
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Nat.Totient
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.GroupTheory.SpecificGroups.Cyclic
+import Mathlib.Algebra.Group.Subgroup.Basic
+import Mathlib.Algebra.Group.Subgroup.ZPowers.Basic
+import Mathlib.Data.ZMod.QuotientGroup
+
+open Subgroup
+
+namespace AngleTrisectionOQ02OQ03OQ03
+
+/-!
+## Section I: 17 is a Fermat prime and φ(17) = 16 = 2⁴
+
+The Gauss–Wantzel criterion for a prime p is: the regular p-gon is constructible iff
+p is a Fermat prime, i.e. p = 2^(2^k) + 1.  For 17 = 2^(2²) + 1 we have φ(17) = 16.
+-/
+
+theorem seventeen_prime : Nat.Prime 17 := by decide
+
+/-- 17 = 2^(2^2) + 1 is a Fermat prime (k = 2). -/
+theorem seventeen_fermat : (17 : ℕ) = 2 ^ (2 ^ 2) + 1 := by norm_num
+
+/-- φ(17) = 16 = 2⁴: the degree of the full cyclotomic field ℚ(ζ₁₇) over ℚ. -/
+theorem totient_17 : Nat.totient 17 = 16 := by decide
+
+theorem totient_17_pow2 : Nat.totient 17 = 2 ^ 4 := by decide
+
+/-!
+## Section II: `3` is a primitive root modulo 17
+
+The multiplicative group (ℤ/17ℤ)ˣ is cyclic of order 16, and `3` is a generator:
+its multiplicative order is exactly 16.  Gauss used the powers of 3 to label the
+seventeen vertices of the polygon.
+-/
+
+/-- 3¹⁶ ≡ 1 (mod 17): the order of 3 divides 16 (Fermat's little theorem for p = 17). -/
+theorem three_pow_16 : (3 : ZMod 17) ^ 16 = 1 := by decide
+
+/-- 3⁸ ≡ 16 ≡ -1 (mod 17): 3 is *not* a quadratic residue, so its order is not 8. -/
+theorem three_pow_8 : (3 : ZMod 17) ^ 8 = 16 := by decide
+
+/-- **3 is a primitive root mod 17**: `orderOf 3 = 16`.
+
+    Proof: the order divides 16 (by `three_pow_16`), and the only prime factor of 16
+    is 2; since `3^(16/2) = 3^8 = -1 ≠ 1`, the order is the full 16. -/
+theorem three_orderOf : orderOf (3 : ZMod 17) = 16 := by
+  apply orderOf_eq_of_pow_and_pow_div_prime (by norm_num) three_pow_16
+  intro p hp hpd
+  have hp2 : p = 2 := by
+    have h16 : (16 : ℕ) = 2 ^ 4 := by norm_num
+    rw [h16] at hpd
+    exact (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow hpd)
+  subst hp2
+  decide
+
+/-!
+## Section III: Gauss's vertex ordering
+
+Listing the powers `3^0, 3^1, …, 3^15` (mod 17) gives Gauss's cyclic ordering of the
+sixteen nonzero residues — the order in which he arranged the vertices so that the
+Gaussian periods appear as contiguous blocks.
+-/
+
+/-- The explicit Gauss ordering: powers of the primitive root 3, in sequence.
+    `[1, 3, 9, 10, 13, 5, 15, 11, 16, 14, 8, 7, 4, 12, 2, 6]`. -/
+theorem gauss_ordering :
+    (List.range 16).map (fun k => (3 : ZMod 17) ^ k)
+      = [1, 3, 9, 10, 13, 5, 15, 11, 16, 14, 8, 7, 4, 12, 2, 6] := by decide
+
+/-- The powers of 3 hit every nonzero residue exactly once: the ordering is a
+    permutation of the sixteen units of ℤ/17ℤ. -/
+theorem gauss_ordering_nodup :
+    ((List.range 16).map (fun k => (3 : ZMod 17) ^ k)).Nodup := by decide
+
+/-- Over one period (the sixteen exponents `0 ≤ k < 16`), no power of 3 is 0:
+    the ordering lands entirely in the nonzero residues, so it is a genuine
+    permutation of the units of ℤ/17ℤ. -/
+theorem gauss_powers_ne_zero :
+    ∀ k : Fin 16, (3 : ZMod 17) ^ (k : ℕ) ≠ 0 := by decide
+
+/-!
+## Section IV: the two Gaussian periods (quadratic residues vs. non-residues)
+
+Splitting the vertices into the eight quadratic residues (even powers of 3) and the
+eight non-residues (odd powers of 3) gives Gauss's first pair of *periods* η₀, η₁.
+As complex sums η₀ = Σ_{a∈QR} ζ^a, η₁ = Σ_{a∉QR} ζ^a they satisfy η₀ + η₁ = -1 and
+η₀·η₁ = -4, hence the quadratic  x² + x − 4 = 0,  whose roots (-1 ± √17)/2 introduce
+the first surd √17.  Here we formalize the underlying index sets and their defining
+arithmetic property: they are exactly the nonzero squares and non-squares mod 17.
+-/
+
+/-- The quadratic residues mod 17 (first Gaussian period's index set): even powers of 3. -/
+def periodQR : Finset (ZMod 17) := {1, 2, 4, 8, 9, 13, 15, 16}
+
+/-- The quadratic non-residues mod 17 (second Gaussian period's index set): odd powers of 3. -/
+def periodNQR : Finset (ZMod 17) := {3, 5, 6, 7, 10, 11, 12, 14}
+
+/-- Each period has eight elements: the vertices split 8 + 8. -/
+theorem periodQR_card : periodQR.card = 8 := by decide
+theorem periodNQR_card : periodNQR.card = 8 := by decide
+
+/-- The two periods are disjoint. -/
+theorem periods_disjoint : Disjoint periodQR periodNQR := by decide
+
+/-- The two periods together cover all sixteen nonzero residues. -/
+theorem periods_cover :
+    periodQR ∪ periodNQR = (Finset.univ : Finset (ZMod 17)).erase 0 := by decide
+
+/-- **The QR period is exactly the nonzero squares mod 17.**
+    `a` lies in the first Gaussian period iff `a ≠ 0` and `a` is a square. -/
+theorem periodQR_eq_squares :
+    ∀ a : ZMod 17, a ∈ periodQR ↔ (a ≠ 0 ∧ ∃ r : ZMod 17, r ^ 2 = a) := by decide
+
+/-- The QR period is the set of even powers of the primitive root 3. -/
+theorem periodQR_eq_even_powers :
+    periodQR = (Finset.range 8).image (fun k => (3 : ZMod 17) ^ (2 * k)) := by decide
+
+/-- The non-QR period is the set of odd powers of the primitive root 3. -/
+theorem periodNQR_eq_odd_powers :
+    periodNQR = (Finset.range 8).image (fun k => (3 : ZMod 17) ^ (2 * k + 1)) := by decide
+
+/-!
+## Section V: the order chain 16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1
+
+Squaring the primitive root repeatedly, `3 → 9 → 13 → 16 → 1`, halves the order at
+each step.  These are the generators of the period tower.
+-/
+
+/-- Successive squares of the primitive root: 3² = 9, (3²)² = 3⁴ = 13, 3⁸ = 16 = -1. -/
+theorem square_step_1 : (3 : ZMod 17) ^ 2 = 9 := by decide
+theorem square_step_2 : (3 : ZMod 17) ^ 4 = 13 := by decide
+theorem square_step_3 : (3 : ZMod 17) ^ 8 = 16 := by decide
+
+/-- `orderOf 9 = 8`: the quadratic residues form an order-8 cyclic subgroup. -/
+theorem nine_orderOf : orderOf (9 : ZMod 17) = 8 := by
+  apply orderOf_eq_of_pow_and_pow_div_prime (by norm_num) (by decide)
+  intro p hp hpd
+  have hp2 : p = 2 := by
+    have h8 : (8 : ℕ) = 2 ^ 3 := by norm_num
+    rw [h8] at hpd
+    exact (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow hpd)
+  subst hp2
+  decide
+
+/-- `orderOf 13 = 4`. -/
+theorem thirteen_orderOf : orderOf (13 : ZMod 17) = 4 := by
+  apply orderOf_eq_of_pow_and_pow_div_prime (by norm_num) (by decide)
+  intro p hp hpd
+  have hp2 : p = 2 := by
+    have h4 : (4 : ℕ) = 2 ^ 2 := by norm_num
+    rw [h4] at hpd
+    exact (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow hpd)
+  subst hp2
+  decide
+
+/-- `orderOf 16 = 2`: the subgroup {±1} of order 2 (complex conjugation on ζ₁₇). -/
+theorem sixteen_orderOf : orderOf (16 : ZMod 17) = 2 :=
+  orderOf_eq_prime (by decide) (by decide)
+
+/-!
+## Section VI: the period tower as index-2 subgroups of (ℤ/17ℤ)ˣ
+
+Lifting to the unit group `(ZMod 17)ˣ`, the generators above yield a descending chain
+of cyclic subgroups, each of index 2 in the previous:
+
+  `zpowers u ⊃ zpowers u² ⊃ zpowers u⁴ ⊃ zpowers u⁸ ⊃ {1}`,
+  cardinalities `16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1`.
+
+This is the exact group-theoretic skeleton of Gauss's construction: by the Galois
+correspondence for the cyclotomic extension ℚ(ζ₁₇)/ℚ (with Galois group ≅ (ℤ/17ℤ)ˣ),
+these four index-2 subgroups correspond to a tower of four quadratic field extensions.
+-/
+
+/-- The primitive root `3` as a unit of `ZMod 17` (3 is coprime to 17). -/
+def u3 : (ZMod 17)ˣ := ZMod.unitOfCoprime 3 (by decide)
+
+/-- The unit `u3` reduces to `3` in `ZMod 17`. -/
+theorem u3_coe : ((u3 : (ZMod 17)ˣ) : ZMod 17) = 3 := by
+  simp [u3, ZMod.coe_unitOfCoprime]
+
+/-- The unit `u3` also has order 16 (matching the primitive root `3`). -/
+theorem u3_orderOf : orderOf u3 = 16 := by
+  have h : orderOf ((u3 : (ZMod 17)ˣ) : ZMod 17) = 16 := by
+    rw [u3_coe]; exact three_orderOf
+  rwa [orderOf_units] at h
+
+/-- Order of the successive squares of `u3`: `16 / 2^i`. -/
+theorem u3_pow_orderOf (i : ℕ) (hi : i ≤ 4) :
+    orderOf (u3 ^ (2 ^ i)) = 16 / 2 ^ i := by
+  have hdvd : (2 ^ i) ∣ orderOf u3 := by
+    rw [u3_orderOf, show (16 : ℕ) = 2 ^ 4 from by norm_num]
+    exact pow_dvd_pow 2 hi
+  rw [orderOf_pow_of_dvd (pow_ne_zero i (by norm_num : (2 : ℕ) ≠ 0)) hdvd, u3_orderOf]
+
+/-- Cardinality of the `i`-th tower subgroup: `#⟨u3^(2^i)⟩ = 16 / 2^i`. -/
+theorem tower_card (i : ℕ) (hi : i ≤ 4) :
+    Nat.card (zpowers (u3 ^ (2 ^ i))) = 16 / 2 ^ i := by
+  rw [Nat.card_zpowers, u3_pow_orderOf i hi]
+
+/-- The tower cardinalities, explicitly: 16, 8, 4, 2, 1. -/
+theorem tower_cards :
+    Nat.card (zpowers (u3 ^ (2 ^ 0))) = 16 ∧
+    Nat.card (zpowers (u3 ^ (2 ^ 1))) = 8 ∧
+    Nat.card (zpowers (u3 ^ (2 ^ 2))) = 4 ∧
+    Nat.card (zpowers (u3 ^ (2 ^ 3))) = 2 ∧
+    Nat.card (zpowers (u3 ^ (2 ^ 4))) = 1 :=
+  ⟨tower_card 0 (by norm_num), tower_card 1 (by norm_num), tower_card 2 (by norm_num),
+   tower_card 3 (by norm_num), tower_card 4 (by norm_num)⟩
+
+/-- Each tower subgroup is contained in the previous one:
+    `⟨u3^(2^(i+1))⟩ ≤ ⟨u3^(2^i)⟩`, since `u3^(2^(i+1)) = (u3^(2^i))²`. -/
+theorem tower_le (i : ℕ) :
+    zpowers (u3 ^ (2 ^ (i + 1))) ≤ zpowers (u3 ^ (2 ^ i)) := by
+  rw [zpowers_le]
+  have : u3 ^ (2 ^ (i + 1)) = (u3 ^ (2 ^ i)) ^ 2 := by
+    rw [← pow_mul, pow_succ]
+  rw [this]
+  exact npow_mem_zpowers _ 2
+
+/-- The tower steps have index 2: `#⟨u3^(2^i)⟩ = 2 · #⟨u3^(2^(i+1))⟩` for `i < 4`.
+    Each descent through the tower is a quadratic (degree-2) step. -/
+theorem tower_index_two (i : ℕ) (hi : i < 4) :
+    Nat.card (zpowers (u3 ^ (2 ^ i))) = 2 * Nat.card (zpowers (u3 ^ (2 ^ (i + 1)))) := by
+  rw [tower_card i (by omega), tower_card (i + 1) (by omega)]
+  interval_cases i <;> decide
+
+/-!
+## Section VII: summary — why 17 works
+
+The four index-2 descents `16 → 8 → 4 → 2 → 1` are the four quadratic extensions in
+the tower ℚ ⊂ ℚ(√17) ⊂ ⋯ ⊂ ℚ(ζ₁₇).  Because there are finitely many of them and each
+has degree 2, every element of ℚ(ζ₁₇) — in particular `cos(2π/17)` and hence the
+coordinates of the vertices — is expressible in nested square roots, so the regular
+17-gon is straightedge-and-compass constructible.  The real subfield ℚ(cos 2π/17) sits
+one order-2 quotient down (fixed field of complex conjugation `{±1} = ⟨16⟩`), with
+degree φ(17)/2 = 8, requiring three quadratic steps.
+
+`4` is the number of quadratic steps for the full cyclotomic tower; `3` for the real
+(cosine) subfield.
+-/
+
+/-- The full cyclotomic tower has 4 quadratic steps: φ(17) = 2⁴. -/
+theorem full_tower_steps : Nat.totient 17 = 2 ^ 4 := by decide
+
+/-- The real (cosine) subfield has 3 quadratic steps: φ(17)/2 = 2³ = 8. -/
+theorem real_subfield_degree : Nat.totient 17 / 2 = 2 ^ 3 := by decide
+
+end AngleTrisectionOQ02OQ03OQ03

--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-primitive-root",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-03",
+    "range": { "startLine": 78, "endLine": 93 },
+    "type": "concept",
+    "title": "3 is a Primitive Root mod 17",
+    "content": "The unit group (ℤ/17ℤ)ˣ is cyclic of order 16, and `3` generates it: `three_orderOf` proves orderOf (3 : ZMod 17) = 16. The argument is the standard order test — 3¹⁶ = 1 by Fermat, and since 16 = 2⁴ has 2 as its only prime factor, it suffices that 3^(16/2) = 3⁸ = 16 = -1 ≠ 1. Gauss used exactly the powers of a primitive root to order the vertices of the polygon.",
+    "mathContext": "$\\mathrm{ord}_{17}(3) = 16$, so $\\langle 3\\rangle = (\\mathbb{Z}/17\\mathbb{Z})^\\times$.",
+    "significance": "key",
+    "relatedConcepts": ["Primitive root", "Cyclic group", "Order of an element", "Fermat's little theorem"],
+    "prerequisites": ["multiplicative group of ZMod p", "orderOf_eq_of_pow_and_pow_div_prime"]
+  },
+  {
+    "id": "ann-gauss-ordering",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-03",
+    "range": { "startLine": 100, "endLine": 118 },
+    "type": "insight",
+    "title": "Gauss's Vertex Ordering",
+    "content": "`gauss_ordering` lists the powers 3⁰,…,3¹⁵ mod 17 as [1,3,9,10,13,5,15,11,16,14,8,7,4,12,2,6] and `gauss_ordering_nodup` shows the list is duplicate-free — so the powers of 3 are a permutation of the sixteen nonzero residues. In Gauss's arrangement the two Gaussian periods, and then the sub-periods, appear as evenly spaced blocks of this list.",
+    "mathContext": "The primitive-root ordering makes each Gaussian period a contiguous residue class in the exponent.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gaussian periods", "Permutation of residues", "Decidable evaluation"],
+    "prerequisites": ["primitive root 3 mod 17"]
+  },
+  {
+    "id": "ann-gaussian-periods",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-03",
+    "range": { "startLine": 141, "endLine": 159 },
+    "type": "concept",
+    "title": "The Two Gaussian Periods = Squares vs. Non-squares",
+    "content": "The vertices split into the eight quadratic residues `periodQR` = {1,2,4,8,9,13,15,16} (even powers of 3) and the eight non-residues `periodNQR` = {3,5,6,7,10,11,12,14} (odd powers). `periodQR_eq_squares` confirms periodQR is exactly the nonzero squares mod 17, and `periods_disjoint`/`periods_cover` show they partition the units. As complex sums η₀ = Σ_{a∈QR} ζ^a and η₁ = Σ_{a∉QR} ζ^a, these periods satisfy η₀+η₁ = -1, η₀η₁ = -4, so they are the roots of x² + x − 4 = 0 — the first quadratic, introducing √17.",
+    "mathContext": "$\\eta_0,\\eta_1$ are roots of $x^2+x-4=0$, i.e. $\\eta = \\tfrac{-1\\pm\\sqrt{17}}{2}$.",
+    "significance": "key",
+    "relatedConcepts": ["Quadratic residues", "Gaussian periods", "Cyclotomic field", "Nested radicals"],
+    "prerequisites": ["quadratic residues mod a prime", "even/odd powers of a primitive root"]
+  },
+  {
+    "id": "ann-index2-tower",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-03",
+    "range": { "startLine": 230, "endLine": 264 },
+    "type": "insight",
+    "title": "The Index-2 Subgroup Tower",
+    "content": "Lifting 3 to a unit u₃, the subgroups ⟨u₃^(2ⁱ)⟩ form a descending chain with cardinalities 16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1 (`tower_cards`), each contained in the previous (`tower_le`) with index 2 (`tower_index_two`). Cardinalities come from `Nat.card_zpowers` (card = orderOf) together with `orderOf_pow_of_dvd` (order of u₃^(2ⁱ) is 16/2ⁱ). Because (ℤ/17ℤ)ˣ ≅ Gal(ℚ(ζ₁₇)/ℚ), this chain of four index-2 subgroups corresponds under the Galois correspondence to a tower ℚ ⊂ K₁ ⊂ K₂ ⊂ K₃ ⊂ ℚ(ζ₁₇) of four quadratic extensions — the algebraic reason the 17-gon needs only nested square roots.",
+    "mathContext": "$\\langle 3\\rangle \\supset \\langle 9\\rangle \\supset \\langle 13\\rangle \\supset \\langle 16\\rangle \\supset \\{1\\}$, orders $16\\supset 8\\supset 4\\supset 2\\supset 1$; each $[\\,\\cdot:\\cdot\\,]=2$.",
+    "significance": "key",
+    "relatedConcepts": ["Cyclic subgroup tower", "Subgroup index", "Galois correspondence", "Quadratic extensions"],
+    "prerequisites": ["zpowers and Nat.card_zpowers", "orderOf_pow_of_dvd", "Galois group of a cyclotomic field"]
+  },
+  {
+    "id": "ann-why-17-works",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-03",
+    "range": { "startLine": 275, "endLine": 285 },
+    "type": "conclusion",
+    "title": "Why 17 Works: Four Quadratic Steps",
+    "content": "`full_tower_steps` records φ(17) = 2⁴ (four quadratic steps for the full cyclotomic tower) and `real_subfield_degree` records φ(17)/2 = 2³ (three steps for the real cosine subfield ℚ(cos 2π/17), the fixed field of complex conjugation ⟨16⟩ = {±1}). Finitely many degree-2 extensions mean every coordinate — in particular cos(2π/17) — is built from nested square roots, so the regular 17-gon is straightedge-and-compass constructible.",
+    "mathContext": "$\\varphi(17)=2^4$, $\\varphi(17)/2 = 2^3$: the height of the quadratic tower.",
+    "significance": "key",
+    "relatedConcepts": ["Constructible number", "Tower of quadratic extensions", "Real subfield", "Complex conjugation"],
+    "prerequisites": ["constructible ⇔ tower of quadratic extensions", "fixed field of complex conjugation"]
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-03/meta.json
@@ -1,0 +1,281 @@
+{
+  "id": "angle-trisection-oq-02-oq-03-oq-03",
+  "title": "The 17-gon via Gauss: Primitive Roots, Gaussian Periods, and the Index-2 Tower",
+  "slug": "angle-trisection-oq-02-oq-03-oq-03",
+  "description": "Formalizes the concrete number-theoretic backbone of Gauss's 1796 heptadecagon construction, complementing the parent's abstract Gauss-Wantzel argument. Proves 3 is a primitive root mod 17 (orderOf = 16), exhibits Gauss's explicit vertex ordering [1,3,9,10,13,5,15,11,16,14,8,7,4,12,2,6], characterizes the two eight-term Gaussian periods as the quadratic residues / non-residues, and constructs the descending index-2 subgroup tower ⟨3⟩ ⊃ ⟨9⟩ ⊃ ⟨13⟩ ⊃ ⟨16⟩ ⊃ ⟨1⟩ of orders 16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1 in (ℤ/17ℤ)ˣ — the group skeleton of the four quadratic field extensions. 285 lines, 32 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Constructible_polygon#Heptadecagon",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ03OQ03.lean",
+    "tags": [
+      "number-theory",
+      "group-theory",
+      "cyclotomy",
+      "constructibility",
+      "gaussian-periods",
+      "primitive-roots",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "orderOf_eq_of_pow_and_pow_div_prime",
+        "description": "x has order n if x^n = 1 and x^(n/p) ≠ 1 for all prime factors p of n",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "orderOf_pow_of_dvd",
+        "description": "orderOf (x^n) = orderOf x / n when n ∣ orderOf x",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Nat.card_zpowers",
+        "description": "Nat.card (zpowers a) = orderOf a",
+        "module": "Mathlib.Data.ZMod.QuotientGroup"
+      },
+      {
+        "theorem": "Subgroup.zpowers_le",
+        "description": "zpowers g ≤ H ↔ g ∈ H",
+        "module": "Mathlib.Algebra.Group.Subgroup.ZPowers.Basic"
+      },
+      {
+        "theorem": "ZMod.unitOfCoprime",
+        "description": "A residue coprime to n as a unit of ZMod n",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "three_orderOf: 3 is a primitive root mod 17 (orderOf (3 : ZMod 17) = 16)",
+      "gauss_ordering: the explicit vertex ordering [1,3,9,10,13,5,15,11,16,14,8,7,4,12,2,6] as powers of 3",
+      "periodQR_eq_squares: the first Gaussian period is exactly the nonzero squares mod 17",
+      "periodQR_eq_even_powers / periodNQR_eq_odd_powers: periods are the even / odd powers of the primitive root",
+      "nine_orderOf / thirteen_orderOf / sixteen_orderOf: the order chain 8, 4, 2 for successive squares 3²,3⁴,3⁸",
+      "tower_cards: the index-2 subgroup tower of (ℤ/17ℤ)ˣ has cardinalities 16, 8, 4, 2, 1",
+      "tower_le / tower_index_two: each tower step is a containment of index 2 (a quadratic descent)"
+    ],
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "angle-trisection-oq-02-oq-03",
+        "relationship": "Parent: Gauss-Wantzel theorem (abstract constructibility criterion, incl. heptadecagon_constructible)"
+      },
+      {
+        "id": "angle-trisection-oq-02-oq-03-oq-01",
+        "relationship": "Sibling: Gauss-Wantzel via cyclotomic fields (Galois-theoretic degree computation)"
+      },
+      {
+        "id": "angle-trisection-oq-02",
+        "relationship": "Grandparent: Galois criterion for constructibility"
+      }
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Every result is a finite, decidable statement about (ℤ/17ℤ)ˣ, discharged by kernel `decide` or standard Mathlib order-of-element lemmas — no `native_decide`, so no `Lean.ofReduceBool` dependency.",
+    "lineCount": 285,
+    "prerequisites": [
+      "The multiplicative group (ℤ/nℤ)ˣ and primitive roots",
+      "Order of an element and cyclic subgroups (zpowers)",
+      "Quadratic residues modulo a prime",
+      "The Galois correspondence for cyclotomic extensions (context only)"
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 32,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "**Gauss and the Heptadecagon (1796)**\n\nOn 30 March 1796, at age 18, Carl Friedrich Gauss discovered that the regular 17-gon can be constructed with straightedge and compass — the first new regular-polygon construction since antiquity. The discovery reportedly settled his decision to pursue mathematics, and he asked for a 17-gon to be engraved on his tombstone.\n\nThe abstract reason is that φ(17) = 16 is a power of two (the Gauss-Wantzel criterion, proved in the parent entry). But Gauss's actual method is more concrete: he ordered the sixteen non-trivial 17th roots of unity by the powers of a primitive root modulo 17, grouped them into *Gaussian periods*, and solved a succession of quadratic equations. This file formalizes that concrete arithmetic machinery.",
+    "problemStatement": "**Goal**: Formalize the number-theoretic data of Gauss's 17-gon construction — the primitive-root ordering of (ℤ/17ℤ)ˣ, the Gaussian-period partition into quadratic residues and non-residues, and the descending chain of index-2 subgroups of orders 16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1 that mirrors the tower of four quadratic field extensions inside ℚ(ζ₁₇).",
+    "text": "A verified, fully decidable companion to the abstract Gauss-Wantzel theorem: 3 is a primitive root mod 17, its powers give Gauss's vertex ordering, the two eight-element periods are the squares and non-squares mod 17, and the successive squares 3²=9, 3⁴=13, 3⁸=16 generate an index-2 subgroup tower whose four quadratic steps are exactly why the 17-gon is constructible.",
+    "proofStrategy": "Everything reduces to finite computation in (ℤ/17ℤ)ˣ:\n\n1. **Primitive root** — 3¹⁶ = 1 and 3⁸ = -1 ≠ 1, so by `orderOf_eq_of_pow_and_pow_div_prime` (the only prime factor of 16 is 2) the order of 3 is exactly 16.\n2. **Vertex ordering** — `decide` evaluates the list of powers 3⁰,…,3¹⁵ and confirms it is duplicate-free, hence a permutation of the sixteen units.\n3. **Gaussian periods** — the quadratic-residue set {1,2,4,8,9,13,15,16} and its complement are shown by `decide` to be the nonzero squares / non-squares and the even / odd powers of 3; they are disjoint and cover all nonzero residues.\n4. **Order chain** — 9 = 3², 13 = 3⁴, 16 = 3⁸ have orders 8, 4, 2 (same order-of-element lemma).\n5. **Index-2 tower** — lifting 3 to a unit u₃ = unitOfCoprime 3, the subgroups ⟨u₃^(2ⁱ)⟩ have cardinality 16/2ⁱ (`Nat.card_zpowers` + `orderOf_pow_of_dvd`), each contained in the previous (`Subgroup.zpowers_le`) with index 2.",
+    "keyInsights": [
+      "3 is a primitive root mod 17: a single generator whose 16 powers enumerate every vertex — the ordering Gauss used.",
+      "The two Gaussian periods coincide with the quadratic residues and non-residues; equivalently, the even and odd powers of the primitive root.",
+      "Squaring the primitive root repeatedly (3 → 9 → 13 → 16 → 1) halves the subgroup order each time, producing a chain of index-2 subgroups.",
+      "Because (ℤ/17ℤ)ˣ ≅ Gal(ℚ(ζ₁₇)/ℚ), this chain of four index-2 subgroups corresponds by the Galois correspondence to a tower of four quadratic field extensions — the algebraic reason nested square roots suffice.",
+      "The real subfield ℚ(cos 2π/17) is the fixed field of the order-2 subgroup ⟨16⟩ = {±1} (complex conjugation), of degree φ(17)/2 = 8, needing three quadratic steps.",
+      "All results are finite and decidable, so the file is fully machine-checked with 0 axioms and no native_decide."
+    ],
+    "prerequisites": [
+      "The multiplicative group (ℤ/nℤ)ˣ and primitive roots",
+      "Order of an element and cyclic subgroups (zpowers)",
+      "Quadratic residues modulo a prime",
+      "The Galois correspondence for cyclotomic extensions (context only)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Docstring situating this file as the concrete arithmetic backbone of Gauss's 1796 construction (vs. the parent's abstract Gauss-Wantzel criterion), narrow Mathlib imports (ZMod, totient, order-of-element, subgroups/zpowers), `open Subgroup`, and the namespace.",
+      "mathContext": "Sets up the finite group (ℤ/17ℤ)ˣ as the arena for the primitive-root ordering, Gaussian periods, and the index-2 subgroup tower."
+    },
+    {
+      "id": "section-1-fermat-prime",
+      "title": "§I. 17 is a Fermat prime and φ(17) = 16 = 2⁴",
+      "startLine": 49,
+      "endLine": 65,
+      "summary": "`seventeen_prime`, `seventeen_fermat` (17 = 2^(2²)+1), and `totient_17` / `totient_17_pow2` establishing φ(17) = 16 = 2⁴, the degree of the full cyclotomic field.",
+      "mathContext": "17 = 2^(2²)+1 is a Fermat prime, so φ(17) = 16 is a power of two — the Gauss-Wantzel precondition for constructibility."
+    },
+    {
+      "id": "section-2-primitive-root",
+      "title": "§II. 3 is a primitive root modulo 17",
+      "startLine": 66,
+      "endLine": 93,
+      "summary": "`three_pow_16` (3¹⁶ = 1), `three_pow_8` (3⁸ = 16 = -1), and the main `three_orderOf`: orderOf (3 : ZMod 17) = 16 via `orderOf_eq_of_pow_and_pow_div_prime` (only prime factor of 16 is 2).",
+      "mathContext": "$\\mathrm{ord}_{17}(3) = 16$: 3 generates the cyclic group $(\\mathbb{Z}/17\\mathbb{Z})^\\times$."
+    },
+    {
+      "id": "section-3-vertex-ordering",
+      "title": "§III. Gauss's vertex ordering",
+      "startLine": 94,
+      "endLine": 118,
+      "summary": "`gauss_ordering`: the explicit list [1,3,9,10,13,5,15,11,16,14,8,7,4,12,2,6] of powers 3⁰..3¹⁵; `gauss_ordering_nodup` (it is duplicate-free, hence a permutation of the units); `gauss_powers_ne_zero` (each of the 16 powers is nonzero).",
+      "mathContext": "The powers of the primitive root list the sixteen vertices in Gauss's order, in which the periods appear as contiguous blocks."
+    },
+    {
+      "id": "section-4-gaussian-periods",
+      "title": "§IV. The two Gaussian periods (quadratic residues vs. non-residues)",
+      "startLine": 119,
+      "endLine": 159,
+      "summary": "Defines `periodQR` = {1,2,4,8,9,13,15,16} and `periodNQR` = {3,5,6,7,10,11,12,14}; proves each has 8 elements, they are disjoint and cover all nonzero residues (`periods_disjoint`, `periods_cover`), that periodQR is exactly the nonzero squares (`periodQR_eq_squares`), and that the periods are the even / odd powers of 3 (`periodQR_eq_even_powers`, `periodNQR_eq_odd_powers`).",
+      "mathContext": "The eight-term periods η₀, η₁ index the quadratic residues / non-residues; as complex sums they satisfy x² + x − 4 = 0, introducing the surd √17."
+    },
+    {
+      "id": "section-5-order-chain",
+      "title": "§V. The order chain 16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1",
+      "startLine": 160,
+      "endLine": 197,
+      "summary": "`square_step_1..3` (3²=9, 3⁴=13, 3⁸=16) and `nine_orderOf`, `thirteen_orderOf`, `sixteen_orderOf`: the successive squares of the primitive root have orders 8, 4, 2 — the generators of the period tower.",
+      "mathContext": "Repeated squaring halves the order: $\\mathrm{ord}(3^{2^i}) = 16/2^i$."
+    },
+    {
+      "id": "section-6-index2-tower",
+      "title": "§VI. The period tower as index-2 subgroups of (ℤ/17ℤ)ˣ",
+      "startLine": 198,
+      "endLine": 264,
+      "summary": "Lifts 3 to a unit `u3 = unitOfCoprime 3` (`u3_coe`, `u3_orderOf` = 16), computes `u3_pow_orderOf` and `tower_card` (Nat.card ⟨u3^(2ⁱ)⟩ = 16/2ⁱ), lists them in `tower_cards` (16,8,4,2,1), proves containment `tower_le` (⟨u3^(2^(i+1))⟩ ≤ ⟨u3^(2ⁱ)⟩), and `tower_index_two` (each step has index 2).",
+      "mathContext": "The descending chain of index-2 subgroups of $(\\mathbb{Z}/17\\mathbb{Z})^\\times$ corresponds, under the Galois isomorphism, to a tower of four quadratic extensions of $\\mathbb{Q}$."
+    },
+    {
+      "id": "section-7-summary",
+      "title": "§VII. Summary — why 17 works",
+      "startLine": 265,
+      "endLine": 285,
+      "summary": "`full_tower_steps` (φ(17) = 2⁴, four quadratic steps for the full cyclotomic tower) and `real_subfield_degree` (φ(17)/2 = 2³ = 8, three quadratic steps for the real cosine subfield).",
+      "mathContext": "Four quadratic descents make every element of ℚ(ζ₁₇) — in particular cos(2π/17) — expressible in nested square roots, so the 17-gon is constructible."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file supplies the concrete number-theoretic content of Gauss's heptadecagon construction that the abstract Gauss-Wantzel theorem leaves implicit: a primitive root (3) modulo 17, its explicit vertex ordering, the Gaussian-period partition into quadratic residues and non-residues, and a descending chain of index-2 subgroups of (ℤ/17ℤ)ˣ of orders 16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1. Everything is finite and decidable — 285 lines, 32 theorems, 0 axioms, 0 sorries, no native_decide.",
+    "implications": "**Mathematical Significance**\n\n1. **Concrete backbone**: Where the parent proves the 17-gon constructible in the abstract, this file exhibits the actual arithmetic Gauss used — the primitive-root ordering and Gaussian periods.\n2. **Group ↔ field tower**: The four index-2 subgroups are the group-theoretic shadow of a tower of four quadratic field extensions inside ℚ(ζ₁₇), via (ℤ/17ℤ)ˣ ≅ Gal(ℚ(ζ₁₇)/ℚ).\n3. **Fully decidable**: All statements are finite computations in a group of order 16, so the formalization is machine-checked with only the standard foundational axioms.",
+    "openQuestions": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-02-oq-03",
+      "relationship": "extends",
+      "description": "Parent: proves the abstract Gauss-Wantzel criterion and heptadecagon_constructible; this file supplies the concrete primitive-root / Gaussian-period data behind the n = 17 case."
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "Companion: computes the real-subfield degree φ(n)/2 via cyclotomic Galois theory; this file gives the matching index-2 subgroup tower of (ℤ/17ℤ)ˣ for n = 17."
+    },
+    {
+      "targetId": "angle-trisection-oq-02",
+      "relationship": "ancestor",
+      "description": "The Galois criterion for constructibility; here specialized to the concrete cyclic group (ℤ/17ℤ)ˣ of 2-power order."
+    },
+    {
+      "targetId": "primitive-roots",
+      "relationship": "foundational",
+      "description": "That (ℤ/pℤ)ˣ is cyclic underlies the existence of the primitive root 3 mod 17 whose powers order the vertices."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "foundational",
+      "description": "φ(17) = 16 = 2⁴ is the size of (ℤ/17ℤ)ˣ and the height (in quadratic steps) of the subgroup tower."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "venue": "Leipzig",
+      "note": "Section VII: the theory of Gaussian periods and cyclotomy underlying the constructibility of the regular 17-gon."
+    },
+    {
+      "authors": "Stewart, Ian",
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "Chapman & Hall/CRC, 4th edition",
+      "note": "Chapter on regular polygons: the primitive-root ordering and Gaussian-period reduction to nested quadratics for the 17-gon."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Data.Nat.Totient",
+      "Mathlib.GroupTheory.OrderOfElement",
+      "Mathlib.GroupTheory.SpecificGroups.Cyclic",
+      "Mathlib.Algebra.Group.Subgroup.Basic",
+      "Mathlib.Algebra.Group.Subgroup.ZPowers.Basic",
+      "Mathlib.Data.ZMod.QuotientGroup"
+    ],
+    "opens": [
+      "Subgroup"
+    ],
+    "namespace": "AngleTrisectionOQ02OQ03OQ03",
+    "lineCount": 285,
+    "axiomCount": 0,
+    "theoremCount": 32,
+    "definitionCount": 3,
+    "mainTheorems": [
+      {
+        "name": "three_orderOf",
+        "type": "core",
+        "description": "3 is a primitive root modulo 17: its multiplicative order is exactly 16",
+        "leanType": "orderOf (3 : ZMod 17) = 16"
+      },
+      {
+        "name": "gauss_ordering",
+        "type": "core",
+        "description": "Gauss's explicit vertex ordering as the powers of the primitive root 3",
+        "leanType": "(List.range 16).map (fun k => (3 : ZMod 17) ^ k) = [1, 3, 9, 10, 13, 5, 15, 11, 16, 14, 8, 7, 4, 12, 2, 6]"
+      },
+      {
+        "name": "periodQR_eq_squares",
+        "type": "core",
+        "description": "The first Gaussian period is exactly the set of nonzero quadratic residues mod 17",
+        "leanType": "∀ a : ZMod 17, a ∈ periodQR ↔ (a ≠ 0 ∧ ∃ r : ZMod 17, r ^ 2 = a)"
+      },
+      {
+        "name": "tower_cards",
+        "type": "core",
+        "description": "The index-2 subgroup tower of (ℤ/17ℤ)ˣ has cardinalities 16, 8, 4, 2, 1",
+        "leanType": "Nat.card (zpowers (u3 ^ 2^0)) = 16 ∧ … ∧ Nat.card (zpowers (u3 ^ 2^4)) = 1"
+      },
+      {
+        "name": "tower_index_two",
+        "type": "core",
+        "description": "Each step of the subgroup tower has index 2 — a quadratic descent",
+        "leanType": "(i : ℕ) → i < 4 → Nat.card (zpowers (u3 ^ 2^i)) = 2 * Nat.card (zpowers (u3 ^ 2^(i+1)))"
+      },
+      {
+        "name": "tower_le",
+        "type": "supporting",
+        "description": "Each tower subgroup is contained in the previous one",
+        "leanType": "(i : ℕ) → zpowers (u3 ^ 2^(i+1)) ≤ zpowers (u3 ^ 2^i)"
+      }
+    ],
+    "path": "Proofs/AngleTrisectionOQ02OQ03OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent entry **OQ02-OQ03** (Gauss–Wantzel) proves the regular 17-gon is constructible *abstractly*, because φ(17) = 16 is a power of two. That statement is silent about *how* Gauss actually did it. This file formalizes the concrete number-theoretic backbone of Gauss's 1796 heptadecagon construction — the piece a reader of "the 17-gon is constructible" still wants to see.

New gallery entry: **`angle-trisection-oq-02-oq-03-oq-03`** — *The 17-gon via Gauss: Primitive Roots, Gaussian Periods, and the Index-2 Tower*.

## Results (all in `(ℤ/17ℤ)ˣ`, all decidable)

- **`three_orderOf`** — `3` is a primitive root mod 17: `orderOf (3 : ZMod 17) = 16`.
- **`gauss_ordering`** — the explicit vertex ordering `[1,3,9,10,13,5,15,11,16,14,8,7,4,12,2,6]` as the powers of 3 (plus `gauss_ordering_nodup`: a permutation of the units).
- **Gaussian periods** — `periodQR = {1,2,4,8,9,13,15,16}`, `periodNQR = {3,5,6,7,10,11,12,14}`: proved to be the nonzero squares / non-squares (`periodQR_eq_squares`) and the even / odd powers of 3, disjoint and covering all units.
- **Order chain** — `nine_orderOf`/`thirteen_orderOf`/`sixteen_orderOf`: successive squares 3²=9, 3⁴=13, 3⁸=16 have orders 8, 4, 2.
- **Index-2 subgroup tower** — `tower_cards` (16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1), `tower_le` (containment), `tower_index_two` (each step index 2): the group-theoretic skeleton of the four quadratic field extensions inside ℚ(ζ₁₇), via (ℤ/17ℤ)ˣ ≅ Gal(ℚ(ζ₁₇)/ℚ).

## Verification

- **285 lines, 32 theorems, 3 defs, 0 sorries, 0 axioms.**
- Every result is a finite computation in a group of order 16, discharged by kernel `decide` or standard Mathlib order-of-element / zpowers lemmas.
- **No `native_decide`** → no `Lean.ofReduceBool` dependency. `#print axioms` on the main theorems shows only `propext, Classical.choice, Quot.sound`.
- Compiled with `lake env lean` against Mathlib v4.26.0 (narrow imports).

## Relationship to the family

Distinct from every sibling: no other entry formalizes the primitive-root ordering, the Gaussian-period partition, or the explicit index-2 subgroup tower for n = 17. This is the number-theoretic content specific to Gauss's 17-gon, complementary to the parent's general Gauss–Wantzel degree argument and the sibling `-oq-01`'s cyclotomic-Galois degree computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)