### PR TITLE
research(divisibility-by-three-oq-01-oq-03): casting out nines generalized to every base [VERIFIED, 0-axiom, +13thm]

### DIFF
--- a/proofs/Proofs/DivisibilityBy3OQ01OQ03.lean
+++ b/proofs/Proofs/DivisibilityBy3OQ01OQ03.lean
@@ -1,0 +1,147 @@
+import Mathlib
+
+/-
+# Divisibility By Three OQ-01 → OQ-03: Casting Out Nines, Generalized
+
+## Open question
+
+`divisibility-by-three-oq-01-oq-03`: *Casting out nines, generalized —
+the base-`b` digit sum is congruent to `n` modulo `d` whenever the base
+satisfies `b ≡ 1 (mod d)`.*
+
+The classical "casting out nines" rule states that a natural number `n` is
+congruent, modulo `9`, to the sum of its decimal digits; the "casting out
+threes" rule is the same statement modulo `3`.  Both are the special case
+`b = 10`, `d ∈ {3, 9}` of a single phenomenon: the digit-sum test works in
+base `b` for a modulus `d` exactly when `b ≡ 1 (mod d)`, i.e. when
+`d ∣ (b - 1)`.
+
+The parent entry `divisibility-by-three-oq-01` develops digital-root theory
+in base `10`; the sibling `divisibility-by-three-oq-01-oq-02` gives a base-`10`
+osculator for divisors coprime to `10`.  Both are anchored to base `10`.
+This entry removes the base restriction entirely.
+
+Mathlib provides the base-agnostic congruence `Nat.modEq_digits_sum` and the
+signed master lemma `Nat.dvd_iff_dvd_ofDigits`, but only *instantiates* them at
+base `10` (`Nat.three_dvd_iff`, `Nat.nine_dvd_iff`, `Nat.eleven_dvd_iff`).
+Here we package the two genuinely general statements and exhibit them at bases
+that Mathlib never touches.
+
+## What this file proves (0 axioms, 0 sorries)
+
+* `digitSum_modEq` — `b ≡ 1 (mod d) → n ≡ (digits b n).sum (mod d)`
+  (the congruence form; a thin repackage of `Nat.modEq_digits_sum`).
+* `dvd_iff_dvd_digitSum` — the **divisibility test** in signed form:
+  `(d : ℤ) ∣ (b - 1) → (d ∣ n ↔ d ∣ (digits b n).sum)`.
+* `digitSum_test_of_dvd_pred` — the **headline**: for every base `b ≥ 1` and
+  every divisor `d` of `b - 1`, `d ∣ n ↔ d ∣ (digits b n).sum`.  This single
+  statement subsumes every classical "casting out" rule.
+* `dvd_iff_dvd_alternatingSum` — the dual **alternating-sum test**:
+  `(d : ℤ) ∣ (b + 1) → (d ∣ n ↔ (d : ℤ) ∣ alternatingSum (digits b n))`.
+  This generalizes divisibility-by-eleven from base `10` to every base.
+* Concrete instances Mathlib does not have: casting out fifteens (and threes,
+  fives) in hexadecimal, casting out elevens in base `12`, alternating
+  seventeens in hexadecimal, together with the base-`10` classics recovered as
+  corollaries of the general theorems.
+-/
+
+namespace DivisibilityBy3OQ01OQ03
+
+open Nat
+
+/-! ## The general digit-sum test (base `b ≡ 1 (mod d)`) -/
+
+/-- **Generalized casting out nines (congruence form).**  If the base `b` is
+congruent to `1` modulo `d`, then any `n` is congruent modulo `d` to the sum of
+its base-`b` digits.  Base `10`, `d = 9` is the classical rule. -/
+theorem digitSum_modEq (b d n : ℕ) (h : b % d = 1) :
+    n ≡ (Nat.digits b n).sum [MOD d] :=
+  Nat.modEq_digits_sum d b h n
+
+/-- **Generalized casting out nines (divisibility form).**  When
+`(d : ℤ) ∣ b - 1`, divisibility of `n` by `d` is equivalent to divisibility of
+its base-`b` digit sum by `d`.  Signed hypothesis so that the trivial modulus
+`d = 1` and arbitrarily large bases are covered uniformly. -/
+theorem dvd_iff_dvd_digitSum (b d n : ℕ) (h : (d : ℤ) ∣ (b : ℤ) - 1) :
+    d ∣ n ↔ d ∣ (Nat.digits b n).sum := by
+  have t := Nat.dvd_iff_dvd_ofDigits d b (1 : ℤ) h n
+  have e : Nat.ofDigits (1 : ℤ) (Nat.digits b n) = ((Nat.digits b n).sum : ℤ) := by
+    have h' := Nat.coe_ofDigits ℤ 1 (Nat.digits b n)
+    rw [Nat.ofDigits_one, Nat.cast_one] at h'
+    exact h'.symm
+  rw [e, Int.natCast_dvd_natCast] at t
+  exact t
+
+/-- **Headline: every divisor of `b - 1` admits a base-`b` digit-sum test.**
+For any base `b ≥ 1` and any `d ∣ (b - 1)`, `n` is divisible by `d` iff the sum
+of its base-`b` digits is.  Recovers casting out nines/threes (base `10`),
+casting out fifteens (base `16`), casting out elevens (base `12`), … all at
+once. -/
+theorem digitSum_test_of_dvd_pred (b d n : ℕ) (hb : 1 ≤ b) (hd : d ∣ b - 1) :
+    d ∣ n ↔ d ∣ (Nat.digits b n).sum := by
+  apply dvd_iff_dvd_digitSum
+  have hcast : ((b - 1 : ℕ) : ℤ) = (b : ℤ) - 1 := by
+    rw [Nat.cast_sub hb, Nat.cast_one]
+  rw [← hcast]
+  exact_mod_cast hd
+
+/-! ## The dual alternating-sum test (base `b ≡ -1 (mod d)`) -/
+
+/-- **Generalized casting out elevens (alternating divisibility form).**  When
+`(d : ℤ) ∣ b + 1`, divisibility of `n` by `d` is equivalent to divisibility of
+the alternating sum of its base-`b` digits.  Base `10`, `d = 11` is the
+classical alternating rule; base `16`, `d = 17` is a new instance. -/
+theorem dvd_iff_dvd_alternatingSum (b d n : ℕ) (h : (d : ℤ) ∣ (b : ℤ) + 1) :
+    d ∣ n ↔ (d : ℤ) ∣ ((Nat.digits b n).map fun x : ℕ => (x : ℤ)).alternatingSum := by
+  have hc : (d : ℤ) ∣ (b : ℤ) - (-1) := by rwa [sub_neg_eq_add]
+  have t := Nat.dvd_iff_dvd_ofDigits d b (-1 : ℤ) hc n
+  rwa [Nat.ofDigits_neg_one] at t
+
+/-! ## Classical base-`10` rules, recovered as corollaries -/
+
+/-- Casting out nines (base `10`), as an instance of the general test. -/
+theorem nine_dvd_iff (n : ℕ) : 9 ∣ n ↔ 9 ∣ (Nat.digits 10 n).sum :=
+  dvd_iff_dvd_digitSum 10 9 n (by norm_num)
+
+/-- Casting out threes (base `10`), as an instance of the general test. -/
+theorem three_dvd_iff (n : ℕ) : 3 ∣ n ↔ 3 ∣ (Nat.digits 10 n).sum :=
+  dvd_iff_dvd_digitSum 10 3 n (by norm_num)
+
+/-- Casting out elevens (base `10`, alternating), recovering `Nat.eleven_dvd_iff`. -/
+theorem eleven_dvd_iff (n : ℕ) :
+    11 ∣ n ↔ (11 : ℤ) ∣ ((Nat.digits 10 n).map fun x : ℕ => (x : ℤ)).alternatingSum :=
+  dvd_iff_dvd_alternatingSum 10 11 n (by norm_num)
+
+/-! ## New instances beyond base `10` -/
+
+/-- **Casting out fifteens in hexadecimal.**  `15 ∣ n` iff `15` divides the sum
+of the base-`16` digits of `n`. -/
+theorem hex_fifteen_dvd_iff (n : ℕ) : 15 ∣ n ↔ 15 ∣ (Nat.digits 16 n).sum :=
+  dvd_iff_dvd_digitSum 16 15 n (by norm_num)
+
+/-- Casting out threes in hexadecimal (`3 ∣ 16 - 1`). -/
+theorem hex_three_dvd_iff (n : ℕ) : 3 ∣ n ↔ 3 ∣ (Nat.digits 16 n).sum :=
+  dvd_iff_dvd_digitSum 16 3 n (by norm_num)
+
+/-- Casting out fives in hexadecimal (`5 ∣ 16 - 1`). -/
+theorem hex_five_dvd_iff (n : ℕ) : 5 ∣ n ↔ 5 ∣ (Nat.digits 16 n).sum :=
+  dvd_iff_dvd_digitSum 16 5 n (by norm_num)
+
+/-- **Casting out elevens in base twelve** (duodecimal): `11 ∣ n` iff `11`
+divides the sum of the base-`12` digits of `n`. -/
+theorem duodecimal_eleven_dvd_iff (n : ℕ) : 11 ∣ n ↔ 11 ∣ (Nat.digits 12 n).sum :=
+  dvd_iff_dvd_digitSum 12 11 n (by norm_num)
+
+/-- **Alternating seventeens in hexadecimal** (`17 ∣ 16 + 1`): `17 ∣ n` iff `17`
+divides the alternating sum of the base-`16` digits of `n`. -/
+theorem hex_seventeen_alternating_dvd_iff (n : ℕ) :
+    17 ∣ n ↔ (17 : ℤ) ∣ ((Nat.digits 16 n).map fun x : ℕ => (x : ℤ)).alternatingSum :=
+  dvd_iff_dvd_alternatingSum 16 17 n (by norm_num)
+
+/-- **Alternating sevens in base six**: `7 ∣ 6 + 1`, so `7 ∣ n` iff `7` divides
+the alternating sum of the base-`6` digits. -/
+theorem base6_seven_alternating_dvd_iff (n : ℕ) :
+    7 ∣ n ↔ (7 : ℤ) ∣ ((Nat.digits 6 n).map fun x : ℕ => (x : ℤ)).alternatingSum :=
+  dvd_iff_dvd_alternatingSum 6 7 n (by norm_num)
+
+end DivisibilityBy3OQ01OQ03

