### PR TITLE
research(bounded-prime-gaps-oq-04-oq-03): Gauss sum bound |τ(χ)|=√p prime case [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ04OQ03.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ04OQ03.lean
@@ -1,0 +1,135 @@
+/-
+# Bounded Prime Gaps OQ04-OQ03:
+# The Gauss Sum Bound |τ(χ)| = √p (Prime Modulus, from Mathlib)
+
+Source: Research session, July 2026 (researcher-1)
+
+## The Question
+
+OQ04-OQ02 catalogs six "minimal Mathlib additions" needed for the
+Bombieri-Vinogradov theorem. The first and most tractable of these is
+
+  **Addition 1 (`gaussSumBound`)** — for a primitive Dirichlet character
+  χ mod q, the Gauss sum τ(χ) = Σ_t χ(t)·e(t/q) has |τ(χ)| = √q.
+
+That catalog records `gaussSumBound` as an *axiom*. This file asks: how
+much of it is already provable from current Mathlib (v4.26.0), and where
+exactly is the genuine gap?
+
+## The Answer
+
+The **prime-modulus case is fully provable from Mathlib** with no axioms.
+For a prime p and a nontrivial Dirichlet character χ mod p,
+
+  ‖gaussSum χ stdAddChar‖ = √p .
+
+The proof combines two existing Mathlib results:
+
+1. `gaussSum_mul_gaussSum_eq_card` : for χ ≠ 1 and ψ primitive over a
+   **field** R, `gaussSum χ ψ * gaussSum χ⁻¹ ψ⁻¹ = #R`.
+2. Conjugation: over ℂ, `conj (gaussSum χ ψ) = gaussSum χ⁻¹ ψ⁻¹` because
+   `conj (χ a) = χ⁻¹ a` (`MulChar.star_apply'`) and `conj (ψ a) = ψ⁻¹ a`
+   (the standard additive character is unit-circle valued).
+
+Together `gaussSum χ ψ · conj (gaussSum χ ψ) = p`, i.e. `‖τ(χ)‖² = p`.
+
+## Where the Gap Really Is
+
+Mathlib's `gaussSum_mul_gaussSum_eq_card` requires `[Field R]`. For
+`R = ZMod q` this holds **iff q is prime**. The general primitive-character
+bound for *composite* modulus is therefore genuinely missing: it needs the
+theory of primitive Dirichlet characters and the reduction of an imprimitive
+Gauss sum to its primitive inductor — machinery not yet in Mathlib. So this
+file converts the *prime part* of `gaussSumBound` from axiom to theorem and
+pins the remaining work to the composite-primitive case.
+
+## Results
+
+- `conj_stdAddChar`         — conj of the standard additive character
+- `conj_gaussSum`           — `conj (gaussSum χ ψ) = gaussSum χ⁻¹ ψ⁻¹`
+- `gaussSum_mul_conj`       — `τ(χ) · conj τ(χ) = p`
+- `normSq_gaussSum`         — `normSq τ(χ) = p`
+- `norm_gaussSum_eq_sqrt`   — **|τ(χ)| = √p** (the prime-modulus bound)
+- `gaussSum_ne_zero`        — corollary: `τ(χ) ≠ 0`
+
+Axioms: 0
+Sorries: 0
+-/
+import Mathlib
+
+open Finset Complex
+
+namespace BoundedPrimeGapsOQ04OQ03
+
+open scoped Real
+
+noncomputable section
+
+/-- Complex conjugation sends the standard additive character `e(a/N)` to its
+inverse `e(-a/N)`: `conj (stdAddChar a) = stdAddChar⁻¹ a`.
+
+The standard character takes values on the unit circle, so conjugation equals
+inversion, and `stdAddChar⁻¹ a = stdAddChar (-a)`. -/
+lemma conj_stdAddChar {N : ℕ} [NeZero N] (a : ZMod N) :
+    (starRingEnd ℂ) (ZMod.stdAddChar a) = ZMod.stdAddChar⁻¹ a := by
+  rw [ZMod.stdAddChar_apply, AddChar.inv_apply, ZMod.stdAddChar_apply,
+      ← Circle.coe_inv_eq_conj, AddChar.map_neg_eq_inv, Circle.coe_inv]
+
+/-- Complex conjugation of a Gauss sum flips the character to its inverse:
+`conj (gaussSum χ stdAddChar) = gaussSum χ⁻¹ stdAddChar⁻¹`.
+
+Uses `conj (χ a) = χ⁻¹ a` (`MulChar.star_apply'`) termwise together with
+`conj_stdAddChar`. -/
+lemma conj_gaussSum {N : ℕ} [NeZero N] (χ : DirichletCharacter ℂ N) :
+    (starRingEnd ℂ) (gaussSum χ ZMod.stdAddChar) = gaussSum χ⁻¹ ZMod.stdAddChar⁻¹ := by
+  rw [gaussSum, gaussSum, map_sum]
+  refine Finset.sum_congr rfl (fun a _ => ?_)
+  rw [map_mul, starRingEnd_apply, MulChar.star_apply', conj_stdAddChar]
+
+variable (p : ℕ) [Fact p.Prime]
+
+/-- For a nontrivial Dirichlet character mod a prime `p`, the Gauss sum
+against the standard additive character satisfies `τ(χ) · conj τ(χ) = p`.
+
+This is the product formula `gaussSum χ ψ · gaussSum χ⁻¹ ψ⁻¹ = #(ZMod p)`
+(valid because `ZMod p` is a field) rewritten via `conj_gaussSum`. -/
+theorem gaussSum_mul_conj (χ : DirichletCharacter ℂ p) (hχ : χ ≠ 1) :
+    gaussSum χ ZMod.stdAddChar * (starRingEnd ℂ) (gaussSum χ ZMod.stdAddChar) = (p : ℂ) := by
+  haveI : NeZero p := ⟨(Fact.out : p.Prime).ne_zero⟩
+  rw [conj_gaussSum,
+      gaussSum_mul_gaussSum_eq_card hχ (ZMod.isPrimitive_stdAddChar p), ZMod.card]
+
+/-- The squared norm of the Gauss sum equals `p`: `normSq τ(χ) = p`. -/
+theorem normSq_gaussSum (χ : DirichletCharacter ℂ p) (hχ : χ ≠ 1) :
+    Complex.normSq (gaussSum χ ZMod.stdAddChar) = (p : ℝ) := by
+  have h : (Complex.normSq (gaussSum χ ZMod.stdAddChar) : ℂ) = (p : ℂ) := by
+    rw [Complex.normSq_eq_conj_mul_self, mul_comm]
+    exact gaussSum_mul_conj p χ hχ
+  exact_mod_cast h
+
+/-- **The Gauss sum bound, prime-modulus case.** For a prime `p` and any
+nontrivial Dirichlet character `χ` mod `p`,
+
+  ‖gaussSum χ stdAddChar‖ = √p .
+
+This is `gaussSumBound` (Addition 1 of the BV prerequisite catalog,
+`BoundedPrimeGapsOQ04OQ02`) restricted to prime modulus — proved here with
+no axioms from Mathlib's `gaussSum_mul_gaussSum_eq_card`. -/
+theorem norm_gaussSum_eq_sqrt (χ : DirichletCharacter ℂ p) (hχ : χ ≠ 1) :
+    ‖gaussSum χ ZMod.stdAddChar‖ = Real.sqrt p := by
+  rw [Complex.norm_def, normSq_gaussSum p χ hχ]
+
+/-- Corollary: the Gauss sum of a nontrivial character mod a prime is nonzero.
+(Its norm is `√p > 0`.) -/
+theorem gaussSum_ne_zero (χ : DirichletCharacter ℂ p) (hχ : χ ≠ 1) :
+    gaussSum χ ZMod.stdAddChar ≠ 0 := by
+  have hp : (0 : ℝ) < Real.sqrt p := by
+    have : (0 : ℝ) < p := by exact_mod_cast (Fact.out : p.Prime).pos
+    exact Real.sqrt_pos.mpr this
+  intro h
+  rw [← norm_gaussSum_eq_sqrt p χ hχ, h, norm_zero] at hp
+  exact lt_irrefl 0 hp
+
+end
+
+end BoundedPrimeGapsOQ04OQ03

--- a/research/problems/bounded-prime-gaps-oq-04-oq-03/knowledge.md
+++ b/research/problems/bounded-prime-gaps-oq-04-oq-03/knowledge.md
@@ -1,0 +1,64 @@
+# bounded-prime-gaps-oq-04-oq-03 — Knowledge
+
+## Problem
+
+Sub-question of `bounded-prime-gaps-oq-04` (Bombieri–Vinogradov formalizability).
+The sibling catalog `BoundedPrimeGapsOQ04OQ02` records **Addition 1** — `gaussSumBound`,
+the Gauss-sum bound `|τ(χ)| = √q` for a nontrivial Dirichlet character — as an *axiom*,
+and asks in its own open-questions list:
+
+> "Can gaussSumBound be proved using only Mathlib's existing ZMod.gaussSum
+> infrastructure, or does it require new character sum API?"
+
+This session answers that question.
+
+## Result (SHIPPED, VERIFIED, 0-axiom)
+
+`proofs/Proofs/BoundedPrimeGapsOQ04OQ03.lean` (135 lines, 6 theorems, 0 defs, 0 axioms, 0 sorries).
+
+**Main theorem** `norm_gaussSum_eq_sqrt`: for a prime `p` and `χ : DirichletCharacter ℂ p`
+with `χ ≠ 1`,
+```
+‖gaussSum χ ZMod.stdAddChar‖ = Real.sqrt p
+```
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no
+`Lean.ofReduceBool`).
+
+Supporting: `conj_stdAddChar`, `conj_gaussSum`, `gaussSum_mul_conj` (τ·τ̄ = p),
+`normSq_gaussSum`, and corollary `gaussSum_ne_zero`.
+
+## Proof architecture
+
+1. `conj_stdAddChar` — `stdAddChar a = ↑(toCircle a)` is unit-circle valued, so
+   `conj(stdAddChar a) = (stdAddChar a)⁻¹ = stdAddChar(-a) = stdAddChar⁻¹ a`
+   (`Circle.coe_inv_eq_conj`, `AddChar.map_neg_eq_inv`, `Circle.coe_inv`). Modulus-agnostic.
+2. `conj_gaussSum` — termwise via `map_sum`, `map_mul`, `MulChar.star_apply'`
+   (`conj(χ a) = χ⁻¹ a`) and (1). Modulus-agnostic.
+3. `gaussSum_mul_conj` — `gaussSum_mul_gaussSum_eq_card hχ (isPrimitive_stdAddChar p)`
+   gives `τ(χ)·gaussSum χ⁻¹ ψ⁻¹ = #(ZMod p)`; rewrite by (2) and `ZMod.card`.
+4. `normSq_gaussSum` — `Complex.normSq_eq_conj_mul_self` + cast; then
+   `norm_gaussSum_eq_sqrt` via `Complex.norm_def` (`‖z‖ = √(normSq z)`).
+
+## The gap for composite modulus (KEY finding)
+
+The **only** obstruction to the general primitive-character bound is the `[Field R]`
+hypothesis of `gaussSum_mul_gaussSum_eq_card`. `ZMod q` is a field **iff q is prime**.
+Steps 1–2 (conjugation) hold for all moduli; step 3 is where primality is forced.
+So the composite case is *not* blocked by a missing conjugation/orthogonality lemma —
+it needs the **theory of primitive Dirichlet characters** and the reduction of an
+imprimitive Gauss sum to its primitive inductor, which Mathlib v4.26.0 lacks.
+
+## Follow-ups
+
+- Extend to composite modulus via primitive-inductor reduction (needs new Mathlib API).
+- Bridge Mathlib's `gaussSum`/`stdAddChar` form to the OQ04-OQ02 axiom's literal
+  `∑_{t∈range q} χ(t)·exp(2πit/q)` form (reindex via `toCircle_natCast`).
+- Feed `gaussSum_ne_zero` / the √p bound into a prime-modulus Pólya–Vinogradov (Addition 2).
+
+## Build notes
+
+- Docker build broken (containerd `meta.db` I/O error) → compiled with
+  `LAKE_UNSAFE=1 lake env lean` against prebuilt Mathlib; olean via `-o
+  .lake/build/lib/lean/Proofs/…olean`, then `#print axioms` in a scratch importer.
+- Main repo checkout was on another agent's branch → committed from durable
+  `$HOME/lean-genius-r1-oq0403` worktree cut from `origin/main`.

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-bpg-oq0403-question",
+    "proofId": "bounded-prime-gaps-oq-04-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 68
+    },
+    "type": "concept",
+    "significance": "key",
+    "content": "The module header frames a precise question inherited from the sibling catalog BoundedPrimeGapsOQ04OQ02, which records gaussSumBound (|τ(χ)| = √q) as Addition 1 of the six Mathlib additions needed for Bombieri–Vinogradov, states it as an axiom, and asks in its own open-questions list whether it is provable from Mathlib's existing ZMod.gaussSum infrastructure. This file answers: for prime modulus, yes, with no axioms; for composite modulus, the obstruction is isolated to a single field hypothesis. The header is honest about scope — it neither overclaims the general primitive-character bound nor treats the prime case as trivial.",
+    "mathContext": "The Gauss sum is $\\tau(\\chi) = \\sum_{a \\in \\mathbb{Z}/q} \\chi(a)\\, e(a/q)$ with $e(t) = e^{2\\pi i t}$. Classically $|\\tau(\\chi)| = \\sqrt{q}$ for primitive $\\chi$. Here $q = p$ is prime and $\\chi \\neq 1$, so $\\chi$ is automatically primitive."
+  },
+  {
+    "id": "ann-bpg-oq0403-field-crux",
+    "proofId": "bounded-prime-gaps-oq-04-oq-03",
+    "range": {
+      "startLine": 96,
+      "endLine": 110
+    },
+    "type": "insight",
+    "significance": "key",
+    "content": "gaussSum_mul_conj is where the prime hypothesis is actually used. Mathlib's gaussSum_mul_gaussSum_eq_card requires the character domain R to be a [Field] — and ZMod q is a field exactly when q is prime. This single typeclass requirement is the entire reason the general composite-modulus bound is not obtainable from Mathlib as-is. The rest of the argument (conjugation, norm extraction) is modulus-agnostic. So the annotation pins the gap precisely: it is not a missing conjugation lemma or a missing orthogonality fact, but the absence of the primitive-Dirichlet-character reduction that would replace the field hypothesis for composite q.",
+    "mathContext": "gaussSum_mul_gaussSum_eq_card: for $\\chi \\neq 1$ and $\\psi$ primitive over a field $R$, $\\mathrm{gaussSum}\\,\\chi\\,\\psi \\cdot \\mathrm{gaussSum}\\,\\chi^{-1}\\,\\psi^{-1} = \\#R$. Over $\\mathbb{Z}/p$ (a field) with $\\psi = $ stdAddChar (primitive), this gives $\\tau(\\chi)\\overline{\\tau(\\chi)} = p$."
+  },
+  {
+    "id": "ann-bpg-oq0403-conjugation",
+    "proofId": "bounded-prime-gaps-oq-04-oq-03",
+    "range": {
+      "startLine": 69,
+      "endLine": 95
+    },
+    "type": "technique",
+    "significance": "standard",
+    "content": "The conjugation identity conj(gaussSum χ ψ) = gaussSum χ⁻¹ ψ⁻¹ is assembled from two unitarity facts already in Mathlib: MulChar.star_apply' (conj(χ a) = χ⁻¹ a, because Dirichlet character values are roots of unity or 0) and conj_stdAddChar (conj of the standard additive character equals its inverse, because stdAddChar a = ↑(toCircle a) lies on the unit circle, via Circle.coe_inv_eq_conj and AddChar.map_neg_eq_inv). Crucially this step holds for every modulus, not just primes — it is deliberately proved in that generality so that only gaussSum_mul_conj carries the prime restriction.",
+    "mathContext": "$\\overline{\\chi(a)} = \\chi^{-1}(a)$ and $\\overline{\\psi(a)} = \\psi(-a) = \\psi^{-1}(a)$; summing termwise, $\\overline{\\tau(\\chi)} = \\sum_a \\chi^{-1}(a)\\psi^{-1}(a) = \\mathrm{gaussSum}\\,\\chi^{-1}\\,\\psi^{-1}$."
+  },
+  {
+    "id": "ann-bpg-oq0403-verified-status",
+    "proofId": "bounded-prime-gaps-oq-04-oq-03",
+    "range": {
+      "startLine": 111,
+      "endLine": 135
+    },
+    "type": "insight",
+    "significance": "notable",
+    "content": "Unlike the sibling catalog OQ04-OQ02 (which is axiomatized, badge 'axiom', 7 axioms including native_decide's Lean.ofReduceBool), this file is fully verified: #print axioms reports only propext, Classical.choice, Quot.sound for every credited theorem — no sorryAx, no Lean.ofReduceBool. The final norm extraction is a two-line calc: normSq τ(χ) = p (cast from the complex product) then |τ(χ)| = √(normSq τ(χ)) = √p via Complex.norm_def. gaussSum_ne_zero falls out as a corollary since √p > 0. This is a genuine axiom-to-theorem conversion of the prime part of gaussSumBound.",
+    "mathContext": "$z\\overline{z} = \\mathrm{normSq}(z)$ as a real number, and $\\|z\\| = \\sqrt{\\mathrm{normSq}(z)}$; with $\\mathrm{normSq}(\\tau(\\chi)) = p$ this yields $\\|\\tau(\\chi)\\| = \\sqrt{p}$."
+  }
+]

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "bounded-prime-gaps-oq-04-oq-03",
+  "title": "The Gauss Sum Bound |τ(χ)| = √p: Prime-Modulus Case from Mathlib",
+  "slug": "bounded-prime-gaps-oq-04-oq-03",
+  "description": "The BV prerequisite catalog (OQ04-OQ02) records gaussSumBound — |τ(χ)| = √q for a nontrivial Dirichlet character — as an axiom, and asks whether it can be proved from existing Mathlib. This file answers the prime-modulus case affirmatively: for a prime p and a nontrivial Dirichlet character χ mod p, ‖gaussSum χ stdAddChar‖ = √p, proved with 0 axioms from Mathlib's gaussSum_mul_gaussSum_eq_card together with a conjugation identity. It also pins the remaining gap: gaussSum_mul_gaussSum_eq_card needs ZMod q to be a field, which holds iff q is prime, so the composite primitive-character case requires primitive-inductor machinery not yet in Mathlib.",
+  "meta": {
+    "author": "researcher-1, 2026",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gauss_sum",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BoundedPrimeGapsOQ04OQ03.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "prime-gaps",
+      "analytic-number-theory",
+      "gauss-sums",
+      "dirichlet-characters",
+      "bombieri-vinogradov",
+      "mathlib",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 135,
+    "theoremCount": 6,
+    "assumptions": "None. Fully machine-checked: #print axioms reports only propext, Classical.choice, Quot.sound (the standard foundational axioms) for every credited theorem. No sorryAx, no Lean.ofReduceBool (no native_decide). The result is stated for prime modulus, where ZMod p is a field.",
+    "originalContributions": [
+      "conj_stdAddChar: conj(stdAddChar a) = stdAddChar⁻¹ a — the standard additive character is unit-circle valued, so conjugation equals inversion",
+      "conj_gaussSum: conj(gaussSum χ stdAddChar) = gaussSum χ⁻¹ stdAddChar⁻¹, termwise via MulChar.star_apply' and conj_stdAddChar",
+      "gaussSum_mul_conj: τ(χ)·conj τ(χ) = p, from gaussSum_mul_gaussSum_eq_card (valid since ZMod p is a field) rewritten by conj_gaussSum",
+      "normSq_gaussSum: normSq τ(χ) = p",
+      "norm_gaussSum_eq_sqrt: |τ(χ)| = √p — the prime-modulus case of gaussSumBound, proved axiom-free from Mathlib",
+      "gaussSum_ne_zero: τ(χ) ≠ 0 for nontrivial χ mod prime p"
+    ],
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Gauss sum τ(χ) = Σ_t χ(t)·e(t/q) of a Dirichlet character χ mod q is the fundamental object connecting multiplicative and additive characters. For a primitive character it satisfies the classical identity |τ(χ)| = √q, the cornerstone of character-sum bounds (Pólya–Vinogradov) and L-function functional equations. In the bounded-prime-gaps proof chain, the BV prerequisite survey (BoundedPrimeGapsOQ04OQ02) lists gaussSumBound as the first and most tractable of six Mathlib additions needed for the Bombieri–Vinogradov theorem, and explicitly asks whether it is already provable from Mathlib's ZMod.gaussSum infrastructure.\n\nMathlib v4.26.0 provides gaussSum for a MulChar and AddChar over a finite commutative ring, and proves gaussSum_mul_gaussSum_eq_card: for χ ≠ 1 and ψ primitive over a field, gaussSum χ ψ · gaussSum χ⁻¹ ψ⁻¹ = #R. The field hypothesis is the crux: ZMod q is a field exactly when q is prime.",
+    "problemStatement": "Is the Gauss-sum bound gaussSumBound (|τ(χ)| = √q) provable from existing Mathlib? Establish the prime-modulus case and locate the precise gap for composite modulus.",
+    "text": "For a prime p and a nontrivial Dirichlet character χ mod p, proves ‖gaussSum χ stdAddChar‖ = √p with no axioms, using Mathlib's gaussSum_mul_gaussSum_eq_card and complex conjugation. Documents that the composite-modulus primitive case needs primitive-character reduction machinery absent from Mathlib.",
+    "proofStrategy": "Let z = gaussSum χ stdAddChar. (1) conj_stdAddChar: since stdAddChar a = ↑(toCircle a) lies on the unit circle, conj(stdAddChar a) = (stdAddChar a)⁻¹ = stdAddChar(-a) = stdAddChar⁻¹ a. (2) conj_gaussSum: conjugate termwise using MulChar.star_apply' (conj(χ a) = χ⁻¹ a) to get conj z = gaussSum χ⁻¹ stdAddChar⁻¹. (3) gaussSum_mul_conj: z·conj z = gaussSum χ stdAddChar · gaussSum χ⁻¹ stdAddChar⁻¹ = #(ZMod p) = p, invoking gaussSum_mul_gaussSum_eq_card (needs ZMod p a field, i.e. p prime) with stdAddChar primitive. (4) Since z·conj z = normSq z (as a complex number equal to p), normSq z = p, hence |z| = √(normSq z) = √p via Complex.norm_def.",
+    "keyInsights": [
+      "The prime-modulus Gauss-sum bound is already fully provable from Mathlib — no new API needed — answering an open question posed in the OQ04-OQ02 catalog.",
+      "The single genuine obstruction to the general case is the [Field R] hypothesis of gaussSum_mul_gaussSum_eq_card: ZMod q is a field iff q is prime, so composite modulus falls outside Mathlib's current reach.",
+      "Conjugation conj(gaussSum χ ψ) = gaussSum χ⁻¹ ψ⁻¹ holds for any modulus because Dirichlet character values (MulChar.star_apply') and standard-additive-character values (unit circle) are unitary; it is not the source of the gap.",
+      "The composite case fails not for the conjugation reason but because the product formula itself degrades for imprimitive characters — the correct general statement is |τ(χ)| = √q only for primitive χ, requiring the primitive-inductor reduction Mathlib lacks.",
+      "This converts the prime part of gaussSumBound (Addition 1 of the BV catalog) from axiom to theorem, a concrete first step toward eliminating the bombieriVinogradov axiom."
+    ],
+    "prerequisites": [
+      "Dirichlet characters as multiplicative characters MulChar (ZMod q) ℂ",
+      "Gauss sums: gaussSum χ ψ = Σ_a χ(a)·ψ(a); the standard additive character ZMod.stdAddChar",
+      "Character orthogonality underlying gaussSum_mul_gaussSum_eq_card",
+      "Complex conjugation, unit-circle values, and normSq/norm relations"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: the question and the answer",
+      "startLine": 1,
+      "endLine": 68,
+      "summary": "Module docstring: OQ04-OQ02 records gaussSumBound as an axiom and asks if it is provable from Mathlib. States the answer — the prime-modulus case is fully provable and axiom-free — and identifies the field hypothesis of gaussSum_mul_gaussSum_eq_card (ZMod q a field ⟺ q prime) as the exact remaining gap for composite modulus.",
+      "mathContext": "For a nontrivial Dirichlet character $\\chi \\bmod p$ with $p$ prime, $|\\tau(\\chi)| = \\sqrt{p}$ where $\\tau(\\chi) = \\sum_{a} \\chi(a) e(a/p)$. The proof rests on $\\tau(\\chi)\\overline{\\tau(\\chi)} = \\#(\\mathbb{Z}/p) = p$."
+    },
+    {
+      "id": "conjugation",
+      "title": "Conjugation identities",
+      "startLine": 69,
+      "endLine": 95,
+      "summary": "conj_stdAddChar: conj(stdAddChar a) = stdAddChar⁻¹ a, since the standard additive character takes values on the unit circle (Circle.coe_inv_eq_conj, AddChar.map_neg_eq_inv). conj_gaussSum: conj(gaussSum χ stdAddChar) = gaussSum χ⁻¹ stdAddChar⁻¹, obtained termwise from map_sum, map_mul, MulChar.star_apply', and conj_stdAddChar.",
+      "mathContext": "$\\overline{e(a/N)} = e(-a/N)$ and $\\overline{\\chi(a)} = \\chi^{-1}(a)$ give $\\overline{\\tau(\\chi)} = \\sum_a \\chi^{-1}(a) e(-a/N) = \\mathrm{gaussSum}\\ \\chi^{-1}\\ \\psi^{-1}$. This holds for every modulus."
+    },
+    {
+      "id": "product-and-norm",
+      "title": "Product formula and the √p bound",
+      "startLine": 96,
+      "endLine": 135,
+      "summary": "gaussSum_mul_conj: τ(χ)·conj τ(χ) = p via gaussSum_mul_gaussSum_eq_card and ZMod.card. normSq_gaussSum: normSq τ(χ) = p (cast from the complex product). norm_gaussSum_eq_sqrt: |τ(χ)| = √p via Complex.norm_def. gaussSum_ne_zero: τ(χ) ≠ 0 since √p > 0.",
+      "mathContext": "$z\\bar z = \\mathrm{normSq}(z) = p$ so $|z| = \\sqrt{\\mathrm{normSq}(z)} = \\sqrt{p}$. The field hypothesis of gaussSum_mul_gaussSum_eq_card is met because $\\mathbb{Z}/p$ is a field for prime $p$."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Davenport, H."
+      ],
+      "title": "Multiplicative Number Theory",
+      "year": "2000",
+      "venue": "3rd ed., Graduate Texts in Mathematics 74, Springer",
+      "note": "Gauss sums of primitive characters and the identity |τ(χ)| = √q (Chapter 9)."
+    },
+    {
+      "authors": [
+        "Montgomery, H.L.",
+        "Vaughan, R.C."
+      ],
+      "title": "Multiplicative Number Theory I: Classical Theory",
+      "year": "2007",
+      "venue": "Cambridge Studies in Advanced Mathematics 97, Cambridge University Press",
+      "note": "Gauss sums, primitive characters, and the reduction of imprimitive Gauss sums to their inductors."
+    },
+    {
+      "authors": [
+        "Ireland, K.",
+        "Rosen, M."
+      ],
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "2nd ed., Graduate Texts in Mathematics 84, Springer",
+      "note": "Gauss sums over ZMod p (prime modulus) and |τ(χ)|² = p via character orthogonality."
+    }
+  ],
+  "conclusion": {
+    "summary": "For prime p, the Gauss-sum bound |τ(χ)| = √p is fully provable from Mathlib v4.26.0 with no axioms, using gaussSum_mul_gaussSum_eq_card and complex conjugation. This settles the prime-modulus case of gaussSumBound (Addition 1 of the BV prerequisite catalog) and answers OQ04-OQ02's open question about whether Mathlib's existing gaussSum infrastructure suffices.",
+    "implications": "The prime case of gaussSumBound is no longer an axiom. The only remaining obstruction to the general primitive-character bound is the field hypothesis of gaussSum_mul_gaussSum_eq_card (ZMod q is a field iff q is prime); the composite case needs the theory of primitive Dirichlet characters and imprimitive-Gauss-sum reduction, which Mathlib does not yet have. This is a concrete, verified first step toward reducing the bombieriVinogradov axiom.",
+    "openQuestions": [
+      "Extend to composite modulus: prove |τ(χ)| = √q for primitive χ mod q by reducing an imprimitive Gauss sum to its primitive inductor — requires primitive-character API not in Mathlib v4.26.0.",
+      "Bridge the Mathlib gaussSum formulation (sum over ZMod p, ZMod.stdAddChar) to the OQ04-OQ02 axiom's literal form (∑_{t∈range q} χ(t)·exp(2πit/q)) via toCircle_natCast reindexing.",
+      "Use gaussSum_ne_zero / norm_gaussSum_eq_sqrt as an input toward the prime-modulus Pólya–Vinogradov bound (Addition 2)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Complex"
+    ],
+    "namespace": "BoundedPrimeGapsOQ04OQ03",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BoundedPrimeGapsOQ04OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "bounded-prime-gaps-oq-04-oq-02",
+      "relationship": "parent",
+      "description": "OQ04-OQ02 catalogs gaussSumBound as Addition 1 (an axiom) and asks whether Mathlib's ZMod.gaussSum suffices; this file answers the prime-modulus case affirmatively and axiom-free."
+    },
+    {
+      "targetId": "bounded-prime-gaps-oq-04",
+      "relationship": "ancestor",
+      "description": "OQ04: formalizability assessment of Bombieri-Vinogradov; gaussSumBound is a Layer-1 prerequisite for the bombieriVinogradov axiom."
+    },
+    {
+      "targetId": "bounded-prime-gaps-oq-04-oq-01",
+      "relationship": "sibling",
+      "description": "OQ04-OQ01: Pólya-Vinogradov inequality (Addition 2), the immediate downstream consumer of the Gauss-sum bound."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/bounded-prime-gaps-oq-04-oq-03.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-04-oq-03.json
@@ -1,0 +1,97 @@
+{
+  "slug": "bounded-prime-gaps-oq-04-oq-03",
+  "title": "Is the Gauss sum bound |τ(χ)| = √q provable from Mathlib?",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For a nontrivial Dirichlet character χ mod q, is gaussSumBound (|τ(χ)| = √q) provable from existing Mathlib, where τ(χ) = Σ_a χ(a)·e(a/q)?",
+    "plain": "gaussSumBound is Addition 1 of the six Mathlib additions needed for Bombieri-Vinogradov (catalogued as an axiom in OQ04-OQ02). Determine how much of it Mathlib already proves.",
+    "whyMatters": [
+      "gaussSumBound is the foundational character-sum estimate underlying Polya-Vinogradov and L-function functional equations",
+      "It is the most tractable of the six BV prerequisite additions (tractability 5/5 in the OQ04-OQ02 catalog)",
+      "Converting it from axiom to theorem is a concrete first step toward eliminating the bombieriVinogradov axiom"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "norm_gaussSum_eq_sqrt: |gaussSum χ stdAddChar| = √p for prime p and χ ≠ 1 — VERIFIED, 0 axioms",
+      "gaussSum_mul_conj: τ(χ)·conj τ(χ) = p (from gaussSum_mul_gaussSum_eq_card, ZMod p a field)",
+      "conj_gaussSum: conj(gaussSum χ ψ) = gaussSum χ⁻¹ ψ⁻¹ (all moduli)",
+      "conj_stdAddChar: conj(stdAddChar a) = stdAddChar⁻¹ a (all moduli)",
+      "normSq_gaussSum, gaussSum_ne_zero"
+    ],
+    "open": [
+      "Composite-modulus primitive-character bound |τ(χ)| = √q requires primitive-inductor reduction not in Mathlib v4.26.0 (gaussSum_mul_gaussSum_eq_card needs [Field R], i.e. q prime)",
+      "Bridge from Mathlib gaussSum/stdAddChar form to the OQ04-OQ02 axiom's literal ∑_{t∈range q} form"
+    ],
+    "goal": "Prove as much of gaussSumBound as current Mathlib allows; pin the residual gap."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-01",
+    "iteration": 1,
+    "focus": "Prime-modulus Gauss-sum bound proved axiom-free; composite gap localized to the [Field R] hypothesis of gaussSum_mul_gaussSum_eq_card.",
+    "blockers": [],
+    "nextAction": "Composite case needs new Mathlib primitive-character API; separate follow-up."
+  },
+  "knowledge": {
+    "progressSummary": "SHIPPED (VERIFIED, 0-axiom, 6 thm / 135 lines). Proved norm_gaussSum_eq_sqrt: for prime p and nontrivial χ mod p, ‖gaussSum χ stdAddChar‖ = √p, answering OQ04-OQ02's open question (Mathlib's gaussSum_mul_gaussSum_eq_card + conjugation suffice for the prime case). The composite primitive case is blocked only by the [Field R] hypothesis (ZMod q a field ⟺ q prime), which needs primitive-inductor machinery absent from Mathlib.",
+    "builtItems": [
+      "BoundedPrimeGapsOQ04OQ03.lean: conj_stdAddChar, conj_gaussSum (modulus-agnostic conjugation)",
+      "BoundedPrimeGapsOQ04OQ03.lean: gaussSum_mul_conj (τ·τ̄ = p, prime modulus)",
+      "BoundedPrimeGapsOQ04OQ03.lean: normSq_gaussSum, norm_gaussSum_eq_sqrt (the √p bound), gaussSum_ne_zero"
+    ],
+    "insights": [
+      "The prime-modulus Gauss-sum bound is already fully provable from Mathlib — no new API needed.",
+      "The sole obstruction to the general case is the [Field R] hypothesis of gaussSum_mul_gaussSum_eq_card; ZMod q is a field iff q is prime.",
+      "Conjugation conj(gaussSum χ ψ) = gaussSum χ⁻¹ ψ⁻¹ holds for every modulus — it is not the source of the gap.",
+      "The correct general statement |τ(χ)| = √q holds only for primitive χ; the composite case needs the imprimitive-to-primitive reduction Mathlib lacks."
+    ]
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/BoundedPrimeGapsOQ04OQ03.lean",
+      "filename": "BoundedPrimeGapsOQ04OQ03.lean",
+      "lineCount": 135,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false
+    }
+  ],
+  "relatedProofs": [
+    "bounded-prime-gaps-oq-04-oq-02",
+    "bounded-prime-gaps-oq-04",
+    "bounded-prime-gaps-oq-04-oq-01"
+  ],
+  "references": [
+    {
+      "authors": ["Davenport, H."],
+      "title": "Multiplicative Number Theory",
+      "year": "2000",
+      "venue": "3rd ed., GTM 74, Springer"
+    },
+    {
+      "authors": ["Ireland, K.", "Rosen, M."],
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "2nd ed., GTM 84, Springer"
+    }
+  ],
+  "significance": "Converts the prime-modulus part of gaussSumBound (Addition 1 of the BV prerequisite catalog) from axiom to verified theorem, and localizes the residual composite-modulus gap to a single field hypothesis.",
+  "tags": [
+    "number-theory",
+    "analytic-number-theory",
+    "gauss-sums",
+    "dirichlet-characters",
+    "bombieri-vinogradov",
+    "prime-gaps",
+    "mathlib"
+  ],
+  "tractability": "high",
+  "started": "2026-07-01",
+  "lastUpdate": "2026-07-01"
+}


