### PR TITLE
research(erdos-1000-oq-03-oq-03): Gauss divisor-sum identity for Jordan's totient via the Dirichlet ring [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1000OQ03OQ03.lean
+++ b/proofs/Proofs/Erdos1000OQ03OQ03.lean
@@ -1,0 +1,123 @@
+import Mathlib
+
+/-
+# Erdős #1000 OQ-03 → OQ-03: The Gauss divisor-sum identity for Jordan's totient, via the Dirichlet ring
+
+## Open question
+
+`erdos-1000-oq-03-oq-03`: *the Gauss divisor-sum identity for the Jordan totient*
+`∑_{d ∣ n} J_k(d) = n^k`.
+
+## Where this sits in the gallery
+
+The sibling entries develop Jordan's totient `J_k` from two independent angles:
+
+* `erdos-1000-oq-03-oq-01` / `-oq-02` prove the **geometric** divisor-sum identity
+  `∑_{d ∣ n} C_k(d) = n^k` for the *combinatorial count* `C_k(n) = #{ a ∈ (ℤ/n)^k :
+  gcd(a, n) = 1 }`, by an explicit fibrewise bijection on `k`-tuples, and Möbius-invert
+  it to obtain `C_k = μ ∗ pow k`.
+* `erdos-1000-oq-03-oq-01-oq-01` studies the **arithmetic function** `J_k := μ ∗ pow k`
+  (valued in `ℤ`): its multiplicativity, prime-power values, and the Euler product.
+
+What neither entry states is the divisor-sum identity **at the level of the abstract
+arithmetic function** `J_k = μ ∗ pow k`, i.e. the *reconstruction* dual of the gallery's
+*Möbius-inversion* result. That is exactly this file: it works entirely inside Mathlib's
+Dirichlet convolution ring `ArithmeticFunction ℤ`, where the identity becomes a one-line
+ring computation, and it adds the **uniqueness characterisation** — that the Gauss
+divisor-sum *determines* `J_k` — which is genuinely new to the gallery.
+
+## What this file proves (0 axioms, 0 sorries)
+
+* `jordan` — `J_k := μ ∗ pow k`, the arithmetic function of `-oq-01-oq-01`.
+* `jordan_mul_zeta` — the **arithmetic-function identity** `J_k ∗ ζ = pow k`.  This is the
+  reconstruction dual of the gallery's inversion `J_k = μ ∗ pow k`: convolving by `ζ`
+  (summation over divisors) undoes the Möbius weighting, because `μ ∗ ζ = 1` in the
+  Dirichlet ring.
+* `jordan_divisor_sum` — the headline **Gauss identity** `∑_{d ∣ n} J_k(d) = n^k` (`n ≠ 0`),
+  read off `jordan_mul_zeta` pointwise via `coe_mul_zeta_apply`.
+* `jordan_unique` — **the divisor-sum characterises `J_k`.**  Any `f : ℕ → ℤ` satisfying
+  `∑_{d ∣ n} f(d) = n^k` for all `n > 0` agrees with `J_k` on the positives.  This is the
+  Möbius-inversion converse: the Gauss identity has a *unique* solution.
+* `jordan_one_apply` — `J_1 = φ` (`k = 1`), Euler's totient.
+* `sum_totient_eq_self` — Gauss's classical `∑_{d ∣ n} φ(d) = n` recovered as the `k = 1`
+  specialisation of `jordan_divisor_sum`.
+
+## Method
+
+Everything is convolution algebra in the commutative ring `ArithmeticFunction ℤ`:
+`coe_moebius_mul_coe_zeta` (`μ ∗ ζ = 1`), `coe_mul_zeta_apply` (`(f ∗ ζ) n = ∑_{d ∣ n} f d`),
+and `sum_eq_iff_sum_smul_moebius_eq` (Möbius inversion) for uniqueness.  No combinatorics,
+no analysis beyond none.
+
+No axioms, no native_decide.
+
+Tags: number-theory, totient-function, jordan-totient, gauss-identity, divisor-sums,
+dirichlet-convolution, moebius-inversion, arithmetic-function, erdos-1000
+-/
+
+open Finset ArithmeticFunction
+open scoped ArithmeticFunction.zeta
+
+namespace Erdos1000OQ03OQ03
+
+/-- **Jordan's totient** `J_k`, as the Dirichlet convolution `μ ∗ pow k` in the ring
+`ArithmeticFunction ℤ` (the definition of `erdos-1000-oq-03-oq-01-oq-01`). -/
+def jordan (k : ℕ) : ArithmeticFunction ℤ := moebius * (pow k : ArithmeticFunction ℤ)
+
+/-- **Reconstruction identity** `J_k ∗ ζ = pow k`.
+
+This is the Dirichlet-ring dual of the gallery's Möbius inversion `J_k = μ ∗ pow k`:
+convolving with `ζ` (summing over divisors) cancels the Möbius factor, because
+`μ ∗ ζ = 1` is the multiplicative identity of the convolution ring. -/
+theorem jordan_mul_zeta (k : ℕ) :
+    jordan k * (ζ : ArithmeticFunction ℤ) = (pow k : ArithmeticFunction ℤ) := by
+  rw [jordan, mul_right_comm, moebius_mul_coe_zeta, one_mul]
+
+/-- **Gauss's divisor-sum identity for Jordan's totient**: `∑_{d ∣ n} J_k(d) = n^k`.
+
+The pointwise reading of `jordan_mul_zeta`, since `(f ∗ ζ) n = ∑_{d ∣ n} f d`. -/
+theorem jordan_divisor_sum (k : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    ∑ d ∈ n.divisors, jordan k d = (n : ℤ) ^ k := by
+  have h : (jordan k * (ζ : ArithmeticFunction ℤ)) n = ∑ d ∈ n.divisors, jordan k d :=
+    coe_mul_zeta_apply
+  rw [jordan_mul_zeta] at h
+  rw [← h, natCoe_apply, pow_apply, if_neg (by simp [hn]), Nat.cast_pow]
+
+/-- **The Gauss identity characterises `J_k`.**
+
+If `f : ℕ → ℤ` satisfies `∑_{d ∣ n} f(d) = n^k` for every `n > 0`, then `f` agrees with
+Jordan's totient on the positive integers.  This is the Möbius-inversion converse of
+`jordan_divisor_sum`: the divisor-sum equation has a unique solution. -/
+theorem jordan_unique (k : ℕ) (f : ℕ → ℤ)
+    (hf : ∀ (n : ℕ), 0 < n → ∑ d ∈ n.divisors, f d = (n : ℤ) ^ k) :
+    ∀ (n : ℕ), 0 < n → f n = jordan k n := by
+  intro n hn
+  -- Möbius-invert the hypothesis: `f n = ∑_{x*y = n} μ(x)·y^k`.
+  have hinv := (sum_eq_iff_sum_smul_moebius_eq (f := f) (g := fun m => (m : ℤ) ^ k)).mp
+    (fun m hm => hf m hm) n hn
+  rw [← hinv, jordan, mul_apply]
+  refine Finset.sum_congr rfl fun x hx => ?_
+  obtain ⟨hprod, hn0⟩ := Nat.mem_divisorsAntidiagonal.mp hx
+  have hx2 : x.2 ≠ 0 := fun h => hn0 (by rw [← hprod, h, mul_zero])
+  rw [natCoe_apply, pow_apply, if_neg (by simp [hx2]), Nat.cast_pow, smul_eq_mul]
+
+/-- **Euler-totient recovery (`k = 1`).**  `J_1 = φ`, since `μ ∗ id = φ` is the Möbius
+inversion of Gauss's `∑_{d ∣ n} φ(d) = n`. -/
+theorem jordan_one_apply (n : ℕ) : jordan 1 n = (Nat.totient n : ℤ) := by
+  rcases eq_or_ne n 0 with rfl | hn
+  · simp [jordan]
+  -- `jordan 1` and `↑φ` both have divisor-sum `n`, so equal by uniqueness.
+  refine (jordan_unique 1 (fun m => (Nat.totient m : ℤ)) (fun m _ => ?_) n
+    (Nat.pos_of_ne_zero hn)).symm
+  rw [← Nat.cast_sum, Nat.sum_totient, pow_one]
+
+/-- **Gauss's classical totient identity**, `∑_{d ∣ n} φ(d) = n`, as the `k = 1`
+specialisation of `jordan_divisor_sum`. -/
+theorem sum_totient_eq_self {n : ℕ} (hn : n ≠ 0) :
+    ∑ d ∈ n.divisors, (Nat.totient d : ℤ) = (n : ℤ) := by
+  have h := jordan_divisor_sum 1 hn
+  rw [pow_one] at h
+  rw [← h]
+  exact Finset.sum_congr rfl fun d _ => (jordan_one_apply d).symm
+
+end Erdos1000OQ03OQ03

--- a/src/data/proofs/erdos-1000-oq-03-oq-03/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-03/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "erdos-1000-oq-03-oq-03",
+  "title": "Gauss's Divisor-Sum Identity for Jordan's Totient, via the Dirichlet Ring",
+  "slug": "erdos-1000-oq-03-oq-03",
+  "description": "The Gauss divisor-sum identity sum_{d|n} J_k(d) = n^k for Jordan's totient, proved at the level of the abstract arithmetic function J_k = mu * pow k inside Mathlib's Dirichlet convolution ring ArithmeticFunction Z. Where the sibling entries erdos-1000-oq-03-oq-01/-oq-02 prove this identity for the COMBINATORIAL count via an explicit fibrewise bijection on k-tuples, this entry gives the CONVOLUTION-ALGEBRA proof: the headline jordan_mul_zeta is the arithmetic-function identity J_k * zeta = pow k, the reconstruction dual of the gallery's Mobius-inversion result J_k = mu * pow k, obtained in one line because mu * zeta = 1 is the multiplicative identity of the convolution ring (coe_moebius_mul_coe_zeta). Reading it pointwise through coe_mul_zeta_apply gives jordan_divisor_sum: sum_{d|n} J_k(d) = n^k. The genuinely new theory-level result is jordan_unique: the Gauss divisor-sum CHARACTERISES J_k -- any f : N -> Z with sum_{d|n} f(d) = n^k for all n > 0 agrees with J_k on the positives, via Mobius inversion (sum_eq_iff_sum_smul_moebius_eq). The k=1 specialisations jordan_one_apply (J_1 = phi) and sum_totient_eq_self (Gauss's classical sum_{d|n} phi(d) = n) close the loop. Fully machine-verified: no axioms, no sorries, no native_decide.",
+  "overview": {
+    "historicalContext": "Camille Jordan's totient $J_k$ (1870) counts the $k$-tuples of residues mod $n$ that are setwise coprime to $n$; for $k=1$ it is Euler's $\\varphi$. Classically $J_k$ has two faces — the geometric tuple count and the analytic Dirichlet convolution $J_k = \\mu * \\mathrm{id}^k$ — bridged by the divisor-sum identity $\\sum_{d\\mid n} J_k(d) = n^k$, the exact generalisation of Gauss's $\\sum_{d\\mid n}\\varphi(d)=n$. The gallery's sibling entries build this identity from the combinatorial side; the present entry proves it on the analytic side, entirely as convolution algebra in the Dirichlet ring, where Möbius inversion ($\\mu * \\zeta = 1$) makes both the identity and its converse (uniqueness) transparent.",
+    "problemStatement": "Working with Jordan's totient as the arithmetic function $J_k := \\mu * \\mathrm{pow}\\,k$ in $\\mathrm{ArithmeticFunction}\\ \\mathbb{Z}$ (the definition of the sibling erdos-1000-oq-03-oq-01-oq-01), prove: (1) the arithmetic-function identity $J_k * \\zeta = \\mathrm{pow}\\,k$; (2) its pointwise form, Gauss's divisor-sum identity $\\sum_{d\\mid n} J_k(d) = n^k$ for $n\\neq 0$; (3) the uniqueness characterisation that the divisor-sum equation $\\sum_{d\\mid n} f(d) = n^k$ determines $J_k$ on the positives; and (4) the $k=1$ recovery of Euler's $\\varphi$ and Gauss's $\\sum_{d\\mid n}\\varphi(d)=n$ — all without axioms.",
+    "proofStrategy": "The whole development is one-line convolution algebra plus Möbius inversion. `jordan_mul_zeta` computes $J_k * \\zeta = (\\mu * \\mathrm{pow}\\,k) * \\zeta = \\mathrm{pow}\\,k * (\\mu * \\zeta) = \\mathrm{pow}\\,k$ using commutativity (`mul_right_comm`) and the ring identity $\\mu * \\zeta = 1$ (`moebius_mul_coe_zeta`). `jordan_divisor_sum` then reads this pointwise: $(J_k * \\zeta)\\,n = \\sum_{d\\mid n} J_k(d)$ by `coe_mul_zeta_apply`, and $(\\mathrm{pow}\\,k)\\,n = n^k$ for $n\\neq 0$ by `pow_apply`. `jordan_unique` invokes Mathlib's Möbius-inversion equivalence `sum_eq_iff_sum_smul_moebius_eq`: a divisor-sum hypothesis $\\sum_{d\\mid n} f(d) = n^k$ inverts to $f(n) = \\sum_{xy=n}\\mu(x)\\,y^k$, which is exactly $(\\mu * \\mathrm{pow}\\,k)\\,n = J_k(n)$ by `mul_apply`. Finally `jordan_one_apply` deduces $J_1=\\varphi$ from uniqueness (both have divisor-sum $n$, using `Nat.sum_totient`), and `sum_totient_eq_self` specialises `jordan_divisor_sum` to $k=1$.",
+    "keyInsights": [
+      "**Reconstruction is the dual of inversion.** The gallery's siblings prove the *Möbius-inversion* direction $J_k = \\mu * \\mathrm{pow}\\,k$; this entry proves the *reconstruction* direction $\\mathrm{pow}\\,k = J_k * \\zeta$. In the Dirichlet ring the two are literally inverse statements, because convolving by $\\zeta$ (summation over divisors) is the two-sided inverse of convolving by $\\mu$ ($\\mu * \\zeta = 1$).",
+      "**The divisor-sum identity is a one-line ring computation.** Once $J_k$ is the ring element $\\mu * \\mathrm{pow}\\,k$, the Gauss identity $\\sum_{d\\mid n}J_k(d)=n^k$ needs no combinatorics: it is $J_k * \\zeta = \\mathrm{pow}\\,k$ read off pointwise. This is the analytic mirror of the sibling entries' fibrewise-bijection proof of the same identity for the combinatorial count.",
+      "**The Gauss identity determines $J_k$.** `jordan_unique` is the genuinely new content: the divisor-sum equation $\\sum_{d\\mid n} f(d) = n^k$ has a *unique* solution on the positive integers, so any function with that divisor-sum — however defined — must be Jordan's totient. This uniqueness (Möbius inversion run backwards) is what lets $k=1$ pin down $\\varphi$ from Gauss's law alone.",
+      "**$k=1$ collapses the whole apparatus to Euler and Gauss.** Specialising, $J_1 = \\varphi$ (`jordan_one_apply`) and $\\sum_{d\\mid n}\\varphi(d) = n$ (`sum_totient_eq_self`) fall out — the classical Gauss totient identity recovered as one instance of the arithmetic-function reconstruction identity."
+    ]
+  },
+  "sections": [
+    {
+      "title": "Header and open question",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Frames the goal and locates it in the gallery: prove the Gauss divisor-sum identity $\\sum_{d\\mid n}J_k(d)=n^k$ for the abstract arithmetic function $J_k=\\mu*\\mathrm{pow}\\,k$, working inside Mathlib's Dirichlet convolution ring, and add the uniqueness characterisation absent from the combinatorial siblings."
+    },
+    {
+      "title": "Definition of Jordan's totient",
+      "startLine": 65,
+      "endLine": 71,
+      "summary": "`jordan k := moebius * (pow k : ArithmeticFunction Z)` — Jordan's totient as a Dirichlet convolution in the ring $\\mathrm{ArithmeticFunction}\\ \\mathbb{Z}$, the same object studied by the sibling erdos-1000-oq-03-oq-01-oq-01."
+    },
+    {
+      "title": "Reconstruction identity J_k * zeta = pow k",
+      "startLine": 72,
+      "endLine": 78,
+      "summary": "`jordan_mul_zeta`: the arithmetic-function identity $J_k*\\zeta=\\mathrm{pow}\\,k$, proved in one `rw` via `mul_right_comm` and $\\mu*\\zeta=1$ (`moebius_mul_coe_zeta`). This is the reconstruction dual of the gallery's Möbius inversion $J_k=\\mu*\\mathrm{pow}\\,k$."
+    },
+    {
+      "title": "Headline: Gauss's divisor-sum identity",
+      "startLine": 79,
+      "endLine": 89,
+      "summary": "`jordan_divisor_sum`: $\\sum_{d\\mid n}J_k(d)=n^k$ for $n\\neq 0$, the pointwise reading of `jordan_mul_zeta` through `coe_mul_zeta_apply` and `pow_apply`."
+    },
+    {
+      "title": "Uniqueness: the divisor-sum characterises J_k",
+      "startLine": 91,
+      "endLine": 104,
+      "summary": "`jordan_unique`: any $f:\\mathbb{N}\\to\\mathbb{Z}$ with $\\sum_{d\\mid n}f(d)=n^k$ for all $n>0$ equals $J_k$ on the positives. Möbius-inverts the hypothesis with `sum_eq_iff_sum_smul_moebius_eq` and matches the result to $(\\mu*\\mathrm{pow}\\,k)\\,n$ termwise via `mul_apply`."
+    },
+    {
+      "title": "Euler recovery and Gauss's classical identity (k = 1)",
+      "startLine": 106,
+      "endLine": 123,
+      "summary": "`jordan_one_apply` ($J_1=\\varphi$, from uniqueness plus `Nat.sum_totient`) and `sum_totient_eq_self` (Gauss's $\\sum_{d\\mid n}\\varphi(d)=n$, the $k=1$ case of the headline)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Jordan's totient, taken as the arithmetic function $J_k=\\mu*\\mathrm{pow}\\,k$ in the Dirichlet ring $\\mathrm{ArithmeticFunction}\\ \\mathbb{Z}$, is machine-verified to satisfy the reconstruction identity $J_k*\\zeta=\\mathrm{pow}\\,k$, hence Gauss's divisor-sum identity $\\sum_{d\\mid n}J_k(d)=n^k$; and this divisor-sum is shown to *determine* $J_k$ uniquely on the positives. The $k=1$ case recovers $J_1=\\varphi$ and Gauss's $\\sum_{d\\mid n}\\varphi(d)=n$. No axioms, no sorries.",
+    "implications": "This supplies the analytic counterpart to the gallery's combinatorial Jordan-totient entries: the same Gauss identity $\\sum_{d\\mid n}J_k(d)=n^k$ they prove by a fibrewise tuple bijection is here a one-line convolution-ring computation, and the reconstruction identity $J_k*\\zeta=\\mathrm{pow}\\,k$ is stated at the level of arithmetic functions (which those entries do not). The uniqueness theorem `jordan_unique` is new to the gallery and explains why the divisor-sum law alone characterises Jordan's totient — the mechanism behind every $k=1$ recovery of Euler's $\\varphi$.",
+    "openQuestions": [
+      "The uniqueness `jordan_unique` shows the divisor-sum $\\sum_{d\\mid n}f(d)=g(n)$ determines $f$ for $g(n)=n^k$. For which multiplicative targets $g$ is the Möbius-inverse $f=g*\\mu$ again a genuine (non-negative, multiplicative) totient, and can one characterise the $g$ whose inverse counts a natural family of objects mod $n$?",
+      "Can the reconstruction identity $J_k*\\zeta=\\mathrm{pow}\\,k$ be upgraded to the Dirichlet-series statement $\\sum_n J_k(n) n^{-s} = \\zeta(s-k)/\\zeta(s)$ within Mathlib's L-series / `ArithmeticFunction` bridge, giving the analytic generating identity behind the divisor-sum law?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "erdos-1000-oq-03-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "That entry defines J_k = mu * pow k as an arithmetic function and proves its multiplicativity, prime-power values, and Euler product. This entry proves the complementary reconstruction identity J_k * zeta = pow k (hence sum_{d|n} J_k(d) = n^k) for that same object, and adds the uniqueness characterisation."
+    },
+    {
+      "proofId": "erdos-1000-oq-03-oq-02",
+      "relationship": "related",
+      "description": "The sibling proves the SAME divisor-sum identity sum_{d|n} J_k(d) = n^k for the combinatorial tuple count via an explicit fibrewise bijection. This entry gives the convolution-algebra proof for the abstract arithmetic function instead, plus the uniqueness converse."
+    },
+    {
+      "proofId": "erdos-1000-oq-03-oq-01",
+      "relationship": "related",
+      "description": "The sibling establishes the combinatorial characterisation of J_k and Mobius-inverts it to J_k = mu * pow k (the inversion direction). This entry proves the reconstruction direction pow k = J_k * zeta, the Dirichlet-ring dual."
+    },
+    {
+      "proofId": "erdos-1000-oq-03",
+      "relationship": "extends",
+      "description": "The parent develops generalized totients via restricted Gauss sums. This entry supplies the arithmetic-function reconstruction identity and uniqueness for Jordan's totient specifically."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "ArithmeticFunction",
+      "ArithmeticFunction.zeta"
+    ],
+    "namespace": "Erdos1000OQ03OQ03",
+    "lineCount": 123,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1000OQ03OQ03.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1000OQ03OQ03.lean",
+    "tags": [
+      "number-theory",
+      "jordan-totient",
+      "euler-totient",
+      "gauss-identity",
+      "divisor-sum",
+      "dirichlet-convolution",
+      "moebius-inversion",
+      "arithmetic-function"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 123,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "assumptions": ""
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry `erdos-1000-oq-03-oq-03` proving **Gauss's divisor-sum identity for Jordan's totient**, `∑_{d|n} J_k(d) = n^k`, at the level of the **abstract arithmetic function** `J_k = μ * pow k` inside Mathlib's Dirichlet convolution ring `ArithmeticFunction ℤ`.

### Why this is not redundant with the siblings

The sibling entries `-oq-03-oq-01` / `-oq-03-oq-02` prove this same identity for the **combinatorial count** (setwise-coprime `k`-tuples) via an explicit fibrewise bijection. This entry gives the complementary **convolution-algebra proof** for the abstract function, plus a **uniqueness characterisation** that is new to the gallery:

- `jordan_mul_zeta` — the arithmetic-function identity `J_k * ζ = pow k`, the *reconstruction* dual of the gallery's *Möbius-inversion* result `J_k = μ * pow k` (one line, since `μ * ζ = 1` in the Dirichlet ring).
- `jordan_divisor_sum` — `∑_{d|n} J_k(d) = n^k` (`n ≠ 0`), read off pointwise via `coe_mul_zeta_apply`.
- `jordan_unique` — **the Gauss divisor-sum determines `J_k`**: any `f : ℕ → ℤ` with `∑_{d|n} f(d) = n^k` for all `n > 0` agrees with `J_k` on the positives (Möbius inversion via `sum_eq_iff_sum_smul_moebius_eq`). This is the genuinely new theory-level content.
- `jordan_one_apply` / `sum_totient_eq_self` — `k=1` recovers `J_1 = φ` and Gauss's classical `∑_{d|n} φ(d) = n`.

### Verification

- **0 axioms** (`#print axioms` → `propext, Classical.choice, Quot.sound` only; no `sorryAx`, no `Lean.ofReduceBool`).
- **0 sorries**, **0 native_decide**.
- 123 lines, 5 theorems + 1 def. Typechecks against Mathlib (`lake env lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)