### PR TITLE
Enrich Integral Test for Antitone Series: add index.ts + sections, fix significance

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/annotations.json
@@ -48,7 +48,7 @@
     "title": "The Integral Test (Summable ↔ BddAbove Integrals)",
     "content": "The main result: for an antitone, nonnegative f on [1,∞), the series ∑ₙ f(n+1) is summable iff the integrals ∫₁^{1+n} f are bounded above. Forward, each integral is ≤ the total sum ∑' f(n+1) via sum_le_hasSum. Reverse, an upper bound B on the integrals yields the uniform partial-sum bound f(1)+B (the n=0 case is pure nonnegativity), and summable_of_sum_range_le concludes. This convergence dichotomy is the reusable engine the parent entry only instantiated for 1/x, and it is absent from Mathlib.",
     "mathContext": "\\text{Summable}\\,(n \\mapsto f(n+1)) \\iff \\text{BddAbove}\\,\\Big\\{\\int_1^{1+n} f : n \\in \\mathbb{N}\\Big\\}",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "integral test",
       "summable",

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/index.ts
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AntitoneIntegralTest.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const antitoneIntegralSumComparisonOq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const antitoneIntegralSumComparisonOq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const antitoneIntegralSumComparisonOq01Oq03Data: ProofData = {
+  proof: antitoneIntegralSumComparisonOq01Oq03Proof,
+  annotations: antitoneIntegralSumComparisonOq01Oq03Annotations,
+}

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/meta.json
@@ -53,6 +53,40 @@
       "BddAbove, upper bounds, and the divergence of log at infinity"
     ]
   },
+  "sections": [
+    {
+      "id": "setup-windowed-antitonicity",
+      "title": "Setup and Windowed Antitonicity (Part I)",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Imports and namespace, then Part I: antitoneOn_window restricts antitonicity of f from [1, ∞) to each finite window [1, 1+n], the local hypothesis both Riemann-sum comparisons need.",
+      "mathContext": "$f$ antitone on $[1,\\infty) \\Rightarrow f$ antitone on $[1, 1+n]$ for every $n$."
+    },
+    {
+      "id": "two-comparisons",
+      "title": "The Two Riemann-Sum Comparisons (Part II)",
+      "startLine": 38,
+      "endLine": 67,
+      "summary": "integral_le_partialSum: the integral over [1, 1+n] is at most the left Riemann sum ∑_{i<n} f(i+1). partialSum_succ_le: the (n+1)-term partial sum is at most f(1) + the integral. Together they trap the partial sums between two integrals of the same antitone f.",
+      "mathContext": "$\\int_1^{1+n} f \\le \\sum_{i<n} f(i+1) \\le f(1) + \\int_1^{1+n} f.$"
+    },
+    {
+      "id": "integral-test",
+      "title": "The Integral Test (Part III)",
+      "startLine": 68,
+      "endLine": 101,
+      "summary": "integral_test: for antitone nonnegative f, the series ∑ f(n+1) is summable iff the family of integrals ∫₁^{1+n} f is bounded above. Both directions follow from the two comparisons plus the monotone-bounded criterion for summability of nonnegative terms.",
+      "mathContext": "$\\sum_n f(n+1) < \\infty \\iff \\Big\\{\\int_1^{1+n} f\\Big\\}_n \\text{ is bounded above}.$"
+    },
+    {
+      "id": "harmonic-divergence",
+      "title": "Application: Divergence of the Harmonic Series (Part IV)",
+      "startLine": 103,
+      "endLine": 141,
+      "summary": "Computes the logarithmic integral ∫₁^{1+n} 1/x dx = log(n+1), which is unbounded, so by the integral test not_summable_one_div_harmonic concludes the harmonic series ∑ 1/n diverges — the showcase application of the framework.",
+      "mathContext": "$\\int_1^{1+n}\\tfrac1x\\,dx = \\log(n+1) \\to \\infty \\;\\Rightarrow\\; \\sum_n \\tfrac1n = \\infty.$"
+    }
+  ],
   "conclusion": {
     "summary": "The parent's sum–integral sandwich is promoted to the general integral test: for an antitone nonnegative f on [1,∞), ∑ₙ f(n+1) is summable iff the integrals ∫₁^{1+n} f are bounded above. The criterion is then applied to 1/x to reprove that the harmonic series diverges, its integrals log(n+1) being unbounded. 7 theorems, 141 lines, 0 sorries, 0 axioms.",
     "implications": "Adds the missing convergence dichotomy to the gallery's integral-test infrastructure in reusable form: integral_test applies verbatim to any antitone nonnegative summand, so a p-series result (∑ 1/(n+1)^p convergent iff p > 1) reduces to bounding ∫₁^{1+n} x^{-p}, and the harmonic divergence recovered here is the p = 1 instance. The Summable ↔ BddAbove shape is exactly what downstream comparison-test arguments consume.",


### PR DESCRIPTION
Enrichment pass for `antitone-integral-sum-comparison-oq-01-oq-03` (the integral test as a convergence criterion for antitone series).

## Changes
- **Added missing `index.ts`** — the entry had no Vite entry point, so the page would render *proof not found* on the live site despite listing in the gallery.
- **Populated the empty `sections` array** — 4 sections aligned to the file's own Part I–IV structure (windowed antitonicity / the two Riemann-sum comparisons / the integral test Summable↔BddAbove / harmonic-series divergence), covering all 141 lines with summaries and LaTeX `mathContext`.
- **Fixed invalid annotation `significance`** — the integral_test annotation used `"critical"`, outside the allowed enum (`key|supporting|technical|context`); changed to `"key"`.

## Verification
- meta.json and annotations.json parse as valid JSON; all 5 annotations now use valid `significance`.
- `index.ts` follows the canonical gallery template.
- No content deleted; entry stays ~13 KB, under the size cap. Overview (5 keyInsights, 3 crossRefs, 5 references) already met targets.