### PR TITLE
research(basel-problem-oq-13-oq-01-oq-01): uniform Dirichlet eta values η(2k)=(1−2^{1−2k})·ζ(2k) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BaselProblemOQ13OQ01OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ13OQ01OQ01.lean
@@ -1,0 +1,177 @@
+/-
+  # Uniform Dirichlet eta values: η(2k) = (1 − 2^{1−2k})·ζ(2k)
+  # (basel-problem-oq-13-oq-01-oq-01)
+
+  ## The Open Question (from basel-problem-oq-13-oq-01)
+
+  > The sibling files derive individual eta values (η(2) = π²/12, η(4) = 7π⁴/720)
+  > by hand-splitting each alternating sum by parity.  Can the parity split be
+  > packaged **once and for all** into a uniform statement
+  >
+  >     η(s) = (1 − 2^{1−s})·ζ(s)
+  >
+  > relating the Dirichlet eta function to the Riemann zeta function, and then
+  > specialised to the even integers s = 2k using Mathlib's closed form for ζ(2k)?
+
+  ## The bridge
+
+  The Dirichlet eta function η(s) = ∑_{n≥1} (-1)^{n+1}/nˢ is the alternating
+  companion of ζ(s) = ∑_{n≥1} 1/nˢ.  Splitting by parity,
+
+      η(s) = ∑_{odd} 1/nˢ − ∑_{even} 1/nˢ,   ζ(s) = ∑_{odd} 1/nˢ + ∑_{even} 1/nˢ.
+
+  Since ∑_{even} 1/nˢ = ∑_k 1/(2k)ˢ = 2^{−s}·ζ(s), we get
+
+      η(s) = ζ(s) − 2·∑_{even} 1/nˢ = ζ(s) − 2·2^{−s}·ζ(s) = (1 − 2^{1−s})·ζ(s).
+
+  The heart of the file is `hasSum_eta_of_hasSum_zeta`, which proves this as a
+  purely formal consequence of *any* convergent `p`-series `HasSum` — no analytic
+  input, no specific value of the exponent.  It therefore applies verbatim to
+  every exponent for which the series converges (natural `m ≥ 2`), and in
+  particular to the even integers, where Mathlib supplies the closed form
+  `hasSum_zeta_nat`.
+
+  Writing the exponent as a natural number `m`, the factor `1 − 2^{1−m}` becomes
+  the rational `1 − 2/2^m`; for the even case `m = 2k` this is `1 − 2^{1−2k}`, and
+  it recovers `1/2` at `k = 1` (η(2) = ζ(2)/2 = π²/12) and `7/8` at `k = 2`
+  (η(4) = 7·ζ(4)/8 = 7π⁴/720).
+
+  ## Axiom count: 0
+-/
+
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.Tactic
+
+open Real
+open scoped Nat
+
+namespace BaselEtaUniform
+
+set_option maxHeartbeats 1000000 in
+/-- **The eta–zeta bridge.**  For *any* natural exponent `m` and any value `Z`,
+    if the `p`-series `∑ 1/nᵐ` converges to `Z` (i.e. `ζ(m) = Z`), then the
+    alternating series `∑ (-1)^{n+1}/nᵐ` converges to `(1 − 2/2ᵐ)·Z`.
+
+    This is the finite-combinatorial content of `η(s) = (1 − 2^{1−s})·ζ(s)`,
+    proved from the parity decomposition alone — no analytic facts about the
+    exponent are used, so it holds for every convergent `p`-series. -/
+theorem hasSum_eta_of_hasSum_zeta {m : ℕ} {Z : ℝ}
+    (h : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ m) Z) :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ m)
+      ((1 - 2 / (2 : ℝ) ^ m) * Z) := by
+  -- Even part of the *plain* series: ∑_k 1/(2k)ᵐ = (1/2ᵐ)·Z.
+  have heven_plain : HasSum (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ m)
+      ((1 / (2 : ℝ) ^ m) * Z) := by
+    have hfun : (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ m)
+        = (fun k : ℕ => (1 / (2 : ℝ) ^ m) * (1 / (k : ℝ) ^ m)) := by
+      funext k
+      have hc : ((2 * k : ℕ) : ℝ) ^ m = (2 : ℝ) ^ m * (k : ℝ) ^ m := by
+        push_cast; rw [mul_pow]
+      rw [hc]; ring
+    rw [hfun]; exact h.mul_left _
+  -- Odd part is summable (image of the injection `k ↦ 2k+1` of a summable family).
+  have hinj : Function.Injective (fun k : ℕ => 2 * k + 1) := by
+    intro a b hab; simp only at hab; omega
+  have hodd_summable : Summable (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ m) :=
+    h.summable.comp_injective hinj
+  have hodd : HasSum (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ m)
+      (∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ m) := hodd_summable.hasSum
+  set B := ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ m with hB
+  -- Uniqueness pins the odd sum: (1/2ᵐ)·Z + B = Z.
+  have hcombined : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ m)
+      ((1 / (2 : ℝ) ^ m) * Z + B) := heven_plain.even_add_odd hodd
+  have hZ : (1 / (2 : ℝ) ^ m) * Z + B = Z := hcombined.unique h
+  -- Even part of the *alternating* series: ∑_k (-1)^{2k+1}/(2k)ᵐ = -(1/2ᵐ)·Z.
+  have heven_alt : HasSum (fun k : ℕ => (-1 : ℝ) ^ (2 * k + 1) / ((2 * k : ℕ) : ℝ) ^ m)
+      (-((1 / (2 : ℝ) ^ m) * Z)) := by
+    have hfun : (fun k : ℕ => (-1 : ℝ) ^ (2 * k + 1) / ((2 * k : ℕ) : ℝ) ^ m)
+        = (fun k : ℕ => -(1 / ((2 * k : ℕ) : ℝ) ^ m)) := by
+      funext k
+      have hs : (-1 : ℝ) ^ (2 * k + 1) = -1 := by rw [pow_succ, pow_mul]; norm_num
+      rw [hs]; ring
+    rw [hfun]; exact heven_plain.neg
+  -- Odd part of the *alternating* series equals the plain odd part (sign = +1).
+  have hodd_alt : HasSum
+      (fun k : ℕ => (-1 : ℝ) ^ (2 * k + 1 + 1) / ((2 * k + 1 : ℕ) : ℝ) ^ m) B := by
+    have hfun : (fun k : ℕ => (-1 : ℝ) ^ (2 * k + 1 + 1) / ((2 * k + 1 : ℕ) : ℝ) ^ m)
+        = (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ m) := by
+      funext k
+      have hs : (-1 : ℝ) ^ (2 * k + 1 + 1) = 1 := by
+        rw [pow_succ, pow_succ, pow_mul]; norm_num
+      rw [hs]
+    rw [hfun]; exact hodd
+  -- Assemble the alternating series (explicit type pins the summand → no HOU).
+  have hfull : HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ m)
+      (-((1 / (2 : ℝ) ^ m) * Z) + B) := heven_alt.even_add_odd hodd_alt
+  have hval : (1 - 2 / (2 : ℝ) ^ m) * Z = -((1 / (2 : ℝ) ^ m) * Z) + B := by
+    linear_combination -hZ
+  rw [hval]; exact hfull
+
+/-- **Uniform even eta values.**  For every `k ≥ 1`,
+    `η(2k) = ∑_{n} (-1)^{n+1}/n^{2k} = (1 − 2/2^{2k})·ζ(2k)`, with `ζ(2k)` in
+    Mathlib's Bernoulli-number closed form (`hasSum_zeta_nat`).  The factor
+    `1 − 2/2^{2k}` is exactly `1 − 2^{1−2k}` (see `eta_factor_eq`). -/
+theorem hasSum_eta_two_mul_nat {k : ℕ} (hk : k ≠ 0) :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ (2 * k))
+      ((1 - 2 / (2 : ℝ) ^ (2 * k)) *
+        ((-1 : ℝ) ^ (k + 1) * (2 : ℝ) ^ (2 * k - 1) * π ^ (2 * k) *
+          bernoulli (2 * k) / (2 * k)!)) :=
+  hasSum_eta_of_hasSum_zeta (hasSum_zeta_nat hk)
+
+/-- The exponent factor `1 − 2/2^{2k}` written in the source form `1 − 2^{1−2k}`
+    (using an integer exponent, since `1 − 2k ≤ 0`). -/
+theorem eta_factor_eq (k : ℕ) :
+    (1 : ℝ) - 2 / (2 : ℝ) ^ (2 * k) = 1 - (2 : ℝ) ^ ((1 : ℤ) - 2 * (k : ℤ)) := by
+  have h2 : (2 : ℝ) ≠ 0 := two_ne_zero
+  have e : (2 : ℝ) ^ ((1 : ℤ) - 2 * (k : ℤ)) = 2 / (2 : ℝ) ^ (2 * k) := by
+    rw [zpow_sub₀ h2, zpow_one, ← zpow_natCast (2 : ℝ) (2 * k)]
+    norm_cast
+  rw [e]
+
+/-- **η(2)** = π²/12, recovered from the uniform bridge via `hasSum_zeta_two`. -/
+theorem hasSum_eta_two :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 2) (π ^ 2 / 12) := by
+  have h := hasSum_eta_of_hasSum_zeta hasSum_zeta_two
+  have hval : (1 - 2 / (2 : ℝ) ^ 2) * (π ^ 2 / 6) = π ^ 2 / 12 := by ring
+  rwa [hval] at h
+
+/-- **η(4)** = 7π⁴/720, recovered from the uniform bridge via `hasSum_zeta_four`.
+    This matches the sibling file `BaselProblemOQ13OQ01`, obtained here as a
+    one-line specialisation of the general theorem. -/
+theorem hasSum_eta_four :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 4) (7 * π ^ 4 / 720) := by
+  have h := hasSum_eta_of_hasSum_zeta hasSum_zeta_four
+  have hval : (1 - 2 / (2 : ℝ) ^ 4) * (π ^ 4 / 90) = 7 * π ^ 4 / 720 := by ring
+  rwa [hval] at h
+
+/-- `η(2)` in `tsum` form. -/
+theorem tsum_eta_two :
+    ∑' n : ℕ, (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 2 = π ^ 2 / 12 :=
+  hasSum_eta_two.tsum_eq
+
+/-- `η(4)` in `tsum` form. -/
+theorem tsum_eta_four :
+    ∑' n : ℕ, (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 4 = 7 * π ^ 4 / 720 :=
+  hasSum_eta_four.tsum_eq
+
+end BaselEtaUniform
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `hasSum_eta_of_hasSum_zeta` | ζ(m)=Z ⟹ η(m) = (1 − 2/2ᵐ)·Z, any exponent `m` |
+  | `hasSum_eta_two_mul_nat`    | η(2k) = (1 − 2/2^{2k})·ζ(2k) (Bernoulli closed form) |
+  | `eta_factor_eq`             | 1 − 2/2^{2k} = 1 − 2^{1−2k} |
+  | `hasSum_eta_two`            | η(2) = π²/12 |
+  | `hasSum_eta_four`           | η(4) = 7π⁴/720 |
+  | `tsum_eta_two`, `tsum_eta_four` | `tsum` forms |
+
+  The single analytic-free lemma `hasSum_eta_of_hasSum_zeta` packages the parity
+  split once; every eta value is then a specialisation of it composed with a
+  zeta `HasSum` (`hasSum_zeta_nat`, `hasSum_zeta_two`, `hasSum_zeta_four`).
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/basel-problem-oq-13-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-13-oq-01-oq-01/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "eta-uniform-overview",
+    "proofId": "basel-problem-oq-13-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "One Bridge for Every Eta Value: η(s) = (1 − 2^{1−s})ζ(s)",
+    "content": "The header states the open question inherited from basel-problem-oq-13-oq-01: rather than hand-splitting each alternating sum by parity, package the eta–zeta relation once and specialize. The Dirichlet eta η(s) = ∑ (-1)^(n+1)/nˢ is the alternating companion of ζ(s) = ∑ 1/nˢ. Splitting by parity, ∑_{even} 1/nˢ = ∑_k 1/(2k)ˢ = 2^{−s}ζ(s), so η(s) = ζ(s) − 2·(even part) = (1 − 2^{1−s})ζ(s). This is finite-combinatorial: nothing about the exponent is used beyond convergence. Writing the exponent as a natural number m, the factor 1 − 2^{1−m} becomes the rational 1 − 2/2ᵐ; for m = 2k this is exactly 1 − 2^{1−2k}, giving 1/2 at k = 1 (η(2) = π²/12) and 7/8 at k = 2 (η(4) = 7π⁴/720).",
+    "mathContext": "$\\eta(s) = \\sum_{n\\ge1}\\frac{(-1)^{n+1}}{n^s} = \\zeta(s) - 2\\sum_{k\\ge1}\\frac{1}{(2k)^s} = (1 - 2^{1-s})\\zeta(s)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Dirichlet eta function η(s)",
+      "Riemann zeta function ζ(s)",
+      "parity decomposition of a series",
+      "eta–zeta relation η(s) = (1 − 2^{1−s})ζ(s)",
+      "alternating zeta values"
+    ],
+    "prerequisites": [
+      "ζ, η Dirichlet series and convergence for the relevant exponent",
+      "closed form for even zeta values ζ(2k) (Mathlib hasSum_zeta_nat)",
+      "summability and HasSum"
+    ]
+  },
+  {
+    "id": "eta-bridge",
+    "proofId": "basel-problem-oq-13-oq-01-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 112
+    },
+    "type": "proof-step",
+    "title": "hasSum_eta_of_hasSum_zeta — the exponent-independent bridge",
+    "content": "The core lemma: for any natural exponent m and any Z with ζ(m) = Z (as a HasSum), the alternating series ∑ (-1)^(n+1)/nᵐ has sum (1 − 2/2ᵐ)·Z. Four moves. (1) heven_plain: the plain even part ∑_k 1/(2k)ᵐ = (1/2ᵐ)·Z, because ((2k))ᵐ = 2ᵐ·kᵐ (push_cast + mul_pow) and h.mul_left rescales the entire hypothesis. (2) hodd: the plain odd part ∑_k 1/(2k+1)ᵐ = B is summable as the image under the injection k ↦ 2k+1 of the summable family h (Summable.comp_injective); reassembling even + odd = full (HasSum.even_add_odd) and comparing with h via HasSum.unique pins (1/2ᵐ)·Z + B = Z, so B = Z − (1/2ᵐ)·Z without ever evaluating B in closed form. (3) heven_alt / hodd_alt: in the alternating series the sign is set by parity — (-1)^(2k+1) = -1 negates the even part to −(1/2ᵐ)·Z while (-1)^(2k+2) = +1 leaves the odd part equal to B (pow_succ / pow_mul + norm_num). (4) Reassembling gives η(m) = −(1/2ᵐ)·Z + B, and one linear_combination on hZ rewrites this to (1 − 2/2ᵐ)·Z. Each subseries HasSum is stated with an explicit summand, so HasSum.even_add_odd matches the ambient function by definitional reduction rather than higher-order unification.",
+    "mathContext": "$\\eta(m) = -\\tfrac{1}{2^m}Z + B,\\quad B = Z - \\tfrac{1}{2^m}Z \\;\\Rightarrow\\; \\eta(m) = \\left(1 - \\tfrac{2}{2^m}\\right)Z.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "HasSum.even_add_odd",
+      "Summable.comp_injective",
+      "HasSum.unique",
+      "HasSum.mul_left / HasSum.neg",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "parity decomposition of infinite sums",
+      "uniqueness of sums in a Hausdorff space",
+      "(2k)ᵐ = 2ᵐ·kᵐ and the sign of (-1)^n by parity"
+    ]
+  },
+  {
+    "id": "eta-even-values",
+    "proofId": "basel-problem-oq-13-oq-01-oq-01",
+    "range": {
+      "startLine": 114,
+      "endLine": 130
+    },
+    "type": "proof-step",
+    "title": "hasSum_eta_two_mul_nat / eta_factor_eq — the uniform even family",
+    "content": "hasSum_eta_two_mul_nat feeds Mathlib's Bernoulli closed form hasSum_zeta_nat (ζ(2k) = (-1)^(k+1)·2^{2k−1}·π^{2k}·bernoulli(2k)/(2k)!) directly into the bridge, yielding η(2k) = (1 − 2/2^{2k})·ζ(2k) for every k ≥ 1 as a single term-mode application. eta_factor_eq then confirms the rational factor equals the classical source form: 1 − 2/2^{2k} = 1 − 2^{1−2k}, using zpow_sub₀ and zpow_natCast to reconcile the negative integer exponent with the natural power.",
+    "mathContext": "$\\eta(2k) = \\left(1 - 2^{1-2k}\\right)\\zeta(2k),\\quad \\zeta(2k) = \\frac{(-1)^{k+1}2^{2k-1}\\pi^{2k}B_{2k}}{(2k)!}.$",
+    "significance": "important",
+    "relatedConcepts": [
+      "hasSum_zeta_nat (Bernoulli closed form)",
+      "even zeta values",
+      "zpow_sub₀ / zpow_natCast",
+      "Dirichlet eta at even integers"
+    ],
+    "prerequisites": [
+      "closed form for ζ(2k) via Bernoulli numbers",
+      "integer vs natural exponents (zpow)"
+    ]
+  },
+  {
+    "id": "eta-specific-values",
+    "proofId": "basel-problem-oq-13-oq-01-oq-01",
+    "range": {
+      "startLine": 132,
+      "endLine": 155
+    },
+    "type": "proof-step",
+    "title": "hasSum_eta_two / hasSum_eta_four — π²/12 and 7π⁴/720",
+    "content": "The two lowest even eta values fall out as one-line specializations of the bridge. Feeding hasSum_zeta_two (ζ(2) = π²/6) gives (1 − 2/2²)·(π²/6) = (1/2)·(π²/6), simplified to π²/12 by ring. Feeding hasSum_zeta_four (ζ(4) = π⁴/90) gives (1 − 2/2⁴)·(π⁴/90) = (7/8)·(π⁴/90), simplified to 7π⁴/720 — reproving the sibling BaselProblemOQ13OQ01 from the uniform statement. The tsum corollaries record the ∑' forms.",
+    "mathContext": "$\\eta(2) = \\tfrac12\\zeta(2) = \\tfrac{\\pi^2}{12}, \\qquad \\eta(4) = \\tfrac78\\zeta(4) = \\tfrac{7\\pi^4}{720}.$",
+    "significance": "important",
+    "relatedConcepts": [
+      "hasSum_zeta_two / hasSum_zeta_four",
+      "HasSum.tsum_eq",
+      "specialization of a general theorem"
+    ],
+    "prerequisites": [
+      "ζ(2) = π²/6 and ζ(4) = π⁴/90",
+      "the eta–zeta bridge"
+    ]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-13-oq-01-oq-01/index.ts
+++ b/src/data/proofs/basel-problem-oq-13-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BaselProblemOQ13OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const baselProblemOq13Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const baselProblemOq13Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const baselProblemOq13Oq01Oq01Data: ProofData = {
+  proof: baselProblemOq13Oq01Oq01Proof,
+  annotations: baselProblemOq13Oq01Oq01Annotations,
+}

--- a/src/data/proofs/basel-problem-oq-13-oq-01-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-13-oq-01-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "basel-problem-oq-13-oq-01-oq-01",
+  "title": "Uniform Dirichlet eta values η(2k) = (1 − 2^{1−2k})·ζ(2k)",
+  "slug": "basel-problem-oq-13-oq-01-oq-01",
+  "description": "Answers the first open question of basel-problem-oq-13-oq-01: instead of hand-splitting each alternating sum by parity, package the eta–zeta relation η(s) = (1 − 2^{1−s})ζ(s) once and for all. The core lemma hasSum_eta_of_hasSum_zeta proves that for ANY natural exponent m and any value Z, if the p-series ∑ 1/nᵐ converges to Z (i.e. ζ(m) = Z), then the alternating series ∑ (-1)^(n+1)/nᵐ converges to (1 − 2/2ᵐ)·Z. This is proved from the parity decomposition alone — no analytic fact about the exponent is used — so it holds for every convergent p-series. Specializing the exponent to 2k and feeding in Mathlib's Bernoulli closed form hasSum_zeta_nat gives the uniform even eta value η(2k) = (1 − 2/2^{2k})·ζ(2k) for every k ≥ 1; eta_factor_eq confirms 1 − 2/2^{2k} = 1 − 2^{1−2k}. The sibling's η(4) = 7π⁴/720 and η(2) = π²/12 both drop out as one-line specializations. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ13OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "series",
+      "zeta-function",
+      "eta-function",
+      "zeta-values",
+      "basel-problem",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 177,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "dateAdded": "2026-07-01",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_nat",
+        "description": "Closed form for ζ(2k) as a HasSum with a Bernoulli-number coefficient; the analytic input specialized by the bridge to give uniform even eta values",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "HasSum.even_add_odd",
+        "description": "Reassemble a series from its even-indexed (f(2k)) and odd-indexed (f(2k+1)) subseries; applied both to the plain and the alternating p-series",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "Summable.comp_injective",
+        "description": "The odd subfamily is summable as the image of the injection k ↦ 2k+1 of a summable family",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Group"
+      },
+      {
+        "theorem": "HasSum.unique",
+        "description": "Uniqueness of sums (T2 space) pins the odd tail: (1/2ᵐ)·Z + B = Z, hence B = (1 − 1/2ᵐ)·Z",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "ζ(2) = π²/6, specialized by the bridge to η(2) = π²/12",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "hasSum_zeta_four",
+        "description": "ζ(4) = π⁴/90, specialized by the bridge to η(4) = 7π⁴/720",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      }
+    ],
+    "originalContributions": [
+      "hasSum_eta_of_hasSum_zeta: the eta–zeta bridge for an arbitrary natural exponent — ζ(m) = Z ⟹ η(m) = (1 − 2/2ᵐ)·Z — proved purely from the parity decomposition with no analytic dependence on the exponent",
+      "hasSum_eta_two_mul_nat: the uniform even eta value η(2k) = (1 − 2/2^{2k})·ζ(2k) for every k ≥ 1, with ζ(2k) in Mathlib's Bernoulli closed form (hasSum_zeta_nat)",
+      "eta_factor_eq: the exponent factor identity 1 − 2/2^{2k} = 1 − 2^{1−2k}, matching the classical source form of η(s) = (1 − 2^{1−s})ζ(s)",
+      "hasSum_eta_two, hasSum_eta_four: η(2) = π²/12 and η(4) = 7π⁴/720 recovered as one-line specializations of the bridge (the latter reproves the sibling BaselProblemOQ13OQ01 from the uniform statement)",
+      "tsum_eta_two, tsum_eta_four: the ∑' forms"
+    ],
+    "prerequisites": [
+      "Closed form for the even zeta values ζ(2k) (Mathlib hasSum_zeta_nat)",
+      "Even/odd parity splitting of an infinite sum (HasSum.even_add_odd)",
+      "Summability of a reindexed subfamily (Summable.comp_injective)",
+      "Uniqueness of sums in a Hausdorff space (HasSum.unique)",
+      "Sign of (-1)^n by parity of the exponent"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Real", "Nat"],
+    "namespace": "BaselEtaUniform",
+    "path": "Proofs/BaselProblemOQ13OQ01OQ01.lean",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The Dirichlet eta function η(s) = ∑_{n≥1} (-1)^(n+1)/nˢ is the alternating companion of the Riemann zeta function, related to it by the classical identity η(s) = (1 − 2^{1−s})ζ(s). Because its series converges (conditionally) for Re(s) > 0, η is a standard vehicle for the analytic continuation of ζ. At the even integers the eta values inherit Euler's closed forms: η(2) = π²/12, η(4) = 7π⁴/720, and in general η(2k) = (1 − 2^{1−2k})ζ(2k). The sibling entry basel-problem-oq-13-oq-01 formalized the single value η(4) by reusing fixed numerical fourth-power sums; this entry isolates the exponent-independent parity argument as one theorem and then obtains every even eta value uniformly from Mathlib's Bernoulli closed form for ζ(2k).",
+    "problemStatement": "Formalize, with 0 sorries and 0 axioms, the uniform eta–zeta relation and its even specialization: prove that for any exponent m, a convergent ζ(m) = ∑ 1/nᵐ = Z forces η(m) = ∑ (-1)^(n+1)/nᵐ = (1 − 2^{1−m})·Z, and specialize to m = 2k using Mathlib's closed form ζ(2k), recovering η(2) = π²/12 and η(4) = 7π⁴/720 as instances.",
+    "text": "The eta–zeta bridge η(s) = (1 − 2^{1−s})ζ(s), packaged as a single exponent-independent HasSum lemma, and its uniform even specialization η(2k) = (1 − 2^{1−2k})ζ(2k).",
+    "proofStrategy": "Fix a HasSum witness h : ∑ 1/nᵐ = Z. Split both the plain and the alternating series by parity via HasSum.even_add_odd. (1) The plain even part ∑_k 1/(2k)ᵐ = (1/2ᵐ)·Z, since ((2k))ᵐ = 2ᵐ·kᵐ and h.mul_left rescales the whole series. (2) The plain odd part ∑_k 1/(2k+1)ᵐ = B is summable as the image of the injection k ↦ 2k+1 (Summable.comp_injective); reassembling even + odd = full and comparing with h through HasSum.unique pins (1/2ᵐ)·Z + B = Z. (3) In the alternating series the sign is decided by parity: (-1)^(2k+1) = -1 negates the even part to -(1/2ᵐ)·Z, while (-1)^(2k+2) = +1 leaves the odd part equal to B. Reassembling gives η(m) = -(1/2ᵐ)·Z + B, and substituting B = Z − (1/2ᵐ)·Z (a single linear_combination on hZ) yields (1 − 2/2ᵐ)·Z. Every subseries HasSum is stated with an explicit summand so HasSum.even_add_odd matches by definitional reduction rather than higher-order unification. The even specialization is then hasSum_eta_of_hasSum_zeta (hasSum_zeta_nat hk); η(2) and η(4) follow by feeding hasSum_zeta_two / hasSum_zeta_four and simplifying the rational factor with ring.",
+    "keyInsights": [
+      "**The eta–zeta relation is finite-combinatorial, not analytic.** η(s) = (1 − 2^{1−s})ζ(s) needs no property of the exponent beyond convergence: ∑_{even} 1/nˢ = 2^{−s}ζ(s), so η = ζ − 2·(even part) = (1 − 2^{1−s})ζ. Capturing this as hasSum_eta_of_hasSum_zeta over an arbitrary natural exponent m turns every eta value into a corollary.",
+      "**Uniqueness extracts the odd tail without evaluating it.** The odd sum B has no elementary closed form on its own, but reassembling even + odd = full and comparing with the hypothesis via HasSum.unique pins (1/2ᵐ)·Z + B = Z exactly, so B = (1 − 1/2ᵐ)·Z is available symbolically.",
+      "**The alternating sign collapses to ±1 by parity of the exponent.** (-1)^(2k+1) = -1 and (-1)^(2k+2) = +1 (pow_succ / pow_mul + norm_num) reduce the alternating summand to ∓1/mᵐ, so the same even/odd HasSum lemmas serve both the plain and the alternating series.",
+      "**Explicit summands defeat higher-order unification.** Stating each even/odd subseries HasSum with its summand written out lets HasSum.even_add_odd unify the ambient function f by definitional reduction of f(2k) / f(2k+1), avoiding the HOU blow-up that arises when f must be guessed from a f(2k) pattern.",
+      "**One bridge, many values.** With the exponent free, η(2) = π²/12 (via ζ(2)), η(4) = 7π⁴/720 (via ζ(4), reproving the sibling), and the whole family η(2k) = (1 − 2^{1−2k})ζ(2k) (via Mathlib's Bernoulli hasSum_zeta_nat) are all specializations of a single theorem instead of separate parity computations."
+    ],
+    "prerequisites": [
+      "Riemann zeta / Dirichlet eta Dirichlet series and the relation η(s) = (1 − 2^{1−s})ζ(s)",
+      "Closed form for even zeta values ζ(2k) via Bernoulli numbers (Mathlib hasSum_zeta_nat)",
+      "Even/odd decomposition of infinite sums (HasSum.even_add_odd) and uniqueness of sums",
+      "HasSum / tsum / Summable API in Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "States the open question (package η(s) = (1 − 2^{1−s})ζ(s) uniformly and specialize to even integers) and the parity derivation; imports Mathlib's ZetaValues (for hasSum_zeta_nat/two/four) and Tactic, opening Real and scoped Nat (factorial notation).",
+      "mathContext": "The Dirichlet eta function as the alternating companion of ζ, and its closed relation to ζ at general exponents."
+    },
+    {
+      "id": "bridge",
+      "title": "hasSum_eta_of_hasSum_zeta — the eta–zeta bridge for any exponent",
+      "startLine": 47,
+      "endLine": 112,
+      "summary": "For any m and Z with ζ(m) = Z, proves η(m) = (1 − 2/2ᵐ)·Z. Builds the plain even part (1/2ᵐ)·Z (rescale of h), the summable odd part B (Summable.comp_injective on k ↦ 2k+1), pins (1/2ᵐ)·Z + B = Z by HasSum.unique, then negates the even part and reassembles the alternating series, finishing with a single linear_combination.",
+      "mathContext": "The exponent-independent heart of η(s) = (1 − 2^{1−s})ζ(s), from parity alone."
+    },
+    {
+      "id": "even-values",
+      "title": "hasSum_eta_two_mul_nat / eta_factor_eq — uniform even eta values",
+      "startLine": 114,
+      "endLine": 130,
+      "summary": "Feeds Mathlib's Bernoulli closed form hasSum_zeta_nat into the bridge to get η(2k) = (1 − 2/2^{2k})·ζ(2k) for every k ≥ 1, and proves the factor identity 1 − 2/2^{2k} = 1 − 2^{1−2k} (zpow_sub₀ / zpow_natCast).",
+      "mathContext": "The full even eta family, with the classical source-form factor 2^{1−2k}."
+    },
+    {
+      "id": "specific-values",
+      "title": "hasSum_eta_two / hasSum_eta_four — π²/12 and 7π⁴/720",
+      "startLine": 132,
+      "endLine": 155,
+      "summary": "Specializes the bridge with hasSum_zeta_two and hasSum_zeta_four, simplifying the rational factor by ring, to recover η(2) = π²/12 and η(4) = 7π⁴/720 (reproving the sibling entry from the uniform statement); tsum corollaries record the ∑' forms.",
+      "mathContext": "The two lowest even eta values as one-line instances of the bridge."
+    }
+  ],
+  "conclusion": {
+    "summary": "The eta–zeta relation η(s) = (1 − 2^{1−s})ζ(s) is formalized as a single exponent-independent HasSum lemma (hasSum_eta_of_hasSum_zeta), proved from the parity decomposition with no analytic assumption on the exponent, and specialized to the even integers via Mathlib's Bernoulli closed form to give the uniform value η(2k) = (1 − 2^{1−2k})ζ(2k). The sibling's η(4) = 7π⁴/720 and the companion η(2) = π²/12 are recovered as one-line instances. Verified with 0 axioms and 0 sorries, answering the first open question of basel-problem-oq-13-oq-01.",
+    "implications": "Replaces per-value parity bookkeeping with one reusable bridge: any convergent p-series HasSum now yields its alternating counterpart automatically. Because the argument never touches the exponent, it applies equally to real or complex exponents where the series converges — the even case is distinguished only by ζ(2k) having a closed form (Bernoulli), whereas at odd integers η(3)/ζ(3) (Apéry's constant) remain closed-form-free.",
+    "openQuestions": [
+      "Lift the bridge from natural exponents to real (or complex) s > 1 via rpow, giving η(s) = (1 − 2^{1−s})ζ(s) as an identity of the Mathlib riemannZeta on its region of absolute convergence rather than a p-series HasSum statement.",
+      "Prove the analogous uniform relation for the Dirichlet lambda function λ(s) = (1 − 2^{−s})ζ(s) and the three-way identity ζ = λ + (even part), so that λ(2k), η(2k), ζ(2k) are all specializations of one parity lemma.",
+      "Formalize the companion Dirichlet beta values β(2k+1) (β(1) = π/4, β(3) = π³/32) by the character/parity split of ∑ (−1)^n/(2n+1)^s, the odd-character analogue of the sign split used here."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-13-oq-01",
+      "relationship": "extends",
+      "description": "Sibling entry formalizing the single value η(4) = 7π⁴/720 by reusing fixed fourth-power sums. This entry answers its first open question by isolating the exponent-independent parity bridge and reproving η(4) as a one-line specialization."
+    },
+    {
+      "targetId": "basel-problem-oq-13",
+      "relationship": "extends",
+      "description": "Ancestor entry supplying the odd/even fourth-power sums; the present bridge subsumes its parity computation for all exponents."
+    },
+    {
+      "targetId": "basel-problem-oq-08",
+      "relationship": "related",
+      "description": "ζ(4) = π⁴/90; η(4) = (1 − 2^{−3})ζ(4) = 7π⁴/720 is its alternating restriction, an instance of the uniform factor 1 − 2^{1−2k}."
+    }
+  ],
+  "references": [
+    {
+      "title": "Riemann's Zeta Function",
+      "author": "Harold M. Edwards",
+      "year": "1974",
+      "venue": "Academic Press",
+      "description": "Develops the Dirichlet lambda and eta functions λ(s) = (1 − 2^{−s})ζ(s) and η(s) = (1 − 2^{1−s})ζ(s) as restrictions of the Riemann zeta function."
+    },
+    {
+      "title": "Introductio in analysin infinitorum",
+      "author": "Leonhard Euler",
+      "year": "1748",
+      "description": "Euler's evaluation of the even zeta values ζ(2k) = (rational)·π^{2k}, from which the even eta values η(2k) = (1 − 2^{1−2k})ζ(2k) follow."
+    }
+  ],
+  "openQuestions": [],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `basel-problem-oq-13-oq-01` (the η(4) entry): rather than hand-splitting each alternating sum by parity, package the eta–zeta relation **η(s) = (1 − 2^{1−s})ζ(s)** once and specialize.

