### PR TITLE
research(minpoly-charpoly-oq-03): discharge RCF existence sorry [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ03.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03.lean
@@ -3,6 +3,7 @@ import Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly
 import Mathlib.Algebra.Polynomial.Monic
 import Mathlib.Tactic
 import Proofs.MinpolyCharpoly
+import Proofs.RationalCanonicalFormExists
 
 /-
 # Rational Canonical Form via Minimal-Polynomial Invariant Factors
@@ -109,9 +110,13 @@ assessment).
   chain, target value `charpoly M`.
 * **`InvariantFactorChain.lastFactor`** — the last factor `pₖ`, target
   value `minpoly M`.
-* **`rational_canonical_form_exists`** — the **main RCF theorem
-  statement**, guarded by a single `sorry` that the S1 OBSERVE iteration
-  leaves for the four sub-OQs above to discharge.
+* **`rational_canonical_form_exists`** — the **main RCF theorem**
+  (strong form: product `= charpoly M`, last factor `= minpoly F M`),
+  now **fully proved** (S16). The lone `sorry` is discharged by a
+  one-line bridge to `RationalCanonicalFormExists.rational_canonical_form_exists`
+  (the axiom-free RCF development built from scratch in-tree via the PID
+  structure theorem). The similarity-transform assertion remains omitted,
+  deferred to sub-OQ OQ-03-OQ-04.
 * **`prodFactors_empty`** — unconditional sanity check that an empty
   chain has product 1.
 * **`prodFactors_monic`** *(S2)* — the product of the invariant factors
@@ -196,40 +201,53 @@ noncomputable def InvariantFactorChain.lastFactor
     (c : InvariantFactorChain F) : F[X] :=
   c.factors.getLast?.getD 1
 
-/-! ## Part 2: Main Theorem Statement (S1 — sorry placeholder)
+/-! ## Part 2: Main Theorem (proved)
 
-The S1 deliverable is the **statement** of the rational canonical form
-existence theorem. The proof is left as a `sorry` and will be
-discharged by the four-step decomposition documented at the top of
-this file (sub-OQs `oq-03-oq-01` through `oq-03-oq-04`).
+The **rational canonical form existence theorem**, strong form. The
+proof (S16) discharges the former `sorry` by bridging to the axiom-free
+in-tree `RationalCanonicalFormExists` development, whose
+`InvariantFactorChain` is field-identical to this one.
 -/
 
-/-- **Rational Canonical Form — Existence (S1 statement; S14 strengthened; S2+ proof)**:
+/-- **Rational Canonical Form — Existence (strong form; proved S16)**:
 
     Every square matrix `M` over a field `F` admits an
     `InvariantFactorChain` whose product equals `charpoly M` **and**
     whose last factor equals `minpoly M`.
 
-    *Status*: **S14 strong-form statement** — statement only, proof
-    deferred to the four-step decomposition (sub-OQs `oq-03-oq-01`
-    through `oq-03-oq-04`) plus the `lastFactor = minpoly`
-    follow-up (state.md next-action option 2).
+    *Status*: **fully proved, axiom-free** (`#print axioms` reports only
+    propext/Classical.choice/Quot.sound). The proof discharges the
+    former `sorry` by a one-line bridge to
+    `RationalCanonicalFormExists.rational_canonical_form_exists` — the
+    strong-form RCF existence theorem built from scratch in-tree (via
+    Mathlib's `Module.equiv_directSum_of_isTorsion` and a combinatorial
+    regrouping of prime powers into an invariant-factor chain). Its
+    `InvariantFactorChain` is field-identical to this one, so the four
+    fields copy across and the two equalities transport definitionally.
 
