### PR TITLE
research(jensen-inequality-oq-01-oq-03): unweighted n-variable AM–GM + equality case [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/JensenInequalityOQ01OQ03.lean
+++ b/proofs/Proofs/JensenInequalityOQ01OQ03.lean
@@ -1,0 +1,103 @@
+/-
+# The Unweighted n-Variable AM–GM Inequality and its Equality Case
+
+This file specializes the parent development
+(`Proofs.JensenInequalityOQ01`, gallery entry `jensen-inequality-oq-01`), which established the
+sharp **weighted** arithmetic–geometric mean inequality and its equality characterization, to the
+classical **unweighted** `n`-variable case obtained with uniform weights `1/|s|`:
+
+    ⁿ√(x₁⋯xₙ)  ≤  (x₁ + ⋯ + xₙ)/n,     with equality  ⇔  x₁ = ⋯ = xₙ.
+
+The bridge from the weighted statement to this one is purely algebraic: the uniform weight family
+`w i = 1/|s|` is strictly positive and sums to `1`, the weighted geometric mean
+`∏ zᵢ^{1/n}` collapses to the single `n`-th root `(∏ zᵢ)^{1/n}` via `Real.finset_prod_rpow`, and the
+weighted arithmetic mean `∑ (1/n)·zᵢ` becomes `(∑ zᵢ)/n`. No new analysis is required — everything
+rides on the parent's `weighted_amgm_le`, `weighted_amgm_eq_iff`, and `weighted_amgm_lt_of_ne`.
+
+## Main results
+
+* `unweighted_amgm_le` — the unweighted AM–GM inequality `(∏ zᵢ)^{1/|s|} ≤ (∑ zᵢ)/|s|`.
+* `unweighted_amgm_eq_iff` — equality `(∏ zᵢ)^{1/|s|} = (∑ zᵢ)/|s|` holds **iff** all `zᵢ` are equal.
+* `unweighted_amgm_lt_of_ne` — if two of the (positive) values differ, the inequality is strict.
+* `amgm_fin_le`, `amgm_fin_eq_iff` — the concrete `Fin n` restatements matching the classical
+  `ⁿ√(x₁⋯xₙ) ≤ (x₁+⋯+xₙ)/n` form.
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+import Proofs.JensenInequalityOQ01
+
+open Finset Real
+
+namespace UnweightedAMGM
+
+variable {ι : Type*} {s : Finset ι} {z : ι → ℝ}
+
+/-- The uniform weights `1/|s|` sum to `1` on a nonempty finite index set. -/
+private theorem sum_uniform (hs : s.Nonempty) :
+    ∑ _i ∈ s, (s.card : ℝ)⁻¹ = 1 := by
+  have hcard : (s.card : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Finset.card_pos.mpr hs).ne'
+  rw [Finset.sum_const, nsmul_eq_mul, mul_inv_cancel₀ hcard]
+
+/-- **Unweighted AM–GM inequality.** For nonnegative data indexed by a nonempty finite set, the
+geometric mean `(∏ zᵢ)^{1/|s|}` is at most the arithmetic mean `(∑ zᵢ)/|s|`. This is the uniform-weight
+specialization of the parent's `weighted_amgm_le`. -/
+theorem unweighted_amgm_le (hs : s.Nonempty) (hz : ∀ i ∈ s, 0 ≤ z i) :
+    (∏ i ∈ s, z i) ^ (s.card : ℝ)⁻¹ ≤ (∑ i ∈ s, z i) / s.card := by
+  have hcpos : (0 : ℝ) < (s.card : ℝ) := by exact_mod_cast Finset.card_pos.mpr hs
+  have hw : ∀ i ∈ s, (0 : ℝ) ≤ (s.card : ℝ)⁻¹ := fun _ _ => (inv_pos.mpr hcpos).le
+  have hle := weighted_amgm_le hw (sum_uniform hs) hz
+  rw [Real.finset_prod_rpow s z hz, ← Finset.mul_sum] at hle
+  rwa [div_eq_inv_mul]
+
+/-- **Equality case of unweighted AM–GM.** With nonnegative data on a nonempty finite index set,
+the geometric and arithmetic means coincide **iff all the data are equal**. Uniform-weight
+specialization of the parent's `weighted_amgm_eq_iff`. -/
+theorem unweighted_amgm_eq_iff (hs : s.Nonempty) (hz : ∀ i ∈ s, 0 ≤ z i) :
+    (∏ i ∈ s, z i) ^ (s.card : ℝ)⁻¹ = (∑ i ∈ s, z i) / s.card
+      ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k := by
+  have hcpos : (0 : ℝ) < (s.card : ℝ) := by exact_mod_cast Finset.card_pos.mpr hs
+  have hw : ∀ i ∈ s, (0 : ℝ) < (s.card : ℝ)⁻¹ := fun _ _ => inv_pos.mpr hcpos
+  have h := weighted_amgm_eq_iff hw (sum_uniform hs) hz
+  rwa [Real.finset_prod_rpow s z hz, ← Finset.mul_sum, ← div_eq_inv_mul] at h
+
+/-- **Strict unweighted AM–GM.** With strictly positive data on a nonempty finite index set, if two
+of the values differ then the geometric mean is *strictly* below the arithmetic mean. Uniform-weight
+specialization of the parent's `weighted_amgm_lt_of_ne`. -/
+theorem unweighted_amgm_lt_of_ne (hs : s.Nonempty) (hz : ∀ i ∈ s, 0 < z i)
+    (hne : ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k) :
+    (∏ i ∈ s, z i) ^ (s.card : ℝ)⁻¹ < (∑ i ∈ s, z i) / s.card := by
+  have hcpos : (0 : ℝ) < (s.card : ℝ) := by exact_mod_cast Finset.card_pos.mpr hs
+  have hw : ∀ i ∈ s, (0 : ℝ) < (s.card : ℝ)⁻¹ := fun _ _ => inv_pos.mpr hcpos
+  have hlt := weighted_amgm_lt_of_ne hw (sum_uniform hs) hz hne
+  rw [Real.finset_prod_rpow s z (fun i hi => (hz i hi).le), ← Finset.mul_sum,
+    ← div_eq_inv_mul] at hlt
+  exact hlt
+
+/-! ## Concrete `Fin n` restatements
+
+These package the results in the familiar `ⁿ√(x₁⋯xₙ) ≤ (x₁+⋯+xₙ)/n` shape. -/
+
+/-- **Classical `n`-variable AM–GM inequality.** For `n > 0` nonnegative reals,
+`(∏ zᵢ)^{1/n} ≤ (∑ zᵢ)/n`. -/
+theorem amgm_fin_le {n : ℕ} (hn : 0 < n) (z : Fin n → ℝ) (hz : ∀ i, 0 ≤ z i) :
+    (∏ i, z i) ^ (n : ℝ)⁻¹ ≤ (∑ i, z i) / n := by
+  haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  have hcard : (Finset.univ : Finset (Fin n)).card = n := by simp
+  have h := unweighted_amgm_le (s := (Finset.univ : Finset (Fin n)))
+    Finset.univ_nonempty (fun i _ => hz i)
+  rwa [hcard] at h
+
+/-- **Classical `n`-variable AM–GM equality case.** For `n > 0` nonnegative reals, equality
+`(∏ zᵢ)^{1/n} = (∑ zᵢ)/n` holds **iff all the values are equal**. -/
+theorem amgm_fin_eq_iff {n : ℕ} (hn : 0 < n) (z : Fin n → ℝ) (hz : ∀ i, 0 ≤ z i) :
+    (∏ i, z i) ^ (n : ℝ)⁻¹ = (∑ i, z i) / n ↔ ∀ j k, z j = z k := by
+  haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  have hcard : (Finset.univ : Finset (Fin n)).card = n := by simp
+  have h := unweighted_amgm_eq_iff (s := (Finset.univ : Finset (Fin n)))
+    Finset.univ_nonempty (fun i _ => hz i)
+  rw [hcard] at h
+  simpa using h
+
+end UnweightedAMGM

--- a/research/problems/jensen-inequality-oq-01-oq-03/knowledge.md
+++ b/research/problems/jensen-inequality-oq-01-oq-03/knowledge.md
@@ -1,0 +1,65 @@
+# Knowledge Base: jensen-inequality-oq-01-oq-03
+
+Unweighted n-variable AM–GM inequality and its equality case, obtained as the
+uniform-weight (wᵢ = 1/|s|) specialization of the parent gallery entry
+`jensen-inequality-oq-01` (weighted AM–GM + equality characterization).
+
+---
+
+## Problem Understanding
+
+Parent `jensen-inequality-oq-01` proved, via strict convexity of `exp`:
+- `weighted_amgm_le`   : `∏ zᵢ^wᵢ ≤ ∑ wᵢ·zᵢ`               (nonneg data, weights ≥ 0 sum 1)
+- `weighted_amgm_eq_iff`: `∏ zᵢ^wᵢ = ∑ wᵢ·zᵢ ↔ ∀ j k, zⱼ = zₖ` (weights > 0)
+- `weighted_amgm_lt_of_ne`: strict form for positive non-constant data.
+
+Goal here: descend to the classical unweighted statement
+`(∏ zᵢ)^(1/n) ≤ (∑ zᵢ)/n`, equality iff all equal, by taking uniform weights.
+
+---
+
+## Insights
+
+- The unweighted AM–GM is exactly the `wᵢ = 1/n` slice of the weighted one; no
+  new analysis is required, only algebra to reshape the weighted means.
+- **Key rewrite** `Real.finset_prod_rpow s z hz r : (∏ i∈s, z i ^ r) = (∏ i∈s, z i) ^ r`
+  collapses the product of individual n-th roots into the single n-th root of the
+  product (needs `∀ i∈s, 0 ≤ z i`). This is the geometric-mean side.
+- Arithmetic side: `∑ i∈s, (|s|)⁻¹ · z i = (|s|)⁻¹ · ∑ z i` via `← Finset.mul_sum`,
+  then `← div_eq_inv_mul` gives `(∑ z i)/|s|`.
+- Uniform weights sum to 1: `Finset.sum_const` → `|s| • (|s|)⁻¹` → `nsmul_eq_mul`
+  → `mul_inv_cancel₀` (needs `(↑|s|) ≠ 0`, i.e. `s.Nonempty`).
+- The equality-case RHS `∀ j k, zⱼ = zₖ` is weight-independent, so it transfers
+  verbatim — no strict-convexity argument repeated.
+- `Fin n` packaging: `s = Finset.univ`, `|univ| = n` (`simp`/`Fintype.card_fin`),
+  `Finset.univ_nonempty` from `haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩`, and
+  `simpa` collapses `∀ j ∈ univ` to `∀ j` via `Finset.mem_univ`.
+
+## Dead Ends
+
+None — the direct uniform-weight specialization worked on the first attempt.
+
+---
+
+## Session 2026-07-01 (Session 1) — Unweighted AM–GM + equality case [COMPLETED]
+
+**Mode**: FRESH
+**Outcome**: completed — new gallery entry, VERIFIED 0-axiom.
+
+### What I Did
+- Read parent `Proofs/JensenInequalityOQ01.lean`; imported it directly.
+- Proved 5 public results + 1 private helper in `Proofs/JensenInequalityOQ01OQ03.lean` (103 lines):
+  `sum_uniform` (helper), `unweighted_amgm_le`, `unweighted_amgm_eq_iff`,
+  `unweighted_amgm_lt_of_ne`, `amgm_fin_le`, `amgm_fin_eq_iff`.
+- Verified with `lake env lean` (Docker unavailable — host containerd storage I/O
+  error; single-file compile against prebuilt Mathlib oleans is the safe fallback).
+- `#print axioms` on all 5 public results: only `[propext, Classical.choice, Quot.sound]`.
+
+### Files Modified
+- `proofs/Proofs/JensenInequalityOQ01OQ03.lean` (new, 103 L, 6 theorems, 0 axioms)
+- `src/data/proofs/jensen-inequality-oq-01-oq-03/{meta,annotations}.json` (new)
+
+### Next Steps
+- Follow-up open questions recorded in meta: (1) quantitative stability (AM–GM gap
+  bounded below by data variance); (2) descended weighted equality case for general
+  rational weight vectors via majorization / Schur convexity.

--- a/src/data/proofs/jensen-inequality-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-03/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "jensen-inequality-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "concept",
+    "title": "Goal: the classical unweighted n-variable AM–GM and its equality case",
+    "content": "The arithmetic–geometric mean inequality ⁿ√(x₁⋯xₙ) ≤ (x₁+⋯+xₙ)/n, with equality exactly when all the xᵢ are equal, is the classical unweighted statement. The parent gallery entry (jensen-inequality-oq-01) proved the sharp weighted form via strict convexity of exp: weighted_amgm_le (the inequality), weighted_amgm_eq_iff (equality iff all data equal), and weighted_amgm_lt_of_ne (strict form). This file descends from that weighted theory to the unweighted case by choosing uniform weights wᵢ = 1/|s|, importing Proofs.JensenInequalityOQ01 and adding no new analysis — only the algebra that reshapes the weighted means into their classical unweighted forms.",
+    "mathContext": "Goal: $\\sqrt[n]{x_1\\cdots x_n} \\le (x_1+\\cdots+x_n)/n$, equality iff $x_1=\\cdots=x_n$, for $x_i \\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "arithmetic–geometric mean inequality",
+      "equality case",
+      "uniform weights",
+      "weighted AM–GM"
+    ],
+    "prerequisites": [
+      "rpow (real power) on nonnegatives",
+      "weighted AM–GM inequality"
+    ]
+  },
+  {
+    "id": "ann-sum-uniform",
+    "proofId": "jensen-inequality-oq-01-oq-03",
+    "range": { "startLine": 38, "endLine": 44 },
+    "type": "proof-technique",
+    "title": "Uniform weights sum to one",
+    "content": "sum_uniform is the private arithmetic lemma powering every specialization: the constant weight family (|s|)⁻¹ sums to 1 over a nonempty finite set s. Finset.sum_const turns ∑_{i∈s} (|s|)⁻¹ into |s| • (|s|)⁻¹; nsmul_eq_mul rewrites the natural-number scalar multiplication as (↑|s|) * (|s|)⁻¹; and mul_inv_cancel₀ finishes, using that (↑|s|) ≠ 0 — which follows from Finset.card_pos.mpr hs (nonemptiness gives |s| > 0). This is the sole hypothesis needed to hand the parent theorems a valid weight vector.",
+    "mathContext": "$\\sum_{i \\in s} |s|^{-1} = |s|\\cdot|s|^{-1} = 1$ for $s$ nonempty.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.sum_const",
+      "mul_inv_cancel₀",
+      "normalized weights"
+    ],
+    "prerequisites": [
+      "cardinality of a finite set",
+      "field inverse cancellation"
+    ]
+  },
+  {
+    "id": "ann-unweighted-le",
+    "proofId": "jensen-inequality-oq-01-oq-03",
+    "range": { "startLine": 46, "endLine": 55 },
+    "type": "theorem",
+    "title": "Unweighted AM–GM inequality",
+    "content": "unweighted_amgm_le applies the parent's weighted_amgm_le to the uniform weights wᵢ = (|s|)⁻¹ (nonnegative via inv_pos; summing to 1 via sum_uniform), yielding ∏ zᵢ^(|s|)⁻¹ ≤ ∑ (|s|)⁻¹·zᵢ. Two rewrites reshape this into the classical form: Real.finset_prod_rpow collapses the product of individual roots ∏ zᵢ^(|s|)⁻¹ into the single root (∏ zᵢ)^(|s|)⁻¹ (valid because every zᵢ ≥ 0), and Finset.mul_sum pulls the constant out of ∑ (|s|)⁻¹·zᵢ = (|s|)⁻¹·∑ zᵢ, which div_eq_inv_mul identifies with (∑ zᵢ)/|s|. The result is (∏ zᵢ)^(1/|s|) ≤ (∑ zᵢ)/|s|.",
+    "mathContext": "$\\left(\\prod_{i\\in s} z_i\\right)^{1/|s|} \\le \\frac{1}{|s|}\\sum_{i\\in s} z_i$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Real.finset_prod_rpow",
+      "Finset.mul_sum",
+      "geometric mean as n-th root of the product"
+    ],
+    "prerequisites": [
+      "weighted AM–GM inequality",
+      "rpow of a finite product"
+    ]
+  },
+  {
+    "id": "ann-unweighted-eq-iff",
+    "proofId": "jensen-inequality-oq-01-oq-03",
+    "range": { "startLine": 57, "endLine": 66 },
+    "type": "theorem",
+    "title": "Equality case: means coincide iff the data are constant",
+    "content": "unweighted_amgm_eq_iff performs the same uniform-weight substitution into the parent's weighted_amgm_eq_iff. Because the parent's right-hand side — ∀ j ∈ s, ∀ k ∈ s, zⱼ = zₖ, 'all data equal' — is symmetric and completely weight-independent, it transfers verbatim: the geometric mean (∏ zᵢ)^(1/|s|) equals the arithmetic mean (∑ zᵢ)/|s| if and only if every pair of values coincides. The same Real.finset_prod_rpow / Finset.mul_sum / div_eq_inv_mul rewrites reshape the two means; no strict-convexity argument is repeated here, since the parent already discharged it once and for all.",
+    "mathContext": "$\\left(\\prod z_i\\right)^{1/|s|} = \\frac{\\sum z_i}{|s|} \\iff \\forall j\\,k,\\ z_j = z_k$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "equality case",
+      "strict convexity of exp",
+      "weight-independent characterization"
+    ],
+    "prerequisites": [
+      "weighted AM–GM equality case"
+    ]
+  },
+  {
+    "id": "ann-unweighted-lt",
+    "proofId": "jensen-inequality-oq-01-oq-03",
+    "range": { "startLine": 68, "endLine": 77 },
+    "type": "theorem",
+    "title": "Strict AM–GM for non-constant positive data",
+    "content": "unweighted_amgm_lt_of_ne is the strict companion, specializing the parent's weighted_amgm_lt_of_ne: if the data are strictly positive and some two values zⱼ, zₖ differ, then the geometric mean is strictly below the arithmetic mean, (∏ zᵢ)^(1/|s|) < (∑ zᵢ)/|s|. The reshaping rewrites are identical, with the nonnegativity input to Real.finset_prod_rpow supplied as (hz i hi).le from the strict-positivity hypothesis.",
+    "mathContext": "$z_j \\ne z_k \\text{ for some } j,k \\Rightarrow \\left(\\prod z_i\\right)^{1/|s|} < \\frac{\\sum z_i}{|s|}$, with $z_i > 0$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "strict inequality",
+      "non-constant data",
+      "strict Jensen"
+    ],
+    "prerequisites": [
+      "strict weighted AM–GM"
+    ]
+  },
+  {
+    "id": "ann-fin-restatements",
+    "proofId": "jensen-inequality-oq-01-oq-03",
+    "range": { "startLine": 78, "endLine": 103 },
+    "type": "concept",
+    "title": "Concrete Fin n restatements: the textbook form",
+    "content": "amgm_fin_le and amgm_fin_eq_iff instantiate the abstract Finset results at s = Finset.univ over Fin n. The cardinality rewrite |Finset.univ| = n (simp via Finset.card_univ and Fintype.card_fin) converts the |s| in the exponent and denominator to n, and Finset.univ_nonempty — available from the instance Nonempty (Fin n) built from the inhabitant ⟨0, hn⟩ using 0 < n — supplies the nonemptiness hypothesis. In the equality case, simpa collapses the bounded quantifiers ∀ j ∈ univ, ∀ k ∈ univ to ∀ j k via Finset.mem_univ. The outputs are the familiar textbook statements (∏ᵢ zᵢ)^(1/n) ≤ (∑ᵢ zᵢ)/n and its equality case, showing the abstract Finset development subsumes the classical n-variable inequality with only bookkeeping.",
+    "mathContext": "$\\left(\\prod_{i} z_i\\right)^{1/n} \\le \\frac{\\sum_i z_i}{n}$ on $\\mathrm{Fin}\\,n$, equality iff all $z_i$ equal.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.univ",
+      "Fintype.card_fin",
+      "Finset.mem_univ",
+      "classical n-variable AM–GM"
+    ],
+    "prerequisites": [
+      "finite types and Finset.univ",
+      "cardinality of Fin n"
+    ]
+  }
+]

