### PR TITLE
Enrich Erdős #11 kernel-reducible squarefree test (oq-02)

### DIFF
--- a/src/data/proofs/erdos-11-wip-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-11-wip-01-oq-02/meta.json
@@ -64,6 +64,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Roadmap and Imports",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "The doc-comment states Erdős #11 (open), recalls why the parent Erdos11WIP01 needed hand-supplied witnesses (Squarefree's Decidable instance routes through Nat.minSqFac, which the kernel does not reduce), and lays out the four contributions that remove that obstruction. Then imports the parent, opens the Erdos11WIP01 namespace and Finset, and reaches the docstring of the SquarefreeCheck definition.",
+      "mathContext": "Erdős #11: every odd $n>1$ is $m+2^k$ with $m$ squarefree — open; this file verifies all odd $1<n<100$ at 0 axioms via a kernel-reducible test."
+    },
+    {
       "id": "check",
       "title": "The Kernel-Reducible Squarefree Test",
       "startLine": 47,


### PR DESCRIPTION
Enrichment pass for `erdos-11-wip-01-oq-02`.

## Change
- **Completed section coverage**: added a 'Roadmap and Imports' section for lines 1–46 (doc-comment roadmap + imports/namespace setup). Previously the `sections` array started at line 47, leaving the file header uncovered; sections now span the full 117-line Lean file.

## Already rich (left in place)
- 4 annotations with mathContext/significance/relatedConcepts/prerequisites covering all 117 lines, 4 keyInsights, complete overview, conclusion, 3 crossReferences, 2 references.

## Guardrails
- meta.json 13.6 KB — well under the 60 KB cap; all collection caps respected. `status: verified`, `axiomCount: 0` accurately reflect the 0-axiom kernel-`decide` Lean source (no `native_decide`).