### PR TITLE
Enrich L^p Interpolation Inequality: add missing index.ts, fix annotation significance

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-03/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzOQ03OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchySchwarzOq03Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchySchwarzOq03Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchySchwarzOq03Oq03Data: ProofData = {
+  proof: cauchySchwarzOq03Oq03Proof,
+  annotations: cauchySchwarzOq03Oq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-03-oq-03` (The L^p Interpolation / log-convexity inequality).

## Changes
- **Added missing `index.ts`** — the entry had none, so Vite's `import.meta.glob` could not discover it and the page would render *proof not found* on the live site despite appearing in the gallery listing. This is the highest-impact fix.
- **Fixed invalid annotation `significance`** — the midpoint annotation used `"standard"`, which is not in the allowed enum (`key|supporting|technical|context`). Changed to `"supporting"`.
- **Added a technique annotation** for the zero-safe summand split `f_i^r = f_i^{rθ}·f_i^{r(1-θ)}` via `NNReal.rpow_add'` (side-condition `rθ + r(1-θ) = r ≠ 0`), covering lines 70–79 which previously had no dedicated annotation.

## Verification
- meta.json and annotations.json parse as valid JSON; gallery-enrichment prebuild links the entry.
- `index.ts` follows the canonical gallery template (raw-import depth `../../../../proofs/Proofs/CauchySchwarzOQ03OQ03.lean?raw`, matching the 599 existing entries).
- No content deleted; meta.json already meets quality targets (5 keyInsights, 4 crossRefs, 5 references, full conclusion) and stays well under the 60 KB size cap (~15 KB).