### PR TITLE
research(minpoly-charpoly-oq-02): similarity-invariance of diagonalizability [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ02.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02.lean
@@ -276,4 +276,46 @@ theorem _root_.Module.End.isSemisimple_iff_squarefree_minpoly
   ⟨Module.End.IsSemisimple.minpoly_squarefree,
    fun h => Module.End.isSemisimple_of_squarefree_aeval_eq_zero h (minpoly.aeval K f)⟩
 
+-- ============================================================
+-- Diagonalizability is a similarity invariant (PROVED, any field)
+-- ============================================================
+
+/-- **Diagonalizability is a similarity invariant.** If `M` is diagonalizable and
+`P` is invertible, then the conjugate `P⁻¹ * M * P` is diagonalizable. If `M = Q⁻¹ D Q`
+with `D` diagonal, then `P⁻¹ M P = (P⁻¹ Q)⁻¹ D (P⁻¹ Q)`, so `P⁻¹ Q` diagonalizes the
+conjugate. This is the matrix-level counterpart of `minpoly.algEquiv_eq` (already used
+for the forward direction via `matConj`) and the change-of-basis step the reverse
+direction transports through `Matrix.toLin'`. Holds over any field. -/
+theorem _root_.Matrix.IsDiagonalizable.conj {M : Matrix n n K}
+    (h : M.IsDiagonalizable) {P : Matrix n n K} (hP : IsUnit P) :
+    (P⁻¹ * M * P).IsDiagonalizable := by
+  obtain ⟨Q, hQ, hdiag⟩ := h
+  have hPdet : IsUnit P.det := (Matrix.isUnit_iff_isUnit_det P).mp hP
+  have hPinv : IsUnit P⁻¹ := (Matrix.isUnit_iff_isUnit_det _).mpr (Matrix.isUnit_nonsing_inv_det P hPdet)
+  refine ⟨P⁻¹ * Q, hPinv.mul hQ, ?_⟩
+  have hPP : P * P⁻¹ = 1 := Matrix.mul_nonsing_inv P hPdet
+  have hexpr : (P⁻¹ * Q)⁻¹ * (P⁻¹ * M * P) * (P⁻¹ * Q) = Q⁻¹ * M * Q := by
+    rw [Matrix.mul_inv_rev, Matrix.nonsing_inv_nonsing_inv P hPdet,
+      show Q⁻¹ * P * (P⁻¹ * M * P) * (P⁻¹ * Q)
+        = Q⁻¹ * (P * P⁻¹) * M * (P * P⁻¹) * Q from by simp only [mul_assoc]]
+    simp only [hPP, mul_one]
+  rw [hexpr]
+  exact hdiag
+
+/-- **Similarity symmetry.** `P⁻¹ * M * P` is diagonalizable iff `M` is (for invertible
+`P`). The forward implication is `Matrix.IsDiagonalizable.conj`; the converse conjugates
+back by `P⁻¹` and rewrites `(P⁻¹)⁻¹ = P`. -/
+theorem _root_.Matrix.isDiagonalizable_conj_iff {M P : Matrix n n K} (hP : IsUnit P) :
+    (P⁻¹ * M * P).IsDiagonalizable ↔ M.IsDiagonalizable := by
+  have hPdet : IsUnit P.det := (Matrix.isUnit_iff_isUnit_det P).mp hP
+  have hPP : P * P⁻¹ = 1 := Matrix.mul_nonsing_inv P hPdet
+  have hPinv : IsUnit P⁻¹ := (Matrix.isUnit_iff_isUnit_det _).mpr (Matrix.isUnit_nonsing_inv_det P hPdet)
+  refine ⟨fun h => ?_, fun h => h.conj hP⟩
+  have hback := h.conj (P := P⁻¹) hPinv
+  have heq : (P⁻¹)⁻¹ * (P⁻¹ * M * P) * P⁻¹ = M := by
+    rw [Matrix.nonsing_inv_nonsing_inv P hPdet,
+      show P * (P⁻¹ * M * P) * P⁻¹ = (P * P⁻¹) * M * (P * P⁻¹) from by simp only [mul_assoc]]
+    simp only [hPP, one_mul, mul_one]
+  rwa [heq] at hback
+
 end Proofs.MinpolyCharpolyOQ02

--- a/src/data/proofs/minpoly-charpoly-oq-02/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/meta.json
@@ -22,13 +22,14 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 279,
+    "lineCount": 321,
     "assumptions": "0 axioms; 1 sorry guarding the proof of `diagonalizable_iff_squarefree_minpoly`. The statement itself is unconditional (hypotheses [IsAlgClosed K] [CharZero K] are explicit, not assumed-as-axiom). The two pre-shipped endomorphism-level bridges (Module.End.iSup_eigenspace_eq_top_of_isSemisimple and Module.End.isSemisimple_iff_squarefree_minpoly) are fully proved with no sorry. The four sub-OQs OQ-02-OQ-01..OQ-02-OQ-04 (estimated ~450 lines total) are the planned discharge route, with the picker-estimated final synthesis at ~59 LOC (~12 + 8 + 33 + 1 + 5 for Bridges A fwd + A rev + B rev + D + compose). Pinned at Mathlib v4.26.0; 18 bearer lemmas verified at SHA 2df2f015… by S7c PREP #19257.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-04",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 2,
     "originalContributions": [
+      "Similarity-invariance of diagonalizability (verified, any field, 0 axioms): `Matrix.IsDiagonalizable.conj` — if M is diagonalizable and P invertible then P⁻¹ M P is diagonalizable (if M = Q⁻¹ D Q then P⁻¹ M P = (P⁻¹ Q)⁻¹ D (P⁻¹ Q)); and `Matrix.isDiagonalizable_conj_iff` — the biconditional form. This is the change-of-basis step the reverse direction transports through Matrix.toLin' (the matrix-level counterpart of minpoly.algEquiv_eq already used for the forward direction), reducing the remaining reverse `sorry` to the pure endomorphism eigenbasis statement.",
       "Matrix.IsDiagonalizable predicate: ∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P) — the matrix-level analogue of Module.End.IsSemisimple ∧ Polynomial.Splits for the associated endomorphism",
       "Module.End.iSup_eigenspace_eq_top_of_isSemisimple: the corrected 3-lemma chain (IsSemisimple → IsFinitelySemisimple → maxGenEigenspace μ = eigenspace μ → ⨆ eigenspace = ⊤) for alg-closed finite-dimensional spaces (Bridge B forward, shipped S7 ACT #19095 after S4 PREP #18626 caught the phantom direct-form name)",
       "Module.End.isSemisimple_iff_squarefree_minpoly: the endomorphism-level iff (Bridge C), constructed by composing Module.End.IsSemisimple.minpoly_squarefree (forward) with Module.End.isSemisimple_of_squarefree_aeval_eq_zero applied to minpoly.aeval (reverse)",
@@ -193,9 +194,9 @@
       "Polynomial"
     ],
     "namespace": "Proofs.MinpolyCharpolyOQ02",
-    "lineCount": 279,
+    "lineCount": 321,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 2,
     "path": "Proofs/MinpolyCharpolyOQ02.lean",
     "sorries": 1


### PR DESCRIPTION
## Summary

Adds two verified, axiom-free lemmas to `MinpolyCharpolyOQ02.lean` (diagonalizable ⟺ squarefree minimal polynomial), advancing the still-open **reverse** direction (`squarefree ⟹ diagonalizable`, the sub-OQ-02-OQ-02 target).

| Theorem | Statement |
|---|---|
| `Matrix.IsDiagonalizable.conj` | `M` diagonalizable, `P` invertible ⟹ `P⁻¹ * M * P` diagonalizable (any field) |
| `Matrix.isDiagonalizable_conj_iff` | `(P⁻¹ * M * P).IsDiagonalizable ↔ M.IsDiagonalizable` |

If `M = Q⁻¹ D Q` with `D` diagonal, then `P⁻¹ M P = (P⁻¹Q)⁻¹ D (P⁻¹Q)`, so `P⁻¹Q` diagonalizes the conjugate. This is the matrix-level counterpart of `minpoly.algEquiv_eq` (already used for the forward direction via `matConj`) and the **change-of-basis step** the reverse direction transports through `Matrix.toLin'` — narrowing the remaining reverse `sorry` toward the pure endomorphism eigenbasis statement.

## Verification

- `#print axioms` on both: `[propext, Classical.choice, Quot.sound]` only — **0 counted axioms**, no `sorryAx`, no `Lean.ofReduceBool`.
- File elaborates cleanly via `lake env lean` (Docker daemon currently has a containerd I/O error; single-file elaboration used, parent `MinpolyCharpoly` olean prebuilt).

## Status

Entry stays `formalized` — the main theorem's reverse `sorry` is unchanged; this is additive verified infrastructure. Gallery `meta.json` refreshed (321 lines, 11 theorems).

Note: Mathlib v4.26.0 has no `IsDiagonalizable` predicate and no "eigenbasis ⟹ diagonalizing matrix" theorem, so fully closing the reverse remains a multi-lemma effort (constructing `P` from an eigenbasis via `Basis.toMatrix`); this PR supplies a reusable piece of that.