### PR TITLE
research(erdos-1021-wip-02): G_k is C₄-free (codegree ≤ 1) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1021Wip02.lean
+++ b/proofs/Proofs/Erdos1021Wip02.lean
@@ -1,0 +1,216 @@
+/-
+# Erdős Problem #1021 — WIP-02
+## The bipartite pair graph G_k is C₄-free
+
+Erdős Problem #1021 asks whether, for every `k ≥ 3`, there is `c_k > 0` with
+`ex(n, G_k) ≪ n^{3/2 - c_k}`. That question is OPEN and this file does NOT touch it.
+
+The sibling files pin down the *asymptotic* boundary (`Erdos1021OQ01Incomplete01.lean`:
+the exponent gap `1/(k-1) → 0`, the `o ⟹ O` collapse) and the *local degree structure*
+(`Erdos1021Wip01.lean`: pair vertices have degree `2`, primary vertices degree `k - 1`).
+Neither says anything, machine-checked, about **why `n^{3/2}` is the natural exponent at all**.
+
+This file supplies that missing structural fact, with **zero axioms and zero sorries**:
+
+> **`G_k` is C₄-free**: any two distinct vertices of `G_k` have **at most one common
+> neighbour**.
+
+Equivalently, `G_k` contains no `K_{2,2}` (no `4`-cycle): the *codegree* of every pair of
+distinct vertices is `≤ 1`. This is exactly the hypothesis of the Kővári–Sós–Turán / Reiman
+theorem, whose conclusion is `ex(n, C₄) ≤ ½(1 + √(4n-3))·n = O(n^{3/2})`. So the `n^{3/2}`
+appearing throughout Problem #1021 is not an accident of the definition of `G_k`; it is forced
+by this elementary `C₄`-freeness, proved here from first principles.
+
+Why `G_k` is C₄-free, combinatorially:
+* two **primary** vertices `y_i, y_j` (`i ≠ j`) have a common neighbour only at the pair
+  vertex `{i,j}` — the unique pair containing both `i` and `j`;
+* two **pair** vertices `⟨{a,b}⟩ ≠ ⟨{c,d}⟩` have a common neighbour `y_m` only when
+  `m ∈ {a,b} ∩ {c,d}`, and two distinct `2`-element sets meet in at most one point;
+* a **primary** and a **pair** vertex have no common neighbour at all (`G_k` is bipartite).
+
+The file is deliberately **self-contained** (same robustness choice as `Wip01`/`Incomplete01`):
+it re-declares `G_k` locally rather than importing `Erdos1021Problem.lean`.
+
+## References
+- Kővári, T., Sós, V., Turán, P. (1954). "On a problem of K. Zarankiewicz." Coll. Math. 3:50–57.
+- Reiman, I. (1958). "Über ein Problem von K. Zarankiewicz." Acta Math. Acad. Sci. Hungar. 9.
+- Bondy, J.A., Simonovits, M. (1974). "Cycles of even length in graphs." J. Combin. Theory 16.
+- https://erdosproblems.com/1021
+-/
+
+import Mathlib
+
+open SimpleGraph
+
+namespace Erdos1021Wip02
+
+variable {k : ℕ}
+
+/-! ## The bipartite pair graph G_k (local, self-contained definition)
+
+`G_k` has `k` "primary" vertices `Fin k` and `C(k,2)` "pair" vertices — unordered pairs
+`{a,b} ⊂ Fin k` encoded as ordered `(a,b)` with `a < b`. Each pair vertex is adjacent to
+exactly the two primary vertices of its pair. This matches `Erdos1021.Gk` and
+`Erdos1021Wip01.Gk`. -/
+
+/-- The vertex type for `G_k`: a primary vertex (`Fin k`) or a pair vertex. -/
+abbrev Gk_vertex (k : ℕ) := Fin k ⊕ { p : Fin k × Fin k // p.1 < p.2 }
+
+/-- `G_k`: each pair vertex `⟨(a,b)⟩` is adjacent to exactly primary vertices `a` and `b`. -/
+def Gk (k : ℕ) : SimpleGraph (Gk_vertex k) where
+  Adj v w := match v, w with
+    | Sum.inl i, Sum.inr ⟨(a, b), _⟩ => i = a ∨ i = b
+    | Sum.inr ⟨(a, b), _⟩, Sum.inl i => i = a ∨ i = b
+    | _, _ => False
+  symm := by
+    intro v w h
+    rcases v with i | ⟨⟨a, b⟩, hab⟩ <;> rcases w with j | ⟨⟨c, d⟩, hcd⟩ <;> exact h
+  loopless := by
+    intro v h
+    rcases v with i | ⟨⟨a, b⟩, hab⟩ <;> exact h
+
+/-! ## Part I: Adjacency characterizations (mirrors `Wip01`) -/
+
+/-- A pair vertex `⟨{a,b}⟩` is adjacent in `G_k` to exactly the primaries `y_a` and `y_b`. -/
+theorem adj_pair_iff (a b : Fin k) (hab : a < b) (w : Gk_vertex k) :
+    (Gk k).Adj (Sum.inr ⟨(a, b), hab⟩) w ↔ w = Sum.inl a ∨ w = Sum.inl b := by
+  cases w with
+  | inl i => simp only [Gk, Sum.inl.injEq]
+  | inr q =>
+      simp only [Gk]
+      constructor
+      · exact False.elim
+      · rintro (h | h) <;> exact (Sum.inr_ne_inl h).elim
+
+/-- A primary vertex `y_i` is adjacent in `G_k` to exactly the pair vertices containing `i`. -/
+theorem adj_primary_iff (i : Fin k) (w : Gk_vertex k) :
+    (Gk k).Adj (Sum.inl i) w ↔
+      ∃ q : { p : Fin k × Fin k // p.1 < p.2 }, w = Sum.inr q ∧ (i = q.val.1 ∨ i = q.val.2) := by
+  cases w with
+  | inl j =>
+      simp only [Gk]
+      constructor
+      · exact False.elim
+      · rintro ⟨q, hq, _⟩; exact (Sum.inl_ne_inr hq).elim
+  | inr q =>
+      obtain ⟨⟨a, b⟩, hab⟩ := q
+      simp only [Gk, Sum.inr.injEq]
+      constructor
+      · intro h; exact ⟨⟨(a, b), hab⟩, rfl, h⟩
+      · rintro ⟨q', hq', h⟩
+        obtain ⟨⟨a', b'⟩, hab'⟩ := q'
+        cases hq'; exact h
+
+/-- Projection-free adjacency: a primary `y_i` is adjacent to the pair vertex `⟨(a,b)⟩`
+    exactly when `i ∈ {a, b}`. (Convenient form for the case analysis below.) -/
+theorem adj_primary_pair (i a b : Fin k) (hab : a < b) :
+    (Gk k).Adj (Sum.inl i) (Sum.inr ⟨(a, b), hab⟩) ↔ (i = a ∨ i = b) := by
+  simp only [Gk]
+
+/-- Projection-free adjacency: the pair vertex `⟨(a,b)⟩` is adjacent to a primary `y_m`
+    exactly when `m ∈ {a, b}`. -/
+theorem adj_pair_inl (a b : Fin k) (hab : a < b) (m : Fin k) :
+    (Gk k).Adj (Sum.inr ⟨(a, b), hab⟩) (Sum.inl m) ↔ (m = a ∨ m = b) := by
+  simp only [Gk]
+
+/-! ## Part II: `G_k` is C₄-free — every two distinct vertices have ≤ 1 common neighbour
+
+The heart of the file. We prove the neighbourhood intersection of any two distinct vertices
+is a *subsingleton*, i.e. has at most one element (`codegree ≤ 1`). -/
+
+/-- **`G_k` is C₄-free.** The set of common neighbours of any two distinct vertices `v ≠ w`
+is a subsingleton: there is at most one vertex adjacent to both. Equivalently, `G_k` contains
+no `K_{2,2}` (no `4`-cycle) — the Kővári–Sós–Turán hypothesis forcing `ex(n, G_k) = O(n^{3/2})`.
+
+The proof is a case analysis on the two sides of the bipartition:
+* two primaries `y_i, y_j` share only the pair vertex `{i,j}`;
+* two distinct pair vertices `{a,b}, {c,d}` share only a primary in `{a,b} ∩ {c,d}`, and
+  two distinct `2`-sets meet in `≤ 1` point;
+* a primary and a pair vertex share nothing (bipartiteness). -/
+theorem Gk_common_neighbors_subsingleton (v w : Gk_vertex k) (hvw : v ≠ w) :
+    Set.Subsingleton ((Gk k).neighborSet v ∩ (Gk k).neighborSet w) := by
+  rintro u₁ ⟨h1v, h1w⟩ u₂ ⟨h2v, h2w⟩
+  simp only [mem_neighborSet] at h1v h1w h2v h2w
+  -- Split on the two sides of `v` and `w`.
+  rcases v with i | ⟨⟨a, b⟩, hab⟩ <;> rcases w with j | ⟨⟨c, d⟩, hcd⟩
+  · -- v = y_i, w = y_j : common neighbours are pair vertices; the pair `{i,j}` is forced.
+    have hij : i ≠ j := fun h => hvw (congrArg Sum.inl h)
+    -- Neighbours of a primary are pair vertices, so `u₁, u₂` have the form `Sum.inr _`.
+    obtain ⟨⟨⟨e₁, f₁⟩, hef₁⟩, rfl⟩ : ∃ q, u₁ = Sum.inr q := by
+      cases u₁ with
+      | inl x => simp only [Gk] at h1v
+      | inr q => exact ⟨q, rfl⟩
+    obtain ⟨⟨⟨e₂, f₂⟩, hef₂⟩, rfl⟩ : ∃ q, u₂ = Sum.inr q := by
+      cases u₂ with
+      | inl x => simp only [Gk] at h2v
+      | inr q => exact ⟨q, rfl⟩
+    rw [adj_primary_pair] at h1v h2v h1w h2w
+    dsimp only at hef₁ hef₂
+    -- h1v : i = e₁ ∨ i = f₁, h1w : j = e₁ ∨ j = f₁, h2v : i = e₂ ∨ i = f₂, h2w : j = e₂ ∨ j = f₂
+    suffices h : e₁ = e₂ ∧ f₁ = f₂ by obtain ⟨rfl, rfl⟩ := h; rfl
+    rcases h1v with rfl | rfl <;> rcases h1w with h1w | h1w <;>
+      rcases h2v with h2v | h2v <;> rcases h2w with h2w | h2w <;>
+      exact ⟨by omega, by omega⟩
+  · -- v = y_i (primary), w = pair `{c,d}` : no common neighbour (bipartite ⇒ contradiction).
+    rw [adj_primary_iff] at h1v
+    obtain ⟨q, rfl, _⟩ := h1v
+    rw [adj_pair_iff c d hcd] at h1w
+    rcases h1w with h | h <;> exact absurd h (by simp)
+  · -- symmetric to the previous case.
+    rw [adj_primary_iff] at h1w
+    obtain ⟨q, rfl, _⟩ := h1w
+    rw [adj_pair_iff a b hab] at h1v
+    rcases h1v with h | h <;> exact absurd h (by simp)
+  · -- v = pair `{a,b}`, w = pair `{c,d}` : common neighbours are primaries in `{a,b}∩{c,d}`.
+    have hpairs : ¬ (a = c ∧ b = d) := by rintro ⟨rfl, rfl⟩; exact hvw rfl
+    -- Neighbours of a pair vertex are primaries, so `u₁, u₂` have the form `Sum.inl _`.
+    obtain ⟨m₁, rfl⟩ : ∃ m, u₁ = Sum.inl m := by
+      cases u₁ with
+      | inl m => exact ⟨m, rfl⟩
+      | inr q => simp only [Gk] at h1v
+    obtain ⟨m₂, rfl⟩ : ∃ m, u₂ = Sum.inl m := by
+      cases u₂ with
+      | inl m => exact ⟨m, rfl⟩
+      | inr q => simp only [Gk] at h2v
+    rw [adj_pair_inl a b hab] at h1v h2v
+    rw [adj_pair_inl c d hcd] at h1w h2w
+    dsimp only at hab hcd
+    -- h1v : m₁ = a ∨ m₁ = b, h1w : m₁ = c ∨ m₁ = d, h2v : m₂ = a ∨ m₂ = b, h2w : m₂ = c ∨ m₂ = d
+    suffices h : m₁ = m₂ by rw [h]
+    rcases h1v with rfl | rfl <;> rcases h1w with h1w | h1w <;>
+      rcases h2v with h2v | h2v <;> rcases h2w with h2w | h2w <;>
+      omega
+
+/-- **Codegree bound (C₄-free, cardinality form).** Any two distinct vertices of `G_k` have
+at most one common neighbour: the neighbourhood intersection has `ncard ≤ 1`. -/
+theorem Gk_codegree_le_one (v w : Gk_vertex k) (hvw : v ≠ w) :
+    ((Gk k).neighborSet v ∩ (Gk k).neighborSet w).ncard ≤ 1 := by
+  rw [Set.ncard_le_one]
+  intro x hx y hy
+  exact Gk_common_neighbors_subsingleton v w hvw hx hy
+
+/-- **No `4`-cycle, explicit form.** There do not exist two distinct vertices `v ≠ w` with two
+*distinct* common neighbours `u₁ ≠ u₂`. This is the standard statement that `G_k` is C₄-free
+(contains no `K_{2,2}`), read off directly from the subsingleton bound. -/
+theorem Gk_no_C4 (v w u₁ u₂ : Gk_vertex k)
+    (hvw : v ≠ w)
+    (h1 : (Gk k).Adj v u₁) (h2 : (Gk k).Adj w u₁)
+    (h3 : (Gk k).Adj v u₂) (h4 : (Gk k).Adj w u₂) :
+    u₁ = u₂ :=
+  Gk_common_neighbors_subsingleton v w hvw ⟨h1, h2⟩ ⟨h3, h4⟩
+
+/-! ## Part III: Summary
+
+Proved here (0 axioms, 0 sorries), all about the *actual* graph `G_k`:
+* `adj_pair_iff`, `adj_primary_iff` — exact adjacency on each side (as in `Wip01`).
+* `Gk_common_neighbors_subsingleton` — **`G_k` is C₄-free**: two distinct vertices have at
+  most one common neighbour (codegree `≤ 1`).
+* `Gk_codegree_le_one` — the same fact in cardinality (`ncard ≤ 1`) form.
+* `Gk_no_C4` — the explicit "no `K_{2,2}` / no `4`-cycle" statement.
+
+This is the elementary structural reason the Kővári–Sós–Turán bound applies and `n^{3/2}` is
+the natural exponent for Erdős Problem #1021. The problem itself — whether the exponent can be
+*beaten* to `3/2 - c_k` — remains OPEN and is untouched here.
+-/
+
+end Erdos1021Wip02

--- a/src/data/proofs/erdos-1021-wip-02/annotations.json
+++ b/src/data/proofs/erdos-1021-wip-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-header-def",
+    "proofId": "erdos-1021-wip-02",
+    "range": { "startLine": 1, "endLine": 70 },
+    "type": "definition",
+    "title": "The Pair Graph G_k (self-contained definition)",
+    "content": "Erdős #1021 asks whether ex(n, G_k) ≪ n^{3/2−c_k} for some c_k > 0 — open, and untouched here. This file instead proves the structural fact that makes the trivial n^{3/2} bound apply. The header explains the design: G_k is re-declared locally (matching the sibling Erdos1021Wip01) rather than imported from the parent Erdos1021Problem.lean. The vertex type Gk_vertex k = Fin k ⊕ {p : Fin k × Fin k // p.1 < p.2} is a disjoint sum of k primary vertices and the C(k,2) pair vertices (unordered pairs encoded as ordered (a,b) with a < b). The graph Gk k makes a pair vertex ⟨(a,b)⟩ adjacent to exactly the two primary vertices a and b (and nothing on the same side), with symmetry and looplessness discharged by case analysis on the Sum constructors.",
+    "mathContext": "$V(G_k) = \\mathrm{Fin}\\,k \\sqcup \\{\\{a,b\\} \\subset \\mathrm{Fin}\\,k\\}$; $z_{\\{a,b\\}} \\sim y_a, y_b$ only.",
+    "significance": "supporting",
+    "relatedConcepts": ["bipartite pair graph", "Zarankiewicz problem", "SimpleGraph structure", "Sum/subtype vertex encoding"],
+    "prerequisites": ["SimpleGraph (Adj, symm, loopless)", "Sum types and subtypes in Lean", "unordered pairs as ordered a < b"]
+  },
+  {
+    "id": "ann-adjacency",
+    "proofId": "erdos-1021-wip-02",
+    "range": { "startLine": 72, "endLine": 115 },
+    "type": "theorem",
+    "title": "Adjacency Characterizations (adj_pair_iff, adj_primary_iff, adj_primary_pair, adj_pair_inl)",
+    "content": "Four iff-lemmas translate the match-defined Adj into clean membership conditions. adj_pair_iff: a pair vertex ⟨(a,b)⟩ is adjacent to w iff w = Sum.inl a or w = Sum.inl b. adj_primary_iff: a primary y_i is adjacent to w iff w is a pair vertex Sum.inr q whose pair contains i. The two projection-free forms adj_primary_pair (y_i ∼ ⟨(a,b)⟩ ↔ i = a ∨ i = b) and adj_pair_inl (⟨(a,b)⟩ ∼ y_m ↔ m = a ∨ m = b) avoid Subtype.val/Prod projections entirely, so the disjunctions they produce are directly consumable by omega in the main case analysis — the key to keeping the C₄-free proof arithmetic-clean.",
+    "mathContext": "$z_{\\{a,b\\}} \\sim w \\iff w \\in \\{y_a, y_b\\}$;  $y_i \\sim z_{\\{a,b\\}} \\iff i \\in \\{a,b\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["adjacency characterization", "case analysis on Sum", "projection-free lemmas for omega", "neighbor conditions"],
+    "prerequisites": ["the Gk definition", "pattern-matching on Sum constructors", "iff proofs by simp"]
+  },
+  {
+    "id": "ann-c4-free",
+    "proofId": "erdos-1021-wip-02",
+    "range": { "startLine": 116, "endLine": 184 },
+    "type": "theorem",
+    "title": "G_k is C₄-free — codegree ≤ 1 (Gk_common_neighbors_subsingleton)",
+    "content": "The heart of the file: the set of common neighbours of any two distinct vertices v ≠ w is a Set.Subsingleton (at most one element). The proof splits on the two sides of the bipartition. (1) Both primaries y_i, y_j: since G_k is bipartite, common neighbours are pair vertices; obtaining them as Sum.inr ⟨(e,f),·⟩ and rewriting through adj_primary_pair gives four membership disjunctions i ∈ {e₁,f₁}, j ∈ {e₁,f₁}, i ∈ {e₂,f₂}, j ∈ {e₂,f₂}; with i ≠ j and the orderings e < f, an rcases + omega sweep forces (e₁,f₁) = (e₂,f₂), i.e. both common neighbours are the unique pair {i,j}. (2) Mixed primary/pair: a common neighbour would have to be simultaneously a pair vertex (neighbour of a primary) and a primary (neighbour of a pair) — impossible, so the intersection is empty. (3) Both pair vertices {a,b} ≠ {c,d}: common neighbours are primaries y_m with m ∈ {a,b} ∩ {c,d}; distinctness ¬(a = c ∧ b = d) plus a < b, c < d forces m unique via rcases + omega, since two distinct 2-element sets meet in at most one point.",
+    "mathContext": "$v \\ne w \\implies |N(v) \\cap N(w)| \\le 1$: two primaries share only $\\{i,j\\}$; two distinct pairs share $\\le 1$ primary; bipartiteness kills the mixed case.",
+    "significance": "key",
+    "relatedConcepts": ["C₄-free / K_{2,2}-free", "codegree", "Kővári–Sós–Turán hypothesis", "Set.Subsingleton", "bipartite case analysis", "omega over Fin"],
+    "prerequisites": ["the adjacency lemmas", "Set.Subsingleton on a neighbourhood intersection", "rcases on disjunctions + omega", "distinct 2-sets meet in ≤ 1 point"]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "erdos-1021-wip-02",
+    "range": { "startLine": 185, "endLine": 216 },
+    "type": "theorem",
+    "title": "Codegree Bound and No 4-Cycle (Gk_codegree_le_one, Gk_no_C4)",
+    "content": "Two immediate corollaries package the subsingleton bound. Gk_codegree_le_one restates it in cardinality form: the neighbourhood intersection of any two distinct vertices has ncard ≤ 1, via Set.ncard_le_one (finiteness of the ambient Fintype vertex set is automatic). Gk_no_C4 gives the explicit graph-theoretic statement that there are no two distinct vertices v ≠ w with two distinct common neighbours u₁, u₂ — i.e. G_k has no K_{2,2} and no 4-cycle. Together these are exactly the Kővári–Sós–Turán / Reiman hypothesis whose conclusion is ex(n, G_k) = O(n^{3/2}), explaining why the n^{3/2} exponent is natural for Erdős #1021 while leaving the open question (beating it to 3/2 − c_k) untouched.",
+    "mathContext": "$(N(v) \\cap N(w)).\\mathrm{ncard} \\le 1$; no $4$-cycle $\\Rightarrow$ KST gives $\\mathrm{ex}(n,G_k) = O(n^{3/2})$.",
+    "significance": "key",
+    "relatedConcepts": ["ncard ≤ 1", "no K_{2,2}", "4-cycle-free", "extremal number ex(n, G_k)", "n^{3/2} exponent"],
+    "prerequisites": ["Gk_common_neighbors_subsingleton", "Set.ncard_le_one and finiteness", "definition of a 4-cycle in a simple graph"]
+  }
+]

