### PR TITLE
research(erdos-101-oq-01): strong refutation — four-point line count is not O(nᵝ) for any β<2 [+1thm]

### DIFF
--- a/proofs/Proofs/Erdos101OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ01.lean
@@ -759,4 +759,79 @@ theorem erdos_three_halves_conjecture_refuted_constructive :
   rw [hcard]
   linarith [hP_lb, h_rpow_lt]
 
+/-! ## S5 ACT: the strong (all-exponents) refutation
+
+`erdos_three_halves_conjecture_refuted` kills exactly one exponent, `β = 3/2`. But the
+Solymosi–Stojaković lower bound is far stronger: its witness exponent `2 - C/√(log n)`
+tends to `2`, so it exceeds *every* fixed `β < 2` eventually. The theorem below records
+this — the four-point line count is not `O(nᵝ)` for any `β < 2` — which subsumes the
+`3/2` refutation as the special case `β = 3/2` and pins the true growth rate firmly in
+the "just below quadratic" regime that OQ-01 asks to sharpen to `o(n²)`.
+
+Sorry count unchanged (still 2). Axiom count unchanged (still 0). Theorem count: +1. -/
+
+/-- **Strong refutation: the four-point line count is not `O(nᵝ)` for any `β < 2`.**
+
+For every exponent `β < 2` there is no global bound `fourPointLineCount P ≤ |P|ᵝ` holding
+for all sufficiently large no-five-collinear `P`. Specialising the Solymosi–Stojaković
+lower bound to `C = 1`, the witness exponent `2 - 1/√(log n)` exceeds `β` once
+`√(log n) > 1/(2 − β)` (i.e. `n > exp(1/(2 − β)²)`), and `Real.rpow` is strictly monotone
+in the exponent for base `> 1`, contradicting the hypothesised `nᵝ` upper bound.
+
+`erdos_three_halves_conjecture_refuted` is the special case `β = 3/2`. Depends only on the
+deferred `solymosi_stojakovic_lower_bound`; the argument here is itself sorry-free and
+axiom-free. -/
+theorem four_point_line_count_not_O_rpow (β : ℝ) (hβ : β < 2) :
+    ¬ (∃ N : ℕ, ∀ (P : PlanarPointSet), NoFiveCollinear P → N ≤ P.points.card →
+        (fourPointLineCount P : ℝ) ≤ (P.points.card : ℝ) ^ β) := by
+  rintro ⟨N₀, hN₀⟩
+  -- Solymosi–Stojaković with `C = 1`.
+  obtain ⟨N₁, hN₁⟩ := solymosi_stojakovic_lower_bound (1 : ℝ) (by norm_num)
+  have h2β : (0 : ℝ) < 2 - β := by linarith
+  -- Threshold on `log`: need `log m > (1/(2-β))²`, i.e. `m > exp ((1/(2-β))²)`.
+  set T : ℝ := (1 / (2 - β)) ^ 2 with hT
+  have hTpos : (0 : ℝ) < T := by positivity
+  obtain ⟨K, hK⟩ := exists_nat_gt (Real.exp T)
+  -- Pick a single `m` beating `N₀`, `N₁`, and `K`.
+  set m : ℕ := max N₀ (max N₁ K) with hm_def
+  have hm_N₀ : N₀ ≤ m := le_max_left _ _
+  have hm_N₁ : N₁ ≤ m := (le_max_left N₁ K).trans (le_max_right _ _)
+  have hm_K : K ≤ m := (le_max_right N₁ K).trans (le_max_right _ _)
+  -- Solymosi–Stojaković witness at size `m`.
+  obtain ⟨P, hcard, hP_no5, hP_lb⟩ := hN₁ m hm_N₁
+  have hP_card_ge : N₀ ≤ P.points.card := hcard.symm ▸ hm_N₀
+  have hP_ub : (fourPointLineCount P : ℝ) ≤ (P.points.card : ℝ) ^ β :=
+    hN₀ P hP_no5 hP_card_ge
+  -- `m > exp T`, hence `m > 1`.
+  have hexpT_lt_m : Real.exp T < (m : ℝ) := by
+    have hKm : (K : ℝ) ≤ (m : ℝ) := by exact_mod_cast hm_K
+    linarith
+  have hexpT_gt_one : (1 : ℝ) < Real.exp T := by
+    rw [show (1 : ℝ) = Real.exp 0 from Real.exp_zero.symm]; exact Real.exp_lt_exp.mpr hTpos
+  have hm_gt_one : (1 : ℝ) < (m : ℝ) := lt_trans hexpT_gt_one hexpT_lt_m
+  -- `log m > T`.
+  have hlog_gt_T : T < Real.log (m : ℝ) := by
+    have h := Real.log_lt_log (Real.exp_pos T) hexpT_lt_m
+    rwa [Real.log_exp] at h
+  -- `√(log m) > 1/(2-β)`.
+  have hsqrt_gt : (1 / (2 - β)) < Real.sqrt (Real.log (m : ℝ)) := by
+    have h := Real.sqrt_lt_sqrt hTpos.le hlog_gt_T
+    rwa [hT, Real.sqrt_sq (by positivity)] at h
+  have hsqrt_pos : (0 : ℝ) < Real.sqrt (Real.log (m : ℝ)) :=
+    lt_trans (by positivity) hsqrt_gt
+  -- `1/√(log m) < 2 - β`, hence `β < 2 - 1/√(log m)`.
+  have hone_lt : (1 : ℝ) < Real.sqrt (Real.log (m : ℝ)) * (2 - β) :=
+    (div_lt_iff₀ h2β).mp hsqrt_gt
+  have h_exp_gt : β < 2 - (1 : ℝ) / Real.sqrt (Real.log (m : ℝ)) := by
+    have hfrac : (1 : ℝ) / Real.sqrt (Real.log (m : ℝ)) < 2 - β := by
+      rw [div_lt_iff₀ hsqrt_pos, mul_comm]; exact hone_lt
+    linarith
+  -- Strict monotonicity of `Real.rpow` in the exponent (base `> 1`).
+  have h_rpow_lt :
+      (m : ℝ) ^ β < (m : ℝ) ^ (2 - (1 : ℝ) / Real.sqrt (Real.log (m : ℝ))) :=
+    Real.rpow_lt_rpow_of_exponent_lt hm_gt_one h_exp_gt
+  -- Chain: `m^(2-1/√log m) ≤ count ≤ m^β < m^(2-1/√log m)` — contradiction.
+  have hP_ub_m : (fourPointLineCount P : ℝ) ≤ (m : ℝ) ^ β := by rw [hcard] at hP_ub; exact hP_ub
+  linarith [hP_lb, hP_ub_m, h_rpow_lt]
+
 end Erdos101OQ01

