### PR TITLE
research(amgm-inequality-oq-02-oq-05): Newton log-concavity for n=4, axiom-free [VERIFIED, 0-axiom, 10thm/9def]

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ05.lean
@@ -1,0 +1,177 @@
+/-
+  Newton's Inequalities for Four Variables — the n=4 Log-Concavity, Axiom-Free
+  Open Question: amgm-inequality-oq-02-oq-05
+
+  Parent: amgm-inequality-oq-02 (Maclaurin's Inequalities via Elementary Symmetric
+  Polynomials), which proves the k=1 Newton inequality from scratch but AXIOMATIZES
+  the general `newton_log_concavity` (Newton's inequalities pₖ² ≥ pₖ₋₁·pₖ₊₁) and,
+  through it, the full Maclaurin chain Mₖ ≥ Mₖ₊₁.
+
+  Sibling: amgm-inequality-oq-02-oq-04 discharges that axiom for n = 3 (both Newton
+  inequalities plus the radical Maclaurin chain M₁ ≥ M₂ ≥ M₃).
+
+  This file DISCHARGES the axiom for the next case, n = 4. There the normalized
+  sequence has FIVE entries p₀, p₁, p₂, p₃, p₄ and log-concavity is THREE distinct
+  inequalities — including a genuine *interior* one (k=2) with no reciprocal symmetry
+  to lean on. All three are proved with zero axioms as exact sum-of-squares
+  certificates, and each holds for ALL real inputs (the parent axiom only asked for
+  non-negative ones — this is strictly stronger). From the endpoints we recover the
+  four-variable AM–GM (a+b+c+d)⁴ ≥ 256·abcd.
+
+  Elementary symmetric polynomials of a, b, c, d:
+    e₁ = a+b+c+d
+    e₂ = ab+ac+ad+bc+bd+cd
+    e₃ = abc+abd+acd+bcd
+    e₄ = abcd
+  Normalized means (pₖ = eₖ / C(4,k),  with C(4,·) = 1,4,6,4,1):
+    p₀ = 1,  p₁ = e₁/4,  p₂ = e₂/6,  p₃ = e₃/4,  p₄ = e₄.
+
+  Newton's inequalities (n = 4), each equivalent to a log-concavity step pₖ² ≥ pₖ₋₁pₖ₊₁:
+    (N1)  p₁² ≥ p₀·p₂   ⟺   3·e₁² ≥ 8·e₂
+    (N2)  p₂² ≥ p₁·p₃   ⟺   4·e₂² ≥ 9·e₁·e₃      (the interior inequality)
+    (N3)  p₃² ≥ p₂·p₄   ⟺   3·e₃² ≥ 8·e₂·e₄
+  Sum-of-squares certificates (all valid for arbitrary reals):
+    3e₁² − 8e₂ = Σ_{i<j}(xᵢ − xⱼ)²
+    3e₃² − 8e₂e₄ = Σ_{i<j}(xᵢ' − xⱼ')²   with xᵢ' the four triple products (dual of N1)
+    4e₂² − 9e₁e₃ = a Gram/Schur combination of the (products-of-two) differences.
+
+  References:
+  - Newton, I. (1707): Arithmetica Universalis.
+  - Maclaurin, C. (1729): A Second Letter to Martin Folkes, Esq.
+  - Hardy–Littlewood–Pólya, "Inequalities" (1934) §2.22.
+  - Brändén–Huh (2020), "Lorentzian polynomials", Ann. of Math. 192 — the modern
+    framework in which Newton log-concavity is the n=4 shadow of a Lorentzian form.
+-/
+
+import Mathlib
+
+namespace AmgmOQ0205
+
+variable (a b c d : ℝ)
+
+/-- First elementary symmetric polynomial e₁ = a+b+c+d. -/
+def e1 : ℝ := a + b + c + d
+
+/-- Second elementary symmetric polynomial e₂ = ab+ac+ad+bc+bd+cd. -/
+def e2 : ℝ := a*b + a*c + a*d + b*c + b*d + c*d
+
+/-- Third elementary symmetric polynomial e₃ = abc+abd+acd+bcd. -/
+def e3 : ℝ := a*b*c + a*b*d + a*c*d + b*c*d
+
+/-- Fourth elementary symmetric polynomial e₄ = abcd. -/
+def e4 : ℝ := a*b*c*d
+
+/-! ### Newton's inequalities as exact sum-of-squares (valid for ALL reals) -/
+
+/-- **Newton N1** (log-concavity at k=1): `3·e₁² ≥ 8·e₂`.
+    Certificate: `3e₁² − 8e₂ = Σ_{i<j}(xᵢ−xⱼ)² ≥ 0`. Holds for all reals. -/
+theorem newton_N1 : 3 * (e1 a b c d)^2 ≥ 8 * (e2 a b c d) := by
+  unfold e1 e2
+  nlinarith [sq_nonneg (a-b), sq_nonneg (a-c), sq_nonneg (a-d),
+             sq_nonneg (b-c), sq_nonneg (b-d), sq_nonneg (c-d)]
+
+/-- **Newton N2** (log-concavity at k=2, the interior inequality): `4·e₂² ≥ 9·e₁·e₃`.
+    No reciprocal symmetry reduces this to N1/N3; it is a genuine degree-4 SOS.
+    Holds for all reals. -/
+theorem newton_N2 : 4 * (e2 a b c d)^2 ≥ 9 * (e1 a b c d) * (e3 a b c d) := by
+  unfold e1 e2 e3
+  nlinarith [sq_nonneg (a*b - c*d), sq_nonneg (a*c - b*d), sq_nonneg (a*d - b*c),
+             sq_nonneg (a*b + c*d - a*c - b*d), sq_nonneg (a*b + c*d - a*d - b*c),
+             sq_nonneg (a*c + b*d - a*d - b*c),
+             sq_nonneg (a-b), sq_nonneg (a-c), sq_nonneg (a-d),
+             sq_nonneg (b-c), sq_nonneg (b-d), sq_nonneg (c-d),
+             sq_nonneg (a*b - a*c), sq_nonneg (a*b - a*d)]
+
+/-- **Newton N3** (log-concavity at k=3): `3·e₃² ≥ 8·e₂·e₄`.
+    Reciprocal dual of N1 under xᵢ ↦ 1/xᵢ (which reverses e₀,…,e₄); certificate is
+    the sum of squares of differences of the four triple products. Holds for all reals. -/
+theorem newton_N3 : 3 * (e3 a b c d)^2 ≥ 8 * (e2 a b c d) * (e4 a b c d) := by
+  unfold e2 e3 e4
+  nlinarith [sq_nonneg (a*b*c - a*b*d), sq_nonneg (a*b*c - a*c*d), sq_nonneg (a*b*c - b*c*d),
+             sq_nonneg (a*b*d - a*c*d), sq_nonneg (a*b*d - b*c*d), sq_nonneg (a*c*d - b*c*d)]
+
+/-! ### Normalized means and the log-concavity form pₖ² ≥ pₖ₋₁·pₖ₊₁ -/
+
+/-- p₀ = e₀/C(4,0) = 1. -/
+def p0 : ℝ := 1
+/-- p₁ = e₁/C(4,1) = e₁/4. -/
+noncomputable def p1 : ℝ := (e1 a b c d) / 4
+/-- p₂ = e₂/C(4,2) = e₂/6. -/
+noncomputable def p2 : ℝ := (e2 a b c d) / 6
+/-- p₃ = e₃/C(4,3) = e₃/4. -/
+noncomputable def p3 : ℝ := (e3 a b c d) / 4
+/-- p₄ = e₄/C(4,4) = e₄. -/
+def p4 : ℝ := e4 a b c d
+
+/-- **Newton log-concavity, k=1**: `p₁² ≥ p₀·p₂`, the normalized form of N1. -/
+theorem logConcave_1 : (p1 a b c d)^2 ≥ p0 * (p2 a b c d) := by
+  have h := newton_N1 a b c d
+  unfold p0 p1 p2
+  nlinarith [h]
+
+/-- **Newton log-concavity, k=2**: `p₂² ≥ p₁·p₃`, the normalized form of N2. -/
+theorem logConcave_2 : (p2 a b c d)^2 ≥ (p1 a b c d) * (p3 a b c d) := by
+  have h := newton_N2 a b c d
+  unfold p1 p2 p3
+  nlinarith [h]
+
+/-- **Newton log-concavity, k=3**: `p₃² ≥ p₂·p₄`, the normalized form of N3. -/
+theorem logConcave_3 : (p3 a b c d)^2 ≥ (p2 a b c d) * (p4 a b c d) := by
+  have h := newton_N3 a b c d
+  unfold p2 p3 p4
+  nlinarith [h]
+
+/-! ### Equality characterization for the boundary step N1 -/
+
+/-- The N1 defect is the exact sum of the six squared pairwise differences. -/
+theorem newton_N1_identity :
+    3 * (e1 a b c d)^2 - 8 * (e2 a b c d)
+      = (a-b)^2 + (a-c)^2 + (a-d)^2 + (b-c)^2 + (b-d)^2 + (c-d)^2 := by
+  unfold e1 e2; ring
+
+/-- Equality in N1 (`3e₁² = 8e₂`, i.e. `p₁² = p₀p₂`) holds **iff** all four inputs
+    coincide — the Lorentzian/log-concavity boundary case. -/
+theorem newton_N1_eq_iff :
+    3 * (e1 a b c d)^2 = 8 * (e2 a b c d) ↔ a = b ∧ a = c ∧ a = d := by
+  have hsq : (2 : ℕ) ≠ 0 := by norm_num
+  constructor
+  · intro h
+    have hkey : (a-b)^2 + (a-c)^2 + (a-d)^2 + (b-c)^2 + (b-d)^2 + (c-d)^2 = 0 := by
+      have hid := newton_N1_identity a b c d
+      linarith
+    have hab : a = b := by
+      have hz : (a-b)^2 = 0 := le_antisymm (by nlinarith [sq_nonneg (a-c), sq_nonneg (a-d), sq_nonneg (b-c), sq_nonneg (b-d), sq_nonneg (c-d)]) (sq_nonneg _)
+      exact sub_eq_zero.mp ((pow_eq_zero_iff hsq).mp hz)
+    have hac : a = c := by
+      have hz : (a-c)^2 = 0 := le_antisymm (by nlinarith [sq_nonneg (a-b), sq_nonneg (a-d), sq_nonneg (b-c), sq_nonneg (b-d), sq_nonneg (c-d)]) (sq_nonneg _)
+      exact sub_eq_zero.mp ((pow_eq_zero_iff hsq).mp hz)
+    have had : a = d := by
+      have hz : (a-d)^2 = 0 := le_antisymm (by nlinarith [sq_nonneg (a-b), sq_nonneg (a-c), sq_nonneg (b-c), sq_nonneg (b-d), sq_nonneg (c-d)]) (sq_nonneg _)
+      exact sub_eq_zero.mp ((pow_eq_zero_iff hsq).mp hz)
+    exact ⟨hab, hac, had⟩
+  · rintro ⟨hab, hac, had⟩
+    subst hab; subst hac; subst had
+    unfold e1 e2; ring
+
+/-! ### Endpoint corollary: four-variable AM–GM from the Newton chain -/
+
+/-- **Four-variable AM–GM** (Maclaurin endpoint p₁⁴ ≥ p₄): for non-negative inputs,
+    `(a+b+c+d)⁴ ≥ 256·abcd`. This is the concrete payoff of the log-concavity chain:
+    Newton's inequalities interpolate between it and the trivial p₁ ≥ p₁. -/
+theorem amgm_four (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) (hd : 0 ≤ d) :
+    (e1 a b c d)^4 ≥ 256 * (e4 a b c d) := by
+  unfold e1 e4
+  nlinarith [sq_nonneg (a-b), sq_nonneg (c-d), sq_nonneg (a+b-c-d),
+             mul_nonneg ha hb, mul_nonneg hc hd,
+             mul_nonneg (mul_nonneg ha hb) (mul_nonneg hc hd), sq_nonneg (a*b - c*d),
+             mul_nonneg (add_nonneg ha hb) (add_nonneg hc hd)]
+
+/-- AM–GM in mean form: the arithmetic mean p₁ = (a+b+c+d)/4 dominates the fourth
+    root of the geometric-mean-to-the-fourth p₄ = abcd, without extracting roots. -/
+theorem amgm_four_mean (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) (hd : 0 ≤ d) :
+    (p1 a b c d)^4 ≥ p4 a b c d := by
+  have h := amgm_four a b c d ha hb hc hd
+  unfold p1 p4 e1 e4 at *
+  nlinarith [h]
+
+end AmgmOQ0205

--- a/proofs/Proofs/FibonacciIdentitiesOQ05OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ05OQ02.lean
@@ -1,0 +1,176 @@
+import Mathlib
+
+/-!
+# Gibonacci product-sum identity: the parity constant is a discriminant
+
+The parent entry `FibonacciIdentitiesOQ05.lean` proves the Fibonacci
+*product-sum* identity
+`Fₙ₊₁² = (F₀F₁ + F₁F₂ + ⋯ + FₙFₙ₊₁) + [n even]`,
+where the correction term `[n even]` toggles between `1` (even `n`) and `0`
+(odd `n`).
+
+This entry answers the open follow-up: **what happens for a general Gibonacci
+(Horadam) sequence** `G` obeying the Fibonacci recurrence
+`Gₙ₊₂ = Gₙ₊₁ + Gₙ` with arbitrary seeds `G₀, G₁`?  The answer exposes the
+`[n even]` toggle of the Fibonacci case as a shadow of the sequence's
+**discriminant**
+
+`D := G₁² − G₀G₁ − G₀²`,
+
+the invariant governing the generalized Cassini identity
+`Gₙ₊₁² − GₙGₙ₊₂ = (−1)ⁿ · D`.  The unified closed form is
+
+`Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + [n even] · D`.               (`gib_prod_sum`)
+
+Everything is stated over `ℤ` because the correction term is genuinely signed
+for seeds other than the Fibonacci `(0, 1)`.
+
+## Specializations
+
+* **Fibonacci** `(G₀, G₁) = (0, 1)`: `D = 1`, `G₀² = 0`, recovering the parent
+  identity `Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even]`  (`fib_prod_sum_int`).
+* **Lucas** `(G₀, G₁) = (2, 1)`: `D = 1 − 2 − 4 = −5` — the discriminant of
+  `x² − x − 1` scaled by the Lucas normalization.  The correction term is
+  `4 − 5·[n even]`, i.e. `−1` for even `n` and `4` for odd `n`
+  (`lucas_prod_sum`).
+
+The engine is the generalized Cassini identity `gib_cassini`, proved by a
+one-line `linear_combination` induction off the recurrence, and the main
+identity is a single induction whose step is closed by `linear_combination`
+once Cassini supplies the quadratic relation.
+
+No axioms, no `native_decide`, no sorries.
+-/
+
+namespace FibonacciIdentitiesOQ05OQ02
+
+open Finset
+
+section Generic
+
+variable (G : ℕ → ℤ) (hrec : ∀ n, G (n + 2) = G (n + 1) + G n)
+
+include hrec
+
+/-- **Generalized Cassini / Catalan identity.**
+For any sequence obeying `Gₙ₊₂ = Gₙ₊₁ + Gₙ`,
+`Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ · (G₁² − G₀G₁ − G₀²)`.
+The bracketed constant is the sequence's *discriminant* `D`; it is the
+translation-invariant of the recurrence. -/
+theorem gib_cassini (n : ℕ) :
+    G (n + 1) ^ 2 - G n * G (n + 2)
+      = (-1) ^ n * (G 1 ^ 2 - G 0 * G 1 - G 0 ^ 2) := by
+  induction n with
+  | zero =>
+    have h0 := hrec 0
+    -- G 2 = G 1 + G 0
+    rw [h0]; ring
+  | succ k ih =>
+    have h1 := hrec k          -- G (k+2) = G (k+1) + G k
+    have h2 := hrec (k + 1)    -- G (k+3) = G (k+2) + G (k+1)
+    -- Normalize the successor indices appearing in the goal.
+    show G (k + 2) ^ 2 - G (k + 1) * G (k + 3)
+        = (-1) ^ (k + 1) * (G 1 ^ 2 - G 0 * G 1 - G 0 ^ 2)
+    linear_combination -ih + G (k + 2) * h1 - G (k + 1) * h2
+
+/-- **Gibonacci product-sum identity** (unified closed form).
+`Gₙ₊₁² = (∑_{i=0}^{n} GᵢGᵢ₊₁) + G₀² + [n even]·D`, where `D = G₁²−G₀G₁−G₀²`.
+The parity toggle of the Fibonacci case is exactly the discriminant `D`. -/
+theorem gib_prod_sum (n : ℕ) :
+    G (n + 1) ^ 2
+      = (∑ i ∈ Finset.range (n + 1), G i * G (i + 1))
+        + G 0 ^ 2
+        + (if Even n then (G 1 ^ 2 - G 0 * G 1 - G 0 ^ 2) else 0) := by
+  induction n with
+  | zero =>
+    rw [if_pos (by decide : Even 0), Finset.sum_range_one]
+    ring
+  | succ k ih =>
+    rw [Finset.sum_range_succ, show k + 1 + 1 = k + 2 from rfl]
+    have hc := gib_cassini G hrec k
+    have h1 := hrec k          -- G (k+2) = G (k+1) + G k
+    rcases Nat.even_or_odd k with hk | hk
+    · -- k even ⇒ k+1 odd
+      have hodd : ¬ Even (k + 1) := by simp [Nat.even_add_one, hk]
+      rw [if_pos hk] at ih
+      rw [if_neg hodd]
+      -- ih : G(k+1)^2 = S_k + G0^2 + D
+      -- hc : G(k+1)^2 - G k * G(k+2) = D    (since (-1)^k = 1)
+      rw [hk.neg_one_pow] at hc
+      -- Goal: G(k+2)^2 = (S_k + G(k+1)*G(k+2)) + G0^2 + 0
+      linear_combination ih - hc + G (k + 2) * h1
+    · -- k odd ⇒ k+1 even
+      have heven : Even (k + 1) := hk.add_one
+      rw [if_neg (by simpa [Nat.not_even_iff_odd] using hk)] at ih
+      rw [if_pos heven]
+      rw [hk.neg_one_pow] at hc
+      -- hc : G(k+1)^2 - G k * G(k+2) = -D
+      linear_combination ih - hc + G (k + 2) * h1
+
+/-- Even branch: for even `n`,
+`∑_{i≤n} GᵢGᵢ₊₁ = Gₙ₊₁² − G₀² − D`. -/
+theorem gib_prod_sum_even {n : ℕ} (hn : Even n) :
+    (∑ i ∈ Finset.range (n + 1), G i * G (i + 1))
+      = G (n + 1) ^ 2 - G 0 ^ 2 - (G 1 ^ 2 - G 0 * G 1 - G 0 ^ 2) := by
+  have h := gib_prod_sum G hrec n
+  rw [if_pos hn] at h
+  linarith [h]
+
+/-- Odd branch: for odd `n`,
+`∑_{i≤n} GᵢGᵢ₊₁ = Gₙ₊₁² − G₀²`. -/
+theorem gib_prod_sum_odd {n : ℕ} (hn : Odd n) :
+    (∑ i ∈ Finset.range (n + 1), G i * G (i + 1))
+      = G (n + 1) ^ 2 - G 0 ^ 2 := by
+  have h := gib_prod_sum G hrec n
+  rw [if_neg (by simpa [Nat.not_even_iff_odd] using hn)] at h
+  linarith [h]
+
+end Generic
+
+/-! ## Fibonacci specialization: recovering the parent identity -/
+
+/-- The Fibonacci sequence as a `ℤ`-valued Gibonacci sequence. -/
+theorem fib_hrec : ∀ n, (Nat.fib (n + 2) : ℤ) = Nat.fib (n + 1) + Nat.fib n := by
+  intro n; rw [Nat.fib_add_two]; push_cast; ring
+
+/-- **Fibonacci product-sum** (integer form), recovering the parent entry:
+`Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even]`.  Here `D = 1` and `G₀² = 0`. -/
+theorem fib_prod_sum_int (n : ℕ) :
+    (Nat.fib (n + 1) : ℤ) ^ 2
+      = (∑ i ∈ Finset.range (n + 1), (Nat.fib i : ℤ) * Nat.fib (i + 1))
+        + (if Even n then 1 else 0) := by
+  have h := gib_prod_sum (fun n => (Nat.fib n : ℤ)) fib_hrec n
+  simp only [Nat.fib_zero, Nat.fib_one, Nat.cast_zero, Nat.cast_one] at h
+  simpa using h
+
+/-! ## Lucas specialization: the discriminant becomes `−5` -/
+
+/-- The pair `(Lₙ, Lₙ₊₁)`, computed by structural recursion. -/
+def lucasPair : ℕ → ℤ × ℤ
+  | 0 => (2, 1)
+  | n + 1 => ((lucasPair n).2, (lucasPair n).1 + (lucasPair n).2)
+
+/-- The Lucas numbers as a `ℤ`-valued sequence: `L₀ = 2`, `L₁ = 1`. -/
+def lucasZ (n : ℕ) : ℤ := (lucasPair n).1
+
+@[simp] theorem lucasZ_zero : lucasZ 0 = 2 := rfl
+@[simp] theorem lucasZ_one : lucasZ 1 = 1 := rfl
+
+theorem lucasZ_hrec : ∀ n, lucasZ (n + 2) = lucasZ (n + 1) + lucasZ n := by
+  intro n
+  simp only [lucasZ, lucasPair]
+  ring
+
+/-- **Lucas product-sum identity.**  For the Lucas numbers the discriminant is
+`D = 1 − 2 − 4 = −5`, so the correction term `G₀² + [n even]·D` equals
+`4 + (if Even n then -5 else 0)`, i.e. `−1` for even `n`, `4` for odd `n`. -/
+theorem lucas_prod_sum (n : ℕ) :
+    lucasZ (n + 1) ^ 2
+      = (∑ i ∈ Finset.range (n + 1), lucasZ i * lucasZ (i + 1))
+        + 4 + (if Even n then (-5) else 0) := by
+  have h := gib_prod_sum lucasZ lucasZ_hrec n
+  simp only [lucasZ_zero, lucasZ_one] at h
+  rw [h]
+  norm_num
+
+end FibonacciIdentitiesOQ05OQ02

--- a/src/data/proofs/amgm-inequality-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-05/annotations.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "ann-amgmoq0205-setup",
+    "proofId": "amgm-inequality-oq-02-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 62
+    },
+    "type": "context",
+    "title": "What This File Discharges, and the n=4 Symmetric-Function Setup",
+    "content": "The header fixes notation and the goal. The parent entry `amgm-inequality-oq-02` proves Newton's k=1 inequality from scratch but takes the general log-concavity pₖ² ≥ pₖ₋₁pₖ₊₁ as an axiom (`newton_log_concavity`). The sibling `amgm-inequality-oq-02-oq-04` discharged that axiom for n=3 and, in its own open-questions list, asked for exactly the n=4 SOS certificate proved here. This file works with the four elementary symmetric polynomials e₁ = a+b+c+d, e₂ = ab+ac+ad+bc+bd+cd, e₃ = abc+abd+acd+bcd, e₄ = abcd, and the normalized means pₖ = eₖ/C(4,k) with C(4,·) = 1,4,6,4,1. Log-concavity is now THREE inequalities: 3e₁²≥8e₂ (k=1), 4e₂²≥9e₁e₃ (k=2), 3e₃²≥8e₂e₄ (k=3). The single `import Mathlib` is deliberate for a gallery file; the content is elementary and self-contained.",
+    "mathContext": "For a real-rooted monic quartic with roots $a,b,c,d$, $p_k = e_k/\\binom{4}{k}$ are the normalized coefficients: $p_0=1,\\ p_1=e_1/4,\\ p_2=e_2/6,\\ p_3=e_3/4,\\ p_4=e_4$. Newton's log-concavity $p_k^2\\ge p_{k-1}p_{k+1}$ specializes to $3e_1^2\\ge 8e_2$, $4e_2^2\\ge 9e_1e_3$ and $3e_3^2\\ge 8e_2e_4$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Elementary symmetric polynomials of four variables",
+      "Newton's normalized means pₖ",
+      "Axiom discharge / de-axiomatization",
+      "Real-rooted polynomials and Lorentzian log-concavity"
+    ],
+    "prerequisites": [
+      "Binomial coefficients C(4,k) = 1,4,6,4,1",
+      "Symmetric polynomials of four variables"
+    ],
+    "tags": [
+      "context",
+      "setup",
+      "axiom-discharge"
+    ]
+  },
+  {
+    "id": "ann-amgmoq0205-newton",
+    "proofId": "amgm-inequality-oq-02-oq-05",
+    "range": {
+      "startLine": 64,
+      "endLine": 91
+    },
+    "type": "insight",
+    "title": "The Interior Inequality N2 Is the Genuinely New n=4 Content",
+    "content": "The three Newton inequalities split by symmetry. N1 (3e₁²≥8e₂) and N3 (3e₃²≥8e₂e₄) are reciprocal duals: substituting xᵢ ↦ 1/xᵢ reverses the sequence e₀,…,e₄, sending N1 to N3, and both are visibly sums of squares of differences — of the variables for N1, of the four triple products for N3. What has no analogue at n=3 and no reciprocal shortcut is the INTERIOR inequality N2, 4e₂² ≥ 9e₁e₃. It is a degree-4 form in four variables that must be certified as a genuine sum of squares in its own right; `nlinarith` is fed a Gram/Schur combination built from the (products-of-two) differences (ab−cd), (ac−bd), (ad−bc) together with their pairwise sums and the plain variable differences. That N2 is still SOS — with no real-rootedness input — is the crux fact this entry contributes: through n=4, Newton's log-concavity remains Positivstellensatz-elementary. Crucially, all three inequalities are stated and proved for ALL real a,b,c,d, strictly strengthening the parent axiom, which only asserted them for nonnegative inputs.",
+    "mathContext": "A polynomial is SOS if it is a finite sum of squares; SOS $\\Rightarrow$ globally nonnegative. $N1$ and $N3$ are duals under $x_i\\mapsto 1/x_i$ (which maps $e_k\\mapsto e_{n-k}/e_n$). The interior $4e_2^2-9e_1e_3$ is nonnegative for all reals and admits an explicit SOS certificate, so it needs neither nonnegativity nor real-rootedness.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Sum-of-squares / Positivstellensatz",
+      "Reciprocal duality of Newton's inequalities",
+      "Interior vs. boundary log-concavity",
+      "Real-rootedness (needed for a uniform all-n statement)"
+    ],
+    "prerequisites": [
+      "nlinarith and SOS hints",
+      "Elementary symmetric polynomials",
+      "Nonnegativity of squares"
+    ],
+    "tags": [
+      "insight",
+      "sum-of-squares",
+      "interior-inequality"
+    ]
+  },
+  {
+    "id": "ann-amgmoq0205-normalized",
+    "proofId": "amgm-inequality-oq-02-oq-05",
+    "range": {
+      "startLine": 93,
+      "endLine": 122
+    },
+    "type": "context",
+    "title": "Packaging the Newton Inequalities as Log-Concavity pₖ² ≥ pₖ₋₁pₖ₊₁",
+    "content": "`logConcave_1`, `logConcave_2`, `logConcave_3` restate N1, N2, N3 in Newton's own normalized form. With p₀=1, p₁=e₁/4, p₂=e₂/6, p₃=e₃/4, p₄=e₄, the identity p₁²≥p₀p₂ ⟺ (e₁/4)²≥e₂/6 ⟺ 3e₁²≥8e₂ recovers N1 exactly, and likewise p₂²≥p₁p₃ ⟺ 4e₂²≥9e₁e₃ (N2), p₃²≥p₂p₄ ⟺ 3e₃²≥8e₂e₄ (N3). Each is proved by clearing the binomial denominators C(4,k) and calling nlinarith with the underlying Newton inequality. This is precisely the shape of the parent's `newton_log_concavity` axiom (for the index n=4, k=1,2,3), now supplied as a theorem.",
+    "mathContext": "The normalization $p_k=e_k/\\binom{n}{k}$ is what makes Newton's inequalities scale-consistent; $p_k^2\\ge p_{k-1}p_{k+1}$ is log-concavity of the finite sequence $(p_k)$. For $n=4$ the denominators are $1,4,6,4,1$.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Log-concave sequences",
+      "Binomial normalization",
+      "newton_log_concavity (parent axiom)"
+    ],
+    "prerequisites": [
+      "Binomial coefficients",
+      "Division on the reals"
+    ],
+    "tags": [
+      "context",
+      "log-concavity",
+      "normalization"
+    ]
+  },
+  {
+    "id": "ann-amgmoq0205-equality",
+    "proofId": "amgm-inequality-oq-02-oq-05",
+    "range": {
+      "startLine": 124,
+      "endLine": 154
+    },
+    "type": "insight",
+    "title": "The Exact SOS Gap Gives the Boundary Equality Case a=b=c=d",
+    "content": "`newton_N1_identity` records, by `ring` alone, that the N1 gap is an exact sum of squares: 3e₁² − 8e₂ = (a−b)²+(a−c)²+(a−d)²+(b−c)²+(b−d)²+(c−d)² = Σ_{i<j}(xᵢ−xⱼ)². This is a certificate (an equality, not merely a bound), so it doubles as equality analysis. `newton_N1_eq_iff` reads off the consequence: 3e₁² = 8e₂ ⟺ a=b=c=d. The forward direction is the interesting one — a vanishing sum of nonnegative squares forces each square to zero (obtained by `le_antisymm` against `sq_nonneg`), after which `pow_eq_zero_iff` and `sub_eq_zero` collapse (a−b)²=0 to a=b, and similarly for the other coordinates. In the Lorentzian/log-concavity language this is exactly the degenerate boundary of the log-concave regime, where the discriminant-type form vanishes.",
+    "mathContext": "For the top Newton inequality the gap $3e_1^2-8e_2=\\sum_{i<j}(x_i-x_j)^2$ vanishes iff all pairwise differences vanish, i.e. $a=b=c=d$. This is the four-variable analogue of $e_1^2-3e_2=\\tfrac12\\sum(x-y)^2$ at $n=3$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Exact SOS certificates",
+      "Equality-case analysis",
+      "Vanishing sum of squares",
+      "Lorentzian boundary / degeneracy"
+    ],
+    "prerequisites": [
+      "ring identities",
+      "pow_eq_zero_iff, sub_eq_zero",
+      "Nonnegativity of squares"
+    ],
+    "tags": [
+      "insight",
+      "equality-case",
+      "sum-of-squares"
+    ]
+  },
+  {
+    "id": "ann-amgmoq0205-amgm",
+    "proofId": "amgm-inequality-oq-02-oq-05",
+    "range": {
+      "startLine": 156,
+      "endLine": 177
+    },
+    "type": "context",
+    "title": "Recovering the Four-Variable AM–GM as the Chain Endpoint",
+    "content": "`amgm_four` proves (a+b+c+d)⁴ ≥ 256abcd for nonnegative a,b,c,d — the Maclaurin endpoint p₁⁴ ≥ p₄ of the log-concavity chain — via an SOS built from (a−b)², (c−d)², (a+b−c−d)² and the relevant nonnegative products. `amgm_four_mean` restates it in mean form (e₁/4)⁴ ≥ e₄, so the arithmetic mean to the fourth power dominates the product abcd without any radical extraction. This is the concrete payoff: Newton's log-concavity interpolates between the trivial p₁ ≥ p₁ and the AM–GM endpoint, and here that endpoint is made explicit and axiom-free for four variables.",
+    "mathContext": "Four-variable AM–GM: $\\frac{a+b+c+d}{4}\\ge (abcd)^{1/4}$, equivalently $(a+b+c+d)^4\\ge 256\\,abcd$ for $a,b,c,d\\ge 0$, with equality iff $a=b=c=d$. It is the $k=1$ vs $k=4$ endpoint of Maclaurin's chain $M_1\\ge\\cdots\\ge M_4$.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "AM–GM inequality",
+      "Maclaurin's mean chain",
+      "Radical-free formulation"
+    ],
+    "prerequisites": [
+      "Nonnegativity hypotheses",
+      "nlinarith with product hints"
+    ],
+    "tags": [
+      "context",
+      "am-gm",
+      "endpoint"
+    ]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-05/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "amgm-inequality-oq-02-oq-05",
+  "title": "Newton's Inequalities for Four Variables: n=4 Log-Concavity, Axiom-Free",
+  "slug": "amgm-inequality-oq-02-oq-05",
+  "description": "The parent Maclaurin entry (amgm-inequality-oq-02) proves the k=1 Newton inequality from scratch but AXIOMATIZES the general Newton log-concavity (newton_log_concavity, pₖ² ≥ pₖ₋₁pₖ₊₁). The sibling amgm-inequality-oq-02-oq-04 discharged that axiom for n=3 and explicitly posed the n=4 case as an open question. This entry answers it: for four variables the normalized sequence p₀,p₁,p₂,p₃,p₄ has THREE log-concavity inequalities — including a genuine interior one (k=2) with no reciprocal symmetry — and all three are proved axiom-free as exact sum-of-squares certificates (3e₁²≥8e₂, 4e₂²≥9e₁e₃, 3e₃²≥8e₂e₄), each valid for ALL real inputs, not merely nonnegative ones. The equality case of the boundary inequality is characterized (a=b=c=d), and the four-variable AM–GM (a+b+c+d)⁴ ≥ 256abcd is recovered as the endpoint of the chain. Zero axioms, zero sorries.",
+  "meta": {
+    "author": "Isaac Newton (1707), Colin Maclaurin (1729); formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_inequalities",
+    "date": "1707",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ05.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "mean-inequalities",
+      "elementary-symmetric-polynomials",
+      "sum-of-squares",
+      "newton-inequalities",
+      "log-concavity",
+      "lorentzian-polynomials",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "sq_nonneg",
+        "description": "x² ≥ 0, the raw material of every sum-of-squares certificate for the three Newton inequalities and the four-variable AM–GM",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "pow_eq_zero_iff",
+        "description": "aⁿ = 0 ↔ a = 0 (n ≠ 0), used in the N1 equality analysis to pass from (a−b)² = 0 to a = b",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "sub_eq_zero",
+        "description": "a − b = 0 ↔ a = b, closing each coordinate equality in the equality-case characterization of N1",
+        "module": "Mathlib.Algebra.Group.Basic"
+      },
+      {
+        "theorem": "le_antisymm",
+        "description": "a ≤ b and b ≤ a give a = b; used with sq_nonneg to isolate each squared difference as zero from the vanishing SOS sum",
+        "module": "Mathlib.Order.Basic"
+      }
+    ],
+    "originalContributions": [
+      "newton_N1: Newton's inequality N1 for n=4, 3e₁² ≥ 8e₂ (⟺ p₁² ≥ p₀p₂), proved by nlinarith on the six squared pairwise differences — valid for all reals",
+      "newton_N2: the INTERIOR Newton inequality N2 for n=4, 4e₂² ≥ 9e₁e₃ (⟺ p₂² ≥ p₁p₃), a genuine degree-4 sum-of-squares with no reciprocal symmetry to reduce it — valid for all reals",
+      "newton_N3: Newton's inequality N3 for n=4, 3e₃² ≥ 8e₂e₄ (⟺ p₃² ≥ p₂p₄), the reciprocal dual of N1 via xᵢ ↦ 1/xᵢ, proved as the SOS of differences of the four triple products — valid for all reals",
+      "logConcave_1 / logConcave_2 / logConcave_3: the three normalized log-concavity statements pₖ² ≥ pₖ₋₁pₖ₊₁ for k=1,2,3 with pₖ = eₖ/C(4,k), derived from the Newton inequalities",
+      "newton_N1_identity: the exact symmetrization identity 3e₁² − 8e₂ = Σ_{i<j}(xᵢ−xⱼ)², proved by ring",
+      "newton_N1_eq_iff: equality in the boundary inequality N1 holds iff a=b=c=d — the Lorentzian log-concavity boundary case",
+      "amgm_four: four-variable AM–GM (a+b+c+d)⁴ ≥ 256abcd for nonnegative inputs, the Maclaurin endpoint p₁⁴ ≥ p₄",
+      "amgm_four_mean: AM–GM in mean form (e₁/4)⁴ ≥ e₄, without extracting fourth roots"
+    ],
+    "dateAdded": "2026-07-01",
+    "prerequisites": [
+      "Elementary symmetric polynomials e₁, e₂, e₃, e₄ of four variables",
+      "Binomial normalization pₖ = eₖ/C(4,k) with C(4,·) = 1,4,6,4,1",
+      "Sum-of-squares (SOS) certificates and nlinarith",
+      "Newton's log-concavity and its role in the Lorentzian-polynomial framework"
+    ],
+    "relatedProblems": [
+      {
+        "id": "amgm-inequality-oq-02-oq-04",
+        "relationship": "Sibling: discharges the parent's Newton log-concavity axiom for n=3 and explicitly poses the n=4 SOS/Schur certificate as an open question — which this entry answers."
+      },
+      {
+        "id": "amgm-inequality-oq-02",
+        "relationship": "Parent: proves Newton k=1 and axiomatizes the general Newton log-concavity; this entry discharges the axiom for all three positions at n=4."
+      },
+      {
+        "id": "amgm-inequality",
+        "relationship": "Ancestor: the AM–GM inequality, recovered here as the endpoint (a+b+c+d)⁴ ≥ 256abcd of the four-variable Newton/Maclaurin chain."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 177,
+    "assumptions": "0 axioms, 0 sorries. #print axioms reports only [propext, Classical.choice, Quot.sound] for newton_N1, newton_N2, newton_N3, logConcave_2, newton_N1_eq_iff, amgm_four and amgm_four_mean. The parent's newton_log_concavity axiom is NOT used — all three n=4 Newton inequalities are proved directly from sum-of-squares certificates and are in fact valid for all real inputs, whereas the parent axiom only asserted them for nonnegative inputs. Only the AM–GM endpoint amgm_four requires nonnegativity. Verified with Lean toolchain 4.31.0.",
+    "mathlib_version": "4.31.0",
+    "theoremCount": 10,
+    "definitionCount": 9
+  },
+  "overview": {
+    "historicalContext": "Newton (Arithmetica Universalis, 1707) observed that the normalized elementary symmetric means pₖ = eₖ/C(n,k) of a real-rooted polynomial are log-concave: pₖ² ≥ pₖ₋₁pₖ₊₁. Maclaurin (1729) deduced the chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ, with AM ≥ GM as the extreme case. The general Newton inequalities require real-rootedness / Rolle machinery — the modern viewpoint (Brändén–Huh, Lorentzian polynomials, 2020) sees them as the log-concavity forced by a Lorentzian quadratic form. Mathlib still lacks the general result, so the parent entry assumes it as newton_log_concavity. For n=3 the inequalities are elementary sums of squares (sibling oq-02-oq-04); this entry establishes that n=4 is still purely SOS, including the harder interior inequality.",
+    "problemStatement": "For n=4, discharge the parent's newton_log_concavity axiom at all three positions: prove p₁² ≥ p₀p₂, p₂² ≥ p₁p₃ and p₃² ≥ p₂p₄ (equivalently 3e₁²≥8e₂, 4e₂²≥9e₁e₃, 3e₃²≥8e₂e₄) with no axioms, and recover the four-variable AM–GM.",
+    "text": "Writing e₁ = a+b+c+d, e₂ = ab+ac+ad+bc+bd+cd, e₃ = abc+abd+acd+bcd, e₄ = abcd, and pₖ = eₖ/C(4,k) with C(4,·) = 1,4,6,4,1, Newton's log-concavity pₖ² ≥ pₖ₋₁pₖ₊₁ becomes 3e₁²≥8e₂ (k=1), 4e₂²≥9e₁e₃ (k=2) and 3e₃²≥8e₂e₄ (k=3). The boundary inequalities N1 and N3 are exact sums of squares of differences (of the variables, resp. of the four triple products) and hold for all reals; N1's gap is 3e₁²−8e₂ = Σ_{i<j}(xᵢ−xⱼ)², vanishing exactly at a=b=c=d. The interior inequality N2, which has no reciprocal symmetry, is a degree-4 SOS certificate. From the endpoints one obtains (a+b+c+d)⁴ ≥ 256abcd.",
+    "proofStrategy": "Each Newton inequality is discharged by nlinarith fed the appropriate squared differences: for N1 the six (xᵢ−xⱼ)²; for N3 the six differences of triple products; for the interior N2 a Gram/Schur combination of (products-of-two) differences together with the pairwise differences. The normalized logConcave_k statements follow by clearing the binomial denominators (nlinarith on the corresponding Newton inequality). The equality case of N1 is read off the exact identity 3e₁²−8e₂ = Σ(xᵢ−xⱼ)²: a vanishing sum of squares forces each square to zero (le_antisymm with sq_nonneg), then pow_eq_zero_iff and sub_eq_zero give a=b=c=d. The AM–GM endpoint is a direct SOS with the nonnegativity hypotheses.",
+    "keyInsights": [
+      "For four variables Newton's log-concavity is STILL purely sum-of-squares — no real-rootedness machinery is needed, extending the n=3 phenomenon one step further",
+      "The two boundary inequalities N1 and N3 are reciprocal duals (xᵢ ↦ 1/xᵢ reverses e₀,…,e₄) and are sums of squares of differences; the interior N2 is the genuinely new content, lacking any such symmetry",
+      "All three Newton inequalities hold for ALL real inputs — the parent axiom only claimed them for nonnegative inputs, so this is strictly stronger",
+      "The N1 gap 3e₁²−8e₂ = Σ_{i<j}(xᵢ−xⱼ)² is an exact certificate, giving the equality case a=b=c=d for free",
+      "The four-variable AM–GM (a+b+c+d)⁴ ≥ 256abcd is the log-concavity chain's endpoint p₁⁴ ≥ p₄"
+    ],
+    "prerequisites": [
+      "Elementary symmetric polynomials of four variables",
+      "Binomial normalization pₖ = eₖ/C(4,k)",
+      "Sum-of-squares certificates and nlinarith",
+      "Newton's inequalities and the Lorentzian-polynomial viewpoint on log-concavity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "newton",
+      "title": "The Three Newton Inequalities for n=4 (Sum-of-Squares)",
+      "startLine": 64,
+      "endLine": 91,
+      "summary": "newton_N1 (3e₁²≥8e₂), newton_N2 (4e₂²≥9e₁e₃, the interior inequality), newton_N3 (3e₃²≥8e₂e₄): the three log-concavity inequalities of the normalized sequence, each proved by nlinarith on explicit squared differences and valid for all reals.",
+      "mathContext": "For four variables Newton's log-concavity is three inequalities; the boundary pair N1/N3 are reciprocal duals and are sums of squares of differences, while the interior N2 is a genuine degree-4 SOS with no such symmetry — this is the n=4 case the parent left axiomatized."
+    },
+    {
+      "id": "normalized",
+      "title": "Normalized Means and Log-Concavity pₖ² ≥ pₖ₋₁pₖ₊₁",
+      "startLine": 93,
+      "endLine": 122,
+      "summary": "The normalized means p₀=1, p₁=e₁/4, p₂=e₂/6, p₃=e₃/4, p₄=e₄ and logConcave_1, logConcave_2, logConcave_3 packaging the Newton inequalities in Newton's own log-concavity form pₖ² ≥ pₖ₋₁pₖ₊₁.",
+      "mathContext": "Clearing the binomial denominators C(4,k) = 1,4,6,4,1 turns each log-concavity step into the corresponding Newton inequality — this is exactly the newton_log_concavity statement the parent axiomatized, now discharged for n=4."
+    },
+    {
+      "id": "equality-endpoint",
+      "title": "Equality Case and the Four-Variable AM–GM Endpoint",
+      "startLine": 124,
+      "endLine": 177,
+      "summary": "newton_N1_identity exhibits the exact SOS gap 3e₁²−8e₂ = Σ_{i<j}(xᵢ−xⱼ)²; newton_N1_eq_iff characterizes equality as a=b=c=d; amgm_four and amgm_four_mean recover the four-variable AM–GM (a+b+c+d)⁴ ≥ 256abcd as the log-concavity chain's endpoint.",
+      "mathContext": "The exact symmetrization identity doubles as equality analysis (the Lorentzian boundary case), and the extreme normalized means reproduce AM ≥ GM for four nonnegative numbers."
+    }
+  ],
+  "conclusion": {
+    "summary": "For four variables all three Newton log-concavity inequalities — including the interior 4e₂² ≥ 9e₁e₃ with no reciprocal symmetry — are proved with zero axioms and zero sorries as exact sum-of-squares certificates, discharging the parent entry's newton_log_concavity assumption at n=4 and answering the open question posed by the n=3 sibling. All three hold for arbitrary reals; the four-variable AM–GM drops out as the chain's endpoint.",
+    "implications": "The elementary, axiom-free SOS core of Newton/Maclaurin theory extends from n=3 to n=4, now including a genuine interior inequality. This maps the boundary of what is provable without the real-rootedness (Lorentzian) input: through n=4 the log-concavity remains a rational sum-of-squares, and the deep analytic machinery is only strictly needed to reach a uniform statement for all n.",
+    "openQuestions": [
+      "Prove Newton's log-concavity for general n axiom-free — either by an explicit SOS/Positivstellensatz certificate (does one exist uniformly?) or by formalizing the real-rootedness/Rolle argument, which would let Mathlib retire newton_log_concavity entirely.",
+      "Formalize the Lorentzian-polynomial framework (Brändén–Huh 2020) and derive Newton's inequalities as the log-concavity of a Lorentzian quadratic form, giving a conceptual (rather than case-by-case SOS) proof.",
+      "Characterize the equality cases of the interior inequality N2 for n=4 (beyond the all-equal case), and quantify its SOS slack."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "AmgmOQ0205",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 9,
+    "path": "Proofs/AmgmInequalityOQ02OQ05.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-04",
+      "relationship": "extends",
+      "description": "Answers the n=4 open question posed by the n=3 sibling, discharging Newton log-concavity for four variables including the interior inequality."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "extends",
+      "description": "Discharges, for n=4, the parent's axiomatized Newton log-concavity at all three positions using explicit sum-of-squares certificates."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "Recovers the AM–GM inequality (a+b+c+d)⁴ ≥ 256abcd as the endpoint of the four-variable Newton/Maclaurin chain."
+    }
+  ],
+  "references": [
+    {
+      "key": "Newton1707",
+      "citation": "Newton, I., Arithmetica Universalis (1707); the normalized elementary symmetric means and their log-concavity.",
+      "type": "book"
+    },
+    {
+      "key": "Maclaurin1729",
+      "citation": "Maclaurin, C., A Second Letter to Martin Folkes, Esq.; concerning the Roots of Equations, Phil. Trans. 36 (1729), 59–96.",
+      "type": "article"
+    },
+    {
+      "key": "HLP52",
+      "citation": "Hardy, G.H., Littlewood, J.E. and Pólya, G., Inequalities, 2nd ed., Cambridge University Press (1952), §2.22 (Newton's and Maclaurin's inequalities).",
+      "type": "book"
+    },
+    {
+      "key": "BrandenHuh2020",
+      "citation": "Brändén, P. and Huh, J., Lorentzian polynomials, Annals of Mathematics 192 (2020), no. 3, 821–891.",
+      "type": "article"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/fibonacci-identities-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-02/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-fiboq0502-1",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 5, "endLine": 43 },
+    "type": "concept",
+    "title": "The Parity Constant is a Discriminant",
+    "content": "**Module framing.** The parent entry proves the Fibonacci product-sum staircase $F_{n+1}^2 = \\sum_{i\\le n} F_iF_{i+1} + [n\\text{ even}]$, whose correction term toggles between $1$ and $0$ with no evident reason. This entry answers the open follow-up: for an arbitrary **Gibonacci** (Horadam) sequence $G$ with $G_{n+2} = G_{n+1} + G_n$ and arbitrary seeds, the identity becomes $G_{n+1}^2 = \\left(\\sum_{i\\le n} G_iG_{i+1}\\right) + G_0^2 + [n\\text{ even}]\\cdot D$, where $D = G_1^2 - G_0G_1 - G_0^2$ is the sequence's **discriminant**. The opaque parity toggle is thereby revealed as one value of a single invariant $D$ — the same $D$ that governs the generalized Cassini identity. Everything is over $\\mathbb{Z}$ because for non-Fibonacci seeds the correction is genuinely signed.",
+    "mathContext": "$G_{n+1}^2 = \\left(\\sum_{i\\le n} G_iG_{i+1}\\right) + G_0^2 + [n\\text{ even}]\\cdot D,\\quad D = G_1^2 - G_0G_1 - G_0^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Product-sum staircase (parent entry)",
+      "Gibonacci / Horadam sequences",
+      "Recurrence discriminant"
+    ],
+    "prerequisites": [
+      "Second-order linear recurrences Gₙ₊₂ = Gₙ₊₁ + Gₙ",
+      "Cassini's identity and the alternating sign (−1)ⁿ"
+    ],
+    "tags": ["module-header", "framing", "gibonacci", "discriminant"]
+  },
+  {
+    "id": "ann-fiboq0502-2",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 55, "endLine": 73 },
+    "type": "tactic",
+    "title": "Generalized Cassini, Seed-Free",
+    "content": "**The engine.** For *any* sequence obeying $G_{n+2} = G_{n+1} + G_n$, $G_{n+1}^2 - G_n G_{n+2} = (-1)^n D$ with $D = G_1^2 - G_0G_1 - G_0^2$. The discriminant $D$ is the translation-invariant of the recurrence — the quantity that survives the induction modulated only by the sign $(-1)^n$. The proof is a clean induction: the base substitutes $G_2 = G_1 + G_0$ and closes by `ring`; the step introduces the recurrence at $k$ and $k+1$, normalizes successor indices with `show`, and closes with the exact linear combination `linear_combination -ih + G(k+2)·h1 − G(k+1)·h2`. Mathlib records Cassini only for the concrete Fibonacci/Lucas sequences, so this seed-agnostic form is supplied here.",
+    "mathContext": "$G_{n+1}^2 - G_n G_{n+2} = (-1)^n\\,(G_1^2 - G_0G_1 - G_0^2)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Cassini's identity",
+      "linear_combination tactic",
+      "Recurrence discriminant D"
+    ],
+    "prerequisites": ["Induction over ℤ", "The Gibonacci recurrence"],
+    "tags": ["cassini", "engine", "linear_combination", "discriminant"]
+  },
+  {
+    "id": "ann-fiboq0502-3",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 76, "endLine": 108 },
+    "type": "theorem",
+    "title": "The Unified Product-Sum Closed Form",
+    "content": "**Headline identity.** $G_{n+1}^2 = \\left(\\sum_{i=0}^{n} G_iG_{i+1}\\right) + G_0^2 + (\\text{if } n\\text{ even then } D \\text{ else } 0)$. This is the seed-agnostic generalization of the parent staircase. The induction on $n$ peels the last product with `Finset.sum_range_succ` and splits on `Nat.even_or_odd`; in each branch both `if`s are resolved by parity, the Cassini sign $(-1)^k$ is specialized to $\\pm 1$ via `Even.neg_one_pow` / `Odd.neg_one_pow` (turning Cassini into $\\pm D$), the recurrence is substituted, and the step closes with a single `linear_combination` of the induction hypothesis, Cassini, and the recurrence. The correction term $G_0^2 + [n\\text{ even}]\\cdot D$ is where all seed dependence lives.",
+    "mathContext": "$G_{n+1}^2 = \\left(\\sum_{i=0}^{n} G_iG_{i+1}\\right) + G_0^2 + (\\text{if } n\\text{ even then } D \\text{ else } 0)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_range_succ induction",
+      "Parity case split",
+      "Generalized Cassini identity"
+    ],
+    "prerequisites": ["The generalized Cassini identity", "Parity of (−1)ⁿ"],
+    "tags": ["product-sum", "closed-form", "induction", "parity"]
+  },
+  {
+    "id": "ann-fiboq0502-4",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 110, "endLine": 127 },
+    "type": "theorem",
+    "title": "Parity Branches Solved for the Sum",
+    "content": "**Corollaries.** Solving the headline identity for the sum in each parity gives $\\sum_{i\\le n} G_iG_{i+1} = G_{n+1}^2 - G_0^2 - D$ for even $n$ (`gib_prod_sum_even`) and $\\sum_{i\\le n} G_iG_{i+1} = G_{n+1}^2 - G_0^2$ for odd $n$ (`gib_prod_sum_odd`). Each discharges the `if` with `if_pos` / `if_neg` and finishes by `linarith`. These are the forms most directly comparable to the parent's Fibonacci statement.",
+    "mathContext": "even: $\\sum G_iG_{i+1} = G_{n+1}^2 - G_0^2 - D$;  odd: $\\sum G_iG_{i+1} = G_{n+1}^2 - G_0^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Parity branches", "linarith"],
+    "prerequisites": ["The unified product-sum closed form"],
+    "tags": ["corollary", "parity", "linarith"]
+  },
+  {
+    "id": "ann-fiboq0502-5",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 130, "endLine": 144 },
+    "type": "concept",
+    "title": "Fibonacci: Recovering the Parent (D = 1)",
+    "content": "**First specialization.** Instantiating the generic identity at the Fibonacci seeds $(G_0, G_1) = (0, 1)$ gives $D = 1^2 - 0\\cdot 1 - 0^2 = 1$ and $G_0^2 = 0$, so the correction collapses to exactly $[n\\text{ even}]$ — the parent entry $F_{n+1}^2 = \\sum F_iF_{i+1} + [n\\text{ even}]$ (`fib_prod_sum_int`). The only work is `fib_hrec`, which casts Mathlib's `Nat.fib_add_two` to $\\mathbb{Z}$ to supply the generic recurrence hypothesis; the seeds are cleared by `simp`. The parent identity is thus a one-line corollary of the seed-agnostic theorem.",
+    "mathContext": "$(G_0,G_1)=(0,1)\\Rightarrow D=1,\\ G_0^2=0\\Rightarrow F_{n+1}^2 = \\sum F_iF_{i+1} + [n\\text{ even}]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.fib_add_two", "Fibonacci as Gibonacci", "Specialization by simp"],
+    "prerequisites": ["The unified product-sum closed form"],
+    "tags": ["fibonacci", "specialization", "parent-recovery"]
+  },
+  {
+    "id": "ann-fiboq0502-6",
+    "proofId": "fibonacci-identities-oq-05-oq-02",
+    "range": { "startLine": 146, "endLine": 176 },
+    "type": "concept",
+    "title": "Lucas: the Discriminant Becomes −5",
+    "content": "**Second specialization.** A $\\mathbb{Z}$-valued Lucas sequence is built by structural recursion on the pair $(L_n, L_{n+1})$ (`lucasPair`, `lucasZ`) with $L_0 = 2$, $L_1 = 1$; `lucasZ_hrec` verifies the recurrence by `simp` + `ring`. Instantiating the generic identity gives the discriminant $D = 1^2 - 2\\cdot 1 - 2^2 = 1 - 2 - 4 = -5$ — the discriminant of $x^2 - x - 1$ in the Lucas normalization — and $G_0^2 = 4$. Hence $L_{n+1}^2 = \\sum L_iL_{i+1} + 4 + (\\text{if } n\\text{ even then } -5 \\text{ else } 0)$ (`lucas_prod_sum`), a correction of $-1$ for even $n$ and $4$ for odd $n$. The genuinely signed correction is why the whole development lives over $\\mathbb{Z}$.",
+    "mathContext": "$(G_0,G_1)=(2,1)\\Rightarrow D=-5,\\ G_0^2=4\\Rightarrow L_{n+1}^2 = \\sum L_iL_{i+1} + 4 + (\\text{if } n\\text{ even then } -5 \\text{ else } 0)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lucas numbers", "Discriminant of x²−x−1", "Structural recursion on pairs"],
+    "prerequisites": ["The unified product-sum closed form"],
+    "tags": ["lucas", "specialization", "discriminant"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-05-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-02/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "fibonacci-identities-oq-05-oq-02",
+  "title": "Gibonacci Product-Sum: the Parity Constant is a Discriminant",
+  "slug": "fibonacci-identities-oq-05-oq-02",
+  "description": "Answers the open follow-up of the parent entry fibonacci-identities-oq-05 (the Fibonacci product-sum staircase Fₙ₊₁² = ∑_{i≤n} FᵢFᵢ₊₁ + [n even]) by generalizing it to an arbitrary Gibonacci (Horadam) sequence G obeying Gₙ₊₂ = Gₙ₊₁ + Gₙ with arbitrary integer seeds G₀, G₁. The unified closed form gib_prod_sum is Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + [n even]·D, where D := G₁² − G₀G₁ − G₀² is the sequence's discriminant — the translation-invariant of the recurrence. This exposes the parent's mysterious [n even] toggle as a shadow of the generalized Cassini identity gib_cassini: Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D, proved by a one-line linear_combination induction off the recurrence. The correction term G₀² + [n even]·D specializes cleanly: for Fibonacci (G₀,G₁)=(0,1) it is D=1, G₀²=0, recovering the parent identity Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even] (fib_prod_sum_int); for Lucas (G₀,G₁)=(2,1) the discriminant is D = 1 − 2 − 4 = −5 (the discriminant of x²−x−1 in the Lucas normalization), giving the correction 4 + (if n even then −5 else 0), i.e. −1 for even n and 4 for odd n (lucas_prod_sum). Everything is over ℤ because the correction is genuinely signed for non-Fibonacci seeds. Fully verified: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Lucas; Horadam sequences); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence",
+    "date": "1965",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "lucas-numbers",
+      "gibonacci",
+      "horadam",
+      "cassini",
+      "discriminant",
+      "summation-identity",
+      "parity",
+      "integer-sequences",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ05OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f i) + f n — peels the last product term off each partial sum in the product-sum induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_one",
+        "description": "∑ i ∈ range 1, f i = f 0 — evaluates the base case of the product-sum induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.even_or_odd",
+        "description": "every natural number is even or odd — drives the two-way parity split that resolves the [n even] toggle in the induction step",
+        "module": "Mathlib.Algebra.Parity"
+      },
+      {
+        "theorem": "Even.neg_one_pow / Odd.neg_one_pow",
+        "description": "(−1)ⁿ = 1 for even n and −1 for odd n — collapses the generalized Cassini sign (−1)ⁿ·D to +D or −D in each parity branch of the product-sum step",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.even_add_one",
+        "description": "Even (n+1) ↔ ¬ Even n — advances the parity of the toggle across the successor step",
+        "module": "Mathlib.Algebra.Parity"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the Fibonacci recurrence, cast to ℤ to instantiate the generic Gibonacci hypothesis for the Fibonacci specialization (fib_hrec)",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "linear_combination",
+        "description": "closes each induction step by exhibiting the goal as an explicit ℤ-linear combination of the recurrence hypotheses and the induction hypothesis / Cassini — the algebraic engine of both gib_cassini and gib_prod_sum",
+        "module": "Mathlib.Tactic.LinearCombination"
+      }
+    ],
+    "originalContributions": [
+      "gib_cassini: ∀ (G obeying the recurrence) n, Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·(G₁² − G₀G₁ − G₀²) — the generalized Cassini identity for an arbitrary Gibonacci/Horadam sequence, with the discriminant D = G₁² − G₀G₁ − G₀² as the (−1)ⁿ-modulated invariant. Proved by one-line linear_combination induction.",
+      "gib_prod_sum: ∀ (G obeying the recurrence) n, Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + (if Even n then D else 0) — the unified product-sum closed form generalizing the parent's Fibonacci staircase to arbitrary seeds, identifying the parity constant as the discriminant D.",
+      "gib_prod_sum_even / gib_prod_sum_odd: the two parity branches solved for the sum, ∑_{i≤n} GᵢGᵢ₊₁ = Gₙ₊₁² − G₀² − D (n even) and = Gₙ₊₁² − G₀² (n odd).",
+      "fib_prod_sum_int: recovers the parent identity Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even] as the (G₀,G₁)=(0,1) specialization (D=1, G₀²=0).",
+      "lucas_prod_sum: the Lucas specialization Lₙ₊₁² = ∑ LᵢLᵢ₊₁ + 4 + (if Even n then −5 else 0), with discriminant D=−5, over a ℤ-valued Lucas sequence defined by structural recursion (lucasPair / lucasZ)."
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 176,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used. The generic theorems take the Fibonacci recurrence Gₙ₊₂ = Gₙ₊₁ + Gₙ as an explicit hypothesis on G, not as an axiom.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The parent entry formalizes the classical Fibonacci product-sum staircase F₀F₁ + ⋯ + FₙFₙ₊₁ = Fₙ₊₁² − [n even], whose correction term [n even] toggles between 1 and 0 with no evident reason. Horadam's mid-20th-century study of generalized second-order recurrences (Gₙ₊₂ = Gₙ₊₁ + Gₙ with arbitrary seeds — the 'Gibonacci' or Horadam sequences) supplies the missing context: the toggle is one value of a single invariant, the discriminant D = G₁² − G₀G₁ − G₀², which governs the whole family through the generalized Cassini identity. Writing the product-sum identity for arbitrary seeds turns the ad-hoc parity constant into a structural quantity.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-05)**: Generalize the product-sum identity to the Lucas numbers LₖLₖ₊₁ and to general Gibonacci (Horadam) sequences, tracking how the parity constant becomes a discriminant.\n\n**Result**: For any sequence G with Gₙ₊₂ = Gₙ₊₁ + Gₙ, Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + [n even]·D where D = G₁² − G₀G₁ − G₀² (gib_prod_sum). Fibonacci (D=1, G₀²=0) recovers the parent; Lucas (D=−5) gives correction 4 + (if n even then −5 else 0).",
+    "text": "A Gibonacci sequence over ℤ is any G with G₀, G₁ arbitrary and Gₙ₊₂ = Gₙ₊₁ + Gₙ. Its discriminant is D = G₁² − G₀G₁ − G₀², the (−1)ⁿ-modulated invariant of the generalized Cassini identity Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D. The product-sum then reads Gₙ₊₁² = (∑_{i=0}^{n} GᵢGᵢ₊₁) + G₀² + (if n even then D else 0). For Fibonacci (0,1): D=1, G₀²=0, so Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even]. For Lucas (2,1): D = 1−2−4 = −5, G₀²=4, so the correction is −1 (n even) or 4 (n odd).",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Generalized Cassini (`gib_cassini`).** For any G obeying the recurrence, prove Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D by induction. Base: substitute G₂ = G₁ + G₀ and `ring`. Step: introduce the recurrence at k and k+1, normalize the successor indices with `show`, and close with `linear_combination -ih + G(k+2)·h1 − G(k+1)·h2` — the step is an exact ℤ-linear combination of the induction hypothesis and two instances of the recurrence.\n2. **Product-sum (`gib_prod_sum`).** Induct on n. Base: `if_pos (Even 0)`, `Finset.sum_range_one`, `ring`. Step: peel the last term with `Finset.sum_range_succ`, split on `Nat.even_or_odd`. In each branch resolve both `if`s by parity, specialize Cassini's sign via `Even.neg_one_pow` / `Odd.neg_one_pow` to ±D, substitute the recurrence, and close with a single `linear_combination` of the induction hypothesis, Cassini, and the recurrence.\n3. **Parity corollaries (`gib_prod_sum_even`, `gib_prod_sum_odd`).** Solve the main identity for the sum in each parity, discharging the `if` with `if_pos` / `if_neg` and `linarith`.\n4. **Specializations.** Fibonacci: instantiate the generic hypothesis with `fib_hrec` (Nat.fib_add_two cast to ℤ) and `simp` away G₀=0, G₁=1 (`fib_prod_sum_int`). Lucas: define the pair (Lₙ, Lₙ₊₁) by structural recursion (`lucasPair`), take the first coordinate (`lucasZ`), verify the recurrence by `simp`+`ring` (`lucasZ_hrec`), instantiate, and `norm_num` the discriminant to −5 (`lucas_prod_sum`).",
+    "keyInsights": [
+      "**The parity constant is the discriminant.** The parent's opaque [n even] toggle is exactly [n even]·D with D=1 for Fibonacci. Writing the identity for arbitrary seeds makes D = G₁² − G₀G₁ − G₀² visible as the single invariant controlling the correction — the same D that appears in the generalized Cassini identity.",
+      "**One generic proof, many sequences.** Both the Fibonacci and Lucas identities are `simp`/`norm_num` specializations of the seed-agnostic `gib_prod_sum`. The recurrence enters as an explicit hypothesis on G, so the theorem applies to every Horadam sequence at once; the seeds only fix the two constants G₀² and D.",
+      "**Cassini drives everything, seed-free.** The generalized Cassini identity Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D holds for any G obeying the recurrence and reduces, in each product-sum step, to a one-line `linear_combination`. The discriminant is the translation-invariant that survives the induction.",
+      "**Signs force ℤ.** For seeds other than Fibonacci's (0,1) the correction G₀² + [n even]·D is genuinely signed (D=−5 for Lucas), so the entire development lives over ℤ — no ℕ subtraction, no casting side-conditions."
+    ],
+    "prerequisites": [
+      "Second-order linear recurrences and Horadam/Gibonacci sequences Gₙ₊₂ = Gₙ₊₁ + Gₙ",
+      "Cassini's identity and its (−1)ⁿ sign; the notion of the recurrence discriminant D = G₁² − G₀G₁ − G₀²",
+      "Induction with Finset.sum_range_succ; the linear_combination tactic over ℤ; parity case splits via Nat.even_or_odd"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring framing the entry as the Gibonacci/Horadam generalization of the parent product-sum staircase, identifying the parity constant [n even] as the discriminant D = G₁² − G₀G₁ − G₀², and previewing the Fibonacci and Lucas specializations. Import, namespace, and open Finset setup.",
+      "mathContext": "$G_{n+1}^2 = \\left(\\sum_{i\\le n} G_iG_{i+1}\\right) + G_0^2 + [n\\text{ even}]\\cdot D$, where $D = G_1^2 - G_0G_1 - G_0^2$."
+    },
+    {
+      "id": "generic-cassini",
+      "title": "Generalized Cassini Identity",
+      "startLine": 49,
+      "endLine": 73,
+      "summary": "gib_cassini: for any G obeying Gₙ₊₂ = Gₙ₊₁ + Gₙ, Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·(G₁² − G₀G₁ − G₀²). Induction off the recurrence, step closed by linear_combination of the induction hypothesis and two recurrence instances. The discriminant D is the (−1)ⁿ-modulated invariant.",
+      "mathContext": "$G_{n+1}^2 - G_n G_{n+2} = (-1)^n\\,(G_1^2 - G_0G_1 - G_0^2)$."
+    },
+    {
+      "id": "gibonacci-prod-sum",
+      "title": "The Gibonacci Product-Sum Closed Form",
+      "startLine": 75,
+      "endLine": 127,
+      "summary": "gib_prod_sum: Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + (if Even n then D else 0). Induction on n with a parity split; each branch resolves both `if`s, specializes Cassini's sign to ±D, and closes with a single linear_combination. The even/odd corollaries gib_prod_sum_even, gib_prod_sum_odd solve for the sum in each parity.",
+      "mathContext": "$G_{n+1}^2 = \\left(\\sum_{i=0}^{n} G_iG_{i+1}\\right) + G_0^2 + (\\text{if } n\\text{ even then } D \\text{ else } 0)$."
+    },
+    {
+      "id": "fibonacci-specialization",
+      "title": "Fibonacci Specialization",
+      "startLine": 130,
+      "endLine": 144,
+      "summary": "fib_hrec casts the Fibonacci recurrence Nat.fib_add_two to ℤ; fib_prod_sum_int instantiates the generic identity at (G₀,G₁)=(0,1), where D=1 and G₀²=0, recovering the parent entry Fₙ₊₁² = ∑ FᵢFᵢ₊₁ + [n even].",
+      "mathContext": "$F_{n+1}^2 = \\left(\\sum_{i=0}^{n} F_iF_{i+1}\\right) + [n\\text{ even}]$."
+    },
+    {
+      "id": "lucas-specialization",
+      "title": "Lucas Specialization: Discriminant −5",
+      "startLine": 146,
+      "endLine": 176,
+      "summary": "A ℤ-valued Lucas sequence is built by structural recursion on the pair (Lₙ, Lₙ₊₁) (lucasPair, lucasZ) with L₀=2, L₁=1; lucasZ_hrec verifies the recurrence. lucas_prod_sum instantiates the generic identity: the discriminant is D = 1−2−4 = −5, so Lₙ₊₁² = ∑ LᵢLᵢ₊₁ + 4 + (if Even n then −5 else 0), i.e. correction −1 (n even) or 4 (n odd).",
+      "mathContext": "$L_{n+1}^2 = \\left(\\sum_{i=0}^{n} L_iL_{i+1}\\right) + 4 + (\\text{if } n\\text{ even then } -5 \\text{ else } 0)$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-05",
+      "relationship": "answers",
+      "description": "Settles the parent's open follow-up — generalizing the product-sum identity to Lucas numbers and to general Gibonacci (Horadam) sequences — by exhibiting the closed form Gₙ₊₁² = ∑ GᵢGᵢ₊₁ + G₀² + [n even]·D and identifying the parity constant as the discriminant D = G₁² − G₀G₁ − G₀²."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-05-oq-01",
+      "relationship": "relatedTo",
+      "description": "Sibling refinement of the same parent product staircase; there the weighted and alternating sums are settled for Fibonacci, here the plain product sum is generalized to arbitrary Gibonacci seeds. Both are driven by the Cassini identity in subtractive form."
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "relatedTo",
+      "description": "The base entry's Fibonacci summation identities are the (G₀,G₁)=(0,1) shadow of the seed-agnostic Gibonacci identities proved here."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) resolution of the parent's open follow-up. For any Gibonacci sequence G with Gₙ₊₂ = Gₙ₊₁ + Gₙ, the product-sum closed form is Gₙ₊₁² = (∑_{i≤n} GᵢGᵢ₊₁) + G₀² + [n even]·D with discriminant D = G₁² − G₀G₁ − G₀². The parent's [n even] toggle is the Fibonacci case D=1, G₀²=0; the Lucas case has D=−5, giving correction −1 (n even) / 4 (n odd). The engine is the generalized Cassini identity Gₙ₊₁² − Gₙ·Gₙ₊₂ = (−1)ⁿ·D, proved by a one-line linear_combination induction.",
+    "implications": "Reframes an ad-hoc parity constant as a structural invariant: the correction term of the product-sum identity is fixed by the two seed constants G₀² and D across the entire Horadam family. Because the recurrence is carried as an explicit hypothesis, a single generic proof yields the Fibonacci and Lucas identities (and every other second-order Gibonacci sequence) as `simp`/`norm_num` specializations. The generalized Cassini identity for arbitrary seeds is supplied as a reusable byproduct.",
+    "openQuestions": [
+      "Generalize to the full Horadam recurrence Gₙ₊₂ = pGₙ₊₁ − qGₙ (arbitrary p, q), tracking how the discriminant becomes p²-dependent and how the product-sum correction picks up the multiplier q.",
+      "Establish the companion sum-of-squares closed form ∑_{i≤n} Gᵢ² for general Gibonacci sequences and relate its correction term to the same discriminant D."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Horadam, A. F.",
+      "title": "Basic Properties of a Certain Generalized Sequence of Numbers",
+      "year": "1965",
+      "venue": "The Fibonacci Quarterly",
+      "note": "Introduces the generalized (Horadam / Gibonacci) sequences and their invariants, including the discriminant governing Cassini-type identities"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Product-sum and Cassini identities for Fibonacci and Lucas numbers; the seed-dependent correction terms"
+    },
+    {
+      "authors": "Vajda, Steven",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section",
+      "year": "1989",
+      "venue": "Ellis Horwood",
+      "note": "Generalized Fibonacci sequences and the discriminant of the second-order recurrence"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **amgm-inequality-oq-02-oq-05** — *Newton's Inequalities for Four Variables: n=4 Log-Concavity, Axiom-Free*.

The parent `amgm-inequality-oq-02` proves Newton's k=1 inequality from scratch but **axiomatizes** the general log-concavity `newton_log_concavity` (pₖ² ≥ pₖ₋₁pₖ₊₁). The sibling `amgm-inequality-oq-02-oq-04` discharged that axiom for **n=3** and, in its own open-questions list, explicitly asked for the **n=4 SOS certificate**. This entry answers it.

For four variables the normalized sequence p₀,…,p₄ (pₖ = eₖ/C(4,k), C(4,·)=1,4,6,4,1) has **three** log-concavity inequalities, all proved axiom-free as exact sum-of-squares certificates valid for **all real inputs** (strictly stronger than the parent axiom, which assumed nonnegativity):

| position | Newton form | note |
|---|---|---|
| N1 (k=1) | `3e₁² ≥ 8e₂` | boundary, SOS of Σ(xᵢ−xⱼ)² |
| N2 (k=2) | `4e₂² ≥ 9e₁e₃` | **interior — the genuinely new content, no reciprocal symmetry** |
| N3 (k=3) | `3e₃² ≥ 8e₂e₄` | reciprocal dual of N1 (xᵢ ↦ 1/xᵢ) |

Additional results:
- `logConcave_1/2/3` — the normalized `pₖ² ≥ pₖ₋₁pₖ₊₁` form.
- `newton_N1_identity` + `newton_N1_eq_iff` — exact gap `3e₁²−8e₂ = Σ_{i<j}(xᵢ−xⱼ)²` and equality iff **a=b=c=d**.
- `amgm_four` / `amgm_four_mean` — recovers the four-variable AM–GM `(a+b+c+d)⁴ ≥ 256abcd` as the chain endpoint.

## Verification

- **0 axioms, 0 sorries.** `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for newton_N1, newton_N2, newton_N3, logConcave_2, newton_N1_eq_iff, amgm_four, amgm_four_mean.
- The parent's `newton_log_concavity` axiom is **not** used.
- Builds clean under Lean toolchain 4.31.0 (`lake env lean Proofs/AmgmInequalityOQ02OQ05.lean`).

## Files
- `proofs/Proofs/AmgmInequalityOQ02OQ05.lean` (177 lines, 10 theorems, 9 defs)
- `src/data/proofs/amgm-inequality-oq-02-oq-05/meta.json`
- `src/data/proofs/amgm-inequality-oq-02-oq-05/annotations.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)