### PR TITLE
research(central-limit-theorem-oq-02-oq-04): S19 — covariance translation-invariance [VERIFIED, 0-axiom, +2thm]

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
@@ -31,7 +31,18 @@ Sorries remaining: 2 (unchanged — this PR adds one proven theorem; the two
 sorries `davydov_covariance_inequality` (S5c) and `mixing_clt_ibragimov` (S6+)
 remain).
 
-**This session: S17 — simple-function (finite-sum) covariance bound.**
+**S19 (this session): covariance translation-invariance.** Added
+`covariance_add_const_left` and `covariance_add_const_right` (PROVEN, 0-axiom):
+`Cov(f + c, g) = Cov(f, g)` and `Cov(f, g + c) = Cov(f, g)` in the explicit
+`∫ f·g − (∫ f)(∫ g)` form, under integrability of `f`, `g`, `f·g` on a
+probability measure. These are the algebraic reduction the Davydov density step
+(S5c) uses to replace a signed bounded `f ∈ [m, M]` by the *nonnegative* shift
+`f − m ∈ [0, M − m]` (the form required by the layer-cake / super-level
+indicator decomposition). Pure Bochner linearity: `integral_add` +
+`integral_const_mul` on the joint integral, `∫ c ∂μ = c` on the marginal.
+Sorries unchanged (2).
+
+**Earlier session: S17 — simple-function (finite-sum) covariance bound.**
 Added `finset_indicator_covariance_le_alpha` (PROVEN, 0-axiom): lifts the S16
 single-cell bound to a *pair of simple functions*
 `f = ∑ᵢ aᵢ 1_{Aᵢ}` (σPair 0-measurable) and `g = ∑ⱼ bⱼ 1_{Bⱼ}`
@@ -776,6 +787,72 @@ theorem finset_indicator_covariance_le_alpha
     _ = (∑ i ∈ s, |a i|) * (∑ j ∈ t, |b j|) * α := by
         rw [Finset.sum_mul_sum]
         simp_rw [Finset.sum_mul]
