### PR TITLE
research(central-limit-theorem-oq-02-oq-04): S20 — telescoping layer-cake Davydov bound [VERIFIED, 0-axiom, +2thm]

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
@@ -788,6 +788,114 @@ theorem finset_indicator_covariance_le_alpha
         rw [Finset.sum_mul_sum]
         simp_rw [Finset.sum_mul]
 
+/-- **Nonnegative-coefficient simple-function Davydov bound** (S20, this session).
+
+Specialization of `finset_indicator_covariance_le_alpha` to the case where every
+cell weight is nonnegative (`0 ≤ aᵢ`, `0 ≤ bⱼ`). The absolute values in the
+constant then collapse — `∑ᵢ |aᵢ| = ∑ᵢ aᵢ` and `∑ⱼ |bⱼ| = ∑ⱼ bⱼ` — so the
+bound reads with the plain coefficient sums:
+$$
+\Bigl|\mathrm{Cov}(f, g)\Bigr|
+   \;\le\; \Bigl(\sum_i a_i\Bigr)\Bigl(\sum_j b_j\Bigr)\,
+     \alpha(\mathcal F, \mathcal G).
+$$
+
+**Why this is the right increment.** The super-level (layer-cake) decomposition
+of a *nonnegative* bounded variable carries only nonnegative weights, so this is
+exactly the form the Davydov density step produces once the signed variable has
+been shifted to `[0, M]` (via `covariance_add_const_left/right`, S19). Removing
+the absolute values is what lets the coefficient sum *telescope to the range* of
+the function — the content of `telescoping_layer_covariance_le_alpha` below —
+rather than growing without bound as the partition is refined. -/
+theorem finset_indicator_covariance_le_alpha_of_nonneg
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    (σPair : Fin 2 → MeasurableSpace Ω)
+    {ι κ : Type*} (s : Finset ι) (t : Finset κ)
+    (a : ι → ℝ) (b : κ → ℝ)
+    (A : ι → Set Ω) (B : κ → Set Ω)
+    (ha : ∀ i ∈ s, 0 ≤ a i) (hb : ∀ j ∈ t, 0 ≤ b j)
+    (hA_amb : ∀ i ∈ s, MeasurableSet (A i))
+    (hB_amb : ∀ j ∈ t, MeasurableSet (B j))
+    (hA : ∀ i ∈ s, @MeasurableSet Ω (σPair 0) (A i))
+    (hB : ∀ j ∈ t, @MeasurableSet Ω (σPair 1) (B j)) :
+    |∫ ω, (∑ i ∈ s, a i * (A i).indicator (1 : Ω → ℝ) ω)
+            * (∑ j ∈ t, b j * (B j).indicator (1 : Ω → ℝ) ω) ∂μ
+      - (∫ ω, ∑ i ∈ s, a i * (A i).indicator (1 : Ω → ℝ) ω ∂μ)
+        * (∫ ω, ∑ j ∈ t, b j * (B j).indicator (1 : Ω → ℝ) ω ∂μ)|
+    ≤ (∑ i ∈ s, a i) * (∑ j ∈ t, b j)
+        * CentralLimitTheoremOQ02.alphaMixingCoeff μ (σPair 0) (σPair 1) := by
+  have hbase := finset_indicator_covariance_le_alpha (μ := μ) σPair s t a b A B
+    hA_amb hB_amb hA hB
+  have hsa : ∑ i ∈ s, |a i| = ∑ i ∈ s, a i :=
+    Finset.sum_congr rfl (fun i hi => abs_of_nonneg (ha i hi))
+  have hsb : ∑ j ∈ t, |b j| = ∑ j ∈ t, b j :=
+    Finset.sum_congr rfl (fun j hj => abs_of_nonneg (hb j hj))
+  rwa [hsa, hsb] at hbase
+
+/-- **Telescoping layer-cake Davydov bound** (S20, this session).
+
+The discretized layer-cake step of Davydov's inequality for *bounded* variables.
+Given increasing grids `sg, ug : ℕ → ℝ` with `sg 0 = 0`, `sg m = M`, `ug 0 = 0`,
+`ug n = N`, form the super-level step approximants with telescoping weights
+`sg (k+1) − sg k ≥ 0` and `ug (k+1) − ug k ≥ 0` attached to sub-σ-measurable
+level sets `A k` (w.r.t. `σPair 0`) and `B k` (w.r.t. `σPair 1`). Then
+$$
+\Bigl|\mathrm{Cov}(f_{\mathrm{step}}, g_{\mathrm{step}})\Bigr|
+   \;\le\; M \cdot N \cdot \alpha(\mathcal F, \mathcal G).
+$$
+
+**The point.** The coefficient sums telescope to the ranges by
+`Finset.sum_range_sub`:
+`∑_{k<m} (sg (k+1) − sg k) = sg m − sg 0 = M` (and likewise `N`), *independently
+of the grid* `sg`. Refining the partition therefore does **not** inflate the
+constant — it stays pinned at `M · N`. This is precisely the uniform bound that
+survives the layer-cake limit and turns the `(∑|aᵢ|)(∑|bⱼ|)` simple-function
+estimate into the sharp `‖X‖_∞ ‖Y‖_∞`-type factor of the bounded-variable
+Davydov inequality. The nonnegativity of the weights (needed to drop the
+absolute values, `finset_indicator_covariance_le_alpha_of_nonneg`) is exactly
+what makes the telescoping legitimate; a signed decomposition would give
+`∑|Δ|`, not `∑ Δ`.
+
+Combined with the constant-shift invariance of S19 (which reduces a signed
+`f ∈ [m, M]` to the nonnegative `f − m ∈ [0, M − m]`), this is the final
+*algebraic* layer of `davydov_covariance_inequality`; the residual content is
+the analytic passage from step functions to general bounded/`L^p` variables
+(monotone convergence for the layer-cake limit + Hölder amplification to the
+`(p−2)/p` exponent). -/
+theorem telescoping_layer_covariance_le_alpha
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    (σPair : Fin 2 → MeasurableSpace Ω)
+    (m n : ℕ) (sg ug : ℕ → ℝ) (M N : ℝ)
+    (A : ℕ → Set Ω) (B : ℕ → Set Ω)
+    (hsg_mono : Monotone sg) (hug_mono : Monotone ug)
+    (hsg0 : sg 0 = 0) (hsgm : sg m = M)
+    (hug0 : ug 0 = 0) (hugn : ug n = N)
+    (hA_amb : ∀ k ∈ Finset.range m, MeasurableSet (A k))
+    (hB_amb : ∀ k ∈ Finset.range n, MeasurableSet (B k))
+    (hA : ∀ k ∈ Finset.range m, @MeasurableSet Ω (σPair 0) (A k))
+    (hB : ∀ k ∈ Finset.range n, @MeasurableSet Ω (σPair 1) (B k)) :
+    |∫ ω, (∑ k ∈ Finset.range m, (sg (k + 1) - sg k) * (A k).indicator (1 : Ω → ℝ) ω)
+            * (∑ k ∈ Finset.range n, (ug (k + 1) - ug k) * (B k).indicator (1 : Ω → ℝ) ω) ∂μ
+      - (∫ ω, ∑ k ∈ Finset.range m, (sg (k + 1) - sg k) * (A k).indicator (1 : Ω → ℝ) ω ∂μ)
+        * (∫ ω, ∑ k ∈ Finset.range n, (ug (k + 1) - ug k) * (B k).indicator (1 : Ω → ℝ) ω ∂μ)|
+    ≤ M * N * CentralLimitTheoremOQ02.alphaMixingCoeff μ (σPair 0) (σPair 1) := by
+  -- Telescoping weights are nonnegative (grids are monotone).
+  have ha : ∀ k ∈ Finset.range m, 0 ≤ sg (k + 1) - sg k := fun k _ =>
+    sub_nonneg.mpr (hsg_mono (Nat.le_succ k))
+  have hb : ∀ k ∈ Finset.range n, 0 ≤ ug (k + 1) - ug k := fun k _ =>
+    sub_nonneg.mpr (hug_mono (Nat.le_succ k))
+  -- Apply the nonnegative-coefficient simple-function bound.
+  have hbound := finset_indicator_covariance_le_alpha_of_nonneg (μ := μ) σPair
+    (Finset.range m) (Finset.range n)
+    (fun k => sg (k + 1) - sg k) (fun k => ug (k + 1) - ug k) A B ha hb
+    hA_amb hB_amb hA hB
+  -- The coefficient sums telescope to the ranges `M`, `N`.
+  have hSsum : ∑ k ∈ Finset.range m, (sg (k + 1) - sg k) = M := by
+    rw [Finset.sum_range_sub sg m, hsgm, hsg0, sub_zero]
+  have hUsum : ∑ k ∈ Finset.range n, (ug (k + 1) - ug k) = N := by
+    rw [Finset.sum_range_sub ug n, hugn, hug0, sub_zero]
+  rwa [hSsum, hUsum] at hbound
+
 /-! ### Covariance translation-invariance (S19 — algebraic reduction for the
      L^p density step)
 

