### PR TITLE
research(cauchy-schwarz-oq-03-oq-03): L^p interpolation inequality (log-convexity of L^p norms) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ03OQ03.lean
+++ b/proofs/Proofs/CauchySchwarzOQ03OQ03.lean
@@ -1,0 +1,114 @@
+/-
+  Cauchy–Schwarz — Open Question 03 · Sub-Question 03:
+  The L^p Interpolation Inequality (log-convexity of the discrete L^p norms)
+
+  The parent proof `cauchy-schwarz-oq-03` develops Hölder's inequality for finite
+  sums as the natural generalization of Cauchy–Schwarz.  This file pushes one step
+  further to the *interpolation* (log-convexity) inequality:
+
+    ‖f‖_r ≤ ‖f‖_p^θ · ‖f‖_q^{1-θ},   where   1/r = θ/p + (1-θ)/q,  θ ∈ (0,1),
+
+  with the discrete norm ‖f‖_p = (∑_i f_i^p)^{1/p}.  This says exactly that the map
+  t ↦ log ‖f‖_{1/t} is convex — the L^p norms are logarithmically convex in the
+  reciprocal exponent.  Cauchy–Schwarz / Hölder is the θ = 1/2 midpoint / boundary
+  face of this convexity.
+
+  The proof is a single application of Hölder's inequality with the conjugate pair
+
+    a = p/(rθ),   b = q/(r(1-θ)),   1/a + 1/b = r(θ/p + (1-θ)/q) = 1,
+
+  to the split f_i^r = f_i^{rθ} · f_i^{r(1-θ)}, followed by raising to the power 1/r.
+  We build the conjugate pair from Mathlib's `Real.HolderConjugate` structure and
+  invoke `NNReal.inner_le_Lp_mul_Lq`.
+
+  0 sorries, 0 axioms.
+-/
+
+import Mathlib
+
+open Finset NNReal
+
+namespace CauchySchwarzOQ03OQ03
+
+/-- **L^p interpolation inequality (discrete, log-convexity of L^p norms).**
+
+    For `ℝ≥0`-valued `f` on a finite set and exponents with
+    `1/r = θ/p + (1-θ)/q` and `θ ∈ (0,1)`,
+
+      `(∑ f_i^r)^{1/r} ≤ (∑ f_i^p)^{θ/p} · (∑ f_i^q)^{(1-θ)/q}`.
+
+    Equivalently `‖f‖_r ≤ ‖f‖_p^θ · ‖f‖_q^{1-θ}`: the reciprocal-exponent map
+    `t ↦ log‖f‖_{1/t}` is convex. -/
+theorem lp_interpolation_nnreal {ι : Type*} (s : Finset ι) (f : ι → ℝ≥0)
+    {p q r θ : ℝ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+    (hθ0 : 0 < θ) (hθ1 : θ < 1)
+    (hpqr : 1 / r = θ / p + (1 - θ) / q) :
+    (∑ i ∈ s, f i ^ r) ^ (1 / r)
+      ≤ (∑ i ∈ s, f i ^ p) ^ (θ / p) * (∑ i ∈ s, f i ^ q) ^ ((1 - θ) / q) := by
+  have h1θ : (0 : ℝ) < 1 - θ := by linarith
+  have hrθ : (0 : ℝ) < r * θ := by positivity
+  have hr1θ : (0 : ℝ) < r * (1 - θ) := by positivity
+  -- The conjugate pair a = p/(rθ), b = q/(r(1-θ)).
+  set a := p / (r * θ) with ha
+  set b := q / (r * (1 - θ)) with hb
+  -- The key algebraic identity r·θ/p + r·(1-θ)/q = 1.
+  have hsum : r * θ / p + r * (1 - θ) / q = 1 := by
+    have h := hpqr
+    field_simp at h ⊢
+    nlinarith [h]
+  have hab : a.HolderConjugate b := by
+    refine ⟨?_, ?_, ?_⟩
+    · show a⁻¹ + b⁻¹ = (1 : ℝ)⁻¹
+      rw [ha, hb, inv_div, inv_div, inv_one]
+      exact hsum
+    · exact div_pos hp hrθ
+    · exact div_pos hq hr1θ
+  -- Hölder applied to F_i = f_i^{rθ}, G_i = f_i^{r(1-θ)}.
+  have hHolder := NNReal.inner_le_Lp_mul_Lq s
+    (fun i => f i ^ (r * θ)) (fun i => f i ^ (r * (1 - θ))) hab
+  -- Simplify the three summands pointwise.
+  have hexp : r * θ + r * (1 - θ) = r := by ring
+  have hprod : ∀ i, (f i ^ (r * θ)) * (f i ^ (r * (1 - θ))) = f i ^ r := by
+    intro i
+    rw [← NNReal.rpow_add' (by rw [hexp]; exact hr.ne') (f i), hexp]
+  have haθ : r * θ * a = p := by rw [ha]; field_simp
+  have hbθ : r * (1 - θ) * b = q := by rw [hb]; field_simp
+  have hFa : ∀ i, (f i ^ (r * θ)) ^ a = f i ^ p := by
+    intro i; rw [← NNReal.rpow_mul, haθ]
+  have hGb : ∀ i, (f i ^ (r * (1 - θ))) ^ b = f i ^ q := by
+    intro i; rw [← NNReal.rpow_mul, hbθ]
+  -- Rewrite Hölder into: ∑ f_i^r ≤ (∑ f_i^p)^{1/a} · (∑ f_i^q)^{1/b}.
+  simp only [hprod, hFa, hGb] at hHolder
+  -- Raise both sides to the power 1/r ≥ 0 and simplify exponents.
+  have hstep : (∑ i ∈ s, f i ^ r) ^ (1 / r)
+      ≤ ((∑ i ∈ s, f i ^ p) ^ (1 / a) * (∑ i ∈ s, f i ^ q) ^ (1 / b)) ^ (1 / r) :=
+    NNReal.rpow_le_rpow hHolder (by positivity)
+  refine hstep.trans_eq ?_
+  rw [NNReal.mul_rpow, ← NNReal.rpow_mul, ← NNReal.rpow_mul]
+  have hExpP : 1 / a * (1 / r) = θ / p := by rw [ha]; field_simp
+  have hExpQ : 1 / b * (1 / r) = (1 - θ) / q := by rw [hb]; field_simp
+  rw [hExpP, hExpQ]
+
+/-- **Midpoint (θ = 1/2) case.** With `2/r = 1/p + 1/q`,
+
+      `‖f‖_r ≤ (‖f‖_p · ‖f‖_q)^{1/2}` — the geometric-mean interpolation,
+    of which Cauchy–Schwarz is the symmetric instance `p = q`. -/
+theorem lp_interpolation_midpoint_nnreal {ι : Type*} (s : Finset ι) (f : ι → ℝ≥0)
+    {p q r : ℝ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+    (hpqr : 2 / r = 1 / p + 1 / q) :
+    (∑ i ∈ s, f i ^ r) ^ (1 / r)
+      ≤ ((∑ i ∈ s, f i ^ p) ^ (1 / p)) ^ (2⁻¹ : ℝ)
+        * ((∑ i ∈ s, f i ^ q) ^ (1 / q)) ^ (2⁻¹ : ℝ) := by
+  have h : (∑ i ∈ s, f i ^ r) ^ (1 / r)
+      ≤ (∑ i ∈ s, f i ^ p) ^ ((1 / 2 : ℝ) / p)
+        * (∑ i ∈ s, f i ^ q) ^ ((1 - 1 / 2 : ℝ) / q) := by
+    refine lp_interpolation_nnreal s f hp hq hr (by norm_num) (by norm_num) ?_
+    rw [one_div r]
+    rw [show (1 / 2 : ℝ) / p + (1 - 1 / 2) / q = (2 / r) / 2 by
+          rw [hpqr]; ring]
+    ring
+  refine h.trans_eq ?_
+  rw [← NNReal.rpow_mul, ← NNReal.rpow_mul]
+  congr 2 <;> ring
+
+end CauchySchwarzOQ03OQ03

--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-03/annotations.json
@@ -1,0 +1,75 @@
+[
+  {
+    "id": "ann-lp-interpolation-main",
+    "proofId": "cauchy-schwarz-oq-03-oq-03",
+    "range": {
+      "startLine": 42,
+      "endLine": 90
+    },
+    "type": "concept",
+    "title": "L^p Interpolation via a Single Hölder Application",
+    "content": "The interpolation inequality ‖f‖_r ≤ ‖f‖_p^θ·‖f‖_q^(1-θ) is reduced to one use of Hölder's inequality. Writing f_i^r = f_i^(rθ)·f_i^(r(1-θ)) and applying Hölder with the conjugate exponents a = p/(rθ) and b = q/(r(1-θ)) (which satisfy 1/a + 1/b = r·θ/p + r·(1-θ)/q = 1 exactly because 1/r = θ/p + (1-θ)/q) yields ∑ f_i^r ≤ (∑ f_i^p)^(1/a)·(∑ f_i^q)^(1/b). Raising both sides to the nonnegative power 1/r and simplifying the exponents (1/a)·(1/r) = θ/p and (1/b)·(1/r) = (1-θ)/q gives the result. The conjugate witness is produced directly from Mathlib's Real.HolderConjugate structure, and the zero-safe split uses rpow_add' so that vanishing coordinates f_i = 0 need no special case.",
+    "mathContext": "$$\\left(\\sum_{i} f_i^r\\right)^{1/r} \\leq \\left(\\sum_{i} f_i^p\\right)^{\\theta/p}\\left(\\sum_{i} f_i^q\\right)^{(1-\\theta)/q}, \\qquad \\frac1r = \\frac{\\theta}{p} + \\frac{1-\\theta}{q},\\ \\theta \\in (0,1).$$\nThis is the statement that $t \\mapsto \\log\\|f\\|_{1/t}$ is convex: the $L^p$ norms are logarithmically convex in the reciprocal exponent.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lp interpolation",
+      "log-convexity",
+      "Hölder inequality",
+      "Riesz-Thorin interpolation",
+      "conjugate exponents"
+    ],
+    "prerequisites": [
+      "NNReal.inner_le_Lp_mul_Lq",
+      "Real.HolderConjugate",
+      "NNReal.rpow_add'",
+      "NNReal.rpow_mul",
+      "NNReal.mul_rpow"
+    ]
+  },
+  {
+    "id": "ann-conjugate-pair-construction",
+    "proofId": "cauchy-schwarz-oq-03-oq-03",
+    "range": {
+      "startLine": 54,
+      "endLine": 65
+    },
+    "type": "technique",
+    "title": "Building the Conjugate Pair from the Interpolation Identity",
+    "content": "The heart of the argument is that the interpolation constraint 1/r = θ/p + (1-θ)/q is precisely the Hölder-conjugacy of the derived exponents a = p/(rθ) and b = q/(r(1-θ)). Multiplying the constraint by r gives r·θ/p + r·(1-θ)/q = 1, i.e. a⁻¹ + b⁻¹ = 1. This identity (hsum) is discharged by field_simp followed by nlinarith against the cleared form of the hypothesis. The Real.HolderConjugate value is then assembled as an anonymous structure ⟨inv_add_inv_eq_inv, left_pos, right_pos⟩, with positivity of a and b following from p,q,r,θ > 0 and 1-θ > 0.",
+    "mathContext": "$a = \\dfrac{p}{r\\theta},\\quad b = \\dfrac{q}{r(1-\\theta)},\\qquad \\frac1a + \\frac1b = \\frac{r\\theta}{p} + \\frac{r(1-\\theta)}{q} = r\\left(\\frac{\\theta}{p}+\\frac{1-\\theta}{q}\\right) = r\\cdot\\frac1r = 1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hölder conjugate exponents",
+      "Real.HolderConjugate structure",
+      "exponent bookkeeping"
+    ],
+    "prerequisites": [
+      "Real.HolderConjugate",
+      "field_simp",
+      "nlinarith",
+      "div_pos"
+    ]
+  },
+  {
+    "id": "ann-midpoint",
+    "proofId": "cauchy-schwarz-oq-03-oq-03",
+    "range": {
+      "startLine": 92,
+      "endLine": 113
+    },
+    "type": "concept",
+    "title": "Midpoint Case: Geometric-Mean Interpolation and Cauchy-Schwarz",
+    "content": "Specializing θ = 1/2 gives the symmetric geometric-mean interpolation ‖f‖_r ≤ (‖f‖_p·‖f‖_q)^(1/2) whenever 2/r = 1/p + 1/q. This is the interpolation face closest to the parent inequalities: taking p = q recovers a Cauchy-Schwarz-type statement, exhibiting Cauchy-Schwarz and Hölder as the boundary/diagonal instances of the full log-convexity phenomenon. The corollary is derived from the main theorem by rewriting the exponents at θ = 1/2 and folding the two 1/2-powers with rpow_mul.",
+    "mathContext": "$\\|f\\|_r \\leq \\left(\\|f\\|_p\\,\\|f\\|_q\\right)^{1/2}, \\qquad \\frac2r = \\frac1p + \\frac1q.$ At $p = q$ this is the Cauchy-Schwarz face of the interpolation family.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "geometric mean",
+      "Cauchy-Schwarz inequality",
+      "midpoint convexity"
+    ],
+    "prerequisites": [
+      "NNReal.rpow_mul",
+      "lp_interpolation_nnreal"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-03/meta.json
@@ -1,0 +1,90 @@
+{
+  "id": "cauchy-schwarz-oq-03-oq-03",
+  "title": "The L^p Interpolation Inequality (Log-Convexity of L^p Norms)",
+  "slug": "cauchy-schwarz-oq-03-oq-03",
+  "description": "Extends the parent Hölder inequality to the L^p interpolation (log-convexity) inequality for discrete norms: ‖f‖_r ≤ ‖f‖_p^θ·‖f‖_q^(1-θ) whenever 1/r = θ/p + (1-θ)/q and θ ∈ (0,1). This states that t ↦ log‖f‖_(1/t) is convex — the L^p norms are logarithmically convex in the reciprocal exponent, with Cauchy-Schwarz/Hölder the boundary face. Proved by a single application of Hölder with the conjugate pair a = p/(rθ), b = q/(r(1-θ)) to the split f_i^r = f_i^(rθ)·f_i^(r(1-θ)).",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Interpolation_inequality",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ03OQ03.lean",
+    "tags": [
+      "cauchy-schwarz",
+      "holder-inequality",
+      "lp-interpolation",
+      "log-convexity",
+      "lp-norms",
+      "convexity",
+      "functional-analysis",
+      "real-analysis",
+      "extension",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "NNReal.inner_le_Lp_mul_Lq",
+        "description": "Hölder's inequality for NNReal finite sums over conjugate exponents.",
+        "module": "Mathlib.Analysis.MeanInequalities"
+      },
+      {
+        "theorem": "Real.HolderConjugate",
+        "description": "The Hölder-conjugate relation p⁻¹ + q⁻¹ = 1, used to build the exponent pair a = p/(rθ), b = q/(r(1-θ)).",
+        "module": "Mathlib.Data.Real.ConjExponents"
+      },
+      {
+        "theorem": "NNReal.rpow_add'",
+        "description": "x^(y+z) = x^y·x^z for NNReal, valid at x = 0 when y+z ≠ 0; merges the split f_i^(rθ)·f_i^(r(1-θ)) = f_i^r.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      },
+      {
+        "theorem": "NNReal.rpow_mul",
+        "description": "x^(y·z) = (x^y)^z for NNReal; collapses (f_i^(rθ))^a = f_i^p under the conjugate choice.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      },
+      {
+        "theorem": "NNReal.mul_rpow",
+        "description": "(x·y)^z = x^z·y^z for NNReal (unconditional); distributes the final power 1/r across the product.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      },
+      {
+        "theorem": "NNReal.rpow_le_rpow",
+        "description": "Monotonicity of x ↦ x^z for z ≥ 0; raises the Hölder bound to the power 1/r.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      }
+    ],
+    "originalContributions": [
+      "Discrete L^p interpolation inequality: ‖f‖_r ≤ ‖f‖_p^θ·‖f‖_q^(1-θ) with 1/r = θ/p + (1-θ)/q, θ ∈ (0,1)",
+      "Reduction of interpolation to a single Hölder application via the conjugate pair a = p/(rθ), b = q/(r(1-θ)) (with 1/a + 1/b = 1)",
+      "Construction of the Real.HolderConjugate witness from the interpolation identity r·θ/p + r·(1-θ)/q = 1",
+      "Zero-safe exponent split f_i^r = f_i^(rθ)·f_i^(r(1-θ)) via rpow_add' (handles f_i = 0)",
+      "Midpoint (θ = 1/2) geometric-mean interpolation ‖f‖_r ≤ (‖f‖_p·‖f‖_q)^(1/2), with 2/r = 1/p + 1/q, of which Cauchy-Schwarz is the symmetric p = q instance"
+    ],
+    "axiomCount": 0,
+    "lineCount": 114,
+    "assumptions": "0 axioms, 0 sorries. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). The interpolation reduction and conjugate-pair construction are original; Hölder's inequality is taken from Mathlib's NNReal.inner_le_Lp_mul_Lq.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "lp-interpolation",
+      "title": "L^p Interpolation Inequality",
+      "summary": "The main result: ‖f‖_r ≤ ‖f‖_p^θ·‖f‖_q^(1-θ) for 1/r = θ/p + (1-θ)/q, θ ∈ (0,1). Built from Hölder with the conjugate pair a = p/(rθ), b = q/(r(1-θ)) applied to the split f_i^r = f_i^(rθ)·f_i^(r(1-θ)).",
+      "startLine": 42,
+      "endLine": 90,
+      "mathContext": "$\\left(\\sum_i f_i^r\\right)^{1/r} \\leq \\left(\\sum_i f_i^p\\right)^{\\theta/p}\\left(\\sum_i f_i^q\\right)^{(1-\\theta)/q}$ where $\\tfrac1r = \\tfrac{\\theta}{p} + \\tfrac{1-\\theta}{q}$. Equivalently $t \\mapsto \\log\\|f\\|_{1/t}$ is convex."
+    },
+    {
+      "id": "lp-interpolation-midpoint",
+      "title": "Midpoint (Geometric-Mean) Interpolation",
+      "summary": "The θ = 1/2 case: ‖f‖_r ≤ (‖f‖_p·‖f‖_q)^(1/2) when 2/r = 1/p + 1/q. Cauchy-Schwarz is the symmetric p = q instance.",
+      "startLine": 92,
+      "endLine": 113,
+      "mathContext": "$\\|f\\|_r \\leq \\left(\\|f\\|_p\\,\\|f\\|_q\\right)^{1/2}$ with $\\tfrac2r = \\tfrac1p + \\tfrac1q$; the geometric-mean face of log-convexity."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extends the parent **Hölder inequality** (`cauchy-schwarz-oq-03`) to the discrete **L^p interpolation / log-convexity** inequality:

$$\left(\sum_i f_i^r\right)^{1/r} \le \left(\sum_i f_i^p\right)^{\theta/p}\left(\sum_i f_i^q\right)^{(1-\theta)/q}, \qquad \frac1r=\frac{\theta}{p}+\frac{1-\theta}{q},\ \theta\in(0,1).$$

Equivalently $t \mapsto \log\|f\|_{1/t}$ is convex — the $L^p$ norms are logarithmically convex in the reciprocal exponent, with Cauchy–Schwarz/Hölder as the boundary face.

## Method

A single application of Hölder's inequality (`NNReal.inner_le_Lp_mul_Lq`) with the conjugate pair
$$a=\frac{p}{r\theta},\quad b=\frac{q}{r(1-\theta)},\qquad \tfrac1a+\tfrac1b = r\big(\tfrac{\theta}{p}+\tfrac{1-\theta}{q}\big)=1,$$
applied to the zero-safe split $f_i^r = f_i^{r\theta}\cdot f_i^{r(1-\theta)}$ (via `rpow_add'`), then raise to the power $1/r$. The `Real.HolderConjugate` witness is built directly from the interpolation identity.

Also includes the **θ = 1/2 midpoint** geometric-mean case $\|f\|_r \le (\|f\|_p\|f\|_q)^{1/2}$ with $2/r=1/p+1/q$, of which Cauchy–Schwarz ($p=q$) is the symmetric instance.

## Verification

- **2 theorems, 0 definitions, 114 lines**
- **0 sorries, 0 axioms** — depends only on `propext`, `Classical.choice`, `Quot.sound` (confirmed via `#print axioms`); no `native_decide`
- Compiles against Mathlib v4.26.0

Gallery entry added at `src/data/proofs/cauchy-schwarz-oq-03-oq-03/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)