### PR TITLE
research(binomial-theorem-oq-01-oq-01-oq-03): closed form C(-1/2,k)=(-1)^k·C(2k,k)/4^k [VERIFIED, 0-axiom]

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/index.ts
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const binomialTheoremOq01Oq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const binomialTheoremOq01Oq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const binomialTheoremOq01Oq01Oq03Data: ProofData = {
+  proof: binomialTheoremOq01Oq01Oq03Proof,
+  annotations: binomialTheoremOq01Oq01Oq03Annotations,
+}


### PR DESCRIPTION
## Summary

Establishes the **general all-$k$ closed form** for the negative half-integer generalized binomial coefficient:
$$\binom{-1/2}{k} = (-1)^k\frac{\binom{2k}{k}}{4^k} = (-1)^k\frac{\mathrm{centralBinom}(k)}{4^k} = (-1)^k\frac{(k+1)\,\mathrm{catalan}(k)}{4^k}.$$
These are exactly the Taylor coefficients of $1/\sqrt{1+x}$, and the identity is why the central binomial coefficients are the coefficients of $1/\sqrt{1-4x}$ and the Catalan numbers generate $(1-\sqrt{1-4x})/(2x)$.

The **parent** proof `binomial-theorem-oq-01-oq-01` only evaluated the *positive* coefficient $\binom{1/2}{k}$ at small $k\le3$. This entry gives the uniform formula for the analytically important *negative* coefficient, for all $k$.

## Proof

A single induction on the division-free form $\binom{-1/2}{k}\cdot 4^k = (-1)^k\,\mathrm{centralBinom}(k)$:
- the parent's `ode_recurrence` gives ratio $\binom{-1/2}{k+1}/\binom{-1/2}{k} = -(2k+1)/(2(k+1))$;
- Mathlib's `Nat.succ_mul_centralBinom_succ` gives the *same* ratio for $(-1)^k\mathrm{centralBinom}(k)/4^k$;
- after cancelling $(k+1)$, a single `linear_combination` of the two recurrences plus the inductive hypothesis closes the step (scalar residue $4(-1/2-n)+2(2n+1)=0$).

The choose and Catalan forms follow by rewriting; nonvanishing (all $k$) and $|\binom{-1/2}{k}| = \mathrm{centralBinom}(k)/4^k$ are corollaries.

## Verification

- **11 theorems, 0 definitions, 152 lines, 0 sorries**
- All main results depend only on `propext`, `Classical.choice`, `Quot.sound` (checked via `#print axioms`); no `native_decide`, no `Lean.ofReduceBool`.
- Compiles against Mathlib v4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)