### PR TITLE
audit: 3 never-audited OQ entries (2 clean, 1 assumptions-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26845,6 +26845,24 @@
       "lastAudited": "2026-07-01T18:37:50Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "dirichlet-approximation-theorem-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T19:35:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1000-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T19:37:01Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "fibonacci-identities-oq-06-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T19:37:36Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/erdos-1000-oq-03-oq-03/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-03/meta.json
@@ -120,6 +120,6 @@
     "lineCount": 123,
     "theoremCount": 5,
     "definitionCount": 1,
-    "assumptions": ""
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The only foundational axioms used are propext / Classical.choice / Quot.sound. The result is unconditional: J_k := mu * pow k in the Dirichlet ring ArithmeticFunction Z, the Gauss divisor-sum identity sum_{d|n} J_k(d) = n^k holds for all n != 0, and the uniqueness characterisation jordan_unique holds for every f : N -> Z on the positives. The proofs are convolution algebra over Mathlib's ArithmeticFunction ring: coe_moebius_mul_coe_zeta (mu * zeta = 1), coe_mul_zeta_apply ((f * zeta) n = sum over divisors), mul_apply, and sum_eq_iff_sum_smul_moebius_eq (Mobius inversion) for the converse; the k=1 recoveries use Nat.sum_totient. Mathlib supplies the Dirichlet-ring and Mobius-inversion API; the Jordan-totient divisor-sum identity, its uniqueness converse, and the totient specialisations are assembled in-file (none are named Mathlib theorems)."
   }
 }


### PR DESCRIPTION
## Gallery Integrity Audit — batch of 3 never-audited entries

All quantitative claims verified against Lean source (`proofs/Proofs/*.lean`). `sorry`/`native_decide` grep hits in each file were confirmed to be docstring prose only.

### ✅ dirichlet-approximation-theorem-oq-05-oq-02 — CLEAN
`Every Quadratic Surd √d is Badly Approximable`. 6 theorems, 0 sorries, 0 axioms, 178 lines — all match. Badge `original` justified: the norm-form identity, non-vanishing, and lower-bound case analysis are entirely in-file; Mathlib supplies only irrationality inputs (`irrational_sqrt_two`, `Nat.Prime.irrational_sqrt`, `Irrational.ne_rational`), honestly disclosed in `assumptions`.

### ✅ fibonacci-identities-oq-06-oq-01-oq-03 — CLEAN
`Doubled-Argument Fibonacci Binomial Transform is a (5,5) Lucas Sequence`. 8 theorems/lemmas, 4 defs, 0 sorries, 0 axioms, 142 lines — all match. Badge `verified` appropriate: the recurrence `Cₙ₊₂ = 5Cₙ₊₁ − 5Cₙ` is derived from scratch (`pascal_conv_ring` + `Nat.fib_add_two`), no deep Mathlib theorem doing the core work.

### 🔧 erdos-1000-oq-03-oq-03 — ISSUES-FIXED (LOW)
`Gauss's Divisor-Sum Identity for Jordan's Totient, via the Dirichlet Ring`. 5 theorems, 1 def, 0 sorries, 0 axioms, 123 lines — all counts accurate; description already discloses the Mathlib Dirichlet-ring dependencies transparently. Badge `original` is consistent with the sibling family (`-oq-03-oq-01/-oq-02/-oq-01-oq-01` are all `original/verified`).

**Fix**: the `assumptions` field was **empty** on a `verified/original` entry. Populated it with the standard axiom-basis disclosure (propext / Classical.choice / Quot.sound, no native_decide) and a note that the Dirichlet-ring + Möbius-inversion API comes from Mathlib while the Jordan-totient divisor-sum identity, its uniqueness converse, and the totient specialisations are assembled in-file.

---
Discovered during gallery integrity audit. A separate PR (#32476) records `combinations-formula-oq-07-oq-01-oq-01` clean. Note: `dirichlet-approximation-theorem-oq-01-oq-03` appeared as a target but is untracked in-flight researcher work (Lean source not yet committed) — released, not audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)