### PR TITLE
research(schroeder-bernstein-oq-03): least-fresh-element computable exhaustion primitive [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -472,6 +472,93 @@ theorem matching_length_cons (a b : ℕ) (L : List (ℕ × ℕ)) :
     ((a, b) :: L).length = L.length + 1 := by simp
 
 /-!
+## Section 4d: Least fresh element — the computable exhaustion primitive
+
+The atomic steps of Section 4c (`matching_step_f`, `matching_step_g`) each extend a
+finite matching by one edge, provided the new endpoint is *fresh* (not already in
+`mDom L` / `mRan L`). To turn these steps into a construction that covers **all** of
+ℕ, the priority scheduler must, at each stage, target the *least* natural number not
+yet present on the relevant side (`mDom` at even stages, `mRan` at odd stages).
+Because it always attacks the least uncovered element, every `k` is guaranteed to be
+handled by stage `2k + 1` — this is exactly the domain/range-exhaustion argument the
+scheduler needs (cf. `matching_length_cons`).
+
+This section provides that targeting function as a total, computable
+`firstMissing : List ℕ → ℕ` returning the least natural not occurring in a finite
+list, together with the two properties the exhaustion proof consumes: `firstMissing`
+is genuinely absent (`firstMissing_not_mem`), and it is *minimal* — every smaller
+number is already present (`firstMissing_lt_mem`), so `List.range (firstMissing L) ⊆
+L` and repeated extension strictly grows the covered prefix. Its computability
+(`firstMissing_computable`) is what keeps the permutation built on top of it
+computable; the proof mirrors the `partialInverse`/`totalInverse` pattern of
+Sections 3–4b (`Nat.rfind` search + everywhere-defined ⟹ total computable).
+-/
+
+/-- Partial version: search (via `Nat.rfind`) for the least `n` absent from `L`.
+    Absence `n ∉ L` is phrased decidably as `List.idxOf n L = L.length` (a list's
+    `idxOf` equals its length exactly when the element is missing). -/
+def firstMissingPart (L : List ℕ) : Part ℕ :=
+  Nat.rfind fun n => decide (List.idxOf n L = L.length)
+
+/-- A finite list of naturals always omits some natural number (ℕ is infinite). -/
+theorem exists_not_mem_list (L : List ℕ) : ∃ n : ℕ, n ∉ L := by
+  obtain ⟨n, hn⟩ := Infinite.exists_notMem_finset L.toFinset
+  exact ⟨n, fun h => hn (List.mem_toFinset.mpr h)⟩
+
+/-- The search terminates: a missing element exists, so `firstMissingPart` is
+    everywhere defined. -/
+theorem firstMissingPart_dom (L : List ℕ) : (firstMissingPart L).Dom := by
+  obtain ⟨n, hn⟩ := exists_not_mem_list L
+  rw [firstMissingPart, Nat.rfind_dom']
+  exact ⟨n, by simp [hn], fun _ => trivial⟩
+
+/-- **Least fresh element**: the least natural number not occurring in `L`. -/
+def firstMissing (L : List ℕ) : ℕ := (firstMissingPart L).get (firstMissingPart_dom L)
+
+/-- `firstMissing L` is a valid value of the underlying `rfind` search. -/
+theorem firstMissing_mem_part (L : List ℕ) : firstMissing L ∈ firstMissingPart L :=
+  Part.get_mem _
+
+/-- **Freshness**: `firstMissing L` is genuinely absent from `L`. This is what makes
+    it a legal endpoint for `matching_step_f` / `matching_step_g` (with `L := mDom …`
+    or `mRan …`). -/
+theorem firstMissing_not_mem (L : List ℕ) : firstMissing L ∉ L := by
+  have h := Nat.rfind_spec (firstMissing_mem_part L)
+  have h2 : List.idxOf (firstMissing L) L = L.length := by simpa using h
+  exact List.idxOf_eq_length_iff.mp h2
+
+/-- **Minimality**: every natural number below `firstMissing L` already occurs in
+    `L`. Equivalently `List.range (firstMissing L) ⊆ L`. Together with
+    `firstMissing_not_mem` this pins down `firstMissing L` as the least element of the
+    complement of `L`, so repeatedly extending by it exhausts an ever-larger initial
+    segment of ℕ — the termination measure of the priority construction. -/
+theorem firstMissing_lt_mem (L : List ℕ) {m : ℕ} (hm : m < firstMissing L) : m ∈ L := by
+  have h := Nat.rfind_min (firstMissing_mem_part L) hm
+  have h2 : ¬ (List.idxOf m L = L.length) := by simpa using h
+  by_contra hmem
+  exact h2 (List.idxOf_eq_length_iff.mpr hmem)
+
+/-- **`firstMissing` is computable.** List membership `n ∈ L` is primitive recursive
+    (through `List.idxOf` and `List.length`), so the bounded `rfind` search is partial
+    recursive; being everywhere defined (`firstMissingPart_dom`) it coincides with the
+    total function `firstMissing`. This is the computability guarantee that lets the
+    back-and-forth permutation assembled from these fresh-element choices remain
+    computable. -/
+theorem firstMissing_computable : Computable firstMissing := by
+  have hp : Partrec firstMissingPart := by
+    unfold firstMissingPart
+    apply Partrec.rfind
+    apply Computable₂.partrec₂
+    have hidx : Computable (fun p : List ℕ × ℕ => List.idxOf p.2 p.1) :=
+      Primrec.list_idxOf.to_comp.comp Computable.snd Computable.fst
+    have hlen : Computable (fun p : List ℕ × ℕ => p.1.length) :=
+      Primrec.list_length.to_comp.comp Computable.fst
+    have heq0 : Primrec₂ (fun a b : ℕ => decide (a = b)) := Primrec.eq.decide
+    have heq : Computable₂ (fun a b : ℕ => decide (a = b)) := heq0.to_comp
+    exact heq.comp hidx hlen
+  exact hp.of_eq (fun L => (Part.some_get (firstMissingPart_dom L)).symm)
+
+/-!
 ## Section 5: The Myhill Isomorphism Theorem
 -/
 

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -124,3 +124,33 @@ its computability (bounded search for the entering stage) is the residual work.
 Gotchas (v4.26): `List.not_mem_nil` here has type `a ∈ [] → False` (not `¬ ...`), so use
 `by intro _ h; simp at h` for the empty-list vacuous case. `List.inj_on_of_nodup_map` takes
 the `Nodup (map f l)` proof + two membership proofs + `f x = f y`, returns `x = y`.
+
+## Session (researcher-6, 2026-07-01) — least-fresh-element exhaustion primitive
+
+Added **Section 4d** (`firstMissing : List ℕ → ℕ`), the computable least-not-in-list
+function, on top of the now-merged Section 4c matching layer (#32280). This is the
+domain/range **exhaustion engine** for the priority scheduler: at each stage the
+back-and-forth targets `firstMissing (mDom L)` (even) / `firstMissing (mRan L)` (odd),
+so every k is covered by stage 2k+1. All VERIFIED 0-axiom (propext/Classical.choice/
+Quot.sound only; no sorryAx, no ofReduceBool). PR #32300.
+
+- `firstMissingPart`/`firstMissing` — total via `Nat.rfind (fun n => decide (idxOf n L = length L))`.
+- `exists_not_mem_list` — `Infinite.exists_notMem_finset L.toFinset` + `List.mem_toFinset`.
+- `firstMissing_not_mem` (freshness) + `firstMissing_lt_mem` (minimality: `range (firstMissing L) ⊆ L`).
+- `firstMissing_computable` — membership primrec via `Primrec.list_idxOf`/`list_length`;
+  rfind→partrec→total computable (mirrors `totalInverse_computable`).
+
+Key facts used: `List.idxOf_eq_length_iff : idxOf a l = length l ↔ a ∉ l` (Data/List/Basic);
+`Primrec.list_idxOf : Primrec₂ (@List.idxOf α _)` (element-first arg order).
+
+Main `myhill_isomorphism` → sorry STILL OPEN — the scheduler (recurse over stages
+building an increasing chain of matchings + collision-chasing alternating f/g chain +
+its computability) is the remaining crux. `firstMissing` supplies the per-stage target;
+what's left is (a) the stage recursion producing `IsMatching`+`MatchingCorr` matchings,
+(b) proving the chain covers ℕ (using `firstMissing_lt_mem`), (c) reading off a computable
+`ℕ ≃ ℕ` and its computability.
+
+WORKTREE HAZARD (this session): editing the file in the MAIN repo was CLOBBERED by a
+concurrent process reverting it to HEAD; then a /private/tmp worktree was REAPED between
+compile and edit. Use a durable worktree AND stage the edit as a snippet file so it can
+be re-applied fast; commit+push immediately after the verifying compile.


### PR DESCRIPTION
## Summary

Advances the **Myhill isomorphism theorem** development (`schroeder-bernstein-oq-03`) by adding **Section 4d: the least-fresh-element computable exhaustion primitive** — the piece the stage-wise back-and-forth scheduler needs on top of the just-merged Section 4c matching layer (#32280).

The open hard direction builds a computable permutation by a priority construction that, at each stage, extends a finite matching (`mDom`/`mRan`, `matching_step_f`/`matching_step_g`) by targeting the **least** natural not yet covered on the relevant side. This PR provides that targeting function and the exhaustion facts it must satisfy.

## New declarations (all VERIFIED, 0-axiom)

`#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for each — **no `sorryAx`, no `Lean.ofReduceBool`**:

- `firstMissingPart` / `firstMissing` — total `List ℕ → ℕ` returning the least absent natural, via `Nat.rfind`
- `exists_not_mem_list` — ℕ is infinite, so a finite list always omits some natural
- `firstMissingPart_dom` — a missing element exists ⟹ the search is everywhere defined
- `firstMissing_not_mem` — **freshness**: `firstMissing L ∉ L` (a legal endpoint for the atomic steps)
- `firstMissing_lt_mem` — **minimality**: every `m < firstMissing L` is already in `L` (i.e. `range (firstMissing L) ⊆ L`), the termination measure for domain/range exhaustion
- `firstMissing_computable` — membership is primitive recursive (`List.idxOf`/`List.length`), so the bounded `rfind` search is partial recursive and, being everywhere defined, a total computable function — this is what keeps the assembled permutation computable

The proof mirrors the existing `partialInverse`/`totalInverse` pattern (Sections 3–4b): `Nat.rfind` search + everywhere-defined ⟹ total computable.

## Scope

Purely additive (new Section 4d). The main `myhill_isomorphism` hard-direction `sorry` (the scheduler / collision-chasing back-and-forth) **remains open and unchanged**.

## Verification

Compiled with `lean` 4.26.0 against the prebuilt Mathlib oleans (single-file `lake env lean`); only warnings are the pre-existing `sorry` in `myhill_isomorphism` and pre-existing unused-variable lints in other theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)