### PR TITLE
research(stirling-first-kind-oq-01-oq-01-oq-01): reverse orthogonality → two-sided Stirling matrix inverse [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean
@@ -29,6 +29,16 @@ single identity into the classical **duality between the two kinds of Stirling n
 
        `∑_{k} S(n,k) · s(k,m) = [n = m]`.
 
+4. **Reverse orthogonality / two-sided inverse** (`stirling_orthogonality_reverse`).  The
+   *other* product is the identity too, so the two triangles genuinely invert one another on
+   both sides:
+
+       `∑_{k} s(n,k) · S(k,m) = [n = m]`.
+
+   The coefficient-comparison in (3) only yields one product; the reverse direction is obtained
+   structurally from `Matrix.mul_eq_one_comm` applied to the `(n+1)×(n+1)` truncations (a
+   one-sided inverse of a square matrix over a commutative ring is automatically two-sided).
+
 ## Context / Mathlib gap
 
 Mathlib defines both `Nat.stirlingFirst` and `Nat.stirlingSecond` with their recurrences, and
@@ -51,6 +61,10 @@ using the second-kind recurrence `S(n+1,k+1) = S(n,k) + (k+1)·S(n,k+1)` reprodu
 
 (3) reads off the coefficient of `Xᵐ` in `Xⁿ`, which is `[m = n]`; expanding `Xⁿ` by (2) and each
 falling factorial's coefficient by (1) turns the same coefficient into `∑_k S(n,k)·s(k,m)`.
+
+(4) packages (3) as the statement `S · s = 1` for the `(n+1)×(n+1)` matrix truncations (the extra
+off-triangle entries vanish), then invokes `Matrix.mul_eq_one_comm` to get `s · S = 1` and reads
+off the `(n,m)` entry — the reverse orthogonality that completes the two-sided inverse.
 
 All results are `0`-axiom (kernel-checked, no `sorry`, no `native_decide`).
 -/
@@ -162,6 +176,73 @@ theorem stirling_orthogonality (n m : ℕ) :
   rw [← coeff_X_pow n m, X_pow_eq_sum_stirlingSecond_descPochhammer, finset_sum_coeff]
   refine Finset.sum_congr rfl (fun k _ => ?_)
   rw [coeff_C_mul, coeff_descPochhammer_eq_stirlingFirst]
+
+/-- **Reverse matrix inversion / orthogonality (two-sided).**  Companion to
+`stirling_orthogonality`, proving the *other* product of the two Stirling triangles is the
+identity as well, so `[s(n,k)]` and `[S(n,k)]` are genuinely **mutually inverse**:
+
+    `∑_{k=0}^{n} s(n,k) · S(k,m) = [m = n]`,
+
+where `s(n,k) = (-1)^(n+k) c(n,k)` is the signed first-kind entry.  The coefficient comparison in
+`stirling_orthogonality` produces only the product `S · s = I`; here we obtain the reverse
+`s · S = I` structurally: for a square matrix over a commutative ring a one-sided inverse is
+automatically two-sided (`Matrix.mul_eq_one_comm`), which we apply to the `(n+1)×(n+1)`
+truncations of the two triangles. -/
+theorem stirling_orthogonality_reverse (n m : ℕ) :
+    (∑ k ∈ range (n + 1),
+        ((-1) ^ (n + k) * (Nat.stirlingFirst n k : R)) * (Nat.stirlingSecond k m : R))
+      = if m = n then 1 else 0 := by
+  rcases le_or_gt m n with hmn | hnm
+  · -- `m ≤ n`: use the square truncations and `Matrix.mul_eq_one_comm`.
+    classical
+    set S : Matrix (Fin (n + 1)) (Fin (n + 1)) R :=
+      Matrix.of (fun i j => (Nat.stirlingSecond i.val j.val : R)) with hSdef
+    set s : Matrix (Fin (n + 1)) (Fin (n + 1)) R :=
+      Matrix.of (fun i j => (-1) ^ (i.val + j.val) * (Nat.stirlingFirst i.val j.val : R)) with hsdef
+    -- forward product is the identity — this is exactly `stirling_orthogonality`, extended
+    -- from `range (i+1)` to all of `Fin (n+1)` (the extra second-kind entries vanish).
+    have hSs : S * s = 1 := by
+      ext i j
+      rw [Matrix.mul_apply, Matrix.one_apply]
+      have hconv :
+          (∑ k : Fin (n + 1), S i k * s k j)
+            = ∑ k ∈ range (i.val + 1),
+                (Nat.stirlingSecond i.val k : R)
+                  * ((-1) ^ (k + j.val) * (Nat.stirlingFirst k j.val : R)) := by
+        simp only [hSdef, hsdef, Matrix.of_apply]
+        rw [Fin.sum_univ_eq_sum_range
+              (fun k => (Nat.stirlingSecond i.val k : R)
+                * ((-1) ^ (k + j.val) * (Nat.stirlingFirst k j.val : R))) (n + 1)]
+        have hsub : range (i.val + 1) ⊆ range (n + 1) := by
+          intro x hx; simp only [Finset.mem_range] at hx ⊢; have := i.isLt; omega
+        refine (Finset.sum_subset hsub ?_).symm
+        intro k _ hk
+        have hik : i.val < k := by
+          simp only [Finset.mem_range] at hk; omega
+        rw [Nat.stirlingSecond_eq_zero_of_lt hik]; simp
+      rw [hconv, stirling_orthogonality i.val j.val]
+      by_cases hij : i = j
+      · subst hij; simp
+      · have hji : j.val ≠ i.val := fun h => hij (Fin.ext h.symm)
+        simp [hji, hij]
+    -- hence the reverse product is the identity too
+    have hsS : s * S = 1 := Matrix.mul_eq_one_comm.mp hSs
+    -- read off entry `(n, m)`
+    have key := congrFun (congrFun hsS ⟨n, Nat.lt_succ_self n⟩) ⟨m, by omega⟩
+    rw [Matrix.mul_apply, Matrix.one_apply] at key
+    simp only [hSdef, hsdef, Matrix.of_apply, Fin.mk.injEq] at key
+    rw [Fin.sum_univ_eq_sum_range
+          (fun k => (-1) ^ (n + k) * (Nat.stirlingFirst n k : R)
+            * (Nat.stirlingSecond k m : R)) (n + 1)] at key
+    rw [key]
+    rcases eq_or_ne m n with h | h
+    · subst h; simp
+    · rw [if_neg h, if_neg (Ne.symm h)]
+  · -- `m > n`: every `S(k,m)` with `k ≤ n < m` vanishes, and `m ≠ n`.
+    rw [if_neg (by omega : ¬ m = n)]
+    refine Finset.sum_eq_zero (fun k hk => ?_)
+    have hkm : k < m := by simp only [Finset.mem_range] at hk; omega
+    rw [Nat.stirlingSecond_eq_zero_of_lt hkm]; simp
 
 end StirlingMatrixInversion
 

--- a/src/data/proofs/stirling-first-kind-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-01-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "stirling-first-kind-oq-01-oq-01-oq-01",
   "slug": "stirling-first-kind-oq-01-oq-01-oq-01",
   "title": "Stirling Matrix Inversion: Signed First-Kind Numbers and the Falling Factorial",
-  "description": "Answers the parent entry's open question by formalising the duality between the two kinds of Stirling numbers. Three companion facts to the parent's rising-factorial identity: (1) the coefficients of the falling factorial descPochhammer R n are the signed Stirling numbers of the first kind, (descPochhammer R n).coeff k = (-1)^(n+k)·c(n,k) = s(n,k); (2) the monomial Xⁿ expands in the falling-factorial basis with the second-kind numbers as coordinates, Xⁿ = ∑_{k=0}^{n} S(n,k)·descPochhammer R k; (3) combining (1) and (2) and comparing the coefficient of Xᵐ shows the signed first-kind matrix [s(n,k)] and the second-kind matrix [S(n,k)] are mutually inverse: ∑_k S(n,k)·s(k,m) = [m=n]. Mathlib defines Nat.stirlingFirst, Nat.stirlingSecond, ascPochhammer and descPochhammer but connects none of them.",
+  "description": "Answers the parent entry's open question by formalising the duality between the two kinds of Stirling numbers. Three companion facts to the parent's rising-factorial identity: (1) the coefficients of the falling factorial descPochhammer R n are the signed Stirling numbers of the first kind, (descPochhammer R n).coeff k = (-1)^(n+k)·c(n,k) = s(n,k); (2) the monomial Xⁿ expands in the falling-factorial basis with the second-kind numbers as coordinates, Xⁿ = ∑_{k=0}^{n} S(n,k)·descPochhammer R k; (3) combining (1) and (2) and comparing the coefficient of Xᵐ shows the signed first-kind matrix [s(n,k)] and the second-kind matrix [S(n,k)] are mutually inverse: ∑_k S(n,k)·s(k,m) = [m=n]. Mathlib defines Nat.stirlingFirst, Nat.stirlingSecond, ascPochhammer and descPochhammer but connects none of them. A fourth theorem, stirling_orthogonality_reverse, proves the reverse product ∑_k s(n,k)·S(k,m) = [m=n] as well — obtained structurally from Matrix.mul_eq_one_comm on the finite triangular truncations — so the two matrices are genuinely mutually inverse on both sides (a two-sided inverse).",
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -13,9 +13,9 @@
       "Finset"
     ],
     "namespace": "StirlingMatrixInversion",
