### PR TITLE
research(spherical-law-of-sines-oq-02): verify + gallery-integrate dual spherical law of cosines [VERIFIED, 0-axiom, 6thm]

### DIFF
--- a/src/data/proofs/spherical-law-of-sines-oq-02/annotations.json
+++ b/src/data/proofs/spherical-law-of-sines-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-sls-oq02-gram-general",
+    "proofId": "spherical-law-of-sines-oq-02",
+    "range": { "startLine": 95, "endLine": 103 },
+    "type": "theorem",
+    "title": "The General Gram / Cauchy–Binet Identity",
+    "content": "tripleProduct_sq_eq expresses the squared scalar triple product as the determinant of the Gram matrix: det[A,B,C]² = |A|²|B|²|C|² + 2⟨A,B⟩⟨B,C⟩⟨A,C⟩ − |A|²⟨B,C⟩² − |B|²⟨A,C⟩² − |C|²⟨A,B⟩². It carries no unit hypotheses — after unfolding the cross product on Fin 3, both sides are polynomials in the nine coordinates and ring closes the gap. This is the fact that later eliminates all square roots.",
+    "mathContext": "\\det[A,B,C]^2 = |A|^2|B|^2|C|^2 + 2\\langle A,B\\rangle\\langle B,C\\rangle\\langle A,C\\rangle - |A|^2\\langle B,C\\rangle^2 - |B|^2\\langle A,C\\rangle^2 - |C|^2\\langle A,B\\rangle^2",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy–Binet", "Gram matrix", "scalar triple product", "ring"],
+    "prerequisites": ["cross product on Fin 3", "Fin.sum_univ_three", "ring tactic"]
+  },
+  {
+    "id": "ann-sls-oq02-gram-unit",
+    "proofId": "spherical-law-of-sines-oq-02",
+    "range": { "startLine": 108, "endLine": 116 },
+    "type": "theorem",
+    "title": "The Gram Identity for Unit Vectors",
+    "content": "tripleProduct_sq_unit specialises the Cauchy–Binet identity to unit vertices. With |A|²=|B|²=|C|²=1 the diagonal terms collapse and det[A,B,C]² = 1 − p² − q² − r² + 2pqr, where p = ⟨A,B⟩ = cos c, q = ⟨A,C⟩ = cos b, r = ⟨B,C⟩ = cos a. This is the substitution that turns the geometric statement into a polynomial identity in p, q, r.",
+    "mathContext": "\\det[A,B,C]^2 = 1 - p^2 - q^2 - r^2 + 2pqr",
+    "significance": "key",
+    "relatedConcepts": ["Gram determinant", "unit vectors", "dot products as cosines"],
+    "prerequisites": ["tripleProduct_sq_eq", "IsUnit3 (normSq = 1)", "ring"]
+  },
+  {
+    "id": "ann-sls-oq02-cleared-identity",
+    "proofId": "spherical-law-of-sines-oq-02",
+    "range": { "startLine": 129, "endLine": 134 },
+    "type": "theorem",
+    "title": "The Cleared Polynomial Core (K)",
+    "content": "dual_law_of_cosines_polynomial is the algebraic heart. Multiplying the target dual law through by the nonzero factor sin a · sin b · sin²c and substituting the projection product identities reduces everything to (p − qr)(1 − p²) = −(r − pq)(q − pr) + det²·p. After rewriting det² by tripleProduct_sq_unit, ring closes it — both sides expand to p − p³ − qr + p²qr. The identity holds for all unit vectors, with no non-degeneracy needed.",
+    "mathContext": "(p-qr)(1-p^2) = -(r-pq)(q-pr) + \\det[A,B,C]^2\\cdot p",
+    "significance": "key",
+    "relatedConcepts": ["clearing denominators", "polynomial identity", "ring"],
+    "prerequisites": ["tripleProduct_sq_unit", "ring tactic"]
+  },
+  {
+    "id": "ann-sls-oq02-main-law",
+    "proofId": "spherical-law-of-sines-oq-02",
+    "range": { "startLine": 155, "endLine": 245 },
+    "type": "theorem",
+    "title": "The Dual Spherical Law of Cosines (Angle γ)",
+    "content": "dual_spherical_law_of_cosines is the main theorem: cos γ = −cos α · cos β + sin α · sin β · cos c for the angle γ opposite side c. The three perpendicular-projection inner products are evaluated by the local law of cosines; the dihedral cosines and sines are rewritten by the OQ-03 product identities cos_dihedralAngle_mul / sin_dihedralAngle_mul (with arcLen_comm to normalise argument order); the two |det| sine-factors recombine to det² via Real.mul_self_sqrt. A calc chain collects the cleared products, lands on dual_law_of_cosines_polynomial, and the common nonzero factor sin a · sin b · sin²c is removed by mul_left_cancel₀.",
+    "mathContext": "\\cos(\\angle C) = -\\cos(\\angle A)\\,\\cos(\\angle B) + \\sin(\\angle A)\\,\\sin(\\angle B)\\,\\cos c",
+    "significance": "key",
+    "relatedConcepts": ["dual law of cosines", "dihedral product identities", "local law of cosines", "mul_left_cancel₀"],
+    "prerequisites": ["cos_dihedralAngle_mul", "sin_dihedralAngle_mul", "spherical_law_of_cosines_local", "Real.mul_self_sqrt", "dual_law_of_cosines_polynomial", "mul_left_cancel₀"]
+  },
+  {
+    "id": "ann-sls-oq02-sibling-angles",
+    "proofId": "spherical-law-of-sines-oq-02",
+    "range": { "startLine": 254, "endLine": 287 },
+    "type": "theorem",
+    "title": "The Sibling Laws for α and β",
+    "content": "dual_spherical_law_of_cosines_A (angle α opposite side a) and dual_spherical_law_of_cosines_B (angle β opposite side b) follow from the main statement by relabelling the vertices (A,B,C)↦(B,C,A) and (A,C,B) and normalising the dihedral argument order with dihedralAngle_comm_last (plus arcLen_comm on the side hypotheses). No new algebra is required — the symmetry of the setup does the work.",
+    "mathContext": "\\cos\\alpha = -\\cos\\beta\\,\\cos\\gamma + \\sin\\beta\\,\\sin\\gamma\\,\\cos a,\\qquad \\cos\\beta = -\\cos\\alpha\\,\\cos\\gamma + \\sin\\alpha\\,\\sin\\gamma\\,\\cos b",
+    "significance": "supporting",
+    "relatedConcepts": ["vertex relabelling", "dihedralAngle_comm_last", "symmetry"],
+    "prerequisites": ["dual_spherical_law_of_cosines", "dihedralAngle_comm_last", "arcLen_comm"]
+  }
+]

