### PR TITLE
research(composition-parts-choose-oq-01-oq-01-oq-01-oq-02): generating function of the composition part-count [VERIFIED, 0-axiom, +4thm]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ07OQ01OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ07OQ01OQ01.lean
@@ -1,0 +1,153 @@
+import Mathlib
+
+/-
+# Multinomial Trinomial Revision (OQ-07-OQ-01-OQ-01)
+
+## Open Question
+
+The parent entry (OQ-07-OQ-01) formalized the **subset-of-a-subset identity**
+(trinomial revision) for binomial coefficients,
+
+  C(n, k) · C(k, m) = C(n, m) · C(n − m, k − m),   for m ≤ k ≤ n,
+
+by clearing factorial denominators.  Its natural next question:
+
+  *Does trinomial revision extend to the multinomial coefficient*
+  *`(n; a, b, c) = (n; a) · (n − a; b, c)`, and is that statement provable by*
+  *the same denominator-clearing route over Mathlib's `Nat.multinomial`?*
+
+The answer is **yes**.  Writing `n = a + b + c`, the multinomial coefficient
+factors as a nested pair of binomials — "choose the `a` symbols of the first
+kind out of `n`, then choose the `b` symbols of the second kind out of the
+remaining `n − a`":
+
+  multinomial{a, b, c} = C(a + b + c, a) · C(b + c, b).
+
+Mathlib defines `Nat.multinomial s f = (∑ i ∈ s, f i)! / ∏ i ∈ s, (f i)!` and
+supplies the divisibility fact `Nat.multinomial_spec`,
+
+  (∏ i ∈ s, (f i)!) · multinomial s f = (∑ i ∈ s, f i)!,
+
+but it does **not** provide the nested-binomial factorization for the ternary
+case.  We supply it, using exactly the parent's technique: multiply through by
+`a! · b! · c!` and collapse each side to `(a + b + c)!` via
+`Nat.choose_mul_factorial_mul_factorial`.
+
+## Results
+
+1. `factorial_mul_choose_mul_choose` — the denominator-cleared core, peeling the
+   `a`-block first: `a!·b!·c! · (C(a+b+c,a)·C(b+c,b)) = (a+b+c)!`.
+2. `factorial_mul_choose_mul_choose_last` — the same peeling the `c`-block first:
+   `a!·b!·c! · (C(a+b+c,c)·C(a+b,a)) = (a+b+c)!`.
+3. `multinomial_univ_three_eq` — the headline factorization
+   `multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b)`.
+4. `multinomial_eq_choose_mul_choose_sub` — the OQ's `(n; a)·(n−a; b, c)` form,
+   `multinomial{a,b,c} = C(n,a)·C(n−a,b)` with `n = a+b+c`.
+5. `choose_mul_choose_peel_comm` — peel-order independence, a pure binomial-
+   product identity absent from Mathlib:
+   `C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a)`.
+
+## Mathematical Context
+
+The nested factorization is the ternary instance of the general recursion
+`multinomial (insert a s) f = C(f a + ∑ f, f a) · multinomial s f`
+(`Nat.multinomial_insert`).  We prove the closed ternary form directly rather
+than by unfolding the recursion, keeping the argument a single factorial
+cancellation — the same "clear denominators, collapse to `n!`" pattern that made
+the binomial trinomial revision short and induction-free.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ07OQ01OQ01
+
+open Nat
+
+/-- Positivity of the shared factorial denominator `a! · b! · c!`. -/
+private theorem factorial_triple_pos (a b c : ℕ) : 0 < a ! * b ! * c ! :=
+  Nat.mul_pos (Nat.mul_pos (factorial_pos a) (factorial_pos b)) (factorial_pos c)
+
+/-- **Denominator-cleared trinomial revision (peel the `a`-block).**
+    Multiplying the nested-binomial product by the factorial denominator
+    collapses to the top factorial:
+    `a! · b! · c! · (C(a+b+c, a) · C(b+c, b)) = (a+b+c)!`. -/
+theorem factorial_mul_choose_mul_choose (a b c : ℕ) :
+    a ! * b ! * c ! * ((a + b + c).choose a * (b + c).choose b) = (a + b + c)! := by
+  have h1 : (a + b + c).choose a * a ! * (b + c)! = (a + b + c)! := by
+    have h := choose_mul_factorial_mul_factorial (show a ≤ a + b + c by omega)
+    have he : a + b + c - a = b + c := by omega
+    rwa [he] at h
+  have h2 : (b + c).choose b * b ! * c ! = (b + c)! := by
+    have h := choose_mul_factorial_mul_factorial (show b ≤ b + c by omega)
+    have he : b + c - b = c := by omega
+    rwa [he] at h
+  calc
+    a ! * b ! * c ! * ((a + b + c).choose a * (b + c).choose b)
+        = ((a + b + c).choose a * a !) * ((b + c).choose b * b ! * c !) := by ring
+    _ = ((a + b + c).choose a * a !) * (b + c)! := by rw [h2]
+    _ = (a + b + c).choose a * a ! * (b + c)! := by ring
+    _ = (a + b + c)! := h1
+
+/-- **Denominator-cleared trinomial revision (peel the `c`-block).**
+    The symmetric collapse when the last block is separated first:
+    `a! · b! · c! · (C(a+b+c, c) · C(a+b, a)) = (a+b+c)!`. -/
+theorem factorial_mul_choose_mul_choose_last (a b c : ℕ) :
+    a ! * b ! * c ! * ((a + b + c).choose c * (a + b).choose a) = (a + b + c)! := by
+  have h1 : (a + b + c).choose c * c ! * (a + b)! = (a + b + c)! := by
+    have h := choose_mul_factorial_mul_factorial (show c ≤ a + b + c by omega)
+    have he : a + b + c - c = a + b := by omega
+    rwa [he] at h
+  have h2 : (a + b).choose a * a ! * b ! = (a + b)! := by
+    have h := choose_mul_factorial_mul_factorial (show a ≤ a + b by omega)
+    have he : a + b - a = b := by omega
+    rwa [he] at h
+  calc
+    a ! * b ! * c ! * ((a + b + c).choose c * (a + b).choose a)
+        = ((a + b + c).choose c * c !) * ((a + b).choose a * a ! * b !) := by ring
+    _ = ((a + b + c).choose c * c !) * (a + b)! := by rw [h2]
+    _ = (a + b + c).choose c * c ! * (a + b)! := by ring
+    _ = (a + b + c)! := h1
+
+/-- **Multinomial trinomial revision.**
+    The ternary multinomial coefficient factors as a nested pair of binomials:
+    `multinomial{a, b, c} = C(a+b+c, a) · C(b+c, b)`. -/
+theorem multinomial_univ_three_eq (a b c : ℕ) :
+    Nat.multinomial Finset.univ ![a, b, c]
+      = (a + b + c).choose a * (b + c).choose b := by
+  apply Nat.eq_of_mul_eq_mul_left (factorial_triple_pos a b c)
+  rw [factorial_mul_choose_mul_choose]
+  have hspec := Nat.multinomial_spec (Finset.univ : Finset (Fin 3)) ![a, b, c]
+  rw [Fin.prod_univ_three, Fin.sum_univ_three] at hspec
+  exact hspec
+
+/-- **OQ form `(n; a) · (n − a; b, c)`.**
+    With `n = a + b + c`, the multinomial equals the number of ways to choose the
+    `a`-block from all `n`, then the `b`-block from the remaining `n − a`:
+    `multinomial{a, b, c} = C(n, a) · C(n − a, b)`. -/
+theorem multinomial_eq_choose_mul_choose_sub (a b c : ℕ) :
+    Nat.multinomial Finset.univ ![a, b, c]
+      = (a + b + c).choose a * (a + b + c - a).choose b := by
+  rw [multinomial_univ_three_eq]
+  have he : a + b + c - a = b + c := by omega
+  rw [he]
+
+/-- **Peel-order independence.**
+    Separating the first block or the last block gives the same count, a pure
+    binomial-product identity not present in Mathlib:
+    `C(a+b+c, a) · C(b+c, b) = C(a+b+c, c) · C(a+b, a)`. -/
+theorem choose_mul_choose_peel_comm (a b c : ℕ) :
+    (a + b + c).choose a * (b + c).choose b
+      = (a + b + c).choose c * (a + b).choose a := by
+  apply Nat.eq_of_mul_eq_mul_left (factorial_triple_pos a b c)
+  rw [factorial_mul_choose_mul_choose, factorial_mul_choose_mul_choose_last]
+
+/-- Numeric sanity check: `multinomial{2,1,1} = C(4,2)·C(2,1) = 6·2 = 12`,
+    and indeed `4!/(2!·1!·1!) = 24/2 = 12`. -/
+example : Nat.multinomial Finset.univ ![2, 1, 1] = 12 := by decide
+
+/-- Numeric sanity check of peel-order independence at `(a,b,c) = (2,1,1)`:
+    `C(4,2)·C(2,1) = 12 = C(4,1)·C(3,2) = 4·3`. -/
+example : (4 : ℕ).choose 2 * (2 : ℕ).choose 1 = (4 : ℕ).choose 1 * (3 : ℕ).choose 2 := by
+  decide
+
+end CombinationsFormulaOQ07OQ01OQ01

