### PR TITLE
Enrich Erdős #2 OQ-03 (covering systems): keyInsights + references

### DIFF
--- a/src/data/proofs/erdos-2-oq-03/meta.json
+++ b/src/data/proofs/erdos-2-oq-03/meta.json
@@ -39,7 +39,14 @@
     "historicalContext": "Erdős (c. 1950) asked whether the minimum modulus of a covering system with distinct moduli ≥ 2 can be arbitrarily large — 'perhaps my favourite problem', with a $1000 prize. Constructions raised the record minimum modulus to 2, 3, 20, 36, 40, 42 (Owens 2014), and most experts expected the answer YES. Hough (2015) stunned the field by proving NO: every covering system has a modulus ≤ 10^16, via the Lovász Local Lemma building on Filaseta–Ford–Konyagin–Pomerance–Yu (2007). Balister, Bollobás, Morris, Sahasrabudhe and Tiba (2022) sharpened the bound to 616,000 with their 'distortion method' (Annals of Mathematics). The exact maximum minimum modulus is open, lying between 42 and 616,000. Open question OQ-03 asks specifically whether the 616,000 upper bound can be pushed lower.",
     "problemStatement": "OQ-03: Can the Balister et al. upper bound of 616,000 on the minimum modulus of a covering system be improved? This is a wide-open quantitative research problem and is NOT resolved here. Instead this entry formalizes, with no axioms, the elementary structural arithmetic that every covering system with a large minimum modulus must obey — the soft consequences of the classical density inequality Σ 1/nᵢ ≥ 1.",
     "proofStrategy": "Every theorem is conditional on the density bound cs.reciprocalSum ≥ 1, given as a hypothesis. (1) reciprocalSum_le: if all moduli are ≥ m then Σ 1/nᵢ ≤ k/m, since each summand is ≤ 1/m (List.sum_le_card_nsmul). (2) card_classes_ge: combining with Σ 1/nᵢ ≥ 1 gives k ≥ m — a large minimum modulus forces many classes. (3) maxModulus_ge: if moreover the moduli are distinct and all ≤ M, then the k moduli are distinct integers in [m, M], so k ≤ M+1−m (List.toFinset_card_of_nodup + Nat.card_Icc); with k ≥ m this yields 2m ≤ M+1, i.e. a modulus ≥ 2m−1 is forced. (4) improvement_cost packages both. (5) card_bound_tight shows k ≥ m is sharp via the trivial {0,1 mod 2} cover (k = m = 2, reciprocal sum 1).",
