### PR TITLE
research(amgm-inequality-oq-05-oq-02-oq-01): classical AM-GM inequality + equality case over Fin n [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ05OQ02OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ05OQ02OQ01.lean
@@ -1,0 +1,164 @@
+/-
+  The classical (unweighted) AM-GM inequality and its equality case, over `Fin n`.
+
+  The parent entry `amgm-inequality-oq-05-oq-02` established the **weighted**
+  AM-GM *equality case* for an arbitrary finite index set: for strictly positive
+  weights `w` summing to `1` and strictly positive `x`,
+
+      ∏ i, (x i) ^ (w i)  =  ∑ i, w i * x i    ↔    all the `xⱼ` are equal.
+
+  Its first stated open question was to specialise this to **equal weights**
+  `wᵢ = 1/n` and read off the classical statement that everyone knows as
+  "AM-GM": the geometric mean of `n` positive reals is at most their arithmetic
+  mean, with equality iff the numbers are all equal.  That is exactly what this
+  file does, in the canonical form indexed over `Fin n`:
+
+      geometric mean  G = (∏ i, x i) ^ (1/n),      arithmetic mean  A = (∑ i, x i) / n,
+
+      G ≤ A            (`classical_amgm_le`),
+      G = A  ↔  all `xᵢ` equal   (`classical_amgm_eq_iff`).
+
+  The inequality direction is a direct specialisation of Mathlib's
+  `Real.geom_mean_le_arith_mean` (weights `≡ 1`).  The equality characterisation
+  is *not* in Mathlib; we obtain it from the strict concavity of `Real.log`
+  (`strictConcaveOn_log_Ioi`) via the equality case of Jensen's inequality
+  `StrictConcaveOn.map_sum_eq_iff`, exactly as the parent did, then convert the
+  weighted geometric mean `∏ (x i) ^ (1/n)` into `(∏ x i) ^ (1/n)` with
+  `Real.finset_prod_rpow`.
+
+  All exponents are real, so `^` denotes `Real.rpow` throughout.
+
+  Verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+
+open Real Finset
+
+namespace AmgmInequalityOQ05OQ02OQ01
+
+variable {ι : Type*}
+
+/-! ### Reusable engine: the weighted equality case (self-contained)
+
+These three helpers plus `weighted_amgm_eq_iff_pairwise` reproduce, in
+self-contained form, the weighted AM-GM equality case that the parent entry
+proved.  We keep them `private`: the point of this entry is the *classical*
+`Fin n` specialisation below, for which they are merely scaffolding. -/
+
+/-- Taking logs turns the weighted geometric mean into the weighted sum of
+logarithms: `log (∏ xᵢ ^ wᵢ) = ∑ wᵢ · log xᵢ`. -/
+private theorem log_prod_rpow {t : Finset ι} {w x : ι → ℝ} (hx : ∀ i ∈ t, 0 < x i) :
+    Real.log (∏ i ∈ t, x i ^ w i) = ∑ i ∈ t, w i * Real.log (x i) := by
+  rw [Real.log_prod (fun i hi => (Real.rpow_pos_of_pos (hx i hi) (w i)).ne')]
+  refine Finset.sum_congr rfl ?_
+  intro i hi
+  rw [Real.log_rpow (hx i hi)]
+
+/-- The weighted geometric mean of positive reals is positive. -/
+private theorem prod_rpow_pos {t : Finset ι} {w x : ι → ℝ} (hx : ∀ i ∈ t, 0 < x i) :
+    0 < ∏ i ∈ t, x i ^ w i :=
+  Finset.prod_pos (fun i hi => Real.rpow_pos_of_pos (hx i hi) (w i))
+
+/-- The weighted arithmetic mean of positive reals with positive weights, over a
+nonempty index set, is positive. -/
+private theorem mean_pos {t : Finset ι} {w x : ι → ℝ} (hw : ∀ i ∈ t, 0 < w i)
+    (hx : ∀ i ∈ t, 0 < x i) (hne : t.Nonempty) :
+    0 < ∑ i ∈ t, w i * x i :=
+  Finset.sum_pos (fun i hi => mul_pos (hw i hi) (hx i hi)) hne
+
+/-- **Weighted AM-GM equality case (pairwise form).**  Equality between the
+weighted geometric and arithmetic means holds iff all the `xⱼ` are equal. -/
+private theorem weighted_amgm_eq_iff_pairwise {t : Finset ι} {w x : ι → ℝ}
+    (hw : ∀ i ∈ t, 0 < w i) (hsum : ∑ i ∈ t, w i = 1) (hx : ∀ i ∈ t, 0 < x i) :
+    (∏ i ∈ t, x i ^ w i = ∑ i ∈ t, w i * x i) ↔
+      (∀ i ∈ t, ∀ j ∈ t, x i = x j) := by
+  have hne : t.Nonempty := by
+    rw [Finset.nonempty_iff_ne_empty]
+    rintro rfl
+    simp at hsum
+  have hA : 0 < ∑ i ∈ t, w i * x i := mean_pos hw hx hne
+  have hP : 0 < ∏ i ∈ t, x i ^ w i := prod_rpow_pos hx
+  -- Equality of the two positive means is equality of their logs.
+  rw [← Real.log_injOn_pos.eq_iff (Set.mem_Ioi.mpr hP) (Set.mem_Ioi.mpr hA),
+      log_prod_rpow hx, eq_comm]
+  -- The strict concavity of `log` supplies the equality case of Jensen.
+  have key := strictConcaveOn_log_Ioi.map_sum_eq_iff (t := t) (w := w) (p := x)
+      hw hsum (fun i hi => Set.mem_Ioi.mpr (hx i hi))
+  simp only [smul_eq_mul] at key
+  rw [key]
+  -- `∀ j, x j = mean` is equivalent to `∀ i j, x i = x j`.
+  constructor
+  · intro h i hi j hj; rw [h i hi, h j hj]
+  · intro h j hj
+    have hconst : ∑ i ∈ t, w i * x i = ∑ i ∈ t, w i * x j := by
+      refine Finset.sum_congr rfl (fun i hi => ?_)
+      rw [h i hi j hj]
+    rw [hconst, ← Finset.sum_mul, hsum, one_mul]
+
+/-! ### The classical `Fin n` statement -/
+
+variable {n : ℕ}
+
+/-- The `n` equal weights `1/n` sum to `1` over `Fin n`. -/
+private theorem sum_inv_card (hn : 0 < n) :
+    ∑ _i : Fin n, (n : ℝ)⁻¹ = 1 := by
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul,
+    mul_inv_cancel₀ (by exact_mod_cast hn.ne')]
+
+/-- **Classical AM-GM inequality** for `n` nonnegative reals: the geometric mean
+`(∏ xᵢ)^{1/n}` is at most the arithmetic mean `(∑ xᵢ)/n`.
+
+This is `Real.geom_mean_le_arith_mean` specialised to the uniform weights `1`. -/
+theorem classical_amgm_le (hn : 0 < n) {x : Fin n → ℝ} (hx : ∀ i, 0 ≤ x i) :
+    (∏ i, x i) ^ (n : ℝ)⁻¹ ≤ (∑ i, x i) / n := by
+  have hcard : ∑ _i : Fin n, (1 : ℝ) = (n : ℝ) := by
+    rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul, mul_one]
+  have key := Real.geom_mean_le_arith_mean (Finset.univ : Finset (Fin n))
+      (fun _ => (1 : ℝ)) x (fun _ _ => zero_le_one)
+      (by rw [hcard]; exact_mod_cast hn) (fun i _ => hx i)
+  simpa only [Real.rpow_one, one_mul, hcard] using key
+
+/-- **Classical AM-GM equality case** for `n` strictly positive reals: the
+geometric mean `(∏ xᵢ)^{1/n}` equals the arithmetic mean `(∑ xᵢ)/n` **iff all
+the `xᵢ` are equal**.
+
+This is the unweighted specialisation (weights `1/n`) of the parent entry's
+weighted equality case, repackaged into the canonical geometric-mean form via
+`Real.finset_prod_rpow`. -/
+theorem classical_amgm_eq_iff (hn : 0 < n) {x : Fin n → ℝ} (hx : ∀ i, 0 < x i) :
+    (∏ i, x i) ^ (n : ℝ)⁻¹ = (∑ i, x i) / n ↔ ∀ i j, x i = x j := by
+  have hw : ∀ i ∈ (Finset.univ : Finset (Fin n)), 0 < (n : ℝ)⁻¹ :=
+    fun _ _ => by positivity
+  have hsum : ∑ i ∈ (Finset.univ : Finset (Fin n)), (n : ℝ)⁻¹ = 1 := sum_inv_card hn
+  have hxpos : ∀ i ∈ (Finset.univ : Finset (Fin n)), 0 < x i := fun i _ => hx i
+  have base := weighted_amgm_eq_iff_pairwise (w := fun _ => (n : ℝ)⁻¹) (x := x)
+      hw hsum hxpos
+  -- Convert `∏ (x i)^{1/n}` into `(∏ x i)^{1/n}`.
+  have hprod : ∏ i ∈ (Finset.univ : Finset (Fin n)), x i ^ (n : ℝ)⁻¹
+      = (∏ i, x i) ^ (n : ℝ)⁻¹ :=
+    Real.finset_prod_rpow Finset.univ x (fun i _ => (hx i).le) _
+  -- Convert `∑ (1/n) * x i` into `(∑ x i)/n`.
+  have hmean : ∑ i ∈ (Finset.univ : Finset (Fin n)), (n : ℝ)⁻¹ * x i
+      = (∑ i, x i) / n := by
+    rw [← Finset.mul_sum, div_eq_mul_inv, mul_comm]
+  rw [hprod, hmean] at base
+  simpa using base
+
+/-- The trivial direction, recorded explicitly: if all `xᵢ` are equal then the
+geometric and arithmetic means coincide. -/
+theorem classical_amgm_eq_of_const (hn : 0 < n) {x : Fin n → ℝ} {c : ℝ}
+    (hx : ∀ i, 0 < x i) (hc : ∀ i, x i = c) :
+    (∏ i, x i) ^ (n : ℝ)⁻¹ = (∑ i, x i) / n :=
+  (classical_amgm_eq_iff hn hx).mpr (fun i j => (hc i).trans (hc j).symm)
+
+/-- **Strict classical AM-GM**: if the `xᵢ` are not all equal, the geometric mean
+is *strictly* below the arithmetic mean. -/
+theorem classical_amgm_lt_of_not_const (hn : 0 < n) {x : Fin n → ℝ}
+    (hx : ∀ i, 0 < x i) (hne : ∃ i j, x i ≠ x j) :
+    (∏ i, x i) ^ (n : ℝ)⁻¹ < (∑ i, x i) / n := by
+  refine lt_of_le_of_ne (classical_amgm_le hn (fun i => (hx i).le)) ?_
+  intro hEq
+  obtain ⟨i, j, hij⟩ := hne
+  exact hij ((classical_amgm_eq_iff hn hx).mp hEq i j)
+
+end AmgmInequalityOQ05OQ02OQ01

--- a/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2024-2026 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+
+/-
+# Generalized Euler constant for an arbitrary antitone summand (OQ-01 · OQ-02 · OQ-02)
+
+The parent file (`AntitoneIntegralSumComparisonOQ01OQ02`) specialized the antitone
+integral test to `f x = 1/x` and identified the limit of the harmonic defect
+`Hₙ − log(n+1)` with Mathlib's Euler–Mascheroni constant `γ`.  That answered the
+convergence question *for the single function `1/x`*.
+
+This file lifts the phenomenon to **every** antitone, nonnegative summand.  For such an
+`f` on `[1, ∞)` define the **defect sequence**
+
+  `D f n := (∑_{i<n} f(1+i)) − ∫₁^{1+n} f`.
+
+The two-sided integral-test sandwich (Mathlib's `AntitoneOn.integral_le_sum` and
+`AntitoneOn.sum_le_integral`) forces `D f` to be **monotone non-decreasing** and bounded
+above by `f 1`, hence convergent.  Its limit
+
+  `generalizedEuler f := ⨆ n, D f n`
+
+is the *generalized Euler constant* of `f`: for `f = 1/x` it is the classical `γ`, and the
+construction requires nothing beyond `f` being antitone and nonnegative — divergence of
+`∑ f` is exactly what makes the constant a nontrivial invariant rather than a shifted tail.
+
+## Main results
+
+* `defect_nonneg`   : `0 ≤ D f n` (the upper Riemann sum dominates the integral).
+* `defect_le`       : `D f n ≤ f 1` (a uniform bound, via a telescoping lower Riemann sum).
+* `defect_monotone` : `Monotone (D f)` (each step adds `f(1+n) − ∫` of a unit cell `≥ 0`).
+* `tendsto_defect`  : `D f → generalizedEuler f`, the bounded-monotone limit.
+* `generalizedEuler_mem_Icc` : `generalizedEuler f ∈ [0, f 1]`.
+
+Everything reduces to the Mathlib sum/integral comparison library; the file is `sorry`-free
+and uses only standard foundational axioms.
+-/
+
+namespace AntitoneIntegralSumComparisonOQ01OQ02OQ02
+
+open Finset Filter Topology MeasureTheory intervalIntegral
+
+variable {f : ℝ → ℝ}
+
+/-- The **generalized Euler defect**: the excess of the right-open Riemann sum
+`∑_{i<n} f(1+i)` over the integral `∫₁^{1+n} f`. -/
+noncomputable def defect (f : ℝ → ℝ) (n : ℕ) : ℝ :=
+  (∑ i ∈ Finset.range n, f (1 + (i : ℝ))) - ∫ x in (1 : ℝ)..(1 + (n : ℝ)), f x
+
+@[simp] theorem defect_zero : defect f 0 = 0 := by
+  simp [defect]
+
+/-- An antitone function on `[1, ∞)` is interval-integrable on any subinterval `[a, b]`
+with `1 ≤ a ≤ b`. -/
+theorem intervalIntegrable_of_antitone (hmono : AntitoneOn f (Set.Ici 1)) {a b : ℝ}
+    (ha : (1 : ℝ) ≤ a) (hb : a ≤ b) : IntervalIntegrable f MeasureTheory.volume a b := by
+  apply AntitoneOn.intervalIntegrable
+  rw [Set.uIcc_of_le hb]
+  exact hmono.mono (fun x hx => le_trans ha hx.1)
+
+/-- Restriction of the antitone hypothesis to the finite window `[1, 1+n]`. -/
+private theorem antitone_window (hmono : AntitoneOn f (Set.Ici 1)) (n : ℕ) :
+    AntitoneOn f (Set.Icc (1 : ℝ) (1 + (n : ℝ))) :=
+  hmono.mono Set.Icc_subset_Ici_self
+
+/-- **The defect is nonnegative.**  The upper Riemann sum `∑_{i<n} f(1+i)` dominates the
+integral `∫₁^{1+n} f`, directly from `AntitoneOn.integral_le_sum`. -/
+theorem defect_nonneg (hmono : AntitoneOn f (Set.Ici 1)) (n : ℕ) : 0 ≤ defect f n := by
+  have h := (antitone_window hmono n).integral_le_sum
+  simp only [defect]
+  linarith [h]
+
+/-- **Uniform upper bound `f 1`.**  Subtracting the shifted (lower) Riemann sum
+`∑_{i<n} f(1+(i+1))` — which lies below the integral — telescopes to `f 1 − f(1+n)`, and
+`f(1+n) ≥ 0`. -/
+theorem defect_le (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) (n : ℕ) : defect f n ≤ f 1 := by
+  have h := (antitone_window hmono n).sum_le_integral
+  -- telescoping of the difference of the two Riemann sums
+  have htel : (∑ i ∈ Finset.range n, f (1 + (i : ℝ)))
+      - (∑ i ∈ Finset.range n, f (1 + ((i + 1 : ℕ) : ℝ))) = f 1 - f (1 + (n : ℝ)) := by
+    rw [← Finset.sum_sub_distrib]
+    have := Finset.sum_range_sub' (fun i : ℕ => f (1 + (i : ℝ))) n
+    simpa using this
+  have hfn : 0 ≤ f (1 + (n : ℝ)) := hnonneg _ (le_add_of_nonneg_right (Nat.cast_nonneg n))
+  simp only [defect]
+  linarith [h, htel, hfn]
+
+/-- **One-cell integral bound.**  On `[1+n, 1+n+1]` the antitone `f` satisfies
+`∫ f ≤ f(1+n)`; this is `AntitoneOn.integral_le_sum` with a single subinterval. -/
+private theorem integral_cell_le (hmono : AntitoneOn f (Set.Ici 1)) (n : ℕ) :
+    (∫ x in (1 + (n : ℝ))..(1 + (n : ℝ) + 1), f x) ≤ f (1 + (n : ℝ)) := by
+  have hanti : AntitoneOn f (Set.Icc (1 + (n : ℝ)) (1 + (n : ℝ) + ((1 : ℕ) : ℝ))) :=
+    hmono.mono (fun x hx => le_trans (le_add_of_nonneg_right (Nat.cast_nonneg n)) hx.1)
+  have h := hanti.integral_le_sum
+  simpa using h
+
+/-- **Monotone step.**  `D f n ≤ D f (n+1)`: the increment equals `f(1+n) − ∫` over the unit
+cell `[1+n, 1+n+1]`, which is `≥ 0` by `integral_cell_le`. -/
+theorem defect_le_succ (hmono : AntitoneOn f (Set.Ici 1)) (n : ℕ) :
+    defect f n ≤ defect f (n + 1) := by
+  have hsplit : (∫ x in (1 : ℝ)..(1 + ((n + 1 : ℕ) : ℝ)), f x)
+      = (∫ x in (1 : ℝ)..(1 + (n : ℝ)), f x)
+        + ∫ x in (1 + (n : ℝ))..(1 + (n : ℝ) + 1), f x := by
+    have hab : IntervalIntegrable f MeasureTheory.volume 1 (1 + (n : ℝ)) :=
+      intervalIntegrable_of_antitone hmono (le_refl 1) (le_add_of_nonneg_right (Nat.cast_nonneg n))
+    have hbc : IntervalIntegrable f MeasureTheory.volume (1 + (n : ℝ)) (1 + (n : ℝ) + 1) :=
+      intervalIntegrable_of_antitone hmono (le_add_of_nonneg_right (Nat.cast_nonneg n)) (by linarith)
+    have hcast : (1 : ℝ) + ((n + 1 : ℕ) : ℝ) = 1 + (n : ℝ) + 1 := by push_cast; ring
+    rw [hcast, ← intervalIntegral.integral_add_adjacent_intervals hab hbc]
+  have hcell := integral_cell_le hmono n
+  simp only [defect, Finset.sum_range_succ, hsplit]
+  linarith [hcell]
+
+/-- **The defect sequence is monotone non-decreasing.** -/
+theorem defect_monotone (hmono : AntitoneOn f (Set.Ici 1)) : Monotone (defect f) :=
+  monotone_nat_of_le_succ (defect_le_succ hmono)
+
+/-- The range of the defect sequence is bounded above (by `f 1`). -/
+theorem defect_bddAbove (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) : BddAbove (Set.range (defect f)) :=
+  ⟨f 1, by rintro _ ⟨n, rfl⟩; exact defect_le hmono hnonneg n⟩
+
+/-- The **generalized Euler constant** of an antitone nonnegative summand `f`: the limit of
+its defect sequence. -/
+noncomputable def generalizedEuler (f : ℝ → ℝ) : ℝ := ⨆ n, defect f n
+
+/-- **Convergence of the defect sequence** to the generalized Euler constant — the bounded
+monotone convergence theorem applied to `D f`. -/
+theorem tendsto_defect (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) :
+    Tendsto (defect f) atTop (𝓝 (generalizedEuler f)) :=
+  tendsto_atTop_ciSup (defect_monotone hmono) (defect_bddAbove hmono hnonneg)
+
+/-- The generalized Euler constant is `≤ f 1`. -/
+theorem generalizedEuler_le (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) : generalizedEuler f ≤ f 1 :=
+  ciSup_le (defect_le hmono hnonneg)
+
+/-- The generalized Euler constant is nonnegative. -/
+theorem generalizedEuler_nonneg (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) : 0 ≤ generalizedEuler f := by
+  have hbdd := defect_bddAbove hmono hnonneg
+  calc (0 : ℝ) = defect f 0 := (defect_zero).symm
+    _ ≤ generalizedEuler f := le_ciSup hbdd 0
+
+/-- **Packaged enclosure.**  The generalized Euler constant of any antitone nonnegative
+summand lies in `[0, f 1]`. -/
+theorem generalizedEuler_mem_Icc (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x, (1 : ℝ) ≤ x → 0 ≤ f x) : generalizedEuler f ∈ Set.Icc (0 : ℝ) (f 1) :=
+  ⟨generalizedEuler_nonneg hmono hnonneg, generalizedEuler_le hmono hnonneg⟩
+
+end AntitoneIntegralSumComparisonOQ01OQ02OQ02

--- a/proofs/Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean
@@ -1,0 +1,192 @@
+/-
+# From Rank-One to Finite-Rank — Projection onto a Subspace as a Sum of Rank-One Projectors
+
+Open Question (cauchy-schwarz-oq-01-oq-02-oq-01-oq-03), a follow-up to
+`CauchySchwarzOQ01OQ02OQ01.lean` (one Gram-Schmidt step is an orthogonal projector).
+
+The parent file established, for a single non-zero vector `v`, that
+`orthProj v x = (⟪v,x⟫/⟪v,v⟫) • v` is the orthogonal projector onto `span{v}`
+(idempotent, complementary residual, exact norm). This file proves the **finite-rank
+generalization**: the orthogonal projection onto the span of a finite orthonormal family
+`e : Fin k → E` is the **sum of the rank-one projectors** over that family, together with
+the **Parseval / Bessel equality on the subspace**. Zero axioms, zero sorries.
+
+Concretely, writing `subProj e x = ∑ i, ⟪e i, x⟫ • e i` and
+`S = span 𝕜 (range e)`:
+
+* **Sum-of-rank-one-projectors identity** `S.starProjection x = ∑ i, ⟪e i, x⟫ • e i`
+  (`subProj_eq_starProjection`) — the headline: Mathlib's orthogonal projection *is*
+  the sum of the one-line projectors. Also as `orthogonalProjection`
+  (`coe_orthogonalProjection_eq_subProj`).
+* **Residual orthogonality** `⟪e j, x - subProj e x⟫ = 0` and, extended to the whole
+  subspace, `∀ w ∈ S, ⟪x - subProj e x, w⟫ = 0`.
+* **Parseval equality on `S`** `‖subProj e x‖² = ∑ i, ‖⟪e i, x⟫‖²`
+  (`norm_subProj_sq`) — the attained (equality) case of Bessel's inequality, with the
+  Bessel bound `‖subProj e x‖² ≤ ‖x‖²` as a corollary.
+* **Idempotency** `subProj e (subProj e x) = subProj e x` and **reconstruction**
+  `subProj e x + (x - subProj e x) = x`.
+* **`k = 1` recovery** `subProj e x = ⟪e 0, x⟫ • e 0` — the one-term sum is exactly the
+  parent's rank-one projector.
+
+The subspace `S = span (range e)` is finite-dimensional, hence complete, so
+`orthogonalProjection`/`starProjection` are well defined with no completeness hypothesis
+on `E`. The scalar field `𝕜` is an arbitrary `RCLike` field (so `ℝ` and `ℂ` at once),
+kept as an explicit argument of `subProj` as in the parent file.
+-/
+
+import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+import Mathlib.Analysis.InnerProductSpace.Orthonormal
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.Topology.Algebra.Module.FiniteDimension
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+
+open scoped InnerProductSpace
+open RCLike
+
+namespace CauchySchwarzOQ01OQ02OQ01OQ03
+
+variable (𝕜 : Type*) [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+/-! ## The span of a finite family is finite-dimensional, hence complete -/
+
+/-- The span of a finite family is finite-dimensional (so `orthogonalProjection` exists
+without any completeness hypothesis on the ambient space `E`). -/
+instance finiteDimensional_span_range {k : ℕ} (e : Fin k → E) :
+    FiniteDimensional 𝕜 (Submodule.span 𝕜 (Set.range e)) :=
+  FiniteDimensional.span_of_finite 𝕜 (Set.finite_range e)
+
+/-- A finite-dimensional subspace over the complete field `𝕜` is complete, so it has an
+orthogonal projection. -/
+instance completeSpace_span_range {k : ℕ} (e : Fin k → E) :
+    CompleteSpace (Submodule.span 𝕜 (Set.range e)) :=
+  FiniteDimensional.complete 𝕜 _
+
+/-! ## Definition: the finite-rank projection as a sum of rank-one projectors -/
+
+/-- The finite-rank projection of `x` onto the family `e`: the sum of the rank-one
+projectors `x ↦ ⟪e i, x⟫ • e i`. For an orthonormal `e` this is the orthogonal
+projection onto `span (range e)` (`subProj_eq_starProjection`). -/
+noncomputable def subProj {k : ℕ} (e : Fin k → E) (x : E) : E :=
+  ∑ i, ⟪e i, x⟫_𝕜 • e i
+
+/-! ## Membership and coordinates -/
+
+/-- `subProj e x` lies in the span of the family. -/
+theorem subProj_mem_span {k : ℕ} (e : Fin k → E) (x : E) :
+    subProj 𝕜 e x ∈ Submodule.span 𝕜 (Set.range e) := by
+  refine Submodule.sum_mem _ ?_
+  intro i _
+  exact Submodule.smul_mem _ _ (Submodule.subset_span (Set.mem_range_self i))
+
+/-- Coordinate extraction: for an orthonormal family, `⟪e j, subProj e x⟫ = ⟪e j, x⟫`.
+The projection has the same coordinates as `x` along each `e j`. -/
+theorem inner_subProj {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) (j : Fin k) :
+    ⟪e j, subProj 𝕜 e x⟫_𝕜 = ⟪e j, x⟫_𝕜 := by
+  unfold subProj
+  exact he.inner_right_fintype (fun i => ⟪e i, x⟫_𝕜) j
+
+/-! ## Residual orthogonality -/
+
+/-- The residual `x - subProj e x` is orthogonal to every basis vector `e j`. -/
+theorem inner_residual {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) (j : Fin k) :
+    ⟪e j, x - subProj 𝕜 e x⟫_𝕜 = 0 := by
+  rw [inner_sub_right, inner_subProj 𝕜 he x j, sub_self]
+
+/-- The residual `x - subProj e x` is orthogonal to the *whole* subspace `span (range e)`,
+not merely to each `e j`. This is the defining orthogonality property of the projection. -/
+theorem residual_orthogonal_span {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    ∀ w ∈ Submodule.span 𝕜 (Set.range e), ⟪x - subProj 𝕜 e x, w⟫_𝕜 = 0 := by
+  intro w hw
+  refine Submodule.span_induction
+    (p := fun w _ => ⟪x - subProj 𝕜 e x, w⟫_𝕜 = 0) ?_ ?_ ?_ ?_ hw
+  · rintro y ⟨j, rfl⟩
+    rw [inner_eq_zero_symm]
+    exact inner_residual 𝕜 he x j
+  · simp
+  · intro a b _ _ pa pb
+    rw [inner_add_right, pa, pb, add_zero]
+  · intro c a _ pa
+    rw [inner_smul_right, pa, mul_zero]
+
+/-! ## Part I: The sum-of-rank-one-projectors identity (headline) -/
+
+/-- **Main theorem.** For a finite orthonormal family `e`, the orthogonal projection onto
+`S = span (range e)` equals the sum of the rank-one projectors:
+`S.starProjection x = ∑ i, ⟪e i, x⟫ • e i`. This is the operator identity
+`P_S = ∑ i, e_i e_i^*` (a finite-rank resolution of the identity). -/
+theorem subProj_eq_starProjection {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    (Submodule.span 𝕜 (Set.range e)).starProjection x = subProj 𝕜 e x :=
+  Submodule.eq_starProjection_of_mem_of_inner_eq_zero
+    (subProj_mem_span 𝕜 e x) (residual_orthogonal_span 𝕜 he x)
+
+/-- The same identity phrased with the subspace-valued `orthogonalProjection`. -/
+theorem coe_orthogonalProjection_eq_subProj {k : ℕ} {e : Fin k → E}
+    (he : Orthonormal 𝕜 e) (x : E) :
+    (((Submodule.span 𝕜 (Set.range e)).orthogonalProjection x : Submodule.span 𝕜 (Set.range e)) : E)
+      = subProj 𝕜 e x := by
+  rw [Submodule.coe_orthogonalProjection_apply]
+  exact subProj_eq_starProjection 𝕜 he x
+
+/-! ## Part II: Parseval / Bessel equality on the subspace -/
+
+/-- **Parseval equality on `S`.** The squared norm of the projection is the sum of the
+squared coordinate moduli: `‖subProj e x‖² = ∑ i, ‖⟪e i, x⟫‖²`. This is the attained
+(equality) form of Bessel's inequality, restricted to the subspace `S`. -/
+theorem norm_subProj_sq {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    ‖subProj 𝕜 e x‖ ^ 2 = ∑ i, ‖⟪e i, x⟫_𝕜‖ ^ 2 := by
+  rw [@norm_sq_eq_re_inner 𝕜]
+  unfold subProj
+  rw [he.inner_sum (fun i => ⟪e i, x⟫_𝕜) (fun i => ⟪e i, x⟫_𝕜) Finset.univ, map_sum]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [RCLike.conj_mul]
+  norm_cast
+
+/-- **Bessel's inequality** as a corollary: `‖subProj e x‖² ≤ ‖x‖²`. -/
+theorem norm_subProj_sq_le {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    ‖subProj 𝕜 e x‖ ^ 2 ≤ ‖x‖ ^ 2 := by
+  rw [norm_subProj_sq 𝕜 he x]
+  exact he.sum_inner_products_le x
+
+/-! ## Part III: Idempotency and reconstruction (projector axioms) -/
+
+/-- **Idempotency** `P² = P`: `subProj e (subProj e x) = subProj e x`. -/
+theorem subProj_idempotent {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) (x : E) :
+    subProj 𝕜 e (subProj 𝕜 e x) = subProj 𝕜 e x := by
+  simp only [subProj]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [he.inner_right_fintype (fun j => ⟪e j, x⟫_𝕜) i]
+
+/-- **Reconstruction** `P + (1 − P) = id`: the projection and residual sum to `x`. -/
+theorem subProj_add_residual {k : ℕ} (e : Fin k → E) (x : E) :
+    subProj 𝕜 e x + (x - subProj 𝕜 e x) = x := by
+  abel
+
+/-! ## Part IV: The `k = 1` case recovers the parent's rank-one projector -/
+
+/-- For a single-vector family, `subProj` is the one-term sum `⟪e 0, x⟫ • e 0`, i.e. the
+parent file's rank-one orthogonal projector onto the line `span{e 0}`. -/
+theorem subProj_one (e : Fin 1 → E) (x : E) :
+    subProj 𝕜 e x = ⟪e 0, x⟫_𝕜 • e 0 := by
+  simp [subProj]
+
+/-! ## Part V: Capstone -/
+
+/-- **Summary.** For a finite orthonormal family `e` with span `S`, the map
+`subProj e = ∑ i ⟪e i, ·⟫ • e i` is the orthogonal projection onto `S`: it agrees with
+Mathlib's `starProjection`, its residual is orthogonal to `S`, it satisfies the Parseval
+equality on `S`, and it is idempotent. -/
+theorem subProj_is_orthogonal_projection {k : ℕ} {e : Fin k → E} (he : Orthonormal 𝕜 e) :
+    (∀ x : E, (Submodule.span 𝕜 (Set.range e)).starProjection x = subProj 𝕜 e x) ∧
+    (∀ x : E, ∀ w ∈ Submodule.span 𝕜 (Set.range e), ⟪x - subProj 𝕜 e x, w⟫_𝕜 = 0) ∧
+    (∀ x : E, ‖subProj 𝕜 e x‖ ^ 2 = ∑ i, ‖⟪e i, x⟫_𝕜‖ ^ 2) ∧
+    (∀ x : E, subProj 𝕜 e (subProj 𝕜 e x) = subProj 𝕜 e x) :=
+  ⟨fun x => subProj_eq_starProjection 𝕜 he x,
+   fun x => residual_orthogonal_span 𝕜 he x,
+   fun x => norm_subProj_sq 𝕜 he x,
+   fun x => subProj_idempotent 𝕜 he x⟩
+
+end CauchySchwarzOQ01OQ02OQ01OQ03

--- a/src/data/proofs/amgm-inequality-oq-05-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02-oq-01/annotations.json
@@ -1,0 +1,70 @@
+[
+  {
+    "id": "ann-engine-pairwise",
+    "proofId": "amgm-inequality-oq-05-oq-02-oq-01",
+    "range": { "startLine": 71, "endLine": 99 },
+    "type": "technique",
+    "title": "weighted_amgm_eq_iff_pairwise: the reused equality engine",
+    "content": "The parent entry's weighted AM-GM equality case, reproduced here as private scaffolding so the file is self-contained. For positive weights summing to 1 it characterises ∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ as 'all xⱼ equal'. The proof injects the equality through log (both means are positive, so Real.log_injOn_pos applies), rewrites the geometric side by log_prod_rpow, and feeds strictConcaveOn_log_Ioi.map_sum_eq_iff — Mathlib's strict-Jensen equality characterisation. The 'every xⱼ = mean' output is repackaged as pairwise equality using ∑ wᵢxⱼ = xⱼ∑wᵢ = xⱼ.",
+    "mathContext": "$\\prod_i x_i^{w_i} = \\sum_i w_i x_i \\iff \\forall i\\,j,\\ x_i = x_j$ (for $w_i>0,\\ \\sum w_i = 1$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "StrictConcaveOn.map_sum_eq_iff",
+      "strictConcaveOn_log_Ioi",
+      "Real.log_injOn_pos"
+    ],
+    "prerequisites": [
+      "Real.log_prod",
+      "Real.log_rpow",
+      "StrictConcaveOn.map_sum_eq_iff"
+    ]
+  },
+  {
+    "id": "ann-sum-inv-card",
+    "proofId": "amgm-inequality-oq-05-oq-02-oq-01",
+    "range": { "startLine": 103, "endLine": 106 },
+    "type": "technique",
+    "title": "sum_inv_card: the equal weights 1/n sum to 1",
+    "content": "The single arithmetic fact that lets the weighted engine specialise to the classical case: the n copies of the weight (n:ℝ)⁻¹ sum to 1 over Fin n. Proved by Finset.sum_const (turning the constant sum into card • (n:ℝ)⁻¹), Finset.card_univ / Fintype.card_fin (card = n), nsmul_eq_mul (n • r = n·r), and mul_inv_cancel₀ with n ≠ 0 from n > 0. This discharges the ∑ wᵢ = 1 hypothesis of the equality engine.",
+    "mathContext": "$\\sum_{i:\\mathrm{Fin}\\,n} \\tfrac1n = n\\cdot\\tfrac1n = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_const", "mul_inv_cancel₀"],
+    "prerequisites": ["Finset.sum_const", "Fintype.card_fin", "mul_inv_cancel₀"]
+  },
+  {
+    "id": "ann-classical-le",
+    "proofId": "amgm-inequality-oq-05-oq-02-oq-01",
+    "range": { "startLine": 108, "endLine": 119 },
+    "type": "insight",
+    "title": "classical_amgm_le: geometric mean ≤ arithmetic mean",
+    "content": "The inequality direction, obtained by feeding the uniform weights w ≡ 1 to Mathlib's Real.geom_mean_le_arith_mean. There the general conclusion (∏ zᵢ^{wᵢ})^{(∑w)⁻¹} ≤ (∑ wᵢzᵢ)/(∑w) becomes, with ∑ 1 = n (helper hcard), (∏ xᵢ^1)^{1/n} ≤ (∑ 1·xᵢ)/n; Real.rpow_one and one_mul clean the powers and products so the statement reads (∏ xᵢ)^{1/n} ≤ (∑ xᵢ)/n. Only nonnegativity of the xᵢ is required.",
+    "mathContext": "$\\left(\\prod_{i} x_i\\right)^{1/n} \\le \\dfrac{\\sum_i x_i}{n}$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.geom_mean_le_arith_mean", "Real.rpow_one"],
+    "prerequisites": ["Real.geom_mean_le_arith_mean", "Real.rpow_one"]
+  },
+  {
+    "id": "ann-classical-eq-iff",
+    "proofId": "amgm-inequality-oq-05-oq-02-oq-01",
+    "range": { "startLine": 121, "endLine": 146 },
+    "type": "insight",
+    "title": "classical_amgm_eq_iff: sharp equality iff all terms equal",
+    "content": "The headline equality characterisation in canonical form. Instantiate the engine weighted_amgm_eq_iff_pairwise at wᵢ = 1/n over Finset.univ (hypotheses discharged by sum_inv_card and positivity), then perform the two repackaging rewrites: Real.finset_prod_rpow turns ∏ xᵢ^{1/n} into the single power (∏ xᵢ)^{1/n}, and Finset.mul_sum turns ∑ (1/n)·xᵢ into (∑ xᵢ)/n. The result is (∏ xᵢ)^{1/n} = (∑ xᵢ)/n ↔ ∀ i j, xᵢ = xⱼ — precisely the classical AM-GM equality locus, absent from Mathlib in this form.",
+    "mathContext": "$\\left(\\prod_i x_i\\right)^{1/n} = \\dfrac{\\sum_i x_i}{n} \\iff \\forall i\\,j,\\ x_i = x_j$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.finset_prod_rpow", "Finset.mul_sum", "equality case"],
+    "prerequisites": ["Real.finset_prod_rpow", "Finset.mul_sum"]
+  },
+  {
+    "id": "ann-classical-lt",
+    "proofId": "amgm-inequality-oq-05-oq-02-oq-01",
+    "range": { "startLine": 154, "endLine": 163 },
+    "type": "insight",
+    "title": "classical_amgm_lt_of_not_const: strict gap for non-constant inputs",
+    "content": "Combining the ≤ bound with the equality locus gives the strict inequality directly usable in extremal arguments: if some xᵢ ≠ xⱼ then the geometric mean is strictly below the arithmetic mean. Proof: lt_of_le_of_ne against classical_amgm_le, ruling out equality via classical_amgm_eq_iff (an equality would force all xᵢ equal, contradicting the witness pair).",
+    "mathContext": "$(\\exists i\\,j,\\ x_i \\ne x_j) \\Rightarrow \\left(\\prod_i x_i\\right)^{1/n} < \\dfrac{\\sum_i x_i}{n}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["lt_of_le_of_ne", "strict inequality"],
+    "prerequisites": ["lt_of_le_of_ne"]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-05-oq-02-oq-01/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AmgmInequalityOQ05OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const amgmInequalityOq05Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const amgmInequalityOq05Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const amgmInequalityOq05Oq02Oq01Data: ProofData = {
+  proof: amgmInequalityOq05Oq02Oq01Proof,
+  annotations: amgmInequalityOq05Oq02Oq01Annotations,
+}

--- a/src/data/proofs/amgm-inequality-oq-05-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02-oq-01/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "amgm-inequality-oq-05-oq-02-oq-01",
+  "slug": "amgm-inequality-oq-05-oq-02-oq-01",
+  "title": "The Classical AM-GM Inequality and Its Equality Case (n Terms)",
+  "description": "The equal-weight specialisation (wᵢ = 1/n) of the parent's weighted AM-GM equality case, stated in the canonical form indexed over Fin n. For n positive reals the geometric mean G = (∏ xᵢ)^{1/n} is at most the arithmetic mean A = (∑ xᵢ)/n (classical_amgm_le, from Mathlib's Real.geom_mean_le_arith_mean with uniform weights), with equality G = A iff all the xᵢ are equal (classical_amgm_eq_iff). The equality characterisation — not packaged in Mathlib — is transported from the weighted case via Real.finset_prod_rpow, which rewrites the weighted geometric mean ∏ (xᵢ)^{1/n} into (∏ xᵢ)^{1/n}. A strict form (classical_amgm_lt_of_not_const) records that non-constant inputs give a strict gap.",
+  "conclusion": {
+    "summary": "The classical unweighted AM-GM inequality over Fin n is fully verified: geometric mean (∏ xᵢ)^{1/n} ≤ arithmetic mean (∑ xᵢ)/n (classical_amgm_le), with equality iff all xᵢ are equal (classical_amgm_eq_iff), and a strict version for non-constant inputs (classical_amgm_lt_of_not_const). 9 theorems, 0 definitions, 0 axioms, 0 sorries. The inequality specialises Mathlib's Real.geom_mean_le_arith_mean to the uniform weights ≡ 1; the equality case is the equal-weight (wᵢ = 1/n) reduction of the parent entry's weighted equality characterisation, repackaged into the standard geometric-mean form with Real.finset_prod_rpow.",
+    "implications": "This closes the parent's first open question by delivering the AM-GM statement in the textbook form actually cited in applications: not the weighted ∏ xᵢ^{wᵢ} vs ∑ wᵢxᵢ, but the plain n-th-root-of-a-product versus the average. The equality clause makes the tightness explicit — in any use of the n-term AM-GM the estimate is sharp exactly when the inputs are constant — and the strict corollary packages the quantitative counterpart directly usable in extremal arguments.",
+    "openQuestions": [
+      "State and verify the reverse (weighted power-mean) chain M₋∞ ≤ … ≤ G ≤ A ≤ … ≤ M_∞ specialised to Fin n, locating this G ≤ A result as the r = 0 versus r = 1 comparison of the power-mean monotonicity theorem.",
+      "Derive the classical isoperimetric-type corollary: among positive n-tuples with a fixed sum the product is maximised exactly at the constant tuple (and dually for fixed product), reading it off from the equality case."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "AmgmInequalityOQ05OQ02OQ01",
+    "lineCount": 164,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/AmgmInequalityOQ05OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "The classical inequality of arithmetic and geometric means states that for positive reals x₁,…,xₙ the geometric mean (x₁⋯xₙ)^{1/n} never exceeds the arithmetic mean (x₁+⋯+xₙ)/n, with equality precisely when all the xᵢ coincide. It is the equal-weight case (wᵢ = 1/n) of the weighted AM-GM inequality and one of the most-used inequalities in analysis and optimisation. Mathlib provides the weighted inequality (Real.geom_mean_le_arith_mean_weighted, and the unweighted Real.geom_mean_le_arith_mean) together with a complete suite of strict-Jensen equality lemmas, but it does not package the equal-weight equality characterisation in the standard geometric-mean form. The parent entry proved the general weighted equality case from the strict concavity of log; its first stated open question was to read off this classical Fin n statement as a standalone corollary. This entry does so.",
+    "problemStatement": "Fix n > 0 and positive reals x : Fin n → ℝ. Prove (i) the geometric mean (∏ᵢ xᵢ)^{1/n} is at most the arithmetic mean (∑ᵢ xᵢ)/n, and (ii) the two means are equal if and only if all the xᵢ are equal; deduce (iii) the strict inequality whenever the xᵢ are not all equal.",
+    "text": "The classical AM-GM inequality over Fin n: (∏ xᵢ)^{1/n} ≤ (∑ xᵢ)/n, with equality iff all xᵢ are equal. Both facts are specialisations of general Mathlib / parent results to the uniform weights 1/n, converted into the canonical geometric-mean form.",
+    "proofStrategy": "The two directions come from two different specialisations. (1) Inequality (classical_amgm_le): apply Mathlib's Real.geom_mean_le_arith_mean to the weights w ≡ 1. There ∑ wᵢ = n, so the general conclusion (∏ zᵢ^{wᵢ})^{(∑w)⁻¹} ≤ (∑ wᵢzᵢ)/(∑w) becomes (∏ xᵢ^1)^{1/n} ≤ (∑ 1·xᵢ)/n; Real.rpow_one and one_mul simplify the powers and products, and the helper hcard : ∑_{i} (1:ℝ) = n rewrites the exponent and denominator. (2) Equality case (classical_amgm_eq_iff): reuse the parent's engine — reproduced here as the private weighted_amgm_eq_iff_pairwise with its log/positivity helpers — at the weights wᵢ = 1/n over Finset.univ. The private sum_inv_card shows ∑ (n:ℝ)⁻¹ = 1 (via Finset.sum_const and mul_inv_cancel₀), so the engine yields ∏ xᵢ^{1/n} = ∑ (1/n)·xᵢ ↔ all xᵢ equal. Two rewrites put this in canonical form: Real.finset_prod_rpow turns ∏ xᵢ^{1/n} into (∏ xᵢ)^{1/n}, and Finset.mul_sum turns ∑ (1/n)·xᵢ into (∑ xᵢ)/n. (3) The strict form classical_amgm_lt_of_not_const combines the two: lt_of_le_of_ne against classical_amgm_le, ruling out equality via the equality case whenever some xᵢ ≠ xⱼ. classical_amgm_eq_of_const records the trivial constant direction.",
+    "keyInsights": [
+      "**One theorem, two Mathlib entry points.** The inequality and its equality case reach Mathlib through different doors: the ≤ is the uniform-weight case of Real.geom_mean_le_arith_mean (a convexity fact), while the equality clause is the equal-weight case of the parent's strict-concavity-of-log characterisation. Neither door alone gives the sharp classical statement; combining them (in classical_amgm_lt_of_not_const) does.",
+      "**Real.finset_prod_rpow is the repackaging step.** The weighted machinery speaks about ∏ᵢ (xᵢ)^{wᵢ}, a product of individual powers; the classical statement speaks about (∏ᵢ xᵢ)^{1/n}, a single power of the product. For nonnegative bases these agree by Real.finset_prod_rpow, and that identity is exactly what converts the general equality case into the geometric-mean form everyone recognises.",
+      "**Uniform weights make the mean the plain average.** Specialising wᵢ = 1/n collapses the weighted arithmetic mean ∑ wᵢxᵢ to (∑ xᵢ)/n (Finset.mul_sum) and the constraint ∑ wᵢ = 1 to the arithmetic fact n·(1/n) = 1 (sum_inv_card). The 'all xⱼ equal the weighted mean' locus of the parent becomes the symmetric 'all xᵢ equal', already available in pairwise form.",
+      "**The strict inequality is a free corollary.** Once the ≤ and the equality locus are both in hand, lt_of_le_of_ne upgrades to <: any non-constant tuple cannot achieve equality, so its geometric mean is strictly smaller — the form most directly useful in extremal and optimisation arguments."
+    ],
+    "prerequisites": [
+      "Mathlib's unweighted AM-GM inequality Real.geom_mean_le_arith_mean",
+      "The rpow product identity Real.finset_prod_rpow and Real.rpow_one",
+      "Equality case of Jensen for the strictly concave log (strictConcaveOn_log_Ioi, StrictConcaveOn.map_sum_eq_iff)",
+      "Finset sum/product bookkeeping: Finset.sum_const, Finset.mul_sum, mul_inv_cancel₀"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-05-oq-02",
+      "relationship": "extends",
+      "description": "The parent proved the general weighted AM-GM equality case and posed 'specialise to equal weights wᵢ = 1/n to state the classical AM-GM equality case indexed over Fin n' as its first open question. This entry answers it, adding the inequality direction (from Mathlib) and the strict form so the classical statement is complete."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "Delivers the AM-GM family's most familiar member — geometric mean ≤ arithmetic mean for n positive reals, sharp iff the reals are equal — in the canonical (∏ xᵢ)^{1/n} versus (∑ xᵢ)/n form."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Classical reference for the AM-GM inequality and its equality case (Theorem 9 and the surrounding discussion of geometric and arithmetic means)."
+    },
+    {
+      "authors": "Steele, J. Michael",
+      "title": "The Cauchy–Schwarz Master Class",
+      "year": "2004",
+      "venue": "Cambridge University Press",
+      "note": "Develops AM-GM, Jensen, and the role of strict convexity in equality cases."
+    }
+  ],
+  "sections": [
+    {
+      "id": "engine",
+      "title": "Self-contained weighted equality-case engine",
+      "startLine": 40,
+      "endLine": 99,
+      "summary": "Reproduces, as private scaffolding, the parent's weighted AM-GM equality case: log_prod_rpow (log of the weighted geometric mean = weighted sum of logs), the positivity helpers prod_rpow_pos and mean_pos, and weighted_amgm_eq_iff_pairwise, which characterises ∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ as 'all xⱼ equal' via log-injectivity and strictConcaveOn_log_Ioi.map_sum_eq_iff."
+    },
+    {
+      "id": "inequality",
+      "title": "The classical inequality (uniform weights)",
+      "startLine": 101,
+      "endLine": 119,
+      "summary": "sum_inv_card records ∑ (n:ℝ)⁻¹ = 1 over Fin n. classical_amgm_le specialises Mathlib's Real.geom_mean_le_arith_mean to the weights ≡ 1: with ∑ 1 = n the general bound collapses to (∏ xᵢ)^{1/n} ≤ (∑ xᵢ)/n after Real.rpow_one/one_mul cleanup."
+    },
+    {
+      "id": "equality-case",
+      "title": "The classical equality case in canonical form",
+      "startLine": 121,
+      "endLine": 146,
+      "summary": "classical_amgm_eq_iff: instantiate the engine at wᵢ = 1/n over Finset.univ, then rewrite with Real.finset_prod_rpow (∏ xᵢ^{1/n} = (∏ xᵢ)^{1/n}) and Finset.mul_sum (∑ (1/n)xᵢ = (∑ xᵢ)/n) to obtain (∏ xᵢ)^{1/n} = (∑ xᵢ)/n ↔ all xᵢ equal."
+    },
+    {
+      "id": "corollaries",
+      "title": "Constant direction and the strict inequality",
+      "startLine": 147,
+      "endLine": 164,
+      "summary": "classical_amgm_eq_of_const records the easy converse (all xᵢ = c ⟹ means coincide). classical_amgm_lt_of_not_const upgrades ≤ to < for non-constant inputs by combining classical_amgm_le with the equality case through lt_of_le_of_ne."
+    }
+  ],
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Inequality_of_arithmetic_and_geometric_means",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ05OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "amgm",
+      "geometric-mean",
+      "arithmetic-mean",
+      "convexity",
+      "jensen",
+      "equality-case",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 164,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-checked from Mathlib with 0 sorries and 0 axioms beyond Lean's foundational propext / Classical.choice / Quot.sound (which all Mathlib developments use). #print axioms on classical_amgm_le, classical_amgm_eq_iff, classical_amgm_lt_of_not_const, and classical_amgm_eq_of_const reports exactly these three. The inequality is Real.geom_mean_le_arith_mean at uniform weights; the equality case is the equal-weight reduction of the parent's strict-concavity-of-log characterisation, transported by Real.finset_prod_rpow.",
+    "mathlib_version": "4.26.0"
+  }
+}

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-isc-oq010202-defect",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 48, "endLine": 54 },
+    "type": "definition",
+    "title": "The General Defect Sequence",
+    "content": "defect f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f is the excess of the right-open Riemann sum over the integral, defined for an arbitrary summand f. The parent's harmonic defect Hₙ − log(n+1) is exactly the case f = 1/x, since ∑_{i<n} 1/(1+i) = Hₙ and ∫₁^{1+n} 1/x = log(1+n). defect f 0 = 0 by convention.",
+    "mathContext": "D_f(n) := \\sum_{i<n} f(1+i) - \\int_1^{1+n} f",
+    "significance": "key",
+    "relatedConcepts": [
+      "generalized Euler constant",
+      "Riemann sum",
+      "integral test"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010202-nonneg",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 69, "endLine": 74 },
+    "type": "theorem",
+    "title": "The Defect Is Nonnegative",
+    "content": "defect_nonneg: 0 ≤ D f n. The upper Riemann sum ∑_{i<n} f(1+i) dominates the integral ∫₁^{1+n} f because f is antitone (on [k,k+1] the maximum of f is f(k)). This is Mathlib's AntitoneOn.integral_le_sum applied on the window [1,1+n].",
+    "mathContext": "\\int_1^{1+n} f \\le \\sum_{i<n} f(1+i)",
+    "significance": "standard",
+    "relatedConcepts": [
+      "antitone integral test",
+      "upper Riemann sum"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010202-le",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 76, "endLine": 90 },
+    "type": "theorem",
+    "title": "Uniform Upper Bound f(1)",
+    "content": "defect_le: D f n ≤ f 1 for every n. Subtracting the lower Riemann sum ∑_{i<n} f(1+(i+1)) — which lies below the integral by AntitoneOn.sum_le_integral — the two Riemann sums telescope: ∑_{i<n} f(1+i) − ∑_{i<n} f(1+(i+1)) = f(1) − f(1+n) (Finset.sum_range_sub'). Since f(1+n) ≥ 0, the defect never exceeds the leading term f(1).",
+    "mathContext": "D_f(n) \\le f(1) - f(1+n) \\le f(1)",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping sum",
+      "lower Riemann sum",
+      "uniform bound"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010202-monotone",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 101, "endLine": 120 },
+    "type": "theorem",
+    "title": "Monotone Non-Decreasing",
+    "content": "defect_le_succ / defect_monotone: D f (n+1) − D f n = f(1+n) − ∫_{1+n}^{1+n+1} f. Splitting the integral over the adjacent intervals [1,1+n] and [1+n,1+n+1] and bounding the unit-cell integral by f(1+n) (integral_cell_le, antitonicity on one cell) shows the increment is ≥ 0. So the same defect sequence that is bounded above is also monotone.",
+    "mathContext": "D_f(n{+}1) - D_f(n) = f(1+n) - \\int_{1+n}^{1+n+1} f \\ge 0",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotone sequence",
+      "interval additivity",
+      "per-cell estimate"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010202-tendsto",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 127, "endLine": 136 },
+    "type": "theorem",
+    "title": "Convergence to the Generalized Euler Constant",
+    "content": "tendsto_defect: D f converges to generalizedEuler f := ⨆ n, D f n. A monotone sequence bounded above converges to its supremum (tendsto_atTop_ciSup). This is the general form of the parent's γ: for f = 1/x, generalizedEuler f is exactly the Euler–Mascheroni constant. The answer to the parent's open question for arbitrary antitone summands.",
+    "mathContext": "D_f \\to \\gamma_f := \\sup_n D_f(n)",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotone convergence",
+      "generalized Euler constant",
+      "supremum"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010202-enclosure",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "range": { "startLine": 150, "endLine": 154 },
+    "type": "theorem",
+    "title": "The Limit Lies in [0, f(1)]",
+    "content": "generalizedEuler_mem_Icc: 0 ≤ generalizedEuler f ≤ f 1. The lower bound comes from D f 0 = 0 ≤ ⨆ (le_ciSup); the upper bound from all terms being ≤ f 1 (ciSup_le). Thus every antitone nonnegative summand carries a generalized Euler constant bounded above by its first term.",
+    "mathContext": "\\gamma_f \\in [0, f(1)]",
+    "significance": "standard",
+    "relatedConcepts": [
+      "supremum bounds",
+      "generalized Euler constant"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/index.ts
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const antitoneIntegralSumComparisonOq01Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const antitoneIntegralSumComparisonOq01Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const antitoneIntegralSumComparisonOq01Oq02Oq02Data: ProofData = {
+  proof: antitoneIntegralSumComparisonOq01Oq02Oq02Proof,
+  annotations: antitoneIntegralSumComparisonOq01Oq02Oq02Annotations,
+}

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+  "slug": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+  "title": "The Generalized Euler Constant of an Arbitrary Antitone Summand",
+  "status": "verified",
+  "badge": "mathlib",
+  "leanFile": {
+    "namespace": "AntitoneIntegralSumComparisonOQ01OQ02OQ02",
+    "lineCount": 156,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 2,
+    "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_constant",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02.lean",
+    "tags": [
+      "analysis",
+      "integral-test",
+      "euler-mascheroni",
+      "generalized-euler-constant",
+      "convergence",
+      "monotone-convergence",
+      "riemann-sum"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None beyond the two hypotheses on f (antitone on [1,∞) and nonnegative there), which are part of the theorem statements rather than global axioms. Fully machine-verified: #print axioms reports only the foundational propext / Classical.choice / Quot.sound.",
+    "lineCount": 156,
+    "theoremCount": 13,
+    "definitionCount": 2,
+    "originalContributions": [
+      "defect (definition): the general defect sequence D f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f for an arbitrary summand f — the parent's harmonic defect Hₙ − log(n+1) is the special case f = 1/x",
+      "defect_nonneg: 0 ≤ D f n, from AntitoneOn.integral_le_sum (the upper Riemann sum dominates the integral)",
+      "defect_le: the uniform bound D f n ≤ f 1, obtained by subtracting the shifted lower Riemann sum ∑_{i<n} f(1+(i+1)) ≤ ∫ and telescoping the two sums to f 1 − f(1+n) with f(1+n) ≥ 0",
+      "integral_cell_le: the one-cell estimate ∫_{1+n}^{1+n+1} f ≤ f(1+n), AntitoneOn.integral_le_sum on a single unit subinterval",
+      "defect_le_succ / defect_monotone: the increment D f (n+1) − D f n = f(1+n) − ∫ over the unit cell [1+n,1+n+1] is ≥ 0, so D f is monotone non-decreasing",
+      "generalizedEuler (definition) and tendsto_defect: D f converges to generalizedEuler f := ⨆ n, D f n, the bounded-monotone limit (tendsto_atTop_ciSup) — the generalized Euler constant of f",
+      "generalizedEuler_nonneg / generalizedEuler_le / generalizedEuler_mem_Icc: the limit lies in [0, f 1]"
+    ]
+  },
+  "description": "Answers the second open question recorded by the parent entry (antitone-integral-sum-comparison-oq-01-oq-02): package the analogous defect for a general antitone summand f, proving ∑_{k≤n} f(k) − ∫₁^n f converges. Where the parent specialized the antitone integral test to f(x) = 1/x and identified the limit of Hₙ − log(n+1) with the classical Euler–Mascheroni constant γ, this entry lifts the whole phenomenon to every antitone, nonnegative f on [1,∞). It defines the defect D f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f, then uses only the two-sided integral-test sandwich (Mathlib's AntitoneOn.integral_le_sum and AntitoneOn.sum_le_integral) to prove D f is nonnegative, bounded above by f 1, and monotone non-decreasing — hence convergent, to the generalized Euler constant generalizedEuler f := ⨆ n, D f n, which lies in [0, f 1]. The harmonic defect of the parent is exactly the case f = 1/x. 13 theorems, 2 definitions, 0 sorries, 0 axioms.",
+  "overview": {
+    "historicalContext": "Euler's constant γ = lim(Hₙ − log n) is the prototype of a whole family: for any antitone f the excess of the partial sum ∑_{k≤n} f(k) over the integral ∫₁^n f settles down to a constant, the 'generalized Euler constant' of f. These constants — Stieltjes constants, generalized Euler–Mascheroni constants — appear throughout analytic number theory. The mechanism that produces them is the integral test itself: the same monotone-sandwich comparison that decides convergence of ∑ f also manufactures the limiting correction term.",
+    "problemStatement": "The parent entry proved the harmonic defect Hₙ − log(n+1) converges to γ for the specific function 1/x. Does the analogous defect ∑_{k≤n} f(k) − ∫₁^n f converge for an arbitrary antitone, nonnegative f, and what can be said about its limit?",
+    "text": "Fix f antitone and nonnegative on [1,∞) and set D f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f. The antitone integral test gives, on each window [1,1+n], the two-sided sandwich ∑_{i<n} f(1+(i+1)) ≤ ∫₁^{1+n} f ≤ ∑_{i<n} f(1+i). The right inequality is D f n ≥ 0. Subtracting the left (lower) sum from the upper sum telescopes to f 1 − f(1+n) ≤ f 1, so D f n ≤ f 1 uniformly. Monotonicity is a per-cell computation: D f (n+1) − D f n = f(1+n) − ∫_{1+n}^{1+n+1} f, and antitonicity forces ∫ over the unit cell to be ≤ f(1+n), so the increment is ≥ 0. A monotone sequence bounded above converges; its limit generalizedEuler f = ⨆ n, D f n is the generalized Euler constant, and it lands in [0, f 1]. For f = 1/x this recovers the parent's γ.",
+    "proofStrategy": "Every step is a short reduction to Mathlib's SumIntegralComparisons library. defect_nonneg is AntitoneOn.integral_le_sum verbatim; defect_le combines AntitoneOn.sum_le_integral with Finset.sum_range_sub' (the telescoping of ∑ f(1+i) − ∑ f(1+(i+1)) to f 1 − f(1+n)) and f(1+n) ≥ 0. integral_cell_le instantiates AntitoneOn.integral_le_sum at a single unit interval. defect_le_succ splits ∫₁^{1+n+1} = ∫₁^{1+n} + ∫_{1+n}^{1+n+1} via intervalIntegral.integral_add_adjacent_intervals (integrability from AntitoneOn.intervalIntegrable) and bounds the cell integral; monotone_nat_of_le_succ upgrades to Monotone. tendsto_defect is tendsto_atTop_ciSup applied to the monotone, bounded-above sequence; the [0, f 1] enclosure follows from ciSup_le and le_ciSup with defect_zero.",
+    "keyInsights": [
+      "The Euler–Mascheroni convergence is not special to 1/x: the only inputs are antitonicity (to make the integral test sandwich hold) and nonnegativity (to bound the telescoped remainder), so every antitone nonnegative summand has its own limiting constant",
+      "Boundedness comes from a global telescoping identity across the whole window, while monotonicity comes from a purely local per-cell integral estimate — two different uses of the same one-sided comparison AntitoneOn.integral_le_sum",
+      "The uniform bound is sharp in form: D f n ≤ f 1 with the limit in [0, f 1], and f 1 is exactly the first term of the series, so the generalized Euler constant never exceeds the leading summand",
+      "Divergence of ∑ f (the 'Euler constant' regime) is not needed for the defect to converge — convergence of D f is automatic; divergence is what makes the constant an interesting invariant rather than a rewriting of the convergent tail"
+    ],
+    "prerequisites": [
+      "The antitone integral-test sandwich ∑ f(x₀+i+1) ≤ ∫ ≤ ∑ f(x₀+i) (parent entry / Mathlib SumIntegralComparisons)",
+      "Monotone sequences bounded above converge to their supremum (tendsto_atTop_ciSup)",
+      "Interval integrability of monotone/antitone functions and additivity of the interval integral over adjacent intervals",
+      "Telescoping finite sums (Finset.sum_range_sub')"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Definition of the general defect",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Import Mathlib; docstring recalling the parent (the harmonic defect for f = 1/x converges to γ) and stating the generalization to arbitrary antitone nonnegative f. Define defect f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f, with defect f 0 = 0.",
+      "mathContext": "$D_f(n) := \\sum_{i<n} f(1+i) - \\int_1^{1+n} f$, $\\;D_f(0)=0$."
+    },
+    {
+      "id": "integrability",
+      "title": "Integrability and window restriction",
+      "startLine": 56,
+      "endLine": 67,
+      "summary": "intervalIntegrable_of_antitone: an antitone function on [1,∞) is interval-integrable on any [a,b] with 1 ≤ a ≤ b (AntitoneOn.intervalIntegrable). antitone_window restricts the hypothesis to the finite window [1,1+n].",
+      "mathContext": "$f$ antitone on $[1,\\infty)\\Rightarrow f$ interval-integrable on $[a,b]$, $1\\le a\\le b$."
+    },
+    {
+      "id": "bounds",
+      "title": "Nonnegativity and the uniform bound f 1",
+      "startLine": 69,
+      "endLine": 90,
+      "summary": "defect_nonneg: 0 ≤ D f n from AntitoneOn.integral_le_sum. defect_le: D f n ≤ f 1, subtracting the lower Riemann sum (≤ ∫ by AntitoneOn.sum_le_integral) and telescoping ∑ f(1+i) − ∑ f(1+(i+1)) = f 1 − f(1+n), with f(1+n) ≥ 0.",
+      "mathContext": "$0 \\le D_f(n) \\le f(1)$; telescoped remainder $= f(1) - f(1+n)$."
+    },
+    {
+      "id": "monotone",
+      "title": "Per-cell estimate and monotonicity",
+      "startLine": 92,
+      "endLine": 120,
+      "summary": "integral_cell_le: ∫_{1+n}^{1+n+1} f ≤ f(1+n) on a single unit interval. defect_le_succ: the increment D f (n+1) − D f n = f(1+n) − ∫ over the cell ≥ 0, via additivity of the interval integral; defect_monotone upgrades to Monotone (D f).",
+      "mathContext": "$D_f(n{+}1) - D_f(n) = f(1+n) - \\int_{1+n}^{1+n+1} f \\ge 0$."
+    },
+    {
+      "id": "convergence",
+      "title": "Convergence to the generalized Euler constant",
+      "startLine": 122,
+      "endLine": 156,
+      "summary": "defect_bddAbove packages f 1 as an upper bound. generalizedEuler f := ⨆ n, D f n; tendsto_defect gives D f → generalizedEuler f (tendsto_atTop_ciSup). generalizedEuler_nonneg / generalizedEuler_le / generalizedEuler_mem_Icc place the limit in [0, f 1].",
+      "mathContext": "$D_f \\to \\gamma_f := \\sup_n D_f(n) \\in [0, f(1)]$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Euler–Mascheroni convergence of the parent entry is generalized from f = 1/x to every antitone, nonnegative summand f on [1,∞). The defect D f n = (∑_{i<n} f(1+i)) − ∫₁^{1+n} f is nonnegative, uniformly bounded by f 1, and monotone non-decreasing, hence convergent to the generalized Euler constant generalizedEuler f = ⨆ n, D f n, which lies in [0, f 1]. 13 theorems, 2 definitions, 156 lines, 0 sorries, 0 axioms.",
+    "implications": "Isolates exactly what the harmonic case used: antitonicity for the integral-test sandwich and nonnegativity for the remainder bound. Every antitone nonnegative series therefore carries a well-defined generalized Euler constant bounded by its leading term, with the classical γ = generalizedEuler (1/x) as the running example.",
+    "openQuestions": [
+      "Identify generalizedEuler (fun x => 1/x) with Mathlib's Real.eulerMascheroniConstant, closing the loop with the parent's γ via ∫₁^{1+n} 1/x = log(1+n)",
+      "Drop nonnegativity: for antitone f with f → L, show ∑_{k≤n} f(k) − ∫₁^n f − (n)L-type corrections converge, or characterize when the defect converges for antitone f of arbitrary sign"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Havil, Julian",
+      "title": "Gamma: Exploring Euler's Constant",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "note": "Book-length account of γ = lim(Hₙ − log n) and the monotone-defect convergence argument, here generalized to arbitrary antitone summands."
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Mathematical Analysis (2nd ed.)",
+      "year": "1974",
+      "venue": "Addison-Wesley",
+      "note": "Integral test (Theorem 8.23) comparing ∑f(n) with ∫f — the sum/integral sandwich this entry uses to produce the generalized Euler constant."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Analysis.SumIntegralComparisons and Mathlib.Topology.Order.MonotoneConvergence",
+      "year": "2024",
+      "venue": "Lean 4 mathematical library (mathlib4)",
+      "note": "Source of AntitoneOn.integral_le_sum / AntitoneOn.sum_le_integral and tendsto_atTop_ciSup, the two engines of this proof."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "antitone-integral-sum-comparison-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry: proved the harmonic defect Hₙ − log(n+1) → γ for f = 1/x and asked (open question 2) for the analogous general-antitone defect. This entry answers that, with the harmonic case as the specialization f = 1/x."
+    }
+  ],
+  "sorries": null
+}

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/annotations.json
@@ -1,0 +1,150 @@
+[
+  {
+    "id": "ann-overview",
+    "title": "From One Line to a Subspace",
+    "type": "concept",
+    "startLine": 1,
+    "endLine": 52,
+    "mathContext": "The parent (cauchy-schwarz-oq-01-oq-02-oq-01) proved that projecting onto a single line span{v} is the rank-one map x ↦ ⟪e,x⟫•e and is a genuine orthogonal projector. This file generalizes to a k-dimensional subspace S = span(range e) spanned by a finite orthonormal family: the projection onto S is the sum of the rank-one projectors, P_S x = ∑ i ⟪e i, x⟫ • e i, and its squared norm is the sum of squared coordinates (Parseval on S).",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthogonal projection",
+      "resolution of the identity",
+      "Parseval's identity",
+      "Bessel's inequality",
+      "orthonormal basis"
+    ],
+    "prerequisites": [
+      "inner product spaces over an RCLike field",
+      "orthonormal families",
+      "orthogonal projection onto a complete subspace"
+    ],
+    "content": "The finite-rank orthogonal projection is the sum of the one-line projectors over an orthonormal basis of the subspace — a finite-rank resolution of the identity P_S = ∑ i e_i e_i^*.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 52 }
+  },
+  {
+    "id": "ann-completeness",
+    "title": "Why the Projection Exists Without Assuming E Complete",
+    "type": "technique",
+    "startLine": 54,
+    "endLine": 66,
+    "mathContext": "Mathlib's orthogonalProjection/starProjection require the subspace to have a HasOrthogonalProjection instance, which follows from completeness. Here S = span(range e) is spanned by finitely many vectors, so FiniteDimensional.span_of_finite (applied to Set.finite_range e) makes it finite-dimensional, and FiniteDimensional.complete over the complete field 𝕜 makes it complete. These are registered as instances so the projection elaborates automatically — no completeness hypothesis on the ambient E is needed.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "finite-dimensional subspaces",
+      "completeness",
+      "typeclass instances"
+    ],
+    "prerequisites": [
+      "finite-dimensional vector spaces",
+      "completeness of finite-dimensional spaces over a complete field"
+    ],
+    "content": "Finite-dimensionality of the span, not completeness of E, is what makes the orthogonal projection well defined.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 54, "endLine": 66 }
+  },
+  {
+    "id": "ann-coordinates",
+    "title": "Coordinate Preservation",
+    "type": "concept",
+    "startLine": 79,
+    "endLine": 90,
+    "mathContext": "For an orthonormal family, Orthonormal.inner_right_fintype gives ⟪e j, ∑ i l i • e i⟫ = l j — the inner product with a basis vector picks out its coefficient. With l i = ⟪e i, x⟫ this yields ⟪e j, subProj e x⟫ = ⟪e j, x⟫: the projection has exactly the same coordinates along each e j as x.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthonormality",
+      "coordinate extraction",
+      "Kronecker delta"
+    ],
+    "prerequisites": [
+      "orthonormal families",
+      "linearity of the inner product"
+    ],
+    "content": "The projection keeps x's coordinates along the basis; the residual carries everything orthogonal to S.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 79, "endLine": 90 }
+  },
+  {
+    "id": "ann-residual-span",
+    "title": "From Basis-Orthogonality to Subspace-Orthogonality",
+    "type": "technique",
+    "startLine": 92,
+    "endLine": 114,
+    "mathContext": "Coordinate preservation gives ⟪e j, x − subProj e x⟫ = 0 for each basis vector. To identify subProj with the orthogonal projection we need the residual orthogonal to ALL of S, not just to each e j. Since w ↦ ⟪x − subProj e x, w⟫ is 𝕜-linear and vanishes on the spanning set range e (using conjugate symmetry inner_eq_zero_symm), Submodule.span_induction extends the vanishing to every w ∈ S.",
+    "significance": "key",
+    "relatedConcepts": [
+      "span induction",
+      "linear functionals",
+      "orthogonal complement"
+    ],
+    "prerequisites": [
+      "spans and linear combinations",
+      "conjugate symmetry of the inner product"
+    ],
+    "content": "A linear functional vanishing on a spanning set vanishes on the whole span — this promotes basis-orthogonality of the residual to subspace-orthogonality.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 92, "endLine": 114 }
+  },
+  {
+    "id": "ann-headline",
+    "title": "The Sum-of-Rank-One-Projectors Identity",
+    "type": "concept",
+    "startLine": 115,
+    "endLine": 133,
+    "mathContext": "By the uniqueness of orthogonal projection (Submodule.eq_starProjection_of_mem_of_inner_eq_zero: if v ∈ K and x − v ⊥ K then P_K x = v), the two facts subProj e x ∈ S and residual ⊥ S identify subProj e x with S.starProjection x. This is the operator identity P_S = ∑ i e_i e_i^*, the finite-rank generalization of the parent's single rank-one projector.",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniqueness of orthogonal projection",
+      "resolution of the identity",
+      "rank-one operators"
+    ],
+    "prerequisites": [
+      "orthogonal projection characterization"
+    ],
+    "content": "The headline identity: Mathlib's orthogonal projection onto S is exactly the sum of the rank-one projectors over the orthonormal basis.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 115, "endLine": 133 }
+  },
+  {
+    "id": "ann-parseval",
+    "title": "Parseval Equality as Attained Bessel",
+    "type": "concept",
+    "startLine": 134,
+    "endLine": 153,
+    "mathContext": "Expanding ‖subProj e x‖² = re ⟪subProj, subProj⟫ with Orthonormal.inner_sum collapses the double sum to the diagonal ∑ i conj⟪e i,x⟫·⟪e i,x⟫; RCLike.conj_mul turns each term into ‖⟪e i,x⟫‖². The result ‖P_S x‖² = ∑ i ‖⟪e i, x⟫‖² is the equality case of Bessel's inequality restricted to S, and Bessel's bound ‖P_S x‖² ≤ ‖x‖² follows immediately from Orthonormal.sum_inner_products_le.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Parseval's identity",
+      "Bessel's inequality",
+      "orthonormal norm expansion"
+    ],
+    "prerequisites": [
+      "norm via inner product",
+      "orthonormal double-sum collapse"
+    ],
+    "content": "The squared projection norm is exactly the sum of squared coordinate moduli — the sharp, attained form of Bessel's inequality on the subspace.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 134, "endLine": 153 }
+  },
+  {
+    "id": "ann-recovery",
+    "title": "k = 1 Recovers the Parent",
+    "type": "concept",
+    "startLine": 168,
+    "endLine": 192,
+    "mathContext": "For a single-vector orthonormal family (k = 1), the sum ∑ i ⟪e i, x⟫ • e i has one term, so subProj e x = ⟪e 0, x⟫ • e 0 — exactly the parent's rank-one projector onto the line span{e 0}. Together with idempotency (P²=P) and reconstruction (P + (1−P) = id), this exhibits the parent as the one-term special case of the finite-rank identity.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "rank-one projector",
+      "specialization",
+      "idempotent operators"
+    ],
+    "prerequisites": [
+      "the parent's rank-one projector"
+    ],
+    "content": "The single-line projector of the parent entry is the k=1 term of this sum-of-projectors identity.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+    "range": { "startLine": 168, "endLine": 192 }
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+  "title": "Projection onto a Subspace as a Sum of Rank-One Projectors",
+  "slug": "cauchy-schwarz-oq-01-oq-02-oq-01-oq-03",
+  "description": "A verified (0-axiom, 0-sorry) follow-up to \"One Gram-Schmidt Step is an Orthogonal Projector\". The parent proved that projecting onto a single line span{v} is the rank-one map x ↦ ⟪e,x⟫•e. This file proves the finite-rank generalization: for a finite orthonormal family e : Fin k → E spanning S = span(range e), the orthogonal projection onto S is the sum of the rank-one projectors, P_S x = ∑ i, ⟪e i, x⟫ • e i (identified with Mathlib's starProjection/orthogonalProjection), together with the Parseval equality on the subspace ‖P_S x‖² = ∑ i ‖⟪e i, x⟫‖² (the attained case of Bessel's inequality). It also derives residual orthogonality to all of S, idempotency, reconstruction, and the k=1 recovery of the parent's rank-one projector.",
+  "meta": {
+    "author": "Research formalization 2026 (researcher-9)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Parseval%27s_identity",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean",
+    "tags": [
+      "linear-algebra",
+      "inner-product-spaces",
+      "orthogonal-projection",
+      "parseval",
+      "bessel",
+      "gram-schmidt"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 192,
+    "assumptions": "None. Every theorem is verified over an arbitrary RCLike field 𝕜 and inner product space E with zero axioms and zero sorries (only foundational propext/Classical.choice/Quot.sound). The subspace S = span(range e) is finite-dimensional, hence complete, so orthogonalProjection is well defined with no completeness hypothesis on E.",
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "The parent chain formalizes the orthogonal-projection picture underlying Gram-Schmidt and Cauchy-Schwarz. The grandparent (cauchy-schwarz-oq-01-oq-02) gave one Gram-Schmidt step via Cauchy-Schwarz (bounded coefficient, orthogonal residual, Pythagoras); its child (cauchy-schwarz-oq-01-oq-02-oq-01) proved that a single step is an orthogonal projector onto a line span{v}. That entry explicitly left open whether the projector identity extends to a finite-dimensional subspace, expressed as a sum of rank-one projectors over an orthonormal basis. This file settles that question: the orthogonal projection onto S = span(range e) is exactly ∑ i ⟪e i, ·⟫ • e i.",
+    "problemStatement": "For a finite orthonormal family e : Fin k → E spanning S, is the orthogonal projection onto S the sum of the rank-one projectors x ↦ ⟪e i, x⟫ • e i, and does the squared projection norm equal the sum of squared coordinate moduli (Parseval equality on S)?",
+    "text": "Verified sum-of-rank-one-projectors identity and subspace Parseval equality for the orthogonal projection onto the span of a finite orthonormal family, over an arbitrary RCLike inner product space.",
+    "proofStrategy": "Self-contained in namespace CauchySchwarzOQ01OQ02OQ01OQ03. Define subProj e x = ∑ i, ⟪e i, x⟫ • e i directly. Prove it equals Mathlib's projection by the uniqueness characterization Submodule.eq_starProjection_of_mem_of_inner_eq_zero: (1) subProj e x ∈ S (a sum of scalar multiples of the e i), and (2) the residual x − subProj e x is orthogonal to all of S. For (2), orthonormality gives ⟪e j, subProj e x⟫ = ⟪e j, x⟫ (Orthonormal.inner_right_fintype), so ⟪e j, x − subProj e x⟫ = 0 for each basis vector, extended to the whole span by span_induction on the linear functional w ↦ ⟪x − subProj e x, w⟫. Finite-dimensionality of S (FiniteDimensional.span_of_finite on Set.finite_range) supplies completeness and hence the projection instance. Parseval follows from Orthonormal.inner_sum expanding ⟪subProj, subProj⟫ = ∑ i conj⟪e i,x⟫·⟪e i,x⟫ and RCLike.conj_mul; Bessel's inequality is then a corollary via Orthonormal.sum_inner_products_le.",
+    "keyInsights": [
+      "**Sum of rank-one projectors**: the orthogonal projection onto S = span(range e) is the operator ∑ i e_i e_i^*, i.e. P_S x = ∑ i ⟪e i, x⟫ • e i — a finite-rank resolution of the identity, the k-fold sum of the parent's single rank-one projector.",
+      "**Coordinates are preserved**: for an orthonormal family, ⟪e j, P_S x⟫ = ⟪e j, x⟫, so P_S x has the same coordinates along each e j as x itself; the residual carries the rest.",
+      "**Residual ⊥ subspace, not just basis**: proving ⟪e j, residual⟫ = 0 for each j extends to ⟪residual, w⟫ = 0 for all w ∈ S because w ↦ ⟪residual, w⟫ is linear and vanishes on a spanning set (span_induction).",
+      "**Parseval as attained Bessel**: ‖P_S x‖² = ∑ i ‖⟪e i, x⟫‖² is the equality case of Bessel's inequality ‖P_S x‖² ≤ ‖x‖²; the cross terms collapse to the diagonal by orthonormality.",
+      "**No completeness hypothesis on E**: S is finite-dimensional (spanned by finitely many vectors), hence complete over the RCLike field 𝕜, so orthogonalProjection exists regardless of whether E itself is complete."
+    ],
+    "prerequisites": [
+      "Inner product spaces over an RCLike field",
+      "Orthonormal families and Bessel's inequality",
+      "Orthogonal projection onto a complete subspace (Mathlib starProjection / orthogonalProjection)",
+      "Finite-dimensional spans and completeness",
+      "Parseval's identity / resolution of the identity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "instances",
+      "title": "Finite-dimensional span is complete",
+      "startLine": 54,
+      "endLine": 66,
+      "summary": "The span of a finite family is finite-dimensional (span_of_finite) and hence complete, so the orthogonal projection exists with no hypothesis on E.",
+      "mathContext": "$S = \\operatorname{span}(\\operatorname{range} e)$ is finite-dimensional over the complete field $\\mathbb{K}$, hence complete."
+    },
+    {
+      "id": "definition",
+      "title": "The finite-rank projection",
+      "startLine": 68,
+      "endLine": 90,
+      "summary": "subProj e x = ∑ i, ⟪e i, x⟫ • e i, its membership in S, and the coordinate-preservation lemma ⟪e j, subProj e x⟫ = ⟪e j, x⟫.",
+      "mathContext": "$\\mathrm{subProj}\\,e\\,x = \\sum_i \\langle e_i, x\\rangle\\, e_i \\in S$ with $\\langle e_j, \\mathrm{subProj}\\,e\\,x\\rangle = \\langle e_j, x\\rangle$."
+    },
+    {
+      "id": "residual",
+      "title": "Residual orthogonality",
+      "startLine": 92,
+      "endLine": 114,
+      "summary": "The residual x − subProj e x is orthogonal to each e j and, by span_induction, to the whole subspace S.",
+      "mathContext": "$\\langle e_j, x - \\mathrm{subProj}\\,e\\,x\\rangle = 0$ for all $j$, hence $\\langle x - \\mathrm{subProj}\\,e\\,x, w\\rangle = 0$ for all $w \\in S$."
+    },
+    {
+      "id": "headline",
+      "title": "Sum-of-rank-one-projectors identity",
+      "startLine": 115,
+      "endLine": 133,
+      "summary": "The headline: S.starProjection x = subProj e x (and the orthogonalProjection coercion form), via the uniqueness of orthogonal projection.",
+      "mathContext": "$P_S x = \\sum_i \\langle e_i, x\\rangle\\, e_i$, the operator identity $P_S = \\sum_i e_i e_i^{*}$."
+    },
+    {
+      "id": "parseval",
+      "title": "Parseval / Bessel equality",
+      "startLine": 134,
+      "endLine": 153,
+      "summary": "‖subProj e x‖² = ∑ i ‖⟪e i, x⟫‖² (Parseval on S) with the Bessel bound ‖subProj e x‖² ≤ ‖x‖² as a corollary.",
+      "mathContext": "$\\lVert P_S x\\rVert^2 = \\sum_i |\\langle e_i, x\\rangle|^2 \\le \\lVert x\\rVert^2$."
+    },
+    {
+      "id": "projector-axioms",
+      "title": "Idempotency, reconstruction, k=1 recovery",
+      "startLine": 154,
+      "endLine": 192,
+      "summary": "Idempotency P²=P, reconstruction P + (1−P) = id, the k=1 recovery of the parent's rank-one projector, and the capstone bundle.",
+      "mathContext": "$P_S^2 = P_S$, $P_S + (1-P_S) = \\mathrm{id}$, and for $k=1$, $P_S x = \\langle e_0, x\\rangle\\, e_0$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file verifies, with zero axioms and zero sorries, that the orthogonal projection onto the span of a finite orthonormal family is the sum of the rank-one projectors over that family, P_S x = ∑ i ⟪e i, x⟫ • e i, and that the squared projection norm equals the sum of squared coordinate moduli (the Parseval equality on the subspace, the attained case of Bessel's inequality). It also records residual orthogonality to the whole subspace, idempotency, reconstruction, and the k=1 recovery of the parent's rank-one projector.",
+    "implications": "This is the exact step that turns the rank-one Gram-Schmidt/Cauchy-Schwarz picture into the general theory of orthogonal projection: the sum-of-rank-one-projectors formula is a finite-rank resolution of the identity, and the subspace Parseval equality is the sharp form of Bessel's inequality. Concretely it is the analytic backbone of the QR decomposition and of least-squares approximation, where the best approximation of x from S is ∑ i ⟪e i, x⟫ • e i.",
+    "openQuestions": [
+      "Can the sum-of-rank-one-projectors identity be assembled into a full QR decomposition of a finite family of vectors?",
+      "Does the Parseval equality extend to a countable orthonormal basis of a separable Hilbert space (the l² case) as a limit of the finite-rank identities?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: one Gram-Schmidt step is a rank-one orthogonal projector onto a line span{v}. This file sums k of them to project onto a k-dimensional subspace, and its k=1 case recovers the parent's rank-one projector; it settles the parent's third open question."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-02",
+      "relationship": "builds-on",
+      "description": "Grandparent: Gram-Schmidt via Cauchy-Schwarz (bounded coefficient, orthogonal residual, Pythagoras)."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "builds-on",
+      "description": "The base inner-product inequality underlying Bessel's inequality and the Parseval equality."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Parseval, M.-A.",
+      "title": "Mémoire sur les séries et sur l'intégration complète d'une équation aux différences partielles linéaires du second ordre, à coefficients constants",
+      "year": "1806",
+      "venue": "Mémoires présentés à l'Institut des Sciences, Lettres et Arts",
+      "note": "Origin of Parseval's identity"
+    },
+    {
+      "authors": "Halmos, P. R.",
+      "title": "Finite-Dimensional Vector Spaces",
+      "year": "1958",
+      "venue": "Springer",
+      "note": "Orthogonal projection onto a subspace and resolution of the identity"
+    },
+    {
+      "authors": "Axler, S.",
+      "title": "Linear Algebra Done Right",
+      "year": "2015",
+      "venue": "Springer, 3rd ed.",
+      "note": "Orthonormal bases, orthogonal projections, and best approximation"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Projection.Basic",
+      "Mathlib.Analysis.InnerProductSpace.Orthonormal",
+      "Mathlib.Analysis.RCLike.Basic",
+      "Mathlib.LinearAlgebra.FiniteDimensional.Defs",
+      "Mathlib.Topology.Algebra.Module.FiniteDimension",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "CauchySchwarzOQ01OQ02OQ01OQ03",
+    "lineCount": 192,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "path": "Proofs/CauchySchwarzOQ01OQ02OQ01OQ03.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of the parent entry `amgm-inequality-oq-05-oq-02` (*The Equality Case of the Weighted AM-GM Inequality*):

> *Specialise to equal weights wᵢ = 1/n to state the classical AM-GM equality case (n-th root of a product equals the average iff all terms are equal) as a standalone corollary indexed over Fin n.*

This entry delivers the classical (unweighted) AM-GM statement in canonical form over `Fin n` — geometric mean `(∏ xᵢ)^{1/n}` vs arithmetic mean `(∑ xᵢ)/n` — with both the inequality and its sharp equality case.

## Results (all VERIFIED, 0-axiom)

| Theorem | Statement |
|---|---|
| `classical_amgm_le` | `(∏ xᵢ)^{1/n} ≤ (∑ xᵢ)/n` for nonnegative xᵢ |
| `classical_amgm_eq_iff` | equality `↔ ∀ i j, xᵢ = xⱼ` for positive xᵢ |
| `classical_amgm_lt_of_not_const` | strict gap when some xᵢ ≠ xⱼ |
| `classical_amgm_eq_of_const` | trivial constant direction |

## Method

- **Inequality**: specialise Mathlib's `Real.geom_mean_le_arith_mean` to uniform weights `≡ 1` (there `∑ 1 = n`, so the exponent `(∑ w)⁻¹` becomes `1/n`).
- **Equality case** (not packaged in Mathlib): reuse the parent's strict-concavity-of-log engine — reproduced as private scaffolding so the file is self-contained — at weights `wᵢ = 1/n`, then convert `∏ (xᵢ)^{1/n}` into `(∏ xᵢ)^{1/n}` via `Real.finset_prod_rpow` and `∑ (1/n)·xᵢ` into `(∑ xᵢ)/n` via `Finset.mul_sum`.
- **Strict form**: `lt_of_le_of_ne` combining the two.

## Verification

- Builds against Mathlib `v4.26.0` (`lake env lean`), 0 sorries, 164 lines, 9 theorems / 0 definitions.
- `#print axioms` on all four public theorems reports exactly `[propext, Classical.choice, Quot.sound]` — 0 axioms beyond Lean's foundational three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)