### PR TITLE
Enrich Feuerbach AH=2·OM_a (oq-01×5): +law-of-cosines cross-reference

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -140,6 +140,11 @@
       "targetId": "feuerbachs-theorem-defs",
       "relationship": "extends",
       "description": "adds the vertex–orthocenter / circumcenter–midpoint segment relation AH = 2·OM_a, a quantity the nine-point-circle and Euler-line development in FeuerbachsTheoremDefs.lean never measures"
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related",
+      "description": "the apothem step OM_a² = R² − (a/2)² is a Pythagorean instance of the law of cosines a² = b² + c² − 2bc·cos A: combined with the extended law of sines a = 2R·sin A it gives OM_a = R·cos A, so the true-distance form AH = 2·OM_a is exactly AH = 2R·cos A"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01` (passes: 0).

This entry was already comprehensively enriched (11 full annotations with mathContext/significance/relatedConcepts/prerequisites, rich overview + conclusion, 6 sections, mainTheorems). Per the diminishing-returns / SKIP rule it needed no inflation — the annotations already cover the full Lean file (the only line gaps are imports/namespace boilerplate). The one genuine gap: all 4 cross-references stayed inside the Feuerbach family, while the file's own docstring states `OM_a = R·cos A` and `AH = 2R·cos A`, a direct link to the broader gallery.

**Change**: added a single `related` cross-reference to `law-of-cosines`, explaining that the apothem identity OM_a² = R² − (a/2)² is a Pythagorean instance of the law of cosines and, with the extended law of sines, yields AH = 2R·cos A.

- meta.json: 21.2 KB → 21.5 KB (well under 60 KB cap); crossReferences 4 → 5 (cap 20)
- JSON validated; check-meta-size passes; targetId `law-of-cosines` confirmed to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)