### PR TITLE
Enrich Markov Equation OQ-05: fix invalid annotation significance values

### DIFF
--- a/src/data/proofs/markov-equation-oq-05/annotations.json
+++ b/src/data/proofs/markov-equation-oq-05/annotations.json
@@ -34,7 +34,7 @@
     "title": "Reducing the Ternary Equation to a Monic Quadratic",
     "content": "markov_quadratic rearranges x² + y² + z² = 3xyz into z² − 3xy·z + (x² + y²) = 0 via a single linear_combination of the Markov equation, exhibiting z as a root of the monic quadratic g. Its two Vieta data are recorded separately: markov_vieta_sum gives the linear coefficient z + (3xy − z) = 3xy (the additive companion of the parent's product formula z·(3xy − z) = x² + y²), and markov_root_diff_sq computes the discriminant (2z − 3xy)² = 9x²y² − 4(x² + y²) by substituting z² = 3xyz − x² − y² into the expansion — the squared gap between the two roots.",
     "mathContext": "$z + (3xy - z) = 3xy, \\quad z\\,(3xy - z) = x^2+y^2, \\quad (2z-3xy)^2 = 9x^2y^2 - 4(x^2+y^2).$",
-    "significance": "standard",
+    "significance": "supporting",
     "relatedConcepts": [
       "Vieta's formulas",
       "discriminant",
@@ -79,7 +79,7 @@
     "title": "Packaging the Jump as an Involutive Permutation",
     "content": "Once the fiber is known to be a doubleton, the self-inverse map z ↦ 3xy − z deserves to be an actual permutation. vieta_involutive shows it is a Function.Involutive on ℤ, and vietaPerm := (vieta_involutive x y).toPerm realizes it as an element of Equiv.Perm ℤ of order dividing 2. vietaPerm_mem records that it preserves the Markov fiber (via the parent's markov_vieta), vietaPerm_involutive its round-trip, and vietaPerm_fixed that it fixes z exactly when 2z = 3xy. This is the correct home for a 'Vieta jump': an involution of the two-element fiber, the reversible move that makes the Markov-tree descent well-defined.",
     "mathContext": "$\\mathrm{vietaPerm}\\,x\\,y \\in \\mathrm{Perm}(\\mathbb{Z}),\\quad (\\mathrm{vietaPerm}\\,x\\,y)^2 = \\mathrm{id},\\quad \\mathrm{fix} \\iff 2z = 3xy.$",
-    "significance": "notable",
+    "significance": "supporting",
     "relatedConcepts": [
       "Equiv.Perm",
       "involution",


### PR DESCRIPTION
Enrichment pass for `markov-equation-oq-05` (Vieta jumping / fiber uniqueness for the Markov equation).

## Changes
Two annotations carried `significance` values outside the allowed enum (`key|supporting|technical|context`):
- `markov-oq05-ann-quadratic`: `"standard"` → `"supporting"`
- `markov-oq05-ann-perm`: `"notable"` → `"supporting"`

## Verification
- All four annotations now use valid `significance` values (checked programmatically).
- meta.json and annotations.json parse as valid JSON.
- No content changed beyond the two enum values; the entry already meets quality targets (4 keyInsights, 3 sections covering all 151 lines, full conclusion, 5 references), ~13 KB (under cap).