### PR TITLE
research(schroeder-bernstein-oq-03): repair stale Aristotle companion [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03Aristotle.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03Aristotle.lean
@@ -29,21 +29,33 @@ def partialInverse (g : ℕ → ℕ) : ℕ →. ℕ :=
     Follows from Partrec.rfind applied to the computable decidable predicate. -/
 lemma partialInverse_partrec {g : ℕ → ℕ} (hg : Computable g) :
     Partrec (partialInverse g) := by
-  sorry
+  unfold partialInverse
+  apply Partrec.rfind
+  apply Computable.partrec
+  -- The predicate `fun (m, n) => decide (g n = m)` is computable: `g` is computable and
+  -- nat-equality is primitive recursive (`Primrec.eq.decide`), composed via `Computable₂.comp`.
+  have heq : Computable₂ (fun a b : ℕ => decide (a = b)) :=
+    Primrec₂.to_comp (Primrec.eq.decide)
+  exact Computable₂.comp heq (hg.comp Computable.snd) Computable.fst
 
 /-- The partial inverse returns the correct preimage.
     If n ∈ partialInverse g m, then g n = m. -/
-lemma partialInverse_spec {g : ℕ → ℕ} (hg_inj : Injective g)
+lemma partialInverse_spec {g : ℕ → ℕ} (_hg_inj : Injective g)
     {m n : ℕ} (h : n ∈ partialInverse g m) : g n = m := by
   unfold partialInverse at h
-  exact of_decide_eq_true (Nat.rfind_spec h)
+  -- `Nat.rfind_spec` returns membership `true ∈ p n`; simp normalizes
+  -- `true ∈ ↑(decide (g n = m))` to `g n = m`.
+  simpa using Nat.rfind_spec h
 
 /-- If m is in the range of g, the partial inverse is defined at m. -/
 lemma partialInverse_dom {g : ℕ → ℕ} {m : ℕ} (hm : ∃ k, g k = m) :
     (partialInverse g m).Dom := by
   unfold partialInverse
   obtain ⟨k, hk⟩ := hm
-  obtain ⟨n, hn, -⟩ := Nat.rfind_min' (p := fun n => decide (g n = m)) (by simp [hk])
+  -- Pin the `rfind_min'` witness index to `k` by supplying `decide (g k = m) = true`
+  -- explicitly (leaving it to unification fails: the witness stays a metavariable).
+  obtain ⟨n, hn, -⟩ := Nat.rfind_min' (p := fun j => decide (g j = m))
+    (show decide (g k = m) = true by simp [hk])
   exact Part.dom_iff_mem.mpr ⟨n, hn⟩
 
 end SchroederBernsteinOQ03.Aristotle

--- a/research/problems/schroeder-bernstein-oq-03/sessions/2026-07-01-s-repair-aristotle-companion.md
+++ b/research/problems/schroeder-bernstein-oq-03/sessions/2026-07-01-s-repair-aristotle-companion.md
@@ -1,0 +1,46 @@
+# Repair the stale Aristotle companion file
+
+**Researcher:** researcher-2
+**Date:** 2026-07-01
+**Phase:** ACT (maintenance) — main research sorry unchanged
+**Scope:** `Proofs/SchroederBernsteinOQ03Aristotle.lean` only.
+
+## What was wrong
+
+The Aristotle companion file did **not compile** on `origin/main` — it had a
+`sorry` (`partialInverse_partrec`) *and* two genuine compile errors from
+Mathlib API drift:
+
+- `partialInverse_spec`: `of_decide_eq_true (Nat.rfind_spec h)` — `Nat.rfind_spec`
+  now returns membership `true ∈ p n`, not `p n = true`.
+- `partialInverse_dom`: `Nat.rfind_min' (by simp [hk])` left the witness index a
+  metavariable (`g ?m = m` unsolved).
+
+All three lemmas are, in fact, **already proved** in the main file
+`SchroederBernsteinOQ03.lean` (theorems `partialInverse_partrec` /
+`partialInverse_spec` / `partialInverse_dom`, lines 129/142/149) — the companion
+is a stale duplicate that was never kept in sync. Per the researcher role doc,
+existing `*Aristotle.lean` companion files are not deleted during the
+deprecation transition, so this repairs rather than removes it.
+
+## Fixes (all verified, 0-axiom)
+
+- `partialInverse_partrec` — proved: `Partrec.rfind` + `Computable.partrec`, with
+  the decidable predicate `fun (m,n) => decide (g n = m)` shown computable via
+  `Computable₂.comp (Primrec₂.to_comp Primrec.eq.decide) (hg.comp Computable.snd) Computable.fst`.
+  Gotcha: `Primrec.eq : PrimrecRel Eq` does **not** unify with
+  `Primrec₂ (fun a b => decide (a = b))` — bridge with `Primrec.eq.decide`.
+- `partialInverse_spec` — `simpa using Nat.rfind_spec h`.
+- `partialInverse_dom` — pin the `rfind_min'` witness: supply
+  `(show decide (g k = m) = true by simp [hk])` explicitly.
+- Renamed unused `hg_inj` → `_hg_inj` (matches the main file, silences the linter).
+
+`#print axioms` on the repaired lemmas: only `propext`/`Classical.choice`/`Quot.sound`.
+Built with `lake env lean` (Docker image build still broken — `containerd` I/O error).
+
+## Main research sorry: unchanged
+
+The hard direction of `myhill_isomorphism` (`SchroederBernsteinOQ03.lean:715`,
+the collision-resolving stage / `isGFree` Π₁ obstruction) is the known
+multi-session, cross-agent blocker (r1/r2/r6). Not attempted here — it needs the
+~200-line back-and-forth priority construction, not a quick fix.


### PR DESCRIPTION
## Summary

`Proofs/SchroederBernsteinOQ03Aristotle.lean` **did not compile** on `main`. It had one `sorry` (`partialInverse_partrec`) **and** two genuine compile errors from Mathlib API drift:

- `partialInverse_spec`: `of_decide_eq_true (Nat.rfind_spec h)` — `Nat.rfind_spec` now returns membership `true ∈ p n`, not `p n = true`.
- `partialInverse_dom`: `Nat.rfind_min' (by simp [hk])` left the witness index a metavariable (`g ?m = m` unsolved).

All three lemmas already exist, fully proved, in the main file `SchroederBernsteinOQ03.lean` (theorems at lines 129/142/149) — the companion is a stale duplicate that was never kept in sync. Per the researcher role doc, existing `*Aristotle.lean` companion files are repaired (not deleted) during the deprecation transition, so this restores the file to a clean build.

## Fixes (all verified, 0-axiom)

- **`partialInverse_partrec`** — proved via `Partrec.rfind` + `Computable.partrec`; the decidable predicate `fun (m,n) => decide (g n = m)` is shown computable with `Computable₂.comp (Primrec₂.to_comp Primrec.eq.decide) (hg.comp Computable.snd) Computable.fst`. Key gotcha: `Primrec.eq : PrimrecRel Eq` does **not** unify with `Primrec₂ (fun a b => decide (a = b))` — bridge with `Primrec.eq.decide`.
- **`partialInverse_spec`** — `simpa using Nat.rfind_spec h`.
- **`partialInverse_dom`** — pin the `rfind_min'` witness index by supplying `(show decide (g k = m) = true by simp [hk])` explicitly.
- Renamed unused `hg_inj` → `_hg_inj` (matches the main file; silences the linter).

`#print axioms` on the repaired lemmas → only `propext`/`Classical.choice`/`Quot.sound`. Built with `lake env lean` (Docker image build is currently broken — `containerd` I/O error).

## Not in scope

The hard direction of `myhill_isomorphism` (`SchroederBernsteinOQ03.lean:715` — the collision-resolving stage / `isGFree` Π₁ obstruction) is the known multi-session, cross-agent blocker (r1/r2/r6) and is **unchanged**. The gallery entry keeps `sorries: 1` / `formalized` / `wip` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)