### PR TITLE
research(triangle-inequality-oq-06): reverse triangle inequality family + sharpness [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/TriangleInequalityOQ06.lean
+++ b/proofs/Proofs/TriangleInequalityOQ06.lean
@@ -1,0 +1,139 @@
+import Mathlib
+
+/-
+# The reverse triangle inequality family and 1-Lipschitz distance
+
+The parent `triangle-inequality` proves the *forward* inequality
+`d(x, z) ≤ d(x, y) + d(y, z)`.  This child collects its *reverse* companions into one
+coherent verified narrative and — crucially — proves that the collected bounds are
+**sharp**, which the parent lemmas alone do not record.
+
+The bundle:
+
+* **reverse (second) triangle inequality** `|d(x,z) - d(y,z)| ≤ d(x,y)`
+  — the distance to a fixed point changes by at most the step you take;
+* its **quadrilateral** strengthening `|d(x,y) - d(x',y')| ≤ d(x,x') + d(y,y')`
+  — moving *both* endpoints;
+* the **seminorm** version `| ‖a‖ - ‖b‖ | ≤ ‖a - b‖`;
+* the consequence that `d(x, ·)` (and `d(·, y)`) is `1`-Lipschitz, hence uniformly
+  continuous and continuous.
+
+The atomic inequalities discharge by the Mathlib lemmas `abs_dist_sub_le`,
+`dist_dist_dist_le`, `abs_norm_sub_norm_le`, `LipschitzWith.dist_right/left`.  The
+genuinely new content of this file is the **sharpness layer**:
+
+* `reverse_triangle_eq_of_between` : for collinear reals `a ≤ b ≤ c` the reverse
+  inequality is an *equality* `|d(a,c) - d(b,c)| = d(a,b)` — so the bound `≤ d(x,y)` is
+  attained and cannot be improved;
+* `quadrilateral_sharp` : an explicit real configuration attaining the quadrilateral
+  bound with both endpoints moved;
+* `dist_lipschitz_optimal` : the Lipschitz constant `1` is *optimal* — no `c < 1`
+  makes `dist x` a `c`-Lipschitz map.
+
+Everything is `0`-axiom.  This is distinct from the strict-convexity equality case
+(gallery `triangle-inequality-oq-05`), which characterises equality in the *forward*
+`‖x + y‖ = ‖x‖ + ‖y‖`; here we treat the *reverse* family and its attainment.
+-/
+
+namespace TriangleInequalityOQ06
+
+open scoped NNReal
+
+/-! ## The reverse triangle inequality family (pseudometric spaces) -/
+
+variable {α : Type*} [PseudoMetricSpace α]
+
+/-- Reverse (second) triangle inequality: the distance to a fixed point `z` changes by
+at most the distance between the two moving points. -/
+theorem reverse_triangle (x y z : α) : |dist x z - dist y z| ≤ dist x y :=
+  abs_dist_sub_le x y z
+
+/-- One-sided form (without the absolute value). -/
+theorem dist_sub_dist_le (x y z : α) : dist x z - dist y z ≤ dist x y :=
+  (abs_le.1 (abs_dist_sub_le x y z)).2
+
+/-- Quadrilateral reverse inequality: move *both* endpoints.  On `ℝ`,
+`dist (dist x y) (dist x' y')` unfolds to `|dist x y - dist x' y'|`. -/
+theorem reverse_triangle_quad (x y x' y' : α) :
+    |dist x y - dist x' y'| ≤ dist x x' + dist y y' := by
+  simpa [Real.dist_eq] using dist_dist_dist_le x y x' y'
+
+/-! ## The 1-Lipschitz / continuity package -/
+
+/-- The distance from a fixed left point is `1`-Lipschitz in its right argument. -/
+theorem dist_lipschitz_right (x : α) : LipschitzWith 1 (dist x) :=
+  LipschitzWith.dist_right x
+
+/-- The distance to a fixed right point is `1`-Lipschitz in its left argument. -/
+theorem dist_lipschitz_left (y : α) : LipschitzWith 1 (fun x => dist x y) :=
+  LipschitzWith.dist_left y
+
+/-- Consequently `d(x, ·)` is uniformly continuous. -/
+theorem dist_uniformContinuous_right (x : α) : UniformContinuous (dist x) :=
+  (dist_lipschitz_right x).uniformContinuous
+
+/-- … and continuous. -/
+theorem dist_continuous_right (x : α) : Continuous (dist x) :=
+  (dist_lipschitz_right x).continuous
+
+/-! ## The seminorm reverse triangle inequality -/
+
+/-- Norm reverse triangle inequality. -/
+theorem reverse_triangle_norm {E : Type*} [SeminormedAddGroup E] (a b : E) :
+    |‖a‖ - ‖b‖| ≤ ‖a - b‖ :=
+  abs_norm_sub_norm_le a b
+
+/-- One-sided seminorm form. -/
+theorem norm_sub_norm_le' {E : Type*} [SeminormedAddGroup E] (a b : E) :
+    ‖a‖ - ‖b‖ ≤ ‖a - b‖ :=
+  norm_sub_norm_le a b
+
+/-! ## Sharpness layer — the new content
+
+The bundle above only re-packages Mathlib lemmas.  The results below certify that the
+inequalities are *tight*: each bound is attained, so no constant can be improved.
+-/
+
+/-- **Sharpness of the reverse inequality.**  For collinear reals `a ≤ b ≤ c` the reverse
+triangle inequality holds with *equality*: `|d(a,c) - d(b,c)| = d(a,b)`.  In particular
+the bound `|d(x,z) - d(y,z)| ≤ d(x,y)` is attained, hence optimal. -/
+theorem reverse_triangle_eq_of_between {a b c : ℝ} (hab : a ≤ b) (hbc : b ≤ c) :
+    |dist a c - dist b c| = dist a b := by
+  have hac : a ≤ c := le_trans hab hbc
+  rw [Real.dist_eq, Real.dist_eq, Real.dist_eq,
+    abs_of_nonpos (by linarith : a - c ≤ 0),
+    abs_of_nonpos (by linarith : b - c ≤ 0),
+    abs_of_nonpos (by linarith : a - b ≤ 0)]
+  rw [show -(a - c) - -(b - c) = -(a - b) by ring, abs_neg, abs_of_nonpos (by linarith : a - b ≤ 0)]
+
+/-- Concrete witness of the reverse-inequality equality: `|d(0,2) - d(1,2)| = d(0,1) = 1`. -/
+example : |dist (0 : ℝ) 2 - dist (1 : ℝ) 2| = dist (0 : ℝ) 1 :=
+  reverse_triangle_eq_of_between (by norm_num) (by norm_num)
+
+/-- **Sharpness of the quadrilateral inequality.**  Moving the two endpoints of a
+degenerate pair in opposite directions attains the bound:
+`|d(0,0) - d(-1,1)| = 2 = d(0,-1) + d(0,1)`. -/
+theorem quadrilateral_sharp :
+    |dist (0 : ℝ) 0 - dist (-1 : ℝ) 1| = dist (0 : ℝ) (-1) + dist (0 : ℝ) 1 := by
+  simp [Real.dist_eq]
+  norm_num
+
+/-- **Optimality of the Lipschitz constant.**  No constant `c < 1` makes `dist x`
+Lipschitz: testing the two points `0` and `1` forces `1 ≤ c`.  Hence the `1` in
+`dist_lipschitz_right` is best possible. -/
+theorem dist_lipschitz_optimal {c : ℝ≥0} (h : LipschitzWith c (dist (0 : ℝ))) : 1 ≤ c := by
+  have key := h.dist_le_mul 0 1
+  simp only [Real.dist_eq] at key
+  norm_num at key
+  exact_mod_cast key
+
+/-! ## Worked real-line examples -/
+
+/-- The reverse inequality on `ℝ` in its familiar absolute-value shape. -/
+example (x y : ℝ) : |(|x| - |y|)| ≤ |x - y| := by
+  simpa [Real.norm_eq_abs] using reverse_triangle_norm x y
+
+/-- The metric on `ℝ` is continuous in each argument. -/
+example (x : ℝ) : Continuous (fun y => dist x y) := dist_continuous_right x
+
+end TriangleInequalityOQ06

--- a/src/data/proofs/triangle-inequality-oq-06/annotations.json
+++ b/src/data/proofs/triangle-inequality-oq-06/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "triangle-inequality-oq-06",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "concept",
+    "title": "The Reverse Triangle Inequality Family",
+    "content": "The parent triangle-inequality proves the FORWARD bound d(x,z) ≤ d(x,y) + d(y,z). This file collects its REVERSE companions — the reverse (second) triangle inequality |d(x,z) − d(y,z)| ≤ d(x,y), its quadrilateral strengthening for moving both endpoints, the seminorm form |‖a‖ − ‖b‖| ≤ ‖a − b‖, and the resulting 1-Lipschitz continuity of the metric. These are the tools that make metric geometry stable under small perturbations, yet they are rarely presented as a unit. Crucially the file adds a SHARPNESS layer that the atomic Mathlib lemmas omit: it certifies each bound is attained, hence optimal. Everything is 0-axiom (only propext, Classical.choice, Quot.sound).",
+    "mathContext": "$|d(x,z)-d(y,z)| \\le d(x,y)$ — the workhorse behind continuity of the metric.",
+    "significance": "supporting",
+    "relatedConcepts": ["reverse triangle inequality", "metric spaces", "Lipschitz", "perturbation stability"],
+    "prerequisites": ["metric spaces", "seminormed groups"]
+  },
+  {
+    "id": "ann-reverse-family",
+    "proofId": "triangle-inequality-oq-06",
+    "range": { "startLine": 42, "endLine": 60 },
+    "type": "theorem",
+    "title": "The Reverse and Quadrilateral Inequalities",
+    "content": "reverse_triangle (Mathlib's abs_dist_sub_le): the distance to a fixed point z changes by at most the distance between the two moving points, |dist x z − dist y z| ≤ dist x y. dist_sub_dist_le is the one-sided form obtained by stripping the absolute value. reverse_triangle_quad is the QUADRILATERAL strengthening |dist x y − dist x' y'| ≤ dist x x' + dist y y', which moves BOTH endpoints and recovers the reverse form by fixing one of them; it comes from Mathlib's dist_dist_dist_le converted from dist (dist x y) (dist x' y') to the absolute-value shape via Real.dist_eq.",
+    "mathContext": "$|d(x,y)-d(x',y')| \\le d(x,x')+d(y,y')$, strengthening the reverse form to two moving endpoints.",
+    "significance": "key",
+    "relatedConcepts": ["abs_dist_sub_le", "dist_dist_dist_le", "Real.dist_eq", "quadrilateral inequality"],
+    "prerequisites": ["metric spaces", "absolute value"]
+  },
+  {
+    "id": "ann-lipschitz",
+    "proofId": "triangle-inequality-oq-06",
+    "range": { "startLine": 61, "endLine": 90 },
+    "type": "theorem",
+    "title": "1-Lipschitz Distance and the Seminorm Form",
+    "content": "The reverse triangle inequality is EXACTLY the statement that the metric is 1-Lipschitz. dist_lipschitz_right / dist_lipschitz_left package LipschitzWith.dist_right / dist_left: d(x,·) and d(·,y) are both 1-Lipschitz. From this, dist_uniformContinuous_right and dist_continuous_right follow by LipschitzWith.uniformContinuous / continuous — the metric is continuous in each argument, which is the payoff of the whole reverse family. reverse_triangle_norm (abs_norm_sub_norm_le) is the seminorm avatar |‖a‖ − ‖b‖| ≤ ‖a − b‖, saying the norm is a 1-Lipschitz function, with its one-sided companion norm_sub_norm_le'.",
+    "mathContext": "$\\mathrm{LipschitzWith}\\ 1\\ (d(x,\\cdot))$; $\\big|\\|a\\|-\\|b\\|\\big| \\le \\|a-b\\|$.",
+    "significance": "key",
+    "relatedConcepts": ["LipschitzWith.dist_right", "uniform continuity", "abs_norm_sub_norm_le", "1-Lipschitz"],
+    "prerequisites": ["Lipschitz maps", "continuity", "seminorms"]
+  },
+  {
+    "id": "ann-sharpness",
+    "proofId": "triangle-inequality-oq-06",
+    "range": { "startLine": 91, "endLine": 129 },
+    "type": "theorem",
+    "title": "Sharpness: Every Bound Is Attained",
+    "content": "The original content of the file. reverse_triangle_eq_of_between: for collinear reals a ≤ b ≤ c the reverse inequality is an EQUALITY |dist a c − dist b c| = dist a b — proved by rewriting the three ℝ-distances as absolute values and discharging the signs by linarith — so the bound |d(x,z) − d(y,z)| ≤ d(x,y) is attained and cannot be improved (concrete witness: |d(0,2) − d(1,2)| = d(0,1) = 1). quadrilateral_sharp exhibits a real configuration attaining the two-endpoint bound: moving the degenerate pair (0,0) to (−1,1) gives |d(0,0) − d(−1,1)| = 2 = d(0,−1) + d(0,1). dist_lipschitz_optimal proves the Lipschitz constant 1 is BEST POSSIBLE: feeding the test points 0 and 1 into LipschitzWith.dist_le_mul forces 1 ≤ c for any Lipschitz constant c.",
+    "mathContext": "$a \\le b \\le c \\Rightarrow |d(a,c)-d(b,c)| = d(a,b)$; $\\mathrm{LipschitzWith}\\ c\\ (d(x,\\cdot)) \\Rightarrow 1 \\le c$.",
+    "significance": "key",
+    "relatedConcepts": ["sharpness", "attainment", "optimal Lipschitz constant", "LipschitzWith.dist_le_mul", "two-point test"],
+    "prerequisites": ["absolute value sign analysis", "Lipschitz maps"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "triangle-inequality-oq-06",
+    "range": { "startLine": 130, "endLine": 139 },
+    "type": "concept",
+    "title": "Worked Real-Line Examples",
+    "content": "Two instantiations on ℝ. The reverse inequality in its familiar absolute-value shape ||x| − |y|| ≤ |x − y| (from reverse_triangle_norm on the real line via Real.norm_eq_abs), and the continuity of y ↦ dist x y on ℝ, confirming the abstract 1-Lipschitz package specialises to the concrete real metric.",
+    "mathContext": "$\\big||x|-|y|\\big| \\le |x-y|$; $y \\mapsto d(x,y)$ continuous on $\\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.norm_eq_abs", "continuity", "real metric"],
+    "prerequisites": ["real absolute value"]
+  }
+]

