### PR TITLE
audit(lovasz-local-lemma-oq-02): correct stale sorry count 1→0 in verified main file

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -17,11 +17,11 @@
       "polynomial-inequalities"
     ],
     "badge": "verified",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "assumptions": "9 sorries total: 1 in main file (lllThreshold_strict_maximum equality case — requires the AM-GM equality characterization, all terms equal iff x = 1/(d+1)) and 8 in the Aristotle companion file (LovaszLocalLemmaOQ02Aristotle.lean) targeting routine supporting lemmas. Proved: lllThreshold_is_maximum (general d) via Real.geom_mean_le_arith_mean2_weighted + rpow monotonicity (PR #11084).",
-    "lineCount": 263,
+    "assumptions": "Main file (LovaszLocalLemmaOQ02.lean) is complete: 0 sorries, 0 axioms — including lllThreshold_strict_maximum, closed via the AM-GM equality characterization (all terms equal iff x = 1/(d+1)). The optional Aristotle companion file (LovaszLocalLemmaOQ02Aristotle.lean) still carries 8 sorries on routine supporting lemmas; it is standalone and is not imported by the main file, so it does not affect the verified status of this entry. Key result: lllThreshold_is_maximum (general d) via Real.geom_mean_le_arith_mean2_weighted + rpow monotonicity (PR #11084).",
+    "lineCount": 318,
     "theoremCount": 13,
     "definitionCount": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `lovasz-local-lemma-oq-02`
**Severity**: HIGH (sorry-count mismatch on a `verified` entry) — internally contradictory metadata, now corrected.

## Problem

The entry's `description` already states the main file is closed to **0 sorries / 0 axioms** (the strict-maximizer theorem `lllThreshold_strict_maximum` was completed via the AM-GM equality characterization). But the numeric fields were stale and contradicted this:

- `meta.sorries: 1`
- `meta.assumptions`: "9 sorries total: 1 in main file … and 8 in the Aristotle companion"
- `meta.lineCount: 263`

## Evidence (proofs/Proofs/LovaszLocalLemmaOQ02.lean)

- **0 sorries**, **0 axioms**, no `native_decide`/`admit` (318 lines, 13 theorems)
- `lllThreshold_strict_maximum` present and fully proved
- Main file imports only `Mathlib` + parent `Proofs.LovaszLocalLemma` — it does **not** import the standalone `LovaszLocalLemmaOQ02Aristotle.lean` companion (8 sorries on routine supporting lemmas), so the companion does not affect this entry's verified status.

## Fix

- `sorries`: `1` → `0`
- `assumptions`: clarify main file is complete (0 sorries / 0 axioms); companion is standalone, not imported, does not affect verified status
- `lineCount`: `263` → `318`

Status/badge remain `verified` — now consistent with the source.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)