### PR TITLE
Enrich Minkowski Theorem OQ-04-OQ-02: add missing index.ts, fix significance

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-02/annotations.json
@@ -19,7 +19,7 @@
     "title": "The ℝ≥0∞ ↔ ℝ Covolume Bridge",
     "content": "ZLattice.covolume is a real number (a .toReal), while the parent's analytic argument lives in ℝ≥0∞. covolume_eq_toReal_volume_fundamentalDomain identifies covol(Λ) with (volume F).toReal via ZLattice.covolume_eq_measure_fundamentalDomain applied to ZSpan.isAddFundamentalDomain. Because the fundamental domain is bounded (ZSpan.fundamentalDomain_isBounded), its volume is finite, so ENNReal.ofReal and toReal are mutually inverse there — giving the arithmetic identity (k:ℝ≥0∞)·volume F = ENNReal.ofReal (k·covol(Λ)) in natCast_mul_volume_fundamentalDomain.",
     "mathContext": "$\\mathrm{covol}(\\Lambda) = (\\mathrm{vol}\\,F).\\mathrm{toReal}$ and, since $\\mathrm{vol}\\,F < \\infty$, $(k:\\mathbb{R}_{\\ge 0}^\\infty)\\cdot\\mathrm{vol}\\,F = \\mathrm{ofReal}(k\\cdot\\mathrm{covol}\\,\\Lambda)$.",
-    "significance": "important",
+    "significance": "technical",
     "relatedConcepts": ["ZLattice.covolume", "ENNReal.ofReal", "fundamental domain volume", "boundedness"],
     "prerequisites": ["ℝ≥0∞ arithmetic", "finiteness of bounded-set volume"]
   },

--- a/src/data/proofs/minkowski-theorem-oq-04-oq-02/index.ts
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MinkowskiTheoremOQ04OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const minkowskiTheoremOq04Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const minkowskiTheoremOq04Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const minkowskiTheoremOq04Oq02Data: ProofData = {
+  proof: minkowskiTheoremOq04Oq02Proof,
+  annotations: minkowskiTheoremOq04Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `minkowski-theorem-oq-04-oq-02` (covolume form of Blichfeldt & Minkowski for a general lattice).

## Changes
- **Added missing `index.ts`** — the entry had no Vite entry point, so the page would render *proof not found* on the live site despite appearing in the gallery listing. Highest-impact fix.
- **Fixed invalid annotation `significance`** — the ℝ≥0∞↔ℝ covolume-bridge annotation used `"important"`, which is outside the allowed enum (`key|supporting|technical|context`). Changed to `"technical"` (it is a technical bridge lemma).

## Verification
- meta.json and annotations.json parse as valid JSON; all four annotations now use valid `significance`.
- `index.ts` follows the canonical gallery template (raw-import `../../../../proofs/Proofs/MinkowskiTheoremOQ04OQ02.lean?raw`).
- No content deleted; entry already meets quality targets (4 keyInsights, 3 sections, 3 crossRefs, full conclusion) at ~23 KB, under the 60 KB cap.