### PR TITLE
Enrich Fibonacci Linear Sums (OQ-06): add arithmetic-series cross-reference

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-06/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-06/annotations.json
@@ -72,7 +72,8 @@
       "moments of a sequence ∑ iᵏ Fᵢ",
       "Fibonacci generating function x/(1−x−x²)",
       "uniform proof recipe (sum_range_succ + fib_add_two)",
-      "second-moment open question"
+      "second-moment open question",
+      "arithmetic series ∑ i = n(n+1)/2 (first moment of the constant sequence)"
     ],
     "prerequisites": [
       "the two identities above",

--- a/src/data/proofs/fibonacci-identities-oq-06/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06/meta.json
@@ -112,6 +112,11 @@
       "targetId": "lucas-sum-oq-01",
       "relationship": "relatedTo",
       "description": "The Lucas analogue of this entry's fib_sum: the partial sum ∑_{k=1}^{n} Lₖ = Lₙ₊₂ − 3 telescopes exactly as F₀ + ⋯ + Fₙ = Fₙ₊₂ − 1 does here, differing only in the constant (3 vs 1) fixed by the initial conditions L₀ = 2, L₁ = 1 rather than F₀ = 0, F₁ = 1. It realizes, at degree zero, the general Gibonacci partial-sum question raised in this entry's open problems and shares the same subtraction-free-in-ℕ + omega proof recipe."
+    },
+    {
+      "targetId": "arithmetic-series",
+      "relationship": "relatedTo",
+      "description": "The archetypal index-weighted sum. Gauss's ∑_{i≤n} i = n(n+1)/2 is the first moment of the constant sequence 1, exactly the trivial rung of the moment ladder S_k(n) = ∑ iᵏ·(sequence) that this entry climbs for the Fibonacci sequence with fib_weighted_sum (∑ i·Fᵢ). Both are index-weighted sums proved by the same Finset.sum_range_succ induction; the Fibonacci case merely replaces the closed-form polynomial n(n+1)/2 with a Fibonacci-valued closed form n·Fₙ₊₂ − Fₙ₊₃ + 2, reflecting that the underlying sequence obeys the two-term recurrence rather than being constant."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-06` (0 prior passes).

## Assessment
This entry is already high quality: rich meta.json (14.5 KB, well under the 60 KB cap), 4 substantive annotations covering the entire 70-line / 2-theorem file (including a fine 'moment ladder' synthesis), 4 keyInsights, 3 references, and a conclusion with 3 open questions. Per the size guardrails (*quality is curation, not accretion*), I did **not** pad the annotations or split the already-complete coverage of a 70-line file. I focused on the one genuinely missing, accurate link.

## Changes
- **New cross-reference to `arithmetic-series`** (3 → 4 crossRefs, cap 20): Gauss's ∑ i = n(n+1)/2 is the *first moment of the constant sequence* — the trivial rung of the moment ladder S_k(n) = ∑ iᵏ·(sequence) that `fib_weighted_sum` (∑ i·Fᵢ) climbs for the Fibonacci sequence. Both are index-weighted sums closed by the same `Finset.sum_range_succ` induction; the Fibonacci case swaps the polynomial closed form for a Fibonacci-valued one, reflecting the two-term recurrence. The entry's existing 'moment ladder' annotation already frames exactly this, so the link is substantive rather than decorative.
- **Wired the connection into the 'moment ladder' annotation's relatedConcepts** for narrative coherence.
- **Verified** all three pre-existing cross-reference targets (`fibonacci-identities`, `fibonacci-identities-oq-05`, `lucas-sum-oq-01`) resolve.

## Validation
- `annotations.json` / `meta.json` parse cleanly (4 annotations, 4 crossRefs).
- `scripts/gallery/check-meta-size.ts`: within caps (14.5 KB ≤ 60 KB).
- No axiom/status changes: entry remains verified, 0 axioms, 0 sorries.