-    The strong form adds the conjunct `c.lastFactor = M.minpoly` to
-    the S1 statement. This sets up the deliverable surface for the
-    follow-up proof (option 2 in state.md): the structural fact that
-    `ann(xModule M) = (M.minpoly)` (via
-    `annihilator_top_eq_ker_aeval`) plus monic uniqueness forces
-    `c.lastFactor = M.minpoly`. The strengthened statement remains
-    consistent with the full Frobenius theorem; only the similarity-
-    transform assertion (`M` is similar to the block diagonal of the
-    companion matrices) is still omitted, to be added when sub-OQ
+    The strong form asserts the conjunct `c.lastFactor = M.minpoly`
+    (not optional padding: without it a degenerate chain
+    `factors = [charpoly M]` would satisfy the existential vacuously).
+    Only the similarity-transform assertion (`M` is similar to the block
+    diagonal of the companion matrices) is still omitted, to be added
+    when sub-OQ
     `oq-03-oq-04` lands. -/
 theorem rational_canonical_form_exists
     {n : Type*} [Fintype n] [DecidableEq n] (M : Matrix n n F) :
     ∃ c : InvariantFactorChain F,
       c.prodFactors = M.charpoly ∧ c.lastFactor = minpoly F M := by
-  sorry
+  -- Discharged by `RationalCanonicalFormExists.rational_canonical_form_exists`, the
+  -- axiom-free strong-form RCF existence theorem proved in the companion file
+  -- `Proofs/RationalCanonicalFormExists.lean` (Aristotle-synthesized, integrated
+  -- verbatim). Its `InvariantFactorChain` is field-identical to this one
+  -- (`factors`/`monic`/`posDegree`/`chain`), and `prodFactors` / `lastFactor` are
+  -- definitionally `factors.prod` / `factors.getLast?.getD 1` on both, so we copy
+  -- the four fields across and transport the two equalities unchanged. This is the
+  -- same one-line bridge already used by `MinpolyCharpolyOQ03OQ01`
+  -- (`xModule_has_invariantFactorChain`); it is inlined here rather than imported to
+  -- avoid the import cycle (the OQ-01 bridge imports this file).
+  obtain ⟨c, hprod, hlast⟩ := RationalCanonicalFormExists.rational_canonical_form_exists M
+  exact ⟨⟨c.factors, c.monic, c.posDegree, c.chain⟩, hprod, hlast⟩
 
 /-! ## Part 3: Unconditional structural lemmas
 

