### PR TITLE
research(fibonacci-identities-oq-06-oq-01): Fibonacci binomial transform ∑ C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ06OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ06OQ01.lean
@@ -1,0 +1,109 @@
+import Mathlib
+
+/-!
+# The Fibonacci binomial transform — `∑ C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ`
+
+The parent entry `FibonacciIdentitiesOQ06` records the two elementary *linear*
+Fibonacci summation identities: the partial sum `∑ Fᵢ = Fₙ₊₂ − 1` and the
+index-weighted first moment `∑ i·Fᵢ`. Every summand there depends on the running
+index only through a *fixed* Fibonacci value or a polynomial coefficient. This
+open-question descendant supplies the qualitatively different **binomial
+transform**, in which the summation weights are the binomial coefficients
+`C(n,k)` — a nonlinear, self-referential weighting that folds the sequence back
+onto itself at a *doubled* index:
+
+* `fib_binom_transform` — for all `n, m`,
+  `∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ`.
+  The binomial-weighted sum of a length-`(n+1)` Fibonacci window starting at `m`
+  collapses to a single Fibonacci number whose index is `2n + m`. The `m`
+  parameter is essential: it is what makes the induction close (the step needs
+  the identity at both `m` and `m+1`).
+
+* `fib_binom_transform_zero` — the headline case `m = 0`:
+  `∑_{k≤n} C(n,k)·Fₖ = F₂ₙ`.
+  The binomial transform of the Fibonacci sequence is the Fibonacci sequence
+  read at even indices. This is the discrete shadow of the golden-ratio identity
+  `1 + φ = φ²`: applying `∑ C(n,k)(·)ᵏ` to `φ` sends `φ ↦ (1+φ)ⁿ = φ²ⁿ`.
+
+The engine is a general **Pascal convolution** for any `ℕ`-valued summand,
+`pascal_conv`, proved from Pascal's rule `C(n+1,k+1) = C(n,k) + C(n,k+1)` and the
+two range-peeling lemmas (`Finset.sum_range_succ'`, `Finset.sum_range_succ`)
+together with the vanishing `C(n,n+1) = 0`. It splits a length-`(n+2)` binomial
+sum for `n+1` into the two length-`(n+1)` binomial sums for `n` at consecutive
+offsets — exactly the shape the Fibonacci recurrence `Fₐ + Fₐ₊₁ = Fₐ₊₂` then
+contracts.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace FibonacciIdentitiesOQ06OQ01
+
+open Finset
+
+/-- **Pascal convolution.** For any summand `f : ℕ → ℕ`, the binomial-weighted
+sum with `C(n+1, ·)` over a length-`(n+2)` window equals the sum of the two
+`C(n, ·)`-weighted length-`(n+1)` windows at offsets `0` and `1`:
+`∑_{k<n+2} C(n+1,k)·f(k) = ∑_{k<n+1} C(n,k)·f(k) + ∑_{k<n+1} C(n,k)·f(k+1)`.
+
+This is Pascal's rule `C(n+1,k+1) = C(n,k) + C(n,k+1)` summed against `f`, with
+the boundary terms (`C(n+1,0) = C(n,0) = 1` and `C(n,n+1) = 0`) reconciled by the
+first-term / last-term range peels. -/
+theorem pascal_conv (f : ℕ → ℕ) (n : ℕ) :
+    ∑ k ∈ range (n + 2), (n + 1).choose k * f k
+      = (∑ k ∈ range (n + 1), n.choose k * f k)
+        + ∑ k ∈ range (n + 1), n.choose k * f (k + 1) := by
+  -- Peel the `k = 0` term off the left sum and reindex the rest by `k ↦ k+1`.
+  rw [Finset.sum_range_succ' (fun k => (n + 1).choose k * f k) (n + 1)]
+  -- Pascal's rule on each reindexed coefficient, then distribute the product.
+  simp only [Nat.choose_succ_succ' n, Nat.choose_zero_right, one_mul, add_mul]
+  rw [Finset.sum_add_distrib]
+  -- Right-hand side: peel the `k = 0` term off `∑ C(n,k)·f(k)` in the same way.
+  rw [Finset.sum_range_succ' (fun k => n.choose k * f k) n, Nat.choose_zero_right, one_mul]
+  -- The `C(n, k+1)·f(k+1)` sum over `range (n+1)` has a vanishing top term
+  -- `C(n, n+1) = 0`, so it agrees with the same sum over `range n`.
+  rw [Finset.sum_range_succ (fun k => n.choose (k + 1) * f (k + 1)) n,
+      Nat.choose_succ_self n, zero_mul, add_zero]
+  ring
+
+/-- **The Fibonacci binomial transform.** For all `n, m`,
+`∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ`: the binomial-weighted sum of the length-`(n+1)`
+Fibonacci window `Fₘ, Fₘ₊₁, …, Fₘ₊ₙ` collapses to the single Fibonacci number at
+the doubled-and-shifted index `2n + m`.
+
+Proved by induction on `n` with `m` universally quantified. The step rewrites the
+`C(n+1, ·)` sum via `pascal_conv` into the two `C(n, ·)` sums at offsets `m` and
+`m+1`, applies the induction hypothesis to each (yielding `F₂ₙ₊ₘ + F₂ₙ₊ₘ₊₁`), and
+contracts with the recurrence `Nat.fib_add_two`. -/
+theorem fib_binom_transform (n m : ℕ) :
+    ∑ k ∈ range (n + 1), n.choose k * Nat.fib (m + k) = Nat.fib (2 * n + m) := by
+  induction n generalizing m with
+  | zero => simp
+  | succ p ih =>
+    -- LHS is the `C(p+1, ·)` binomial sum over `range (p+2)`.
+    have hconv := pascal_conv (fun k => Nat.fib (m + k)) p
+    -- Reindex the offset-1 sum: `Fₘ₊₍ₖ₊₁₎ = F₍ₘ₊₁₎₊ₖ`.
+    have hshift : (∑ k ∈ range (p + 1), p.choose k * Nat.fib (m + (k + 1)))
+        = ∑ k ∈ range (p + 1), p.choose k * Nat.fib ((m + 1) + k) := by
+      apply Finset.sum_congr rfl
+      intro k _
+      congr 2
+      omega
+    calc
+      ∑ k ∈ range (p + 1 + 1), (p + 1).choose k * Nat.fib (m + k)
+          = (∑ k ∈ range (p + 1), p.choose k * Nat.fib (m + k))
+            + ∑ k ∈ range (p + 1), p.choose k * Nat.fib (m + (k + 1)) := hconv
+      _ = Nat.fib (2 * p + m) + Nat.fib (2 * p + (m + 1)) := by
+            rw [hshift, ih m, ih (m + 1)]
+      _ = Nat.fib (2 * (p + 1) + m) := by
+            have e : 2 * p + (m + 1) = (2 * p + m) + 1 := by omega
+            have e2 : 2 * (p + 1) + m = (2 * p + m) + 2 := by omega
+            rw [e, e2, Nat.fib_add_two]
+
+/-- **The binomial transform of the Fibonacci sequence is the even-indexed
+Fibonacci sequence.** The `m = 0` headline case: `∑_{k≤n} C(n,k)·Fₖ = F₂ₙ`. -/
+theorem fib_binom_transform_zero (n : ℕ) :
+    ∑ k ∈ range (n + 1), n.choose k * Nat.fib k = Nat.fib (2 * n) := by
+  have h := fib_binom_transform n 0
+  simpa using h
+
+end FibonacciIdentitiesOQ06OQ01

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01/annotations.json
@@ -1,0 +1,120 @@
+[
+  {
+    "id": "ann-fiboq06oq01-1",
+    "proofId": "fibonacci-identities-oq-06-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "From Polynomial Weights to Binomial Weights",
+    "content": "**Module framing.** The parent entry `fibonacci-identities-oq-06` proves the *linear* Fibonacci sums, where the summand $i\\,F_i$ carries the index only as a polynomial coefficient. This descendant makes the qualitative jump to *binomial* weights $\\binom{n}{k}$, where the sum folds the sequence back onto itself at a **doubled** index: $\\sum_{k=0}^{n}\\binom{n}{k}F_{m+k} = F_{2n+m}$, and at $m=0$, $\\sum_{k=0}^{n}\\binom{n}{k}F_k = F_{2n}$. The parent's identities *shift* the index (to $n+2$); binomial weights *double* it.",
+    "mathContext": "$\\sum_{k=0}^{n}\\binom{n}{k}F_{m+k} = F_{2n+m}$; the binomial transform of $(F_k)$ is the even-indexed subsequence $(F_{2n})$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Binomial transform of a sequence",
+      "Index-doubling identities",
+      "Golden-ratio identity 1 + φ = φ²",
+      "Parent linear Fibonacci sums (oq-06)"
+    ],
+    "prerequisites": [
+      "The 0-indexed Fibonacci sequence Nat.fib",
+      "Binomial coefficients Nat.choose"
+    ],
+    "tags": [
+      "module-header",
+      "framing",
+      "binomial-transform",
+      "fibonacci"
+    ]
+  },
+  {
+    "id": "ann-fiboq06oq01-2",
+    "proofId": "fibonacci-identities-oq-06-oq-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 75
+    },
+    "type": "technique",
+    "title": "Pascal Convolution: Splitting a Binomial Sum",
+    "content": "**The reusable engine.** `pascal_conv` proves, for *any* summand $f:\\mathbb{N}\\to\\mathbb{N}$, that\n$$\\sum_{k=0}^{n+1}\\binom{n+1}{k}f(k) \\;=\\; \\sum_{k=0}^{n}\\binom{n}{k}f(k) \\;+\\; \\sum_{k=0}^{n}\\binom{n}{k}f(k+1).$$\nThe proof peels the $k=0$ term with `Finset.sum_range_succ'` (which reindexes the tail by $k\\mapsto k+1$), applies Pascal's rule `Nat.choose_succ_succ'` $\\binom{n+1}{k+1}=\\binom{n}{k}+\\binom{n}{k+1}$ to each coefficient, distributes with `add_mul`, and splits via `Finset.sum_add_distrib`. The offset-1 sub-sum lands exactly on the target's second summand; the leftover $\\binom{n}{k+1}$-weighted sum plus the peeled boundary term is reconciled with the first summand by peeling *its* $k=0$ term and dropping the vanishing top term $\\binom{n}{n+1}=0$ (`Nat.choose_succ_self`). This is the binomial-weighted analogue of `Finset.sum_range_succ`, and is Fibonacci-free — it splits the binomial transform of any sequence.",
+    "mathContext": "$\\sum_{k=0}^{n+1}\\binom{n+1}{k}f(k) = \\sum_{k=0}^{n}\\binom{n}{k}f(k) + \\sum_{k=0}^{n}\\binom{n}{k}f(k+1)$, from Pascal's rule and the two range peels.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Pascal's rule / Pascal's triangle",
+      "Binomial transform",
+      "Finset.sum_range_succ' (first-term peel + reindex)",
+      "Vanishing coefficient C(n,n+1)=0"
+    ],
+    "prerequisites": [
+      "Pascal's rule Nat.choose_succ_succ'",
+      "Range-peeling of finite sums",
+      "Finset.sum_add_distrib"
+    ],
+    "tags": [
+      "pascal-rule",
+      "binomial-transform",
+      "finset-sum",
+      "reusable-lemma"
+    ]
+  },
+  {
+    "id": "ann-fiboq06oq01-3",
+    "proofId": "fibonacci-identities-oq-06-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 102
+    },
+    "type": "theorem",
+    "title": "The Transform: Index-Doubling via Recurrence",
+    "content": "**Main induction.** `fib_binom_transform` proves $\\sum_{k=0}^{n}\\binom{n}{k}F_{m+k}=F_{2n+m}$ by induction on $n$ with $m$ **universally quantified**. In the step, instantiate `pascal_conv` at $f=(k\\mapsto F_{m+k})$ to split the $\\binom{p+1}{\\cdot}$ sum into the two $\\binom{p}{\\cdot}$ sums at offsets $m$ and $m+1$ (reindexing $F_{m+(k+1)}=F_{(m+1)+k}$ with `Finset.sum_congr` and `omega`). The induction hypothesis, applied at both $m$ and $m+1$, yields $F_{2p+m}+F_{2p+m+1}$, which the Fibonacci recurrence `Nat.fib_add_two` contracts to $F_{2p+m+2}=F_{2(p+1)+m}$. **Each inductive step advances the target index by 2** — this is exactly why $n$ steps land on $F_{2n+m}$.",
+    "mathContext": "Step: $\\sum_{k}\\binom{p+1}{k}F_{m+k} \\overset{\\text{pascal\\_conv}}{=} \\big(\\sum_k\\binom{p}{k}F_{m+k}\\big)+\\big(\\sum_k\\binom{p}{k}F_{(m+1)+k}\\big) \\overset{\\text{IH}}{=} F_{2p+m}+F_{2p+m+1} \\overset{\\text{fib\\_add\\_two}}{=} F_{2(p+1)+m}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Induction with a generalized parameter",
+      "Fibonacci recurrence Nat.fib_add_two",
+      "Index-doubling",
+      "Load-bearing offset m"
+    ],
+    "prerequisites": [
+      "The pascal_conv splitting lemma",
+      "Nat.fib_add_two",
+      "Generalizing the induction over m"
+    ],
+    "tags": [
+      "induction",
+      "index-doubling",
+      "fibonacci-recurrence",
+      "binomial-transform"
+    ]
+  },
+  {
+    "id": "ann-fiboq06oq01-4",
+    "proofId": "fibonacci-identities-oq-06-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 108
+    },
+    "type": "concept",
+    "title": "Headline Corollary: Binomial Transform = Even-Indexed Fibonacci",
+    "content": "**The clean statement.** Specializing `fib_binom_transform` at $m=0$ and simplifying ($F_{0+k}=F_k$, $2n+0=2n$) gives\n$$\\sum_{k=0}^{n}\\binom{n}{k}F_k = F_{2n}.$$\nThe binomial transform of the Fibonacci sequence is the sequence of *even-indexed* Fibonacci numbers. This is the discrete shadow of the golden-ratio identity $1+\\varphi=\\varphi^2$: the binomial theorem gives $\\sum_k\\binom{n}{k}\\varphi^k=(1+\\varphi)^n=\\varphi^{2n}$, which the Binet formula turns into $F_{2n}$. Note the offset $m$ was **load-bearing**: the tidy $m=0$ statement is not directly inductable — the step needs the shifted window at $m+1$, so the stronger offset form had to be proved first.",
+    "mathContext": "$\\sum_{k=0}^{n}\\binom{n}{k}F_k = F_{2n}$, the $m=0$ case; golden-ratio origin $(1+\\varphi)^n=\\varphi^{2n}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Binet formula",
+      "Golden ratio 1 + φ = φ²",
+      "Even-indexed Fibonacci numbers",
+      "Necessity of generalizing the induction"
+    ],
+    "prerequisites": [
+      "The main theorem fib_binom_transform",
+      "Specialization at m = 0"
+    ],
+    "tags": [
+      "corollary",
+      "index-doubling",
+      "golden-ratio",
+      "fibonacci"
+    ]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ06OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ06OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ06OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ06OQ01Data: ProofData = {
+  proof: fibonacciIdentitiesOQ06OQ01Proof,
+  annotations: fibonacciIdentitiesOQ06OQ01Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "fibonacci-identities-oq-06-oq-01",
+  "title": "The Fibonacci Binomial Transform: ∑ C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ",
+  "slug": "fibonacci-identities-oq-06-oq-01",
+  "description": "The parent entry fibonacci-identities-oq-06 records the two elementary *linear* Fibonacci summation identities — the partial sum ∑ Fᵢ = Fₙ₊₂ − 1 and the index-weighted first moment ∑ i·Fᵢ — in which every summand depends on the running index only through a fixed Fibonacci value or a polynomial coefficient. This open-question descendant supplies the qualitatively different *binomial transform*, whose weights are the binomial coefficients C(n,k): fib_binom_transform proves ∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ for all n and m — the binomial-weighted sum of a length-(n+1) Fibonacci window starting at m collapses to a single Fibonacci number at the doubled-and-shifted index 2n+m. The m=0 headline corollary fib_binom_transform_zero reads ∑_{k≤n} C(n,k)·Fₖ = F₂ₙ: the binomial transform of the Fibonacci sequence is the Fibonacci sequence at even indices, the discrete shadow of the golden-ratio identity 1+φ=φ² (since ∑ C(n,k)φᵏ = (1+φ)ⁿ = φ²ⁿ). The engine is a general Pascal convolution (pascal_conv) — proved from Pascal's rule C(n+1,k+1)=C(n,k)+C(n,k+1), the two range-peeling lemmas, and the vanishing C(n,n+1)=0 — which splits a length-(n+2) binomial sum for n+1 into the two length-(n+1) binomial sums for n at consecutive offsets, exactly the shape the recurrence Fₐ+Fₐ₊₁=Fₐ₊₂ contracts. The proofs use 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Fibonacci binomial-transform folklore; golden-ratio identity 1+φ=φ²); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence",
+    "date": "1876",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "summation-identity",
+      "binomial-transform",
+      "binomial-coefficients",
+      "index-doubling",
+      "integer-sequences",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ06OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_succ'",
+        "description": "choose (n+1) (k+1) = choose n k + choose n (k+1) — Pascal's rule (the (n+1)/(k+1)-shifted form); the algebraic heart of the pascal_conv splitting lemma",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_self",
+        "description": "choose n (n+1) = 0 — the coefficient just past the diagonal vanishes; lets the offset-1 reindexed sum over range (n+1) be truncated to range n in pascal_conv",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the defining Fibonacci recurrence; the only Fibonacci-specific fact, contracting fib (2p+m) + fib (2p+m+1) into fib (2p+m+2) = fib (2(p+1)+m) in the induction step",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f (i+1)) + f 0 — peels the FIRST term and reindexes the rest by i ↦ i+1; used twice in pascal_conv to expose the Pascal shift on the coefficient",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f i) + f n — peels the LAST term; used with choose_succ_self to drop the vanishing top term of the offset-1 sum",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "∑ (f i + g i) = (∑ f i) + (∑ g i) — splits the Pascal-distributed summand (C(n,k) + C(n,k+1))·f(k+1) into two binomial sums",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "pascal_conv: ∀ (f : ℕ → ℕ) n, ∑_{k<n+2} C(n+1,k)·f(k) = (∑_{k<n+1} C(n,k)·f(k)) + ∑_{k<n+1} C(n,k)·f(k+1) — a general Pascal-convolution splitting of a binomial-weighted sum into two shifted lower-order binomial sums, absent from Mathlib",
+      "fib_binom_transform: ∀ n m, ∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ — the Fibonacci binomial transform with a free window offset m, index-doubling, absent from Mathlib",
+      "fib_binom_transform_zero: ∀ n, ∑_{k≤n} C(n,k)·Fₖ = F₂ₙ — the headline m=0 case: the binomial transform of the Fibonacci sequence is the even-indexed Fibonacci sequence"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 109,
+    "assumptions": "None. The proofs contain 0 axioms and 0 sorries and use only Mathlib's foundational propext/Classical.choice/Quot.sound (confirmed by #print axioms on all three theorems); no decide on substantive results and no native_decide.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The binomial transform sends a sequence (aₖ) to (∑ₖ C(n,k) aₖ). Applied to the Fibonacci sequence it produces the even-indexed Fibonacci numbers, ∑ C(n,k) Fₖ = F₂ₙ — one of the cleanest classical instances of an index-doubling identity. It is the discrete shadow of the golden-ratio relation 1 + φ = φ²: since Fₖ = (φᵏ − ψᵏ)/√5 and the binomial theorem gives ∑ C(n,k) φᵏ = (1+φ)ⁿ = φ²ⁿ, the transform doubles every index. The parent gallery entry formalized the elementary linear Fibonacci sums (partial sum, first moment); this descendant climbs from polynomial index-weights to the binomial weights C(n,k), where the sum folds the sequence back onto itself at a doubled index.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-06-oq-01)**: Formalize the binomial transform of the Fibonacci sequence — the index-doubling identity ∑_{k≤n} C(n,k)·Fₖ = F₂ₙ — and the offset generalization ∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ, going beyond the parent entry's polynomial-weighted linear sums to genuinely binomial weights.\n\n**Result**: fib_binom_transform (∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ) and its m=0 corollary fib_binom_transform_zero (∑_{k≤n} C(n,k)·Fₖ = F₂ₙ), via a reusable Pascal-convolution lemma pascal_conv.",
+    "text": "Using Mathlib's 0-indexed Nat.fib (F₀ = 0, F₁ = 1) and binomial coefficients Nat.choose: for all n and m, the binomial-weighted window sum ∑_{k=0}^{n} C(n,k)·F₍ₘ₊ₖ₎ equals the single Fibonacci number F₍₂ₙ₊ₘ₎. Specializing to m = 0 gives ∑_{k=0}^{n} C(n,k)·Fₖ = F₂ₙ, so the binomial transform of the Fibonacci sequence is the sequence of even-indexed Fibonacci numbers.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Pascal convolution (`pascal_conv`).** For an arbitrary summand f : ℕ → ℕ, prove ∑_{k<n+2} C(n+1,k)·f(k) = (∑_{k<n+1} C(n,k)·f(k)) + ∑_{k<n+1} C(n,k)·f(k+1). Peel the k=0 term off the left sum with Finset.sum_range_succ' (which also reindexes the tail by k ↦ k+1), apply Pascal's rule Nat.choose_succ_succ' to each reindexed coefficient, distribute the product (add_mul) and split with Finset.sum_add_distrib. The offset-1 sub-sum matches the target's second summand directly; the remaining C(n,k+1)-weighted sum plus the peeled boundary term is reconciled with the target's first summand by peeling k=0 from it (Finset.sum_range_succ') and dropping the vanishing top term C(n,n+1)=0 (Nat.choose_succ_self via Finset.sum_range_succ). A final ring closes the ℕ bookkeeping.\n\n2. **Fibonacci binomial transform (`fib_binom_transform`).** Induct on n with m universally quantified (the offset m is what makes the step close). The base case n=0 is ∑_{k<1} C(0,k)·Fₘ₊ₖ = Fₘ = F₂·₀₊ₘ, closed by simp. In the step, instantiate pascal_conv at f = (k ↦ Fₘ₊ₖ) to rewrite the C(p+1,·) sum as the two C(p,·) sums at offsets m and m+1; reindex Fₘ₊₍ₖ₊₁₎ = F₍ₘ₊₁₎₊ₖ with Finset.sum_congr and omega; apply the induction hypothesis at m and m+1 to obtain F₍₂ₚ₊ₘ₎ + F₍₂ₚ₊ₘ₊₁₎; and contract with Nat.fib_add_two (after omega-normalizing the indices 2p+(m+1) = (2p+m)+1 and 2(p+1)+m = (2p+m)+2) to F₍₂ₚ₊ₘ₊₂₎ = F₍₂₍ₚ₊₁₎₊ₘ₎.\n\n3. **Headline corollary (`fib_binom_transform_zero`).** Instantiate fib_binom_transform at m=0 and simplify Fₘ₊ₖ = Fₖ and 2n+0 = 2n by simpa.",
+    "keyInsights": [
+      "**Index-doubling, not just telescoping.** The parent's linear sums collapse to Fibonacci numbers at a *shifted* index (n+2). The binomial weights instead *double* the index: ∑ C(n,k) Fₖ = F₂ₙ. The mechanism is that Pascal's rule turns one C(n+1,·) sum into two C(n,·) sums at adjacent offsets, and each application of the Fibonacci recurrence advances the target index by 1 — so n steps of induction advance it by 2n.",
+      "**The offset m is load-bearing.** The clean-looking m=0 statement ∑ C(n,k) Fₖ = F₂ₙ does not prove itself by induction: the step needs the identity for the *shifted* window starting at m+1. Generalizing over m (proving the stronger ∑ C(n,k) Fₘ₊ₖ = F₂ₙ₊ₘ) is exactly what supplies both halves F₂ₙ₊ₘ and F₂ₙ₊ₘ₊₁ that the recurrence then fuses.",
+      "**pascal_conv is a reusable, Fibonacci-free splitting lemma.** The combinatorial core — splitting a length-(n+2) binomial sum for n+1 into two length-(n+1) binomial sums for n at consecutive offsets — is proved for an arbitrary ℕ-valued summand, using only Pascal's rule, the two range peels, and C(n,n+1)=0. It is the binomial-transform analogue of Finset.sum_range_succ and applies to the binomial transform of any sequence, not just Fibonacci.",
+      "**Discrete shadow of 1 + φ = φ².** The identity is the ℕ-level image of the golden-ratio computation ∑ C(n,k) φᵏ = (1+φ)ⁿ = φ²ⁿ (and likewise for ψ), which the Binet formula would turn into F₂ₙ. The inductive Pascal/recurrence proof formalizes this without ever leaving ℕ or invoking irrationals."
+    ],
+    "prerequisites": [
+      "The binomial coefficients Nat.choose and Pascal's rule Nat.choose_succ_succ'",
+      "The Fibonacci recurrence Nat.fib_add_two",
+      "Range-peeling of finite sums: Finset.sum_range_succ' (first term) and Finset.sum_range_succ (last term)",
+      "Induction with a universally quantified parameter (generalizing m)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring framing the binomial transform ∑ C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ as the qualitatively different, index-doubling descendant of the parent's polynomial-weighted linear sums, with the golden-ratio motivation 1+φ=φ² and an outline of the Pascal-convolution engine, plus the import and namespace setup (open Finset).",
+      "mathContext": "$\\sum_{k=0}^{n} \\binom{n}{k} F_{m+k} = F_{2n+m}$, and at $m=0$, $\\sum_{k=0}^{n}\\binom{n}{k}F_k = F_{2n}$."
+    },
+    {
+      "id": "pascal_conv",
+      "title": "Pascal Convolution (the Splitting Engine)",
+      "startLine": 43,
+      "endLine": 75,
+      "summary": "pascal_conv: for any f : ℕ → ℕ, ∑_{k<n+2} C(n+1,k)·f(k) = (∑_{k<n+1} C(n,k)·f(k)) + ∑_{k<n+1} C(n,k)·f(k+1). Peels the first term with Finset.sum_range_succ', applies Pascal's rule Nat.choose_succ_succ', distributes and splits via Finset.sum_add_distrib, then reconciles the residual against the first target summand by peeling its first term and dropping the vanishing top term C(n,n+1)=0 (Nat.choose_succ_self); closed by ring.",
+      "mathContext": "$\\sum_{k=0}^{n+1}\\binom{n+1}{k}f(k) = \\sum_{k=0}^{n}\\binom{n}{k}f(k) + \\sum_{k=0}^{n}\\binom{n}{k}f(k+1)$."
+    },
+    {
+      "id": "fib_binom_transform",
+      "title": "The Fibonacci Binomial Transform",
+      "startLine": 77,
+      "endLine": 102,
+      "summary": "fib_binom_transform: ∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ by induction on n with m generalized. The step rewrites the C(p+1,·) sum via pascal_conv into the two C(p,·) sums at offsets m and m+1, reindexes Fₘ₊₍ₖ₊₁₎ = F₍ₘ₊₁₎₊ₖ (Finset.sum_congr + omega), applies the induction hypothesis at both offsets, and contracts F₍₂ₚ₊ₘ₎ + F₍₂ₚ₊ₘ₊₁₎ = F₍₂₍ₚ₊₁₎₊ₘ₎ via Nat.fib_add_two.",
+      "mathContext": "$\\sum_{k=0}^{n}\\binom{n}{k}F_{m+k} = F_{2n+m}$; the window offset $m$ is generalized so the inductive step can invoke the identity at both $m$ and $m+1$."
+    },
+    {
+      "id": "fib_binom_transform_zero",
+      "title": "The Headline Case ∑ C(n,k)·Fₖ = F₂ₙ",
+      "startLine": 104,
+      "endLine": 108,
+      "summary": "fib_binom_transform_zero: the m=0 specialization ∑_{k≤n} C(n,k)·Fₖ = F₂ₙ, obtained from fib_binom_transform n 0 by simplifying Fₘ₊ₖ = Fₖ and 2n+0 = 2n (simpa). States that the binomial transform of the Fibonacci sequence is the even-indexed Fibonacci sequence.",
+      "mathContext": "$\\sum_{k=0}^{n}\\binom{n}{k}F_k = F_{2n}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-06",
+      "relationship": "extends",
+      "description": "The parent entry proves the linear Fibonacci sums ∑ Fᵢ = Fₙ₊₂ − 1 and the first moment ∑ i·Fᵢ, where the summand's index-dependence is polynomial. This entry replaces the polynomial weights with the binomial weights C(n,k), producing the qualitatively different index-doubling transform ∑ C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ — directly answering the parent's open question about summation weights beyond the polynomial ladder."
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "relatedTo",
+      "description": "The base FibonacciIdentities entry catalogues the pointwise/quadratic identities (sum of squares, parity sums). The binomial transform here is a summation identity of a different flavour — its weights are combinatorial rather than sequence-derived — and its index-doubling conclusion F₂ₙ echoes the doubling formulas fib_two_mul / fib_two_mul_add_one that live alongside the base recurrence in Mathlib."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "relatedTo",
+      "description": "The identity is the Fibonacci image of the binomial theorem: ∑ C(n,k)·xᵏ = (1+x)ⁿ specialized at the golden ratio x=φ gives (1+φ)ⁿ = φ²ⁿ (since 1+φ=φ²), which the Binet formula turns into F₂ₙ. The Lean proof formalizes this over ℕ via the Pascal-rule convolution pascal_conv, the combinatorial engine underlying the binomial theorem's own inductive proof."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete proofs (0 sorries, 0 axioms, no native_decide) of the Fibonacci binomial transform ∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ and its headline m=0 corollary ∑_{k≤n} C(n,k)·Fₖ = F₂ₙ, together with the reusable Pascal-convolution splitting lemma pascal_conv that drives them.",
+    "implications": "Adds a genuinely index-doubling summation identity to the Fibonacci gallery, beyond the parent's polynomial-weighted linear sums, and all absent from Mathlib. The proof isolates a general, Fibonacci-free binomial-transform splitting lemma (pascal_conv) — the binomial-weighted analogue of Finset.sum_range_succ — which applies to the binomial transform of any ℕ-valued sequence.",
+    "openQuestions": [
+      "Prove the Lucas binomial transform ∑_{k≤n} C(n,k)·Lₖ = L₂ₙ and, via pascal_conv, the general Horadam/Gibonacci binomial transform, tracking how the doubled-index closed form depends on the recurrence coefficients.",
+      "Establish the falling/alternating binomial transforms ∑ (−1)ᵏ C(n,k) Fₖ and the k-fold iterate ∑ C(n,k) F_{2k}, and relate the latter to F at index scaling by higher powers of 2.",
+      "Give the generating-function / Binet derivation ∑ C(n,k) Fₖ = F₂ₙ from (1+φ)ⁿ = φ²ⁿ, and formalize the golden-ratio step 1+φ=φ² as the algebraic source of index-doubling."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "FibonacciIdentitiesOQ06OQ01",
+    "lineCount": 109,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Binomial transform and index-doubling identities for the Fibonacci and Lucas sequences, including ∑ C(n,k) Fₖ = F₂ₙ"
+    },
+    {
+      "authors": "Graham, Ronald L.; Knuth, Donald E.; Patashnik, Oren",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "note": "Binomial transforms of sequences and Pascal-rule manipulations of binomial-weighted sums"
+    },
+    {
+      "authors": "Vajda, Steven",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section",
+      "year": "1989",
+      "venue": "Ellis Horwood",
+      "note": "Golden-ratio derivations of Fibonacci summation identities, including the binomial transform via (1+φ)ⁿ = φ²ⁿ"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified leaf under **fibonacci-identities-oq-06**. The parent records the elementary *linear* Fibonacci sums (partial sum ∑Fᵢ = Fₙ₊₂−1, first moment ∑i·Fᵢ), where the index enters each summand only polynomially. This entry proves the qualitatively different, **index-doubling binomial transform**.

## Results (all 0-axiom, 0-sorry, no `native_decide`)

- **`pascal_conv`** *(reusable, Fibonacci-free)* — for any `f : ℕ → ℕ`:
  `∑_{k<n+2} C(n+1,k)·f(k) = ∑_{k<n+1} C(n,k)·f(k) + ∑_{k<n+1} C(n,k)·f(k+1)`.
  The binomial-weighted analogue of `Finset.sum_range_succ`, proved from Pascal's rule `Nat.choose_succ_succ'`, the two range peels (`sum_range_succ'`/`sum_range_succ`), and the vanishing `C(n,n+1)=0`.
- **`fib_binom_transform`** — `∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ`. Induction on `n` with the window offset `m` generalized (load-bearing: the step needs the shifted window at `m+1`); `pascal_conv` splits the step and `Nat.fib_add_two` contracts `F₂ₚ₊ₘ + F₂ₚ₊ₘ₊₁` to `F₂₍ₚ₊₁₎₊ₘ`.
- **`fib_binom_transform_zero`** — `∑_{k≤n} C(n,k)·Fₖ = F₂ₙ`: the binomial transform of the Fibonacci sequence is the even-indexed Fibonacci sequence. Discrete shadow of the golden-ratio identity `1+φ=φ²` (since `∑ C(n,k)φᵏ = (1+φ)ⁿ = φ²ⁿ`).

Each inductive step advances the target index by **2** — this is why `n` steps land on `F₂ₙ`. All three identities are absent from Mathlib.

## Verification

- `#print axioms` on all three theorems → `[propext, Classical.choice, Quot.sound]` only (0 axioms, no `Lean.ofReduceBool`/`sorryAx`).
- Compiles clean under Lean 4 / Mathlib 4.26.0 (`lake env lean`; docker builder was down with a containerd I/O error).

## Files

- `proofs/Proofs/FibonacciIdentitiesOQ06OQ01.lean` (3 thm / 0 def / 109 lines)
- `src/data/proofs/fibonacci-identities-oq-06-oq-01/` (meta.json, annotations.json, index.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)