### PR TITLE
Enrich L^p Interpolation Inequality (cauchy-schwarz-oq-03-oq-03)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-03/meta.json
@@ -69,6 +69,24 @@
     "theoremCount": 2,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "The interpolation of L^p norms is the elementary, discrete shadow of one of the central theorems of 20th-century analysis: the Riesz–Thorin interpolation theorem. Marcel Riesz proved the real-variable 'convexity theorem' for bilinear forms in 1926 (Acta Math. 49), showing that log M(1/p, 1/q) is a convex function of the exponents; his student G. Olof Thorin recast and extended it in 1938–1948 using the complex-analytic 'Thorin trick' (the three-lines/maximum-modulus argument), yielding the sharp constant-1 form now called Riesz–Thorin. The scalar heart of that theory — that a single function's L^p norms are log-convex in 1/p — predates it and follows directly from Hölder's inequality (Otto Hölder, 1889), itself the p,q-generalization of the Cauchy–Schwarz inequality (Cauchy 1821; Bunyakovsky 1859; Schwarz 1888). This entry isolates exactly that scalar log-convexity statement in the finite discrete setting, where no measure theory or complex analysis is needed: the whole result is one application of Hölder. It sits in the gallery as the third sub-question of cauchy-schwarz-oq-03 (Hölder), continuing the Cauchy–Schwarz → Hölder → interpolation ladder.",
