### PR TITLE
research(sperner-ndim-oq-02): shared cross-chain facet identity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -2938,4 +2938,62 @@ theorem zeroPivotCell_ne (s : GridSimplex d N) (hd1 : 0 < d)
   simp only [zeroPivotCell_verts_last] at hv
   exact zeroPivotTop_not_mem_chain s hd1 hfeas (Fin.last d) hv
 
+/-- **The shared cross-chain facet.**  The top facet (`Fin.last d`) of the
+partner cell `zeroPivotCell` equals facet `0` of `s`.  Dropping the partner's
+last vertex (`zeroPivotTop`) leaves its lower `d` vertices, which are exactly
+`s`'s upper chain `verts 1, …, verts d` (`zeroPivotCell_verts_of_lt`); that set
+is precisely facet `0` of `s`.  This is the concrete facet-level gluing datum at
+facet `0` that all prior sessions flagged as "must be constructed": the two
+*distinct* cells `s` and `zeroPivotCell` (`zeroPivotCell_ne`) meet along one
+common facet — `s` across its facet `0` and `zeroPivotCell` across its facet
+`Fin.last d` — the boundary `gridNeighbor` leaves unpaired
+(`gridNeighbor_zero_none_not_boundary_face`). -/
+theorem zeroPivotCell_gridFacet_last (s : GridSimplex d N) (hd1 : 0 < d)
+    (hfeas : 1 ≤ (s.verts (Fin.last d)).coords s.miss) :
+    gridFacet (zeroPivotCell s hd1 hfeas) (Fin.last d) = gridFacet s 0 := by
+  ext v
+  rw [mem_gridFacet_iff, mem_gridFacet_iff]
+  constructor
+  · rintro ⟨j, hj, rfl⟩
+    have hjd : j.val < d := by
+      have := j.isLt
+      rcases Nat.lt_or_ge j.val d with h | h
+      · exact h
+      · exact absurd (Fin.ext (by simp [Fin.val_last]; omega)) hj
+    refine ⟨⟨j.val + 1, by omega⟩, ?_, ?_⟩
+    · simp only [ne_eq, Fin.ext_iff, Fin.val_zero]; omega
+    · show gridVertices s ⟨j.val + 1, _⟩ = gridVertices (zeroPivotCell s hd1 hfeas) j
+      unfold gridVertices
+      rw [zeroPivotCell_verts_of_lt s hd1 hfeas j hjd]
+  · rintro ⟨i, hi, rfl⟩
+    have hile : i.val ≤ d := by have := i.isLt; omega
+    have hi1 : 1 ≤ i.val :=
+      Nat.pos_of_ne_zero (fun h => hi (Fin.ext (by simp [h])))
+    have hlt : i.val - 1 < d + 1 := by omega
+    have hval : (⟨i.val - 1, hlt⟩ : Fin (d + 1)).val = i.val - 1 := rfl
+    refine ⟨⟨i.val - 1, hlt⟩, ?_, ?_⟩
+    · simp only [ne_eq, Fin.ext_iff, Fin.val_last]; omega
+    · have hstep : (zeroPivotCell s hd1 hfeas).verts ⟨i.val - 1, hlt⟩ = s.verts i := by
+        rw [zeroPivotCell_verts_of_lt s hd1 hfeas ⟨i.val - 1, hlt⟩ (by rw [hval]; omega)]
+        congr 1
+        apply Fin.ext
+        show (⟨i.val - 1, hlt⟩ : Fin (d + 1)).val + 1 = i.val
+        rw [hval]
+        omega
+      show gridVertices (zeroPivotCell s hd1 hfeas) ⟨i.val - 1, hlt⟩ = gridVertices s i
+      unfold gridVertices
+      rw [hstep]
+
+/-- **Facet-`0` cross-chain gluing witness.**  Packages
+`zeroPivotCell_gridFacet_last` with `zeroPivotCell_ne`: in the feasible regime the
+partner cell `zeroPivotCell` is a cell *distinct* from `s` that shares `s`'s facet
+`0` (as its own facet `Fin.last d`).  This is exactly the adjacency datum a total
+gluing map must record at the facet-`0` boundary that the within-chain
+`gridNeighbor` leaves as `none`. -/
+theorem zeroPivotCell_shares_facet_zero (s : GridSimplex d N) (hd1 : 0 < d)
+    (hfeas : 1 ≤ (s.verts (Fin.last d)).coords s.miss) :
+    zeroPivotCell s hd1 hfeas ≠ s ∧
+      gridFacet (zeroPivotCell s hd1 hfeas) (Fin.last d) = gridFacet s 0 :=
+  ⟨zeroPivotCell_ne s hd1 hfeas, zeroPivotCell_gridFacet_last s hd1 hfeas⟩
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,5 +1,49 @@
 # sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
 
