### PR TITLE
research(de-moivre-oq-01-oq-01): binomial expansion of cos(nθ) and its Chebyshev connection [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DeMoivreOQ01OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ01OQ01.lean
@@ -1,0 +1,156 @@
+import Mathlib
+
+/-
+# De Moivre OQ-01-OQ-01: The Binomial Expansion of cos(nθ) and its Chebyshev Connection
+
+## Open Question
+
+The parent entry (De Moivre OQ-01) establishes the *existence* result
+`cos(nθ) = T_n(cos θ)` by quoting Mathlib's `Chebyshev.T_real_cos`.  This entry
+supplies the missing *constructive* content: the **explicit binomial expansion**
+of `cos(nθ)`, obtained by expanding `(cos θ + i sin θ)^n` with the binomial
+theorem and taking the real part, and then proves that this explicit sum equals
+the Chebyshev polynomial `T_n(cos θ)`.
+
+## Mathematical Content
+
+De Moivre's theorem gives `(cos θ + i sin θ)^n = cos(nθ) + i sin(nθ)`.
+Expanding the left side by the binomial theorem,
+
+  `(cos θ + i sin θ)^n = Σ_{k=0}^n C(n,k) cos^k θ · (i sin θ)^{n-k}`,
+
+and comparing real parts yields
+
+  `cos(nθ) = Σ_{k=0}^n C(n,k) cos^k θ · sin^{n-k} θ · Re(i^{n-k})`.
+
+Since `Re(i^m) = 0` for odd `m` and `Re(i^{2j}) = (-1)^j`, only even powers of
+`sin` survive, recovering the classical closed form
+
+  `cos(nθ) = Σ_{j=0}^{⌊n/2⌋} (-1)^j C(n,2j) cos^{n-2j} θ · sin^{2j} θ`.
+
+## What is proved here (0 axioms, Mathlib-backed)
+
+* `cos_nsmul_eq_re_pow` — `cos(nθ) = Re((cos θ + i sin θ)^n)` (real-part extraction).
+* `cos_nsmul_binomial_re` — the full binomial expansion with the `Re(i^{n-k})` factor.
+* `cos_nsmul_binomial_even` — the classical `(-1)^j`, even-index closed form.
+* `binomial_eq_chebyshev_T` — the explicit sum equals `T_n(cos θ)`.
+-/
+
+open Polynomial Polynomial.Chebyshev Real Finset
+
+namespace DeMoivreOQ01OQ01
+
+-- ============================================================
+-- PART 1: Real-part extraction from De Moivre
+-- ============================================================
+
+/-- The De Moivre base point `cos θ + i sin θ` equals `exp(iθ)`. -/
+lemma cos_add_sin_I_eq_exp (θ : ℝ) :
+    (Real.cos θ : ℂ) + (Real.sin θ : ℂ) * Complex.I = Complex.exp (↑θ * Complex.I) := by
+  rw [Complex.exp_mul_I, Complex.ofReal_cos, Complex.ofReal_sin]
+
+/-- **Real-part extraction**: `cos(nθ)` is the real part of `(cos θ + i sin θ)^n`.
+This is the precise meaning of "comparing real parts in De Moivre's theorem". -/
+lemma cos_nsmul_eq_re_pow (θ : ℝ) (n : ℕ) :
+    Real.cos ((n : ℝ) * θ) = (((Real.cos θ : ℂ) + (Real.sin θ : ℂ) * Complex.I) ^ n).re := by
+  rw [cos_add_sin_I_eq_exp, ← Complex.exp_nat_mul]
+  rw [show (↑n * (↑θ * Complex.I) : ℂ) = ↑((n : ℝ) * θ) * Complex.I by push_cast; ring]
+  rw [Complex.exp_ofReal_mul_I_re]
+
+-- ============================================================
+-- PART 2: The binomial expansion of cos(nθ)
+-- ============================================================
+
+/-- **Binomial expansion of cos(nθ)** (real-part form).  Expanding
+`(cos θ + i sin θ)^n` by the binomial theorem and taking the real part gives an
+explicit polynomial in `cos θ` and `sin θ`.  The factor `Re(i^{n-k})` records the
+sign pattern coming from the powers of `i`. -/
+theorem cos_nsmul_binomial_re (θ : ℝ) (n : ℕ) :
+    Real.cos ((n : ℝ) * θ) =
+      ∑ k ∈ Finset.range (n + 1),
+        (n.choose k : ℝ) * Real.cos θ ^ k * Real.sin θ ^ (n - k) *
+          (Complex.I ^ (n - k)).re := by
+  rw [cos_nsmul_eq_re_pow, add_pow, Complex.re_sum]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  have hcast :
+      (Real.cos θ : ℂ) ^ k * ((Real.sin θ : ℂ) * Complex.I) ^ (n - k) * (n.choose k : ℂ)
+        = ((Real.cos θ ^ k * Real.sin θ ^ (n - k) * (n.choose k : ℝ) : ℝ) : ℂ) *
+            Complex.I ^ (n - k) := by
+    rw [mul_pow]; push_cast; ring
+  rw [hcast, Complex.re_ofReal_mul]; ring
+
+-- ============================================================
+-- PART 3: Parity of Re(iᵐ) and the even-index closed form
+-- ============================================================
+
+/-- `Re(i^m) = 0` when `m` is odd. -/
+lemma re_I_pow_odd {m : ℕ} (hm : ¬ Even m) : (Complex.I ^ m).re = 0 := by
+  obtain ⟨j, rfl⟩ : Odd m := Nat.not_even_iff_odd.mp hm
+  have h : Complex.I ^ (2 * j + 1) = (((-1 : ℝ) ^ j : ℝ) : ℂ) * Complex.I := by
+    rw [pow_add, pow_mul, Complex.I_sq, pow_one]; push_cast; ring
+  rw [h, Complex.mul_I_re, Complex.ofReal_im, neg_zero]
+
+/-- `Re(i^{2j}) = (-1)^j`. -/
+lemma re_I_pow_two_mul (j : ℕ) : (Complex.I ^ (2 * j)).re = (-1 : ℝ) ^ j := by
+  have h : Complex.I ^ (2 * j) = (((-1 : ℝ) ^ j : ℝ) : ℂ) := by
+    rw [pow_mul, Complex.I_sq]; push_cast; ring
+  rw [h, Complex.ofReal_re]
+
+/-- **Classical closed form of cos(nθ)**: only even powers of `sin θ` survive,
+with alternating signs.  This is the standard multiple-angle formula
+`cos(nθ) = Σ_j (-1)^j C(n,2j) cos^{n-2j} θ · sin^{2j} θ`. -/
+theorem cos_nsmul_binomial_even (θ : ℝ) (n : ℕ) :
+    Real.cos ((n : ℝ) * θ) =
+      ∑ j ∈ Finset.range (n / 2 + 1),
+        (-1 : ℝ) ^ j * (n.choose (2 * j) : ℝ) *
+          Real.cos θ ^ (n - 2 * j) * Real.sin θ ^ (2 * j) := by
+  -- Reflect the index k ↦ n - k so the surviving power is that of `sin`.
+  have key : Real.cos ((n : ℝ) * θ)
+      = ∑ i ∈ Finset.range (n + 1),
+          (n.choose i : ℝ) * Real.cos θ ^ (n - i) * Real.sin θ ^ i * (Complex.I ^ i).re := by
+    rw [cos_nsmul_binomial_re, ← Finset.sum_range_reflect
+          (fun k => (n.choose k : ℝ) * Real.cos θ ^ k * Real.sin θ ^ (n - k) *
+            (Complex.I ^ (n - k)).re) (n + 1)]
+    refine Finset.sum_congr rfl (fun i hi => ?_)
+    rw [Finset.mem_range] at hi
+    have hle : i ≤ n := by omega
+    have h1 : n + 1 - 1 - i = n - i := by omega
+    have h2 : n - (n - i) = i := by omega
+    rw [h1, h2, Nat.choose_symm hle]
+  -- The even indices `i = 2j` are exactly the image of `range (n/2+1)` under doubling.
+  have hsub : (Finset.range (n / 2 + 1)).image (fun j => 2 * j) ⊆ Finset.range (n + 1) := by
+    intro i hi
+    simp only [Finset.mem_image, Finset.mem_range] at hi ⊢
+    obtain ⟨j, hj, rfl⟩ := hi
+    omega
+  -- Odd-index terms vanish because `Re(i^i) = 0`.
+  have hzero : ∀ i ∈ Finset.range (n + 1),
+      i ∉ (Finset.range (n / 2 + 1)).image (fun j => 2 * j) →
+      (n.choose i : ℝ) * Real.cos θ ^ (n - i) * Real.sin θ ^ i * (Complex.I ^ i).re = 0 := by
+    intro i hi hni
+    rw [Finset.mem_range] at hi
+    have hodd : ¬ Even i := by
+      rintro ⟨k, rfl⟩
+      exact hni (by
+        rw [Finset.mem_image]
+        exact ⟨k, Finset.mem_range.mpr (by omega), by omega⟩)
+    rw [re_I_pow_odd hodd, mul_zero]
+  rw [key, ← Finset.sum_subset hsub hzero,
+      Finset.sum_image (fun x _ y _ h => by omega)]
+  refine Finset.sum_congr rfl (fun j _ => ?_)
+  rw [re_I_pow_two_mul]; ring
+
+-- ============================================================
+-- PART 4: Connection to Chebyshev polynomials
+-- ============================================================
+
+/-- **Chebyshev connection**: the explicit binomial sum for `cos(nθ)` equals the
+`n`-th Chebyshev polynomial of the first kind evaluated at `cos θ`. -/
+theorem binomial_eq_chebyshev_T (θ : ℝ) (n : ℕ) :
+    (∑ k ∈ Finset.range (n + 1),
+        (n.choose k : ℝ) * Real.cos θ ^ k * Real.sin θ ^ (n - k) * (Complex.I ^ (n - k)).re)
+      = (Polynomial.Chebyshev.T ℝ (n : ℤ)).eval (Real.cos θ) := by
+  rw [← cos_nsmul_binomial_re, Polynomial.Chebyshev.T_real_cos]
+  congr 1
+
+end DeMoivreOQ01OQ01

--- a/src/data/proofs/de-moivre-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-dm0101-re-extraction",
+    "proofId": "de-moivre-oq-01-oq-01",
+    "range": { "startLine": 47, "endLine": 58 },
+    "type": "technique",
+    "title": "Real-part extraction: cos(nθ) = Re((cos θ + i sin θ)ⁿ)",
+    "content": "The base point is identified with the complex exponential: `cos_add_sin_I_eq_exp` rewrites $\\cos\\theta + i\\sin\\theta$ as $e^{i\\theta}$ through Mathlib's `Complex.exp_mul_I` together with `ofReal_cos`/`ofReal_sin`. Then `cos_nsmul_eq_re_pow` powers up — $(\\cos\\theta + i\\sin\\theta)^n = (e^{i\\theta})^n = e^{in\\theta}$ via `exp_nat_mul` — and reads off the real part with `exp_ofReal_mul_I_re`, giving $\\cos(n\\theta) = \\operatorname{Re}((\\cos\\theta + i\\sin\\theta)^n)$. This is the precise, machine-checked meaning of the informal phrase 'compare real parts in De Moivre's theorem'.",
+    "mathContext": "$\\cos\\theta + i\\sin\\theta = e^{i\\theta},\\quad \\cos(n\\theta) = \\operatorname{Re}\\big((\\cos\\theta + i\\sin\\theta)^n\\big).$",
+    "significance": "key",
+    "relatedConcepts": ["Euler's formula", "complex exponential", "De Moivre's theorem", "real part"],
+    "prerequisites": ["Complex.exp_mul_I", "exp_nat_mul", "ofReal casts"]
+  },
+  {
+    "id": "ann-dm0101-binomial-re",
+    "proofId": "de-moivre-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 80 },
+    "type": "concept",
+    "title": "The binomial expansion as the real part of the binomial theorem",
+    "content": "`cos_nsmul_binomial_re` applies `add_pow` to $(\\cos\\theta + i\\sin\\theta)^n = \\sum_k \\binom{n}{k}\\cos^k\\theta\\,(i\\sin\\theta)^{n-k}$, distributes the real part over the finite sum with `Complex.re_sum`, and simplifies each summand. The key per-term step factors the summand as $\\overline{r}\\cdot i^{n-k}$ with $r = \\binom{n}{k}\\cos^k\\theta\\,\\sin^{n-k}\\theta$ real, so that `re_ofReal_mul` yields $r\\cdot\\operatorname{Re}(i^{n-k})$. The result is the exact, unsimplified multiple-angle expansion with every sign and coefficient explicit.",
+    "mathContext": "$\\cos(n\\theta) = \\sum_{k=0}^{n} \\binom{n}{k}\\cos^k\\theta\\,\\sin^{n-k}\\theta\\,\\operatorname{Re}(i^{\\,n-k}).$",
+    "significance": "key",
+    "relatedConcepts": ["binomial theorem", "additivity of the real part", "multiple-angle formula"],
+    "prerequisites": ["add_pow", "Complex.re_sum", "re_ofReal_mul"]
+  },
+  {
+    "id": "ann-dm0101-parity",
+    "proofId": "de-moivre-oq-01-oq-01",
+    "range": { "startLine": 82, "endLine": 97 },
+    "type": "technique",
+    "title": "The sign engine: Re(iᵐ) is 0 or ±1 with period four",
+    "content": "Two short lemmas isolate where the alternating signs come from. `re_I_pow_odd` writes an odd power $i^{2j+1} = (-1)^j\\, i$ (using $i^2 = -1$), a purely imaginary number, so its real part is $0$. `re_I_pow_two_mul` writes an even power $i^{2j} = (-1)^j$ and reads $\\operatorname{Re}(i^{2j}) = (-1)^j$. Together they show that the $\\operatorname{Re}(i^{n-k})$ factor of the previous step vanishes on odd $n-k$ and supplies the alternating sign on even $n-k$ — the single source of both features of the closed form.",
+    "mathContext": "$\\operatorname{Re}(i^{2j+1}) = 0,\\qquad \\operatorname{Re}(i^{2j}) = (-1)^j.$",
+    "significance": "supporting",
+    "relatedConcepts": ["powers of i", "four-periodicity", "parity"],
+    "prerequisites": ["Complex.I_sq", "Complex.mul_I_re", "even/odd naturals"]
+  },
+  {
+    "id": "ann-dm0101-closed-form",
+    "proofId": "de-moivre-oq-01-oq-01",
+    "range": { "startLine": 99, "endLine": 141 },
+    "type": "technique",
+    "title": "Reflect, drop, reindex: collapsing to the ⌊n/2⌋ closed form",
+    "content": "`cos_nsmul_binomial_even` transforms the raw binomial sum into the textbook alternating form by pure finite combinatorics. First `sum_range_reflect` sends $k \\mapsto n-k$ so the surviving index counts powers of $\\sin$ (and `Nat.choose_symm` restores the binomial coefficient). Next `sum_subset` discards the odd-index terms, which are zero by `re_I_pow_odd`, restricting the sum to even indices — realized as the image of $\\{0,\\dots,\\lfloor n/2\\rfloor\\}$ under doubling. Finally `sum_image` reindexes $i = 2j$ and `re_I_pow_two_mul` replaces $\\operatorname{Re}(i^{2j})$ by $(-1)^j$, giving the classical formula.",
+    "mathContext": "$\\cos(n\\theta) = \\sum_{j=0}^{\\lfloor n/2\\rfloor} (-1)^j \\binom{n}{2j}\\cos^{\\,n-2j}\\theta\\,\\sin^{2j}\\theta.$",
+    "significance": "key",
+    "relatedConcepts": ["sum reindexing", "reflection of a range", "parity filtering", "even-index extraction"],
+    "prerequisites": ["Finset.sum_range_reflect", "Finset.sum_subset", "Finset.sum_image", "Nat.choose_symm"]
+  },
+  {
+    "id": "ann-dm0101-chebyshev",
+    "proofId": "de-moivre-oq-01-oq-01",
+    "range": { "startLine": 143, "endLine": 156 },
+    "type": "concept",
+    "title": "Closing the loop with T_n(cos θ)",
+    "content": "`binomial_eq_chebyshev_T` proves the explicit binomial sum equals $T_n(\\cos\\theta)$ by composing `cos_nsmul_binomial_re` (sum $= \\cos(n\\theta)$) with Mathlib's `T_real_cos` ($T_n(\\cos\\theta) = \\cos(n\\theta)$). Where the parent entry established the *existence* fact $\\cos(n\\theta) = T_n(\\cos\\theta)$ abstractly, this identifies the concrete binomial polynomial with the Chebyshev polynomial, directly answering the parent's leading open question.",
+    "mathContext": "$\\sum_{k=0}^{n}\\binom{n}{k}\\cos^k\\theta\\,\\sin^{n-k}\\theta\\,\\operatorname{Re}(i^{\\,n-k}) = T_n(\\cos\\theta).$",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev polynomials", "constructive vs existential", "multiple-angle formula"],
+    "prerequisites": ["Polynomial.Chebyshev.T_real_cos"]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-01/meta.json
@@ -1,0 +1,222 @@
+{
+  "id": "de-moivre-oq-01-oq-01",
+  "title": "The Binomial Expansion of cos(nθ) and its Chebyshev Connection",
+  "slug": "de-moivre-oq-01-oq-01",
+  "description": "A constructive formalization of the explicit binomial expansion of cos(nθ). Expanding (cos θ + i sin θ)^n by the binomial theorem and taking the real part gives cos(nθ) = Σ C(n,k) cos^k θ · sin^{n-k} θ · Re(i^{n-k}); since Re(i^m) vanishes for odd m and equals (-1)^{m/2} for even m, only even powers of sin survive, yielding the classical closed form cos(nθ) = Σ_{j=0}^{⌊n/2⌋} (-1)^j C(n,2j) cos^{n-2j} θ · sin^{2j} θ. The explicit sum is proved equal to the Chebyshev polynomial T_n(cos θ), answering the parent entry's leading open question.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/De_Moivre%27s_formula",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ01OQ01.lean",
+    "tags": [
+      "trigonometry",
+      "chebyshev-polynomials",
+      "de-moivre",
+      "multiple-angle",
+      "binomial-theorem",
+      "complex-numbers",
+      "real-analysis",
+      "extension",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.exp_mul_I",
+        "description": "exp(z·i) = cos z + sin z · i: identifies the De Moivre base point cos θ + i sin θ with exp(iθ)",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Complex.exp_ofReal_mul_I_re",
+        "description": "Re(exp(x·i)) = cos x for real x: extracts the cosine as the real part of the exponential",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "add_pow",
+        "description": "(x+y)^n = Σ_k x^k y^{n-k} C(n,k): the binomial theorem over a commutative ring, applied to x = cos θ, y = i sin θ",
+        "module": "Mathlib.Algebra.BigOperators.Ring"
+      },
+      {
+        "theorem": "Complex.re_sum",
+        "description": "(Σ f i).re = Σ (f i).re: the real part is additive, distributing over the binomial sum",
+        "module": "Mathlib.Data.Complex.BigOperators"
+      },
+      {
+        "theorem": "Finset.sum_range_reflect",
+        "description": "reindexes Σ_{k} f(k) = Σ_{k} f(n-k): reflects the summation so the surviving index counts powers of sin",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.sum_subset",
+        "description": "drops terms that vanish outside a subset: eliminates the odd-index terms whose Re(i^i) factor is zero",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_image",
+        "description": "reindexes a sum along an injective map: reindexes even indices i = 2j via doubling",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.T_real_cos",
+        "description": "T_n(cos θ) = cos(nθ): the Chebyshev polynomial of the first kind encodes the cosine multiple-angle formula",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev"
+      }
+    ],
+    "originalContributions": [
+      "Real-part extraction cos(nθ) = Re((cos θ + i sin θ)^n) proved via the identification cos θ + i sin θ = exp(iθ) and Re(exp(inθ)) = cos(nθ)",
+      "The full binomial expansion cos(nθ) = Σ_{k=0}^n C(n,k) cos^k θ · sin^{n-k} θ · Re(i^{n-k}), obtained by taking real parts of the binomial theorem applied to (cos θ + i sin θ)^n",
+      "The parity lemmas Re(i^m) = 0 for odd m and Re(i^{2j}) = (-1)^j, isolating exactly which terms of the binomial sum survive",
+      "The classical alternating closed form cos(nθ) = Σ_{j=0}^{⌊n/2⌋} (-1)^j C(n,2j) cos^{n-2j} θ · sin^{2j} θ, derived by reflecting the index, dropping the odd terms, and reindexing the even ones i = 2j",
+      "The Chebyshev connection: the explicit binomial sum is proved equal to T_n(cos θ), directly answering the parent entry's leading open question"
+    ],
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 156,
+    "assumptions": "0 axioms, 0 sorries. #print axioms confirms all main theorems depend only on the foundational propext / Classical.choice / Quot.sound. Real-part extraction uses Mathlib's Complex.exp_mul_I and exp_ofReal_mul_I_re; the closed form is derived by elementary Finset reindexing (sum_range_reflect, sum_subset, sum_image); the Chebyshev identity uses T_real_cos.",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**From De Moivre to the Binomial Expansion**\n\nDe Moivre's theorem states $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$. The parent entry (De Moivre OQ-01) established the *existence* result $\\cos(n\\theta) = T_n(\\cos\\theta)$ by quoting Mathlib's Chebyshev library, and listed as its leading open question: *can the binomial expansion formula for $\\cos(n\\theta)$ — with alternating sums of binomial coefficients — be formally derived and connected to $T_n$?* This entry answers that question.\n\n**The Explicit Formula**\n\nExpanding the left side of De Moivre by the binomial theorem and comparing real parts gives the constructive expansion\n$$\\cos(n\\theta) = \\sum_{k=0}^{n} \\binom{n}{k} \\cos^k\\theta \\, \\sin^{n-k}\\theta \\, \\operatorname{Re}(i^{n-k}).$$\nThe factor $\\operatorname{Re}(i^{n-k})$ is $0$ when $n-k$ is odd and $(-1)^{(n-k)/2}$ when $n-k$ is even, so only even powers of $\\sin$ survive. Reindexing the surviving terms recovers the classical closed form\n$$\\cos(n\\theta) = \\sum_{j=0}^{\\lfloor n/2\\rfloor} (-1)^j \\binom{n}{2j} \\cos^{n-2j}\\theta \\, \\sin^{2j}\\theta.$$",
+    "problemStatement": "**The Open Question (from De Moivre OQ-01)**\n\nCan the binomial expansion formula for $\\cos(n\\theta)$ — with its alternating sums of binomial coefficients — be formally derived from De Moivre's theorem and connected to the Chebyshev polynomial $T_n$?\n\n**Answer: YES.** Taking the real part of the binomial theorem applied to $(\\cos\\theta + i\\sin\\theta)^n$ yields an explicit polynomial in $\\cos\\theta$ and $\\sin\\theta$; the sign pattern of the powers of $i$ collapses this to the alternating even-index closed form; and the resulting sum is machine-checked to equal $T_n(\\cos\\theta)$.",
+    "text": "A constructive formalization of the explicit binomial expansion of cos(nθ), derived by taking the real part of the binomial theorem applied to (cos θ + i sin θ)^n, collapsed to the classical alternating even-index closed form, and proved equal to the Chebyshev polynomial T_n(cos θ).",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Real-part extraction** (`cos_add_sin_I_eq_exp`, `cos_nsmul_eq_re_pow`): identify $\\cos\\theta + i\\sin\\theta = e^{i\\theta}$ via `Complex.exp_mul_I`, so $(\\cos\\theta + i\\sin\\theta)^n = e^{in\\theta}$ by `exp_nat_mul`, and $\\operatorname{Re}(e^{in\\theta}) = \\cos(n\\theta)$ by `exp_ofReal_mul_I_re`.\n\n2. **Binomial expansion** (`cos_nsmul_binomial_re`): apply `add_pow` to $(\\cos\\theta + i\\sin\\theta)^n$, distribute the real part over the sum with `Complex.re_sum`, and simplify each term using $\\operatorname{Re}(\\bar r \\cdot i^{m}) = r \\cdot \\operatorname{Re}(i^m)$ for real $r$ (`re_ofReal_mul`).\n\n3. **Parity of $\\operatorname{Re}(i^m)$** (`re_I_pow_odd`, `re_I_pow_two_mul`): using $i^2 = -1$, show $\\operatorname{Re}(i^{2j+1}) = 0$ (a purely imaginary number) and $\\operatorname{Re}(i^{2j}) = (-1)^j$.\n\n4. **Even-index closed form** (`cos_nsmul_binomial_even`): reflect the index with `sum_range_reflect`, drop the odd-index terms with `sum_subset` (their $\\operatorname{Re}(i^i)$ factor vanishes), and reindex the even indices $i = 2j$ with `sum_image`, replacing $\\operatorname{Re}(i^{2j})$ by $(-1)^j$.\n\n5. **Chebyshev connection** (`binomial_eq_chebyshev_T`): compose the binomial expansion with Mathlib's `T_real_cos` to conclude the explicit sum equals $T_n(\\cos\\theta)$.",
+    "keyInsights": [
+      "**Real part of the binomial theorem**: the entire multiple-angle expansion is nothing more than $\\operatorname{Re}$ applied term-by-term to $(\\cos\\theta + i\\sin\\theta)^n = \\sum_k \\binom{n}{k}\\cos^k\\theta\\,(i\\sin\\theta)^{n-k}$.",
+      "**The sign pattern is $\\operatorname{Re}(i^m)$**: the alternating $(-1)^j$ and the vanishing of odd-power-of-sin terms both come from a single source — the four-periodic real part of the powers of $i$.",
+      "**Reflect, drop, reindex**: converting the raw binomial sum to the textbook $\\lfloor n/2\\rfloor$ closed form is pure finite combinatorics — `sum_range_reflect` to orient the index, `sum_subset` to discard vanishing terms, `sum_image` to reindex $i = 2j$.",
+      "**Constructive vs. existential**: the parent entry proved $\\cos(n\\theta)$ *is* $T_n(\\cos\\theta)$ abstractly; here the polynomial is written out explicitly and then shown to agree with $T_n$, closing the loop between the binomial and Chebyshev descriptions."
+    ],
+    "prerequisites": [
+      "De Moivre's theorem and Euler's formula e^{iθ} = cos θ + i sin θ",
+      "The binomial theorem over a commutative ring",
+      "The complex unit i and the four-periodicity of its powers",
+      "Chebyshev polynomials of the first kind (T_n) and the identity T_n(cos θ) = cos(nθ)",
+      "Finite-sum reindexing (reflection, subset restriction, image reindexing)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports",
+      "summary": "Imports Mathlib, providing the complex exponential/trigonometric bridge (Complex.exp_mul_I, exp_ofReal_mul_I_re), the binomial theorem (add_pow), complex big-operator lemmas (Complex.re_sum), Finset reindexing, and the Chebyshev polynomial library (T_real_cos).",
+      "startLine": 1,
+      "endLine": 41,
+      "mathContext": "Imports Mathlib for the complex exponential, the binomial theorem, Finset reindexing, and Chebyshev polynomials $T_n$ satisfying $\\cos(n\\theta) = T_n(\\cos\\theta)$."
+    },
+    {
+      "id": "real-part-extraction",
+      "title": "Real-Part Extraction from De Moivre",
+      "summary": "Proves cos_add_sin_I_eq_exp (cos θ + i sin θ = exp(iθ)) and cos_nsmul_eq_re_pow (cos(nθ) = Re((cos θ + i sin θ)^n)), giving the precise meaning of 'comparing real parts in De Moivre's theorem'.",
+      "startLine": 43,
+      "endLine": 58,
+      "mathContext": "Identifies $\\cos\\theta + i\\sin\\theta = e^{i\\theta}$, hence $(\\cos\\theta + i\\sin\\theta)^n = e^{in\\theta}$ and $\\cos(n\\theta) = \\operatorname{Re}((\\cos\\theta + i\\sin\\theta)^n)$."
+    },
+    {
+      "id": "binomial-expansion",
+      "title": "The Binomial Expansion of cos(nθ)",
+      "summary": "Proves cos_nsmul_binomial_re: cos(nθ) = Σ_{k=0}^n C(n,k) cos^k θ · sin^{n-k} θ · Re(i^{n-k}), by applying the binomial theorem to (cos θ + i sin θ)^n and distributing the real part over the sum.",
+      "startLine": 60,
+      "endLine": 80,
+      "mathContext": "The full binomial expansion $\\cos(n\\theta) = \\sum_{k=0}^n \\binom{n}{k}\\cos^k\\theta\\,\\sin^{n-k}\\theta\\,\\operatorname{Re}(i^{n-k})$, the real part of the binomial theorem."
+    },
+    {
+      "id": "parity-and-closed-form",
+      "title": "Parity of Re(iᵐ) and the Even-Index Closed Form",
+      "summary": "Proves re_I_pow_odd (Re(i^m) = 0 for odd m) and re_I_pow_two_mul (Re(i^{2j}) = (-1)^j), then cos_nsmul_binomial_even: cos(nθ) = Σ_{j=0}^{⌊n/2⌋} (-1)^j C(n,2j) cos^{n-2j} θ · sin^{2j} θ, via reflect/drop/reindex.",
+      "startLine": 82,
+      "endLine": 141,
+      "mathContext": "Since $\\operatorname{Re}(i^m)$ is $0$ for odd $m$ and $(-1)^{m/2}$ for even $m$, the expansion collapses to $\\cos(n\\theta) = \\sum_{j=0}^{\\lfloor n/2\\rfloor} (-1)^j \\binom{n}{2j}\\cos^{n-2j}\\theta\\,\\sin^{2j}\\theta$."
+    },
+    {
+      "id": "chebyshev-connection",
+      "title": "Connection to Chebyshev Polynomials",
+      "summary": "Proves binomial_eq_chebyshev_T: the explicit binomial sum for cos(nθ) equals T_n(cos θ), composing the binomial expansion with Mathlib's T_real_cos and closing the loop between the binomial and Chebyshev descriptions.",
+      "startLine": 143,
+      "endLine": 156,
+      "mathContext": "The explicit binomial sum equals $T_n(\\cos\\theta)$, the Chebyshev polynomial of the first kind — connecting the constructive expansion to the parent's existence result."
+    }
+  ],
+  "conclusion": {
+    "summary": "The formalization answers the parent entry's leading open question affirmatively: the binomial expansion of cos(nθ) can be formally derived from De Moivre's theorem and connected to the Chebyshev polynomial T_n. The proof is complete with 7 theorems/lemmas and 0 sorries, verified 0-axiom. The chain is: De Moivre / Euler → real part of the binomial theorem → full expansion with Re(i^{n-k}) factors → parity of powers of i → alternating even-index closed form → equality with T_n(cos θ).",
+    "implications": "**Theoretical Significance**\n\n1. **Constructive Chebyshev**: where the parent proved $\\cos(n\\theta) = T_n(\\cos\\theta)$ abstractly, this entry writes the polynomial explicitly and then verifies the agreement, unifying the binomial and Chebyshev descriptions of the multiple-angle formula.\n\n2. **One source for the sign pattern**: the alternating signs and the survival of only even powers of $\\sin$ both trace to the single fact $\\operatorname{Re}(i^m) \\in \\{0, \\pm 1\\}$ with period four.\n\n3. **Reusable reindexing template**: the reflect / drop-vanishing / reindex-by-doubling pattern (`sum_range_reflect`, `sum_subset`, `sum_image`) is a self-contained recipe for extracting even-index closed forms from parity-filtered sums.",
+    "openQuestions": [
+      "Can the companion sin(nθ) = sin θ · Σ_{j} (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j} θ expansion be derived the same way (as the imaginary part of the binomial theorem) and connected to U_{n-1}?",
+      "Can the explicit binomial coefficients of T_n be read off from this expansion to give a closed form for the polynomial coefficients of T_n over ℤ?"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-01",
+      "relationship": "Directly answers the leading open question of the parent entry: deriving the binomial expansion of cos(nθ) and connecting it to T_n."
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "Extends De Moivre's theorem by taking the real part of its binomial expansion to obtain an explicit multiple-angle polynomial."
+    },
+    {
+      "id": "angle-trisection",
+      "relationship": "The n=3 case of the closed form is cos(3θ) = 4cos³θ - 3cosθ, the cubic central to the impossibility of angle trisection."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Polynomial.Chebyshev",
+      "Real",
+      "Finset"
+    ],
+    "namespace": "DeMoivreOQ01OQ01",
+    "lineCount": 156,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "A. de Moivre",
+      "title": "Miscellanea Analytica de Seriebus et Quadraturis",
+      "year": "1730",
+      "venue": "London",
+      "note": "First systematic treatment of (cos θ + i sin θ)^n = cos(nθ) + i sin(nθ)"
+    },
+    {
+      "authors": "P. L. Chebyshev",
+      "title": "Théorie des mécanismes connus sous le nom de parallélogrammes",
+      "year": "1853",
+      "venue": "Mémoires des Savants étrangers présentés à l'Académie de Saint-Pétersbourg",
+      "note": "Introduced the polynomials T_n whose value at cos θ is cos(nθ)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent entry's leading open question by deriving the explicit binomial expansion of $\\cos(n\\theta)$ and proving it equals $T_n(\\cos\\theta)$"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "Builds directly on De Moivre's theorem $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$, whose real part (via the binomial theorem) is the formula proved here"
+    },
+    {
+      "targetId": "angle-trisection",
+      "relationship": "related",
+      "description": "The $n=3$ instance $\\cos(3\\theta) = 4\\cos^3\\theta - 3\\cos\\theta$ is the cubic whose unsolvability by radicals underlies the impossibility of angle trisection"
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "foundational",
+      "description": "The proof identifies $\\cos\\theta + i\\sin\\theta = e^{i\\theta}$ (Euler's formula); the expansion is the real part of $(e^{i\\theta})^n = e^{in\\theta}$"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **leading open question** of the parent entry *De Moivre OQ-01* (verbatim: *"Can the binomial expansion formula for cos(nθ), with alternating sums of binomial coefficients, be formally derived and connected to T_n?"*).

The parent established the *existence* result `cos(nθ) = T_n(cos θ)` by quoting Mathlib's `Chebyshev.T_real_cos`. This entry supplies the missing **constructive** content — the explicit binomial expansion — and proves it equals `T_n(cos θ)`.

## What is proved (`proofs/Proofs/DeMoivreOQ01OQ01.lean`, 7 thm/lemma, 156 L)

| Theorem | Statement |
|---|---|
| `cos_nsmul_eq_re_pow` | `cos(nθ) = Re((cos θ + i sin θ)^n)` via `cos θ + i sin θ = e^{iθ}` |
| `cos_nsmul_binomial_re` | `cos(nθ) = Σ_{k} C(n,k) cos^k θ · sin^{n-k} θ · Re(i^{n-k})` — the real part of the binomial theorem |
| `re_I_pow_odd`, `re_I_pow_two_mul` | `Re(i^m) = 0` (m odd), `Re(i^{2j}) = (-1)^j` — the sign engine |
| `cos_nsmul_binomial_even` | `cos(nθ) = Σ_{j=0}^{⌊n/2⌋} (-1)^j C(n,2j) cos^{n-2j} θ · sin^{2j} θ` — the classical closed form |
| `binomial_eq_chebyshev_T` | the explicit sum `= T_n(cos θ)` |

## Method

1. Identify `cos θ + i sin θ = exp(iθ)` (`Complex.exp_mul_I`), power up (`exp_nat_mul`), extract the real part (`exp_ofReal_mul_I_re`).
2. Expand with `add_pow`, distribute `Re` over the sum (`Complex.re_sum`), factor each term as `real · i^{n-k}` (`re_ofReal_mul`).
3. The `(-1)^j` sign pattern and the vanishing of odd-power-of-sin terms both come from the four-periodicity of `Re(i^m)`.
4. Collapse to the `⌊n/2⌋` closed form by pure finite combinatorics: `sum_range_reflect` (orient index) → `sum_subset` (drop vanishing odd terms) → `sum_image` (reindex `i = 2j`).

## Verification

- Compiles against Mathlib 4.26 (`lake env lean`, 0 errors; docker containerd is down on this host).
- `#print axioms` on all three main theorems: `[propext, Classical.choice, Quot.sound]` only — **no `sorryAx`, no `Lean.ofReduceBool`**. Genuinely 0-axiom, status `verified`.
- 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions.

## Gallery

New entry `src/data/proofs/de-moivre-oq-01-oq-01/` (meta.json + 5 annotations), cross-referenced to the parent, `de-moivre`, `angle-trisection`, and `euler-identity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)