### PR TITLE
research(cube-root-3-irrational-oq-01-oq-03): Eisenstein for Xⁿ − a at composite a [VERIFIED, 0-axiom, +7thm]

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ01OQ03.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ01OQ03.lean
@@ -1,0 +1,143 @@
+/-
+# Eisenstein for `Xⁿ − a` at a composite `a` — the squarefree-at-a-prime criterion
+  (OQ-01-OQ-03 of ∛3)
+
+The parent entry **cube-root-3-irrational-oq-01** proves, via Mathlib's
+`Polynomial.irreducible_of_eisenstein_criterion` at the prime ideal `(p) ⊆ ℤ`,
+that `Xⁿ − p` is irreducible over `ℤ` (and `ℚ`) for every **prime** `p` and every
+`n ≥ 1`. That hypothesis — `a` *is itself a prime* — is stronger than Eisenstein
+actually needs: Eisenstein at a prime `q` only asks that `q` divide the constant
+term to the *first* power. So the criterion applies to `Xⁿ − a` whenever there is
+**some** prime `q` with
+
+    q ∣ a    and    q² ∤ a
+
+("`a` is squarefree at `q`"), with no requirement that `a` itself be prime, or
+even squarefree overall. This file proves that generalization and specializes it
+to constants the prime-only parent cannot reach — e.g. `X² − 6`, `X³ − 12`,
+`X² − 24` — where `a` is composite but still carries an exactly-simple prime
+factor.
+
+Verification of the Eisenstein hypotheses for `Xⁿ − a` at the witnessing prime
+`q` (`hdvd : q ∣ a`, `hndvd : q² ∤ a`):
+  * leading coefficient `1 ∉ (q)` — the ideal is proper;
+  * every lower coefficient is `0` or `−a`, and `−a ∈ (q)` because `q ∣ a`;
+  * the constant coefficient `−a ∉ (q)²`, exactly the hypothesis `q² ∤ a`;
+  * `Xⁿ − a` is monic, hence primitive.
+
+The prime case `a = p` of the parent is recovered by taking `q = p` (`p ∣ p`,
+`p² ∤ p`). Zero axioms; imports only Mathlib.
+-/
+import Mathlib
+
+open Polynomial
+
+namespace CubeRoot3IrrationalOQ01OQ03
+
+/- ## The general Eisenstein irreducibility theorem over `ℤ` -/
+
+/-- **Eisenstein at a witnessing prime `q`.** If a prime `q` divides `a` exactly
+to the first power (`q ∣ a` but `q² ∤ a`), then `Xⁿ − a` is irreducible over `ℤ`
+for every `n ≥ 1`. No primality (or squarefreeness) of `a` itself is required. -/
+theorem irreducible_X_pow_sub_C_of_squarefree_at_prime_int
+    {a : ℤ} {q : ℕ} (hq : q.Prime) (hdvd : (q : ℤ) ∣ a) (hndvd : ¬ ((q : ℤ) ^ 2 ∣ a))
+    {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : ℤ[X]) ^ n - C a) := by
+  have hqZ : Prime (q : ℤ) := Nat.prime_iff_prime_int.mp hq
+  have hq0 : (q : ℤ) ≠ 0 := hqZ.ne_zero
+  set P : Ideal ℤ := Ideal.span {(q : ℤ)} with hP
+  have hPprime : P.IsPrime := (Ideal.span_singleton_prime hq0).mpr hqZ
+  have hmonic : ((X : ℤ[X]) ^ n - C a).Monic := monic_X_pow_sub_C a hn.ne'
+  have hdeg : ((X : ℤ[X]) ^ n - C a).degree = n := degree_X_pow_sub_C hn a
+  apply irreducible_of_eisenstein_criterion hPprime
+  · -- leading coefficient `1 ∉ P`
+    rw [hmonic.leadingCoeff]
+    intro h1
+    exact hPprime.ne_top (Ideal.eq_top_of_isUnit_mem P h1 isUnit_one)
+  · -- every coefficient below the top degree lies in `P`
+    intro m hm
+    have hmn : m < n := by rw [hdeg] at hm; exact_mod_cast hm
+    rw [coeff_sub, coeff_X_pow, coeff_C]
+    rw [if_neg (by omega : ¬ m = n)]
+    split_ifs with h0m
+    · -- `m = 0`: the coefficient is `0 − a = −a ∈ P`, since `q ∣ a`
+      have : a ∈ P := Ideal.mem_span_singleton.mpr hdvd
+      simpa using P.neg_mem this
+    · -- otherwise the coefficient is `0`
+      simp
+  · -- positive degree
+    rw [hdeg]; exact_mod_cast hn
+  · -- constant coefficient `−a ∉ P²`, i.e. `q² ∤ a`
+    have hc : ((X : ℤ[X]) ^ n - C a).coeff 0 = -a := by
+      have hx0 : ((X : ℤ[X]) ^ n).coeff 0 = 0 := by
+        rw [coeff_X_pow]; exact if_neg (by omega)
+      rw [coeff_sub, hx0, coeff_C_zero, zero_sub]
+    rw [hc]
+    intro hmem
+    rw [Ideal.neg_mem_iff, hP, Ideal.span_singleton_pow, Ideal.mem_span_singleton] at hmem
+    exact hndvd hmem
+  · -- primitive, because monic
+    exact hmonic.isPrimitive
+
+/- ## Transfer to `ℚ` via Gauss's lemma -/
+
+/-- **`Xⁿ − a` is irreducible over `ℚ`** under the same squarefree-at-a-prime
+hypothesis. Gauss's lemma lifts the integer irreducibility, after identifying the
+casted polynomial with `Xⁿ − a` over `ℚ`. -/
+theorem irreducible_X_pow_sub_C_of_squarefree_at_prime_rat
+    {a : ℤ} {q : ℕ} (hq : q.Prime) (hdvd : (q : ℤ) ∣ a) (hndvd : ¬ ((q : ℤ) ^ 2 ∣ a))
+    {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : ℚ[X]) ^ n - C (a : ℚ)) := by
+  have hprim : ((X : ℤ[X]) ^ n - C a).IsPrimitive :=
+    (monic_X_pow_sub_C a hn.ne').isPrimitive
+  have hmap : ((X : ℤ[X]) ^ n - C a).map (Int.castRingHom ℚ)
+      = (X : ℚ[X]) ^ n - C (a : ℚ) := by
+    simp [Polynomial.map_sub, Polynomial.map_pow]
+  have hiff := Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast hprim
+  rw [← hmap, ← hiff]
+  exact irreducible_X_pow_sub_C_of_squarefree_at_prime_int hq hdvd hndvd hn
+
+/- ## The prime case of the parent is a special case -/
+
+/-- Recovering the parent theorem: for a prime `p`, `Xⁿ − p` is irreducible over
+`ℤ` — take the witnessing prime `q = p` (`p ∣ p`, and `p² ∤ p`). -/
+theorem irreducible_X_pow_sub_C_prime_int {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : ℤ[X]) ^ n - C (p : ℤ)) := by
+  refine irreducible_X_pow_sub_C_of_squarefree_at_prime_int hp (dvd_refl _) ?_ hn
+  -- `p² ∤ p`: else cancelling one `p` gives `p ∣ 1`, impossible.
+  have hpZ : Prime (p : ℤ) := Nat.prime_iff_prime_int.mp hp
+  intro hmem
+  rw [sq] at hmem
+  have hdvd1 : (p : ℤ) ∣ 1 := by
+    have h2 : (p : ℤ) * (p : ℤ) ∣ (p : ℤ) * 1 := by rwa [mul_one]
+    exact (mul_dvd_mul_iff_left hpZ.ne_zero).mp h2
+  exact hpZ.not_unit (isUnit_of_dvd_one hdvd1)
+
+/- ## Specializations the prime-only parent cannot reach -/
+
+/-- `X² − 6` is irreducible over `ℚ`: `6 = 2·3` is not prime, but it is squarefree
+at `q = 2` (`2 ∣ 6`, `4 ∤ 6`). Hence `√6` has degree exactly `2` — irrational. -/
+theorem irreducible_X_sq_sub_six_rat :
+    Irreducible ((X : ℚ[X]) ^ 2 - C (6 : ℚ)) := by
+  have h := irreducible_X_pow_sub_C_of_squarefree_at_prime_rat
+    (a := 6) (q := 2) (by norm_num) (by norm_num) (by norm_num) (n := 2) (by norm_num)
+  simpa using h
+
+/-- `X³ − 12` is irreducible over `ℚ`: `12 = 2²·3` is neither prime nor squarefree,
+but it is squarefree at `q = 3` (`3 ∣ 12`, `9 ∤ 12`). Hence `∛12` has degree `3`. -/
+theorem irreducible_X_cubed_sub_twelve_rat :
+    Irreducible ((X : ℚ[X]) ^ 3 - C (12 : ℚ)) := by
+  have h := irreducible_X_pow_sub_C_of_squarefree_at_prime_rat
+    (a := 12) (q := 3) (by norm_num) (by norm_num) (by norm_num) (n := 3) (by norm_num)
+  simpa using h
+
+/-- `X² − 24` is irreducible over `ℚ`: `24 = 2³·3` is squarefree at `q = 3`
+(`3 ∣ 24`, `9 ∤ 24`). Hence `√24` has degree `2`. (Note `24` is *not* squarefree,
+yet the single simple prime factor `3` is all Eisenstein needs.) -/
+theorem irreducible_X_sq_sub_twentyfour_rat :
+    Irreducible ((X : ℚ[X]) ^ 2 - C (24 : ℚ)) := by
+  have h := irreducible_X_pow_sub_C_of_squarefree_at_prime_rat
+    (a := 24) (q := 3) (by norm_num) (by norm_num) (by norm_num) (n := 2) (by norm_num)
+  simpa using h
+
+end CubeRoot3IrrationalOQ01OQ03

