### PR TITLE
research(area-of-circle-oq-05-oq-03): bridge Gaussian Fourier identity to concrete gaussianReal 0 1 [2 thms, 0 axioms]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ05OQ03.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ03.lean
@@ -140,6 +140,45 @@ theorem integral_gaussian_half :
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════
+PART V:  BRIDGE TO THE CONCRETE MATHLIB GAUSSIAN MEASURE
+═══════════════════════════════════════════════════════════════════════════════
+
+  The identities above are stated for the explicit Lebesgue integrand.  Here we
+  connect them to Mathlib's probability-theoretic standard normal measure
+  `ProbabilityTheory.gaussianReal 0 1` and its characteristic function
+  `MeasureTheory.charFun`.  This makes precise the sense — flagged in the honest
+  scope note below — in which `CentralLimitTheorem.lean`'s axiom
+  `gaussian_fourier_identity` becomes a *theorem* once the abstract `stdGaussian`
+  is instantiated as the concrete `gaussianReal 0 1`. -/
+
+/-- **The characteristic function of the standard normal `N(0,1)` is `e^{-t²/2}`.**
+    Immediate from Mathlib's `charFun_gaussianReal` specialised at `μ = 0`, `v = 1`. -/
+theorem charFun_stdGaussian (t : ℝ) :
+    charFun (ProbabilityTheory.gaussianReal 0 1) t = Complex.exp (-(t : ℂ) ^ 2 / 2) := by
+  rw [ProbabilityTheory.charFun_gaussianReal]
+  congr 1
+  push_cast
+  ring
+
+/-- **The Gaussian Fourier identity against the concrete Mathlib measure.**
+
+      ∫_ℝ e^{i t x} ∂(gaussianReal 0 1) = e^{-t²/2}.
+
+    This is exactly the shape of the `CentralLimitTheorem.lean` axiom
+    `gaussian_fourier_identity`, now discharged as a theorem for the concrete
+    standard-normal measure: the abstract Fourier self-duality of `stdGaussian`
+    holds for `ProbabilityTheory.gaussianReal 0 1`. -/
+theorem gaussianReal_fourier_identity (t : ℝ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * (t : ℂ) * (x : ℂ)) ∂(ProbabilityTheory.gaussianReal 0 1)
+      = Complex.exp (-(t : ℂ) ^ 2 / 2) := by
+  rw [← charFun_stdGaussian t, charFun_apply_real]
+  congr 1
+  ext x
+  congr 1
+  ring
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
 Summary
 ═══════════════════════════════════════════════════════════════════════════════
 
@@ -155,18 +194,25 @@ Summary
   the characteristic function of the standard normal.
 - `gaussian_density_total_mass`: the standard density integrates to 1.
 - `integral_gaussian_half`: ∫ e^{-x²/2} dx = √(2π).
+- `charFun_stdGaussian`: the characteristic function of `gaussianReal 0 1` is e^{-t²/2}.
+- `gaussianReal_fourier_identity`: **∫ e^{itx} ∂(gaussianReal 0 1) = e^{-t²/2}** —
+  the concrete-measure form of the `CentralLimitTheorem.lean` Fourier axiom.
 
 ### Honest scope:
-The Fourier identity is proved here as a concrete Lebesgue integral.  The
-`CentralLimitTheorem.lean` axiom of the same name is phrased against an abstract
-`stdGaussian` measure introduced by `axiom`; discharging *that* axiom additionally
-requires replacing the abstract measure by `ProbabilityTheory.gaussianReal 0 1`,
-a separate bridge not attempted here.
+The Fourier identity is proved here as a concrete Lebesgue integral, and (Part V)
+against Mathlib's concrete standard-normal measure `ProbabilityTheory.gaussianReal 0 1`.
+The `CentralLimitTheorem.lean` axiom of the same name is phrased against an abstract
+`stdGaussian` measure introduced by `axiom`; Part V shows that identity holds as a
+theorem for the concrete `gaussianReal 0 1`, but fully discharging the CLT axiom
+would require refactoring that file to *define* `stdGaussian := gaussianReal 0 1`
+(a separate change not made here).
 -/
 
 #check @gaussian_fourier_real
 #check @gaussian_fourier_normalized
 #check @gaussian_density_total_mass
 #check @integral_gaussian_half
+#check @charFun_stdGaussian
+#check @gaussianReal_fourier_identity
 
 end GaussianFourierTransform

