### PR TITLE
Enrich Hölder Bridge beyond L² (csi-oq-03-oq-01): annotation depth + cross-refs

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-03-oq-01/annotations.json
@@ -5,8 +5,21 @@
     "range": { "startLine": 66, "endLine": 79 },
     "type": "theorem",
     "title": "Signed Hölder Integral Inequality",
-    "content": "holder_integral_abs is the genuine extension of the L² bridge: for real f ∈ Lᵖ and g ∈ Lᵍ with conjugate exponents, |∫ f·g dμ| ≤ (∫ |f|ᵖ)^{1/p}·(∫ |g|ᵍ)^{1/q}. The absolute value is placed outside the integral (the signed pairing), matching the parent's |∫ f·g| ≤ ‖f‖·‖g‖ rather than Mathlib's ∫ ‖f‖·‖g‖ or nonnegative-only forms.",
-    "mathContext": "|∫ f·g dμ| ≤ (∫ |f|^p dμ)^{1/p} · (∫ |g|^q dμ)^{1/q}"
+    "content": "holder_integral_abs is the genuine extension of the L² bridge: for real f ∈ Lᵖ and g ∈ Lᵍ with conjugate exponents, |∫ f·g dμ| ≤ (∫ |f|ᵖ)^{1/p}·(∫ |g|ᵍ)^{1/q}. The absolute value is placed outside the integral (the signed pairing), matching the parent's |∫ f·g| ≤ ‖f‖·‖g‖ rather than Mathlib's ∫ ‖f‖·‖g‖ or nonnegative-only forms. This is the one result here with content beyond the library: Mathlib ships integral_mul_le_Lp_mul_Lq_of_nonneg (nonnegative f, g) and integral_mul_norm_le_Lp_mul_Lq (bounds ∫ ‖f‖·‖g‖), but not the signed pairing bound directly.",
+    "mathContext": "|∫ f·g dμ| ≤ (∫ |f|^p dμ)^{1/p} · (∫ |g|^q dμ)^{1/q}",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hölder's inequality",
+      "conjugate exponents 1/p + 1/q = 1",
+      "Lᵖ–Lᵍ duality",
+      "MemLp membership",
+      "signed vs nonnegative pairing"
+    ],
+    "prerequisites": [
+      "Lᵖ spaces and MemLp",
+      "conjugate (Hölder) exponents",
+      "the Bochner integral"
+    ]
   },
   {
     "id": "ann-csi-oq0301-proof-chain",
@@ -14,8 +27,20 @@
     "range": { "startLine": 80, "endLine": 84 },
     "type": "insight",
     "title": "Pulling the Sign Outside",
-    "content": "The three-step calc: |∫ f·g| ≤ ∫ |f·g| holds with no integrability hypothesis (abs_integral_le_integral_abs, a specialization of norm_integral_le_integral_norm), then ∫ |f·g| = ∫ |f|·|g| by abs_mul, then Mathlib's norm-form Hölder integral_mul_norm_le_Lp_mul_Lq closes it after rewriting ‖x‖ = |x| on ℝ.",
-    "mathContext": "|∫ f·g| ≤ ∫ |f·g| = ∫ |f|·|g| ≤ ‖f‖_p‖g‖_q"
+    "content": "The three-step calc: |∫ f·g| ≤ ∫ |f·g| holds with no integrability hypothesis (abs_integral_le_integral_abs, a specialization of norm_integral_le_integral_norm), then ∫ |f·g| = ∫ |f|·|g| by abs_mul, then Mathlib's norm-form Hölder integral_mul_norm_le_Lp_mul_Lq closes it after rewriting ‖x‖ = |x| on ℝ. The key move is that the first step needs no hypothesis: |∫ h| ≤ ∫ |h| is the integral triangle inequality, valid even for non-integrable h (both sides can be +∞ or the integral defaults to 0), so signedness costs nothing.",
+    "mathContext": "|∫ f·g| ≤ ∫ |f·g| = ∫ |f|·|g| ≤ ‖f‖_p‖g‖_q",
+    "significance": "technical",
+    "relatedConcepts": [
+      "integral triangle inequality",
+      "abs_integral_le_integral_abs",
+      "norm_integral_le_integral_norm",
+      "‖x‖ = |x| on ℝ",
+      "abs_mul"
+    ],
+    "prerequisites": [
+      "properties of the Bochner integral",
+      "the real absolute value as a norm"
+    ]
   },
   {
     "id": "ann-csi-oq0301-l2",
@@ -23,8 +48,20 @@
     "range": { "startLine": 85, "endLine": 103 },
     "type": "theorem",
     "title": "The L² Case as the Conjugation Fixed Point",
-    "content": "holder_integral_abs_L2 instantiates the general bound at p = q = 2 — the unique self-conjugate exponent (Real.HolderConjugate.two_two). Rewriting |f|^(2:ℝ) = f² (Real.rpow_two, sq_abs) and the 1/2-powers as square roots (Real.sqrt_eq_rpow) turns the bound into √(∫ f²)·√(∫ g²), which is exactly ‖f‖_{L²}·‖g‖_{L²}.",
-    "mathContext": "|∫ f·g dμ| ≤ √(∫ f² dμ) · √(∫ g² dμ)"
+    "content": "holder_integral_abs_L2 instantiates the general bound at p = q = 2 — the unique self-conjugate exponent (Real.HolderConjugate.two_two), the fixed point of the involution p ↦ p/(p−1). Rewriting |f|^(2:ℝ) = f² (Real.rpow_two, sq_abs) and the 1/2-powers as square roots (Real.sqrt_eq_rpow) turns the bound into √(∫ f²)·√(∫ g²), which is exactly ‖f‖_{L²}·‖g‖_{L²}. This is the precise sense in which the parent's inner-product proof is one point of a continuum: the Hilbert-space structure that made L² effortless is the p = 2 slice of Lᵖ–Lᵍ duality.",
+    "mathContext": "|∫ f·g dμ| ≤ √(∫ f² dμ) · √(∫ g² dμ) = ‖f‖_{L²}·‖g‖_{L²}",
+    "significance": "key",
+    "relatedConcepts": [
+      "self-conjugate exponent p = q = 2",
+      "Real.HolderConjugate.two_two",
+      "L² inner product",
+      "rpow ↔ npow at p = 2",
+      "Real.sqrt_eq_rpow"
+    ],
+    "prerequisites": [
+      "Hilbert space L² and its inner product",
+      "real power identities (rpow_two, sqrt_eq_rpow)"
+    ]
   },
   {
     "id": "ann-csi-oq0301-recover",
@@ -32,8 +69,19 @@
     "range": { "startLine": 105, "endLine": 124 },
     "type": "theorem",
     "title": "Squared Cauchy–Schwarz is the Diagonal of Hölder",
-    "content": "holder_recovers_cauchy_schwarz squares the sqrt-form bound (pow_le_pow_left₀ on the nonnegative sides) and collapses (√A)² = A via Real.sq_sqrt to obtain (∫ f·g)² ≤ (∫ f²)·(∫ g²). This proves the parent's bunyakovsky_schwarz_sq is not an independent theorem but the p = q = 2 restriction of the conjugate-exponent family.",
-    "mathContext": "(∫ f·g dμ)² ≤ (∫ f² dμ)·(∫ g² dμ)"
+    "content": "holder_recovers_cauchy_schwarz squares the sqrt-form bound (pow_le_pow_left₀ on the nonnegative sides) and collapses (√A)² = A via Real.sq_sqrt to obtain (∫ f·g)² ≤ (∫ f²)·(∫ g²). This proves the parent's bunyakovsky_schwarz_sq is not an independent theorem but the p = q = 2 restriction of the conjugate-exponent family — a genuine reduction, not a re-proof: the classical squared Cauchy–Schwarz is deduced from Hölder rather than established afresh.",
+    "mathContext": "(∫ f·g dμ)² ≤ (∫ f² dμ)·(∫ g² dμ)",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bunyakovsky–Schwarz inequality",
+      "squaring monotonicity (pow_le_pow_left₀)",
+      "Real.sq_sqrt",
+      "specialization/reduction of theorems"
+    ],
+    "prerequisites": [
+      "monotonicity of squaring on nonnegatives",
+      "the squared Cauchy–Schwarz statement"
+    ]
   },
   {
     "id": "ann-csi-oq0301-symm",
@@ -41,7 +89,17 @@
     "range": { "startLine": 126, "endLine": 133 },
     "type": "theorem",
     "title": "Symmetry of the Pairing",
-    "content": "holder_integral_abs_symm records that swapping (f, p) ↔ (g, q) leaves the bound invariant, an immediate consequence of Real.HolderConjugate.symm. The integral ∫ f·g pairs Lᵖ against Lᵍ symmetrically, with no preferred factor — the structural reason Cauchy–Schwarz lives at the symmetric point p = q.",
-    "mathContext": "p.HolderConjugate q ↔ q.HolderConjugate p"
+    "content": "holder_integral_abs_symm records that swapping (f, p) ↔ (g, q) leaves the bound invariant, an immediate consequence of Real.HolderConjugate.symm. The integral ∫ f·g pairs Lᵖ against Lᵍ symmetrically, with no preferred factor — the structural reason Cauchy–Schwarz lives at the symmetric point p = q, where the two dual spaces coincide.",
+    "mathContext": "p.HolderConjugate q ↔ q.HolderConjugate p",
+    "significance": "context",
+    "relatedConcepts": [
+      "symmetry of conjugacy",
+      "Real.HolderConjugate.symm",
+      "duality pairing",
+      "commutativity of pointwise product"
+    ],
+    "prerequisites": [
+      "the symmetry of the Hölder conjugation relation"
+    ]
   }
 ]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-03-oq-01/meta.json