-    "lineCount": 166,
+    "lineCount": 248,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 5,
     "definitionCount": 0,
     "mainTheorems": [
       {
@@ -41,6 +41,12 @@
         "type": "original",
         "description": "The multiplication engine driving the second-kind expansion: X·descPochhammer R k = descPochhammer R (k+1) + k·descPochhammer R k, the falling-factorial analogue of X·xᵏ = xᵏ⁺¹",
         "leanType": "(k : ℕ) → (X : R[X]) * descPochhammer R k = descPochhammer R (k + 1) + (k : R[X]) * descPochhammer R k"
+      },
+      {
+        "name": "stirling_orthogonality_reverse",
+        "type": "original",
+        "description": "Reverse orthogonality completing the two-sided inverse: the other product of the two Stirling triangles is also the identity, ∑_k s(n,k)·S(k,m) = [m=n]. Obtained structurally from Matrix.mul_eq_one_comm applied to the (n+1)×(n+1) truncations, since a one-sided inverse of a square matrix over a commutative ring is automatically two-sided.",
+        "leanType": "(n m : ℕ) → (∑ k ∈ Finset.range (n + 1), ((-1) ^ (n + k) * (Nat.stirlingFirst n k : R)) * (Nat.stirlingSecond k m : R)) = if m = n then 1 else 0"
       }
     ],
     "path": "Proofs/StirlingFirstKindOQ01OQ01OQ01.lean",
