### PR TITLE
Enrich Elementary PNT von Mangoldt identity (oq-03): +1 worked-example annotation

### DIFF
--- a/src/data/proofs/prime-number-theorem-oq-03/annotations.json
+++ b/src/data/proofs/prime-number-theorem-oq-03/annotations.json
@@ -89,5 +89,28 @@
       "floor versus true quotient",
       "monotonicity of finite sums"
     ]
+  },
+  {
+    "id": "ann-worked-example",
+    "proofId": "prime-number-theorem-oq-03",
+    "range": {
+      "startLine": 67,
+      "endLine": 73
+    },
+    "type": "context",
+    "title": "The Identity in Concrete Numbers (N = 4)",
+    "content": "Checking the identity on N = 4 makes the double-counting tangible. The von Mangoldt values are Λ(1) = 0, Λ(2) = log 2, Λ(3) = log 3, Λ(4) = log 2 (Λ(m) = log p when m is a power of a prime p, else 0). The floor weights are ⌊4/1⌋ = 4, ⌊4/2⌋ = 2, ⌊4/3⌋ = 1, ⌊4/4⌋ = 1. So the left side is 0·4 + (log 2)·2 + (log 3)·1 + (log 2)·1 = 3 log 2 + log 3 = log(2³·3) = log 24. And the right side is log(4!) = log 24 — they match. The weight ⌊N/m⌋ counts exactly how many of 1, …, N are divisible by m, which is why each Λ(m) is tallied once for every n ≤ N it divides: this is the Dirichlet double-count log(N!) = ∑_{n≤N} log n = ∑_{n≤N} ∑_{d∣n} Λ(d) read column-by-column.",
+    "mathContext": "$N=4$: $\\sum_m \\Lambda(m)\\lfloor 4/m\\rfloor = 2\\log 2 + \\log 3 + \\log 2 = \\log(2^3\\cdot 3) = \\log 24 = \\log(4!)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked example",
+      "von Mangoldt function values on prime powers",
+      "⌊N/m⌋ counts multiples of m up to N",
+      "Dirichlet double-counting"
+    ],
+    "prerequisites": [
+      "evaluating Λ on small integers",
+      "log of a factorial"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `prime-number-theorem-oq-03` (quality 89, pass 0).

## Changes
- **+1 annotation** (4 → 5, all fully fielded): a concrete worked example on the main identity theorem — N=4 gives ∑ Λ(m)⌊4/m⌋ = 2log2 + log3 + log2 = log24 = log(4!) — making the Dirichlet double-count and the '⌊N/m⌋ counts multiples of m' weighting tangible.

## Notes
- The four existing annotations already cover the whole 122-line file; this adds new illustrative (pedagogical) content, not deepening of existing prose. meta.json untouched, within all size caps.
- JSON validated; `check-meta-size` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)