### PR TITLE
research(erdos-335-oq-01): Schnirelmann↔asymptotic density bridge [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos335Problem.lean
+++ b/proofs/Proofs/Erdos335Problem.lean
@@ -25,6 +25,7 @@ import Mathlib.Data.Set.Finite.Lattice
 import Mathlib.Topology.Basic
 import Mathlib.Topology.Order.Basic
 import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Combinatorics.Schnirelmann
 import Mathlib.Tactic
 
 open Set Filter
@@ -457,3 +458,66 @@ theorem exists_self_additive_density_quarter :
   refine ⟨FractionalPartSet (Real.sqrt 2) (Set.Ico (0 : ℝ) (1 / 4)), ?_, hadd, hdens, ?_⟩
   · unfold HasPositiveDensity; rw [hdens]; norm_num
   · rw [hadd.2.2.2, hdens]; norm_num
+
+/- ## Bridge to Mathlib's Schnirelmann Density
+
+This section connects the file's `asympDensity` (the asymptotic/natural density,
+which is *not* in Mathlib at the pinned SHA — its module TODO lists it as
+unformalized) to Mathlib's `schnirelmannDensity`. The Schnirelmann density is the
+*infimum* of the same counting ratios `|A ∩ {1,…,n}| / n`, whereas the asymptotic
+density is their *limit*. Consequently the Schnirelmann density is a lower bound
+for the asymptotic density whenever the latter exists.
+
+The bridge is proved by matching the two counting functions: `countingFn A N`
+(defined here via `Set.ncard (A ∩ Icc 1 N)`) equals Mathlib's filtered-cardinal
+counting `#{a ∈ Ioc 0 N | a ∈ A}`, since `Set.Ioc 0 N = Set.Icc 1 N` on `ℕ`. -/
+
+/-- The counting function of this file agrees with the filtered-cardinal counting
+used in Mathlib's Schnirelmann density: `|A ∩ {1,…,N}|` computed as a set-`ncard`
+equals the `Finset.filter` cardinality over `Ioc 0 N`. -/
+theorem countingFn_eq_filter_card (A : Set ℕ) [DecidablePred (· ∈ A)] (N : ℕ) :
+    countingFn A N = ((Finset.Ioc 0 N).filter (· ∈ A)).card := by
+  unfold countingFn
+  rw [← Set.ncard_coe_finset]
+  congr 1
+  ext x
+  simp only [Finset.coe_filter, Finset.mem_Ioc, Set.mem_setOf_eq, Set.mem_inter_iff,
+    Set.mem_Icc]
+  constructor
+  · rintro ⟨hA, h1, h2⟩; exact ⟨⟨by omega, h2⟩, hA⟩
+  · rintro ⟨⟨h0, h2⟩, hA⟩; exact ⟨hA, by omega, h2⟩
+
+/-- **Schnirelmann–asymptotic bridge.** For any set `A ⊆ ℕ` whose asymptotic
+density exists, the Schnirelmann density is a lower bound:
+`schnirelmannDensity A ≤ asympDensity A`.
+
+This is the natural comparison between the two densities: Schnirelmann is the
+infimum of the ratios `|A ∩ {1,…,n}| / n` while `asympDensity` is their limit, so
+the infimum cannot exceed the limit. It gives a route to transfer Mathlib's ~20
+Schnirelmann lemmas into statements about the asymptotic density used throughout
+this file. Note the inequality can be strict: `schnirelmannDensity {even} = 0`
+(as `1 ∉ {even}` forces the `n = 1` ratio to `0`) while `asympDensity {even} = 1/2`. -/
+theorem schnirelmann_le_asymp (A : Set ℕ) [DecidablePred (· ∈ A)]
+    (hA : DensityExists A) : schnirelmannDensity A ≤ asympDensity A := by
+  obtain ⟨d, hd⟩ := hA
+  rw [show asympDensity A = d from hd.limUnder_eq]
+  refine ge_of_tendsto hd ?_
+  filter_upwards [Filter.eventually_ne_atTop 0] with N hN
+  rw [countingFn_eq_filter_card A N]
+  exact schnirelmannDensity_le_div hN
+
+/-- Consequence of the bridge: for a set with positive Schnirelmann density and an
+existing asymptotic density, the asymptotic density is also positive. This lets one
+certify `HasPositiveDensity` from the more computable Schnirelmann density. -/
+theorem hasPositiveDensity_of_schnirelmann_pos (A : Set ℕ) [DecidablePred (· ∈ A)]
+    (hA : DensityExists A) (hpos : 0 < schnirelmannDensity A) : HasPositiveDensity A :=
+  lt_of_lt_of_le hpos (schnirelmann_le_asymp A hA)
+
+/-- In a density-additive pair, the Schnirelmann density of each part is bounded by
+its share of the total: `schnirelmannDensity A ≤ asympDensity A ≤ 1 - asympDensity B`.
+Combines the bridge with `density_additive_complement_bound`. -/
+theorem schnirelmann_le_complement (A B : Set ℕ) [DecidablePred (· ∈ A)]
+    (h : DensityAdditive A B) : schnirelmannDensity A ≤ 1 - asympDensity B := by
+  have hbridge := schnirelmann_le_asymp A h.1
+  have hsum := additive_sum_le_one A B h
+  linarith

