### PR TITLE
Enrich Buffon Higher Codimension (buffons-noodle-oq-03-oq-02): add index.ts

### DIFF
--- a/src/data/proofs/buffons-noodle-oq-03-oq-02/index.ts
+++ b/src/data/proofs/buffons-noodle-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BuffonsNoodleOQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const buffonsNoodleOQ03OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const buffonsNoodleOQ03OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const buffonsNoodleOQ03OQ02Data: ProofData = {
+  proof: buffonsNoodleOQ03OQ02Proof,
+  annotations: buffonsNoodleOQ03OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `buffons-noodle-oq-03-oq-02`.

**Critical fix:** the entry was missing its `index.ts`, so Vite's `import.meta.glob` could not discover the proof — the page rendered 'proof not found' on the live site despite appearing in the gallery listing. Added the standard `index.ts` (correct Lean source path `Proofs/BuffonsNoodleOQ03OQ02.lean`, camelCase exports).

**No inflation:** meta.json (19 KB) and the 3 annotations are already richly enriched — full overview, 5 keyInsights, sections covering the whole file, conclusion with implications + 3 open questions, references, cross-references. Per the size guardrails, I did not deepen an already-rich entry.