### PR TITLE
Enrich Alternating Row Sum of Pascal's Triangle (combinations-formula-oq-05): add index.ts + worked-verification annotation

### DIFF
--- a/src/data/proofs/combinations-formula-oq-05/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-05/annotations.json
@@ -62,21 +62,39 @@
   {
     "id": "each-half-theorem",
     "proofId": "combinations-formula-oq-05",
-    "range": { "startLine": 86, "endLine": 114 },
+    "range": { "startLine": 86, "endLine": 107 },
     "type": "theorem",
     "title": "Each Half Equals 2^{n-1}",
-    "content": "sum_choose_int casts the total row sum to ℤ: ∑ C(n,k) = 2^n (from Nat.sum_range_choose). sum_even_choose then combines the even/odd equality E = O with the total E + O = 2^n and the identity 2^n = 2·2^{n-1} (for n ≥ 1) to conclude ∑_{k even} C(n,k) = 2^{n-1}. A worked example confirms the even part of row 4 sums to 8 = 2^3.",
-    "mathContext": "From $E = O$ and $E + O = 2^n$ we get $2E = 2^n = 2 \\cdot 2^{n-1}$, so $E = 2^{n-1}$ (and likewise $O = 2^{n-1}$). The exponent arithmetic $2^n = 2\\cdot 2^{n-1}$ for $n \\ge 1$ is handled by omega. For $n=4$: even terms $\\binom{4}{0}+\\binom{4}{2}+\\binom{4}{4} = 1+6+1 = 8 = 2^3$.",
+    "content": "sum_choose_int casts the total row sum to ℤ: ∑ C(n,k) = 2^n (from Nat.sum_range_choose). sum_even_choose then combines the even/odd equality E = O (via sum_even_choose_eq_sum_odd_choose) with the total split E + O = 2^n and the identity 2^n = 2·2^{n-1} (for n ≥ 1) to conclude ∑_{k even} C(n,k) = 2^{n-1}. The final step is a single linarith once 2E = 2^n and 2^n = 2·2^{n-1} are in context.",
+    "mathContext": "From $E = O$ and $E + O = 2^n$ we get $2E = 2^n = 2 \\cdot 2^{n-1}$, so $E = 2^{n-1}$ (and likewise $O = 2^{n-1}$). The exponent arithmetic $2^n = 2\\cdot 2^{n-1}$ for $n \\ge 1$ is proved by rewriting with pow_succ' and discharging the exponent equality n = (n-1)+1 with omega.",
     "significance": "key",
     "relatedConcepts": [
       "Nat.sum_range_choose",
       "total row sum 2^n",
-      "pow_succ",
+      "pow_succ'",
       "cancellation 2E = 2^n"
     ],
     "prerequisites": [
       "total row sum ∑ C(n,k) = 2^n",
       "casting Nat sums to ℤ"
+    ]
+  },
+  {
+    "id": "worked-verification",
+    "proofId": "combinations-formula-oq-05",
+    "range": { "startLine": 109, "endLine": 114 },
+    "type": "context",
+    "title": "Worked Verification (Row 4)",
+    "content": "A closing example evaluates the even part of row 4 by decide: ∑_{k even, k ≤ 4} C(4,k) = C(4,0)+C(4,2)+C(4,4) = 1+6+1 = 8. This is exactly 2^{4-1} = 2^3, a concrete instance of sum_even_choose. Because every quantity is a literal natural number, decide discharges the goal by kernel computation without invoking the general theorem — an independent cross-check of the formalized identity.",
+    "mathContext": "For $n=4$: the even-indexed terms are $\\binom{4}{0}+\\binom{4}{2}+\\binom{4}{4} = 1+6+1 = 8 = 2^3 = 2^{n-1}$, and correspondingly the odd part $\\binom{4}{1}+\\binom{4}{3} = 4+4 = 8$. Both halves equal $2^{n-1}$, matching the general result.",
+    "significance": "context",
+    "relatedConcepts": [
+      "decide tactic",
+      "kernel computation",
+      "concrete verification of an identity"
+    ],
+    "prerequisites": [
+      "evaluating Nat.choose on literals"
     ]
   }
 ]

--- a/src/data/proofs/combinations-formula-oq-05/index.ts
+++ b/src/data/proofs/combinations-formula-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CombinationsFormulaOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const combinationsFormulaOq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const combinationsFormulaOq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const combinationsFormulaOq05Data: ProofData = {
+  proof: combinationsFormulaOq05Proof,
+  annotations: combinationsFormulaOq05Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-05`.

## Changes
- **Added missing `index.ts`** — the entry had none, so the proof page would render 'proof not found' on the live site despite appearing in the gallery listing. Now discoverable by Vite's `import.meta.glob` (matches the established sibling pattern, e.g. combinations-formula-oq-04).
- **Split the each-half annotation** (previously spanned lines 86–114, conflating the theorem with the closing example) into:
  - a tightened theorem annotation (86–107) describing the 2E = 2^n = 2·2^{n-1} cancellation, and
  - a dedicated **worked-verification** annotation (109–114) with mathContext showing both parity halves of row 4 equal 2^{n-1} (even: 1+6+1=8; odd: 4+4=8).
- Entry now has **5 annotations**, all carrying `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

## Integrity
- `status: verified`, `axiomCount: 0` confirmed against the Lean source (no `axiom` decls, no assumption-carrying structures; `decide` used only in an illustrative literal-arithmetic example, not the substantive theorems).
- Gallery enrichment build step parses meta.json/annotations.json cleanly.

meta.json unchanged (7.9 KB, well under caps).