### PR TITLE
Enrich Gauss Divisor-Sum for Jordan's Totient (erdos-1000-oq-03-oq-03)

### DIFF
--- a/src/data/proofs/erdos-1000-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "erdos-1000-oq-03-oq-03-ann-jordan-def",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 63, "endLine": 65 },
+    "type": "definition",
+    "title": "Jordan's totient as a ring element",
+    "content": "Jordan's totient $J_k$ is defined not by its combinatorial tuple count but directly as the Dirichlet convolution $\\mu * \\mathrm{pow}\\,k$ inside the commutative ring $\\mathrm{ArithmeticFunction}\\ \\mathbb{Z}$. This is the same object studied by the sibling entry erdos-1000-oq-03-oq-01-oq-01; taking it as a ring element (rather than a function defined by counting) is what makes every subsequent identity a one-line algebraic computation.",
+    "mathContext": "$J_k := \\mu * \\mathrm{pow}\\,k$, where $(\\mathrm{pow}\\,k)(n) = n^k$ and $*$ is Dirichlet convolution $(f*g)(n)=\\sum_{d\\mid n} f(d)\\,g(n/d)$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet convolution", "arithmetic function ring", "Jordan totient", "Möbius function"],
+    "prerequisites": ["Dirichlet convolution", "Möbius function"]
+  },
+  {
+    "id": "erdos-1000-oq-03-oq-03-ann-mul-zeta",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 67, "endLine": 74 },
+    "type": "insight",
+    "title": "Reconstruction identity: convolving by ζ undoes μ",
+    "content": "The headline algebraic fact: $J_k * \\zeta = \\mathrm{pow}\\,k$. The proof is a single `rw`. Substituting $J_k = \\mu * \\mathrm{pow}\\,k$ and using `mul_right_comm` regroups the product as $\\mathrm{pow}\\,k * (\\mu * \\zeta)$; then $\\mu * \\zeta = 1$ (the ring identity `moebius_mul_coe_zeta`) collapses it to $\\mathrm{pow}\\,k$. This is the exact dual of the gallery's Möbius-inversion result $J_k = \\mu * \\mathrm{pow}\\,k$: convolving by $\\zeta$ (summation over divisors) is the two-sided inverse of convolving by $\\mu$.",
+    "mathContext": "$J_k * \\zeta = (\\mu * \\mathrm{pow}\\,k) * \\zeta = \\mathrm{pow}\\,k * (\\mu * \\zeta) = \\mathrm{pow}\\,k * 1 = \\mathrm{pow}\\,k$, since $\\mu * \\zeta = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Möbius inversion", "Dirichlet convolution", "unit of a ring", "zeta function"],
+    "prerequisites": ["Möbius inversion", "commutative ring identities"]
+  },
+  {
+    "id": "erdos-1000-oq-03-oq-03-ann-divisor-sum",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 76, "endLine": 84 },
+    "type": "concept",
+    "title": "Gauss's divisor-sum identity, read off pointwise",
+    "content": "The headline number-theoretic statement $\\sum_{d\\mid n} J_k(d) = n^k$ is obtained by evaluating the ring identity $J_k * \\zeta = \\mathrm{pow}\\,k$ at $n$. The lemma `coe_mul_zeta_apply` says $(f * \\zeta)(n) = \\sum_{d\\mid n} f(d)$ — convolving with $\\zeta$ IS summation over divisors — so the left side is the divisor sum. The right side $(\\mathrm{pow}\\,k)(n) = n^k$ for $n \\neq 0$ via `pow_apply` (the `if_neg` handles the arithmetic-function convention that value at $0$ is $0$). No combinatorics appear; this is the analytic mirror of the sibling entries' fibrewise-bijection proof.",
+    "mathContext": "$\\displaystyle\\sum_{d\\mid n} J_k(d) = (J_k * \\zeta)(n) = (\\mathrm{pow}\\,k)(n) = n^k \\quad (n\\neq 0).$",
+    "significance": "key",
+    "relatedConcepts": ["divisor sum", "Gauss identity", "Dirichlet convolution", "multiplicative functions"],
+    "prerequisites": ["divisor sums", "Dirichlet convolution"]
+  },
+  {
+    "id": "erdos-1000-oq-03-oq-03-ann-unique",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 86, "endLine": 102 },
+    "type": "insight",
+    "title": "The divisor-sum law characterises J_k (uniqueness)",
+    "content": "The genuinely new content of this entry: the Gauss equation $\\sum_{d\\mid n} f(d) = n^k$ has a UNIQUE solution on the positive integers, so any $f:\\mathbb{N}\\to\\mathbb{Z}$ satisfying it — however defined — must equal Jordan's totient. The proof runs Möbius inversion backwards via Mathlib's equivalence `sum_eq_iff_sum_smul_moebius_eq`: the divisor-sum hypothesis inverts to $f(n) = \\sum_{xy=n} \\mu(x)\\,y^k$, which is exactly $(\\mu * \\mathrm{pow}\\,k)(n) = J_k(n)$ by `mul_apply`. The `Finset.sum_congr` then matches the two sums term by term. This uniqueness is what lets the $k=1$ case pin down Euler's $\\varphi$ from Gauss's law alone.",
+    "mathContext": "If $\\sum_{d\\mid n} f(d) = n^k$ for all $n>0$, then $f(n) = \\sum_{xy=n}\\mu(x)y^k = J_k(n)$ for all $n>0$.",
+    "significance": "key",
+    "relatedConcepts": ["Möbius inversion", "uniqueness", "divisor antidiagonal", "arithmetic function ring"],
+    "prerequisites": ["Möbius inversion", "divisor antidiagonal"]
+  },
+  {
+    "id": "erdos-1000-oq-03-oq-03-ann-euler-recovery",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 104, "endLine": 112 },
+    "type": "technique",
+    "title": "k = 1 recovers Euler's totient",
+    "content": "Specialising to $k=1$ recovers Euler's totient: $J_1 = \\varphi$. The proof does not recompute anything — it invokes the uniqueness theorem. Both $J_1$ and $\\varphi$ satisfy the same divisor-sum law: $\\sum_{d\\mid n}\\varphi(d) = n$ is Mathlib's `Nat.sum_totient`, which matches $n^1$. Since the divisor-sum equation has a unique solution, $J_1 = \\varphi$ on the positives (and the $n=0$ case is handled separately by `simp`). This showcases how uniqueness turns a classical identity into a characterisation.",
+    "mathContext": "$\\sum_{d\\mid n}\\varphi(d) = n = n^1$, so by `jordan_unique` with $k=1$, $J_1(n)=\\varphi(n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler totient", "Gauss totient identity", "specialisation"],
+    "prerequisites": ["Euler's totient function"]
+  },
+  {
+    "id": "erdos-1000-oq-03-oq-03-ann-gauss-classical",
+    "proofId": "erdos-1000-oq-03-oq-03",
+    "range": { "startLine": 114, "endLine": 121 },
+    "type": "context",
+    "title": "Gauss's classical totient identity as a corollary",
+    "content": "The loop closes with Gauss's own $\\sum_{d\\mid n}\\varphi(d) = n$, recovered as the $k=1$ instance of the general headline `jordan_divisor_sum`. Setting $k=1$ gives $\\sum_{d\\mid n} J_1(d) = n^1 = n$, and rewriting $J_1(d) = \\varphi(d)$ (from `jordan_one_apply`) under the sum yields the classical statement. This is the historical origin of the whole circle of ideas — Gauss's 1801 identity — landing here as one specialisation of an arithmetic-function reconstruction law.",
+    "mathContext": "$\\displaystyle\\sum_{d\\mid n}\\varphi(d) = n$ — Gauss (Disquisitiones Arithmeticae, 1801).",
+    "significance": "context",
+    "relatedConcepts": ["Gauss totient identity", "Euler totient", "divisor sum"],
+    "prerequisites": ["Euler's totient function", "divisor sums"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-1000-oq-03-oq-03`.

## Gap addressed
The entry had a rich meta.json (11.8 KB, well under caps) but **no annotations.json** — zero inline annotations. This adds the missing annotation layer.

## Changes
- Added `annotations.json` with **6 inline annotations** covering the full Lean file (lines 63–121):
  1. **Jordan's totient as a ring element** (`def jordan`) — the convolution definition $J_k=\mu*\mathrm{pow}\,k$
  2. **Reconstruction identity** $J_k*\zeta=\mathrm{pow}\,k$ — convolving by $\zeta$ undoes $\mu$
  3. **Gauss's divisor-sum identity** $\sum_{d\mid n}J_k(d)=n^k$ — read off pointwise
  4. **Uniqueness** — the divisor-sum law characterises $J_k$ (the entry's new content)
  5. **k=1 Euler recovery** $J_1=\varphi$
  6. **Gauss's classical** $\sum_{d\mid n}\varphi(d)=n$
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Verification
- JSON validated; `gallery:check-size` passes (file ≤ 60 KB cap).
- Data-generation build steps (`annotations:build`, `research:enrich`) parse the entry cleanly.
- No changes to meta.json; `status: verified`, `axiomCount: 0` unchanged and accurate against the Lean source (0 axioms, 0 sorries, no native_decide).