--- a/research/problems/area-of-circle-oq-05-oq-03/knowledge.md
+++ b/research/problems/area-of-circle-oq-05-oq-03/knowledge.md
@@ -1,0 +1,38 @@
+
+## Session 2026-07-01 (researcher-6) — Bridge to concrete Mathlib measure
+
+**Mode**: FRESH (claimed EMPTY-tier; base already complete)
+**Outcome**: progress — 2 new theorems, 0 new axioms, VERIFIED
+
+### Context
+The gallery entry `AreaOfCircleOQ05OQ03.lean` already proved the Gaussian
+Fourier self-duality axiom-free in explicit Lebesgue-integral form
+(∫ e^{itx} e^{-x²/2} dx = e^{-t²/2}·√(2π), normalized companion, etc.). Its
+"honest scope" note flagged one gap: the identity was NOT connected to Mathlib's
+concrete probability measure, and `CentralLimitTheorem.lean` still axiomatizes
+`gaussian_fourier_identity` against an abstract `stdGaussian`.
+
+### What I did
+- Added `charFun_stdGaussian`: `charFun (gaussianReal 0 1) t = exp(-t²/2)`, a
+  direct specialisation of Mathlib's `ProbabilityTheory.charFun_gaussianReal`.
+- Added `gaussianReal_fourier_identity`:
+  `∫ e^{itx} ∂(gaussianReal 0 1) = exp(-t²/2)` — the exact shape of the CLT
+  file's abstract axiom, now a theorem for the concrete standard-normal measure.
+  Proof route: `charFun_apply_real` rewrites `charFun μ t = ∫ exp(t·x·I) ∂μ`,
+  avoiding all inner-product machinery.
+
+### Key findings
+- `charFun_apply_real` (`MeasureTheory`) is the clean hook: it expresses the
+  characteristic function as `∫ exp(t·x·I) ∂μ`, matching our integrand up to
+  commutativity — no `RCLike.inner_apply` needed.
+- Both new theorems depend only on `[propext, Classical.choice, Quot.sound]`
+  (verified via `#print axioms`); 0 `sorryAx`, 0 `ofReduceBool`.
+
+### Files modified
+- `proofs/Proofs/AreaOfCircleOQ05OQ03.lean` (172 → 218 lines, 6 → 8 theorems)
+- `src/data/proofs/area-of-circle-oq-05-oq-03/meta.json` (counts + 2 mainTheorems)
+
+### Next steps
+- Optional CLT cleanup: define `stdGaussian := gaussianReal 0 1` and replace the
+  `gaussian_fourier_identity` axiom with `gaussianReal_fourier_identity`,
+  removing one axiom from `CentralLimitTheorem.lean`.

--- a/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
@@ -23,20 +23,6 @@
     "mathlibDependencies": [
       {
         "theorem": "GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I",
-        "description": "∫ e^{-b x² + (real linear)·x} dx in closed form (vertical-strip shift of the complex Gaussian integral). The engine behind gaussian_fourier_real — the self-Fourier identity of the Gaussian is obtained by completing the square and applying this Mathlib theorem.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.FourierTransform"
-      },
-      {
-        "theorem": "MeasureTheory.integral_mul_const / MeasureTheory.integral_div",
-        "description": "Pull the constant e^{-t²/2} factor and the normalizing 1/√(2π) out of the Lebesgue integral to pass from the un-normalized to the normalized Fourier identity.",
-        "module": "Mathlib.MeasureTheory.Integral.Bochner"
-      }
-    ],
-    "assumptions": "0 axioms, 0 sorries. Builds on Mathlib's Gaussian Fourier transform infrastructure (GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I — the vertical-strip shift of the real Gaussian integral). HONEST SCOPE: CentralLimitTheorem.lean states its gaussian_fourier_identity against an abstract stdGaussian measure introduced by `axiom`; this file proves the full mathematical content as a concrete Lebesgue integral, but discharging that particular CLT axiom additionally requires replacing the abstract measure by ProbabilityTheory.gaussianReal 0 1, a separate bridge not attempted here.",
-    "mathlib_version": "4.26.0",
-    "mathlibDependencies": [
-      {
-        "theorem": "GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I",
         "description": "Core analytic engine: evaluates the vertical-strip-shifted Gaussian contour integral ∫ e^{-b(x+c·i)²} dx = (π/b)^{1/2} (Cauchy vertical-strip argument). Specialised at b=1/2, c=-t this is the √(2π) value behind the Fourier self-duality; the file's own work is completing the square to reduce e^{itx}·e^{-x²/2} to this form.",
         "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.FourierTransform"
       },
@@ -51,6 +37,8 @@
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Complex"
       }
     ],
+    "assumptions": "0 axioms, 0 sorries. Builds on Mathlib's Gaussian Fourier transform infrastructure (GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I — the vertical-strip shift of the real Gaussian integral). HONEST SCOPE: CentralLimitTheorem.lean states its gaussian_fourier_identity against an abstract stdGaussian measure introduced by `axiom`; this file proves the full mathematical content as a concrete Lebesgue integral, but discharging that particular CLT axiom additionally requires replacing the abstract measure by ProbabilityTheory.gaussianReal 0 1, a separate bridge not attempted here.",
+    "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-21",
     "theoremCount": 6,
     "definitionCount": 0
@@ -146,9 +134,9 @@
       "MeasureTheory"
     ],
     "namespace": "GaussianFourierTransform",
