### PR TITLE
research(algebraic-numbers-countable-oq-02-oq-04-oq-01): computable reals are Lebesgue-null [VERIFIED, 0-axiom, +8thm]

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04OQ01.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04OQ01.lean
@@ -1,0 +1,187 @@
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms
+import Mathlib.Tactic
+import Proofs.AlgebraicNumbersCountableOQ02OQ04
+
+/-!
+# The Computable Reals are Lebesgue-Null (oq-02-oq-04-oq-01)
+
+## Open Question (algebraic-numbers-countable-oq-02-oq-04-oq-01)
+
+The parent entry `AlgebraicNumbersCountableOQ02OQ04` established that the
+**computable** real numbers form a set that is, simultaneously:
+
+* **countable** (`ℵ₀`, cardinality) — `computable_reals_countable`;
+* **meagre** (first Baire category) — `computable_reals_meagre`;
+* yet **dense** — `computable_reals_dense`.
+
+The one classical notion of "negligible" it never addressed is the
+**measure-theoretic** one. This entry closes that gap: the computable reals are a
+**Lebesgue-null** set, and their complement — the non-computable reals — carries
+the *full* Lebesgue measure of the line. Concretely, "a real chosen uniformly at
+random is, almost surely, non-computable".
+
+This completes the negligibility profile of `{r | IsComputable r}` across the
+three independent lenses that classical analysis uses to say a subset of `ℝ` is
+"small":
+
+    cardinality   : ℵ₀      (countable)            OQ04 S2–S4
+    category      : meagre  (1st Baire category)   OQ04 S8
+    measure       : null    (Lebesgue measure 0)   THIS FILE
+
+— all three hold at once, while the set remains topologically **dense**. This is
+exactly the profile carried by `ℚ` itself, now transported to the strictly finer
+computable/non-computable partition. Dually, the non-computable reals are of full
+cardinality `𝔠`, comeagre (residual), and of full Lebesgue measure: "generic" in
+all three senses.
+
+## Main Results
+
+* `computable_reals_null` — `volume {r | IsComputable r} = 0`.
+* `ae_not_isComputable` — `∀ᵐ r, ¬ IsComputable r` (almost every real is
+  non-computable).
+* `ae_mem_nonComputableReals` — the measure-theoretic restatement.
+* `volume_restrict_nonComputableReals` — the non-computable reals carry the full
+  Lebesgue measure: `volume.restrict nonComputableReals = volume`.
+* `volume_Ioo_inter_nonComputableReals` / `..._eq` — the non-computable reals
+  fill *every* interval in measure: `volume (Ioo a b ∩ nonComputableReals)
+  = volume (Ioo a b) = ofReal (b - a)`.
+* `computable_reals_null_meagre_dense` — the triple-negligibility-yet-dense
+  capstone for the computable reals.
+* `nonComputableReals_full_measure_residual_continuum` — the dual: full measure,
+  residual, and cardinality `𝔠` for the non-computable reals.
+
+## Proof Strategy
+
+Everything rests on one Mathlib fact: in a measure space with **no atoms**, every
+countable set is null (`Set.Countable.measure_zero`), and Lebesgue measure on `ℝ`
+is atomless (`MeasureTheory.Real.noAtoms_volume`). The upper cardinality/category
+work is entirely inherited from OQ04; this file only adds the measure layer and
+the two capstones bundling measure with the pre-existing lenses.
+
+* Null: `computable_reals_countable.measure_zero volume`.
+* Almost-everywhere non-computability: `Set.Countable.ae_notMem`.
+* Full measure of the complement: `Set.Countable.measure_restrict_compl`.
+* Interval-filling: `measure_diff_null` applied to `Ioo a b`, exactly as in
+  Mathlib's `Portmanteau` development.
+
+## References
+
+- Mathlib `Set.Countable.measure_zero`, `Set.Countable.ae_notMem`,
+  `Set.Countable.measure_restrict_compl` — `MeasureTheory.Measure.Typeclasses.NoAtoms`.
+- Mathlib `Real.noAtoms_volume`, `Real.volume_Ioo` — `MeasureTheory.Measure.Lebesgue.Basic`.
+- Oxtoby, *Measure and Category* (1980) — the measure/category duality this file
+  instantiates for the computable reals.
+- Turing, "On Computable Numbers" (1936).
+
+Tags: set-theory, measure-theory, real-analysis, computability, cardinality
+-/
+
+namespace AlgebraicNumbersCountableOQ02OQ04OQ01
+
+open MeasureTheory Filter Cardinal
+open AlgebraicNumbersCountableOQ02OQ04
+
+/-! ## The measure layer: computable reals are Lebesgue-null -/
+
+/-- **The computable reals are Lebesgue-null.**
+
+    Lebesgue measure on `ℝ` has no atoms (`Real.noAtoms_volume`), and every
+    countable set in an atomless measure space is null
+    (`Set.Countable.measure_zero`). Since the computable reals are countable
+    (OQ04 `computable_reals_countable`), they have Lebesgue measure zero.
+
+    This is the measure-theoretic counterpart of OQ04's `computable_reals_meagre`
+    (category) and `computable_reals_countable` (cardinality): the computable
+    reals are negligible in *every* classical sense. -/
+theorem computable_reals_null :
+    volume {r : ℝ | IsComputable r} = 0 :=
+  computable_reals_countable.measure_zero volume
+
+/-- **Almost every real number is non-computable.**
+
+    A `volume`-almost-everywhere statement: the set of computable reals being
+    null (`computable_reals_null`), its complement is conull, so for almost every
+    `r : ℝ`, `r` fails to be computable. This is the sharp measure-theoretic form
+    of Turing's negative observation `exists_non_computable_real`: not merely that
+    *some* real is non-computable, but that *almost all* are. -/
+theorem ae_not_isComputable :
+    ∀ᵐ r : ℝ, ¬ IsComputable r := by
+  simpa using computable_reals_countable.ae_notMem (volume : Measure ℝ)
+
+/-- **Almost every real lies in the non-computable reals** — the same statement
+    as `ae_not_isComputable`, phrased with the `nonComputableReals` set of OQ04. -/
+theorem ae_mem_nonComputableReals :
+    ∀ᵐ r : ℝ, r ∈ nonComputableReals := by
+  simpa [nonComputableReals] using ae_not_isComputable
+
+/-- **The non-computable reals carry the full Lebesgue measure.**
+
+    Restricting Lebesgue measure to the non-computable reals changes nothing:
+    `volume.restrict nonComputableReals = volume`. This is
+    `Set.Countable.measure_restrict_compl` applied to the countable computable
+    reals (`nonComputableReals` is their complement). It is the exact
+    measure-theoretic dual of OQ04's `card_nonComputableReals_eq_continuum`
+    (the complement keeps *all* of the line's cardinality) and
+    `nonComputableReals_residual` (the complement keeps *all* of the line's Baire
+    category). -/
+theorem volume_restrict_nonComputableReals :
+    (volume : Measure ℝ).restrict nonComputableReals = volume := by
+  have h : nonComputableReals = ({r : ℝ | IsComputable r})ᶜ := by ext r; rfl
+  rw [h]
+  exact computable_reals_countable.measure_restrict_compl volume
+
+/-! ## The non-computable reals fill every interval in measure -/
+
+/-- **The non-computable reals fill every open interval in measure.**
+
+    For any `a b : ℝ`, `volume (Ioo a b ∩ nonComputableReals) = volume (Ioo a b)`:
+    removing the (null) computable reals from an interval does not change its
+    measure. Proof: `Ioo a b ∩ nonComputableReals = Ioo a b \ {computable}`, and
+    `measure_diff_null` discards the null computable part. -/
+theorem volume_Ioo_inter_nonComputableReals (a b : ℝ) :
+    volume (Set.Ioo a b ∩ nonComputableReals) = volume (Set.Ioo a b) := by
+  have h : nonComputableReals = ({r : ℝ | IsComputable r})ᶜ := by ext r; rfl
+  rw [h, ← Set.diff_eq]
+  exact measure_diff_null computable_reals_null
+
+/-- **Quantitative interval-filling.** The non-computable reals occupy an interval
+    `Ioo a b` with its full length `b - a`:
+    `volume (Ioo a b ∩ nonComputableReals) = ENNReal.ofReal (b - a)`. -/
+theorem volume_Ioo_inter_nonComputableReals_eq (a b : ℝ) :
+    volume (Set.Ioo a b ∩ nonComputableReals) = ENNReal.ofReal (b - a) := by
+  rw [volume_Ioo_inter_nonComputableReals, Real.volume_Ioo]
+
+/-! ## Capstones: negligibility and genericity across all three lenses -/
+
+/-- **Capstone (computable side): countable, null, meagre — yet dense.**
+
+    Bundles the three independent notions of "negligible" for the computable
+    reals — cardinality (`countable`), measure (`null`), category (`meagre`) —
+    together with the fact that the set is nonetheless topologically `Dense`.
+    This is the canonical signature of a countable dense set (the same profile
+    as `ℚ`), now established for the strictly finer set of computable reals. -/
+theorem computable_reals_null_meagre_dense :
+    Set.Countable {r : ℝ | IsComputable r} ∧
+      volume {r : ℝ | IsComputable r} = 0 ∧
+      IsMeagre {r : ℝ | IsComputable r} ∧
+      Dense {r : ℝ | IsComputable r} :=
+  ⟨computable_reals_countable, computable_reals_null,
+   computable_reals_meagre, computable_reals_dense⟩
+
+/-- **Capstone (non-computable side): full measure, residual, cardinality `𝔠`.**
+
+    The measure-theoretic dual of the computable side. The non-computable reals
+    are "generic" in all three classical senses: they carry the full Lebesgue
+    measure of the line (`volume.restrict nonComputableReals = volume`), they are
+    comeagre (`residual`), and they have full cardinality `𝔠`. A real drawn at
+    random — whether "random" is read as measure-theoretic, Baire-generic, or
+    merely cardinality-typical — is non-computable. -/
+theorem nonComputableReals_full_measure_residual_continuum :
+    (volume : Measure ℝ).restrict nonComputableReals = volume ∧
+      nonComputableReals ∈ residual ℝ ∧
+      (#(↑nonComputableReals : Set ℝ) : Cardinal) = 𝔠 :=
+  ⟨volume_restrict_nonComputableReals, nonComputableReals_residual,
+   card_nonComputableReals_eq_continuum⟩
+
+end AlgebraicNumbersCountableOQ02OQ04OQ01

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-04-oq-01",
+    "range": { "startLine": 6, "endLine": 84 },
+    "type": "concept",
+    "title": "The Missing Measure Lens on the Computable Reals",
+    "content": "The sibling computable-reals entry (oq-02-oq-04) proved the computable reals countable (cardinality) and meagre (Baire category), but never addressed the measure-theoretic notion of smallness. This entry completes the profile: the computable reals are Lebesgue-null, the non-computable reals carry the full measure of the line, and almost every real is non-computable. Countable + meagre + null hold at once — the profile of ℚ — while the set stays dense.",
+    "mathContext": "Three independent smallness notions on $\\mathbb{R}$: cardinality $(\\aleph_0)$, Baire category (meagre), Lebesgue measure (null).",
+    "significance": "context",
+    "relatedConcepts": ["computable reals", "Lebesgue measure", "Baire category", "measure/category duality", "Oxtoby"],
+    "prerequisites": ["computable reals are countable", "atomless measures"]
+  },
+  {
+    "id": "ann-computable-null",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-04-oq-01",
+    "range": { "startLine": 87, "endLine": 106 },
+    "type": "theorem",
+    "title": "The Computable Reals are Lebesgue-Null",
+    "content": "Lebesgue measure on ℝ has no atoms (`Real.noAtoms_volume`), and in an atomless measure space every countable set has measure zero (`Set.Countable.measure_zero`). Since the computable reals are countable (sibling entry), their Lebesgue measure is 0. No explicit covering-by-intervals argument is required — atomlessness plus countability suffices.",
+    "mathContext": "$\\mathrm{volume}\\,\\{r : \\mathrm{IsComputable}\\ r\\} = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Set.Countable.measure_zero", "NoAtoms", "Lebesgue measure", "null set"],
+    "prerequisites": ["countable set is null in atomless measure", "atomlessness of Lebesgue measure"]
+  },
+  {
+    "id": "ann-ae-noncomputable",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-04-oq-01",
+    "range": { "startLine": 108, "endLine": 126 },
+    "type": "theorem",
+    "title": "Almost Every Real is Non-Computable",
+    "content": "Because the computable reals are null, their complement is conull: for volume-almost-every r, r is not computable (`Set.Countable.ae_notMem`). This is the sharp measure-theoretic form of Turing's negative observation — not merely that some real is non-computable, but that a random real is non-computable with probability one.",
+    "mathContext": "$\\forall^m (r : \\mathbb{R}),\\ \\neg\\,\\mathrm{IsComputable}\\ r$.",
+    "significance": "key",
+    "relatedConcepts": ["almost everywhere", "ae filter", "Turing's non-computable real", "conull set"],
+    "prerequisites": ["null complement is conull", "∀ᵐ statements"]
+  },
+  {
+    "id": "ann-full-measure",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-04-oq-01",
+    "range": { "startLine": 128, "endLine": 133 },
+    "type": "theorem",
+    "title": "The Non-Computable Reals Carry the Full Measure",
+    "content": "Restricting Lebesgue measure to the non-computable reals is the identity (`Set.Countable.measure_restrict_compl`), because the non-computable reals are the complement of the countable computable reals. This is the measure dual of the sibling facts that the complement keeps the full cardinality 𝔠 and the full Baire category (residual).",
+    "mathContext": "$\\mathrm{volume}\\restriction \\mathrm{nonComputableReals} = \\mathrm{volume}$.",
+    "significance": "key",
+    "relatedConcepts": ["measure restriction", "measure_restrict_compl", "conull complement"],
+    "prerequisites": ["restrict of measure to conull set"]
+  },
+  {
+    "id": "ann-interval-filling",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-04-oq-01",
+    "range": { "startLine": 134, "endLine": 154 },
+    "type": "theorem",
+    "title": "The Non-Computable Reals Fill Every Interval",
+    "content": "For any a, b, the non-computable part of the open interval Ioo a b has the same measure as the whole interval: removing the null computable reals changes nothing (`measure_diff_null`, using Ioo a b ∩ nonComputable = Ioo a b \\ computable). Quantitatively this measure is ofReal (b − a) via `Real.volume_Ioo`.",
+    "mathContext": "$\\mathrm{volume}\\,(\\mathrm{Ioo}\\ a\\ b \\cap \\mathrm{nonComputableReals}) = \\mathrm{ofReal}(b-a)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["measure_diff_null", "Real.volume_Ioo", "interval measure"],
+    "prerequisites": ["measure unchanged by removing null set", "measure of an interval"]
+  },
+  {
+    "id": "ann-capstones",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-04-oq-01",
+    "range": { "startLine": 155, "endLine": 187 },
+    "type": "concept",
+    "title": "Capstones: Negligible in Every Sense, Yet Dense",
+    "content": "Two bundled theorems close the entry. computable_reals_null_meagre_dense: the computable reals are countable, null, and meagre all at once, yet dense — negligible in cardinality, measure, and category simultaneously. nonComputableReals_full_measure_residual_continuum (dual): the non-computable reals carry the full measure, are residual, and have cardinality 𝔠 — generic in all three senses. Pairing null with meagre is a concrete instance of the classical (Oxtoby) independence of measure and category.",
+    "mathContext": "Computable: countable $\\wedge$ null $\\wedge$ meagre $\\wedge$ dense. Non-computable: full measure $\\wedge$ residual $\\wedge$ $\\mathfrak{c}$.",
+    "significance": "key",
+    "relatedConcepts": ["measure/category/cardinality", "residual", "meagre", "dense", "generic real"],
+    "prerequisites": ["measure, category, and cardinality smallness notions"]
+  }
+]

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04-oq-01/meta.json
@@ -1,0 +1,257 @@
+{
+  "id": "algebraic-numbers-countable-oq-02-oq-04-oq-01",
+  "title": "The Computable Reals are Lebesgue-Null — Almost Every Real is Non-Computable",
+  "slug": "algebraic-numbers-countable-oq-02-oq-04-oq-01",
+  "description": "Completes the negligibility profile of the computable real numbers by adding the one classical lens the parent computable-reals entry (oq-02-oq-04) never addressed: measure. The computable reals are countable, so — Lebesgue measure on ℝ being atomless — they are a Lebesgue-null set. Dually, the non-computable reals carry the FULL Lebesgue measure of the line: restricting volume to them changes nothing, and they fill every open interval Ioo a b with its complete length b − a. Almost every real number (∀ᵐ) is therefore non-computable — the sharp measure-theoretic form of Turing's negative observation. The two capstone theorems bundle the three independent notions of 'small' on ℝ: the computable reals are countable (cardinality ℵ₀), meagre (Baire category), AND null (measure) all at once, yet remain dense; the non-computable reals are dually of full cardinality 𝔠, comeagre (residual), and of full measure. This is exactly the measure/category pairing flagged as an open question by the cousin oq-02-oq-03-oq-02 entry.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Computable_number",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ02OQ04OQ01.lean",
+    "tags": [
+      "measure-theory",
+      "set-theory",
+      "real-analysis",
+      "computability",
+      "computable-analysis",
+      "lebesgue-measure",
+      "cardinality",
+      "baire-category"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.Countable.measure_zero",
+        "description": "In an atomless measure space every countable set has measure zero",
+        "module": "Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms"
+      },
+      {
+        "theorem": "Set.Countable.ae_notMem",
+        "description": "In an atomless measure space, a countable set is avoided almost everywhere",
+        "module": "Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms"
+      },
+      {
+        "theorem": "Set.Countable.measure_restrict_compl",
+        "description": "Restricting an atomless measure to the complement of a countable set is the identity",
+        "module": "Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms"
+      },
+      {
+        "theorem": "Real.noAtoms_volume",
+        "description": "Lebesgue measure on ℝ has no atoms",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      },
+      {
+        "theorem": "measure_diff_null",
+        "description": "Removing a null set from any set leaves the measure unchanged",
+        "module": "Mathlib.MeasureTheory.OuterMeasure.Basic"
+      },
+      {
+        "theorem": "Real.volume_Ioo",
+        "description": "The Lebesgue measure of the open interval Ioo a b is ENNReal.ofReal (b - a)",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      },
+      {
+        "theorem": "AlgebraicNumbersCountableOQ02OQ04.computable_reals_countable",
+        "description": "The set of computable reals is countable (parent entry)",
+        "module": "Proofs.AlgebraicNumbersCountableOQ02OQ04"
+      },
+      {
+        "theorem": "AlgebraicNumbersCountableOQ02OQ04.computable_reals_meagre",
+        "description": "The computable reals are meagre in ℝ (parent entry)",
+        "module": "Proofs.AlgebraicNumbersCountableOQ02OQ04"
+      },
+      {
+        "theorem": "AlgebraicNumbersCountableOQ02OQ04.nonComputableReals_residual",
+        "description": "The non-computable reals are residual (comeagre) in ℝ (parent entry)",
+        "module": "Proofs.AlgebraicNumbersCountableOQ02OQ04"
+      },
+      {
+        "theorem": "AlgebraicNumbersCountableOQ02OQ04.card_nonComputableReals_eq_continuum",
+        "description": "The non-computable reals have cardinality 𝔠 (parent entry)",
+        "module": "Proofs.AlgebraicNumbersCountableOQ02OQ04"
+      }
+    ],
+    "originalContributions": [
+      "computable_reals_null: PROVED the computable reals are a Lebesgue-null set (volume = 0), via atomlessness of Lebesgue measure and countability — the measure-theoretic lens absent from the parent oq-02-oq-04 (which covered only cardinality and Baire category)",
+      "ae_not_isComputable: PROVED that ∀ᵐ (r : ℝ), ¬ IsComputable r — almost every real is non-computable, the sharp measure form of Turing's existence-of-a-non-computable-real result",
+      "volume_restrict_nonComputableReals: PROVED the non-computable reals carry the full Lebesgue measure of the line (volume.restrict nonComputableReals = volume) — the measure dual of the full-cardinality and comeagre facts",
+      "volume_Ioo_inter_nonComputableReals / _eq: PROVED the non-computable reals fill every open interval in measure, with the quantitative value ENNReal.ofReal (b - a)",
+      "computable_reals_null_meagre_dense: PROVED the capstone bundling countable + null + meagre + dense — the computable reals are negligible in every classical sense yet topologically dense (the profile of ℚ, transported to the computable reals)",
+      "nonComputableReals_full_measure_residual_continuum: PROVED the dual capstone — full measure, residual, cardinality 𝔠 — so a 'random' real is non-computable in the measure-theoretic, Baire-generic, and cardinality-typical senses simultaneously"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Lebesgue measure on ℝ; atomless (NoAtoms) measures",
+      "Countable sets are null in atomless measure spaces",
+      "Almost-everywhere (∀ᵐ) statements and the ae filter",
+      "Baire category (residual/meagre) and cardinality (ℵ₀, 𝔠) from the parent computable-reals entry"
+    ],
+    "lineCount": 187,
+    "relatedProblems": [
+      {
+        "id": "algebraic-numbers-countable-oq-02-oq-04",
+        "relationship": "Parent: establishes the computable reals are countable, meagre, and dense (cardinality + category lenses). This entry adds the measure lens (null) and reuses its IsComputable definition and cardinality/category results."
+      },
+      {
+        "id": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+        "relationship": "Cousin: the transcendental Gδ/Fσ classification; its openQuestions explicitly flags 'pair the Gδ/Fσ classification with the measure-theoretic side' — the measure/category independence witnessed here."
+      },
+      {
+        "id": "algebraic-numbers-countable-oq-02",
+        "relationship": "Grandparent: ℝ is uncountable (Cantor's diagonal argument); this entry deepens one of its follow-up subtrees (the computable reals) with the measure-theoretic lens."
+      }
+    ],
+    "assumptions": "0 axioms (only propext, Classical.choice, Quot.sound — the standard foundational axioms, which do not count). Relies on Mathlib's atomless-measure infrastructure, the Lebesgue measure on ℝ, and the countability/category/cardinality results of the parent computable-reals entry.",
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Turing (1936) defined the computable reals and observed there must exist non-computable ones — the computable reals form a countable family (each named by a finite Turing-machine description) inside the uncountable continuum. Cantor (1874) supplied the uncountability, and Baire category (1899) and Lebesgue measure (1902) supply two further, independent notions of 'smallness'. The classical slogan of Oxtoby's Measure and Category is that meagre (category-small) and null (measure-small) sets, though both 'small', are logically independent. The computable reals — being countable — happen to be small in every one of these senses simultaneously, exactly like ℚ, while remaining dense.",
+    "problemStatement": "Determine the Lebesgue measure of the computable reals, and quantify the measure-theoretic size of their complement. Is 'almost every' real non-computable?",
+    "text": "A 187-line, 0-sorry, 0-axiom formalization adding the measure-theoretic layer to the computable/non-computable partition of ℝ. The computable reals are shown Lebesgue-null; the non-computable reals carry the full measure of the line and fill every interval; almost every real is non-computable. Two capstone theorems bundle measure with the cardinality and Baire-category lenses inherited from the parent entry.",
+    "proofStrategy": "The whole layer rests on one Mathlib fact: in an atomless measure space every countable set is null (Set.Countable.measure_zero), and Lebesgue measure on ℝ is atomless (Real.noAtoms_volume). Nullity of the computable reals is then immediate from their countability (parent entry). Almost-everywhere non-computability is Set.Countable.ae_notMem; the full measure of the complement is Set.Countable.measure_restrict_compl; interval-filling is measure_diff_null applied to Ioo a b (discarding the null computable part), quantified by Real.volume_Ioo. The capstones are conjunctions assembling the new measure results with the parent's countability, meagreness, density, residuality, and cardinality theorems.",
+    "keyInsights": [
+      "**Countable ⇒ null in any atomless measure**: the single fact Set.Countable.measure_zero, plus the atomlessness of Lebesgue measure, delivers the entire measure-smallness of the computable reals — no explicit covering-by-intervals argument is needed.",
+      "**Almost every real is non-computable**: the ∀ᵐ statement is strictly sharper than Turing's 'some real is non-computable' — measure-theoretically, the computable reals are a set of probability zero.",
+      "**The complement keeps everything**: the non-computable reals carry the full Lebesgue measure of ℝ, fill every interval, are comeagre, and have cardinality 𝔠 — the measure dual of the cardinality and category facts.",
+      "**Small in all three senses, yet dense**: the computable reals are countable, meagre, and null simultaneously, while being topologically dense — the exact profile of ℚ, now for the strictly finer computable reals.",
+      "**Measure/category independence, instantiated**: pairing the null result with the parent's meagre result gives a concrete witness of the classical fact that a set can be small in both measure and category at once — resolving the follow-up flagged by the transcendental-Gδ cousin entry."
+    ],
+    "prerequisites": [
+      "Lebesgue measure on ℝ and atomless (NoAtoms) measures",
+      "Countable sets are null; almost-everywhere (∀ᵐ) statements",
+      "Baire category (meagre/residual) and cardinality (ℵ₀, 𝔠) from the parent computable-reals entry"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: The Missing Measure Lens",
+      "startLine": 1,
+      "endLine": 84,
+      "summary": "File docstring and imports. Recalls that the parent computable-reals entry established countability (cardinality) and meagreness (category) but never the measure-theoretic lens, and frames this entry as completing the negligibility profile: the computable reals are Lebesgue-null, the non-computable reals of full measure, and almost every real non-computable.",
+      "mathContext": "Lebesgue measure on ℝ is atomless, so every countable set — in particular the computable reals — is null."
+    },
+    {
+      "id": "measure-layer",
+      "title": "The Measure Layer: Computable Reals are Null",
+      "startLine": 85,
+      "endLine": 133,
+      "summary": "computable_reals_null proves volume {r | IsComputable r} = 0 from atomlessness and countability. ae_not_isComputable and ae_mem_nonComputableReals give the almost-everywhere non-computability. volume_restrict_nonComputableReals shows the non-computable reals carry the full Lebesgue measure of the line.",
+      "mathContext": "μ(computable) = 0, ∀ᵐ r ¬IsComputable r, and μ.restrict(nonComputable) = μ."
+    },
+    {
+      "id": "interval-filling",
+      "title": "The Non-Computable Reals Fill Every Interval",
+      "startLine": 134,
+      "endLine": 154,
+      "summary": "volume_Ioo_inter_nonComputableReals proves volume (Ioo a b ∩ nonComputableReals) = volume (Ioo a b) via measure_diff_null (the null computable part is discarded). volume_Ioo_inter_nonComputableReals_eq quantifies this as ENNReal.ofReal (b - a).",
+      "mathContext": "Removing the null computable reals from any interval leaves its full length b − a."
+    },
+    {
+      "id": "capstones",
+      "title": "Capstones: Negligibility and Genericity Across All Three Lenses",
+      "startLine": 155,
+      "endLine": 187,
+      "summary": "computable_reals_null_meagre_dense bundles countable + null + meagre + dense for the computable reals. nonComputableReals_full_measure_residual_continuum bundles full measure + residual + cardinality 𝔠 for the complement — the measure/category/cardinality trichotomy in a single statement per side.",
+      "mathContext": "Computable reals: countable ∧ null ∧ meagre ∧ dense. Non-computable reals: full measure ∧ residual ∧ 𝔠."
+    }
+  ],
+  "theorems": [
+    {
+      "name": "computable_reals_null",
+      "type": "main",
+      "description": "The computable reals are a Lebesgue-null set: volume {r | IsComputable r} = 0",
+      "leanType": "volume {r : ℝ | IsComputable r} = 0"
+    },
+    {
+      "name": "ae_not_isComputable",
+      "type": "main",
+      "description": "Almost every real number is non-computable",
+      "leanType": "∀ᵐ r : ℝ, ¬ IsComputable r"
+    },
+    {
+      "name": "ae_mem_nonComputableReals",
+      "type": "supporting",
+      "description": "Almost every real lies in the non-computable reals (restatement via the nonComputableReals set)",
+      "leanType": "∀ᵐ r : ℝ, r ∈ nonComputableReals"
+    },
+    {
+      "name": "volume_restrict_nonComputableReals",
+      "type": "main",
+      "description": "The non-computable reals carry the full Lebesgue measure of ℝ",
+      "leanType": "(volume : Measure ℝ).restrict nonComputableReals = volume"
+    },
+    {
+      "name": "volume_Ioo_inter_nonComputableReals",
+      "type": "supporting",
+      "description": "The non-computable reals fill every open interval in measure",
+      "leanType": "volume (Set.Ioo a b ∩ nonComputableReals) = volume (Set.Ioo a b)"
+    },
+    {
+      "name": "volume_Ioo_inter_nonComputableReals_eq",
+      "type": "supporting",
+      "description": "Quantitative interval-filling: the non-computable part of Ioo a b has measure ofReal (b - a)",
+      "leanType": "volume (Set.Ioo a b ∩ nonComputableReals) = ENNReal.ofReal (b - a)"
+    },
+    {
+      "name": "computable_reals_null_meagre_dense",
+      "type": "main",
+      "description": "Capstone: the computable reals are countable, null, and meagre — yet dense",
+      "leanType": "Set.Countable {r : ℝ | IsComputable r} ∧ volume {r : ℝ | IsComputable r} = 0 ∧ IsMeagre {r : ℝ | IsComputable r} ∧ Dense {r : ℝ | IsComputable r}"
+    },
+    {
+      "name": "nonComputableReals_full_measure_residual_continuum",
+      "type": "main",
+      "description": "Capstone (dual): the non-computable reals have full measure, are residual, and have cardinality 𝔠",
+      "leanType": "(volume : Measure ℝ).restrict nonComputableReals = volume ∧ nonComputableReals ∈ residual ℝ ∧ (#(↑nonComputableReals : Set ℝ) : Cardinal) = 𝔠"
+    }
+  ],
+  "conclusion": {
+    "summary": "A 187-line, 0-sorry, 0-axiom formalization proving the computable reals are Lebesgue-null and almost every real is non-computable, with the non-computable reals carrying the full measure of the line and filling every interval. Two capstones bundle the measure lens with the cardinality and Baire-category lenses of the parent entry.",
+    "implications": "Completes the classical smallness profile of the computable reals: countable (ℵ₀), meagre (category), and null (measure) all at once, yet dense — the profile of ℚ, transported to the strictly finer computable reals. Dually, the non-computable reals are generic in the measure-theoretic, Baire, and cardinality senses simultaneously. Pairing the null and meagre results is a concrete instance of the classical (Oxtoby) independence of measure and category, resolving the follow-up flagged by the transcendental-Gδ cousin entry.",
+    "openQuestions": [
+      "Prove the computable reals form a subfield of ℝ (closure under +, −, ×, and ⁻¹ for nonzero elements), which requires establishing computability of ℚ-arithmetic (addition/multiplication on ℚ) — infrastructure currently absent from Mathlib.",
+      "Sharpen 'null and meagre' to an explicit dense Gδ of full measure inside the non-computable reals, giving a single set that is simultaneously topologically and measure-theoretically generic."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Oxtoby, John C.",
+      "title": "Measure and Category",
+      "year": "1980",
+      "venue": "Graduate Texts in Mathematics 2, Springer, 2nd edition",
+      "note": "The classical duality between meagre and null sets; the computable reals are shown here to be small in both senses at once."
+    },
+    {
+      "authors": "Turing, Alan M.",
+      "title": "On Computable Numbers, with an Application to the Entscheidungsproblem",
+      "year": "1936",
+      "venue": "Proceedings of the London Mathematical Society",
+      "note": "Introduces the computable reals and the existence of non-computable reals, here sharpened to 'almost every real is non-computable'."
+    }
+  ],
+  "sorries": 0,
+  "crossReferences": [
+    {
+      "targetId": "algebraic-numbers-countable-oq-02-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry: proves the computable reals are countable, meagre, and dense. This entry adds the measure-theoretic lens (Lebesgue-null) and reuses its IsComputable definition and its cardinality/category/density results in the capstones."
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+      "relationship": "related",
+      "description": "Cousin entry (transcendental Gδ/Fσ classification) whose openQuestions explicitly flags pairing the Gδ/Fσ picture with the measure-theoretic side; this entry supplies the measure lens for the parallel computable/non-computable partition."
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-02",
+      "relationship": "related",
+      "description": "Grandparent: ℝ is uncountable via Cantor's diagonal argument. This entry deepens the computable-reals follow-up subtree with the measure-theoretic lens."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **measure-theoretic** lens to the computable/non-computable partition of ℝ — the one classical notion of "negligible" that the parent computable-reals entry (`oq-02-oq-04`) never addressed (it covered cardinality and Baire category only).

The computable reals are countable, and Lebesgue measure on ℝ is atomless, so they are **Lebesgue-null**. Dually, the non-computable reals carry the **full** measure of the line and fill every interval. Hence **almost every real is non-computable** — the sharp measure form of Turing's negative observation.

## Theorems (8, 0 sorries)

- `computable_reals_null` — `volume {r | IsComputable r} = 0`
- `ae_not_isComputable` — `∀ᵐ r, ¬ IsComputable r`
- `ae_mem_nonComputableReals` — restatement via `nonComputableReals`
- `volume_restrict_nonComputableReals` — complement carries the full Lebesgue measure
- `volume_Ioo_inter_nonComputableReals` / `_eq` — non-computable reals fill every interval, value `ofReal (b - a)`
- `computable_reals_null_meagre_dense` — capstone: countable ∧ null ∧ meagre ∧ dense
- `nonComputableReals_full_measure_residual_continuum` — dual capstone: full measure ∧ residual ∧ cardinality 𝔠

Completes the profile: the computable reals are small in **cardinality (ℵ₀), category (meagre), and measure (null)** simultaneously, yet remain **dense** — the profile of ℚ. A concrete instance of the Oxtoby measure/category duality, on the strictly finer computable/non-computable split.

## Verification

- Built with `lake env lean` (Docker image build is currently down: containerd I/O error).
- `#print axioms` on all main theorems: `[propext, Classical.choice, Quot.sound]` only — **0 counted axioms**.
- 187 lines, imports the parent `Proofs.AlgebraicNumbersCountableOQ02OQ04`.

## Note on re-homing

Originally scoped as `oq-02-oq-05`, but that slot was concurrently completed by an **unrelated** first-order-definability result (#32400, merged mid-session). This measure layer is entirely distinct and its natural home is under `oq-04` (the computable-reals entry it extends), hence `oq-02-oq-04-oq-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)