### PR TITLE
research(abel-ruffini-oq-04-oq-01-oq-01): general relative IsMaxNorm ⇔ IsSimpleGroup(↥K ⧸ H.subgroupOf K) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01OQ01.lean
@@ -1,0 +1,192 @@
+/-
+  Abel–Ruffini / Galois extensions, Jordan–Hölder branch (oq-04), open
+  question oq-01, follow-up oq-01:
+
+      "The fully general `K`/`subgroupOf` version (working inside the subtype
+       group `↥K`) is left for the upstream Mathlib development."
+                       — AbelRuffiniGaloisExtensionsOQ04OQ01.lean
+
+  The parent entry (`…OQ04`) defines the *relative* predicate `IsMaxNorm H K`
+  ("H is a maximal normal subgroup of K") and states — without proof — that it
+  is equivalent to `IsSimpleGroup (↥K ⧸ H.subgroupOf K)` "by the correspondence
+  theorem, but avoids quotient typeclass issues".  Its child (`…OQ04OQ01`) then
+  proved the `K = ⊤` instance of that bridge, explicitly deferring the general
+  relative case.
+
+  This file settles the deferred general case, axiom-free:
+
+      given `H ≤ K` and `(H.subgroupOf K).Normal`,
+        `IsSimpleGroup (↥K ⧸ H.subgroupOf K)  ↔  IsMaxNorm H K`.
+
+  The mathematical content beyond the `K = ⊤` case is the lattice transfer
+  between `Subgroup ↥K` and the interval `[H, K]` of `Subgroup G`, carried out
+  through `Subgroup.map K.subtype` / `Subgroup.subgroupOf K` and their round
+  trips.  This lets the abstract simplicity of the subtype quotient `↥K ⧸ …`
+  be tested entirely inside the ambient group `G`, which is what a
+  composition-series / Jordan–Hölder development actually needs.
+
+  Main results:
+    * `isMaximalNormal_subgroupOf_iff_isMaxNorm` — the lattice-transfer bridge
+      `IsMaximalNormal (H.subgroupOf K) ↔ IsMaxNorm H K` (for `H ≤ K`);
+    * `isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm` — the packaged
+      correspondence `IsSimpleGroup (↥K ⧸ H.subgroupOf K) ↔ IsMaxNorm H K`;
+    * `IsMaxNorm.isSimpleGroup_quotient` / `.of_isSimpleGroup_quotient`
+      — the two directions as standalone lemmas.
+
+  The absolute (`K = ⊤`) correspondence is reproved inline (self-contained,
+  Mathlib-only) so the file has no dependency beyond `import Mathlib`.
+-/
+
+import Mathlib
+
+open Subgroup QuotientGroup
+
+namespace AbelRuffiniGaloisExtensionsOQ04OQ01OQ01
+
+variable {G : Type*} [Group G]
+
+/-! ## The absolute correspondence (reproved inline, `K = ⊤` case) -/
+
+/-- `N` is a **maximal normal subgroup** of `G`: normal, proper, and not
+strictly contained in any proper normal subgroup. -/
+def IsMaximalNormal (N : Subgroup G) : Prop :=
+  N.Normal ∧ N ≠ ⊤ ∧ ∀ M : Subgroup G, N ≤ M → M.Normal → M = N ∨ M = ⊤
+
+/-- **Simple quotient ⇔ maximal normal subgroup** (absolute form).
+
+For a normal subgroup `N ◁ G`, the quotient `G ⧸ N` is simple iff `N` is
+proper and maximal among proper normal subgroups. -/
+theorem isSimpleGroup_quotient_iff (N : Subgroup G) [N.Normal] :
+    IsSimpleGroup (G ⧸ N) ↔
+      N ≠ ⊤ ∧ ∀ M : Subgroup G, N ≤ M → M.Normal → M = N ∨ M = ⊤ := by
+  rw [isSimpleGroup_iff]
+  constructor
+  · rintro ⟨hnt, hbt⟩
+    refine ⟨?_, ?_⟩
+    · intro hN
+      subst hN
+      exact (not_subsingleton (G ⧸ (⊤ : Subgroup G))) subsingleton_quotient_top
+    · intro M hNM hM
+      rcases hbt (M.map (mk' N)) inferInstance with h | h
+      · left
+        have hc : Subgroup.comap (mk' N) (M.map (mk' N))
+            = Subgroup.comap (mk' N) (⊥ : Subgroup (G ⧸ N)) := by rw [h]
+        rw [comap_map_mk' N M, MonoidHom.comap_bot, ker_mk', sup_eq_right.mpr hNM] at hc
+        exact hc
+      · right
+        have hc : Subgroup.comap (mk' N) (M.map (mk' N))
+            = Subgroup.comap (mk' N) (⊤ : Subgroup (G ⧸ N)) := by rw [h]
+        rw [comap_map_mk' N M, comap_top, sup_eq_right.mpr hNM] at hc
+        exact hc
+  · rintro ⟨hNtop, hmax⟩
+    refine ⟨?_, ?_⟩
+    · have hns : ¬ Subsingleton (G ⧸ N) :=
+        fun h => hNtop (subgroup_eq_top_of_subsingleton N h)
+      exact not_subsingleton_iff_nontrivial.mp hns
+    · intro H' hH'
+      have hcN : N ≤ Subgroup.comap (mk' N) H' := le_comap_mk' N H'
+      rcases hmax (Subgroup.comap (mk' N) H') hcN inferInstance with h | h
+      · left
+        have hb : Subgroup.comap (mk' N) (⊥ : Subgroup (G ⧸ N)) = N := by
+          rw [MonoidHom.comap_bot, ker_mk']
+        apply (comapMk'OrderIso N).injective
+        apply Subtype.ext
+        simp only [comapMk'OrderIso, RelIso.coe_fn_mk, Equiv.coe_fn_mk]
+        rw [h, hb]
+      · right
+        have ht : Subgroup.comap (mk' N) (⊤ : Subgroup (G ⧸ N)) = ⊤ := comap_top _
+        apply (comapMk'OrderIso N).injective
+        apply Subtype.ext
+        simp only [comapMk'OrderIso, RelIso.coe_fn_mk, Equiv.coe_fn_mk]
+        rw [h, ht]
+
+/-- Packaged absolute form via `IsMaximalNormal`. -/
+theorem isSimpleGroup_quotient_iff_isMaximalNormal (N : Subgroup G) [hN : N.Normal] :
+    IsSimpleGroup (G ⧸ N) ↔ IsMaximalNormal N := by
+  rw [isSimpleGroup_quotient_iff N, IsMaximalNormal]
+  exact ⟨fun h => ⟨hN, h.1, h.2⟩, fun h => ⟨h.2.1, h.2.2⟩⟩
+
+/-! ## The relative predicate and the lattice-transfer bridge -/
+
+/-- `H` is a **maximal normal subgroup of `K`** (parent entry `…OQ04`):
+`H < K`, `H` is relatively normal in `K`, and every normal-in-`K` subgroup
+between `H` and `K` equals `H` or `K`. -/
+def IsMaxNorm (H K : Subgroup G) : Prop :=
+  H < K ∧
+  (H.subgroupOf K).Normal ∧
+  ∀ N : Subgroup G, H ≤ N → N ≤ K → (N.subgroupOf K).Normal → N = H ∨ N = K
+
+/-- **Lattice-transfer bridge.**  For `H ≤ K`, being a maximal normal subgroup
+of the subtype group `↥K` (i.e. `IsMaximalNormal (H.subgroupOf K)`) is exactly
+the relative predicate `IsMaxNorm H K` stated in the ambient group `G`.
+
+This is the crux the open question flags: it moves the maximality test from the
+inaccessible subtype lattice `Subgroup ↥K` into the concrete interval `[H, K]`
+of `Subgroup G`, using the `map K.subtype` / `subgroupOf K` correspondence. -/
+theorem isMaximalNormal_subgroupOf_iff_isMaxNorm
+    {H K : Subgroup G} (hHK : H ≤ K) :
+    IsMaximalNormal (H.subgroupOf K) ↔ IsMaxNorm H K := by
+  constructor
+  · rintro ⟨hnorm, hne, hmax⟩
+    refine ⟨?_, hnorm, ?_⟩
+    · -- `H < K`: `H ≤ K` and `H ≠ K` (else `H.subgroupOf K = ⊤`).
+      refine lt_of_le_of_ne hHK ?_
+      intro hHKeq
+      exact hne (by rw [hHKeq, subgroupOf_self])
+    · -- relative maximality from subtype maximality via `N ↦ N.subgroupOf K`.
+      intro N hHN hNK hNnorm
+      have hle : H.subgroupOf K ≤ N.subgroupOf K := by
+        simpa only [subgroupOf] using comap_mono hHN
+      rcases hmax (N.subgroupOf K) hle hNnorm with h | h
+      · left
+        -- `N.subgroupOf K = H.subgroupOf K`, push through `map K.subtype`.
+        have := congrArg (Subgroup.map K.subtype) h
+        rwa [map_subgroupOf_eq_of_le hNK, map_subgroupOf_eq_of_le hHK] at this
+      · right
+        -- `N.subgroupOf K = ⊤` means `K ≤ N`, with `N ≤ K` gives `N = K`.
+        exact le_antisymm hNK (subgroupOf_eq_top.mp h)
+  · rintro ⟨hlt, hnorm, hmax⟩
+    refine ⟨hnorm, ?_, ?_⟩
+    · -- `H.subgroupOf K ≠ ⊤` since `H ≠ K` and `H ≤ K`.
+      rw [Ne, subgroupOf_eq_top]
+      exact fun hKH => absurd (le_antisymm hHK hKH) hlt.ne
+    · -- subtype maximality from relative maximality via `M ↦ M.map K.subtype`.
+      intro M hHM hMnorm
+      set N : Subgroup G := M.map K.subtype with hN
+      have hNK : N ≤ K := map_subtype_le M
+      have hMback : N.subgroupOf K = M := by
+        rw [hN, subgroupOf, comap_map_eq_self_of_injective K.subtype_injective]
+      have hHN : H ≤ N := by
+        have : (H.subgroupOf K).map K.subtype ≤ M.map K.subtype := map_mono hHM
+        rwa [map_subgroupOf_eq_of_le hHK] at this
+      have hNnorm : (N.subgroupOf K).Normal := by rw [hMback]; exact hMnorm
+      rcases hmax N hHN hNK hNnorm with h | h
+      · left; rw [← hMback, h]
+      · right; rw [← hMback, h, subgroupOf_self]
+
+/-! ## The packaged relative correspondence -/
+
+/-- **General relative correspondence** (the deferred `subgroupOf` case).
+
+For `H ≤ K` with `H.subgroupOf K` normal in `↥K`, the subtype quotient
+`↥K ⧸ H.subgroupOf K` is simple iff `H` is a maximal normal subgroup of `K`. -/
+theorem isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm
+    {H K : Subgroup G} (hHK : H ≤ K) [(H.subgroupOf K).Normal] :
+    IsSimpleGroup (↥K ⧸ H.subgroupOf K) ↔ IsMaxNorm H K := by
+  rw [isSimpleGroup_quotient_iff_isMaximalNormal (H.subgroupOf K),
+      isMaximalNormal_subgroupOf_iff_isMaxNorm hHK]
+
+/-- Maximal-normal ⇒ simple subtype quotient. -/
+theorem IsMaxNorm.isSimpleGroup_quotient
+    {H K : Subgroup G} (hHK : H ≤ K) (h : IsMaxNorm H K) :
+    haveI := h.2.1; IsSimpleGroup (↥K ⧸ H.subgroupOf K) := by
+  haveI := h.2.1
+  exact (isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm hHK).mpr h
+
+/-- Simple subtype quotient ⇒ maximal-normal. -/
+theorem IsMaxNorm.of_isSimpleGroup_quotient
+    {H K : Subgroup G} (hHK : H ≤ K) [(H.subgroupOf K).Normal]
+    (h : IsSimpleGroup (↥K ⧸ H.subgroupOf K)) : IsMaxNorm H K :=
+  (isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm hHK).mp h
+
+end AbelRuffiniGaloisExtensionsOQ04OQ01OQ01

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "ann-absolute-bridge",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 52,
+      "endLine": 108
+    },
+    "type": "theorem",
+    "title": "The Absolute Correspondence (reproved inline)",
+    "content": "isSimpleGroup_quotient_iff_isMaximalNormal reproves the K = ⊤ bridge — IsSimpleGroup (G ⧸ N) ↔ N is a maximal normal subgroup — directly from Mathlib via isSimpleGroup_iff and the correspondence map comapMk'OrderIso. It is included inline so the whole file depends only on `import Mathlib`, and instantiating it at the subtype group ↥K with N = H.subgroupOf K is the first half of the general argument.",
+    "mathContext": "$\\mathrm{IsSimpleGroup}(G/N) \\iff N \\lhd G,\\ N \\ne G,\\ \\forall M \\lhd G\\ (N \\le M \\Rightarrow M = N \\vee M = G).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "correspondence theorem",
+      "simple group",
+      "quotient group"
+    ],
+    "prerequisites": [
+      "QuotientGroup.comapMk'OrderIso",
+      "isSimpleGroup_iff"
+    ]
+  },
+  {
+    "id": "ann-ismaxnorm-def",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 114,
+      "endLine": 117
+    },
+    "type": "definition",
+    "title": "The Relative Predicate IsMaxNorm",
+    "content": "IsMaxNorm H K is the parent branch's combinatorial maximality relation: H < K, H is relatively normal in K (phrased as (H.subgroupOf K).Normal), and every N with H ≤ N ≤ K that is normal in K equals H or K. Crucially, normality is stated through subgroupOf K, so it matches the subtype-lattice normality with no extra transport.",
+    "mathContext": "$\\mathrm{IsMaxNorm}(H,K) :\\Leftrightarrow H < K \\wedge (H.\\mathrm{subgroupOf}\\,K)\\lhd \\uparrow K \\wedge \\forall N\\,(H \\le N \\le K \\wedge (N.\\mathrm{subgroupOf}\\,K)\\lhd \\uparrow K \\Rightarrow N = H \\vee N = K).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "relative normal subgroup",
+      "subgroupOf",
+      "maximal normal subgroup"
+    ],
+    "prerequisites": [
+      "Subgroup.subgroupOf",
+      "Subgroup.Normal"
+    ]
+  },
+  {
+    "id": "ann-lattice-transfer",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 126,
+      "endLine": 166
+    },
+    "type": "theorem",
+    "title": "The Lattice-Transfer Bridge",
+    "content": "isMaximalNormal_subgroupOf_iff_isMaxNorm is the core new result: for H ≤ K it identifies IsMaximalNormal (H.subgroupOf K) — maximal-normality inside the subtype lattice Subgroup ↥K — with IsMaxNorm H K, stated in the ambient interval [H, K] ⊆ Subgroup G. Each direction transports a subgroup across the order isomorphism subgroupOf K / map K.subtype: forward sends N ≤ K to N.subgroupOf K, reverse sends M : Subgroup ↥K to M.map K.subtype. The round trips map_subgroupOf_eq_of_le and comap_map_eq_self_of_injective (injectivity of K.subtype) recover the originals; subgroupOf_self and subgroupOf_eq_top handle the N = K and properness edge cases.",
+    "mathContext": "For $H \\le K$: $\\mathrm{IsMaximalNormal}(H.\\mathrm{subgroupOf}\\,K) \\iff \\mathrm{IsMaxNorm}(H,K)$, the transfer between $\\mathrm{Subgroup}\\,\\uparrow K$ and the interval $[H,K]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "subgroup lattice correspondence",
+      "subgroupOf / map subtype",
+      "order isomorphism"
+    ],
+    "prerequisites": [
+      "Subgroup.map_subgroupOf_eq_of_le",
+      "Subgroup.comap_map_eq_self_of_injective",
+      "Subgroup.subgroupOf_eq_top"
+    ]
+  },
+  {
+    "id": "ann-packaged-correspondence",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 173,
+      "endLine": 195
+    },
+    "type": "theorem",
+    "title": "The Packaged Relative Correspondence",
+    "content": "isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm chains the absolute correspondence (instantiated at ↥K) with the lattice-transfer bridge to yield the deferred general statement: IsSimpleGroup (↥K ⧸ H.subgroupOf K) ↔ IsMaxNorm H K for H ≤ K. The two directions are exposed as dot-notation lemmas IsMaxNorm.isSimpleGroup_quotient and IsMaxNorm.of_isSimpleGroup_quotient, matching how a composition-series argument consumes the bridge one implication at a time.",
+    "mathContext": "For $H \\le K$ with $(H.\\mathrm{subgroupOf}\\,K)\\lhd \\uparrow K$: $\\mathrm{IsSimpleGroup}(\\uparrow K / H.\\mathrm{subgroupOf}\\,K) \\iff \\mathrm{IsMaxNorm}(H,K).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "simple quotient",
+      "Jordan–Hölder lattice",
+      "composition series"
+    ],
+    "prerequisites": [
+      "IsSimpleGroup",
+      "Subgroup.subgroupOf"
+    ]
+  }
+]

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "abel-ruffini-galois-extensions-oq-04-oq-01-oq-01",
+  "title": "General relative correspondence: IsSimpleGroup (↥K ⧸ H.subgroupOf K) ⇔ IsMaxNorm H K",
+  "slug": "abel-ruffini-galois-extensions-oq-04-oq-01-oq-01",
+  "description": "The parent entry proved the IsMaxNorm ⇔ IsSimpleGroup bridge only for K = ⊤ (a genuine quotient G ⧸ N) and explicitly deferred 'the fully general K/subgroupOf version — working inside the subtype group ↥K, the quotient typeclass issues the open question flags'. This formalization settles that deferred case, axiom-free: for H ≤ K with H.subgroupOf K normal in ↥K, the subtype quotient ↥K ⧸ H.subgroupOf K is simple if and only if H is a maximal normal subgroup of K in the sense of the parent's combinatorial IsMaxNorm predicate. The mathematical content beyond the K = ⊤ case is the lattice transfer between Subgroup ↥K and the ambient interval [H, K] of Subgroup G, carried out via Subgroup.map K.subtype and Subgroup.subgroupOf K and their round trips (map_subgroupOf_eq_of_le, comap_map_eq_self_of_injective, subgroupOf_self, subgroupOf_eq_top). This is exactly what a composition-series / Jordan-Hölder development needs: it lets the abstract simplicity of a subtype quotient be tested entirely inside the ambient group G.",
+  "meta": {
+    "author": "Jordan, Hölder; Lean formalization original (researcher-11)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01OQ01.lean",
+    "tags": [
+      "group-theory",
+      "jordan-holder",
+      "simple-group",
+      "maximal-normal-subgroup",
+      "correspondence-theorem",
+      "subgroup-lattice",
+      "subgroupOf",
+      "abel-ruffini",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Every result is machine-checked with 0 axioms and 0 sorries (foundational propext/Classical.choice/Quot.sound only). Built on Mathlib's subtype-subgroup API (Subgroup.map_subgroupOf_eq_of_le, Subgroup.comap_map_eq_self_of_injective, Subgroup.subgroupOf_self, Subgroup.subgroupOf_eq_top, Subgroup.map_subtype_le, Subgroup.subtype_injective) and the correspondence theorem (QuotientGroup.comapMk'OrderIso, reproved inline for the K = ⊤ case so the file depends only on `import Mathlib`). This proves the general relative case the parent entry left open; upstreaming a full JordanHolderLattice (Subgroup G) instance remains open.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Subgroup.map_subgroupOf_eq_of_le",
+        "description": "For N ≤ K, (N.subgroupOf K).map K.subtype = N — the map∘subgroupOf round trip on the interval below K",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      },
+      {
+        "theorem": "Subgroup.comap_map_eq_self_of_injective",
+        "description": "Injective f ⟹ comap f (map f M) = M — the subgroupOf∘map round trip using injectivity of K.subtype",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      },
+      {
+        "theorem": "Subgroup.subgroupOf_eq_top",
+        "description": "H.subgroupOf K = ⊤ ↔ K ≤ H — converts the properness/top edge cases into ambient ≤ statements",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      },
+      {
+        "theorem": "QuotientGroup.comapMk'OrderIso",
+        "description": "Correspondence (fourth isomorphism) theorem, used inline for the K = ⊤ absolute bridge",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      }
+    ],
+    "originalContributions": [
+      "IsMaxNorm (parent predicate, reproduced): H < K, H relatively normal in K, and every normal-in-K subgroup between H and K equals H or K",
+      "isMaximalNormal_subgroupOf_iff_isMaxNorm: the lattice-transfer bridge IsMaximalNormal (H.subgroupOf K) ↔ IsMaxNorm H K for H ≤ K — the core new result, transferring maximality between the subtype lattice Subgroup ↥K and the ambient interval [H, K]",
+      "isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm: the packaged general relative correspondence IsSimpleGroup (↥K ⧸ H.subgroupOf K) ↔ IsMaxNorm H K, the case the parent deferred",
+      "IsMaxNorm.isSimpleGroup_quotient / .of_isSimpleGroup_quotient: the two directions as reusable dot-notation lemmas",
+      "isSimpleGroup_quotient_iff / isSimpleGroup_quotient_iff_isMaximalNormal: the absolute (K = ⊤) correspondence reproved inline so the file is self-contained"
+    ],
+    "lineCount": 197,
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "leanFile": {
+    "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01OQ01.lean",
+    "lineCount": 197,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 6
+  },
+  "overview": {
+    "historicalContext": "The Jordan–Hölder theorem (Camille Jordan, 1870; Otto Hölder, 1889) states that any two composition series of a finite group have the same length and the same simple composition factors up to permutation and isomorphism. It underlies the modern proof of the Abel–Ruffini theorem via solvability of the Galois group. A composition series is a maximal chain of normal subgroups, and each maximal step Hᵢ ◁ Hᵢ₊₁ has a simple quotient Hᵢ₊₁ / Hᵢ. Mathlib models this abstractly through a JordanHolderLattice typeclass whose maximality relation is combinatorial. The parent branch (oq-04) defined a relative predicate IsMaxNorm H K to serve as that relation on Subgroup G, and its child (oq-04-oq-01) proved that IsMaxNorm is equivalent to simplicity of the quotient — but only in the case K = ⊤, where the quotient is a genuine G ⧸ N. The general case works inside the subtype group ↥K, where the quotient is ↥K ⧸ H.subgroupOf K; the parent explicitly deferred it, citing 'quotient typeclass issues'. This entry closes that gap.",
+    "problemStatement": "Let $G$ be a group and $H \\le K$ subgroups with $H.\\mathrm{subgroupOf}\\,K$ normal in $\\uparrow K$. Prove that the subtype quotient $\\uparrow K / (H.\\mathrm{subgroupOf}\\,K)$ is simple if and only if $H$ is a maximal normal subgroup of $K$ in the sense of $\\mathrm{IsMaxNorm}\\,H\\,K$: $H < K$, $H$ is relatively normal in $K$, and every $N$ with $H \\le N \\le K$ that is normal in $K$ satisfies $N = H$ or $N = K$.",
+    "proofStrategy": "Reduce to the absolute correspondence and a lattice transfer. First reprove the K = ⊤ bridge isSimpleGroup_quotient_iff_isMaximalNormal inline (isSimpleGroup_iff + the correspondence map comapMk'OrderIso), then instantiate it at the group ↥K with N = H.subgroupOf K to get IsSimpleGroup (↥K ⧸ H.subgroupOf K) ↔ IsMaximalNormal (H.subgroupOf K). The new content is isMaximalNormal_subgroupOf_iff_isMaxNorm, which identifies IsMaximalNormal (H.subgroupOf K) (a statement about the subtype lattice Subgroup ↥K) with IsMaxNorm H K (a statement about the ambient interval [H, K]). The transfer uses the order-preserving pair N ↦ N.subgroupOf K (for N ≤ K) and M ↦ M.map K.subtype (for M : Subgroup ↥K), which are mutually inverse on the relevant ranges: map_subgroupOf_eq_of_le gives the round trip on [⊥, K] and comap_map_eq_self_of_injective (via injectivity of K.subtype) the other. Properness H.subgroupOf K ≠ ⊤ becomes H < K through subgroupOf_eq_top and subgroupOf_self; each maximality quantifier is transported by mapping subgroups across the correspondence and rewriting normality through the round trips.",
+    "keyInsights": [
+      "The maximality test that JordanHolderLattice needs lives, a priori, in the subtype lattice Subgroup ↥K, which is awkward to reason about; the whole point is to relocate it into the concrete ambient interval [H, K] ⊆ Subgroup G. The bridge isMaximalNormal_subgroupOf_iff_isMaxNorm is exactly that relocation.",
+      "The subgroupOf / map K.subtype pair is an order isomorphism between Subgroup ↥K and the interval of subgroups of G contained in K; map_subgroupOf_eq_of_le and comap_map_eq_self_of_injective are the two round-trip identities that make the transfer of both the ≤-hypotheses and the conclusions mechanical.",
+      "Normality is stated identically on both sides — the parent's IsMaxNorm already phrases relative normality as (N.subgroupOf K).Normal — so once M = N.subgroupOf K the normality hypotheses match with no extra transport lemma.",
+      "The edge cases collapse cleanly: subgroupOf_self turns N = K into M = ⊤, and subgroupOf_eq_top turns H.subgroupOf K = ⊤ into K ≤ H, so properness of the subtype subgroup is precisely H < K given H ≤ K.",
+      "Because IsMaxNorm depends only on H ⊓ K, the equivalence is stated under the hypothesis H ≤ K, which is the only regime where the subtype maximality faithfully reflects the ambient one; this is the honest scope of the bridge rather than an unconditional claim."
+    ],
+    "prerequisites": [
+      "Subgroups, normal subgroups, quotient groups and the canonical projection mk'",
+      "Subtype groups ↥K, Subgroup.subgroupOf, Subgroup.map / comap and the subtype correspondence",
+      "Simple groups and IsSimpleGroup / isSimpleGroup_iff, the correspondence (fourth isomorphism) theorem",
+      "Composition series, maximal normal subgroups, and the Jordan–Hölder theorem (motivation)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "absolute",
+      "title": "The Absolute Correspondence (K = ⊤, reproved inline)",
+      "startLine": 48,
+      "endLine": 108,
+      "summary": "IsMaximalNormal N and isSimpleGroup_quotient_iff_isMaximalNormal: IsSimpleGroup (G ⧸ N) ↔ N maximal normal, via the correspondence map comapMk'OrderIso. Self-contained so the file needs only import Mathlib."
+    },
+    {
+      "id": "predicate",
+      "title": "The Relative Predicate IsMaxNorm",
+      "startLine": 109,
+      "endLine": 117,
+      "summary": "IsMaxNorm H K: H < K, H relatively normal in K, and every normal-in-K subgroup between H and K equals H or K — the parent's combinatorial predicate."
+    },
+    {
+      "id": "bridge",
+      "title": "The Lattice-Transfer Bridge",
+      "startLine": 118,
+      "endLine": 166,
+      "summary": "isMaximalNormal_subgroupOf_iff_isMaxNorm: for H ≤ K, IsMaximalNormal (H.subgroupOf K) ↔ IsMaxNorm H K. Transfers maximality between Subgroup ↥K and the interval [H, K] via subgroupOf / map K.subtype round trips."
+    },
+    {
+      "id": "packaged",
+      "title": "The Packaged Relative Correspondence",
+      "startLine": 167,
+      "endLine": 195,
+      "summary": "isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm plus the two dot-notation directions: IsSimpleGroup (↥K ⧸ H.subgroupOf K) ↔ IsMaxNorm H K, the general case deferred by the parent."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "Galois Theory",
+      "year": "1998",
+      "venue": "2nd ed., Universitext, Springer",
+      "note": "Jordan–Hölder theory and the simple-quotient / maximal-normal-subgroup correspondence."
+    },
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Subtype (relative) subgroups, the lattice correspondence, and composition series."
+    }
+  ],
+  "conclusion": {
+    "summary": "The relative maximal-normal predicate IsMaxNorm H K and simplicity of the subtype quotient ↥K ⧸ H.subgroupOf K are equivalent whenever H ≤ K. The proof reduces to the absolute K = ⊤ correspondence and a lattice transfer: the pair subgroupOf K / map K.subtype is an order isomorphism between Subgroup ↥K and the interval [⊥, K], and its round-trip identities carry each maximality quantifier and every edge case across. This settles the general relative correspondence that the parent entry proved only for K = ⊤ and explicitly deferred.",
+    "implications": [
+      "Supplies the exact bridge needed to make IsMaxNorm the IsMaximal relation of a JordanHolderLattice (Subgroup G) instance without ever leaving the ambient subgroup lattice of G.",
+      "Shows the subtype-quotient 'typeclass issues' the open question flagged are dischargeable: the transfer is entirely lattice-theoretic once normality is phrased via subgroupOf, as the parent already did."
+    ],
+    "openQuestions": [
+      "Assemble the results into a complete, upstreamable JordanHolderLattice (Subgroup G) instance and contribute it to Mathlib.",
+      "Derive the relative second/third isomorphism steps (jordan_holder consumption) directly from this bridge to shorten the parent's composition-series development."
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "child-of",
+      "description": "Completes the general K/subgroupOf case of the IsMaxNorm ⇔ IsSimpleGroup bridge that this parent proved only for K = ⊤ and deferred.",
+      "targetId": "abel-ruffini-galois-extensions-oq-04-oq-01"
+    },
+    {
+      "relationship": "related-to",
+      "description": "Provides the maximality relation used by the JordanHolderLattice (Subgroup G) instance of the parent branch.",
+      "targetId": "abel-ruffini-galois-extensions-oq-04"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Settles the open question **abel-ruffini-galois-extensions-oq-04-oq-01-oq-01** — the general relative case of the `IsMaxNorm` ⇔ `IsSimpleGroup` correspondence that the parent (`…OQ04OQ01`) proved **only for `K = ⊤`** and explicitly deferred:

> "the fully general `K`/`subgroupOf` version (working inside the subtype group `↥K`) is left for the upstream Mathlib development."

The parent's own `meta.json` lists this exact case as its top open question.

## Main result

For `H ≤ K` with `H.subgroupOf K` normal in `↥K`:

```
IsSimpleGroup (↥K ⧸ H.subgroupOf K)  ↔  IsMaxNorm H K
```

The mathematical content beyond the `K = ⊤` case is the **lattice transfer** between the subtype lattice `Subgroup ↥K` and the ambient interval `[H, K] ⊆ Subgroup G`, carried out through the order isomorphism `subgroupOf K` / `map K.subtype` and its round-trip identities (`map_subgroupOf_eq_of_le`, `comap_map_eq_self_of_injective`, `subgroupOf_self`, `subgroupOf_eq_top`). This relocates the maximality test a Jordan–Hölder / composition-series development needs out of the awkward subtype lattice and into the concrete ambient interval.

## Contents

- `isMaximalNormal_subgroupOf_iff_isMaxNorm` — the core new bridge `IsMaximalNormal (H.subgroupOf K) ↔ IsMaxNorm H K` (for `H ≤ K`)
- `isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm` — the packaged general relative correspondence
- `IsMaxNorm.isSimpleGroup_quotient` / `.of_isSimpleGroup_quotient` — the two directions as dot-notation lemmas
- `isSimpleGroup_quotient_iff_isMaximalNormal` — the absolute (`K = ⊤`) correspondence reproved inline so the file depends only on `import Mathlib`

## Verification

- **6 theorems, 2 defs, 197 lines**
- `#print axioms` on the main theorems: only `propext`, `Classical.choice`, `Quot.sound` → **VERIFIED, 0-axiom, 0-sorry**
- Typechecked with `lake env lean` against Mathlib.

Includes gallery entry (`meta.json` + `annotations.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)