### PR TITLE
research(buffons-noodle-oq-03-oq-02): codimension dichotomy — curves a.s. miss codim-≥2 flats [VERIFIED, 0-axiom, +4thm]

### DIFF
--- a/proofs/Proofs/BuffonsNoodleOQ03OQ02.lean
+++ b/proofs/Proofs/BuffonsNoodleOQ03OQ02.lean
@@ -1,0 +1,136 @@
+import Mathlib.MeasureTheory.Measure.Hausdorff
+import Mathlib.Topology.MetricSpace.HausdorffDimension
+import Mathlib.Tactic
+
+/-!
+# Buffon's Noodle, higher codimension — the degeneracy dichotomy (oq-03 · oq-02)
+
+## The open question
+
+The parent line of work generalises Buffon's Noodle to `ℝⁿ`: a rectifiable curve of
+length `L` thrown at a family of parallel **hyperplanes** spaced `d` apart crosses them
+`E = αₙ · L / d` times on average, where `αₙ = 𝔼_{u ∼ S^{n-1}} |u₁|` is the *crossing
+factor* (parent file `BuffonsNoodleOQ03.lean`; its closed form
+`αₙ = Γ(n/2)/(√π·Γ((n+1)/2))` is `BuffonsNoodleOQ03OQ01.lean`).
+
+Open question **oq-03 · oq-02** asks to *generalise the codimension*: what is the expected
+number of intersections of a length-`L` curve with a fixed family of parallel
+**`k`-dimensional affine subspaces** (`k`-flats) in `ℝⁿ`?
+
+## What this file proves: the codimension dichotomy
+
+A `k`-flat in `ℝⁿ` has **codimension** `c = n - k`. A hyperplane is the case `c = 1`, which
+is exactly the nondegenerate parent problem. This file settles the *complementary regime*:
+
+> **For codimension `c ≥ 2`, a rectifiable curve almost surely misses every flat: the
+> expected number of intersections is `0`.**
+
+The geometry is dimension-counting. Fix the `c`-dimensional orthogonal complement `W = ℝᶜ`
+of the common flat direction and let `P : ℝⁿ → W` be the orthogonal projection. A flat with
+offset `w ∈ W` meets the curve `Γ : [0,L] → ℝⁿ` **iff** `w` lies in the image of the
+*projected* curve `P ∘ Γ : [0,L] → W`. That projected curve is again Lipschitz, so its image
+is a `1`-dimensional (Hausdorff dimension `≤ 1`) subset of the `c`-dimensional space `W`. When
+`c ≥ 2` a set of Hausdorff dimension `< c` is Lebesgue-null, so the set of *hit offsets* has
+measure zero — and hence the expected count against any offset distribution absolutely
+continuous with respect to Lebesgue measure vanishes.
+
+This is the honest and complete answer to the higher-codimension question: the only
+nondegenerate parallel-flat Buffon law is the hyperplane (`c = 1`) case treated by the
+parent files; every higher-codimension family is degenerate for a `1`-dimensional needle.
+(The nondegenerate higher-codimension generalisation of integral geometry requires the
+*moving* object to have dimension at least the codimension — Cauchy–Crofton / Santaló — a
+genuinely different theorem, not a special case of the noodle law.)
+
+## The three results
+
+* `volume_lipschitzImage_eq_zero` — the analytic core: the image of any Lipschitz map
+  `γ : ℝ → (Fin c → ℝ)` (`c ≥ 2`) on an arbitrary subset of `ℝ` has Lebesgue measure `0`.
+  Proof: `dimH (γ '' s) ≤ dimH s ≤ dimH (univ : Set ℝ) = 1 < c`, and Hausdorff dimension
+  strictly below the ambient dimension forces Lebesgue-nullity via
+  `hausdorffMeasure_pi_real` (`μH[c] = volume` on `Fin c → ℝ`).
+* `crossedOffsets_measure_zero` — the Buffon interpretation: the set of offsets
+  `{w | ∃ t ∈ [0,L], γ t = w}` hit by the projected curve `γ` is Lebesgue-null.
+* `spatialCurve_crossedOffsets_measure_zero` — the full `ℝⁿ` framing: for a Lipschitz spatial
+  curve `Γ` and any Lipschitz projection `P` onto the `c`-dimensional complement, the hit-offset
+  set `{w | ∃ t ∈ [0,L], P (Γ t) = w}` is Lebesgue-null.
+* `crossing_ae_zero` — the expectation consequence: almost every offset is missed, so the
+  crossing count is `0` almost surely and its expectation is `0`.
+
+We work in the coordinate space `Fin c → ℝ` with its product (sup) metric, where
+`hausdorffMeasure_pi_real` identifies `μH[c]` with Lebesgue `volume`. The measure-zero
+conclusion is bi-Lipschitz invariant, so it transfers verbatim to the Euclidean metric.
+
+## Status
+
+0 axioms, 0 sorries, builds on Mathlib.
+-/
+
+namespace BuffonsNoodleOQ03OQ02
+
+open MeasureTheory Set
+open scoped ENNReal NNReal
+
+variable {c : ℕ}
+
+/-- **Analytic core.** The image of a Lipschitz map `γ : ℝ → (Fin c → ℝ)` on any subset
+`s ⊆ ℝ` has Lebesgue measure zero once the target dimension satisfies `c ≥ 2`.
+
+The image has Hausdorff dimension at most `1` (Lipschitz maps do not increase Hausdorff
+dimension, and `dimH (univ : Set ℝ) = 1`), which is strictly below the ambient dimension
+`c ≥ 2`. A set of Hausdorff dimension `< c` is null for `μH[c]`, and `μH[c] = volume` on
+`Fin c → ℝ` by `hausdorffMeasure_pi_real`. -/
+theorem volume_lipschitzImage_eq_zero (hc : 2 ≤ c)
+    {γ : ℝ → (Fin c → ℝ)} {K : ℝ≥0} (hγ : LipschitzWith K γ) (s : Set ℝ) :
+    volume (γ '' s) = 0 := by
+  -- The image has Hausdorff dimension strictly below `c`.
+  have hdimle : dimH (γ '' s) ≤ 1 :=
+    calc dimH (γ '' s) ≤ dimH s := hγ.dimH_image_le s
+      _ ≤ dimH (univ : Set ℝ) := dimH_mono (subset_univ s)
+      _ = 1 := Real.dimH_univ
+  have hlt : dimH (γ '' s) < (c : ℝ≥0) := by
+    refine lt_of_le_of_lt hdimle ?_
+    have : (1 : ℝ≥0∞) < (c : ℝ≥0∞) := by exact_mod_cast (by omega : 1 < c)
+    simpa using this
+  -- `μH[c] = volume`, so the dimension gap makes the image Lebesgue-null.
+  have hpi : (μH[((c : ℝ≥0) : ℝ)] : Measure (Fin c → ℝ)) = volume := by
+    rw [NNReal.coe_natCast]
+    simpa using (hausdorffMeasure_pi_real (ι := Fin c))
+  have hac : (volume : Measure (Fin c → ℝ)) ≪ μH[((c : ℝ≥0) : ℝ)] := by
+    rw [hpi]
+  exact measure_zero_of_dimH_lt hac hlt
+
+/-- **Buffon interpretation (projected curve).** The set of parallel-flat offsets that are
+*hit* by the projected curve `γ : ℝ → (Fin c → ℝ)` on the parameter interval `[0, L]` is
+Lebesgue-null when the codimension is `c ≥ 2`. An offset `w` is hit exactly when `w = γ t`
+for some parameter `t ∈ [0, L]`, i.e. when `w` lies in the curve's image. -/
+theorem crossedOffsets_measure_zero (hc : 2 ≤ c)
+    {γ : ℝ → (Fin c → ℝ)} {K : ℝ≥0} (hγ : LipschitzWith K γ) (L : ℝ) :
+    volume {w : Fin c → ℝ | ∃ t ∈ Icc (0 : ℝ) L, γ t = w} = 0 := by
+  have hset : {w : Fin c → ℝ | ∃ t ∈ Icc (0 : ℝ) L, γ t = w} = γ '' Icc 0 L := by
+    ext w; simp [Set.mem_image]
+  rw [hset]
+  exact volume_lipschitzImage_eq_zero hc hγ _
+
+/-- **Full `ℝⁿ` framing.** Let `Γ : ℝ → (Fin n → ℝ)` be a Lipschitz spatial curve and let
+`P : (Fin n → ℝ) → (Fin c → ℝ)` be any Lipschitz projection onto the `c`-dimensional
+complement of the common flat direction. When the codimension is `c ≥ 2`, the set of offsets
+`w ∈ ℝᶜ` for which the `k`-flat `{x | P x = w}` meets the curve on `[0, L]` is Lebesgue-null.
+
+The projected curve `P ∘ Γ` is Lipschitz (composition of Lipschitz maps), so this reduces to
+`crossedOffsets_measure_zero`. -/
+theorem spatialCurve_crossedOffsets_measure_zero {n : ℕ} (hc : 2 ≤ c)
+    {Γ : ℝ → (Fin n → ℝ)} {K : ℝ≥0} (hΓ : LipschitzWith K Γ)
+    {P : (Fin n → ℝ) → (Fin c → ℝ)} {M : ℝ≥0} (hP : LipschitzWith M P) (L : ℝ) :
+    volume {w : Fin c → ℝ | ∃ t ∈ Icc (0 : ℝ) L, P (Γ t) = w} = 0 :=
+  crossedOffsets_measure_zero hc (hP.comp hΓ) L
+
+/-- **Expectation consequence.** Since the hit-offset set is Lebesgue-null, *almost every*
+offset is missed by the projected curve. Consequently the number of intersections is `0`
+almost surely, and its expectation against any offset distribution absolutely continuous with
+respect to Lebesgue measure is `0`. -/
+theorem crossing_ae_zero (hc : 2 ≤ c)
+    {γ : ℝ → (Fin c → ℝ)} {K : ℝ≥0} (hγ : LipschitzWith K γ) (L : ℝ) :
+    ∀ᵐ w : Fin c → ℝ, w ∉ {w : Fin c → ℝ | ∃ t ∈ Icc (0 : ℝ) L, γ t = w} :=
+  (measure_eq_zero_iff_ae_notMem).1 (crossedOffsets_measure_zero hc hγ L)
+
+end BuffonsNoodleOQ03OQ02