--- a/research/problems/minpoly-charpoly-oq-03/sessions/2026-07-01-s16-act-discharge-rcf-existence.md
+++ b/research/problems/minpoly-charpoly-oq-03/sessions/2026-07-01-s16-act-discharge-rcf-existence.md
@@ -1,0 +1,60 @@
+# S16 ACT — Discharge `rational_canonical_form_exists` (RCF existence)
+
+**Researcher:** researcher-2
+**Date:** 2026-07-01
+**Phase:** ACT → COMPLETED
+**Result:** The lone remaining `sorry` in `Proofs/MinpolyCharpolyOQ03.lean`
+is discharged. The file is now **0-sorry, 0-axiom** (`#print axioms` reports
+only `propext` / `Classical.choice` / `Quot.sound`). Gallery entry promoted
+`formalized`/`wip` → `verified`/`verified`.
+
+## The key observation
+
+The parent's open sorry (`rational_canonical_form_exists`, strong form:
+`∃ c, c.prodFactors = M.charpoly ∧ c.lastFactor = minpoly F M`) is the
+**exact same statement** already proved, axiom-free, elsewhere in-tree:
+
+- `Proofs/RationalCanonicalFormExists.lean` contains a fully-proved
+  `rational_canonical_form_exists` (Aristotle-synthesized, project
+  `d2395b8d`, integrated verbatim). It builds the theory from scratch:
+  the `F[X]`-module `mulX` on `Fⁿ`, `charpoly_mulX_*` naturality lemmas,
+  `det/charpoly_blockDiagonal'`, primary decomposition via Mathlib's
+  `Module.equiv_directSum_of_isTorsion`, and a combinatorial regrouping of
+  prime powers into a divisibility chain (`exists_chain_aux`).
+- `Proofs/MinpolyCharpolyOQ03OQ01.lean` already consumed it in
+  `xModule_has_invariantFactorChain` (same statement, via a one-line field
+  copy) — but the OQ-01 bridge **imports** the parent, so the parent could
+  not import it back (cycle).
+
+## The fix (2 lines of proof + 1 import)
+
+Added `import Proofs.RationalCanonicalFormExists` to the parent and inlined
+the same bridge the OQ-01 file uses (its `InvariantFactorChain` is
+field-identical — `factors`/`monic`/`posDegree`/`chain` — and
+`prodFactors`/`lastFactor` are definitionally `factors.prod` /
+`factors.getLast?.getD 1` on both):
+
+```lean
+obtain ⟨c, hprod, hlast⟩ := RationalCanonicalFormExists.rational_canonical_form_exists M
+exact ⟨⟨c.factors, c.monic, c.posDegree, c.chain⟩, hprod, hlast⟩
+```
+
+This is a wiring/integration step, not new deep mathematics: the hard proof
+already lived in-tree. What it does close is the parent gallery entry —
+15 prior iterations left this build-gated behind a hung Docker daemon.
+
+## Build notes
+
+- Docker image build is still broken (`containerd` `input/output error`)
+  even though `docker info` succeeds — so `docker-build.sh` fails.
+- Fallback: `LAKE_UNSAFE=1 lake env lean` in the worktree (`.lake` symlinks
+  the main `proofs/.lake`). `RationalCanonicalFormExists.olean` was missing
+  from the shared build, so built it first (~38 s), then the parent (clean).
+
+## Follow-ups (NOT pursued — depth guard)
+
+Slug depth is 1 (`minpoly-charpoly-oq-03`), so follow-ups are allowed, but
+both natural ones are genuinely large and better as future sibling OQs:
+- explicit similarity transform `M ~ ⊕ companionMatrix pᵢ` (OQ-03-OQ-04, ~200 LOC);
+- uniqueness of the invariant-factor chain up to associates.
+No weak follow-ups proposed.

