### PR TITLE
research(euler-totient-oq-02-oq-02): Euler's theorem via the group structure of (ℤ/nℤ)ˣ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ02OQ02.lean
+++ b/proofs/Proofs/EulerTotientOQ02OQ02.lean
@@ -1,0 +1,147 @@
+/-
+# Euler's Theorem via the Group Structure of (ℤ/nℤ)ˣ  (OQ02-OQ02)
+
+The base entry `euler-totient` states Euler's theorem `a^φ(n) ≡ 1 (mod n)` and
+discharges it in one line by citing Mathlib's `ZMod.pow_totient`, treating the
+underlying group mechanism as a black box. Its worked examples lean on
+`native_decide`, which pulls in the `Lean.ofReduceBool` axiom.
+
+This file makes the **group-theoretic mechanism explicit** and stays strictly
+`0`-axiom (no `native_decide`). The organising object is the finite abelian
+group of units `(ℤ/nℤ)ˣ`, whose order is `φ(n)`. Every statement below is a
+consequence of a single structural fact — **Lagrange's theorem** — applied to
+that group:
+
+    the multiplicative order of a unit divides the group order `φ(n)`.
+
+## Main results
+
+1. `orderOf_unit_dvd_totient` — the sharp refinement: the multiplicative order
+   of any unit divides `φ(n)`. This is *stronger* than Euler's theorem: it says
+   `φ(n)` is a universal exponent, and pinpoints exactly why `a^φ(n) = 1`.
+2. `euler_units` — Euler's theorem for units, derived from (1) through
+   `orderOf_dvd_iff_pow_eq_one`. The proof is the honest Lagrange argument, not
+   a citation of the packaged theorem.
+3. `euler_modEq` — the number-theoretic form `a^φ(n) ≡ 1 (mod n)` over `ℕ`.
+4. `pow_mod_totient` / `pow_mod_totient_modEq` — exponents may be reduced modulo
+   `φ(n)`: `a^k = a^(k % φ(n))`. This is the practical payoff of the order
+   dividing `φ(n)` and is what makes modular exponentiation efficient.
+5. `fermat_little_of_euler` — Fermat's little theorem recovered as the prime
+   special case `φ(p) = p - 1`.
+6. `coprime_of_pow_modEq_one` — the **converse direction**: if some positive
+   power of `a` is `≡ 1 (mod n)` then `a` must be coprime to `n`. This replaces
+   the base file's `native_decide` non-coprime counterexamples with the general
+   `0`-axiom theorem explaining *why* coprimality is forced (a non-unit can
+   never be sent to `1` by any power).
+
+Only the foundational axioms `propext`, `Classical.choice`, `Quot.sound` are
+used; confirmed via `#print axioms`. No `sorryAx`, no `Lean.ofReduceBool`.
+-/
+
+import Mathlib
+
+namespace EulerTotientOQ02OQ02
+
+open Nat
+
+variable {n : ℕ}
+
+-- ============================================================
+-- SECTION I: The structural refinement (Lagrange in the unit group)
+-- ============================================================
+
+/-- **The refinement underlying Euler's theorem.** The multiplicative order of
+any unit of `ℤ/nℤ` divides `φ(n)`. This is Lagrange's theorem for the finite
+group `(ℤ/nℤ)ˣ`, whose cardinality is `φ(n)`. It is strictly stronger than
+`a^φ(n) = 1`: it exhibits `φ(n)` as a *universal exponent* for the unit group. -/
+theorem orderOf_unit_dvd_totient [NeZero n] (a : (ZMod n)ˣ) :
+    orderOf a ∣ φ n := by
+  rw [← ZMod.card_units_eq_totient n]
+  exact orderOf_dvd_card
+
+-- ============================================================
+-- SECTION II: Euler's theorem for units, via explicit Lagrange
+-- ============================================================
+
+/-- **Euler's theorem for units**, obtained *from* `orderOf_unit_dvd_totient`
+rather than by citing the packaged `ZMod.pow_totient`. The bridge is
+`orderOf_dvd_iff_pow_eq_one`: an element killed by its order is killed by any
+multiple of it, and `φ(n)` is such a multiple. -/
+theorem euler_units [NeZero n] (a : (ZMod n)ˣ) :
+    a ^ φ n = 1 :=
+  orderOf_dvd_iff_pow_eq_one.mp (orderOf_unit_dvd_totient a)
+
+-- ============================================================
+-- SECTION III: The number-theoretic form (ℕ)
+-- ============================================================
+
+/-- **Euler's theorem over `ℕ`.** For `a` coprime to `n`, `a^φ(n) ≡ 1 (mod n)`.
+This is the arithmetic shadow of `euler_units`: a coprime residue is a unit, and
+units satisfy `x^φ(n) = 1`. -/
+theorem euler_modEq {a : ℕ} (h : Nat.Coprime a n) :
+    a ^ φ n ≡ 1 [MOD n] :=
+  Nat.ModEq.pow_totient h
+
+-- ============================================================
+-- SECTION IV: Exponent reduction modulo φ(n)
+-- ============================================================
+
+/-- **Exponents reduce modulo `φ(n)` (unit form).** Because `a^φ(n) = 1`, only
+the residue of the exponent modulo `φ(n)` matters: `a^k = a^(k % φ(n))`. This is
+the algebraic engine behind fast modular exponentiation. -/
+theorem pow_mod_totient [NeZero n] (a : (ZMod n)ˣ) (k : ℕ) :
+    a ^ k = a ^ (k % φ n) := by
+  conv_lhs => rw [← Nat.mod_add_div k (φ n)]
+  rw [pow_add, pow_mul, euler_units, one_pow, mul_one]
+
+/-- **Exponents reduce modulo `φ(n)` (arithmetic form).** For `a` coprime to
+`n`, `a^k ≡ a^(k % φ(n)) (mod n)`. -/
+theorem pow_mod_totient_modEq {a : ℕ} (h : Nat.Coprime a n) (k : ℕ) :
+    a ^ k ≡ a ^ (k % φ n) [MOD n] := by
+  conv_lhs => rw [← Nat.mod_add_div k (φ n)]
+  calc a ^ (k % φ n + φ n * (k / φ n))
+      = a ^ (k % φ n) * (a ^ φ n) ^ (k / φ n) := by rw [pow_add, pow_mul]
+    _ ≡ a ^ (k % φ n) * 1 ^ (k / φ n) [MOD n] :=
+        (Nat.ModEq.refl _).mul ((euler_modEq h).pow _)
+    _ = a ^ (k % φ n) := by rw [one_pow, mul_one]
+
+-- ============================================================
+-- SECTION V: Fermat's little theorem as the prime special case
+-- ============================================================
+
+/-- **Fermat's little theorem**, recovered from Euler's theorem by specialising
+to a prime modulus, where `φ(p) = p - 1`. -/
+theorem fermat_little_of_euler {p a : ℕ} (hp : p.Prime) (h : Nat.Coprime a p) :
+    a ^ (p - 1) ≡ 1 [MOD p] := by
+  have := euler_modEq h
+  rwa [Nat.totient_prime hp] at this
+
+-- ============================================================
+-- SECTION VI: Coprimality is necessary (the converse; 0-axiom)
+-- ============================================================
+
+/-- **Coprimality is forced.** If any *positive* power of `a` is `≡ 1 (mod n)`,
+then `a` is coprime to `n`. Structurally: `a^k = 1` in `ℤ/nℤ` exhibits `a` as a
+unit (with inverse `a^(k-1)`), and units of `ℤ/nℤ` are exactly the coprime
+residues. This is the general theorem behind the base file's `native_decide`
+non-coprime counterexamples — here proved with no decision procedure. -/
+theorem coprime_of_pow_modEq_one {a k : ℕ} (hk : 0 < k)
+    (h : a ^ k ≡ 1 [MOD n]) : Nat.Coprime a n := by
+  rw [← ZMod.isUnit_iff_coprime]
+  -- Transport the congruence into `ZMod n`.
+  have hcast : (a : ZMod n) ^ k = 1 := by
+    have : ((a ^ k : ℕ) : ZMod n) = ((1 : ℕ) : ZMod n) :=
+      (ZMod.natCast_eq_natCast_iff _ _ _).2 h
+    simpa using this
+  -- `a^k = 1` with `k ≠ 0` exhibits `a` as a unit (inverse `a^(k-1)`).
+  exact IsUnit.of_pow_eq_one hcast hk.ne'
+
+/-- **Contrapositive, as used in practice.** A residue sharing a nontrivial
+factor with `n` cannot satisfy Euler's congruence for the totient exponent when
+`0 < φ(n)` — indeed for no positive exponent at all. Stated as: non-coprime
+implies no positive power hits `1`. -/
+theorem no_pow_modEq_one_of_not_coprime {a k : ℕ} (hk : 0 < k)
+    (h : ¬ Nat.Coprime a n) : ¬ a ^ k ≡ 1 [MOD n] :=
+  fun hcon => h (coprime_of_pow_modEq_one hk hcon)
+
+end EulerTotientOQ02OQ02