--- a/src/data/proofs/erdos-1021-wip-02/meta.json
+++ b/src/data/proofs/erdos-1021-wip-02/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "erdos-1021-wip-02",
+  "title": "The Bipartite Pair Graph G_k is C₄-free (Erdős #1021)",
+  "slug": "erdos-1021-wip-02",
+  "description": "A fully verified (0-axiom, 0-sorry) proof that the bipartite pair graph G_k of Erdős #1021 is C₄-free: any two distinct vertices have at most one common neighbour (codegree ≤ 1), so G_k contains no K_{2,2} and no 4-cycle. Where the sibling files formalize the asymptotic boundary of the open question and the local degree structure, this file supplies the structural reason n^{3/2} is the natural exponent at all — C₄-freeness is exactly the Kővári–Sós–Turán / Reiman hypothesis giving ex(n, G_k) = O(n^{3/2}).",
+  "meta": {
+    "author": "Research formalization 2026 (researcher-1)",
+    "sourceUrl": "https://erdosproblems.com/1021",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1021Wip02.lean",
+    "tags": [
+      "graph-theory",
+      "extremal-combinatorics",
+      "erdos",
+      "zarankiewicz",
+      "c4-free",
+      "kovari-sos-turan"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 216,
+    "assumptions": "None. Every theorem is elementary finite combinatorics about the graph G_k, with zero axioms and zero sorries (#print axioms lists only the foundational propext / Classical.choice / Quot.sound). The open question of Erdős #1021 (whether the exponent can be beaten to 3/2 − c_k) and the deep KST upper bound are deliberately NOT assumed or addressed here — only the C₄-freeness that makes the trivial n^{3/2} bound apply is proved.",
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1021 asks whether ex(n, G_k) ≪ n^{3/2-c_k} for some c_k > 0, where G_k is the bipartite 'pair graph': k primary vertices and C(k,2) pair vertices, each pair vertex joined to exactly the two primary vertices of its pair. The sibling formalizations handle the asymptotic side (Erdos1021OQ01Incomplete01.lean: the exponent gap 1/(k-1) → 0) and the local degree structure (Erdos1021Wip01.lean: pair vertices have degree 2, primary vertices degree k-1). None of them explains, machine-checked, why n^{3/2} is the natural exponent. This file supplies that: G_k is C₄-free, which is exactly the Kővári–Sós–Turán / Reiman hypothesis yielding ex(n, G_k) = O(n^{3/2}).",
+    "problemStatement": "Is the bipartite pair graph G_k C₄-free? Equivalently: do any two distinct vertices of G_k have at most one common neighbour (codegree ≤ 1), so that G_k contains no K_{2,2} and no 4-cycle?",
+    "text": "A 0-axiom, 0-sorry proof that G_k is C₄-free: any two distinct vertices have at most one common neighbour, so G_k has no K_{2,2} / no 4-cycle — the KST hypothesis behind the n^{3/2} bound.",
+    "proofStrategy": "Self-contained in namespace Erdos1021Wip02, importing only Mathlib. It re-declares G_k locally (matching Erdos1021Wip01), then proves adjacency iff-lemmas on each side, including projection-free forms adj_primary_pair and adj_pair_inl convenient for arithmetic. The heart, Gk_common_neighbors_subsingleton, shows the neighbourhood intersection of any two distinct vertices v ≠ w is a Set.Subsingleton by case analysis on the bipartition: (1) two primaries y_i, y_j (i ≠ j) — both common neighbours are pair vertices, and the four membership disjunctions plus a < b, i ≠ j force the same pair {i,j}, closed by rcases + omega; (2) mixed primary/pair — a common neighbour would have to be both a pair vertex and a primary, impossible by bipartiteness; (3) two distinct pair vertices — both common neighbours are primaries in {a,b} ∩ {c,d}, and two distinct 2-sets meet in ≤ 1 point, again closed by rcases + omega using the distinctness ¬(a=c ∧ b=d). Gk_codegree_le_one restates this as ncard ≤ 1 via Set.ncard_le_one, and Gk_no_C4 as the explicit 'no two distinct common neighbours' statement.",
+    "keyInsights": [
+      "**C₄-freeness is the real reason for n^{3/2}**: a graph in which every pair of vertices has at most one common neighbour contains no K_{2,2}, and the Kővári–Sós–Turán / Reiman theorem then bounds its edge count by ½(1 + √(4n-3))·n = O(n^{3/2}). This file proves that hypothesis for G_k from first principles.",
+      "**Two primaries share exactly one pair**: y_i and y_j (i ≠ j) have a common neighbour only at the unique pair vertex {i,j}; the a < b ordering pins the pair down uniquely.",
+      "**Two distinct pairs share at most one primary**: pair vertices {a,b} ≠ {c,d} have a common primary neighbour only for m ∈ {a,b} ∩ {c,d}, and distinct 2-element sets meet in at most one point.",
+      "**Honest boundary**: this file proves only that the trivial KST bound applies; whether the exponent can be *beaten* to 3/2 − c_k (the actual Erdős #1021 question) remains open and is untouched."
+    ],
+    "prerequisites": [
+      "Simple graphs and neighbor sets (SimpleGraph.neighborSet)",
+      "Set.Subsingleton and Set.ncard (Set.ncard_le_one)",
+      "Sum types and subtype encodings of unordered pairs",
+      "The Kővári–Sós–Turán / Reiman C₄-free extremal bound (context, not used)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-definition",
+      "title": "Module Header and the Graph G_k",
+      "startLine": 1,
+      "endLine": 70,
+      "summary": "Docstring framing the file as the verified C₄-free structure around the open Erdős #1021, plus the self-contained definition of the vertex type and the graph G_k."
+    },
+    {
+      "id": "adjacency",
+      "title": "Adjacency Characterizations",
+      "startLine": 72,
+      "endLine": 115,
+      "summary": "adj_pair_iff / adj_primary_iff characterize adjacency on each side; adj_primary_pair / adj_pair_inl give projection-free forms (i ∈ {a,b}) convenient for the arithmetic case analysis.",
+      "mathContext": "$z_{\\{a,b\\}} \\sim w \\iff w \\in \\{y_a, y_b\\}$; $y_i \\sim z_{\\{a,b\\}} \\iff i \\in \\{a,b\\}$."
+    },
+    {
+      "id": "c4-free",
+      "title": "G_k is C₄-free (codegree ≤ 1)",
+      "startLine": 116,
+      "endLine": 184,
+      "summary": "Gk_common_neighbors_subsingleton: the neighbourhood intersection of any two distinct vertices is a subsingleton. Case analysis on the bipartition — two primaries share only the pair {i,j}; two distinct pairs share at most one primary; a primary and a pair share nothing.",
+      "mathContext": "$v \\ne w \\implies |N(v) \\cap N(w)| \\le 1$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Codegree Bound and No 4-Cycle",
+      "startLine": 185,
+      "endLine": 216,
+      "summary": "Gk_codegree_le_one restates the subsingleton bound as ncard ≤ 1; Gk_no_C4 gives the explicit 'no two distinct common neighbours' (no K_{2,2}) form.",
+      "mathContext": "$(N(v) \\cap N(w)).\\mathrm{ncard} \\le 1$; no $4$-cycle."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file verifies, with zero axioms and zero sorries, that the bipartite pair graph G_k of Erdős #1021 is C₄-free: any two distinct vertices have at most one common neighbour, so G_k contains no K_{2,2} and no 4-cycle.",
+    "implications": "C₄-freeness is precisely the Kővári–Sós–Turán / Reiman hypothesis, whose conclusion is ex(n, G_k) = O(n^{3/2}). So this file supplies the machine-checked structural reason the n^{3/2} exponent is natural for Erdős #1021, complementing the sibling files' asymptotic and degree-structure results. It is the natural foundation for any future verified attack on the trivial upper bound.",
+    "openQuestions": [
+      "Does ex(n, G_k) = o(n^{3/2}) — let alone ≪ n^{3/2−c_k} — for some/every k ≥ 4? (the open Erdős #1021 question, still open)",
+      "Can the C₄-free property proved here be combined with a Lean formalization of the Kővári–Sós–Turán / Reiman counting to yield a verified O(n^{3/2}) upper bound for ex(n, G_k)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1021-wip-01",
+      "relationship": "extends",
+      "description": "Sibling verified structure: Wip-01 establishes the local degrees of G_k (pair side 2-regular, primary side degree k-1); this file adds the global C₄-freeness (codegree ≤ 1) that makes the KST n^{3/2} bound apply."
+    },
+    {
+      "targetId": "erdos-1021-oq-01-incomplete-01",
+      "relationship": "complements",
+      "description": "Where Incomplete01 handles the asymptotic boundary (the exponent gap 1/(k-1) → 0, o ⟹ O), this file handles the structural reason the n^{3/2} exponent arises: C₄-freeness of G_k."
+    },
+    {
+      "targetId": "erdos-1021-oq-01",
+      "relationship": "extends",
+      "description": "Parent OQ-01 survey of Erdős #1021; this file adds the verified C₄-free fact the survey cited (as the KST trivial-bound hypothesis) but did not prove."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Kővári, T., Sós, V., Turán, P.",
+      "title": "On a problem of K. Zarankiewicz",
+      "year": "1954",
+      "venue": "Colloquium Mathematicum 3:50–57",
+      "note": "The C₄-free (K_{2,2}-free) hypothesis proved here is exactly the KST hypothesis giving O(n^{3/2})"
+    },
+    {
+      "authors": "Reiman, I.",
+      "title": "Über ein Problem von K. Zarankiewicz",
+      "year": "1958",
+      "venue": "Acta Mathematica Academiae Scientiarum Hungaricae 9:269–273",
+      "note": "Sharp C₄-free edge bound ex(n, C₄) ≤ ½(1 + √(4n-3))·n"
+    },
+    {
+      "authors": "Bondy, J.A., Simonovits, M.",
+      "title": "Cycles of even length in graphs",
+      "year": "1974",
+      "venue": "Journal of Combinatorial Theory, Series B, 16(2):97–105",
+      "note": "Settles the k=3 case via ex(n, C_6) ≪ n^{7/6}"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1021Wip02",
+    "lineCount": 216,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "path": "Proofs/Erdos1021Wip02.lean",
+    "sorries": 0,
+    "definitionCount": 2,
+    "additionalFiles": []
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New **verified, 0-axiom, 0-sorry** gallery entry `erdos-1021-wip-02` for **Erdős Problem #1021** (extremal numbers for the bipartite pair graph `G_k`).

Formalizes the elementary structural fact that explains *why `n^{3/2}` is the natural exponent* in Erdős #1021: **`G_k` is C₄-free** — any two distinct vertices have **at most one common neighbour** (codegree ≤ 1), so `G_k` contains no `K_{2,2}` and no `4`-cycle. This is exactly the Kővári–Sós–Turán / Reiman hypothesis whose conclusion is `ex(n, G_k) = O(n^{3/2})`.

The sibling files formalize the *asymptotic boundary* (`…Incomplete01`: exponent gap `1/(k-1) → 0`) and the *local degree structure* (`…Wip01`: pair side 2-regular, primary side degree `k-1`). None of them established the C₄-freeness that makes the trivial bound apply — this file fills that gap.

## Main results (`Proofs/Erdos1021Wip02.lean`, self-contained, imports only Mathlib)

- `Gk_common_neighbors_subsingleton` — `N(v) ∩ N(w)` is a `Set.Subsingleton` for any `v ≠ w`. Case analysis on the bipartition: two primaries `y_i, y_j` share only the pair vertex `{i,j}`; two distinct pair vertices `{a,b} ≠ {c,d}` share at most one primary (distinct 2-sets meet in ≤ 1 point); a primary and a pair vertex share nothing (bipartiteness).
- `Gk_codegree_le_one` — the `ncard ≤ 1` cardinality form.
- `Gk_no_C4` — the explicit "no two distinct common neighbours" (no `K_{2,2}` / no `4`-cycle) form.
- Plus 4 supporting adjacency lemmas (including projection-free forms `adj_primary_pair`, `adj_pair_inl`).

## Verification

- 0 sorries, 0 `axiom` declarations.
- `#print axioms Gk_common_neighbors_subsingleton` / `Gk_no_C4` → only `propext, Classical.choice, Quot.sound` (the foundational axioms; no `sorryAx`, no `Lean.ofReduceBool`).
- Type-checks against Mathlib 4.26.0 via `lake env lean`.

## Honest scope

This proves only that the *trivial* KST `n^{3/2}` bound applies to `G_k`. The actual Erdős #1021 question — whether the exponent can be **beaten** to `3/2 − c_k` for `c_k > 0` — remains **OPEN** and is untouched here.

## Files

- `proofs/Proofs/Erdos1021Wip02.lean` (216 lines, 7 theorems, 2 defs)
- `src/data/proofs/erdos-1021-wip-02/meta.json`
- `src/data/proofs/erdos-1021-wip-02/annotations.json`