### PR TITLE
research(cube-root-3-irrational-oq-03-oq-03): ℚ(∛3)/ℚ is not normal/Galois [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ03OQ03.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ03OQ03.lean
@@ -1,0 +1,116 @@
+/-
+Proof: **ℚ(∛3)/ℚ is not a normal (Galois) extension** — the minimal polynomial
+`X³ − 3` of ∛3 does not split inside ℚ(∛3), because ℚ(∛3) sits inside ℝ and
+`X³ − 3` has only one real root.
+Research: cube-root-3-irrational-oq-03-oq-03
+Date: 2026-07-01
+
+Open question (child of `cube-root-3-irrational-oq-03`): the parent established
+that ∛3 has degree 3 over ℚ with minimal polynomial `X³ − 3`
+(`minpoly_cbrt3`, `finrank_adjoin_cbrt3`). A sibling (`…-oq-03-oq-02`) drew the
+constructibility corollary. Here we settle the **Galois-theoretic** status of the
+extension: it is *not* normal.
+
+## Why this is the natural next question
+
+The degree `[ℚ(∛3) : ℚ] = 3` is *odd*, so ℚ(∛3) cannot be built from ℚ by
+quadratic steps (that was the non-constructibility corollary). But degree alone
+does not decide normality. The classical fact is that ℚ(∛3)/ℚ is the standard
+first example of a **non-normal** finite extension: `X³ − 3` has the one real
+root ∛3 in ℚ(∛3) but its two complex conjugate roots `ω∛3, ω²∛3` are missing.
+Consequently the splitting field ℚ(∛3, ω) is strictly larger (degree 6), and the
+Galois group of the splitting field is `S₃`, not a group acting on ℚ(∛3) alone.
+
+## The proof
+
+`Normal ℚ ℚ⟮cbrt3⟯` would force the minimal polynomial of ∛3, namely `X³ − 3`,
+to split *inside* ℚ(∛3) (`Normal.splits`).  Since ℚ(∛3) is an intermediate field
+of ℝ, the algebra embedding `ℚ(∛3) ↪ ℝ` (`IntermediateField.val`) transports that
+splitting to ℝ (`Polynomial.splits_of_algHom`).  But `X³ − 3` does **not** split
+over ℝ:
+
+* if it did, `splits_iff_card_roots` would give it three roots (with
+  multiplicity) in ℝ;
+* `X³ − 3` is separable over ℝ (`separable_X_pow_sub_C`), so its roots are
+  distinct (`nodup_roots`);
+* yet every real root `r` satisfies `r³ = 3 = (∛3)³`, and `x ↦ x³` is injective
+  on ℝ (`Odd.strictMono_pow`), so `r = ∛3` — there is only **one** real root.
+
+Three distinct roots collapsing to one is the contradiction.
+-/
+
+import Mathlib
+import Proofs.CubeRoot3IrrationalOQ03
+
+open CubeRoot3Irrational CubeRoot3IrrationalOQ03 Polynomial IntermediateField
+
+namespace CubeRoot3IrrationalOQ03OQ03
+
+/-! ### The real polynomial `X³ − 3` -/
+
+/-- `(X³ − 3 : ℚ[X])` maps to `X³ − 3 : ℝ[X]` under `algebraMap ℚ ℝ`. -/
+theorem map_X_cubed_sub_three :
+    (X ^ 3 - C 3 : ℚ[X]).map (algebraMap ℚ ℝ) = (X ^ 3 - C 3 : ℝ[X]) := by
+  simp
+
+/-- **Uniqueness of the real cube root of 3.** Any real `r` with `r³ = 3`
+equals `∛3`, since `x ↦ x³` is injective on ℝ. -/
+theorem real_root_eq_cbrt3 {r : ℝ} (hr : r ^ 3 = 3) : r = cbrt3 := by
+  have h : r ^ 3 = cbrt3 ^ 3 := by rw [hr, cbrt3_pow_three]
+  exact (Odd.strictMono_pow (by norm_num : Odd 3)).injective h
+
+/-- **`X³ − 3` does not split over ℝ.** A splitting would supply three real roots
+(counted without multiplicity, by separability), but `X³ − 3` has the single
+real root `∛3`. -/
+theorem not_splits_real : ¬ (X ^ 3 - C 3 : ℝ[X]).Splits := by
+  intro hsplit
+  have hdeg : (X ^ 3 - C 3 : ℝ[X]).natDegree = 3 := natDegree_X_pow_sub_C
+  -- three roots with multiplicity
+  have hcard : (X ^ 3 - C 3 : ℝ[X]).roots.card = 3 := by
+    rw [splits_iff_card_roots.mp hsplit, hdeg]
+  -- separable ⇒ roots are distinct
+  have hsep : (X ^ 3 - C 3 : ℝ[X]).Separable :=
+    separable_X_pow_sub_C (3 : ℝ) (by norm_num) (by norm_num)
+  have hnodup := nodup_roots hsep
+  -- but every root equals ∛3
+  have hsub : (X ^ 3 - C 3 : ℝ[X]).roots.toFinset ⊆ {cbrt3} := by
+    intro r hr
+    rw [Multiset.mem_toFinset, mem_roots'] at hr
+    obtain ⟨-, hroot⟩ := hr
+    rw [IsRoot.def, eval_sub, eval_pow, eval_X, eval_C] at hroot
+    rw [Finset.mem_singleton]
+    exact real_root_eq_cbrt3 (by linarith [hroot])
+  have h1 : (X ^ 3 - C 3 : ℝ[X]).roots.toFinset.card ≤ 1 := by
+    refine le_trans (Finset.card_le_card hsub) ?_
+    simp
+  rw [Multiset.toFinset_card_of_nodup hnodup, hcard] at h1
+  omega
+
+/-! ### The obstruction and the headline non-normality result -/
+
+/-- **The minimal polynomial of ∛3 does not split in ℚ(∛3).** This is the direct
+obstruction to normality: the two complex conjugate roots of `X³ − 3` lie outside
+the real field ℚ(∛3). -/
+theorem minpoly_not_splits_adjoin :
+    ¬ ((X ^ 3 - C 3 : ℚ[X]).map (algebraMap ℚ ℚ⟮cbrt3⟯)).Splits := by
+  intro h
+  have hR : ((X ^ 3 - C 3 : ℚ[X]).map (algebraMap ℚ ℝ)).Splits :=
+    splits_of_algHom h (IntermediateField.val ℚ⟮cbrt3⟯)
+  rw [map_X_cubed_sub_three] at hR
+  exact not_splits_real hR
+
+/-- **ℚ(∛3)/ℚ is not a normal extension.** The classical first example of a
+finite, non-normal field extension. -/
+theorem not_normal_adjoin_cbrt3 : ¬ Normal ℚ ℚ⟮cbrt3⟯ := by
+  intro hnormal
+  have hsplitK : ((minpoly ℚ (AdjoinSimple.gen ℚ cbrt3)).map
+      (algebraMap ℚ ℚ⟮cbrt3⟯)).Splits := hnormal.splits (AdjoinSimple.gen ℚ cbrt3)
+  rw [minpoly_gen, minpoly_cbrt3] at hsplitK
+  exact minpoly_not_splits_adjoin hsplitK
+
+/-- **ℚ(∛3)/ℚ is not a Galois extension**, since Galois extensions are normal. -/
+theorem not_isGalois_adjoin_cbrt3 : ¬ IsGalois ℚ ℚ⟮cbrt3⟯ := by
+  intro h
+  exact not_normal_adjoin_cbrt3 (IsGalois.to_normal)
+
+end CubeRoot3IrrationalOQ03OQ03

--- a/src/data/proofs/cube-root-3-irrational-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03-oq-03/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "real-root-unique",
+    "proofId": "cube-root-3-irrational-oq-03-oq-03",
+    "range": { "startLine": 55, "endLine": 63 },
+    "type": "theorem",
+    "title": "Uniqueness of the Real Cube Root of 3",
+    "content": "`real_root_eq_cbrt3` proves that any real number `r` with `r³ = 3` is exactly `∛3`. The argument is a one-liner: `r³ = 3 = (∛3)³` (using the parent's `cbrt3_pow_three`), and `x ↦ x³` is injective on ℝ because it is strictly monotone (`Odd.strictMono_pow` with `Odd 3`). This is the real-analytic heart of the whole proof — the fact that ℝ contains only ONE cube root of 3, unlike ℂ which contains three (∛3, ω∛3, ω²∛3).",
+    "significance": "key"
+  },
+  {
+    "id": "not-splits-real",
+    "proofId": "cube-root-3-irrational-oq-03-oq-03",
+    "range": { "startLine": 65, "endLine": 87 },
+    "type": "theorem",
+    "title": "X³ − 3 Does Not Split over ℝ",
+    "content": "`not_splits_real` refutes splitting over ℝ by a counting contradiction. If `X³ − 3` split, `splits_iff_card_roots` would give `roots.card = natDegree = 3` (three roots with multiplicity). Separability (`separable_X_pow_sub_C`, valid since `3 ≠ 0` in ℝ) upgrades this via `nodup_roots` to three DISTINCT roots. But the finset of distinct roots is contained in `{∛3}` — every root `r` has `r³ = 3` hence `r = ∛3` (`real_root_eq_cbrt3`) — so its cardinality is at most 1. Three distinct roots inside a one-element set is the contradiction.",
+    "significance": "key"
+  },
+  {
+    "id": "minpoly-not-splits",
+    "proofId": "cube-root-3-irrational-oq-03-oq-03",
+    "range": { "startLine": 91, "endLine": 102 },
+    "type": "theorem",
+    "title": "The Minimal Polynomial Does Not Split in ℚ(∛3)",
+    "content": "`minpoly_not_splits_adjoin` is the direct obstruction to normality. A hypothetical splitting of `X³ − 3` over the intermediate field ℚ(∛3) is transported to ℝ by `Polynomial.splits_of_algHom` along the canonical algebra embedding `IntermediateField.val : ℚ(∛3) →ₐ[ℚ] ℝ`, after rewriting the mapped polynomial as `X³ − 3 : ℝ[X]` (`map_X_cubed_sub_three`). That contradicts `not_splits_real`. Conceptually: the two complex-conjugate roots `ω∛3, ω²∛3` of `X³ − 3` cannot live in the real field ℚ(∛3).",
+    "significance": "supporting"
+  },
+  {
+    "id": "not-normal-headline",
+    "proofId": "cube-root-3-irrational-oq-03-oq-03",
+    "range": { "startLine": 104, "endLine": 114 },
+    "type": "theorem",
+    "title": "ℚ(∛3)/ℚ Is Not Normal (nor Galois)",
+    "content": "`not_normal_adjoin_cbrt3` is the headline. If ℚ(∛3)/ℚ were normal, `Normal.splits` applied to the generator `AdjoinSimple.gen ℚ ∛3` — whose minimal polynomial is `X³ − 3` via `minpoly_gen ▸ minpoly_cbrt3` — would force `X³ − 3` to split in ℚ(∛3), contradicting `minpoly_not_splits_adjoin`. `not_isGalois_adjoin_cbrt3` follows immediately since every Galois extension is normal (`IsGalois.to_normal`). This is the standard first example of a finite non-normal field extension.",
+    "significance": "key"
+  }
+]