--- a/src/data/proofs/triangle-inequality-oq-06/index.ts
+++ b/src/data/proofs/triangle-inequality-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/TriangleInequalityOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const triangleInequalityOq06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const triangleInequalityOq06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const triangleInequalityOq06Data: ProofData = {
+  proof: triangleInequalityOq06Proof,
+  annotations: triangleInequalityOq06Annotations,
+}

--- a/src/data/proofs/triangle-inequality-oq-06/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-06/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "triangle-inequality-oq-06",
+  "title": "The Reverse Triangle Inequality Family and Optimal 1-Lipschitz Distance",
+  "slug": "triangle-inequality-oq-06",
+  "description": "The parent triangle-inequality proves the forward bound d(x,z) ≤ d(x,y) + d(y,z). This child collects its reverse companions into one verified narrative — the reverse (second) triangle inequality |d(x,z) − d(y,z)| ≤ d(x,y), its quadrilateral strengthening |d(x,y) − d(x',y')| ≤ d(x,x') + d(y,y'), the seminorm form |‖a‖ − ‖b‖| ≤ ‖a − b‖, and the consequence that d(x,·) is 1-Lipschitz hence uniformly continuous — and then proves the new content: each bound is SHARP. The reverse inequality is an equality for collinear reals, the quadrilateral bound is attained by moving both endpoints in opposite directions, and the Lipschitz constant 1 is optimal (no c < 1 works).",
+  "meta": {
+    "author": "Classical (metric geometry); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/MetricSpace/Basic.html",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "metric-spaces",
+      "normed-groups",
+      "triangle-inequality",
+      "lipschitz",
+      "continuity",
+      "sharpness"
+    ],
+    "proofRepoPath": "Proofs/TriangleInequalityOQ06.lean",
+    "badge": "verified",
+    "packagingNote": "Tier B bundle with an original sharpness layer. The atomic inequalities are one-line re-exports of named Mathlib lemmas (abs_dist_sub_le, dist_dist_dist_le, abs_norm_sub_norm_le, LipschitzWith.dist_right/left) plus the standard glue for the quadrilateral form (Real.dist_eq). The genuinely new content is the three sharpness theorems: reverse_triangle_eq_of_between (the reverse inequality is an equality for collinear reals a ≤ b ≤ c), quadrilateral_sharp (an explicit real configuration attaining the two-endpoint bound), and dist_lipschitz_optimal (the Lipschitz constant 1 is best possible). Status is verified (0 sorries, 0 axioms — only propext/Classical.choice/Quot.sound).",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 139,
+    "mathlibDependencies": [
+      {
+        "theorem": "abs_dist_sub_le",
+        "description": "Reverse triangle inequality: |dist x z − dist y z| ≤ dist x y",
+        "module": "Mathlib.Topology.MetricSpace.Pseudo.Defs"
+      },
+      {
+        "theorem": "dist_dist_dist_le",
+        "description": "Quadrilateral inequality: dist (dist x y) (dist x' y') ≤ dist x x' + dist y y'",
+        "module": "Mathlib.Topology.MetricSpace.Pseudo.Defs"
+      },
+      {
+        "theorem": "abs_norm_sub_norm_le",
+        "description": "Seminorm reverse triangle inequality: |‖a‖ − ‖b‖| ≤ ‖a − b‖",
+        "module": "Mathlib.Analysis.Normed.Group.Basic"
+      },
+      {
+        "theorem": "LipschitzWith.dist_right",
+        "description": "The distance from a fixed point is 1-Lipschitz in its right argument",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      },
+      {
+        "theorem": "LipschitzWith.dist_le_mul",
+        "description": "Turns a LipschitzWith c hypothesis into the pointwise bound dist (f a) (f b) ≤ c * dist a b, used to prove optimality of the constant 1",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      }
+    ],
+    "originalContributions": [
+      "reverse_triangle_eq_of_between: for collinear reals a ≤ b ≤ c the reverse triangle inequality is an EQUALITY |dist a c − dist b c| = dist a b, certifying the bound |d(x,z) − d(y,z)| ≤ d(x,y) is attained and optimal",
+      "quadrilateral_sharp: an explicit real configuration |dist 0 0 − dist (−1) 1| = dist 0 (−1) + dist 0 1 attaining the two-endpoint quadrilateral bound",
+      "dist_lipschitz_optimal: the Lipschitz constant 1 in LipschitzWith 1 (dist x) is best possible — testing the points 0 and 1 forces any Lipschitz constant c ≥ 1",
+      "A unified bundle: reverse, one-sided, quadrilateral, seminorm, and both-argument Lipschitz/continuity forms packaged with worked ℝ examples"
+    ],
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The forward triangle inequality d(x,z) ≤ d(x,y) + d(y,z) is one of the three defining axioms of a metric space. Its reverse companion — sometimes called the second triangle inequality — |d(x,z) − d(y,z)| ≤ d(x,y) is equally fundamental but far less often stated as a headline result, despite being the workhorse behind continuity of the metric, well-definedness of limits, and stability of distance estimates under perturbation. Its normed-space avatar |‖a‖ − ‖b‖| ≤ ‖a − b‖ expresses that the norm is a 1-Lipschitz function; the quadrilateral form generalises to moving both endpoints of a pair simultaneously. Together these say that metric geometry is stable under small perturbations, which is exactly what makes the distance function continuous.",
+    "problemStatement": "In a pseudometric space $\\alpha$ and a seminormed additive group $E$:\n\n$$|d(x,z) - d(y,z)| \\le d(x,y), \\qquad |d(x,y) - d(x',y')| \\le d(x,x') + d(y,y'), \\qquad \\big|\\,\\|a\\| - \\|b\\|\\,\\big| \\le \\|a-b\\|,$$\n\nand $d(x,\\cdot)$ is $1$-Lipschitz, hence uniformly continuous and continuous. Moreover each bound is sharp: the first is an equality for collinear reals, the quadrilateral bound is attained, and the Lipschitz constant $1$ cannot be lowered.",
+    "proofStrategy": "The atomic inequalities are direct Mathlib lemmas: abs_dist_sub_le for the reverse form, dist_dist_dist_le for the quadrilateral form (converted to the |·| shape on ℝ via Real.dist_eq), abs_norm_sub_norm_le for the seminorm form, and LipschitzWith.dist_right / dist_left for the Lipschitz package, from which uniform continuity and continuity follow.\n\nThe sharpness layer is the original work. reverse_triangle_eq_of_between rewrites all three distances on ℝ as absolute values and discharges the sign conditions from a ≤ b ≤ c by linarith, showing |dist a c − dist b c| = dist a b exactly. quadrilateral_sharp is a direct computation on a degenerate configuration with both endpoints moved. dist_lipschitz_optimal feeds the two test points 0 and 1 into LipschitzWith.dist_le_mul: since dist (dist 0 0) (dist 0 1) = 1 and dist 0 1 = 1, the Lipschitz hypothesis forces 1 ≤ c, so the constant 1 is optimal.",
+    "keyInsights": [
+      "The reverse triangle inequality is the exact statement that d(x,·) is 1-Lipschitz — the |d(x,z) − d(y,z)| ≤ d(x,y) form and the LipschitzWith 1 form are two faces of the same fact.",
+      "On the real line the reverse inequality degenerates to an equality precisely when the three points are collinear with the moving pair on the same side of the fixed point — the sharpness witness reverse_triangle_eq_of_between makes this quantitative.",
+      "The quadrilateral form is strictly stronger than the reverse form (it recovers the reverse form by fixing one endpoint) and is still attained, so neither summand d(x,x') nor d(y,y') is wasteful.",
+      "Optimality of the Lipschitz constant is proved not by an abstract argument but by exhibiting a single pair of test points, which is the cleanest possible certificate that 1 cannot be improved."
+    ],
+    "prerequisites": [
+      "Pseudometric spaces and the forward triangle inequality",
+      "Seminormed additive groups and the norm",
+      "Lipschitz maps (LipschitzWith) and the induced continuity",
+      "Real absolute value and sign case analysis"
+    ]
+  },
+  "conclusion": {
+    "summary": "We packaged the reverse triangle inequality family — the reverse (second) inequality, its one-sided and quadrilateral forms, the seminorm version, and the 1-Lipschitz/continuity consequences — into one verified narrative, and added the sharpness layer the parent Mathlib lemmas omit: the reverse inequality is an equality for collinear reals, the quadrilateral bound is attained, and the Lipschitz constant 1 is optimal. All twelve theorems are fully machine-checked with 0 sorries and 0 axioms.",
+    "implications": "The reverse family is the toolkit that makes distance a continuous, perturbation-stable quantity; recording that its bounds are sharp certifies that none of the standard estimates can be tightened. The optimal-constant argument is a reusable template for proving Lipschitz constants best-possible by a two-point test.",
+    "openQuestions": [
+      "Characterise the full equality locus of the reverse inequality |d(x,z) − d(y,z)| = d(x,y) in a general geodesic space (betweenness of the projection of z onto a geodesic through x and y).",
+      "State and prove the n-point telescoping refinement |d(x₀,xₙ) − d(y,xₙ)| ≤ Σ d(xᵢ,xᵢ₊₁) with its own attainment condition."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Imports, expository docstring laying out the reverse-inequality family and flagging the sharpness layer as the new content, and namespace setup."
+    },
+    {
+      "id": "reverse-family",
+      "title": "Part I: The Reverse Triangle Inequality Family",
+      "startLine": 42,
+      "endLine": 60,
+      "summary": "reverse_triangle (abs_dist_sub_le), the one-sided form dist_sub_dist_le, and the quadrilateral strengthening reverse_triangle_quad moving both endpoints.",
+      "mathContext": "$|d(x,z)-d(y,z)| \\le d(x,y)$ and $|d(x,y)-d(x',y')| \\le d(x,x')+d(y,y')$"
+    },
+    {
+      "id": "lipschitz-package",
+      "title": "Part II: The 1-Lipschitz / Continuity Package",
+      "startLine": 61,
+      "endLine": 90,
+      "summary": "dist_lipschitz_right / left (1-Lipschitz in each argument), the induced uniform continuity and continuity, and the seminorm reverse triangle inequality reverse_triangle_norm.",
+      "mathContext": "$\\mathrm{LipschitzWith}\\ 1\\ (d(x,\\cdot))$; $\\big|\\|a\\|-\\|b\\|\\big| \\le \\|a-b\\|$"
+    },
+    {
+      "id": "sharpness",
+      "title": "Part III: Sharpness — the New Content",
+      "startLine": 91,
+      "endLine": 129,
+      "summary": "reverse_triangle_eq_of_between (the reverse inequality is an equality for collinear reals a ≤ b ≤ c), a concrete witness, quadrilateral_sharp, and dist_lipschitz_optimal (the constant 1 is best possible).",
+      "mathContext": "$a \\le b \\le c \\Rightarrow |d(a,c)-d(b,c)| = d(a,b)$; $\\mathrm{LipschitzWith}\\ c\\ (d(x,\\cdot)) \\Rightarrow 1 \\le c$"
+    },
+    {
+      "id": "examples",
+      "title": "Part IV: Worked Real-Line Examples",
+      "startLine": 130,
+      "endLine": 139,
+      "summary": "The reverse inequality in its familiar ||x| − |y|| ≤ |x − y| shape and continuity of the metric on ℝ in each argument.",
+      "mathContext": "$\\big||x|-|y|\\big| \\le |x-y|$"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "extends",
+      "description": "Triangle Inequality (parent: the forward bound)"
+    },
+    {
+      "targetId": "triangle-inequality-oq-05",
+      "relationship": "related",
+      "description": "Equality Case of the Triangle Inequality in Strictly Convex Spaces (forward equality)"
+    },
+    {
+      "targetId": "triangle-inequality-oq-03",
+      "relationship": "related",
+      "description": "Ultrametric Triangle Inequality"
+    }
+  ],
+  "references": [
+    {
+      "text": "Reverse (second) triangle inequality — standard in any metric-space or normed-space text.",
+      "url": "https://en.wikipedia.org/wiki/Triangle_inequality#Reverse_triangle_inequality"
+    },
+    {
+      "text": "Mathlib4: Topology.MetricSpace.Pseudo.Defs (abs_dist_sub_le, dist_dist_dist_le) and Topology.MetricSpace.Lipschitz.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/MetricSpace/Lipschitz.html"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "NNReal (scoped)"
+    ],
+    "namespace": "TriangleInequalityOQ06",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/TriangleInequalityOQ06.lean",
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the open question **triangle-inequality-oq-06** ("The Reverse Triangle Inequality Family and 1-Lipschitz Distance"), a child of the verified `triangle-inequality` gallery entry.

The parent proves the *forward* bound `d(x,z) ≤ d(x,y) + d(y,z)`. This entry collects its **reverse** companions into one coherent verified narrative and adds the genuinely new content: a **sharpness layer** certifying each bound is attained, hence optimal.

## What's proved (12 theorems, `Proofs/TriangleInequalityOQ06.lean`)

**The reverse family** (one-line re-exports of named Mathlib lemmas):
- `reverse_triangle` : `|d(x,z) − d(y,z)| ≤ d(x,y)` (`abs_dist_sub_le`)
- `dist_sub_dist_le` : one-sided form
- `reverse_triangle_quad` : quadrilateral `|d(x,y) − d(x',y')| ≤ d(x,x') + d(y,y')` (`dist_dist_dist_le`)
- `reverse_triangle_norm` : `| ‖a‖ − ‖b‖ | ≤ ‖a − b‖` (`abs_norm_sub_norm_le`)
- `dist_lipschitz_right/left`, `dist_uniformContinuous_right`, `dist_continuous_right` : the metric is 1-Lipschitz, hence uniformly continuous and continuous in each argument

**The sharpness layer (new content the atomic lemmas omit):**
- `reverse_triangle_eq_of_between` : for collinear reals `a ≤ b ≤ c` the reverse inequality is an **equality** `|d(a,c) − d(b,c)| = d(a,b)` — the bound is attained, so it cannot be improved
- `quadrilateral_sharp` : an explicit real configuration attaining the two-endpoint bound
- `dist_lipschitz_optimal` : the Lipschitz constant `1` is **best possible** — testing points `0` and `1` forces any Lipschitz constant `c ≥ 1`

## Verification

- **0 sorries, 0 axioms** — `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` (the ordinary foundational axioms; no `ofReduceBool`/`sorryAx`).
- Builds against Lean `v4.26.0` + Mathlib.
- `status: verified`, `badge: verified`.
- Gallery data (`meta.json`, `annotations.json`, `index.ts`) added; `gallery:check-size` passes; annotations validate with no errors for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)