### PR TITLE
Enrich Probabilistic Method Applications WIP-01-OQ-01: add missing index.ts

### DIFF
--- a/src/data/proofs/prob-method-applications-wip-01-oq-01/index.ts
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ProbMethodApplicationsWIPOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const probMethodApplicationsWip01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const probMethodApplicationsWip01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const probMethodApplicationsWip01Oq01Data: ProofData = {
+  proof: probMethodApplicationsWip01Oq01Proof,
+  annotations: probMethodApplicationsWip01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `prob-method-applications-wip-01-oq-01`.

## Changes
- **Added missing `index.ts`** — the entry had no Vite entry point, so `import.meta.glob` could not discover it and the page would render *proof not found* on the live site. Follows the canonical gallery template (raw-import `../../../../proofs/Proofs/ProbMethodApplicationsWIPOQ01.lean?raw`).

## Verification
- `index.ts` structure checked programmatically; meta.json/annotations.json already valid.
- No content changed; the entry already meets quality targets (5 keyInsights, all annotations with valid significance, mathContext, relatedConcepts, prerequisites; full conclusion) at ~18 KB, under the size cap.