### PR TITLE
research(shapley-folkman-oq-04): excess bounded by min(dim, #non-convex summands) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ShapleyFolkmanOQ04.lean
+++ b/proofs/Proofs/ShapleyFolkmanOQ04.lean
@@ -1,0 +1,254 @@
+/-
+# Shapley-Folkman Refined: Excess Bounded by the Number of Non-Convex Summands (OQ04)
+
+The base `shapley_folkman` lemma bounds the number of "excess" summands (those
+requiring convexification, i.e. `xᵢ ∈ conv(Sᵢ) \ Sᵢ`) by the dimension `d` of
+the ambient space. This is dimension-driven and completely ignores *how many* of
+the summands were already convex.
+
+This file proves the sharper **structural** bound
+
+    excess ≤ min(d, #{i : Sᵢ is not convex}).
+
+The mechanism is elementary but sharp: a convex summand `Sᵢ` satisfies
+`conv(Sᵢ) = Sᵢ`, so *every* point of `conv(Sᵢ)` already lies in `Sᵢ` and such an
+index can never be an excess index. Hence the excess set is always contained in
+the set of non-convex indices — a fact that requires **no** finite-dimensionality
+at all. Intersecting with the dimension bound yields the `min`.
+
+## Main Results
+
+1. `excessIndices_subset_nonConvex` — for ANY decomposition, the excess indices
+   are a subset of the non-convex indices (holds in any real vector space).
+2. `excess_card_le_nonConvex` — pure combinatorial corollary: excess count is at
+   most the number of non-convex summands, with **no dimension hypothesis**.
+3. `shapley_folkman_refined` — the headline `min(d, #nonConvex)` bound.
+4. `sum_close_refined` — the `sum_close_to_convexHull` corollary, sharpened.
+5. `convex_summands_hull_eq` — recovers the classical fact "the Minkowski sum of
+   convex sets is convex" as the excess = 0 special case (all summands convex).
+6. `shapley_folkman_starr_refined` — Starr's distance bound `dist ≤ (…)·δ`, with
+   the dimension factor replaced by `min(d, #nonConvex)`.
+
+## Why this is a genuine refinement
+
+If a large economy has `n` agents but only `k` of them have non-convex feasible
+sets, the aggregate is within `min(d, k)` — NOT `d` — of being exactly convex,
+uniformly in `n`. When every agent is convex (`k = 0`) the aggregate is *exactly*
+convex: there is no approximation error at all.
+-/
+
+import Mathlib
+import Proofs.ShapleyFolkman
+
+set_option linter.unusedVariables false
+
+namespace ShapleyFolkmanOQ04
+
+open Set Finset Pointwise ShapleyFolkman
+
+-- Matches the base file: Classical decidability lets `Finset.filter` range over
+-- arbitrary `Set`/`Convex` predicates without threading `DecidablePred` instances.
+attribute [local instance] Classical.propDecidable
+
+variable {E : Type*} [AddCommGroup E] [Module ℝ E]
+
+-- ============================================================
+-- SECTION I: Non-convex indices and the subset lemma
+-- ============================================================
+
+/-- The indices whose summand set is **not** convex. Convex summands never
+    contribute excess, so this set governs the refined bound. -/
+noncomputable def nonConvexIndices {ι : Type*} (S : ι → Set E) (t : Finset ι) : Finset ι :=
+  t.filter (fun i => ¬ Convex ℝ (S i))
+
+/-- For a convex set `S`, every point of its convex hull already lies in `S`
+    (`conv(S) = S`). This is the pointwise reason convex summands are "free". -/
+lemma mem_of_convex {S : Set E} (hS : Convex ℝ S) {x : E}
+    (hx : x ∈ convexHull ℝ S) : x ∈ S := by
+  rwa [hS.convexHull_eq] at hx
+
+/-- **Core structural lemma.** For *any* decomposition of `x`, every excess index
+    is a non-convex index. Equivalently: if `Sᵢ` is convex then `i` is not an
+    excess index. This holds in an arbitrary real vector space — no
+    finite-dimensionality is used. -/
+theorem excessIndices_subset_nonConvex {ι : Type*} [DecidableEq ι]
+    {S : ι → Set E} {t : Finset ι} {x : E} (D : Decomposition S t x) :
+    D.excessIndices ⊆ nonConvexIndices S t := by
+  intro i hi
+  -- `i ∈ excessIndices` unpacks to `i ∈ t` and `D.point i ∉ S i`.
+  simp only [Decomposition.excessIndices, Finset.mem_filter] at hi
+  obtain ⟨hit, hnot⟩ := hi
+  -- The chosen point lies in `conv(Sᵢ)` because `i ∈ t`.
+  have hmem : D.point i ∈ convexHull ℝ (S i) := D.mem_convexHull i hit
+  -- If `Sᵢ` were convex, `D.point i` would land in `Sᵢ`, contradicting `hnot`.
+  simp only [nonConvexIndices, Finset.mem_filter]
+  refine ⟨hit, fun hconv => hnot (mem_of_convex hconv hmem)⟩
+
+/-- **Dimension-free counting corollary.** The number of excess summands never
+    exceeds the number of non-convex summands, in any real vector space. -/
+theorem excess_card_le_nonConvex {ι : Type*} [DecidableEq ι]
+    {S : ι → Set E} {t : Finset ι} {x : E} (D : Decomposition S t x) :
+    D.excessIndices.card ≤ (nonConvexIndices S t).card :=
+  Finset.card_le_card (excessIndices_subset_nonConvex D)
+
+/-- Filter-level form of the subset lemma: for any family `f` with
+    `f i ∈ conv(Sᵢ)`, the indices where `f i ∉ Sᵢ` are all non-convex indices.
+    This avoids repackaging into a `Decomposition`. -/
+theorem excessFilter_subset_nonConvex {ι : Type*} {S : ι → Set E} {t : Finset ι}
+    {f : ι → E} (hf_mem : ∀ i ∈ t, f i ∈ convexHull ℝ (S i)) :
+    t.filter (fun i => f i ∉ S i) ⊆ nonConvexIndices S t := by
+  intro i hi
+  simp only [Finset.mem_filter] at hi
+  obtain ⟨hit, hnot⟩ := hi
+  simp only [nonConvexIndices, Finset.mem_filter]
+  exact ⟨hit, fun hconv => hnot (mem_of_convex hconv (hf_mem i hit))⟩
+
+-- ============================================================
+-- SECTION II: The refined Shapley-Folkman bound
+-- ============================================================
+
+/-- **Refined Shapley-Folkman Lemma.** Any point of `∑ conv(Sᵢ)` admits a
+    decomposition whose excess count is bounded by `min(d, #nonConvex)`, where
+    `d = dim E` and `#nonConvex` counts the non-convex summands.
+
+    This strictly sharpens `shapley_folkman`: the excess is controlled by the
+    *smaller* of the dimension and the number of genuinely non-convex sets. -/
+theorem shapley_folkman_refined [FiniteDimensional ℝ E]
+    {ι : Type*} [DecidableEq ι] {S : ι → Set E} {t : Finset ι}
+    (hne : ∀ i ∈ t, (S i).Nonempty)
+    {x : E} (hx : ∃ (f : ι → E), (∀ i ∈ t, f i ∈ convexHull ℝ (S i)) ∧
+      (∀ i, i ∉ t → f i = 0) ∧ ∑ i ∈ t, f i = x) :
+    ∃ (d : Decomposition S t x),
+      d.excessIndices.card ≤ min (Module.finrank ℝ E) (nonConvexIndices S t).card := by
+  obtain ⟨D, hD⟩ := shapley_folkman hne hx
+  exact ⟨D, le_min hD (excess_card_le_nonConvex D)⟩
+
+/-- **Refined "sum close to convex hull" corollary.** For a point in
+    `conv(∑ Sᵢ)`, the summand decomposition needs convexification on at most
+    `min(d, #nonConvex)` indices. -/
+theorem sum_close_refined [FiniteDimensional ℝ E]
+    {ι : Type*} [DecidableEq ι] {S : ι → Set E} {t : Finset ι}
+    (hne : ∀ i ∈ t, (S i).Nonempty)
+    {x : E} (hx : x ∈ convexHull ℝ (∑ i ∈ t, S i)) :
+    ∃ (f : ι → E),
+      (∀ i ∈ t, f i ∈ convexHull ℝ (S i)) ∧
+      ∑ i ∈ t, f i = x ∧
+      (t.filter (fun i => f i ∉ S i)).card
+        ≤ min (Module.finrank ℝ E) (nonConvexIndices S t).card := by
+  -- Base corollary gives the dimension bound; the filter-level subset lemma
+  -- gives the non-convex bound. Take the minimum.
+  obtain ⟨f, hf_mem, hf_sum, hf_excess⟩ := sum_close_to_convexHull hne hx
+  exact ⟨f, hf_mem, hf_sum,
+    le_min hf_excess (Finset.card_le_card (excessFilter_subset_nonConvex hf_mem))⟩
+
+-- ============================================================
+-- SECTION III: All-convex special case (classical Minkowski fact)
+-- ============================================================
+
+/-- When **every** summand is convex there are no non-convex indices. -/
+lemma nonConvexIndices_eq_empty {ι : Type*} {S : ι → Set E} {t : Finset ι}
+    (hconv : ∀ i ∈ t, Convex ℝ (S i)) :
+    nonConvexIndices S t = ∅ := by
+  simp only [nonConvexIndices]
+  rw [Finset.filter_eq_empty_iff]
+  intro i hi; simpa using hconv i hi
+
+/-- **Minkowski sum of convex sets is convex — recovered as the excess = 0 case.**
+    If all summands are convex, then `conv(∑ Sᵢ) = ∑ Sᵢ`: every point of the
+    convex hull of the Minkowski sum already lies in the sum, with no
+    convexification needed. -/
+theorem convex_summands_hull_eq [FiniteDimensional ℝ E]
+    {ι : Type*} [DecidableEq ι] {S : ι → Set E} {t : Finset ι}
+    (hne : ∀ i ∈ t, (S i).Nonempty)
+    (hconv : ∀ i ∈ t, Convex ℝ (S i))
+    {x : E} (hx : x ∈ convexHull ℝ (∑ i ∈ t, S i)) :
+    x ∈ ∑ i ∈ t, S i := by
+  -- Refined corollary: excess ≤ #nonConvex = 0, so the decomposition sits in ∑ Sᵢ.
+  obtain ⟨f, hf_mem, hf_sum, hf_excess⟩ := sum_close_refined hne hx
+  -- `#nonConvex = 0`, so the excess filter is empty and every `f i ∈ S i`.
+  have hcard0 : (t.filter (fun i => f i ∉ S i)).card = 0 := by
+    rw [nonConvexIndices_eq_empty hconv, Finset.card_empty, Nat.min_zero,
+      Nat.le_zero] at hf_excess
+    exact hf_excess
+  have hmem : ∀ i ∈ t, f i ∈ S i := by
+    rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff] at hcard0
+    intro i hi; exact not_not.mp (hcard0 hi)
+  rw [Set.mem_finset_sum]
+  refine ⟨f, ?_, hf_sum⟩
+  intro i hi
+  exact hmem i hi
+
+-- ============================================================
+-- SECTION IV: Refined Starr distance bound (normed setting)
+-- ============================================================
+
+section Normed
+
+variable {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+
+/-- If `p ∈ conv(S)`, `q ∈ S`, and `S` has diameter `≤ δ`, then `dist p q ≤ δ`.
+    (Local copy of the OQ03 distance lemma so this file stays self-contained.) -/
+private lemma convexHull_dist_le_diam {S : Set F} {p q : F} {δ : ℝ}
+    (hq : q ∈ S) (hdiam : ∀ s₁ ∈ S, ∀ s₂ ∈ S, dist s₁ s₂ ≤ δ)
+    (hp : p ∈ convexHull ℝ S) : dist p q ≤ δ := by
+  have hS_sub : S ⊆ Metric.closedBall q δ := fun s hs =>
+    Metric.mem_closedBall.mpr (hdiam s hs q hq)
+  have hsub := convexHull_min hS_sub (convex_closedBall q δ)
+  exact Metric.mem_closedBall.mp (hsub hp)
+
+/-- **Refined Shapley-Folkman-Starr Theorem.** Any point in `conv(∑ Sᵢ)` is
+    within distance `min(d, #nonConvex) · δ` of the actual Minkowski sum, where
+    `δ` bounds each summand's diameter. This sharpens `shapley_folkman_starr`
+    (OQ03): the number of *non-convex* agents, not the ambient dimension, caps
+    the aggregate non-convexity when the former is smaller. -/
+theorem shapley_folkman_starr_refined [FiniteDimensional ℝ F]
+    {ι : Type*} [DecidableEq ι] {S : ι → Set F} {t : Finset ι}
+    (hne : ∀ i ∈ t, (S i).Nonempty)
+    (δ : ℝ) (hδ : 0 ≤ δ)
+    (hdiam : ∀ i ∈ t, ∀ s₁ ∈ S i, ∀ s₂ ∈ S i, dist s₁ s₂ ≤ δ)
+    {x : F} (hx : x ∈ convexHull ℝ (∑ i ∈ t, S i)) :
+    ∃ x' ∈ ∑ i ∈ t, S i,
+      dist x x' ≤ (min (Module.finrank ℝ F) (nonConvexIndices S t).card : ℝ) * δ := by
+  classical
+  -- Refined decomposition: excess set `J` has card ≤ min(d, #nonConvex).
+  obtain ⟨f, hf_mem, hf_sum, hf_excess⟩ := sum_close_refined hne hx
+  set J := t.filter (fun i => f i ∉ S i) with hJ
+  have hJ_sub : J ⊆ t := Finset.filter_subset _ _
+  -- Replace each excess summand by a genuine point of its set.
+  let g : ι → F := fun i => if h : i ∈ J then (hne i (hJ_sub h)).choose else f i
+  have hg_J : ∀ j ∈ J, g j ∈ S j := fun j hj => by
+    simp only [g, dif_pos hj]; exact (hne j (hJ_sub hj)).choose_spec
+  have hg_notJ : ∀ i ∈ t, i ∉ J → g i ∈ S i := fun i hi hiJ => by
+    simp only [g, dif_neg hiJ]
+    simp only [hJ, Finset.mem_filter, hi, true_and, not_not] at hiJ
+    exact hiJ
+  have hx'_mem : ∑ i ∈ t, g i ∈ ∑ i ∈ t, S i := by
+    rw [Set.mem_finset_sum]
+    refine ⟨g, ?_, rfl⟩
+    intro i hi
+    by_cases hiJ : i ∈ J
+    · exact hg_J i hiJ
+    · exact hg_notJ i hi hiJ
+  refine ⟨∑ i ∈ t, g i, hx'_mem, ?_⟩
+  rw [← hf_sum]
+  calc dist (∑ i ∈ t, f i) (∑ i ∈ t, g i)
+      = ‖∑ i ∈ t, f i - ∑ i ∈ t, g i‖ := dist_eq_norm _ _
+    _ = ‖∑ i ∈ t, (f i - g i)‖ := by rw [← Finset.sum_sub_distrib]
+    _ = ‖∑ i ∈ J, (f i - g i)‖ := by
+        congr 1; symm
+        apply Finset.sum_subset hJ_sub
+        intro i hi hiJ; simp only [g, dif_neg hiJ, sub_self]
+    _ ≤ ∑ i ∈ J, ‖f i - g i‖ := norm_sum_le J _
+    _ ≤ ∑ i ∈ J, δ := by
+        apply Finset.sum_le_sum
+        intro j hj
+        rw [← dist_eq_norm]
+        exact convexHull_dist_le_diam (hg_J j hj) (hdiam j (hJ_sub hj))
+          (hf_mem j (hJ_sub hj))
+    _ = J.card * δ := by rw [Finset.sum_const, nsmul_eq_mul]
+    _ ≤ (min (Module.finrank ℝ F) (nonConvexIndices S t).card : ℝ) * δ :=
+        mul_le_mul_of_nonneg_right (by exact_mod_cast hf_excess) hδ
+
+end Normed
+
+end ShapleyFolkmanOQ04

--- a/src/data/proofs/shapley-folkman-oq-04/annotations.json
+++ b/src/data/proofs/shapley-folkman-oq-04/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-oq04-header",
+    "proofId": "shapley-folkman-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 62
+    },
+    "type": "concept",
+    "title": "Refining the Shapley-Folkman Bound: min(d, #nonConvex)",
+    "content": "The base Shapley-Folkman lemma bounds the number of 'excess' summands (those needing convexification, i.e. xᵢ ∈ conv(Sᵢ) \\ Sᵢ) by the ambient dimension d. That bound is purely dimensional — it never looks at *how many* of the summands were already convex.\n\nThis file proves the sharper bound\n\n    excess ≤ min(d, k),   k = #{i : Sᵢ is not convex}.\n\nThe mechanism is elementary but sharp: a convex Sᵢ satisfies conv(Sᵢ) = Sᵢ, so every point of conv(Sᵢ) is already in Sᵢ, and i can never be an excess index. Hence the excess set is always contained in the non-convex index set — with **no** finite-dimensionality needed. Intersecting with the dimension bound gives the min.\n\n**Setup**: the counting results work over an arbitrary real vector space (AddCommGroup + Module ℝ); only the min bound and the Starr metric refinement use FiniteDimensional. Classical.propDecidable is a local instance (as in the base file) so Finset.filter can range over Convex/membership predicates.",
+    "mathContext": "$\\mathrm{nonConvexIndices}\\,S\\,t = \\{i \\in t : S_i \\text{ not convex}\\}$. The refined statement is $\\#\\mathrm{excess} \\le \\min(\\dim E,\\ \\#\\mathrm{nonConvexIndices})$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Shapley-Folkman lemma",
+      "Minkowski sum",
+      "convex hull",
+      "non-convex summands",
+      "approximate convexity"
+    ],
+    "prerequisites": [
+      "Shapley-Folkman lemma",
+      "convex hull of a convex set",
+      "Minkowski sums"
+    ]
+  },
+  {
+    "id": "ann-oq04-subset",
+    "proofId": "shapley-folkman-oq-04",
+    "range": {
+      "startLine": 63,
+      "endLine": 104
+    },
+    "type": "insight",
+    "title": "Core Lemma: Every Excess Index Is a Non-Convex Index",
+    "content": "`mem_of_convex` records the pointwise fact: for convex S, conv(S) = S (Mathlib's `Convex.convexHull_eq`), so any x ∈ conv(S) lies in S.\n\n`excessIndices_subset_nonConvex` is the structural heart of the file: for **any** decomposition D of x, D.excessIndices ⊆ nonConvexIndices. If i is an excess index then D.point i ∉ Sᵢ while D.point i ∈ conv(Sᵢ) (because i ∈ t); were Sᵢ convex, mem_of_convex would force D.point i ∈ Sᵢ, a contradiction. So i is non-convex.\n\n`excessFilter_subset_nonConvex` gives the same containment directly for a raw summand family f with f i ∈ conv(Sᵢ), bypassing the Decomposition wrapper — this is what the corollaries actually use.\n\n**Crucially, both lemmas are dimension-free**: they hold in an arbitrary real vector space.",
+    "mathContext": "Contrapositive of 'convex ⟹ not excess': $i \\in \\mathrm{excess} \\Rightarrow S_i$ not convex. As Finsets, $\\mathrm{excess} \\subseteq \\mathrm{nonConvexIndices}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Convex.convexHull_eq",
+      "excess indices",
+      "Decomposition"
+    ],
+    "prerequisites": [
+      "convex hull of a convex set equals the set"
+    ]
+  },
+  {
+    "id": "ann-oq04-refined",
+    "proofId": "shapley-folkman-oq-04",
+    "range": {
+      "startLine": 105,
+      "endLine": 143
+    },
+    "type": "main-theorem",
+    "title": "The Refined Bound: excess ≤ min(d, #nonConvex)",
+    "content": "`excess_card_le_nonConvex` turns the subset lemma into a counting bound via `Finset.card_le_card`: the excess count is at most the number of non-convex summands, with **no** dimension hypothesis.\n\n`shapley_folkman_refined` is the headline result. It takes the base `shapley_folkman` decomposition (excess ≤ dim E) and the non-convex bound (excess ≤ #nonConvex) and combines them with `le_min`:\n\n    D.excessIndices.card ≤ min (Module.finrank ℝ E) (nonConvexIndices S t).card.\n\n`sum_close_refined` lifts this to the `sum_close_to_convexHull` corollary: for x ∈ conv(∑Sᵢ) there is a summand family f with ∑f = x and (filter of convexification indices).card ≤ min(d, #nonConvex).",
+    "mathContext": "$\\text{excess} \\le d$ (base lemma) and $\\text{excess} \\le k$ (subset lemma) together give $\\text{excess} \\le \\min(d,k)$ by `le_min`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "shapley_folkman",
+      "sum_close_to_convexHull",
+      "le_min",
+      "Finset.card_le_card"
+    ],
+    "prerequisites": [
+      "Shapley-Folkman dimension bound",
+      "cardinality monotonicity"
+    ]
+  },
+  {
+    "id": "ann-oq04-convex-case",
+    "proofId": "shapley-folkman-oq-04",
+    "range": {
+      "startLine": 144,
+      "endLine": 180
+    },
+    "type": "insight",
+    "title": "k = 0: Minkowski Sum of Convex Sets Is Convex",
+    "content": "`nonConvexIndices_eq_empty`: if every summand is convex, there are no non-convex indices.\n\n`convex_summands_hull_eq` then recovers a classical theorem as the zero-excess special case: if every Sᵢ is convex, then conv(∑Sᵢ) = ∑Sᵢ, i.e. any point of the convex hull of the Minkowski sum already lies in the sum. The proof drives the refined excess bound to min(d, 0) = 0, so the convexification filter is empty, meaning every f i ∈ Sᵢ; assembling these gives membership in ∑Sᵢ.\n\nThis is a satisfying sanity check: the refinement's endpoint is exactly the well-known fact that a Minkowski sum of convex sets is convex — obtained here for free from the counting bound.",
+    "mathContext": "$k = 0 \\Rightarrow \\text{excess} \\le \\min(d, 0) = 0 \\Rightarrow \\mathrm{conv}(\\sum_i S_i) \\subseteq \\sum_i S_i$; the reverse inclusion is automatic, so equality holds.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Minkowski sum of convex sets",
+      "convex hull",
+      "zero excess"
+    ],
+    "prerequisites": [
+      "convexity of Minkowski sums"
+    ]
+  },
+  {
+    "id": "ann-oq04-starr",
+    "proofId": "shapley-folkman-oq-04",
+    "range": {
+      "startLine": 181,
+      "endLine": 254
+    },
+    "type": "main-theorem",
+    "title": "Refined Starr Bound: dist ≤ min(d, #nonConvex)·δ",
+    "content": "In a finite-dimensional normed space F, `shapley_folkman_starr_refined` sharpens OQ03's Starr theorem. Given x ∈ conv(∑Sᵢ) with each Sᵢ of diameter ≤ δ, it produces x' ∈ ∑Sᵢ with\n\n    dist(x, x') ≤ min(dim F, #nonConvex)·δ.\n\nThe proof reuses OQ03's point-selection argument: take the refined decomposition from `sum_close_refined` (excess filter J with |J| ≤ min(d, k)), replace each excess summand by a genuine point of its set, and estimate ‖x - x'‖ = ‖∑_{j∈J}(fⱼ - gⱼ)‖ ≤ |J|·δ ≤ min(d,k)·δ via the triangle inequality and the local `convexHull_dist_le_diam` lemma.\n\nEconomic reading: a market with n agents but only k non-convex ones is within min(d, k)·δ of exactly convex — a strictly better guarantee than d·δ whenever k < d, and uniform in n.",
+    "mathContext": "$\\|x - x'\\| = \\|\\sum_{j \\in J}(f_j - g_j)\\| \\le \\sum_{j \\in J}\\delta = |J|\\cdot\\delta \\le \\min(\\dim F, k)\\cdot\\delta$, since only excess indices contribute and $|J| \\le \\min(\\dim F, k)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Shapley-Folkman-Starr theorem",
+      "approximate convexity",
+      "triangle inequality",
+      "convexHull_dist_le_diam"
+    ],
+    "prerequisites": [
+      "Starr distance bound (OQ03)",
+      "norm_sum_le",
+      "convex hull diameter bound"
+    ]
+  }
+]