@@ -62,7 +68,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 166,
+    "lineCount": 248,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (each of the four theorems depends only on propext, Classical.choice, Quot.sound). The results connect four existing but previously unlinked Mathlib definitions — Nat.stirlingFirst, Nat.stirlingSecond, ascPochhammer, descPochhammer — using the falling-factorial recurrence descPochhammer_succ_right, both Stirling recurrences, and standard polynomial coefficient lemmas. Mathlib contains neither the signed-coefficient identity, the second-kind falling-factorial expansion, nor the orthogonality relation.",
     "originalContributions": [
       "coeff_descPochhammer_eq_stirlingFirst: (descPochhammer R n).coeff k = (-1)^(n+k)·c(n,k) — original, the signed first-kind companion to the parent's unsigned rising-factorial identity, proved by induction through descPochhammer_succ_right with the alternating sign carried as (-1)^(n+k)",
@@ -175,10 +181,18 @@
       "endLine": 165,
       "summary": "Proves stirling_orthogonality: ∑_k S(n,k)·s(k,m) = [m=n]. The proof rewrites the Kronecker delta as coeff m of Xⁿ (coeff_X_pow), expands Xⁿ by the second-kind identity, distributes the coefficient over the sum (finset_sum_coeff), and applies coeff_C_mul together with the signed first-kind identity to each term, turning the single coefficient into ∑_k S(n,k)·s(k,m).",
       "mathContext": "$[m=n] = (X^n).\\mathrm{coeff}\\,m = \\sum_k S(n,k)\\,(x^{(k\\downarrow)}).\\mathrm{coeff}\\,m = \\sum_k S(n,k)\\,s(k,m)$."
+    },
+    {
+      "id": "reverse-orthogonality",
+      "title": "Reverse Orthogonality (Two-Sided Inverse)",
+      "startLine": 167,
+      "endLine": 247,
+      "summary": "Proves stirling_orthogonality_reverse: ∑_k s(n,k)·S(k,m) = [m=n], the companion product completing the two-sided inverse. The coefficient comparison of the previous section yields only S·s = I; here the two triangles are packaged as (n+1)×(n+1) matrices S and s over Fin (n+1). The forward identity is re-derived as the matrix equation S*s = 1 (extending the range-(i+1) sum to all of Fin (n+1), where the off-triangle second-kind entries vanish), and Matrix.mul_eq_one_comm then gives s*S = 1 for free. Reading off the (n,m) entry recovers the reverse orthogonality. The case m>n is handled elementarily since every S(k,m) with k≤n<m vanishes.",
+      "mathContext": "For square matrices over a commutative ring, $AB=I \\iff BA=I$; applied to the triangular truncations of $[s(n,k)]$ and $[S(n,k)]$ this upgrades the one-sided relation $S\\cdot s = I$ to the two-sided $s\\cdot S = I$, i.e. $\\sum_k s(n,k)\\,S(k,m) = [m=n]$."
     }
   ],
   "conclusion": {
-    "summary": "The two Stirling triangles are mutually inverse change-of-basis matrices: the falling factorial's coefficients are the signed first-kind numbers s(n,k) = (-1)^(n+k)·c(n,k), the monomial Xⁿ expands in the falling-factorial basis with the second-kind numbers, and comparing the coefficient of Xᵐ in Xⁿ forces ∑_k S(n,k)·s(k,m) = [m=n]. All four results are verified over an arbitrary commutative ring with 0 axioms and 0 sorries, completing the parent entry's rising-factorial picture on the falling-factorial side.",
+    "summary": "The two Stirling triangles are mutually inverse change-of-basis matrices: the falling factorial's coefficients are the signed first-kind numbers s(n,k) = (-1)^(n+k)·c(n,k), the monomial Xⁿ expands in the falling-factorial basis with the second-kind numbers, and comparing the coefficient of Xᵐ in Xⁿ forces ∑_k S(n,k)·s(k,m) = [m=n]. All four results are verified over an arbitrary commutative ring with 0 axioms and 0 sorries, completing the parent entry's rising-factorial picture on the falling-factorial side. The reverse product s·S = I is also established (via Matrix.mul_eq_one_comm on the finite truncations), so the inversion is genuinely two-sided.",
     "implications": [
       "Bridges four previously disconnected Mathlib definitions — Nat.stirlingFirst, Nat.stirlingSecond, ascPochhammer, descPochhammer — with the missing change-of-basis identities in both directions between monomials and factorials.",
       "Supplies the orthogonality relation ∑_k S(n,k)·s(k,m) = [m=n] as reusable infrastructure for finite-difference calculus, Stirling-transform inversion, and umbral identities.",

--- a/src/data/research/problems/stirling-first-kind-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/stirling-first-kind-oq-01-oq-01-oq-01.json
@@ -1,0 +1,41 @@
+{
+  "slug": "stirling-first-kind-oq-01-oq-01-oq-01",
+  "phase": "COMPLETE",
+  "status": "completed",
+  "currentState": {
+    "phase": "COMPLETE",
+    "since": "2026-07-01T16:00:00.000Z",
+    "iteration": 1,
+    "focus": "Falling-factorial companion identity, Stirling matrix inversion, and the reverse (two-sided) orthogonality.",
+    "blockers": [],
+    "nextAction": "None — problem solved; two-sided Stirling matrix inversion formalized and verified 0-axiom.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED and shipped. The falling-factorial companion to the signed Stirling-first-kind identity and the mutual inversion of the two Stirling triangles are fully formalized in proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean (gallery entry stirling-first-kind-oq-01-oq-01-oq-01), 0 axioms / 0 sorries. This iteration additionally proved the REVERSE orthogonality s·S = I, upgrading the previously one-sided 'mutually inverse' claim to a genuine two-sided inverse.",
+    "builtItems": [
+      "coeff_descPochhammer_eq_stirlingFirst: (descPochhammer R n).coeff k = (-1)^(n+k)·c(n,k) = s(n,k) — the signed first-kind coefficients of the falling factorial (0-axiom).",
+      "X_pow_eq_sum_stirlingSecond_descPochhammer: Xⁿ = ∑_{k≤n} S(n,k)·descPochhammer R k — monomial expansion in the falling-factorial basis (0-axiom).",
+      "stirling_orthogonality: ∑_k S(n,k)·s(k,m) = [m=n] — the S·s = I direction, via coefficient comparison (0-axiom).",
+      "stirling_orthogonality_reverse (NEW this iteration): ∑_k s(n,k)·S(k,m) = [m=n] — the s·S = I direction, giving a genuine two-sided inverse (0-axiom)."
+    ],
+    "insights": [
+      "The signed first-kind matrix and the second-kind matrix are the mutually-inverse change-of-basis matrices between the monomial basis {Xⁿ} and the falling-factorial basis {descPochhammer R n}.",
+      "Coefficient comparison of Xⁿ=Xⁿ yields only ONE product (S·s=I). The reverse direction (s·S=I) does not fall out of the same comparison and needs a separate argument.",
+      "The reverse direction is obtained structurally, not by re-running the polynomial argument: for the (n+1)×(n+1) truncations over Fin (n+1), Matrix.mul_eq_one_comm upgrades S*s=1 to s*S=1 (a one-sided inverse of a square matrix over a commutative ring is two-sided). Off-triangle entries vanish (stirlingSecond_eq_zero_of_lt), so the finite truncation faithfully carries the identity."
+    ],
+    "mathlibGaps": [
+      "Mathlib defines Nat.stirlingFirst, Nat.stirlingSecond, ascPochhammer, descPochhammer but links none of them: no falling-factorial coefficient identity, no Stirling matrix inversion (either direction)."
+    ],
+    "nextSteps": [
+      "Optional: state the inversion as an actual Matrix.inv / IsUnit fact over ℤ, or generalize the two-sided-inverse packaging into a reusable lemma about triangular integer change-of-basis matrices."
+    ]
+  },
+  "significance": 6,
+  "tractability": 7,
+  "lastUpdate": "2026-07-01T16:00:00.000Z"
+}


### PR DESCRIPTION
## Summary

Problem `stirling-first-kind-oq-01-oq-01-oq-01` — *Falling-Factorial Companion Identity and Stirling Matrix Inversion* — was already answered by the shipped gallery entry, but that entry proved only **one** direction of the inversion (`stirling_orthogonality`: $S\cdot s = I$) while its prose claims the two triangles are *mutually inverse*. This PR closes that honesty gap by adding the **reverse orthogonality**, giving a genuine **two-sided** inverse.

## What's added

`stirling_orthogonality_reverse` (in `proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean`):

$$\sum_{k=0}^{n} s(n,k)\,S(k,m) = [m=n], \qquad s(n,k)=(-1)^{n+k}c(n,k).$$

### Technique
Rather than re-running the polynomial coefficient argument (which only yields $S\cdot s=I$), the reverse direction is obtained **structurally**:
- Package the two triangles as $(n{+}1)\times(n{+}1)$ matrices `S`, `s` over `Fin (n+1)`.
- Re-derive the forward identity as the matrix equation `S * s = 1` (extending the `range (i+1)` sum to all of `Fin (n+1)`; the off-triangle second-kind entries vanish by `Nat.stirlingSecond_eq_zero_of_lt`).
- Apply **`Matrix.mul_eq_one_comm`**: for a square matrix over a commutative ring a one-sided inverse is automatically two-sided, so `s * S = 1`.
- Read off the $(n,m)$ entry. The $m>n$ case is elementary (every $S(k,m)$ with $k\le n<m$ vanishes).

## Verification
- **0 axioms** — `#print axioms` on both `stirling_orthogonality` and `stirling_orthogonality_reverse` reports only `propext, Classical.choice, Quot.sound`.
- 0 sorries, no `native_decide`. Compiled with `lake env lean` (Mathlib v4.26).
- File: 166 → 248 lines, 4 → 5 theorems.

## Also
- `meta.json`: theorem count 4→5, new "Reverse Orthogonality (Two-Sided Inverse)" section, updated description/conclusion.
- Adds the problem knowledge record (`src/data/research/problems/...json`), status `completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)