### PR TITLE
Enrich Erdős #634 Square Reptiling (erdos-634-medial-congruence-oq-01)

### DIFF
--- a/src/data/proofs/erdos-634-medial-congruence-oq-01/index.ts
+++ b/src/data/proofs/erdos-634-medial-congruence-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos634MedialCongruenceOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos634MedialCongruenceOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos634MedialCongruenceOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos634MedialCongruenceOQ01Data: ProofData = {
+  proof: erdos634MedialCongruenceOQ01Proof,
+  annotations: erdos634MedialCongruenceOQ01Annotations,
+}

--- a/src/data/proofs/erdos-634-medial-congruence-oq-01/meta.json
+++ b/src/data/proofs/erdos-634-medial-congruence-oq-01/meta.json
@@ -80,7 +80,64 @@
       "Triangle reptiling / dissection background for Erdős #634"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Module docstring framing OQ-01 (generalize the medial k=2 subdivision to all k) and its place in Erdős #634. Imports Mathlib and the base entry Proofs.Erdos634MedialCongruence, opens its namespace to reuse the TriCongruent equivalence relation and pointRefl isometry, and works over an arbitrary real normed space V.",
+      "mathContext": "Setting: NormedAddCommGroup V, NormedSpace ℝ V; reuse TriCongruent (an isometry-congruence equivalence relation) from the k=2 base entry."
+    },
+    {
+      "id": "part1-grid",
+      "title": "Part I: The k-Subdivision Grid",
+      "startLine": 63,
+      "endLine": 81,
+      "summary": "Defines the triangular grid P i j = A + (i/k)(B−A) + (j/k)(C−A), the base scaled triangle U0 = (P 0 0, P 1 0, P 0 1) with corner at A and side 1/k, and the upward/downward sub-triangles Up i j (same orientation as ABC) and Down i j (reversed).",
+      "mathContext": "P i j = A + (i/k)(B−A) + (j/k)(C−A); U0 = (P₀₀, P₁₀, P₀₁); Up/Down are the two cell orientations of the grid."
+    },
+    {
+      "id": "part2-congruence",
+      "title": "Part II: Congruence of Every Sub-Triangle to the Base Copy",
+      "startLine": 82,
+      "endLine": 111,
+      "summary": "cong_U0_Up: every upward cell is a translate of U0 (via IsometryEquiv.constVAdd); cong_U0_Down: every downward cell is a point reflection of U0. Vertex-image identities are ℝ-linear, discharged by the `module` tactic after push_cast. Reusing TriCongruent's symm/trans then yields cong_Up_Up, cong_Down_Down, cong_Up_Down — pairwise congruence of all pieces.",
+      "mathContext": "Two isometry families suffice: Up = translate(U0), Down = pointRefl(U0); equivalence-relation symm/trans give congruence between any two of the k² pieces for free."
+    },
+    {
+      "id": "part3-scaling",
+      "title": "Part III: The Pieces are 1/k-Scale Copies",
+      "startLine": 112,
+      "endLine": 138,
+      "summary": "U0_sides_scaled: the base copy U0 has side lengths exactly dist A B / k, dist B C / k, dist C A / k, exhibiting each piece as a genuine 1/k-scale copy. The single computation ‖(1/k)·v‖ = ‖v‖/k (norm_smul) handles all three sides, generalizing the exact halving of the medial k=2 case.",
+      "mathContext": "‖(1/k)·v‖ = ‖v‖/k, so each side of U0 is 1/k the corresponding side of triangle ABC."
+    },
+    {
+      "id": "part4-count",
+      "title": "Part IV: There are Exactly k² Pieces",
+      "startLine": 139,
+      "endLine": 176,
+      "summary": "triIdx n = {(i,j) : i+j < n} realized as a disjoint union of antidiagonals; card_triIdx computes its cardinality as a triangular number (Finset.card_biUnion + Finset.Nat.card_antidiagonal). card_pieces: a (k+1)-subdivision has T(k+1)+T(k) = (k+1)² pieces, and a k=2 cross-check recovers the medial 3+1 = 4 = 2².",
+      "mathContext": "T(k+1) + T(k) = (k+1)²: T(k+1) upward pieces + T(k) downward pieces; triangular numbers arise as antidiagonal-union cardinalities."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "Erdős Problem #634 (tiling a triangle by N congruent copies of a triangle)",
+      "year": "1990s",
+      "venue": "erdosproblems.com/634",
+      "note": "The $25 problem asking to characterize all triples (T, R, N) with T tileable by N congruent copies of R; the square reptiling supplies the always-achievable counts N = k²."
+    },
+    {
+      "authors": "Snover, Stephen L.; Waiveris, Charles; Williams, John K.",
+      "title": "Rep-tiling for triangles",
+      "year": "1991",
+      "venue": "Discrete Mathematics 91(2), 193–200",
+      "note": "Standard reference on triangle rep-tilings and the k² square-reptiling subdivision generalized here to arbitrary k."
+    }
+  ],
   "conclusion": {
     "summary": "A fully machine-checked, axiom-free formalization (0 sorries; only propext/Classical.choice/Quot.sound) over an arbitrary real normed space that the k-subdivision of any triangle A B C yields k² mutually congruent 1/k-scale copies. Upward pieces are translates of a base copy U0 and downward pieces are point reflections of U0; isometry-congruence (an equivalence relation reused from the base entry) makes all pieces pairwise congruent. The base copy has side lengths exactly 1/k of A B C, and a Finset cardinality argument gives the exact count T(k+1) + T(k) = (k+1)². The k = 2 case recovers the medial 4 = 2² pieces.",
     "implications": "This settles open question OQ-01 of the medial base entry and completes the congruence/scaling/count content of the square reptiling that underlies the 'always achievable' counts N = k² in Erdős #634. Because the argument uses only translations and point reflections — isometries available in any normed space — it is coordinate-free and reusable. What remains for a full tiling claim is the analytic covering/interior-disjointness, deliberately not formalized here.",


### PR DESCRIPTION
Enrichment pass for `erdos-634-medial-congruence-oq-01`.

**Critical fix:** added the missing `index.ts` — without it Vite's `import.meta.glob` cannot discover the proof and the page shows 'proof not found' on the live site.

**Coverage:**
- Populated the empty `sections` array with 5 sections (header/imports, Part I the k-subdivision grid, Part II congruence to the base copy, Part III 1/k-scaling, Part IV the k² count) — each with line ranges and mathContext, covering the full 176-line file and matching the Lean `/-! ## Part I…IV` structure.
- Added a `references` array (Erdős #634 problem page + Snover–Waiveris–Williams, *Rep-tiling for triangles*).

The overview (5 keyInsights) and conclusion (summary, implications, 2 open questions) were already rich and are preserved. meta.json stays well under all size caps.