### PR TITLE
Enrich falling-factorial Vandermonde (CommRing): add index.ts, sections, conclusion

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/index.ts
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const arithmeticSeriesOq02Oq04Oq01Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const arithmeticSeriesOq02Oq04Oq01Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const arithmeticSeriesOq02Oq04Oq01Oq03Oq01Data: ProofData = {
+  proof: arithmeticSeriesOq02Oq04Oq01Oq03Oq01Proof,
+  annotations: arithmeticSeriesOq02Oq04Oq01Oq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01`.

## Changes
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site (the entry had none; the parent entry is missing one too and should be fixed separately).
- **Sections**: added `startLine`/`endLine`/`summary` to all four sections so they now map to the actual Lean line ranges (37–130, 132–153, 155–172, 174–187).
- **Conclusion**: added `summary`, `implications`, and 4 genuine open questions (upstream ascPochhammer_add, q-analogue/Gaussian factorial convolutions, unification via binomial-type sequences, mod-p Lucas structure).
- **Annotations**: added a 5th annotation covering the self-contained recursive factorial definitions (previously uncovered lines 37–46).

## Verification
- `pnpm build` passes (tsc typecheck clean, vite build ✓).
- JSON validated; `meta.json` is 14 KB, well under the 60 KB cap.
- No axiom/status claims altered; entry remains verified, 0-axiom.