### PR TITLE
Enrich British Flag even-moment (OQ-01-02-02): sections[], annotation tags, fix 3 ranges

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-02/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-bfem010202-header",
     "proofId": "british-flag-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 1, "endLine": 90 },
+    "range": {
+      "startLine": 1,
+      "endLine": 90
+    },
     "type": "concept",
     "title": "Module Overview: The Arbitrary Even Moment, Uniformly in m",
     "content": "The British Flag Theorem's alternating vertex sum is generalized here to the 2m-th power distance for every m at once. For a parallelepiped with base c and edge vectors u : Fin n → V, the vertex indexed by t ⊆ {0,…,n−1} is pVertex c u t = c + ∑_{i∈t} uᵢ, and the 2m-th moment defect is defectPow X c u m = ∑_t (−1)^{|t|}·‖X − vertex t‖^{2m}. The headline even_moment_defect_eq_zero proves this vanishes whenever 2m < n. Two gallery cases — the parent parallelepiped (m = 1, n ≥ 3) and the fourth-moment sibling (m = 2, n ≥ 5) — fall out as corollaries. The section opens with alt_sum_zero_of_inter, a repackaging of the parent's finite-difference lemma: if g(t) depends on t only through t ∩ A for a proper subset A ≠ univ, then ∑_t (−1)^{|t|}·g(t) = 0 (choose a coordinate k ∉ A; inserting k never changes t ∩ A, so g is invariant and the parent's alt_sum_eq_zero_of_indep applies).",
