### PR TITLE
research(angle-trisection-oq-05-oq-04-incomplete-01): constructive core of Huzita–Hatori HH-5 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ05OQ04Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ05OQ04Incomplete01.lean
@@ -1,0 +1,217 @@
+/-
+# Curved-Crease Origami — Constructive Core of Huzita–Hatori Axiom HH-5
+
+This entry **completes** a piece of the open problem
+`angle-trisection-oq-05-oq-04` (Curved-Crease Origami: strengthening the
+Huzita–Hatori axioms). The parent file
+`Proofs/AngleTrisectionOQ05OQ04.lean` builds the seven Huzita–Hatori (HH)
+fold operations up constructively, one axiom at a time, and had reached
+the frontier:
+
+> "… six of seven HH ingredients are now constructive … only **HH-5**
+> (Beloch-light) and **HH-6** (Beloch fold) remain, plus the intersecting
+> case of HH-3."
+
+This file discharges the **rational (square-root-free) core of HH-5**.
+
+## HH-5
+
+> Given two distinct points `P₁`, `P₂` and a line `ℓ`, there is a fold
+> through `P₂` that places `P₁` onto `ℓ`.
+
+Geometrically the fold is a reflection fixing `P₂`, so the landing point
+`P₁'` of `P₁` must satisfy `|P₁' − P₂| = |P₁ − P₂|`: it lies on the
+circle centred at `P₂` through `P₁`. HH-5 is therefore solvable **iff**
+that circle meets `ℓ`, and *finding* the landing point is a circle-line
+intersection — genuinely a `Real.sqrt` step. The present file isolates
+that irrational existence step (kept as a hypothesis, a **witness**
+landing point `P₁'`) from the fold construction itself, which is purely
+rational:
+
+* **`reflectAcross_distSq_fixed`** — reflecting across *any* fold through
+  `P₂` preserves the squared distance to `P₂` (reflection is an isometry
+  about a fixed point). This shows the equidistance condition on the
+  landing point is not merely sufficient but **necessary**.
+* **`perpBisector_contains_of_equidistSq`** — `P₂` lies on the
+  perpendicular bisector of `P₁` and any equidistant point `P₁'`.
+* **`hh5_core` / `hh5_core_exact`** — given a witness landing point
+  `P₁' ∈ ℓ` equidistant from `P₂`, the perpendicular bisector of
+  `P₁P₁'` is a fold through `P₂` sending `P₁` onto `ℓ` (and onto `P₁'`
+  precisely).
+
+Together these give a full **characterisation**: HH-5 is solvable for
+`(P₁, P₂, ℓ)` exactly when `ℓ` contains a point at squared-distance
+`|P₁ − P₂|²` from `P₂`, and the fold is then explicit and rational in
+that point. The only irrational content of HH-5 is the existence of the
+witness (circle-line intersection); the fold operation carries no further
+degree.
+
+Self-contained: the planar primitives (`Point`, `Line`, `reflectAcross`,
+`perpBisector`) are copied verbatim from the parent so this file compiles
+against `Mathlib` alone. 0 `sorry`, 0 `axiom`.
+
+## References
+- Huzita, H. (1989). Axiomatic Development of Flat Origami.
+- Alperin, R.C. & Lang, R.J. (2006). One-, Two-, and Multi-fold Origami
+  Axioms. 4OSME, 371-393.
+- Demaine, E., Demaine, M., Hart, V., Price, G., Tachi, T. (2011).
+  (Non)existence of Pleated Folds.
+-/
+import Mathlib
+
+namespace AngleTrisectionOQ05OQ04Incomplete01
+
+open Real
+
+/-! ## Planar primitives (copied verbatim from the parent file) -/
+
+/-- A point in the Euclidean plane. -/
+abbrev Point := ℝ × ℝ
+
+/-- A line `a x + b y + c = 0` with `(a, b) ≠ (0, 0)`. -/
+structure Line where
+  a : ℝ
+  b : ℝ
+  c : ℝ
+  nondeg : a ≠ 0 ∨ b ≠ 0
+
+/-- A point lies on a line. -/
+def Line.contains (l : Line) (p : Point) : Prop :=
+  l.a * p.1 + l.b * p.2 + l.c = 0
+
+/-- Reflection of a point across a line, `P' = P − 2·((aPx+bPy+c)/(a²+b²))·(a,b)`. -/
+noncomputable def reflectAcross (l : Line) (p : Point) : Point :=
+  let t := 2 * (l.a * p.1 + l.b * p.2 + l.c) / (l.a^2 + l.b^2)
+  (p.1 - t * l.a, p.2 - t * l.b)
+
+/-- The squared norm of a line's normal vector is positive. -/
+theorem Line.normSq_pos (l : Line) : 0 < l.a^2 + l.b^2 := by
+  rcases l.nondeg with ha | hb
+  · have : 0 < l.a^2 := by positivity
+    nlinarith [sq_nonneg l.b]
+  · have : 0 < l.b^2 := by positivity
+    nlinarith [sq_nonneg l.a]
+
+/-- The perpendicular bisector of two distinct points `p₁ ≠ p₂`. -/
+noncomputable def perpBisector (p₁ p₂ : Point) (h : p₁ ≠ p₂) : Line where
+  a := p₂.1 - p₁.1
+  b := p₂.2 - p₁.2
+  c := -((p₂.1^2 - p₁.1^2) + (p₂.2^2 - p₁.2^2)) / 2
+  nondeg := by
+    by_contra hcontra
+    push_neg at hcontra
+    obtain ⟨ha, hb⟩ := hcontra
+    apply h
+    have hx : p₁.1 = p₂.1 := by linarith [sub_eq_zero.mp ha]
+    have hy : p₁.2 = p₂.2 := by linarith [sub_eq_zero.mp hb]
+    exact Prod.ext hx hy
+
+/-- The squared chord length is positive when `p₁ ≠ p₂`. -/
+theorem perpBisector_dirSq_pos (p₁ p₂ : Point) (h : p₁ ≠ p₂) :
+    0 < (p₂.1 - p₁.1)^2 + (p₂.2 - p₁.2)^2 := by
+  rcases eq_or_ne p₁.1 p₂.1 with hx | hx
+  · have hy : p₁.2 ≠ p₂.2 := fun heq => h (Prod.ext hx heq)
+    have h2 : 0 < (p₂.2 - p₁.2)^2 :=
+      sq_pos_of_ne_zero (sub_ne_zero.mpr (Ne.symm hy))
+    nlinarith [sq_nonneg (p₂.1 - p₁.1)]
+  · have h1 : 0 < (p₂.1 - p₁.1)^2 :=
+      sq_pos_of_ne_zero (sub_ne_zero.mpr (Ne.symm hx))
+    nlinarith [sq_nonneg (p₂.2 - p₁.2)]
+
+/-- Reflecting `p₁` across the perpendicular bisector of `p₁`, `p₂` yields `p₂`. -/
+theorem reflectAcross_perpBisector (p₁ p₂ : Point) (h : p₁ ≠ p₂) :
+    reflectAcross (perpBisector p₁ p₂ h) p₁ = p₂ := by
+  have hD : (p₂.1 - p₁.1)^2 + (p₂.2 - p₁.2)^2 ≠ 0 :=
+    ne_of_gt (perpBisector_dirSq_pos p₁ p₂ h)
+  refine Prod.ext ?_ ?_
+  · simp only [reflectAcross, perpBisector]
+    field_simp
+    ring
+  · simp only [reflectAcross, perpBisector]
+    field_simp
+    ring
+
+/-! ## New content — HH-5 constructive core (S8) -/
+
+/-- Squared Euclidean distance in the plane. (Note: this is *not* the
+default `dist` on `ℝ × ℝ`, which is the sup metric; we work with the
+polynomial squared-Euclidean form throughout.) -/
+def distSq (p q : Point) : ℝ := (p.1 - q.1)^2 + (p.2 - q.2)^2
+
+/-- **Reflection about a fixed point is an isometry (fixed-point core).**
+If a fold line `l` passes through `p₂`, then reflecting any point `p₁`
+across `l` preserves its squared distance to `p₂`. Consequently the
+landing point of `p₁` under an HH-5 fold through `p₂` is *forced* to lie
+at squared-distance `distSq p₁ p₂` from `p₂` — the equidistance condition
+below is necessary, not just sufficient. -/
+theorem reflectAcross_distSq_fixed (l : Line) (p₁ p₂ : Point)
+    (hp₂ : l.contains p₂) :
+    distSq (reflectAcross l p₁) p₂ = distSq p₁ p₂ := by
+  have hD : l.a^2 + l.b^2 ≠ 0 := ne_of_gt l.normSq_pos
+  simp only [distSq, reflectAcross, Line.contains] at hp₂ ⊢
+  field_simp
+  linear_combination
+    (4 * (l.a * p₁.1 + l.b * p₁.2 + l.c) * (l.a^2 + l.b^2)) * hp₂
+
+/-- **Equidistance ⇒ on the perpendicular bisector.** If `q` is
+equidistant (in squared Euclidean distance) from `p₁` and `p₂`, then `q`
+lies on their perpendicular bisector. -/
+theorem perpBisector_contains_of_equidistSq
+    (p₁ p₂ q : Point) (h : p₁ ≠ p₂)
+    (hequi : distSq q p₁ = distSq q p₂) :
+    (perpBisector p₁ p₂ h).contains q := by
+  simp only [distSq] at hequi
+  simp only [Line.contains, perpBisector]
+  linear_combination hequi / 2
+
+/-- **HH-5 constructive core (witnessed form).** Suppose `P₁'` is a point
+of the target line `ℓ` that is equidistant from `P₂` as `P₁` is (i.e. a
+valid landing point — the circle centred at `P₂` through `P₁` meets `ℓ`
+at `P₁'`). Then there is a fold line through `P₂` whose reflection sends
+`P₁` onto `ℓ`. The explicit witness is the perpendicular bisector of
+`P₁` and `P₁'`, which is rational in the data. -/
+theorem hh5_core (p₁ p₂ p₁' : Point) (ℓ : Line)
+    (hne : p₁ ≠ p₁')
+    (hmem : ℓ.contains p₁')
+    (hequi : distSq p₂ p₁ = distSq p₂ p₁') :
+    ∃ l : Line, l.contains p₂ ∧ ℓ.contains (reflectAcross l p₁) := by
+  refine ⟨perpBisector p₁ p₁' hne, ?_, ?_⟩
+  · exact perpBisector_contains_of_equidistSq p₁ p₁' p₂ hne hequi
+  · rw [reflectAcross_perpBisector p₁ p₁' hne]; exact hmem
+
+/-- **HH-5 constructive core (exact form).** The same fold not only lands
+`P₁` on `ℓ` but sends it precisely to the witness point `P₁'`. -/
+theorem hh5_core_exact (p₁ p₂ p₁' : Point) (ℓ : Line)
+    (hne : p₁ ≠ p₁')
+    (hmem : ℓ.contains p₁')
+    (hequi : distSq p₂ p₁ = distSq p₂ p₁') :
+    ∃ l : Line, l.contains p₂ ∧ reflectAcross l p₁ = p₁'
+      ∧ ℓ.contains (reflectAcross l p₁) := by
+  refine ⟨perpBisector p₁ p₁' hne,
+    perpBisector_contains_of_equidistSq p₁ p₁' p₂ hne hequi,
+    reflectAcross_perpBisector p₁ p₁' hne, ?_⟩
+  rw [reflectAcross_perpBisector p₁ p₁' hne]; exact hmem
+
+/-- **HH-5 solvability characterisation.** For distinct `P₁`, `P₂` and a
+target line `ℓ`, an HH-5 fold (through `P₂`, sending `P₁` onto `ℓ`) whose
+landing point is distinct from `P₁` **exists iff** `ℓ` contains a point at
+squared-distance `distSq P₁ P₂` from `P₂`. This pins down exactly the
+irrational content of HH-5: the existence of the witness landing point (a
+circle-line intersection), everything else being rational. -/
+theorem hh5_solvable_iff (p₁ p₂ : Point) (ℓ : Line) :
+    (∃ p₁' : Point, p₁ ≠ p₁' ∧ ℓ.contains p₁' ∧ distSq p₂ p₁ = distSq p₂ p₁')
+      ↔ (∃ l : Line, l.contains p₂ ∧ (∃ p₁' : Point, p₁ ≠ p₁' ∧
+          reflectAcross l p₁ = p₁' ∧ ℓ.contains p₁')) := by
+  constructor
+  · rintro ⟨p₁', hne, hmem, hequi⟩
+    obtain ⟨l, hp₂, hrefl, _⟩ := hh5_core_exact p₁ p₂ p₁' ℓ hne hmem hequi
+    exact ⟨l, hp₂, p₁', hne, hrefl, hmem⟩
+  · rintro ⟨l, hp₂, p₁', hne, hrefl, hmem⟩
+    refine ⟨p₁', hne, hmem, ?_⟩
+    have := reflectAcross_distSq_fixed l p₁ p₂ hp₂
+    rw [hrefl] at this
+    -- `distSq p₁' p₂ = distSq p₁ p₂`; convert to `distSq p₂ _` form.
+    simp only [distSq] at this ⊢
+    linear_combination -this
+
+end AngleTrisectionOQ05OQ04Incomplete01

--- a/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/annotations.json
@@ -1,0 +1,176 @@
+[
+  {
+    "id": "ann-reflect-across",
+    "proofId": "angle-trisection-oq-05-oq-04-incomplete-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 86
+    },
+    "type": "definition",
+    "title": "reflectAcross: Reflection Across a Line",
+    "content": "The reflection of a planar point P across the line ax+by+c=0 is P' = P − 2·((a·Px+b·Py+c)/(a²+b²))·(a,b). This is the geometric action of an origami fold: creasing along a line maps each point to its mirror image. Copied verbatim from the parent file.",
+    "mathContext": "Every Huzita–Hatori fold operation is expressed as a constraint on this reflection map.",
+    "significance": "high",
+    "relatedConcepts": [
+      "reflection",
+      "isometry",
+      "fold operation"
+    ],
+    "prerequisites": [
+      "coordinate geometry",
+      "lines in ℝ²"
+    ]
+  },
+  {
+    "id": "ann-normsq-pos",
+    "proofId": "angle-trisection-oq-05-oq-04-incomplete-01",
+    "range": {
+      "startLine": 88,
+      "endLine": 94
+    },
+    "type": "theorem",
+    "title": "Line.normSq_pos: Nonzero Normal Vector",
+    "content": "The squared norm a²+b² of a line's normal vector is strictly positive, derived from the non-degeneracy field a≠0∨b≠0. This discharges the denominator in reflectAcross so the reflection is always well-defined.",
+    "mathContext": "A degenerate 'line' with a=b=0 is excluded by the Line structure; this lemma converts that data into positivity of the reflection denominator.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "non-degeneracy",
+      "positivity"
+    ],
+    "prerequisites": [
+      "Line structure"
+    ]
+  },
+  {
+    "id": "ann-reflect-perpbisector",
+    "proofId": "angle-trisection-oq-05-oq-04-incomplete-01",
+    "range": {
+      "startLine": 122,
+      "endLine": 137
+    },
+    "type": "theorem",
+    "title": "reflectAcross_perpBisector: The HH-2 Reflection Law",
+    "content": "Reflecting P₁ across the perpendicular bisector of P₁ and P₂ yields exactly P₂. Plugging the bisector coefficients into reflectAcross gives reflection parameter t = −1, so P₁ maps to P₁+(P₂−P₁)=P₂. This is reused here as the mechanism that lands P₁ on its target in the HH-5 fold.",
+    "mathContext": "The perpendicular bisector is the unique fold sending P₁ to P₂; the HH-5 construction chooses P₂ to be a point of the target line.",
+    "significance": "high",
+    "relatedConcepts": [
+      "perpendicular bisector",
+      "reflection",
+      "HH-2"
+    ],
+    "prerequisites": [
+      "reflectAcross",
+      "perpBisector"
+    ]
+  },
+  {
+    "id": "ann-distsq",
+    "proofId": "angle-trisection-oq-05-oq-04-incomplete-01",
+    "range": {
+      "startLine": 137,
+      "endLine": 140
+    },
+    "type": "definition",
+    "title": "distSq: Squared Euclidean Distance",
+    "content": "distSq p q = (p.1−q.1)² + (p.2−q.2)². Used deliberately in place of Mathlib's `dist` on ℝ×ℝ, which is the SUP metric (max of coordinate differences), not the Euclidean one — using `dist` here would state a different, incorrect quantity. Squared distance keeps every statement polynomial.",
+    "mathContext": "Origami reflections are Euclidean isometries; the squared-Euclidean form is what the reflection algebra preserves and what circle-line intersection is phrased in.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Euclidean metric",
+      "product metric pitfall"
+    ],
+    "prerequisites": [
+      "real arithmetic"
+    ]
+  },
+  {
+    "id": "ann-reflect-distsq-fixed",
+    "proofId": "angle-trisection-oq-05-oq-04-incomplete-01",
+    "range": {
+      "startLine": 147,
+      "endLine": 157
+    },
+    "type": "theorem",
+    "title": "reflectAcross_distSq_fixed: Fixed-Point Isometry (Necessity)",
+    "content": "If a fold line l passes through P₂, then reflecting any point P₁ across l preserves its squared distance to P₂: distSq (reflectAcross l P₁) P₂ = distSq P₁ P₂. Proof: field_simp then linear_combination against the on-line hypothesis a·P₂x+b·P₂y+c=0, the residual polynomial vanishing exactly. This shows an HH-5 landing point is FORCED to be equidistant from P₂ — the necessity half of the characterisation.",
+    "mathContext": "A reflection whose axis passes through P₂ fixes P₂ and is an isometry, so distances to P₂ are invariant; here it certifies that no HH-5 fold can reach a landing point off the circle centred at P₂.",
+    "significance": "high",
+    "relatedConcepts": [
+      "isometry",
+      "fixed point",
+      "necessity",
+      "circle"
+    ],
+    "prerequisites": [
+      "reflectAcross",
+      "Line.normSq_pos",
+      "distSq"
+    ]
+  },
+  {
+    "id": "ann-perpbisector-equidist",
+    "proofId": "angle-trisection-oq-05-oq-04-incomplete-01",
+    "range": {
+      "startLine": 159,
+      "endLine": 171
+    },
+    "type": "theorem",
+    "title": "perpBisector_contains_of_equidistSq: Equidistant ⇒ On the Bisector",
+    "content": "A point q with distSq q P₁ = distSq q P₂ lies on the perpendicular bisector of P₁ and P₂. The incidence equation (P₂−P₁)·q coefficients equals exactly one half of the expanded equidistance identity, closed by linear_combination hequi/2.",
+    "mathContext": "The perpendicular bisector is precisely the locus of points equidistant from its two defining points; this is the converse incidence used to place P₂ on the crease.",
+    "significance": "high",
+    "relatedConcepts": [
+      "perpendicular bisector",
+      "equidistant locus"
+    ],
+    "prerequisites": [
+      "distSq",
+      "Line.contains"
+    ]
+  },
+  {
+    "id": "ann-hh5-core",
+    "proofId": "angle-trisection-oq-05-oq-04-incomplete-01",
+    "range": {
+      "startLine": 173,
+      "endLine": 199
+    },
+    "type": "theorem",
+    "title": "hh5_core / hh5_core_exact: Constructive HH-5 Fold",
+    "content": "Given distinct P₁ and a witness landing point P₁' on the target line ℓ that is equidistant from P₂ (distSq P₂ P₁ = distSq P₂ P₁'), the perpendicular bisector of P₁ and P₁' is a fold line through P₂ whose reflection sends P₁ onto ℓ (hh5_core) — indeed sends P₁ exactly to P₁' (hh5_core_exact). The crease passes through P₂ by the equidistance incidence lemma; it lands P₁ on P₁' by the HH-2 reflection law.",
+    "mathContext": "This is the sufficiency (constructive) half of HH-5: the fold is rational in the coordinates once the landing point is supplied.",
+    "significance": "high",
+    "relatedConcepts": [
+      "HH-5",
+      "origami fold",
+      "perpendicular bisector"
+    ],
+    "prerequisites": [
+      "reflectAcross_perpBisector",
+      "perpBisector_contains_of_equidistSq"
+    ]
+  },
+  {
+    "id": "ann-hh5-solvable-iff",
+    "proofId": "angle-trisection-oq-05-oq-04-incomplete-01",
+    "range": {
+      "startLine": 201,
+      "endLine": 216
+    },
+    "type": "theorem",
+    "title": "hh5_solvable_iff: Solvability Characterisation",
+    "content": "For distinct P₁, P₂ and target line ℓ: an HH-5 fold (through P₂, sending P₁ onto ℓ, with landing point distinct from P₁) EXISTS iff ℓ contains a point at squared-distance distSq P₁ P₂ from P₂. The forward direction is hh5_core_exact (sufficiency); the reverse uses reflectAcross_distSq_fixed (necessity). This pins the sole irrational content of HH-5 to the existence of the landing point — a circle-line intersection.",
+    "mathContext": "Reduces HH-5 to one Real.sqrt existence step (circle meets line) atop a rational fold, matching the Alperin–Lang degree-2 classification of HH-5 and separating it from the cubic-solving HH-6.",
+    "significance": "high",
+    "relatedConcepts": [
+      "characterisation",
+      "solvability",
+      "circle-line intersection",
+      "Alperin–Lang"
+    ],
+    "prerequisites": [
+      "hh5_core_exact",
+      "reflectAcross_distSq_fixed"
+    ]
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "angle-trisection-oq-05-oq-04-incomplete-01",
+  "title": "Curved-Crease Origami: Constructive Core of Huzita–Hatori Axiom HH-5",
+  "slug": "angle-trisection-oq-05-oq-04-incomplete-01",
+  "description": "Completes the square-root-free (rational) core of Huzita–Hatori axiom HH-5 for the open problem angle-trisection-oq-05-oq-04 (curved-crease origami: strengthening the Huzita–Hatori axioms). The parent file constructs the seven HH fold operations one axiom at a time and had reached the frontier where only HH-5 (Beloch-light), HH-6 (Beloch fold) and the intersecting case of HH-3 remained. HH-5 asks, given distinct points P₁, P₂ and a line ℓ, for a fold through P₂ that places P₁ onto ℓ. Because the fold is a reflection fixing P₂, the landing point P₁' is forced to lie on the circle centred at P₂ through P₁, so HH-5 is solvable iff that circle meets ℓ — a genuinely irrational (Real.sqrt) circle-line intersection. This self-contained file isolates that irrational existence step (kept as a witness landing point hypothesis) from the fold construction itself, which is purely rational. It proves: reflectAcross_distSq_fixed (reflecting across any fold through P₂ preserves squared distance to P₂ — reflection is an isometry about a fixed point, giving the necessity of the equidistance condition); perpBisector_contains_of_equidistSq (P₂ lies on the perpendicular bisector of P₁ and any equidistant point); hh5_core and hh5_core_exact (given a witness landing point P₁'∈ℓ equidistant from P₂, the perpendicular bisector of P₁P₁' is a fold through P₂ sending P₁ onto ℓ, and onto P₁' precisely); and hh5_solvable_iff, a full characterisation: an HH-5 fold with landing point distinct from P₁ exists iff ℓ contains a point at squared-distance |P₁−P₂|² from P₂. This pins the only irrational content of HH-5 to the existence of the witness; the fold operation carries no further algebraic degree. Self-contained (planar primitives Point, Line, reflectAcross, perpBisector copied verbatim from the parent), compiles against Mathlib alone, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Huzita%E2%80%93Hatori_axioms",
+    "date": "1989 (Huzita); 2001 (Hatori); 2006 (Alperin-Lang)",
+    "status": "verified",
+    "tags": [
+      "geometry",
+      "constructibility",
+      "origami",
+      "curved-crease",
+      "huzita-hatori",
+      "reflection",
+      "perpendicular-bisector",
+      "extension"
+    ],
+    "proofRepoPath": "Proofs/AngleTrisectionOQ05OQ04Incomplete01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 217,
+    "assumptions": [],
+    "mathlib_version": "v4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 6,
+    "mathlibDependencies": [
+      {
+        "theorem": "sq_pos_of_ne_zero",
+        "description": "A nonzero real has positive square — discharges the perpendicular-bisector chord-length positivity",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "sub_ne_zero",
+        "description": "x ≠ y ↔ x - y ≠ 0 — used in the non-degeneracy of perpBisector",
+        "module": "Mathlib.Algebra.Group.Basic"
+      },
+      {
+        "theorem": "Prod.ext",
+        "description": "Componentwise equality of pairs — planar points are pairs of reals",
+        "module": "Mathlib.Data.Prod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Line.normSq_pos: the squared norm of a line's normal vector (a²+b²) is positive from the non-degeneracy field a≠0∨b≠0",
+      "distSq: squared Euclidean distance in the plane, used throughout in place of the sup-metric `dist` on ℝ×ℝ (which would be a different, incorrect quantity)",
+      "reflectAcross_distSq_fixed: reflection across any fold line through P₂ preserves squared distance to P₂ — the fixed-point isometry core, establishing NECESSITY of the equidistance condition on an HH-5 landing point",
+      "perpBisector_contains_of_equidistSq: a point equidistant (squared Euclidean) from P₁ and P₂ lies on their perpendicular bisector",
+      "hh5_core: HH-5 constructive core (witnessed) — given a landing point P₁'∈ℓ equidistant from P₂, there is a fold through P₂ sending P₁ onto ℓ; witness is perpBisector P₁ P₁'",
+      "hh5_core_exact: strengthening of hh5_core — the same fold sends P₁ precisely to the witness P₁'",
+      "hh5_solvable_iff: full HH-5 solvability characterisation — a fold (through P₂, landing P₁ on ℓ, landing point ≠ P₁) exists IFF ℓ contains a point at squared-distance distSq P₁ P₂ from P₂; isolates the sole irrational content (circle-line witness existence)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Huzita–Hatori axioms (Huzita 1989, Justin 1991, with the seventh added by Hatori 2001) characterise the single-fold operations of origami. Alperin (2000) and Alperin–Lang (2006) showed these folds construct exactly the numbers in a tower of degree-2 and degree-3 field extensions, matching neusis (marked-ruler) constructibility and strictly exceeding compass-and-straightedge via the cubic-solving Beloch fold (HH-6). The parent research programme (angle-trisection-oq-05-oq-04) formalises each HH axiom constructively in Lean toward the open question of whether curved creases enlarge the constructible field; this entry supplies the rational core of HH-5.",
+    "problemStatement": "HH-5: given two distinct points P₁, P₂ and a line ℓ, produce a fold through P₂ that reflects P₁ onto ℓ. Formalise the rational part of this operation and characterise exactly when it is solvable.",
+    "text": "A fold is a reflection across a crease line. An HH-5 fold must fix P₂ (the crease passes through it), so it is an isometry about P₂ and the image P₁' of P₁ satisfies |P₁'−P₂| = |P₁−P₂|: the landing point lies on the circle centred at P₂ through P₁. Hence HH-5 is solvable exactly when that circle meets ℓ. Finding the landing point is a circle-line intersection — the one genuinely irrational (square-root) step. Given such a landing point P₁', the crease is simply the perpendicular bisector of P₁ and P₁' (which automatically passes through the equidistant P₂), a rational construction in the coordinates. This entry proves the rational half in full and pins the irrational half to a single explicit existence hypothesis.",
+    "proofStrategy": "Copy the parent's planar primitives (Point, Line, reflectAcross, perpBisector) verbatim so the file is self-contained. Prove the fixed-point isometry lemma reflectAcross_distSq_fixed by field_simp + linear_combination against the on-line hypothesis (necessity). Prove perpBisector_contains_of_equidistSq by expanding squared distances — the perpendicular-bisector incidence equation is exactly half the equidistance identity (linear_combination hequi/2). Assemble hh5_core / hh5_core_exact from the reflection law reflectAcross_perpBisector (already giving P₁↦P₁') plus the incidence lemma (P₂ on the bisector). Combine necessity and sufficiency into the iff characterisation hh5_solvable_iff.",
+    "keyInsights": [
+      "The crease of an HH-5 fold is forced to be the perpendicular bisector of P₁ and its landing image, because the fold fixes P₂ and is an isometry — so P₂ is automatically equidistant from source and image.",
+      "Reflection across a line through P₂ preserves squared distance to P₂; this single algebraic identity yields the necessity direction and shows the equidistance hypothesis captures ALL solvable configurations, not merely some.",
+      "The entire algebraic degree of HH-5 lives in the circle-line intersection that produces the landing point (a Real.sqrt); once that witness is given, the fold is rational, so HH-5 introduces at most a quadratic — consistent with the Alperin–Lang classification of HH-5 as a degree-2 operation.",
+      "Working with an explicit squared-Euclidean distSq rather than Mathlib's `dist` on ℝ×ℝ avoids a correctness trap: the default product metric is the sup metric, not the Euclidean one."
+    ],
+    "prerequisites": [
+      "Reflection of a point across a line ax+by+c=0 in coordinates",
+      "Perpendicular bisector as the locus of points equidistant from two given points",
+      "The Huzita–Hatori single-fold origami axioms (HH-1 through HH-7)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "planar-primitives",
+      "title": "Planar Primitives (copied from parent)",
+      "startLine": 66,
+      "endLine": 135,
+      "summary": "Point := ℝ×ℝ, the Line structure (a,b,c with a≠0∨b≠0), Line.contains, reflectAcross (P − 2·((aPx+bPy+c)/(a²+b²))·(a,b)), Line.normSq_pos (a²+b²>0 from non-degeneracy), perpBisector of two distinct points, perpBisector_dirSq_pos, and reflectAcross_perpBisector (the perpendicular bisector reflects P₁ onto P₂). Copied verbatim from Proofs/AngleTrisectionOQ05OQ04.lean so the file compiles against Mathlib alone.",
+      "mathContext": "These are the shared coordinate-geometry definitions underlying every Huzita–Hatori construction in the parent programme."
+    },
+    {
+      "id": "hh5-core",
+      "title": "HH-5 Constructive Core (S8)",
+      "startLine": 137,
+      "endLine": 216,
+      "summary": "distSq (squared Euclidean distance); reflectAcross_distSq_fixed (reflection across a fold through P₂ preserves squared distance to P₂ — necessity of equidistance); perpBisector_contains_of_equidistSq (equidistant ⇒ on the bisector); hh5_core and hh5_core_exact (witnessed constructive HH-5 folds via the perpendicular bisector of P₁ and the landing point); hh5_solvable_iff (solvability characterisation isolating the sole irrational circle-line-intersection step).",
+      "mathContext": "Reduces HH-5 to a single square-root existence (the landing point) plus a rational fold, matching the Alperin–Lang degree-2 classification of HH-5."
+    }
+  ],
+  "conclusion": {
+    "summary": "The rational core of Huzita–Hatori axiom HH-5 is formalised in Lean, 0 sorries and 0 axioms. Given a witness landing point (the sole irrational, circle-line-intersection input), the HH-5 fold is the perpendicular bisector of the source point and its image — an explicit rational construction — and hh5_solvable_iff characterises HH-5 solvability exactly by the existence of such a landing point on the target line. This advances the parent programme from six of seven constructive HH ingredients toward seven, leaving HH-3 (intersecting case) and HH-6 (Beloch cubic).",
+    "implications": [
+      "HH-5 introduces at most a quadratic field extension (the circle-line intersection), consistent with the Alperin–Lang classification separating HH-6 (the unique cubic-solving axiom) from the rest.",
+      "The isometry-about-a-fixed-point lemma reflectAcross_distSq_fixed is reusable for any HH construction whose fold passes through a prescribed point (HH-2, HH-4, HH-7 fragments).",
+      "Isolating the irrational witness as a hypothesis is the standard pattern for the remaining HH axioms (HH-3 intersecting, HH-6), whose irrational content is a Real.sqrt or a real cubic root."
+    ],
+    "openQuestions": [
+      "Discharge the witness-existence step for HH-5 (circle meets line) using Real.sqrt and the solvability condition dist(P₂,ℓ) ≤ |P₁−P₂|, yielding an unconditional HH-5 existence theorem.",
+      "The intersecting case of HH-3 (angle bisector, requires Real.sqrt) and HH-6 (Beloch fold, a real cubic root) remain for the full HHAxioms witness.",
+      "Assemble all seven constructive HH ingredients into a complete HHAxioms instance, discharging the S3 target straight_fold_recovers_HH without the structure-encoded assumption."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-05-oq-04",
+      "relationship": "extends",
+      "description": "Parent open problem — the curved-crease origami / Huzita–Hatori strengthening programme. This entry discharges the rational core of HH-5, one of the three HH ingredients the parent listed as still open (HH-3 intersecting, HH-5, HH-6). Planar primitives are copied verbatim from the parent's Proofs/AngleTrisectionOQ05OQ04.lean."
+    },
+    {
+      "targetId": "angle-trisection-oq-05",
+      "relationship": "builds-on",
+      "description": "Grandparent — defines the HHAxioms structure (the seven Huzita–Hatori axioms, HH-5 being the field discharged here in its rational core) and the origami-constructibility framework."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "AngleTrisectionOQ05OQ04Incomplete01",
+    "lineCount": 217,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 6,
+    "path": "Proofs/AngleTrisectionOQ05OQ04Incomplete01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Huzita, H.",
+      "title": "Axiomatic development of origami geometry",
+      "year": "1989",
+      "venue": "Proceedings of the First International Meeting of Origami Science and Technology",
+      "note": "Original axiomatisation of single-fold origami operations (HH-1 through HH-6)"
+    },
+    {
+      "authors": "Hatori, K.",
+      "title": "K's origami: origami construction",
+      "year": "2001",
+      "venue": "Online",
+      "note": "Added the seventh axiom HH-7 to the Huzita list"
+    },
+    {
+      "authors": "Alperin, R. C. and Lang, R. J.",
+      "title": "One-, two-, and multi-fold origami axioms",
+      "year": "2006",
+      "venue": "4th International Meeting of Origami Science, Mathematics, and Education (4OSME), 371-393",
+      "note": "Complete algebraic classification of the single-fold axioms; HH-5 is a degree-2 operation, HH-6 the unique degree-3 one"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Completes the **square-root-free (rational) core of Huzita–Hatori axiom HH-5** for the open problem `angle-trisection-oq-05-oq-04` (curved-crease origami: strengthening the Huzita–Hatori axioms). The parent programme constructs the seven HH fold operations one axiom at a time and had reached the frontier where only **HH-5** (Beloch-light), **HH-6** (Beloch fold), and the intersecting case of HH-3 remained.

**HH-5**: given distinct points `P₁`, `P₂` and a line `ℓ`, produce a fold through `P₂` placing `P₁` onto `ℓ`. The fold is a reflection fixing `P₂`, so the landing point `P₁'` lies on the circle centred at `P₂` through `P₁` — HH-5 is solvable **iff** that circle meets `ℓ`, a genuinely irrational (`Real.sqrt`) circle-line intersection. This entry isolates that irrational existence step (kept as a witness hypothesis) from the fold construction itself, which is purely **rational**.

## Theorems (8, all proved; 0 sorries, 0 axioms)

- `reflectAcross_distSq_fixed` — reflecting across any fold through `P₂` preserves squared distance to `P₂` (fixed-point isometry) ⇒ the equidistance condition on a landing point is **necessary**.
- `perpBisector_contains_of_equidistSq` — a point equidistant from `P₁`,`P₂` lies on their perpendicular bisector.
- `hh5_core` / `hh5_core_exact` — given a witness landing point `P₁' ∈ ℓ` equidistant from `P₂`, the perpendicular bisector of `P₁P₁'` is a fold through `P₂` sending `P₁` onto `ℓ` (and onto `P₁'` exactly).
- `hh5_solvable_iff` — full characterisation: an HH-5 fold (landing point ≠ `P₁`) exists **iff** `ℓ` contains a point at squared-distance `|P₁−P₂|²` from `P₂`.

This pins the sole irrational content of HH-5 to the witness existence; the fold carries no further algebraic degree, matching the Alperin–Lang degree-2 classification of HH-5 (vs. the cubic-solving HH-6).

## Verification

- Self-contained: planar primitives (`Point`, `Line`, `reflectAcross`, `perpBisector`) copied verbatim from the parent, so the file compiles against Mathlib alone.
- `#print axioms` on the main theorems: only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Genuine **0-axiom**.
- New gallery entry `src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/` (status `verified`, badge `verified`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)