### PR TITLE
research(fibonacci-identities-oq-02-oq-02): general Lucas sequences are divisibility sequences, m∣n⟹Uₘ∣Uₙ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean
@@ -1,0 +1,152 @@
+/-
+  binomial-theorem-oq-01-oq-01-oq-03:
+  "The closed form C(-1/2, k) = (-1)^k · C(2k,k) / 4^k, connecting the
+   generalized (Newton) binomial coefficient at α = -1/2 to the central
+   binomial coefficients and the Catalan numbers."
+  ====================================================
+
+  Verified: all theorems compile against Mathlib (lean v4.26.0) and depend only
+  on the foundational axioms `propext`, `Classical.choice`, `Quot.sound`
+  (0 sorries, 0 `axiom` declarations, no `native_decide`).
+
+  The parent gallery proof `binomial-theorem-oq-01-oq-01`
+  (proofs/Proofs/BinomialTheoremOQ01OQ01.lean) provides:
+    * `genBinom α k = (∏ j ∈ range k, (α - j)) / k!`   — the coefficient C(α,k)
+    * `ode_recurrence α k : (k+1) · C(α,k+1) = (α-k) · C(α,k)`
+    * concrete values of the POSITIVE half-integer coefficients C(1/2,k) at
+      small k (k ≤ 3), with the observation that they are eventually nonzero.
+
+  That parent stops at ad-hoc small-k evaluation.  This OQ delivers the general
+  UNIFORM closed form for the NEGATIVE half-integer coefficient — the one that
+  actually appears in analysis, as the Taylor coefficients of (1+x)^(-1/2) =
+  1/√(1+x):
+
+        C(-1/2, k) = (-1)^k · C(2k, k) / 4^k
+                   = (-1)^k · centralBinom k / 4^k
+                   = (-1)^k · (k+1) · catalan k / 4^k.
+
+  These are the coefficients underlying the generating function of the central
+  binomial coefficients, √(1-4x) = 1 - 2 ∑_{k≥1} catalan(k-1) x^k, and the fact
+  that ∑ centralBinom k · x^k = 1/√(1-4x).
+
+  Proof strategy: a single induction on k using the parent's `ode_recurrence`
+  together with Mathlib's central-binomial recurrence
+    `Nat.succ_mul_centralBinom_succ n :
+        (n+1) · centralBinom (n+1) = 2·(2n+1) · centralBinom n`.
+  The two recurrences have matching ratios:
+    C(-1/2, n+1)/C(-1/2, n) = (-1/2 - n)/(n+1) = -(2n+1)/(2(n+1)),
+    [(-1)^{n+1} cb_{n+1}/4^{n+1}] / [(-1)^n cb_n/4^n]
+        = -cb_{n+1}/(4 cb_n) = -(2n+1)/(2(n+1)),
+  so a `linear_combination` of the two recurrences plus the inductive hypothesis
+  closes the step exactly.
+-/
+import Mathlib
+import Proofs.BinomialTheoremOQ01OQ01
+
+open Finset Nat
+
+namespace BinomialTheoremOQ01OQ01OQ03
+
+open BinomialTheoremOQ01OQ01
+
+/-! ### The central-binomial recurrence, cast to `ℝ` -/
+
+/-- Mathlib's `Nat.succ_mul_centralBinom_succ`, transported to `ℝ`:
+    `(n+1) · centralBinom (n+1) = 2·(2n+1) · centralBinom n`. -/
+theorem centralBinom_rec_real (n : ℕ) :
+    ((n : ℝ) + 1) * (Nat.centralBinom (n + 1) : ℝ)
+      = 2 * (2 * (n : ℝ) + 1) * (Nat.centralBinom n : ℝ) := by
+  have h := congrArg (Nat.cast : ℕ → ℝ) (Nat.succ_mul_centralBinom_succ n)
+  push_cast at h
+  linarith
+
+/-! ### Multiplied-through closed form (division-free) -/
+
+/-- The division-free form of the closed formula:
+    `C(-1/2, k) · 4^k = (-1)^k · centralBinom k`.
+    Proved by induction on `k`, cancelling the factor `(k+1)` and closing the
+    inductive step with a `linear_combination` of the two recurrences. -/
+theorem genBinom_negHalf_mul_pow (k : ℕ) :
+    genBinom (-1/2 : ℝ) k * 4 ^ k = (-1) ^ k * (Nat.centralBinom k : ℝ) := by
+  induction k with
+  | zero => simp [genBinom_zero, Nat.centralBinom_zero]
+  | succ n ih =>
+    have hn1 : ((n : ℝ) + 1) ≠ 0 := by positivity
+    have hrec := ode_recurrence (-1/2 : ℝ) n
+    have hcb := centralBinom_rec_real n
+    -- Cancel the common factor (n+1) on both sides, then close by
+    -- linear_combination of ode_recurrence, ih, and the central recurrence.
+    apply mul_left_cancel₀ hn1
+    linear_combination (4 * 4 ^ n) * hrec + (4 * (-1/2 - (n : ℝ))) * ih
+      + ((-1 : ℝ) ^ n) * hcb
+
+/-! ### Main closed forms -/
+
+/-- **Main result.** `C(-1/2, k) = (-1)^k · centralBinom k / 4^k`. -/
+theorem genBinom_negHalf (k : ℕ) :
+    genBinom (-1/2 : ℝ) k = (-1) ^ k * (Nat.centralBinom k : ℝ) / 4 ^ k := by
+  rw [eq_div_iff (by positivity : (4 : ℝ) ^ k ≠ 0)]
+  exact genBinom_negHalf_mul_pow k
+
+/-- The same, written with the explicit central binomial coefficient
+    `C(2k, k)`: `C(-1/2, k) = (-1)^k · C(2k,k) / 4^k`. -/
+theorem genBinom_negHalf_choose (k : ℕ) :
+    genBinom (-1/2 : ℝ) k = (-1) ^ k * ((2 * k).choose k : ℝ) / 4 ^ k := by
+  rw [genBinom_negHalf, Nat.centralBinom_eq_two_mul_choose]
+
+/-- Catalan form: `C(-1/2, k) = (-1)^k · (k+1) · catalan k / 4^k`, using the
+    identity `(k+1)·catalan k = centralBinom k`. -/
+theorem genBinom_negHalf_catalan (k : ℕ) :
+    genBinom (-1/2 : ℝ) k
+      = (-1) ^ k * (((k : ℝ) + 1) * (catalan k : ℝ)) / 4 ^ k := by
+  rw [genBinom_negHalf]
+  have h : ((Nat.centralBinom k : ℝ)) = ((k : ℝ) + 1) * (catalan k : ℝ) := by
+    have := congrArg (Nat.cast : ℕ → ℝ) (succ_mul_catalan_eq_centralBinom k)
+    push_cast at this
+    linarith
+  rw [h]
+
+/-! ### Sign and nonvanishing -/
+
+/-- The negative half-integer coefficient is strictly alternating in sign:
+    it never vanishes.  (Contrast the positive case `C(1/2,k)`, whose parent
+    proof establishes nonvanishing only for small `k`.) -/
+theorem genBinom_negHalf_ne_zero (k : ℕ) : genBinom (-1/2 : ℝ) k ≠ 0 := by
+  rw [genBinom_negHalf]
+  have hcb : (Nat.centralBinom k : ℝ) ≠ 0 := by
+    exact_mod_cast (Nat.centralBinom_pos k).ne'
+  have h4 : (4 : ℝ) ^ k ≠ 0 := by positivity
+  have hsign : ((-1 : ℝ) ^ k) ≠ 0 := pow_ne_zero k (by norm_num)
+  exact div_ne_zero (mul_ne_zero hsign hcb) h4
+
+/-- The absolute value of the coefficient is `centralBinom k / 4^k`, a positive
+    rational strictly decreasing to `0` — the Wallis-type decay of the Taylor
+    coefficients of `1/√(1+x)`. -/
+theorem abs_genBinom_negHalf (k : ℕ) :
+    |genBinom (-1/2 : ℝ) k| = (Nat.centralBinom k : ℝ) / 4 ^ k := by
+  rw [genBinom_negHalf, abs_div, abs_mul]
+  have h4 : |(4 : ℝ) ^ k| = 4 ^ k := abs_of_pos (by positivity)
+  have hcb : |(Nat.centralBinom k : ℝ)| = (Nat.centralBinom k : ℝ) := Nat.abs_cast _
+  have hsign : |(-1 : ℝ) ^ k| = 1 := by
+    rw [abs_pow]; simp
+  rw [h4, hcb, hsign, one_mul]
+
+/-! ### Concrete values (sanity checks against the parent's small-`k` data) -/
+
+/-- `C(-1/2, 0) = 1`. -/
+theorem genBinom_negHalf_zero : genBinom (-1/2 : ℝ) 0 = 1 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom]
+
+/-- `C(-1/2, 1) = -1/2`. -/
+theorem genBinom_negHalf_one : genBinom (-1/2 : ℝ) 1 = -1/2 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom, Nat.choose]
+
+/-- `C(-1/2, 2) = 3/8`. -/
+theorem genBinom_negHalf_two : genBinom (-1/2 : ℝ) 2 = 3/8 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom, Nat.choose]
+
+/-- `C(-1/2, 3) = -5/16`. -/
+theorem genBinom_negHalf_three : genBinom (-1/2 : ℝ) 3 = -5/16 := by
+  rw [genBinom_negHalf]; norm_num [Nat.centralBinom, Nat.choose]
+
+end BinomialTheoremOQ01OQ01OQ03

