### PR TITLE
research(fibonacci-identities-oq-05-oq-02): Gibonacci product-sum — the parity constant is a discriminant [VERIFIED, 0-axiom, +10thm]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ05OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ05OQ02.lean
@@ -1,0 +1,176 @@
+import Mathlib
+
+/-!
+# Gibonacci product-sum identity: the parity constant is a discriminant
+
+The parent entry `FibonacciIdentitiesOQ05.lean` proves the Fibonacci
+*product-sum* identity
+`Fₙ₊₁² = (F₀F₁ + F₁F₂ + ⋯ + FₙFₙ₊₁) + [n even]`,
+where the correction term `[n even]` toggles between `1` (even `n`) and `0`
+(odd `n`).
+
+This entry answers the open follow-up: **what happens for a general Gibonacci
+(Horadam) sequence** `G` obeying the Fibonacci recurrence
+`Gₙ₊₂ = Gₙ₊₁ + Gₙ` with arbitrary seeds `G₀, G₁`?  The answer exposes the
+`[n even]` toggle of the Fibonacci case as a shadow of the sequence's
+**discriminant**
+
+`D := G₁² − G₀G₁ − G₀²`,
+
+the invariant governing the generalized Cassini identity
+`Gₙ₊₁² − GₙGₙ₊₂ = (−1)ⁿ · D`.  The unified closed form is
+
+`Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + [n even] · D`.               (`gib_prod_sum`)
+
+Everything is stated over `ℤ` because the correction term is genuinely signed
+for seeds other than the Fibonacci `(0, 1)`.
+
+## Specializations
+
+* **Fibonacci** `(G₀, G₁) = (0, 1)`: `D = 1`, `G₀² = 0`, recovering the parent
+  identity `Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even]`  (`fib_prod_sum_int`).
+* **Lucas** `(G₀, G₁) = (2, 1)`: `D = 1 − 2 − 4 = −5` — the discriminant of
+  `x² − x − 1` scaled by the Lucas normalization.  The correction term is
+  `4 − 5·[n even]`, i.e. `−1` for even `n` and `4` for odd `n`
+  (`lucas_prod_sum`).
+
+The engine is the generalized Cassini identity `gib_cassini`, proved by a
+one-line `linear_combination` induction off the recurrence, and the main
+identity is a single induction whose step is closed by `linear_combination`
+once Cassini supplies the quadratic relation.
+
+No axioms, no `native_decide`, no sorries.
+-/
+
+namespace FibonacciIdentitiesOQ05OQ02
+
+open Finset
+
+section Generic
+
+variable (G : ℕ → ℤ) (hrec : ∀ n, G (n + 2) = G (n + 1) + G n)
+
+include hrec
+
+/-- **Generalized Cassini / Catalan identity.**
+For any sequence obeying `Gₙ₊₂ = Gₙ₊₁ + Gₙ`,
+`Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ · (G₁² − G₀G₁ − G₀²)`.
+The bracketed constant is the sequence's *discriminant* `D`; it is the
+translation-invariant of the recurrence. -/
+theorem gib_cassini (n : ℕ) :
+    G (n + 1) ^ 2 - G n * G (n + 2)
+      = (-1) ^ n * (G 1 ^ 2 - G 0 * G 1 - G 0 ^ 2) := by
+  induction n with
+  | zero =>
+    have h0 := hrec 0
+    -- G 2 = G 1 + G 0
+    rw [h0]; ring
+  | succ k ih =>
+    have h1 := hrec k          -- G (k+2) = G (k+1) + G k
+    have h2 := hrec (k + 1)    -- G (k+3) = G (k+2) + G (k+1)
+    -- Normalize the successor indices appearing in the goal.
+    show G (k + 2) ^ 2 - G (k + 1) * G (k + 3)
+        = (-1) ^ (k + 1) * (G 1 ^ 2 - G 0 * G 1 - G 0 ^ 2)
+    linear_combination -ih + G (k + 2) * h1 - G (k + 1) * h2
+
+/-- **Gibonacci product-sum identity** (unified closed form).
+`Gₙ₊₁² = (∑_{i=0}^{n} GᵢGᵢ₊₁) + G₀² + [n even]·D`, where `D = G₁²−G₀G₁−G₀²`.
+The parity toggle of the Fibonacci case is exactly the discriminant `D`. -/
+theorem gib_prod_sum (n : ℕ) :
+    G (n + 1) ^ 2
+      = (∑ i ∈ Finset.range (n + 1), G i * G (i + 1))
+        + G 0 ^ 2
+        + (if Even n then (G 1 ^ 2 - G 0 * G 1 - G 0 ^ 2) else 0) := by
+  induction n with
+  | zero =>
+    rw [if_pos (by decide : Even 0), Finset.sum_range_one]
+    ring
+  | succ k ih =>
+    rw [Finset.sum_range_succ, show k + 1 + 1 = k + 2 from rfl]
+    have hc := gib_cassini G hrec k
+    have h1 := hrec k          -- G (k+2) = G (k+1) + G k
+    rcases Nat.even_or_odd k with hk | hk
+    · -- k even ⇒ k+1 odd
+      have hodd : ¬ Even (k + 1) := by simp [Nat.even_add_one, hk]
+      rw [if_pos hk] at ih
+      rw [if_neg hodd]
+      -- ih : G(k+1)^2 = S_k + G0^2 + D
+      -- hc : G(k+1)^2 - G k * G(k+2) = D    (since (-1)^k = 1)
+      rw [hk.neg_one_pow] at hc
+      -- Goal: G(k+2)^2 = (S_k + G(k+1)*G(k+2)) + G0^2 + 0
+      linear_combination ih - hc + G (k + 2) * h1
+    · -- k odd ⇒ k+1 even
+      have heven : Even (k + 1) := hk.add_one
+      rw [if_neg (by simpa [Nat.not_even_iff_odd] using hk)] at ih
+      rw [if_pos heven]
+      rw [hk.neg_one_pow] at hc
+      -- hc : G(k+1)^2 - G k * G(k+2) = -D
+      linear_combination ih - hc + G (k + 2) * h1
+
+/-- Even branch: for even `n`,
+`∑_{i≤n} GᵢGᵢ₊₁ = Gₙ₊₁² − G₀² − D`. -/
+theorem gib_prod_sum_even {n : ℕ} (hn : Even n) :
+    (∑ i ∈ Finset.range (n + 1), G i * G (i + 1))
+      = G (n + 1) ^ 2 - G 0 ^ 2 - (G 1 ^ 2 - G 0 * G 1 - G 0 ^ 2) := by
+  have h := gib_prod_sum G hrec n
+  rw [if_pos hn] at h
+  linarith [h]
+
+/-- Odd branch: for odd `n`,
+`∑_{i≤n} GᵢGᵢ₊₁ = Gₙ₊₁² − G₀²`. -/
+theorem gib_prod_sum_odd {n : ℕ} (hn : Odd n) :
+    (∑ i ∈ Finset.range (n + 1), G i * G (i + 1))
+      = G (n + 1) ^ 2 - G 0 ^ 2 := by
+  have h := gib_prod_sum G hrec n
+  rw [if_neg (by simpa [Nat.not_even_iff_odd] using hn)] at h
+  linarith [h]
+
+end Generic
+
+/-! ## Fibonacci specialization: recovering the parent identity -/
+
+/-- The Fibonacci sequence as a `ℤ`-valued Gibonacci sequence. -/
+theorem fib_hrec : ∀ n, (Nat.fib (n + 2) : ℤ) = Nat.fib (n + 1) + Nat.fib n := by
+  intro n; rw [Nat.fib_add_two]; push_cast; ring
+
+/-- **Fibonacci product-sum** (integer form), recovering the parent entry:
+`Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even]`.  Here `D = 1` and `G₀² = 0`. -/
+theorem fib_prod_sum_int (n : ℕ) :
+    (Nat.fib (n + 1) : ℤ) ^ 2
+      = (∑ i ∈ Finset.range (n + 1), (Nat.fib i : ℤ) * Nat.fib (i + 1))
+        + (if Even n then 1 else 0) := by
+  have h := gib_prod_sum (fun n => (Nat.fib n : ℤ)) fib_hrec n
+  simp only [Nat.fib_zero, Nat.fib_one, Nat.cast_zero, Nat.cast_one] at h
+  simpa using h
+
+/-! ## Lucas specialization: the discriminant becomes `−5` -/
+
+/-- The pair `(Lₙ, Lₙ₊₁)`, computed by structural recursion. -/
+def lucasPair : ℕ → ℤ × ℤ
+  | 0 => (2, 1)
+  | n + 1 => ((lucasPair n).2, (lucasPair n).1 + (lucasPair n).2)
+
+/-- The Lucas numbers as a `ℤ`-valued sequence: `L₀ = 2`, `L₁ = 1`. -/
+def lucasZ (n : ℕ) : ℤ := (lucasPair n).1
+
+@[simp] theorem lucasZ_zero : lucasZ 0 = 2 := rfl
+@[simp] theorem lucasZ_one : lucasZ 1 = 1 := rfl
+
+theorem lucasZ_hrec : ∀ n, lucasZ (n + 2) = lucasZ (n + 1) + lucasZ n := by
+  intro n
+  simp only [lucasZ, lucasPair]
+  ring
+
+/-- **Lucas product-sum identity.**  For the Lucas numbers the discriminant is
+`D = 1 − 2 − 4 = −5`, so the correction term `G₀² + [n even]·D` equals
+`4 + (if Even n then -5 else 0)`, i.e. `−1` for even `n`, `4` for odd `n`. -/
+theorem lucas_prod_sum (n : ℕ) :
+    lucasZ (n + 1) ^ 2
+      = (∑ i ∈ Finset.range (n + 1), lucasZ i * lucasZ (i + 1))
+        + 4 + (if Even n then (-5) else 0) := by
+  have h := gib_prod_sum lucasZ lucasZ_hrec n
+  simp only [lucasZ_zero, lucasZ_one] at h
+  rw [h]
+  norm_num
+
+end FibonacciIdentitiesOQ05OQ02

