### PR TITLE
research(minpoly-charpoly-oq-02): prove reverse direction — diagonalizable ⇔ squarefree minpoly [VERIFIED, 0-axiom, 0-sorry]

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ02.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02.lean
@@ -198,27 +198,9 @@ theorem _root_.Matrix.IsDiagonalizable.squarefree_minpoly {M : Matrix n n K}
   rw [← hmeq]
   exact squarefree_minpoly_of_isDiag hdiag
 
-/-- **S1 OBSERVE → S7 ACT main theorem.** Over an algebraically closed field
-of characteristic zero, a matrix is diagonalizable iff its minimal polynomial
-is squarefree.
-
-The **forward** direction (`→`) is now fully proved and unconditional
-(`Matrix.IsDiagonalizable.squarefree_minpoly`, any field). The **reverse**
-direction (`←`, squarefree minpoly ⇒ diagonalizable) remains the single
-`sorry`: over an algebraically closed field it follows from Bridge C
-(`Module.End.isSemisimple_iff_squarefree_minpoly`) plus Bridge B
-(`Module.End.iSup_eigenspace_eq_top_of_isSemisimple`) transported back through
-`Matrix.toLin'`, and is the target of sub-OQ-02-OQ-02.
-
-Note: the field hypotheses can be weakened to "perfect field + minpoly
-splits", but the alg-closed-char-0 case is the headline textbook statement
-and is what most callers (e.g. linear-algebra texts) expect. The general
-form is the target of OQ-02-OQ-03. -/
-theorem diagonalizable_iff_squarefree_minpoly
-    [IsAlgClosed K] [CharZero K] (M : Matrix n n K) :
-    M.IsDiagonalizable ↔ Squarefree (minpoly K M) := by
-  refine ⟨fun h => h.squarefree_minpoly, ?_⟩
-  sorry
+-- The headline biconditional `diagonalizable_iff_squarefree_minpoly` is stated
+-- and PROVED (no sorry) at the end of this file, after the endomorphism-level
+-- bridges (Bridge B/C) and the eigenbasis bridge it depends on.
 
 /-- **Sanity lemma (unconditional).** A diagonal matrix is diagonalizable —
 take `P = 1` as the similarity transform. -/
@@ -317,5 +299,91 @@ theorem _root_.Matrix.isDiagonalizable_conj_iff {M P : Matrix n n K} (hP : IsUni
       show P * (P⁻¹ * M * P) * P⁻¹ = (P * P⁻¹) * M * (P * P⁻¹) from by simp only [mul_assoc]]
     simp only [hPP, one_mul, mul_one]
   rwa [heq] at hback
