### PR TITLE
research(mantel-theorem-oq-03-oq-01-oq-02): minimum degree of general Turán graph = n − ⌈n/r⌉ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/MantelTheoremOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/MantelTheoremOQ03OQ01OQ02.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2024-2026 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+
+/-!
+# Minimum Degree of the General Turán Graph `turanGraph n r` (OQ-03 · OQ-01 · OQ-02)
+
+The parent entry (`MantelTheoremOQ03OQ01`) proved the `r = 2` sharpness certificate for the
+minimum-degree corollary of Mantel's theorem: the balanced complete bipartite graph
+`turanGraph n 2` is triangle-free and has minimum degree exactly `⌊n/2⌋`.
+
+This file lifts that computation to **every** `r ≥ 1`, certifying sharpness of the Turán
+minimum-degree bound `(1 − 1/r)·n` for `K_{r+1}`-free graphs (the parent's third open
+question). Recall Mathlib's `turanGraph n r : SimpleGraph (Fin n)` with
+`v ~ w ↔ v % r ≠ w % r`, the complete `r`-partite graph whose parts are the residue classes
+mod `r` inside `Fin n`. A vertex is adjacent to everyone outside its own residue class, so
+its degree is `n` minus the size of that class; the minimum degree lives in the largest
+class, residue `0`, of size `⌈n/r⌉ = (n + r − 1)/r`.
+
+## Results
+
+* `turanGraph_degree` : the exact per-vertex degree,
+  `degree v = n − #{k < n : k % r = v % r}` (as a `Nat.count`).
+* `count_mod_eq_zero` : the residue-class-`0` size, `#{k < n : k % r = 0} = (n + r − 1)/r`.
+* `count_mod_le_zero` : residue class `0` is the largest, `#{k < n : k % r = j} ≤ #{k < n :
+  k % r = 0}`, via the injection `k ↦ k − j`.
+* `turanGraph_minDegree` : `(turanGraph n r).minDegree = n − ⌈n/r⌉` for `n, r ≥ 1`.
+* `turanGraph_minDegree_sharp` : the packaged sharpness certificate (`K_{r+1}`-free *and*
+  minimum degree exactly `n − ⌈n/r⌉`).
+* `turanGraph_minDegree_bound` : the `(1 − 1/r)·n` bound in cleared-denominator form,
+  `r · minDegree ≤ (r − 1)·n`.
+* `turanTwo_specialization` : `r = 2` recovers the parent's `⌊n/2⌋`.
+
+## Method
+
+The graph-theoretic scaffolding mirrors the parent `r = 2` file: transfer the per-vertex
+neighbour count to `Nat.count` over `range n` (`card_fin_filter_val`), then read off the
+minimum degree from the `minDegree` extremality lemmas. The only genuinely new content is
+the general residue-class-size arithmetic: the closed form for class `0` (induction on `n`
+via `Nat.succ_div`) and the antitonicity of class size in the residue (an explicit injection
+`k ↦ k − j` on the counting `Finset`s).
+-/
+
+open Finset SimpleGraph
+
+namespace MantelTuranGeneral
+
+/-! ## Counting residues modulo `r` -/
+
+/-- Transfer a `Fin n`-indexed count of a `val`-predicate to `Nat.count` over `range n`.
+(Reused verbatim from the parent `r = 2` file.) -/
+lemma card_fin_filter_val (n : ℕ) (Q : ℕ → Prop) [DecidablePred Q] :
+    #(Finset.univ.filter fun w : Fin n => Q w.val) = Nat.count Q n := by
+  rw [Nat.count_eq_card_filter_range]
+  rw [← Finset.card_image_of_injective
+        (Finset.univ.filter fun w : Fin n => Q w.val) Fin.val_injective]
+  congr 1
+  ext k
+  simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_range]
+  constructor
+  · rintro ⟨w, hw, rfl⟩
+    exact ⟨w.isLt, hw⟩
+  · rintro ⟨hk, hQ⟩
+    exact ⟨⟨k, hk⟩, hQ, rfl⟩
+
+/-- The size of residue class `0` modulo `r` inside `Fin n`: `#{k < n : k % r = 0} =
+⌈n/r⌉ = (n + r − 1)/r`. Proved by induction on `n` using `Nat.succ_div`. -/
+lemma count_mod_eq_zero (r n : ℕ) (hr : 0 < r) :
+    Nat.count (fun k => k % r = 0) n = (n + r - 1) / r := by
+  induction n with
+  | zero =>
+    simp only [Nat.count_zero]
+    symm
+    exact Nat.div_eq_of_lt (by omega)
+  | succ m ih =>
+    rw [Nat.count_succ, ih]
+    have e1 : m + 1 + r - 1 = (m + r - 1) + 1 := by omega
+    rw [e1, Nat.succ_div]
+    have hcond : (r ∣ (m + r - 1) + 1) ↔ (m % r = 0) := by
+      have e2 : (m + r - 1) + 1 = m + r := by omega
+      rw [e2, Nat.dvd_iff_mod_eq_zero, Nat.add_mod_right]
+    simp only [hcond]
+
+/-- **Residue class `0` is the largest.** For any residue `j`, the class `{k < n : k % r = j}`
+injects into `{k < n : k % r = 0}` via `k ↦ k − j` (each such `k` satisfies `k ≥ k % r = j`,
+so `k − j = r·(k/r)` is a multiple of `r`), whence its size is bounded by that of class `0`. -/
+lemma count_mod_le_zero (r n j : ℕ) :
+    Nat.count (fun k => k % r = j) n ≤ Nat.count (fun k => k % r = 0) n := by
+  simp only [Nat.count_eq_card_filter_range]
+  apply Finset.card_le_card_of_injOn (fun k => k - j)
+  · intro k hk
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_range] at hk ⊢
+    obtain ⟨hkn, hkj⟩ := hk
+    refine ⟨by omega, ?_⟩
+    have hdm := Nat.div_add_mod k r
+    have hsub : k - j = r * (k / r) := by omega
+    rw [hsub]
+    exact Nat.mul_mod_right r (k / r)
+  · intro a ha b hb hab
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_range] at ha hb
+    have hja : j ≤ a := ha.2 ▸ Nat.mod_le a r
+    have hjb : j ≤ b := hb.2 ▸ Nat.mod_le b r
+    simp only at hab
+    omega
+
+/-! ## The general Turán graph `turanGraph n r` -/
+
+/-- **Exact per-vertex degree.** A vertex `v` in `turanGraph n r` is adjacent to every vertex
+outside its own residue class, so `degree v = n − #{k < n : k % r = v % r}`. -/
+theorem turanGraph_degree (n r : ℕ) (v : Fin n) :
+    (turanGraph n r).degree v = n - Nat.count (fun k => k % r = v.val % r) n := by
+  have key : (turanGraph n r).degree v + Nat.count (fun k => k % r = v.val % r) n = n := by
+    rw [SimpleGraph.degree, SimpleGraph.neighborFinset_eq_filter,
+        ← card_fin_filter_val n (fun k => k % r = v.val % r)]
+    have hadj : (Finset.univ.filter ((turanGraph n r).Adj v))
+        = Finset.univ.filter (fun w : Fin n => v.val % r ≠ w.val % r) :=
+      Finset.filter_congr (fun w _ => by rw [turanGraph_adj])
+    have hnegeq : (Finset.univ.filter (fun w : Fin n => w.val % r = v.val % r))
+        = Finset.univ.filter (fun w : Fin n => ¬ (v.val % r ≠ w.val % r)) :=
+      Finset.filter_congr (fun w _ => by constructor <;> intro h <;> omega)
+    rw [hadj, hnegeq, Finset.filter_card_add_filter_neg_card_eq_card,
+        Finset.card_univ, Fintype.card_fin]
+  omega
+
+/-- **Sharpness, minimum degree, general `r`.** For `n ≥ 1` and `r ≥ 1`, the Turán graph
+`turanGraph n r` has minimum degree exactly `n − ⌈n/r⌉ = n − (n + r − 1)/r`, attained on the
+residue class `0`. -/
+theorem turanGraph_minDegree (n r : ℕ) (hn : 0 < n) (hr : 0 < r) :
+    (turanGraph n r).minDegree = n - (n + r - 1) / r := by
+  haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  refine le_antisymm ?_ ?_
+  · calc (turanGraph n r).minDegree
+        ≤ (turanGraph n r).degree ⟨0, hn⟩ := (turanGraph n r).minDegree_le_degree _
+      _ = n - Nat.count (fun k => k % r = (⟨0, hn⟩ : Fin n).val % r) n :=
+            turanGraph_degree n r _
+      _ = n - (n + r - 1) / r := by
+            have h0 : (⟨0, hn⟩ : Fin n).val % r = 0 := by simp
+            rw [h0, count_mod_eq_zero r n hr]
+  · refine (turanGraph n r).le_minDegree_of_forall_le_degree (n - (n + r - 1) / r) (fun v => ?_)
+    rw [turanGraph_degree n r v]
+    have hle : Nat.count (fun k => k % r = v.val % r) n ≤ (n + r - 1) / r := by
+      calc Nat.count (fun k => k % r = v.val % r) n
+          ≤ Nat.count (fun k => k % r = 0) n := count_mod_le_zero r n (v.val % r)
+        _ = (n + r - 1) / r := count_mod_eq_zero r n hr
+    exact Nat.sub_le_sub_left hle n
+
+/-- **Sharpness certificate for the parent's third open question.** `turanGraph n r` is
+`K_{r+1}`-free and its minimum degree `n − ⌈n/r⌉` witnesses that the `(1 − 1/r)·n`
+minimum-degree bound for `K_{r+1}`-free graphs cannot be improved. -/
+theorem turanGraph_minDegree_sharp (n r : ℕ) (hn : 0 < n) (hr : 0 < r) :
+    (turanGraph n r).CliqueFree (r + 1)
+      ∧ (turanGraph n r).minDegree = n - (n + r - 1) / r :=
+  ⟨turanGraph_cliqueFree hr, turanGraph_minDegree n r hn hr⟩
+
+/-- The minimum degree realises the `(1 − 1/r)·n` bound: in cleared-denominator form,
+`r · minDegree ≤ (r − 1)·n`. Equivalently `minDegree = n − ⌈n/r⌉ ≤ (1 − 1/r)·n`. -/
+theorem turanGraph_minDegree_bound (n r : ℕ) (hn : 0 < n) (hr : 0 < r) :
+    r * (turanGraph n r).minDegree ≤ (r - 1) * n := by
+  rw [turanGraph_minDegree n r hn hr, Nat.mul_sub, Nat.sub_one_mul]
+  have hdm := Nat.div_add_mod (n + r - 1) r
+  have hlt : (n + r - 1) % r < r := Nat.mod_lt _ hr
+  have hge : n ≤ r * ((n + r - 1) / r) := by omega
+  exact Nat.sub_le_sub_left hge (r * n)
+
+/-- **Consistency with the parent.** For `r = 2`, the general formula
+`n − ⌈n/2⌉ = ⌊n/2⌋` recovers `turanTwo_minDegree`. -/
+theorem turanTwo_specialization (n : ℕ) (hn : 0 < n) :
+    (turanGraph n 2).minDegree = n / 2 := by
+  rw [turanGraph_minDegree n 2 hn (by norm_num)]
+  omega
+
+end MantelTuranGeneral

