### PR TITLE
research(combinations-formula-oq-08-oq-02): uniform stride-s s-bonacci recurrence [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ08OQ02.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ08OQ02.lean
@@ -1,0 +1,207 @@
+import Mathlib
+
+/-
+# Stride-`s` Shallow Diagonals: a Uniform `s`-bonacci Recurrence (OQ-08-OQ-02)
+
+Parent entry `combinations-formula-oq-08` proves that the Fibonacci numbers are the
+sums along the *shallow* diagonals of Pascal's triangle (stepping one row up and one
+column right), and the sibling follow-up `combinations-formula-oq-08-oq-01` derives the
+Fibonacci recurrence directly from those diagonals by Pascal's rule.
+
+Both entries left the same open question:
+
+  *Does the analogous shallow-diagonal sum with a fixed stride `s` (stepping `s` columns
+  per row) satisfy a higher-order recurrence, and can the same peeling-then-Pascal method
+  formalize it uniformly in `s`?*
+
+This entry answers it.  Fix a stride parameter `t = s - 1 ≥ 0` and define the `t`-strided
+diagonal total
+
+  `D t n := ∑ k ∈ range (n + 1), C(n - t·k, k)`.
+
+The centerpiece is the **uniform strided recurrence**
+
+  `D_recurrence : D t (n + t + 1) = D t (n + t) + D t n`,
+
+proved for *every* stride `t` by a single term-by-term Pascal expansion and reindexing of
+finite sums — no generating functions, no case split on `t`.  Specializing `t` recovers a
+whole family of classical sequences from one theorem:
+
+  * `t = 0`:  `D 0 n = 2 ^ n`         and  `2 ^ (n+1) = 2 ^ n + 2 ^ n`      (`two_pow_recurrence`)
+  * `t = 1`:  `D 1 n = fib (n + 1)`   and  `fib (n+3) = fib (n+2) + fib (n+1)` (`fib_recurrence_via_diagonal`)
+  * `t = 2`:  `D 2 n` is the Padovan sequence `1,1,1,2,3,4,6,9,…`, obeying `D 2 (n+3) = D 2 (n+2) + D 2 n`.
+
+## Proof of the recurrence (sketch)
+
+Peeling the `k = 0` term of `D t (n+t+1)` and of `D t (n+t)` with `Finset.sum_range_succ'`
+(each contributes the constant `C(·, 0) = 1`) reduces the goal, after cancelling the `+1`,
+to a single sum identity.  The driving arithmetic fact is the **unconditional** Pascal
+split of one strided diagonal term
+
+  `pascal_stride : C(n+1 - t·k, k+1) = C(n - t·k, k) + C(n - t·k, k+1)`,
+
+valid for all `k` (when `t·k > n` both sides collapse to `0` in `ℕ`).  Summing it over
+`range (n+t+1)` and splitting with `Finset.sum_add_distrib` yields two sums: the first,
+`∑ C(n - t·k, k)`, is `D t n` once the vanishing tail terms `C(n - t·k, k) = 0`
+(for `k > n`) are dropped via `Finset.sum_subset`; the second, `∑ C(n - t·k, k+1)`,
+is the peeled body of `D t (n+t)` once its single vanishing top term is dropped via
+`Finset.sum_range_succ`.  Matching the two sides gives the recurrence.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ08OQ02
+
+open Finset
+
+/-- `D t n` is the total of the shallow diagonal of Pascal's triangle taken with stride
+    `t` (i.e. stepping `t` columns per row):
+    `D t n = C(n, 0) + C(n - t, 1) + C(n - 2t, 2) + ⋯`.
+    `t = 0` gives `∑ C(n,k) = 2^n`; `t = 1` gives the Fibonacci diagonal `∑ C(n-k,k)`. -/
+def D (t n : ℕ) : ℕ := ∑ k ∈ Finset.range (n + 1), Nat.choose (n - t * k) k
+
+/-- **Unconditional strided Pascal split.**
+    Each strided diagonal entry on level `n + 1` splits into the two entries below it on
+    level `n`.  When `t * k > n` the upper index truncates to `0` and both sides vanish, so
+    the identity needs no side condition — the single arithmetic fact driving the whole
+    recurrence. -/
+theorem pascal_stride (t n k : ℕ) :
+    Nat.choose (n + 1 - t * k) (k + 1)
+      = Nat.choose (n - t * k) k + Nat.choose (n - t * k) (k + 1) := by
+  rcases le_or_gt (t * k) n with h | h
+  · have h1 : n + 1 - t * k = (n - t * k) + 1 := by omega
+    rw [h1, Nat.choose_succ_succ]
+  · have h1 : n + 1 - t * k = 0 := by omega
+    have h2 : n - t * k = 0 := by omega
+    have hk : k ≠ 0 := by rintro rfl; simp at h
+    rw [h1, h2, Nat.choose_eq_zero_of_lt (Nat.pos_of_ne_zero hk),
+        Nat.choose_eq_zero_of_lt (show 0 < k + 1 by omega)]
+
+/-- After peeling the `k = 0` term, the diagonal total `D t (n + t + 1)` is a single sum
+    over `range (n + t + 1)` plus the constant `1`.  The upper index simplifies as
+    `n + t + 1 - t·(k+1) = n + 1 - t·k`. -/
+theorem D_peel_top (t n : ℕ) :
+    D t (n + t + 1) = (∑ k ∈ range (n + t + 1), Nat.choose (n + 1 - t * k) (k + 1)) + 1 := by
+  unfold D
+  rw [Finset.sum_range_succ' (fun k => Nat.choose (n + t + 1 - t * k) k) (n + t + 1)]
+  simp only [mul_zero, Nat.sub_zero, Nat.choose_zero_right]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro k _
+  have hmul : t * (k + 1) = t * k + t := by ring
+  congr 1
+  omega
+
+/-- After peeling the `k = 0` term, the diagonal total `D t (n + t)` is a single sum over
+    `range (n + t)` plus the constant `1`.  The upper index simplifies as
+    `n + t - t·(k+1) = n - t·k`. -/
+theorem D_peel_mid (t n : ℕ) :
+    D t (n + t) = (∑ k ∈ range (n + t), Nat.choose (n - t * k) (k + 1)) + 1 := by
+  unfold D
+  rw [Finset.sum_range_succ' (fun k => Nat.choose (n + t - t * k) k) (n + t)]
+  simp only [mul_zero, Nat.sub_zero, Nat.choose_zero_right]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro k _
+  have hmul : t * (k + 1) = t * k + t := by ring
+  congr 1
+  omega
+
+/-- **The uniform strided recurrence — the combinatorial core.**
+    For every stride `t`, the strided diagonal totals satisfy
+    `D t (n + t + 1) = D t (n + t) + D t n`, derived purely by applying the strided Pascal
+    rule to each diagonal term.  No case split on `t`, no appeal to any named recurrence. -/
+theorem D_recurrence (t n : ℕ) : D t (n + t + 1) = D t (n + t) + D t n := by
+  rw [D_peel_top, D_peel_mid]
+  unfold D
+  -- Drop the vanishing tail of `∑_{range(n+t+1)} C(n - t·k, k)` back to `range (n+1)`.
+  have eqA : (∑ k ∈ range (n + t + 1), Nat.choose (n - t * k) k)
+      = ∑ k ∈ range (n + 1), Nat.choose (n - t * k) k := by
+    refine (Finset.sum_subset ?_ ?_).symm
+    · intro x hx
+      rw [Finset.mem_range] at hx ⊢
+      omega
+    · intro k hk hk'
+      rw [Finset.mem_range] at hk
+      rw [Finset.mem_range, not_lt] at hk'
+      exact Nat.choose_eq_zero_of_lt
+        (lt_of_le_of_lt (Nat.sub_le n (t * k)) (by omega))
+  -- Drop the single vanishing top term of `∑_{range(n+t+1)} C(n - t·k, k+1)`.
+  have eqB : (∑ k ∈ range (n + t + 1), Nat.choose (n - t * k) (k + 1))
+      = ∑ k ∈ range (n + t), Nat.choose (n - t * k) (k + 1) := by
+    rw [Finset.sum_range_succ,
+        Nat.choose_eq_zero_of_lt
+          (lt_of_le_of_lt (Nat.sub_le n (t * (n + t))) (by omega : n < n + t + 1)),
+        add_zero]
+  -- Split the peeled top sum by strided Pascal and reassemble.
+  have hsplit : ∀ k ∈ range (n + t + 1),
+      Nat.choose (n + 1 - t * k) (k + 1)
+        = Nat.choose (n - t * k) k + Nat.choose (n - t * k) (k + 1) :=
+    fun k _ => pascal_stride t n k
+  have key : (∑ k ∈ range (n + t + 1), Nat.choose (n + 1 - t * k) (k + 1))
+      = (∑ k ∈ range (n + 1), Nat.choose (n - t * k) k)
+        + ∑ k ∈ range (n + t), Nat.choose (n - t * k) (k + 1) :=
+    calc (∑ k ∈ range (n + t + 1), Nat.choose (n + 1 - t * k) (k + 1))
+        = ∑ k ∈ range (n + t + 1),
+            (Nat.choose (n - t * k) k + Nat.choose (n - t * k) (k + 1)) :=
+          Finset.sum_congr rfl hsplit
+      _ = (∑ k ∈ range (n + t + 1), Nat.choose (n - t * k) k)
+            + ∑ k ∈ range (n + t + 1), Nat.choose (n - t * k) (k + 1) :=
+          Finset.sum_add_distrib
+      _ = (∑ k ∈ range (n + 1), Nat.choose (n - t * k) k)
+            + ∑ k ∈ range (n + t), Nat.choose (n - t * k) (k + 1) := by rw [eqA, eqB]
+  rw [key]
+  omega
+
+/-! ### Specializations: one recurrence, three classical sequences -/
+
+/-- **Stride `0` is the full binomial row.**  `D 0 n = ∑ C(n,k) = 2 ^ n`. -/
+theorem D_zero_eq_two_pow (n : ℕ) : D 0 n = 2 ^ n := by
+  unfold D
+  simp only [zero_mul, Nat.sub_zero]
+  exact Nat.sum_range_choose n
+
+/-- **Stride `1` is the Fibonacci diagonal.**  `D 1 n = fib (n + 1)`, reproved inline by
+    reindexing Mathlib's antidiagonal form so this file stands alone. -/
+theorem D_one_eq_fib (n : ℕ) : D 1 n = Nat.fib (n + 1) := by
+  unfold D
+  simp only [one_mul]
+  symm
+  rw [Nat.fib_succ_eq_sum_choose,
+      Finset.Nat.sum_antidiagonal_eq_sum_range_succ (fun i j => Nat.choose i j) n,
+      ← Finset.sum_range_reflect (fun k => Nat.choose (n - k) k) (n + 1)]
+  refine Finset.sum_congr rfl (fun k hk => ?_)
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+  simp only [Nat.add_sub_cancel, Nat.sub_sub_self hk]
+
+/-- **Powers of two from the diagonal recurrence.**  Specializing `D_recurrence` at
+    stride `0` and applying `D_zero_eq_two_pow` recovers `2^(n+1) = 2^n + 2^n`. -/
+theorem two_pow_recurrence (n : ℕ) : 2 ^ (n + 1) = 2 ^ n + 2 ^ n := by
+  have h := D_recurrence 0 n
+  simp only [D_zero_eq_two_pow] at h
+  simpa using h
+
+/-- **The Fibonacci recurrence from the diagonal recurrence.**  Specializing `D_recurrence`
+    at stride `1` and applying `D_one_eq_fib` recovers `fib (n+3) = fib (n+2) + fib (n+1)`,
+    as a special case of the uniform strided recurrence. -/
+theorem fib_recurrence_via_diagonal (n : ℕ) :
+    Nat.fib (n + 3) = Nat.fib (n + 2) + Nat.fib (n + 1) := by
+  have h := D_recurrence 1 n
+  simp only [D_one_eq_fib] at h
+  exact h
+
+/-! ### Sanity checks -/
+
+/-- Stride `0`: `D 0 5 = 2^5 = 32`. -/
+example : D 0 5 = 32 := by decide
+
+/-- Stride `1`: `D 1 6 = fib 7 = 13`. -/
+example : D 1 6 = 13 := by decide
+
+/-- Stride `2` gives the Padovan sequence `D 2 : 1,1,1,2,3,4,6,9,13,…`. -/
+example : D 2 6 = 6 := by decide
+
+/-- Stride `2` recurrence instance: `D 2 6 = D 2 5 + D 2 3`, i.e. `6 = 4 + 2`. -/
+example : D 2 (3 + 2 + 1) = D 2 (3 + 2) + D 2 3 := by decide
+
+end CombinationsFormulaOQ08OQ02

--- a/src/data/proofs/combinations-formula-oq-08-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-08-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-cf0802-setup-defD",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 3, "endLine": 66 },
+    "type": "definition",
+    "title": "Setup and the Strided Diagonal Total D t n",
+    "content": "The parent combinations-formula-oq-08 and its sibling oq-08-oq-01 handle the stride-1 shallow diagonals of Pascal's triangle, where the k-th diagonal term is C(n−k, k) and the totals are Fibonacci numbers. This entry generalizes to an arbitrary stride, using the shifted parameter t = s − 1 so the multiplier t·k stays a genuine product rather than a truncated subtraction. The definition `D t n := ∑ k ∈ range (n+1), C(n − t·k, k)` names the stride-t diagonal total: t=0 gives the full binomial row ∑ C(n,k) = 2^n, t=1 the Fibonacci diagonal, t=2 the Padovan sequence. Everything downstream is phrased uniformly in t.",
+    "mathContext": "$D_t(n) = \\sum_{k=0}^{n} \\binom{n - t k}{k}$, the sum along the $n$-th diagonal of Pascal's triangle taken with stride $t = s-1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["shallow diagonals", "Pascal's triangle", "binomial coefficients", "Fibonacci numbers", "Padovan sequence"],
+    "prerequisites": ["binomial coefficients C(n,k)", "finite sums over Finset.range", "the stride-1 shallow-diagonal identity"]
+  },
+  {
+    "id": "ann-cf0802-pascal-stride",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 67, "endLine": 82 },
+    "type": "theorem",
+    "title": "The Unconditional Strided Pascal Split",
+    "content": "`pascal_stride` is the single arithmetic fact driving the recurrence: C(n+1 − t·k, k+1) = C(n − t·k, k) + C(n − t·k, k+1), for ALL k with no side condition. The proof splits on t·k relative to n. When t·k ≤ n the strided upper index n+1 − t·k is an exact successor (n − t·k)+1, so `Nat.choose_succ_succ` (Pascal's rule) applies directly. When t·k > n both truncated upper indices are 0 and the lower indices k, k+1 are positive, so all three binomials vanish (`Nat.choose_eq_zero_of_lt`) and the identity is 0 = 0 + 0. Unlike the Fibonacci case, which needed k ≤ n, the strided split holds unconditionally — the key to a clean uniform proof.",
+    "mathContext": "$\\binom{n+1 - t k}{k+1} = \\binom{n - t k}{k} + \\binom{n - t k}{k+1}$ for all $k$ (Pascal's rule where non-trivial, $0=0$ past the diagonal).",
+    "significance": "key",
+    "relatedConcepts": ["Pascal's rule", "Nat.choose_succ_succ", "Nat.choose_eq_zero_of_lt", "truncated subtraction (ℕ)"],
+    "prerequisites": ["Pascal's identity", "vanishing of C(a,b) for a < b", "case analysis on t·k versus n"]
+  },
+  {
+    "id": "ann-cf0802-peeling",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 83, "endLine": 109 },
+    "type": "theorem",
+    "title": "Index-Shift Normal Forms",
+    "content": "`D_peel_top` and `D_peel_mid` bring D t (n+t+1) and D t (n+t) to a common shape — a single sum plus the constant 1 — by peeling the k=0 term with `Finset.sum_range_succ'` (whose peeled constant is C(·,0)=1). The only subtlety is the strided upper index after the shift: n+t+1 − t·(k+1) = n+1 − t·k and n+t − t·(k+1) = n − t·k. These are discharged by `omega` once `ring` supplies the linear fact t·(k+1) = t·k + t, letting omega treat t·k as an opaque nonnegative atom.",
+    "mathContext": "$D_t(n+t+1) = \\big(\\sum_{k} \\binom{n+1 - t k}{k+1}\\big) + 1$ and $D_t(n+t) = \\big(\\sum_{k} \\binom{n - t k}{k+1}\\big) + 1$.",
+    "significance": "technical",
+    "relatedConcepts": ["Finset.sum_range_succ'", "index shifting", "ring normalization", "omega"],
+    "prerequisites": ["peeling the first term of a range sum", "ℕ arithmetic with an opaque product atom"]
+  },
+  {
+    "id": "ann-cf0802-recurrence",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 110, "endLine": 154 },
+    "type": "theorem",
+    "title": "The Uniform Strided Recurrence",
+    "content": "`D_recurrence` is the combinatorial core: for EVERY stride t, D t (n+t+1) = D t (n+t) + D t n, proved by a single term-by-term Pascal expansion with no case split on t. After the peels, summing `pascal_stride` over range(n+t+1) and splitting with `Finset.sum_add_distrib` yields two sums. The first, ∑ C(n − t·k, k), shrinks to D t n via `Finset.sum_subset` (the tail terms with k > n vanish since n − t·k ≤ n < k). The second, ∑ C(n − t·k, k+1), loses its single vanishing top term via `Finset.sum_range_succ`, matching the peeled D t (n+t). Cancelling the +1 constants closes the goal — the reindexing sends the k↦k+1 shift back exactly t columns, so the recurrence gap is t+1 = s.",
+    "mathContext": "$D_t(n+t+1) = D_t(n+t) + D_t(n)$ for all $t, n$ — the $s$-bonacci recurrence with $s = t+1$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_add_distrib", "Finset.sum_subset", "Finset.sum_range_succ", "term-by-term Pascal expansion"],
+    "prerequisites": ["pascal_stride", "the peeling normal forms", "reconciling sums over different ranges via vanishing terms"]
+  },
+  {
+    "id": "ann-cf0802-specializations",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 156, "endLine": 191 },
+    "type": "theorem",
+    "title": "One Recurrence, Three Classical Sequences",
+    "content": "The uniform recurrence collapses onto classical sequences by identifying D t n for small t. `D_zero_eq_two_pow` gives D 0 n = ∑ C(n,k) = 2^n (`Nat.sum_range_choose`), and `two_pow_recurrence` reads off 2^(n+1) = 2^n + 2^n from D_recurrence at t=0. `D_one_eq_fib` gives D 1 n = fib(n+1) (reproved inline by antidiagonal reindexing), and `fib_recurrence_via_diagonal` reads off fib(n+3) = fib(n+2) + fib(n+1) from D_recurrence at t=1. At t=2 the totals are the Padovan sequence 1,1,1,2,3,4,6,9,…, obeying D 2 (n+3) = D 2 (n+2) + D 2 n — all instances of the same theorem.",
+    "mathContext": "$D_0(n)=2^n$, $D_1(n)=\\mathrm{fib}(n+1)$, $D_2(n)$ Padovan; one recurrence yields $2^{n+1}=2\\cdot 2^n$, $\\mathrm{fib}(n+3)=\\mathrm{fib}(n+2)+\\mathrm{fib}(n+1)$, and the Padovan recurrence.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.sum_range_choose", "Nat.fib", "Padovan sequence", "specialization of a uniform theorem"],
+    "prerequisites": ["∑ C(n,k) = 2^n", "the stride-1 Fibonacci diagonal identity"]
+  },
+  {
+    "id": "ann-cf0802-verification",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 193, "endLine": 207 },
+    "type": "example",
+    "title": "Worked Verifications",
+    "content": "Kernel `decide` sanity checks pin down the specializations concretely: D 0 5 = 32 = 2^5; D 1 6 = 13 = fib 7; the Padovan value D 2 6 = 6; and the stride-2 recurrence instance D 2 6 = D 2 5 + D 2 3 (6 = 4 + 2). These use kernel decidability, not native_decide, so they add no axioms.",
+    "mathContext": "$D_0(5)=32$, $D_1(6)=13$, $D_2(6)=6$, and $D_2(6)=D_2(5)+D_2(3)$.",
+    "significance": "context",
+    "relatedConcepts": ["decide", "kernel decidability", "concrete verification"],
+    "prerequisites": ["evaluation of Nat.choose and Finset.sum"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-08-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-08-oq-02/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "combinations-formula-oq-08-oq-02",
+  "title": "Stride-s Shallow Diagonals: One Uniform s-bonacci Recurrence",
+  "slug": "combinations-formula-oq-08-oq-02",
+  "description": "Generalizes the shallow-diagonal Fibonacci identity to an arbitrary stride t = s - 1: for D t n = ∑_{k} C(n - t·k, k), a single theorem D_recurrence proves the uniform recurrence D t (n+t+1) = D t (n+t) + D t n for EVERY stride t, by term-by-term Pascal expansion and reindexing of finite sums — no case split on t, no generating functions. Specializing t recovers a whole family of classical sequences from one theorem: t=0 gives D 0 n = 2^n with 2^(n+1) = 2^n + 2^n; t=1 gives D 1 n = fib(n+1) with fib(n+3) = fib(n+2) + fib(n+1); t=2 gives the Padovan sequence 1,1,1,2,3,4,6,9,… obeying D 2 (n+3) = D 2 (n+2) + D 2 n. The driving fact is an UNCONDITIONAL strided Pascal split pascal_stride: C(n+1-t·k, k+1) = C(n-t·k, k) + C(n-t·k, k+1), valid for all k because both sides collapse to 0 in ℕ once t·k > n. This answers the second open question left by both combinations-formula-oq-08 and its sibling oq-08-oq-01.",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ08OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 207,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "assumptions": "None. The recurrence holds for every stride t and every natural number n and is fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool — the decide sanity checks use kernel decidability, not native_decide).",
+    "tags": [
+      "combinatorics",
+      "fibonacci",
+      "padovan",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "finset-sums",
+      "recurrence",
+      "number-theory"
+    ],
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "D_recurrence: for EVERY stride t, the strided shallow-diagonal totals D t n = ∑_{k<n+1} C(n - t·k, k) satisfy the uniform recurrence D t (n+t+1) = D t (n+t) + D t n, proved by a single term-by-term Pascal expansion and reindexing — no case split on t, no appeal to any named recurrence",
+      "pascal_stride: the UNCONDITIONAL strided Pascal split C(n+1 - t·k, k+1) = C(n - t·k, k) + C(n - t·k, k+1), valid for all k with no side condition because when t·k > n both sides collapse to 0 in ℕ (the single arithmetic fact driving the recurrence)",
+      "D_peel_top and D_peel_mid: index-shift normal forms expressing D t (n+t+1) and D t (n+t) as a single sum over range(n+t+1) / range(n+t) plus the constant 1, obtained by peeling k=0 with Finset.sum_range_succ' and simplifying the strided upper index n+t+1 - t·(k+1) = n+1 - t·k",
+      "D_zero_eq_two_pow: the stride-0 diagonal is the full binomial row, D 0 n = ∑ C(n,k) = 2^n, giving two_pow_recurrence 2^(n+1) = 2^n + 2^n as a special case of the uniform recurrence",
+      "D_one_eq_fib: the stride-1 diagonal is the Fibonacci diagonal D 1 n = fib(n+1) (reproved inline by reindexing the antidiagonal form), giving fib_recurrence_via_diagonal fib(n+3) = fib(n+2) + fib(n+1) as a special case",
+      "Worked identification of the stride-2 diagonal totals with the Padovan sequence 1,1,1,2,3,4,6,9,… and its recurrence D 2 (n+3) = D 2 (n+2) + D 2 n"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule C(n+1, k+1) = C(n, k) + C(n, k+1); the arithmetic heart of pascal_stride in the branch t·k ≤ n, where the strided upper index n+1 - t·k is an exact successor.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_eq_zero_of_lt",
+        "description": "C(a, b) = 0 when a < b; supplies the vanishing terms in the t·k > n branch of pascal_stride and drops the tail of the strided sums back to the range of D t n.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Peels the first term: ∑_{i<n+1} f i = (∑_{i<n} f(i+1)) + f 0. Used to strip the k=0 term of the strided diagonal totals before applying Pascal's rule.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_subset",
+        "description": "Extends a sum to a larger index set when the added terms vanish; used to shrink ∑_{range(n+t+1)} C(n - t·k, k) back to ∑_{range(n+1)} = D t n by discarding vanishing tail terms.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "Splits ∑ (f + g) = ∑ f + ∑ g; separates the two halves of the Pascal-split summand into the D t n term and the peeled D t (n+t) term.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.fib_succ_eq_sum_choose",
+        "description": "Fibonacci as a sum over the antidiagonal; the starting point for the inline reproof of D_one_eq_fib (the stride-1 specialization).",
+        "module": "Mathlib.Combinatorics.Choose.Sum"
+      },
+      {
+        "theorem": "Nat.sum_range_choose",
+        "description": "∑_{k<n+1} C(n,k) = 2^n; identifies the stride-0 diagonal total D 0 n with a power of two.",
+        "module": "Mathlib.Combinatorics.Choose.Sum"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ08OQ02.lean",
+    "namespace": "CombinationsFormulaOQ08OQ02",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 207,
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The appearance of Fibonacci numbers as sums along the shallow diagonals of Pascal's triangle is classical (Lucas, 1876). The parent entry combinations-formula-oq-08 formalized that identity; the sibling oq-08-oq-01 derived the Fibonacci recurrence from it via Pascal's rule. Both entries closed with the same open question: does a fixed larger stride s (stepping s columns per row) produce a higher-order recurrence, uniformly formalizable by the same method? The strided diagonals interpolate between well-known sequences — stride 1 is Fibonacci, stride 2 is the Padovan/Perrin-type sequence — so a single uniform statement collects several classical recurrences under one combinatorial umbrella.",
+    "problemStatement": "For a stride parameter t = s - 1 ≥ 0, define D t n = ∑_{k<n+1} C(n - t·k, k). Prove, uniformly in t, the strided recurrence D t (n+t+1) = D t (n+t) + D t n by the same peeling-then-Pascal method used for Fibonacci, and identify the specializations t = 0 (powers of two) and t = 1 (Fibonacci) and t = 2 (Padovan).",
+    "proofStrategy": "Work with the shifted parameter t = s - 1 to avoid truncated subtraction in the stride. (1) Peel the k=0 term of D t (n+t+1) and of D t (n+t) with Finset.sum_range_succ'; each contributes the constant C(·,0)=1, and the strided upper index simplifies via n+t+1 - t·(k+1) = n+1 - t·k (proved by omega after ring-normalizing t·(k+1) = t·k + t). (2) The core arithmetic is pascal_stride: C(n+1 - t·k, k+1) = C(n - t·k, k) + C(n - t·k, k+1), which holds UNCONDITIONALLY — for t·k ≤ n it is Pascal's rule on the successor n+1 - t·k = (n - t·k)+1, and for t·k > n both sides vanish in ℕ. (3) Sum pascal_stride over range(n+t+1) and split with Finset.sum_add_distrib. The first half ∑ C(n - t·k, k) shrinks to D t n via Finset.sum_subset (tail terms C(n - t·k, k) vanish for k > n); the second half ∑ C(n - t·k, k+1) loses its single vanishing top term via Finset.sum_range_succ, matching the peeled D t (n+t). Cancelling the +1 constants gives the recurrence. Specializations follow by Nat.sum_range_choose (t=0) and an inline antidiagonal reindexing (t=1).",
+    "keyInsights": [
+      "Shifting to the stride parameter t = s - 1 keeps the multiplier t·k a genuine product (never a truncated subtraction), so ring normalizes t·(k+1) = t·k + t and omega discharges every strided index identity treating t·k as an opaque nonnegative atom.",
+      "The strided Pascal split is unconditional: unlike the Fibonacci case which needed k ≤ n, here the identity C(n+1 - t·k, k+1) = C(n - t·k, k) + C(n - t·k, k+1) holds for all k, because once t·k > n every truncated upper index is 0 and the surviving lower indices are positive, so all three binomials vanish.",
+      "One recurrence subsumes several classical sequences: stride 0 is the binomial row summing to 2^n, stride 1 is the Fibonacci diagonal, stride 2 is the Padovan sequence — the uniform D_recurrence proves 2^(n+1)=2^n+2^n, fib(n+3)=fib(n+2)+fib(n+1), and D 2 (n+3)=D 2 (n+2)+D 2 n all at once.",
+      "The step size in the recurrence equals the stride plus one: reading off the reindexing, applying Pascal to level n+t+1 sends the k↦k+1 shift back exactly t columns, landing on level n — so the recurrence gap is t+1 = s, matching the s-bonacci intuition of the open question."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Strategy",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Header stating OQ-08-OQ-02: does the stride-s shallow diagonal satisfy a uniform higher-order recurrence, formalizable by the same peeling-then-Pascal method? Introduces the stride parameter t = s-1 and sketches the proof."
+    },
+    {
+      "id": "definition",
+      "title": "The Strided Diagonal Total D t n",
+      "startLine": 53,
+      "endLine": 66,
+      "summary": "Defines D t n = ∑_{k<n+1} C(n - t·k, k), the shallow diagonal taken with stride t; t=0 gives the binomial row summing to 2^n, t=1 the Fibonacci diagonal."
+    },
+    {
+      "id": "pascal-stride",
+      "title": "The Unconditional Strided Pascal Split",
+      "startLine": 67,
+      "endLine": 82,
+      "summary": "pascal_stride: C(n+1 - t·k, k+1) = C(n - t·k, k) + C(n - t·k, k+1) for all k, by cases on t·k ≤ n (Nat.choose_succ_succ on a successor) versus t·k > n (all three binomials vanish in ℕ)."
+    },
+    {
+      "id": "peeling",
+      "title": "Index-Shift Normal Forms",
+      "startLine": 83,
+      "endLine": 109,
+      "summary": "D_peel_top and D_peel_mid: express D t (n+t+1) and D t (n+t) as a single sum plus the constant 1, peeling k=0 with Finset.sum_range_succ' and simplifying the strided upper index n+t+1 - t·(k+1) = n+1 - t·k."
+    },
+    {
+      "id": "recurrence",
+      "title": "The Uniform Strided Recurrence",
+      "startLine": 110,
+      "endLine": 154,
+      "summary": "D_recurrence: D t (n+t+1) = D t (n+t) + D t n for every stride t, by summing pascal_stride over range(n+t+1), splitting with Finset.sum_add_distrib, shrinking one half to D t n via Finset.sum_subset and the other to the peeled D t (n+t) via Finset.sum_range_succ."
+    },
+    {
+      "id": "specializations",
+      "title": "One Recurrence, Three Classical Sequences",
+      "startLine": 156,
+      "endLine": 191,
+      "summary": "Specializations: D_zero_eq_two_pow (D 0 n = 2^n) and two_pow_recurrence (2^(n+1) = 2^n + 2^n); D_one_eq_fib (D 1 n = fib(n+1), reproved inline) and fib_recurrence_via_diagonal (fib(n+3) = fib(n+2) + fib(n+1))."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 193,
+      "endLine": 207,
+      "summary": "decide sanity checks: D 0 5 = 32; D 1 6 = fib 7 = 13; the Padovan value D 2 6 = 6; and the stride-2 recurrence instance D 2 6 = D 2 5 + D 2 3."
+    }
+  ],
+  "conclusion": {
+    "summary": "8 theorems, 1 definition, 0 sorries, 0 axioms. For every stride t, the strided shallow-diagonal totals D t n = ∑_{k<n+1} C(n - t·k, k) satisfy the uniform recurrence D t (n+t+1) = D t (n+t) + D t n (D_recurrence), proved by a single term-by-term Pascal expansion — no case split on t. The driving fact pascal_stride is an unconditional Pascal split of one strided term. Specializing t recovers three classical sequences: t=0 gives 2^(n+1) = 2^n + 2^n, t=1 gives fib(n+3) = fib(n+2) + fib(n+1), and t=2 gives the Padovan recurrence.",
+    "implications": "This answers the second open question of both combinations-formula-oq-08 and its sibling oq-08-oq-01: the shallow-diagonal picture extends uniformly across strides, with the recurrence gap equal to the stride, so Fibonacci, powers of two, and Padovan-type sequences are all shadows of Pascal's rule read at different slopes. The peeling-then-Pascal pattern (sum_range_succ' to peel, ring+omega to normalize the strided index treating t·k as an opaque atom, an unconditional term-by-term Pascal split, and sum_subset/sum_range_succ to reconcile ranges) is now demonstrated to be fully stride-uniform.",
+    "openQuestions": [
+      "Does the strided total admit a closed generating function ∑_n (D t n) x^n = 1 / (1 - x - x^(t+1)), and can the recurrence D_recurrence be re-derived from it, giving a second, generating-function proof to complement the combinatorial one?",
+      "For stride t ≥ 2 the recurrence D t (n+t+1) = D t (n+t) + D t n skips the intermediate terms; is there a companion partial-sum identity ∑_{i<n} D t i = (a shifted D t value) - c generalizing the Lucas telescoping ∑_{i<n} D 1 i = fib(n+2) - 1 of the sibling entry?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-08",
+      "relationship": "grandparent — provides the stride-1 shallow-diagonal Fibonacci identity and posed the stride-s generalization as its second open question"
+    },
+    {
+      "targetId": "combinations-formula-oq-08-oq-01",
+      "relationship": "sibling — derives the Fibonacci recurrence from the stride-1 diagonals; this entry generalizes its peeling-then-Pascal method uniformly to all strides"
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "T. Koshy",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": 2001,
+      "venue": "Wiley",
+      "note": "Fibonacci/Lucas identities, shallow diagonals of Pascal's triangle, and generalized recurrences."
+    },
+    {
+      "authors": "R. L. Graham, D. E. Knuth, O. Patashnik",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "venue": "Addison-Wesley",
+      "note": "Standard reference for binomial-coefficient identities and generalized Fibonacci recurrences."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.choose, Nat.fib, Nat.sum_range_choose, and the antidiagonal/binomial API underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the second open question of both `combinations-formula-oq-08` and its sibling `combinations-formula-oq-08-oq-01`: does the shallow-diagonal sum with a fixed stride `s` satisfy a uniform higher-order recurrence, formalizable by the same peeling-then-Pascal method?

Working with the shifted stride parameter `t = s - 1 ≥ 0`, define the strided diagonal total
```
D t n := ∑ k ∈ range (n+1), C(n - t·k, k)
```
The centerpiece is the **uniform recurrence**, proved for *every* stride `t` with no case split on `t`:
```
D_recurrence : D t (n + t + 1) = D t (n + t) + D t n
```

**One recurrence, three classical sequences** (all as specializations):
| stride | `D t n` | recurrence |
|---|---|---|
| `t = 0` | `2^n` (`D_zero_eq_two_pow`) | `2^(n+1) = 2^n + 2^n` (`two_pow_recurrence`) |
| `t = 1` | `fib(n+1)` (`D_one_eq_fib`) | `fib(n+3) = fib(n+2) + fib(n+1)` (`fib_recurrence_via_diagonal`) |
| `t = 2` | Padovan `1,1,1,2,3,4,6,9,…` | `D 2 (n+3) = D 2 (n+2) + D 2 n` |

## Key idea

The driving arithmetic fact `pascal_stride` is an **unconditional** strided Pascal split:
```
C(n+1 - t·k, k+1) = C(n - t·k, k) + C(n - t·k, k+1)   -- for ALL k
```
For `t·k ≤ n` this is Pascal's rule on the successor `n+1 - t·k = (n - t·k)+1`; for `t·k > n` all three binomials vanish in ℕ. Summing over `range(n+t+1)`, splitting with `Finset.sum_add_distrib`, and reconciling ranges via `Finset.sum_subset` / `Finset.sum_range_succ` gives the recurrence. The reindexing sends the `k↦k+1` shift back exactly `t` columns, so the recurrence gap is `t+1 = s`.

## Verification

- **8 theorems, 1 definition, 207 lines, 0 sorries.**
- `#print axioms` on `D_recurrence`, `fib_recurrence_via_diagonal`, `two_pow_recurrence`, `D_one_eq_fib`: only `propext`, `Classical.choice`, `Quot.sound`. No `sorryAx`, no `Lean.ofReduceBool` (the `decide` sanity checks use kernel decidability, not `native_decide`). **VERIFIED, 0-axiom.**
- Typechecks via `lake env lean Proofs/CombinationsFormulaOQ08OQ02.lean` (exit 0, no warnings).

## Files
- `proofs/Proofs/CombinationsFormulaOQ08OQ02.lean`
- `src/data/proofs/combinations-formula-oq-08-oq-02/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)