### PR TITLE
research(algebraic-reals-meager-dense-gdelta-oq-03): generically Liouville — comeagre-yet-null refinement [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AlgebraicRealsMeagerDenseGDeltaOQ03.lean
+++ b/proofs/Proofs/AlgebraicRealsMeagerDenseGDeltaOQ03.lean
@@ -1,0 +1,152 @@
+import Mathlib.NumberTheory.Transcendental.Liouville.Residual
+import Mathlib.NumberTheory.Transcendental.Liouville.Measure
+import Mathlib.RingTheory.Localization.Integral
+import Mathlib.Tactic
+import Proofs.AlgebraicRealsMeagerDenseGDelta
+
+/-!
+# Generically Liouville: a Comeagre Refinement Inside the Transcendental Gδ
+
+## Open Question (algebraic-reals-meager-dense-gdelta-oq-03)
+
+The parent entry `algebraic-reals-meager-dense-gdelta` exhibits the transcendental reals
+`{x : ℝ | ¬ IsAlgebraic ℚ x}` as an explicit **dense Gδ** — the residual (comeagre) witness for
+the transcendentals. This open question asks to *refine* that picture: the transcendentals are
+comeagre, but they are not homogeneous, and one may ask **which** transcendentals are
+topologically generic.
+
+The answer is the classical Baire-category theorem for Liouville numbers, here assembled from
+Mathlib's `IsGδ.setOf_liouville` / `eventually_residual_liouville` and connected to the parent's
+transcendental Gδ. The **Liouville numbers** `{x : ℝ | Liouville x}` are themselves a dense Gδ,
+they sit *inside* the transcendentals (`Liouville.transcendental`), and — being comeagre — they
+are the topologically generic transcendentals: the transcendentals that are **not** Liouville form
+a *meagre* set. So a "generic" transcendental (in the Baire sense) is not merely transcendental but
+Liouville.
+
+The striking counterpoint is measure-theoretic. The very same Liouville set has **Lebesgue measure
+zero** (`volume_setOf_liouville`). Thus the set of Liouville numbers is simultaneously
+**comeagre** (topologically enormous) and **null** (measure-theoretically negligible), and the two
+notions of "generic transcendental" diverge completely:
+
+* the **comeagre** transcendental is Liouville (Baire genericity);
+* the **almost-every** transcendental is *non*-Liouville (measure genericity).
+
+These two genericity filters are literally disjoint (`Real.disjoint_residual_ae`).
+
+## Main Results
+
+* `liouville_subset_transcendental`: every Liouville number is transcendental over `ℚ` — the
+  bridge from Mathlib's `Transcendental ℤ` phrasing to the parent's `¬ IsAlgebraic ℚ` set, via
+  denominator clearing (`IsFractionRing.isAlgebraic_iff`).
+* `liouville_dense_isGδ`: the Liouville numbers are a dense Gδ in `ℝ`.
+* `liouville_residual`: the Liouville numbers are a residual (comeagre) set.
+* `transcendental_not_liouville_isMeagre`: **the refinement** — the non-Liouville transcendentals
+  are meagre, i.e. the generic transcendental is Liouville.
+* `eventually_residual_transcendental_liouville`: comeagrely, a real is transcendental *and*
+  Liouville.
+* `ae_transcendental_not_liouville`: almost everywhere, a real is transcendental and *not*
+  Liouville.
+* `liouville_comeagre_yet_null`: **the punchline** — the Liouville set is residual yet Lebesgue-null.
+* `generic_transcendental_dichotomy`: the Baire-vs-measure split of the generic transcendental.
+-/
+
+open Set Topology MeasureTheory Filter
+
+namespace AlgebraicRealsMeagerDenseGDeltaOQ03
+
+/-! ### The transcendence bridge: Liouville ⟹ transcendental over ℚ -/
+
+/-- **Every Liouville number is transcendental over `ℚ`.**
+
+Mathlib's `Liouville.transcendental` proves transcendence over `ℤ`. Over the *field* `ℚ` this is
+the (a priori stronger) statement that no rational-coefficient polynomial annihilates `x`; it
+follows by clearing denominators, packaged as `IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ`
+(`IsAlgebraic ℤ x ↔ IsAlgebraic ℚ x`). This lands the Liouville set inside the parent's
+transcendental Gδ `{x | ¬ IsAlgebraic ℚ x}`. -/
+theorem liouville_subset_transcendental :
+    {x : ℝ | Liouville x} ⊆ {x : ℝ | ¬ IsAlgebraic ℚ x} := by
+  intro x hx halg
+  exact hx.transcendental ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mpr halg)
+
+/-! ### The Liouville numbers are a dense Gδ / residual set -/
+
+/-- **The Liouville numbers are a Gδ in `ℝ`** (Mathlib: `IsGδ.setOf_liouville`). -/
+theorem liouville_isGδ : IsGδ {x : ℝ | Liouville x} := IsGδ.setOf_liouville
+
+/-- **The Liouville numbers are a dense Gδ in `ℝ`.** -/
+theorem liouville_dense_isGδ :
+    IsGδ {x : ℝ | Liouville x} ∧ Dense {x : ℝ | Liouville x} :=
+  ⟨IsGδ.setOf_liouville, dense_liouville⟩
+
+/-- **The Liouville numbers are a residual (comeagre) set** (Mathlib:
+`eventually_residual_liouville`). -/
+theorem liouville_residual : {x : ℝ | Liouville x} ∈ residual ℝ :=
+  eventually_residual_liouville
+
+/-! ### The refinement: the generic transcendental is Liouville -/
+
+/-- **The non-Liouville transcendentals are meagre.**
+
+`{x | ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x} ⊆ {x | ¬ Liouville x} = {x | Liouville x}ᶜ`, and the
+latter is meagre because the Liouville set is residual. Hence, *generically* (in the Baire sense),
+a transcendental real is Liouville. -/
+theorem transcendental_not_liouville_isMeagre :
+    IsMeagre {x : ℝ | ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x} := by
+  have hmeagre : IsMeagre {x : ℝ | ¬ Liouville x} := by
+    have hcompl : {x : ℝ | ¬ Liouville x}ᶜ = {x : ℝ | Liouville x} := by
+      ext x; simp only [mem_compl_iff, mem_setOf_eq, not_not]
+    show {x : ℝ | ¬ Liouville x}ᶜ ∈ residual ℝ
+    rw [hcompl]; exact liouville_residual
+  exact hmeagre.mono (fun x hx => hx.2)
+
+/-- **Comeagrely, a real is transcendental and Liouville.**
+
+Since the Liouville set is residual and every Liouville number is transcendental over `ℚ`, the
+comeagre-many reals are transcendental *and* Liouville. -/
+theorem eventually_residual_transcendental_liouville :
+    ∀ᶠ x in residual ℝ, ¬ IsAlgebraic ℚ x ∧ Liouville x :=
+  eventually_residual_liouville.mono fun _ hx => ⟨liouville_subset_transcendental hx, hx⟩
+
+/-! ### The measure-theoretic counterpoint -/
+
+/-- **Almost every real is transcendental and non-Liouville.**
+
+The algebraic reals are countable (`AlgebraicNumbersCountable.algebraic_reals_countable`), hence
+Lebesgue-null, so almost every real is transcendental; and `ae_not_liouville` says almost every
+real is non-Liouville. -/
+theorem ae_transcendental_not_liouville :
+    ∀ᵐ x : ℝ, ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x := by
+  have hae_trans : ∀ᵐ x : ℝ, ¬ IsAlgebraic ℚ x := by
+    rw [ae_iff]
+    simpa using
+      (AlgebraicNumbersCountable.algebraic_reals_countable.measure_zero volume)
+  exact hae_trans.and ae_not_liouville
+
+/-- **The Liouville set is comeagre yet Lebesgue-null.**
+
+`{x | Liouville x}` is residual (topologically generic) but has Lebesgue measure zero — a set that
+is enormous for Baire category and negligible for measure. This is the source of the divergence
+between the two notions of "generic transcendental". -/
+theorem liouville_comeagre_yet_null :
+    {x : ℝ | Liouville x} ∈ residual ℝ ∧ volume {x : ℝ | Liouville x} = 0 :=
+  ⟨liouville_residual, volume_setOf_liouville⟩
+
+/-- **The Baire-vs-measure dichotomy of the generic transcendental.**
+
+The topologically generic (comeagre) transcendental is Liouville; the measure-generic
+(almost-every) transcendental is *non*-Liouville. The two witnessing filters are disjoint
+(`Real.disjoint_residual_ae`), so no single "genericity" reconciles them. -/
+theorem generic_transcendental_dichotomy :
+    (∀ᶠ x in residual ℝ, ¬ IsAlgebraic ℚ x ∧ Liouville x) ∧
+      (∀ᵐ x : ℝ, ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x) :=
+  ⟨eventually_residual_transcendental_liouville, ae_transcendental_not_liouville⟩
+
+end AlgebraicRealsMeagerDenseGDeltaOQ03
+
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ03.liouville_subset_transcendental
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ03.liouville_dense_isGδ
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ03.transcendental_not_liouville_isMeagre
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ03.eventually_residual_transcendental_liouville
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ03.ae_transcendental_not_liouville
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ03.liouville_comeagre_yet_null
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ03.generic_transcendental_dichotomy

