### PR TITLE
research(dirichlet-approximation-theorem-oq-05-oq-02): every quadratic surd √d is badly approximable [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DirichletApproximationOQ05OQ02.lean
+++ b/proofs/Proofs/DirichletApproximationOQ05OQ02.lean
@@ -1,0 +1,178 @@
+/-
+  Every Quadratic Surd √d is Badly Approximable: the Norm-Form Argument, Uniformly
+  (research problem: dirichlet-approximation-theorem-oq-05-oq-02)
+
+  The parent entry `dirichlet-approximation-theorem-oq-05` proves that the golden ratio
+  φ = (1+√5)/2 is *badly approximable*: there is a constant c > 0 with c/q² ≤ |φ − p/q|
+  for all integers p and q > 0.  Its proof is the elementary norm-form argument: φ and its
+  conjugate ψ are the roots of x² − x − 1, so q²(p/q − φ)(p/q − ψ) = p² − pq − q² is a
+  nonzero integer, hence ≥ 1 in absolute value, which forces |φ − p/q| ≥ 1/(4q²).
+
+  Its open follow-up asks whether the *same* norm-form argument extends to other quadratic
+  irrationals — √2, √3, √5, … — to yield explicit badly-approximable constants.  This entry
+  answers YES, and does so at full generality with a single structural theorem:
+
+  **Main result** (`badly_approximable_sqrt`).  Let `d : ℕ` and let `x : ℝ` be any
+  *positive irrational* square root of `d` (`x² = d`).  Then `x` is badly approximable with
+  the explicit constant `c = 1/(1 + 2x)`: for every integer `p` and every `q > 0`,
+
+        (1 / (1 + 2x)) / q²  ≤  |x − p/q|.
+
+  The conjugate of `x = √d` is simply `−x = −√d` (the two roots of `X² − d`), so the norm
+  form is `q²(p/q − x)(p/q + x) = p² − d·q² ∈ ℤ`.  It is nonzero because `x` is irrational,
+  hence `|p² − d·q²| ≥ 1`, giving `|x − p/q|·|x + p/q| ≥ 1/q²`.  When `|x − p/q| < 1` the
+  second factor is bounded by `|x − p/q| + 2x < 1 + 2x`, and the bound follows; when
+  `|x − p/q| ≥ 1` it is trivial.
+
+  Unlike the golden-ratio proof this needs *no* dedicated `Real.goldenRatio` API — only the
+  hypothesis `x² = d` and irrationality of `x`.  The irrationality input is completely
+  decoupled from the analytic core, so any source of irrational square roots specializes it.
+
+  **Specializations proved here.**
+
+  * `sqrtTwo_badly_approximable`   — √2 is badly approximable (`irrational_sqrt_two`).
+  * `sqrtThree_badly_approximable` — √3 (`Nat.Prime.irrational_sqrt` at p = 3).
+  * `sqrtFive_badly_approximable`  — √5 (`Nat.Prime.irrational_sqrt` at p = 5).
+
+  More generally the theorem applies to `√n` for *any* non-square `n : ℕ`, since
+  `irrational_sqrt_natCast_iff : Irrational (√n) ↔ ¬IsSquare n` supplies the irrationality
+  hypothesis (so e.g. the non-prime squarefree √6 is covered too).
+
+  Everything is proved sorry-free and axiom-free (no `native_decide`).
+-/
+import Mathlib
+
+open Real
+
+namespace DirichletApproximationOQ05OQ02
+
+section General
+
+variable {d : ℕ} {x : ℝ}
+
+/-- **Norm-form identity.**  For a square root `x` of `d` (`x² = d`), the conjugate is
+`−x`, and the product `(p/q − x)(p/q + x)` is the integer `p² − d·q²` divided by `q²`.
+This is the value of the `ℤ[x]`-norm form `N(p − qx) = p² − d·q²` at `p − qx`. -/
+theorem norm_form_identity (hx2 : x ^ 2 = (d : ℝ)) (p : ℤ) (q : ℕ) (hq : 0 < q) :
+    ((p : ℝ) / q - x) * ((p : ℝ) / q + x)
+      = ((p ^ 2 - (d : ℤ) * (q : ℤ) ^ 2 : ℤ) : ℝ) / (q : ℝ) ^ 2 := by
+  have hqR : (q : ℝ) ≠ 0 := by exact_mod_cast hq.ne'
+  have expand : ((p : ℝ) / q - x) * ((p : ℝ) / q + x) = ((p : ℝ) / q) ^ 2 - x ^ 2 := by
+    ring
+  rw [expand, hx2]
+  push_cast
+  field_simp
+
+/-- **Non-vanishing of the norm form.**  For `q > 0` the integer `p² − d·q²` is never zero,
+because otherwise `p/q` would equal one of the irrational roots `x`, `−x`. -/
+theorem norm_form_ne_zero (hx2 : x ^ 2 = (d : ℝ)) (hirr : Irrational x)
+    (p : ℤ) (q : ℕ) (hq : 0 < q) :
+    p ^ 2 - (d : ℤ) * (q : ℤ) ^ 2 ≠ 0 := by
+  intro h
+  have hqR : (q : ℝ) ≠ 0 := by exact_mod_cast hq.ne'
+  have hid := norm_form_identity hx2 p q hq
+  rw [h] at hid
+  rw [show (((0 : ℤ)) : ℝ) / (q : ℝ) ^ 2 = 0 by simp] at hid
+  rcases mul_eq_zero.mp hid with h1 | h1
+  · -- p/q − x = 0 ⇒ x = p/q, contradicting irrationality
+    have hval : x = ((p : ℤ) : ℝ) / ((q : ℤ) : ℝ) := by push_cast; linarith
+    exact hirr.ne_rational p (q : ℤ) hval
+  · -- p/q + x = 0 ⇒ x = (−p)/q, contradicting irrationality
+    have hval : x = ((-p : ℤ) : ℝ) / ((q : ℤ) : ℝ) := by
+      have hxeq : x = -((p : ℝ) / (q : ℝ)) := by linarith
+      rw [hxeq]; push_cast; ring
+    exact hirr.ne_rational (-p) (q : ℤ) hval
+
+/-- **Every quadratic surd is badly approximable.**  If `x > 0` is an irrational square
+root of a natural number `d` (`x² = d`), then no rational `p/q` approximates `x` faster
+than `1/q²` up to the explicit constant `c = 1/(1 + 2x)`:
+
+    `(1/(1 + 2x)) / q² ≤ |x − p/q|`  for all `p ∈ ℤ`, `q > 0`.
+
+This is the sharpness (Diophantine lower-bound) counterpart to Dirichlet's theorem for the
+entire family of real quadratic irrationals `√d`, proved by the same norm-form argument that
+handles the golden ratio in the parent entry. -/
+theorem badly_approximable_sqrt (hx2 : x ^ 2 = (d : ℝ)) (hxpos : 0 < x)
+    (hirr : Irrational x) :
+    ∃ c : ℝ, 0 < c ∧ ∀ (p : ℤ) (q : ℕ), 0 < q →
+      c / (q : ℝ) ^ 2 ≤ |x - (p : ℝ) / q| := by
+  have h1p2x : (0 : ℝ) < 1 + 2 * x := by linarith
+  refine ⟨1 / (1 + 2 * x), div_pos one_pos h1p2x, ?_⟩
+  intro p q hq
+  have hqR : (0 : ℝ) < (q : ℝ) := by exact_mod_cast hq
+  have hq2 : (0 : ℝ) < (q : ℝ) ^ 2 := by positivity
+  set A := |(p : ℝ) / q - x| with hA
+  set B := |(p : ℝ) / q + x| with hB
+  have hid := norm_form_identity hx2 p q hq
+  have hmne := norm_form_ne_zero hx2 hirr p q hq
+  have hpos : (0 : ℤ) < |p ^ 2 - (d : ℤ) * (q : ℤ) ^ 2| := abs_pos.mpr hmne
+  have hone : (1 : ℤ) ≤ |p ^ 2 - (d : ℤ) * (q : ℤ) ^ 2| := by omega
+  have hm1 : (1 : ℝ) ≤ |((p ^ 2 - (d : ℤ) * (q : ℤ) ^ 2 : ℤ) : ℝ)| := by
+    calc (1 : ℝ) = ((1 : ℤ) : ℝ) := by norm_num
+      _ ≤ ((|p ^ 2 - (d : ℤ) * (q : ℤ) ^ 2| : ℤ) : ℝ) := by exact_mod_cast hone
+      _ = |((p ^ 2 - (d : ℤ) * (q : ℤ) ^ 2 : ℤ) : ℝ)| := by rw [Int.cast_abs]
+  have hq2ne : (q : ℝ) ^ 2 ≠ 0 := ne_of_gt hq2
+  have hAB : A * B = |((p ^ 2 - (d : ℤ) * (q : ℤ) ^ 2 : ℤ) : ℝ)| / (q : ℝ) ^ 2 := by
+    rw [hA, hB, ← abs_mul, hid, abs_div, abs_of_pos hq2]
+  have hge1 : (1 : ℝ) ≤ A * B * (q : ℝ) ^ 2 := by
+    rw [hAB, div_mul_cancel₀ _ hq2ne]; exact hm1
+  have hgoalabs : |x - (p : ℝ) / q| = A := by rw [hA]; exact abs_sub_comm _ _
+  rw [hgoalabs]
+  have hAnn : 0 ≤ A := abs_nonneg _
+  have hBnn : 0 ≤ B := abs_nonneg _
+  have hq1R : (1 : ℝ) ≤ (q : ℝ) := by exact_mod_cast hq
+  rcases le_or_gt 1 A with hbig | hsmall
+  · -- |x − p/q| ≥ 1: the bound c/q² ≤ c ≤ 1 ≤ A is trivial
+    have hq1 : (1 : ℝ) ≤ (q : ℝ) ^ 2 := by nlinarith [hq1R]
+    have hcle1 : (1 / (1 + 2 * x)) ≤ 1 := by rw [div_le_one h1p2x]; linarith
+    have : (1 / (1 + 2 * x)) / (q : ℝ) ^ 2 ≤ 1 / (1 + 2 * x) :=
+      div_le_self (by positivity) hq1
+    linarith
+  · -- |x − p/q| < 1: then |x + p/q| < 1 + 2x, and A·B·q² ≥ 1 forces A ≥ c/q²
+    have htri : B ≤ A + 2 * x := by
+      rw [hA, hB]
+      calc |(p : ℝ) / q + x|
+          = |((p : ℝ) / q - x) + 2 * x| := by congr 1; ring
+        _ ≤ |(p : ℝ) / q - x| + |2 * x| := abs_add_le _ _
+        _ = |(p : ℝ) / q - x| + 2 * x := by
+            rw [abs_of_nonneg (by positivity : (0 : ℝ) ≤ 2 * x)]
+    have hBlt : B < 1 + 2 * x := by linarith
+    rw [div_le_iff₀ hq2, div_le_iff₀ h1p2x]
+    nlinarith [hge1, hBlt, hAnn, hBnn, hq2,
+      mul_nonneg (mul_nonneg hAnn (le_of_lt hq2)) (sub_nonneg.mpr (le_of_lt hBlt))]
+
+end General
+
+/-! ### Specializations to concrete quadratic surds
+
+Each just supplies the two hypotheses `x² = d` (via `Real.sq_sqrt`) and `Irrational x`. -/
+
+/-- **√2 is badly approximable.**  `c = 1/(1 + 2√2)` works. -/
+theorem sqrtTwo_badly_approximable :
+    ∃ c : ℝ, 0 < c ∧ ∀ (p : ℤ) (q : ℕ), 0 < q →
+      c / (q : ℝ) ^ 2 ≤ |Real.sqrt 2 - (p : ℝ) / q| := by
+  refine badly_approximable_sqrt (d := 2) (x := Real.sqrt 2) ?_ ?_ irrational_sqrt_two
+  · rw [Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]; norm_num
+  · exact Real.sqrt_pos.mpr (by norm_num)
+
+/-- **√3 is badly approximable.** -/
+theorem sqrtThree_badly_approximable :
+    ∃ c : ℝ, 0 < c ∧ ∀ (p : ℤ) (q : ℕ), 0 < q →
+      c / (q : ℝ) ^ 2 ≤ |Real.sqrt 3 - (p : ℝ) / q| := by
+  have hirr : Irrational (Real.sqrt 3) := by
+    simpa using Nat.Prime.irrational_sqrt (show Nat.Prime 3 by norm_num)
+  refine badly_approximable_sqrt (d := 3) (x := Real.sqrt 3) ?_ ?_ hirr
+  · rw [Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 3)]; norm_num
+  · exact Real.sqrt_pos.mpr (by norm_num)
+
+/-- **√5 is badly approximable.**  (The golden ratio lives in `ℚ(√5)`; here √5 itself.) -/
+theorem sqrtFive_badly_approximable :
+    ∃ c : ℝ, 0 < c ∧ ∀ (p : ℤ) (q : ℕ), 0 < q →
+      c / (q : ℝ) ^ 2 ≤ |Real.sqrt 5 - (p : ℝ) / q| := by
+  have hirr : Irrational (Real.sqrt 5) := by
+    simpa using Nat.Prime.irrational_sqrt (show Nat.Prime 5 by norm_num)
+  refine badly_approximable_sqrt (d := 5) (x := Real.sqrt 5) ?_ ?_ hirr
+  · rw [Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 5)]; norm_num
+  · exact Real.sqrt_pos.mpr (by norm_num)
+
+end DirichletApproximationOQ05OQ02

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-05-oq-02/annotations.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": "ann-header-uniform-surds",
+    "proofId": "dirichlet-approximation-theorem-oq-05-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 48
+    },
+    "type": "context",
+    "title": "From One Surd to All: the Norm-Form Argument, Decoupled from φ",
+    "content": "The header answers the explicit open question left by the parent oq-05 (φ is badly approximable): does the same elementary norm-form argument extend to other quadratic irrationals? The insight is that φ used the golden-ratio Vieta relations only incidentally — for a bare square root x = √d the Galois conjugate is simply −x (the two roots of X² − d), so the norm form q²(p/q − x)(p/q + x) = p² − d·q² has no middle term and no need for any goldenRatio API. The whole analytic core is developed over an ABSTRACT positive irrational x with x² = d, so the concrete surds √2, √3, √5 (and any √n with n non-square) are one-line specializations differing only in which Mathlib irrationality lemma is cited.",
+    "mathContext": "Parent (φ): norm form $p^2 - pq - q^2$ from $\\varphi+\\psi=1,\\varphi\\psi=-1$. Here (√d): norm form $p^2 - d\\,q^2$ from conjugate $-x$, $x^2=d$.",
+    "significance": "context",
+    "relatedConcepts": ["badly approximable numbers", "quadratic irrationals", "norm form", "Galois conjugate", "Diophantine approximation"],
+    "prerequisites": ["Dirichlet approximation oq-05 (golden ratio case)", "roots of X² − d are ±√d", "Mathlib irrationality lemmas for √n"]
+  },
+  {
+    "id": "ann-norm-form-identity",
+    "proofId": "dirichlet-approximation-theorem-oq-05-oq-02",
+    "range": {
+      "startLine": 56,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "The Norm-Form Identity: (p/q − x)(p/q + x) = (p² − d·q²)/q²",
+    "content": "The engine of the whole proof, in its simplest form. Because the two roots of X² − d are x and −x, the product (p/q − x)(p/q + x) = (p/q)² − x² = (p/q)² − d, and clearing the denominator gives (p² − d·q²)/q². The numerator p² − d·q² is the norm of the algebraic integer p − q√d in ℤ[√d] (equivalently the left side of the Pell equation). The Lean proof expands with `ring`, substitutes the single hypothesis x² = d, and finishes with `field_simp` — no Vieta relations, no dedicated API.",
+    "mathContext": "$\\left(\\tfrac pq - x\\right)\\left(\\tfrac pq + x\\right) = \\left(\\tfrac pq\\right)^2 - x^2 = \\left(\\tfrac pq\\right)^2 - d = \\dfrac{p^2 - d\\,q^2}{q^2}.$",
+    "prerequisites": [
+      "The two roots of X² − d are x and −x",
+      "The single equation x² = d"
+    ],
+    "relatedConcepts": [
+      "norm form",
+      "ring of integers ℤ[√d]",
+      "Pell equation"
+    ],
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-non-vanishing",
+    "proofId": "dirichlet-approximation-theorem-oq-05-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "Non-Vanishing of the Norm: p² − d·q² ≠ 0",
+    "content": "The norm form never vanishes for q > 0. If p² − d·q² were 0, the identity would force (p/q − x)(p/q + x) = 0, so p/q = x or p/q = −x; either way x = ±p/q would be rational. `Irrational.ne_rational` — an irrational is never a/b for integers a, b — closes both cases (the second by writing x = (−p)/q). This is the sole point where irrationality enters, and it is exactly what makes the integer norm nonzero, hence of absolute value at least 1.",
+    "mathContext": "If $p^2 - d\\,q^2 = 0$ then $p/q \\in \\{x, -x\\}$, contradicting $x \\notin \\mathbb{Q}$.",
+    "prerequisites": [
+      "Irrationality of x = √d",
+      "A nonzero integer has absolute value ≥ 1"
+    ],
+    "relatedConcepts": [
+      "irrationality",
+      "Irrational.ne_rational"
+    ],
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-badly-approximable-general",
+    "proofId": "dirichlet-approximation-theorem-oq-05-oq-02",
+    "range": {
+      "startLine": 94,
+      "endLine": 143
+    },
+    "type": "theorem",
+    "title": "Every √d is Badly Approximable: c/q² ≤ |x − p/q| with c = 1/(1+2x)",
+    "content": "The headline uniform result. From non-vanishing, |p² − d·q²| ≥ 1, so with A = |p/q − x| and B = |p/q + x| one has A·B·q² = |p² − d·q²| ≥ 1. Take c = 1/(1+2x), positive because x > 0. A case split on A finishes: if A ≥ 1 then c/q² ≤ c ≤ 1 ≤ A; if A < 1 the triangle inequality bounds the conjugate factor B = |(p/q − x) + 2x| ≤ A + 2x < 1 + 2x, and `nlinarith` combines this with A·B·q² ≥ 1 and A·q² ≥ 0 to derive 1 ≤ A·q²·(1+2x), i.e. c/q² ≤ A. The constant is explicit but not optimal (the sharp value is 1/(2√d)); badly-approximability only requires some positive c.",
+    "mathContext": "$\\dfrac{1/(1+2x)}{q^2} \\le \\left| x - \\dfrac pq \\right| \\quad \\text{for all } p \\in \\mathbb{Z},\\ q > 0,\\ x^2=d,\\ x>0,\\ x\\notin\\mathbb{Q}.$",
+    "prerequisites": [
+      "The triangle inequality for absolute value",
+      "The product bound A·B·q² ≥ 1 from non-vanishing",
+      "nonlinear arithmetic (nlinarith)"
+    ],
+    "relatedConcepts": [
+      "badly approximable numbers",
+      "irrationality measure",
+      "Lagrange spectrum",
+      "Hurwitz's theorem"
+    ],
+    "significance": "key"
+  },
+  {
+    "id": "ann-specializations",
+    "proofId": "dirichlet-approximation-theorem-oq-05-oq-02",
+    "range": {
+      "startLine": 146,
+      "endLine": 178
+    },
+    "type": "theorem",
+    "title": "Specializations: √2, √3, √5 are Badly Approximable",
+    "content": "Three one-line instantiations of the general theorem, each supplying only its two hypotheses. The equation x² = d comes from `Real.sq_sqrt` (valid since d ≥ 0); irrationality comes from `irrational_sqrt_two` for √2 and `Nat.Prime.irrational_sqrt` at p = 3 and p = 5 for √3 and √5. The docstring records that `irrational_sqrt_natCast_iff` (√n irrational ↔ n not a perfect square) supplies the hypothesis for every non-square n, so non-prime squarefree surds such as √6 fall under the same theorem — the argument is genuinely uniform across all real quadratic surds.",
+    "mathContext": "$\\sqrt2,\\sqrt3,\\sqrt5$ each badly approximable with $c = 1/(1+2\\sqrt d)$; generally $\\sqrt n$ for any non-square $n$.",
+    "prerequisites": [
+      "Real.sq_sqrt for x² = d",
+      "irrational_sqrt_two, Nat.Prime.irrational_sqrt, irrational_sqrt_natCast_iff"
+    ],
+    "relatedConcepts": [
+      "quadratic surds",
+      "perfect squares",
+      "prime square roots"
+    ],
+    "significance": "supporting"
+  }
+]

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-05-oq-02/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-05-oq-02/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "dirichlet-approximation-theorem-oq-05-oq-02",
+  "title": "Every Quadratic Surd √d is Badly Approximable: the Norm-Form Argument, Uniformly",
+  "slug": "dirichlet-approximation-theorem-oq-05-oq-02",
+  "description": "Answers the open follow-up of oq-05 (the golden ratio is badly approximable): does the same elementary norm-form argument extend to other quadratic irrationals? Yes, and uniformly. The single structural theorem badly_approximable_sqrt shows that any positive irrational x with x² = d (d a natural number) is badly approximable with the EXPLICIT constant c = 1/(1 + 2x): for all p ∈ ℤ and q > 0, (1/(1+2x))/q² ≤ |x − p/q|. The conjugate of x = √d is just −√d (the two roots of X² − d), so the norm form is q²(p/q − x)(p/q + x) = p² − d·q² ∈ ℤ, nonzero because x is irrational, hence ≥ 1 in absolute value; the resulting product bound |x − p/q|·|x + p/q| ≥ 1/q² plus a short case analysis (bounding the conjugate factor by |x − p/q| + 2x < 1 + 2x) yields the lower bound. Unlike the parent this needs no dedicated goldenRatio API — the irrationality input is fully decoupled from the analytic core, so it specializes immediately to √2 (irrational_sqrt_two), √3 and √5 (Nat.Prime.irrational_sqrt), and via irrational_sqrt_natCast_iff to √n for every non-square n (e.g. the non-prime √6). Zero axioms, zero sorries, no native_decide.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "DirichletApproximationOQ05OQ02",
+    "lineCount": 178,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/DirichletApproximationOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Badly_approximable_number",
+    "date": "1842",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DirichletApproximationOQ05OQ02.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-approximation",
+      "badly-approximable",
+      "quadratic-irrational",
+      "norm-form",
+      "square-root",
+      "irrationality-measure",
+      "continued-fractions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "dirichlet-approximation-theorem-oq-05",
+        "relationship": "Parent entry: proves the golden ratio φ = (1+√5)/2 is badly approximable with c = 1/4 via the ℤ[φ]-norm form p² − pq − q². This entry answers its explicit open question — whether the same norm-form argument extends to other quadratic irrationals — with a single uniform theorem covering every √d, using the simpler conjugate pair (√d, −√d) and norm form p² − d·q²."
+      },
+      {
+        "id": "dirichlet-approximation-theorem",
+        "relationship": "Grandparent entry: Dirichlet's existence theorem (good approximations |α − p/q| < 1/q² exist). This entry contributes lower bounds (badly-approximability) for the whole family of real quadratic surds √d, the sharpness dual showing the exponent 2 cannot be improved for any of them."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 178,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational propext / Classical.choice / Quot.sound are used (no Lean.ofReduceBool, no native_decide; verified with #print axioms badly_approximable_sqrt, sqrtTwo_badly_approximable, sqrtThree_badly_approximable, sqrtFive_badly_approximable). The result is unconditional: for any positive irrational x with x² = d (d : ℕ), ∃ c > 0 (explicitly c = 1/(1+2x)) with c/q² ≤ |x − p/q| for all p ∈ ℤ, q > 0. The constant 1/(1+2x) is explicit but not optimal (the sharp Hurwitz-type constant for √d is 1/(2√d)); badly-approximability only requires SOME positive c, which the norm-form argument delivers without continued fractions. Mathlib supplies only the irrationality inputs (irrational_sqrt_two, Nat.Prime.irrational_sqrt, irrational_sqrt_natCast_iff) and Irrational.ne_rational; the analytic core — the norm-form identity, its non-vanishing, and the case-analysis lower bound — is entirely in-file and abstract over x.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "A real number α is badly approximable if |α − p/q| ≥ c/q² for some c > 0 and all rationals p/q — equivalently, if its continued-fraction partial quotients are bounded. The classical theorem (Lagrange, refined by Hurwitz 1891) is that the badly approximable numbers are exactly the reals with eventually periodic-or-bounded continued fractions, and the quadratic irrationals √d are the cleanest examples: their continued fractions are periodic. The parent oq-05 proved the prototype case, the golden ratio φ ∈ ℚ(√5), by an elementary norm-form argument. That argument is not special to φ: for any quadratic surd √d the Galois conjugate is −√d, the norm N(p − q√d) = p² − d·q² is an integer that is nonzero exactly when √d is irrational, and the whole lower bound falls out. This entry isolates that observation as a single theorem over an abstract irrational square root, recovering √2, √3, √5, … as one-line specializations.",
+    "problemStatement": "Show that every real quadratic surd is badly approximable by the norm-form argument: if $x > 0$ is irrational with $x^2 = d$ for some $d \\in \\mathbb{N}$, then there exists $c > 0$ (explicitly $c = 1/(1+2x)$) such that for every integer $p$ and every natural number $q > 0$,\n\n$$\\frac{c}{q^2} \\le \\left| x - \\frac{p}{q} \\right|.$$\n\nSpecialize to $\\sqrt2, \\sqrt3, \\sqrt5$.",
+    "text": "The parent entry's proof leans on Mathlib's Real.goldenRatio API (Vieta relations φ+ψ=1, φψ=−1, φ−ψ=√5). This entry removes that dependency entirely: the only facts used are x² = d and that x is irrational. The conjugate is the syntactically trivial −x, the norm form is p² − d·q² (no linear middle term), and the whole development is a section abstract over x, so instantiating it at any concrete irrational square root is immediate.",
+    "proofStrategy": "norm_form_identity: since the two roots of X² − d are x and −x, the product (p/q − x)(p/q + x) = (p/q)² − x² = (p/q)² − d = (p² − d·q²)/q², proved by expanding and substituting x² = d then clearing denominators. norm_form_ne_zero: if p² − d·q² = 0 the identity forces (p/q − x)(p/q + x) = 0, so p/q = x or p/q = −x; both make x = ±p/q rational, contradicting Irrational.ne_rational. Hence |p² − d·q²| ≥ 1. badly_approximable_sqrt: set A = |p/q − x|, B = |p/q + x|; then A·B·q² = |p² − d·q²| ≥ 1. Choose c = 1/(1+2x) (positive since x > 0). Split on A: if A ≥ 1 then c/q² ≤ c ≤ 1 ≤ A; if A < 1 then the triangle inequality gives B = |(p/q − x) + 2x| ≤ A + 2x < 1 + 2x, and nlinarith combines A·B·q² ≥ 1 with B < 1 + 2x and A·q² ≥ 0 to conclude 1 ≤ A·q²·(1+2x), i.e. c/q² ≤ A. The three specializations supply x² = d via Real.sq_sqrt and irrationality via the respective Mathlib lemmas.",
+    "keyInsights": [
+      "**The conjugate of √d is just −√d**: the parent's norm form needed the golden-ratio Vieta relations, but for a bare square root the two roots of X² − d are x and −x, so the norm form q²(p/q − x)(p/q + x) = p² − d·q² has no middle term and no special API — the argument is *simpler* than the golden-ratio case, not harder",
+      "**Irrationality is the only nonelementary input, and it is fully decoupled**: the analytic core (identity + non-vanishing + case analysis) is stated over an abstract irrational x with x² = d, so every concrete surd √2, √3, √5, √6, … is a one-line instantiation differing only in which Mathlib irrationality lemma is cited",
+      "**A nonzero integer is ≥ 1**: exactly as in the parent, the entire lower bound reduces to the triviality that |p² − d·q²| ≥ 1 once it is known to be nonzero — badly-approximability of quadratic surds is, at bottom, this integrality fact plus a triangle inequality",
+      "**Explicit but non-optimal constant**: c = 1/(1+2x) is fully explicit (e.g. 1/(1+2√2) for √2) and requires no continued fractions; the sharp constant 1/(2√d) needs the periodic CF convergents, but badly-approximability only asks for some positive c"
+    ],
+    "prerequisites": [
+      "The identity that √d and −√d are the two roots of X² − d, giving the norm form p² − d·q² = q²(p/q − √d)(p/q + √d)",
+      "Irrational.ne_rational: an irrational number is never a/b for integers a, b — the source of the norm form's non-vanishing",
+      "Mathlib irrationality lemmas for square roots: irrational_sqrt_two, Nat.Prime.irrational_sqrt (for √3, √5), and irrational_sqrt_natCast_iff (√n irrational ↔ n not a perfect square) for the general non-square case",
+      "Elementary inequalities: the triangle inequality for absolute value and that a nonzero integer has absolute value at least 1"
+    ]
+  },
+  "sections": [
+    {
+      "id": "norm-form-identity",
+      "title": "The Norm-Form Identity p² − d·q² over ℤ[√d]",
+      "startLine": 1,
+      "endLine": 66,
+      "mathContext": "$q^2\\left(\\tfrac pq - x\\right)\\left(\\tfrac pq + x\\right) = p^2 - d\\,q^2 \\in \\mathbb{Z}$, where $x^2 = d$ so the roots of $X^2 - d$ are $x$ and $-x$.",
+      "summary": "After a docstring contrasting the golden-ratio parent with the uniform statement proved here, norm_form_identity establishes the core algebraic fact for an abstract square root x of d: because the conjugate of x is −x, the product (p/q − x)(p/q + x) collapses to (p/q)² − x² = (p/q)² − d, which equals (p² − d·q²)/q². The proof expands the product with ring, substitutes the hypothesis x² = d, and clears denominators with field_simp. No golden-ratio-specific API is used — only the single equation x² = d."
+    },
+    {
+      "id": "non-vanishing",
+      "title": "Non-Vanishing of the Norm Form via Irrationality",
+      "startLine": 68,
+      "endLine": 92,
+      "mathContext": "$p^2 - d\\,q^2 \\ne 0$ for $q > 0$, since otherwise $p/q \\in \\{x, -x\\}$ would be rational.",
+      "summary": "norm_form_ne_zero shows the integer p² − d·q² never vanishes for q > 0. If it were zero, the norm-form identity forces (p/q − x)(p/q + x) = 0, so p/q = x or p/q = −x. The first gives x = p/q; the second gives x = (−p)/q; both express x as a ratio of integers, contradicting Irrational.ne_rational. This is the only place irrationality enters, and it is precisely what makes the norm a nonzero integer — hence ≥ 1 in absolute value."
+    },
+    {
+      "id": "badly-approximable-general",
+      "title": "The Uniform Lower Bound: every √d is Badly Approximable",
+      "startLine": 94,
+      "endLine": 144,
+      "mathContext": "$\\dfrac{1/(1+2x)}{q^2} \\le \\left| x - \\dfrac pq \\right|$ for all $p \\in \\mathbb{Z},\\ q > 0$, whenever $x > 0$ is irrational with $x^2 = d$.",
+      "summary": "badly_approximable_sqrt assembles the bound with explicit constant c = 1/(1+2x). From non-vanishing, |p² − d·q²| ≥ 1, so with A = |p/q − x| and B = |p/q + x| one has A·B·q² = |p² − d·q²| ≥ 1. A case split on A finishes: if A ≥ 1 then c/q² ≤ c ≤ 1 ≤ A; if A < 1 then the triangle inequality bounds the conjugate factor B = |(p/q − x) + 2x| ≤ A + 2x < 1 + 2x, and nlinarith combines this with A·B·q² ≥ 1 to conclude 1 ≤ A·q²·(1+2x), i.e. c/q² ≤ A."
+    },
+    {
+      "id": "specializations",
+      "title": "Specializations: √2, √3, √5",
+      "startLine": 146,
+      "endLine": 178,
+      "mathContext": "$\\sqrt2, \\sqrt3, \\sqrt5$ are badly approximable, with $c = 1/(1+2\\sqrt d)$.",
+      "summary": "Each specialization instantiates badly_approximable_sqrt by supplying the two hypotheses. The equation x² = d comes from Real.sq_sqrt (0 ≤ d), and irrationality from the appropriate Mathlib lemma: irrational_sqrt_two for √2, Nat.Prime.irrational_sqrt at p = 3 and p = 5 for √3 and √5. The docstring notes that irrational_sqrt_natCast_iff (√n irrational ↔ n not a perfect square) supplies the hypothesis for every non-square n, so non-prime squarefree surds such as √6 are covered by the same theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "Every real quadratic surd √d is badly approximable, with the explicit constant c = 1/(1+2√d), proved sorry-free and axiom-free by an abstract norm-form argument. The engine is the identity q²(p/q − x)(p/q + x) = p² − d·q², a nonzero integer (via irrationality), whose absolute value ≥ 1 forces the lower bound after a one-line triangle-inequality bound on the conjugate factor. √2, √3, √5 are one-line instantiations.",
+    "implications": "This generalizes the parent's golden-ratio lower bound to the entire family of quadratic surds, confirming that the norm-form argument is not special to φ but is the uniform mechanism behind badly-approximability of quadratic irrationals. Because the analytic core is stated over an abstract irrational square root, the proof cleanly separates the elementary integrality argument from the (Mathlib-supplied) irrationality inputs.",
+    "openQuestions": [
+      "Can the explicit constant be improved from 1/(1+2√d) to the optimal 1/(2√d) using the periodic continued fraction of √d?",
+      "Does the abstract norm-form theorem extend to arbitrary real quadratic irrationals a + b√d (not just bare √d) by replacing the conjugate −x with the Galois conjugate a − b√d, recovering the golden-ratio case as a special instance?",
+      "Can one package a decidable/explicit lower bound c(d) as a function of d and prove a uniform statement quantified over all non-square d in a single theorem?"
+    ]
+  },
+  "crossReferences": [
+    "dirichlet-approximation-theorem-oq-05",
+    "dirichlet-approximation-theorem",
+    "dirichlet-approximation-theorem-oq-01",
+    "dirichlet-approximation-theorem-oq-03"
+  ],
+  "references": [
+    {
+      "authors": [
+        "Aleksandr Ya. Khinchin"
+      ],
+      "title": "Continued Fractions",
+      "year": 1964,
+      "venue": "University of Chicago Press",
+      "note": "Periodic continued fractions of quadratic surds and their bounded partial quotients — the structural reason every √d is badly approximable."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed., rev. Heath-Brown & Silverman)",
+      "note": "Dirichlet's and Hurwitz's approximation theorems, badly approximable numbers, and the norm-form / Pell-equation viewpoint on quadratic irrationals."
+    },
+    {
+      "authors": [
+        "Adolf Hurwitz"
+      ],
+      "title": "Über die angenäherte Darstellung der Irrationalzahlen durch rationale Brüche",
+      "year": 1891,
+      "venue": "Mathematische Annalen 39, 279–284",
+      "note": "Sharp constant 1/√5 for the best rational approximation, of which the explicit non-optimal constants here are elementary lower-bound counterparts."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the explicit open question of the parent **dirichlet-approximation-theorem-oq-05** (the golden ratio φ is badly approximable): *does the same elementary norm-form argument extend to other quadratic irrationals?* **Yes, and uniformly.**

A single structural theorem `badly_approximable_sqrt` shows that any positive irrational `x` with `x² = d` (`d : ℕ`) is badly approximable with the **explicit constant `c = 1/(1 + 2x)`**:

$$\frac{1/(1+2x)}{q^2} \le \left| x - \frac{p}{q} \right| \qquad \forall\, p \in \mathbb{Z},\ q > 0.$$

## Why it works

The conjugate of `x = √d` is simply `−x` (the two roots of `X² − d`), so the norm form is
`q²(p/q − x)(p/q + x) = p² − d·q² ∈ ℤ` — no middle term, no dedicated `goldenRatio` API. It is nonzero because `x` is irrational (`Irrational.ne_rational`), hence `≥ 1` in absolute value; the product bound `|x − p/q|·|x + p/q| ≥ 1/q²` plus a one-line triangle-inequality bound on the conjugate factor (`< 1 + 2x`) gives the result.

The analytic core is abstract over `x`, so the irrationality input is fully decoupled. Specializations, one line each:

- `sqrtTwo_badly_approximable` — via `irrational_sqrt_two`
- `sqrtThree_badly_approximable`, `sqrtFive_badly_approximable` — via `Nat.Prime.irrational_sqrt`
- and via `irrational_sqrt_natCast_iff` (√n irrational ↔ n not a perfect square), every non-square `n` is covered (e.g. the non-prime √6).

## Verification

- **178 lines, 6 theorems, 0 defs, 0 sorries, 0 axioms.**
- `#print axioms` on all four headline results lists only `propext / Classical.choice / Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`.
- Typechecks against Mathlib v4.26.0.

New gallery entry: `src/data/proofs/dirichlet-approximation-theorem-oq-05-oq-02/` (meta.json + annotations.json, status `verified`, badge `original`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)