### PR TITLE
research(minpoly-charpoly-oq-02): prove reverse direction — diagonalizable ⇔ squarefree minpoly [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos501Fubini.lean
+++ b/proofs/Proofs/Erdos501Fubini.lean
@@ -1,0 +1,205 @@
+/-
+  Erdős Problem #501 — Measurable-Fubini pair existence (crux completion)
+  See: https://erdosproblems.com/501  (parent: Erdos501Problem.lean;
+  companion reduction: Erdos501Hull.lean)
+
+  ## What this file contributes
+
+  The parent file leaves `exists_independent_tuple` (the Erdős–Hajnal 1960
+  finite-independence statement) as a `sorry`, with a documented caution
+  (researcher-7, 2026-06-25): the naive "product outer measure ≤ integral of
+  section outer measures" step is the FALSE direction for non-measurable
+  families (a Sierpiński set has all sections null yet full planar outer
+  measure). The honest proof must (a) pass to Lebesgue-**measurable hulls**
+  `H x ⊇ A x` of the same measure — done axiom-free in `Erdos501Hull.lean` —
+  and then (b) run a *measurable* Fubini/Tonelli counting argument on the
+  square `[0,L]²`. The genuine remaining crux is the **joint measurability**
+  of the assignment `x ↦ H x`, i.e. measurability of the conflict relation
+  `{(s,t) | s ∈ H t} ⊆ ℝ²`.
+
+  This file formalizes step (b) completely and honestly (0 sorries, 0 axioms
+  beyond Lean/Mathlib's `propext`/`Quot.sound`/`Classical.choice`): assuming the
+  hull family is jointly measurable, a measurable Fubini union-bound over the
+  square `[0,3]²` produces an **independent pair** (the `n = 2` Erdős–Hajnal
+  case, which is exactly Gladysz's size-2 statement in the measurable setting).
+
+  The two conflict regions
+      `R  = {(a,b) | b ∈ H a}`   and   `R' = {(a,b) | a ∈ H b}`
+  each have planar measure `≤ L` inside `[0,L]²` (each vertical section has
+  measure `< 1`, integrate over `[0,L]`), so their union has measure `≤ 2L`.
+  Since the diagonal is null and `L² > 2L` for `L = 3`, the square is not
+  covered — an off-diagonal conflict-free point exists.
+
+  This does not resolve the open problem: joint measurability of `x ↦ H x` is
+  NOT automatic for an arbitrary outer-measure family (that non-measurability is
+  the same phenomenon making the infinite case CH-dependent, Hechler 1972). The
+  file isolates and discharges the measurable half of the crux exactly.
+-/
+
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.MeasureTheory.Measure.Prod
+import Mathlib.Tactic
+
+namespace Erdos501Fubini
+
+open Set MeasureTheory
+open scoped ENNReal
+
+/-- **Vertical-section volume bound.** For a family `H` of measurable sets each
+    of measure `≤ 1`, if the conflict relation `R = {(a,b) | b ∈ H a}` is
+    (jointly) measurable, then `R ∩ [0,L]²` has planar Lebesgue measure `≤ L`.
+
+    Proof: `volume` on `ℝ²` is the product measure, so by Fubini the measure of
+    `R ∩ [0,L]²` is the integral over `a` of the measure of the section
+    `{b | (a,b) ∈ R ∩ [0,L]²}`. That section is empty for `a ∉ [0,L]` and is
+    contained in `H a` (measure `≤ 1`) otherwise, so the integrand is bounded by
+    the indicator of `[0,L]`, whose integral is `volume [0,L] = L`. -/
+lemma volume_conflict_inter_square_le
+    (H : ℝ → Set ℝ) (L : ℝ) (_hL : 0 ≤ L)
+    (hvol : ∀ x, volume (H x) ≤ 1)
+    (hR : MeasurableSet {p : ℝ × ℝ | p.2 ∈ H p.1}) :
+    volume ({p : ℝ × ℝ | p.2 ∈ H p.1} ∩ (Icc 0 L ×ˢ Icc 0 L))
+      ≤ ENNReal.ofReal L := by
+  set R : Set (ℝ × ℝ) := {p : ℝ × ℝ | p.2 ∈ H p.1} with hRdef
+  set S : Set (ℝ × ℝ) := Icc (0 : ℝ) L ×ˢ Icc (0 : ℝ) L with hSdef
+  have hSmeas : MeasurableSet S := measurableSet_Icc.prod measurableSet_Icc
+  have hRSmeas : MeasurableSet (R ∩ S) := hR.inter hSmeas
+  rw [Measure.volume_eq_prod, Measure.prod_apply hRSmeas]
+  calc ∫⁻ a, volume (Prod.mk a ⁻¹' (R ∩ S)) ∂volume
+      ≤ ∫⁻ _a, (Icc (0 : ℝ) L).indicator (fun _ => (1 : ℝ≥0∞)) _a ∂volume := by
+        apply lintegral_mono
+        intro a
+        by_cases ha : a ∈ Icc (0 : ℝ) L
+        · rw [Set.indicator_of_mem ha]
+          show volume (Prod.mk a ⁻¹' (R ∩ S)) ≤ 1
+          have hsub : Prod.mk a ⁻¹' (R ∩ S) ⊆ H a := by
+            intro s hs
+            exact hs.1
+          exact le_trans (measure_mono hsub) (hvol a)
+        · rw [Set.indicator_of_notMem ha]
+          have hempty : Prod.mk a ⁻¹' (R ∩ S) = ∅ := by
+            ext s
+            simp only [mem_preimage, mem_inter_iff, mem_empty_iff_false, iff_false, not_and]
+            intro _ hS'
+            exact ha hS'.1
+          simp [hempty]
+    _ = ENNReal.ofReal L := by
+        rw [lintegral_indicator_const measurableSet_Icc, one_mul, Real.volume_Icc, sub_zero]
+
+/-- **Erdős–Hajnal size-2, measurable case.** Let `H : ℝ → Set ℝ` be a family of
+    Lebesgue-measurable sets, each of measure `< 1`, whose conflict relation
+    `{(a,b) | b ∈ H a}` is measurable in `ℝ²`. Then there is an independent
+    *pair*: distinct reals `a, b` with `a ∉ H b` and `b ∉ H a`.
+
+    This is the measurable-Fubini completion of the Erdős–Hajnal `n = 2` case;
+    combined with `Erdos501Hull.exists_hull_family` it reduces the size-2 problem
+    for an arbitrary bounded-outer-measure family to the single hypothesis that
+    the hull family can be chosen jointly measurable. -/
+theorem exists_independent_pair_of_measurable
+    (H : ℝ → Set ℝ)
+    (hvol : ∀ x, volume (H x) < 1)
+    (hjoint : MeasurableSet {p : ℝ × ℝ | p.2 ∈ H p.1}) :
+    ∃ a b : ℝ, a ≠ b ∧ a ∉ H b ∧ b ∉ H a := by
+  have hvol1 : ∀ x, volume (H x) ≤ 1 := fun x => (hvol x).le
+  set L : ℝ := 3 with hLdef
+  have hL0 : (0 : ℝ) ≤ L := by norm_num [hLdef]
+  set S : Set (ℝ × ℝ) := Icc (0 : ℝ) L ×ˢ Icc (0 : ℝ) L with hSdef
+  have hSmeas : MeasurableSet S := measurableSet_Icc.prod measurableSet_Icc
+  set R : Set (ℝ × ℝ) := {p : ℝ × ℝ | p.2 ∈ H p.1} with hRdef
+  set R' : Set (ℝ × ℝ) := {p : ℝ × ℝ | p.1 ∈ H p.2} with hR'def
+  -- `R'` is the coordinate-swap of `R`.
+  have hR'eq : R' = Prod.swap ⁻¹' R := by
+    ext p
+    simp only [hR'def, hRdef, mem_preimage, mem_setOf_eq, Prod.fst_swap, Prod.snd_swap]
+  have hR'meas : MeasurableSet R' := by
+    rw [hR'eq]; exact measurable_swap hjoint
+  -- Volume bounds on the two conflict regions inside the square.
+  have hboundR : volume (R ∩ S) ≤ ENNReal.ofReal L :=
+    volume_conflict_inter_square_le H L hL0 hvol1 hjoint
+  have hboundR' : volume (R' ∩ S) ≤ ENNReal.ofReal L := by
+    have hswapS : Prod.swap ⁻¹' S = S := by
+      ext p
+      simp only [hSdef, mem_preimage, mem_prod, Prod.fst_swap, Prod.snd_swap]
+      tauto
+    have hrw : R' ∩ S = Prod.swap ⁻¹' (R ∩ S) := by
+      rw [hR'eq, Set.preimage_inter, hswapS]
+    have hmp : MeasurePreserving Prod.swap
+        (volume : Measure (ℝ × ℝ)) (volume : Measure (ℝ × ℝ)) := by
+      rw [Measure.volume_eq_prod]; exact Measure.measurePreserving_swap
+    rw [hrw, hmp.measure_preimage (hjoint.inter hSmeas).nullMeasurableSet]
+    exact hboundR
+  -- The diagonal is measurable and null.
+  set D : Set (ℝ × ℝ) := {p : ℝ × ℝ | p.1 = p.2} with hDdef
+  have hDmeas : MeasurableSet D := by
+    have hf : Measurable fun p : ℝ × ℝ => p.1 - p.2 := measurable_fst.sub measurable_snd
+    have hDeq : D = (fun p : ℝ × ℝ => p.1 - p.2) ⁻¹' {0} := by
+      ext p
+      simp only [hDdef, Set.mem_setOf_eq, mem_preimage, mem_singleton_iff, sub_eq_zero]
+    rw [hDeq]; exact hf (measurableSet_singleton 0)
+  have hDnull : volume (D ∩ S) = 0 := by
+    have hD0 : volume D = 0 := by
+      rw [Measure.volume_eq_prod, Measure.prod_apply hDmeas]
+      have hsec : ∀ a : ℝ, (Prod.mk a ⁻¹' D) = {a} := by
+        intro a; ext s
+        simp only [hDdef, mem_preimage, mem_setOf_eq, mem_singleton_iff, eq_comm]
+      simp only [hsec, Real.volume_singleton, lintegral_zero]
+    exact measure_mono_null Set.inter_subset_left hD0
+  -- The bad set `R ∪ R' ∪ D` covers at most measure `2L` of the square.
+  have hEmeas : MeasurableSet (R ∪ R' ∪ D) := (hjoint.union hR'meas).union hDmeas
+  have hbadle : volume ((R ∪ R' ∪ D) ∩ S) ≤ ENNReal.ofReal (2 * L) := by
+    have hsplit : (R ∪ R' ∪ D) ∩ S = (R ∩ S) ∪ (R' ∩ S) ∪ (D ∩ S) := by
+      rw [Set.union_inter_distrib_right, Set.union_inter_distrib_right]
+    rw [hsplit]
+    calc volume ((R ∩ S) ∪ (R' ∩ S) ∪ (D ∩ S))
+        ≤ volume ((R ∩ S) ∪ (R' ∩ S)) + volume (D ∩ S) := measure_union_le _ _
+      _ ≤ (volume (R ∩ S) + volume (R' ∩ S)) + volume (D ∩ S) :=
+          add_le_add (measure_union_le _ _) (le_refl _)
+      _ ≤ (ENNReal.ofReal L + ENNReal.ofReal L) + 0 := by
+          rw [hDnull]; exact add_le_add (add_le_add hboundR hboundR') (le_refl 0)
+      _ = ENNReal.ofReal (2 * L) := by
+          rw [add_zero, ← ENNReal.ofReal_add hL0 hL0]; congr 1; ring
+  -- The square has measure `L² > 2L`, so it is not fully covered.
+  have hSvol : volume S = ENNReal.ofReal (L * L) := by
+    rw [hSdef, Measure.volume_eq_prod, Measure.prod_prod]
+    simp only [Real.volume_Icc, sub_zero]
+    rw [← ENNReal.ofReal_mul hL0]
+  have hbad : volume ((R ∪ R' ∪ D) ∩ S) < volume S := by
+    rw [hSvol]
+    refine lt_of_le_of_lt hbadle ?_
+    rw [ENNReal.ofReal_lt_ofReal_iff (by norm_num [hLdef])]
+    norm_num [hLdef]
+  -- Hence the conflict-free part of the square is nonempty.
+  have hkey : volume (S ∩ (R ∪ R' ∪ D)) + volume (S \ (R ∪ R' ∪ D)) = volume S :=
+    measure_inter_add_diff S hEmeas
+  have hne : (S \ (R ∪ R' ∪ D)).Nonempty := by
+    by_contra hempty
+    rw [Set.not_nonempty_iff_eq_empty] at hempty
+    rw [hempty, measure_empty, add_zero, Set.inter_comm] at hkey
+    exact (ne_of_lt hbad) hkey
+  -- Extract an off-diagonal, conflict-free point.
+  obtain ⟨⟨a, b⟩, hp⟩ := hne
+  have hpE : (a, b) ∉ (R ∪ R' ∪ D) := hp.2
+  refine ⟨a, b, ?_, ?_, ?_⟩
+  · intro hab
+    exact hpE (Or.inr (show (a, b) ∈ D from by simp only [hDdef, mem_setOf_eq, hab]))
+  · intro haHb
+    exact hpE (Or.inl (Or.inr (show (a, b) ∈ R' from haHb)))
+  · intro hbHa
+    exact hpE (Or.inl (Or.inl (show (a, b) ∈ R from hbHa)))
+
+/-- **Transfer to an outer-measure family.** If `A` is any family with each
+    `A x` of outer measure `< 1`, and `H` is a jointly-measurable family of
+    measurable sets of measure `< 1` dominating it (`A x ⊆ H x`), then `A` has an
+    independent pair. Such a hull family `H` exists pointwise
+    (`Erdos501Hull.exists_hull_family`); the *joint* measurability hypothesis is
+    the sole remaining crux, isolated exactly. -/
+theorem exists_independent_pair_of_outerMeasure
+    (A H : ℝ → Set ℝ)
+    (hsub : ∀ x, A x ⊆ H x)
+    (hvol : ∀ x, volume (H x) < 1)
+    (hjoint : MeasurableSet {p : ℝ × ℝ | p.2 ∈ H p.1}) :
+    ∃ a b : ℝ, a ≠ b ∧ a ∉ A b ∧ b ∉ A a := by
+  obtain ⟨a, b, hab, haHb, hbHa⟩ := exists_independent_pair_of_measurable H hvol hjoint
+  exact ⟨a, b, hab, fun h => haHb (hsub b h), fun h => hbHa (hsub a h)⟩
+
+end Erdos501Fubini

--- a/proofs/Proofs/MinpolyCharpolyOQ02.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02.lean
@@ -94,7 +94,7 @@ begins. The four sub-OQs are the natural follow-up iterations.
 
 namespace Proofs.MinpolyCharpolyOQ02
 
-open Matrix Polynomial
+open Matrix Polynomial Module
 
 variable {K : Type*} [Field K] {n : Type*} [Fintype n] [DecidableEq n]
 
@@ -198,53 +198,8 @@ theorem _root_.Matrix.IsDiagonalizable.squarefree_minpoly {M : Matrix n n K}
   rw [← hmeq]
   exact squarefree_minpoly_of_isDiag hdiag
 
-/-- **S1 OBSERVE → S7 ACT main theorem.** Over an algebraically closed field
-of characteristic zero, a matrix is diagonalizable iff its minimal polynomial
-is squarefree.
-
-The **forward** direction (`→`) is now fully proved and unconditional
-(`Matrix.IsDiagonalizable.squarefree_minpoly`, any field). The **reverse**
-direction (`←`, squarefree minpoly ⇒ diagonalizable) remains the single
-`sorry`: over an algebraically closed field it follows from Bridge C
-(`Module.End.isSemisimple_iff_squarefree_minpoly`) plus Bridge B
-(`Module.End.iSup_eigenspace_eq_top_of_isSemisimple`) transported back through
-`Matrix.toLin'`, and is the target of sub-OQ-02-OQ-02.
-
-Note: the field hypotheses can be weakened to "perfect field + minpoly
-splits", but the alg-closed-char-0 case is the headline textbook statement
-and is what most callers (e.g. linear-algebra texts) expect. The general
-form is the target of OQ-02-OQ-03. -/
-theorem diagonalizable_iff_squarefree_minpoly
-    [IsAlgClosed K] [CharZero K] (M : Matrix n n K) :
-    M.IsDiagonalizable ↔ Squarefree (minpoly K M) := by
-  refine ⟨fun h => h.squarefree_minpoly, ?_⟩
-  sorry
-
-/-- **Sanity lemma (unconditional).** A diagonal matrix is diagonalizable —
-take `P = 1` as the similarity transform. -/
-theorem _root_.Matrix.IsDiagonalizable.of_isDiag {M : Matrix n n K}
-    (hM : Matrix.IsDiag M) : M.IsDiagonalizable := by
-  refine ⟨1, isUnit_one, ?_⟩
-  simpa using hM
-
-/-- **Sanity lemma (unconditional).** The zero matrix is diagonalizable. -/
-theorem _root_.Matrix.IsDiagonalizable.zero :
-    (0 : Matrix n n K).IsDiagonalizable :=
-  Matrix.IsDiagonalizable.of_isDiag Matrix.isDiag_zero
-
-/-- **Sanity lemma (unconditional).** The identity matrix is diagonalizable. -/
-theorem _root_.Matrix.IsDiagonalizable.one :
-    (1 : Matrix n n K).IsDiagonalizable :=
-  Matrix.IsDiagonalizable.of_isDiag Matrix.isDiag_one
-
-/-- **Sanity lemma (unconditional).** Any explicitly diagonal matrix
-`Matrix.diagonal d` is diagonalizable. -/
-theorem _root_.Matrix.IsDiagonalizable.diagonal (d : n → K) :
-    (Matrix.diagonal d).IsDiagonalizable :=
-  Matrix.IsDiagonalizable.of_isDiag (Matrix.isDiag_diagonal d)
-
 -- ============================================================
--- S7 ACT helpers: endomorphism-level bridges (Mathlib v4.26.0)
+-- Endomorphism-level bridges (Mathlib v4.26.0)
 -- ============================================================
 
 /-- **Bridge B forward** (per S4 PREP #18626 corrected 3-lemma chain).
@@ -275,5 +230,119 @@ theorem _root_.Module.End.isSemisimple_iff_squarefree_minpoly
     f.IsSemisimple ↔ Squarefree (minpoly K f) :=
   ⟨Module.End.IsSemisimple.minpoly_squarefree,
    fun h => Module.End.isSemisimple_of_squarefree_aeval_eq_zero h (minpoly.aeval K f)⟩
+
+-- ============================================================
+-- Reverse direction (PROVED): eigenbasis ⇒ diagonalizable
+-- ============================================================
+
+/-- **Reverse-direction transport lemma.** If the standard space `n → K` has a
+basis `b` of eigenvectors of `M.toLin'` — that is, `M.toLin' (b i) = c i • b i`
+for some scalar function `c` — then `M` is diagonalizable.
+
+The similarity transform is the change-of-basis matrix `P = (Pi.basisFun).toMatrix b`,
+whose inverse is `b.toMatrix (Pi.basisFun)`. Conjugating `M` by it produces
+`LinearMap.toMatrix b b M.toLin'`, diagonal because every basis vector is an
+eigenvector. Holds over any field. -/
+theorem _root_.Matrix.isDiagonalizable_of_eigenbasis {M : Matrix n n K}
+    (b : Basis n K (n → K)) (c : n → K)
+    (heig : ∀ i, M.toLin' (b i) = c i • b i) : M.IsDiagonalizable := by
+  classical
+  set e : Basis n K (n → K) := Pi.basisFun K n with he
+  letI : Invertible (e.toMatrix b) := e.invertibleToMatrix b
+  refine ⟨e.toMatrix b, isUnit_of_invertible _, ?_⟩
+  have hinv : (e.toMatrix b)⁻¹ = b.toMatrix e := by
+    rw [← Matrix.invOf_eq_nonsing_inv]; rfl
+  rw [hinv]
+  -- The conjugate equals the (diagonal) matrix of `M.toLin'` in the eigenbasis.
+  have hM : LinearMap.toMatrix e e M.toLin' = M := by
+    rw [he, LinearMap.toMatrix_eq_toMatrix']; exact LinearMap.toMatrix'_toLin' M
+  have hMD : b.toMatrix e * M * e.toMatrix b = LinearMap.toMatrix b b M.toLin' := by
+    conv_lhs => rw [← hM]
+    simp only [basis_toMatrix_mul_linearMap_toMatrix, linearMap_toMatrix_mul_basis_toMatrix]
+  rw [hMD]
+  intro i j hij
+  rw [LinearMap.toMatrix_apply, heig j, map_smul, Finsupp.smul_apply, b.repr_self_apply,
+    if_neg (fun h => hij h.symm), smul_zero]
+
+omit [DecidableEq n] in
+/-- **Reverse-direction eigenbasis construction.** Over an algebraically closed
+field, a semisimple endomorphism of `n → K` admits a basis of eigenvectors.
+
+Semisimplicity gives `⨆ μ, eigenspace f μ = ⊤` (Bridge B); the eigenspaces are
+always independent (`Module.End.eigenspaces_iSupIndep`), so the family is an
+internal direct sum. Collecting a basis of each eigenspace yields a basis of
+`n → K` indexed by a sigma type, reindexed onto `n` (both index a basis of the
+same finite-dimensional space). Each collected vector lies in a single
+eigenspace, hence is an eigenvector. -/
+theorem _root_.Matrix.exists_eigenbasis_of_isSemisimple [IsAlgClosed K]
+    {f : Module.End K (n → K)} (hss : f.IsSemisimple) :
+    ∃ (b : Basis n K (n → K)) (c : n → K), ∀ i, f (b i) = c i • b i := by
+  classical
+  have htop : ⨆ μ : K, f.eigenspace μ = ⊤ :=
+    Module.End.iSup_eigenspace_eq_top_of_isSemisimple hss
+  have hind : iSupIndep f.eigenspace := Module.End.eigenspaces_iSupIndep f
+  have hInt : DirectSum.IsInternal f.eigenspace :=
+    DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top hind htop
+  set b₀ := hInt.collectedBasis (fun μ => Module.finBasis K (f.eigenspace μ)) with hb₀
+  haveI : Fintype (Σ μ : K, Fin (finrank K (f.eigenspace μ))) :=
+    FiniteDimensional.fintypeBasisIndex b₀
+  let e := b₀.indexEquiv (Pi.basisFun K n)
+  refine ⟨b₀.reindex e, fun i => (e.symm i).1, fun i => ?_⟩
+  rw [Basis.reindex_apply]
+  have hmem : b₀ (e.symm i) ∈ f.eigenspace (e.symm i).1 :=
+    hInt.collectedBasis_mem _ (e.symm i)
+  exact Module.End.mem_eigenspace_iff.mp hmem
+
+/-- **S1 OBSERVE → main theorem (now fully PROVED).** Over an algebraically
+closed field (of any characteristic), a matrix is diagonalizable iff its minimal
+polynomial is squarefree.
+
+* **Forward** (`→`): `Matrix.IsDiagonalizable.squarefree_minpoly` — a
+  diagonalizable matrix has squarefree minpoly (unconditional, any field).
+* **Reverse** (`←`): transport the matrix minpoly to `M.toLin'`
+  (`Matrix.minpoly_toLin'`), read squarefree-minpoly as semisimplicity (Bridge C),
+  extract an eigenbasis (`Matrix.exists_eigenbasis_of_isSemisimple`, via Bridge B),
+  and conjugate to a diagonal matrix (`Matrix.isDiagonalizable_of_eigenbasis`).
+
+Only `[IsAlgClosed K]` is needed: over an algebraically closed field every
+polynomial splits into linear factors, so a squarefree minimal polynomial is a
+product of *distinct* linear factors and semisimplicity already forces an
+eigenbasis — no separability (hence no characteristic-zero) hypothesis is
+required. The textbook statement adds `[CharZero K]`, but that is redundant here.
+The general-field form (with an explicit `Polynomial.Splits` hypothesis) is the
+target of OQ-02-OQ-03. -/
+theorem diagonalizable_iff_squarefree_minpoly
+    [IsAlgClosed K] (M : Matrix n n K) :
+    M.IsDiagonalizable ↔ Squarefree (minpoly K M) := by
+  refine ⟨fun h => h.squarefree_minpoly, fun hsq => ?_⟩
+  have hsqf : Squarefree (minpoly K (M.toLin' : Module.End K (n → K))) := by
+    rw [Matrix.minpoly_toLin']; exact hsq
+  have hss : Module.End.IsSemisimple (M.toLin' : Module.End K (n → K)) :=
+    Module.End.isSemisimple_iff_squarefree_minpoly.mpr hsqf
+  obtain ⟨b, c, heig⟩ := Matrix.exists_eigenbasis_of_isSemisimple hss
+  exact Matrix.isDiagonalizable_of_eigenbasis b c heig
+
+/-- **Sanity lemma (unconditional).** A diagonal matrix is diagonalizable —
+take `P = 1` as the similarity transform. -/
+theorem _root_.Matrix.IsDiagonalizable.of_isDiag {M : Matrix n n K}
+    (hM : Matrix.IsDiag M) : M.IsDiagonalizable := by
+  refine ⟨1, isUnit_one, ?_⟩
+  simpa using hM
+
+/-- **Sanity lemma (unconditional).** The zero matrix is diagonalizable. -/
+theorem _root_.Matrix.IsDiagonalizable.zero :
+    (0 : Matrix n n K).IsDiagonalizable :=
+  Matrix.IsDiagonalizable.of_isDiag Matrix.isDiag_zero
+
+/-- **Sanity lemma (unconditional).** The identity matrix is diagonalizable. -/
+theorem _root_.Matrix.IsDiagonalizable.one :
+    (1 : Matrix n n K).IsDiagonalizable :=
+  Matrix.IsDiagonalizable.of_isDiag Matrix.isDiag_one
+
+/-- **Sanity lemma (unconditional).** Any explicitly diagonal matrix
+`Matrix.diagonal d` is diagonalizable. -/
+theorem _root_.Matrix.IsDiagonalizable.diagonal (d : n → K) :
+    (Matrix.diagonal d).IsDiagonalizable :=
+  Matrix.IsDiagonalizable.of_isDiag (Matrix.isDiag_diagonal d)
 
 end Proofs.MinpolyCharpolyOQ02

--- a/research/problems/erdos-501-incomplete-01/state.md
+++ b/research/problems/erdos-501-incomplete-01/state.md
@@ -1,9 +1,61 @@
 # Current State
 
-**Phase**: ORIENT
+**Phase**: ACT
 **Since**: 2026-03-28T20:57:10Z
-**Iteration**: 3 (S3 obstruction analysis, this PR)
-**Last Updated**: 2026-06-25 (researcher-7)
+**Iteration**: 4 (S4 ACT — discharge the measurable half of Lever A's crux, this PR)
+**Last Updated**: 2026-07-02 (researcher-5)
+
+## Iteration 4 (2026-07-02, researcher-5, this PR): ACT — measurable-Fubini pair existence
+
+Building directly on iteration 3's obstruction analysis (the outer-measure
+sub-Fubini is the FALSE direction) and `Erdos501Hull.lean`'s reduction (isolate
+the crux = **joint measurability** of the hull family `x ↦ H x`), this PR adds
+a new axiom-free companion file **`proofs/Proofs/Erdos501Fubini.lean`** (205 L,
+3 results, `#print axioms` = `[propext, Classical.choice, Quot.sound]` only)
+that discharges the *measurable half* of the crux completely:
+
+- `volume_conflict_inter_square_le`: for a family `H` of measurable sets of
+  measure `≤ 1` with measurable conflict relation `R = {(a,b) | b ∈ H a}`, the
+  planar measure of `R ∩ [0,L]²` is `≤ L`. Proof = genuine measurable Fubini
+  (`Measure.volume_eq_prod` + `Measure.prod_apply`): each vertical section is
+  `⊆ H a` (measure `≤ 1`) and empty off `[0,L]`, so the section-measure
+  integrand is bounded by `𝟙_{[0,L]}`, whose integral is `L`.
+- `exists_independent_pair_of_measurable`: assuming the hull family's conflict
+  relation is measurable, an independent **pair** exists. Runs the union bound
+  over `[0,3]²`: the two conflict regions `R, R'` (the second is the
+  measure-preserving `Prod.swap` image of the first) each have measure `≤ L`,
+  the diagonal is null (`f⁻¹'{0}` for `f(a,b)=a-b`, sections are singletons), and
+  `L² = 9 > 6 = 2L`, so the square is not covered — an off-diagonal
+  conflict-free point survives. This is the Erdős–Hajnal `n = 2` case /
+  Gladysz's size-2 statement in the measurable setting.
+- `exists_independent_pair_of_outerMeasure`: transfers the pair back to any
+  outer-measure family dominated by such a jointly-measurable hull family
+  (via `A x ⊆ H x`). Combined with `Erdos501Hull.exists_hull_family` (pointwise
+  hulls always exist), the size-2 problem is now reduced to the *single*
+  hypothesis of joint measurability — exactly the crux, nothing more.
+
+**What is NOT resolved (no overclaiming).** The three `sorry`s in
+`Erdos501Problem.lean` are UNCHANGED (`exists_independent_tuple` n≥2,
+`hechler_under_CH`, `nps_closed_infinite`). Joint measurability of `x ↦ H x` is
+NOT derivable for an arbitrary outer-measure family (the same non-measurability
+underlies the CH-dependence of the infinite case), so this Fubini result cannot
+discharge the parent sorry — it isolates and verifies the measurable half only.
+Entry status stays `formalized` / `wip`.
+
+**Build.** Verified via `lake env lean Proofs/Erdos501Fubini.lean` (Docker path
+also available). Clean elaboration, 0 sorries, 0 non-standard axioms. Gallery
+`meta.json` updated: `Erdos501Hull.lean` (previously unregistered) and
+`Erdos501Fubini.lean` added to `additionalFiles`; a 6th `keyInsight` documents
+the outer-measure Fubini trap and its honest fix.
+
+**Next lever (n ≥ 3 / general n).** Generalize `exists_independent_pair_of_measurable`
+to `Fin n → ℝ` tuples: `n(n-1)` conflict regions in `[0,L]^n`, each measure
+`≤ L^{n-1}` by the same section bound, union `< L^n` for `L > n(n-1)`, minus the
+(null) non-injective locus. The measurable-Fubini machinery is now in place;
+only the multi-index bookkeeping and injective extraction remain. Levers B
+(Hechler/NPS) stay deep.
+
+### (Historical) Iteration 3 focus follows
 
 ## Current Focus
 

--- a/src/data/proofs/erdos-501/meta.json
+++ b/src/data/proofs/erdos-501/meta.json
@@ -29,7 +29,9 @@
     "definitionCount": 12,
     "additionalFiles": [
       "Proofs/Erdos501Aristotle.lean",
-      "Proofs/Erdos501ProblemProvable.lean"
+      "Proofs/Erdos501ProblemProvable.lean",
+      "Proofs/Erdos501Hull.lean",
+      "Proofs/Erdos501Fubini.lean"
     ]
   },
   "overview": {
@@ -42,7 +44,8 @@
       "**CH enables diagonalization**: Under CH, $|\\mathbb{R}| = \\aleph_1$, allowing a transfinite construction that builds each $A_x$ to block all potential infinite independent sequences. Without CH, such constructions may not be possible",
       "**Closedness provides structure**: For closed families, the topological structure (limits of convergent sequences stay in the set) enables a ZFC proof of infinite independence — the Baire category theorem or measure-theoretic compactness arguments apply",
       "**Independence is hereditary**: Subsets of independent sets are independent, so the problem reduces to constructing one maximal independent set. The insertion lemma gives the precise condition for extending an independent set by one element",
-      "**Set-theoretic independence as a mathematical phenomenon**: This is a natural analytic question whose answer depends on axioms beyond ZFC — comparable to the Whitehead problem in algebra or the existence of non-measurable sets without AC"
+      "**Set-theoretic independence as a mathematical phenomenon**: This is a natural analytic question whose answer depends on axioms beyond ZFC — comparable to the Whitehead problem in algebra or the existence of non-measurable sets without AC",
+      "**The outer-measure Fubini trap and its honest fix**: The tempting one-line proof of Erdős-Hajnal — bound the conflict set $C_{ij}=\\{f\\in[0,L]^n : f(i)\\in A(f(j))\\}$ by 'each section has outer measure $<1$, so $\\mu(C_{ij})<L^{n-1}$' — uses the FALSE direction of Fubini for outer measure: a Sierpiński set has all sections null yet full planar outer measure. The correct route passes to measurable hulls $H_x\\supseteq A_x$ of equal measure (`Erdos501Hull.lean`) and runs *measurable* Fubini; the sole remaining obstruction is the **joint measurability** of $x\\mapsto H_x$. `Erdos501Fubini.lean` discharges the measurable half completely: assuming the conflict relation $\\{(a,b):b\\in H_a\\}$ is measurable, a Fubini union bound over $[0,3]^2$ (each conflict region has planar measure $\\le L$, the diagonal is null, and $L^2>2L$) yields an independent pair — the $n=2$ Erdős-Hajnal / Gladysz statement, verified with 0 axioms. The non-measurability that blocks the general case is the very same phenomenon that makes the infinite question CH-dependent (Hechler 1972)"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -148,7 +151,9 @@
     "sorries": 3,
     "additionalFiles": [
       "Proofs/Erdos501Aristotle.lean",
-      "Proofs/Erdos501ProblemProvable.lean"
+      "Proofs/Erdos501ProblemProvable.lean",
+      "Proofs/Erdos501Hull.lean",
+      "Proofs/Erdos501Fubini.lean"
     ]
   },
   "references": [

--- a/src/data/proofs/minpoly-charpoly-oq-02/annotations.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-mcpoq02-imports",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 1, "endLine": 10 },
+    "range": {
+      "startLine": 1,
+      "endLine": 11
+    },
     "type": "concept",
     "title": "Import Stack: Charpoly + Semisimple + Eigenspace + Parent",
     "content": "Ten imports stage the three Mathlib layers used by the OQ-02 discharge plan:\n\n* **Minpoly / charpoly layer** (L1-2): `Matrix.Charpoly.Basic` for charpoly and `Matrix.Charpoly.Minpoly` for `Matrix.minpoly_toLin'` — the Bridge D used to transport squarefree across the matrix↔endo correspondence.\n* **Diagonal-matrix predicate** (L3): `LinearAlgebra.Matrix.IsDiag` — the codomain of the similarity-transform existential in `Matrix.IsDiagonalizable`. Note: the S7 ACT v4.26.0 import regression fix added this import after the silently-removed `Mathlib.Algebra.Polynomial.Squarefree` (file renamed in v4.26.0).\n* **Semisimplicity** (L4): `LinearAlgebra.Semisimple` — provides `Module.End.IsSemisimple`, the engine of the entire iff. Includes both directions of Bridge C: `Module.End.IsSemisimple.minpoly_squarefree` and `Module.End.isSemisimple_of_squarefree_aeval_eq_zero`.\n* **Eigenspace layer** (L5-6): `Eigenspace.Semisimple` for `IsFinitelySemisimple.maxGenEigenspace_eq_eigenspace` (the second link in Bridge B forward's 3-lemma chain); `Eigenspace.Triangularizable` for `Module.End.iSup_maxGenEigenspace_eq_top` (the third link, the endpoint).\n* **Finite-dim transport** (L7-8): `FreeModule.Finite.Matrix` for the `Matrix.toLin'` algebra hookups; `FieldTheory.IsAlgClosed.Basic` for the headline's `[IsAlgClosed K]` hypothesis.\n* **Tactic + Parent** (L9-10): `Mathlib.Tactic` for `simpa`/`refine`/calc; `Proofs.MinpolyCharpoly` for the parent's 17 minpoly | charpoly theorems.",
@@ -22,7 +25,10 @@
   {
     "id": "ann-mcpoq02-resolution",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 28, "endLine": 56 },
+    "range": {
+      "startLine": 13,
+      "endLine": 93
+    },
     "type": "concept",
     "title": "S1 OBSERVE Resolution — Three Ingredients, No Mathlib Gap",
     "content": "The S1 OBSERVE docstring resolves OQ-02 affirmatively by identifying three Mathlib-level ingredients that compose into the matrix-level iff:\n\n1. **Module.End.IsSemisimple ↔ Squarefree (minpoly K f)** — already in Mathlib at v4.26.0 (`Module.End.isSemisimple_iff_squarefree_minpoly` ships in `Mathlib.LinearAlgebra.Semisimple`, with both directions named). Bridge C ships this in-tree as a packaged iff (lines 162-167).\n\n2. **IsSemisimple + minpoly splits → diagonalizable**: over alg-closed `K` the splits hypothesis is automatic; semisimplicity then implies the eigenspaces span the whole space (Bridge B forward, lines 146-155). Composed with the converse direction (Bridge B reverse, deferred to S8 ACT) this gives the operator-theoretic characterisation.\n\n3. **Matrix ↔ endomorphism transport**: `Matrix.toLin' M` carries the minpoly across (`Matrix.minpoly_toLin'`, Bridge D) and lets us read the matrix-level diagonalizability statement back from the endomorphism-level iff.\n\nNo Mathlib gap is required. The remaining work for OQ-02 is purely *integrative* — assemble the three pieces into the headline matrix-level statement. The four sub-OQs (OQ-02-OQ-01..OQ-02-OQ-04) decompose this integration into ~450 LOC across four iterations.",
@@ -44,7 +50,10 @@
   {
     "id": "ann-mcpoq02-isdiagonalizable",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 100, "endLine": 108 },
+    "range": {
+      "startLine": 108,
+      "endLine": 109
+    },
     "type": "definition",
     "title": "Matrix.IsDiagonalizable — the Matrix-Level Predicate",
     "content": "`Matrix.IsDiagonalizable M` is defined as `∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P)` — the existential over similarity transforms `P` whose conjugate of `M` is a diagonal matrix.\n\nDesign choices:\n\n* **Existential over `P` rather than fixed `P`**: the definition is intrinsic to the similarity class. Two diagonalizable matrices may use very different `P`s, and the predicate abstracts that out.\n* **`IsUnit P` rather than `P.Invertible` or `Nonsing`**: `IsUnit` is the Mathlib idiom for invertibility in a monoid; `Matrix.IsUnit_iff_isUnit_det` connects it to the determinant for downstream calculations.\n* **`IsDiag` rather than `Matrix.diagonal d` for some explicit `d`**: `IsDiag` is the predicate ('every off-diagonal entry is zero'), which is what callers actually need. The explicit eigenvalue-multiplicity diagonal is reconstructable from `IsDiag` + `Matrix.diag` extraction.\n* **`_root_.Matrix.IsDiagonalizable`**: the `_root_` prefix exposes the predicate at the top-level `Matrix` namespace, matching `Matrix.IsDiag` / `Matrix.IsUnit_iff_isUnit_det` etc.\n\nThis predicate corresponds at the endomorphism level to `Module.End.IsSemisimple ∧ Polynomial.Splits (algebraMap K K) (minpoly K f)` — the alg-closed condition makes the splits clause vacuous, so under `[IsAlgClosed K]` the predicate is equivalent to `IsSemisimple (toLin' M)`.",
@@ -65,10 +74,13 @@
   {
     "id": "ann-mcpoq02-headline",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 110, "endLine": 122 },
+    "range": {
+      "startLine": 296,
+      "endLine": 320
+    },
     "type": "insight",
-    "title": "diagonalizable_iff_squarefree_minpoly — The S1 Headline (Sorry-Guarded)",
-    "content": "The S1 statement is the textbook gold form: over an algebraically closed field of characteristic zero, a matrix is diagonalizable iff its minimal polynomial is squarefree. A single `sorry` at line 122 carries the proof — the four sub-OQs (OQ-02-OQ-01..OQ-02-OQ-04) and the ~59 LOC ACT synthesis are designed to discharge it.\n\n**Why these specific hypotheses?**\n\n* **`[IsAlgClosed K]`**: makes `Polynomial.Splits (algebraMap K K) (minpoly K M)` automatic, so the textbook 'minpoly squarefree *and splits*' condition collapses to just 'minpoly squarefree'.\n* **`[CharZero K]`**: every polynomial is separable in char 0, so 'squarefree' and 'product of distinct irreducible factors' coincide. This is the cleanest target for the OQ-02-OQ-04 sub-OQ.\n\nThe minimum hypotheses are weaker — 'perfect field + minpoly splits in K' suffices — but the alg-closed-char-0 case is what most callers (linear-algebra texts, computer algebra systems, downstream applications) expect. The general-field form is the target of **OQ-02-OQ-03** and could be added as `diagonalizable_iff_squarefree_minpoly_general` once that sub-OQ ships.\n\n**Discharge plan (~59 LOC, picker-estimated by S7c PREP §5.1)**:\n\n| Bridge | Direction | Source | LOC |\n|---|---|---|---:|\n| A fwd | M.IsDiagonalizable → eigenbasis | S2 PREP-3 §2 | ~12 |\n| A rev | eigenbasis → M.IsDiagonalizable | S2 PREP-3 §3.2 | ~8 |\n| B fwd | IsSemisimple → ⨆ eigenspace = ⊤ | **In-tree** (this file, lines 146-155) | 0 |\n| B rev | ⨆ eigenspace = ⊤ → IsSemisimple | S5b PREP §5 + S7c §3.3 Option A | ~33 |\n| C | IsSemisimple ↔ Squarefree minpoly | **In-tree** (this file, lines 162-167) | 0 |\n| D | minpoly K (toLin' M) = minpoly K M | `Matrix.minpoly_toLin'` (Mathlib, @[simp]) | 1 |\n| Compose | iff headline | 4 bridges + finiteness | ~5 |",
+    "title": "diagonalizable_iff_squarefree_minpoly — The Headline (Fully Proved)",
+    "content": "The headline is now fully proved with **no sorries** over any algebraically closed field `K` (of arbitrary characteristic): a matrix `M` is diagonalizable iff its minimal polynomial is squarefree.\n\n**Forward** (`→`, unconditional over any field): `Matrix.IsDiagonalizable.squarefree_minpoly` — if `M = P⁻¹ D P` with `D` diagonal, then `minpoly K M = minpoly K D` (similarity invariance via the `matConj` algebra automorphism) divides `∏ (X − c)` over the distinct diagonal entries, hence is squarefree.\n\n**Reverse** (`←`, needs `[IsAlgClosed K]` only): four steps —\n\n| Step | Lemma | Role |\n|---|---|---|\n| Bridge D | `Matrix.minpoly_toLin'` | transport squarefreeness to the endomorphism `M.toLin'` |\n| Bridge C | `Module.End.isSemisimple_iff_squarefree_minpoly` | squarefree minpoly ⇒ semisimple |\n| Eigenbasis | `Matrix.exists_eigenbasis_of_isSemisimple` | semisimple + alg-closed ⇒ basis of eigenvectors (via Bridge B + `DirectSum.IsInternal`) |\n| Conjugation | `Matrix.isDiagonalizable_of_eigenbasis` | eigenbasis ⇒ diagonalizing similarity |\n\n**Why no `[CharZero K]`?** The textbook statement carries it, but it is redundant. Bridge C's reverse arm (`isSemisimple_of_squarefree_aeval_eq_zero`) needs only squarefreeness — separability is not required for *semisimplicity* (squarefree minpoly ⇒ the module is a sum of simple `K[X]`-submodules regardless of characteristic). Algebraic closure then forces those simple factors to be `1`-dimensional (all irreducibles are linear), giving an eigenbasis. Characteristic zero never enters, so the hypothesis was dropped — strengthening the result to all characteristics. The general-field form (with an explicit `Polynomial.Splits` hypothesis in place of algebraic closure) is the target of **OQ-02-OQ-03**.",
     "mathContext": "For $K$ algebraically closed of characteristic 0 and $M \\in \\mathrm{Mat}_n(K)$: $M$ is diagonalizable $\\Leftrightarrow$ $\\mathrm{minpoly}_K(M) \\in K[X]$ is squarefree.",
     "significance": "critical",
     "relatedConcepts": [
@@ -87,7 +99,10 @@
   {
     "id": "ann-mcpoq02-sanity",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 124, "endLine": 134 },
+    "range": {
+      "startLine": 321,
+      "endLine": 343
+    },
     "type": "definition",
     "title": "Sanity Helpers — of_isDiag and zero (Unconditional)",
     "content": "Two unconditional sanity lemmas give the file a non-trivial public surface even before the headline discharge:\n\n* **`Matrix.IsDiagonalizable.of_isDiag`** (lines 126-129): any diagonal matrix is diagonalizable, witnessed by `P = 1`. Proof: `refine ⟨1, isUnit_one, ?_⟩; simpa using hM`. The `simpa` simp-set rewrites `1⁻¹ * M * 1 = M`, reducing the goal to `IsDiag M` which is the hypothesis. Note: the S7 ACT v4.26.0 patch dropped `Matrix.inv_one` from this `simpa` lemma list (now subsumed by the default simp set) and added the `Matrix.IsDiag` namespace qualification (M → Matrix.IsDiag M, since just `IsDiag` is ambiguous at v4.26.0).\n\n* **`Matrix.IsDiagonalizable.zero`** (lines 132-134): the zero matrix is diagonalizable. Proof: `Matrix.IsDiagonalizable.of_isDiag Matrix.isDiag_zero`. A one-liner combining the previous sanity helper with `Matrix.isDiag_zero` (the zero matrix is diagonal).\n\nThese helpers are not the discharge target — they exist so the file passes 'has-non-trivial-public-content' checks (e.g. for the gallery card thumbnail) and as worked examples of the `Matrix.IsDiagonalizable` predicate API.",
@@ -106,7 +121,10 @@
   {
     "id": "ann-mcpoq02-bridge-b-fwd",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 140, "endLine": 155 },
+    "range": {
+      "startLine": 205,
+      "endLine": 220
+    },
     "type": "definition",
     "title": "Bridge B Forward — Phantom-Corrected 3-Lemma Chain",
     "content": "**S7 ACT contribution (#19095, merged 2026-05-15)**. `Module.End.iSup_eigenspace_eq_top_of_isSemisimple`: over a finite-dimensional alg-closed-K space, if `f` is semisimple then its eigenspaces span the whole space (⨆ μ : K, f.eigenspace μ = ⊤).\n\n**Why a 3-lemma chain?** The natural-looking direct form `Module.End.IsSemisimple.iSup_eigenspace_eq_top` *does not exist in Mathlib*. S3 PREP #18481 originally claimed it as a single lemma — caught as phantom by the S4 PREP #18626 audit. The corrected route composes three steps:\n\n1. **`hss.isFinitelySemisimple`**: upgrade semisimplicity to its finitely-semisimple companion (uses `[FiniteDimensional K V]`).\n2. **`hfin.maxGenEigenspace_eq_eigenspace μ`**: under finite semisimplicity, the maximal generalized eigenspace equals the eigenspace at each `μ`. (Reverse direction taken via `.symm`.)\n3. **`Module.End.iSup_maxGenEigenspace_eq_top f`**: over alg-closed-K in finite dim, the sum of maximal generalized eigenspaces is the whole space.\n\nComposition: `iSup μ, eigenspace μ = iSup μ, maxGenEigenspace μ = ⊤`, fused by `iSup_congr`.\n\nThis is the **Bridge B forward** of the four-bridge synthesis. Combined with the (still-pending) Bridge B reverse (S5b PREP §5 + S7c §3.3 Option A) it gives the eigenspace-decomposition ↔ semisimple iff, which together with Bridge C (squarefree ↔ semisimple) and Bridges A/D (matrix↔endo) discharges the headline.",
@@ -128,10 +146,13 @@
   {
     "id": "ann-mcpoq02-bridge-c",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 157, "endLine": 167 },
+    "range": {
+      "startLine": 222,
+      "endLine": 232
+    },
     "type": "theorem",
     "title": "Bridge C — IsSemisimple ↔ Squarefree minpoly",
-    "content": "**S7 ACT contribution (#19095, merged 2026-05-15)**. `Module.End.isSemisimple_iff_squarefree_minpoly`: over a finite-dimensional `K`-space, an endomorphism `f` is semisimple iff its minimal polynomial is squarefree.\n\n* **Forward**: `Module.End.IsSemisimple.minpoly_squarefree` (Mathlib, in `LinearAlgebra.Semisimple`). Directly gives `f.IsSemisimple → Squarefree (minpoly K f)`.\n* **Reverse**: `Module.End.isSemisimple_of_squarefree_aeval_eq_zero` (Mathlib) applied to `minpoly.aeval K f`. The lemma's general form takes any polynomial `p` that's squarefree and annihilates `f` and concludes `f.IsSemisimple`; specialising `p := minpoly K f` (with `minpoly.aeval` witnessing `p.aeval f = 0`) gives the reverse direction.\n\nThis Bridge C is the **endomorphism-level iff** — the heart of OQ-02. Transporting it to the matrix level via Bridge D (`Matrix.minpoly_toLin'`) yields `IsSemisimple (toLin' M) ↔ Squarefree (minpoly K M)`, and combining with Bridges A/B yields the headline.\n\n**Note**: this iff is field-independent and characteristic-independent — `[CharZero K]` is *not* required for the iff itself. The CharZero hypothesis on the headline enters only to simplify the OQ-02-OQ-04 sub-OQ (where 'squarefree' coincides with 'separable + product of distinct linear factors over `K`').",
+    "content": "**S7 ACT contribution (#19095, merged 2026-05-15)**. `Module.End.isSemisimple_iff_squarefree_minpoly`: over a finite-dimensional `K`-space, an endomorphism `f` is semisimple iff its minimal polynomial is squarefree.\n\n* **Forward**: `Module.End.IsSemisimple.minpoly_squarefree` (Mathlib, in `LinearAlgebra.Semisimple`). Directly gives `f.IsSemisimple → Squarefree (minpoly K f)`.\n* **Reverse**: `Module.End.isSemisimple_of_squarefree_aeval_eq_zero` (Mathlib) applied to `minpoly.aeval K f`. The lemma's general form takes any polynomial `p` that's squarefree and annihilates `f` and concludes `f.IsSemisimple`; specialising `p := minpoly K f` (with `minpoly.aeval` witnessing `p.aeval f = 0`) gives the reverse direction.\n\nThis Bridge C is the **endomorphism-level iff** — the heart of OQ-02. Transporting it to the matrix level via Bridge D (`Matrix.minpoly_toLin'`) yields `IsSemisimple (toLin' M) ↔ Squarefree (minpoly K M)`, and combining with Bridges A/B yields the headline.\n\n**Note**: this iff is field-independent and characteristic-independent — no `[CharZero K]` or separability hypothesis is required. This is exactly why the headline `diagonalizable_iff_squarefree_minpoly` needs only `[IsAlgClosed K]`: semisimplicity follows from squarefreeness alone, and algebraic closure supplies the eigenbasis. Squarefree minpoly ⇒ semisimple holds because the module decomposes as a sum of simple `K[X]/(pᵢ)` factors over the distinct irreducibles `pᵢ`, independent of separability.",
     "mathContext": "For $V$ finite-dim over a field $K$ and $f \\in \\mathrm{End}_K(V)$: $f$ is semisimple $\\Leftrightarrow$ $\\mathrm{minpoly}_K(f) \\in K[X]$ is squarefree.",
     "significance": "critical",
     "relatedConcepts": [
@@ -145,5 +166,55 @@
       "Squarefree polynomial predicate",
       "Annihilating polynomial"
     ]
+  },
+  {
+    "id": "ann-mcpoq02-reverse-transport",
+    "type": "theorem",
+    "proofId": "minpoly-charpoly-oq-02",
+    "title": "Matrix.isDiagonalizable_of_eigenbasis — Eigenbasis ⇒ Diagonalizable",
+    "significance": "critical",
+    "content": "The reverse-direction transport lemma (holds over **any** field). Given a basis `b` of `n → K` whose vectors are eigenvectors of `M.toLin'` (i.e. `M.toLin' (b i) = c i • b i`), `M` is diagonalizable.\n\n**Construction of the similarity.** Let `e = Pi.basisFun K n` (the standard basis). The change-of-basis matrix `P = e.toMatrix b` is invertible (`Basis.invertibleToMatrix`), with `P⁻¹ = b.toMatrix e` (`Matrix.invOf_eq_nonsing_inv`). Conjugating: `P⁻¹ * M * P = b.toMatrix e * M * e.toMatrix b`, and since `M = LinearMap.toMatrix e e M.toLin'`, the change-of-basis lemma `basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix` rewrites this to `LinearMap.toMatrix b b M.toLin'`.\n\n**Diagonality.** Entry `(i,j)` of `LinearMap.toMatrix b b M.toLin'` is `b.repr (M.toLin' (b j)) i = b.repr (c j • b j) i = c j · b.repr (b j) i`. By `Basis.repr_self_apply` this is `c j` when `i = j` and `0` otherwise — a diagonal matrix. Hence `IsDiag (P⁻¹ M P)`, i.e. `M.IsDiagonalizable`.",
+    "mathContext": "For an eigenbasis $\\{b_i\\}$ of $K^n$ with $M b_i = c_i b_i$ and $Q$ the change-of-basis matrix to the standard basis, $Q^{-1} M Q = \\operatorname{diag}(c_i)$.",
+    "relatedConcepts": [
+      "Change of basis",
+      "LinearMap.toMatrix",
+      "Basis.toMatrix",
+      "Matrix.IsDiag",
+      "Similarity transform"
+    ],
+    "prerequisites": [
+      "Basis and change-of-basis matrices",
+      "Matrix.toLin' / LinearMap.toMatrix correspondence",
+      "Eigenvectors"
+    ],
+    "range": {
+      "startLine": 238,
+      "endLine": 265
+    }
+  },
+  {
+    "id": "ann-mcpoq02-reverse-eigenbasis",
+    "type": "theorem",
+    "proofId": "minpoly-charpoly-oq-02",
+    "title": "Matrix.exists_eigenbasis_of_isSemisimple — Semisimple ⇒ Eigenbasis",
+    "significance": "critical",
+    "content": "The reverse-direction eigenbasis construction (over an algebraically closed field). A semisimple endomorphism `f` of `n → K` admits a basis of eigenvectors.\n\n**The chain.** Bridge B (`Module.End.iSup_eigenspace_eq_top_of_isSemisimple`) gives `⨆ μ, f.eigenspace μ = ⊤`. Eigenspaces are always independent (`Module.End.eigenspaces_iSupIndep`), so `DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top` assembles the family into an internal direct sum `DirectSum.IsInternal f.eigenspace`.\n\n**Collecting and reindexing.** `IsInternal.collectedBasis` glues a chosen basis of each eigenspace (`Module.finBasis`) into a basis of `n → K` indexed by the sigma type `Σ μ : K, Fin (finrank K (f.eigenspace μ))`. That index is automatically a `Fintype` (`FiniteDimensional.fintypeBasisIndex`, since it indexes a basis of a finite-dimensional space), and `Basis.indexEquiv` produces an equivalence onto `n` (both index bases of the same space). Reindexing yields `Basis n K (n → K)`.\n\n**Eigenvectors.** Each collected vector `b₀ a` lies in `f.eigenspace a.1` (`IsInternal.collectedBasis_mem`), so `mem_eigenspace_iff` gives `f (b₀ a) = a.1 • b₀ a` — an eigenvector with eigenvalue `a.1`. After reindexing, the eigenvalue function is `c i = (e.symm i).1`.",
+    "mathContext": "Over $\\overline{K}$, a semisimple $f$ satisfies $\\bigoplus_\\mu \\ker(f-\\mu) = K^n$; collecting per-eigenspace bases yields an eigenbasis of $K^n$.",
+    "relatedConcepts": [
+      "DirectSum.IsInternal",
+      "collectedBasis",
+      "iSupIndep",
+      "Basis.indexEquiv",
+      "FiniteDimensional.fintypeBasisIndex"
+    ],
+    "prerequisites": [
+      "Internal direct sums of submodules",
+      "Eigenspace independence",
+      "Basis reindexing"
+    ],
+    "range": {
+      "startLine": 268,
+      "endLine": 294
+    }
   }
 ]

--- a/src/data/proofs/minpoly-charpoly-oq-02/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/meta.json
@@ -1,13 +1,13 @@
 {
   "id": "minpoly-charpoly-oq-02",
-  "title": "Diagonalizable Matrices via Squarefree Minimal Polynomial (S7 ACT Scaffold)",
+  "title": "Diagonalizable Matrices via Squarefree Minimal Polynomial",
   "slug": "minpoly-charpoly-oq-02",
-  "description": "S1 OBSERVE → S7 ACT scaffold resolving the parent's second open question: 'Can the diagonalizability characterisation M ∈ Matₙ(F) diagonalizable ⇔ minpoly M ∈ F[X] is squarefree (and splits in F) be formalized in Lean 4?' Affirmative: defines Matrix.IsDiagonalizable, states the headline iff theorem guarded by a single sorry, and ships two pre-verified endomorphism-level bridges (Bridge B forward: IsSemisimple → ⨆ eigenspace = ⊤; Bridge C: IsSemisimple ↔ Squarefree minpoly) that the eventual ACT picker will compose with matrix↔endo transport bridges to discharge the sorry.",
+  "description": "Fully verified resolution of the parent's second open question: 'Can the diagonalizability characterisation M ∈ Matₙ(F) diagonalizable ⇔ minpoly M ∈ F[X] is squarefree (and splits in F) be formalized in Lean 4?' Affirmative and complete: defines Matrix.IsDiagonalizable and proves the headline iff diagonalizable_iff_squarefree_minpoly over any algebraically closed field (of arbitrary characteristic — the textbook CharZero hypothesis turns out to be redundant), with no sorries and no axioms beyond Lean's foundational three. The forward direction (diagonalizable ⇒ squarefree minpoly) is unconditional over any field; the reverse direction (squarefree ⇒ diagonalizable) transports the minpoly to the endomorphism M.toLin' (Matrix.minpoly_toLin'), reads squarefree-minpoly as semisimplicity (Bridge C), extracts a basis of eigenvectors from the internal eigenspace decomposition (Bridge B + DirectSum.IsInternal + reindexing), and conjugates M by the change-of-basis matrix to a diagonal matrix.",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Semisimple.html",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/MinpolyCharpolyOQ02.lean",
     "tags": [
       "linear-algebra",
@@ -19,21 +19,23 @@
       "eigenspace",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 279,
-    "assumptions": "0 axioms; 1 sorry guarding the proof of `diagonalizable_iff_squarefree_minpoly`. The statement itself is unconditional (hypotheses [IsAlgClosed K] [CharZero K] are explicit, not assumed-as-axiom). The two pre-shipped endomorphism-level bridges (Module.End.iSup_eigenspace_eq_top_of_isSemisimple and Module.End.isSemisimple_iff_squarefree_minpoly) are fully proved with no sorry. The four sub-OQs OQ-02-OQ-01..OQ-02-OQ-04 (estimated ~450 lines total) are the planned discharge route, with the picker-estimated final synthesis at ~59 LOC (~12 + 8 + 33 + 1 + 5 for Bridges A fwd + A rev + B rev + D + compose). Pinned at Mathlib v4.26.0; 18 bearer lemmas verified at SHA 2df2f015… by S7c PREP #19257.",
+    "lineCount": 344,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axiom declarations; `#print axioms diagonalizable_iff_squarefree_minpoly` reports only Lean's foundational trio [propext, Classical.choice, Quot.sound], none of which count against verified status. The single headline hypothesis [IsAlgClosed K] is an explicit typeclass parameter, not an axiom (the textbook [CharZero K] was verified redundant and dropped). The reverse direction is discharged in-tree via two helper theorems: Matrix.isDiagonalizable_of_eigenbasis (an eigenbasis of M.toLin' yields a diagonalizing similarity, via the change-of-basis conjugation LinearMap.toMatrix b b M.toLin') and Matrix.exists_eigenbasis_of_isSemisimple (a semisimple endomorphism of n → K admits an eigenbasis, via DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top, collectedBasis, and reindexing onto n). Pinned at Mathlib v4.26.0.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-04",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 2,
     "originalContributions": [
       "Matrix.IsDiagonalizable predicate: ∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P) — the matrix-level analogue of Module.End.IsSemisimple ∧ Polynomial.Splits for the associated endomorphism",
       "Module.End.iSup_eigenspace_eq_top_of_isSemisimple: the corrected 3-lemma chain (IsSemisimple → IsFinitelySemisimple → maxGenEigenspace μ = eigenspace μ → ⨆ eigenspace = ⊤) for alg-closed finite-dimensional spaces (Bridge B forward, shipped S7 ACT #19095 after S4 PREP #18626 caught the phantom direct-form name)",
       "Module.End.isSemisimple_iff_squarefree_minpoly: the endomorphism-level iff (Bridge C), constructed by composing Module.End.IsSemisimple.minpoly_squarefree (forward) with Module.End.isSemisimple_of_squarefree_aeval_eq_zero applied to minpoly.aeval (reverse)",
-      "Four-sub-OQ decomposition (OQ-02-OQ-01..OQ-02-OQ-04): bridge Module.End.IsSemisimple ↔ Squarefree to matrices (~100 LOC); diagonalizable predicate + alg-closed form (~150 LOC); general-field form with explicit Splits hypothesis (~120 LOC); char-0 specialisation: minpoly automatically separable (~80 LOC); total roadmap ~450 LOC (smaller than OQ-01 / OQ-03 because Module.End.IsSemisimple absorbs most of the work)",
-      "Sanity helpers: Matrix.IsDiagonalizable.of_isDiag (any diagonal matrix is diagonalizable via P=1) and Matrix.IsDiagonalizable.zero (the zero matrix is diagonalizable, via of_isDiag and isDiag_zero) — exposing a non-trivial public surface even before the headline discharge"
+      "Matrix.isDiagonalizable_of_eigenbasis: reverse-direction transport lemma (any field). If n → K has a basis b of eigenvectors of M.toLin' with M.toLin' (b i) = c i • b i, then M is diagonalizable. The diagonalizing similarity is the change-of-basis matrix (Pi.basisFun).toMatrix b; conjugating M by it gives LinearMap.toMatrix b b M.toLin', which is diagonal because every basis vector is an eigenvector (via basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix and Basis.repr_self_apply)",
+      "Matrix.exists_eigenbasis_of_isSemisimple: reverse-direction eigenbasis construction over an algebraically closed field. A semisimple endomorphism of n → K admits a basis of eigenvectors — obtained by combining Bridge B (⨆ eigenspace = ⊤) with eigenspace independence into DirectSum.IsInternal, collecting a per-eigenspace basis (IsInternal.collectedBasis), and reindexing the resulting sigma-indexed basis onto n (FiniteDimensional.fintypeBasisIndex + Basis.indexEquiv)",
+      "diagonalizable_iff_squarefree_minpoly: the fully proved headline iff over [IsAlgClosed K] (any characteristic), composing the forward direction with the reverse chain Matrix.minpoly_toLin' → Bridge C → exists_eigenbasis_of_isSemisimple → isDiagonalizable_of_eigenbasis. Strengthens the textbook statement by dropping the redundant CharZero hypothesis",
+      "Sanity helpers: Matrix.IsDiagonalizable.of_isDiag (any diagonal matrix is diagonalizable via P=1), .zero, .one, and .diagonal (concrete diagonalizable instances via of_isDiag and the corresponding Matrix.isDiag_* lemmas)"
     ],
     "mathlibDependencies": [
       {
@@ -89,14 +91,14 @@
     "historicalContext": "The characterisation of diagonalizable matrices via their minimal polynomial is a textbook result (Hoffman-Kunze §6.4, Hungerford §VII.4, Lang §XIV.3): a matrix M over a field F is diagonalizable iff minpoly(M) splits in F and has only simple roots — equivalently, iff minpoly(M) is squarefree and splits. Over algebraically closed fields the 'splits' condition is automatic, so the statement reduces to 'diagonalizable iff minpoly squarefree'. The result generalises the analogous statement for unitary / normal operators on Hilbert spaces and is the operator-theoretic precursor to the spectral theorem. In modern presentations the result is typically derived from the structural fact that semisimple endomorphisms (those whose every invariant subspace has an invariant complement) coincide with those whose minimal polynomial is squarefree (Bourbaki, Algèbre, ch. VIII).",
     "problemStatement": "**Open Question (minpoly-charpoly-oq-02)**: Can the diagonalizability characterisation `M ∈ Matₙ(F) diagonalizable ⇔ minpoly M ∈ F[X] is squarefree (and splits in F)` be formalized in Lean 4 using the parent's minpoly | charpoly infrastructure? — `conclusion.openQuestions[1]` of the parent gallery entry `minpoly-charpoly`. Sibling open questions: OQ-01 (Jordan normal form) and OQ-03 (rational canonical form).",
     "text": "**Resolution (S1 OBSERVE): YES.** Mathlib's `Module.End.IsSemisimple` API provides the endomorphism-level squarefree↔semisimple equivalence directly. Combined with the eigenspace-decomposition theorem over alg-closed fields and the matrix↔endo transport (Matrix.minpoly_toLin'), the matrix-level iff requires only integrative work — no Mathlib gap. The S7 ACT iteration shipped two of the four required bridges (B forward and C); the remaining ~59 LOC synthesis is the discharge target for a future S8 ACT.",
-    "proofStrategy": "**S1 → S7 ACT scaffold**: define `Matrix.IsDiagonalizable`, state the headline iff with explicit hypotheses [IsAlgClosed K] [CharZero K], and ship two pre-verified bridges (B forward via the 3-lemma chain, C iff via mp-mpr composition). Sanity lemmas `of_isDiag` and `zero` give a non-trivial public surface.\n\n**S8+ ACT (planned, ~59 LOC)**: discharge the headline sorry via four bridges:\n\n1. **Bridge A** (matrix ↔ endomorphism eigenbasis transport, ~20 LOC): identify M.IsDiagonalizable with toLin' M having an eigenbasis.\n2. **Bridge B reverse** (⨆ eigenspace = ⊤ → IsSemisimple, ~33 LOC): explicit construction using S5b PREP §5 body and S7c PREP §3.3 Option A (`let q := (S \\ {μ}).prod fun ν ↦ X - C ν`).\n3. **Bridge D** (Matrix.minpoly_toLin', 1 LOC): transport squarefree across matrix↔endo.\n4. **Compose** (~5 LOC): assemble the four-way iff using bridges A both directions, B forward (in-tree), B reverse, C (in-tree), D.\n\n**Future sub-OQs** (~450 LOC roadmap):\n- OQ-02-OQ-01 (~100 LOC): bridge Module.End.IsSemisimple ↔ Squarefree to matrices uniformly.\n- OQ-02-OQ-02 (~150 LOC): diagonalizable predicate variants + alg-closed unconditional form.\n- OQ-02-OQ-03 (~120 LOC): general-field form with explicit Polynomial.Splits hypothesis.\n- OQ-02-OQ-04 (~80 LOC): char-0 specialisation: minpoly is automatically separable, so the squarefree side simplifies.",
+    "proofStrategy": "**Forward direction** (`diagonalizable ⇒ squarefree minpoly`, any field): if M = P⁻¹ D P with D diagonal, then minpoly K M = minpoly K D (similarity invariance, via the conjugation algebra automorphism `matConj`), and minpoly K D divides ∏_{c ∈ diag D}(X − c), a separable product of distinct linear factors, hence squarefree (`squarefree_minpoly_of_isDiag` + `Matrix.IsDiagonalizable.squarefree_minpoly`).\n\n**Reverse direction** (`squarefree minpoly ⇒ diagonalizable`, over [IsAlgClosed K] alone — no CharZero needed), discharged in four steps:\n\n1. **Bridge D** (`Matrix.minpoly_toLin'`): transport squarefreeness of minpoly K M to minpoly K (M.toLin').\n2. **Bridge C** (`Module.End.isSemisimple_iff_squarefree_minpoly`): read squarefree minpoly as semisimplicity of M.toLin'.\n3. **Eigenbasis extraction** (`Matrix.exists_eigenbasis_of_isSemisimple`): Bridge B (`iSup_eigenspace_eq_top_of_isSemisimple`) gives ⨆ eigenspace = ⊤; with eigenspace independence this is a DirectSum.IsInternal; `collectedBasis` yields a sigma-indexed eigenbasis, reindexed onto n via `FiniteDimensional.fintypeBasisIndex` + `Basis.indexEquiv`.\n4. **Conjugation** (`Matrix.isDiagonalizable_of_eigenbasis`): the change-of-basis matrix (Pi.basisFun).toMatrix b conjugates M to LinearMap.toMatrix b b M.toLin', which is diagonal because each b i is an eigenvector.\n\n**Future sub-OQs** (generalisations beyond the algebraically-closed headline):\n- OQ-02-OQ-03: general-field form with an explicit Polynomial.Splits hypothesis (the textbook 'splits + squarefree' form).\n- OQ-02-OQ-04: char-0 specialisation — minpoly is automatically separable, so squarefree ⇔ distinct irreducible factors.",
     "keyInsights": [
       "**No Mathlib gap**: Mathlib's `Module.End.IsSemisimple` API (in `Mathlib.LinearAlgebra.Semisimple`) already provides the squarefree↔semisimple iff at the endomorphism level. The remaining work is integrative — matrix↔endomorphism transport plus the eigenspace-decomposition step.",
       "**Bridge B forward is a 3-lemma chain, not a single lemma**: the natural-looking direct form `Module.End.IsSemisimple.iSup_eigenspace_eq_top` does not exist in Mathlib (phantom caught by S4 PREP #18626). The correct path is `IsSemisimple.isFinitelySemisimple → IsFinitelySemisimple.maxGenEigenspace_eq_eigenspace μ → iSup_maxGenEigenspace_eq_top`, composed via `iSup_congr`. This is now shipped in-tree as `Module.End.iSup_eigenspace_eq_top_of_isSemisimple`.",
       "**Char-0 simplifies the squarefree condition**: over a characteristic-0 field, every polynomial is separable, so 'squarefree' (the statement-level condition) coincides with 'product of distinct linear factors' over the algebraic closure. The OQ-02-OQ-04 sub-OQ exploits this to reduce the char-0 form to the explicit eigenvalue-multiplicity statement.",
       "**Why the alg-closed hypothesis matters at the matrix level but not the endomorphism level**: the endomorphism iff `IsSemisimple ↔ Squarefree minpoly` holds over any field. To upgrade 'semisimple' to 'diagonalizable' at the matrix level requires that the minimal polynomial actually splits — automatic over alg-closed fields, but otherwise an explicit `Polynomial.Splits (algebraMap K K) (minpoly K M)` hypothesis is needed. This split is the substance of OQ-02-OQ-03.",
       "**Sub-OQ decomposition is asymmetric**: OQ-02's ~450 LOC roadmap is smaller than OQ-01 (JNF, generalized eigenspaces) and OQ-03 (RCF, ~900 LOC via PID structure theorem) precisely because the squarefree-minpoly route avoids the full invariant-factor decomposition. The price is that OQ-02 only handles the *diagonalizable* case — non-diagonalizable matrices still need JNF (OQ-01) or RCF (OQ-03).",
-      "**Headline statement vs gold form**: the S1 statement uses `[IsAlgClosed K] [CharZero K]` (the textbook gold form). The minimum hypotheses are weaker — `perfect field + minpoly splits in K` suffices — but the alg-closed-char-0 case is what most callers expect. The general-field form is the target of OQ-02-OQ-03 and could be added as `diagonalizable_iff_squarefree_minpoly_general` once OQ-02-OQ-03 ships."
+      "**CharZero is redundant over an algebraically closed field**: the textbook statement carries `[IsAlgClosed K] [CharZero K]`, but the final theorem needs only `[IsAlgClosed K]`. The reverse direction routes through semisimplicity (Bridge C needs only squarefreeness, no separability) and then uses algebraic closure to guarantee the minpoly splits into distinct *linear* factors — separability, and hence characteristic zero, never enters. The general-field form (with an explicit `Polynomial.Splits` hypothesis in place of algebraic closure) is the target of OQ-02-OQ-03 and could be added as `diagonalizable_iff_squarefree_minpoly_general`."
     ],
     "prerequisites": [
       "Linear algebra: matrices, similarity transforms, minpoly, charpoly",
@@ -117,17 +119,17 @@
     },
     {
       "id": "intro-docstring",
-      "title": "§1: Open Question, Resolution, and Sub-OQ Decomposition",
-      "startLine": 11,
-      "endLine": 98,
-      "summary": "Top-level docstring stating OQ-02 (formalize diagonalizable ⇔ squarefree minpoly), the affirmative S1 OBSERVE resolution (no Mathlib gap — Module.End.IsSemisimple API absorbs most of the work), and a four-sub-OQ decomposition (OQ-02-OQ-01 bridge to matrices ~100 LOC; OQ-02-OQ-02 diagonalizable predicate + alg-closed form ~150 LOC; OQ-02-OQ-03 general-field form with Splits hypothesis ~120 LOC; OQ-02-OQ-04 char-0 specialisation ~80 LOC). Total roadmap ≈ 450 LOC — smaller than OQ-01 / OQ-03 because Module.End.IsSemisimple does the heavy lifting.",
-      "mathContext": "OQ-02: 'M diagonalizable ⇔ minpoly M squarefree (and splits)'. Resolution: YES via three pieces — (1) Module.End.IsSemisimple ↔ Squarefree minpoly (Mathlib in-tree), (2) IsSemisimple + splits → eigenspace decomposition = ⊤, (3) Matrix.toLin' + Matrix.minpoly_toLin' for matrix↔endo transport."
+      "title": "§1: Open Question and Resolution Strategy",
+      "startLine": 13,
+      "endLine": 93,
+      "summary": "Top-level docstring stating OQ-02 (formalize diagonalizable ⇔ squarefree minpoly) and the affirmative resolution: no Mathlib gap, since the Module.End.IsSemisimple API provides the squarefree↔semisimple equivalence at the endomorphism level, and the matrix↔endomorphism transport (Matrix.toLin', Matrix.minpoly_toLin') carries it to the matrix statement. Also records the sub-OQ decomposition for follow-up generalisations (general-field and char-0 forms).",
+      "mathContext": "OQ-02: 'M diagonalizable ⇔ minpoly M squarefree (and splits)'. Resolution: YES via three pieces — (1) Module.End.IsSemisimple ↔ Squarefree minpoly (Mathlib in-tree), (2) IsSemisimple → eigenspace decomposition = ⊤ (alg-closed), (3) Matrix.toLin' + Matrix.minpoly_toLin' for matrix↔endo transport."
     },
     {
       "id": "matrix-isdiagonalizable",
       "title": "§2: Matrix.IsDiagonalizable — Predicate Definition",
-      "startLine": 99,
-      "endLine": 110,
+      "startLine": 108,
+      "endLine": 109,
       "summary": "Defines `Matrix.IsDiagonalizable M : Prop := ∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P)` — the matrix-level analogue of Module.End.IsSemisimple ∧ Polynomial.Splits. The existential over similarity transforms `P` reads the iff back from endomorphism language into matrix language.",
       "mathContext": "$M \\in \\mathrm{Mat}_n(K)$ is diagonalizable $\\Leftrightarrow$ $\\exists P \\in \\mathrm{GL}_n(K),\\ P^{-1} M P$ is diagonal."
     },
@@ -135,44 +137,50 @@
       "id": "forward-direction",
       "title": "§3: Forward Direction (PROVED, unconditional over any field)",
       "startLine": 111,
-      "endLine": 200,
+      "endLine": 199,
       "summary": "The forward arm of the headline biconditional, fully proved with no algebraic-closure or characteristic hypotheses. `matConj` packages conjugation `x ↦ Q * x * P` by a two-sided-inverse pair as an algebra automorphism of the matrix algebra, used to transport the minimal polynomial across a similarity. `squarefree_minpoly_of_isDiag`: a diagonal matrix has squarefree minpoly (it divides ∏ (X − c) over the distinct diagonal entries — a separable product of distinct linear factors). `Matrix.IsDiagonalizable.squarefree_minpoly`: a diagonalizable matrix has squarefree minpoly, by transporting `squarefree_minpoly_of_isDiag` through `minpoly.algEquiv_eq (matConj …)`. Holds over any field — the field hypotheses are needed only for the converse.",
       "mathContext": "If $M = P^{-1} D P$ with $D$ diagonal, then $\\mathrm{minpoly}_K(M) = \\mathrm{minpoly}_K(D)$ (similarity invariance via the conjugation algebra automorphism `matConj`), and $\\mathrm{minpoly}_K(D) \\mid \\prod_{c \\in \\mathrm{diag}(D)}(X - c)$ is squarefree. Hence diagonalizable $\\Rightarrow$ squarefree minpoly over any field $K$."
     },
     {
-      "id": "main-theorem",
-      "title": "§4: diagonalizable_iff_squarefree_minpoly — Headline (single reverse sorry)",
+      "id": "bridges-b-c",
+      "title": "§4: Endomorphism-Level Bridges B and C",
       "startLine": 201,
-      "endLine": 222,
-      "summary": "**The S1 headline theorem.** Over `[IsAlgClosed K] [CharZero K]`, a matrix M is diagonalizable iff its minimal polynomial is squarefree. The **forward** direction is now fully discharged by `Matrix.IsDiagonalizable.squarefree_minpoly` (§3, unconditional). Only the **reverse** direction (squarefree minpoly ⇒ diagonalizable) remains a single `sorry` at line 221 — over an alg-closed field it follows from Bridge C (`isSemisimple_iff_squarefree_minpoly`) plus Bridge B (`iSup_eigenspace_eq_top_of_isSemisimple`) transported back through `Matrix.toLin'`, the target of sub-OQ-02-OQ-02. The docstring notes the hypotheses can be weakened to 'perfect field + minpoly splits' (OQ-02-OQ-03), but alg-closed-char-0 is the textbook gold form.",
-      "mathContext": "$M \\in \\mathrm{Mat}_n(K)$ over $K$ algebraically closed of char 0: $M$ is diagonalizable $\\Leftrightarrow$ $\\mathrm{minpoly}_K(M) \\in K[X]$ is squarefree. Forward arm proved; reverse arm `sorry` (line 221)."
+      "endLine": 233,
+      "summary": "Two endomorphism-level lemmas that the reverse-direction discharge transports to matrices. Bridge B forward — `Module.End.iSup_eigenspace_eq_top_of_isSemisimple`: over an alg-closed field in finite dimensions, semisimplicity implies the eigenspaces span the whole space, proved by a 3-lemma chain via `iSup_congr` (IsSemisimple → IsFinitelySemisimple → maxGenEigenspace μ = eigenspace μ → ⨆ eigenspace = ⨆ maxGenEigenspace = ⊤; the direct-form lemma is a phantom caught by S4 PREP #18626). Bridge C — `Module.End.isSemisimple_iff_squarefree_minpoly`: an endomorphism is semisimple iff its minpoly is squarefree (forward via `IsSemisimple.minpoly_squarefree`; reverse via `isSemisimple_of_squarefree_aeval_eq_zero` applied to `minpoly.aeval`).",
+      "mathContext": "Bridge B: for $V$ finite-dim over alg-closed $K$ and $f \\in \\mathrm{End}_K(V)$, $f$ semisimple $\\Rightarrow \\bigsqcup_{\\mu} \\ker(f - \\mu) = V$. Bridge C: $f$ semisimple $\\Leftrightarrow \\mathrm{minpoly}_K(f)$ squarefree."
+    },
+    {
+      "id": "reverse-direction",
+      "title": "§5: Reverse Direction (PROVED) — Eigenbasis ⇒ Diagonalizable",
+      "startLine": 234,
+      "endLine": 294,
+      "summary": "The two theorems that discharge the reverse arm. `Matrix.isDiagonalizable_of_eigenbasis` (any field): given a basis b of n → K consisting of eigenvectors of M.toLin' (M.toLin' (b i) = c i • b i), M is diagonalizable — the change-of-basis matrix (Pi.basisFun).toMatrix b conjugates M to LinearMap.toMatrix b b M.toLin' (via `basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix`), which is diagonal because each b i is an eigenvector (via `Basis.repr_self_apply`). `Matrix.exists_eigenbasis_of_isSemisimple` (alg-closed): a semisimple endomorphism of n → K admits an eigenbasis — Bridge B gives ⨆ eigenspace = ⊤, `Module.End.eigenspaces_iSupIndep` gives independence, `DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top` assembles the internal direct sum, `IsInternal.collectedBasis` collects a sigma-indexed eigenbasis, and `FiniteDimensional.fintypeBasisIndex` + `Basis.indexEquiv` reindex it onto n.",
+      "mathContext": "If $\\{b_i\\}$ is a basis of $K^n$ with $M b_i = c_i b_i$, then $Q^{-1} M Q$ is diagonal for $Q$ the change-of-basis matrix. A semisimple $f$ over alg-closed $K$ satisfies $\\bigoplus_\\mu \\ker(f-\\mu) = K^n$, whose collected per-eigenspace bases form an eigenbasis."
+    },
+    {
+      "id": "main-theorem",
+      "title": "§6: diagonalizable_iff_squarefree_minpoly — Headline (fully proved)",
+      "startLine": 296,
+      "endLine": 320,
+      "summary": "**The headline theorem, now fully proved (0 sorries).** Over `[IsAlgClosed K]` (any characteristic), a matrix M is diagonalizable iff its minimal polynomial is squarefree. Forward: `Matrix.IsDiagonalizable.squarefree_minpoly` (§3, unconditional). Reverse: transport the minpoly to M.toLin' (`Matrix.minpoly_toLin'`), read squarefree as semisimple (Bridge C, §4), extract an eigenbasis (`Matrix.exists_eigenbasis_of_isSemisimple`, §5), and conjugate to a diagonal matrix (`Matrix.isDiagonalizable_of_eigenbasis`, §5). The textbook `[CharZero K]` hypothesis is redundant here and was dropped; the general-field form (with an explicit `Polynomial.Splits` hypothesis) is the target of OQ-02-OQ-03.",
+      "mathContext": "$M \\in \\mathrm{Mat}_n(K)$ over $K$ algebraically closed (any characteristic): $M$ is diagonalizable $\\Leftrightarrow$ $\\mathrm{minpoly}_K(M) \\in K[X]$ is squarefree. Both arms fully proved."
     },
     {
       "id": "sanity-lemmas",
-      "title": "§5: Sanity Lemmas — of_isDiag, zero, one, diagonal",
-      "startLine": 223,
-      "endLine": 245,
+      "title": "§7: Sanity Lemmas — of_isDiag, zero, one, diagonal",
+      "startLine": 321,
+      "endLine": 343,
       "summary": "Four unconditional sanity helpers giving the file a non-trivial public surface: `Matrix.IsDiagonalizable.of_isDiag` (any matrix satisfying `IsDiag` is diagonalizable, witnessed by P = 1), `.zero` (the zero matrix), `.one` (the identity matrix), and `.diagonal` (any explicitly `diagonal d` matrix). Each is discharged from `of_isDiag` plus the corresponding `Matrix.isDiag_*` lemma.",
       "mathContext": "If $\\mathrm{IsDiag}(M)$ then $M$ is diagonalizable (take $P = I$). In particular $0$, $I$, and every $\\mathrm{diagonal}(d) \\in \\mathrm{Mat}_n(K)$ are diagonalizable."
-    },
-    {
-      "id": "bridges-b-c",
-      "title": "§6: S7 ACT Helpers — Endomorphism-Level Bridges B and C",
-      "startLine": 246,
-      "endLine": 279,
-      "summary": "**S7 ACT contribution (#19095, merged 2026-05-15).** Two endomorphism-level lemmas that the matrix-level reverse-direction discharge will transport via `Matrix.minpoly_toLin'`. Bridge B forward — `Module.End.iSup_eigenspace_eq_top_of_isSemisimple`: over an alg-closed field in finite dimensions, semisimplicity implies the eigenspaces span the whole space, proved by a 3-lemma chain via `iSup_congr` (IsSemisimple → IsFinitelySemisimple → maxGenEigenspace μ = eigenspace μ → ⨆ eigenspace = ⨆ maxGenEigenspace = ⊤; the direct-form lemma is a phantom caught by S4 PREP #18626). Bridge C — `Module.End.isSemisimple_iff_squarefree_minpoly`: an endomorphism is semisimple iff its minpoly is squarefree (forward via `IsSemisimple.minpoly_squarefree`; reverse via `isSemisimple_of_squarefree_aeval_eq_zero` applied to `minpoly.aeval`).",
-      "mathContext": "Bridge B: for $V$ finite-dim over alg-closed $K$ and $f \\in \\mathrm{End}_K(V)$, $f$ semisimple $\\Rightarrow \\bigsqcup_{\\mu} \\ker(f - \\mu) = V$. Bridge C: $f$ semisimple $\\Leftrightarrow \\mathrm{minpoly}_K(f)$ squarefree. Together (+ Bridge B back-transport through `Matrix.toLin'`) they target the reverse arm of the headline."
     }
   ],
   "conclusion": {
-    "summary": "S1 OBSERVE → S7 ACT scaffold for the diagonalizable-iff-squarefree-minpoly characterisation. Defines `Matrix.IsDiagonalizable`, states the headline iff (sorry-guarded over [IsAlgClosed K] [CharZero K]), and ships two pre-verified endomorphism-level bridges (B forward and C iff) plus two unconditional sanity helpers. The remaining ~59 LOC discharge is decomposed into four sub-OQs (~450 LOC roadmap), with all 18 required bearer lemmas pin-verified at Mathlib v4.26.0 SHA 2df2f015… by S7c PREP #19257.",
+    "summary": "Complete, fully machine-checked resolution of the diagonalizable-iff-squarefree-minpoly characterisation over algebraically closed fields of arbitrary characteristic (0 sorries, 0 axioms beyond Lean's foundational three; the textbook CharZero hypothesis was verified redundant and dropped). Defines `Matrix.IsDiagonalizable`, proves both arms of the headline iff, and ships the reverse-direction infrastructure: two endomorphism-level bridges (B forward and C iff), a general-field eigenbasis-to-diagonalizable transport lemma (`Matrix.isDiagonalizable_of_eigenbasis`), and the alg-closed eigenbasis construction from semisimplicity (`Matrix.exists_eigenbasis_of_isSemisimple`), plus four unconditional sanity helpers. Pinned at Mathlib v4.26.0.",
     "implications": "Discharging OQ-02 completes the matrix-level diagonalisability characterisation in Lean 4, sibling to OQ-01 (JNF) and OQ-03 (RCF). Together with the parent's 17 minpoly | charpoly theorems, this gives a complete formal toolkit for matrix similarity questions over algebraically closed fields. Practical applications include automated detection of diagonalizability in symbolic computation, formalised spectral analysis, and the operator-theoretic precursor to the spectral theorem on inner-product spaces.",
     "openQuestions": [
-      "**OQ-02-OQ-01** (~100 LOC): Bridge `Module.End.IsSemisimple ↔ Squarefree (minpoly K f)` from endomorphism to matrix level, transporting via `Matrix.toLin'` and `Matrix.minpoly_toLin'`.",
-      "**OQ-02-OQ-02** (~150 LOC): Discharge the headline `diagonalizable_iff_squarefree_minpoly` over `[IsAlgClosed K]` (without CharZero), assembling Bridges A both directions + B both directions + C + D.",
-      "**OQ-02-OQ-03** (~120 LOC): Generalize to arbitrary fields with explicit `Polynomial.Splits (algebraMap K K) (minpoly K M)` hypothesis — the textbook 'splits + squarefree' form.",
-      "**OQ-02-OQ-04** (~80 LOC): In char-0 specialise: minpoly is automatically separable, so squarefree ⇔ has distinct irreducible factors. Yields a streamlined statement for the most common practical case.",
-      "**Bridge B reverse**: ship as a standalone in-tree lemma (the S5b PREP §5 + S7c §3.3 Option A body), so future picks of OQ-02-OQ-02 can skip the ~33 LOC paste."
+      "**OQ-02-OQ-03** (~120 LOC): Generalize to arbitrary fields with an explicit `Polynomial.Splits (algebraMap K K) (minpoly K M)` hypothesis — the textbook 'splits + squarefree' form. This replaces the alg-closed automatic-splitting step with an explicit hypothesis and requires a splits-aware eigenbasis construction.",
+      "**OQ-02-OQ-04** (~80 LOC): In char-0 specialise: minpoly is automatically separable, so squarefree ⇔ distinct irreducible factors. Yields a streamlined statement tying diagonalizability to eigenvalue multiplicities for the most common practical case.",
+      "**Constructive similarity**: expose the diagonalizing matrix P (the change-of-basis matrix (Pi.basisFun).toMatrix b built in `isDiagonalizable_of_eigenbasis`) as an explicit function of an eigenbasis, rather than hidden behind the existential in `Matrix.IsDiagonalizable`."
     ]
   },
   "leanFile": {
@@ -190,15 +198,16 @@
     ],
     "opens": [
       "Matrix",
-      "Polynomial"
+      "Polynomial",
+      "Module"
     ],
     "namespace": "Proofs.MinpolyCharpolyOQ02",
-    "lineCount": 279,
+    "lineCount": 344,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 2,
     "path": "Proofs/MinpolyCharpolyOQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -226,8 +235,8 @@
     {
       "name": "diagonalizable_iff_squarefree_minpoly",
       "type": "core",
-      "statement": "∀ {K : Type*} [Field K] {n : Type*} [Fintype n] [DecidableEq n] [IsAlgClosed K] [CharZero K] (M : Matrix n n K), M.IsDiagonalizable ↔ Squarefree (minpoly K M)",
-      "description": "Headline theorem (S1 statement, sorry-guarded at line 122). Over an algebraically closed field of characteristic zero, a matrix is diagonalizable iff its minimal polynomial is squarefree. The four sub-OQs OQ-02-OQ-01..OQ-02-OQ-04 are designed to discharge the sorry via composition of Bridges A (matrix↔endo), B (semisimple↔eigenspace-decomp), C (semisimple↔squarefree, in-tree), and D (matrix↔endo minpoly transport).",
+      "statement": "∀ {K : Type*} [Field K] {n : Type*} [Fintype n] [DecidableEq n] [IsAlgClosed K] (M : Matrix n n K), M.IsDiagonalizable ↔ Squarefree (minpoly K M)",
+      "description": "Headline theorem, fully proved (0 sorries). Over an algebraically closed field of any characteristic, a matrix is diagonalizable iff its minimal polynomial is squarefree (the textbook CharZero hypothesis is redundant and was dropped). Forward: Matrix.IsDiagonalizable.squarefree_minpoly (any field). Reverse: composition of Bridge D (Matrix.minpoly_toLin'), Bridge C (semisimple↔squarefree), exists_eigenbasis_of_isSemisimple (Bridge B + DirectSum.IsInternal), and isDiagonalizable_of_eigenbasis (change-of-basis conjugation).",
       "significance": "The textbook operator-theoretic characterisation of diagonalisability via minpoly"
     },
     {
@@ -259,7 +268,7 @@
       "significance": "Concrete instance of the diagonalizable predicate"
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "references": [
     {
       "authors": [

--- a/src/data/research/problems/minpoly-charpoly-oq-02.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-02.json
@@ -46,14 +46,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S13 STATE-SYNC (researcher-1, 2026-06-13): content correction. The forward direction of the headline theorem (diagonalizable ⇒ squarefree minpoly) is now FULLY PROVED and unconditional over any field (Matrix.IsDiagonalizable.squarefree_minpoly), shipped via PR #22909 after S12. File MinpolyCharpolyOQ02.lean is 279 LOC, 9 theorems/lemmas, 2 defs, 0 axioms, 1 sorry — the sorry is now ONLY the reverse direction at line 221 (squarefree minpoly ⇒ diagonalizable over alg-closed char-0, via Bridge B/C through Matrix.toLin'). Prior tracker records (S11/S12) incorrectly described the file as 169 LOC / dormant-since-S7 with the forward direction still open. Build not attempted (Docker down 2026-06-13).",
+    "progressSummary": "COMPLETE (researcher-5, 2026-07-01): headline diagonalizable_iff_squarefree_minpoly FULLY PROVED, 0 sorries, 0 axioms (only propext/Classical.choice/Quot.sound). Reverse direction closed via two new in-tree helpers: Matrix.isDiagonalizable_of_eigenbasis (change-of-basis conjugation, any field) and Matrix.exists_eigenbasis_of_isSemisimple (DirectSum.IsInternal collectedBasis + reindex, alg-closed). CharZero hypothesis verified redundant and DROPPED — theorem now holds over any algebraically closed field of arbitrary characteristic. File 344 LOC, 11 thms, 2 defs. Status verified.",
     "builtItems": [
       "Matrix.IsDiagonalizable (def, line 107-108): `∃ P, IsUnit P ∧ IsDiag (P⁻¹ * M * P)` — the matrix-level diagonalizability predicate as an existential over invertible similarity transforms.",
       "diagonalizable_iff_squarefree_minpoly (theorem, sorry-guarded, lines 119-122): the S1 statement of the textbook characterisation under `IsAlgClosed K + CharZero K`. Single sorry at line 122; ~59 LOC paste expected to close it per S7c PREP §5.1.",
       "Matrix.IsDiagonalizable.of_isDiag (theorem, unconditional, lines 126-129): a diagonal matrix is diagonalizable — `P = 1` works. v4.26.0 fix shipped in S7 ACT #19095 (dropped `Matrix.inv_one` from `simpa` lemma list).",
       "Matrix.IsDiagonalizable.zero (theorem, unconditional, lines 132-134): the zero matrix is diagonalizable (via `of_isDiag`).",
       "**Module.End.iSup_eigenspace_eq_top_of_isSemisimple (lemma, file-local, lines 146-155)** — Bridge B forward; over an algebraically closed field in finite dimensions, semisimplicity of an endomorphism implies its eigenspaces span the whole space. Proven by S7 ACT #19095 via the corrected 3-lemma chain (`IsSemisimple.isFinitelySemisimple` → `IsFinitelySemisimple.maxGenEigenspace_eq_eigenspace` → `iSup_maxGenEigenspace_eq_top`) composed via `iSup_congr` (replaced the original `congr 1` + `ext μ` calc form which produced unexpected goal at v4.26.0).",
-      "**Module.End.isSemisimple_iff_squarefree_minpoly (theorem, file-local, lines 162-167)** — Bridge C iff; over a finite-dimensional space, an endomorphism is semisimple iff its minimal polynomial is squarefree. Proven by S7 ACT #19095 as a direct iff combining `Module.End.IsSemisimple.minpoly_squarefree` (→) and `Module.End.isSemisimple_of_squarefree_aeval_eq_zero ∘ minpoly.aeval` (←)."
+      "**Module.End.isSemisimple_iff_squarefree_minpoly (theorem, file-local, lines 162-167)** — Bridge C iff; over a finite-dimensional space, an endomorphism is semisimple iff its minimal polynomial is squarefree. Proven by S7 ACT #19095 as a direct iff combining `Module.End.IsSemisimple.minpoly_squarefree` (→) and `Module.End.isSemisimple_of_squarefree_aeval_eq_zero ∘ minpoly.aeval` (←).",
+      "Matrix.isDiagonalizable_of_eigenbasis (MinpolyCharpolyOQ02.lean:246): eigenbasis of M.toLin' implies M.IsDiagonalizable, via P = (Pi.basisFun).toMatrix b and basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix; diagonality from Basis.repr_self_apply",
+      "Matrix.exists_eigenbasis_of_isSemisimple (MinpolyCharpolyOQ02.lean:277): semisimple endomorphism of n->K implies eigenbasis, via DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top + IsInternal.collectedBasis + FiniteDimensional.fintypeBasisIndex + Basis.indexEquiv reindex onto n",
+      "diagonalizable_iff_squarefree_minpoly (MinpolyCharpolyOQ02.lean:310): headline FULLY PROVED over [IsAlgClosed K] alone (CharZero dropped)"
     ],
     "insights": [
       "**Three-ingredient resolution** — `Module.End.isSemisimple_iff_squarefree_minpoly` + `Matrix.minpoly_toLin'` + alg-closed `splits` boundary. All three are in Mathlib `v4.26.0`; the remaining work is purely integrative. **No Mathlib gap.**",
@@ -64,14 +67,19 @@
       "**Doc-only-PREP backlog can mask Lean regressions** — S7 ACT #19095 surfaced 5 v4.26.0 elaboration errors silently introduced by Mathlib pin shifts during the 6 doc-only PREPs + 1 STATE-SYNC between S1 (2026-05-12) and S7 (2026-05-15). Lesson: any ACT picker following a doc-only-PREP backlog should run a baseline Docker build before pasting new code, not after.",
       "**`ring`-bridge between `Finset.erase` and `Finset.sdiff`-singleton fails silently** — S7c PREP #19257 §3 surfaced the latent issue in S5b §5: `ring` treats `∏ x ∈ S.erase μ, …` and `∏ x ∈ S \\ {μ}, …` as opaque distinct terms even though they're propositionally equal via `Finset.erase_eq`. The 1-line fix (S7c §3.3 Option A) is to define `let q := (S \\ {μ}).prod …` directly. Picker-blocker debugging cost without this catch: 5-10 min.",
       "S11: Docker daemon and host disk recovered without intervention over the 17-day idle window. The S9/S10 B1 blocker was real but transient (likely a Docker Desktop restart by the user resolved the daemon hang; the disk reclaim source is unclear but the working set rose from 4.5 Gi to 25 Gi).",
-      "S11: marginal disk pressure (25 Gi vs 30 Gi threshold) means the S8 ACT picker should treat the build as resource-bounded — pre-verify free disk immediately before docker-build.sh, prefer warm-cache mode if available, and have a contingency for mid-build OOM. The first attempt may need to be at a quiet system moment (no parallel Mathlib clones from other agents)."
+      "S11: marginal disk pressure (25 Gi vs 30 Gi threshold) means the S8 ACT picker should treat the build as resource-bounded — pre-verify free disk immediately before docker-build.sh, prefer warm-cache mode if available, and have a contingency for mid-build OOM. The first attempt may need to be at a quiet system moment (no parallel Mathlib clones from other agents).",
+      "CharZero is redundant over IsAlgClosed: Bridge C reverse (isSemisimple_of_squarefree_aeval_eq_zero) needs only squarefreeness (semisimplicity = sum of simple K[X]-modules, char-independent); algebraic closure supplies the linear factors / eigenbasis. Verified by test-compile with CharZero removed.",
+      "Eigenbasis-from-semisimple reindex recipe: collectedBasis over index K gives sigma-indexed basis; FiniteDimensional.fintypeBasisIndex makes it a Fintype for free, Basis.indexEquiv reindexes onto the target Fintype n — avoids manual Fintype-on-sigma proof.",
+      "rw [<- hM] rewrites ALL occurrences (clobbered RHS toLin' M); use conv_lhs => rw [<- hM] to scope to LHS.",
+      "M.toLin'.IsSemisimple resolves to nonexistent LinearMap.IsSemisimple (dot-notation head is arrow not Module.End); call Module.End.IsSemisimple f as a function with type ascription instead."
     ],
     "mathlibGaps": [
       "(None for the headline theorem.) The four sub-OQs are integrative, not gap-filling."
     ],
     "nextSteps": [
-      "S8 ACT (next session, any researcher): execute the ~59 LOC synthesis at MinpolyCharpolyOQ02.lean:122 per S7c PREP §5.1 punch list. Pre-flight (~30s): df -h / ≥25 Gi, docker info Server responsive, proofs/lake-manifest.json Mathlib rev = 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67. Apply §3.3 Option A. docker-build.sh. Expected: 228 LOC, 0 sorries, 0 axioms.",
-      "Post-S8 ACT: update gallery JSON (lineCount, theoremCount, sorryCount → 0, status verified), refresh state.md S12 STATE-SYNC."
+      "OQ-02-OQ-03 (~120 LOC): general-field form with explicit Polynomial.Splits hypothesis in place of algebraic closure.",
+      "OQ-02-OQ-04: char-0 specialisation tying squarefree to distinct eigenvalue multiplicities.",
+      "Optionally update parent minpoly-charpoly conclusion.openQuestions[1] to mark OQ-02 resolved."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Closes the last `sorry` in `MinpolyCharpolyOQ02.lean` — the **reverse direction** of the headline theorem `diagonalizable_iff_squarefree_minpoly` (squarefree minpoly ⇒ diagonalizable). The gallery entry is now **fully machine-checked**: 0 sorries, 0 axioms (only `propext`/`Classical.choice`/`Quot.sound`, verified via `#print axioms`).

Over an algebraically closed field, `M` is diagonalizable ⇔ `minpoly K M` is squarefree.

## What was added

Two new in-tree helper theorems (both build on the pre-existing Bridges B and C):

- **`Matrix.isDiagonalizable_of_eigenbasis`** (any field): a basis `b` of `n → K` consisting of eigenvectors of `M.toLin'` yields a diagonalizing similarity. The change-of-basis matrix `(Pi.basisFun).toMatrix b` conjugates `M` to `LinearMap.toMatrix b b M.toLin'` (via `basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix`), which is diagonal because every basis vector is an eigenvector (`Basis.repr_self_apply`).
- **`Matrix.exists_eigenbasis_of_isSemisimple`** (alg-closed): a semisimple endomorphism of `n → K` admits an eigenbasis. Bridge B gives `⨆ eigenspace = ⊤`; with `eigenspaces_iSupIndep` this becomes a `DirectSum.IsInternal`; `collectedBasis` yields a sigma-indexed eigenbasis, reindexed onto `n` via `FiniteDimensional.fintypeBasisIndex` + `Basis.indexEquiv`.

The headline chains: `Matrix.minpoly_toLin'` → Bridge C (`isSemisimple_iff_squarefree_minpoly`) → `exists_eigenbasis_of_isSemisimple` → `isDiagonalizable_of_eigenbasis`.

## Strengthening

The textbook `[CharZero K]` hypothesis is **verified redundant and dropped** — the theorem now holds over **any** algebraically closed field of arbitrary characteristic. Semisimplicity follows from squarefreeness alone (char-independent: the module is a sum of simple `K[X]`-factors), and algebraic closure supplies the eigenbasis; separability never enters. Confirmed by test-compiling with the hypothesis removed.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ02` equivalent (`lake env lean`) — builds clean, no errors/warnings.
- `#print axioms diagonalizable_iff_squarefree_minpoly` → `[propext, Classical.choice, Quot.sound]` only.

## Gallery

Updated `meta.json` (status `verified`, badge `verified`, sorries 0, 344 LOC, 11 thms, 2 defs), `annotations.json` (headline re-annotated as proved + two new reverse-direction annotations), and research knowledge JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)