### PR TITLE
Enrich Generalized (Iterated) CRT via Bézout: add index.ts + sections, fix significance

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/annotations.json
@@ -7,7 +7,7 @@
     "title": "The Keystone: gcd Distributes over lcm (a Mathlib gap)",
     "content": "nat_gcd_lcm_distrib proves gcd(a, lcm(b,c)) = lcm(gcd(a,b), gcd(a,c)) on ℕ — a lemma Mathlib does not provide. The proof compares the two numbers through their prime factorizations using Nat.eq_of_factorization_eq: a natural number is determined by its exponent vector. Nat.factorization_gcd rewrites a gcd's factorization as the pointwise infimum (min) of the factorizations, and Nat.factorization_lcm as the pointwise supremum (max). After Finsupp.inf_apply / sup_apply expose the scalar form, the goal becomes min(α, max(β,γ)) = max(min(α,β), min(α,γ)), which is exactly inf_sup_left — the distributive law of the linear order ℕ.",
     "mathContext": "$\\gcd(a,\\operatorname{lcm}(b,c)) = \\operatorname{lcm}(\\gcd(a,b),\\gcd(a,c))$, equivalently $\\min(\\alpha,\\max(\\beta,\\gamma)) = \\max(\\min(\\alpha,\\beta),\\min(\\alpha,\\gamma))$ on each prime exponent.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "Nat.eq_of_factorization_eq",
       "Nat.factorization_gcd",
@@ -69,7 +69,7 @@
     "title": "Promoting Distributivity to a List: the Divisibility Engine",
     "content": "gcd_lcmList_dvd is where distributivity does its work for the existence proof. It shows that if gcd(m₀, mᵢ) divides d for every modulus mᵢ in the list, then gcd(m₀, lcm of all mᵢ) divides d. The induction step rewrites gcd(m₀, lcm(m_head, lcm rest)) as lcm(gcd(m₀,m_head), gcd(m₀, lcm rest)) via int_gcd_lcm_distrib, then int_natLcm_dvd combines the head divisibility (hypothesis) with the tail divisibility (induction hypothesis). This is exactly the statement gcd(a, lcm bᵢ) = lcm gcd(a,bᵢ), specialized to 'all of them divide d'.",
     "mathContext": "$\\bigl(\\forall i,\\ \\gcd(m_0,m_i)\\mid d\\bigr) \\implies \\gcd(m_0,\\operatorname{lcm}_i m_i)\\mid d$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "int_gcd_lcm_distrib",
       "int_natLcm_dvd",
@@ -105,7 +105,7 @@
     "title": "Sufficiency: Building a Solution by Iterated Merge",
     "content": "solves_of_compatible is the hard direction, by induction on the list. Given a solution Y of the tail (valid modulo L = lcmList of the tail), the head congruence a₀ mod m₀ is merged with Y mod L using the parent's two-modulus gcd_dvd_implies_solvable. The merge condition gcd(m₀, L) | (a₀ - Y) is exactly what gcd_lcmList_dvd delivers: for each tail modulus mᵢ, gcd(m₀,mᵢ) divides both a₀-aᵢ (pairwise compatibility) and aᵢ-Y (since Y solves the tail), hence divides a₀-Y. The merged x then solves the head directly and every tail congruence because x ≡ Y mod L and each tail modulus divides L.",
     "mathContext": "Merge $a_0\\ (m_0)$ with $Y\\ (L)$; solvable since $\\gcd(m_0,L)=\\operatorname{lcm}_i\\gcd(m_0,m_i)\\mid (a_0-Y)$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "NonCoprimeCRT.gcd_dvd_implies_solvable",
       "gcd_lcmList_dvd",
@@ -125,7 +125,7 @@
     "title": "Main Theorem: Solvable iff Pairwise Compatible",
     "content": "solvable_iff_compatible assembles the two directions into the generalized CRT solvability criterion for k congruences with nonzero moduli: a common solution exists if and only if every pair of congruences is compatible, gcd(mᵢ,mⱼ) | (aᵢ-aⱼ). This is the working form of the Chinese Remainder Theorem used in computational number theory, now fully machine-checked for arbitrary non-coprime moduli.",
     "mathContext": "$\\bigl(\\exists x,\\ \\forall i,\\ x\\equiv a_i\\ (m_i)\\bigr) \\iff \\bigl(\\forall i,j,\\ \\gcd(m_i,m_j)\\mid(a_i-a_j)\\bigr)$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "compatible_of_solves",
       "solves_of_compatible",

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ03OQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const bezoutIdentityOq03Oq01Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bezoutIdentityOq03Oq01Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bezoutIdentityOq03Oq01Oq02Oq01Data: ProofData = {
+  proof: bezoutIdentityOq03Oq01Oq02Oq01Proof,
+  annotations: bezoutIdentityOq03Oq01Oq02Oq01Annotations,
+}

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/meta.json
@@ -23,6 +23,48 @@
       "ℤ/ℕ divisibility bridges: Int.natCast_dvd, Int.lcm_def, Nat.lcm_dvd"
     ]
   },
