### PR TITLE
Enrich Erdős #111 Bipartite Cover: add sections navigation array

### DIFF
--- a/src/data/proofs/erdos-111-oq-01/meta.json
+++ b/src/data/proofs/erdos-111-oq-01/meta.json
@@ -43,6 +43,50 @@
       "Mathlib's chromaticNumber lives in ℕ∞, which collapses every infinite cardinal to ⊤. The formalization is therefore honest about scope: 'χ(G) = ℵ₁' is captured precisely as 'not finitely colorable', and the corollary proves only that exact statement — the genuine verifiable shadow of the infinite-combinatorial fact."
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Header: Problem and Results",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Module docstring for Erdős #111 OQ-01: the dual bipartite-cover viewpoint on large-chromatic graphs. A bipartite cover is a family of Bool-valued 2-colorings separating every edge in some coordinate. States the four results (product coloring, χ ≤ 2^|ι| bound, the sharp finite equivalence, and the ℵ₁ shadow corollary) and the honesty note that Mathlib's ℕ∞-valued chromaticNumber collapses every uncountable value to ⊤. Imports SimpleGraph.Coloring and Fin/Fintype big-operator lemmas; fixes V, G, ι."
+    },
+    {
+      "id": "sec-def",
+      "title": "The BipartiteCover Structure",
+      "startLine": 65,
+      "endLine": 77,
+      "summary": "BipartiteCover G ι: a family part : ι → V → Bool of bipartitions together with covers, the condition that every edge {u,v} of G is separated by some coordinate (∃ i, part i u ≠ part i v) — i.e. lies in the i-th bipartite graph B_i."
+    },
+    {
+      "id": "sec-correspondence",
+      "title": "Covers ↔ Colorings Correspondence",
+      "startLine": 79,
+      "endLine": 98,
+      "summary": "The two directions of the correspondence. BipartiteCover.coloring: the product/binary-expansion coloring v ↦ (part i v)_i is a proper G.Coloring with color set ι → Bool, valid for arbitrary ι (adjacent vertices differ in a separating coordinate). bipartiteCoverOfColoring: conversely any proper (ι → Bool)-coloring yields a cover by reading the i-th bit of each color."
+    },
+    {
+      "id": "sec-bound",
+      "title": "Finite Cover ⇒ Chromatic Bound",
+      "startLine": 100,
+      "endLine": 113,
+      "summary": "colorable_of_bipartiteCover: a bipartite cover by a finite index type ι makes G colorable with 2^|ι| colors, since the product color set (ι → Bool) has cardinality 2^|ι| (Fintype.card_fun / card_bool). The private finPowEquiv fixes an explicit Fin (2^k) ≃ (Fin k → Bool) used to recolor in the equivalence below."
+    },
+    {
+      "id": "sec-equivalence",
+      "title": "The Sharp Finite Equivalence",
+      "startLine": 115,
+      "endLine": 128,
+      "summary": "colorable_two_pow_iff_bipartiteCover: the central fully-verified statement — G.Colorable (2^k) ↔ Nonempty (BipartiteCover G (Fin k)), i.e. G's edges are coverable by k bipartite graphs iff χ(G) ≤ 2^k, so the bipartite cover number is ⌈log₂ χ(G)⌉. Forward direction recolors along finPowEquiv then reads bits; reverse applies the 2^|ι| bound."
+    },
+    {
+      "id": "sec-corollary",
+      "title": "Chromatic Bound and the ℵ₁ Corollary",
+      "startLine": 130,
+      "endLine": 154,
+      "summary": "chromaticNumber_le_of_bipartiteCover lifts the colorability bound to G.chromaticNumber ≤ 2^|ι| < ⊤. not_nonempty_bipartiteCover_of_chromaticNumber_top is the verifiable shadow of the ℵ₁ statement: if G is not finitely colorable (chromaticNumber = ⊤, as for any uncountable-chromatic graph) then it admits no finite bipartite cover — covering an ℵ₁-chromatic graph's edges needs infinitely many bipartite graphs."
+    }
+  ],
   "conclusion": {
     "summary": "The file fully verifies the folklore equivalence that the edges of a graph G are coverable by k bipartite graphs if and only if χ(G) ≤ 2^k, i.e. the bipartite-cover number equals ⌈log₂ χ(G)⌉. As a corollary, a graph that is not finitely colorable — in particular any graph with chromatic number ℵ₁, the central objects of Erdős #111 — admits no finite bipartite cover and so requires infinitely many bipartite graphs to cover its edges.",
     "implications": "The equivalence pins down a classical invariant (bipartite cover number) in terms of the chromatic number with a short, kernel-checked Mathlib proof. It supplies the parent problem #111 with a clean, exactly-computable companion to the edge-deletion measure h_G(n): where #111 quantifies *how many edges* must be removed to reach a *single* bipartite graph, this entry quantifies *how many bipartite graphs* are needed to *cover* G, and shows the latter is finite exactly when χ(G) is finite.",


### PR DESCRIPTION
Enrichment pass for `erdos-111-oq-01` (Chromatic number of ℵ₁-chromatic graphs and bipartite covers).

## Gap addressed
The entry had **0 sections** — no navigation array for its 154-line Lean file.

## Change
Added a 6-entry `sections` array with accurate line ranges and substantive summaries:
1. **Header: Problem and Results** (1–63)
2. **The BipartiteCover Structure** (65–77)
3. **Covers ↔ Colorings Correspondence** (79–98)
4. **Finite Cover ⇒ Chromatic Bound** (100–113)
5. **The Sharp Finite Equivalence** (115–128) — `colorable_two_pow_iff_bipartiteCover`
6. **Chromatic Bound and the ℵ₁ Corollary** (130–154)

## Notes
- Annotations (5, all with mathContext) and overview/conclusion were already complete.
- meta.json 7.7 KB → 10.6 KB, well under the 60 KB cap (`gallery:check-size`: within caps).
- JSON validated.