@@ -18,12 +21,21 @@
     "prerequisites": [
       "The parent parallelepiped defect (Proofs.BritishFlagParallelepipedOQ010201)",
       "Signed powerset sums as iterated finite differences"
+    ],
+    "tags": [
+      "concept",
+      "british-flag-theorem",
+      "finite-differences",
+      "overview"
     ]
   },
   {
     "id": "ann-bfem010202-model",
     "proofId": "british-flag-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 92, "endLine": 136 },
+    "range": {
+      "startLine": 90,
+      "endLine": 136
+    },
     "type": "technique",
     "title": "The Optional-Coordinate Model of the Displacement",
     "content": "The crux that makes the arbitrary moment tractable: write the displacement X − vertex t as a single weighted sum ∑_{a : Option (Fin n)} indᵗ(a) • e(a) over optional coordinates, where e(none) = X − c, e(some i) = −uᵢ (def evec), and indᵗ(none) = 1, indᵗ(some i) = [i ∈ t] (def ind). Then displacement_eq_sum verifies this identity, and sqDist_eq_sum expands ‖X − vertex t‖² = ⟪·,·⟫ by bilinearity into a single sum over pairs p : Option(Fin n)² of term X c u t p = indᵗ(p.1)·indᵗ(p.2)·⟪e p.1, e p.2⟫. All t-dependence now lives in the two indicator factors; the inner product ⟪e p.1, e p.2⟫ is a fixed coefficient.",
@@ -38,12 +50,21 @@
     "prerequisites": [
       "real_inner_self_eq_norm_sq and inner-product bilinearity over Finset sums",
       "Fintype.sum_option and Fintype.sum_prod_type"
+    ],
+    "tags": [
+      "technique",
+      "bilinearity",
+      "indicator-functions",
+      "augmented-index"
     ]
   },
   {
     "id": "ann-bfem010202-touched",
     "proofId": "british-flag-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 138, "endLine": 165 },
+    "range": {
+      "startLine": 136,
+      "endLine": 165
+    },
     "type": "insight",
     "title": "The Degree-vs-Dimension Count: a Multi-Index Touches ≤ 2m Coordinates",
     "content": "Raising ‖·‖^{2m} = (‖·‖²)^m via Fintype.sum_pow turns it into a sum over multi-indices π : Fin m → Option(Fin n)² of products ∏_j term X c u t (π j). The set of coordinates such a product constrains is touched π = univ.biUnion (fun j => (π j).1.toFinset ∪ (π j).2.toFinset). card_touched_le bounds |touched π| ≤ 2m (each of the m factors contributes at most two coordinates, via card_biUnion_le and card_union_le). Hence touched_ne_univ: when 2m < n, touched π ≠ univ — some coordinate is always free.",
@@ -58,12 +79,21 @@
     "prerequisites": [
       "Fintype.sum_pow: (∑ a, f a)^m = ∑ π : Fin m → ι, ∏ i, f (π i)",
       "Finset.card_biUnion_le and Finset.card_union_le"
+    ],
+    "tags": [
+      "insight",
+      "multi-index",
+      "dimension-threshold",
+      "key-result"
     ]
   },
   {
     "id": "ann-bfem010202-factor",
     "proofId": "british-flag-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 167, "endLine": 190 },
+    "range": {
+      "startLine": 167,
+      "endLine": 190
+    },
     "type": "technique",
     "title": "Each Product Factors Through t ∩ touched π",
     "content": "ind_inter shows an indicator weight indᵗ(a) equals ind_{t∩A}(a) once a's coordinate lies in A. term_inter lifts this to a whole term factor: term X c u t (π j) = term X c u (t ∩ touched π) (π j), because each factor's coordinate pair sits inside touched π (Finset.subset_biUnion_of_mem, then subset_union_left/right). Consequently the product ∏_j term X c u t (π j) depends on t only through t ∩ touched π.",
@@ -77,12 +107,20 @@
     "prerequisites": [
       "Finset.subset_biUnion_of_mem",
       "Finset.inter and membership indicators"
+    ],
+    "tags": [
+      "technique",
+      "restriction",
+      "indicator-invariance"
     ]
   },
   {
     "id": "ann-bfem010202-main",
     "proofId": "british-flag-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 192, "endLine": 212 },
+    "range": {
+      "startLine": 203,
+      "endLine": 212
+    },
     "type": "theorem",
     "title": "Main Theorem: Every Even Moment Vanishes for 2m < n",
     "content": "even_moment_defect_eq_zero assembles the pieces. Expand each ‖X − vertex t‖^{2m} = (sqDist)^m as a sum over multi-indices π (hexp, via sqDist_eq_sum and Fintype.sum_pow). Swap the powerset sum and the multi-index sum (Finset.sum_comm). For each fixed π, the summand ∏_j term X c u t (π j) factors through t ∩ touched π (term_inter) with touched π a proper subset (touched_ne_univ, using 2m < n), so alt_sum_zero_of_inter forces its signed powerset sum to 0. Summing over π gives defectPow X c u m = 0.",
@@ -96,12 +134,21 @@
     "prerequisites": [
       "sqDist_eq_sum, Fintype.sum_pow, Finset.sum_comm",
       "alt_sum_zero_of_inter and touched_ne_univ"
+    ],
+    "tags": [
+      "theorem",
+      "main-result",
+      "finite-differences",
+      "key-result"
     ]
   },
   {
     "id": "ann-bfem010202-corollaries",
     "proofId": "british-flag-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 214, "endLine": 242 },
+    "range": {
+      "startLine": 214,
+      "endLine": 242
+    },
     "type": "theorem",
     "title": "Corollaries: Recovering the n ≥ 3 and n ≥ 5 Gallery Thresholds",
     "content": "defectPow_eq rewrites the internal defectPow (built on sqDist^m) into the informal ‖X − vertex t‖^{2m} form via pow_mul. second_moment_zero (m = 1, n ≥ 3) reproduces the parent parallelepiped defect identity, and fourth_moment_zero (m = 2, n ≥ 5) reproduces the fourth-moment sibling — each is a one-line instantiation of even_moment_defect_eq_zero. This concretely exhibits the single uniform theorem subsuming both prior gallery entries.",
@@ -115,6 +162,11 @@
     "prerequisites": [
       "pow_mul and the definition of sqDist",
       "The parent (n ≥ 3) and sibling (n ≥ 5) entries"
+    ],
+    "tags": [
+      "theorem",
+      "corollary",
+      "sharp-threshold"
     ]
   }
 ]

--- a/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-02/meta.json
@@ -113,6 +113,56 @@
       "The parent parallelepiped defect entry (Proofs.BritishFlagParallelepipedOQ010201) and its finite-difference lemma"
     ]
   },