--- a/src/data/proofs/cube-root-3-irrational-oq-03-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03-oq-03/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "cube-root-3-irrational-oq-03-oq-03",
+  "slug": "cube-root-3-irrational-oq-03-oq-03",
+  "title": "ℚ(∛3)/ℚ is not a normal (Galois) extension",
+  "description": "Settles the Galois-theoretic status of the degree-3 extension ℚ(∛3)/ℚ: it is NOT normal, the standard first example of a finite non-normal field extension. The minimal polynomial X³ − 3 of ∛3 has its one real root inside ℚ(∛3) but its two complex-conjugate roots ω∛3, ω²∛3 outside, so X³ − 3 does not split in ℚ(∛3). The proof pushes any hypothetical splitting through the field embedding ℚ(∛3) ↪ ℝ and derives a contradiction from the fact that X³ − 3 has exactly one real root. Fully machine-checked, 0 sorries, 0 axioms beyond Lean/Mathlib foundations.",
+  "overview": {
+    "historicalContext": "A finite extension K/F is normal when every irreducible polynomial over F with a root in K splits completely in K — equivalently, K is the splitting field of some polynomial. Normality is one of the two ingredients (with separability) of a Galois extension, and Galois theory's central results (the fundamental theorem, the correspondence between subgroups and subfields) require it. The extension ℚ(∛3)/ℚ is the textbook counterexample showing degree alone does not confer normality: it has degree 3 yet fails to be normal, because adjoining a single real cube root of 3 does not bring along the two non-real cube roots. Its Galois closure is ℚ(∛3, ω) of degree 6, whose automorphism group is the symmetric group S₃. This entry pins down the non-normality that the parent's degree computation ([ℚ(∛3):ℚ] = 3) leaves open.",
+    "problemStatement": "Building on the parent entry (minpoly ℚ ∛3 = X³ − 3 and [ℚ(∛3):ℚ] = 3), prove that ℚ(∛3)/ℚ is not a normal extension — equivalently, that X³ − 3 does not split inside ℚ(∛3), and hence that ℚ(∛3)/ℚ is not Galois.",
+    "proofStrategy": "Argue by contradiction. If ℚ(∛3)/ℚ were normal, then Normal.splits applied to the generator (AdjoinSimple.gen ℚ ∛3), whose minimal polynomial is X³ − 3 (minpoly_gen ▸ minpoly_cbrt3), would give that X³ − 3 splits over ℚ(∛3). Because ℚ(∛3) is an IntermediateField of ℝ, the canonical algebra embedding IntermediateField.val : ℚ(∛3) →ₐ[ℚ] ℝ transports the splitting to ℝ via Polynomial.splits_of_algHom, yielding that X³ − 3 splits over ℝ. This is refuted directly: splits_iff_card_roots would force the real polynomial X³ − 3 to have 3 roots counted with multiplicity; separable_X_pow_sub_C gives separability, so nodup_roots makes the roots distinct; but every real root r satisfies r³ = 3 = (∛3)³, and x ↦ x³ is injective on ℝ (Odd.strictMono_pow), so r = ∛3 — a single root. Three distinct roots collapsing to one is the contradiction.",
+    "keyInsights": [
+      "Normality is exactly the statement that the minimal polynomial of each element splits in the field. The obstruction here is concrete: X³ − 3 keeps its two complex-conjugate roots ω∛3, ω²∛3 outside the real field ℚ(∛3), so it cannot split there.",
+      "The whole argument reduces to a real-analytic fact — X³ − 3 has a unique real root — transported along the embedding ℚ(∛3) ↪ ℝ. Polynomial.splits_of_algHom is the clean bridge: a polynomial that splits over an intermediate field still splits after mapping into the ambient field.",
+      "Separability turns 'three roots with multiplicity' into 'three DISTINCT roots', which is what actually contradicts the single-real-root fact. Over ℝ, X³ − 3 is separable by separable_X_pow_sub_C (3 ≠ 0 in ℝ), so nodup_roots applies with no extra work.",
+      "Non-normality complements the sibling results: the parent (oq-03) computed degree 3, and oq-03-oq-02 drew the non-constructibility corollary; this entry explains WHY the splitting field ℚ(∛3, ω) is strictly larger (degree 6) and why the Galois group lives on the closure, not on ℚ(∛3).",
+      "The same template — one real root, embedding into ℝ, injectivity of an odd power — proves ℚ(∛n)/ℚ non-normal for every non-cube n > 1, and more generally X^p − a (p odd prime, a not a p-th power) gives a non-normal simple radical extension of ℝ-embeddable type."
+    ]
+  },
+  "conclusion": {
+    "summary": "ℚ(∛3)/ℚ is not a normal extension: X³ − 3, the minimal polynomial of ∛3, does not split inside ℚ(∛3), because ℚ(∛3) ⊆ ℝ and X³ − 3 has only one real root. Consequently ℚ(∛3)/ℚ is not Galois. All four theorems are fully machine-checked with 0 sorries and no axioms beyond Lean/Mathlib's foundational propext / Classical.choice / Quot.sound (no native_decide).",
+    "implications": "Non-normality is the reason the Galois-theoretic study of X³ − 3 must pass to the splitting field ℚ(∛3, ω) (degree 6, Galois group S₃): ℚ(∛3) alone has too few automorphisms (only the identity fixes ℚ, since any ℚ-automorphism would have to permute the roots of X³ − 3, but two of them are not present). The proof template (unique real root + embedding into ℝ + injectivity of odd powers) generalizes verbatim to show ℚ(∛n)/ℚ is non-normal for every n that is not a perfect cube.",
+    "openQuestions": [
+      "Compute the splitting field degree [ℚ(∛3, ω) : ℚ] = 6 and identify the Galois group of ℚ(∛3, ω)/ℚ with S₃, exhibiting the full Galois closure whose non-existence inside ℚ(∛3) this entry establishes.",
+      "Formalize the general statement: for a squarefree integer n > 1 that is not a perfect cube, ℚ(∛n)/ℚ is a non-normal cubic extension, factoring out the ∛3-specific arithmetic into a reusable lemma."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 116,
+    "path": "Proofs/CubeRoot3IrrationalOQ03OQ03.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius (Researcher)",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CubeRoot3IrrationalOQ03OQ03.lean",
+    "tags": [
+      "galois-theory",
+      "normal-extension",
+      "field-theory",
+      "minimal-polynomial",
+      "splitting-field",
+      "cube-roots",
+      "field-extensions",
+      "number-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean/Mathlib's foundational propext / Classical.choice / Quot.sound (0 axiom declarations, 0 sorries, no native_decide). Verified via #print axioms on not_normal_adjoin_cbrt3 and not_isGalois_adjoin_cbrt3. Builds on CubeRoot3IrrationalOQ03 (minpoly_cbrt3 : minpoly ℚ ∛3 = X³ − 3, cbrt3_pow_three : ∛3³ = 3), which is itself 0-axiom. Uses Mathlib's Normal.splits, IntermediateField.minpoly_gen, Polynomial.splits_of_algHom, Polynomial.splits_iff_card_roots, Polynomial.separable_X_pow_sub_C, Polynomial.nodup_roots, and Odd.strictMono_pow.",
+    "lineCount": 116,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "not_normal_adjoin_cbrt3: ℚ(∛3)/ℚ is not a normal extension — the headline result and standard first example of a finite non-normal field extension.",
+      "not_isGalois_adjoin_cbrt3: ℚ(∛3)/ℚ is not a Galois extension, since Galois extensions are normal (IsGalois.to_normal).",
+      "minpoly_not_splits_adjoin: the minimal polynomial X³ − 3 of ∛3 does not split in ℚ(∛3) — the direct obstruction, obtained by transporting a hypothetical splitting to ℝ via the embedding ℚ(∛3) ↪ ℝ.",
+      "not_splits_real: X³ − 3 does not split over ℝ — a splitting would give three distinct real roots (separability + splits_iff_card_roots), but every real root equals ∛3.",
+      "real_root_eq_cbrt3: uniqueness of the real cube root of 3 — any real r with r³ = 3 equals ∛3, since x ↦ x³ is injective on ℝ.",
+      "map_X_cubed_sub_three: (X³ − 3 : ℚ[X]) maps to X³ − 3 : ℝ[X] under algebraMap ℚ ℝ."
+    ]
+  },
+  "references": [
+    {
+      "title": "Normal extension",
+      "url": "https://en.wikipedia.org/wiki/Normal_extension"
+    },
+    {
+      "title": "Galois extension",
+      "url": "https://en.wikipedia.org/wiki/Galois_extension"
+    },
+    {
+      "title": "Splitting field",
+      "url": "https://en.wikipedia.org/wiki/Splitting_field"
+    },
+    {
+      "title": "Mathlib: FieldTheory.Normal (Normal.splits)",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/Normal/Defs.html"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cube-root-3-irrational-oq-03",
+      "relationship": "extends",
+      "description": "Parent entry proving X³ − 3 irreducible, minpoly ℚ ∛3 = X³ − 3, and [ℚ(∛3):ℚ] = 3. This child consumes minpoly_cbrt3 and cbrt3_pow_three to show that the minimal polynomial fails to split in ℚ(∛3), settling the normality question the parent's degree computation leaves open."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-03-oq-02",
+      "relationship": "related",
+      "description": "Sibling entry deriving non-constructibility (degree 3 ≠ 2ⁿ). Both are structural consequences of the parent's degree-3 result: oq-03-oq-02 uses the degree to rule out ruler-and-compass construction, while this entry uses the shape of the roots to rule out normality."
+    },
+    {
+      "targetId": "cube-root-3-irrational",
+      "relationship": "related",
+      "description": "Grandparent entry establishing ∛3 ∉ ℚ. Non-normality of ℚ(∛3)/ℚ is a Galois-theoretic refinement of the irrationality: not only is ∛3 not rational, its defining cubic keeps two conjugates outside the field it generates."
+    }
+  ],
+  "sections": [
+    {
+      "id": "real-polynomial",
+      "title": "The Real Polynomial X³ − 3 and Its Unique Real Root",
+      "startLine": 49,
+      "endLine": 63,
+      "summary": "map_X_cubed_sub_three records that (X³ − 3 : ℚ[X]) maps to X³ − 3 : ℝ[X] under algebraMap ℚ ℝ. real_root_eq_cbrt3 proves the key arithmetic fact: any real r with r³ = 3 equals ∛3, since r³ = (∛3)³ and x ↦ x³ is injective on ℝ (Odd.strictMono_pow with Odd 3).",
+      "mathContext": "$x\\mapsto x^3$ is strictly monotone on $\\mathbb{R}$, so $r^3=3=(\\sqrt[3]{3})^3\\Rightarrow r=\\sqrt[3]{3}$."
+    },
+    {
+      "id": "not-splits-real",
+      "title": "X³ − 3 Does Not Split over ℝ",
+      "startLine": 65,
+      "endLine": 87,
+      "summary": "not_splits_real: assuming X³ − 3 splits over ℝ, splits_iff_card_roots gives roots.card = natDegree = 3. separable_X_pow_sub_C makes X³ − 3 separable, so nodup_roots makes its roots distinct. But the toFinset of roots is contained in {∛3} (every root equals ∛3 by real_root_eq_cbrt3), so its cardinality is ≤ 1 — contradicting 3.",
+      "mathContext": "Over $\\mathbb{R}$, $X^3-3=(X-\\sqrt[3]{3})(X^2+\\sqrt[3]{3}\\,X+\\sqrt[3]{9})$ with an irreducible quadratic factor, so it does not split."
+    },
+    {
+      "id": "not-normal",
+      "title": "ℚ(∛3)/ℚ Is Not Normal — and Not Galois",
+      "startLine": 89,
+      "endLine": 116,
+      "summary": "minpoly_not_splits_adjoin transports a hypothetical splitting of X³ − 3 over ℚ(∛3) to ℝ via splits_of_algHom and the embedding IntermediateField.val, contradicting not_splits_real. not_normal_adjoin_cbrt3 then applies Normal.splits to AdjoinSimple.gen ℚ ∛3 (whose minpoly is X³ − 3 via minpoly_gen ▸ minpoly_cbrt3). not_isGalois_adjoin_cbrt3 follows since IsGalois ⇒ Normal.",
+      "mathContext": "$\\mathbb{Q}(\\sqrt[3]{3})/\\mathbb{Q}$ is not normal: $\\min(\\sqrt[3]{3})=X^3-3$ has a root here but does not split, as $\\omega\\sqrt[3]{3},\\omega^2\\sqrt[3]{3}\\notin\\mathbb{R}$."
+    }
+  ]
+}

