### PR TITLE
Enrich Egorov Sharpness (egorov-theorem-oq-01-oq-03)

### DIFF
--- a/src/data/proofs/egorov-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/egorov-theorem-oq-01-oq-03/annotations.json
@@ -28,7 +28,7 @@
     "id": "ann-egorov-oq0103-marching",
     "proofId": "egorov-theorem-oq-01-oq-03",
     "range": {
-      "startLine": 60,
+      "startLine": 63,
       "endLine": 66
     },
     "type": "definition",
@@ -91,6 +91,32 @@
       "Real.volume_Ici",
       "measure_mono",
       "Nat.floor bounds"
+    ]
+  },
+  {
+    "id": "ann-egorov-oq0103-integral-measure",
+    "proofId": "egorov-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 147,
+      "endLine": 210
+    },
+    "type": "theorem",
+    "title": "The Integral and Convergence-in-Measure Faces",
+    "content": "The same marching counterexample defeats two further finite-measure principles. marching_integral_eq_one computes ∫ fₙ = vol[n,n+1] = 1 (via integral_indicator + setIntegral_const + Real.volume_real_Icc_of_le), so a fixed unit of mass is conserved for every n; marching_integral_not_tendsto_zero then observes ∫ fₙ ≡ 1 → 1 ≠ 0 = ∫(lim fₙ) (tendsto_const_nhds_iff), breaking the limit–integral interchange — the mechanism behind the failure of dominated/bounded convergence on infinite measure. marching_not_tendstoInMeasure gives the third face: for ε = 1/2 the bad set {x : 1/2 ≤ ‖fₙ(x)‖} = [n,n+1] has constant measure 1, so fₙ does not converge to 0 in measure, even though it converges everywhere. On a finite-measure space a.e. convergence would force convergence in measure; here the escaping unit of mass defeats all three implications at once.",
+    "mathContext": "$\\int f_n = 1 \\not\\to 0$ and $\\mathrm{vol}\\{x:\\tfrac12\\le\\|f_n(x)\\|\\}=1\\not\\to 0$: the integral and in-measure faces of mass escaping to $+\\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "limit–integral interchange",
+      "dominated convergence theorem",
+      "convergence in measure",
+      "tightness / uniform integrability",
+      "mass escaping to infinity"
+    ],
+    "prerequisites": [
+      "MeasureTheory.integral_indicator",
+      "Real.volume_real_Icc_of_le",
+      "tendsto_const_nhds_iff",
+      "TendstoInMeasure"
     ]
   }
 ]

--- a/src/data/proofs/egorov-theorem-oq-01-oq-03/index.ts
+++ b/src/data/proofs/egorov-theorem-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EgorovTheoremOQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const egorovTheoremOQ01OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const egorovTheoremOQ01OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const egorovTheoremOQ01OQ03Data: ProofData = {
+  proof: egorovTheoremOQ01OQ03Proof,
+  annotations: egorovTheoremOQ01OQ03Annotations,
+}

--- a/src/data/proofs/egorov-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/egorov-theorem-oq-01-oq-03/meta.json
@@ -22,6 +22,7 @@
     "sorries": 0
   },
   "title": "Sharpness of Egorov: the Finite-Measure Hypothesis is Essential",