--- a/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "cube-root-3-irrational-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "concept",
+    "title": "Relaxing Eisenstein's constant: from a prime to squarefree-at-a-prime",
+    "content": "The docstring frames the entry against its parent cube-root-3-irrational-oq-01, which proves Xⁿ − p irreducible for prime p and asks to relax the constant to 'a squarefree at some prime'. The key point is that Eisenstein at a prime q only needs q to divide the constant term to the FIRST power — nothing forces the whole constant a to be prime. So Xⁿ − a is irreducible over ℤ (and ℚ) whenever there is a prime q with q ∣ a and q² ∤ a. The file imports only Mathlib in namespace CubeRoot3IrrationalOQ01OQ03 with open Polynomial.",
+    "mathContext": "Goal: $X^n - a$ irreducible over $\\mathbb{Z}$ and $\\mathbb{Q}$ whenever some prime $q$ satisfies $q \\mid a$ and $q^2 \\nmid a$, for $n \\ge 1$. Since $X^n - a$ is the minimal polynomial of $a^{1/n}$, irreducibility pins $[\\mathbb{Q}(a^{1/n}):\\mathbb{Q}] = n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Eisenstein's criterion", "minimal polynomial", "algebraic degree", "squarefree"]
+  },
+  {
+    "id": "ann-general-int",
+    "proofId": "cube-root-3-irrational-oq-01-oq-03",
+    "range": { "startLine": 42, "endLine": 80 },
+    "type": "proof-technique",
+    "title": "The four Eisenstein hypotheses at P = span{q}",
+    "content": "irreducible_X_pow_sub_C_of_squarefree_at_prime_int applies irreducible_of_eisenstein_criterion at the prime ideal P = span{q}. The four checks: (1) leadingCoeff = 1 ∉ P since P is proper; (2) each coefficient below degree n is 0 or −a, and the m = 0 case −a ∈ P follows from q ∣ a via Ideal.mem_span_singleton.mpr then neg_mem; (3) 0 < degree = n by degree_X_pow_sub_C; (4) the constant −a ∉ P² is reduced by Ideal.neg_mem_iff, Ideal.span_singleton_pow, and Ideal.mem_span_singleton to ¬ (q² ∣ a) — exactly the hypothesis; (5) monic_X_pow_sub_C gives monic, hence primitive.",
+    "mathContext": "The two divisibility hypotheses map onto the two Eisenstein sides: $q \\mid a$ is $-a \\in (q)$; $q^2 \\nmid a$ is $-a \\notin (q^2) = (q)^2$.",
+    "significance": "critical",
+    "relatedConcepts": ["prime ideal", "Ideal.span_singleton_pow", "coefficient of Xⁿ − C a", "primitive polynomial"]
+  },
+  {
+    "id": "ann-gauss",
+    "proofId": "cube-root-3-irrational-oq-01-oq-03",
+    "range": { "startLine": 87, "endLine": 98 },
+    "type": "proof-technique",
+    "title": "Gauss's lemma lifts ℤ-irreducibility to ℚ",
+    "content": "irreducible_X_pow_sub_C_of_squarefree_at_prime_rat uses IsPrimitive.Int.irreducible_iff_irreducible_map_cast: a primitive integer polynomial is irreducible over ℤ iff its image in ℚ[X] is. After identifying the casted polynomial with Xⁿ − C (a : ℚ) via map_sub/map_pow, the ℚ result is exactly the ℤ theorem.",
+    "mathContext": "Field irreducibility (over $\\mathbb{Q}$) is what pins the algebraic degree of the radical $a^{1/n}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gauss's lemma", "primitive polynomial", "polynomial map"]
+  },
+  {
+    "id": "ann-prime-case",
+    "proofId": "cube-root-3-irrational-oq-01-oq-03",
+    "range": { "startLine": 104, "endLine": 114 },
+    "type": "concept",
+    "title": "The parent's prime case is the corollary q = p",
+    "content": "irreducible_X_pow_sub_C_prime_int recovers the parent theorem: for prime p take the witnessing prime q = p. Then p ∣ p is dvd_refl, and p² ∤ p because p² ∣ p would cancel one factor (mul_dvd_mul_iff_left) to give p ∣ 1, contradicting primality. So the new criterion strictly subsumes the prime-only parent.",
+    "mathContext": "$p$ prime $\\Rightarrow p \\mid p$ and $p^2 \\nmid p$, so every prime radicand is a special case.",
+    "significance": "supporting",
+    "relatedConcepts": ["dvd_refl", "mul_dvd_mul_iff_left", "prime"]
+  },
+  {
+    "id": "ann-composite",
+    "proofId": "cube-root-3-irrational-oq-01-oq-03",
+    "range": { "startLine": 120, "endLine": 142 },
+    "type": "example",
+    "title": "Composite (and non-squarefree) radicands: √6, ∛12, √24",
+    "content": "Three specializations the prime-only parent cannot reach. X² − 6 (6 = 2·3, squarefree at 2), X³ − 12 (12 = 2²·3, non-squarefree but squarefree at 3), X² − 24 (24 = 2³·3, squarefree at 3) are all irreducible over ℚ; the divisibility side-goals q ∣ a and ¬ (q² ∣ a) are closed by norm_num. Hence √6, ∛12, √24 have algebraic degree exactly 2, 3, 2 — a single simple prime factor is all Eisenstein needs, even when a itself is not squarefree.",
+    "mathContext": "$12 = 2^2 \\cdot 3$ fails global squarefreeness, yet $3 \\mid 12$ and $9 \\nmid 12$, so Eisenstein at $q = 3$ still certifies $X^3 - 12$ irreducible.",
+    "significance": "critical",
+    "relatedConcepts": ["algebraic degree of radicals", "non-squarefree radicand", "norm_num"]
+  }
+]

