### PR TITLE
research(combinations-formula-oq-08-oq-02): stride shallow-diagonal sums recover lagged Fibonacci recurrences [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ08OQ02.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ08OQ02.lean
@@ -1,0 +1,210 @@
+import Mathlib
+
+/-
+# Shallow-Diagonal Sums with Stride recover Lagged Fibonacci Recurrences (OQ-08-OQ-02)
+
+Parent entry `combinations-formula-oq-08` proves that the Fibonacci numbers are the sums
+along the **shallow diagonals** of Pascal's triangle,
+
+  `fib (n + 1) = ∑ k ∈ range (n + 1), C(n - k, k)`,
+
+and the follow-up `combinations-formula-oq-08-oq-01` re-derives the Fibonacci recurrence
+`F_{n+2} = F_{n+1} + F_n` from that sum by applying Pascal's rule term-by-term.
+
+This entry answers the open question raised there:
+
+  *Does the analogous shallow-diagonal sum with a fixed stride `s` (stepping `s` columns
+  per row) recover a higher-order / lagged recurrence, and can that be formalized
+  uniformly?*
+
+**Answer: yes, uniformly.**  Writing the stride as `s = t + 1`, define the stride-`(t+1)`
+diagonal total
+
+  `Dg t n := ∑ k ∈ range (n + 1), C(n - t·k, k)`.
+
+The single theorem `Dg_recurrence` shows that, **for every stride `t + 1` and every `n`**,
+
+  `Dg t (n + t + 1) = Dg t (n + t) + Dg t n`,
+
+i.e. `Dg t` satisfies the *lagged Fibonacci recurrence* `a(m) = a(m-1) + a(m-(t+1))`.  The
+proof is pure Pascal's rule: the whole content is the term identity `stride_term`, which
+splits one diagonal entry into the two entries feeding it under the stride, handled
+uniformly in `t` (including the truncated tail where the entries vanish).
+
+Two specializations pin down the "recovers higher-order recurrence numbers" claim:
+
+* `Dg_zero : Dg 0 n = 2 ^ n`         — stride `1` gives the row sums `2ⁿ`
+  (recurrence `a(m) = 2·a(m-1)`, the degenerate lag-`1` case);
+* `Dg_one  : Dg 1 n = fib (n + 1)`   — stride `2` gives the Fibonacci diagonals
+  (recurrence `a(m) = a(m-1) + a(m-2)`).
+
+The stride-`3` case `Dg 2` is the lag-`2` recurrence `a(m) = a(m-1) + a(m-3)` — Narayana's
+cows / the "Padovan-like" sequence — obtained as `Dg_recurrence 2`.
+
+## Proof of the recurrence (sketch)
+
+The `k`-th entry on diagonal `n + t + 1` of the stride-`(t+1)` family is
+`C(n + t + 1 - t·k, k)`.  Pascal's rule `C(a+1, b+1) = C(a, b) + C(a, b+1)` applied to it
+(when the top index does not truncate) yields, after matching indices,
+
+  `C(n+t+1 - t(k+1), k+1) = C(n+t - t(k+1), k+1) + C(n - t·k, k)`   (`stride_term`),
+
+i.e. it splits into the entry directly above it on diagonal `n + t` and the entry `t`
+steps back on diagonal `n`.  Summing over `k` and peeling the constant `k = 0` term gives
+the recurrence.  Where the top index truncates (`t·(k+1) > n + t`), both entries are `0`
+and the identity holds trivially — this uniform handling of the tail is what lets a single
+statement cover all strides.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ08OQ02
+
+open Finset
+
+/-- `Dg t n` is the total along the shallow diagonal of Pascal's triangle taken with
+    **stride `t + 1`** (stepping `t + 1` columns per row):
+
+      `Dg t n = C(n, 0) + C(n - t, 1) + C(n - 2t, 2) + ⋯ = ∑ₖ C(n - t·k, k)`.
+
+    Stride `1` (`t = 0`) gives the row sums `2ⁿ`; stride `2` (`t = 1`) gives the Fibonacci
+    shallow diagonals; stride `t + 1` gives the lag-`t` recurrence `a(m) = a(m-1) + a(m-t-1)`.
+    Terms with `t·k > n` vanish, so the generous range `range (n + 1)` is harmless. -/
+def Dg (t n : ℕ) : ℕ := ∑ k ∈ Finset.range (n + 1), Nat.choose (n - t * k) k
+
+/-- **The stride term identity — the combinatorial core.**
+    One diagonal entry on level `n + t + 1` splits, by Pascal's rule, into the entry
+    directly above it on level `n + t` and the entry `t` columns back on level `n`.
+    Holds uniformly in `t` and `k`: where the top index truncates the two entries vanish
+    and both sides are `0`. -/
+theorem stride_term (t n k : ℕ) :
+    Nat.choose (n + t + 1 - t * (k + 1)) (k + 1)
+      = Nat.choose (n + t - t * (k + 1)) (k + 1) + Nat.choose (n - t * k) k := by
+  rcases le_or_gt (t * (k + 1)) (n + t) with hle | hlt
+  · -- No truncation: the top index is a successor, apply Pascal directly.
+    have hb : n + t + 1 - t * (k + 1) = (n + t - t * (k + 1)) + 1 := by omega
+    have hc : n + t - t * (k + 1) = n - t * k := by rw [Nat.mul_succ]; omega
+    rw [hb, Nat.choose_succ_succ, hc, Nat.add_comm]
+  · -- Truncation: both top indices are `0`, and `k ≥ 1`, so both sides are `0`.
+    have hk : 1 ≤ k := by
+      rcases Nat.eq_zero_or_pos k with rfl | h
+      · simp only [Nat.zero_add, Nat.mul_one] at hlt; omega
+      · exact h
+    have h1 : n + t + 1 - t * (k + 1) = 0 := by omega
+    have h2 : n + t - t * (k + 1) = 0 := by omega
+    have h3 : n - t * k = 0 := by
+      have hlt' := hlt; rw [Nat.mul_succ] at hlt'; omega
+    have hz : Nat.choose 0 k = 0 := Nat.choose_eq_zero_of_lt (by omega)
+    rw [h1, h2, h3, hz]
+    omega
+
+/-- **The stride recurrence — uniform in the stride `t + 1`.**
+    For every stride `t + 1` and every `n`, the stride diagonal totals satisfy the lagged
+    Fibonacci recurrence `a(m) = a(m-1) + a(m-(t+1))`, derived purely by Pascal's rule.
+    Specializes to the Fibonacci recurrence (`t = 1`) and to `2ⁿ`'s doubling (`t = 0`). -/
+theorem Dg_recurrence (t n : ℕ) : Dg t (n + t + 1) = Dg t (n + t) + Dg t n := by
+  -- Expand the LHS, peel the `k = 0` term, and split each remaining term via `stride_term`.
+  have hLHS : Dg t (n + t + 1)
+      = (∑ k ∈ range (n + t + 1),
+          (Nat.choose (n + t - t * (k + 1)) (k + 1) + Nat.choose (n - t * k) k)) + 1 := by
+    unfold Dg
+    rw [Finset.sum_range_succ' (fun k => Nat.choose (n + t + 1 - t * k) k) (n + t + 1)]
+    simp only [Nat.mul_zero, Nat.sub_zero, Nat.choose_zero_right]
+    congr 1
+    apply Finset.sum_congr rfl
+    intro k _
+    exact stride_term t n k
+  rw [hLHS, Finset.sum_add_distrib]
+  -- First sum + 1 = Dg t (n + t): reassemble the peeled diagonal on level `n + t`.
+  have hS1 : (∑ k ∈ range (n + t + 1), Nat.choose (n + t - t * (k + 1)) (k + 1)) + 1
+      = Dg t (n + t) := by
+    have peel : (∑ k ∈ range (n + t + 2), Nat.choose (n + t - t * k) k)
+        = (∑ k ∈ range (n + t + 1), Nat.choose (n + t - t * (k + 1)) (k + 1)) + 1 := by
+      rw [Finset.sum_range_succ' (fun k => Nat.choose (n + t - t * k) k) (n + t + 1)]
+      simp
+    have shrink : (∑ k ∈ range (n + t + 2), Nat.choose (n + t - t * k) k) = Dg t (n + t) := by
+      unfold Dg
+      rw [Finset.sum_range_succ]
+      rw [Nat.choose_eq_zero_of_lt (show n + t - t * (n + t + 1) < n + t + 1 by omega),
+          Nat.add_zero]
+    rw [← peel]; exact shrink
+  -- Second sum = Dg t n: the extra tail terms `k > n` vanish.
+  have hS2 : (∑ k ∈ range (n + t + 1), Nat.choose (n - t * k) k) = Dg t n := by
+    unfold Dg
+    have hsub : range (n + 1) ⊆ range (n + t + 1) := by
+      intro x hx
+      rw [Finset.mem_range] at hx ⊢
+      omega
+    have hvanish : ∀ k ∈ range (n + t + 1), k ∉ range (n + 1) →
+        Nat.choose (n - t * k) k = 0 := by
+      intro k _ hk
+      rw [Finset.mem_range, not_lt] at hk
+      apply Nat.choose_eq_zero_of_lt
+      omega
+    exact (Finset.sum_subset hsub hvanish).symm
+  omega
+
+/-! ### Stride `1`: the row sums `2ⁿ` (degenerate lag-`1` recurrence) -/
+
+/-- Stride `1` (`t = 0`) recovers the binomial row sums `∑ₖ C(n, k) = 2ⁿ`. -/
+theorem Dg_zero (n : ℕ) : Dg 0 n = 2 ^ n := by
+  unfold Dg
+  simp only [Nat.zero_mul, Nat.sub_zero]
+  exact Nat.sum_range_choose n
+
+/-- The stride-`1` recurrence is the doubling `2^{m+1} = 2·2^m`. -/
+theorem Dg_zero_recurrence (n : ℕ) : Dg 0 (n + 1) = Dg 0 n + Dg 0 n := by
+  have h := Dg_recurrence 0 n
+  simpa using h
+
+/-! ### Stride `2`: the Fibonacci diagonals -/
+
+/-- **Parent identity (`combinations-formula-oq-08`)**, reproved inline so this file stands
+    alone: the stride-`2` shallow-diagonal sum is a Fibonacci number.  Reindexes Mathlib's
+    antidiagonal form `Nat.fib_succ_eq_sum_choose` via the reflection `k ↦ n - k`. -/
+theorem fib_eq_sum_range_choose (n : ℕ) :
+    Nat.fib (n + 1) = ∑ k ∈ Finset.range (n + 1), Nat.choose (n - k) k := by
+  rw [Nat.fib_succ_eq_sum_choose,
+      Finset.Nat.sum_antidiagonal_eq_sum_range_succ (fun i j => Nat.choose i j) n,
+      ← Finset.sum_range_reflect (fun k => Nat.choose (n - k) k) (n + 1)]
+  refine Finset.sum_congr rfl (fun k hk => ?_)
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+  simp only [Nat.add_sub_cancel, Nat.sub_sub_self hk]
+
+/-- Stride `2` (`t = 1`) recovers the Fibonacci shallow diagonals `Dg 1 n = fib (n + 1)`. -/
+theorem Dg_one (n : ℕ) : Dg 1 n = Nat.fib (n + 1) := by
+  unfold Dg
+  simp only [Nat.one_mul]
+  exact (fib_eq_sum_range_choose n).symm
+
+/-- The stride-`2` recurrence is the Fibonacci recurrence `F_{n+3} = F_{n+2} + F_{n+1}`,
+    obtained here entirely from Pascal's rule on the stride diagonals. -/
+theorem fib_recurrence_via_stride (n : ℕ) :
+    Nat.fib (n + 3) = Nat.fib (n + 2) + Nat.fib (n + 1) := by
+  have h := Dg_recurrence 1 n
+  rw [Dg_one, Dg_one, Dg_one] at h
+  -- `n + 1 + 1 = n + 2`, `n + 1 = n + 1`; the arguments align after normalization.
+  simpa [Nat.add_assoc] using h
+
+/-! ### Stride `3`: Narayana's cows (lag-`2` recurrence `a(m) = a(m-1) + a(m-3)`) -/
+
+/-- Stride `3` (`t = 2`) satisfies the lag-`2` recurrence `a(m) = a(m-1) + a(m-3)`
+    (Narayana's cows sequence), a genuinely higher-order recurrence with no `n-2` term. -/
+theorem Dg_two_recurrence (n : ℕ) : Dg 2 (n + 3) = Dg 2 (n + 2) + Dg 2 n := by
+  have h := Dg_recurrence 2 n
+  simpa [Nat.add_assoc] using h
+
+/-! ### Sanity checks -/
+
+/-- `Dg 1 6 = fib 7 = 13`, from `C(6,0)+C(5,1)+C(4,2)+C(3,3) = 1+5+6+1 = 13`. -/
+example : Dg 1 6 = 13 := by decide
+
+/-- `Dg 0 4 = 2^4 = 16`, the fourth row sum of Pascal's triangle. -/
+example : Dg 0 4 = 16 := by decide
+
+/-- Stride `3` gives Narayana's cows `1,1,1,2,3,4,6,9,13,…`: `Dg 2 7 = 9` and the lagged
+    recurrence `Dg 2 8 = Dg 2 7 + Dg 2 5`, i.e. `13 = 9 + 4`. -/
+example : Dg 2 7 = 9 := by decide
+example : Dg 2 8 = Dg 2 7 + Dg 2 5 := by decide
+
+end CombinationsFormulaOQ08OQ02

--- a/src/data/proofs/combinations-formula-oq-08-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-08-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-cf0802-def-dg",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 63, "endLine": 78 },
+    "type": "definition",
+    "title": "The Stride Diagonal Total Dg(t, n)",
+    "content": "The sibling entry combinations-formula-oq-08-oq-01 derived the Fibonacci recurrence from the shallow diagonals of Pascal's triangle by Pascal's rule, and asked whether a stride-s sum recovers a higher-order recurrence uniformly. This file answers that. Writing the stride as s = t+1, the definition `Dg t n := ∑ k ∈ range (n+1), C(n − t·k, k)` names the total along the diagonal that steps t+1 columns per row. At t=0 the multiplier vanishes and Dg(0,n) = ∑_k C(n,k) = 2ⁿ; at t=1 it is ∑_k C(n−k, k) = fib(n+1). Terms with t·k > n have top index below the bottom index and vanish, so the generous range range(n+1) is harmless — a point that recurs throughout the proof.",
+    "mathContext": "$Dg(t, n) = \\sum_{k=0}^{n} \\binom{n - t\\,k}{k}$, the sum along the shallow diagonal of stride $t+1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["shallow diagonals", "Pascal's triangle", "binomial coefficients", "lagged recurrences", "generating function 1/(1−x−x^s)"],
+    "prerequisites": ["binomial coefficients C(n,k)", "finite sums over Finset.range", "the sibling Fibonacci-from-Pascal entry"]
+  },
+  {
+    "id": "ann-cf0802-stride-term",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 80, "endLine": 103 },
+    "type": "theorem",
+    "title": "The Stride Term Identity: One Pascal Split, Uniform in the Stride",
+    "content": "`stride_term` is the entire combinatorial content: C(n+t+1 − t(k+1), k+1) = C(n+t − t(k+1), k+1) + C(n − t·k, k). It says one diagonal entry on level n+t+1 splits into the entry directly above it on level n+t and the entry t columns back on level n — the two predecessors of the lagged recurrence. The proof case-splits on t(k+1) ≤ n+t. When it holds, the top index n+t+1 − t(k+1) is a successor (n+t − t(k+1))+1, so `Nat.choose_succ_succ` (Pascal's rule) applies, and the index identity n+t − t(k+1) = n − t·k is closed by `omega` after `Nat.mul_succ` exposes t(k+1) = t·k + t. When it fails the top indices nat-truncate to 0; crucially k ≥ 1 there (k = 0 would force t ≥ n+t+1), so C(0, k) = 0 and both sides vanish. This uniform handling of the truncated tail is exactly what lets one statement cover every stride, degenerate t = 0 included.",
+    "mathContext": "$\\binom{n+t+1 - t(k+1)}{k+1} = \\binom{n+t - t(k+1)}{k+1} + \\binom{n - t k}{k}$ for all $t, k$.",
+    "significance": "key",
+    "relatedConcepts": ["Pascal's rule", "Nat.choose_succ_succ", "Nat.choose_eq_zero_of_lt", "truncated subtraction", "case analysis"],
+    "prerequisites": ["Pascal's identity C(a+1,b+1)=C(a,b)+C(a,b+1)", "vanishing binomials C(0,k)=0 for k≥1", "ℕ subtraction arithmetic via omega"]
+  },
+  {
+    "id": "ann-cf0802-recurrence",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 105, "endLine": 148 },
+    "type": "theorem",
+    "title": "The Uniform Stride Recurrence Dg(t, n+t+1) = Dg(t, n+t) + Dg(t, n)",
+    "content": "`Dg_recurrence` proves the lagged Fibonacci recurrence a(m) = a(m−1) + a(m−(t+1)) for every stride t+1 and every n. Expand Dg(t, n+t+1) and peel its k=0 term with `Finset.sum_range_succ'` (the constant C(n+t+1, 0) = 1); apply `stride_term` to each remaining summand and split with `Finset.sum_add_distrib`. The first child-sum, after re-attaching its own peeled boundary term (sum_range_succ') and discarding a vanishing top term C(n+t − t(n+t+1), n+t+1) = 0, reassembles Dg(t, n+t). The second child-sum is ∑_{k<n+t+1} C(n − t·k, k); its terms with k > n vanish, so `Finset.sum_subset` identifies it with Dg(t, n) = ∑_{k<n+1}. A final `omega` recombines the pieces (S₁ + 1 = Dg(t,n+t), S₂ = Dg(t,n), and the peeled +1). No appeal to any predefined recurrence sequence.",
+    "mathContext": "$Dg(t, n{+}t{+}1) = Dg(t, n{+}t) + Dg(t, n)$, equivalently $a(m) = a(m{-}1) + a(m{-}(t{+}1))$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_range_succ'", "Finset.sum_add_distrib", "Finset.sum_subset", "boundary-term peeling", "range reconciliation"],
+    "prerequisites": ["the stride term identity", "peeling first/last terms of a range sum", "dropping vanishing terms across differing supports", "omega for the final linear combination"]
+  },
+  {
+    "id": "ann-cf0802-stride-one",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 150, "endLine": 162 },
+    "type": "theorem",
+    "title": "Stride 1: the Binomial Row Sums 2ⁿ",
+    "content": "`Dg_zero` records the degenerate stride: at t = 0 the multiplier t·k vanishes, so Dg(0, n) = ∑_k C(n, k), which is 2ⁿ by Mathlib's `Nat.sum_range_choose`. `Dg_zero_recurrence` then specializes the uniform recurrence to Dg(0, n+1) = Dg(0, n) + Dg(0, n), i.e. the doubling 2^{n+1} = 2·2ⁿ — the lag-1 member of the family, where 'lag 1' collapses both predecessors onto a(m−1).",
+    "mathContext": "$Dg(0, n) = \\sum_{k=0}^{n}\\binom{n}{k} = 2^n$, with recurrence $2^{n+1} = 2\\cdot 2^n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.sum_range_choose", "binomial theorem row sums", "degenerate recurrence"],
+    "prerequisites": ["the row-sum identity ∑_k C(n,k) = 2ⁿ", "the uniform stride recurrence"]
+  },
+  {
+    "id": "ann-cf0802-stride-two",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 164, "endLine": 190 },
+    "type": "theorem",
+    "title": "Stride 2: the Fibonacci Diagonals and Recurrence",
+    "content": "`fib_eq_sum_range_choose` reproves the parent shallow-diagonal identity fib(n+1) = ∑_k C(n−k, k) inline (from `Nat.fib_succ_eq_sum_choose` via the antidiagonal-to-range conversion and the reflection k ↦ n−k), so the file stands alone. `Dg_one` reads off Dg(1, n) = fib(n+1) (stride 2). `fib_recurrence_via_stride` then obtains fib(n+3) = fib(n+2) + fib(n+1) as the t = 1 case of `Dg_recurrence` — the classical Fibonacci recurrence produced by Pascal's rule on the stride diagonals, not by Nat.fib_add_two.",
+    "mathContext": "$Dg(1, n) = \\mathrm{fib}(n+1)$ and $\\mathrm{fib}(n+3) = \\mathrm{fib}(n+2) + \\mathrm{fib}(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.fib_succ_eq_sum_choose", "Finset.sum_range_reflect", "index reflection", "Fibonacci recurrence"],
+    "prerequisites": ["Mathlib's antidiagonal Fibonacci form", "reindexing finite sums", "the uniform stride recurrence at t=1"]
+  },
+  {
+    "id": "ann-cf0802-stride-three",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 192, "endLine": 197 },
+    "type": "theorem",
+    "title": "Stride 3: Narayana's Cows, a Genuinely Higher-Order Recurrence",
+    "content": "`Dg_two_recurrence` specializes the uniform recurrence to stride 3 (t = 2): Dg(2, n+3) = Dg(2, n+2) + Dg(2, n). This is the lag-2 recurrence a(m) = a(m−1) + a(m−3) — note the absence of any a(m−2) term — which generates Narayana's cows sequence 1,1,1,2,3,4,6,9,13,… (OEIS A000930). It witnesses that the single Dg_recurrence produces genuinely higher-order recurrences beyond Fibonacci, confirming the 'higher-order' half of the open question.",
+    "mathContext": "$Dg(2, n+3) = Dg(2, n+2) + Dg(2, n)$, i.e. $a(m) = a(m-1) + a(m-3)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Narayana's cows", "OEIS A000930", "lagged recurrence", "higher-order linear recurrence"],
+    "prerequisites": ["the uniform stride recurrence at t=2"]
+  },
+  {
+    "id": "ann-cf0802-verification",
+    "proofId": "combinations-formula-oq-08-oq-02",
+    "range": { "startLine": 199, "endLine": 208 },
+    "type": "tactic",
+    "title": "Worked Verifications",
+    "content": "Four `decide` sanity checks anchor the abstractions in numbers: Dg(1, 6) = fib(7) = 13 (from C(6,0)+C(5,1)+C(4,2)+C(3,3) = 1+5+6+1); Dg(0, 4) = 2⁴ = 16, the fourth Pascal row sum; and for Narayana's cows, Dg(2, 7) = 9 together with the lagged recurrence Dg(2, 8) = Dg(2, 7) + Dg(2, 5), i.e. 13 = 9 + 4. These use kernel decidability (decide), not native_decide, so they add no axioms.",
+    "mathContext": "$Dg(1,6)=13,\\ Dg(0,4)=16,\\ Dg(2,7)=9,\\ Dg(2,8)=Dg(2,7)+Dg(2,5)=13$.",
+    "significance": "context",
+    "relatedConcepts": ["decide", "kernel decidability", "sanity checks"],
+    "prerequisites": ["decidable equality on ℕ"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-08-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-08-oq-02/meta.json
@@ -1,0 +1,195 @@
+{
+  "id": "combinations-formula-oq-08-oq-02",
+  "title": "Stride Shallow-Diagonal Sums and Lagged Fibonacci Recurrences",
+  "slug": "combinations-formula-oq-08-oq-02",
+  "description": "Generalizes the Fibonacci-from-Pascal identity to arbitrary stride. Writing the stride as s = t+1, define the stride-(t+1) shallow-diagonal total Dg(t, n) = ∑_{k} C(n − t·k, k) — stepping t+1 columns per row down the triangle. The central result Dg_recurrence proves, uniformly in the stride t+1 and for every n, the lagged Fibonacci recurrence Dg(t, n+t+1) = Dg(t, n+t) + Dg(t, n), i.e. a(m) = a(m−1) + a(m−(t+1)), by a single term-by-term Pascal split (stride_term) that is handled uniformly across the truncated tail where the binomial entries vanish. Two specializations pin down the recovered sequences: stride 1 (t=0) gives the binomial row sums Dg(0, n) = 2ⁿ with doubling recurrence, and stride 2 (t=1) gives the Fibonacci shallow diagonals Dg(1, n) = fib(n+1) with the classical recurrence fib(n+3) = fib(n+2) + fib(n+1). Stride 3 (t=2) yields the lag-2 recurrence a(m) = a(m−1) + a(m−3) of Narayana's cows sequence 1,1,1,2,3,4,6,9,13,…",
+  "meta": {
+    "author": "Lean Genius researcher-6",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ08OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 210,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "assumptions": "None. All identities hold for every natural number and are fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool — the decide sanity checks use kernel decidability, not native_decide).",
+    "tags": [
+      "combinatorics",
+      "fibonacci",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "finset-sums",
+      "recurrence",
+      "number-theory"
+    ],
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "Dg_recurrence: for every stride t+1 and every n, the stride shallow-diagonal totals Dg(t,n) = ∑_{k} C(n − t·k, k) satisfy the lagged Fibonacci recurrence Dg(t, n+t+1) = Dg(t, n+t) + Dg(t, n) — a single statement covering all strides uniformly, proved purely by Pascal's rule with no reference to any predefined recurrence sequence",
+      "stride_term: the uniform Pascal split C(n+t+1 − t(k+1), k+1) = C(n+t − t(k+1), k+1) + C(n − t·k, k), the combinatorial core; it holds for all t, k including the truncated tail (t(k+1) > n+t), where a case split shows both entries vanish and k ≥ 1 forces the residual C(0,k) = 0",
+      "Dg_zero: stride 1 (t=0) recovers the binomial row sums Dg(0,n) = 2ⁿ (via Nat.sum_range_choose), with Dg_zero_recurrence giving the degenerate lag-1 doubling 2^{m+1} = 2·2^m as a specialization of Dg_recurrence",
+      "Dg_one: stride 2 (t=1) recovers the Fibonacci shallow diagonals Dg(1,n) = fib(n+1); fib_recurrence_via_stride then obtains fib(n+3) = fib(n+2) + fib(n+1) as the stride-2 case of Dg_recurrence — Pascal's rule, not Nat.fib_add_two",
+      "Dg_two_recurrence: stride 3 (t=2) yields the genuinely higher-order lag-2 recurrence Dg(2, n+3) = Dg(2, n+2) + Dg(2, n) (Narayana's cows sequence), a case with no n−2 term, demonstrating that the single Dg_recurrence produces higher-order recurrences and not just Fibonacci",
+      "fib_eq_sum_range_choose: the parent shallow-diagonal identity fib(n+1) = ∑_{k} C(n−k, k), reproved inline so the file stands alone"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule C(n+1, k+1) = C(n, k) + C(n, k+1); the arithmetic heart of stride_term in the non-truncating case, after rewriting the top index as a successor.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_eq_zero_of_lt",
+        "description": "C(a, b) = 0 when a < b; used to kill the truncated tail entries in stride_term and to drop the vanishing boundary terms when adjusting summation ranges.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Peels the first term: ∑_{i<n+1} f i = (∑_{i<n} f(i+1)) + f 0. Used to strip the k=0 term of the stride diagonal totals before applying the Pascal split, and to reassemble the level-(n+t) diagonal.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_subset",
+        "description": "Equates two sums whose supports differ only by terms that vanish; used to identify the stride-n tail sum ∑_{k<n+t+1} C(n − t·k, k) with Dg(t, n) = ∑_{k<n+1}, since the extra terms k > n vanish.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.sum_range_choose",
+        "description": "∑_{k<n+1} C(n, k) = 2ⁿ; gives the stride-1 specialization Dg(0, n) = 2ⁿ directly.",
+        "module": "Mathlib.Combinatorics.Choose.Sum"
+      },
+      {
+        "theorem": "Nat.fib_succ_eq_sum_choose",
+        "description": "Fibonacci as a sum over the antidiagonal; the starting point for the inline reproof of the shallow-diagonal identity fib_eq_sum_range_choose used by the stride-2 specialization.",
+        "module": "Mathlib.Combinatorics.Choose.Sum"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ08OQ02.lean",
+    "namespace": "CombinationsFormulaOQ08OQ02",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 210,
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "That the Fibonacci numbers are the sums along the shallow diagonals of Pascal's triangle is classical (Lucas, 1876), and its sibling entry combinations-formula-oq-08-oq-01 re-derived the Fibonacci recurrence from those diagonals purely by Pascal's rule. That entry closed with an explicit open question: does the analogous sum with a fixed stride s (stepping s columns per row) recover a higher-order / lagged recurrence, and can the same peeling-then-Pascal method formalize it uniformly in s? This entry answers that question affirmatively and uniformly. The diagonal sums with slope 1/s are the classical generating-function coefficients of 1/(1 − x − x^s); their appearance for s = 3 as Narayana's cows sequence (OEIS A000930) is a standard example in enumerative combinatorics.",
+    "problemStatement": "For a stride s = t+1, define the stride diagonal total Dg(t, n) = ∑_{k} C(n − t·k, k). Show, uniformly in t and n, that Dg satisfies the lagged Fibonacci recurrence Dg(t, n+t+1) = Dg(t, n+t) + Dg(t, n), i.e. a(m) = a(m−1) + a(m−(t+1)), by applying Pascal's rule term-by-term; and identify the sequences recovered at strides 1, 2, and 3.",
+    "proofStrategy": "The entire content is the term identity stride_term: C(n+t+1 − t(k+1), k+1) = C(n+t − t(k+1), k+1) + C(n − t·k, k). Its proof splits on whether t(k+1) ≤ n+t. In the non-truncating case the top index n+t+1 − t(k+1) is a successor (n+t − t(k+1)) + 1, so Nat.choose_succ_succ (Pascal's rule) applies and the two children are exactly the level-(n+t) entry and the level-n entry t steps back (the index identity n+t − t(k+1) = n − t·k is discharged by omega after Nat.mul_succ). In the truncating case both top indices are 0; here k ≥ 1 is forced (k = 0 would need t ≥ n+t+1), so C(0, k) = 0 and both sides vanish. Summing stride_term over range(n+t+1), peeling the k=0 term with Finset.sum_range_succ', and splitting via Finset.sum_add_distrib yields the recurrence: the first child-sum reassembles Dg(t, n+t) (reattaching its peeled boundary term via sum_range_succ' and dropping a vanishing top term), and the second child-sum equals Dg(t, n) after Finset.sum_subset discards the extra tail terms k > n, which vanish. The specializations then follow: Dg(0,n) = 2ⁿ by Nat.sum_range_choose, and Dg(1,n) = fib(n+1) by the inline shallow-diagonal identity fib_eq_sum_range_choose.",
+    "keyInsights": [
+      "One stride diagonal entry on level n+t+1 splits, under Pascal's rule, into the entry directly above it on level n+t and the entry t columns back on level n — precisely the two predecessors of the lagged recurrence a(m) = a(m−1) + a(m−(t+1)). Stride s = t+1 makes the second predecessor lag by exactly s.",
+      "Uniformity in the stride is achieved by handling the truncated tail head-on: where t(k+1) exceeds n+t the binomial top index nat-truncates to 0, and the single observation that k ≥ 1 there (k = 0 is impossible) makes both sides of stride_term equal to 0. This one case split is what lets a single statement cover every stride, including the degenerate t = 0.",
+      "The natural-number subtraction t·k inside the binomial is exact wherever the term is nonzero, so omega discharges every index identity (e.g. n+t − t(k+1) = n − t·k) once Nat.mul_succ exposes t(k+1) = t·k + t; the generous range range(n+1) is harmless because surplus terms with t·k > n vanish and are removed by Finset.sum_subset.",
+      "The lagged recurrence is genuinely higher-order: at stride 3 (t = 2) it is a(m) = a(m−1) + a(m−3) with no a(m−2) term — Narayana's cows sequence 1,1,1,2,3,4,6,9,13,… — so the single Dg_recurrence produces an infinite family of recurrences, of which Fibonacci (stride 2) and the doubling 2ⁿ (stride 1) are just the first two members."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Strategy",
+      "startLine": 1,
+      "endLine": 71,
+      "summary": "Header stating OQ-08-OQ-02: does the stride-s shallow-diagonal sum recover a higher-order recurrence, uniformly in s? Records the answer (yes), the definition Dg(t,n) with s = t+1, the uniform recurrence, and the stride 1/2/3 specializations, with a sketch of the peeling-then-Pascal proof and its uniform handling of the truncated tail."
+    },
+    {
+      "id": "definition",
+      "title": "The Stride Diagonal Total Dg(t, n)",
+      "startLine": 73,
+      "endLine": 78,
+      "summary": "Defines Dg(t, n) = ∑_{k<n+1} C(n − t·k, k), the total along the shallow diagonal taken with stride t+1. Terms with t·k > n vanish, so the range range(n+1) is generous but harmless."
+    },
+    {
+      "id": "stride-term",
+      "title": "The Stride Term Identity (Combinatorial Core)",
+      "startLine": 80,
+      "endLine": 103,
+      "summary": "stride_term: C(n+t+1 − t(k+1), k+1) = C(n+t − t(k+1), k+1) + C(n − t·k, k), uniformly in t and k. A case split on t(k+1) ≤ n+t: the non-truncating branch is Pascal's rule (Nat.choose_succ_succ) after exposing a successor top index; the truncating branch has both sides 0, using k ≥ 1."
+    },
+    {
+      "id": "recurrence",
+      "title": "The Uniform Stride Recurrence",
+      "startLine": 105,
+      "endLine": 148,
+      "summary": "Dg_recurrence: Dg(t, n+t+1) = Dg(t, n+t) + Dg(t, n) for all t, n. Peels the k=0 term (Finset.sum_range_succ'), applies stride_term term-by-term, splits with Finset.sum_add_distrib; the first child-sum reassembles Dg(t, n+t) and the second equals Dg(t, n) via Finset.sum_subset dropping vanishing tail terms, combined by omega."
+    },
+    {
+      "id": "stride-one",
+      "title": "Stride 1: the Row Sums 2ⁿ",
+      "startLine": 150,
+      "endLine": 162,
+      "summary": "Dg_zero: Dg(0, n) = 2ⁿ via Nat.sum_range_choose (stride 1 gives the binomial row sums). Dg_zero_recurrence specializes the uniform recurrence to the degenerate lag-1 doubling 2^{m+1} = 2·2^m."
+    },
+    {
+      "id": "stride-two",
+      "title": "Stride 2: the Fibonacci Diagonals",
+      "startLine": 164,
+      "endLine": 190,
+      "summary": "fib_eq_sum_range_choose reproves the parent identity fib(n+1) = ∑_{k} C(n−k, k) inline. Dg_one: Dg(1, n) = fib(n+1). fib_recurrence_via_stride recovers fib(n+3) = fib(n+2) + fib(n+1) as the stride-2 case of Dg_recurrence."
+    },
+    {
+      "id": "stride-three",
+      "title": "Stride 3: Narayana's Cows (Lag-2 Recurrence)",
+      "startLine": 192,
+      "endLine": 197,
+      "summary": "Dg_two_recurrence: Dg(2, n+3) = Dg(2, n+2) + Dg(2, n), the lag-2 recurrence a(m) = a(m−1) + a(m−3) with no n−2 term — a genuinely higher-order recurrence obtained as the stride-3 specialization."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 199,
+      "endLine": 208,
+      "summary": "decide sanity checks: Dg(1,6) = fib(7) = 13; Dg(0,4) = 2⁴ = 16; Narayana's cows Dg(2,7) = 9 and the lagged recurrence Dg(2,8) = Dg(2,7) + Dg(2,5), i.e. 13 = 9 + 4."
+    }
+  ],
+  "conclusion": {
+    "summary": "8 theorems, 1 definition, 0 sorries, 0 axioms. The single theorem Dg_recurrence proves, uniformly in the stride t+1 and for every n, the lagged Fibonacci recurrence Dg(t, n+t+1) = Dg(t, n+t) + Dg(t, n) for the stride diagonal totals Dg(t, n) = ∑_{k} C(n − t·k, k), by a single term-by-term Pascal split (stride_term) handled uniformly across the truncated tail. The recovered sequences are identified at three strides: 2ⁿ (stride 1, doubling), the Fibonacci numbers (stride 2, with fib(n+3) = fib(n+2) + fib(n+1) reproved via Pascal), and Narayana's cows (stride 3, the lag-2 recurrence a(m) = a(m−1) + a(m−3)).",
+    "implications": "This answers the sibling entry's open question in full: a single, stride-uniform statement generalizes the Fibonacci-from-Pascal recurrence to an infinite family of lagged recurrences a(m) = a(m−1) + a(m−(t+1)), with Fibonacci and 2ⁿ as its first two members. The decisive technique is handling nat-truncated binomial entries head-on inside the term identity — a case split that makes both children of a truncated entry vanish — which is what allows one lemma to cover all strides including the degenerate t = 0. The peeling-then-Pascal plus sum_subset pattern for range reconciliation is reusable for any diagonal-stride binomial recurrence.",
+    "openQuestions": [
+      "Do the *diagonal partial sums* ∑_{i<n} Dg(t, i) telescope to a closed form generalizing the Lucas identity ∑_{i<n} fib(i) = fib(n+1) − 1 (which is the stride-2 case), and can that be formalized uniformly in the stride t+1?",
+      "The stride diagonal totals are the coefficients of 1/(1 − x − x^{t+1}); can the ordinary generating function ∑_n Dg(t, n) x^n = 1/(1 − x − x^{t+1}) be formalized as a formal power series identity, upgrading the term-level recurrence to a generating-function statement?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-08-oq-01",
+      "relationship": "sibling — posed this stride generalization as its explicit open question; this entry answers it uniformly in the stride"
+    },
+    {
+      "targetId": "combinations-formula-oq-08",
+      "relationship": "grandparent — provides the base shallow-diagonal Fibonacci identity fib(n+1) = ∑_k C(n−k, k), recovered here as the stride-2 case"
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "T. Koshy",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": 2001,
+      "venue": "Wiley",
+      "note": "Fibonacci/Lucas identities and the shallow diagonals of Pascal's triangle."
+    },
+    {
+      "authors": "R. L. Graham, D. E. Knuth, O. Patashnik",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "venue": "Addison-Wesley",
+      "note": "Standard reference for binomial-coefficient identities, diagonal sums, and linear recurrences via generating functions 1/(1 − x − x^s)."
+    },
+    {
+      "authors": "N. J. A. Sloane (ed.)",
+      "title": "The On-Line Encyclopedia of Integer Sequences, A000930 (Narayana's cows)",
+      "year": 2024,
+      "venue": "OEIS Foundation",
+      "note": "The stride-3 sequence 1,1,1,2,3,4,6,9,13,… with recurrence a(n) = a(n−1) + a(n−3)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.choose, Nat.fib, Nat.sum_range_choose, and the antidiagonal/binomial API underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **open question** posed by the sibling entry `combinations-formula-oq-08-oq-01` — *does the analogous shallow-diagonal sum with a fixed stride s recover a higher-order / lagged recurrence, and can that be formalized uniformly?* — affirmatively and uniformly in the stride.

Writing the stride as `s = t + 1`, define the stride diagonal total

  `Dg t n := ∑ k ∈ range (n+1), C(n − t·k, k)`.

The single theorem **`Dg_recurrence`** proves, for **every** stride `t+1` and every `n`, the lagged Fibonacci recurrence

  `Dg t (n + t + 1) = Dg t (n + t) + Dg t n`,   i.e.  `a(m) = a(m−1) + a(m−(t+1))`,

by one stride-uniform Pascal split (`stride_term`) that handles the nat-truncated tail head-on (a case split makes both children of a truncated entry vanish, using `k ≥ 1` there).

### Recovered sequences
- **Stride 1** (`t=0`): `Dg 0 n = 2ⁿ` (`Dg_zero`), with the degenerate doubling recurrence.
- **Stride 2** (`t=1`): `Dg 1 n = fib(n+1)` (`Dg_one`); `fib_recurrence_via_stride` recovers `fib(n+3) = fib(n+2) + fib(n+1)` from Pascal's rule, not `Nat.fib_add_two`.
- **Stride 3** (`t=2`): the lag-2 recurrence `a(m) = a(m−1) + a(m−3)` of Narayana's cows `1,1,1,2,3,4,6,9,13,…` (`Dg_two_recurrence`) — a genuinely higher-order recurrence with no `n−2` term.

## Verification
- `#print axioms Dg_recurrence` → `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
- 210 lines, 8 theorems, 1 definition, 0 sorries, 0 axioms. Typechecks against Mathlib via `lake env lean`.
- `decide` sanity checks use kernel decidability (not `native_decide`).

## Files
- `proofs/Proofs/CombinationsFormulaOQ08OQ02.lean`
- `src/data/proofs/combinations-formula-oq-08-oq-02/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)