### PR TITLE
Enrich Markov Vieta fiber-involution (oq-05): +2 cross-references

### DIFF
--- a/src/data/proofs/markov-equation-oq-05/meta.json
+++ b/src/data/proofs/markov-equation-oq-05/meta.json
@@ -40,6 +40,16 @@
       "targetId": "markov-equation",
       "relationship": "extends",
       "description": "Supplies the structural converse of the parent's Vieta lemmas. The parent proves the neighbor 3xy − z is *a* solution (markov_vieta) and computes the root product (markov_root_prod); this entry proves it is the *unique* other solution, so the fiber over (x,y) is exactly {z, 3xy − z} and Vieta jumping is an involutive permutation of it."
+    },
+    {
+      "targetId": "markov-equation-oq-06",
+      "relationship": "related",
+      "description": "Vieta ascent generates infinitely many Markov triples by iterating the neighbor move z ↦ 3xy − z. This entry supplies the well-definedness that ascent relies on: because each fixed-pair fiber is exactly the doubleton {z, 3xy − z} swapped by the involution vietaPerm, the ascent step lands on a unique, genuinely new triple."
+    },
+    {
+      "targetId": "markov-equation-oq-03",
+      "relationship": "related",
+      "description": "Generalizes Vieta jumping to the parametric Markov–Hurwitz family x² + y² + z² = kxyz. This entry's open question — whether each fixed-pair fiber is still a doubleton and how the fixed-point locus 2z = kxy varies with k — is exactly the fiber-uniqueness question oq-03 pursues for general k; the monic-quadratic + integral-domain template proved here is what transfers."
     }
   ],
   "overview": {


### PR DESCRIPTION
Enrichment pass for `markov-equation-oq-05` ("Vieta Jumping as a Fiber Involution").

This entry was already richly enriched (4 keyInsights, 3 sections, 5 strong references, full conclusion, all annotations complete). The single genuine thin spot was `crossReferences`: only the parent `markov-equation` was linked, despite two directly complementary sibling entries.

**Change** — added two precise `related` cross-references (1 → 3, cap 20):
- `markov-equation-oq-06` ("Vieta Ascent Generates Infinitely Many Markov Triples"): ascent iterates the neighbor move z ↦ 3xy − z, and this entry proves the well-definedness (fiber = doubleton {z, 3xy − z} swapped by an involution) that ascent relies on.
- `markov-equation-oq-03` ("Generalizations… Markov–Hurwitz Vieta Jumping"): the entry's own open question about the general x²+y²+z²=kxyz family is exactly the fiber-uniqueness question oq-03 pursues.

- meta.json within 60 KB cap; JSON validated; check-meta-size passes; all targetIds exist
- No prose inflation — the entry already meets all quality minimums

🤖 Generated with [Claude Code](https://claude.com/claude-code)