### PR TITLE
research(composition-parts-choose-oq-01-oq-03): third moment + vanishing skewness of composition part-count [VERIFIED, 0-axiom, +5thm]

### DIFF
--- a/src/data/research/problems/composition-parts-choose-oq-01-oq-03.json
+++ b/src/data/research/problems/composition-parts-choose-oq-01-oq-03.json
@@ -1,0 +1,122 @@
+{
+  "slug": "composition-parts-choose-oq-01-oq-03",
+  "title": "Does the same cut-set / double-erase technique extend to other graded refinem...",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "8·∑_c (c.length)³ + 2^n = (n³+6n²+3n)·2^(n−1); ∑_c (c.length − (n+1)/2)³ = 0",
+    "plain": "Does the same cut-set / double-erase technique extend to other graded refinements of Mathlib's ungraded composition cardinalities?",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-01T10:38:56-07:00",
+    "iteration": 1,
+    "focus": "Solved in one session — third moment + vanishing skewness, VERIFIED 0-axiom.",
+    "blockers": [],
+    "nextAction": "None — verified 0-axiom, 0-sorry.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE — third moment + vanishing skewness formalized, VERIFIED 0-axiom, 0-sorry, 5 theorems.",
+    "builtItems": [
+      "sum_choose_mul_cube — 8·∑_k C(m,k)·k³ = m²·(m+3)·2^m (CompositionPartsChooseOQ01OQ03.lean)",
+      "sum_finset_card_cube — 8·∑_{s⊆Fin m} |s|³ = m²·(m+3)·2^m",
+      "third_moment — 8·∑_c (c.length)³ + 2^n = (n³+6n²+3n)·2^(n−1) for n ≥ 1",
+      "parts_distribution_symmetric — ∑_c g(c.length) = ∑_c g(n+1−c.length) for any weight g",
+      "third_central_moment_zero — ∑_c (c.length − (n+1)/2)³ = 0 (skewness vanishes)"
+    ],
+    "insights": [
+      "Third central moment of the part-count is exactly 0 for every n — distribution symmetric about mean (n+1)/2, so all odd central moments vanish; only variance (n−1)/4 grows.",
+      "The symmetry is the cut-set complement involution s ↦ sᶜ: |sᶜ|=(n−1)−|s|, pairing a composition with |s|+1 parts against one with n−|s|=(n+1)−(|s|+1) parts — graded form of C(n−1,k−1)=C(n−1,n−k).",
+      "Cubic weighted sum 8·∑ k³C = m²(m+3)2^m extends ladder ∑ kC = m2^(m−1), 4∑ k²C = m(m+1)2^m via one more absorption step; ℕ-clearing factor grows 1,4,8."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks weighted binomial sums ∑ k^j C(m,k) for j ≥ 1 (only ∑ C(m,k)=2^m present).",
+      "No Mathlib statement on the part-count distribution of a random composition or its symmetry/moments."
+    ],
+    "nextSteps": [
+      "Fourth central moment / kurtosis via ∑ k⁴·C(m,k).",
+      "Generating function ∑_c x^(c.length) = x(1+x)^(n−1) unifying all moments."
+    ],
+    "markdown": "# Knowledge Base: composition-parts-choose-oq-01-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "compositions",
+    "binomial-coefficients",
+    "moments",
+    "skewness",
+    "symmetry",
+    "involution"
+  ],
+  "relatedProofs": [
+    "composition-parts-choose-oq-01",
+    "composition-parts-choose-oq-01-oq-01",
+    "composition-parts-choose-oq-01-oq-01-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-01T18:30:22.750Z",
+  "lastUpdate": "2026-07-01T19:00:00.000Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/CompositionPartsChooseOQ01.lean",
+      "filename": "CompositionPartsChooseOQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CompositionPartsChooseOQ01.lean"
+    },
+    {
+      "path": "Proofs/CompositionPartsChooseOQ01OQ01.lean",
+      "filename": "CompositionPartsChooseOQ01OQ01.lean",
+      "lineCount": 208,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CompositionPartsChooseOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CompositionPartsChooseOQ01OQ01OQ01.lean",
+      "filename": "CompositionPartsChooseOQ01OQ01OQ01.lean",
+      "lineCount": 214,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CompositionPartsChooseOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CompositionPartsChooseOQ01OQ03.lean",
+      "filename": "CompositionPartsChooseOQ01OQ03.lean",
+      "lineCount": 228,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CompositionPartsChooseOQ01OQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Continues the **moment ladder** of the number-of-parts statistic of a composition — mean `(n+1)/2` (oq-01-oq-01), variance `(n−1)/4` (oq-01-oq-01-oq-01) — to the **third moment**, and extracts its structural payoff, using the family's cut-set / graded-refinement technique.

## Theorems (all VERIFIED, 0-axiom, 0-sorry, no native_decide)

| Theorem | Statement |
|---|---|
| `sum_choose_mul_cube` | `8·∑_k C(m,k)·k³ = m²·(m+3)·2^m` — the cubic weighted binomial sum, by **double absorption** |
| `sum_finset_card_cube` | `8·∑_{s⊆Fin m} \|s\|³ = m²·(m+3)·2^m` |
| `third_moment` | `8·∑_c (c.length)³ + 2^n = (n³+6n²+3n)·2^(n−1)`, `n ≥ 1` |
| `parts_distribution_symmetric` | `∑_c g(c.length) = ∑_c g(n+1−c.length)` for **any** weight `g` — the structural symmetry |
| `third_central_moment_zero` | `∑_c (c.length − (n+1)/2)³ = 0` — the **skewness vanishes** |

## Why it's interesting

Where the variance `(n−1)/4` grows with `n`, the third central moment is **exactly 0** for every `n`. This is not a coincidence of the moments: `parts_distribution_symmetric` shows the whole part-count distribution is invariant under `k ↦ n+1−k` — the **cut-set complement involution** `s ↦ sᶜ` on `Finset (Fin (n−1))`, with `|sᶜ| = (n−1)−|s|` — so *every odd central moment* vanishes at once. This is the graded promotion of the palindrome `C(n−1,k−1) = C(n−1,n−k)` to arbitrary weighted sums.

The cubic binomial identity `8·∑ k³·C(m,k) = m²(m+3)2^m` extends the family's ladder `∑ kC = m2^(m−1)`, `4∑ k²C = m(m+1)2^m` by one more application of the absorption rule; Mathlib has none of the weighted sums `∑ k^j C(m,k)` for `j ≥ 1`.

## Verification

- `#print axioms` on all five theorems lists only `propext / Classical.choice / Quot.sound`.
- Typechecks against the main Mathlib cache (`lake env lean`); reuses the family's `gapsEquiv`, `length_eq_card_gaps`, `sum_finset_card`, `sum_choose_mul_sq`.

New gallery entry: `src/data/proofs/composition-parts-choose-oq-01-oq-03/` (meta.json + annotations.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)