--- a/src/data/proofs/mantel-theorem-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/mantel-theorem-oq-03-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "mantel-oq030102-ann-imports",
+    "proofId": "mantel-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 5 },
+    "type": "concept",
+    "title": "A Single `import Mathlib`: Turán Graphs, Degrees, Nat.count, Nat-Division",
+    "content": "The file imports all of Mathlib to reach four developments at once: Mathlib.Combinatorics.SimpleGraph.Extremal.Turan (turanGraph n r, turanGraph_adj, turanGraph_cliqueFree), Mathlib.Combinatorics.SimpleGraph.Finite (degree, minDegree, neighborFinset_eq_filter, extremality lemmas), Mathlib.Data.Nat.Count (Nat.count and its successor recurrence), and the Init Nat-division lemmas (Nat.succ_div). No axioms or sorries are introduced.",
+    "mathContext": "$\\mathrm{turanGraph}\\,n\\,r$ has $\\mathrm{Adj}\\,v\\,w \\iff (v : \\mathbb{N}) \\% r \\ne (w : \\mathbb{N}) \\% r$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Turán graph", "complete r-partite graph", "minimum degree", "Nat.count"],
+    "prerequisites": ["simple graphs", "vertex degree", "modular arithmetic"]
+  },
+  {
+    "id": "mantel-oq030102-ann-docstring",
+    "proofId": "mantel-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 7, "endLine": 48 },
+    "type": "concept",
+    "title": "Lifting Sharpness from Parity to an Arbitrary Modulus",
+    "content": "The parent computed the r = 2 case: the balanced complete bipartite graph turanGraph n 2 has minimum degree ⌊n/2⌋, certifying sharpness of Mantel's minimum-degree bound. This file lifts that to every r ≥ 1. The Turán graph turanGraph n r joins two vertices exactly when they lie in different residue classes mod r, so a vertex is adjacent to everyone outside its own class and its degree is n minus its class size. The minimum degree lives in the largest class — residue 0, of size ⌈n/r⌉ — giving minDegree = n − ⌈n/r⌉, the sharpness witness for the (1 − 1/r)·n bound of Kᵣ₊₁-free graphs.",
+    "mathContext": "$\\deg v = n - c_r(v \\% r, n)$ with class size $c_r(j,n) = \\lceil (n-j)/r\\rceil$; the minimum is at $j = 0$.",
+    "significance": "critical",
+    "relatedConcepts": ["Turán's theorem", "extremal graph theory", "sharpness", "residue classes"],
+    "prerequisites": ["upper vs lower bounds", "extremal constructions", "ceiling division"]
+  },
+  {
+    "id": "mantel-oq030102-ann-bridge",
+    "proofId": "mantel-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 50, "endLine": 68 },
+    "type": "tactic",
+    "title": "The Fin n → Nat.count Bridge (Reused from the Parent)",
+    "content": "card_fin_filter_val equates the Fin n count #{w : Fin n | Q w.val} with Nat.count Q n. The proof takes the image of the filter under the injective Fin.val (card_image_of_injective) and identifies it with {x ∈ range n | Q x}. Stated for a general predicate Q : ℕ → Prop, it is reused verbatim from the parent and underpins both the degree computation and the class-size cardinality comparison.",
+    "mathContext": "$\\#\\{w : \\mathrm{Fin}\\,n \\mid Q\\,w\\} = \\mathrm{count}\\,Q\\,n$, via the injective image of $\\mathrm{Fin.val}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.count", "Finset image", "injectivity", "Fin.val"],
+    "prerequisites": ["Finset cardinality", "injective maps"]
+  },
+  {
+    "id": "mantel-oq030102-ann-class-zero",
+    "proofId": "mantel-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 70, "endLine": 87 },
+    "type": "key-step",
+    "title": "Closed Form for the Largest Class: #{k < n : k % r = 0} = ⌈n/r⌉",
+    "content": "count_mod_eq_zero proves the residue-class-0 size equals (n+r−1)/r = ⌈n/r⌉ by induction on n. Where the parity case could close its /2 goals with omega, division by a variable r is not omega-decidable, so the successor step instead invokes the exact Nat-division recurrence Nat.succ_div ((a+1)/b = a/b + [b ∣ a+1]) on the target and matches its indicator to the count_succ increment through the equivalence r ∣ m+r ↔ m % r = 0 (from Nat.dvd_iff_mod_eq_zero and Nat.add_mod_right). This is the crux new lemma of the generalisation.",
+    "mathContext": "$\\mathrm{count}(\\cdot \\% r = 0)\\,n = \\lceil n/r\\rceil = (n+r-1)/r$ for $r \\ge 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["ceiling division", "Nat.succ_div", "Nat.count_succ", "induction"],
+    "prerequisites": ["Nat division and modulo", "induction on ℕ"]
+  },
+  {
+    "id": "mantel-oq030102-ann-antitone",
+    "proofId": "mantel-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 89, "endLine": 106 },
+    "type": "key-step",
+    "title": "Residue Class 0 Is the Largest, via the Injection k ↦ k − j",
+    "content": "count_mod_le_zero proves Nat.count (·%r=j) n ≤ Nat.count (·%r=0) n for every residue j — the monotonicity that identifies the minimum-degree vertex, and which the two-class parity case never needed. After moving both counts to range-n filters, card_le_card_of_injOn applies the shift k ↦ k − j: any k with k % r = j satisfies k ≥ k % r = j, so k − j = r·(k/r) has residue 0 and stays below n (maps-into), and injectivity is immediate since all elements exceed j. Thus class j embeds in class 0.",
+    "mathContext": "$k \\% r = j \\Rightarrow k - j = r\\cdot(k/r)$, giving an injection $\\{k < n : k \\% r = j\\} \\hookrightarrow \\{k < n : k \\% r = 0\\}$.",
+    "significance": "critical",
+    "relatedConcepts": ["injective maps", "Finset.card_le_card_of_injOn", "monotonicity", "residue classes"],
+    "prerequisites": ["Finset cardinality", "Nat.div_add_mod"]
+  },
+  {
+    "id": "mantel-oq030102-ann-degree",
+    "proofId": "mantel-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 108, "endLine": 128 },
+    "type": "key-step",
+    "title": "Exact Per-Vertex Degree: deg v = n − (own class size)",
+    "content": "turanGraph_degree computes deg v = n − #{k < n : k % r = v % r}. The neighbour finset is univ.filter ((turanGraph n r).Adj v); rewriting the adjacency to the residue predicate v % r ≠ w % r (turanGraph_adj, filter_congr) makes filter_card_add_filter_neg_card_eq_card split Fin n into the neighbour class and its complement (the same-residue class), giving deg v + #{same class} = n. The complement count is transferred to Nat.count by the bridge, and omega finishes. Normalising to the residue predicate first keeps all Decidable instances uniform.",
+    "mathContext": "$\\deg v + \\#\\{w : w \\% r = v \\% r\\} = n$, hence $\\deg v = n - \\mathrm{count}(\\cdot \\% r = v \\% r)\\,n$.",
+    "significance": "critical",
+    "relatedConcepts": ["vertex degree", "neighborFinset", "filter complement", "Nat.count"],
+    "prerequisites": ["SimpleGraph.degree", "Finset.filter"]
+  },
+  {
+    "id": "mantel-oq030102-ann-mindegree",
+    "proofId": "mantel-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 130, "endLine": 150 },
+    "type": "key-step",
+    "title": "Minimum Degree Exactly n − ⌈n/r⌉",
+    "content": "turanGraph_minDegree proves (turanGraph n r).minDegree = n − ⌈n/r⌉ for n, r ≥ 1 by antisymmetry. Upper bound: the residue-0 vertex ⟨0, hn⟩ has degree n − count(·%r=0) n = n − ⌈n/r⌉ (turanGraph_degree with count_mod_eq_zero), so minDegree ≤ n − ⌈n/r⌉ via minDegree_le_degree. Lower bound: for every v, count(·%r=v%r) n ≤ count(·%r=0) n = ⌈n/r⌉ (count_mod_le_zero, count_mod_eq_zero), so deg v ≥ n − ⌈n/r⌉; le_minDegree_of_forall_le_degree closes it.",
+    "mathContext": "$(\\mathrm{turanGraph}\\,n\\,r).\\mathrm{minDegree} = n - \\lceil n/r\\rceil$.",
+    "significance": "critical",
+    "relatedConcepts": ["minimum degree", "antisymmetry", "extremal vertex", "sharpness"],
+    "prerequisites": ["minDegree extremality lemmas", "Nat subtraction monotonicity"]
+  },
+  {
+    "id": "mantel-oq030102-ann-certificate",
+    "proofId": "mantel-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 152, "endLine": 174 },
+    "type": "concept",
+    "title": "Sharpness Certificate, the (1 − 1/r)·n Bound, and the r = 2 Check",
+    "content": "turanGraph_minDegree_sharp packages CliqueFree (r+1) (turanGraph_cliqueFree) with the minimum-degree formula — the certificate answering the parent's third open question. turanGraph_minDegree_bound records the (1 − 1/r)·n bound in cleared-denominator form r·minDegree ≤ (r−1)·n, derived from the single inequality n ≤ r·⌈n/r⌉ (via Nat.div_add_mod and the mod bound). turanTwo_specialization verifies consistency: for r = 2 the formula n − ⌈n/2⌉ collapses to ⌊n/2⌋, recovering the parent's turanTwo_minDegree.",
+    "mathContext": "$K_{r+1}$-free $\\wedge\\ \\min\\deg = n - \\lceil n/r\\rceil$; $r\\cdot\\min\\deg \\le (r-1)n$; $r = 2 \\Rightarrow \\lfloor n/2\\rfloor$.",
+    "significance": "critical",
+    "relatedConcepts": ["sharpness certificate", "Turán bound", "specialization", "clique-free"],
+    "prerequisites": ["Kᵣ₊₁-free graphs", "ceiling identities"]
+  }
+]

