### PR TITLE
Enrich Friendship Theorem (Spectral Proof): add annotations, index.ts, sections

### DIFF
--- a/src/data/proofs/friendship-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/friendship-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "friendship-oq0102-defs",
+    "proofId": "friendship-theorem-oq-01-oq-02",
+    "range": { "startLine": 75, "endLine": 85 },
+    "type": "definition",
+    "title": "Friendship Graph and Politician",
+    "content": "The ported Archive definitions phrase the hypothesis and conclusion in Fintype.card terms. Friendship G says every pair of distinct vertices u ≠ v has exactly one common neighbor (Fintype.card of the common-neighbor set equals 1); ExistsPolitician G says some vertex is adjacent to all others. The theorem asserts Friendship G → ExistsPolitician G for nonempty finite G. Keeping the upstream names lets the port be diffed line-for-line against Mathlib's Archive.",
+    "mathContext": "$\\forall u \\ne v,\\ |N(u)\\cap N(v)| = 1 \\;\\Longrightarrow\\; \\exists c,\\ \\forall v\\ne c,\\ c\\sim v.$",
+    "significance": "supporting",
+    "relatedConcepts": ["friendship graph", "common neighbors", "universal vertex", "windmill graph"],
+    "prerequisites": ["simple graphs", "Fintype.card", "adjacency"]
+  },
+  {
+    "id": "friendship-oq0102-adjsq",
+    "proofId": "friendship-theorem-oq-01-oq-02",
+    "range": { "startLine": 96, "endLine": 148 },
+    "type": "technique",
+    "title": "The Adjacency Matrix Squared Encodes the Friendship Condition",
+    "content": "adjMatrix_sq_of_ne reads the friendship hypothesis matricially: for v ≠ w, (A²)_{vw} counts common neighbors of v and w, which is exactly 1. On the diagonal (A²)_{vv} = deg(v). Combined with regularity, adjMatrix_sq_of_regular gives A² = (d−1)I + J where J is the all-ones matrix — the single algebraic identity from which the whole proof flows. degree_eq_of_not_adj shows any two nonadjacent vertices have equal degree by a length-3 walk count using the symmetry of A.",
+    "mathContext": "$(A^2)_{vw} = |N(v)\\cap N(w)| = 1\\ (v\\ne w), \\quad (A^2)_{vv} = \\deg v; \\qquad A^2 = (d-1)I + J.$",
+    "significance": "key",
+    "relatedConcepts": ["adjacency matrix", "matrix powers", "common-neighbor counting", "regular graph", "all-ones matrix"],
+    "prerequisites": ["adjacency matrices", "matrix multiplication", "walk counting"]
+  },
+  {
+    "id": "friendship-oq0102-regular-count",
+    "proofId": "friendship-theorem-oq-01-oq-02",
+    "range": { "startLine": 163, "endLine": 226 },
+    "type": "insight",
+    "title": "No Politician ⇒ Regular, with d²−d+1 Vertices",
+    "content": "isRegularOf_not_existsPolitician shows a friendship graph with no politician is d-regular for some d: because nonadjacent vertices share a degree and the no-politician assumption forces the graph to be connected in the required way. card_of_regular then counts the vertices exactly: d + (|V| − 1) = d², i.e. |V| = d² − d + 1 (each of the d neighbors of a fixed vertex, plus the vertex, and the friendship structure pins the rest). Reducing A² = (d−1)I + J modulo a prime p ∣ d−1 collapses the identity to A² = J over ZMod p.",
+    "mathContext": "$|V| = d^2 - d + 1; \\qquad A^2 \\equiv J \\pmod{p}\\ \\text{for } p \\mid d-1.$",
+    "significance": "key",
+    "relatedConcepts": ["regular graph", "vertex counting", "ZMod p reduction", "strongly regular graph"],
+    "prerequisites": ["regularity", "double counting", "modular reduction of matrices"]
+  },
+  {
+    "id": "friendship-oq0102-trace",
+    "proofId": "friendship-theorem-oq-01-oq-02",
+    "range": { "startLine": 254, "endLine": 288 },
+    "type": "insight",
+    "title": "The Trace-mod-p Contradiction (d ≥ 3)",
+    "content": "false_of_three_le_degree is the heart of the spectral proof. Pick a prime p ∣ d−1. Since A² = J mod p, all higher powers Aᵏ = J for k ≥ 2 (adjMatrix_pow_mod_p_of_regular), so tr(Aᵖ) = |V| = d²−d+1 ≡ 1 (mod p). But the Frobenius identity over ZMod p, ZMod.trace_pow_card, gives tr(Aᵖ) = (tr A)ᵖ, and tr A = 0 because a simple graph has no self-loops, so (tr A)ᵖ = 0. Thus 1 = 0 in ZMod p — impossible for p ≥ 2. This rules out every degree d ≥ 3.",
+    "mathContext": "$\\operatorname{tr}(A^p) = |V| \\equiv 1, \\qquad \\operatorname{tr}(A^p) = (\\operatorname{tr} A)^p = 0^p = 0 \\;\\Rightarrow\\; 1 = 0 \\text{ in } \\mathbb{Z}/p.$",
+    "significance": "key",
+    "relatedConcepts": ["matrix trace", "Frobenius endomorphism", "finite fields", "ZMod.trace_pow_card", "proof by contradiction"],
+    "prerequisites": ["trace of a matrix", "Frobenius (x↦xᵖ) over ZMod p", "prime factors"]
+  },
+  {
+    "id": "friendship-oq0102-smalldeg",
+    "proofId": "friendship-theorem-oq-01-oq-02",
+    "range": { "startLine": 290, "endLine": 358 },
+    "type": "technique",
+    "title": "Small-Degree Casework and Assembly",
+    "content": "The trace argument needs d ≥ 3, so d ≤ 2 is handled directly. For d ≤ 1 the graph has at most one vertex (existsPolitician_of_degree_le_one), trivially with a politician. For d = 2 the graph has exactly 3 vertices and must be the complete graph K₃, so every vertex is universal (neighborFinset_eq_of_degree_eq_two, existsPolitician_of_degree_eq_two). friendship_theorem then assembles the proof by contradiction: assume no politician ⇒ d-regular; casework d ≤ 2 (politician exists anyway) versus d ≥ 3 (graph cannot exist).",
+    "mathContext": "$d \\le 1: |V| \\le 1; \\quad d = 2: G \\cong K_3; \\quad d \\ge 3: \\text{contradiction}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["case analysis", "complete graph", "interval_cases"],
+    "prerequisites": ["regular graphs of small degree", "complete graph K₃"]
+  },
+  {
+    "id": "friendship-oq0102-bridge",
+    "proofId": "friendship-theorem-oq-01-oq-02",
+    "range": { "startLine": 373, "endLine": 411 },
+    "type": "concept",
+    "title": "Gallery Bridge: ncard ↔ Fintype.card",
+    "content": "The gallery's own predicates count common neighbors with Set.ncard and phrase 'politician' as IsUniversalVertex. isFriendship_iff_friendship reconciles the two countings — Nat.card_coe_set_eq and Nat.card_eq_fintype_card identify (commonNeighbors u v).ncard with the Fintype.card used by the ported proof — establishing IsFriendshipGraph G ↔ Theorems100.Friendship G. friendship_theorem_of_isFriendship then delivers the gallery's headline (∃ universal vertex) with 0 axioms, using the classical spectral route rather than the sibling entry's characteristic-polynomial axiom.",
+    "mathContext": "$\\mathrm{IsFriendshipGraph}\\,G \\iff \\mathrm{Friendship}\\,G, \\qquad (G.\\mathrm{commonNeighbors}\\,u\\,v).\\mathrm{ncard} = \\mathrm{Fintype.card}\\,(\\ldots).$",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.ncard", "Nat.card", "Fintype.card", "predicate bridging", "Mathlib Archive port"],
+    "prerequisites": ["Set.ncard vs Fintype.card", "cardinality reconciliation"]
+  }
+]