--- a/research/problems/central-limit-theorem-oq-02-oq-04/knowledge.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-04/knowledge.md
@@ -603,3 +603,56 @@ super-level indicators with telescoping coefficients (`∑|Δcᵢ| ≤ M`), then
 `finset_indicator_covariance_le_alpha`. The residual analytic gap is the L^p→
 bounded truncation (`truncation_tail_sq_le`, S18) + Hölder amplification to the
 `(p-2)/p` exponent.
+
+---
+
+## S20 (researcher-1, 2026-07-01) — Telescoping layer-cake Davydov bound
+
+**Delivered (VERIFIED, 0-axiom, +2 theorems), stacked on the S19 line at HEAD
+343fc16518f.** Both `#print axioms` = `[propext, Classical.choice, Quot.sound]`
+only; neither depends on the `davydov_covariance_inequality` sorry (no
+`sorryAx`). File now 1119 → 1227 lines.
+
+- `finset_indicator_covariance_le_alpha_of_nonneg`: when all cell weights are
+  nonnegative, the simple-function bound reads
+  `|Cov(f,g)| ≤ (∑ᵢ aᵢ)(∑ⱼ bⱼ) · α` — the absolute values collapse
+  (`∑|aᵢ| = ∑aᵢ` via `abs_of_nonneg`).
+- `telescoping_layer_covariance_le_alpha`: the discretized layer-cake step.
+  For increasing grids `sg, ug : ℕ → ℝ` with `sg 0 = 0, sg m = M`, `ug 0 = 0,
+  ug n = N`, the super-level step approximants with telescoping weights
+  `sg(k+1) − sg k ≥ 0` satisfy `|Cov(f_step, g_step)| ≤ M · N · α`.
+
+**Why this is the right increment.** `finset_indicator_covariance_le_alpha`
+(S17) gives `(∑|aᵢ|)(∑|bⱼ|)·α`, whose constant blows up as the partition is
+refined for a *general* signed decomposition. The Davydov bounded-variable step
+needs the constant pinned at the *range* `M·N`, uniformly in the grid. This is
+achieved precisely because (a) after the S19 shift to `[0, M]` the super-level
+weights are nonnegative, so the absolute values drop
+(`..._of_nonneg`), and (b) the telescoping weights sum to the range via
+`Finset.sum_range_sub`: `∑_{k<m}(sg(k+1)−sg k) = sg m − sg 0 = M`, *independent
+of the grid*. Together with S19's constant-shift invariance, this is the last
+purely-algebraic layer of `davydov_covariance_inequality`.
+
+**Proof recipe.**
+- `..._of_nonneg`: `have hbase := finset_indicator_covariance_le_alpha ...`;
+  `hsa : ∑ i ∈ s, |a i| = ∑ i ∈ s, a i := Finset.sum_congr rfl (fun i hi =>
+  abs_of_nonneg (ha i hi))`; likewise `hsb`; `rwa [hsa, hsb] at hbase`.
+- telescoping: weights nonneg by `sub_nonneg.mpr (hsg_mono (Nat.le_succ k))`;
+  apply `..._of_nonneg` with `a := fun k => sg (k+1) − sg k`; ranges by
+  `rw [Finset.sum_range_sub sg m, hsgm, hsg0, sub_zero]`; `rwa [hSsum, hUsum] at
+  hbound`.
+
+**Key Mathlib fact used.** `Finset.sum_range_sub (f : ℕ → G) (n) :
+∑ i ∈ range n, (f (i+1) − f i) = f n − f 0` (telescoping).
+
+**Sorries unchanged (2):** `davydov_covariance_inequality` (S5c, the residual
+*analytic* content — monotone-convergence layer-cake limit + Hölder
+amplification to exponent `(p−2)/p`) and `mixing_clt_ibragimov` (S6+). This
+session adds no assumptions.
+
+**Next (S5c analytic).** The remaining gap is now cleanly delimited: pass from
+the telescoping step bound `M·N·α` to a general bounded variable by monotone
+convergence of the super-level step functions (layer-cake:
+`f = ∫₀^M 1_{f>t} dt`, dominated-convergence for the covariance integral), then
+Hölder-amplify `M·N` down to `‖X‖_{L^p}‖Y‖_{L^p} · α^{(p−2)/p}` using the
+truncation tail second-moment bound `truncation_tail_sq_le` (S18).

