### PR TITLE
research(cauchy-schwarz-oq-01-oq-02-oq-01-oq-03): projection onto a subspace as a sum of rank-one projectors [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean
@@ -1,0 +1,192 @@
+/-
+# From Rank-One to Finite-Rank — Projection onto a Subspace as a Sum of Rank-One Projectors
+
+Open Question (cauchy-schwarz-oq-01-oq-02-oq-01-oq-03), a follow-up to
+`CauchySchwarzOQ01OQ02OQ01.lean` (one Gram-Schmidt step is an orthogonal projector).
+
+The parent file established, for a single non-zero vector `v`, that
+`orthProj v x = (⟪v,x⟫/⟪v,v⟫) • v` is the orthogonal projector onto `span{v}`
+(idempotent, complementary residual, exact norm). This file proves the **finite-rank
+generalization**: the orthogonal projection onto the span of a finite orthonormal family
+`e : Fin k → E` is the **sum of the rank-one projectors** over that family, together with
+the **Parseval / Bessel equality on the subspace**. Zero axioms, zero sorries.
+
+Concretely, writing `subProj e x = ∑ i, ⟪e i, x⟫ • e i` and
+`S = span 𝕜 (range e)`:
+
+* **Sum-of-rank-one-projectors identity** `S.starProjection x = ∑ i, ⟪e i, x⟫ • e i`
+  (`subProj_eq_starProjection`) — the headline: Mathlib's orthogonal projection *is*
+  the sum of the one-line projectors. Also as `orthogonalProjection`
+  (`coe_orthogonalProjection_eq_subProj`).
+* **Residual orthogonality** `⟪e j, x - subProj e x⟫ = 0` and, extended to the whole
+  subspace, `∀ w ∈ S, ⟪x - subProj e x, w⟫ = 0`.
+* **Parseval equality on `S`** `‖subProj e x‖² = ∑ i, ‖⟪e i, x⟫‖²`
+  (`norm_subProj_sq`) — the attained (equality) case of Bessel's inequality, with the
+  Bessel bound `‖subProj e x‖² ≤ ‖x‖²` as a corollary.
+* **Idempotency** `subProj e (subProj e x) = subProj e x` and **reconstruction**
+  `subProj e x + (x - subProj e x) = x`.
+* **`k = 1` recovery** `subProj e x = ⟪e 0, x⟫ • e 0` — the one-term sum is exactly the
+  parent's rank-one projector.
+
+The subspace `S = span (range e)` is finite-dimensional, hence complete, so
+`orthogonalProjection`/`starProjection` are well defined with no completeness hypothesis
+on `E`. The scalar field `𝕜` is an arbitrary `RCLike` field (so `ℝ` and `ℂ` at once),
+kept as an explicit argument of `subProj` as in the parent file.
+-/
+
+import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+import Mathlib.Analysis.InnerProductSpace.Orthonormal
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.Topology.Algebra.Module.FiniteDimension
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+
+open scoped InnerProductSpace
+open RCLike
+
+namespace CauchySchwarzOQ01OQ02OQ01OQ03
+
+variable (𝕜 : Type*) [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+/-! ## The span of a finite family is finite-dimensional, hence complete -/
+
+/-- The span of a finite family is finite-dimensional (so `orthogonalProjection` exists
+without any completeness hypothesis on the ambient space `E`). -/
+instance finiteDimensional_span_range {k : ℕ} (e : Fin k → E) :
+    FiniteDimensional 𝕜 (Submodule.span 𝕜 (Set.range e)) :=
+  FiniteDimensional.span_of_finite 𝕜 (Set.finite_range e)
+
+/-- A finite-dimensional subspace over the complete field `𝕜` is complete, so it has an
+orthogonal projection. -/
+instance completeSpace_span_range {k : ℕ} (e : Fin k → E) :
+    CompleteSpace (Submodule.span 𝕜 (Set.range e)) :=
+  FiniteDimensional.complete 𝕜 _
+
+/-! ## Definition: the finite-rank projection as a sum of rank-one projectors -/
+
+/-- The finite-rank projection of `x` onto the family `e`: the sum of the rank-one
+projectors `x ↦ ⟪e i, x⟫ • e i`. For an orthonormal `e` this is the orthogonal
+projection onto `span (range e)` (`subProj_eq_starProjection`). -/
+noncomputable def subProj {k : ℕ} (e : Fin k → E) (x : E) : E :=
+  ∑ i, ⟪e i, x⟫_𝕜 • e i
+
+/-! ## Membership and coordinates -/
+
+/-- `subProj e x` lies in the span of the family. -/
+theorem subProj_mem_span {k : ℕ} (e : Fin k → E) (x : E) :
+    subProj 𝕜 e x ∈ Submodule.span 𝕜 (Set.range e) := by
+  refine Submodule.sum_mem _ ?_
+  intro i _
+  exact Submodule.smul_mem _ _ (Submodule.subset_span (Set.mem_range_self i))
+
+/-- Coordinate extraction: for an orthonormal family, `⟪e j, subProj e x⟫ = ⟪e j, x⟫`.
+The projection has the same coordinates as `x` along each `e j`. -/
+theorem inner_subProj {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) (j : Fin k) :
+    ⟪e j, subProj 𝕜 e x⟫_𝕜 = ⟪e j, x⟫_𝕜 := by
+  unfold subProj
+  exact he.inner_right_fintype (fun i => ⟪e i, x⟫_𝕜) j
+
+/-! ## Residual orthogonality -/
+
+/-- The residual `x - subProj e x` is orthogonal to every basis vector `e j`. -/
+theorem inner_residual {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) (j : Fin k) :
+    ⟪e j, x - subProj 𝕜 e x⟫_𝕜 = 0 := by
+  rw [inner_sub_right, inner_subProj 𝕜 he x j, sub_self]
+
+/-- The residual `x - subProj e x` is orthogonal to the *whole* subspace `span (range e)`,
+not merely to each `e j`. This is the defining orthogonality property of the projection. -/
+theorem residual_orthogonal_span {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    ∀ w ∈ Submodule.span 𝕜 (Set.range e), ⟪x - subProj 𝕜 e x, w⟫_𝕜 = 0 := by
+  intro w hw
+  refine Submodule.span_induction
+    (p := fun w _ => ⟪x - subProj 𝕜 e x, w⟫_𝕜 = 0) ?_ ?_ ?_ ?_ hw
+  · rintro y ⟨j, rfl⟩
+    rw [inner_eq_zero_symm]
+    exact inner_residual 𝕜 he x j
+  · simp
+  · intro a b _ _ pa pb
+    rw [inner_add_right, pa, pb, add_zero]
+  · intro c a _ pa
+    rw [inner_smul_right, pa, mul_zero]
+
+/-! ## Part I: The sum-of-rank-one-projectors identity (headline) -/
+
+/-- **Main theorem.** For a finite orthonormal family `e`, the orthogonal projection onto
+`S = span (range e)` equals the sum of the rank-one projectors:
+`S.starProjection x = ∑ i, ⟪e i, x⟫ • e i`. This is the operator identity
+`P_S = ∑ i, e_i e_i^*` (a finite-rank resolution of the identity). -/
+theorem subProj_eq_starProjection {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    (Submodule.span 𝕜 (Set.range e)).starProjection x = subProj 𝕜 e x :=
+  Submodule.eq_starProjection_of_mem_of_inner_eq_zero
+    (subProj_mem_span 𝕜 e x) (residual_orthogonal_span 𝕜 he x)
+
+/-- The same identity phrased with the subspace-valued `orthogonalProjection`. -/
+theorem coe_orthogonalProjection_eq_subProj {k : ℕ} {e : Fin k → E}
+    (he : Orthonormal 𝕜 e) (x : E) :
+    (((Submodule.span 𝕜 (Set.range e)).orthogonalProjection x : Submodule.span 𝕜 (Set.range e)) : E)
+      = subProj 𝕜 e x := by
+  rw [Submodule.coe_orthogonalProjection_apply]
+  exact subProj_eq_starProjection 𝕜 he x
+
+/-! ## Part II: Parseval / Bessel equality on the subspace -/
+
+/-- **Parseval equality on `S`.** The squared norm of the projection is the sum of the
+squared coordinate moduli: `‖subProj e x‖² = ∑ i, ‖⟪e i, x⟫‖²`. This is the attained
+(equality) form of Bessel's inequality, restricted to the subspace `S`. -/
+theorem norm_subProj_sq {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    ‖subProj 𝕜 e x‖ ^ 2 = ∑ i, ‖⟪e i, x⟫_𝕜‖ ^ 2 := by
+  rw [@norm_sq_eq_re_inner 𝕜]
+  unfold subProj
+  rw [he.inner_sum (fun i => ⟪e i, x⟫_𝕜) (fun i => ⟪e i, x⟫_𝕜) Finset.univ, map_sum]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [RCLike.conj_mul]
+  norm_cast
+
+/-- **Bessel's inequality** as a corollary: `‖subProj e x‖² ≤ ‖x‖²`. -/
+theorem norm_subProj_sq_le {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    ‖subProj 𝕜 e x‖ ^ 2 ≤ ‖x‖ ^ 2 := by
+  rw [norm_subProj_sq 𝕜 he x]
+  exact he.sum_inner_products_le x
+
+/-! ## Part III: Idempotency and reconstruction (projector axioms) -/
+
+/-- **Idempotency** `P² = P`: `subProj e (subProj e x) = subProj e x`. -/
+theorem subProj_idempotent {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    subProj 𝕜 e (subProj 𝕜 e x) = subProj 𝕜 e x := by
+  simp only [subProj]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [he.inner_right_fintype (fun j => ⟪e j, x⟫_𝕜) i]
+
+/-- **Reconstruction** `P + (1 − P) = id`: the projection and residual sum to `x`. -/
+theorem subProj_add_residual {k : ℕ} (e : Fin k → E) (x : E) :
+    subProj 𝕜 e x + (x - subProj 𝕜 e x) = x := by
+  abel
+
+/-! ## Part IV: The `k = 1` case recovers the parent's rank-one projector -/
+
+/-- For a single-vector family, `subProj` is the one-term sum `⟪e 0, x⟫ • e 0`, i.e. the
+parent file's rank-one orthogonal projector onto the line `span{e 0}`. -/
+theorem subProj_one (e : Fin 1 → E) (x : E) :
+    subProj 𝕜 e x = ⟪e 0, x⟫_𝕜 • e 0 := by
+  simp [subProj]
+
+/-! ## Part V: Capstone -/
+
+/-- **Summary.** For a finite orthonormal family `e` with span `S`, the map
+`subProj e = ∑ i ⟪e i, ·⟫ • e i` is the orthogonal projection onto `S`: it agrees with
+Mathlib's `starProjection`, its residual is orthogonal to `S`, it satisfies the Parseval
+equality on `S`, and it is idempotent. -/
+theorem subProj_is_orthogonal_projection {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) :
+    (∀ x : E, (Submodule.span 𝕜 (Set.range e)).starProjection x = subProj 𝕜 e x) ∧
+    (∀ x : E, ∀ w ∈ Submodule.span 𝕜 (Set.range e), ⟪x - subProj 𝕜 e x, w⟫_𝕜 = 0) ∧
+    (∀ x : E, ‖subProj 𝕜 e x‖ ^ 2 = ∑ i, ‖⟪e i, x⟫_𝕜‖ ^ 2) ∧
+    (∀ x : E, subProj 𝕜 e (subProj 𝕜 e x) = subProj 𝕜 e x) :=
+  ⟨fun x => subProj_eq_starProjection 𝕜 he x,
+   fun x => residual_orthogonal_span 𝕜 he x,
+   fun x => norm_subProj_sq 𝕜 he x,
+   fun x => subProj_idempotent 𝕜 he x⟩
+
+end CauchySchwarzOQ01OQ02OQ01OQ03

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/annotations.json
@@ -1,0 +1,150 @@
+[
+  {
+    "id": "ann-overview",
+    "title": "From One Line to a Subspace",
+    "type": "concept",
+    "startLine": 1,
+    "endLine": 52,
+    "mathContext": "The parent (cauchy-schwarz-oq-01-oq-02-oq-01) proved that projecting onto a single line span{v} is the rank-one map x ↦ ⟪e,x⟫•e and is a genuine orthogonal projector. This file generalizes to a k-dimensional subspace S = span(range e) spanned by a finite orthonormal family: the projection onto S is the sum of the rank-one projectors, P_S x = ∑ i ⟪e i, x⟫ • e i, and its squared norm is the sum of squared coordinates (Parseval on S).",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthogonal projection",
+      "resolution of the identity",
+      "Parseval's identity",
+      "Bessel's inequality",
+      "orthonormal basis"
+    ],
+    "prerequisites": [
+      "inner product spaces over an RCLike field",
+      "orthonormal families",
+      "orthogonal projection onto a complete subspace"
+    ],
+    "content": "The finite-rank orthogonal projection is the sum of the one-line projectors over an orthonormal basis of the subspace — a finite-rank resolution of the identity P_S = ∑ i e_i e_i^*.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 52 }
+  },
+  {
+    "id": "ann-completeness",
+    "title": "Why the Projection Exists Without Assuming E Complete",
+    "type": "technique",
+    "startLine": 54,
+    "endLine": 66,
+    "mathContext": "Mathlib's orthogonalProjection/starProjection require the subspace to have a HasOrthogonalProjection instance, which follows from completeness. Here S = span(range e) is spanned by finitely many vectors, so FiniteDimensional.span_of_finite (applied to Set.finite_range e) makes it finite-dimensional, and FiniteDimensional.complete over the complete field 𝕜 makes it complete. These are registered as instances so the projection elaborates automatically — no completeness hypothesis on the ambient E is needed.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "finite-dimensional subspaces",
+      "completeness",
+      "typeclass instances"
+    ],
+    "prerequisites": [
+      "finite-dimensional vector spaces",
+      "completeness of finite-dimensional spaces over a complete field"
+    ],
+    "content": "Finite-dimensionality of the span, not completeness of E, is what makes the orthogonal projection well defined.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 54, "endLine": 66 }
+  },
+  {
+    "id": "ann-coordinates",
+    "title": "Coordinate Preservation",
+    "type": "concept",
+    "startLine": 79,
+    "endLine": 90,
+    "mathContext": "For an orthonormal family, Orthonormal.inner_right_fintype gives ⟪e j, ∑ i l i • e i⟫ = l j — the inner product with a basis vector picks out its coefficient. With l i = ⟪e i, x⟫ this yields ⟪e j, subProj e x⟫ = ⟪e j, x⟫: the projection has exactly the same coordinates along each e j as x.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthonormality",
+      "coordinate extraction",
+      "Kronecker delta"
+    ],
+    "prerequisites": [
+      "orthonormal families",
+      "linearity of the inner product"
+    ],
+    "content": "The projection keeps x's coordinates along the basis; the residual carries everything orthogonal to S.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 79, "endLine": 90 }
+  },
+  {
+    "id": "ann-residual-span",
+    "title": "From Basis-Orthogonality to Subspace-Orthogonality",
+    "type": "technique",
+    "startLine": 92,
+    "endLine": 114,
+    "mathContext": "Coordinate preservation gives ⟪e j, x − subProj e x⟫ = 0 for each basis vector. To identify subProj with the orthogonal projection we need the residual orthogonal to ALL of S, not just to each e j. Since w ↦ ⟪x − subProj e x, w⟫ is 𝕜-linear and vanishes on the spanning set range e (using conjugate symmetry inner_eq_zero_symm), Submodule.span_induction extends the vanishing to every w ∈ S.",
+    "significance": "key",
+    "relatedConcepts": [
+      "span induction",
+      "linear functionals",
+      "orthogonal complement"
+    ],
+    "prerequisites": [
+      "spans and linear combinations",
+      "conjugate symmetry of the inner product"
+    ],
+    "content": "A linear functional vanishing on a spanning set vanishes on the whole span — this promotes basis-orthogonality of the residual to subspace-orthogonality.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 92, "endLine": 114 }
+  },
+  {
+    "id": "ann-headline",
+    "title": "The Sum-of-Rank-One-Projectors Identity",
+    "type": "concept",
+    "startLine": 115,
+    "endLine": 133,
+    "mathContext": "By the uniqueness of orthogonal projection (Submodule.eq_starProjection_of_mem_of_inner_eq_zero: if v ∈ K and x − v ⊥ K then P_K x = v), the two facts subProj e x ∈ S and residual ⊥ S identify subProj e x with S.starProjection x. This is the operator identity P_S = ∑ i e_i e_i^*, the finite-rank generalization of the parent's single rank-one projector.",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniqueness of orthogonal projection",
+      "resolution of the identity",
+      "rank-one operators"
+    ],
+    "prerequisites": [
+      "orthogonal projection characterization"
+    ],
+    "content": "The headline identity: Mathlib's orthogonal projection onto S is exactly the sum of the rank-one projectors over the orthonormal basis.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 115, "endLine": 133 }
+  },
+  {
+    "id": "ann-parseval",
+    "title": "Parseval Equality as Attained Bessel",
+    "type": "concept",
+    "startLine": 134,
+    "endLine": 153,
+    "mathContext": "Expanding ‖subProj e x‖² = re ⟪subProj, subProj⟫ with Orthonormal.inner_sum collapses the double sum to the diagonal ∑ i conj⟪e i,x⟫·⟪e i,x⟫; RCLike.conj_mul turns each term into ‖⟪e i,x⟫‖². The result ‖P_S x‖² = ∑ i ‖⟪e i, x⟫‖² is the equality case of Bessel's inequality restricted to S, and Bessel's bound ‖P_S x‖² ≤ ‖x‖² follows immediately from Orthonormal.sum_inner_products_le.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Parseval's identity",
+      "Bessel's inequality",
+      "orthonormal norm expansion"
+    ],
+    "prerequisites": [
+      "norm via inner product",
+      "orthonormal double-sum collapse"
+    ],
+    "content": "The squared projection norm is exactly the sum of squared coordinate moduli — the sharp, attained form of Bessel's inequality on the subspace.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 134, "endLine": 153 }
+  },
+  {
+    "id": "ann-recovery",
+    "title": "k = 1 Recovers the Parent",
+    "type": "concept",
+    "startLine": 168,
+    "endLine": 192,
+    "mathContext": "For a single-vector orthonormal family (k = 1), the sum ∑ i ⟪e i, x⟫ • e i has one term, so subProj e x = ⟪e 0, x⟫ • e 0 — exactly the parent's rank-one projector onto the line span{e 0}. Together with idempotency (P²=P) and reconstruction (P + (1−P) = id), this exhibits the parent as the one-term special case of the finite-rank identity.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "rank-one projector",
+      "specialization",
+      "idempotent operators"
+    ],
+    "prerequisites": [
+      "the parent's rank-one projector"
+    ],
+    "content": "The single-line projector of the parent entry is the k=1 term of this sum-of-projectors identity.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 168, "endLine": 192 }
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+  "title": "Projection onto a Subspace as a Sum of Rank-One Projectors",
+  "slug": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+  "description": "A verified (0-axiom, 0-sorry) follow-up to \"One Gram-Schmidt Step is an Orthogonal Projector\". The parent proved that projecting onto a single line span{v} is the rank-one map x ↦ ⟪e,x⟫•e. This file proves the finite-rank generalization: for a finite orthonormal family e : Fin k → E spanning S = span(range e), the orthogonal projection onto S is the sum of the rank-one projectors, P_S x = ∑ i, ⟪e i, x⟫ • e i (identified with Mathlib's starProjection/orthogonalProjection), together with the Parseval equality on the subspace ‖P_S x‖² = ∑ i ‖⟪e i, x⟫‖² (the attained case of Bessel's inequality). It also derives residual orthogonality to all of S, idempotency, reconstruction, and the k=1 recovery of the parent's rank-one projector.",
+  "meta": {
+    "author": "Research formalization 2026 (researcher-9)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Parseval%27s_identity",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean",
+    "tags": [
+      "linear-algebra",
+      "inner-product-spaces",
+      "orthogonal-projection",
+      "parseval",
+      "bessel",
+      "gram-schmidt"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 192,
+    "assumptions": "None. Every theorem is verified over an arbitrary RCLike field 𝕜 and inner product space E with zero axioms and zero sorries (only foundational propext/Classical.choice/Quot.sound). The subspace S = span(range e) is finite-dimensional, hence complete, so orthogonalProjection is well defined with no completeness hypothesis on E.",
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "The parent chain formalizes the orthogonal-projection picture underlying Gram-Schmidt and Cauchy-Schwarz. The grandparent (cauchy-schwarz-oq-01-oq-02) gave one Gram-Schmidt step via Cauchy-Schwarz (bounded coefficient, orthogonal residual, Pythagoras); its child (cauchy-schwarz-oq-01-oq-02-oq-01) proved that a single step is an orthogonal projector onto a line span{v}. That entry explicitly left open whether the projector identity extends to a finite-dimensional subspace, expressed as a sum of rank-one projectors over an orthonormal basis. This file settles that question: the orthogonal projection onto S = span(range e) is exactly ∑ i ⟪e i, ·⟫ • e i.",
+    "problemStatement": "For a finite orthonormal family e : Fin k → E spanning S, is the orthogonal projection onto S the sum of the rank-one projectors x ↦ ⟪e i, x⟫ • e i, and does the squared projection norm equal the sum of squared coordinate moduli (Parseval equality on S)?",
+    "text": "Verified sum-of-rank-one-projectors identity and subspace Parseval equality for the orthogonal projection onto the span of a finite orthonormal family, over an arbitrary RCLike inner product space.",
+    "proofStrategy": "Self-contained in namespace CauchySchwarzOQ01OQ02OQ01OQ03. Define subProj e x = ∑ i, ⟪e i, x⟫ • e i directly. Prove it equals Mathlib's projection by the uniqueness characterization Submodule.eq_starProjection_of_mem_of_inner_eq_zero: (1) subProj e x ∈ S (a sum of scalar multiples of the e i), and (2) the residual x − subProj e x is orthogonal to all of S. For (2), orthonormality gives ⟪e j, subProj e x⟫ = ⟪e j, x⟫ (Orthonormal.inner_right_fintype), so ⟪e j, x − subProj e x⟫ = 0 for each basis vector, extended to the whole span by span_induction on the linear functional w ↦ ⟪x − subProj e x, w⟫. Finite-dimensionality of S (FiniteDimensional.span_of_finite on Set.finite_range) supplies completeness and hence the projection instance. Parseval follows from Orthonormal.inner_sum expanding ⟪subProj, subProj⟫ = ∑ i conj⟪e i,x⟫·⟪e i,x⟫ and RCLike.conj_mul; Bessel's inequality is then a corollary via Orthonormal.sum_inner_products_le.",
+    "keyInsights": [
+      "**Sum of rank-one projectors**: the orthogonal projection onto S = span(range e) is the operator ∑ i e_i e_i^*, i.e. P_S x = ∑ i ⟪e i, x⟫ • e i — a finite-rank resolution of the identity, the k-fold sum of the parent's single rank-one projector.",
+      "**Coordinates are preserved**: for an orthonormal family, ⟪e j, P_S x⟫ = ⟪e j, x⟫, so P_S x has the same coordinates along each e j as x itself; the residual carries the rest.",
+      "**Residual ⊥ subspace, not just basis**: proving ⟪e j, residual⟫ = 0 for each j extends to ⟪residual, w⟫ = 0 for all w ∈ S because w ↦ ⟪residual, w⟫ is linear and vanishes on a spanning set (span_induction).",
+      "**Parseval as attained Bessel**: ‖P_S x‖² = ∑ i ‖⟪e i, x⟫‖² is the equality case of Bessel's inequality ‖P_S x‖² ≤ ‖x‖²; the cross terms collapse to the diagonal by orthonormality.",
+      "**No completeness hypothesis on E**: S is finite-dimensional (spanned by finitely many vectors), hence complete over the RCLike field 𝕜, so orthogonalProjection exists regardless of whether E itself is complete."
+    ],
+    "prerequisites": [
+      "Inner product spaces over an RCLike field",
+      "Orthonormal families and Bessel's inequality",
+      "Orthogonal projection onto a complete subspace (Mathlib starProjection / orthogonalProjection)",
+      "Finite-dimensional spans and completeness",
+      "Parseval's identity / resolution of the identity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "instances",
+      "title": "Finite-dimensional span is complete",
+      "startLine": 54,
+      "endLine": 66,
+      "summary": "The span of a finite family is finite-dimensional (span_of_finite) and hence complete, so the orthogonal projection exists with no hypothesis on E.",
+      "mathContext": "$S = \\operatorname{span}(\\operatorname{range} e)$ is finite-dimensional over the complete field $\\mathbb{K}$, hence complete."
+    },
+    {
+      "id": "definition",
+      "title": "The finite-rank projection",
+      "startLine": 68,
+      "endLine": 90,
+      "summary": "subProj e x = ∑ i, ⟪e i, x⟫ • e i, its membership in S, and the coordinate-preservation lemma ⟪e j, subProj e x⟫ = ⟪e j, x⟫.",
+      "mathContext": "$\\mathrm{subProj}\\,e\\,x = \\sum_i \\langle e_i, x\\rangle\\, e_i \\in S$ with $\\langle e_j, \\mathrm{subProj}\\,e\\,x\\rangle = \\langle e_j, x\\rangle$."
+    },
+    {
+      "id": "residual",
+      "title": "Residual orthogonality",
+      "startLine": 92,
+      "endLine": 114,
+      "summary": "The residual x − subProj e x is orthogonal to each e j and, by span_induction, to the whole subspace S.",
+      "mathContext": "$\\langle e_j, x - \\mathrm{subProj}\\,e\\,x\\rangle = 0$ for all $j$, hence $\\langle x - \\mathrm{subProj}\\,e\\,x, w\\rangle = 0$ for all $w \\in S$."
+    },
+    {
+      "id": "headline",
+      "title": "Sum-of-rank-one-projectors identity",
+      "startLine": 115,
+      "endLine": 133,
+      "summary": "The headline: S.starProjection x = subProj e x (and the orthogonalProjection coercion form), via the uniqueness of orthogonal projection.",
+      "mathContext": "$P_S x = \\sum_i \\langle e_i, x\\rangle\\, e_i$, the operator identity $P_S = \\sum_i e_i e_i^{*}$."
+    },
+    {
+      "id": "parseval",
+      "title": "Parseval / Bessel equality",
+      "startLine": 134,
+      "endLine": 153,
+      "summary": "‖subProj e x‖² = ∑ i ‖⟪e i, x⟫‖² (Parseval on S) with the Bessel bound ‖subProj e x‖² ≤ ‖x‖² as a corollary.",
+      "mathContext": "$\\lVert P_S x\\rVert^2 = \\sum_i |\\langle e_i, x\\rangle|^2 \\le \\lVert x\\rVert^2$."
+    },
+    {
+      "id": "projector-axioms",
+      "title": "Idempotency, reconstruction, k=1 recovery",
+      "startLine": 154,
+      "endLine": 192,
+      "summary": "Idempotency P²=P, reconstruction P + (1−P) = id, the k=1 recovery of the parent's rank-one projector, and the capstone bundle.",
+      "mathContext": "$P_S^2 = P_S$, $P_S + (1-P_S) = \\mathrm{id}$, and for $k=1$, $P_S x = \\langle e_0, x\\rangle\\, e_0$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file verifies, with zero axioms and zero sorries, that the orthogonal projection onto the span of a finite orthonormal family is the sum of the rank-one projectors over that family, P_S x = ∑ i ⟪e i, x⟫ • e i, and that the squared projection norm equals the sum of squared coordinate moduli (the Parseval equality on the subspace, the attained case of Bessel's inequality). It also records residual orthogonality to the whole subspace, idempotency, reconstruction, and the k=1 recovery of the parent's rank-one projector.",
+    "implications": "This is the exact step that turns the rank-one Gram-Schmidt/Cauchy-Schwarz picture into the general theory of orthogonal projection: the sum-of-rank-one-projectors formula is a finite-rank resolution of the identity, and the subspace Parseval equality is the sharp form of Bessel's inequality. Concretely it is the analytic backbone of the QR decomposition and of least-squares approximation, where the best approximation of x from S is ∑ i ⟪e i, x⟫ • e i.",
+    "openQuestions": [
+      "Can the sum-of-rank-one-projectors identity be assembled into a full QR decomposition of a finite family of vectors?",
+      "Does the Parseval equality extend to a countable orthonormal basis of a separable Hilbert space (the l² case) as a limit of the finite-rank identities?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: one Gram-Schmidt step is a rank-one orthogonal projector onto a line span{v}. This file sums k of them to project onto a k-dimensional subspace, and its k=1 case recovers the parent's rank-one projector; it settles the parent's third open question."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-02",
+      "relationship": "builds-on",
+      "description": "Grandparent: Gram-Schmidt via Cauchy-Schwarz (bounded coefficient, orthogonal residual, Pythagoras)."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "builds-on",
+      "description": "The base inner-product inequality underlying Bessel's inequality and the Parseval equality."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Parseval, M.-A.",
+      "title": "Mémoire sur les séries et sur l'intégration complète d'une équation aux différences partielles linéaires du second ordre, à coefficients constants",
+      "year": "1806",
+      "venue": "Mémoires présentés à l'Institut des Sciences, Lettres et Arts",
+      "note": "Origin of Parseval's identity"
+    },
+    {
+      "authors": "Halmos, P. R.",
+      "title": "Finite-Dimensional Vector Spaces",
+      "year": "1958",
+      "venue": "Springer",
+      "note": "Orthogonal projection onto a subspace and resolution of the identity"
+    },
+    {
+      "authors": "Axler, S.",
+      "title": "Linear Algebra Done Right",
+      "year": "2015",
+      "venue": "Springer, 3rd ed.",
+      "note": "Orthonormal bases, orthogonal projections, and best approximation"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Projection.Basic",
+      "Mathlib.Analysis.InnerProductSpace.Orthonormal",
+      "Mathlib.Analysis.RCLike.Basic",
+      "Mathlib.LinearAlgebra.FiniteDimensional.Defs",
+      "Mathlib.Topology.Algebra.Module.FiniteDimension",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "CauchySchwarzOQ01OQ02OQ01OQ03",
+    "lineCount": 192,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "path": "Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Verified (0-axiom, 0-sorry) formalization of the **finite-rank generalization** of the parent's rank-one orthogonal projector (`cauchy-schwarz-oq-01-oq-02-oq-01`). For a finite orthonormal family `e : Fin k → E` spanning `S = span(range e)`, the orthogonal projection onto `S` is the **sum of the rank-one projectors**:

$$P_S\,x = \sum_{i} \langle e_i, x\rangle\, e_i \qquad (= \texttt{S.starProjection}\,x)$$

together with the **Parseval equality on the subspace**

$$\lVert P_S\,x\rVert^2 = \sum_i \lvert\langle e_i, x\rangle\rvert^2,$$

the attained (equality) case of Bessel's inequality restricted to `S`. This settles the third open question left by the parent entry ("Does the projector identity extend to a finite-dimensional subspace, expressed as a sum of rank-one projectors over an orthonormal basis?").

## Contents (`Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean`, 12 thm / 1 def / 192 L)

- `subProj_eq_starProjection` — **headline**: `S.starProjection x = ∑ i, ⟪e i, x⟫ • e i`
- `coe_orthogonalProjection_eq_subProj` — same via the subspace-valued `orthogonalProjection`
- `norm_subProj_sq` — Parseval equality on `S`; `norm_subProj_sq_le` — Bessel corollary
- `residual_orthogonal_span` — residual `⊥` all of `S` (span induction), `inner_subProj` — coordinate preservation
- `subProj_idempotent`, `subProj_add_residual` — projector axioms; `subProj_one` — `k=1` recovers the parent
- `subProj_is_orthogonal_projection` — capstone bundle

## Method

Direct definition `subProj e x = ∑ i, ⟪e i, x⟫ • e i`, identified with Mathlib's projection by the uniqueness characterization `Submodule.eq_starProjection_of_mem_of_inner_eq_zero` (membership in `S` + residual `⊥ S`). Coordinate preservation from `Orthonormal.inner_right_fintype`; residual-⊥-span by `span_induction`; Parseval from `Orthonormal.inner_sum` + `RCLike.conj_mul`; Bessel from `Orthonormal.sum_inner_products_le`. Finite-dimensionality of `S` (`FiniteDimensional.span_of_finite`) supplies completeness, so no completeness hypothesis on `E` is needed.

## Verification

- `lake env lean` compiles clean, Lean **4.26.0** / Mathlib 4.26.0
- `#print axioms` on all main theorems: only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`) → **VERIFIED, 0-axiom**
- Gallery `meta.json` + `annotations.json` added (auto-discovered; cross-referenced to parent/grandparent/base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)