### PR TITLE
Enrich Falling-Factorial Vandermonde Convolution (CommRing)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "ann-asoq010301-defs",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01",
+    "range": { "startLine": 37, "endLine": 46 },
+    "type": "definition",
+    "title": "Both Factorials, Built From Scratch Over a Commutative Ring",
+    "content": "risingFactorial and fallingFactorial are defined by direct recursion on the exponent k: x^{(0)} = 1, x^{(k+1)} = x^{(k)}·(x+k) for the rising factorial, and x^{underline 0} = 1, x^{underline (k+1)} = x^{underline k}·(x-k) for the falling one. Each ships with a `@[simp]` zero lemma and a `succ` unfolding lemma proved by `rfl`. The design choice is deliberate: rather than route through Mathlib's `ascPochhammer`/`descPochhammer` (which are polynomials evaluated at a ring element), the factorials are recursive `R`-valued functions. This keeps every downstream proof elementary — the reflection lemma becomes one line, and `risingFactorial_succ`/`fallingFactorial_succ` rewrite definitionally — at the cost of not reusing the Pochhammer API. The falling definition's use of `x - k` is exactly why the development lives over a `CommRing` and not a `CommSemiring`.",
+    "mathContext": "The rising factorial $x^{\\overline{k}}=x(x+1)\\cdots(x+k-1)$ and falling factorial $x^{\\underline{k}}=x(x-1)\\cdots(x-k+1)$ are the empty product $1$ at $k=0$. Here $k \\in \\mathbb{N}$ is a genuine natural-number recursion index while $x \\in R$ ranges over an arbitrary commutative ring, so $x + k$ and $x - k$ read the cast $(k : R)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "falling factorial",
+      "rising factorial",
+      "Pochhammer symbol",
+      "primitive recursion",
+      "commutative ring"
+    ],
+    "prerequisites": [
+      "structural recursion on ℕ",
+      "Nat.cast into a ring",
+      "empty product convention"
+    ]
+  },
+  {
     "id": "ann-asoq010301-rising",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01",
     "range": { "startLine": 51, "endLine": 128 },

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/meta.json
@@ -59,19 +59,31 @@
   "sections": [
     {
       "id": "rising-convolution",
-      "title": "Part I: The Rising-Factorial Vandermonde Convolution (CommRing)"
+      "title": "Part I: The Rising-Factorial Vandermonde Convolution (CommRing)",
+      "startLine": 37,
+      "endLine": 130,
+      "summary": "Defines the rising factorial $x^{\\overline{k}} = x(x+1)\\cdots(x+k-1)$ recursively over any commutative ring (with `risingFactorial_zero` and `risingFactorial_succ` unfolding lemmas), then proves the headline rising convolution `risingFactorial_add`: $(x+y)^{\\overline{r}} = \\sum_{j=0}^{r}\\binom{r}{j}x^{\\overline{j}}y^{\\overline{r-j}}$. The induction on $r$ mirrors `Commute.add_pow`, with the index-dependent shift $(x+y)+r$ split as $(x+j)+(y+(r-j))$ and Pascal's rule $\\binom{r+1}{j+1}=\\binom{r}{j}+\\binom{r}{j+1}$ recombining the two resulting sums."
     },
     {
       "id": "reflection",
-      "title": "Part II: The Sign Reflection x^{underline k} = (-1)^k·(-x)^{(k)}"
+      "title": "Part II: The Sign Reflection x^{underline k} = (-1)^k·(-x)^{(k)}",
+      "startLine": 132,
+      "endLine": 153,
+      "summary": "Defines the falling factorial $x^{\\underline{k}} = x(x-1)\\cdots(x-k+1)$ (again recursively, using ring subtraction) and proves the duality `fallingFactorial_eq_neg_one_pow_mul_risingFactorial`: $x^{\\underline{k}} = (-1)^k(-x)^{\\overline{k}}$ by a one-line induction closed with `ring`. This reflection is the hinge that transports the rising convolution to the falling one and the exact point where additive inverses (a ring, not a semiring) become necessary."
     },
     {
       "id": "falling-convolution",
-      "title": "Part III: The Falling-Factorial Convolution over a Commutative Ring"
+      "title": "Part III: The Falling-Factorial Convolution over a Commutative Ring",
+      "startLine": 155,
+      "endLine": 172,
+      "summary": "Proves the headline `fallingFactorial_add`: $(x+y)^{\\underline{r}} = \\sum_{j=0}^{r}\\binom{r}{j}x^{\\underline{j}}y^{\\underline{r-j}}$ over any commutative ring — with no fresh induction. Each falling factorial is rewritten by the reflection, $-(x+y)=(-x)+(-y)$ feeds `risingFactorial_add`, and the global sign reassembles term-by-term from $(-1)^r = (-1)^j(-1)^{r-j}$."
     },
     {
       "id": "nat-bridge",
-      "title": "Part IV: Numerical Bridge to the Parent's ℕ Identity"
+      "title": "Part IV: Numerical Bridge to the Parent's ℕ Identity",
+      "startLine": 174,
+      "endLine": 187,
+      "summary": "Proves `risingFactorial_natCast`: $\\text{risingFactorial}\\,(m:R)\\,k = (\\text{Nat.ascFactorial}\\,m\\,k : R)$ by induction against `Nat.ascFactorial_succ`. Specializing the ring convolutions to natural-number casts reproduces the parent's ℕ-valued descFactorial/ascFactorial Vandermonde identities exactly, confirming the ring statement is a strict generalization."
     }
   ],
   "crossReferences": [
@@ -91,5 +103,14 @@
       "description": "Grandparent: the descending (falling) factorial identity C(n,k)·k! = n(n-1)···(n-k+1) over ℕ, whose ring-element falling convolution is completed here."
     }
   ],
