### PR TITLE
research(fibonacci-identities-oq-06-oq-01-oq-03): doubled-argument binomial transform is a (5,5) Lucas sequence [VERIFIED, 0-axiom, +8thm]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ03.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ03.lean
@@ -1,0 +1,142 @@
+import Mathlib
+
+/-!
+# The doubled-argument Fibonacci binomial transform `∑ C(n,k) F₂ₖ`
+
+The parent entry `FibonacciIdentitiesOQ06OQ01` proves the **binomial transform**
+of the Fibonacci sequence, `∑_{k≤n} C(n,k)·Fₖ = F₂ₙ` — the transform *doubles* the
+index. Its sibling `FibonacciIdentitiesOQ06OQ01OQ02` handles the *alternating*
+transform `∑ (−1)ᵏ C(n,k) Fₖ = −Fₙ`. This descendant answers the remaining open
+question of that family: **what happens when you feed the transform the
+even-indexed Fibonacci numbers `F₂ₖ`** — i.e. the "k-fold iterate"
+`∑_{k≤n} C(n,k) F₂ₖ`?
+
+The naive guess is that iterating index-doubling gives `F₄ₙ`. It does **not**.
+The sequence
+
+  `Cₙ = ∑_{k≤n} C(n,k) F₂ₖ = 0, 1, 5, 20, 75, 275, 1000, …`
+
+is not a Fibonacci sequence at any index; it is the **Lucas sequence `Uₙ(P,Q)`
+with `P = 5, Q = 5`**, i.e. it satisfies the second-order recurrence
+
+  `Cₙ₊₂ = 5·Cₙ₊₁ − 5·Cₙ`,  `C₀ = 0`, `C₁ = 1`.
+
+* `fib_two_k_binom_transform_rec` — the recurrence `Cₙ₊₂ = 5·Cₙ₊₁ − 5·Cₙ`.
+* `C2_zero`, `C2_one` — the base values, so the recurrence pins down `Cₙ` uniquely.
+
+**Why `(5,5)`.** By Binet, `∑ C(n,k) φ²ᵏ = (1+φ²)ⁿ`. Since `φ² = φ+1`, the base is
+`1+φ² = φ+2 = √5·φ` (as `φ+2 = (5+√5)/2 = √5·(1+√5)/2`), and likewise
+`1+ψ² = −√5·ψ`. So `φ+2` and `ψ+2` are the roots of `x² − 5x + 5`, whence the
+`(P,Q) = (5,5)` recurrence. Tracking the `√5` factors gives the closed form
+`Cₙ = 5^{n/2}·Fₙ` for even `n` and `Cₙ = 5^{(n−1)/2}·Lₙ` for odd `n` (`Lₙ` the
+`n`-th Lucas number) — so the transform of `F₂ₖ` really *scales by powers of √5*
+and alternates between the Fibonacci and Lucas sequences, rather than landing at a
+further-doubled Fibonacci index.
+
+The engine is the general **Pascal convolution over a commutative ring**,
+`pascal_conv_ring` (the ring-valued analogue of the parent's `pascal_conv`).
+Applying it to `k ↦ F₂ₖ` and to `k ↦ F₂ₖ₊₂`, together with the even-index
+Fibonacci recurrence `F_{m+4} = 3·F_{m+2} − F_m`, gives the coupled first-order
+system `Cₙ₊₁ = Cₙ + Dₙ`, `Dₙ₊₁ = 4·Dₙ − Cₙ`, which collapses to the stated
+second-order recurrence.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace FibonacciIdentitiesOQ06OQ01OQ03
+
+open Finset
+
+variable {R : Type*} [CommRing R]
+
+/-- **Pascal convolution over a commutative ring.** For any summand `f : ℕ → R`,
+`∑_{k<n+2} C(n+1,k)·f(k) = ∑_{k<n+1} C(n,k)·f(k) + ∑_{k<n+1} C(n,k)·f(k+1)`.
+
+The ring-valued analogue of the parent entry's `pascal_conv`: Pascal's rule
+`C(n+1,k+1) = C(n,k) + C(n,k+1)` summed against `f`, with the boundary terms
+`C(n+1,0) = C(n,0) = 1` and `C(n,n+1) = 0` reconciled by the first- and
+last-term range peels. -/
+theorem pascal_conv_ring (f : ℕ → R) (n : ℕ) :
+    ∑ k ∈ range (n + 2), ((n + 1).choose k : R) * f k
+      = (∑ k ∈ range (n + 1), (n.choose k : R) * f k)
+        + ∑ k ∈ range (n + 1), (n.choose k : R) * f (k + 1) := by
+  rw [Finset.sum_range_succ' (fun k => ((n + 1).choose k : R) * f k) (n + 1)]
+  simp only [Nat.choose_succ_succ' n, Nat.choose_zero_right, Nat.cast_add, Nat.cast_one,
+    one_mul, add_mul]
+  rw [Finset.sum_add_distrib]
+  rw [Finset.sum_range_succ' (fun k => (n.choose k : R) * f k) n, Nat.choose_zero_right,
+    Nat.cast_one, one_mul]
+  rw [Finset.sum_range_succ (fun k => (n.choose (k + 1) : R) * f (k + 1)) n,
+    Nat.choose_succ_self n, Nat.cast_zero, zero_mul, add_zero]
+  ring
+
+/-- Even-indexed Fibonacci summand `pₖ = F₂ₖ` (offset `0`). -/
+def p (k : ℕ) : ℤ := (Nat.fib (2 * k) : ℤ)
+
+/-- Even-indexed Fibonacci summand `qₖ = F₂ₖ₊₂` (offset `1`, i.e. `F₂₍ₖ₊₁₎`). -/
+def q (k : ℕ) : ℤ := (Nat.fib (2 * k + 2) : ℤ)
+
+/-- The doubled-argument binomial transform `Cₙ = ∑_{k≤n} C(n,k) F₂ₖ`. -/
+def C2 (n : ℕ) : ℤ := ∑ k ∈ range (n + 1), (n.choose k : ℤ) * p k
+
+/-- The shifted doubled-argument transform `Dₙ = ∑_{k≤n} C(n,k) F₂ₖ₊₂`. -/
+def D2 (n : ℕ) : ℤ := ∑ k ∈ range (n + 1), (n.choose k : ℤ) * q k
+
+/-- Shifting: `pₖ₊₁ = F₂₍ₖ₊₁₎ = F₂ₖ₊₂ = qₖ` (`2·(k+1)` is `2·k+2` definitionally). -/
+lemma p_succ (k : ℕ) : p (k + 1) = q k := rfl
+
+/-- Shifting, via `F₂ₖ₊₄ = 3·F₂ₖ₊₂ − F₂ₖ`: `qₖ₊₁ = 3·qₖ − pₖ`. -/
+lemma q_succ (k : ℕ) : q (k + 1) = 3 * q k - p k := by
+  unfold p q
+  have e : 2 * (k + 1) + 2 = 2 * k + 4 := by ring
+  rw [e]
+  have h4 : Nat.fib (2 * k + 4) = Nat.fib (2 * k + 2) + Nat.fib (2 * k + 3) := Nat.fib_add_two
+  have h3 : Nat.fib (2 * k + 3) = Nat.fib (2 * k + 1) + Nat.fib (2 * k + 2) := Nat.fib_add_two
+  have h2 : Nat.fib (2 * k + 2) = Nat.fib (2 * k) + Nat.fib (2 * k + 1) := Nat.fib_add_two
+  rw [h4, h3, h2]; push_cast; ring
+
+/-- Recurrence: `Cₙ₊₁ = Cₙ + Dₙ`. -/
+lemma C2_succ (n : ℕ) : C2 (n + 1) = C2 n + D2 n := by
+  have hp := pascal_conv_ring p n
+  have e : C2 (n + 1) = ∑ k ∈ range (n + 2), ((n + 1).choose k : ℤ) * p k := rfl
+  rw [e, hp]
+  unfold C2 D2
+  congr 1
+
+/-- Recurrence: `Dₙ₊₁ = 4·Dₙ − Cₙ`. -/
+lemma D2_succ (n : ℕ) : D2 (n + 1) = 4 * D2 n - C2 n := by
+  have hp := pascal_conv_ring q n
+  have e : D2 (n + 1) = ∑ k ∈ range (n + 2), ((n + 1).choose k : ℤ) * q k := rfl
+  rw [e, hp]
+  have hqs : (∑ k ∈ range (n + 1), (n.choose k : ℤ) * q (k + 1)) = 3 * D2 n - C2 n := by
+    unfold C2 D2
+    rw [Finset.mul_sum, ← Finset.sum_sub_distrib]
+    apply Finset.sum_congr rfl
+    intro k _
+    rw [q_succ]; ring
+  rw [hqs]
+  show D2 n + (3 * D2 n - C2 n) = 4 * D2 n - C2 n
+  ring
+
+/-- **The doubled-argument binomial transform is a `(5,5)` Lucas sequence.**
+`Cₙ = ∑_{k≤n} C(n,k) F₂ₖ` satisfies the second-order recurrence
+`Cₙ₊₂ = 5·Cₙ₊₁ − 5·Cₙ`. Together with the base values `C₀ = 0`, `C₁ = 1`
+(`C2_zero`, `C2_one`) this characterises `Cₙ` completely as the Lucas sequence
+`Uₙ(5,5)` — not a further index-doubled Fibonacci sequence. -/
+theorem fib_two_k_binom_transform_rec (n : ℕ) :
+    C2 (n + 2) = 5 * C2 (n + 1) - 5 * C2 n := by
+  have h1 := C2_succ (n + 1)
+  have h2 := D2_succ n
+  have h3 := C2_succ n
+  have hD : D2 n = C2 (n + 1) - C2 n := by rw [h3]; ring
+  rw [h1, h2, hD]; ring
+
+/-- Base value `C₀ = 0` (since `F₀ = 0`). -/
+theorem C2_zero : C2 0 = 0 := by
+  simp [C2, p]
+
+/-- Base value `C₁ = 1` (since `C₁ = F₀ + F₂ = 0 + 1`). -/
+theorem C2_one : C2 1 = 1 := by
+  simp [C2, p, Finset.sum_range_succ]
+
+end FibonacciIdentitiesOQ06OQ01OQ03

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-03/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "ann-oq060103-pascal-ring",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-03",
+    "range": {
+      "startLine": 59,
+      "endLine": 72
+    },
+    "type": "theorem",
+    "title": "Pascal Convolution over a Commutative Ring",
+    "content": "pascal_conv_ring lifts the parent entry's ℕ-valued pascal_conv to an arbitrary commutative ring R. For any f : ℕ → R it splits the degree-(n+1) binomial sum ∑ C(n+1,k) f(k) into the two degree-n binomial sums of f and of f(·+1). The proof peels the k=0 term with Finset.sum_range_succ' and reindexes by k ↦ k+1, applies Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1) (Nat.choose_succ_succ', cast to R via the Nat.cast_add / Nat.cast_one simp set), splits with Finset.sum_add_distrib, drops the vanishing top term C(n,n+1) = 0 (Nat.choose_succ_self), and closes with ring. Working over a ring (rather than ℕ) is what lets the doubled-argument transform be handled over ℤ, where the recurrences use subtraction.",
+    "mathContext": "$\\sum_{k<n+2} \\binom{n+1}{k} f_k = \\sum_{k<n+1} \\binom{n}{k} f_k + \\sum_{k<n+1} \\binom{n}{k} f_{k+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.choose_succ_succ'",
+      "Nat.choose_succ_self",
+      "Finset.sum_range_succ'",
+      "pascal_conv",
+      "binomial transform"
+    ],
+    "prerequisites": [
+      "Pascal's rule",
+      "reindexing finite sums",
+      "casting ℕ to a ring"
+    ]
+  },
+  {
+    "id": "ann-oq060103-shifts",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-03",
+    "range": {
+      "startLine": 74,
+      "endLine": 97
+    },
+    "type": "definition",
+    "title": "Even-Indexed Summands and the Even-Index Recurrence",
+    "content": "The summands pₖ = F₂ₖ and qₖ = F₂ₖ₊₂ define the transform sequences Cₙ = ∑ C(n,k) F₂ₖ and Dₙ = ∑ C(n,k) F₂ₖ₊₂. The shift lemma p_succ (pₖ₊₁ = qₖ) is definitional, since 2·(k+1) reduces to 2·k+2 in ℕ. The lemma q_succ proves the even-indexed Fibonacci recurrence F₂ₖ₊₄ = 3·F₂ₖ₊₂ − F₂ₖ by unfolding three steps of Nat.fib_add_two over ℤ (push_cast + ring) — this second-order recurrence of the even-indexed subsequence is what makes the doubled-argument transform close, and its coefficient 3 becomes the transform's 4.",
+    "mathContext": "$p_k = F_{2k},\\ q_k = F_{2k+2};\\quad F_{2k+4} = 3F_{2k+2} - F_{2k}$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.fib_add_two",
+      "even-indexed Fibonacci",
+      "second-order recurrence"
+    ],
+    "prerequisites": [
+      "Fibonacci recurrence",
+      "definitional equality of 2·(k+1) and 2·k+2"
+    ]
+  },
+  {
+    "id": "ann-oq060103-recurrences",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-03",
+    "range": {
+      "startLine": 99,
+      "endLine": 124
+    },
+    "type": "theorem",
+    "title": "Coupled First-Order Recurrences",
+    "content": "C2_succ (Cₙ₊₁ = Cₙ + Dₙ) and D2_succ (Dₙ₊₁ = 4·Dₙ − Cₙ) are each a single application of pascal_conv_ring — to p and to q respectively. In C2_succ the offset-1 sum ∑ C(n,k) p(k+1) equals Dₙ because p(k+1) = q(k) definitionally, so congr 1 closes it. In D2_succ the offset-1 sum uses q(k+1) = 3q(k) − p(k) (q_succ), collected with Finset.mul_sum and Finset.sum_sub_distrib and closed by ring. The resulting 2×2 update matrix [[1,1],[−1,4]] has trace 5 and determinant 5 — precisely the (P,Q) = (5,5) Lucas data.",
+    "mathContext": "$C_{n+1} = C_n + D_n,\\qquad D_{n+1} = 4D_n - C_n.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.mul_sum",
+      "Finset.sum_sub_distrib",
+      "coupled linear recurrence",
+      "Lucas sequence data (P,Q)"
+    ],
+    "prerequisites": [
+      "pascal_conv_ring",
+      "even-index Fibonacci recurrence",
+      "manipulating finite sums over ℤ"
+    ]
+  },
+  {
+    "id": "ann-oq060103-main",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-03",
+    "range": {
+      "startLine": 126,
+      "endLine": 141
+    },
+    "type": "theorem",
+    "title": "The (5,5) Lucas Recurrence (Headline) and Base Values",
+    "content": "fib_two_k_binom_transform_rec proves the second-order recurrence Cₙ₊₂ = 5·Cₙ₊₁ − 5·Cₙ by chaining C2_succ (n+1), D2_succ n, and the elimination Dₙ = Cₙ₊₁ − Cₙ (from C2_succ n), closed by ring. Together with C2_zero (C₀ = 0, since F₀ = 0) and C2_one (C₁ = 1, since C₁ = F₀ + F₂ = 0 + 1) this characterises Cₙ completely as the Lucas sequence Uₙ(5,5) — the sequence 0, 1, 5, 20, 75, 275, 1000, …. The key mathematical content is that iterating the index-doubling transform lands here, NOT at a further-doubled Fibonacci index F₄ₙ.",
+    "mathContext": "$C_{n+2} = 5C_{n+1} - 5C_n,\\quad C_0 = 0,\\ C_1 = 1;\\quad C_n = U_n(5,5).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lucas sequence Uₙ(P,Q)",
+      "second-order linear recurrence",
+      "characteristic polynomial x² − 5x + 5",
+      "binomial transform iteration"
+    ],
+    "prerequisites": [
+      "coupled first-order recurrences",
+      "elimination to a second-order recurrence",
+      "evaluating small finite sums"
+    ]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-03/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "fibonacci-identities-oq-06-oq-01-oq-03",
+  "title": "The Doubled-Argument Fibonacci Binomial Transform: ∑ C(n,k) F₂ₖ is a (5,5) Lucas Sequence",
+  "slug": "fibonacci-identities-oq-06-oq-01-oq-03",
+  "description": "The 'k-fold iterate' of the Fibonacci binomial transform. Where the parent proves ∑ C(n,k) Fₖ = F₂ₙ (index doubling), this feeds the transform the even-indexed Fibonacci numbers F₂ₖ and shows the result Cₙ = ∑ C(n,k) F₂ₖ = 0,1,5,20,75,… is NOT a further index-doubled Fibonacci sequence but the Lucas sequence Uₙ(5,5): Cₙ₊₂ = 5·Cₙ₊₁ − 5·Cₙ, C₀=0, C₁=1. Fully machine-checked, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binomial_transform",
+    "date": "Classical result, formalized 2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "lucas-sequence",
+      "binomial-transform",
+      "linear-recurrence",
+      "combinatorial-identity",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ06OQ01OQ03.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. Every theorem's `#print axioms` lists only the standard foundational axioms propext / Classical.choice / Quot.sound; no native_decide, no Lean.ofReduceBool. Fully machine-checked.",
+    "originalContributions": [
+      "fib_two_k_binom_transform_rec (n : ℕ): the headline — the doubled-argument transform Cₙ = ∑_{k≤n} C(n,k) F₂ₖ satisfies the second-order recurrence Cₙ₊₂ = 5·Cₙ₊₁ − 5·Cₙ, so it is the Lucas sequence Uₙ(5,5), not a further index-doubled Fibonacci sequence",
+      "C2_zero, C2_one: the base values C₀ = 0 and C₁ = 1, which together with the recurrence pin Cₙ down uniquely",
+      "pascal_conv_ring (f : ℕ → R) (n : ℕ): the parent's Pascal convolution lifted to an arbitrary commutative ring R — ∑_{k<n+2} C(n+1,k) f(k) = ∑_{k<n+1} C(n,k) f(k) + ∑_{k<n+1} C(n,k) f(k+1)",
+      "C2_succ, D2_succ: the coupled first-order recurrences Cₙ₊₁ = Cₙ + Dₙ and Dₙ₊₁ = 4·Dₙ − Cₙ (Dₙ = ∑ C(n,k) F₂ₖ₊₂), driven by pascal_conv_ring and the even-index Fibonacci recurrence F₂ₖ₊₄ = 3·F₂ₖ₊₂ − F₂ₖ (q_succ)"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 142,
+    "theoremCount": 8,
+    "definitionCount": 4,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The binomial transform sends a sequence (aₖ) to (∑ C(n,k) aₖ). Applied to the Fibonacci sequence it doubles the index, ∑ C(n,k) Fₖ = F₂ₙ (the parent entry) — the discrete shadow of 1 + φ = φ², since ∑ C(n,k) φᵏ = (1+φ)ⁿ = φ²ⁿ. A natural next question is what happens on iteration: feed the transform the even-indexed sequence F₂ₖ that it just produced. Naively one might expect the index to double again to F₄ₙ. It does not. By Binet, ∑ C(n,k) φ²ᵏ = (1+φ²)ⁿ, and since φ² = φ+1 the base is 1+φ² = φ+2 = √5·φ (because φ+2 = (5+√5)/2 = √5·(1+√5)/2), with 1+ψ² = −√5·ψ. Thus φ+2 and ψ+2 are the two roots of x² − 5x + 5, so the transformed sequence obeys the (P,Q)=(5,5) Lucas recurrence Cₙ₊₂ = 5Cₙ₊₁ − 5Cₙ. The √5 factors give the closed form Cₙ = 5^{n/2}·Fₙ for even n and 5^{(n−1)/2}·Lₙ for odd n (Lₙ the Lucas numbers): the iterate scales by powers of √5 and alternates between the Fibonacci and Lucas sequences.",
+    "problemStatement": "**Open Question (OQ-02 from fibonacci-identities-oq-06-oq-01, second half)**: Establish the k-fold iterate ∑_{k≤n} C(n,k) F₂ₖ of the Fibonacci binomial transform, and relate it to F at index scaling by higher powers of two.\n\n**Answer**: The iterate Cₙ = ∑_{k≤n} C(n,k) F₂ₖ is NOT a Fibonacci sequence at a further-doubled index. It is the Lucas sequence Uₙ(5,5), satisfying Cₙ₊₂ = 5·Cₙ₊₁ − 5·Cₙ with C₀ = 0, C₁ = 1 (sequence 0, 1, 5, 20, 75, 275, 1000, …), with closed form 5^{n/2}Fₙ (n even) / 5^{(n−1)/2}Lₙ (n odd).",
+    "text": "A 142-line, 8-result (4 theorem + 4 lemma), 4-definition, 0-sorry, 0-axiom formalization over ℤ. The engine pascal_conv_ring lifts the parent's pascal_conv to any commutative ring. Applying it to the summands pₖ = F₂ₖ and qₖ = F₂ₖ₊₂ gives the coupled first-order system Cₙ₊₁ = Cₙ + Dₙ, Dₙ₊₁ = 4·Dₙ − Cₙ, where the coefficient 4 comes from the even-index Fibonacci recurrence F₂ₖ₊₄ = 3·F₂ₖ₊₂ − F₂ₖ. Eliminating Dₙ (its characteristic data trace 5, determinant 5) yields the second-order recurrence Cₙ₊₂ = 5·Cₙ₊₁ − 5·Cₙ, and the base values C₀ = 0, C₁ = 1 make the characterization complete.",
+    "proofStrategy": "**pascal_conv_ring.** The parent's pascal_conv proof carried through over an arbitrary commutative ring R: peel the k=0 term with Finset.sum_range_succ' and reindex; apply Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1) (Nat.choose_succ_succ', cast by the Nat.cast_add/Nat.cast_one simp set); split with Finset.sum_add_distrib; drop the vanishing top term C(n,n+1) = 0 (Nat.choose_succ_self) and reconcile the boundary with ring.\n\n**Even-index shift q_succ.** F₂ₖ₊₄ = 3·F₂ₖ₊₂ − F₂ₖ, obtained by unfolding three steps of Nat.fib_add_two over ℤ (push_cast + ring). This is the second-order recurrence of the even-indexed Fibonacci subsequence, whose 3 becomes the transform's 4 = 3 + 1.\n\n**Coupled recurrences C2_succ, D2_succ.** C2_succ = pascal_conv_ring at p with p(k+1) = q(k) (definitional, since 2(k+1) = 2k+2); D2_succ = pascal_conv_ring at q with q(k+1) = 3q(k) − p(k), collected by Finset.mul_sum / Finset.sum_sub_distrib and ring.\n\n**Second-order recurrence.** fib_two_k_binom_transform_rec chains C2_succ (n+1), D2_succ n, and Dₙ = Cₙ₊₁ − Cₙ (from C2_succ n) and closes by ring. C2_zero and C2_one evaluate the length-1 and length-2 sums by simp.",
+    "keyInsights": [
+      "**Iterating index-doubling does NOT give F₄ₙ.** The single most important finding: ∑ C(n,k) F₂ₖ is a genuinely new sequence (0, 1, 5, 20, 75, …), the (5,5) Lucas sequence, not F at any Fibonacci index. The naive 'transform doubles indices, so iterate to quadruple' intuition fails because the transform of F₂ₖ picks up √5 scaling.",
+      "**Why (5,5): 1 + φ² = √5·φ.** Since φ² = φ+1, the binomial-theorem base 1+φ² equals φ+2 = √5·φ, and 1+ψ² = −√5·ψ. So φ+2, ψ+2 are the roots of x² − 5x + 5 — the characteristic polynomial of the recurrence Cₙ₊₂ = 5Cₙ₊₁ − 5Cₙ (trace 5, determinant 5).",
+      "**The even-index recurrence's 3 becomes the transform's 4.** F₂ₖ₊₄ = 3F₂ₖ₊₂ − F₂ₖ drives Dₙ₊₁ = 4Dₙ − Cₙ (the 3 gains a +1 from the extra binomial offset). The 2×2 update matrix [[1,1],[−1,4]] has trace 5 and determinant 5, which is exactly the (P,Q) = (5,5) Lucas data.",
+      "**pascal_conv_ring is ring-generic.** Lifting the parent's ℕ-valued pascal_conv to an arbitrary commutative ring makes it reusable for the doubled-argument transform over ℤ (which needs subtraction) — and for the binomial transform of any R-valued sequence.",
+      "**Closed form mixes Fibonacci and Lucas.** Cₙ = 5^{n/2}Fₙ for even n and 5^{(n−1)/2}Lₙ for odd n: the √5-scaling from 1+φ² = √5φ makes the parity of n select between the F and L branches of the Binet formula."
+    ],
+    "prerequisites": [
+      "Parent entry fibonacci-identities-oq-06-oq-01 (the positive binomial transform ∑ C(n,k) Fₖ = F₂ₙ and pascal_conv)",
+      "Nat.fib and the recurrence Nat.fib_add_two",
+      "Pascal's rule Nat.choose_succ_succ' and Nat.choose_succ_self",
+      "Finset.sum_range_succ' / Finset.sum_range_succ, Finset.mul_sum, Finset.sum_sub_distrib",
+      "Lucas sequences Uₙ(P,Q) and second-order linear recurrences"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-06-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the positive binomial transform ∑ C(n,k) Fₖ = F₂ₙ via pascal_conv; this entry iterates the transform on the even-indexed output F₂ₖ and shows the result is a (5,5) Lucas sequence, using pascal_conv_ring (the parent's convolution lifted to any commutative ring)."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-06-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The sibling entry handles the alternating transform ∑ (−1)ᵏ C(n,k) Fₖ = −Fₙ (the x = −1 companion); together the two answer both halves of the parent's open question — the alternating transform and the doubled-argument iterate."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "FibonacciIdentitiesOQ06OQ01OQ03",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 4,
+    "path": "Proofs/FibonacciIdentitiesOQ06OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring stating the doubled-argument binomial transform, the (5,5) Lucas result, the golden-ratio motivation (1 + φ² = √5·φ, so φ+2 and ψ+2 are the roots of x² − 5x + 5), the closed form 5^{n/2}Fₙ / 5^{(n−1)/2}Lₙ, imports (Mathlib), namespace, open Finset."
+    },
+    {
+      "id": "sec-pascal-ring",
+      "title": "Pascal Convolution over a Commutative Ring",
+      "startLine": 46,
+      "endLine": 72,
+      "summary": "pascal_conv_ring: the parent entry's pascal_conv lifted to an arbitrary commutative ring R. Splits a degree-(n+1) binomial sum into two degree-n binomial sums at offsets 0 and 1, via Pascal's rule and the first-/last-term range peels.",
+      "mathContext": "$\\sum_{k<n+2} \\binom{n+1}{k} f_k = \\sum_{k<n+1} \\binom{n}{k} f_k + \\sum_{k<n+1} \\binom{n}{k} f_{k+1}$."
+    },
+    {
+      "id": "sec-summands",
+      "title": "Even-Indexed Summands and Their Shifts",
+      "startLine": 73,
+      "endLine": 97,
+      "summary": "The summands pₖ = F₂ₖ, qₖ = F₂ₖ₊₂, the transform sequences Cₙ = ∑ C(n,k) F₂ₖ and Dₙ = ∑ C(n,k) F₂ₖ₊₂, and the shift lemmas p_succ (pₖ₊₁ = qₖ, definitional) and q_succ (qₖ₊₁ = 3qₖ − pₖ, the even-index Fibonacci recurrence F₂ₖ₊₄ = 3F₂ₖ₊₂ − F₂ₖ).",
+      "mathContext": "$F_{2k+4} = 3F_{2k+2} - F_{2k}$."
+    },
+    {
+      "id": "sec-recurrences",
+      "title": "Coupled First-Order Recurrences",
+      "startLine": 98,
+      "endLine": 124,
+      "summary": "C2_succ (Cₙ₊₁ = Cₙ + Dₙ) and D2_succ (Dₙ₊₁ = 4Dₙ − Cₙ), each an application of pascal_conv_ring to p and q. The coefficient 4 = 3 + 1 combines the even-index recurrence's 3 with the extra binomial offset.",
+      "mathContext": "$C_{n+1} = C_n + D_n,\\quad D_{n+1} = 4D_n - C_n$; update matrix $\\begin{pmatrix}1&1\\\\-1&4\\end{pmatrix}$, trace $5$, determinant $5$."
+    },
+    {
+      "id": "sec-main",
+      "title": "The (5,5) Lucas Recurrence and Base Values",
+      "startLine": 125,
+      "endLine": 142,
+      "summary": "fib_two_k_binom_transform_rec (Cₙ₊₂ = 5Cₙ₊₁ − 5Cₙ, from eliminating Dₙ) with C2_zero (C₀ = 0) and C2_one (C₁ = 1), which together pin down Cₙ = Uₙ(5,5) uniquely.",
+      "mathContext": "$C_{n+2} = 5C_{n+1} - 5C_n,\\quad C_0 = 0,\\ C_1 = 1$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes the doubled-argument (iterated) Fibonacci binomial transform Cₙ = ∑_{k≤n} C(n,k) F₂ₖ and identifies it as the Lucas sequence Uₙ(5,5): Cₙ₊₂ = 5·Cₙ₊₁ − 5·Cₙ with C₀ = 0, C₁ = 1 (0, 1, 5, 20, 75, 275, …). The reusable primitive pascal_conv_ring (the parent's Pascal convolution over any commutative ring) plus the even-index Fibonacci recurrence F₂ₖ₊₄ = 3F₂ₖ₊₂ − F₂ₖ drive a coupled first-order system that collapses to the stated second-order recurrence. 8 results (4 theorem + 4 lemma), 4 definitions, 0 sorries, 0 axioms.",
+    "implications": "This is the 'iterate' half of the parent's open question, and its answer corrects a natural misconception: iterating the index-doubling transform does NOT reach F₄ₙ. The transform of the even-indexed Fibonacci numbers lands in a genuinely new (5,5) Lucas sequence, with √5-power scaling (closed form 5^{n/2}Fₙ for even n, 5^{(n−1)/2}Lₙ for odd n) rooted in 1 + φ² = √5·φ. Together with the sibling alternating transform (∑ (−1)ᵏ C(n,k) Fₖ = −Fₙ), both halves of the parent open question are now machine-checked. pascal_conv_ring is stated over an arbitrary commutative ring and so applies to the binomial transform of any R-valued sequence.",
+    "openQuestions": [
+      "Formalize the explicit closed form Cₙ = 5^{n/2}Fₙ (n even), 5^{(n−1)/2}Lₙ (n odd) directly, via the Binet identity 1 + φ² = √5·φ.",
+      "Determine the (P,Q) Lucas data of the m-fold iterate ∑ C(n,k) F_{2ᵐk} for general m, tracking how (P,Q) evolves under repeated binomial transformation."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second half** of the parent open question (fibonacci-identities-oq-06-oq-01, OQ-02): the *k-fold iterate* `∑_{k≤n} C(n,k) F₂ₖ` of the Fibonacci binomial transform. The sibling PR #32443 handled the *alternating* transform `∑ (−1)ᵏ C(n,k) Fₖ = −Fₙ`; this PR handles the *doubled-argument* iterate, so both halves of the parent OQ are now machine-checked.

## Headline result

`Cₙ = ∑_{k≤n} C(n,k) F₂ₖ` is **not** a further index-doubled Fibonacci sequence (`F₄ₙ`). It is the **Lucas sequence `Uₙ(5,5)`**:

```
C_{n+2} = 5·C_{n+1} − 5·C_n,   C₀ = 0, C₁ = 1
C = 0, 1, 5, 20, 75, 275, 1000, …
```

**Why (5,5):** By Binet `∑ C(n,k) φ²ᵏ = (1+φ²)ⁿ`, and since `φ² = φ+1` the base is `1+φ² = φ+2 = √5·φ` (likewise `1+ψ² = −√5·ψ`), so `φ+2, ψ+2` are the roots of `x² − 5x + 5` — trace 5, determinant 5. The √5 factors give the closed form `Cₙ = 5^{n/2}Fₙ` (n even) / `5^{(n−1)/2}Lₙ` (n odd): the iterate scales by powers of √5 and alternates between the Fibonacci and Lucas sequences.

## Contents (`proofs/Proofs/FibonacciIdentitiesOQ06OQ01OQ03.lean`, 142 lines)

- `fib_two_k_binom_transform_rec` — the second-order recurrence (headline)
- `C2_zero`, `C2_one` — base values pinning down `Cₙ = Uₙ(5,5)`
- `pascal_conv_ring` — the parent's `pascal_conv` lifted to any commutative ring (reusable)
- `C2_succ`, `D2_succ` — coupled first-order recurrences `Cₙ₊₁ = Cₙ + Dₙ`, `Dₙ₊₁ = 4Dₙ − Cₙ`, from `pascal_conv_ring` + the even-index Fibonacci recurrence `F₂ₖ₊₄ = 3F₂ₖ₊₂ − F₂ₖ`

## Verification

- `lake env lean Proofs/FibonacciIdentitiesOQ06OQ01OQ03.lean` → exit 0
- `#print axioms` on all results lists only `propext / Classical.choice / Quot.sound` — **no** `sorryAx`, `native_decide`, or `Lean.ofReduceBool`. Genuinely 0-axiom, 0-sorry.
- 4 theorems + 4 lemmas, 4 defs. Gallery entry added at `src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-03/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)