--- a/proofs/Proofs/FibonacciIdentitiesOQ02OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02OQ02.lean
@@ -1,0 +1,167 @@
+import Mathlib
+
+/-
+# General Lucas sequences are divisibility sequences: `m ∣ n → U_m ∣ U_n`
+
+The parent entry `fibonacci-identities-oq-02` shows the Fibonacci numbers form a
+*strong divisibility sequence*: `fib m ∣ fib n ↔ m ∣ n` (for `3 ≤ m`), leaning on
+Mathlib's `Nat.fib_gcd` / `Nat.fib_dvd`.  A sibling (`oq-02-oq-01`) shows the
+*companion* Lucas numbers `Lₙ` are **not** a divisibility sequence.
+
+This entry answers the open question:
+
+> *Does the divisibility characterization extend to a general Lucas sequence of
+> the first kind `Uₙ(P, Q)`?*
+
+We introduce, from scratch, the first-kind Lucas sequence over `ℤ`
+
+  `U₀ = 0,  U₁ = 1,  U_{n+2} = P · U_{n+1} − Q · Uₙ`,
+
+so that `Uₙ(1, −1) = fib n`, and prove the **forward divisibility direction for
+every choice of parameters**:
+
+  **`m ∣ n → Uₙ(P, Q) is divisible by Uₘ(P, Q)`   (all `P Q : ℤ`).**
+
+This is the genuinely general statement: unlike the full `↔`, the divisibility
+direction needs *no* coprimality or growth hypothesis on `(P, Q)` — it is a
+purely formal consequence of the index-addition law
+
+  `U_{m+n+1} = U_{m+1} · U_{n+1} − Q · Uₘ · Uₙ`.
+
+Mathlib records this only for `fib` (`Nat.fib_dvd`); here it is derived for the
+whole two-parameter family, and the Fibonacci case is recovered as a corollary
+*without* invoking `Nat.fib_dvd`, giving an independent proof.
+
+### Scope and honesty
+
+Only the forward direction (`m ∣ n → Uₘ ∣ Uₙ`) is universal.  The converse
+(`Uₘ ∣ Uₙ → m ∣ n`) genuinely requires extra hypotheses: `gcd(P, Q) = 1` for the
+strong-divisibility law `gcd(Uₘ, Uₙ) = U_{gcd(m,n)}`, plus a monotonicity/growth
+condition to invert `U` — witness the companion Lucas numbers of `oq-02-oq-01`,
+which fail it.  The converse is left as recorded future work; nothing here claims
+it.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace FibonacciIdentitiesOQ02OQ02
+
+/-- The **first-kind Lucas sequence** `Uₙ(P, Q)` over `ℤ`:
+`U₀ = 0`, `U₁ = 1`, `U_{n+2} = P · U_{n+1} − Q · Uₙ`.
+For `(P, Q) = (1, −1)` this is the Fibonacci sequence. -/
+def lucasU (P Q : ℤ) : ℕ → ℤ
+  | 0 => 0
+  | 1 => 1
+  | (n + 2) => P * lucasU P Q (n + 1) - Q * lucasU P Q n
+
+@[simp] theorem lucasU_zero (P Q : ℤ) : lucasU P Q 0 = 0 := rfl
+
+@[simp] theorem lucasU_one (P Q : ℤ) : lucasU P Q 1 = 1 := rfl
+
+/-- The defining recurrence, as a rewrite lemma. -/
+theorem lucasU_add_two (P Q : ℤ) (n : ℕ) :
+    lucasU P Q (n + 2) = P * lucasU P Q (n + 1) - Q * lucasU P Q n := rfl
+
+@[simp] theorem lucasU_two (P Q : ℤ) : lucasU P Q 2 = P := by
+  rw [lucasU_add_two]; simp
+
+/-- **Index-addition law.** `U_{m+n+1} = U_{m+1} · U_{n+1} − Q · Uₘ · Uₙ`.
+
+Proved by a single induction on `n` carrying the statement for both `n` and
+`n+1` (the sequence is second-order, so two consecutive instances are needed to
+push the recurrence one step). -/
+theorem lucasU_add (P Q : ℤ) (m n : ℕ) :
+    lucasU P Q (m + n + 1)
+      = lucasU P Q (m + 1) * lucasU P Q (n + 1) - Q * lucasU P Q m * lucasU P Q n := by
+  suffices h : ∀ n,
+      (lucasU P Q (m + n + 1)
+          = lucasU P Q (m + 1) * lucasU P Q (n + 1) - Q * lucasU P Q m * lucasU P Q n) ∧
+      (lucasU P Q (m + (n + 1) + 1)
+          = lucasU P Q (m + 1) * lucasU P Q (n + 2) - Q * lucasU P Q m * lucasU P Q (n + 1))
+    from (h n).1
+  intro n
+  induction n with
+  | zero =>
+    refine ⟨?_, ?_⟩
+    · -- `U (m+1) = U (m+1) * U 1 - Q * U m * U 0`
+      simp
+    · -- `U (m+2) = U (m+1) * U 2 - Q * U m * U 1`
+      rw [show m + (0 + 1) + 1 = m + 2 by omega, lucasU_add_two,
+        show (0 : ℕ) + 2 = 2 by rfl, show (0 : ℕ) + 1 = 1 by rfl,
+        lucasU_two, lucasU_one]
+      ring
+  | succ n ih =>
+    obtain ⟨ih1, ih2⟩ := ih
+    refine ⟨ih2, ?_⟩
+    -- Goal `A (n+2)`: `U (m+(n+2)+1) = U (m+1) * U (n+3) - Q * U m * U (n+2)`.
+    -- Rewrite the index `m+(n+2)+1 = (m+n+1)+2` and unfold the recurrence.
+    rw [show m + (n + 1 + 1) + 1 = (m + n + 1) + 2 by omega, lucasU_add_two]
+    -- Now LHS = P * U (m+n+2) - Q * U (m+n+1).
+    -- Note `m+n+1+1 = m+(n+1)+1`, so `U (m+n+2)` is the head of `ih2`.
+    rw [show m + n + 1 + 1 = m + (n + 1) + 1 by omega, ih2, ih1]
+    -- Reduce `U (n+3)` and `U (n+2)` to the recurrence in terms of `U (n+1), U n`.
+    have hU3 : lucasU P Q (n + 1 + 2) = P * lucasU P Q (n + 2) - Q * lucasU P Q (n + 1) := by
+      rw [lucasU_add_two]
+    have hU2 : lucasU P Q (n + 2) = P * lucasU P Q (n + 1) - Q * lucasU P Q n := by
+      rw [lucasU_add_two]
+    rw [show n + 1 + 1 = n + 2 by omega, hU3, hU2]
+    ring
+
+/-- **Self-divisibility along multiples.** `Uₘ ∣ U_{k·m}` for all `k`.
+Induction on `k` using the index-addition law to split `U_{(k+1)m}`. -/
+theorem lucasU_dvd_mul (P Q : ℤ) (m k : ℕ) :
+    lucasU P Q m ∣ lucasU P Q (k * m) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    rcases Nat.eq_zero_or_pos m with hm | hm
+    · subst hm; simp
+    · -- Write `m = m' + 1`.
+      obtain ⟨m', rfl⟩ : ∃ m', m = m' + 1 := ⟨m - 1, by omega⟩
+      -- `(k+1)*(m'+1) = (k*(m'+1)) + m' + 1`, matching the `U_{a+b+1}` shape with
+      -- `a = k*(m'+1)`, `b = m'`.
+      have eidx : (k + 1) * (m' + 1) = (k * (m' + 1)) + m' + 1 := by ring
+      rw [eidx, lucasU_add]
+      -- `U (k*(m'+1)+1) * U (m'+1) - Q * U (k*(m'+1)) * U m'`.
+      -- First summand divisible by `U (m'+1)` (explicit factor); second because
+      -- `U (m'+1) ∣ U (k*(m'+1))` by the induction hypothesis.
+      apply dvd_sub
+      · exact Dvd.intro_left _ rfl
+      · exact Dvd.dvd.mul_right (Dvd.dvd.mul_left ih _) _
+
+/-- **Forward divisibility for every Lucas sequence of the first kind.**
+`m ∣ n → Uₘ(P,Q) ∣ Uₙ(P,Q)` for all `P Q : ℤ`. -/
+theorem lucasU_dvd_of_dvd (P Q : ℤ) {m n : ℕ} (h : m ∣ n) :
+    lucasU P Q m ∣ lucasU P Q n := by
+  obtain ⟨k, rfl⟩ := h
+  rw [mul_comm m k]
+  exact lucasU_dvd_mul P Q m k
+
+/-! ### Fibonacci is the case `(P, Q) = (1, −1)`
+
+We identify `lucasU 1 (-1)` with `Nat.fib`, then recover the parent's
+`fib m ∣ fib n` corollary as a specialization — an independent proof that does
+not call `Nat.fib_dvd`. -/
+
+/-- `Uₙ(1, −1) = fib n`. -/
+theorem lucasU_fib (n : ℕ) : lucasU 1 (-1) n = (Nat.fib n : ℤ) := by
+  suffices h : ∀ n, lucasU 1 (-1) n = (Nat.fib n : ℤ) ∧
+      lucasU 1 (-1) (n + 1) = (Nat.fib (n + 1) : ℤ) from (h n).1
+  intro n
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    obtain ⟨ih0, ih1⟩ := ih
+    refine ⟨ih1, ?_⟩
+    rw [lucasU_add_two, ih0, ih1, Nat.fib_add_two]
+    push_cast
+    ring
+
+/-- Fibonacci divisibility recovered from the general theorem, independently of
+`Nat.fib_dvd`: `m ∣ n → fib m ∣ fib n`. -/
+theorem fib_dvd_of_dvd {m n : ℕ} (h : m ∣ n) : Nat.fib m ∣ Nat.fib n := by
+  have hz : lucasU 1 (-1) m ∣ lucasU 1 (-1) n := lucasU_dvd_of_dvd 1 (-1) h
+  rw [lucasU_fib, lucasU_fib] at hz
+  exact_mod_cast hz
+
+end FibonacciIdentitiesOQ02OQ02

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-centralbinom-rec-real",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 56, "endLine": 61 },
+    "type": "theorem",
+    "title": "The central-binomial recurrence, cast to ℝ",
+    "content": "Mathlib's `Nat.succ_mul_centralBinom_succ` states `(n+1)·centralBinom(n+1) = 2·(2n+1)·centralBinom(n)` over ℕ. To use it inside a real-valued induction it must live in ℝ, so we apply `congrArg (Nat.cast : ℕ → ℝ)`, then `push_cast` distributes the cast across the products and successors, and `linarith` closes the resulting real identity. This cast recurrence is the bridge whose ratio `centralBinom(n+1)/centralBinom(n) = 2(2n+1)/(n+1)` matches the coefficient ratio coming from the parent's ODE recurrence.",
+    "mathContext": "$(n+1)\\,\\binom{2(n+1)}{n+1} = 2(2n+1)\\,\\binom{2n}{n}$ transported to $\\mathbb{R}$. Equivalently $\\frac{\\mathrm{cb}_{n+1}}{\\mathrm{cb}_n} = \\frac{2(2n+1)}{n+1}$, the exact ratio needed to match $\\frac{C(-1/2,\\,n+1)}{C(-1/2,\\,n)} = -\\frac{2n+1}{2(n+1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficients", "recurrence relations", "Nat.cast / push_cast", "matching-ratio induction"],
+    "prerequisites": ["central binomial coefficients", "casting ℕ identities into ℝ"]
+  },
+  {
+    "id": "ann-genbinom-neghalf-mul-pow",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 69, "endLine": 81 },
+    "type": "theorem",
+    "title": "Division-free closed form (the core induction)",
+    "content": "The heart of the entry: `C(-1/2, k)·4^k = (-1)^k·centralBinom(k)`, cleared of the `4^k` denominator so the induction stays polynomial. The base case is `simp` on `genBinom_zero` and `centralBinom_zero`. For the step, the common factor `(n+1)` is stripped with `mul_left_cancel₀`, then a single `linear_combination` — weighting the parent's `ode_recurrence` by `4·4^n`, the inductive hypothesis by `4·(-1/2 - n)`, and the real central recurrence by `(-1)^n` — closes the goal exactly. This is where the two matching ratios are algebraically fused.",
+    "mathContext": "$C(-1/2,k)\\,4^{k} = (-1)^{k}\\,\\mathrm{cb}_k$. Induction: assuming it at $n$, multiply the ODE recurrence $(n+1)C(-1/2,n+1) = (-1/2-n)C(-1/2,n)$ by $4^{n+1}$ and substitute both the hypothesis and $\\mathrm{cb}_{n+1} = \\tfrac{2(2n+1)}{n+1}\\mathrm{cb}_n$ to obtain the claim at $n+1$.",
+    "significance": "critical",
+    "relatedConcepts": ["generalized binomial coefficient", "linear_combination tactic", "induction", "mul_left_cancel₀", "Newton series of 1/√(1+x)"],
+    "prerequisites": ["the parent's ODE recurrence for C(α,k)", "the central-binomial recurrence over ℝ"]
+  },
+  {
+    "id": "ann-genbinom-neghalf-main",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 86, "endLine": 89 },
+    "type": "theorem",
+    "title": "Main closed form C(-1/2, k) = (-1)^k·centralBinom(k)/4^k",
+    "content": "The headline identity, recovered from the division-free version by reintroducing the `4^k` denominator via `eq_div_iff` (valid since `4^k ≠ 0`). Its companion `genBinom_negHalf_choose` immediately rewrites `centralBinom k` as `(2k).choose k` to display the fully explicit `C(-1/2,k) = (-1)^k·C(2k,k)/4^k`. These are exactly the Taylor coefficients of `(1+x)^(-1/2) = 1/√(1+x)`.",
+    "mathContext": "$\\binom{-1/2}{k} = \\frac{(-1)^k}{4^k}\\binom{2k}{k}$, the coefficients of $\\frac{1}{\\sqrt{1+x}} = \\sum_{k\\ge 0}\\binom{-1/2}{k}x^k$. Uniform in $k$, where the parent proof only evaluated the positive coefficient $C(1/2,k)$ at small $k$.",
+    "significance": "critical",
+    "relatedConcepts": ["Newton's generalized binomial theorem", "generating function of central binomial coefficients", "eq_div_iff", "Taylor series of 1/√(1+x)"],
+    "prerequisites": ["the division-free closed form", "generalized binomial coefficients"]
+  },
+  {
+    "id": "ann-genbinom-neghalf-catalan",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 99, "endLine": 107 },
+    "type": "theorem",
+    "title": "Catalan form via (k+1)·catalan(k) = centralBinom(k)",
+    "content": "Rewrites the main formula through Mathlib's `succ_mul_catalan_eq_centralBinom` (cast to ℝ with `push_cast`/`linarith`) to expose the Catalan number: `C(-1/2,k) = (-1)^k·(k+1)·catalan(k)/4^k`. This is the algebraic shadow of the generating-function identity `√(1-4x) = 1 - 2∑_{k≥1} catalan(k-1) x^k`, tying the half-integer binomial coefficient directly to the Catalan sequence.",
+    "mathContext": "$\\binom{-1/2}{k} = \\frac{(-1)^k (k+1)\\,C_k}{4^k}$ where $C_k$ is the $k$-th Catalan number, using $(k+1)C_k = \\binom{2k}{k}$. Connects the analytic $1/\\sqrt{1+x}$ coefficients to the combinatorial Catalan generating function $\\frac{1-\\sqrt{1-4x}}{2x}$.",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "central binomial coefficients", "generating functions", "√(1-4x) expansion"],
+    "prerequisites": ["Catalan's formula (k+1)·catalan k = centralBinom k", "the main closed form"]
+  },
+  {
+    "id": "ann-abs-genbinom-neghalf",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 125, "endLine": 132 },
+    "type": "theorem",
+    "title": "Strict alternation and Wallis-type magnitude decay",
+    "content": "Two structural consequences proved uniformly for all k. `genBinom_negHalf_ne_zero` shows the coefficient never vanishes — it strictly alternates in sign — because `centralBinom k > 0`; contrast the parent, which established nonvanishing of the positive coefficient only for small k. `abs_genBinom_negHalf` computes the magnitude `|C(-1/2,k)| = centralBinom(k)/4^k`, the positive rational that decays to 0 like Wallis' product — the actual size of the Taylor coefficients of `1/√(1+x)`.",
+    "mathContext": "$\\bigl|\\binom{-1/2}{k}\\bigr| = \\frac{\\binom{2k}{k}}{4^k} \\sim \\frac{1}{\\sqrt{\\pi k}}$ by Wallis/Stirling asymptotics, a strictly decreasing positive sequence; and $\\binom{-1/2}{k}\\ne 0$ for every $k$ with sign $(-1)^k$.",
+    "significance": "key",
+    "relatedConcepts": ["sign alternation", "Wallis product decay", "abs_pow / abs_div", "central binomial positivity"],
+    "prerequisites": ["the main closed form", "positivity of central binomial coefficients"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "binomial-theorem-oq-01-oq-01-oq-03",
+  "title": "The Closed Form C(-1/2, k) = (-1)^k·C(2k,k)/4^k: Central Binomial and Catalan Coefficients",
+  "slug": "binomial-theorem-oq-01-oq-01-oq-03",
+  "description": "Establishes the general uniform closed form for the negative half-integer generalized binomial coefficient: C(-1/2, k) = (-1)^k·C(2k,k)/4^k = (-1)^k·centralBinom(k)/4^k = (-1)^k·(k+1)·catalan(k)/4^k. These are exactly the Taylor coefficients of 1/√(1+x). The parent proof only evaluated the positive coefficient C(1/2,k) at small k; this entry gives the all-k formula for the coefficient that actually appears in analysis, together with its strict sign alternation, nonvanishing, and absolute-value decay.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ01OQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-series",
+      "central-binomial-coefficient",
+      "catalan-numbers",
+      "generating-functions",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.succ_mul_centralBinom_succ",
+        "description": "The central-binomial recurrence (n+1)·centralBinom(n+1) = 2·(2n+1)·centralBinom(n), the combinatorial engine of the induction",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom(n) = C(2n, n), converting the central binomial coefficient to the explicit binomial coefficient",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.succ_mul_catalan_eq_centralBinom",
+        "description": "(n+1)·catalan(n) = centralBinom(n), giving the Catalan form of the coefficient",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.centralBinom_pos",
+        "description": "0 < centralBinom(n), used for nonvanishing and the absolute-value identity",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      }
+    ],
+    "originalContributions": [
+      "genBinom_negHalf: the main closed form C(-1/2, k) = (-1)^k·centralBinom(k)/4^k for ALL k, proved by a single induction pairing the parent's ode_recurrence with Mathlib's central-binomial recurrence via one linear_combination",
+      "genBinom_negHalf_mul_pow: the division-free form C(-1/2, k)·4^k = (-1)^k·centralBinom(k), the actual inductive workhorse",
+      "genBinom_negHalf_choose: the explicit C(2k,k) form C(-1/2, k) = (-1)^k·C(2k,k)/4^k",
+      "genBinom_negHalf_catalan: the Catalan form C(-1/2, k) = (-1)^k·(k+1)·catalan(k)/4^k",
+      "genBinom_negHalf_ne_zero: the negative half-integer coefficient never vanishes for any k (the parent proved nonvanishing only for the positive coefficient at small k)",
+      "abs_genBinom_negHalf: |C(-1/2, k)| = centralBinom(k)/4^k, the Wallis-type magnitude of the Taylor coefficients of 1/√(1+x)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 152,
+    "assumptions": "0 axioms, 0 sorries. Every theorem depends only on the foundational axioms propext, Classical.choice, Quot.sound (no native_decide, no Lean.ofReduceBool). The closed form is derived by pure induction from the parent proof's ode_recurrence and Mathlib's central-binomial recurrence.",
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "prerequisites": [
+      "Generalized binomial coefficients genBinom and the ode_recurrence (k+1)·C(α,k+1) = (α-k)·C(α,k) (parent proof binomial-theorem-oq-01-oq-01)",
+      "Central binomial coefficients centralBinom(n) = C(2n,n) and their recurrence",
+      "Catalan numbers and the identity (n+1)·catalan(n) = centralBinom(n)"
+    ],
+    "relatedProblems": [
+      "binomial-theorem-oq-01-oq-01",
+      "binomial-theorem-oq-01-oq-01-oq-02"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Newton's generalized binomial series $(1+x)^\\alpha = \\sum_{k\\ge0}\\binom{\\alpha}{k}x^k$ specializes at $\\alpha=-1/2$ to the Taylor expansion of $1/\\sqrt{1+x}$, whose coefficients are among the most ubiquitous in combinatorics and analysis. The closed form $\\binom{-1/2}{k} = (-1)^k\\binom{2k}{k}/4^k$ is the reason the central binomial coefficients $\\binom{2k}{k}$ appear as the Taylor coefficients of $1/\\sqrt{1-4x}$ and, after one further division, why the Catalan numbers generate $(1-\\sqrt{1-4x})/(2x)$. The parent gallery proof computed only the positive coefficients $\\binom{1/2}{k}$ at $k\\le3$; this entry supplies the general all-$k$ identity for the negative coefficient.",
+    "problemStatement": "Prove, for all $k$, the closed form $\\binom{-1/2}{k} = (-1)^k\\binom{2k}{k}/4^k$, and connect it to the central binomial coefficient $\\mathrm{centralBinom}(k)=\\binom{2k}{k}$ and the Catalan number via $(k+1)\\,\\mathrm{catalan}(k)=\\mathrm{centralBinom}(k)$. Establish the sign alternation, nonvanishing for all $k$, and the absolute-value formula $|\\binom{-1/2}{k}| = \\mathrm{centralBinom}(k)/4^k$.",
+    "text": "The generalized binomial coefficient at $\\alpha=-1/2$ has the exact closed form $(-1)^k\\binom{2k}{k}/4^k$. The proof is a single induction: the parent's ode_recurrence gives the ratio $\\binom{-1/2}{k+1}/\\binom{-1/2}{k} = (-1/2-k)/(k+1)$, and Mathlib's central-binomial recurrence gives the matching ratio for $(-1)^k\\mathrm{centralBinom}(k)/4^k$. A one-line linear_combination of the two recurrences and the inductive hypothesis closes the step exactly.",
+    "proofStrategy": "Work with the division-free form $\\binom{-1/2}{k}\\cdot 4^k = (-1)^k\\,\\mathrm{centralBinom}(k)$ to keep everything polynomial. Induct on $k$. Base case: both sides are $1$ ($\\mathrm{centralBinom}(0)=1$). Inductive step: cancel the common factor $(n+1)$ using mul_left_cancel₀, then discharge the resulting identity with a single linear_combination of (i) the parent's ode_recurrence $(n+1)\\binom{-1/2}{n+1} = (-1/2-n)\\binom{-1/2}{n}$, (ii) the inductive hypothesis, and (iii) the central-binomial recurrence $(n+1)\\mathrm{centralBinom}(n+1) = 2(2n+1)\\mathrm{centralBinom}(n)$ cast to ℝ. The remaining scalar identity $4(-1/2-n) + 2(2n+1) = 0$ is closed by ring. Dividing back through by $4^k$ yields the main form; the choose and Catalan forms follow by rewriting with centralBinom_eq_two_mul_choose and succ_mul_catalan_eq_centralBinom.",
+    "keyInsights": [
+      "The two recurrences — the analytic ode_recurrence for $\\binom{\\alpha}{k}$ at $\\alpha=-1/2$ and the combinatorial central-binomial recurrence — have identical ratios $-(2n+1)/(2(n+1))$, so their solutions with matching initial value coincide term by term.",
+      "Proving the multiplied-through form $\\binom{-1/2}{k}\\cdot 4^k = (-1)^k\\,\\mathrm{centralBinom}(k)$ avoids all division inside the induction; the single division back to the stated closed form happens once, outside the induction.",
+      "After cancelling $(n+1)$, the entire inductive step reduces to one linear_combination whose scalar residue is $4(-1/2-n)+2(2n+1)=0$ — the algebraic shadow of the two ratios agreeing.",
+      "The Catalan form drops out for free because $(k+1)\\,\\mathrm{catalan}(k)=\\mathrm{centralBinom}(k)$: the negative half-integer binomial coefficient is $(-1)^k(k+1)\\,\\mathrm{catalan}(k)/4^k$.",
+      "Nonvanishing for ALL $k$ is immediate from the closed form (centralBinom is always positive), whereas the parent could only check it case-by-case for the positive coefficient at small $k$."
+    ],
+    "prerequisites": [
+      "Generalized binomial coefficients and the ode_recurrence (parent proof)",
+      "Central binomial coefficients and their recurrence",
+      "Catalan numbers and (n+1)·catalan(n) = centralBinom(n)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "central-recurrence",
+      "title": "The Central-Binomial Recurrence over ℝ",
+      "startLine": 52,
+      "endLine": 61,
+      "summary": "centralBinom_rec_real transports Mathlib's Nat.succ_mul_centralBinom_succ to ℝ: (n+1)·centralBinom(n+1) = 2·(2n+1)·centralBinom(n). This is the combinatorial half of the matching-ratios argument.",
+      "mathContext": "$(n+1)\\binom{2n+2}{n+1} = 2(2n+1)\\binom{2n}{n}$."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Closed Form by Induction",
+      "startLine": 63,
+      "endLine": 107,
+      "summary": "genBinom_negHalf_mul_pow proves the division-free form C(-1/2,k)·4^k = (-1)^k·centralBinom(k) by induction, cancelling (n+1) and closing with a single linear_combination of ode_recurrence, the inductive hypothesis, and the central recurrence. genBinom_negHalf divides back to the stated closed form; genBinom_negHalf_choose and genBinom_negHalf_catalan restate it with C(2k,k) and with (k+1)·catalan(k).",
+      "mathContext": "$\\binom{-1/2}{k} = (-1)^k\\binom{2k}{k}/4^k = (-1)^k(k+1)\\,\\mathrm{catalan}(k)/4^k$."
+    },
+    {
+      "id": "sign-nonvanishing",
+      "title": "Sign, Nonvanishing, and Magnitude",
+      "startLine": 109,
+      "endLine": 132,
+      "summary": "genBinom_negHalf_ne_zero shows the coefficient never vanishes for any k (centralBinom is positive); abs_genBinom_negHalf gives |C(-1/2,k)| = centralBinom(k)/4^k, the strictly positive magnitude of the Taylor coefficients of 1/√(1+x).",
+      "mathContext": "$\\left|\\binom{-1/2}{k}\\right| = \\binom{2k}{k}/4^k$, the Wallis-type decay."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Values",
+      "startLine": 134,
+      "endLine": 150,
+      "summary": "Sanity checks C(-1/2,0)=1, C(-1/2,1)=-1/2, C(-1/2,2)=3/8, C(-1/2,3)=-5/16, each derived from the closed form by norm_num — the alternating negatives of the parent's positive-coefficient values scaled by the central binomial pattern.",
+      "mathContext": "$1,\\ -\\tfrac12,\\ \\tfrac38,\\ -\\tfrac{5}{16},\\dots$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Eleven machine-checked theorems (0 sorries, 0 axioms beyond the foundational propext/Classical.choice/Quot.sound) establish the general closed form C(-1/2, k) = (-1)^k·C(2k,k)/4^k for all k, in central-binomial and Catalan forms, together with sign alternation, nonvanishing, and the absolute-value magnitude. The proof is a single induction pairing the parent's ode_recurrence with Mathlib's central-binomial recurrence through one linear_combination.",
+    "implications": "Upgrades the parent proof's ad-hoc small-k evaluation of the positive coefficient C(1/2,k) to the uniform all-k closed form for the analytically important negative coefficient. This is the identity that makes the central binomial coefficients the Taylor coefficients of 1/√(1-4x) and underlies the Catalan generating function; the formalization exposes it as a two-recurrence matching argument requiring no analytic machinery.",
+    "openQuestions": [
+      "Prove the generating-function identity ∑_k centralBinom(k)·x^k = 1/√(1-4x) on the disk of convergence by combining this coefficient formula with the parent's binomial_series_analytic at α = -1/2.",
+      "Derive the Catalan generating function (1-√(1-4x))/(2x) = ∑_k catalan(k)·x^k from genBinom_negHalf_catalan and the α = 1/2 series."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Upgrades the parent's small-k evaluation of the positive coefficient C(1/2,k) to the general all-k closed form for the negative coefficient C(-1/2,k), reusing the parent's ode_recurrence as the analytic half of the induction."
+    }
+  ],
+  "status": "verified",
+  "badge": "verified",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BinomialTheoremOQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "BinomialTheoremOQ01OQ01OQ03",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "key": "Ne65",
+      "citation": "Newton, I., De analysi per aequationes numero terminorum infinitas (1665, published 1711). Original generalized binomial series for non-integer exponents.",
+      "type": "paper"
+    },
+    {
+      "key": "GKP94",
+      "citation": "Graham, R. L., Knuth, D. E., Patashnik, O., Concrete Mathematics, 2nd ed., Addison-Wesley (1994), §5.3–5.4. Central binomial coefficients, the identity C(-1/2,k) = (-1)^k C(2k,k)/4^k, and Catalan generating functions.",
+      "type": "book"
+    },
+    {
+      "key": "St99",
+      "citation": "Stanley, R. P., Enumerative Combinatorics, Vol. 2, Cambridge University Press (1999), Chapter 6. Catalan numbers and their generating function.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02/annotations.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "ann-fiboq0202-1",
+    "proofId": "fibonacci-identities-oq-02-oq-02",
+    "range": { "startLine": 3, "endLine": 50 },
+    "type": "concept",
+    "title": "From Fibonacci to the Whole Lucas Family",
+    "content": "**Framing.** A first-kind *Lucas sequence* $U_n(P,Q)$ is the second-order linear recurrence $U_0=0,\\ U_1=1,\\ U_{n+2}=P\\,U_{n+1}-Q\\,U_n$. Fibonacci is the single instance $U_n(1,-1)$. The parent entry (`fibonacci-identities-oq-02`) proves the Fibonacci *biconditional* $F_m \\mid F_n \\iff m \\mid n$ using Mathlib's `Nat.fib_gcd`/`Nat.fib_dvd`, and explicitly asks to extend the divisibility law to general $U_n(P,Q)$. This entry answers the **forward direction for every $(P,Q)$**: $m \\mid n \\Rightarrow U_m \\mid U_n$, with no coprimality or growth hypothesis. That the forward direction is parameter-free — while the converse is not — is the structural point.",
+    "mathContext": "$U_0=0,\\ U_1=1,\\ U_{n+2}=P\\,U_{n+1}-Q\\,U_n$; Fibonacci $=U_n(1,-1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lucas sequences of the first kind",
+      "Divisibility sequences",
+      "Second-order linear recurrences",
+      "Strong divisibility sequences"
+    ],
+    "prerequisites": [
+      "Divisibility in a commutative ring",
+      "Linear recurrence sequences"
+    ],
+    "tags": ["module-header", "framing", "lucas-sequences"]
+  },
+  {
+    "id": "ann-fiboq0202-2",
+    "proofId": "fibonacci-identities-oq-02-oq-02",
+    "range": { "startLine": 52, "endLine": 71 },
+    "type": "definition",
+    "title": "Defining Uₙ(P,Q) from Scratch",
+    "content": "**Why a new definition.** Mathlib has `Nat.fib` but no general Lucas sequence, so `lucasU P Q : ℕ → ℤ` is introduced directly by structural recursion on the `n+2` pattern. Working over $\\mathbb{Z}$ (not $\\mathbb{N}$) is essential: for generic $(P,Q)$ the terms need not be non-negative, and the addition law involves the subtraction $-Q\\,U_mU_n$. The base/recurrence lemmas `lucasU_zero`, `lucasU_one`, `lucasU_two` ($U_2=P$) and the rewrite form `lucasU_add_two` are all definitional (`rfl`), giving clean handles for later rewriting.",
+    "mathContext": "$U_2 = P\\cdot U_1 - Q\\cdot U_0 = P$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Structural recursion", "Integer-valued sequences"],
+    "prerequisites": ["Recursive definitions on ℕ", "The Lucas recurrence"],
+    "tags": ["definition", "recurrence", "base-values"]
+  },
+  {
+    "id": "ann-fiboq0202-3",
+    "proofId": "fibonacci-identities-oq-02-oq-02",
+    "range": { "startLine": 73, "endLine": 110 },
+    "type": "technique",
+    "title": "Conjunction Induction for a Second-Order Recurrence",
+    "content": "**The index-addition law** $U_{m+n+1}=U_{m+1}U_{n+1}-Q\\,U_mU_n$ is the engine of the whole file. The proof technique is the noteworthy part: because the recurrence is *second-order*, advancing the induction on $n$ by one step consumes the statement at **two** consecutive indices. A plain `induction n` stalls with only one predecessor. The fix is to induct on the **conjunction** $A(n)\\wedge A(n+1)$: the successor step returns $\\langle A(n+1),\\,A(n+2)\\rangle$, deriving $A(n+2)$ from both components via $U_{k+2}=P\\,U_{k+1}-Q\\,U_k$. After unfolding, each step closes by `ring`.",
+    "mathContext": "$U_{m+n+1} = U_{m+1}U_{n+1} - Q\\,U_m U_n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Strong / paired induction",
+      "Two-step (Fibonacci-style) induction",
+      "Linear recurrence identities"
+    ],
+    "prerequisites": ["Induction with a strengthened hypothesis", "ring on ℤ"],
+    "tags": ["induction", "addition-formula", "proof-technique"]
+  },
+  {
+    "id": "ann-fiboq0202-4",
+    "proofId": "fibonacci-identities-oq-02-oq-02",
+    "range": { "startLine": 112, "endLine": 145 },
+    "type": "key-step",
+    "title": "Forward Divisibility Holds for All Parameters",
+    "content": "**Main theorem.** $m \\mid n \\Rightarrow U_m(P,Q) \\mid U_n(P,Q)$, for every $P,Q\\in\\mathbb{Z}$. Reduced to $U_m \\mid U_{k\\cdot m}$ (induction on $k$): writing $m=m'+1$ and applying the addition law with $a=k\\cdot m,\\ b=m'$ gives $U_{(k+1)m}=U_{k m+1}\\,U_m - Q\\,U_{k m}\\,U_{m'}$ — the first summand has the explicit factor $U_m$, the second is divisible by $U_m$ by the induction hypothesis $U_m \\mid U_{km}$. Casing $m=m'+1$ keeps every index a genuine successor, sidestepping the truncated $m-1$ of the textbook $U_{a+b}=U_aU_{b+1}-Q\\,U_{a-1}U_b$ form. **No hypothesis on $(P,Q)$ appears** — the forward law is purely formal.",
+    "mathContext": "$U_m \\mid U_{km}$ for all $k$, hence $m \\mid n \\Rightarrow U_m \\mid U_n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Divisibility sequences",
+      "Induction on multiples",
+      "dvd_sub / factor extraction"
+    ],
+    "prerequisites": ["Divisibility algebra (dvd_sub, mul factors)", "The index-addition law"],
+    "tags": ["main-result", "divisibility", "parameter-free"]
+  },
+  {
+    "id": "ann-fiboq0202-5",
+    "proofId": "fibonacci-identities-oq-02-oq-02",
+    "range": { "startLine": 147, "endLine": 167 },
+    "type": "key-step",
+    "title": "Fibonacci Recovered — and the Converse Deliberately Not Claimed",
+    "content": "**Cross-check.** $U_n(1,-1)=F_n$ is proved by the same conjunction induction ($1\\cdot U_{n+1}-(-1)U_n=U_{n+1}+U_n$ matches `Nat.fib_add_two`). Transporting the general theorem across this identity — casting $\\mathbb{Z}$-divisibility back to $\\mathbb{N}$ via `exact_mod_cast` — reproves $m \\mid n \\Rightarrow F_m \\mid F_n$ **without ever calling** `Nat.fib_dvd`, an independent confirmation the from-scratch sequence agrees with `fib`. **Honesty note:** only the forward direction is universal. The converse $U_m \\mid U_n \\Rightarrow m \\mid n$ genuinely needs $\\gcd(P,Q)=1$ (for $\\gcd(U_m,U_n)=U_{\\gcd(m,n)}$) plus growth to invert $U$; the companion Lucas numbers of `oq-02-oq-01` are a concrete counterexample, so the biconditional is left as recorded future work.",
+    "mathContext": "$U_n(1,-1)=F_n$; converse needs $\\gcd(P,Q)=1$ + monotonicity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fibonacci as a Lucas sequence",
+      "ℤ↔ℕ cast of divisibility",
+      "Scope of the biconditional"
+    ],
+    "prerequisites": ["Nat.fib recurrence", "Int/Nat divisibility cast"],
+    "tags": ["specialization", "cross-check", "honest-scope"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "fibonacci-identities-oq-02-oq-02",
+  "slug": "fibonacci-identities-oq-02-oq-02",
+  "title": "General Lucas Sequences Are Divisibility Sequences: m ∣ n ⟹ Uₘ ∣ Uₙ",
+  "sorries": 0,
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "FibonacciIdentitiesOQ02OQ02",
+    "lineCount": 167,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/FibonacciIdentitiesOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Édouard Lucas / classical Lucas-sequence theory; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_sequence#Divisibility_properties",
+    "date": "1878",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "lucas-sequences",
+      "fibonacci",
+      "divisibility",
+      "divisibility-sequence",
+      "recurrence",
+      "integer-sequences",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ02OQ02.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n+2) = fib n + fib (n+1) — the Fibonacci recurrence, used only to identify Uₙ(1,−1) with fib n in the specialization",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Int.natCast_dvd_natCast",
+        "description": "(↑a ∣ ↑b) ↔ (a ∣ b) over ℤ/ℕ — transports the ℤ-valued divisibility of Uₙ(1,−1) back to ℕ-valued fib divisibility (via exact_mod_cast)",
+        "module": "Mathlib.Data.Int.GCD"
+      }
+    ],
+    "originalContributions": [
+      "lucasU: the first-kind Lucas sequence Uₙ(P,Q) over ℤ (U₀=0, U₁=1, U_{n+2}=P·U_{n+1}−Q·Uₙ) defined from scratch — no general Lucas sequence exists in Mathlib, which has only Nat.fib",
+      "lucasU_add: the index-addition law U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ, proved by a conjunction induction that carries the statement at n and n+1 simultaneously (needed for the second-order recurrence)",
+      "lucasU_dvd_of_dvd: m ∣ n ⟹ Uₘ(P,Q) ∣ Uₙ(P,Q) for ALL P,Q : ℤ — the forward divisibility direction holds with no coprimality or growth hypothesis, generalizing Mathlib's fib-only Nat.fib_dvd to the entire two-parameter family",
+      "fib_dvd_of_dvd: Fibonacci divisibility recovered as the (P,Q)=(1,−1) instance, an independent proof that never invokes Nat.fib_dvd"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 167,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No native_decide, so no Lean.ofReduceBool. Only the FORWARD divisibility direction is proved; the converse Uₘ ∣ Uₙ ⟹ m ∣ n is not claimed here — it genuinely requires gcd(P,Q)=1 (for the strong-divisibility gcd law) plus a growth condition, and fails for the companion Lucas numbers of oq-02-oq-01.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The forward divisibility law 'm ∣ n ⟹ Uₘ ∣ Uₙ' is one of the oldest structural facts about linear recurrences, due to Lucas (1878) in his theory of the sequences Uₙ(P,Q). The Fibonacci case Uₙ(1,−1) = Fₙ is its most famous instance, but the divisibility property is entirely uniform in the parameters: it depends only on the shape of the recurrence, not on any arithmetic of P and Q. Mathlib records the Fibonacci corollary (Nat.fib_dvd) but has no general Lucas sequence at all, so the family-wide statement had no formal home.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-02, OQ #2)**: Extend the divisibility characterization to general Lucas sequences Uₙ(P,Q), identifying the hypotheses under which Uₘ ∣ Uₙ.\n\n**Result**: The FORWARD direction m ∣ n ⟹ Uₘ(P,Q) ∣ Uₙ(P,Q) holds for every P,Q : ℤ with no side hypotheses (lucasU_dvd_of_dvd). The full biconditional does NOT — its converse requires gcd(P,Q)=1 plus growth, and is left as recorded future work.",
+    "text": "Define Uₙ(P,Q) over ℤ by U₀=0, U₁=1, U_{n+2}=P·U_{n+1}−Q·Uₙ. Then for all P,Q and all m,n, m ∣ n implies Uₘ ∣ Uₙ. Specializing (P,Q)=(1,−1) recovers Fibonacci divisibility m ∣ n ⟹ Fₘ ∣ Fₙ.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Index-addition law (lucasU_add).** U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ. Because the recurrence is second-order, a plain induction on n cannot advance one step from a single instance; instead we induct proving the conjunction 'A(n) ∧ A(n+1)', so the step has both predecessors available to feed the recurrence U_{k+2}=P·U_{k+1}−Q·U_k. Base cases n=0,1 are the definitions; the step is a `ring` identity after unfolding.\n\n2. **Self-divisibility along multiples (lucasU_dvd_mul).** Uₘ ∣ U_{k·m} by induction on k. Writing m = m′+1, the addition law splits U_{(k+1)m} = U_{k·m+1}·Uₘ − Q·U_{k·m}·U_{m′}: the first summand carries the explicit factor Uₘ, the second is divisible by Uₘ because Uₘ ∣ U_{k·m} by the induction hypothesis. No natural-number subtraction is needed.\n\n3. **Forward divisibility (lucasU_dvd_of_dvd).** From m ∣ n write n = m·k and apply step 2.\n\n4. **Fibonacci specialization (lucasU_fib, fib_dvd_of_dvd).** Uₙ(1,−1) = fib n by the same conjunction induction, matching P·U_{n+1}−(−1)·Uₙ = U_{n+1}+Uₙ against fib_add_two. Transporting lucasU_dvd_of_dvd across this identity (exact_mod_cast over ℤ↔ℕ) reproves m ∣ n ⟹ fib m ∣ fib n without calling Nat.fib_dvd.",
+    "keyInsights": [
+      "**Forward divisibility is parameter-free.** m ∣ n ⟹ Uₘ ∣ Uₙ needs nothing about P and Q — it is a purely formal consequence of the additive index law, which is why it holds for the entire family while the converse does not.",
+      "**The second-order recurrence forces conjunction induction.** Carrying 'A(n) ∧ A(n+1)' through the induction is exactly what supplies the two predecessors the recurrence consumes; a single-instance induction stalls.",
+      "**Casing m = m′+1 dodges truncated subtraction.** Splitting U_{(k+1)m} via the addition law with a=k·m, b=m′ keeps every index a genuine ℕ successor, avoiding the m−1 that would appear in the textbook U_{a+b}=U_{a}U_{b+1}−Q·U_{a−1}U_b form.",
+      "**Fibonacci divisibility as a corollary, independently.** Recovering Nat.fib_dvd from the general theorem (never using Mathlib's lemma) is a genuine cross-check that the from-scratch sequence agrees with fib."
+    ],
+    "prerequisites": [
+      "Linear recurrences and the first-kind Lucas sequence Uₙ(P,Q)",
+      "Divisibility in a commutative ring (dvd_sub, Dvd.intro_left)",
+      "Induction carrying a conjunction of consecutive instances",
+      "ℤ↔ℕ cast of divisibility (Int.natCast_dvd_natCast)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The First-Kind Lucas Sequence",
+      "startLine": 52,
+      "endLine": 71,
+      "summary": "lucasU P Q : ℕ → ℤ with U₀=0, U₁=1, U_{n+2}=P·U_{n+1}−Q·Uₙ, plus the base-value and recurrence rewrite lemmas (lucasU_zero/one/two, lucasU_add_two).",
+      "mathContext": "$U_0=0,\\ U_1=1,\\ U_{n+2}=P\\,U_{n+1}-Q\\,U_n$; $U_2=P$."
+    },
+    {
+      "id": "addition-law",
+      "title": "The Index-Addition Law",
+      "startLine": 73,
+      "endLine": 110,
+      "summary": "lucasU_add: U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ, by conjunction induction on n carrying the statement at n and n+1.",
+      "mathContext": "$U_{m+n+1} = U_{m+1}U_{n+1} - Q\\,U_m U_n$."
+    },
+    {
+      "id": "forward-divisibility",
+      "title": "Forward Divisibility for Every (P,Q)",
+      "startLine": 112,
+      "endLine": 145,
+      "summary": "lucasU_dvd_mul (Uₘ ∣ U_{k·m} by induction on k) and lucasU_dvd_of_dvd (m ∣ n ⟹ Uₘ ∣ Uₙ), with no hypotheses on P, Q.",
+      "mathContext": "$m \\mid n \\Rightarrow U_m \\mid U_n$ for all $P,Q\\in\\mathbb{Z}$."
+    },
+    {
+      "id": "fibonacci-specialization",
+      "title": "Fibonacci Is the Case (1,−1)",
+      "startLine": 147,
+      "endLine": 167,
+      "summary": "lucasU_fib (Uₙ(1,−1) = fib n) and fib_dvd_of_dvd, recovering Fibonacci divisibility as a corollary independent of Nat.fib_dvd.",
+      "mathContext": "$U_n(1,-1) = F_n$, so $m \\mid n \\Rightarrow F_m \\mid F_n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-02",
+      "relationship": "extends",
+      "description": "The parent proves Fibonacci strong divisibility (Fₘ ∣ Fₙ ↔ m ∣ n) and lists 'extend to general Uₙ(P,Q)' as an open question; this entry answers its forward direction for the whole two-parameter family."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-02-oq-01",
+      "relationship": "related",
+      "description": "The companion Lucas numbers Vₙ studied there are NOT a divisibility sequence — the concrete obstruction to the converse Uₘ ∣ Uₙ ⟹ m ∣ n that this entry deliberately does not claim."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lucas, Édouard",
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "venue": "American Journal of Mathematics",
+      "note": "Origin of the sequences Uₙ(P,Q) and their divisibility properties"
+    },
+    {
+      "authors": "Ribenboim, Paulo",
+      "title": "My Numbers, My Friends: Popular Lectures on Number Theory",
+      "year": "2000",
+      "venue": "Springer",
+      "note": "Ch. 1 on Lucas sequences Uₙ(P,Q), Vₙ(P,Q) and divisibility"
+    }
+  ],
+  "conclusion": {
+    "summary": "A from-scratch first-kind Lucas sequence Uₙ(P,Q) over ℤ, with the index-addition law and the forward divisibility theorem m ∣ n ⟹ Uₘ ∣ Uₙ proved for every parameter choice (0 sorries, 0 axioms). Fibonacci divisibility is recovered as the (1,−1) instance without invoking Mathlib's Nat.fib_dvd.",
+    "implications": "Generalizes the Fibonacci-only Nat.fib_dvd to the whole two-parameter Lucas family as a universally quantified theorem, and isolates precisely which half of the parent's biconditional survives dropping all arithmetic hypotheses on (P,Q): the forward direction, and only it.",
+    "openQuestions": [
+      "Prove the converse Uₘ ∣ Uₙ ⟹ m ∣ n under gcd(P,Q)=1, via the strong-divisibility law gcd(Uₘ,Uₙ) = U_{gcd(m,n)} plus a growth/monotonicity condition to invert U.",
+      "Formalize the general strong-divisibility gcd law gcd(Uₘ,Uₙ) = U_{gcd(m,n)} for gcd(P,Q)=1, of which Mathlib's Nat.fib_gcd is the (1,−1) instance."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers **open question #2** of the parent entry `fibonacci-identities-oq-02` ("Extend the divisibility characterization to general Lucas sequences Uₙ(P,Q)").

Defines the **first-kind Lucas sequence** `Uₙ(P,Q)` over ℤ from scratch (`U₀=0, U₁=1, U_{n+2}=P·U_{n+1}−Q·Uₙ`) — Mathlib has only `Nat.fib` — and proves the **forward divisibility law for every parameter choice**:

> **`m ∣ n ⟹ Uₘ(P,Q) ∣ Uₙ(P,Q)` for all `P Q : ℤ`** — no coprimality or growth hypothesis.

This is the natural general theorem: unlike the full biconditional, the forward direction is *parameter-free*, a purely formal consequence of the index-addition law. Mathlib records it only for Fibonacci (`Nat.fib_dvd`); here it holds for the whole two-parameter family.

## Contents (9 theorems / 1 def / 167 lines)

- `lucasU` — the sequence `Uₙ(P,Q)` over ℤ, with base/recurrence lemmas (`lucasU_zero/one/two`, `lucasU_add_two`).
- `lucasU_add` — **index-addition law** `U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ`, proved by *conjunction induction* (a second-order recurrence needs both predecessors; a plain induction stalls).
- `lucasU_dvd_mul` / `lucasU_dvd_of_dvd` — `Uₘ ∣ U_{k·m}`, hence `m ∣ n ⟹ Uₘ ∣ Uₙ`. Casing `m=m′+1` keeps every index a ℕ successor, dodging truncated `m−1` subtraction.
- `lucasU_fib` / `fib_dvd_of_dvd` — `Uₙ(1,−1)=fib n`, recovering Fibonacci divisibility as a corollary **without** invoking `Nat.fib_dvd` (independent cross-check).

## Verification

- **0 sorries, 0 axioms.** `#print axioms lucasU_dvd_of_dvd` → only `propext, Classical.choice, Quot.sound`. No `native_decide` / `Lean.ofReduceBool`.
- Compiled against Mathlib (lean4 v4.26.0).

## Honest scope

Only the **forward** direction is universal. The converse `Uₘ ∣ Uₙ ⟹ m ∣ n` genuinely requires `gcd(P,Q)=1` (for the strong-divisibility gcd law) plus a growth condition to invert `U` — the companion Lucas numbers of `oq-02-oq-01` are a concrete counterexample. The biconditional is left as recorded future work; nothing here claims it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)