### PR TITLE
research(algebraic-numbers-countable-oq-07-oq-03): algebraic points in ℝⁿ and ℂⁿ are negligible [VERIFIED, 0-axiom, 9thm]

### DIFF
--- a/proofs/Proofs/AlgebraicPointsNull.lean
+++ b/proofs/Proofs/AlgebraicPointsNull.lean
@@ -1,0 +1,201 @@
+import Mathlib.MeasureTheory.Constructions.Pi
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.MeasureTheory.Measure.Lebesgue.Complex
+import Mathlib.Tactic
+import Proofs.AlgebraicNumbersCountable
+import Proofs.AlgebraicRealsNull
+
+/-!
+# Algebraic Points in ℝⁿ and ℂⁿ are Negligible: Almost Every Point is Coordinatewise Transcendental
+
+## Open Question (algebraic-numbers-countable-oq-07-oq-03)
+
+The parent entry `algebraic-numbers-countable-oq-07` proves the one-dimensional
+measure pillar of the small/co-small trichotomy:
+
+> `volume {x : ℝ | IsAlgebraic ℚ x} = 0` — almost every *real* is transcendental,
+
+and its complex companion `volume {z : ℂ | IsAlgebraic ℚ z} = 0`. Its third
+open question asks for the **n-dimensional generalization**:
+
+> "Generalize to ℝⁿ and ℂⁿ: the set of points with at least one algebraic
+>  coordinate is null in ℝⁿ, and the algebraic points (all coordinates
+>  algebraic) are countable hence null. State and prove the n-dimensional
+>  version, where 'almost every point has all coordinates transcendental'."
+
+This entry answers it. Working in the finite-product measure space `Fin n → ℝ`
+(equivalently ℝⁿ with the product Lebesgue measure) we prove two independent
+smallness statements and reconcile them:
+
+* **The "at least one algebraic coordinate" set is Lebesgue-null.**
+  This is the *strong* statement: it is null for **every** `n` (including the
+  degenerate `n = 0`, where the set is empty), and the null set here is
+  *uncountable* — e.g. in ℝ² the line `{(a, y) : a algebraic}` has the
+  cardinality of the continuum yet planar measure zero. The mechanism is
+  Fubini/Tonelli: a coordinate cylinder `{x | xᵢ ∈ A}` is the box
+  `A × ℝ × ⋯ × ℝ`, whose product measure `volume A · ∞ · ⋯` vanishes because
+  the offending factor `volume A = 0` (and `0 · ∞ = 0` in `ℝ≥0∞`).
+
+* **The "all coordinates algebraic" set is countable, hence null.**
+  This is the *cardinality* statement: `(algebraic reals)ⁿ` is a finite product
+  of countable sets, so it is countable; for `n ≥ 1` it sits inside the
+  at-least-one set and is therefore also null. (For `n = 0` the single point
+  of ℝ⁰ is "all-algebraic" vacuously and has measure `1`, so the null claim
+  genuinely needs `n ≥ 1` — a boundary the one-dimensional parent never sees.)
+
+The two facts are not the same: the null set of the first is far larger
+(continuum-sized) than the countable set of the second, illustrating that
+"measure zero" is strictly weaker than "countable" once `n ≥ 2`.
+
+Dually, **almost every point of ℝⁿ (and of ℂⁿ) has all coordinates
+transcendental**: the complement of the at-least-one-algebraic set is conull.
+Everything is proved verbatim for ℂⁿ as well.
+
+## Main results
+
+* `coord_preimage_volume_zero`   : a coordinate cylinder over a null factor is null
+* `atLeastOneAlgebraicReal_null` : `volume {x : Fin n → ℝ | ∃ i, IsAlgebraic ℚ (x i)} = 0`
+* `allAlgebraicReal_countable`   : the all-algebraic points of ℝⁿ are countable
+* `allAlgebraicReal_null`        : for `n ≥ 1` the all-algebraic points are null
+* `ae_all_transcendental`        : a.e. point of ℝⁿ is coordinatewise transcendental
+* `atLeastOneAlgebraicComplex_null`, `allAlgebraicComplex_countable`,
+  `allAlgebraicComplex_null`, `ae_all_transcendental_complex` : the ℂⁿ analogues
+
+0 sorries, 0 axioms (no `native_decide`).
+-/
+
+open MeasureTheory Set
+
+namespace AlgebraicPointsNull
+
+-- ============================================================================
+-- § 1. A coordinate cylinder over a null factor is null (Fubini / Tonelli)
+-- ============================================================================
+
+/-- **A coordinate cylinder over a null factor has product measure zero.**
+
+If `A` is `volume`-null in the factor space `α`, then the cylinder
+`{x : Fin n → α | x i ∈ A}` (i.e. the box `A` in coordinate `i`, `univ`
+elsewhere) is null for the product Lebesgue measure. The box factors as
+`∏ j, volume (tⱼ)` via `volume_pi_pi`, and the `i`-th factor is `volume A = 0`,
+so the whole product vanishes (`0 · ∞ = 0` in `ℝ≥0∞`). -/
+theorem coord_preimage_volume_zero
+    {α : Type*} [MeasureSpace α] [SigmaFinite (volume : Measure α)]
+    {n : ℕ} {A : Set α} (hA : volume A = 0) (i : Fin n) :
+    volume {x : Fin n → α | x i ∈ A} = 0 := by
+  have hset : {x : Fin n → α | x i ∈ A}
+      = Set.univ.pi (Function.update (fun _ => (Set.univ : Set α)) i A) := by
+    ext x
+    simp only [Set.mem_setOf_eq, Set.mem_univ_pi]
+    constructor
+    · intro hxi j
+      rcases eq_or_ne j i with rfl | hj
+      · rwa [Function.update_self]
+      · rw [Function.update_of_ne hj]; exact Set.mem_univ _
+    · intro h
+      have := h i
+      rwa [Function.update_self] at this
+  rw [hset, volume_pi_pi]
+  exact Finset.prod_eq_zero (Finset.mem_univ i)
+    (by rw [Function.update_self]; exact hA)
+
+-- ============================================================================
+-- § 2. ℝⁿ: at least one algebraic coordinate ⇒ null
+-- ============================================================================
+
+/-- **The points of ℝⁿ with at least one algebraic coordinate are Lebesgue-null.**
+
+The set is the finite union over coordinates `i` of the cylinders
+`{x | IsAlgebraic ℚ (x i)}`, each null by `coord_preimage_volume_zero` applied
+to the parent result `algebraic_reals_null`. A finite (indeed countable) union
+of null sets is null. Holds for every `n`, including `n = 0` (empty union). -/
+theorem atLeastOneAlgebraicReal_null {n : ℕ} :
+    volume {x : Fin n → ℝ | ∃ i, IsAlgebraic ℚ (x i)} = 0 := by
+  have hunion : {x : Fin n → ℝ | ∃ i, IsAlgebraic ℚ (x i)}
+      = ⋃ i, {x : Fin n → ℝ | IsAlgebraic ℚ (x i)} := by
+    ext x; simp only [Set.mem_setOf_eq, Set.mem_iUnion]
+  rw [hunion]
+  refine measure_iUnion_null (fun i => ?_)
+  exact coord_preimage_volume_zero
+    (A := {r : ℝ | IsAlgebraic ℚ r}) AlgebraicRealsNull.algebraic_reals_null i
+
+-- ============================================================================
+-- § 3. ℝⁿ: all coordinates algebraic ⇒ countable ⇒ (for n ≥ 1) null
+-- ============================================================================
+
+/-- **The points of ℝⁿ with all coordinates algebraic are countable.**
+
+They form `(algebraic reals)ⁿ`, a finite product of the countable set of
+algebraic reals; `countable_pi` (finite index, countable factors) gives
+countability. This holds for every `n`. -/
+theorem allAlgebraicReal_countable {n : ℕ} :
+    {x : Fin n → ℝ | ∀ i, IsAlgebraic ℚ (x i)}.Countable :=
+  countable_pi (fun _ => AlgebraicNumbersCountable.algebraic_reals_countable)
+
+/-- **For `n ≥ 1`, the all-algebraic points of ℝⁿ are Lebesgue-null.**
+
+Being countable they are null already, but we get it for free by monotonicity:
+when `n ≥ 1` the index set `Fin n` is nonempty, so "all coordinates algebraic"
+implies "at least one algebraic coordinate", and the latter set is null by
+`atLeastOneAlgebraicReal_null`. (For `n = 0` the claim is false — ℝ⁰ is a single
+point of measure `1`, all of whose coordinates are vacuously algebraic.) -/
+theorem allAlgebraicReal_null {n : ℕ} (hn : 0 < n) :
+    volume {x : Fin n → ℝ | ∀ i, IsAlgebraic ℚ (x i)} = 0 := by
+  refine measure_mono_null ?_ atLeastOneAlgebraicReal_null
+  intro x hx
+  exact ⟨⟨0, hn⟩, hx ⟨0, hn⟩⟩
+
+/-- **Almost every point of ℝⁿ has all coordinates transcendental.**
+
+The set of coordinatewise-transcendental points is exactly the complement of
+the at-least-one-algebraic set, which is null. Holds for every `n`. -/
+theorem ae_all_transcendental {n : ℕ} :
+    ∀ᵐ x : Fin n → ℝ ∂volume, ∀ i, Transcendental ℚ (x i) := by
+  have hset : {x : Fin n → ℝ | ∀ i, Transcendental ℚ (x i)}
+      = {x : Fin n → ℝ | ∃ i, IsAlgebraic ℚ (x i)}ᶜ := by
+    ext x
+    simp only [Set.mem_setOf_eq, Set.mem_compl_iff, not_exists, Transcendental]
+  rw [Filter.eventually_iff, hset]
+  exact compl_mem_ae_iff.mpr atLeastOneAlgebraicReal_null
+
+-- ============================================================================
+-- § 4. ℂⁿ: the same statements for the complex algebraic numbers
+-- ============================================================================
+
+/-- **The points of ℂⁿ with at least one algebraic coordinate are null.**
+
+Identical argument to `atLeastOneAlgebraicReal_null`, using the parent complex
+result `algebraic_complex_null` for the null factor. -/
+theorem atLeastOneAlgebraicComplex_null {n : ℕ} :
+    volume {z : Fin n → ℂ | ∃ i, IsAlgebraic ℚ (z i)} = 0 := by
+  have hunion : {z : Fin n → ℂ | ∃ i, IsAlgebraic ℚ (z i)}
+      = ⋃ i, {z : Fin n → ℂ | IsAlgebraic ℚ (z i)} := by
+    ext z; simp only [Set.mem_setOf_eq, Set.mem_iUnion]
+  rw [hunion]
+  refine measure_iUnion_null (fun i => ?_)
+  exact coord_preimage_volume_zero
+    (A := {w : ℂ | IsAlgebraic ℚ w}) AlgebraicRealsNull.algebraic_complex_null i
+
+/-- **The points of ℂⁿ with all coordinates algebraic are countable.** -/
+theorem allAlgebraicComplex_countable {n : ℕ} :
+    {z : Fin n → ℂ | ∀ i, IsAlgebraic ℚ (z i)}.Countable :=
+  countable_pi (fun _ => AlgebraicNumbersCountable.algebraic_complex_countable)
+
+/-- **For `n ≥ 1`, the all-algebraic points of ℂⁿ are null.** -/
+theorem allAlgebraicComplex_null {n : ℕ} (hn : 0 < n) :
+    volume {z : Fin n → ℂ | ∀ i, IsAlgebraic ℚ (z i)} = 0 := by
+  refine measure_mono_null ?_ atLeastOneAlgebraicComplex_null
+  intro z hz
+  exact ⟨⟨0, hn⟩, hz ⟨0, hn⟩⟩
+
+/-- **Almost every point of ℂⁿ has all coordinates transcendental.** -/
+theorem ae_all_transcendental_complex {n : ℕ} :
+    ∀ᵐ z : Fin n → ℂ ∂volume, ∀ i, Transcendental ℚ (z i) := by
+  have hset : {z : Fin n → ℂ | ∀ i, Transcendental ℚ (z i)}
+      = {z : Fin n → ℂ | ∃ i, IsAlgebraic ℚ (z i)}ᶜ := by
+    ext z
+    simp only [Set.mem_setOf_eq, Set.mem_compl_iff, not_exists, Transcendental]
+  rw [Filter.eventually_iff, hset]
+  exact compl_mem_ae_iff.mpr atLeastOneAlgebraicComplex_null
+
+end AlgebraicPointsNull

