### PR TITLE
research(erdos-862-oq-03): verify B_h counting framework [VERIFIED, 0-axiom] + gallery

### DIFF
--- a/proofs/Proofs/Erdos862OQ03Problem.lean
+++ b/proofs/Proofs/Erdos862OQ03Problem.lean
@@ -74,6 +74,7 @@ def IsMaximalBhSet (N h : ℕ) (S : Finset ℕ) : Prop :=
   IsBhSubset N h S ∧
   ∀ x ∈ Interval N, x ∉ S → ¬ IsBhSet h (insert x S)
 
+open Classical in
 /-- `Aₕ(N, h)` = number of maximal B_h subsets of `{1,…,N}`.
     For `h = 2` this is the parent's `A₁(N)`. -/
 noncomputable def Aₕ (N h : ℕ) : ℕ :=
@@ -106,7 +107,7 @@ theorem bhSet_empty {h : ℕ} (hh : 2 ≤ h) : IsBhSet h (∅ : Finset ℕ) :=
 /-- Every singleton is a B_h set for every `h ≥ 2`. -/
 theorem bhSet_singleton {h : ℕ} (hh : 2 ≤ h) (a : ℕ) :
     IsBhSet h ({a} : Finset ℕ) :=
-  bhSet_of_card_le hh (by simp)
+  bhSet_of_card_le hh (by rw [Finset.card_singleton]; omega)
 
 /-- **Bridge to the parent #862.** The Sidon (B₂) condition of the parent
     entry implies the `IsBhSet 2` condition used here, so this B_h framework
@@ -121,6 +122,22 @@ theorem sidon_imp_b2 {S : Finset ℕ} (hS : IsSidonSet S) : IsBhSet 2 S := by
   have hd : d ∈ S := h₂ (by simp)
   rw [Finset.sum_pair hab, Finset.sum_pair hcd] at he
   exact hS a b c d ha hb hc hd he
+
+/-- `0` is never a member of the ambient interval `{1,…,N}`. -/
+theorem zero_notMem_interval (N : ℕ) : (0 : ℕ) ∉ Interval N := by
+  simp [Interval]
+
+/-- **Ambient size.** The interval `{1,…,N}` has exactly `N` elements.  This
+    pins down the size of the ground set over which maximal B_h subsets are
+    counted, so `Aₕ(N,h)` is a count of subsets of an `N`-element set. -/
+theorem interval_card (N : ℕ) : (Interval N).card = N := by
+  have hIcc : Interval N = Finset.Icc 1 N := by
+    ext x
+    simp only [Interval, Finset.mem_sdiff, Finset.mem_range, Finset.mem_singleton,
+      Finset.mem_Icc]
+    omega
+  rw [hIcc, Nat.card_Icc]
+  omega
 
 /-! ## Part III — Existence of maximal B_h sets and well-definedness of `Aₕ` -/
 
@@ -146,7 +163,7 @@ theorem exists_maximal_bhSet (N h : ℕ) (hh : 2 ≤ h) :
     rw [h𝒮, Finset.mem_filter, Finset.mem_powerset]
     exact ⟨Finset.insert_subset hxI hSsub, hcontra⟩
   have hle := hSmax (insert x S) hins_mem
-  rw [Finset.card_insert_of_not_mem hxS] at hle
+  rw [Finset.card_insert_of_notMem hxS] at hle
   omega
 
 /-- **`Aₕ` is well-defined and positive.** Since a maximal B_h subset always
@@ -154,10 +171,10 @@ theorem exists_maximal_bhSet (N h : ℕ) (hh : 2 ≤ h) :
 theorem Aₕ_pos (N h : ℕ) (hh : 2 ≤ h) : 1 ≤ Aₕ N h := by
   classical
   obtain ⟨S, hS⟩ := exists_maximal_bhSet N h hh
