### PR TITLE
Enrich Königsberg OQ-05 (Eulerian trail endpoints): +annotation, tags, prerequisites

### DIFF
--- a/src/data/proofs/konigsberg-oq-05/annotations.json
+++ b/src/data/proofs/konigsberg-oq-05/annotations.json
@@ -19,6 +19,38 @@
     "prerequisites": [
       "SimpleGraph.Walk.IsEulerian",
       "Nat parity (Even/Odd)"
+    ],
+    "tags": [
+      "theorem",
+      "eulerian-trail",
+      "parity",
+      "key-result"
+    ]
+  },
+  {
+    "id": "ann-endpoint-corollaries",
+    "proofId": "konigsberg-oq-05",
+    "range": {
+      "startLine": 67,
+      "endLine": 75
+    },
+    "type": "theorem",
+    "title": "Each Endpoint Individually Has Odd Degree",
+    "content": "`euler_trail_left_odd` and `euler_trail_right_odd` are the two immediate corollaries of the biconditional, specialised at $w = u$ and $w = v$: each endpoint of an open Eulerian trail has odd degree. They are one-liners — `(euler_trail_odd_iff_endpoint …).mpr (Or.inl rfl)` and `… (Or.inr rfl)` — but they isolate the concrete odd-degree witnesses that the exact-count proof relies on: the count cannot be 0 precisely because $u$ is provably odd.",
+    "mathContext": "$\\mathrm{Odd}(\\deg_G u)$ and $\\mathrm{Odd}(\\deg_G v)$ for an open trail $u \\to v$; these are the witnesses that upgrade $\\text{card} \\in \\{0,2\\}$ to $\\text{card} = 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "corollary specialisation",
+      "odd-degree witness",
+      "Eulerian trail endpoints"
+    ],
+    "prerequisites": [
+      "the endpoint biconditional"
+    ],
+    "tags": [
+      "theorem",
+      "corollary",
+      "eulerian-trail"
     ]
   },
   {
@@ -39,6 +71,11 @@
     ],
     "prerequisites": [
       "Set.ext"
+    ],
+    "tags": [
+      "theorem",
+      "set-equality",
+      "eulerian-trail"
     ]
   },
   {
@@ -59,6 +96,11 @@
     ],
     "prerequisites": [
       "Fintype cardinality"
+    ],
+    "tags": [
+      "theorem",
+      "cardinality",
+      "sharpening"
     ]
   },
   {
@@ -80,6 +122,11 @@
     ],
     "prerequisites": [
       "Fintype.card_eq_zero_iff"
+    ],
+    "tags": [
+      "theorem",
+      "eulerian-circuit",
+      "vacuous-guard"
     ]
   }
 ]

--- a/src/data/proofs/konigsberg-oq-05/meta.json
+++ b/src/data/proofs/konigsberg-oq-05/meta.json
@@ -33,6 +33,12 @@
       "The genuinely new half is the converse endpoint ⟹ odd: the sibling file KonigsbergOQ01 only established non-endpoint ⟹ even, one direction short of 'exactly the endpoints'.",
       "The exact count = 2 is a strict sharpening of Mathlib's `card_odd_degree` (0 ∨ 2): the endpoint u is a concrete odd-degree witness, so the count cannot be 0 for an open trail.",
       "The open/closed dichotomy is unified: distinct endpoints ⟹ odd-degree set = {u, v} (count 2); a circuit ⟹ odd-degree set = ∅ (count 0), the two vacuous/nonvacuous branches of the same guarded implication."
+    ],
+    "prerequisites": [
+      "Eulerian trails and circuits (SimpleGraph.Walk.IsEulerian)",
+      "Vertex degree and its parity (Even/Odd on ℕ)",
+      "Mathlib's even_degree_iff and card_odd_degree",
+      "Set extensionality and Fintype cardinality"
     ]
   },
   "sections": [


### PR DESCRIPTION
## Enrichment pass — konigsberg-oq-05

**Endpoints of an Eulerian Trail Are Exactly the Odd-Degree Vertices.**

The entry was solid but had three concrete gaps: the two endpoint corollaries were unannotated, annotations lacked the gallery-standard `tags[]`, and `overview` was missing a `prerequisites` array.

### Change
- **5th annotation** (lines 67–75): covers `euler_trail_left_odd` / `euler_trail_right_odd` — the only previously-uncovered theorems. They isolate the concrete odd-degree witnesses ($u$, $v$) that the exact-count-of-2 proof depends on.
- **`tags[]`** added to all five annotations.
- **`overview.prerequisites`** added (IsEulerian, degree parity, `even_degree_iff`/`card_odd_degree`, set extensionality / Fintype cardinality).

### Verification
- `annotations/build.ts`: **0 errors** for this entry (all 5 ranges land on real Lean constructs)
- `gallery/check-meta-size.ts`: within caps
- Only the entry's `annotations.json` and `meta.json` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)