### PR TITLE
research(sperner-ndim-oq-02): facet-0 partner shares s's facet as a vertex set [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -2938,4 +2938,42 @@ theorem zeroPivotCell_ne (s : GridSimplex d N) (hd1 : 0 < d)
   simp only [zeroPivotCell_verts_last] at hv
   exact zeroPivotTop_not_mem_chain s hd1 hfeas (Fin.last d) hv
 
+/-- **The cross-chain door is literally shared.**  The facet of the partner cell
+`zeroPivotCell s` obtained by dropping *its own last* vertex is *equal as a vertex
+set* to the facet of `s` obtained by dropping *its base* vertex `0`; both are
+`{verts 1, …, verts d}`.  So `s` and `zeroPivotCell s` are two distinct
+(`zeroPivotCell_ne`) cells meeting along one common facet — exactly the pair a
+total `SpernerTriangulation.adj` must glue across the always-unpaired facet `0`
+(`gridNeighbor_none_geom_interior_iff`).  This upgrades the pointwise
+correspondence `zeroPivotCell_verts_of_lt` to the set-level statement the
+adjacency actually consumes.  0-sorry, 0-axiom. -/
+theorem zeroPivotCell_shares_facet (s : GridSimplex d N) (hd1 : 0 < d)
+    (hfeas : 1 ≤ (s.verts (Fin.last d)).coords s.miss) :
+    (Finset.univ.erase (Fin.last d)).image (zeroPivotCell s hd1 hfeas).verts
+      = (Finset.univ.erase (0 : Fin (d + 1))).image s.verts := by
+  ext x
+  simp only [Finset.mem_image, Finset.mem_erase, Finset.mem_univ, and_true]
+  constructor
+  · rintro ⟨j, hj, rfl⟩
+    have hjd : j.val < d := by
+      have hjne : j.val ≠ d := fun h => hj (Fin.ext (by simp [Fin.val_last, h]))
+      have := j.isLt; omega
+    refine ⟨⟨j.val + 1, by omega⟩, ?_, ?_⟩
+    · simp only [Ne, Fin.ext_iff, Fin.val_zero]; omega
+    · exact (zeroPivotCell_verts_of_lt s hd1 hfeas j hjd).symm
+  · rintro ⟨i, hi, rfl⟩
+    have hipos : 0 < i.val := by
+      have : i.val ≠ 0 := by
+        simp only [Ne, Fin.ext_iff, Fin.val_zero] at hi; exact hi
+      omega
+    have hile : i.val ≤ d := by have := i.isLt; omega
+    refine ⟨⟨i.val - 1, by omega⟩, ?_, ?_⟩
+    · simp only [Ne, Fin.ext_iff, Fin.val_last]; omega
+    · rw [zeroPivotCell_verts_of_lt s hd1 hfeas ⟨i.val - 1, by omega⟩
+          (by show i.val - 1 < d; omega)]
+      congr 1
+      apply Fin.ext
+      show i.val - 1 + 1 = i.val
+      omega
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -2346,3 +2346,32 @@ signatures were read from source and match the abstract stand-ins exactly.
    formally eliminated by `zero_facet_not_on_boundary`).
 2. Define total `adj` with geometric none-fibre exactly `{Fin.last d}` on interior cells.
 3. Assemble `SpernerTriangulation`; Phase-2 door oddness induction on `d`.
+
+## Session 2026-07-01 (R6) — facet-0 partner cell COMPLETE; shared-facet door proved
+
+**Mode**: REVISIT (continuing frontier) · **Outcome**: progress (VERIFIED, 0-axiom)
+
+### State update
+- Docker + `lake env lean` are BACK UP this session; full machine verification works
+  again (the Kaehler `.olean.server` wall does NOT bite in batch `lake env lean`).
+- The **facet-0 cross-chain partner cell is now fully constructed and merged**
+  (`zeroPivotCell` in #32251): a bona-fide `GridSimplex` whose chain is
+  `verts 1, …, verts d, zeroPivotTop`, increment directions cyclically rotated so the
+  omitted `incDir 0` is raised last. `zeroPivotCell_ne` shows it is distinct from `s`.
+- This session added `zeroPivotCell_shares_facet` (PR #32277): the facet of the partner
+  (drop its last vertex) equals **as a Finset of vertices** the facet-0 of `s` (drop
+  vertex 0) — both `{verts 1,…,verts d}`. Elementary image/erase membership via the
+  `k ↦ k+1` shift bijection. This is the set-level "shared door" the total `adj` consumes.
+
+### Collision note (important for parallel runs)
+Multiple processes are working sperner-oq-02 concurrently. My independent partner-cell
+build (`zeroPartnerSimplex`, via `Fin.snoc`) was discarded as a duplicate of the merged
+`zeroPivotCell` — checked origin BEFORE pushing. Live sibling branches:
+`research/sperner-ndim-oq-02-pivot-involution`, `research/sperner-ndim-oq02-canon-lexmin`.
+
+### Next steps (crux, unchanged)
+1. **Pivot involution**: `zeroPivotCell` applied appropriately returns to `s` (double
+   pivot reconstructs the base) — the key to door-parity. (Sibling branch in progress.)
+2. Define total `adj` with geometric none-fibre exactly `{Fin.last d}` on interior cells,
+   now gluing facet 0 via `zeroPivotCell` / `zeroPivotCell_shares_facet`.
+3. Assemble `SpernerTriangulation`; Phase-2 door-oddness induction on `d`.


### PR DESCRIPTION
## Summary

Adds `zeroPivotCell_shares_facet` to `Proofs/Proofs/SpernerNDimOQ02.lean`, building directly on the facet-0 partner cell `zeroPivotCell` merged in #32251.

The facet of the partner cell `zeroPivotCell s` obtained by dropping *its own last* vertex is proved **equal as a Finset of vertices** to the facet of `s` obtained by dropping *its base* vertex `0`:

```
(univ.erase (Fin.last d)).image (zeroPivotCell s hd1 hfeas).verts
  = (univ.erase 0).image s.verts
```

Both sides are `{verts 1, …, verts d}`.

## Why this matters

`gridNeighbor_none_geom_interior_iff` (#32251) pins facet `0` as the *always-unpaired, geometrically-interior* facet where a total `SpernerTriangulation.adj` must glue across Kuhn chains. `zeroPivotCell` supplies the partner and `zeroPivotCell_ne` shows it is distinct from `s`.

This theorem upgrades the pointwise correspondence `zeroPivotCell_verts_of_lt` to the **set-level "shared door" statement** the adjacency actually consumes: `s` and `zeroPivotCell s` are two distinct cells meeting along exactly one common facet.

## Proof

Elementary `Finset.image`/`Finset.erase` membership reasoning via the shift bijection `k ↦ k+1` on `Fin d`.

## Verification

- 0 sorries, 0 `axiom` declarations, no `native_decide`
- `#print axioms zeroPivotCell_shares_facet` → `[propext, Classical.choice, Quot.sound]` (foundational only)
- Compiles clean via `lake env lean Proofs/SpernerNDimOQ02.lean` (Lean v4.26.0), EXIT 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)