### PR TITLE
research(combinations-formula-oq-07-oq-01-oq-01): multinomial extension of trinomial revision [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ07OQ01OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ07OQ01OQ01.lean
@@ -1,0 +1,153 @@
+import Mathlib
+
+/-
+# Multinomial Trinomial Revision (OQ-07-OQ-01-OQ-01)
+
+## Open Question
+
+The parent entry (OQ-07-OQ-01) formalized the **subset-of-a-subset identity**
+(trinomial revision) for binomial coefficients,
+
+  C(n, k) · C(k, m) = C(n, m) · C(n − m, k − m),   for m ≤ k ≤ n,
+
+by clearing factorial denominators.  Its natural next question:
+
+  *Does trinomial revision extend to the multinomial coefficient*
+  *`(n; a, b, c) = (n; a) · (n − a; b, c)`, and is that statement provable by*
+  *the same denominator-clearing route over Mathlib's `Nat.multinomial`?*
+
+The answer is **yes**.  Writing `n = a + b + c`, the multinomial coefficient
+factors as a nested pair of binomials — "choose the `a` symbols of the first
+kind out of `n`, then choose the `b` symbols of the second kind out of the
+remaining `n − a`":
+
+  multinomial{a, b, c} = C(a + b + c, a) · C(b + c, b).
+
+Mathlib defines `Nat.multinomial s f = (∑ i ∈ s, f i)! / ∏ i ∈ s, (f i)!` and
+supplies the divisibility fact `Nat.multinomial_spec`,
+
+  (∏ i ∈ s, (f i)!) · multinomial s f = (∑ i ∈ s, f i)!,
+
+but it does **not** provide the nested-binomial factorization for the ternary
+case.  We supply it, using exactly the parent's technique: multiply through by
+`a! · b! · c!` and collapse each side to `(a + b + c)!` via
+`Nat.choose_mul_factorial_mul_factorial`.
+
+## Results
+
+1. `factorial_mul_choose_mul_choose` — the denominator-cleared core, peeling the
+   `a`-block first: `a!·b!·c! · (C(a+b+c,a)·C(b+c,b)) = (a+b+c)!`.
+2. `factorial_mul_choose_mul_choose_last` — the same peeling the `c`-block first:
+   `a!·b!·c! · (C(a+b+c,c)·C(a+b,a)) = (a+b+c)!`.
+3. `multinomial_univ_three_eq` — the headline factorization
+   `multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b)`.
+4. `multinomial_eq_choose_mul_choose_sub` — the OQ's `(n; a)·(n−a; b, c)` form,
+   `multinomial{a,b,c} = C(n,a)·C(n−a,b)` with `n = a+b+c`.
+5. `choose_mul_choose_peel_comm` — peel-order independence, a pure binomial-
+   product identity absent from Mathlib:
+   `C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a)`.
+
+## Mathematical Context
+
+The nested factorization is the ternary instance of the general recursion
+`multinomial (insert a s) f = C(f a + ∑ f, f a) · multinomial s f`
+(`Nat.multinomial_insert`).  We prove the closed ternary form directly rather
+than by unfolding the recursion, keeping the argument a single factorial
+cancellation — the same "clear denominators, collapse to `n!`" pattern that made
+the binomial trinomial revision short and induction-free.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ07OQ01OQ01
+
+open Nat
+
+/-- Positivity of the shared factorial denominator `a! · b! · c!`. -/
+private theorem factorial_triple_pos (a b c : ℕ) : 0 < a ! * b ! * c ! :=
+  Nat.mul_pos (Nat.mul_pos (factorial_pos a) (factorial_pos b)) (factorial_pos c)
+
+/-- **Denominator-cleared trinomial revision (peel the `a`-block).**
+    Multiplying the nested-binomial product by the factorial denominator
+    collapses to the top factorial:
+    `a! · b! · c! · (C(a+b+c, a) · C(b+c, b)) = (a+b+c)!`. -/
+theorem factorial_mul_choose_mul_choose (a b c : ℕ) :
+    a ! * b ! * c ! * ((a + b + c).choose a * (b + c).choose b) = (a + b + c)! := by
+  have h1 : (a + b + c).choose a * a ! * (b + c)! = (a + b + c)! := by
+    have h := choose_mul_factorial_mul_factorial (show a ≤ a + b + c by omega)
+    have he : a + b + c - a = b + c := by omega
+    rwa [he] at h
+  have h2 : (b + c).choose b * b ! * c ! = (b + c)! := by
+    have h := choose_mul_factorial_mul_factorial (show b ≤ b + c by omega)
+    have he : b + c - b = c := by omega
+    rwa [he] at h
+  calc
+    a ! * b ! * c ! * ((a + b + c).choose a * (b + c).choose b)
+        = ((a + b + c).choose a * a !) * ((b + c).choose b * b ! * c !) := by ring
+    _ = ((a + b + c).choose a * a !) * (b + c)! := by rw [h2]
+    _ = (a + b + c).choose a * a ! * (b + c)! := by ring
+    _ = (a + b + c)! := h1
+
+/-- **Denominator-cleared trinomial revision (peel the `c`-block).**
+    The symmetric collapse when the last block is separated first:
+    `a! · b! · c! · (C(a+b+c, c) · C(a+b, a)) = (a+b+c)!`. -/
+theorem factorial_mul_choose_mul_choose_last (a b c : ℕ) :
+    a ! * b ! * c ! * ((a + b + c).choose c * (a + b).choose a) = (a + b + c)! := by
+  have h1 : (a + b + c).choose c * c ! * (a + b)! = (a + b + c)! := by
+    have h := choose_mul_factorial_mul_factorial (show c ≤ a + b + c by omega)
+    have he : a + b + c - c = a + b := by omega
+    rwa [he] at h
+  have h2 : (a + b).choose a * a ! * b ! = (a + b)! := by
+    have h := choose_mul_factorial_mul_factorial (show a ≤ a + b by omega)
+    have he : a + b - a = b := by omega
+    rwa [he] at h
+  calc
+    a ! * b ! * c ! * ((a + b + c).choose c * (a + b).choose a)
+        = ((a + b + c).choose c * c !) * ((a + b).choose a * a ! * b !) := by ring
+    _ = ((a + b + c).choose c * c !) * (a + b)! := by rw [h2]
+    _ = (a + b + c).choose c * c ! * (a + b)! := by ring
+    _ = (a + b + c)! := h1
+
+/-- **Multinomial trinomial revision.**
+    The ternary multinomial coefficient factors as a nested pair of binomials:
+    `multinomial{a, b, c} = C(a+b+c, a) · C(b+c, b)`. -/
+theorem multinomial_univ_three_eq (a b c : ℕ) :
+    Nat.multinomial Finset.univ ![a, b, c]
+      = (a + b + c).choose a * (b + c).choose b := by
+  apply Nat.eq_of_mul_eq_mul_left (factorial_triple_pos a b c)
+  rw [factorial_mul_choose_mul_choose]
+  have hspec := Nat.multinomial_spec (Finset.univ : Finset (Fin 3)) ![a, b, c]
+  rw [Fin.prod_univ_three, Fin.sum_univ_three] at hspec
+  exact hspec
+
+/-- **OQ form `(n; a) · (n − a; b, c)`.**
+    With `n = a + b + c`, the multinomial equals the number of ways to choose the
+    `a`-block from all `n`, then the `b`-block from the remaining `n − a`:
+    `multinomial{a, b, c} = C(n, a) · C(n − a, b)`. -/
+theorem multinomial_eq_choose_mul_choose_sub (a b c : ℕ) :
+    Nat.multinomial Finset.univ ![a, b, c]
+      = (a + b + c).choose a * (a + b + c - a).choose b := by
+  rw [multinomial_univ_three_eq]
+  have he : a + b + c - a = b + c := by omega
+  rw [he]
+
+/-- **Peel-order independence.**
+    Separating the first block or the last block gives the same count, a pure
+    binomial-product identity not present in Mathlib:
+    `C(a+b+c, a) · C(b+c, b) = C(a+b+c, c) · C(a+b, a)`. -/
+theorem choose_mul_choose_peel_comm (a b c : ℕ) :
+    (a + b + c).choose a * (b + c).choose b
+      = (a + b + c).choose c * (a + b).choose a := by
+  apply Nat.eq_of_mul_eq_mul_left (factorial_triple_pos a b c)
+  rw [factorial_mul_choose_mul_choose, factorial_mul_choose_mul_choose_last]
+
+/-- Numeric sanity check: `multinomial{2,1,1} = C(4,2)·C(2,1) = 6·2 = 12`,
+    and indeed `4!/(2!·1!·1!) = 24/2 = 12`. -/
+example : Nat.multinomial Finset.univ ![2, 1, 1] = 12 := by decide
+
+/-- Numeric sanity check of peel-order independence at `(a,b,c) = (2,1,1)`:
+    `C(4,2)·C(2,1) = 12 = C(4,1)·C(3,2) = 4·3`. -/
+example : (4 : ℕ).choose 2 * (2 : ℕ).choose 1 = (4 : ℕ).choose 1 * (3 : ℕ).choose 2 := by
+  decide
+
+end CombinationsFormulaOQ07OQ01OQ01

--- a/src/data/proofs/combinations-formula-oq-07-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-01-oq-01/annotations.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "multinomial-peeling-context",
+    "proofId": "combinations-formula-oq-07-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 60 },
+    "type": "concept",
+    "title": "From Trinomial Revision to the Three-Part Multinomial",
+    "content": "The parent entry proved binomial trinomial revision C(n,k)·C(k,m) = C(n,m)·C(n−m,k−m) by clearing factorial denominators. This follow-up asks whether the same route reaches the genuine three-part multinomial coefficient (a+b+c)!/(a!·b!·c!). It does: the multinomial peels into a nested pair of binomials multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b) — choose the a-block out of all a+b+c objects, then split the remaining b+c into a b-block and a c-block. Mathlib defines Nat.multinomial and supplies multinomial_spec but not this closed ternary factorization.",
+    "mathContext": "$\\binom{a+b+c}{a,b,c} = \\dfrac{(a+b+c)!}{a!\\,b!\\,c!} = \\binom{a+b+c}{a}\\binom{b+c}{b}$. This is the ternary instance of the general recursion $\\mathrm{multinomial}(\\mathrm{insert}\\,a\\,s) = \\binom{a + \\sum s}{a}\\,\\mathrm{multinomial}(s)$, proved here in closed form rather than by unfolding.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multinomial coefficient",
+      "trinomial revision",
+      "nested-selection double counting",
+      "Nat.multinomial_insert",
+      "trinomial coefficient"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "Nat.multinomial and multinomial_spec",
+      "factorial identity for binomial coefficients"
+    ]
+  },
+  {
+    "id": "cleared-core-thm",
+    "proofId": "combinations-formula-oq-07-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 89 },
+    "type": "theorem",
+    "title": "Denominator-Cleared Core (Peel the a-Block)",
+    "content": "factorial_mul_choose_mul_choose proves a!·b!·c!·(C(a+b+c,a)·C(b+c,b)) = (a+b+c)! with no summation and no induction — the exact three-part analogue of the parent's LHS·D = n! step. After regrouping by ring, the inner block C(b+c,b)·b!·c! collapses to (b+c)! via Nat.choose_mul_factorial_mul_factorial (b ≤ b+c, (b+c)−b = c), leaving C(a+b+c,a)·a!·(b+c)! which collapses to (a+b+c)! via the same fact at the outer selection (a ≤ a+b+c, (a+b+c)−a = b+c).",
+    "mathContext": "Each binomial $\\binom{a+b+c}{a} = \\frac{(a+b+c)!}{a!(b+c)!}$ and $\\binom{b+c}{b} = \\frac{(b+c)!}{b!c!}$ is missing exactly the factorials in $D = a!\\,b!\\,c!$; multiplying by $D$ telescopes the product to $(a+b+c)!$. The multiplicative regrouping is closed by `ring` (ℕ a commutative semiring with the choose/factorial terms as atoms), the subtraction facts $(a+b+c)-a = b+c$ and $(b+c)-b = c$ by `omega`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.choose_mul_factorial_mul_factorial",
+      "clearing denominators",
+      "telescoping factorial collapse",
+      "ring tactic over ℕ"
+    ],
+    "prerequisites": [
+      "C(n,k)·k!·(n-k)! = n!",
+      "omega for natural subtraction"
+    ]
+  },
+  {
+    "id": "cleared-last-thm",
+    "proofId": "combinations-formula-oq-07-oq-01-oq-01",
+    "range": { "startLine": 91, "endLine": 109 },
+    "type": "theorem",
+    "title": "Denominator-Cleared Core (Peel the c-Block)",
+    "content": "factorial_mul_choose_mul_choose_last is the symmetric cleared form a!·b!·c!·(C(a+b+c,c)·C(a+b,a)) = (a+b+c)!, separating the last block first. The c-selection is now outer (C(a+b+c,c)·c!·(a+b)! = (a+b+c)!) and the a-selection inner (C(a+b,a)·a!·b! = (a+b)!). Providing both peel directions as cleared identities is what makes peel-order independence a one-line consequence.",
+    "mathContext": "$a!\\,b!\\,c!\\cdot\\binom{a+b+c}{c}\\binom{a+b}{a} = (a+b+c)!$, using $(a+b+c)-c = a+b$ and $(a+b)-a = b$. The right-hand side is the same $(a+b+c)!$ as the a-peel, which is the arithmetic reason the two peels agree.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.choose_mul_factorial_mul_factorial",
+      "symmetry of the trinomial coefficient",
+      "clearing denominators"
+    ],
+    "prerequisites": [
+      "C(n,k)·k!·(n-k)! = n!",
+      "omega for natural subtraction"
+    ]
+  },
+  {
+    "id": "headline-oq-form-thm",
+    "proofId": "combinations-formula-oq-07-oq-01-oq-01",
+    "range": { "startLine": 111, "endLine": 132 },
+    "type": "theorem",
+    "title": "Multinomial Factorization and the OQ (n;a)·(n−a;b,c) Form",
+    "content": "multinomial_univ_three_eq is the headline: multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b). The bridge is Nat.multinomial_spec, which on univ over Fin 3 (evaluated by Fin.prod_univ_three and Fin.sum_univ_three) reads a!·b!·c!·multinomial{a,b,c} = (a+b+c)!; equating with the cleared core and cancelling the positive denominator by Nat.eq_of_mul_eq_mul_left finishes it. multinomial_eq_choose_mul_choose_sub then rewrites (b+c) as (a+b+c)−a to give the OQ's exact C(n,a)·C(n−a,b) shape with n = a+b+c.",
+    "mathContext": "$\\mathrm{multinomial}\\{a,b,c\\} = \\binom{n}{a}\\binom{n-a}{b}$ with $n = a+b+c$. The proof only needs that the multinomial and the binomial product satisfy the same cleared equation $D\\cdot(\\cdot) = n!$ and that $D = a!b!c! > 0$; cancellation does the rest, so no properties of division are invoked despite Mathlib defining the multinomial by division.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.multinomial_spec",
+      "Nat.eq_of_mul_eq_mul_left",
+      "Fin.prod_univ_three",
+      "Fin.sum_univ_three"
+    ],
+    "prerequisites": [
+      "(∏ (f i)!)·multinomial = (∑ f i)!",
+      "left cancellation in ℕ",
+      "the cleared core identity"
+    ]
+  },
+  {
+    "id": "peel-comm-thm",
+    "proofId": "combinations-formula-oq-07-oq-01-oq-01",
+    "range": { "startLine": 134, "endLine": 153 },
+    "type": "theorem",
+    "title": "Peel-Order Independence",
+    "content": "choose_mul_choose_peel_comm proves C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a): peeling the a-block first equals peeling the c-block first. Both cleared forms equal a!·b!·c!·(product) = (a+b+c)!, so the two products agree after left-cancellation — no binomial manipulation needed. This is the symmetry of the trinomial coefficient under permuting its parts. Numeric checks confirm multinomial{2,1,1} = C(4,2)·C(2,1) = 12 and C(4,2)·C(2,1) = C(4,1)·C(3,2) = 12 by decide.",
+    "mathContext": "$\\binom{a+b+c}{a}\\binom{b+c}{b} = \\binom{a+b+c}{c}\\binom{a+b}{a}$ because both equal $\\binom{a+b+c}{a,b,c}$, which is symmetric in $a,b,c$. The proof route — equate two cleared identities against a common $(a+b+c)!$ — is a reusable way to obtain multinomial symmetries without touching the binomials.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "symmetry of the multinomial coefficient",
+      "Nat.eq_of_mul_eq_mul_left",
+      "peel-order independence"
+    ],
+    "prerequisites": [
+      "the two cleared-core identities",
+      "left cancellation in ℕ"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-07-oq-01-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-01-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "combinations-formula-oq-07-oq-01-oq-01",
+  "title": "Trinomial Peeling: the Multinomial Extension of Trinomial Revision",
+  "slug": "combinations-formula-oq-07-oq-01-oq-01",
+  "description": "Answers OQ-07-OQ-01-OQ-01: trinomial revision extends to the three-part multinomial coefficient, and by the same denominator-clearing route. The ternary multinomial factors as a nested pair of binomials, multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b) — choose the a-block from all a+b+c, then split the remaining b+c into a b-block and a c-block. Proved against Mathlib's Nat.multinomial by multiplying through by a!·b!·c! and collapsing each side to (a+b+c)! with Nat.choose_mul_factorial_mul_factorial, exactly the parent's technique, with no summation and no induction. Records the OQ's C(n,a)·C(n−a,b) form (n = a+b+c) and peel-order independence C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a).",
+  "meta": {
+    "author": "Lean Genius researcher-10",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ07OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 153,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. The identities hold for all a, b, c and are fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms — no Lean.ofReduceBool, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "multinomial-coefficient",
+      "trinomial-revision",
+      "trinomial-coefficient",
+      "factorial",
+      "double-counting"
+    ],
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "factorial_mul_choose_mul_choose: the denominator-cleared core a!·b!·c!·(C(a+b+c,a)·C(b+c,b)) = (a+b+c)!, peeling the a-block first, absent from Mathlib and proved by the same clear-denominators/collapse-to-n! pattern as the binomial trinomial revision",
+      "factorial_mul_choose_mul_choose_last: the symmetric cleared form peeling the c-block first, a!·b!·c!·(C(a+b+c,c)·C(a+b,a)) = (a+b+c)!",
+      "multinomial_univ_three_eq: the headline factorization multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b) against Mathlib's Nat.multinomial, via multinomial_spec and left-cancellation",
+      "multinomial_eq_choose_mul_choose_sub: the OQ's (n;a)·(n−a;b,c) form, multinomial{a,b,c} = C(n,a)·C(n−a,b) with n = a+b+c",
+      "choose_mul_choose_peel_comm: peel-order independence C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a), a pure binomial-product identity not in Mathlib, from equating both cleared forms",
+      "Worked numeric checks multinomial{2,1,1} = C(4,2)·C(2,1) = 12 and C(4,2)·C(2,1) = C(4,1)·C(3,2) = 12"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "For k ≤ n, C(n,k)·k!·(n-k)! = n!. Applied to the outer selection (a ≤ a+b+c, with (a+b+c)-a = b+c) and the inner selection (b ≤ b+c, with (b+c)-b = c) it collapses the nested-binomial product to (a+b+c)! after multiplication by a!·b!·c!.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.multinomial_spec",
+        "description": "(∏ i ∈ s, (f i)!)·multinomial s f = (∑ i ∈ s, f i)!. Specialized to s = univ over Fin 3 and f = ![a,b,c] (via Fin.prod_univ_three and Fin.sum_univ_three) it reads a!·b!·c!·multinomial{a,b,c} = (a+b+c)!, the bridge from the cleared factorial identity to the multinomial coefficient.",
+        "module": "Mathlib.Data.Nat.Choose.Multinomial"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_left",
+        "description": "Left-cancellation c·a = c·b → a = b for 0 < c. Cancels the positive factorial denominator a!·b!·c! after both the multinomial and the binomial product are shown to satisfy the same cleared equation.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Fin.prod_univ_three",
+        "description": "∏ i : Fin 3, f i = f 0 · f 1 · f 2; with Fin.sum_univ_three it evaluates the multinomial_spec product and sum over Fin 3 to the concrete a!·b!·c! and a+b+c.",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ07OQ01OQ01.lean",
+    "namespace": "CombinationsFormulaOQ07OQ01OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 153,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The trinomial (three-part multinomial) coefficient (a+b+c)!/(a!·b!·c!) counts ordered partitions of a+b+c labelled objects into blocks of sizes a, b, c, and is the natural next object after the binomial coefficient. The parent entry (OQ-07-OQ-01) formalized trinomial revision C(n,k)·C(k,m) = C(n,m)·C(n−m,k−m) — Vandermonde's multiplicative companion — by clearing factorial denominators, and asked whether the same route reaches the genuine three-part multinomial. It does: the peeling C(a+b+c,a)·C(b+c,b) is the ternary instance of Mathlib's Nat.multinomial_insert recursion, here proved in closed form directly rather than by unfolding the recursion.",
+    "problemStatement": "Open Question OQ-07-OQ-01-OQ-01: Does trinomial revision extend to the multinomial coefficient (n; a,b,c) = (n; a)·(n−a; b,c), and is that statement provable by the same denominator-clearing route over Mathlib's Nat.multinomial? Concretely, with n = a+b+c, does multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b), and can it be proved by multiplying through by a!·b!·c! and collapsing to (a+b+c)! rather than by summation or by unfolding the multinomial recursion?",
+    "proofStrategy": "Work division-free. First prove the cleared core factorial_mul_choose_mul_choose: a!·b!·c!·(C(a+b+c,a)·C(b+c,b)) = (a+b+c)!. Regroup (by ring over the commutative semiring ℕ, with choose/factorial terms as atoms) so the inner block C(b+c,b)·b!·c! collapses to (b+c)! via Nat.choose_mul_factorial_mul_factorial (b ≤ b+c, (b+c)−b = c), leaving C(a+b+c,a)·a!·(b+c)! which collapses to (a+b+c)! via the same fact at the outer selection (a ≤ a+b+c, (a+b+c)−a = b+c); the natural-subtraction facts are discharged by omega. Then bridge to Mathlib's Nat.multinomial: multinomial_spec on univ over Fin 3 (evaluated by Fin.prod_univ_three / Fin.sum_univ_three) gives a!·b!·c!·multinomial{a,b,c} = (a+b+c)!; equate with the cleared core and cancel the positive denominator by Nat.eq_of_mul_eq_mul_left. Peel-order independence follows by proving the symmetric cleared form (peel the c-block first) and equating both against (a+b+c)!.",
+    "keyInsights": [
+      "The three-part multinomial peels into two ordinary binomials, C(a+b+c,a)·C(b+c,b): choose the a-block from everything, then split the remaining b+c — the exact ternary analogue of the committee–subcommittee double count.",
+      "The parent's clear-denominators pattern transfers verbatim: multiply by the shared denominator a!·b!·c!, collapse each nested choice to a factorial with Nat.choose_mul_factorial_mul_factorial, and the product telescopes to (a+b+c)!.",
+      "Unlike binomial trinomial revision, the peeling identity is unconditional — a, b, c are free and a+(b+c), b+c are exact by construction, so no m ≤ k ≤ n side conditions and only trivial subtraction bookkeeping arise.",
+      "Nat.multinomial_spec is the clean bridge to Mathlib's division-based multinomial: it turns the divisibility multinomial s f = (∑ f)!/∏(f i)! into the multiplication ∏(f i)!·multinomial = (∑ f)!, matching the cleared factorial identity so cancellation finishes the proof.",
+      "Peel-order independence C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a) is the symmetry of the trinomial coefficient under permuting its parts, obtained for free by equating two cleared forms rather than manipulating binomials directly."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Header stating OQ-07-OQ-01-OQ-01: does trinomial revision extend to the three-part multinomial coefficient by the same denominator-clearing route? Gives the nested-binomial peeling multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b) and its relation to Nat.multinomial_insert."
+    },
+    {
+      "id": "cleared-core",
+      "title": "Denominator-Cleared Core (Peel the a-Block)",
+      "startLine": 66,
+      "endLine": 89,
+      "summary": "factorial_triple_pos (positivity of a!·b!·c!) and factorial_mul_choose_mul_choose: a!·b!·c!·(C(a+b+c,a)·C(b+c,b)) = (a+b+c)!. Two applications of Nat.choose_mul_factorial_mul_factorial collapse the inner block to (b+c)! then the outer to (a+b+c)!, with ring regrouping and omega for subtraction."
+    },
+    {
+      "id": "cleared-last",
+      "title": "Denominator-Cleared Core (Peel the c-Block)",
+      "startLine": 91,
+      "endLine": 109,
+      "summary": "factorial_mul_choose_mul_choose_last: the symmetric cleared form a!·b!·c!·(C(a+b+c,c)·C(a+b,a)) = (a+b+c)!, separating the last block first. Same collapse pattern with the c-selection outer and the a-selection inner."
+    },
+    {
+      "id": "headline-and-oq-form",
+      "title": "Multinomial Factorization and OQ Form",
+      "startLine": 111,
+      "endLine": 132,
+      "summary": "multinomial_univ_three_eq: multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b), via multinomial_spec (evaluated by Fin.prod_univ_three / Fin.sum_univ_three) and left-cancellation of a!·b!·c!. multinomial_eq_choose_mul_choose_sub recasts it in the OQ's C(n,a)·C(n−a,b) form with n = a+b+c."
+    },
+    {
+      "id": "peel-comm",
+      "title": "Peel-Order Independence",
+      "startLine": 134,
+      "endLine": 153,
+      "summary": "choose_mul_choose_peel_comm: C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a), the trinomial coefficient's symmetry under permuting parts, from equating both cleared forms. Worked numeric checks multinomial{2,1,1} = 12 and C(4,2)·C(2,1) = C(4,1)·C(3,2) = 12 by decide."
+    }
+  ],
+  "conclusion": {
+    "summary": "6 theorems, 0 sorries, 0 axioms. Trinomial revision does extend to the genuine three-part multinomial coefficient, and by the same denominator-clearing route: multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b), proved against Mathlib's Nat.multinomial by multiplying through by a!·b!·c! and collapsing each nested choice to (a+b+c)! with Nat.choose_mul_factorial_mul_factorial. The entry records the OQ's C(n,a)·C(n−a,b) form and peel-order independence C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a).",
+    "implications": "Confirms the parent's factorial-clearing pattern scales to the multinomial setting and supplies the closed ternary factorization that Mathlib states only as the Nat.multinomial_insert recursion. The cleared-form technique (prove a!·b!·c!·(binomial product) = (a+b+c)!, then cancel against multinomial_spec) is reusable for any fixed-arity multinomial factorization, and peel-order independence exhibits the trinomial coefficient's symmetry without any binomial manipulation.",
+    "openQuestions": [
+      "Does the nested factorization extend to four parts, multinomial{a,b,c,d} = C(a+b+c+d,a)·C(b+c+d,b)·C(c+d,c), by iterating the same cleared-denominator collapse, and can the general k-part statement be proved uniformly by induction on the Nat.multinomial_insert recursion?",
+      "Can the peel-order independence C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a) be lifted to a full symmetric-group action on the parts of a general multinomial coefficient, recovering the invariance of multinomial{a₁,…,a_k} under permutations of (a₁,…,a_k) as a corollary of the peeling recursion?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-07-oq-01",
+      "relationship": "parent — binomial trinomial revision C(n,k)·C(k,m) = C(n,m)·C(n−m,k−m), whose denominator-clearing route this entry extends to the three-part multinomial coefficient"
+    },
+    {
+      "targetId": "combinations-formula-oq-07",
+      "relationship": "ancestor — Vandermonde's additive convolution, the additive counterpart of the multiplicative multinomial factorization proved here"
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "R. L. Graham, D. E. Knuth, O. Patashnik",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "venue": "Addison-Wesley",
+      "note": "Standard reference for binomial and multinomial coefficient identities; trinomial revision is eq. 5.21."
+    },
+    {
+      "authors": "J. Riordan",
+      "title": "Combinatorial Identities",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Systematic treatment of binomial- and multinomial-sum identities."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.multinomial, Nat.multinomial_spec, Nat.multinomial_insert, and the Nat.choose factorial API underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **OQ-07-OQ-01-OQ-01**: *does trinomial revision extend to the three-part multinomial coefficient, and by the same denominator-clearing route?* **Yes on both counts.**

With `n = a+b+c`, the ternary multinomial factors into a nested pair of ordinary binomials — choose the `a`-block from all `n`, then split the remaining `b+c`:

```
multinomial{a,b,c} = C(a+b+c, a) · C(b+c, b)
```

Proved against Mathlib's `Nat.multinomial` by multiplying through by `a!·b!·c!` and collapsing each nested choice to `(a+b+c)!` with `Nat.choose_mul_factorial_mul_factorial` — exactly the parent entry's technique, with no summation and no induction.

## Results (6 theorems, 0 sorries, 0 axioms)

- `factorial_mul_choose_mul_choose` — cleared core (peel the `a`-block): `a!·b!·c!·(C(a+b+c,a)·C(b+c,b)) = (a+b+c)!`
- `factorial_mul_choose_mul_choose_last` — cleared core (peel the `c`-block)
- `multinomial_univ_three_eq` — headline factorization against `Nat.multinomial` (via `multinomial_spec` + left-cancellation)
- `multinomial_eq_choose_mul_choose_sub` — the OQ's `C(n,a)·C(n−a,b)` form, `n = a+b+c`
- `choose_mul_choose_peel_comm` — peel-order independence `C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a)` (trinomial-coefficient symmetry)

## Verification

- Typechecks via `lake env lean` against the Mathlib cache.
- `#print axioms` on the headline results: `propext`, `Classical.choice`, `Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely 0-axiom / `verified`.

## Gallery

Adds `src/data/proofs/combinations-formula-oq-07-oq-01-oq-01/` (meta.json + annotations.json). Cross-referenced to parent `combinations-formula-oq-07-oq-01` (binomial trinomial revision) and ancestor `combinations-formula-oq-07` (Vandermonde).

🤖 Generated with [Claude Code](https://claude.com/claude-code)