+  "description": "Shows Egorov's theorem is sharp in its ambient hypothesis: the finiteness of the total measure cannot be dropped. On (ℝ, Lebesgue) the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at every point, yet for any set s of finite Lebesgue measure they fail to converge uniformly to 0 on sᶜ — killing the bump uniformly past index N would force the infinite-measure tail [N,∞) into s. The same escaping unit of mass also breaks the limit–integral interchange (∫ fₙ = 1 ↛ 0) and convergence in measure. Mathlib has the abstract Egorov theorem but not this counterexample witnessing the necessity of finiteness. Fully machine-checked: 7 theorems, 1 definition, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -168,15 +169,31 @@
       "mathContext": "Uniform 1/2-control off s past index N ⇒ the tail [N,∞) ⊆ s ⇒ vol s = ∞, contradicting finiteness. Only monotonicity of measure is used; s need not be measurable."
     },
     {
+      "id": "integral-face",
+      "title": "The Integral Face: Mass Escaping to Infinity",
+      "startLine": 135,
+      "endLine": 163,
+      "summary": "marching_integral_eq_one: each fₙ = 𝟙_[n,n+1] integrates to exactly 1 (∫ = vol[n,n+1] = 1) via integral_indicator + setIntegral_const, so mass is conserved even as the bump escapes. marching_integral_not_tendsto_zero: since ∫ fₙ ≡ 1, the integral sequence converges to 1 ≠ 0 = ∫(lim fₙ), so the same counterexample defeats the limit–integral interchange (and dominated/bounded convergence) on infinite measure.",
+      "mathContext": "$\\int f_n = 1$ for all $n$, yet $f_n \\to 0$ pointwise, so $\\lim_n \\int f_n = 1 \\ne 0 = \\int \\lim_n f_n$."
+    },
+    {
       "id": "conv-in-measure",
       "title": "No Convergence in Measure",
-      "summary": "marching_not_tendstoInMeasure: fₙ → 0 everywhere but not in measure on (ℝ, vol). For ε = 1/2 the bad set {x : 1/2 ≤ edist (fₙ x) 0} equals [n,n+1] (volume 1, constant), so it cannot tend to 0 — the infinite-measure failure of the a.e. ⇒ in-measure implication that holds on finite-measure spaces."
+      "startLine": 164,
+      "endLine": 210,
+      "summary": "marching_not_tendstoInMeasure: fₙ → 0 everywhere but not in measure on (ℝ, vol). For ε = 1/2 the bad set {x : 1/2 ≤ edist (fₙ x) 0} equals [n,n+1] (volume 1, constant), so it cannot tend to 0 — the infinite-measure failure of the a.e. ⇒ in-measure implication that holds on finite-measure spaces.",
+      "mathContext": "$\\mathrm{vol}\\{x : \\tfrac12 \\le \\|f_n(x)\\|\\} = \\mathrm{vol}[n,n+1] = 1 \\not\\to 0$, so $f_n \\not\\to 0$ in measure."
     }
   ],
   "sorries": 0,
   "conclusion": {
-    "summary": "The finite-measure hypothesis in Egorov's theorem is essential. On (ℝ, Lebesgue) the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at every point (marching_tendsto_zero), yet for any set s of finite Lebesgue measure they fail to converge uniformly to 0 on sᶜ (marching_not_tendstoUniformlyOn_of_volume_lt_top): uniform 1/2-control off s would force the infinite-measure tail [N,∞) into s. Packaged as volume_finite_hypothesis_essential (no finite-measure exceptional set exists) and marching_not_tendstoUniformlyOn_univ (non-uniformity on all of ℝ). The same construction is read through integrals: each fₙ has integral 1 (marching_integral_eq_one), so ∫ fₙ = 1 ↛ 0 = ∫(lim fₙ) (marching_integral_not_tendsto_zero) — the mass-escaping-to-infinity, integral-side face of the infinite-measure pathology. 163 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries. A convergence-in-measure face is also added: fₙ → 0 everywhere yet not in measure, the infinite-measure failure of the a.e. ⇒ in-measure implication.",
+    "summary": "The finite-measure hypothesis in Egorov's theorem is essential. On (ℝ, Lebesgue) the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at every point (marching_tendsto_zero), yet for any set s of finite Lebesgue measure they fail to converge uniformly to 0 on sᶜ (marching_not_tendstoUniformlyOn_of_volume_lt_top): uniform 1/2-control off s would force the infinite-measure tail [N,∞) into s. Packaged as volume_finite_hypothesis_essential (no finite-measure exceptional set exists) and marching_not_tendstoUniformlyOn_univ (non-uniformity on all of ℝ). The same construction is read through integrals: each fₙ has integral 1 (marching_integral_eq_one), so ∫ fₙ = 1 ↛ 0 = ∫(lim fₙ) (marching_integral_not_tendsto_zero) — the mass-escaping-to-infinity, integral-side face of the infinite-measure pathology. 210 lines, 7 theorems, 1 definition, 0 axioms, 0 sorries. A convergence-in-measure face is also added: fₙ → 0 everywhere yet not in measure, the infinite-measure failure of the a.e. ⇒ in-measure implication.",
     "implications": "Together with the parent entry — which shows the removed exceptional set cannot be taken null on a finite-measure example — this delimits Egorov's theorem from both sides: the conclusion needs a genuinely positive exceptional set, and the hypothesis needs genuinely finite total measure. The integral view links the failure to the failure of the limit–integral interchange (and dominated/bounded convergence) on infinite-measure spaces: a single escaping unit of mass defeats both. The counterexample is original to the gallery; Mathlib has the theorem but not the sharpness witness.",
-    "openQuestions": []
+    "openQuestions": [
+      "Quantify the failure: for the marching indicators, is there a sharp lower bound on vol{x ∈ sᶜ : sup_{n≥N} fₙ(x) ≥ 1/2} in terms of vol s, making 'uniformity forces the whole tail into s' a quantitative measure-lower-bound statement rather than an all-or-nothing contradiction?",
+      "Characterize which σ-finite (infinite total measure) spaces admit an Egorov-type theorem after all — e.g. does a weighted/finite equivalent measure ν ≈ vol restore uniform convergence off a ν-small set, and does the marching example survive such a reweighting?",
+      "Formalize the positive counterpart on the same space: identify the exact class of sequences on (ℝ, vol) for which a finite-measure exceptional set DOES suffice (e.g. sequences with uniformly integrable or tight tails), separating them from the marching-bump obstruction by a tightness condition.",
+      "State and prove the general principle behind the three faces (non-uniformity, ∫ fₙ ↛ ∫ lim, non-convergence in measure) as a single theorem on tightness: on an infinite-measure space, everywhere convergence upgrades to none of the three exactly when mass can escape to infinity."
+    ]
   }
 }


### PR DESCRIPTION
Enrichment pass for `egorov-theorem-oq-01-oq-03`.

**Critical fixes**
- Added the missing `index.ts` — without it Vite's `import.meta.glob` cannot discover the proof and the page renders 'proof not found' on the live site.
- Added the missing top-level `description` field (the index.ts / Proof type expects it).

**Coverage & accuracy**
- Added an `integral-face` section (lines 135–163) and gave the `conv-in-measure` section its missing line range (164–210) — previously the integral theorems and the convergence-in-measure theorem were not covered by any section.
- Added an annotation covering the integral + in-measure theorem faces (∫ fₙ = 1 ↛ 0; bad set of constant measure 1).
- Corrected stale conclusion prose: '163 lines, 6 theorems' → '210 lines, 7 theorems' (matches leanFile).

**Content**
- Filled the empty `conclusion.openQuestions` with 4 substantive extensions (quantitative measure lower bounds, σ-finite reweighting, the positive tightness counterpart, and a unified tightness principle behind the three failure faces).

meta.json stays well under all size caps; existing rich fields were preserved.