--- a/src/data/proofs/spherical-law-of-sines-oq-02/meta.json
+++ b/src/data/proofs/spherical-law-of-sines-oq-02/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "spherical-law-of-sines-oq-02",
+  "title": "The Dual Spherical Law of Cosines (an Angle from Two Angles and a Side)",
+  "slug": "spherical-law-of-sines-oq-02",
+  "description": "Proves the dual (polar) spherical law of cosines cos γ = -cos α · cos β + sin α · sin β · cos c — an interior angle expressed in terms of the other two angles and the opposite side, dual to the standard law cos c = cos a · cos b + sin a · sin b · cos γ (a side from two sides and an angle). The textbook route derives this by applying the ordinary law of cosines to the polar triangle, which requires constructing the polar triangle and its side↔angle (π − ·) duality (~150–300 lines of new infrastructure). This entry avoids the polar triangle entirely: it multiplies the target through by the nonzero factor sin a · sin b · sin²c, substitutes the unconditional dihedral product identities (cos_dihedralAngle_mul, sin_dihedralAngle_mul) from the sibling OQ-03 file and the local law of cosines, and reduces the whole statement to a single cleared polynomial identity in the three pairwise dot products, closed by ring once the Gram determinant det[A,B,C]² = 1 − p² − q² − r² + 2pqr is expanded. Cancelling the nonzero factor (genuine triangle) recovers the honest cosine form. 6 theorems, 0 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Spherical_law_of_cosines",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SphericalLawOfSinesOQ02.lean",
+    "tags": [
+      "geometry",
+      "spherical-geometry",
+      "trigonometry",
+      "law-of-cosines",
+      "polar-triangle",
+      "non-euclidean-geometry",
+      "gram-determinant"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (only the foundational propext / Classical.choice / Quot.sound). The non-degeneracy hypotheses (sin a, sin b, sin c ≠ 0) are the standard genuine-triangle assumptions needed to cancel the common factor.",
+    "lineCount": 304,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "originalContributions": [
+      "tripleProduct_sq_eq: the general Cauchy–Binet / Gram identity det[A,B,C]² = |A|²|B|²|C|² + 2⟨A,B⟩⟨B,C⟩⟨A,C⟩ − |A|²⟨B,C⟩² − |B|²⟨A,C⟩² − |C|²⟨A,B⟩², a pure ring identity with no unit hypotheses",
+      "tripleProduct_sq_unit: the Gram identity specialised to unit vectors, det² = 1 − p² − q² − r² + 2pqr with p = ⟨A,B⟩, q = ⟨A,C⟩, r = ⟨B,C⟩",
+      "dual_law_of_cosines_polynomial: the cleared polynomial core (p − qr)(1 − p²) = −(r − pq)(q − pr) + det²·p, obtained by clearing sin a · sin b · sin²c from the honest dual law; closed by ring after the Gram substitution",
+      "dual_spherical_law_of_cosines: the dual law cos γ = −cos α · cos β + sin α · sin β · cos c for the angle γ opposite side c, proved by substituting the OQ-03 product identities and the local law of cosines into the cleared identity and cancelling the nonzero factor",
+      "dual_spherical_law_of_cosines_A and dual_spherical_law_of_cosines_B: the sibling laws for the angles α and β, obtained from the main statement by relabelling the vertices via dihedralAngle_comm_last"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Spherical trigonometry has two laws of cosines, dual to each other under the polar-triangle correspondence. The ordinary spherical law of cosines, cos c = cos a · cos b + sin a · sin b · cos C, computes a side from the other two sides and the included angle — the spherical analogue of the planar law of cosines. Its dual, cos C = −cos A · cos B + sin A · sin B · cos c, computes an angle from the other two angles and the opposite side, a phenomenon with no planar counterpart (in the plane the three angles sum to π, so any one is determined by the other two alone). Classically the dual law is proved by applying the ordinary law of cosines to the polar triangle, whose sides are the supplements of the original angles and vice versa. This entry derives it directly in the ℝ³ vector model, bypassing the polar construction.",
+    "problemStatement": "For a non-degenerate spherical triangle with unit-vector vertices A, B, C, sides a = arcLen B C, b = arcLen A C, c = arcLen A B and interior dihedral angles α = dihedralAngle A B C, β = dihedralAngle B A C, γ = dihedralAngle C A B, prove the dual law of cosines cos γ = −cos α · cos β + sin α · sin β · cos c.",
+    "text": "In the parent's cross-product framework, write p = ⟨A,B⟩ = cos c, q = ⟨A,C⟩ = cos b, r = ⟨B,C⟩ = cos a. The sibling OQ-03 file supplies two unconditional product identities: cos(dih A B C) · sin c · sin b = ⟨projPerp B A, projPerp C A⟩ (which the local law of cosines evaluates to r − pq), and sin(dih A B C) · sin c · sin b = |det[A,B,C]|. Multiplying the target dual law through by the nonzero factor sin a · sin b · sin²c and substituting these identities — together with sin²c = 1 − p² and the Gram determinant det² = 1 − p² − q² − r² + 2pqr — collapses the trigonometric statement to the single polynomial identity (p − qr)(1 − p²) = −(r − pq)(q − pr) + det²·p, both sides of which expand (by ring) to p − p³ − qr + p²qr. The two sin-form factors combine as |det|·|det| = det² via Real.mul_self_sqrt, so no square roots survive. Cancelling sin a · sin b · sin²c (nonzero for a genuine triangle) recovers the honest cosine identity.",
+    "proofStrategy": "tripleProduct_sq_eq proves the Cauchy–Binet Gram identity as a pure ring identity after unfolding the cross product on Fin 3. tripleProduct_sq_unit specialises it to unit vectors, giving det² = 1 − p² − q² − r² + 2pqr. dual_law_of_cosines_polynomial then closes the cleared identity K by ring after substituting det². dual_spherical_law_of_cosines assembles the geometric proof: it evaluates the three perpendicular-projection inner products via spherical_law_of_cosines_local, rewrites the three dihedral cosines and two dihedral sines through cos_dihedralAngle_mul / sin_dihedralAngle_mul (normalising arcLen argument order with arcLen_comm), collects everything into a calc chain that lands on dual_law_of_cosines_polynomial, and finishes with mul_left_cancel₀ on the nonzero factor. dual_spherical_law_of_cosines_A and _B relabel the vertices and normalise the angle argument order with dihedralAngle_comm_last.",
+    "keyInsights": [
+      "The dual law is genuinely three-dimensional: an angle determined by two angles and a side has no planar analogue, since planar angles already sum to π",
+      "The polar-triangle construction — the classical proof route — is avoided entirely; only the unconditional dihedral product identities and the local law of cosines are needed",
+      "Clearing the nonzero factor sin a · sin b · sin²c turns the transcendental statement into one polynomial identity in the three dot products p, q, r, closable by ring",
+      "The Gram / Cauchy–Binet identity det[A,B,C]² = det(⟨·,·⟩) is the single algebraic fact that eliminates the square roots: the two |det| sine-factors multiply back to det²",
+      "The two sibling angle laws cost no new algebra — they are the main statement with the vertices relabelled and the dihedral argument order normalised"
+    ],
+    "prerequisites": [
+      "The parent's ℝ³ vector model (dot, normSq, arcLen, IsUnit3, tripleProduct, projPerp, dihedralAngle)",
+      "The sibling OQ-03 product identities cos_dihedralAngle_mul, sin_dihedralAngle_mul, and the local law of cosines spherical_law_of_cosines_local",
+      "The Cauchy–Binet / Gram determinant identity for three vectors",
+      "Real.mul_self_sqrt (√x · √x = x for x ≥ 0) to recombine the two |det| factors, and mul_left_cancel₀ to cancel the common nonzero factor"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-dual-law",
+      "title": "Overview: The Dual Law and the Polar-Triangle Detour",
+      "startLine": 1,
+      "endLine": 75,
+      "summary": "Introduces the dual spherical law of cosines cos γ = −cos α · cos β + sin α · sin β · cos c — an angle from the other two angles and the opposite side — and contrasts it with the standard law (a side from two sides and an angle). The classical proof applies the ordinary law to the polar triangle; this file avoids that construction, reducing the statement to one cleared polynomial identity via the OQ-03 dihedral product identities.",
+      "mathContext": "$\\cos\\gamma = -\\cos\\alpha\\,\\cos\\beta + \\sin\\alpha\\,\\sin\\beta\\,\\cos c$, dual to $\\cos c = \\cos a\\,\\cos b + \\sin a\\,\\sin b\\,\\cos\\gamma$."
+    },
+    {
+      "id": "gram-determinant",
+      "title": "The Gram Determinant of Three Vectors",
+      "startLine": 86,
+      "endLine": 116,
+      "summary": "tripleProduct_sq_eq: the general Cauchy–Binet identity det[A,B,C]² = det of the Gram matrix (⟨·,·⟩), a pure ring identity with no unit hypotheses. tripleProduct_sq_unit specialises it to unit vectors, collapsing the diagonal to 1 and giving det² = 1 − p² − q² − r² + 2pqr.",
+      "mathContext": "$\\det[A,B,C]^2 = 1 - p^2 - q^2 - r^2 + 2pqr,\\quad p=\\langle A,B\\rangle,\\ q=\\langle A,C\\rangle,\\ r=\\langle B,C\\rangle.$"
+    },
+    {
+      "id": "cleared-identity",
+      "title": "The Cleared Polynomial Core",
+      "startLine": 118,
+      "endLine": 134,
+      "summary": "dual_law_of_cosines_polynomial: the algebraic heart of the proof, (p − qr)(1 − p²) = −(r − pq)(q − pr) + det²·p, the identity obtained by clearing the factor sin a · sin b · sin²c from the honest dual law. It holds for all unit vectors (no non-degeneracy) and is closed by ring once det² is expanded — both sides equal p − p³ − qr + p²qr.",
+      "mathContext": "$(p-qr)(1-p^2) = -(r-pq)(q-pr) + \\det[A,B,C]^2\\cdot p.$"
+    },
+    {
+      "id": "dual-law-gamma",
+      "title": "The Dual Law for the Angle γ (Main Theorem)",
+      "startLine": 136,
+      "endLine": 245,
+      "summary": "dual_spherical_law_of_cosines: the headline result for angle γ opposite side c. Evaluates the three perpendicular-projection inner products via the local law of cosines, rewrites the dihedral cosines and sines by the OQ-03 product identities, recombines the two |det| factors into det² by Real.mul_self_sqrt, assembles a calc chain landing on the cleared polynomial identity, and cancels the nonzero factor sin a · sin b · sin²c by mul_left_cancel₀.",
+      "mathContext": "$\\cos(\\angle C) = -\\cos(\\angle A)\\cos(\\angle B) + \\sin(\\angle A)\\sin(\\angle B)\\cos c.$"
+    },
+    {
+      "id": "sibling-angles",
+      "title": "The Sibling Laws for α and β",
+      "startLine": 247,
+      "endLine": 287,
+      "summary": "dual_spherical_law_of_cosines_A (angle α opposite side a) and dual_spherical_law_of_cosines_B (angle β opposite side b): obtained from the main statement by relabelling the vertices (A,B,C)↦(B,C,A) and (A,C,B), normalising the dihedral argument order with dihedralAngle_comm_last. No new algebra.",
+      "mathContext": "$\\cos\\alpha = -\\cos\\beta\\,\\cos\\gamma + \\sin\\beta\\,\\sin\\gamma\\,\\cos a$ and $\\cos\\beta = -\\cos\\alpha\\,\\cos\\gamma + \\sin\\alpha\\,\\sin\\gamma\\,\\cos b.$"
+    }
+  ],
+  "conclusion": {
+    "summary": "The dual spherical law of cosines cos γ = −cos α · cos β + sin α · sin β · cos c is proved directly in the ℝ³ vector model for all three angles, without constructing the polar triangle. The trigonometric statement is cleared to a single polynomial identity in the pairwise dot products — closable by ring once the Gram determinant is expanded — and the common nonzero factor is cancelled for a genuine triangle. 6 theorems, 0 definitions, 304 lines, 0 sorries, 0 axioms.",
+    "implications": "Completes the classical spherical-trigonometry suite in the vector framework: together with the standard law of cosines (a side from two sides and an angle) and the law of sines, one can now solve for any angle from two angles and a side. The clear-and-ring strategy — multiply out by the nonzero sine factor, substitute the unconditional dihedral product identities, and close a polynomial identity — is reusable for further spherical identities (e.g. the four-parts / cotangent formula).",
+    "openQuestions": [
+      "Derive the four-parts (cotangent) formula cot a · sin b = cos b · cos γ + sin γ · cot α in the same vector framework, combining the standard and dual laws of cosines",
+      "Prove the polar-triangle duality itself (side = π − opposite angle) in the vector model and re-derive the dual law as a one-line corollary, giving an independent check of this entry's direct proof"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "spherical-law-of-sines",
+      "relationship": "Parent gallery entry",
+      "description": "The squared spherical law of sines, the parent entry whose open-question OQ-02 this file answers. Both live in the same ℝ³ cross-product model of the sphere."
+    },
+    {
+      "proofId": "spherical-law-of-cosines",
+      "relationship": "Law this entry is dual to",
+      "description": "The standard spherical law of cosines cos c = cos a · cos b + sin a · sin b · cos γ (a side from two sides and an angle). The present entry proves its polar dual, cos γ = −cos α · cos β + sin α · sin β · cos c (an angle from two angles and a side)."
+    },
+    {
+      "proofId": "spherical-law-of-sines-oq-01",
+      "relationship": "Sibling open-question entry",
+      "description": "The unsquared spherical law of sines, a sibling follow-up to the same parent. Together with this dual law of cosines it rounds out the core computational laws of spherical trigonometry."
+    }
+  ],
+  "leanFile": {
+    "namespace": "SphericalLawOfSines",
+    "lineCount": 304,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/SphericalLawOfSinesOQ02.lean",
+    "sorries": 0
+  }
+}

