### PR TITLE
research(hurwitz-oq-03-oq-01): Frobenius Step 2 — completing the square + real/imaginary dichotomy [VERIFIED, 0-axiom, +2thm]

### DIFF
--- a/proofs/Proofs/HurwitzOnlyIf.lean
+++ b/proofs/Proofs/HurwitzOnlyIf.lean
@@ -41,7 +41,13 @@ by choosing an orthonormal basis and transporting multiplication through coordin
 ## Key results
 
 - `hurwitz_field_case`: proved (0 sorries) — Gelfand-Mazur for commutative algebras
-- `hurwitz_only_if_ring`: 1 sorry — the non-commutative case (Clifford algebras needed)
+- `minpoly_natDegree_le_two`, `exists_quadratic`: proved (0 sorries) — Frobenius Step 1
+  (every element satisfies a real quadratic)
+- `exists_real_shift_sq_scalar`, `eq_smul_one_of_sq_eq_nonneg_smul`: proved (0 sorries) —
+  Frobenius Step 2 (completing the square; nonnegative square ⟹ real, so the imaginary
+  part squares to a *negative* scalar)
+- `hurwitz_only_if_ring`: 1 sorry — the remaining global structure argument (Step 3:
+  `Im A` is a subspace with a positive-definite bilinear form / Clifford structure)
 -/
 
 namespace HurwitzOnlyIf
