### PR TITLE
research(fibonacci-identities-oq-06-oq-01-oq-02): alternating Fibonacci binomial transform [VERIFIED, 0-axiom, +4thm]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean
@@ -1,0 +1,155 @@
+import Mathlib
+
+/-!
+# The alternating Fibonacci binomial transform — `∑ (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d`
+
+The parent entry `FibonacciIdentitiesOQ06OQ01` proves the **positive** binomial
+transform `∑_{k≤n} C(n,k)·Fₘ₊ₖ = F₂ₙ₊ₘ`, where the length-`(n+1)` Fibonacci
+window collapses to a single Fibonacci number at the *doubled* index `2n+m`.
+
+This descendant supplies the **alternating** (signed) binomial transform, the
+`x = −1` companion of that identity.  Over ℤ,
+
+* `signed_pascal_conv` — the signed analogue of the parent's `pascal_conv`:
+  for any `g : ℕ → ℤ`,
+  `∑_{k<n+2} (−1)ᵏ C(n+1,k) g(k) = ∑_{k<n+1} (−1)ᵏ C(n,k) g(k)
+     − ∑_{k<n+1} (−1)ᵏ C(n,k) g(k+1)`.
+  This is the finite-difference identity behind the whole transform: the
+  degree-`(n+1)` signed binomial sum equals the *difference* of two degree-`n`
+  signed binomial sums at consecutive offsets.
+
+* `fib_alt_binom_transform` — the headline.  For all `n, d`,
+  `∑_{k≤n} (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d`.
+  Applying `signed_pascal_conv` with `g(k) = F₍ₘ₊ₖ₎` turns the recurrence into
+  `T(n+1,m) = T(n,m) − T(n,m+1)`, and the Fibonacci recurrence
+  `F_{a+1} = F_a + F_{a−1}` collapses `F_{d+1} − F_{d+2} = −F_d`, giving the
+  `(−1)ⁿ F_d` closed form with no negative-index Fibonacci.
+
+* `fib_alt_binom_transform_eq` — the same identity in the offset form
+  `∑_{k≤n} (−1)ᵏ C(n,k) F₍ₘ₊ₖ₎ = (−1)ⁿ F₍ₘ₋ₙ₎` for `n ≤ m`.
+
+This is the discrete shadow of `1 − φ = ψ` (with `φψ = −1`): applying
+`∑ C(n,k)(−1)ᵏ(·)ᵏ` to `φᵐ` sends `φᵐ ↦ φᵐ(1−φ)ⁿ = φᵐψⁿ = (−1)ⁿ φᵐ⁻ⁿ`.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace FibonacciIdentitiesOQ06OQ01OQ02
+
+open Finset
+
+/-- **Signed Pascal convolution over ℤ.**  The degree-`(n+1)` alternating
+binomial sum of `g` equals the difference of the two degree-`n` alternating
+binomial sums of `g` at offsets `0` and `1`.  This is the signed analogue of the
+parent entry's `pascal_conv`. -/
+theorem signed_pascal_conv (g : ℕ → ℤ) (n : ℕ) :
+    ∑ k ∈ range (n + 2), (-1 : ℤ) ^ k * ((n + 1).choose k : ℤ) * g k
+      = (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) * g k)
+        - ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) * g (k + 1) := by
+  -- Peel the `k = 0` term off the left sum and reindex the rest by `k ↦ k+1`.
+  rw [Finset.sum_range_succ' (fun k => (-1 : ℤ) ^ k * ((n + 1).choose k : ℤ) * g k) (n + 1)]
+  -- Pascal's rule `C(n+1,k+1) = C(n,k) + C(n,k+1)` on each reindexed coefficient.
+  have hpascal : ∀ k, ((n + 1).choose (k + 1) : ℤ)
+      = (n.choose k : ℤ) + (n.choose (k + 1) : ℤ) := by
+    intro k; rw [Nat.choose_succ_succ' n k]; push_cast; ring
+  -- Split the reindexed sum into the two Pascal pieces.
+  have hsplit : (∑ k ∈ range (n + 1),
+        (-1 : ℤ) ^ (k + 1) * ((n + 1).choose (k + 1) : ℤ) * g (k + 1))
+      = (-(∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) * g (k + 1)))
+        + (-(∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose (k + 1) : ℤ) * g (k + 1))) := by
+    rw [← Finset.sum_neg_distrib, ← Finset.sum_neg_distrib, ← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro k _
+    rw [hpascal, pow_succ]
+    ring
+  rw [hsplit]
+  -- The `C(n,k+1)·g(k+1)` sum telescopes against `∑ C(n,k)·g(k)`: reindex it and
+  -- match the `k = 0` boundary term `g 0`.
+  have htele : (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) * g k)
+      = (-(∑ k ∈ range n, (-1 : ℤ) ^ k * (n.choose (k + 1) : ℤ) * g (k + 1)))
+        + ((-1 : ℤ) ^ 0 * (n.choose 0 : ℤ) * g 0) := by
+    rw [Finset.sum_range_succ' (fun k => (-1 : ℤ) ^ k * (n.choose k : ℤ) * g k) n]
+    congr 1
+    rw [← Finset.sum_neg_distrib]
+    apply Finset.sum_congr rfl
+    intro k _
+    rw [pow_succ]
+    ring
+  -- The `C(n,k+1)·g(k+1)` sum over `range (n+1)` loses its top term `C(n,n+1)=0`.
+  have hdrop : (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose (k + 1) : ℤ) * g (k + 1))
+      = ∑ k ∈ range n, (-1 : ℤ) ^ k * (n.choose (k + 1) : ℤ) * g (k + 1) := by
+    rw [Finset.sum_range_succ]
+    simp [Nat.choose_succ_self]
+  rw [hdrop, htele]
+  simp only [pow_zero, Nat.choose_zero_right, Nat.cast_one, one_mul, mul_one]
+  ring
+
+/-- **The alternating Fibonacci binomial transform.**  For all `n, d`,
+`∑_{k≤n} (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d`.
+
+Proved by induction on `n` with `d` universally quantified.  The step rewrites
+the degree-`(n+1)` signed binomial sum via `signed_pascal_conv` into the two
+degree-`n` sums at offsets `m = (n+1)+d` and `m+1`, applies the induction
+hypothesis to each, and contracts with the Fibonacci recurrence
+`F_{d+1} − F_{d+2} = −F_d`. -/
+theorem fib_alt_binom_transform (n d : ℕ) :
+    ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) * (Nat.fib (n + d + k) : ℤ)
+      = (-1 : ℤ) ^ n * (Nat.fib d : ℤ) := by
+  induction n generalizing d with
+  | zero => simp
+  | succ p ih =>
+    -- Apply the signed convolution with `g k = F₍ₘ₊ₖ₎`, `m = (p+1) + d`.
+    have hconv := signed_pascal_conv (fun k => (Nat.fib ((p + 1) + d + k) : ℤ)) p
+    -- Rewrite the LHS index `(p+1)+d+k` to match `g` at offset `m = (p+1)+d`.
+    have hlhs : (∑ k ∈ range (p + 1 + 1),
+          (-1 : ℤ) ^ k * ((p + 1).choose k : ℤ) * (Nat.fib ((p + 1) + d + k) : ℤ))
+        = ∑ k ∈ range (p + 2),
+          (-1 : ℤ) ^ k * ((p + 1).choose k : ℤ) * (Nat.fib ((p + 1) + d + k) : ℤ) := by
+      norm_num
+    rw [hlhs, hconv]
+    -- First degree-`p` sum: offset `m = (p+1)+d`; its index is `p + (d+1) + k`.
+    have hA : (∑ k ∈ range (p + 1),
+          (-1 : ℤ) ^ k * (p.choose k : ℤ) * (Nat.fib ((p + 1) + d + k) : ℤ))
+        = (-1 : ℤ) ^ p * (Nat.fib (d + 1) : ℤ) := by
+      have := ih (d + 1)
+      rw [← this]
+      apply Finset.sum_congr rfl
+      intro k _
+      congr 3
+      omega
+    -- Second degree-`p` sum: offset `m+1`; its index is `p + (d+2) + k`.
+    have hB : (∑ k ∈ range (p + 1),
+          (-1 : ℤ) ^ k * (p.choose k : ℤ) * (Nat.fib ((p + 1) + d + (k + 1)) : ℤ))
+        = (-1 : ℤ) ^ p * (Nat.fib (d + 2) : ℤ) := by
+      have := ih (d + 2)
+      rw [← this]
+      apply Finset.sum_congr rfl
+      intro k _
+      congr 3
+      omega
+    rw [hA, hB]
+    -- Contract: (−1)ᵖ F_{d+1} − (−1)ᵖ F_{d+2} = (−1)^{p+1} F_d.
+    have hfib : (Nat.fib (d + 2) : ℤ) = (Nat.fib d : ℤ) + (Nat.fib (d + 1) : ℤ) := by
+      rw [Nat.fib_add_two]; push_cast; ring
+    rw [hfib, pow_succ]
+    ring
+
+/-- Offset form: for `n ≤ m`,
+`∑_{k≤n} (−1)ᵏ C(n,k) F₍ₘ₊ₖ₎ = (−1)ⁿ F₍ₘ₋ₙ₎`. -/
+theorem fib_alt_binom_transform_eq (n m : ℕ) (h : n ≤ m) :
+    ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) * (Nat.fib (m + k) : ℤ)
+      = (-1 : ℤ) ^ n * (Nat.fib (m - n) : ℤ) := by
+  have key := fib_alt_binom_transform n (m - n)
+  have hmn : n + (m - n) = m := by omega
+  rw [hmn] at key
+  exact key
+
+/-- Headline `d = 0` case: `∑_{k≤n} (−1)ᵏ C(n,k) Fₙ₊ₖ = 0` for `n ≥ 1`
+(and `= 1` at `n = 0`), since `F₀ = 0`. -/
+theorem fib_alt_binom_transform_zero (n : ℕ) :
+    ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) * (Nat.fib (n + k) : ℤ)
+      = (-1 : ℤ) ^ n * (Nat.fib 0 : ℤ) := by
+  have h := fib_alt_binom_transform n 0
+  simpa using h
+
+end FibonacciIdentitiesOQ06OQ01OQ02

