### PR TITLE
Enrich L^p Interpolation Inequality (log-convexity): +3 annotations, fix schema

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-03/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-log-convexity-framing",
+    "proofId": "cauchy-schwarz-oq-03-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 25
+    },
+    "type": "context",
+    "title": "Log-Convexity: The Organizing Idea",
+    "content": "The file header frames the whole entry through one principle: the map t ↦ log‖f‖_(1/t) is convex. Writing the exponent constraint as an average, 1/r = θ·(1/p) + (1-θ)·(1/q), places 1/r on the line segment between 1/p and 1/q at parameter θ; the interpolation inequality is then exactly the statement that log‖f‖ at that interior reciprocal-exponent lies below the corresponding convex combination θ·log‖f‖_p + (1-θ)·log‖f‖_q of the endpoint values. Under this lens Cauchy–Schwarz and Hölder are not distinct theorems but named faces of a single convex curve — the θ = 1/2 midpoint and the diagonal p = q instance. Everything downstream (the conjugate pair, the Hölder call, the final power) is bookkeeping that turns this geometric picture into a Lean term.",
+    "mathContext": "$\\log\\|f\\|_{1/(\\theta t_1 + (1-\\theta)t_2)} \\;\\leq\\; \\theta\\,\\log\\|f\\|_{1/t_1} + (1-\\theta)\\,\\log\\|f\\|_{1/t_2}$, i.e. $t \\mapsto \\log\\|f\\|_{1/t}$ is convex, with $t_1 = 1/p,\\ t_2 = 1/q,\\ 1/r = \\theta t_1 + (1-\\theta)t_2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "log-convexity",
+      "convex combination",
+      "Lp norms",
+      "Riesz-Thorin interpolation",
+      "Lyapunov inequality"
+    ],
+    "prerequisites": [
+      "convex functions",
+      "Lp norm definition",
+      "logarithm"
+    ]
+  },
+  {
     "id": "ann-lp-interpolation-main",
     "proofId": "cauchy-schwarz-oq-03-oq-03",
     "range": {
@@ -51,6 +76,56 @@
     ]
   },
   {
+    "id": "ann-zero-safe-split",
+    "proofId": "cauchy-schwarz-oq-03-oq-03",
+    "range": {
+      "startLine": 66,
+      "endLine": 73
+    },
+    "type": "technique",
+    "title": "Zero-Safe Summand Split via rpow_add'",
+    "content": "Before Hölder can be applied, each summand must factor as f_i^r = f_i^(rθ)·f_i^(r(1-θ)). Over the reals this factorization is delicate: the general law x^(y+z) = x^y·x^z can fail at x = 0 because of the 0^0 convention, forcing a case split on whether f_i vanishes. Working in ℝ≥0 with NNReal.rpow_add' sidesteps this entirely — its side condition is only that the total exponent y + z ≠ 0, which holds here since rθ + r(1-θ) = r > 0. So hprod establishes the split uniformly over all i, including the coordinates where f_i = 0, and the proof never branches on the support of f. This is a recurring payoff of formulating discrete-norm inequalities in ℝ≥0 rather than ℝ.",
+    "mathContext": "$f_i^{r\\theta}\\cdot f_i^{r(1-\\theta)} = f_i^{\\,r\\theta + r(1-\\theta)} = f_i^{\\,r}$, valid for all $f_i \\geq 0$ because $r\\theta + r(1-\\theta) = r \\neq 0$ (the side condition of $\\texttt{rpow\\_add'}$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "NNReal.rpow_add'",
+      "zero-exponent conventions",
+      "case-split elimination",
+      "nonnegative reals"
+    ],
+    "prerequisites": [
+      "NNReal.rpow_add'",
+      "real powers of nonnegative reals",
+      "0^0 convention"
+    ]
+  },
+  {
+    "id": "ann-exponent-collapse-and-power",
+    "proofId": "cauchy-schwarz-oq-03-oq-03",
+    "range": {
+      "startLine": 74,
+      "endLine": 90
+    },
+    "type": "technique",
+    "title": "Collapsing the Powers and Raising to 1/r",
+    "content": "After the Hölder application the bound reads ∑ f_i^r ≤ (∑ (f_i^(rθ))^a)^(1/a)·(∑ (f_i^(r(1-θ)))^b)^(1/b). The nested powers collapse by NNReal.rpow_mul: (f_i^(rθ))^a = f_i^(rθ·a) = f_i^p exactly because a = p/(rθ) makes rθ·a = p (proved by haθ via field_simp), and symmetrically (f_i^(r(1-θ)))^b = f_i^q. Rewriting with simp only [hprod, hFa, hGb] turns Hölder into ∑ f_i^r ≤ (∑ f_i^p)^(1/a)·(∑ f_i^q)^(1/b). The final step raises both sides to 1/r ≥ 0 (monotone, NNReal.rpow_le_rpow), distributes across the product with NNReal.mul_rpow, and folds the nested exponents with rpow_mul; the arithmetic (1/a)(1/r) = θ/p and (1/b)(1/r) = (1-θ)/q lands exactly on the target exponents.",
+    "mathContext": "$(f_i^{r\\theta})^{a} = f_i^{r\\theta\\, a} = f_i^{p}$ since $r\\theta\\,a = r\\theta\\cdot\\tfrac{p}{r\\theta} = p$; and $\\tfrac1a\\cdot\\tfrac1r = \\tfrac{r\\theta}{p}\\cdot\\tfrac1r = \\tfrac{\\theta}{p}$, giving the endpoint exponent $\\theta/p$ (symmetrically $(1-\\theta)/q$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "NNReal.rpow_mul",
+      "NNReal.mul_rpow",
+      "NNReal.rpow_le_rpow",
+      "exponent bookkeeping",
+      "monotonicity of rpow"
+    ],
+    "prerequisites": [
+      "NNReal.rpow_mul",
+      "NNReal.mul_rpow",
+      "NNReal.rpow_le_rpow",
+      "field_simp"
+    ]
+  },
+  {
     "id": "ann-midpoint",
     "proofId": "cauchy-schwarz-oq-03-oq-03",
     "range": {
@@ -61,7 +136,7 @@
     "title": "Midpoint Case: Geometric-Mean Interpolation and Cauchy-Schwarz",
     "content": "Specializing θ = 1/2 gives the symmetric geometric-mean interpolation ‖f‖_r ≤ (‖f‖_p·‖f‖_q)^(1/2) whenever 2/r = 1/p + 1/q. This is the interpolation face closest to the parent inequalities: taking p = q recovers a Cauchy-Schwarz-type statement, exhibiting Cauchy-Schwarz and Hölder as the boundary/diagonal instances of the full log-convexity phenomenon. The corollary is derived from the main theorem by rewriting the exponents at θ = 1/2 and folding the two 1/2-powers with rpow_mul.",
     "mathContext": "$\\|f\\|_r \\leq \\left(\\|f\\|_p\\,\\|f\\|_q\\right)^{1/2}, \\qquad \\frac2r = \\frac1p + \\frac1q.$ At $p = q$ this is the Cauchy-Schwarz face of the interpolation family.",
-    "significance": "standard",
+    "significance": "supporting",
     "relatedConcepts": [
       "geometric mean",
       "Cauchy-Schwarz inequality",


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-03-oq-03` (The L^p Interpolation Inequality / log-convexity of L^p norms).

## Changes
- **Fixed schema violation**: the midpoint annotation had `significance: "standard"`, which is not in the allowed enum (key/supporting/technical/context). Corrected to `supporting`.
- **Annotation coverage 3 → 6**, filling the gaps in the proof machinery:
  - **Log-Convexity framing** (header, context): recasts the exponent constraint `1/r = θ·(1/p)+(1-θ)·(1/q)` as a convex combination, so Cauchy–Schwarz/Hölder appear as faces of one convex curve.
  - **Zero-safe summand split** (technique): why `NNReal.rpow_add'` avoids the `0^0` case split that plagues real-valued formulations.
  - **Exponent collapse + raise-to-1/r** (technique): how `rpow_mul` collapses `(f_i^{rθ})^a = f_i^p` under `a = p/(rθ)`, and the final `mul_rpow` bookkeeping landing on `θ/p`, `(1-θ)/q`.
- All 6 annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

## Not changed
- `meta.json` was already comprehensive (rich historicalContext, 5 keyInsights, full conclusion with 4 open questions, references, cross-references) and near all size targets — left untouched to avoid inflation per the size guardrails.
- No `index.ts` created: the gallery loader fetches meta.json + annotations.json by slug (index.ts is obsolete).