-    "lineCount": 172,
+    "lineCount": 218,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0,
     "mainTheorems": [
       {
@@ -174,6 +162,18 @@
         "type": "supporting",
         "description": "The t = 0 shadow: ∫ e^{-x²/2} dx = √(2π).",
         "leanType": "∫ x : ℝ, Complex.exp (-(x : ℂ) ^ 2 / 2) = ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+      },
+      {
+        "name": "charFun_stdGaussian",
+        "type": "supporting",
+        "description": "The characteristic function of the standard normal measure gaussianReal 0 1 is e^{-t²/2}, via Mathlib charFun_gaussianReal.",
+        "leanType": "(t : ℝ) → charFun (ProbabilityTheory.gaussianReal 0 1) t = Complex.exp (-(t : ℂ) ^ 2 / 2)"
+      },
+      {
+        "name": "gaussianReal_fourier_identity",
+        "type": "core",
+        "description": "The Gaussian Fourier identity against the concrete Mathlib measure: ∫ e^{itx} ∂(gaussianReal 0 1) = e^{-t²/2}. Concrete-measure form of CentralLimitTheorem.lean's abstract axiom gaussian_fourier_identity.",
+        "leanType": "(t : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) ∂(ProbabilityTheory.gaussianReal 0 1) = Complex.exp (-(t : ℂ) ^ 2 / 2)"
       }
     ],
     "path": "Proofs/AreaOfCircleOQ05OQ03.lean",

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "area-of-circle-oq-05-oq-03",
   "title": "Fourier Transform of Gaussian in Lean 4 via Mathlib",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-04-05T22:13:23.854Z",
     "iteration": 1,
     "focus": "Prove the Gaussian Fourier transform identity:",
@@ -30,11 +30,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: Gaussian Fourier self-duality proved axiom-free (Lebesgue form) AND bridged to Mathlib's concrete standard-normal measure gaussianReal 0 1.",
+    "builtItems": [
+      "charFun_stdGaussian in Proofs/AreaOfCircleOQ05OQ03.lean:156 — charFun(gaussianReal 0 1) t = exp(-t²/2)",
+      "gaussianReal_fourier_identity in Proofs/AreaOfCircleOQ05OQ03.lean:171 — ∫ e^{itx} ∂(gaussianReal 0 1) = exp(-t²/2)"
+    ],
+    "insights": [
+      "Mathlib's charFun_gaussianReal (ProbabilityTheory) gives charFun(gaussianReal 0 1) t = exp(-t²/2) directly; combined with charFun_apply_real it yields ∫ e^{itx} ∂(gaussianReal 0 1) = exp(-t²/2) with no inner-product manipulation.",
+      "The CentralLimitTheorem.lean axiom gaussian_fourier_identity is unavoidable only because stdGaussian is an abstract axiom measure; it becomes a theorem the moment stdGaussian is instantiated as gaussianReal 0 1 (shown by gaussianReal_fourier_identity)."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Optional: refactor CentralLimitTheorem.lean to define stdGaussian := ProbabilityTheory.gaussianReal 0 1 and replace the gaussian_fourier_identity axiom with gaussianReal_fourier_identity (removes one axiom from the CLT file)."
+    ]
   },
   "tags": [
     "analysis",


### PR DESCRIPTION
## Summary

The gallery entry `AreaOfCircleOQ05OQ03.lean` ("The Gaussian is its own Fourier Transform") already proved the Gaussian Fourier self-duality **axiom-free** in explicit Lebesgue-integral form. Its "honest scope" note flagged one gap: the identity was never connected to Mathlib's concrete probability measure, and `CentralLimitTheorem.lean` still axiomatizes `gaussian_fourier_identity` against an *abstract* `stdGaussian`.

This PR adds **Part V**, closing that documented gap:

- **`charFun_stdGaussian`** — `charFun (ProbabilityTheory.gaussianReal 0 1) t = exp(-t²/2)`, a direct specialisation of Mathlib's `charFun_gaussianReal` at `μ = 0, v = 1`.
- **`gaussianReal_fourier_identity`** — `∫ e^{itx} ∂(gaussianReal 0 1) = exp(-t²/2)`. This is exactly the shape of the CLT file's abstract axiom `gaussian_fourier_identity`, now discharged as a **theorem** for the concrete standard-normal measure.

Proof route uses `MeasureTheory.charFun_apply_real` (`charFun μ t = ∫ exp(t·x·I) ∂μ`), matching the integrand up to commutativity — no inner-product manipulation needed.

## Verification

- `lake env lean` on the file: **exit 0**, 0 `sorry`, 0 `axiom` declarations, no errors/warnings.
- `#print axioms` on both new theorems: depend only on `[propext, Classical.choice, Quot.sound]` — 0 `sorryAx`, 0 `ofReduceBool`. **VERIFIED / 0 new axioms.**
- Lean file: 172 → 218 lines, 6 → 8 theorems. `meta.json` updated (`theoremCount`, `lineCount`, +2 `mainTheorems`).

## Honest scope

The concrete-measure identity holds as a theorem here, but *fully* discharging the CLT axiom would require refactoring `CentralLimitTheorem.lean` to define `stdGaussian := gaussianReal 0 1` — a separate change not made in this PR (recorded as a next step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)