### PR TITLE
research(antitone-integral-sum-comparison-oq-01-oq-02-oq-02): generalized Euler constant for any antitone summand [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2024-2026 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+
+/-
+# Generalized Euler constant for an arbitrary antitone summand (OQ-01 · OQ-02 · OQ-02)
+
+The parent file (`AntitoneIntegralSumComparisonOQ01OQ02`) specialized the antitone
+integral test to `f x = 1/x` and identified the limit of the harmonic defect
+`Hₙ − log(n+1)` with Mathlib's Euler–Mascheroni constant `γ`.  That answered the
+convergence question *for the single function `1/x`*.
+
+This file lifts the phenomenon to **every** antitone, nonnegative summand.  For such an
+`f` on `[1, ∞)` define the **defect sequence**
+
+  `D f n := (∑_{i<n} f(1+i)) − ∫₁^{1+n} f`.
+
+The two-sided integral-test sandwich (Mathlib's `AntitoneOn.integral_le_sum` and
+`AntitoneOn.sum_le_integral`) forces `D f` to be **monotone non-decreasing** and bounded
+above by `f 1`, hence convergent.  Its limit
+
+  `generalizedEuler f := ⨆ n, D f n`
+
+is the *generalized Euler constant* of `f`: for `f = 1/x` it is the classical `γ`, and the
+construction requires nothing beyond `f` being antitone and nonnegative — divergence of
+`∑ f` is exactly what makes the constant a nontrivial invariant rather than a shifted tail.
+
+## Main results
+
+* `defect_nonneg`   : `0 ≤ D f n` (the upper Riemann sum dominates the integral).
+* `defect_le`       : `D f n ≤ f 1` (a uniform bound, via a telescoping lower Riemann sum).
+* `defect_monotone` : `Monotone (D f)` (each step adds `f(1+n) − ∫` of a unit cell `≥ 0`).
+* `tendsto_defect`  : `D f → generalizedEuler f`, the bounded-monotone limit.
+* `generalizedEuler_mem_Icc` : `generalizedEuler f ∈ [0, f 1]`.
+
+Everything reduces to the Mathlib sum/integral comparison library; the file is `sorry`-free
+and uses only standard foundational axioms.
+-/
+
+namespace AntitoneIntegralSumComparisonOQ01OQ02OQ02
+
+open Finset Filter Topology MeasureTheory intervalIntegral
+
+variable {f : ℝ → ℝ}
+
+/-- The **generalized Euler defect**: the excess of the right-open Riemann sum
+`∑_{i<n} f(1+i)` over the integral `∫₁^{1+n} f`. -/
+noncomputable def defect (f : ℝ → ℝ) (n : ℕ) : ℝ :=
+  (∑ i ∈ Finset.range n, f (1 + (i : ℝ))) - ∫ x in (1 : ℝ)..(1 + (n : ℝ)), f x
+
+@[simp] theorem defect_zero : defect f 0 = 0 := by
+  simp [defect]
+
+/-- An antitone function on `[1, ∞)` is interval-integrable on any subinterval `[a, b]`
+with `1 ≤ a ≤ b`. -/
+theorem intervalIntegrable_of_antitone (hmono : AntitoneOn f (Set.Ici 1)) {a b : ℝ}
+    (ha : (1 : ℝ) ≤ a) (hb : a ≤ b) : IntervalIntegrable f MeasureTheory.volume a b := by
+  apply AntitoneOn.intervalIntegrable
+  rw [Set.uIcc_of_le hb]
+  exact hmono.mono (fun x hx => le_trans ha hx.1)
+
+/-- Restriction of the antitone hypothesis to the finite window `[1, 1+n]`. -/
+private theorem antitone_window (hmono : AntitoneOn f (Set.Ici 1)) (n : ℕ) :
+    AntitoneOn f (Set.Icc (1 : ℝ) (1 + (n : ℝ))) :=
+  hmono.mono Set.Icc_subset_Ici_self
+
+/-- **The defect is nonnegative.**  The upper Riemann sum `∑_{i<n} f(1+i)` dominates the
+integral `∫₁^{1+n} f`, directly from `AntitoneOn.integral_le_sum`. -/
+theorem defect_nonneg (hmono : AntitoneOn f (Set.Ici 1)) (n : ℕ) : 0 ≤ defect f n := by
+  have h := (antitone_window hmono n).integral_le_sum
+  simp only [defect]
+  linarith [h]
+
+/-- **Uniform upper bound `f 1`.**  Subtracting the shifted (lower) Riemann sum
+`∑_{i<n} f(1+(i+1))` — which lies below the integral — telescopes to `f 1 − f(1+n)`, and
+`f(1+n) ≥ 0`. -/
+theorem defect_le (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) (n : ℕ) : defect f n ≤ f 1 := by
+  have h := (antitone_window hmono n).sum_le_integral
+  -- telescoping of the difference of the two Riemann sums
+  have htel : (∑ i ∈ Finset.range n, f (1 + (i : ℝ)))
+      - (∑ i ∈ Finset.range n, f (1 + ((i + 1 : ℕ) : ℝ))) = f 1 - f (1 + (n : ℝ)) := by
+    rw [← Finset.sum_sub_distrib]
+    have := Finset.sum_range_sub' (fun i : ℕ => f (1 + (i : ℝ))) n
+    simpa using this
+  have hfn : 0 ≤ f (1 + (n : ℝ)) := hnonneg _ (le_add_of_nonneg_right (Nat.cast_nonneg n))
+  simp only [defect]
+  linarith [h, htel, hfn]
+
+/-- **One-cell integral bound.**  On `[1+n, 1+n+1]` the antitone `f` satisfies
+`∫ f ≤ f(1+n)`; this is `AntitoneOn.integral_le_sum` with a single subinterval. -/
+private theorem integral_cell_le (hmono : AntitoneOn f (Set.Ici 1)) (n : ℕ) :
+    (∫ x in (1 + (n : ℝ))..(1 + (n : ℝ) + 1), f x) ≤ f (1 + (n : ℝ)) := by
+  have hanti : AntitoneOn f (Set.Icc (1 + (n : ℝ)) (1 + (n : ℝ) + ((1 : ℕ) : ℝ))) :=
+    hmono.mono (fun x hx => le_trans (le_add_of_nonneg_right (Nat.cast_nonneg n)) hx.1)
+  have h := hanti.integral_le_sum
+  simpa using h
+
+/-- **Monotone step.**  `D f n ≤ D f (n+1)`: the increment equals `f(1+n) − ∫` over the unit
+cell `[1+n, 1+n+1]`, which is `≥ 0` by `integral_cell_le`. -/
+theorem defect_le_succ (hmono : AntitoneOn f (Set.Ici 1)) (n : ℕ) :
+    defect f n ≤ defect f (n + 1) := by
+  have hsplit : (∫ x in (1 : ℝ)..(1 + ((n + 1 : ℕ) : ℝ)), f x)
+      = (∫ x in (1 : ℝ)..(1 + (n : ℝ)), f x)
+        + ∫ x in (1 + (n : ℝ))..(1 + (n : ℝ) + 1), f x := by
+    have hab : IntervalIntegrable f MeasureTheory.volume 1 (1 + (n : ℝ)) :=
+      intervalIntegrable_of_antitone hmono (le_refl 1) (le_add_of_nonneg_right (Nat.cast_nonneg n))
+    have hbc : IntervalIntegrable f MeasureTheory.volume (1 + (n : ℝ)) (1 + (n : ℝ) + 1) :=
+      intervalIntegrable_of_antitone hmono (le_add_of_nonneg_right (Nat.cast_nonneg n)) (by linarith)
+    have hcast : (1 : ℝ) + ((n + 1 : ℕ) : ℝ) = 1 + (n : ℝ) + 1 := by push_cast; ring
+    rw [hcast, ← intervalIntegral.integral_add_adjacent_intervals hab hbc]
+  have hcell := integral_cell_le hmono n
+  simp only [defect, Finset.sum_range_succ, hsplit]
+  linarith [hcell]
+
+/-- **The defect sequence is monotone non-decreasing.** -/
+theorem defect_monotone (hmono : AntitoneOn f (Set.Ici 1)) : Monotone (defect f) :=
+  monotone_nat_of_le_succ (defect_le_succ hmono)
+
+/-- The range of the defect sequence is bounded above (by `f 1`). -/
+theorem defect_bddAbove (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) : BddAbove (Set.range (defect f)) :=
+  ⟨f 1, by rintro _ ⟨n, rfl⟩; exact defect_le hmono hnonneg n⟩
+
+/-- The **generalized Euler constant** of an antitone nonnegative summand `f`: the limit of
+its defect sequence. -/
+noncomputable def generalizedEuler (f : ℝ → ℝ) : ℝ := ⨆ n, defect f n
+
+/-- **Convergence of the defect sequence** to the generalized Euler constant — the bounded
+monotone convergence theorem applied to `D f`. -/
+theorem tendsto_defect (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) :
+    Tendsto (defect f) atTop (𝓝 (generalizedEuler f)) :=
+  tendsto_atTop_ciSup (defect_monotone hmono) (defect_bddAbove hmono hnonneg)
+
+/-- The generalized Euler constant is `≤ f 1`. -/
+theorem generalizedEuler_le (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) : generalizedEuler f ≤ f 1 :=
+  ciSup_le (defect_le hmono hnonneg)
+
+/-- The generalized Euler constant is nonnegative. -/
+theorem generalizedEuler_nonneg (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) : 0 ≤ generalizedEuler f := by
+  have hbdd := defect_bddAbove hmono hnonneg
+  calc (0 : ℝ) = defect f 0 := (defect_zero).symm
+    _ ≤ generalizedEuler f := le_ciSup hbdd 0
+
+/-- **Packaged enclosure.**  The generalized Euler constant of any antitone nonnegative
+summand lies in `[0, f 1]`. -/
+theorem generalizedEuler_mem_Icc (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) : generalizedEuler f ∈ Set.Icc (0 : ℝ) (f 1) :=
+  ⟨generalizedEuler_nonneg hmono hnonneg, generalizedEuler_le hmono hnonneg⟩
+
+end AntitoneIntegralSumComparisonOQ01OQ02OQ02

--- a/proofs/Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean
@@ -1,0 +1,192 @@
+/-
+# From Rank-One to Finite-Rank — Projection onto a Subspace as a Sum of Rank-One Projectors
+
+Open Question (cauchy-schwarz-oq-01-oq-02-oq-01-oq-03), a follow-up to
+`CauchySchwarzOQ01OQ02OQ01.lean` (one Gram-Schmidt step is an orthogonal projector).
+
+The parent file established, for a single non-zero vector `v`, that
+`orthProj v x = (⟪v,x⟫/⟪v,v⟫) • v` is the orthogonal projector onto `span{v}`
+(idempotent, complementary residual, exact norm). This file proves the **finite-rank
+generalization**: the orthogonal projection onto the span of a finite orthonormal family
+`e : Fin k → E` is the **sum of the rank-one projectors** over that family, together with
+the **Parseval / Bessel equality on the subspace**. Zero axioms, zero sorries.
+
+Concretely, writing `subProj e x = ∑ i, ⟪e i, x⟫ • e i` and
+`S = span 𝕜 (range e)`:
+
+* **Sum-of-rank-one-projectors identity** `S.starProjection x = ∑ i, ⟪e i, x⟫ • e i`
+  (`subProj_eq_starProjection`) — the headline: Mathlib's orthogonal projection *is*
+  the sum of the one-line projectors. Also as `orthogonalProjection`
+  (`coe_orthogonalProjection_eq_subProj`).
+* **Residual orthogonality** `⟪e j, x - subProj e x⟫ = 0` and, extended to the whole
+  subspace, `∀ w ∈ S, ⟪x - subProj e x, w⟫ = 0`.
+* **Parseval equality on `S`** `‖subProj e x‖² = ∑ i, ‖⟪e i, x⟫‖²`
+  (`norm_subProj_sq`) — the attained (equality) case of Bessel's inequality, with the
+  Bessel bound `‖subProj e x‖² ≤ ‖x‖²` as a corollary.
+* **Idempotency** `subProj e (subProj e x) = subProj e x` and **reconstruction**
+  `subProj e x + (x - subProj e x) = x`.
+* **`k = 1` recovery** `subProj e x = ⟪e 0, x⟫ • e 0` — the one-term sum is exactly the
+  parent's rank-one projector.
+
+The subspace `S = span (range e)` is finite-dimensional, hence complete, so
+`orthogonalProjection`/`starProjection` are well defined with no completeness hypothesis
+on `E`. The scalar field `𝕜` is an arbitrary `RCLike` field (so `ℝ` and `ℂ` at once),
+kept as an explicit argument of `subProj` as in the parent file.
+-/
+
+import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+import Mathlib.Analysis.InnerProductSpace.Orthonormal
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.Topology.Algebra.Module.FiniteDimension
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+
+open scoped InnerProductSpace
+open RCLike
+
+namespace CauchySchwarzOQ01OQ02OQ01OQ03
+
+variable (𝕜 : Type*) [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+/-! ## The span of a finite family is finite-dimensional, hence complete -/
+
+/-- The span of a finite family is finite-dimensional (so `orthogonalProjection` exists
+without any completeness hypothesis on the ambient space `E`). -/
+instance finiteDimensional_span_range {k : ℕ} (e : Fin k → E) :
+    FiniteDimensional 𝕜 (Submodule.span 𝕜 (Set.range e)) :=
+  FiniteDimensional.span_of_finite 𝕜 (Set.finite_range e)
+
+/-- A finite-dimensional subspace over the complete field `𝕜` is complete, so it has an
+orthogonal projection. -/
+instance completeSpace_span_range {k : ℕ} (e : Fin k → E) :
+    CompleteSpace (Submodule.span 𝕜 (Set.range e)) :=
+  FiniteDimensional.complete 𝕜 _
+
+/-! ## Definition: the finite-rank projection as a sum of rank-one projectors -/
+
+/-- The finite-rank projection of `x` onto the family `e`: the sum of the rank-one
+projectors `x ↦ ⟪e i, x⟫ • e i`. For an orthonormal `e` this is the orthogonal
+projection onto `span (range e)` (`subProj_eq_starProjection`). -/
+noncomputable def subProj {k : ℕ} (e : Fin k → E) (x : E) : E :=
+  ∑ i, ⟪e i, x⟫_𝕜 • e i
+
+/-! ## Membership and coordinates -/
+
+/-- `subProj e x` lies in the span of the family. -/
+theorem subProj_mem_span {k : ℕ} (e : Fin k → E) (x : E) :
+    subProj 𝕜 e x ∈ Submodule.span 𝕜 (Set.range e) := by
+  refine Submodule.sum_mem _ ?_
+  intro i _
+  exact Submodule.smul_mem _ _ (Submodule.subset_span (Set.mem_range_self i))
+
+/-- Coordinate extraction: for an orthonormal family, `⟪e j, subProj e x⟫ = ⟪e j, x⟫`.
+The projection has the same coordinates as `x` along each `e j`. -/
+theorem inner_subProj {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) (j : Fin k) :
+    ⟪e j, subProj 𝕜 e x⟫_𝕜 = ⟪e j, x⟫_𝕜 := by
+  unfold subProj
+  exact he.inner_right_fintype (fun i => ⟪e i, x⟫_𝕜) j
+
+/-! ## Residual orthogonality -/
+
+/-- The residual `x - subProj e x` is orthogonal to every basis vector `e j`. -/
+theorem inner_residual {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) (j : Fin k) :
+    ⟪e j, x - subProj 𝕜 e x⟫_𝕜 = 0 := by
+  rw [inner_sub_right, inner_subProj 𝕜 he x j, sub_self]
+
+/-- The residual `x - subProj e x` is orthogonal to the *whole* subspace `span (range e)`,
+not merely to each `e j`. This is the defining orthogonality property of the projection. -/
+theorem residual_orthogonal_span {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    ∀ w ∈ Submodule.span 𝕜 (Set.range e), ⟪x - subProj 𝕜 e x, w⟫_𝕜 = 0 := by
+  intro w hw
+  refine Submodule.span_induction
+    (p := fun w _ => ⟪x - subProj 𝕜 e x, w⟫_𝕜 = 0) ?_ ?_ ?_ ?_ hw
+  · rintro y ⟨j, rfl⟩
+    rw [inner_eq_zero_symm]
+    exact inner_residual 𝕜 he x j
+  · simp
+  · intro a b _ _ pa pb
+    rw [inner_add_right, pa, pb, add_zero]
+  · intro c a _ pa
+    rw [inner_smul_right, pa, mul_zero]
+
+/-! ## Part I: The sum-of-rank-one-projectors identity (headline) -/
+
+/-- **Main theorem.** For a finite orthonormal family `e`, the orthogonal projection onto
+`S = span (range e)` equals the sum of the rank-one projectors:
+`S.starProjection x = ∑ i, ⟪e i, x⟫ • e i`. This is the operator identity
+`P_S = ∑ i, e_i e_i^*` (a finite-rank resolution of the identity). -/
+theorem subProj_eq_starProjection {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    (Submodule.span 𝕜 (Set.range e)).starProjection x = subProj 𝕜 e x :=
+  Submodule.eq_starProjection_of_mem_of_inner_eq_zero
+    (subProj_mem_span 𝕜 e x) (residual_orthogonal_span 𝕜 he x)
+
+/-- The same identity phrased with the subspace-valued `orthogonalProjection`. -/
+theorem coe_orthogonalProjection_eq_subProj {k : ℕ} {e : Fin k → E}
+    (he : Orthonormal 𝕜 e) (x : E) :
+    (((Submodule.span 𝕜 (Set.range e)).orthogonalProjection x : Submodule.span 𝕜 (Set.range e)) : E)
+      = subProj 𝕜 e x := by
+  rw [Submodule.coe_orthogonalProjection_apply]
+  exact subProj_eq_starProjection 𝕜 he x
+
+/-! ## Part II: Parseval / Bessel equality on the subspace -/
+
+/-- **Parseval equality on `S`.** The squared norm of the projection is the sum of the
+squared coordinate moduli: `‖subProj e x‖² = ∑ i, ‖⟪e i, x⟫‖²`. This is the attained
+(equality) form of Bessel's inequality, restricted to the subspace `S`. -/
+theorem norm_subProj_sq {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    ‖subProj 𝕜 e x‖ ^ 2 = ∑ i, ‖⟪e i, x⟫_𝕜‖ ^ 2 := by
+  rw [@norm_sq_eq_re_inner 𝕜]
+  unfold subProj
+  rw [he.inner_sum (fun i => ⟪e i, x⟫_𝕜) (fun i => ⟪e i, x⟫_𝕜) Finset.univ, map_sum]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [RCLike.conj_mul]
+  norm_cast
+
+/-- **Bessel's inequality** as a corollary: `‖subProj e x‖² ≤ ‖x‖²`. -/
+theorem norm_subProj_sq_le {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    ‖subProj 𝕜 e x‖ ^ 2 ≤ ‖x‖ ^ 2 := by
+  rw [norm_subProj_sq 𝕜 he x]
+  exact he.sum_inner_products_le x
+
+/-! ## Part III: Idempotency and reconstruction (projector axioms) -/
+
+/-- **Idempotency** `P² = P`: `subProj e (subProj e x) = subProj e x`. -/
+theorem subProj_idempotent {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    subProj 𝕜 e (subProj 𝕜 e x) = subProj 𝕜 e x := by
+  simp only [subProj]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [he.inner_right_fintype (fun j => ⟪e j, x⟫_𝕜) i]
+
+/-- **Reconstruction** `P + (1 − P) = id`: the projection and residual sum to `x`. -/
+theorem subProj_add_residual {k : ℕ} (e : Fin k → E) (x : E) :
+    subProj 𝕜 e x + (x - subProj 𝕜 e x) = x := by
+  abel
+
+/-! ## Part IV: The `k = 1` case recovers the parent's rank-one projector -/
+
+/-- For a single-vector family, `subProj` is the one-term sum `⟪e 0, x⟫ • e 0`, i.e. the
+parent file's rank-one orthogonal projector onto the line `span{e 0}`. -/
+theorem subProj_one (e : Fin 1 → E) (x : E) :
+    subProj 𝕜 e x = ⟪e 0, x⟫_𝕜 • e 0 := by
+  simp [subProj]
+
+/-! ## Part V: Capstone -/
+
+/-- **Summary.** For a finite orthonormal family `e` with span `S`, the map
+`subProj e = ∑ i ⟪e i, ·⟫ • e i` is the orthogonal projection onto `S`: it agrees with
+Mathlib's `starProjection`, its residual is orthogonal to `S`, it satisfies the Parseval
+equality on `S`, and it is idempotent. -/
+theorem subProj_is_orthogonal_projection {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) :
+    (∀ x : E, (Submodule.span 𝕜 (Set.range e)).starProjection x = subProj 𝕜 e x) ∧
+    (∀ x : E, ∀ w ∈ Submodule.span 𝕜 (Set.range e), ⟪x - subProj 𝕜 e x, w⟫_𝕜 = 0) ∧
+    (∀ x : E, ‖subProj 𝕜 e x‖ ^ 2 = ∑ i, ‖⟪e i, x⟫_𝕜‖ ^ 2) ∧
+    (∀ x : E, subProj 𝕜 e (subProj 𝕜 e x) = subProj 𝕜 e x) :=
+  ⟨fun x => subProj_eq_starProjection 𝕜 he x,
+   fun x => residual_orthogonal_span 𝕜 he x,
+   fun x => norm_subProj_sq 𝕜 he x,
+   fun x => subProj_idempotent 𝕜 he x⟩
+
+end CauchySchwarzOQ01OQ02OQ01OQ03

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-isc-oq010202-defect",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 48, "endLine": 54 },
+    "type": "definition",
+    "title": "The General Defect Sequence",
+    "content": "defect f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f is the excess of the right-open Riemann sum over the integral, defined for an arbitrary summand f. The parent's harmonic defect Hₙ − log(n+1) is exactly the case f = 1/x, since ∑_{i<n} 1/(1+i) = Hₙ and ∫₁^{1+n} 1/x = log(1+n). defect f 0 = 0 by convention.",
+    "mathContext": "D_f(n) := \\sum_{i<n} f(1+i) - \\int_1^{1+n} f",
+    "significance": "key",
+    "relatedConcepts": [
+      "generalized Euler constant",
+      "Riemann sum",
+      "integral test"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010202-nonneg",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 69, "endLine": 74 },
+    "type": "theorem",
+    "title": "The Defect Is Nonnegative",
+    "content": "defect_nonneg: 0 ≤ D f n. The upper Riemann sum ∑_{i<n} f(1+i) dominates the integral ∫₁^{1+n} f because f is antitone (on [k,k+1] the maximum of f is f(k)). This is Mathlib's AntitoneOn.integral_le_sum applied on the window [1,1+n].",
+    "mathContext": "\\int_1^{1+n} f \\le \\sum_{i<n} f(1+i)",
+    "significance": "standard",
+    "relatedConcepts": [
+      "antitone integral test",
+      "upper Riemann sum"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010202-le",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 76, "endLine": 90 },
+    "type": "theorem",
+    "title": "Uniform Upper Bound f(1)",
+    "content": "defect_le: D f n ≤ f 1 for every n. Subtracting the lower Riemann sum ∑_{i<n} f(1+(i+1)) — which lies below the integral by AntitoneOn.sum_le_integral — the two Riemann sums telescope: ∑_{i<n} f(1+i) − ∑_{i<n} f(1+(i+1)) = f(1) − f(1+n) (Finset.sum_range_sub'). Since f(1+n) ≥ 0, the defect never exceeds the leading term f(1).",
+    "mathContext": "D_f(n) \\le f(1) - f(1+n) \\le f(1)",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping sum",
+      "lower Riemann sum",
+      "uniform bound"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010202-monotone",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 101, "endLine": 120 },
+    "type": "theorem",
+    "title": "Monotone Non-Decreasing",
+    "content": "defect_le_succ / defect_monotone: D f (n+1) − D f n = f(1+n) − ∫_{1+n}^{1+n+1} f. Splitting the integral over the adjacent intervals [1,1+n] and [1+n,1+n+1] and bounding the unit-cell integral by f(1+n) (integral_cell_le, antitonicity on one cell) shows the increment is ≥ 0. So the same defect sequence that is bounded above is also monotone.",
+    "mathContext": "D_f(n{+}1) - D_f(n) = f(1+n) - \\int_{1+n}^{1+n+1} f \\ge 0",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotone sequence",
+      "interval additivity",
+      "per-cell estimate"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010202-tendsto",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 127, "endLine": 136 },
+    "type": "theorem",
+    "title": "Convergence to the Generalized Euler Constant",
+    "content": "tendsto_defect: D f converges to generalizedEuler f := ⨆ n, D f n. A monotone sequence bounded above converges to its supremum (tendsto_atTop_ciSup). This is the general form of the parent's γ: for f = 1/x, generalizedEuler f is exactly the Euler–Mascheroni constant. The answer to the parent's open question for arbitrary antitone summands.",
+    "mathContext": "D_f \\to \\gamma_f := \\sup_n D_f(n)",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotone convergence",
+      "generalized Euler constant",
+      "supremum"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010202-enclosure",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 150, "endLine": 154 },
+    "type": "theorem",
+    "title": "The Limit Lies in [0, f(1)]",
+    "content": "generalizedEuler_mem_Icc: 0 ≤ generalizedEuler f ≤ f 1. The lower bound comes from D f 0 = 0 ≤ ⨆ (le_ciSup); the upper bound from all terms being ≤ f 1 (ciSup_le). Thus every antitone nonnegative summand carries a generalized Euler constant bounded above by its first term.",
+    "mathContext": "\\gamma_f \\in [0, f(1)]",
+    "significance": "standard",
+    "relatedConcepts": [
+      "supremum bounds",
+      "generalized Euler constant"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/index.ts
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const antitoneIntegralSumComparisonOq01Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const antitoneIntegralSumComparisonOq01Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const antitoneIntegralSumComparisonOq01Oq02Oq02Data: ProofData = {
+  proof: antitoneIntegralSumComparisonOq01Oq02Oq02Proof,
+  annotations: antitoneIntegralSumComparisonOq01Oq02Oq02Annotations,
+}

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+  "slug": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+  "title": "The Generalized Euler Constant of an Arbitrary Antitone Summand",
+  "status": "verified",
+  "badge": "mathlib",
+  "leanFile": {
+    "namespace": "AntitoneIntegralSumComparisonOQ01OQ02OQ02",
+    "lineCount": 156,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 2,
+    "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_constant",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02.lean",
+    "tags": [
+      "analysis",
+      "integral-test",
+      "euler-mascheroni",
+      "generalized-euler-constant",
+      "convergence",
+      "monotone-convergence",
+      "riemann-sum"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None beyond the two hypotheses on f (antitone on [1,∞) and nonnegative there), which are part of the theorem statements rather than global axioms. Fully machine-verified: #print axioms reports only the foundational propext / Classical.choice / Quot.sound.",
+    "lineCount": 156,
+    "theoremCount": 13,
+    "definitionCount": 2,
+    "originalContributions": [
+      "defect (definition): the general defect sequence D f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f for an arbitrary summand f — the parent's harmonic defect Hₙ − log(n+1) is the special case f = 1/x",
+      "defect_nonneg: 0 ≤ D f n, from AntitoneOn.integral_le_sum (the upper Riemann sum dominates the integral)",
+      "defect_le: the uniform bound D f n ≤ f 1, obtained by subtracting the shifted lower Riemann sum ∑_{i<n} f(1+(i+1)) ≤ ∫ and telescoping the two sums to f 1 − f(1+n) with f(1+n) ≥ 0",
+      "integral_cell_le: the one-cell estimate ∫_{1+n}^{1+n+1} f ≤ f(1+n), AntitoneOn.integral_le_sum on a single unit subinterval",
+      "defect_le_succ / defect_monotone: the increment D f (n+1) − D f n = f(1+n) − ∫ over the unit cell [1+n,1+n+1] is ≥ 0, so D f is monotone non-decreasing",
+      "generalizedEuler (definition) and tendsto_defect: D f converges to generalizedEuler f := ⨆ n, D f n, the bounded-monotone limit (tendsto_atTop_ciSup) — the generalized Euler constant of f",
+      "generalizedEuler_nonneg / generalizedEuler_le / generalizedEuler_mem_Icc: the limit lies in [0, f 1]"
+    ]
+  },
+  "description": "Answers the second open question recorded by the parent entry (antitone-integral-sum-comparison-oq-01-oq-02): package the analogous defect for a general antitone summand f, proving ∑_{k≤n} f(k) − ∫₁^n f converges. Where the parent specialized the antitone integral test to f(x) = 1/x and identified the limit of Hₙ − log(n+1) with the classical Euler–Mascheroni constant γ, this entry lifts the whole phenomenon to every antitone, nonnegative f on [1,∞). It defines the defect D f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f, then uses only the two-sided integral-test sandwich (Mathlib's AntitoneOn.integral_le_sum and AntitoneOn.sum_le_integral) to prove D f is nonnegative, bounded above by f 1, and monotone non-decreasing — hence convergent, to the generalized Euler constant generalizedEuler f := ⨆ n, D f n, which lies in [0, f 1]. The harmonic defect of the parent is exactly the case f = 1/x. 13 theorems, 2 definitions, 0 sorries, 0 axioms.",
+  "overview": {
+    "historicalContext": "Euler's constant γ = lim(Hₙ − log n) is the prototype of a whole family: for any antitone f the excess of the partial sum ∑_{k≤n} f(k) over the integral ∫₁^n f settles down to a constant, the 'generalized Euler constant' of f. These constants — Stieltjes constants, generalized Euler–Mascheroni constants — appear throughout analytic number theory. The mechanism that produces them is the integral test itself: the same monotone-sandwich comparison that decides convergence of ∑ f also manufactures the limiting correction term.",
+    "problemStatement": "The parent entry proved the harmonic defect Hₙ − log(n+1) converges to γ for the specific function 1/x. Does the analogous defect ∑_{k≤n} f(k) − ∫₁^n f converge for an arbitrary antitone, nonnegative f, and what can be said about its limit?",
+    "text": "Fix f antitone and nonnegative on [1,∞) and set D f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f. The antitone integral test gives, on each window [1,1+n], the two-sided sandwich ∑_{i<n} f(1+(i+1)) ≤ ∫₁^{1+n} f ≤ ∑_{i<n} f(1+i). The right inequality is D f n ≥ 0. Subtracting the left (lower) sum from the upper sum telescopes to f 1 − f(1+n) ≤ f 1, so D f n ≤ f 1 uniformly. Monotonicity is a per-cell computation: D f (n+1) − D f n = f(1+n) − ∫_{1+n}^{1+n+1} f, and antitonicity forces ∫ over the unit cell to be ≤ f(1+n), so the increment is ≥ 0. A monotone sequence bounded above converges; its limit generalizedEuler f = ⨆ n, D f n is the generalized Euler constant, and it lands in [0, f 1]. For f = 1/x this recovers the parent's γ.",
+    "proofStrategy": "Every step is a short reduction to Mathlib's SumIntegralComparisons library. defect_nonneg is AntitoneOn.integral_le_sum verbatim; defect_le combines AntitoneOn.sum_le_integral with Finset.sum_range_sub' (the telescoping of ∑ f(1+i) − ∑ f(1+(i+1)) to f 1 − f(1+n)) and f(1+n) ≥ 0. integral_cell_le instantiates AntitoneOn.integral_le_sum at a single unit interval. defect_le_succ splits ∫₁^{1+n+1} = ∫₁^{1+n} + ∫_{1+n}^{1+n+1} via intervalIntegral.integral_add_adjacent_intervals (integrability from AntitoneOn.intervalIntegrable) and bounds the cell integral; monotone_nat_of_le_succ upgrades to Monotone. tendsto_defect is tendsto_atTop_ciSup applied to the monotone, bounded-above sequence; the [0, f 1] enclosure follows from ciSup_le and le_ciSup with defect_zero.",
+    "keyInsights": [
+      "The Euler–Mascheroni convergence is not special to 1/x: the only inputs are antitonicity (to make the integral test sandwich hold) and nonnegativity (to bound the telescoped remainder), so every antitone nonnegative summand has its own limiting constant",
+      "Boundedness comes from a global telescoping identity across the whole window, while monotonicity comes from a purely local per-cell integral estimate — two different uses of the same one-sided comparison AntitoneOn.integral_le_sum",
+      "The uniform bound is sharp in form: D f n ≤ f 1 with the limit in [0, f 1], and f 1 is exactly the first term of the series, so the generalized Euler constant never exceeds the leading summand",
+      "Divergence of ∑ f (the 'Euler constant' regime) is not needed for the defect to converge — convergence of D f is automatic; divergence is what makes the constant an interesting invariant rather than a rewriting of the convergent tail"
+    ],
+    "prerequisites": [
+      "The antitone integral-test sandwich ∑ f(x₀+i+1) ≤ ∫ ≤ ∑ f(x₀+i) (parent entry / Mathlib SumIntegralComparisons)",
+      "Monotone sequences bounded above converge to their supremum (tendsto_atTop_ciSup)",
+      "Interval integrability of monotone/antitone functions and additivity of the interval integral over adjacent intervals",
+      "Telescoping finite sums (Finset.sum_range_sub')"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Definition of the general defect",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Import Mathlib; docstring recalling the parent (the harmonic defect for f = 1/x converges to γ) and stating the generalization to arbitrary antitone nonnegative f. Define defect f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f, with defect f 0 = 0.",
+      "mathContext": "$D_f(n) := \\sum_{i<n} f(1+i) - \\int_1^{1+n} f$, $\\;D_f(0)=0$."
+    },
+    {
+      "id": "integrability",
+      "title": "Integrability and window restriction",
+      "startLine": 56,
+      "endLine": 67,
+      "summary": "intervalIntegrable_of_antitone: an antitone function on [1,∞) is interval-integrable on any [a,b] with 1 ≤ a ≤ b (AntitoneOn.intervalIntegrable). antitone_window restricts the hypothesis to the finite window [1,1+n].",
+      "mathContext": "$f$ antitone on $[1,\\infty)\\Rightarrow f$ interval-integrable on $[a,b]$, $1\\le a\\le b$."
+    },
+    {
+      "id": "bounds",
+      "title": "Nonnegativity and the uniform bound f 1",
+      "startLine": 69,
+      "endLine": 90,
+      "summary": "defect_nonneg: 0 ≤ D f n from AntitoneOn.integral_le_sum. defect_le: D f n ≤ f 1, subtracting the lower Riemann sum (≤ ∫ by AntitoneOn.sum_le_integral) and telescoping ∑ f(1+i) − ∑ f(1+(i+1)) = f 1 − f(1+n), with f(1+n) ≥ 0.",
+      "mathContext": "$0 \\le D_f(n) \\le f(1)$; telescoped remainder $= f(1) - f(1+n)$."
+    },
+    {
+      "id": "monotone",
+      "title": "Per-cell estimate and monotonicity",
+      "startLine": 92,
+      "endLine": 120,
+      "summary": "integral_cell_le: ∫_{1+n}^{1+n+1} f ≤ f(1+n) on a single unit interval. defect_le_succ: the increment D f (n+1) − D f n = f(1+n) − ∫ over the cell ≥ 0, via additivity of the interval integral; defect_monotone upgrades to Monotone (D f).",
+      "mathContext": "$D_f(n{+}1) - D_f(n) = f(1+n) - \\int_{1+n}^{1+n+1} f \\ge 0$."
+    },
+    {
+      "id": "convergence",
+      "title": "Convergence to the generalized Euler constant",
+      "startLine": 122,
+      "endLine": 156,
+      "summary": "defect_bddAbove packages f 1 as an upper bound. generalizedEuler f := ⨆ n, D f n; tendsto_defect gives D f → generalizedEuler f (tendsto_atTop_ciSup). generalizedEuler_nonneg / generalizedEuler_le / generalizedEuler_mem_Icc place the limit in [0, f 1].",
+      "mathContext": "$D_f \\to \\gamma_f := \\sup_n D_f(n) \\in [0, f(1)]$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Euler–Mascheroni convergence of the parent entry is generalized from f = 1/x to every antitone, nonnegative summand f on [1,∞). The defect D f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f is nonnegative, uniformly bounded by f 1, and monotone non-decreasing, hence convergent to the generalized Euler constant generalizedEuler f = ⨆ n, D f n, which lies in [0, f 1]. 13 theorems, 2 definitions, 156 lines, 0 sorries, 0 axioms.",
+    "implications": "Isolates exactly what the harmonic case used: antitonicity for the integral-test sandwich and nonnegativity for the remainder bound. Every antitone nonnegative series therefore carries a well-defined generalized Euler constant bounded by its leading term, with the classical γ = generalizedEuler (1/x) as the running example.",
+    "openQuestions": [
+      "Identify generalizedEuler (fun x => 1/x) with Mathlib's Real.eulerMascheroniConstant, closing the loop with the parent's γ via ∫₁^{1+n} 1/x = log(1+n)",
+      "Drop nonnegativity: for antitone f with f → L, show ∑_{k≤n} f(k) − ∫₁^n f − (n)L-type corrections converge, or characterize when the defect converges for antitone f of arbitrary sign"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Havil, Julian",
+      "title": "Gamma: Exploring Euler's Constant",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "note": "Book-length account of γ = lim(Hₙ − log n) and the monotone-defect convergence argument, here generalized to arbitrary antitone summands."
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Mathematical Analysis (2nd ed.)",
+      "year": "1974",
+      "venue": "Addison-Wesley",
+      "note": "Integral test (Theorem 8.23) comparing ∑f(n) with ∫f — the sum/integral sandwich this entry uses to produce the generalized Euler constant."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Analysis.SumIntegralComparisons and Mathlib.Topology.Order.MonotoneConvergence",
+      "year": "2024",
+      "venue": "Lean 4 mathematical library (mathlib4)",
+      "note": "Source of AntitoneOn.integral_le_sum / AntitoneOn.sum_le_integral and tendsto_atTop_ciSup, the two engines of this proof."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "antitone-integral-sum-comparison-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry: proved the harmonic defect Hₙ − log(n+1) → γ for f = 1/x and asked (open question 2) for the analogous general-antitone defect. This entry answers that, with the harmonic case as the specialization f = 1/x."
+    }
+  ],
+  "sorries": null
+}

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/annotations.json
@@ -1,0 +1,150 @@
+[
+  {
+    "id": "ann-overview",
+    "title": "From One Line to a Subspace",
+    "type": "concept",
+    "startLine": 1,
+    "endLine": 52,
+    "mathContext": "The parent (cauchy-schwarz-oq-01-oq-02-oq-01) proved that projecting onto a single line span{v} is the rank-one map x ↦ ⟪e,x⟫•e and is a genuine orthogonal projector. This file generalizes to a k-dimensional subspace S = span(range e) spanned by a finite orthonormal family: the projection onto S is the sum of the rank-one projectors, P_S x = ∑ i ⟪e i, x⟫ • e i, and its squared norm is the sum of squared coordinates (Parseval on S).",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthogonal projection",
+      "resolution of the identity",
+      "Parseval's identity",
+      "Bessel's inequality",
+      "orthonormal basis"
+    ],
+    "prerequisites": [
+      "inner product spaces over an RCLike field",
+      "orthonormal families",
+      "orthogonal projection onto a complete subspace"
+    ],
+    "content": "The finite-rank orthogonal projection is the sum of the one-line projectors over an orthonormal basis of the subspace — a finite-rank resolution of the identity P_S = ∑ i e_i e_i^*.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 52 }
+  },
+  {
+    "id": "ann-completeness",
+    "title": "Why the Projection Exists Without Assuming E Complete",
+    "type": "technique",
+    "startLine": 54,
+    "endLine": 66,
+    "mathContext": "Mathlib's orthogonalProjection/starProjection require the subspace to have a HasOrthogonalProjection instance, which follows from completeness. Here S = span(range e) is spanned by finitely many vectors, so FiniteDimensional.span_of_finite (applied to Set.finite_range e) makes it finite-dimensional, and FiniteDimensional.complete over the complete field 𝕜 makes it complete. These are registered as instances so the projection elaborates automatically — no completeness hypothesis on the ambient E is needed.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "finite-dimensional subspaces",
+      "completeness",
+      "typeclass instances"
+    ],
+    "prerequisites": [
+      "finite-dimensional vector spaces",
+      "completeness of finite-dimensional spaces over a complete field"
+    ],
+    "content": "Finite-dimensionality of the span, not completeness of E, is what makes the orthogonal projection well defined.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 54, "endLine": 66 }
+  },
+  {
+    "id": "ann-coordinates",
+    "title": "Coordinate Preservation",
+    "type": "concept",
+    "startLine": 79,
+    "endLine": 90,
+    "mathContext": "For an orthonormal family, Orthonormal.inner_right_fintype gives ⟪e j, ∑ i l i • e i⟫ = l j — the inner product with a basis vector picks out its coefficient. With l i = ⟪e i, x⟫ this yields ⟪e j, subProj e x⟫ = ⟪e j, x⟫: the projection has exactly the same coordinates along each e j as x.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthonormality",
+      "coordinate extraction",
+      "Kronecker delta"
+    ],
+    "prerequisites": [
+      "orthonormal families",
+      "linearity of the inner product"
+    ],
+    "content": "The projection keeps x's coordinates along the basis; the residual carries everything orthogonal to S.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 79, "endLine": 90 }
+  },
+  {
+    "id": "ann-residual-span",
+    "title": "From Basis-Orthogonality to Subspace-Orthogonality",
+    "type": "technique",
+    "startLine": 92,
+    "endLine": 114,
+    "mathContext": "Coordinate preservation gives ⟪e j, x − subProj e x⟫ = 0 for each basis vector. To identify subProj with the orthogonal projection we need the residual orthogonal to ALL of S, not just to each e j. Since w ↦ ⟪x − subProj e x, w⟫ is 𝕜-linear and vanishes on the spanning set range e (using conjugate symmetry inner_eq_zero_symm), Submodule.span_induction extends the vanishing to every w ∈ S.",
+    "significance": "key",
+    "relatedConcepts": [
+      "span induction",
+      "linear functionals",
+      "orthogonal complement"
+    ],
+    "prerequisites": [
+      "spans and linear combinations",
+      "conjugate symmetry of the inner product"
+    ],
+    "content": "A linear functional vanishing on a spanning set vanishes on the whole span — this promotes basis-orthogonality of the residual to subspace-orthogonality.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 92, "endLine": 114 }
+  },
+  {
+    "id": "ann-headline",
+    "title": "The Sum-of-Rank-One-Projectors Identity",
+    "type": "concept",
+    "startLine": 115,
+    "endLine": 133,
+    "mathContext": "By the uniqueness of orthogonal projection (Submodule.eq_starProjection_of_mem_of_inner_eq_zero: if v ∈ K and x − v ⊥ K then P_K x = v), the two facts subProj e x ∈ S and residual ⊥ S identify subProj e x with S.starProjection x. This is the operator identity P_S = ∑ i e_i e_i^*, the finite-rank generalization of the parent's single rank-one projector.",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniqueness of orthogonal projection",
+      "resolution of the identity",
+      "rank-one operators"
+    ],
+    "prerequisites": [
+      "orthogonal projection characterization"
+    ],
+    "content": "The headline identity: Mathlib's orthogonal projection onto S is exactly the sum of the rank-one projectors over the orthonormal basis.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 115, "endLine": 133 }
+  },
+  {
+    "id": "ann-parseval",
+    "title": "Parseval Equality as Attained Bessel",
+    "type": "concept",
+    "startLine": 134,
+    "endLine": 153,
+    "mathContext": "Expanding ‖subProj e x‖² = re ⟪subProj, subProj⟫ with Orthonormal.inner_sum collapses the double sum to the diagonal ∑ i conj⟪e i,x⟫·⟪e i,x⟫; RCLike.conj_mul turns each term into ‖⟪e i,x⟫‖². The result ‖P_S x‖² = ∑ i ‖⟪e i, x⟫‖² is the equality case of Bessel's inequality restricted to S, and Bessel's bound ‖P_S x‖² ≤ ‖x‖² follows immediately from Orthonormal.sum_inner_products_le.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Parseval's identity",
+      "Bessel's inequality",
+      "orthonormal norm expansion"
+    ],
+    "prerequisites": [
+      "norm via inner product",
+      "orthonormal double-sum collapse"
+    ],
+    "content": "The squared projection norm is exactly the sum of squared coordinate moduli — the sharp, attained form of Bessel's inequality on the subspace.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 134, "endLine": 153 }
+  },
+  {
+    "id": "ann-recovery",
+    "title": "k = 1 Recovers the Parent",
+    "type": "concept",
+    "startLine": 168,
+    "endLine": 192,
+    "mathContext": "For a single-vector orthonormal family (k = 1), the sum ∑ i ⟪e i, x⟫ • e i has one term, so subProj e x = ⟪e 0, x⟫ • e 0 — exactly the parent's rank-one projector onto the line span{e 0}. Together with idempotency (P²=P) and reconstruction (P + (1−P) = id), this exhibits the parent as the one-term special case of the finite-rank identity.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "rank-one projector",
+      "specialization",
+      "idempotent operators"
+    ],
+    "prerequisites": [
+      "the parent's rank-one projector"
+    ],
+    "content": "The single-line projector of the parent entry is the k=1 term of this sum-of-projectors identity.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 168, "endLine": 192 }
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+  "title": "Projection onto a Subspace as a Sum of Rank-One Projectors",
+  "slug": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+  "description": "A verified (0-axiom, 0-sorry) follow-up to \"One Gram-Schmidt Step is an Orthogonal Projector\". The parent proved that projecting onto a single line span{v} is the rank-one map x ↦ ⟪e,x⟫•e. This file proves the finite-rank generalization: for a finite orthonormal family e : Fin k → E spanning S = span(range e), the orthogonal projection onto S is the sum of the rank-one projectors, P_S x = ∑ i, ⟪e i, x⟫ • e i (identified with Mathlib's starProjection/orthogonalProjection), together with the Parseval equality on the subspace ‖P_S x‖² = ∑ i ‖⟪e i, x⟫‖² (the attained case of Bessel's inequality). It also derives residual orthogonality to all of S, idempotency, reconstruction, and the k=1 recovery of the parent's rank-one projector.",
+  "meta": {
+    "author": "Research formalization 2026 (researcher-9)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Parseval%27s_identity",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean",
+    "tags": [
+      "linear-algebra",
+      "inner-product-spaces",
+      "orthogonal-projection",
+      "parseval",
+      "bessel",
+      "gram-schmidt"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 192,
+    "assumptions": "None. Every theorem is verified over an arbitrary RCLike field 𝕜 and inner product space E with zero axioms and zero sorries (only foundational propext/Classical.choice/Quot.sound). The subspace S = span(range e) is finite-dimensional, hence complete, so orthogonalProjection is well defined with no completeness hypothesis on E.",
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "The parent chain formalizes the orthogonal-projection picture underlying Gram-Schmidt and Cauchy-Schwarz. The grandparent (cauchy-schwarz-oq-01-oq-02) gave one Gram-Schmidt step via Cauchy-Schwarz (bounded coefficient, orthogonal residual, Pythagoras); its child (cauchy-schwarz-oq-01-oq-02-oq-01) proved that a single step is an orthogonal projector onto a line span{v}. That entry explicitly left open whether the projector identity extends to a finite-dimensional subspace, expressed as a sum of rank-one projectors over an orthonormal basis. This file settles that question: the orthogonal projection onto S = span(range e) is exactly ∑ i ⟪e i, ·⟫ • e i.",
+    "problemStatement": "For a finite orthonormal family e : Fin k → E spanning S, is the orthogonal projection onto S the sum of the rank-one projectors x ↦ ⟪e i, x⟫ • e i, and does the squared projection norm equal the sum of squared coordinate moduli (Parseval equality on S)?",
+    "text": "Verified sum-of-rank-one-projectors identity and subspace Parseval equality for the orthogonal projection onto the span of a finite orthonormal family, over an arbitrary RCLike inner product space.",
+    "proofStrategy": "Self-contained in namespace CauchySchwarzOQ01OQ02OQ01OQ03. Define subProj e x = ∑ i, ⟪e i, x⟫ • e i directly. Prove it equals Mathlib's projection by the uniqueness characterization Submodule.eq_starProjection_of_mem_of_inner_eq_zero: (1) subProj e x ∈ S (a sum of scalar multiples of the e i), and (2) the residual x − subProj e x is orthogonal to all of S. For (2), orthonormality gives ⟪e j, subProj e x⟫ = ⟪e j, x⟫ (Orthonormal.inner_right_fintype), so ⟪e j, x − subProj e x⟫ = 0 for each basis vector, extended to the whole span by span_induction on the linear functional w ↦ ⟪x − subProj e x, w⟫. Finite-dimensionality of S (FiniteDimensional.span_of_finite on Set.finite_range) supplies completeness and hence the projection instance. Parseval follows from Orthonormal.inner_sum expanding ⟪subProj, subProj⟫ = ∑ i conj⟪e i,x⟫·⟪e i,x⟫ and RCLike.conj_mul; Bessel's inequality is then a corollary via Orthonormal.sum_inner_products_le.",
+    "keyInsights": [
+      "**Sum of rank-one projectors**: the orthogonal projection onto S = span(range e) is the operator ∑ i e_i e_i^*, i.e. P_S x = ∑ i ⟪e i, x⟫ • e i — a finite-rank resolution of the identity, the k-fold sum of the parent's single rank-one projector.",
+      "**Coordinates are preserved**: for an orthonormal family, ⟪e j, P_S x⟫ = ⟪e j, x⟫, so P_S x has the same coordinates along each e j as x itself; the residual carries the rest.",
+      "**Residual ⊥ subspace, not just basis**: proving ⟪e j, residual⟫ = 0 for each j extends to ⟪residual, w⟫ = 0 for all w ∈ S because w ↦ ⟪residual, w⟫ is linear and vanishes on a spanning set (span_induction).",
+      "**Parseval as attained Bessel**: ‖P_S x‖² = ∑ i ‖⟪e i, x⟫‖² is the equality case of Bessel's inequality ‖P_S x‖² ≤ ‖x‖²; the cross terms collapse to the diagonal by orthonormality.",
+      "**No completeness hypothesis on E**: S is finite-dimensional (spanned by finitely many vectors), hence complete over the RCLike field 𝕜, so orthogonalProjection exists regardless of whether E itself is complete."
+    ],
+    "prerequisites": [
+      "Inner product spaces over an RCLike field",
+      "Orthonormal families and Bessel's inequality",
+      "Orthogonal projection onto a complete subspace (Mathlib starProjection / orthogonalProjection)",
+      "Finite-dimensional spans and completeness",
+      "Parseval's identity / resolution of the identity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "instances",
+      "title": "Finite-dimensional span is complete",
+      "startLine": 54,
+      "endLine": 66,
+      "summary": "The span of a finite family is finite-dimensional (span_of_finite) and hence complete, so the orthogonal projection exists with no hypothesis on E.",
+      "mathContext": "$S = \\operatorname{span}(\\operatorname{range} e)$ is finite-dimensional over the complete field $\\mathbb{K}$, hence complete."
+    },
+    {
+      "id": "definition",
+      "title": "The finite-rank projection",
+      "startLine": 68,
+      "endLine": 90,
+      "summary": "subProj e x = ∑ i, ⟪e i, x⟫ • e i, its membership in S, and the coordinate-preservation lemma ⟪e j, subProj e x⟫ = ⟪e j, x⟫.",
+      "mathContext": "$\\mathrm{subProj}\\,e\\,x = \\sum_i \\langle e_i, x\\rangle\\, e_i \\in S$ with $\\langle e_j, \\mathrm{subProj}\\,e\\,x\\rangle = \\langle e_j, x\\rangle$."
+    },
+    {
+      "id": "residual",
+      "title": "Residual orthogonality",
+      "startLine": 92,
+      "endLine": 114,
+      "summary": "The residual x − subProj e x is orthogonal to each e j and, by span_induction, to the whole subspace S.",
+      "mathContext": "$\\langle e_j, x - \\mathrm{subProj}\\,e\\,x\\rangle = 0$ for all $j$, hence $\\langle x - \\mathrm{subProj}\\,e\\,x, w\\rangle = 0$ for all $w \\in S$."
+    },
+    {
+      "id": "headline",
+      "title": "Sum-of-rank-one-projectors identity",
+      "startLine": 115,
+      "endLine": 133,
+      "summary": "The headline: S.starProjection x = subProj e x (and the orthogonalProjection coercion form), via the uniqueness of orthogonal projection.",
+      "mathContext": "$P_S x = \\sum_i \\langle e_i, x\\rangle\\, e_i$, the operator identity $P_S = \\sum_i e_i e_i^{*}$."
+    },
+    {
+      "id": "parseval",
+      "title": "Parseval / Bessel equality",
+      "startLine": 134,
+      "endLine": 153,
+      "summary": "‖subProj e x‖² = ∑ i ‖⟪e i, x⟫‖² (Parseval on S) with the Bessel bound ‖subProj e x‖² ≤ ‖x‖² as a corollary.",
+      "mathContext": "$\\lVert P_S x\\rVert^2 = \\sum_i |\\langle e_i, x\\rangle|^2 \\le \\lVert x\\rVert^2$."
+    },
+    {
+      "id": "projector-axioms",
+      "title": "Idempotency, reconstruction, k=1 recovery",
+      "startLine": 154,
+      "endLine": 192,
+      "summary": "Idempotency P²=P, reconstruction P + (1−P) = id, the k=1 recovery of the parent's rank-one projector, and the capstone bundle.",
+      "mathContext": "$P_S^2 = P_S$, $P_S + (1-P_S) = \\mathrm{id}$, and for $k=1$, $P_S x = \\langle e_0, x\\rangle\\, e_0$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file verifies, with zero axioms and zero sorries, that the orthogonal projection onto the span of a finite orthonormal family is the sum of the rank-one projectors over that family, P_S x = ∑ i ⟪e i, x⟫ • e i, and that the squared projection norm equals the sum of squared coordinate moduli (the Parseval equality on the subspace, the attained case of Bessel's inequality). It also records residual orthogonality to the whole subspace, idempotency, reconstruction, and the k=1 recovery of the parent's rank-one projector.",
+    "implications": "This is the exact step that turns the rank-one Gram-Schmidt/Cauchy-Schwarz picture into the general theory of orthogonal projection: the sum-of-rank-one-projectors formula is a finite-rank resolution of the identity, and the subspace Parseval equality is the sharp form of Bessel's inequality. Concretely it is the analytic backbone of the QR decomposition and of least-squares approximation, where the best approximation of x from S is ∑ i ⟪e i, x⟫ • e i.",
+    "openQuestions": [
+      "Can the sum-of-rank-one-projectors identity be assembled into a full QR decomposition of a finite family of vectors?",
+      "Does the Parseval equality extend to a countable orthonormal basis of a separable Hilbert space (the l² case) as a limit of the finite-rank identities?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: one Gram-Schmidt step is a rank-one orthogonal projector onto a line span{v}. This file sums k of them to project onto a k-dimensional subspace, and its k=1 case recovers the parent's rank-one projector; it settles the parent's third open question."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-02",
+      "relationship": "builds-on",
+      "description": "Grandparent: Gram-Schmidt via Cauchy-Schwarz (bounded coefficient, orthogonal residual, Pythagoras)."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "builds-on",
+      "description": "The base inner-product inequality underlying Bessel's inequality and the Parseval equality."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Parseval, M.-A.",
+      "title": "Mémoire sur les séries et sur l'intégration complète d'une équation aux différences partielles linéaires du second ordre, à coefficients constants",
+      "year": "1806",
+      "venue": "Mémoires présentés à l'Institut des Sciences, Lettres et Arts",
+      "note": "Origin of Parseval's identity"
+    },
+    {
+      "authors": "Halmos, P. R.",
+      "title": "Finite-Dimensional Vector Spaces",
+      "year": "1958",
+      "venue": "Springer",
+      "note": "Orthogonal projection onto a subspace and resolution of the identity"
+    },
+    {
+      "authors": "Axler, S.",
+      "title": "Linear Algebra Done Right",
+      "year": "2015",
+      "venue": "Springer, 3rd ed.",
+      "note": "Orthonormal bases, orthogonal projections, and best approximation"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Projection.Basic",
+      "Mathlib.Analysis.InnerProductSpace.Orthonormal",
+      "Mathlib.Analysis.RCLike.Basic",
+      "Mathlib.LinearAlgebra.FiniteDimensional.Defs",
+      "Mathlib.Topology.Algebra.Module.FiniteDimension",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "CauchySchwarzOQ01OQ02OQ01OQ03",
+    "lineCount": 192,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "path": "Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** recorded by the parent entry `antitone-integral-sum-comparison-oq-01-oq-02`:

> *Package the analogous defect for a general antitone f, proving ∑_{k≤n} f(k) − ∫₁^n f converges (the generalized Euler constant of f).*

Where the parent specialized the antitone integral test to `f(x) = 1/x` and identified the limit of `Hₙ − log(n+1)` with the Euler–Mascheroni constant γ, this entry lifts the whole phenomenon to **every** antitone, nonnegative `f` on `[1,∞)`.

## What is proved

Define the **defect** `D f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f`. Using only Mathlib's two-sided antitone integral-test sandwich (`AntitoneOn.integral_le_sum` / `AntitoneOn.sum_le_integral`):

- `defect_nonneg` — `0 ≤ D f n` (upper Riemann sum dominates the integral)
- `defect_le` — `D f n ≤ f 1` uniformly, via telescoping the two Riemann sums to `f 1 − f(1+n)`
- `defect_monotone` — monotone non-decreasing (per-cell increment `f(1+n) − ∫ ≥ 0`)
- `tendsto_defect` — `D f → generalizedEuler f := ⨆ n, D f n` (bounded-monotone convergence)
- `generalizedEuler_mem_Icc` — the limit lies in `[0, f 1]`

The parent's harmonic defect is exactly the case `f = 1/x`.

## Verification

- **13 theorems, 2 definitions, 156 lines, 0 sorries**
- `#print axioms tendsto_defect` → `propext, Classical.choice, Quot.sound` only → **0-axiom / VERIFIED**
- Compiled against pinned Lean v4.26.0 + Mathlib (narrow-import `lake env lean`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)