### PR TITLE
research(myhill-oq-03): matching-as-computed-partial-function layer [0-axiom, partial]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -557,6 +557,16 @@ theorem matchingCorr_mLookup {p q : ℕ → Prop} {L : List (ℕ × ℕ)}
     (hC : MatchingCorr p q L) {a b : ℕ} (h : mLookup L a = some b) : p a ↔ q b :=
   hC (a, b) (mem_of_mLookup_eq_some h)
 
+/-- **Stability of the partner under matching extension.** If a matching `L'`
+extends `L` (as lists, `L ⊆ L'`) and `L` already records `(a, b)`, then the lookup
+in the larger matching still returns `b`. This is the crux that makes the
+back-and-forth *limit* well-defined: once the stage-`s` matching commits `σ(a) = b`,
+every later stage agrees, so `σ` on the union `⋃ₛ Lₛ` is a genuine function. It is
+an immediate consequence of `mLookup_eq_some_of_mem` applied to `L'`. -/
+theorem mLookup_stable {L L' : List (ℕ × ℕ)} (hL' : IsMatching L')
+    (hsub : L ⊆ L') {a b : ℕ} (h : (a, b) ∈ L) : mLookup L' a = some b :=
+  mLookup_eq_some_of_mem hL' (hsub h)
+
 /-!
 ## Section 5: The Myhill Isomorphism Theorem
 -/

--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -472,6 +472,92 @@ theorem matching_length_cons (a b : ℕ) (L : List (ℕ × ℕ)) :
     ((a, b) :: L).length = L.length + 1 := by simp
 
 /-!
+### Section 4d: The matching as a *computed* partial function (`List.lookup`)
+
+`matching_functional` / `matching_cofunctional` establish that a matching is a
+partial bijection *set-theoretically* (each coordinate determines its partner).
+For the scheduler's final step — reading off the total permutation `σ` from the
+limiting matching, and certifying its computability — we need the *functional*
+counterpart: an actual computed partner map with a full specification. We use the
+computable `List.lookup`, which returns the partner of a domain element and `none`
+off the domain, and prove it agrees with membership, with the uniqueness lemmas,
+and (crucially) with the `p ↔ q` correspondence. -/
+
+/-- The partial partner map of a matching: the computable `List.lookup`. -/
+def mLookup (L : List (ℕ × ℕ)) (a : ℕ) : Option ℕ := L.lookup a
+
+theorem mLookup_nil (a : ℕ) : mLookup [] a = none := rfl
+
+/-- If a matching records `(a, b)`, then looking up `a` returns exactly `b`.
+This is the functional (computed) form of `matching_functional`: not only is the
+partner unique, it is the value the computable lookup produces. -/
+theorem mLookup_eq_some_of_mem :
+    ∀ {L : List (ℕ × ℕ)}, IsMatching L → ∀ {a b : ℕ}, (a, b) ∈ L →
+      mLookup L a = some b := by
+  intro L
+  induction L with
+  | nil => intro _ a b h; simp at h
+  | cons hd tl ih =>
+    obtain ⟨k, v⟩ := hd
+    intro hL a b h
+    have hknd : k ∉ mDom tl := by
+      have hnd := hL.1; rw [mDom_cons] at hnd; exact (List.nodup_cons.mp hnd).1
+    have hLtl : IsMatching tl := by
+      refine ⟨?_, ?_⟩
+      · have hnd := hL.1; rw [mDom_cons] at hnd; exact hnd.of_cons
+      · have hnd := hL.2; rw [mRan_cons] at hnd; exact hnd.of_cons
+    unfold mLookup at *
+    rw [List.lookup_cons]
+    rcases List.mem_cons.mp h with heq | hmem
+    · rw [Prod.mk.injEq] at heq; obtain ⟨rfl, rfl⟩ := heq; simp
+    · have ha_dom : a ∈ mDom tl := by
+        simp only [mDom, List.mem_map]; exact ⟨(a, b), hmem, rfl⟩
+      have hne : a ≠ k := by rintro rfl; exact hknd ha_dom
+      have hbeq : (a == k) = false := by simpa using hne
+      rw [hbeq]; simpa using ih hLtl hmem
+
+/-- The lookup is defined exactly on the domain: `mLookup L a` succeeds iff
+`a ∈ mDom L`. Together with `mLookup_eq_some_of_mem` this says the matching *is*
+its lookup — a computable partial map whose support is precisely `mDom L`. -/
+theorem mLookup_isSome_iff (L : List (ℕ × ℕ)) (a : ℕ) :
+    (mLookup L a).isSome ↔ a ∈ mDom L := by
+  unfold mLookup mDom
+  induction L with
+  | nil => simp
+  | cons hd tl ih =>
+    obtain ⟨k, v⟩ := hd
+    rw [List.lookup_cons]
+    rcases eq_or_ne a k with rfl | hne
+    · simp
+    · have hbeq : (a == k) = false := by simpa using hne
+      rw [hbeq, List.map_cons, List.mem_cons]
+      simp only [hne, false_or]; exact ih
+
+/-- A successful lookup corresponds to a recorded pair — the converse of
+`mLookup_eq_some_of_mem`, valid for *any* list (no matching hypothesis needed). -/
+theorem mem_of_mLookup_eq_some {L : List (ℕ × ℕ)} {a b : ℕ}
+    (h : mLookup L a = some b) : (a, b) ∈ L := by
+  unfold mLookup at h
+  induction L with
+  | nil => simp at h
+  | cons hd tl ih =>
+    obtain ⟨k, v⟩ := hd
+    rw [List.lookup_cons] at h
+    rcases eq_or_ne a k with rfl | hne
+    · simp only [beq_self_eq_true] at h
+      rw [Option.some.injEq] at h; subst h; exact List.mem_cons_self ..
+    · have hbeq : (a == k) = false := by simpa using hne
+      rw [hbeq] at h; exact List.mem_cons_of_mem _ (ih h)
+
+/-- The computed lookup respects the `p ↔ q` correspondence: if `mLookup L a = some b`
+in a correspondence-respecting matching, then `p a ↔ q b`. This is what lets the
+scheduler read off a correspondence-preserving `σ` *without* ever evaluating the
+(possibly non-computable) predicates `p, q`. -/
+theorem matchingCorr_mLookup {p q : ℕ → Prop} {L : List (ℕ × ℕ)}
+    (hC : MatchingCorr p q L) {a b : ℕ} (h : mLookup L a = some b) : p a ↔ q b :=
+  hC (a, b) (mem_of_mLookup_eq_some h)
+
+/-!
 ## Section 5: The Myhill Isomorphism Theorem
 -/
 

--- a/research/problems/schroeder-bernstein-oq-03/sessions/2026-07-01-matching-lookup-functional-layer.md
+++ b/research/problems/schroeder-bernstein-oq-03/sessions/2026-07-01-matching-lookup-functional-layer.md
@@ -1,0 +1,41 @@
+# researcher-2 — Myhill OQ-03: the matching as a computed partial function (2026-07-01)
+
+## Context
+Myhill's isomorphism theorem (computable injections ⟹ computable bijection). The
+easy direction and a large infrastructure layer are proved; the single remaining
+`sorry` is the hard direction (`myhill_isomorphism` →) — the stage-wise
+back-and-forth scheduler with collision-chasing (~200 lines of Partrec work).
+
+researcher-6 built the fully-computable easy case + Π₁ obstruction analysis.
+researcher-1 (PR #32280) built the finite-matching layer: `IsMatching`,
+`MatchingCorr`, atomic steps `matching_step_f`/`matching_step_g`, and the
+set-theoretic partial-bijection lemmas `matching_functional`/`matching_cofunctional`.
+
+## This session — the functional/computed layer (Section 4d)
+The scheduler's final step reads off the total permutation `σ` from the *limiting*
+matching and must certify `σ` computable. That needs the matching presented as an
+actual **computed function**, not merely a set-theoretic partial bijection. Added:
+
+- **`mLookup L a := L.lookup a`** — the computable partner map.
+- **`mLookup_eq_some_of_mem`** — on a matching, `(a,b) ∈ L ⟹ mLookup L a = some b`
+  (the functional/computed form of `matching_functional`). Proof: induction using
+  domain-side `Nodup` — off the head `a ≠ k` so `List.lookup` skips it.
+- **`mLookup_isSome_iff`** — `(mLookup L a).isSome ↔ a ∈ mDom L`: the lookup is
+  defined *exactly* on the domain.
+- **`mem_of_mLookup_eq_some`** — converse (no matching hypothesis needed).
+- **`matchingCorr_mLookup`** — the computed lookup respects `p ↔ q`, so `σ` is read
+  off **without** ever evaluating the possibly-non-computable predicates `p, q`.
+
+All four are 0-axiom (`#print axioms` = only `propext, Classical.choice, Quot.sound`;
+no `sorryAx`). File: 674 LOC, 41 theorems/lemmas, 11 defs, **1 sorry** (the open
+hard core, unchanged). Compiles clean against pinned Mathlib v4.26.0.
+
+## Honest status
+This is partial progress on an OPEN problem. The single hard `sorry` (the scheduler)
+is untouched; this PR completes a verified sub-API it will consume. No new axioms,
+no `True` placeholders.
+
+## Next
+- Define the stage builder (recursion over stages) using the atomic `matching_step_f/_g`.
+- Prove exhaustion invariants (k enters by stage 2k+1) and read off `σ` via `mLookup`
+  on the limiting matching; derive computability from the stage function + `mLookup`.

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 674,
+    "lineCount": 684,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",
@@ -51,12 +51,13 @@
       "mLookup + mLookup_eq_some_of_mem: PROVED — the computed (List.lookup-based) partner map of a matching returns the recorded partner (functional form of matching_functional)",
       "mLookup_isSome_iff: PROVED — the lookup is defined exactly on the domain mDom L",
       "mem_of_mLookup_eq_some: PROVED — a successful lookup recovers a recorded pair (converse, no matching hypothesis)",
-      "matchingCorr_mLookup: PROVED — the computed lookup respects the p↔q correspondence, so σ can be read off the limiting matching without evaluating p, q"
+      "matchingCorr_mLookup: PROVED — the computed lookup respects the p↔q correspondence, so σ can be read off the limiting matching without evaluating p, q",
+      "mLookup_stable: PROVED — the partner is stable under matching extension (L ⊆ L' ⟹ same lookup), the well-definedness crux for reading σ off the back-and-forth limit"
     ],
     "openProblems": [
       "Hard direction of Myhill's theorem: construct computable bijection from computable injections via back-and-forth priority argument (~200 lines of Partrec-based formalization)"
     ],
-    "theoremCount": 41,
+    "theoremCount": 42,
     "definitionCount": 11,
     "additionalFiles": [
       "Proofs/SchroederBernsteinOQ03Aristotle.lean"
@@ -137,7 +138,7 @@
       "id": "matching-lookup",
       "title": "Section 4d: The matching as a computed partial function",
       "startLine": 474,
-      "endLine": 561,
+      "endLine": 572,
       "summary": "Adds mLookup (the computable List.lookup partner map) with its full spec: mLookup_eq_some_of_mem (returns the recorded partner), mLookup_isSome_iff (defined exactly on mDom L), mem_of_mLookup_eq_some (converse), and matchingCorr_mLookup (respects the p↔q correspondence).",
       "mathContext": "For the scheduler to read off the total permutation σ from the limiting matching and certify its computability, the matching must be presented as an actual computed function, not merely a set-theoretic partial bijection. List.lookup supplies this: it returns the partner on the domain and none off it, agrees with the uniqueness lemmas, and preserves the correspondence, so σ is obtained without ever evaluating the possibly non-computable predicates p, q."
     }
@@ -255,9 +256,9 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 674,
+    "lineCount": 684,
     "axiomCount": 0,
-    "theoremCount": 41,
+    "theoremCount": 42,
     "definitionCount": 11,
     "sorries": 1,
     "path": "Proofs/SchroederBernsteinOQ03.lean",

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 269,
+    "lineCount": 674,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",
@@ -47,13 +47,17 @@
       "Clean proof of the easy direction: computable bijection implies one-one equivalence",
       "Fully proved partial-inverse infrastructure via Nat.rfind: partialInverse_partrec (Partrec), partialInverse_spec (recovers input under injection), partialInverse_dom (defined on range)",
       "Proof that computable isomorphism is an equivalence relation (reflexive, symmetric, transitive)",
-      "Forward orbit definition: (g∘f)^k(n) for the back-and-forth construction"
+      "Forward orbit definition: (g∘f)^k(n) for the back-and-forth construction",
+      "mLookup + mLookup_eq_some_of_mem: PROVED — the computed (List.lookup-based) partner map of a matching returns the recorded partner (functional form of matching_functional)",
+      "mLookup_isSome_iff: PROVED — the lookup is defined exactly on the domain mDom L",
+      "mem_of_mLookup_eq_some: PROVED — a successful lookup recovers a recorded pair (converse, no matching hypothesis)",
+      "matchingCorr_mLookup: PROVED — the computed lookup respects the p↔q correspondence, so σ can be read off the limiting matching without evaluating p, q"
     ],
     "openProblems": [
       "Hard direction of Myhill's theorem: construct computable bijection from computable injections via back-and-forth priority argument (~200 lines of Partrec-based formalization)"
     ],
-    "theoremCount": 14,
-    "definitionCount": 4,
+    "theoremCount": 41,
+    "definitionCount": 11,
     "additionalFiles": [
       "Proofs/SchroederBernsteinOQ03Aristotle.lean"
     ]
@@ -68,7 +72,8 @@
       "The partial inverse $g^{-1}(m) = \\mu n[g(n) = m]$ (computable via `Nat.rfind`) is the key technical tool: it lets the back-and-forth construction 'step backward' along $g$, and its partial recursiveness (not total computability) is precisely why the construction requires `Partrec` rather than `Computable`",
       "The back-and-forth orbit classification (Type A/B/C) is a finite-priority precursor to the Friedberg-Muchnik priority method (1956). Understanding Myhill's construction is the natural stepping-stone to formalizing infinite-injury priority arguments",
       "Lean 4's `Equiv.Computable` captures exactly the right notion: a computable permutation requires both $e$ and $e^{-1}$ to be computable — this is non-trivial since a computable bijection can have a non-computable inverse in general (though not for permutations of $\\mathbb{N}$ with decidable range)",
-      "The corollaries (reflexivity via identity, symmetry via inverse, transitivity via composition) show that computable isomorphism is a genuine equivalence relation on predicates — paving the way for quotient structures over the one-one degrees"
+      "The corollaries (reflexivity via identity, symmetry via inverse, transitivity via composition) show that computable isomorphism is a genuine equivalence relation on predicates — paving the way for quotient structures over the one-one degrees",
+      "**Matching as a computable partial function:** The uniqueness lemmas (matching_functional/cofunctional) show a matching is a partial bijection set-theoretically; the new mLookup API gives the *functional* counterpart — a computable List.lookup returning the partner, defined exactly on mDom L, respecting the correspondence. This is the concrete object the scheduler reads off the limiting matching to build σ, and certifies σ's computability reduces to computability of lookup."
     ]
   },
   "sections": [
@@ -127,6 +132,14 @@
       "endLine": 269,
       "summary": "Proves that ∅ and ℕ (the empty and universal predicates) are fixed points of computable isomorphism: any computable permutation maps ∅ to ∅ and ℕ to ℕ. These are the extreme cases in the one-one degree hierarchy.",
       "mathContext": "For the empty predicate $p = \\bot$: if $e$ maps $\\bot$ to $q$ (meaning $\\bot(n) \\leftrightarrow q(e(n))$), then $q(m) = \\bot$ for all $m$ (surjectivity of $e$). Dually for $p = \\top$. These facts follow from surjectivity of $e$ as a bijection."
+    },
+    {
+      "id": "matching-lookup",
+      "title": "Section 4d: The matching as a computed partial function",
+      "startLine": 474,
+      "endLine": 561,
+      "summary": "Adds mLookup (the computable List.lookup partner map) with its full spec: mLookup_eq_some_of_mem (returns the recorded partner), mLookup_isSome_iff (defined exactly on mDom L), mem_of_mLookup_eq_some (converse), and matchingCorr_mLookup (respects the p↔q correspondence).",
+      "mathContext": "For the scheduler to read off the total permutation σ from the limiting matching and certify its computability, the matching must be presented as an actual computed function, not merely a set-theoretic partial bijection. List.lookup supplies this: it returns the partner on the domain and none off it, agrees with the uniqueness lemmas, and preserves the correspondence, so σ is obtained without ever evaluating the possibly non-computable predicates p, q."
     }
   ],
   "crossReferences": [
@@ -242,10 +255,10 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 444,
+    "lineCount": 674,
     "axiomCount": 0,
-    "theoremCount": 26,
-    "definitionCount": 6,
+    "theoremCount": 41,
+    "definitionCount": 11,
     "sorries": 1,
     "path": "Proofs/SchroederBernsteinOQ03.lean",
     "additionalFiles": [

--- a/src/data/research/problems/schroeder-bernstein-oq-03.json
+++ b/src/data/research/problems/schroeder-bernstein-oq-03.json
@@ -53,7 +53,8 @@
       "mLookup_eq_some_of_mem (PROVED) - lookup returns the recorded partner (functional matching_functional)",
       "mLookup_isSome_iff (PROVED) - lookup defined exactly on mDom L",
       "mem_of_mLookup_eq_some (PROVED) - successful lookup recovers a recorded pair (converse)",
-      "matchingCorr_mLookup (PROVED) - lookup respects the p↔q correspondence"
+      "matchingCorr_mLookup (PROVED) - lookup respects the p↔q correspondence",
+      "mLookup_stable (PROVED) - partner stable under matching extension (well-definedness of σ on the back-and-forth limit)"
     ],
     "insights": [
       "Mathlib has OneOneReducible/OneOneEquiv/ManyOneEquiv (Computability.Reduce) but NOT Myhill's isomorphism theorem — genuine gap.",
@@ -148,8 +149,8 @@
     {
       "path": "Proofs/SchroederBernsteinOQ03.lean",
       "filename": "SchroederBernsteinOQ03.lean",
-      "lineCount": 674,
-      "theoremCount": 41,
+      "lineCount": 684,
+      "theoremCount": 42,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/schroeder-bernstein-oq-03.json
+++ b/src/data/research/problems/schroeder-bernstein-oq-03.json
@@ -28,10 +28,10 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-04-21T16:44:09+02:00",
-    "iteration": 1,
-    "focus": "Hard direction open; obstruction (Π₁ isGFree) identified; back-and-forth builder is the path.",
+    "iteration": 2,
+    "focus": "Hard direction still open (stage-wise back-and-forth scheduler). researcher-2 added the functional/computed partial-map layer on top of r1's finite-matching layer: mLookup (List.lookup partner map) + full spec, the object the scheduler reads off the limiting matching to build σ.",
     "blockers": [],
-    "nextAction": "Formalize stage-wise partial-bijection builder + invariants.",
+    "nextAction": "Define the stage builder (recursion over stages) using the atomic matching_step_f/_g, then read off σ via mLookup on the limiting matching.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 0,
@@ -39,7 +39,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-6, VERIFIED 0-axiom via direct-lean-compile; Docker down host-wide): Landed the flagged TRACTABLE PARTIAL WIN — the fully computable easy case. Added to SchroederBernsteinOQ03.lean: (1) decidableIsGFree — the Π₁ obstruction isGFree g becomes DECIDABLE once Set.range g is decidable (via isGFree_iff_not_mem_range), making explicit that range-decidability is exactly what the general merely-computable case lacks; (2) totalInverse + totalInverse_{mem,right,left,computable} — a surjective computable injection's partialInverse is everywhere-defined, giving a total COMPUTABLE two-sided inverse (Part.some_get + Partrec.of_eq); (3) computable_bijection_isComputablePerm — a computable BIJECTION of ℕ is a computable permutation (Equiv.ofBijective g hg).Computable, both g and g⁻¹ computable; (4) oneOneEquiv_of_computable_bijection — Myhill's easy case discharged with no back-and-forth. All 6 new decls #print axioms = only foundational (no sorryAx). The HARD direction (myhill_isomorphism, arbitrary computable injections → computable permutation) remains OPEN: still needs the stage-wise bounded back-and-forth/priority construction; the isGFree Π₁ obstruction blocks the naive orbit classification.",
+    "progressSummary": "PROGRESS (researcher-2, VERIFIED 0-axiom via direct lean-compile): added the FUNCTIONAL/computed partial-map layer bridging r1's finite-matching layer to σ. New: mLookup (computable List.lookup partner map), mLookup_eq_some_of_mem (returns recorded partner — functional form of matching_functional), mLookup_isSome_iff (defined exactly on mDom L), mem_of_mLookup_eq_some (converse), matchingCorr_mLookup (respects p↔q so σ is read off WITHOUT evaluating p,q). All 4 lemmas #print axioms = only propext/Classical.choice/Quot.sound (no sorryAx). File now 674L/41thm/11def/1 sorry. HARD direction (myhill_isomorphism →) still OPEN: the stage-wise scheduler with collision-chasing remains the single sorry.",
     "builtItems": [
       "partialInverse_unique in Proofs/SchroederBernsteinOQ03.lean (single-valued partial inverse)",
       "fwdOrbit_eq_iterate in Proofs/SchroederBernsteinOQ03.lean (orbit = Function.iterate of g∘f)",
@@ -48,7 +48,12 @@
       "totalInverse + totalInverse_{mem,right,left} — total two-sided inverse of a surjective (injective) g from the everywhere-defined partialInverse (VERIFIED, 0-axiom)",
       "totalInverse_computable — Computable (totalInverse g hg) for computable surjective g, via Partrec.of_eq + Part.some_get (VERIFIED, 0-axiom)",
       "computable_bijection_isComputablePerm — a computable bijection of ℕ is a computable permutation (Equiv.ofBijective g hg).Computable (VERIFIED, 0-axiom)",
-      "oneOneEquiv_of_computable_bijection — fully computable easy-case Myhill: computable bijection g with p n↔q(g n) ⟹ OneOneEquiv p q (VERIFIED, 0-axiom)"
+      "oneOneEquiv_of_computable_bijection — fully computable easy-case Myhill: computable bijection g with p n↔q(g n) ⟹ OneOneEquiv p q (VERIFIED, 0-axiom)",
+      "mLookup (def) - computable List.lookup partner map of a matching",
+      "mLookup_eq_some_of_mem (PROVED) - lookup returns the recorded partner (functional matching_functional)",
+      "mLookup_isSome_iff (PROVED) - lookup defined exactly on mDom L",
+      "mem_of_mLookup_eq_some (PROVED) - successful lookup recovers a recorded pair (converse)",
+      "matchingCorr_mLookup (PROVED) - lookup respects the p↔q correspondence"
     ],
     "insights": [
       "Mathlib has OneOneReducible/OneOneEquiv/ManyOneEquiv (Computability.Reduce) but NOT Myhill's isomorphism theorem — genuine gap.",
@@ -56,12 +61,14 @@
       "Correct route: stage-wise finite back-and-forth (priority) where each stage does only a BOUNDED search and never decides range g (matches myhill_isomorphism docstring, not the Section-4 orbit sketch).",
       "p,q are arbitrary predicates (NOT computable); the construction must route membership through the computable reductions f,g structurally and never test p/q directly.",
       "partialInverse is single-valued under injective g (partialInverse_unique) — collision-freeness for extending the partial map by a g-edge.",
-      "fwdOrbit f g n k = (g∘f)^[k] n (fwdOrbit_eq_iterate): the forward orbit is unproblematically computable; difficulty is entirely backward."
+      "fwdOrbit f g n k = (g∘f)^[k] n (fwdOrbit_eq_iterate): the forward orbit is unproblematically computable; difficulty is entirely backward.",
+      "The scheduler's final step (reading σ off the limiting matching) needs the matching as a COMPUTED function, not just a set-theoretic partial bijection. List.lookup supplies this: mLookup_eq_some_of_mem via induction using domain-side Nodup (a≠k off-head so lookup skips), mLookup_isSome_iff for support=mDom, matchingCorr_mLookup so the correspondence transfers without touching p,q."
     ],
     "mathlibGaps": [
       "Mathlib lacks Myhill isomorphism theorem (OneOneEquiv → computable permutation)."
     ],
     "nextSteps": [
+      "DONE (researcher-2): functional layer mLookup + spec — the matching now presents as a computable partial map with support mDom, ready to read off σ. Remaining frontier unchanged: the stage-wise scheduler with collision-chasing.",
       "DONE (researcher-6): the 'tractable partial win' (classical/computable SB is computable when ranges decidable / when g is a bijection) is now formalized as computable_bijection_isComputablePerm + decidableIsGFree. Remaining frontier is unchanged: the stage-wise back-and-forth for arbitrary computable injections.",
       "Formalize the stage-wise partial-bijection builder (List (ℕ×ℕ) by recursion on stage) using f for domain-side and partialInverse g for range-side extensions.",
       "Prove the stage invariants: injectivity (via partialInverse_unique + f injective), correspondence p↔q preserved, and domain/range exhaustion (n covered by stage 2n+1).",
@@ -141,11 +148,11 @@
     {
       "path": "Proofs/SchroederBernsteinOQ03.lean",
       "filename": "SchroederBernsteinOQ03.lean",
-      "lineCount": 258,
-      "theoremCount": 14,
+      "lineCount": 674,
+      "theoremCount": 41,
       "axiomCount": 0,
-      "defCount": 4,
-      "sorryCount": 5,
+      "defCount": 11,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchroederBernsteinOQ03.lean"
     },


### PR DESCRIPTION
## Summary

Partial progress on the **OPEN** hard direction of **Myhill's isomorphism theorem** (computable injections ⟹ computable bijection). The single remaining `sorry` — the stage-wise back-and-forth scheduler with collision-chasing — is **unchanged**; this PR completes a verified sub-API that the scheduler will consume.

Builds on researcher-1's finite-matching layer (#32280). The scheduler's final step reads the total permutation `σ` off the *limiting* matching and must certify `σ` computable, which requires the matching presented as an actual **computed function**, not merely a set-theoretic partial bijection (which `matching_functional`/`matching_cofunctional` already give).

## New — Section 4d (all 0-axiom)

| Declaration | Statement |
|---|---|
| `mLookup L a := L.lookup a` | the computable partner map |
| `mLookup_eq_some_of_mem` | on a matching, `(a,b) ∈ L ⟹ mLookup L a = some b` (functional form of `matching_functional`) |
| `mLookup_isSome_iff` | `(mLookup L a).isSome ↔ a ∈ mDom L` — defined exactly on the domain |
| `mem_of_mLookup_eq_some` | converse: a successful lookup recovers a recorded pair (no matching hypothesis) |
| `matchingCorr_mLookup` | the lookup respects `p ↔ q`, so `σ` is read off **without** evaluating the possibly-non-computable predicates `p, q` |

## Axiom integrity

`#print axioms` on all 4 lemmas reports only `propext, Classical.choice, Quot.sound` — no `sorryAx`, genuinely 0-axiom. The file's single `sorry` (the open scheduler) is honestly preserved.

## Honesty

This is **partial progress on an open problem**, not a claim of resolution. No new axioms, no `True` placeholders, no scaffolding on unproved axioms — a complete, verified, reusable component toward the scheduler.

## Build

`cd proofs && lake env lean Proofs/SchroederBernsteinOQ03.lean` — compiles clean (only the pre-existing open-`sorry` warning) against pinned Mathlib v4.26.0.

674 LOC · 41 theorems/lemmas · 11 defs · **1 sorry** (open hard core). Status stays `formalized`/`wip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)