### PR TITLE
Enrich Fibonacci linear sums (oq-06)

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-06/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06/meta.json
@@ -36,6 +36,11 @@
         "theorem": "Finset.sum_range_one",
         "description": "∑ i ∈ range 1, f i = f 0 — evaluates the singleton base-case sum to its only term",
         "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "linear_combination",
+        "description": "Closes the succ step of fib_weighted_sum after zify moves the goal into ℤ: the new goal is an integer-linear consequence of the (zified) induction hypothesis, so linear_combination ih discharges it. Needed because the weighted summand i·Fᵢ makes the recurrence bookkeeping nonlinear in ℕ subtraction.",
+        "module": "Mathlib.Tactic.LinearCombination"
       }
     ],
     "originalContributions": [


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-06`.

## Change
- **Added `linear_combination` to `meta.mathlibDependencies`**: the crux tactic closing `fib_weighted_sum`'s successor step (after `zify` moves the goal into ℤ), which was the one notable tactic missing from the dependency list.

## Already rich (left in place)
- 3 sections covering all 70 lines, 4 annotations with mathContext, 4 keyInsights, complete overview and conclusion, 3 crossReferences with descriptions, 3 references, 3 prior mathlibDependencies.

## Guardrails
- meta.json within the 60 KB cap; JSON validated and processed by the data-build. `status: verified`, 0-axiom / 0-sorry accurately reflected.