### PR TITLE
Enrich Erdős 19 (oq-02): +prerequisites on all annotations

### DIFF
--- a/src/data/proofs/erdos-19-oq-02/annotations.json
+++ b/src/data/proofs/erdos-19-oq-02/annotations.json
@@ -8,7 +8,8 @@
     "content": "The parent problem (Erdős–Faber–Lovász) lives among set families with small pairwise intersections; this file develops the complementary large-intersection theme. A finite family 𝒜 of elements of a Boolean algebra is k-wise intersecting if every nonempty subfamily of size at most k has a meet that is not ⊥ — for set families, every ≤ k members share a common point. The file proves three things: the property is antitone in k and closed under subfamilies; for k ≥ 2 it reduces to Mathlib's pairwise Set.Intersecting; and consequently 2·|𝒜| ≤ |α| (Kleitman's half bound), i.e. 2·|𝒜| ≤ 2ⁿ for subsets of an n-set. Sharpness is witnessed by principal up-sets.",
     "mathContext": "k-wise intersecting (k ≥ 2) ⟹ pairwise intersecting ⟹ 2·|𝒜| ≤ |α| via Set.Intersecting.card_le.",
     "significance": "critical",
-    "relatedConcepts": ["intersecting family", "Kleitman bound", "extremal set theory", "Boolean algebra"]
+    "relatedConcepts": ["intersecting family", "Kleitman bound", "extremal set theory", "Boolean algebra"],
+    "prerequisites": ["Boolean algebras and the meet ⊓", "Set.Intersecting (pairwise intersecting families)", "Kleitman's half bound"]
   },
   {
     "id": "ann-e19oq02-01-def",
@@ -19,7 +20,8 @@
     "content": "KWiseIntersecting k 𝒜 holds when every subfamily t ⊆ 𝒜 with 0 < |t| ≤ k satisfies t.inf id ≠ ⊥. The meet t.inf id is the greatest lower bound of the members of t; over a Boolean algebra of finite sets, t.inf id ≠ ⊥ says the chosen members have a common point. Bundling all subfamily sizes up to k into one quantifier is what makes the antitonicity and pairwise-reduction proofs one-liners.",
     "mathContext": "∀ t ⊆ 𝒜, 0 < |t| ≤ k → ⨅_{x ∈ t} x ≠ ⊥.",
     "significance": "critical",
-    "relatedConcepts": ["Finset.inf", "meet-semilattice", "common point"]
+    "relatedConcepts": ["Finset.inf", "meet-semilattice", "common point"],
+    "prerequisites": ["Finset.inf (meet over a finite set)", "bottom element ⊥", "bounded quantifiers over subfamilies"]
   },
   {
     "id": "ann-e19oq02-02-antitone",
@@ -30,7 +32,8 @@
     "content": "Both facts follow immediately from the definition. A subfamily of a k-wise intersecting family is k-wise intersecting (any t ⊆ ℬ ⊆ 𝒜). And j ≤ k makes KWiseIntersecting k 𝒜 imply KWiseIntersecting j 𝒜, since a subfamily of size ≤ j is in particular of size ≤ k — so the property is antitone in k: larger k is a stronger hypothesis. The singleton subfamily {a} also shows every member is ≠ ⊥ (mem_ne_bot).",
     "mathContext": "j ≤ k ⟹ (KWiseIntersecting k 𝒜 → KWiseIntersecting j 𝒜).",
     "significance": "supporting",
-    "relatedConcepts": ["monotonicity", "antitone"]
+    "relatedConcepts": ["monotonicity", "antitone"],
+    "prerequisites": ["antitone predicates", "Finset subset relation", "singleton subfamilies"]
   },
   {
     "id": "ann-e19oq02-03-reduction",
@@ -41,7 +44,8 @@
     "content": "The crux: a k-wise intersecting family with k ≥ 2 is intersecting in Mathlib's pairwise sense. For members a, b ∈ 𝒜, apply the hypothesis to the two-element subfamily {a, b}: its meet is exactly a ⊓ b (Finset.inf_insert then Finset.inf_singleton, valid even when a = b), so a ⊓ b ≠ ⊥, which is precisely ¬ Disjoint a b (disjoint_iff). This is the bridge that lets all subsequent cardinality results be inherited from Mathlib's intersecting-family API.",
     "mathContext": "{a,b}.inf id = a ⊓ b; a ⊓ b ≠ ⊥ ⟺ ¬ Disjoint a b.",
     "significance": "critical",
-    "relatedConcepts": ["Set.Intersecting", "Disjoint", "Finset.inf_insert"]
+    "relatedConcepts": ["Set.Intersecting", "Disjoint", "Finset.inf_insert"],
+    "prerequisites": ["Finset.inf_insert / Finset.inf_singleton", "disjoint_iff (a ⊓ b = ⊥ ⟺ Disjoint a b)", "Set.Intersecting"]
   },
   {
     "id": "ann-e19oq02-04-cardbound",
@@ -52,7 +56,8 @@
     "content": "Composing the reduction with Mathlib's Kleitman bound Set.Intersecting.card_le gives 2·|𝒜| ≤ Fintype.card α for a k-wise intersecting family (k ≥ 2) in a finite Boolean algebra. Specializing α to Finset (Fin n) and rewriting with Fintype.card_finset (|Finset (Fin n)| = 2ⁿ) yields the classical statement 2·|𝒜| ≤ 2ⁿ — at most 2ⁿ⁻¹ members.",
     "mathContext": "2·|𝒜| ≤ |α|; for subsets of [n], 2·|𝒜| ≤ 2ⁿ.",
     "significance": "critical",
-    "relatedConcepts": ["Kleitman", "Fintype.card_finset", "extremal bound"]
+    "relatedConcepts": ["Kleitman", "Fintype.card_finset", "extremal bound"],
+    "prerequisites": ["Set.Intersecting.card_le (Kleitman)", "Fintype.card_finset (|Finset (Fin n)| = 2ⁿ)", "finite Boolean algebra cardinality"]
   },
   {
     "id": "ann-e19oq02-05-sharpness",
@@ -63,6 +68,7 @@
     "content": "principalUp a = {x | a ≤ x}. Every subfamily of it has meet ≥ a (Finset.le_inf), hence ≠ ⊥ whenever a ≠ ⊥ — so the principal up-set is k-wise intersecting for every k at once. This shows the reduction to pairwise is tight: the same extremal families witness intersection at all levels k, and exists_kWiseIntersecting confirms nonempty examples exist in any nontrivial finite Boolean algebra.",
     "mathContext": "a ≤ t.inf id for t ⊆ {x | a ≤ x}; a ≠ ⊥ ⟹ k-wise intersecting for all k.",
     "significance": "supporting",
-    "relatedConcepts": ["principal up-set", "Finset.le_inf", "sharpness"]
+    "relatedConcepts": ["principal up-set", "Finset.le_inf", "sharpness"],
+    "prerequisites": ["principal up-set {x | a ≤ x}", "Finset.le_inf", "extremal witnesses / tightness"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for erdos-19-oq-02 (k-wise intersecting families / Kleitman half-bound).

**Gap closed:** all 6 annotations lacked the `prerequisites` field (the other structured fields were present). Filled each with accurate dependencies:
- overview → Boolean algebras, Set.Intersecting, Kleitman bound
- definition → Finset.inf, ⊥, bounded subfamily quantifiers
- antitonicity → antitone predicates, Finset subsets
- reduction → Finset.inf_insert/singleton, disjoint_iff, Set.Intersecting
- half-bound → Set.Intersecting.card_le, Fintype.card_finset
- sharpness → principal up-sets, Finset.le_inf

No content changed. Validates cleanly in the gallery build.