### PR TITLE
Enrich Raabe Multiplication (oq-01): annotate m=0 base case

### DIFF
--- a/src/data/proofs/hermite-sawtooth-identity-oq-01/annotations.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-01/annotations.json
@@ -24,6 +24,18 @@
     "relatedConcepts": ["Gauss sum", "Faulhaber identities", "push_cast"]
   },
   {
+    "id": "ann-raabe-zero",
+    "proofId": "hermite-sawtooth-identity-oq-01",
+    "range": { "startLine": 74, "endLine": 83 },
+    "type": "theorem",
+    "title": "Raabe m=0: ∑ B₀(x+k/n) = n·B₀(nx) — the degenerate base case",
+    "content": "The order-$0$ case, where the prefactor is $n^{1-0} = n$. Since $B_0 \\equiv 1$, both sides collapse immediately: the left is $\\sum_{k<n} 1 = n$ and the right is $n \\cdot 1 = n$. The proof is correspondingly trivial — `simp only [bernoulli_eval_zero']` rewrites every $B_0$ evaluation to $1$, and a bare `simp` finishes by counting the range. It is the degenerate rung of the ladder (no power sums are needed at all), but it is included so the three low orders $m = 0, 1, 2$ — with prefactors $n, 1, 1/n$ — appear uniformly, making transparent that $n^{1-m}$ is a plain rational coefficient at each fixed order rather than a genuine power. Note it holds for every $n$ (no $n \\ge 1$ hypothesis, since the empty sum at $n = 0$ gives $0 = 0$).",
+    "mathContext": "$\\sum_{k<n} B_0\\!\\left(x+\\tfrac kn\\right) = n = n\\cdot B_0(nx)$, since $B_0 \\equiv 1$ and $n^{1-0} = n$.",
+    "significance": "supporting",
+    "prerequisites": ["Finset.sum_const", "Finset.card_range"],
+    "relatedConcepts": ["Raabe multiplication theorem", "constant Bernoulli polynomial B₀", "degenerate base case"]
+  },
+  {
     "id": "ann-raabe-one",
     "proofId": "hermite-sawtooth-identity-oq-01",
     "range": { "startLine": 86, "endLine": 96 },


### PR DESCRIPTION
Enrichment pass for `hermite-sawtooth-identity-oq-01` (quality 89, pass 0).

## Change
The entry's headline results are the Raabe multiplication formula at orders m=0, 1, 2. Annotations covered the evaluations, power-sums, m=1 and m=2, but the **m=0 case (`raabe_zero`, lines 74–83) had no annotation** — an inline-coverage gap on a headline theorem.

Added `ann-raabe-zero`: the degenerate base case where $B_0\equiv 1$ and the prefactor is $n^{1-0}=n$, so both sides collapse to $n$ (proof is `simp only [bernoulli_eval_zero']; simp`). Notes that it holds for every $n$ (no $n\ge1$ hypothesis) and makes the uniform $n^{1-m}=n,1,1/n$ pattern visible across the three orders. Full structured fields (mathContext/significance/prerequisites/relatedConcepts).

## Notes
- Annotation count 4 → 5; all now carry structured fields.
- meta.json already comprehensive (4 keyInsights, conclusion summary/implications/3 openQuestions, 2 crossRefs, 2 refs) — left intact, well under 60 KB cap.
- Verified against `Proofs/HermiteSawtoothIdentityOQ01.lean`.