+
+/-! ### Covariance translation-invariance (S19 — algebraic reduction for the
+     L^p density step)
+
+The Davydov density step (`davydov_covariance_inequality`, S5c) reduces a
+signed bounded variable `f` with values in `[m, M]` to the *nonnegative* shift
+`f − m ∈ [0, M − m]`, which is the form required by the layer-cake /
+super-level indicator decomposition `f − m = ∫₀^{M−m} 1_{f − m > t} dt`. That
+reduction is legitimate precisely because covariance is unchanged when a
+constant is added to either argument:
+`Cov(f + c, g) = Cov(f, g)` and `Cov(f, g + c) = Cov(f, g)`.
+
+Both identities are pure linearity of the Bochner integral together with
+`∫ c ∂μ = c` on a probability measure; they carry no assumption beyond
+integrability of `f`, `g`, and the product `f · g`. -/
+
+/-- **Covariance is invariant under adding a constant to the left argument.**
+
+`Cov(f + c, g) = Cov(f, g)`, where covariance is written in the explicit form
+`∫ f·g − (∫ f)(∫ g)` used throughout this file. The proof splits the joint
+integral `∫ (f + c)·g = ∫ f·g + c ∫ g` and the marginal `∫ (f + c) = ∫ f + c`
+(using `IsProbabilityMeasure μ`, so `∫ c ∂μ = c`); the two `c ∫ g` terms then
+cancel. This is the algebraic reduction that lets the Davydov density step
+replace a bounded `f ∈ [m, M]` by the nonnegative shift `f − m`. -/
+theorem covariance_add_const_left
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {f g : Ω → ℝ} (c : ℝ)
+    (hf : Integrable f μ) (hg : Integrable g μ)
+    (hfg : Integrable (fun ω => f ω * g ω) μ) :
+    (∫ ω, (f ω + c) * g ω ∂μ) - (∫ ω, (f ω + c) ∂μ) * (∫ ω, g ω ∂μ)
+      = (∫ ω, f ω * g ω ∂μ) - (∫ ω, f ω ∂μ) * (∫ ω, g ω ∂μ) := by
+  have hcg : Integrable (fun ω => c * g ω) μ := hg.const_mul c
+  -- Joint integral splits: `∫ (f + c)·g = ∫ f·g + c ∫ g`.
+  have hjoint : (∫ ω, (f ω + c) * g ω ∂μ)
+      = (∫ ω, f ω * g ω ∂μ) + c * ∫ ω, g ω ∂μ := by
+    have hpt : (fun ω => (f ω + c) * g ω) = (fun ω => f ω * g ω + c * g ω) := by
+      funext ω; ring
+    rw [hpt, integral_add hfg hcg, integral_const_mul]
+  -- Marginal integral splits: `∫ (f + c) = ∫ f + c` (probability measure).
+  have hmarg : (∫ ω, (f ω + c) ∂μ) = (∫ ω, f ω ∂μ) + c := by
+    rw [integral_add hf (integrable_const c), integral_const]; simp
+  rw [hjoint, hmarg]; ring
+
+/-- **Covariance is invariant under adding a constant to the right argument.**
+
+`Cov(f, g + c) = Cov(f, g)`, the right-hand companion of
+`covariance_add_const_left`. Proved analogously by splitting the joint integral
+`∫ f·(g + c) = ∫ f·g + c ∫ f` and the marginal `∫ (g + c) = ∫ g + c`. -/
+theorem covariance_add_const_right
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {f g : Ω → ℝ} (c : ℝ)
+    (hf : Integrable f μ) (hg : Integrable g μ)
+    (hfg : Integrable (fun ω => f ω * g ω) μ) :
+    (∫ ω, f ω * (g ω + c) ∂μ) - (∫ ω, f ω ∂μ) * (∫ ω, (g ω + c) ∂μ)
+      = (∫ ω, f ω * g ω ∂μ) - (∫ ω, f ω ∂μ) * (∫ ω, g ω ∂μ) := by
+  have hcf : Integrable (fun ω => c * f ω) μ := hf.const_mul c
+  -- Joint integral splits: `∫ f·(g + c) = ∫ f·g + c ∫ f`.
+  have hjoint : (∫ ω, f ω * (g ω + c) ∂μ)
+      = (∫ ω, f ω * g ω ∂μ) + c * ∫ ω, f ω ∂μ := by
+    have hpt : (fun ω => f ω * (g ω + c)) = (fun ω => f ω * g ω + c * f ω) := by
+      funext ω; ring
+    rw [hpt, integral_add hfg hcf, integral_const_mul]
+  -- Marginal integral splits: `∫ (g + c) = ∫ g + c` (probability measure).
+  have hmarg : (∫ ω, (g ω + c) ∂μ) = (∫ ω, g ω ∂μ) + c := by
+    rw [integral_add hg (integrable_const c), integral_const]; simp
+  rw [hjoint, hmarg]; ring
 
 /-- **Davydov's covariance inequality** (Davydov 1968).
 

--- a/research/problems/central-limit-theorem-oq-02-oq-04/knowledge.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-04/knowledge.md
@@ -556,3 +556,50 @@ axiomCount 0.
   `/tmp` worktree was reaped mid-session, losing edits) and symlink
   `proofs/.lake → main repo proofs/.lake` to typecheck via `lake env lean`
   without a full rebuild (parent olean + Mathlib cache already present).
