### PR TITLE
research(de-moivre-oq-01-oq-01-oq-01-oq-01): explicit closed form of Chebyshev U_n [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DeMoivreOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,187 @@
+import Mathlib
+/-
+# De Moivre OQ-01-OQ-01-OQ-01-OQ-01: The Explicit Closed Form of the Chebyshev U_n
+
+## Open Question
+
+This entry answers the **leading open question** posed by the parent entry
+`de-moivre-oq-01-oq-01-oq-01` ("The Binomial Expansion of sin(nθ) and its
+Chebyshev-U Connection"):
+
+> Can the polynomial coefficients of `U_n` over `ℤ` be read off from the
+> odd-index expansion, giving an explicit closed form for `U_n` analogous to
+> the `T_n` coefficient question?
+
+The answer is **yes**.  We prove the classical explicit formula for the
+Chebyshev polynomial of the second kind
+
+  `U_n(X) = ∑_{k=0}^{⌊n/2⌋} (-1)^k · C(n-k, k) · (2X)^{n-2k}`,
+
+as an identity of integer polynomials `U ℤ n = Uexpl n`.  Mathlib defines
+`Polynomial.Chebyshev.U` by its recurrence but (as of the current version)
+provides **no** explicit coefficient formula — its source even lists
+"Add explicit formula ... for Chebyshev polynomials" as a TODO — so this is a
+genuinely new, machine-checked closed form rather than a restatement.
+
+## Mathematical Content
+
+The Chebyshev polynomials of the second kind satisfy `U_0 = 1`, `U_1 = 2X`, and
+the recurrence `U_{n+2} = 2X·U_{n+1} - U_n`.  The candidate explicit sum
+`Uexpl n` satisfies the *same* two base cases and the *same* recurrence, so the
+two agree for all `n` by two-step induction.
+
+The heart of the proof is the **termwise Pascal recurrence** (`term_succ_rec`):
+
+  `term (n+2) (k+1) = 2X · term (n+1) (k+1) - term n k`,
+
+where `term m k = (-1)^k · C(m-k, k) · (2X)^{m-2k}`.  Shifting the summation
+index by one (`k ↦ k+1`) keeps every binomial coefficient of the classical form
+`C((n-k)+1, k+1)`, so Pascal's rule `C((n-k)+1, k+1) = C(n-k, k) + C(n-k, k+1)`
+applies directly, with the two Pascal pieces producing the `-term n k` and
+`2X·term (n+1) (k+1)` contributions respectively.  Boundary terms where
+`2k > m` vanish because `C(m-k, k) = 0` (`Nat.choose_eq_zero_of_lt`), which lets
+us sum over a uniform range and dispenses with all floor bookkeeping.
+
+## What is proved here (0 axioms, Mathlib-backed)
+
+* `term_eq_zero`     — a summand vanishes once `2k > m`.
+* `Uexpl_eq_sum_range`— `Uexpl n` may be summed over any range covering its support.
+* `term_succ_rec`    — the termwise Pascal recurrence (the combinatorial core).
+* `Uexpl_rec`        — `Uexpl` obeys the Chebyshev-U recurrence.
+* `Uexpl_zero`, `Uexpl_one` — the two base cases.
+* `U_eq_Uexpl`       — **the explicit closed form** `U ℤ n = Uexpl n`.
+
+This supplies the `U_n` coefficient formula that mirrors, on the second-kind
+side, the `T_n` development of the ancestor entries; together they give explicit
+integer-coefficient closed forms for both kinds of Chebyshev polynomials.
+-/
+
+open Polynomial Finset
+
+namespace DeMoivreExplicitU
+
+/-- The `k`-th summand of the explicit expansion of `U_m`:
+`(-1)^k · C(m-k, k) · (2X)^{m-2k}`. -/
+noncomputable def term (m k : ℕ) : Polynomial ℤ :=
+  (-1 : Polynomial ℤ) ^ k * ((m - k).choose k : Polynomial ℤ) * (2 * X) ^ (m - 2 * k)
+
+/-- The explicit closed-form candidate for `U_n`:
+`∑_{k=0}^{⌊n/2⌋} (-1)^k · C(n-k, k) · (2X)^{n-2k}`. -/
+noncomputable def Uexpl (n : ℕ) : Polynomial ℤ :=
+  ∑ k ∈ Finset.range (n / 2 + 1), term n k
+
+/-- A summand vanishes once `2k > m`, because the binomial coefficient is zero. -/
+lemma term_eq_zero {m k : ℕ} (h : m < 2 * k) : term m k = 0 := by
+  have hlt : m - k < k := by omega
+  simp [term, Nat.choose_eq_zero_of_lt hlt]
+
+/-- `Uexpl n` may be summed over any range large enough to contain its support. -/
+lemma Uexpl_eq_sum_range {n N : ℕ} (hN : n / 2 + 1 ≤ N) :
+    Uexpl n = ∑ k ∈ Finset.range N, term n k := by
+  unfold Uexpl
+  apply Finset.sum_subset
+  · intro x hx
+    simp only [Finset.mem_range] at hx ⊢
+    omega
+  · intro k _ hk
+    rw [Finset.mem_range, not_lt] at hk
+    exact term_eq_zero (by omega)
+
+/-- The termwise Pascal recurrence, with the summation index shifted by one.
+This is the combinatorial core: `term (n+2) (k+1) = 2X·term (n+1) (k+1) - term n k`. -/
+lemma term_succ_rec (n k : ℕ) :
+    term (n + 2) (k + 1) = 2 * X * term (n + 1) (k + 1) - term n k := by
+  rcases le_or_gt (2 * k + 1) n with h | h
+  · -- Regular case `n ≥ 2k+1`: all exponents are genuine and Pascal applies.
+    have e1 : n + 2 - (k + 1) = (n - k) + 1 := by omega
+    have e2 : n + 2 - 2 * (k + 1) = (n - 1 - 2 * k) + 1 := by omega
+    have e3 : n + 1 - (k + 1) = n - k := by omega
+    have e4 : n + 1 - 2 * (k + 1) = n - 1 - 2 * k := by omega
+    have e5 : n - 2 * k = (n - 1 - 2 * k) + 1 := by omega
+    simp only [term, e1, e2, e3, e4, e5, Nat.choose_succ_succ, pow_succ]
+    push_cast
+    ring
+  · -- Degenerate case `n ≤ 2k`: the `term (n+1) (k+1)` piece vanishes.
+    have hz : term (n + 1) (k + 1) = 0 := term_eq_zero (by omega)
+    rw [hz, mul_zero, zero_sub]
+    rcases eq_or_lt_of_le (show n ≤ 2 * k from by omega) with he | hl
+    · -- `n = 2k`: both surviving terms are `±1`.
+      subst he
+      have a1 : 2 * k + 2 - (k + 1) = k + 1 := by omega
+      have a2 : 2 * k + 2 - 2 * (k + 1) = 0 := by omega
+      have a3 : 2 * k - k = k := by omega
+      have a4 : 2 * k - 2 * k = 0 := by omega
+      simp only [term, a1, a2, a3, a4, Nat.choose_self, Nat.cast_one, pow_zero, pow_succ]
+      ring
+    · -- `n < 2k`: both surviving terms vanish.
+      rw [term_eq_zero (show n + 2 < 2 * (k + 1) by omega),
+          term_eq_zero (show n < 2 * k from hl), neg_zero]
+
+/-- `Uexpl` obeys the Chebyshev-U recurrence `Uexpl (n+2) = 2X·Uexpl (n+1) - Uexpl n`. -/
+lemma Uexpl_rec (n : ℕ) :
+    Uexpl (n + 2) = 2 * X * Uexpl (n + 1) - Uexpl n := by
+  have hU2 : Uexpl (n + 2)
+      = (∑ k ∈ Finset.range (n + 1), term (n + 2) (k + 1)) + term (n + 2) 0 := by
+    rw [Uexpl_eq_sum_range (show (n + 2) / 2 + 1 ≤ n + 2 by omega)]
+    exact Finset.sum_range_succ' (term (n + 2)) (n + 1)
+  have hU1 : Uexpl (n + 1)
+      = (∑ k ∈ Finset.range (n + 1), term (n + 1) (k + 1)) + term (n + 1) 0 := by
+    rw [Uexpl_eq_sum_range (show (n + 1) / 2 + 1 ≤ n + 2 by omega)]
+    exact Finset.sum_range_succ' (term (n + 1)) (n + 1)
+  have hU0 : Uexpl n = ∑ k ∈ Finset.range (n + 1), term n k := by
+    rw [Uexpl_eq_sum_range (show n / 2 + 1 ≤ n + 2 by omega), Finset.sum_range_succ,
+        term_eq_zero (show n < 2 * (n + 1) by omega), add_zero]
+  have hA : (∑ k ∈ Finset.range (n + 1), term (n + 2) (k + 1))
+      = 2 * X * (∑ k ∈ Finset.range (n + 1), term (n + 1) (k + 1))
+        - ∑ k ∈ Finset.range (n + 1), term n k := by
+    rw [Finset.mul_sum, ← Finset.sum_sub_distrib]
+    exact Finset.sum_congr rfl (fun k _ => term_succ_rec n k)
+  have h0 : term (n + 2) 0 = 2 * X * term (n + 1) 0 := by
+    simp only [term, pow_zero, Nat.sub_zero, mul_zero, Nat.choose_zero_right,
+      Nat.cast_one, mul_one, one_mul]
+    rw [show n + 2 = (n + 1) + 1 by omega, pow_succ]
+    ring
+  rw [hU2, hU1, hU0, hA, h0]
+  ring
+
+/-- Base case `U_0 = 1`. -/
+lemma Uexpl_zero : Uexpl 0 = 1 := by
+  simp [Uexpl, term]
+
+/-- Base case `U_1 = 2X`. -/
+lemma Uexpl_one : Uexpl 1 = 2 * X := by
+  simp [Uexpl, term]
+
+/-- **The explicit closed form of the Chebyshev polynomial of the second kind.**
+`U_n(X) = ∑_{k=0}^{⌊n/2⌋} (-1)^k · C(n-k, k) · (2X)^{n-2k}`. -/
+theorem U_eq_Uexpl (n : ℕ) : Polynomial.Chebyshev.U ℤ n = Uexpl n := by
+  induction n using Nat.twoStepInduction with
+  | zero => simp [Uexpl_zero]
+  | one => simp [Uexpl_one]
+  | more n ih1 ih2 =>
+      have h := Polynomial.Chebyshev.U_add_two ℤ (n : ℤ)
+      rw [Uexpl_rec, ← ih1, ← ih2]
+      push_cast
+      push_cast at h
+      exact h
+
+/-- Sanity check: the explicit formula reproduces `U_2 = 4X² - 1`. -/
+example : Uexpl 2 = 4 * X ^ 2 - 1 := by
+  simp only [Uexpl, Finset.sum_range_succ, Finset.sum_range_zero, term]
+  norm_num
+  ring
+
+/-- Sanity check: the explicit formula reproduces `U_4 = 16X⁴ - 12X² + 1`. -/
+example : Uexpl 4 = 16 * X ^ 4 - 12 * X ^ 2 + 1 := by
+  simp only [Uexpl, Finset.sum_range_succ, Finset.sum_range_zero, term]
+  norm_num
+  ring
+
+/-- Consistency: composing with the Mathlib definition, `U_3 = 8X³ - 4X`. -/
+example : Polynomial.Chebyshev.U ℤ ((3 : ℕ) : ℤ) = 8 * X ^ 3 - 4 * X := by
+  rw [U_eq_Uexpl]
+  simp only [Uexpl, Finset.sum_range_succ, Finset.sum_range_zero, term]
+  norm_num
+  ring
+
+end DeMoivreExplicitU

--- a/src/data/proofs/de-moivre-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "ann-dm01010101-definitions",
+    "proofId": "de-moivre-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 65,
+      "endLine": 72
+    },
+    "type": "technique",
+    "title": "The summand and the explicit sum",
+    "content": "The building block `term m k` is $(-1)^k \\binom{m-k}{k}(2X)^{m-2k}$, an element of `Polynomial ℤ`, and `Uexpl n` sums it over $k \\in \\mathrm{range}(\\lfloor n/2\\rfloor + 1)$. Working with a named summand (rather than an inline lambda) is what makes the later termwise recurrence `term_succ_rec` a clean, reusable lemma. Note the binomial coefficient uses the *natural-number* subtraction $m-k$ and the exponent the natural-number subtraction $m-2k$; both are honest values exactly on the summation support and are neutralized off it by the vanishing lemma.",
+    "mathContext": "$\\mathrm{term}(m,k) = (-1)^k \\binom{m-k}{k}(2X)^{m-2k},\\qquad U_{\\mathrm{expl}}(n) = \\sum_{k=0}^{\\lfloor n/2\\rfloor} \\mathrm{term}(n,k).$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Chebyshev polynomials of the second kind",
+      "binomial coefficients",
+      "polynomial ring over ℤ"
+    ],
+    "prerequisites": [
+      "Nat.choose",
+      "Polynomial.X"
+    ]
+  },
+  {
+    "id": "ann-dm01010101-vanishing-range",
+    "proofId": "de-moivre-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 74,
+      "endLine": 90
+    },
+    "type": "technique",
+    "title": "Vanishing tails give a uniform summation range",
+    "content": "`term_eq_zero` observes that when $2k > m$ we have $m - k < k$, so $\\binom{m-k}{k} = 0$ by `Nat.choose_eq_zero_of_lt` and the whole summand collapses. `Uexpl_eq_sum_range` then uses `Finset.sum_subset` to enlarge the summation range from $\\mathrm{range}(\\lfloor n/2\\rfloor+1)$ to any $\\mathrm{range}(N)$ with $N \\ge \\lfloor n/2\\rfloor+1$: the newly included terms are exactly those with $2k > n$, all zero. This is the single move that removes floor arithmetic from the entire development — the recurrence proof can put every sum on a common range and never track $\\lfloor n/2\\rfloor$ again.",
+    "mathContext": "$2k > m \\;\\Rightarrow\\; \\binom{m-k}{k} = 0,\\qquad U_{\\mathrm{expl}}(n) = \\sum_{k \\in \\mathrm{range}(N)} \\mathrm{term}(n,k)\\ \\text{ for any } N \\ge \\lfloor n/2\\rfloor+1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial coefficient vanishing",
+      "Finset.sum_subset",
+      "support of a finite sum"
+    ],
+    "prerequisites": [
+      "Nat.choose_eq_zero_of_lt",
+      "Finset.sum_subset"
+    ]
+  },
+  {
+    "id": "ann-dm01010101-termwise-pascal",
+    "proofId": "de-moivre-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 119
+    },
+    "type": "key-step",
+    "title": "The termwise Pascal recurrence (combinatorial core)",
+    "content": "The crux is `term (n+2) (k+1) = 2X · term (n+1) (k+1) - term n k`, an identity of summands rather than sums. Shifting the index by one is deliberate: it forces every binomial coefficient into the successor shape $\\binom{(n-k)+1}{k+1}$, which `Nat.choose_succ_succ` (Pascal's rule) splits as $\\binom{n-k}{k} + \\binom{n-k}{k+1}$ — the first piece produces $-\\mathrm{term}(n,k)$, the second $2X\\cdot\\mathrm{term}(n+1,k+1)$. A case split governs the exponents: on $n \\ge 2k+1$ all natural-number subtractions are genuine and `push_cast; ring` finishes after rewriting them; on $n \\le 2k$ the $\\mathrm{term}(n+1,k+1)$ factor is a vanishing binomial coefficient, and a further split $n = 2k$ (both survivors are $\\pm 1$) versus $n < 2k$ (both survivors vanish) closes the degenerate boundary.",
+    "mathContext": "$\\binom{(n-k)+1}{k+1} = \\binom{n-k}{k} + \\binom{n-k}{k+1}\\ \\Longrightarrow\\ \\mathrm{term}(n+2,k+1) = 2X\\,\\mathrm{term}(n+1,k+1) - \\mathrm{term}(n,k).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pascal's rule",
+      "index shifting",
+      "case analysis on boundary terms"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_succ",
+      "Nat.choose_eq_zero_of_lt"
+    ]
+  },
+  {
+    "id": "ann-dm01010101-polynomial-recurrence",
+    "proofId": "de-moivre-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 121,
+      "endLine": 146
+    },
+    "type": "key-step",
+    "title": "Lifting the termwise identity to the U-recurrence",
+    "content": "`Uexpl_rec` assembles `Uexpl (n+2) = 2X · Uexpl (n+1) - Uexpl n`. All three sums are first placed on the common range $\\mathrm{range}(n+2)$ via `Uexpl_eq_sum_range`. The $k=0$ term is peeled off the bottom with `Finset.sum_range_succ'` (shifting the remaining indices to $k+1$, exactly where `term_succ_rec` applies), the shifted recurrence is summed under `Finset.sum_congr`, and the pieces are recombined with `Finset.mul_sum` and `Finset.sum_sub_distrib`. The leftover $k=0$ contributions match because $\\mathrm{term}(n+2,0) = (2X)^{n+2} = 2X\\cdot(2X)^{n+1} = 2X\\,\\mathrm{term}(n+1,0)$, and a final `ring` closes the bookkeeping.",
+    "mathContext": "$U_{\\mathrm{expl}}(n+2) = \\Big(\\sum_{k} \\mathrm{term}(n+2,k+1)\\Big) + \\mathrm{term}(n+2,0) = 2X\\,U_{\\mathrm{expl}}(n+1) - U_{\\mathrm{expl}}(n).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_range_succ'",
+      "distributing sums",
+      "three-term recurrence"
+    ],
+    "prerequisites": [
+      "Finset.sum_range_succ'",
+      "Finset.sum_sub_distrib",
+      "Finset.mul_sum"
+    ]
+  },
+  {
+    "id": "ann-dm01010101-main-theorem",
+    "proofId": "de-moivre-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 148,
+      "endLine": 167
+    },
+    "type": "insight",
+    "title": "Two-step induction closes the explicit formula",
+    "content": "Because `Uexpl` matches `U` on the two base cases (`Uexpl_zero`: $U_0 = 1$; `Uexpl_one`: $U_1 = 2X$) and obeys the same second-order recurrence (`Uexpl_rec`), the identity `U ℤ n = Uexpl n` follows by `Nat.twoStepInduction` — the induction principle tailored to recurrences of order two — using Mathlib's `Polynomial.Chebyshev.U_add_two` in the inductive step. This 'same base cases + same recurrence ⟹ same sequence' pattern is what reduces a coefficient-identity question to two small computations and one Pascal step. The result is the explicit closed form $U_n(X) = \\sum_{k=0}^{\\lfloor n/2\\rfloor}(-1)^k\\binom{n-k}{k}(2X)^{n-2k}$ that Mathlib itself does not provide.",
+    "mathContext": "$U_n(X) = \\sum_{k=0}^{\\lfloor n/2\\rfloor} (-1)^k \\binom{n-k}{k}(2X)^{n-2k}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "two-step induction",
+      "characterization by recurrence",
+      "explicit closed form"
+    ],
+    "prerequisites": [
+      "Nat.twoStepInduction",
+      "Polynomial.Chebyshev.U_add_two"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,239 @@
+{
+  "id": "de-moivre-oq-01-oq-01-oq-01-oq-01",
+  "slug": "de-moivre-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Explicit Closed Form of the Chebyshev Polynomial U_n",
+  "description": "Answers the parent entry's leading open question by proving the classical explicit closed form of the Chebyshev polynomial of the second kind, as an identity of integer polynomials: U_n(X) = Σ_{k=0}^{⌊n/2⌋} (-1)^k C(n-k,k) (2X)^{n-2k}. Mathlib defines U by its recurrence and provides no explicit coefficient formula (its source lists this as a TODO), so this is a genuinely new machine-checked closed form. The proof shows the explicit sum obeys the same two base cases (U_0 = 1, U_1 = 2X) and the same recurrence (U_{n+2} = 2X·U_{n+1} - U_n) as U, then concludes by two-step induction. The combinatorial heart is a termwise Pascal recurrence: shifting the summation index by one keeps every binomial coefficient in the form C((n-k)+1, k+1), so Pascal's rule applies directly, with boundary terms vanishing because C(m-k,k) = 0 once 2k > m.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Finset"
+    ],
+    "namespace": "DeMoivreExplicitU",
+    "lineCount": 187,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "path": "Proofs/DeMoivreOQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials",
+    "date": "2026",
+    "dateAdded": "2026-07-01",
+    "status": "verified",
+    "assumptions": "0 axioms, 0 sorries. #print axioms confirms the main theorem U_eq_Uexpl depends only on the foundational propext / Classical.choice / Quot.sound. The explicit closed form is derived by two-step induction (Nat.twoStepInduction) matching Mathlib's Chebyshev-U recurrence (U_add_two) and base cases (U_zero, U_one); the combinatorial core is a termwise Pascal recurrence (Nat.choose_succ_succ) with boundary terms vanishing via Nat.choose_eq_zero_of_lt, assembled with elementary Finset manipulation (sum_subset, sum_range_succ', sum_sub_distrib, mul_sum).",
+    "axiomCount": 0,
+    "definitionCount": 2,
+    "lineCount": 187,
+    "theoremCount": 7,
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "The explicit integer-coefficient closed form U_n(X) = Σ_{k=0}^{⌊n/2⌋} (-1)^k C(n-k,k) (2X)^{n-2k}, proved as an identity of Polynomial ℤ — a formula Mathlib does not provide (its Chebyshev source lists an explicit coefficient formula as an open TODO)",
+      "A termwise Pascal recurrence term (n+2) (k+1) = 2X·term (n+1) (k+1) - term n k, obtained by shifting the summation index so every binomial coefficient takes the successor form C((n-k)+1, k+1) that Pascal's rule consumes directly",
+      "A vanishing-tail lemma (C(m-k,k) = 0 once 2k > m) that lets every sum be taken over a uniform range, eliminating all floor bookkeeping from the recurrence proof",
+      "The polynomial recurrence Uexpl (n+2) = 2X·Uexpl (n+1) - Uexpl n for the explicit sum, assembled from the termwise identity by peeling the k=0 term and redistributing the sums",
+      "The identity U ℤ n = Uexpl n concluded by two-step induction, characterizing U by matching its base cases and second-order recurrence"
+    ],
+    "proofRepoPath": "Proofs/DeMoivreOQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "explicit-formula",
+      "binomial-coefficients",
+      "pascals-rule",
+      "polynomial-identities",
+      "induction",
+      "combinatorics",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Chebyshev.U_add_two",
+        "description": "U_{n+2} = 2X·U_{n+1} - U_n: the defining three-term recurrence of the Chebyshev polynomials of the second kind, matched by the explicit sum",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.U_zero",
+        "description": "U_0 = 1: the first base case of the two-step induction",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.U_one",
+        "description": "U_1 = 2X: the second base case of the two-step induction",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "C(n+1,k+1) = C(n,k) + C(n,k+1): Pascal's rule, applied to C((n-k)+1, k+1) to split each summand into the 2X·U_{n+1} and -U_n contributions",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_eq_zero_of_lt",
+        "description": "n < k → C(n,k) = 0: makes summands with 2k > m vanish, allowing a uniform summation range with no floor bookkeeping",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.twoStepInduction",
+        "description": "Two base cases plus P n → P (n+1) → P (n+2): the induction principle matching the second-order Chebyshev recurrence",
+        "module": "Mathlib.Data.Nat.Init"
+      },
+      {
+        "theorem": "Finset.sum_subset",
+        "description": "Extends a sum to a larger index set when the added terms vanish: the mechanism behind Uexpl_eq_sum_range's uniform range",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Peels the k = 0 term off the bottom of a range sum, shifting the rest to index k+1: aligns the sums for the termwise Pascal recurrence",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_sub_distrib",
+        "description": "Σ(f - g) = Σf - Σg: assembles the shifted termwise identity into the polynomial recurrence Uexpl (n+2) = 2X·Uexpl (n+1) - Uexpl n",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "**An Explicit Formula Mathlib Does Not Have**\n\nThe ancestor entries developed De Moivre's theorem $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$ into explicit binomial expansions of $\\cos(n\\theta)$ (real part, landing on the Chebyshev polynomial $T_n$) and $\\sin(n\\theta)$ (imaginary part, landing on $U_{n-1}$). The immediate parent (De Moivre OQ-01-OQ-01-OQ-01) posed as its leading open question: *can the polynomial coefficients of $U_n$ over $\\mathbb{Z}$ be read off in an explicit closed form, analogous to the $T_n$ coefficient question?*\n\n**The Classical Closed Form**\n\nThe answer is the classical explicit formula\n$$U_n(X) = \\sum_{k=0}^{\\lfloor n/2 \\rfloor} (-1)^k \\binom{n-k}{k} (2X)^{n-2k}.$$\nMathlib defines $U$ purely by its recurrence and, as of the current version, offers **no** explicit coefficient formula — its source file even lists \"Add explicit formula ... for Chebyshev polynomials\" as an open TODO. This entry supplies and machine-checks that formula as an identity of integer polynomials.",
+    "problemStatement": "**The Open Question (from De Moivre OQ-01-OQ-01-OQ-01)**\n\nCan the polynomial coefficients of the Chebyshev polynomial of the second kind $U_n$ over $\\mathbb{Z}$ be read off in an explicit closed form, giving a coefficient formula analogous to the $T_n$ development of the ancestor entries?\n\n**Answer: YES.** We prove\n$$U_n(X) = \\sum_{k=0}^{\\lfloor n/2 \\rfloor} (-1)^k \\binom{n-k}{k} (2X)^{n-2k}$$\nas an identity `U ℤ n = Uexpl n` of `Polynomial ℤ`. The explicit sum is shown to satisfy the same two base cases and the same second-order recurrence as $U$, so the two coincide for every $n$ by two-step induction.",
+    "text": "A constructive formalization of the explicit closed form of the Chebyshev polynomial of the second kind U_n over the integers: U_n(X) = Σ_{k=0}^{⌊n/2⌋} (-1)^k C(n-k,k) (2X)^{n-2k}. The explicit sum matches U's base cases and recurrence, and equality follows by two-step induction; the combinatorial core is a termwise Pascal recurrence with vanishing boundary terms.",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **The summand and the sum** (`term`, `Uexpl`): define `term m k = (-1)^k · C(m-k,k) · (2X)^{m-2k}` and `Uexpl n = Σ_{k ∈ range (⌊n/2⌋+1)} term n k`.\n\n2. **Vanishing tail** (`term_eq_zero`): a summand is zero once $2k > m$, because $C(m-k,k) = 0$ by `Nat.choose_eq_zero_of_lt`.\n\n3. **Uniform range** (`Uexpl_eq_sum_range`): using the vanishing tail via `Finset.sum_subset`, `Uexpl n` may be summed over any range large enough to contain its support — this eliminates all floor arithmetic from the recurrence proof.\n\n4. **Termwise Pascal recurrence** (`term_succ_rec`): the combinatorial heart, `term (n+2) (k+1) = 2X · term (n+1) (k+1) - term n k`. Shifting the index by one keeps every coefficient in the shape $C((n-k)+1, k+1)$, so `Nat.choose_succ_succ` (Pascal's rule) splits it into the two pieces; a case split on $n \\ge 2k+1$ versus $n \\le 2k$ handles genuine versus degenerate (choose-zero) exponents, each closed by `push_cast; ring`.\n\n5. **Polynomial recurrence** (`Uexpl_rec`): put all three sums on a common range, peel the $k=0$ term with `Finset.sum_range_succ'`, apply the termwise recurrence under `Finset.sum_congr`, and reassemble with `Finset.sum_sub_distrib` and `Finset.mul_sum` to obtain `Uexpl (n+2) = 2X · Uexpl (n+1) - Uexpl n`.\n\n6. **Two-step induction** (`Uexpl_zero`, `Uexpl_one`, `U_eq_Uexpl`): `Uexpl` matches `U_zero` and `U_one`, and shares the recurrence, so `Nat.twoStepInduction` with `Polynomial.Chebyshev.U_add_two` gives `U ℤ n = Uexpl n`.",
+    "keyInsights": [
+      "**Shift the index to tame Pascal**: reindexing the sum by $k \\mapsto k+1$ turns every binomial coefficient into the successor form $C((n-k)+1, k+1)$, exactly the shape Pascal's rule `Nat.choose_succ_succ` consumes, so the term-by-term recurrence becomes a one-line algebraic identity rather than a nest of nat-subtraction.",
+      "**Vanishing tails erase the floor**: because $C(m-k,k) = 0$ whenever $2k > m$, the summation range does not have to track $\\lfloor n/2 \\rfloor$ precisely; summing over any large-enough range gives the same polynomial, which removes the even/odd floor casework that usually dominates such proofs.",
+      "**Same base cases + same recurrence = same sequence**: the explicit sum is characterized by matching $U$ on $U_0, U_1$ and on the second-order recurrence; `Nat.twoStepInduction` then does all the work, turning a coefficient-identity question into two computations and one Pascal step.",
+      "**Filling a Mathlib gap**: Mathlib supplies the recurrence, evaluation, and derivative lemmas for $U$ but no explicit coefficient formula (an open TODO in its source); this entry contributes exactly that closed form over $\\mathbb{Z}$, from which the formula over any commutative ring follows by the ring map."
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the second kind U_n and their three-term recurrence U_{n+2} = 2X·U_{n+1} - U_n",
+      "Binomial coefficients and Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1)",
+      "The vanishing condition C(n,k) = 0 for n < k",
+      "Two-step (second-order) induction on the natural numbers",
+      "Finite-sum manipulation: index shifting, range extension, and distributing multiplication and subtraction over sums"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Overview",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Imports Mathlib and states the open question and the explicit closed form U_n(X) = Σ (-1)^k C(n-k,k) (2X)^{n-2k}, noting that Mathlib provides no such coefficient formula.",
+      "mathContext": "The Chebyshev polynomial of the second kind and its recurrence-based Mathlib definition."
+    },
+    {
+      "id": "definitions",
+      "title": "The Summand and the Explicit Sum",
+      "startLine": 65,
+      "endLine": 72,
+      "summary": "Defines term m k = (-1)^k C(m-k,k) (2X)^{m-2k} and Uexpl n as the sum of term n k over k ∈ range(⌊n/2⌋+1).",
+      "mathContext": "$\\mathrm{term}(m,k) = (-1)^k \\binom{m-k}{k}(2X)^{m-2k},\\quad U_{\\mathrm{expl}}(n) = \\sum_{k=0}^{\\lfloor n/2\\rfloor} \\mathrm{term}(n,k).$"
+    },
+    {
+      "id": "vanishing-and-range",
+      "title": "Vanishing Tails and a Uniform Range",
+      "startLine": 74,
+      "endLine": 90,
+      "summary": "Proves a summand vanishes once 2k > m (choose is zero), then that Uexpl n may be summed over any range covering its support — removing all floor bookkeeping from later steps.",
+      "mathContext": "$2k > m \\Rightarrow \\binom{m-k}{k} = 0$, so the range may be freely enlarged."
+    },
+    {
+      "id": "termwise-pascal",
+      "title": "The Termwise Pascal Recurrence",
+      "startLine": 92,
+      "endLine": 119,
+      "summary": "The combinatorial core: term (n+2) (k+1) = 2X·term (n+1) (k+1) - term n k, proved by Pascal's rule after shifting the index by one, with a case split for the degenerate choose-zero boundary.",
+      "mathContext": "$\\binom{(n-k)+1}{k+1} = \\binom{n-k}{k} + \\binom{n-k}{k+1}$ splits each summand into its two contributions."
+    },
+    {
+      "id": "polynomial-recurrence",
+      "title": "The Chebyshev-U Recurrence for Uexpl",
+      "startLine": 121,
+      "endLine": 146,
+      "summary": "Assembles the termwise identity into Uexpl (n+2) = 2X·Uexpl (n+1) - Uexpl n by peeling the k=0 term, summing the shifted recurrence, and reassembling.",
+      "mathContext": "$U_{\\mathrm{expl}}(n+2) = 2X\\,U_{\\mathrm{expl}}(n+1) - U_{\\mathrm{expl}}(n).$"
+    },
+    {
+      "id": "main-theorem",
+      "title": "Base Cases and the Explicit Formula",
+      "startLine": 148,
+      "endLine": 167,
+      "summary": "Verifies Uexpl 0 = 1 and Uexpl 1 = 2X, then proves U ℤ n = Uexpl n by two-step induction using Mathlib's U_add_two.",
+      "mathContext": "$U_n(X) = \\sum_{k=0}^{\\lfloor n/2\\rfloor} (-1)^k \\binom{n-k}{k}(2X)^{n-2k}.$"
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Small-Case Verifications",
+      "startLine": 169,
+      "endLine": 187,
+      "summary": "Concrete checks that the formula reproduces U_2 = 4X² - 1, U_4 = 16X⁴ - 12X² + 1, and U_3 = 8X³ - 4X.",
+      "mathContext": "The explicit sum evaluated at small n recovers the standard Chebyshev polynomials."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent entry's leading open question by providing the explicit $\\mathbb{Z}$-coefficient closed form of $U_n$ whose existence the parent posed after connecting $\\sin(n\\theta)$ to $U_{n-1}$"
+    },
+    {
+      "targetId": "de-moivre-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The grandparent develops the $\\cos(n\\theta)$/$T_n$ side; this entry supplies the matching explicit closed form on the second-kind $U_n$ side"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "The whole $U_n$ thread originates in De Moivre's theorem $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$, whose imaginary part carries the second-kind Chebyshev structure"
+    }
+  ],
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-01-oq-01-oq-01",
+      "relationship": "Directly answers the parent entry's leading open question: the explicit integer-coefficient closed form for U_n, mirroring on the second-kind side the T_n coefficient development of the ancestor entries."
+    },
+    {
+      "id": "de-moivre-oq-01-oq-01",
+      "relationship": "Complements the grandparent's cos(nθ)/T_n binomial expansion with the corresponding explicit U_n closed form, completing the coefficient picture for both kinds of Chebyshev polynomials."
+    }
+  ],
+  "references": [
+    {
+      "authors": "P. L. Chebyshev",
+      "title": "Théorie des mécanismes connus sous le nom de parallélogrammes",
+      "year": "1853",
+      "venue": "Mémoires des Savants étrangers présentés à l'Académie de Saint-Pétersbourg",
+      "note": "Introduced the polynomials T_n and U_n and their recurrences"
+    },
+    {
+      "authors": "T. J. Rivlin",
+      "title": "Chebyshev Polynomials: From Approximation Theory to Algebra and Number Theory",
+      "year": "1990",
+      "venue": "Wiley-Interscience",
+      "note": "Standard reference; gives the explicit closed form U_n(x) = Σ_k (-1)^k C(n-k,k) (2x)^{n-2k}"
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Mathlib.RingTheory.Polynomial.Chebyshev",
+      "year": "2024",
+      "venue": "Lean 4 mathematical library",
+      "note": "Defines U by recurrence; its source lists an explicit coefficient formula as a TODO"
+    }
+  ],
+  "conclusion": {
+    "summary": "The formalization answers the parent entry's leading open question affirmatively: the Chebyshev polynomial of the second kind admits the explicit integer-coefficient closed form U_n(X) = Σ_{k=0}^{⌊n/2⌋} (-1)^k C(n-k,k) (2X)^{n-2k}, proved as an identity of Polynomial ℤ. The proof is complete with 7 theorems/lemmas, 2 definitions, and 0 sorries, verified 0-axiom. The explicit sum is shown to match U's two base cases and its second-order recurrence; equality then follows by Nat.twoStepInduction. The combinatorial core is a termwise Pascal recurrence made tractable by shifting the summation index (so every coefficient sits in Pascal-successor form) and by discarding boundary terms via the vanishing of binomial coefficients.",
+    "implications": "**Theoretical Significance**\n\n1. **A genuinely new closed form**: Mathlib provides the recurrence, evaluation, and derivative lemmas for U_n but no explicit coefficient formula (an open TODO in its source). This entry contributes exactly that formula over ℤ, machine-checked.\n\n2. **Completing the Chebyshev coefficient picture**: paired with the ancestor entries' cos(nθ)/T_n development, both kinds of Chebyshev polynomials now have explicit integer-coefficient closed forms in this gallery.\n\n3. **A reusable proof pattern**: 'characterize by base cases + recurrence, then Nat.twoStepInduction' combined with 'shift the index so Pascal applies and let vanishing coefficients erase the floor' is a general recipe for explicit formulas of second-order integer polynomial recurrences.",
+    "openQuestions": [
+      "Does the explicit U_n formula, differentiated term by term and combined with Mathlib's T_derivative_eq_U (T_n' = n·U_{n-1}), yield an independent machine-checked derivation of the explicit T_n coefficient formula?",
+      "Can the same shift-and-Pascal technique produce the explicit closed form of T_n(X) = (n/2) Σ_k (-1)^k (n-k-1)!/(k!(n-2k)!) (2X)^{n-2k} directly, rather than via the U_n formula?"
+    ]
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the **leading open question** of the parent entry `de-moivre-oq-01-oq-01-oq-01` ("The Binomial Expansion of sin(nθ) and its Chebyshev-U Connection"): *can the polynomial coefficients of `U_n` over `ℤ` be read off in an explicit closed form?*

**Answer: yes.** Proves the classical explicit formula for the Chebyshev polynomial of the second kind as an identity of integer polynomials:

$$U_n(X) = \sum_{k=0}^{\lfloor n/2 \rfloor} (-1)^k \binom{n-k}{k} (2X)^{n-2k}.$$

Mathlib defines `U` purely by its recurrence and (as of v4.26.0) provides **no** explicit coefficient formula — its source file lists "Add explicit formula ... for Chebyshev polynomials" as an open TODO — so this is a genuinely new machine-checked closed form, not a restatement.

## Proof approach

- **Characterize by base cases + recurrence.** The explicit sum `Uexpl n` is shown to match `U` on `U_0 = 1`, `U_1 = 2X`, and on the second-order recurrence `U_{n+2} = 2X·U_{n+1} - U_n`; equality `U ℤ n = Uexpl n` then follows by `Nat.twoStepInduction`.
- **Termwise Pascal recurrence (combinatorial core).** `term (n+2) (k+1) = 2X·term (n+1) (k+1) - term n k`. Shifting the summation index by one forces every binomial coefficient into successor form `C((n-k)+1, k+1)`, which `Nat.choose_succ_succ` (Pascal's rule) splits directly into the two contributions.
- **Vanishing tails erase the floor.** Since `C(m-k,k) = 0` once `2k > m` (`Nat.choose_eq_zero_of_lt`), every sum can be taken over a uniform range, removing all `⌊n/2⌋` bookkeeping from the recurrence proof.

## Verification

- **VERIFIED, 0-axiom, 0-sorry.** `#print axioms U_eq_Uexpl` → `propext, Classical.choice, Quot.sound` only.
- 7 theorems/lemmas, 2 definitions; 187 lines.
- Three concrete sanity checks (`U_2`, `U_3`, `U_4`) reproduce the standard polynomials.
- Typechecks against Mathlib v4.26.0 (Docker containerd was down this session; verified via `lake env lean`).
- Gallery entry ingests cleanly (annotations build, no warnings).

## Files

- `proofs/Proofs/DeMoivreOQ01OQ01OQ01OQ01.lean`
- `src/data/proofs/de-moivre-oq-01-oq-01-oq-01-oq-01/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)