--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -24,12 +24,12 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-05-11",
     "axiomCount": 0,
-    "lineCount": 762,
-    "assumptions": "2 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize, primary ε–N form); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred). The Mathlib-idiom form erdos_101_oq_01_isLittleO is no longer an independent sorry: it is *derived* from the main conjecture via the chain erdos_101_oq_01_conjecture → rate_form ↔ isLittleO_form (lemmas erdos_101_oq_01_conjecture_iff_rate_form and erdos_101_oq_01_rate_form_iff_isLittleO), so the file's open content is the single primary conjecture plus the deferred Solymosi–Stojaković construction. S14 (2026-06-03) unifies the S12 surrogate `maxFourPointLines` with the S13 genuine sup `maxCountAtSize` via the pointwise bridge `maxCountAtSize_le_maxFourPointLines` (uniform lift of `improved_upper_bound`) and propagates the `O(n²)` certificate to the sup via `maxCountAtSize_isBigO_n_squared`. S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness, IsBigO certificates for surrogate + true sup, isLittleOh ↔ Mathlib IsLittleO bridge) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
+    "lineCount": 837,
+    "assumptions": "2 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize, primary ε–N form); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred). S5 (2026-07-01) adds four_point_line_count_not_O_rpow: the strong refutation that the four-point line count is not O(nᵝ) for ANY β < 2 (the witness exponent 2 − C/√(log n) → 2 beats every fixed β < 2), of which erdos_three_halves_conjecture_refuted is the β = 3/2 special case. Its proof is itself sorry-free (adds no new sorry; file remains at 2) but, like the existing refutation theorems, transitively consumes the deferred solymosi_stojakovic_lower_bound (so #print axioms lists sorryAx until that obligation is discharged). The Mathlib-idiom form erdos_101_oq_01_isLittleO is no longer an independent sorry: it is *derived* from the main conjecture via the chain erdos_101_oq_01_conjecture → rate_form ↔ isLittleO_form (lemmas erdos_101_oq_01_conjecture_iff_rate_form and erdos_101_oq_01_rate_form_iff_isLittleO), so the file's open content is the single primary conjecture plus the deferred Solymosi–Stojaković construction. S14 (2026-06-03) unifies the S12 surrogate `maxFourPointLines` with the S13 genuine sup `maxCountAtSize` via the pointwise bridge `maxCountAtSize_le_maxFourPointLines` (uniform lift of `improved_upper_bound`) and propagates the `O(n²)` certificate to the sup via `maxCountAtSize_isBigO_n_squared`. S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness, IsBigO certificates for surrogate + true sup, isLittleOh ↔ Mathlib IsLittleO bridge) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
+    "theoremCount": 21,
     "definitionCount": 7,