@@ -140,6 +140,21 @@
       "targetId": "cauchy-schwarz-integral",
       "relationship": "extends",
       "description": "Parent entry: proved the L² Bunyakovsky–Schwarz inequality via the inner-product = integral bridge and asked (open question 3) whether the bridge extends to Lᵖ for p ≠ 2. This entry answers yes via Hölder's inequality, recovering the parent's absolute-value and squared L² theorems as the self-conjugate case p = q = 2."
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-01",
+      "relationship": "relatedTo",
+      "description": "Sibling under the same parent, also framing Hölder as the generalization of Cauchy–Schwarz — but in the nonnegative / norm form ∫ |f·g| ≤ (∫|f|ᵖ)^{1/p}(∫|g|ᵍ)^{1/q}. This entry supplies the complementary signed pairing bound |∫ f·g| ≤ … and additionally recovers the L² sqrt-form and squared Cauchy–Schwarz as the p = q = 2 fixed point."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "relatedTo",
+      "description": "The finite-dimensional / inner-product Cauchy–Schwarz inequality (abstract inner product, Lagrange identity, and finite sums). It is the discrete counterpart of the L² case recovered here as p = q = 2; the integral bound ∫ f·g ≤ ‖f‖₂‖g‖₂ is the continuum analogue of ⟨u,v⟩ ≤ ‖u‖‖v‖."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01",
+      "relationship": "relatedTo",
+      "description": "Hölder's inequality rests on convexity: the pointwise Young inequality ab ≤ aᵖ/p + bᵍ/q that underlies it is exactly the convexity (Jensen) inequality for exp, and the equality case |f|ᵖ ∝ |g|ᵍ mirrors Jensen's equality-iff-constant characterization. This entry's open question on the extremal case connects directly to that Jensen equality analysis."
     }
   ],
   "sorries": null


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-integral-oq-03-oq-01` (quality 78, pass 0).

## Changes
- **Annotation depth**: added `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations. Previously none of them carried these fields — the principal reason for the lower quality score.
- Deepened two annotation `content` fields: the integral triangle inequality needs no integrability hypothesis (so signedness is free), and the L² case as the conjugation fixed point.
- **Cross-references 1 → 4**: added the sibling nonnegative/norm Hölder entry (`cauchy-schwarz-integral-oq-01`), the discrete/inner-product `cauchy-schwarz`, and `jensen-inequality-oq-01` (convexity/Young underpinning + the extremal-case connection).

## Notes
- meta.json within all size caps; verified.
- JSON validated; `check-meta-size` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)