### PR TITLE
research(fibonacci-identities-oq-02-oq-02-oq-01): companion Lucas sequence + doubling law U₂ₙ=Uₙ·Vₙ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02OQ02OQ01.lean
@@ -1,0 +1,165 @@
+import Mathlib
+import Proofs.FibonacciIdentitiesOQ02OQ02
+
+/-
+# The companion Lucas sequence and the doubling law `U_{2n} = Uₙ · Vₙ`
+
+The parent entry `fibonacci-identities-oq-02-oq-02` builds the first-kind Lucas
+sequence `Uₙ(P, Q)` over `ℤ` (`U₀ = 0`, `U₁ = 1`, `U_{n+2} = P·U_{n+1} − Q·Uₙ`)
+and proves the *forward divisibility* law `m ∣ n → Uₘ ∣ Uₙ`.  In particular
+`Uₙ ∣ U_{2n}`, but that theorem gives no information about the cofactor.
+
+This entry answers the open question:
+
+> *What is the explicit cofactor of `Uₙ` in `U_{2n}`?  Is there a companion
+> sequence `Vₙ` with `U_{2n} = Uₙ · Vₙ`?*
+
+We introduce the **second-kind (companion) Lucas sequence** `Vₙ(P, Q)` over `ℤ`
+
+  `V₀ = 2,  V₁ = P,  V_{n+2} = P · V_{n+1} − Q · Vₙ`,
+
+which satisfies `Vₙ(1, −1) = Lₙ` (the Lucas numbers `2, 1, 3, 4, 7, …`), and
+prove the two classical **doubling identities**
+
+  **`U_{2n} = Uₙ · Vₙ`**        (even index),
+  **`U_{2n+1} = U_{n+1}² − Q·Uₙ²`**  (odd index).
+
+The even identity refines the parent's divisibility statement `Uₙ ∣ U_{2n}` by
+naming the exact quotient `Vₙ`.  Both are derived from the parent's
+index-addition law
+
+  `U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ`,
+
+together with the bridge lemma `V_{n+1} = U_{n+2} − Q·Uₙ` expressing the
+companion sequence inside the first-kind sequence.
+
+As a corollary, specialising to `(P, Q) = (1, −1)` recovers Mathlib's
+`Nat.fib_two_mul` (`fib (2n) = fib n · (2·fib (n+1) − fib n)`) from the general
+two-parameter doubling law — an independent proof.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace FibonacciIdentitiesOQ02OQ02OQ01
+
+open FibonacciIdentitiesOQ02OQ02
+
+/-- The **second-kind (companion) Lucas sequence** `Vₙ(P, Q)` over `ℤ`:
+`V₀ = 2`, `V₁ = P`, `V_{n+2} = P · V_{n+1} − Q · Vₙ`.
+For `(P, Q) = (1, −1)` this is the sequence of Lucas numbers. -/
+def lucasV (P Q : ℤ) : ℕ → ℤ
+  | 0 => 2
+  | 1 => P
+  | (n + 2) => P * lucasV P Q (n + 1) - Q * lucasV P Q n
+
+@[simp] theorem lucasV_zero (P Q : ℤ) : lucasV P Q 0 = 2 := rfl
+
+@[simp] theorem lucasV_one (P Q : ℤ) : lucasV P Q 1 = P := rfl
+
+/-- The defining recurrence for `V`, as a rewrite lemma. -/
+theorem lucasV_add_two (P Q : ℤ) (n : ℕ) :
+    lucasV P Q (n + 2) = P * lucasV P Q (n + 1) - Q * lucasV P Q n := rfl
+
+/-- **Bridge lemma.** The companion sequence lives inside the first-kind
+sequence: `V_{n+1} = U_{n+2} − Q · Uₙ`.
+
+Proved by induction carrying the statement for both `n` and `n+1` (both `U` and
+`V` are second-order, so two consecutive instances are needed). -/
+theorem lucasV_succ_eq (P Q : ℤ) (n : ℕ) :
+    lucasV P Q (n + 1) = lucasU P Q (n + 2) - Q * lucasU P Q n := by
+  suffices h : ∀ n,
+      (lucasV P Q (n + 1) = lucasU P Q (n + 2) - Q * lucasU P Q n) ∧
+      (lucasV P Q (n + 2) = lucasU P Q (n + 3) - Q * lucasU P Q (n + 1))
+    from (h n).1
+  intro n
+  induction n with
+  | zero =>
+    refine ⟨?_, ?_⟩
+    · -- `V 1 = U 2 - Q * U 0`, i.e. `P = P - Q * 0`.
+      simp
+    · -- `V 2 = U 3 - Q * U 1`.
+      have hu3 : lucasU P Q 3 = P * lucasU P Q 2 - Q * lucasU P Q 1 := lucasU_add_two P Q 1
+      have hv2 : lucasV P Q 2 = P * lucasV P Q 1 - Q * lucasV P Q 0 := lucasV_add_two P Q 0
+      rw [hv2, hu3]
+      simp [lucasU_two]
+      ring
+  | succ n ih =>
+    obtain ⟨ih1, ih2⟩ := ih
+    refine ⟨ih2, ?_⟩
+    -- Goal: `V (n+3) = U (n+4) - Q * U (n+2)`.
+    have hv : lucasV P Q (n + 3) = P * lucasV P Q (n + 2) - Q * lucasV P Q (n + 1) := by
+      have := lucasV_add_two P Q (n + 1); simpa using this
+    have e2 : lucasU P Q (n + 2) = P * lucasU P Q (n + 1) - Q * lucasU P Q n :=
+      lucasU_add_two P Q n
+    have e3 : lucasU P Q (n + 3) = P * lucasU P Q (n + 2) - Q * lucasU P Q (n + 1) := by
+      have := lucasU_add_two P Q (n + 1); simpa using this
+    have e4 : lucasU P Q (n + 4) = P * lucasU P Q (n + 3) - Q * lucasU P Q (n + 2) := by
+      have := lucasU_add_two P Q (n + 2); simpa using this
+    show lucasV P Q (n + 3) = lucasU P Q (n + 4) - Q * lucasU P Q (n + 2)
+    rw [hv, ih2, ih1, e4, e3, e2]
+    ring
+
+/-- **Even doubling law.** `U_{2n} = Uₙ · Vₙ`.
+
+For `n = 0` both sides vanish.  For `n = j+1`, the parent's index-addition law
+with `(m, n) = (j+1, j)` gives
+`U_{2j+2} = U_{j+2}·U_{j+1} − Q·U_{j+1}·U_j = U_{j+1}·(U_{j+2} − Q·U_j)`,
+and the bracket is `V_{j+1}` by `lucasV_succ_eq`. -/
+theorem lucasU_two_mul (P Q : ℤ) (n : ℕ) :
+    lucasU P Q (2 * n) = lucasU P Q n * lucasV P Q n := by
+  rcases n with _ | j
+  · simp
+  · -- `n = j + 1`.
+    have hidx : 2 * (j + 1) = (j + 1) + j + 1 := by ring
+    have hadd := lucasU_add P Q (j + 1) j
+    -- `U ((j+1)+j+1) = U (j+2) · U (j+1) − Q · U (j+1) · U j`.
+    have hbridge : lucasV P Q (j + 1) = lucasU P Q (j + 2) - Q * lucasU P Q j :=
+      lucasV_succ_eq P Q j
+    rw [hidx, hadd, hbridge]
+    ring
+
+/-- **Odd doubling law.** `U_{2n+1} = U_{n+1}² − Q · Uₙ²`.
+
+Immediate from the index-addition law with `m = n`. -/
+theorem lucasU_two_mul_add_one (P Q : ℤ) (n : ℕ) :
+    lucasU P Q (2 * n + 1) = lucasU P Q (n + 1) ^ 2 - Q * lucasU P Q n ^ 2 := by
+  have hidx : 2 * n + 1 = n + n + 1 := by ring
+  have hadd := lucasU_add P Q n n
+  rw [hidx, hadd]
+  ring
+
+/-! ### Fibonacci / Lucas-number specialisation `(P, Q) = (1, −1)`
+
+We identify `lucasV 1 (-1)` with the closed form `2·fib (n+1) − fib n` (the Lucas
+numbers), then recover Mathlib's `Nat.fib_two_mul` from the general even doubling
+law — an independent proof that does not unfold `Nat.fib_two_mul`. -/
+
+/-- `Vₙ(1, −1) = 2·fib (n+1) − fib n` (the Lucas numbers, cast to `ℤ`). -/
+theorem lucasV_fib (n : ℕ) :
+    lucasV 1 (-1) n = 2 * (Nat.fib (n + 1) : ℤ) - (Nat.fib n : ℤ) := by
+  suffices h : ∀ n,
+      (lucasV 1 (-1) n = 2 * (Nat.fib (n + 1) : ℤ) - (Nat.fib n : ℤ)) ∧
+      (lucasV 1 (-1) (n + 1) = 2 * (Nat.fib (n + 2) : ℤ) - (Nat.fib (n + 1) : ℤ))
+    from (h n).1
+  intro n
+  induction n with
+  | zero => refine ⟨?_, ?_⟩ <;> simp
+  | succ n ih =>
+    obtain ⟨ih0, ih1⟩ := ih
+    refine ⟨ih1, ?_⟩
+    have hv : lucasV 1 (-1) (n + 2) = lucasV 1 (-1) (n + 1) + lucasV 1 (-1) n := by
+      rw [lucasV_add_two]; ring
+    rw [hv, ih0, ih1, Nat.fib_add_two (n := n + 1)]
+    push_cast
+    ring
+
+/-- Mathlib's `Nat.fib_two_mul` recovered from the general even doubling law
+`U_{2n} = Uₙ · Vₙ` at `(P, Q) = (1, −1)`, cast to `ℤ`. -/
+theorem fib_two_mul_via_lucas (n : ℕ) :
+    (Nat.fib (2 * n) : ℤ)
+      = (Nat.fib n : ℤ) * (2 * (Nat.fib (n + 1) : ℤ) - (Nat.fib n : ℤ)) := by
+  have h := lucasU_two_mul 1 (-1) n
+  rw [lucasU_fib, lucasU_fib, lucasV_fib] at h
+  exact h
+
+end FibonacciIdentitiesOQ02OQ02OQ01