-  have hmem : S ∈ (Interval N).powerset.filter (fun S => IsMaximalBhSet N h S) := by
-    rw [Finset.mem_filter, Finset.mem_powerset]
-    exact ⟨hS.1.1, hS⟩
-  exact Finset.Nonempty.card_pos ⟨S, hmem⟩
+  rw [Aₕ]
+  refine Finset.Nonempty.card_pos ⟨S, ?_⟩
+  rw [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨hS.1.1, hS⟩
 
 /-! ## Part IV — The open question (stated, not proved) -/
 

--- a/research/problems/erdos-862-oq-03/knowledge.md
+++ b/research/problems/erdos-862-oq-03/knowledge.md
@@ -39,3 +39,33 @@ card_le`, `Finset.card_eq_two`, `Finset.sum_pair`, `Finset.insert_subset`,
 - If verified: add gallery `src/data/proofs/erdos-862-oq-03/` (status
   axiomatized? no — file is 0-axiom; the OPEN law is a `def` not a claim, so
   status `verified`/badge `original` for the framework lemmas is defensible).
+
+## Session 2 (researcher-1, 2026-07-01) — VERIFIED + gallery
+
+The Session-1 file was merged (PR #30720) but **never compiled** (Docker was
+down). Rebuilt via `lake env lean` from the main `proofs/` (mathlib oleans
+present) and caught **3 genuine compile errors** the eyeball review missed:
+
+1. `Aₕ` filter had no `DecidablePred` instance → added `open Classical in`
+   before the def (must precede the doc comment, else parse error).
+2. `bhSet_singleton`'s `by simp` left `1 ≤ h` unsolved → `by rw [Finset.card_singleton]; omega`.
+3. `Aₕ_pos` had an instance/`0<` vs `1≤` type mismatch → `rw [Aₕ]; refine Finset.Nonempty.card_pos ⟨S, ?_⟩; ...`.
+   (Also `card_insert_of_not_mem` → `card_insert_of_notMem`, dropped deprecation warning.)
+
+Added 2 new verified lemmas:
+- `zero_notMem_interval`: 0 ∉ {1,…,N}.
+- `interval_card`: |{1,…,N}| = N (via `Interval N = Finset.Icc 1 N`, `Nat.card_Icc`;
+  note this Mathlib's `Finset.card_sdiff` is the *unconditional* `#(t\s)=#t-#(s∩t)` form).
+
+**Status now: VERIFIED, 0-axiom.** `#print axioms` on all 10 theorems lists only
+`propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.
+198 lines, 10 theorems, 7 defs, 0 axioms, 0 sorries.
+
+Created the missing gallery entry `src/data/proofs/erdos-862-oq-03/`
+(meta.json status `verified`/badge `original`, annotations.json, mirrors parent
+erdos-862 format — no index.ts needed, gallery auto-discovers the dir).
+
+### Next steps
+- The open growth law (`MaximalBhCountingQuestion`) remains a `def`, unproven —
+  genuinely open. To attack: formalize tight max-size asymptotics for B_h
+  subsets of [N] (the input the container division argument needs).

--- a/src/data/proofs/erdos-862-oq-03/annotations.json
+++ b/src/data/proofs/erdos-862-oq-03/annotations.json
@@ -1,0 +1,111 @@
+[
+  {
+    "id": "erdos-862-oq-03-intro",
+    "proofId": "erdos-862-oq-03",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 45
+    },
+    "title": "Open Question and Imports",
+    "content": "The docstring states OQ-03 (extend maximal-Sidon counting to maximal $B_h$ subsets for $h \\geq 3$), recalls the parent Saxton–Thomason bound $A_2(N) \\geq 2^{(0.16+o(1))\\sqrt{N}}$, and explains why $h \\geq 3$ is open: the container hypergraph becomes $(2h)$-uniform and $B_h$ size asymptotics are imprecise. Imports all of Mathlib and opens `Real`, `Finset`.",
+    "mathContext": "A $B_h$ set is one in which every $h$-element subset has a distinct sum; $h = 2$ is the Sidon (B₂) case. The maximal-$B_h$ counting problem for $h \\geq 3$ is genuinely open.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Sidon sets",
+      "B_h sequences",
+      "hypergraph container method"
+    ],
+    "prerequisites": [
+      "Lean 4 type system",
+      "Mathlib Finset library"
+    ]
+  },
+  {
+    "id": "erdos-862-oq-03-defs",
+    "proofId": "erdos-862-oq-03",
+    "type": "definition",
+    "range": {
+      "startLine": 47,
+      "endLine": 81
+    },
+    "title": "B_h Sets and the Counting Function Aₕ",
+    "content": "`IsBhSet h S` requires $2 \\leq h$ and that any two $h$-element subsets $T_1, T_2 \\subseteq S$ with $\\sum T_1 = \\sum T_2$ coincide — the natural element-sum reading of the $B_h$ condition. `Interval N` is $\\{1,\\ldots,N\\}$ as `range(N+1) \\ {0}`; `IsBhSubset` and `IsMaximalBhSet` build on it, and `Aₕ N h` counts maximal $B_h$ subsets as the cardinality of a filtered powerset. The `open Classical in` on `Aₕ` supplies decidability for the (noncomputable) filter.",
+    "mathContext": "For $h = 2$ this specializes to (a subset form of) the Sidon condition; `Aₕ N 2` is the parent's $A_1(N)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "B_h sequence",
+      "Finset.powerset",
+      "maximal independent set"
+    ],
+    "prerequisites": [
+      "Finset operations",
+      "decidable predicates"
+    ]
+  },
+  {
+    "id": "erdos-862-oq-03-structural",
+    "proofId": "erdos-862-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 83,
+      "endLine": 141
+    },
+    "title": "Heredity, Small-Set Triviality, and the Ground Set",
+    "content": "`bhSet_subset`: a subset of a $B_h$ set is $B_h$ (shrinking cannot create a sum collision). `bhSet_of_card_le`: a set of $\\leq h$ elements is automatically $B_h$ (at most one $h$-subset exists), with corollaries `bhSet_empty` and `bhSet_singleton`. `sidon_imp_b2` bridges to the parent: `IsSidonSet S → IsBhSet 2 S` via `Finset.card_eq_two` and `Finset.sum_pair`. `zero_notMem_interval` and `interval_card` establish that $\\{1,\\ldots,N\\}$ has exactly $N$ elements (proved by rewriting to `Finset.Icc 1 N`).",
+    "mathContext": "Heredity and small-set triviality hold with identical proofs for every $h$, so the $h \\geq 3$ theory reuses the $h = 2$ scaffolding. All lemmas are axiom-free.",
+    "significance": "key",
+    "relatedConcepts": [
+      "hereditary property",
+      "Finset.card_eq_two",
+      "Finset.sum_pair",
+      "Nat.card_Icc"
+    ],
+    "prerequisites": [
+      "Finset cardinality lemmas"
+    ]
+  },
+  {
+    "id": "erdos-862-oq-03-existence",
+    "proofId": "erdos-862-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 142,
+      "endLine": 178
+    },
+    "title": "Existence of Maximal B_h Sets and Positivity of Aₕ",
+    "content": "`exists_maximal_bhSet`: for every $N$ and $h \\geq 2$ a maximal $B_h$ subset of $[N]$ exists. The proof takes a maximum-cardinality $B_h$ subset via `Finset.exists_max_image` (the family is nonempty because $\\varnothing$ is $B_h$) and shows it cannot be extended — any extension would be a strictly larger $B_h$ subset, contradicting maximality of cardinality. This is the finite, constructive analogue of the Zorn step used implicitly in the parent. `Aₕ_pos` then gives $A_h(N) \\geq 1$.",
+    "mathContext": "Finite Zorn: in a finite poset a maximum-cardinality element of a downward-closed family is maximal. No choice beyond `Finset.exists_max_image` is needed.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Zorn's lemma",
+      "Finset.exists_max_image",
+      "maximal element"
+    ],
+    "prerequisites": [
+      "Finset maximum extraction",
+      "cardinality monotonicity"
+    ]
+  },
+  {
+    "id": "erdos-862-oq-03-open",
+    "proofId": "erdos-862-oq-03",
+    "type": "concept",
+    "range": {
+      "startLine": 179,
+      "endLine": 198
+    },
+    "title": "The Open Growth Law (stated, not proved)",
+    "content": "`MaximalBhCountingQuestion h` records the open conjecture — $\\exists \\alpha > 0,\\, N_0,\\, \\forall N \\geq N_0,\\; A_h(N) \\geq 2^{\\alpha N^{1/(h+1)}}$ — as a Prop-valued `def`, deliberately unproven. `maximal_bh_counting_well_posed` certifies that this asks about an honestly-defined positive quantity. Recording the open law as a `def` rather than a theorem or axiom means the file asserts nothing unproven.",
+    "mathContext": "The $h = 2$ instance is the Saxton–Thomason theorem; for $h \\geq 3$ no analogous bound is known. The exponent $N^{1/(h+1)}$ is a plausible guess reflecting the $(2h)$-uniform hypergraph structure, not an established rate.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "open conjecture",
+      "asymptotic growth",
+      "honest formalization"
+    ],
+    "prerequisites": [
+      "asymptotic notation"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-862-oq-03/meta.json
+++ b/src/data/proofs/erdos-862-oq-03/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "erdos-862-oq-03",
+  "title": "Erdős #862 OQ-03: Counting Maximal B_h Sets (h ≥ 3)",
+  "slug": "erdos-862-oq-03",
+  "description": "Open question extending the parent #862 (maximal Sidon = B₂ counting, solved by Saxton-Thomason 2015) to maximal B_h subsets of {1,…,N} for h ≥ 3: how does the count grow? This entry builds the verified, axiom-free counting framework — B_h heredity, existence of maximal B_h subsets, and well-definedness/positivity of the counting function Aₕ(N,h) — and records the open growth law as an unproven statement.",
+  "meta": {
+    "author": "researcher-1 (framework); open question after Cameron-Erdős (1992), Saxton-Thomason (2015)",
+    "sourceUrl": "https://erdosproblems.com/862",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos862OQ03Problem.lean",
+    "tags": [
+      "erdos",
+      "combinatorics",
+      "sidon-sets",
+      "bh-sets",
+      "extremal-combinatorics",
+      "counting",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "erdosNumber": 862,
+    "erdosUrl": "https://erdosproblems.com/862",
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.exists_max_image",
+        "description": "Extract a maximum-cardinality element from a nonempty finite family (finite Zorn step)",
+        "module": "Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "Finset.powerset",
+        "description": "Power set of a finset for counting subsets",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Finset.eq_of_subset_of_card_le",
+        "description": "A subset with cardinality ≥ the superset equals it (for the ≤ h card case)",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.card_Icc",
+        "description": "Cardinality of an integer interval, used to prove |{1,…,N}| = N",
+        "module": "Mathlib.Order.Interval.Finset.Nat"
+      }
+    ],
+    "originalContributions": [
+      "IsBhSet h S: element-sum reading of the B_h condition (every h-subset has a distinct sum); h=2 recovers the Sidon property",
+      "bhSet_subset: B_h is hereditary (subset-closed)",
+      "bhSet_of_card_le / bhSet_empty / bhSet_singleton: any set of ≤ h elements is automatically B_h",
+      "sidon_imp_b2: parent's IsSidonSet S → IsBhSet 2 S, tying this framework to #862",
+      "zero_notMem_interval / interval_card: the ground set {1,…,N} has exactly N elements",
+      "exists_maximal_bhSet: a maximal B_h subset of [N] always exists (finite analogue of the Zorn step)",
+      "Aₕ N h and Aₕ_pos: the counting function is well-defined and ≥ 1",
+      "MaximalBhCountingQuestion: the OPEN growth law, recorded as a statement (def), not a theorem"
+    ],
+    "axiomCount": 0,
+    "lineCount": 198,
+    "assumptions": "0 axioms, 0 sorries. Only foundational axioms (propext, Classical.choice, Quot.sound) appear via #print axioms. The open growth law is a `def`, so the file makes no unproven claim.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 7
+  },
+  "overview": {
+    "historicalContext": "**Erdős #862, Open Question OQ-03 — Counting maximal $B_h$ sets for $h \\geq 3$.**\n\nA **Sidon set** (a $B_2$ sequence) is a set of integers whose pairwise sums are all distinct. The parent problem #862 (Cameron–Erdős 1992) asks how the number $A_1(N)$ of *maximal* Sidon subsets of $\\{1,\\ldots,N\\}$ grows; Saxton and Thomason resolved it in 2015 via the hypergraph container method, proving $A_1(N) \\geq 2^{(0.16+o(1))\\sqrt{N}}$.\n\nA **$B_h$ set** generalizes this: every $h$-element subset has a distinct sum (equivalently, all $h$-fold sums are distinct). This open question asks for the analogue of the counting theory for maximal $B_h$ subsets when $h \\geq 3$. The problem is genuinely open: the container method still applies, but the controlling hypergraph becomes $(2h)$-uniform, and the size asymptotics of $B_h$ sets in $[N]$ are far less precise than the $f(N) \\sim \\sqrt{N}$ estimate that drives the $h = 2$ argument.\n\nThis entry does **not** resolve the open question. It builds the fully machine-checked, axiom-free *counting framework* on which any such theory rests, and records the open growth law honestly as a statement rather than a claimed theorem.",
+    "problemStatement": "**Open Question (OQ-03).** Extend the counting theory of maximal Sidon subsets to maximal $B_h$ subsets of $\\{1,\\ldots,N\\}$ for $h \\geq 3$: how does $A_h(N)$, the number of maximal $B_h$ subsets, grow with $N$? For $h = 2$ this is the Saxton–Thomason theorem $A_2(N) \\geq 2^{(0.16+o(1))\\sqrt{N}}$; for $h \\geq 3$ no analogous bound is known.",
+    "text": "Extend the counting theory to maximal B_h sets for h ≥ 3: how does the number of maximal B_h subsets of {1,…,N} grow?",
+    "proofStrategy": "**What is verified (0 sorry, 0 axiom):**\n\n1. **Definitions (Part I).** `IsBhSet h S` reads the $B_h$ condition as: any two $h$-element subsets of $S$ with equal element-sum coincide. `Interval N` is $\\{1,\\ldots,N\\}$; `IsMaximalBhSet` and the counting function `Aₕ N h` (cardinality of the filtered powerset of maximal $B_h$ subsets) are defined on top.\n\n2. **Structural lemmas (Part II).** `bhSet_subset` (heredity), `bhSet_of_card_le` and its corollaries `bhSet_empty`/`bhSet_singleton` (small sets are automatically $B_h$), and the bridge `sidon_imp_b2` connecting to the parent. `interval_card` and `zero_notMem_interval` pin the ground set at exactly $N$ elements.\n\n3. **Existence and well-definedness (Part III).** `exists_maximal_bhSet` takes a maximum-cardinality $B_h$ subset of $[N]$ (the family is nonempty since $\\varnothing$ qualifies) and shows it cannot be extended — the finite, constructive analogue of the Zorn step. `Aₕ_pos` then gives $A_h(N) \\geq 1$.\n\n4. **The open question (Part IV).** `MaximalBhCountingQuestion h` is a `def` (a Prop-valued statement), deliberately left unproven, asking whether $A_h(N) \\geq 2^{\\alpha N^{1/(h+1)}}$ for some $\\alpha > 0$. `maximal_bh_counting_well_posed` certifies that this asks a question about an honestly-defined, positive quantity.",
+    "keyInsights": [
+      "**The counting function is well-posed before it is estimated.** The value of this entry is separating the settled part (that $A_h(N)$ is a genuine positive integer for every $N$ and every $h \\geq 2$) from the open part (its growth rate). `exists_maximal_bhSet` + `Aₕ_pos` make the former fully machine-checked.",
+      "**Finite Zorn is constructive.** Existence of a maximal $B_h$ subset needs no choice beyond `Finset.exists_max_image`: a maximum-cardinality $B_h$ subset is automatically maximal, because any extension would be a strictly larger $B_h$ subset, contradicting maximality of cardinality.",
+      "**Heredity is what makes the framework uniform in $h$.** `bhSet_subset` (a subset of a $B_h$ set is $B_h$) and `bhSet_of_card_le` (sets of $\\leq h$ elements are vacuously $B_h$) hold for all $h$ with identical proofs, so the $h \\geq 3$ theory shares its scaffolding with the $h = 2$ case.",
+      "**Why $h \\geq 3$ is open.** The container method encodes $B_h$ violations as edges of a $(2h)$-uniform hypergraph, but the counting bound requires tight control on the maximum size of a $B_h$ set in $[N]$; for $h \\geq 3$ these size asymptotics are imprecise, so the division argument that closes the $h = 2$ case does not go through.",
+      "**No overclaiming.** The open growth law is recorded as a `def MaximalBhCountingQuestion`, not a theorem or axiom. The file therefore asserts nothing unproven: `#print axioms` on every theorem lists only `propext`, `Classical.choice`, `Quot.sound`."
+    ],
+    "prerequisites": [
+      "Combinatorics (counting, extremal problems)",
+      "Additive number theory (Sidon and B_h sequences)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-setup",
+      "title": "Module Header and Imports",
+      "summary": "Docstring explaining OQ-03, the parent Saxton–Thomason result, and why $h \\geq 3$ is open, followed by `import Mathlib` and `open Real Finset`.",
+      "startLine": 1,
+      "endLine": 45,
+      "mathContext": "Problem-statement docstring plus Mathlib import."
+    },
+    {
+      "id": "definitions",
+      "title": "Part I — Definitions",
+      "summary": "`IsSidonSet` (reproduced from the parent), `Interval N` = $\\{1,\\ldots,N\\}$, `IsBhSet h S`, `IsBhSubset`, `IsMaximalBhSet`, and the counting function `Aₕ N h`.",
+      "startLine": 47,
+      "endLine": 81,
+      "mathContext": "Defines the B_h predicate as h-subset sum-distinctness and the maximal-B_h counting function."
+    },
+    {
+      "id": "structural-lemmas",
+      "title": "Part II — Structural Lemmas (verified, axiom-free)",
+      "summary": "`bhSet_subset` (heredity), `bhSet_of_card_le`, `bhSet_empty`, `bhSet_singleton`, the bridge `sidon_imp_b2`, and the ground-set facts `zero_notMem_interval` and `interval_card` (|{1,…,N}| = N).",
+      "startLine": 83,
+      "endLine": 141,
+      "mathContext": "Heredity, small-set triviality, the Sidon→B₂ bridge, and the size of the ambient interval."
+    },
+    {
+      "id": "existence",
+      "title": "Part III — Existence and Well-Definedness of Aₕ",
+      "summary": "`exists_maximal_bhSet`: a maximal B_h subset of [N] always exists (max-cardinality B_h subset is maximal). `Aₕ_pos`: the count is ≥ 1.",
+      "startLine": 142,
+      "endLine": 178,
+      "mathContext": "Finite Zorn step via Finset.exists_max_image; positivity of the counting function."
+    },
+    {
+      "id": "open-question",
+      "title": "Part IV — The Open Question (stated, not proved)",
+      "summary": "`MaximalBhCountingQuestion h`: the open growth law, a Prop-valued `def` left unproven. `maximal_bh_counting_well_posed`: it asks about an honestly-defined positive quantity.",
+      "startLine": 179,
+      "endLine": 198,
+      "mathContext": "The open conjecture recorded as a statement, with a well-posedness certificate."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry provides the verified, axiom-free counting framework for maximal $B_h$ subsets of $\\{1,\\ldots,N\\}$: heredity, small-set triviality, the Sidon→$B_2$ bridge, the exact ground-set size, existence of maximal $B_h$ subsets, and positivity/well-definedness of the counting function $A_h(N)$. The open growth law for $h \\geq 3$ is recorded as a statement, not proved — it is genuinely open in the literature.",
+    "implications": "The framework isolates precisely what must be estimated to make progress on OQ-03: the maximum size of a $B_h$ subset of $[N]$, which controls the division argument used in the $h = 2$ (Saxton–Thomason) case. By certifying that $A_h(N)$ is a well-defined positive integer for every $N$ and every $h \\geq 2$, it also confirms the open question is asked about an honest quantity.",
+    "openQuestions": [
+      "Determine the growth rate of $A_h(N)$ for $h \\geq 3$: is there $\\alpha > 0$ with $A_h(N) \\geq 2^{\\alpha N^{1/(h+1)}}$ for large $N$?",
+      "Obtain tight asymptotics for the maximum size of a $B_h$ subset of $[N]$, the input the container-method division argument needs.",
+      "Formalize the hypergraph-container lower bound for $h = 2$ (currently axiomatized in the parent #862) as a stepping stone toward $h \\geq 3$."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "Erdos862OQ03",
+    "lineCount": 198,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 7,
+    "path": "Proofs/Erdos862OQ03Problem.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-862",
+      "relationship": "parent",
+      "description": "Parent problem: counting maximal Sidon (B₂) subsets, solved by Saxton-Thomason (2015). This OQ generalizes to B_h, h ≥ 3."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
The Erdős #862 OQ-03 file (maximal $B_h$ counting framework, $h \geq 3$) was created and **merged** in PR #30720 as a DRAFT "pending build" — Docker was down when it was written, so it was **never compiled**. This session rebuilt it, caught 3 genuine compile errors the eyeball review missed, fixed them, and added the missing gallery entry.

## Fixes (the file did not compile before)
- **`Aₕ`**: filtered powerset had no `DecidablePred` instance → added `open Classical in` before the def.
- **`bhSet_singleton`**: `by simp` left `1 ≤ h` unsolved → `by rw [Finset.card_singleton]; omega`.
- **`Aₕ_pos`**: decidability-instance / `0 <` vs `1 ≤` type mismatch → rewrite via `rw [Aₕ]; refine Finset.Nonempty.card_pos ⟨S, ?_⟩`.
- `card_insert_of_not_mem` → `card_insert_of_notMem` (deprecation).

## New verified content
- `zero_notMem_interval`: $0 \notin \{1,\dots,N\}$.
- `interval_card`: $|\{1,\dots,N\}| = N$ (via `Interval N = Finset.Icc 1 N`, `Nat.card_Icc`).

## Verification
Built with `lake env lean` against the main `proofs/` Mathlib oleans (Docker unusable). `#print axioms` on all 10 theorems lists **only** `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.

**198 lines · 10 theorems · 7 defs · 0 axioms · 0 sorries.**

## Files
- `proofs/Proofs/Erdos862OQ03Problem.lean` (fixed + 2 lemmas)
- `src/data/proofs/erdos-862-oq-03/{meta.json,annotations.json}` (new gallery entry; status `verified`, badge `original`)
- `research/problems/erdos-862-oq-03/knowledge.md` (Session 2 notes)

## Status
**Outcome**: completed (framework verified; the open growth law for $h \geq 3$ remains a `def`, unproven — genuinely open).
**Next**: to attack the open law, formalize tight max-size asymptotics for $B_h$ subsets of $[N]$ (the input the container division argument needs).

🤖 Generated by researcher-1