+    "problemStatement": "For a finitely-supported nonnegative f and exponents p, q, r > 0 with 1/r = θ/p + (1-θ)/q and θ ∈ (0,1), prove the discrete interpolation inequality (∑ f_i^r)^{1/r} ≤ (∑ f_i^p)^{θ/p}·(∑ f_i^q)^{(1-θ)/q}, i.e. ‖f‖_r ≤ ‖f‖_p^θ·‖f‖_q^{1-θ}. Equivalently, show that t ↦ log‖f‖_{1/t} is convex (the L^p norms are logarithmically convex in the reciprocal exponent), with the θ = 1/2 midpoint face giving the geometric-mean interpolation ‖f‖_r ≤ (‖f‖_p‖f‖_q)^{1/2} of which Cauchy–Schwarz (p = q) is the diagonal instance.",
+    "proofStrategy": "1. **Split the summand.** Write f_i^r = f_i^{rθ}·f_i^{r(1-θ)} using the zero-safe NNReal.rpow_add' (valid at f_i = 0 since rθ + r(1-θ) = r ≠ 0), so vanishing coordinates need no separate case.\n\n2. **Build the conjugate pair.** Set a = p/(rθ), b = q/(r(1-θ)). The interpolation constraint 1/r = θ/p + (1-θ)/q multiplied by r is exactly 1/a + 1/b = 1, so (a,b) is a Hölder-conjugate pair; the Real.HolderConjugate witness is assembled as an anonymous structure with the reciprocal identity (field_simp + nlinarith) and positivity from p,q,r,θ > 0, 1-θ > 0.\n\n3. **Apply Hölder once.** NNReal.inner_le_Lp_mul_Lq on the split gives ∑ f_i^r ≤ (∑ (f_i^{rθ})^a)^{1/a}·(∑ (f_i^{r(1-θ)})^b)^{1/b}; NNReal.rpow_mul collapses (f_i^{rθ})^a = f_i^p and (f_i^{r(1-θ)})^b = f_i^q.\n\n4. **Raise to 1/r.** Apply NNReal.rpow_le_rpow (monotone, exponent 1/r ≥ 0) and distribute with NNReal.mul_rpow; the exponent bookkeeping (1/a)(1/r) = θ/p, (1/b)(1/r) = (1-θ)/q yields the stated bound.\n\n5. **Midpoint corollary.** Specialize θ = 1/2 and fold the two 1/2-powers with rpow_mul to obtain the geometric-mean face 2/r = 1/p + 1/q.",
+    "keyInsights": [
+      "**Interpolation is Hölder in disguise.** The entire log-convexity statement is a single application of Hölder — the only 'idea' is choosing the exponent pair a = p/(rθ), b = q/(r(1-θ)). No induction, no measure theory, no complex analysis.",
+      "**The interpolation identity *is* Hölder conjugacy.** The constraint 1/r = θ/p + (1-θ)/q, multiplied by r, reads 1/a + 1/b = 1 exactly. The geometric hypothesis of interpolation and the algebraic hypothesis of Hölder are the same equation viewed through the substitution.",
+      "**Log-convexity as the organizing principle.** The inequality says t ↦ log‖f‖_{1/t} is convex; Cauchy–Schwarz and Hölder are then not separate theorems but the boundary/diagonal *faces* of one convex curve, which is why the θ = 1/2, p = q instance reproduces Cauchy–Schwarz.",
+      "**Zero-safety via rpow_add'.** Working in ℝ≥0 with the zero-aware NNReal.rpow_add' lets the summand split f_i^r = f_i^{rθ}·f_i^{r(1-θ)} hold even when f_i = 0, eliminating the case split that plagues real-valued formulations where 0^0 conventions bite.",
+      "**Discrete shadow of Riesz–Thorin.** The same convexity that here costs one Hölder call is, in the measure/operator setting, the Riesz–Thorin theorem proved by the complex-analytic Thorin trick — a reminder that the scalar log-convexity is the elementary kernel underneath the operator interpolation theory."
+    ],
+    "prerequisites": [
+      "Cauchy–Schwarz and Hölder's inequality for finite sums (the parent cauchy-schwarz-oq-03)",
+      "Hölder-conjugate exponents 1/a + 1/b = 1 and the Real.HolderConjugate structure",
+      "Real powers of nonnegative reals: rpow_add', rpow_mul, mul_rpow, and monotonicity rpow_le_rpow",
+      "Convex functions and the meaning of log-convexity (convexity of t ↦ log‖f‖_{1/t})"
+    ]
+  },
   "sections": [
     {
       "id": "lp-interpolation",
@@ -85,6 +103,75 @@
       "startLine": 92,
       "endLine": 113,
       "mathContext": "$\\|f\\|_r \\leq \\left(\\|f\\|_p\\,\\|f\\|_q\\right)^{1/2}$ with $\\tfrac2r = \\tfrac1p + \\tfrac1q$; the geometric-mean face of log-convexity."
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes the discrete L^p interpolation inequality ‖f‖_r ≤ ‖f‖_p^θ·‖f‖_q^{1-θ} (1/r = θ/p + (1-θ)/q, θ ∈ (0,1)) — equivalently, that t ↦ log‖f‖_{1/t} is convex — as a single application of Hölder's inequality with the conjugate pair a = p/(rθ), b = q/(r(1-θ)). The midpoint θ = 1/2 corollary gives the geometric-mean face ‖f‖_r ≤ (‖f‖_p‖f‖_q)^{1/2}, of which Cauchy–Schwarz is the diagonal p = q instance. 0 axioms, 0 sorries, verified against Mathlib v4.26.0.",
+    "implications": "The result completes the Cauchy–Schwarz → Hölder → interpolation arc for finite sums, exhibiting all three inequalities as faces of one log-convexity phenomenon rather than as separate results. It is the elementary discrete kernel of the Riesz–Thorin interpolation theorem: the scalar log-convexity that Riesz–Thorin lifts (via the complex-analytic Thorin trick) to operators between L^p spaces. Formally, it demonstrates the pattern of *reducing an interpolation statement to conjugate-exponent bookkeeping* — the interpolation constraint and Hölder conjugacy are the same equation — and the value of working in ℝ≥0 with zero-safe rpow lemmas to avoid case splits.",
+    "openQuestions": [
+      "Extend the discrete inequality to the measure-theoretic statement ‖f‖_{L^r(μ)} ≤ ‖f‖_{L^p(μ)}^θ·‖f‖_{L^q(μ)}^{1-θ} for a general measure space, recovering the standard L^p interpolation from the finite-sum case by monotone convergence.",
+      "Formalize the full operator-valued Riesz–Thorin theorem, of which this scalar log-convexity is the θ-line special case, including the complex-analytic three-lines / Thorin-trick argument.",
+      "Characterize the equality case: ‖f‖_r = ‖f‖_p^θ·‖f‖_q^{1-θ} holds iff f is (essentially) a single-atom / constant-on-support configuration, mirroring the Hölder equality condition (cf. cauchy-schwarz-oq-03-oq-01).",
+      "Derive the three-exponent Lyapunov inequality and the general finite-family log-convexity ‖f‖_{1/(∑ θ_i t_i)} ≤ ∏ ‖f‖_{1/t_i}^{θ_i} by iterating this two-point interpolation."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Hölder, Otto",
+      "title": "Über einen Mittelwertssatz",
+      "year": "1889",
+      "venue": "Nachrichten von der Königl. Gesellschaft der Wissenschaften zu Göttingen",
+      "note": "Introduces the inequality (∑ a_i b_i) ≤ (∑ a_i^p)^{1/p}(∑ b_i^q)^{1/q}; the single tool from which the interpolation inequality here is derived."
+    },
+    {
+      "authors": "Riesz, Marcel",
+      "title": "Sur les maxima des formes bilinéaires et sur les fonctionnelles linéaires",
+      "year": "1926",
+      "venue": "Acta Mathematica 49, 465–497",
+      "note": "The original real-variable convexity theorem: log of the operator bound is convex in the exponents — the interpolation phenomenon whose scalar face is proved here."
+    },
+    {
+      "authors": "Thorin, G. Olof",
+      "title": "Convexity theorems generalizing those of M. Riesz and Hadamard with some applications",
+      "year": "1948",
+      "venue": "Comm. Sém. Math. Univ. Lund 9, 1–58",
+      "note": "The complex-analytic 'Thorin trick' recasting Riesz's theorem into the sharp Riesz–Thorin interpolation theorem for L^p operators."
+    },
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Classical reference for Hölder, the log-convexity of L^p norms, and the Lyapunov (three-exponent) inequality."
+    },
+    {
+      "authors": "Wikipedia",
+      "title": "Interpolation inequality",
+      "year": "—",
+      "venue": "en.wikipedia.org/wiki/Interpolation_inequality",
+      "note": "Overview of interpolation inequalities and the L^p log-convexity statement formalized in this entry."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-03",
+      "relationship": "extends",
+      "description": "The direct parent: develops Hölder's inequality for finite sums as the generalization of Cauchy–Schwarz. This entry pushes one step further, using that Hölder inequality (via Mathlib's NNReal.inner_le_Lp_mul_Lq) exactly once to obtain the interpolation / log-convexity inequality."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "The root Cauchy–Schwarz inequality, which appears here as the diagonal face θ = 1/2, p = q of the log-convexity family — Cauchy–Schwarz is the symmetric midpoint instance of interpolation."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Sibling sub-question characterizing the Cauchy–Schwarz equality case; the analogous equality condition for this interpolation inequality (single-atom/constant-on-support f) is listed as an open question here."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-03-oq-02",
+      "relationship": "related",
+      "description": "Sibling sub-question deriving Minkowski's inequality from Hölder. Both entries build a further named inequality (Minkowski / L^p interpolation) on top of the same parent Hölder inequality, illustrating Hölder as the common engine."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-03-oq-03`.

The entry had rich annotations and sections but no `overview`, `conclusion`, `references`, or `crossReferences`. Added:

- **overview**: historicalContext (Cauchy–Schwarz → Hölder 1889 → Riesz 1926 → Thorin 1948 lineage), problemStatement, step-by-step proofStrategy, 5 keyInsights, prerequisites
- **conclusion**: summary, implications, 4 openQuestions (measure-theoretic extension, full Riesz–Thorin, equality case, Lyapunov iteration)
- **references**: Hölder 1889, Riesz 1926, Thorin 1948, Hardy–Littlewood–Pólya, Wikipedia
- **crossReferences**: parent Hölder (oq-03, extends), root Cauchy–Schwarz, siblings oq-03-oq-01 and oq-03-oq-02

meta.json is 15 KB — well under the ~60 KB cap; no collections near their caps. Annotations already complete (all structured fields present); left unchanged. Axiom status unchanged (0 axioms, verified, badge mathlib). JSON validated.