### PR TITLE
research(composition-parts-choose-oq-01-oq-03): third moment, distribution symmetry, and vanishing skewness [VERIFIED, 0-axiom, +5thm]

### DIFF
--- a/proofs/Proofs/CompositionPartsChooseOQ01OQ03.lean
+++ b/proofs/Proofs/CompositionPartsChooseOQ01OQ03.lean
@@ -1,0 +1,228 @@
+import Mathlib
+import Proofs.CompositionPartsChooseOQ01OQ01OQ01
+
+/-
+# Symmetry of the part-count distribution and the vanishing third central moment
+
+A *composition* of `n` is an ordered tuple of positive integers summing to `n`
+(Mathlib's `Composition n`); its number of parts is `c.length`. Earlier entries in
+this family establish, via the "cut-set" bijection `gapsEquiv n : Composition n ≃
+Finset (Fin (n−1))` (a composition is the set of internal gaps it cuts) and the
+bridge `length_eq_card_gaps : c.length = (gaps c).card + 1`:
+
+* grandparent (`composition-parts-choose-oq-01`): exactly `C(n−1, k−1)` of the
+  `2^(n−1)` compositions of `n` have `k` parts;
+* parent (`composition-parts-choose-oq-01-oq-01`): the **first moment** — mean
+  number of parts `(n+1)/2`;
+* sibling (`…-oq-01-oq-01-oq-01`): the **second moment** and **variance** `(n−1)/4`.
+
+This leaf pushes the graded-refinement / cut-set technique one step further, to the
+**third** moment, and extracts the structural payoff.
+
+## What this proves
+
+* `sum_choose_mul_cube` — the new weighted binomial identity
+  `8·Σ_k C(m,k)·k³ = m²·(m+3)·2^m`, the cubic analogue of the parent's
+  `Σ_k C(m,k)·k = m·2^(m−1)` and the sibling's `4·Σ_k C(m,k)·k² = m·(m+1)·2^m`.
+  It is obtained by the **double-absorption** ("double-erase") step: applying
+  `(k+1)·C(m,k+1) = m·C(m−1,k)` (`Nat.add_one_mul_choose_eq`) drops one factor of
+  `k+1`, reducing the `k³`-sum to the already-known `k²`, `k` and plain binomial
+  sums.
+
+* `third_moment` — the third moment of the part-count over all `2^(n−1)`
+  compositions of `n ≥ 1`:
+  `8·Σ_c (c.length)³ + 2^n = (n³ + 6n² + 3n)·2^(n−1)`
+  (equivalently the raw value is `(n³ + 6n² + 3n − 2)·2^(n−3)`). Same route as the
+  lower moments: transport across `gapsEquiv`, expand `(|s|+1)³`, and feed in the
+  three subset sums.
+
+* `parts_distribution_symmetric` — the **structural theorem**: for *any* weight
+  `g : ℕ → M`,
+  `Σ_c g(c.length) = Σ_c g(n + 1 − c.length)`.
+  The part-count distribution is symmetric about its mean `(n+1)/2`. The proof is
+  the cut-set **complement** involution `s ↦ sᶜ` on `Finset (Fin (n−1))`, under
+  which a composition with `|s|+1` parts is exchanged with one with
+  `(n−1−|s|)+1 = n − |s|` parts, i.e. `k ↦ n + 1 − k`. This is the graded
+  incarnation of `C(n−1, k−1) = C(n−1, n−k)`.
+
+* `third_central_moment_zero` — the payoff: the **third central moment vanishes**,
+  `Σ_c (c.length − (n+1)/2)³ = 0` (`n ≥ 1`). Where the variance `(n−1)/4` grows
+  with `n`, the skewness is exactly `0`: the distribution has no third-order
+  asymmetry. This follows immediately from `parts_distribution_symmetric` with the
+  odd weight `g(k) = (k − (n+1)/2)³`, for which `g(n+1−k) = −g(k)`; more generally
+  the same argument kills *every* odd central moment.
+
+Mathlib records `Σ_k C(m,k) = 2^m` but none of the weighted sums `Σ k^j C(m,k)`,
+nor any statement about the part-count distribution of a random composition or its
+symmetry. No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace CompositionPartsChooseOQ01OQ03
+
+open Finset CompositionPartsChooseOQ01OQ01 CompositionPartsChooseOQ01OQ01OQ01
+
+/-! ## The third-moment binomial sum (double absorption) -/
+
+/-- **Third-moment binomial identity.** `8·Σ_k C(m,k)·k³ = m²·(m+3)·2^m`.
+Stated with the factor `8` so it holds in `ℕ` for all `m`. Proved by the
+absorption rule `(k+1)·C(m,k+1) = m·C(m−1,k)` (`Nat.add_one_mul_choose_eq`), which
+lowers one factor of `k+1`, reducing the `k³`-sum to the `k²`, `k` and plain
+binomial sums. -/
+theorem sum_choose_mul_cube (m : ℕ) :
+    8 * ∑ k ∈ range (m + 1), m.choose k * k ^ 3 = m ^ 2 * (m + 3) * 2 ^ m := by
+  cases m with
+  | zero => simp
+  | succ M =>
+    rw [Finset.sum_range_succ']
+    simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, mul_zero, add_zero]
+    -- `∑ k, C(M+1, k+1) · (k+1)³ = (M+1) · ∑ k, C(M,k)·(k+1)²`
+    have step : ∀ k ∈ range (M + 1),
+        (M + 1).choose (k + 1) * (k + 1) ^ 3 = (M + 1) * (M.choose k * (k + 1) ^ 2) := by
+      intro k _
+      have h : (M + 1) * M.choose k = (M + 1).choose (k + 1) * (k + 1) :=
+        Nat.add_one_mul_choose_eq M k
+      calc (M + 1).choose (k + 1) * (k + 1) ^ 3
+            = ((M + 1).choose (k + 1) * (k + 1)) * (k + 1) ^ 2 := by ring
+        _ = ((M + 1) * M.choose k) * (k + 1) ^ 2 := by rw [← h]
+        _ = (M + 1) * (M.choose k * (k + 1) ^ 2) := by ring
+    rw [Finset.sum_congr rfl step, ← Finset.mul_sum]
+    -- expand `(k+1)² = k² + 2k + 1`
+    have esplit : ∑ k ∈ range (M + 1), M.choose k * (k + 1) ^ 2
+        = (∑ k ∈ range (M + 1), M.choose k * k ^ 2)
+          + 2 * (∑ k ∈ range (M + 1), M.choose k * k)
+          + (∑ k ∈ range (M + 1), M.choose k) := by
+      rw [Finset.mul_sum, ← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+      exact Finset.sum_congr rfl (fun k _ => by ring)
+    rw [esplit]
+    -- feed in the three known sums: `4·Σk² = M(M+1)2^M`, `Σk = M·2^(M−1)`, `Σ1 = 2^M`
+    have hA := sum_choose_mul_sq M
+    have hB := sum_choose_mul M
+    have hC := Nat.sum_range_choose M
+    have key : 8 * ((M + 1) * ((∑ k ∈ range (M + 1), M.choose k * k ^ 2)
+          + 2 * (∑ k ∈ range (M + 1), M.choose k * k)
+          + (∑ k ∈ range (M + 1), M.choose k)))
+        = 2 * (M + 1) * (4 * ∑ k ∈ range (M + 1), M.choose k * k ^ 2)
+          + 16 * (M + 1) * (∑ k ∈ range (M + 1), M.choose k * k)
+          + 8 * (M + 1) * (∑ k ∈ range (M + 1), M.choose k) := by ring
+    rw [key, hA, hB, hC]
+    cases M with
+    | zero => norm_num
+    | succ N => simp only [Nat.add_sub_cancel, pow_succ]; ring
+
+/-- **Third-moment subset sum.** `8·Σ_{s ⊆ Fin m} |s|³ = m²·(m+3)·2^m`.
+Transported from `sum_choose_mul_cube` via `Finset.sum_powerset_apply_card`. -/
+theorem sum_finset_card_cube (m : ℕ) :
+    8 * ∑ s : Finset (Fin m), s.card ^ 3 = m ^ 2 * (m + 3) * 2 ^ m := by
+  have h1 : ∑ s : Finset (Fin m), s.card ^ 3
+      = ∑ s ∈ (univ : Finset (Fin m)).powerset, s.card ^ 3 := by rw [Finset.powerset_univ]
+  rw [h1, Finset.sum_powerset_apply_card (fun k => k ^ 3)]
+  simp only [smul_eq_mul, Finset.card_univ, Fintype.card_fin]
+  exact sum_choose_mul_cube m
+
+/-! ## The third moment over compositions -/
+
+/-- **Third moment of the number of parts.** Summed over all `2^(n−1)` compositions
+of `n ≥ 1`:
+`8·Σ_c (c.length)³ + 2^n = (n³ + 6n² + 3n)·2^(n−1)`
+(the `+ 2^n` clears the constant `−2` of the raw closed form `(n³+6n²+3n−2)·2^(n−3)`
+so the statement stays in `ℕ`). Route: push across `gapsEquiv`, expand `(|s|+1)³`,
+and combine the four subset sums. -/
+theorem third_moment (n : ℕ) (hn : 1 ≤ n) :
+    8 * ∑ c : Composition n, c.length ^ 3 + 2 ^ n
+      = (n ^ 3 + 6 * n ^ 2 + 3 * n) * 2 ^ (n - 1) := by
+  obtain ⟨M, rfl⟩ : ∃ M, n = M + 1 := ⟨n - 1, by omega⟩
+  have e1 : ∑ c : Composition (M + 1), c.length ^ 3
+      = ∑ s : Finset (Fin (M + 1 - 1)), (s.card + 1) ^ 3 := by
+    rw [← Equiv.sum_comp (gapsEquiv (M + 1)) (fun s => (s.card + 1) ^ 3)]
+    exact Finset.sum_congr rfl (fun c _ => by rw [length_eq_card_gaps (M + 1) hn c])
+  rw [e1, show M + 1 - 1 = M from rfl]
+  -- expand `(|s|+1)³ = |s|³ + 3|s|² + 3|s| + 1`
+  have hsum : (∑ s : Finset (Fin M), (s.card + 1) ^ 3)
+      = (∑ s : Finset (Fin M), s.card ^ 3) + 3 * (∑ s : Finset (Fin M), s.card ^ 2)
+        + 3 * (∑ s : Finset (Fin M), s.card) + (∑ _s : Finset (Fin M), (1 : ℕ)) := by
+    rw [Finset.mul_sum, Finset.mul_sum, ← Finset.sum_add_distrib, ← Finset.sum_add_distrib,
+      ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl (fun s _ => by ring)
+  have hs0 : (∑ _s : Finset (Fin M), (1 : ℕ)) = 2 ^ M := by
+    rw [Finset.sum_const, Finset.card_univ, Fintype.card_finset, Fintype.card_fin, smul_eq_mul,
+      mul_one]
+  rw [hsum]
+  have hs3 := sum_finset_card_cube M
+  have hs2 := sum_finset_card_sq M
+  have hs1 := sum_finset_card M
+  have key : 8 * ((∑ s : Finset (Fin M), s.card ^ 3)
+        + 3 * (∑ s : Finset (Fin M), s.card ^ 2)
+        + 3 * (∑ s : Finset (Fin M), s.card) + (∑ _s : Finset (Fin M), (1 : ℕ))) + 2 ^ (M + 1)
+      = (8 * ∑ s : Finset (Fin M), s.card ^ 3)
+        + 6 * (4 * ∑ s : Finset (Fin M), s.card ^ 2)
+        + 24 * (∑ s : Finset (Fin M), s.card) + 8 * (∑ _s : Finset (Fin M), (1 : ℕ))
+        + 2 ^ (M + 1) := by ring
+  rw [key, hs3, hs2, hs1, hs0]
+  cases M with
+  | zero => norm_num
+  | succ N => simp only [Nat.add_sub_cancel, pow_succ]; ring
+
+/-! ## Symmetry of the distribution and the vanishing skewness -/
+
+/-- **Symmetry of the part-count distribution.** For any weight `g : ℕ → M`,
+`Σ_c g(c.length) = Σ_c g(n + 1 − c.length)` (`n ≥ 1`). The distribution of the
+number of parts is symmetric about its mean `(n+1)/2`.
+
+Proof: transport both sums across the cut-set bijection `gapsEquiv` to sums over
+`Finset (Fin (n−1))`, then reindex by the **complement** involution `s ↦ sᶜ`. Since
+`|sᶜ| = (n−1) − |s|`, a composition with `|s|+1` parts is exchanged with one with
+`(n−1−|s|)+1 = n − |s| = (n+1) − (|s|+1)` parts. -/
+theorem parts_distribution_symmetric {M : Type*} [AddCommMonoid M]
+    (n : ℕ) (hn : 1 ≤ n) (g : ℕ → M) :
+    ∑ c : Composition n, g c.length = ∑ c : Composition n, g (n + 1 - c.length) := by
+  -- transport the left sum to subsets of the `n−1` gaps
+  have hL : ∑ c : Composition n, g c.length
+      = ∑ s : Finset (Fin (n - 1)), g (s.card + 1) := by
+    rw [← Equiv.sum_comp (gapsEquiv n) (fun s => g (s.card + 1))]
+    exact Finset.sum_congr rfl (fun c _ => by rw [length_eq_card_gaps n hn c])
+  -- transport the right sum to subsets
+  have hR : ∑ c : Composition n, g (n + 1 - c.length)
+      = ∑ s : Finset (Fin (n - 1)), g (n + 1 - (s.card + 1)) := by
+    rw [← Equiv.sum_comp (gapsEquiv n) (fun s => g (n + 1 - (s.card + 1)))]
+    exact Finset.sum_congr rfl (fun c _ => by rw [length_eq_card_gaps n hn c])
+  rw [hL, hR]
+  -- the complement involution on subsets
+  let e : Finset (Fin (n - 1)) ≃ Finset (Fin (n - 1)) := ⟨(·ᶜ), (·ᶜ), compl_compl, compl_compl⟩
+  rw [← Equiv.sum_comp e (fun s => g (n + 1 - (s.card + 1)))]
+  apply Finset.sum_congr rfl
+  intro s _
+  have hcard : (e s).card = (n - 1) - s.card := by
+    show sᶜ.card = (n - 1) - s.card
+    rw [Finset.card_compl, Fintype.card_fin]
+  have hsle : s.card ≤ n - 1 := by
+    have := Finset.card_le_univ s
+    simpa [Fintype.card_fin] using this
+  show g (s.card + 1) = g (n + 1 - ((e s).card + 1))
+  rw [hcard]
+  congr 1
+  omega
+
+/-- **The third central moment vanishes.** Under the uniform distribution on the
+`2^(n−1)` compositions of `n ≥ 1`, with mean `μ = (n+1)/2`,
+`Σ_c (c.length − (n+1)/2)³ = 0`: the part-count distribution has zero skewness.
+
+Immediate from `parts_distribution_symmetric` applied to the odd weight
+`g(k) = (k − (n+1)/2)³`, which satisfies `g(n+1−k) = −g(k)`; hence the sum equals
+its own negative. -/
+theorem third_central_moment_zero (n : ℕ) (hn : 1 ≤ n) :
+    ∑ c : Composition n, ((c.length : ℚ) - (n + 1) / 2) ^ 3 = 0 := by
+  have hsym := parts_distribution_symmetric n hn (fun k => ((k : ℚ) - (n + 1) / 2) ^ 3)
+  -- hsym : ∑ c, (↑c.length − (n+1)/2)³ = ∑ c, (↑(n+1−c.length) − (n+1)/2)³
+  have hterm : ∀ c : Composition n,
+      (((n + 1 - c.length : ℕ) : ℚ) - (n + 1) / 2) ^ 3
+        = -(((c.length : ℚ) - (n + 1) / 2) ^ 3) := by
+    intro c
+    have hle : c.length ≤ n := c.length_le
+    have hcast : ((n + 1 - c.length : ℕ) : ℚ) = (n : ℚ) + 1 - c.length := by
+      rw [Nat.cast_sub (by omega : c.length ≤ n + 1)]
+      push_cast; ring
+    rw [hcast]; ring
+  rw [Finset.sum_congr rfl (fun c _ => hterm c), Finset.sum_neg_distrib] at hsym
+  linarith [hsym]
+
+end CompositionPartsChooseOQ01OQ03

--- a/research/problems/composition-parts-choose-oq-01-oq-03/knowledge.md
+++ b/research/problems/composition-parts-choose-oq-01-oq-03/knowledge.md
@@ -1,0 +1,52 @@
+# composition-parts-choose-oq-01-oq-03 — Third moment, symmetry, and vanishing skewness of the part-count
+
+**Status:** COMPLETED (VERIFIED, 0-axiom) — PR shipped 2026-07-01.
+
+## Problem
+
+Leaf of the `composition-parts-choose` family (graded refinements of composition
+counts via the "cut-set / double-erase" technique). A composition of `n` is an
+ordered tuple of positive integers summing to `n` (Mathlib's `Composition n`);
+its part-count is `c.length`. The family had built the count `2^(n−1)`, the
+graded count `C(n−1,k−1)`, the first moment (mean `(n+1)/2`), and the second
+moment / variance `(n−1)/4`. The sibling `oq-01-oq-01-oq-01`'s open question
+asked for the **third moment / skewness** — this leaf answers it.
+
+## Result (Proofs/CompositionPartsChooseOQ01OQ03.lean, 228L, 5 thm)
+
+1. `sum_choose_mul_cube` : `8·∑_k C(m,k)·k³ = m²(m+3)·2^m` — cubic binomial
+   identity by **double absorption** (`Nat.add_one_mul_choose_eq` drops one
+   `(k+1)`, reducing `k³` to the family's `k²`, `k`, plain sums).
+2. `sum_finset_card_cube` : subset form `8·∑_{s⊆Fin m} |s|³ = m²(m+3)2^m`
+   (via `Finset.sum_powerset_apply_card`).
+3. `third_moment` : `8·∑_c (c.length)³ + 2^n = (n³+6n²+3n)·2^(n−1)` (n ≥ 1);
+   raw value `(n³+6n²+3n−2)·2^(n−3)`.
+4. `parts_distribution_symmetric` : **structural** — for any `g : ℕ → M`,
+   `∑_c g(c.length) = ∑_c g(n+1−c.length)`. Proved by the **complement
+   involution** `s ↦ sᶜ` on `Finset (Fin (n−1))` (`|sᶜ| = (n−1)−|s|`), the graded
+   form of `C(n−1,k−1) = C(n−1,n−k)`.
+5. `third_central_moment_zero` : `∑_c ((c.length:ℚ) − (n+1)/2)³ = 0` — zero
+   skewness, one line from (4) via the odd weight `g(k)=(k−(n+1)/2)³`,
+   `g(n+1−k) = −g(k)`. Kills every odd central moment.
+
+## Key techniques
+
+- Gap bijection `gapsEquiv : Composition n ≃ Finset (Fin (n−1))` + bridge
+  `length_eq_card_gaps` (from `oq-01-oq-01`); transport sums with `Equiv.sum_comp`.
+- Double absorption for weighted binomial sums (reuse of family lemmas
+  `sum_choose_mul`, `sum_choose_mul_sq`, `sum_finset_card`, `sum_finset_card_sq`).
+- Reindex-by-involution (`s ↦ sᶜ`) for the symmetry theorem — the new idea here.
+
+## Provenance
+
+Adopted an orphan `.lean` left untracked in the main working tree by a prior
+session; verified it typechecks against main's Mathlib cache
+(`env -u LAKE lake env lean`) and confirmed `#print axioms` = `[propext,
+Classical.choice, Quot.sound]` only (0 substantive). Authored the full gallery
+entry (meta.json, annotations.json, index.ts).
+
+## Follow-ups (see meta.json openQuestions)
+
+- Fourth moment / kurtosis via `∑ k⁴ C(m,k)` + the same absorption chain.
+- Symmetry/moments of *largest part* or *number of distinct part-sizes* — does
+  gap-bijection transport survive for non-additive statistics?

--- a/src/data/proofs/composition-parts-choose-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-03/annotations.json
@@ -1,0 +1,105 @@
+[
+  {
+    "id": "ann-compparts-m3-header",
+    "proofId": "composition-parts-choose-oq-01-oq-03",
+    "range": { "startLine": 4, "endLine": 58 },
+    "type": "concept",
+    "title": "From Variance to Skewness: the Third Moment and the Symmetry of the Part-Count",
+    "content": "The docstring places this leaf in its lineage and states the payoff. A composition of n is an ordered tuple of positive integers summing to n; its part-count is c.length. The family already knows: 2^(n−1) compositions of n (great-grandparent), C(n−1,k−1) with exactly k parts (grandparent), mean (n+1)/2 (parent), variance (n−1)/4 (sibling), recognising the part-count as 1 + Binomial(n−1, ½). The sibling's open question asked for the third moment / skewness; this entry answers it three ways: (1) the cubic binomial identity 8∑ k³C(m,k) = m²(m+3)2^m; (2) the third moment 8∑ length³ + 2^n = (n³+6n²+3n)2^(n−1); and, the structural heart, (3) the distribution is symmetric about its mean, so the skewness is exactly 0. Same engine as the lower moments — the gap bijection gapsEquiv : Composition n ≃ Finset (Fin (n−1)) and length = |gaps|+1 — plus one new idea: the complement involution on gap subsets.",
+    "mathContext": "$X(c) = c.\\mathrm{length}$; $\\;8\\sum_c X^3 + 2^n = (n^3{+}6n^2{+}3n)2^{n-1}$, and $\\sum_c (X - \\tfrac{n+1}{2})^3 = 0$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "compositions of an integer",
+      "gap bijection",
+      "third moment and skewness",
+      "distribution symmetry",
+      "binomial distribution",
+      "family lineage"
+    ],
+    "prerequisites": [
+      "Mathlib's Composition n",
+      "the gap bijection and the first/second moments from earlier entries",
+      "central moments and skewness"
+    ]
+  },
+  {
+    "id": "ann-compparts-m3-cube",
+    "proofId": "composition-parts-choose-oq-01-oq-03",
+    "range": { "startLine": 66, "endLine": 120 },
+    "type": "technique",
+    "title": "The Cubic Binomial Sum by Double Absorption",
+    "content": "sum_choose_mul_cube proves 8·∑_k C(m,k)·k³ = m²(m+3)2^m. The trick is absorption: (k+1)·C(m+1,k+1) = (m+1)·C(m,k) (Nat.add_one_mul_choose_eq) removes one factor (k+1) from the shifted sum, turning ∑ C(m+1,k+1)(k+1)³ into (m+1)·∑ C(m,k)(k+1)². Expanding (k+1)² = k² + 2k + 1 splits this into the sibling's second-moment sum 4∑k²C = m(m+1)2^m, the parent's first-moment sum ∑kC = m·2^(m−1), and the plain ∑C = 2^m (Nat.sum_range_choose); a case split on m resolves the 2-powers and ring finishes. Stating the identity times 8 avoids truncated ℕ-subtraction. sum_finset_card_cube then transports it to ∑_{s ⊆ Fin m} |s|³ via Finset.sum_powerset_apply_card.",
+    "mathContext": "$(k+1)\\binom{m+1}{k+1} = (m+1)\\binom{m}{k}$ lowers $k^3$ to $(k+1)^2$ inside an $m$-binomial.",
+    "significance": "key-technique",
+    "relatedConcepts": [
+      "absorption identity",
+      "weighted binomial sums",
+      "powerset-by-cardinality sum"
+    ],
+    "prerequisites": [
+      "Nat.add_one_mul_choose_eq",
+      "Nat.sum_range_choose",
+      "the family's first- and second-moment binomial sums"
+    ]
+  },
+  {
+    "id": "ann-compparts-m3-thirdmoment",
+    "proofId": "composition-parts-choose-oq-01-oq-03",
+    "range": { "startLine": 122, "endLine": 164 },
+    "type": "milestone",
+    "title": "The Third Moment over All Compositions",
+    "content": "third_moment: for n ≥ 1, 8·∑_c (c.length)³ + 2^n = (n³ + 6n² + 3n)·2^(n−1). The proof pushes the cubed part-count across the gap bijection (length_eq_card_gaps turns c.length into (gapsEquiv n c).card + 1, and Equiv.sum_comp reindexes the sum), expands (|s|+1)³ = |s|³ + 3|s|² + 3|s| + 1, and combines the four subset sums: the new sum_finset_card_cube, the sibling's sum_finset_card_sq, the parent's sum_finset_card, and the count ∑1 = 2^(n−1). A single ring call after substituting n = M + 1 yields the closed form (the raw exact value is (n³+6n²+3n−2)·2^(n−3)).",
+    "mathContext": "$\\sum_c (|s|+1)^3 = \\sum_s |s|^3 + 3\\sum_s |s|^2 + 3\\sum_s |s| + 2^{n-1}$.",
+    "significance": "main-result",
+    "relatedConcepts": [
+      "moments of a distribution",
+      "gap bijection transport",
+      "subset cardinality sums"
+    ],
+    "prerequisites": [
+      "gapsEquiv and length_eq_card_gaps",
+      "Equiv.sum_comp",
+      "the four subset-cardinality sums ∑|s|^j"
+    ]
+  },
+  {
+    "id": "ann-compparts-m3-symmetry",
+    "proofId": "composition-parts-choose-oq-01-oq-03",
+    "range": { "startLine": 165, "endLine": 203 },
+    "type": "insight",
+    "title": "Symmetry via the Cut-Set Complement Involution",
+    "content": "parts_distribution_symmetric is the structural theorem: for ANY weight g : ℕ → M (any AddCommMonoid), ∑_c g(c.length) = ∑_c g(n + 1 − c.length). Both sides are transported to sums over Finset (Fin (n−1)) via gapsEquiv; the right side is then reindexed by the complement involution e : s ↦ sᶜ (an Equiv from compl_compl). Because |sᶜ| = (n−1) − |s| (Finset.card_compl over Fin (n−1)), a composition with |s|+1 parts is matched to one with n − |s| = (n+1) − (|s|+1) parts, and omega closes the arithmetic. This is the graded incarnation of C(n−1,k−1) = C(n−1,n−k): complementing the set of cut gaps sends a k-part composition to an (n+1−k)-part one. It instantly forces EVERY odd central moment to vanish.",
+    "mathContext": "$s \\mapsto s^c$ on $\\mathrm{Finset}(\\mathrm{Fin}(n-1))$; $\\;|s^c| = (n-1) - |s|$, so $k \\mapsto n+1-k$ parts.",
+    "significance": "key-insight",
+    "relatedConcepts": [
+      "involution / reindexing a sum",
+      "set complement",
+      "binomial symmetry C(n−1,k−1) = C(n−1,n−k)"
+    ],
+    "prerequisites": [
+      "Finset.card_compl and compl_compl",
+      "Equiv.sum_comp",
+      "the gap bijection"
+    ]
+  },
+  {
+    "id": "ann-compparts-m3-skewness",
+    "proofId": "composition-parts-choose-oq-01-oq-03",
+    "range": { "startLine": 205, "endLine": 227 },
+    "type": "milestone",
+    "title": "The Third Central Moment Vanishes (Zero Skewness)",
+    "content": "third_central_moment_zero: ∑_c ((c.length : ℚ) − (n+1)/2)³ = 0 for n ≥ 1. It is one line of consequence from symmetry: apply parts_distribution_symmetric with the odd centred weight g(k) = ((k:ℚ) − (n+1)/2)³. The reflected term g(n+1−c.length) equals −g(c.length) — shown by Nat.cast_sub (valid since c.length ≤ n) followed by ring — so the whole sum equals its own negation, and linarith concludes it is 0. The uniform distribution on the 2^(n−1) compositions of n therefore has exactly zero skewness, matching the symmetric Binomial(n−1, ½); the same odd-weight argument annihilates every odd central moment.",
+    "mathContext": "$g(n{+}1-k) = -g(k)$ for $g(k) = (k - \\tfrac{n+1}{2})^3$, so $\\sum_c g = -\\sum_c g = 0$.",
+    "significance": "main-result",
+    "relatedConcepts": [
+      "skewness",
+      "odd central moments",
+      "symmetric distribution"
+    ],
+    "prerequisites": [
+      "parts_distribution_symmetric",
+      "Nat.cast_sub",
+      "a symmetric distribution has zero odd central moments"
+    ]
+  }
+]

--- a/src/data/proofs/composition-parts-choose-oq-01-oq-03/index.ts
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CompositionPartsChooseOQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const compositionPartsChooseOq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const compositionPartsChooseOq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const compositionPartsChooseOq01Oq03Data: ProofData = {
+  proof: compositionPartsChooseOq01Oq03Proof,
+  annotations: compositionPartsChooseOq01Oq03Annotations,
+}

--- a/src/data/proofs/composition-parts-choose-oq-01-oq-03/meta.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-03/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "composition-parts-choose-oq-01-oq-03",
+  "title": "Composition Parts OQ-01-OQ-03: The Third Moment, Distribution Symmetry, and Vanishing Skewness of the Number of Parts",
+  "slug": "composition-parts-choose-oq-01-oq-03",
+  "description": "A composition of a natural number n is an ordered tuple of positive integers summing to n (Mathlib's Composition n); its number of parts is c.length. This family has built up the part-count distribution moment by moment: the great-grandparent counts compositions (card (Composition n) = 2^(n−1)), the grandparent grades that count by part number (C(n−1, k−1) compositions of n into exactly k parts), the parent computes the first moment (total (n+1)·2^(n−2), mean (n+1)/2), and the direct sibling computes the second moment and variance (n−1)/4 — recognising the part-count as 1 + Binomial(n−1, 1/2). That sibling's own open question asked for the third moment / skewness; this leaf answers it. The new binomial core sum_choose_mul_cube proves 8·∑_k C(m,k)·k³ = m²(m+3)2^m (the factor 8 keeps the statement in ℕ), by the double-absorption step: the rule (k+1)·C(m,k+1) = m·C(m−1,k) (Nat.add_one_mul_choose_eq) drops one factor k+1, reducing the k³-sum to the already-known k², k, and plain binomial sums. Transported along the gap bijection gapsEquiv : Composition n ≃ Finset (Fin (n−1)) via length = |gaps|+1, this yields third_moment: 8·∑_c (c.length)³ + 2^n = (n³ + 6n² + 3n)·2^(n−1) for n ≥ 1. The structural payoff is parts_distribution_symmetric: for ANY weight g : ℕ → M, ∑_c g(c.length) = ∑_c g(n + 1 − c.length), i.e. the part-count distribution is symmetric about its mean (n+1)/2 — proved by the cut-set COMPLEMENT involution s ↦ sᶜ on Finset (Fin (n−1)), the graded incarnation of C(n−1, k−1) = C(n−1, n−k). The headline third_central_moment_zero then follows in one line: with the odd weight g(k) = (k − (n+1)/2)³ (for which g(n+1−k) = −g(k)), the sum equals its own negative, so ∑_c (c.length − (n+1)/2)³ = 0 — the skewness is exactly zero, and the same argument kills every odd central moment. Mathlib records ∑_k C(m,k) = 2^m but neither the weighted sums ∑ k^j C(m,k) for j ≥ 1 nor any statement about the part-count distribution of a random composition or its symmetry; all of that is original content here.",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CompositionPartsChooseOQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "CompositionPartsChooseOQ01OQ01",
+      "CompositionPartsChooseOQ01OQ01OQ01"
+    ],
+    "namespace": "CompositionPartsChooseOQ01OQ03",
+    "lineCount": 228,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CompositionPartsChooseOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Composition_(combinatorics)",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompositionPartsChooseOQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "compositions",
+      "counting",
+      "binomial-coefficients",
+      "third-moment",
+      "skewness",
+      "symmetry"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "composition-parts-choose-oq-01-oq-01-oq-01",
+        "relationship": "Direct sibling / predecessor: computes the second moment and variance (n−1)/4 of the number of parts, and its open questions explicitly ask for the third moment / skewness. This entry answers that: the new cubic binomial identity 8∑ k³C(m,k) = m²(m+3)2^m gives the third moment, and the complement involution shows the third central moment is exactly 0."
+      },
+      {
+        "id": "composition-parts-choose-oq-01-oq-01",
+        "relationship": "First-moment parent: mean number of parts (n+1)/2, the centre about which parts_distribution_symmetric shows the whole distribution is symmetric."
+      },
+      {
+        "id": "composition-parts-choose-oq-01",
+        "relationship": "Grandparent: the part-graded count C(n−1, k−1) of compositions of n into exactly k parts — the distribution whose third moment, symmetry, and skewness are computed here. The symmetry theorem is the graded form of C(n−1,k−1) = C(n−1,n−k)."
+      },
+      {
+        "id": "composition-card-2pow-oq-01",
+        "relationship": "Great-grandparent: the ungraded total card (Composition n) = 2^(n−1), the number of compositions being summed over."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 228,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All named theorems (sum_choose_mul_cube, sum_finset_card_cube, third_moment, parts_distribution_symmetric, third_central_moment_zero) were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. Mathlib contains ∑_k C(m,k) = 2^m (Nat.sum_range_choose) and the absorption rule Nat.add_one_mul_choose_eq, but neither the third-moment binomial sum 8∑ k³C(m,k) = m²(m+3)2^m nor any moment or symmetry statement about the part-count distribution of a composition; all are original content here, built on the family's gapsEquiv, length_eq_card_gaps, sum_choose_mul, sum_choose_mul_sq, sum_finset_card, sum_finset_card_sq together with Finset.sum_powerset_apply_card, Equiv.sum_comp, the complement involution on Finset (Fin (n−1)), and Fintype.card_finset. The integer identities are stated multiplied by 8 (third moment) to stay in ℕ; the skewness is stated over ℚ where the centring is exact. The symmetry theorem parts_distribution_symmetric holds for an arbitrary AddCommMonoid-valued weight and n ≥ 1.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Compositions of n are ordered sequences of positive parts summing to n. There are 2^(n−1) of them, C(n−1, k−1) with exactly k parts, so the number of parts of a uniformly random composition is distributed as 1 + Binomial(n−1, 1/2): each of the n−1 internal gaps is independently cut or not. Earlier entries in this family established the count, the graded count, the mean (n+1)/2, and the variance (n−1)/4 by transporting sums along the gap bijection rather than invoking probability theory. The natural next questions are the shape of the distribution beyond its spread — its symmetry and its third moment / skewness. A Binomial(n−1, 1/2) is symmetric, so its skewness should vanish; this entry proves that combinatorially, and pins down the exact third moment.",
+    "problemStatement": "Across all 2^(n−1) compositions of n, compute the third moment of the number of parts, establish the symmetry of the part-count distribution about its mean, and deduce the skewness. Show, for n ≥ 1,\n\n$$8\\sum_{c} (c.\\mathrm{length})^3 + 2^n = (n^3 + 6n^2 + 3n)\\,2^{\\,n-1}, \\qquad \\sum_{c}\\Bigl(c.\\mathrm{length} - \\tfrac{n+1}{2}\\Bigr)^3 = 0,$$\n\nand more structurally that $\\sum_c g(c.\\mathrm{length}) = \\sum_c g(n+1 - c.\\mathrm{length})$ for every weight $g$.",
+    "text": "The part-count of a composition equals one plus the number of internal gaps it cuts, and a composition of n corresponds bijectively to the subset of the n−1 internal gaps it cuts (gapsEquiv : Composition n ≃ Finset (Fin (n−1))). Transporting the cubed part-count along this bijection reduces the third moment to the subset sum ∑_{s ⊆ [m]} (|s|+1)³, and hence to the four elementary subset sums ∑|s|³, ∑|s|², ∑|s|, ∑1. The arithmetic core is the third-moment binomial identity 8∑_k k³C(m,k) = m²(m+3)2^m, established here by a single double-absorption step. Symmetry is a separate, structural phenomenon: the complement involution s ↦ sᶜ on the gap subsets carries a composition with |s|+1 parts to one with n − |s| parts, exchanging k parts with n+1−k parts. The vanishing skewness is an immediate corollary for the odd centred weight.",
+    "proofStrategy": "sum_choose_mul_cube proves 8·∑_{k≤m} C(m,k)·k³ = m²(m+3)2^m: peel the k = 0 term (Finset.sum_range_succ'), then for the shifted sum use C(m+1,k+1)·(k+1)³ = (m+1)·(C(m,k)·(k+1)²) via the absorption rule Nat.add_one_mul_choose_eq (dropping one factor k+1), expand (k+1)² = k² + 2k + 1, and feed in the family's second-moment sum (4∑k²C = m(m+1)2^m), first-moment sum (∑kC = m·2^(m−1)) and Nat.sum_range_choose (∑C = 2^m); a case split resolves the 2-powers and ring closes. sum_finset_card_cube transports this to ∑_{s ⊆ Fin m} |s|³ via Finset.powerset_univ and Finset.sum_powerset_apply_card. third_moment rewrites ∑_c c.length³ through length_eq_card_gaps as ∑_c ((gapsEquiv n c).card + 1)³, reindexes by Equiv.sum_comp to ∑_{s : Finset (Fin (n−1))} (|s|+1)³, expands (|s|+1)³, and combines the four subset sums to give (n³+6n²+3n)2^(n−1) − 2^n by ring after substituting n = M + 1. parts_distribution_symmetric transports ∑_c g(length c) and ∑_c g(n+1−length c) to subset sums via gapsEquiv and length_eq_card_gaps, then reindexes the latter by the complement equivalence e : s ↦ sᶜ; since |sᶜ| = (n−1) − |s|, the terms match after an omega on the cardinalities. third_central_moment_zero applies parts_distribution_symmetric with g(k) = ((k : ℚ) − (n+1)/2)³, shows the reflected term equals the negative of the original (Nat.cast_sub plus ring), and concludes the sum is its own negative, hence 0, by linarith.",
+    "keyInsights": [
+      "**Symmetry is structural, not just numerical.** parts_distribution_symmetric proves ∑_c g(c.length) = ∑_c g(n+1−c.length) for EVERY weight g, via the complement involution s ↦ sᶜ on the gap subsets. This is the graded incarnation of the binomial symmetry C(n−1,k−1) = C(n−1,n−k): complementing the set of cut gaps sends a k-part composition to an (n+1−k)-part one. Every odd central moment vanishes as a corollary; the third is only the first instance.",
+      "**Zero skewness in one line from symmetry.** Once the distribution is known symmetric about (n+1)/2, the odd centred weight g(k) = (k − (n+1)/2)³ satisfies g(n+1−k) = −g(k), so the third central moment equals its own negative and is therefore 0 — no cubic sum needed for the skewness itself. The explicit third moment (n³+6n²+3n−2)·2^(n−3) is computed separately for its own sake.",
+      "**8∑ k³C(m,k) = m²(m+3)2^m from a single absorption.** The cubic binomial core is proved by applying (k+1)·C(m,k+1) = m·C(m−1,k) once, lowering k³ to (k+1)² inside an (m−1)-binomial and reducing the third-moment sum to the family's second- and first-moment sums plus the plain binomial sum. Stating it times 8 sidesteps the truncated ℕ-subtraction in the exact form.",
+      "**Mathlib stops at ∑ C(m,k) = 2^m.** Neither the weighted binomial sums ∑ k^j C(m,k) for j ≥ 1 nor any moment or symmetry of the part-count of a composition is in Mathlib; the cubic identity, the third moment, the distribution symmetry, and the vanishing skewness are all original content, completing the family's moment analysis begun with the mean and variance."
+    ],
+    "prerequisites": [
+      "Compositions of a natural number (Mathlib's Composition n), the number of parts c.length, and the gap bijection gapsEquiv : Composition n ≃ Finset (Fin (n−1)) with the bridge length c = (gaps c).card + 1 (from the family's earlier entries)",
+      "Finite-sum reindexing along an equivalence (Equiv.sum_comp), the powerset-by-cardinality grouping Finset.sum_powerset_apply_card, and reindexing by an involution such as the set complement s ↦ sᶜ",
+      "Binomial identities: the absorption rule Nat.add_one_mul_choose_eq, ∑_{j=0}^m C(m,j) = 2^m (Nat.sum_range_choose), and the family's first- and second-moment sums ∑ k·C(m,k) = m·2^(m−1) and 4∑ k²·C(m,k) = m(m+1)2^m",
+      "Central moments and skewness: the third central moment E[(X − μ)³], and the fact that a distribution symmetric about its mean has all odd central moments zero"
+    ]
+  },
+  "sections": [
+    {
+      "id": "third-moment-binomial",
+      "title": "The Third-Moment Binomial Sum (Double Absorption)",
+      "startLine": 64,
+      "endLine": 120,
+      "mathContext": "$8\\sum_{k} k^3\\binom{m}{k} = m^2(m+3)2^m$ and $8\\sum_{s \\subseteq \\mathrm{Fin}\\,m} \\#s^3 = m^2(m+3)2^m$.",
+      "summary": "sum_choose_mul_cube proves 8·∑_{k=0}^m k³·C(m,k) = m²(m+3)2^m by peeling the k = 0 term (Finset.sum_range_succ') and applying the absorption identity (k+1)·C(m,k+1) = m·C(m−1,k) (Nat.add_one_mul_choose_eq) once, lowering the k³-sum to (m+1)·∑_k C(m,k)·(k+1)²; expanding (k+1)² = k² + 2k + 1 reduces it to the family's second-moment sum (4∑k²C = m(m+1)2^m), first-moment sum (∑kC = m·2^(m−1)) and Nat.sum_range_choose (∑C = 2^m), and a final case split plus ring closes. The factor 8 keeps the identity in ℕ for all m. sum_finset_card_cube transports this to the subset sum ∑_{s ⊆ Fin m} |s|³ via Finset.powerset_univ and Finset.sum_powerset_apply_card."
+    },
+    {
+      "id": "third-moment",
+      "title": "The Third Moment of the Number of Parts",
+      "startLine": 122,
+      "endLine": 164,
+      "mathContext": "$8\\sum_{c} (c.\\mathrm{length})^3 + 2^n = (n^3 + 6n^2 + 3n)2^{n-1}$ for $n \\ge 1$.",
+      "summary": "third_moment rewrites ∑_c c.length³ through length_eq_card_gaps as ∑_c ((gapsEquiv n c).card + 1)³, reindexes by Equiv.sum_comp to ∑_{s : Finset (Fin (n−1))} (|s|+1)³, expands (|s|+1)³ = |s|³ + 3|s|² + 3|s| + 1, and combines the four subset sums — sum_finset_card_cube, the sibling's sum_finset_card_sq, the parent's sum_finset_card, and the count 2^(n−1) — to give (n³+6n²+3n)2^(n−1) − 2^n by ring after substituting n = M + 1. The +2^n on the left clears the constant −2 of the raw closed form (n³+6n²+3n−2)·2^(n−3), keeping the statement in ℕ."
+    },
+    {
+      "id": "symmetry-and-skewness",
+      "title": "Distribution Symmetry and the Vanishing Third Central Moment",
+      "startLine": 165,
+      "endLine": 227,
+      "mathContext": "$\\sum_c g(c.\\mathrm{length}) = \\sum_c g(n{+}1 - c.\\mathrm{length})$ for any $g$; hence $\\sum_c (c.\\mathrm{length} - \\tfrac{n+1}{2})^3 = 0$.",
+      "summary": "parts_distribution_symmetric transports both ∑_c g(c.length) and ∑_c g(n+1−c.length) to sums over Finset (Fin (n−1)) via gapsEquiv and length_eq_card_gaps, then reindexes the second by the complement involution e : s ↦ sᶜ (built as an Equiv from compl_compl). Since |sᶜ| = (n−1) − |s| (Finset.card_compl), a composition with |s|+1 parts is exchanged with one with n − |s| = (n+1) − (|s|+1) parts, and omega matches the arguments. third_central_moment_zero specialises to the odd centred weight g(k) = ((k:ℚ) − (n+1)/2)³: the reflected term equals −g(c.length) (Nat.cast_sub with c.length ≤ n, then ring), so the sum equals its own negation and linarith gives 0."
+    }
+  ],
+  "conclusion": {
+    "summary": "Across all $2^{n-1}$ compositions of $n \\ge 1$, the third moment, the full distribution symmetry, and the skewness of the number of parts are formalised sorry-free and axiom-free. The total of the cubed part-counts is $8\\sum_c (c.\\mathrm{length})^3 + 2^n = (n^3+6n^2+3n)2^{n-1}$ (`third_moment`); the part-count distribution satisfies $\\sum_c g(c.\\mathrm{length}) = \\sum_c g(n{+}1 - c.\\mathrm{length})$ for every weight $g$ (`parts_distribution_symmetric`); and the third central moment vanishes, $\\sum_c (c.\\mathrm{length} - \\tfrac{n+1}{2})^3 = 0$ (`third_central_moment_zero`) — the skewness is exactly zero, as befits the $1 + \\mathrm{Binomial}(n-1, 1/2)$ part-count.",
+    "implications": "The content beyond Mathlib is the cubic binomial identity $8\\sum_k k^3\\binom{m}{k} = m^2(m+3)2^m$ (`sum_choose_mul_cube`), proved by a single absorption step that reduces it to the family's second- and first-moment sums, and — more importantly — the structural theorem `parts_distribution_symmetric`, which via the cut-set complement involution shows the entire part-count distribution is symmetric about its mean $(n+1)/2$. That symmetry is the graded incarnation of $\\binom{n-1}{k-1} = \\binom{n-1}{n-k}$ and immediately forces every odd central moment to vanish, of which the third is the first case. Together with the family's count $2^{n-1}$, graded count $\\binom{n-1}{k-1}$, mean $(n+1)/2$, and variance $(n-1)/4$, this completes the elementary moment description of the part-count distribution by pure combinatorial transport, recovering the shifted-Binomial's zero skewness with no probability theory.",
+    "openQuestions": [
+      "Does the same complement-involution argument, combined with an even-moment binomial sum $\\sum_k k^4\\binom{m}{k}$, give the fourth moment and hence the kurtosis of the part-count — and does the general even moment admit a closed form via repeated absorption?",
+      "Is there an analogous symmetry and moment structure for the *largest part* or the *number of distinct part-sizes* of a random composition, or does the gap-bijection transport break down for statistics that are not additive over the cut structure?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "composition-parts-choose-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Direct predecessor: computes the second moment and variance (n−1)/4, and its open questions explicitly ask for the third moment / skewness. This entry answers that — the cubic binomial identity 8∑ k³C = m²(m+3)2^m gives the third moment, and the complement involution forces the third central moment to be exactly 0."
+    },
+    {
+      "proofId": "composition-parts-choose-oq-01-oq-01",
+      "relationship": "builds-on",
+      "description": "First-moment parent: the mean number of parts (n+1)/2 — the centre about which parts_distribution_symmetric shows the whole part-count distribution is symmetric."
+    },
+    {
+      "proofId": "composition-parts-choose-oq-01",
+      "relationship": "builds-on",
+      "description": "Grandparent: the part-graded count C(n−1, k−1) of compositions of n into exactly k parts. The symmetry theorem is the graded form of C(n−1,k−1) = C(n−1,n−k), realised by complementing the set of cut gaps."
+    },
+    {
+      "proofId": "composition-card-2pow-oq-01",
+      "relationship": "foundational",
+      "description": "Great-grandparent: the ungraded total card (Composition n) = 2^(n−1), the number of compositions summed over in every moment."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry answering the **open question of sibling `composition-parts-choose-oq-01-oq-01-oq-01`** (which computed the second moment/variance and explicitly asked for the third moment / skewness of the part-count of a random composition of `n`).

A composition of `n` is an ordered tuple of positive integers summing to `n` (`Composition n`); its part-count `c.length` is distributed as `1 + Binomial(n−1, ½)`. This entry completes the family's moment analysis:

| thm | statement |
|-----|-----------|
| `sum_choose_mul_cube` | `8·∑_k C(m,k)·k³ = m²(m+3)·2^m` — cubic binomial identity by **double absorption** (`Nat.add_one_mul_choose_eq`) |
| `sum_finset_card_cube` | subset form `8·∑_{s⊆Fin m} \|s\|³ = m²(m+3)2^m` |
| `third_moment` | `8·∑_c (c.length)³ + 2^n = (n³+6n²+3n)·2^(n−1)` (n ≥ 1) |
| `parts_distribution_symmetric` | **structural**: `∑_c g(c.length) = ∑_c g(n+1−c.length)` for *any* `g`, via the cut-set **complement involution** `s ↦ sᶜ` — the graded form of `C(n−1,k−1)=C(n−1,n−k)` |
| `third_central_moment_zero` | `∑_c (c.length − (n+1)/2)³ = 0` — **zero skewness**, one line from symmetry; kills every odd central moment |

Engine: the gap bijection `gapsEquiv : Composition n ≃ Finset (Fin (n−1))` + `length = |gaps|+1` (transport with `Equiv.sum_comp`), reusing the family's first/second-moment binomial and subset sums.

## Verification
- **0 axioms** — `#print axioms` on all named theorems yields only `propext / Classical.choice / Quot.sound`.
- 0 sorries, no `native_decide`.
- Typechecked against Mathlib via `lake env lean` (228 lines, 5 theorems, 0 defs).

## Files
- `proofs/Proofs/CompositionPartsChooseOQ01OQ03.lean`
- `src/data/proofs/composition-parts-choose-oq-01-oq-03/{meta,annotations}.json`, `index.ts`
- `research/problems/composition-parts-choose-oq-01-oq-03/knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)