--- a/src/data/research/problems/central-limit-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-02-oq-04.json
@@ -292,11 +292,11 @@
     {
       "path": "Proofs/CentralLimitTheoremOQ02OQ04.lean",
       "filename": "CentralLimitTheoremOQ02OQ04.lean",
-      "lineCount": 808,
-      "theoremCount": 15,
+      "lineCount": 1227,
+      "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 8,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean"
     },


### PR DESCRIPTION
## S20: Telescoping layer-cake Davydov bound (VERIFIED, 0-axiom, +2 theorems)

Continues the mixing-CLT / Davydov covariance-inequality work on `CentralLimitTheoremOQ02OQ04.lean`, stacking on S19 (covariance translation-invariance, #32431).

### What's new
Two fully machine-checked theorems (`#print axioms` = `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, independent of the open Davydov sorry):

- **`finset_indicator_covariance_le_alpha_of_nonneg`** — nonnegative-coefficient specialization of the S17 simple-function bound `finset_indicator_covariance_le_alpha`. When all cell weights are `≥ 0`, the absolute values collapse (`∑|aᵢ| = ∑aᵢ`), giving `|Cov(f,g)| ≤ (∑ᵢ aᵢ)(∑ⱼ bⱼ)·α`.

- **`telescoping_layer_covariance_le_alpha`** — the discretized layer-cake step. For increasing grids `sg, ug : ℕ → ℝ` with `sg 0 = 0, sg m = M`, `ug 0 = 0, ug n = N`, the super-level step approximants with telescoping weights `sg(k+1) − sg k ≥ 0` satisfy `|Cov(f_step, g_step)| ≤ M·N·α`.

### Why this matters
The S17 bound `(∑|aᵢ|)(∑|bⱼ|)·α` has a constant that would blow up as a signed partition is refined. Davydov's bounded-variable step needs the constant pinned at the **range** `M·N`, uniformly in the grid. This holds because:
1. After S19's shift to `[0, M]` the super-level weights are nonnegative → absolute values drop (`..._of_nonneg`);
2. The telescoping weights sum to the range via `Finset.sum_range_sub`: `∑_{k<m}(sg(k+1)−sg k) = sg m − sg 0 = M`, **independent of the grid**.

Together with S19 constant-shift invariance, this is the last purely-**algebraic** layer of `davydov_covariance_inequality`. The residual content is now cleanly delimited as the **analytic** layer-cake limit (monotone/dominated convergence of super-level step functions) + Hölder amplification of `M·N` to `‖X‖_{L^p}‖Y‖_{L^p}·α^{(p−2)/p}` (using S18's `truncation_tail_sq_le`).

### Status
- Build: typechecks via `lake env lean` against the cached Mathlib/parent olean.
- Sorries unchanged (2): `davydov_covariance_inequality` (S5c analytic) and `mixing_clt_ibragimov` (S6+). No new assumptions.
- File: 1119 → 1227 lines; +2 verified theorems.