### PR TITLE
research(abundant-number-oq-03-oq-01): odd abundant counting bound #{n≤N}≥N/1890 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbundantOddDensityOQ0301.lean
+++ b/proofs/Proofs/AbundantOddDensityOQ0301.lean
@@ -1,0 +1,102 @@
+/-
+  A quantitative lower bound on the counting function of ODD abundant numbers.
+
+  `AbundantOddInfiniteOQ03.lean` shows the set of odd abundant numbers is
+  infinite, via the witness family `945·(2k+1) = 945, 2835, 4725, …` (each a
+  positive odd multiple of the smallest odd abundant seed `945 = 3³·5·7`).
+  Infinitude is a purely qualitative statement. This file sharpens it to an
+  explicit *counting* bound, the first of the open questions raised by that
+  entry:
+
+      #{ n ≤ N : n odd and abundant }  ≥  N / 1890.
+
+  Equivalently, odd abundant numbers have **positive lower density**
+  ≥ 1/1890 among all positive integers — a quantitative strengthening of
+  infinitude. The constant comes directly from the witness spacing: the
+  members of `945·(2k+1)` below `N` number roughly `N/1890`, since consecutive
+  witnesses differ by `2·945 = 1890`.
+
+  The bound is not claimed to be sharp; the true density of odd abundant
+  numbers is larger (the family `945·(2k+1)` misses every odd abundant number
+  not divisible by `945`). What it *does* give is a clean, dimension-free,
+  axiom-free linear lower bound, resting only on:
+    * `odd_abundant_945_mul`  — every `945·(2k+1)` is odd and abundant,
+    * `odd_mul_succ_injective` — the witnesses are pairwise distinct.
+
+  The proof is axiom-free (no `sorry`, no `axiom`, no `native_decide`).
+-/
+import Mathlib
+import Proofs.AbundantOddInfiniteOQ03
+
+namespace AbundantOddDensityOQ0301
+
+open AbundantOddInfiniteOQ03
+
+-- Match the base files' classical decidability setup so `Finset.filter` may
+-- range over the (decidable, but conveniently classical) predicate
+-- `fun n => Odd n ∧ n.Abundant`.
+attribute [local instance] Classical.propDecidable
+
+/-- The counting function of odd abundant numbers: the number of `n` with
+`1 ≤ n ≤ N` that are both odd and abundant. -/
+noncomputable def oddAbundantCount (N : ℕ) : ℕ :=
+  ((Finset.Icc 1 N).filter (fun n => Odd n ∧ n.Abundant)).card
+
+/-- **Core counting estimate.** If `1890·m ≤ N`, then there are at least `m`
+odd abundant numbers in `[1, N]`.
+
+The first `m` witnesses `945·(2k+1)` (`k = 0, …, m-1`) are pairwise distinct
+odd abundant numbers, and the largest of them, `945·(2m-1) ≤ 1890·m ≤ N`,
+still lies in `[1, N]`. Hence the filtered set contains an injective image of
+`range m`, so its cardinality is at least `m`. -/
+theorem count_lower_bound (N m : ℕ) (h : 1890 * m ≤ N) :
+    m ≤ oddAbundantCount N := by
+  unfold oddAbundantCount
+  -- The image of `range m` under `k ↦ 945·(2k+1)` lands in the filtered set.
+  have himg : (Finset.range m).image (fun k => 945 * (2 * k + 1)) ⊆
+      (Finset.Icc 1 N).filter (fun n => Odd n ∧ n.Abundant) := by
+    intro n hn
+    simp only [Finset.mem_image, Finset.mem_range] at hn
+    obtain ⟨k, hk, rfl⟩ := hn
+    rw [Finset.mem_filter, Finset.mem_Icc]
+    refine ⟨⟨Nat.one_le_iff_ne_zero.mpr (by positivity), ?_⟩, odd_abundant_945_mul k⟩
+    -- `945·(2k+1) ≤ 945·(2m) = 1890·m ≤ N` since `k < m ⟹ 2k+1 ≤ 2m`.
+    have hkm : 2 * k + 1 ≤ 2 * m := by omega
+    calc 945 * (2 * k + 1) ≤ 945 * (2 * m) := Nat.mul_le_mul_left _ hkm
+      _ = 1890 * m := by ring
+      _ ≤ N := h
+  -- The image has exactly `m` elements (the witness map is injective).
+  have hcard : ((Finset.range m).image (fun k => 945 * (2 * k + 1))).card = m := by
+    rw [Finset.card_image_of_injective _ odd_mul_succ_injective, Finset.card_range]
+  calc m = ((Finset.range m).image (fun k => 945 * (2 * k + 1))).card := hcard.symm
+    _ ≤ ((Finset.Icc 1 N).filter (fun n => Odd n ∧ n.Abundant)).card :=
+        Finset.card_le_card himg
+
+/-- **Explicit linear lower bound on the counting function.**
+
+For every `N`, the number of odd abundant numbers in `[1, N]` is at least
+`N / 1890` (natural-number division). In particular odd abundant numbers have
+positive lower density ≥ 1/1890. -/
+theorem oddAbundantCount_ge_div (N : ℕ) : N / 1890 ≤ oddAbundantCount N := by
+  apply count_lower_bound
+  -- `1890 · (N / 1890) ≤ N`.
+  have := Nat.div_mul_le_self N 1890
+  omega
+
+/-- **Quantitative infinitude.** For every target `M`, there is a bound `N`
+below which at least `M` odd abundant numbers occur — namely `N = 1890·M`.
+This recovers `infinitely_many_odd_abundant` with an explicit rate. -/
+theorem oddAbundantCount_unbounded (M : ℕ) : M ≤ oddAbundantCount (1890 * M) :=
+  count_lower_bound (1890 * M) M (le_refl _)
+
+/-- The counting function of odd abundant numbers tends to infinity: for every
+`M` it is `≥ M` from `N = 1890·M` onward, so it is unbounded. -/
+theorem oddAbundantCount_atTop (M : ℕ) : ∃ N, ∀ K, N ≤ K → M ≤ oddAbundantCount K :=
+  ⟨1890 * M, fun K hK => count_lower_bound K M hK⟩
+
+-- Confirms the result depends only on the standard foundational axioms
+-- (propext, Classical.choice, Quot.sound) and NOT on `Lean.ofReduceBool`
+-- (which `native_decide` would introduce) or `sorryAx`.
+#print axioms oddAbundantCount_ge_div
+
+end AbundantOddDensityOQ0301