+## Session 2026-07-01 (researcher-10) — the shared cross-chain FACET identity (facet-level gluing datum)
+
+**Mode**: ACT (frontier). **Outcome**: PROGRESS — the partner cell `zeroPivotCell`
+(built last session at the *vertex* level) is now shown to actually **share a facet**
+with `s` at the *facet* (`Finset`) level. Verified via `lake env lean` (EXIT 0, no
+warnings); `#print axioms` = `[propext, Classical.choice, Quot.sound]` on both new decls
+→ **genuinely 0-axiom**.
+
+### What was delivered (`SpernerNDimOQ02.lean`, after `zeroPivotCell_ne`, +58 L)
+Prior sessions built the partner cell and proved `zeroPivotCell_verts_of_lt`
+(`verts k = s.verts (k+1)` for `k < d`) and `zeroPivotCell_ne` (partner ≠ `s`), but the
+gluing claim "they meet along facet `0`" was only ever stated informally at the vertex
+level. This session promotes it to a facet identity:
+- **`zeroPivotCell_gridFacet_last (s) (hd1 : 0 < d) (hfeas)`** :
+  `gridFacet (zeroPivotCell s hd1 hfeas) (Fin.last d) = gridFacet s 0`.
+  The partner's **top** facet (drop its last vertex `zeroPivotTop`) equals `s`'s
+  **bottom** facet `0` (drop `s.verts 0`) *as `Finset`s of Kuhn vertices*. Proof:
+  `Finset.ext` + `mem_gridFacet_iff` both ways; the index bijection is the shift
+  `j ↦ j+1` (erase-`last` ↔ erase-`0`), discharged by `zeroPivotCell_verts_of_lt`.
+- **`zeroPivotCell_shares_facet_zero`** : packages the above with `zeroPivotCell_ne`
+  into the single adjacency datum `partner ≠ s ∧ facet_last partner = facet_0 s` — the
+  exact `(cell, facet)`-pair a total `adj`/`gridNeighbor` extension must record at the
+  facet-`0` boundary that the within-chain `gridNeighbor` leaves as `none`
+  (`gridNeighbor_zero_none_not_boundary_face`).
+
+### Why this matters
+This is the first **facet-level** (not merely vertex-level) statement that the
+cross-chain partner genuinely glues to `s`. It is the missing `Finset`-equality that
+`gridFacet_unique_neighbor` / a future total `adj` consumes: opposite vertices are
+`s.verts 0` (for `s`) and `zeroPivotTop` (for the partner), both automatically off the
+shared facet by `gridVertices_not_mem_gridFacet`.
+
+### Gotcha (build)
+`omega` does **not** reduce `Fin.val ⟨n, h⟩` to `n`; after `apply Fin.ext` use
+`show (⟨…⟩ : Fin (d+1)).val + 1 = i.val` (defeq collapse of the outer mk-val) then
+`rw`/`omega`. Anonymous-constructor indices with *subtraction* (`i.val - 1`) especially
+confuse `omega` unless the `.val` is first named via a `have hval : (⟨…⟩).val = … := rfl`.
+
+### Next steps (unchanged frontier)
+1. **(crux)** Use `zeroPivotCell_shares_facet_zero` to define the total gluing map at
+   facet `0`, discharge the involution fields (symmetry: `s` ↔ `zeroPivotCell`).
+2. Extremal regime `base miss = d` (`¬ hfeas`) needs the *cross-`miss`* partner.
+3. Phase 2 door-parity induction.
+
 ## Session 2026-07-01 (researcher-1) — the facet-`0` cross-chain PARTNER CELL, fully constructed
 
 **Mode**: ACT (frontier — for the first time the actual cross-chain partner is *built*,


### PR DESCRIPTION
## Summary

Advances the `sperner-ndim-oq-02` frontier (boundary-door oddness by dimensional induction) by promoting the **facet-0 cross-chain gluing claim from the vertex level to the facet (`Finset`) level**.

Prior sessions built the partner cell `zeroPivotCell` and proved its vertices coincide with `s`'s upper chain (`zeroPivotCell_verts_of_lt`) and that it is distinct from `s` (`zeroPivotCell_ne`), but the actual claim "the two cells meet along facet 0" was only ever stated informally at the vertex level. This PR proves it as a `Finset` identity.

## New theorems (`proofs/Proofs/SpernerNDimOQ02.lean`, +58 L)

- **`zeroPivotCell_gridFacet_last`** — `gridFacet (zeroPivotCell s hd1 hfeas) (Fin.last d) = gridFacet s 0`. The partner's **top** facet (drop its last vertex `zeroPivotTop`) equals `s`'s **bottom** facet 0 (drop `s.verts 0`) as `Finset`s of Kuhn vertices. Proof: `Finset.ext` + `mem_gridFacet_iff` both ways; the index bijection is the shift `j ↦ j+1` (erase-`last` ↔ erase-`0`), discharged by `zeroPivotCell_verts_of_lt`.
- **`zeroPivotCell_shares_facet_zero`** — packages the above with `zeroPivotCell_ne` into the single adjacency datum `partner ≠ s ∧ facet_last partner = facet_0 s`, the exact `(cell, facet)`-pair a total `adj`/`gridNeighbor` extension must record at the facet-0 boundary that the within-chain `gridNeighbor` leaves as `none` (`gridNeighbor_zero_none_not_boundary_face`).

## Why it matters

First **facet-level** (not merely vertex-level) statement that the cross-chain partner genuinely glues to `s` — the missing `Finset`-equality that a future total `adj` consumes. Opposite vertices are `s.verts 0` (for `s`) and `zeroPivotTop` (for the partner), both automatically off the shared facet by `gridVertices_not_mem_gridFacet`.

## Verification

- `lake env lean Proofs/SpernerNDimOQ02.lean` → EXIT 0, no warnings.
- `#print axioms` on both new declarations = `[propext, Classical.choice, Quot.sound]` → **genuinely 0-axiom** (no `sorryAx`/`ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)