### PR TITLE
research(halting-problem-oq-02): totality problem undecidable via Rice's theorem [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/HaltingProblemOQ02.lean
+++ b/proofs/Proofs/HaltingProblemOQ02.lean
@@ -1,0 +1,144 @@
+import Mathlib.Computability.Halting
+import Mathlib.Computability.PartrecCode
+import Mathlib.Tactic
+
+/-
+# The Totality Problem is Undecidable (a Rice's-Theorem instance)
+
+## Open Question (halting-problem-oq-02)
+"Undecidability of the Totality Problem (Rice's Theorem instance): is the set of
+(indices of) programs that halt on *every* input decidable?"
+
+## Answer
+No. The **totality problem** `TOT = { c | ∀ n, program c halts on input n }` is not
+computable. This is the archetypal application of Rice's theorem: totality is a
+*semantic* (extensional) property of the partial function `eval c` — it depends only
+on the function computed, not on the code — and it is *nontrivial* (some programs are
+total, some are not). Every such property is undecidable.
+
+We work in Mathlib's standard model of computation: `Nat.Partrec.Code`, with
+`Code.eval : Code → ℕ →. ℕ` the universal evaluator. "`c` halts on input `n`" is
+`(eval c n).Dom`, so totality of `c` is `∀ n, (eval c n).Dom`.
+
+## What is proved (all VERIFIED, 0 sorries, 0 axioms beyond Mathlib's foundational core)
+
+* `totalFns` / `TotalCodes` — the totality property, as a set of partial functions
+  (`ℕ →. ℕ`) and, extensionally, as a set of codes.
+* `some_mem_totalFns` / `none_notMem_totalFns` — the two witnesses that make totality
+  **nontrivial**: the identity function is total, the empty (everywhere-divergent)
+  function is not. Nontriviality is exactly the hypothesis Rice's theorem needs.
+* `totality_not_computable` — **the main result**: `TOT` is not computable, via
+  Mathlib's `rice`.
+* `totality_not_computable_of_codes` — the same on the level of `Set Code`, via
+  `rice₂` (which characterises the computable extensional code-sets as exactly `∅`
+  and `univ`); totality is neither.
+* `emptiness_not_computable` — the *dual* Rice instance: the "emptiness" problem
+  `{ c | ∀ n, program c diverges on n }` (never halts) is also undecidable.
+
+## Scope / honesty
+This proves totality is **not computable**. Totality is in fact `Π₂` (`∀ n, ∃ s`, the
+computation halts within `s` steps) and is `Π₂`-complete, hence neither computably
+enumerable nor co-c.e.; those sharper classifications are *not* established here.
+The result is a faithful, index-based companion to the abstract diagonalization in
+`HaltingProblem.lean` (which uses a bespoke oracle model rather than `Code`).
+
+## References
+- Rice, H. G. (1953). "Classes of recursively enumerable sets and their decision
+  problems." Trans. Amer. Math. Soc. 74, 358–366.
+- Rogers, H. (1967). Theory of Recursive Functions and Effective Computability, §14.8.
+- Soare, R. (2016). Turing Computability, Springer, §II.4 (the arithmetical hierarchy).
+-/
+
+open Nat.Partrec (Code)
+open Nat.Partrec.Code
+
+namespace TotalityProblem
+
+/-! ## Section 1: The totality property -/
+
+/-- The **totality** property, as a set of partial functions: `f` is total when it
+    halts (is defined) on every input. -/
+def totalFns : Set (ℕ →. ℕ) := { f | ∀ n, (f n).Dom }
+
+/-- The identity function `n ↦ n` (Mathlib's `Part.some`) is total. It is the witness
+    that the totality property is *satisfiable* — the first half of nontriviality. -/
+theorem some_mem_totalFns : (fun n => Part.some n) ∈ totalFns := fun _ => trivial
+
+/-- The everywhere-divergent function `n ↦ ⊥` is **not** total: it halts nowhere. This
+    is the second half of nontriviality (the property is not universally true). -/
+theorem none_notMem_totalFns : (fun _ => (Part.none : Part ℕ)) ∉ totalFns := by
+  intro h; exact (h 0)
+
+/-! ## Section 2: The totality problem is undecidable -/
+
+/-- **The Totality Problem is undecidable.** There is no algorithm deciding, from a
+    code `c`, whether `eval c` is total (halts on every input).
+
+    This is Rice's theorem applied to the totality property: totality is a semantic
+    property of `eval c` and is nontrivial (`some_mem_totalFns`, `none_notMem_totalFns`),
+    so it cannot be computable. Concretely, `rice` says a computable semantic property
+    that holds of *some* function must hold of *every* function; feeding it the
+    everywhere-divergent function forces the false conclusion that it is total. -/
+theorem totality_not_computable :
+    ¬ ComputablePred (fun c : Code => eval c ∈ totalFns)
+  | h => none_notMem_totalFns (ComputablePred.rice totalFns h Nat.Partrec.some Nat.Partrec.none
+      some_mem_totalFns)
+
+/-! ## Section 3: The code-level formulation via `rice₂` -/
+
+/-- The set of **total codes**: codes whose evaluated partial function is total. -/
+def TotalCodes : Set Code := { c | ∀ n, (eval c n).Dom }
+
+/-- `TotalCodes` is an **extensional** (index-invariant) set of codes: whether a code
+    is total depends only on the function it computes. This is the hypothesis of
+    `rice₂`. -/
+theorem totalCodes_extensional :
+    ∀ cf cg : Code, eval cf = eval cg → (cf ∈ TotalCodes ↔ cg ∈ TotalCodes) := by
+  intro cf cg he
+  simp only [TotalCodes, Set.mem_setOf_eq, he]
+
+/-- `TotalCodes` is **nontrivial**: it is neither empty (some code is total) nor
+    everything (some code is not). We exhibit a total code and a non-total code by
+    pulling back the two function-level witnesses through `exists_code`. -/
+theorem totalCodes_nontrivial : TotalCodes ≠ ∅ ∧ TotalCodes ≠ Set.univ := by
+  obtain ⟨ct, hct⟩ := exists_code.mp Nat.Partrec.some
+  obtain ⟨cn, hcn⟩ := exists_code.mp Nat.Partrec.none
+  constructor
+  · intro hempty
+    have : ct ∈ TotalCodes := by
+      simp only [TotalCodes, Set.mem_setOf_eq, hct]; exact fun _ => trivial
+    rw [hempty] at this; exact this
+  · intro huniv
+    have hcnmem : cn ∈ TotalCodes := huniv ▸ Set.mem_univ cn
+    simp only [TotalCodes, Set.mem_setOf_eq, hcn] at hcnmem
+    exact (hcnmem 0)
+
+/-- **Code-level totality is undecidable**, via `rice₂`: the computable extensional
+    code-sets are exactly `∅` and `Set.univ`, and `TotalCodes` is neither. -/
+theorem totality_not_computable_of_codes :
+    ¬ ComputablePred (fun c : Code => c ∈ TotalCodes) := by
+  intro h
+  rcases (ComputablePred.rice₂ TotalCodes totalCodes_extensional).mp h with h0 | h1
+  · exact totalCodes_nontrivial.1 h0
+  · exact totalCodes_nontrivial.2 h1
+
+/-! ## Section 4: The dual — the emptiness (never-halts) problem -/
+
+/-- The **emptiness** property: `f` diverges on every input (halts nowhere). -/
+def emptyFns : Set (ℕ →. ℕ) := { f | ∀ n, ¬ (f n).Dom }
+
+/-- The everywhere-divergent function witnesses that emptiness is satisfiable. -/
+theorem none_mem_emptyFns : (fun _ => (Part.none : Part ℕ)) ∈ emptyFns := fun _ h => h
+
+/-- The identity function is **not** empty: it halts (indeed everywhere). -/
+theorem some_notMem_emptyFns : (fun n => Part.some n) ∉ emptyFns := by
+  intro h; exact (h 0) trivial
+
+/-- **The Emptiness Problem is undecidable.** Deciding whether a program halts on *no*
+    input is impossible — the dual Rice instance to totality. -/
+theorem emptiness_not_computable :
+    ¬ ComputablePred (fun c : Code => eval c ∈ emptyFns)
+  | h => some_notMem_emptyFns (ComputablePred.rice emptyFns h Nat.Partrec.none Nat.Partrec.some
+      none_mem_emptyFns)
+
+end TotalityProblem

--- a/research/problems/halting-problem-oq-02/knowledge.md
+++ b/research/problems/halting-problem-oq-02/knowledge.md
@@ -1,0 +1,58 @@
+# Knowledge Base: halting-problem-oq-02 (Totality Problem Undecidability)
+
+## Problem Understanding
+
+Target (from problem.md sketch): prove the **totality problem** is undecidable —
+`¬ ComputablePred (fun c => c ∈ TotalCodes)` where
+`TotalCodes = {c | ∀ n, (eval c n).Dom}`. A direct Rice's-theorem instance on a
+concrete extensional, nontrivial code-class. Category: extension of parent
+`halting-problem`.
+
+## Result (07-01, researcher-1) — SHIPPED, VERIFIED 0-axiom, 0 sorries
+
+New file `proofs/Proofs/HaltingProblemOQ02.lean` (144 lines, 9 thm / 3 def).
+`#print axioms` on the three headline theorems: `[propext, Classical.choice,
+Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. Compiled with
+`lake env lean` against pinned Mathlib v4.26.0.
+
+Works inside Mathlib's real computation model `Nat.Partrec.Code` (universal
+evaluator `eval : Code → ℕ →. ℕ`), so this is the GENUINE computation-theoretic
+undecidability — the parent `halting-problem` gallery entry explicitly states its
+abstract-oracle model does NOT establish this and points to `Nat.Partrec /
+ComputablePred` as the needed route. This file supplies exactly that.
+
+Declarations:
+- `totalFns := {f : ℕ →. ℕ | ∀ n, (f n).Dom}`; nontriviality witnesses
+  `some_mem_totalFns` (identity total), `none_notMem_totalFns` (divergent not total).
+- `totality_not_computable` — MAIN, via `ComputablePred.rice totalFns h
+  Nat.Partrec.some Nat.Partrec.none some_mem_totalFns` then apply to `0`.
+- `TotalCodes := {c | ∀ n, (eval c n).Dom}`; `totalCodes_extensional` (simp with
+  eval-equality), `totalCodes_nontrivial` (pull witnesses back through `exists_code`).
+- `totality_not_computable_of_codes` — code-level, via `ComputablePred.rice₂`
+  (computable extensional code-sets = exactly ∅ / univ; TotalCodes is neither).
+- Dual: `emptyFns`, `emptiness_not_computable` (halts-on-no-input, swap witnesses).
+
+Gallery data added: `src/data/proofs/halting-problem-oq-02/{meta.json,annotations.json}`
+(status verified, badge verified, parentId halting-problem, openQuestionId oq-02).
+
+## Gotchas / lessons
+
+- `rice` / `rice₂` live in namespace `ComputablePred` (NOT bare `rice`). Use
+  `ComputablePred.rice` / `ComputablePred.rice₂`.
+- `rice` signature: `(C) (h : ComputablePred fun c => eval c ∈ C) {f g}
+  (hf : Nat.Partrec f) (hg : Nat.Partrec g) (fC : f ∈ C) : g ∈ C`. It only takes
+  the `f ∈ C` witness; the contradiction comes from `g ∈ C` being false.
+- `Nat.Partrec.some : Partrec Part.some` (total identity), `Nat.Partrec.none :
+  Partrec fun _ => Part.none`. `(Part.none).Dom` reduces definitionally to `False`.
+- `open Nat.Partrec (Code)` + `open Nat.Partrec.Code` exposes `eval`, `exists_code`.
+- BUILD/INFRA: `/private/tmp` worktrees get REAPED mid-session (Lean file + research/
+  + src/data/research vanished, .git severed). Use a durable path under
+  `/Users/rwalters/GitHub/lean-genius-wt/` instead.
+
+## Scope / open
+
+Proves NOT computable. Totality is Π₂-complete (hence not c.e., not co-c.e.); the
+sharper arithmetical classification is NOT done — Mathlib v4.26.0 lacks the
+arithmetical hierarchy. Left as the open follow-up.
+
+## Status: COMPLETED (0-sorry, 0-axiom, gallery entry created).

--- a/src/data/proofs/halting-problem-oq-02/annotations.json
+++ b/src/data/proofs/halting-problem-oq-02/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-totality-property",
+    "proofId": "halting-problem-oq-02",
+    "range": { "startLine": 59, "endLine": 61 },
+    "type": "definition",
+    "title": "Totality as a Semantic Property",
+    "content": "`totalFns` is the set of partial functions defined on **every** input. It is a property of the *function* `eval c`, not of the code `c` — this extensionality is what makes Rice's theorem applicable. A code is total exactly when its evaluated partial function lies in this set.",
+    "mathContext": "$\\mathrm{totalFns} = \\{\\, f : \\mathbb{N} \\rightharpoonup \\mathbb{N} \\mid \\forall n,\\ (f\\,n){\\downarrow} \\,\\}$, where $(f\\,n){\\downarrow}$ is `(f n).Dom` (the computation halts).",
+    "significance": "key",
+    "prerequisites": [
+      "Partial functions ℕ →. ℕ and Part.Dom in Lean",
+      "Semantic vs syntactic properties of programs"
+    ],
+    "relatedConcepts": [
+      "extensional property",
+      "index set",
+      "Rice's theorem"
+    ]
+  },
+  {
+    "id": "ann-nontriviality-witnesses",
+    "proofId": "halting-problem-oq-02",
+    "range": { "startLine": 63, "endLine": 70 },
+    "type": "insight",
+    "title": "Two Witnesses Make the Property Nontrivial",
+    "content": "Rice's theorem needs the property to be **neither always true nor always false**. Two witnesses supply exactly this: the identity function `fun n => Part.some n` is total, and the everywhere-divergent function `fun _ => Part.none` is not. Both are partial recursive, so by `exists_code` each is `eval` of some code — giving a total code and a non-total code.",
+    "mathContext": "$\\mathrm{some} = (n \\mapsto \\lfloor n \\rfloor) \\in \\mathrm{totalFns}$ and $\\mathrm{none} = (n \\mapsto \\bot) \\notin \\mathrm{totalFns}$; both are `Nat.Partrec`.",
+    "significance": "key",
+    "prerequisites": [
+      "Nat.Partrec.some and Nat.Partrec.none",
+      "Nontrivial index sets"
+    ],
+    "relatedConcepts": [
+      "nontriviality",
+      "exists_code",
+      "partial recursive functions"
+    ]
+  },
+  {
+    "id": "ann-main-rice",
+    "proofId": "halting-problem-oq-02",
+    "range": { "startLine": 82, "endLine": 85 },
+    "type": "insight",
+    "title": "Undecidability via Rice's Theorem",
+    "content": "The main theorem: no algorithm decides totality. `ComputablePred.rice` says a computable extensional property holding of *some* partial function holds of *every* one. Applied with the total witness as `f ∈ C`, it would force the everywhere-divergent function into `totalFns` — i.e. `(Part.none).Dom`, which is `False`. That contradiction refutes decidability.",
+    "mathContext": "$\\neg\\,\\mathrm{ComputablePred}\\,(\\lambda c.\\ \\mathrm{eval}\\,c \\in \\mathrm{totalFns})$.",
+    "significance": "key",
+    "prerequisites": [
+      "ComputablePred and decidability of predicates",
+      "Rice's theorem statement"
+    ],
+    "relatedConcepts": [
+      "Rice's theorem",
+      "halting problem",
+      "proof by contradiction"
+    ]
+  },
+  {
+    "id": "ann-code-level-rice2",
+    "proofId": "halting-problem-oq-02",
+    "range": { "startLine": 116, "endLine": 123 },
+    "type": "tactic",
+    "title": "Code-Level Form via rice₂",
+    "content": "`ComputablePred.rice₂` characterises the computable extensional code-sets as **exactly** `∅` and `Set.univ`. So proving `TotalCodes` undecidable reduces to showing it is extensional (`totalCodes_extensional`, by `simp` with the eval-equality) and neither trivial (`totalCodes_nontrivial`, from the two witnesses via `exists_code`). The `rcases` on the disjunction discharges both trivial cases.",
+    "mathContext": "$\\big(\\mathrm{ComputablePred}\\,(\\lambda c.\\ c \\in C)\\big) \\iff C = \\varnothing \\vee C = \\mathrm{univ}$ for extensional $C$; $\\mathrm{TotalCodes}$ is neither.",
+    "significance": "key",
+    "prerequisites": [
+      "Set.mem_setOf_eq and rewriting under eval-equality",
+      "exists_code : Nat.Partrec f ↔ ∃ c, eval c = f"
+    ],
+    "relatedConcepts": [
+      "rice₂",
+      "extensional code sets",
+      "Set.univ"
+    ]
+  },
+  {
+    "id": "ann-emptiness-dual",
+    "proofId": "halting-problem-oq-02",
+    "range": { "startLine": 137, "endLine": 142 },
+    "type": "concept",
+    "title": "The Dual: the Emptiness Problem",
+    "content": "Swapping the two witnesses gives the dual Rice instance: deciding whether a program halts on **no** input is also undecidable. The everywhere-divergent function witnesses satisfiability and the identity function witnesses non-triviality — the mirror image of the totality argument.",
+    "mathContext": "$\\mathrm{emptyFns} = \\{\\, f \\mid \\forall n,\\ \\neg (f\\,n){\\downarrow} \\,\\}$, and $\\neg\\,\\mathrm{ComputablePred}\\,(\\lambda c.\\ \\mathrm{eval}\\,c \\in \\mathrm{emptyFns})$.",
+    "significance": "key",
+    "prerequisites": [
+      "Duality of totality and emptiness properties"
+    ],
+    "relatedConcepts": [
+      "emptiness problem",
+      "duality",
+      "Rice's theorem"
+    ]
+  }
+]

--- a/src/data/proofs/halting-problem-oq-02/meta.json
+++ b/src/data/proofs/halting-problem-oq-02/meta.json
@@ -1,0 +1,214 @@
+{
+  "id": "halting-problem-oq-02",
+  "title": "Undecidability of the Totality Problem (Rice's Theorem Instance)",
+  "slug": "halting-problem-oq-02",
+  "description": "The totality problem — deciding whether a program halts on every input — is undecidable. A faithful, index-based instance of Rice's theorem in Mathlib's Nat.Partrec.Code model: totality is a semantic (extensional) property of the computed partial function and is nontrivial (some programs are total, some are not), so it cannot be computable. Complements the parent halting-problem entry, which models oracles abstractly and does not use a computation model.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HaltingProblemOQ02.lean",
+    "tags": [
+      "computability",
+      "undecidability",
+      "rices-theorem",
+      "totality",
+      "partial-recursive",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 144,
+    "mathlibDependencies": [
+      {
+        "theorem": "ComputablePred.rice",
+        "description": "Rice's theorem: a computable extensional property of eval c that holds of some partial function holds of every partial function",
+        "module": "Mathlib.Computability.Halting"
+      },
+      {
+        "theorem": "ComputablePred.rice₂",
+        "description": "Rice's theorem on codes: the computable extensional code-sets are exactly ∅ and Set.univ",
+        "module": "Mathlib.Computability.Halting"
+      },
+      {
+        "theorem": "Nat.Partrec.Code.eval",
+        "description": "The universal evaluator eval : Code → ℕ →. ℕ for the standard partial-recursive code model",
+        "module": "Mathlib.Computability.PartrecCode"
+      },
+      {
+        "theorem": "Nat.Partrec.Code.exists_code",
+        "description": "Every partial recursive function is eval of some code (used to pull function-level witnesses back to codes)",
+        "module": "Mathlib.Computability.PartrecCode"
+      },
+      {
+        "theorem": "Nat.Partrec.some / Nat.Partrec.none",
+        "description": "The total identity function and the everywhere-divergent function are partial recursive — the two nontriviality witnesses",
+        "module": "Mathlib.Computability.Partrec"
+      }
+    ],
+    "originalContributions": [
+      "Complete, 0-sorry, 0-axiom formalization of the undecidability of the totality problem in Mathlib's Nat.Partrec.Code model — the genuine computation-theoretic statement the parent halting-problem entry explicitly leaves out of scope",
+      "Two formulations: totality_not_computable (function-level, via ComputablePred.rice) and totality_not_computable_of_codes (code-level, via ComputablePred.rice₂ with an explicit nontriviality proof)",
+      "Nontriviality made explicit: some_mem_totalFns / none_notMem_totalFns and the code-level totalCodes_nontrivial pin down exactly why Rice's theorem applies",
+      "The dual result emptiness_not_computable: deciding whether a program halts on no input is also undecidable"
+    ],
+    "openProblems": [
+      "Sharpen 'not computable' to the exact arithmetical classification: totality is Π₂ and Π₂-complete, hence neither computably enumerable nor co-c.e. — not established here"
+    ],
+    "theoremCount": 9,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Henry Gordon Rice proved in 1953 that every nontrivial semantic property of the partial function computed by a program is undecidable, generalizing Turing's 1936 halting theorem. The totality problem — 'does this program halt on all inputs?' — is the canonical example beyond the fixed-input halting question: it is a property of the computed function (not the code text) and is satisfied by some programs but not others, so Rice's theorem applies verbatim. In the arithmetical hierarchy of Kleene (1943) and Mostowski (1947), the totality set is Π₂-complete, strictly harder than the Σ₁-complete halting set: totality asserts '∀ input ∃ number of steps, the computation halts', a genuine two-quantifier statement. This entry formalizes the undecidability half in Lean 4 using Mathlib's Nat.Partrec.Code model of computation and its mechanized Rice's theorem.",
+    "problemStatement": "In Mathlib's model of computation (Nat.Partrec.Code with universal evaluator eval : Code → ℕ →. ℕ), a code c is total when eval c halts on every input: ∀ n, (eval c n).Dom. The totality problem asks whether the set TotalCodes = { c | ∀ n, (eval c n).Dom } is decidable. Theorem: it is not — ¬ ComputablePred (fun c => c ∈ TotalCodes).",
+    "proofStrategy": "Totality is a semantic property: it depends only on the partial function eval c, not on the code c (totalCodes_extensional). It is nontrivial: the identity function is total (some_mem_totalFns) and the everywhere-divergent function is not (none_notMem_totalFns), and both are partial recursive so they arise as eval of some code (exists_code). Rice's theorem then forbids decidability. Two packagings are given: ComputablePred.rice at the level of partial functions (feeding the total witness as 'f ∈ C' forces the divergent witness into C, a contradiction), and ComputablePred.rice₂ at the level of codes (the computable extensional code-sets are exactly ∅ and univ; TotalCodes is neither).",
+    "keyInsights": [
+      "Totality is the archetypal Rice instance beyond halting: it is extensional (a property of the computed function) and nontrivial (some but not all programs are total), which is exactly the hypothesis Rice's theorem needs.",
+      "The two nontriviality witnesses do all the work: the total identity function and the everywhere-divergent function. Rice's theorem converts 'the property is neither always-true nor always-false' into 'the property is not decidable'.",
+      "The parent halting-problem entry deliberately models halting oracles as arbitrary Boolean functions with no computation model, so it proves only the diagonalization schema. This entry supplies the missing computation-theoretic content by working inside Mathlib's Nat.Partrec.Code — the genuine undecidability, not just the diagonal schema.",
+      "The emptiness problem (halts on no input) is the exact dual and is equally undecidable, obtained by swapping the two witnesses. Together, totality and emptiness show both extremes of the halting-domain are undecidable.",
+      "'Not computable' is weaker than the full truth: totality is Π₂-complete, so it is not even computably enumerable. That sharper classification needs the arithmetical hierarchy, which is outside the scope of this entry."
+    ]
+  },
+  "sections": [
+    {
+      "id": "totality-property",
+      "title": "Section 1: The Totality Property",
+      "startLine": 57,
+      "endLine": 70,
+      "summary": "Defines totalFns, the totality property as a set of partial functions, and proves the two nontriviality witnesses: the identity function is total, the everywhere-divergent function is not.",
+      "mathContext": "totalFns = { f : ℕ →. ℕ | ∀ n, (f n).Dom }. Witnesses: (fun n => Part.some n) ∈ totalFns (identity halts everywhere) and (fun _ => Part.none) ∉ totalFns (diverges everywhere)."
+    },
+    {
+      "id": "totality-undecidable",
+      "title": "Section 2: The Totality Problem is Undecidable",
+      "startLine": 72,
+      "endLine": 85,
+      "summary": "The main result: ¬ ComputablePred (fun c => eval c ∈ totalFns), by Mathlib's ComputablePred.rice applied to the totality property with the two nontriviality witnesses.",
+      "mathContext": "Rice: if fun c => eval c ∈ C is computable and some f ∈ C, then every g ∈ C. Feeding the everywhere-divergent g forces (Part.none).Dom, i.e. False."
+    },
+    {
+      "id": "code-level",
+      "title": "Section 3: The Code-Level Formulation via rice₂",
+      "startLine": 87,
+      "endLine": 123,
+      "summary": "Defines TotalCodes ⊆ Code, proves it is extensional (index-invariant) and nontrivial (neither ∅ nor univ, via exists_code on the two witnesses), then concludes undecidability via ComputablePred.rice₂.",
+      "mathContext": "rice₂ : (ComputablePred fun c => c ∈ C) ↔ C = ∅ ∨ C = Set.univ, for extensional C. TotalCodes is extensional and neither trivial, so it is not computable."
+    },
+    {
+      "id": "emptiness-dual",
+      "title": "Section 4: The Dual — the Emptiness Problem",
+      "startLine": 125,
+      "endLine": 143,
+      "summary": "Defines emptyFns (halts nowhere), proves its two witnesses, and concludes the emptiness problem is undecidable — the exact dual of totality, obtained by swapping the witnesses in Rice's theorem.",
+      "mathContext": "emptyFns = { f | ∀ n, ¬ (f n).Dom }. Witnesses: (fun _ => Part.none) ∈ emptyFns and (fun n => Part.some n) ∉ emptyFns. Rice ⇒ ¬ ComputablePred (fun c => eval c ∈ emptyFns)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "halting-problem",
+      "relationship": "extends",
+      "description": "Parent entry: undecidability of the halting problem (abstract diagonalization). This entry supplies the computation-model-based undecidability the parent leaves out of scope, and instantiates Rice's theorem — which the parent names as the universal generalization."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry gives a complete, 0-sorry, 0-axiom formalization of the undecidability of the totality problem inside Mathlib's Nat.Partrec.Code model. Totality is proved undecidable both at the level of partial functions (ComputablePred.rice) and at the level of codes (ComputablePred.rice₂ with an explicit nontriviality argument), and the dual emptiness problem is shown undecidable as well. The result is the genuine computation-theoretic undecidability that the parent halting-problem entry explicitly leaves out of scope.",
+    "implications": "The totality problem is the standard first example of Rice's theorem beyond halting, and its undecidability underlies the impossibility of a general termination checker that is both sound and complete. Formalizing it validates that Mathlib's computability stack (Nat.Partrec.Code, ComputablePred, rice, rice₂) is expressive enough for real recursion theory, and provides reusable nontriviality witnesses (the total and divergent functions) for future Rice-theorem instances.",
+    "openQuestions": [
+      "Can the result be sharpened to the exact arithmetical classification — totality is Π₂-complete, hence not computably enumerable and not co-c.e.? This requires formalizing the arithmetical hierarchy, which Mathlib v4.26.0 lacks.",
+      "Which other named program properties (e.g. 'computes a constant function', 'has infinite domain') admit similarly short Rice-theorem formalizations with explicit witnesses?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Rice, H. G.",
+      "title": "Classes of recursively enumerable sets and their decision problems",
+      "year": 1953,
+      "journal": "Transactions of the American Mathematical Society",
+      "volume": "74",
+      "pages": "358–366",
+      "note": "Original paper proving that every nontrivial semantic property is undecidable"
+    },
+    {
+      "authors": "Rogers, H.",
+      "title": "Theory of Recursive Functions and Effective Computability",
+      "year": 1967,
+      "publisher": "MIT Press",
+      "note": "§14.8 — Rice's theorem and index sets"
+    },
+    {
+      "authors": "Soare, R.",
+      "title": "Turing Computability: Theory and Applications",
+      "year": 2016,
+      "publisher": "Springer",
+      "note": "§II.4 — the arithmetical hierarchy (totality is Π₂-complete)"
+    }
+  ],
+  "sorries": 0,
+  "parentId": "halting-problem",
+  "openQuestionId": "oq-02",
+  "theorems": [
+    {
+      "name": "some_mem_totalFns",
+      "statement": "(fun n => Part.some n) ∈ totalFns",
+      "status": "proved",
+      "description": "The identity function is total — the first nontriviality witness"
+    },
+    {
+      "name": "none_notMem_totalFns",
+      "statement": "(fun _ => Part.none) ∉ totalFns",
+      "status": "proved",
+      "description": "The everywhere-divergent function is not total — the second nontriviality witness"
+    },
+    {
+      "name": "totality_not_computable",
+      "statement": "¬ ComputablePred (fun c : Code => eval c ∈ totalFns)",
+      "status": "proved",
+      "description": "Main result: the totality problem is undecidable, via ComputablePred.rice"
+    },
+    {
+      "name": "totalCodes_extensional",
+      "statement": "∀ cf cg, eval cf = eval cg → (cf ∈ TotalCodes ↔ cg ∈ TotalCodes)",
+      "status": "proved",
+      "description": "Totality is an extensional (index-invariant) property of codes"
+    },
+    {
+      "name": "totalCodes_nontrivial",
+      "statement": "TotalCodes ≠ ∅ ∧ TotalCodes ≠ Set.univ",
+      "status": "proved",
+      "description": "There is a total code and a non-total code (via exists_code on the two witnesses)"
+    },
+    {
+      "name": "totality_not_computable_of_codes",
+      "statement": "¬ ComputablePred (fun c : Code => c ∈ TotalCodes)",
+      "status": "proved",
+      "description": "Code-level undecidability of totality, via ComputablePred.rice₂"
+    },
+    {
+      "name": "emptiness_not_computable",
+      "statement": "¬ ComputablePred (fun c : Code => eval c ∈ emptyFns)",
+      "status": "proved",
+      "description": "The dual: deciding whether a program halts on no input is undecidable"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Computability.Halting",
+      "Mathlib.Computability.PartrecCode",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat.Partrec (Code)",
+      "Nat.Partrec.Code"
+    ],
+    "namespace": "TotalityProblem",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 3,
+    "sorries": 0,
+    "path": "Proofs/HaltingProblemOQ02.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Answers **halting-problem-oq-02** — *Undecidability of the Totality Problem (Rice's Theorem instance)* — with a complete, **0-sorry, 0-axiom** formalization inside Mathlib's real model of computation (`Nat.Partrec.Code`). New file `proofs/Proofs/HaltingProblemOQ02.lean` (144 lines, 9 theorems / 3 defs).

The **totality problem** asks whether `TotalCodes = { c | ∀ n, (eval c n).Dom }` (programs that halt on *every* input) is decidable. It is not: totality is a semantic (extensional) property of `eval c` that is nontrivial, so Rice's theorem applies.

## What's proved (all VERIFIED)

| Decl | Content |
|------|---------|
| `totalFns` / `TotalCodes` | totality as a set of partial functions / of codes |
| `some_mem_totalFns` / `none_notMem_totalFns` | the two nontriviality witnesses — identity is total, everywhere-divergent is not |
| `totality_not_computable` | **main result** — `¬ ComputablePred (fun c => eval c ∈ totalFns)`, via `ComputablePred.rice` |
| `totalCodes_extensional` / `totalCodes_nontrivial` | totality is index-invariant and neither `∅` nor `univ` |
| `totality_not_computable_of_codes` | code-level form via `ComputablePred.rice₂` |
| `emptiness_not_computable` | the dual — deciding "halts on **no** input" is also undecidable |

## Why this matters

The parent `halting-problem` gallery entry deliberately models oracles as arbitrary Boolean functions with **no computation model**, so it proves only the diagonalization *schema* — its `assumptions` field explicitly notes the genuine undecidability "requires a model of computation (e.g. Mathlib's `Nat.Partrec` / `ComputablePred`)… it is not formalized here." **This PR supplies exactly that**, and instantiates Rice's theorem, which the parent names as the universal generalization.

## Verification

`lake env lean` clean compile against pinned Mathlib (Lean v4.26.0). `#print axioms` on the headline theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.

## Scope (honest)

Proves totality is **not computable**. Totality is in fact `Π₂`-complete (hence neither c.e. nor co-c.e.); that sharper classification needs the arithmetical hierarchy (absent from Mathlib v4.26.0) and is left as the open follow-up, noted in the file and gallery `openQuestions`.

## Gallery integration

Adds `src/data/proofs/halting-problem-oq-02/{meta.json, annotations.json}` (status `verified`, parent `halting-problem`, `oq-02`) and research `knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)