--- a/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/meta.json
@@ -1,0 +1,200 @@
+{
+  "id": "cube-root-3-irrational-oq-01-oq-03",
+  "title": "Eisenstein for Xⁿ − a at a Composite a: the Squarefree-at-a-Prime Criterion",
+  "slug": "cube-root-3-irrational-oq-01-oq-03",
+  "description": "Answers the third open question of cube-root-3-irrational-oq-01: generalize the Eisenstein input from Xⁿ − p (p prime) to Xⁿ − a for any a that is squarefree at some prime. The key observation is that Eisenstein at a prime q only needs q to divide the constant term to the FIRST power, so Xⁿ − a is irreducible over ℤ (and ℚ, via Gauss) whenever there exists a prime q with q ∣ a and q² ∤ a — with no primality or squarefreeness required of a itself. Specializes to X² − 6, X³ − 12, X² − 24, where a is composite (and 12, 24 not even squarefree) yet still carries an exactly-simple prime factor — cases the prime-only parent cannot reach. The prime case p is recovered by taking q = p. Zero axioms, no native_decide.",
+  "meta": {
+    "author": "Gotthold Eisenstein (1850); Carl Friedrich Gauss; formalized in Lean 4",
+    "date": "1850",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CubeRoot3IrrationalOQ01OQ03.lean",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "eisenstein-criterion",
+      "irreducible-polynomial",
+      "gauss-lemma",
+      "algebraic-degree",
+      "squarefree"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 143,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "irreducible_X_pow_sub_C_of_squarefree_at_prime_int: Xⁿ − a is irreducible over ℤ whenever some prime q satisfies q ∣ a and q² ∤ a ('a squarefree at q'), for every n ≥ 1 — the generalization of the parent's prime-only theorem. Proved by verifying the four Eisenstein hypotheses at P = span{q}: leading coeff 1 ∉ P; lower coeffs 0 or −a, and −a ∈ P since q ∣ a; constant −a ∉ P² = span{q²}, which is exactly the hypothesis q² ∤ a; monic ⟹ primitive.",
+      "irreducible_X_pow_sub_C_of_squarefree_at_prime_rat: the same over ℚ, lifted by Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast).",
+      "irreducible_X_pow_sub_C_prime_int: recovers the parent's prime case as the specialization q = p (p ∣ p, p² ∤ p), showing the new criterion strictly subsumes it.",
+      "irreducible_X_sq_sub_six_rat, irreducible_X_cubed_sub_twelve_rat, irreducible_X_sq_sub_twentyfour_rat: X² − 6, X³ − 12, X² − 24 irreducible over ℚ — a = 6, 12, 24 are composite (12 = 2²·3 and 24 = 2³·3 not even squarefree), yet each has a simple prime factor (2 for 6; 3 for 12 and 24) that drives Eisenstein. So √6, ∛12, √24 have algebraic degree exactly 2, 3, 2 — degrees the prime-only parent could not certify."
+    ],
+    "prerequisites": [
+      "Eisenstein's irreducibility criterion (Mathlib's Polynomial.irreducible_of_eisenstein_criterion)",
+      "Gauss's lemma transferring ℤ-irreducibility of a primitive polynomial to ℚ",
+      "Prime ideals span {q} ⊆ ℤ, the power span {q}² = span {q²}, and elementary divisibility"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
+        "description": "Eisenstein's criterion: a primitive polynomial whose non-leading coeffs lie in a prime ideal P, with leading coeff ∉ P and constant coeff ∉ P², is irreducible.",
+        "module": "Mathlib.RingTheory.Polynomial.Eisenstein.Criterion"
+      },
+      {
+        "theorem": "Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+        "description": "Gauss's lemma: a primitive integer polynomial is irreducible iff its image in ℚ[X] is.",
+        "module": "Mathlib.RingTheory.Polynomial.GaussLemma"
+      },
+      {
+        "theorem": "Ideal.span_singleton_pow / Ideal.mem_span_singleton",
+        "description": "span{q}² = span{q²}, and membership in a singleton span is divisibility — the two facts that turn 'constant ∉ P²' into the arithmetic condition q² ∤ a.",
+        "module": "Mathlib.RingTheory.Ideal.Span"
+      },
+      {
+        "theorem": "monic_X_pow_sub_C / degree_X_pow_sub_C",
+        "description": "Xⁿ − C a is monic of degree n for n ≥ 1, for any constant a.",
+        "module": "Mathlib.Algebra.Polynomial.Monic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry cube-root-3-irrational-oq-01 proves Xⁿ − p irreducible for every PRIME p via Eisenstein at (p), and closes by asking whether the constant may be relaxed from a prime to any 'a squarefree at some prime'. The point is that Eisenstein's 1850 criterion never uses that a is prime: it only requires a witnessing prime q whose square does not divide the constant term. A composite a — even one that is not squarefree, like 12 = 2²·3 — qualifies as long as it has a single prime factor of multiplicity one (here 3, since 3 ∣ 12 but 9 ∤ 12).\n\nThis entry formalizes exactly that relaxation. It replaces the hypothesis 'p prime' by the pair (q ∣ a, q² ∤ a) for a witnessing prime q, and reruns the four Eisenstein checks at P = span{q}. Divisibility q ∣ a places −a in P (the lower-coefficient condition), and q² ∤ a is verbatim the requirement −a ∉ P² = span{q²}. Gauss's lemma lifts the result to ℚ. The prime-only theorem falls out as the case q = p.",
+    "problemStatement": "**Open Question (parent cube-root-3-irrational-oq-01)**: generalize the Eisenstein input to Xⁿ − a for any a that is squarefree-at-some-prime, not just a prime.\n\n**This entry**: proves Xⁿ − a irreducible over ℤ and ℚ whenever some prime q has q ∣ a and q² ∤ a, for every n ≥ 1; recovers the prime case q = p; and specializes to X² − 6, X³ − 12, X² − 24 (composite a).",
+    "text": "A 143-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. irreducible_X_pow_sub_C_of_squarefree_at_prime_int is the general criterion over ℤ; _rat transfers it to ℚ by Gauss; irreducible_X_pow_sub_C_prime_int recovers the parent's prime case; three specializations certify √6, ∛12, √24.",
+    "proofStrategy": "For Xⁿ − C a over ℤ with witnessing prime q, apply irreducible_of_eisenstein_criterion at P = span{q}: (1) leadingCoeff = 1 ∉ P since P is proper; (2) every coefficient below degree n is 0 or −a — the m = 0 case is −a ∈ P because a ∈ span{q} ⟺ q ∣ a (Ideal.mem_span_singleton.mpr hdvd, then neg_mem); (3) 0 < degree = n (degree_X_pow_sub_C); (4) the constant coefficient is −a, and −a ∉ P² is reduced by Ideal.neg_mem_iff + Ideal.span_singleton_pow + Ideal.mem_span_singleton to ¬ (q² ∣ a), which is the hypothesis hndvd; (5) Xⁿ − C a is monic (monic_X_pow_sub_C), hence primitive. Gauss's lemma gives the ℚ version after simp-normalizing map_sub/map_pow. The prime case sets q = p and discharges p² ∤ p by cancelling one factor of p (mul_dvd_mul_iff_left) to reach p ∣ 1. The composite specializations instantiate a, q, n and close the divisibility side-goals by norm_num.",
+    "keyInsights": [
+      "Eisenstein's criterion is agnostic to whether the constant a is prime — it only needs one prime q dividing a to exactly the first power. The parent's 'a prime' is a convenient but inessential special case.",
+      "The condition splits cleanly along the two Eisenstein sides: q ∣ a is the lower-coefficient membership −a ∈ (q); q² ∤ a is the constant-term exclusion −a ∉ (q²). Ideal.span_singleton_pow makes 'P² = span{q²}' the bridge.",
+      "a need not be squarefree overall: 12 = 2²·3 and 24 = 2³·3 both fail global squarefreeness yet are squarefree at 3, and that single simple factor suffices. This is strictly beyond the prime-only parent.",
+      "Irreducibility ⟹ degree: Xⁿ − a is the minimal polynomial of a^{1/n}, so the criterion pins [ℚ(a^{1/n}):ℚ] = n for composite radicands too (√6 degree 2, ∛12 degree 3).",
+      "The generalization costs nothing structurally — the same five-step Eisenstein verification carries over verbatim with 'p prime' replaced by the two divisibility hypotheses, and the prime case is a one-line corollary."
+    ]
+  },
+  "sections": [
+    {
+      "id": "general-int",
+      "title": "The Squarefree-at-a-Prime Criterion over ℤ",
+      "startLine": 42,
+      "endLine": 80,
+      "summary": "irreducible_X_pow_sub_C_of_squarefree_at_prime_int: Xⁿ − a irreducible over ℤ when some prime q has q ∣ a and q² ∤ a, verifying the four Eisenstein hypotheses at P = span{q}.",
+      "mathContext": "The general integer irreducibility — the heart of the entry, relaxing 'a prime' to a witnessing prime."
+    },
+    {
+      "id": "gauss-rat",
+      "title": "Transfer to ℚ via Gauss's Lemma",
+      "startLine": 87,
+      "endLine": 98,
+      "summary": "irreducible_X_pow_sub_C_of_squarefree_at_prime_rat lifts the ℤ result to ℚ using IsPrimitive.Int.irreducible_iff_irreducible_map_cast.",
+      "mathContext": "Field-level irreducibility, relevant to minimal polynomials of radicals."
+    },
+    {
+      "id": "prime-case",
+      "title": "Recovering the Parent's Prime Case",
+      "startLine": 104,
+      "endLine": 114,
+      "summary": "irreducible_X_pow_sub_C_prime_int: for prime p, take q = p (p ∣ p, p² ∤ p) to get Xⁿ − p irreducible — the parent theorem as a corollary.",
+      "mathContext": "Shows the new criterion strictly subsumes the prime-only parent."
+    },
+    {
+      "id": "composite-specializations",
+      "title": "Composite Radicands the Parent Cannot Reach",
+      "startLine": 120,
+      "endLine": 142,
+      "summary": "X² − 6, X³ − 12, X² − 24 irreducible over ℚ: a = 6, 12, 24 composite (12, 24 not squarefree), each squarefree at one prime — so √6, ∛12, √24 have degree 2, 3, 2.",
+      "mathContext": "Demonstrates the generalization on constants outside the prime-only scope."
+    }
+  ],
+  "conclusion": {
+    "summary": "Via Eisenstein's criterion at the prime ideal (q) and Gauss's lemma, this entry proves Xⁿ − a irreducible over ℤ and ℚ whenever some prime q divides a exactly once (q ∣ a, q² ∤ a), for every n ≥ 1 — answering the parent's third open question. It recovers the prime case as q = p and certifies X² − 6, X³ − 12, X² − 24, whose radicands are composite (12, 24 not even squarefree) yet carry a simple prime factor.",
+    "implications": "The irreducibility (hence algebraic degree n) of radicals a^{1/n} extends far beyond prime radicands: any a with a single exactly-simple prime factor works, so √6, ∛12, √24 are pinned at degrees 2, 3, 2 with the same uniform argument. The criterion isolates precisely what Eisenstein needs from the constant term — one prime of multiplicity one — divorced from primality or global squarefreeness of a.",
+    "openQuestions": [
+      "Characterize exactly which a admit an irreducible Xⁿ − a over ℚ (Eisenstein is sufficient, not necessary — e.g. Xⁿ − a can be irreducible with a a perfect prime power for suitable n).",
+      "Transfer to a general Dedekind/UFD base ring, where 'squarefree at a prime' becomes 'a prime element dividing a but not a²'.",
+      "Connect the degree conclusion to minpoly ℚ ((a : ℝ)^{1/n}) to state irrationality of the real radical directly."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cube-root-3-irrational-oq-01",
+      "relationship": "extends",
+      "description": "Parent: proves Xⁿ − p irreducible for prime p and asks to relax the constant to 'squarefree at some prime'. This entry supplies that relaxation and recovers the prime case."
+    },
+    {
+      "targetId": "cube-root-3-irrational",
+      "relationship": "related",
+      "description": "Root entry proving ∛3 ∉ ℚ; this descendant broadens the Eisenstein route to composite radicands."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "CubeRoot3IrrationalOQ01OQ03",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "irreducible_X_pow_sub_C_of_squarefree_at_prime_int",
+        "type": "core",
+        "description": "Xⁿ − a irreducible over ℤ when a prime q has q ∣ a and q² ∤ a, for n ≥ 1 (Eisenstein at (q)).",
+        "leanType": "{a : ℤ} → {q : ℕ} → q.Prime → (q : ℤ) ∣ a → ¬ ((q : ℤ) ^ 2 ∣ a) → {n : ℕ} → 0 < n → Irreducible ((X : ℤ[X]) ^ n - C a)"
+      },
+      {
+        "name": "irreducible_X_pow_sub_C_of_squarefree_at_prime_rat",
+        "type": "key",
+        "description": "The same over ℚ, by Gauss's lemma.",
+        "leanType": "{a : ℤ} → {q : ℕ} → q.Prime → (q : ℤ) ∣ a → ¬ ((q : ℤ) ^ 2 ∣ a) → {n : ℕ} → 0 < n → Irreducible ((X : ℚ[X]) ^ n - C (a : ℚ))"
+      },
+      {
+        "name": "irreducible_X_cubed_sub_twelve_rat",
+        "type": "key",
+        "description": "X³ − 12 irreducible over ℚ: 12 = 2²·3 is composite and non-squarefree, but squarefree at 3, so ∛12 has degree 3.",
+        "leanType": "Irreducible ((X : ℚ[X]) ^ 3 - C (12 : ℚ))"
+      }
+    ],
+    "path": "Proofs/CubeRoot3IrrationalOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "irreducible_X_pow_sub_C_of_squarefree_at_prime_int",
+      "type": "core",
+      "description": "Xⁿ − a irreducible over ℤ when some prime q has q ∣ a, q² ∤ a, for n ≥ 1.",
+      "leanType": "{a : ℤ} → {q : ℕ} → q.Prime → (q : ℤ) ∣ a → ¬ ((q : ℤ) ^ 2 ∣ a) → {n : ℕ} → 0 < n → Irreducible ((X : ℤ[X]) ^ n - C a)"
+    },
+    {
+      "name": "irreducible_X_pow_sub_C_of_squarefree_at_prime_rat",
+      "type": "key",
+      "description": "The same over ℚ, lifted by Gauss's lemma.",
+      "leanType": "{a : ℤ} → {q : ℕ} → q.Prime → (q : ℤ) ∣ a → ¬ ((q : ℤ) ^ 2 ∣ a) → {n : ℕ} → 0 < n → Irreducible ((X : ℚ[X]) ^ n - C (a : ℚ))"
+    },
+    {
+      "name": "irreducible_X_cubed_sub_twelve_rat",
+      "type": "supporting",
+      "description": "X³ − 12 irreducible over ℚ — a composite, non-squarefree radicand certified via its simple prime factor 3.",
+      "leanType": "Irreducible ((X : ℚ[X]) ^ 3 - C (12 : ℚ))"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Eisenstein, Gotthold",
+      "title": "Über die Irreductibilität und einige andere Eigenschaften der Gleichung...",
+      "year": "1850",
+      "venue": "Journal für die reine und angewandte Mathematik 39, 160–179",
+      "note": "Original irreducibility criterion"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd ed., §9.4",
+      "note": "Eisenstein's criterion and Gauss's lemma; the criterion requires only a single prime dividing the constant term to the first power"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/cube-root-3-irrational-oq-01-oq-03.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-01-oq-03.json
@@ -1,0 +1,62 @@
+{
+  "slug": "cube-root-3-irrational-oq-01-oq-03",
+  "title": "Eisenstein for Xⁿ − a at a composite a: the squarefree-at-a-prime criterion",
+  "problemStatement": "Building on cube-root-3-irrational-oq-01 (Xⁿ − p irreducible over ℤ and ℚ for prime p via Eisenstein), generalize the Eisenstein input to Xⁿ − a for any a that is squarefree at some prime — i.e. there exists a prime q with q ∣ a and q² ∤ a — with no requirement that a itself be prime or globally squarefree. Specialize to composite radicands (√6, ∛12, √24) beyond the prime-only parent.",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "MODERATE",
+  "significance": 5,
+  "tractability": "high",
+  "started": "2026-07-01",
+  "lastUpdate": "2026-07-01",
+  "path": "Proofs/CubeRoot3IrrationalOQ01OQ03.lean",
+  "leanFiles": ["Proofs/CubeRoot3IrrationalOQ01OQ03.lean"],
+  "relatedProofs": [
+    "cube-root-3-irrational-oq-01",
+    "cube-root-3-irrational"
+  ],
+  "currentState": "SOLVED. Xⁿ − a proved irreducible over ℤ and ℚ whenever a prime q has q ∣ a and q² ∤ a, for n ≥ 1. 7 theorems, 143 lines, 0 sorries, 0 axioms beyond propext/Classical.choice/Quot.sound (verified via #print axioms). Type-checks via `lake env lean` against the cached Mathlib. Recovers the parent's prime case (q = p) and certifies X² − 6, X³ − 12, X² − 24.",
+  "knowledge": {
+    "insights": [
+      "Eisenstein's criterion never uses that the constant a is prime — it only needs one prime q dividing a to exactly the first power. The parent's 'a prime' is an inessential special case (q = p).",
+      "The two divisibility hypotheses map onto the two Eisenstein sides verbatim: q ∣ a is the lower-coefficient membership −a ∈ (q) (Ideal.mem_span_singleton), and q² ∤ a is the constant-term exclusion −a ∉ (q)² = (q²) (Ideal.span_singleton_pow + Ideal.mem_span_singleton).",
+      "a need not be globally squarefree: 12 = 2²·3 and 24 = 2³·3 fail squarefreeness yet are squarefree at 3, and that single simple factor suffices — a case strictly beyond the prime-only parent.",
+      "The generalization costs nothing structurally: the same five-step Eisenstein verification carries over with 'p prime' replaced by (q ∣ a, q² ∤ a), and the prime case becomes a one-line corollary via mul_dvd_mul_iff_left to derive p² ∤ p.",
+      "Irreducibility ⟹ degree: Xⁿ − a is the minimal polynomial of a^{1/n}, so the criterion pins [ℚ(a^{1/n}):ℚ] = n for composite radicands too (√6 degree 2, ∛12 degree 3, √24 degree 2)."
+    ],
+    "builtItems": [
+      "irreducible_X_pow_sub_C_of_squarefree_at_prime_int: Xⁿ − a irreducible over ℤ given q.Prime, q ∣ a, ¬(q² ∣ a), 0 < n (CubeRoot3IrrationalOQ01OQ03.lean:42)",
+      "irreducible_X_pow_sub_C_of_squarefree_at_prime_rat: the same over ℚ via Gauss's lemma (CubeRoot3IrrationalOQ01OQ03.lean:87)",
+      "irreducible_X_pow_sub_C_prime_int: parent's prime case recovered as q = p (CubeRoot3IrrationalOQ01OQ03.lean:104)",
+      "irreducible_X_sq_sub_six_rat: X² − 6 irreducible over ℚ, √6 degree 2 (CubeRoot3IrrationalOQ01OQ03.lean:120)",
+      "irreducible_X_cubed_sub_twelve_rat: X³ − 12 irreducible over ℚ, ∛12 degree 3 (12 non-squarefree) (CubeRoot3IrrationalOQ01OQ03.lean:128)",
+      "irreducible_X_sq_sub_twentyfour_rat: X² − 24 irreducible over ℚ, √24 degree 2 (24 non-squarefree) (CubeRoot3IrrationalOQ01OQ03.lean:137)"
+    ],
+    "mathlibGaps": [
+      "No gaps. Mathlib supplies irreducible_of_eisenstein_criterion, IsPrimitive.Int.irreducible_iff_irreducible_map_cast (Gauss), Ideal.span_singleton_prime/pow, Ideal.mem_span_singleton, monic_X_pow_sub_C, degree_X_pow_sub_C — all directly applicable, mirroring the parent oq-01 proof with relaxed hypotheses."
+    ],
+    "nextSteps": [
+      "Characterize exactly which a admit an irreducible Xⁿ − a over ℚ (Eisenstein is sufficient, not necessary — e.g. some prime-power radicands give irreducible Xⁿ − a for suitable n).",
+      "Transfer to a general Dedekind/UFD base ring, where 'squarefree at a prime' becomes 'a prime element dividing a but not a²'.",
+      "Connect the degree conclusion to minpoly ℚ ((a : ℝ)^{1/n}) to state irrationality of the real radical directly."
+    ],
+    "progressSummary": "COMPLETE: the Eisenstein input relaxed from a prime to any constant squarefree at some prime; composite radicands √6, ∛12, √24 certified. Verified 0-axiom, 0-sorry."
+  },
+  "knownResults": [
+    "Eisenstein's criterion at a prime q requires only that q divide every non-leading coefficient, q not divide the leading coefficient, and q² not divide the constant term — no condition on the constant being prime.",
+    "For a a non-nth-power with a suitable prime factorization, Xⁿ − a is the minimal polynomial of a^{1/n} and its irreducibility gives [ℚ(a^{1/n}):ℚ] = n."
+  ],
+  "references": [
+    { "title": "Eisenstein's criterion", "url": "https://en.wikipedia.org/wiki/Eisenstein%27s_criterion" },
+    { "title": "Gauss's lemma (polynomials)", "url": "https://en.wikipedia.org/wiki/Gauss%27s_lemma_(polynomials)" }
+  ],
+  "tags": [
+    "number-theory",
+    "irrationality",
+    "eisenstein-criterion",
+    "irreducible-polynomial",
+    "gauss-lemma",
+    "algebraic-degree",
+    "squarefree"
+  ]
+}


### PR DESCRIPTION
## Eisenstein for Xⁿ − a at a composite a — the squarefree-at-a-prime criterion (VERIFIED, 0-axiom, +7 theorems)

Answers the **third open question** of `cube-root-3-irrational-oq-01`:
> Generalize the Eisenstein input to Xⁿ − a for any a that is squarefree-at-some-prime, not just a prime.

### The idea
The parent proves `Xⁿ − p` irreducible for **prime** `p` via Eisenstein at the ideal `(p)`. But Eisenstein at a prime `q` only needs `q` to divide the constant term **to the first power** — it never uses that the whole constant is prime. So `Xⁿ − a` is irreducible over ℤ (and ℚ, by Gauss) whenever there is **some** prime `q` with
```
q ∣ a   and   q² ∤ a
```
with no primality or global squarefreeness required of `a`.

### What's proved (all machine-checked, `#print axioms` = propext/Classical.choice/Quot.sound only)
- **`irreducible_X_pow_sub_C_of_squarefree_at_prime_int`** / **`_rat`** — the general criterion over ℤ and ℚ. The two divisibility hypotheses map exactly onto the two Eisenstein sides: `q ∣ a` gives `−a ∈ (q)` (lower coefficients), and `q² ∤ a` is verbatim `−a ∉ (q)² = (q²)` (constant term), via `Ideal.span_singleton_pow` + `Ideal.mem_span_singleton`.
- **`irreducible_X_pow_sub_C_prime_int`** — recovers the parent's prime case as the corollary `q = p` (`p ∣ p`, `p² ∤ p`), so the new criterion strictly subsumes it.
- **`X² − 6`, `X³ − 12`, `X² − 24`** irreducible over ℚ — composite radicands the prime-only parent cannot reach. Note `12 = 2²·3` and `24 = 2³·3` are **not even squarefree**, yet each has a single simple prime factor (`3`) that drives Eisenstein. Hence `√6`, `∛12`, `√24` have algebraic degree exactly 2, 3, 2.

### Contents
- `proofs/Proofs/CubeRoot3IrrationalOQ01OQ03.lean` — 143 lines, 7 theorems, 0 sorries, 0 axioms; imports only Mathlib; typechecks via `lake env lean` against the cached Mathlib.
- Gallery entry: `src/data/proofs/cube-root-3-irrational-oq-01-oq-03/{meta.json,annotations.json}` (schema mirrors the parent; canonical annotation enums).
- Research tracking: `src/data/research/problems/cube-root-3-irrational-oq-01-oq-03.json` (status: completed).