### PR TITLE
research(schroeder-bernstein-oq-03): forward-orbit computability [VERIFIED building block]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -179,6 +179,32 @@ theorem fwdOrbit_eq_iterate (f g : ℕ → ℕ) (n k : ℕ) :
   | succ k ih =>
       simp only [fwdOrbit, ih, Function.iterate_succ_apply']
 
+/-- **The forward orbit is computable**, as a two-argument function of the base
+    point `n` and the iteration count `k`: `fwdOrbit f g` is `Computable₂` whenever
+    `f` and `g` are computable. This discharges (with an actual machine-checked
+    `Computable` certificate) the prose remark on `fwdOrbit_eq_iterate` that the
+    *forward* direction of the orbit is unproblematic — the computability difficulty
+    in Myhill's construction lies entirely in the *backward* direction, where
+    deciding `range g` membership (`isGFree`, below) is `Π₁`.
+
+    The proof identifies `fwdOrbit f g n` with `Nat.rec` on the iteration count and
+    applies `Computable.nat_rec`, whose step function `IH ↦ g (f IH)` is computable
+    because `f` and `g` are. -/
+theorem fwdOrbit_computable {f g : ℕ → ℕ} (hf : Computable f) (hg : Computable g) :
+    Computable₂ (fwdOrbit f g) := by
+  have key : ∀ (n k : ℕ), fwdOrbit f g n k
+      = Nat.rec (motive := fun _ => ℕ) n (fun _ IH => g (f IH)) k := by
+    intro n k
+    induction k with
+    | zero => rfl
+    | succ k ih => rw [fwdOrbit, ih]
+  have h := Computable.nat_rec (α := ℕ × ℕ) (σ := ℕ)
+    (f := fun a => a.2) (g := fun a => a.1)
+    (h := fun (_ : ℕ × ℕ) (p : ℕ × ℕ) => g (f p.2))
+    Computable.snd Computable.fst
+    ((hg.comp (hf.comp (Computable.snd.comp Computable.snd))).to₂)
+  exact h.of_eq (fun a => (key a.1 a.2).symm)
+
 /-- The back-and-forth strategy: an element n is "f-type" if its backward chain
     under alternating g⁻¹, f⁻¹ terminates outside range(g) (i.e., not a g-image).
     These are exactly the elements where σ(n) := f(n) is the right choice.

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -81,3 +81,16 @@ classification. Treat that suggested milestone with care.
    the entering stage.
 4. Tractable partial win to consider first: classical SB bijection *is* computable
    when `range f` and `range g` are decidable — isolates the obstruction cleanly.
+
+## Session (researcher-1, 2026-07-01)
+
+- `fwdOrbit_computable` — PROVED (0-axiom): `fwdOrbit f g` is `Computable₂` for
+  computable `f, g`, via `Computable.nat_rec` (identify the orbit with `Nat.rec` on
+  the iteration count; step `IH ↦ g (f IH)` is computable). This closes the prose
+  gap on `fwdOrbit_eq_iterate` with an actual machine-checked `Computable` certificate
+  and confirms the computability obstruction is *entirely* in the backward direction
+  (`isGFree`/`range g`, Π₁). File: 396→422 lines, +1 theorem; main hard-direction
+  sorry (`myhill_isomorphism` →) UNCHANGED — still needs the stage-wise back-and-forth
+  builder (knowledge Next Steps 1–3). Build: Docker down; verify via
+  `elan run leanprover/lean4:v4.26.0 lean` with LEAN_PATH→main oleans (NOT homebrew
+  lean 4.31, which gives incompatible-header errors).


### PR DESCRIPTION
## Summary

A verified, 0-axiom building block toward the open **hard direction** of Myhill's
isomorphism theorem (`schroeder-bernstein-oq-03`).

Adds **`fwdOrbit_computable`**: for computable injections `f, g`, the forward orbit
`fwdOrbit f g` (iterating `g ∘ f`) is `Computable₂`. Proved by identifying the orbit
with `Nat.rec` on the iteration count and applying `Computable.nat_rec` (the step
`IH ↦ g (f IH)` is computable since `f, g` are).

This discharges — with an actual machine-checked `Computable` certificate — the prose
remark on `fwdOrbit_eq_iterate` that the *forward* direction is unproblematic, confirming
the computability obstruction in Myhill's construction lies **entirely** in the backward
direction (`isGFree` / `range g` membership, which is `Π₁`).

## Scope / honesty

- The **main hard-direction sorry** (`myhill_isomorphism` →, the stage-wise back-and-forth
  priority construction) is **UNCHANGED and still open**. This PR is an additive building
  block, not a closure of that sorry.
- File `SchroederBernsteinOQ03.lean`: 396 → 422 lines, +1 theorem. No new sorries or axioms.

## Housekeeping

- Refreshes the **stale** gallery meta counts to match the current file
  (`lineCount` 269→422, `theoremCount` 14→24, `definitionCount` 4→6); status remains
  `formalized` (1 open sorry).
- Records the session in the problem knowledge base.

## Verification

- Whole file compiles under Lean `4.26.0` against pinned Mathlib (only the pre-existing
  `myhill_isomorphism` sorry warning + pre-existing unused-variable warnings).
- `#print axioms fwdOrbit_computable` → `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)