### PR TITLE
research(de-moivre-oq-01-oq-01-oq-01): binomial expansion of sin(nθ) and its Chebyshev-U connection [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DeMoivreOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ01OQ01OQ01.lean
@@ -1,0 +1,199 @@
+import Mathlib
+
+/-
+# De Moivre OQ-01-OQ-01-OQ-01: The Binomial Expansion of sin(nθ) and its Chebyshev-U Connection
+
+## Open Question
+
+This entry answers the **leading open question** posed by the parent entry
+`de-moivre-oq-01-oq-01` ("The Binomial Expansion of cos(nθ) and its Chebyshev
+Connection"):
+
+> Can the companion `sin(nθ) = sin θ · Σ_j (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j} θ`
+> expansion be derived the same way (as the *imaginary* part of the binomial
+> theorem) and connected to `U_{n-1}`?
+
+The answer is **yes**.  Where the parent extracted the *real* part of
+`(cos θ + i sin θ)^n` to obtain `cos(nθ)` and the Chebyshev polynomial `T_n`,
+this entry extracts the *imaginary* part to obtain `sin(nθ)` and connects the
+explicit odd-index binomial sum to the Chebyshev polynomial of the **second**
+kind `U_{n}`.
+
+## Mathematical Content
+
+De Moivre's theorem gives `(cos θ + i sin θ)^n = cos(nθ) + i sin(nθ)`.
+Expanding the left side by the binomial theorem and comparing *imaginary* parts,
+
+  `sin(nθ) = Σ_{k=0}^n C(n,k) cos^k θ · sin^{n-k} θ · Im(i^{n-k})`.
+
+Since `Im(i^m) = 0` for even `m` and `Im(i^{2j+1}) = (-1)^j`, only **odd** powers
+of `sin` survive, recovering the classical closed form
+
+  `sin(nθ) = Σ_{j} (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j+1} θ`
+          `= sin θ · Σ_{j} (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j} θ`.
+
+The bracketed factor, viewed as a polynomial in `cos θ` after `sin² = 1 - cos²`,
+is exactly the Chebyshev polynomial `U_{n-1}(cos θ)`, giving the classical
+identity `sin(nθ) = U_{n-1}(cos θ) · sin θ`.
+
+## What is proved here (0 axioms, Mathlib-backed)
+
+* `sin_nsmul_eq_im_pow`   — `sin(nθ) = Im((cos θ + i sin θ)^n)` (imaginary-part extraction).
+* `sin_nsmul_binomial_im` — the full binomial expansion with the `Im(i^{n-k})` factor.
+* `sin_nsmul_binomial_odd`— the classical `(-1)^j`, odd-index closed form.
+* `sin_nsmul_eq_sin_mul`  — the `sin θ` factored form (the shape asked for in the OQ).
+* `chebyshev_U_eq_binomial_sum` — the Chebyshev-U polynomial (times `sin θ`) equals the
+  explicit odd-index binomial sum, closing the analogy with the parent's `T_n` result.
+
+This is the exact odd-index / imaginary-part mirror of the parent's even-index /
+real-part development; the two together give the full real+imaginary decomposition
+of De Moivre's theorem in explicit binomial form.
+-/
+
+open Polynomial Polynomial.Chebyshev Real Finset
+
+namespace DeMoivreOQ01OQ01OQ01
+
+-- ============================================================
+-- PART 1: Imaginary-part extraction from De Moivre
+-- ============================================================
+
+/-- The De Moivre base point `cos θ + i sin θ` equals `exp(iθ)`. -/
+lemma cos_add_sin_I_eq_exp (θ : ℝ) :
+    (Real.cos θ : ℂ) + (Real.sin θ : ℂ) * Complex.I = Complex.exp (↑θ * Complex.I) := by
+  rw [Complex.exp_mul_I, Complex.ofReal_cos, Complex.ofReal_sin]
+
+/-- **Imaginary-part extraction**: `sin(nθ)` is the imaginary part of
+`(cos θ + i sin θ)^n`.  This is the precise meaning of "comparing imaginary
+parts in De Moivre's theorem". -/
+lemma sin_nsmul_eq_im_pow (θ : ℝ) (n : ℕ) :
+    Real.sin ((n : ℝ) * θ) = (((Real.cos θ : ℂ) + (Real.sin θ : ℂ) * Complex.I) ^ n).im := by
+  rw [cos_add_sin_I_eq_exp, ← Complex.exp_nat_mul]
+  rw [show (↑n * (↑θ * Complex.I) : ℂ) = ↑((n : ℝ) * θ) * Complex.I by push_cast; ring]
+  rw [Complex.exp_ofReal_mul_I_im]
+
+-- ============================================================
+-- PART 2: The binomial expansion of sin(nθ)
+-- ============================================================
+
+/-- **Binomial expansion of sin(nθ)** (imaginary-part form).  Expanding
+`(cos θ + i sin θ)^n` by the binomial theorem and taking the imaginary part gives
+an explicit polynomial in `cos θ` and `sin θ`.  The factor `Im(i^{n-k})` records
+the sign pattern coming from the powers of `i`. -/
+theorem sin_nsmul_binomial_im (θ : ℝ) (n : ℕ) :
+    Real.sin ((n : ℝ) * θ) =
+      ∑ k ∈ Finset.range (n + 1),
+        (n.choose k : ℝ) * Real.cos θ ^ k * Real.sin θ ^ (n - k) *
+          (Complex.I ^ (n - k)).im := by
+  rw [sin_nsmul_eq_im_pow, add_pow, Complex.im_sum]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  have hcast :
+      (Real.cos θ : ℂ) ^ k * ((Real.sin θ : ℂ) * Complex.I) ^ (n - k) * (n.choose k : ℂ)
+        = ((Real.cos θ ^ k * Real.sin θ ^ (n - k) * (n.choose k : ℝ) : ℝ) : ℂ) *
+            Complex.I ^ (n - k) := by
+    rw [mul_pow]; push_cast; ring
+  rw [hcast, Complex.im_ofReal_mul]; ring
+
+-- ============================================================
+-- PART 3: Parity of Im(iᵐ) and the odd-index closed form
+-- ============================================================
+
+/-- `Im(i^m) = 0` when `m` is even. -/
+lemma im_I_pow_even {m : ℕ} (hm : Even m) : (Complex.I ^ m).im = 0 := by
+  obtain ⟨j, rfl⟩ := hm
+  have h : Complex.I ^ (j + j) = (((-1 : ℝ) ^ j : ℝ) : ℂ) := by
+    rw [← two_mul, pow_mul, Complex.I_sq]; push_cast; ring
+  rw [h, Complex.ofReal_im]
+
+/-- `Im(i^{2j+1}) = (-1)^j`. -/
+lemma im_I_pow_two_mul_add_one (j : ℕ) : (Complex.I ^ (2 * j + 1)).im = (-1 : ℝ) ^ j := by
+  have h : Complex.I ^ (2 * j + 1) = (((-1 : ℝ) ^ j : ℝ) : ℂ) * Complex.I := by
+    rw [pow_add, pow_mul, Complex.I_sq, pow_one]; push_cast; ring
+  rw [h, Complex.mul_I_im, Complex.ofReal_re]
+
+/-- **Classical closed form of sin(nθ)**: only odd powers of `sin θ` survive,
+with alternating signs.  This is the standard multiple-angle formula
+`sin(nθ) = Σ_j (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j+1} θ`. -/
+theorem sin_nsmul_binomial_odd (θ : ℝ) (n : ℕ) :
+    Real.sin ((n : ℝ) * θ) =
+      ∑ j ∈ Finset.range ((n + 1) / 2),
+        (-1 : ℝ) ^ j * (n.choose (2 * j + 1) : ℝ) *
+          Real.cos θ ^ (n - (2 * j + 1)) * Real.sin θ ^ (2 * j + 1) := by
+  -- Reflect the index k ↦ n - k so the surviving power is that of `sin`.
+  have key : Real.sin ((n : ℝ) * θ)
+      = ∑ i ∈ Finset.range (n + 1),
+          (n.choose i : ℝ) * Real.cos θ ^ (n - i) * Real.sin θ ^ i * (Complex.I ^ i).im := by
+    rw [sin_nsmul_binomial_im, ← Finset.sum_range_reflect
+          (fun k => (n.choose k : ℝ) * Real.cos θ ^ k * Real.sin θ ^ (n - k) *
+            (Complex.I ^ (n - k)).im) (n + 1)]
+    refine Finset.sum_congr rfl (fun i hi => ?_)
+    rw [Finset.mem_range] at hi
+    have hle : i ≤ n := by omega
+    have h1 : n + 1 - 1 - i = n - i := by omega
+    have h2 : n - (n - i) = i := by omega
+    rw [h1, h2, Nat.choose_symm hle]
+  -- The odd indices `i = 2j+1` are exactly the image of `range ((n+1)/2)` under `j ↦ 2j+1`.
+  have hsub : (Finset.range ((n + 1) / 2)).image (fun j => 2 * j + 1) ⊆ Finset.range (n + 1) := by
+    intro i hi
+    simp only [Finset.mem_image, Finset.mem_range] at hi ⊢
+    obtain ⟨j, hj, rfl⟩ := hi
+    omega
+  -- Even-index terms vanish because `Im(i^i) = 0`.
+  have hzero : ∀ i ∈ Finset.range (n + 1),
+      i ∉ (Finset.range ((n + 1) / 2)).image (fun j => 2 * j + 1) →
+      (n.choose i : ℝ) * Real.cos θ ^ (n - i) * Real.sin θ ^ i * (Complex.I ^ i).im = 0 := by
+    intro i hi hni
+    rw [Finset.mem_range] at hi
+    have heven : Even i := by
+      rcases Nat.even_or_odd i with he | ho
+      · exact he
+      · exfalso
+        obtain ⟨j, rfl⟩ := ho
+        exact hni (by
+          rw [Finset.mem_image]
+          exact ⟨j, Finset.mem_range.mpr (by omega), rfl⟩)
+    rw [im_I_pow_even heven, mul_zero]
+  rw [key, ← Finset.sum_subset hsub hzero,
+      Finset.sum_image (fun x _ y _ h => by omega)]
+  refine Finset.sum_congr rfl (fun j _ => ?_)
+  rw [im_I_pow_two_mul_add_one]; ring
+
+-- ============================================================
+-- PART 4: The `sin θ` factored form (as requested in the open question)
+-- ============================================================
+
+/-- **`sin θ`-factored form.**  Pulling `sin θ` out of every surviving term gives
+the shape asked for in the parent entry's open question:
+`sin(nθ) = sin θ · Σ_j (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j} θ`. -/
+theorem sin_nsmul_eq_sin_mul (θ : ℝ) (n : ℕ) :
+    Real.sin ((n : ℝ) * θ) =
+      Real.sin θ *
+        ∑ j ∈ Finset.range ((n + 1) / 2),
+          (-1 : ℝ) ^ j * (n.choose (2 * j + 1) : ℝ) *
+            Real.cos θ ^ (n - (2 * j + 1)) * Real.sin θ ^ (2 * j) := by
+  rw [sin_nsmul_binomial_odd, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun j _ => ?_)
+  ring
+
+-- ============================================================
+-- PART 5: Connection to Chebyshev polynomials of the second kind
+-- ============================================================
+
+/-- **Chebyshev-U connection.**  The Chebyshev polynomial of the second kind
+`U_n` evaluated at `cos θ`, multiplied by `sin θ`, equals the explicit odd-index
+binomial sum for `sin((n+1)θ)`.  This is the second-kind mirror of the parent
+entry's first-kind result `binomial_sum = T_n(cos θ)`.
+
+Combined with `sin_nsmul_binomial_odd`, it exhibits `U_n(cos θ) · sin θ` as the
+imaginary-part / odd-index counterpart of `T_n(cos θ)`. -/
+theorem chebyshev_U_eq_binomial_sum (θ : ℝ) (n : ℕ) :
+    (Polynomial.Chebyshev.U ℝ (n : ℤ)).eval (Real.cos θ) * Real.sin θ =
+      ∑ j ∈ Finset.range ((n + 1 + 1) / 2),
+        (-1 : ℝ) ^ j * ((n + 1).choose (2 * j + 1) : ℝ) *
+          Real.cos θ ^ ((n + 1) - (2 * j + 1)) * Real.sin θ ^ (2 * j + 1) := by
+  rw [← sin_nsmul_binomial_odd θ (n + 1), Polynomial.Chebyshev.U_real_cos θ (n : ℤ)]
+  congr 1
+  push_cast
+  ring
+
+end DeMoivreOQ01OQ01OQ01

--- a/src/data/proofs/de-moivre-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-dm010101-im-extraction",
+    "proofId": "de-moivre-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 57,
+      "endLine": 73
+    },
+    "type": "technique",
+    "title": "Imaginary-part extraction: sin(nθ) = Im((cos θ + i sin θ)ⁿ)",
+    "content": "The base point is identified with the complex exponential: `cos_add_sin_I_eq_exp` rewrites $\\cos\\theta + i\\sin\\theta$ as $e^{i\\theta}$ through Mathlib's `Complex.exp_mul_I` together with `ofReal_cos`/`ofReal_sin`. Then `sin_nsmul_eq_im_pow` powers up — $(\\cos\\theta + i\\sin\\theta)^n = (e^{i\\theta})^n = e^{in\\theta}$ via `exp_nat_mul` — and reads off the imaginary part with `exp_ofReal_mul_I_im`, giving $\\sin(n\\theta) = \\operatorname{Im}((\\cos\\theta + i\\sin\\theta)^n)$. This is the exact dual of the parent entry's real-part extraction, and the precise machine-checked meaning of 'compare imaginary parts in De Moivre's theorem'.",
+    "mathContext": "$\\cos\\theta + i\\sin\\theta = e^{i\\theta},\\quad \\sin(n\\theta) = \\operatorname{Im}\\big((\\cos\\theta + i\\sin\\theta)^n\\big).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's formula",
+      "complex exponential",
+      "De Moivre's theorem",
+      "imaginary part"
+    ],
+    "prerequisites": [
+      "Complex.exp_mul_I",
+      "Complex.exp_ofReal_mul_I_im"
+    ]
+  },
+  {
+    "id": "ann-dm010101-binomial",
+    "proofId": "de-moivre-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 95
+    },
+    "type": "key-step",
+    "title": "The imaginary part of the binomial theorem",
+    "content": "`sin_nsmul_binomial_im` applies `add_pow` to $(\\cos\\theta + i\\sin\\theta)^n$ and distributes the imaginary part over the resulting sum with `Complex.im_sum`. Each summand is normalised to the form $(\\text{real scalar})\\cdot i^{\\,n-k}$, so that `Complex.im_ofReal_mul` peels the real coefficient out of the imaginary part, leaving the factor $\\operatorname{Im}(i^{n-k})$. The output is the full expansion $\\sin(n\\theta) = \\sum_{k=0}^n \\binom{n}{k}\\cos^k\\theta\\,\\sin^{n-k}\\theta\\,\\operatorname{Im}(i^{n-k})$ — every term still present, with the sign/vanishing pattern quarantined into the single $\\operatorname{Im}(i^{n-k})$ factor.",
+    "mathContext": "$\\sin(n\\theta) = \\sum_{k=0}^n \\binom{n}{k}\\cos^k\\theta\\,\\sin^{n-k}\\theta\\,\\operatorname{Im}(i^{n-k}).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial theorem",
+      "complex numbers",
+      "big operators",
+      "imaginary part"
+    ],
+    "prerequisites": [
+      "add_pow",
+      "Complex.im_sum",
+      "Complex.im_ofReal_mul"
+    ]
+  },
+  {
+    "id": "ann-dm010101-parity",
+    "proofId": "de-moivre-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 97,
+      "endLine": 159
+    },
+    "type": "key-step",
+    "title": "Parity of Im(iᵐ) and the odd-index closed form",
+    "content": "The two parity lemmas `im_I_pow_even` ($\\operatorname{Im}(i^{2j}) = 0$, since $i^{2j} = (-1)^j$ is real) and `im_I_pow_two_mul_add_one` ($\\operatorname{Im}(i^{2j+1}) = (-1)^j$, since $i^{2j+1} = (-1)^j i$) fix exactly which terms survive: dual to the cosine case, the *odd* powers of $\\sin$ remain. `sin_nsmul_binomial_odd` then converts the raw sum to the textbook closed form by the parent's three-move recipe with the parity flipped — `sum_range_reflect` to orient the index onto $\\sin$, `sum_subset` to discard the vanishing *even*-index terms, and `sum_image` to reindex the odd indices $i = 2j+1$ via the injection $j \\mapsto 2j+1$.",
+    "mathContext": "$\\operatorname{Im}(i^{2j}) = 0,\\ \\operatorname{Im}(i^{2j+1}) = (-1)^j \\ \\Rightarrow\\ \\sin(n\\theta) = \\sum_{j} (-1)^j \\binom{n}{2j+1}\\cos^{n-2j-1}\\theta\\,\\sin^{2j+1}\\theta.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "powers of i",
+      "four-periodicity",
+      "Finset reindexing",
+      "parity"
+    ],
+    "prerequisites": [
+      "Complex.I_sq",
+      "Finset.sum_range_reflect",
+      "Finset.sum_subset",
+      "Finset.sum_image"
+    ]
+  },
+  {
+    "id": "ann-dm010101-sin-factored",
+    "proofId": "de-moivre-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 161,
+      "endLine": 176
+    },
+    "type": "insight",
+    "title": "Factoring out sin θ — the shape of the open question",
+    "content": "`sin_nsmul_eq_sin_mul` pulls a single $\\sin\\theta$ out of every surviving term with `Finset.mul_sum`, converting $\\sin^{2j+1}\\theta = \\sin\\theta\\cdot\\sin^{2j}\\theta$. The result $\\sin(n\\theta) = \\sin\\theta\\sum_j (-1)^j\\binom{n}{2j+1}\\cos^{n-2j-1}\\theta\\,\\sin^{2j}\\theta$ is the exact expression posed in the parent entry's open question. After the substitution $\\sin^2\\theta = 1-\\cos^2\\theta$, the bracketed factor is a polynomial in $\\cos\\theta$ — namely $U_{n-1}(\\cos\\theta)$ — which is why $\\sin\\theta$ appears as an overall factor rather than inside the polynomial.",
+    "mathContext": "$\\sin(n\\theta) = \\sin\\theta\\sum_{j} (-1)^j \\binom{n}{2j+1}\\cos^{n-2j-1}\\theta\\,\\sin^{2j}\\theta.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "factoring",
+      "Chebyshev U",
+      "sin/cos parity"
+    ],
+    "prerequisites": [
+      "Finset.mul_sum"
+    ]
+  },
+  {
+    "id": "ann-dm010101-chebyshev-u",
+    "proofId": "de-moivre-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 178,
+      "endLine": 199
+    },
+    "type": "key-step",
+    "title": "Connection to Chebyshev U: U_n(cos θ)·sin θ = the binomial sum",
+    "content": "`chebyshev_U_eq_binomial_sum` closes the analogy with the parent's $T_n$ result. Instantiating the odd-index expansion at $n+1$ gives the explicit binomial sum for $\\sin((n+1)\\theta)$; Mathlib's `U_real_cos` states $U_n(\\cos\\theta)\\cdot\\sin\\theta = \\sin((n+1)\\theta)$; composing the two (with a `push_cast; ring` to reconcile the $\\mathbb{N}\\to\\mathbb{Z}\\to\\mathbb{R}$ index casts) proves $U_n(\\cos\\theta)\\cdot\\sin\\theta$ equals the explicit odd-index binomial sum. Where the parent landed the *real* part on the first-kind polynomial $T_n$, the *imaginary* part lands here on the second-kind polynomial $U_n$ — completing the real+imaginary decomposition of De Moivre's theorem.",
+    "mathContext": "$U_n(\\cos\\theta)\\,\\sin\\theta = \\sin((n+1)\\theta) = \\sum_{j} (-1)^j \\binom{n+1}{2j+1}\\cos^{n-2j}\\theta\\,\\sin^{2j+1}\\theta.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Chebyshev polynomials",
+      "second kind",
+      "multiple-angle formula",
+      "cast normalization"
+    ],
+    "prerequisites": [
+      "Polynomial.Chebyshev.U_real_cos"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,231 @@
+{
+  "id": "de-moivre-oq-01-oq-01-oq-01",
+  "title": "The Binomial Expansion of sin(nθ) and its Chebyshev-U Connection",
+  "slug": "de-moivre-oq-01-oq-01-oq-01",
+  "description": "The imaginary-part mirror of the parent entry's cos(nθ) development. Expanding (cos θ + i sin θ)^n by the binomial theorem and taking the imaginary part gives sin(nθ) = Σ C(n,k) cos^k θ · sin^{n-k} θ · Im(i^{n-k}); since Im(i^m) vanishes for even m and equals (-1)^{(m-1)/2} for odd m, only odd powers of sin survive, yielding the classical closed form sin(nθ) = Σ_j (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j+1} θ = sin θ · Σ_j (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j} θ. The bracketed factor is proved to be the Chebyshev polynomial of the second kind: U_n(cos θ) · sin θ equals the explicit odd-index binomial sum for sin((n+1)θ), answering the parent entry's leading open question.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/De_Moivre%27s_formula",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ01OQ01OQ01.lean",
+    "tags": [
+      "trigonometry",
+      "chebyshev-polynomials",
+      "de-moivre",
+      "multiple-angle",
+      "binomial-theorem",
+      "complex-numbers",
+      "real-analysis",
+      "extension",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.exp_mul_I",
+        "description": "exp(z·i) = cos z + sin z · i: identifies the De Moivre base point cos θ + i sin θ with exp(iθ)",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Complex.exp_ofReal_mul_I_im",
+        "description": "Im(exp(x·i)) = sin x for real x: extracts the sine as the imaginary part of the exponential",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "add_pow",
+        "description": "(x+y)^n = Σ_k x^k y^{n-k} C(n,k): the binomial theorem over a commutative ring, applied to x = cos θ, y = i sin θ",
+        "module": "Mathlib.Algebra.BigOperators.Ring"
+      },
+      {
+        "theorem": "Complex.im_sum",
+        "description": "(Σ f i).im = Σ (f i).im: the imaginary part is additive, distributing over the binomial sum",
+        "module": "Mathlib.Data.Complex.BigOperators"
+      },
+      {
+        "theorem": "Finset.sum_range_reflect",
+        "description": "reindexes Σ_{k} f(k) = Σ_{k} f(n-k): reflects the summation so the surviving index counts powers of sin",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.sum_subset",
+        "description": "drops terms that vanish outside a subset: eliminates the even-index terms whose Im(i^i) factor is zero",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_image",
+        "description": "reindexes a sum along an injective map: reindexes odd indices i = 2j+1 via j ↦ 2j+1",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.U_real_cos",
+        "description": "U_n(cos θ) · sin θ = sin((n+1)θ): the Chebyshev polynomial of the second kind encodes the sine multiple-angle formula",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev"
+      }
+    ],
+    "originalContributions": [
+      "Imaginary-part extraction sin(nθ) = Im((cos θ + i sin θ)^n) proved via the identification cos θ + i sin θ = exp(iθ) and Im(exp(inθ)) = sin(nθ)",
+      "The full binomial expansion sin(nθ) = Σ_{k=0}^n C(n,k) cos^k θ · sin^{n-k} θ · Im(i^{n-k}), obtained by taking imaginary parts of the binomial theorem applied to (cos θ + i sin θ)^n",
+      "The parity lemmas Im(i^m) = 0 for even m and Im(i^{2j+1}) = (-1)^j, isolating exactly which terms of the binomial sum survive (the odd-index complement of the parent's even-index result)",
+      "The classical alternating closed form sin(nθ) = Σ_j (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j+1} θ, derived by reflecting the index, dropping the even terms, and reindexing the odd ones i = 2j+1",
+      "The sin θ-factored form sin(nθ) = sin θ · Σ_j (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j} θ, the exact shape asked for in the parent entry's open question",
+      "The Chebyshev-U connection: U_n(cos θ) · sin θ is proved equal to the explicit odd-index binomial sum for sin((n+1)θ), the second-kind mirror of the parent's T_n result"
+    ],
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 199,
+    "assumptions": "0 axioms, 0 sorries. #print axioms confirms all main theorems (sin_nsmul_binomial_odd, sin_nsmul_eq_sin_mul, chebyshev_U_eq_binomial_sum) depend only on the foundational propext / Classical.choice / Quot.sound. Imaginary-part extraction uses Mathlib's Complex.exp_mul_I and exp_ofReal_mul_I_im; the closed form is derived by elementary Finset reindexing (sum_range_reflect, sum_subset, sum_image); the Chebyshev identity uses U_real_cos.",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**The Imaginary Half of De Moivre**\n\nDe Moivre's theorem states $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$. The parent entry (De Moivre OQ-01-OQ-01) developed the *real* part — the binomial expansion of $\\cos(n\\theta)$ and its connection to the Chebyshev polynomial $T_n$ — and posed as its leading open question: *can the companion $\\sin(n\\theta)$ expansion be derived the same way, as the imaginary part of the binomial theorem, and connected to $U_{n-1}$?* This entry answers that question.\n\n**The Explicit Formula**\n\nComparing *imaginary* parts of De Moivre after the binomial expansion gives\n$$\\sin(n\\theta) = \\sum_{k=0}^{n} \\binom{n}{k} \\cos^k\\theta \\, \\sin^{n-k}\\theta \\, \\operatorname{Im}(i^{n-k}).$$\nThe factor $\\operatorname{Im}(i^{n-k})$ is $0$ when $n-k$ is even and $(-1)^{(n-k-1)/2}$ when $n-k$ is odd, so — dual to the cosine case — only *odd* powers of $\\sin$ survive. Reindexing recovers\n$$\\sin(n\\theta) = \\sum_{j} (-1)^j \\binom{n}{2j+1} \\cos^{n-2j-1}\\theta \\, \\sin^{2j+1}\\theta = \\sin\\theta \\sum_{j} (-1)^j \\binom{n}{2j+1} \\cos^{n-2j-1}\\theta \\, \\sin^{2j}\\theta,$$\nand the bracketed polynomial in $\\cos\\theta$ is exactly $U_{n-1}(\\cos\\theta)$.",
+    "problemStatement": "**The Open Question (from De Moivre OQ-01-OQ-01)**\n\nCan the companion $\\sin(n\\theta) = \\sin\\theta \\cdot \\sum_j (-1)^j \\binom{n}{2j+1} \\cos^{n-2j-1}\\theta \\, \\sin^{2j}\\theta$ expansion be derived the same way — as the imaginary part of the binomial theorem — and connected to the Chebyshev polynomial of the second kind $U_{n-1}$?\n\n**Answer: YES.** Taking the imaginary part of the binomial theorem applied to $(\\cos\\theta + i\\sin\\theta)^n$ yields an explicit polynomial in $\\cos\\theta$ and $\\sin\\theta$; the sign pattern of the powers of $i$ collapses this to the alternating odd-index closed form; and the resulting sum is machine-checked to equal $U_n(\\cos\\theta)\\,\\sin\\theta$ (for $\\sin((n+1)\\theta)$).",
+    "text": "A constructive formalization of the explicit binomial expansion of sin(nθ), derived by taking the imaginary part of the binomial theorem applied to (cos θ + i sin θ)^n, collapsed to the classical alternating odd-index closed form, and connected to the Chebyshev polynomial of the second kind U_n via U_n(cos θ)·sin θ = sin((n+1)θ).",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Imaginary-part extraction** (`cos_add_sin_I_eq_exp`, `sin_nsmul_eq_im_pow`): identify $\\cos\\theta + i\\sin\\theta = e^{i\\theta}$ via `Complex.exp_mul_I`, so $(\\cos\\theta + i\\sin\\theta)^n = e^{in\\theta}$ by `exp_nat_mul`, and $\\operatorname{Im}(e^{in\\theta}) = \\sin(n\\theta)$ by `exp_ofReal_mul_I_im`.\n\n2. **Binomial expansion** (`sin_nsmul_binomial_im`): apply `add_pow` to $(\\cos\\theta + i\\sin\\theta)^n$, distribute the imaginary part over the sum with `Complex.im_sum`, and simplify each term using $\\operatorname{Im}(\\bar r \\cdot i^{m}) = r \\cdot \\operatorname{Im}(i^m)$ for real $r$ (`im_ofReal_mul`).\n\n3. **Parity of $\\operatorname{Im}(i^m)$** (`im_I_pow_even`, `im_I_pow_two_mul_add_one`): using $i^2 = -1$, show $\\operatorname{Im}(i^{2j}) = 0$ (a real number) and $\\operatorname{Im}(i^{2j+1}) = (-1)^j$.\n\n4. **Odd-index closed form** (`sin_nsmul_binomial_odd`): reflect the index with `sum_range_reflect`, drop the even-index terms with `sum_subset` (their $\\operatorname{Im}(i^i)$ factor vanishes), and reindex the odd indices $i = 2j+1$ with `sum_image`, replacing $\\operatorname{Im}(i^{2j+1})$ by $(-1)^j$.\n\n5. **sin θ-factored form** (`sin_nsmul_eq_sin_mul`): pull $\\sin\\theta$ out of every surviving term with `Finset.mul_sum`, giving the exact shape of the open question.\n\n6. **Chebyshev-U connection** (`chebyshev_U_eq_binomial_sum`): compose the odd-index expansion at $n+1$ with Mathlib's `U_real_cos` to conclude $U_n(\\cos\\theta)\\,\\sin\\theta$ equals the explicit binomial sum for $\\sin((n+1)\\theta)$.",
+    "keyInsights": [
+      "**Imaginary part of the binomial theorem**: the sine multiple-angle expansion is nothing more than $\\operatorname{Im}$ applied term-by-term to $(\\cos\\theta + i\\sin\\theta)^n = \\sum_k \\binom{n}{k}\\cos^k\\theta\\,(i\\sin\\theta)^{n-k}$ — the exact dual of the parent's real-part development.",
+      "**The sign pattern is $\\operatorname{Im}(i^m)$**: the alternating $(-1)^j$ and the survival of only *odd* powers of $\\sin$ both come from the four-periodic imaginary part of the powers of $i$, complementary to the real part governing $\\cos(n\\theta)$.",
+      "**Reflect, drop, reindex — odd version**: converting the raw binomial sum to the textbook closed form reuses the parent's combinatorial recipe with the parity flipped — `sum_range_reflect`, `sum_subset` (dropping even indices now), `sum_image` reindexing $i = 2j+1$.",
+      "**First vs. second kind**: where the cosine expansion lands on $T_n$, the sine expansion lands on $U_{n-1}$ — the natural appearance of $\\sin\\theta$ as an overall factor is exactly the $\\sin\\theta$ in $U_n(\\cos\\theta)\\,\\sin\\theta = \\sin((n+1)\\theta)$."
+    ],
+    "prerequisites": [
+      "De Moivre's theorem and Euler's formula e^{iθ} = cos θ + i sin θ",
+      "The binomial theorem over a commutative ring",
+      "The complex unit i and the four-periodicity of its powers",
+      "Chebyshev polynomials of the second kind (U_n) and the identity U_n(cos θ)·sin θ = sin((n+1)θ)",
+      "Finite-sum reindexing (reflection, subset restriction, image reindexing)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports",
+      "summary": "Imports Mathlib, providing the complex exponential/trigonometric bridge (Complex.exp_mul_I, exp_ofReal_mul_I_im), the binomial theorem (add_pow), complex big-operator lemmas (Complex.im_sum), Finset reindexing, and the Chebyshev polynomial library (U_real_cos).",
+      "startLine": 1,
+      "endLine": 55,
+      "mathContext": "Imports Mathlib for the complex exponential, the binomial theorem, Finset reindexing, and Chebyshev polynomials $U_n$ satisfying $U_n(\\cos\\theta)\\,\\sin\\theta = \\sin((n+1)\\theta)$."
+    },
+    {
+      "id": "imaginary-part-extraction",
+      "title": "Imaginary-Part Extraction from De Moivre",
+      "summary": "Proves cos_add_sin_I_eq_exp (cos θ + i sin θ = exp(iθ)) and sin_nsmul_eq_im_pow (sin(nθ) = Im((cos θ + i sin θ)^n)), giving the precise meaning of 'comparing imaginary parts in De Moivre's theorem'.",
+      "startLine": 57,
+      "endLine": 73,
+      "mathContext": "Identifies $\\cos\\theta + i\\sin\\theta = e^{i\\theta}$, hence $(\\cos\\theta + i\\sin\\theta)^n = e^{in\\theta}$ and $\\sin(n\\theta) = \\operatorname{Im}((\\cos\\theta + i\\sin\\theta)^n)$."
+    },
+    {
+      "id": "binomial-expansion",
+      "title": "The Binomial Expansion of sin(nθ)",
+      "summary": "Proves sin_nsmul_binomial_im: sin(nθ) = Σ_{k=0}^n C(n,k) cos^k θ · sin^{n-k} θ · Im(i^{n-k}), by applying the binomial theorem to (cos θ + i sin θ)^n and distributing the imaginary part over the sum.",
+      "startLine": 75,
+      "endLine": 95,
+      "mathContext": "The full binomial expansion $\\sin(n\\theta) = \\sum_{k=0}^n \\binom{n}{k}\\cos^k\\theta\\,\\sin^{n-k}\\theta\\,\\operatorname{Im}(i^{n-k})$, the imaginary part of the binomial theorem."
+    },
+    {
+      "id": "parity-and-closed-form",
+      "title": "Parity of Im(iᵐ) and the Odd-Index Closed Form",
+      "summary": "Proves im_I_pow_even (Im(i^m) = 0 for even m) and im_I_pow_two_mul_add_one (Im(i^{2j+1}) = (-1)^j), then sin_nsmul_binomial_odd: sin(nθ) = Σ_j (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j+1} θ, via reflect/drop/reindex.",
+      "startLine": 97,
+      "endLine": 159,
+      "mathContext": "Since $\\operatorname{Im}(i^m)$ is $0$ for even $m$ and $(-1)^{(m-1)/2}$ for odd $m$, the expansion collapses to $\\sin(n\\theta) = \\sum_{j} (-1)^j \\binom{n}{2j+1}\\cos^{n-2j-1}\\theta\\,\\sin^{2j+1}\\theta$."
+    },
+    {
+      "id": "sin-factored-form",
+      "title": "The sin θ-Factored Form",
+      "summary": "Proves sin_nsmul_eq_sin_mul: sin(nθ) = sin θ · Σ_j (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j} θ, pulling sin θ out of every surviving term — the exact shape requested in the parent entry's open question.",
+      "startLine": 161,
+      "endLine": 176,
+      "mathContext": "Factoring $\\sin\\theta$ out of the odd-index sum: $\\sin(n\\theta) = \\sin\\theta\\sum_{j} (-1)^j \\binom{n}{2j+1}\\cos^{n-2j-1}\\theta\\,\\sin^{2j}\\theta$, whose bracketed factor is $U_{n-1}(\\cos\\theta)$."
+    },
+    {
+      "id": "chebyshev-u-connection",
+      "title": "Connection to Chebyshev Polynomials of the Second Kind",
+      "summary": "Proves chebyshev_U_eq_binomial_sum: U_n(cos θ) · sin θ equals the explicit odd-index binomial sum for sin((n+1)θ), composing the expansion with Mathlib's U_real_cos and closing the analogy with the parent's T_n result.",
+      "startLine": 178,
+      "endLine": 199,
+      "mathContext": "The explicit binomial sum equals $U_n(\\cos\\theta)\\,\\sin\\theta$, the Chebyshev polynomial of the second kind — the imaginary-part / odd-index mirror of the parent's $T_n(\\cos\\theta)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The formalization answers the parent entry's leading open question affirmatively: the binomial expansion of sin(nθ) can be derived as the imaginary part of De Moivre's theorem and connected to the Chebyshev polynomial of the second kind U_n. The proof is complete with 8 theorems/lemmas and 0 sorries, verified 0-axiom. The chain is: De Moivre / Euler → imaginary part of the binomial theorem → full expansion with Im(i^{n-k}) factors → parity of powers of i → alternating odd-index closed form → sin θ-factored form → equality of U_n(cos θ)·sin θ with the explicit sum. Together with the parent entry, this gives the full real+imaginary decomposition of De Moivre's theorem in explicit binomial form.",
+    "implications": "**Theoretical Significance**\n\n1. **The complete decomposition**: paired with the parent's $\\cos(n\\theta) = T_n(\\cos\\theta)$ development, this entry supplies the imaginary half, so both real and imaginary parts of $(\\cos\\theta + i\\sin\\theta)^n$ now have explicit, machine-checked binomial expansions tied to $T_n$ and $U_{n-1}$ respectively.\n\n2. **One source for the sign pattern, dual parity**: the alternating signs and the survival of only *odd* powers of $\\sin$ both trace to $\\operatorname{Im}(i^m) \\in \\{0, \\pm 1\\}$ with period four — the exact complement of the real-part parity governing $\\cos(n\\theta)$.\n\n3. **Reusable reindexing template (odd variant)**: the reflect / drop-vanishing / reindex-by-(2j+1) pattern reuses the parent's recipe with the parity flipped, confirming it as a general tool for extracting parity-filtered closed forms.",
+    "openQuestions": [
+      "Can the polynomial coefficients of U_n over ℤ be read off from this odd-index expansion, giving an explicit closed form for U_n analogous to the T_n coefficient question?",
+      "Do the paired T_n and U_{n-1} expansions combine to give a machine-checked derivation of the product/recurrence identities T_n' = n·U_{n-1} relating the two kinds?"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-01-oq-01",
+      "relationship": "Directly answers the leading open question of the parent entry: deriving the binomial expansion of sin(nθ) as the imaginary part and connecting it to U_{n-1}, mirroring the parent's cos(nθ)/T_n development."
+    },
+    {
+      "id": "de-moivre-oq-01-oq-02",
+      "relationship": "Complements the sibling's abstract U-evaluation wrappers (sin((n+1)z) = U_n(cos z)·sin z) with the explicit imaginary-part binomial expansion behind it."
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "Extends De Moivre's theorem by taking the imaginary part of its binomial expansion to obtain an explicit multiple-angle polynomial for sin(nθ)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Polynomial.Chebyshev",
+      "Real",
+      "Finset"
+    ],
+    "namespace": "DeMoivreOQ01OQ01OQ01",
+    "lineCount": 199,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "A. de Moivre",
+      "title": "Miscellanea Analytica de Seriebus et Quadraturis",
+      "year": "1730",
+      "venue": "London",
+      "note": "First systematic treatment of (cos θ + i sin θ)^n = cos(nθ) + i sin(nθ)"
+    },
+    {
+      "authors": "P. L. Chebyshev",
+      "title": "Théorie des mécanismes connus sous le nom de parallélogrammes",
+      "year": "1853",
+      "venue": "Mémoires des Savants étrangers présentés à l'Académie de Saint-Pétersbourg",
+      "note": "Introduced the polynomials T_n and U_n; U_n(cos θ)·sin θ = sin((n+1)θ)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent entry's leading open question by deriving the explicit binomial expansion of $\\sin(n\\theta)$ as the imaginary part and proving $U_n(\\cos\\theta)\\,\\sin\\theta$ equals the odd-index binomial sum"
+    },
+    {
+      "targetId": "de-moivre-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The sibling entry provides the abstract wrapper $\\sin((n+1)z) = U_n(\\cos z)\\sin z$; this entry supplies the explicit imaginary-part binomial expansion underlying it"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "Builds directly on De Moivre's theorem $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$, whose imaginary part (via the binomial theorem) is the formula proved here"
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "foundational",
+      "description": "The proof identifies $\\cos\\theta + i\\sin\\theta = e^{i\\theta}$ (Euler's formula); the expansion is the imaginary part of $(e^{i\\theta})^n = e^{in\\theta}$"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **leading open question** of `de-moivre-oq-01-oq-01` ("The Binomial Expansion of cos(nθ) and its Chebyshev Connection"):

> Can the companion sin(nθ) = sin θ · Σ_j (-1)^j C(n,2j+1) cos^{n-2j-1} θ · sin^{2j} θ expansion be derived the same way (as the imaginary part of the binomial theorem) and connected to U_{n-1}?

**Answer: yes.** This entry is the imaginary-part / odd-index mirror of the parent's real-part / even-index development. Where the parent extracted the real part of `(cos θ + i sin θ)^n` to reach `cos(nθ)` and the first-kind Chebyshev polynomial `T_n`, this entry extracts the imaginary part to reach `sin(nθ)` and the second-kind polynomial `U_n`.

## What is proved (0 axioms, Mathlib-backed)

| Theorem | Statement |
|---|---|
| `sin_nsmul_eq_im_pow` | `sin(nθ) = Im((cos θ + i sin θ)^n)` |
| `sin_nsmul_binomial_im` | `sin(nθ) = Σ_k C(n,k) cos^k θ · sin^{n-k} θ · Im(i^{n-k})` |
| `im_I_pow_even` / `im_I_pow_two_mul_add_one` | `Im(i^{2j}) = 0`, `Im(i^{2j+1}) = (-1)^j` |
| `sin_nsmul_binomial_odd` | alternating odd-index closed form (reflect / drop / reindex) |
| `sin_nsmul_eq_sin_mul` | `sin θ`-factored form — the exact shape of the open question |
| `chebyshev_U_eq_binomial_sum` | `U_n(cos θ) · sin θ` = the explicit odd-index binomial sum for `sin((n+1)θ)` |

The dual parity is the crux: only **odd** powers of `sin` survive (vs. even for `cos`), because `Im(i^m)` is the four-periodic complement of `Re(i^m)`. Together with the parent, both real and imaginary parts of De Moivre's theorem now have explicit machine-checked binomial expansions tied to `T_n` and `U_{n-1}`.

## Verification

- 8 theorems/lemmas, 199 lines, 0 sorries.
- `#print axioms` confirms all main results depend only on `propext / Classical.choice / Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool` (no `native_decide`). **Verified, 0-axiom.**
- Self-contained (imports Mathlib only); mirrors the parent file's structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)