--- a/research/problems/erdos-335/sessions/2026-07-01-s08-act-schnirelmann-asymptotic-bridge.md
+++ b/research/problems/erdos-335/sessions/2026-07-01-s08-act-schnirelmann-asymptotic-bridge.md
@@ -1,0 +1,50 @@
+# S8 ACT — Schnirelmann↔Asymptotic Density Bridge (researcher-2, 2026-07-01)
+
+## Goal
+Land the remaining S7 roadmap item pinned since S6 PREP: connect this file's
+`asympDensity` to Mathlib's `schnirelmannDensity`.
+
+## What shipped (4 new theorems, all 0-axiom, 0 sorries)
+
+1. **`countingFn_eq_filter_card`** — this file's counting function
+   `countingFn A N = Set.ncard (A ∩ Icc 1 N)` equals Mathlib's filtered-cardinal
+   counting `((Finset.Ioc 0 N).filter (· ∈ A)).card`, because `Set.Ioc 0 N =
+   Set.Icc 1 N` on `ℕ`. Proof: `Set.ncard_coe_finset` + `Finset.coe_filter` + set
+   `ext`. (omega cannot close the ext goal — `x ∈ A` is a non-arithmetic atom — so
+   the membership equivalence is discharged by explicit `constructor`/`rintro`.)
+
+2. **`schnirelmann_le_asymp`** — the bridge:
+   `schnirelmannDensity A ≤ asympDensity A` when `DensityExists A`.
+   Schnirelmann density is the *infimum* of the ratios `|A∩{1,…,n}|/n`,
+   `asympDensity` is their *limit*, so infimum ≤ limit. Proof:
+   `ge_of_tendsto` on the density limit + `schnirelmannDensity_le_div` per `n`,
+   after rewriting the counting function via lemma (1).
+
+3. **`hasPositiveDensity_of_schnirelmann_pos`** — positive Schnirelmann density
+   certifies `HasPositiveDensity` (positive asymptotic density).
+
+4. **`schnirelmann_le_complement`** — in a density-additive pair,
+   `schnirelmannDensity A ≤ 1 − asympDensity B` (bridge + `additive_sum_le_one`).
+
+## Why this matters
+Mathlib has ~20 `schnirelmannDensity` lemmas but does NOT formalize the asymptotic
+density (its module TODO lists it as unformalized). The bridge lets those lemmas
+transfer to lower bounds on the asymptotic density used throughout #335. The
+inequality is genuinely strict in general: `schnirelmannDensity {even} = 0`
+(as `1 ∉ {even}`) while `d({even}) = 1/2`.
+
+## Axiom status
+`#print axioms` on all 4 new theorems: only `propext, Classical.choice, Quot.sound`.
+The 3 deep file axioms (`weyl_equidistribution`, `fractional_part_density_additive`,
+`erdos_335_conjecture`) are untouched — this session adds NO new assumptions.
+
+## New import
+`import Mathlib.Combinatorics.Schnirelmann`
+
+## Build
+`cd proofs && lake env lean Proofs/Erdos335Problem.lean` — 0 errors / 0 warnings
+against pinned Mathlib v4.26.0.
+
+## Next
+- Transfer `schnirelmannDensity_le_of_notMem` etc. through the bridge to asymptotic upper bounds.
+- Mann-type lower bound `d(A+B) ≥ min(d(A)+d(B),1)` remains blocked upstream (absent from Mathlib).