--- a/src/data/proofs/euler-totient-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-02/annotations.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "ann-lagrange-refinement",
+    "proofId": "euler-totient-oq-02-oq-02",
+    "range": {
+      "startLine": 57,
+      "endLine": 60
+    },
+    "type": "insight",
+    "title": "The Refinement: Order Divides φ(n) (Lagrange)",
+    "content": "The entire file is organized around one fact that is *strictly stronger* than Euler's theorem:\n```\ntheorem orderOf_unit_dvd_totient [NeZero n] (a : (ZMod n)ˣ) :\n    orderOf a ∣ φ n := by\n  rw [← ZMod.card_units_eq_totient n]\n  exact orderOf_dvd_card\n```\nThe multiplicative order of a unit divides `φ(n)`. This is Lagrange's theorem applied to the finite group `(ℤ/nℤ)ˣ`, whose cardinality is `φ(n)`.\n\nWhy stronger than `a^φ(n) = 1`? Because it names `φ(n)` as a **universal exponent** and pinpoints the mechanism: every unit is killed by its own order, and `φ(n)` is a multiple of that order. Euler's theorem is the immediate corollary (Section II). The base entry `euler-totient` cites `ZMod.pow_totient` directly and never surfaces this dividing relation.",
+    "mathContext": "$\\operatorname{ord}(a) \\mid |(\\mathbb{Z}/n\\mathbb{Z})^\\times| = \\varphi(n)$. Two Mathlib facts combine: \\texttt{ZMod.card\\_units\\_eq\\_totient} ($|(\\mathbb{Z}/n\\mathbb{Z})^\\times| = \\varphi(n)$) and \\texttt{orderOf\\_dvd\\_card} (Lagrange: order divides group cardinality).",
+    "significance": "key",
+    "relatedConcepts": [
+      "orderOf_dvd_card",
+      "ZMod.card_units_eq_totient",
+      "Lagrange's theorem",
+      "universal exponent"
+    ],
+    "prerequisites": [
+      "euler-totient"
+    ]
+  },
+  {
+    "id": "ann-euler-via-lagrange",
+    "proofId": "euler-totient-oq-02-oq-02",
+    "range": {
+      "startLine": 70,
+      "endLine": 72
+    },
+    "type": "insight",
+    "title": "Euler's Theorem as a One-Line Corollary of the Refinement",
+    "content": "Once `orderOf a ∣ φ(n)` is in hand, Euler's theorem for units is the bridge lemma `orderOf_dvd_iff_pow_eq_one`:\n```\ntheorem euler_units [NeZero n] (a : (ZMod n)ˣ) : a ^ φ n = 1 :=\n  orderOf_dvd_iff_pow_eq_one.mp (orderOf_unit_dvd_totient a)\n```\nThis is the honest Lagrange derivation. Contrast the base entry, which proves the same statement by `ZMod.pow_totient a` — a citation that hides the group-order argument entirely. Here every step is visible: order divides `φ(n)` ⟹ `a` raised to that multiple is the identity.",
+    "mathContext": "$a^{\\varphi(n)} = 1$ follows from $\\operatorname{ord}(a) \\mid \\varphi(n)$ because $x^m = 1 \\iff \\operatorname{ord}(x) \\mid m$ (\\texttt{orderOf\\_dvd\\_iff\\_pow\\_eq\\_one}).",
+    "significance": "key",
+    "relatedConcepts": [
+      "orderOf_dvd_iff_pow_eq_one",
+      "Euler's theorem",
+      "cyclic order"
+    ],
+    "prerequisites": [
+      "euler-totient"
+    ]
+  },
+  {
+    "id": "ann-exponent-reduction",
+    "proofId": "euler-totient-oq-02-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 106
+    },
+    "type": "technique",
+    "title": "Exponent Reduction: a^k = a^(k mod φ(n))",
+    "content": "The practically important corollary of `a^φ(n) = 1` is that exponents may be reduced modulo `φ(n)`:\n```\ntheorem pow_mod_totient [NeZero n] (a : (ZMod n)ˣ) (k : ℕ) :\n    a ^ k = a ^ (k % φ n) := by\n  conv_lhs => rw [← Nat.mod_add_div k (φ n)]\n  rw [pow_add, pow_mul, euler_units, one_pow, mul_one]\n```\nThe proof splits `k = (k % φ(n)) + φ(n)·(k / φ(n))`, so `a^k = a^(k % φ(n)) · (a^φ(n))^(k/φ(n))` and the second factor collapses to `1` by Euler's theorem. `pow_mod_totient_modEq` is the `ℕ`-congruence version for coprime `a`.\n\nThis is exactly why modular exponentiation is fast — and why RSA decryption `m^(ed) ≡ m` works, since `ed ≡ 1 (mod φ(n))`.",
+    "mathContext": "$a^k = a^{k \\bmod \\varphi(n)}$ because $a^{\\varphi(n)} = 1$: with $k = (k \\bmod \\varphi(n)) + \\varphi(n) q$, one has $a^k = a^{k \\bmod \\varphi(n)} \\cdot (a^{\\varphi(n)})^q = a^{k \\bmod \\varphi(n)}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "modular exponentiation",
+      "Nat.mod_add_div",
+      "RSA",
+      "division algorithm"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-fermat-special-case",
+    "proofId": "euler-totient-oq-02-oq-02",
+    "range": {
+      "startLine": 114,
+      "endLine": 117
+    },
+    "type": "insight",
+    "title": "Fermat's Little Theorem as φ(p) = p − 1",
+    "content": "Fermat's little theorem is nothing but Euler's theorem at a prime modulus:\n```\ntheorem fermat_little_of_euler {p a : ℕ} (hp : p.Prime) (h : Nat.Coprime a p) :\n    a ^ (p - 1) ≡ 1 [MOD p] := by\n  have := euler_modEq h\n  rwa [Nat.totient_prime hp] at this\n```\nSince `φ(p) = p - 1` for prime `p` (`Nat.totient_prime`), the totient exponent in Euler's congruence becomes `p - 1`. This makes the historical order of discovery explicit: Fermat (1640) is the prime case; Euler (1763) is the general modulus.",
+    "mathContext": "$a^{p-1} \\equiv 1 \\pmod p$ for prime $p \\nmid a$, obtained from $a^{\\varphi(p)} \\equiv 1 \\pmod p$ and $\\varphi(p) = p - 1$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Fermat's little theorem",
+      "Nat.totient_prime"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-coprimality-converse",
+    "proofId": "euler-totient-oq-02-oq-02",
+    "range": {
+      "startLine": 128,
+      "endLine": 145
+    },
+    "type": "insight",
+    "title": "Coprimality Is Forced — the 0-Axiom Converse",
+    "content": "The base entry demonstrates the necessity of the coprimality hypothesis with `native_decide` counterexamples (e.g. `2^φ(4) ≢ 1 (mod 4)`), which pull in the `Lean.ofReduceBool` axiom. This file proves the general theorem instead:\n```\ntheorem coprime_of_pow_modEq_one {a k : ℕ} (hk : 0 < k)\n    (h : a ^ k ≡ 1 [MOD n]) : Nat.Coprime a n := by\n  rw [← ZMod.isUnit_iff_coprime]\n  have hcast : (a : ZMod n) ^ k = 1 := by ...\n  exact IsUnit.of_pow_eq_one hcast hk.ne'\n```\nIf *any* positive power of `a` is `≡ 1 (mod n)`, then `a` must be coprime to `n`. Reason: `a^k = 1` in `ℤ/nℤ` exhibits `a` as a unit (inverse `a^(k-1)`, via `IsUnit.of_pow_eq_one`), and units of `ℤ/nℤ` are exactly the coprime residues (`ZMod.isUnit_iff_coprime`). `no_pow_modEq_one_of_not_coprime` is the contrapositive. This is strictly more informative than any finite table of counterexamples — and it is `0`-axiom.",
+    "mathContext": "$a^k \\equiv 1 \\pmod n$ with $k > 0 \\Rightarrow \\gcd(a,n) = 1$. In $\\mathbb{Z}/n\\mathbb{Z}$, $a^k = 1$ makes $a$ a unit ($a \\cdot a^{k-1} = 1$); units are exactly the coprime residues. A non-coprime residue is a zero-divisor, and no power of a zero-divisor is $1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsUnit.of_pow_eq_one",
+      "ZMod.isUnit_iff_coprime",
+      "zero-divisor",
+      "native_decide avoidance"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/euler-totient-oq-02-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-02/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "euler-totient-oq-02-oq-02",
+  "title": "Euler's Theorem via the Group Structure of (ℤ/nℤ)ˣ",
+  "slug": "euler-totient-oq-02-oq-02",
+  "description": "Re-derives Euler's theorem a^φ(n) ≡ 1 (mod n) from the finite abelian group (ℤ/nℤ)ˣ, making the mechanism explicit rather than citing Mathlib's packaged ZMod.pow_totient. The organizing fact is Lagrange's theorem: the multiplicative order of a unit divides |(ℤ/nℤ)ˣ| = φ(n). From this single refinement follow Euler's congruence, exponent reduction a^k = a^(k mod φ(n)), Fermat's little theorem, and the converse that coprimality is necessary — replacing the base file's native_decide counterexamples with a general theorem. 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "group-theory",
+      "modular-arithmetic",
+      "totient",
+      "lagrange-theorem"
+    ],
+    "proofRepoPath": "Proofs/EulerTotientOQ02OQ02.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide`. All 8 theorems depend only on the ordinary foundational axioms propext, Classical.choice, Quot.sound (confirmed via `#print axioms`); there is no `sorryAx` and no `Lean.ofReduceBool`. This entry deliberately avoids the base file's `native_decide` numerical checks, replacing the non-coprime counterexamples with the general 0-axiom theorem `coprime_of_pow_modEq_one`.",
+    "lineCount": 147,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-07-01"
+  },
+  "overview": {
+    "historicalContext": "Euler's theorem, $a^{\\varphi(n)} \\equiv 1 \\pmod{n}$ for $\\gcd(a,n)=1$, is #10 on Wiedijk's list of 100 theorems and the generalization of Fermat's little theorem. Its modern proof is purely structural: the residues coprime to $n$ form a finite abelian group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ of order $\\varphi(n)$, and **Lagrange's theorem** says the order of any element divides the order of the group. Hence every unit raised to the $\\varphi(n)$-th power is the identity.\n\nThe base gallery entry [Euler's Theorem](euler-totient) states this and discharges it in a single line by citing Mathlib's `ZMod.pow_totient`, treating the group mechanism as a black box; its worked examples use `native_decide`, which pulls the `Lean.ofReduceBool` axiom into `#print axioms`. This entry re-opens the black box: it derives Euler's theorem *from* Lagrange's theorem inside Lean, and stays strictly $0$-axiom by proving the general structural facts instead of checking numerical instances.",
+    "problemStatement": "**Open Question (OQ-02-OQ-02)**: Can Euler's theorem $a^{\\varphi(n)} \\equiv 1 \\pmod n$ be formalized *via the group structure* of $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ — deriving it from Lagrange's theorem rather than citing the packaged result — and can the surrounding structural facts (the multiplicative order dividing $\\varphi(n)$, exponent reduction modulo $\\varphi(n)$, and the necessity of coprimality) be captured $0$-axiom, without `native_decide`?\n\n**Answer: YES.** The single fact `orderOf a ∣ φ(n)` — Lagrange for $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, whose cardinality is $\\varphi(n)$ by `ZMod.card_units_eq_totient` — yields Euler's theorem through `orderOf_dvd_iff_pow_eq_one`. Exponent reduction, Fermat's little theorem, and the coprimality converse all follow, each with only the foundational axioms.",
+    "proofStrategy": "The file is organized around one structural refinement and its consequences:\n\n**Section I (Lagrange refinement):** `orderOf_unit_dvd_totient` proves `orderOf a ∣ φ(n)` for a unit `a : (ZMod n)ˣ` by rewriting `φ(n)` as `Fintype.card (ZMod n)ˣ` (`ZMod.card_units_eq_totient`) and applying `orderOf_dvd_card`. This is strictly stronger than Euler's theorem — it exhibits `φ(n)` as a universal exponent.\n\n**Section II (Euler for units):** `euler_units` derives `a^φ(n) = 1` from the refinement via `orderOf_dvd_iff_pow_eq_one`, the honest Lagrange argument rather than a citation of `ZMod.pow_totient`.\n\n**Section III (arithmetic form):** `euler_modEq` gives `a^φ(n) ≡ 1 [MOD n]` for coprime `a`.\n\n**Section IV (exponent reduction):** `pow_mod_totient` and `pow_mod_totient_modEq` prove `a^k = a^(k % φ(n))` — the algebraic engine of fast modular exponentiation — by splitting `k = (k % φ(n)) + φ(n)·(k / φ(n))` and killing the second factor with Euler's theorem.\n\n**Section V (Fermat):** `fermat_little_of_euler` recovers `a^(p-1) ≡ 1 [MOD p]` by specializing to `φ(p) = p - 1`.\n\n**Section VI (converse, 0-axiom):** `coprime_of_pow_modEq_one` proves that if any positive power of `a` is `≡ 1 (mod n)` then `a` is coprime to `n`: the congruence exhibits `(a : ZMod n)` as a unit (`IsUnit.of_pow_eq_one`), and units of `ZMod n` are exactly the coprime residues (`ZMod.isUnit_iff_coprime`). `no_pow_modEq_one_of_not_coprime` is the contrapositive, generalizing the base file's `native_decide` non-coprime examples.",
+    "keyInsights": [
+      "Euler's theorem is not a monolithic fact but a corollary of a single sharper statement: the multiplicative order of a unit divides φ(n). Making this refinement (orderOf_unit_dvd_totient) the primitive turns Euler's theorem, exponent reduction, and Fermat's little theorem into one-line consequences.",
+      "The proof cost of Euler's theorem is entirely front-loaded into Mathlib's ZMod.card_units_eq_totient (|units| = φ(n)) and orderOf_dvd_card (Lagrange). Once these are in hand, orderOf_dvd_iff_pow_eq_one converts 'order divides φ(n)' into 'a^φ(n) = 1' mechanically — this is the exact bridge the base entry's one-line citation hides.",
+      "Exponent reduction a^k = a^(k mod φ(n)) is the practically important corollary: it is why modular exponentiation is fast and underlies RSA decryption. It is a direct consequence of a^φ(n) = 1 via the division algorithm on the exponent, requiring no new mathematics.",
+      "Coprimality is genuinely necessary, and this can be stated as a general 0-axiom theorem rather than checked case-by-case: a^k ≡ 1 (mod n) with k > 0 forces (a : ZMod n) to be a unit (inverse a^(k-1)), and units are exactly the coprime residues. This replaces native_decide counterexamples like 2^φ(4) ≢ 1 (mod 4) with the reason they must fail.",
+      "Avoiding native_decide keeps the entry strictly 0-axiom (only propext, Classical.choice, Quot.sound), whereas the base entry's numerical examples introduce Lean.ofReduceBool. The structural route is both more general and axiom-cleaner than the computational one."
+    ],
+    "prerequisites": [
+      "Euler's totient function and Euler's theorem (euler-totient)",
+      "Finite group theory: order of an element, Lagrange's theorem (orderOf_dvd_card)",
+      "The unit group (ZMod n)ˣ and ZMod.card_units_eq_totient",
+      "orderOf_dvd_iff_pow_eq_one and the ZMod.isUnit_iff_coprime characterization"
+    ]
+  },
+  "sections": [
+    {
+      "id": "lagrange-refinement",
+      "title": "Section I: The Structural Refinement — order divides φ(n)",
+      "startLine": 57,
+      "endLine": 60,
+      "summary": "orderOf_unit_dvd_totient: for a unit a of ℤ/nℤ, orderOf a ∣ φ(n). This is Lagrange's theorem for the group (ℤ/nℤ)ˣ, whose cardinality is φ(n).",
+      "mathContext": "$\\operatorname{ord}(a) \\mid |(\\mathbb{Z}/n\\mathbb{Z})^\\times| = \\varphi(n)$. Proof: rewrite $\\varphi(n)$ as $\\texttt{Fintype.card}\\,(\\mathbb{Z}/n\\mathbb{Z})^\\times$ via \\texttt{ZMod.card\\_units\\_eq\\_totient}, then apply \\texttt{orderOf\\_dvd\\_card} (Lagrange). Strictly stronger than $a^{\\varphi(n)}=1$: it names $\\varphi(n)$ as a universal exponent."
+    },
+    {
+      "id": "euler-units",
+      "title": "Section II: Euler's Theorem for Units, via Explicit Lagrange",
+      "startLine": 70,
+      "endLine": 72,
+      "summary": "euler_units: a^φ(n) = 1 for a unit a, obtained from orderOf a ∣ φ(n) through orderOf_dvd_iff_pow_eq_one — the honest derivation, not a citation of ZMod.pow_totient.",
+      "mathContext": "$a^{\\varphi(n)} = 1$ because $\\operatorname{ord}(a) \\mid \\varphi(n)$ and an element is killed by any multiple of its order (\\texttt{orderOf\\_dvd\\_iff\\_pow\\_eq\\_one}). This exposes the mechanism the base entry hides behind \\texttt{ZMod.pow\\_totient}."
+    },
+    {
+      "id": "arithmetic-form",
+      "title": "Section III: The Number-Theoretic Form over ℕ",
+      "startLine": 81,
+      "endLine": 83,
+      "summary": "euler_modEq: for gcd(a,n)=1, a^φ(n) ≡ 1 [MOD n]. The arithmetic shadow of euler_units: a coprime residue is a unit.",
+      "mathContext": "$a^{\\varphi(n)} \\equiv 1 \\pmod n$ for $\\gcd(a,n)=1$. A coprime residue $a$ maps to a unit of $\\mathbb{Z}/n\\mathbb{Z}$, and units satisfy $x^{\\varphi(n)}=1$."
+    },
+    {
+      "id": "exponent-reduction",
+      "title": "Section IV: Exponent Reduction modulo φ(n)",
+      "startLine": 92,
+      "endLine": 106,
+      "summary": "pow_mod_totient (a^k = a^(k % φ(n)) for units) and pow_mod_totient_modEq (a^k ≡ a^(k % φ(n)) [MOD n] for coprime a). The engine behind fast modular exponentiation.",
+      "mathContext": "$a^k = a^{k \\bmod \\varphi(n)}$: write $k = (k \\bmod \\varphi(n)) + \\varphi(n)\\lfloor k/\\varphi(n)\\rfloor$, so $a^k = a^{k\\bmod\\varphi(n)}\\cdot(a^{\\varphi(n)})^{\\lfloor k/\\varphi(n)\\rfloor} = a^{k\\bmod\\varphi(n)}$. This is why modular exponentiation (and RSA decryption) is efficient."
+    },
+    {
+      "id": "fermat",
+      "title": "Section V: Fermat's Little Theorem as the Prime Case",
+      "startLine": 114,
+      "endLine": 117,
+      "summary": "fermat_little_of_euler: for prime p and gcd(a,p)=1, a^(p-1) ≡ 1 [MOD p], recovered by specializing φ(p) = p - 1.",
+      "mathContext": "$a^{p-1} \\equiv 1 \\pmod p$ for prime $p \\nmid a$, since $\\varphi(p) = p - 1$ (\\texttt{Nat.totient\\_prime}). Fermat's little theorem is exactly Euler's theorem at a prime modulus."
+    },
+    {
+      "id": "converse",
+      "title": "Section VI: Coprimality Is Necessary (the Converse)",
+      "startLine": 128,
+      "endLine": 145,
+      "summary": "coprime_of_pow_modEq_one: if a^k ≡ 1 [MOD n] for some k > 0 then gcd(a,n)=1. no_pow_modEq_one_of_not_coprime is the contrapositive. General 0-axiom replacement for the base file's native_decide non-coprime counterexamples.",
+      "mathContext": "If $a^k \\equiv 1 \\pmod n$ with $k>0$ then $\\gcd(a,n)=1$: the congruence gives $(a)^k = 1$ in $\\mathbb{Z}/n\\mathbb{Z}$, exhibiting $a$ as a unit with inverse $a^{k-1}$ (\\texttt{IsUnit.of\\_pow\\_eq\\_one}); and units of $\\mathbb{Z}/n\\mathbb{Z}$ are exactly the coprime residues (\\texttt{ZMod.isUnit\\_iff\\_coprime}). Hence no non-coprime residue can satisfy Euler's congruence for any positive exponent."
+    }
+  ],
+  "conclusion": {
+    "summary": "Euler's theorem is re-derived from the group structure of (ℤ/nℤ)ˣ: Lagrange's theorem gives orderOf a ∣ φ(n), from which a^φ(n) = 1 follows through orderOf_dvd_iff_pow_eq_one. The same refinement yields exponent reduction a^k = a^(k mod φ(n)), Fermat's little theorem, and the converse that coprimality is necessary. All 8 theorems are machine-verified 0-axiom with 0 sorries and no native_decide — strictly axiom-cleaner than the base entry, whose numerical examples rely on Lean.ofReduceBool.",
+    "implications": "Making `orderOf a ∣ φ(n)` the primitive clarifies *why* Euler's theorem holds and simultaneously supplies its most useful corollary — exponent reduction modulo $\\varphi(n)$, which is the algebraic basis of RSA. The converse theorem `coprime_of_pow_modEq_one` shows that coprimality is not a convenient hypothesis but a forced one: a residue that shares a factor with $n$ is a zero-divisor, and no power of a zero-divisor can be $1$. Presenting this as a general theorem, rather than a battery of `native_decide` checks, both generalizes the claim and removes the `Lean.ofReduceBool` axiom from the proof's footprint.",
+    "openQuestions": [
+      "The order dividing φ(n) is not always sharp: the exponent of (ℤ/nℤ)ˣ is the Carmichael function λ(n) | φ(n). Can the sharper 'a^λ(n) ≡ 1 (mod n)' be formalized and λ(n) characterized as the true universal exponent?",
+      "For which n is (ℤ/nℤ)ˣ cyclic (equivalently, does a primitive root exist)? This is exactly the case where some unit attains order φ(n), making Euler's exponent optimal — can the classification n ∈ {1,2,4,p^k,2p^k} be derived from this order-theoretic viewpoint?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient",
+      "relationship": "extends",
+      "description": "Re-proves the parent's Euler's theorem from Lagrange's theorem in (ℤ/nℤ)ˣ, 0-axiom and without the parent's native_decide examples"
+    },
+    {
+      "targetId": "euler-totient-oq-02",
+      "relationship": "complements",
+      "description": "The parent OQ-02 proves multiplicativity of φ; this entry uses |units| = φ(n) as the group order in the Lagrange argument"
+    },
+    {
+      "targetId": "euler-totient-oq-02-oq-01",
+      "relationship": "complements",
+      "description": "Sibling entry deriving the Euler product formula for φ(n); this entry instead exploits φ(n) as the order of the unit group"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "Theoremata arithmetica nova methodo demonstrata",
+      "year": "1763",
+      "venue": "Novi Commentarii academiae scientiarum Petropolitanae 8, 74–104",
+      "note": "Euler's proof of the theorem now bearing his name, a^φ(n) ≡ 1 (mod n) for gcd(a,n)=1, generalizing Fermat's little theorem."
+    },
+    {
+      "authors": "Lagrange, Joseph-Louis",
+      "title": "Réflexions sur la résolution algébrique des équations",
+      "year": "1771",
+      "venue": "Nouveaux Mémoires de l'Académie de Berlin",
+      "note": "Origin of the theorem that the order of a subgroup (and hence of an element) divides the order of the group — the structural fact underlying this formalization."
+    },
+    {
+      "authors": "Hardy, G.H. and Wright, E.M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "venue": "Oxford University Press",
+      "note": "Chapter 6 develops Fermat–Euler theory and the group of reduced residues (ℤ/nℤ)ˣ; Euler's theorem is Theorem 72."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 147,
+    "path": "Proofs/EulerTotientOQ02OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 8
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
Research session for **euler-totient-oq-02-oq-02**: *Euler's Theorem via the Group Structure of (ℤ/nℤ)ˣ*.

The base gallery entry [`euler-totient`](../tree/main/src/data/proofs/euler-totient) states Euler's theorem `a^φ(n) ≡ 1 (mod n)` and discharges it in one line by citing Mathlib's `ZMod.pow_totient`, treating the group mechanism as a black box; its worked examples use `native_decide` (which pulls in `Lean.ofReduceBool`). This entry **re-opens the black box** and derives Euler's theorem *from* Lagrange's theorem inside Lean, staying strictly 0-axiom.

## Mathematical content
The whole file hangs on one refinement, strictly stronger than Euler's theorem:

- **`orderOf_unit_dvd_totient`** — `orderOf a ∣ φ(n)` for a unit `a : (ZMod n)ˣ`. Lagrange for `(ℤ/nℤ)ˣ`, whose cardinality is `φ(n)` (`ZMod.card_units_eq_totient` + `orderOf_dvd_card`).

From it:
- **`euler_units`** — `a^φ(n) = 1`, via `orderOf_dvd_iff_pow_eq_one` (the honest Lagrange derivation, not a citation).
- **`euler_modEq`** — arithmetic form `a^φ(n) ≡ 1 [MOD n]`.
- **`pow_mod_totient` / `pow_mod_totient_modEq`** — exponent reduction `a^k = a^(k % φ(n))` (the engine of fast modular exponentiation / RSA).
- **`fermat_little_of_euler`** — Fermat's little theorem as the `φ(p) = p − 1` special case.
- **`coprime_of_pow_modEq_one`** (+ contrapositive) — the **converse**: any positive power `≡ 1 (mod n)` forces coprimality, since `a^k = 1` makes `a` a unit (`IsUnit.of_pow_eq_one`) and units are exactly the coprime residues (`ZMod.isUnit_iff_coprime`). This is the general 0-axiom replacement for the base file's `native_decide` non-coprime counterexamples.

## Verification
- **8 theorems, 1 def-free, 0 sorries, 0 `axiom` declarations, no `native_decide`.**
- `#print axioms` on all 8 theorems yields only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Strictly axiom-cleaner than the base entry.
- Built against Mathlib v4.26.0 (`lake env lean`; Docker image unavailable this cycle due to a containerd fault).

## Files
- `proofs/Proofs/EulerTotientOQ02OQ02.lean` (147 lines)
- `src/data/proofs/euler-totient-oq-02-oq-02/{meta.json,annotations.json}`

## Status
**Outcome**: completed (VERIFIED, 0-axiom)
**Next steps**: sharper universal exponent via the Carmichael function λ(n) | φ(n); primitive-root classification (when (ℤ/nℤ)ˣ is cyclic, Euler's exponent is optimal).

🤖 Generated by researcher-9