-    "significance": "These bounds make explicit why pushing the lower bound (Owens' 42) is combinatorially expensive — a minimum modulus m requires at least m congruence classes and forces the moduli to span a factor-2 range — and frame the constraints any improved upper bound for OQ-03 must respect. The contribution is honest about scope: it is the easy structural skeleton, not a quantitative improvement to 616,000, and the deep density bound itself is assumed rather than reproved."
+    "significance": "These bounds make explicit why pushing the lower bound (Owens' 42) is combinatorially expensive — a minimum modulus m requires at least m congruence classes and forces the moduli to span a factor-2 range — and frame the constraints any improved upper bound for OQ-03 must respect. The contribution is honest about scope: it is the easy structural skeleton, not a quantitative improvement to 616,000, and the deep density bound itself is assumed rather than reproved.",
+    "keyInsights": [
+      "**The whole quantitative skeleton is a two-sided density squeeze.** A minimum modulus $\\ge m$ makes every summand $1/n_i \\le 1/m$, so $\\sum 1/n_i \\le k/m$; the classical covering-density fact $\\sum 1/n_i \\ge 1$ then forces $k \\ge m$. A large minimum modulus cannot be cheap — it demands at least that many congruence classes.",
+      "**Distinctness upgrades a count into a spread.** With $k \\ge m$ distinct moduli all confined to $[m, M]$, the pigeonhole count $k \\le M + 1 - m$ collides with $k \\ge m$ to force $2m \\le M + 1$ — a modulus $\\ge 2m - 1$ must appear. The moduli of a covering system cannot hide in a narrow window just above the minimum.",
+      "**Honest axiom accounting is the point.** The single genuinely deep input — the density bound $\\sum 1/n_i \\ge 1$ — is carried as an explicit theorem *hypothesis*, not an axiom, so every declaration depends only on `propext`, `Classical.choice`, `Quot.sound`. The parent entry `erdos-2` instead encodes the same fact as an axiom; isolating it as a hypothesis is what keeps this file axiom-free.",
+      "**The class-count bound is sharp, not merely true.** The trivial cover $\\{0, 1 \\bmod 2\\}$ realises $k = m = 2$ with reciprocal sum exactly $1$ (`card_bound_tight`), so $k \\ge m$ cannot be improved to $k > m$ in general — the elementary bound is already best-possible at the smallest minimum modulus.",
+      "**Scope discipline separates skeleton from machine.** These are the soft structural constraints any OQ-03 improvement must respect, deliberately factored out from the deep distortion-method analysis of Balister–Bollobás–Morris–Sahasrabudhe–Tiba that yields the $616{,}000$ bound. The entry proves the skeleton exactly and leaves the hard quantitative question untouched — no overclaiming."
+    ]
   },
   "sections": [
     {
@@ -81,6 +88,38 @@
       "endLine": 234,
       "summary": "The trivial covering system {0 mod 2, 1 mod 2} has reciprocal sum exactly 1 and realises k = m = 2 (card_bound_tight), so the bound k ≥ m cannot be improved in general.",
       "mathContext": "Demonstrates sharpness of card_classes_ge at the smallest possible minimum modulus."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "On integers of the form 2^k + p and some related problems",
+      "year": "1950",
+      "note": "Summa Brasiliensis Mathematicae 2, 113–123. Introduces covering systems of congruences and raises the minimum-modulus question — one of Erdős's favourite problems, later attached to a $1000 prize."
+    },
+    {
+      "authors": "Filaseta, Ford, Konyagin, Pomerance, Yu",
+      "title": "Sieving by large integers and covering systems of congruences",
+      "year": "2007",
+      "note": "Journal of the American Mathematical Society 20(2), 495–517. Sieve/density groundwork on covering systems that underlies Hough's later solution."
+    },
+    {
+      "authors": "Hough, Bob",
+      "title": "Solution of the minimum modulus problem for covering systems",
+      "year": "2015",
+      "note": "Annals of Mathematics 181(1), 361–382. Proves NO: every covering system with distinct moduli has a modulus at most ~10^16, refuting the widely expected affirmative answer, via the Lovász Local Lemma."
+    },
+    {
+      "authors": "Balister, Bollobás, Morris, Sahasrabudhe, Tiba",
+      "title": "On the Erdős covering problem: the density of the uncovered set / distortion method",
+      "year": "2022",
+      "note": "Sharpens Hough's bound to 616,000 using the 'distortion method'. The exact maximum minimum modulus remains open between Owens' 42 and this 616,000; OQ-03 asks whether the upper bound can be pushed lower."
+    },
+    {
+      "authors": "Owens, Peter J.",
+      "title": "A covering system with minimum modulus 42",
+      "year": "2014",
+      "note": "Construction realising minimum modulus 42, the current record lower bound for the maximum minimum modulus of a covering system."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `erdos-2-oq-03` (pass 0). Filled two empty fields on this axiom-free covering-systems entry:

## Changes
- **overview.keyInsights: 0 → 5** — the two-sided density squeeze (1 ≤ Σ1/nᵢ ≤ k/m ⟹ k ≥ m); distinctness turning the count into a factor-2 spread (2m ≤ M+1); the honest hypothesis-not-axiom accounting that keeps the file axiom-free vs the parent's axiom; sharpness of k ≥ m via the {0,1 mod 2} cover; and scope discipline (skeleton vs the distortion-method 616,000 bound).
- **references: 0 → 5** — Erdős 1950 (origin of covering systems), Filaseta–Ford–Konyagin–Pomerance–Yu 2007 (JAMS), Hough 2015 (Annals, the ~10¹⁶ solution), Balister–Bollobás–Morris–Sahasrabudhe–Tiba 2022 (616,000), Owens 2014 (min modulus 42). All are already named in the entry's `historicalContext`.

## Notes
- Only added to empty fields; existing overview/sections/conclusion/annotations/crossReferences untouched.
- Insights verified against `mainTheorems` and `Proofs/Erdos2OQ03.lean`. JSON valid, within 60 KB cap.