### PR TITLE
research(inverse-galois-oq-04-oq-01): Kummer–Dedekind Step-1 brick [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/DedekindKummerStep1.lean
+++ b/proofs/Proofs/DedekindKummerStep1.lean
@@ -1,0 +1,95 @@
+import Mathlib
+
+/-!
+# Kummer–Dedekind Step 1 brick for inertia degrees (inverse-Galois A₅, OQ-04)
+
+This file isolates the *first* of the three abstract steps in the ongoing effort to
+discharge the last assumption of `Proofs.InverseGaloisA5`,
+
+```
+axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal     -- InverseGaloisA5.lean:309
+```
+
+The companion file `Proofs.InverseGaloisA5DedekindInstantiation` reduces that axiom to the
+single sharp arithmetic fact `3 ∣ Ideal.inertiaDegIn (7) (𝓞 q.SplittingField)` at an
+unramified prime over `7`, and its "residual gap" note spells out a three-step route:
+
+1. **Kummer–Dedekind** — the prime of `𝓞 ℚ(α)` matching an *irreducible cubic factor* of
+   `q mod 7` has inertia degree `3`;
+2. **inertia-degree multiplicativity in a tower** — lifts that to a prime of the splitting
+   field;
+3. **Galois uniformity** — spreads it to all primes over `7`, giving `3 ∣ inertiaDegIn (7)`.
+
+Steps **2 and 3** were packaged, `0`-axiom, in `Proofs.DedekindInertiaTower`
+(`inertiaDeg_dvd_inertiaDegIn`). This file packages step **1** as a single, fully general,
+`0`-axiom existence/divisibility statement about an *arbitrary* number field `K`, algebraic
+integer `θ`, and rational prime `p` not dividing the Kummer–Dedekind exponent of `θ`:
+
+* `exists_prime_inertiaDeg_eq_natDegree`: every monic irreducible factor `Q` of
+  `minpoly ℤ θ` modulo `p` is matched by a maximal prime `P` of `𝓞 K` over `(p)` with
+  `inertiaDeg (p) P = Q.natDegree`;
+* `exists_prime_dvd_inertiaDeg_of_dvd_natDegree`: the divisibility shape the A₅ argument
+  consumes — if `d ∣ Q.natDegree`, then some prime `P` over `(p)` has `d ∣ inertiaDeg (p) P`.
+
+Feeding such a `P` into `DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg` promotes
+`d ∣ inertiaDeg (p) P` all the way to `d ∣ inertiaDegIn (p)` on the Galois splitting field.
+Together with the already-verified arithmetic factorization
+`Proofs.InverseGaloisA5DedekindMod7` (cubic factor of `q mod 7`, degree `3`), the two
+bricks reduce the residual gap to the tower/top-prime *wiring* alone. Only the ordinary
+foundational axioms (`propext`, `Classical.choice`, `Quot.sound`) are used — no `sorry`,
+no new `axiom`.
+
+The whole content is a thin, reusable repackaging of Mathlib's
+`NumberField.Ideal.primesOverSpanEquivMonicFactorsMod` bijection and its residual-degree
+computation `inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply'`, exposed in the
+divisibility currency the inverse-Galois–via–Frobenius argument actually needs.
+-/
+
+open Polynomial NumberField Ideal RingOfIntegers
+
+namespace DedekindKummerStep1
+
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {p : ℕ} [Fact (Nat.Prime p)]
+
+/-- **Kummer–Dedekind Step 1 (existence form).** Let `K` be a number field, `θ` an algebraic
+integer of `K`, and `p` a rational prime that does not divide the Kummer–Dedekind exponent
+of `θ` (equivalently, `p` does not divide the conductor `[𝓞 K : ℤ[θ]]`). Then every monic
+irreducible factor `Q` of `minpoly ℤ θ` modulo `p` is matched by a maximal prime `P` of
+`𝓞 K` lying over the rational prime `(p)`, whose inertia degree equals the degree of `Q`.
+
+This is the concrete splitting datum consumed by the inverse-Galois argument: an
+irreducible degree-`d` factor mod `p` produces a prime of inertia degree exactly `d`.
+
+The witness is `(primesOverSpanEquivMonicFactorsMod hp).symm ⟨Q, hQ⟩`; primality and
+lying-over are its `primesOver`-membership components, maximality is
+`Ideal.isMaximal_of_mem_primesOver`, and the inertia-degree computation is Mathlib's
+`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply'`. -/
+theorem exists_prime_inertiaDeg_eq_natDegree
+    (hp : ¬ p ∣ RingOfIntegers.exponent θ) {Q : (ZMod p)[X]}
+    (hQ : Q ∈ RingOfIntegers.monicFactorsMod θ p) :
+    ∃ P : Ideal (𝓞 K), P.IsMaximal ∧ P.LiesOver (span {(p : ℤ)}) ∧
+      inertiaDeg (span {(p : ℤ)}) P = Q.natDegree := by
+  refine ⟨((NumberField.Ideal.primesOverSpanEquivMonicFactorsMod hp).symm ⟨Q, hQ⟩ :
+      Ideal (𝓞 K)), ?_, ?_,
+      NumberField.Ideal.inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply' hp hQ⟩
+  · exact Ideal.isMaximal_of_mem_primesOver
+      ((NumberField.Ideal.primesOverSpanEquivMonicFactorsMod hp).symm ⟨Q, hQ⟩).2
+  · exact ((NumberField.Ideal.primesOverSpanEquivMonicFactorsMod hp).symm ⟨Q, hQ⟩).2.2
+
+/-- **Kummer–Dedekind Step 1 (divisibility form).** If a natural number `d` divides the
+degree of a monic irreducible factor `Q` of `minpoly ℤ θ` modulo `p` (with `p` not dividing
+the exponent of `θ`), then some maximal prime `P` of `𝓞 K` over `(p)` has
+`d ∣ inertiaDeg (p) P`.
+
+This is exactly the hypothesis of `DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg`:
+in the A₅ application `d = 3` and `Q` is the irreducible cubic factor of `q mod 7`, so the
+two bricks compose to `3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)`. -/
+theorem exists_prime_dvd_inertiaDeg_of_dvd_natDegree
+    (hp : ¬ p ∣ RingOfIntegers.exponent θ) {Q : (ZMod p)[X]}
+    (hQ : Q ∈ RingOfIntegers.monicFactorsMod θ p) {d : ℕ} (hd : d ∣ Q.natDegree) :
+    ∃ P : Ideal (𝓞 K), P.IsMaximal ∧ P.LiesOver (span {(p : ℤ)}) ∧
+      d ∣ inertiaDeg (span {(p : ℤ)}) P := by
+  obtain ⟨P, hPmax, hPlo, hPdeg⟩ := exists_prime_inertiaDeg_eq_natDegree hp hQ
+  exact ⟨P, hPmax, hPlo, hPdeg ▸ hd⟩
+
+end DedekindKummerStep1

--- a/src/data/proofs/inverse-galois-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-01/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-header-oq0401",
+    "proofId": "inverse-galois-oq-04-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 62
+    },
+    "type": "concept",
+    "title": "Step 1 of the three-step Kummer–Dedekind route",
+    "content": "The docstring situates this file within OQ-04's plan to eliminate the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` (InverseGaloisA5.lean:309). The companion `InverseGaloisA5DedekindInstantiation` reduces that axiom to the arithmetic fact `3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)`, provable by a three-step route: (1) Kummer–Dedekind turns an irreducible cubic factor of q mod 7 into a prime of 𝓞 ℚ(α) of inertia degree 3; (2) inertia-degree tower multiplicativity lifts it to the splitting field; (3) Galois uniformity spreads it to all primes over 7. The sibling entry `Proofs.DedekindInertiaTower` machine-checked steps (2)–(3); this file packages step (1) in full generality, for an arbitrary number field K, algebraic integer θ, and prime p not dividing the Kummer–Dedekind exponent of θ, using only foundational axioms."
+  },
+  {
+    "id": "ann-existence-oq0401",
+    "proofId": "inverse-galois-oq-04-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 84
+    },
+    "type": "theorem",
+    "title": "exists_prime_inertiaDeg_eq_natDegree — splitting datum ⇒ inertia degree",
+    "content": "The main theorem: for a number field K, an algebraic integer θ ∈ 𝓞 K, and a rational prime p with p ∤ exponent θ (equivalently p ∤ the conductor [𝓞 K : ℤ[θ]]), every monic irreducible factor Q of minpoly ℤ θ modulo p is matched by a maximal prime P of 𝓞 K lying over (p) with inertiaDeg (p) P = Q.natDegree. The witness is `(primesOverSpanEquivMonicFactorsMod hp).symm ⟨Q, hQ⟩`, the inverse image of Q under Mathlib's Kummer–Dedekind bijection between primes over (p) and monic factors of minpoly θ mod p. Primality and lying-over are the `primesOver`-membership components `.2.1` / `.2.2`; maximality is `Ideal.isMaximal_of_mem_primesOver`; and the inertia-degree value is Mathlib's `inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply'`, which computes it as exactly the degree of Q. In the A₅ application θ = α (a root of q), p = 7, and Q is the irreducible cubic factor of q mod 7, so P has inertia degree 3."
+  },
+  {
+    "id": "ann-divisibility-oq0401",
+    "proofId": "inverse-galois-oq-04-oq-01",
+    "range": {
+      "startLine": 86,
+      "endLine": 95
+    },
+    "type": "theorem",
+    "title": "exists_prime_dvd_inertiaDeg_of_dvd_natDegree — the composable form",
+    "content": "The divisibility corollary, phrased in the currency the OQ-04 tower brick consumes: if a natural number d divides Q.natDegree, then some maximal prime P of 𝓞 K over (p) has d ∣ inertiaDeg (p) P. The proof `obtain`s the prime and its inertia-degree equality from the existence theorem and rewrites by the hypothesis d ∣ Q.natDegree. Feeding such a P into `DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg` promotes d ∣ inertiaDeg (p) P to d ∣ inertiaDegIn (p) on the Galois splitting field — so with d = 3 and Q the cubic factor of q mod 7, the two bricks compose to 3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)."
+  }
+]

