### PR TITLE
Enrich Erdős #729 OQ-04 (multinomial Legendre/Kummer): add annotations.json

### DIFF
--- a/src/data/proofs/erdos-729-oq-04/annotations.json
+++ b/src/data/proofs/erdos-729-oq-04/annotations.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "ann-e729oq04-prod",
+    "proofId": "erdos-729-oq-04",
+    "range": {
+      "startLine": 59,
+      "endLine": 71
+    },
+    "type": "theorem",
+    "title": "Valuation Splits Over a Product of Factorials",
+    "content": "`padicValNat_prod_factorial` proves `v_p(∏ᵢ (f i)!) = ∑ᵢ v_p((f i)!)` by `Finset.induction`. The only fact needed at each step is that every factorial is nonzero (`Nat.factorial_ne_zero`), so `padicValNat.mul` applies termwise — no prime-by-prime analysis. This is the additive-over-a-product engine that lets the multinomial's valuation be read off from `Nat.multinomial_spec`.",
+    "mathContext": "For $p$-adic valuation, $v_p(ab)=v_p(a)+v_p(b)$ whenever $a,b\\neq 0$; iterating over a finite product gives $v_p\\!\\big(\\prod_i (f i)!\\big)=\\sum_i v_p((f i)!)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "p-adic valuation",
+      "Finset induction",
+      "Multiplicativity of valuations"
+    ],
+    "prerequisites": [
+      "padicValNat.mul",
+      "Nat.factorial_ne_zero",
+      "Finset.induction"
+    ],
+    "tags": [
+      "theorem",
+      "valuation",
+      "induction"
+    ]
+  },
+  {
+    "id": "ann-e729oq04-legendre",
+    "proofId": "erdos-729-oq-04",
+    "range": {
+      "startLine": 73,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "Legendre's Identity in Subtraction-Free Additive Form",
+    "content": "`legendre_add` recasts Legendre's formula as `(p−1)·v_p(n!) + s_p(n) = n`, where `s_p(n) = (p.digits n).sum`. It combines Mathlib's multiplied form `sub_one_mul_padicValNat_factorial` with the digit-sum bound `Nat.digit_sum_le` and closes by `omega`. Keeping the identity additive (rather than the classical `v_p(n!) = (n − s_p(n))/(p−1)`) is the key move: it eliminates natural-number subtraction, so the whole downstream derivation can be discharged by `omega` on shared atoms.",
+    "mathContext": "Legendre (1808): $v_p(n!) = \\dfrac{n - s_p(n)}{p-1}$. Clearing the denominator gives the subtraction-free form $(p-1)\\,v_p(n!) + s_p(n) = n$, valid since $s_p(n)\\le n$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Legendre's formula",
+      "Base-p digit sum",
+      "Subtraction-free reformulation"
+    ],
+    "prerequisites": [
+      "sub_one_mul_padicValNat_factorial",
+      "Nat.digit_sum_le",
+      "omega"
+    ],
+    "tags": [
+      "theorem",
+      "legendre-formula",
+      "digit-sum",
+      "key-result"
+    ]
+  },
+  {
+    "id": "ann-e729oq04-main",
+    "proofId": "erdos-729-oq-04",
+    "range": {
+      "startLine": 83,
+      "endLine": 117
+    },
+    "type": "theorem",
+    "title": "The Multinomial Legendre/Kummer Identity (★)",
+    "content": "`sub_one_mul_padicValNat_multinomial` is the core result: `(p−1)·v_p(multinomial s f) + s_p(Σᵢ f i) = Σᵢ s_p(f i)` over an arbitrary finite index set `s` (any number of parts `k = |s|`). The proof extracts `v_p(N!) = Σᵢ v_p((f i)!) + v_p(multinomial)` from `Nat.multinomial_spec` (via `padicValNat.mul` and `padicValNat_prod_factorial`), sums `legendre_add` over the parts, expands `legendre_add` for the total `N` through that relation, and lets `omega` cancel the shared atom `(p−1)·Σ v_p((f i)!)`. No subtraction, no per-prime bookkeeping.",
+    "mathContext": "For $N=\\sum_i a_i$: $(p-1)\\,v_p\\!\\big(\\tfrac{N!}{\\prod a_i!}\\big) = \\sum_i s_p(a_i) - s_p(N)$. The right side, divided by $p-1$, is the number of carries when the $a_i$ are added in base $p$ (multinomial Kummer theorem).",
+    "significance": "central",
+    "relatedConcepts": [
+      "Kummer's theorem",
+      "Multinomial coefficients",
+      "Carry counting in base p"
+    ],
+    "prerequisites": [
+      "Nat.multinomial_spec",
+      "padicValNat.mul",
+      "legendre_add",
+      "omega on shared atoms"
+    ],
+    "tags": [
+      "theorem",
+      "kummer-theorem",
+      "multinomials",
+      "key-result"
+    ]
+  },
+  {
+    "id": "ann-e729oq04-div",
+    "proofId": "erdos-729-oq-04",
+    "range": {
+      "startLine": 119,
+      "endLine": 130
+    },
+    "type": "theorem",
+    "title": "The Classical Division Form",
+    "content": "`padicValNat_multinomial_eq_div` restates (★) in the familiar quotient form `v_p(multinomial s f) = (Σᵢ s_p(f i) − s_p(Σᵢ f i))/(p−1)`. Because `p ≥ 2` gives `p−1 > 0`, the additive identity can be divided cleanly by `Nat.mul_div_cancel_left`. This is the shape most directly comparable to Legendre's `v_p(n!) = (n − s_p(n))/(p−1)`.",
+    "mathContext": "$v_p\\!\\big(\\tfrac{N!}{\\prod a_i!}\\big) = \\dfrac{\\sum_i s_p(a_i) - s_p(N)}{p-1}$, the multinomial analogue of Legendre's factorial valuation.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Legendre's formula",
+      "Exact division in ℕ",
+      "p-adic valuation"
+    ],
+    "prerequisites": [
+      "Nat.mul_div_cancel_left",
+      "Positivity of p−1",
+      "The additive identity (★)"
+    ],
+    "tags": [
+      "theorem",
+      "valuation",
+      "division-form"
+    ]
+  },
+  {
+    "id": "ann-e729oq04-fin-dvd",
+    "proofId": "erdos-729-oq-04",
+    "range": {
+      "startLine": 132,
+      "endLine": 154
+    },
+    "type": "theorem",
+    "title": "The k-Part Form and the Kummer Divisibility Criterion",
+    "content": "`sub_one_mul_padicValNat_multinomial_fin` specializes (★) to `k` parts indexed by `Fin k` (via `s = Finset.univ`), the literal answer to the parent's `n!/(a₁!⋯a_k!)` with `k > 2` phrasing. `prime_dvd_multinomial_iff` then reads off the divisibility criterion `p ∣ multinomial s f ↔ s_p(Σᵢ f i) < Σᵢ s_p(f i)` — i.e. adding the parts in base `p` produces at least one carry. It uses `dvd_iff_padicValNat_ne_zero` and `mul_pos_iff_of_pos_left` to turn `p ∣ ·` into positivity of the left side of (★), then `omega`.",
+    "mathContext": "$p \\mid \\dfrac{N!}{\\prod a_i!} \\iff s_p(N) < \\sum_i s_p(a_i)$: a prime divides the multinomial coefficient exactly when the base-$p$ addition of the parts carries. The two-part case $s=\\{a,b\\}$ is the classical binomial Kummer theorem.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Kummer's theorem",
+      "Divisibility criteria",
+      "Fin-indexed specialization"
+    ],
+    "prerequisites": [
+      "dvd_iff_padicValNat_ne_zero",
+      "mul_pos_iff_of_pos_left",
+      "Finset.univ specialization"
+    ],
+    "tags": [
+      "theorem",
+      "kummer-theorem",
+      "divisibility",
+      "key-result"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment pass — erdos-729-oq-04

**Erdős #729 OQ-04: The Multinomial Legendre/Kummer Identity, Axiom-Free**

The entry had a rich `meta.json` but **no `annotations.json`** (quality score 41). This adds inline annotation coverage across the whole Lean file.

### Change
Create `annotations.json` with **5 per-theorem inline annotations**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, and `tags`:

1. **`padicValNat_prod_factorial`** — valuation splits over a factorial product
2. **`legendre_add`** — subtraction-free additive form of Legendre's identity
3. **`sub_one_mul_padicValNat_multinomial`** — the core identity (★), `(p−1)·v_p(multinomial) + s_p(N) = Σ s_p(aᵢ)`
4. **`padicValNat_multinomial_eq_div`** — the classical division form
5. **Fin-k form + `prime_dvd_multinomial_iff`** — the multinomial Kummer carry-divisibility criterion

### Verification
- `annotations/build.ts`: **0 errors** for this entry (all 5 ranges land on real Lean constructs)
- `gallery/check-meta-size.ts`: within caps
- meta.json unchanged; only `src/data/proofs/erdos-729-oq-04/annotations.json` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)