### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-04-oq-03): all factorial moments E[(X)_r]=(n)_r·p^r [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ04OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ04OQ03.lean
@@ -1,0 +1,211 @@
+/-
+# All Factorial Moments of the Binomial Marginal (OQ-02-OQ-01-OQ-04-OQ-03)
+
+*Open Question from `BinomialTheoremOQ02OQ01OQ04` (Multinomial Variance).* The
+variance file closes the diagonal **second** moment of a multinomial component,
+and it does so by reducing to the binomial marginal's first two moments proved
+in `BinomialTheoremOQ03`:
+
+  * `binomial_mean`                    : `E[X]      = n·p`      (needs `1 ≤ n`)
+  * `binomial_second_factorial_moment` : `E[X(X-1)] = n(n-1)·p²` (needs `2 ≤ n`)
+
+Each was proved separately by peeling off `r` vanishing low-order terms and
+applying an `r`-fold "absorption" identity (`absorption`, `double_absorption`).
+That approach does not scale: the `r`-th factorial moment would need an
+`r`-fold absorption lemma written out by hand.
+
+## Answer
+
+YES — **all** factorial moments have one uniform closed form, with **no** side
+condition on `n` or `r`. For `X ~ Binomial(n, p)` and the falling factorial
+`(m)_r = m(m-1)⋯(m-r+1) = Nat.descFactorial m r`,
+
+  E[(X)_r] = ∑ₖ (k)_r · C(n,k) pᵏ (1-p)ⁿ⁻ᵏ = (n)_r · pʳ.
+
+Setting `r = 1` recovers `E[X] = n·p` and `r = 2` recovers `E[X(X-1)] =
+n(n-1)·p²`, both now valid for *every* `n` (the earlier `1 ≤ n` / `2 ≤ n`
+hypotheses were artefacts of the term-peeling proof, not the mathematics).
+
+## Proof Strategy
+
+The engine is the single **subset-of-a-subset** identity for the falling
+factorial (one lemma replacing the whole `absorption` tower):
+
+  (k)_r · C(n,k) = (n)_r · C(n-r, k-r)          [for `r ≤ k`]
+
+which follows from Mathlib's `Nat.choose_mul`
+(`C(n,k)·C(k,r) = C(n,r)·C(n-r,k-r)`) together with
+`descFactorial = r! · choose`. Casting to `ℝ` and matching exponents turns each
+term into a *lower* binomial term:
+
+  (k)_r · binomPMF n p k = (n)_r · pʳ · binomPMF (n-r) p (k-r)     [for `r ≤ k ≤ n`].
+
+Summing, the low terms `k < r` vanish (`(k)_r = 0`), the index shifts by `r`,
+and what remains is `(n)_r · pʳ` times the normalization
+`∑ binomPMF (n-r) p = 1` (`BinomialTheoremOQ03.binomPMF_sum_eq_one`). The case
+`r > n` gives `0 = 0` on both sides.
+
+No new axioms, no sorries.
+
+Tags: probability, binomial-distribution, factorial-moment, falling-factorial,
+      descFactorial, moments, combinatorics
+-/
+
+import Mathlib
+import Proofs.BinomialTheoremOQ03
+
+open Finset BigOperators
+
+namespace BinomialTheoremOQ02OQ01OQ04OQ03
+
+open BinomialTheoremOQ03
+
+/-! ## The engine: a single subset-of-a-subset identity -/
+
+/-- **Falling-factorial absorption.** For `r ≤ k`,
+`(k)_r · C(n,k) = (n)_r · C(n-r, k-r)`, where `(m)_r = Nat.descFactorial m r`.
+
+This one identity subsumes the entire `absorption` / `double_absorption` tower
+used for the first and second factorial moments: it is the `r`-fold statement.
+It is `Nat.choose_mul` (`C(n,k)·C(k,r) = C(n,r)·C(n-r,k-r)`) dressed with
+`descFactorial = r! · choose`. -/
+theorem descFactorial_mul_choose (n k r : ℕ) (hrk : r ≤ k) :
+    k.descFactorial r * n.choose k = n.descFactorial r * (n - r).choose (k - r) := by
+  have hcm := Nat.choose_mul (n := n) (k := k) (s := r) hrk
+  -- hcm : n.choose k * k.choose r = n.choose r * (n - r).choose (k - r)
+  rw [Nat.descFactorial_eq_factorial_mul_choose k r,
+      Nat.descFactorial_eq_factorial_mul_choose n r, mul_assoc, mul_assoc]
+  -- goal: r! * (C(k,r) * C(n,k)) = r! * (C(n,r) * C(n-r,k-r))
+  congr 1
+  rw [mul_comm]
+  exact hcm
+
+/-- **Termwise reduction.** For `r ≤ k ≤ n`, a single falling-factorial-weighted
+binomial term collapses to `(n)_r · pʳ` times a *lower* binomial PMF:
+
+  `(k)_r · binomPMF n p k = (n)_r · pʳ · binomPMF (n-r) p (k-r)`. -/
+private theorem descFactorial_mul_binomPMF (n r k : ℕ) (p : ℝ)
+    (hrk : r ≤ k) (hkn : k ≤ n) :
+    (k.descFactorial r : ℝ) * binomPMF n p k =
+    (n.descFactorial r : ℝ) * p ^ r * binomPMF (n - r) p (k - r) := by
+  unfold binomPMF
+  have hnat : (k.descFactorial r : ℝ) * (n.choose k : ℝ) =
+      (n.descFactorial r : ℝ) * ((n - r).choose (k - r) : ℝ) := by
+    exact_mod_cast descFactorial_mul_choose n k r hrk
+  have hp : p ^ k = p ^ r * p ^ (k - r) := by rw [← pow_add]; congr 1; omega
+  have hq : (1 - p) ^ (n - k) = (1 - p) ^ (n - r - (k - r)) := by congr 1; omega
+  calc (k.descFactorial r : ℝ) * ((n.choose k : ℝ) * p ^ k * (1 - p) ^ (n - k))
+      = ((k.descFactorial r : ℝ) * (n.choose k : ℝ)) * p ^ k * (1 - p) ^ (n - k) := by ring
+    _ = ((n.descFactorial r : ℝ) * ((n - r).choose (k - r) : ℝ)) * p ^ k *
+          (1 - p) ^ (n - k) := by rw [hnat]
+    _ = (n.descFactorial r : ℝ) * p ^ r *
+          (((n - r).choose (k - r) : ℝ) * p ^ (k - r) * (1 - p) ^ (n - r - (k - r))) := by
+          rw [hp, hq]; ring
+
+/-! ## The general factorial moment -/
+
+/-- **General factorial moment of the binomial distribution.**
+For every `n, r : ℕ` and every `p : ℝ`,
+
+  `E[(X)_r] = ∑ₖ (k)_r · binomPMF n p k = (n)_r · pʳ`,
+
+where `(m)_r = Nat.descFactorial m r = m(m-1)⋯(m-r+1)` is the falling factorial.
+No lower bound on `n` or `r` is required. -/
+theorem binomial_factorial_moment (n r : ℕ) (p : ℝ) :
+    ∑ k ∈ range (n + 1), (k.descFactorial r : ℝ) * binomPMF n p k =
+    (n.descFactorial r : ℝ) * p ^ r := by
+  rcases le_or_gt r n with hrn | hrn
+  · -- `r ≤ n`: shift the index and reduce to lower-order normalization.
+    -- Terms with `k < r` vanish, so restrict the sum to `Ico r (n+1)`.
+    have hsplit : ∑ k ∈ range (n + 1), (k.descFactorial r : ℝ) * binomPMF n p k =
+        ∑ k ∈ Ico r (n + 1), (k.descFactorial r : ℝ) * binomPMF n p k := by
+      rw [Finset.range_eq_Ico,
+          ← Finset.sum_Ico_consecutive _ (Nat.zero_le r) (by omega : r ≤ n + 1)]
+      have hzero : ∑ k ∈ Ico 0 r, (k.descFactorial r : ℝ) * binomPMF n p k = 0 := by
+        apply Finset.sum_eq_zero
+        intro k hk
+        rw [Finset.mem_Ico] at hk
+        have : k.descFactorial r = 0 := Nat.descFactorial_eq_zero_iff_lt.mpr hk.2
+        rw [this]; simp
+      rw [hzero, zero_add]
+    rw [hsplit, Finset.sum_Ico_eq_sum_range]
+    -- Now `∑ i ∈ range (n+1-r), (r+i)_r · binomPMF n p (r+i)`.
+    have hterms : ∀ i ∈ range (n + 1 - r),
+        ((r + i).descFactorial r : ℝ) * binomPMF n p (r + i) =
+        (n.descFactorial r : ℝ) * p ^ r * binomPMF (n - r) p i := by
+      intro i hi
+      rw [Finset.mem_range] at hi
+      have hkn : r + i ≤ n := by omega
+      have hstep := descFactorial_mul_binomPMF n r (r + i) p (Nat.le_add_right r i) hkn
+      have hri : r + i - r = i := by omega
+      rw [hri] at hstep
+      exact hstep
+    rw [Finset.sum_congr rfl hterms, ← Finset.mul_sum]
+    have hone : ∑ i ∈ range (n + 1 - r), binomPMF (n - r) p i = 1 := by
+      rw [show n + 1 - r = (n - r) + 1 by omega]
+      exact binomPMF_sum_eq_one (n - r) p
+    rw [hone, mul_one]
+  · -- `r > n`: both sides are `0`.
+    have hdn : n.descFactorial r = 0 := Nat.descFactorial_eq_zero_iff_lt.mpr hrn
+    rw [hdn]
+    simp only [Nat.cast_zero, zero_mul]
+    apply Finset.sum_eq_zero
+    intro k hk
+    rw [Finset.mem_range] at hk
+    have : k.descFactorial r = 0 := Nat.descFactorial_eq_zero_iff_lt.mpr (by omega)
+    rw [this]; simp
+
+/-! ## Recovering the mean and the second factorial moment
+
+Both special cases of `binomial_factorial_moment` now hold for **every** `n`,
+dropping the `1 ≤ n` and `2 ≤ n` hypotheses of the original term-peeling proofs
+in `BinomialTheoremOQ03`. -/
+
+/-- The zeroth factorial moment is normalization: `E[1] = 1`. (`r = 0`.) -/
+theorem binomial_zeroth_factorial_moment (n : ℕ) (p : ℝ) :
+    ∑ k ∈ range (n + 1), binomPMF n p k = 1 := by
+  have h := binomial_factorial_moment n 0 p
+  simpa using h
+
+/-- `r = 1`: the mean `E[X] = n·p`, now with **no** lower bound on `n`
+(cf. `BinomialTheoremOQ03.binomial_mean`, which requires `1 ≤ n`). -/
+theorem binomial_mean' (n : ℕ) (p : ℝ) :
+    ∑ k ∈ range (n + 1), (k : ℝ) * binomPMF n p k = (n : ℝ) * p := by
+  have h := binomial_factorial_moment n 1 p
+  simpa [Nat.descFactorial_one, pow_one] using h
+
+/-- `r = 2`: the second factorial moment `E[X(X-1)] = n(n-1)·p²`, now with **no**
+lower bound on `n` (cf. `BinomialTheoremOQ03.binomial_second_factorial_moment`,
+which requires `2 ≤ n`). -/
+theorem binomial_second_factorial_moment' (n : ℕ) (p : ℝ) :
+    ∑ k ∈ range (n + 1), ((k : ℝ) * ((k : ℝ) - 1)) * binomPMF n p k =
+    (n : ℝ) * ((n : ℝ) - 1) * p ^ 2 := by
+  have h := binomial_factorial_moment n 2 p
+  simp only [Nat.cast_descFactorial_two] at h
+  convert h using 2
+
+/-- `r = 3`: the third factorial moment `E[X(X-1)(X-2)] = n(n-1)(n-2)·p³` — a
+genuinely new closed form beyond what the previous absorption tower reached. -/
+theorem binomial_third_factorial_moment (n : ℕ) (p : ℝ) :
+    ∑ k ∈ range (n + 1),
+        ((k : ℝ) * ((k : ℝ) - 1) * ((k : ℝ) - 2)) * binomPMF n p k =
+    (n : ℝ) * ((n : ℝ) - 1) * ((n : ℝ) - 2) * p ^ 3 := by
+  have h := binomial_factorial_moment n 3 p
+  have hcast : ∀ m : ℕ, (m.descFactorial 3 : ℝ) = (m : ℝ) * ((m : ℝ) - 1) * ((m : ℝ) - 2) := by
+    intro m
+    match m with
+    | 0 => simp
+    | 1 => simp [Nat.descFactorial]
+    | 2 => simp [Nat.descFactorial]
+    | (k + 3) =>
+        have hnat : (k + 3).descFactorial 3 = (k + 3) * (k + 2) * (k + 1) := by
+          rw [Nat.descFactorial, Nat.descFactorial, Nat.descFactorial,
+              Nat.descFactorial_zero, mul_one]
+          rw [show k + 3 - 0 = k + 3 from rfl, show k + 3 - 1 = k + 2 from by omega,
+              show k + 3 - 2 = k + 1 from by omega]
+          ring
+        rw [hnat]; push_cast; ring
+  simp only [hcast] at h
+  convert h using 2
+
+end BinomialTheoremOQ02OQ01OQ04OQ03

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04-oq-03",
+    "range": { "startLine": 9, "endLine": 70 },
+    "type": "concept",
+    "title": "All Factorial Moments in One Closed Form",
+    "content": "The parent multinomial-variance file computes the first two moments (mean, variance) of a binomial marginal one order at a time, each via a bespoke absorption identity. This file answers its concluding open question — whether the reduction extends to all orders — by proving the entire factorial-moment sequence at once: $E[(X)_r] = (n)_r\\,p^r$, where $(m)_r = m(m-1)\\cdots(m-r+1)$ is the falling factorial `Nat.descFactorial m r`. Factorial moments are the $r$-th derivatives of the probability generating function $G(t) = E[t^X]$ at $t = 1$, and every ordinary moment $E[X^m]$ is a Stirling-number combination of them.",
+    "mathContext": "$E[(X)_r] = \\sum_{k=0}^{n} (k)_r \\binom{n}{k} p^k (1-p)^{n-k} = (n)_r\\,p^r,\\qquad (m)_r = \\mathrm{descFactorial}(m, r).$",
+    "significance": "key",
+    "relatedConcepts": ["binomial distribution", "factorial moment", "falling factorial", "probability generating function", "Stirling numbers"],
+    "prerequisites": ["probability theory", "binomial distribution"]
+  },
+  {
+    "id": "ann-descfactorial-mul-choose",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04-oq-03",
+    "range": { "startLine": 71, "endLine": 85 },
+    "type": "lemma",
+    "title": "Falling-Factorial Absorption (the engine)",
+    "content": "`descFactorial_mul_choose` proves $(k)_r \\binom{n}{k} = (n)_r \\binom{n-r}{k-r}$ for $r \\le k$. Rewriting each falling factorial as $(m)_r = r!\\binom{m}{r}$ (`Nat.descFactorial_eq_factorial_mul_choose`) reduces the claim to Mathlib's subset-of-a-subset identity `Nat.choose_mul`, $\\binom{n}{k}\\binom{k}{r} = \\binom{n}{r}\\binom{n-r}{k-r}$, after cancelling the common $r!$. This single lemma is the $r$-fold generalization of the `absorption` ($r=1$) and `double_absorption` ($r=2$) identities the earlier file wrote out by hand.",
+    "mathContext": "$(k)_r \\binom{n}{k} = (n)_r \\binom{n-r}{k-r},\\qquad r \\le k.$",
+    "significance": "key",
+    "relatedConcepts": ["binomial coefficient", "subset of a subset", "falling factorial", "absorption identity"],
+    "prerequisites": ["binomial coefficients", "factorials"]
+  },
+  {
+    "id": "ann-descfactorial-mul-binompmf",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04-oq-03",
+    "range": { "startLine": 86, "endLine": 112 },
+    "type": "lemma",
+    "title": "Termwise Reduction to a Lower Binomial Term",
+    "content": "The private lemma `descFactorial_mul_binomPMF` casts the natural-number identity into $\\mathbb{R}$ and matches exponents: for $r \\le k \\le n$, a single falling-factorial-weighted term collapses to $(n)_r p^r$ times a binomial PMF at parameter $n-r$. The powers split as $p^k = p^r p^{k-r}$ and $(1-p)^{n-k} = (1-p)^{(n-r)-(k-r)}$, so the surviving $\\binom{n-r}{k-r}$ reassembles into $\\mathrm{binomPMF}(n-r, p, k-r)$.",
+    "mathContext": "$(k)_r\\,\\mathrm{binomPMF}(n,p,k) = (n)_r\\,p^r\\,\\mathrm{binomPMF}(n-r, p, k-r),\\qquad r \\le k \\le n.$",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial PMF", "exponent arithmetic", "index shift"],
+    "prerequisites": ["binomial distribution", "natural-number casting"]
+  },
+  {
+    "id": "ann-general-factorial-moment",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04-oq-03",
+    "range": { "startLine": 113, "endLine": 163 },
+    "type": "theorem",
+    "title": "Main Theorem: E[(X)ᵣ] = (n)ᵣ·pʳ",
+    "content": "`binomial_factorial_moment` sums the termwise identity. For $r \\le n$ the low terms $k < r$ vanish (since $(k)_r = 0$), so the sum over $\\mathrm{range}(n+1)$ restricts to $\\mathrm{Ico}\\,r\\,(n+1)$; an index shift $k \\mapsto k - r$ (`Finset.sum_Ico_eq_sum_range`) turns it into $(n)_r p^r$ times $\\sum \\mathrm{binomPMF}(n-r, p) = 1$ (`BinomialTheoremOQ03.binomPMF_sum_eq_one`). For $r > n$ both sides are $0$. No hypothesis on $n$ or $r$ is needed — the falling factorial absorbs all the degenerate cases.",
+    "mathContext": "$\\sum_{k=0}^{n} (k)_r\\,\\mathrm{binomPMF}(n,p,k) = (n)_r\\,p^r,\\qquad \\forall\\, n, r \\in \\mathbb{N},\\ p \\in \\mathbb{R}.$",
+    "significance": "key",
+    "relatedConcepts": ["factorial moment", "index shift", "binomial normalization"],
+    "prerequisites": ["finite sums", "binomial distribution"]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04-oq-03",
+    "range": { "startLine": 164, "endLine": 211 },
+    "type": "corollary",
+    "title": "Mean, Second and Third Factorial Moments",
+    "content": "Specializations of the main theorem: $r=0$ is normalization $E[1]=1$; $r=1$ gives the mean $E[X]=n p$; $r=2$ gives $E[X(X-1)] = n(n-1)p^2$; $r=3$ gives the new third factorial moment $E[X(X-1)(X-2)] = n(n-1)(n-2)p^3$. The mean and second-moment forms hold for every $n$, dropping the $1 \\le n$ and $2 \\le n$ hypotheses that `BinomialTheoremOQ03` needed because it peeled off a fixed number of leading terms; those bounds were proof artefacts, not mathematics.",
+    "mathContext": "$E[X] = np,\\quad E[X(X-1)] = n(n-1)p^2,\\quad E[X(X-1)(X-2)] = n(n-1)(n-2)p^3.$",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial mean", "binomial variance", "third factorial moment"],
+    "prerequisites": ["binomial distribution", "expectation"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04-oq-03/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "binomial-theorem-oq-02-oq-01-oq-04-oq-03",
+  "title": "All Factorial Moments of the Binomial Marginal: E[(X)ᵣ] = (n)ᵣ·pʳ",
+  "slug": "binomial-theorem-oq-02-oq-01-oq-04-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BinomialTheoremOQ03"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "BinomialTheoremOQ03"
+    ],
+    "namespace": "BinomialTheoremOQ02OQ01OQ04OQ03",
+    "lineCount": 211,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ02OQ01OQ04OQ03.lean",
+    "sorries": 0
+  },
+  "description": "Proves the closed form for every factorial moment of a binomial random variable in one uniform theorem: E[(X)ᵣ] = ∑ₖ (k)ᵣ·binomPMF(n,p,k) = (n)ᵣ·pʳ, where (m)ᵣ = m(m-1)⋯(m-r+1) = Nat.descFactorial m r is the falling factorial. This answers the parent file's open question — whether the moment reduction extends to all r — and does so with no lower bound on n or r. The engine is a single subset-of-a-subset identity (k)ᵣ·C(n,k) = (n)ᵣ·C(n-r,k-r), which replaces the entire hand-written absorption/double_absorption tower that BinomialTheoremOQ03 needed for r = 1 and r = 2. Casting to ℝ turns each term into a lower binomial term (n)ᵣ·pʳ·binomPMF(n-r,p,k-r), and the sum collapses by index shift and the normalization ∑ binomPMF(n-r,p) = 1. The r = 1 and r = 2 specializations recover E[X] = n·p and E[X(X-1)] = n(n-1)·p² for every n, dropping the 1 ≤ n and 2 ≤ n hypotheses of the original proofs; r = 3 is a genuinely new closed form. Fully machine-verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ04OQ03.lean",
+    "tags": [
+      "probability",
+      "binomial distribution",
+      "factorial moment",
+      "falling factorial",
+      "descFactorial",
+      "moments",
+      "binomial marginal",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 211,
+    "assumptions": "None. All seven theorems are fully machine-verified with 0 sorries and 0 axioms (the only dependencies are Lean's foundational axioms propext, Classical.choice, Quot.sound). Built on the verified binomial PMF, normalization, and binomial theorem from BinomialTheoremOQ03, plus Mathlib's Nat.choose_mul and descFactorial API.",
+    "theoremCount": 7,
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Factorial moments E[(X)ᵣ] = E[X(X-1)⋯(X-r+1)] are the natural moment coordinates for counting distributions: they are the values of the r-th derivative of the probability generating function G(t) = E[tˣ] at t = 1, and they linearize the combinatorics of the binomial by turning the r-fold falling factorial into a clean product. For X ~ Binomial(n, p) the whole sequence has one closed form, E[(X)ᵣ] = (n)ᵣ·pʳ, from which every ordinary moment E[Xᵐ] is recovered by Stirling numbers of the second kind. The identity has been standard since the 19th-century calculus of finite differences (Boole, Charlier); this file gives it a uniform machine-checked proof valid for all r, superseding the case-by-case moment computations (mean, variance) that earlier files in the binomial family carried out one order at a time.",
+    "problemStatement": "For X ~ Binomial(n, p), prove that every factorial moment has the closed form E[(X)ᵣ] = ∑ₖ (k)ᵣ·C(n,k)·pᵏ·(1-p)ⁿ⁻ᵏ = (n)ᵣ·pʳ, where (m)ᵣ = Nat.descFactorial m r, uniformly in n and r with no side conditions.",
+    "text": "The general factorial moment binomial_factorial_moment is proved once and for all r, then specialized: r = 0 is normalization (E[1] = 1), r = 1 recovers the mean E[X] = n·p, r = 2 recovers the second factorial moment E[X(X-1)] = n(n-1)·p², and r = 3 gives the new third factorial moment E[X(X-1)(X-2)] = n(n-1)(n-2)·p³. The mean and second-moment corollaries hold for every n, whereas the original term-peeling proofs in BinomialTheoremOQ03 needed 1 ≤ n and 2 ≤ n respectively.",
+    "proofStrategy": "The core is one nat-level identity, descFactorial_mul_choose: for r ≤ k, (k)ᵣ·C(n,k) = (n)ᵣ·C(n-r,k-r). It follows from Mathlib's subset-of-a-subset lemma Nat.choose_mul (C(n,k)·C(k,r) = C(n,r)·C(n-r,k-r)) combined with descFactorial = r!·choose. This single lemma is the r-fold generalization of the absorption and double_absorption identities that BinomialTheoremOQ03 wrote out by hand for r = 1 and r = 2. Casting to ℝ (descFactorial_mul_binomPMF) shows each term equals (n)ᵣ·pʳ·binomPMF(n-r, p, k-r), using pᵏ = pʳ·pᵏ⁻ʳ and n-k = (n-r)-(k-r) for r ≤ k ≤ n. Summing over range(n+1), the low terms k < r vanish because (k)ᵣ = 0, so the sum restricts to Ico r (n+1); an index shift k ↦ k-r turns it into (n)ᵣ·pʳ times ∑ binomPMF(n-r, p) = 1 (BinomialTheoremOQ03.binomPMF_sum_eq_one). The case r > n makes both sides 0.",
+    "keyInsights": [
+      "A single subset-of-a-subset identity (k)ᵣ·C(n,k) = (n)ᵣ·C(n-r,k-r) replaces the entire hand-written absorption tower: it is exactly the r-fold statement of which absorption (r=1) and double_absorption (r=2) are the first two rungs.",
+      "Each falling-factorial-weighted binomial term at parameter n collapses to a lower binomial term at parameter n-r: (k)ᵣ·binomPMF(n,p,k) = (n)ᵣ·pʳ·binomPMF(n-r,p,k-r). Summation then reduces the whole moment to the normalization of the smaller binomial.",
+      "The moment is uniform in r with no side condition: the vanishing of the low terms (k)ᵣ = 0 for k < r and the degenerate case r > n are handled by the falling factorial itself, so no case split on n is needed.",
+      "The 1 ≤ n and 2 ≤ n hypotheses in the original binomial mean and second-moment proofs were artefacts of peeling off a fixed number of leading terms, not of the mathematics; the uniform proof removes them, giving E[X] = n·p and E[X(X-1)] = n(n-1)·p² for every n including the degenerate n = 0, 1.",
+      "Every ordinary moment E[Xᵐ] is a Stirling-number combination of these factorial moments, so the single closed form E[(X)ᵣ] = (n)ᵣ·pʳ encodes the entire moment sequence of the binomial distribution."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: All Factorial Moments of the Binomial Marginal",
+      "startLine": 1,
+      "endLine": 70,
+      "summary": "Imports Mathlib and the verified binomial framework BinomialTheoremOQ03 (binomPMF, binomPMF_sum_eq_one, binomial_expansion). The docblock states the open question inherited from BinomialTheoremOQ02OQ01OQ04 — whether the moment reduction extends to all r — the answer E[(X)ᵣ] = (n)ᵣ·pʳ, and the proof plan: one subset-of-a-subset identity, a termwise reduction to a lower binomial term, and an index shift onto the binomial normalization."
+    },
+    {
+      "id": "descfactorial-mul-choose",
+      "title": "The engine: falling-factorial absorption",
+      "startLine": 71,
+      "endLine": 85,
+      "summary": "descFactorial_mul_choose proves (k)ᵣ·C(n,k) = (n)ᵣ·C(n-r,k-r) for r ≤ k. It rewrites both falling factorials via Nat.descFactorial_eq_factorial_mul_choose ((m)ᵣ = r!·C(m,r)) and closes with Mathlib's subset-of-a-subset identity Nat.choose_mul (C(n,k)·C(k,r) = C(n,r)·C(n-r,k-r)) after cancelling the common r! factor. This one lemma is the r-fold generalization of absorption/double_absorption."
+    },
+    {
+      "id": "descfactorial-mul-binompmf",
+      "title": "Termwise reduction to a lower binomial term",
+      "startLine": 86,
+      "endLine": 112,
+      "summary": "The private lemma descFactorial_mul_binomPMF casts the nat identity into ℝ and matches exponents: for r ≤ k ≤ n, (k)ᵣ·binomPMF(n,p,k) = (n)ᵣ·pʳ·binomPMF(n-r,p,k-r). The powers split as pᵏ = pʳ·pᵏ⁻ʳ and (1-p)ⁿ⁻ᵏ = (1-p)⁽ⁿ⁻ʳ⁾⁻⁽ᵏ⁻ʳ⁾, so the C(n-r,k-r) term reassembles into the lower binomial PMF."
+    },
+    {
+      "id": "general-factorial-moment",
+      "title": "Main theorem: E[(X)ᵣ] = (n)ᵣ·pʳ",
+      "startLine": 113,
+      "endLine": 163,
+      "summary": "binomial_factorial_moment sums the termwise identity. For r ≤ n it drops the vanishing k < r terms (restricting range(n+1) to Ico r (n+1)), shifts the index by r via Finset.sum_Ico_eq_sum_range, applies the termwise reduction, and factors out (n)ᵣ·pʳ, leaving ∑ binomPMF(n-r,p) = 1 by BinomialTheoremOQ03.binomPMF_sum_eq_one. For r > n both sides are 0 because (m)ᵣ = 0 for m < r. No hypothesis on n or r."
+    },
+    {
+      "id": "corollaries",
+      "title": "Recovering the mean, the second and third factorial moments",
+      "startLine": 164,
+      "endLine": 211,
+      "summary": "Specializations of the main theorem: binomial_zeroth_factorial_moment (r=0, normalization), binomial_mean' (r=1, E[X]=n·p), binomial_second_factorial_moment' (r=2, E[X(X-1)]=n(n-1)·p²), and binomial_third_factorial_moment (r=3, E[X(X-1)(X-2)]=n(n-1)(n-2)·p³). The mean and second-moment forms hold for every n — dropping the 1 ≤ n and 2 ≤ n hypotheses of BinomialTheoremOQ03 — and the third moment is beyond what the previous absorption tower reached."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "binomial-theorem-oq-02-oq-01-oq-04",
+      "relationship": "Parent open question",
+      "description": "Its concluding open question asks whether the fiber-grouping moment reduction extends to higher moments $E[X_i^r]$, recovering all marginal binomial moments uniformly. This file answers it in the affirmative for the factorial moments, from which all ordinary moments follow by Stirling numbers."
+    },
+    {
+      "proofId": "binomial-theorem-oq-03",
+      "relationship": "Generalizes the mean and second moment",
+      "description": "Provides binomPMF, its normalization $\\sum_k \\mathrm{binomPMF}(n,p,k) = 1$, and the $r = 1$ (mean $E[X] = np$) and $r = 2$ (second factorial moment $n(n-1)p^2$) cases proved via the hand-written absorption/double_absorption identities. This file subsumes both into one $r$-fold theorem and removes their $n$-lower-bound hypotheses."
+    },
+    {
+      "proofId": "binomial-theorem",
+      "relationship": "Foundational identity",
+      "description": "The binomial theorem $\\sum_k \\binom{n}{k} p^k (1-p)^{n-k} = 1$ normalizes the binomial PMF and, applied at parameter $n-r$, is exactly the sum that the factorial-moment reduction collapses onto."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file machine-checks the full factorial-moment sequence of the binomial distribution, $E[(X)_r] = (n)_r\\,p^r$, in one uniform theorem with 0 sorries and 0 axioms. The proof rests on a single subset-of-a-subset identity $(k)_r\\binom{n}{k} = (n)_r\\binom{n-r}{k-r}$ that generalizes the ad hoc absorption identities used for the mean and variance, reducing each factorial-moment sum to the normalization of a smaller binomial by an index shift.",
+    "implications": "Because every ordinary moment $E[X^m]$ is a Stirling-number-of-the-second-kind combination of the factorial moments $E[(X)_r]$, the closed form $(n)_r p^r$ encodes the entire moment sequence — mean, variance, skewness, kurtosis — of $\\mathrm{Binomial}(n,p)$ at once. The $r = 1, 2$ specializations recover the mean and second factorial moment for every $n$, removing the degenerate-case hypotheses of the earlier term-peeling proofs, and the same reduction applies verbatim to the binomial marginals of the multinomial distribution.",
+    "openQuestions": [
+      "Can the factorial moments be summed into a closed form for the ordinary moments $E[X^m] = \\sum_r S(m,r)\\,(n)_r\\,p^r$ via Stirling numbers of the second kind, formalized directly in Lean?",
+      "Does the same subset-of-a-subset reduction give the factorial moments of the multinomial marginals $E[(X_i)_r] = (n)_r p_i^r$ by the fiber-grouping argument of the parent file?",
+      "Is there an analogous uniform closed form for the factorial moments of the Poisson limit, $E[(X)_r] = \\lambda^r$, recoverable as the $n \\to \\infty$, $np \\to \\lambda$ limit of $(n)_r p^r$?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "G. Boole",
+      "title": "A Treatise on the Calculus of Finite Differences",
+      "year": 1860,
+      "venue": "Macmillan",
+      "note": "Factorial moments and the calculus of finite differences underlying the falling-factorial reduction."
+    },
+    {
+      "authors": "N. L. Johnson, S. Kotz, A. W. Kemp",
+      "title": "Univariate Discrete Distributions",
+      "year": 2005,
+      "venue": "Wiley",
+      "note": "Binomial distribution: factorial moments E[(X)_r] = (n)_r p^r and their relation to ordinary moments via Stirling numbers."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.descFactorial, Nat.choose_mul (subset-of-a-subset), and the finite-sum API (Finset.sum_Ico_eq_sum_range) used in the reduction."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **entire factorial-moment sequence** of the binomial distribution in one uniform theorem, answering the parent file `binomial-theorem-oq-02-oq-01-oq-04` (Multinomial Variance)'s concluding open question — *"Does the reduction extend to higher moments, recovering all marginal binomial moments uniformly?"*

For `X ~ Binomial(n, p)` and the falling factorial `(m)_r = m(m-1)⋯(m-r+1) = Nat.descFactorial m r`:

```
E[(X)_r] = ∑_k (k)_r · C(n,k) p^k (1-p)^(n-k) = (n)_r · p^r
```

valid for **every** `n` and `r`, with no side conditions.

## Why this is more than a routine variant

The existing `BinomialTheoremOQ03` proved the mean (`r=1`) and second factorial moment (`r=2`) *one order at a time*, each via a bespoke hand-written identity (`absorption`, `double_absorption`). That approach does not scale. This file replaces the whole tower with a **single** subset-of-a-subset identity

```
(k)_r · C(n,k) = (n)_r · C(n-r, k-r)     [r ≤ k]
```

(`descFactorial_mul_choose`, from Mathlib's `Nat.choose_mul` + `descFactorial = r!·choose`). Casting to ℝ turns each term into a *lower* binomial term `(n)_r·p^r·binomPMF(n-r,p,k-r)`; the sum then collapses by an index shift onto the binomial normalization `∑ binomPMF(n-r,p) = 1`.

## Corollaries (all machine-checked)

| `r` | Result | Note |
|-----|--------|------|
| 0 | `E[1] = 1` | normalization |
| 1 | `E[X] = n·p` | **holds for every n** (was `1 ≤ n`) |
| 2 | `E[X(X-1)] = n(n-1)p²` | **holds for every n** (was `2 ≤ n`) |
| 3 | `E[X(X-1)(X-2)] = n(n-1)(n-2)p³` | new — beyond the old absorption tower |

The `1 ≤ n` / `2 ≤ n` hypotheses in the original proofs were artefacts of peeling a fixed number of leading terms, not of the mathematics; the uniform proof removes them.

## Verification

- **7 theorems, 0 definitions, 211 lines, 0 sorries.**
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only — **0-axiom / VERIFIED** (no `sorryAx`, no `Lean.ofReduceBool`).
- Compiled with `lake env lean` against Mathlib (Lean 4.26.0). Docker image build was unavailable (host I/O error), so verification used the narrow single-file `lake env lean` path against the main repo's prebuilt oleans.

Gallery data (`meta.json`, `annotations.json`) added under `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04-oq-03/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)