### PR TITLE
Alternating Fibonacci binomial transform: ∑ (−1)ᵏ C(n,k)·Fₖ = −Fₙ (oq-06-oq-01-oq-02)

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean
@@ -1,0 +1,129 @@
+import Mathlib
+
+/-!
+# The alternating Fibonacci binomial transform — `∑ (−1)ᵏ C(n,k)·Fₖ = −Fₙ`
+
+The parent entry `FibonacciIdentitiesOQ06OQ01` established the *ordinary* Fibonacci
+binomial transform `∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ`, whose plus-signed binomial
+weights fold the sequence onto itself at a *doubled* index. This open-question
+descendant supplies the **alternating (falling) binomial transform**, where the
+weights carry the sign `(−1)ᵏ`. Now the fold *collapses* rather than doubles:
+
+* `alt_fib_binom_transform_zero` — `∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ = −Fₙ`.
+  The alternating binomial transform of the Fibonacci sequence returns the same
+  sequence *negated*, with the index held fixed (contrast the doubling `n ↦ 2n`
+  of the plus-signed transform). This is the discrete shadow of `1 − φ = ψ`
+  (`ψ = (1−√5)/2` the conjugate root): applying `∑ (−1)ᵏ C(n,k)(·)ᵏ` to `φ`
+  sends `φ ↦ (1−φ)ⁿ = ψⁿ`, so via Binet `∑ (−1)ᵏ C(n,k) Fₖ = (ψⁿ − φⁿ)/√5 = −Fₙ`.
+
+* `alt_fib_binom_transform_one` — the offset-`1` companion
+  `∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ₊₁ = Fₙ₊₁ − Fₙ` (`= Fₙ₋₁`).
+
+The engine is a **signed Pascal convolution** `signed_pascal_conv` — the `(−1)ᵏ`
+analogue of the parent's `pascal_conv` — which splits a length-`(n+2)` signed
+binomial sum for `n+1` into the *difference* of the two length-`(n+1)` signed
+binomial sums for `n` at consecutive offsets. The sign turns the parent's
+`+` into a `−`, and it is precisely this minus that converts the doubling into
+a cancellation. Because the two offset-`0` and offset-`1` transforms feed each
+other through the recurrence `Fₖ₊₂ = Fₖ + Fₖ₊₁`, they are proved together by a
+single joint induction on `n` (the pair
+`(∑(−1)ᵏC(n,k)Fₖ, ∑(−1)ᵏC(n,k)Fₖ₊₁) = (−Fₙ, Fₙ₊₁−Fₙ)` is the loop invariant).
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace FibonacciIdentitiesOQ06OQ01OQ02
+
+open Finset
+
+/-- **Signed Pascal convolution.** For any summand `f : ℕ → ℤ`, the
+`(−1)ᵏ`-signed binomial-weighted sum with `C(n+1, ·)` over a length-`(n+2)`
+window equals the *difference* of the two `C(n, ·)`-weighted length-`(n+1)`
+signed windows at offsets `0` and `1`:
+`∑_{k<n+2} (−1)ᵏ C(n+1,k)·f(k) = ∑_{k<n+1} (−1)ᵏ C(n,k)·f(k) − ∑_{k<n+1} (−1)ᵏ C(n,k)·f(k+1)`.
+
+This is Pascal's rule `C(n+1,k+1) = C(n,k) + C(n,k+1)` summed against the
+alternating weight `(−1)ᵏ f`; the sign `(−1)^{k+1} = −(−1)^k` on the reindexed
+term is what turns the parent `pascal_conv`'s `+` into a `−`. -/
+theorem signed_pascal_conv (f : ℕ → ℤ) (n : ℕ) :
+    ∑ k ∈ range (n + 2), (-1 : ℤ) ^ k * (n + 1).choose k * f k
+      = (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * n.choose k * f k)
+        - ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * n.choose k * f (k + 1) := by
+  -- Peel the `k = 0` term off the left sum and reindex the rest by `k ↦ k+1`.
+  rw [Finset.sum_range_succ' (fun k => (-1 : ℤ) ^ k * (n + 1).choose k * f k) (n + 1)]
+  -- Pascal's rule + `(−1)^{k+1} = −(−1)^k` on the reindexed summand.
+  have hpascal : ∀ k, (-1 : ℤ) ^ (k + 1) * ((n + 1).choose (k + 1) : ℤ) * f (k + 1)
+      = -((-1 : ℤ) ^ k * (n.choose k : ℤ) * f (k + 1))
+        - ((-1 : ℤ) ^ k * (n.choose (k + 1) : ℤ) * f (k + 1)) := by
+    intro k
+    rw [Nat.choose_succ_succ' n]
+    push_cast
+    ring
+  rw [Finset.sum_congr rfl (fun k _ => hpascal k)]
+  -- Split `∑ (−A − B) = −∑A − ∑B`.
+  rw [Finset.sum_sub_distrib, Finset.sum_neg_distrib]
+  -- Truncate the `C(n,k+1)` sum: its top term `k = n` has `C(n,n+1) = 0`.
+  rw [Finset.sum_range_succ (fun k => (-1 : ℤ) ^ k * (n.choose (k + 1) : ℤ) * f (k + 1)) n,
+      Nat.choose_succ_self n]
+  -- Peel the first term off the RHS `∑ (−1)ᵏ C(n,k) f k`.
+  rw [Finset.sum_range_succ' (fun k => (-1 : ℤ) ^ k * (n.choose k : ℤ) * f k) n]
+  -- The reindexed RHS sum uses `C(n,k+1)` at offset 1, matching the LHS truncation.
+  simp only [Nat.choose_zero_right, Nat.cast_one, Nat.cast_zero, pow_zero,
+    pow_succ, one_mul, mul_zero, zero_mul, mul_one, add_zero]
+  -- The peeled RHS term carries an inner `·(−1)`; pull it out to match the LHS sum.
+  have key : ∑ x ∈ range n, (-1 : ℤ) ^ x * -1 * (n.choose (x + 1) : ℤ) * f (x + 1)
+      = -∑ x ∈ range n, (-1 : ℤ) ^ x * (n.choose (x + 1) : ℤ) * f (x + 1) := by
+    rw [← Finset.sum_neg_distrib]
+    apply Finset.sum_congr rfl
+    intro k _
+    ring
+  rw [key]
+  ring
+
+/-- **Joint invariant.** The two alternating transforms at offsets `0` and `1`
+evaluate to `(−Fₙ, Fₙ₊₁ − Fₙ)`. Proved together by induction on `n`: the step
+feeds each through `signed_pascal_conv`, and the offset-`2` sum that appears is
+reduced back to the pair via `Fₖ₊₂ = Fₖ + Fₖ₊₁`. -/
+theorem alt_fib_pair (n : ℕ) :
+    (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * n.choose k * Nat.fib k = -Nat.fib n)
+      ∧ (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * n.choose k * Nat.fib (k + 1)
+          = Nat.fib (n + 1) - Nat.fib n) := by
+  induction n with
+  | zero => constructor <;> simp
+  | succ p ih =>
+    obtain ⟨ihS, ihT⟩ := ih
+    -- The offset-1 sum for `p` (call it `T p`) reappears in both steps.
+    have hconvS := signed_pascal_conv (fun k => Nat.fib k) p
+    have hconvT := signed_pascal_conv (fun k => Nat.fib (k + 1)) p
+    -- The offset-2 sum splits into offset-0 + offset-1 via `Fₖ₊₂ = Fₖ + Fₖ₊₁`.
+    have hsplit : (∑ k ∈ range (p + 1), (-1 : ℤ) ^ k * p.choose k * Nat.fib (k + 1 + 1))
+        = (∑ k ∈ range (p + 1), (-1 : ℤ) ^ k * p.choose k * Nat.fib k)
+          + ∑ k ∈ range (p + 1), (-1 : ℤ) ^ k * p.choose k * Nat.fib (k + 1) := by
+      rw [← Finset.sum_add_distrib]
+      apply Finset.sum_congr rfl
+      intro k _
+      have : Nat.fib (k + 1 + 1) = Nat.fib k + Nat.fib (k + 1) := by
+        rw [Nat.fib_add_two]
+      rw [this]; push_cast; ring
+    have hfib : Nat.fib (p + 1 + 1) = Nat.fib p + Nat.fib (p + 1) := by
+      rw [Nat.fib_add_two]
+    constructor
+    · -- offset-0 at `p+1`: `S(p+1) = S(p) − T(p) = −Fₚ − (Fₚ₊₁ − Fₚ) = −Fₚ₊₁`.
+      rw [hconvS, ihS, ihT]; ring
+    · -- offset-1 at `p+1`: `T(p+1) = T(p) − U(p) = T(p) − (S(p)+T(p)) = −S(p) = Fₚ`.
+      rw [hconvT, hsplit, ihS, ihT, hfib]; push_cast; ring
+
+/-- **The alternating binomial transform of the Fibonacci sequence is its own
+negation.** The headline offset-`0` case: `∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ = −Fₙ`. -/
+theorem alt_fib_binom_transform_zero (n : ℕ) :
+    ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * n.choose k * Nat.fib k = -Nat.fib n :=
+  (alt_fib_pair n).1
+
+/-- **The offset-`1` alternating binomial transform.**
+`∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ₊₁ = Fₙ₊₁ − Fₙ` (`= Fₙ₋₁`). -/
+theorem alt_fib_binom_transform_one (n : ℕ) :
+    ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * n.choose k * Nat.fib (k + 1)
+      = Nat.fib (n + 1) - Nat.fib n :=
+  (alt_fib_pair n).2
+
+end FibonacciIdentitiesOQ06OQ01OQ02

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-fiboq06oq01oq02-1",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 33
+    },
+    "type": "concept",
+    "title": "From the Plus-Signed to the Alternating Transform",
+    "content": "**Module framing.** The parent entry `fibonacci-identities-oq-06-oq-01` proves the *plus-signed* Fibonacci binomial transform $\\sum_{k=0}^{n}\\binom{n}{k}F_{m+k} = F_{2n+m}$, folding the sequence onto itself at a **doubled** index. This descendant supplies the *alternating* (falling) transform, where each weight carries the sign $(-1)^k$: $\\sum_{k=0}^{n}(-1)^k\\binom{n}{k}F_k = -F_n$. The index is now held **fixed** and the sequence is merely negated — the single sign flip converts the parent's index-doubling $n\\mapsto 2n$ into a pure cancellation.",
+    "mathContext": "$\\sum_{k=0}^{n}(-1)^k\\binom{n}{k}F_k = -F_n$, versus the parent's $\\sum_{k=0}^{n}\\binom{n}{k}F_k = F_{2n}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Alternating (falling) binomial transform",
+      "Conjugate-root identity 1 − φ = ψ",
+      "Index-fixed vs index-doubling summation identities",
+      "Parent plus-signed binomial transform (oq-06-oq-01)"
+    ],
+    "prerequisites": [
+      "The 0-indexed Fibonacci sequence Nat.fib",
+      "Binomial coefficients Nat.choose",
+      "The alternating weight (−1)ᵏ over ℤ"
+    ],
+    "tags": [
+      "module-header",
+      "framing",
+      "alternating-sum",
+      "binomial-transform",
+      "fibonacci"
+    ]
+  },
+  {
+    "id": "ann-fiboq06oq01oq02-2",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-02",
+    "range": {
+      "startLine": 48,
+      "endLine": 85
+    },
+    "type": "technique",
+    "title": "Signed Pascal Convolution: a Difference of Shifts",
+    "content": "**The reusable engine.** `signed_pascal_conv` proves, for *any* summand $f:\\mathbb{N}\\to\\mathbb{Z}$, that\n$$\\sum_{k=0}^{n+1}(-1)^k\\binom{n+1}{k}f(k) \\;=\\; \\sum_{k=0}^{n}(-1)^k\\binom{n}{k}f(k) \\;-\\; \\sum_{k=0}^{n}(-1)^k\\binom{n}{k}f(k+1).$$\nThe proof peels the $k=0$ term with `Finset.sum_range_succ'` (reindexing the tail by $k\\mapsto k+1$), applies Pascal's rule `Nat.choose_succ_succ'` together with the sign law $(-1)^{k+1}=-(-1)^k$, splits via `Finset.sum_sub_distrib`, and pulls the sign out with `Finset.sum_neg_distrib`. The leftover $\\binom{n}{k+1}$-weighted signed sum plus the peeled boundary term is reconciled with the first summand by peeling *its* $k=0$ term and dropping the vanishing top term $\\binom{n}{n+1}=0$ (`Nat.choose_succ_self`). The **only** structural difference from the parent's `pascal_conv` is a minus in place of a plus — and that minus is the entire source of the cancellation.",
+    "mathContext": "$\\sum_{k=0}^{n+1}(-1)^k\\binom{n+1}{k}f(k) = \\sum_{k=0}^{n}(-1)^k\\binom{n}{k}f(k) - \\sum_{k=0}^{n}(-1)^k\\binom{n}{k}f(k+1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1)",
+      "Range-peeling lemmas Finset.sum_range_succ / sum_range_succ'",
+      "Signed-sum bookkeeping (sum_sub_distrib, sum_neg_distrib)",
+      "Binomial transform of an arbitrary integer sequence"
+    ],
+    "prerequisites": [
+      "Pascal's rule Nat.choose_succ_succ' and the vanishing C(n,n+1)=0",
+      "The sign law (−1)^{k+1} = −(−1)^k"
+    ],
+    "tags": [
+      "signed-pascal-convolution",
+      "reusable-lemma",
+      "alternating-sum",
+      "finset-sum"
+    ]
+  },
+  {
+    "id": "ann-fiboq06oq01oq02-3",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-02",
+    "range": {
+      "startLine": 87,
+      "endLine": 116
+    },
+    "type": "technique",
+    "title": "A Joint Induction: the Two Offsets are Inseparable",
+    "content": "**Why a pair.** Neither $\\sum(-1)^k\\binom{n}{k}F_k = -F_n$ nor its offset-1 sibling proves itself by induction: `signed_pascal_conv` sends offset $0$ to a combination involving offset $1$, and offset $1$ to one involving offset $2$. But the offset-2 sum reduces back via $F_{k+2}=F_k+F_{k+1}$ (`Nat.fib_add_two`, `Finset.sum_add_distrib`): $U(n)=S(n)+T(n)$. So the pair $(S,T)=\\big(\\sum(-1)^k\\binom{n}{k}F_k,\\ \\sum(-1)^k\\binom{n}{k}F_{k+1}\\big)$ is self-reproducing, and `alt_fib_pair` proves $(S,T)=(-F_n,\\,F_{n+1}-F_n)$ by a single induction on $n$. The step computes $S(n{+}1)=S(n)-T(n)=-F_{n+1}$ and $T(n{+}1)=T(n)-U(n)=-S(n)=F_n$ — the loop invariant obeys the Fibonacci recurrence itself.",
+    "mathContext": "$\\big(\\sum (-1)^k\\binom{n}{k}F_k,\\ \\sum (-1)^k\\binom{n}{k}F_{k+1}\\big) = (-F_n,\\ F_{n+1}-F_n)$; step: $S_{n+1}=S_n-T_n,\\ T_{n+1}=-S_n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Mutually-dependent loop invariant",
+      "Proving a conjunction by joint induction",
+      "Linearity of the transform in the summand",
+      "The Fibonacci recurrence Nat.fib_add_two"
+    ],
+    "prerequisites": [
+      "signed_pascal_conv",
+      "Nat.fib_add_two and Finset.sum_add_distrib"
+    ],
+    "tags": [
+      "joint-induction",
+      "loop-invariant",
+      "fibonacci-recurrence",
+      "alternating-sum"
+    ]
+  },
+  {
+    "id": "ann-fiboq06oq01oq02-4",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-02",
+    "range": {
+      "startLine": 118,
+      "endLine": 127
+    },
+    "type": "key_step",
+    "title": "The Headline ∑ (−1)ᵏ C(n,k)·Fₖ = −Fₙ",
+    "content": "**The result.** `alt_fib_binom_transform_zero` and `alt_fib_binom_transform_one` are the two projections of `alt_fib_pair`: the alternating binomial transform of the Fibonacci sequence is its own negation, $\\sum_{k=0}^{n}(-1)^k\\binom{n}{k}F_k = -F_n$, and the offset-1 variant is $\\sum_{k=0}^{n}(-1)^k\\binom{n}{k}F_{k+1} = F_{n+1}-F_n$ (equal to $F_{n-1}$). This is the discrete image of $\\sum(-1)^k\\binom{n}{k}\\varphi^k = (1-\\varphi)^n = \\psi^n$, which Binet sends to $(\\psi^n-\\varphi^n)/\\sqrt5 = -F_n$.",
+    "mathContext": "$\\sum_{k=0}^{n}(-1)^k\\binom{n}{k}F_k = -F_n,\\qquad \\sum_{k=0}^{n}(-1)^k\\binom{n}{k}F_{k+1} = F_{n+1}-F_n = F_{n-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Binet formula and the conjugate root ψ",
+      "Alternating binomial theorem ∑(−1)ᵏC(n,k)xᵏ = (1−x)ⁿ",
+      "Fibonacci at fixed vs doubled index"
+    ],
+    "prerequisites": [
+      "alt_fib_pair (the joint invariant)"
+    ],
+    "tags": [
+      "headline-result",
+      "alternating-sum",
+      "fibonacci",
+      "binomial-transform"
+    ]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ06OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ06OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ06OQ01OQ02Data: ProofData = {
+  proof: fibonacciIdentitiesOQ06OQ01OQ02Proof,
+  annotations: fibonacciIdentitiesOQ06OQ01OQ02Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "fibonacci-identities-oq-06-oq-01-oq-02",
+  "title": "The Alternating Fibonacci Binomial Transform: ∑ (−1)ᵏ C(n,k)·Fₖ = −Fₙ",
+  "slug": "fibonacci-identities-oq-06-oq-01-oq-02",
+  "description": "The parent entry fibonacci-identities-oq-06-oq-01 established the ordinary Fibonacci binomial transform ∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ, whose plus-signed weights fold the sequence onto itself at a doubled index. This open-question descendant supplies the qualitatively different ALTERNATING (falling) binomial transform, where the weights carry the sign (−1)ᵏ: alt_fib_binom_transform_zero proves ∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ = −Fₙ, so the alternating transform of the Fibonacci sequence returns the same sequence negated, with the index held FIXED — the sign converts the parent's index-doubling n↦2n into a pure cancellation. This is the discrete shadow of the conjugate-root identity 1 − φ = ψ (ψ = (1−√5)/2): applying ∑ (−1)ᵏ C(n,k)(·)ᵏ to φ sends φ ↦ (1−φ)ⁿ = ψⁿ, so via Binet ∑ (−1)ᵏ C(n,k) Fₖ = (ψⁿ − φⁿ)/√5 = −Fₙ. The offset-1 companion alt_fib_binom_transform_one reads ∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ₊₁ = Fₙ₊₁ − Fₙ (= Fₙ₋₁). The engine is a signed Pascal convolution (signed_pascal_conv), the (−1)ᵏ analogue of the parent's pascal_conv, which splits a length-(n+2) signed binomial sum for n+1 into the DIFFERENCE of the two length-(n+1) signed binomial sums for n at consecutive offsets; the sign is exactly what turns the parent's + into a −. Because the offset-0 and offset-1 transforms feed each other through Fₖ₊₂ = Fₖ + Fₖ₊₁, they are proved together by a single joint induction on n (the pair (∑(−1)ᵏC(n,k)Fₖ, ∑(−1)ᵏC(n,k)Fₖ₊₁) = (−Fₙ, Fₙ₊₁−Fₙ) is the loop invariant). The proofs use 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (alternating binomial transform of Fibonacci; conjugate-root identity 1−φ=ψ); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binomial_transform",
+    "date": "1876",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "summation-identity",
+      "binomial-transform",
+      "binomial-coefficients",
+      "alternating-sum",
+      "integer-sequences",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_succ'",
+        "description": "choose (n+1) (k+1) = choose n k + choose n (k+1) — Pascal's rule (the (n+1)/(k+1)-shifted form); the algebraic heart of the signed_pascal_conv splitting lemma, summed against the alternating weight (−1)ᵏ",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_self",
+        "description": "choose n (n+1) = 0 — the coefficient just past the diagonal vanishes; lets the offset-1 reindexed sum over range (n+1) be truncated to range n in signed_pascal_conv",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the defining Fibonacci recurrence; the only Fibonacci-specific fact, used both to split the offset-2 sum into offset-0 + offset-1 and to contract the closed-form targets in the joint induction",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f (i+1)) + f 0 — peels the FIRST term and reindexes the rest by i ↦ i+1; used to expose the Pascal shift on the signed coefficient",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f i) + f n — peels the LAST term; used with choose_succ_self to drop the vanishing top term of the offset-1 signed sum",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_sub_distrib",
+        "description": "∑ (f i − g i) = (∑ f i) − (∑ g i) — splits the Pascal-distributed signed summand into two signed binomial sums; the subtraction (vs the parent's sum_add_distrib) is the sign's structural fingerprint",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_neg_distrib",
+        "description": "∑ (−f i) = −∑ f i — pulls the (−1)^{k+1} = −(−1)^k sign out of the reindexed signed sum so the residual terms align for the closing ring",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "signed_pascal_conv: ∀ (f : ℕ → ℤ) n, ∑_{k<n+2} (−1)ᵏ C(n+1,k)·f(k) = (∑_{k<n+1} (−1)ᵏ C(n,k)·f(k)) − ∑_{k<n+1} (−1)ᵏ C(n,k)·f(k+1) — the alternating (−1)ᵏ analogue of the parent's pascal_conv, splitting a signed binomial-weighted sum into the DIFFERENCE of two shifted lower-order signed sums; absent from Mathlib",
+      "alt_fib_binom_transform_zero: ∀ n, ∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ = −Fₙ — the headline: the alternating binomial transform of the Fibonacci sequence is its own negation, index held fixed (contrast the parent's index-doubling)",
+      "alt_fib_binom_transform_one: ∀ n, ∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ₊₁ = Fₙ₊₁ − Fₙ — the offset-1 companion (= Fₙ₋₁), the second component of the joint loop invariant"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 129,
+    "assumptions": "None. The proofs contain 0 axioms and 0 sorries and use only Mathlib's foundational propext/Classical.choice/Quot.sound (confirmed by #print axioms on signed_pascal_conv, alt_fib_binom_transform_zero and alt_fib_binom_transform_one); no decide on substantive results and no native_decide.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The binomial transform sends a sequence (aₖ) to (∑ₖ (±1)ᵏ C(n,k) aₖ). Its plus-signed form applied to the Fibonacci sequence yields the even-indexed subsequence F₂ₙ (the parent entry). Its alternating (falling) form — the classical inverse-type transform — instead reproduces the sequence up to sign: ∑ (−1)ᵏ C(n,k) Fₖ = −Fₙ. The two are the discrete shadows of the two golden-ratio roots: 1 + φ = φ² doubles the index, while 1 − φ = ψ (the conjugate root) fixes it. This descendant formalizes the alternating half, completing the ± pair opened by the parent's index-doubling transform.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-06-oq-01-oq-02)**: Establish the alternating/falling binomial transform ∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ, the qualitatively different signed counterpart of the parent's plus-signed index-doubling transform ∑ C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ.\n\n**Result**: alt_fib_binom_transform_zero (∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ = −Fₙ) and its offset-1 companion alt_fib_binom_transform_one (∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ₊₁ = Fₙ₊₁ − Fₙ), via a reusable signed Pascal-convolution lemma signed_pascal_conv and a single joint induction.",
+    "text": "Using Mathlib's 0-indexed Nat.fib (F₀ = 0, F₁ = 1), binomial coefficients Nat.choose, and the alternating weight (−1)ᵏ in ℤ: for all n, the signed binomial-weighted sum ∑_{k=0}^{n} (−1)ᵏ C(n,k)·Fₖ equals −Fₙ, and the offset-1 variant ∑_{k=0}^{n} (−1)ᵏ C(n,k)·Fₖ₊₁ equals Fₙ₊₁ − Fₙ (i.e. Fₙ₋₁). The alternating binomial transform therefore returns the Fibonacci sequence negated, with its index held fixed — where the plus-signed transform of the parent doubled it.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Signed Pascal convolution (`signed_pascal_conv`).** For an arbitrary summand f : ℕ → ℤ, prove ∑_{k<n+2} (−1)ᵏ C(n+1,k)·f(k) = (∑_{k<n+1} (−1)ᵏ C(n,k)·f(k)) − ∑_{k<n+1} (−1)ᵏ C(n,k)·f(k+1). Peel the k=0 term with Finset.sum_range_succ' (reindexing the tail by k ↦ k+1), apply Pascal's rule Nat.choose_succ_succ' together with (−1)^{k+1} = −(−1)^k, split with Finset.sum_sub_distrib and pull the sign out with Finset.sum_neg_distrib. The offset-1 sub-sum matches the target's second summand; the residual C(n,k+1)-weighted signed sum plus the peeled boundary term is reconciled with the first summand by peeling k=0 from it and dropping the vanishing top term C(n,n+1)=0 (Nat.choose_succ_self via Finset.sum_range_succ). A final ring closes the ℤ bookkeeping. The lone structural difference from the parent pascal_conv — a minus in place of a plus — is precisely the sign's fingerprint.\n\n2. **Joint induction (`alt_fib_pair`).** The offset-0 and offset-1 transforms cannot be proved separately: the inductive step for one produces the other. Prove the PAIR ∑(−1)ᵏC(n,k)Fₖ = −Fₙ ∧ ∑(−1)ᵏC(n,k)Fₖ₊₁ = Fₙ₊₁−Fₙ together by induction on n. The base n=0 is closed by simp. In the step, feed each transform through signed_pascal_conv: the offset-0 sum at n+1 becomes S(n) − T(n) = −Fₙ − (Fₙ₊₁−Fₙ) = −Fₙ₊₁; the offset-1 sum at n+1 becomes T(n) − U(n), where the offset-2 sum U(n) = ∑(−1)ᵏC(n,k)Fₖ₊₂ splits via Fₖ₊₂ = Fₖ + Fₖ₊₁ (Nat.fib_add_two, Finset.sum_add_distrib) back into S(n) + T(n), giving T(n) − (S(n)+T(n)) = −S(n) = Fₙ = Fₙ₊₂ − Fₙ₊₁. Each closes with push_cast and ring.\n\n3. **Headline corollaries.** alt_fib_binom_transform_zero and alt_fib_binom_transform_one are the two projections of alt_fib_pair.",
+    "keyInsights": [
+      "**The sign converts doubling into cancellation.** The parent's plus-signed transform advances the Fibonacci index by 1 at each of n induction steps, doubling it to 2n. The single structural change here — Pascal's rule summed against (−1)ᵏ produces a DIFFERENCE of shifted sums rather than a sum — makes those advances cancel, so the index returns to n (and the sequence picks up an overall minus). One sign flip in signed_pascal_conv is the entire mathematical content of the doubling-vs-fixed dichotomy.",
+      "**Discrete shadow of the conjugate root 1 − φ = ψ.** The plus-signed transform is the ℕ-image of ∑ C(n,k) φᵏ = (1+φ)ⁿ = φ²ⁿ (using 1+φ=φ²). The alternating transform is the image of ∑ (−1)ᵏ C(n,k) φᵏ = (1−φ)ⁿ = ψⁿ (using 1−φ=ψ, the OTHER golden-ratio root). Binet then gives (ψⁿ − φⁿ)/√5 = −Fₙ. The inductive proof formalizes this without ever leaving ℤ or invoking irrationals.",
+      "**The two offsets are inseparable — a joint invariant is forced.** Neither ∑(−1)ᵏC(n,k)Fₖ = −Fₙ nor its offset-1 sibling proves itself by induction: signed_pascal_conv sends offset 0 to a combination involving offset 1, and offset 1 to one involving offset 2, which the Fibonacci recurrence folds back to offsets 0 and 1. The closed 2-vector (−Fₙ, Fₙ₊₁−Fₙ) is the smallest self-reproducing loop invariant, and it satisfies exactly the Fibonacci recurrence itself.",
+      "**signed_pascal_conv is a reusable, Fibonacci-free splitting lemma.** Like the parent's pascal_conv it holds for an arbitrary ℤ-valued summand, so it computes the alternating binomial transform of ANY integer sequence — the difference-of-shifts structure is the signed analogue of Finset.sum_range_succ."
+    ],
+    "prerequisites": [
+      "The binomial coefficients Nat.choose and Pascal's rule Nat.choose_succ_succ'",
+      "The Fibonacci recurrence Nat.fib_add_two",
+      "Range-peeling of finite sums: Finset.sum_range_succ' (first term) and Finset.sum_range_succ (last term)",
+      "Signed-sum bookkeeping over ℤ: Finset.sum_sub_distrib and Finset.sum_neg_distrib",
+      "Proving a conjunction by a single joint induction (mutually-dependent loop invariant)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the alternating binomial transform ∑ (−1)ᵏ C(n,k)·Fₖ = −Fₙ as the signed, index-FIXED counterpart of the parent's plus-signed index-doubling transform, with the conjugate-root motivation 1−φ=ψ and an outline of the signed Pascal-convolution engine and the joint induction, plus the import and namespace setup (open Finset).",
+      "mathContext": "$\\sum_{k=0}^{n} (-1)^k \\binom{n}{k} F_k = -F_n$; the sign turns the parent's $n\\mapsto 2n$ into a fixed index."
+    },
+    {
+      "id": "signed_pascal_conv",
+      "title": "Signed Pascal Convolution (the Splitting Engine)",
+      "startLine": 48,
+      "endLine": 85,
+      "summary": "signed_pascal_conv: for any f : ℕ → ℤ, ∑_{k<n+2} (−1)ᵏ C(n+1,k)·f(k) = (∑_{k<n+1} (−1)ᵏ C(n,k)·f(k)) − ∑_{k<n+1} (−1)ᵏ C(n,k)·f(k+1). Peels the first term with Finset.sum_range_succ', applies Pascal's rule Nat.choose_succ_succ' with the sign (−1)^{k+1}=−(−1)^k, splits with Finset.sum_sub_distrib and Finset.sum_neg_distrib, then reconciles the residual against the first target summand by peeling its first term and dropping the vanishing top term C(n,n+1)=0 (Nat.choose_succ_self); closed by ring. The minus in place of the parent's plus is the sign's structural fingerprint.",
+      "mathContext": "$\\sum_{k=0}^{n+1}(-1)^k\\binom{n+1}{k}f(k) = \\sum_{k=0}^{n}(-1)^k\\binom{n}{k}f(k) - \\sum_{k=0}^{n}(-1)^k\\binom{n}{k}f(k+1)$."
+    },
+    {
+      "id": "alt_fib_pair",
+      "title": "The Joint Invariant (offsets 0 and 1 together)",
+      "startLine": 87,
+      "endLine": 116,
+      "summary": "alt_fib_pair: ∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ = −Fₙ AND ∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ₊₁ = Fₙ₊₁ − Fₙ, proved together by induction on n. The step feeds each transform through signed_pascal_conv; the offset-2 sum that appears is reduced back to the pair via Fₖ₊₂ = Fₖ + Fₖ₊₁ (Nat.fib_add_two, Finset.sum_add_distrib). Base case by simp; steps by push_cast and ring.",
+      "mathContext": "$\\big(\\sum (-1)^k\\binom{n}{k}F_k,\\ \\sum (-1)^k\\binom{n}{k}F_{k+1}\\big) = (-F_n,\\ F_{n+1}-F_n)$."
+    },
+    {
+      "id": "corollaries",
+      "title": "The Headline ∑ (−1)ᵏ C(n,k)·Fₖ = −Fₙ and its Offset-1 Companion",
+      "startLine": 118,
+      "endLine": 127,
+      "summary": "alt_fib_binom_transform_zero (∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ = −Fₙ) and alt_fib_binom_transform_one (∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ₊₁ = Fₙ₊₁ − Fₙ = Fₙ₋₁), the two projections of alt_fib_pair. The headline states that the alternating binomial transform of the Fibonacci sequence is its own negation.",
+      "mathContext": "$\\sum_{k=0}^{n}(-1)^k\\binom{n}{k}F_k = -F_n,\\qquad \\sum_{k=0}^{n}(-1)^k\\binom{n}{k}F_{k+1} = F_{n+1}-F_n."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-06-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry proves the plus-signed Fibonacci binomial transform ∑ C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ via a Pascal convolution pascal_conv, folding the sequence onto itself at a doubled index. This entry supplies the alternating counterpart ∑ (−1)ᵏ C(n,k)·Fₖ = −Fₙ via the signed analogue signed_pascal_conv; the single sign change turns the sum-of-shifts into a difference-of-shifts, converting index-doubling into a pure cancellation — completing the ± pair."
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "relatedTo",
+      "description": "The base FibonacciIdentities entry catalogues the pointwise/quadratic identities. The alternating binomial transform is a summation identity whose combinatorial weights carry a sign; its index-FIXED conclusion −Fₙ contrasts both the base entry's local recurrences and the doubling F₂ₙ of the plus-signed transform."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "relatedTo",
+      "description": "The identity is the Fibonacci image of the alternating binomial theorem ∑ (−1)ᵏ C(n,k)·xᵏ = (1−x)ⁿ specialized at the golden ratio x=φ: (1−φ)ⁿ = ψⁿ (since 1−φ=ψ, the conjugate root), which Binet turns into (ψⁿ−φⁿ)/√5 = −Fₙ. The Lean proof formalizes this over ℤ via the signed Pascal-rule convolution signed_pascal_conv."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New **verified, 0-axiom** gallery entry `fibonacci-identities-oq-06-oq-01-oq-02` answering the alternating/falling binomial-transform open question descended from the plus-signed parent `fibonacci-identities-oq-06-oq-01` (`∑ C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ`).

Where the parent's **plus-signed** transform folds the Fibonacci sequence onto itself at a **doubled** index, the **alternating** transform holds the index **fixed** and merely negates:

- `alt_fib_binom_transform_zero` — `∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ = −Fₙ` (headline)
- `alt_fib_binom_transform_one` — `∑_{k≤n} (−1)ᵏ C(n,k)·Fₖ₊₁ = Fₙ₊₁ − Fₙ` (`= Fₙ₋₁`)

A single sign flip is the entire mathematical content: it is the discrete shadow of the *conjugate* golden-ratio root `1 − φ = ψ` (the parent uses `1 + φ = φ²`), since `∑ (−1)ᵏ C(n,k) φᵏ = (1−φ)ⁿ = ψⁿ` and Binet gives `(ψⁿ − φⁿ)/√5 = −Fₙ`.

## Contributions (all absent from Mathlib)

- **`signed_pascal_conv`** — the `(−1)ᵏ` analogue of the parent's `pascal_conv`: for any `f : ℕ → ℤ`, splits a length-`(n+2)` signed binomial sum into the **difference** of two length-`(n+1)` signed sums at consecutive offsets. Reusable for the alternating binomial transform of *any* integer sequence.
- **`alt_fib_pair`** — the two offsets are inseparable (offset 0 → offset 1 → offset 2 → back), so they are proved together by one joint induction; the loop invariant `(−Fₙ, Fₙ₊₁−Fₙ)` itself obeys the Fibonacci recurrence.
- The two headline corollaries above.

## Verification

- `lake env lean` typechecks clean (built against the pinned Mathlib cache).
- `#print axioms` on `signed_pascal_conv`, `alt_fib_binom_transform_zero`, `alt_fib_binom_transform_one` → only `propext, Classical.choice, Quot.sound`.
- **0 sorries, 0 axioms, no `native_decide`.** `status: verified`, `badge: mathlib`.

## Files

- `proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean` (129 lines, 4 theorems)
- `src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/{meta,annotations,index}.{json,ts}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)