--- a/research/problems/buffons-noodle-oq-03-oq-02/knowledge.md
+++ b/research/problems/buffons-noodle-oq-03-oq-02/knowledge.md
@@ -1,0 +1,63 @@
+# buffons-noodle-oq-03-oq-02 — Knowledge
+
+**Status: COMPLETED & VERIFIED (0 sorries, 0 axioms).**
+
+## Problem
+
+Generalize the codimension of Buffon's Noodle: for a length-`L` curve and a family
+of parallel `k`-dimensional affine subspaces (`k`-flats) of codimension `c = n - k`
+in `ℝⁿ`, what is the expected number of intersections? The parent `buffons-noodle-oq-03`
+solves the hyperplane case `c = 1` (`E = αₙ·L/d`); sibling `oq-01` evaluates the
+crossing factor `αₙ` and explicitly lists "extend to codimension-k" as open.
+
+## Result (the codimension dichotomy)
+
+**For codimension `c ≥ 2`, a rectifiable (Lipschitz) curve almost surely misses every
+flat: the expected number of intersections is 0.**
+
+Mechanism (dimension counting): a flat with orthogonal offset `w ∈ ℝᶜ` meets the curve
+`Γ` iff `w` lies in the image of the projected curve `P∘Γ : [0,L] → ℝᶜ`. That projected
+curve is Lipschitz, so its image has Hausdorff dimension `≤ dimH(ℝ) = 1 < c`, and a set
+of dimension below the ambient dimension is Lebesgue-null (`μH[c] = volume`). Hence the
+set of hit offsets is null and the crossing count is `0` almost surely.
+
+This is the honest complete answer: codimension 1 (hyperplanes) is the *unique*
+nondegenerate parallel-flat Buffon regime for a 1-dimensional needle. The nondegenerate
+higher-codimension law of integral geometry (Cauchy–Crofton / Santaló) requires the
+*moving* object to have dimension at least the codimension — a different theorem.
+
+## Session 2026-07-01 (Session 1, researcher-6) — FRESH → COMPLETED
+
+**Mode**: FRESH
+**Outcome**: completed (new verified gallery entry)
+
+### What I Did
+- Selected from the available pool after triaging RICH/MODERATE problems (all blocked or
+  live-twinned: CLT-oq0204 blocked on unmerged PR #32388, erdos-263 blocked, erdos-101
+  live-twin, ballot blocked-infra).
+- Identified the correct math: 1-dim curve × codimension-`c` flats is degenerate for `c ≥ 2`.
+- Verified Mathlib support: `LipschitzWith.dimH_image_le`, `Real.dimH_univ`,
+  `measure_zero_of_dimH_lt`, `hausdorffMeasure_pi_real`.
+- Wrote `proofs/Proofs/BuffonsNoodleOQ03OQ02.lean` (136 lines, 4 theorems).
+- Typechecked against Mathlib v4.26 (`lake env lean`, 0 errors), `#print axioms` = only
+  `propext, Classical.choice, Quot.sound` (0-axiom VERIFIED).
+- Created gallery entry (`meta.json` + `annotations.json`) and research problem JSON.
+
+### Key Findings
+- The whole geometric question collapses to: does a Lipschitz curve's image in `ℝᶜ`
+  have positive Lebesgue measure? For `c ≥ 2` the answer is no (Hausdorff dim ≤ 1 < c).
+- `hausdorffMeasure_pi_real` (`μH[c] = volume` on `Fin c → ℝ`) is the bridge from the
+  abstract dimension gap to concrete Lebesgue-nullity.
+- Cast bookkeeping ℕ → ℝ≥0 → ℝ≥0∞ / ℝ is the only fiddly part; `exact_mod_cast` and
+  `NNReal.coe_natCast` handle it.
+
+### Files Modified
+- `proofs/Proofs/BuffonsNoodleOQ03OQ02.lean` (new)
+- `src/data/proofs/buffons-noodle-oq-03-oq-02/{meta,annotations}.json` (new)
+- `src/data/research/problems/buffons-noodle-oq-03-oq-02.json` (new)
+- `research/problems/buffons-noodle-oq-03-oq-02/knowledge.md` (this file)
+
+### Next Steps (follow-up, not blocking)
+- Prove the nondegenerate `d ≥ codimension` law (Cauchy–Crofton / Santaló).
+- Upgrade `crossing_ae_zero` to an explicit Bochner-integral `E = 0` over a uniform
+  offset window.

