### PR TITLE
research(erdos-455-oq-04): rigidity + strict-boundary theorems [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos455OQ04.lean
+++ b/proofs/Proofs/Erdos455OQ04.lean
@@ -234,4 +234,33 @@ theorem eulerPoly_closed_form (n : ℕ) :
         + (n : ℤ) * ((n : ℤ) - 1) * 2 :=
   apGap_closed_form eulerPoly_hasAPGaps n
 
+/-- **Rigidity: an AP-gap sequence is pinned down by `d` and its first two terms.**
+Two sequences sharing the same common second-difference `d` and the same values at
+`0` and `1` are equal everywhere. Immediate from the quadratic closed form
+`apGap_closed_form`: both sides have identical `2·q n` expansions, so they agree after
+cancelling the `2` and the `ℕ → ℤ` cast. This is the initial-value uniqueness of the
+second-difference recurrence `HasAPGaps`. -/
+theorem apGap_unique {p q : ℕ → ℕ} {d : ℤ}
+    (hp : HasAPGaps p d) (hq : HasAPGaps q d)
+    (h0 : p 0 = q 0) (h1 : p 1 = q 1) : p = q := by
+  funext n
+  have hpn := apGap_closed_form hp n
+  have hqn := apGap_closed_form hq n
+  have h2 : (2 : ℤ) * (p n : ℤ) = 2 * (q n : ℤ) := by rw [hpn, hqn, h0, h1]
+  have hz : (p n : ℤ) = (q n : ℤ) := by linarith
+  exact_mod_cast hz
+
+/-- **`d > 0` ⟹ strictly increasing gaps.** The sharp form of `apGap_gaps_monotone`:
+a strictly positive common second-difference makes the gap sequence strictly monotone.
+Together with `apGap_zero_gaps_constant` (the `d = 0` case has all gaps equal) this
+witnesses the strictness of the inclusion `ConstantGap (d = 0) ⊊ APGap_{d>0}`: a
+`d > 0` sequence has genuinely growing gaps and so is never a constant-gap
+(prime-AP) sequence. -/
+theorem apGap_gaps_strictMono {q : ℕ → ℕ} {d : ℤ} (h : HasAPGaps q d) (hd : 0 < d)
+    {m n : ℕ} (hmn : m < n) :
+    (q (m + 1) : ℤ) - (q m : ℤ) < (q (n + 1) : ℤ) - (q n : ℤ) := by
+  rw [apGap_gap_linear h m, apGap_gap_linear h n]
+  have hmn' : (m : ℤ) < (n : ℤ) := by exact_mod_cast hmn
+  nlinarith [mul_pos (by linarith : (0 : ℤ) < (n : ℤ) - (m : ℤ)) hd]
+
 end Erdos455OQ04

--- a/research/problems/erdos-455-oq-04/sessions/2026-07-01-s-rigidity-strict-boundary.md
+++ b/research/problems/erdos-455-oq-04/sessions/2026-07-01-s-rigidity-strict-boundary.md
@@ -1,0 +1,44 @@
+# Verified additions: rigidity + strict-boundary sharpening
+
+**Researcher:** researcher-2
+**Date:** 2026-07-01
+**Phase:** ACT (look-outward on a SOLVED/axiomatized entry)
+**Result:** +2 verified, axiom-free theorems on the structural theory of
+`HasAPGaps` sequences. File 237 → 266 LOC; theoremCount 10 → 12. Axioms
+unchanged (Green-Tao, Bunyakovsky, and the `native_decide` `ofReduceBool` —
+all irremovable); entry stays `axiomatized`.
+
+## Assessment
+
+The two `axiom` declarations are genuinely irremovable:
+- `greenTao_finitary` — Green-Tao (2008) is proved but not in Mathlib v4.26
+  (30 pages of additive combinatorics; no path to a derivation).
+- `bunyakovsky_finitary` — Bunyakovsky (1857) is an **open conjecture**.
+
+So axiom elimination is not on the table. The file is already sorry-free with a
+solid structural theory (r6, #32339). Per the SOLVED playbook I looked outward
+for genuinely theory-level additions (not cosmetic variants):
+
+## Added (both build clean, 0 counted axioms)
+
+- **`apGap_unique`** — rigidity / initial-value uniqueness: two `HasAPGaps _ d`
+  sequences agreeing at `0` and `1` are equal everywhere. Two-line corollary of
+  `apGap_closed_form` (both `2·q n` expansions coincide; cancel the `2` and the
+  `ℕ → ℤ` cast). This is the structural statement that an AP-gap sequence is
+  *completely determined* by `(d, q 0, q 1)`.
+- **`apGap_gaps_strictMono`** — sharpens `apGap_gaps_monotone` from `≤` to `<`:
+  `d > 0` forces strictly increasing gaps. With `apGap_zero_gaps_constant` (all
+  gaps equal at `d = 0`) this witnesses the strictness of the inclusion
+  `ConstantGap (d = 0) ⊊ APGap_{d>0}` from `problem.md`.
+
+## Build
+
+`lake env lean` (Docker image build broken — `containerd` I/O error). Both new
+theorems `#print axioms` → propext / Classical.choice / Quot.sound only.
+
+## No follow-up OQs proposed
+
+The inclusion chain `ConstantGap ⊊ APGap_{d>0} ⊊ MonotoneGap` is now fully
+pinned (linear gaps, quadratic closed form, monotone + strict-monotone
+inclusions, rigidity). Remaining open directions (max AP-gap length for fixed d)
+are exactly Bunyakovsky and need no new gallery child.

--- a/src/data/proofs/erdos-455-oq-04/meta.json
+++ b/src/data/proofs/erdos-455-oq-04/meta.json
@@ -29,8 +29,8 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-05-12",
     "mathlib_version": "4.26.0",
-    "lineCount": 237,
-    "theoremCount": 10,
+    "lineCount": 266,
+    "theoremCount": 12,
     "definitionCount": 2,
     "mathlibDependencies": [
       {
@@ -75,7 +75,8 @@
       "Concrete length-5 Green-Tao d=0 cross-check (`exists_apGap_zero_length_5_witness`): the AP 5, 11, 17, 23, 29 (common difference 6) gives five primes — confirmed sorry-free and axiom-free via `decide`. Independent of `greenTao_finitary`, this provides a sanity check on the k = 5 instance of the d = 0 axiom.",
       "Predicate-form (F5) Bunyakovsky axiom signature: rather than the raw-triple (F1) form `∃ q₀ g₀, ∀ n, Nat.Prime (q₀ + n·g₀ + (n·(n-1)/2)·d.toNat)` which would require ℤ-cast bookkeeping for the quadratic, the F5 form directly returns the bridge tuple `⟨q, StrictMono q, primality prefix, HasAPGaps q d⟩` — sidesteps the ℤ-cast complications and makes the bridge theorem a one-line restatement.",
       "Bridge theorems for both axiom paths: `exists_apGap_zero_of_length` (d = 0, Green-Tao) and `exists_apGapPrimeSeq_of_length_d_pos` (d > 0, Bunyakovsky) connect the raw axioms to the slug's `HasAPGaps`/`APGapPrimeSeq` data structures — the bridge architecture isolates Mathlib-style triple-form axioms from the slug's predicate-form data types.",
-      "Verified axiom-free structural theory of AP-gap sequences (`apGap_gap_linear`, `apGap_zero_gaps_constant`, `apGap_gaps_monotone`, `apGap_closed_form`, `eulerPoly_closed_form`): unconditional consequences of the second-difference recurrence, requiring neither primality nor the Green-Tao / Bunyakovsky axioms. `apGap_gap_linear` integrates the recurrence once to show the gaps `q(n+1) - q(n) = (q 1 - q 0) + n·d` form an arithmetic progression; `apGap_closed_form` integrates again to the quadratic closed form `2·q(n) = 2·q0 + 2n·(q1 - q0) + n(n-1)·d` (with d = 2, q0 = 41, q1 = 43 this is exactly Euler's n² + n + 41, checked by `eulerPoly_closed_form`). `apGap_gaps_monotone` establishes the key inclusion `APGap_{d ≥ 0} ⊆ MonotoneGap` (non-negative common difference ⟹ non-decreasing gaps), formally placing the AP-gap condition inside the parent erdos-455 monotone-gap condition; `apGap_zero_gaps_constant` is the d = 0 endpoint (constant gaps = primes in AP). All five depend only on propext / Classical.choice / Quot.sound (0 counted axioms)."
+      "Verified axiom-free structural theory of AP-gap sequences (`apGap_gap_linear`, `apGap_zero_gaps_constant`, `apGap_gaps_monotone`, `apGap_closed_form`, `eulerPoly_closed_form`): unconditional consequences of the second-difference recurrence, requiring neither primality nor the Green-Tao / Bunyakovsky axioms. `apGap_gap_linear` integrates the recurrence once to show the gaps `q(n+1) - q(n) = (q 1 - q 0) + n·d` form an arithmetic progression; `apGap_closed_form` integrates again to the quadratic closed form `2·q(n) = 2·q0 + 2n·(q1 - q0) + n(n-1)·d` (with d = 2, q0 = 41, q1 = 43 this is exactly Euler's n² + n + 41, checked by `eulerPoly_closed_form`). `apGap_gaps_monotone` establishes the key inclusion `APGap_{d ≥ 0} ⊆ MonotoneGap` (non-negative common difference ⟹ non-decreasing gaps), formally placing the AP-gap condition inside the parent erdos-455 monotone-gap condition; `apGap_zero_gaps_constant` is the d = 0 endpoint (constant gaps = primes in AP). All five depend only on propext / Classical.choice / Quot.sound (0 counted axioms).",
+      "Rigidity and strict-boundary sharpenings (`apGap_unique`, `apGap_gaps_strictMono`), verified and axiom-free. `apGap_unique` is the initial-value uniqueness of the second-difference recurrence: two `HasAPGaps _ d` sequences that agree at n = 0 and n = 1 agree everywhere (a two-line corollary of the quadratic closed form). `apGap_gaps_strictMono` sharpens `apGap_gaps_monotone` from ≤ to <, showing d > 0 forces strictly increasing gaps; combined with `apGap_zero_gaps_constant` (all gaps equal when d = 0) it witnesses the strictness of the inclusion `ConstantGap (d = 0) ⊊ APGap_{d>0}`. Both depend only on propext / Classical.choice / Quot.sound."
     ],
     "prerequisites": [
       "Elementary number theory (primality of natural numbers, arithmetic progressions)",
@@ -176,11 +177,11 @@
   ],
   "leanFile": {
     "axiomCount": 2,
-    "lineCount": 237,
+    "lineCount": 266,
     "path": "Proofs/Erdos455OQ04.lean",
     "sorries": 0,
     "definitionCount": 2,
-    "theoremCount": 10
+    "theoremCount": 12
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Two verified, axiom-free additions to the structural theory of `HasAPGaps` sequences in `Proofs/Erdos455OQ04.lean` — looking outward on a solved/axiomatized entry (the `greenTao_finitary` and `bunyakovsky_finitary` axioms are irremovable; Bunyakovsky is an open conjecture and Green-Tao is not in Mathlib v4.26).

- **`apGap_unique`** — rigidity / initial-value uniqueness of the second-difference recurrence: two `HasAPGaps _ d` sequences that agree at `n = 0` and `n = 1` are equal everywhere. A short corollary of the existing quadratic closed form `apGap_closed_form` (both `2·q n` expansions coincide; cancel the `2` and the `ℕ → ℤ` cast). Structurally: an AP-gap sequence is completely determined by `(d, q 0, q 1)`.
- **`apGap_gaps_strictMono`** — sharpens the existing `apGap_gaps_monotone` from `≤` to `<`: `d > 0` forces strictly increasing gaps. Combined with `apGap_zero_gaps_constant` (all gaps equal when `d = 0`), this witnesses the strictness of the inclusion `ConstantGap (d = 0) ⊊ APGap_{d>0}` from `problem.md`.

## Verification

- Built with `lake env lean` (Docker image build currently broken — `containerd` I/O error). Full file compiles clean: 0 error / 0 warning / 0 sorry.
- `#print axioms apGap_unique` and `#print axioms apGap_gaps_strictMono` → `propext / Classical.choice / Quot.sound` only.
- `meta.json`: `lineCount` 237 → 266, `theoremCount` 10 → 12. Status stays `axiomatized` (the file's two axioms + the `native_decide` `ofReduceBool` are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)