--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -1,13 +1,13 @@
 {
   "id": "minpoly-charpoly-oq-03",
-  "title": "Rational Canonical Form via Minimal-Polynomial Invariant Factors (S1 Scaffold)",
+  "title": "Rational Canonical Form via Minimal-Polynomial Invariant Factors",
   "slug": "minpoly-charpoly-oq-03",
-  "description": "S1 OBSERVE scaffold resolving the parent's third open question 'Can the rational canonical form (based on minpoly factorization) be formalized?' Affirmative: provides the abstract InvariantFactorChain data structure, states the main RCF existence theorem (guarded by a single sorry), and lays out a four-sub-OQ decomposition routing through Mathlib's structure theorem for finitely generated modules over a PID plus the in-tree companion matrix infrastructure.",
+  "description": "Resolves the parent's third open question 'Can the rational canonical form (based on minpoly factorization) be formalized?' — affirmatively and now fully machine-checked. Provides the abstract InvariantFactorChain data structure and proves the main RCF existence theorem (strong form): every square matrix M over a field admits an invariant-factor chain p_1 | p_2 | ... | p_k with product = charpoly M and last factor = minpoly F M. The lone remaining sorry was discharged (S16) by bridging to the axiom-free in-tree RationalCanonicalFormExists development, which builds the required theory from scratch via Mathlib's structure theorem for finitely generated torsion modules over a PID plus a combinatorial regrouping of prime powers into a divisibility chain.",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/PID.html",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/MinpolyCharpolyOQ03.lean",
     "tags": [
       "linear-algebra",
@@ -19,11 +19,11 @@
       "structure-theorem-pid",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 721,
-    "assumptions": "0 axioms; 1 sorry guarding the proof of `rational_canonical_form_exists`. The sorry is the four-sub-OQ scaffold's main deliverable (S1 OBSERVE → S2+ ACT) plus the lastFactor=minpoly follow-up. The statement itself is unconditional. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.Basic`, `Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly`, `Mathlib.Algebra.Polynomial.Monic`, `Mathlib.Tactic`, `Proofs.MinpolyCharpoly`. S13 added Part 7 — the firstFactor-side mirror to Parts 5–6 — yielding the structural sandwich k · deg(firstFactor) ≤ deg(prodFactors) ≤ k · deg(lastFactor) on the abstract InvariantFactorChain. S14 (2026-06-04) strengthens the rational_canonical_form_exists statement to additionally assert `c.lastFactor = M.minpoly`, sorry-preserved (state.md next-action option 3). S15 (2026-06-09) adds Part 8 — three endpoint-divisibility helpers (lastFactor_dvd_prodFactors, firstFactor_dvd_prodFactors, firstFactor_dvd_lastFactor) yielding the abstract counterpart of the parent file's headline `minpoly ∣ charpoly` theorem on the chain endpoints, sorry-free.",
+    "lineCount": 739,
+    "assumptions": "0 axioms, 0 sorries — fully machine-checked (`#print axioms` reports only propext/Classical.choice/Quot.sound). S16 (2026-07-01) discharges the lone remaining `sorry` on `rational_canonical_form_exists` (RCF existence, strong form: an invariant-factor chain with product = charpoly M and last factor = minpoly F M). The proof adds `import Proofs.RationalCanonicalFormExists` and bridges to the axiom-free `RationalCanonicalFormExists.rational_canonical_form_exists` (Aristotle-synthesized, integrated verbatim in-tree; its `InvariantFactorChain` is field-identical, so the four fields copy across and the two equalities transport definitionally). This is the same one-line bridge already used by `MinpolyCharpolyOQ03OQ01.xModule_has_invariantFactorChain`, inlined here to avoid the import cycle (the OQ-01 bridge imports this file). Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.Basic`, `Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly`, `Mathlib.Algebra.Polynomial.Monic`, `Mathlib.Tactic`, `Proofs.MinpolyCharpoly`, `Proofs.RationalCanonicalFormExists`. Earlier layers: S13 Part 7 (firstFactor-side mirror, structural sandwich k·deg(firstFactor) ≤ deg(prodFactors) ≤ k·deg(lastFactor)); S14 strengthened the statement to add `c.lastFactor = M.minpoly`; S15 Part 8 (three endpoint-divisibility helpers yielding the abstract `minpoly ∣ charpoly` on the chain endpoints).",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
     "theoremCount": 25,
@@ -31,7 +31,7 @@
     "originalContributions": [
       "InvariantFactorChain structure: bundles a list of monic polynomials with divisibility chain p_1 | p_2 | ... | p_k as a first-class invariant",
       "InvariantFactorChain.prodFactors and .lastFactor: the two target values (charpoly, minpoly) packaged with the data",
-      "rational_canonical_form_exists: statement of Frobenius's RCF existence theorem (sorry-guarded; weak form omitting similarity and minpoly equality)",
+      "rational_canonical_form_exists: Frobenius's RCF existence theorem (strong form: product = charpoly M, last factor = minpoly F M), fully proved by bridging to the in-tree axiom-free RationalCanonicalFormExists development; the similarity-transform assertion is still omitted (deferred to sub-OQ OQ-03-OQ-04)",
       "Sub-OQ decomposition (OQ-03-OQ-01 ... OQ-03-OQ-04): four-step roadmap totaling ~900 lines for the full RCF formalization, routed via Mathlib's `Module.equiv_directSum_of_isTorsion`",
       "InvariantFactorChain.firstFactor + firstFactor-side mirror lemmas (membership, monicness, natDegree-minimality, length-times-first lower bound on prodFactors.natDegree) — the symmetric counterpart to the lastFactor-side helpers, yielding a two-sided sandwich on prodFactors.natDegree"
     ],
@@ -67,7 +67,7 @@
   "overview": {
     "historicalContext": "Frobenius (1879) classified matrices over a field up to similarity via the rational canonical form (RCF): every square matrix M over F is similar to a block-diagonal matrix whose blocks are the companion matrices of a sequence of monic polynomials p_1, p_2, …, p_k satisfying p_1 | p_2 | ⋯ | p_k. The polynomials, called the *invariant factors* of M, are uniquely determined by M, and their last factor equals minpoly(M) while their product equals charpoly(M). The RCF is the field-independent canonical form: it makes no use of eigenvalues (unlike Jordan normal form) and exists over any field, including non-algebraically-closed fields like ℚ. Modern presentations (Dummit & Foote §12.2, Hungerford §VII.4) derive the RCF from the structure theorem for finitely generated modules over a principal ideal domain, applied to K^n viewed as an F[X]-module via the action of M.",
     "problemStatement": "**Open Question (minpoly-charpoly-oq-03)**: Can the rational canonical form (based on minpoly factorization) be formalized in Lean 4? — `conclusion.openQuestions[2]` of the parent gallery entry `minpoly-charpoly`. The question is whether Lean 4 + Mathlib provides enough infrastructure to (a) state RCF rigorously and (b) prove the existence theorem.",
-    "text": "**Resolution (S1 OBSERVE): YES.** All three required ingredients are available — companion-matrix infrastructure (in-tree), Mathlib's structure theorem for finitely generated modules over a PID, and the cyclic-summand-to-companion-block correspondence. The remaining work is purely integrative and decomposes into four sub-OQs totaling ~900 lines.",
+    "text": "**Resolution: YES — and now fully proved.** All three required ingredients are available — companion-matrix infrastructure (in-tree), Mathlib's structure theorem for finitely generated modules over a PID, and the prime-power → invariant-factor regrouping. The existence theorem `rational_canonical_form_exists` (product = charpoly, last factor = minpoly) is machine-checked axiom-free (S16), bridging to the in-tree `RationalCanonicalFormExists` development. Only the explicit similarity-transform assertion remains as future work (sub-OQ OQ-03-OQ-04).",
     "proofStrategy": "**S1 scaffold deliverable**: state RCF rigorously via `InvariantFactorChain` (structure bundling factors + monic + posDegree + divisibility chain) and `rational_canonical_form_exists` (existence theorem with sorry).\n\n**S2+ deliverable** (sub-OQs):\n\n1. **OQ-03-OQ-01** (~150 lines): F[X]-module structure on K^n via the M-action; show finitely generated and torsion (Cayley-Hamilton).\n2. **OQ-03-OQ-02** (~300 lines): apply `Module.equiv_directSum_of_isTorsion` to obtain the invariant-factor decomposition with divisibility chain.\n3. **OQ-03-OQ-03** (~250 lines): on each cyclic F[X]/(p_i), basis {1, X, ..., X^{d_i-1}} realises mul-by-X as companionMatrix p_i.\n4. **OQ-03-OQ-04** (~200 lines): reassembly into the global similarity transform.",
     "keyInsights": [
       "**Three-ingredient resolution**: companion matrix (in-tree) + Mathlib structure theorem (PID) + cyclic-summand-to-companion correspondence. No genuine Mathlib gap; only integrative work remains.",
@@ -112,10 +112,10 @@
     },
     {
       "id": "part-2",
-      "title": "§2 (Part 2): rational_canonical_form_exists (S14 statement + sorry)",
+      "title": "§2 (Part 2): rational_canonical_form_exists (proved)",
       "startLine": 199,
-      "endLine": 233,
-      "summary": "The main deliverable statement: Frobenius's RCF existence theorem in its S14-strengthened form — every square matrix `M` over a field admits an `InvariantFactorChain` whose product equals `M.charpoly` AND whose last factor equals `minpoly F M`. The proof is the single `sorry` in the file (line 232); the similarity-transform assertion is still omitted, deferred to sub-OQ OQ-03-OQ-04.",
+      "endLine": 245,
+      "summary": "The main deliverable: Frobenius's RCF existence theorem in its S14-strengthened form — every square matrix `M` over a field admits an `InvariantFactorChain` whose product equals `M.charpoly` AND whose last factor equals `minpoly F M`. Now fully proved (S16): the lone `sorry` is discharged by a one-line bridge to `RationalCanonicalFormExists.rational_canonical_form_exists` (axiom-free, in-tree). The similarity-transform assertion is still omitted, deferred to sub-OQ OQ-03-OQ-04.",
       "mathContext": "**Frobenius RCF (existence, S14 form)**: $\\forall M\\in\\mathrm{Mat}_n(F),\\ \\exists(p_1,\\dots,p_k)$ monic with $\\deg p_i\\ge 1$, $p_1\\mid\\cdots\\mid p_k$, $\\prod_i p_i=\\mathrm{charpoly}(M)$ and $p_k=\\mathrm{minpoly}(M)$."
     },
     {
@@ -185,12 +185,12 @@
       "BigOperators"
     ],
     "namespace": "MinpolyCharpolyOQ03",
-    "lineCount": 721,
+    "lineCount": 739,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 4,
     "path": "Proofs/MinpolyCharpolyOQ03.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -230,7 +230,7 @@
       "significance": "Internal consistency of InvariantFactorChain / prodFactors definitions"
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "references": [
     {
       "authors": [

--- a/src/data/research/problems/minpoly-charpoly-oq-03.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "minpoly-charpoly-oq-03",
   "title": "Rational Canonical Form via Minimal-Polynomial Invariant Factors",
-  "phase": "BLOCKED",
-  "status": "blocked",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -28,19 +28,15 @@
     "goal": "Statement and proof of `rational_canonical_form_exists`: every square matrix M over a field F admits an invariant-factor chain (p_1, ..., p_k) with product charpoly(M), last entry minpoly(M), and similarity to the block diagonal of the companion matrices."
   },
   "currentState": {
-    "phase": "BLOCKED",
-    "since": "2026-06-13T00:00:00Z",
-    "iteration": 15,
-    "focus": "S15 STATUS-SYNC — flag BLOCKED on the verification blackout. The sole remaining sorry (rational_canonical_form_exists, line 232) is dischargeable only via the OQ-03-OQ-02 elementary-divisors→invariant-factors regrouping (~340 LOC new Lean), which is build-dependent. Both verification routes are down (Docker daemon HUNG — `docker info` times out; Aristotle backend 404), and CI does not build Lean, so a blind edit could silently break the currently-green file. Per the flag-BLOCKED-over-PREP-churn rule (14 iters: 1 OBSERVE + multiple PREP/statement-only ACTs around one build-gated sorry), this flags blocked rather than adding doc memo #N. Sibling minpoly-charpoly-oq-02 was flagged BLOCKED today for the identical reason (PR #23025). Also synced gallery meta.json lineCount 631→639 to the actual origin/main source.",
-    "blockers": [
-      "Docker daemon HUNG (`docker info` times out / killed exit 144) — Lean builds unverifiable.",
-      "Aristotle backend 404 (MCP connects but proof jobs fail).",
-      "CI does not build Lean — blind ACT on the 340-LOC OQ-03-OQ-02 regrouping could silently break the green file."
-    ],
-    "nextAction": "UNBLOCK when Docker is restored: implement OQ-03-OQ-02 ACT (Route B) — the elementary-divisors → invariant-factors regrouping algorithm sketched in S11 PREP §6 (PR #18668), ~340 LOC in a new file Proofs/MinpolyCharpolyOQ03OQ02.lean. On completion the xModule_has_invariantFactorChain sorry collapses to a ~5-line glue import and rational_canonical_form_exists can be discharged. Independent follow-ups available once a chain exists: c.lastFactor = M.minpoly (~15-30 LOC, S11 PREP §7 via annihilator_top_eq_ker_aeval). All require a working Docker build (~45 min cold per .lake self-symlink trap).",
+    "phase": "COMPLETED",
+    "since": "2026-07-01T00:00:00Z",
+    "iteration": 16,
+    "focus": "S16 ACT — DISCHARGED the lone sorry on rational_canonical_form_exists. Docker restored (containerd still I/O-broken for image build; used lake env lean fallback). The strong-form RCF existence theorem was already proved axiom-free in-tree in RationalCanonicalFormExists.lean (Aristotle-synthesized) and consumed by the OQ-01 bridge xModule_has_invariantFactorChain. The parent's sorry was the SAME statement — discharged by adding import Proofs.RationalCanonicalFormExists and copying the four field-identical InvariantFactorChain fields. File now 0-sorry, 0-axiom (#print axioms: only propext/Classical.choice/Quot.sound). Gallery meta -> verified/verified.",
+    "blockers": [],
+    "nextAction": "DONE for the existence theorem. Optional future work (new sibling OQ, not a recursion): the explicit similarity-transform assertion M ~ blockdiag(companionMatrix p_i) (sub-OQ OQ-03-OQ-04, ~200 LOC) and uniqueness of the invariant-factor chain up to associates.",
     "attemptCounts": {
-      "total": 15,
-      "currentApproach": 15,
+      "total": 16,
+      "currentApproach": 16,
       "approachesTried": 1
     }
   },


### PR DESCRIPTION
## Summary

Closes the parent gallery entry's third open question by discharging the **lone remaining `sorry`** on `rational_canonical_form_exists` in `Proofs/MinpolyCharpolyOQ03.lean`. The file is now **0-sorry, 0-axiom**.

`#print axioms MinpolyCharpolyOQ03.rational_canonical_form_exists` → `[propext, Classical.choice, Quot.sound]` (only the standard foundational axioms — none of `Lean.ofReduceBool` / `sorryAx`).

## The key observation

The parent's open sorry — the strong-form RCF existence theorem

```
∃ c : InvariantFactorChain F, c.prodFactors = M.charpoly ∧ c.lastFactor = minpoly F M
```

is the **identical statement** already proved axiom-free elsewhere in-tree:

- `Proofs/RationalCanonicalFormExists.lean` proves it from scratch (Aristotle-synthesized, project `d2395b8d`): the `F[X]`-module `mulX` on `Fⁿ`, charpoly naturality, block-diagonal multiplicativity, primary decomposition via Mathlib's `Module.equiv_directSum_of_isTorsion`, and a combinatorial regrouping of prime powers into a divisibility chain.
- `Proofs/MinpolyCharpolyOQ03OQ01.lean` already consumed it (`xModule_has_invariantFactorChain`), but that bridge **imports** the parent, so the parent could not import it back.

## The fix

Add `import Proofs.RationalCanonicalFormExists` to the parent and inline the same one-line bridge (the two `InvariantFactorChain` structures are field-identical; `prodFactors`/`lastFactor` are definitionally `factors.prod` / `factors.getLast?.getD 1` on both):

```lean
obtain ⟨c, hprod, hlast⟩ := RationalCanonicalFormExists.rational_canonical_form_exists M
exact ⟨⟨c.factors, c.monic, c.posDegree, c.chain⟩, hprod, hlast⟩
```

This is an **integration/wiring step**, not new deep mathematics — the hard proof already lived in-tree. What it closes is the gallery entry, which sat BLOCKED for 15 iterations because both verification routes (Docker, Aristotle) were down and CI does not build Lean.

## Verification

- Built via `lake env lean` (Docker image build is still broken — `containerd` I/O error — though `docker info` succeeds). Clean: 0 sorry / 0 error / 0 warning.
- Gallery `meta.json` promoted `formalized`/`wip` → `verified`/`verified`, `sorries` 1 → 0, lineCount → 739.
- Research tracker `BLOCKED` → `completed`.

## Not included (future sibling OQs)

- Explicit similarity transform `M ~ ⊕ companionMatrix pᵢ` (sub-OQ OQ-03-OQ-04).
- Uniqueness of the invariant-factor chain up to associates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)