### PR TITLE
Enrich Metabelian/Metacyclic Solvability (OQ-03): +framing annotation, +header section

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04-oq-03/annotations.json
@@ -1,5 +1,21 @@
 [
   {
+    "id": "ann-abelruffini-metabelian-framing",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-04-oq-03",
+    "range": {
+      "startLine": 9,
+      "endLine": 51
+    },
+    "type": "concept",
+    "title": "From a Concrete Dihedral Proof to the Structural Theorem",
+    "content": "**Module framing.** The parent entry proved each dihedral group $D_n$ solvable by *building* the short exact sequence $1 \\to \\langle r\\rangle \\to D_n \\to \\mathbb{Z}/2 \\to 1$ and invoking `solvable_of_ker_le_range`. Its open question OQ-03 asked what that argument *really* proves. This file answers: the concrete construction is a special case of a purely structural fact about **metabelian** groups (an abelian normal subgroup with abelian quotient), and the honest conclusion is not merely 'solvable' but the sharp derived-length bound `derivedSeries G 2 = ⊥`. The logical spine is the hierarchy **cyclic ⟹ metabelian ⟹ solvable of class ≤ 2**: `comm_of_isCyclic` turns a cyclic-by-cyclic (metacyclic) hypothesis into the two abelian hypotheses the metabelian theorem needs, so metacyclic solvability drops out as a one-line corollary. Dihedral, dicyclic, order-$pq$, and the solvable symmetric groups $S_2, S_3, S_4$ are all instances of the same theorem.",
+    "mathContext": "Metabelian $\\iff G^{(2)} = [[G,G],[G,G]] = 1 \\iff$ derived length $\\le 2$; metacyclic (cyclic-by-cyclic) $\\subsetneq$ metabelian.",
+    "significance": "supporting",
+    "relatedConcepts": ["metabelian group", "metacyclic group", "solvable derived length", "short exact sequence", "Abel–Ruffini / Galois solvability"],
+    "prerequisites": ["solvable groups and the derived series", "the parent dihedral solvability proof", "group extensions"],
+    "tags": ["module-header", "framing", "group-theory", "abel-ruffini"]
+  },
+  {
     "id": "ann-comm-of-cyclic",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-04-oq-03",
     "range": {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04-oq-03/meta.json
@@ -53,6 +53,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Context",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Imports (GroupTheory.Solvable, SpecificGroups.Cyclic) and a docstring framing the file as the structural generalization of the parent's concrete dihedral solvability proof: metabelian ⟹ derived length ≤ 2, with the metacyclic case (OQ-03) as the cyclic-by-cyclic corollary. Lists the five results and the two-step derived-series descent method.",
+      "mathContext": "Answers parent OQ-03: cyclic-by-cyclic (metacyclic), more generally abelian-by-abelian (metabelian), groups are solvable — sharpened to $\\mathrm{derivedSeries}\\,G\\,2 = \\bot$."
+    },
+    {
       "id": "cyclic-comm",
       "title": "Cyclic Groups Are Commutative",
       "startLine": 57,


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-04-oq-03` (0 prior passes).

## Assessment
A fresh, already-strong entry: rich meta.json (12 KB, well under the 60 KB cap), 4 substantive technique/theorem annotations, 4 keyInsights, 3 sections, 2 references, and a conclusion with 3 open questions. The one real coverage gap: the annotations started at line 61 and the sections at line 57, leaving the **substantial module docstring (lines 9–51)** — which frames the whole cyclic ⟹ metabelian ⟹ solvable story — with no annotation and no section.

## Changes
- **New framing annotation** (`ann-abelruffini-metabelian-framing`, lines 9–51): covers the module header, explaining how the parent's *concrete* dihedral short-exact-sequence proof generalizes to the purely structural metabelian theorem, and laying out the **cyclic ⟹ metabelian ⟹ solvable of class ≤ 2** hierarchy that `comm_of_isCyclic` bridges. Brings the entry to **5 annotations**, one per structural component.
- **New `header` section** (lines 1–55) so the `sections` array covers the full 129-line file instead of starting at line 57.

## Validation
- `annotations.json` / `meta.json` parse cleanly (5 annotations, 4 sections).
- `scripts/gallery/check-meta-size.ts`: within caps (12.5 KB ≤ 60 KB).
- No axiom/status changes: entry remains verified, 0 axioms, 0 sorries — consistent with the Lean file's `#print axioms` (only propext/Classical.choice/Quot.sound; no native_decide).