--- a/src/data/proofs/buffons-noodle-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/buffons-noodle-oq-03-oq-02/annotations.json
@@ -1,0 +1,75 @@
+[
+  {
+    "id": "ann-buffons-noodle-oq-03-oq-02-01",
+    "proofId": "buffons-noodle-oq-03-oq-02",
+    "range": {
+      "startLine": 24,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "The Codimension Dichotomy of Buffon's Noodle",
+    "content": "A k-dimensional affine subspace (k-flat) in ℝⁿ has codimension c = n - k. The parent noodle law E = αₙ·L/d is the codimension-1 case (hyperplanes). This file settles the complementary regime: for codimension c ≥ 2 a rectifiable curve almost surely misses every flat, so the expected number of intersections is 0. The reason is dimension counting: a flat at orthogonal offset w ∈ ℝᶜ meets the curve Γ iff w lies in the image of the projected curve P∘Γ : [0,L] → ℝᶜ. That image is 1-dimensional (Hausdorff dimension ≤ 1) inside a c-dimensional space, and a set of dimension below the ambient dimension is Lebesgue-null. So the set of hit offsets has measure zero. The nondegenerate higher-codimension law of integral geometry (Cauchy–Crofton) requires the moving object's dimension to be at least the codimension — a different theorem entirely.",
+    "mathContext": "For a curve ($d=1$) and codimension $c = n-k$: nonzero expected crossings require $d \\ge c$, i.e. $c \\le 1$. Hence $c \\ge 2 \\Rightarrow \\mathbb{E}[\\#\\text{crossings}] = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "codimension",
+      "integral geometry",
+      "Cauchy–Crofton formula",
+      "dimension counting",
+      "Buffon's noodle"
+    ],
+    "prerequisites": [
+      "affine subspaces and codimension",
+      "geometric probability",
+      "linearity of expectation"
+    ]
+  },
+  {
+    "id": "ann-buffons-noodle-oq-03-oq-02-02",
+    "proofId": "buffons-noodle-oq-03-oq-02",
+    "range": {
+      "startLine": 82,
+      "endLine": 104
+    },
+    "type": "tactic",
+    "title": "Analytic Core: a Lipschitz Curve's Image is Lebesgue-Null in ℝᶜ (c ≥ 2)",
+    "content": "volume_lipschitzImage_eq_zero proves that the image γ '' s of a Lipschitz map γ : ℝ → (Fin c → ℝ) has Lebesgue measure zero when c ≥ 2. The chain is: dimH (γ '' s) ≤ dimH s (LipschitzWith.dimH_image_le — Lipschitz maps do not increase Hausdorff dimension) ≤ dimH (univ : Set ℝ) = 1 (Real.dimH_univ). Since c ≥ 2, the image dimension is strictly below the ambient dimension, so 1 < c gives dimH (γ '' s) < c. Rewriting μH[c] = volume via hausdorffMeasure_pi_real turns measure_zero_of_dimH_lt (μ ≪ μH[d] ∧ dimH s < d ⟹ μ s = 0) into volume (γ '' s) = 0. The cast bookkeeping (ℕ → ℝ≥0 → ℝ≥0∞ and ℝ) is discharged by exact_mod_cast and NNReal.coe_natCast.",
+    "mathContext": "$\\dim_H(\\gamma(s)) \\le \\dim_H(\\mathbb{R}) = 1 < c \\;\\Rightarrow\\; \\mu_H^{c}(\\gamma(s)) = 0 = \\mathrm{vol}(\\gamma(s))$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Hausdorff dimension",
+      "Hausdorff measure",
+      "Lipschitz map",
+      "Lebesgue measure",
+      "measure zero"
+    ],
+    "prerequisites": [
+      "Hausdorff dimension and measure",
+      "Lipschitz continuity",
+      "μH[n] = volume on ℝⁿ"
+    ]
+  },
+  {
+    "id": "ann-buffons-noodle-oq-03-oq-02-03",
+    "proofId": "buffons-noodle-oq-03-oq-02",
+    "range": {
+      "startLine": 106,
+      "endLine": 136
+    },
+    "type": "concept",
+    "title": "From Measure-Zero to Zero Expected Crossings",
+    "content": "The three remaining theorems convert the core into the Buffon statement. crossedOffsets_measure_zero rewrites the hit-offset set {w | ∃ t ∈ [0,L], γ t = w} as the image γ '' Icc 0 L and applies the core, so the offsets meeting the projected curve form a Lebesgue-null set. spatialCurve_crossedOffsets_measure_zero handles the full ℝⁿ picture: a Lipschitz spatial curve Γ composed with any Lipschitz orthogonal projection P onto the codimension complement stays Lipschitz (LipschitzWith.comp), so its hit-offset set is null too. Finally crossing_ae_zero applies measure_eq_zero_iff_ae_notMem: a null hit set means almost every offset is missed, hence the crossing count is 0 almost surely and its expectation against any Lebesgue-absolutely-continuous offset distribution vanishes.",
+    "mathContext": "$\\mathrm{vol}\\{w : \\exists t\\in[0,L],\\, P(\\Gamma(t)) = w\\} = 0 \\;\\Rightarrow\\; \\text{for a.e. } w,\\ \\text{no crossing} \\;\\Rightarrow\\; \\mathbb{E} = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "almost everywhere",
+      "expectation",
+      "orthogonal projection",
+      "composition of Lipschitz maps"
+    ],
+    "prerequisites": [
+      "almost-everywhere statements",
+      "expectation and absolute continuity"
+    ]
+  }
+]