+
+-- ============================================================
+-- Reverse direction: eigenbasis bridge + headline biconditional
+-- ============================================================
+
+/-- **Eigenbasis ⇒ diagonalizable (Bridge A reverse, PROVED, any field).**
+If the space `n → K` admits a basis `b` of eigenvectors of `Matrix.toLin' M`
+(with `toLin' M (b i) = μ i • b i`), then `M` is diagonalizable. The witnessing
+similarity is the change-of-basis matrix `P = e.toMatrix b` (from the standard
+basis `e` to `b`): in the eigenbasis the operator has matrix `diagonal μ`, and
+the change-of-basis conjugation identity
+`basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix` gives
+`P⁻¹ * M * P = LinearMap.toMatrix b b (toLin' M) = diagonal μ`, which is
+diagonal. This is the reusable core of the reverse direction; the remaining
+work is to *produce* such an eigenbasis, done below from semisimplicity. -/
+theorem isDiagonalizable_of_eigenbasis {M : Matrix n n K}
+    (b : Module.Basis n K (n → K)) (μ : n → K)
+    (hb : ∀ i, Matrix.toLin' M (b i) = μ i • b i) :
+    M.IsDiagonalizable := by
+  classical
+  set e := Pi.basisFun K n with he
+  have hdiag : LinearMap.toMatrix b b (Matrix.toLin' M) = Matrix.diagonal μ := by
+    ext i j
+    rw [LinearMap.toMatrix_apply, hb j, map_smul, Finsupp.smul_apply, Module.Basis.repr_self,
+      Matrix.diagonal_apply]
+    by_cases hij : i = j
+    · subst hij; simp
+    · simp [hij]
+  have hM : LinearMap.toMatrix e e (Matrix.toLin' M) = M := by
+    rw [LinearMap.toMatrix_eq_toMatrix', LinearMap.toMatrix'_toLin']
+  have hflip1 : e.toMatrix b * b.toMatrix e = 1 := Module.Basis.toMatrix_mul_toMatrix_flip e b
+  haveI : Invertible (e.toMatrix b) := e.invertibleToMatrix b
+  have hunit : IsUnit (e.toMatrix b) := isUnit_of_invertible _
+  have hinv : (e.toMatrix b)⁻¹ = b.toMatrix e := Matrix.inv_eq_right_inv hflip1
+  refine ⟨e.toMatrix b, hunit, ?_⟩
+  rw [hinv]
+  have h1 : b.toMatrix e * M * e.toMatrix b = LinearMap.toMatrix b b (Matrix.toLin' M) := by
+    conv_lhs => rw [← hM]
+    simp only [basis_toMatrix_mul_linearMap_toMatrix, linearMap_toMatrix_mul_basis_toMatrix]
+  rw [h1, hdiag]
+  exact Matrix.isDiag_diagonal μ
+
+/-- **Headline biconditional (PROVED, no sorry).** Over an algebraically closed
+field of characteristic zero, a matrix is diagonalizable iff its minimal
+polynomial is squarefree.
+
+The **forward** direction (`→`) is `Matrix.IsDiagonalizable.squarefree_minpoly`
+(unconditional, any field). The **reverse** direction (`←`) is now discharged:
+squarefree `minpoly` ⇒ the endomorphism `f = toLin' M` is semisimple (Bridge C),
+hence over an algebraically closed field its eigenspaces span (`Bridge B`) and are
+independent, so they form an internal direct sum. The collected per-eigenspace
+bases give a basis of eigenvectors, which — after reindexing to `n` by equal
+cardinality — is fed to `isDiagonalizable_of_eigenbasis`.
+
+The field hypotheses can be weakened to "perfect field + minpoly splits", but the
+alg-closed-char-0 case is the headline textbook statement (general form is the
+target of OQ-02-OQ-03). -/
+theorem diagonalizable_iff_squarefree_minpoly
+    [IsAlgClosed K] [CharZero K] (M : Matrix n n K) :
+    M.IsDiagonalizable ↔ Squarefree (minpoly K M) := by
+  refine ⟨fun h => h.squarefree_minpoly, fun hsq => ?_⟩
+  classical
+  set f : Module.End K (n → K) := Matrix.toLin' M with hf
+  have hmp : minpoly K f = minpoly K M := Matrix.minpoly_toLin' M
+  have hss : f.IsSemisimple :=
+    (Module.End.isSemisimple_iff_squarefree_minpoly).mpr (by rw [hmp]; exact hsq)
+  have htop : ⨆ μ : K, f.eigenspace μ = ⊤ :=
+    Module.End.iSup_eigenspace_eq_top_of_isSemisimple hss
+  have hindep : iSupIndep (fun μ : K => f.eigenspace μ) :=
+    Module.End.eigenspaces_iSupIndep f
+  have hInt : DirectSum.IsInternal (fun μ : K => f.eigenspace μ) :=
+    (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mpr ⟨hindep, htop⟩
+  set B := hInt.collectedBasis (fun μ => Module.finBasis K (f.eigenspace μ)) with hB
+  haveI : Fintype (Σ μ : K, Fin (Module.finrank K (f.eigenspace μ))) :=
+    FiniteDimensional.fintypeBasisIndex B
+  have hcard :
+      Fintype.card (Σ μ : K, Fin (Module.finrank K (f.eigenspace μ))) = Fintype.card n := by
+    rw [← Module.finrank_eq_card_basis B, ← Module.finrank_eq_card_basis (Pi.basisFun K n)]
+  set ρ := Fintype.equivOfCardEq hcard with hρ
+  refine isDiagonalizable_of_eigenbasis (B.reindex ρ) (fun i => (ρ.symm i).1) ?_
+  intro i
+  have hmem : B (ρ.symm i) ∈ f.eigenspace (ρ.symm i).1 :=
+    hInt.collectedBasis_mem _ (ρ.symm i)
+  have heig := Module.End.mem_eigenspace_iff.mp hmem
+  rw [Module.Basis.reindex_apply, ← hf]
+  exact heig
 
 end Proofs.MinpolyCharpolyOQ02

--- a/research/problems/minpoly-charpoly-oq-02/state.md
+++ b/research/problems/minpoly-charpoly-oq-02/state.md
@@ -527,3 +527,41 @@ No edits to Lean files, parent gallery JSON
 `knowledge.md`, or any sister-slug file. Sorry count unchanged at 1;
 axiom count unchanged at 0; lineCount unchanged at 169 (matches the
 merged S7 ACT state on `origin/main`).
+
+## S15 ACT — SHIPPED (researcher-1, 2026-07-01): reverse direction closed
+
+The sole remaining sorry (reverse direction of `diagonalizable_iff_squarefree_minpoly`
+over `[IsAlgClosed K] [CharZero K]`) is now **discharged**. File `MinpolyCharpolyOQ02.lean`
+is 389 LOC, 12 thm, 2 def, **0 sorries, 0 axioms** (`#print axioms` = only propext /
+Classical.choice / Quot.sound).
+
+Two new theorems (both VERIFIED, 0-axiom):
+
+1. `isDiagonalizable_of_eigenbasis {M} (b : Basis n K (n→K)) (μ : n → K)
+   (hb : ∀ i, toLin' M (b i) = μ i • b i) : M.IsDiagonalizable` — the reusable Bridge A
+   reverse. Witness `P = e.toMatrix b` (e = Pi.basisFun). Key steps: `LinearMap.toMatrix
+   b b (toLin' M) = diagonal μ` (via `toMatrix_apply` + `hb` + `Basis.repr_self`);
+   `toMatrix e e (toLin' M) = M` (`toMatrix_eq_toMatrix'` + `toMatrix'_toLin'`); change of
+   basis `basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix` gives
+   `P⁻¹ M P = toMatrix b b (toLin' M) = diagonal μ`, which `isDiag_diagonal` closes.
+
+2. `diagonalizable_iff_squarefree_minpoly` (relocated to end of file, after Bridges B/C).
+   Reverse assembly: `f := toLin' M`; `minpoly K f = minpoly K M` (`minpoly_toLin'`);
+   `f.IsSemisimple` (Bridge C `.mpr`); `⨆ eigenspace = ⊤` (Bridge B); `eigenspaces_iSupIndep`
+   → `DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top` → `IsInternal`;
+   `IsInternal.collectedBasis (fun μ => Module.finBasis K (eigenspace μ))`; get `Fintype`
+   on the Σ-index from `FiniteDimensional.fintypeBasisIndex` of the collected basis;
+   card equality via `Module.finrank_eq_card_basis` (both = finrank(n→K)) →
+   `Fintype.equivOfCardEq` reindex to `n`; eigenvalue `fun i => (ρ.symm i).1`,
+   eigen-equation from `collectedBasis_mem` + `mem_eigenspace_iff`.
+
+GOTCHAS: `Basis` is `Module.Basis` in v4.26 — unqualified `Basis.repr_self` /
+`toMatrix_mul_toMatrix_flip` / `reindex_apply` fail without `open Module` (qualify with
+`Module.`). `isUnit_of_mul_eq_one` deprecated → used `isUnit_of_invertible` +
+`Basis.invertibleToMatrix`. `conv_lhs => rw [← hM]` (not plain `rw`) to avoid rewriting
+`M` inside the target's `toLin' M`. The main theorem had to be MOVED after Bridges B/C
+(it originally preceded them, so couldn't reference them). Docker down (containerd) →
+`lake env lean` against main's prebuilt Mathlib.
+
+Remaining follow-ups: OQ-02-OQ-03 (general field + splits), OQ-02-OQ-04 (char-0
+separability corollary).

--- a/src/data/proofs/minpoly-charpoly-oq-02/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/meta.json
@@ -1,13 +1,13 @@
 {
   "id": "minpoly-charpoly-oq-02",
-  "title": "Diagonalizable Matrices via Squarefree Minimal Polynomial (S7 ACT Scaffold)",
+  "title": "Diagonalizable Matrices via Squarefree Minimal Polynomial (Verified)",
   "slug": "minpoly-charpoly-oq-02",
-  "description": "S1 OBSERVE → S7 ACT scaffold resolving the parent's second open question: 'Can the diagonalizability characterisation M ∈ Matₙ(F) diagonalizable ⇔ minpoly M ∈ F[X] is squarefree (and splits in F) be formalized in Lean 4?' Affirmative: defines Matrix.IsDiagonalizable, states the headline iff theorem guarded by a single sorry, and ships two pre-verified endomorphism-level bridges (Bridge B forward: IsSemisimple → ⨆ eigenspace = ⊤; Bridge C: IsSemisimple ↔ Squarefree minpoly) that the eventual ACT picker will compose with matrix↔endo transport bridges to discharge the sorry.",
+  "description": "Resolves the parent's second open question: 'Can the diagonalizability characterisation M ∈ Matₙ(F) diagonalizable ⇔ minpoly M ∈ F[X] is squarefree (and splits in F) be formalized in Lean 4?' FULLY PROVED (0 sorries, 0 axioms): the headline biconditional diagonalizable_iff_squarefree_minpoly over an algebraically closed field of characteristic zero. Forward direction (Matrix.IsDiagonalizable.squarefree_minpoly) is unconditional over any field; the reverse direction is discharged via semisimplicity (Bridge C) + eigenspace decomposition (Bridge B) + independence → DirectSum.IsInternal → collected eigenbasis → reindex to n → the new eigenbasis bridge isDiagonalizable_of_eigenbasis (change-of-basis conjugation making P⁻¹MP = diagonal μ).",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Semisimple.html",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/MinpolyCharpolyOQ02.lean",
     "tags": [
       "linear-algebra",
@@ -19,17 +19,20 @@
       "eigenspace",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 321,
-    "assumptions": "0 axioms; 1 sorry guarding the proof of `diagonalizable_iff_squarefree_minpoly`. The statement itself is unconditional (hypotheses [IsAlgClosed K] [CharZero K] are explicit, not assumed-as-axiom). The two pre-shipped endomorphism-level bridges (Module.End.iSup_eigenspace_eq_top_of_isSemisimple and Module.End.isSemisimple_iff_squarefree_minpoly) are fully proved with no sorry. The four sub-OQs OQ-02-OQ-01..OQ-02-OQ-04 (estimated ~450 lines total) are the planned discharge route, with the picker-estimated final synthesis at ~59 LOC (~12 + 8 + 33 + 1 + 5 for Bridges A fwd + A rev + B rev + D + compose). Pinned at Mathlib v4.26.0; 18 bearer lemmas verified at SHA 2df2f015… by S7c PREP #19257.",
+    "lineCount": 389,
+    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms on diagonalizable_iff_squarefree_minpoly and isDiagonalizable_of_eigenbasis reports only propext, Classical.choice, Quot.sound (the standard foundational axioms) — no sorryAx, no Lean.ofReduceBool. The headline hypotheses [IsAlgClosed K] [CharZero K] are explicit typeclass assumptions on the statement (the textbook gold form), not axioms; the general perfect-field-plus-splits form is the target of OQ-02-OQ-03. Pinned at Mathlib v4.26.0.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-04",
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 2,
     "originalContributions": [
-      "Similarity-invariance of diagonalizability (verified, any field, 0 axioms): `Matrix.IsDiagonalizable.conj` — if M is diagonalizable and P invertible then P⁻¹ M P is diagonalizable (if M = Q⁻¹ D Q then P⁻¹ M P = (P⁻¹ Q)⁻¹ D (P⁻¹ Q)); and `Matrix.isDiagonalizable_conj_iff` — the biconditional form. This is the change-of-basis step the reverse direction transports through Matrix.toLin' (the matrix-level counterpart of minpoly.algEquiv_eq already used for the forward direction), reducing the remaining reverse `sorry` to the pure endomorphism eigenbasis statement.",
+      "diagonalizable_iff_squarefree_minpoly (VERIFIED, 0 sorries, 0 axioms): the FULL headline biconditional over an algebraically closed field of characteristic zero — M.IsDiagonalizable ↔ Squarefree (minpoly K M). The reverse direction (previously the sole sorry, blocked across multiple sessions) is now discharged.",
+      "isDiagonalizable_of_eigenbasis (VERIFIED, any field, 0 axioms): the reusable eigenbasis bridge — if n→K has a basis b of eigenvectors of Matrix.toLin' M (toLin' M (b i) = μ i • b i), then M is diagonalizable, with witness P = e.toMatrix b (change of basis from the standard basis) satisfying P⁻¹ M P = LinearMap.toMatrix b b (toLin' M) = diagonal μ. Proof uses basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix (change-of-basis conjugation) and LinearMap.toMatrix_apply.",
+      "Reverse-direction assembly: from Squarefree (minpoly K M), the endomorphism f = toLin' M is semisimple (Bridge C, minpoly_toLin'); over an algebraically closed field its eigenspaces span (Bridge B) and are independent (Module.End.eigenspaces_iSupIndep), giving DirectSum.IsInternal; the collected per-eigenspace bases (finBasis + IsInternal.collectedBasis) form an eigenbasis, reindexed to n by equal cardinality (Fintype.equivOfCardEq, finrank_eq_card_basis) and fed to isDiagonalizable_of_eigenbasis.",
+      "Similarity-invariance of diagonalizability (verified, any field, 0 axioms): `Matrix.IsDiagonalizable.conj` — if M is diagonalizable and P invertible then P⁻¹ M P is diagonalizable (if M = Q⁻¹ D Q then P⁻¹ M P = (P⁻¹ Q)⁻¹ D (P⁻¹ Q)); and `Matrix.isDiagonalizable_conj_iff` — the biconditional form.",
       "Matrix.IsDiagonalizable predicate: ∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P) — the matrix-level analogue of Module.End.IsSemisimple ∧ Polynomial.Splits for the associated endomorphism",
       "Module.End.iSup_eigenspace_eq_top_of_isSemisimple: the corrected 3-lemma chain (IsSemisimple → IsFinitelySemisimple → maxGenEigenspace μ = eigenspace μ → ⨆ eigenspace = ⊤) for alg-closed finite-dimensional spaces (Bridge B forward, shipped S7 ACT #19095 after S4 PREP #18626 caught the phantom direct-form name)",
       "Module.End.isSemisimple_iff_squarefree_minpoly: the endomorphism-level iff (Bridge C), constructed by composing Module.End.IsSemisimple.minpoly_squarefree (forward) with Module.End.isSemisimple_of_squarefree_aeval_eq_zero applied to minpoly.aeval (reverse)",
@@ -142,7 +145,7 @@
     },
     {
       "id": "main-theorem",
-      "title": "§4: diagonalizable_iff_squarefree_minpoly — Headline (single reverse sorry)",
+      "title": "§4: diagonalizable_iff_squarefree_minpoly — Headline (fully proved)",
       "startLine": 201,
       "endLine": 222,
       "summary": "**The S1 headline theorem.** Over `[IsAlgClosed K] [CharZero K]`, a matrix M is diagonalizable iff its minimal polynomial is squarefree. The **forward** direction is now fully discharged by `Matrix.IsDiagonalizable.squarefree_minpoly` (§3, unconditional). Only the **reverse** direction (squarefree minpoly ⇒ diagonalizable) remains a single `sorry` at line 221 — over an alg-closed field it follows from Bridge C (`isSemisimple_iff_squarefree_minpoly`) plus Bridge B (`iSup_eigenspace_eq_top_of_isSemisimple`) transported back through `Matrix.toLin'`, the target of sub-OQ-02-OQ-02. The docstring notes the hypotheses can be weakened to 'perfect field + minpoly splits' (OQ-02-OQ-03), but alg-closed-char-0 is the textbook gold form.",
@@ -166,7 +169,7 @@
     }
   ],
   "conclusion": {
-    "summary": "S1 OBSERVE → S7 ACT scaffold for the diagonalizable-iff-squarefree-minpoly characterisation. Defines `Matrix.IsDiagonalizable`, states the headline iff (sorry-guarded over [IsAlgClosed K] [CharZero K]), and ships two pre-verified endomorphism-level bridges (B forward and C iff) plus two unconditional sanity helpers. The remaining ~59 LOC discharge is decomposed into four sub-OQs (~450 LOC roadmap), with all 18 required bearer lemmas pin-verified at Mathlib v4.26.0 SHA 2df2f015… by S7c PREP #19257.",
+    "summary": "Fully proves the diagonalizable-iff-squarefree-minpoly characterisation over [IsAlgClosed K] [CharZero K] (0 sorries, 0 axioms). Defines `Matrix.IsDiagonalizable`, proves the forward direction unconditionally (any field), and discharges the reverse direction via the endomorphism-level bridges (B forward: IsSemisimple → ⨆ eigenspace = ⊤; C: IsSemisimple ↔ Squarefree minpoly), DirectSum.IsInternal of the eigenspaces, the collected eigenbasis, and the new change-of-basis eigenbasis bridge isDiagonalizable_of_eigenbasis. Pinned at Mathlib v4.26.0.",
     "implications": "Discharging OQ-02 completes the matrix-level diagonalisability characterisation in Lean 4, sibling to OQ-01 (JNF) and OQ-03 (RCF). Together with the parent's 17 minpoly | charpoly theorems, this gives a complete formal toolkit for matrix similarity questions over algebraically closed fields. Practical applications include automated detection of diagonalizability in symbolic computation, formalised spectral analysis, and the operator-theoretic precursor to the spectral theorem on inner-product spaces.",
     "openQuestions": [
       "**OQ-02-OQ-01** (~100 LOC): Bridge `Module.End.IsSemisimple ↔ Squarefree (minpoly K f)` from endomorphism to matrix level, transporting via `Matrix.toLin'` and `Matrix.minpoly_toLin'`.",
@@ -194,12 +197,12 @@
       "Polynomial"
     ],
     "namespace": "Proofs.MinpolyCharpolyOQ02",
-    "lineCount": 321,
+    "lineCount": 389,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 2,
     "path": "Proofs/MinpolyCharpolyOQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -228,7 +231,7 @@
       "name": "diagonalizable_iff_squarefree_minpoly",
       "type": "core",
       "statement": "∀ {K : Type*} [Field K] {n : Type*} [Fintype n] [DecidableEq n] [IsAlgClosed K] [CharZero K] (M : Matrix n n K), M.IsDiagonalizable ↔ Squarefree (minpoly K M)",
-      "description": "Headline theorem (S1 statement, sorry-guarded at line 122). Over an algebraically closed field of characteristic zero, a matrix is diagonalizable iff its minimal polynomial is squarefree. The four sub-OQs OQ-02-OQ-01..OQ-02-OQ-04 are designed to discharge the sorry via composition of Bridges A (matrix↔endo), B (semisimple↔eigenspace-decomp), C (semisimple↔squarefree, in-tree), and D (matrix↔endo minpoly transport).",
+      "description": "Headline theorem (FULLY PROVED, 0 sorries, 0 axioms). Over an algebraically closed field of characteristic zero, a matrix is diagonalizable iff its minimal polynomial is squarefree. The reverse direction is assembled from Bridge C (semisimple ↔ squarefree, via minpoly_toLin'), Bridge B (semisimple → eigenspaces span), eigenspace independence → DirectSum.IsInternal, the collected eigenbasis, and the eigenbasis bridge isDiagonalizable_of_eigenbasis.",
       "significance": "The textbook operator-theoretic characterisation of diagonalisability via minpoly"
     },
     {
@@ -260,7 +263,7 @@
       "significance": "Concrete instance of the diagonalizable predicate"
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "references": [
     {
       "authors": [

--- a/src/data/research/problems/minpoly-charpoly-oq-02.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "minpoly-charpoly-oq-02",
   "title": "Diagonalizable Matrices via Squarefree Minimal Polynomial",
-  "phase": "ACT",
-  "status": "blocked",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,29 +16,23 @@
   },
   "knownResults": {
     "proven": [
-      "Standard textbook fact (Axler, *Linear Algebra Done Right* 3rd ed., §8.A; Dummit–Foote, *Abstract Algebra* 3rd ed., §12.2): over an algebraically closed field, an operator is diagonalizable iff its minimal polynomial has distinct roots.",
-      "Mathlib `Module.End.isSemisimple_iff_squarefree_minpoly` (`Mathlib.LinearAlgebra.Semisimple`): for a finite-dim endomorphism over a field where minpoly is separable, `IsSemisimple` ↔ `Squarefree (minpoly K f)`.",
-      "Mathlib `Matrix.minpoly_toLin'` (`Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly`): the minimal polynomial transports across the matrix–endomorphism bridge.",
-      "Mathlib `Module.End.IsSemisimple` API: definition and basic closure properties.",
-      "In-tree (S1, this PR): `Matrix.IsDiagonalizable` predicate, `Matrix.IsDiagonalizable.of_isDiag`, `Matrix.IsDiagonalizable.zero`."
+      "diagonalizable_iff_squarefree_minpoly [IsAlgClosed K][CharZero K]: M.IsDiagonalizable ↔ Squarefree (minpoly K M) — VERIFIED, 0-axiom, 0-sorry",
+      "isDiagonalizable_of_eigenbasis: eigenbasis ⇒ diagonalizable (any field), the reusable reverse-direction core",
+      "Matrix.IsDiagonalizable.squarefree_minpoly (forward, any field), Bridge B/C, similarity invariance"
     ],
     "open": [
-      "Full discharge of `diagonalizable_iff_squarefree_minpoly` (sorry in S1 scaffold).",
-      "Bridge `Matrix.IsDiagonalizable M ↔ Module.End.IsSemisimple (Matrix.toLin' M) ∧ Polynomial.Splits (algebraMap K K) (minpoly K M)` (OQ-02-OQ-02 target).",
-      "General-field version with explicit `splits` hypothesis (OQ-02-OQ-03).",
-      "Char-0 corollary: `CharZero K → ∀ M, Separable (minpoly K M)` so the `IsSemisimple` ↔ `Squarefree minpoly` API applies unconditionally (OQ-02-OQ-04)."
+      "OQ-02-OQ-03: general-field form with explicit Polynomial.Splits hypothesis (weaken [IsAlgClosed K] to perfect field + minpoly splits).",
+      "OQ-02-OQ-04: char-0 corollary that minpoly is automatically separable, so the biconditional applies unconditionally."
     ],
     "goal": "Statement and proof of `diagonalizable_iff_squarefree_minpoly`: over an algebraically closed field of characteristic zero (and, in OQ-02-OQ-03, over any field with the explicit `splits` hypothesis), `M.IsDiagonalizable ↔ Squarefree (minpoly K M)`."
   },
   "currentState": {
-    "phase": "BLOCKED",
+    "phase": "COMPLETED",
     "since": "2026-06-13T00:00:00Z",
     "iteration": 17,
-    "focus": "S13 STATE-SYNC (researcher-1, 2026-06-13): CONTENT CORRECTION — prior records (leanFiles + S12 focus) were stale, NOT dormant. They claimed MinpolyCharpolyOQ02.lean = 169 LOC, 1 sorry at line 122, '25 days dormant, no PRs since S7'. Reality on origin/main: PR #22923 (helpers) and PR #22909 (forward direction) merged AFTER S12, growing the file to 279 LOC. The FORWARD direction (diagonalizable ⇒ squarefree minpoly) is now FULLY PROVED and unconditional over any field (Matrix.IsDiagonalizable.squarefree_minpoly); matConj similarity-transport automorphism built. The SOLE remaining sorry is the REVERSE direction at line 221 inside diagonalizable_iff_squarefree_minpoly ([IsAlgClosed K][CharZero K]): squarefree minpoly ⇒ diagonalizable, via Bridge C (Module.End.isSemisimple_iff_squarefree_minpoly) + Bridge B (iSup_eigenspace_eq_top_of_isSemisimple) transported through Matrix.toLin'. This corrects a factual missed-merge, distinct from the prior 5:1 doc-only infra re-measurement churn (S6/S8/S10/S11/S12). Build NOT attempted: Docker down 2026-06-13 (verification blackout).",
-    "blockers": [
-      "Verification blackout (2026-06-13, all routes): Docker daemon HUNG (docker info rc=124) and Aristotle backend 404 (mcp-smoke-test.sh). The sole remaining sorry (reverse direction, MinpolyCharpolyOQ02.lean:221) is build-dependent; CI does not build Lean, so a blind edit could silently break the currently-green file. Mathematically unblocked — bridges pinned."
-    ],
-    "nextAction": "UNBLOCK when Docker recovers, then S15 ACT (reverse direction only). Bridges B-fwd/C/D are in-tree; the sole gap is Bridge A reverse (eigenspace decomposition -> conjugating matrix), recipe written out in state.md S14: set f:=toLin' M; minpoly K f = minpoly K M (Matrix.minpoly_toLin'); f.IsSemisimple (Bridge C); iSup eigenspace = top (Bridge B fwd); then DirectSum.IsInternal of eigenspaces -> collectedBasis -> reindex to n -> P:=Basis.toMatrix -> IsDiag(P-inv M P). Est ~50 LOC -> ~330 LOC, 0 sorries, promote to verified.",
+    "focus": "SHIPPED (VERIFIED, 0-axiom, 0-sorry): reverse direction of diagonalizable_iff_squarefree_minpoly discharged; headline biconditional fully proved.",
+    "blockers": [],
+    "nextAction": "Done. Optional follow-ups: OQ-02-OQ-03 general-field form (perfect field + splits); OQ-02-OQ-04 char-0 separability corollary.",
     "attemptCounts": {
       "total": 15,
       "currentApproach": 14,
@@ -46,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S13 STATE-SYNC (researcher-1, 2026-06-13): content correction. The forward direction of the headline theorem (diagonalizable ⇒ squarefree minpoly) is now FULLY PROVED and unconditional over any field (Matrix.IsDiagonalizable.squarefree_minpoly), shipped via PR #22909 after S12. File MinpolyCharpolyOQ02.lean is 279 LOC, 9 theorems/lemmas, 2 defs, 0 axioms, 1 sorry — the sorry is now ONLY the reverse direction at line 221 (squarefree minpoly ⇒ diagonalizable over alg-closed char-0, via Bridge B/C through Matrix.toLin'). Prior tracker records (S11/S12) incorrectly described the file as 169 LOC / dormant-since-S7 with the forward direction still open. Build not attempted (Docker down 2026-06-13).",
+    "progressSummary": "SHIPPED (researcher-1, VERIFIED 0-axiom, 0-sorry). Closed the multi-session-blocked reverse-direction sorry: diagonalizable_iff_squarefree_minpoly is now fully proved over [IsAlgClosed K][CharZero K]. Added isDiagonalizable_of_eigenbasis (change-of-basis eigenbasis bridge: P=e.toMatrix b gives P⁻¹MP=diagonal μ) and assembled the reverse direction via Bridge C (semisimple↔squarefree, minpoly_toLin') + Bridge B (eigenspaces span) + eigenspaces_iSupIndep → DirectSum.IsInternal → collectedBasis eigenbasis → reindex to n (equivOfCardEq) → the eigenbasis bridge. File now 389 LOC, 12 thm, 2 def, 0 sorries, 0 axioms. #print axioms = only propext/Classical.choice/Quot.sound.",
     "builtItems": [
       "Matrix.IsDiagonalizable (def, line 107-108): `∃ P, IsUnit P ∧ IsDiag (P⁻¹ * M * P)` — the matrix-level diagonalizability predicate as an existential over invertible similarity transforms.",
       "diagonalizable_iff_squarefree_minpoly (theorem, sorry-guarded, lines 119-122): the S1 statement of the textbook characterisation under `IsAlgClosed K + CharZero K`. Single sorry at line 122; ~59 LOC paste expected to close it per S7c PREP §5.1.",
@@ -117,7 +111,7 @@
     ]
   },
   "started": "2026-05-12T20:35:00Z",
-  "lastUpdate": "2026-06-13T00:00:00.000Z",
+  "lastUpdate": "2026-07-01",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

**Closes the multi-session-blocked reverse-direction sorry.** The headline biconditional `diagonalizable_iff_squarefree_minpoly` over an algebraically closed field of characteristic zero is now **fully proved**:

```
M.IsDiagonalizable ↔ Squarefree (minpoly K M)     -- [IsAlgClosed K] [CharZero K]
```

**0 sorries, 0 axioms.** `#print axioms` on the headline theorem (and the new bridge) reports only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `ofReduceBool`.

## Two new verified theorems

1. **`isDiagonalizable_of_eigenbasis`** (any field): if `n → K` admits a basis `b` of eigenvectors of `Matrix.toLin' M` (`toLin' M (b i) = μ i • b i`), then `M` is diagonalizable. The witness is the change-of-basis matrix `P = e.toMatrix b` (from the standard basis `e`); in the eigenbasis the operator has matrix `diagonal μ`, and `basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix` gives `P⁻¹ M P = LinearMap.toMatrix b b (toLin' M) = diagonal μ`. This is the reusable reverse-direction core.

2. **`diagonalizable_iff_squarefree_minpoly`**: the reverse direction is assembled from
   - Bridge C (`Module.End.isSemisimple_iff_squarefree_minpoly`) + `Matrix.minpoly_toLin'` ⟹ `f = toLin' M` is semisimple;
   - Bridge B (`iSup_eigenspace_eq_top_of_isSemisimple`) ⟹ eigenspaces span (alg-closed);
   - `Module.End.eigenspaces_iSupIndep` + `DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top` ⟹ `DirectSum.IsInternal`;
   - `IsInternal.collectedBasis` of per-eigenspace `Module.finBasis` ⟹ an eigenbasis; `Fintype` on the Σ-index from `FiniteDimensional.fintypeBasisIndex`;
   - reindex to `n` by equal cardinality (`Fintype.equivOfCardEq`, `Module.finrank_eq_card_basis`) and apply the eigenbasis bridge.

The headline theorem was **relocated to the end of the file** (it originally preceded Bridges B/C and so could not reference them).

## Changes

- `proofs/Proofs/MinpolyCharpolyOQ02.lean`: 321 → 389 LOC, 11 → 12 theorems, **1 → 0 sorries**.
- `src/data/proofs/minpoly-charpoly-oq-02/meta.json`: promoted `formalized`/`wip` → **`verified`**/`verified`, sorries 1 → 0, counts refreshed, new contributions documented.
- Research entry marked `completed`.

## Verification

Built with `lake env lean` against Mathlib v4.26.0 (Docker unavailable — containerd I/O error). Full file compiles with **no errors or warnings**; axioms confirmed via `#print axioms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)