--- a/src/data/research/problems/spherical-law-of-sines-oq-02.json
+++ b/src/data/research/problems/spherical-law-of-sines-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "spherical-law-of-sines-oq-02",
   "title": "Spherical Law of Sines OQ-02: Squared Ratio Formalization",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -42,9 +42,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Verified SphericalLawOfSinesOQ02.lean typechecks (lean exit 0, #print axioms = [propext,Classical.choice,Quot.sound] only) and created the gallery entry (meta.json + annotations.json) so the dual spherical law of cosines is discoverable. 6 theorems, 0 axioms, 0 sorries, 304 lines.",
+    "builtItems": [
+      "Gallery entry src/data/proofs/spherical-law-of-sines-oq-02/ (meta.json, annotations.json)"
+    ],
+    "insights": [
+      "File was committed UNVERIFIED (#30742, build host down); confirmed VERIFIED via main-cache lake env lean and gallery-integrated this session."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: spherical-law-of-sines-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Research session for **spherical-law-of-sines-oq-02** — the **dual spherical law of cosines**:

    cos γ = -cos α · cos β + sin α · sin β · cos c

(an interior angle from the other two angles and the opposite side, dual to the standard law `cos c = cos a · cos b + sin a · sin b · cos γ`).

The Lean file `Proofs/SphericalLawOfSinesOQ02.lean` was already committed in #30742 but marked **UNVERIFIED** (the Docker build host was down at the time) and had **no gallery entry**. This session verifies it and integrates it into the gallery.

## Verification
- `lake env lean Proofs/SphericalLawOfSinesOQ02.lean` (against main's Mathlib cache) exits **0** with no diagnostics.
- `#print axioms` on `dual_spherical_law_of_cosines`, `_A`, `_B` reports only `[propext, Classical.choice, Quot.sound]` — the foundational axioms. **0 axioms, 0 sorries.**

## Changes
- New gallery entry `src/data/proofs/spherical-law-of-sines-oq-02/` (`meta.json` + `annotations.json`).
- Problem status → `completed`.

No Lean source changes — the proof was already on `main`; this PR only verifies and adds the gallery metadata.

## Proof highlights
- Avoids the classical polar-triangle construction entirely.
- Multiplies the target through by the nonzero factor `sin a · sin b · sin²c`, substitutes the unconditional dihedral product identities from the sibling OQ-03 file, and reduces to a single cleared polynomial identity in the pairwise dot products, closed by `ring` after expanding the Gram determinant `det[A,B,C]² = 1 − p² − q² − r² + 2pqr`.
- The two `|det|` sine-factors recombine to `det²` via `Real.mul_self_sqrt`, so no square roots survive; the common factor is cancelled by `mul_left_cancel₀`.
- 6 theorems, 0 definitions, 304 lines.

## Status
**Outcome**: completed (verified + gallery-integrated)

🤖 Generated by researcher-2