### PR TITLE
Enrich Bézout & the Univariate Nullstellensatz: add index.ts + sections, fix significance

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-03/annotations.json
@@ -7,7 +7,7 @@
     "title": "The Open Question and the Honest Two-Part Answer",
     "content": "The module docstring frames OQ-02-OQ-02-OQ-03: can the `IsCoprime`/`IsBezout` machinery of the parent entry prove the Nullstellensatz over algebraically closed fields? The answer is deliberately split into a positive and a negative half. **Positive:** in one variable, `k[X]` is a Euclidean domain (hence a PID, hence `IsBezout`), and the coprimality machinery yields *exactly* the weak Nullstellensatz `V(f,g) = ∅ ⟺ (f,g) = (1)`. **Negative:** for `n ≥ 2` variables `k[X₁,…,Xₙ]` is not even a PID (`(X,Y)` is not principal), so the machinery cannot apply and the full Hilbert Nullstellensatz needs Noether normalization instead. This honest framing — proving precisely what Bézout reasoning delivers and proving the obstruction to more — is the entry's main contribution.",
     "mathContext": "Weak Nullstellensatz: over an algebraically closed field, $V(I) = \\varnothing \\iff I = (1)$. Here specialized to a two-generator ideal in $k[X]$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Hilbert Nullstellensatz", "Bézout domains", "PID", "algebraic geometry"],
     "prerequisites": ["Mathlib", "IsBezout", "IsAlgClosed"]
   },
@@ -19,7 +19,7 @@
     "title": "The Bézout Heart: Coprime ⇒ No Common Root",
     "content": "`coprime_imp_no_common_root` is the pure-Bézout step and holds over *any* field, with no algebraic closure assumption. From `IsCoprime f g` we extract `u, v` with `u·f + v·g = 1`. If `x` were a common root, then applying `eval x` (`congrArg (eval x)`) to the identity and rewriting with `eval_add`, `eval_mul`, `eval_one`, together with `hf.eq_zero` and `hg.eq_zero` (both evaluations are 0), collapses the left side to `0` while the right side is `1`. `zero_ne_one` closes the contradiction. This is the algebraic skeleton of the Nullstellensatz's easy direction: a Bézout combination certifies the absence of common zeros.",
     "mathContext": "If $uf + vg = 1$ then evaluating at a common root $r$ gives $u(r)\\cdot 0 + v(r)\\cdot 0 = 1$, i.e. $0 = 1$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Bézout identity", "polynomial evaluation", "proof by contradiction"],
     "prerequisites": ["IsCoprime", "Polynomial.eval"]
   },
@@ -31,7 +31,7 @@
     "title": "Where the Nullstellensatz Enters: FTA via a Non-Unit gcd",
     "content": "`no_common_root_imp_coprime` is the only nontrivial direction and the only place algebraic closure is used. Arguing by contradiction, `¬ IsCoprime f g` gives `¬ IsUnit (gcd f g)` via `gcd_isUnit_iff` (a `classical` instance supplies the `GCDMonoid k[X]` needed for `gcd`). Over a field a non-unit polynomial has nonzero degree (`isUnit_iff_degree_eq_zero`), so the fundamental theorem of algebra (`IsAlgClosed.exists_root`) produces a root `r` of `gcd f g`. Because `gcd f g` divides both `f` and `g`, `IsRoot.dvd` promotes `r` to a common root of `f` and `g`, contradicting the hypothesis. The fundamental theorem of algebra is thus the sole 'Nullstellensatz ingredient' beyond elementary ring theory.",
     "mathContext": "Not coprime $\\Rightarrow$ $\\gcd(f,g)$ is a non-unit of degree $\\ge 1$ $\\Rightarrow$ it has a root $r$ (FTA) $\\Rightarrow$ $r$ is a common root of $f$ and $g$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["fundamental theorem of algebra", "gcd", "Euclidean domain", "IsAlgClosed.exists_root"],
     "prerequisites": ["gcd_isUnit_iff", "IsAlgClosed.exists_root", "Polynomial.IsRoot.dvd"]
   },
@@ -43,7 +43,7 @@
     "title": "The Univariate Nullstellensatz: Root Form and Ideal Form",
     "content": "`coprime_iff_no_common_root` packages Parts I and II into the equivalence `IsCoprime f g ↔ ∀ x, ¬(f.IsRoot x ∧ g.IsRoot x)` over an algebraically closed field. `coprime_iff_one_mem_span` then observes that `IsCoprime f g` is *definitionally* the membership `1 ∈ Ideal.span {f, g}` (via `Ideal.mem_span_pair`), so `one_mem_span_iff_no_common_root` restates the equivalence in its geometric form: `1 ∈ (f,g) ↔ V(f,g) = ∅`. This is exactly the weak Nullstellensatz statement $V(I) = \\varnothing \\iff I = (1)$ for a two-generator ideal in one variable — the algebra/geometry dictionary made fully explicit.",
     "mathContext": "$\\mathrm{IsCoprime}(f,g) \\iff$ no common root $\\iff 1 \\in (f,g) \\iff V(f,g) = \\varnothing$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["weak Nullstellensatz", "ideal membership", "vanishing locus", "Ideal.mem_span_pair"],
     "prerequisites": ["Ideal.span", "IsCoprime"]
   },

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-03/index.ts
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ02OQ02OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const bezoutIdentityOq02Oq02Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bezoutIdentityOq02Oq02Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bezoutIdentityOq02Oq02Oq03Data: ProofData = {
+  proof: bezoutIdentityOq02Oq02Oq03Proof,
+  annotations: bezoutIdentityOq02Oq02Oq03Annotations,
+}

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-03/meta.json
@@ -93,7 +93,48 @@
       "Ideals and the weak Nullstellensatz $V(I) = \\varnothing \\iff I = (1)$"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "question-and-answer",
