### PR TITLE
Enrich ℚ(∛3)/ℚ not normal: annotation depth + setup section

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03-oq-03/annotations.json
@@ -1,12 +1,27 @@
 [
   {
+    "id": "map-x-cubed",
+    "proofId": "cube-root-3-irrational-oq-03-oq-03",
+    "range": { "startLine": 51, "endLine": 54 },
+    "type": "technique",
+    "title": "Transporting X³ − 3 from ℚ to ℝ",
+    "content": "`map_X_cubed_sub_three` records that applying `algebraMap ℚ ℝ` to `(X³ − 3 : ℚ[X])` yields `X³ − 3 : ℝ[X]`, discharged by `simp` because the ring hom fixes the integer coefficients. This tiny rewrite is the pivot of the whole argument: it lets a splitting fact stated over the intermediate field ℚ(∛3) be re-expressed as a splitting fact over ℝ, where the single-real-root obstruction lives. Polynomial `map` along a ring homomorphism is a ring homomorphism `ℚ[X] → ℝ[X]`, so it commutes with `X`, `C`, powers, and subtraction.",
+    "mathContext": "$\\varphi_*(X^3 - 3) = X^3 - 3$ where $\\varphi = \\mathrm{algebraMap}\\,\\mathbb{Q}\\,\\mathbb{R}$, since $\\varphi(3)=3$.",
+    "significance": "technical",
+    "relatedConcepts": ["polynomial map along a ring homomorphism", "algebra map", "scalar extension of polynomials"],
+    "prerequisites": ["ring homomorphisms", "polynomial rings"]
+  },
+  {
     "id": "real-root-unique",
     "proofId": "cube-root-3-irrational-oq-03-oq-03",
     "range": { "startLine": 55, "endLine": 63 },
     "type": "theorem",
     "title": "Uniqueness of the Real Cube Root of 3",
     "content": "`real_root_eq_cbrt3` proves that any real number `r` with `r³ = 3` is exactly `∛3`. The argument is a one-liner: `r³ = 3 = (∛3)³` (using the parent's `cbrt3_pow_three`), and `x ↦ x³` is injective on ℝ because it is strictly monotone (`Odd.strictMono_pow` with `Odd 3`). This is the real-analytic heart of the whole proof — the fact that ℝ contains only ONE cube root of 3, unlike ℂ which contains three (∛3, ω∛3, ω²∛3).",
-    "significance": "key"
+    "mathContext": "$x\\mapsto x^3$ is strictly monotone on $\\mathbb{R}$ (an odd power), hence injective: $r^3=3=(\\sqrt[3]{3})^3\\Rightarrow r=\\sqrt[3]{3}$.",
+    "significance": "key",
+    "relatedConcepts": ["strict monotonicity of odd powers", "injectivity", "real cube root", "order on ℝ"],
+    "prerequisites": ["real analysis", "monotone functions", "cube roots"]
   },
   {
     "id": "not-splits-real",
@@ -15,7 +30,10 @@
     "type": "theorem",
     "title": "X³ − 3 Does Not Split over ℝ",
     "content": "`not_splits_real` refutes splitting over ℝ by a counting contradiction. If `X³ − 3` split, `splits_iff_card_roots` would give `roots.card = natDegree = 3` (three roots with multiplicity). Separability (`separable_X_pow_sub_C`, valid since `3 ≠ 0` in ℝ) upgrades this via `nodup_roots` to three DISTINCT roots. But the finset of distinct roots is contained in `{∛3}` — every root `r` has `r³ = 3` hence `r = ∛3` (`real_root_eq_cbrt3`) — so its cardinality is at most 1. Three distinct roots inside a one-element set is the contradiction.",
-    "significance": "key"
+    "mathContext": "Over $\\mathbb{R}$, $X^3-3=(X-\\sqrt[3]{3})(X^2+\\sqrt[3]{3}\\,X+\\sqrt[3]{9})$; the quadratic factor has discriminant $-3\\sqrt[3]{9}<0$, so only one real root. A split would demand $\\#\\mathrm{roots}=3$ distinct.",
+    "significance": "key",
+    "relatedConcepts": ["splitting of polynomials", "separable polynomial", "roots with multiplicity", "counting roots"],
+    "prerequisites": ["field theory", "polynomial roots", "separability"]
   },
   {
     "id": "minpoly-not-splits",
@@ -24,7 +42,10 @@
     "type": "theorem",
     "title": "The Minimal Polynomial Does Not Split in ℚ(∛3)",
     "content": "`minpoly_not_splits_adjoin` is the direct obstruction to normality. A hypothetical splitting of `X³ − 3` over the intermediate field ℚ(∛3) is transported to ℝ by `Polynomial.splits_of_algHom` along the canonical algebra embedding `IntermediateField.val : ℚ(∛3) →ₐ[ℚ] ℝ`, after rewriting the mapped polynomial as `X³ − 3 : ℝ[X]` (`map_X_cubed_sub_three`). That contradicts `not_splits_real`. Conceptually: the two complex-conjugate roots `ω∛3, ω²∛3` of `X³ − 3` cannot live in the real field ℚ(∛3).",
-    "significance": "supporting"
+    "mathContext": "If $f$ splits over $K$ and $\\iota:K\\hookrightarrow L$ is an $F$-algebra map, then $f$ splits over $L$. Here $K=\\mathbb{Q}(\\sqrt[3]{3})\\subseteq\\mathbb{R}=L$, forcing $X^3-3$ to split over $\\mathbb{R}$ — false.",
+    "significance": "supporting",
+    "relatedConcepts": ["intermediate field", "algebra embedding", "splits_of_algHom", "complex conjugate roots"],
+    "prerequisites": ["field extensions", "algebra homomorphisms", "intermediate fields"]
   },
   {
     "id": "not-normal-headline",
@@ -33,6 +54,9 @@
     "type": "theorem",
     "title": "ℚ(∛3)/ℚ Is Not Normal (nor Galois)",
     "content": "`not_normal_adjoin_cbrt3` is the headline. If ℚ(∛3)/ℚ were normal, `Normal.splits` applied to the generator `AdjoinSimple.gen ℚ ∛3` — whose minimal polynomial is `X³ − 3` via `minpoly_gen ▸ minpoly_cbrt3` — would force `X³ − 3` to split in ℚ(∛3), contradicting `minpoly_not_splits_adjoin`. `not_isGalois_adjoin_cbrt3` follows immediately since every Galois extension is normal (`IsGalois.to_normal`). This is the standard first example of a finite non-normal field extension.",
-    "significance": "key"
+    "mathContext": "$K/F$ normal $\\iff$ for every $\\alpha\\in K$, $\\min_F(\\alpha)$ splits in $K$. Taking $\\alpha=\\sqrt[3]{3}$, $\\min_{\\mathbb{Q}}(\\sqrt[3]{3})=X^3-3$ fails to split, so $\\mathbb{Q}(\\sqrt[3]{3})/\\mathbb{Q}$ is not normal, hence not Galois.",
+    "significance": "key",
+    "relatedConcepts": ["normal extension", "Galois extension", "minimal polynomial of a generator", "AdjoinSimple.gen", "IsGalois.to_normal"],
+    "prerequisites": ["Galois theory", "normal extensions", "minimal polynomials"]
   }
 ]

