### PR TITLE
Enrich Nicomachus Odd Cubes (oq-03): +header annotation, +prerequisites

### DIFF
--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-03/annotations.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-odd-cube-overview",
+    "proofId": "nicomachus-sum-of-cubes-oq-03",
+    "range": { "startLine": 4, "endLine": 42 },
+    "type": "concept",
+    "title": "The Odd-Cube Analogue of Nicomachus's Theorem",
+    "content": "Where the parent identity sums *all* cubes, $1^3 + 2^3 + \\cdots + n^3 = (\\sum k)^2$, this entry sums only the **odd** cubes: $1^3 + 3^3 + 5^3 + \\cdots + (2n-1)^3 = n^2(2n^2-1)$. Indexing the $n$ odd numbers as $2k+1$ for $k = 0,\\dots,n-1$, the statement is $\\sum_{k<n}(2k+1)^3 = n^2(2n^2-1)$ — verified by hand at $n=1$ ($1 = 1\\cdot 1$), $n=2$ ($1+27 = 28 = 4\\cdot 7$), and $n=3$ ($1+27+125 = 153 = 9\\cdot 17$). Unlike the all-cubes case, the right side is not a perfect square: the triangular-number structure is replaced by the factor $2n^2-1$. The proof's central design choice — foreshadowed here — is to dodge the truncated subtraction in $2n^2-1 = 2n^4/n^2 - 1$ by proving a subtraction-free equivalent over $\\mathbb{N}$ and recovering the headline form over $\\mathbb{Z}$ only at the end. Mathlib has neither the odd-cube identity nor this repackaging.",
+    "mathContext": "$\\sum_{k=1}^{n}(2k-1)^3 = 1^3+3^3+\\cdots+(2n-1)^3 = n^2(2n^2-1)$.",
+    "significance": "context",
+    "prerequisites": ["Nicomachus's theorem (∑k³ = (∑k)²)", "odd-number indexing 2k+1", "figurate/power sums"],
+    "relatedConcepts": ["Nicomachus's theorem", "odd cubes", "Faulhaber identities", "truncated subtraction in ℕ"]
+  },
+  {
     "id": "ann-subtraction-free",
     "proofId": "nicomachus-sum-of-cubes-oq-03",
     "range": { "startLine": 56, "endLine": 67 },
@@ -20,6 +32,7 @@
     "content": "The inductive step is closed by a clean division of labor. The `key` hypothesis $2m^4 + (2m+1)^3 + (m+1)^2 = 2(m+1)^4 + m^2$ is a fixed, subtraction-free polynomial identity that `ring` verifies outright. Then `omega` finishes: it treats the nonlinear terms $m^4$, $(2m+1)^3$, $(m+1)^2$, $(m+1)^4$ and the sum as opaque atoms and does the purely *linear* algebra needed to combine `key` with the inductive hypothesis $\\sum_{k<m}(2k+1)^3 + m^2 = 2m^4$. Neither tactic does the other's job — `ring` cannot use the hypothesis, `omega` cannot expand the polynomials.",
     "mathContext": "$2m^4 + (2m+1)^3 + (m+1)^2 = 2(m+1)^4 + m^2$.",
     "significance": "key",
+    "prerequisites": ["ring tactic", "omega tactic", "linear vs nonlinear reasoning"],
     "relatedConcepts": ["ring tactic", "omega tactic", "Atomization of nonlinear terms"]
   },
   {
@@ -43,6 +56,7 @@
     "content": "A division-free, ℕ-native packaging of the same content, scaled by 4 and derived in a single `omega` step from the core lemma. Useful for downstream callers that prefer to avoid casting to $\\mathbb{Z}$ entirely; the factor of 4 keeps everything multiplicative and subtraction-free.",
     "mathContext": "$4\\sum_{k<n}(2k+1)^3 + 4n^2 = 8n^4$.",
     "significance": "supporting",
+    "prerequisites": ["sum_odd_cubes_add", "omega tactic", "division-free ℕ arithmetic"],
     "relatedConcepts": ["Natural-number division avoidance", "Closed-form power sums"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for nicomachus-sum-of-cubes-oq-03.

**Gaps closed:**
- The module docstring (lines 4–42) — stating the odd-cube identity $\sum(2k+1)^3 = n^2(2n^2-1)$, its $n=1,2,3$ sanity checks, the contrast with the all-cubes perfect-square form, and the subtraction-free ℕ→ℤ strategy — had **no annotation**. Added `ann-odd-cube-overview`.
- `ann-ring-omega-step` and `ann-scaled-form` were missing `prerequisites`. All 5 annotations now carry full metadata (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`).

Annotation count 4→5. meta.json unchanged. Entry validates cleanly in the gallery build (no errors for this id).