+
+---
+
+## S19 (researcher-1, 2026-07-01) — Covariance translation-invariance
+
+**Delivered (VERIFIED, 0-axiom, +2 theorems):** stacked on the open S18 PR
+#32411 branch.
+
+- `covariance_add_const_left`: `Cov(f + c, g) = Cov(f, g)`
+- `covariance_add_const_right`: `Cov(f, g + c) = Cov(f, g)`
+
+Stated in the explicit `∫ f·g − (∫ f)(∫ g)` form used throughout the file,
+under integrability of `f`, `g`, and the product `f·g`, on a probability
+measure. Both `#print axioms` = `[propext, Classical.choice, Quot.sound]` only.
+
+**Why this is the right next algebraic increment.** The remaining Davydov
+density step (`davydov_covariance_inequality`, S5c) reduces a *signed* bounded
+variable `f ∈ [m, M]` to the *nonnegative* shift `f − m ∈ [0, M − m]` before
+applying the layer-cake / super-level indicator decomposition
+`f − m = ∫₀^{M−m} 1_{f−m>t} dt` (which feeds the already-proven
+`finset_indicator_covariance_le_alpha`). That reduction is only valid because
+covariance is constant-shift invariant — now formalized.
+
+**Proof recipe (both directions identical up to a swap).**
+- Joint: `∫ (f+c)·g = ∫ f·g + c ∫ g` via a `funext`/`ring` pointwise rewrite
+  `(f+c)·g = f·g + c·g`, then `integral_add hfg (hg.const_mul c)` and
+  `integral_const_mul`.
+- Marginal: `∫ (f+c) = ∫ f + c` via `integral_add hf (integrable_const c)`,
+  then `integral_const` + `simp`.
+- Close with `rw [hjoint, hmarg]; ring`.
+
+**Gotcha.** `integral_const` rewrites `∫ c ∂μ` to `μ.real Set.univ • c`
+(measure-*real*, not `(μ Set.univ).toReal`), so `rw [measure_univ]` fails to
+unify. Just finish the marginal with `simp` — it knows
+`measureReal_univ`/`IsProbabilityMeasure` and reduces `μ.real univ • c` to `c`.
+
+**Sorries unchanged (2):** `davydov_covariance_inequality` (S5c, the analytic
+Hölder + layer-cake amplification) and `mixing_clt_ibragimov` (S6+). This
+session adds no new assumptions.
+
+**Next (S5c) concrete target.** Bounded-variable Davydov: prove
+`|Cov(f, g)| ≤ 4·M·N·α` for `σPair`-measurable *bounded* simple functions
+`|f| ≤ M`, `|g| ≤ N`, by: shift to nonnegative (now available), layer-cake to
+super-level indicators with telescoping coefficients (`∑|Δcᵢ| ≤ M`), then
+`finset_indicator_covariance_le_alpha`. The residual analytic gap is the L^p→
+bounded truncation (`truncation_tail_sq_le`, S18) + Hölder amplification to the
+`(p-2)/p` exponent.

--- a/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
@@ -23,9 +23,9 @@
       "Topology"
     ],
     "namespace": "CentralLimitTheoremOQ02OQ04",
-    "lineCount": 1042,
+    "lineCount": 1119,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 3,
     "path": "Proofs/CentralLimitTheoremOQ02OQ04.lean",
     "sorries": 2
@@ -48,12 +48,12 @@
     "badge": "axiom",
     "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 1042,