--- a/research/problems/divisibility-by-three-oq-01-oq-03/knowledge.md
+++ b/research/problems/divisibility-by-three-oq-01-oq-03/knowledge.md
@@ -1,0 +1,66 @@
+# Knowledge — divisibility-by-three-oq-01-oq-03
+
+## S1 (researcher-2, 2026-07-01) — SOLVED, VERIFIED 0-axiom
+
+**Question**: Casting out nines, generalized — prove that the base-`b` digit
+sum is congruent to `n` modulo `d` whenever the base satisfies `b ≡ 1 (mod d)`,
+and derive the associated divisibility test for an arbitrary base.
+
+**Outcome**: SOLVED. New file `proofs/Proofs/DivisibilityBy3OQ01OQ03.lean`
+(147 lines, 13 theorems, 0 defs, 0 sorries, 0 axioms — every `#print axioms`
+lists only `propext / Classical.choice / Quot.sound`, no `native_decide`).
+
+### Deliverable
+
+| Theorem | Statement |
+|---|---|
+| `digitSum_modEq` | `b % d = 1 → n ≡ (digits b n).sum [MOD d]` |
+| `dvd_iff_dvd_digitSum` | `(d:ℤ) ∣ (b:ℤ)-1 → (d ∣ n ↔ d ∣ (digits b n).sum)` |
+| `digitSum_test_of_dvd_pred` | **headline**: `b ≥ 1, d ∣ b-1 → (d ∣ n ↔ d ∣ (digits b n).sum)` |
+| `dvd_iff_dvd_alternatingSum` | `(d:ℤ) ∣ (b:ℤ)+1 → (d ∣ n ↔ (d:ℤ) ∣ alternatingSum(digits b n))` |
+| `nine_dvd_iff`, `three_dvd_iff`, `eleven_dvd_iff` | base-10 classics as corollaries |
+| `hex_fifteen_dvd_iff`, `hex_three_dvd_iff`, `hex_five_dvd_iff` | base-16 digit-sum tests |
+| `duodecimal_eleven_dvd_iff` | base-12 elevens |
+| `hex_seventeen_alternating_dvd_iff`, `base6_seven_alternating_dvd_iff` | alternating tests |
+
+### Proof recipe (reusable)
+
+The load-bearing Mathlib lemma is **`Nat.dvd_iff_dvd_ofDigits (d b : ℕ) (c : ℤ)`**
+`(h : (d:ℤ) ∣ (b:ℤ) - c) (n) : d ∣ n ↔ (d:ℤ) ∣ ofDigits c (digits b n)`.
+
+- `c = 1` → digit-sum test. Rewrite `ofDigits (1:ℤ) L` to `((L.sum:ℕ):ℤ)`:
+  the literal `(1:ℤ)` is **not** syntactically `↑(1:ℕ)`, so `rw [← Nat.coe_ofDigits]`
+  fails directly. Fix: `have h' := Nat.coe_ofDigits ℤ 1 L; rw [Nat.ofDigits_one,
+  Nat.cast_one] at h'; exact h'.symm`, then `rw [that, Int.natCast_dvd_natCast]`.
+- `c = -1` → alternating-sum test. `sub_neg_eq_add` turns `b+1` into `b-(-1)`;
+  `Nat.ofDigits_neg_one : ofDigits (-1) L = (L.map (↑·)).alternatingSum`.
+- Bridge `d ∣ b-1` (ℕ) → `(d:ℤ) ∣ (b:ℤ)-1`: `Nat.cast_sub hb` (needs `1 ≤ b`),
+  then `exact_mod_cast`.
+- Concrete instance side conditions `(15:ℤ) ∣ 16-1` etc. close by `norm_num`.
+
+### Relation to prior art (why not a duplicate)
+
+- **Mathlib** has `Nat.modEq_digits_sum` (general congruence) and
+  `Nat.dvd_iff_dvd_ofDigits` (general master lemma) but only *instantiates*
+  them at base 10 (`three_dvd_iff`, `nine_dvd_iff`, `eleven_dvd_iff`). The
+  packaged general divisibility tests and non-base-10 instances are new.
+- **Parent `divisibility-by-three-oq-01`** develops base-10 digital-root theory
+  and last-k-digit rules; **sibling `-oq-01-oq-02`** is base-10 digital-root
+  iteration — both anchored to base 10. One of oq-01-oq-02's stated open
+  questions asked for exactly this base-`b` generalization (fixed point via
+  `n mod (b-1)`), so this entry answers it.
+
+### Verification
+
+Compiled offline with `lake env lean Proofs/DivisibilityBy3OQ01OQ03.lean`
+against the prebuilt Mathlib oleans (Docker not required — file imports only
+`Mathlib`). RC=0, no diagnostics. `#print axioms` on the four core theorems +
+`hex_fifteen_dvd_iff` shows only the standard foundational axioms.
+
+### Follow-up questions (2, depth guard OK — current slug depth = 2)
+
+1. **Period-`p` block-sum test**: for `d` where `b` has multiplicative order `p`
+   mod `d`, group base-`b` digits into blocks of `p` and sum the block values;
+   the digit-sum (`p=1`) and alternating-sum (`p=2`) tests are the first cases.
+2. **Two-sided characterization**: classify residues `b mod d` admitting a plain
+   digit-sum test (`b ≡ 1`), an alternating test (`b ≡ -1`), or neither.

