### PR TITLE
Enrich Hermite's Floor Identity: +1 worked-example annotation

### DIFF
--- a/src/data/proofs/hermite-floor-identity/annotations.json
+++ b/src/data/proofs/hermite-floor-identity/annotations.json
@@ -90,5 +90,27 @@
       "the floor/division interchange ⌊a/n⌋ = ⌊a⌋/n",
       "termwise rewriting of a finite sum"
     ]
+  },
+  {
+    "id": "ann-hermitefloor-worked-example",
+    "proofId": "hermite-floor-identity",
+    "range": {
+      "startLine": 85,
+      "endLine": 88
+    },
+    "type": "context",
+    "title": "The Identity in Concrete Numbers",
+    "content": "It helps to see the statement fire on small inputs. Take n = 3 and x = 2/3. The three sampled floors are ⌊2/3⌋ = 0, ⌊2/3 + 1/3⌋ = ⌊1⌋ = 1, and ⌊2/3 + 2/3⌋ = ⌊4/3⌋ = 1, summing to 2 — which is exactly ⌊3 · 2/3⌋ = ⌊2⌋ = 2. The mechanism is that as x increases, each of the n uniformly spaced floors ⌊x + k/n⌋ jumps by 1 exactly once per unit increase of x, and the jumps are staggered so that ∑ jumps at rate n, matching ⌊n·x⌋. The identity also holds for negative x, which is why the integer lemma needs two-sided induction: for n = 2, x = −1/2 the left side is ⌊−1/2⌋ + ⌊0⌋ = −1 + 0 = −1, equal to ⌊2·(−1/2)⌋ = ⌊−1⌋ = −1. The smallest nontrivial case n = 2 is the familiar ⌊x⌋ + ⌊x + 1/2⌋ = ⌊2x⌋.",
+    "mathContext": "$n=3,\\ x=\\tfrac23$: $\\lfloor\\tfrac23\\rfloor + \\lfloor 1\\rfloor + \\lfloor\\tfrac43\\rfloor = 0+1+1 = 2 = \\lfloor 2\\rfloor$. Negative case $n=2,\\ x=-\\tfrac12$: $\\lfloor-\\tfrac12\\rfloor + \\lfloor 0\\rfloor = -1 = \\lfloor-1\\rfloor$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked example",
+      "floor function jumps",
+      "the n = 2 case ⌊x⌋ + ⌊x + 1/2⌋ = ⌊2x⌋",
+      "behaviour at negative arguments"
+    ],
+    "prerequisites": [
+      "evaluating the floor function on rationals"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `hermite-floor-identity` (quality 89, pass 0).

## Changes
- **+1 annotation** (4 → 5, all with mathContext/significance/relatedConcepts/prerequisites): a concrete worked-example annotation on the theorem statement — n=3, x=2/3 (sum 0+1+1 = 2 = ⌊2⌋), a negative case n=2, x=−1/2 motivating the two-sided integer induction, and the familiar n=2 special case ⌊x⌋+⌊x+1/2⌋=⌊2x⌋.

## Notes
- The four existing annotations already cover the whole file richly; this adds genuinely new pedagogical (illustrative) content rather than deepening existing prose. meta.json untouched, within all size caps.
- JSON validated; `check-meta-size` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)