### PR TITLE
research(algebraic-numbers-countable-oq-02-oq-05): definable reals are countable (first-order base case) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ05.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ05.lean
@@ -1,0 +1,192 @@
+/-
+  Königsberg… no — Algebraic Numbers Countable, OQ-02 OQ-05:
+  Definable Reals are Countable (First-Order Base Case)
+
+  ## Open Question (algebraic-numbers-countable-oq-02-oq-05)
+
+  The parent chain establishes that ℝ is uncountable (Cantor 1874) while the
+  "nameable" subfamilies sit below it in cardinality:
+
+      ℚ  ⊊  algebraic  ⊊  computable  ⊊  ℝ
+      ↑          ↑            ↑        ↑
+      ℵ₀         ℵ₀           ℵ₀       𝔠
+
+  Sibling OQ-04 added the *computable* reals (countable, named by Turing-machine
+  codes). The natural next layer is the **definable** reals: the raw open
+  question asks whether *each level of the analytical hierarchy of definable
+  reals is countable*.
+
+  ## What is proved here (and what is deferred — read this honestly)
+
+  The literal open question is about the **analytical hierarchy** — Σ¹ₙ
+  definability in *second-order* arithmetic (quantifying over sets of naturals /
+  reals). Mathlib currently has no formalization of second-order logic or the
+  analytical hierarchy, so that statement is genuinely blocked (it would require
+  building the second-order syntax, satisfaction, and the Σ¹ₙ stratification from
+  scratch — well over a thousand lines of foundational logic). See the
+  `## Deferred` note at the end.
+
+  What *is* fully formalizable today — and is the honest **base case** of that
+  hierarchy — is the **first-order** (arithmetical-flavoured) definability layer,
+  using Mathlib's `FirstOrder.Language` model theory. This file proves, for an
+  **arbitrary countable first-order language** `L` and **any** `L`-structure on
+  ℝ:
+
+  1. `Countable (L.Formula (Fin 1))` — a countable language has only countably
+     many one-variable formulas (derived from `BoundedFormula.encoding`).
+
+  2. `foDefinable_reals_countable` — the set of reals that are ∅-definable
+     (uniquely pinned down by a single one-variable formula) is countable.
+     The proof is a pure counting argument: distinct definable reals need
+     distinct defining formulas, so the definable reals inject into the
+     countable formula set.
+
+  3. `exists_non_foDefinable_real` / `non_foDefinable_reals_uncountable` — the
+     cardinality punchline: since ℝ is uncountable, *most* reals are **not**
+     first-order definable. This is the definability analogue of "most reals are
+     transcendental" (parent OQ-03) and a concrete face of the Skolem/Tarski
+     observation that a countable language cannot name a continuum of points.
+
+  ## Why this is the right general statement
+
+  The theorem is deliberately stated for an *arbitrary* countable language and an
+  *arbitrary* structure on ℝ, because that is the uniform engine behind every
+  entry in the hierarchy above:
+
+  * Instantiated at the language of ordered rings, Tarski's quantifier
+    elimination identifies the ∅-definable reals with the **real algebraic
+    numbers**, so this theorem *subsumes* the parent result
+    "algebraic reals are countable".
+  * Any countable expansion of the language (adding exp, a truth predicate for a
+    fixed countable set of constants, …) still yields only countably many
+    definable reals — the same one-line counting argument.
+
+  So rather than re-proving one instance, we isolate the single reason all such
+  levels are countable: **countable syntax ⟹ countably many definitions**.
+
+  ## Deferred (the genuinely open remainder)
+
+  The full analytical hierarchy (Σ¹ₙ, second-order definability) is *not* proved
+  here and is blocked pending a Mathlib formalization of second-order logic. The
+  recommended path is exactly the argument above lifted to second-order syntax:
+  once the Σ¹ₙ formula sets are shown countable, the identical injection gives
+  countability of each analytical-hierarchy level. This file supplies the
+  first-order base case and the reusable counting lemma.
+
+  References:
+  - Tarski (1951): quantifier elimination for real closed fields.
+  - Skolem (1922): the Löwenheim–Skolem observations on countable languages.
+  - Cantor (1874): ℝ is uncountable (parent, algebraic-numbers-countable-oq-02).
+-/
+
+import Mathlib.ModelTheory.Encoding
+import Mathlib.ModelTheory.Semantics
+import Mathlib.Analysis.Real.Cardinality
+import Mathlib.Tactic
+
+open FirstOrder Language
+
+namespace AlgebraicNumbersCountableOQ02OQ05
+
+variable (L : Language)
+  [Countable (Σ l, L.Functions l)] [Countable (Σ l, L.Relations l)]
+
+/-
+══════════════════════════════════════════════════════════════
+PART I: A COUNTABLE LANGUAGE HAS COUNTABLY MANY ONE-VARIABLE FORMULAS
+══════════════════════════════════════════════════════════════
+
+  `BoundedFormula.encoding` encodes each bounded formula as a finite list over
+  the alphabet `Γ = (Σ k, L.Term (α ⊕ Fin k)) ⊕ ((Σ n, L.Relations n) ⊕ ℕ)`.
+  When the language is countable, `Γ` is countable, hence so is the list type,
+  and the injectivity of the encoding transports countability back to formulas.
+-/
+
+/-- All bounded formulas over one free variable (of every nesting depth) form a
+    countable type, for a countable language. -/
+instance instCountableSigmaBoundedFormula :
+    Countable (Σ n, L.BoundedFormula (Fin 1) n) := by
+  -- Register `Countable Γ` at the (definitionally equal) explicit sum type so the
+  -- `Countable (List Γ)` instance the encoding needs can be synthesised.
+  haveI hΓ : Countable (BoundedFormula.encoding (L := L) (α := Fin 1)).Γ :=
+    (inferInstance :
+      Countable ((Σ k, L.Term ((Fin 1) ⊕ Fin k)) ⊕ ((Σ n, L.Relations n) ⊕ ℕ)))
+  exact (BoundedFormula.encoding (L := L) (α := Fin 1)).encode_injective.countable
+
+/-- **Countably many one-variable formulas.** A countable first-order language
+    has only countably many `Formula (Fin 1)`s (the depth-`0` bounded formulas). -/
+instance instCountableFormulaFinOne : Countable (L.Formula (Fin 1)) :=
+  Function.Injective.countable
+    (f := fun φ : L.Formula (Fin 1) =>
+      (⟨0, φ⟩ : Σ n, L.BoundedFormula (Fin 1) n))
+    (fun _ _ h => by simpa using h)
+
+/-
+══════════════════════════════════════════════════════════════
+PART II: DEFINABLE REALS ARE COUNTABLE
+══════════════════════════════════════════════════════════════ -/
+
+variable [L.Structure ℝ]
+
+/-- A real `r` is **(∅-)definable** over the structure `(ℝ, L)` if some single
+    one-variable formula is satisfied by `r` and by `r` alone. This is the
+    first-order (arithmetical-style) definability whose analytical-hierarchy
+    generalisation is the raw open question. -/
+def FODefinable (r : ℝ) : Prop :=
+  ∃ φ : L.Formula (Fin 1), ∀ x : ℝ, φ.Realize ![x] ↔ x = r
+
+/-- **Main theorem: the ∅-definable reals are countable.**
+
+    Counting argument: each definable real carries (by choice) a formula that it
+    uniquely satisfies; two reals sharing such a formula would each be its unique
+    realiser and hence be equal. The definable reals therefore inject into the
+    countable set of one-variable formulas. -/
+theorem foDefinable_reals_countable : {r : ℝ | FODefinable L r}.Countable := by
+  rw [← Set.countable_coe_iff]
+  apply Function.Injective.countable
+    (f := fun x : ↥{r : ℝ | FODefinable L r} => x.2.choose)
+  intro a b hf
+  simp only [] at hf
+  have ha := a.2.choose_spec        -- ∀ x, (φₐ).Realize ![x] ↔ x = a
+  have hb := b.2.choose_spec         -- ∀ x, (φ_b).Realize ![x] ↔ x = b
+  rw [← hf] at hb                    -- φ_b = φₐ, so hb is now about φₐ
+  refine Subtype.ext ?_
+  have h1 := ha a.1                  -- (φₐ).Realize ![a] ↔ a = a
+  have h2 := hb a.1                  -- (φₐ).Realize ![a] ↔ a = b
+  rw [h1] at h2                      -- a = a ↔ a = b
+  simpa using h2.mp rfl
+
+/-
+══════════════════════════════════════════════════════════════
+PART III: MOST REALS ARE NOT FIRST-ORDER DEFINABLE
+══════════════════════════════════════════════════════════════
+
+  ℝ is uncountable, but only countably many reals are definable, so definability
+  cannot exhaust ℝ. This is the definability analogue of the parent's
+  "the transcendental reals are uncountable".
+-/
+
+/-- **There is an undefinable real.** No countable language can name every real. -/
+theorem exists_non_foDefinable_real : ∃ r : ℝ, ¬ FODefinable L r := by
+  by_contra h
+  push_neg at h
+  have huniv : {r : ℝ | FODefinable L r} = Set.univ :=
+    Set.eq_univ_of_forall h
+  have hcount := foDefinable_reals_countable L
+  rw [huniv, Set.countable_univ_iff] at hcount
+  exact (not_countable (α := ℝ)) hcount
+
+/-- **The undefinable reals are uncountable.** Sharpening
+    `exists_non_foDefinable_real`: definability misses not just one real but a
+    full continuum's worth. -/
+theorem non_foDefinable_reals_uncountable :
+    ¬ {r : ℝ | ¬ FODefinable L r}.Countable := by
+  intro h
+  have hcov : {r : ℝ | FODefinable L r} ∪ {r : ℝ | ¬ FODefinable L r} = Set.univ := by
+    ext r; by_cases hr : FODefinable L r <;> simp [hr]
+  have huniv : (Set.univ : Set ℝ).Countable := by
+    rw [← hcov]; exact (foDefinable_reals_countable L).union h
+  rw [Set.countable_univ_iff] at huniv
+  exact (not_countable (α := ℝ)) huniv
+
+end AlgebraicNumbersCountableOQ02OQ05

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-05/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-fodef-scoping",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 88
+    },
+    "type": "concept",
+    "title": "Honest Scoping: First-Order Base Case vs. the Second-Order Analytical Hierarchy",
+    "content": "The raw open question asks whether each level of the ANALYTICAL HIERARCHY of definable reals is countable. That hierarchy (Σ¹ₙ) is a SECOND-ORDER notion: its formulas quantify over sets of naturals / reals. Mathlib currently formalizes only first-order logic (`FirstOrder.Language`), with no second-order syntax, satisfaction, or Σ¹ₙ stratification. Formalizing that from scratch is well over a thousand lines of foundational logic, so the literal statement is genuinely blocked.\n\nRather than overclaim, this entry proves the honest FIRST-ORDER base case — the arithmetical-flavoured definability layer — and states exactly the lift needed to reach the full result: once the Σ¹ₙ formula sets are shown countable, the same injection used here (§3) gives countability of each analytical level. The docstring records this deferral explicitly so the entry's scope is not mistaken for the whole open question.\n\nThe hierarchy of 'nameable' reals sits below ℝ in cardinality: ℚ ⊊ algebraic ⊊ computable ⊊ definable ⊊ ℝ, with the first four countable (ℵ₀) and ℝ of cardinality 𝔠. Sibling OQ-04 handled the computable layer; this entry handles (the first-order part of) the definable layer.",
+    "mathContext": "First-order definability is the base of the analytical hierarchy (arithmetical ⊂ analytical). The counting argument is identical across levels; only the countability of the syntax at each level differs, and second-order syntax is the missing Mathlib ingredient.",
+    "significance": "key",
+    "relatedConcepts": [
+      "analytical hierarchy",
+      "second-order logic",
+      "first-order definability",
+      "FirstOrder.Language",
+      "cardinality hierarchy"
+    ],
+    "prerequisites": [
+      "distinction between first-order and second-order logic",
+      "the analytical hierarchy Σ¹ₙ"
+    ]
+  },
+  {
+    "id": "ann-fodef-formula-countable",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-05",
+    "range": {
+      "startLine": 107,
+      "endLine": 124
+    },
+    "type": "technique",
+    "title": "Countable Language ⟹ Countably Many One-Variable Formulas",
+    "content": "The load-bearing fact is that a countable first-order language has only countably many one-variable formulas. Mathlib supplies `BoundedFormula.encoding : Encoding (Σ n, L.BoundedFormula α n)`, an injective encoding of every bounded formula (of every nesting depth) into a finite list over the alphabet\n\n  Γ = (Σ k, L.Term (α ⊕ Fin k)) ⊕ ((Σ n, L.Relations n) ⊕ ℕ).\n\nWhen the language's function- and relation-symbol sigmas are countable, Γ is countable (Terms over a countable variable set are countable, and a countable sum/sigma of countables stays countable), hence so is `List Γ`. Injectivity of the encoding then transports countability back: `encode_injective.countable` gives `Countable (Σ n, L.BoundedFormula (Fin 1) n)`.\n\nOne subtlety: instance resolution will not unfold the projection `BoundedFormula.encoding.Γ` to the explicit sum, so the file registers `Countable BoundedFormula.encoding.Γ` at the projected type (using that it is DEFINITIONALLY the explicit sum) before invoking the encoding's countability. Finally `L.Formula (Fin 1) = L.BoundedFormula (Fin 1) 0` injects into the sigma via `φ ↦ ⟨0, φ⟩`, yielding `instCountableFormulaFinOne`.",
+    "mathContext": "This is the reusable 'countable syntax' infrastructure. Every countability-of-definable-objects theorem reduces to it: countably many names ⟹ countably many named objects.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "BoundedFormula.encoding",
+      "Function.Injective.countable",
+      "Encoding",
+      "Countable",
+      "definitional equality vs. instance synthesis"
+    ],
+    "prerequisites": [
+      "Mathlib model-theory syntax (Term, BoundedFormula, Formula)",
+      "countability of lists over a countable alphabet"
+    ]
+  },
+  {
+    "id": "ann-fodef-main",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-05",
+    "range": {
+      "startLine": 135,
+      "endLine": 159
+    },
+    "type": "proof-step",
+    "title": "The Definable Reals Inject into the Countable Formulas",
+    "content": "`FODefinable r := ∃ φ : L.Formula (Fin 1), ∀ x, φ.Realize ![x] ↔ x = r` says r is the UNIQUE realiser of some one-variable formula. The main theorem `foDefinable_reals_countable` shows `{r : ℝ | FODefinable L r}` is countable by a pure counting argument:\n\n- Map each definable real (as a subtype element) to a formula it uniquely satisfies, chosen by `Exists.choose`.\n- Injectivity: suppose two definable reals a, b choose the SAME formula φ. From a's specification, `∀ x, φ.Realize ![x] ↔ x = a`; from b's (after rewriting b's chosen formula to φ), `∀ x, φ.Realize ![x] ↔ x = b`. Instantiating both at x = a gives `(a = a) ↔ (a = b)`, whence a = b.\n\nSo the definable reals inject into `L.Formula (Fin 1)`, which §2 proved countable; `Set.countable_coe_iff` and `Function.Injective.countable` finish. Stated for an ARBITRARY countable language and structure, this single argument is the uniform reason every layer of the nameability hierarchy is countable.",
+    "mathContext": "At the language of ordered rings, Tarski's quantifier elimination makes the ∅-definable reals exactly the real algebraic numbers, so this theorem subsumes the grandparent 'algebraic reals are countable'. Any countable expansion of the language is handled by the identical injection.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Formula.Realize",
+      "Exists.choose",
+      "Function.Injective.countable",
+      "Set.countable_coe_iff",
+      "Tarski quantifier elimination"
+    ],
+    "prerequisites": [
+      "the satisfaction relation Formula.Realize",
+      "uniqueness of a formula's sole realiser"
+    ]
+  },
+  {
+    "id": "ann-fodef-undefinable",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-05",
+    "range": {
+      "startLine": 170,
+      "endLine": 192
+    },
+    "type": "concept",
+    "title": "Most Reals are Undefinable: the Skolem/Tarski Punchline",
+    "content": "ℝ is uncountable (Cantor 1874, parent entry) but only countably many reals are first-order definable, so definability cannot exhaust ℝ.\n\n- `exists_non_foDefinable_real`: if every real were definable, `{r | FODefinable L r} = univ` would be countable (via `Set.countable_univ_iff`), contradicting `Uncountable ℝ`.\n- `non_foDefinable_reals_uncountable`: sharpening — if the undefinable reals were also countable, then ℝ, the union of the countable definable set and the (assumed countable) undefinable set, would be countable. So the undefinable reals form a full uncountable remainder.\n\nThis is the definability analogue of the parent OQ-03's 'the transcendental reals are uncountable', and a concrete face of the Skolem/Tarski observation that a countable language cannot pin down a continuum of distinct points. The named reals are always a measure-zero, countable sliver of the real line.",
+    "mathContext": "Removing a countable set from an uncountable ℝ leaves an uncountable set. The argument uses only the countability of the definable reals (§3) and the uncountability of ℝ — no cardinal arithmetic beyond ℵ₀ < 𝔠.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Uncountable ℝ",
+      "Set.countable_univ_iff",
+      "Set.Countable.union",
+      "Skolem paradox",
+      "Cantor uncountability"
+    ],
+    "prerequisites": [
+      "ℝ is uncountable",
+      "a countable union of countable sets is countable"
+    ]
+  }
+]

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-05/meta.json
@@ -1,0 +1,243 @@
+{
+  "id": "algebraic-numbers-countable-oq-02-oq-05",
+  "slug": "algebraic-numbers-countable-oq-02-oq-05",
+  "title": "Definable Reals are Countable (First-Order Base Case)",
+  "description": "For an arbitrary countable first-order language L and any L-structure on ℝ, the set of reals that are ∅-definable (uniquely pinned down by a single one-variable formula) is countable. The proof is a pure counting argument: distinct definable reals require distinct defining formulas, and a countable language has only countably many one-variable formulas (derived from Mathlib's BoundedFormula.encoding). As a cardinality punchline, since ℝ is uncountable, most reals are NOT first-order definable — the definability analogue of 'most reals are transcendental'. This is the honest first-order base case of the raw open question, which asks about the second-order analytical hierarchy Σ¹ₙ, not yet formalizable in Mathlib.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.ModelTheory.Encoding",
+      "Mathlib.ModelTheory.Semantics",
+      "Mathlib.Analysis.Real.Cardinality",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "FirstOrder",
+      "Language"
+    ],
+    "namespace": "AlgebraicNumbersCountableOQ02OQ05",
+    "lineCount": 192,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/AlgebraicNumbersCountableOQ02OQ05.lean"
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Cantor (1874) showed the algebraic reals are countable while ℝ is uncountable, so most reals are transcendental. The same theme recurs at every 'nameable' layer: Turing (1936) singled out the computable reals, and Tarski (1951) and Skolem (1922) clarified that a countable language can only define countably many objects. The parent gallery chain formalizes ℝ's uncountability (oq-02) and the exact cardinality of the transcendentals (oq-03); sibling oq-04 adds the computable reals. This entry addresses the definable reals — the layer the raw open question phrases in terms of the analytical hierarchy.",
+    "problemStatement": "The open question asks whether each level of the analytical hierarchy of definable reals is countable. The analytical hierarchy (Σ¹ₙ) is second-order — its formulas quantify over sets of naturals / reals — and Mathlib has no formalization of second-order logic, so the literal statement is blocked. This entry proves the honest first-order base case: for any countable first-order language L and any L-structure on ℝ, the ∅-definable reals are countable, and (since ℝ is uncountable) the undefinable reals are uncountable.",
+    "proofStrategy": "Counting by countable names. (1) A countable language has countably many one-variable formulas: Mathlib's BoundedFormula.encoding injects every bounded formula into a finite list over a countable alphabet, so Formula (Fin 1) is countable. (2) Each ∅-definable real is the unique realiser of some one-variable formula; mapping each definable real (by choice) to such a formula is injective, so the definable reals inject into the countable formula set. (3) Since ℝ is uncountable, definability cannot exhaust it, so the undefinable reals are uncountable.",
+    "keyInsights": [
+      "Countable syntax ⟹ countably many definitions — the single reason every layer of the nameability hierarchy (algebraic, computable, definable) is countable.",
+      "Uniqueness makes the map injective: two reals defined by the same formula would each be its sole realiser, hence equal.",
+      "Stated for an arbitrary countable language, the theorem subsumes 'algebraic reals are countable' (Tarski's quantifier elimination makes the ∅-definable reals of the ordered field ℝ exactly the real algebraic numbers).",
+      "The undefinable-uncountable corollary is the Skolem/Tarski punchline: a countable language names only ℵ₀ of the continuum-many reals."
+    ],
+    "prerequisites": [
+      "First-order model theory (FirstOrder.Language: terms, bounded formulas, the satisfaction relation Realize)",
+      "Countability: a countable language / countable alphabet gives countable lists and countable formulas",
+      "ℝ is uncountable (Cantor, parent entry)"
+    ],
+    "furtherWork": [
+      "Lift the identical counting argument to second-order logic once Mathlib formalizes the analytical hierarchy Σ¹ₙ.",
+      "Make the subsumption of algebraic countability explicit via Tarski's quantifier elimination.",
+      "Exhibit a concrete undefinable real (a definability analogue of a named transcendental)."
+    ]
+  },
+  "conclusion": {
+    "summary": "For an arbitrary countable first-order language L and any L-structure on ℝ, the ∅-definable reals form a countable set (`foDefinable_reals_countable`), because distinct definable reals need distinct defining formulas and a countable language has only countably many one-variable formulas (`instCountableFormulaFinOne`, from `BoundedFormula.encoding`). Since ℝ is uncountable, the undefinable reals are uncountable (`non_foDefinable_reals_uncountable`): definability, like algebraicity and computability, names only ℵ₀ of the continuum-many reals. All three theorems are fully machine-checked — `#print axioms` reports only propext, Classical.choice, Quot.sound; no sorry, no custom axioms.",
+    "implications": "This entry pins the first-order layer of the nameability hierarchy ℚ ⊊ algebraic ⊊ computable ⊊ definable ⊊ ℝ, and isolates the single reason every such layer is countable: countable syntax ⟹ countably many definitions. Stated for an arbitrary countable language, the main theorem subsumes the grandparent 'algebraic reals are countable' (Tarski's quantifier elimination for the ordered field ℝ makes the ∅-definable reals exactly the real algebraic numbers) and every countable language expansion. The reusable `instCountableFormulaFinOne` gives 'a countable language has countably many one-variable formulas' for downstream model-theory entries.",
+    "openQuestions": [
+      "Lift the counting argument to second-order logic: formalize the analytical hierarchy Σ¹ₙ and prove each level's formula set countable, so the identical injection yields countability of each analytical-hierarchy level (the raw open question). Blocked pending a Mathlib formalization of second-order logic / second-order arithmetic.",
+      "Make the subsumption of 'algebraic reals are countable' explicit by instantiating the main theorem at the language of ordered rings and invoking Tarski's quantifier elimination.",
+      "Exhibit a concrete undefinable real — a definability analogue of a named transcendental — witnessing `exists_non_foDefinable_real` beyond the cardinality existence argument.",
+      "Abstract the shared pattern of the algebraic / computable / definable countability proofs into a single lemma 'countable index type + partial denotation map ⟹ countable image', refactoring all three sibling entries through it."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "FODefinable",
+      "type": "definition",
+      "description": "A real r is (∅-)definable over the structure (ℝ, L) if some single one-variable formula φ : L.Formula (Fin 1) is satisfied by r and by r alone: ∀ x, φ.Realize ![x] ↔ x = r.",
+      "leanType": "(L : Language) → [L.Structure ℝ] → (r : ℝ) → Prop"
+    },
+    {
+      "name": "foDefinable_reals_countable",
+      "type": "theorem",
+      "description": "The set {r : ℝ | FODefinable L r} is countable, for any countable language L and any L-structure on ℝ. Counting argument: each definable real chooses a formula it uniquely satisfies; two reals sharing such a formula would both be its unique realiser, hence equal — so the definable reals inject into the countable one-variable formulas.",
+      "leanType": "{r : ℝ | FODefinable L r}.Countable"
+    },
+    {
+      "name": "exists_non_foDefinable_real",
+      "type": "theorem",
+      "description": "There is an undefinable real: ∃ r : ℝ, ¬ FODefinable L r. If every real were definable, {r | FODefinable L r} = univ would be countable, contradicting the uncountability of ℝ.",
+      "leanType": "∃ r : ℝ, ¬ FODefinable L r"
+    },
+    {
+      "name": "non_foDefinable_reals_uncountable",
+      "type": "theorem",
+      "description": "The undefinable reals are uncountable: ¬ {r : ℝ | ¬ FODefinable L r}.Countable. Otherwise ℝ, the union of the countable definable set and the (assumed countable) undefinable set, would be countable.",
+      "leanType": "¬ {r : ℝ | ¬ FODefinable L r}.Countable"
+    }
+  ],
+  "sections": [
+    {
+      "id": "introduction",
+      "title": "§1: Open Question, Honest Scoping, and the Hierarchy",
+      "startLine": 1,
+      "endLine": 88,
+      "summary": "Module docstring framing the open question, locating definable reals below ℝ in the hierarchy ℚ ⊊ algebraic ⊊ computable ⊊ definable ⊊ ℝ, and — crucially — separating what is proved (the first-order base case) from what is deferred (the second-order analytical hierarchy Σ¹ₙ, blocked pending Mathlib second-order logic).",
+      "mathContext": "The analytical hierarchy is genuinely second-order; the literal open question cannot be stated in Mathlib today. The docstring commits to the honest first-order layer and records the exact lift needed to reach the full statement: countability of the Σ¹ₙ formula sets."
+    },
+    {
+      "id": "formula-countability",
+      "title": "§2: A Countable Language has Countably Many One-Variable Formulas",
+      "startLine": 96,
+      "endLine": 124,
+      "summary": "Two instances. instCountableSigmaBoundedFormula: the sigma of all bounded formulas over one free variable is countable, via BoundedFormula.encoding.encode_injective into List Γ (Γ countable when the language's function- and relation-symbol sigmas are countable). instCountableFormulaFinOne: Formula (Fin 1) = BoundedFormula (Fin 1) 0 injects into that sigma, hence is countable.",
+      "mathContext": "Countability of syntax is the load-bearing fact. The alphabet Γ = (Σ k, Term (Fin 1 ⊕ Fin k)) ⊕ ((Σ n, Relations n) ⊕ ℕ) must be registered as countable at the encoding's projected type so the Countable (List Γ) instance the encoding requires can be synthesised."
+    },
+    {
+      "id": "main-countability",
+      "title": "§3: The Definable Reals are Countable",
+      "startLine": 126,
+      "endLine": 159,
+      "summary": "FODefinable r := ∃ φ, ∀ x, φ.Realize ![x] ↔ x = r. foDefinable_reals_countable injects the subtype of definable reals into Formula (Fin 1) by sending each definable real to a formula (via choice) it uniquely satisfies; injectivity follows because a formula's unique realiser is unique.",
+      "mathContext": "This is the structural heart: countable syntax ⟹ countably many definitions. It is stated for an arbitrary countable language and arbitrary structure on ℝ, so it subsumes the grandparent (algebraic reals countable, via Tarski for ordered rings) and every countable language expansion."
+    },
+    {
+      "id": "undefinable-uncountable",
+      "title": "§4: Most Reals are Not First-Order Definable",
+      "startLine": 161,
+      "endLine": 192,
+      "summary": "exists_non_foDefinable_real and non_foDefinable_reals_uncountable: since ℝ is uncountable (Cantor, parent) but the definable reals are countable, the undefinable reals cannot be countable. A countable language names only ℵ₀ of the continuum-many reals.",
+      "mathContext": "The Skolem/Tarski punchline and definability analogue of the parent OQ-03's 'transcendental reals are uncountable': removing a countable definable set from an uncountable ℝ leaves an uncountable remainder."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "algebraic-numbers-countable-oq-02",
+      "relationship": "parent",
+      "description": "Parent result: ℝ is uncountable (Cantor 1874). Supplies the uncountability of ℝ used in §4 to show most reals are undefinable."
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "ancestor",
+      "description": "Grandparent: the algebraic reals are countable. Instantiated at the language of ordered rings, this entry's main theorem re-derives that fact (the ∅-definable reals of a real closed field are the real algebraic numbers, by Tarski)."
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-02-oq-04",
+      "relationship": "sibling",
+      "description": "Sibling: the computable reals are countable (named by Turing-machine codes). This entry is the next layer — definable reals named by formulas — with the same counting-by-countable-names strategy."
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-02-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling: #transcendentalReals = 𝔠. The §4 punchline here mirrors its 'most reals are transcendental' at the level of definability."
+    }
+  ],
+  "references": [
+    {
+      "authors": ["Alfred Tarski"],
+      "title": "A Decision Method for Elementary Algebra and Geometry",
+      "year": 1951,
+      "venue": "University of California Press",
+      "note": "Quantifier elimination for real closed fields; identifies the ∅-definable reals of the ordered field ℝ with the real algebraic numbers."
+    },
+    {
+      "authors": ["Thoralf Skolem"],
+      "title": "Einige Bemerkungen zur axiomatischen Begründung der Mengenlehre",
+      "year": 1922,
+      "venue": "Matematikerkongressen i Helsingfors",
+      "note": "The Löwenheim–Skolem observations: a countable language has only countably many definitions."
+    },
+    {
+      "authors": ["Georg Cantor"],
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": 1874,
+      "venue": "Journal für die reine und angewandte Mathematik",
+      "note": "ℝ is uncountable; the parent result behind §4."
+    }
+  ],
+  "meta": {
+    "status": "verified",
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "lineCount": 192,
+    "author": "researcher-11",
+    "date": "2026-07-01",
+    "dateAdded": "07/01/26",
+    "mathlib_version": "v4.26.0",
+    "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ02OQ05.lean",
+    "sourceUrl": "",
+    "mathlibDependencies": [
+      {
+        "theorem": "FirstOrder.Language.BoundedFormula.encoding",
+        "description": "Injective list-encoding of bounded formulas over a countable alphabet; the source of 'countable language ⟹ countably many formulas'.",
+        "module": "Mathlib.ModelTheory.Encoding"
+      },
+      {
+        "theorem": "FirstOrder.Language.Formula.Realize",
+        "description": "The satisfaction relation φ.Realize v for a first-order formula in a structure; used to define FODefinable.",
+        "module": "Mathlib.ModelTheory.Semantics"
+      },
+      {
+        "theorem": "Function.Injective.countable",
+        "description": "An injection into a countable type makes the domain countable; the engine of the main counting argument.",
+        "module": "Mathlib.Data.Countable.Defs"
+      },
+      {
+        "theorem": "Cardinal.not_countable_real / Uncountable ℝ",
+        "description": "ℝ is uncountable; behind the §4 corollaries that most reals are undefinable.",
+        "module": "Mathlib.Analysis.Real.Cardinality"
+      }
+    ],
+    "assumptions": "None beyond Lean/Mathlib foundations. #print axioms reports only propext, Classical.choice, Quot.sound for all three theorems — no sorry, no custom axioms, no native_decide. The hypotheses [Countable (Σ l, L.Functions l)], [Countable (Σ l, L.Relations l)] (countable language) and [L.Structure ℝ] are typeclass parameters of the theorems, not global assumptions.",
+    "prerequisites": [
+      "Mathlib.ModelTheory.Encoding: BoundedFormula.encoding — the injective list-encoding of bounded formulas used to prove syntax is countable",
+      "Mathlib.ModelTheory.Semantics: Formula.Realize — the satisfaction relation defining FODefinable",
+      "Mathlib.Analysis.Real.Cardinality: the Uncountable ℝ instance behind §4",
+      "Function.Injective.countable — inject into a countable type to conclude countability"
+    ],
+    "originalContributions": [
+      "FODefinable (r : ℝ) : Prop — first-order ∅-definability: r is the unique realiser of some one-variable formula over (ℝ, L)",
+      "instCountableSigmaBoundedFormula — Countable (Σ n, L.BoundedFormula (Fin 1) n) for a countable language, via BoundedFormula.encoding.encode_injective with Countable Γ registered at the encoding's projected alphabet type",
+      "instCountableFormulaFinOne — Countable (L.Formula (Fin 1)): the reusable 'countable language ⟹ countably many one-variable formulas' infrastructure lemma",
+      "foDefinable_reals_countable — main theorem: {r : ℝ | FODefinable L r} is countable, by injecting definable reals into the countable one-variable formulas (choice of uniquely-satisfied formula)",
+      "exists_non_foDefinable_real — corollary: an undefinable real exists (ℝ uncountable vs. countable definable set)",
+      "non_foDefinable_reals_uncountable — corollary: the undefinable reals are uncountable (partition of ℝ into countable definable + undefinable)"
+    ],
+    "openQuestions": [
+      "Lift the counting argument to second-order logic: formalize the analytical hierarchy Σ¹ₙ and prove each level's formula set countable, so the identical injection gives countability of each analytical-hierarchy level (the raw open question). Blocked pending a Mathlib formalization of second-order logic.",
+      "Instantiate the main theorem at the language of ordered rings and connect it, via Tarski's quantifier elimination, to the grandparent 'algebraic reals are countable' — making the subsumption explicit rather than remarked.",
+      "Exhibit a concrete undefinable real (a definability analogue of a specific transcendental), witnessing exists_non_foDefinable_real beyond the cardinality existence argument."
+    ],
+    "relatedProblems": [
+      {
+        "id": "algebraic-numbers-countable-oq-02",
+        "relationship": "Parent: ℝ is uncountable. Combined with the present countability of definable reals, yields that most reals are undefinable."
+      },
+      {
+        "id": "algebraic-numbers-countable-oq-02-oq-04",
+        "relationship": "Sibling: computable reals are countable. Same counting-by-countable-names schema, one layer down (codes vs. formulas)."
+      },
+      {
+        "id": "algebraic-numbers-countable-oq-02-oq-03",
+        "relationship": "Sibling: #transcendentalReals = 𝔠. The undefinable-uncountable corollary mirrors it at the definability level."
+      }
+    ],
+    "tags": [
+      "model-theory",
+      "definability",
+      "countability",
+      "first-order-logic",
+      "cardinality",
+      "analytical-hierarchy",
+      "tarski",
+      "skolem"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry `algebraic-numbers-countable-oq-02-oq-05`: **for an arbitrary countable first-order language `L` and any `L`-structure on ℝ, the ∅-definable reals are countable** — and (since ℝ is uncountable) the *undefinable* reals are uncountable.

- `Proofs/AlgebraicNumbersCountableOQ02OQ05.lean` — 3 theorems + 1 definition, 192 lines.
- **VERIFIED, 0-axiom**: `#print axioms` reports only `propext / Classical.choice / Quot.sound` for all three theorems. No `sorry`, no custom axioms, no `native_decide`.

## What is proved

1. `instCountableFormulaFinOne` — a countable language has only countably many one-variable formulas (derived from Mathlib's `BoundedFormula.encoding`).
2. `foDefinable_reals_countable` — the ∅-definable reals `{r | ∃ φ, ∀ x, φ.Realize ![x] ↔ x = r}` are countable, by injecting each definable real into the countable formula set (a definable real is the *unique* realiser of its formula).
3. `exists_non_foDefinable_real` / `non_foDefinable_reals_uncountable` — the cardinality punchline: a countable language names only ℵ₀ of the continuum-many reals (Skolem/Tarski), the definability analogue of the sibling OQ-03's 'most reals are transcendental'.

Stated for an arbitrary countable language, the main theorem is the uniform engine behind the whole nameability hierarchy ℚ ⊊ algebraic ⊊ computable ⊊ definable ⊊ ℝ: instantiated at the ordered field it subsumes the grandparent 'algebraic reals are countable' via Tarski's quantifier elimination.

## Honest scope

The *literal* open question concerns the **second-order analytical hierarchy** (Σ¹ₙ), which Mathlib cannot yet express (no second-order logic). This PR ships the **first-order base case** plus the reusable countable-formula infrastructure, and documents the exact lift needed for the full result (countability of the Σ¹ₙ formula sets ⟹ the identical injection). The analytical-hierarchy statement is explicitly recorded as deferred/blocked.

## Verification

`lake env lean Proofs/AlgebraicNumbersCountableOQ02OQ05.lean` compiles cleanly and `#print axioms` confirms 0 custom axioms. (Docker build wrapper was unavailable this session due to a containerd I/O error; the single-file `lake env lean` elaboration is a complete kernel check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)