### PR TITLE
Enrich Monotone Integral Test (Stirling + p-series): add index.ts + sections

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01/index.ts
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const antitoneIntegralSumComparisonOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const antitoneIntegralSumComparisonOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const antitoneIntegralSumComparisonOq01Oq01Data: ProofData = {
+  proof: antitoneIntegralSumComparisonOq01Oq01Proof,
+  annotations: antitoneIntegralSumComparisonOq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `antitone-integral-sum-comparison-oq-01-oq-01` (monotone integral test: Stirling bounds for log n! and the p-series criterion).

## Changes
- **Added missing `index.ts`** — the entry had no Vite entry point, so the page would render *proof not found* on the live site despite appearing in the gallery listing.
- **Populated the empty `sections` array** — added 5 sections aligned to the file's own Part I–IV structure (setup / monotone integral-test sandwich / Stirling-type bounds for log n! / p-series convergence test / worked witnesses), covering all 203 lines, each with a summary and LaTeX `mathContext`.

## Verification
- meta.json and annotations.json parse as valid JSON; sections cover 1–203 contiguously.
- `index.ts` follows the canonical gallery template.
- No content deleted; entry stays ~12 KB, well under the 60 KB cap. Overview (5 keyInsights) and 6 annotations (all valid significance) already met targets.