### PR TITLE
Enrich Nicomachus Sum of Cubes (oq-01): +corollary annotation, +prerequisites

### DIFF
--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-01/annotations.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-01/annotations.json
@@ -8,6 +8,7 @@
     "content": "This is the entire algebraic content of the induction, isolated as a standalone lemma. The expression $m^2(m-1) + m^2$ would be $m^3$ over $\\mathbb{Z}$, but in $\\mathbb{N}$ the subtraction $m-1$ is truncated (it is $0$ when $m = 0$). A `cases m` split sends $m \\mapsto 0$ (closed by `rfl`) and $m \\mapsto p+1$ (where $m-1$ simplifies to $p$ via `Nat.succ_sub_one`), after which `ring` closes the branch because no subtraction remains. This is what lets the whole proof live in $\\mathbb{N}$.",
     "mathContext": "$m^3 = m^2(m-1) + m^2$, with $m-1$ the truncated natural subtraction.",
     "significance": "key",
+    "prerequisites": ["Truncated subtraction in ℕ", "Nat.succ_sub_one", "ring / case analysis"],
     "relatedConcepts": ["Truncated natural subtraction", "Case analysis", "ring tactic"]
   },
   {
@@ -31,7 +32,20 @@
     "content": "Instead of re-deriving the closed form for $\\sum_{k<m} k$, the proof imports Mathlib's `sum_range_id_mul_two`, which states $(\\sum_{i<m} i)\\cdot 2 = m(m-1)$. A one-line `omega` reshapes it into $2\\cdot\\sum_{k<m} k = m(m-1)$, exactly the substitution the inductive step needs. The genuinely new mathematical content of this file is therefore concentrated in the cube lemma — the triangular half is borrowed.",
     "mathContext": "$2\\sum_{k<m} k = m(m-1)$ (Gauss).",
     "significance": "supporting",
+    "prerequisites": ["Finset.sum_range_id_mul_two", "omega tactic"],
     "relatedConcepts": ["Gauss sum", "Lemma reuse"]
+  },
+  {
+    "id": "ann-first-n-corollary",
+    "proofId": "nicomachus-sum-of-cubes-oq-01",
+    "range": { "startLine": 68, "endLine": 74 },
+    "type": "theorem",
+    "title": "The 1-Indexed Corollary: ∑_{k=0}^{n} k³ = (∑_{k=0}^{n} k)²",
+    "content": "`sum_cubes_first` restates Nicomachus in the classical \"first $n$ cubes\" phrasing. The main theorem sums over `range n` (the values $0,\\dots,n-1$); this corollary sums over `range (n+1)` (the values $0,\\dots,n$), which is what the schoolbook statement $1^3 + 2^3 + \\cdots + n^3 = (1 + 2 + \\cdots + n)^2$ means once the vanishing $k=0$ term is included. The proof is a one-liner — `sum_cubes (n + 1)` — because the $0$-indexed and $1$-indexed forms differ only by the harmless leading zero term. It exists purely to expose the identity in the shape a reader expects, avoiding an off-by-one mismatch at the point of reuse.",
+    "mathContext": "$\\sum_{k=0}^{n} k^3 = \\left(\\sum_{k=0}^{n} k\\right)^2$, i.e. `range (n+1)` in place of `range n`.",
+    "significance": "supporting",
+    "prerequisites": ["Finset.range indexing conventions", "the main theorem sum_cubes"],
+    "relatedConcepts": ["off-by-one range shifts", "1-indexed vs 0-indexed sums", "triangular numbers"]
   },
   {
     "id": "ann-closed-form",
@@ -42,6 +56,7 @@
     "content": "A `calc` derivation: substitute Nicomachus to get $4(\\sum k)^2$, regroup as $((\\sum k)\\cdot 2)^2$ by `ring`, then rewrite with Gauss's identity to land on $(n(n-1))^2$. Multiplying by $4$ up front keeps the statement entirely in $\\mathbb{N}$ with no division — the same design choice Mathlib makes for `sum_range_id_mul_two`. This is the form most convenient for downstream reuse.",
     "mathContext": "$4\\sum_{k<n} k^3 = (n(n-1))^2$.",
     "significance": "supporting",
+    "prerequisites": ["Finset.sum_range_id_mul_two", "calc blocks", "division-free ℕ arithmetic"],
     "relatedConcepts": ["Closed-form power sums", "Natural-number division avoidance"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for nicomachus-sum-of-cubes-oq-01.

**Gaps closed:**
- `sum_cubes_first` (lines 68–74), the 1-indexed "first n cubes" corollary summing over `range (n+1)`, had **no annotation**. Added `ann-first-n-corollary` explaining the 0-indexed vs 1-indexed range shift and why the corollary exists (off-by-one convenience at the point of reuse).
- Three annotations (`ann-cube-lemma`, `ann-gauss-reuse`, `ann-closed-form`) were missing the `prerequisites` field. All 5 annotations now carry full metadata (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`).

Annotation count 4→5 with contiguous coverage of the whole 84-line file. meta.json unchanged (already well-developed, 10.5 KB). Entry validates cleanly in the gallery build (no errors for this id).