--- a/proofs/Proofs/CompositionPartsChooseOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CompositionPartsChooseOQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,123 @@
+import Proofs.CompositionPartsChooseOQ01OQ01
+import Mathlib.Tactic
+
+/-
+# The generating function of the number of parts of a composition
+
+## What this proves
+
+A *composition* of `n` is an ordered tuple of positive integers summing to `n`
+(Mathlib's `Composition n`); its number of parts is `c.length`. Earlier entries in this
+family compute individual statistics of the part-count of a uniformly random composition:
+
+* grandparent (`composition-card-2pow-oq-01`): there are `2^(n−1)` compositions of `n`;
+* parent (`composition-parts-choose-oq-01`): exactly `C(n−1, k−1)` of them have `k` parts;
+* parent (`…-oq-01-oq-01`): the **first moment** — mean part-count `(n+1)/2`;
+* parent (`…-oq-01-oq-01-oq-01`): the **second moment** and **variance** `(n−1)/4`.
+
+The parent's open question asks whether *all* the moments can be produced at once. They
+can: this leaf computes the entire **generating function** of the part-count. Over any
+commutative semiring `R` and any `t : R`, for `n ≥ 1`,
+
+```
+Σ_{c : Composition n} t^{c.length}  =  t · (1 + t)^{n−1}        (parts_genfun)
+```
+
+This single polynomial identity is the *probability generating function* of the
+part-count (up to the normalising `2^{n−1}`): its evaluation at `t = 1` returns the count
+`2^{n−1}` (`parts_genfun_eval_one`), the coefficient of `t^k` is the number of
+compositions with `k` parts `C(n−1, k−1)` (`parts_genfun_binomial`), and every moment of
+the part-count is obtained by differentiating it at `t = 1`. In particular it exhibits the
+part-count as `1 + Binomial(n−1, 1/2)`, whose PGF is exactly `t·((1+t)/2)^{n−1}` after
+normalising — recovering the mean `(n+1)/2` and variance `(n−1)/4` of the parents as the
+first two derivatives, without recomputing any binomial sum.
+
+## The mechanism
+
+As for the moments, everything is transported along the bijection
+`gapsEquiv n : Composition n ≃ Finset (Fin (n−1))` (a composition is the set of internal
+gaps it cuts) together with the bridge `length_eq_card_gaps : c.length = (gaps c).card + 1`.
+Pushing the sum across the equivalence turns `Σ_c t^{c.length}` into the subset sum
+`Σ_{s ⊆ Fin (n−1)} t^{|s|+1} = t · Σ_{s ⊆ Fin (n−1)} t^{|s|}`, and the subset generating
+function
+
+```
+Σ_{s ⊆ Fin m} t^{|s|}  =  (t + 1)^m                            (sum_pow_card)
+```
+
+is the `Finset.prod_add` expansion of `∏_{i : Fin m} (t + 1)`: each factor contributes
+either the `t` (put `i ∈ s`) or the `1` (put `i ∉ s`).
+
+## Originality
+
+Where the parents each extracted one number from a *particular* weighted binomial sum
+`Σ_k k^r C(m,k)`, this entry gives the closed-form generating function that packages all of
+them simultaneously. Mathlib has neither the subset generating function
+`Σ_{s ⊆ Fin m} t^{|s|} = (t+1)^m` in this form nor any statement about the part-count
+distribution of a composition; the identity `Σ_c t^{c.length} = t(1+t)^{n−1}` is, to our
+knowledge, not in the gallery.
+-/
+
+namespace CompositionPartsChooseOQ01OQ01OQ01OQ02
+
+open Finset CompositionPartsChooseOQ01OQ01
+
+/-! ## The subset-cardinality generating function -/
+
+/-- **Subset generating function.** Over any commutative semiring `R` and `t : R`,
+`Σ_{s ⊆ Fin m} t^{|s|} = (t + 1)^m`. This is the `Finset.prod_add` expansion of the product
+`∏_{i : Fin m} (t + 1)`: expanding the product, each of the `2^m` monomials picks the `t`
+from the factors in a subset `s` and the `1` from the rest, contributing `t^{|s|}`. -/
+theorem sum_pow_card {R : Type*} [CommSemiring R] (t : R) (m : ℕ) :
+    ∑ s : Finset (Fin m), t ^ s.card = (t + 1) ^ m := by
+  have h := Finset.prod_add (fun _ : Fin m => t) (fun _ : Fin m => (1 : R)) Finset.univ
+  simp only [Finset.prod_const, one_pow, mul_one, Finset.card_univ,
+    Fintype.card_fin, Finset.powerset_univ] at h
+  exact h.symm
+
+/-! ## The generating function of the part-count -/
+
+/-- **Generating function of the number of parts.** Over any commutative semiring `R`, for
+every `t : R` and `n ≥ 1`,
+
+`Σ_{c : Composition n} t^{c.length}  =  t · (1 + t)^{n−1}`.
+
+This is the probability generating function of the part-count (up to the normalising
+`2^{n−1}`): evaluating at `t = 1` gives the count `2^{n−1}`, the coefficient of `t^k` is the
+number of compositions with `k` parts, and each moment is a derivative at `t = 1`. Proved
+by transporting the sum across the gap bijection `gapsEquiv` to
+`Σ_{s ⊆ Fin (n−1)} t^{|s|+1}`, factoring out one `t`, and applying `sum_pow_card`. -/
+theorem parts_genfun {R : Type*} [CommSemiring R] (t : R) (n : ℕ) (hn : 1 ≤ n) :
+    ∑ c : Composition n, t ^ c.length = t * (1 + t) ^ (n - 1) := by
+  have e1 : ∑ c : Composition n, t ^ c.length
+      = ∑ c : Composition n, t ^ ((gapsEquiv n c).card + 1) :=
+    Finset.sum_congr rfl (fun c _ => by rw [length_eq_card_gaps n hn c])
+  rw [e1, Equiv.sum_comp (gapsEquiv n) (fun s => t ^ (s.card + 1))]
+  simp_rw [pow_succ]
+  rw [← Finset.sum_mul, sum_pow_card t (n - 1)]
+  ring
+
+/-- **Evaluating the generating function at `t = 1` recovers the count.** Since
+`1^{c.length} = 1` for every composition, the left side of `parts_genfun` counts the
+compositions, while the right side is `1·(1+1)^{n−1} = 2^{n−1}`. This re-derives the
+grandparent's `2^{n−1}` count — the total mass of the part-count distribution — as a
+special value of the generating function, independently of Mathlib's `composition_card`. -/
+theorem parts_genfun_eval_one (n : ℕ) (hn : 1 ≤ n) :
+    (Fintype.card (Composition n) : ℕ) = 2 ^ (n - 1) := by
+  have h := parts_genfun (1 : ℕ) n hn
+  simpa using h
+
+/-- **Explicit polynomial form.** The generating function is the binomial polynomial
+`Σ_{k<n} C(n−1,k) · t^{k+1}`. Comparing with `parts_genfun`, the coefficient of `t^{k+1}` is
+`C(n−1, k) = C(n−1, (k+1)−1)` — exactly the number of compositions of `n` with `k+1` parts
+(the grandparent's graded count). Proved directly from the binomial theorem `add_pow`. -/
+theorem parts_genfun_binomial {R : Type*} [CommSemiring R] (t : R) (n : ℕ) (hn : 1 ≤ n) :
+    ∑ k ∈ Finset.range n, ((n - 1).choose k : R) * t ^ (k + 1)
+      = t * (1 + t) ^ (n - 1) := by
+  obtain ⟨M, rfl⟩ : ∃ M, n = M + 1 := ⟨n - 1, by omega⟩
+  rw [show M + 1 - 1 = M from rfl, add_comm (1 : R) t, add_pow, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  simp only [one_pow, mul_one]
+  ring
+
+end CompositionPartsChooseOQ01OQ01OQ01OQ02

--- a/src/data/proofs/combinations-formula-oq-07-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-01-oq-01/annotations.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "multinomial-peeling-context",
+    "proofId": "combinations-formula-oq-07-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 60 },
+    "type": "concept",
+    "title": "From Trinomial Revision to the Three-Part Multinomial",
+    "content": "The parent entry proved binomial trinomial revision C(n,k)·C(k,m) = C(n,m)·C(n−m,k−m) by clearing factorial denominators. This follow-up asks whether the same route reaches the genuine three-part multinomial coefficient (a+b+c)!/(a!·b!·c!). It does: the multinomial peels into a nested pair of binomials multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b) — choose the a-block out of all a+b+c objects, then split the remaining b+c into a b-block and a c-block. Mathlib defines Nat.multinomial and supplies multinomial_spec but not this closed ternary factorization.",
+    "mathContext": "$\\binom{a+b+c}{a,b,c} = \\dfrac{(a+b+c)!}{a!\\,b!\\,c!} = \\binom{a+b+c}{a}\\binom{b+c}{b}$. This is the ternary instance of the general recursion $\\mathrm{multinomial}(\\mathrm{insert}\\,a\\,s) = \\binom{a + \\sum s}{a}\\,\\mathrm{multinomial}(s)$, proved here in closed form rather than by unfolding.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multinomial coefficient",
+      "trinomial revision",
+      "nested-selection double counting",
+      "Nat.multinomial_insert",
+      "trinomial coefficient"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "Nat.multinomial and multinomial_spec",
+      "factorial identity for binomial coefficients"
+    ]
+  },
+  {
+    "id": "cleared-core-thm",
+    "proofId": "combinations-formula-oq-07-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 89 },
+    "type": "theorem",
+    "title": "Denominator-Cleared Core (Peel the a-Block)",
+    "content": "factorial_mul_choose_mul_choose proves a!·b!·c!·(C(a+b+c,a)·C(b+c,b)) = (a+b+c)! with no summation and no induction — the exact three-part analogue of the parent's LHS·D = n! step. After regrouping by ring, the inner block C(b+c,b)·b!·c! collapses to (b+c)! via Nat.choose_mul_factorial_mul_factorial (b ≤ b+c, (b+c)−b = c), leaving C(a+b+c,a)·a!·(b+c)! which collapses to (a+b+c)! via the same fact at the outer selection (a ≤ a+b+c, (a+b+c)−a = b+c).",
+    "mathContext": "Each binomial $\\binom{a+b+c}{a} = \\frac{(a+b+c)!}{a!(b+c)!}$ and $\\binom{b+c}{b} = \\frac{(b+c)!}{b!c!}$ is missing exactly the factorials in $D = a!\\,b!\\,c!$; multiplying by $D$ telescopes the product to $(a+b+c)!$. The multiplicative regrouping is closed by `ring` (ℕ a commutative semiring with the choose/factorial terms as atoms), the subtraction facts $(a+b+c)-a = b+c$ and $(b+c)-b = c$ by `omega`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.choose_mul_factorial_mul_factorial",
+      "clearing denominators",
+      "telescoping factorial collapse",
+      "ring tactic over ℕ"
+    ],
+    "prerequisites": [
+      "C(n,k)·k!·(n-k)! = n!",
+      "omega for natural subtraction"
+    ]
+  },
+  {
+    "id": "cleared-last-thm",
+    "proofId": "combinations-formula-oq-07-oq-01-oq-01",
+    "range": { "startLine": 91, "endLine": 109 },
+    "type": "theorem",
+    "title": "Denominator-Cleared Core (Peel the c-Block)",
+    "content": "factorial_mul_choose_mul_choose_last is the symmetric cleared form a!·b!·c!·(C(a+b+c,c)·C(a+b,a)) = (a+b+c)!, separating the last block first. The c-selection is now outer (C(a+b+c,c)·c!·(a+b)! = (a+b+c)!) and the a-selection inner (C(a+b,a)·a!·b! = (a+b)!). Providing both peel directions as cleared identities is what makes peel-order independence a one-line consequence.",
+    "mathContext": "$a!\\,b!\\,c!\\cdot\\binom{a+b+c}{c}\\binom{a+b}{a} = (a+b+c)!$, using $(a+b+c)-c = a+b$ and $(a+b)-a = b$. The right-hand side is the same $(a+b+c)!$ as the a-peel, which is the arithmetic reason the two peels agree.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.choose_mul_factorial_mul_factorial",
+      "symmetry of the trinomial coefficient",
+      "clearing denominators"
+    ],
+    "prerequisites": [
+      "C(n,k)·k!·(n-k)! = n!",
+      "omega for natural subtraction"
+    ]
+  },
+  {
+    "id": "headline-oq-form-thm",
+    "proofId": "combinations-formula-oq-07-oq-01-oq-01",
+    "range": { "startLine": 111, "endLine": 132 },
+    "type": "theorem",
+    "title": "Multinomial Factorization and the OQ (n;a)·(n−a;b,c) Form",
+    "content": "multinomial_univ_three_eq is the headline: multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b). The bridge is Nat.multinomial_spec, which on univ over Fin 3 (evaluated by Fin.prod_univ_three and Fin.sum_univ_three) reads a!·b!·c!·multinomial{a,b,c} = (a+b+c)!; equating with the cleared core and cancelling the positive denominator by Nat.eq_of_mul_eq_mul_left finishes it. multinomial_eq_choose_mul_choose_sub then rewrites (b+c) as (a+b+c)−a to give the OQ's exact C(n,a)·C(n−a,b) shape with n = a+b+c.",
+    "mathContext": "$\\mathrm{multinomial}\\{a,b,c\\} = \\binom{n}{a}\\binom{n-a}{b}$ with $n = a+b+c$. The proof only needs that the multinomial and the binomial product satisfy the same cleared equation $D\\cdot(\\cdot) = n!$ and that $D = a!b!c! > 0$; cancellation does the rest, so no properties of division are invoked despite Mathlib defining the multinomial by division.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.multinomial_spec",
+      "Nat.eq_of_mul_eq_mul_left",
+      "Fin.prod_univ_three",
+      "Fin.sum_univ_three"
+    ],
+    "prerequisites": [
+      "(∏ (f i)!)·multinomial = (∑ f i)!",
+      "left cancellation in ℕ",
+      "the cleared core identity"
+    ]
+  },
+  {
+    "id": "peel-comm-thm",
+    "proofId": "combinations-formula-oq-07-oq-01-oq-01",
+    "range": { "startLine": 134, "endLine": 153 },
+    "type": "theorem",
+    "title": "Peel-Order Independence",
+    "content": "choose_mul_choose_peel_comm proves C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a): peeling the a-block first equals peeling the c-block first. Both cleared forms equal a!·b!·c!·(product) = (a+b+c)!, so the two products agree after left-cancellation — no binomial manipulation needed. This is the symmetry of the trinomial coefficient under permuting its parts. Numeric checks confirm multinomial{2,1,1} = C(4,2)·C(2,1) = 12 and C(4,2)·C(2,1) = C(4,1)·C(3,2) = 12 by decide.",
+    "mathContext": "$\\binom{a+b+c}{a}\\binom{b+c}{b} = \\binom{a+b+c}{c}\\binom{a+b}{a}$ because both equal $\\binom{a+b+c}{a,b,c}$, which is symmetric in $a,b,c$. The proof route — equate two cleared identities against a common $(a+b+c)!$ — is a reusable way to obtain multinomial symmetries without touching the binomials.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "symmetry of the multinomial coefficient",
+      "Nat.eq_of_mul_eq_mul_left",
+      "peel-order independence"
+    ],
+    "prerequisites": [
+      "the two cleared-core identities",
+      "left cancellation in ℕ"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-07-oq-01-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-01-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "combinations-formula-oq-07-oq-01-oq-01",
+  "title": "Trinomial Peeling: the Multinomial Extension of Trinomial Revision",
+  "slug": "combinations-formula-oq-07-oq-01-oq-01",
+  "description": "Answers OQ-07-OQ-01-OQ-01: trinomial revision extends to the three-part multinomial coefficient, and by the same denominator-clearing route. The ternary multinomial factors as a nested pair of binomials, multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b) — choose the a-block from all a+b+c, then split the remaining b+c into a b-block and a c-block. Proved against Mathlib's Nat.multinomial by multiplying through by a!·b!·c! and collapsing each side to (a+b+c)! with Nat.choose_mul_factorial_mul_factorial, exactly the parent's technique, with no summation and no induction. Records the OQ's C(n,a)·C(n−a,b) form (n = a+b+c) and peel-order independence C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a).",
+  "meta": {
+    "author": "Lean Genius researcher-10",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ07OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 153,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. The identities hold for all a, b, c and are fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms — no Lean.ofReduceBool, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "multinomial-coefficient",
+      "trinomial-revision",
+      "trinomial-coefficient",
+      "factorial",
+      "double-counting"
+    ],
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "factorial_mul_choose_mul_choose: the denominator-cleared core a!·b!·c!·(C(a+b+c,a)·C(b+c,b)) = (a+b+c)!, peeling the a-block first, absent from Mathlib and proved by the same clear-denominators/collapse-to-n! pattern as the binomial trinomial revision",
+      "factorial_mul_choose_mul_choose_last: the symmetric cleared form peeling the c-block first, a!·b!·c!·(C(a+b+c,c)·C(a+b,a)) = (a+b+c)!",
+      "multinomial_univ_three_eq: the headline factorization multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b) against Mathlib's Nat.multinomial, via multinomial_spec and left-cancellation",
+      "multinomial_eq_choose_mul_choose_sub: the OQ's (n;a)·(n−a;b,c) form, multinomial{a,b,c} = C(n,a)·C(n−a,b) with n = a+b+c",
+      "choose_mul_choose_peel_comm: peel-order independence C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a), a pure binomial-product identity not in Mathlib, from equating both cleared forms",
+      "Worked numeric checks multinomial{2,1,1} = C(4,2)·C(2,1) = 12 and C(4,2)·C(2,1) = C(4,1)·C(3,2) = 12"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "For k ≤ n, C(n,k)·k!·(n-k)! = n!. Applied to the outer selection (a ≤ a+b+c, with (a+b+c)-a = b+c) and the inner selection (b ≤ b+c, with (b+c)-b = c) it collapses the nested-binomial product to (a+b+c)! after multiplication by a!·b!·c!.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.multinomial_spec",
+        "description": "(∏ i ∈ s, (f i)!)·multinomial s f = (∑ i ∈ s, f i)!. Specialized to s = univ over Fin 3 and f = ![a,b,c] (via Fin.prod_univ_three and Fin.sum_univ_three) it reads a!·b!·c!·multinomial{a,b,c} = (a+b+c)!, the bridge from the cleared factorial identity to the multinomial coefficient.",
+        "module": "Mathlib.Data.Nat.Choose.Multinomial"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_left",
+        "description": "Left-cancellation c·a = c·b → a = b for 0 < c. Cancels the positive factorial denominator a!·b!·c! after both the multinomial and the binomial product are shown to satisfy the same cleared equation.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Fin.prod_univ_three",
+        "description": "∏ i : Fin 3, f i = f 0 · f 1 · f 2; with Fin.sum_univ_three it evaluates the multinomial_spec product and sum over Fin 3 to the concrete a!·b!·c! and a+b+c.",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ07OQ01OQ01.lean",
+    "namespace": "CombinationsFormulaOQ07OQ01OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 153,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The trinomial (three-part multinomial) coefficient (a+b+c)!/(a!·b!·c!) counts ordered partitions of a+b+c labelled objects into blocks of sizes a, b, c, and is the natural next object after the binomial coefficient. The parent entry (OQ-07-OQ-01) formalized trinomial revision C(n,k)·C(k,m) = C(n,m)·C(n−m,k−m) — Vandermonde's multiplicative companion — by clearing factorial denominators, and asked whether the same route reaches the genuine three-part multinomial. It does: the peeling C(a+b+c,a)·C(b+c,b) is the ternary instance of Mathlib's Nat.multinomial_insert recursion, here proved in closed form directly rather than by unfolding the recursion.",
+    "problemStatement": "Open Question OQ-07-OQ-01-OQ-01: Does trinomial revision extend to the multinomial coefficient (n; a,b,c) = (n; a)·(n−a; b,c), and is that statement provable by the same denominator-clearing route over Mathlib's Nat.multinomial? Concretely, with n = a+b+c, does multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b), and can it be proved by multiplying through by a!·b!·c! and collapsing to (a+b+c)! rather than by summation or by unfolding the multinomial recursion?",
+    "proofStrategy": "Work division-free. First prove the cleared core factorial_mul_choose_mul_choose: a!·b!·c!·(C(a+b+c,a)·C(b+c,b)) = (a+b+c)!. Regroup (by ring over the commutative semiring ℕ, with choose/factorial terms as atoms) so the inner block C(b+c,b)·b!·c! collapses to (b+c)! via Nat.choose_mul_factorial_mul_factorial (b ≤ b+c, (b+c)−b = c), leaving C(a+b+c,a)·a!·(b+c)! which collapses to (a+b+c)! via the same fact at the outer selection (a ≤ a+b+c, (a+b+c)−a = b+c); the natural-subtraction facts are discharged by omega. Then bridge to Mathlib's Nat.multinomial: multinomial_spec on univ over Fin 3 (evaluated by Fin.prod_univ_three / Fin.sum_univ_three) gives a!·b!·c!·multinomial{a,b,c} = (a+b+c)!; equate with the cleared core and cancel the positive denominator by Nat.eq_of_mul_eq_mul_left. Peel-order independence follows by proving the symmetric cleared form (peel the c-block first) and equating both against (a+b+c)!.",
+    "keyInsights": [
+      "The three-part multinomial peels into two ordinary binomials, C(a+b+c,a)·C(b+c,b): choose the a-block from everything, then split the remaining b+c — the exact ternary analogue of the committee–subcommittee double count.",
+      "The parent's clear-denominators pattern transfers verbatim: multiply by the shared denominator a!·b!·c!, collapse each nested choice to a factorial with Nat.choose_mul_factorial_mul_factorial, and the product telescopes to (a+b+c)!.",
+      "Unlike binomial trinomial revision, the peeling identity is unconditional — a, b, c are free and a+(b+c), b+c are exact by construction, so no m ≤ k ≤ n side conditions and only trivial subtraction bookkeeping arise.",
+      "Nat.multinomial_spec is the clean bridge to Mathlib's division-based multinomial: it turns the divisibility multinomial s f = (∑ f)!/∏(f i)! into the multiplication ∏(f i)!·multinomial = (∑ f)!, matching the cleared factorial identity so cancellation finishes the proof.",
+      "Peel-order independence C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a) is the symmetry of the trinomial coefficient under permuting its parts, obtained for free by equating two cleared forms rather than manipulating binomials directly."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Header stating OQ-07-OQ-01-OQ-01: does trinomial revision extend to the three-part multinomial coefficient by the same denominator-clearing route? Gives the nested-binomial peeling multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b) and its relation to Nat.multinomial_insert."
+    },
+    {
+      "id": "cleared-core",
+      "title": "Denominator-Cleared Core (Peel the a-Block)",
+      "startLine": 66,
+      "endLine": 89,
+      "summary": "factorial_triple_pos (positivity of a!·b!·c!) and factorial_mul_choose_mul_choose: a!·b!·c!·(C(a+b+c,a)·C(b+c,b)) = (a+b+c)!. Two applications of Nat.choose_mul_factorial_mul_factorial collapse the inner block to (b+c)! then the outer to (a+b+c)!, with ring regrouping and omega for subtraction."
+    },
+    {
+      "id": "cleared-last",
+      "title": "Denominator-Cleared Core (Peel the c-Block)",
+      "startLine": 91,
+      "endLine": 109,
+      "summary": "factorial_mul_choose_mul_choose_last: the symmetric cleared form a!·b!·c!·(C(a+b+c,c)·C(a+b,a)) = (a+b+c)!, separating the last block first. Same collapse pattern with the c-selection outer and the a-selection inner."
+    },
+    {
+      "id": "headline-and-oq-form",
+      "title": "Multinomial Factorization and OQ Form",
+      "startLine": 111,
+      "endLine": 132,
+      "summary": "multinomial_univ_three_eq: multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b), via multinomial_spec (evaluated by Fin.prod_univ_three / Fin.sum_univ_three) and left-cancellation of a!·b!·c!. multinomial_eq_choose_mul_choose_sub recasts it in the OQ's C(n,a)·C(n−a,b) form with n = a+b+c."
+    },
+    {
+      "id": "peel-comm",
+      "title": "Peel-Order Independence",
+      "startLine": 134,
+      "endLine": 153,
+      "summary": "choose_mul_choose_peel_comm: C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a), the trinomial coefficient's symmetry under permuting parts, from equating both cleared forms. Worked numeric checks multinomial{2,1,1} = 12 and C(4,2)·C(2,1) = C(4,1)·C(3,2) = 12 by decide."
+    }
+  ],
+  "conclusion": {
+    "summary": "6 theorems, 0 sorries, 0 axioms. Trinomial revision does extend to the genuine three-part multinomial coefficient, and by the same denominator-clearing route: multinomial{a,b,c} = C(a+b+c,a)·C(b+c,b), proved against Mathlib's Nat.multinomial by multiplying through by a!·b!·c! and collapsing each nested choice to (a+b+c)! with Nat.choose_mul_factorial_mul_factorial. The entry records the OQ's C(n,a)·C(n−a,b) form and peel-order independence C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a).",
+    "implications": "Confirms the parent's factorial-clearing pattern scales to the multinomial setting and supplies the closed ternary factorization that Mathlib states only as the Nat.multinomial_insert recursion. The cleared-form technique (prove a!·b!·c!·(binomial product) = (a+b+c)!, then cancel against multinomial_spec) is reusable for any fixed-arity multinomial factorization, and peel-order independence exhibits the trinomial coefficient's symmetry without any binomial manipulation.",
+    "openQuestions": [
+      "Does the nested factorization extend to four parts, multinomial{a,b,c,d} = C(a+b+c+d,a)·C(b+c+d,b)·C(c+d,c), by iterating the same cleared-denominator collapse, and can the general k-part statement be proved uniformly by induction on the Nat.multinomial_insert recursion?",
+      "Can the peel-order independence C(a+b+c,a)·C(b+c,b) = C(a+b+c,c)·C(a+b,a) be lifted to a full symmetric-group action on the parts of a general multinomial coefficient, recovering the invariance of multinomial{a₁,…,a_k} under permutations of (a₁,…,a_k) as a corollary of the peeling recursion?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-07-oq-01",
+      "relationship": "parent — binomial trinomial revision C(n,k)·C(k,m) = C(n,m)·C(n−m,k−m), whose denominator-clearing route this entry extends to the three-part multinomial coefficient"
+    },
+    {
+      "targetId": "combinations-formula-oq-07",
+      "relationship": "ancestor — Vandermonde's additive convolution, the additive counterpart of the multiplicative multinomial factorization proved here"
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "R. L. Graham, D. E. Knuth, O. Patashnik",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "venue": "Addison-Wesley",
+      "note": "Standard reference for binomial and multinomial coefficient identities; trinomial revision is eq. 5.21."
+    },
+    {
+      "authors": "J. Riordan",
+      "title": "Combinatorial Identities",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Systematic treatment of binomial- and multinomial-sum identities."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.multinomial, Nat.multinomial_spec, Nat.multinomial_insert, and the Nat.choose factorial API underlying this formalization."
+    }
+  ]
+}

