### PR TITLE
Enrich Fibonacci Linear Sums (oq-06): +1 annotation (base-case decide / axiom integrity)

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-06/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-06/annotations.json
@@ -81,5 +81,26 @@
       "generating functions (for the heuristic)"
     ],
     "tags": ["synthesis", "moment-ladder", "fibonacci", "open-question"]
+  },
+  {
+    "id": "ann-fiboq06-5",
+    "proofId": "fibonacci-identities-oq-06",
+    "range": { "startLine": 38, "endLine": 39 },
+    "type": "technique",
+    "title": "The Base Case Uses decide on Ground Values — Not native_decide",
+    "content": "**Why the 0-axiom claim survives the `decide`.** Both theorems open their induction with `simp only [..., Finset.sum_range_one]; decide` (line 39 here, and identically at line 54 for `fib_weighted_sum`). After `sum_range_one` collapses the singleton sum, the residual goal is a *fully ground* arithmetic equation — `Nat.fib 0 + 1 = Nat.fib 2` for `fib_sum`, and `0 + Nat.fib 3 = 0 * Nat.fib 2 + 2` for `fib_weighted_sum`. These contain no free variables, so `decide` discharges them by *kernel* evaluation of the `Decidable` instance for `Nat` equality: the kernel unfolds `Nat.fib` on the concrete inputs and checks the resulting numerals. Crucially this is `decide`, **not** `native_decide` — it does not compile to native code and therefore does not invoke `Lean.ofReduceBool`. That is exactly why the entry can honestly claim `axiomCount: 0` and depend only on `propext`/`Classical.choice`/`Quot.sound`; a `native_decide` on a substantive goal would have forced `status: axiomatized` under the project's axiom-integrity policy. The subtle inductive arithmetic is instead carried by `omega` and `linear_combination`, both of which produce genuine kernel-checkable proof terms.",
+    "mathContext": "Base cases: $F_0 + 1 = F_2$ (i.e. $0 + 1 = 1$) and $0\\cdot F_0 + F_3 = 0\\cdot F_2 + 2$ (i.e. $2 = 2$). Ground equalities decided by kernel reduction of $\\mathtt{Nat.fib}$, contributing no trusted-compiler axiom.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "decide vs native_decide",
+      "Lean.ofReduceBool axiom",
+      "kernel reduction of Decidable instances",
+      "axiom integrity (0-axiom verification)"
+    ],
+    "prerequisites": [
+      "Decidable equality on ℕ",
+      "the distinction between decide and native_decide"
+    ],
+    "tags": ["base-case", "decide", "axiom-integrity"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-06` (quality 89, pass 0).

## Changes
- **+1 annotation** (4 → 5, all with mathContext/significance/relatedConcepts): a technical annotation on the base-case `decide` (lines 38–39, mirrored at line 54) documenting *why* it preserves the entry's `axiomCount: 0` claim — it is kernel evaluation of ground `Nat.fib` values, **not** `native_decide`, so it introduces no `Lean.ofReduceBool` dependency. This was the one substantive uncovered point in an otherwise fully-annotated file.

## Notes
- meta.json unchanged; already well-curated at 15.4 KB (within all size caps).
- JSON validated; `check-meta-size` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)