--- a/src/data/proofs/buffons-noodle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/buffons-noodle-oq-03-oq-02/meta.json
@@ -1,0 +1,233 @@
+{
+  "id": "buffons-noodle-oq-03-oq-02",
+  "title": "Buffon in Higher Codimension: a Curve Almost Surely Misses Codimension-≥2 Flats",
+  "slug": "buffons-noodle-oq-03-oq-02",
+  "description": "Settles the higher-codimension generalization of Buffon's Noodle. A k-dimensional affine subspace (k-flat) in ℝⁿ has codimension c = n - k; a hyperplane is c = 1, the nondegenerate parent case with expected crossings E = αₙ·L/d. This file proves the complementary regime is degenerate: for codimension c ≥ 2, a rectifiable (Lipschitz) curve almost surely misses every flat, so the expected number of intersections is 0. The geometry is dimension-counting: a flat with orthogonal offset w ∈ ℝᶜ meets the curve Γ iff w lies in the image of the projected curve P∘Γ : [0,L] → ℝᶜ, which is Lipschitz and hence has Hausdorff dimension ≤ 1 < c; a set of dimension below the ambient dimension is Lebesgue-null (via μH[c] = volume on Fin c → ℝ). Thus the set of hit offsets has measure zero and the crossing count is 0 a.e. The nondegenerate higher-codimension theory of integral geometry (Cauchy–Crofton / Santaló) requires the moving object to have dimension at least the codimension — a genuinely different theorem, not a case of the noodle law. Fully machine-checked: 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BuffonsNoodleOQ03OQ02.lean",
+    "tags": [
+      "geometric-probability",
+      "integral-geometry",
+      "buffon",
+      "buffon-noodle",
+      "higher-codimension",
+      "hausdorff-dimension",
+      "measure-zero",
+      "lipschitz",
+      "cauchy-crofton"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "LipschitzWith.dimH_image_le",
+        "description": "A Lipschitz map does not increase Hausdorff dimension: dimH (f '' s) ≤ dimH s. Applied to the projected curve to bound its image dimension by dimH (univ : Set ℝ) = 1.",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDimension"
+      },
+      {
+        "theorem": "Real.dimH_univ",
+        "description": "dimH (univ : Set ℝ) = 1, the Hausdorff dimension of the parameter line, which caps the projected curve's image dimension.",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDimension"
+      },
+      {
+        "theorem": "MeasureTheory.measure_zero_of_dimH_lt",
+        "description": "If μ ≪ μH[d] and dimH s < d then μ s = 0 — the mechanism converting the dimension gap (image dim ≤ 1 < c) into Lebesgue-nullity.",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDimension"
+      },
+      {
+        "theorem": "MeasureTheory.hausdorffMeasure_pi_real",
+        "description": "μH[card ι] = volume on ι → ℝ; specialized to ι = Fin c gives μH[c] = volume, identifying the c-dimensional Hausdorff measure with Lebesgue measure so measure_zero_of_dimH_lt applies to volume.",
+        "module": "Mathlib.MeasureTheory.Measure.Hausdorff"
+      },
+      {
+        "theorem": "LipschitzWith.comp",
+        "description": "Composition of Lipschitz maps is Lipschitz; shows the projected curve P∘Γ is Lipschitz when Γ and the projection P are, delivering the full ℝⁿ framing from the projected-curve core.",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      }
+    ],
+    "originalContributions": [
+      "volume_lipschitzImage_eq_zero: PROVED that the image of any Lipschitz map γ : ℝ → (Fin c → ℝ) with c ≥ 2, on an arbitrary subset of ℝ, has Lebesgue measure zero — by bounding dimH (γ '' s) ≤ dimH (univ : Set ℝ) = 1 < c and invoking measure_zero_of_dimH_lt with μH[c] = volume",
+      "crossedOffsets_measure_zero: PROVED the Buffon interpretation — the set {w | ∃ t ∈ [0,L], γ t = w} of parallel-flat offsets hit by the projected curve is Lebesgue-null when c ≥ 2",
+      "spatialCurve_crossedOffsets_measure_zero: PROVED the full ℝⁿ framing — for a Lipschitz spatial curve Γ and any Lipschitz orthogonal projection P onto the c-dimensional complement, the hit-offset set {w | ∃ t ∈ [0,L], P (Γ t) = w} is Lebesgue-null",
+      "crossing_ae_zero: PROVED the expectation consequence — almost every offset is missed, so the crossing count is 0 a.e. and its expectation against any Lebesgue-absolutely-continuous offset distribution vanishes",
+      "Identified and formalized the codimension dichotomy of Buffon's Noodle: c = 1 (hyperplanes) is the unique nondegenerate parallel-flat case (parent E = αₙ·L/d); every codimension c ≥ 2 family is degenerate for a 1-dimensional needle, answering the parent's own listed open direction"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "The higher-dimensional Buffon noodle law E = αₙ·L/d for hyperplanes (codimension 1) in ℝⁿ (parent BuffonsNoodleOQ03)",
+      "Hausdorff dimension and measure: Lipschitz maps do not increase Hausdorff dimension; a set of Hausdorff dimension below the ambient dimension is Lebesgue-null",
+      "The identity μH[c] = volume on ℝᶜ (Hausdorff measure equals Lebesgue measure at the top dimension)"
+    ],
+    "lineCount": 136,
+    "relatedProblems": [
+      {
+        "id": "buffons-noodle-oq-03",
+        "relationship": "Direct parent: proves the codimension-1 noodle law E = αₙ·L/d; this file settles the complementary codimension-≥2 regime as degenerate (expected count 0), answering the parent's listed 'codimension-k' open direction"
+      },
+      {
+        "id": "buffons-noodle-oq-03-oq-01",
+        "relationship": "Sibling: evaluates the crossing factor αₙ (the codimension-1 constant) in closed form; its openQuestions explicitly asks to extend to codimension-k, which this file resolves"
+      },
+      {
+        "id": "buffons-noodle",
+        "relationship": "The planar codimension-1 root; the dichotomy explains why the classical noodle law lives only at codimension 1"
+      }
+    ],
+    "assumptions": "None. 0 axioms, 0 sorries (the theorems depend only on the standard foundational axioms propext, Classical.choice, Quot.sound, which are not assumptions). The curve is modelled as a Lipschitz (rectifiable) map, the standard regularity for Buffon-type problems. Work is carried out in the coordinate space Fin c → ℝ with its product (sup) metric, where μH[c] = volume; the measure-zero conclusion is bi-Lipschitz invariant and so transfers verbatim to the Euclidean metric on ℝᶜ.",
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "structureCount": 0
+  },
+  "overview": {
+    "historicalContext": "Buffon's needle (1733) and its shape-independent generalization, Buffon's noodle (Barbier 1860), compute the expected number of crossings of a planar curve with a family of equally spaced parallel lines. The parent line of this work lifts the law to ℝⁿ, where a length-L curve crosses parallel hyperplanes E = αₙ·L/d times on average, αₙ being the mean absolute value of one coordinate of a uniform unit vector. A natural question — raised explicitly in the sibling file — is what happens when the parallel obstacles are lower-dimensional: k-flats of codimension c = n - k > 1 instead of hyperplanes. Integral geometry (Santaló) answers via dimension counting: a d-dimensional moving object generically meets a family of codimension-c flats only when d ≥ c. For a 1-dimensional needle this means only hyperplanes (c = 1) give nonzero crossings; every higher codimension is degenerate.",
+    "problemStatement": "Generalize the codimension of Buffon's Noodle: for a length-L curve and a family of parallel k-dimensional affine subspaces (codimension c = n - k) in ℝⁿ, determine the expected number of intersections. This file proves the degeneracy half: for c ≥ 2 the expected number of intersections is 0, because the set of flat-offsets meeting the curve is Lebesgue-null.",
+    "text": "A 136-line file proving that for codimension c ≥ 2 a rectifiable curve almost surely misses every parallel k-flat. The analytic core (volume_lipschitzImage_eq_zero) shows a Lipschitz curve's image in ℝᶜ has Lebesgue measure zero when c ≥ 2, since its Hausdorff dimension is ≤ 1 < c. The Buffon reading (crossedOffsets_measure_zero) reinterprets this as: the set of hit offsets is null. The spatial framing (spatialCurve_crossedOffsets_measure_zero) composes with an arbitrary Lipschitz projection onto the codimension complement, and crossing_ae_zero draws the expectation-zero consequence — all 0 sorries, 0 axioms.",
+    "proofStrategy": "Reduce the geometric intersection question to a measure-zero statement about a projected curve. (1) An offset w ∈ ℝᶜ (the orthogonal complement of the common flat direction) indexes a flat that meets the curve Γ iff w = P(Γ t) for some t ∈ [0,L], i.e. iff w is in the image of the projected curve P∘Γ. (2) P∘Γ is Lipschitz (LipschitzWith.comp), and a Lipschitz image cannot exceed the Hausdorff dimension of its domain (LipschitzWith.dimH_image_le), which for a subinterval of ℝ is ≤ dimH (univ : Set ℝ) = 1. (3) When c ≥ 2 we have image-dimension ≤ 1 < c, and a set of Hausdorff dimension strictly below the ambient dimension is null for the c-dimensional Hausdorff measure (measure_zero_of_dimH_lt); since μH[c] = volume on ℝᶜ (hausdorffMeasure_pi_real), the hit-offset set is Lebesgue-null. (4) Lebesgue-nullity of the hit set is exactly ‘almost every offset is missed’, so the crossing count is 0 a.e. and its expectation vanishes.",
+    "keyInsights": [
+      "**The Buffon law is a codimension-1 phenomenon.** Parallel obstacles yield a nonzero expected crossing count for a curve only when they are hyperplanes (codimension 1). This file makes the boundary precise: codimension ≥ 2 is uniformly degenerate.",
+      "**Intersection ↔ image of a projected curve.** A flat at offset w meets the curve exactly when w lies in the image of the curve projected onto the codimension complement. The whole geometric question becomes a measure question about that projected image.",
+      "**Dimension counting is the mechanism.** A Lipschitz curve's image has Hausdorff dimension ≤ 1. In ℝᶜ with c ≥ 2 that is strictly below the ambient dimension, forcing Lebesgue measure zero — the exact reason 1-dimensional needles cannot generically hit codimension-≥2 flats.",
+      "**μH[c] = volume ties Hausdorff dimension to Lebesgue nullity.** The identity of the top-dimensional Hausdorff measure with Lebesgue measure (hausdorffMeasure_pi_real) is what converts the abstract dimension gap into a concrete ‘expected crossings = 0’.",
+      "**The nondegenerate higher-codimension theory needs a bigger object.** Cauchy–Crofton / Santaló give nonzero counts for codimension c only when the moving object has dimension ≥ c (e.g. a surface meeting curves in ℝ³). That is a distinct integral-geometry theorem, not a specialization of the noodle law — this file delimits precisely where the noodle law stops."
+    ],
+    "prerequisites": [
+      "The codimension-1 noodle law E = αₙ·L/d (parent file)",
+      "Hausdorff dimension: Lipschitz maps do not increase it; below-ambient dimension implies Lebesgue-null",
+      "μH[c] = volume on ℝᶜ"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "buffons-noodle-oq-03",
+      "relationship": "extends",
+      "description": "Answers the parent's codimension-k open direction: the parent proves the codimension-1 law E = αₙ·L/d; this file shows every codimension ≥ 2 family is degenerate (expected crossings 0) for a rectifiable curve."
+    },
+    {
+      "targetId": "buffons-noodle-oq-03-oq-01",
+      "relationship": "relatedTo",
+      "description": "The sibling evaluates the codimension-1 crossing factor αₙ in closed form and lists 'extend to codimension-k' as an open question; this file resolves that direction with the degeneracy dichotomy."
+    },
+    {
+      "targetId": "buffons-noodle",
+      "relationship": "relatedTo",
+      "description": "Explains why the classical planar noodle law is a codimension-1 statement: for a 1-dimensional curve, codimension 1 is the only nondegenerate parallel-obstacle regime."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 136,
+    "namespace": "BuffonsNoodleOQ03OQ02",
+    "opens": [
+      "MeasureTheory",
+      "Set"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "substantiveTheoremCount": 2,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Mathlib.MeasureTheory.Measure.Hausdorff",
+      "Mathlib.Topology.MetricSpace.HausdorffDimension",
+      "Mathlib.Tactic"
+    ],
+    "path": "Proofs/BuffonsNoodleOQ03OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "volume_lipschitzImage_eq_zero",
+      "type": "core",
+      "description": "Analytic core: the image of a Lipschitz map γ : ℝ → (Fin c → ℝ) with c ≥ 2, on any subset of ℝ, has Lebesgue measure zero (dimH ≤ 1 < c) (PROVED, 0 axioms)",
+      "leanType": "∀ {c : ℕ}, 2 ≤ c → ∀ {γ : ℝ → (Fin c → ℝ)} {K : ℝ≥0}, LipschitzWith K γ → ∀ (s : Set ℝ), volume (γ '' s) = 0"
+    },
+    {
+      "name": "crossedOffsets_measure_zero",
+      "type": "core",
+      "description": "Buffon interpretation: the set {w | ∃ t ∈ [0,L], γ t = w} of parallel-flat offsets hit by the projected curve is Lebesgue-null when c ≥ 2 (PROVED, 0 axioms)",
+      "leanType": "∀ {c : ℕ}, 2 ≤ c → ∀ {γ : ℝ → (Fin c → ℝ)} {K : ℝ≥0}, LipschitzWith K γ → ∀ (L : ℝ), volume {w | ∃ t ∈ Set.Icc 0 L, γ t = w} = 0"
+    },
+    {
+      "name": "spatialCurve_crossedOffsets_measure_zero",
+      "type": "supporting",
+      "description": "Full ℝⁿ framing: for a Lipschitz spatial curve Γ and Lipschitz projection P onto the codimension-c complement, the hit-offset set is Lebesgue-null (PROVED, 0 axioms)",
+      "leanType": "∀ {c n : ℕ}, 2 ≤ c → LipschitzWith K Γ → LipschitzWith M P → ∀ (L : ℝ), volume {w | ∃ t ∈ Set.Icc 0 L, P (Γ t) = w} = 0"
+    },
+    {
+      "name": "crossing_ae_zero",
+      "type": "supporting",
+      "description": "Expectation consequence: almost every offset is missed, so the crossing count is 0 a.e. and its expectation vanishes (PROVED, 0 axioms)",
+      "leanType": "∀ {c : ℕ}, 2 ≤ c → LipschitzWith K γ → ∀ (L : ℝ), ∀ᵐ w, w ∉ {w | ∃ t ∈ Set.Icc 0 L, γ t = w}"
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-overview",
+      "title": "Overview: the codimension dichotomy",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "Frames the open question (expected intersections of a length-L curve with parallel k-flats of codimension c = n - k) and states the answer: c = 1 (hyperplanes) is the unique nondegenerate case (parent E = αₙ·L/d), while c ≥ 2 is degenerate. Explains the dimension-counting mechanism (projected curve, Hausdorff dimension ≤ 1 < c, Lebesgue-nullity) and contrasts with the Cauchy–Crofton theory needed for a genuinely nonzero higher-codimension law."
+    },
+    {
+      "id": "core",
+      "title": "Analytic core: Lipschitz curve image is Lebesgue-null in ℝᶜ, c ≥ 2",
+      "startLine": 82,
+      "endLine": 104,
+      "summary": "volume_lipschitzImage_eq_zero: bounds dimH (γ '' s) ≤ dimH s ≤ dimH (univ : Set ℝ) = 1 via LipschitzWith.dimH_image_le and dimH_mono, notes 1 < c, rewrites μH[c] = volume with hausdorffMeasure_pi_real, and concludes volume (γ '' s) = 0 through measure_zero_of_dimH_lt."
+    },
+    {
+      "id": "buffon-interpretation",
+      "title": "Buffon interpretation and the ℝⁿ framing",
+      "startLine": 106,
+      "endLine": 129,
+      "summary": "crossedOffsets_measure_zero rewrites the hit-offset set {w | ∃ t ∈ [0,L], γ t = w} as γ '' Icc 0 L and applies the core; spatialCurve_crossedOffsets_measure_zero composes a Lipschitz spatial curve with a Lipschitz projection (LipschitzWith.comp) to obtain the full ℝⁿ statement."
+    },
+    {
+      "id": "expectation",
+      "title": "Expectation consequence",
+      "startLine": 131,
+      "endLine": 136,
+      "summary": "crossing_ae_zero converts the Lebesgue-nullity of the hit-offset set into the almost-everywhere statement that a random offset is missed, so the expected number of crossings is 0."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully machine-checked (0 sorries, 0 axioms) resolution of the codimension-≥2 regime of the higher-dimensional Buffon problem: a rectifiable (Lipschitz) curve almost surely misses every family of parallel k-flats of codimension c ≥ 2, so the expected number of intersections is 0. The proof reduces the intersection question to the Lebesgue-nullity of a projected curve's image, established by the dimension gap dimH ≤ 1 < c and the identity μH[c] = volume.",
+    "implications": "Delimits exactly where Buffon's Noodle law applies: codimension 1 (hyperplanes) is the unique nondegenerate parallel-obstacle regime for a 1-dimensional curve, with expected crossings E = αₙ·L/d; all higher codimensions are degenerate. Together with the parent (the law) and sibling oq-01 (the crossing factor αₙ in closed form), this completes the qualitative picture of the parallel-flat Buffon problem in ℝⁿ.",
+    "openQuestions": [
+      "Prove the nondegenerate higher-codimension law (Cauchy–Crofton / Santaló): for a d-dimensional moving surface of finite d-volume and parallel k-flats with d ≥ codimension, the expected number of intersections is proportional to the surface's d-volume, with an explicit integral-geometric constant.",
+      "Quantify the boundary case d = c exactly: identify the crossing constant for a curve (d = 1) meeting a family of hyperplanes (c = 1) as the sharp d = c instance, unifying it with the parent's αₙ.",
+      "Formalize the intersection count as an integer-valued random variable and prove E = 0 as a Bochner-integral statement over a uniform offset distribution on a bounded window, upgrading the almost-everywhere form to an explicit expectation."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Barbier, Joseph-Émile",
+      "title": "Note sur le problème de l'aiguille et le jeu du joint couvert",
+      "year": "1860",
+      "venue": "Journal de mathématiques pures et appliquées, 2e série, tome 5",
+      "note": "Origin of the noodle (shape-independence) principle for the planar codimension-1 case."
+    },
+    {
+      "authors": "Santaló, Luis A.",
+      "title": "Integral Geometry and Geometric Probability",
+      "year": "2004",
+      "venue": "Cambridge Mathematical Library, 2nd edition",
+      "note": "Standard reference for Cauchy–Crofton formulas and the dimension-counting rule d ≥ codimension for nonzero expected intersections."
+    },
+    {
+      "authors": "Federer, Herbert",
+      "title": "Geometric Measure Theory",
+      "year": "1969",
+      "venue": "Springer, Grundlehren der mathematischen Wissenschaften 153",
+      "note": "Hausdorff measure and dimension, Lipschitz image bounds, and the identity of top-dimensional Hausdorff measure with Lebesgue measure underlying the degeneracy proof."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/buffons-noodle-oq-03-oq-02.json
+++ b/src/data/research/problems/buffons-noodle-oq-03-oq-02.json
@@ -1,0 +1,54 @@
+{
+  "slug": "buffons-noodle-oq-03-oq-02",
+  "title": "Buffon in Higher Codimension: a Curve Almost Surely Misses Codimension-≥2 Flats",
+  "path": "full",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "problemStatement": {
+    "formal": "For a length-L rectifiable curve and a family of parallel k-dimensional affine subspaces (codimension c = n - k) in ℝⁿ, determine the expected number of intersections. Prove that for codimension c ≥ 2 the expected number of intersections is 0: the set of flat-offsets w ∈ ℝᶜ meeting the curve is Lebesgue-null.",
+    "plain": "Generalizes the codimension of Buffon's Noodle. A k-flat in ℝⁿ has codimension c = n - k; the parent noodle law E = αₙ·L/d is the hyperplane case c = 1. This file proves the complementary regime is degenerate: for c ≥ 2 a rectifiable (Lipschitz) curve almost surely misses every flat, so the expected number of intersections is 0. The mechanism is dimension counting — a flat at orthogonal offset w meets the curve iff w lies in the image of the projected curve P∘Γ : [0,L] → ℝᶜ, which is Lipschitz and hence has Hausdorff dimension ≤ 1 < c, so its image is Lebesgue-null (μH[c] = volume). The nondegenerate higher-codimension law (Cauchy–Crofton / Santaló) requires the moving object to have dimension at least the codimension. Fully machine-checked: 0 sorries, 0 axioms.",
+    "whyMatters": []
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-01T00:00:00Z",
+    "iteration": 1,
+    "focus": "Verified deliverable: proofs/Proofs/BuffonsNoodleOQ03OQ02.lean (4 theorems, 0 sorries, 0 axioms) and gallery entry buffons-noodle-oq-03-oq-02 (status verified). Answers the parent's and sibling oq-01's listed codimension-k open direction with the degeneracy dichotomy."
+  },
+  "knowledge": {
+    "insights": [
+      "Codimension dichotomy: a 1-dimensional curve gives nonzero expected crossings with parallel k-flats only at codimension 1 (hyperplanes); every codimension c ≥ 2 is degenerate. This is the integral-geometry dimension rule d ≥ codimension specialized to d = 1.",
+      "The intersection question reduces to a measure-zero statement: a flat at offset w ∈ ℝᶜ meets the curve iff w is in the image of the curve projected onto the c-dimensional orthogonal complement.",
+      "A Lipschitz curve's image has Hausdorff dimension ≤ 1; in ℝᶜ with c ≥ 2 this is below the ambient dimension, so the image is Lebesgue-null (μH[c] = volume, hausdorffMeasure_pi_real).",
+      "The nondegenerate higher-codimension generalization (Cauchy–Crofton / Santaló) is a genuinely different theorem requiring the moving object to have dimension ≥ codimension — not a specialization of the noodle law."
+    ],
+    "builtItems": [
+      "volume_lipschitzImage_eq_zero (BuffonsNoodleOQ03OQ02.lean:82): image of a Lipschitz γ : ℝ → (Fin c → ℝ), c ≥ 2, on any subset of ℝ has Lebesgue measure 0",
+      "crossedOffsets_measure_zero (BuffonsNoodleOQ03OQ02.lean:106): the hit-offset set {w | ∃ t ∈ [0,L], γ t = w} is Lebesgue-null for c ≥ 2",
+      "spatialCurve_crossedOffsets_measure_zero (BuffonsNoodleOQ03OQ02.lean:121): full ℝⁿ framing via a Lipschitz projection P onto the codimension complement",
+      "crossing_ae_zero (BuffonsNoodleOQ03OQ02.lean:131): almost every offset is missed, so expected crossings = 0"
+    ],
+    "mathlibGaps": [
+      "Mathlib has no Buffon/Cauchy–Crofton integral-geometry API; the degeneracy result was built directly from Hausdorff-dimension primitives (LipschitzWith.dimH_image_le, measure_zero_of_dimH_lt, hausdorffMeasure_pi_real)."
+    ],
+    "nextSteps": [
+      "Prove the nondegenerate higher-codimension law (Cauchy–Crofton / Santaló): a d-dimensional surface of finite d-volume meeting parallel k-flats with d ≥ codimension has expected intersections proportional to its d-volume.",
+      "Upgrade crossing_ae_zero to an explicit Bochner-integral expectation E = 0 over a uniform offset distribution on a bounded window.",
+      "Formalize the boundary case d = c and unify the d = c = 1 instance with the parent's crossing factor αₙ."
+    ],
+    "progressSummary": "COMPLETE: codimension-≥2 regime settled as degenerate (expected crossings 0) — 4 theorems, 0 sorries, 0 axioms; verified gallery entry. Nondegenerate d ≥ codimension (Cauchy–Crofton) law left as follow-up."
+  },
+  "knownResults": [],
+  "tags": [
+    "geometric-probability",
+    "integral-geometry",
+    "buffon",
+    "buffon-noodle",
+    "higher-codimension",
+    "hausdorff-dimension",
+    "measure-zero",
+    "lipschitz",
+    "cauchy-crofton"
+  ]
+}


### PR DESCRIPTION
## Summary

Settles the **higher-codimension** generalization of Buffon's Noodle (open question `buffons-noodle-oq-03-oq-02`), the direction explicitly left open by the parent `buffons-noodle-oq-03` and sibling `oq-01`.

A `k`-dimensional affine subspace (`k`-flat) in `ℝⁿ` has **codimension** `c = n − k`. The parent noodle law `E = αₙ·L/d` is the hyperplane case `c = 1`. This PR proves the complementary regime is **degenerate**:

> **For codimension `c ≥ 2`, a rectifiable (Lipschitz) curve almost surely misses every flat — the expected number of intersections is `0`.**

### Why

Dimension counting. A flat at orthogonal offset `w ∈ ℝᶜ` meets the curve `Γ` iff `w` lies in the image of the *projected* curve `P∘Γ : [0,L] → ℝᶜ`. That image is Lipschitz, so its Hausdorff dimension is `≤ dimH(ℝ) = 1 < c`; a set of dimension below the ambient dimension is Lebesgue-null (`μH[c] = volume`). So the set of hit offsets is null and the crossing count is `0` a.e. This is the honest complete answer: codimension 1 (hyperplanes) is the *unique* nondegenerate parallel-flat Buffon regime for a 1-dimensional needle; the nondegenerate higher-codimension law (Cauchy–Crofton / Santaló) requires the moving object to have dimension ≥ codimension — a different theorem.

## Theorems (`proofs/Proofs/BuffonsNoodleOQ03OQ02.lean`, 136 lines)

- `volume_lipschitzImage_eq_zero` — image of a Lipschitz `γ : ℝ → (Fin c → ℝ)` (`c ≥ 2`) is Lebesgue-null
- `crossedOffsets_measure_zero` — the hit-offset set is Lebesgue-null
- `spatialCurve_crossedOffsets_measure_zero` — full `ℝⁿ` framing via a Lipschitz projection
- `crossing_ae_zero` — a.e. offset missed ⟹ expected crossings `0`

## Verification

- **0 sorries, 0 axioms.** `#print axioms` on all four theorems returns only `propext, Classical.choice, Quot.sound` (the standard foundational axioms; no `sorryAx`, no `Lean.ofReduceBool`).
- Typechecked against **Mathlib v4.26.0** via `lake env lean` (0 errors, 0 warnings).
- Key Mathlib lemmas: `LipschitzWith.dimH_image_le`, `Real.dimH_univ`, `measure_zero_of_dimH_lt`, `hausdorffMeasure_pi_real`.

## Files

- `proofs/Proofs/BuffonsNoodleOQ03OQ02.lean` (new)
- `src/data/proofs/buffons-noodle-oq-03-oq-02/{meta,annotations}.json` (new gallery entry, status `verified`)
- `src/data/research/problems/buffons-noodle-oq-03-oq-02.json` + `research/problems/.../knowledge.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)