### PR TITLE
research(bezout-identity-oq-03-oq-04-oq-01-oq-01): iterated CRT for multiple coprime moduli over CommRing [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ03OQ04OQ01OQ01.lean
+++ b/proofs/Proofs/BezoutIdentityOQ03OQ04OQ01OQ01.lean
@@ -1,0 +1,196 @@
+import Mathlib.RingTheory.Coprime.Basic
+import Mathlib.RingTheory.Coprime.Lemmas
+import Mathlib.Tactic
+
+/-
+# Bézout Identity OQ03-OQ04-OQ01-OQ01:
+# Iterated CRT for Multiple Coprime Moduli over Commutative Rings
+
+## Open Question (bezout-identity-oq-03-oq-04-oq-01-oq-01)
+
+Parent open question #1 of `bezout-identity-oq-03-oq-04-oq-01`
+("CRT for Commutative Rings via Bézout Coefficients"):
+
+"Can the folding approach for multiple coprime moduli (iterated CRT) be
+generalized to commutative rings? The key lemma needed: if IsCoprime m₁ m₂
+and IsCoprime (m₁*m₂) m₃, then IsCoprime m₁ (m₂*m₃) — available in Mathlib
+as IsCoprime.mul_right."
+
+## Answer
+
+YES. Given a list of (residue, modulus) pairs whose moduli are *pairwise*
+coprime in an arbitrary `CommRing R`, the CRT system always has a solution,
+and any two solutions agree modulo the product of the moduli.
+
+The construction folds the two-modulus CRT (from the parent file) over the
+list. The crux is that a single modulus that is coprime to each modulus in a
+list is coprime to their product — proved here by induction from
+`IsCoprime.mul_right` (exactly the lemma flagged in the open question).
+
+## Builds On
+- BezoutIdentityOQ03OQ04OQ01.lean: the two-modulus `crtRing` over a CommRing.
+  The two-modulus construction is reproduced inline so this file is
+  self-contained (Mathlib-only imports).
+-/
+
+namespace BezoutIdentityOQ03OQ04OQ01OQ01
+
+/-! ## Part 1: Two-modulus CRT (reproduced from the parent, self-contained) -/
+
+/-- The direct Bézout CRT formula over any commutative ring. -/
+def crtRing {R : Type*} [CommRing R] (a b s t m n : R) : R :=
+  b * s * m + a * t * n
+
+theorem crtRing_mod_m {R : Type*} [CommRing R] (a b s t m n : R)
+    (hbez : s * m + t * n = 1) :
+    m ∣ (crtRing a b s t m n - a) :=
+  ⟨b * s - a * s, by unfold crtRing; linear_combination a * hbez⟩
+
+theorem crtRing_mod_n {R : Type*} [CommRing R] (a b s t m n : R)
+    (hbez : s * m + t * n = 1) :
+    n ∣ (crtRing a b s t m n - b) :=
+  ⟨a * t - b * t, by unfold crtRing; linear_combination b * hbez⟩
+
+/-- Two-modulus existence: coprime `m, n` ⟹ the system `(a,m), (b,n)` is solvable. -/
+theorem crtRing_exists {R : Type*} [CommRing R] (a b m n : R)
+    (hcop : IsCoprime m n) :
+    ∃ x : R, m ∣ (x - a) ∧ n ∣ (x - b) := by
+  obtain ⟨s, t, hst⟩ := hcop
+  exact ⟨crtRing a b s t m n,
+         crtRing_mod_m a b s t m n hst,
+         crtRing_mod_n a b s t m n hst⟩
+
+/-! ## Part 2: Coprimality to a product
+
+The lemma named in the open question: an element coprime to every factor is
+coprime to the product. Folded from `IsCoprime.mul_right`
+(`IsCoprime a b → IsCoprime a c → IsCoprime a (b*c)`) and
+`isCoprime_one_right` (`IsCoprime a 1`). -/
+
+/-- If `a` is coprime to every element of a list `l`, then `a` is coprime to
+    `l.prod`. This is the iterated form of `IsCoprime.mul_right`. -/
+theorem isCoprime_list_prod {R : Type*} [CommRing R] (a : R) :
+    ∀ l : List R, (∀ b ∈ l, IsCoprime a b) → IsCoprime a l.prod
+  | [], _ => by simp only [List.prod_nil]; exact isCoprime_one_right
+  | b :: t, h => by
+      rw [List.prod_cons]
+      exact (h b (List.mem_cons_self)).mul_right
+        (isCoprime_list_prod a t (fun c hc => h c (List.mem_cons_of_mem _ hc)))
+
+/-! ## Part 3: Iterated CRT existence (the folding approach)
+
+We work over a list of `(residue, modulus)` pairs whose moduli are pairwise
+coprime, encoded by `List.Pairwise (fun p q => IsCoprime p.2 q.2)`.
+
+The fold: given a solution `x` for the tail with modulus product `M`, the head
+modulus `p.2` is coprime to `M` (Part 2), so the two-modulus CRT produces a
+`y` congruent to the head residue mod `p.2` and to `x` mod `M`. Since every
+tail modulus divides `M`, `y` inherits every tail congruence. -/
+
+/-- **Iterated CRT existence over an arbitrary commutative ring.**
+    For pairwise-coprime moduli, the simultaneous congruence system is solvable. -/
+theorem crtRing_list_exists {R : Type*} [CommRing R] :
+    ∀ l : List (R × R),
+      l.Pairwise (fun p q => IsCoprime p.2 q.2) →
+      ∃ x : R, ∀ p ∈ l, p.2 ∣ (x - p.1)
+  | [], _ => ⟨0, by simp⟩
+  | p :: t, hpw => by
+      obtain ⟨htp, htail⟩ := List.pairwise_cons.mp hpw
+      obtain ⟨x, hx⟩ := crtRing_list_exists t htail
+      -- M = product of the tail moduli
+      set M := (t.map Prod.snd).prod with hM
+      have hcopM : IsCoprime p.2 M := by
+        apply isCoprime_list_prod
+        intro b hb
+        obtain ⟨q, hq, rfl⟩ := List.mem_map.mp hb
+        exact htp q hq
+      obtain ⟨y, hy1, hy2⟩ := crtRing_exists p.1 x p.2 M hcopM
+      refine ⟨y, ?_⟩
+      intro q hq
+      rcases List.mem_cons.mp hq with rfl | hqt
+      · exact hy1
+      · -- q.2 ∣ M ∣ (y - x), and q.2 ∣ (x - q.1), so q.2 ∣ (y - q.1)
+        have hdvdM : q.2 ∣ M := by
+          rw [hM]; exact List.dvd_prod (List.mem_map.mpr ⟨q, hqt, rfl⟩)
+        have h1 : q.2 ∣ (y - x) := hdvdM.trans hy2
+        have h2 : q.2 ∣ (x - q.1) := hx q hqt
+        have h3 : q.2 ∣ ((y - x) + (x - q.1)) := dvd_add h1 h2
+        simpa using h3
+
+/-! ## Part 4: Iterated CRT uniqueness
+
+Any two solutions of the system agree modulo the product of all moduli. The
+crux is the dual of Part 2: pairwise-coprime elements each dividing `d` have
+their product dividing `d`, folded from `IsCoprime.mul_dvd`. -/
+
+/-- If a list of pairwise-coprime elements each divide `d`, so does their product. -/
+theorem prod_dvd_of_pairwise_coprime {R : Type*} [CommRing R] (d : R) :
+    ∀ l : List R, l.Pairwise IsCoprime → (∀ b ∈ l, b ∣ d) → l.prod ∣ d
+  | [], _, _ => by simpa using one_dvd d
+  | b :: t, hpw, hd => by
+      obtain ⟨hbt, htail⟩ := List.pairwise_cons.mp hpw
+      have hcop : IsCoprime b t.prod :=
+        isCoprime_list_prod b t (fun c hc => hbt c hc)
+      have ht : t.prod ∣ d :=
+        prod_dvd_of_pairwise_coprime d t htail
+          (fun c hc => hd c (List.mem_cons_of_mem _ hc))
+      have hb : b ∣ d := hd b (List.mem_cons_self)
+      rw [List.prod_cons]
+      exact hcop.mul_dvd hb ht
+
+/-- **Iterated CRT uniqueness over an arbitrary commutative ring.**
+    Two solutions `x, y` of the same pairwise-coprime system agree modulo the
+    product of all moduli. -/
+theorem crtRing_list_unique {R : Type*} [CommRing R] (l : List (R × R)) (x y : R)
+    (hpw : l.Pairwise (fun p q => IsCoprime p.2 q.2))
+    (hxy : ∀ p ∈ l, p.2 ∣ (x - y)) :
+    (l.map Prod.snd).prod ∣ (x - y) := by
+  apply prod_dvd_of_pairwise_coprime
+  · exact List.pairwise_map.mpr hpw
+  · intro b hb
+    obtain ⟨q, hq, rfl⟩ := List.mem_map.mp hb
+    exact hxy q hq
+
+/-! ## Part 5: Worked instance — three pairwise-coprime moduli -/
+
+/-- The iterated theorem specializes to any fixed number of moduli. Here three
+    pairwise-coprime moduli in an arbitrary `CommRing`. -/
+theorem crtRing_three {R : Type*} [CommRing R]
+    (a₁ a₂ a₃ m₁ m₂ m₃ : R)
+    (h₁₂ : IsCoprime m₁ m₂) (h₁₃ : IsCoprime m₁ m₃) (h₂₃ : IsCoprime m₂ m₃) :
+    ∃ x : R, m₁ ∣ (x - a₁) ∧ m₂ ∣ (x - a₂) ∧ m₃ ∣ (x - a₃) := by
+  have hpw : [(a₁, m₁), (a₂, m₂), (a₃, m₃)].Pairwise (fun p q => IsCoprime p.2 q.2) := by
+    refine .cons ?_ (.cons ?_ (.cons ?_ .nil))
+    · intro q hq; fin_cases hq
+      · exact h₁₂
+      · exact h₁₃
+    · intro q hq; fin_cases hq
+      · exact h₂₃
+    · intro q hq; fin_cases hq
+  obtain ⟨x, hx⟩ := crtRing_list_exists _ hpw
+  exact ⟨x, hx (a₁, m₁) (by simp), hx (a₂, m₂) (by simp), hx (a₃, m₃) (by simp)⟩
+
+/-! ## Summary -/
+
+/-
+## The Answer to OQ-03-OQ-04-OQ-01-OQ-01
+
+**YES**, the folding approach for iterated CRT generalizes to any commutative ring.
+
+Key facts:
+1. `isCoprime_list_prod` — an element coprime to each factor is coprime to the
+   product. This is the iterated `IsCoprime.mul_right` flagged in the question.
+2. `crtRing_list_exists` — pairwise-coprime moduli give a solvable system. The
+   proof folds the two-modulus `crtRing`, using that every tail modulus divides
+   the tail product (`List.dvd_prod`) to inherit congruences.
+3. `prod_dvd_of_pairwise_coprime` / `crtRing_list_unique` — solutions are unique
+   modulo the product of all moduli, folding `IsCoprime.mul_dvd`.
+4. Everything is stated over an arbitrary `CommRing R`: ℤ, k[X], ℤ[i], any PID.
+-/
+
+#check @crtRing_list_exists
+#check @crtRing_list_unique
+#check @isCoprime_list_prod
+#check @crtRing_three
+
+end BezoutIdentityOQ03OQ04OQ01OQ01

--- a/research/problems/bezout-identity-oq-03-oq-04-oq-01-oq-01/knowledge.md
+++ b/research/problems/bezout-identity-oq-03-oq-04-oq-01-oq-01/knowledge.md
@@ -1,0 +1,45 @@
+# Knowledge: Iterated CRT over Commutative Rings
+
+## Summary
+
+The two-modulus CRT (`crtRing = b·s·m + a·t·n`) folds over a list of
+pairwise-coprime moduli to give iterated CRT existence and uniqueness over any
+`CommRing`, with no ring-specific machinery.
+
+## Key lemmas / techniques
+
+- **`isCoprime_list_prod`** — an element coprime to every entry of a list is
+  coprime to the list product. Two-case list induction folding
+  `IsCoprime.mul_right` (`IsCoprime a b → IsCoprime a c → IsCoprime a (b*c)`)
+  and `isCoprime_one_right`. This is the lemma the parent OQ named.
+- **`crtRing_list_exists`** — pairwise-coprime moduli (encoded
+  `List.Pairwise (fun p q => IsCoprime p.2 q.2)`) give a solvable system.
+  Induct on the list; `List.pairwise_cons` yields head-vs-tail coprimalities
+  (→ `isCoprime_list_prod` gives head coprime to tail product) and the tail's
+  own pairwise structure (→ IH). One `crtRing_exists` combines head residue
+  with the tail solution; `List.dvd_prod` propagates tail congruences via
+  `q.2 ∣ M ∣ y - x` plus `q.2 ∣ x - q.1` and `dvd_add`.
+- **`prod_dvd_of_pairwise_coprime` / `crtRing_list_unique`** — the dual fold of
+  `IsCoprime.mul_dvd`; `List.pairwise_map` transports pairwise coprimality from
+  pairs to their moduli.
+- **`crtRing_three`** — three-modulus specialization; build the `List.Pairwise`
+  witness with explicit `.cons`/`.nil` and discharge membership with `fin_cases`.
+
+## Gotchas encountered
+
+- `hx _ (by simp)` leaves metavariables — pass the explicit pair
+  `hx (a₁, m₁) (by simp)` so Lean knows which list member.
+- For the concrete three-element `List.Pairwise`, a `simp` + `rcases` approach
+  is fragile (trailing `∨ False` disjunct from `mem_cons` on `[]`). Explicit
+  `Pairwise.cons` constructors + `fin_cases hq` is robust.
+- Base case `IsCoprime a (List.prod [])`: `simp only [List.prod_nil]; exact
+  isCoprime_one_right` (bare `simpa` triggers the unnecessarySimpa linter).
+- Docker build down (containerd I/O); compiled via
+  `lake env lean -o .lake/build/lib/lean/Proofs/<name>.olean`.
+
+## Remaining open questions
+
+- Repackage as a ring isomorphism `R/(∏ mᵢ) ≅ ∏ (R/mᵢ)` via
+  `Ideal.quotientInfRingEquivPiQuotient`.
+- Extract an explicit k-modulus reconstruction formula + complexity bound.
+- Relax pairwise coprimality to coprimality of successive partial products.

--- a/research/problems/bezout-identity-oq-03-oq-04-oq-01-oq-01/problem.md
+++ b/research/problems/bezout-identity-oq-03-oq-04-oq-01-oq-01/problem.md
@@ -1,0 +1,27 @@
+# Problem: Iterated CRT for Multiple Coprime Moduli over Commutative Rings
+
+**Slug**: bezout-identity-oq-03-oq-04-oq-01-oq-01
+**Status**: Completed
+**Source**: bezout-identity-oq-03-oq-04-oq-01 (open question #1)
+
+## Problem Statement
+
+Can the folding approach for multiple coprime moduli (iterated CRT) be
+generalized to commutative rings? The key lemma named in the parent open
+question: if `IsCoprime m₁ m₂` and `IsCoprime (m₁*m₂) m₃`, then
+`IsCoprime m₁ (m₂*m₃)` — available in Mathlib as `IsCoprime.mul_right`.
+
+## Answer
+
+YES. Over an arbitrary `CommRing R`, a list of `(residue, modulus)` pairs with
+pairwise-coprime moduli always has a simultaneous solution
+(`crtRing_list_exists`), unique modulo the product of all moduli
+(`crtRing_list_unique`). The construction folds the two-modulus `crtRing`; the
+crux is `isCoprime_list_prod` (an element coprime to each factor is coprime to
+the product), the iterated form of `IsCoprime.mul_right` the question flagged.
+
+## Result
+
+- Lean file: `Proofs/BezoutIdentityOQ03OQ04OQ01OQ01.lean`
+- Gallery: `src/data/proofs/bezout-identity-oq-03-oq-04-oq-01-oq-01/`
+- Status: VERIFIED, 0 axioms, 0 sorries, 8 theorems / 1 definition / 196 lines.

--- a/research/problems/bezout-identity-oq-03-oq-04-oq-01-oq-01/state.md
+++ b/research/problems/bezout-identity-oq-03-oq-04-oq-01-oq-01/state.md
@@ -1,0 +1,26 @@
+# Research State: bezout-identity-oq-03-oq-04-oq-01-oq-01
+
+## Current State
+**Phase**: COMPLETED
+**Path**: fast
+**Iteration**: 1
+
+## Current Focus
+Iterated CRT over commutative rings — SOLVED and shipped.
+
+## Active Approach
+Fold the two-modulus `crtRing` over a `List.Pairwise IsCoprime` of moduli.
+`isCoprime_list_prod` (iterated `IsCoprime.mul_right`) supplies head-vs-tail
+coprimality; `List.dvd_prod` propagates congruences; uniqueness dualizes with
+`IsCoprime.mul_dvd`.
+
+## Result
+VERIFIED, 0-axiom, 0-sorry. 8 theorems / 1 def / 196 lines.
+- `Proofs/BezoutIdentityOQ03OQ04OQ01OQ01.lean`
+- `src/data/proofs/bezout-identity-oq-03-oq-04-oq-01-oq-01/`
+
+## Blockers
+None.
+
+## Next Action
+Done — released claim, PR opened.

--- a/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-module-preamble",
+    "proofId": "bezout-identity-oq-03-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "Module Setup and the Iterated-CRT Question",
+    "content": "The file imports `Mathlib.RingTheory.Coprime.Basic` and `Mathlib.RingTheory.Coprime.Lemmas` (providing `IsCoprime`, `IsCoprime.mul_right`, and `IsCoprime.mul_dvd`) plus the tactic library. The module docstring quotes parent open question #1 verbatim: can the folding approach for multiple coprime moduli be generalized to commutative rings? The docstring already names the load-bearing lemma the question flagged — `IsCoprime.mul_right` — and commits to answering YES over an arbitrary `CommRing`. The namespace `BezoutIdentityOQ03OQ04OQ01OQ01` scopes every declaration.",
+    "mathContext": "`IsCoprime a b` unfolds to $\\exists s\\,t,\\; s a + t b = 1$. Over a commutative ring, comaximality of the principal ideals $(m_i)$ and $(m_j)$ is exactly `IsCoprime m_i m_j`, so a pairwise-coprime family of moduli is a pairwise-comaximal family of ideals — the hypothesis of the classical ring CRT.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "IsCoprime in Mathlib",
+      "pairwise comaximal ideals",
+      "namespace scoping in Lean 4"
+    ],
+    "prerequisites": [
+      "Lean 4 module system",
+      "commutative ring theory"
+    ]
+  },
+  {
+    "id": "ann-two-modulus-base",
+    "proofId": "bezout-identity-oq-03-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 38,
+      "endLine": 62
+    },
+    "type": "definition",
+    "title": "Two-Modulus CRT, Reproduced Self-Contained",
+    "content": "Part 1 reproduces the parent's `crtRing a b s t m n = b * s * m + a * t * n` together with its correctness theorems (`crtRing_mod_m`, `crtRing_mod_n`, each a one-line `linear_combination`) and existence (`crtRing_exists`, which destructures `IsCoprime m n` to Bézout coefficients and applies the formula). Reproducing rather than importing keeps this file dependent on Mathlib alone, so it compiles independently of the parent's `.olean`. This two-modulus existence result is the single black box the entire fold calls in its inductive step.",
+    "mathContext": "Given $s m + t n = 1$, the element $x = b s m + a t n$ satisfies $x \\equiv a \\pmod m$ and $x \\equiv b \\pmod n$: e.g. $x - a = b s m + a(tn - 1) = m(bs - as)$ using $tn = 1 - sm$. `crtRing_exists` packages this as $\\exists x,\\; m \\mid x-a \\wedge n \\mid x-b$ from `IsCoprime m n` alone.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bézout coefficients",
+      "linear_combination tactic",
+      "constructive CRT witness"
+    ],
+    "prerequisites": [
+      "divisibility in rings",
+      "IsCoprime destructuring"
+    ]
+  },
+  {
+    "id": "ann-coprime-list-prod",
+    "proofId": "bezout-identity-oq-03-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 79
+    },
+    "type": "key-step",
+    "title": "isCoprime_list_prod: Coprimality Folds over Products",
+    "content": "This is the lemma the open question singled out. `isCoprime_list_prod a l` proves that if `a` is coprime to every entry of `l`, then `a` is coprime to `l.prod`. The proof is a two-case list induction: the empty list gives `IsCoprime a 1` via `isCoprime_one_right` (after `List.prod_nil`), and the cons case rewrites `List.prod_cons` and applies `IsCoprime.mul_right` to the head coprimality and the recursively-obtained tail coprimality. This is precisely the iterated form of the `IsCoprime.mul_right` step named in parent OQ #1, and it is what lets the head modulus be shown coprime to the entire tail product in one call.",
+    "mathContext": "By induction: $\\mathrm{IsCoprime}(a,1)$ holds, and $\\mathrm{IsCoprime}(a,b) \\wedge \\mathrm{IsCoprime}(a, \\textstyle\\prod t) \\Rightarrow \\mathrm{IsCoprime}(a, b\\cdot \\prod t)$ is exactly `IsCoprime.mul_right`. Hence $\\mathrm{IsCoprime}(a, \\prod_{b \\in l} b)$ whenever $a$ is coprime to each $b$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsCoprime.mul_right",
+      "list induction",
+      "iterated coprimality"
+    ],
+    "prerequisites": [
+      "List.prod",
+      "structural induction on lists"
+    ]
+  },
+  {
+    "id": "ann-iterated-existence",
+    "proofId": "bezout-identity-oq-03-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 119
+    },
+    "type": "key-step",
+    "title": "crtRing_list_exists: the Folding Construction",
+    "content": "The main existence theorem. The system is a list of `(residue, modulus)` pairs, with pairwise coprimality encoded as `List.Pairwise (fun p q => IsCoprime p.2 q.2)`. The proof inducts on the list. `List.pairwise_cons` splits the hypothesis into (a) the head modulus is coprime to every tail modulus and (b) the tail is itself pairwise coprime. The induction hypothesis solves the tail, giving `x` and the tail product `M`. `isCoprime_list_prod` upgrades (a) to `IsCoprime p.2 M`, so a single `crtRing_exists` call produces `y` with `p.2 ∣ y - p.1` and `M ∣ y - x`. For any tail modulus `q.2`, `List.dvd_prod` gives `q.2 ∣ M`, hence `q.2 ∣ y - x`; combined with `q.2 ∣ x - q.1` from the IH, `dvd_add` yields `q.2 ∣ y - q.1`. No ring-specific arithmetic appears — only divisibility bookkeeping over a general `CommRing`.",
+    "mathContext": "Folding: to solve $\\{x \\equiv a_i \\pmod{m_i}\\}_{i}$, solve the tail to get $x_0$ with $m_i \\mid x_0 - a_i$ for $i \\ge 2$, set $M = \\prod_{i\\ge 2} m_i$, and CRT-combine $(a_1, m_1)$ with $(x_0, M)$ (legal since $m_1$ is coprime to $M$). The result $y$ satisfies $m_1 \\mid y - a_1$ directly and $m_i \\mid M \\mid y - x_0$, so $m_i \\mid (y - x_0) + (x_0 - a_i) = y - a_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "iterated Chinese Remainder Theorem",
+      "List.Pairwise",
+      "List.dvd_prod",
+      "folding argument"
+    ],
+    "prerequisites": [
+      "list induction",
+      "divisibility transitivity",
+      "two-modulus CRT"
+    ]
+  },
+  {
+    "id": "ann-iterated-uniqueness",
+    "proofId": "bezout-identity-oq-03-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 120,
+      "endLine": 153
+    },
+    "type": "key-step",
+    "title": "Uniqueness: Product of Pairwise-Coprime Divisors",
+    "content": "Uniqueness mirrors existence. `prod_dvd_of_pairwise_coprime d l` shows that if the entries of a pairwise-coprime list `l` each divide `d`, then `l.prod ∣ d`; it folds `IsCoprime.mul_dvd` (using `isCoprime_list_prod` to see the head is coprime to the tail product) exactly as existence folded `IsCoprime.mul_right`. `crtRing_list_unique` then concludes that two solutions `x`, `y` of the same pairwise-coprime system satisfy `(l.map Prod.snd).prod ∣ (x - y)`: every modulus divides `x - y`, and `List.pairwise_map` transports pairwise coprimality from the pairs to their moduli so the fold applies.",
+    "mathContext": "If $m_1, \\dots, m_k$ are pairwise coprime and each $m_i \\mid d$, then $\\prod m_i \\mid d$, because $\\mathrm{IsCoprime}(m_1, \\prod_{i\\ge 2} m_i)$ lets `IsCoprime.mul_dvd` combine $m_1 \\mid d$ and $\\prod_{i \\ge 2} m_i \\mid d$ into $\\prod_i m_i \\mid d$. Applied to $d = x - y$ this is CRT uniqueness modulo the product.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsCoprime.mul_dvd",
+      "List.pairwise_map",
+      "uniqueness modulo product"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "list induction"
+    ]
+  },
+  {
+    "id": "ann-three-moduli",
+    "proofId": "bezout-identity-oq-03-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 154,
+      "endLine": 196
+    },
+    "type": "concept",
+    "title": "Worked Three-Modulus Instance and Summary",
+    "content": "`crtRing_three` specializes the list theorem to three pairwise-coprime moduli. The `List.Pairwise` witness for `[(a₁,m₁),(a₂,m₂),(a₃,m₃)]` is built with explicit `.cons`/`.nil` constructors, and each 'head vs. tail' obligation is discharged by `fin_cases hq`, which enumerates the finitely many tail members and closes each with the supplied coprimality hypothesis. Extracting the individual congruences from the packaged `∀ p ∈ l` statement recovers the familiar three-congruence form. The closing docstring summarizes the answer: existence and uniqueness for any finite pairwise-coprime family generalize to any commutative ring, each as a fold of the corresponding two-element IsCoprime lemma.",
+    "mathContext": "For three pairwise-coprime moduli $m_1, m_2, m_3$ in any $R$, there is $x$ with $m_i \\mid x - a_i$ for $i = 1,2,3$. Instantiating at $R = k[X]$ with $m_i = X - c_i$ recovers three-point Lagrange interpolation; at $R = \\mathbb{Z}$ it is ordinary CRT.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "fin_cases tactic",
+      "Lagrange interpolation as CRT",
+      "specialization of general theorems"
+    ],
+    "prerequisites": [
+      "List.Pairwise constructors",
+      "membership in concrete lists"
+    ]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,190 @@
+{
+  "id": "bezout-identity-oq-03-oq-04-oq-01-oq-01",
+  "title": "Iterated CRT for Multiple Coprime Moduli over Commutative Rings",
+  "slug": "bezout-identity-oq-03-oq-04-oq-01-oq-01",
+  "description": "Answers open question #1 of the CommRing CRT entry: the folding approach for multiple coprime moduli generalizes to any commutative ring. Over an arbitrary CommRing, a list of (residue, modulus) pairs with pairwise-coprime moduli always has a simultaneous solution, unique modulo the product of all moduli. The proof folds the two-modulus crtRing, with the crux lemma isCoprime_list_prod (an element coprime to each factor is coprime to the product) built from IsCoprime.mul_right, exactly as the open question anticipated.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chinese_remainder_theorem#Statement_for_principal_ideal_domains",
+    "date": "Classical; formalized 2026",
+    "status": "verified",
+    "tags": [
+      "ring-theory",
+      "chinese-remainder-theorem",
+      "bezout-identity",
+      "commutative-algebra",
+      "coprimality",
+      "induction"
+    ],
+    "proofRepoPath": "Proofs/BezoutIdentityOQ03OQ04OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "IsCoprime.mul_right",
+        "description": "IsCoprime a b → IsCoprime a c → IsCoprime a (b*c); folded to give coprimality to a product",
+        "module": "Mathlib.RingTheory.Coprime.Lemmas"
+      },
+      {
+        "theorem": "IsCoprime.mul_dvd",
+        "description": "If m, n are coprime and both divide d, then m*n divides d; folded for uniqueness",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      },
+      {
+        "theorem": "List.dvd_prod",
+        "description": "A member of a list divides the list product; used to inherit tail congruences",
+        "module": "Mathlib.Algebra.BigOperators.Group.List"
+      },
+      {
+        "theorem": "List.Pairwise",
+        "description": "Pairwise relation on a list, used to encode pairwise coprimality of moduli",
+        "module": "Mathlib.Data.List.Pairwise"
+      }
+    ],
+    "originalContributions": [
+      "isCoprime_list_prod: an element coprime to each list entry is coprime to the product (iterated IsCoprime.mul_right)",
+      "crtRing_list_exists: iterated CRT existence for pairwise-coprime moduli over any CommRing, by folding the two-modulus crtRing",
+      "prod_dvd_of_pairwise_coprime: pairwise-coprime divisors of d have their product dividing d (iterated IsCoprime.mul_dvd)",
+      "crtRing_list_unique: two solutions of the same system agree modulo the product of all moduli",
+      "crtRing_three: worked three-modulus specialization over an arbitrary CommRing"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 196,
+    "assumptions": "0 axioms. 0 sorries. Uses only propext / Classical.choice / Quot.sound (the standard Mathlib foundation).",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The two-modulus Chinese Remainder Theorem extends to any finite family of pairwise-coprime moduli by a folding argument going back to Qin Jiushao's Da Yan Qiu Yi Shu (1247): solve two congruences, treat their combined modulus as a single new modulus, and fold in the next. Over ℤ this is standard; the parent entry (bezout-identity-oq-03-oq-04-oq-01) lifted the two-modulus case to an arbitrary commutative ring using Mathlib's element-level IsCoprime predicate but explicitly left the iterated case as open question #1. In the ideal-theoretic formulation (Atiyah–Macdonald), the CRT for pairwise-comaximal ideals I₁,…,Iₖ gives R/(∩Iⱼ) ≅ ∏ R/Iⱼ; the element-level statement here is the principal-ideal shadow of that isomorphism, where comaximality of (mᵢ) and (mⱼ) is exactly IsCoprime mᵢ mⱼ.",
+    "problemStatement": "Can the folding approach for multiple coprime moduli (iterated CRT) be generalized to commutative rings? The key lemma needed: if IsCoprime m₁ m₂ and IsCoprime (m₁·m₂) m₃, then IsCoprime m₁ (m₂·m₃) — available in Mathlib as IsCoprime.mul_right.",
+    "proofStrategy": "Encode the system as a list of (residue, modulus) pairs with List.Pairwise IsCoprime on the moduli. Induct on the list: given a solution x for the tail with modulus product M, the head modulus is coprime to M (isCoprime_list_prod, the iterated IsCoprime.mul_right named in the question), so the two-modulus crtRing yields a y congruent to the head residue mod the head modulus and to x mod M. Because every tail modulus divides M (List.dvd_prod), y inherits every tail congruence. Uniqueness dualizes: pairwise-coprime divisors of a difference have their product dividing it, folding IsCoprime.mul_dvd.",
+    "keyInsights": [
+      "The open question flags IsCoprime.mul_right as the key lemma; the clean way to use it is isCoprime_list_prod — a one-line induction that an element coprime to every factor is coprime to the whole product. This is the load-bearing step of the entire fold.",
+      "Folding is done at the element level with no ring-specific arithmetic: the inductive step calls the two-modulus crtRing exactly once and then propagates congruences via divisibility (q.2 ∣ M ∣ y - x together with q.2 ∣ x - q.1 gives q.2 ∣ y - q.1 by dvd_add). Nothing beyond CommRing is assumed.",
+      "Pairwise coprimality (List.Pairwise), not merely coprimality of each modulus to the running product, is the right hypothesis: List.pairwise_cons hands you both the head-vs-tail coprimalities (feeding isCoprime_list_prod) and the tail's own pairwise structure (feeding the induction hypothesis).",
+      "Uniqueness is the mirror image of existence: prod_dvd_of_pairwise_coprime folds IsCoprime.mul_dvd the same way isCoprime_list_prod folds IsCoprime.mul_right, and List.pairwise_map transports pairwise coprimality from the pairs to their moduli.",
+      "The whole development is Mathlib-only and parametric in R: instantiating at ℤ recovers classical CRT, at k[X] gives multi-point Lagrange interpolation, and at ℤ[i] gives CRT for Gaussian integers — with no change to the proof."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Module Documentation",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Imports Mathlib's coprimality API (Basic + Lemmas) and Tactic. The module docstring states parent open question #1 and the answer: the folding approach for iterated CRT generalizes to any CommRing."
+    },
+    {
+      "id": "two-modulus",
+      "title": "Part 1: Two-Modulus CRT (self-contained)",
+      "startLine": 38,
+      "endLine": 62,
+      "summary": "Reproduces the parent's crtRing = b·s·m + a·t·n and its correctness (crtRing_mod_m, crtRing_mod_n via linear_combination) and existence (crtRing_exists from IsCoprime), keeping the file self-contained with Mathlib-only imports."
+    },
+    {
+      "id": "coprime-product",
+      "title": "Part 2: Coprimality to a Product",
+      "startLine": 63,
+      "endLine": 79,
+      "summary": "isCoprime_list_prod: an element coprime to every entry of a list is coprime to the list product. Proved by induction folding IsCoprime.mul_right and isCoprime_one_right — the lemma the open question flagged as key."
+    },
+    {
+      "id": "iterated-existence",
+      "title": "Part 3: Iterated CRT Existence (folding)",
+      "startLine": 80,
+      "endLine": 119,
+      "summary": "crtRing_list_exists: for pairwise-coprime moduli the system is solvable. Inducts on the list; the head modulus is coprime to the tail product, one crtRing call combines head residue with the tail solution, and List.dvd_prod propagates every tail congruence to the new witness."
+    },
+    {
+      "id": "iterated-uniqueness",
+      "title": "Part 4: Iterated CRT Uniqueness",
+      "startLine": 120,
+      "endLine": 153,
+      "summary": "prod_dvd_of_pairwise_coprime folds IsCoprime.mul_dvd so that pairwise-coprime divisors of d have product dividing d; crtRing_list_unique then shows two solutions agree modulo the product of all moduli, using List.pairwise_map."
+    },
+    {
+      "id": "three-moduli",
+      "title": "Part 5: Worked Instance — Three Moduli",
+      "startLine": 154,
+      "endLine": 172,
+      "summary": "crtRing_three specializes the list theorem to three pairwise-coprime moduli in an arbitrary CommRing, building the Pairwise witness with explicit constructors and fin_cases."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 173,
+      "endLine": 196,
+      "summary": "Recaps the answer: the folding approach generalizes to any commutative ring, with existence and uniqueness both obtained by folding the corresponding two-element IsCoprime lemmas."
+    }
+  ],
+  "conclusion": {
+    "summary": "The folding construction for iterated CRT generalizes verbatim to an arbitrary commutative ring. Given pairwise-coprime moduli (encoded as List.Pairwise IsCoprime), crtRing_list_exists produces a simultaneous solution and crtRing_list_unique shows it is unique modulo the product of the moduli. Both proofs are folds of two-element lemmas: existence folds IsCoprime.mul_right (via isCoprime_list_prod) over the two-modulus crtRing, and uniqueness folds IsCoprime.mul_dvd. The development is 0-axiom, 0-sorry, and parametric in the ring.",
+    "implications": [
+      "Confirms the parent entry's conjecture: no ring-specific machinery (Int.gcd, linarith, IsBezout) is needed for the iterated case — only element-level IsCoprime and ring arithmetic.",
+      "Instantiating at k[X] yields multi-point Lagrange interpolation as iterated CRT; at ℤ[i] it gives CRT for the Gaussian integers; at ℤ it recovers classical CRT.",
+      "isCoprime_list_prod and prod_dvd_of_pairwise_coprime are reusable folds of IsCoprime.mul_right / IsCoprime.mul_dvd over lists, useful anywhere pairwise coprimality meets a product."
+    ],
+    "openQuestions": [
+      "Can the list formulation be repackaged as a ring isomorphism R / (∏ mᵢ) ≅ ∏ (R / mᵢ) using Mathlib's Ideal.quotientInfRingEquivPiQuotient, connecting the element-level fold to the structural CRT?",
+      "Can an explicit reconstruction formula (analogous to the two-modulus b·s·m + a·t·n) be extracted for k moduli, giving a computable iterated-CRT algorithm with a complexity bound?",
+      "Does the pairwise-coprime hypothesis relax to coprimality of successive partial products, and is that strictly weaker over a non-Bézout CommRing?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-03-oq-04-oq-01",
+      "relationship": "generalizes",
+      "description": "Parent: two-modulus CRT over a CommRing. This entry answers its open question #1 by folding that construction over a list of pairwise-coprime moduli."
+    },
+    {
+      "targetId": "bezout-identity-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling: multiple-moduli CRT via folding over ℤ. This entry lifts the folding approach to an arbitrary commutative ring."
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "grandparent",
+      "description": "Root Bézout entry (sm + tn = gcd). The iterated fold rests on the IsCoprime (sm + tn = 1) special case throughout."
+    }
+  ],
+  "sorries": [],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Coprime.Basic",
+      "Mathlib.RingTheory.Coprime.Lemmas",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "BezoutIdentityOQ03OQ04OQ01OQ01",
+    "lineCount": 196,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/BezoutIdentityOQ03OQ04OQ01OQ01.lean"
+  },
+  "references": [
+    {
+      "authors": "M. F. Atiyah, I. G. Macdonald",
+      "title": "Introduction to Commutative Algebra",
+      "year": 1969,
+      "venue": "Addison-Wesley",
+      "note": "Proposition 1.10: CRT for pairwise-comaximal ideals, R/(∩Iⱼ) ≅ ∏ R/Iⱼ."
+    },
+    {
+      "authors": "D. S. Dummit, R. M. Foote",
+      "title": "Abstract Algebra",
+      "year": 2004,
+      "venue": "Wiley",
+      "note": "Chinese Remainder Theorem for commutative rings via comaximal ideals; iterated form."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides IsCoprime, IsCoprime.mul_right, IsCoprime.mul_dvd, List.Pairwise, and List.dvd_prod."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **open question #1** of `bezout-identity-oq-03-oq-04-oq-01` ("CRT for Commutative Rings via Bézout Coefficients"):

> Can the folding approach for multiple coprime moduli (iterated CRT) be generalized to commutative rings? The key lemma needed: if `IsCoprime m₁ m₂` and `IsCoprime (m₁*m₂) m₃`, then `IsCoprime m₁ (m₂*m₃)` — available in Mathlib as `IsCoprime.mul_right`.

**YES.** Over an arbitrary `CommRing R`, a list of `(residue, modulus)` pairs with pairwise-coprime moduli always has a simultaneous solution, unique modulo the product of all moduli. The construction folds the parent's two-modulus `crtRing`; the crux is exactly the `IsCoprime.mul_right` fold the question flagged.

## Contributions (`Proofs/BezoutIdentityOQ03OQ04OQ01OQ01.lean`)

- **`isCoprime_list_prod`** — an element coprime to each list entry is coprime to the product (iterated `IsCoprime.mul_right`).
- **`crtRing_list_exists`** — iterated CRT existence for pairwise-coprime moduli (`List.Pairwise IsCoprime`), by folding the two-modulus `crtRing`; tail congruences propagate via `List.dvd_prod`.
- **`prod_dvd_of_pairwise_coprime`** / **`crtRing_list_unique`** — uniqueness modulo the product of all moduli, folding `IsCoprime.mul_dvd`.
- **`crtRing_three`** — worked three-modulus specialization over an arbitrary `CommRing`.

The two-modulus base is reproduced inline so the file is **Mathlib-only / self-contained**.

## Verification

- **VERIFIED, 0 axioms, 0 sorries.** `#print axioms` lists only `propext` / `Quot.sound` (standard foundation; no `Lean.ofReduceBool`, no `sorryAx`).
- 8 theorems / 1 definition / 196 lines.
- Built via `lake env lean` (docker wrapper currently down — containerd I/O error).

Instantiating at `ℤ` recovers classical CRT; at `k[X]` gives multi-point Lagrange interpolation; at `ℤ[i]` gives CRT for Gaussian integers — with no change to the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)