## Core result

`hasSum_eta_of_hasSum_zeta` — for **any** natural exponent `m` and any `Z`:
$$\zeta(m)=\sum \tfrac{1}{n^m}=Z \;\Longrightarrow\; \eta(m)=\sum \tfrac{(-1)^{n+1}}{n^m}=\left(1-\tfrac{2}{2^m}\right)Z.$$
Proved from the **parity decomposition alone** — no analytic fact about the exponent — so it holds for every convergent `p`-series.

**Machinery:** even/odd split (`HasSum.even_add_odd`) of both the plain and the alternating series; the odd tail `B` extracted *symbolically* via `HasSum.unique` (never evaluated in closed form); the alternating sign collapsed to ±1 by parity of the exponent; finished with a single `linear_combination`. Each subseries `HasSum` is stated with an explicit summand so `even_add_odd` matches by definitional reduction (avoids a higher-order-unification blow-up).

## Specializations

| Theorem | Statement |
|---------|-----------|
| `hasSum_eta_two_mul_nat` | η(2k) = (1 − 2/2^{2k})·ζ(2k), every k ≥ 1, ζ(2k) via Mathlib `hasSum_zeta_nat` (Bernoulli) |
| `eta_factor_eq` | 1 − 2/2^{2k} = 1 − 2^{1−2k} (classical source form) |
| `hasSum_eta_two` | η(2) = π²/12 |
| `hasSum_eta_four` | η(4) = 7π⁴/720 (reproves sibling `BaselProblemOQ13OQ01` from the uniform statement) |
| `tsum_eta_two`, `tsum_eta_four` | ∑' forms |

## Verification

- **7 theorems, 0 definitions, 177 lines.**
- `#print axioms` on every theorem → `[propext, Classical.choice, Quot.sound]` only. **0 axioms, 0 sorries.**
- Compiles under Lean 4.26.0 / current Mathlib pin (`lake env lean`).

## Files
- `proofs/Proofs/BaselProblemOQ13OQ01OQ01.lean`
- `src/data/proofs/basel-problem-oq-13-oq-01-oq-01/{meta,annotations}.json`, `index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)