--- a/src/data/proofs/shapley-folkman-oq-04/meta.json
+++ b/src/data/proofs/shapley-folkman-oq-04/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "shapley-folkman-oq-04",
+  "title": "Shapley-Folkman Refined: Excess Bounded by the Number of Non-Convex Summands",
+  "slug": "shapley-folkman-oq-04",
+  "description": "Sharpens the Shapley-Folkman lemma: the number of summands requiring convexification is bounded not just by the dimension d, but by min(d, k) where k is the number of genuinely non-convex summands. The excess set is always contained in the non-convex index set — a fact requiring no finite-dimensionality. As the k = 0 special case, the Minkowski sum of convex sets is recovered as exactly convex, and Starr's metric bound sharpens from d·δ to min(d,k)·δ.",
+  "meta": {
+    "author": "researcher-7",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShapleyFolkmanOQ04.lean",
+    "tags": [
+      "convex-analysis",
+      "combinatorics",
+      "minkowski-sum",
+      "shapley-folkman",
+      "economics",
+      "caratheodory"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "dateUpdated": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "excessIndices_subset_nonConvex: for ANY decomposition, the excess indices are contained in the non-convex indices — proved in an arbitrary real vector space, no finite-dimensionality used",
+      "excessFilter_subset_nonConvex: filter-level form working directly on a summand family f with f i ∈ conv(S i), avoiding the Decomposition wrapper",
+      "excess_card_le_nonConvex: dimension-free counting corollary — excess count ≤ number of non-convex summands",
+      "shapley_folkman_refined: the headline min(dim E, #nonConvex) bound on excess, sharpening the base shapley_folkman dimension bound",
+      "sum_close_refined: the sum_close_to_convexHull corollary with the min bound on the convexification filter",
+      "convex_summands_hull_eq: recovers the classical fact 'Minkowski sum of convex sets is convex' (conv(∑Sᵢ) = ∑Sᵢ) as the k = 0 special case",
+      "shapley_folkman_starr_refined: Starr's distance bound sharpened to dist ≤ min(dim F, #nonConvex)·δ"
+    ],
+    "historicalContext": "The Shapley-Folkman lemma (Shapley & Folkman 1967, via Starr 1969) bounds the number of non-convexified summands in a Minkowski-sum decomposition by the ambient dimension d. This bound is purely dimensional and does not exploit any prior convexity of the individual summands. The refinement formalized here — that the excess is bounded by min(d, k) where k counts the non-convex summands — is folklore in the convex-analysis and mathematical-economics literature (it is implicit in Starr's own remark that convex agents contribute no error), but is rarely stated as a clean counting theorem. Its economic reading is sharp: in a market with n agents of which only k have non-convex feasible sets, the aggregate is within min(d, k) — not d — of exact convexity, uniformly in n.",
+    "problemStatement": "Refine the Shapley-Folkman lemma so that the excess (number of summands needing convexification) is bounded by min(dim E, #{i : Sᵢ not convex}) rather than dim E alone. Establish the dimension-free counting bound, recover 'Minkowski sum of convex sets is convex' as the zero-excess case, and sharpen Starr's metric bound accordingly.",
+    "proofStrategy": "A convex summand Sᵢ satisfies conv(Sᵢ) = Sᵢ, so every point of conv(Sᵢ) already lies in Sᵢ and index i can never be an excess index. Hence the excess set is always a subset of the non-convex index set (excessIndices_subset_nonConvex / excessFilter_subset_nonConvex) — this uses only the real-vector-space structure. Card-monotonicity gives excess ≤ #nonConvex with no dimension hypothesis; intersecting with the base shapley_folkman dimension bound via le_min yields min(d, #nonConvex). The all-convex case sends #nonConvex to 0, forcing zero excess and hence conv(∑Sᵢ) = ∑Sᵢ. The refined Starr bound re-runs the point-selection argument of ShapleyFolkmanOQ03 with the sharpened excess-cardinality bound.",
+    "assumptions": "0 axioms. 0 sorries. Fully machine-checked against Mathlib v4.26.0. The parent ShapleyFolkman.lean is fully proved (0 sorries), so the entire chain is verified end-to-end. Only the foundational axioms propext, Classical.choice, Quot.sound are used (confirmed via #print axioms); no sorryAx and no native_decide.",
+    "axiomCount": 0,
+    "lineCount": 254,
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Shapley-Folkman lemma states that any point of the convex hull of a Minkowski sum $\\sum_{i} S_i$ of sets in $\\mathbb{R}^d$ can be written as $\\sum_i x_i$ with $x_i \\in \\mathrm{conv}(S_i)$, where at most $d$ of the $x_i$ fail to lie in the original set $S_i$. This dimensional bound — independent of the number of summands $N$ — underlies Starr's (1969) theorem that large economies are approximately convex. However, the bound $d$ ignores a basic structural fact: a summand that is *already convex* can never require convexification, because $\\mathrm{conv}(S_i) = S_i$ forces its chosen point into $S_i$. Thus the genuine obstruction is the number $k$ of *non-convex* summands, and the sharp bound is $\\min(d, k)$. This entry formalizes that refinement as an explicit counting theorem, together with its two natural endpoints: the classical statement that a Minkowski sum of convex sets is convex ($k = 0$), and a sharpened form of Starr's metric estimate.",
+    "problemStatement": "Prove that in the Shapley-Folkman decomposition the number of summands requiring convexification is at most $\\min(d, k)$, where $d = \\dim E$ and $k$ is the number of non-convex summands; recover the convex-Minkowski-sum identity as the $k = 0$ case; and sharpen Starr's distance bound to $\\min(d,k)\\cdot\\delta$.",
+    "proofStrategy": "The core is a single pointwise observation: if $S_i$ is convex then $\\mathrm{conv}(S_i) = S_i$ (Mathlib's Convex.convexHull_eq), so any decomposition point $x_i \\in \\mathrm{conv}(S_i)$ lies in $S_i$ and $i$ is not an excess index. Contrapositively, every excess index is non-convex, so the excess *set* is contained in the non-convex *set*. This containment needs no dimension hypothesis, giving the dimension-free bound $\\text{excess} \\le k$; combined with the base lemma's $\\text{excess} \\le d$ it yields $\\min(d,k)$. Setting $k = 0$ empties the excess filter, so the decomposition already lies in $\\sum_i S_i$, i.e. $\\mathrm{conv}(\\sum_i S_i) = \\sum_i S_i$. The metric refinement reuses the OQ03 selection argument with the sharpened cardinality bound.",
+    "keyInsights": [
+      "Convex summands are free: $\\mathrm{conv}(S_i) = S_i$ means a convex summand can never be an excess index. The excess set is therefore always a subset of the non-convex index set.",
+      "The containment is dimension-free: excessIndices_subset_nonConvex and its filter form hold in an arbitrary real vector space, with no FiniteDimensional hypothesis. Only the final min uses the dimension bound.",
+      "min(d, k) is the honest bound: when few summands are non-convex (k < d), the number of non-convex agents — not the ambient dimension — controls the aggregate non-convexity.",
+      "Convex Minkowski sums recovered: the k = 0 case gives conv(∑Sᵢ) = ∑Sᵢ, the classical statement that a Minkowski sum of convex sets is convex, obtained here purely as zero excess.",
+      "Metric sharpening: Starr's dist ≤ d·δ becomes dist ≤ min(d,k)·δ, so a market with only k non-convex agents is within min(d,k)·δ of exactly convex, uniformly in the number of agents.",
+      "Reuse over rebuild: the refinement is a thin, high-leverage layer over the parent Decomposition machinery and the OQ03 point-selection argument — one structural lemma does the work."
+    ],
+    "prerequisites": [
+      "Shapley-Folkman lemma (shapley_folkman, sum_close_to_convexHull from ShapleyFolkman.lean)",
+      "Convex.convexHull_eq (a convex set equals its convex hull)",
+      "Finset.card_le_card (cardinality monotone under subset)",
+      "Minkowski sums and convex hulls in real vector spaces"
+    ],
+    "text": "A structural sharpening of the Shapley-Folkman lemma: the convexification excess is bounded by min(dimension, number of non-convex summands), recovering convexity of Minkowski sums of convex sets and a sharper Starr distance bound."
+  },
+  "conclusion": {
+    "summary": "Refines the Shapley-Folkman excess bound from d to min(d, k), where k counts non-convex summands, by showing the excess index set is always contained in the non-convex index set (a dimension-free fact). Recovers 'Minkowski sum of convex sets is convex' as the k = 0 case and sharpens Starr's metric bound to min(d,k)·δ. 0 sorries, 0 axioms, verified end-to-end against a fully-proved parent.",
+    "implications": "Gives the honest structural bound on aggregate non-convexity: only genuinely non-convex summands can contribute error, so markets whose non-convex agents are few are far closer to convex than the dimensional bound suggests. When all agents are convex the aggregate is exactly convex.",
+    "openQuestions": [
+      "Is min(d, k) sharp? Construct a family with exactly k non-convex summands (k ≤ d) whose Minkowski-sum convex hull achieves excess exactly k, proving no smaller uniform bound holds.",
+      "Can the refinement be combined with the √d Starr–Cauchy-Schwarz bound to give min(√d, √k)·(per-set radius) style estimates?",
+      "Does a weighted version hold, where each non-convex summand carries a 'non-convexity defect' and the excess is bounded by a defect-weighted count rather than a raw count?"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Overview and Non-Convex Index Set",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Module docstring stating the min(d, #nonConvex) refinement and its six main results. Imports Mathlib and Proofs.ShapleyFolkman, installs Classical.propDecidable as a local instance (matching the base file) so Finset.filter can range over Convex/membership predicates, and defines nonConvexIndices S t = t.filter (fun i => ¬ Convex ℝ (S i)).",
+      "mathContext": "Works over an arbitrary real vector space $E$ ($\\mathrm{AddCommGroup}$ + $\\mathrm{Module}\\,\\mathbb{R}$). The non-convex index set $\\{i \\in t : S_i \\text{ not convex}\\}$ is the object governing the refined bound."
+    },
+    {
+      "id": "subset-lemma",
+      "title": "Excess Indices Are Non-Convex Indices",
+      "startLine": 63,
+      "endLine": 104,
+      "summary": "mem_of_convex (conv(S) = S for convex S, via Convex.convexHull_eq), then the core structural lemma excessIndices_subset_nonConvex: for any Decomposition, D.excessIndices ⊆ nonConvexIndices. excessFilter_subset_nonConvex gives the same at the level of a raw summand family f. Both are dimension-free.",
+      "mathContext": "If $i$ is an excess index then $x_i \\notin S_i$ while $x_i \\in \\mathrm{conv}(S_i)$; were $S_i$ convex, $\\mathrm{conv}(S_i) = S_i$ would force $x_i \\in S_i$. Hence $i$ is non-convex."
+    },
+    {
+      "id": "refined-bound",
+      "title": "The min(d, #nonConvex) Bound",
+      "startLine": 105,
+      "endLine": 143,
+      "summary": "excess_card_le_nonConvex (excess ≤ #nonConvex via Finset.card_le_card, no dimension needed), then shapley_folkman_refined combining the base dimension bound with the non-convex bound through le_min. sum_close_refined lifts this to the sum_close_to_convexHull corollary, bounding the convexification filter by min(d, #nonConvex).",
+      "mathContext": "$\\text{excess} \\le d$ (base) and $\\text{excess} \\le k$ (subset) give $\\text{excess} \\le \\min(d,k)$."
+    },
+    {
+      "id": "convex-case",
+      "title": "All-Convex Case: Minkowski Sum of Convex Sets is Convex",
+      "startLine": 144,
+      "endLine": 180,
+      "summary": "nonConvexIndices_eq_empty (all summands convex ⟹ no non-convex indices), then convex_summands_hull_eq: if every Sᵢ is convex then conv(∑Sᵢ) = ∑Sᵢ. Proved by driving the refined excess bound to 0 and reading off that every summand already lies in its set.",
+      "mathContext": "$k = 0 \\Rightarrow \\text{excess} \\le \\min(d,0) = 0 \\Rightarrow$ decomposition lies in $\\sum_i S_i$, i.e. $\\mathrm{conv}(\\sum_i S_i) = \\sum_i S_i$."
+    },
+    {
+      "id": "starr-refined",
+      "title": "Refined Shapley-Folkman-Starr Distance Bound",
+      "startLine": 181,
+      "endLine": 254,
+      "summary": "In a normed space F: convexHull_dist_le_diam (local copy of the OQ03 distance lemma) and shapley_folkman_starr_refined, which produces x' ∈ ∑Sᵢ with dist(x, x') ≤ min(dim F, #nonConvex)·δ by re-running the OQ03 point-selection argument with the sharpened excess-cardinality bound from sum_close_refined.",
+      "mathContext": "$\\|x - x'\\| = \\|\\sum_{j \\in J}(f_j - g_j)\\| \\le |J|\\cdot\\delta \\le \\min(\\dim F, k)\\cdot\\delta$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "shapley-folkman",
+      "relationship": "depends-on",
+      "description": "Builds directly on the parent lemma shapley_folkman and its corollary sum_close_to_convexHull, together with the Decomposition structure and excessIndices definition. The refinement adds the observation that excess indices are always non-convex indices."
+    },
+    {
+      "targetId": "shapley-folkman-oq-03",
+      "relationship": "extends",
+      "description": "Sharpens OQ03's Starr distance bound d·δ to min(d, k)·δ and generalizes OQ03's pointwise no_excess_for_convex into the counting statement that the entire excess set lies among the non-convex summands. Reuses OQ03's point-selection argument for the metric refinement."
+    },
+    {
+      "targetId": "caratheodory-theorem",
+      "relationship": "related",
+      "description": "The Shapley-Folkman lemma is a Minkowski-sum strengthening of Carathéodory's theorem; this refinement observes that only non-convex summands contribute to the Carathéodory-style vertex excess, so convex summands are 'transparent' to the bound."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Starr, Ross M.",
+      "title": "Quasi-Equilibria in Markets with Non-Convex Preferences",
+      "year": "1969",
+      "venue": "Econometrica, vol. 37, no. 1, pp. 25–38",
+      "note": "Introduces the Shapley-Folkman lemma (as an appendix) and the metric bound d·δ. Remarks that convex agents contribute no approximation error — the pointwise seed of the min(d,k) refinement formalized here."
+    },
+    {
+      "authors": "Shapley, Lloyd S.; Folkman, John",
+      "title": "Correspondence with Ross Starr",
+      "year": "1967",
+      "venue": "Unpublished; reproduced as appendix in Starr (1969)",
+      "note": "Original proof of the Shapley-Folkman lemma bounding the number of non-convexified summands by the ambient dimension."
+    },
+    {
+      "authors": "Schneider, Rolf",
+      "title": "Convex Bodies: The Brunn–Minkowski Theory",
+      "year": "2014",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "Standard reference for Minkowski sums and convex hulls; the identity conv(A + B) = conv(A) + conv(B) and convexity of Minkowski sums of convex sets (the k = 0 case) are treated here."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ShapleyFolkman"
+    ],
+    "namespace": "ShapleyFolkmanOQ04",
+    "lineCount": 254,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ShapleyFolkmanOQ04.lean",
+    "definitionCount": 1,
+    "theoremCount": 10
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Refines the **Shapley-Folkman lemma**: the number of summands requiring convexification is bounded by **min(d, k)**, where `d = dim E` and `k` is the number of genuinely **non-convex** summands — strictly sharpening the base dimension-only bound `excess ≤ d`.

### Core idea (dimension-free)
A convex summand satisfies `conv(Sᵢ) = Sᵢ` (Mathlib's `Convex.convexHull_eq`), so its chosen decomposition point always lies in `Sᵢ` and index `i` can never be an excess index. Hence the excess index set is **always contained in the non-convex index set** — a fact requiring *no* finite-dimensionality. Intersecting with the base dimension bound via `le_min` yields `min(d, k)`.

### Main results (`Proofs/ShapleyFolkmanOQ04.lean`, namespace `ShapleyFolkmanOQ04`)
- `excessIndices_subset_nonConvex` / `excessFilter_subset_nonConvex` — the core containment (any real vector space).
- `excess_card_le_nonConvex` — dimension-free counting bound: `excess ≤ k`.
- `shapley_folkman_refined` — **headline**: `excess ≤ min(dim E, k)`.
- `sum_close_refined` — the `sum_close_to_convexHull` corollary, sharpened.
- `convex_summands_hull_eq` — recovers the classical **"Minkowski sum of convex sets is convex"** (`conv(∑Sᵢ) = ∑Sᵢ`) as the `k = 0` case.
- `shapley_folkman_starr_refined` — Starr's metric bound sharpened from `d·δ` to `min(d, k)·δ`.

### Economic reading
A market with `n` agents of which only `k` are non-convex is within `min(d, k)·δ` — not `d·δ` — of exact convexity, uniformly in `n`. When all agents are convex the aggregate is *exactly* convex.

## Verification
- **0 sorries, 0 axioms.** `#print axioms` on all main results shows only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`).
- Builds against **Mathlib v4.26.0** on the fully-proved parent `ShapleyFolkman.lean`.
- 10 theorems/lemmas, 1 definition, 254 lines.
- Gallery entry added (`src/data/proofs/shapley-folkman-oq-04/` meta + annotations).

Builds on #shapley-folkman and extends `shapley-folkman-oq-03`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)