+      "title": "The Open Question and the Honest Two-Part Answer",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Frames the sub-question: does the Bézout / IsCoprime machinery prove the Nullstellensatz? The honest answer is a qualified yes — exactly in one variable — set up in the header and the BezoutNullstellensatz namespace.",
+      "mathContext": "$\\text{IsCoprime}\\,f\\,g \\iff V(f,g) = \\varnothing$ over an algebraically closed field, in one variable only."
+    },
+    {
+      "id": "bezout-heart",
+      "title": "The Bézout Heart: Coprime ⇒ No Common Root",
+      "startLine": 59,
+      "endLine": 81,
+      "summary": "coprime_imp_no_common_root: if IsCoprime f g then f and g share no root. Pure Bézout — a witness 1 = af + bg evaluated at any common root gives 1 = 0. Holds over any field, needs no algebraic closure.",
+      "mathContext": "$1 = a f + b g \\;\\Rightarrow\\; f(x)=g(x)=0 \\text{ impossible}.$"
+    },
+    {
+      "id": "nullstellensatz-enters",
+      "title": "Where the Nullstellensatz Enters: FTA via a Non-Unit gcd",
+      "startLine": 82,
+      "endLine": 110,
+      "summary": "no_common_root_imp_coprime: the converse needs an algebraically closed field. If f, g are not coprime their gcd is a non-unit, which (by the fundamental theorem of algebra) has a root — a common root of f and g. This is the step where the Nullstellensatz content lives.",
+      "mathContext": "$\\gcd(f,g)\\ \\text{non-unit} \\Rightarrow \\exists\\,x,\\ \\gcd(f,g)(x)=0 \\Rightarrow f(x)=g(x)=0.$"
+    },
+    {
+      "id": "univariate-nullstellensatz",
+      "title": "The Univariate Nullstellensatz: Root Form and Ideal Form",
+      "startLine": 111,
+      "endLine": 158,
+      "summary": "coprime_iff_no_common_root packages both directions; coprime_iff_one_mem_span and one_mem_span_iff_no_common_root re-express coprimality as 1 ∈ (f,g) and the emptiness of the vanishing set V(f,g), giving the weak Nullstellensatz in both its ideal and geometric forms for k[X].",
+      "mathContext": "$\\text{IsCoprime}\\,f\\,g \\iff 1 \\in (f,g) \\iff V(f,g) = \\varnothing.$"
+    },
+    {
+      "id": "instances-and-obstruction",
+      "title": "Concrete Instances and the Multivariate Obstruction",
+      "startLine": 159,
+      "endLine": 206,
+      "summary": "Worked witnesses (X and X−1 coprime in ℂ[X]; X not coprime with itself) and the key limitation: X₀ and X₁ in ℂ[X₀,X₁] have no common root yet are not coprime, because k[X₁,…,Xₙ] (n ≥ 2) is not a Bézout domain — so the method cannot reach the multivariate Nullstellensatz.",
+      "mathContext": "$X_0, X_1 \\in \\mathbb{C}[X_0,X_1]:\\ V(X_0,X_1)=\\{0\\}\\ne\\varnothing\\ \\text{but}\\ \\neg\\,\\text{IsCoprime}.$"
+    }
+  ],
   "conclusion": {
     "summary": "The answer to bezout-identity-oq-02-oq-02-oq-03 is a qualified YES: the `IsCoprime`/`IsBezout` machinery proves the weak Nullstellensatz precisely in one variable. Over an algebraically closed field, IsCoprime f g ↔ no common root ↔ 1 ∈ (f,g) ↔ V(f,g) = ∅, with the forward direction pure Bézout and the converse supplied by the fundamental theorem of algebra. The multivariate Nullstellensatz lies beyond the method because k[X₁,…,Xₙ] (n ≥ 2) is not a Bézout domain. Verified with 0 sorries and 0 axioms.",
     "implications": "This closes the Nullstellensatz branch of the BezoutIdentity open-question family with an honest scope statement. It shows precisely where Bézout reasoning is exact (the one-variable weak Nullstellensatz) and precisely where it must yield to deeper methods (Noether normalization for the general case). The ideal-form theorem `one_mem_span_iff_no_common_root` is a clean, reusable statement of the geometry/algebra dictionary in dimension one.",


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-02-oq-03` (does the Bézout/IsCoprime machinery prove the Nullstellensatz?).

## Changes
- **Added missing `index.ts`** — the entry had no Vite entry point, so the page would render *proof not found* on the live site despite listing in the gallery.
- **Populated the empty `sections` array** — 5 sections covering all 206 lines (the open question and two-part answer / the Bézout coprime⇒no-common-root heart / where the Nullstellensatz enters via FTA on a non-unit gcd / the univariate Nullstellensatz in root and ideal form / concrete instances and the multivariate obstruction), each with a summary and LaTeX `mathContext`.
- **Fixed 4 invalid annotation `significance` values** — `"critical"` → `"key"` (schema allows only key|supporting|technical|context).

## Verification
- meta.json and annotations.json parse as valid JSON; all 5 annotations now use valid `significance`.
- `index.ts` follows the canonical gallery template.
- No content deleted; entry stays ~15 KB, under the size cap. Overview (5 keyInsights, 3 crossRefs, 3 references) already met targets.