### PR TITLE
research(divisibility-by-three-oq-01-oq-03): general alternating digit-sum rule for base b ≡ -1 (mod d) [VERIFIED, 0-axiom, +14thm]

### DIFF
--- a/proofs/Proofs/DivisibilityByThreeOQ01OQ03.lean
+++ b/proofs/Proofs/DivisibilityByThreeOQ01OQ03.lean
@@ -1,0 +1,204 @@
+/-
+Formal Divisibility Rules — Extension OQ-01-OQ-03
+
+**Casting out nines, the alternating dual: general alternating digit-sum rule
+for any base b ≡ -1 (mod d).**
+
+The parent extension (DivisibilityByThreeOQ01) develops the *additive* digit-sum
+theory: when the base b satisfies b ≡ 1 (mod d), a number is congruent to the
+plain sum of its base-b digits (casting out nines is the case b = 10, d = 9).
+Mathlib packages this as `Nat.modEq_digits_sum` / `Nat.dvd_iff_dvd_digits_sum`.
+
+The *dual* phenomenon — bases with b ≡ -1 (mod d) — produces the **alternating**
+digit-sum rule. Mathlib only records the single classical instance
+`Nat.modEq_eleven_digits_sum` / `Nat.eleven_dvd_iff` (base 10, mod 11). This file
+proves the general statement for arbitrary (b, d) with d ∣ b + 1, exactly
+paralleling the additive theory, and derives the divisibility tests that the
+parent's Part X only *mentions* without proof: since 1001 = 7·11·13, alternating
+three-digit (base-1000) group sums simultaneously test divisibility by 7, 11, 13
+and 1001.
+
+Main results:
+* `modEq_alternating_digits`  — congruence: n ≡ altSum(digits b n) (mod d) when d ∣ b+1
+* `dvd_iff_dvd_alternating_digits` — divisibility test form
+* `dvd_succ_base_iff_alternating` — the universal corollary: in any base b,
+    (b+1) ∣ n ↔ (b+1) ∣ altSum(digits b n)  (generalizes "11 in base 10")
+* Instances: 11 (base 10), 101 (base 100), and 7 / 11 / 13 / 1001 (base 1000)
+* `alternating_digit_rules_summary` — master statement
+
+Everything reduces to Mathlib's master congruence `Nat.zmodeq_ofDigits_digits`
+with residue c = -1, so the file is fully machine-checked with no axioms.
+
+Tags: number-theory, modular-arithmetic, divisibility, alternating-digit-sum, extension
+-/
+
+import Mathlib.Data.Nat.Digits.Div
+import Mathlib.Tactic
+
+open Nat
+
+namespace DivisibilityByThreeOQ01OQ03
+
+/-- The alternating sum of the base-`b` digits of `n`, taken in `ℤ`.
+    `[a₀, a₁, a₂, …] ↦ a₀ - a₁ + a₂ - …`. -/
+def altDigitSum (b n : ℕ) : ℤ :=
+  ((Nat.digits b n).map fun k : ℕ => (k : ℤ)).alternatingSum
+
+-- ============================================================
+-- Part I: The general alternating digit-sum theorem
+-- ============================================================
+
+/-- **General casting-out (alternating form), congruence version.**
+
+    If the base `b` satisfies `d ∣ b + 1` (i.e. `b ≡ -1 mod d`), then every
+    natural number is congruent modulo `d` to the alternating sum of its
+    base-`b` digits. This is the exact dual of the additive rule
+    `Nat.modEq_digits_sum` (which needs `b ≡ 1 mod d`).
+
+    Specializing `b = 10, d = 11` recovers `Nat.modEq_eleven_digits_sum`. -/
+theorem modEq_alternating_digits (d b : ℕ) (h : (d : ℤ) ∣ (b : ℤ) + 1) (n : ℕ) :
+    (n : ℤ) ≡ altDigitSum b n [ZMOD (d : ℤ)] := by
+  have hmod : (b : ℤ) ≡ -1 [ZMOD (d : ℤ)] := by
+    rw [Int.modEq_iff_dvd]
+    have : (-1 : ℤ) - (b : ℤ) = -((b : ℤ) + 1) := by ring
+    rw [this]
+    exact (dvd_neg).mpr h
+  have t := Nat.zmodeq_ofDigits_digits d b (-1 : ℤ) hmod n
+  rwa [Nat.ofDigits_neg_one] at t
+
+/-- **General casting-out (alternating form), divisibility test version.**
+
+    If `d ∣ b + 1`, then `d ∣ n` iff `d` divides the alternating sum of the
+    base-`b` digits of `n`. Dual of `Nat.dvd_iff_dvd_digits_sum`. -/
+theorem dvd_iff_dvd_alternating_digits (d b : ℕ) (h : (d : ℤ) ∣ (b : ℤ) + 1) (n : ℕ) :
+    d ∣ n ↔ (d : ℤ) ∣ altDigitSum b n := by
+  have hd : (d : ℤ) ∣ (b : ℤ) - (-1 : ℤ) := by
+    have : (b : ℤ) - (-1 : ℤ) = (b : ℤ) + 1 := by ring
+    rw [this]; exact h
+  have t := Nat.dvd_iff_dvd_ofDigits d b (-1 : ℤ) hd n
+  rwa [Nat.ofDigits_neg_one] at t
+
+/-- **Universal corollary.** For *every* base `b ≥ 2`, the number `b + 1` divides
+    `n` exactly when it divides the alternating sum of the base-`b` digits of `n`.
+
+    This is the "one free divisor" every positional system carries: base 10 gives
+    the classical divisibility-by-11 rule, base 2 gives divisibility by 3, base 16
+    gives divisibility by 17, etc. No coprimality or primality hypothesis is
+    needed — it holds because `(b+1) ∣ (b+1)` tautologically. -/
+theorem dvd_succ_base_iff_alternating (b n : ℕ) :
+    (b + 1) ∣ n ↔ ((b : ℤ) + 1) ∣ altDigitSum b n := by
+  have h : ((b + 1 : ℕ) : ℤ) ∣ (b : ℤ) + 1 := by push_cast; exact dvd_refl _
+  have := dvd_iff_dvd_alternating_digits (b + 1) b h n
+  rwa [show ((b + 1 : ℕ) : ℤ) = (b : ℤ) + 1 by push_cast; ring] at this
+
+-- ============================================================
+-- Part II: Classical and new instances
+-- ============================================================
+
+/-- **Divisibility by 11** (base 10) — recovers `Nat.eleven_dvd_iff`. -/
+theorem eleven_dvd_iff_alt (n : ℕ) :
+    11 ∣ n ↔ (11 : ℤ) ∣ altDigitSum 10 n :=
+  dvd_iff_dvd_alternating_digits 11 10 (by norm_num) n
+
+/-- **Divisibility by 101** via alternating two-digit (base-100) groups.
+    Here `101 ∣ 100 + 1`. -/
+theorem onehundredone_dvd_iff_alt (n : ℕ) :
+    101 ∣ n ↔ (101 : ℤ) ∣ altDigitSum 100 n :=
+  dvd_iff_dvd_alternating_digits 101 100 (by norm_num) n
+
+-- The next four all ride on 1001 = 7·11·13, i.e. 1000 ≡ -1 (mod 7, 11, 13, 1001).
+-- This is the classical "alternating three-digit groups" test.
+
+/-- **Divisibility by 7** via alternating three-digit (base-1000) groups. -/
+theorem seven_dvd_iff_alt_base1000 (n : ℕ) :
+    7 ∣ n ↔ (7 : ℤ) ∣ altDigitSum 1000 n :=
+  dvd_iff_dvd_alternating_digits 7 1000 (by norm_num) n
+
+/-- **Divisibility by 11** via alternating three-digit (base-1000) groups. -/
+theorem eleven_dvd_iff_alt_base1000 (n : ℕ) :
+    11 ∣ n ↔ (11 : ℤ) ∣ altDigitSum 1000 n :=
+  dvd_iff_dvd_alternating_digits 11 1000 (by norm_num) n
+
+/-- **Divisibility by 13** via alternating three-digit (base-1000) groups. -/
+theorem thirteen_dvd_iff_alt_base1000 (n : ℕ) :
+    13 ∣ n ↔ (13 : ℤ) ∣ altDigitSum 1000 n :=
+  dvd_iff_dvd_alternating_digits 13 1000 (by norm_num) n
+
+/-- **Divisibility by 1001** via alternating three-digit (base-1000) groups. -/
+theorem tenohone_dvd_iff_alt_base1000 (n : ℕ) :
+    1001 ∣ n ↔ (1001 : ℤ) ∣ altDigitSum 1000 n :=
+  dvd_iff_dvd_alternating_digits 1001 1000 (by norm_num) n
+
+/-- **Divisibility by 3 in binary**: `2 ≡ -1 (mod 3)`, so `3 ∣ n` iff `3` divides
+    the alternating sum of the *bits* of `n`. (Instance of the universal corollary
+    with `b = 2`.) -/
+theorem three_dvd_iff_alt_binary (n : ℕ) :
+    3 ∣ n ↔ (3 : ℤ) ∣ altDigitSum 2 n :=
+  dvd_iff_dvd_alternating_digits 3 2 (by norm_num) n
+
+/-- **Divisibility by 17 in hexadecimal**: `16 ≡ -1 (mod 17)`. -/
+theorem seventeen_dvd_iff_alt_hex (n : ℕ) :
+    17 ∣ n ↔ (17 : ℤ) ∣ altDigitSum 16 n :=
+  dvd_iff_dvd_alternating_digits 17 16 (by norm_num) n
+
+-- ============================================================
+-- Part III: Congruence (casting-out) instances
+-- ============================================================
+
+/-- Casting out elevens: `n ≡ altDigitSum₁₀(n) (mod 11)`. -/
+theorem casting_out_elevens (n : ℕ) :
+    (n : ℤ) ≡ altDigitSum 10 n [ZMOD 11] :=
+  modEq_alternating_digits 11 10 (by norm_num) n
+
+/-- Alternating three-digit groups mod 7 (base 1000): `n ≡ altDigitSum₁₀₀₀(n) (mod 7)`. -/
+theorem casting_out_sevens_base1000 (n : ℕ) :
+    (n : ℤ) ≡ altDigitSum 1000 n [ZMOD 7] :=
+  modEq_alternating_digits 7 1000 (by norm_num) n
+
+-- ============================================================
+-- Part IV: Numerical verification
+-- ============================================================
+
+-- 1001 = 7·11·13 is the arithmetic behind the base-1000 alternating test.
+example : 1001 = 7 * 11 * 13 := by norm_num
+example : (1000 : ℤ) + 1 = 1001 := by norm_num
+
+-- Concrete divisibility checks.
+example : 11 ∣ 121 := by decide
+example : 11 ∣ 1001 := by decide
+example : 7 ∣ 1001 := by decide
+example : 13 ∣ 1001 := by decide
+example : 101 ∣ 10201 := by decide
+
+-- The alternating base-1000 digit sum of 1_002_001 is 1 - 2 + 1 = 0, so it is
+-- divisible by 7, 11, 13 and 1001 simultaneously.
+example : altDigitSum 1000 1002001 = 0 := by native_decide
+example : 1001 ∣ 1002001 := by decide
+
+-- Alternating decimal digit sum of 1331 is 1 - 3 + 3 - 1 = 0 ⇒ divisible by 11.
+example : altDigitSum 10 1331 = 0 := by native_decide
+example : 11 ∣ 1331 := by decide
+
+-- ============================================================
+-- Part V: Master summary theorem
+-- ============================================================
+
+/-- Master statement collecting the alternating digit-sum divisibility tests
+    proved in this extension, alongside the universal corollary. -/
+theorem alternating_digit_rules_summary :
+    -- Universal: every base carries a free divisor b+1
+    (∀ (b n : ℕ), (b + 1) ∣ n ↔ ((b : ℤ) + 1) ∣ altDigitSum b n) ∧
+    -- Classical base-10 rule for 11
+    (∀ n, 11 ∣ n ↔ (11 : ℤ) ∣ altDigitSum 10 n) ∧
+    -- Base-100 rule for 101
+    (∀ n, 101 ∣ n ↔ (101 : ℤ) ∣ altDigitSum 100 n) ∧
+    -- Base-1000 alternating group tests (1001 = 7·11·13)
+    (∀ n, 7 ∣ n ↔ (7 : ℤ) ∣ altDigitSum 1000 n) ∧
+    (∀ n, 11 ∣ n ↔ (11 : ℤ) ∣ altDigitSum 1000 n) ∧
+    (∀ n, 13 ∣ n ↔ (13 : ℤ) ∣ altDigitSum 1000 n) ∧
+    (∀ n, 1001 ∣ n ↔ (1001 : ℤ) ∣ altDigitSum 1000 n) := by
+  refine ⟨dvd_succ_base_iff_alternating, eleven_dvd_iff_alt, onehundredone_dvd_iff_alt,
+    seven_dvd_iff_alt_base1000, eleven_dvd_iff_alt_base1000, thirteen_dvd_iff_alt_base1000,
+    tenohone_dvd_iff_alt_base1000⟩
+
+end DivisibilityByThreeOQ01OQ03

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-oq0103-altdigitsum-def",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 42, "endLine": 45 },
+    "type": "definition",
+    "title": "Alternating Digit Sum over ℤ",
+    "content": "altDigitSum b n is defined as the alternating sum a₀ - a₁ + a₂ - … of the base-b digits of n, computed in ℤ. Concretely it maps the digit list Nat.digits b n (least-significant-first) into ℤ and applies List.alternatingSum. Working over ℤ (rather than ℕ) is essential: alternating sums can be negative, and the divisibility/congruence statements are naturally integer statements. This is the alternating counterpart of the plain digit sum used in casting out nines.",
+    "mathContext": "$\\text{altDigitSum}_b(n) = \\sum_i (-1)^i a_i = a_0 - a_1 + a_2 - \\cdots$ where $n = \\sum_i a_i b^i$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.digits", "List.alternatingSum", "base representation", "casting out elevens"],
+    "prerequisites": ["positional notation", "Nat.digits API", "List.alternatingSum"]
+  },
+  {
+    "id": "ann-oq0103-modeq-general",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 59, "endLine": 71 },
+    "type": "theorem",
+    "title": "General Alternating Casting-Out (Congruence Form)",
+    "content": "The central result: whenever the base b satisfies d ∣ b+1 (equivalently b ≡ -1 mod d), every natural number is congruent modulo d to the alternating sum of its base-b digits. The proof converts the divisibility hypothesis d ∣ b+1 into the modular hypothesis b ≡ -1 [ZMOD d] using Int.modEq_iff_dvd (with the ring rewrite -1 - b = -(b+1) and dvd_neg), then applies Mathlib's master congruence Nat.zmodeq_ofDigits_digits at residue c = -1, and finally rewrites Nat.ofDigits_neg_one to expose the alternating sum. This is the exact dual of Nat.modEq_digits_sum (which requires b ≡ 1 mod d).",
+    "mathContext": "If $d \\mid b+1$ then $n \\equiv \\text{altDigitSum}_b(n) \\pmod d$. Dual to casting out nines: there $10 \\equiv 1 \\pmod 9$; here $b \\equiv -1 \\pmod d$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.zmodeq_ofDigits_digits", "Nat.ofDigits_neg_one", "Int.modEq_iff_dvd", "casting out nines"],
+    "prerequisites": ["Int.ModEq", "Nat.ofDigits", "modular arithmetic"]
+  },
+  {
+    "id": "ann-oq0103-dvd-general",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 73, "endLine": 84 },
+    "type": "theorem",
+    "title": "General Alternating Divisibility Test",
+    "content": "The divisibility-test form: when d ∣ b+1, we have d ∣ n if and only if d divides the alternating sum of the base-b digits of n. Proved by applying Nat.dvd_iff_dvd_ofDigits at c = -1 (whose hypothesis d ∣ b - (-1) = b + 1 is exactly ours) and rewriting Nat.ofDigits_neg_one. This is the dual of Nat.dvd_iff_dvd_digits_sum and the engine behind every concrete rule below.",
+    "mathContext": "If $d \\mid b+1$ then $d \\mid n \\iff d \\mid \\text{altDigitSum}_b(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.dvd_iff_dvd_ofDigits", "divisibility rule", "alternating sum"],
+    "prerequisites": ["Nat.ofDigits", "divisibility in ℤ"]
+  },
+  {
+    "id": "ann-oq0103-universal-corollary",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 88, "endLine": 92 },
+    "type": "theorem",
+    "title": "Universal Corollary: Every Base Tests b+1",
+    "content": "For every base b, the number b+1 divides n exactly when it divides the alternating base-b digit sum. This needs no coprimality or primality hypothesis because the required condition d ∣ b+1 becomes (b+1) ∣ (b+1), a tautology (dvd_refl after push_cast). Thus every positional numeral system carries a built-in alternating-sum divisibility test for b+1: base 10 → divisibility by 11, base 2 → by 3, base 16 → by 17.",
+    "mathContext": "$(b+1) \\mid n \\iff (b+1) \\mid \\text{altDigitSum}_b(n)$ for all bases $b$.",
+    "significance": "key",
+    "relatedConcepts": ["dvd_refl", "positional notation", "divisibility by eleven"],
+    "prerequisites": ["natural number coercion to ℤ", "push_cast"]
+  },
+  {
+    "id": "ann-oq0103-base1000-tests",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 111, "endLine": 132 },
+    "type": "concept",
+    "title": "Base-1000 Group Tests: 7, 11, 13, 1001 via 1001 = 7·11·13",
+    "content": "Because 1001 = 7·11·13, we have 1000 ≡ -1 modulo each of 7, 11, 13 and 1001. Applying the general alternating divisibility test in base 1000 therefore yields simultaneous divisibility tests for all four moduli: group the decimal digits into blocks of three and alternately add and subtract the blocks. This is exactly the classical hand rule for divisibility by 7. The parent extension only remarked on this factorization in a comment; here each rule is a proven theorem obtained by a one-line application with a norm_num proof of d ∣ 1001.",
+    "mathContext": "$1000 \\equiv -1 \\pmod{7},\\ \\pmod{11},\\ \\pmod{13},\\ \\pmod{1001}$, so alternating three-digit group sums decide divisibility by all four at once.",
+    "significance": "supporting",
+    "relatedConcepts": ["1001 = 7·11·13", "divisibility by 7", "three-digit grouping"],
+    "prerequisites": ["general alternating divisibility test", "norm_num"]
+  },
+  {
+    "id": "ann-oq0103-summary",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 188, "endLine": 204 },
+    "type": "theorem",
+    "title": "Master Summary Statement",
+    "content": "alternating_digit_rules_summary bundles the universal corollary (every base b tests b+1) together with the base-10 (11), base-100 (101), and base-1000 (7, 11, 13, 1001) instances into a single conjunction, giving a one-glance record of the alternating digit-sum rules formalized in this entry. Its proof is simply the tuple of the individually proved theorems.",
+    "mathContext": "A conjunction collecting the general rule and its principal instances into one statement.",
+    "significance": "context",
+    "relatedConcepts": ["summary theorem", "divisibility rules"],
+    "prerequisites": ["all preceding theorems in the file"]
+  }
+]

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-03/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "divisibility-by-three-oq-01-oq-03",
+  "title": "General Alternating Digit-Sum Rule (base b ≡ -1 mod d)",
+  "slug": "divisibility-by-three-oq-01-oq-03",
+  "description": "The alternating dual of casting out nines: proves that for any base b with d ∣ b+1 (i.e. b ≡ -1 mod d), a number is congruent modulo d to the alternating sum of its base-b digits. This generalizes Mathlib's single base-10/mod-11 instance to arbitrary (b, d), and derives the classical base-1000 alternating three-digit-group tests for 7, 11, 13 and 1001 (since 1001 = 7·11·13). Fully machine-checked, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Divisibility_rule#Divisibility_by_7",
+    "date": "Classical result, formalized 2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "modular-arithmetic",
+      "divisibility",
+      "alternating-digit-sum",
+      "casting-out-nines",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/DivisibilityByThreeOQ01OQ03.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 sorries, 0 explicit axiom declarations, 0 structure-encoded assumptions. All four headline theorems (modEq_alternating_digits, dvd_iff_dvd_alternating_digits, dvd_succ_base_iff_alternating, alternating_digit_rules_summary) verified via `#print axioms` to depend only on the standard foundational axioms propext / Classical.choice / Quot.sound — NOT sorryAx and NOT Lean.ofReduceBool. Two illustrative `example` blocks in Part IV use `native_decide` to evaluate concrete alternating digit sums (Nat.digits is well-founded recursion and does not reduce under `decide`), but these examples are not the substantive results and do not appear in any theorem's axiom set.",
+    "originalContributions": [
+      "modEq_alternating_digits (d b : ℕ) (h : (d:ℤ) ∣ (b:ℤ)+1) : (n:ℤ) ≡ altDigitSum b n [ZMOD d] — the general alternating casting-out congruence, dual to Nat.modEq_digits_sum",
+      "dvd_iff_dvd_alternating_digits — the divisibility-test form, dual to Nat.dvd_iff_dvd_digits_sum, general over all (b, d) with d ∣ b+1",
+      "dvd_succ_base_iff_alternating (b n : ℕ) : (b+1) ∣ n ↔ ((b:ℤ)+1) ∣ altDigitSum b n — universal corollary: every positional base b carries a free divisor b+1 tested by alternating digit sum (no coprimality hypothesis)",
+      "seven/eleven/thirteen/tenohone_dvd_iff_alt_base1000 — proves the classical alternating three-digit-group tests for 7, 11, 13, 1001 (the parent extension only mentions these in a comment without proof)",
+      "alternating_digit_rules_summary — master statement bundling the universal corollary with the base-10, base-100, and base-1000 instances"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 204,
+    "theoremCount": 14,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Casting out nines — the observation that 10 ≡ 1 (mod 9), so a decimal number is congruent to the sum of its digits mod 9 — is ancient, appearing in Indian and Islamic arithmetic and popularized in Europe by Fibonacci's 1202 Liber Abaci. Its lesser-known dual arises when the base is one *less* than a multiple of the modulus: 10 ≡ -1 (mod 11) gives the divisibility-by-eleven rule using the *alternating* digit sum a₀ - a₁ + a₂ - …. The same idea, applied in base 1000, exploits the factorization 1001 = 7·11·13: since 1000 ≡ -1 (mod 7), (mod 11), and (mod 13), grouping decimal digits into blocks of three and alternately adding and subtracting them simultaneously tests divisibility by 7, 11, 13 and 1001 — the standard hand rule taught for divisibility by 7. Mathlib formalizes the additive casting-out rule in full generality (Nat.modEq_digits_sum, any base b ≡ 1 mod d) but records the alternating rule only in the single classical instance base 10 / mod 11 (Nat.modEq_eleven_digits_sum). This entry closes that asymmetry.",
+    "problemStatement": "**Open Question (OQ-03 from divisibility-by-three-oq-01)**: The parent extension develops the additive digit-sum theory (base b ≡ 1 mod d) and, in its Part X, merely *remarks* that 1001 = 7·11·13 makes alternating three-digit group sums test divisibility by 7, 11, 13. Can the *alternating* casting-out rule be proved in the same generality as the additive one — for every base b with b ≡ -1 (mod d) — and can the base-1000 group tests be turned from a comment into theorems?\n\n**Answer**: YES. A single application of Mathlib's master congruence Nat.zmodeq_ofDigits_digits with residue c = -1 yields the general congruence and divisibility forms, from which all the concrete rules follow.",
+    "text": "A 204-line formalization. `altDigitSum b n` is defined as the alternating sum (over ℤ) of the base-b digits of n. The two general theorems `modEq_alternating_digits` and `dvd_iff_dvd_alternating_digits` are proved by reducing to Mathlib's `Nat.zmodeq_ofDigits_digits` / `Nat.dvd_iff_dvd_ofDigits` at residue c = -1 and rewriting `Nat.ofDigits (-1) = List.alternatingSum ∘ map`. From these follow the universal corollary (every base b tests b+1 via alternating digits) and the concrete rules for 11 (base 10), 101 (base 100), 3 (binary), 17 (hex), and 7/11/13/1001 (base 1000). All substantive theorems are 0-axiom.",
+    "proofStrategy": "**Part I** (general theorems): For `modEq_alternating_digits`, convert the hypothesis d ∣ b+1 into b ≡ -1 [ZMOD d] via `Int.modEq_iff_dvd` (rewriting -1 - b = -(b+1) and using dvd_neg), apply `Nat.zmodeq_ofDigits_digits d b (-1)`, then rewrite `Nat.ofDigits_neg_one` to expose the alternating sum. The divisibility form `dvd_iff_dvd_alternating_digits` is analogous via `Nat.dvd_iff_dvd_ofDigits`. The universal corollary `dvd_succ_base_iff_alternating` instantiates d = b+1, where d ∣ b+1 holds by `dvd_refl` after `push_cast`.\n\n**Part II** (instances): Each named rule is a one-line application of the general divisibility theorem with the modulus/base pair and a `norm_num` proof of d ∣ b+1. The 7/11/13/1001 rules all use base 1000, encoding 1001 = 7·11·13.\n\n**Part III/IV** (congruences and numerical checks): casting_out_elevens / casting_out_sevens_base1000 are congruence-form instances; Part IV verifies concrete computations (e.g. altDigitSum 1000 1002001 = 0 ⇒ divisibility by 1001).\n\n**Part V**: `alternating_digit_rules_summary` bundles the universal corollary and the key instances into a single master statement.",
+    "keyInsights": [
+      "**One master lemma, two dual rules**: Mathlib's `Nat.zmodeq_ofDigits_digits b b' c` (n ≡ ofDigits c (digits b' n) mod b whenever b' ≡ c mod b) specializes at c = 1 to the digit-sum rule and at c = -1 to the alternating rule. The additive theory (parent) and this alternating theory are the two faces of the same theorem.",
+      "**ofDigits at -1 is the alternating sum**: `Nat.ofDigits_neg_one` rewrites ofDigits (-1) L into (L.map (↑·)).alternatingSum, the bridge that turns the abstract polynomial evaluation into the familiar a₀ - a₁ + a₂ - … .",
+      "**Every base carries a free divisor**: `dvd_succ_base_iff_alternating` needs no coprimality or primality — (b+1) ∣ (b+1) is a tautology — so *every* positional numeral system has a built-in alternating-sum test for b+1 (base 10 → 11, base 2 → 3, base 16 → 17).",
+      "**1001 = 7·11·13 unifies three tests**: Because 1000 ≡ -1 modulo each of 7, 11, 13 (and 1001), a single base-1000 alternating group sum simultaneously decides divisibility by all four — this is precisely the hand rule for divisibility by 7.",
+      "**Congruence via modEq_iff_dvd**: The residue hypothesis b ≡ -1 [ZMOD d] is obtained cleanly from the divisibility hypothesis d ∣ b+1 by `Int.modEq_iff_dvd` and a `ring` rewrite of -1 - b = -(b+1)."
+    ],
+    "prerequisites": [
+      "Casting out nines: n ≡ digitSum(n) (mod 9), and its generalization to base b ≡ 1 mod d",
+      "Nat.digits in Lean 4: Nat.digits b n returns the base-b digit list (least significant first)",
+      "List.alternatingSum: a₀ - a₁ + a₂ - a₃ + …",
+      "Nat.zmodeq_ofDigits_digits and Nat.ofDigits_neg_one from Mathlib.Data.Nat.Digits.Div",
+      "Int.modEq_iff_dvd: a ≡ b [ZMOD n] ↔ n ∣ b - a"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "divisibility-by-three-oq-01",
+      "relationship": "extends",
+      "description": "Parent extension developing the additive digit-sum theory (base b ≡ 1 mod d). Its Part X remarks that 1001 = 7·11·13 makes alternating three-digit group sums test 7/11/13; this entry proves that remark as theorems and generalizes the alternating rule to arbitrary (b, d)."
+    },
+    {
+      "targetId": "divisibility-by-three-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling leaf proving convergence of the (additive) digital root iteration; this entry is the alternating-sum counterpart of the same casting-out principle."
+    },
+    {
+      "targetId": "divisibility-rules",
+      "relationship": "related",
+      "description": "Comprehensive collection of divisibility rules; the general alternating rule proved here subsumes the eleven / seven (via 1001) hand rules listed there."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Digits.Div",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "DivisibilityByThreeOQ01OQ03",
+    "lineCount": 204,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 1,
+    "path": "Proofs/DivisibilityByThreeOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header, Imports, and altDigitSum Definition",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring explaining the alternating dual of casting out nines, imports (Mathlib.Data.Nat.Digits.Div for the master congruence), and the definition altDigitSum b n = alternatingSum of the base-b digits mapped into ℤ.",
+      "mathContext": "$\\text{altDigitSum}_b(n) = a_0 - a_1 + a_2 - \\cdots$ where $[a_0, a_1, \\ldots]$ are the base-$b$ digits of $n$."
+    },
+    {
+      "id": "sec-general",
+      "title": "Part I: The General Alternating Digit-Sum Theorems",
+      "startLine": 47,
+      "endLine": 92,
+      "summary": "modEq_alternating_digits (congruence form) and dvd_iff_dvd_alternating_digits (divisibility form) for any base b with d ∣ b+1, plus the universal corollary dvd_succ_base_iff_alternating. All proved by reducing to Nat.zmodeq_ofDigits_digits / Nat.dvd_iff_dvd_ofDigits at c = -1.",
+      "mathContext": "If $d \\mid b+1$ then $n \\equiv \\text{altDigitSum}_b(n) \\pmod d$ and $d \\mid n \\iff d \\mid \\text{altDigitSum}_b(n)$. In particular $(b+1) \\mid n \\iff (b+1) \\mid \\text{altDigitSum}_b(n)$ for every base $b$."
+    },
+    {
+      "id": "sec-instances",
+      "title": "Part II: Classical and New Instances",
+      "startLine": 94,
+      "endLine": 142,
+      "summary": "Divisibility tests: 11 (base 10, recovers Nat.eleven_dvd_iff), 101 (base 100), 7 / 11 / 13 / 1001 (base 1000 via 1001 = 7·11·13), 3 (binary), 17 (hexadecimal). Each is a one-line application of the general theorem with a norm_num proof of d ∣ b+1.",
+      "mathContext": "$1001 = 7 \\cdot 11 \\cdot 13$, so $1000 \\equiv -1 \\pmod{7,\\,11,\\,13,\\,1001}$; base-1000 alternating group sums test all four moduli at once."
+    },
+    {
+      "id": "sec-congruence",
+      "title": "Part III: Congruence (Casting-Out) Instances",
+      "startLine": 144,
+      "endLine": 156,
+      "summary": "casting_out_elevens (n ≡ altDigitSum₁₀(n) mod 11) and casting_out_sevens_base1000 (n ≡ altDigitSum₁₀₀₀(n) mod 7) as congruence-form specializations.",
+      "mathContext": "$n \\equiv \\text{altDigitSum}_{10}(n) \\pmod{11}$ and $n \\equiv \\text{altDigitSum}_{1000}(n) \\pmod 7$."
+    },
+    {
+      "id": "sec-verification",
+      "title": "Part IV: Numerical Verification",
+      "startLine": 158,
+      "endLine": 181,
+      "summary": "Concrete checks: 1001 = 7·11·13; 11 ∣ 121/1001, 7 ∣ 1001, 13 ∣ 1001, 101 ∣ 10201; altDigitSum 1000 1002001 = 0 (⇒ 1001 ∣ 1002001); altDigitSum 10 1331 = 0 (⇒ 11 ∣ 1331). The two altDigitSum evaluations use native_decide (illustrative only).",
+      "mathContext": "$1\\,002\\,001 = 1001^2$ has base-1000 digits $[1,2,1]$ with alternating sum $1-2+1 = 0$, so $1001 \\mid 1\\,002\\,001$."
+    },
+    {
+      "id": "sec-summary",
+      "title": "Part V: Master Summary Theorem",
+      "startLine": 182,
+      "endLine": 204,
+      "summary": "alternating_digit_rules_summary bundles the universal corollary (∀ b, (b+1) test) with the base-10 (11), base-100 (101), and base-1000 (7, 11, 13, 1001) instances into a single conjunction.",
+      "mathContext": "A single statement collecting the general rule and its principal instances."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves the alternating dual of casting out nines in full generality: for any base b with d ∣ b+1, a number is congruent mod d to the alternating sum of its base-b digits, and divisibility by d is decided by that alternating sum. This generalizes Mathlib's lone base-10/mod-11 instance and turns the parent extension's Part X remark about 1001 = 7·11·13 into proven theorems for the 7/11/13/1001 base-1000 tests. All four headline theorems are 0-axiom (propext/Classical.choice/Quot.sound only).",
+    "implications": "The additive rule (base b ≡ 1 mod d) and the alternating rule (base b ≡ -1 mod d) are now both formalized as specializations of the same master congruence Nat.zmodeq_ofDigits_digits at residues c = ±1, making the symmetry explicit. The universal corollary dvd_succ_base_iff_alternating records that every positional numeral system carries a free alternating-sum divisibility test for b+1, independent of any coprimality assumption. The base-1000 unification of the 7, 11, 13 tests via 1001 = 7·11·13 formalizes the standard hand rule for divisibility by 7. Natural next steps generalize the residue to arbitrary c (mixed digit-weight rules such as the osculator/truncation methods) and to product moduli where multiple ±1 residues combine.",
+    "openQuestions": [
+      "Unify the additive and alternating rules into a single parameterized theorem over the residue c ∈ {1, -1}, and extend to general residues c to capture weighted digit tests (osculator methods for 7, 13, 17, 19)",
+      "Prove a block-grouping meta-theorem: for base b^k, digits group into k-blocks, and derive simultaneously all divisors of b^k ± 1 (e.g. base 100 gives 3, 9, 11, 33, 99, 101 tests at once)",
+      "Formalize the alternating persistence / iterated alternating digit sum and characterize its fixed points, mirroring the additive digital root convergence in the sibling entry"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves the **alternating dual of casting out nines** in full generality. For any base `b` with `d ∣ b+1` (equivalently `b ≡ -1 mod d`), a number is congruent modulo `d` to the **alternating** sum of its base-`b` digits, and divisibility by `d` is decided by that alternating sum.

This closes an asymmetry in Mathlib: the additive rule `Nat.modEq_digits_sum` is fully general (any `b ≡ 1 mod d`), but the alternating rule exists only as the single classical instance `Nat.modEq_eleven_digits_sum` (base 10, mod 11). It also turns the parent extension's Part X *remark* about `1001 = 7·11·13` into proven theorems.

## Problem

**OQ-03 from `divisibility-by-three-oq-01`.** The parent develops the additive digit-sum theory (`b ≡ 1 mod d`) and only comments that `1001 = 7·11·13` makes alternating three-digit group sums test 7/11/13. Can the alternating rule be proved in the same generality, and those base-1000 tests made into theorems? **Yes.**

## Main results (all VERIFIED, 0-axiom)

- `modEq_alternating_digits` — `n ≡ altDigitSum b n [ZMOD d]` when `d ∣ b+1`
- `dvd_iff_dvd_alternating_digits` — divisibility-test form
- `dvd_succ_base_iff_alternating` — **universal corollary**: every base `b` carries a free `b+1` test (base 10 → 11, base 2 → 3, base 16 → 17), no coprimality needed
- Instances: 11 (base 10, recovers `Nat.eleven_dvd_iff`), 101 (base 100), 7/11/13/1001 (base 1000), 3 (binary), 17 (hex)
- `alternating_digit_rules_summary` — master statement

Everything reduces to Mathlib's master congruence `Nat.zmodeq_ofDigits_digits` at residue `c = -1`, making the additive/alternating symmetry (`c = ±1`) explicit.

## Verification

`#print axioms` on all four headline theorems lists only `propext / Classical.choice / Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Two `example` blocks use `native_decide` to evaluate concrete alternating sums (`Nat.digits` is well-founded recursion and won't reduce under `decide`); these are illustrative only and appear in no theorem's axiom set. File type-checks via `lake env lean` (204 lines, 14 theorems, 1 definition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)