### PR TITLE
research(wilsons-theorem-oq-04-oq-02-oq-01): product of all group elements in the non-abelian case [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/WilsonsTheoremOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ04OQ02OQ01.lean
@@ -1,0 +1,133 @@
+import Mathlib.GroupTheory.Abelianization.Defs
+import Mathlib.Tactic
+
+/-!
+# Product of All Group Elements in the Non-Abelian Case
+
+## Overview
+
+The parent result (`WilsonsTheoremOQ04OQ02`) computes the product of all
+elements of a finite **commutative** group: in that setting `∏ x : G, x` is a
+single well-defined element (`Finset.prod` needs commutativity), equal to the
+unique nontrivial involution when one exists.
+
+For a general (possibly **non-abelian**) finite group there is no canonical
+"product of all elements": the value of an ordered product depends on the
+chosen ordering, so `Finset.prod` is not even defined. This file identifies the
+precise sense in which the product survives:
+
+> **Main theorem** (`abelianization_prod_enum`): for *any* enumeration `l` of a
+> finite group `G` (a `Nodup` list containing every element), the image of the
+> ordered product `l.prod` in the abelianization `Gᵃᵇ` is independent of the
+> ordering and equals the order-free `Finset` product `∏ x : G, of x`.
+
+So while `l.prod` is order-dependent in `G`, its class modulo the commutator
+subgroup is a genuine invariant of the group. The proof is forced to pass to
+the abelianization *before* using permutation-invariance, because
+`List.Perm.prod_eq` requires a commutative target — `l.prod` itself lives in the
+noncommutative `G`.
+
+## Main results
+
+- `enum_perm` / `enum_perm_toList` — any two enumerations of a `Fintype` are
+  permutations of each other (and of `univ.toList`).
+- `abelianization_prod_enum` — the abelianized ordered product equals
+  `∏ x : G, of x`, independent of ordering.
+- `abelianization_prod_order_independent` — two enumerations have equal image
+  in `Gᵃᵇ`.
+- `prod_enum_eq_of_commGroup` — the abelian contrast: when `G` is commutative
+  every enumeration's product already equals `∏ x : G, x` in `G` itself.
+- `two_elt_prod_ne` / `two_elt_abelianization_eq` — the smallest witness:
+  noncommuting `a, b` give `[a,b].prod ≠ [b,a].prod` in `G`, yet equal images
+  in `Gᵃᵇ`.
+-/
+
+namespace WilsonsTheoremOQ04OQ02OQ01
+
+open Finset List
+
+variable {G : Type*} [Group G]
+
+-- ============================================================================
+-- Part 1: Enumerations of a finite group are mutually permutations
+-- ============================================================================
+
+omit [Group G] in
+/-- An *enumeration* of a finite group is a `Nodup` list containing every
+    element. Any two enumerations are permutations of each other: they are
+    duplicate-free and have exactly the same members. -/
+theorem enum_perm [Fintype G] {l₁ l₂ : List G}
+    (h₁n : l₁.Nodup) (h₁ : ∀ x, x ∈ l₁)
+    (h₂n : l₂.Nodup) (h₂ : ∀ x, x ∈ l₂) : l₁ ~ l₂ :=
+  (perm_ext_iff_of_nodup h₁n h₂n).mpr (fun a => ⟨fun _ => h₂ a, fun _ => h₁ a⟩)
+
+omit [Group G] in
+/-- Every enumeration of a finite group is a permutation of the canonical
+    enumeration `univ.toList`. -/
+theorem enum_perm_toList [Fintype G] {l : List G}
+    (hn : l.Nodup) (hmem : ∀ x, x ∈ l) : l ~ (univ : Finset G).toList :=
+  enum_perm hn hmem (Finset.nodup_toList _)
+    (fun x => Finset.mem_toList.mpr (mem_univ x))
+
+-- ============================================================================
+-- Part 2: The ordered product is well-defined modulo commutators
+-- ============================================================================
+
+/-- **Main theorem.** For any enumeration `l` of a finite group `G`, the image
+    of the ordered product `l.prod` in the abelianization is independent of the
+    ordering and equals the order-free `Finset` product `∏ x : G, of x`.
+
+    The proof passes to the abelianization *first* (`map_list_prod`): `l.prod`
+    lives in the noncommutative `G`, so `List.Perm.prod_eq` — which needs a
+    commutative target — only becomes available after applying the homomorphism
+    `Abelianization.of`. -/
+theorem abelianization_prod_enum [Fintype G] {l : List G}
+    (hn : l.Nodup) (hmem : ∀ x, x ∈ l) :
+    Abelianization.of l.prod = ∏ x : G, Abelianization.of x := by
+  have hperm : l ~ (univ : Finset G).toList := enum_perm_toList hn hmem
+  rw [map_list_prod Abelianization.of l,
+      (hperm.map (⇑Abelianization.of)).prod_eq,
+      Finset.prod_map_toList univ Abelianization.of]
+
+/-- **Order-independence.** Any two enumerations of `G` have the same image
+    under abelianization, even though their ordered products in `G` may
+    differ. -/
+theorem abelianization_prod_order_independent [Fintype G]
+    {l₁ l₂ : List G} (h₁n : l₁.Nodup) (h₁ : ∀ x, x ∈ l₁)
+    (h₂n : l₂.Nodup) (h₂ : ∀ x, x ∈ l₂) :
+    Abelianization.of l₁.prod = Abelianization.of l₂.prod := by
+  rw [abelianization_prod_enum h₁n h₁, abelianization_prod_enum h₂n h₂]
+
+-- ============================================================================
+-- Part 3: The abelian contrast — order-independence already holds in G
+-- ============================================================================
+
+/-- In an abelian group the ordered product is *already* order-independent in
+    `G` itself: every enumeration's product equals `∏ x : G, x`. Contrast with
+    the general case, where only the abelianization image is well-defined. -/
+theorem prod_enum_eq_of_commGroup {G : Type*} [CommGroup G] [Fintype G]
+    {l : List G} (hn : l.Nodup) (hmem : ∀ x, x ∈ l) :
+    l.prod = ∏ x : G, x := by
+  rw [(enum_perm_toList hn hmem).prod_eq, Finset.prod_toList]
+
+-- ============================================================================
+-- Part 4: The smallest witness — noncommuting pair
+-- ============================================================================
+
+/-- The ordered product genuinely depends on order in a non-abelian group: if
+    `a` and `b` do not commute, the two orderings `[a, b]` and `[b, a]` of the
+    same pair have different products. This is why `Finset.prod` cannot define
+    "the product of all elements" without commutativity. -/
+theorem two_elt_prod_ne {a b : G} (h : a * b ≠ b * a) :
+    ([a, b] : List G).prod ≠ ([b, a] : List G).prod := by
+  simpa using h
+
+/-- ...yet the images of both orderings in the abelianization agree,
+    illustrating `abelianization_prod_enum` on the smallest ordered pair. -/
+theorem two_elt_abelianization_eq (a b : G) :
+    Abelianization.of ([a, b] : List G).prod
+      = Abelianization.of ([b, a] : List G).prod := by
+  simp only [List.prod_cons, List.prod_nil, mul_one, map_mul]
+  exact mul_comm _ _
+
+end WilsonsTheoremOQ04OQ02OQ01

--- a/src/data/proofs/wilsons-theorem-oq-04-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-04-oq-02-oq-01/annotations.json
@@ -1,0 +1,75 @@
+[
+  {
+    "id": "ann-wilson-oq04oq02oq01-perm-enum",
+    "proofId": "wilsons-theorem-oq-04-oq-02-oq-01",
+    "range": {
+      "startLine": 53,
+      "endLine": 76
+    },
+    "type": "concept",
+    "title": "Enumerations of a Finite Group Are Mutually Permutations",
+    "content": "enum_perm and enum_perm_toList set up the combinatorial backbone. An 'enumeration' of G is any duplicate-free list (Nodup) that contains every element. Two such lists have identical membership, so List.perm_ext_iff_of_nodup makes them permutations of each other; in particular each is a permutation of the canonical univ.toList (which is Nodup by Finset.nodup_toList and total by Finset.mem_toList). These lemmas need no group structure, so [Group G] is omitted.",
+    "mathContext": "For a finite type $G$, two lists $l_1, l_2$ with $\\mathrm{Nodup}$ and $\\{x : x \\in l_1\\} = \\{x : x \\in l_2\\} = G$ satisfy $l_1 \\sim l_2$ (they are permutations). Every enumeration is thus $\\sim \\mathrm{univ.toList}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "List.perm_ext_iff_of_nodup",
+      "Finset.nodup_toList",
+      "permutations",
+      "enumeration"
+    ],
+    "prerequisites": [
+      "Fintype",
+      "List.Nodup",
+      "List.Perm"
+    ]
+  },
+  {
+    "id": "ann-wilson-oq04oq02oq01-main",
+    "proofId": "wilsons-theorem-oq-04-oq-02-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 101
+    },
+    "type": "insight",
+    "title": "Pass to the Abelianization BEFORE Using Permutation-Invariance",
+    "content": "abelianization_prod_enum is the main theorem. The decisive subtlety: l.prod is an ordered product in the (possibly noncommutative) G, where List.Perm.prod_eq — which requires a commutative monoid — cannot be applied. The proof therefore applies the homomorphism Abelianization.of FIRST via map_list_prod, converting Abelianization.of l.prod into (l.map of).prod, a product now living in the commutative Abelianization G. Only then is permutation-invariance legal: l ~ univ.toList gives (l.map of) ~ (univ.toList.map of), so List.Perm.prod_eq equates their products, and Finset.prod_map_toList rewrites the result as the order-free ∏ x : G, of x.",
+    "mathContext": "For an enumeration $l$ of a finite group $G$, $\\mathrm{of}(l.\\mathrm{prod}) = \\prod_{x : G} \\mathrm{of}(x)$ in $G^{\\mathrm{ab}} = G/[G,G]$. The homomorphism $\\mathrm{of} : G \\to G^{\\mathrm{ab}}$ turns the order-dependent product into a canonical element of the commutative quotient, on which reordering is invisible.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Abelianization.of",
+      "map_list_prod",
+      "List.Perm.prod_eq",
+      "Finset.prod_map_toList",
+      "commutator subgroup"
+    ],
+    "prerequisites": [
+      "Abelianization",
+      "MonoidHom.map_list_prod",
+      "permutation-invariance of commutative products"
+    ]
+  },
+  {
+    "id": "ann-wilson-oq04oq02oq01-contrast-witness",
+    "proofId": "wilsons-theorem-oq-04-oq-02-oq-01",
+    "range": {
+      "startLine": 112,
+      "endLine": 133
+    },
+    "type": "concept",
+    "title": "The Abelian Contrast and the Smallest Noncommuting Witness",
+    "content": "prod_enum_eq_of_commGroup shows that when G is already commutative the abelianization step is unnecessary: List.Perm.prod_eq applies directly in G, so every enumeration's product equals ∏ x : G, x. The pair two_elt_prod_ne / two_elt_abelianization_eq isolates the obstruction the quotient removes: for the two-element orderings [a,b] and [b,a], the G-products a·b and b·a differ exactly when a and b fail to commute, yet their abelianization images always agree by mul_comm. This is abelianization_prod_enum in miniature.",
+    "mathContext": "If $G$ is abelian, $l.\\mathrm{prod} = \\prod_{x : G} x$ in $G$. In general, $ab \\neq ba \\implies [a,b].\\mathrm{prod} \\neq [b,a].\\mathrm{prod}$ in $G$, while $\\mathrm{of}(ab) = \\mathrm{of}(ba)$ always holds in $G^{\\mathrm{ab}}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "List.Perm.prod_eq",
+      "Finset.prod_toList",
+      "mul_comm",
+      "commutativity obstruction"
+    ],
+    "prerequisites": [
+      "CommGroup",
+      "List.prod",
+      "Abelianization.of"
+    ]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-04-oq-02-oq-01/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "wilsons-theorem-oq-04-oq-02-oq-01",
+  "title": "Product of All Group Elements in the Non-Abelian Case",
+  "slug": "wilsons-theorem-oq-04-oq-02-oq-01",
+  "description": "In a non-abelian finite group there is no canonical product of all elements: the value of an ordered product depends on the ordering. This file pins down the invariant that survives — the image of the ordered product in the abelianization Gᵃᵇ is order-independent and equals the order-free Finset product ∏ x : G, of x. So while the product is order-dependent in G, its class modulo the commutator subgroup is a genuine group invariant. This refines the parent's open question 'generalize to non-abelian groups'.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ04OQ02OQ01.lean",
+    "tags": [
+      "group-theory",
+      "abstract-algebra",
+      "abelianization",
+      "commutator-subgroup",
+      "non-abelian-groups",
+      "gauss-wilson",
+      "permutation-invariance"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (depends only on propext, Classical.choice, Quot.sound).",
+    "lineCount": 133,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "abelianization_prod_enum: for any enumeration l of a finite group G, Abelianization.of l.prod = ∏ x : G, Abelianization.of x — the ordered product is well-defined modulo commutators and order-independent",
+      "abelianization_prod_order_independent: any two enumerations of G have equal image in Gᵃᵇ, even though their ordered products in G may differ",
+      "enum_perm / enum_perm_toList: any two Nodup lists covering a Fintype are permutations (of each other and of univ.toList)",
+      "prod_enum_eq_of_commGroup: the abelian contrast — when G is commutative every enumeration's product already equals ∏ x : G, x in G itself",
+      "two_elt_prod_ne / two_elt_abelianization_eq: smallest witness — noncommuting a, b give [a,b].prod ≠ [b,a].prod in G yet equal images in Gᵃᵇ"
+    ]
+  },
+  "overview": {
+    "historicalContext": "For a finite abelian group, the product of all elements is a single well-defined element (Gauss–Wilson: it equals the unique nontrivial involution, or 1). Passing to non-abelian groups immediately breaks this: 'the product of all elements' is not defined, because Finset.prod requires a commutative monoid and different orderings of the same elements yield different products. The classical fix is to observe that the ambiguity lives entirely inside the commutator subgroup: the abelianization Gᵃᵇ = G/[G,G] is the universal commutative quotient, and the image of any ordered product there is canonical. This is the group-theoretic content behind the parent proof's open question 'generalize to non-abelian groups: when does ∏G = e?'.",
+    "problemStatement": "Fix a finite group G. An 'enumeration' is a duplicate-free list l : List G containing every element. The ordered product l.prod ∈ G depends on the ordering when G is non-abelian. Show that its image Abelianization.of l.prod ∈ Gᵃᵇ is independent of the enumeration, and compute it as the order-free Finset product ∏ x : G, Abelianization.of x.",
+    "proofStrategy": "**Step 1** (Enumerations are permutations): Two Nodup lists with the same members are permutations (List.perm_ext_iff_of_nodup). In particular every enumeration is a permutation of the canonical univ.toList.\n\n**Step 2** (Pass to the abelianization first): The key subtlety is that l.prod lives in the noncommutative G, where List.Perm.prod_eq — which requires a commutative target — does not apply. Applying the homomorphism Abelianization.of first (map_list_prod) turns the ordered product into a product in the commutative Gᵃᵇ: Abelianization.of l.prod = (l.map of).prod.\n\n**Step 3** (Permutation-invariance in Gᵃᵇ): Since l ~ univ.toList, the mapped lists are permutations, so (l.map of).prod = (univ.toList.map of).prod by List.Perm.prod_eq (now valid in the commutative Gᵃᵇ).\n\n**Step 4** (Identify the Finset product): Finset.prod_map_toList rewrites (univ.toList.map of).prod as ∏ x ∈ univ, of x = ∏ x : G, of x, an expression with no ordering.\n\n**Contrast**: When G is already commutative, Step 2 is unnecessary and l.prod = ∏ x : G, x holds in G itself. The smallest non-abelian witness [a,b] vs [b,a] shows the G-level products differ exactly when a, b do not commute, while their Gᵃᵇ-images always agree by mul_comm.",
+    "keyInsights": [
+      "The product of all elements is not defined in a non-abelian group, but its class in the abelianization Gᵃᵇ = G/[G,G] is a canonical invariant",
+      "The proof must apply Abelianization.of BEFORE using permutation-invariance: l.prod lives in noncommutative G, and List.Perm.prod_eq needs a commutative target",
+      "Order-independence is a corollary: two enumerations map to the same element of Gᵃᵇ because both equal the order-free ∏ x : G, of x",
+      "The abelian case is the degenerate contrast where the invariant already lives in G with no quotient needed",
+      "The two-element witness [a,b] vs [b,a] isolates exactly why the quotient is necessary: G-products differ iff a, b fail to commute, yet Gᵃᵇ-images always agree"
+    ],
+    "prerequisites": [
+      "Abelianization: Abelianization.of : G →* Abelianization G, the CommGroup instance on Abelianization G",
+      "List/permutation API: List.perm_ext_iff_of_nodup, List.Perm.map, List.Perm.prod_eq (commutative), map_list_prod",
+      "Finset enumeration: Finset.nodup_toList, Finset.mem_toList, Finset.prod_map_toList, Finset.prod_toList"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-and-overview",
+      "title": "Imports and Overview",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Imports Mathlib.GroupTheory.Abelianization.Defs and Mathlib.Tactic. The docstring contrasts the abelian parent result with the non-abelian case, states the main theorem (the abelianized ordered product is order-independent and equals ∏ x : G, of x), and lists the five results."
+    },
+    {
+      "id": "enumerations-are-permutations",
+      "title": "Part 1: Enumerations Are Mutually Permutations",
+      "startLine": 53,
+      "endLine": 76,
+      "summary": "Proves enum_perm (two Nodup lists covering a Fintype are permutations) and enum_perm_toList (every enumeration is a permutation of univ.toList), via List.perm_ext_iff_of_nodup. These lemmas carry no group structure (omit [Group G])."
+    },
+    {
+      "id": "well-defined-mod-commutators",
+      "title": "Part 2: The Product Is Well-Defined Modulo Commutators",
+      "startLine": 78,
+      "endLine": 110,
+      "summary": "Proves the main theorem abelianization_prod_enum: Abelianization.of l.prod = ∏ x : G, of x for any enumeration l. The proof applies map_list_prod (pass to Gᵃᵇ first), then List.Perm.prod_eq on the mapped permutation, then Finset.prod_map_toList. Corollary abelianization_prod_order_independent follows immediately."
+    },
+    {
+      "id": "abelian-contrast",
+      "title": "Part 3: The Abelian Contrast",
+      "startLine": 112,
+      "endLine": 121,
+      "summary": "Proves prod_enum_eq_of_commGroup: when G is commutative the ordered product is already order-independent in G itself, equalling ∏ x : G, x. Here List.Perm.prod_eq applies directly in G (no abelianization needed), highlighting exactly what the quotient buys in the general case."
+    },
+    {
+      "id": "smallest-witness",
+      "title": "Part 4: The Smallest Witness — Noncommuting Pair",
+      "startLine": 123,
+      "endLine": 133,
+      "summary": "Proves two_elt_prod_ne (noncommuting a, b give [a,b].prod ≠ [b,a].prod in G) and two_elt_abelianization_eq (their abelianization images agree via mul_comm). Together they isolate the exact obstruction that the abelianization removes."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "wilsons-theorem-oq-04-oq-02",
+      "relationship": "extends",
+      "description": "Parent proof, which computes the product of all elements for finite commutative groups and poses the open question 'generalize to non-abelian groups: when does ∏G = e?'. This file answers a precise refinement: the product is well-defined modulo commutators, its Gᵃᵇ-image being order-independent."
+    },
+    {
+      "targetId": "wilsons-theorem-oq-02",
+      "relationship": "related",
+      "description": "Sibling proof instantiating the abelian product formula for the units group (ℤ/nℤ)×. The present file explains what remains of that statement once commutativity is dropped."
+    },
+    {
+      "targetId": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Classical root: Wilson's theorem (p-1)! ≡ -1 (mod p) is the product-of-all-elements formula for the cyclic group (ℤ/pℤ)×; the non-abelian generalization here lives at the opposite extreme of the abelian/non-abelian spectrum."
+    }
+  ],
+  "conclusion": {
+    "summary": "Identified the invariant that survives the passage to non-abelian groups: while the ordered product of all elements is order-dependent in G, its image in the abelianization Gᵃᵇ is order-independent and equals the order-free Finset product ∏ x : G, of x. Proved order-independence, the abelian contrast, and the smallest noncommuting witness. 5 theorems, 0 axioms, 133 lines, fully machine-verified.",
+    "implications": "This makes precise the sense in which 'the product of all elements of a finite group' is meaningful without commutativity: it is a canonical element of the abelianization Gᵃᵇ = G/[G,G]. The abelian Gauss–Wilson computation is recovered as the special case where Gᵃᵇ = G. The proof also exposes a reusable pattern — apply a homomorphism into a commutative target before invoking permutation-invariance — for reasoning about ordered products in noncommutative structures.",
+    "openQuestions": [
+      "Compute ∏ x : G, Abelianization.of x explicitly in terms of the structure of Gᵃᵇ (e.g. via the Sylow-2 subgroup of Gᵃᵇ and the multiplicity |[G,G]| with which each abelianization class is hit).",
+      "Characterize the finite groups for which some (equivalently, every) enumeration has ∏ l = 1 in G itself — the Hall–Paige / sequenceable-group phenomenon lying beyond the abelianization invariant."
+    ]
+  },
+  "leanFile": {
+    "namespace": "WilsonsTheoremOQ04OQ02OQ01",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/WilsonsTheoremOQ04OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "J. J. Rotman",
+      "title": "An Introduction to the Theory of Groups",
+      "year": 1995,
+      "venue": "Springer",
+      "note": "Abelianization G/[G,G] as the universal abelian quotient; product of all elements of a finite abelian group."
+    },
+    {
+      "authors": "M. Hall and L. J. Paige",
+      "title": "Complete mappings of finite groups",
+      "year": 1955,
+      "venue": "Pacific J. Math.",
+      "note": "Context for when the elements of a finite group can be ordered so that their product is the identity (sequenceable / R-sequenceable groups)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Abelianization, map_list_prod, List.Perm.prod_eq, and the Finset enumeration API used here."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers a precise refinement of the parent proof's open question *"generalize to non-abelian groups: when does ∏G = e?"* (`wilsons-theorem-oq-04-oq-02`).

For a finite **abelian** group the product of all elements is a single well-defined element (Gauss–Wilson). For a **non-abelian** group it is not — `Finset.prod` needs commutativity, and different orderings of the elements give different products. This file pins down the invariant that survives:

> **Main theorem** (`abelianization_prod_enum`): for any enumeration `l` of a finite group `G` (a `Nodup` list containing every element),
> `Abelianization.of l.prod = ∏ x : G, Abelianization.of x`.

So while `l.prod` is order-dependent in `G`, its class modulo the commutator subgroup `[G,G]` is a canonical group invariant.

## Key idea

The proof is *forced* to pass to the abelianization **before** using permutation-invariance: `l.prod` lives in the noncommutative `G`, where `List.Perm.prod_eq` (which requires a commutative target) does not apply. Applying the homomorphism `Abelianization.of` first (`map_list_prod`) moves the ordered product into the commutative `Gᵃᵇ`, where reordering is invisible.

## Results (5 theorems, 0 axioms, 133 lines)

- `enum_perm` / `enum_perm_toList` — any two `Nodup` lists covering a `Fintype` are permutations (of each other and of `univ.toList`).
- `abelianization_prod_enum` — **main**: the abelianized ordered product is order-independent and equals `∏ x : G, of x`.
- `abelianization_prod_order_independent` — two enumerations have equal image in `Gᵃᵇ`.
- `prod_enum_eq_of_commGroup` — abelian contrast: when `G` is commutative the product is already order-independent in `G` itself.
- `two_elt_prod_ne` / `two_elt_abelianization_eq` — smallest witness: noncommuting `a, b` give `[a,b].prod ≠ [b,a].prod` in `G`, yet equal images in `Gᵃᵇ`.

## Verification

- Builds cleanly against Mathlib (`lake env lean`), 0 sorries, 0 warnings.
- `#print axioms` on all 5 theorems: only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). Genuinely axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)