-    "substantiveTheoremCount": 17
+    "substantiveTheoremCount": 18
   },
   "sections": [
     {
@@ -116,9 +116,17 @@
       "id": "s4-constructive-refutation",
       "title": "S4 ACT: constructive refutation of the $\\Theta(n^{3/2})$ conjecture",
       "startLine": 675,
-      "endLine": 762,
+      "endLine": 761,
       "summary": "Provides the positive (constructive) form `erdos_three_halves_conjecture_refuted_constructive`: for every threshold `N` there exists a no-five-collinear planar point set `P` with `|P| ≥ N` and strictly more than `|P|^{3/2}` four-point lines. The proof reuses the S3 chain verbatim through `Real.rpow_lt_rpow_of_exponent_lt` (specialise `solymosi_stojakovic_lower_bound` at `C = 1/2`, then `m ≥ 3 ⟹ log m > 1 ⟹ √(log m) > 1 ⟹ 2 − 1/(2√(log m)) > 3/2`), changing only the final assembly to deliver the witness directly. Sorry-free and axiom-free; depends only on the deferred `solymosi_stojakovic_lower_bound`.",
       "mathContext": "The constructive form is more useful downstream than the negated-existence S3 refutation: it produces explicit witnesses rather than contradicting a hypothetical bound. Both forms are mutually derivable and share the same single deferred proof obligation; the file's sorry count stays 2 and axiom count stays 0."
+    },
+    {
+      "id": "s5-strong-refutation",
+      "title": "S5 ACT: strong refutation — not O(nᵝ) for any β < 2",
+      "startLine": 762,
+      "endLine": 837,
+      "summary": "four_point_line_count_not_O_rpow: for every exponent β < 2 there is no global O(nᵝ) upper bound on fourPointLineCount. Specialises solymosi_stojakovic_lower_bound to C=1; the witness exponent 2 − 1/√(log n) exceeds β once n > exp(1/(2−β)²) (threshold obtained via exists_nat_gt (Real.exp T)), and Real.rpow_lt_rpow_of_exponent_lt (base > 1) closes the contradiction. erdos_three_halves_conjecture_refuted is the β = 3/2 special case.",
+      "mathContext": "Strengthens the single-exponent 3/2 refutation to all β < 2, pinning the true growth firmly in the 'just below quadratic' regime OQ-01 asks to sharpen to o(n²). Proof is sorry-free but transitively consumes the deferred Solymosi–Stojaković obligation (sorryAx), matching the existing refutation theorems."
     }
   ],
   "overview": {
@@ -161,9 +169,9 @@
       "Classical"
     ],
     "namespace": "Erdos101OQ01",
-    "lineCount": 762,
+    "lineCount": 837,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 21,
     "definitionCount": 7,
     "path": "Proofs/Erdos101OQ01.lean",
     "sorries": 2


### PR DESCRIPTION
## Summary

Adds **`four_point_line_count_not_O_rpow`** to `Erdos101OQ01.lean`: for every exponent `β < 2`, there is no global bound `fourPointLineCount P ≤ |P|ᵝ` holding for all large no-five-collinear point sets `P`.

This **strictly generalizes** the existing `erdos_three_halves_conjecture_refuted` (which killed only the single exponent `β = 3/2`) to **all** sub-quadratic exponents — the four-point line count is not `O(nᵝ)` for any `β < 2`. That pins the true growth rate firmly in the "just below quadratic" regime that Erdős's open OQ-01 asks to sharpen to `o(n²)`.

## Proof

Specialise the Solymosi–Stojaković lower bound to `C = 1`: the witness exponent `2 − 1/√(log n)` exceeds `β` once `√(log n) > 1/(2 − β)`, i.e. `n > exp(1/(2 − β)²)`. The threshold is produced explicitly via `exists_nat_gt (Real.exp T)` with `T = (1/(2 − β))²`, and `Real.rpow_lt_rpow_of_exponent_lt` (strict monotonicity in the exponent, base `> 1`) closes the contradiction against the hypothesised `nᵝ` upper bound. The analytic chain `m > exp T ⟹ log m > T ⟹ √(log m) > 1/(2−β) ⟹ 1/√(log m) < 2−β` generalises the existing S3 `C = 1/2` argument.

`erdos_three_halves_conjecture_refuted` is exactly the `β = 3/2` special case.

## Honest status

- The new proof is **sorry-free** and adds **no new `sorry`** — the file remains at exactly **2** (`erdos_101_oq_01`, the open $100 conjecture; and `solymosi_stojakovic_lower_bound`, the deferred 2013 construction).
- Like the existing refutation theorems, it **transitively consumes** the deferred `solymosi_stojakovic_lower_bound`, so `#print axioms four_point_line_count_not_O_rpow` lists `sorryAx` (same footprint as `erdos_three_halves_conjecture_refuted`) until that obligation is discharged.
- The file still has **0 literal `axiom` declarations**; gallery `meta.json` refreshed (762→837 lines, 20→21 theorems, +1 section, honest assumptions note).

Verified via `lake env lean` (Docker containerd currently down): only the two pre-existing expected `sorry` warnings, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)