--- a/proofs/Proofs/FibonacciIdentitiesOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02OQ02OQ01.lean
@@ -149,9 +149,12 @@ theorem lucasV_fib (n : ℕ) :
     refine ⟨ih1, ?_⟩
     have hv : lucasV 1 (-1) (n + 2) = lucasV 1 (-1) (n + 1) + lucasV 1 (-1) n := by
       rw [lucasV_add_two]; ring
-    rw [hv, ih0, ih1, Nat.fib_add_two (n := n + 1)]
-    push_cast
-    ring
+    have f2 : (Nat.fib (n + 2) : ℤ) = (Nat.fib n : ℤ) + (Nat.fib (n + 1) : ℤ) :=
+      by exact_mod_cast (Nat.fib_add_two : Nat.fib (n + 2) = Nat.fib n + Nat.fib (n + 1))
+    have f3 : (Nat.fib (n + 3) : ℤ) = (Nat.fib (n + 1) : ℤ) + (Nat.fib (n + 2) : ℤ) :=
+      by exact_mod_cast (Nat.fib_add_two : Nat.fib (n + 3) = Nat.fib (n + 1) + Nat.fib (n + 2))
+    rw [hv, ih0, ih1]
+    linarith [f2, f3]
 
 /-- Mathlib's `Nat.fib_two_mul` recovered from the general even doubling law
 `U_{2n} = Uₙ · Vₙ` at `(P, Q) = (1, −1)`, cast to `ℤ`. -/

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,75 @@
+[
+  {
+    "id": "ann-fiboq020201-1",
+    "proofId": "fibonacci-identities-oq-02-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 48 },
+    "type": "concept",
+    "title": "Naming the Cofactor: the Companion Sequence",
+    "content": "**Framing.** The parent entry proves that the first-kind Lucas sequence $U_n(P,Q)$ satisfies $U_n \\mid U_{2n}$, but says nothing about the quotient. Here we name it. Every first-kind sequence has a twin — the *second-kind (companion) sequence* $V_n(P,Q)$ obeying the same recurrence with seed $V_0=2,\\ V_1=P$ — and the two are locked together by the **doubling law** $U_{2n}=U_n\\,V_n$. This is the recurrence analogue of $\\sin 2\\theta = 2\\sin\\theta\\cos\\theta$: the pair $(U,V)$ plays the role of $(\\sin,\\cos)$. For $(P,Q)=(1,-1)$ the companion is the Lucas number sequence $2,1,3,4,7,\\dots$ and the law becomes the classical $F_{2n}=F_n L_n$.",
+    "mathContext": "$U_{2n}=U_n V_n$; the recurrence analogue of $\\sin 2\\theta = 2\\sin\\theta\\cos\\theta$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Second-kind (companion) Lucas sequences",
+      "Doubling identities",
+      "Fibonacci and Lucas numbers",
+      "Second-order linear recurrences"
+    ],
+    "prerequisites": [
+      "The first-kind Lucas sequence Uₙ(P,Q) (parent entry)",
+      "Linear recurrence sequences"
+    ],
+    "tags": ["module-header", "framing", "lucas-sequences", "doubling"]
+  },
+  {
+    "id": "ann-fiboq020201-2",
+    "proofId": "fibonacci-identities-oq-02-oq-02-oq-01",
+    "range": { "startLine": 50, "endLine": 65 },
+    "type": "definition",
+    "title": "The Companion Sequence Vₙ(P,Q)",
+    "content": "**Why a new definition.** Mathlib has neither the first-kind nor the second-kind Lucas sequence, so `lucasV P Q : ℕ → ℤ` is introduced directly by structural recursion on the $n+2$ pattern. The only difference from the parent's `lucasU` is the seed: $V_0=2$ (not $0$) and $V_1=P$ (not $1$). Working over $\\mathbb{Z}$ is again essential, since the recurrence subtracts $Q\\,V_n$. The base and recurrence lemmas `lucasV_zero`, `lucasV_one`, `lucasV_add_two` are all definitional (`rfl`).",
+    "mathContext": "$V_0=2,\\ V_1=P,\\ V_{n+2}=P\\,V_{n+1}-Q\\,V_n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Structural recursion", "Companion sequence seed values"],
+    "prerequisites": ["Recursive definitions on ℕ", "The Lucas recurrence"],
+    "tags": ["definition", "recurrence", "companion"]
+  },
+  {
+    "id": "ann-fiboq020201-3",
+    "proofId": "fibonacci-identities-oq-02-oq-02-oq-01",
+    "range": { "startLine": 68, "endLine": 106 },
+    "type": "technique",
+    "title": "The Bridge Lemma via Conjunction Induction",
+    "content": "**Tying V to U.** The doubling proof needs the companion expressed inside the first-kind sequence: $V_{n+1} = U_{n+2} - Q\\,U_n$. Because *both* $U$ and $V$ are second-order, a single-instance induction stalls — the step needs two consecutive predecessors. So we induct on the conjunction $A(n)\\wedge A(n+1)$. In the successor step, we unfold the $V$-recurrence, substitute both induction hypotheses, then expand every $U_{n+k}$ ($k=2,3,4$) down to $U_{n+1},U_n$ using the $U$-recurrence; the goal collapses to a `ring` identity. **Index hygiene:** the textbook form $V_n = U_{n+1}-Q\\,U_{n-1}$ carries a truncated $n-1$; the $+1$-shifted form used here keeps every subscript a genuine `ℕ` successor, so `Nat.sub` never appears.",
+    "mathContext": "$V_{n+1} = U_{n+2} - Q\\,U_n$, proved by induction on $A(n)\\wedge A(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Conjunction induction", "Second-order recurrences", "Avoiding truncated subtraction"],
+    "prerequisites": ["Induction carrying consecutive instances", "The index-addition law lucasU_add"],
+    "tags": ["technique", "induction", "bridge-lemma"]
+  },
+  {
+    "id": "ann-fiboq020201-4",
+    "proofId": "fibonacci-identities-oq-02-oq-02-oq-01",
+    "range": { "startLine": 108, "endLine": 129 },
+    "type": "key-step",
+    "title": "Both Doubling Laws from One Addition Law",
+    "content": "**The payoff.** The parent's index-addition law $U_{m+n+1}=U_{m+1}U_{n+1}-Q\\,U_mU_n$ yields both doubling identities by choosing the two indices.\n\n- **Odd:** set $m=n$. Then $U_{2n+1}=U_{n+1}^2-Q\\,U_n^2$ — immediate (`lucasU_two_mul_add_one`).\n- **Even:** set $(m,n)=(j+1,j)$, so the sum index is $2j+2=2(j+1)$. This gives $U_{2j+2}=U_{j+2}U_{j+1}-Q\\,U_{j+1}U_j = U_{j+1}(U_{j+2}-Q\\,U_j)$, and the bracket is $V_{j+1}$ by the bridge lemma. The $n=0$ case is $0=0$. So $U_{2n}=U_n V_n$ (`lucasU_two_mul`).\n\nBoth hold for **every** $P,Q:\\mathbb{Z}$ — the even law refines the parent's divisibility $U_n \\mid U_{2n}$ to an identity with the explicit quotient $V_n$.",
+    "mathContext": "$U_{2n+1}=U_{n+1}^2-Q\\,U_n^2$ (m=n); $U_{2n}=U_n V_n$ (m=n+1, factor, apply bridge).",
+    "significance": "key",
+    "relatedConcepts": ["Index-addition law", "Doubling identities", "Divisibility refinement"],
+    "prerequisites": ["lucasU_add (parent)", "The bridge lemma lucasV_succ_eq"],
+    "tags": ["key-step", "doubling", "factoring"]
+  },
+  {
+    "id": "ann-fiboq020201-5",
+    "proofId": "fibonacci-identities-oq-02-oq-02-oq-01",
+    "range": { "startLine": 131, "endLine": 166 },
+    "type": "key-step",
+    "title": "Lucas Numbers and Recovering Nat.fib_two_mul",
+    "content": "**The (1,−1) instance.** Specializing $(P,Q)=(1,-1)$, the companion recurrence becomes $V_{n+2}=V_{n+1}+V_n$ with $V_0=2,V_1=1$ — the Lucas numbers $2,1,3,4,7,11,\\dots$. We prove the closed form $V_n(1,-1)=2F_{n+1}-F_n$ (`lucasV_fib`) by conjunction induction against `Nat.fib_add_two` (the finishing step is a `linarith` over the two Fibonacci recurrence instances). Transporting the even doubling law across the parent's `lucasU_fib` ($U_n(1,-1)=F_n$) and this identity yields $F_{2n}=F_n\\,(2F_{n+1}-F_n)$ — exactly Mathlib's `Nat.fib_two_mul`, obtained here as a corollary of the general two-parameter law rather than by unfolding Mathlib's proof.",
+    "mathContext": "$V_n(1,-1)=2F_{n+1}-F_n=L_n$, so $F_{2n}=F_n(2F_{n+1}-F_n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lucas numbers", "Fibonacci doubling", "Independent cross-check"],
+    "prerequisites": ["lucasU_fib (parent)", "Nat.fib_add_two", "Nat.fib_two_mul"],
+    "tags": ["key-step", "specialization", "fibonacci", "lucas-numbers"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "fibonacci-identities-oq-02-oq-02-oq-01",
+  "slug": "fibonacci-identities-oq-02-oq-02-oq-01",
+  "title": "The Companion Lucas Sequence and the Doubling Law U₂ₙ = Uₙ·Vₙ",
+  "sorries": 0,
+  "leanFile": {
+    "imports": ["Mathlib", "Proofs.FibonacciIdentitiesOQ02OQ02"],
+    "opens": ["FibonacciIdentitiesOQ02OQ02"],
+    "namespace": "FibonacciIdentitiesOQ02OQ02OQ01",
+    "lineCount": 168,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/FibonacciIdentitiesOQ02OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Édouard Lucas / classical Lucas-sequence theory; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_sequence#Other_relations",
+    "date": "1878",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "lucas-sequences",
+      "fibonacci",
+      "lucas-numbers",
+      "companion-sequence",
+      "doubling-identity",
+      "recurrence",
+      "integer-sequences",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ02OQ02OQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n+2) = fib n + fib (n+1) — the Fibonacci recurrence, used to identify Vₙ(1,−1) with the closed form 2·fib(n+1) − fib n (the Lucas numbers)",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_two_mul",
+        "description": "fib (2n) = fib n · (2·fib(n+1) − fib n) — recovered here as a corollary of the general even doubling law at (P,Q)=(1,−1); named only to state the cross-check, not used in the proof",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ],
+    "originalContributions": [
+      "lucasV: the second-kind (companion) Lucas sequence Vₙ(P,Q) over ℤ (V₀=2, V₁=P, V_{n+2}=P·V_{n+1}−Q·Vₙ) defined from scratch, completing the parent's first-kind sequence Uₙ — Mathlib has neither",
+      "lucasV_succ_eq: the bridge identity V_{n+1} = U_{n+2} − Q·Uₙ expressing the companion sequence inside the first-kind sequence, proved by conjunction induction carrying n and n+1 (both sequences are second-order)",
+      "lucasU_two_mul: the even doubling law U_{2n} = Uₙ·Vₙ for ALL P,Q : ℤ, refining the parent's divisibility statement Uₙ ∣ U_{2n} by naming the exact cofactor Vₙ; derived from the parent's index-addition law and the bridge lemma",
+      "lucasU_two_mul_add_one: the odd doubling law U_{2n+1} = U_{n+1}² − Q·Uₙ², immediate from the index-addition law at m=n",
+      "lucasV_fib + fib_two_mul_via_lucas: Vₙ(1,−1) = 2·fib(n+1) − fib n (the Lucas numbers), and Mathlib's Nat.fib_two_mul recovered from the general two-parameter doubling law as an independent proof"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 168,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No native_decide, so no Lean.ofReduceBool. Builds on the parent entry fibonacci-identities-oq-02-oq-02 (imported), whose lucasU and lucasU_add are themselves 0-axiom.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Every first-kind Lucas sequence Uₙ(P,Q) has a twin, the second-kind (companion) sequence Vₙ(P,Q), obeying the same recurrence with the different seed V₀=2, V₁=P. Lucas (1878) built his theory on the interplay of the two: the pair (U,V) behaves like (sin, cos) for the recurrence, and the doubling law U_{2n}=Uₙ·Vₙ is the recurrence analogue of sin 2θ = 2 sin θ cos θ. For (P,Q)=(1,−1) the companion is the Lucas number sequence 2,1,3,4,7,11,… and the doubling law becomes the classical fib(2n)=fib(n)·L(n). Mathlib has fib and even Nat.fib_two_mul, but no general Lucas sequences and no companion sequence, so the two-parameter statement had no formal home.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-02-oq-02, follow-up)**: The parent proves Uₙ ∣ U_{2n} but says nothing about the quotient. What is the explicit cofactor of Uₙ in U_{2n}? Is there a companion sequence Vₙ with U_{2n} = Uₙ·Vₙ?\n\n**Result**: Yes. Introducing the second-kind Lucas sequence Vₙ(P,Q) (V₀=2, V₁=P, same recurrence), the even doubling law U_{2n} = Uₙ·Vₙ holds for every P,Q : ℤ (lucasU_two_mul), alongside the odd law U_{2n+1} = U_{n+1}² − Q·Uₙ² (lucasU_two_mul_add_one). Specializing (P,Q)=(1,−1) recovers Mathlib's Nat.fib_two_mul.",
+    "text": "Define Vₙ(P,Q) over ℤ by V₀=2, V₁=P, V_{n+2}=P·V_{n+1}−Q·Vₙ. Then for all P,Q and all n: U_{2n} = Uₙ·Vₙ and U_{2n+1} = U_{n+1}² − Q·Uₙ². The bridge V_{n+1}=U_{n+2}−Q·Uₙ ties the companion sequence to the first-kind sequence. Specializing (P,Q)=(1,−1) gives Vₙ = the Lucas numbers 2·fib(n+1)−fib n and recovers fib(2n)=fib(n)·(2·fib(n+1)−fib n).",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Companion sequence (lucasV).** Define Vₙ(P,Q) by structural recursion on the n+2 pattern with seed V₀=2, V₁=P. Base and recurrence lemmas are definitional (`rfl`).\n\n2. **Bridge lemma (lucasV_succ_eq).** V_{n+1} = U_{n+2} − Q·Uₙ. Both U and V are second-order, so a single-instance induction stalls; we induct on the conjunction 'A(n) ∧ A(n+1)'. In the step, unfolding the V-recurrence and both induction hypotheses, then expanding every Uₙ₊ₖ down to Uₙ₊₁, Uₙ via the U-recurrence, reduces the goal to a `ring` identity.\n\n3. **Even doubling (lucasU_two_mul).** For n=0 both sides vanish. For n=j+1, the parent's index-addition law U_{m+n+1}=U_{m+1}·U_{n+1}−Q·Uₘ·Uₙ at (m,n)=(j+1,j) gives U_{2j+2} = U_{j+2}·U_{j+1} − Q·U_{j+1}·U_j = U_{j+1}·(U_{j+2}−Q·U_j), and the bracket is V_{j+1} by the bridge lemma. A single `ring` after these rewrites closes it.\n\n4. **Odd doubling (lucasU_two_mul_add_one).** The index-addition law at m=n directly gives U_{2n+1}=U_{n+1}²−Q·Uₙ².\n\n5. **Fibonacci/Lucas specialization.** Vₙ(1,−1)=2·fib(n+1)−fib n by conjunction induction against fib_add_two (lucasV_fib). Transporting the even doubling law across lucasU_fib (from the parent) and lucasV_fib recovers Nat.fib_two_mul over ℤ (fib_two_mul_via_lucas), never unfolding Mathlib's proof.",
+    "keyInsights": [
+      "**The cofactor of Uₙ in U_{2n} is exactly the companion Vₙ.** The parent's divisibility Uₙ ∣ U_{2n} is silent about the quotient; naming it Vₙ upgrades a divisibility fact to an identity, and does so uniformly in (P,Q).",
+      "**One index-addition law yields both doubling laws.** Setting the two indices equal (m=n) gives the odd law immediately; offsetting them by one (m=n+1, n=n) and factoring gives the even law. No separate machinery is needed — everything rides on the parent's lucasU_add.",
+      "**The bridge V_{n+1}=U_{n+2}−Q·Uₙ avoids nat subtraction.** The textbook form Vₙ=U_{n+1}−Q·U_{n−1} has a truncated n−1; shifting the index by one keeps every subscript a genuine ℕ successor, so the conjunction induction never touches Nat.sub.",
+      "**Doubling is the recurrence analogue of sin 2θ = 2 sinθ cosθ.** (U,V) plays the role of (sin,cos): U_{2n}=Uₙ·Vₙ mirrors the double-angle formula, and the (1,−1) instance is the classical fib(2n)=fib(n)·L(n)."
+    ],
+    "prerequisites": [
+      "The first-kind Lucas sequence Uₙ(P,Q) and its index-addition law (parent entry)",
+      "Second-order linear recurrences and companion sequences",
+      "Induction carrying a conjunction of consecutive instances",
+      "Fibonacci and Lucas numbers; the recurrence fib(n+2)=fib n + fib(n+1)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "companion-definition",
+      "title": "The Companion Lucas Sequence Vₙ",
+      "startLine": 50,
+      "endLine": 65,
+      "summary": "lucasV P Q : ℕ → ℤ with V₀=2, V₁=P, V_{n+2}=P·V_{n+1}−Q·Vₙ, plus the base-value and recurrence rewrite lemmas (lucasV_zero/one, lucasV_add_two).",
+      "mathContext": "$V_0=2,\\ V_1=P,\\ V_{n+2}=P\\,V_{n+1}-Q\\,V_n$."
+    },
+    {
+      "id": "bridge-lemma",
+      "title": "The Bridge V_{n+1} = U_{n+2} − Q·Uₙ",
+      "startLine": 68,
+      "endLine": 106,
+      "summary": "lucasV_succ_eq: the companion sequence expressed inside the first-kind sequence, by conjunction induction on n carrying the statement at n and n+1.",
+      "mathContext": "$V_{n+1} = U_{n+2} - Q\\,U_n$."
+    },
+    {
+      "id": "doubling-laws",
+      "title": "The Doubling Laws",
+      "startLine": 108,
+      "endLine": 129,
+      "summary": "lucasU_two_mul (U_{2n} = Uₙ·Vₙ, from the index-addition law + bridge) and lucasU_two_mul_add_one (U_{2n+1} = U_{n+1}² − Q·Uₙ², from the index-addition law at m=n), for all P,Q.",
+      "mathContext": "$U_{2n} = U_n V_n,\\quad U_{2n+1} = U_{n+1}^2 - Q\\,U_n^2$."
+    },
+    {
+      "id": "fibonacci-specialization",
+      "title": "Lucas Numbers and Nat.fib_two_mul",
+      "startLine": 131,
+      "endLine": 166,
+      "summary": "lucasV_fib (Vₙ(1,−1) = 2·fib(n+1) − fib n, the Lucas numbers) and fib_two_mul_via_lucas, recovering Mathlib's Nat.fib_two_mul from the general even doubling law.",
+      "mathContext": "$V_n(1,-1) = 2F_{n+1}-F_n = L_n$, so $F_{2n} = F_n L_n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "The parent builds the first-kind sequence Uₙ(P,Q) and proves Uₙ ∣ U_{2n}; this entry adds the companion Vₙ and names the exact cofactor, U_{2n} = Uₙ·Vₙ, reusing the parent's index-addition law lucasU_add."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-02-oq-01",
+      "relationship": "related",
+      "description": "The Lucas numbers Lₙ studied there are exactly Vₙ(1,−1); this entry places them in the two-parameter family and derives the doubling law fib(2n)=fib(n)·Lₙ as a special case."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lucas, Édouard",
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "venue": "American Journal of Mathematics",
+      "note": "Origin of the paired sequences Uₙ(P,Q), Vₙ(P,Q) and the doubling identities"
+    },
+    {
+      "authors": "Ribenboim, Paulo",
+      "title": "My Numbers, My Friends: Popular Lectures on Number Theory",
+      "year": "2000",
+      "venue": "Springer",
+      "note": "Ch. 1 on the first- and second-kind Lucas sequences and their algebraic relations"
+    }
+  ],
+  "conclusion": {
+    "summary": "The second-kind companion Lucas sequence Vₙ(P,Q) over ℤ, with the bridge V_{n+1}=U_{n+2}−Q·Uₙ and the two classical doubling laws U_{2n}=Uₙ·Vₙ and U_{2n+1}=U_{n+1}²−Q·Uₙ², proved for every parameter choice (0 sorries, 0 axioms). Specializing (P,Q)=(1,−1) identifies Vₙ with the Lucas numbers and recovers Mathlib's Nat.fib_two_mul as an independent corollary.",
+    "implications": "Upgrades the parent's divisibility fact Uₙ ∣ U_{2n} to the exact identity U_{2n}=Uₙ·Vₙ, introduces the companion sequence Vₙ that Mathlib lacks, and exhibits the classical fib(2n)=fib(n)·L(n) as the (1,−1) instance of a uniform two-parameter law.",
+    "openQuestions": [
+      "Prove the companion doubling law V_{2n} = Vₙ² − 2·Qⁿ and the mixed law U_{2n} = Uₙ·Vₙ's partner U_{m+n} = Uₘ·U_{n+1} − Q·Uₘ₋₁·Uₙ, completing the standard doubling/addition toolkit for (U,V).",
+      "Establish the Pell-like identity Vₙ² − D·Uₙ² = 4·Qⁿ (with D = P² − 4Q), the recurrence analogue of cos²+sin²=1, linking the companion sequence to the discriminant of the characteristic equation."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to **fibonacci-identities-oq-02-oq-02** (the parent proves the first-kind Lucas sequence Uₙ(P,Q) satisfies Uₙ ∣ U₂ₙ but says nothing about the quotient). This entry **names the cofactor**.

Introduces the **second-kind (companion) Lucas sequence** Vₙ(P,Q) over ℤ (V₀=2, V₁=P, same recurrence) and proves the two classical **doubling identities** for the entire two-parameter family:

- **Even:** `U₂ₙ = Uₙ · Vₙ`  — refines the parent's divisibility Uₙ ∣ U₂ₙ to an identity with explicit quotient Vₙ
- **Odd:**  `U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ²`

Both are derived from the parent's index-addition law `lucasU_add`, together with the bridge lemma `Vₙ₊₁ = Uₙ₊₂ − Q·Uₙ` (conjunction induction, +1-shifted to avoid ℕ subtraction).

Specializing `(P,Q)=(1,−1)` identifies Vₙ with the **Lucas numbers** 2·fib(n+1)−fib n and recovers Mathlib's `Nat.fib_two_mul` as an independent corollary.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound`
- No `native_decide` → no `Lean.ofReduceBool`
- 8 theorems, 1 definition, 168 lines
- Built clean (0 errors, 0 warnings) against Mathlib v4.26.0 via `lake env lean` (Docker image build broken locally — containerd I/O error)

## Files

- `proofs/Proofs/FibonacciIdentitiesOQ02OQ02OQ01.lean`
- `src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)