--- a/src/data/proofs/abundant-number-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/abundant-number-oq-03-oq-01/annotations.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "abundant0301-ann-statement",
+    "proofId": "abundant-number-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "concept",
+    "title": "From Infinitude to a Counting Bound",
+    "content": "The parent entry (abundant-number-oq-03) proves the set $\\{n : \\text{Odd } n \\wedge n \\text{ abundant}\\}$ is infinite, using the witness family $945\\cdot(2k+1) = 945, 2835, 4725, \\dots$ — each an odd positive multiple of the smallest odd abundant number $945 = 3^3\\cdot 5\\cdot 7$. That is a purely qualitative fact. Here we extract the *quantitative* content already latent in the family. Define the **counting function**\n$$\\mathrm{oddAbundantCount}(N) = \\#\\{\\, n \\in [1,N] : n \\text{ odd and abundant} \\,\\}.$$\nBecause consecutive witnesses differ by exactly $2\\cdot 945 = 1890$, one witness falls in each length-$1890$ window, so about $N/1890$ of them lie below $N$. This gives odd abundant numbers **positive lower density** $\\geq 1/1890$ — the first open question raised in the parent's conclusion. The predicate `Odd n ∧ n.Abundant` is filtered under the base files' `Classical.propDecidable` local instance, so the counting function is marked `noncomputable` (a proof-irrelevant convenience, not an assumption)."
+  },
+  {
+    "id": "abundant0301-ann-core",
+    "proofId": "abundant-number-oq-03-oq-01",
+    "range": { "startLine": 45, "endLine": 73 },
+    "type": "proof-technique",
+    "title": "Core Estimate: Inject the First m Witnesses",
+    "content": "`count_lower_bound (N m) (h : 1890\\cdot m \\le N) : m \\le \\mathrm{oddAbundantCount}\\, N`. The engine is a single application of cardinality monotonicity to an injective image. Consider the image of $\\{0,1,\\dots,m-1\\}$ under $k \\mapsto 945\\cdot(2k+1)$. Each image element is:\n\n- **odd and abundant** — this is exactly `odd_abundant_945_mul k` from the parent;\n- **in $[1,N]$** — clearly $\\geq 945 \\geq 1$, and for $k < m$ we have $2k+1 \\le 2m$ (immediate by `omega`), so $945\\cdot(2k+1) \\le 945\\cdot(2m) = 1890\\cdot m \\le N$.\n\nSo the image is a subset of the filtered counting set. The witness map is injective (`odd_mul_succ_injective` from the parent), hence its image has exactly $m$ elements (`Finset.card_image_of_injective`), and `Finset.card_le_card` yields $m \\le \\mathrm{oddAbundantCount}\\, N$. Phrasing the hypothesis as $1890\\cdot m \\le N$ (rather than bounding by the largest witness $945\\cdot(2m-1)$) keeps every step in $\\mathbb{N}$ with no truncated subtraction."
+  },
+  {
+    "id": "abundant0301-ann-linear",
+    "proofId": "abundant-number-oq-03-oq-01",
+    "range": { "startLine": 75, "endLine": 84 },
+    "type": "key-insight",
+    "title": "The Linear Bound N/1890 and Positive Lower Density",
+    "content": "`oddAbundantCount_ge_div (N) : N / 1890 \\le \\mathrm{oddAbundantCount}\\, N`. Instantiate the core estimate at $m = \\lfloor N/1890 \\rfloor$: the hypothesis $1890\\cdot \\lfloor N/1890\\rfloor \\le N$ is `Nat.div_mul_le_self`, and the conclusion is the headline bound. Read analytically, this is exactly\n$$\\liminf_{N\\to\\infty} \\frac{\\mathrm{oddAbundantCount}(N)}{N} \\ge \\frac{1}{1890} > 0,$$\ni.e. odd abundant numbers have positive lower density. The constant $1/1890$ is precisely the reciprocal witness spacing and is **not sharp**: the family $945\\cdot(2k+1)$ enumerates only odd multiples of $945$, missing odd abundant numbers like $1575 = 3^2\\cdot 5^2\\cdot 7$ and $2205$, so the true density is larger. The entry deliberately proves the clean, provable bound rather than the sharp constant."
+  },
+  {
+    "id": "abundant0301-ann-infinitude",
+    "proofId": "abundant-number-oq-03-oq-01",
+    "range": { "startLine": 86, "endLine": 102 },
+    "type": "concept",
+    "title": "Quantitative Infinitude",
+    "content": "Two corollaries repackage the counting bound as an *effective* form of infinitude. `oddAbundantCount_unbounded (M) : M \\le \\mathrm{oddAbundantCount}(1890\\cdot M)$ takes $m = M,\\, N = 1890M$ in the core estimate: at least $M$ odd abundant numbers occur below $1890M$. `oddAbundantCount_atTop (M) : \\exists N, \\forall K \\ge N,\\, M \\le \\mathrm{oddAbundantCount}\\, K$ lifts this to 'eventually $\\ge M$', so the counting function is unbounded — recovering `infinitely_many_odd_abundant` with an explicit rate rather than a bare `Set.Infinite`. The file closes with `#print axioms oddAbundantCount_ge_div`, confirming dependence only on the standard foundational axioms (`propext`, `Classical.choice`, `Quot.sound`) — no `sorryAx`, no `native_decide`."
+  }
+]

