### PR TITLE
research(erdos-1000-oq-03-oq-03): Gauss divisor-sum identity for Jordan's totient J_k

### DIFF
--- a/proofs/Proofs/Erdos1000OQ03OQ03.lean
+++ b/proofs/Proofs/Erdos1000OQ03OQ03.lean
@@ -1,0 +1,141 @@
+import Mathlib
+
+/-!
+# The Gauss divisor-sum identity for Jordan's totient `J_k`, via Dirichlet convolution
+
+**Follow-up open question (`erdos-1000-oq-03-oq-03`).**  The Jordan-totient family in
+this gallery defines `J_k` as the Dirichlet convolution `J_k = μ ∗ pow k`
+(`erdos-1000-oq-03-oq-01-oq-01`) and establishes its multiplicativity, prime-power
+values, Euler product, and positivity.  The *combinatorial* companion
+(`erdos-1000-oq-03-oq-01`) proves the Gauss-type identity `∑_{d ∣ n} C_k(d) = n^k`
+for the tuple count `C_k` by an explicit fiberwise bijection, and separately identifies
+`C_k = J_k`.
+
+This file closes the remaining gap by proving the Gauss identity **directly for the
+convolution `J_k`**, through pure **Dirichlet-convolution algebra** rather than a
+combinatorial bijection.  The key observation is that summing an arithmetic function
+over the divisors of `n` is *convolution with `ζ`*, and that `ζ` is a unit in the
+arithmetic-function ring with inverse `μ` (`ζ ∗ μ = 1`).  Hence
+
+$$ \zeta * J_k \;=\; \zeta * (\mu * \mathrm{pow}\,k)
+   \;=\; (\zeta * \mu) * \mathrm{pow}\,k \;=\; \mathrm{pow}\,k, $$
+
+which read at `n` is exactly `∑_{d ∣ n} J_k(d) = n^k`.
+
+## What this file proves (0 axioms, 0 sorries)
+
+* `zeta_mul_jordan` — the **structural identity** `ζ ∗ J_k = pow k` at the level of
+  arithmetic functions.  This is the true content: the numeric Gauss identity is its
+  evaluation at a point.
+* `jordan_divisor_sum` — `∑_{d ∣ n} J_k(d) = n^k`, the Gauss divisor-sum identity for
+  Jordan's totient (generalizing `∑_{d ∣ n} φ(d) = n`).
+* `jordan_unique` — **uniqueness / characterization**: `J_k` is the *only* arithmetic
+  function whose divisor sums are `n ↦ n^k`.  Since `ζ` is a unit (inverse `μ`), the
+  Gauss identity *characterizes* `J_k = μ ∗ pow k`.  Proved by Möbius inversion.
+* `jordan_apply` — the closed form `J_k(n) = ∑_{d ∣ n} μ(d)·(n/d)^k`.
+* `jordan_one_apply` — `J_1 = φ`, recovering Euler's totient (`k = 1`).
+* `gauss_sum_totient` — the classical `∑_{d ∣ n} φ(d) = n` recovered as the `k = 1`
+  specialization of `jordan_divisor_sum`.
+
+The whole development rests on Mathlib's Dirichlet-convolution machinery
+(`coe_zeta_mul_apply`, `coe_zeta_mul_moebius`, `sum_eq_iff_sum_smul_moebius_eq`); no
+analysis, no `native_decide`.
+
+Tags: number-theory, totient-function, jordan-totient, gauss-identity, divisor-sums,
+Dirichlet-convolution, moebius-inversion
+-/
+
+open Finset ArithmeticFunction
+open scoped ArithmeticFunction.zeta
+
+namespace Erdos1000OQ03OQ03
+
+/-- **Jordan's totient** `J_k := μ ∗ pow k`, the Dirichlet convolution defining the
+generalized totient (the same definition used in `erdos-1000-oq-03-oq-01-oq-01`). -/
+def jordan (k : ℕ) : ArithmeticFunction ℤ := moebius * (pow k : ArithmeticFunction ℤ)
+
+/-- **Structural identity.**  `ζ ∗ J_k = pow k` as arithmetic functions.
+
+Convolving Jordan's totient with `ζ` — i.e. forming the summatory (divisor-sum)
+function — returns `pow k`.  This is the arithmetic-function form of the Gauss identity
+and the reason `J_k` is the Möbius inverse of `n ↦ n^k`.  Read pointwise (via
+`coe_zeta_mul_apply`), both sides are divisor sums and the identity collapses to one
+line of convolution algebra: `ζ ∗ (μ ∗ pow k) = (ζ ∗ μ) ∗ pow k = 1 ∗ pow k = pow k`. -/
+theorem zeta_mul_jordan (k : ℕ) :
+    (ζ : ArithmeticFunction ℤ) * jordan k = (pow k : ArithmeticFunction ℤ) := by
+  ext n
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · simp
+  rw [coe_zeta_mul_apply, jordan, ← coe_zeta_mul_apply, ← mul_assoc,
+      coe_zeta_mul_moebius, one_mul]
+
+/-- **Gauss divisor-sum identity for Jordan's totient.**
+`∑_{d ∣ n} J_k(d) = n^k` — the exact generalization of Gauss's `∑_{d ∣ n} φ(d) = n`
+(the `k = 1` case).
+
+Proof: rewrite the divisor sum as `(ζ ∗ J_k)(n)` via `coe_zeta_mul_apply`, collapse
+`ζ ∗ μ = 1`, and evaluate `pow k` at `n`.  This is a genuinely different proof from the
+combinatorial fiberwise bijection of `erdos-1000-oq-03-oq-01`. -/
+theorem jordan_divisor_sum (k : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    ∑ d ∈ n.divisors, jordan k d = (n : ℤ) ^ k := by
+  rw [← coe_zeta_mul_apply, jordan, ← mul_assoc, coe_zeta_mul_moebius, one_mul,
+      natCoe_apply, pow_apply, if_neg (fun hc => hn hc.2), Nat.cast_pow]
+
+/-- **Closed form.**  `J_k(n) = ∑_{d ∣ n} μ(d)·(n/d)^k` — the Dirichlet-convolution
+formula (as in `erdos-1000-oq-03-oq-01-oq-01`), recorded here so the uniqueness and
+`k = 1` results below are self-contained. -/
+theorem jordan_apply {k n : ℕ} (hn : n ≠ 0) :
+    jordan k n = ∑ d ∈ n.divisors, (moebius d) * ((n / d : ℕ) : ℤ) ^ k := by
+  rw [jordan, mul_apply,
+    Nat.sum_divisorsAntidiagonal (fun x y => (moebius x) * ((pow k : ArithmeticFunction ℤ) y))]
+  refine Finset.sum_congr rfl fun d hd => ?_
+  obtain ⟨hdvd, _⟩ := Nat.mem_divisors.mp hd
+  have hpos : 0 < n / d :=
+    Nat.div_pos (Nat.le_of_dvd (Nat.pos_of_ne_zero hn) hdvd) (Nat.pos_of_mem_divisors hd)
+  rw [natCoe_apply, pow_apply, if_neg (by simp [hpos.ne']), Nat.cast_pow]
+
+/-- **Uniqueness / characterization.**  `J_k` is the *unique* arithmetic function whose
+divisor sums are `n ↦ n^k`: if `∑_{d ∣ m} f(d) = m^k` for every `m ≥ 1`, then `f = J_k`.
+
+Because `ζ` is a unit in the Dirichlet-convolution ring with inverse `μ`, the
+divisor-sum operator is invertible, so the Gauss identity *pins down* `J_k = μ ∗ pow k`.
+Concretely this is Möbius inversion (`sum_eq_iff_sum_smul_moebius_eq`). -/
+theorem jordan_unique (k : ℕ) (f : ArithmeticFunction ℤ)
+    (hf : ∀ m : ℕ, 0 < m → ∑ d ∈ m.divisors, f d = (m : ℤ) ^ k) :
+    f = jordan k := by
+  ext n
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · simp [jordan]
+  have H : ∀ m : ℕ, 0 < m → ∑ i ∈ m.divisors, f i = ((m : ℕ) : ℤ) ^ k := hf
+  have hinv := (ArithmeticFunction.sum_eq_iff_sum_smul_moebius_eq
+      (f := fun i => f i) (g := fun m => ((m : ℕ) : ℤ) ^ k)).mp H n hn
+  rw [← hinv, jordan_apply hn.ne',
+      Nat.sum_divisorsAntidiagonal (fun p q => (moebius p) • ((q : ℕ) : ℤ) ^ k)]
+  exact Finset.sum_congr rfl fun d _ => smul_eq_mul _ _
+
+/-- **Euler-totient recovery (`k = 1`).**  `J_1 = φ`: Jordan's totient specialises to
+Euler's totient, since `μ ∗ id = φ` is the Möbius inversion of `∑_{d ∣ n} φ(d) = n`. -/
+theorem jordan_one_apply (n : ℕ) : jordan 1 n = (Nat.totient n : ℤ) := by
+  rcases eq_or_ne n 0 with rfl | hn
+  · simp [jordan]
+  rw [jordan_apply hn]
+  have H : ∀ m, 0 < m → ∑ i ∈ m.divisors, (Nat.totient i : ℤ) = ((m : ℕ) : ℤ) := by
+    intro m _
+    rw [← Nat.cast_sum, Nat.sum_totient]
+  have hinv := (ArithmeticFunction.sum_eq_iff_sum_smul_moebius_eq
+      (f := fun i => (Nat.totient i : ℤ)) (g := fun m => ((m : ℕ) : ℤ))).mp H n
+      (Nat.pos_of_ne_zero hn)
+  rw [← hinv, Nat.sum_divisorsAntidiagonal (fun p q => (moebius p) • ((q : ℕ) : ℤ))]
+  refine Finset.sum_congr rfl fun d _ => ?_
+  simp [pow_one]
+
+/-- **Classical Gauss identity recovered.**  `∑_{d ∣ n} φ(d) = n`, obtained as the
+`k = 1` specialization of `jordan_divisor_sum` together with `J_1 = φ`. -/
+theorem gauss_sum_totient {n : ℕ} (hn : n ≠ 0) :
+    ∑ d ∈ n.divisors, (Nat.totient d : ℤ) = (n : ℤ) := by
+  have h := jordan_divisor_sum 1 (n := n) hn
+  rw [pow_one] at h
+  rw [← h]
+  exact Finset.sum_congr rfl fun d _ => (jordan_one_apply d).symm
+
+end Erdos1000OQ03OQ03

--- a/src/data/proofs/erdos-1000-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "jordan-def",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 55, "endLine": 55 },
+    "type": "definition",
+    "title": "Jordan's totient as a Dirichlet convolution",
+    "content": "`jordan k := moebius * (pow k)` reuses the exact Dirichlet-convolution definition of $J_k = \\mu * \\mathrm{pow}_k$ from the sibling entry `erdos-1000-oq-03-oq-01-oq-01`, valued in $\\mathbb{Z}$. Packaging $J_k$ as a convolution is what makes the Gauss identity a one-line computation: convolving with $\\zeta$ (the divisor-sum operator) telescopes against the $\\mu$ inside $J_k$ because $\\zeta * \\mu = 1$.",
+    "mathContext": "$J_k = \\mu * \\mathrm{pow}_k$, where $(\\mathrm{pow}_k)(n) = n^k$ and $(f*g)(n) = \\sum_{d\\mid n} f(d)\\,g(n/d)$ is Dirichlet convolution.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet convolution", "arithmetic function", "Mobius function", "Jordan totient"],
+    "prerequisites": ["Dirichlet convolution", "arithmetic functions"]
+  },
+  {
+    "id": "zeta-mul-jordan",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 64, "endLine": 77 },
+    "type": "theorem",
+    "title": "Structural identity: ζ * J_k = pow k",
+    "content": "`zeta_mul_jordan` is the heart of the entry: the Gauss identity stated as an equation of arithmetic functions, $\\zeta * J_k = \\mathrm{pow}_k$. The proof is extensionality plus convolution algebra — for each $n$ both sides become divisor sums via `coe_zeta_mul_apply`, and $\\zeta * (\\mu * \\mathrm{pow}_k) = (\\zeta * \\mu) * \\mathrm{pow}_k = 1 * \\mathrm{pow}_k = \\mathrm{pow}_k$ using $\\zeta * \\mu = 1$ (`coe_zeta_mul_moebius`). The numeric Gauss identity is just this evaluated at a point.",
+    "mathContext": "$\\zeta * J_k = \\mathrm{pow}_k$ in the arithmetic-function ring; equivalently $\\mathrm{pow}_k = \\zeta * J_k$, the Dirichlet-series relation $\\zeta(s-k) = \\zeta(s)\\cdot\\frac{\\zeta(s-k)}{\\zeta(s)}$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet convolution", "zeta function", "Mobius function", "unit of a ring"],
+    "prerequisites": ["Dirichlet convolution", "convolution with zeta as divisor sum"]
+  },
+  {
+    "id": "jordan-divisor-sum",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 79, "endLine": 85 },
+    "type": "theorem",
+    "title": "The Gauss divisor-sum identity ∑ J_k(d) = n^k",
+    "content": "`jordan_divisor_sum` is the headline result: $\\sum_{d\\mid n} J_k(d) = n^k$, the exact generalization of Gauss's $\\sum_{d\\mid n}\\varphi(d) = n$. It rewrites the divisor sum as $(\\zeta * J_k)(n)$ (`coe_zeta_mul_apply`), collapses $\\zeta * \\mu = 1$, and evaluates $\\mathrm{pow}_k$ at $n$. This is a structurally different proof from the combinatorial fiberwise bijection used for the tuple count $C_k$ in `erdos-1000-oq-03-oq-01`: no tuples or gcd-scaling, just that $\\zeta$ is invertible.",
+    "mathContext": "$\\sum_{d\\mid n} J_k(d) = n^k$ for $n \\geq 1$; at $k=1$ this is Gauss's $\\sum_{d\\mid n}\\varphi(d)=n$.",
+    "significance": "key",
+    "relatedConcepts": ["Gauss identity", "divisor sum", "Jordan totient", "Mobius inversion"],
+    "prerequisites": ["Dirichlet convolution", "zeta * mu = 1"]
+  },
+  {
+    "id": "jordan-apply",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 87, "endLine": 101 },
+    "type": "tactic",
+    "title": "Closed form of J_k",
+    "content": "`jordan_apply` unfolds the convolution to the explicit divisor sum $J_k(n) = \\sum_{d\\mid n}\\mu(d)(n/d)^k$, recorded so that the uniqueness theorem and the $k=1$ recovery are self-contained. The proof rewrites `mul_apply` over the divisor antidiagonal and discharges the `pow` branch (the arithmetic function $\\mathrm{pow}_k$ sends $0\\mapsto 0$, so the guard needs $n/d \\neq 0$).",
+    "mathContext": "$J_k(n) = \\sum_{d\\mid n}\\mu(d)\\left(\\tfrac{n}{d}\\right)^k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["divisor sum", "Mobius function", "divisor antidiagonal"],
+    "prerequisites": ["Dirichlet convolution", "Mobius function"]
+  },
+  {
+    "id": "jordan-unique",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 103, "endLine": 116 },
+    "type": "theorem",
+    "title": "Uniqueness: the Gauss identity characterizes J_k",
+    "content": "`jordan_unique` upgrades the identity from a property to a characterization: if an arithmetic function $f$ satisfies $\\sum_{d\\mid m} f(d) = m^k$ for every $m \\geq 1$, then $f = J_k$. Because $\\zeta$ is a unit in the convolution ring (inverse $\\mu$), the divisor-sum operator is invertible, so its output determines its input. Concretely the proof is Möbius inversion (`sum_eq_iff_sum_smul_moebius_eq`) matched against the closed form `jordan_apply`. Thus $J_k$ is the ONLY function whose divisor sums are $n \\mapsto n^k$.",
+    "mathContext": "If $\\forall m\\geq 1,\\ \\sum_{d\\mid m} f(d) = m^k$, then $f = \\mu * \\mathrm{pow}_k = J_k$.",
+    "significance": "key",
+    "relatedConcepts": ["Mobius inversion", "uniqueness", "unit of a ring", "characterization"],
+    "prerequisites": ["Mobius inversion", "invertibility of zeta"]
+  },
+  {
+    "id": "jordan-one-apply",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 118, "endLine": 132 },
+    "type": "theorem",
+    "title": "Euler totient recovery: J_1 = φ",
+    "content": "`jordan_one_apply` proves $J_1 = \\varphi$ by Möbius inversion of Gauss's identity $\\sum_{d\\mid n}\\varphi(d) = n$, anchoring $J_k$ as the genuine generalization of Euler's totient and setting up the $k=1$ collapse of the Gauss divisor-sum identity.",
+    "mathContext": "$J_1(n) = \\varphi(n)$, since $\\mu * \\mathrm{id} = \\varphi$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler totient", "Mobius inversion", "Gauss identity"],
+    "prerequisites": ["Mobius inversion", "Euler totient"]
+  },
+  {
+    "id": "gauss-sum-totient",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 134, "endLine": 139 },
+    "type": "theorem",
+    "title": "Classical Gauss identity recovered at k = 1",
+    "content": "`gauss_sum_totient` recovers the textbook $\\sum_{d\\mid n}\\varphi(d) = n$ as the $k=1$ specialization of `jordan_divisor_sum` together with $J_1 = \\varphi$. This confirms the generalized identity $\\sum_{d\\mid n} J_k(d) = n^k$ collapses correctly to the classical case, closing the loop between the general convolution argument and Gauss's original statement.",
+    "mathContext": "$\\sum_{d\\mid n}\\varphi(d) = n$, the $k=1$ case of $\\sum_{d\\mid n} J_k(d) = n^k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gauss identity", "Euler totient", "specialization"],
+    "prerequisites": ["Euler totient", "Gauss identity"]
+  }
+]