-  "relatedProblems": null
+  "relatedProblems": null,
+  "conclusion": {
+    "summary": "The entry settles the parent's open question by upgrading the falling-factorial Vandermonde convolution from a numerical identity over ℕ to a genuine polynomial identity of ring elements: for any commutative ring $R$ and $x, y \\in R$, $(x+y)^{\\underline{r}} = \\sum_{j=0}^{r}\\binom{r}{j}x^{\\underline{j}}y^{\\underline{r-j}}$, with the companion rising form $(x+y)^{\\overline{r}} = \\sum_{j=0}^{r}\\binom{r}{j}x^{\\overline{j}}y^{\\overline{r-j}}$ and the reflection $x^{\\underline{k}} = (-1)^k(-x)^{\\overline{k}}$ that ties them together. Both factorials are built from scratch by recursion over `CommRing`, the rising convolution is proved by a single `add_pow`-style induction, and the falling one follows with no further induction via the reflection. The whole development is 0-axiom, 0-sorry, kernel-verified against Mathlib v4.26.0.",
+    "implications": "Stated over a commutative ring, the identity holds simultaneously for $\\mathbb{Z}$, $\\mathbb{Q}$, $\\mathbb{R}$, $\\mathbb{C}$, and any polynomial ring, so it is a true polynomial identity in $x$ and $y$ rather than a fact about counting. The natural-number bridge `risingFactorial_natCast` shows the parent's ℕ statement is the $x,y\\in\\mathbb{N}$ specialization, so the ring theorem is strictly stronger. Structurally it exhibits the falling and rising factorials as sequences of binomial type — the monomials of the finite-difference calculus $\\Delta f(x)=f(x+1)-f(x)$ — for which this convolution is the exact analogue of $(x+y)^n=\\sum\\binom{n}{m}x^m y^{n-m}$. The reflection cleanly localizes where negation is essential: the rising case lives already over a semiring, but the falling case genuinely requires additive inverses.",
+    "openQuestions": [
+      "Can the two convolutions be unified and reproved through Mathlib's existing `ascPochhammer`/`descPochhammer` polynomial API — supplying the missing `ascPochhammer_add`/`descPochhammer_add` binomial-convolution lemmas upstream — rather than via the self-contained recursive definitions used here?",
+      "Does the same reflection-plus-induction template extend to other sequences of binomial type (e.g. the Abel polynomials $A_k(x;a)=x(x-ka)^{k-1}$ or the exponential/Bell polynomials), giving a uniform ring-level umbral binomial theorem?",
+      "Is there a $q$-analogue: a Gaussian-binomial convolution for the $q$-falling factorial $(x;q)_k$ valid over an arbitrary commutative ring, recovering this identity as $q\\to 1$?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01` (quality 78, pass 0).

## Changes
- **Added `conclusion`** (previously missing): summary, implications, and 3 substantive open questions (route via Mathlib `ascPochhammer`/`descPochhammer` API supplying the missing `*_add` convolution lemmas; extension to other binomial-type sequences like Abel/Bell polynomials; a $q$-analogue via the $q$-falling factorial).
- **Section line ranges + summaries** on all 4 sections (were title-only), mapped to the Lean file: Part I rising convolution (37–130), Part II reflection (132–153), Part III falling convolution (155–172), Part IV ℕ bridge (174–187).
- **5th annotation** covering the self-contained recursive definitions of both factorials (lines 37–46), the previously-uncovered setup section — explains the deliberate choice to build `risingFactorial`/`fallingFactorial` from scratch rather than through Pochhammer, and pinpoints `x - k` as why the development needs `CommRing` not `CommSemiring`.

## Verification
- JSON valid; meta.json 14.9 KB (well under 60 KB cap); 5 annotations.
- Build data-generation prebuild consumed the entry cleanly (regenerated `public/data/proofs/<id>/`, present in `listings.json`). Downstream `tsc` step is blocked by a pre-existing worktree `node_modules`/`better-sqlite3` native-build failure, unrelated to these JSON-only edits.
- Axiom integrity unchanged: entry remains `status: verified`, `badge: original`, `axiomCount: 0` — consistent with the Lean file (0 `axiom`, 0 `sorry`, no `native_decide`).