### PR TITLE
Enrich Alternating Fibonacci Binomial Transform (fibonacci-identities-oq-06-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ06OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ06OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ06OQ01OQ02Data: ProofData = {
+  proof: fibonacciIdentitiesOQ06OQ01OQ02Proof,
+  annotations: fibonacciIdentitiesOQ06OQ01OQ02Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/meta.json
@@ -116,7 +116,12 @@
   "conclusion": {
     "summary": "Establishes the alternating (signed) Fibonacci binomial transform ∑_{k≤n} (−1)ᵏ C(n,k) F₍ₙ₊d₊ₖ₎ = (−1)ⁿ F_d, the x = −1 companion of the parent's positive transform ∑ C(n,k) Fₘ₊ₖ = F₂ₙ₊ₘ. The reusable primitive signed_pascal_conv (a signed Pascal convolution over ℤ) drives the induction; the Fibonacci recurrence enters only at the final contraction. 4 theorems, 0 sorries, 0 axioms.",
     "implications": "Together the two entries realize both the positive and alternating binomial transforms of the Fibonacci sequence as machine-checked identities, mirroring the two golden-ratio facts 1 + φ = φ² and 1 − φ = ψ. signed_pascal_conv is stated for an arbitrary integer sequence and so is immediately reusable for the alternating binomial transform of any g : ℕ → ℤ — the general finite-difference machinery, not just its Fibonacci instance.",
-    "openQuestions": []
+    "openQuestions": [
+      "Interpolate between the two transforms: the positive (x = 1) transform gives F₂ₙ₊ₘ and the alternating (x = −1) transform gives (−1)ⁿ F₍ₘ₋ₙ₎. Determine the closed form of the full weighted transform ∑_{k≤n} xᵏ C(n,k) F₍ₘ₊ₖ₎ for a formal parameter x, which by Binet applies ∑ C(n,k)(xφ)ᵏ = (1 + xφ)ⁿ and (1 + xψ)ⁿ; identify when (1 + xφ, 1 + xψ) are again a scaled conjugate pair of golden type.",
+      "Prove the alternating binomial transform for the companion Lucas numbers Lₙ and, more generally, for an arbitrary Lucas sequence Uₙ(P,Q) / Vₙ(P,Q): signed_pascal_conv is sequence-agnostic, so the only new input is the two-term recurrence at the final contraction — is the closed form always (−1)ⁿ times a shifted term, or does the sign/shift depend on the discriminant P² − 4Q?",
+      "Upgrade signed_pascal_conv to a structural theorem about the n-th forward-difference operator Δⁿ acting on any linear-recurrence sequence: characterize precisely which sequences g have Δⁿ g in closed form, recovering the Fibonacci result as the case where the characteristic roots satisfy φψ = −1.",
+      "Formalize the iterated / higher-order version: does composing the transform (applying Δ repeatedly, or the two-variable transform ∑ C(n,j)C(n,k)(−1)ᵏ F₍ₘ₊ⱼ₊ₖ₎) collapse to a single Fibonacci term, and is there a q-analogue replacing C(n,k) by the Gaussian binomial coefficient?"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-06-oq-01-oq-02`.

**Critical fix:** added the missing `index.ts` — without it Vite's `import.meta.glob` cannot discover the proof and the page shows 'proof not found' on the live site.

**Content:** the `conclusion.openQuestions` array was empty; filled it with 4 substantive, mathematically-grounded extensions:
- the x-parametrized transform ∑ xᵏ C(n,k) F₍ₘ₊ₖ₎ interpolating between the positive (x=1 → F₂ₙ₊ₘ) and alternating (x=−1 → (−1)ⁿF₍ₘ₋ₙ₎) cases via Binet;
- the Lucas-sequence generalization Uₙ(P,Q)/Vₙ(P,Q) exploiting that `signed_pascal_conv` is sequence-agnostic;
- a structural theorem on the n-th forward-difference operator Δⁿ over linear recurrences;
- the iterated / q-analogue (Gaussian binomial) version.

meta.json (already richly enriched: overview, 4 keyInsights, sections with mathContext, 3 full annotations) stays well under all size caps; no field inflation.