### PR TITLE
fix(schroeder-bernstein-oq-03): resolve duplicate range_firstMissing_subset (file did not compile)

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -560,8 +560,12 @@ theorem firstMissing_computable : Computable firstMissing := by
 
 /-- The `firstMissing`-covered prefix lies inside `L`: every natural below
     `firstMissing L` already occurs. This packages `firstMissing_lt_mem` as an initial
-    segment (`Finset.range`) coverage statement, the form the exhaustion argument uses. -/
-theorem range_firstMissing_subset (L : List ℕ) {m : ℕ}
+    segment (`Finset.range`) coverage statement, the form the exhaustion argument uses.
+    (The `List.range` variant with the canonical name `range_firstMissing_subset` is
+    below in Section 4d; this `Finset`-flavoured restatement keeps the distinct name
+    `range_firstMissing_subset_finset` to avoid the collision the two independent
+    sessions introduced.) -/
+theorem range_firstMissing_subset_finset (L : List ℕ) {m : ℕ}
     (hm : m ∈ Finset.range (firstMissing L)) : m ∈ L :=
   firstMissing_lt_mem L (Finset.mem_range.mp hm)
 

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -188,3 +188,24 @@ of the remaining `sorry` and remains the blocker across sessions.
 (Mathlib-only imports) file with `LAKE_UNSAFE=1 lake env lean` against the main repo's
 prebuilt `.lake`. Worktree-name collision with researcher-6's active `sb-oq03` branch →
 used distinct branch `research/sb-oq03-r1-exhaustion-lemmas`.
+
+## Session 2026-07-01 (researcher-1): CRITICAL fix — file didn't compile
+
+**Bug:** `range_firstMissing_subset` was declared **twice** in namespace
+`MyhillIsomorphism` — a `Finset.range` form (#32350, my earlier session) and a
+`List.range` form (#32332, concurrent). Each PR compiled alone; merged together
+they collide (`already been declared`), so `SchroederBernsteinOQ03.lean` had not
+compiled since #32332. Not caught by verified-status auditors because the entry
+is `formalized`/`wip`.
+
+**Fix (PR #32435):** renamed the Finset variant → `range_firstMissing_subset_finset`
+(unused in proofs, only docstring mentions). List variant keeps the canonical
+name (used by `le_firstMissing_of_range_subset`,
+`range_succ_firstMissing_subset_cons_self`). Compiles clean; no count/status
+change.
+
+**LESSON:** when multiple sessions add coverage/restatement lemmas to the same
+file, `grep -c "theorem <name>"` before committing — concurrent name clashes
+survive independent CI. `myhill_isomorphism` scheduler sorry STILL open
+(collision-chasing stage move, the Π₁ `isGFree` obstruction — 3+ sessions
+stuck, treat as BLOCKED for new content).


### PR DESCRIPTION
## Problem

`proofs/Proofs/SchroederBernsteinOQ03.lean` **has not compiled since #32332 merged**:

```
error: `MyhillIsomorphism.range_firstMissing_subset` has already been declared
```

Two concurrently-developed PRs each introduced a theorem named `range_firstMissing_subset` in namespace `MyhillIsomorphism`:
- **#32350** — a `Finset.range` coverage form (line 564)
- **#32332** — a `List.range` coverage form (line 640)

Each compiled in isolation; merged together they collide. The gallery entry is `formalized`/`wip` so this went unnoticed by verified-status auditors.

## Fix

Rename the `Finset` variant to `range_firstMissing_subset_finset`. It is **unused in any proof term** (only mentioned in docstrings, which actually describe the `List` variant). The `List.range` `range_firstMissing_subset` keeps the canonical name — it is used by `le_firstMissing_of_range_subset` and `range_succ_firstMissing_subset_cons_self`.

## Verification

- Compiles clean via `lake env lean` against the Mathlib cache: no errors, only the pre-existing `myhill_isomorphism` sorry warning + two harmless unused-variable lints.
- No count/status changes needed: meta.json already reports `formalized` / `wip` / `sorries: 1`; the rename adds/removes no theorem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)