### PR TITLE
Enrich L'Hôpital monotone-converse (oq-01-oq-01): +relatedConcepts/prerequisites

### DIFF
--- a/src/data/proofs/lhopital-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lhopital-oq-01-oq-01/annotations.json
@@ -7,7 +7,18 @@
     "title": "The sole analytic input: forward L'Hôpital",
     "content": "lhopital_atTop is a thin, readable repackaging of Mathlib's HasDerivAt.lhopital_zero_atTop_on_Ioi for the 0/0 indeterminate form at infinity. Everything else in the file is purely logical: it consumes the existence of lim f'/g' and uniqueness of limits. Crucially, this rule says the existence of c = lim f'/g' is enough to conclude lim f/g = c — there is no order or monotonicity premise anywhere in its statement.",
     "mathContext": "$f, g \\to 0$ on $(a,\\infty),\\ g' \\ne 0,\\ f'/g' \\to c \\ \\Rightarrow\\ f/g \\to c.$",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": [
+      "L'Hôpital's rule",
+      "indeterminate form 0/0",
+      "limits at infinity (atTop filter)",
+      "HasDerivAt.lhopital_zero_atTop_on_Ioi"
+    ],
+    "prerequisites": [
+      "derivatives and HasDerivAt",
+      "filter limits (Tendsto, 𝓝, atTop)",
+      "the forward L'Hôpital rule"
+    ]
   },
   {
     "id": "ann-lh-oq0101-main",
@@ -17,7 +28,18 @@
     "title": "Both limits existing forces them equal — no monotonicity",
     "content": "This is the headline answer. The hypothesis list contains NO monotonicity assumption. The two-line proof is the whole argument: forward L'Hôpital turns the assumed limit L = lim f'/g' into Tendsto (f/g) atTop (𝓝 L); then tendsto_nhds_unique pits this against the assumed Tendsto (f/g) atTop (𝓝 l) to force l = L. So the open question's 'whenever both limits exist' qualifier already settles equality, independently of how f/g behaves order-wise.",
     "mathContext": "$\\lim f'/g' = L \\Rightarrow \\lim f/g = L$ (forward rule); with $\\lim f/g = l$, uniqueness gives $l = L$.",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": [
+      "uniqueness of limits",
+      "tendsto_nhds_unique",
+      "Hausdorff separation",
+      "converse of L'Hôpital"
+    ],
+    "prerequisites": [
+      "the forward L'Hôpital rule",
+      "uniqueness of limits in a Hausdorff space",
+      "existence of both limits as hypotheses"
+    ]
   },
   {
     "id": "ann-lh-oq0101-unused-hyp",
@@ -27,7 +49,18 @@
     "title": "The monotonicity hypothesis, certified inert",
     "content": "monotone_quotient_converse states the open question verbatim — it explicitly assumes MonotoneOn (fun x => f x / g x) (Ioi a). The proof is converse_holds_when_both_limits_exist applied with exactly the other hypotheses; the monotonicity argument is bound to the name `_hmono` and never appears in the proof term. The leading underscore is a machine-checkable certificate that the hypothesis is discharged without use: monotonicity is a tempting but completely inert addition.",
     "mathContext": "Assuming $f/g$ monotone on $(a,\\infty)$ leaves the conclusion $l = L$ untouched; the hypothesis is logically idle.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "superfluous hypothesis",
+      "MonotoneOn",
+      "unused-variable certificate (leading underscore)",
+      "hypothesis minimization"
+    ],
+    "prerequisites": [
+      "monotone functions on an interval",
+      "reading a Lean proof term for hypothesis usage",
+      "the both-limits-exist lemma it delegates to"
+    ]
   },
   {
     "id": "ann-lh-oq0101-contrapositive",
@@ -37,7 +70,18 @@
     "title": "Non-existence is the only failure mode",
     "content": "converse_failure_only_via_nonexistence re-presents the forward rule as a transfer principle: if f'/g' converges to L, then f/g converges to the same L. Read contrapositively, two existing limits can never disagree, so the converse of L'Hôpital can break in exactly one way — lim f'/g' failing to exist. This is precisely what happens in the parent entry, where f'/g' = 1 + cos x oscillates between 0 and 2 with no limit.",
     "mathContext": "$f'/g' \\to L \\Rightarrow f/g \\to L$; the parent's $f'/g' = 1 + \\cos x$ has no limit, the sole obstruction.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "contrapositive reasoning",
+      "oscillation / non-convergence",
+      "transfer principle for limits",
+      "the parent counterexample f'/g' = 1 + cos x"
+    ],
+    "prerequisites": [
+      "the forward L'Hôpital rule as a transfer principle",
+      "when a limit fails to exist (oscillation)",
+      "the parent entry's counterexample"
+    ]
   },
   {
     "id": "ann-lh-oq0101-axioms",
@@ -47,6 +91,17 @@
     "title": "Verified, zero axioms",
     "content": "All four theorems depend only on Lean's foundational axioms propext, Classical.choice, and Quot.sound (confirmed by #print axioms). There is no sorryAx and no native_decide / Lean.ofReduceBool, so per the project's axiom-integrity policy the entry is a genuine 0-axiom, fully machine-verified result. The only mathematical assumption is Mathlib's forward L'Hôpital rule, used as a lemma, not an axiom.",
     "mathContext": "Foundational axioms (propext, Classical.choice, Quot.sound) do not count as assumptions under the project policy.",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": [
+      "axiom integrity policy",
+      "#print axioms",
+      "foundational axioms (propext, Classical.choice, Quot.sound)",
+      "0-axiom verification"
+    ],
+    "prerequisites": [
+      "Lean's foundational axioms",
+      "the distinction between a lemma and an axiom",
+      "reading #print axioms output"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lhopital-oq-01-oq-01` ("Monotone Quotients Do Not Rescue L'Hôpital's Converse — and Need Not").

The meta.json overview/conclusion/sections and annotation `content`/`mathContext`/`significance` were already strong. The one genuine gap: all 5 annotations lacked `relatedConcepts` and `prerequisites` (the role's per-annotation target).

**Change**: added accurate `relatedConcepts` and `prerequisites` arrays to each of the 5 annotations (forward L'Hôpital, uniqueness of limits, the inert-monotonicity certificate, contrapositive/non-existence failure mode, axiom integrity). No prose inflation; content untouched.

- JSON validated; annotations-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)