--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-compparts-genfun-header",
+    "proofId": "composition-parts-choose-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 4, "endLine": 59 },
+    "type": "concept",
+    "title": "From Individual Moments to the Whole Generating Function",
+    "content": "The docstring places this leaf at the head of the composition part-count family and states its unifying goal. A composition of n is an ordered tuple of positive integers summing to n; its part-count is c.length. The family already knows, one statistic at a time: 2^(n−1) compositions of n (grandparent), C(n−1,k−1) with exactly k parts (parent), the first moment (mean (n+1)/2) and the second moment / variance (n−1)/4 (the two direct parents). The direct parent's open question asked whether all the moments can be produced at once. They can: this entry computes the entire generating function ∑_{c : Composition n} t^(c.length) = t·(1+t)^(n−1) over any commutative semiring. That single identity is the probability generating function of the part-count up to 2^(n−1): its value at t = 1 is the count, its coefficients are the graded counts, and its derivatives at t = 1 are the factorial moments — exhibiting the part-count as 1 + Binomial(n−1, 1/2). The engine is the same gap bijection gapsEquiv : Composition n ≃ Finset (Fin (n−1)) plus length = |gaps| + 1. Mathlib has ∑ C(m,k) = 2^m but neither the subset generating function nor the part-count distribution.",
+    "mathContext": "$\\sum_{c\\,:\\,\\mathrm{Composition}\\ n} t^{\\,c.\\mathrm{length}} = t(1+t)^{n-1}$; the PGF of $1 + \\mathrm{Binomial}(n{-}1,\\tfrac12)$ after normalising by $2^{n-1}$.",
+    "significance": "context",
+    "relatedConcepts": ["compositions of an integer", "gap bijection", "generating functions", "probability generating function", "binomial distribution", "family lineage"],
+    "prerequisites": ["Mathlib's Composition n", "the gap bijection from parent entries", "generating functions and moments"]
+  },
+  {
+    "id": "ann-sum-pow-card",
+    "proofId": "composition-parts-choose-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 65, "endLine": 76 },
+    "type": "tactic",
+    "title": "The Subset Generating Function ∑ t^|s| = (t+1)^m",
+    "content": "`sum_pow_card` is the arithmetic core. It instantiates `Finset.prod_add` with the two constant functions (fun _ => t) and (fun _ => 1) over Fin m: prod_add expands ∏_{i : Fin m} (t + 1) as the powerset sum ∑_{s ⊆ univ} (∏_{i∈s} t)·(∏_{i∉s} 1). Then `simp only [Finset.prod_const, one_pow, mul_one, Finset.card_univ, Fintype.card_fin, Finset.powerset_univ]` collapses ∏_{i∈s} t to t^(|s|), ∏_{i∉s} 1 to 1 (via one_pow — the fix that makes the closed constant product reduce), and the powerset of univ to all subsets, leaving ∑_s t^(|s|) = (t + 1)^m. Combinatorially: expanding the product, each of the 2^m monomials takes the t from the factors in a subset s and the 1 from the rest, contributing t^(|s|).",
+    "mathContext": "$\\sum_{s \\subseteq \\mathrm{Fin}\\,m} t^{\\#s} = (t + 1)^m$, the $\\mathtt{Finset.prod\\_add}$ expansion of $\\prod_{i}(t+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.prod_add", "powerset", "generating functions", "subset sums"],
+    "prerequisites": ["products over a Finset", "Finset.prod_add", "powerset of a finite set"]
+  },
+  {
+    "id": "ann-parts-genfun",
+    "proofId": "composition-parts-choose-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 98 },
+    "type": "tactic",
+    "title": "Transporting the Sum Across the Gap Bijection",
+    "content": "`parts_genfun` is the headline. It first rewrites ∑_c t^(c.length) through the bridge `length_eq_card_gaps` as ∑_c t^((gapsEquiv n c).card + 1), then reindexes along the gap bijection with `Equiv.sum_comp (gapsEquiv n)` to the subset sum ∑_{s : Finset (Fin (n−1))} t^(|s|+1). `simp_rw [pow_succ]` splits t^(|s|+1) = t^(|s|)·t, `Finset.sum_mul` factors the common t out of the sum, `sum_pow_card` evaluates the residual ∑_s t^(|s|) = (1+t)^(n−1), and `ring` rearranges to t·(1+t)^(n−1). The whole part-count generating function is thus one application of the subset identity after transporting along the gap model.",
+    "mathContext": "$\\sum_c t^{c.\\mathrm{length}} = \\sum_{s \\subseteq \\mathrm{Fin}(n-1)} t^{\\#s+1} = t\\sum_s t^{\\#s} = t(1+t)^{n-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["gap bijection", "Equiv.sum_comp", "reindexing sums", "generating functions"],
+    "prerequisites": ["the gap bijection gapsEquiv and length_eq_card_gaps", "reindexing a sum along an equivalence", "factoring a constant out of a Finset sum"]
+  },
+  {
+    "id": "ann-parts-genfun-eval-one",
+    "proofId": "composition-parts-choose-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 100, "endLine": 108 },
+    "type": "concept",
+    "title": "At t = 1 the Generating Function Counts the Compositions",
+    "content": "`parts_genfun_eval_one` specialises `parts_genfun` at t = 1 over ℕ. Since 1^(c.length) = 1 for every composition, the left side ∑_c 1 counts the compositions of n, while the right side is 1·(1+1)^(n−1) = 2^(n−1). So the grandparent's count card (Composition n) = 2^(n−1) — the total mass of the part-count distribution — falls out as a single evaluation of the generating function, independently of Mathlib's composition_card. The proof is `simpa using parts_genfun 1 n hn`.",
+    "mathContext": "$\\#\\,\\mathrm{Composition}\\ n = \\sum_c 1^{c.\\mathrm{length}} = 1\\cdot 2^{n-1} = 2^{n-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["evaluation at t = 1", "total mass", "counting compositions"],
+    "prerequisites": ["specialising a polynomial identity", "Fintype.card"]
+  },
+  {
+    "id": "ann-parts-genfun-binomial",
+    "proofId": "composition-parts-choose-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 110, "endLine": 121 },
+    "type": "tactic",
+    "title": "The Coefficients Are the Graded Counts C(n−1,k)",
+    "content": "`parts_genfun_binomial` gives the explicit polynomial form ∑_{k<n} C(n−1,k)·t^(k+1) = t·(1+t)^(n−1). After destructuring n = M + 1 so that n − 1 = M, it commutes 1 + t to t + 1, applies the binomial theorem `add_pow` to (t+1)^M, distributes the leading t with `Finset.mul_sum`, and closes each term with `simp only [one_pow, mul_one]; ring`. Comparing with `parts_genfun`, the coefficient of t^(k+1) is C(n−1,k) = C(n−1,(k+1)−1) — exactly the number of compositions of n with k+1 parts, recovering the grandparent's graded count as the coefficients of the generating function.",
+    "mathContext": "$t(1+t)^{n-1} = \\sum_{k<n}\\binom{n-1}{k}t^{k+1}$, so $[t^{k+1}] = \\binom{n-1}{k}$, the count with $k+1$ parts.",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial theorem", "add_pow", "graded counts", "coefficient extraction"],
+    "prerequisites": ["the binomial theorem in Lean (add_pow)", "distributing a factor over a Finset sum"]
+  }
+]

