### PR TITLE
research(researcher-11): Eulerian trail endpoint characterization (konigsberg-oq-05) + Myhill obstruction is Π₁ (schroeder-bernstein-oq-03) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/KonigsbergOQ05.lean
+++ b/proofs/Proofs/KonigsbergOQ05.lean
@@ -1,0 +1,130 @@
+/-
+Endpoints of an Eulerian Trail Are Exactly the Odd-Degree Vertices
+
+This file completes the degree characterization of Eulerian trails for finite
+simple graphs. Mathlib's `SimpleGraph.Walk.IsEulerian.even_degree_iff` gives the
+awkwardly-quantified statement
+
+    Even (G.degree x) ↔ (u ≠ v → x ≠ u ∧ x ≠ v)
+
+and `IsEulerian.card_odd_degree` gives the count `0 ∨ 2`. The sibling file
+`KonigsbergOQ01.lean` derives only the *non-endpoint ⟹ even* half of the
+open-trail characterization (`euler_trail_non_endpoint_even`).
+
+What was still missing — and is proved here — is the clean two-sided form:
+
+* **Open trail (u ≠ v):** `Odd (G.degree w) ↔ (w = u ∨ w = v)`, i.e. the
+  odd-degree vertices are *exactly* the two endpoints. The new content is the
+  converse (endpoint ⟹ odd). As a set: `{w | Odd (G.degree w)} = {u, v}`, and
+  the count is *exactly* 2 (sharpening the Mathlib `0 ∨ 2` to `= 2`).
+* **Closed trail (circuit, u = v):** `{w | Odd (G.degree w)} = ∅`, with count 0.
+
+Together these give the sharp dichotomy: an Eulerian trail exists as an open
+walk with distinct endpoints iff there are exactly two odd vertices (and they
+are the endpoints), and as a circuit iff there are none.
+
+Builds on: Konigsberg.lean, KonigsbergOQ01.lean (Euler trail extensions)
+Authors: lean-genius research (researcher-11)
+-/
+import Mathlib.Combinatorics.SimpleGraph.Trails
+import Mathlib.Algebra.Ring.Parity
+
+namespace KonigsbergOQ05
+
+open SimpleGraph
+
+variable {V : Type*} [Fintype V] [DecidableEq V] (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-
+## Part 1: The open-trail endpoint characterization
+
+For an Eulerian trail from `u` to `v` with `u ≠ v`, a vertex has odd degree
+**if and only if** it is one of the two endpoints. This is the two-sided
+strengthening of `KonigsbergOQ01.euler_trail_non_endpoint_even`.
+-/
+
+/-- **Endpoint ⟺ odd degree.** For an Eulerian trail from `u` to `v` with
+`u ≠ v`, a vertex `w` has odd degree iff `w` is an endpoint (`w = u ∨ w = v`).
+The forward direction (odd ⟹ endpoint) restates the contrapositive of Mathlib's
+`even_degree_iff`; the backward direction (endpoint ⟹ odd) is the genuinely new
+content. -/
+theorem euler_trail_odd_iff_endpoint {u v w : V} (p : G.Walk u v)
+    (hp : p.IsEulerian) (huv : u ≠ v) :
+    Odd (G.degree w) ↔ (w = u ∨ w = v) := by
+  rw [← Nat.not_even_iff_odd, hp.even_degree_iff]
+  constructor
+  · -- ¬(u ≠ v → w ≠ u ∧ w ≠ v) ⟹ w = u ∨ w = v
+    intro hn
+    by_contra hc
+    exact hn (fun _ => ⟨fun h => hc (Or.inl h), fun h => hc (Or.inr h)⟩)
+  · -- w = u ∨ w = v ⟹ ¬(u ≠ v → w ≠ u ∧ w ≠ v)
+    intro hor hi
+    obtain ⟨h1, h2⟩ := hi huv
+    rcases hor with rfl | rfl
+    · exact h1 rfl
+    · exact h2 rfl
+
+/-- The left endpoint of an open Eulerian trail has odd degree. -/
+theorem euler_trail_left_odd {u v : V} (p : G.Walk u v)
+    (hp : p.IsEulerian) (huv : u ≠ v) : Odd (G.degree u) :=
+  (euler_trail_odd_iff_endpoint G (w := u) p hp huv).mpr (Or.inl rfl)
+
+/-- The right endpoint of an open Eulerian trail has odd degree. -/
+theorem euler_trail_right_odd {u v : V} (p : G.Walk u v)
+    (hp : p.IsEulerian) (huv : u ≠ v) : Odd (G.degree v) :=
+  (euler_trail_odd_iff_endpoint G (w := v) p hp huv).mpr (Or.inr rfl)
+
+/-- **The odd-degree vertices are exactly the endpoints.** For an open Eulerian
+trail, the set of odd-degree vertices equals the (two-element) endpoint set. -/
+theorem euler_trail_odd_set {u v : V} (p : G.Walk u v)
+    (hp : p.IsEulerian) (huv : u ≠ v) :
+    {w : V | Odd (G.degree w)} = {u, v} := by
+  ext w
+  simp only [Set.mem_setOf_eq, Set.mem_insert_iff, Set.mem_singleton_iff]
+  exact euler_trail_odd_iff_endpoint G p hp huv
+
+/-- **Exactly two odd-degree vertices.** For an open Eulerian trail (`u ≠ v`),
+there are *exactly* two odd-degree vertices — sharpening Mathlib's
+`card_odd_degree` (which only gives `0 ∨ 2`), since the endpoint `u` witnesses
+that the count is nonzero. -/
+theorem euler_trail_card_odd_eq_two {u v : V} (p : G.Walk u v)
+    (hp : p.IsEulerian) (huv : u ≠ v) :
+    Fintype.card {w : V | Odd (G.degree w)} = 2 := by
+  rcases hp.card_odd_degree with h0 | h2
+  · exfalso
+    have hu : Odd (G.degree u) := euler_trail_left_odd G p hp huv
+    have hne : Nonempty {w : V | Odd (G.degree w)} := ⟨⟨u, hu⟩⟩
+    rw [← Fintype.card_pos_iff] at hne
+    omega
+  · exact h2
+
+/-
+## Part 2: The closed-trail (circuit) characterization
+
+For an Eulerian circuit (`u = u`), every vertex has even degree, so there are no
+odd-degree vertices at all. This is the `= ∅` / count `= 0` complement of the
+open-trail case, completing the dichotomy.
+-/
+
+/-- **A circuit has no odd-degree vertices.** For an Eulerian circuit the set of
+odd-degree vertices is empty. -/
+theorem euler_circuit_no_odd {u : V} (p : G.Walk u u)
+    (hp : p.IsEulerian) : {w : V | Odd (G.degree w)} = ∅ := by
+  ext w
+  simp only [Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false]
+  rw [Nat.not_odd_iff_even]
+  exact (hp.even_degree_iff (x := w)).mpr (by simp)
+
+/-- **Zero odd-degree vertices in a circuit.** The count complement of
+`euler_trail_card_odd_eq_two`. -/
+theorem euler_circuit_card_odd_eq_zero {u : V} (p : G.Walk u u)
+    (hp : p.IsEulerian) : Fintype.card {w : V | Odd (G.degree w)} = 0 := by
+  rw [Fintype.card_eq_zero_iff]
+  refine ⟨fun w => ?_⟩
+  have hw : Odd (G.degree (w : V)) := w.2
+  have hne : ¬ Odd (G.degree (w : V)) := by
+    rw [Nat.not_odd_iff_even]
+    exact (hp.even_degree_iff (x := (w : V))).mpr (by simp)
+  exact hne hw
+
+end KonigsbergOQ05

--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -1,5 +1,6 @@
 import Mathlib.Computability.Reduce
 import Mathlib.Computability.Partrec
+import Mathlib.Computability.Halting
 import Mathlib.Computability.Primrec
 import Mathlib.Data.Nat.Basic
 import Mathlib.Tactic
@@ -52,6 +53,9 @@ computable via Partrec.rfind. The orbit type is determined by bounded search.
 - fwdOrbit_eq_iterate: proved (forward orbit = iteration of g∘f; forward direction is computable)
 - isGFree_iff_not_mem_range: proved — pins down WHY the naive orbit classification is
   not computable: `isGFree` is Π₁ (complement of the c.e. set `range g`), hence undecidable
+- partialInverse_dom_iff_mem_range / mem_range_re / not_isGFree_re: proved — the Σ₁/Π₁
+  complexity claim made machine-checked: `range g` is `REPred` (c.e.) for computable `g`
+  (its the domain of `partialInverse g`), so `isGFree g` is co-c.e. (Π₁)
 - decidableIsGFree: proved — the Π₁ obstruction becomes decidable once `range g` is decidable
 - totalInverse_{mem,right,left,computable}: proved — a surjective computable injection has a
   total, computable two-sided inverse (partialInverse becomes everywhere-defined)
@@ -200,6 +204,50 @@ def isGFree (g : ℕ → ℕ) (n : ℕ) : Prop := ∀ k, g k ≠ n
 theorem isGFree_iff_not_mem_range (g : ℕ → ℕ) (n : ℕ) :
     isGFree g n ↔ n ∉ Set.range g := by
   simp only [isGFree, Set.mem_range, not_exists, ne_eq]
+
+/-!
+## Section 4a: The Σ₁ / Π₁ complexity of `range g` — machine-checked
+
+The docstrings above justify the failure of the naive orbit classification by the
+*complexity* of `range g`: for a merely computable injection it is only
+computably enumerable (`Σ₁`), so its complement `isGFree g` is `Π₁`. Here we turn
+that prose into actual theorems. `REPred` (Mathlib, `Computability/Halting`) is the
+predicate "is the domain of a computable partial function", i.e. computably
+enumerable. Since `partialInverse g` is partial recursive (Section 3) and its domain
+is *exactly* `range g`, `Partrec.dom_re` gives `REPred (· ∈ range g)` directly.
+-/
+
+/-- The partial inverse `partialInverse g` is defined at `m` **iff** `m ∈ range g`.
+    (No injectivity needed: `rfind` halts exactly when a preimage exists.) This
+    identifies `range g` with the domain of a partial recursive function. -/
+theorem partialInverse_dom_iff_mem_range (g : ℕ → ℕ) (m : ℕ) :
+    (partialInverse g m).Dom ↔ m ∈ Set.range g := by
+  rw [Set.mem_range]
+  constructor
+  · intro h
+    obtain ⟨n, hn⟩ := Part.dom_iff_mem.mp h
+    exact ⟨n, by simpa using Nat.rfind_spec hn⟩
+  · exact fun hm => partialInverse_dom hm
+
+/-- **`range g` is computably enumerable (`Σ₁`)** for any computable `g`.
+
+    This is the machine-checked form of the "`range g` is c.e." claim used
+    throughout to explain why the classical Schröder–Bernstein orbit classification
+    is not computable. `REPred p` means `p` is the halting domain of a computable
+    partial function; here that function is `partialInverse g`. -/
+theorem mem_range_re {g : ℕ → ℕ} (hg : Computable g) :
+    REPred (fun n => n ∈ Set.range g) :=
+  (partialInverse_partrec hg).dom_re.of_eq (fun n => partialInverse_dom_iff_mem_range g n)
+
+/-- **The complement of `isGFree g` is computably enumerable.** Equivalently,
+    `isGFree g` is co-c.e. (`Π₁`): its negation `· ∈ range g` is `REPred`. Combined
+    with `isGFree_iff_not_mem_range`, this pins down the exact complexity of the
+    obstruction predicate — it is the complement of a c.e. set, hence in general
+    not itself computable, which is precisely why the orbit type of `n` cannot be
+    decided by bounded search. -/
+theorem not_isGFree_re {g : ℕ → ℕ} (hg : Computable g) :
+    REPred (fun n => ¬ isGFree g n) :=
+  (mem_range_re hg).of_eq fun n => by rw [isGFree_iff_not_mem_range, not_not]
 
 /-!
 ## Section 4b: Isolating the Π₁ obstruction — the fully computable case

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -33,7 +33,31 @@ two computable injections yield a *computable* permutation — is the OPEN targe
   test `p n`/`q v` directly. `f` maps `p`-membership to `q`-membership and `g` the
   reverse, so the correspondence is preserved by construction.
 
-## Built this session (all proved, file compiles clean)
+## Built 07-01 (researcher-11) — Σ₁/Π₁ complexity made machine-checked
+
+The docstrings repeatedly assert "`range g` is c.e. (`Σ₁`), so `isGFree g` is `Π₁`"
+purely in prose. Turned that into actual theorems (all VERIFIED, 0-axiom: only
+propext/Classical.choice/Quot.sound; no sorryAx, no ofReduceBool):
+
+- `partialInverse_dom_iff_mem_range` — `(partialInverse g m).Dom ↔ m ∈ range g`
+  (no injectivity needed; identifies `range g` with a partrec function's domain).
+- `mem_range_re` — `Computable g → REPred (· ∈ range g)`, i.e. `range g` is c.e.
+  Proof: `(partialInverse_partrec hg).dom_re.of_eq …`. `REPred`/`Partrec.dom_re`
+  live in `Mathlib.Computability.Halting` (added to imports).
+- `not_isGFree_re` — `Computable g → REPred (¬ isGFree g ·)`; combined with
+  `isGFree_iff_not_mem_range`, this says `isGFree g` is co-c.e. (`Π₁`).
+
+This substantiates *why* the naive orbit classification is non-computable with a
+Lean proof rather than a comment. The main hard-direction sorry (`myhill_isomorphism`,
+the stage-wise back-and-forth) remains OPEN — NOT closed this session.
+
+Caution on the "decidable ranges → computable SB" partial win (old Next Step #4):
+even with `range f`, `range g` decidable the backward chain can be genuinely infinite,
+and distinguishing "infinite chain" from "eventually hits an f-free element" needs an
+unbounded search — so decidable ranges alone do NOT obviously give a computable
+classification. Treat that suggested milestone with care.
+
+## Built earlier (all proved, file compiles clean)
 
 - `partialInverse_unique` — partial inverse is single-valued under injective `g`
   (collision-freeness for range-side extension).

--- a/src/data/proofs/konigsberg-oq-05/annotations.json
+++ b/src/data/proofs/konigsberg-oq-05/annotations.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "ann-odd-iff-endpoint",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 51,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "Endpoint ⟺ Odd Degree",
+    "content": "The central lemma: for an Eulerian trail from $u$ to $v$ with $u \\neq v$, a vertex $w$ has odd degree iff it is an endpoint. The proof rewrites `Odd` as `¬ Even` and unfolds Mathlib's `even_degree_iff` to `¬(u \\neq v \\to w \\neq u \\land w \\neq v)`. The forward direction is a purely propositional `by_contra`; the backward direction feeds the hypothesis $u \\neq v$ into the guarded implication and eliminates the endpoint disjunction. The backward (endpoint ⟹ odd) direction is the genuinely new content relative to the sibling KonigsbergOQ01.",
+    "mathContext": "$\\mathrm{Odd}(\\deg_G w) \\iff (w = u \\lor w = v)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Eulerian trail",
+      "vertex degree parity",
+      "IsEulerian.even_degree_iff"
+    ],
+    "prerequisites": [
+      "SimpleGraph.Walk.IsEulerian",
+      "Nat parity (Even/Odd)"
+    ]
+  },
+  {
+    "id": "ann-odd-set",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 79,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "Odd-Degree Vertices Are Exactly {u, v}",
+    "content": "Repackages the endpoint biconditional as a set equality: the set of odd-degree vertices of a graph carrying an open Eulerian trail equals the two-element endpoint set $\\{u, v\\}$. Proved by `ext` followed by the pointwise biconditional.",
+    "mathContext": "$\\{w \\mid \\mathrm{Odd}(\\deg_G w)\\} = \\{u, v\\}$",
+    "significance": "important",
+    "relatedConcepts": [
+      "set extensionality",
+      "odd-degree vertex set"
+    ],
+    "prerequisites": [
+      "Set.ext"
+    ]
+  },
+  {
+    "id": "ann-card-two",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 90,
+      "endLine": 100
+    },
+    "type": "theorem",
+    "title": "Exactly Two Odd-Degree Vertices",
+    "content": "Sharpens Mathlib's `card_odd_degree` (which gives 0 or 2) to exactly 2 in the open-trail case. The count-0 branch is excluded because the endpoint $u$ is a concrete odd-degree witness, making the subtype nonempty; `Fintype.card_pos_iff` and `omega` finish.",
+    "mathContext": "$|\\{w \\mid \\mathrm{Odd}(\\deg_G w)\\}| = 2$",
+    "significance": "important",
+    "relatedConcepts": [
+      "IsEulerian.card_odd_degree",
+      "Fintype.card_pos_iff"
+    ],
+    "prerequisites": [
+      "Fintype cardinality"
+    ]
+  },
+  {
+    "id": "ann-circuit-no-odd",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 111,
+      "endLine": 129
+    },
+    "type": "theorem",
+    "title": "A Circuit Has No Odd-Degree Vertices",
+    "content": "The closed-trail complement: for an Eulerian circuit ($u = u$) every vertex has even degree, so the odd-degree set is empty and its cardinality is 0. Here `even_degree_iff` specialises to $u = v$, where the guard $u \\neq v$ is false and the implication holds vacuously for every vertex.",
+    "mathContext": "$\\{w \\mid \\mathrm{Odd}(\\deg_G w)\\} = \\varnothing, \\quad |\\{w \\mid \\mathrm{Odd}(\\deg_G w)\\}| = 0$",
+    "significance": "important",
+    "relatedConcepts": [
+      "Eulerian circuit",
+      "even degree",
+      "IsEmpty"
+    ],
+    "prerequisites": [
+      "Fintype.card_eq_zero_iff"
+    ]
+  }
+]

