### PR TITLE
Enrich Erdős #357 OQ-04 (little-o ⇔ ratio-limit): +1 annotation, +1 keyInsight

### DIFF
--- a/src/data/proofs/erdos-357-oq-04/annotations.json
+++ b/src/data/proofs/erdos-357-oq-04/annotations.json
@@ -60,11 +60,11 @@
     "proofId": "erdos-357-oq-04",
     "range": {
       "startLine": 73,
-      "endLine": 92
+      "endLine": 83
     },
     "type": "theorem",
     "title": "ε–N Characterization of Sublinear Growth",
-    "content": "**`littleO_natCast_iff_eventually_le`.** For a *nonnegative* sequence $u$, $u =o[atTop] n$ is equivalent to $\\forall \\varepsilon > 0,\\ \\forall^{\\!f} n,\\ u(n) \\le \\varepsilon\\, n$. The proof rewrites the little-o relation via `Asymptotics.isLittleO_iff` into $\\forall c > 0,\\ \\forall^{\\!f} n,\\ \\lVert u(n)\\rVert \\le c\\,\\lVert n\\rVert$ and erases both norms with `Real.norm_of_nonneg` ($\\lVert u(n)\\rVert = u(n)$ since $u \\ge 0$, and $\\lVert(n:\\mathbb{R})\\rVert = n$). `sublinear_tfae` then packages the little-o, ratio-limit, and ε–N forms into one equivalence. This ε–N form is the operational shape density estimates are written in.",
+    "content": "**`littleO_natCast_iff_eventually_le`.** For a *nonnegative* sequence $u$, $u =o[atTop] n$ is equivalent to $\\forall \\varepsilon > 0,\\ \\forall^{\\!f} n,\\ u(n) \\le \\varepsilon\\, n$. The proof rewrites the little-o relation via `Asymptotics.isLittleO_iff` into $\\forall c > 0,\\ \\forall^{\\!f} n,\\ \\lVert u(n)\\rVert \\le c\\,\\lVert n\\rVert$ and erases both norms with `Real.norm_of_nonneg` ($\\lVert u(n)\\rVert = u(n)$ since $u \\ge 0$, and $\\lVert(n:\\mathbb{R})\\rVert = n$). The nonnegativity hypothesis is used *only* to drop the numerator norm — the ratio-limit half needs no such assumption. This ε–N form is the operational shape density estimates are written in.",
     "mathContext": "`isLittleO_iff : f =o[l] g ↔ ∀ ⦃c⦄, 0 < c → ∀ᶠ x in l, ‖f x‖ ≤ c * ‖g x‖`; for $u \\ge 0$ and $n \\ge 0$ the norms drop.",
     "significance": "key",
     "relatedConcepts": [
@@ -81,6 +81,33 @@
       "epsilon-n",
       "asymptotics",
       "nonnegative"
+    ]
+  },
+  {
+    "id": "ann-e357oq04-tfae",
+    "proofId": "erdos-357-oq-04",
+    "range": {
+      "startLine": 84,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "Packaging the Trichotomy",
+    "content": "**`sublinear_tfae`.** For a nonnegative $u$, this collapses the two preceding lemmas into a single equivalence between the ratio-limit form $\\mathrm{Tendsto}\\,(\\lambda n.\\,u(n)/n)\\,atTop\\,(\\mathcal{N}\\,0)$ and the ε–N form $\\forall \\varepsilon>0,\\ \\forall^{\\!f} n,\\ u(n) \\le \\varepsilon\\,n$. The proof is a two-line composition: rewrite along `← littleO_natCast_iff_ratio_tendsto` to expose the little-o form, then apply `littleO_natCast_iff_eventually_le`. The little-o form is the hidden pivot connecting the two 'analyst-facing' forms — it never appears in the statement of `sublinear_tfae`, yet it is what makes the equivalence hold. This is the single result the density corollaries below instantiate.",
+    "mathContext": "$\\lim_n u(n)/n = 0 \\iff \\forall\\varepsilon>0,\\ \\text{eventually } u(n) \\le \\varepsilon n$ (for $u \\ge 0$), with $u =o[atTop] n$ as the intermediary.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Transitivity of iff",
+      "little-o as intermediary form",
+      "TFAE-style packaging"
+    ],
+    "prerequisites": [
+      "The general equivalence and ε–N lemma above"
+    ],
+    "tags": [
+      "theorem",
+      "trichotomy",
+      "asymptotics",
+      "packaging"
     ]
   },
   {

--- a/src/data/proofs/erdos-357-oq-04/meta.json
+++ b/src/data/proofs/erdos-357-oq-04/meta.json
@@ -94,7 +94,8 @@
       "The parent's conjecture_equiv is a one-off specialization: the ONLY property of f it uses is that the numerator is a sequence and the denominator n is eventually nonzero. Abstracting to arbitrary u : ℕ → ℝ loses nothing and makes the bridge reusable.",
       "Along atTop the side condition of isLittleO_iff_tendsto' is vacuous — n is eventually positive, hence nonzero — so the little-o and ratio-limit forms are unconditionally equivalent for every sequence.",
       "For nonnegative sequences the little-o statement is literally the ε–N definition of sublinear growth: ∀ ε > 0, eventually u n ≤ ε·n. This is the operational form for density work, obtained by erasing the norms via Real.norm_of_nonneg.",
-      "The parent states its infinite-set density-zero conjecture only as a ratio limit; the same trichotomy gives it the little-o and ε–N faces for free, so any attack on that OPEN conjecture can pick whichever form is most convenient."
+      "The parent states its infinite-set density-zero conjecture only as a ratio limit; the same trichotomy gives it the little-o and ε–N faces for free, so any attack on that OPEN conjecture can pick whichever form is most convenient.",
+      "The two halves of the trichotomy carry different hypotheses, and reading the proof pinpoints why. The little-o ⇔ ratio-limit equivalence (littleO_natCast_iff_ratio_tendsto) is unconditional — it holds for every u : ℕ → ℝ, including sign-changing sequences — because it needs only that the denominator (n:ℝ) is eventually nonzero. The ε–N face (littleO_natCast_iff_eventually_le) additionally assumes u ≥ 0, and that hypothesis is spent in exactly one place: erasing the numerator norm via Real.norm_of_nonneg (‖u n‖ = u n). For counting functions, which are nonnegative by construction, this extra cost is invisible, so the density corollaries inherit all three forms with no side conditions."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `erdos-357-oq-04` (0 prior passes).

## Gap addressed
The entry already had rich meta.json (14 KB, under the 60 KB cap) and 4 annotations covering the whole file, but sat at the bare minimum on two axes: **4 annotations** (target ≥5) and **4 keyInsights** (minimum 4). The Lean file has 6 declarations, so the ε–N lemma and the `sublinear_tfae` trichotomy were sharing one annotation. No `index.ts` is needed — the gallery loads entries by slug from the build-generated manifest (per `src/data/proofs/index.ts`), not per-directory shims.

## Changes
- **Split** the combined 'ε–N + trichotomy' annotation (lines 73–92) into two concept-per-annotation entries: ε–N characterization (73–83) and a new **'Packaging the Trichotomy'** annotation (84–92) for `sublinear_tfae`, noting that the little-o form is the *hidden pivot* connecting the two analyst-facing forms — it never appears in the theorem statement yet is what makes the equivalence hold. → **5 annotations**, one per declaration group.
- **Added a 5th keyInsight** pinpointing, from the proof, that the little-o ⇔ ratio-limit equivalence is *unconditional* (any `u : ℕ → ℝ`, sign-changing included) while the ε–N face's nonnegativity hypothesis is spent in exactly one place: erasing the numerator norm via `Real.norm_of_nonneg`. Counting functions are nonnegative by construction, so the density corollaries inherit all three forms with no side conditions.

## Validation
- `annotations.json` and `meta.json` parse cleanly (5 annotations, 5 keyInsights).
- `scripts/gallery/check-meta-size.ts erdos-357-oq-04`: within caps (14.6 KB ≤ 60 KB).
- `pnpm build` data-generation/enrichment step processes the entry without error (final `tsc` step fails only due to missing node_modules in the fresh worktree — environmental, unrelated to these JSON edits).
- No axiom/status changes: entry remains verified, 0 axioms, 0 sorries.