+    "lineCount": 1119,
     "assumptions": "2 sorries: (1) davydov_covariance_inequality — Davydov L^p covariance bound. Structurally reduces to (a) alphaMixingCoeff_le_one [proven S5], (b) alphaMixingCoeff_nonneg [proven S5 — closes parent file TODO at line 444], (c) davydov_indicator_bound [proven S5b — indicator base case via le_ciSup_of_le + ciSup_pos at the 4 nested ⨆ layers], (d) L^p density step via level-set decomposition + Hölder. With (a)/(b)/(c) all proven and the S5c-prep covariance-integral packaging indicator_covariance_le_alpha now in place (35 LOC, this session), only (d) remains for the full L^p Davydov bound; (d) is the S5c target (~100 lines). (2) mixing_clt_ibragimov — main CLT, deferred to S6+ pending Bernstein blocks + Lindeberg. S5c-prep ACT (latest session, this PR) adds indicator_covariance_le_alpha: bridges S4 indicator_pair_covariance_eq + S5b davydov_indicator_bound into the covariance-form indicator α-bound |∫1_A · 1_B dμ − (∫1_A dμ)(∫1_B dμ)| ≤ alphaMixingCoeff μ ℱ 𝒢. 3-line proof composing the algebraic identity + Measure.real_def + S5b. Build verified Docker (3131 jobs). Also fixes line-419 unused-simp-arg linter warning. Sorry count unchanged. A later session (S16) adds scaled_indicator_covariance_le_alpha (PROVEN): promotes the unit-indicator bound to arbitrary real scalars, |Cov(a·1_A, b·1_B)| ≤ |a|·|b|·alphaMixingCoeff μ ℱ 𝒢, the single-cell building block of the simple-function step toward davydov_covariance_inequality — purely additive infrastructure, sorry count still 2. 0 axioms; parent file CentralLimitTheoremOQ02.lean carries 1 axiom (martingale_clt) and 3 sorries reused by reference.",
     "mathlib_version": "4.26.0",
     "historicalContext": "Ibragimov's 1962 paper *Some limit theorems for stationary processes* (Theory Probab. Appl. 7, 349-382) is the foundational result for CLT under strong mixing. Building on Rosenblatt's 1956 introduction of α-mixing, Ibragimov showed that for stationary sequences with E[X₁²+δ] < ∞ and ∑_n α(n)^{δ/(2+δ)} < ∞, the partial sums S_n/√n converge weakly to a centered Gaussian with the long-run variance σ² = Var(X₁) + 2∑_{k=1}^∞ Cov(X₁, X_{1+k}). The polynomial-rate specialization α(n) ≤ C·n^{-r} translates Ibragimov's covariance summability condition to the algebraic threshold r > (2+δ)/δ — a sharpness statement first made explicit in the survey literature (Doukhan 1994, *Mixing: Properties and Examples*, Springer LNS 85, and Rio 2017, *Asymptotic Theory of Weakly Dependent Random Variables*). The threshold rate δ/(2+δ) is the Davydov exponent from his 1968 covariance inequality |Cov(X,Y)| ≤ C·α^{δ/(2+δ)}·‖X‖_{2+δ}·‖Y‖_{2+δ}.",
     "proofStrategy": "S1-S3 (done): scaffolding, predicates, structure, helpers, longrun_variance_absolutely_convergent modulo Davydov. S4 (in progress): #17939 (researcher-6) added indicator_pair_covariance_eq (proven algebraic identity); THIS PR adds build-fix (stale Mathlib.Probability.Variance import removal, davydov_covariance_inequality signature refactor to Fin 2 → MS Ω wrap to dodge typeclass-synthesis quirk on MS Ω args, σ² → σsq rename, ℝ≥0∞ → ENNReal + open Topology for 𝓝) plus proven `indicator_cov_le_one` ([0,1] envelope) and documented structural decomposition of davydov_covariance_inequality into 3 named order-theory ingredients (alphaMixingCoeff_le_one, alphaMixingCoeff_nonneg, davydov_indicator_bound) + L^p density step. S5a (next, mechanic-pass): formalize the 3 order-theory ingredients. S5b (next, ~100 lines): L^p density / truncation step. S6+ ACT: Bernstein blocks + Lindeberg + invoke parent CLT.",
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 3,
     "originalContributions": [
       "Sharp-threshold formulation: IbragimovHypotheses structure encoding the r > (2+δ)/δ constraint as a top-level field",


### PR DESCRIPTION
## Summary

Stacked on the open S18 PR #32411 (includes its 2 commits until #32411 merges). Adds two verified, 0-axiom covariance identities to `CentralLimitTheoremOQ02OQ04.lean`:

- `covariance_add_const_left`: `Cov(f + c, g) = Cov(f, g)`
- `covariance_add_const_right`: `Cov(f, g + c) = Cov(f, g)`

Stated in the explicit `∫ f·g − (∫ f)(∫ g)` form used throughout the file, under integrability of `f`, `g`, and the product `f·g`, on a probability measure.

## Why this is the right next increment

The remaining Davydov density step (`davydov_covariance_inequality`, S5c) reduces a *signed* bounded variable `f ∈ [m, M]` to the *nonnegative* shift `f − m ∈ [0, M − m]` before the layer-cake / super-level indicator decomposition `f − m = ∫₀^{M−m} 1_{f−m>t} dt` (which feeds the already-proven `finset_indicator_covariance_le_alpha`). That reduction is valid precisely because covariance is constant-shift invariant — now formalized.

## Verification

- Typechecks against Mathlib cache (`lake env lean`); only the 2 pre-existing deep sorries warn.
- `#print axioms` for both new theorems = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`.
- Sorries unchanged (2): `davydov_covariance_inequality` (S5c), `mixing_clt_ibragimov` (S6+). No new assumptions.

meta.json: theoremCount 18→20, lineCount updated. knowledge.md: S19 entry with proof recipe + `integral_const` → `μ.real` gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)