--- a/src/data/proofs/friendship-theorem-oq-01-oq-02/index.ts
+++ b/src/data/proofs/friendship-theorem-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FriendshipTheoremOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const friendshipTheoremOq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const friendshipTheoremOq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const friendshipTheoremOq01Oq02Data: ProofData = {
+  proof: friendshipTheoremOq01Oq02Proof,
+  annotations: friendshipTheoremOq01Oq02Annotations,
+}

--- a/src/data/proofs/friendship-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-01-oq-02/meta.json
@@ -68,6 +68,56 @@
       "The Frobenius/trace identity tr(Aᵖ) = (tr A)ᵖ over ZMod p"
     ]
   },
+  "sections": [
+    {
+      "id": "setup-definitions",
+      "title": "Setup and Definitions",
+      "startLine": 1,
+      "endLine": 95,
+      "summary": "Imports Mathlib and opens the ported namespace Theorems100. Defines Friendship G (every pair of distinct vertices has exactly one common neighbor) and ExistsPolitician G (a vertex adjacent to all others), matching the upstream Archive names for line-by-line diffability.",
+      "mathContext": "$\\forall u\\ne v,\\ |N(u)\\cap N(v)| = 1; \\qquad \\exists c,\\ \\forall v\\ne c,\\ c\\sim v.$"
+    },
+    {
+      "id": "adjacency-square",
+      "title": "The Adjacency Matrix Squared",
+      "startLine": 96,
+      "endLine": 162,
+      "summary": "Reads the friendship condition matricially: (A²)_{vw} counts common neighbors (= 1 for v ≠ w), (A²)_{vv} = deg v. degree_eq_of_not_adj proves nonadjacent vertices share a degree via a length-3 walk count; adjMatrix_sq_of_regular yields A² = (d−1)I + J and its mod-p reduction A² = J.",
+      "mathContext": "$A^2 = (d-1)I + J, \\qquad A^2 \\equiv J \\pmod{p\\mid d-1}.$"
+    },
+    {
+      "id": "regularity-and-count",
+      "title": "Regularity and the Vertex Count",
+      "startLine": 163,
+      "endLine": 253,
+      "summary": "isRegularOf_not_existsPolitician: a friendship graph with no politician is d-regular. card_of_regular counts the vertices as |V| = d²−d+1. adjMatrix_pow_mod_p_of_regular pushes A² = J up to Aᵏ = J (k ≥ 2) over ZMod p.",
+      "mathContext": "$|V| = d^2 - d + 1, \\qquad A^k \\equiv J \\pmod p\\ (k\\ge 2).$"
+    },
+    {
+      "id": "trace-contradiction",
+      "title": "The Trace-mod-p Contradiction (d ≥ 3)",
+      "startLine": 254,
+      "endLine": 288,
+      "summary": "false_of_three_le_degree: for a prime p ∣ d−1, tr(Aᵖ) = |V| ≡ 1 (mod p) because Aᵖ = J, while the Frobenius identity ZMod.trace_pow_card gives tr(Aᵖ) = (tr A)ᵖ = 0. Hence 1 = 0 in ZMod p — impossible. This is the spectral heart of the proof.",
+      "mathContext": "$\\operatorname{tr}(A^p) = |V| \\equiv 1 \\ \\text{and}\\ = (\\operatorname{tr}A)^p = 0 \\Rightarrow 1=0.$"
+    },
+    {
+      "id": "small-degree-assembly",
+      "title": "Small-Degree Casework and the Friendship Theorem",
+      "startLine": 289,
+      "endLine": 362,
+      "summary": "Handles d ≤ 2 directly (d ≤ 1 gives ≤ 1 vertex; d = 2 gives the complete graph K₃, all vertices universal), then friendship_theorem assembles the whole proof by contradiction: no politician ⇒ d-regular ⇒ casework d ≤ 2 vs d ≥ 3.",
+      "mathContext": "$d\\le 1:|V|\\le 1;\\quad d=2:G\\cong K_3;\\quad d\\ge 3:\\text{false}.$"
+    },
+    {
+      "id": "gallery-bridge",
+      "title": "Gallery Bridge",
+      "startLine": 364,
+      "endLine": 411,
+      "summary": "Connects the ported Archive statement to the gallery's own Set.ncard-based IsFriendshipGraph and IsUniversalVertex predicates. isFriendship_iff_friendship reconciles ncard with Fintype.card; friendship_theorem_of_isFriendship states the gallery headline (∃ universal vertex), 0 axioms.",
+      "mathContext": "$\\mathrm{IsFriendshipGraph}\\,G \\iff \\mathrm{Friendship}\\,G \\;\\Rightarrow\\; \\exists c,\\ \\mathrm{IsUniversalVertex}\\,G\\,c.$"
+    }
+  ],
   "conclusion": {
     "summary": "A complete, self-contained, 0-axiom Lean 4 formalization of the classical spectral (trace-mod-p) proof of the Friendship Theorem, ported from Mathlib's non-importable Archive and bridged to the gallery's own friendship-graph predicates. It complements the sibling entry friendship-theorem-oq-01, which proves the same result while deliberately avoiding spectral methods.",
     "implications": "The friendship theorem is now available in the gallery via BOTH of its standard proofs — the classical eigenvalue/trace argument (here) and the characteristic-polynomial/UFD argument (friendship-theorem-oq-01). The port also demonstrates a reusable pattern: valuable results stranded in Mathlib's Archive target can be brought into verified gallery code with proper attribution.",


### PR DESCRIPTION
Enrichment pass for `friendship-theorem-oq-01-oq-02` (classical trace-mod-p spectral proof of the Friendship Theorem).

The entry shipped with **only meta.json** — no annotations, no Vite entry point, and an empty sections array. This pass builds all three.

## Changes
- **Created `index.ts`** — without it the page renders *proof not found* on the live site despite listing in the gallery.
- **Created `annotations.json`** (was absent) — 6 substantive annotations tracing the proof: the A² = (d−1)I + J adjacency-square identity, no-politician ⇒ d-regular with |V| = d²−d+1, the mod-p reduction A^k = J, the **trace-mod-p contradiction** (tr(Aᵖ) = |V| ≡ 1 vs. Frobenius (tr A)ᵖ = 0), the small-degree casework, and the ncard↔Fintype.card gallery bridge. Each has `mathContext` (LaTeX), valid `significance`, `relatedConcepts`, and `prerequisites`.
- **Populated the empty `sections` array** — 6 sections covering all 411 lines with summaries and LaTeX `mathContext`.

## Verification
- meta.json and the new annotations.json parse as valid JSON; all annotation `significance` values are in {key, supporting, technical, context}.
- `index.ts` follows the canonical gallery template (raw-import `../../../../proofs/Proofs/FriendshipTheoremOQ01OQ02.lean?raw`).
- Content is drawn faithfully from the Lean source (ported Mathlib Archive proof by Anderson/Stark/Miller); no claims invented. meta.json ~15 KB, under the 60 KB cap.