### PR TITLE
Enrich Erdős #729 OQ-04 (multinomial Kummer identity): annotations + index.ts

### DIFF
--- a/src/data/proofs/erdos-729-oq-04/index.ts
+++ b/src/data/proofs/erdos-729-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos729LegendreMultinomial.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos729Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos729Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos729Oq04Data: ProofData = {
+  proof: erdos729Oq04Proof,
+  annotations: erdos729Oq04Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-729-oq-04` (quality 41 → the entry had **no annotations.json and no index.ts**).

## Changes
- **Created `annotations.json`** with 5 substantive annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. `padicValNat_prod_factorial` — v_p distributes over a finite product of factorials
  2. `legendre_add` — the subtraction-free additive Legendre form (the key engineering trick)
  3. `sub_one_mul_padicValNat_multinomial` — the headline multinomial Legendre/Kummer identity
  4. `padicValNat_multinomial_eq_div` — the classical division form
  5. `prime_dvd_multinomial_iff` — the multinomial Kummer divisibility criterion
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site.

## Verification
- `pnpm build` passes (tsc typecheck clean, vite ✓ built in 18.70s).
- JSON validated; `meta.json` unchanged (already rich, 14 KB, under the 60 KB cap).
- No axiom/status claims altered; entry remains verified, 0-axiom.