### PR TITLE
Enrich Elliott–Halberstam OQ-02: band decomposition, convex cone, dyadic ascent, von-Mangoldt grounding

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-02/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-02/annotations.json
@@ -89,5 +89,149 @@
       "Real.log_pos",
       "Real.rpow_pos_of_pos"
     ]
+  },
+  {
+    "id": "ann-bpg-oq02-concrete-functional",
+    "proofId": "bounded-prime-gaps-oq-02",
+    "range": {
+      "startLine": 186,
+      "endLine": 249
+    },
+    "type": "definition",
+    "title": "The Canonical Concrete Functional — Level-Monotonicity Proved, Not Assumed",
+    "content": "`discrepancySum f θ x = Σ_{q ∈ [1, ⌊x^θ⌋]} f q x` is the canonical *shape* of the Elliott–Halberstam sum: a sum of nonnegative per-modulus weights over the moduli `q ≤ x^θ`. Its level-monotonicity — the one structural fact the abstract hierarchy takes as a hypothesis — is here *proved* (`discrepancySum_mono_level`): on `x ≥ 1`, `x^·` is monotone, so `θ₁ ≤ θ₂` gives `⌊x^θ₁⌋ ≤ ⌊x^θ₂⌋` (via `Nat.floor_le_floor` ∘ `Real.rpow_le_rpow_of_exponent_le`), and the extra terms are nonnegative (`Finset.sum_le_sum_of_subset_of_nonneg`). The base-**clamped** variant `discrepancySumClamped` (base `max 1 x`) coincides with the canonical sum on `x ≥ 1` yet is level-monotone for *every* real `x`, giving a generally nonzero global model of `LevelMonotone` to which the hierarchy `EHAtLevel_of_le` applies non-vacuously.",
+    "mathContext": "$\\mathrm{discrepancySum}(f,\\theta,x)=\\sum_{q=1}^{\\lfloor x^\\theta\\rfloor} f(q,x)$. For $f\\ge 0$ and $x\\ge 1$: $\\theta_1\\le\\theta_2 \\Rightarrow \\lfloor x^{\\theta_1}\\rfloor\\le\\lfloor x^{\\theta_2}\\rfloor \\Rightarrow \\mathrm{discrepancySum}(f,\\theta_1,x)\\le\\mathrm{discrepancySum}(f,\\theta_2,x)$. The clamp $\\max(1,x)$ extends this to all $x$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "level of distribution",
+      "monotone real power function",
+      "Finset.Icc sums",
+      "Nat.floor"
+    ],
+    "prerequisites": [
+      "Finset.sum_le_sum_of_subset_of_nonneg",
+      "Real.rpow_le_rpow_of_exponent_le",
+      "Nat.floor_le_floor"
+    ]
+  },
+  {
+    "id": "ann-bpg-oq02-exact-band",
+    "proofId": "bounded-prime-gaps-oq-02",
+    "range": {
+      "startLine": 251,
+      "endLine": 292
+    },
+    "type": "theorem",
+    "title": "Exact Level Increment: Monotonicity Upgraded to an Identity",
+    "content": "The `discrepancyBand f θ₁ θ₂ x = Σ_{⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋} f q x` isolates the contribution of exactly the *new* moduli that level `θ₂` admits over `θ₁`. The key result `discrepancySum_eq_add_band` sharpens the monotonicity inequality into an equality with explicit defect: on `x ≥ 1`, `discrepancySum f θ₂ x = discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x`. The proof converts the `Icc 1 m` ranges to `Ioc 0 m` (an `omega`-checked reindex) and applies `Finset.sum_Ioc_consecutive`. Monotonicity (`discrepancySum_mono_level_of_band`) then falls out as a one-line corollary of `discrepancyBand_nonneg`, localizing all inter-level growth to the band.",
+    "mathContext": "$\\mathrm{discrepancyBand}(f,\\theta_1,\\theta_2,x)=\\sum_{\\lfloor x^{\\theta_1}\\rfloor < q\\le \\lfloor x^{\\theta_2}\\rfloor} f(q,x)$; for $x\\ge 1,\\ \\theta_1\\le\\theta_2$: $\\mathrm{discrepancySum}(f,\\theta_2,x)=\\mathrm{discrepancySum}(f,\\theta_1,x)+\\mathrm{discrepancyBand}(f,\\theta_1,\\theta_2,x)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "telescoping / consecutive interval sums",
+      "Finset.Ioc",
+      "exact defect decomposition"
+    ],
+    "prerequisites": [
+      "Finset.sum_Ioc_consecutive",
+      "Finset.sum_nonneg"
+    ]
+  },
+  {
+    "id": "ann-bpg-oq02-convex-cone",
+    "proofId": "bounded-prime-gaps-oq-02",
+    "range": {
+      "startLine": 294,
+      "endLine": 364
+    },
+    "type": "theorem",
+    "title": "The EH-Bound Class Is a Convex Cone; Ascending a Level",
+    "content": "At a fixed level `θ` the functionals satisfying the EH bound form a convex cone: `EHAtLevel_add` (sum, constant `C₁+C₂`), `EHAtLevel_smul` (nonnegative scaling `c·D`, constant `c·C+1` — the `+1` keeps the constant strictly positive when `c=0`), and their combination `EHAtLevel_nonneg_linear`. This is the algebraic engine of the analytic program: the genuine discrepancy naturally decomposes into pieces (major/minor arcs, dyadic ranges), and cone closure says bounding each piece suffices. Building on it, `EHAtLevel_discrepancySum_up` gives the *ascent* dual to the hierarchy's descent: EH at level `θ₁` plus an EH-type bound on the new-moduli band `⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋` yields EH at the higher level `θ₂` — pinning the band as exactly the extra analytic input needed to raise the level of distribution.",
+    "mathContext": "Closure: $D_1,D_2$ at level $\\theta$ with $C_1,C_2 \\Rightarrow D_1+D_2$ with $C_1+C_2$; $cD$ ($c\\ge 0$) with $cC+1$. Ascent: $\\mathrm{EH}(\\theta_1) \\wedge \\mathrm{band\\text{-}bound}(\\theta_1,\\theta_2) \\Rightarrow \\mathrm{EH}(\\theta_2)$ with constant $C_1+C_2$, via the exact band decomposition.",
+    "significance": "key",
+    "relatedConcepts": [
+      "convex cone",
+      "major/minor arc decomposition",
+      "dyadic decomposition of moduli",
+      "level of distribution"
+    ],
+    "prerequisites": [
+      "mul_le_mul_of_nonneg_left",
+      "convex cone closure",
+      "discrepancySum_eq_add_band"
+    ]
+  },
+  {
+    "id": "ann-bpg-oq02-band-subdivision",
+    "proofId": "bounded-prime-gaps-oq-02",
+    "range": {
+      "startLine": 366,
+      "endLine": 423
+    },
+    "type": "theorem",
+    "title": "Band Cocycle (Chasles) and the Dyadic Split",
+    "content": "The new-moduli band is itself additive. `discrepancyBand_self` records the empty base case (from a level to itself there are no new moduli, so the band vanishes via `Finset.Ioc_self`), and `discrepancyBand_add_consecutive` is the cocycle / Chasles identity: for `θ₁ ≤ θ₂ ≤ θ₃` on `x ≥ 1`, `band θ₁ θ₃ = band θ₁ θ₂ + band θ₂ θ₃` (again `Finset.sum_Ioc_consecutive`). `EHAtLevel_discrepancySum_up_split` then raises the level from `θ₁` to `θ₃` using only EH-type bounds on the two consecutive sub-bands: the cocycle splits the full band, and the convex-cone closure (`EHAtLevel_add`) recombines the sub-band bounds. This is the formal statement that the modulus range may be attacked dyadically — the standard analytic strategy for Elliott–Halberstam.",
+    "mathContext": "$\\mathrm{band}(\\theta_1,\\theta_3)=\\mathrm{band}(\\theta_1,\\theta_2)+\\mathrm{band}(\\theta_2,\\theta_3)$ for $\\theta_1\\le\\theta_2\\le\\theta_3,\\ x\\ge 1$; $\\mathrm{band}(\\theta,\\theta)=0$. Hence $\\mathrm{EH}(\\theta_1)\\wedge \\mathrm{bound}(\\theta_1,\\theta_2)\\wedge \\mathrm{bound}(\\theta_2,\\theta_3)\\Rightarrow \\mathrm{EH}(\\theta_3)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cocycle / Chasles identity",
+      "dyadic decomposition",
+      "Finset.Ioc_self",
+      "divide and conquer"
+    ],
+    "prerequisites": [
+      "Finset.sum_Ioc_consecutive",
+      "EHAtLevel_add",
+      "EHAtLevel_discrepancySum_up"
+    ]
+  },
+  {
+    "id": "ann-bpg-oq02-dyadic-chain",
+    "proofId": "bounded-prime-gaps-oq-02",
+    "range": {
+      "startLine": 425,
+      "endLine": 499
+    },
+    "type": "theorem",
+    "title": "Finite Dyadic Chain: Ascent over Arbitrarily Many Sub-Bands",
+    "content": "The two-band split is only the first instance of the real strategy, which splits `q ≤ x^θ` into `≍ log x` dyadic blocks. `EHAtLevel_discrepancySum_up_chain` iterates the single-band ascent along an arbitrary monotone level chain `L : ℕ → ℝ`: EH at the base `L 0` plus an EH-type bound on every consecutive band `L k → L(k+1)` lifts EH to *every* level `L n` (induction; `n=2` recovers the split lemma). `EHAtLevel_discrepancySum_up_arith` specializes to the equipartition chain `L k = θ₀ + k·δ` (`δ ≥ 0`, with `Monotone L` discharged from `δ ≥ 0`), and `EHAtLevel_discrepancySum_up_target` packages this to reach a *prescribed* endpoint `θ ≥ θ₀` in a chosen `n ≥ 1` equal blocks by fixing `δ = (θ−θ₀)/n` and discharging the `θ₀ + n·δ = θ` algebra internally (`field_simp; ring`).",
+    "mathContext": "Chain: $\\mathrm{EH}(L\\,0)\\wedge\\big(\\forall k,\\ \\mathrm{bound}(L\\,k,L(k{+}1))\\big)\\Rightarrow \\forall n,\\ \\mathrm{EH}(L\\,n)$ for monotone $L$. Equipartition: $L\\,k=\\theta_0+k\\delta$, and $\\delta=(\\theta-\\theta_0)/n$ reaches the exact target $\\theta\\ge\\theta_0$ in $n$ blocks.",
+    "significance": "key",
+    "relatedConcepts": [
+      "dyadic decomposition",
+      "induction on chains",
+      "equipartition of the modulus range",
+      "Monotone sequences"
+    ],
+    "prerequisites": [
+      "Nat.rec / induction",
+      "EHAtLevel_discrepancySum_up",
+      "field_simp"
+    ]
+  },
+  {
+    "id": "ann-bpg-oq02-vonmangoldt",
+    "proofId": "bounded-prime-gaps-oq-02",
+    "range": {
+      "startLine": 501,
+      "endLine": 659
+    },
+    "type": "definition",
+    "title": "Grounding in the Genuine von-Mangoldt Discrepancy",
+    "content": "The abstract weight `f` is finally instantiated with the *genuine* Elliott–Halberstam summand. `psiAP q a x = Σ_{n ≤ ⌊x⌋, n ≡ a (q)} Λ(n)` is Chebyshev's ψ in the progression `a mod q` (Mathlib's `ArithmeticFunction.vonMangoldt`); `apDiscrepancy q a x = |ψ(x;q,a) − x/φ(q)|` the per-residue defect against its main term `x/φ(q)` (`Nat.totient`); and `vonMangoldtWeight q x = max_{(a,q)=1} apDiscrepancy q a x` (or `0` for the degenerate `q=0`) the worst-case discrepancy — exactly the real EH summand. `vonMangoldtWeight_nonneg` proves it nonnegative (a max/`0` of absolute values, via `Finset.le_sup'`), discharging the *sole* structural hypothesis the whole framework needs. Consequently `vonMangoldtDiscrepancySum θ x = Σ_{q ≤ x^θ} max_{(a,q)=1}|ψ(x;q,a) − x/φ(q)|` inherits — with no further work — level-monotonicity, the exact band decomposition, EH ⟹ BV, the convex-cone closure, and the full dyadic/equipartition ascent, converting the skeleton into statements about the genuine object of the conjecture.",
+    "mathContext": "$\\mathrm{vonMangoldtWeight}(q,x)=\\max_{(a,q)=1}\\big|\\psi(x;q,a)-x/\\varphi(q)\\big|\\ge 0$, with $\\psi(x;q,a)=\\sum_{n\\le x,\\ n\\equiv a\\,(q)}\\Lambda(n)$. Then $\\mathrm{vonMangoldtDiscrepancySum}(\\theta,x)=\\sum_{q\\le x^\\theta}\\mathrm{vonMangoldtWeight}(q,x)$ is the actual level-$\\theta$ EH sum, and every structural theorem specializes to it.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "von Mangoldt function Λ",
+      "Chebyshev ψ in arithmetic progressions",
+      "Euler totient φ",
+      "worst-case discrepancy",
+      "Finset.sup'"
+    ],
+    "prerequisites": [
+      "ArithmeticFunction.vonMangoldt",
+      "Nat.totient",
+      "Finset.le_sup'",
+      "abs_nonneg"
+    ]
   }
 ]

