### PR TITLE
Enrich Two-Sided p-Series Tail Sandwich: add index.ts + sections

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const antitoneIntegralSumComparisonOq01Oq01Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const antitoneIntegralSumComparisonOq01Oq01Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const antitoneIntegralSumComparisonOq01Oq01Oq02Oq01Data: ProofData = {
+  proof: antitoneIntegralSumComparisonOq01Oq01Oq02Oq01Proof,
+  annotations: antitoneIntegralSumComparisonOq01Oq01Oq02Oq01Annotations,
+}

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -56,6 +56,56 @@
       "Partial sums bounded by the tsum (Summable.sum_le_tsum) and the shifted p-series summability criterion (summable_nat_add_iff, Real.summable_one_div_nat_rpow)"
     ]
   },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: The Left-Riemann Lower-Bound Strategy",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Imports the parent entry (which supplies the matching upper bound) and states the goal: derive the p-series tail LOWER bound from the left Riemann sum and assemble the two-sided sandwich (N+1)^{1−p}/(p−1) ≤ ∑_{n>N} 1/nᵖ ≤ N^{1−p}/(p−1).",
+      "mathContext": "$\\sum_{n>N}\\tfrac1{n^p} \\ge \\int_{N+1}^{\\infty} x^{-p}\\,dx = \\tfrac{(N+1)^{1-p}}{p-1}$ — the left-endpoint half of the integral test."
+    },
+    {
+      "id": "partial-lower-bound",
+      "title": "Tail Partial-Sum Lower Bound (Left Riemann Sum)",
+      "startLine": 45,
+      "endLine": 97,
+      "summary": "pseries_tail_partial_ge: every finite tail ∑_{i<m} 1/(N+1+i)ᵖ dominates ∫_{N+1}^{N+1+m} x^{−p} dx = ((N+1)^{1−p} − (N+1+m)^{1−p})/(p−1), via AntitoneOn.integral_le_sum with the integral evaluated by integral_rpow.",
+      "mathContext": "$\\tfrac{(N+1)^{1-p} - (N+1+m)^{1-p}}{p-1} \\le \\sum_{i<m}\\tfrac1{(N+1+i)^p}.$"
+    },
+    {
+      "id": "tsum-floor",
+      "title": "The Tail Floor in the Limit",
+      "startLine": 98,
+      "endLine": 134,
+      "summary": "pseries_tail_tsum_ge: passing the uniform partial-sum bound to the limit with le_of_tendsto' gives (N+1)^{1−p}/(p−1) ≤ ∑'_i 1/(N+1+i)ᵖ; the subtracted endpoint term (N+1+m)^{1−p} → 0 by tendsto_rpow_neg_atTop, and each partial sum ≤ tsum by Summable.sum_le_tsum.",
+      "mathContext": "$\\tfrac{(N+1)^{1-p}}{p-1} \\le \\sum'_{i}\\tfrac1{(N+1+i)^p}$ since $(N+1+m)^{1-p}\\to 0$ for $p>1$."
+    },
+    {
+      "id": "explicit-form",
+      "title": "Explicit Lower Bound, Textbook Form",
+      "startLine": 135,
+      "endLine": 150,
+      "summary": "pseries_tail_ge_explicit rewrites the floor as 1/((p−1)·(N+1)^{p−1}) via Real.rpow_neg and field_simp, exhibiting the matching O(N^{1−p}) order from below.",
+      "mathContext": "$\\tfrac{(N+1)^{1-p}}{p-1} = \\tfrac1{(p-1)\\,(N+1)^{p-1}}.$"
+    },
+    {
+      "id": "sandwich",
+      "title": "The Two-Sided Remainder Sandwich",
+      "startLine": 151,
+      "endLine": 166,
+      "summary": "pseries_tail_sandwich pairs the new lower bound with the parent's pseries_tail_tsum_le upper bound, pinning the remainder between two consecutive values of the same primitive x ↦ x^{1−p}/(p−1) — leading order exactly N^{1−p}.",
+      "mathContext": "$\\tfrac{(N+1)^{1-p}}{p-1} \\le \\sum_{n>N}\\tfrac1{n^p} \\le \\tfrac{N^{1-p}}{p-1}.$"
+    },
+    {
+      "id": "witnesses",
+      "title": "Worked Witnesses (Basel Exponent)",
+      "startLine": 167,
+      "endLine": 194,
+      "summary": "Two example specializations at p = 2: the Basel-exponent sandwich 1/(N+1) ≤ ∑_{n>N} 1/n² ≤ 1/N for all N ≥ 1, and the concrete floor 1/11 ≤ ∑_{n>10} 1/n².",
+      "mathContext": "$\\tfrac1{N+1} \\le \\sum_{n>N}\\tfrac1{n^2} \\le \\tfrac1N; \\qquad \\tfrac1{11} \\le \\sum_{n>10}\\tfrac1{n^2}.$"
+    }
+  ],
   "conclusion": {
     "summary": "The p-series tail is sandwiched: for p > 1 and N ≥ 1, (N+1)^{1−p}/(p−1) ≤ ∑_{n>N} 1/nᵖ ≤ N^{1−p}/(p−1). The lower bound is the antitone integral test in left-Riemann form (∫_{N+1}^∞) passed to the limit; the upper bound is the parent's right-Riemann estimate (∫_N^∞). The Basel exponent gives 1/(N+1) ≤ ∑_{n>N} 1/n² ≤ 1/N. 4 theorems, 2 witnesses, 0 definitions, 194 lines, 0 sorries, 0 axioms.",
     "implications": "Upgrades the parent's one-sided remainder bound to a two-sided estimate, certifying that N^{1−p}/(p−1) is the exact leading order of the truncation error of ζ(p), not just an upper bound. The base-shift technique (run the left-Riemann comparison from x = N+1) produces matching lower bounds for any antitone summand whose integral can be evaluated.",


### PR DESCRIPTION
Enrichment pass for `antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01` (two-sided sandwich for the p-series tail).

## Changes
- **Added missing `index.ts`** — the entry had no Vite entry point, so the page would render *proof not found* on the live site despite appearing in the gallery listing.
- **Populated the empty `sections` array** — the entry had `sections: []`. Added 6 sections covering all 194 lines of the Lean file (setup / left-Riemann partial lower bound / tsum floor in the limit / explicit textbook form / two-sided sandwich / Basel-exponent witnesses), each with a summary and LaTeX `mathContext` matched to the theorem line ranges.

## Verification
- meta.json and annotations.json parse as valid JSON; sections cover 1–194 contiguously.
- `index.ts` follows the canonical gallery template.
- No content deleted; entry stays ~14 KB, well under the 60 KB cap. Overview (6 keyInsights) and annotations (all valid significance) already met targets.