### PR TITLE
research(binomial-theorem-oq-01-oq-01-oq-03): C(-1/2,k) = (-1)^k·C(2k,k)/4^k closed form [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean
@@ -1,0 +1,152 @@
+/-
+  binomial-theorem-oq-01-oq-01-oq-03:
+  "The closed form C(-1/2, k) = (-1)^k · C(2k,k) / 4^k, connecting the
+   generalized (Newton) binomial coefficient at α = -1/2 to the central
+   binomial coefficients and the Catalan numbers."
+  ====================================================
+
+  Verified: all theorems compile against Mathlib (lean v4.26.0) and depend only
+  on the foundational axioms `propext`, `Classical.choice`, `Quot.sound`
+  (0 sorries, 0 `axiom` declarations, no `native_decide`).
+
+  The parent gallery proof `binomial-theorem-oq-01-oq-01`
+  (proofs/Proofs/BinomialTheoremOQ01OQ01.lean) provides:
+    * `genBinom α k = (∏ j ∈ range k, (α - j)) / k!`   — the coefficient C(α,k)
+    * `ode_recurrence α k : (k+1) · C(α,k+1) = (α-k) · C(α,k)`
+    * concrete values of the POSITIVE half-integer coefficients C(1/2,k) at
+      small k (k ≤ 3), with the observation that they are eventually nonzero.
+
+  That parent stops at ad-hoc small-k evaluation.  This OQ delivers the general
+  UNIFORM closed form for the NEGATIVE half-integer coefficient — the one that
+  actually appears in analysis, as the Taylor coefficients of (1+x)^(-1/2) =
+  1/√(1+x):
+
+        C(-1/2, k) = (-1)^k · C(2k, k) / 4^k
+                   = (-1)^k · centralBinom k / 4^k
+                   = (-1)^k · (k+1) · catalan k / 4^k.
+
+  These are the coefficients underlying the generating function of the central
+  binomial coefficients, √(1-4x) = 1 - 2 ∑_{k≥1} catalan(k-1) x^k, and the fact
+  that ∑ centralBinom k · x^k = 1/√(1-4x).
+
+  Proof strategy: a single induction on k using the parent's `ode_recurrence`
+  together with Mathlib's central-binomial recurrence
+    `Nat.succ_mul_centralBinom_succ n :
+        (n+1) · centralBinom (n+1) = 2·(2n+1) · centralBinom n`.
+  The two recurrences have matching ratios:
+    C(-1/2, n+1)/C(-1/2, n) = (-1/2 - n)/(n+1) = -(2n+1)/(2(n+1)),
+    [(-1)^{n+1} cb_{n+1}/4^{n+1}] / [(-1)^n cb_n/4^n]
+        = -cb_{n+1}/(4 cb_n) = -(2n+1)/(2(n+1)),
+  so a `linear_combination` of the two recurrences plus the inductive hypothesis
+  closes the step exactly.
+-/
+import Mathlib
+import Proofs.BinomialTheoremOQ01OQ01
+
+open Finset Nat
+
+namespace BinomialTheoremOQ01OQ01OQ03
+
+open BinomialTheoremOQ01OQ01
+
+/-! ### The central-binomial recurrence, cast to `ℝ` -/
+
+/-- Mathlib's `Nat.succ_mul_centralBinom_succ`, transported to `ℝ`:
+    `(n+1) · centralBinom (n+1) = 2·(2n+1) · centralBinom n`. -/
+theorem centralBinom_rec_real (n : ℕ) :
+    ((n : ℝ) + 1) * (Nat.centralBinom (n + 1) : ℝ)
+      = 2 * (2 * (n : ℝ) + 1) * (Nat.centralBinom n : ℝ) := by
+  have h := congrArg (Nat.cast : ℕ → ℝ) (Nat.succ_mul_centralBinom_succ n)
+  push_cast at h
+  linarith
+
+/-! ### Multiplied-through closed form (division-free) -/
+
+/-- The division-free form of the closed formula:
+    `C(-1/2, k) · 4^k = (-1)^k · centralBinom k`.
+    Proved by induction on `k`, cancelling the factor `(k+1)` and closing the
+    inductive step with a `linear_combination` of the two recurrences. -/
+theorem genBinom_negHalf_mul_pow (k : ℕ) :
+    genBinom (-1/2 : ℝ) k * 4 ^ k = (-1) ^ k * (Nat.centralBinom k : ℝ) := by
+  induction k with
+  | zero => simp [genBinom_zero, Nat.centralBinom_zero]
+  | succ n ih =>
+    have hn1 : ((n : ℝ) + 1) ≠ 0 := by positivity
+    have hrec := ode_recurrence (-1/2 : ℝ) n
+    have hcb := centralBinom_rec_real n
+    -- Cancel the common factor (n+1) on both sides, then close by
+    -- linear_combination of ode_recurrence, ih, and the central recurrence.
+    apply mul_left_cancel₀ hn1
+    linear_combination (4 * 4 ^ n) * hrec + (4 * (-1/2 - (n : ℝ))) * ih
+      + ((-1 : ℝ) ^ n) * hcb
+
+/-! ### Main closed forms -/
+
+/-- **Main result.** `C(-1/2, k) = (-1)^k · centralBinom k / 4^k`. -/
+theorem genBinom_negHalf (k : ℕ) :
+    genBinom (-1/2 : ℝ) k = (-1) ^ k * (Nat.centralBinom k : ℝ) / 4 ^ k := by
+  rw [eq_div_iff (by positivity : (4 : ℝ) ^ k ≠ 0)]
+  exact genBinom_negHalf_mul_pow k
+
+/-- The same, written with the explicit central binomial coefficient
+    `C(2k, k)`: `C(-1/2, k) = (-1)^k · C(2k,k) / 4^k`. -/
+theorem genBinom_negHalf_choose (k : ℕ) :
+    genBinom (-1/2 : ℝ) k = (-1) ^ k * ((2 * k).choose k : ℝ) / 4 ^ k := by
+  rw [genBinom_negHalf, Nat.centralBinom_eq_two_mul_choose]
+
+/-- Catalan form: `C(-1/2, k) = (-1)^k · (k+1) · catalan k / 4^k`, using the
+    identity `(k+1)·catalan k = centralBinom k`. -/
+theorem genBinom_negHalf_catalan (k : ℕ) :
+    genBinom (-1/2 : ℝ) k
+      = (-1) ^ k * (((k : ℝ) + 1) * (catalan k : ℝ)) / 4 ^ k := by
+  rw [genBinom_negHalf]
+  have h : ((Nat.centralBinom k : ℝ)) = ((k : ℝ) + 1) * (catalan k : ℝ) := by
+    have := congrArg (Nat.cast : ℕ → ℝ) (succ_mul_catalan_eq_centralBinom k)
+    push_cast at this
+    linarith
+  rw [h]
+
+/-! ### Sign and nonvanishing -/
+
+/-- The negative half-integer coefficient is strictly alternating in sign:
+    it never vanishes.  (Contrast the positive case `C(1/2,k)`, whose parent
+    proof establishes nonvanishing only for small `k`.) -/
+theorem genBinom_negHalf_ne_zero (k : ℕ) : genBinom (-1/2 : ℝ) k ≠ 0 := by
+  rw [genBinom_negHalf]
+  have hcb : (Nat.centralBinom k : ℝ) ≠ 0 := by
+    exact_mod_cast (Nat.centralBinom_pos k).ne'
+  have h4 : (4 : ℝ) ^ k ≠ 0 := by positivity
+  have hsign : ((-1 : ℝ) ^ k) ≠ 0 := pow_ne_zero k (by norm_num)
+  exact div_ne_zero (mul_ne_zero hsign hcb) h4
+
+/-- The absolute value of the coefficient is `centralBinom k / 4^k`, a positive
+    rational strictly decreasing to `0` — the Wallis-type decay of the Taylor
+    coefficients of `1/√(1+x)`. -/
+theorem abs_genBinom_negHalf (k : ℕ) :
+    |genBinom (-1/2 : ℝ) k| = (Nat.centralBinom k : ℝ) / 4 ^ k := by
+  rw [genBinom_negHalf, abs_div, abs_mul]
+  have h4 : |(4 : ℝ) ^ k| = 4 ^ k := abs_of_pos (by positivity)
+  have hcb : |(Nat.centralBinom k : ℝ)| = (Nat.centralBinom k : ℝ) := Nat.abs_cast _
+  have hsign : |(-1 : ℝ) ^ k| = 1 := by
+    rw [abs_pow]; simp
+  rw [h4, hcb, hsign, one_mul]
+
+/-! ### Concrete values (sanity checks against the parent's small-`k` data) -/
+
+/-- `C(-1/2, 0) = 1`. -/
+theorem genBinom_negHalf_zero : genBinom (-1/2 : ℝ) 0 = 1 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom]
+
+/-- `C(-1/2, 1) = -1/2`. -/
+theorem genBinom_negHalf_one : genBinom (-1/2 : ℝ) 1 = -1/2 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom, Nat.choose]
+
+/-- `C(-1/2, 2) = 3/8`. -/
+theorem genBinom_negHalf_two : genBinom (-1/2 : ℝ) 2 = 3/8 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom, Nat.choose]
+
+/-- `C(-1/2, 3) = -5/16`. -/
+theorem genBinom_negHalf_three : genBinom (-1/2 : ℝ) 3 = -5/16 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom, Nat.choose]
+
+end BinomialTheoremOQ01OQ01OQ03