--- a/src/data/proofs/abundant-number-oq-03-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-03-oq-01/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "abundant-number-oq-03-oq-01",
+  "title": "Odd Abundant Numbers Have Positive Lower Density (Counting Bound N/1890)",
+  "slug": "abundant-number-oq-03-oq-01",
+  "description": "Sharpens 'infinitely many odd abundant numbers' (abundant-number-oq-03) from a qualitative statement to a quantitative counting bound: the number of odd abundant numbers in [1, N] is at least N/1890. Equivalently, odd abundant numbers have positive lower density ≥ 1/1890 among the positive integers. The constant is read directly off the witness family 945·(2k+1) = 945, 2835, 4725, … from the parent entry: consecutive witnesses differ by 2·945 = 1890, so at least N/1890 of them fall in [1, N]. The core estimate count_lower_bound shows 1890·m ≤ N ⟹ at least m odd abundant numbers ≤ N, by injecting the first m witnesses (all ≤ 945·(2m-1) ≤ 1890·m ≤ N) into the counting set. The bound is not claimed sharp — the family misses every odd abundant number not divisible by 945 — but it is a clean, axiom-free linear lower bound that upgrades infinitude to an explicit density statement. 0 axioms, 0 sorries, verified against Mathlib v4.26.0.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abundant_number",
+    "date": "Classical; OEIS A005231 (odd abundant numbers)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbundantOddDensityOQ0301.lean",
+    "badge": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-sum",
+      "abundant-numbers",
+      "counting-function",
+      "density",
+      "odd-numbers",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 102,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries. `#print axioms oddAbundantCount_ge_div` reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no sorryAx, no native_decide, hence no Lean.ofReduceBool. The counting function `oddAbundantCount` is marked `noncomputable` only because it filters over the classically-decidable predicate `Odd n ∧ n.Abundant` (matching the base files' `Classical.propDecidable` local instance); this is a proof-irrelevant convenience, not a mathematical assumption. The proof reuses `odd_abundant_945_mul` and `odd_mul_succ_injective` from abundant-number-oq-03, adding no new computational content.",
+    "originalContributions": [
+      "Proves `oddAbundantCount_ge_div (N) : N / 1890 ≤ oddAbundantCount N` — the number of odd abundant numbers in [1, N] is at least N/1890, upgrading the parent's qualitative infinitude to an explicit linear counting bound (positive lower density ≥ 1/1890).",
+      "Proves the core estimate `count_lower_bound (N m) (h : 1890·m ≤ N) : m ≤ oddAbundantCount N` by injecting the first m witnesses 945·(2k+1) (k < m) into the counting set: each is odd and abundant (odd_abundant_945_mul), pairwise distinct (odd_mul_succ_injective), and ≤ 945·(2m-1) ≤ 1890·m ≤ N, so Finset.card_le_card on an injective image gives the bound.",
+      "Introduces the counting function `oddAbundantCount N = #{ n ∈ [1,N] : Odd n ∧ n.Abundant }` as a reusable object for density arguments over the abundant-number family.",
+      "Proves `oddAbundantCount_unbounded (M) : M ≤ oddAbundantCount (1890·M)` and `oddAbundantCount_atTop (M) : ∃ N, ∀ K ≥ N, M ≤ oddAbundantCount K`, recovering the parent's infinitude with an explicit rate: at least M odd abundant numbers occur below 1890·M."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Abundant numbers (σ(n) > 2n) have positive natural density ≈ 0.2476 (Deléglise, 1998, rigorously bounded the density of abundant numbers in [0.2474, 0.2480]). Odd abundant numbers (OEIS A005231: 945, 1575, 2205, 2835, …) are far rarer and have a much smaller — but still positive — density. The parent entry abundant-number-oq-03 proved there are infinitely many of them via the odd-multiples family 945·(2k+1). That argument is qualitative: it produces an infinite injective family but says nothing about how often odd abundant numbers occur. This entry extracts the quantitative content already latent in that family. Because consecutive witnesses 945·(2k+1) are spaced exactly 1890 apart, the witnesses below N number roughly N/1890 — giving a positive lower density ≥ 1/1890 for odd abundant numbers, the first open question raised in the parent's conclusion.",
+    "problemStatement": "Sharpen the infinitude of odd abundant numbers to a quantitative counting bound. Define the counting function oddAbundantCount N = #{n ∈ [1,N] : Odd n ∧ Nat.Abundant n} and prove an explicit linear lower bound oddAbundantCount N ≥ N/1890, establishing positive lower density among the positive integers, using only the witness family 945·(2k+1) from the parent entry.",
+    "text": "A short Lean 4 / Mathlib formalization (102 lines, 0 sorries, 0 axioms) that upgrades the parent's Set.Infinite result to an explicit counting bound. The key object is the counting function oddAbundantCount N. The core lemma count_lower_bound injects the first m witnesses 945·(2k+1) into the counting set whenever 1890·m ≤ N; specializing m = N/1890 yields oddAbundantCount N ≥ N/1890. Two corollaries package the same estimate as quantitative infinitude. No divisor sums are recomputed — the entry is a pure counting layer over the parent's two facts (each witness is odd and abundant; the witness map is injective).",
+    "proofStrategy": "1. **Counting function.** oddAbundantCount N := ((Finset.Icc 1 N).filter (fun n => Odd n ∧ n.Abundant)).card.\n\n2. **Core estimate (count_lower_bound).** If 1890·m ≤ N, the image of Finset.range m under k ↦ 945·(2k+1) lies inside the filtered set: each image is odd and abundant (odd_abundant_945_mul k), and for k < m satisfies 2k+1 ≤ 2m so 945·(2k+1) ≤ 945·(2m) = 1890·m ≤ N (and ≥ 945 ≥ 1). The map is injective (odd_mul_succ_injective), so its image has exactly m elements (Finset.card_image_of_injective), and Finset.card_le_card gives m ≤ oddAbundantCount N.\n\n3. **Linear bound (oddAbundantCount_ge_div).** Instantiate m = N/1890; Nat.div_mul_le_self gives 1890·(N/1890) ≤ N, discharging the hypothesis, so N/1890 ≤ oddAbundantCount N.\n\n4. **Quantitative infinitude.** oddAbundantCount_unbounded takes m = M, N = 1890·M; oddAbundantCount_atTop lifts this to eventual-≥-M for every M.",
+    "keyInsights": [
+      "**Witness spacing is the density constant.** Consecutive witnesses 945·(2k+1) and 945·(2k+3) differ by 2·945 = 1890, so exactly one witness occurs per length-1890 window — the counting bound N/1890 and the lower density 1/1890 are this spacing read off directly.",
+      "**Injectivity + membership ⟹ cardinality lower bound.** The parent already proved the witness map is injective and lands in the odd abundant set. Feeding those two facts to Finset.card_image_of_injective and Finset.card_le_card converts an infinite family into a finite counting estimate — no new number theory is needed.",
+      "**A subtraction-free hypothesis.** Phrasing the core estimate as '1890·m ≤ N ⟹ m ≤ count' (rather than bounding by the largest witness 945·(2m-1)) keeps every arithmetic step in ℕ without truncated subtraction: for k < m, 2k+1 ≤ 2m is immediate from omega, and 945·(2k+1) ≤ 1890·m follows by monotonicity.",
+      "**The bound is honest but not sharp.** 945·(2k+1) enumerates only the odd multiples of 945; odd abundant numbers not divisible by 945 (e.g. 1575 = 3²·5²·7, 2205, …) are missed entirely, so the true lower density of odd abundant numbers exceeds 1/1890. The entry deliberately proves the clean, provable bound rather than the sharp constant.",
+      "**Density as a corollary of counting.** oddAbundantCount N ≥ N/1890 is exactly the statement that the lower density liminf_{N} oddAbundantCount N / N ≥ 1/1890 > 0; the finite counting inequality is the constructive content behind 'positive lower density'."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ and the abundant / deficient / perfect classification",
+      "Infinitude of odd abundant numbers and the witness family 945·(2k+1) (abundant-number-oq-03)",
+      "Finset.card_image_of_injective and Finset.card_le_card (cardinality of an injective image; monotonicity of card under subset)",
+      "Natural-number division facts (Nat.div_mul_le_self) and lower density of a set of integers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement and Counting Function",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring stating the target bound #{n ≤ N : odd, abundant} ≥ N/1890 and its reading as positive lower density ≥ 1/1890. Imports Mathlib and Proofs.AbundantOddInfiniteOQ03, installs Classical.propDecidable as a local instance (matching the base files) so Finset.filter may range over 'Odd n ∧ n.Abundant', and defines the (noncomputable) counting function oddAbundantCount N.",
+      "mathContext": "The witness spacing 2·945 = 1890 fixes the density constant; oddAbundantCount N = #{n ∈ [1,N] : Odd n ∧ Nat.Abundant n} is the object to be bounded below."
+    },
+    {
+      "id": "core-estimate",
+      "title": "Core Counting Estimate",
+      "startLine": 45,
+      "endLine": 73,
+      "summary": "count_lower_bound (N m) (h : 1890·m ≤ N) : m ≤ oddAbundantCount N. The image of Finset.range m under k ↦ 945·(2k+1) is shown to be a subset of the filtered counting set — each image is odd and abundant (odd_abundant_945_mul) and, for k < m, satisfies 945·(2k+1) ≤ 945·(2m) = 1890·m ≤ N with 1 ≤ 945·(2k+1). The witness map is injective (odd_mul_succ_injective), so the image has exactly m elements (Finset.card_image_of_injective); Finset.card_le_card then gives the bound.",
+      "mathContext": "The first m witnesses are m distinct odd abundant numbers, all ≤ 1890·m ≤ N, so at least m of them are counted."
+    },
+    {
+      "id": "linear-bound",
+      "title": "Explicit Linear Lower Bound and Positive Density",
+      "startLine": 75,
+      "endLine": 84,
+      "summary": "oddAbundantCount_ge_div (N) : N / 1890 ≤ oddAbundantCount N, obtained by instantiating count_lower_bound at m = N/1890 and discharging 1890·(N/1890) ≤ N via Nat.div_mul_le_self. This is the headline positive-lower-density bound (liminf oddAbundantCount N / N ≥ 1/1890 > 0).",
+      "mathContext": "Choosing m = ⌊N/1890⌋ makes the core estimate give the linear bound N/1890 ≤ count."
+    },
+    {
+      "id": "quantitative-infinitude",
+      "title": "Quantitative Infinitude",
+      "startLine": 86,
+      "endLine": 102,
+      "summary": "oddAbundantCount_unbounded (M) : M ≤ oddAbundantCount (1890·M) and oddAbundantCount_atTop (M) : ∃ N, ∀ K ≥ N, M ≤ oddAbundantCount K, recovering the parent's infinitude with an explicit rate. Closes with #print axioms oddAbundantCount_ge_div confirming the result is axiom-free.",
+      "mathContext": "At least M odd abundant numbers occur below 1890·M, so the counting function is unbounded — an effective form of infinitude."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "oddAbundantCount_ge_div",
+      "type": "core",
+      "description": "N / 1890 ≤ oddAbundantCount N — the number of odd abundant numbers in [1, N] is at least N/1890, so odd abundant numbers have positive lower density ≥ 1/1890 among the positive integers. Axiom-free; sharpens the parent's infinitude to an explicit counting bound.",
+      "leanType": "N / 1890 ≤ oddAbundantCount N"
+    },
+    {
+      "name": "count_lower_bound",
+      "type": "supporting",
+      "description": "1890·m ≤ N → m ≤ oddAbundantCount N — the core estimate: the first m witnesses 945·(2k+1) form an injective image of Finset.range m inside the counting set (all ≤ 1890·m ≤ N), so the count is at least m.",
+      "leanType": "1890 * m ≤ N → m ≤ oddAbundantCount N"
+    },
+    {
+      "name": "oddAbundantCount_unbounded",
+      "type": "supporting",
+      "description": "M ≤ oddAbundantCount (1890·M) — quantitative infinitude: at least M odd abundant numbers occur below 1890·M.",
+      "leanType": "M ≤ oddAbundantCount (1890 * M)"
+    },
+    {
+      "name": "oddAbundantCount_atTop",
+      "type": "supporting",
+      "description": "∃ N, ∀ K, N ≤ K → M ≤ oddAbundantCount K — the counting function is eventually ≥ M for every M, hence unbounded; an effective restatement of infinitely_many_odd_abundant.",
+      "leanType": "∃ N, ∀ K, N ≤ K → M ≤ oddAbundantCount K"
+    }
+  ],
+  "conclusion": {
+    "summary": "Upgrades 'infinitely many odd abundant numbers' to a quantitative counting bound: oddAbundantCount N = #{n ∈ [1,N] : Odd n ∧ n.Abundant} satisfies oddAbundantCount N ≥ N/1890, so odd abundant numbers have positive lower density ≥ 1/1890 among the positive integers. The proof injects the first ⌊N/1890⌋ witnesses 945·(2k+1) into the counting set and applies Finset.card_le_card; two corollaries repackage it as quantitative infinitude. 0 axioms, 0 sorries, verified end-to-end against a fully-proved parent.",
+    "implications": "The entry answers the first open question of abundant-number-oq-03 in its provable form — a positive lower-density bound with an explicit constant — while making transparent that the constant 1/1890 is exactly the witness spacing and is not sharp. It illustrates the general pattern: an injective witness family with fixed arithmetic spacing yields not just infinitude but a positive-lower-density counting bound, obtained by a single application of Finset.card_le_card to the family's image.",
+    "openQuestions": [
+      "Determine the true lower density of odd abundant numbers by combining the 945·(2k+1) family with other odd abundant seeds (1575, 2205, 3465, …) and inclusion–exclusion over overlaps, improving the constant beyond 1/1890.",
+      "Prove a matching upper bound oddAbundantCount N ≤ C·N with C < 0.2476, establishing that the density of odd abundant numbers is strictly smaller than that of all abundant numbers (as stated in the parent open question).",
+      "Formalize convergence of oddAbundantCount N / N to a genuine natural density (not merely a lower density), which requires a sieve/analytic input beyond the elementary witness-counting used here."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Nicomachus of Gerasa",
+      "title": "Introduction to Arithmetic",
+      "year": "~100 CE",
+      "venue": "—",
+      "note": "Earliest classification of numbers as deficient, perfect, and abundant."
+    },
+    {
+      "authors": "Deléglise, Marc",
+      "title": "Bounds for the Density of Abundant Integers",
+      "year": "1998",
+      "venue": "Experimental Mathematics 7(2), 137–143",
+      "note": "Rigorously bounds the natural density of abundant numbers in [0.2474, 0.2480]; the ≈ 0.2476 figure the odd density is compared against."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A005231: Odd abundant numbers (odd n with σ(n) > 2n)",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "The sequence 945, 1575, 2205, 2835, … of odd abundant numbers; this entry bounds its counting function below by N/1890."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abundant-number-oq-03",
+      "relationship": "extends",
+      "description": "The parent proves {n | Odd n ∧ n.Abundant}.Infinite via the injective witness family 945·(2k+1) and records as its first open question a positive-density / counting bound for odd abundant numbers. This entry answers that question in provable form: it reuses the parent's odd_abundant_945_mul and odd_mul_succ_injective to bound the counting function below by N/1890, giving positive lower density ≥ 1/1890."
+    },
+    {
+      "targetId": "abundant-number-oq-01",
+      "relationship": "related",
+      "description": "abundant-number-oq-01 supplies abundant_mul_right (closure of abundant numbers under positive multiples), the closure fact underlying the witness family whose spacing 1890 = 2·945 fixes the density constant proved here."
+    },
+    {
+      "targetId": "abundant-number-oq-02",
+      "relationship": "related",
+      "description": "abundant-number-oq-02 proves 945 = 3³·5·7 is the smallest odd abundant number; 945 is the seed of the witness family, and its value directly determines the counting constant 1/1890."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AbundantOddDensityOQ0301.lean",
+    "namespace": "AbundantOddDensityOQ0301",
+    "imports": [
+      "Mathlib",
+      "Proofs.AbundantOddInfiniteOQ03"
+    ],
+    "lineCount": 102,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 4,
+    "definitionCount": 1
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `abundant-number-oq-03` (*Infinitely Many Odd Abundant Numbers*) in its provable form: a **quantitative counting lower bound** upgrading the parent's qualitative `Set.Infinite` result to positive lower density.

**Headline:** `oddAbundantCount_ge_div : N / 1890 ≤ oddAbundantCount N`

where `oddAbundantCount N = #{ n ∈ [1,N] : Odd n ∧ n.Abundant }`. Equivalently, odd abundant numbers have **positive lower density ≥ 1/1890** among the positive integers.

## How

- **Core estimate** `count_lower_bound (N m) (h : 1890·m ≤ N) : m ≤ oddAbundantCount N` — inject the first `m` parent witnesses `945·(2k+1)` (`k < m`) into the counting set. Each is odd + abundant (`odd_abundant_945_mul`), pairwise distinct (`odd_mul_succ_injective`), and `≤ 945·(2m) = 1890·m ≤ N`. Then `Finset.card_image_of_injective` + `Finset.card_le_card`.
- **Linear bound** — instantiate `m = ⌊N/1890⌋`; discharge `1890·⌊N/1890⌋ ≤ N` via `Nat.div_mul_le_self`.
- **Quantitative infinitude** — `oddAbundantCount_unbounded`, `oddAbundantCount_atTop` recover the parent's infinitude with an explicit rate.

The constant `1/1890 = 1/(2·945)` is exactly the witness spacing. It is honest but **not sharp** — the family `945·(2k+1)` misses odd abundant numbers not divisible by 945 (e.g. `1575 = 3²·5²·7`), so the true density is larger. Reuses the parent's two facts with no new computation.

## Verification

- **4 theorems, 1 def, 102 lines. 0 sorries, 0 `axiom` declarations.**
- `#print axioms oddAbundantCount_ge_div` → `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- Built via `lake env lean` against Mathlib v4.26.0 (Docker image build was down: containerd I/O error).
- `oddAbundantCount` is `noncomputable` only because it filters over the classically-decidable `Odd n ∧ n.Abundant` (matches base files' `Classical.propDecidable` local instance) — proof-irrelevant, not an assumption.

## Files
- `proofs/Proofs/AbundantOddDensityOQ0301.lean` (new)
- `src/data/proofs/abundant-number-oq-03-oq-01/{meta.json,annotations.json}` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)