--- a/src/data/proofs/cube-root-3-irrational-oq-03-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03-oq-03/meta.json
@@ -102,6 +102,14 @@
   ],
   "sections": [
     {
+      "id": "setup",
+      "title": "Setup: Imports, Parent Results, and Namespace",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "The docstring motivates the question — degree 3 is odd (ruling out constructibility) but degree alone does not decide normality — and sketches the embedding-into-ℝ strategy. `import Proofs.CubeRoot3IrrationalOQ03` pulls in the parent's `minpoly_cbrt3 : minpoly ℚ ∛3 = X³ − 3` and `cbrt3_pow_three : ∛3³ = 3`, the two facts this entry consumes. Opening `Polynomial` and `IntermediateField` brings the `Splits`, `roots`, `AdjoinSimple.gen`, and `IntermediateField.val` API into scope.",
+      "mathContext": "Builds on the parent: $\\min_{\\mathbb{Q}}(\\sqrt[3]{3}) = X^3 - 3$ and $[\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}] = 3$."
+    },
+    {
       "id": "real-polynomial",
       "title": "The Real Polynomial X³ − 3 and Its Unique Real Root",
       "startLine": 49,


### PR DESCRIPTION
Enrichment pass for `cube-root-3-irrational-oq-03-oq-03` (quality 71, pass 0).

## Changes
- **Annotations**: added `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to all existing annotations, which previously carried only `significance`.
- **New annotation**: `map-x-cubed` documenting `map_X_cubed_sub_three` (the ℚ→ℝ polynomial-map pivot), bringing coverage to 5 annotations.
- **New section**: `setup` covering the docstring/imports/namespace (lines 1–47), which the sections array previously started past (line 49). Now the full 116-line Lean file is covered.

## Notes
- meta.json 12.7 KB — well under the 60 KB cap; no trimming needed.
- No `index.ts` created: since #20993 phase 2, proofs load from the build-generated manifest, not per-proof shims (only 609/4316 dirs have index.ts). The enricher.md instruction on this is stale.
- Axiom integrity preserved: entry remains `verified`/0-axiom, matching the Lean source (#print axioms clean, no native_decide).