--- a/src/data/proofs/fibonacci-identities-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-02/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-fiboq0502-1",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 5, "endLine": 43 },
+    "type": "concept",
+    "title": "The Parity Constant is a Discriminant",
+    "content": "**Module framing.** The parent entry proves the Fibonacci product-sum staircase $F_{n+1}^2 = \\sum_{i\\le n} F_iF_{i+1} + [n\\text{ even}]$, whose correction term toggles between $1$ and $0$ with no evident reason. This entry answers the open follow-up: for an arbitrary **Gibonacci** (Horadam) sequence $G$ with $G_{n+2} = G_{n+1} + G_n$ and arbitrary seeds, the identity becomes $G_{n+1}^2 = \\left(\\sum_{i\\le n} G_iG_{i+1}\\right) + G_0^2 + [n\\text{ even}]\\cdot D$, where $D = G_1^2 - G_0G_1 - G_0^2$ is the sequence's **discriminant**. The opaque parity toggle is thereby revealed as one value of a single invariant $D$ — the same $D$ that governs the generalized Cassini identity. Everything is over $\\mathbb{Z}$ because for non-Fibonacci seeds the correction is genuinely signed.",
+    "mathContext": "$G_{n+1}^2 = \\left(\\sum_{i\\le n} G_iG_{i+1}\\right) + G_0^2 + [n\\text{ even}]\\cdot D,\\quad D = G_1^2 - G_0G_1 - G_0^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Product-sum staircase (parent entry)",
+      "Gibonacci / Horadam sequences",
+      "Recurrence discriminant"
+    ],
+    "prerequisites": [
+      "Second-order linear recurrences Gₙ₊₂ = Gₙ₊₁ + Gₙ",
+      "Cassini's identity and the alternating sign (−1)ⁿ"
+    ],
+    "tags": ["module-header", "framing", "gibonacci", "discriminant"]
+  },
+  {
+    "id": "ann-fiboq0502-2",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 55, "endLine": 73 },
+    "type": "tactic",
+    "title": "Generalized Cassini, Seed-Free",
+    "content": "**The engine.** For *any* sequence obeying $G_{n+2} = G_{n+1} + G_n$, $G_{n+1}^2 - G_n G_{n+2} = (-1)^n D$ with $D = G_1^2 - G_0G_1 - G_0^2$. The discriminant $D$ is the translation-invariant of the recurrence — the quantity that survives the induction modulated only by the sign $(-1)^n$. The proof is a clean induction: the base substitutes $G_2 = G_1 + G_0$ and closes by `ring`; the step introduces the recurrence at $k$ and $k+1$, normalizes successor indices with `show`, and closes with the exact linear combination `linear_combination -ih + G(k+2)·h1 − G(k+1)·h2`. Mathlib records Cassini only for the concrete Fibonacci/Lucas sequences, so this seed-agnostic form is supplied here.",
+    "mathContext": "$G_{n+1}^2 - G_n G_{n+2} = (-1)^n\\,(G_1^2 - G_0G_1 - G_0^2)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Cassini's identity",
+      "linear_combination tactic",
+      "Recurrence discriminant D"
+    ],
+    "prerequisites": ["Induction over ℤ", "The Gibonacci recurrence"],
+    "tags": ["cassini", "engine", "linear_combination", "discriminant"]
+  },
+  {
+    "id": "ann-fiboq0502-3",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 76, "endLine": 108 },
+    "type": "theorem",
+    "title": "The Unified Product-Sum Closed Form",
+    "content": "**Headline identity.** $G_{n+1}^2 = \\left(\\sum_{i=0}^{n} G_iG_{i+1}\\right) + G_0^2 + (\\text{if } n\\text{ even then } D \\text{ else } 0)$. This is the seed-agnostic generalization of the parent staircase. The induction on $n$ peels the last product with `Finset.sum_range_succ` and splits on `Nat.even_or_odd`; in each branch both `if`s are resolved by parity, the Cassini sign $(-1)^k$ is specialized to $\\pm 1$ via `Even.neg_one_pow` / `Odd.neg_one_pow` (turning Cassini into $\\pm D$), the recurrence is substituted, and the step closes with a single `linear_combination` of the induction hypothesis, Cassini, and the recurrence. The correction term $G_0^2 + [n\\text{ even}]\\cdot D$ is where all seed dependence lives.",
+    "mathContext": "$G_{n+1}^2 = \\left(\\sum_{i=0}^{n} G_iG_{i+1}\\right) + G_0^2 + (\\text{if } n\\text{ even then } D \\text{ else } 0)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_range_succ induction",
+      "Parity case split",
+      "Generalized Cassini identity"
+    ],
+    "prerequisites": ["The generalized Cassini identity", "Parity of (−1)ⁿ"],
+    "tags": ["product-sum", "closed-form", "induction", "parity"]
+  },
+  {
+    "id": "ann-fiboq0502-4",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 110, "endLine": 127 },
+    "type": "theorem",
+    "title": "Parity Branches Solved for the Sum",
+    "content": "**Corollaries.** Solving the headline identity for the sum in each parity gives $\\sum_{i\\le n} G_iG_{i+1} = G_{n+1}^2 - G_0^2 - D$ for even $n$ (`gib_prod_sum_even`) and $\\sum_{i\\le n} G_iG_{i+1} = G_{n+1}^2 - G_0^2$ for odd $n$ (`gib_prod_sum_odd`). Each discharges the `if` with `if_pos` / `if_neg` and finishes by `linarith`. These are the forms most directly comparable to the parent's Fibonacci statement.",
+    "mathContext": "even: $\\sum G_iG_{i+1} = G_{n+1}^2 - G_0^2 - D$;  odd: $\\sum G_iG_{i+1} = G_{n+1}^2 - G_0^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Parity branches", "linarith"],
+    "prerequisites": ["The unified product-sum closed form"],
+    "tags": ["corollary", "parity", "linarith"]
+  },
+  {
+    "id": "ann-fiboq0502-5",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 130, "endLine": 144 },
+    "type": "concept",
+    "title": "Fibonacci: Recovering the Parent (D = 1)",
+    "content": "**First specialization.** Instantiating the generic identity at the Fibonacci seeds $(G_0, G_1) = (0, 1)$ gives $D = 1^2 - 0\\cdot 1 - 0^2 = 1$ and $G_0^2 = 0$, so the correction collapses to exactly $[n\\text{ even}]$ — the parent entry $F_{n+1}^2 = \\sum F_iF_{i+1} + [n\\text{ even}]$ (`fib_prod_sum_int`). The only work is `fib_hrec`, which casts Mathlib's `Nat.fib_add_two` to $\\mathbb{Z}$ to supply the generic recurrence hypothesis; the seeds are cleared by `simp`. The parent identity is thus a one-line corollary of the seed-agnostic theorem.",
+    "mathContext": "$(G_0,G_1)=(0,1)\\Rightarrow D=1,\\ G_0^2=0\\Rightarrow F_{n+1}^2 = \\sum F_iF_{i+1} + [n\\text{ even}]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.fib_add_two", "Fibonacci as Gibonacci", "Specialization by simp"],
+    "prerequisites": ["The unified product-sum closed form"],
+    "tags": ["fibonacci", "specialization", "parent-recovery"]
+  },
+  {
+    "id": "ann-fiboq0502-6",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 146, "endLine": 176 },
+    "type": "concept",
+    "title": "Lucas: the Discriminant Becomes −5",
+    "content": "**Second specialization.** A $\\mathbb{Z}$-valued Lucas sequence is built by structural recursion on the pair $(L_n, L_{n+1})$ (`lucasPair`, `lucasZ`) with $L_0 = 2$, $L_1 = 1$; `lucasZ_hrec` verifies the recurrence by `simp` + `ring`. Instantiating the generic identity gives the discriminant $D = 1^2 - 2\\cdot 1 - 2^2 = 1 - 2 - 4 = -5$ — the discriminant of $x^2 - x - 1$ in the Lucas normalization — and $G_0^2 = 4$. Hence $L_{n+1}^2 = \\sum L_iL_{i+1} + 4 + (\\text{if } n\\text{ even then } -5 \\text{ else } 0)$ (`lucas_prod_sum`), a correction of $-1$ for even $n$ and $4$ for odd $n$. The genuinely signed correction is why the whole development lives over $\\mathbb{Z}$.",
+    "mathContext": "$(G_0,G_1)=(2,1)\\Rightarrow D=-5,\\ G_0^2=4\\Rightarrow L_{n+1}^2 = \\sum L_iL_{i+1} + 4 + (\\text{if } n\\text{ even then } -5 \\text{ else } 0)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lucas numbers", "Discriminant of x²−x−1", "Structural recursion on pairs"],
+    "prerequisites": ["The unified product-sum closed form"],
+    "tags": ["lucas", "specialization", "discriminant"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-05-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-02/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "fibonacci-identities-oq-05-oq-02",
+  "title": "Gibonacci Product-Sum: the Parity Constant is a Discriminant",
+  "slug": "fibonacci-identities-oq-05-oq-02",
+  "description": "Answers the open follow-up of the parent entry fibonacci-identities-oq-05 (the Fibonacci product-sum staircase Fₙ₊₁² = ∑_{i≤n} FᵢFᵢ₊₁ + [n even]) by generalizing it to an arbitrary Gibonacci (Horadam) sequence G obeying Gₙ₊₂ = Gₙ₊₁ + Gₙ with arbitrary integer seeds G₀, G₁. The unified closed form gib_prod_sum is Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + [n even]·D, where D := G₁² − G₀G₁ − G₀² is the sequence's discriminant — the translation-invariant of the recurrence. This exposes the parent's mysterious [n even] toggle as a shadow of the generalized Cassini identity gib_cassini: Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D, proved by a one-line linear_combination induction off the recurrence. The correction term G₀² + [n even]·D specializes cleanly: for Fibonacci (G₀,G₁)=(0,1) it is D=1, G₀²=0, recovering the parent identity Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even] (fib_prod_sum_int); for Lucas (G₀,G₁)=(2,1) the discriminant is D = 1 − 2 − 4 = −5 (the discriminant of x²−x−1 in the Lucas normalization), giving the correction 4 + (if n even then −5 else 0), i.e. −1 for even n and 4 for odd n (lucas_prod_sum). Everything is over ℤ because the correction is genuinely signed for non-Fibonacci seeds. Fully verified: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Lucas; Horadam sequences); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence",
+    "date": "1965",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "lucas-numbers",
+      "gibonacci",
+      "horadam",
+      "cassini",
+      "discriminant",
+      "summation-identity",
+      "parity",
+      "integer-sequences",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ05OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f i) + f n — peels the last product term off each partial sum in the product-sum induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_one",
+        "description": "∑ i ∈ range 1, f i = f 0 — evaluates the base case of the product-sum induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.even_or_odd",
+        "description": "every natural number is even or odd — drives the two-way parity split that resolves the [n even] toggle in the induction step",
+        "module": "Mathlib.Algebra.Parity"
+      },
+      {
+        "theorem": "Even.neg_one_pow / Odd.neg_one_pow",
+        "description": "(−1)ⁿ = 1 for even n and −1 for odd n — collapses the generalized Cassini sign (−1)ⁿ·D to +D or −D in each parity branch of the product-sum step",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.even_add_one",
+        "description": "Even (n+1) ↔ ¬ Even n — advances the parity of the toggle across the successor step",
+        "module": "Mathlib.Algebra.Parity"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the Fibonacci recurrence, cast to ℤ to instantiate the generic Gibonacci hypothesis for the Fibonacci specialization (fib_hrec)",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "linear_combination",
+        "description": "closes each induction step by exhibiting the goal as an explicit ℤ-linear combination of the recurrence hypotheses and the induction hypothesis / Cassini — the algebraic engine of both gib_cassini and gib_prod_sum",
+        "module": "Mathlib.Tactic.LinearCombination"
+      }
+    ],
+    "originalContributions": [
+      "gib_cassini: ∀ (G obeying the recurrence) n, Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·(G₁² − G₀G₁ − G₀²) — the generalized Cassini identity for an arbitrary Gibonacci/Horadam sequence, with the discriminant D = G₁² − G₀G₁ − G₀² as the (−1)ⁿ-modulated invariant. Proved by one-line linear_combination induction.",
+      "gib_prod_sum: ∀ (G obeying the recurrence) n, Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + (if Even n then D else 0) — the unified product-sum closed form generalizing the parent's Fibonacci staircase to arbitrary seeds, identifying the parity constant as the discriminant D.",
+      "gib_prod_sum_even / gib_prod_sum_odd: the two parity branches solved for the sum, ∑_{i≤n} GᵢGᵢ₊₁ = Gₙ₊₁² − G₀² − D (n even) and = Gₙ₊₁² − G₀² (n odd).",
+      "fib_prod_sum_int: recovers the parent identity Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even] as the (G₀,G₁)=(0,1) specialization (D=1, G₀²=0).",
+      "lucas_prod_sum: the Lucas specialization Lₙ₊₁² = ∑ LᵢLᵢ₊₁ + 4 + (if Even n then −5 else 0), with discriminant D=−5, over a ℤ-valued Lucas sequence defined by structural recursion (lucasPair / lucasZ)."
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 176,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used. The generic theorems take the Fibonacci recurrence Gₙ₊₂ = Gₙ₊₁ + Gₙ as an explicit hypothesis on G, not as an axiom.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The parent entry formalizes the classical Fibonacci product-sum staircase F₀F₁ + ⋯ + FₙFₙ₊₁ = Fₙ₊₁² − [n even], whose correction term [n even] toggles between 1 and 0 with no evident reason. Horadam's mid-20th-century study of generalized second-order recurrences (Gₙ₊₂ = Gₙ₊₁ + Gₙ with arbitrary seeds — the 'Gibonacci' or Horadam sequences) supplies the missing context: the toggle is one value of a single invariant, the discriminant D = G₁² − G₀G₁ − G₀², which governs the whole family through the generalized Cassini identity. Writing the product-sum identity for arbitrary seeds turns the ad-hoc parity constant into a structural quantity.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-05)**: Generalize the product-sum identity to the Lucas numbers LₖLₖ₊₁ and to general Gibonacci (Horadam) sequences, tracking how the parity constant becomes a discriminant.\n\n**Result**: For any sequence G with Gₙ₊₂ = Gₙ₊₁ + Gₙ, Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + [n even]·D where D = G₁² − G₀G₁ − G₀² (gib_prod_sum). Fibonacci (D=1, G₀²=0) recovers the parent; Lucas (D=−5) gives correction 4 + (if n even then −5 else 0).",
+    "text": "A Gibonacci sequence over ℤ is any G with G₀, G₁ arbitrary and Gₙ₊₂ = Gₙ₊₁ + Gₙ. Its discriminant is D = G₁² − G₀G₁ − G₀², the (−1)ⁿ-modulated invariant of the generalized Cassini identity Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D. The product-sum then reads Gₙ₊₁² = (∑_{i=0}^{n} GᵢGᵢ₊₁) + G₀² + (if n even then D else 0). For Fibonacci (0,1): D=1, G₀²=0, so Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even]. For Lucas (2,1): D = 1−2−4 = −5, G₀²=4, so the correction is −1 (n even) or 4 (n odd).",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Generalized Cassini (`gib_cassini`).** For any G obeying the recurrence, prove Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D by induction. Base: substitute G₂ = G₁ + G₀ and `ring`. Step: introduce the recurrence at k and k+1, normalize the successor indices with `show`, and close with `linear_combination -ih + G(k+2)·h1 − G(k+1)·h2` — the step is an exact ℤ-linear combination of the induction hypothesis and two instances of the recurrence.\n2. **Product-sum (`gib_prod_sum`).** Induct on n. Base: `if_pos (Even 0)`, `Finset.sum_range_one`, `ring`. Step: peel the last term with `Finset.sum_range_succ`, split on `Nat.even_or_odd`. In each branch resolve both `if`s by parity, specialize Cassini's sign via `Even.neg_one_pow` / `Odd.neg_one_pow` to ±D, substitute the recurrence, and close with a single `linear_combination` of the induction hypothesis, Cassini, and the recurrence.\n3. **Parity corollaries (`gib_prod_sum_even`, `gib_prod_sum_odd`).** Solve the main identity for the sum in each parity, discharging the `if` with `if_pos` / `if_neg` and `linarith`.\n4. **Specializations.** Fibonacci: instantiate the generic hypothesis with `fib_hrec` (Nat.fib_add_two cast to ℤ) and `simp` away G₀=0, G₁=1 (`fib_prod_sum_int`). Lucas: define the pair (Lₙ, Lₙ₊₁) by structural recursion (`lucasPair`), take the first coordinate (`lucasZ`), verify the recurrence by `simp`+`ring` (`lucasZ_hrec`), instantiate, and `norm_num` the discriminant to −5 (`lucas_prod_sum`).",
+    "keyInsights": [
+      "**The parity constant is the discriminant.** The parent's opaque [n even] toggle is exactly [n even]·D with D=1 for Fibonacci. Writing the identity for arbitrary seeds makes D = G₁² − G₀G₁ − G₀² visible as the single invariant controlling the correction — the same D that appears in the generalized Cassini identity.",
+      "**One generic proof, many sequences.** Both the Fibonacci and Lucas identities are `simp`/`norm_num` specializations of the seed-agnostic `gib_prod_sum`. The recurrence enters as an explicit hypothesis on G, so the theorem applies to every Horadam sequence at once; the seeds only fix the two constants G₀² and D.",
+      "**Cassini drives everything, seed-free.** The generalized Cassini identity Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D holds for any G obeying the recurrence and reduces, in each product-sum step, to a one-line `linear_combination`. The discriminant is the translation-invariant that survives the induction.",
+      "**Signs force ℤ.** For seeds other than Fibonacci's (0,1) the correction G₀² + [n even]·D is genuinely signed (D=−5 for Lucas), so the entire development lives over ℤ — no ℕ subtraction, no casting side-conditions."
+    ],
+    "prerequisites": [
+      "Second-order linear recurrences and Horadam/Gibonacci sequences Gₙ₊₂ = Gₙ₊₁ + Gₙ",
+      "Cassini's identity and its (−1)ⁿ sign; the notion of the recurrence discriminant D = G₁² − G₀G₁ − G₀²",
+      "Induction with Finset.sum_range_succ; the linear_combination tactic over ℤ; parity case splits via Nat.even_or_odd"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring framing the entry as the Gibonacci/Horadam generalization of the parent product-sum staircase, identifying the parity constant [n even] as the discriminant D = G₁² − G₀G₁ − G₀², and previewing the Fibonacci and Lucas specializations. Import, namespace, and open Finset setup.",
+      "mathContext": "$G_{n+1}^2 = \\left(\\sum_{i\\le n} G_iG_{i+1}\\right) + G_0^2 + [n\\text{ even}]\\cdot D$, where $D = G_1^2 - G_0G_1 - G_0^2$."
+    },
+    {
+      "id": "generic-cassini",
+      "title": "Generalized Cassini Identity",
+      "startLine": 49,
+      "endLine": 73,
+      "summary": "gib_cassini: for any G obeying Gₙ₊₂ = Gₙ₊₁ + Gₙ, Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·(G₁² − G₀G₁ − G₀²). Induction off the recurrence, step closed by linear_combination of the induction hypothesis and two recurrence instances. The discriminant D is the (−1)ⁿ-modulated invariant.",
+      "mathContext": "$G_{n+1}^2 - G_n G_{n+2} = (-1)^n\\,(G_1^2 - G_0G_1 - G_0^2)$."
+    },
+    {
+      "id": "gibonacci-prod-sum",
+      "title": "The Gibonacci Product-Sum Closed Form",
+      "startLine": 75,
+      "endLine": 127,
+      "summary": "gib_prod_sum: Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + (if Even n then D else 0). Induction on n with a parity split; each branch resolves both `if`s, specializes Cassini's sign to ±D, and closes with a single linear_combination. The even/odd corollaries gib_prod_sum_even, gib_prod_sum_odd solve for the sum in each parity.",
+      "mathContext": "$G_{n+1}^2 = \\left(\\sum_{i=0}^{n} G_iG_{i+1}\\right) + G_0^2 + (\\text{if } n\\text{ even then } D \\text{ else } 0)$."
+    },
+    {
+      "id": "fibonacci-specialization",
+      "title": "Fibonacci Specialization",
+      "startLine": 130,
+      "endLine": 144,
+      "summary": "fib_hrec casts the Fibonacci recurrence Nat.fib_add_two to ℤ; fib_prod_sum_int instantiates the generic identity at (G₀,G₁)=(0,1), where D=1 and G₀²=0, recovering the parent entry Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even].",
+      "mathContext": "$F_{n+1}^2 = \\left(\\sum_{i=0}^{n} F_iF_{i+1}\\right) + [n\\text{ even}]$."
+    },
+    {
+      "id": "lucas-specialization",
+      "title": "Lucas Specialization: Discriminant −5",
+      "startLine": 146,
+      "endLine": 176,
+      "summary": "A ℤ-valued Lucas sequence is built by structural recursion on the pair (Lₙ, Lₙ₊₁) (lucasPair, lucasZ) with L₀=2, L₁=1; lucasZ_hrec verifies the recurrence. lucas_prod_sum instantiates the generic identity: the discriminant is D = 1−2−4 = −5, so Lₙ₊₁² = ∑ LᵢLᵢ₊₁ + 4 + (if Even n then −5 else 0), i.e. correction −1 (n even) or 4 (n odd).",
+      "mathContext": "$L_{n+1}^2 = \\left(\\sum_{i=0}^{n} L_iL_{i+1}\\right) + 4 + (\\text{if } n\\text{ even then } -5 \\text{ else } 0)$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-05",
+      "relationship": "answers",
+      "description": "Settles the parent's open follow-up — generalizing the product-sum identity to Lucas numbers and to general Gibonacci (Horadam) sequences — by exhibiting the closed form Gₙ₊₁² = ∑ GᵢGᵢ₊₁ + G₀² + [n even]·D and identifying the parity constant as the discriminant D = G₁² − G₀G₁ − G₀²."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-05-oq-01",
+      "relationship": "relatedTo",
+      "description": "Sibling refinement of the same parent product staircase; there the weighted and alternating sums are settled for Fibonacci, here the plain product sum is generalized to arbitrary Gibonacci seeds. Both are driven by the Cassini identity in subtractive form."
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "relatedTo",
+      "description": "The base entry's Fibonacci summation identities are the (G₀,G₁)=(0,1) shadow of the seed-agnostic Gibonacci identities proved here."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) resolution of the parent's open follow-up. For any Gibonacci sequence G with Gₙ₊₂ = Gₙ₊₁ + Gₙ, the product-sum closed form is Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + [n even]·D with discriminant D = G₁² − G₀G₁ − G₀². The parent's [n even] toggle is the Fibonacci case D=1, G₀²=0; the Lucas case has D=−5, giving correction −1 (n even) / 4 (n odd). The engine is the generalized Cassini identity Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D, proved by a one-line linear_combination induction.",
+    "implications": "Reframes an ad-hoc parity constant as a structural invariant: the correction term of the product-sum identity is fixed by the two seed constants G₀² and D across the entire Horadam family. Because the recurrence is carried as an explicit hypothesis, a single generic proof yields the Fibonacci and Lucas identities (and every other second-order Gibonacci sequence) as `simp`/`norm_num` specializations. The generalized Cassini identity for arbitrary seeds is supplied as a reusable byproduct.",
+    "openQuestions": [
+      "Generalize to the full Horadam recurrence Gₙ₊₂ = pGₙ₊₁ − qGₙ (arbitrary p, q), tracking how the discriminant becomes p²-dependent and how the product-sum correction picks up the multiplier q.",
+      "Establish the companion sum-of-squares closed form ∑_{i≤n} Gᵢ² for general Gibonacci sequences and relate its correction term to the same discriminant D."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Horadam, A. F.",
+      "title": "Basic Properties of a Certain Generalized Sequence of Numbers",
+      "year": "1965",
+      "venue": "The Fibonacci Quarterly",
+      "note": "Introduces the generalized (Horadam / Gibonacci) sequences and their invariants, including the discriminant governing Cassini-type identities"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Product-sum and Cassini identities for Fibonacci and Lucas numbers; the seed-dependent correction terms"
+    },
+    {
+      "authors": "Vajda, Steven",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section",
+      "year": "1989",
+      "venue": "Ellis Horwood",
+      "note": "Generalized Fibonacci sequences and the discriminant of the second-order recurrence"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open follow-up of **fibonacci-identities-oq-05** — *generalize the product-sum identity to the Lucas numbers and to general Gibonacci (Horadam) sequences, tracking how the parity constant becomes a discriminant.*

For any sequence `G` obeying `Gₙ₊₂ = Gₙ₊₁ + Gₙ` with arbitrary integer seeds `G₀, G₁`:

```
gib_prod_sum:  Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + [n even]·D,   D := G₁² − G₀G₁ − G₀²
```

The parent's mysterious `[n even]` toggle is exposed as the Fibonacci case (`D = 1`, `G₀² = 0`). The whole family is governed by the seed-free **generalized Cassini identity**

```
gib_cassini:  Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D
```

proved by a one-line `linear_combination` induction off the recurrence.

## Specializations
- **Fibonacci** `(0,1)`: `D=1`, recovering the parent `Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even]` (`fib_prod_sum_int`).
- **Lucas** `(2,1)`: `D = 1−2−4 = −5`, giving `Lₙ₊₁² = ∑ LᵢLᵢ₊₁ + 4 + (if Even n then −5 else 0)` (`lucas_prod_sum`).

Everything is over `ℤ` because the correction is genuinely signed for non-Fibonacci seeds.

## Verification
- **0 sorries, 0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`), no `native_decide`.
- Typechecks against Mathlib 4.26.0. 176 lines, 10 theorems + 2 definitions.
- New gallery entry: `src/data/proofs/fibonacci-identities-oq-05-oq-02/` (meta + annotations, integrates cleanly into listings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)