--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-03/annotations.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-03/annotations.json
@@ -1,0 +1,141 @@
+[
+  {
+    "id": "ann-armdg-oq03-bridge",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-03",
+    "range": { "startLine": 66, "endLine": 69 },
+    "type": "theorem",
+    "title": "Liouville ⟹ transcendental over ℚ (the fraction-ring bridge)",
+    "content": "Mathlib proves Liouville's theorem as `Liouville.transcendental : Transcendental ℤ x`, i.e. no integer-coefficient polynomial annihilates x. The parent's transcendental set is over the field ℚ. These match pointwise because ℚ = Frac(ℤ): `IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ` gives `IsAlgebraic ℤ x ↔ IsAlgebraic ℚ x`, and its `.mpr` (clear denominators) turns an ℚ-algebraic witness into a ℤ-algebraic one, contradicting ℤ-transcendence. This single step lands the Liouville set inside the parent's transcendental Gδ.",
+    "mathContext": "$\\text{Liouville}(x) \\Rightarrow \\neg\\,\\mathrm{IsAlgebraic}_{\\mathbb{Q}}(x)$, via $\\mathrm{IsAlgebraic}_{\\mathbb{Z}}(x) \\leftrightarrow \\mathrm{IsAlgebraic}_{\\mathbb{Q}}(x)$ over $\\mathbb{Q} = \\mathrm{Frac}(\\mathbb{Z})$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Liouville's theorem",
+      "transcendence",
+      "field of fractions",
+      "clearing denominators"
+    ],
+    "prerequisites": [
+      "algebraic and transcendental numbers",
+      "polynomials over ℤ and ℚ"
+    ]
+  },
+  {
+    "id": "ann-armdg-oq03-dense-gdelta",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-03",
+    "range": { "startLine": 74, "endLine": 84 },
+    "type": "theorem",
+    "title": "The Liouville numbers as a dense Gδ / residual set",
+    "content": "The topological backbone, imported from Mathlib's `Liouville.Residual`: the Liouville set is a Gδ (`IsGδ.setOf_liouville`, a countable intersection of the open shells around rationals), it is dense (`dense_liouville`), and hence residual (`eventually_residual_liouville`). By the Baire Category Theorem a dense Gδ is comeagre — topologically 'almost all' reals.",
+    "mathContext": "$\\{x \\mid \\text{Liouville}(x)\\} = \\bigcap_n \\bigcup_{a,\\,b>1} B\\!\\left(\\tfrac{a}{b}, \\tfrac{1}{b^n}\\right)\\setminus\\{\\tfrac ab\\}$ is a dense $G_\\delta$, hence residual.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Gδ set",
+      "residual set",
+      "Baire category theorem",
+      "dense set"
+    ],
+    "prerequisites": [
+      "Baire category",
+      "Gδ and comeagre sets"
+    ]
+  },
+  {
+    "id": "ann-armdg-oq03-meagre-refinement",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-03",
+    "range": { "startLine": 93, "endLine": 104 },
+    "type": "theorem",
+    "title": "HEADLINE — the generic transcendental is Liouville",
+    "content": "The refinement of the parent. The non-Liouville transcendentals `{x | ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x}` are a subset of `{x | ¬ Liouville x} = {Liouville}ᶜ`, which is meagre because the Liouville set is residual. `IsMeagre.mono` closes it in one line. So within the parent's transcendental Gδ, the Baire-generic point is not merely transcendental but Liouville.",
+    "mathContext": "$\\{x \\mid \\neg\\mathrm{Alg}_{\\mathbb{Q}}(x) \\wedge \\neg\\text{Liou}(x)\\} \\subseteq \\{x \\mid \\text{Liou}(x)\\}^c$, meagre; so generically a transcendental is Liouville.",
+    "significance": "key",
+    "relatedConcepts": [
+      "meagre set",
+      "comeagre / residual",
+      "genericity",
+      "monotonicity of meagreness"
+    ],
+    "prerequisites": [
+      "meagre sets",
+      "complement of a residual set"
+    ]
+  },
+  {
+    "id": "ann-armdg-oq03-comeagre-and",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-03",
+    "range": { "startLine": 106, "endLine": 108 },
+    "type": "theorem",
+    "title": "Comeagrely, a real is transcendental and Liouville",
+    "content": "Combining the residuality of the Liouville set with `liouville_subset_transcendental`: since comeagre-many reals are Liouville and every Liouville number is transcendental, comeagre-many reals satisfy BOTH properties. A `.mono` on the residual filter.",
+    "mathContext": "$\\forall^{\\text{comeagre}} x,\\ \\neg\\mathrm{Alg}_{\\mathbb{Q}}(x) \\wedge \\text{Liou}(x)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "residual filter",
+      "eventually",
+      "comeagre"
+    ],
+    "prerequisites": [
+      "filters",
+      "residual set"
+    ]
+  },
+  {
+    "id": "ann-armdg-oq03-ae-side",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-03",
+    "range": { "startLine": 117, "endLine": 127 },
+    "type": "theorem",
+    "title": "Almost every real is transcendental and NOT Liouville",
+    "content": "The measure-theoretic counterpoint. The algebraic reals are countable (`AlgebraicNumbersCountable.algebraic_reals_countable`), hence Lebesgue-null, so almost every real is transcendental; and `ae_not_liouville` says almost every real is non-Liouville. Conjoining gives that a.e. real is a non-Liouville transcendental — the opposite of the Baire-generic behaviour.",
+    "mathContext": "$\\forall^{\\text{a.e.}} x,\\ \\neg\\mathrm{Alg}_{\\mathbb{Q}}(x) \\wedge \\neg\\text{Liou}(x)$, using $\\mathrm{vol}\\{x \\mid \\mathrm{Alg}_{\\mathbb{Q}}(x)\\}=0$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Lebesgue measure",
+      "null set",
+      "almost everywhere",
+      "countable set"
+    ],
+    "prerequisites": [
+      "measure zero of countable sets",
+      "the a.e. filter"
+    ]
+  },
+  {
+    "id": "ann-armdg-oq03-comeagre-null",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-03",
+    "range": { "startLine": 130, "endLine": 133 },
+    "type": "theorem",
+    "title": "PUNCHLINE — comeagre yet Lebesgue-null",
+    "content": "The source of the divergence: the very same Liouville set is residual (comeagre) yet has Lebesgue measure zero (`volume_setOf_liouville`). This is the textbook example of a set that is enormous for Baire category and negligible for measure — the orthogonality of the two notions of 'almost every real', made arithmetic.",
+    "mathContext": "$\\{x \\mid \\text{Liou}(x)\\} \\in \\mathrm{residual}\\ \\mathbb{R}$ and $\\mathrm{vol}\\{x \\mid \\text{Liou}(x)\\} = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "category vs measure",
+      "comeagre set",
+      "null set",
+      "Liouville numbers"
+    ],
+    "prerequisites": [
+      "Baire category",
+      "Lebesgue measure"
+    ]
+  },
+  {
+    "id": "ann-armdg-oq03-dichotomy",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-03",
+    "range": { "startLine": 139, "endLine": 144 },
+    "type": "theorem",
+    "title": "The Baire-vs-measure dichotomy of the generic transcendental",
+    "content": "The packaged result: the comeagre (topologically generic) transcendental is Liouville, while the almost-every (measure-generic) transcendental is non-Liouville. The two witnessing filters — `residual ℝ` and `ae volume` — are disjoint (`Real.disjoint_residual_ae`), so no single genericity reconciles them. The generic transcendental has two irreconcilable answers depending on whether 'generic' means Baire or measure.",
+    "mathContext": "Comeagre: $\\neg\\mathrm{Alg}_{\\mathbb{Q}} \\wedge \\text{Liou}$;  a.e.: $\\neg\\mathrm{Alg}_{\\mathbb{Q}} \\wedge \\neg\\text{Liou}$;  on disjoint filters.",
+    "significance": "key",
+    "relatedConcepts": [
+      "genericity",
+      "disjoint filters",
+      "residual",
+      "almost everywhere"
+    ],
+    "prerequisites": [
+      "filters on ℝ",
+      "category and measure genericity"
+    ]
+  }
+]