--- a/src/data/research/problems/cube-root-3-irrational-oq-03-oq-03.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-03-oq-03.json
@@ -1,0 +1,61 @@
+{
+  "slug": "cube-root-3-irrational-oq-03-oq-03",
+  "title": "ℚ(∛3)/ℚ is not a normal (Galois) extension",
+  "problemStatement": "Building on cube-root-3-irrational-oq-03 (minpoly ℚ ∛3 = X³ − 3, [ℚ(∛3):ℚ] = 3), prove that ℚ(∛3)/ℚ is not a normal extension: the minimal polynomial X³ − 3 of ∛3 does not split inside ℚ(∛3). Deduce that ℚ(∛3)/ℚ is not Galois.",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "MODERATE",
+  "significance": 7,
+  "tractability": "high",
+  "started": "2026-07-01",
+  "lastUpdate": "2026-07-01",
+  "path": "Proofs/CubeRoot3IrrationalOQ03OQ03.lean",
+  "leanFiles": ["Proofs/CubeRoot3IrrationalOQ03OQ03.lean"],
+  "relatedProofs": [
+    "cube-root-3-irrational-oq-03",
+    "cube-root-3-irrational-oq-03-oq-02",
+    "cube-root-3-irrational"
+  ],
+  "currentState": "SOLVED. ℚ(∛3)/ℚ proved non-normal and non-Galois, 0 sorries, 0 axioms beyond propext/Classical.choice/Quot.sound (verified via #print axioms). 4 theorems, 116 lines, type-checks via `lake env lean` against the prebuilt Proofs.CubeRoot3IrrationalOQ03 olean.",
+  "knowledge": {
+    "insights": [
+      "Non-normality reduces to a real-analytic fact: X³ − 3 has exactly one real root (∛3), whereas splitting a degree-3 separable polynomial needs 3 distinct roots. Since ℚ(∛3) ⊆ ℝ, it cannot hold all three.",
+      "The clean bridge from an intermediate field to the ambient field is Polynomial.splits_of_algHom: a splitting over ℚ(∛3) maps forward to a splitting over ℝ along IntermediateField.val : ℚ(∛3) →ₐ[ℚ] ℝ.",
+      "Normal.splits (new single-argument Splits API, post 2025-11 overhaul: `Splits (f : L[X])` means f splits over its own field L) applied to AdjoinSimple.gen ℚ α, combined with IntermediateField.minpoly_gen and the parent's minpoly_cbrt3, yields the splitting hypothesis to contradict.",
+      "Separability (separable_X_pow_sub_C, needs (n:F)≠0 and a≠0) + nodup_roots turns 'roots.card = 3 with multiplicity' into '3 DISTINCT roots', which is what actually contradicts the single-real-root fact.",
+      "Odd.strictMono_pow gives injectivity of x ↦ x³ on ℝ in one line — the same trick the parent used for no_rat_cube_three, reused here for uniqueness of the real cube root."
+    ],
+    "builtItems": [
+      "map_X_cubed_sub_three: (X³ − 3 : ℚ[X]).map (algebraMap ℚ ℝ) = X³ − 3 : ℝ[X] (CubeRoot3IrrationalOQ03OQ03.lean:52)",
+      "real_root_eq_cbrt3: ∀ r:ℝ, r³ = 3 → r = ∛3 (CubeRoot3IrrationalOQ03OQ03.lean:58)",
+      "not_splits_real: ¬ (X³ − 3 : ℝ[X]).Splits (CubeRoot3IrrationalOQ03OQ03.lean:65)",
+      "minpoly_not_splits_adjoin: ¬ ((X³ − 3).map (algebraMap ℚ ℚ⟮cbrt3⟯)).Splits (CubeRoot3IrrationalOQ03OQ03.lean:94)",
+      "not_normal_adjoin_cbrt3: ¬ Normal ℚ ℚ⟮cbrt3⟯ (CubeRoot3IrrationalOQ03OQ03.lean:104)",
+      "not_isGalois_adjoin_cbrt3: ¬ IsGalois ℚ ℚ⟮cbrt3⟯ (CubeRoot3IrrationalOQ03OQ03.lean:112)"
+    ],
+    "mathlibGaps": [
+      "No gaps encountered. Mathlib supplies Normal.splits, IntermediateField.minpoly_gen, Polynomial.splits_of_algHom, splits_iff_card_roots, separable_X_pow_sub_C, nodup_roots, and Odd.strictMono_pow — all directly applicable."
+    ],
+    "nextSteps": [
+      "Compute [ℚ(∛3, ω) : ℚ] = 6 and identify Gal(ℚ(∛3, ω)/ℚ) ≅ S₃ — the full Galois closure whose absence in ℚ(∛3) is established here.",
+      "Generalize to ℚ(∛n)/ℚ non-normal for any non-cube n > 1 by factoring out the ∛3-specific arithmetic into a reusable lemma about X^p − a over ℝ-embeddable fields."
+    ],
+    "progressSummary": "COMPLETE: ℚ(∛3)/ℚ proved not normal and not Galois — the standard first example of a finite non-normal extension. Verified 0-axiom, 0-sorry."
+  },
+  "knownResults": [
+    "ℚ(∛3)/ℚ is a non-normal extension of degree 3; its Galois closure is ℚ(∛3, ω) of degree 6 with Galois group S₃ (classical).",
+    "A finite extension is normal iff it is the splitting field of some polynomial iff the minimal polynomial of every element splits."
+  ],
+  "references": [
+    { "title": "Normal extension", "url": "https://en.wikipedia.org/wiki/Normal_extension" },
+    { "title": "Galois extension", "url": "https://en.wikipedia.org/wiki/Galois_extension" }
+  ],
+  "tags": [
+    "galois-theory",
+    "normal-extension",
+    "field-theory",
+    "minimal-polynomial",
+    "splitting-field",
+    "cube-roots"
+  ]
+}


