### PR TITLE
research(dirichlet-approximation-theorem-oq-01-oq-03): simultaneous Diophantine approximation via n-dim pigeonhole [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DirichletApproximationOQ01OQ03.lean
+++ b/proofs/Proofs/DirichletApproximationOQ01OQ03.lean
@@ -1,0 +1,162 @@
+/-
+# Dirichlet Approximation — OQ-01-OQ-03: Simultaneous Diophantine Approximation
+
+**Open Question (third open question of OQ-01).** The parent `DirichletApproximation`
+proves the *single-real* one-shot pigeonhole bound: for each `Q` there is one
+fraction `p/q` with `1 ≤ q ≤ Q` and `|qα − p| < 1/Q`. Its OQ-01 upgrade recasts this
+as the classical coprime integer-pair statement and asks, as its third open question,
+whether the reformulation
+
+> *"Does it extend to the simultaneous approximation theorem — one denominator
+> approximating several reals at once?"*
+
+This file answers that question by proving **Dirichlet's simultaneous approximation
+theorem** in full generality over an arbitrary finite family of reals.
+
+## Statement
+
+For real numbers `α : Fin n → ℝ` and any `N ≥ 1`, there is a single denominator
+`q` with `1 ≤ q ≤ Nⁿ` and integers `p : Fin n → ℤ` such that, *simultaneously* for
+every coordinate `i`,
+```
+|q · αᵢ − pᵢ| < 1 / N .
+```
+Equivalently, one denominator `q ≤ Nⁿ` makes all `n` of the numbers `q·αᵢ` lie
+within `1/N` of an integer at once. The `n = 1` case recovers the parent one-shot
+bound (with `Q = N`).
+
+## Proof
+
+Pure pigeonhole in the `n`-dimensional unit cube. Chop `[0,1)ⁿ` into `Nⁿ` boxes of
+side `1/N`. The `Nⁿ + 1` cube points
+```
+(frac(m·α₀), …, frac(m·α_{n-1})),   m = 0, 1, …, Nⁿ,
+```
+cannot all lie in distinct boxes, so two of them — say for `m = i > j` — share a box.
+Their difference has every coordinate within `1/N`, and taking `q = i − j`,
+`pᵢ = ⌊i·αᵢ⌋ − ⌊j·αᵢ⌋` gives the claim, since
+`q·αᵢ − pᵢ = frac(i·αᵢ) − frac(j·αᵢ)`.
+
+The "same box ⟹ close" step is isolated as `abs_sub_lt_one_of_floor_eq`: two reals
+with equal integer part differ by less than one. This is the multi-dimensional
+analogue of the parent's `interval_bound`.
+
+## References
+
+* Mathlib: `Mathlib/NumberTheory/DiophantineApproximation/Basic.lean`
+* G.H. Hardy & E.M. Wright, *An Introduction to the Theory of Numbers*, Thm 200
+  (simultaneous approximation).
+* J.W.S. Cassels, *An Introduction to Diophantine Approximation*, Ch. I §5.
+-/
+import Mathlib
+
+namespace DirichletApproximationOQ01OQ03
+
+/-- Two reals with the same integer part differ by less than one. This is the
+"same box ⟹ close" step of the pigeonhole argument. -/
+private lemma abs_sub_lt_one_of_floor_eq {a b : ℝ} (h : ⌊a⌋ = ⌊b⌋) :
+    |a - b| < 1 := by
+  have ha := Int.fract_nonneg a
+  have ha' := Int.fract_lt_one a
+  have hb := Int.fract_nonneg b
+  have hb' := Int.fract_lt_one b
+  have hrw : a - b = Int.fract a - Int.fract b := by
+    simp only [Int.fract]; rw [h]; ring
+  rw [hrw, abs_lt]
+  constructor <;> linarith
+
+/-- The pigeonhole map: index `m ↦ (i ↦ ⌊N · frac(m·αᵢ)⌋)`, sending each of the
+`Nⁿ + 1` cube points to one of the `Nⁿ` boxes `(Fin n → Fin N)`. -/
+private noncomputable def boxMap {n : ℕ} (α : Fin n → ℝ) (N : ℕ) (hN : 0 < N) :
+    Fin (N ^ n + 1) → (Fin n → Fin N) := fun m i =>
+  ⟨Int.toNat ⌊(N : ℝ) * Int.fract ((m : ℕ) * α i)⌋, by
+    have hN' : (0 : ℝ) < N := by exact_mod_cast hN
+    have h0 : 0 ≤ (N : ℝ) * Int.fract ((m : ℕ) * α i) :=
+      mul_nonneg hN'.le (Int.fract_nonneg _)
+    have h1 : (N : ℝ) * Int.fract ((m : ℕ) * α i) < N := by
+      have hlt := Int.fract_lt_one ((m : ℕ) * α i)
+      nlinarith [Int.fract_nonneg ((m : ℕ) * α i)]
+    rw [Int.toNat_lt (Int.floor_nonneg.mpr h0)]
+    exact_mod_cast Int.floor_lt.mpr h1⟩
+
+/-- Core step: given a pigeonhole collision with `j < i` (as naturals), extract a
+simultaneous approximation with denominator `q = i − j`. -/
+private lemma exists_of_gt {n : ℕ} (α : Fin n → ℝ) (N : ℕ) (hN : 0 < N)
+    {i j : Fin (N ^ n + 1)} (hgt : (j : ℕ) < (i : ℕ))
+    (hfij : boxMap α N hN i = boxMap α N hN j) :
+    ∃ (q : ℕ) (p : Fin n → ℤ), 1 ≤ q ∧ q ≤ N ^ n ∧
+      ∀ k, |(q : ℝ) * α k - (p k : ℝ)| < 1 / (N : ℝ) := by
+  have hN' : (0 : ℝ) < N := by exact_mod_cast hN
+  have hji : (j : ℕ) ≤ (i : ℕ) := le_of_lt hgt
+  set q : ℕ := (i : ℕ) - (j : ℕ) with hq_def
+  refine ⟨q, fun k => ⌊(i : ℕ) * α k⌋ - ⌊(j : ℕ) * α k⌋, ?_, ?_, ?_⟩
+  · -- 1 ≤ q
+    omega
+  · -- q ≤ Nⁿ
+    have hi := i.isLt
+    omega
+  · -- simultaneous bound
+    intro k
+    -- q·αₖ − pₖ = frac(i·αₖ) − frac(j·αₖ)
+    have hkey : (q : ℝ) * α k - ((⌊(i : ℕ) * α k⌋ - ⌊(j : ℕ) * α k⌋ : ℤ) : ℝ)
+        = Int.fract ((i : ℕ) * α k) - Int.fract ((j : ℕ) * α k) := by
+      simp only [Int.fract, hq_def]
+      rw [Nat.cast_sub hji]
+      push_cast
+      ring
+    rw [hkey]
+    -- Extract the per-coordinate floor equality from the box collision.
+    have hval := congr_fun hfij k
+    have hvv : (⌊(N : ℝ) * Int.fract ((i : ℕ) * α k)⌋).toNat
+        = (⌊(N : ℝ) * Int.fract ((j : ℕ) * α k)⌋).toNat := by
+      have := congr_arg Fin.val hval
+      simpa [boxMap] using this
+    have hnn_i : 0 ≤ ⌊(N : ℝ) * Int.fract ((i : ℕ) * α k)⌋ :=
+      Int.floor_nonneg.mpr (mul_nonneg hN'.le (Int.fract_nonneg _))
+    have hnn_j : 0 ≤ ⌊(N : ℝ) * Int.fract ((j : ℕ) * α k)⌋ :=
+      Int.floor_nonneg.mpr (mul_nonneg hN'.le (Int.fract_nonneg _))
+    have hfloor : ⌊(N : ℝ) * Int.fract ((i : ℕ) * α k)⌋
+        = ⌊(N : ℝ) * Int.fract ((j : ℕ) * α k)⌋ := by omega
+    -- Same box ⟹ the scaled fracs are within one of each other.
+    have hlt1 : |(N : ℝ) * Int.fract ((i : ℕ) * α k)
+        - (N : ℝ) * Int.fract ((j : ℕ) * α k)| < 1 :=
+      abs_sub_lt_one_of_floor_eq hfloor
+    rw [show (N : ℝ) * Int.fract ((i : ℕ) * α k) - (N : ℝ) * Int.fract ((j : ℕ) * α k)
+        = (N : ℝ) * (Int.fract ((i : ℕ) * α k) - Int.fract ((j : ℕ) * α k)) from by ring,
+      abs_mul, abs_of_pos hN'] at hlt1
+    rw [mul_comm] at hlt1
+    exact (lt_div_iff₀ hN').mpr hlt1
+
+/-- **Dirichlet's Simultaneous Approximation Theorem.** For any finite family of
+reals `α : Fin n → ℝ` and any `N ≥ 1`, there is a single denominator `q` with
+`1 ≤ q ≤ Nⁿ` and integers `p : Fin n → ℤ` such that
+`|q · αᵢ − pᵢ| < 1 / N` holds simultaneously for every coordinate `i`.
+
+Proved by the pigeonhole principle in the `n`-dimensional unit cube: the `Nⁿ + 1`
+points `(frac(m·αᵢ))ᵢ` for `m = 0, …, Nⁿ` cannot all lie in distinct side-`1/N`
+boxes, so two coincide and their difference is the sought approximation. -/
+theorem simultaneous_dirichlet {n : ℕ} (α : Fin n → ℝ) (N : ℕ) (hN : 0 < N) :
+    ∃ (q : ℕ) (p : Fin n → ℤ), 1 ≤ q ∧ q ≤ N ^ n ∧
+      ∀ k, |(q : ℝ) * α k - (p k : ℝ)| < 1 / (N : ℝ) := by
+  -- Pigeonhole: Nⁿ + 1 points, Nⁿ boxes.
+  have hcard : Fintype.card (Fin n → Fin N) < Fintype.card (Fin (N ^ n + 1)) := by
+    simp only [Fintype.card_fun, Fintype.card_fin]
+    omega
+  obtain ⟨i, j, hij, hfij⟩ :=
+    Fintype.exists_ne_map_eq_of_card_lt (boxMap α N hN) hcard
+  -- Order the colliding indices; both orderings reduce to `exists_of_gt`.
+  rcases lt_or_gt_of_ne (fun h => hij (Fin.ext h)) with h | h
+  · exact exists_of_gt α N hN h hfij.symm
+  · exact exists_of_gt α N hN h hfij
+
+/-- The `n = 1` specialization recovers the shape of the parent one-shot bound:
+for a single real `α` and `N ≥ 1` there are integers `p, q` with `1 ≤ q ≤ N` and
+`|q·α − p| < 1/N`. -/
+theorem dirichlet_one_real (α : ℝ) (N : ℕ) (hN : 0 < N) :
+    ∃ (q : ℕ) (p : ℤ), 1 ≤ q ∧ q ≤ N ∧ |(q : ℝ) * α - (p : ℝ)| < 1 / (N : ℝ) := by
+  obtain ⟨q, p, hq1, hqle, hbound⟩ :=
+    simultaneous_dirichlet (fun _ : Fin 1 => α) N hN
+  refine ⟨q, p 0, hq1, ?_, hbound 0⟩
+  simpa using hqle
+
+end DirichletApproximationOQ01OQ03

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "dir-oq0103-ann-header",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "concept",
+    "title": "Simultaneous Diophantine approximation",
+    "content": "The docstring frames the third open question of the parent OQ-01: can one denominator approximate several reals at once? Dirichlet's simultaneous theorem answers yes — for α : Fin n → ℝ and N ≥ 1 there is a single q with 1 ≤ q ≤ Nⁿ and |q·αᵢ − pᵢ| < 1/N for every coordinate i. The method is the n-dimensional pigeonhole in the unit cube: chop [0,1)ⁿ into Nⁿ boxes of side 1/N; among the Nⁿ+1 cube points (frac(m·α₀), …, frac(m·α_{n−1})) for m = 0, …, Nⁿ, two share a box, and their index difference is the common denominator. Mathlib has only the single-real version.",
+    "mathContext": "Statement and pigeonhole strategy for the simultaneous approximation theorem.",
+    "prerequisites": ["Fractional parts", "Pigeonhole principle", "The parent single-real Dirichlet bound"],
+    "relatedConcepts": ["Geometry of numbers", "Simultaneous approximation", "Diophantine exponents"],
+    "significance": "high"
+  },
+  {
+    "id": "dir-oq0103-ann-samebox",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-03",
+    "range": { "startLine": 55, "endLine": 67 },
+    "type": "lemma",
+    "title": "Same box ⟹ close: abs_sub_lt_one_of_floor_eq",
+    "content": "The sole metric ingredient: if ⌊a⌋ = ⌊b⌋ then |a − b| < 1. Writing a − b = frac a − frac b (valid because the floors agree) and using 0 ≤ frac < 1 for both bounds the difference. Applied later with a = N·frac(i·αₖ), b = N·frac(j·αₖ): equal box index in coordinate k means the scaled fractional parts are within 1 of each other, i.e. the fractional parts themselves within 1/N. This is the multi-dimensional analogue of the parent file's interval_bound.",
+    "mathContext": "Two reals with the same integer part differ by less than one.",
+    "prerequisites": ["Int.fract", "abs_lt"],
+    "relatedConcepts": ["Fractional part", "Floor function"],
+    "significance": "medium"
+  },
+  {
+    "id": "dir-oq0103-ann-boxmap",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-03",
+    "range": { "startLine": 68, "endLine": 81 },
+    "type": "definition",
+    "title": "The box-assignment map boxMap",
+    "content": "boxMap α N hN : Fin (Nⁿ+1) → (Fin n → Fin N) sends m ↦ (i ↦ ⌊N·frac(m·αᵢ)⌋), recording which side-1/N box the m-th cube point occupies in each coordinate. The coordinate is a legitimate Fin N index because 0 ≤ N·frac(m·αᵢ) < N (from 0 ≤ frac < 1 and N > 0), discharged via Int.toNat_lt and Int.floor_lt. The domain has Nⁿ+1 elements, the codomain exactly Nⁿ — the imbalance that forces a collision.",
+    "mathContext": "Encodes the box lattice as the codomain of the pigeonhole map.",
+    "prerequisites": ["Int.floor", "Int.toNat", "Fin"],
+    "relatedConcepts": ["Pigeonhole map", "Box lattice"],
+    "significance": "medium"
+  },
+  {
+    "id": "dir-oq0103-ann-core",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-03",
+    "range": { "startLine": 82, "endLine": 128 },
+    "type": "lemma",
+    "title": "Collision ⟹ approximation: exists_of_gt",
+    "content": "From a box collision boxMap i = boxMap j with j < i, set q = i − j and pₖ = ⌊i·αₖ⌋ − ⌊j·αₖ⌋. The identity q·αₖ − pₖ = frac(i·αₖ) − frac(j·αₖ) (hkey, via Nat.cast_sub and unfolding Int.fract) holds in every coordinate with the SAME q — this is why one denominator serves all n reals. The per-coordinate floor equality ⌊N·frac(i·αₖ)⌋ = ⌊N·frac(j·αₖ)⌋ is pulled from the function equality by congr_fun then congr_arg Fin.val and omega on the toNat values; abs_sub_lt_one_of_floor_eq plus clearing the factor N (abs_mul, lt_div_iff₀) yields |q·αₖ − pₖ| < 1/N. The bounds 1 ≤ q ≤ Nⁿ come from 0 ≤ j < i ≤ Nⁿ.",
+    "mathContext": "Extract the common denominator and integer vector from a pigeonhole collision.",
+    "prerequisites": ["congr_fun", "Nat.cast_sub", "lt_div_iff₀", "Int.fract"],
+    "relatedConcepts": ["Telescoping fractional parts", "Common denominator"],
+    "significance": "high"
+  },
+  {
+    "id": "dir-oq0103-ann-main",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-03",
+    "range": { "startLine": 130, "endLine": 150 },
+    "type": "theorem",
+    "title": "Dirichlet's simultaneous approximation theorem",
+    "content": "simultaneous_dirichlet: computes card (Fin n → Fin N) = Nⁿ < Nⁿ+1 = card (Fin (Nⁿ+1)) via Fintype.card_fun, invokes Fintype.exists_ne_map_eq_of_card_lt for a collision i ≠ j, and reduces both index orderings to exists_of_gt through lt_or_gt_of_ne. The result: one denominator q ≤ Nⁿ approximating all n reals within 1/N simultaneously. Elementary and axiom-free.",
+    "mathContext": "Main theorem: pigeonhole to a collision, then invoke the core step.",
+    "prerequisites": ["Fintype.exists_ne_map_eq_of_card_lt", "Fintype.card_fun"],
+    "relatedConcepts": ["Pigeonhole principle", "Simultaneous approximation"],
+    "significance": "high"
+  },
+  {
+    "id": "dir-oq0103-ann-onereal",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-03",
+    "range": { "startLine": 152, "endLine": 162 },
+    "type": "theorem",
+    "title": "n = 1 specialization recovers the parent bound",
+    "content": "dirichlet_one_real: feeding the constant family fun _ : Fin 1 => α into the simultaneous theorem recovers the parent one-shot single-real bound — integers p, q with 1 ≤ q ≤ N (since N¹ = N) and |q·α − p| < 1/N. This exhibits the simultaneous theorem as a strict generalization of the parent entry.",
+    "mathContext": "The one-dimensional case matches the parent one-shot Dirichlet bound.",
+    "prerequisites": ["Fin 1"],
+    "relatedConcepts": ["Specialization", "Single-real Dirichlet bound"],
+    "significance": "low"
+  }
+]

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-03/meta.json
@@ -1,0 +1,195 @@
+{
+  "id": "dirichlet-approximation-theorem-oq-01-oq-03",
+  "slug": "dirichlet-approximation-theorem-oq-01-oq-03",
+  "title": "Dirichlet Approximation OQ-01-OQ-03: Simultaneous Diophantine Approximation",
+  "description": "Dirichlet's simultaneous approximation theorem, formalized in full generality over an arbitrary finite family of reals. The parent one-shot bound and its OQ-01 upgrade approximate a single real; their third open question asks whether one denominator can approximate several reals at once. This entry answers it: for any α : Fin n → ℝ and any N ≥ 1 there is a single denominator q with 1 ≤ q ≤ Nⁿ and integers p : Fin n → ℤ such that |q·αᵢ − pᵢ| < 1/N holds simultaneously for every coordinate i. The proof is the n-dimensional pigeonhole: chop the unit cube [0,1)ⁿ into Nⁿ boxes of side 1/N; among the Nⁿ+1 cube points (frac(m·α₀), …, frac(m·α_{n−1})) for m = 0, …, Nⁿ, two share a box, and taking q = i − j, pᵢ = ⌊i·αᵢ⌋ − ⌊j·αᵢ⌋ for the colliding indices i > j gives q·αᵢ − pᵢ = frac(i·αᵢ) − frac(j·αᵢ), which is within 1/N in every coordinate. The n = 1 case recovers the parent one-shot bound with Q = N. Mathlib has the single-real Dirichlet/Legendre theorems and continued fractions but no simultaneous version; this is a genuinely new, elementary, axiom-free result. Zero sorries, zero axioms.",
+  "overview": {
+    "historicalContext": "Dirichlet's 1842 approximation theorem, in its single-variable form, guarantees for each bound Q a fraction p/q (1 ≤ q ≤ Q) with |α − p/q| < 1/(qQ) ≤ 1/q². Dirichlet already stated the far stronger simultaneous version (Hardy & Wright, Theorem 200): for any reals α₁,…,αₙ and any N there is one common denominator q ≤ Nⁿ with all n numbers q·αᵢ within 1/N of an integer at once. This is the foundational result of the geometry of numbers and of multidimensional Diophantine approximation — it is the input to the theory of simultaneously badly approximable vectors, to Minkowski's convex-body theorem's number-theoretic consequences, and to the subject of Diophantine exponents in higher dimension. The parent gallery entry formalized the one-shot single-real bound; its OQ-01 recast it in coprime integer-pair form and asked, as its third open question, whether the reformulation extends to the simultaneous theorem. This entry settles that question by proving the simultaneous theorem over an arbitrary finite index type Fin n.",
+    "problemStatement": "Let α : Fin n → ℝ be any finite family of real numbers and let N ≥ 1. Then there exist a natural number q and integers p : Fin n → ℤ with\n\n$$1 \\le q \\le N^n \\quad\\text{and}\\quad \\left| q\\,\\alpha_i - p_i \\right| < \\frac{1}{N} \\ \\text{ for every } i.$$\n\nOne single denominator q ≤ Nⁿ therefore makes all n of the numbers q·αᵢ lie within 1/N of an integer simultaneously.",
+    "text": "Mathlib provides the single-real Dirichlet theorem, Legendre's theorem, and continued fractions, but no simultaneous (multi-dimensional) approximation theorem. This entry supplies it in full generality: the family is an arbitrary function α : Fin n → ℝ, and the argument is the honest n-dimensional pigeonhole in the unit cube, reusing nothing beyond elementary floor/fractional-part facts and Fintype.exists_ne_map_eq_of_card_lt.",
+    "proofStrategy": "Chop the unit cube [0,1)ⁿ into Nⁿ boxes of side 1/N. Encode the box containing the point (frac(m·αᵢ))ᵢ by the map boxMap : Fin (Nⁿ+1) → (Fin n → Fin N), m ↦ (i ↦ ⌊N·frac(m·αᵢ)⌋); each coordinate is a valid index because 0 ≤ N·frac(m·αᵢ) < N. The domain has Nⁿ+1 elements and the codomain (Fin n → Fin N) has exactly Nⁿ (Fintype.card_fun), so by pigeonhole (Fintype.exists_ne_map_eq_of_card_lt) two distinct indices collide: boxMap i = boxMap j with, say, j < i. For each coordinate k, congr_fun gives equal box indices, i.e. ⌊N·frac(i·αₖ)⌋ = ⌊N·frac(j·αₖ)⌋. Two reals with equal integer part differ by less than one (abs_sub_lt_one_of_floor_eq), so |N·frac(i·αₖ) − N·frac(j·αₖ)| < 1, i.e. |frac(i·αₖ) − frac(j·αₖ)| < 1/N. Setting q = i − j and pₖ = ⌊i·αₖ⌋ − ⌊j·αₖ⌋ makes q·αₖ − pₖ = frac(i·αₖ) − frac(j·αₖ), giving the simultaneous bound; and 1 ≤ q ≤ Nⁿ because 0 ≤ j < i ≤ Nⁿ.",
+    "keyInsights": [
+      "**The codomain size is the whole point**: the box space (Fin n → Fin N) has exactly Nⁿ elements (Fintype.card_fun), and the pigeonhole engine only needs one more point than that — hence Nⁿ+1 sample denominators and the sharp bound q ≤ Nⁿ. The exponent n in the denominator bound is not an artifact; it is the cardinality of the box lattice",
+      "**Same box ⟹ close, isolated once**: the entire metric content is the one-line lemma that two reals with the same floor differ by less than 1. Scaling by N turns 'same side-1/N box' into 'fractional parts within 1/N', uniformly across all n coordinates at once",
+      "**The telescoping identity is coordinatewise**: q·αₖ − pₖ = frac(i·αₖ) − frac(j·αₖ) holds separately in every coordinate with the SAME q = i − j, which is exactly why one denominator serves all n reals — the shared denominator is the shared pigeonhole index difference",
+      "**Full generality is free**: quantifying over α : Fin n → ℝ (rather than a fixed n) costs nothing — the pigeonhole map, the card computation, and the coordinatewise extraction are all uniform in n. The n = 0 case is handled automatically (vacuous conclusion, q = 1), and n = 1 recovers the parent one-shot bound",
+      "**Elementary and axiom-free**: no measure theory, no Minkowski convex-body machinery — just floors, fractional parts, and finite pigeonhole. The result depends only on propext, Classical.choice, Quot.sound"
+    ],
+    "prerequisites": [
+      "The fractional part Int.fract and its bounds 0 ≤ frac x < 1, plus Int.floor / Int.toNat coercion facts",
+      "Finite pigeonhole: Fintype.exists_ne_map_eq_of_card_lt, and the cardinality of a function type Fintype.card_fun : card (α → β) = card β ^ card α",
+      "Elementary ordered-field manipulation (lt_div_iff₀, abs_mul) to clear the denominator N"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-and-setup",
+      "title": "Module Overview and Setup",
+      "startLine": 1,
+      "endLine": 54,
+      "mathContext": "Goal: one denominator q ≤ Nⁿ approximating n reals simultaneously within 1/N.",
+      "summary": "Module docstring stating the simultaneous approximation theorem, framing it as the third open question of the parent OQ-01 (one denominator for several reals), and describing the n-dimensional pigeonhole method (chop [0,1)ⁿ into Nⁿ side-1/N boxes; Nⁿ+1 cube points force a collision). Notes that Mathlib has the single-real theorem but no simultaneous version. Followed by import Mathlib and namespace DirichletApproximationOQ01OQ03."
+    },
+    {
+      "id": "same-box-lemma",
+      "title": "Same Box ⟹ Close (abs_sub_lt_one_of_floor_eq)",
+      "startLine": 55,
+      "endLine": 67,
+      "mathContext": "Two reals with equal integer part differ by less than one.",
+      "summary": "abs_sub_lt_one_of_floor_eq: if ⌊a⌋ = ⌊b⌋ then |a − b| < 1. Proved by writing a − b = frac a − frac b (using the floor equality) and bounding each fractional part in [0,1). This is the sole metric ingredient of the pigeonhole argument — the multi-dimensional analogue of the parent file's interval_bound — applied later to a = N·frac(i·αₖ), b = N·frac(j·αₖ)."
+    },
+    {
+      "id": "pigeonhole-map",
+      "title": "The Box-Assignment Map (boxMap)",
+      "startLine": 68,
+      "endLine": 81,
+      "mathContext": "Assign each of the Nⁿ+1 cube points to one of the Nⁿ boxes.",
+      "summary": "boxMap α N hN : Fin (Nⁿ+1) → (Fin n → Fin N), m ↦ (i ↦ ⌊N·frac(m·αᵢ)⌋). The coordinate is a valid Fin N index because 0 ≤ N·frac(m·αᵢ) < N (from 0 ≤ frac < 1 and N > 0), discharged via Int.toNat_lt and Int.floor_lt. This is the pigeonhole map whose non-injectivity (domain bigger than codomain) drives the whole theorem."
+    },
+    {
+      "id": "collision-core",
+      "title": "Extracting the Approximation from a Collision (exists_of_gt)",
+      "startLine": 82,
+      "endLine": 128,
+      "mathContext": "Given a box collision with j < i, produce q = i − j and p = ⌊i·α⌋ − ⌊j·α⌋.",
+      "summary": "exists_of_gt: from boxMap i = boxMap j with j < i, extract q = i − j (so 1 ≤ q ≤ Nⁿ) and pₖ = ⌊i·αₖ⌋ − ⌊j·αₖ⌋. Establishes coordinatewise q·αₖ − pₖ = frac(i·αₖ) − frac(j·αₖ) (hkey, via Nat.cast_sub and Int.fract unfolding), then pulls the per-coordinate floor equality ⌊N·frac(i·αₖ)⌋ = ⌊N·frac(j·αₖ)⌋ out of the box equality (congr_fun + congr_arg Fin.val + omega on the toNat values), applies abs_sub_lt_one_of_floor_eq, and clears the factor N (abs_mul, lt_div_iff₀) to reach |q·αₖ − pₖ| < 1/N for every k."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Simultaneous Dirichlet Theorem and n = 1 Specialization",
+      "startLine": 130,
+      "endLine": 162,
+      "mathContext": "Pigeonhole to a collision, then invoke the core step in either ordering.",
+      "summary": "simultaneous_dirichlet: computes card (Fin n → Fin N) = Nⁿ < Nⁿ+1 = card (Fin (Nⁿ+1)) (Fintype.card_fun), invokes Fintype.exists_ne_map_eq_of_card_lt to get a collision i ≠ j, and reduces both orderings to exists_of_gt via lt_or_gt_of_ne. dirichlet_one_real: the n = 1 specialization, recovering the parent one-shot shape (single real α, 1 ≤ q ≤ N, |q·α − p| < 1/N) by feeding the constant family fun _ : Fin 1 => α."
+    }
+  ],
+  "conclusion": {
+    "summary": "Dirichlet's simultaneous approximation theorem is formalized in full generality: for any α : Fin n → ℝ and N ≥ 1 there is one denominator q with 1 ≤ q ≤ Nⁿ and integers p with |q·αᵢ − pᵢ| < 1/N for every coordinate i. The proof is the n-dimensional pigeonhole — Nⁿ+1 cube points in Nⁿ side-1/N boxes force a collision, whose index difference is the common denominator — with the only metric input being that two reals with equal floor differ by less than 1. The n = 1 case recovers the parent one-shot bound. Zero sorries, zero axioms (only propext, Classical.choice, Quot.sound).",
+    "implications": "This is the multidimensional foundation of Diophantine approximation and the geometry of numbers: it is the pigeonhole prototype that Minkowski's convex-body theorem generalizes, and the starting point for simultaneously badly approximable vectors, Diophantine exponents in dimension n, and the transference principles relating simultaneous approximation to approximation of a single linear form. Formalizing it over an arbitrary Fin n (rather than a fixed small n) makes the sharp bound q ≤ Nⁿ available uniformly for downstream multidimensional work.",
+    "openQuestions": [
+      "Can the theorem be upgraded to an infinitude statement — for an α with 1, α₁, …, αₙ linearly independent over ℚ, infinitely many common denominators q with maxᵢ ‖q·αᵢ‖ < q^{−1/n} — the simultaneous analogue of the parent OQ-01 infinitude upgrade?",
+      "Does the dual (linear-form) Dirichlet theorem follow by the same pigeonhole — one integer vector making a single linear form Σ qᵢαᵢ small — and can the transference principle between the two be formalized?",
+      "Can Minkowski's linear-forms theorem be derived to sharpen the constant, replacing the strict 1/N by the closed Nⁿ-lattice bound and handling the boundary case?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: upgrades the single-real one-shot bound to infinitely many approximations within 1/q² and recasts it in coprime integer-pair form. This entry answers its third open question by extending the reformulation to the simultaneous theorem — one denominator approximating several reals at once."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem",
+      "relationship": "extends",
+      "description": "The grandparent one-shot single-real Dirichlet bound. This entry is the multidimensional generalization: the same pigeonhole argument in the n-dimensional cube, with the single-real bound recovered as the n = 1 case (dirichlet_one_real)."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed., rev. Heath-Brown & Silverman)",
+      "note": "Theorem 200: Dirichlet's simultaneous approximation theorem via the n-dimensional pigeonhole principle."
+    },
+    {
+      "authors": [
+        "J. W. S. Cassels"
+      ],
+      "title": "An Introduction to Diophantine Approximation",
+      "year": 1957,
+      "venue": "Cambridge Tracts in Mathematics 45, Cambridge University Press",
+      "note": "Chapter I §5: simultaneous approximation and the pigeonhole (Schubfachprinzip) argument; transference principles."
+    },
+    {
+      "authors": [
+        "Wolfgang M. Schmidt"
+      ],
+      "title": "Diophantine Approximation",
+      "year": 1980,
+      "venue": "Lecture Notes in Mathematics 785, Springer",
+      "note": "Simultaneous approximation, badly approximable systems, and the geometry-of-numbers viewpoint generalizing the pigeonhole bound."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/DirichletApproximationOQ01OQ03.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "DirichletApproximationOQ01OQ03",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 4
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_approximation_theorem",
+    "date": "1842",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DirichletApproximationOQ01OQ03.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-approximation",
+      "simultaneous-approximation",
+      "pigeonhole-principle",
+      "geometry-of-numbers",
+      "rational-approximation"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.exists_ne_map_eq_of_card_lt",
+        "description": "The finite pigeonhole principle: a map from a finite type to a strictly smaller finite type is not injective, so two distinct inputs collide. The engine of the whole proof — applied to boxMap : Fin (Nⁿ+1) → (Fin n → Fin N) with Nⁿ+1 > Nⁿ.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Fintype.card_fun",
+        "description": "card (α → β) = card β ^ card α. Computes card (Fin n → Fin N) = Nⁿ, giving the box-lattice size and hence the sharp denominator bound q ≤ Nⁿ.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Int.fract_nonneg / Int.fract_lt_one / Int.fract",
+        "description": "The fractional part satisfies 0 ≤ frac x < 1 with frac x = x − ⌊x⌋. Confines N·frac(m·αᵢ) to [0,N) (so boxMap lands in Fin N) and drives the same-box-close lemma and the coordinatewise identity q·αₖ − pₖ = frac(i·αₖ) − frac(j·αₖ).",
+        "module": "Mathlib.Algebra.Order.Floor.Div"
+      },
+      {
+        "theorem": "Int.floor_nonneg / Int.floor_lt / Int.toNat_lt",
+        "description": "Floor/toNat coercion facts used to show ⌊N·frac(m·αᵢ)⌋.toNat < N (validity of the boxMap coordinate) and to recover the integer floor equality from the collision (⌊N·frac(i·αₖ)⌋ = ⌊N·frac(j·αₖ)⌋).",
+        "module": "Mathlib.Algebra.Order.Floor.Basic"
+      },
+      {
+        "theorem": "lt_div_iff₀ / abs_mul",
+        "description": "Ordered-field manipulation: clears the factor N in |N·(frac(i·αₖ) − frac(j·αₖ))| < 1 to reach the final |frac(i·αₖ) − frac(j·αₖ)| < 1/N.",
+        "module": "Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic"
+      }
+    ],
+    "originalContributions": [
+      "simultaneous_dirichlet: Dirichlet's simultaneous approximation theorem for an arbitrary finite family α : Fin n → ℝ — one denominator q with 1 ≤ q ≤ Nⁿ and |q·αᵢ − pᵢ| < 1/N for every coordinate i. Mathlib has the single-real Dirichlet/Legendre theorems and continued fractions but no simultaneous (multi-dimensional) version; this is new, elementary, and axiom-free.",
+      "boxMap: the n-dimensional pigeonhole map Fin (Nⁿ+1) → (Fin n → Fin N) encoding which side-1/N box each cube point (frac(m·αᵢ))ᵢ lies in, together with the coordinatewise validity proof that ⌊N·frac(m·αᵢ)⌋ ∈ Fin N.",
+      "abs_sub_lt_one_of_floor_eq: two reals with equal integer part differ by less than one — the single metric ingredient isolating the 'same box ⟹ close' step, the multi-dimensional analogue of the parent file's interval_bound.",
+      "exists_of_gt: the collision-to-approximation core, extracting the common denominator q = i − j and integer vector pₖ = ⌊i·αₖ⌋ − ⌊j·αₖ⌋ from a box collision and proving the coordinatewise bound uniformly in k, including the identity q·αₖ − pₖ = frac(i·αₖ) − frac(j·αₖ).",
+      "dirichlet_one_real: the n = 1 specialization recovering the parent one-shot single-real bound (1 ≤ q ≤ N, |q·α − p| < 1/N), demonstrating that the simultaneous theorem strictly generalizes it."
+    ],
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "dirichlet-approximation-theorem-oq-01",
+        "relationship": "Parent entry: infinitude upgrade of the single-real one-shot bound in coprime integer-pair form. This OQ-01-OQ-03 answers its third open question by extending to the simultaneous approximation theorem (one denominator, several reals)."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 162,
+    "assumptions": "0 axioms, 0 sorries. The only hypotheses are the ambient family α : Fin n → ℝ and N ≥ 1 (0 < N). The result is proved in-file from elementary Mathlib facts — the fractional part bounds 0 ≤ frac x < 1, floor/toNat coercions, the pigeonhole principle Fintype.exists_ne_map_eq_of_card_lt, and the function-type cardinality Fintype.card_fun — with no measure theory or convex-body machinery. Badge is 'original' because the simultaneous theorem and all supporting declarations are new in-file results; Mathlib contains only the single-real version. Verified: #print axioms lists exactly propext, Classical.choice, Quot.sound.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of `dirichlet-approximation-theorem-oq-01`: *does the reformulation extend to the simultaneous approximation theorem — one denominator approximating several reals at once?* **Yes.** This entry proves **Dirichlet's simultaneous approximation theorem** in full generality over an arbitrary finite family of reals.

## Statement

For `α : Fin n → ℝ` and any `N ≥ 1`, there is one denominator `q` with `1 ≤ q ≤ Nⁿ` and integers `p : Fin n → ℤ` such that, simultaneously for every coordinate `i`,
```
|q · αᵢ − pᵢ| < 1 / N .
```

## Proof

Pure `n`-dimensional pigeonhole in the unit cube. Chop `[0,1)ⁿ` into `Nⁿ` boxes of side `1/N`; among the `Nⁿ + 1` cube points `(frac(m·α₀), …, frac(m·α_{n−1}))` for `m = 0, …, Nⁿ`, two share a box (`Fintype.exists_ne_map_eq_of_card_lt`, `Fintype.card_fun`). For the colliding indices `i > j`, taking `q = i − j` and `pₖ = ⌊i·αₖ⌋ − ⌊j·αₖ⌋` gives `q·αₖ − pₖ = frac(i·αₖ) − frac(j·αₖ)`, within `1/N` in every coordinate. The only metric input is `abs_sub_lt_one_of_floor_eq` (two reals with equal integer part differ by less than 1).

## Declarations
- `simultaneous_dirichlet` — the main theorem (arbitrary `Fin n`).
- `boxMap` — the `n`-dimensional pigeonhole map `Fin (Nⁿ+1) → (Fin n → Fin N)`.
- `abs_sub_lt_one_of_floor_eq` — same box ⟹ close.
- `exists_of_gt` — collision → approximation core.
- `dirichlet_one_real` — the `n = 1` specialization recovering the parent one-shot bound.

## Verification
- Compiles against Mathlib (Lean v4.26.0).
- `#print axioms simultaneous_dirichlet` = `{propext, Classical.choice, Quot.sound}` → **0-axiom, verified**.
- 162 lines, 4 theorems/lemmas, 1 definition, **0 sorries**.

Mathlib has only the single-real Dirichlet/Legendre theorems and continued fractions; the simultaneous (multi-dimensional) version is new, elementary, and axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)