--- a/src/data/proofs/mantel-theorem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-03-oq-01-oq-02/meta.json
@@ -1,0 +1,235 @@
+{
+  "id": "mantel-theorem-oq-03-oq-01-oq-02",
+  "title": "Minimum Degree of the General Turán Graph turanGraph n r Is Exactly n − ⌈n/r⌉",
+  "slug": "mantel-theorem-oq-03-oq-01-oq-02",
+  "description": "A fully verified, axiom-free computation of the minimum degree of Mathlib's general Turán graph turanGraph n r on Fin n (v ~ w ↔ v % r ≠ w % r, the complete r-partite graph on residue classes mod r). We prove the exact per-vertex degree deg v = n − #{k < n : k % r = v % r}, the closed form #{k < n : k % r = 0} = ⌈n/r⌉ = (n+r−1)/r for the size of residue class 0, and its antitonicity #{k < n : k % r = j} ≤ #{k < n : k % r = 0} (residue class 0 is the largest). Together these give (turanGraph n r).minDegree = n − ⌈n/r⌉ for n, r ≥ 1, packaged with turanGraph_cliqueFree into a sharpness certificate for the (1 − 1/r)·n minimum-degree bound of Kᵣ₊₁-free graphs — the parent mantel-theorem-oq-03-oq-01's third open question. Specialising r = 2 recovers the parent's ⌊n/2⌋. This lifts the parent's r = 2 residue-counting architecture from parity to an arbitrary modulus.",
+  "meta": {
+    "author": "lean-genius researcher agents, formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Tur%C3%A1n_graph",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "graph-theory",
+      "combinatorics",
+      "extremal-graph-theory",
+      "turan-graph",
+      "turan-theorem",
+      "minimum-degree",
+      "sharpness",
+      "residue-classes"
+    ],
+    "proofRepoPath": "Proofs/MantelTheoremOQ03OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.turanGraph",
+        "description": "The Turán graph on Fin n with Adj v w ↔ v % r ≠ w % r; the complete r-partite graph whose parts are the residue classes mod r",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Extremal.Turan"
+      },
+      {
+        "theorem": "SimpleGraph.turanGraph_adj",
+        "description": "The adjacency characterisation (turanGraph n r).Adj v w ↔ (v : ℕ) % r ≠ (w : ℕ) % r; used to rewrite the neighbour filter as a residue predicate",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Extremal.Turan"
+      },
+      {
+        "theorem": "SimpleGraph.turanGraph_cliqueFree",
+        "description": "For 0 < r the Turán graph turanGraph n r is CliqueFree (r+1); supplies the Kᵣ₊₁-free half of the sharpness certificate",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Extremal.Turan"
+      },
+      {
+        "theorem": "SimpleGraph.le_minDegree_of_forall_le_degree",
+        "description": "In a nonempty graph, if k ≤ deg v for every v then k ≤ minDegree; supplies the lower bound n − ⌈n/r⌉ ≤ minDegree",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "SimpleGraph.minDegree_le_degree",
+        "description": "minDegree ≤ deg v for any vertex v; evaluated at residue-0 vertex it gives minDegree ≤ n − ⌈n/r⌉",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "Nat.count_eq_card_filter_range",
+        "description": "count p n equals the cardinality of {x ∈ range n | p x}; the bridge turning a Fin n neighbour count into a Nat.count and an injection-based cardinality comparison",
+        "module": "Mathlib.Data.Nat.Count"
+      },
+      {
+        "theorem": "Nat.succ_div",
+        "description": "(a+1)/b = a/b + if b ∣ a+1 then 1 else 0; the exact successor recurrence for Nat-division that evaluates the residue-class-0 size in closed form",
+        "module": "Init.Data.Nat.Div.Lemmas"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "An injection on a Finset bounds its cardinality by that of the codomain; with k ↦ k − j it proves residue class 0 is the largest class",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.filter_card_add_filter_neg_card_eq_card",
+        "description": "#(s.filter p) + #(s.filter ¬p) = #s; splits Fin n into neighbours (v % r ≠ w % r) and same-class vertices to give deg v + #{same class} = n",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "card_fin_filter_val: the reusable Fin n → Nat.count bridge from the parent, equating #{w : Fin n | Q w.val} with Nat.count Q n via the injective image of Fin.val onto range n",
+      "count_mod_eq_zero: the residue-class-0 size Nat.count (·%r=0) n = (n+r−1)/r = ⌈n/r⌉ for r ≥ 1, proved by induction on n using Nat.count_succ and the exact Nat-division recurrence Nat.succ_div (the general-modulus replacement for the parity case's omega-friendly /2)",
+      "count_mod_le_zero: antitonicity of residue-class size — Nat.count (·%r=j) n ≤ Nat.count (·%r=0) n for every j — via the explicit injection k ↦ k − j on range-n filters (each element satisfies k ≥ k % r = j, so k − j = r·(k/r) lands in class 0), pinning the minimum-degree vertex to residue 0",
+      "turanGraph_degree: the exact per-vertex degree deg v = n − #{k < n : k % r = v % r}, obtained by splitting Fin n into the neighbour class (v % r ≠ w % r) and its complement and transferring the complement count to Nat.count",
+      "turanGraph_minDegree: the headline formula (turanGraph n r).minDegree = n − ⌈n/r⌉ for n, r ≥ 1, by minDegree antisymmetry (residue-0 vertex attains it from above; the class-size antitonicity bounds every degree from below)",
+      "turanGraph_minDegree_sharp: the packaged certificate — turanGraph n r is CliqueFree (r+1) AND has minimum degree exactly n − ⌈n/r⌉ — answering the parent's third open question that the (1 − 1/r)·n Kᵣ₊₁-free minimum-degree bound is sharp",
+      "turanGraph_minDegree_bound: the (1 − 1/r)·n bound in cleared-denominator form r·minDegree ≤ (r−1)·n, derived from n ≤ r·⌈n/r⌉",
+      "turanTwo_specialization: consistency with the parent — for r = 2 the formula n − ⌈n/2⌉ = ⌊n/2⌋ recovers turanTwo_minDegree"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCountNote": "0 axiom declarations, 0 sorries, 0 structure-encoded assumptions, no native_decide. Every theorem is machine-checked (verified via `lake env lean` with #print axioms) from Mathlib's Turán-graph, simple-graph degree, Nat.count and Nat-division APIs; the only foundational dependencies are propext/Classical.choice/Quot.sound, which the project does not count."
+  },
+  "overview": {
+    "historicalContext": "Turán's 1941 theorem bounds the edges of a Kᵣ₊₁-free graph on n vertices by those of the Turán graph turanGraph n r, the balanced complete r-partite graph. Its local companion — the minimum-degree version — states that a Kᵣ₊₁-free graph must have a vertex of degree at most (1 − 1/r)·n. As with any upper bound, this is only meaningful once one exhibits a graph attaining it, and the natural witness is the Turán graph itself. The parent gallery entry (mantel-theorem-oq-03-oq-01) supplied this witness for r = 2 — the balanced complete bipartite graph with minimum degree ⌊n/2⌋ — as the sharpness certificate for Mantel's minimum-degree corollary. This entry lifts that computation to every r ≥ 1, closing the parent's third open question in one uniform statement and producing, as a byproduct, the full minimum-degree data of the extremal graph in Turán's theorem.",
+    "problemStatement": "For every n, r ≥ 1, compute the minimum degree of the general Turán graph turanGraph n r and certify that it witnesses sharpness of the (1 − 1/r)·n minimum-degree bound for Kᵣ₊₁-free graphs. Concretely: prove deg v = n − #{k < n : k % r = v % r}, that residue class 0 (of size ⌈n/r⌉) is the largest, and hence (turanGraph n r).minDegree = n − ⌈n/r⌉, packaged with turanGraph_cliqueFree.",
+    "proofStrategy": "turanGraph n r is defined on Fin n by Adj v w ↔ (v : ℕ) % r ≠ (w : ℕ) % r, so a vertex is adjacent to exactly the vertices outside its own residue class mod r. (1) Degree: Fin n splits into the neighbour class {w : v % r ≠ w % r} and the same-residue class {w : w % r = v % r}; filter_card_add_filter_neg_card_eq_card gives deg v + #{same class} = n, and card_fin_filter_val transfers the same-class count to Nat.count (fun k => k % r = v % r) n, yielding deg v = n − that count. (2) Class-0 size: Nat.count (·%r=0) n = ⌈n/r⌉ = (n+r−1)/r by induction on n; the successor step uses Nat.succ_div (the exact Nat-division recurrence) since division by a variable r is not omega-decidable as it was for the parity case. (3) Class 0 is largest: for any residue j, the map k ↦ k − j injects {k < n : k % r = j} into {k < n : k % r = 0}, because every such k satisfies k ≥ k % r = j and k − j = r·(k/r) is a multiple of r; card_le_card_of_injOn gives the antitonicity. (4) Minimum degree: the residue-0 vertex ⟨0, hn⟩ attains deg = n − ⌈n/r⌉, giving minDegree ≤ n − ⌈n/r⌉ (minDegree_le_degree); and since every same-residue count is ≤ ⌈n/r⌉, every degree is ≥ n − ⌈n/r⌉, giving the reverse bound (le_minDegree_of_forall_le_degree). Antisymmetry closes minDegree = n − ⌈n/r⌉.",
+    "keyInsights": [
+      "The whole minimum-degree computation reduces to one arithmetic fact — the size of the largest residue class mod r inside Fin n — plus the observation that a vertex's degree is n minus its own class size. Extremal graph theory becomes elementary Nat.count arithmetic.",
+      "The parity case (parent, r = 2) hid a subtlety: division by the literal 2 is omega-decidable, so its closed forms fell out of omega. For a variable modulus r that shortcut is gone; the successor recurrence Nat.succ_div (a+1)/b = a/b + [b ∣ a+1] is the exact replacement that keeps the induction two lines long.",
+      "Identifying the minimum-degree vertex needs a genuine monotonicity argument absent in the r = 2 case (where only two class sizes differ by at most one). The injection k ↦ k − j — shifting residue class j down onto class 0 — proves once and for all that class 0 is the largest, so residue 0 minimises the degree.",
+      "The formula n − ⌈n/r⌉ survives the degenerate regime n ≤ r without special-casing: there some residue classes are empty, the graph is the complete Kₙ, and every degree is n − 1 — which is exactly n − ⌈n/r⌉ since ⌈n/r⌉ = 1 when 0 < n ≤ r.",
+      "Cleared of denominators, minDegree = n − ⌈n/r⌉ becomes r·minDegree ≤ (r−1)·n, the honest Nat statement of the (1 − 1/r)·n bound, and follows from the single inequality n ≤ r·⌈n/r⌉."
+    ]
+  },
+  "references": [
+    {
+      "authors": [
+        "Turán, P."
+      ],
+      "title": "On an extremal problem in graph theory (Hungarian)",
+      "year": "1941",
+      "venue": "Matematikai és Fizikai Lapok 48, pp. 436–452",
+      "note": "The extremal theorem whose extremal graph is turanGraph n r and whose minimum-degree companion this entry certifies as sharp."
+    },
+    {
+      "authors": [
+        "Bollobás, B."
+      ],
+      "title": "Extremal Graph Theory",
+      "year": "1978",
+      "venue": "London Mathematical Society Monographs 11, Academic Press",
+      "note": "Standard reference for Turán's theorem, the Turán graph and its degree sequence."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, axiom-free and sorry-free computation of the minimum degree of the general Turán graph: for every n, r ≥ 1, (turanGraph n r).minDegree = n − ⌈n/r⌉, packaged with Kᵣ₊₁-freeness into a sharpness certificate for the (1 − 1/r)·n minimum-degree bound. Along the way it establishes the exact per-vertex degree, the closed-form size of residue class 0, and the antitonicity of class size that pins the minimising vertex to residue 0.",
+    "implications": "Answers the parent's third open question uniformly in r: the Kᵣ₊₁-free minimum-degree bound (1 − 1/r)·n is attained by the Turán graph, so it is exact. It also records the full minimum-degree datum of the extremal graph in Turán's theorem as a reusable Mathlib-level fact, and demonstrates that the parent's parity residue-counting technique scales to an arbitrary modulus. The residue-class-size closed form count_mod_eq_zero and the antitonicity count_mod_le_zero are reusable for any modular-counting argument over Fin n.",
+    "openQuestions": [
+      "Compute the full degree sequence of turanGraph n r — the multiset of class sizes ⌈(n−j)/r⌉ for j = 0, …, r−1 — and its maximum degree n − ⌊n/r⌋, completing the local extremal data.",
+      "Combine minDegree = n − ⌈n/r⌉ with Mathlib's edge-count card_edgeFinset_turanGraph to relate the local (minimum-degree) and global (edge-count) forms of Turán's theorem for the extremal graph."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "License and Imports",
+      "startLine": 1,
+      "endLine": 5,
+      "summary": "Apache-2.0 license header and a single import Mathlib, supplying the Turán-graph development (Extremal.Turan), the simple-graph degree API (Finite), Nat.count, and the Nat-division lemmas.",
+      "mathContext": "Relies on Mathlib.Combinatorics.SimpleGraph.Extremal.Turan, .Finite, Mathlib.Data.Nat.Count and Init Nat-division."
+    },
+    {
+      "id": "docstring",
+      "title": "Statement and Method",
+      "startLine": 7,
+      "endLine": 48,
+      "summary": "Module docstring locating the result as the general-r lift of the parent's r = 2 sharpness certificate, naming the witness turanGraph n r and outlining the residue-counting method: degree = n − own class size, closed-form class-0 size, and class-size antitonicity.",
+      "mathContext": "(turanGraph n r).minDegree = n − ⌈n/r⌉ for n, r ≥ 1."
+    },
+    {
+      "id": "bridge",
+      "title": "Counting Bridge: Fin n to Nat.count",
+      "startLine": 50,
+      "endLine": 68,
+      "summary": "card_fin_filter_val equates #{w : Fin n | Q w.val} with Nat.count Q n via the injective image of Fin.val onto range n. Reused verbatim from the parent; converts per-vertex counting into Nat.count and Finset cardinality comparisons.",
+      "mathContext": "$\\#\\{w : \\mathrm{Fin}\\,n \\mid Q\\,w\\} = \\mathrm{count}\\,Q\\,n$."
+    },
+    {
+      "id": "class-zero-size",
+      "title": "Closed Form for Residue Class 0",
+      "startLine": 70,
+      "endLine": 87,
+      "summary": "count_mod_eq_zero evaluates #{k < n : k % r = 0} = (n+r−1)/r = ⌈n/r⌉ by induction on n. The successor step rewrites the target Nat-division with Nat.succ_div and matches the count_succ increment via the equivalence r ∣ m+r ↔ m % r = 0.",
+      "mathContext": "$\\#\\{k < n : k \\% r = 0\\} = \\lceil n/r\\rceil = (n+r-1)/r$."
+    },
+    {
+      "id": "class-antitone",
+      "title": "Residue Class 0 Is the Largest",
+      "startLine": 89,
+      "endLine": 106,
+      "summary": "count_mod_le_zero proves Nat.count (·%r=j) n ≤ Nat.count (·%r=0) n by injecting the class-j filter into the class-0 filter through k ↦ k − j. Each element satisfies k ≥ k % r = j, so k − j = r·(k/r) has residue 0 and stays below n; injectivity is immediate since all elements exceed j.",
+      "mathContext": "$\\#\\{k < n : k \\% r = j\\} \\le \\#\\{k < n : k \\% r = 0\\}$."
+    },
+    {
+      "id": "degree",
+      "title": "Exact Per-Vertex Degree",
+      "startLine": 108,
+      "endLine": 128,
+      "summary": "turanGraph_degree computes deg v = n − #{k < n : k % r = v % r}. Fin n splits into the neighbour class (v % r ≠ w % r) and its complement (same residue) via filter_card_add_filter_neg_card_eq_card, giving deg v + count = n; the complement count is transferred to Nat.count by the bridge.",
+      "mathContext": "$\\deg v = n - \\#\\{k < n : k \\% r = v \\% r\\}$."
+    },
+    {
+      "id": "min-degree",
+      "title": "Minimum Degree Exactly n − ⌈n/r⌉",
+      "startLine": 130,
+      "endLine": 150,
+      "summary": "turanGraph_minDegree proves (turanGraph n r).minDegree = n − ⌈n/r⌉ for n, r ≥ 1 by antisymmetry: the residue-0 vertex ⟨0, hn⟩ attains n − ⌈n/r⌉ (minDegree_le_degree with count_mod_eq_zero); and every degree is ≥ n − ⌈n/r⌉ because every same-residue count is ≤ ⌈n/r⌉ (count_mod_le_zero), giving the reverse bound via le_minDegree_of_forall_le_degree.",
+      "mathContext": "$n, r \\ge 1 \\Rightarrow (\\mathrm{turanGraph}\\,n\\,r).\\mathrm{minDegree} = n - \\lceil n/r\\rceil$."
+    },
+    {
+      "id": "certificate-and-bound",
+      "title": "Sharpness Certificate, Bound, and r = 2 Check",
+      "startLine": 152,
+      "endLine": 174,
+      "summary": "turanGraph_minDegree_sharp packages CliqueFree (r+1) with the minimum-degree formula. turanGraph_minDegree_bound gives the cleared-denominator (1 − 1/r)·n bound r·minDegree ≤ (r−1)·n from n ≤ r·⌈n/r⌉. turanTwo_specialization checks that r = 2 recovers the parent's ⌊n/2⌋.",
+      "mathContext": "$K_{r+1}$-free and $\\min\\deg = n - \\lceil n/r\\rceil$; $r\\cdot\\min\\deg \\le (r-1)n$; $r = 2$ gives $\\lfloor n/2\\rfloor$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "mantel-theorem-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "The direct parent computes the r = 2 case (turanTwo_minDegree: minimum degree ⌊n/2⌋ of the balanced complete bipartite graph). This entry generalises its residue-counting architecture from parity to an arbitrary modulus r, proving (turanGraph n r).minDegree = n − ⌈n/r⌉ and answering the parent's third open question. turanTwo_specialization confirms r = 2 reproduces turanTwo_minDegree."
+    },
+    {
+      "targetId": "mantel-theorem-oq-03",
+      "relationship": "related",
+      "description": "The grandparent proves the triangle-free (r = 2) minimum-degree bound this construction shows is sharp; the general-r version certifies sharpness of the analogous (1 − 1/r)·n bound for Kᵣ₊₁-free graphs."
+    },
+    {
+      "targetId": "mantel-theorem",
+      "relationship": "related",
+      "description": "mantel-theorem is the r = 2 global edge bound ⌊n²/4⌋; turanGraph n r is the extremal graph of the general Turán theorem, whose minimum-degree data this entry computes."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "SimpleGraph"
+    ],
+    "namespace": "MantelTuranGeneral",
+    "lineCount": 174,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/MantelTheoremOQ03OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    "card_fin_filter_val",
+    "count_mod_eq_zero",
+    "count_mod_le_zero",
+    "turanGraph_degree",
+    "turanGraph_minDegree",
+    "turanGraph_minDegree_sharp",
+    "turanGraph_minDegree_bound",
+    "turanTwo_specialization"
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Generalizes the parent **mantel-theorem-oq-03-oq-01** (`r = 2` sharpness certificate for Mantel's minimum-degree bound) to **every `r ≥ 1`**, answering the parent's third open question. For Mathlib's general Turán graph `turanGraph n r` on `Fin n` (`v ~ w ↔ v % r ≠ w % r`, the complete `r`-partite graph on residue classes mod `r`):

$$(\texttt{turanGraph}\ n\ r).\mathrm{minDegree} = n - \lceil n/r\rceil = n - (n+r-1)/r \qquad (n, r \ge 1).$$

Packaged with `turanGraph_cliqueFree` into a sharpness certificate that the `(1 − 1/r)·n` minimum-degree bound for `K_{r+1}`-free graphs is attained, hence exact.

## Theorems (8, 174 lines, `Proofs/MantelTheoremOQ03OQ01OQ02.lean`)

- `turanGraph_degree` — exact per-vertex degree `deg v = n − #{k < n : k % r = v % r}`
- `count_mod_eq_zero` — residue-class-0 size `#{k < n : k % r = 0} = ⌈n/r⌉` (via `Nat.succ_div` induction)
- `count_mod_le_zero` — class 0 is the largest, via the injection `k ↦ k − j`
- `turanGraph_minDegree` — the headline formula `minDegree = n − ⌈n/r⌉`
- `turanGraph_minDegree_sharp` — `CliqueFree (r+1) ∧ minDegree = n − ⌈n/r⌉`
- `turanGraph_minDegree_bound` — `(1 − 1/r)·n` bound as `r·minDegree ≤ (r−1)·n`
- `turanTwo_specialization` — `r = 2` recovers the parent's `⌊n/2⌋`

## Method

Ports the parent's `card_fin_filter_val → Nat.count` pipeline from parity to an arbitrary modulus. The two genuinely new pieces the `r = 2` case did not need:
- **Closed-form class-0 size.** Division by the literal `2` was `omega`-decidable; for variable `r` the successor step uses the exact recurrence `Nat.succ_div`.
- **Class-size antitonicity.** With only two parity classes the parent never had to identify the largest class; here the shift `k ↦ k − j` (each `k` with `k % r = j` has `k − j = r·(k/r)`) injects class `j` into class `0`.

## Verification

Machine-checked with `lake env lean`; `#print axioms` reports only `propext, Classical.choice, Quot.sound` — **0-axiom / VERIFIED** per the project's axiom policy (0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions, no `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)