### PR TITLE
Enrich Erdős #1003 density layer (oq-03): +relatedConcepts/prerequisites

### DIFF
--- a/src/data/proofs/erdos-1003-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1003-oq-03/annotations.json
@@ -7,7 +7,18 @@
     "title": "The counting function and its bookkeeping lemma",
     "content": "ConsecutiveEqualTotients = {n | φ(n) = φ(n+1)} and countConsecutiveEqual N = #{n ≤ N : φ(n)=φ(n+1)} mirror the parent #1003 entry verbatim, keeping the density layer compatible with the existing definitions. mem_filter_iff is the workhorse identity: an element of the counted finset over Finset.range (N+1) is exactly a solution that is ≤ N. Every later proof routes membership through this equivalence, so the counting function and the set-theoretic solution set are kept in lockstep.",
     "mathContext": "$\\text{count}(N) = \\#\\{n \\le N : \\varphi(n)=\\varphi(n+1)\\}$, and $n$ counted $\\iff \\varphi(n)=\\varphi(n+1) \\wedge n \\le N$.",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euler totient φ",
+      "counting function of a set",
+      "Finset.filter and mem_filter_iff",
+      "consecutive-totient solution set"
+    ],
+    "prerequisites": [
+      "Euler's totient function",
+      "Finset.range and filtering",
+      "set-builder vs counting-function correspondence"
+    ]
   },
   {
     "id": "ann-e1003-oq03-elementary",
@@ -17,7 +28,18 @@
     "title": "Monotone and bounded: the density ratio is well-behaved",
     "content": "countConsecutiveEqual_monotone shows a wider window never loses solutions (proved directly from mem_filter_iff: a solution ≤ a is a solution ≤ b when a ≤ b), and countConsecutiveEqual_le bounds the count by N+1 (the size of {0,…,N}). With density_ratio_nonneg / density_ratio_le_one these confine count/(N+1) to [0,1], so any limit value (the natural density) necessarily lies in [0,1].",
     "mathContext": "$\\text{count}$ monotone, $\\text{count}(N) \\le N+1$, hence $\\text{count}(N)/(N+1) \\in [0,1]$.",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": [
+      "natural (asymptotic) density",
+      "monotone counting function",
+      "bounded ratio in [0,1]",
+      "density_ratio bounds"
+    ],
+    "prerequisites": [
+      "monotonicity of a set-counting function",
+      "cardinality bound #{0,…,N} = N+1",
+      "the density ratio count(N)/(N+1)"
+    ]
   },
   {
     "id": "ann-e1003-oq03-bridge",
@@ -27,7 +49,18 @@
     "title": "The bridge: infinitude ⇔ unbounded count",
     "content": "infinite_iff_count_unbounded is the structural heart, tying OQ-03's density/counting view to the infinitude view of the main #1003 conjecture and sibling OQ-02. Forward: from an infinite set, Set.Infinite.exists_subset_card_eq supplies a size-M subset; its supremum bounds a single window containing all M elements, so count there is ≥ M. Reverse (contrapositive): if the solution set is finite, every window injects into the finite set of all solutions, capping count by its cardinality — so unbounded count forces infinitude.",
     "mathContext": "$\\{n : \\varphi(n)=\\varphi(n+1)\\}$ infinite $\\iff \\forall M,\\ \\exists N,\\ M \\le \\text{count}(N)$.",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": [
+      "infinite vs finite sets (Set.Infinite)",
+      "Set.Infinite.exists_subset_card_eq",
+      "pigeonhole / injection into a finite set",
+      "Erdős #1003 infinitude conjecture"
+    ],
+    "prerequisites": [
+      "infinitude of a subset of ℕ",
+      "extracting a finite subset of prescribed size",
+      "contrapositive: finite ⇒ bounded count"
+    ]
   },
   {
     "id": "ann-e1003-oq03-finite-zero",
@@ -37,7 +70,18 @@
     "title": "Finiteness forces density 0 — the conjectured value is the baseline",
     "content": "hasNaturalDensity_zero_of_finite shows that if the solution set is finite then count is uniformly bounded by its total cardinality C, so 0 ≤ count/(N+1) ≤ C/(N+1) and squeeze_zero (with C/(N+1) → 0 from tendsto_const_div_atTop_nhds_zero_nat) gives density 0. The point: density 0 is exactly the value any finite solution set exhibits, so the conjectured answer 'density 0' is the finiteness baseline and carries strictly less information than the open infinitude conjecture.",
     "mathContext": "Finite $\\Rightarrow 0 \\le \\text{count}(N)/(N+1) \\le C/(N+1) \\to 0 \\Rightarrow$ density $0$.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "squeeze theorem (squeeze_zero)",
+      "tendsto_const_div_atTop_nhds_zero_nat",
+      "density 0 of a finite set",
+      "information content of a conjecture"
+    ],
+    "prerequisites": [
+      "the squeeze / sandwich theorem for limits",
+      "C/(N+1) → 0 as N → ∞",
+      "definition of natural density 0"
+    ]
   },
   {
     "id": "ann-e1003-oq03-pos-density",
@@ -47,6 +91,17 @@
     "title": "Positive density would resolve #1003 — locating the difficulty",
     "content": "infinite_of_pos_density: a positive natural density forces the solution set to be infinite. The proof is a one-line contradiction — were the set finite it would have density 0, and uniqueness of limits (tendsto_nhds_unique) would force d = 0, contradicting d > 0. The consequence sharpens OQ-03: any positive density is equivalent to a strong form of the open #1003 conjecture, so the genuine content lies entirely in the lower bound — the density is 0 in both the finite world and the conjectured sparse-but-infinite world.",
     "mathContext": "$\\text{density} = d > 0 \\Rightarrow$ infinite (else density $0$ and $d = 0$ by uniqueness of limits).",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "uniqueness of limits (tendsto_nhds_unique)",
+      "proof by contradiction",
+      "positive density ⇒ infinite",
+      "Erdős–Pomerance–Sárközy sparsity bound"
+    ],
+    "prerequisites": [
+      "uniqueness of limits in a Hausdorff space",
+      "the finite ⇒ density-0 lemma",
+      "positive vs zero natural density"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1003-oq-03` ("The Density Layer of Erdős #1003").

The meta.json and annotation `content`/`mathContext`/`significance` were already strong. The one genuine gap: all 5 annotations lacked `relatedConcepts` and `prerequisites`.

**Change**: added accurate `relatedConcepts` and `prerequisites` to each of the 5 annotations (totient counting function, natural density bounds, the infinitude ⇔ unbounded-count bridge, squeeze-to-zero finiteness baseline, positive-density ⇒ infinite). Content untouched; no prose inflation.

- JSON validated; annotations-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)