--- a/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
@@ -103,7 +103,11 @@
       "The level hierarchy is a one-line le_trans: the SAME constant C from a higher level works verbatim at every lower level for a level-monotone functional.",
       "EH ⟹ BV is the θ = 1/2 instance; more strongly, any level ≥ 1/2 bound already implies BV via the hierarchy.",
       "EH is equivalent to its restriction to levels in [1/2, 1): the lower range descends from the BV-strength θ = 1/2 bound.",
-      "The zero functional satisfies the full hierarchy with C = 1, certifying that the predicates are satisfiable rather than vacuously empty."
+      "The zero functional satisfies the full hierarchy with C = 1, certifying that the predicates are satisfiable rather than vacuously empty.",
+      "Monotonicity is sharpened to an exact identity: discrepancySum θ₂ = discrepancySum θ₁ + discrepancyBand θ₁ θ₂, localizing the entire inter-level growth to the band of new moduli ⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋. The inequality is then a one-line corollary of the band's nonnegativity.",
+      "The functionals meeting the level-θ bound form a convex cone (closed under addition and nonnegative scaling), so the analytic task of bounding the whole discrepancy reduces to bounding each additive piece — the algebraic reason a divide-and-conquer of the modulus range is legitimate.",
+      "The band cocycle (Chasles) identity band θ₁ θ₃ = band θ₁ θ₂ + band θ₂ θ₃ subdivides the new-moduli range at any intermediate level, and the ascent lemmas turn this into the formal license for dyadic decomposition: EH at a base level plus EH-type bounds on each consecutive sub-band lifts the level of distribution to the top of an arbitrarily long chain (equipartition reaches any target θ in n equal blocks).",
+      "The abstract skeleton is grounded in the genuine object: instantiating f with the von-Mangoldt weight max_{(a,q)=1}|ψ(x;q,a)−x/φ(q)| (from Mathlib's ArithmeticFunction.vonMangoldt and Nat.totient) discharges the only structural hypothesis (nonnegativity) automatically, so level-monotonicity, the band decomposition, EH ⟹ BV, and the dyadic ascent all specialize to the actual Elliott–Halberstam sum with no further assumptions."
     ],
     "prerequisites": [
       "Analytic number theory (level of distribution)",
@@ -142,6 +146,54 @@
       "startLine": 135,
       "endLine": 154,
       "mathContext": "$D\\equiv 0$ is level-monotone and satisfies $\\mathrm{EHAtLevel}$ at every level (take $C=1$, using $x>0$ and $(\\log x)^A>0$ for $x\\ge 2$), hence models the full Elliott–Halberstam hierarchy."
+    },
+    {
+      "id": "concrete-functional",
+      "title": "A Canonical Concrete Discrepancy Functional",
+      "summary": "discrepancySum f θ x = Σ_{q≤x^θ} f(q,x): the canonical shape of the EH sum, with level-monotonicity PROVED (not assumed); the base-clamped variant gives a global (generally nonzero) model of LevelMonotone",
+      "startLine": 186,
+      "endLine": 249,
+      "mathContext": "$\\mathrm{discrepancySum}(f,\\theta,x) := \\sum_{q=1}^{\\lfloor x^\\theta\\rfloor} f(q,x)$. For nonnegative $f$ and $x\\ge 1$, $\\theta_1\\le\\theta_2 \\Rightarrow \\mathrm{discrepancySum}(f,\\theta_1,x) \\le \\mathrm{discrepancySum}(f,\\theta_2,x)$, because $x^{\\cdot}$ is monotone (base $\\ge 1$) so $\\lfloor x^{\\theta_1}\\rfloor \\le \\lfloor x^{\\theta_2}\\rfloor$ and the extra terms are $\\ge 0$."
+    },
+    {
+      "id": "exact-band",
+      "title": "The Exact Level Increment (Band Decomposition)",
+      "summary": "discrepancyBand isolates the new-moduli contribution ⌊x^θ₁⌋<q≤⌊x^θ₂⌋; discrepancySum_eq_add_band upgrades monotonicity from an inequality to an identity",
+      "startLine": 251,
+      "endLine": 292,
+      "mathContext": "$\\mathrm{discrepancyBand}(f,\\theta_1,\\theta_2,x) := \\sum_{\\lfloor x^{\\theta_1}\\rfloor < q \\le \\lfloor x^{\\theta_2}\\rfloor} f(q,x)$; and for $x\\ge 1,\\ \\theta_1\\le\\theta_2$: $\\mathrm{discrepancySum}(f,\\theta_2,x) = \\mathrm{discrepancySum}(f,\\theta_1,x) + \\mathrm{discrepancyBand}(f,\\theta_1,\\theta_2,x)$ (via $\\sum_{\\mathrm{Ioc}}$ consecutivity)."
+    },
+    {
+      "id": "convex-cone",
+      "title": "The EH-Bound Class Is a Convex Cone; Raising the Level",
+      "summary": "EHAtLevel_add / EHAtLevel_smul / EHAtLevel_nonneg_linear: functionals meeting the level-θ bound are closed under addition and nonnegative scaling; EHAtLevel_discrepancySum_up ascends a level given a band bound",
+      "startLine": 294,
+      "endLine": 364,
+      "mathContext": "If $D_1,D_2$ meet the level-$\\theta$ bound with constants $C_1,C_2$ then $D_1+D_2$ meets it with $C_1+C_2$, and $cD$ ($c\\ge 0$) meets it with $cC+1$. Ascent: EH at $\\theta_1$ plus an EH-type bound on the band $\\theta_1\\to\\theta_2$ gives EH at $\\theta_2$ (constant $C_1+C_2$)."
+    },
+    {
+      "id": "band-subdivision",
+      "title": "Subdividing the Band: the Chasles Cocycle and Dyadic Split",
+      "summary": "discrepancyBand_self (empty band) and discrepancyBand_add_consecutive (band θ₁→θ₃ = band θ₁→θ₂ + band θ₂→θ₃); EHAtLevel_discrepancySum_up_split raises the level using only per-sub-band bounds",
+      "startLine": 366,
+      "endLine": 423,
+      "mathContext": "Cocycle: for $x\\ge 1,\\ \\theta_1\\le\\theta_2\\le\\theta_3$, $\\mathrm{band}(\\theta_1,\\theta_3) = \\mathrm{band}(\\theta_1,\\theta_2) + \\mathrm{band}(\\theta_2,\\theta_3)$, with $\\mathrm{band}(\\theta,\\theta)=0$. Recombining the two sub-band bounds via the convex cone lifts EH from $\\theta_1$ to $\\theta_3$."
+    },
+    {
+      "id": "dyadic-chain",
+      "title": "Finite Dyadic Chain: Ascent over Arbitrarily Many Sub-Bands",
+      "summary": "EHAtLevel_discrepancySum_up_chain iterates the single-band ascent along a monotone level chain L; the arithmetic (equipartition) form up_arith and the target-endpoint wrapper up_target reach any prescribed θ in n equal modulus blocks",
+      "startLine": 425,
+      "endLine": 499,
+      "mathContext": "For monotone $L:\\mathbb N\\to\\mathbb R$: EH at $L\\,0$ plus an EH-type bound on every band $L\\,k\\to L(k{+}1)$ gives EH at every $L\\,n$ (induction). Equipartition $L\\,k=\\theta_0+k\\delta$ with $\\delta=(\\theta-\\theta_0)/n$ reaches the exact target $\\theta\\ge\\theta_0$ in $n$ blocks."
+    },
+    {
+      "id": "vonmangoldt-grounding",
+      "title": "Grounding in the Genuine von-Mangoldt Discrepancy",
+      "summary": "psiAP, apDiscrepancy, vonMangoldtWeight (proved nonnegative) and vonMangoldtDiscrepancySum instantiate f with the actual EH summand max_{(a,q)=1}|ψ(x;q,a)−x/φ(q)|; the whole hierarchy specializes to the real object with no extra hypotheses",
+      "startLine": 501,
+      "endLine": 659,
+      "mathContext": "$f(q,x) = \\max_{(a,q)=1}\\big|\\psi(x;q,a) - x/\\varphi(q)\\big|$ with $\\psi(x;q,a)=\\sum_{n\\le x,\\ n\\equiv a\\,(q)}\\Lambda(n)$, built from Mathlib's `ArithmeticFunction.vonMangoldt` and `Nat.totient`. Being a max of absolute values it is $\\ge 0$, discharging the sole structural hypothesis."
     }
   ],
   "conclusion": {
@@ -150,7 +202,9 @@
     "openQuestions": [
       "Instantiate D with the genuine von-Mangoldt discrepancy sum ∑_{q≤x^θ} max_{(a,q)=1}|ψ(x;q,a)−x/φ(q)| and verify LevelMonotone for it.",
       "Connect EHAtLevel at θ→1 to the Maynard–Tao gap bound H ≤ 12 as a downstream consequence.",
-      "Formalize the strict version of the hierarchy (a quantitative gain in the constant as the level drops)."
+      "Formalize the strict version of the hierarchy (a quantitative gain in the constant as the level drops).",
+      "Discharge an actual per-sub-band bound for the von-Mangoldt weight, so the dyadic ascent (EHAtLevel_vonMangoldt_up_chain / _up_target) proves a genuine level-of-distribution statement beyond θ = 1/2 rather than remaining conditional on the band hypotheses.",
+      "Formalize the Zhang / Polymath8 partial progress past 1/2 (level 1/2 + 1/584, resp. the smoothed variants) as concrete instances of the band-ascent framework, tracking how the effective constant degrades with the extra band contributions."
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-02` (Elliott–Halberstam level-of-distribution hierarchy).

## Gap addressed
Sections and annotations previously covered only lines 61–154 of the 662-line Lean file, leaving the entire second half — the concrete functional, exact band decomposition, convex-cone closure, dyadic ascent chain, and genuine von-Mangoldt grounding — undocumented on the gallery page.

## Changes
- **+6 sections** covering lines 186–659: canonical concrete functional (`discrepancySum`, level-monotonicity proved), exact band decomposition (`discrepancyBand`, identity not inequality), the EH-bound convex cone + level ascent, the band cocycle/Chasles split, the finite dyadic/equipartition chain, and the genuine von-Mangoldt instantiation.
- **+6 annotations** with `mathContext`, `significance`, `relatedConcepts`, `prerequisites` for the same blocks.
- **+4 keyInsights** (5→9, under the 12 cap): exact band identity, convex-cone closure, dyadic ascent, von-Mangoldt grounding.
- **+2 openQuestions**: discharging a genuine per-band von-Mangoldt bound, and formalizing Zhang/Polymath8 progress past level 1/2.

## Verification
- `meta.json` valid JSON, 23.5 KB (well under the 60 KB cap; `check-meta-size.ts` passes).
- `annotations.json` valid JSON; all `significance` values in the canonical `critical|key|supporting` enum.
- Gallery data-generation phase of `pnpm build` completed with no JSON/validation errors. (The subsequent `tsc` step is unavailable in this worktree because `node_modules` is not installed — an environment limitation, not a data issue.)
- No axiom/status changes: entry remains `verified`, 0 axioms, matching the Lean source.