--- a/src/data/proofs/jensen-inequality-oq-01-oq-03/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-03/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "jensen-inequality-oq-01-oq-03",
+  "title": "The Unweighted n-Variable AM–GM Inequality and its Equality Case",
+  "slug": "jensen-inequality-oq-01-oq-03",
+  "description": "Specializes the parent's sharp weighted arithmetic–geometric mean inequality and its equality characterization (gallery entry jensen-inequality-oq-01: weighted_amgm_le / weighted_amgm_eq_iff / weighted_amgm_lt_of_ne) to the classical unweighted n-variable case with uniform weights 1/|s|: for nonnegative data indexed by a nonempty finite set, (∏ᵢ zᵢ)^(1/|s|) ≤ (∑ᵢ zᵢ)/|s|, with equality iff all the zᵢ are equal, and strict inequality whenever two positive values differ. The bridge from the weighted statement is purely algebraic and needs no new analysis: the uniform weight family wᵢ = 1/|s| is strictly positive and sums to 1 (Finset.sum_const, mul_inv_cancel₀), the weighted geometric mean ∏ zᵢ^(1/|s|) collapses to the single n-th root (∏ zᵢ)^(1/|s|) via Real.finset_prod_rpow, and the weighted arithmetic mean ∑ (1/|s|)·zᵢ becomes (∑ zᵢ)/|s| via Finset.mul_sum and div_eq_inv_mul. Concrete Fin n restatements (amgm_fin_le, amgm_fin_eq_iff) package the results in the familiar ⁿ√(x₁⋯xₙ) ≤ (x₁+⋯+xₙ)/n form, obtained by taking s = Finset.univ with |univ| = n. Answers, on the geometric-vs-arithmetic rung, the equality-case open question posed by the power-mean sibling jensen-inequality-oq-01-oq-02.",
+  "meta": {
+    "author": "Lean Genius (uniform-weight specialization of the parent weighted AM–GM development); classical (arithmetic–geometric mean inequality, Cauchy 1821)",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01OQ03.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "am-gm",
+      "inequalities",
+      "jensen",
+      "equality-case",
+      "rpow",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-01",
+    "lineCount": 103,
+    "originalContributions": [
+      "unweighted_amgm_le: the unweighted AM–GM inequality (∏ᵢ zᵢ)^(1/|s|) ≤ (∑ᵢ zᵢ)/|s| for nonnegative data on a nonempty finite index set, obtained as the uniform-weight (wᵢ = 1/|s|) specialization of the parent's weighted_amgm_le.",
+      "unweighted_amgm_eq_iff: the equality characterization — geometric and arithmetic means coincide iff all the data are equal — as the uniform-weight specialization of the parent's weighted_amgm_eq_iff.",
+      "unweighted_amgm_lt_of_ne: strict AM–GM for positive data, (∏ᵢ zᵢ)^(1/|s|) < (∑ᵢ zᵢ)/|s| whenever two of the values differ, specializing the parent's weighted_amgm_lt_of_ne.",
+      "amgm_fin_le and amgm_fin_eq_iff: the concrete Fin n restatements ⁿ√(x₁⋯xₙ) ≤ (x₁+⋯+xₙ)/n and its equality case, obtained from the Finset versions with s = Finset.univ, |univ| = n."
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. #print axioms reports only propext / Classical.choice / Quot.sound for all five results. Builds on the parent gallery entry jensen-inequality-oq-01 (weighted_amgm_le, weighted_amgm_eq_iff, weighted_amgm_lt_of_ne) and the Mathlib rpow library (Real.finset_prod_rpow, Finset.sum_const, Finset.mul_sum).",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01",
+      "relationship": "extends",
+      "description": "Directly specializes the parent's weighted AM–GM development — weighted_amgm_le, weighted_amgm_eq_iff, and weighted_amgm_lt_of_ne — to uniform weights 1/|s|, recovering the classical unweighted n-variable AM–GM inequality, its equality case, and its strict form."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01-oq-02",
+      "relationship": "related",
+      "description": "That power-mean entry proves monotonicity M_p ≤ M_q of the weighted power mean over positive exponents and poses, as an open question, the equality case M_p = M_q iff all data equal. This entry establishes exactly that equality case on the geometric-vs-arithmetic rung (the r → 0 versus r = 1 comparison), in the unweighted setting."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The arithmetic–geometric mean inequality ⁿ√(x₁⋯xₙ) ≤ (x₁+⋯+xₙ)/n is one of the oldest inequalities in analysis, with a rigorous general-n proof given by Cauchy in his 1821 Cours d'analyse via his celebrated forward–backward induction. Its equality case — the two means coincide exactly when all the data are equal — is the sharp form that underlies countless optimization arguments. Mathlib provides the weighted geometric-vs-arithmetic mean inequality (Real.geom_mean_le_arith_mean_weighted) and, through the strict convexity of exp, the weighted equality characterization (Real.geom_mean_eq_arith_mean_weighted_iff'). The parent gallery entry packaged these into weighted_amgm_le / weighted_amgm_eq_iff / weighted_amgm_lt_of_ne; this entry closes the loop by descending from the weighted statement back to the classical unweighted n-variable inequality that motivated the whole theory, via the single change of variable wᵢ = 1/n.",
+    "problemStatement": "Specialize the parent's weighted AM–GM equality characterization to uniform weights 1/n, obtaining the classical unweighted n-variable AM–GM inequality (∏ᵢ zᵢ)^(1/n) ≤ (∑ᵢ zᵢ)/n together with its equality case (equality iff all zᵢ equal) and strict form, keeping the development fully 0-axiom.",
+    "proofStrategy": "Take the uniform weight family w i = (|s|)⁻¹. It is strictly positive (inv_pos, |s| > 0 from nonemptiness) and sums to 1 (Finset.sum_const gives |s| • (|s|)⁻¹, then nsmul_eq_mul and mul_inv_cancel₀). Feeding this w into the parent's weighted results yields ∏ zᵢ^(|s|)⁻¹ ≤ / = / < ∑ (|s|)⁻¹·zᵢ. The left side rewrites to (∏ zᵢ)^(|s|)⁻¹ by Real.finset_prod_rpow (a genuine collapse of a product of rpows into an rpow of the product, valid because zᵢ ≥ 0); the right side rewrites to (∑ zᵢ)/|s| by Finset.mul_sum (pulling the constant out of the sum) and div_eq_inv_mul. The Fin n corollaries instantiate s = Finset.univ, using |Finset.univ| = n (Finset.card_univ, Fintype.card_fin) and Finset.univ_nonempty from an inhabitant ⟨0, hn⟩ of Fin n; the membership quantifiers ∀ j ∈ univ collapse to ∀ j via Finset.mem_univ.",
+    "keyInsights": [
+      "The unweighted AM–GM is not a separate theorem but the wᵢ = 1/n slice of the weighted one; the entire content of the reduction is the arithmetic that 1/n weights sum to 1 and that the two rpow/sum identities line the geometric and arithmetic means up with their classical forms.",
+      "Real.finset_prod_rpow is the crucial rewrite: ∏ᵢ zᵢ^(1/n) = (∏ᵢ zᵢ)^(1/n) turns the weighted geometric mean (a product of individual n-th roots) into the single n-th root of the product that appears in the classical statement. It requires nonnegativity of every zᵢ.",
+      "The equality case transfers verbatim: the parent's symmetric 'all data equal' right-hand side is weight-independent, so uniform weights inherit exactly the characterization ∀ j k, zⱼ = zₖ, with no strict-convexity argument repeated here.",
+      "The Fin n packaging shows the abstract Finset statement subsumes the textbook ⁿ√(x₁⋯xₙ) ≤ (x₁+⋯+xₙ)/n form with only bookkeeping (card of univ, collapsing membership hypotheses), not new mathematics."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "States the goal — the classical unweighted n-variable AM–GM inequality and its equality case — and outlines the uniform-weight reduction from the parent's weighted development, importing Proofs.JensenInequalityOQ01.",
+      "mathContext": "Goal: $\\sqrt[n]{x_1\\cdots x_n} \\le (x_1+\\cdots+x_n)/n$, equality iff $x_1=\\cdots=x_n$, for $x_i \\ge 0$."
+    },
+    {
+      "id": "sum-uniform",
+      "title": "Uniform weights sum to one",
+      "startLine": 38,
+      "endLine": 44,
+      "summary": "sum_uniform (private helper): the constant family (|s|)⁻¹ sums to 1 over a nonempty s, via Finset.sum_const, nsmul_eq_mul, and mul_inv_cancel₀ using |s| ≠ 0.",
+      "mathContext": "$\\sum_{i \\in s} |s|^{-1} = |s|\\cdot|s|^{-1} = 1$ for $s$ nonempty."
+    },
+    {
+      "id": "unweighted-le",
+      "title": "Unweighted AM–GM inequality",
+      "startLine": 46,
+      "endLine": 55,
+      "summary": "unweighted_amgm_le: instantiate the parent's weighted_amgm_le at wᵢ = (|s|)⁻¹, then rewrite the geometric side by Real.finset_prod_rpow and the arithmetic side by Finset.mul_sum / div_eq_inv_mul to reach (∏ zᵢ)^(1/|s|) ≤ (∑ zᵢ)/|s|.",
+      "mathContext": "$\\left(\\prod_{i\\in s} z_i\\right)^{1/|s|} \\le \\frac{1}{|s|}\\sum_{i\\in s} z_i$."
+    },
+    {
+      "id": "unweighted-eq-iff",
+      "title": "Equality case: means coincide iff data constant",
+      "startLine": 57,
+      "endLine": 66,
+      "summary": "unweighted_amgm_eq_iff: the same uniform-weight substitution into the parent's weighted_amgm_eq_iff, giving (∏ zᵢ)^(1/|s|) = (∑ zᵢ)/|s| ↔ ∀ j ∈ s, ∀ k ∈ s, zⱼ = zₖ. The weight-independent right-hand side carries over unchanged.",
+      "mathContext": "$\\left(\\prod z_i\\right)^{1/|s|} = \\frac{\\sum z_i}{|s|} \\iff \\forall j\\,k,\\ z_j = z_k$."
+    },
+    {
+      "id": "unweighted-lt",
+      "title": "Strict AM–GM for non-constant positive data",
+      "startLine": 68,
+      "endLine": 77,
+      "summary": "unweighted_amgm_lt_of_ne: uniform-weight specialization of the parent's weighted_amgm_lt_of_ne — if two of the strictly positive values differ, the geometric mean is strictly below the arithmetic mean.",
+      "mathContext": "$z_j \\ne z_k$ for some $j,k \\Rightarrow \\left(\\prod z_i\\right)^{1/|s|} < \\frac{\\sum z_i}{|s|}$, $z_i > 0$."
+    },
+    {
+      "id": "fin-restatements",
+      "title": "Concrete Fin n restatements",
+      "startLine": 78,
+      "endLine": 103,
+      "summary": "amgm_fin_le and amgm_fin_eq_iff: instantiate the Finset results at s = Finset.univ over Fin n, using |univ| = n and Finset.univ_nonempty (from ⟨0, hn⟩), and collapse the ∀ j ∈ univ quantifiers via Finset.mem_univ, recovering the textbook ⁿ√(x₁⋯xₙ) ≤ (x₁+⋯+xₙ)/n and its equality case.",
+      "mathContext": "$\\left(\\prod_{i} z_i\\right)^{1/n} \\le \\frac{\\sum_i z_i}{n}$ on $\\mathrm{Fin}\\,n$, with equality iff all $z_i$ equal."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Cauchy, A.-L."
+      ],
+      "title": "Cours d'analyse de l'École royale polytechnique",
+      "year": "1821",
+      "venue": "Paris; Note II",
+      "note": "Contains the original general-n proof of the arithmetic–geometric mean inequality via forward–backward induction, including its equality case."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "Canonical reference for AM–GM, power means, and their equality cases, treated via convexity and Jensen's inequality."
+    },
+    {
+      "authors": [
+        "Steele, J.M."
+      ],
+      "title": "The Cauchy–Schwarz Master Class",
+      "year": "2004",
+      "venue": "Cambridge University Press",
+      "note": "Modern exposition of the AM–GM inequality, its equality case, and the forward–backward and smoothing proofs."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 103-line file (0 sorries, 0 axioms, no native_decide) derives the classical unweighted n-variable AM–GM inequality (∏ zᵢ)^(1/|s|) ≤ (∑ zᵢ)/|s|, its equality case (equality iff all data equal), and its strict form, as the uniform-weight (wᵢ = 1/|s|) specialization of the parent gallery entry's weighted AM–GM development. Concrete Fin n restatements recover the textbook ⁿ√(x₁⋯xₙ) ≤ (x₁+⋯+xₙ)/n form.",
+    "implications": "The reduction shows the classical unweighted inequality is exactly the uniform slice of the weighted theory, and its equality case answers, on the geometric-vs-arithmetic rung, the open question posed by the power-mean sibling entry. The same uniform-weight template applies to any weighted mean inequality with a weight-independent equality condition.",
+    "openQuestions": [
+      "Prove the smoothing/rearrangement quantitative refinement: bound the AM–GM gap (∑ zᵢ)/n − (∏ zᵢ)^(1/n) below by a multiple of the variance of the data, sharpening the qualitative equality case to a stability estimate.",
+      "Establish the weighted equality case in the same descended form for a general (non-uniform) rational weight vector, and connect it to the majorization/Schur-convexity characterization of when the two means agree."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 103,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01OQ03.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 6,
+    "imports": [
+      "Mathlib",
+      "Proofs.JensenInequalityOQ01"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **jensen-inequality-oq-01-oq-03**: the classical **unweighted n-variable AM–GM inequality and its equality case**, derived as the uniform-weight (wᵢ = 1/|s|) specialization of the parent gallery entry `jensen-inequality-oq-01`.

For nonnegative data on a nonempty finite index set:
$$\left(\prod_i z_i\right)^{1/|s|} \le \frac{\sum_i z_i}{|s|}, \qquad \text{equality} \iff \forall j\,k,\ z_j = z_k,$$
with strict inequality whenever two positive values differ.

## Results (`Proofs/JensenInequalityOQ01OQ03.lean`, 103 lines, 6 theorems)

- `unweighted_amgm_le` — the inequality (Finset form)
- `unweighted_amgm_eq_iff` — equality iff all data equal
- `unweighted_amgm_lt_of_ne` — strict form for positive non-constant data
- `amgm_fin_le`, `amgm_fin_eq_iff` — concrete `Fin n` restatements (textbook ⁿ√(x₁⋯xₙ) ≤ (x₁+⋯+xₙ)/n)
- `sum_uniform` — private helper (uniform weights sum to 1)

## Proof idea

Purely algebraic reduction from the parent's weighted theory — no new analysis:
- uniform weights sum to 1: `Finset.sum_const` → `nsmul_eq_mul` → `mul_inv_cancel₀`;
- `Real.finset_prod_rpow` collapses `∏ zᵢ^(1/n)` into `(∏ zᵢ)^(1/n)` (needs `zᵢ ≥ 0`);
- `Finset.mul_sum` + `div_eq_inv_mul` turn `∑ (1/n)·zᵢ` into `(∑ zᵢ)/n`;
- the equality RHS `∀ j k, zⱼ = zₖ` is weight-independent, so it transfers verbatim.

## Verification

- 0 sorries, 0 `axiom` declarations, no `native_decide`.
- `#print axioms` on all five public results: only `propext / Classical.choice / Quot.sound`.
- Compiled with `lake env lean` against prebuilt Mathlib oleans (Docker image build was blocked by a host containerd storage I/O error; single-file compile is the standard safe fallback).

Answers, on the geometric-vs-arithmetic rung, the equality-case open question posed by the power-mean sibling `jensen-inequality-oq-01-oq-02`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)