### PR TITLE
research(binomial-theorem-oq-01-oq-01-oq-03): closed form C(-1/2,k)=(-1)^k·C(2k,k)/4^k [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean
@@ -1,0 +1,152 @@
+/-
+  binomial-theorem-oq-01-oq-01-oq-03:
+  "The closed form C(-1/2, k) = (-1)^k · C(2k,k) / 4^k, connecting the
+   generalized (Newton) binomial coefficient at α = -1/2 to the central
+   binomial coefficients and the Catalan numbers."
+  ====================================================
+
+  Verified: all theorems compile against Mathlib (lean v4.26.0) and depend only
+  on the foundational axioms `propext`, `Classical.choice`, `Quot.sound`
+  (0 sorries, 0 `axiom` declarations, no `native_decide`).
+
+  The parent gallery proof `binomial-theorem-oq-01-oq-01`
+  (proofs/Proofs/BinomialTheoremOQ01OQ01.lean) provides:
+    * `genBinom α k = (∏ j ∈ range k, (α - j)) / k!`   — the coefficient C(α,k)
+    * `ode_recurrence α k : (k+1) · C(α,k+1) = (α-k) · C(α,k)`
+    * concrete values of the POSITIVE half-integer coefficients C(1/2,k) at
+      small k (k ≤ 3), with the observation that they are eventually nonzero.
+
+  That parent stops at ad-hoc small-k evaluation.  This OQ delivers the general
+  UNIFORM closed form for the NEGATIVE half-integer coefficient — the one that
+  actually appears in analysis, as the Taylor coefficients of (1+x)^(-1/2) =
+  1/√(1+x):
+
+        C(-1/2, k) = (-1)^k · C(2k, k) / 4^k
+                   = (-1)^k · centralBinom k / 4^k
+                   = (-1)^k · (k+1) · catalan k / 4^k.
+
+  These are the coefficients underlying the generating function of the central
+  binomial coefficients, √(1-4x) = 1 - 2 ∑_{k≥1} catalan(k-1) x^k, and the fact
+  that ∑ centralBinom k · x^k = 1/√(1-4x).
+
+  Proof strategy: a single induction on k using the parent's `ode_recurrence`
+  together with Mathlib's central-binomial recurrence
+    `Nat.succ_mul_centralBinom_succ n :
+        (n+1) · centralBinom (n+1) = 2·(2n+1) · centralBinom n`.
+  The two recurrences have matching ratios:
+    C(-1/2, n+1)/C(-1/2, n) = (-1/2 - n)/(n+1) = -(2n+1)/(2(n+1)),
+    [(-1)^{n+1} cb_{n+1}/4^{n+1}] / [(-1)^n cb_n/4^n]
+        = -cb_{n+1}/(4 cb_n) = -(2n+1)/(2(n+1)),
+  so a `linear_combination` of the two recurrences plus the inductive hypothesis
+  closes the step exactly.
+-/
+import Mathlib
+import Proofs.BinomialTheoremOQ01OQ01
+
+open Finset Nat
+
+namespace BinomialTheoremOQ01OQ01OQ03
+
+open BinomialTheoremOQ01OQ01
+
+/-! ### The central-binomial recurrence, cast to `ℝ` -/
+
+/-- Mathlib's `Nat.succ_mul_centralBinom_succ`, transported to `ℝ`:
+    `(n+1) · centralBinom (n+1) = 2·(2n+1) · centralBinom n`. -/
+theorem centralBinom_rec_real (n : ℕ) :
+    ((n : ℝ) + 1) * (Nat.centralBinom (n + 1) : ℝ)
+      = 2 * (2 * (n : ℝ) + 1) * (Nat.centralBinom n : ℝ) := by
+  have h := congrArg (Nat.cast : ℕ → ℝ) (Nat.succ_mul_centralBinom_succ n)
+  push_cast at h
+  linarith
+
+/-! ### Multiplied-through closed form (division-free) -/
+
+/-- The division-free form of the closed formula:
+    `C(-1/2, k) · 4^k = (-1)^k · centralBinom k`.
+    Proved by induction on `k`, cancelling the factor `(k+1)` and closing the
+    inductive step with a `linear_combination` of the two recurrences. -/
+theorem genBinom_negHalf_mul_pow (k : ℕ) :
+    genBinom (-1/2 : ℝ) k * 4 ^ k = (-1) ^ k * (Nat.centralBinom k : ℝ) := by
+  induction k with
+  | zero => simp [genBinom_zero, Nat.centralBinom_zero]
+  | succ n ih =>
+    have hn1 : ((n : ℝ) + 1) ≠ 0 := by positivity
+    have hrec := ode_recurrence (-1/2 : ℝ) n
+    have hcb := centralBinom_rec_real n
+    -- Cancel the common factor (n+1) on both sides, then close by
+    -- linear_combination of ode_recurrence, ih, and the central recurrence.
+    apply mul_left_cancel₀ hn1
+    linear_combination (4 * 4 ^ n) * hrec + (4 * (-1/2 - (n : ℝ))) * ih
+      + ((-1 : ℝ) ^ n) * hcb
+
+/-! ### Main closed forms -/
+
+/-- **Main result.** `C(-1/2, k) = (-1)^k · centralBinom k / 4^k`. -/
+theorem genBinom_negHalf (k : ℕ) :
+    genBinom (-1/2 : ℝ) k = (-1) ^ k * (Nat.centralBinom k : ℝ) / 4 ^ k := by
+  rw [eq_div_iff (by positivity : (4 : ℝ) ^ k ≠ 0)]
+  exact genBinom_negHalf_mul_pow k
+
+/-- The same, written with the explicit central binomial coefficient
+    `C(2k, k)`: `C(-1/2, k) = (-1)^k · C(2k,k) / 4^k`. -/
+theorem genBinom_negHalf_choose (k : ℕ) :
+    genBinom (-1/2 : ℝ) k = (-1) ^ k * ((2 * k).choose k : ℝ) / 4 ^ k := by
+  rw [genBinom_negHalf, Nat.centralBinom_eq_two_mul_choose]
+
+/-- Catalan form: `C(-1/2, k) = (-1)^k · (k+1) · catalan k / 4^k`, using the
+    identity `(k+1)·catalan k = centralBinom k`. -/
+theorem genBinom_negHalf_catalan (k : ℕ) :
+    genBinom (-1/2 : ℝ) k
+      = (-1) ^ k * (((k : ℝ) + 1) * (catalan k : ℝ)) / 4 ^ k := by
+  rw [genBinom_negHalf]
+  have h : ((Nat.centralBinom k : ℝ)) = ((k : ℝ) + 1) * (catalan k : ℝ) := by
+    have := congrArg (Nat.cast : ℕ → ℝ) (succ_mul_catalan_eq_centralBinom k)
+    push_cast at this
+    linarith
+  rw [h]
+
+/-! ### Sign and nonvanishing -/
+
+/-- The negative half-integer coefficient is strictly alternating in sign:
+    it never vanishes.  (Contrast the positive case `C(1/2,k)`, whose parent
+    proof establishes nonvanishing only for small `k`.) -/
+theorem genBinom_negHalf_ne_zero (k : ℕ) : genBinom (-1/2 : ℝ) k ≠ 0 := by
+  rw [genBinom_negHalf]
+  have hcb : (Nat.centralBinom k : ℝ) ≠ 0 := by
+    exact_mod_cast (Nat.centralBinom_pos k).ne'
+  have h4 : (4 : ℝ) ^ k ≠ 0 := by positivity
+  have hsign : ((-1 : ℝ) ^ k) ≠ 0 := pow_ne_zero k (by norm_num)
+  exact div_ne_zero (mul_ne_zero hsign hcb) h4
+
+/-- The absolute value of the coefficient is `centralBinom k / 4^k`, a positive
+    rational strictly decreasing to `0` — the Wallis-type decay of the Taylor
+    coefficients of `1/√(1+x)`. -/
+theorem abs_genBinom_negHalf (k : ℕ) :
+    |genBinom (-1/2 : ℝ) k| = (Nat.centralBinom k : ℝ) / 4 ^ k := by
+  rw [genBinom_negHalf, abs_div, abs_mul]
+  have h4 : |(4 : ℝ) ^ k| = 4 ^ k := abs_of_pos (by positivity)
+  have hcb : |(Nat.centralBinom k : ℝ)| = (Nat.centralBinom k : ℝ) := Nat.abs_cast _
+  have hsign : |(-1 : ℝ) ^ k| = 1 := by
+    rw [abs_pow]; simp
+  rw [h4, hcb, hsign, one_mul]
+
+/-! ### Concrete values (sanity checks against the parent's small-`k` data) -/
+
+/-- `C(-1/2, 0) = 1`. -/
+theorem genBinom_negHalf_zero : genBinom (-1/2 : ℝ) 0 = 1 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom]
+
+/-- `C(-1/2, 1) = -1/2`. -/
+theorem genBinom_negHalf_one : genBinom (-1/2 : ℝ) 1 = -1/2 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom, Nat.choose]
+
+/-- `C(-1/2, 2) = 3/8`. -/
+theorem genBinom_negHalf_two : genBinom (-1/2 : ℝ) 2 = 3/8 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom, Nat.choose]
+
+/-- `C(-1/2, 3) = -5/16`. -/
+theorem genBinom_negHalf_three : genBinom (-1/2 : ℝ) 3 = -5/16 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom, Nat.choose]
+
+end BinomialTheoremOQ01OQ01OQ03

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-centralbinom-rec-real",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 56, "endLine": 61 },
+    "type": "theorem",
+    "title": "The central-binomial recurrence, cast to ℝ",
+    "content": "Mathlib's `Nat.succ_mul_centralBinom_succ` states `(n+1)·centralBinom(n+1) = 2·(2n+1)·centralBinom(n)` over ℕ. To use it inside a real-valued induction it must live in ℝ, so we apply `congrArg (Nat.cast : ℕ → ℝ)`, then `push_cast` distributes the cast across the products and successors, and `linarith` closes the resulting real identity. This cast recurrence is the bridge whose ratio `centralBinom(n+1)/centralBinom(n) = 2(2n+1)/(n+1)` matches the coefficient ratio coming from the parent's ODE recurrence.",
+    "mathContext": "$(n+1)\\,\\binom{2(n+1)}{n+1} = 2(2n+1)\\,\\binom{2n}{n}$ transported to $\\mathbb{R}$. Equivalently $\\frac{\\mathrm{cb}_{n+1}}{\\mathrm{cb}_n} = \\frac{2(2n+1)}{n+1}$, the exact ratio needed to match $\\frac{C(-1/2,\\,n+1)}{C(-1/2,\\,n)} = -\\frac{2n+1}{2(n+1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficients", "recurrence relations", "Nat.cast / push_cast", "matching-ratio induction"],
+    "prerequisites": ["central binomial coefficients", "casting ℕ identities into ℝ"]
+  },
+  {
+    "id": "ann-genbinom-neghalf-mul-pow",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 69, "endLine": 81 },
+    "type": "theorem",
+    "title": "Division-free closed form (the core induction)",
+    "content": "The heart of the entry: `C(-1/2, k)·4^k = (-1)^k·centralBinom(k)`, cleared of the `4^k` denominator so the induction stays polynomial. The base case is `simp` on `genBinom_zero` and `centralBinom_zero`. For the step, the common factor `(n+1)` is stripped with `mul_left_cancel₀`, then a single `linear_combination` — weighting the parent's `ode_recurrence` by `4·4^n`, the inductive hypothesis by `4·(-1/2 - n)`, and the real central recurrence by `(-1)^n` — closes the goal exactly. This is where the two matching ratios are algebraically fused.",
+    "mathContext": "$C(-1/2,k)\\,4^{k} = (-1)^{k}\\,\\mathrm{cb}_k$. Induction: assuming it at $n$, multiply the ODE recurrence $(n+1)C(-1/2,n+1) = (-1/2-n)C(-1/2,n)$ by $4^{n+1}$ and substitute both the hypothesis and $\\mathrm{cb}_{n+1} = \\tfrac{2(2n+1)}{n+1}\\mathrm{cb}_n$ to obtain the claim at $n+1$.",
+    "significance": "critical",
+    "relatedConcepts": ["generalized binomial coefficient", "linear_combination tactic", "induction", "mul_left_cancel₀", "Newton series of 1/√(1+x)"],
+    "prerequisites": ["the parent's ODE recurrence for C(α,k)", "the central-binomial recurrence over ℝ"]
+  },
+  {
+    "id": "ann-genbinom-neghalf-main",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 86, "endLine": 89 },
+    "type": "theorem",
+    "title": "Main closed form C(-1/2, k) = (-1)^k·centralBinom(k)/4^k",
+    "content": "The headline identity, recovered from the division-free version by reintroducing the `4^k` denominator via `eq_div_iff` (valid since `4^k ≠ 0`). Its companion `genBinom_negHalf_choose` immediately rewrites `centralBinom k` as `(2k).choose k` to display the fully explicit `C(-1/2,k) = (-1)^k·C(2k,k)/4^k`. These are exactly the Taylor coefficients of `(1+x)^(-1/2) = 1/√(1+x)`.",
+    "mathContext": "$\\binom{-1/2}{k} = \\frac{(-1)^k}{4^k}\\binom{2k}{k}$, the coefficients of $\\frac{1}{\\sqrt{1+x}} = \\sum_{k\\ge 0}\\binom{-1/2}{k}x^k$. Uniform in $k$, where the parent proof only evaluated the positive coefficient $C(1/2,k)$ at small $k$.",
+    "significance": "critical",
+    "relatedConcepts": ["Newton's generalized binomial theorem", "generating function of central binomial coefficients", "eq_div_iff", "Taylor series of 1/√(1+x)"],
+    "prerequisites": ["the division-free closed form", "generalized binomial coefficients"]
+  },
+  {
+    "id": "ann-genbinom-neghalf-catalan",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 99, "endLine": 107 },
+    "type": "theorem",
+    "title": "Catalan form via (k+1)·catalan(k) = centralBinom(k)",
+    "content": "Rewrites the main formula through Mathlib's `succ_mul_catalan_eq_centralBinom` (cast to ℝ with `push_cast`/`linarith`) to expose the Catalan number: `C(-1/2,k) = (-1)^k·(k+1)·catalan(k)/4^k`. This is the algebraic shadow of the generating-function identity `√(1-4x) = 1 - 2∑_{k≥1} catalan(k-1) x^k`, tying the half-integer binomial coefficient directly to the Catalan sequence.",
+    "mathContext": "$\\binom{-1/2}{k} = \\frac{(-1)^k (k+1)\\,C_k}{4^k}$ where $C_k$ is the $k$-th Catalan number, using $(k+1)C_k = \\binom{2k}{k}$. Connects the analytic $1/\\sqrt{1+x}$ coefficients to the combinatorial Catalan generating function $\\frac{1-\\sqrt{1-4x}}{2x}$.",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "central binomial coefficients", "generating functions", "√(1-4x) expansion"],
+    "prerequisites": ["Catalan's formula (k+1)·catalan k = centralBinom k", "the main closed form"]
+  },
+  {
+    "id": "ann-abs-genbinom-neghalf",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 125, "endLine": 132 },
+    "type": "theorem",
+    "title": "Strict alternation and Wallis-type magnitude decay",
+    "content": "Two structural consequences proved uniformly for all k. `genBinom_negHalf_ne_zero` shows the coefficient never vanishes — it strictly alternates in sign — because `centralBinom k > 0`; contrast the parent, which established nonvanishing of the positive coefficient only for small k. `abs_genBinom_negHalf` computes the magnitude `|C(-1/2,k)| = centralBinom(k)/4^k`, the positive rational that decays to 0 like Wallis' product — the actual size of the Taylor coefficients of `1/√(1+x)`.",
+    "mathContext": "$\\bigl|\\binom{-1/2}{k}\\bigr| = \\frac{\\binom{2k}{k}}{4^k} \\sim \\frac{1}{\\sqrt{\\pi k}}$ by Wallis/Stirling asymptotics, a strictly decreasing positive sequence; and $\\binom{-1/2}{k}\\ne 0$ for every $k$ with sign $(-1)^k$.",
+    "significance": "key",
+    "relatedConcepts": ["sign alternation", "Wallis product decay", "abs_pow / abs_div", "central binomial positivity"],
+    "prerequisites": ["the main closed form", "positivity of central binomial coefficients"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "binomial-theorem-oq-01-oq-01-oq-03",
+  "title": "The Closed Form C(-1/2, k) = (-1)^k·C(2k,k)/4^k: Central Binomial and Catalan Coefficients",
+  "slug": "binomial-theorem-oq-01-oq-01-oq-03",
+  "description": "Establishes the general uniform closed form for the negative half-integer generalized binomial coefficient: C(-1/2, k) = (-1)^k·C(2k,k)/4^k = (-1)^k·centralBinom(k)/4^k = (-1)^k·(k+1)·catalan(k)/4^k. These are exactly the Taylor coefficients of 1/√(1+x). The parent proof only evaluated the positive coefficient C(1/2,k) at small k; this entry gives the all-k formula for the coefficient that actually appears in analysis, together with its strict sign alternation, nonvanishing, and absolute-value decay.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ01OQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-series",
+      "central-binomial-coefficient",
+      "catalan-numbers",
+      "generating-functions",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.succ_mul_centralBinom_succ",
+        "description": "The central-binomial recurrence (n+1)·centralBinom(n+1) = 2·(2n+1)·centralBinom(n), the combinatorial engine of the induction",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom(n) = C(2n, n), converting the central binomial coefficient to the explicit binomial coefficient",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.succ_mul_catalan_eq_centralBinom",
+        "description": "(n+1)·catalan(n) = centralBinom(n), giving the Catalan form of the coefficient",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.centralBinom_pos",
+        "description": "0 < centralBinom(n), used for nonvanishing and the absolute-value identity",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      }
+    ],
+    "originalContributions": [
+      "genBinom_negHalf: the main closed form C(-1/2, k) = (-1)^k·centralBinom(k)/4^k for ALL k, proved by a single induction pairing the parent's ode_recurrence with Mathlib's central-binomial recurrence via one linear_combination",
+      "genBinom_negHalf_mul_pow: the division-free form C(-1/2, k)·4^k = (-1)^k·centralBinom(k), the actual inductive workhorse",
+      "genBinom_negHalf_choose: the explicit C(2k,k) form C(-1/2, k) = (-1)^k·C(2k,k)/4^k",
+      "genBinom_negHalf_catalan: the Catalan form C(-1/2, k) = (-1)^k·(k+1)·catalan(k)/4^k",
+      "genBinom_negHalf_ne_zero: the negative half-integer coefficient never vanishes for any k (the parent proved nonvanishing only for the positive coefficient at small k)",
+      "abs_genBinom_negHalf: |C(-1/2, k)| = centralBinom(k)/4^k, the Wallis-type magnitude of the Taylor coefficients of 1/√(1+x)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 152,
+    "assumptions": "0 axioms, 0 sorries. Every theorem depends only on the foundational axioms propext, Classical.choice, Quot.sound (no native_decide, no Lean.ofReduceBool). The closed form is derived by pure induction from the parent proof's ode_recurrence and Mathlib's central-binomial recurrence.",
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "prerequisites": [
+      "Generalized binomial coefficients genBinom and the ode_recurrence (k+1)·C(α,k+1) = (α-k)·C(α,k) (parent proof binomial-theorem-oq-01-oq-01)",
+      "Central binomial coefficients centralBinom(n) = C(2n,n) and their recurrence",
+      "Catalan numbers and the identity (n+1)·catalan(n) = centralBinom(n)"
+    ],
+    "relatedProblems": [
+      "binomial-theorem-oq-01-oq-01",
+      "binomial-theorem-oq-01-oq-01-oq-02"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Newton's generalized binomial series $(1+x)^\\alpha = \\sum_{k\\ge0}\\binom{\\alpha}{k}x^k$ specializes at $\\alpha=-1/2$ to the Taylor expansion of $1/\\sqrt{1+x}$, whose coefficients are among the most ubiquitous in combinatorics and analysis. The closed form $\\binom{-1/2}{k} = (-1)^k\\binom{2k}{k}/4^k$ is the reason the central binomial coefficients $\\binom{2k}{k}$ appear as the Taylor coefficients of $1/\\sqrt{1-4x}$ and, after one further division, why the Catalan numbers generate $(1-\\sqrt{1-4x})/(2x)$. The parent gallery proof computed only the positive coefficients $\\binom{1/2}{k}$ at $k\\le3$; this entry supplies the general all-$k$ identity for the negative coefficient.",
+    "problemStatement": "Prove, for all $k$, the closed form $\\binom{-1/2}{k} = (-1)^k\\binom{2k}{k}/4^k$, and connect it to the central binomial coefficient $\\mathrm{centralBinom}(k)=\\binom{2k}{k}$ and the Catalan number via $(k+1)\\,\\mathrm{catalan}(k)=\\mathrm{centralBinom}(k)$. Establish the sign alternation, nonvanishing for all $k$, and the absolute-value formula $|\\binom{-1/2}{k}| = \\mathrm{centralBinom}(k)/4^k$.",
+    "text": "The generalized binomial coefficient at $\\alpha=-1/2$ has the exact closed form $(-1)^k\\binom{2k}{k}/4^k$. The proof is a single induction: the parent's ode_recurrence gives the ratio $\\binom{-1/2}{k+1}/\\binom{-1/2}{k} = (-1/2-k)/(k+1)$, and Mathlib's central-binomial recurrence gives the matching ratio for $(-1)^k\\mathrm{centralBinom}(k)/4^k$. A one-line linear_combination of the two recurrences and the inductive hypothesis closes the step exactly.",
+    "proofStrategy": "Work with the division-free form $\\binom{-1/2}{k}\\cdot 4^k = (-1)^k\\,\\mathrm{centralBinom}(k)$ to keep everything polynomial. Induct on $k$. Base case: both sides are $1$ ($\\mathrm{centralBinom}(0)=1$). Inductive step: cancel the common factor $(n+1)$ using mul_left_cancel₀, then discharge the resulting identity with a single linear_combination of (i) the parent's ode_recurrence $(n+1)\\binom{-1/2}{n+1} = (-1/2-n)\\binom{-1/2}{n}$, (ii) the inductive hypothesis, and (iii) the central-binomial recurrence $(n+1)\\mathrm{centralBinom}(n+1) = 2(2n+1)\\mathrm{centralBinom}(n)$ cast to ℝ. The remaining scalar identity $4(-1/2-n) + 2(2n+1) = 0$ is closed by ring. Dividing back through by $4^k$ yields the main form; the choose and Catalan forms follow by rewriting with centralBinom_eq_two_mul_choose and succ_mul_catalan_eq_centralBinom.",
+    "keyInsights": [
+      "The two recurrences — the analytic ode_recurrence for $\\binom{\\alpha}{k}$ at $\\alpha=-1/2$ and the combinatorial central-binomial recurrence — have identical ratios $-(2n+1)/(2(n+1))$, so their solutions with matching initial value coincide term by term.",
+      "Proving the multiplied-through form $\\binom{-1/2}{k}\\cdot 4^k = (-1)^k\\,\\mathrm{centralBinom}(k)$ avoids all division inside the induction; the single division back to the stated closed form happens once, outside the induction.",
+      "After cancelling $(n+1)$, the entire inductive step reduces to one linear_combination whose scalar residue is $4(-1/2-n)+2(2n+1)=0$ — the algebraic shadow of the two ratios agreeing.",
+      "The Catalan form drops out for free because $(k+1)\\,\\mathrm{catalan}(k)=\\mathrm{centralBinom}(k)$: the negative half-integer binomial coefficient is $(-1)^k(k+1)\\,\\mathrm{catalan}(k)/4^k$.",
+      "Nonvanishing for ALL $k$ is immediate from the closed form (centralBinom is always positive), whereas the parent could only check it case-by-case for the positive coefficient at small $k$."
+    ],
+    "prerequisites": [
+      "Generalized binomial coefficients and the ode_recurrence (parent proof)",
+      "Central binomial coefficients and their recurrence",
+      "Catalan numbers and (n+1)·catalan(n) = centralBinom(n)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "central-recurrence",
+      "title": "The Central-Binomial Recurrence over ℝ",
+      "startLine": 52,
+      "endLine": 61,
+      "summary": "centralBinom_rec_real transports Mathlib's Nat.succ_mul_centralBinom_succ to ℝ: (n+1)·centralBinom(n+1) = 2·(2n+1)·centralBinom(n). This is the combinatorial half of the matching-ratios argument.",
+      "mathContext": "$(n+1)\\binom{2n+2}{n+1} = 2(2n+1)\\binom{2n}{n}$."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Closed Form by Induction",
+      "startLine": 63,
+      "endLine": 107,
+      "summary": "genBinom_negHalf_mul_pow proves the division-free form C(-1/2,k)·4^k = (-1)^k·centralBinom(k) by induction, cancelling (n+1) and closing with a single linear_combination of ode_recurrence, the inductive hypothesis, and the central recurrence. genBinom_negHalf divides back to the stated closed form; genBinom_negHalf_choose and genBinom_negHalf_catalan restate it with C(2k,k) and with (k+1)·catalan(k).",
+      "mathContext": "$\\binom{-1/2}{k} = (-1)^k\\binom{2k}{k}/4^k = (-1)^k(k+1)\\,\\mathrm{catalan}(k)/4^k$."
+    },
+    {
+      "id": "sign-nonvanishing",
+      "title": "Sign, Nonvanishing, and Magnitude",
+      "startLine": 109,
+      "endLine": 132,
+      "summary": "genBinom_negHalf_ne_zero shows the coefficient never vanishes for any k (centralBinom is positive); abs_genBinom_negHalf gives |C(-1/2,k)| = centralBinom(k)/4^k, the strictly positive magnitude of the Taylor coefficients of 1/√(1+x).",
+      "mathContext": "$\\left|\\binom{-1/2}{k}\\right| = \\binom{2k}{k}/4^k$, the Wallis-type decay."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Values",
+      "startLine": 134,
+      "endLine": 150,
+      "summary": "Sanity checks C(-1/2,0)=1, C(-1/2,1)=-1/2, C(-1/2,2)=3/8, C(-1/2,3)=-5/16, each derived from the closed form by norm_num — the alternating negatives of the parent's positive-coefficient values scaled by the central binomial pattern.",
+      "mathContext": "$1,\\ -\\tfrac12,\\ \\tfrac38,\\ -\\tfrac{5}{16},\\dots$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Eleven machine-checked theorems (0 sorries, 0 axioms beyond the foundational propext/Classical.choice/Quot.sound) establish the general closed form C(-1/2, k) = (-1)^k·C(2k,k)/4^k for all k, in central-binomial and Catalan forms, together with sign alternation, nonvanishing, and the absolute-value magnitude. The proof is a single induction pairing the parent's ode_recurrence with Mathlib's central-binomial recurrence through one linear_combination.",
+    "implications": "Upgrades the parent proof's ad-hoc small-k evaluation of the positive coefficient C(1/2,k) to the uniform all-k closed form for the analytically important negative coefficient. This is the identity that makes the central binomial coefficients the Taylor coefficients of 1/√(1-4x) and underlies the Catalan generating function; the formalization exposes it as a two-recurrence matching argument requiring no analytic machinery.",
+    "openQuestions": [
+      "Prove the generating-function identity ∑_k centralBinom(k)·x^k = 1/√(1-4x) on the disk of convergence by combining this coefficient formula with the parent's binomial_series_analytic at α = -1/2.",
+      "Derive the Catalan generating function (1-√(1-4x))/(2x) = ∑_k catalan(k)·x^k from genBinom_negHalf_catalan and the α = 1/2 series."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Upgrades the parent's small-k evaluation of the positive coefficient C(1/2,k) to the general all-k closed form for the negative coefficient C(-1/2,k), reusing the parent's ode_recurrence as the analytic half of the induction."
+    }
+  ],
+  "status": "verified",
+  "badge": "verified",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BinomialTheoremOQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "BinomialTheoremOQ01OQ01OQ03",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "key": "Ne65",
+      "citation": "Newton, I., De analysi per aequationes numero terminorum infinitas (1665, published 1711). Original generalized binomial series for non-integer exponents.",
+      "type": "paper"
+    },
+    {
+      "key": "GKP94",
+      "citation": "Graham, R. L., Knuth, D. E., Patashnik, O., Concrete Mathematics, 2nd ed., Addison-Wesley (1994), §5.3–5.4. Central binomial coefficients, the identity C(-1/2,k) = (-1)^k C(2k,k)/4^k, and Catalan generating functions.",
+      "type": "book"
+    },
+    {
+      "key": "St99",
+      "citation": "Stanley, R. P., Enumerative Combinatorics, Vol. 2, Cambridge University Press (1999), Chapter 6. Catalan numbers and their generating function.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Ships the open-question follow-up **binomial-theorem-oq-01-oq-01-oq-03**: the uniform, all-`k` closed form for Newton's generalized binomial coefficient at α = −1/2,

$$\binom{-1/2}{k} = \frac{(-1)^k}{4^k}\binom{2k}{k} = \frac{(-1)^k}{4^k}\,\mathrm{centralBinom}(k) = \frac{(-1)^k (k+1)\,\mathrm{catalan}(k)}{4^k}.$$

These are the Taylor coefficients of $(1+x)^{-1/2} = 1/\sqrt{1+x}$. The parent proof (`binomial-theorem-oq-01-oq-01`) only evaluated the *positive* coefficient $C(1/2,k)$ ad hoc at small `k`; this entry gives the general negative-coefficient formula that actually appears in analysis.

## What's proved (11 theorems, 153 lines, 0 sorries, 0 axioms)

- `genBinom_negHalf_mul_pow` — division-free core `C(-1/2,k)·4^k = (-1)^k·centralBinom(k)`, one induction closing the step with a single `linear_combination` of the parent's ODE recurrence and Mathlib's `Nat.succ_mul_centralBinom_succ` (the two recurrences share the ratio `-(2n+1)/(2(n+1))`).
- `genBinom_negHalf`, `genBinom_negHalf_choose` — main forms with `centralBinom k` and explicit `(2k).choose k`.
- `genBinom_negHalf_catalan` — Catalan form via `(k+1)·catalan k = centralBinom k`.
- `genBinom_negHalf_ne_zero`, `abs_genBinom_negHalf` — strict sign alternation and the Wallis-type magnitude `|C(-1/2,k)| = centralBinom(k)/4^k`, proved uniformly for all `k`.
- Concrete sanity checks `C(-1/2,k)` for `k ≤ 3`.

## Verification

Compiles against Mathlib (Lean v4.26.0). `#print axioms` on the key theorems lists only `propext, Classical.choice, Quot.sound` — 0 `axiom` declarations, 0 sorries, no `native_decide`. Status: **verified**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)