--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-03/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-03/meta.json
@@ -1,0 +1,283 @@
+{
+  "id": "algebraic-reals-meager-dense-gdelta-oq-03",
+  "slug": "algebraic-reals-meager-dense-gdelta-oq-03",
+  "title": "Generically Liouville: A Comeagre Refinement Inside the Transcendental Gδ",
+  "status": null,
+  "badge": null,
+  "axiomCount": null,
+  "sorryCount": null,
+  "leanFile": {
+    "lineCount": 152,
+    "namespace": "AlgebraicRealsMeagerDenseGDeltaOQ03",
+    "opens": [
+      "Set",
+      "Topology",
+      "MeasureTheory",
+      "Filter"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "substantiveTheoremCount": 8,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Mathlib.NumberTheory.Transcendental.Liouville.Residual",
+      "Mathlib.NumberTheory.Transcendental.Liouville.Measure",
+      "Mathlib.RingTheory.Localization.Integral",
+      "Mathlib.Tactic",
+      "Proofs.AlgebraicRealsMeagerDenseGDelta"
+    ],
+    "path": "Proofs/AlgebraicRealsMeagerDenseGDeltaOQ03.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Liouville_number",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicRealsMeagerDenseGDeltaOQ03.lean",
+    "tags": [
+      "baire-category",
+      "real-analysis",
+      "descriptive-set-theory",
+      "liouville-numbers",
+      "transcendental-numbers",
+      "g-delta-set",
+      "residual-set",
+      "comeagre",
+      "lebesgue-measure",
+      "genericity"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsGδ.setOf_liouville",
+        "description": "The set of Liouville numbers {x | Liouville x} is a Gδ (countable intersection of open sets)",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Residual"
+      },
+      {
+        "theorem": "eventually_residual_liouville",
+        "description": "The Liouville numbers are residual: ∀ᶠ x in residual ℝ, Liouville x — the comeagre input",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Residual"
+      },
+      {
+        "theorem": "dense_liouville",
+        "description": "The Liouville numbers are dense in ℝ",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Residual"
+      },
+      {
+        "theorem": "Liouville.transcendental",
+        "description": "Liouville's theorem: every Liouville number is transcendental over ℤ (Transcendental ℤ x)",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Basic"
+      },
+      {
+        "theorem": "IsFractionRing.isAlgebraic_iff",
+        "description": "IsAlgebraic ℤ x ↔ IsAlgebraic ℚ x — denominator clearing over the fraction ring, the bridge from transcendence over ℤ to transcendence over ℚ",
+        "module": "Mathlib.RingTheory.Localization.Integral"
+      },
+      {
+        "theorem": "volume_setOf_liouville",
+        "description": "The Liouville numbers have Lebesgue measure zero: volume {x | Liouville x} = 0 — the measure-theoretic counterpoint",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "ae_not_liouville",
+        "description": "Almost every real is not a Liouville number: ∀ᵐ x, ¬ Liouville x",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "Real.disjoint_residual_ae",
+        "description": "The residual (Baire-generic) and a.e. (measure-generic) filters on ℝ are disjoint — witnessing that the two genericities never coincide",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "IsMeagre.mono",
+        "description": "A subset of a meagre set is meagre — used to push meagreness of the non-Liouville reals down to the non-Liouville transcendentals",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      },
+      {
+        "theorem": "AlgebraicNumbersCountable.algebraic_reals_countable",
+        "description": "The real algebraic numbers are countable — hence Lebesgue-null, giving that a.e. real is transcendental (reused from the gallery)",
+        "module": "Proofs.AlgebraicNumbersCountable"
+      }
+    ],
+    "originalContributions": [
+      "liouville_subset_transcendental: PROVED every Liouville number is transcendental over ℚ, bridging Mathlib's Transcendental ℤ phrasing of Liouville's theorem to the parent's ¬ IsAlgebraic ℚ transcendental set via the denominator-clearing equivalence IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ — this is what lands the Liouville set inside the parent's transcendental Gδ",
+      "liouville_dense_isGδ / liouville_residual: PACKAGED the Liouville numbers as a dense Gδ and as a residual (comeagre) set, the topological engine of the refinement",
+      "transcendental_not_liouville_isMeagre (HEADLINE): PROVED the non-Liouville transcendentals {x | ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x} are meagre — so the Baire-generic transcendental is Liouville, refining the parent's undifferentiated transcendental Gδ",
+      "eventually_residual_transcendental_liouville: PROVED that comeagrely a real is transcendental AND Liouville",
+      "ae_transcendental_not_liouville: PROVED that almost everywhere a real is transcendental and NOT Liouville, combining countability-null of the algebraic reals with ae_not_liouville",
+      "liouville_comeagre_yet_null (PUNCHLINE): PACKAGED the striking Baire-vs-measure contrast — the Liouville set is residual (comeagre) yet has Lebesgue measure zero",
+      "generic_transcendental_dichotomy: PROVED the full dichotomy — the comeagre transcendental is Liouville while the almost-every transcendental is non-Liouville, on the disjoint residual/ae filters (Real.disjoint_residual_ae)"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Baire category: residual (comeagre) and meagre sets, dense Gδ (parent entry)",
+      "Liouville numbers and Liouville's transcendence theorem",
+      "The field-of-fractions passage IsAlgebraic ℤ ↔ IsAlgebraic ℚ (denominator clearing)",
+      "Lebesgue measure on ℝ: countable sets are null, the a.e. filter"
+    ],
+    "lineCount": 152,
+    "relatedProblems": [
+      {
+        "id": "algebraic-reals-meager-dense-gdelta",
+        "relationship": "Parent: exhibits the transcendentals {x | ¬ IsAlgebraic ℚ x} as an explicit dense Gδ. This entry refines that set from the inside — the generic (comeagre) transcendental is not merely transcendental but Liouville"
+      },
+      {
+        "id": "algebraic-numbers-countable",
+        "relationship": "Supplies algebraic_reals_countable: the algebraic reals are countable, hence Lebesgue-null, giving the measure-theoretic half (a.e. real is transcendental)"
+      },
+      {
+        "id": "algebraic-reals-meager",
+        "relationship": "Grandparent: the algebraic reals are meagre and dense, the Baire-category dichotomy this entry sharpens with the Liouville/measure contrast"
+      }
+    ],
+    "assumptions": "0 axioms (only propext, Classical.choice, Quot.sound — the standard Mathlib triple; no sorryAx, no native_decide, no Lean.ofReduceBool). All results are assembled from Mathlib's Liouville residual/measure theory and the fraction-ring algebraic equivalence, reusing the parent's transcendental Gδ and the gallery's countability of the algebraic reals.",
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "tags": null,
+  "difficulty": null,
+  "category": null,
+  "discipline": null,
+  "description": "Refines the parent's dense-Gδ transcendentals from the inside by asking WHICH transcendentals are topologically generic. The answer is the classical Baire theorem for Liouville numbers: {x : ℝ | Liouville x} is itself a dense Gδ (Mathlib's IsGδ.setOf_liouville, dense_liouville), it sits inside the transcendentals (Liouville's theorem, bridged from Transcendental ℤ to ¬ IsAlgebraic ℚ by denominator clearing), and being comeagre it captures the generic transcendental — the non-Liouville transcendentals are meagre. The counterpoint is measure-theoretic: the same Liouville set has Lebesgue measure zero (volume_setOf_liouville), so it is comeagre yet null. Hence the two notions of 'generic transcendental' diverge completely: the comeagre transcendental is Liouville, whereas the almost-every transcendental is non-Liouville — on the disjoint residual/ae filters (Real.disjoint_residual_ae).",
+  "overview": {
+    "historicalContext": "Joseph Liouville constructed the first explicit transcendental numbers in 1844, showing that any real approximable to arbitrarily high order by rationals — a Liouville number — cannot be algebraic. A century of descriptive set theory (Baire, Borel, Lebesgue) then revealed a striking dichotomy of 'size': the Liouville numbers form a dense Gδ, hence a comeagre (topologically generic) set by the Baire Category Theorem, even though they form a Lebesgue-null set. This is the canonical example of a set that is large for Baire category yet negligible for measure — the two notions of 'almost every real' pointing in opposite directions. The classic reference for the category-versus-measure duality is Oxtoby's Measure and Category (GTM 2); the arithmetic of Liouville numbers is in Bugeaud's Approximation by Algebraic Numbers. This entry sits atop a gallery chain that already placed the transcendentals as a dense Gδ; it names the generic transcendental.",
+    "problemStatement": "The parent entry exhibits the transcendental reals $\\{x : \\mathbb{R} \\mid \\neg\\,\\mathrm{IsAlgebraic}\\ \\mathbb{Q}\\ x\\}$ as an explicit dense $G\\delta$, i.e. a comeagre set. But the transcendentals are not homogeneous: which of them is topologically generic? The refinement asserts that the generic transcendental (in the Baire sense) is a Liouville number. Concretely: the Liouville set $\\{x \\mid \\mathrm{Liouville}\\ x\\}$ is a dense $G\\delta$ contained in the transcendentals, the non-Liouville transcendentals are meagre, and yet the Liouville set has Lebesgue measure zero — so almost every transcendental (in the measure sense) is NOT Liouville. Formally: prove Liouville $\\subseteq$ transcendental over $\\mathbb{Q}$, package the Liouville dense $G\\delta$/residual facts, prove the non-Liouville transcendentals meagre, and record the comeagre-yet-null contrast on the disjoint residual/a.e. filters.",
+    "proofStrategy": "The topological facts come from Mathlib's Liouville.Residual: IsGδ.setOf_liouville, dense_liouville, eventually_residual_liouville. The arithmetic bridge liouville_subset_transcendental turns Liouville.transcendental (transcendence over ℤ) into transcendence over ℚ: since ℚ is the fraction field of ℤ, IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ gives IsAlgebraic ℤ x ↔ IsAlgebraic ℚ x, and the .mpr direction (clear denominators) contraposes a Liouville number's ℤ-transcendence into ¬ IsAlgebraic ℚ x. The refinement transcendental_not_liouville_isMeagre observes {x | ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x} ⊆ {x | ¬ Liouville x} = {Liouville}ᶜ, meagre since Liouville is residual (IsMeagre.mono). The measure half ae_transcendental_not_liouville uses that the algebraic reals are countable (AlgebraicNumbersCountable.algebraic_reals_countable) hence null, so a.e. real is transcendental, combined with ae_not_liouville. The punchline liouville_comeagre_yet_null pairs residuality with volume_setOf_liouville = 0, and generic_transcendental_dichotomy packages the comeagre-Liouville vs a.e.-non-Liouville split, whose filters are disjoint by Real.disjoint_residual_ae.",
+    "keyInsights": [
+      "The parent's transcendental Gδ is not the end of the story: comeagreness is a coarse notion, and inside the transcendental Gδ lies a strictly smaller dense Gδ — the Liouville numbers — that still captures the generic point. Being residual is closed under passing to residual subsets, so 'generic transcendental' really means 'generic Liouville number'.",
+      "Liouville's theorem in Mathlib is phrased over ℤ (Transcendental ℤ), but the parent's transcendental set is over the field ℚ. These agree pointwise for reals because ℚ = Frac(ℤ): IsFractionRing.isAlgebraic_iff turns a rational-coefficient annihilator into an integer-coefficient one by clearing denominators. The single .mpr application is the whole bridge.",
+      "Meagreness of the non-Liouville transcendentals costs nothing beyond monotonicity: the set is a subset of the complement of the residual Liouville set, so IsMeagre.mono closes it immediately — no fresh category argument is needed.",
+      "The decisive phenomenon is that comeagre and full-measure diverge: the Liouville set is residual yet Lebesgue-null. So the Baire-generic transcendental (Liouville) and the measure-generic transcendental (non-Liouville) are different, and Real.disjoint_residual_ae certifies that no single filter reconciles them.",
+      "This is the arithmetic incarnation of the textbook fact that category and measure are orthogonal: ℝ splits as a meagre set of full measure union a comeagre null set. Here the comeagre null set is exactly the Liouville numbers, sitting inside the transcendentals."
+    ]
+  },
+  "conclusion": {
+    "summary": "A 152-line, 0-sorry, 0-axiom entry that refines the parent's dense-Gδ transcendentals by identifying the generic transcendental. The Liouville numbers are a dense Gδ inside the transcendentals (bridged from Mathlib's ℤ-phrasing of Liouville's theorem via denominator clearing), the non-Liouville transcendentals are meagre, and — the punchline — the Liouville set is comeagre yet Lebesgue-null.",
+    "implications": "The transcendental Gδ of the parent is now stratified: generically (Baire) a transcendental is Liouville, but almost everywhere (measure) it is not. The two witnessing filters are disjoint (Real.disjoint_residual_ae), giving a clean arithmetic instance of the orthogonality of category and measure — ℝ as a comeagre null set (the Liouville numbers, inside the transcendentals) against a meagre full-measure set. The fraction-ring bridge liouville_subset_transcendental (Transcendental ℤ ⇒ ¬ IsAlgebraic ℚ) is reusable wherever Mathlib's ℤ-phrased transcendence must meet a ℚ-phrased algebraic set.",
+    "openQuestions": [
+      "Quantify the refinement metrically: for each irrationality exponent μ ≥ 2, the μ-Liouville (LiouvilleWith) sets interpolate between Liouville and Diophantine reals — is each level a Gδ, and where does comeagreness break as μ → ∞?",
+      "Express the comeagre-yet-null contrast as a single formal statement about the pair (residual ℝ, ae volume) being mutually singular on the transcendentals, connecting IsMeagre/residual to MeasureTheory.Measure.mutuallySingular."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "algebraic-reals-meager-dense-gdelta",
+      "relationship": "extends",
+      "description": "Parent: exhibits the transcendentals as an explicit dense Gδ. This entry refines that set — the comeagre (generic) transcendental is a Liouville number, while a.e. transcendental is not"
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "related",
+      "description": "Supplies the countability of the algebraic reals, hence their Lebesgue-nullity, which powers the measure-theoretic half (a.e. real is transcendental)"
+    },
+    {
+      "targetId": "algebraic-reals-meager",
+      "relationship": "related",
+      "description": "Grandparent: the algebraic reals are meagre and dense, the Baire-category dichotomy this entry sharpens with the Liouville comeagre-yet-null contrast"
+    }
+  ],
+  "sections": [
+    {
+      "id": "transcendence-bridge",
+      "title": "The transcendence bridge: Liouville ⟹ transcendental over ℚ",
+      "startLine": 57,
+      "endLine": 69,
+      "summary": "liouville_subset_transcendental proves every Liouville number is transcendental over ℚ, turning Mathlib's Transcendental ℤ phrasing of Liouville's theorem into the parent's ¬ IsAlgebraic ℚ set via the denominator-clearing equivalence IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ."
+    },
+    {
+      "id": "liouville-dense-gdelta",
+      "title": "The Liouville numbers as a dense Gδ / residual set",
+      "startLine": 71,
+      "endLine": 85,
+      "summary": "liouville_isGδ, liouville_dense_isGδ and liouville_residual package Mathlib's IsGδ.setOf_liouville, dense_liouville and eventually_residual_liouville as the topological engine of the refinement."
+    },
+    {
+      "id": "generic-transcendental-liouville",
+      "title": "The refinement: the generic transcendental is Liouville",
+      "startLine": 86,
+      "endLine": 109,
+      "summary": "transcendental_not_liouville_isMeagre shows the non-Liouville transcendentals are meagre (subset of the complement of the residual Liouville set, via IsMeagre.mono); eventually_residual_transcendental_liouville shows comeagrely a real is transcendental and Liouville."
+    },
+    {
+      "id": "measure-counterpoint",
+      "title": "The measure-theoretic counterpoint and dichotomy",
+      "startLine": 110,
+      "endLine": 145,
+      "summary": "ae_transcendental_not_liouville shows a.e. real is transcendental and non-Liouville; liouville_comeagre_yet_null pairs residuality with Lebesgue-nullity; generic_transcendental_dichotomy packages the Baire-vs-measure split on the disjoint residual/ae filters. Closing #print axioms confirm 0 axioms."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "liouville_subset_transcendental",
+      "type": "core",
+      "description": "Every Liouville number is transcendental over ℚ — the fraction-ring bridge landing Liouville numbers inside the parent's transcendental Gδ",
+      "leanType": "{x : ℝ | Liouville x} ⊆ {x : ℝ | ¬ IsAlgebraic ℚ x}"
+    },
+    {
+      "name": "liouville_dense_isGδ",
+      "type": "core",
+      "description": "The Liouville numbers are a dense Gδ in ℝ",
+      "leanType": "IsGδ {x : ℝ | Liouville x} ∧ Dense {x : ℝ | Liouville x}"
+    },
+    {
+      "name": "liouville_residual",
+      "type": "core",
+      "description": "The Liouville numbers are a residual (comeagre) set",
+      "leanType": "{x : ℝ | Liouville x} ∈ residual ℝ"
+    },
+    {
+      "name": "transcendental_not_liouville_isMeagre",
+      "type": "headline",
+      "description": "The non-Liouville transcendentals are meagre — so the Baire-generic transcendental is Liouville",
+      "leanType": "IsMeagre {x : ℝ | ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x}"
+    },
+    {
+      "name": "eventually_residual_transcendental_liouville",
+      "type": "core",
+      "description": "Comeagrely, a real is transcendental and Liouville",
+      "leanType": "∀ᶠ x in residual ℝ, ¬ IsAlgebraic ℚ x ∧ Liouville x"
+    },
+    {
+      "name": "ae_transcendental_not_liouville",
+      "type": "core",
+      "description": "Almost every real is transcendental and NOT Liouville",
+      "leanType": "∀ᵐ x : ℝ, ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x"
+    },
+    {
+      "name": "liouville_comeagre_yet_null",
+      "type": "headline",
+      "description": "The Liouville set is residual (comeagre) yet Lebesgue-null — the category-versus-measure contrast",
+      "leanType": "{x : ℝ | Liouville x} ∈ residual ℝ ∧ volume {x : ℝ | Liouville x} = 0"
+    },
+    {
+      "name": "generic_transcendental_dichotomy",
+      "type": "headline",
+      "description": "The Baire-vs-measure split: the comeagre transcendental is Liouville, the almost-every transcendental is non-Liouville",
+      "leanType": "(∀ᶠ x in residual ℝ, ¬ IsAlgebraic ℚ x ∧ Liouville x) ∧ (∀ᵐ x : ℝ, ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x)"
+    }
+  ],
+  "references": [
+    {
+      "title": "Liouville number — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Liouville_number"
+    },
+    {
+      "title": "Oxtoby, Measure and Category (Springer GTM 2)",
+      "url": "https://link.springer.com/book/10.1007/978-1-4684-9339-9"
+    },
+    {
+      "title": "Bugeaud, Approximation by Algebraic Numbers (Cambridge Tracts in Mathematics 160)",
+      "url": "https://www.cambridge.org/core/books/approximation-by-algebraic-numbers/"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes open question **algebraic-reals-meager-dense-gdelta-oq-03** — *Generically Liouville: A Comeagre Refinement Inside the Transcendental Gδ*.

The parent entry exhibits the transcendental reals `{x : ℝ | ¬ IsAlgebraic ℚ x}` as an explicit **dense Gδ** (comeagre). This entry refines that from the inside by identifying **which** transcendentals are topologically generic.

### Result
- **The generic transcendental is Liouville.** The Liouville numbers form a dense Gδ (`IsGδ.setOf_liouville`, `dense_liouville`) *inside* the transcendentals, so the non-Liouville transcendentals are **meagre** (`transcendental_not_liouville_isMeagre`).
- **The measure counterpoint.** The same Liouville set is **Lebesgue-null** (`volume_setOf_liouville`), so *almost every* transcendental is **not** Liouville (`ae_transcendental_not_liouville`).
- **The dichotomy.** Comeagrely a real is transcendental ∧ Liouville; a.e. it is transcendental ∧ ¬Liouville — on the *disjoint* filters `residual ℝ` and `ae volume` (`Real.disjoint_residual_ae`). This is the arithmetic instance of the orthogonality of Baire category and Lebesgue measure.

### Key contribution
`liouville_subset_transcendental` bridges Mathlib's `Liouville.transcendental : Transcendental ℤ x` to the parent's `¬ IsAlgebraic ℚ` set via `IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ` (`IsAlgebraic ℤ x ↔ IsAlgebraic ℚ x`, denominator clearing).

### Verification
- **9 theorems, 152 lines, 0 sorries, 0 axioms.**
- `#print axioms` on all results returns only `[propext, Classical.choice, Quot.sound]` — the standard Mathlib triple (no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`).
- Compiled with pinned Lean `v4.26.0` against the built Mathlib oleans.

Files: `proofs/Proofs/AlgebraicRealsMeagerDenseGDeltaOQ03.lean`, gallery `meta.json` + `annotations.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)