### PR TITLE
Enrich Abel summability of Grandi's series (oq-01)

### DIFF
--- a/src/data/proofs/geometric-series-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01/meta.json
@@ -65,6 +65,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "The Open Question and Setup",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "The doc-comment states the open question inherited from the parent GeometricSeriesOQ01 (the geometric series at the boundary |r| = 1): can the Abel summability of Grandi's series 1 − 1 + 1 − 1 + ⋯ be formalized? Abel's method assigns lim_{x→1⁻} ∑ (−1)ⁿ xⁿ = lim_{x→1⁻} 1/(1+x) = 1/2, independently confirming the Cesàro value. It previews the two results and their agreement via Frobenius's theorem, then imports Mathlib and opens the Filter and Topology scopes.",
+      "mathContext": "Abel sum: $\\lim_{x\\to1^-}\\sum_{n}(-1)^n x^n = \\lim_{x\\to1^-}\\frac{1}{1+x} = \\tfrac12$, matching Grandi's Cesàro value."
+    },
+    {
       "id": "closed-form",
       "title": "The Abel Power Series",
       "startLine": 30,


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-01-oq-01`.

## Change
- **Added 'The Open Question and Setup' section (lines 1–29)**: covers the doc-comment stating the inherited open question (Abel summability of Grandi's series) plus imports/namespace setup. Sections previously started at line 30, leaving the header uncovered; they now span the full 79-line file.

## Already rich (left in place)
- 5 keyInsights, 4 annotations with mathContext, 2 existing sections, complete overview and conclusion, 2 crossReferences, 2 references, 3 mathlibDependencies.

## Guardrails
- meta.json ~9 KB — well under the 60 KB cap; JSON validated and processed by the data-build. `status: verified`, 0-axiom / 0-sorry accurately reflected.