@@ -134,6 +140,52 @@ theorem exists_quadratic (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A
     rw [hc2, one_smul] at hexp
     exact ⟨-m.coeff 1, -m.coeff 0, by linear_combination (norm := module) hexp⟩
 
+/-! ### Frobenius Step 2: Completing the Square and the Real/Imaginary Dichotomy
+
+The quadratic relation `a ^ 2 = p • a + q • 1` of Step 1 can be *completed*: shifting `a`
+by the real scalar `p / 2` produces an element whose square is a pure real scalar. This is
+the concrete form of the classical decomposition `A = ℝ ⬝ 1 ⊕ Im A`. The sign of that scalar
+then decides everything: a nonnegative scalar square forces the element back into `ℝ ⬝ 1`
+(using that a division ring has no zero divisors), so the genuinely "imaginary" elements are
+exactly those whose shifted square is a *negative* real scalar. These two lemmas are fully
+verified (0 sorries) and set up the imaginary subspace `Im A`. -/
+
+open Polynomial in
+/-- **Frobenius Step 2a (completing the square).** For every element `a`, subtracting the
+real scalar `p / 2` (half the linear coefficient of its quadratic) yields an element whose
+square is a pure real scalar: `(a - c • 1) ^ 2 = r • 1`. This is the concrete form of the
+`A = ℝ ⬝ 1 ⊕ Im A` splitting — `c • 1` is the real part and `a - c • 1` the imaginary part. -/
+theorem exists_real_shift_sq_scalar (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (a : A) : ∃ c r : ℝ, (a - c • (1 : A)) ^ 2 = r • (1 : A) := by
+  obtain ⟨p, q, hpq⟩ := exists_quadratic A a
+  refine ⟨p / 2, q + (p / 2) ^ 2, ?_⟩
+  have hexp : (a - (p / 2) • (1 : A)) ^ 2
+      = a * a - (2 * (p / 2)) • a + ((p / 2) ^ 2) • (1 : A) := by
+    simp only [sq, mul_sub, sub_mul, mul_smul_comm, smul_mul_assoc, one_mul, mul_one]
+    module
+  rw [hexp, ← pow_two, hpq]
+  module
+
+/-- **Frobenius Step 2b (nonnegative square ⟹ real).** If an element `b` of a normed
+division ring satisfies `b ^ 2 = r • 1` with `r ≥ 0`, then `b` is a real scalar multiple of
+`1`. Indeed `(b - √r • 1)(b + √r • 1) = b ^ 2 - r • 1 = 0`, and a division ring has no zero
+divisors, so one factor vanishes. Consequently the "imaginary part" `a - c • 1` from Step 2a
+is genuinely non-real only when its square scalar `r` is *negative*. -/
+theorem eq_smul_one_of_sq_eq_nonneg_smul (A : Type*) [NormedDivisionRing A]
+    [NormedAlgebra ℝ A] (b : A) (r : ℝ) (hr : 0 ≤ r) (hb : b ^ 2 = r • (1 : A)) :
+    ∃ s : ℝ, b = s • (1 : A) := by
+  set s := Real.sqrt r with hs
+  have hs2 : s ^ 2 = r := Real.sq_sqrt hr
+  have factored : (b - s • (1 : A)) * (b + s • (1 : A)) = 0 := by
+    have hexp : (b - s • (1 : A)) * (b + s • (1 : A)) = b * b - (s ^ 2) • (1 : A) := by
+      simp only [mul_add, sub_mul, mul_smul_comm, smul_mul_assoc, one_mul, mul_one]
+      module
+    rw [hexp, ← pow_two, hb, hs2]
+    module
+  rcases mul_eq_zero.mp factored with h | h
+  · exact ⟨s, by linear_combination (norm := module) h⟩
+  · exact ⟨-s, by linear_combination (norm := module) h⟩
+
 /-! ### The General (Division Ring) Case -/
 
 /-- **Hurwitz Only-If for Normed Division Rings**:
@@ -161,13 +213,19 @@ theorem hurwitz_only_if_ring (A : Type*) [NormedDivisionRing A] [NormedAlgebra �
      STEP 1 (VERIFIED above): every `a : A` satisfies a real quadratic `a² = p•a + q•1`
        via `exists_quadratic` / `minpoly_natDegree_le_two`. Hence each element generates a
        subalgebra isomorphic to `ℝ` or `ℂ`.
-     STEP 2 (remaining): split `A = ℝ•1 ⊕ Im A` where `Im A := {a | a² ∈ ℝ≤0 • 1}` is the
-       set of "pure imaginary" elements (those whose quadratic has `p = 0`, `q ≤ 0`).
-     STEP 3 (remaining): the map `(x, y) ↦ -(x*y + y*x)` is a positive-definite symmetric
-       bilinear form on `Im A`; multiplication makes `Im A` a Clifford-type space, forcing
-       `finrank ℝ (Im A) ∈ {0, 1, 3}` and thus `finrank ℝ A ∈ {1, 2, 4}`.
-     Steps 2–3 (the global structure argument) are not yet formalized; Mathlib lacks the
-     Clifford-algebra / bilinear-form machinery to discharge them directly. -/
+     STEP 2a (VERIFIED above): completing the square, `(a - (p/2)•1)² = r•1` for a real
+       scalar `r` (`exists_real_shift_sq_scalar`). This is the concrete `A = ℝ•1 ⊕ Im A`
+       shift: `(p/2)•1` is the real part, `a - (p/2)•1` the imaginary part.
+     STEP 2b (VERIFIED above): if `b² = r•1` with `r ≥ 0` then `b ∈ ℝ•1`
+       (`eq_smul_one_of_sq_eq_nonneg_smul`, from the absence of zero divisors). So the
+       imaginary part is genuinely non-real exactly when its square scalar `r` is negative,
+       pinning down `Im A := {a | a² ∈ ℝ≤0 • 1}`.
+     STEP 3 (remaining): showing `Im A` is an ℝ-subspace (equivalently, that `x*y + y*x ∈
+       ℝ•1` for imaginary `x, y`) and that `(x, y) ↦ -(x*y + y*x)` is a positive-definite
+       symmetric bilinear form; multiplication then makes `Im A` a Clifford-type space,
+       forcing `finrank ℝ (Im A) ∈ {0, 1, 3}` and thus `finrank ℝ A ∈ {1, 2, 4}`.
+     Step 3 (the global structure/bilinear-form argument) is not yet formalized; Mathlib
+     lacks the Clifford-algebra / bilinear-form machinery to discharge it directly. -/
   sorry
 
 end HurwitzOnlyIf

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
@@ -21,9 +21,9 @@
     "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "1 sorry: hurwitz_only_if_ring (the global structure argument of Frobenius theorem — split A = ℝ⊕Im A, positive-definite bilinear form on Im A). Frobenius Step 1 is now VERIFIED (0 sorries): minpoly_natDegree_le_two and exists_quadratic show every element satisfies a real quadratic, i.e. generates ℝ or ℂ. The commutative subcase (hurwitz_field_case) is axiom-free.",
-    "lineCount": 173,
-    "theoremCount": 5,
+    "assumptions": "1 sorry: hurwitz_only_if_ring (the remaining global structure argument of Frobenius' theorem — Step 3: show Im A is an ℝ-subspace carrying a positive-definite bilinear form / Clifford structure). Frobenius Steps 1 and 2 are now VERIFIED (0 sorries): minpoly_natDegree_le_two and exists_quadratic show every element satisfies a real quadratic (generates ℝ or ℂ); exists_real_shift_sq_scalar completes the square so the imaginary part squares to a real scalar, and eq_smul_one_of_sq_eq_nonneg_smul shows a nonnegative such scalar forces the element into ℝ•1 (via no zero divisors), isolating the genuinely imaginary elements as those with negative square scalar. The commutative subcase (hurwitz_field_case) is axiom-free.",
+    "lineCount": 231,
+    "theoremCount": 7,
     "definitionCount": 1,
     "originalContributions": [
       "admissibleDimensions: Def {1,2,4,8} — the four admissible finranks",
@@ -31,7 +31,9 @@
       "hurwitz_field_case: commutative Hurwitz only-if direction (0 sorries)",
       "minpoly_natDegree_le_two: every element of a finite-dim real division ring has minimal polynomial of degree ≤ 2 (0 sorries) — Frobenius Step 1a",
       "exists_quadratic: explicit quadratic relation a²=p•a+q•1 for every element (0 sorries) — Frobenius Step 1b, the ℝ-or-ℂ generation heart of Frobenius",
-      "hurwitz_only_if_ring: general division ring case (1 sorry: global Frobenius structure argument)"
+      "exists_real_shift_sq_scalar: completing the square, (a-(p/2)•1)²=r•1 (0 sorries) — Frobenius Step 2a, the concrete A=ℝ•1⊕Im A shift",
+      "eq_smul_one_of_sq_eq_nonneg_smul: b²=r•1 with r≥0 ⟹ b∈ℝ•1 via absence of zero divisors (0 sorries) — Frobenius Step 2b, isolating imaginary elements as those with negative square scalar",
+      "hurwitz_only_if_ring: general division ring case (1 sorry: remaining global Frobenius structure argument, Step 3)"
     ]
   },
   "overview": {
@@ -119,19 +121,35 @@
       "mathContext": "Uses NormedAlgebra.Real.nonempty_algEquiv_or (Gelfand-Mazur): F ≅ ℝ or F ≅ ℂ. Then LinearEquiv.finrank_eq + CommSemiring.finrank_self / Complex.finrank_real_complex give finrank = 1 or 2."
     },
     {
+      "id": "frobenius-step1",
+      "title": "Frobenius Step 1: Quadratic Minimal Polynomials",
+      "startLine": 85,
+      "endLine": 140,
+      "summary": "minpoly_natDegree_le_two and exists_quadratic (0 sorries): every element of a finite-dim real normed division ring has minimal polynomial of degree ≤ 2, and hence satisfies an explicit real quadratic a²=p•a+q•1. This is the 'each element generates ℝ or ℂ' heart of Frobenius' theorem.",
+      "mathContext": "minpoly is irreducible over the division-ring domain (element is integral by Module.Finite); irreducible real polynomials have degree ≤ 2 (Irreducible.natDegree_le_two). The quadratic is extracted via aeval_eq_sum_range' over range 3 with interval_cases on the degree."
+    },
+    {
+      "id": "frobenius-step2",
+      "title": "Frobenius Step 2: Completing the Square, Real/Imaginary Dichotomy",
+      "startLine": 141,
+      "endLine": 182,
+      "summary": "exists_real_shift_sq_scalar and eq_smul_one_of_sq_eq_nonneg_smul (0 sorries): completing the square, (a-(p/2)•1)²=r•1 gives the concrete A=ℝ•1⊕Im A shift; and b²=r•1 with r≥0 forces b∈ℝ•1 (via no zero divisors: (b-√r•1)(b+√r•1)=0). Thus the genuinely imaginary elements are exactly those whose shifted square scalar is negative.",
+      "mathContext": "The difference-of-squares factorization uses that a division ring has no zero divisors (DivisionRing ⟹ NoZeroDivisors), so a nonnegative-scalar square pins the element to ±√r•1 ∈ ℝ•1. Ring/module manipulations discharged by simp normalization + the module tactic."
+    },
+    {
       "id": "general-case",
       "title": "General Division Ring Case (1 sorry)",
-      "startLine": 81,
-      "endLine": 113,
-      "summary": "hurwitz_only_if_ring: the non-commutative case with a documented sorry and full proof sketch. Two resolution paths: (1) NSquareIdentity reduction via orthonormal basis transport, (2) direct Clifford algebra + Radon-Hurwitz argument.",
+      "startLine": 183,
+      "endLine": 231,
+      "summary": "hurwitz_only_if_ring: the non-commutative case with a documented sorry and full proof sketch. Steps 1–2 are verified above; the remaining Step 3 is the global structure argument — Im A is a subspace with a positive-definite bilinear form / Clifford structure forcing finrank ∈ {1,2,4}.",
       "mathContext": "The sorry covers NormedDivisionRing A, NormedAlgebra ℝ A, Module.Finite ℝ A. By Frobenius, the associative case only admits dims 1, 2, 4 — the '8' entry is vacuous for NormedDivisionRing."
     }
   ],
   "leanFile": {
     "namespace": "HurwitzOnlyIf",
-    "lineCount": 173,
+    "lineCount": 231,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 1,
     "path": "Proofs/HurwitzOnlyIf.lean",
     "sorries": 1


### PR DESCRIPTION
## Summary

Continues the **Frobenius program** for the associative (`NormedDivisionRing`) case of the Hurwitz Only-If direction (`hurwitz-theorem-oq-03-oq-01`). Builds on the merged Step 1 (PR #32365, quadratic minimal polynomials) with two more verified lemmas — **0 sorries, 0 axioms** each.

## New results (`proofs/Proofs/HurwitzOnlyIf.lean`)

- **`exists_real_shift_sq_scalar`** — *completing the square*. For every `a`, shifting by `p/2` (half the linear coefficient of its Step-1 quadratic) gives `(a - (p/2)•1)² = r•1` for a real scalar `r`. This is the concrete form of the classical splitting `A = ℝ•1 ⊕ Im A`: `(p/2)•1` is the real part, `a - (p/2)•1` the imaginary part.
- **`eq_smul_one_of_sq_eq_nonneg_smul`** — *nonnegative square ⟹ real*. If `b² = r•1` with `r ≥ 0` then `b ∈ ℝ•1`. Proof: `(b - √r•1)(b + √r•1) = b² - r•1 = 0`, and a division ring has no zero divisors, so a factor vanishes. Consequently the imaginary part is genuinely non-real **exactly when its square scalar is negative**, pinning down `Im A = {a | a² ∈ ℝ≤0 • 1}`.

## Verification

Both new theorems `#print axioms` to `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. File type-checks against pinned Mathlib v4.26. The remaining `sorry` (`hurwitz_only_if_ring`) is now narrowed to **Step 3**: showing `Im A` is an ℝ-subspace carrying a positive-definite bilinear form / Clifford structure (needs machinery Mathlib currently lacks).

Docstrings, the in-proof outline, and the gallery `meta.json` (lineCount 173→231, theoremCount 5→7, new contributions + sections) are refreshed to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)