### PR TITLE
research(pythagorean-triples-oq-04-oq-04): sums of three & four squares — Lagrange + Legendre obstruction [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ04OQ04.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ04OQ04.lean
@@ -1,0 +1,170 @@
+import Mathlib.NumberTheory.SumFourSquares
+import Mathlib.Tactic
+
+/-
+# Sums of Three and Four Squares: Lagrange's Theorem and Legendre's Obstruction
+  (pythagorean-triples-oq-04-oq-04)
+
+The two-square theorem (parent `pythagorean-triples-oq-04`) tells us *exactly*
+which numbers are sums of two squares, and the answer is governed by a
+congruence obstruction mod 4. This file extends the story to **three** and
+**four** squares and contrasts their obstruction patterns.
+
+The picture sharpens dramatically as the number of squares grows:
+
+  * **Four squares — no obstruction at all.** Lagrange's four-square theorem
+    (1770) says *every* natural number is a sum of four squares. We package
+    Mathlib's `Nat.sum_four_squares` as `sum_four_squares`. There is no
+    congruence class that four squares cannot reach.
+
+  * **Three squares — a genuine obstruction.** Legendre's three-square theorem
+    says `n` is a sum of three squares **iff** `n` is *not* of the form
+    `4^a (8b + 7)`. The hard *sufficiency* direction (every other number *is*
+    a sum of three squares) needs the deep theory of ternary quadratic forms
+    and is left open here. But the **necessity** direction — that no number of
+    the form `4^a (8b + 7)` is a sum of three squares — is completely
+    elementary, and we prove it here from scratch:
+      - squares are `0, 1, 4` mod `8`, so a sum of three squares is never
+        `7` mod `8` (this kills the base case `a = 0`);
+      - a `4`-power descent: if `4n` is a sum of three squares then so is `n`
+        (all three squares must be even), which strips the powers of `4`.
+
+So the contrast is: **two squares** ↦ obstruction mod 4 (`n ≡ 3`),
+**three squares** ↦ obstruction `4^a(8b+7)`, **four squares** ↦ no obstruction.
+
+Status: 0 axioms, 0 sorries (necessity direction of Legendre; Lagrange in full).
+-/
+
+namespace PythagoreanTriplesOQ04OQ04
+
+/-- `n` is a sum of three squares. -/
+def IsSumThreeSquares (n : ℕ) : Prop := ∃ a b c : ℕ, a ^ 2 + b ^ 2 + c ^ 2 = n
+
+-- ============================================================================
+-- Part I: Lagrange's four-square theorem — no obstruction
+-- ============================================================================
+
+/-- **Lagrange's four-square theorem.** Every natural number is a sum of four
+squares. Packaged from Mathlib's `Nat.sum_four_squares`, whose proof runs through
+the arithmetic of the quaternions / the descent of Euler's four-square identity.
+The point of stating it here is the *contrast*: unlike two or three squares,
+four squares have **no** congruence obstruction whatsoever. -/
+theorem sum_four_squares (n : ℕ) :
+    ∃ a b c d : ℕ, a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 = n :=
+  Nat.sum_four_squares n
+
+-- ============================================================================
+-- Part II: The mod-8 obstruction (base case of Legendre necessity)
+-- ============================================================================
+
+/-- A perfect square is `0`, `1`, or `4` modulo `8`. -/
+theorem sq_mod_eight (n : ℕ) : n ^ 2 % 8 = 0 ∨ n ^ 2 % 8 = 1 ∨ n ^ 2 % 8 = 4 := by
+  have e : n ^ 2 % 8 = (n % 8) ^ 2 % 8 := by rw [Nat.pow_mod]
+  have h : n % 8 < 8 := Nat.mod_lt _ (by norm_num)
+  interval_cases (n % 8) <;> simp_all
+
+/-- **The mod-8 obstruction.** A sum of three squares is never congruent to `7`
+modulo `8`: each square contributes `0`, `1`, or `4`, and no three of those sum
+to `7` mod `8`. This is the base-case heart of Legendre's necessity direction. -/
+theorem sum_three_squares_mod_eight_ne_seven (a b c : ℕ) :
+    (a ^ 2 + b ^ 2 + c ^ 2) % 8 ≠ 7 := by
+  have ha := sq_mod_eight a
+  have hb := sq_mod_eight b
+  have hc := sq_mod_eight c
+  omega
+
+-- ============================================================================
+-- Part III: The 4-power descent
+-- ============================================================================
+
+/-- A perfect square is `0` or `1` modulo `4`. -/
+theorem sq_mod_four (n : ℕ) : n ^ 2 % 4 = 0 ∨ n ^ 2 % 4 = 1 := by
+  have e : n ^ 2 % 4 = (n % 4) ^ 2 % 4 := by rw [Nat.pow_mod]
+  have h : n % 4 < 4 := Nat.mod_lt _ (by norm_num)
+  interval_cases (n % 4) <;> simp_all
+
+/-- If a square is `0` mod `4`, its root is even. (An odd number squared is
+`1` mod `4`.) -/
+theorem two_dvd_of_sq_mod_four_eq_zero {n : ℕ} (h : n ^ 2 % 4 = 0) : 2 ∣ n := by
+  rcases Nat.even_or_odd n with he | ho
+  · obtain ⟨r, rfl⟩ := he
+    exact ⟨r, by ring⟩
+  · exfalso
+    obtain ⟨k, rfl⟩ := ho
+    have hsq : (2 * k + 1) ^ 2 = 4 * (k ^ 2 + k) + 1 := by ring
+    rw [hsq] at h
+    omega
+
+/-- **The 4-power descent.** If `4 * n` is a sum of three squares, then so is `n`.
+Because `4n ≡ 0 (mod 4)` forces each of the three squares to be `0 (mod 4)`, so
+all three roots are even; halving each root divides the total by `4`. -/
+theorem three_squares_descent {n : ℕ} (h : IsSumThreeSquares (4 * n)) :
+    IsSumThreeSquares n := by
+  obtain ⟨a, b, c, habc⟩ := h
+  -- Each square is 0 mod 4 because their sum is 4n ≡ 0 mod 4.
+  have ha4 : a ^ 2 % 4 = 0 := by
+    have := sq_mod_four a; have := sq_mod_four b; have := sq_mod_four c; omega
+  have hb4 : b ^ 2 % 4 = 0 := by
+    have := sq_mod_four a; have := sq_mod_four b; have := sq_mod_four c; omega
+  have hc4 : c ^ 2 % 4 = 0 := by
+    have := sq_mod_four a; have := sq_mod_four b; have := sq_mod_four c; omega
+  -- Hence each root is even.
+  obtain ⟨a', rfl⟩ := two_dvd_of_sq_mod_four_eq_zero ha4
+  obtain ⟨b', rfl⟩ := two_dvd_of_sq_mod_four_eq_zero hb4
+  obtain ⟨c', rfl⟩ := two_dvd_of_sq_mod_four_eq_zero hc4
+  refine ⟨a', b', c', ?_⟩
+  -- 4 * (a'² + b'² + c'²) = 4 * n, cancel the 4.
+  have key : 4 * (a' ^ 2 + b' ^ 2 + c' ^ 2) = 4 * n := by rw [← habc]; ring
+  exact Nat.eq_of_mul_eq_mul_left (by norm_num) key
+
+-- ============================================================================
+-- Part IV: Legendre's obstruction (necessity direction)
+-- ============================================================================
+
+/-- **Legendre's obstruction (necessity direction).** No number of the form
+`4^a (8b + 7)` is a sum of three squares.
+
+Proof by induction on `a`. The base case `a = 0` is the mod-8 obstruction:
+`8b + 7 ≡ 7 (mod 8)`. The inductive step strips one factor of `4` via the descent
+lemma: `4^(a+1)(8b+7) = 4 · 4^a(8b+7)`, and if the left side were a sum of three
+squares the descent would make `4^a(8b+7)` one too, contradicting the hypothesis. -/
+theorem not_sum_three_squares_legendre (a b : ℕ) :
+    ¬ IsSumThreeSquares (4 ^ a * (8 * b + 7)) := by
+  induction a with
+  | zero =>
+    rw [pow_zero, one_mul]
+    rintro ⟨x, y, z, hxyz⟩
+    have h7 : (x ^ 2 + y ^ 2 + z ^ 2) % 8 = 7 := by rw [hxyz]; omega
+    exact sum_three_squares_mod_eight_ne_seven x y z h7
+  | succ k ih =>
+    intro h
+    apply ih
+    apply three_squares_descent
+    rwa [show 4 ^ (k + 1) * (8 * b + 7) = 4 * (4 ^ k * (8 * b + 7)) by ring] at h
+
+-- ============================================================================
+-- Part V: Contrast in a single number — 7
+-- ============================================================================
+
+/-- `7` is **not** a sum of three squares (the smallest such number): it is the
+`a = 0, b = 0` case of Legendre's obstruction. -/
+theorem seven_not_sum_three_squares : ¬ IsSumThreeSquares 7 := by
+  have := not_sum_three_squares_legendre 0 0
+  simpa using this
+
+/-- Yet `7` **is** a sum of four squares: `7 = 2² + 1² + 1² + 1²`. This exhibits
+the exact gap between the three-square obstruction and Lagrange's four squares. -/
+theorem seven_sum_four_squares : ∃ a b c d : ℕ, a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 = 7 :=
+  ⟨2, 1, 1, 1, by norm_num⟩
+
+/-- The three-square obstruction is nonempty at every scale: for each `a`, the
+number `4^a · 7` is not a sum of three squares, but (by Lagrange) is a sum of
+four squares. -/
+theorem obstruction_persists (a : ℕ) :
+    ¬ IsSumThreeSquares (4 ^ a * 7) ∧
+      (∃ w x y z : ℕ, w ^ 2 + x ^ 2 + y ^ 2 + z ^ 2 = 4 ^ a * 7) := by
+  refine ⟨?_, sum_four_squares _⟩
+  have := not_sum_three_squares_legendre a 0
+  simpa using this
+
+end PythagoreanTriplesOQ04OQ04

--- a/src/data/proofs/pythagorean-triples-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-04-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "pythagorean-triples-oq-04-oq-04",
+    "range": { "startLine": 4, "endLine": 37 },
+    "type": "concept",
+    "title": "Two → Three → Four Squares: A Weakening Obstruction",
+    "content": "The parent entry characterized which primes are sums of two squares, governed by an obstruction mod 4. This file extends the story: four squares always suffice (Lagrange — no obstruction at all), while three squares carry the obstruction 4^a(8b+7). The file proves Lagrange in full (via Mathlib) and the elementary necessity direction of Legendre's three-square theorem from scratch, leaving the deep sufficiency direction open.",
+    "mathContext": "Two squares: obstruction mod $4$ ($n\\not\\equiv 3$). Three squares: $n$ representable iff $n \\ne 4^a(8b+7)$. Four squares: $\\forall n,\\ n = a^2+b^2+c^2+d^2$ (Lagrange).",
+    "significance": "key",
+    "relatedConcepts": ["sum of squares", "Lagrange four-square theorem", "Legendre three-square theorem", "Waring's problem"],
+    "prerequisites": ["squares mod 4 and mod 8", "infinite descent"]
+  },
+  {
+    "id": "ann-four-squares",
+    "proofId": "pythagorean-triples-oq-04-oq-04",
+    "range": { "startLine": 52, "endLine": 54 },
+    "type": "theorem",
+    "title": "Lagrange's Four-Square Theorem",
+    "content": "Every natural number is a sum of four squares, packaged from Mathlib's Nat.sum_four_squares. The point is the contrast: unlike two or three squares, four squares reach every congruence class — there is no obstruction.",
+    "mathContext": "$\\forall n \\in \\mathbb{N},\\ \\exists a,b,c,d,\\ a^2+b^2+c^2+d^2 = n.$",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange four-square theorem", "no obstruction"],
+    "prerequisites": ["Euler four-square identity", "descent"]
+  },
+  {
+    "id": "ann-sq-mod-eight",
+    "proofId": "pythagorean-triples-oq-04-oq-04",
+    "range": { "startLine": 61, "endLine": 67 },
+    "type": "theorem",
+    "title": "Squares mod 8 land in {0, 1, 4}",
+    "content": "A perfect square is 0, 1, or 4 modulo 8. Proved by reducing n² mod 8 to (n mod 8)² mod 8 via Nat.pow_mod and checking the eight residues with interval_cases. This is the arithmetic input for the base case of Legendre's necessity direction.",
+    "mathContext": "$n^2 \\bmod 8 \\in \\{0,1,4\\}$ for all $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic residues mod 8"],
+    "prerequisites": ["Nat.pow_mod", "interval_cases"]
+  },
+  {
+    "id": "ann-mod-eight-obstruction",
+    "proofId": "pythagorean-triples-oq-04-oq-04",
+    "range": { "startLine": 69, "endLine": 74 },
+    "type": "theorem",
+    "title": "A Sum of Three Squares Is Never 7 mod 8",
+    "content": "Since each square is 0, 1, or 4 mod 8, no three of them sum to 7 mod 8. The three residue disjunctions are handed to omega, which closes all 27 combinations. This is the base-case obstruction (a = 0) of Legendre's theorem.",
+    "mathContext": "$(a^2+b^2+c^2) \\bmod 8 \\ne 7.$",
+    "significance": "key",
+    "relatedConcepts": ["local obstruction", "ternary quadratic form"],
+    "prerequisites": ["squares mod 8", "omega"]
+  },
+  {
+    "id": "ann-descent",
+    "proofId": "pythagorean-triples-oq-04-oq-04",
+    "range": { "startLine": 101, "endLine": 118 },
+    "type": "theorem",
+    "title": "The 4-Power Descent",
+    "content": "If 4n is a sum of three squares, then so is n. Because 4n ≡ 0 mod 4 and squares are 0 or 1 mod 4, all three squares must be 0 mod 4 (via omega on the residues), so all three roots are even (two_dvd_of_sq_mod_four_eq_zero); halving each root divides the total by exactly 4. This makes the powers of 4 in the obstruction scale-invariant.",
+    "mathContext": "$\\text{IsSumThreeSquares}(4n) \\implies \\text{IsSumThreeSquares}(n).$",
+    "significance": "key",
+    "relatedConcepts": ["infinite descent", "even roots", "scale invariance"],
+    "prerequisites": ["squares mod 4", "divisibility by 2", "Nat.eq_of_mul_eq_mul_left"]
+  },
+  {
+    "id": "ann-legendre-necessity",
+    "proofId": "pythagorean-triples-oq-04-oq-04",
+    "range": { "startLine": 131, "endLine": 143 },
+    "type": "theorem",
+    "title": "Legendre's Obstruction (Necessity Direction)",
+    "content": "No number of the form 4^a(8b+7) is a sum of three squares. Induction on a: the base case a=0 is the mod-8 obstruction (8b+7 ≡ 7 mod 8); the inductive step rewrites 4^(a+1)(8b+7) = 4·4^a(8b+7) and applies the descent lemma to contradict the induction hypothesis. The sufficiency converse (every other n is representable) is the deep part, left open.",
+    "mathContext": "$\\neg\\,\\text{IsSumThreeSquares}(4^a(8b+7)).$",
+    "significance": "key",
+    "relatedConcepts": ["Legendre three-square theorem", "descent", "local obstruction"],
+    "prerequisites": ["mod-8 obstruction", "4-power descent", "induction"]
+  },
+  {
+    "id": "ann-contrast",
+    "proofId": "pythagorean-triples-oq-04-oq-04",
+    "range": { "startLine": 151, "endLine": 169 },
+    "type": "concept",
+    "title": "The Contrast at 7 and Every Scale",
+    "content": "7 is the smallest number that is not a sum of three squares (a=0, b=0), yet 7 = 2²+1²+1²+1² is a sum of four squares. obstruction_persists generalizes: for every a, the number 4^a·7 evades three squares but Lagrange still writes it as four — the obstruction and its dissolution exhibited at every scale.",
+    "mathContext": "$\\neg\\,\\text{IsSumThreeSquares}(4^a\\cdot 7) \\ \\wedge\\ \\exists w,x,y,z,\\ w^2+x^2+y^2+z^2 = 4^a\\cdot 7.$",
+    "significance": "supporting",
+    "relatedConcepts": ["smallest counterexample", "four-square witness"],
+    "prerequisites": ["Legendre necessity", "Lagrange four-square theorem"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-04-oq-04/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-04-oq-04/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "pythagorean-triples-oq-04-oq-04",
+  "title": "Pythagorean Triples OQ-04-OQ-04: Sums of Three and Four Squares — Lagrange's Theorem and Legendre's Obstruction",
+  "slug": "pythagorean-triples-oq-04-oq-04",
+  "description": "Extends the two-square story to three and four squares and contrasts their obstruction patterns. Lagrange's four-square theorem (packaged from Mathlib's Nat.sum_four_squares) says every natural number is a sum of four squares — no obstruction. For three squares, the necessity direction of Legendre's theorem is proved from scratch: no number of the form 4^a(8b+7) is a sum of three squares, via the mod-8 fact that a sum of three squares is never 7 mod 8 plus a 4-power descent. The hard sufficiency direction of Legendre is left open. 10 theorems, 1 definition, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ04OQ04.lean",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "sum-of-squares",
+      "lagrange-four-squares",
+      "legendre-three-squares",
+      "modular-arithmetic",
+      "descent"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Lagrange's four-square theorem reuses Mathlib's Nat.sum_four_squares; the mod-8 obstruction, the 4-power descent, and the necessity direction of Legendre's three-square theorem are proved from scratch. Depends only on propext, Classical.choice, and Quot.sound. The sufficiency direction of Legendre's theorem is not claimed (left as an open question).",
+    "lineCount": 170,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "originalContributions": [
+      "sq_mod_eight: a perfect square is 0, 1, or 4 modulo 8 (via Nat.pow_mod + interval_cases on n mod 8)",
+      "sum_three_squares_mod_eight_ne_seven: a sum of three squares is never 7 mod 8 — the base-case obstruction of Legendre's theorem, discharged by omega from the mod-8 residues",
+      "three_squares_descent: if 4n is a sum of three squares then so is n, because 4n ≡ 0 mod 4 forces all three roots even (proved via two_dvd_of_sq_mod_four_eq_zero)",
+      "not_sum_three_squares_legendre: the full necessity direction — no number 4^a(8b+7) is a sum of three squares, by induction on a using the base case and the descent",
+      "obstruction_persists: for every a, the number 4^a·7 is not a sum of three squares yet is a sum of four squares — the obstruction contrasted with Lagrange at every scale"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The question of how many squares are needed to represent every integer was answered in stages. Fermat and Euler settled the prime case for two squares; Lagrange proved in 1770 that four squares always suffice (his four-square theorem), completing a claim of Bachet and Diophantus. Three squares are more subtle: Legendre (1797–1798) and Gauss (Disquisitiones, 1801) proved that a positive integer is a sum of three squares if and only if it is not of the form 4^a(8b+7). The three-square theorem is genuinely deeper than either neighbor — its sufficiency direction rests on the theory of ternary quadratic forms and (in Gauss's hands) on the class number of binary forms — while its necessity direction is an elementary congruence argument. The progression two → three → four squares is the classical prototype of Waring's problem.",
+    "problemStatement": "Extend the two-square theorem to three and four squares and contrast the obstruction patterns: prove Lagrange's four-square theorem (every n is a sum of four squares, no obstruction) and the necessity direction of Legendre's three-square theorem (no 4^a(8b+7) is a sum of three squares).",
+    "text": "As the number of allowed squares grows, the obstruction to representability weakens and then vanishes. Two squares: n is representable only if no prime ≡ 3 (mod 4) divides n to an odd power; the local obstruction is mod 4. Three squares: the only obstruction is that n must not be 4^a(8b+7) — equivalently, after removing all factors of 4, n must not be 7 mod 8. Four squares: there is no obstruction at all — every natural number is a sum of four squares (Lagrange). This file formalizes the two endpoints of that contrast that admit elementary or Mathlib-backed proofs: Lagrange in full (via Nat.sum_four_squares), and the necessity half of Legendre from scratch. The heart of the Legendre necessity argument is that squares are 0, 1, or 4 modulo 8, so three of them never sum to 7 mod 8; a descent argument then removes powers of 4, since 4n being a sum of three squares forces all three roots even.",
+    "proofStrategy": "Package Lagrange as sum_four_squares := Nat.sum_four_squares. For Legendre necessity, first prove sq_mod_eight (square ≡ 0,1,4 mod 8) by Nat.pow_mod + interval_cases, then sum_three_squares_mod_eight_ne_seven by feeding the three residue disjunctions to omega. Build the descent: sq_mod_four gives square ≡ 0,1 mod 4; two_dvd_of_sq_mod_four_eq_zero shows a square ≡ 0 mod 4 has an even root; three_squares_descent deduces from a²+b²+c²=4n that a,b,c are all even and halves them to get a sum of three squares equal to n. Finally not_sum_three_squares_legendre inducts on a: the base case a=0 is the mod-8 obstruction (8b+7 ≡ 7 mod 8), and the step rewrites 4^(a+1)(8b+7) = 4·4^a(8b+7) and applies the descent against the induction hypothesis.",
+    "keyInsights": [
+      "The obstruction pattern strictly weakens with the number of squares: mod-4 for two squares, the 4^a(8b+7) form for three, and nothing at all for four — a clean illustration of representability improving as degrees of freedom increase",
+      "Legendre's theorem splits like Fermat's: the necessity (obstruction) direction is completely elementary — squares mod 8 land in {0,1,4}, missing 7 for a triple sum — while the sufficiency direction needs the deep theory of ternary quadratic forms",
+      "The powers of 4 in 4^a(8b+7) come from an exact descent, not a coincidence: 4n a sum of three squares forces each square ≡ 0 mod 4, hence each root even, so the whole configuration halves — the obstruction is scale-invariant",
+      "Lagrange's four-square theorem removes the obstruction entirely; witnessing it via Nat.sum_four_squares lets us exhibit, for every 4^a·7 (never three squares), an explicit four-square representation"
+    ],
+    "prerequisites": [
+      "Modular arithmetic: residues of squares mod 4 and mod 8",
+      "Lagrange's four-square theorem (Nat.sum_four_squares)",
+      "Proof by infinite descent / strong induction on the exponent of 4",
+      "Legendre's three-square theorem (background for the open sufficiency direction)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Machine-verified extension of the sums-of-squares story to three and four squares. Lagrange's four-square theorem is packaged from Mathlib (every natural number is a sum of four squares — no obstruction). The necessity direction of Legendre's three-square theorem is proved from scratch: no number of the form 4^a(8b+7) is a sum of three squares, via the mod-8 obstruction (a sum of three squares is never 7 mod 8) together with a 4-power descent. Zero axioms, zero sorries. The sufficiency direction of Legendre is left open.",
+    "implications": "The two → three → four squares progression is the classical seed of Waring's problem: g(2)=4, with three squares already exhibiting a genuine congruence obstruction that four squares dissolve. The 4^a(8b+7) obstruction is the local (2-adic) obstruction to representability by the ternary form x²+y²+z², and its elementary necessity proof is the prototype of a local obstruction to a global quadratic-form question. The sufficiency direction — the content left open here — is equivalent to the statement that the ternary form represents every eligible integer, and is tied to the class number of binary quadratic forms and, via Gauss, to the count r₃(n) of representations.",
+    "openQuestions": [
+      "Formalize the sufficiency direction of Legendre's three-square theorem: every n not of the form 4^a(8b+7) is a sum of three squares (needs ternary quadratic forms / the Hasse–Minkowski local-global principle)",
+      "Prove that removing all factors of 4 from n leaves a number ≢ 7 (mod 8) exactly when n is a sum of three squares, packaging necessity and sufficiency as a decidable criterion",
+      "Relate the count r₄(n) of four-square representations to the sum of divisors (Jacobi's four-square theorem, r₄(n) = 8·σ(n) for odd n) and r₃(n) to class numbers (Gauss)",
+      "Extend to Waring's problem for higher powers: bounds on g(k) and G(k) for sums of k-th powers"
+    ]
+  },
+  "leanFile": {
+    "namespace": "PythagoreanTriplesOQ04OQ04",
+    "lineCount": 170,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/PythagoreanTriplesOQ04OQ04.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples-oq-04",
+      "relationship": "extends",
+      "description": "The parent entry proves Fermat's two-square theorem for primes and isolates the mod-4 obstruction. This entry answers its open question #4 — extending to three and four squares — and contrasts the mod-4, 4^a(8b+7), and no-obstruction patterns."
+    }
+  ],
+  "sections": [
+    {
+      "id": "four-squares",
+      "title": "Part I: Lagrange's four-square theorem — no obstruction",
+      "startLine": 43,
+      "endLine": 55,
+      "summary": "sum_four_squares packages Mathlib's Nat.sum_four_squares: every natural number is a sum of four squares. Establishes the endpoint of the contrast — four squares have no congruence obstruction whatsoever."
+    },
+    {
+      "id": "mod-eight",
+      "title": "Part II: The mod-8 obstruction",
+      "startLine": 56,
+      "endLine": 75,
+      "summary": "sq_mod_eight (a square is 0, 1, or 4 mod 8, by Nat.pow_mod + interval_cases) and sum_three_squares_mod_eight_ne_seven (a sum of three squares is never 7 mod 8, via omega over the residues). This is the base-case heart of Legendre's necessity direction."
+    },
+    {
+      "id": "descent",
+      "title": "Part III: The 4-power descent",
+      "startLine": 76,
+      "endLine": 119,
+      "summary": "sq_mod_four (square is 0 or 1 mod 4), two_dvd_of_sq_mod_four_eq_zero (a square ≡ 0 mod 4 has an even root), and three_squares_descent: if 4n is a sum of three squares then so is n, because all three roots must be even and halving divides the total by 4."
+    },
+    {
+      "id": "legendre",
+      "title": "Part IV: Legendre's obstruction (necessity)",
+      "startLine": 120,
+      "endLine": 144,
+      "summary": "not_sum_three_squares_legendre: no number 4^a(8b+7) is a sum of three squares. Induction on a — base case is the mod-8 obstruction, the step strips one factor of 4 via the descent lemma against the induction hypothesis."
+    },
+    {
+      "id": "contrast",
+      "title": "Part V: The contrast at 7 and at every scale",
+      "startLine": 145,
+      "endLine": 170,
+      "summary": "seven_not_sum_three_squares (7 is the smallest non-representable number) versus seven_sum_four_squares (7 = 2²+1²+1²+1²), and obstruction_persists: for every a, 4^a·7 is not a sum of three squares yet is a sum of four squares — the obstruction and its absence contrasted at every scale."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry answering **openQuestion #4** of `pythagorean-triples-oq-04` ("Extend to sums of three and four squares (Legendre's and Lagrange's theorems) and contrast the obstruction patterns").

As the number of allowed squares grows, the obstruction to representability strictly weakens:

| squares | obstruction |
|---------|-------------|
| two   | mod 4: `n ≢ 3` |
| three | `n ≠ 4^a(8b+7)` |
| four  | **none** |

This entry formalizes the two endpoints of that contrast that admit clean proofs.

## Results (10 theorems, 1 definition, 170 lines)

- **`sum_four_squares`** — Lagrange's four-square theorem: every `n` is a sum of four squares. Packaged from Mathlib's `Nat.sum_four_squares` (no obstruction whatsoever).
- **Legendre necessity, from scratch:**
  - `sq_mod_eight` — a square is `0, 1, 4` mod 8.
  - `sum_three_squares_mod_eight_ne_seven` — a sum of three squares is never `7` mod 8 (base case).
  - `three_squares_descent` — if `4n` is a sum of three squares then so is `n` (all roots forced even).
  - `not_sum_three_squares_legendre` — **no number `4^a(8b+7)` is a sum of three squares** (induction on `a`).
- **Contrast:** `seven_not_sum_three_squares` vs `seven_sum_four_squares` (`7 = 2²+1²+1²+1²`), and `obstruction_persists` (for every `a`, `4^a·7` evades three squares but Lagrange writes it as four).

The **sufficiency** direction of Legendre (every other `n` *is* a sum of three squares — needs ternary quadratic forms) is left as a stated open question.

## Verification

- ✅ Compiles against Mathlib (`lake env lean`).
- ✅ **0 axioms** — `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- ✅ 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)