--- a/src/data/proofs/algebraic-numbers-countable-oq-07-oq-03/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07-oq-03/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-oq0703-cylinder-null",
+    "proofId": "algebraic-numbers-countable-oq-07-oq-03",
+    "range": {
+      "startLine": 71,
+      "endLine": 101
+    },
+    "type": "concept",
+    "title": "A Coordinate Cylinder over a Null Factor is Null (Fubini)",
+    "content": "The one genuinely n-dimensional step. Given a null set `A` (volume A = 0) in the factor space and a coordinate `i`, the cylinder `{x : Fin n → α | x i ∈ A}` is rewritten as the box `Set.univ.pi (Function.update (fun _ => Set.univ) i A)` — the set `A` in slot `i` and the whole line in every other slot. `volume_pi_pi` computes its measure as the finite product `∏ j, volume (t j)`, and `Finset.prod_eq_zero (Finset.mem_univ i)` kills it because the `i`-th factor is `volume A = 0`. In ℝ≥0∞ this is exactly `0 · ∞ · ⋯ = 0`: the other factors are infinite, yet the slice still carries no volume.",
+    "mathContext": "volume_pi_pi : volume (univ.pi s) = ∏ i, volume (s i). With s = update (fun _ => univ) i A, the i-th factor is volume A = 0, so the product vanishes. This is the measure-theoretic content of Fubini: a lower-dimensional slice has zero n-dimensional measure.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "volume_pi_pi",
+      "Finset.prod_eq_zero",
+      "Function.update",
+      "product measure",
+      "Fubini's theorem"
+    ],
+    "prerequisites": [
+      "Product Lebesgue measure on Fin n → α",
+      "0 · ∞ = 0 in ℝ≥0∞"
+    ]
+  },
+  {
+    "id": "ann-oq0703-atleastone-null",
+    "proofId": "algebraic-numbers-countable-oq-07-oq-03",
+    "range": {
+      "startLine": 102,
+      "endLine": 121
+    },
+    "type": "concept",
+    "title": "At Least One Algebraic Coordinate: an Uncountable Null Set",
+    "content": "`atLeastOneAlgebraicReal_null` writes `{x | ∃ i, IsAlgebraic ℚ (x i)}` as the union `⋃ i, {x | IsAlgebraic ℚ (x i)}` of coordinate cylinders over the null algebraic reals (parent `algebraic_reals_null`), each null by §1, and applies `measure_iUnion_null` (a countable union of null sets is null). The striking point is size: for n ≥ 2 this set is uncountable — in ℝ² it already contains every vertical line through an algebraic number — yet it is Lebesgue-null. So in dimension ≥ 2, 'measure zero' is strictly weaker than 'countable', a gap invisible in the one-dimensional parent.",
+    "mathContext": "{x | ∃ i, IsAlgebraic ℚ (x i)} = ⋃ i, {x | x i ∈ (algebraic reals)}. Each term is null by the cylinder lemma; measure_iUnion_null over the countable index Fin n gives volume of the union = 0. Valid for all n (empty union when n = 0).",
+    "significance": "key",
+    "relatedConcepts": [
+      "measure_iUnion_null",
+      "coordinate cylinder",
+      "uncountable null set",
+      "IsAlgebraic"
+    ],
+    "prerequisites": [
+      "Coordinate-cylinder nullity (§1)",
+      "One-dimensional algebraic_reals_null (parent entry)"
+    ]
+  },
+  {
+    "id": "ann-oq0703-all-countable-null",
+    "proofId": "algebraic-numbers-countable-oq-07-oq-03",
+    "range": {
+      "startLine": 122,
+      "endLine": 160
+    },
+    "type": "concept",
+    "title": "All Coordinates Algebraic: Countable, hence Null for n ≥ 1",
+    "content": "The all-algebraic points `{x | ∀ i, IsAlgebraic ℚ (x i)}` are `(algebraic reals)ⁿ`, a finite product of countable sets; `countable_pi` (finite index, countable factors) gives `allAlgebraicReal_countable`. For nullity, rather than invoke atomlessness of the product measure, `allAlgebraicReal_null` observes that when `Fin n` is nonempty (n ≥ 1) 'all algebraic' implies 'at least one algebraic', so the set is a subset of the §2 null set and `measure_mono_null` finishes. The `n = 0` case is a genuine exception: ℝ⁰ is one point of measure 1, vacuously all-algebraic — hence the explicit `0 < n` hypothesis. Complementing the §2 set gives `ae_all_transcendental` via `compl_mem_ae_iff`.",
+    "mathContext": "countable_pi : (∀ a, (s a).Countable) → {f | ∀ a, f a ∈ s a}.Countable, over the finite index Fin n. allAlgebraic ⊆ atLeastOne when Fin n ≠ ∅, so measure_mono_null transfers nullity. compl_mem_ae_iff turns the null complement into ∀ᵐ x, ∀ i, Transcendental ℚ (x i).",
+    "significance": "key",
+    "relatedConcepts": [
+      "countable_pi",
+      "measure_mono_null",
+      "compl_mem_ae_iff",
+      "vacuous truth at n = 0"
+    ],
+    "prerequisites": [
+      "Countability of the algebraic reals (parent entry)",
+      "At-least-one nullity (§2)"
+    ]
+  },
+  {
+    "id": "ann-oq0703-complex",
+    "proofId": "algebraic-numbers-countable-oq-07-oq-03",
+    "range": {
+      "startLine": 161,
+      "endLine": 201
+    },
+    "type": "concept",
+    "title": "The ℂⁿ Analogues Come for Free",
+    "content": "Because `coord_preimage_volume_zero` is stated over an arbitrary σ-finite factor `α`, the entire ℂⁿ development (`atLeastOneAlgebraicComplex_null`, `allAlgebraicComplex_countable`, `allAlgebraicComplex_null`, `ae_all_transcendental_complex`) is a line-for-line copy of the real case with only the one-dimensional inputs swapped: `algebraic_complex_null` for the null factor and `algebraic_complex_countable` for the countable factor, both from the parent entries. No new geometry is needed — the planar Lebesgue measure on ℂ is σ-finite, which is all the cylinder lemma requires.",
+    "mathContext": "The generic factor α in coord_preimage_volume_zero instantiates to ℂ (a σ-finite MeasureSpace). The proofs of the ℂⁿ statements are identical to their ℝⁿ counterparts modulo the substituted one-dimensional lemmas.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "SigmaFinite",
+      "algebraic_complex_null",
+      "algebraic_complex_countable",
+      "generic factor space"
+    ],
+    "prerequisites": [
+      "Coordinate-cylinder nullity (§1)",
+      "One-dimensional complex null and countable results (parent entries)"
+    ]
+  }
+]