+  "sections": [
+    {
+      "id": "setup-distributivity",
+      "title": "The Keystone: gcd Distributes over lcm",
+      "startLine": 1,
+      "endLine": 83,
+      "summary": "Header and IteratedCRT namespace, then the lemma that fills a genuine Mathlib gap: nat_gcd_lcm_distrib proves gcd a (lcm b c) = lcm (gcd a b) (gcd a c) on ℕ (via prime factorizations / lattice distributivity), int_gcd_lcm_distrib lifts it to ℤ moduli through natAbs, and int_natLcm_dvd packages the divisibility fact both divide ⇒ lcm divides.",
+      "mathContext": "$\\gcd(a, \\operatorname{lcm}(b,c)) = \\operatorname{lcm}(\\gcd(a,b), \\gcd(a,c)).$"
+    },
+    {
+      "id": "list-lcm-engine",
+      "title": "The List lcm and the Divisibility Engine",
+      "startLine": 84,
+      "endLine": 155,
+      "summary": "Defines lcmList (the lcm of all moduli in a list of congruences), proves it is nonzero when all moduli are and that each modulus divides it, then the key step gcd_lcmList_dvd: if gcd(m₀, mᵢ) divides d for every i, then gcd(m₀, lcmList) divides d — the recursion that promotes pairwise compatibility to a single divisibility.",
+      "mathContext": "$\\forall i,\\ \\gcd(m_0, m_i)\\mid d \\;\\Rightarrow\\; \\gcd(m_0, \\operatorname{lcm}(m_1,\\dots,m_k))\\mid d.$"
+    },
+    {
+      "id": "necessity-sufficiency",
+      "title": "Necessity and Sufficiency",
+      "startLine": 156,
+      "endLine": 221,
+      "summary": "Defines CongSolves and Compatible. compatible_of_solves: any common solution forces pairwise compatibility (necessity). solves_of_compatible: a pairwise-compatible system with nonzero moduli has a solution, built by iterated merge of two congruences at a time, using the divisibility engine to keep the merged modulus consistent (sufficiency).",
+      "mathContext": "$\\text{solvable} \\Rightarrow \\gcd(m_i,m_j)\\mid a_i-a_j; \\quad \\text{compatible} \\Rightarrow \\exists x,\\ x\\equiv a_i\\ (m_i)\\ \\forall i.$"
+    },
+    {
+      "id": "main-uniqueness",
+      "title": "Main Theorem and Uniqueness",
+      "startLine": 222,
+      "endLine": 258,
+      "summary": "solvable_iff_compatible states the generalized CRT solvability criterion (solvable ⟺ pairwise compatible). solutions_unique_mod_lcmList shows any two solutions agree modulo lcmList, and iterated_crt_full bundles existence + uniqueness modulo the list lcm.",
+      "mathContext": "$\\text{solvable} \\iff \\text{compatible}; \\quad x \\equiv y \\pmod{\\operatorname{lcm}(m_1,\\dots,m_k)}.$"
+    },
+    {
+      "id": "worked-examples",
+      "title": "Worked Examples",
+      "startLine": 259,
+      "endLine": 289,
+      "summary": "Concrete instances: a pairwise-coprime system (x ≡ 2 mod 3, 3 mod 5, 2 mod 7, solution 23) and a non-coprime but compatible system (x ≡ 1 mod 4, 3 mod 6, 0 mod 9, solution 9), exhibiting that compatibility — not coprimality — is the right hypothesis.",
+      "mathContext": "$x\\equiv 2\\,(3),\\ 3\\,(5),\\ 2\\,(7)\\Rightarrow x=23;\\quad x\\equiv 1\\,(4),\\ 3\\,(6),\\ 0\\,(9)\\Rightarrow x=9.$"
+    }
+  ],
   "conclusion": {
     "summary": "The k-congruence (iterated) CRT: a system x ≡ aᵢ (mod mᵢ) with nonzero moduli is solvable iff it is pairwise compatible (gcd(mᵢ,mⱼ) | aᵢ-aⱼ for all i,j), and the solution is unique modulo lcm(m₁,…,mₖ). The proof is reduced to a single new lemma — distributivity of gcd over lcm on ℕ, proved via prime factorizations — that fills a genuine Mathlib gap. 13 theorems, 0 axioms, 289 lines.",
     "implications": "The pairwise-compatibility criterion is the working form of CRT used throughout computational number theory (modular algorithms, Hensel lifting, multi-modular arithmetic). The standalone gcd/lcm distributivity lemma is reusable wherever divisibility lattices appear.",


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-03-oq-01-oq-02-oq-01` (the k-congruence / iterated Chinese Remainder Theorem).

## Changes
- **Added missing `index.ts`** — the entry had no Vite entry point, so the page would render *proof not found* on the live site despite listing in the gallery.
- **Populated the empty `sections` array** — 5 sections covering all 289 lines (the gcd-over-lcm distributivity keystone that fills a Mathlib gap / the list-lcm divisibility engine / necessity + sufficiency / the solvability criterion + uniqueness mod lcm / worked examples), each with a summary and LaTeX `mathContext`.
- **Fixed 4 invalid annotation `significance` values** — `"critical"` → `"key"` (schema allows only key|supporting|technical|context).

## Verification
- meta.json and annotations.json parse as valid JSON; all 8 annotations now use valid `significance`.
- `index.ts` follows the canonical gallery template.
- No content deleted; entry stays ~13 KB, under the size cap. Overview (5 keyInsights, 3 crossRefs, 3 references) already met targets.