--- a/research/problems/erdos-335/state.md
+++ b/research/problems/erdos-335/state.md
@@ -1,16 +1,16 @@
 # Current State
 
-**Phase**: ACT (build repair + S8/S9 lemmas landed)
-**Since**: 2026-06-25T13:30:00Z (S7 ACT shipped 2026-06-25; baseline iteration tracking carried over from S1 OBSERVE on 2026-01-13)
-**Iteration**: 7
+**Phase**: ACT (Schnirelmann↔asymptotic bridge landed — S7 roadmap item closed)
+**Since**: 2026-07-01 (S8 ACT shipped 2026-07-01; baseline iteration tracking carried over from S1 OBSERVE on 2026-01-13)
+**Iteration**: 8
 
 ## Current Focus
 
-S7 ACT (researcher-4) **repaired a broken build**: the `origin/main` file no longer compiled against its *own* pinned Mathlib v4.26.0 due to API drift (`Set.ncard_Icc`, `div_le_div_right`, `div_lt_iff` removed; `Tendsto.congr'` arg order changed). Fixed all four and landed S8 (`density_additive_zero_singleton`) + S9 (`Sumset_singleton_left`/`_right`) from the S6 roadmap, plus two strict-bound corollaries. Remaining roadmap item — the Schnirelmann↔asymptotic bridge — is still open.
+S8 ACT (researcher-2) **closed the last open S6 roadmap item**, the Schnirelmann↔asymptotic bridge. Imported `Mathlib.Combinatorics.Schnirelmann` and proved `schnirelmann_le_asymp : schnirelmannDensity A ≤ asympDensity A` when the asymptotic density exists (infimum of the ratios ≤ their limit), plus the supporting `countingFn_eq_filter_card` (identifying this file's `Set.ncard` counting with Mathlib's `Finset.filter` counting over `Ioc 0 N`) and two corollaries (`hasPositiveDensity_of_schnirelmann_pos`, `schnirelmann_le_complement`). All four are 0-axiom; the three deep axioms are untouched. This makes Mathlib's ~20 Schnirelmann lemmas available as lower bounds for the asymptotic density used throughout the file.
 
-## Lean File Snapshot (HEAD = research/erdos-335-oq-01-build-repair)
+## Lean File Snapshot
 
-- `proofs/Proofs/Erdos335Problem.lean`: 414 LOC, **40 theorems/lemmas**, 8 defs, **0 sorries**, **3 axioms**. Compiles clean (0 errors / 0 warnings) against pinned Mathlib v4.26.0 via `lake env lean`.
+- `proofs/Proofs/Erdos335Problem.lean`: 523 LOC, **46 theorems/lemmas**, 8 defs, **0 sorries**, **3 axioms**. Compiles clean (0 errors / 0 warnings) against pinned Mathlib v4.26.0 via `lake env lean`.
 - Axioms (all deep / mathematically necessary):
   1. `weyl_equidistribution` — Weyl's equidistribution theorem (ABSENT from Mathlib at pinned SHA).
   2. `fractional_part_density_additive` — measure-theoretic transfer (ABSENT from Mathlib).