--- a/src/data/proofs/algebraic-numbers-countable-oq-07-oq-03/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07-oq-03/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "algebraic-numbers-countable-oq-07-oq-03",
+  "title": "Algebraic Points in ℝⁿ and ℂⁿ are Negligible: Almost Every Point is Coordinatewise Transcendental",
+  "slug": "algebraic-numbers-countable-oq-07-oq-03",
+  "description": "The n-dimensional generalization of the measure pillar of the algebraic-number smallness trichotomy. Two independent smallness statements are proved for the product Lebesgue measure on ℝⁿ (and ℂⁿ): (1) the set of points with at least one algebraic coordinate is Lebesgue-null — an uncountable, continuum-sized null set once n ≥ 2, via the Fubini fact that a coordinate cylinder over a null factor has product measure zero (0·∞ = 0); (2) the all-algebraic points form a finite product of countable sets, hence are countable, and for n ≥ 1 sit inside the at-least-one set, so are also null. Dually, almost every point of ℝⁿ (and ℂⁿ) has all coordinates transcendental. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicPointsNull.lean",
+    "tags": [
+      "set-theory",
+      "measure-theory",
+      "lebesgue-measure",
+      "product-measure",
+      "algebraic-numbers",
+      "transcendental-numbers",
+      "almost-everywhere",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 201,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "dateAdded": "2026-07-01",
+    "mathlibDependencies": [
+      {
+        "theorem": "volume_pi_pi",
+        "description": "The product Lebesgue measure of a box equals the product of the factor measures: volume (univ.pi s) = ∏ i, volume (s i). Applied to the coordinate cylinder A × ℝ × ⋯, whose i-th factor has measure 0, forcing the whole product to vanish.",
+        "module": "Mathlib.MeasureTheory.Constructions.Pi"
+      },
+      {
+        "theorem": "Finset.prod_eq_zero",
+        "description": "A finite product with a zero factor is zero — in ℝ≥0∞ this encodes 0·∞ = 0, the mechanism that kills the coordinate cylinder even though the remaining factors have infinite measure.",
+        "module": "Mathlib.Algebra.BigOperators.GroupWithZero.Basic"
+      },
+      {
+        "theorem": "measure_iUnion_null",
+        "description": "A countable union of null sets is null. The at-least-one-algebraic-coordinate set is the finite union over the Fin n coordinates of the cylinders, so nullity of each cylinder yields nullity of the union.",
+        "module": "Mathlib.MeasureTheory.OuterMeasure.Basic"
+      },
+      {
+        "theorem": "countable_pi",
+        "description": "For a finite index type and countable factor sets, {f | ∀ a, f a ∈ s a} is countable. Applied with each factor the countable algebraic reals (resp. complex algebraic numbers), it makes the all-algebraic points of ℝⁿ (resp. ℂⁿ) countable.",
+        "module": "Mathlib.Data.Set.Countable"
+      },
+      {
+        "theorem": "measure_mono_null",
+        "description": "A subset of a null set is null. For n ≥ 1 the all-algebraic points are contained in the at-least-one-algebraic set, giving their nullity for free from the stronger cylinder result.",
+        "module": "Mathlib.MeasureTheory.Measure.MeasureSpace"
+      },
+      {
+        "theorem": "compl_mem_ae_iff",
+        "description": "A set is conull iff its complement is null; converts the null at-least-one-algebraic set into the almost-everywhere statement that every coordinate is transcendental.",
+        "module": "Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms"
+      }
+    ],
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. The proof works in the product measure space `Fin n → ℝ` (and `Fin n → ℂ`) whose `volume` is the product Lebesgue measure. The countability of the one-dimensional algebraic reals/complex numbers is imported from `AlgebraicNumbersCountable`, and the one-dimensional nullity from the parent `AlgebraicRealsNull` (`algebraic_reals_null`, `algebraic_complex_null`). `#print axioms` on all main results reports only propext, Classical.choice, Quot.sound — no `Lean.ofReduceBool`, no `sorryAx`.",
+    "originalContributions": [
+      "coord_preimage_volume_zero: a coordinate cylinder {x : Fin n → α | x i ∈ A} over a null factor A is null for the product measure — the general Fubini/Tonelli lemma powering both dimensions and both fields",
+      "atLeastOneAlgebraicReal_null: volume {x : Fin n → ℝ | ∃ i, IsAlgebraic ℚ (x i)} = 0 — the (continuum-sized, for n ≥ 2) set of points with some algebraic coordinate is Lebesgue-null, for every n",
+      "allAlgebraicReal_countable: the all-algebraic points of ℝⁿ are countable (a finite product of countable sets)",
+      "allAlgebraicReal_null: for n ≥ 1 the all-algebraic points of ℝⁿ are Lebesgue-null (they lie in the at-least-one set)",
+      "ae_all_transcendental: almost every point of ℝⁿ has all coordinates transcendental (∀ᵐ x ∂volume, ∀ i, Transcendental ℚ (x i))",
+      "atLeastOneAlgebraicComplex_null: the ℂⁿ analogue — points with some algebraic coordinate are planar-Lebesgue-null",
+      "allAlgebraicComplex_countable: the all-algebraic points of ℂⁿ are countable",
+      "allAlgebraicComplex_null: for n ≥ 1 the all-algebraic points of ℂⁿ are null",
+      "ae_all_transcendental_complex: almost every point of ℂⁿ has all coordinates transcendental"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cantor's 1874 countability theorem shows the algebraic reals are a small, ℵ₀-sized subset of the continuum, and the gallery already records the three independent one-dimensional senses in which they are negligible: cardinality (countable), Baire category (meagre), and measure (Lebesgue-null, the parent entry algebraic-numbers-countable-oq-07). The natural next question is dimensional: what happens in ℝⁿ and ℂⁿ?\n\nIn higher dimensions the picture splits into two genuinely different statements. One can ask for the points that are algebraic in *every* coordinate — these form (algebraic reals)ⁿ, a countable set, small in the cardinality sense. Or one can ask for the far larger set of points that are algebraic in *at least one* coordinate — in ℝ² this already contains the vertical and horizontal lines through every algebraic number, an uncountable, continuum-sized set. Remarkably the second set, despite being uncountable, is still Lebesgue-null: it is a countable union of coordinate hyperplanes-thickened-to-cylinders, each of which has measure zero because one of its factors does. This is the geometric heart of Fubini's theorem — a lower-dimensional slice has no n-dimensional volume — and it shows that in dimension ≥ 2 'measure zero' is strictly weaker than 'countable'.\n\nThe dual slogan is that a point of ℝⁿ chosen uniformly at random has, with probability one, all coordinates transcendental. This is the multi-dimensional form of 'almost every real is transcendental'.",
+    "problemStatement": "**Open question (algebraic-numbers-countable-oq-07-oq-03)**: Generalize the measure pillar of the smallness trichotomy to ℝⁿ and ℂⁿ. Prove that the set of points with at least one algebraic coordinate is Lebesgue-null, and that the all-algebraic points (every coordinate algebraic) are countable, hence null. Conclude that almost every point has all coordinates transcendental.\n\n**Main theorems**: `volume {x : Fin n → ℝ | ∃ i, IsAlgebraic ℚ (x i)} = 0` and `{x : Fin n → ℝ | ∀ i, IsAlgebraic ℚ (x i)}.Countable`, with the analogous pair over ℂ, and the a.e. corollary `∀ᵐ x ∂volume, ∀ i, Transcendental ℚ (x i)`.",
+    "proofStrategy": "The argument has one genuinely new n-dimensional ingredient and then reduces everything else to the one-dimensional parent.\n\n**Step 1 — the coordinate-cylinder lemma (`coord_preimage_volume_zero`).** Fix a factor-null set `A` (volume A = 0) and a coordinate `i`. The cylinder `{x | x i ∈ A}` is exactly the box `Set.univ.pi (Function.update (fun _ => univ) i A)` — the set `A` in coordinate `i` and the whole line elsewhere. By `volume_pi_pi` its measure is the finite product `∏ j, volume (t j)`, and the `i`-th factor is `volume A = 0`, so `Finset.prod_eq_zero` collapses the whole product to `0`. This is where `0 · ∞ = 0` in `ℝ≥0∞` does the work: the other factors are infinite, yet the product still vanishes.\n\n**Step 2 — at least one algebraic coordinate is null.** The set `{x | ∃ i, IsAlgebraic ℚ (x i)}` is the union `⋃ i, {x | IsAlgebraic ℚ (x i)}` of coordinate cylinders over the null algebraic reals (parent result `algebraic_reals_null`). Each is null by Step 1, and a countable union of null sets is null (`measure_iUnion_null`). This holds for every `n`, including the degenerate `n = 0` where the union is empty.\n\n**Step 3 — all coordinates algebraic is countable.** The set `{x | ∀ i, IsAlgebraic ℚ (x i)}` is `(algebraic reals)ⁿ`, and `countable_pi` (finite index `Fin n`, countable factors from `AlgebraicNumbersCountable.algebraic_reals_countable`) makes it countable.\n\n**Step 4 — all coordinates algebraic is null for n ≥ 1.** When `Fin n` is nonempty, 'all algebraic' implies 'at least one algebraic', so the all-algebraic set is a subset of the Step 2 null set; `measure_mono_null` finishes. (For `n = 0` this is genuinely false — ℝ⁰ is a single point of measure 1 whose unique coordinate-tuple is vacuously all-algebraic — a boundary invisible to the one-dimensional parent.)\n\n**Step 5 — almost every point is coordinatewise transcendental.** `Transcendental ℚ` unfolds to `¬ IsAlgebraic ℚ`, so `{x | ∀ i, Transcendental ℚ (x i)}` is the complement of the Step 2 set; `compl_mem_ae_iff` turns its nullity into the a.e. statement. Steps 1–5 run verbatim over ℂ using `algebraic_complex_null` and `algebraic_complex_countable`.",
+    "keyInsights": [
+      "In dimension ≥ 2, 'at least one algebraic coordinate' is an uncountable (continuum-sized) set that is nonetheless Lebesgue-null, so 'measure zero' is strictly weaker than 'countable' — a distinction the one-dimensional parent cannot exhibit, since there both notions coincide on the countable algebraic reals.",
+      "The nullity of a coordinate cylinder is pure Fubini/Tonelli: a lower-dimensional slice (here A × ℝ × ⋯) carries no n-dimensional volume. Formally this is `0 · ∞ = 0` inside the finite product `∏ j, volume (t j)`, made rigorous by `volume_pi_pi` and `Finset.prod_eq_zero`.",
+      "The two headline sets are of very different sizes: the all-algebraic points are countable, while the at-least-one-algebraic set is continuum-sized; yet both are null. The strong statement (at-least-one) implies the weak one (all) by monotonicity, so proving the cylinder lemma once yields the countable-set nullity for free — no atomlessness of the product measure is invoked.",
+      "The `n = 0` boundary is real: ℝ⁰ is a one-point space of total measure 1, and its unique point is vacuously all-algebraic, so `allAlgebraicReal_null` genuinely requires the hypothesis `0 < n`, whereas the at-least-one statement (empty set) and the countability statement hold for all n.",
+      "Everything transfers to ℂⁿ with no extra work because the coordinate-cylinder lemma is stated generically over any σ-finite factor `α`; only the one-dimensional null and countable inputs change (`algebraic_complex_null`, `algebraic_complex_countable`)."
+    ],
+    "prerequisites": [
+      "algebraic-numbers-countable-oq-07 (AlgebraicRealsNull): the one-dimensional measure pillar — algebraic reals and complex algebraic numbers are Lebesgue-null",
+      "algebraic-numbers-countable (AlgebraicNumbersCountable): countability of the one-dimensional algebraic reals and complex algebraic numbers",
+      "volume_pi_pi: the product Lebesgue measure of a box is the product of the factor measures",
+      "countable_pi: a finite product of countable sets is countable",
+      "measure_iUnion_null: a countable union of null sets is null",
+      "compl_mem_ae_iff: sᶜ ∈ ae μ ↔ μ s = 0 — the bridge from measure-zero to almost-everywhere"
+    ],
+    "furtherWork": "Natural follow-ups: (1) Strengthen 'null' to a Hausdorff-dimension statement: the at-least-one-algebraic set in ℝⁿ has Hausdorff dimension n − 1 (it is a countable union of (n−1)-dimensional cylinders), while the all-algebraic set has dimension 0. (2) Prove the stronger measure-and-independence claim hinted at by the open question — almost every point of ℝⁿ has algebraically *independent* transcendental coordinates — which requires a Fubini argument over the algebraic-dependence variety rather than a single coordinate. (3) Replace Lebesgue measure by an arbitrary product of atomless Borel probability measures (e.g. an n-dimensional Gaussian), for which the same cylinder argument applies verbatim."
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 70,
+      "summary": "Imports (product Lebesgue measure on ℝ and ℂ, the parent countability and nullity entries), the module docstring stating the n-dimensional open question and the split into the two smallness statements, the list of main results, and the namespace with opens (MeasureTheory, Set).",
+      "mathContext": "Open question: generalize the measure pillar of the algebraic smallness trichotomy to ℝⁿ and ℂⁿ."
+    },
+    {
+      "id": "section-1-cylinder",
+      "title": "§1. A Coordinate Cylinder over a Null Factor is Null",
+      "startLine": 71,
+      "endLine": 101,
+      "summary": "`coord_preimage_volume_zero`: for a σ-finite factor space α and a null set A, the cylinder {x : Fin n → α | x i ∈ A} is null. Rewrites the cylinder as the box univ.pi (update (fun _ => univ) i A), applies volume_pi_pi, and kills the product via Finset.prod_eq_zero at the i-th (measure-zero) factor.",
+      "mathContext": "$\\mathrm{vol}\\{x : \\mathrm{Fin}\\,n \\to \\alpha \\mid x_i \\in A\\} = \\prod_j \\mathrm{vol}(t_j) = 0$ since $\\mathrm{vol}(A) = 0$ and $0 \\cdot \\infty = 0$."
+    },
+    {
+      "id": "section-2-real-atleastone",
+      "title": "§2. ℝⁿ: At Least One Algebraic Coordinate ⇒ Null",
+      "startLine": 102,
+      "endLine": 121,
+      "summary": "`atLeastOneAlgebraicReal_null`: volume {x : Fin n → ℝ | ∃ i, IsAlgebraic ℚ (x i)} = 0, as the countable union over coordinates of null cylinders (via §1 and the parent algebraic_reals_null). Holds for every n.",
+      "mathContext": "$\\mathrm{vol}\\{x \\in \\mathbb{R}^n \\mid \\exists i,\\ \\mathrm{IsAlgebraic}_\\mathbb{Q}\\,x_i\\} = 0$."
+    },
+    {
+      "id": "section-3-real-all",
+      "title": "§3. ℝⁿ: All Coordinates Algebraic ⇒ Countable ⇒ Null",
+      "startLine": 122,
+      "endLine": 160,
+      "summary": "`allAlgebraicReal_countable`: the all-algebraic points are countable via countable_pi. `allAlgebraicReal_null` (n ≥ 1): they are null as a subset of the §2 set. `ae_all_transcendental`: almost every point of ℝⁿ is coordinatewise transcendental (complement of the §2 null set).",
+      "mathContext": "$\\{x \\in \\mathbb{R}^n \\mid \\forall i,\\ \\mathrm{IsAlgebraic}_\\mathbb{Q}\\,x_i\\}$ is countable; null for $n \\ge 1$; a.e. point is coordinatewise transcendental."
+    },
+    {
+      "id": "section-4-complex",
+      "title": "§4. ℂⁿ: The Same Statements for the Complex Algebraic Numbers",
+      "startLine": 161,
+      "endLine": 201,
+      "summary": "`atLeastOneAlgebraicComplex_null`, `allAlgebraicComplex_countable`, `allAlgebraicComplex_null` (n ≥ 1), and `ae_all_transcendental_complex`: the verbatim ℂⁿ analogues, using the parent algebraic_complex_null and algebraic_complex_countable as the one-dimensional inputs.",
+      "mathContext": "$\\mathrm{vol}\\{z \\in \\mathbb{C}^n \\mid \\exists i,\\ \\mathrm{IsAlgebraic}_\\mathbb{Q}\\,z_i\\} = 0$ and a.e. point of $\\mathbb{C}^n$ is coordinatewise transcendental."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry lifts the measure pillar of the algebraic-number smallness trichotomy to ℝⁿ and ℂⁿ. The single new ingredient is that a coordinate cylinder over a Lebesgue-null factor has product measure zero (Fubini: a slice has no full-dimensional volume). From it, the points with at least one algebraic coordinate are null for every n — an uncountable null set once n ≥ 2 — and the all-algebraic points are countable, hence (for n ≥ 1) null by containment. Dually, almost every point of ℝⁿ and ℂⁿ has all coordinates transcendental. All 9 theorems are proved with 0 sorries and 0 axioms.",
+    "implications": "The n-dimensional picture cleanly separates two notions that coincide in dimension one. The all-algebraic points remain countable (cardinality-small), but the geometrically natural set — at least one algebraic coordinate — is uncountable yet still measure-zero, showing 'null' is strictly weaker than 'countable' for n ≥ 2. The a.e. statement is the multidimensional form of 'almost every real is transcendental': a uniformly random point of any box in ℝⁿ has all coordinates transcendental with probability one. Because the coordinate-cylinder lemma is stated over an arbitrary σ-finite factor, the same conclusions hold for any finite product of atomless Borel measures, not just Lebesgue.",
+    "openQuestions": [
+      "Sharpen 'null' to Hausdorff dimension: the at-least-one-algebraic set in ℝⁿ is a countable union of (n−1)-dimensional cylinders and should have Hausdorff dimension exactly n − 1, while the all-algebraic set has dimension 0. Formalizing this would refine the measure statement into the fractal-dimension hierarchy.",
+      "Prove the algebraic-independence strengthening: almost every point of ℝⁿ has coordinates that are not merely individually transcendental but algebraically independent over ℚ. This requires showing the algebraic-dependence variety {x | x₁,…,xₙ are ℚ-algebraically dependent} is Lebesgue-null, a Fubini argument over a proper subvariety rather than a single coordinate hyperplane."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "algebraic-numbers-countable-oq-07",
+      "relationship": "extends",
+      "description": "The parent entry proves the one-dimensional measure pillar: the algebraic reals (and complex algebraic numbers) are Lebesgue-null. This entry consumes those exact theorems (`algebraic_reals_null`, `algebraic_complex_null`) as the null factor in the coordinate-cylinder lemma, lifting the result to the product measure on ℝⁿ and ℂⁿ. It answers the parent's third open question."
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "depends-on",
+      "description": "Supplies the countability of the one-dimensional algebraic reals and complex algebraic numbers (`algebraic_reals_countable`, `algebraic_complex_countable`), which `countable_pi` turns into the countability of the all-algebraic points of ℝⁿ and ℂⁿ."
+    },
+    {
+      "targetId": "algebraic-reals-meager",
+      "relationship": "complementary",
+      "description": "Provides the Baire-category pillar of the one-dimensional smallness trichotomy (the algebraic reals are meagre). This entry is the measure pillar's n-dimensional form. Together they illustrate that in higher dimensions the various notions of smallness — countable, meagre, null — diverge further: the at-least-one-algebraic set is null but neither countable nor (in general) meagre-forcing on every coordinate."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/AlgebraicPointsNull.lean",
+    "lineCount": 201,
+    "theoremCount": 9,
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": [
+        "G. Cantor"
+      ],
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik (Crelle's Journal), vol. 77, pp. 258–262",
+      "note": "The countability of the algebraic numbers, the one-dimensional input that (with Fubini) yields the n-dimensional nullity here."
+    },
+    {
+      "authors": [
+        "P. R. Halmos"
+      ],
+      "title": "Measure Theory",
+      "year": "1950",
+      "venue": "Van Nostrand",
+      "note": "Standard reference for product measures and the Fubini/Tonelli theorem underlying the coordinate-cylinder nullity lemma."
+    },
+    {
+      "authors": [
+        "J. C. Oxtoby"
+      ],
+      "title": "Measure and Category: A Survey of the Analogies between Topological and Measure Spaces",
+      "year": "1980",
+      "venue": "Springer, Graduate Texts in Mathematics 2",
+      "note": "The independence of the various notions of smallness (cardinality, category, measure), which this entry shows diverge further in higher dimensions."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry answering the **third open question** of `algebraic-numbers-countable-oq-07` (*The Algebraic Reals are Lebesgue-Null*): the **n-dimensional** measure pillar of the algebraic-number smallness trichotomy.

Working in the product Lebesgue measure space `Fin n → ℝ` (and `Fin n → ℂ`), two independent smallness statements are proved and reconciled:

1. **At least one algebraic coordinate ⇒ Lebesgue-null.** `volume {x : Fin n → ℝ | ∃ i, IsAlgebraic ℚ (x i)} = 0`. This is an *uncountable*, continuum-sized null set once `n ≥ 2` (in ℝ² it contains every line through an algebraic number), yet it has measure zero — so in dimension ≥ 2, 'null' is strictly weaker than 'countable'.
2. **All coordinates algebraic ⇒ countable, hence null.** `{x | ∀ i, IsAlgebraic ℚ (x i)}` is `(algebraic reals)ⁿ`, a finite product of countable sets (`countable_pi`); for `n ≥ 1` it sits inside set (1) and is therefore null.

Dually: **almost every point of ℝⁿ and ℂⁿ has all coordinates transcendental** (`ae_all_transcendental`).

## Key idea

The one genuinely n-dimensional ingredient is `coord_preimage_volume_zero`: a coordinate cylinder `{x | x i ∈ A}` over a null factor `A` is null, because `volume_pi_pi` factors it as `∏ j, volume (t j)` with a zero `i`-th factor — i.e. `0 · ∞ = 0` in `ℝ≥0∞` (Fubini: a slice carries no full-dimensional volume). Stated generically over a σ-finite factor, so the entire ℂⁿ development is a line-for-line copy with only the one-dimensional inputs (`algebraic_complex_null`, `algebraic_complex_countable`) swapped in.

The `n = 0` boundary is genuine and handled explicitly: ℝ⁰ is a one-point space of measure 1, vacuously all-algebraic, so `allAlgebraicReal_null` carries the hypothesis `0 < n`.

## Verification

- **9 theorems, 0 definitions, 201 lines**, `Proofs/AlgebraicPointsNull.lean`
- **0 sorries, 0 axioms** — `#print axioms` on all main results reports only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`)
- Type-checks against prebuilt Mathlib via `lake env lean` (Docker build unavailable this session — containerd I/O error)

## Files
- `proofs/Proofs/AlgebraicPointsNull.lean` (new)
- `src/data/proofs/algebraic-numbers-countable-oq-07-oq-03/{meta,annotations}.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)