--- a/research/problems/binomial-theorem-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/binomial-theorem-oq-01-oq-01-oq-03/knowledge.md
@@ -1,0 +1,38 @@
+# Knowledge Base: binomial-theorem-oq-01-oq-01-oq-03
+
+C(-1/2, k) = (-1)^k · C(2k,k) / 4^k — Newton's generalized binomial coefficient
+at the half-integer point α = -1/2, the Taylor coefficients of 1/√(1+x).
+
+---
+
+## Session 2026-07-01 (Session 1) — COMPLETED, VERIFIED 0-axiom
+
+**Mode**: FRESH
+**Outcome**: completed (0 sorries, 0 axioms; PR opened)
+
+### What I Did
+- Proved the uniform closed form `genBinom_negHalf : C(-1/2, k) = (-1)^k·centralBinom k / 4^k` by induction on k.
+- Built `proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean` (152 lines, 11 theorems), reusing the parent's `genBinom`/`ode_recurrence` via `import Proofs.BinomialTheoremOQ01OQ01`.
+- Added gallery entry `src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/` (meta.json + annotations.json).
+
+### Key Findings
+- The proof reduces to **ratio matching**: the ODE falling-factorial recurrence gives ratio `(-1/2 - k)/(k+1) = -(2k+1)/(2(k+1))`; Mathlib's `Nat.succ_mul_centralBinom_succ` gives `centralBinom(k+1)/centralBinom(k) = 2(2k+1)/(k+1)`, so `(-1)^k·centralBinom k/4^k` has the **same** ratio. Agreement at k=0 (both = 1) closes the induction.
+- Working in the **division-free** form `C(-1/2,k)·4^k = (-1)^k·centralBinom k` lets the inductive step close with a single `linear_combination` (coeffs `(4·4^n)·hrec + (4·(-1/2 - n))·ih + (-1)^n·hcb`) after `mul_left_cancel₀` on `(n+1)`.
+- Catalan form via `succ_mul_catalan_eq_centralBinom : (n+1)·catalan n = centralBinom n`.
+
+### Gotchas
+- `catalan` / `succ_mul_catalan_eq_centralBinom` live in the **root** namespace, NOT `Nat.` — writing `Nat.catalan` fails with unknownIdentifier.
+- `positivity` does NOT prove `|x| = x` equalities → use `abs_of_pos` / `Nat.abs_cast`.
+- Docker build down (containerd I/O error) → compiled with `LAKE_UNSAFE=1 lake env lean` from main `proofs/` (parent olean prebuilt).
+- Concurrent agents doing `git reset/clean` on the shared main working tree WIPED uncommitted files mid-session → recreated everything in an isolated `$HOME/lean-genius-wt` worktree and committed there.
+
+### Files Modified
+- `proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean`
+- `src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/{meta,annotations}.json`
+
+### Axioms
+All theorems depend only on `[propext, Classical.choice, Quot.sound]` — VERIFIED, 0-axiom.
+
+### Follow-Up Questions Generated
+1. Generating-function identity `Σ C(-1/2,k)·(-4x)^k = 1/√(1-4x) = Σ C(2k,k) x^k` as a power-series equality (tie to Mathlib `HasFPowerSeriesOnBall` for `(1+·)^(-1/2)`).
+2. General half-odd-integer closed form `C(-(2m+1)/2, k)` in terms of `C(2k,k)` and rising factorials (this proof is the m=0 case).

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "ann-binom-oq010103-01-header",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "concept",
+    "title": "The Negative Half-Integer Coefficient and Its Central-Binomial Closed Form",
+    "content": "This file proves the uniform closed form C(-1/2, k) = (-1)^k · C(2k,k) / 4^k for Newton's generalized binomial coefficient at α = -1/2. Unlike the positive case α = 1/2 (√(1+x)), the negative case gives the Taylor coefficients of 1/√(1+x), which — after x ↦ -4x — become the generating function 1/√(1-4x) = Σ C(2k,k) x^k of the central binomial coefficients. The parent entry evaluated only a few small-k values of the positive coefficient ad hoc; here the negative case is settled uniformly for all k.",
+    "mathContext": "$\\binom{-1/2}{k} = \\dfrac{1}{k!}\\prod_{j=0}^{k-1}\\left(-\\tfrac12 - j\\right) = \\dfrac{(-1)^k}{4^k}\\binom{2k}{k}$. The generating function is $\\sum_k \\binom{-1/2}{k} x^k = (1+x)^{-1/2} = 1/\\sqrt{1+x}$.",
+    "significance": "foundational",
+    "relatedConcepts": ["central binomial coefficient", "square root generating function", "Newton's binomial series"],
+    "prerequisites": ["generalized binomial coefficient", "power series"],
+    "tags": ["overview", "central-binomial"]
+  },
+  {
+    "id": "ann-binom-oq010103-02-central-rec",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 54, "endLine": 61 },
+    "type": "technique",
+    "title": "Transporting the Central-Binomial Recurrence to ℝ",
+    "content": "Mathlib's Nat.succ_mul_centralBinom_succ states (n+1)·centralBinom(n+1) = 2·(2n+1)·centralBinom(n) over ℕ. Casting it to ℝ (via congrArg + push_cast) is the crucial bridge: it exposes that (-1)^k·centralBinom(k)/4^k has successive ratio -(2k+1)/(2(k+1)), matching the ODE recurrence ratio (-1/2 - k)/(k+1) of the binomial coefficient exactly.",
+    "mathContext": "Over $\\mathbb{R}$: $(n+1)\\,\\mathrm{cb}(n+1) = 2(2n+1)\\,\\mathrm{cb}(n)$, hence $\\dfrac{\\mathrm{cb}(n+1)}{\\mathrm{cb}(n)} = \\dfrac{2(2n+1)}{n+1}$ and the ratio of $(-1)^n \\mathrm{cb}(n)/4^n$ is $-\\dfrac{2n+1}{2(n+1)}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["recurrence relation", "central binomial coefficient", "cast lemmas"],
+    "prerequisites": ["central binomial recurrence"],
+    "tags": ["technique", "recurrence"]
+  },
+  {
+    "id": "ann-binom-oq010103-03-division-free",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 65, "endLine": 81 },
+    "type": "key-step",
+    "title": "Division-Free Induction via a Single linear_combination",
+    "content": "The heart of the proof: rather than manipulate fractions, we prove C(-1/2, k)·4^k = (-1)^k·centralBinom(k). In the inductive step, cancelling the common factor (n+1) with mul_left_cancel₀ reduces the goal to a linear identity in the ODE recurrence, the inductive hypothesis, and the ℝ-cast central recurrence — closed by one linear_combination with explicit coefficients (4·4^n)·hrec + (4·(-1/2 - n))·ih + (-1)^n·hcb.",
+    "mathContext": "Multiplying through by $4^k$ removes all denominators; the two shared-ratio recurrences then combine linearly, so no field arithmetic is needed and the step is a pure ring identity.",
+    "significance": "critical",
+    "relatedConcepts": ["induction", "linear_combination", "mul_left_cancel"],
+    "prerequisites": ["ODE recurrence", "central binomial recurrence"],
+    "tags": ["key-step", "induction"]
+  },
+  {
+    "id": "ann-binom-oq010103-04-closed-forms",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 85, "endLine": 107 },
+    "type": "key-step",
+    "title": "Three Equivalent Closed Forms: centralBinom, C(2k,k), Catalan",
+    "content": "From the division-free identity, dividing by 4^k gives the main closed form C(-1/2, k) = (-1)^k·centralBinom(k)/4^k. Rewriting centralBinom k = (2k).choose k (Nat.centralBinom_eq_two_mul_choose) yields the explicit C(2k,k) form; substituting Catalan's identity (k+1)·catalan k = centralBinom k (succ_mul_catalan_eq_centralBinom) yields the Catalan form C(-1/2, k) = (-1)^k·(k+1)·catalan k/4^k.",
+    "mathContext": "$\\binom{-1/2}{k} = \\dfrac{(-1)^k}{4^k}\\binom{2k}{k} = \\dfrac{(-1)^k (k+1)}{4^k}\\,C_k$, where $C_k$ is the $k$-th Catalan number.",
+    "significance": "foundational",
+    "relatedConcepts": ["Catalan numbers", "central binomial coefficient", "closed form"],
+    "prerequisites": ["Catalan's formula"],
+    "tags": ["key-step", "catalan"]
+  },
+  {
+    "id": "ann-binom-oq010103-05-sign-magnitude",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 109, "endLine": 152 },
+    "type": "concept",
+    "title": "Sign, Nonvanishing, Magnitude, and Concrete Values",
+    "content": "The closed form immediately gives structural consequences uniform in k: the coefficient never vanishes (strict alternation of sign), and its magnitude is |C(-1/2, k)| = centralBinom(k)/4^k — the Wallis-type decay of the 1/√(1+x) coefficients. Concrete values C(-1/2, k) for k = 0,1,2,3 (namely 1, -1/2, 3/8, -5/16) are verified by norm_num as sanity checks against the parent's small-k data.",
+    "mathContext": "$\\left|\\binom{-1/2}{k}\\right| = \\dfrac{\\binom{2k}{k}}{4^k} \\to 0$ (Wallis decay $\\sim 1/\\sqrt{\\pi k}$); the sign is $(-1)^k$, so $\\binom{-1/2}{k} \\ne 0$ for all $k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Wallis product", "alternating series", "nonvanishing"],
+    "prerequisites": ["central binomial positivity"],
+    "tags": ["concept", "sign-analysis"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "binomial-theorem-oq-01-oq-01-oq-03",
+  "title": "The Closed Form C(-1/2, k) = (-1)^k·C(2k,k)/4^k: Central Binomial and Catalan Coefficients",
+  "slug": "binomial-theorem-oq-01-oq-01-oq-03",
+  "description": "Establishes the general uniform closed form for the negative half-integer generalized binomial coefficient: C(-1/2, k) = (-1)^k·C(2k,k)/4^k = (-1)^k·centralBinom(k)/4^k = (-1)^k·(k+1)·catalan(k)/4^k. These are exactly the Taylor coefficients of 1/√(1+x). The parent proof only evaluated the positive coefficient C(1/2,k) at small k; this entry gives the all-k formula for the coefficient that actually appears in analysis, together with its strict sign alternation, nonvanishing, and absolute-value decay.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ01OQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-series",
+      "central-binomial-coefficient",
+      "catalan-numbers",
+      "generating-functions",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.succ_mul_centralBinom_succ",
+        "description": "The central-binomial recurrence (n+1)·centralBinom(n+1) = 2·(2n+1)·centralBinom(n), the combinatorial engine of the induction",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom(n) = C(2n, n), converting the central binomial coefficient to the explicit binomial coefficient",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.succ_mul_catalan_eq_centralBinom",
+        "description": "(n+1)·catalan(n) = centralBinom(n), giving the Catalan form of the coefficient",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.centralBinom_pos",
+        "description": "0 < centralBinom(n), used for nonvanishing and the absolute-value identity",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      }
+    ],
+    "originalContributions": [
+      "genBinom_negHalf: the main closed form C(-1/2, k) = (-1)^k·centralBinom(k)/4^k for ALL k, proved by a single induction pairing the parent's ode_recurrence with Mathlib's central-binomial recurrence via one linear_combination",
+      "genBinom_negHalf_mul_pow: the division-free form C(-1/2, k)·4^k = (-1)^k·centralBinom(k), the actual inductive workhorse",
+      "genBinom_negHalf_choose: the explicit C(2k,k) form C(-1/2, k) = (-1)^k·C(2k,k)/4^k",
+      "genBinom_negHalf_catalan: the Catalan form C(-1/2, k) = (-1)^k·(k+1)·catalan(k)/4^k",
+      "genBinom_negHalf_ne_zero: the negative half-integer coefficient never vanishes for any k (the parent proved nonvanishing only for the positive coefficient at small k)",
+      "abs_genBinom_negHalf: |C(-1/2, k)| = centralBinom(k)/4^k, the Wallis-type magnitude of the Taylor coefficients of 1/√(1+x)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 152,
+    "assumptions": "0 axioms, 0 sorries. Every theorem depends only on the foundational axioms propext, Classical.choice, Quot.sound (no native_decide, no Lean.ofReduceBool). The closed form is derived by pure induction from the parent proof's ode_recurrence and Mathlib's central-binomial recurrence.",
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "prerequisites": [
+      "Generalized binomial coefficients genBinom and the ode_recurrence (k+1)·C(α,k+1) = (α-k)·C(α,k) (parent proof binomial-theorem-oq-01-oq-01)",
+      "Central binomial coefficients centralBinom(n) = C(2n,n) and their recurrence",
+      "Catalan numbers and the identity (n+1)·catalan(n) = centralBinom(n)"
+    ],
+    "relatedProblems": [
+      "binomial-theorem-oq-01-oq-01",
+      "binomial-theorem-oq-01-oq-01-oq-02"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Newton's generalized binomial series $(1+x)^\\alpha = \\sum_{k\\ge0}\\binom{\\alpha}{k}x^k$ specializes at $\\alpha=-1/2$ to the Taylor expansion of $1/\\sqrt{1+x}$, whose coefficients are among the most ubiquitous in combinatorics and analysis. The closed form $\\binom{-1/2}{k} = (-1)^k\\binom{2k}{k}/4^k$ is the reason the central binomial coefficients $\\binom{2k}{k}$ appear as the Taylor coefficients of $1/\\sqrt{1-4x}$ and, after one further division, why the Catalan numbers generate $(1-\\sqrt{1-4x})/(2x)$. The parent gallery proof computed only the positive coefficients $\\binom{1/2}{k}$ at $k\\le3$; this entry supplies the general all-$k$ identity for the negative coefficient.",
+    "problemStatement": "Prove, for all $k$, the closed form $\\binom{-1/2}{k} = (-1)^k\\binom{2k}{k}/4^k$, and connect it to the central binomial coefficient $\\mathrm{centralBinom}(k)=\\binom{2k}{k}$ and the Catalan number via $(k+1)\\,\\mathrm{catalan}(k)=\\mathrm{centralBinom}(k)$. Establish the sign alternation, nonvanishing for all $k$, and the absolute-value formula $|\\binom{-1/2}{k}| = \\mathrm{centralBinom}(k)/4^k$.",
+    "text": "The generalized binomial coefficient at $\\alpha=-1/2$ has the exact closed form $(-1)^k\\binom{2k}{k}/4^k$. The proof is a single induction: the parent's ode_recurrence gives the ratio $\\binom{-1/2}{k+1}/\\binom{-1/2}{k} = (-1/2-k)/(k+1)$, and Mathlib's central-binomial recurrence gives the matching ratio for $(-1)^k\\mathrm{centralBinom}(k)/4^k$. A one-line linear_combination of the two recurrences and the inductive hypothesis closes the step exactly.",
+    "proofStrategy": "Work with the division-free form $\\binom{-1/2}{k}\\cdot 4^k = (-1)^k\\,\\mathrm{centralBinom}(k)$ to keep everything polynomial. Induct on $k$. Base case: both sides are $1$ ($\\mathrm{centralBinom}(0)=1$). Inductive step: cancel the common factor $(n+1)$ using mul_left_cancel₀, then discharge the resulting identity with a single linear_combination of (i) the parent's ode_recurrence $(n+1)\\binom{-1/2}{n+1} = (-1/2-n)\\binom{-1/2}{n}$, (ii) the inductive hypothesis, and (iii) the central-binomial recurrence $(n+1)\\mathrm{centralBinom}(n+1) = 2(2n+1)\\mathrm{centralBinom}(n)$ cast to ℝ. The remaining scalar identity $4(-1/2-n) + 2(2n+1) = 0$ is closed by ring. Dividing back through by $4^k$ yields the main form; the choose and Catalan forms follow by rewriting with centralBinom_eq_two_mul_choose and succ_mul_catalan_eq_centralBinom.",
+    "keyInsights": [
+      "The two recurrences — the analytic ode_recurrence for $\\binom{\\alpha}{k}$ at $\\alpha=-1/2$ and the combinatorial central-binomial recurrence — have identical ratios $-(2n+1)/(2(n+1))$, so their solutions with matching initial value coincide term by term.",
+      "Proving the multiplied-through form $\\binom{-1/2}{k}\\cdot 4^k = (-1)^k\\,\\mathrm{centralBinom}(k)$ avoids all division inside the induction; the single division back to the stated closed form happens once, outside the induction.",
+      "After cancelling $(n+1)$, the entire inductive step reduces to one linear_combination whose scalar residue is $4(-1/2-n)+2(2n+1)=0$ — the algebraic shadow of the two ratios agreeing.",
+      "The Catalan form drops out for free because $(k+1)\\,\\mathrm{catalan}(k)=\\mathrm{centralBinom}(k)$: the negative half-integer binomial coefficient is $(-1)^k(k+1)\\,\\mathrm{catalan}(k)/4^k$.",
+      "Nonvanishing for ALL $k$ is immediate from the closed form (centralBinom is always positive), whereas the parent could only check it case-by-case for the positive coefficient at small $k$."
+    ],
+    "prerequisites": [
+      "Generalized binomial coefficients and the ode_recurrence (parent proof)",
+      "Central binomial coefficients and their recurrence",
+      "Catalan numbers and (n+1)·catalan(n) = centralBinom(n)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "central-recurrence",
+      "title": "The Central-Binomial Recurrence over ℝ",
+      "startLine": 52,
+      "endLine": 61,
+      "summary": "centralBinom_rec_real transports Mathlib's Nat.succ_mul_centralBinom_succ to ℝ: (n+1)·centralBinom(n+1) = 2·(2n+1)·centralBinom(n). This is the combinatorial half of the matching-ratios argument.",
+      "mathContext": "$(n+1)\\binom{2n+2}{n+1} = 2(2n+1)\\binom{2n}{n}$."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Closed Form by Induction",
+      "startLine": 63,
+      "endLine": 107,
+      "summary": "genBinom_negHalf_mul_pow proves the division-free form C(-1/2,k)·4^k = (-1)^k·centralBinom(k) by induction, cancelling (n+1) and closing with a single linear_combination of ode_recurrence, the inductive hypothesis, and the central recurrence. genBinom_negHalf divides back to the stated closed form; genBinom_negHalf_choose and genBinom_negHalf_catalan restate it with C(2k,k) and with (k+1)·catalan(k).",
+      "mathContext": "$\\binom{-1/2}{k} = (-1)^k\\binom{2k}{k}/4^k = (-1)^k(k+1)\\,\\mathrm{catalan}(k)/4^k$."
+    },
+    {
+      "id": "sign-nonvanishing",
+      "title": "Sign, Nonvanishing, and Magnitude",
+      "startLine": 109,
+      "endLine": 132,
+      "summary": "genBinom_negHalf_ne_zero shows the coefficient never vanishes for any k (centralBinom is positive); abs_genBinom_negHalf gives |C(-1/2,k)| = centralBinom(k)/4^k, the strictly positive magnitude of the Taylor coefficients of 1/√(1+x).",
+      "mathContext": "$\\left|\\binom{-1/2}{k}\\right| = \\binom{2k}{k}/4^k$, the Wallis-type decay."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Values",
+      "startLine": 134,
+      "endLine": 150,
+      "summary": "Sanity checks C(-1/2,0)=1, C(-1/2,1)=-1/2, C(-1/2,2)=3/8, C(-1/2,3)=-5/16, each derived from the closed form by norm_num — the alternating negatives of the parent's positive-coefficient values scaled by the central binomial pattern.",
+      "mathContext": "$1,\\ -\\tfrac12,\\ \\tfrac38,\\ -\\tfrac{5}{16},\\dots$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Eleven machine-checked theorems (0 sorries, 0 axioms beyond the foundational propext/Classical.choice/Quot.sound) establish the general closed form C(-1/2, k) = (-1)^k·C(2k,k)/4^k for all k, in central-binomial and Catalan forms, together with sign alternation, nonvanishing, and the absolute-value magnitude. The proof is a single induction pairing the parent's ode_recurrence with Mathlib's central-binomial recurrence through one linear_combination.",
+    "implications": "Upgrades the parent proof's ad-hoc small-k evaluation of the positive coefficient C(1/2,k) to the uniform all-k closed form for the analytically important negative coefficient. This is the identity that makes the central binomial coefficients the Taylor coefficients of 1/√(1-4x) and underlies the Catalan generating function; the formalization exposes it as a two-recurrence matching argument requiring no analytic machinery.",
+    "openQuestions": [
+      "Prove the generating-function identity ∑_k centralBinom(k)·x^k = 1/√(1-4x) on the disk of convergence by combining this coefficient formula with the parent's binomial_series_analytic at α = -1/2.",
+      "Derive the Catalan generating function (1-√(1-4x))/(2x) = ∑_k catalan(k)·x^k from genBinom_negHalf_catalan and the α = 1/2 series."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Upgrades the parent's small-k evaluation of the positive coefficient C(1/2,k) to the general all-k closed form for the negative coefficient C(-1/2,k), reusing the parent's ode_recurrence as the analytic half of the induction."
+    }
+  ],
+  "status": "verified",
+  "badge": "verified",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BinomialTheoremOQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "BinomialTheoremOQ01OQ01OQ03",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "key": "Ne65",
+      "citation": "Newton, I., De analysi per aequationes numero terminorum infinitas (1665, published 1711). Original generalized binomial series for non-integer exponents.",
+      "type": "paper"
+    },
+    {
+      "key": "GKP94",
+      "citation": "Graham, R. L., Knuth, D. E., Patashnik, O., Concrete Mathematics, 2nd ed., Addison-Wesley (1994), §5.3–5.4. Central binomial coefficients, the identity C(-1/2,k) = (-1)^k C(2k,k)/4^k, and Catalan generating functions.",
+      "type": "book"
+    },
+    {
+      "key": "St99",
+      "citation": "Stanley, R. P., Enumerative Combinatorics, Vol. 2, Cambridge University Press (1999), Chapter 6. Catalan numbers and their generating function.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves OQ-03 of **Newton's Generalized Binomial Theorem** (`binomial-theorem-oq-01-oq-01`): the uniform closed form for Newton's generalized binomial coefficient at the half-integer point **α = −1/2** — the Taylor coefficients of 1/√(1+x).

$$\binom{-1/2}{k} = \frac{(-1)^k}{4^k}\,\mathrm{centralBinom}(k) = \frac{(-1)^k}{4^k}\binom{2k}{k} = \frac{(-1)^k(k+1)}{4^k}\,C_k.$$

The parent entry evaluates only a handful of small-`k` values of the *positive* coefficient C(1/2,k) ad hoc; this supplies the general form for the analytically central *negative* case (the generating function of the central binomial coefficients, 1/√(1−4x) = Σ C(2k,k) xᵏ).

## Proof idea

Both `C(-1/2, k)` (via the parent's ODE falling-factorial recurrence) and `(-1)^k·centralBinom(k)/4^k` (via Mathlib's `Nat.succ_mul_centralBinom_succ`) share the successive ratio **−(2k+1)/(2(k+1))** and agree at k=0, so a single induction closes the identity. The inductive step is discharged in the **division-free** form `C(-1/2,k)·4^k = (-1)^k·centralBinom(k)` by one `linear_combination` after `mul_left_cancel₀` on `(n+1)` — no field arithmetic.

## Contents

`proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean` — 11 theorems, 152 lines, **0 sorries**:
- `genBinom_negHalf` — main closed form (centralBinom)
- `genBinom_negHalf_mul_pow` — division-free form (the induction)
- `genBinom_negHalf_choose` — explicit C(2k,k) form
- `genBinom_negHalf_catalan` — Catalan form via `succ_mul_catalan_eq_centralBinom`
- `genBinom_negHalf_ne_zero`, `abs_genBinom_negHalf` — strict sign alternation + magnitude (Wallis decay)
- concrete values `1, -1/2, 3/8, -5/16`

## Verification

All theorems depend only on `[propext, Classical.choice, Quot.sound]` — **VERIFIED, 0-axiom**, no `native_decide`. Compiled against Mathlib v4.26.0.

Gallery entry: `src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/` (meta.json + 5 annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)