### PR TITLE
Enrich Feuerbach Orthocentric System (feuerbachs-theorem-defs-oq-01-oq-01-oq-02): fix conclusion schema

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-02/meta.json
@@ -139,8 +139,8 @@
   ],
   "conclusion": {
     "summary": "Establishes the orthocentric system that the concurrency, metric, and reflection strands of the orthocenter sub-line left implicit: the four-point set {A, B, C, H} is symmetric, each point being the orthocenter of the triangle on the other three. The deep-looking symmetry reduces entirely to the three perpendicular-bisector relations of the circumcenter — one linear_combination per perpendicularity — and a 2×2 Cramer argument upgrades the memberships to a uniqueness statement identifying THE orthocenter. As a structural consequence the six connector midpoints of the system share one nine-point circle, and an acute worked example exhibits a genuine, non-collapsed configuration.",
-    "significance": "Completes the conceptual picture of the orthocenter begun by the concurrency entry: beyond existing and being measured, the orthocenter is the fourth point of a symmetric four-point system, which is the natural home of the nine-point circle and the reflection facts proved earlier in the strand.",
-    "futureDirections": [
+    "implications": "Completes the conceptual picture of the orthocenter begun by the concurrency entry: beyond existing and being measured, the orthocenter is the fourth point of a symmetric four-point system, which is the natural home of the nine-point circle and the reflection facts proved earlier in the strand. The reduction of the whole symmetry to the circumcenter's three perpendicular-bisector relations (one linear_combination each) is a reusable template for the strand's remaining incidence results.",
+    "openQuestions": [
       "Identify the common nine-point centre N as the circumcenter of the medial-type configuration shared by all four triangles of the system, and prove the four circumcircles are congruent (all radius R).",
       "Show the de Longchamps point (reflection of H over O) is the orthocenter of the anticomplementary triangle, extending the system outward.",
       "Formalize that the four triangles of an orthocentric system have a common nine-point circle as an equality of circles, not just a shared six-point incidence."


### PR DESCRIPTION
Fixes the `conclusion` schema: renames the non-schema fields `significance`→`implications` (the required `ProofConclusion` field, previously absent so the conclusion under-rendered) and `futureDirections`→`openQuestions` (3 items preserved). The `implications` text is slightly deepened with the reusable perpendicular-bisector template note. No mathematical content changed; meta.json valid, ~19 KB (under caps).