--- a/src/data/proofs/erdos-1000-oq-03-oq-03/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-03/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "erdos-1000-oq-03-oq-03",
+  "title": "The Gauss Divisor-Sum Identity for Jordan's Totient $J_k$",
+  "slug": "erdos-1000-oq-03-oq-03",
+  "description": "Proves the Gauss-type divisor-sum identity ∑_{d∣n} J_k(d) = n^k for Jordan's totient J_k = μ * pow k directly at the level of the Dirichlet convolution, answering the converse-Möbius open question left by erdos-1000-oq-03-oq-01-oq-01. Where the combinatorial companion (erdos-1000-oq-03-oq-01) established the numeric identity ∑_{d∣n} C_k(d) = n^k for the tuple count C_k via an explicit fiberwise bijection, this entry gives a structurally different proof by pure Dirichlet-convolution algebra: summing an arithmetic function over the divisors of n is convolution with ζ, and ζ is a unit in the arithmetic-function ring with inverse μ (ζ * μ = 1), so ζ * J_k = ζ * (μ * pow k) = (ζ * μ) * pow k = pow k. With 0 axioms and 0 sorries (no native_decide) it proves: the structural identity ζ * J_k = pow k at the arithmetic-function level (zeta_mul_jordan); the pointwise Gauss identity ∑_{d∣n} J_k(d) = n^k (jordan_divisor_sum); a uniqueness/characterization theorem showing J_k is the ONLY arithmetic function whose divisor sums are n ↦ n^k, via Möbius inversion (jordan_unique); the closed form J_k(n) = ∑_{d∣n} μ(d)(n/d)^k (jordan_apply); the Euler-totient recovery J_1 = φ (jordan_one_apply); and the classical Gauss identity ∑_{d∣n} φ(d) = n recovered as the k = 1 case (gauss_sum_totient). The whole development rests on Mathlib's Dirichlet-convolution machinery (coe_zeta_mul_apply, coe_zeta_mul_moebius, sum_eq_iff_sum_smul_moebius_eq); no analysis.",
+  "overview": {
+    "historicalContext": "Gauss's identity ∑_{d∣n} φ(d) = n is one of the oldest facts about Euler's totient: summing φ over the divisors of n reconstructs n. Camille Jordan's totient J_k (Traité des substitutions, ~1870) generalizes φ = J_1, and it satisfies the exact generalization ∑_{d∣n} J_k(d) = n^k. In the language of Dirichlet series this is the identity ζ(s−k) = ζ(s) · (ζ(s−k)/ζ(s)), i.e. pow k = ζ * J_k, dual to the divisor-power relation σ_k = ζ * pow k that Mathlib already formalizes. The parent thread of this gallery built J_k from its combinatorial count and from its multiplicative structure; the multiplicativity entry (erdos-1000-oq-03-oq-01-oq-01) explicitly flagged the converse-Möbius relation ∑_{d∣n} J_k(d) = n^k as an open follow-up 'completing the convolution-inverse pair'. This entry supplies exactly that, and does so by the clean unit-of-the-convolution-ring argument rather than the combinatorial bijection used by the sibling count.",
+    "problemStatement": "Prove, in Lean 4 with 0 axioms and 0 sorries, the Gauss divisor-sum identity ∑_{d∣n} J_k(d) = n^k for Jordan's totient J_k = μ * pow k, directly for the Dirichlet-convolution definition; establish the underlying arithmetic-function identity ζ * J_k = pow k; show the identity characterizes J_k uniquely; and recover the classical ∑_{d∣n} φ(d) = n as the case k = 1.",
+    "proofStrategy": "Read the divisor-sum operator as convolution with ζ. Since summing f over divisors of n equals (ζ * f)(n) (coe_zeta_mul_apply), and ζ * μ = 1 in the arithmetic-function ring (coe_zeta_mul_moebius), the identity ζ * J_k = ζ * (μ * pow k) = (ζ * μ) * pow k = pow k follows by associativity — this is zeta_mul_jordan, proved by extensionality reducing both sides to divisor sums. Evaluating at n and unfolding pow k gives the numeric identity jordan_divisor_sum. For uniqueness, invert: because ζ is a unit with inverse μ, any f with ζ * f = pow k must equal μ * pow k = J_k; concretely this is Möbius inversion (sum_eq_iff_sum_smul_moebius_eq) matched against the closed form jordan_apply. Specializing k = 1 and using J_1 = φ (jordan_one_apply, itself Möbius inversion of Gauss's identity) recovers ∑_{d∣n} φ(d) = n.",
+    "keyInsights": [
+      "The divisor-sum operator IS convolution with ζ: ∑_{d∣n} f(d) = (ζ * f)(n). This single reinterpretation turns the Gauss identity from a counting statement into one line of ring algebra.",
+      "ζ is a unit in the Dirichlet-convolution ring with inverse μ (ζ * μ = 1). Hence J_k = μ * pow k and pow k = ζ * J_k are two readings of the same invertible relation — Möbius inversion and Gauss summation are inverse operations.",
+      "The identity ∑_{d∣n} J_k(d) = n^k does not merely hold for J_k — it characterizes J_k: any arithmetic function with those divisor sums equals μ * pow k, because a unit is cancellable. This upgrades the identity from a property to a definition.",
+      "This convolution-algebra proof is structurally different from the combinatorial fiberwise bijection of the sibling count C_k: no tuples, no gcd-scaling, no fibers — just the fact that ζ has an inverse.",
+      "The classical Gauss identity ∑_{d∣n} φ(d) = n is the k = 1 shadow of a whole family; recovering it from jordan_divisor_sum via J_1 = φ makes the generalization concrete."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-docstring",
+      "title": "Context: closing the convolution-inverse pair",
+      "startLine": 3,
+      "endLine": 46,
+      "summary": "Module docstring situating the entry as the converse-Möbius follow-up to the Jordan-totient thread, contrasting the Dirichlet-convolution proof with the combinatorial bijection of the sibling count, and listing the six results (0 axioms, 0 sorries)."
+    },
+    {
+      "id": "definition",
+      "title": "Definition: J_k as μ * pow k",
+      "startLine": 48,
+      "endLine": 55,
+      "summary": "Opens Finset, ArithmeticFunction and the ζ notation, and defines jordan k = moebius * (pow k) over ℤ — the same Dirichlet-convolution definition as erdos-1000-oq-03-oq-01-oq-01."
+    },
+    {
+      "id": "structural-identity",
+      "title": "Structural identity ζ * J_k = pow k (zeta_mul_jordan)",
+      "startLine": 57,
+      "endLine": 77,
+      "summary": "Proves the arithmetic-function identity ζ * J_k = pow k by extensionality: each side read at n is a divisor sum (coe_zeta_mul_apply), and ζ * μ = 1 collapses the convolution. The numeric Gauss identity is this evaluated at a point."
+    },
+    {
+      "id": "divisor-sum",
+      "title": "Gauss divisor-sum identity (jordan_divisor_sum)",
+      "startLine": 79,
+      "endLine": 85,
+      "summary": "The headline: ∑_{d∣n} J_k(d) = n^k, obtained by rewriting the divisor sum as (ζ * J_k)(n), collapsing ζ * μ = 1, and evaluating pow k at n."
+    },
+    {
+      "id": "closed-form",
+      "title": "Closed form (jordan_apply)",
+      "startLine": 87,
+      "endLine": 101,
+      "summary": "Unfolds the convolution to J_k(n) = ∑_{d∣n} μ(d)(n/d)^k, recorded so the uniqueness and k = 1 results are self-contained."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness / characterization (jordan_unique)",
+      "startLine": 103,
+      "endLine": 116,
+      "summary": "Shows J_k is the unique arithmetic function whose divisor sums are n ↦ n^k: if ∑_{d∣m} f(d) = m^k for all m ≥ 1 then f = J_k, by Möbius inversion (sum_eq_iff_sum_smul_moebius_eq) against the closed form. The Gauss identity pins down J_k."
+    },
+    {
+      "id": "euler-recovery",
+      "title": "Euler totient recovery (jordan_one_apply)",
+      "startLine": 118,
+      "endLine": 132,
+      "summary": "Proves J_1 = φ by Möbius inversion of Gauss's identity ∑_{d∣n} φ(d) = n, anchoring J_k as the generalization of Euler's totient."
+    },
+    {
+      "id": "classical-gauss",
+      "title": "Classical Gauss identity recovered (gauss_sum_totient)",
+      "startLine": 134,
+      "endLine": 139,
+      "summary": "Recovers the textbook ∑_{d∣n} φ(d) = n as the k = 1 specialization of jordan_divisor_sum together with J_1 = φ, confirming the family collapses to the classical case."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry completes the Jordan-totient thread's convolution-inverse pair by proving the Gauss divisor-sum identity ∑_{d∣n} J_k(d) = n^k directly for the Dirichlet convolution J_k = μ * pow k, with 0 axioms and 0 sorries. The proof reinterprets the divisor-sum operator as convolution with ζ and uses that ζ is a unit with inverse μ (ζ * μ = 1), giving the structural identity ζ * J_k = pow k (zeta_mul_jordan) in one line of ring algebra; the numeric identity (jordan_divisor_sum) is its evaluation at a point. A uniqueness theorem (jordan_unique) upgrades the identity to a characterization: J_k is the only arithmetic function with those divisor sums. The case k = 1 recovers Euler's totient (jordan_one_apply) and the classical Gauss identity ∑_{d∣n} φ(d) = n (gauss_sum_totient). The convolution-algebra proof is structurally independent of the combinatorial fiberwise bijection used by the sibling count erdos-1000-oq-03-oq-01.",
+    "implications": "Together with the sibling entries this closes the elementary theory of J_k: the combinatorial meaning (oq-03-oq-01), the multiplicative structure and Euler products (oq-03-oq-01-oq-01), and now the defining Gauss/summation identity and its uniqueness (this entry). The structural identity ζ * J_k = pow k is the natural launch point for the Dirichlet-series formulation ∑ J_k(n)/n^s = ζ(s−k)/ζ(s), and the uniqueness result means any future object shown to have divisor sums n^k is automatically J_k.",
+    "openQuestions": [
+      "Formalize the Dirichlet-series identity ∑_n J_k(n)/n^s = ζ(s−k)/ζ(s), reading the ζ * J_k = pow k relation analytically and connecting to Mathlib's L-series library.",
+      "State and prove the σ_k / J_k reciprocity within a single framework: both are ζ- and μ-convolutions of pow k, so σ_k * (μ-analogue) relations should follow from the same unit-of-the-ring argument."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1000-oq-03-oq-01-oq-01",
+      "relationship": "depends-on",
+      "description": "Sibling entry defining J_k = μ * pow k and developing its multiplicativity and Euler products. Its open question #3 explicitly asked for the converse-Möbius relation ∑_{d∣n} J_k(d) = n^k 'completing the convolution-inverse pair' — which this entry proves."
+    },
+    {
+      "targetId": "erdos-1000-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Combinatorial companion. Proves ∑_{d∣n} C_k(d) = n^k for the jointly-coprime tuple count C_k via an explicit fiberwise bijection, and identifies C_k = J_k. This entry reproves the divisor-sum identity for the convolution J_k by structurally different Dirichlet-convolution algebra."
+    },
+    {
+      "targetId": "erdos-1000-oq-03",
+      "relationship": "related",
+      "description": "Grandparent entry on generalized totients with restricted denominator conditions, source of the Jordan-totient thread and of the classical Gauss identity ∑_{d∣n} φ(d) = n that this entry recovers at k = 1."
+    }
+  ],
+  "meta": {
+    "author": "Classical theory of Jordan's totient (Camille Jordan, 1870); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Jordan%27s_totient_function",
+    "date": "1870",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1000OQ03OQ03.lean",
+    "tags": [
+      "number-theory",
+      "jordan-totient",
+      "euler-totient",
+      "gauss-identity",
+      "divisor-sums",
+      "dirichlet-convolution",
+      "moebius-inversion",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 141,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (no native_decide). #print axioms confirms the headline theorems (zeta_mul_jordan, jordan_divisor_sum, jordan_unique, gauss_sum_totient) depend only on the foundational propext, Classical.choice, Quot.sound.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.coe_zeta_mul_apply",
+        "description": "(ζ * f)(x) = ∑_{i∣x} f(i): convolution with the arithmetic zeta function is exactly the divisor-sum operator. This is the reinterpretation that turns the Gauss identity into convolution algebra.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Zeta"
+      },
+      {
+        "theorem": "ArithmeticFunction.coe_zeta_mul_moebius",
+        "description": "ζ * μ = 1 in the arithmetic-function ring over ℤ. Collapses ζ * (μ * pow k) = pow k, the core of both zeta_mul_jordan and jordan_divisor_sum.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Moebius"
+      },
+      {
+        "theorem": "ArithmeticFunction.sum_eq_iff_sum_smul_moebius_eq",
+        "description": "Möbius inversion over an AddCommGroup. Used to prove uniqueness (jordan_unique): the divisor sums n ↦ n^k determine f = μ * pow k, and to recover J_1 = φ from Gauss's identity.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Moebius"
+      },
+      {
+        "theorem": "ArithmeticFunction.pow_apply",
+        "description": "pow k n = n^k for n ≠ 0 (with pow 0 0 = 0). Evaluates the right-hand side pow k at n to give the numeric n^k.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "Nat.sum_totient",
+        "description": "∑_{d∣n} φ(d) = n, Gauss's classical identity. Anchors the k = 1 recovery J_1 = φ and the recovered gauss_sum_totient.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction"
+      },
+      {
+        "theorem": "Nat.sum_divisorsAntidiagonal",
+        "description": "Reindexes a sum over the divisor antidiagonal {(d, n/d)} as a sum over divisors d∣n. Bridges the convolution mul_apply / Möbius-inversion antidiagonal forms and the divisor-sum closed form.",
+        "module": "Mathlib.NumberTheory.Divisors"
+      }
+    ],
+    "originalContributions": [
+      "`zeta_mul_jordan`: the structural identity ζ * J_k = pow k at the arithmetic-function level — the Gauss divisor-sum identity read as an equation of arithmetic functions, proved by extensionality plus ζ * μ = 1.",
+      "`jordan_divisor_sum`: ∑_{d∣n} J_k(d) = n^k for the Dirichlet-convolution J_k, proved by convolution algebra rather than the combinatorial fiberwise bijection of the sibling count — answering the converse-Möbius open question of erdos-1000-oq-03-oq-01-oq-01.",
+      "`jordan_unique`: uniqueness/characterization — J_k is the ONLY arithmetic function whose divisor sums are n ↦ n^k, via Möbius inversion, upgrading the Gauss identity from a property to a defining characterization.",
+      "`jordan_apply`: the closed form J_k(n) = ∑_{d∣n} μ(d)(n/d)^k, recorded self-containedly.",
+      "`jordan_one_apply`: J_1 = φ, recovering Euler's totient via Möbius inversion of Gauss's identity.",
+      "`gauss_sum_totient`: the classical ∑_{d∣n} φ(d) = n recovered as the k = 1 specialization of jordan_divisor_sum, confirming the generalization collapses correctly."
+    ],
+    "prerequisites": [
+      "Dirichlet convolution of arithmetic functions and the arithmetic zeta and Möbius functions",
+      "The unit ζ * μ = 1 and the equivalence between Gauss summation and Möbius inversion",
+      "Reading ∑_{d∣n} f(d) as convolution with ζ (coe_zeta_mul_apply)",
+      "Gauss's classical identity ∑_{d∣n} φ(d) = n and Euler's totient as J_1"
+    ],
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "erdos-1000-oq-03-oq-01-oq-01",
+        "relationship": "Sibling entry defining J_k = μ * pow k and its multiplicative/Euler-product theory; its open question #3 requested exactly the converse-Möbius identity ∑_{d∣n} J_k(d) = n^k proved here."
+      },
+      {
+        "id": "erdos-1000-oq-03-oq-01",
+        "relationship": "Combinatorial companion proving ∑_{d∣n} C_k(d) = n^k for the tuple count C_k via a fiberwise bijection; this entry reproves the identity for the convolution J_k by structurally different algebra."
+      },
+      {
+        "id": "erdos-1000-oq-03",
+        "relationship": "Grandparent entry on generalized totients, source of the Jordan-totient thread and of the classical Gauss identity recovered here at k = 1."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **erdos-1000-oq-03-oq-03** — the **Gauss divisor-sum identity** $\sum_{d\mid n} J_k(d) = n^k$ for Jordan's totient $J_k = \mu * \mathrm{pow}_k$, proved **directly for the Dirichlet convolution** by convolution algebra.

This **answers open question #3** of the sibling entry `erdos-1000-oq-03-oq-01-oq-01`, which explicitly requested the converse-Möbius relation $\sum_{d\mid n} J_k(d) = n^k$ "completing the convolution-inverse pair."

## What's new

The combinatorial companion (`erdos-1000-oq-03-oq-01`) proved $\sum_{d\mid n} C_k(d) = n^k$ for the jointly-coprime tuple count $C_k$ via an explicit **fiberwise bijection**. This entry gives a **structurally different proof** for the convolution $J_k$: summing over divisors is convolution with $\zeta$, and $\zeta$ is a unit with inverse $\mu$ ($\zeta * \mu = 1$), so
$$\zeta * J_k = \zeta * (\mu * \mathrm{pow}_k) = (\zeta * \mu) * \mathrm{pow}_k = \mathrm{pow}_k.$$

## Results (0 axioms, 0 sorries, no `native_decide`)

- `zeta_mul_jordan` — structural identity $\zeta * J_k = \mathrm{pow}_k$ at the arithmetic-function level
- `jordan_divisor_sum` — **headline**: $\sum_{d\mid n} J_k(d) = n^k$
- `jordan_unique` — **uniqueness/characterization**: $J_k$ is the *only* arithmetic function whose divisor sums are $n \mapsto n^k$ (via Möbius inversion) — upgrades the identity from a property to a definition
- `jordan_apply` — closed form $J_k(n) = \sum_{d\mid n}\mu(d)(n/d)^k$
- `jordan_one_apply` — $J_1 = \varphi$
- `gauss_sum_totient` — classical $\sum_{d\mid n}\varphi(d) = n$ recovered as the $k=1$ case

## Verification

`#print axioms` on all headline theorems reports only `propext, Classical.choice, Quot.sound` (foundational). Typechecked against Mathlib via `lake env lean`.

**Note:** the numeric fact was already available combinatorially via the sibling `C_k` route; the contribution here is the **convolution-algebra proof**, the **arithmetic-function-level structural identity**, and the **uniqueness characterization** — closing the Jordan-totient theory's convolution-inverse pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)