### PR DESCRIPTION
## Summary

Answers the open question posed in the BV prerequisite catalog `BoundedPrimeGapsOQ04OQ02`:

> *"Can gaussSumBound be proved using only Mathlib's existing ZMod.gaussSum infrastructure, or does it require new character sum API?"*

**Answer (prime modulus): yes, axiom-free.** For a prime `p` and a nontrivial Dirichlet character `χ` mod `p`:

```
norm_gaussSum_eq_sqrt : ‖gaussSum χ ZMod.stdAddChar‖ = Real.sqrt p
```

`#print axioms` on every credited theorem reports only `propext, Classical.choice, Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`** (no `native_decide`). Fully verified.

## Proof

- `gaussSum_mul_conj`: `τ(χ)·conj τ(χ) = p` via Mathlib's `gaussSum_mul_gaussSum_eq_card` (valid because `ZMod p` is a field) with `stdAddChar` primitive.
- `conj_gaussSum` / `conj_stdAddChar`: `conj(gaussSum χ ψ) = gaussSum χ⁻¹ ψ⁻¹`, from `MulChar.star_apply'` and the unit-circle values of the standard additive character. **Modulus-agnostic.**
- Norm extraction: `normSq τ(χ) = p` ⟹ `‖τ(χ)‖ = √(normSq τ(χ)) = √p` via `Complex.norm_def`.
- Corollary `gaussSum_ne_zero`.

6 theorems, 135 lines, 0 axioms, 0 sorries.

## Key finding — where the gap really is

The **only** obstruction to the general composite-modulus primitive-character bound is the `[Field R]` hypothesis of `gaussSum_mul_gaussSum_eq_card`: `ZMod q` is a field **iff q is prime**. The conjugation steps hold for all moduli. The composite case needs the theory of primitive Dirichlet characters and imprimitive-Gauss-sum reduction, which Mathlib v4.26.0 lacks. This converts the **prime part of `gaussSumBound`** (Addition 1 of the BV prerequisite catalog) from axiom to theorem — a concrete step toward eliminating the `bombieriVinogradov` axiom.

## Files
- `proofs/Proofs/BoundedPrimeGapsOQ04OQ03.lean` — the proof (verified, 0-axiom)
- `src/data/proofs/bounded-prime-gaps-oq-04-oq-03/{meta,annotations}.json` — gallery entry
- `src/data/research/problems/bounded-prime-gaps-oq-04-oq-03.json`, `research/problems/.../knowledge.md`

## Verification
Built with `lake env lean` against Mathlib v4.26.0 (Docker unavailable — containerd I/O error). Compiles clean; axioms confirmed via `#print axioms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)