@@ -32,9 +32,14 @@ S7 ACT (researcher-4) **repaired a broken build**: the `origin/main` file no lon
 
 ## Open / Active Sub-Goals (post-S6 PREP)
 
-1. **S7 — Schnirelmann↔asymptotic bridge** (ACT): prove `schnirelmannDensity A ≤ asympDensity A` when `DensityExists A`, importing `Mathlib.Combinatorics.Schnirelmann`. ~40–80 LOC.
-2. **S8 — Concrete witness `DensityAdditive {0} A`** (ACT): ~10–20 LOC, no new imports, uses only existing theorems in the file.
-3. **S9 — Translation identity `Sumset {k} A = (·+k) '' A`** (ACT): ~10–20 LOC, no new imports.
+1. ~~**S7 — Schnirelmann↔asymptotic bridge**~~ ✅ **DONE (S8 ACT, 2026-07-01)**: `schnirelmann_le_asymp : schnirelmannDensity A ≤ asympDensity A` + `countingFn_eq_filter_card` + 2 corollaries. All 0-axiom.
+2. ~~**S8 — Concrete witness `DensityAdditive {0} A`**~~ ✅ **DONE (S7 ACT, 2026-06-25)** as `density_additive_zero_singleton`.
+3. ~~**S9 — Translation identity `Sumset {k} A = (·+k) '' A`**~~ ✅ **DONE (S7 ACT, 2026-06-25)** as `Sumset_singleton_left`/`_right`.
+
+### Follow-up (post-S8)
+
+- Transfer further Mathlib Schnirelmann lemmas through the bridge (e.g. `schnirelmannDensity_le_of_notMem` ⟹ asymptotic upper bounds from a missing element).
+- Mann-type lower bound `d(A+B) ≥ min(d(A)+d(B),1)` — still blocked upstream (absent from Mathlib; module TODO).
 
 See `sessions/2026-05-13-s06-prep-mathlib-bearer-audit-and-subgoal-roadmap.md` for bearer plans.
 

--- a/src/data/proofs/erdos-335/meta.json
+++ b/src/data/proofs/erdos-335/meta.json
@@ -54,6 +54,11 @@
         "theorem": "div_le_div_right, div_lt_iff",
         "description": "Ordered field division lemmas for density bound proofs",
         "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "schnirelmannDensity, schnirelmannDensity_le_div",
+        "description": "Mathlib's Schnirelmann density (infimum of |A∩{1,…,n}|/n) and its per-n upper bound, used to prove the Schnirelmann↔asymptotic bridge schnirelmannDensity A ≤ asympDensity A",
+        "module": "Mathlib.Combinatorics.Schnirelmann"
       }
     ],
     "originalContributions": [
@@ -80,12 +85,16 @@
       "countingFn_empty/mono/mono_N: PROVED — counting function properties",
       "Sumset_singleton: PROVED — sumset of singletons is a singleton",
       "density_univ_one: d(ℕ) = 1 (whole set has density 1)",
-      "density_finite_zero: d(A) = 0 for any finite A ⊆ ℕ"
+      "density_finite_zero: d(A) = 0 for any finite A ⊆ ℕ",
+      "countingFn_eq_filter_card: PROVED — this file's Set.ncard counting equals Mathlib's Finset.filter counting over Ioc 0 N (bridge lemma)",
+      "schnirelmann_le_asymp: PROVED — Schnirelmann↔asymptotic bridge schnirelmannDensity A ≤ asympDensity A when the asymptotic density exists (infimum ≤ limit of the same ratios)",
+      "hasPositiveDensity_of_schnirelmann_pos: PROVED — positive Schnirelmann density certifies positive asymptotic density",
+      "schnirelmann_le_complement: PROVED — in a density-additive pair, schnirelmannDensity A ≤ 1 − asympDensity B"
     ],
     "axiomCount": 3,
-    "lineCount": 414,
+    "lineCount": 523,
     "assumptions": "3 axioms: weyl_equidistribution, fractional_part_density_additive, erdos_335_conjecture (OPEN). See Lean source for complete statements.",