### PR DESCRIPTION
## Summary

Settles the Galois-theoretic status of the degree-3 extension **ℚ(∛3)/ℚ**: it is **not normal** — the standard first example of a finite non-normal field extension — and hence not Galois.

Child of `cube-root-3-irrational-oq-03` (which proved `minpoly ℚ ∛3 = X³ − 3` and `[ℚ(∛3):ℚ] = 3`). Sibling of `-oq-03-oq-02` (non-constructibility). Where the degree computation left normality open, this entry closes it.

## Mathematical content

If ℚ(∛3)/ℚ were normal, `Normal.splits` would force the minimal polynomial `X³ − 3` of ∛3 to split *inside* ℚ(∛3). Since ℚ(∛3) is an intermediate field of ℝ, the embedding `IntermediateField.val : ℚ(∛3) →ₐ[ℚ] ℝ` transports that splitting to ℝ (`Polynomial.splits_of_algHom`). But `X³ − 3` does **not** split over ℝ:

- `splits_iff_card_roots` would give 3 roots with multiplicity;
- `separable_X_pow_sub_C` + `nodup_roots` make them **distinct**;
- yet every real root `r` has `r³ = 3 = (∛3)³`, and `x ↦ x³` is injective on ℝ (`Odd.strictMono_pow`), so `r = ∛3` — a single root.

Three distinct roots collapsing to one is the contradiction. Conceptually: the two complex-conjugate roots ω∛3, ω²∛3 cannot live in the real field ℚ(∛3).

## Theorems (4, +2 helpers)

- `not_normal_adjoin_cbrt3` — ¬ Normal ℚ ℚ⟮cbrt3⟯ (headline)
- `not_isGalois_adjoin_cbrt3` — ¬ IsGalois ℚ ℚ⟮cbrt3⟯
- `minpoly_not_splits_adjoin` — X³ − 3 does not split in ℚ(∛3)
- `not_splits_real`, `real_root_eq_cbrt3`, `map_X_cubed_sub_three`

## Verification

- 116 lines, 0 sorries, 0 `axiom` declarations.
- `#print axioms not_normal_adjoin_cbrt3` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`). **VERIFIED, 0-axiom.**
- Type-checks via `lake env lean` against the prebuilt `Proofs.CubeRoot3IrrationalOQ03` olean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)