--- a/src/data/proofs/inverse-galois-oq-04-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-01/meta.json
@@ -1,0 +1,130 @@
+{
+  "id": "inverse-galois-oq-04-oq-01",
+  "title": "Inverse Galois OQ-04-01: The Kummer–Dedekind Step-1 Brick (Splitting Datum ⇒ Inertia Degree)",
+  "slug": "inverse-galois-oq-04-oq-01",
+  "description": "Answers the first open question of the OQ-04 entry — 'Formalize the remaining Kummer–Dedekind step (step 1): the prime matching an irreducible factor of a polynomial mod p has that factor's degree as its inertia degree.' For an arbitrary number field K, an algebraic integer θ, and a rational prime p not dividing the Kummer–Dedekind exponent (conductor index) of θ, every monic irreducible factor Q of minpoly ℤ θ modulo p is matched by a maximal prime P of 𝓞 K lying over (p) with inertiaDeg (p) P = deg Q, and — in divisibility form — d ∣ deg Q yields a prime with d ∣ inertiaDeg (p) P. This is the missing Step 1 that composes with the OQ-04 tower brick (steps 2–3) to reduce the last A₅ realizability axiom three_dvd_gal_card to the purely arithmetic factorization of q mod 7. Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "number-theory",
+      "algebraic-number-theory",
+      "inverse-galois",
+      "kummer-dedekind",
+      "inertia-degree",
+      "dedekind-domain"
+    ],
+    "proofRepoPath": "Proofs/DedekindKummerStep1.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "prerequisites": [
+      "Algebraic number theory (rings of integers, prime factorization in extensions, inertia degree, the conductor of an order)",
+      "The Kummer–Dedekind theorem (factorization of a rational prime read off from the factorization of a minimal polynomial modulo p)",
+      "Polynomials over finite fields (monic irreducible factors, degrees)"
+    ],
+    "assumptions": "None beyond the ordinary foundational axioms of Lean/Mathlib (propext, Classical.choice, Quot.sound). No `axiom` declarations and no `sorry`: both theorems are derived from Mathlib's `NumberField.Ideal.primesOverSpanEquivMonicFactorsMod` bijection and its residual-degree computation `inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply'`, together with `Ideal.isMaximal_of_mem_primesOver`. No `decide` or `native_decide` is used. This entry does not by itself close the A₅ realizability axiom `three_dvd_gal_card`; it verifies Step 1 of the three-step Kummer–Dedekind route and, combined with the sibling entry inverse-galois-oq-04 (steps 2–3, the tower + Galois-uniformity brick), reduces the residual gap to the tower/top-prime wiring plus the already-verified arithmetic factorization of q mod 7.",
+    "relatedProblems": [
+      {
+        "id": "inverse-galois-oq-04",
+        "relationship": "Parent entry; this brick supplies Step 1 (Kummer–Dedekind) complementing that entry's Steps 2–3 (inertia tower + Galois uniformity)"
+      },
+      {
+        "id": "inverse-galois-a5",
+        "relationship": "The A₅ realization whose sole remaining assumption three_dvd_gal_card the Step-1 + tower bricks are designed to help discharge"
+      },
+      {
+        "id": "inverse-galois",
+        "relationship": "Grandparent entry stating the Inverse Galois Problem; OQ-04 is its fourth open question"
+      }
+    ],
+    "lineCount": 95,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "The Inverse Galois Problem asks whether every finite group occurs as $\\mathrm{Gal}(K/\\mathbb{Q})$. The alternating group $A_5$ — the smallest non-solvable group — is realizable over $\\mathbb{Q}$, and the Lean development `Proofs.InverseGaloisA5` formalizes this down to one remaining assumption, `three_dvd_gal_card : 3 \\mid \\mathrm{card}\\,q.\\mathrm{Gal}$. A companion reduction rewrites that as the arithmetic fact $3 \\mid \\mathrm{inertiaDegIn}_{(7)}(\\mathcal{O}_{q.\\mathrm{SplittingField}})$ at an unramified prime over $7$, provable by a three-step Kummer–Dedekind route. The sibling entry `inverse-galois-oq-04` machine-checked steps (2)–(3) — inertia-degree tower multiplicativity and Galois uniformity — leaving step (1), the Kummer–Dedekind translation from a mod-$p$ factorization to an inertia degree, as its own explicit open question. This entry formalizes exactly that step.",
+    "problemStatement": "**Formalize Step 1 of the Kummer–Dedekind route: an irreducible factor of $\\mathrm{minpoly}\\,\\theta$ modulo $p$ produces a prime of the ring of integers whose inertia degree is that factor's degree.**\n\nConcretely: given a number field $K$, an algebraic integer $\\theta \\in \\mathcal{O}_K$, and a rational prime $p$ not dividing the Kummer–Dedekind exponent of $\\theta$ (the smallest positive integer in the conductor $[\\mathcal{O}_K : \\mathbb{Z}[\\theta]]$), every monic irreducible factor $Q$ of $\\mathrm{minpoly}_{\\mathbb{Z}}\\,\\theta \\bmod p$ is matched by a maximal prime $P$ of $\\mathcal{O}_K$ lying over $(p)$ with $\\mathrm{inertiaDeg}_{(p)}\\,P = \\deg Q$.",
+    "text": "A 95-line, 0-axiom, 2-theorem file in the namespace `DedekindKummerStep1`. The main theorem `exists_prime_inertiaDeg_eq_natDegree` fixes a number field $K$, an algebraic integer $\\theta$, and a prime $p$ with $p \\nmid \\mathrm{exponent}\\,\\theta$, and produces from each monic irreducible factor $Q \\in \\mathrm{monicFactorsMod}\\,\\theta\\,p$ a prime $P \\lhd \\mathcal{O}_K$ that is maximal, lies over $(p)$, and satisfies $\\mathrm{inertiaDeg}\\,(p)\\,P = Q.\\mathrm{natDegree}$. The corollary `exists_prime_dvd_inertiaDeg_of_dvd_natDegree` restates this in divisibility form — the exact shape consumed by the OQ-04 tower brick: if $d \\mid \\deg Q$ then some prime $P$ over $(p)$ has $d \\mid \\mathrm{inertiaDeg}\\,(p)\\,P$. In the $A_5$ application, $\\theta = \\alpha$ is a root of the quintic $q$, $p = 7$, $Q$ is the irreducible cubic factor of $q \\bmod 7$ (already verified in `Proofs.InverseGaloisA5DedekindMod7`), and $d = 3$; feeding the resulting $P$ into `DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg` yields $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$.",
+    "proofStrategy": "The witness is the prime $P := (\\mathrm{primesOverSpanEquivMonicFactorsMod}\\;hp)^{-1}\\langle Q, hQ\\rangle$ produced by Mathlib's Kummer–Dedekind bijection between the primes of $\\mathcal{O}_K$ over $(p)$ and the monic irreducible factors of $\\mathrm{minpoly}\\,\\theta \\bmod p$ (valid precisely because $p \\nmid \\mathrm{exponent}\\,\\theta$).\n\n1. **Primality and lying-over** come for free: $P$ is, by construction, an element of the subtype `primesOver (span {(p : ℤ)}) (𝓞 K)`, whose membership proof `.2` unpacks to $P.\\mathrm{IsPrime} \\wedge P.\\mathrm{LiesOver}\\,(p)$.\n\n2. **Maximality** is `Ideal.isMaximal_of_mem_primesOver` applied to that same membership (a prime over a maximal ideal in a ring of integers is maximal).\n\n3. **Inertia degree** is Mathlib's `inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply'`, which computes $\\mathrm{inertiaDeg}\\,(p)\\,P = Q.\\mathrm{natDegree}$ directly.\n\nThe divisibility corollary is one `obtain` plus rewriting the extracted equality with the hypothesis $d \\mid \\deg Q$. Only foundational axioms are used.",
+    "keyInsights": [
+      "**The exponent condition is the whole hypothesis**: Kummer–Dedekind's translation from `minpoly θ mod p` to primes of `𝓞 K` is valid exactly when `p ∤ exponent θ` (equivalently `p` does not divide the conductor `[𝓞 K : ℤ[θ]]`). In the A₅ setting this is $7 \\nmid \\mathrm{disc}(q) = 32000^2$, so $7$ misses the conductor and the factorization of $q \\bmod 7$ reads off the splitting directly.",
+      "**Degree becomes inertia degree, verbatim**: the degree of the irreducible factor mod $p$ equals the residue-field degree of the matched prime. This is why an *irreducible cubic* factor is what the $A_5$ argument needs — it manufactures a prime of inertia degree exactly $3$, hence a Frobenius element of order $3$.",
+      "**Divisibility is the currency that composes**: phrasing the corollary as `d ∣ inertiaDeg (p) P` (rather than tracking the exact degree) is precisely the input to the sibling tower brick `dvd_inertiaDegIn_of_dvd_inertiaDeg`, so Step 1 and Steps 2–3 snap together into `d ∣ inertiaDegIn (p)` on the splitting field.",
+      "**Thin repackaging, sharp interface**: the mathematics lives entirely in Mathlib's `primesOverSpanEquivMonicFactorsMod` bijection and its residual-degree lemma; the contribution is isolating and re-exporting them in the existence/divisibility form the inverse-Galois–via–Frobenius argument actually consumes, so the residual OQ-04 gap is now just tower/top-prime wiring over two verified bricks.",
+      "**Honest partial progress**: this entry does not on its own remove `three_dvd_gal_card`; it closes Step 1 with 0 axioms and, together with the verified Steps 2–3, leaves only the concrete tower instantiation (a scalar tower $\\mathbb{Z} \\subseteq \\mathcal{O}_{\\mathbb{Q}(\\alpha)} \\subseteq \\mathcal{O}_{q.\\mathrm{SplittingField}}$ with a top prime over the Step-1 prime) between the machine-checked bricks and the arithmetic fact."
+    ],
+    "prerequisites": [
+      "Algebraic number theory (rings of integers, prime factorization in extensions, inertia degree, the conductor of an order)",
+      "The Kummer–Dedekind theorem (factorization of a rational prime read off from a minimal polynomial modulo p)",
+      "Polynomials over finite fields (monic irreducible factors, degrees)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "roadmap",
+      "title": "Docstring: Step 1 of the three-step Kummer–Dedekind route",
+      "startLine": 3,
+      "endLine": 62,
+      "summary": "Frames OQ-04 and its companion reduction of three_dvd_gal_card to 3 ∣ inertiaDegIn (7); recalls that the sibling entry machine-checked steps (2)–(3) (inertia tower + Galois uniformity) and states that this file packages step (1), the Kummer–Dedekind translation from an irreducible factor mod p to a prime of that inertia degree, with only foundational axioms."
+    },
+    {
+      "id": "existence",
+      "title": "exists_prime_inertiaDeg_eq_natDegree — the splitting datum",
+      "startLine": 64,
+      "endLine": 84,
+      "summary": "For a number field K, algebraic integer θ, and prime p not dividing exponent θ, every monic irreducible factor Q of minpoly ℤ θ mod p is matched by a maximal prime P of 𝓞 K over (p) with inertiaDeg (p) P = Q.natDegree. Proof: the witness is the Kummer–Dedekind bijection's inverse image of Q; primality and lying-over are its primesOver-membership components, maximality is isMaximal_of_mem_primesOver, and the inertia degree is inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply'."
+    },
+    {
+      "id": "divisibility",
+      "title": "exists_prime_dvd_inertiaDeg_of_dvd_natDegree — the composable form",
+      "startLine": 86,
+      "endLine": 95,
+      "summary": "Divisibility restatement consumed by the tower brick: if d ∣ Q.natDegree then some maximal prime P of 𝓞 K over (p) has d ∣ inertiaDeg (p) P. One obtain from the existence theorem plus a rewrite by the extracted degree equality."
+    }
+  ],
+  "conclusion": {
+    "mainResult": "For any number field K, algebraic integer θ ∈ 𝓞 K, and rational prime p not dividing the Kummer–Dedekind exponent of θ, every monic irreducible factor Q of minpoly ℤ θ modulo p is matched by a maximal prime P of 𝓞 K lying over (p) with inertiaDeg (p) P = deg Q; consequently d ∣ deg Q yields a prime with d ∣ inertiaDeg (p) P. Both theorems are machine-checked with 0 axioms and 0 sorries, supplying Step 1 of the three-step Kummer–Dedekind route toward eliminating the last A₅ realizability axiom.",
+    "openQuestions": [
+      "Instantiate the concrete tower ℤ ⊆ 𝓞 ℚ(α) ⊆ 𝓞 q.SplittingField with a top prime over the Step-1 prime, so this brick and the OQ-04 tower brick compose to 3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField).",
+      "Verify the exponent hypothesis 7 ∤ exponent α for a root α of q (via 7 ∤ disc q = 32000²), matching the irreducible cubic factor of q mod 7 to the monicFactorsMod input of this brick.",
+      "Chain the two bricks into InverseGaloisA5DedekindInstantiation.three_dvd_gal_card_of_bridge to fully discharge three_dvd_gal_card and make the A₅ realization 0-axiom."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "inverse-galois-oq-04",
+      "relationship": "related",
+      "description": "Parent entry (the tower + Galois-uniformity brick, Steps 2–3); this entry supplies the complementary Step 1 it names as its own open question"
+    },
+    {
+      "targetId": "inverse-galois-a5",
+      "relationship": "related",
+      "description": "The A₅ realization whose sole remaining axiom three_dvd_gal_card these two bricks are designed to help eliminate"
+    },
+    {
+      "targetId": "inverse-galois",
+      "relationship": "related",
+      "description": "Grandparent entry stating the Inverse Galois Problem; OQ-04 is its fourth open question"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/DedekindKummerStep1.lean",
+    "lineCount": 95,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "imports": [
+      "Mathlib"
+    ],
+    "lemmaCount": 0,
+    "additionalFiles": []
+  }
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **`inverse-galois-oq-04-oq-01`** answering the parent OQ-04 entry's own first open question: *"formalize the remaining Kummer–Dedekind step (step 1)."*

For an arbitrary number field `K`, algebraic integer `θ ∈ 𝓞 K`, and rational prime `p` not dividing the Kummer–Dedekind exponent (conductor index `[𝓞 K : ℤ[θ]]`) of `θ`, every monic irreducible factor `Q` of `minpoly ℤ θ` modulo `p` is matched by a maximal prime `P` of `𝓞 K` lying over `(p)` with `inertiaDeg (p) P = deg Q`. The divisibility corollary — `d ∣ deg Q ⇒ ∃ P, d ∣ inertiaDeg (p) P` — is exactly the shape consumed by the sibling OQ-04 tower brick.

## Why it matters

The A₅ realization `Proofs.InverseGaloisA5` rests on one remaining axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`, reduced by a companion file to `3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)` via a three-step Kummer–Dedekind route:

1. **(this entry)** an irreducible cubic factor of `q mod 7` ⇒ a prime of inertia degree 3;
2. inertia-degree tower multiplicativity — verified in sibling `inverse-galois-oq-04`;
3. Galois uniformity — verified in sibling `inverse-galois-oq-04`.

Steps 2–3 were already machine-checked in `Proofs.DedekindInertiaTower`. This brick supplies **step 1**, so the two verified bricks now bracket the residual gap: only the concrete tower/top-prime wiring plus the already-verified arithmetic factorization (`Proofs.InverseGaloisA5DedekindMod7`) remain.

## Proof

Thin, reusable repackaging of Mathlib's Kummer–Dedekind bijection `NumberField.Ideal.primesOverSpanEquivMonicFactorsMod` and its residual-degree computation `inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply'`, plus `Ideal.isMaximal_of_mem_primesOver`. Structural tactics only (`refine`/`exact`/`obtain`/`▸`) — no `decide`/`native_decide`/`sorry`/`axiom`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.DedekindKummerStep1` — **succeeded** (`Built Proofs.DedekindKummerStep1`).
- **0 axioms** (foundational only: `propext`/`Classical.choice`/`Quot.sound`), **0 sorries**, 2 theorems, 95 lines. A separate `#print axioms` container could not complete under current host disk pressure (cache re-download), but the proof is 0-axiom by construction — it contains no `decide`/`native_decide`/`sorry`/`axiom` and only composes standard Mathlib theorems, matching the sibling `DedekindInertiaTower` entry.
- Gallery validators (`gallery:check-size`, `annotations:validate`) pass for the new slug.

## Files

- `proofs/Proofs/DedekindKummerStep1.lean` (new, 95L)
- `src/data/proofs/inverse-galois-oq-04-oq-01/{meta,annotations}.json` (new)

Note: this branch (`feature/researcher-4`) previously carried the erdos-460 drift repair, which is already merged to `main` (#32648); the branch has been reused for this new work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)