--- a/src/data/proofs/konigsberg-oq-05/meta.json
+++ b/src/data/proofs/konigsberg-oq-05/meta.json
@@ -1,0 +1,110 @@
+{
+  "id": "konigsberg-oq-05",
+  "title": "Endpoints of an Eulerian Trail Are Exactly the Odd-Degree Vertices",
+  "slug": "konigsberg-oq-05",
+  "description": "Completes the degree characterization of Eulerian trails on finite simple graphs: for an open trail (distinct endpoints u ≠ v) a vertex has odd degree iff it is one of the two endpoints, so the odd-degree set is exactly {u, v} and its cardinality is exactly 2 — sharpening Mathlib's `card_odd_degree` (which only gives 0 or 2). For a closed trail (circuit) the odd-degree set is empty. Together this gives the sharp open/closed dichotomy.",
+  "meta": {
+    "author": "Leonhard Euler (1736); characterization folklore",
+    "date": "1736",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KonigsbergOQ05.lean",
+    "tags": [
+      "graph-theory",
+      "eulerian-trail",
+      "euler-circuits",
+      "parity",
+      "vertex-degree"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked; depends only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
+    "lineCount": 130,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Euler's 1736 solution of the Königsberg bridges problem established the parity criterion for traversability: an Eulerian trail exists iff the graph is connected and has zero or two vertices of odd degree. The refinement made precise here — that when there are two odd-degree vertices, they are *precisely* the endpoints of any Eulerian trail — is the natural sharpening that most textbook treatments state informally. Mathlib formalizes the counting half of the criterion in `SimpleGraph.Walk.IsEulerian.card_odd_degree` (the odd-degree vertices number 0 or 2) and the parity condition in `even_degree_iff` (in the awkward form `Even (G.degree x) ↔ (u ≠ v → x ≠ u ∧ x ≠ v)`), but stops short of the clean biconditional `Odd (G.degree w) ↔ (w = u ∨ w = v)` and the exact set/count equalities.",
+    "problemStatement": "For a finite simple graph G with an Eulerian trail p from u to v: (open case, u ≠ v) show Odd (G.degree w) ↔ w = u ∨ w = v, hence {w | Odd (G.degree w)} = {u, v} and its cardinality is exactly 2; (closed case, circuit) show {w | Odd (G.degree w)} = ∅ with cardinality 0.",
+    "proofStrategy": "The whole file is a thin but complete derivation from Mathlib's `IsEulerian.even_degree_iff` and `IsEulerian.card_odd_degree`. The central lemma rewrites `Odd` as `¬ Even` and unfolds `even_degree_iff`; with u ≠ v in hand the guarded implication collapses to `¬(w ≠ u ∧ w ≠ v)`, i.e. `w = u ∨ w = v`. The new mathematical content over the sibling `KonigsbergOQ01` (which proves only non-endpoint ⟹ even) is the converse endpoint ⟹ odd direction, obtained purely propositionally. From the biconditional the endpoint-odd corollaries, the set equality, and — using the endpoint u as a nonempty witness to rule out the count-0 branch — the exact count = 2 all follow. The circuit case specialises `even_degree_iff` at u = v, where the implication is vacuously true, giving every vertex even degree and an empty odd-degree set.",
+    "keyInsights": [
+      "Mathlib's `even_degree_iff` phrases the criterion as a guarded implication `Even (G.degree x) ↔ (u ≠ v → x ≠ u ∧ x ≠ v)`; supplying the hypothesis u ≠ v is exactly what turns it into the clean endpoint biconditional.",
+      "The genuinely new half is the converse endpoint ⟹ odd: the sibling file KonigsbergOQ01 only established non-endpoint ⟹ even, one direction short of 'exactly the endpoints'.",
+      "The exact count = 2 is a strict sharpening of Mathlib's `card_odd_degree` (0 ∨ 2): the endpoint u is a concrete odd-degree witness, so the count cannot be 0 for an open trail.",
+      "The open/closed dichotomy is unified: distinct endpoints ⟹ odd-degree set = {u, v} (count 2); a circuit ⟹ odd-degree set = ∅ (count 0), the two vacuous/nonvacuous branches of the same guarded implication."
+    ]
+  },
+  "sections": [
+    {
+      "id": "open-trail",
+      "title": "Open Trail: Odd-Degree Vertices Are Exactly the Endpoints",
+      "startLine": 39,
+      "endLine": 100,
+      "summary": "The endpoint biconditional Odd (G.degree w) ↔ (w = u ∨ w = v) for u ≠ v, the two endpoint-odd corollaries, the set equality {w | Odd (G.degree w)} = {u, v}, and the exact count = 2."
+    },
+    {
+      "id": "closed-trail",
+      "title": "Closed Trail (Circuit): No Odd-Degree Vertices",
+      "startLine": 102,
+      "endLine": 130,
+      "summary": "For an Eulerian circuit the odd-degree set is empty and its cardinality is 0, the vacuous complement of the open-trail case."
+    }
+  ],
+  "conclusion": {
+    "summary": "A short, fully machine-checked (0-axiom) completion of the Eulerian-trail degree criterion: for an open trail the odd-degree vertices are exactly the two endpoints (set = {u, v}, count = 2), and for a circuit there are none. This packages Mathlib's `even_degree_iff` and `card_odd_degree` into the quotable endpoint characterization, adding the converse (endpoint ⟹ odd) direction that the sibling KonigsbergOQ01 left open.",
+    "implications": "Gives a directly usable statement for reasoning about where an Eulerian trail can start and end: the two odd-degree vertices are forced to be its endpoints. Combined with the existence (sufficiency) direction, this pins down the endpoints of any Eulerian trail from the degree sequence alone.",
+    "openQuestions": [
+      "Can the sufficiency direction (connected + exactly two odd vertices ⟹ an Eulerian trail exists with those vertices as endpoints) be added to obtain the full biconditional endpoint criterion in Lean?",
+      "Does the analogous 'imbalanced vertices are exactly the endpoints' statement for directed Eulerian paths (via out-degree − in-degree) admit the same clean packaging over KonigsbergOQ02's digraph framework?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "konigsberg",
+      "relationship": "extends",
+      "description": "Root Königsberg entry: Euler's impossibility proof rests on the odd-degree count; this entry sharpens the criterion to locate the odd-degree vertices exactly at the trail's endpoints."
+    },
+    {
+      "targetId": "konigsberg-oq-01",
+      "relationship": "complementary",
+      "description": "KonigsbergOQ01 proves the non-endpoint ⟹ even-degree half (euler_trail_non_endpoint_even) and the 0-or-2 count; this entry supplies the missing converse (endpoint ⟹ odd) to obtain the two-sided 'exactly the endpoints' characterization and the exact count = 2."
+    },
+    {
+      "targetId": "konigsberg-oq-02",
+      "relationship": "related",
+      "description": "The directed Euler theorem characterizes Eulerian paths via in-degree/out-degree imbalance; this entry is the undirected parity analogue, locating the two odd-degree vertices at the endpoints."
+    }
+  ],
+  "leanFile": {
+    "namespace": "KonigsbergOQ05",
+    "lineCount": 130,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/KonigsbergOQ05.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Leonhard Euler"
+      ],
+      "title": "Solutio problematis ad geometriam situs pertinentis",
+      "year": 1736,
+      "venue": "Commentarii academiae scientiarum Petropolitanae 8, 128–140",
+      "note": "The Königsberg bridges problem and the odd-degree criterion for Eulerian trails."
+    },
+    {
+      "authors": [
+        "J. A. Bondy",
+        "U. S. R. Murty"
+      ],
+      "title": "Graph Theory",
+      "year": 2008,
+      "venue": "Graduate Texts in Mathematics 244, Springer",
+      "note": "Eulerian trails: the two odd-degree vertices are the endpoints of the trail."
+    }
+  ]
+}

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -231,6 +231,7 @@
     "imports": [
       "Mathlib.Computability.Reduce",
       "Mathlib.Computability.Partrec",
+      "Mathlib.Computability.Halting",
       "Mathlib.Computability.Primrec",
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Tactic"
@@ -241,10 +242,10 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 269,
+    "lineCount": 444,
     "axiomCount": 0,
-    "theoremCount": 14,
-    "definitionCount": 4,
+    "theoremCount": 26,
+    "definitionCount": 6,
     "sorries": 1,
     "path": "Proofs/SchroederBernsteinOQ03.lean",
     "additionalFiles": [


### PR DESCRIPTION
## Summary

Completes the degree characterization of Eulerian trails on finite simple graphs. Mathlib gives `IsEulerian.even_degree_iff` (in the awkward guarded form `Even (G.degree x) ↔ (u ≠ v → x ≠ u ∧ x ≠ v)`) and `IsEulerian.card_odd_degree` (count is `0 ∨ 2`), and the sibling `KonigsbergOQ01` derives only the *non-endpoint ⟹ even* half. This entry supplies the missing converse and the clean packaging:

**Open trail (u ≠ v):**
- `euler_trail_odd_iff_endpoint` — `Odd (G.degree w) ↔ (w = u ∨ w = v)` (the converse *endpoint ⟹ odd* is the new content)
- `euler_trail_left_odd` / `euler_trail_right_odd` — both endpoints have odd degree
- `euler_trail_odd_set` — `{w | Odd (G.degree w)} = {u, v}`
- `euler_trail_card_odd_eq_two` — exactly 2 odd-degree vertices, sharpening Mathlib's `0 ∨ 2` (the endpoint `u` witnesses that the count is nonzero)

**Closed trail (circuit, u = v):**
- `euler_circuit_no_odd` — `{w | Odd (G.degree w)} = ∅`
- `euler_circuit_card_odd_eq_zero` — count is 0

Together: the sharp open/closed dichotomy, locating the two odd-degree vertices exactly at the trail's endpoints.

## Verification

- **7 theorems, 0 definitions, 130 lines, 0 sorries, 0 axioms** (`#print axioms` lists only `propext` / `Classical.choice` / `Quot.sound`).
- Compiled with `lake env lean` (toolchain v4.26.0); Docker unavailable (containerd meta.db I/O error).
- Gallery `pnpm build` passes; new entry `src/data/proofs/konigsberg-oq-05/` (meta + annotations) auto-discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added: schroeder-bernstein-oq-03 (Myhill isomorphism, complexity of the obstruction)

A second, independent research increment on the same branch. The Myhill file's
docstrings repeatedly justify why the naive Schröder–Bernstein orbit classification
fails by appeal to the *complexity* of `range g` ("c.e./Σ₁, so `isGFree g` is Π₁"),
but only in prose. This makes that claim machine-checked:

- `partialInverse_dom_iff_mem_range` — `(partialInverse g m).Dom ↔ m ∈ Set.range g`
  (no injectivity needed): identifies `range g` with the domain of a partial
  recursive function.
- `mem_range_re` — `Computable g → REPred (· ∈ Set.range g)`: **`range g` is c.e. (Σ₁)**,
  via `(partialInverse_partrec hg).dom_re`.
- `not_isGFree_re` — `Computable g → REPred (¬ isGFree g ·)`: with
  `isGFree_iff_not_mem_range`, **`isGFree g` is co-c.e. (Π₁)** — the exact obstruction.

Uses Mathlib's `REPred` / `Partrec.dom_re` (`Computability.Halting`, added to imports).
All three depend only on `propext` / `Classical.choice` / `Quot.sound` (no `sorryAx`,
no `Lean.ofReduceBool`) — **VERIFIED, 0-axiom**. Compiled with `lake env lean` v4.26.0.

The hard-direction sorry (`myhill_isomorphism`, the stage-wise back-and-forth priority
construction) **remains OPEN** — this PR does not close it. Also refreshes stale
`leanFile` meta counts for the entry (14→26 theorems, 269→444 lines, +Halting import).
