### PR TITLE
research(cauchy-interlacing-oq-01-oq-01-oq-01-oq-03): matrix-form Poincaré separation for m×m principal submatrices [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingOQ01OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/CauchyInterlacingOQ01OQ01OQ01OQ03.lean
@@ -1,0 +1,345 @@
+import Mathlib
+import Proofs.CauchyInterlacingPoincare
+import Proofs.CauchyInterlacingOQ01OQ01
+
+/-
+# Poincaré separation for m×m principal submatrices (matrix form)
+
+`Proofs/CauchyInterlacingOQ01OQ01OQ02.lean` proves **codimension-one** Cauchy
+interlacing at the level of concrete matrices: for a Hermitian
+`(n+1) × (n+1)` matrix `A` and one deleted index `j`, the eigenvalues of the
+principal submatrix `A.submatrix j.succAbove j.succAbove` interlace those of `A`,
+`λ_{k+1} ≤ μ_k ≤ λ_k`. The single deleted coordinate is encoded by the specific
+injection `j.succAbove : Fin n ↪ Fin (n+1)`.
+
+Separately, `Proofs/CauchyInterlacingPoincare.lean` proves the **abstract**
+Poincaré separation theorem for an *arbitrary*-codimension compression: for a
+symmetric operator on a space of dimension `n + m` compressed to a subspace of
+dimension `n`, `λ_{k+m} ≤ μ_k ≤ λ_k`.
+
+This file joins the two, delivering the theorem the whole chain was building
+toward: **Poincaré separation at the level of concrete matrices for an arbitrary
+`n × n` principal submatrix**. Fix a Hermitian `(n+m) × (n+m)` matrix `A` and an
+injective index map `ι : Fin n → Fin (n+m)` (choosing which `n` of the `n+m`
+rows/columns to keep). Then the eigenvalues of the principal submatrix
+`A.submatrix ι ι` separate those of `A`:
+
+  `λ_{k+m}(A) ≤ μ_k(A.submatrix ι ι) ≤ λ_k(A)`,     for every `k : Fin n`.
+
+The mechanism generalises the codimension-one file verbatim, replacing the
+specific injection `j.succAbove` by an arbitrary injective `ι`:
+
+* The coordinate subspace `H = span {e_{ι i}}` (the span of the kept coordinate
+  axes) is `n`-dimensional (`finrank_coordSubspace`, using injectivity of `ι`).
+* The orthogonal compression of `toEuclideanLin A` to `H`, read on the basis
+  `(e_{ι i})`, is exactly `A.submatrix ι ι` (`compress_inner_eq_submatrix`).
+* Under the coordinate isometry `coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H`,
+  `e_i ↦ e_{ι i}`, the compression *is* the submatrix operator
+  (`compress_intertwine`), so pushing the submatrix's spectral eigenbasis through
+  `coordEquiv` yields an eigenbasis of the compression with the *same* antitone
+  eigenvalues — feeding the abstract `poincare_separation` with no
+  eigenvalue-uniqueness lemma required (`interlacing_poincare_of_intertwine`).
+
+## Main results
+
+* `principalSubmatrix_poincare_separation` — operator-eigenvalue form:
+  `λ_{k+m} ≤ μ_k ≤ λ_k` for the descending eigenvalues of `toEuclideanLin A` and
+  of `toEuclideanLin (A.submatrix ι ι)`.
+* `eigenvalues₀_principalSubmatrix_poincare` — the literal matrix statement in
+  terms of `Matrix.IsHermitian.eigenvalues₀`.
+
+The codimension-one file is the special case `m = 1`, `ι = j.succAbove`. Over any
+`RCLike` field `𝕜` (so `ℝ` and `ℂ`). Absent from Mathlib.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace
+open Matrix
+open CauchyInterlacingOQ01OQ01
+open CauchyInterlacing.Poincare
+
+namespace CauchyInterlacingOQ01OQ01OQ01OQ03
+
+set_option maxHeartbeats 4000000
+set_option synthInstance.maxHeartbeats 1000000
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n m : ℕ}
+
+/-! ## Eigenvalues are independent of the `finrank` proof (index bookkeeping) -/
+
+/-- `LinearMap.IsSymmetric.eigenvalues` depends on the dimension proof only through
+its right-hand side: two proofs of `finrank = p` and `finrank = p'` give the same
+eigenvalue list up to the (forced) equality `p = p'`. -/
+theorem eigenvalues_finrank_congr {E : Type*} [NormedAddCommGroup E]
+    [InnerProductSpace 𝕜 E] [FiniteDimensional 𝕜 E] {T : E →ₗ[𝕜] E}
+    (hT : T.IsSymmetric) {p p' : ℕ} (hp : Module.finrank 𝕜 E = p)
+    (hp' : Module.finrank 𝕜 E = p') (i : Fin p) :
+    hT.eigenvalues hp i = hT.eigenvalues hp' (Fin.cast (hp.symm.trans hp') i) := by
+  obtain rfl : p = p' := hp.symm.trans hp'
+  simp only [Fin.cast_eq_self]
+
+/-! ## The Poincaré transfer engine -/
+
+/-- **Poincaré separation transfers across an isometric intertwining.**
+
+Let `T` (with antitone eigendata `b, lam`) act on `V` of dimension `n + m`, let
+`Hs ≤ V` have dimension `n` (codimension `m`), and let `T'` (with antitone
+eigendata `b', mu`) act on a model space `E`. If an isometry `ee' : E ≃ₗᵢ Hs`
+intertwines a symmetric operator `TH` on `Hs` with `T'` (`TH (ee' x) = ee' (T' x)`)
+and `TH` satisfies the Rayleigh agreement of the orthogonal compression, then the
+eigenvalues separate: `lam ⟨k+m⟩ ≤ mu k ≤ lam ⟨k⟩`.
+
+Pushing `T'`'s eigenbasis `b'` through `ee'` produces an eigenbasis of `TH` with
+the *same* eigenvalues `mu` — so no eigenvalue-uniqueness lemma is needed — which
+is fed to the abstract `poincare_separation`. This is the arbitrary-codimension
+analogue of `interlacing_of_intertwine` from the codimension-one file. -/
+theorem interlacing_poincare_of_intertwine {V E : Type*}
+    [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [FiniteDimensional 𝕜 V]
+    [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [FiniteDimensional 𝕜 E]
+    (T : V →ₗ[𝕜] V) (b : OrthonormalBasis (Fin (n + m)) 𝕜 V) (lam : Fin (n + m) → ℝ)
+    (hT : ∀ i, T (b i) = (lam i : 𝕜) • b i) (hlam : Antitone lam)
+    (Hs : Submodule 𝕜 V) (hHdim : Module.finrank 𝕜 Hs = n)
+    (TH : Hs →ₗ[𝕜] Hs)
+    (T' : E →ₗ[𝕜] E) (b' : OrthonormalBasis (Fin n) 𝕜 E) (mu : Fin n → ℝ)
+    (hT' : ∀ i, T' (b' i) = (mu i : 𝕜) • b' i) (hmu : Antitone mu)
+    (ee' : E ≃ₗᵢ[𝕜] Hs) (hinter : ∀ x : E, TH (ee' x) = ee' (T' x))
+    (hRay : ∀ y : Hs, y ≠ 0 →
+      RCLike.re (@inner 𝕜 Hs _ (TH y) y) / ‖y‖ ^ 2
+        = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2)
+    (k : Fin n) :
+    lam ⟨(k : ℕ) + m, by have := k.isLt; omega⟩ ≤ mu k
+      ∧ mu k ≤ lam ⟨(k : ℕ), by have := k.isLt; omega⟩ := by
+  set bH : OrthonormalBasis (Fin n) 𝕜 Hs := b'.map ee' with hbHdef
+  have hbH : ∀ i, bH i = ee' (b' i) := fun i => OrthonormalBasis.map_apply _ _ _
+  have hTH : ∀ i, TH (bH i) = (mu i : 𝕜) • bH i := by
+    intro i; rw [hbH, hinter, hT', map_smul]
+  exact poincare_separation T b lam hT hlam Hs hHdim TH bH mu hTH hmu hRay k
+
+/-! ## The coordinate subspace and coordinate isometry for a general injection -/
+
+/-- The standard basis vector `e_a = single a 1` of `EuclideanSpace 𝕜 (Fin (n+m))`. -/
+noncomputable abbrev ee (a : Fin (n + m)) : EuclideanSpace 𝕜 (Fin (n + m)) :=
+  EuclideanSpace.single a (1 : 𝕜)
+
+/-- **Matrix entries via inner products of basis vectors.** Viewing `A` as the
+operator `toEuclideanLin A`, the `(a, b)` entry is `⟪e_a, A e_b⟫`. -/
+theorem inner_single_toEuclideanLin_single (A : Matrix (Fin (n + m)) (Fin (n + m)) 𝕜)
+    (a b : Fin (n + m)) :
+    @inner 𝕜 _ _ (ee (𝕜 := 𝕜) a) (Matrix.toEuclideanLin A (ee b)) = A a b := by
+  rw [EuclideanSpace.inner_single_left, map_one, one_mul]
+  show (Matrix.toEuclideanLin A (EuclideanSpace.single b (1 : 𝕜))) a = A a b
+  rw [Matrix.toEuclideanLin_apply, EuclideanSpace.ofLp_single, Matrix.mulVec_single_one]
+  rfl
+
+variable (ι : Fin n → Fin (n + m))
+
+/-- The **coordinate subspace** for an index map `ι`: the span of the `n` standard
+basis vectors `e_{ι i}` (the coordinate axes kept by the principal submatrix). -/
+noncomputable def coordSubspace : Submodule 𝕜 (EuclideanSpace 𝕜 (Fin (n + m))) :=
+  Submodule.span 𝕜 (Set.range fun i : Fin n => ee (𝕜 := 𝕜) (ι i))
+
+/-- `e_{ι i}` lies in the coordinate subspace. -/
+theorem mem_coordSubspace (i : Fin n) :
+    ee (𝕜 := 𝕜) (ι i) ∈ coordSubspace (𝕜 := 𝕜) ι :=
+  Submodule.subset_span ⟨i, rfl⟩
+
+/-- The `i`-th natural basis vector of the coordinate subspace, as a subspace element. -/
+noncomputable def coordVec (i : Fin n) : coordSubspace (𝕜 := 𝕜) ι :=
+  ⟨ee (ι i), mem_coordSubspace ι i⟩
+
+/-- The natural basis vectors of the coordinate subspace are orthonormal
+(uses injectivity of `ι`). -/
+theorem orthonormal_coordVec (hι : Function.Injective ι) :
+    Orthonormal 𝕜 (coordVec (𝕜 := 𝕜) ι) := by
+  have hbase : Orthonormal 𝕜 (fun i : Fin n => ee (𝕜 := 𝕜) (ι i)) :=
+    (EuclideanSpace.orthonormal_single (𝕜 := 𝕜) (ι := Fin (n + m))).comp _ hι
+  rw [orthonormal_iff_ite] at hbase ⊢
+  intro i i'
+  rw [Submodule.coe_inner]
+  exact hbase i i'
+
+/-- The natural basis vectors span the coordinate subspace. -/
+theorem span_coordVec_top :
+    (⊤ : Submodule 𝕜 (coordSubspace (𝕜 := 𝕜) ι)) ≤
+      Submodule.span 𝕜 (Set.range (coordVec (𝕜 := 𝕜) ι)) := by
+  rw [top_le_iff]
+  apply Submodule.map_injective_of_injective
+    (Submodule.subtype_injective (coordSubspace (𝕜 := 𝕜) ι))
+  rw [Submodule.map_subtype_top, Submodule.map_span]
+  have : (coordSubspace (𝕜 := 𝕜) ι).subtype '' Set.range (coordVec (𝕜 := 𝕜) ι)
+      = Set.range (fun i : Fin n => ee (𝕜 := 𝕜) (ι i)) := by
+    rw [← Set.range_comp]; rfl
+  rw [this, coordSubspace]
+
+/-- An orthonormal basis of the coordinate subspace: `coordBasis i = e_{ι i}`. -/
+noncomputable def coordBasis (hι : Function.Injective ι) :
+    OrthonormalBasis (Fin n) 𝕜 (coordSubspace (𝕜 := 𝕜) ι) :=
+  OrthonormalBasis.mk (orthonormal_coordVec ι hι) (span_coordVec_top ι)
+
+@[simp] theorem coordBasis_apply (hι : Function.Injective ι) (i : Fin n) :
+    coordBasis (𝕜 := 𝕜) ι hι i = coordVec ι i := by
+  rw [coordBasis, OrthonormalBasis.coe_mk]
+
+/-- The coordinate isometry `EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H`, `e_i ↦ e_{ι i}`. -/
+noncomputable def coordEquiv (hι : Function.Injective ι) :
+    EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ[𝕜] coordSubspace (𝕜 := 𝕜) ι :=
+  (coordBasis (𝕜 := 𝕜) ι hι).repr.symm
+
+theorem coordEquiv_eq_sum (hι : Function.Injective ι) (x : EuclideanSpace 𝕜 (Fin n)) :
+    coordEquiv (𝕜 := 𝕜) ι hι x = ∑ i, x i • coordBasis (𝕜 := 𝕜) ι hι i := by
+  rw [coordEquiv, OrthonormalBasis.sum_repr_symm]
+
+/-- Reading off a coordinate of the isometry image against the basis returns the
+input coordinate: `⟪coordBasis i', coordEquiv x⟫ = x i'`. -/
+theorem coordBasis_inner_coordEquiv (hι : Function.Injective ι)
+    (x : EuclideanSpace 𝕜 (Fin n)) (i' : Fin n) :
+    @inner 𝕜 _ _ (coordBasis (𝕜 := 𝕜) ι hι i') (coordEquiv (𝕜 := 𝕜) ι hι x) = x i' := by
+  rw [← OrthonormalBasis.repr_apply_apply]
+  have h : (coordBasis (𝕜 := 𝕜) ι hι).repr (coordEquiv (𝕜 := 𝕜) ι hι x) = x :=
+    (coordBasis (𝕜 := 𝕜) ι hι).repr.apply_symm_apply x
+  rw [h]
+
+/-- The coordinate subspace has dimension `n`: it is a codimension-`m` subspace of
+the `(n+m)`-dimensional ambient space. -/
+theorem finrank_coordSubspace (hι : Function.Injective ι) :
+    Module.finrank 𝕜 (coordSubspace (𝕜 := 𝕜) ι) = n := by
+  have hli : LinearIndependent 𝕜 (fun i : Fin n => ee (𝕜 := 𝕜) (ι i)) :=
+    ((EuclideanSpace.orthonormal_single (𝕜 := 𝕜) (ι := Fin (n + m))).comp _ hι).linearIndependent
+  rw [coordSubspace, finrank_span_eq_card hli, Fintype.card_fin]
+
+/-! ## The intertwining: the compression is the submatrix operator -/
+
+variable (A : Matrix (Fin (n + m)) (Fin (n + m)) 𝕜)
+
+/-- **Main identification.** The orthogonal compression of `toEuclideanLin A` to
+the coordinate subspace `H`, read as a sesquilinear form on the natural basis
+`(e_{ι i})` of `H`, is exactly the principal submatrix `A.submatrix ι ι`:
+
+`⟪e_{ι i'}, compress (toEuclideanLin A) H e_{ι i}⟫ = (A.submatrix ι ι) i' i`. -/
+theorem compress_inner_eq_submatrix (hι : Function.Injective ι) (i i' : Fin n) :
+    @inner 𝕜 _ _ (coordBasis (𝕜 := 𝕜) ι hι i')
+        (compress (Matrix.toEuclideanLin A) (coordSubspace ι) (coordBasis (𝕜 := 𝕜) ι hι i))
+      = (A.submatrix ι ι) i' i := by
+  rw [coordBasis_apply, coordBasis_apply, inner_compress_eq]
+  exact inner_single_toEuclideanLin_single A (ι i') (ι i)
+
+/-- **The intertwining on a single coordinate basis vector.** -/
+theorem compress_coordBasis (hι : Function.Injective ι) (i₀ : Fin n) :
+    compress (Matrix.toEuclideanLin A) (coordSubspace ι) (coordBasis (𝕜 := 𝕜) ι hι i₀)
+      = coordEquiv (𝕜 := 𝕜) ι hι
+          (Matrix.toEuclideanLin (A.submatrix ι ι) (EuclideanSpace.single i₀ (1 : 𝕜))) := by
+  apply (coordBasis (𝕜 := 𝕜) ι hι).repr.injective
+  ext i'
+  rw [OrthonormalBasis.repr_apply_apply, OrthonormalBasis.repr_apply_apply,
+    coordBasis_inner_coordEquiv, compress_inner_eq_submatrix]
+  simp [Matrix.toEuclideanLin_apply, Matrix.mulVec_single, PiLp.toLp_apply,
+    EuclideanSpace.ofLp_single]
+
+/-- **The intertwining.** Under the coordinate isometry `coordEquiv`, the
+orthogonal compression of `toEuclideanLin A` to the coordinate subspace is the
+operator of the principal submatrix `A.submatrix ι ι`:
+
+  `compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin A' x)`. -/
+theorem compress_intertwine (hι : Function.Injective ι) (x : EuclideanSpace 𝕜 (Fin n)) :
+    compress (Matrix.toEuclideanLin A) (coordSubspace ι) (coordEquiv (𝕜 := 𝕜) ι hι x)
+      = coordEquiv (𝕜 := 𝕜) ι hι (Matrix.toEuclideanLin (A.submatrix ι ι) x) := by
+  have hx : x = ∑ i, x i • EuclideanSpace.single i (1 : 𝕜) := by
+    conv_lhs => rw [← (EuclideanSpace.basisFun (Fin n) 𝕜).sum_repr x]
+    simp_rw [EuclideanSpace.basisFun_repr, EuclideanSpace.basisFun_apply]
+  rw [coordEquiv_eq_sum, map_sum]
+  conv_rhs => rw [hx, map_sum]
+  simp_rw [map_smul, compress_coordBasis, map_sum, map_smul]
+
+/-! ## The eigenvalue interlacing corollary -/
+
+/-- **Poincaré separation for a principal submatrix (operator-eigenvalue form).**
+
+For a Hermitian `(n+m) × (n+m)` matrix `A` and an injective index map
+`ι : Fin n → Fin (n+m)`, write `λ` for the descending eigenvalues of
+`toEuclideanLin A` and `μ` for those of the `n × n` principal submatrix
+`A.submatrix ι ι`. Then for every `k : Fin n`:
+
+  `λ ⟨k+m⟩ ≤ μ k`   and   `μ k ≤ λ ⟨k⟩`,
+
+i.e. `λ_{k+m} ≤ μ_k ≤ λ_k`. This is the assembly of the geometric identification
+`compress_intertwine` with the abstract `poincare_separation`. The
+codimension-one `principalSubmatrix_eigenvalues_interlacing` is the special case
+`m = 1`, `ι = j.succAbove`. -/
+theorem principalSubmatrix_poincare_separation
+    (hA : A.IsHermitian) (hι : Function.Injective ι) (k : Fin n) :
+    (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace_fin
+          ⟨(k : ℕ) + m, by have := k.isLt; omega⟩
+        ≤ (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix ι)).eigenvalues
+            finrank_euclideanSpace_fin k
+      ∧ (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix ι)).eigenvalues
+            finrank_euclideanSpace_fin k
+          ≤ (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace_fin
+              ⟨(k : ℕ), by have := k.isLt; omega⟩ := by
+  -- Rayleigh agreement of the orthogonal compression.
+  have hRay : ∀ y : coordSubspace (𝕜 := 𝕜) ι, y ≠ 0 →
+      RCLike.re (@inner 𝕜 _ _
+          (compress (Matrix.toEuclideanLin A) (coordSubspace ι) y) y) / ‖y‖ ^ 2
+        = RCLike.re (@inner 𝕜 (EuclideanSpace 𝕜 (Fin (n + m))) _
+            (Matrix.toEuclideanLin A (y : EuclideanSpace 𝕜 (Fin (n + m))))
+            (y : EuclideanSpace 𝕜 (Fin (n + m)))) /
+            ‖(y : EuclideanSpace 𝕜 (Fin (n + m)))‖ ^ 2 := by
+    intro y _
+    have hi : @inner 𝕜 _ _ (compress (Matrix.toEuclideanLin A) (coordSubspace ι) y) y
+        = @inner 𝕜 (EuclideanSpace 𝕜 (Fin (n + m))) _
+            (Matrix.toEuclideanLin A (y : EuclideanSpace 𝕜 (Fin (n + m))))
+            (y : EuclideanSpace 𝕜 (Fin (n + m))) := by
+      rw [compress_apply, Submodule.inner_orthogonalProjection_eq_of_mem_right]
+    rw [hi, Submodule.coe_norm]
+  exact interlacing_poincare_of_intertwine
+    (T := Matrix.toEuclideanLin A)
+    (b := (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvectorBasis finrank_euclideanSpace_fin)
+    (lam := (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace_fin)
+    (hT := (Matrix.isHermitian_iff_isSymmetric.1 hA).apply_eigenvectorBasis _)
+    (hlam := (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues_antitone _)
+    (Hs := coordSubspace ι) (hHdim := finrank_coordSubspace ι hι)
+    (TH := compress (Matrix.toEuclideanLin A) (coordSubspace ι))
+    (T' := Matrix.toEuclideanLin (A.submatrix ι ι))
+    (b' := (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix ι)).eigenvectorBasis
+      finrank_euclideanSpace_fin)
+    (mu := (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix ι)).eigenvalues
+      finrank_euclideanSpace_fin)
+    (hT' := (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix ι)).apply_eigenvectorBasis _)
+    (hmu := (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix ι)).eigenvalues_antitone _)
+    (ee' := coordEquiv ι hι)
+    (hinter := compress_intertwine (𝕜 := 𝕜) (ι := ι) (A := A) hι)
+    (hRay := hRay) (k := k)
+
+/-- **Poincaré separation for a principal submatrix (literal `eigenvalues₀` form).**
+
+The descending eigenvalues `Matrix.IsHermitian.eigenvalues₀` of a Hermitian
+`(n+m) × (n+m)` matrix `A` and of its `n × n` principal submatrix
+`A.submatrix ι ι` (for injective `ι`) separate:
+
+  `A.eigenvalues₀ ⟨k+m⟩ ≤ (A.submatrix ι ι).eigenvalues₀ k ≤ A.eigenvalues₀ ⟨k⟩`,
+
+read through the index identifications `Fin (n+m) ≃ Fin (card)` and
+`Fin n ≃ Fin (card)`. This is the literal matrix statement of the Poincaré
+separation theorem for arbitrary principal submatrices. -/
+theorem eigenvalues₀_principalSubmatrix_poincare
+    (hA : A.IsHermitian) (hι : Function.Injective ι) (k : Fin n) :
+    hA.eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm ⟨(k : ℕ) + m, by have := k.isLt; omega⟩)
+        ≤ (hA.submatrix ι).eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm k)
+      ∧ (hA.submatrix ι).eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm k)
+          ≤ hA.eigenvalues₀
+              (Fin.cast (Fintype.card_fin _).symm ⟨(k : ℕ), by have := k.isLt; omega⟩) := by
+  have bridgeA : ∀ i : Fin (n + m),
+      (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace_fin i
+        = hA.eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm i) := fun i =>
+    eigenvalues_finrank_congr _ finrank_euclideanSpace_fin finrank_euclideanSpace i
+  have bridgeA' : ∀ i : Fin n,
+      (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix ι)).eigenvalues
+          finrank_euclideanSpace_fin i
+        = (hA.submatrix ι).eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm i) :=
+    fun i => eigenvalues_finrank_congr _ finrank_euclideanSpace_fin finrank_euclideanSpace i
+  obtain ⟨hlo, hup⟩ := principalSubmatrix_poincare_separation (𝕜 := 𝕜) (ι := ι) A hA hι k
+  rw [bridgeA, bridgeA'] at hlo
+  rw [bridgeA', bridgeA] at hup
+  exact ⟨hlo, hup⟩
+
+end CauchyInterlacingOQ01OQ01OQ01OQ03

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 5, "endLine": 60 },
+    "type": "concept",
+    "title": "The Theorem the Chain Was Building Toward",
+    "content": "The module docstring frames the contribution. The parent chain built two halves separately: the codimension-one matrix interlacing (oq-01-oq-01-oq-02, using the specific injection j.succAbove to delete one row/column) and the abstract arbitrary-codimension operator separation (CauchyInterlacingPoincare). This file joins them into the matrix-form Poincaré separation theorem for an ARBITRARY n×n principal submatrix A.submatrix ι ι, selected by any injective index map ι : Fin n → Fin (n+m). The result holds over any RCLike field 𝕜 (ℝ and ℂ), with 0 sorries and 0 axioms; it is a research file intentionally not registered in Proofs.lean.",
+    "mathContext": "Goal: $\\lambda_{k+m}(A) \\le \\mu_k(A.\\mathrm{submatrix}\\ \\iota\\ \\iota) \\le \\lambda_k(A)$ for a Hermitian $A$ of size $n+m$ and injective $\\iota$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Poincaré separation", "Cauchy interlacing", "principal submatrix", "min-max principle"],
+    "prerequisites": ["Hermitian matrices", "self-adjoint operators", "eigenvalues"]
+  },
+  {
+    "id": "ann-finrank-congr",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 74, "endLine": 80 },
+    "type": "insight",
+    "title": "Eigenvalues Do Not Depend on the finrank Proof",
+    "content": "eigenvalues_finrank_congr: Mathlib's LinearMap.IsSymmetric.eigenvalues takes a proof that finrank E = p as an argument, but the result depends on that proof only through the value p. Two proofs of finrank = p and finrank = p' yield the same tuple up to the forced cast p = p'. This tiny bookkeeping lemma is what lets the operator-level statement (indexed via finrank_euclideanSpace_fin) be re-read as the literal Matrix.IsHermitian.eigenvalues₀ statement (indexed via Fintype.card).",
+    "mathContext": "The sorted eigenvalue tuple is a function of the operator and the dimension value alone, not of the dimension proof term.",
+    "significance": "supporting",
+    "relatedConcepts": ["proof irrelevance", "eigenvalue indexing", "Fin.cast"],
+    "prerequisites": ["LinearMap.IsSymmetric.eigenvalues"]
+  },
+  {
+    "id": "ann-transfer-engine",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 97, "endLine": 117 },
+    "type": "insight",
+    "title": "Transferring Poincaré Separation Across an Isometry",
+    "content": "interlacing_poincare_of_intertwine is the transfer engine. Suppose a symmetric operator T on V (dimension n+m) has antitone eigendata, Hs ≤ V is a codimension-m subspace carrying a compression operator TH, and an isometry ee' : E ≃ₗᵢ Hs intertwines TH with a model operator T' on E (TH (ee' x) = ee' (T' x)), with TH satisfying the compression's Rayleigh agreement. Then the eigenvalues separate as lam ⟨k+m⟩ ≤ mu k ≤ lam ⟨k⟩. The key move: instead of proving TH and T' have equal spectra by uniqueness, push T''s eigenbasis b' through ee' with OrthonormalBasis.map — the image is an eigenbasis of TH with the SAME eigenvalue tuple mu. This eigendata is handed straight to the abstract poincare_separation.",
+    "mathContext": "Isometric intertwining carries eigenbases (hence sorted spectra) from the model operator to the compression; no eigenvalue-uniqueness lemma is required.",
+    "significance": "key",
+    "relatedConcepts": ["unitary equivalence", "OrthonormalBasis.map", "Poincaré separation", "Rayleigh quotient"],
+    "prerequisites": ["linear isometry equivalence", "orthonormal bases", "poincare_separation"]
+  },
+  {
+    "id": "ann-coordinate-subspace",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 139, "endLine": 209 },
+    "type": "insight",
+    "title": "The Coordinate Subspace for an Arbitrary Injection",
+    "content": "The geometric heart, generalising the parent's codimension-one construction from j.succAbove to any injective ι : Fin n → Fin (n+m). coordSubspace ι is the span of the kept coordinate axes {e_{ι i}}. Injectivity of ι makes these orthonormal — orthonormal_coordVec applies EuclideanSpace.orthonormal_single composed with ι — and finrank_coordSubspace reads off dimension n (codimension m) via finrank_span_eq_card. coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H is the coordinate isometry e_i ↦ e_{ι i}, built as the inverse of the coordBasis representation. Only injectivity of ι is ever used, which is exactly why the specific j.succAbove of the codimension-one file can be swapped for a general injection.",
+    "mathContext": "H = span {e_{ι i}} has dim n and an explicit isometry from the model space EuclideanSpace 𝕜 (Fin n).",
+    "significance": "key",
+    "relatedConcepts": ["coordinate subspace", "orthonormal basis", "linear isometry", "codimension"],
+    "prerequisites": ["EuclideanSpace.orthonormal_single", "finrank_span_eq_card", "OrthonormalBasis.mk"]
+  },
+  {
+    "id": "ann-intertwining",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 220, "endLine": 252 },
+    "type": "insight",
+    "title": "The Compression Is Literally the Principal Submatrix",
+    "content": "compress_inner_eq_submatrix shows the orthogonal compression of toEuclideanLin A to the coordinate subspace, read on the basis (e_{ι i}), has entry ⟪e_{ι i'}, compress ... e_{ι i}⟫ = A (ι i') (ι i) = (A.submatrix ι ι) i' i: the orthogonal projection collapses away (inner_compress_eq) and the entry formula ⟪e_a, toEuclideanLin A e_b⟫ = A a b finishes it. compress_coordBasis and compress_intertwine lift this pointwise identity to the operator identity compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin (A.submatrix ι ι) x), by expanding x in the standard basis and pushing compress, the submatrix operator, and coordEquiv through the sum with map_sum/map_smul (so the isometry is never unfolded).",
+    "mathContext": "Under coordEquiv the abstract compression of toEuclideanLin A becomes exactly the concrete submatrix operator toEuclideanLin (A.submatrix ι ι).",
+    "significance": "key",
+    "relatedConcepts": ["orthogonal compression", "principal submatrix", "sesquilinear form", "intertwining"],
+    "prerequisites": ["orthogonal projection", "Matrix.toEuclideanLin", "Matrix.submatrix"]
+  },
+  {
+    "id": "ann-separation",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 269, "endLine": 322 },
+    "type": "insight",
+    "title": "Poincaré Separation in Operator-Eigenvalue Form",
+    "content": "principalSubmatrix_poincare_separation assembles the theorem: λ ⟨k+m⟩ ≤ μ k ≤ λ ⟨k⟩ for the descending eigenvalues λ of toEuclideanLin A and μ of toEuclideanLin (A.submatrix ι ι). The compression's Rayleigh agreement is discharged internally (the orthogonal projection is invisible to inner products against subspace vectors, via inner_orthogonalProjection_eq_of_mem_right and Submodule.coe_norm), and everything is fed to interlacing_poincare_of_intertwine with T := toEuclideanLin A, T' := toEuclideanLin (A.submatrix ι ι), and ee' := coordEquiv, intertwined by compress_intertwine. The index shift k+m is the codimension m.",
+    "mathContext": "λ_{k+m} ≤ μ_k ≤ λ_k — the interlacing indices differ by exactly the number of deleted coordinates.",
+    "significance": "key",
+    "relatedConcepts": ["Poincaré separation", "Rayleigh quotient", "eigenvalue interlacing"],
+    "prerequisites": ["interlacing_poincare_of_intertwine", "orthogonal projection adjoint identity"]
+  },
+  {
+    "id": "ann-eigenvalues0",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 324, "endLine": 343 },
+    "type": "insight",
+    "title": "The Literal Matrix Statement",
+    "content": "eigenvalues₀_principalSubmatrix_poincare restates the separation directly in terms of Matrix.IsHermitian.eigenvalues₀ — the sorted eigenvalue tuples of the Hermitian matrices A and A.submatrix ι ι themselves — read through the index identifications Fin (n+m) ≃ Fin (card) and Fin n ≃ Fin (card). The bridge is the two eigenvalues_finrank_congr rewrites turning the operator-indexed statement into the eigenvalues₀-indexed one. This is the textbook form of the Poincaré separation theorem for an arbitrary m×m-deleted principal submatrix, which is absent from Mathlib.",
+    "mathContext": "A.eigenvalues₀ ⟨k+m⟩ ≤ (A.submatrix ι ι).eigenvalues₀ k ≤ A.eigenvalues₀ ⟨k⟩.",
+    "significance": "key",
+    "relatedConcepts": ["Matrix.IsHermitian.eigenvalues₀", "principal submatrix", "Poincaré separation"],
+    "prerequisites": ["eigenvalues_finrank_congr", "principalSubmatrix_poincare_separation"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03/index.ts
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchyInterlacingOQ01OQ01OQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchyInterlacingTheoremOq01Oq01Oq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchyInterlacingTheoremOq01Oq01Oq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchyInterlacingTheoremOq01Oq01Oq01Oq03Data: ProofData = {
+  proof: cauchyInterlacingTheoremOq01Oq01Oq01Oq03Proof,
+  annotations: cauchyInterlacingTheoremOq01Oq01Oq01Oq03Annotations,
+}

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03",
+  "title": "Poincaré Separation for m×m Principal Submatrices (Matrix Form)",
+  "slug": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03",
+  "description": "The parent chain built two halves of the classical eigenvalue interlacing theory but left a seam between them. On the concrete side, cauchy-interlacing-theorem-oq-01-oq-01-oq-02 proves codimension-one Cauchy interlacing for matrices: deleting one row/column j from a Hermitian (n+1)×(n+1) matrix A gives a principal submatrix A.submatrix j.succAbove j.succAbove whose eigenvalues interlace A's, λ_{k+1} ≤ μ_k ≤ λ_k. On the abstract side, CauchyInterlacingPoincare proves the arbitrary-codimension Poincaré separation theorem at the operator level: a symmetric operator on an (n+m)-dimensional space compressed to an n-dimensional subspace has eigenvalues separating as λ_{k+m} ≤ μ_k ≤ λ_k. This entry answers the parent's third open question by joining the two into the theorem the whole chain was building toward: Poincaré separation at the level of concrete matrices for an ARBITRARY n×n principal submatrix. Fix a Hermitian (n+m)×(n+m) matrix A and an injective index map ι : Fin n → Fin (n+m) selecting which n rows/columns to keep; then the eigenvalues of the principal submatrix A.submatrix ι ι separate those of A: λ_{k+m}(A) ≤ μ_k(A.submatrix ι ι) ≤ λ_k(A) for every k. The mechanism generalises the codimension-one file verbatim, replacing the specific injection j.succAbove by an arbitrary injective ι: the coordinate subspace H = span {e_{ι i}} is n-dimensional (finrank_coordSubspace, using injectivity of ι), the orthogonal compression of toEuclideanLin A to H is exactly A.submatrix ι ι read on the basis (e_{ι i}) (compress_inner_eq_submatrix), and under the coordinate isometry coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H, e_i ↦ e_{ι i}, the compression IS the submatrix operator (compress_intertwine). Pushing the submatrix's spectral eigenbasis through coordEquiv gives an eigenbasis of the compression with the same antitone eigenvalues, feeding the abstract poincare_separation with no eigenvalue-uniqueness lemma required. Both the operator-eigenvalue form and the literal Matrix.IsHermitian.eigenvalues₀ form are delivered. The codimension-one file is the special case m = 1, ι = j.succAbove. Holds over any RCLike field (ℝ and ℂ), 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Poincaré (separation theorem); formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyInterlacingOQ01OQ01OQ01OQ03.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral",
+      "hermitian",
+      "cauchy-interlacing",
+      "poincare-separation",
+      "eigenvalues",
+      "principal-submatrix",
+      "min-max"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.IsHermitian.eigenvalues₀",
+        "description": "the sorted (descending) real eigenvalue tuple of a Hermitian matrix — the concrete object the literal statement is phrased in",
+        "module": "Mathlib.LinearAlgebra.Matrix.Spectrum"
+      },
+      {
+        "theorem": "Matrix.isHermitian_iff_isSymmetric",
+        "description": "A.IsHermitian ↔ (toEuclideanLin A).IsSymmetric — bridges the matrix and operator pictures of self-adjointness",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric.eigenvalues",
+        "description": "the sorted antitone eigenvalue tuple of a self-adjoint operator on a finite-dimensional inner product space",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "EuclideanSpace.orthonormal_single",
+        "description": "the standard basis vectors single a 1 of EuclideanSpace 𝕜 (Fin N) are orthonormal — composed with an injection ι gives orthonormality of the kept coordinate axes",
+        "module": "Mathlib.Analysis.InnerProductSpace.EuclideanDist"
+      },
+      {
+        "theorem": "OrthonormalBasis.map",
+        "description": "transport an orthonormal basis along a linear isometry equivalence — used to push the submatrix eigenbasis through the coordinate isometry, producing an eigenbasis of the compression with identical eigenvalues",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Submodule.inner_orthogonalProjection_eq_of_mem_right",
+        "description": "the orthogonal projection is invisible to inner products against a vector already in the subspace — discharges the Rayleigh-agreement hypothesis of the compression",
+        "module": "Mathlib.Analysis.InnerProductSpace.Projection"
+      },
+      {
+        "theorem": "finrank_span_eq_card",
+        "description": "the span of a linearly independent family has dimension equal to its cardinality — gives dim (coordinate subspace) = n from injectivity of ι",
+        "module": "Mathlib.LinearAlgebra.Dimension.Finrank"
+      }
+    ],
+    "originalContributions": [
+      "coordSubspace / finrank_coordSubspace: the coordinate subspace span {e_{ι i}} for an arbitrary injective index map ι : Fin n → Fin (n+m), shown to have dimension n (codimension m) — the general-injection replacement for the parent's codimension-one coordinateHyperplane built from j.succAbove",
+      "compress_inner_eq_submatrix: the orthogonal compression of toEuclideanLin A to the coordinate subspace, read on the basis (e_{ι i}), is exactly the principal submatrix A.submatrix ι ι — the sesquilinear-form identification for an arbitrary principal submatrix",
+      "compress_intertwine: under the coordinate isometry coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H, the compression of toEuclideanLin A equals the submatrix operator toEuclideanLin (A.submatrix ι ι)",
+      "interlacing_poincare_of_intertwine: the arbitrary-codimension transfer engine — pushing the model operator's eigenbasis through an intertwining isometry produces an eigenbasis of the compression with identical eigenvalues, feeding poincare_separation without any eigenvalue-uniqueness lemma",
+      "principalSubmatrix_poincare_separation: Poincaré separation in operator-eigenvalue form, λ_{k+m} ≤ μ_k ≤ λ_k for the descending eigenvalues of toEuclideanLin A and of toEuclideanLin (A.submatrix ι ι)",
+      "eigenvalues₀_principalSubmatrix_poincare: the literal matrix statement in terms of Matrix.IsHermitian.eigenvalues₀ — the m×m principal-submatrix Poincaré separation theorem, absent from Mathlib"
+    ],
+    "openQuestions": [
+      "Recover the codimension-one principalSubmatrix_eigenvalues_interlacing as the literal special case m = 1, ι = j.succAbove, confirming this entry is a faithful generalisation (the two agree after the index identifications k.succ = ⟨k+1⟩, k.castSucc = ⟨k⟩).",
+      "Derive the Cauchy interlacing inequalities for eigenvalues of A and A.submatrix ι ι under a NON-injective or partial index map by restricting to the injective core, and state the interlacing for arbitrary (not-necessarily-contiguous) principal submatrices selected by a Finset.",
+      "Upstream the matrix-form Poincaré separation to Mathlib as Matrix.IsHermitian.eigenvalues₀_submatrix_interlacing, together with the operator-level poincare_separation."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Poincaré separation theorem (Henri Poincaré, 1890) generalises Cauchy's 1829 interlacing theorem from a single deleted row/column to an arbitrary m-fold compression: for a Hermitian matrix A of size n+m and any n×n principal submatrix B (obtained by keeping n of the coordinates), the descending eigenvalues satisfy λ_k(A) ≥ μ_k(B) ≥ λ_{k+m}(A). It is a cornerstone of the variational theory of eigenvalues — the Courant–Fischer min-max principle, Weyl's monotonicity inequalities, and the Cauchy interlacing theorem are all special cases or close relatives — and it underlies the analysis of principal-submatrix (deflation) methods in numerical linear algebra. Mathlib provides the finite-dimensional spectral theorem and a sorted eigenvalue tuple for self-adjoint operators, and the parent chain built both the codimension-one matrix interlacing and the abstract arbitrary-codimension operator separation. What remained was to identify the compression to a coordinate subspace with a concrete principal submatrix for an arbitrary choice of kept coordinates, and read off the matrix-level theorem.",
+    "problemStatement": "Prove the Poincaré separation theorem at the level of concrete matrices for an arbitrary n×n principal submatrix. Concretely: for a Hermitian (n+m)×(n+m) matrix A over an RCLike field and an injective index map ι : Fin n → Fin (n+m), let λ be the descending eigenvalues of A and μ those of the principal submatrix A.submatrix ι ι. Then for every k : Fin n, λ_{k+m} ≤ μ_k ≤ λ_k, in both the operator-eigenvalue and the literal Matrix.IsHermitian.eigenvalues₀ formulations.",
+    "proofStrategy": "Generalise the codimension-one matrix bridge from the specific injection j.succAbove to an arbitrary injective ι, then feed the already-proven arbitrary-codimension operator separation. (1) coordSubspace ι := span {e_{ι i}} is the span of the kept coordinate axes; injectivity of ι makes the (e_{ι i}) orthonormal (via EuclideanSpace.orthonormal_single composed with ι), so finrank_coordSubspace gives dim = n (codimension m). (2) compress_inner_eq_submatrix: the orthogonal compression of toEuclideanLin A to this subspace, read on the basis (e_{ι i}), has sesquilinear form exactly A.submatrix ι ι, because the orthogonal projection is invisible to inner products against vectors already in the subspace and ⟪e_a, toEuclideanLin A e_b⟫ = A a b. (3) compress_intertwine: under the coordinate isometry coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H, e_i ↦ e_{ι i}, the compression IS toEuclideanLin (A.submatrix ι ι). (4) interlacing_poincare_of_intertwine: pushing the submatrix operator's spectral eigenbasis through coordEquiv (OrthonormalBasis.map) produces an eigenbasis of the compression with the SAME antitone eigenvalues, so no eigenvalue-uniqueness lemma is needed; this data is fed to the abstract poincare_separation. (5) The literal eigenvalues₀ form follows by the index-bookkeeping lemma eigenvalues_finrank_congr bridging the finrank_euclideanSpace_fin indexing to Matrix.IsHermitian.eigenvalues₀.",
+    "keyInsights": [
+      "**One injection replaces the whole codimension-one apparatus.** The parent file is written for the specific injection j.succAbove : Fin n ↪ Fin (n+1) (delete one coordinate). Every geometric step — orthonormality, the span, the coordinate isometry, the sesquilinear identification — uses only that j.succAbove is injective. Replacing it by an arbitrary injective ι : Fin n → Fin (n+m) generalises from codimension one to codimension m with no new mathematics.",
+      "**The compression is literally the principal submatrix.** Reading the orthogonal compression of toEuclideanLin A on the kept coordinate axes (e_{ι i}) reproduces exactly the entries A (ι i') (ι i) = (A.submatrix ι ι) i' i. The abstract 'compress to a subspace' operation and the concrete 'delete the other rows and columns' operation coincide on the nose.",
+      "**No eigenvalue-uniqueness lemma is needed.** Rather than proving the compression and the submatrix operator have equal spectra by a uniqueness-of-sorted-eigenvalues argument, one simply transports the submatrix's spectral eigenbasis through the coordinate isometry (OrthonormalBasis.map). The image is an eigenbasis of the compression with the identical eigenvalue tuple μ, which the abstract Poincaré theorem accepts directly.",
+      "**The index shift λ_{k+m} is exactly the codimension.** The lower interlacing index is k + m, where m is the codimension (number of deleted coordinates). At m = 1 this is the classical Cauchy shift k+1; the general m recovers the full Poincaré separation, uniformly in how many coordinates are dropped.",
+      "**Everything works over any RCLike field.** The eigenvalues live in ℝ via self-adjointness and the argument never orders 𝕜, so the theorem holds identically for real symmetric and complex Hermitian matrices."
+    ],
+    "prerequisites": [
+      "Self-adjoint operators and the finite-dimensional spectral theorem (Mathlib.Analysis.InnerProductSpace.Spectrum)",
+      "The min-max / Courant–Fischer characterisation of eigenvalues, packaged in the parent CauchyInterlacingPoincare as poincare_separation",
+      "Orthogonal projection and compression of an operator to a subspace",
+      "Principal submatrices, Matrix.toEuclideanLin, and Matrix.IsHermitian.eigenvalues₀"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Background and Statement",
+      "startLine": 3,
+      "endLine": 60,
+      "summary": "Docstring: describes the seam between the codimension-one matrix interlacing (oq-01-oq-01-oq-02) and the abstract arbitrary-codimension operator separation (CauchyInterlacingPoincare), states the joined theorem (matrix-form Poincaré separation for an arbitrary n×n principal submatrix A.submatrix ι ι via an injective ι), and sketches the generalisation from j.succAbove to a general injection. Notes scope: any RCLike field, 0 sorries, 0 axioms, research file.",
+      "mathContext": "λ_{k+m}(A) ≤ μ_k(A.submatrix ι ι) ≤ λ_k(A) — Poincaré separation, generalising Cauchy's codimension-one interlacing."
+    },
+    {
+      "id": "sec-finrank-congr",
+      "title": "Eigenvalues Independent of the finrank Proof",
+      "startLine": 69,
+      "endLine": 80,
+      "summary": "eigenvalues_finrank_congr: LinearMap.IsSymmetric.eigenvalues depends on the dimension proof only through its stated value, so two proofs of finrank = p and finrank = p' give the same eigenvalue list up to the forced equality p = p'. Pure index bookkeeping used to bridge to the eigenvalues₀ statement.",
+      "mathContext": "The sorted eigenvalue tuple is well-defined independent of which proof of finrank E = p is supplied."
+    },
+    {
+      "id": "sec-transfer-engine",
+      "title": "The Poincaré Transfer Engine",
+      "startLine": 82,
+      "endLine": 117,
+      "summary": "interlacing_poincare_of_intertwine: the arbitrary-codimension transfer lemma. Given a symmetric T on V (dim n+m) with antitone eigendata, a codimension-m subspace Hs, a compression operator TH intertwined via an isometry ee' with a model operator T' on E, and the Rayleigh-agreement hypothesis, the eigenvalues separate as lam ⟨k+m⟩ ≤ mu k ≤ lam ⟨k⟩. Proof: push T''s eigenbasis through ee' (OrthonormalBasis.map) to get an eigenbasis of TH with the same eigenvalues mu, then invoke the abstract poincare_separation.",
+      "mathContext": "Isometric intertwining transfers Poincaré separation from the model operator to the compression with no eigenvalue-uniqueness argument."
+    },
+    {
+      "id": "sec-coordinate-subspace",
+      "title": "The Coordinate Subspace for a General Injection",
+      "startLine": 119,
+      "endLine": 209,
+      "summary": "For an arbitrary injective ι : Fin n → Fin (n+m): inner_single_toEuclideanLin_single (matrix entries as ⟪e_a, toEuclideanLin A e_b⟫ = A a b), coordSubspace ι = span {e_{ι i}}, its natural basis vectors coordVec, their orthonormality (orthonormal_coordVec, from EuclideanSpace.orthonormal_single ∘ ι) and span (span_coordVec_top), the assembled orthonormal coordBasis and the coordinate isometry coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H sending e_i ↦ e_{ι i}, and finrank_coordSubspace = n via finrank_span_eq_card.",
+      "mathContext": "The kept coordinate axes span an n-dimensional (codimension-m) subspace with an explicit coordinate isometry from the model space."
+    },
+    {
+      "id": "sec-intertwining",
+      "title": "The Compression Is the Submatrix Operator",
+      "startLine": 211,
+      "endLine": 252,
+      "summary": "compress_inner_eq_submatrix: the compression of toEuclideanLin A to the coordinate subspace, read on (e_{ι i}), is exactly (A.submatrix ι ι) i' i (collapsing the projection via inner_compress_eq, then the entry formula). compress_coordBasis and compress_intertwine lift this to the operator identity compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin (A.submatrix ι ι) x) by expanding x in the standard basis and pushing through with map_sum/map_smul.",
+      "mathContext": "Under coordEquiv, the orthogonal compression of toEuclideanLin A is precisely toEuclideanLin (A.submatrix ι ι)."
+    },
+    {
+      "id": "sec-eigenvalue-corollary",
+      "title": "The Poincaré Separation Corollary",
+      "startLine": 254,
+      "endLine": 344,
+      "summary": "principalSubmatrix_poincare_separation: operator-eigenvalue form, λ_{k+m} ≤ μ_k ≤ λ_k for the descending eigenvalues of toEuclideanLin A and toEuclideanLin (A.submatrix ι ι), assembled by discharging the compression's Rayleigh agreement and feeding interlacing_poincare_of_intertwine. eigenvalues₀_principalSubmatrix_poincare: the literal Matrix.IsHermitian.eigenvalues₀ statement, obtained via the eigenvalues_finrank_congr index bridge.",
+      "mathContext": "The m×m principal-submatrix Poincaré separation theorem in both operator and literal matrix forms."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified (0 sorries, 0 axioms, any RCLike field): for a Hermitian (n+m)×(n+m) matrix A and an injective index map ι : Fin n → Fin (n+m), the descending eigenvalues of the n×n principal submatrix A.submatrix ι ι separate those of A, λ_{k+m}(A) ≤ μ_k ≤ λ_k(A), in both the operator-eigenvalue form (principalSubmatrix_poincare_separation) and the literal Matrix.IsHermitian.eigenvalues₀ form (eigenvalues₀_principalSubmatrix_poincare). The proof generalises the codimension-one matrix bridge from the specific injection j.succAbove to an arbitrary injective ι and feeds the already-proven arbitrary-codimension operator separation poincare_separation, transporting the submatrix's spectral eigenbasis through the coordinate isometry so that no eigenvalue-uniqueness lemma is required.",
+    "implications": "This is the matrix-level Poincaré separation theorem — the m-fold generalisation of Cauchy interlacing — which the parent entry explicitly flagged as future work. It completes the concrete side of the Cauchy-interlacing chain: the classical codimension-one statement is now the special case m = 1, ι = j.succAbove, and the general principal submatrix (any n kept coordinates) is covered uniformly. It supplies the interlacing inequalities that underlie deflation and principal-submatrix methods in numerical linear algebra, and packages the compression-to-submatrix identification for an arbitrary coordinate selection.",
+    "openQuestions": [
+      "Recover the codimension-one principalSubmatrix_eigenvalues_interlacing as the literal special case m = 1, ι = j.succAbove.",
+      "State the interlacing for arbitrary (not-necessarily-contiguous) principal submatrices selected by a Finset, and for non-injective index maps by restricting to the injective core.",
+      "Upstream the matrix-form Poincaré separation to Mathlib as Matrix.IsHermitian.eigenvalues₀_submatrix_interlacing."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The unitary-conjugation invariance entry that flagged Poincaré separation for m×m principal submatrices as its third open question; this entry answers it by identifying the compression to a coordinate subspace with an arbitrary principal submatrix."
+    },
+    {
+      "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The codimension-one principal-submatrix identification (compress_inner_eq_principalSubmatrix) whose j.succAbove construction is generalised here to an arbitrary injective index map ι."
+    },
+    {
+      "proofId": "cauchy-interlacing-theorem",
+      "relationship": "related",
+      "description": "The Cauchy interlacing keystone; the matrix-form Poincaré separation proved here is its m-fold generalisation to arbitrary principal submatrices."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the third open question of `cauchy-interlacing-theorem-oq-01-oq-01-oq-01`: the **Poincaré separation theorem at the level of concrete matrices for an arbitrary n×n principal submatrix**.

For a Hermitian `(n+m)×(n+m)` matrix `A` over any `RCLike` field and an **injective** index map `ι : Fin n → Fin (n+m)` (choosing which n rows/columns to keep), the eigenvalues of the principal submatrix `A.submatrix ι ι` separate those of `A`:

```
λ_{k+m}(A) ≤ μ_k(A.submatrix ι ι) ≤ λ_k(A)   for every k : Fin n
```

## What was missing

The parent chain had built both halves but left a seam:
- **Concrete, codimension-one**: `principalSubmatrix_eigenvalues_interlacing` (oq-01-oq-01-oq-02) — deletes *one* row/column via the specific injection `j.succAbove`.
- **Abstract, arbitrary codimension**: `poincare_separation` (`CauchyInterlacingPoincare`) — operator-level, takes an abstract compression + Rayleigh hypothesis as input.

This PR joins them: the codimension-one matrix bridge is generalized **verbatim** from `j.succAbove` to an arbitrary injective `ι`, and the resulting compression is fed to the abstract operator separation.

## Mechanism

- `coordSubspace ι = span {e_{ι i}}` — the kept coordinate axes; injectivity of `ι` ⟹ orthonormal ⟹ `finrank = n` (codimension m).
- `compress_inner_eq_submatrix` — the orthogonal compression of `toEuclideanLin A` to this subspace, read on `(e_{ι i})`, is **exactly** `A.submatrix ι ι`.
- `compress_intertwine` — under the coordinate isometry `coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H`, `e_i ↦ e_{ι i}`, the compression **is** `toEuclideanLin (A.submatrix ι ι)`.
- `interlacing_poincare_of_intertwine` — pushing the submatrix's spectral eigenbasis through `coordEquiv` (`OrthonormalBasis.map`) yields an eigenbasis of the compression with the *same* antitone eigenvalues, so no eigenvalue-uniqueness lemma is needed; fed to `poincare_separation`.

## Main results (0 sorries, 0 axioms)

- `principalSubmatrix_poincare_separation` — operator-eigenvalue form.
- `eigenvalues₀_principalSubmatrix_poincare` — literal `Matrix.IsHermitian.eigenvalues₀` form.

The codimension-one file is the special case `m = 1`, `ι = j.succAbove`. Holds over ℝ and ℂ.

## Verification

- `lake build Proofs.CauchyInterlacingOQ01OQ01OQ01OQ03` succeeds (exit 0).
- `#print axioms` on both main theorems: only `propext, Classical.choice, Quot.sound` (the standard foundational axioms — no `sorryAx`, no `Lean.ofReduceBool`). **Genuinely 0-axiom / verified.**

## Files

- `proofs/Proofs/CauchyInterlacingOQ01OQ01OQ01OQ03.lean` (new, 345 lines)
- `src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03/` (meta.json, annotations.json, index.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)