### PR TITLE
Enrich Oppermann's Conjecture (Legendre OQ-04): add sections navigation array

### DIFF
--- a/src/data/proofs/legendre-partial-oq-04/meta.json
+++ b/src/data/proofs/legendre-partial-oq-04/meta.json
@@ -62,6 +62,43 @@
       "Finset cardinality and the prime-gap conjecture hierarchy"
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring for Oppermann's conjecture (Legendre-partial OQ-04): both halves of every square-gap (n², (n+1)²), split at the composite point n²+n, contain a prime. Frames the file as honest structural implications from Oppermann plus native_decide spot-checks, with the conjecture itself left as an axiom. Imports Mathlib and the parent LegendrePartial, and works in namespace Legendre.Oppermann."
+    },
+    {
+      "id": "sec-statement",
+      "title": "Statement",
+      "startLine": 51,
+      "endLine": 64,
+      "summary": "OppermannAt n: a prime in the lower half (n², n²+n) and a prime in the upper half (n²+n, (n+1)²). OppermannConjecture: OppermannAt n for every n ≥ 2 (n = 1 excluded since the lower half (1,2) is empty)."
+    },
+    {
+      "id": "sec-structural",
+      "title": "Structural Theorems (0-axiom Implications)",
+      "startLine": 66,
+      "endLine": 115,
+      "summary": "Honest hypothesis-taking implications, none asserting Oppermann is true. oppermann_at_implies_legendre_at: the lower-half prime already witnesses Legendre at n. oppermann_at_two_primes: the distinct lower/upper primes give ≥ 2 primes in (n², (n+1)²), strengthening Legendre. The two conjecture-level forms (oppermann_implies_legendre, oppermann_implies_two_primes) lift these to all n ≥ 2 — all by elementary interval arithmetic (omega)."
+    },
+    {
+      "id": "sec-computational",
+      "title": "Computational Verification (native_decide)",
+      "startLine": 117,
+      "endLine": 166,
+      "summary": "OppermannAt n verified for 2 ≤ n ≤ 20 (oppermann_2 … oppermann_20) by exhibiting an explicit (lower-half prime, upper-half prime) pair and discharging primality/interval bounds with native_decide (which introduces the Lean.ofReduceBool axiom). two_primes_2 combines a verified instance with the 0-axiom structural theorem to conclude two primes in a concrete gap."
+    },
+    {
+      "id": "sec-open",
+      "title": "The Open Conjecture",
+      "startLine": 168,
+      "endLine": 179,
+      "summary": "oppermann_conjecture is stated as an axiom (open since 1882; strictly stronger than both Legendre's and the open Brocard conjecture). legendre_of_oppermann derives Legendre for all n ≥ 2 as a downstream consequence, inheriting the axiom."
+    }
+  ],
   "conclusion": {
     "summary": "This entry formalizes Oppermann's conjecture — a prime in both halves of every square-gap — as the natural strengthening of Legendre's conjecture requested by the base entry. It contributes two fully machine-checked (0-axiom) structural theorems: Oppermann implies Legendre, and Oppermann implies at least two primes between every pair of consecutive squares. Oppermann itself is verified computationally for n = 2 to 20 and stated as an axiom for the general case.",
     "implications": "Locating Oppermann precisely above Legendre in the prime-gap hierarchy (Cramér ⟹ Oppermann ⟹ Legendre ⟺ Andrica ⟹ Bertrand) and supplying the verified Oppermann ⟹ Legendre link turns an informal 'strictly stronger' remark into a checked implication. The two-primes corollary quantifies the strengthening: any proof of Oppermann would immediately yield ≥ 2 primes in each (n², (n+1)²), a statement well beyond what Legendre alone provides.",


### PR DESCRIPTION
Enrichment pass for `legendre-partial-oq-04` (Oppermann's conjecture ⟹ Legendre, with computational spot-checks).

## Gap addressed
The entry had **0 sections** — no navigation array for its 179-line Lean file.

## Change
Added a 5-entry `sections` array aligned to the file's own `##` markers:
1. **Header and Imports** (1–49)
2. **Statement** (51–64) — `OppermannAt`, `OppermannConjecture`
3. **Structural Theorems (0-axiom Implications)** (66–115)
4. **Computational Verification (native_decide)** (117–166) — `oppermann_2`…`oppermann_20`
5. **The Open Conjecture** (168–179) — the `oppermann_conjecture` axiom

## Notes
- Section summaries honestly reflect the native_decide/`Lean.ofReduceBool` and axiom scoping (meta is correctly `axiomatized`, axiomCount 2).
- Annotations (7, all with mathContext) and overview/conclusion were already complete.
- meta.json well under the 60 KB cap (`gallery:check-size`: within caps). JSON validated.