+  "sections": [
+    {
+      "id": "vanishing-principle",
+      "title": "The Abstract Vanishing Principle",
+      "startLine": 67,
+      "endLine": 86,
+      "summary": "alt_sum_zero_of_inter: if g(t) depends on t only through t ∩ A for a proper subset A ≠ univ, then the signed powerset sum ∑_t (−1)^{|t|}·g(t) = 0. Repackages the parent's finite-difference lemma by choosing a free coordinate k ∉ A on which g is invariant.",
+      "mathContext": "The alternating powerset operator g ↦ ∑_t (−1)^{|t|}·g(t) is the n-fold iterated finite difference on the Boolean cube; it annihilates any function that ignores at least one coordinate."
+    },
+    {
+      "id": "displacement-model",
+      "title": "The Optional-Coordinate Model of the Displacement",
+      "startLine": 87,
+      "endLine": 132,
+      "summary": "The definitions evec (e(none)=X−c, e(some i)=−uᵢ), ind (indicator with ind(none)=1), and term, then displacement_eq_sum (X − vertex t = ∑_a indᵗ(a)•e(a)) and sqDist_eq_sum expanding ‖X − vertex t‖² by bilinearity into a single sum over coordinate pairs, with all t-dependence confined to the indicator factors.",
+      "mathContext": "Encoding the base point as an extra coordinate `none` unifies the constant, linear, and quadratic pieces of the squared distance into one indexed sum, so ‖·‖^{2m} becomes a single Fintype.sum_pow."
+    },
+    {
+      "id": "touched-count",
+      "title": "The Degree-vs-Dimension Count",
+      "startLine": 133,
+      "endLine": 161,
+      "summary": "touched π (the coordinates a multi-index constrains), card_touched_le (|touched π| ≤ 2m, each of the m factors contributing ≤ 2 coordinates), and touched_ne_univ (when 2m < n, touched π is a proper subset — some coordinate is always free).",
+      "mathContext": "The exact analogue of 'an order-n finite difference kills degree < n': a length-m multi-index has degree ≤ 2m in the indicators, so it omits a coordinate precisely when n > 2m, giving the sharp threshold n ≥ 2m+1."
+    },
+    {
+      "id": "factor-through-touched",
+      "title": "Each Product Factors Through t ∩ touched π",
+      "startLine": 162,
+      "endLine": 187,
+      "summary": "ind_inter (an indicator weight is unchanged by restricting to a superset of its coordinate) and term_inter (a whole term factors through t ∩ touched π), so the product ∏_j term X c u t (π j) depends on t only through t ∩ touched π.",
+      "mathContext": "Supplies exactly the hypothesis alt_sum_zero_of_inter requires: the summand for a fixed multi-index is a function of t ∩ (a proper subset)."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: Every Even Moment Vanishes for 2m < n",
+      "startLine": 188,
+      "endLine": 217,
+      "summary": "defectPow and even_moment_defect_eq_zero: expand each ‖X − vertex t‖^{2m} over multi-indices (sqDist_eq_sum + Fintype.sum_pow), swap the powerset and multi-index sums (Finset.sum_comm), and for each π apply term_inter + touched_ne_univ + alt_sum_zero_of_inter to kill its signed powerset sum; summing over π gives defectPow = 0.",
+      "mathContext": "The whole moment family collapses to one statement: the 2m-th power distance is a degree-2m function on the cube, and the n-fold finite difference annihilates it whenever 2m < n — no orthogonality, no edge-vector constraints, no restriction on X."
+    },
+    {
+      "id": "corollaries",
+      "title": "Consistency Corollaries: the n ≥ 3 and n ≥ 5 Thresholds",
+      "startLine": 218,
+      "endLine": 246,
+      "summary": "defectPow_eq (rewriting sqDist^m into ‖·‖^{2m} via pow_mul), second_moment_zero (m=1, n≥3, recovering the parent parallelepiped defect) and fourth_moment_zero (m=2, n≥5, recovering the fourth-moment sibling) — each a one-line instantiation of the main theorem.",
+      "mathContext": "n ≥ 2m+1 is sharp: m=1 gives n≥3 and m=2 gives n≥5, exactly matching the independently proved thresholds of the parent and sibling entries."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "british-flag-theorem-oq-01-oq-02",


### PR DESCRIPTION
## Enrichment pass — british-flag-theorem-oq-01-oq-02-oq-02

**Every Even-Moment British Flag Defect Vanishes Below the Dimension.**

A rich entry (6 annotations, 18.9KB meta) that nonetheless had concrete gaps:

### Change
- **`sections[]` array added** (meta.json previously had none — an explicit enricher target). Six sections aligned to the file's `/-! ###` headers: vanishing principle, displacement model, touched-count, factor-through-touched, main theorem, corollaries — each with `summary` + `mathContext`.
- **`tags[]` added** to all 6 annotations (gallery-standard field previously absent).
- **Fixed 3 pre-existing annotation range mismatches** so annotations attach to real Lean constructs on the live site:
  - `model` 92→90 (`def evec`)
  - `touched` 138→136 (`def touched`)
  - `main` 192→203 (`theorem even_moment_defect_eq_zero`; was landing on `def defectPow`)

### Verification
- `annotations/build.ts`: entry now builds with **0 errors** (was 3)
- `gallery/check-meta-size.ts`: within caps
- Only the entry's `annotations.json` and `meta.json` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)