### PR TITLE
Enrich First-Moment Rigidity (prob-method-expectation-oq-05): annotation coverage 3→5

### DIFF
--- a/src/data/proofs/prob-method-expectation-oq-05/annotations.json
+++ b/src/data/proofs/prob-method-expectation-oq-05/annotations.json
@@ -1,5 +1,63 @@
 [
   {
+    "id": "ann-pmeoq05-context",
+    "proofId": "prob-method-expectation-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "context",
+    "title": "From Existence to Rigidity in the First-Moment Method",
+    "content": "The header states what this entry adds to the probabilistic-method family. The parent `prob-method-expectation` and siblings prove the *existence* half of the first-moment method: over a nonempty finite set some element meets or beats the average (`exists_ge_average`, and dually `exists_le_average`). That element could sit strictly above the mean while others sit below. This file supplies the *rigidity* half the family left open: the averaging inequality saturates — every element attains the mean — exactly when `f` is constant. Note the generality: everything is stated over an arbitrary linearly ordered field `𝕜` (`[Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]`), not just ℝ, so nothing analytic or measure-theoretic is used — the results are purely order-algebraic. No `sorry`, no `axiom`, no `native_decide`.",
+    "mathContext": "First-moment method: if $\\mathbb{E}[X] = \\mu$ then $\\exists\\,\\omega,\\ X(\\omega)\\ge\\mu$ and $\\exists\\,\\omega,\\ X(\\omega)\\le\\mu$. Rigidity/equality case: $X(\\omega)=\\mu$ for *all* $\\omega$ iff $X$ is constant — equivalently the variance $\\mathbb{E}[(X-\\mu)^2]$ is zero.",
+    "significance": "context",
+    "relatedConcepts": [
+      "First-moment / probabilistic method",
+      "Expectation and averaging arguments",
+      "Equality case of an inequality",
+      "Linearly ordered fields"
+    ],
+    "prerequisites": [
+      "Finite sums over Finset",
+      "Ordered field axioms",
+      "Empirical mean"
+    ],
+    "tags": [
+      "context",
+      "probabilistic-method",
+      "rigidity"
+    ]
+  },
+  {
+    "id": "ann-pmeoq05-engine",
+    "proofId": "prob-method-expectation-oq-05",
+    "range": {
+      "startLine": 68,
+      "endLine": 89
+    },
+    "type": "technique",
+    "title": "One Lemma Powers Every Rigidity Result",
+    "content": "Both `eq_mean_of_forall_le` and `eq_mean_of_forall_ge` — and through them the packaged iffs and the strict-compensation statements — reduce to a single Mathlib lemma: `Finset.sum_eq_zero_iff_of_nonneg`, which says a sum of nonnegative terms is zero iff *every* term is zero. The pattern is uniform: from one-sided domination each deviation `mean − f a` (or `f a − mean`) is nonnegative; the conservation law `sum_sub_mean_eq_zero` makes their sum zero; hence each deviation is individually zero, i.e. `f a = mean`. The ≤ side flips the sign of the conservation identity with `sum_neg_distrib`/`neg_sub` first. This 'nonnegative-sum-is-zero ⟹ termwise-zero' move is the workhorse of every equality-case argument here, and reappears in `variance_pos_of_exists_ne` applied to squared deviations.",
+    "mathContext": "If $t_a \\ge 0$ for all $a\\in s$ and $\\sum_{a\\in s} t_a = 0$, then $t_a = 0$ for every $a$. Applied with $t_a = \\mathrm{mean} - f(a)\\ge 0$ (or $f(a)-\\mathrm{mean}$, or $(f(a)-\\mathrm{mean})^2$).",
+    "significance": "high",
+    "relatedConcepts": [
+      "Finset.sum_eq_zero_iff_of_nonneg",
+      "Equality case via termwise vanishing",
+      "Conservation of the first moment",
+      "Sign duality (≤ vs ≥)"
+    ],
+    "prerequisites": [
+      "Finset.sum_eq_zero_iff_of_nonneg",
+      "sub_nonneg / sub_eq_zero",
+      "sum_sub_mean_eq_zero"
+    ],
+    "tags": [
+      "technique",
+      "proof-engine",
+      "rigidity"
+    ]
+  },
+  {
     "id": "ann-pmeoq05-0",
     "proofId": "prob-method-expectation-oq-05",
     "range": {


### PR DESCRIPTION
Enrichment pass for `prob-method-expectation-oq-05` (quality 83, pass 0). meta.json is already rich (overview, 3 sections, conclusion, cross-references, references); the gap was **annotation coverage** — 3 annotations spanned lines 49–143, leaving the header/setup uncovered.

## Changes (annotations.json only)
- **Context annotation** (lines 1–47, previously uncovered): frames the entry as the *rigidity* complement to the family's *existence* results (`exists_ge_average`), and highlights that everything holds over an arbitrary linearly ordered field — no analysis/measure theory.
- **Technique annotation** (lines 68–89): identifies the single shared engine `Finset.sum_eq_zero_iff_of_nonneg` (nonneg sum is zero ⟹ every term zero) behind all rigidity, compensation, and variance results.
- Annotation count 3 → 5; both align to Lean constructs (no annotation-build errors for this entry).

## Verification
- JSON valid; meta.json unchanged at 13.0 KB.
- `pnpm annotations:build` reports no errors for this entry.
- Axiom integrity unchanged: `status: verified`, `badge: original` — file has no `sorry`/`axiom`/`native_decide`.