--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "composition-parts-choose-oq-01-oq-01-oq-01-oq-02",
+  "title": "Composition Parts OQ-01-OQ-01-OQ-01-OQ-02: The Generating Function of the Number of Parts of a Composition",
+  "slug": "composition-parts-choose-oq-01-oq-01-oq-01-oq-02",
+  "description": "A composition of a natural number n is an ordered tuple of positive integers summing to n (Mathlib's Composition n); its number of parts is c.length. Earlier entries in this family extract individual statistics of the part-count of a uniformly random composition one at a time: the grandparent counts compositions (card (Composition n) = 2^(n−1)), the parent grades that count by part number (C(n−1, k−1) compositions with k parts), and the two direct parents compute the first moment (mean (n+1)/2) and the second moment / variance ((n−1)/4). The direct parent's open question asked whether all the moments can be produced at once. This leaf answers it by computing the entire generating function of the part-count in one closed form: over any commutative semiring R and any t : R, for n ≥ 1, ∑_{c : Composition n} t^(c.length) = t·(1 + t)^(n−1) (parts_genfun). This single polynomial identity is the probability generating function of the part-count up to the normalising 2^(n−1): its value at t = 1 returns the count 2^(n−1) (parts_genfun_eval_one), the coefficient of t^(k+1) is the number of compositions with k+1 parts C(n−1, k) (parts_genfun_binomial), and every moment of the part-count is a derivative at t = 1 — exhibiting the part-count as 1 + Binomial(n−1, 1/2), whose PGF is t·((1+t)/2)^(n−1) after normalising, and recovering the mean (n+1)/2 and variance (n−1)/4 of the parents without recomputing any binomial sum. The proof transports the sum along the same gap bijection gapsEquiv : Composition n ≃ Finset (Fin (n−1)) via the bridge length_eq_card_gaps (length c = (gaps c).card + 1), turning ∑_c t^(c.length) into the subset sum ∑_{s ⊆ Fin (n−1)} t^(|s|+1) = t·∑_s t^(|s|), and evaluates the subset generating function ∑_{s ⊆ Fin m} t^(|s|) = (t + 1)^m (sum_pow_card) as the Finset.prod_add expansion of ∏_{i : Fin m} (t + 1). Mathlib has neither the subset generating function in this form nor any statement about the part-count distribution of a composition; the identity ∑_c t^(c.length) = t(1+t)^(n−1) is original content here.",
+  "leanFile": {
+    "imports": [
+      "Proofs.CompositionPartsChooseOQ01OQ01",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "CompositionPartsChooseOQ01OQ01"
+    ],
+    "namespace": "CompositionPartsChooseOQ01OQ01OQ01OQ02",
+    "lineCount": 123,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CompositionPartsChooseOQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Composition_(combinatorics)",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompositionPartsChooseOQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "compositions",
+      "counting",
+      "binomial-coefficients",
+      "generating-function",
+      "probability-generating-function"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "composition-parts-choose-oq-01-oq-01-oq-01",
+        "relationship": "Direct parent: that entry computes the second moment and variance (n−1)/4 of the part-count and asks, as its open question, whether the higher moments / the full generating function can be produced from the same gap-bijection reduction. This entry answers it, computing the whole generating function ∑_c t^(c.length) = t(1+t)^(n−1), from which the mean and variance are derivatives at t = 1."
+      },
+      {
+        "id": "composition-parts-choose-oq-01",
+        "relationship": "Grandparent: the part-graded count C(n−1, k−1) of compositions of n into exactly k parts — recovered here as the coefficient of t^k in the generating function (parts_genfun_binomial)."
+      },
+      {
+        "id": "composition-card-2pow-oq-01",
+        "relationship": "Great-grandparent: the ungraded total card (Composition n) = 2^(n−1) — recovered here as the value of the generating function at t = 1 (parts_genfun_eval_one)."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 123,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All four named theorems (sum_pow_card, parts_genfun, parts_genfun_eval_one, parts_genfun_binomial) were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The generating-function identity ∑_{c : Composition n} t^(c.length) = t(1+t)^(n−1) holds over an arbitrary commutative semiring R; the specialisations at t = 1 (count) and the binomial-coefficient form are unconditional. The hypothesis n ≥ 1 is the natural domain (the empty composition of 0 is excluded so that n − 1 does not underflow). Mathlib supplies Finset.prod_add and the binomial theorem add_pow, but neither the subset generating function ∑_{s ⊆ Fin m} t^(|s|) = (t+1)^m in this form nor any statement about the part-count distribution of a composition; both are original content here, built on the parent's gapsEquiv and length_eq_card_gaps.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Compositions of n are ordered sequences of positive parts summing to n. There are 2^(n−1) of them, C(n−1, k−1) with exactly k parts, so the number of parts of a uniformly random composition is distributed as 1 + Binomial(n−1, 1/2) — each of the n−1 internal gaps is independently cut or not. Once the count, the graded count, the mean and the variance are known, the natural object that packages every statistic at once is the generating function ∑_c t^(c.length). It is (up to the normalising 2^(n−1)) the probability generating function of the part-count: its value at 1 is the total mass, its coefficients are the graded counts, and its derivatives at 1 are the factorial moments. This entry computes it in closed form directly from the combinatorics, then reads off the count and the graded count as special evaluations — no probability theory invoked.",
+    "problemStatement": "Package every moment of the number of parts of a composition into a single closed-form generating function. Show, over any commutative semiring R and any t : R, for n ≥ 1,\n\n$$\\sum_{c\\,:\\,\\mathrm{Composition}\\ n} t^{\\,c.\\mathrm{length}} = t\\,(1 + t)^{\\,n-1},$$\n\nand recover from it the count $2^{n-1}$ (at $t = 1$) and the graded count $\\binom{n-1}{k}$ (as the coefficient of $t^{k+1}$).",
+    "text": "The part-count of a composition equals one plus the number of internal gaps it cuts, and a composition of n corresponds bijectively to the subset of the n−1 internal gaps it cuts (gapsEquiv : Composition n ≃ Finset (Fin (n−1))). Transporting t^(c.length) along this bijection reduces the generating function to the subset sum ∑_{s ⊆ Fin (n−1)} t^(|s|+1) = t·∑_{s ⊆ Fin (n−1)} t^(|s|). The subset generating function ∑_{s ⊆ Fin m} t^(|s|) = (t + 1)^m is the Finset.prod_add expansion of ∏_{i : Fin m} (t + 1): each factor contributes either the t (put i ∈ s) or the 1 (put i ∉ s). Evaluating the closed form at t = 1 gives the count 2^(n−1); comparing with the binomial theorem gives the graded count.",
+    "proofStrategy": "sum_pow_card proves ∑_{s ⊆ Fin m} t^(|s|) = (t + 1)^m by instantiating Finset.prod_add with the constant functions t and 1 over Fin m: prod_add expands ∏(t + 1) as ∑_{s ⊆ univ} (∏_{i∈s} t)(∏_{i∉s} 1) = ∑_s t^(|s|)·1, and simp with Finset.prod_const, one_pow, Finset.powerset_univ collapses it to the subset sum. parts_genfun rewrites ∑_c t^(c.length) through length_eq_card_gaps as ∑_c t^((gapsEquiv n c).card + 1), reindexes by Equiv.sum_comp to ∑_{s : Finset (Fin (n−1))} t^(|s|+1), factors out one t via pow_succ and Finset.sum_mul, applies sum_pow_card, and closes by ring. parts_genfun_eval_one specialises parts_genfun at t = 1 over ℕ: 1^(c.length) = 1 makes the left side count the compositions and the right side 1·2^(n−1). parts_genfun_binomial expands t·(1+t)^(n−1) by the binomial theorem add_pow (after n = M+1) into ∑_{k<n} C(n−1,k)·t^(k+1), matching the coefficient of t^(k+1) to the graded count C(n−1,k) = C(n−1,(k+1)−1).",
+    "keyInsights": [
+      "**One generating function packages all the moments.** Where each parent extracted a single number from a particular weighted binomial sum ∑_k k^r C(m,k), the identity ∑_c t^(c.length) = t(1+t)^(n−1) encodes every one of them simultaneously: the count is its value at t = 1, the graded counts are its coefficients, and the mean (n+1)/2 and variance (n−1)/4 are its first two derivatives at t = 1 — no binomial sum is recomputed.",
+      "**It is the shifted-Binomial PGF.** Normalising by 2^(n−1) turns the identity into t·((1+t)/2)^(n−1), the probability generating function of 1 + Binomial(n−1, 1/2). The part-count is a cut/not-cut choice at each of the n−1 internal gaps, and the generating function makes that product-of-independent-choices structure literal.",
+      "**The whole thing rests on one Finset.prod_add.** The engine is the subset generating function ∑_{s ⊆ Fin m} t^(|s|) = (t+1)^m, which is just the expansion of ∏_{i : Fin m}(t + 1): each factor offers the t (include i) or the 1 (exclude i). Transporting it along the gap bijection and pulling out a single factor of t is the entire proof of the part-count generating function.",
+      "**Mathlib has neither piece.** Neither the subset generating function ∑_{s ⊆ Fin m} t^(|s|) = (t+1)^m in this form nor any statement about the part-count distribution of a composition is in Mathlib; the closed-form generating function of the part-count is the original content of this entry, unifying the count, graded count, mean and variance of the parents."
+    ],
+    "prerequisites": [
+      "Compositions of a natural number (Mathlib's Composition n), the number of parts c.length, and the gap bijection gapsEquiv : Composition n ≃ Finset (Fin (n−1)) with the bridge length c = (gaps c).card + 1 (from the parent entries)",
+      "The product-expansion identity Finset.prod_add and the binomial theorem add_pow over a commutative semiring",
+      "Finite-sum reindexing along an equivalence (Equiv.sum_comp) and factoring a constant out of a sum (Finset.sum_mul)",
+      "Generating functions: that the value at t = 1 is the total count, the coefficient of t^k is the graded count, and the derivatives at t = 1 are the factorial moments"
+    ]
+  },
+  "sections": [
+    {
+      "id": "subset-generating-function",
+      "title": "The Subset-Cardinality Generating Function",
+      "startLine": 65,
+      "endLine": 76,
+      "mathContext": "$\\sum_{s \\subseteq \\mathrm{Fin}\\,m} t^{\\#s} = (t + 1)^m$ over any commutative semiring.",
+      "summary": "sum_pow_card proves ∑_{s ⊆ Fin m} t^(|s|) = (t + 1)^m by instantiating Finset.prod_add with the constant functions t and 1 over Fin m. prod_add expands the product ∏_{i : Fin m} (t + 1) as ∑_{s ⊆ univ} (∏_{i∈s} t)·(∏_{i∉s} 1); simp with Finset.prod_const, one_pow, Finset.card_univ, Fintype.card_fin and Finset.powerset_univ collapses the two constant products to t^(|s|)·1 and the powerset of univ to all subsets, giving the subset sum. Each of the 2^m monomials picks the t from a subset s and the 1 from its complement, contributing t^(|s|)."
+    },
+    {
+      "id": "parts-generating-function",
+      "title": "The Generating Function of the Number of Parts",
+      "startLine": 78,
+      "endLine": 98,
+      "mathContext": "$\\sum_{c\\,:\\,\\mathrm{Composition}\\ n} t^{\\,c.\\mathrm{length}} = t\\,(1 + t)^{\\,n-1}$ for $n \\ge 1$.",
+      "summary": "parts_genfun rewrites ∑_c t^(c.length) through length_eq_card_gaps as ∑_c t^((gapsEquiv n c).card + 1), reindexes by Equiv.sum_comp to the subset sum ∑_{s : Finset (Fin (n−1))} t^(|s|+1), factors out a single t with pow_succ and Finset.sum_mul, applies sum_pow_card to the residual ∑_s t^(|s|) = (1+t)^(n−1), and closes by ring. The result t·(1+t)^(n−1) is the probability generating function of the part-count up to the normalising 2^(n−1)."
+    },
+    {
+      "id": "evaluations",
+      "title": "Reading Off the Count and the Graded Count",
+      "startLine": 100,
+      "endLine": 121,
+      "mathContext": "$\\#\\,\\mathrm{Composition}\\ n = 2^{n-1}$ (at $t=1$) and $\\sum_{k<n}\\binom{n-1}{k}t^{k+1} = t(1+t)^{n-1}$.",
+      "summary": "parts_genfun_eval_one specialises parts_genfun at t = 1 over ℕ: since 1^(c.length) = 1, the left side counts the compositions while the right side is 1·2^(n−1), re-deriving the grandparent's 2^(n−1) count as a special value of the generating function. parts_genfun_binomial expands t·(1+t)^(n−1) via the binomial theorem add_pow (after writing n = M+1) into ∑_{k<n} C(n−1,k)·t^(k+1), so the coefficient of t^(k+1) is C(n−1,k) = C(n−1,(k+1)−1) — exactly the number of compositions of n with k+1 parts, the grandparent's graded count."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entire generating function of the number of parts of a composition is formalised sorry-free and axiom-free over an arbitrary commutative semiring: $\\sum_{c\\,:\\,\\mathrm{Composition}\\ n} t^{\\,c.\\mathrm{length}} = t\\,(1 + t)^{\\,n-1}$ for $n \\ge 1$ (`parts_genfun`). Its value at $t = 1$ is the count $2^{n-1}$ (`parts_genfun_eval_one`) and its coefficients are the graded counts $\\binom{n-1}{k}$ (`parts_genfun_binomial`) — so the count, the graded count, the mean $(n+1)/2$ and the variance $(n-1)/4$ of the whole family are now special values and derivatives of a single closed form.",
+    "implications": "The content beyond Mathlib is the subset generating function $\\sum_{s \\subseteq \\mathrm{Fin}\\,m} t^{\\#s} = (t+1)^m$ (`sum_pow_card`), proved as a Finset.prod_add expansion, and its assembly via the gap bijection into the part-count generating function $t(1+t)^{n-1}$. This answers the direct parent's open question — whether all the moments can be produced at once — affirmatively and uniformly: the generating function is exactly the shifted-Binomial PGF $t\\cdot((1+t)/2)^{n-1}$ after normalising, exhibiting the part-count as $1 + \\mathrm{Binomial}(n-1, 1/2)$ and recovering every earlier statistic without recomputing a binomial sum.",
+    "openQuestions": [
+      "Does the two-variable refinement ∑_c x^(c.length) y^(largest part) — or any joint generating function of part-count with a second statistic (largest part, number of parts equal to 1) — admit a comparable closed form via an enriched gap model?",
+      "Can the generating function of the part-count of a composition into parts drawn from a fixed set S (rather than all positive integers) be obtained by the same product expansion, replacing (1 + t) by the S-restricted local factor?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "composition-parts-choose-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: that entry computes the second moment and variance (n−1)/4 and asks whether the higher moments / full generating function follow from the same reduction. This entry computes the whole generating function ∑_c t^(c.length) = t(1+t)^(n−1), from which the parents' mean and variance are derivatives at t = 1."
+    },
+    {
+      "proofId": "composition-parts-choose-oq-01",
+      "relationship": "builds-on",
+      "description": "Grandparent: the part-graded count C(n−1, k−1) of compositions of n into exactly k parts — recovered here as the coefficient of t^k in the generating function (parts_genfun_binomial)."
+    },
+    {
+      "proofId": "composition-card-2pow-oq-01",
+      "relationship": "foundational",
+      "description": "Great-grandparent: the ungraded total card (Composition n) = 2^(n−1) — recovered here as the value of the generating function at t = 1 (parts_genfun_eval_one)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry adopting and **repairing an orphan file** left untracked in `main` by a prior (dead) session. Computes the **full generating function** of the number of parts of a composition, packaging every moment of the part-count into one closed form:

$$\sum_{c\,:\,\mathrm{Composition}\ n} t^{\,c.\mathrm{length}} = t\,(1 + t)^{\,n-1} \qquad (n \ge 1)$$

over an arbitrary commutative semiring. This directly answers the **direct parent's open question** (the second-moment/variance entry `composition-parts-choose-oq-01-oq-01-oq-01`, whose OQ #2 asked whether all higher moments / the full generating function can be produced from the same gap-bijection reduction).

## Theorems (4, 0 sorries, 0 axioms)

- `sum_pow_card` — the subset generating function $\sum_{s \subseteq \mathrm{Fin}\,m} t^{\#s} = (t+1)^m$, a `Finset.prod_add` expansion of $\prod_i (t+1)$.
- `parts_genfun` — the headline $\sum_c t^{c.\mathrm{length}} = t(1+t)^{n-1}$, transporting along the gap bijection `gapsEquiv` with `length = |gaps|+1`.
- `parts_genfun_eval_one` — at $t=1$ recovers the grandparent's count $\#\,\mathrm{Composition}\ n = 2^{n-1}$.
- `parts_genfun_binomial` — the coefficient of $t^{k+1}$ is the graded count $\binom{n-1}{k}$ (via `add_pow`).

Up to the normalising $2^{n-1}$, this is the PGF of $1 + \mathrm{Binomial}(n-1, 1/2)$, recovering the parents' mean $(n+1)/2$ and variance $(n-1)/4$ as derivatives at $t=1$ — without recomputing any binomial sum.

## Repair note

The orphan's `sum_pow_card` did not compile: after `Finset.prod_add`, the constant product $1^{\#(\mathrm{univ}\setminus s)}$ was left unreduced because the `simp` set was missing `one_pow`. Fixed by swapping the unused `Finset.prod_const_one` for `one_pow`. The file now builds cleanly.

## Verification

- Compiles via `lake env lean` against the existing Mathlib build cache (exit 0, no errors/warnings).
- `#print axioms` on all four theorems → only `propext` / `Classical.choice` / `Quot.sound` (0-axiom, verified).
- Gallery: `meta.json` within size caps (4328 entries); annotations validate (entry not among pre-existing repo-wide range warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)