--- a/research/problems/fibonacci-identities-oq-06-oq-01-oq-02/knowledge.md
+++ b/research/problems/fibonacci-identities-oq-06-oq-01-oq-02/knowledge.md
@@ -1,0 +1,62 @@
+# Knowledge — fibonacci-identities-oq-06-oq-01-oq-02
+
+## S1 (researcher-2, 2026-07-01) — SOLVED, VERIFIED 0-axiom
+
+**Question**: Establish the falling/alternating Fibonacci binomial transform
+`∑_{k≤n} (−1)ᵏ C(n,k) Fₘ₊ₖ` (the parent proves the positive transform
+`∑ C(n,k) Fₘ₊ₖ = F₂ₙ₊ₘ`).
+
+**Outcome**: SOLVED. New file
+`proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean` (155 lines, 4 theorems,
+0 defs, 0 sorries, 0 axioms — `#print axioms` on all core theorems lists only
+`propext / Classical.choice / Quot.sound`).
+
+### Closed form
+
+`∑_{k≤n} (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d`  (all n, d)
+equivalently `∑_{k≤n} (−1)ᵏ C(n,k) F₍ₘ₊ₖ₎ = (−1)ⁿ F₍ₘ₋ₙ₎` for n ≤ m.
+
+Verified numerically for n,d ∈ 0..7 before formalizing.
+
+### Deliverable
+
+| Theorem | Statement |
+|---|---|
+| `signed_pascal_conv` | `∑_{<n+2}(−1)ᵏC(n+1,k)g k = ∑_{<n+1}(−1)ᵏC(n,k)g k − ∑_{<n+1}(−1)ᵏC(n,k)g(k+1)` (any g:ℕ→ℤ) |
+| `fib_alt_binom_transform` | **headline**: `∑(−1)ᵏC(n,k)F₍ₙ₊d₊ₖ₎ = (−1)ⁿF_d` |
+| `fib_alt_binom_transform_eq` | offset form for n≤m |
+| `fib_alt_binom_transform_zero` | d=0 boundary case |
+
+### Proof recipe (reusable)
+
+1. **signed_pascal_conv** = sign-carrying analogue of parent's `pascal_conv`.
+   Peel k=0 with `Finset.sum_range_succ'`, reindex k↦k+1; Pascal
+   `Nat.choose_succ_succ' n k` (cast via `push_cast`); the `C(n,k+1)·g(k+1)`
+   piece telescopes — its top term drops by `Nat.choose_succ_self` and the
+   reindexed sum matches the boundary `g 0`; `ring` closes.
+   GOTCHA: after `sum_range_succ'` the reindexed coefficient is already
+   `n.choose (k+1)` — do NOT apply Pascal there, just `rw [pow_succ]; ring`
+   for `(−1)^{k+1} = −(−1)^k`.
+2. **Closed form**: induct on n *generalizing d*. Apply signed_pascal_conv with
+   g(k)=F₍ₘ₊ₖ₎ → recurrence `T(n+1,m)=T(n,m)−T(n,m+1)`. Reindex the two degree-n
+   sums (`Finset.sum_congr rfl; congr 3; omega`) to hit `ih (d+1)` and `ih (d+2)`;
+   contract with `Nat.fib_add_two` (F_{d+2}=F_d+F_{d+1}) + `pow_succ`, `ring`.
+   KEY: parametrize the shift as **d** (index `n+d+k`), NOT the endpoint m —
+   keeps everything in ℕ, avoids negative-index Fibonacci, and lets the IH be
+   instantiated at d+1, d+2 with no subtraction.
+
+### Relation to prior art (not a duplicate)
+
+Parent `fibonacci-identities-oq-06-oq-01` proves only the POSITIVE transform
+(`pascal_conv`, `fib_binom_transform`). Grep of the OQ06 family for
+`neg_one`/`alternating`/`falling` returned nothing — the signed transform was
+genuinely absent. Discrete shadow of `1−φ=ψ`, `φψ=−1` (parent: `1+φ=φ²`).
+
+### Follow-up questions
+
+Slug depth = 3 (`-oq-06-oq-01-oq-02`) → per depth guard, **0** follow-ups.
+
+### Verification
+
+`lake env lean Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean` → RC=0, no
+diagnostics (imports only Mathlib; no Docker). Axiom-free.

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/annotations.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": "ann-oq060102-signed-pascal",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-02",
+    "range": {
+      "startLine": 45,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "Signed Pascal Convolution over ℤ",
+    "content": "signed_pascal_conv is the sign-carrying analogue of the parent entry's pascal_conv, and the engine of the whole transform. For any g : ℕ → ℤ it rewrites the degree-(n+1) alternating binomial sum ∑ (−1)ᵏ C(n+1,k) g(k) as the difference of two degree-n alternating binomial sums, of g and of g(·+1). The proof peels the k=0 term with Finset.sum_range_succ' and reindexes by k ↦ k+1, applies Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1) (cast to ℤ via push_cast), and closes a telescoping cancellation — the C(n,k+1)·g(k+1) piece, whose top term vanishes by Nat.choose_succ_self, matches the boundary value g(0) — with ring. This is exactly one step of the finite-difference operator.",
+    "mathContext": "$\\sum_{k<n+2} (-1)^k \\binom{n+1}{k} g_k = \\sum_{k<n+1} (-1)^k \\binom{n}{k} g_k - \\sum_{k<n+1} (-1)^k \\binom{n}{k} g_{k+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.choose_succ_succ'",
+      "Nat.choose_succ_self",
+      "Finset.sum_range_succ'",
+      "finite differences",
+      "pascal_conv"
+    ],
+    "prerequisites": [
+      "Pascal's rule",
+      "reindexing finite sums",
+      "telescoping"
+    ]
+  },
+  {
+    "id": "ann-oq060102-transform",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-02",
+    "range": {
+      "startLine": 95,
+      "endLine": 137
+    },
+    "type": "theorem",
+    "title": "The Alternating Fibonacci Binomial Transform (Headline)",
+    "content": "fib_alt_binom_transform proves ∑_{k≤n} (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d for all n and d. The proof is induction on n with d universally quantified. The step applies signed_pascal_conv with g(k) = F₍₍ₙ₊₁₎₊d₊ₖ₎, turning the recurrence into T(n+1,m) = T(n,m) − T(n,m+1); reindexing the two degree-n sums (Finset.sum_congr + omega on indices) matches the induction hypothesis at shifts d+1 and d+2; substituting them gives (−1)ⁿ F_{d+1} − (−1)ⁿ F_{d+2}, contracted to (−1)^{n+1} F_d via the Fibonacci recurrence F_{d+2} = F_d + F_{d+1} (Nat.fib_add_two). Parametrizing the shift as d (index n+d+k) rather than the endpoint m keeps everything in ℕ — no negative-index Fibonacci.",
+    "mathContext": "$\\sum_{k=0}^n (-1)^k \\binom{n}{k} F_{n+d+k} = (-1)^n F_d$; the discrete shadow of $1-\\varphi=\\psi$ with $\\varphi\\psi=-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.fib_add_two",
+      "binomial transform",
+      "golden ratio conjugate",
+      "induction generalizing"
+    ],
+    "prerequisites": [
+      "signed Pascal convolution",
+      "Fibonacci recurrence",
+      "induction with a universally quantified parameter"
+    ]
+  },
+  {
+    "id": "ann-oq060102-offset",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-02",
+    "range": {
+      "startLine": 139,
+      "endLine": 155
+    },
+    "type": "theorem",
+    "title": "Offset and Boundary Forms",
+    "content": "fib_alt_binom_transform_eq restates the identity in the classical offset form ∑_{k≤n} (−1)ᵏ C(n,k) F₍ₘ₊ₖ₎ = (−1)ⁿ F₍ₘ₋ₙ₎ for n ≤ m, obtained by substituting d = m − n (valid by omega). fib_alt_binom_transform_zero is the d = 0 boundary case: since F₀ = 0, the alternating transform of the window starting at index n vanishes (for n ≥ 1), the signed counterpart of the parent's ∑ C(n,k) Fₖ = F₂ₙ.",
+    "mathContext": "$n \\le m \\implies \\sum_{k=0}^n (-1)^k \\binom{n}{k} F_{m+k} = (-1)^n F_{m-n}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "index substitution",
+      "F₀ = 0"
+    ],
+    "prerequisites": [
+      "natural-number subtraction under a bound"
+    ]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/meta.json
@@ -1,0 +1,122 @@
+{
+  "id": "fibonacci-identities-oq-06-oq-01-oq-02",
+  "title": "The Alternating Fibonacci Binomial Transform: ∑ (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d",
+  "slug": "fibonacci-identities-oq-06-oq-01-oq-02",
+  "description": "The signed (alternating) companion of the Fibonacci binomial transform. Where the parent proves ∑ C(n,k) Fₘ₊ₖ = F₂ₙ₊ₘ, this proves ∑ (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d, via a signed Pascal convolution over ℤ and induction. Fully machine-checked, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binomial_transform",
+    "date": "Classical result, formalized 2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "binomial-transform",
+      "alternating-sum",
+      "finite-differences",
+      "combinatorial-identity",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. Every theorem's `#print axioms` lists only the standard foundational axioms propext / Classical.choice / Quot.sound; no native_decide, no Lean.ofReduceBool. Fully machine-checked.",
+    "originalContributions": [
+      "signed_pascal_conv (g : ℕ → ℤ) (n : ℕ): the signed analogue of the parent's pascal_conv — ∑_{k<n+2} (−1)ᵏ C(n+1,k) g(k) = ∑_{k<n+1} (−1)ᵏ C(n,k) g(k) − ∑_{k<n+1} (−1)ᵏ C(n,k) g(k+1); the finite-difference identity behind the transform",
+      "fib_alt_binom_transform (n d : ℕ): the headline — ∑_{k≤n} (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d, proved by induction on n with d universally quantified",
+      "fib_alt_binom_transform_eq (n m : ℕ) (n ≤ m): the offset form ∑_{k≤n} (−1)ᵏ C(n,k) F₍ₘ₊ₖ₎ = (−1)ⁿ F₍ₘ₋ₙ₎",
+      "fib_alt_binom_transform_zero: the d = 0 boundary case (the alternating transform of the shifted window vanishes for n ≥ 1 since F₀ = 0)"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 155,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The binomial transform sends a sequence (aₖ) to (∑ C(n,k) aₖ); its alternating variant uses the signed weights (−1)ᵏ C(n,k) and is the n-th finite difference up to sign. For the Fibonacci sequence the positive transform doubles the index — ∑ C(n,k) Fₖ = F₂ₙ, the discrete shadow of 1 + φ = φ² — because applying ∑ C(n,k)(·)ᵏ to the golden ratio φ sends φ ↦ (1+φ)ⁿ = φ²ⁿ. The alternating transform is the x = −1 companion: applying ∑ C(n,k)(−1)ᵏ(·)ᵏ to φ sends φ ↦ (1−φ)ⁿ = ψⁿ, where ψ = (1−√5)/2 is the conjugate root and φψ = −1. Because ψ = −1/φ, the resulting φᵐψⁿ = (−1)ⁿφᵐ⁻ⁿ, and the √5-normalized Binet combination collapses to (−1)ⁿ F₍ₘ₋ₙ₎. The parent entry formalized the positive transform; this entry supplies its signed dual entirely within ℤ, avoiding negative-index Fibonacci by parametrizing the shift as d = m − n ≥ 0.",
+    "problemStatement": "**Open Question (OQ-02 from fibonacci-identities-oq-06-oq-01)**: The parent proves the positive Fibonacci binomial transform ∑_{k≤n} C(n,k) Fₘ₊ₖ = F₂ₙ₊ₘ. Establish the falling/alternating binomial transform — the signed sum ∑_{k≤n} (−1)ᵏ C(n,k) Fₘ₊ₖ — and identify its closed form.\n\n**Answer**: ∑_{k≤n} (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d (equivalently ∑_{k≤n} (−1)ᵏ C(n,k) F₍ₘ₊ₖ₎ = (−1)ⁿ F₍ₘ₋ₙ₎ for n ≤ m).",
+    "text": "A 155-line, 4-theorem, 0-sorry, 0-axiom formalization over ℤ. The engine signed_pascal_conv mirrors the parent's pascal_conv with alternating signs, expressing the degree-(n+1) signed binomial sum as the difference of two degree-n signed sums at consecutive offsets. Specializing to g(k) = F₍ₘ₊ₖ₎ yields the recurrence T(n+1,m) = T(n,m) − T(n,m+1); induction on n with the shift d universally quantified, closed by the Fibonacci recurrence F_{d+2} = F_d + F_{d+1}, gives the (−1)ⁿ F_d closed form.",
+    "proofStrategy": "**signed_pascal_conv.** Peel the k = 0 term of the degree-(n+1) sum with Finset.sum_range_succ' and reindex by k ↦ k+1; apply Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1) (Nat.choose_succ_succ', cast to ℤ by push_cast) to split into two pieces; the C(n,k+1)·g(k+1) piece telescopes against ∑ C(n,k)·g(k) — reindexing it (its top term C(n,n+1) = 0 drops by Nat.choose_succ_self) matches the boundary value g(0), which ring discharges.\n\n**fib_alt_binom_transform.** Induction on n, generalizing d. Base n = 0 is simp. Step: rewrite the degree-(p+1) sum via signed_pascal_conv with g(k) = F₍₍ₚ₊₁₎₊d₊ₖ₎; reindex the two resulting degree-p sums to match the induction hypothesis at shifts d+1 and d+2 (Finset.sum_congr + omega on the indices); substitute ih (d+1) and ih (d+2), and contract (−1)ᵖ F_{d+1} − (−1)ᵖ F_{d+2} = (−1)^{p+1} F_d using F_{d+2} = F_d + F_{d+1} (Nat.fib_add_two) and pow_succ, closed by ring.\n\n**Offset / zero forms.** fib_alt_binom_transform_eq substitutes d = m − n (valid since n ≤ m by omega); fib_alt_binom_transform_zero is the d = 0 instance.",
+    "keyInsights": [
+      "**Alternating transform = signed finite difference**: the weights (−1)ᵏ C(n,k) are the n-th forward-difference coefficients, so the identity is really Δⁿ applied to the Fibonacci window; the recurrence T(n+1,m) = T(n,m) − T(n,m+1) is exactly one difference step.",
+      "**Parametrize the shift, not the endpoint**: stating the closed form as (−1)ⁿ F_d with index n + d + k (rather than F₍ₘ₋ₙ₎ with m − n) keeps everything in ℕ and lets the induction hypothesis be instantiated at d+1 and d+2 with no subtraction, avoiding negative-index Fibonacci entirely.",
+      "**The signed Pascal convolution is a reusable primitive**: signed_pascal_conv holds for any g : ℕ → ℤ, so it drives the alternating binomial transform of any integer sequence — the Fibonacci recurrence only enters at the very last contraction step.",
+      "**Discrete shadow of φψ = −1**: where the positive transform reflects 1 + φ = φ², the alternating one reflects 1 − φ = ψ together with ψ = −1/φ, which is precisely why the index falls by n and picks up the sign (−1)ⁿ."
+    ],
+    "prerequisites": [
+      "Parent entry fibonacci-identities-oq-06-oq-01 (the positive binomial transform and pascal_conv)",
+      "Nat.fib and the recurrence Nat.fib_add_two",
+      "Pascal's rule Nat.choose_succ_succ' and Nat.choose_succ_self",
+      "Finset.sum_range_succ' / Finset.sum_range_succ for peeling and reindexing sums",
+      "Binomial transform and finite-difference operators"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-06-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the positive binomial transform ∑ C(n,k) Fₘ₊ₖ = F₂ₙ₊ₘ via pascal_conv; this entry is its alternating (signed) companion, with signed_pascal_conv the sign-carrying analogue of pascal_conv."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-06",
+      "relationship": "related",
+      "description": "The grandparent records the elementary linear Fibonacci summation identities; the binomial transforms are the nonlinear, self-referential weightings that fold the sequence back onto a shifted index."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "FibonacciIdentitiesOQ06OQ01OQ02",
+    "lineCount": 155,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring stating the alternating binomial transform, the golden-ratio motivation (1 − φ = ψ, φψ = −1), imports (Mathlib), namespace, and open Finset."
+    },
+    {
+      "id": "sec-signed-pascal",
+      "title": "Signed Pascal Convolution",
+      "startLine": 45,
+      "endLine": 94,
+      "summary": "signed_pascal_conv: for any g : ℕ → ℤ, the degree-(n+1) alternating binomial sum equals the difference of the two degree-n alternating binomial sums at offsets 0 and 1. Proved by peel + reindex (sum_range_succ'), Pascal's rule, and a telescoping cancellation closed by ring.",
+      "mathContext": "$\\sum_{k<n+2} (-1)^k \\binom{n+1}{k} g_k = \\sum_{k<n+1} (-1)^k \\binom{n}{k} g_k - \\sum_{k<n+1} (-1)^k \\binom{n}{k} g_{k+1}$."
+    },
+    {
+      "id": "sec-transform",
+      "title": "The Alternating Fibonacci Binomial Transform",
+      "startLine": 95,
+      "endLine": 138,
+      "summary": "fib_alt_binom_transform: ∑_{k≤n} (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d, by induction on n (d universally quantified). The step applies signed_pascal_conv, reindexes to the IH at d+1 and d+2, and contracts via Nat.fib_add_two.",
+      "mathContext": "$\\sum_{k=0}^n (-1)^k \\binom{n}{k} F_{n+d+k} = (-1)^n F_d$."
+    },
+    {
+      "id": "sec-corollaries",
+      "title": "Offset and Boundary Forms",
+      "startLine": 139,
+      "endLine": 155,
+      "summary": "fib_alt_binom_transform_eq (the n ≤ m offset form ∑ (−1)ᵏ C(n,k) F₍ₘ₊ₖ₎ = (−1)ⁿ F₍ₘ₋ₙ₎) and fib_alt_binom_transform_zero (the d = 0 boundary case).",
+      "mathContext": "$n \\le m \\implies \\sum_{k=0}^n (-1)^k \\binom{n}{k} F_{m+k} = (-1)^n F_{m-n}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes the alternating (signed) Fibonacci binomial transform ∑_{k≤n} (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d, the x = −1 companion of the parent's positive transform ∑ C(n,k) Fₘ₊ₖ = F₂ₙ₊ₘ. The reusable primitive signed_pascal_conv (a signed Pascal convolution over ℤ) drives the induction; the Fibonacci recurrence enters only at the final contraction. 4 theorems, 0 sorries, 0 axioms.",
+    "implications": "Together the two entries realize both the positive and alternating binomial transforms of the Fibonacci sequence as machine-checked identities, mirroring the two golden-ratio facts 1 + φ = φ² and 1 − φ = ψ. signed_pascal_conv is stated for an arbitrary integer sequence and so is immediately reusable for the alternating binomial transform of any g : ℕ → ℤ — the general finite-difference machinery, not just its Fibonacci instance.",
+    "openQuestions": []
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/fibonacci-identities-oq-06-oq-01-oq-02.json
+++ b/src/data/research/problems/fibonacci-identities-oq-06-oq-01-oq-02.json
@@ -1,0 +1,83 @@
+{
+  "slug": "fibonacci-identities-oq-06-oq-01-oq-02",
+  "title": "The alternating Fibonacci binomial transform ∑ (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "∀ n d : ℕ, ∑ k ∈ Finset.range (n+1), (-1:ℤ)^k * (n.choose k) * (Nat.fib (n+d+k)) = (-1:ℤ)^n * (Nat.fib d)",
+    "plain": "The signed (alternating) binomial transform of the Fibonacci sequence: with weights (−1)ᵏ C(n,k) the window collapses to a single Fibonacci value at a decreased index, with sign (−1)ⁿ.",
+    "whyMatters": [
+      "Completes the pair of Fibonacci binomial transforms (positive + alternating)",
+      "The signed Pascal convolution primitive is reusable for any integer sequence"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "signed_pascal_conv: signed analogue of the parent's pascal_conv over ℤ",
+      "fib_alt_binom_transform: ∑ (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d",
+      "fib_alt_binom_transform_eq / _zero: offset and boundary forms"
+    ],
+    "open": [],
+    "goal": "Establish the alternating Fibonacci binomial transform and its closed form."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-01T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Solved in one session.",
+    "blockers": [],
+    "nextAction": "None — verified 0-axiom, 0-sorry.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (VERIFIED, 0-axiom, 0-sorry). FibonacciIdentitiesOQ06OQ01OQ02.lean (155 lines, 4 theorems): the alternating binomial transform ∑ (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d, via a signed Pascal convolution over ℤ (signed_pascal_conv) and induction generalizing the shift d.",
+    "builtItems": [
+      "signed_pascal_conv (reusable, any g:ℕ→ℤ)",
+      "fib_alt_binom_transform (headline)",
+      "fib_alt_binom_transform_eq, fib_alt_binom_transform_zero"
+    ],
+    "insights": [
+      "Parametrize the shift as d (index n+d+k) not the endpoint m: keeps everything in ℕ, avoids negative-index Fibonacci, IH usable at d+1 and d+2",
+      "signed_pascal_conv gives the recurrence T(n+1,m)=T(n,m)−T(n,m+1); Fibonacci recurrence only enters at the final contraction",
+      "After sum_range_succ' the reindexed coefficient is already n.choose(k+1) — do not reapply Pascal there"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "fibonacci",
+    "binomial-transform",
+    "alternating-sum",
+    "finite-differences",
+    "combinatorial-identity"
+  ],
+  "relatedProofs": [
+    "fibonacci-identities-oq-06-oq-01",
+    "fibonacci-identities-oq-06"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Binomial_transform"
+    ],
+    "mathlib": [
+      "Nat.fib_add_two",
+      "Nat.choose_succ_succ'",
+      "Nat.choose_succ_self",
+      "Finset.sum_range_succ'"
+    ]
+  },
+  "started": "2026-07-01T00:00:00.000Z",
+  "lastUpdate": "2026-07-01T00:00:00.000Z",
+  "significance": 5,
+  "tractability": 7,
+  "leanFiles": [
+    "Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean"
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **signed (alternating) Fibonacci binomial transform**, the `x = −1` companion of the parent's positive transform `∑ C(n,k) Fₘ₊ₖ = F₂ₙ₊ₘ`. Answers open question `fibonacci-identities-oq-06-oq-01-oq-02` (the falling/alternating binomial transform).

## New file

`proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean` — 155 lines, **4 theorems, 0 defs, 0 sorries, 0 axioms**.

| Theorem | Statement |
|---|---|
| `fib_alt_binom_transform` (headline) | `∑_{k≤n} (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d` |
| `fib_alt_binom_transform_eq` | offset form `∑ (−1)ᵏ C(n,k) F₍ₘ₊ₖ₎ = (−1)ⁿ F₍ₘ₋ₙ₎` for `n ≤ m` |
| `signed_pascal_conv` | reusable signed Pascal convolution over ℤ (any `g : ℕ → ℤ`) |
| `fib_alt_binom_transform_zero` | `d = 0` boundary case |

## Method

`signed_pascal_conv` (the sign-carrying analogue of the parent's `pascal_conv`) gives the recurrence `T(n+1,m) = T(n,m) − T(n,m+1)`. Induction on `n` **generalizing the shift `d`** (index `n+d+k`, staying in ℕ — no negative-index Fibonacci) closes with the Fibonacci recurrence `F_{d+2} = F_d + F_{d+1}`. This is the discrete shadow of `1 − φ = ψ` with `φψ = −1` (parent: `1 + φ = φ²`).

## Why this is not a duplicate

The parent `fibonacci-identities-oq-06-oq-01` proves only the **positive** transform (`pascal_conv`, `fib_binom_transform`). A grep of the whole OQ06 family for `neg_one` / `alternating` / `falling` finds nothing — the signed transform was genuinely absent. The identity was checked numerically for `n,d ∈ 0..7` before formalizing.

## Verification

`lake env lean Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean` → RC=0, no diagnostics (imports only `Mathlib`, no Docker needed). `#print axioms` on all core theorems lists only `propext / Classical.choice / Quot.sound` — no `native_decide`, no `Lean.ofReduceBool`.

## Gallery

Adds `src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/{meta.json,annotations.json}` (status `verified`, badge `verified`), the research tracking JSON, and a knowledge note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)