--- a/src/data/research/problems/divisibility-by-three-oq-01-oq-03.json
+++ b/src/data/research/problems/divisibility-by-three-oq-01-oq-03.json
@@ -1,0 +1,88 @@
+{
+  "slug": "divisibility-by-three-oq-01-oq-03",
+  "title": "Casting out nines, generalized: base-b digit-sum tests when b ≡ 1 (mod d)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "∀ b d n : ℕ, (d:ℤ) ∣ (b:ℤ) - 1 → (d ∣ n ↔ d ∣ (Nat.digits b n).sum)",
+    "plain": "The base-b digit sum determines divisibility by d exactly when d divides b-1 (casting out nines is the case b=10, d=9); dually, the alternating base-b digit sum works when d divides b+1.",
+    "whyMatters": [
+      "Explains all classical digit-sum divisibility rules as instances of one theorem",
+      "Fills the gap between Mathlib's general lemmas and its base-10-only instances"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "digitSum_test_of_dvd_pred: b≥1, d∣b-1 → (d∣n ↔ d∣digitSum_b(n))",
+      "dvd_iff_dvd_alternatingSum: (d:ℤ)∣b+1 → (d∣n ↔ (d:ℤ)∣alternatingSum(digits_b n))",
+      "base-10 rules for 3, 9, 11 and new tests in bases 6, 12, 16"
+    ],
+    "open": [],
+    "goal": "State and prove the base-agnostic casting-out-nines rule and its divisibility test."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-01T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Solved in one session.",
+    "blockers": [],
+    "nextAction": "None — verified 0-axiom, 0-sorry.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (VERIFIED, 0-axiom, 0-sorry). DivisibilityBy3OQ01OQ03.lean (147 lines, 13 theorems): general digit-sum test (d∣b-1) and alternating-sum test (d∣b+1) via Nat.dvd_iff_dvd_ofDigits, with base-10 classics recovered and new hexadecimal / duodecimal / base-6 instances added.",
+    "builtItems": [
+      "digitSum_modEq, dvd_iff_dvd_digitSum, digitSum_test_of_dvd_pred (headline)",
+      "dvd_iff_dvd_alternatingSum",
+      "nine/three/eleven_dvd_iff, hex_{fifteen,three,five}_dvd_iff, duodecimal_eleven_dvd_iff, hex_seventeen_alternating_dvd_iff, base6_seven_alternating_dvd_iff"
+    ],
+    "insights": [
+      "Nat.dvd_iff_dvd_ofDigits with c∈{1,-1} yields both the digit-sum and alternating-sum tests from one master lemma",
+      "ofDigits (1:ℤ) L needs Nat.coe_ofDigits + Nat.ofDigits_one + Nat.cast_one to reach ((L.sum:ℕ):ℤ); the literal 1:ℤ is not syntactically ↑(1:ℕ)",
+      "d∣b-1 (ℕ) → (d:ℤ)∣b-1 via Nat.cast_sub (needs 1≤b)"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Period-p block-sum test for d where b has multiplicative order p mod d",
+      "Classify residues b mod d admitting digit-sum vs alternating vs neither test"
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "divisibility",
+    "casting-out-nines",
+    "digit-sum",
+    "modular-arithmetic",
+    "radix"
+  ],
+  "relatedProofs": [
+    "divisibility-by-three-oq-01",
+    "divisibility-by-three-oq-01-oq-02",
+    "divisibility-by-three"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Casting_out_nines"
+    ],
+    "mathlib": [
+      "Nat.modEq_digits_sum",
+      "Nat.dvd_iff_dvd_ofDigits",
+      "Nat.ofDigits_one",
+      "Nat.ofDigits_neg_one"
+    ]
+  },
+  "started": "2026-07-01T00:00:00.000Z",
+  "lastUpdate": "2026-07-01T00:00:00.000Z",
+  "significance": 6,
+  "tractability": 7,
+  "leanFiles": [
+    "Proofs/DivisibilityBy3OQ01OQ03.lean"
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes the **casting out nines / casting out threes** divisibility rules from base 10 to an **arbitrary base `b` and modulus `d`**. Answers the open question `divisibility-by-three-oq-01-oq-03`.

The base-`b` digit sum determines divisibility by `d` exactly when `d ∣ (b-1)`; dually, the **alternating** base-`b` digit sum works when `d ∣ (b+1)`.

## New file

`proofs/Proofs/DivisibilityBy3OQ01OQ03.lean` — 147 lines, **13 theorems, 0 defs, 0 sorries, 0 axioms**.

| Theorem | Statement |
|---|---|
| `digitSum_test_of_dvd_pred` (headline) | `b ≥ 1, d ∣ b-1 → (d ∣ n ↔ d ∣ (digits b n).sum)` |
| `dvd_iff_dvd_alternatingSum` (dual) | `(d:ℤ) ∣ b+1 → (d ∣ n ↔ (d:ℤ) ∣ alternatingSum(digits b n))` |
| `digitSum_modEq` | `b % d = 1 → n ≡ (digits b n).sum [MOD d]` |
| `dvd_iff_dvd_digitSum` | `(d:ℤ) ∣ b-1 → (d ∣ n ↔ d ∣ (digits b n).sum)` |
| `nine_dvd_iff`, `three_dvd_iff`, `eleven_dvd_iff` | base-10 classics as corollaries |
| `hex_fifteen_dvd_iff`, `hex_three_dvd_iff`, `hex_five_dvd_iff` | base-16 digit-sum tests |
| `duodecimal_eleven_dvd_iff` | base-12 elevens |
| `hex_seventeen_alternating_dvd_iff`, `base6_seven_alternating_dvd_iff` | alternating tests |

## Method

Both general tests are applications of Mathlib's signed master lemma `Nat.dvd_iff_dvd_ofDigits` with `c ∈ {1, -1}`. The only real work is bridging `ofDigits` over `ℤ` back to a natural-number digit sum (`Nat.coe_ofDigits` + `Nat.ofDigits_one`) and to the alternating sum (`Nat.ofDigits_neg_one`).

## Why this is not a duplicate

- **Mathlib** has `Nat.modEq_digits_sum` and `Nat.dvd_iff_dvd_ofDigits` but only *instantiates* them at base 10 (`three_dvd_iff`, `nine_dvd_iff`, `eleven_dvd_iff`).
- The **parent** `divisibility-by-three-oq-01` and **sibling** `-oq-01-oq-02` are both anchored to base 10 (digital-root theory). The sibling's own open-question list asked for exactly this base-`b` generalization.

## Verification

`lake env lean Proofs/DivisibilityBy3OQ01OQ03.lean` → RC=0, no diagnostics (file imports only `Mathlib`, so no Docker needed). `#print axioms` on the four core theorems + an instance lists only `propext / Classical.choice / Quot.sound` — no `native_decide`, no `Lean.ofReduceBool`.

## Gallery

Adds `src/data/proofs/divisibility-by-three-oq-01-oq-03/{meta.json,annotations.json}` (status `verified`, badge `verified`), the research tracking JSON, and a knowledge note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)