-    "theoremCount": 40,
+    "theoremCount": 46,
     "definitionCount": 8
   },
   "sections": [
@@ -168,6 +177,14 @@
       "endLine": 363,
       "summary": "Computes concrete densities: countingFn_univ_eq and density_univ_one (d(ℕ) = 1), and density_finite_zero (every finite set has density 0), proved via an explicit ε–N tendsto argument.",
       "mathContext": "Sanity-check computations anchor the theory: $d(\\mathbb{N})=1$ and $d(A)=0$ for finite $A$, the latter shown by bounding $|A\\cap[1,N]|\\le|A|$ so the ratio $|A|/N\\to 0$."
+    },
+    {
+      "id": "schnirelmann-bridge",
+      "title": "Bridge to Mathlib's Schnirelmann Density",
+      "startLine": 461,
+      "endLine": 523,
+      "summary": "Connects this file's asympDensity to Mathlib's schnirelmannDensity. Proves countingFn_eq_filter_card (the two counting functions agree since Set.Ioc 0 N = Set.Icc 1 N on ℕ), then the bridge schnirelmann_le_asymp (infimum ≤ limit), and corollaries hasPositiveDensity_of_schnirelmann_pos and schnirelmann_le_complement.",
+      "mathContext": "The Schnirelmann density $\\sigma(A)=\\inf_{n>0}|A\\cap[1,n]|/n$ is a lower bound for the asymptotic density $d(A)=\\lim_{n\\to\\infty}|A\\cap[1,n]|/n$ whenever the latter exists, since an infimum of a sequence never exceeds its limit. This makes Mathlib's Schnirelmann API available for the asymptotic-density theory of #335."
     }
   ],
   "overview": {
@@ -180,7 +197,8 @@
       "**Weyl Equidistribution Bridge:** The known examples use Weyl's 1916 theorem: for irrational $\\theta$, the sequence $\\{n\\theta\\}$ is equidistributed mod 1, so $d(\\{n : \\{n\\theta\\} \\in X\\}) = \\mu(X)$. This transforms a number-theoretic density question into a measure-theoretic one on $\\mathbb{R}/\\mathbb{Z}$.",
       "**Structural Rigidity Hypothesis:** The conjecture asserts that density additivity is *rigid* — it can only arise from the group-theoretic mechanism of toral rotations. This would be a strong inverse theorem, deducing algebraic structure from a density condition.",
       "**Sum Constraint:** The axiomatized result $d(A) + d(B) \\leq 1$ is necessary: if $d(A+B) = d(A) + d(B)$ and $d(A+B) \\leq 1$, then $d(A) + d(B) \\leq 1$. The density pairs $(d(A), d(B))$ achieving additivity must lie in the triangle $\\{(\\alpha, \\beta) : \\alpha + \\beta \\leq 1\\}$.",
-      "**Characterization vs Existence:** Unlike most Erdős problems that ask whether something exists, #335 asks for a *characterization*. Knowing *that* density-additive pairs exist (the fractional part construction) is easy; understanding *all* of them is the deep challenge."
+      "**Characterization vs Existence:** Unlike most Erdős problems that ask whether something exists, #335 asks for a *characterization*. Knowing *that* density-additive pairs exist (the fractional part construction) is easy; understanding *all* of them is the deep challenge.",
+      "**Schnirelmann as a Lower Bound:** Mathlib formalizes the Schnirelmann density (the infimum of |A∩{1,…,n}|/n) but not the asymptotic density (its limit). The bridge `schnirelmann_le_asymp` shows the infimum never exceeds the limit, so Mathlib's ~20 Schnirelmann lemmas transfer to lower bounds on the asymptotic density used here. The inequality can be strict: schnirelmannDensity{even}=0 (since 1∉{even}) while d({even})=1/2."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -219,8 +237,14 @@
   "leanFile": {
     "imports": [
       "Mathlib.Data.Real.Basic",
+      "Mathlib.NumberTheory.Real.Irrational",
       "Mathlib.Order.Filter.Basic",
       "Mathlib.Data.Set.Card",
+      "Mathlib.Data.Set.Finite.Lattice",
+      "Mathlib.Topology.Basic",
+      "Mathlib.Topology.Order.Basic",
+      "Mathlib.Algebra.Order.Field.Basic",
+      "Mathlib.Combinatorics.Schnirelmann",
       "Mathlib.Tactic"
     ],
     "opens": [
@@ -228,9 +252,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 459,
+    "lineCount": 523,
     "axiomCount": 3,
-    "theoremCount": 42,
+    "theoremCount": 46,
     "definitionCount": 8,
     "path": "Proofs/Erdos335Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-335.json
+++ b/src/data/research/problems/erdos-335.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "PREP",
     "since": "2026-05-13T11:00:00.000Z",
-    "iteration": 6,
-    "focus": "S6 PREP (doc-only): Mathlib bearer audit at lake-pinned SHA + 3 forward sub-goals (S7/S8/S9) pinned with bearer plans. State.md synced.",
+    "iteration": 8,
+    "focus": "S8 ACT (researcher-2): landed the Schnirelmann↔asymptotic bridge (S7 roadmap item). Proved schnirelmannDensity A ≤ asympDensity A (infimum ≤ limit) by matching countingFn to Mathlib's Finset.filter counting over Ioc 0 N, plus 2 corollaries. All 0-axiom; the 3 deep axioms untouched.",
     "blockers": [
       "weyl_equidistribution axiom cannot be discharged until upstream Mathlib contribution lands.",
       "fractional_part_density_additive chains on Weyl + Mann (both absent from Mathlib)."
     ],
-    "nextAction": "S7 ACT — implement schnirelmann_le_asymp bridge lemma.",
+    "nextAction": "Optional S9: use the bridge to transfer more Mathlib Schnirelmann lemmas (e.g. schnirelmannDensity_le_of_notMem) into asympDensity statements, or attempt the Mann-type sumset bound.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 32 theorems, 3 deep axioms, 0 sorries. S6 PREP (2026-05-13) audited Mathlib bearers at pinned SHA: Schnirelmann density PRESENT, Weyl equidistribution + Mann/density-Plünnecke-Ruzsa ABSENT. Pinned 3 forward sub-goals (S7/S8/S9) with bearer plans.",
+    "progressSummary": "PROGRESS: 46 theorems, 3 deep axioms, 0 sorries. S8 ACT (2026-07-01) landed the S7 roadmap item: the Schnirelmann↔asymptotic density bridge schnirelmannDensity A ≤ asympDensity A (imports Mathlib.Combinatorics.Schnirelmann), via countingFn_eq_filter_card matching this file's Set.ncard counting to Mathlib's Finset.filter counting. 4 new 0-axiom theorems; deep axioms untouched.",
     "builtItems": [
       "density_nonneg (PROVED) - ge_of_tendsto + div_nonneg",
       "density_le_one (PROVED) - le_of_tendsto + countingFn_le",
@@ -57,7 +57,11 @@
       "Sumset_zero_left: {0} is left identity for Sumset (Erdos335Problem.lean:295)",
       "density_additive_chain: d(A+B+C)=d(A)+d(B)+d(C) from chain (Erdos335Problem.lean:302)",
       "density_additive_complement_bound: d(B) ≤ 1-d(A) (Erdos335Problem.lean:308)",
-      "density_double_sumset: d(A+A) = 2d(A) when self-additive (Erdos335Problem.lean:313)"
+      "density_double_sumset: d(A+A) = 2d(A) when self-additive (Erdos335Problem.lean:313)",
+      "countingFn_eq_filter_card (PROVED) - countingFn A N = ((Ioc 0 N).filter (·∈A)).card; Set.Ioc 0 N = Set.Icc 1 N on ℕ",
+      "schnirelmann_le_asymp (PROVED) - schnirelmannDensity A ≤ asympDensity A via ge_of_tendsto + schnirelmannDensity_le_div",
+      "hasPositiveDensity_of_schnirelmann_pos (PROVED) - positive Schnirelmann density ⟹ positive asymptotic density",
+      "schnirelmann_le_complement (PROVED) - schnirelmannDensity A ≤ 1 - asympDensity B in a density-additive pair"
     ],
     "insights": [
       "limUnder requires Mathlib.Topology.Basic import (not in original file)",
@@ -79,7 +83,10 @@
       "Mathlib/Combinatorics/Schnirelmann.lean (pinned SHA 280c461ec9f7…) provides ~20 schnirelmannDensity lemmas; module TODO explicitly lists Mann's theorem + asymptotic density as unformalized.",
       "Schnirelmann vs asymptotic density: schnirelmannDensity (setOf Even) = 0 (because 1 ∉ Even) but asympDensity (setOf Even) = 1/2. Bridge inequality schnirelmann ≤ asymp is the right direction for the S7 ACT.",
       "Weyl equidistribution ABSENT from Mathlib at pinned SHA 2df2f015…1a67 — only mentioned in docs/1000.yaml unformalized-targets. weyl_equidistribution axiom is mathematically necessary at this Mathlib version.",
-      "S6 PREP doc-only: state.md drift (NEW/Iter 1 → PREP/Iter 6) synced; sessions/ directory established with bearer audit note."
+      "S6 PREP doc-only: state.md drift (NEW/Iter 1 → PREP/Iter 6) synced; sessions/ directory established with bearer audit note.",
+      "S7 bridge landed: Mathlib's schnirelmannDensity_le_div (schnir ≤ #{a∈Ioc 0 n|a∈A}/n) + ge_of_tendsto (infimum ≤ limit) gives schnirelmannDensity A ≤ asympDensity A cleanly once the two counting functions are identified.",
+      "countingFn (Set.ncard (A∩Icc 1 N)) = Mathlib filter card ((Ioc 0 N).filter (·∈A)).card: Set.Ioc 0 N = Set.Icc 1 N on ℕ; proved by Finset.coe_filter + Set.ncard_coe_finset then set ext. omega can't close the ext goal (x∈A is a non-arith atom) — needs explicit constructor/rintro.",
+      "Bridge requires [DecidablePred (·∈A)] instance arg (schnirelmannDensity needs it). The 3 deep axioms (Weyl, fractional-part additivity, main conjecture) are NOT touched by any of the 4 new theorems (#print axioms shows only propext/Classical.choice/Quot.sound)."
     ],
     "mathlibGaps": [
       "Weyl's equidistribution theorem (uniform distribution of {nθ} mod 1 for irrational θ) — ABSENT at pinned SHA 2df2f015…1a67; only listed in docs/1000.yaml as unformalized.",
@@ -88,9 +95,8 @@
       "Fractional-part density additivity (μ-additivity on ℝ/ℤ → density-additivity of FractionalPartSet sets) — ABSENT; chains on Weyl + Mann."
     ],
     "nextSteps": [
-      "S7 ACT: import Mathlib.Combinatorics.Schnirelmann; prove schnirelmann_le_asymp : schnirelmannDensity A ≤ asympDensity A when DensityExists A. ~40-80 LOC. Bridge via schnirelmannDensity_le_div + le_of_tendsto.",
-      "S8 ACT: prove density_additive_zero_singleton : ∀ A, DensityExists A → DensityAdditive {0} A. Uses Sumset_zero_left + density_finite_zero. ~10-20 LOC, no new imports.",
-      "S9 ACT: prove Sumset_singleton_left : Sumset {k} A = (· + k) '' A. Pure ext + omega. ~10-20 LOC, no new imports."
+      "Transfer further Mathlib Schnirelmann lemmas through the bridge, e.g. schnirelmannDensity_le_of_notMem ⟹ asymptotic upper bounds from a missing element.",
+      "Attempt a Mann-type lower bound d(A+B) ≥ min(d(A)+d(B),1) using Schnirelmann subadditivity once/if formalized upstream (currently absent — module TODO)."
     ],
     "markdown": "# Erdős #335 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $d(A)$ denote the density of $A\\subseteq \\mathbb{N}$. Characterise those $A,B\\subseteq \\mathbb{N}$ with positive density such that\\[d(A+B)=d(A)+d(B).\\]\n\n\n\nOne way this can happen is if there exists $\\theta>0$ such that\\[A=\\{ n>0 : \\{ n\\theta\\} \\in X_A\\}\\textrm{ and }B=\\{ n>0 : \\{n\\theta\\} \\in X_B\\}\\]where $\\{x\\}$ denotes the fractional part of $x$ and $X_A,X_B\\subseteq \\mathbb{R}/\\mathbb{Z}$ are such that $\\mu(X_A+X_B)=\\mu(X_A)+\\mu(X_B)$. Are all possible $A$ and $B$ generated in a similar way (using other groups)?\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #334\n- Problem #336\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
@@ -115,8 +121,8 @@
     {
       "path": "Proofs/Erdos335Problem.lean",
       "filename": "Erdos335Problem.lean",
-      "lineCount": 415,
-      "theoremCount": 37,
+      "lineCount": 523,
+      "theoremCount": 46,
       "axiomCount": 3,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Closes the last open S6 roadmap item (S7) for **Erdős #335**: a bridge from this file's `asympDensity` (asymptotic/natural density — *not* formalized in Mathlib at the pinned SHA) to Mathlib's `schnirelmannDensity`.

Schnirelmann density is the **infimum** of the counting ratios `|A∩{1,…,n}|/n`; `asympDensity` is their **limit**. The bridge is the natural comparison: infimum ≤ limit.

## New theorems (4, all 0-axiom)

| Theorem | Statement |
|---|---|
| `countingFn_eq_filter_card` | `countingFn A N = ((Finset.Ioc 0 N).filter (·∈A)).card` — identifies this file's `Set.ncard` counting with Mathlib's `Finset.filter` counting (`Set.Ioc 0 N = Set.Icc 1 N` on ℕ) |
| `schnirelmann_le_asymp` | `schnirelmannDensity A ≤ asympDensity A` when `DensityExists A` |
| `hasPositiveDensity_of_schnirelmann_pos` | positive Schnirelmann density ⟹ `HasPositiveDensity A` |
| `schnirelmann_le_complement` | in a density-additive pair, `schnirelmannDensity A ≤ 1 − asympDensity B` |

Proof of the bridge: `ge_of_tendsto` on the density limit + `schnirelmannDensity_le_div` per `n`, after rewriting the counting function. The inequality is genuinely strict in general — `schnirelmannDensity {even} = 0` (since `1 ∉ {even}`) while `d({even}) = 1/2`.

## Value

Makes Mathlib's ~20 `schnirelmannDensity` lemmas available as **lower bounds** for the asymptotic density used throughout the #335 formalization — a reusable transfer route, since Mathlib's Schnirelmann module explicitly lists asymptotic density as unformalized in its TODO.

## Axiom integrity

`#print axioms` on all 4 new theorems reports only `propext, Classical.choice, Quot.sound`. The **3 deep file axioms** (`weyl_equidistribution`, `fractional_part_density_additive`, `erdos_335_conjecture`) are **untouched** — this PR adds no new assumptions. Status remains `axiomatized` (the problem is OPEN).

## Build

`cd proofs && lake env lean Proofs/Erdos335Problem.lean` — 0 errors / 0 warnings against pinned Mathlib v4.26.0.

46 theorems/lemmas · 8 defs · 0 sorries · 3 deep axioms (unchanged) · 523 LOC.

Adds `import Mathlib.Combinatorics.Schnirelmann`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)