### PR TITLE
audit: fix theoremCount 7→6 for cube-root-3-irrational-oq-01-oq-03

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26839,6 +26839,12 @@
       "lastAudited": "2026-07-01T18:32:44Z",
       "result": "clean",
       "issues": []
+    },
+    "cube-root-3-irrational-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T18:37:50Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 143,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [
       "irreducible_X_pow_sub_C_of_squarefree_at_prime_int: Xⁿ − a is irreducible over ℤ whenever some prime q satisfies q ∣ a and q² ∤ a ('a squarefree at q'), for every n ≥ 1 — the generalization of the parent's prime-only theorem. Proved by verifying the four Eisenstein hypotheses at P = span{q}: leading coeff 1 ∉ P; lower coeffs 0 or −a, and −a ∈ P since q ∣ a; constant −a ∉ P² = span{q²}, which is exactly the hypothesis q² ∤ a; monic ⟹ primitive.",
@@ -135,7 +135,7 @@
     "namespace": "CubeRoot3IrrationalOQ01OQ03",
     "lineCount": 143,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 0,
     "mainTheorems": [
       {


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: cube-root-3-irrational-oq-01-oq-03
**Problem**: `theoremCount` overstated as 7; Lean source declares exactly 6 theorems.

## Evidence

`grep -cE "^\s*(theorem|lemma) " proofs/Proofs/CubeRoot3IrrationalOQ01OQ03.lean` → **6**:
- `irreducible_X_pow_sub_C_of_squarefree_at_prime_int`
- `irreducible_X_pow_sub_C_of_squarefree_at_prime_rat`
- `irreducible_X_pow_sub_C_prime_int`
- `irreducible_X_sq_sub_six_rat`
- `irreducible_X_cubed_sub_twelve_rat`
- `irreducible_X_sq_sub_twentyfour_rat`

meta.json claimed `theoremCount: 7` in both `meta.theoremCount` and `leanFile.theoremCount`.

## Fix

Corrected both fields to 6. Severity: LOW (cosmetic count; no overclaim of verification status).

All other integrity claims verified accurate: `status: verified`, 0 sorries, 0 axioms, no `native_decide`, 143 lines.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)