### PR TITLE
research(geometric-series-oq-07-...-oq-01): third moment & vanishing skewness of the descent statistic

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,121 @@
+/-
+# Geometric series, open question oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01:
+# The third moment and vanishing skewness of the descent statistic
+
+The Eulerian number `⟨n,k⟩` (`eulerian n k`) counts permutations of `{1,…,n}` with exactly `k`
+descents, and the row `(⟨n,0⟩,…,⟨n,n−1⟩)` is the distribution of the descent statistic `X` of a
+uniformly random permutation.  The parent entry
+(`geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01`) computed the **mean** `(n−1)/2` and the
+**variance** `(n+1)/12` — the first and second moments — using a single **moment-transfer engine**
+(`moment_transfer`), which turns a weighted row-`(n+1)` sum into a weighted row-`n` sum.
+
+This entry pushes the same engine to the **third moment** and extracts the *shape* consequence that
+the descent distribution has **zero skewness**:
+
+* `eulerian_M3_succ`      : the third-moment recurrence
+  `M₃(n+1) = (n−2)·M₃(n) + 3(n−1)·M₂(n) + (3n−1)·M₁(n) + n·M₀(n)`, read straight off
+  `moment_transfer` with weight `w(k) = k³` (the coefficient `i³(i+1)+(i+1)³(n−i)` simplifies to
+  `(n−2)i³ + 3(n−1)i² + (3n−1)i + n`);
+* `eulerian_third_moment` : the closed form `8·∑ₖ k³·⟨n,k⟩ = (n−1)(n²−n+2)·n!` for `n ≥ 2`, by
+  induction from the base row `n = 2`, feeding in the row sum `M₀ = n!` and the parent's first and
+  second moments;
+* `eulerian_third_central_moment_zero` : `∑ₖ (2k−(n−1))³·⟨n,k⟩ = 0` for `n ≥ 1`.  Since `2k−(n−1)`
+  is (twice) the deviation of `k` from the mean, this is the vanishing of the third central moment:
+  the descent distribution is **symmetric**, so its skewness is `0`.  It follows purely from the
+  palindromy `⟨n,k⟩ = ⟨n,n−1−k⟩`: reflecting `k ↦ n−1−k` negates the odd weight `(2k−(n−1))³` while
+  fixing `⟨n,k⟩`, so the sum equals its own negative.
+
+For example row `3` is `1,4,1`: `∑ k³·⟨3,k⟩ = 0+4+8 = 12`, and `8·12 = 96 = (3−1)(9−3+2)·3! = 2·8·6`;
+while `∑ₖ (2k−2)³·⟨3,k⟩ = (−2)³·1 + 0³·4 + 2³·1 = −8+0+8 = 0`, confirming the symmetry.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and `sorry`-free.
+-/
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ05
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01OQ01
+
+open Nat Finset GeometricSeriesOQ07OQ01OQ01OQ01 GeometricSeriesOQ07OQ01OQ01OQ01OQ01
+  GeometricSeriesOQ07OQ01OQ01OQ01OQ05 GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01
+
+/-! ## The third moment via the moment recurrence -/
+
+/-- The third-moment recurrence, read off `moment_transfer` with weight `w(k) = k³`:
+`M₃(n+1) = (n−2)·M₃(n) + 3(n−1)·M₂(n) + (3n−1)·M₁(n) + n·M₀(n)`.  The transfer coefficient
+`i³·(i+1) + (i+1)³·(n−i)` simplifies to `(n−2)i³ + 3(n−1)i² + (3n−1)i + n`. -/
+theorem eulerian_M3_succ (n : ℕ) :
+    ∑ k ∈ range (n + 2), (k : ℤ) ^ 3 * (eulerian (n + 1) k : ℤ)
+      = ((n : ℤ) - 2) * (∑ k ∈ range (n + 1), (k : ℤ) ^ 3 * (eulerian n k : ℤ))
+        + 3 * ((n : ℤ) - 1) * (∑ k ∈ range (n + 1), (k : ℤ) ^ 2 * (eulerian n k : ℤ))
+        + (3 * (n : ℤ) - 1) * (∑ k ∈ range (n + 1), (k : ℤ) * (eulerian n k : ℤ))
+        + (n : ℤ) * (∑ k ∈ range (n + 1), (eulerian n k : ℤ)) := by
+  rw [moment_transfer (fun k => (k : ℤ) ^ 3) n]
+  rw [Finset.mul_sum, Finset.mul_sum, Finset.mul_sum, Finset.mul_sum,
+    ← Finset.sum_add_distrib, ← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro i _
+  push_cast
+  ring
+
+/-- **Third moment of the descent statistic.**  `8·∑ₖ k³·⟨n,k⟩ = (n−1)(n²−n+2)·n!` for `n ≥ 2`.
+Induction on `n` from the base row `n = 2`, stepping with `eulerian_M3_succ` and feeding in the row
+sum `M₀ = n!`, the first moment `M₁`, and the second moment `M₂`. -/
+theorem eulerian_third_moment (n : ℕ) (hn : 2 ≤ n) :
+    8 * ∑ k ∈ range (n + 1), (k : ℤ) ^ 3 * (eulerian n k : ℤ)
+      = ((n : ℤ) - 1) * ((n : ℤ) ^ 2 - n + 2) * (n ! : ℤ) := by
+  induction n, hn using Nat.le_induction with
+  | base => decide
+  | succ n hn ih =>
+    have hM0 : ∑ k ∈ range (n + 1), (eulerian n k : ℤ) = (n ! : ℤ) := eulerian_M0 n
+    have hM1 : 2 * ∑ k ∈ range (n + 1), (k : ℤ) * (eulerian n k : ℤ) = ((n : ℤ) - 1) * (n ! : ℤ) :=
+      eulerian_first_moment n (by omega)
+    have hM2 : 12 * ∑ k ∈ range (n + 1), (k : ℤ) ^ 2 * (eulerian n k : ℤ)
+        = (n ! : ℤ) * (3 * (n : ℤ) ^ 2 - 5 * n + 4) := eulerian_second_moment n hn
+    rw [eulerian_M3_succ, hM0, Nat.factorial_succ]
+    push_cast
+    linear_combination ((n : ℤ) - 2) * ih + 2 * ((n : ℤ) - 1) * hM2 + 4 * (3 * (n : ℤ) - 1) * hM1
+
+/-! ## Vanishing skewness: the descent distribution is symmetric -/
+
+/-- **Third central moment of the descent statistic is zero.**  `∑ₖ (2k−(n−1))³·⟨n,k⟩ = 0` for
+`n ≥ 1`.  As `2k−(n−1)` is twice the deviation of `k` from the mean `(n−1)/2`, this says the third
+central moment — hence the skewness — vanishes: the descent distribution is symmetric.  Proof: the
+reflection `k ↦ n−1−k` negates the odd weight `(2k−(n−1))³` and fixes `⟨n,k⟩` by palindromy, so the
+sum equals its own negative. -/
+theorem eulerian_third_central_moment_zero (n : ℕ) (hn : 1 ≤ n) :
+    ∑ k ∈ range n, (2 * (k : ℤ) - ((n : ℤ) - 1)) ^ 3 * (eulerian n k : ℤ) = 0 := by
+  set f : ℕ → ℤ := fun k => (2 * (k : ℤ) - ((n : ℤ) - 1)) ^ 3 * (eulerian n k : ℤ) with hf
+  have hrefl : ∑ k ∈ range n, f (n - 1 - k) = ∑ k ∈ range n, f k :=
+    Finset.sum_range_reflect f n
+  have hodd : ∀ k ∈ range n, f (n - 1 - k) = - f k := by
+    intro k hk
+    rw [mem_range] at hk
+    have hpal : eulerian n (n - 1 - k) = eulerian n k := (eulerian_palindrome' hn hk).symm
+    have hcast : ((n - 1 - k : ℕ) : ℤ) = (n : ℤ) - 1 - (k : ℤ) := by
+      rw [Nat.cast_sub (by omega : k ≤ n - 1), Nat.cast_sub (by omega : 1 ≤ n)]
+      push_cast; ring
+    simp only [hf]
+    rw [hpal, hcast]; ring
+  have hsum2 : ∑ k ∈ range n, f k + ∑ k ∈ range n, f k = 0 := by
+    nth_rewrite 1 [← hrefl]
+    rw [← Finset.sum_add_distrib]
+    apply Finset.sum_eq_zero
+    intro k hk
+    rw [hodd k hk]; ring
+  simp only [hf] at hsum2 ⊢
+  linarith
+
+/-! ## Corroboration on concrete rows -/
+
+-- Third moment: row 3 `1,4,1` has `∑ k³·⟨3,k⟩ = 12`, and `8·12 = 96 = (3−1)(9−3+2)·3!`.
+example : 8 * ∑ k ∈ range 4, (k : ℤ) ^ 3 * (eulerian 3 k : ℤ)
+    = ((3 : ℤ) - 1) * ((3 : ℤ) ^ 2 - 3 + 2) * (3 ! : ℤ) := by decide
+-- Third moment: row 4 `1,11,11,1` has `∑ k³·⟨4,k⟩ = 126`, and `8·126 = 1008 = (4−1)(16−4+2)·4!`.
+example : 8 * ∑ k ∈ range 5, (k : ℤ) ^ 3 * (eulerian 4 k : ℤ)
+    = ((4 : ℤ) - 1) * ((4 : ℤ) ^ 2 - 4 + 2) * (4 ! : ℤ) := by decide
+-- Vanishing skewness: row 4 has `∑ₖ (2k−3)³·⟨4,k⟩ = 0`.
+example : ∑ k ∈ range 4, (2 * (k : ℤ) - ((4 : ℤ) - 1)) ^ 3 * (eulerian 4 k : ℤ) = 0 := by decide
+
+end GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "third-moment-recurrence",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 48,
+      "endLine": 63
+    },
+    "type": "tactic",
+    "title": "The third-moment recurrence from the transfer engine",
+    "content": "`eulerian_M3_succ` is the $k=3$ instance of the parent's transfer operator. Feeding the weight $w(k)=k^3$ into `moment_transfer` produces the row-$n$ coefficient $i^3(i+1)+(i+1)^3(n-i)$, which `ring` simplifies (after `push_cast`) to $(n-2)i^3+3(n-1)i^2+(3n-1)i+n$. Reading this off termwise gives the recurrence $M_3(n{+}1) = (n{-}2)M_3(n) + 3(n{-}1)M_2(n) + (3n{-}1)M_1(n) + n\\,M_0(n)$: the third moment at row $n+1$ is a linear combination of the third, second, first and zeroth moments at row $n$. Only linearity (`Finset.mul_sum`, `Finset.sum_add_distrib`) and the single polynomial identity enter — the combinatorics is entirely inside `moment_transfer`.",
+    "mathContext": "$M_3(n{+}1) = (n{-}2)M_3(n) + 3(n{-}1)M_2(n) + (3n{-}1)M_1(n) + n\\,M_0(n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "moment-transfer operator",
+      "monomial weight specialisation",
+      "linear recurrence on moments",
+      "polynomial coefficient identity"
+    ],
+    "prerequisites": [
+      "Eulerian numbers",
+      "moment_transfer engine"
+    ]
+  },
+  {
+    "id": "third-moment-closed-form",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 65,
+      "endLine": 78
+    },
+    "type": "tactic",
+    "title": "Closing the closed form by induction",
+    "content": "`eulerian_third_moment` proves $8\\sum_k k^3\\langle n,k\\rangle = (n-1)(n^2-n+2)\\,n!$ for $n\\ge 2$ by `Nat.le_induction` from the base row $n=2$ (`decide`). The step rewrites with `eulerian_M3_succ`, substitutes $M_0=n!$ (`eulerian_M0`) and $(n{+}1)! = (n{+}1)\\,n!$, and closes with `linear_combination` over the recurrence using coefficients $(n-2)$, $2(n-1)$, $4(3n-1)$ against the induction hypothesis, the second moment (`eulerian_second_moment`) and the first moment (`eulerian_first_moment`). The integer coefficients $2(n-1)$ and $4(3n-1)$ are exactly what clear the $1/12$ and $1/2$ denominators hidden in $M_2$ and $M_1$, so the whole identity stays over $\\mathbb{Z}$.",
+    "mathContext": "$8\\sum_k k^3\\langle n,k\\rangle = (n-1)(n^2-n+2)\\,n!$ for $n\\ge 2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "induction from a base row",
+      "linear_combination",
+      "clearing denominators over ℤ",
+      "coupling to lower moments"
+    ],
+    "prerequisites": [
+      "Nat.le_induction",
+      "first and second moments"
+    ]
+  },
+  {
+    "id": "vanishing-skewness",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 87,
+      "endLine": 108
+    },
+    "type": "insight",
+    "title": "Zero skewness from palindromy alone",
+    "content": "`eulerian_third_central_moment_zero` proves $\\sum_k (2k-(n-1))^3\\langle n,k\\rangle = 0$, the vanishing of the third central moment (the deviation $2k-(n-1)$ is twice $k-\\tfrac{n-1}{2}$). The proof is pure symmetry: `Finset.sum_range_reflect` rewrites the sum by $k\\mapsto n-1-k$, and palindromy $\\langle n,n{-}1{-}k\\rangle=\\langle n,k\\rangle$ (`eulerian_palindrome'`) together with $2(n{-}1{-}k)-(n-1) = -(2k-(n-1))$ shows the reflected summand is the negative of the original. Hence the sum equals its own negative and must be $0$. No recurrence and no induction are used — this is the odd-weight dual of the mean computation, and nothing in the argument depends on the exponent $3$ beyond its being odd.",
+    "mathContext": "$\\sum_k (2k-(n-1))^3\\langle n,k\\rangle = 0$, i.e. $\\mathbb{E}[(X-\\mu)^3]=0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "palindromy of the Eulerian row",
+      "index reflection",
+      "odd central moments",
+      "symmetric distribution"
+    ],
+    "prerequisites": [
+      "eulerian_palindrome'",
+      "Finset.sum_range_reflect"
+    ]
+  },
+  {
+    "id": "concrete-checks",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 110,
+      "endLine": 119
+    },
+    "type": "example",
+    "title": "Corroboration on small rows",
+    "content": "Three `decide` checks pin the results to concrete Eulerian rows. Row $3 = (1,4,1)$: $\\sum_k k^3\\langle 3,k\\rangle = 0+4+8 = 12$ and $8\\cdot 12 = 96 = (3-1)(9-3+2)\\cdot 3!$. Row $4 = (1,11,11,1)$: $\\sum_k k^3\\langle 4,k\\rangle = 11+88+27 = 126$ and $8\\cdot 126 = 1008 = 3\\cdot 14\\cdot 24$; and $\\sum_k (2k-3)^3\\langle 4,k\\rangle = (-3)^3+(-1)^3\\cdot 11+1^3\\cdot 11+3^3 = -27-11+11+27 = 0$. These use kernel `decide` (not `native_decide`), so the file remains axiom-free.",
+    "mathContext": "Row $4$: third moment $126$, centred cube-sum $0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "kernel decide",
+      "concrete verification",
+      "axiom-free checks"
+    ],
+    "prerequisites": [
+      "Eulerian numbers"
+    ]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Third Moment and Vanishing Skewness of the Descent Statistic",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ05",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Nat",
+      "Finset",
+      "GeometricSeriesOQ07OQ01OQ01OQ01",
+      "GeometricSeriesOQ07OQ01OQ01OQ01OQ01",
+      "GeometricSeriesOQ07OQ01OQ01OQ01OQ05",
+      "GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01OQ01",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "descent-statistic",
+      "moments",
+      "third-moment",
+      "skewness",
+      "symmetry",
+      "recurrence",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 121,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "eulerian_M3_succ: the third-moment recurrence M₃(n+1) = (n−2)·M₃(n) + 3(n−1)·M₂(n) + (3n−1)·M₁(n) + n·M₀(n), read straight off the parent's moment-transfer engine at the weight w(k) = k³. The transferred coefficient i³·(i+1) + (i+1)³·(n−i) simplifies (by ring) to (n−2)·i³ + 3(n−1)·i² + (3n−1)·i + n, exhibiting the third moment as a linear combination of the three lower moments at the previous row. This is the k=3 instance of the transfer operator, extending the parent's k=0,1,2 cases.",
+      "eulerian_third_moment: the closed form 8·∑ₖ k³·⟨n,k⟩ = (n−1)(n²−n+2)·n! for n ≥ 2. Proved by induction on n from the base row n = 2, stepping with eulerian_M3_succ and feeding in the zeroth moment M₀ = n! (eulerian_M0), the first moment M₁ (eulerian_first_moment) and the second moment M₂ (eulerian_second_moment); the inductive step closes by linear_combination over the recurrence with coefficients (n−2), 2(n−1), 4(3n−1). Verified on rows n=2,3,4 (e.g. row 4 gives ∑ k³·⟨4,k⟩ = 126 and 8·126 = 1008 = 3·14·24).",
+      "eulerian_third_central_moment_zero: ∑ₖ (2k−(n−1))³·⟨n,k⟩ = 0 for n ≥ 1. Since 2k−(n−1) is twice the deviation of the descent count k from its mean (n−1)/2, this is the vanishing of the third central moment — hence the skewness of the descent distribution is 0: the distribution is symmetric. Proved purely from palindromy: the reflection k ↦ n−1−k (Finset.sum_range_reflect) negates the odd weight (2k−(n−1))³ while fixing ⟨n,k⟩ = ⟨n,n−1−k⟩, so the sum equals its own negative and must be zero. No recurrence, no induction — the symmetry does all the work, complementing the mean (which is the same reflection applied to a linear weight)."
+    ],
+    "prerequisites": [
+      "Parent: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01 (the mean, second moment, and variance of the descent statistic) — supplies THE ENGINE moment_transfer, the zeroth moment eulerian_M0, the first moment eulerian_first_moment, and the second moment eulerian_second_moment, all fed into the third-moment recurrence and closed form",
+      "Grandparent: geometric-series-oq-07-oq-01-oq-01-oq-01 (the combinatorial Eulerian numbers ⟨n,k⟩) — supplies the eulerian triangle used throughout",
+      "Sibling: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05 (palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩) — supplies eulerian_palindrome', the reflection symmetry from which the vanishing skewness is read off",
+      "Mathlib: Finset.sum_range_reflect (index reflection), Finset.sum_add_distrib and Finset.mul_sum (linearity), Finset.sum_eq_zero, Nat.le_induction (induction from a base n=2), Nat.cast_sub, and linear_combination for the closing algebra"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_reflect",
+        "description": "∑ i in range n, f (n−1−i) = ∑ i in range n, f i. Reflecting the index and applying palindromy negates the odd weight (2k−(n−1))³ while fixing ⟨n,k⟩, so the third central moment is its own negative — hence zero.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.le_induction",
+        "description": "Induction starting from a base value (here n = 2). Drives the proof of the third-moment closed form, with eulerian_M3_succ as the inductive step.",
+        "module": "Mathlib.Order.Basic"
+      },
+      {
+        "theorem": "moment_transfer",
+        "description": "THE ENGINE from the parent entry: ∑ₖ w(k)·⟨n+1,k⟩ = ∑ᵢ (w(i)·(i+1)+w(i+1)·(n−i))·⟨n,i⟩ for any integer weight w. Specialised here to w(k) = k³ to produce the third-moment recurrence.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01"
+      },
+      {
+        "theorem": "eulerian_second_moment",
+        "description": "The closed form 12·∑ₖ k²·⟨n,k⟩ = n!·(3n²−5n+4) from the parent, fed (as M₂) into the third-moment recurrence during the inductive step.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01"
+      },
+      {
+        "theorem": "eulerian_first_moment",
+        "description": "The mean identity 2·∑ₖ k·⟨n,k⟩ = (n−1)·n! from the parent, fed (as M₁) into the third-moment recurrence.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01"
+      },
+      {
+        "theorem": "eulerian_palindrome'",
+        "description": "The palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩ from the sibling oq-05. Combined with Finset.sum_range_reflect it gives the vanishing third central moment (zero skewness) purely by symmetry.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ05"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent (the mean, second moment, and variance of the descent statistic). This entry answers the parent's first open question: it drives the same moment-transfer engine one step further to the third moment (the k=3 instance of the transfer operator) and extracts the shape consequence that the descent distribution has zero skewness."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05",
+      "relationship": "uses",
+      "description": "Sibling (palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩). The reflection symmetry is exactly what makes the third central moment vanish: reflecting the index negates the odd deviation weight (2k−(n−1))³ while fixing ⟨n,k⟩, so the centred cube-sum is its own negative."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Grandparent (the combinatorial Eulerian numbers ⟨n,k⟩). Supplies the triangle recurrence that the moment-transfer engine turns into the moment recurrences used here."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, descent statistic)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian numbers and the moments of the descent statistic of a random permutation."
+    },
+    {
+      "title": "Combinatorics of Permutations",
+      "author": "Miklós Bóna",
+      "year": "2012",
+      "venue": "CRC Press",
+      "description": "Develops the distribution of descents and its asymptotic normality; the symmetry of the Eulerian row (vanishing skewness) and the low moments computed here are the elementary seed facts behind that central-limit behaviour."
+    }
+  ],
+  "sorries": 0,
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "question": "Push the moment-transfer engine to the fourth moment and compute the (excess) kurtosis of the descent statistic, checking it tends to the normal value 0 as n → ∞ — the next order beyond the vanishing skewness established here.",
+      "significance": "low"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02",
+      "question": "Prove that ALL odd central moments of the descent statistic vanish (not just the third), as a single corollary of palindromy: ∑ₖ (2k−(n−1))^(2m+1)·⟨n,k⟩ = 0 for every m, by the same reflection argument with an arbitrary odd weight.",
+      "significance": "medium"
+    }
+  ],
+  "description": "Extends the parent's mean/variance computation to the third moment of the number of descents of a uniformly random permutation of {1,…,n}, distributed as the Eulerian row (⟨n,0⟩,…,⟨n,n−1⟩), and extracts the vanishing of its skewness. The third-moment recurrence M₃(n+1) = (n−2)·M₃(n) + 3(n−1)·M₂(n) + (3n−1)·M₁(n) + n·M₀(n) is read off the parent's moment-transfer engine at weight w(k)=k³ (the transferred coefficient i³(i+1)+(i+1)³(n−i) = (n−2)i³+3(n−1)i²+(3n−1)i+n), and closes the closed form 8·∑ₖ k³·⟨n,k⟩ = (n−1)(n²−n+2)·n! for n ≥ 2 by induction from n=2. Independently, the third CENTRED moment ∑ₖ (2k−(n−1))³·⟨n,k⟩ = 0 (n ≥ 1) follows purely from palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩: the reflection k ↦ n−1−k negates the odd deviation weight and fixes the Eulerian entry, so the sum is its own negative. Thus the descent distribution is symmetric — its skewness is 0. 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "Row n of Euler's triangle of Eulerian numbers ⟨n,k⟩ is the distribution of the descent statistic of a uniformly random permutation of {1,…,n}: mean (n−1)/2, variance (n+1)/12. Beyond the variance, the distribution is famously symmetric — the palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩ makes it a mirror image about its mean — so every odd central moment vanishes and, after standardising, the descent count is asymptotically normal (a classical result going back to the study of the Eulerian polynomials). The third moment and the vanishing skewness computed here are the next order of that story after the parent's mean and variance. Mathlib has neither the Eulerian numbers nor the descent statistic, so this computation is gallery-specific; only linearity of finite sums, index reflection, and induction come from Mathlib.",
+    "problemStatement": "For the Eulerian numbers ⟨n,k⟩ of the grandparent entry, use the parent's moment-transfer engine to compute the third moment of the descent statistic — prove 8·∑ₖ k³·⟨n,k⟩ = (n−1)(n²−n+2)·n! (n ≥ 2), over ℤ to avoid denominators — and prove that its third central moment vanishes, ∑ₖ (2k−(n−1))³·⟨n,k⟩ = 0 (n ≥ 1), so the descent distribution has zero skewness.",
+    "proofStrategy": "(1) THIRD-MOMENT RECURRENCE (eulerian_M3_succ): specialise the parent's moment_transfer to w(k)=k³; the transferred coefficient i³(i+1)+(i+1)³(n−i) simplifies (ring) to (n−2)i³+3(n−1)i²+(3n−1)i+n, giving M₃(n+1) = (n−2)·M₃(n)+3(n−1)·M₂(n)+(3n−1)·M₁(n)+n·M₀(n). (2) CLOSED FORM (eulerian_third_moment): induct from n=2, feeding M₀=n! (eulerian_M0), M₁ (eulerian_first_moment) and M₂ (eulerian_second_moment) into the recurrence and closing with linear_combination using coefficients (n−2), 2(n−1), 4(3n−1) that clear the 1/2 and 1/12 denominators of M₁, M₂. (3) VANISHING SKEWNESS (eulerian_third_central_moment_zero): apply Finset.sum_range_reflect to ∑ₖ (2k−(n−1))³·⟨n,k⟩; palindromy (eulerian_palindrome') sends the reflected summand (2(n−1−k)−(n−1))³·⟨n,n−1−k⟩ to −(2k−(n−1))³·⟨n,k⟩, so the sum equals its own negative and is zero.",
+    "keyInsights": [
+      "The third moment is one more turn of the same crank. The parent's moment_transfer is a transfer operator on weighted row sums; feeding it the monomial weight k³ (after k⁰,k¹,k² for M₀,M₁,M₂) mechanically yields the third-moment recurrence, with the only new content the polynomial identity i³(i+1)+(i+1)³(n−i) = (n−2)i³+3(n−1)i²+(3n−1)i+n verified by ring.",
+      "Zero skewness is a pure symmetry fact, dual to the mean. The mean came from reflecting a LINEAR weight k; the vanishing third central moment comes from reflecting the ODD cubic deviation weight (2k−(n−1))³, which the reflection k ↦ n−1−k negates. Palindromy fixes ⟨n,k⟩, so the centred cube-sum is antisymmetric and collapses to 0 — no recurrence needed.",
+      "Working over ℤ keeps everything an exact integer identity. The closed form is stated cleared of denominators as 8·M₃ = (n−1)(n²−n+2)·n!, and the centred moment as ∑ₖ (2k−(n−1))³·⟨n,k⟩ = 0 with the deviation doubled to 2k−(n−1) so no halving of the mean is needed; the closing steps are linear_combination over the recurrence, no field inversion.",
+      "The same reflection argument proves ALL odd central moments vanish. Nothing in eulerian_third_central_moment_zero uses the exponent 3 beyond its oddness: any odd power of 2k−(n−1) is negated by the reflection, so the descent distribution is symmetric to all orders — the exact statement of which is left as an open question."
+    ]
+  },
+  "sections": [
+    {
+      "id": "third-moment",
+      "title": "The Third Moment via the Moment Recurrence",
+      "startLine": 43,
+      "endLine": 78,
+      "summary": "eulerian_M3_succ reads the recurrence M₃(n+1) = (n−2)·M₃(n)+3(n−1)·M₂(n)+(3n−1)·M₁(n)+n·M₀(n) off the parent's moment_transfer at w=k³; eulerian_third_moment closes the closed form 8·∑ₖ k³·⟨n,k⟩ = (n−1)(n²−n+2)·n! by induction from n=2, feeding in M₀, M₁ and M₂.",
+      "mathContext": "$8\\sum_{k} k^3\\langle n,k\\rangle = (n-1)(n^2-n+2)\\,n!$."
+    },
+    {
+      "id": "vanishing-skewness",
+      "title": "Vanishing Skewness: the Distribution is Symmetric",
+      "startLine": 80,
+      "endLine": 108,
+      "summary": "eulerian_third_central_moment_zero proves ∑ₖ (2k−(n−1))³·⟨n,k⟩ = 0 by reflecting k ↦ n−1−k (Finset.sum_range_reflect): palindromy fixes ⟨n,k⟩ and the reflection negates the odd deviation weight, so the centred cube-sum is its own negative.",
+      "mathContext": "$\\sum_{k}\\big(2k-(n-1)\\big)^3\\langle n,k\\rangle = 0$, i.e. $\\mathbb{E}[(X-\\mu)^3]=0$."
+    },
+    {
+      "id": "checks",
+      "title": "Corroboration on Concrete Rows",
+      "startLine": 110,
+      "endLine": 119,
+      "summary": "Row 3 (1,4,1): ∑ k³·⟨3,k⟩ = 12 and 8·12 = 96 = (3−1)(9−3+2)·3!; row 4 (1,11,11,1): ∑ k³·⟨4,k⟩ = 126 and 8·126 = 1008, and ∑ₖ (2k−3)³·⟨4,k⟩ = 0. All discharged by kernel decide (not native_decide, so still axiom-free).",
+      "mathContext": "Row 4 gives third moment $126$ and centred cube-sum $0$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Computes the third moment of the descent statistic of a uniformly random permutation of {1,…,n} — 8·∑ₖ k³·⟨n,k⟩ = (n−1)(n²−n+2)·n! for n ≥ 2, via the k=3 instance of the parent's moment-transfer engine and induction from n=2 — and proves the third central moment vanishes, ∑ₖ (2k−(n−1))³·⟨n,k⟩ = 0 for n ≥ 1, from palindromy alone. The latter says the descent distribution is symmetric: its skewness is 0. 121 lines, 3 theorems, 0 definitions, 0 axioms, 0 sorries (depends only on propext, Classical.choice, Quot.sound; the concrete-row checks use kernel decide, not native_decide).",
+    "implications": "Adding the third moment and vanishing skewness to the parent's mean and variance advances the description of the Eulerian distribution to third order. The reflection argument that kills the third central moment uses only the oddness of the weight, so it in fact shows every odd central moment vanishes — the exact symmetry underlying the asymptotic normality of the standardised descent count. The moment-transfer engine remains reusable for the fourth moment (kurtosis) and beyond; the whole development stays elementary (one polynomial identity, one induction, one reflection).",
+    "openQuestions": [
+      "Push the engine to the fourth moment and compute the excess kurtosis, checking it tends to 0 as n → ∞.",
+      "Prove that all odd central moments vanish, ∑ₖ (2k−(n−1))^(2m+1)·⟨n,k⟩ = 0, by the same reflection with an arbitrary odd weight."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01** — extends the parent's mean/variance computation to the **third moment** of the Eulerian descent statistic and proves its **skewness vanishes**. This **answers the parent's open question `…-oq-01`**, which asked to "use the moment-transfer engine to compute the third (and higher) moments … or the centred moments."

The descent statistic $X$ of a uniformly random permutation of $\{1,\dots,n\}$ is distributed as the Eulerian row $(\langle n,0\rangle,\dots,\langle n,n-1\rangle)$. The parent gave the mean $(n-1)/2$ and variance $(n+1)/12$; this entry gives the third moment and shows the distribution is symmetric.

## What's new (3 theorems, 0 def)

- **`eulerian_M3_succ`** — the third-moment recurrence
  $M_3(n{+}1) = (n{-}2)M_3(n) + 3(n{-}1)M_2(n) + (3n{-}1)M_1(n) + n\,M_0(n)$,
  the $k=3$ instance of the parent's `moment_transfer` engine. The transferred coefficient $i^3(i{+}1)+(i{+}1)^3(n{-}i)$ simplifies (`ring`) to $(n{-}2)i^3+3(n{-}1)i^2+(3n{-}1)i+n$.
- **`eulerian_third_moment`** — the closed form $8\sum_k k^3\langle n,k\rangle = (n-1)(n^2-n+2)\,n!$ for $n\ge 2$, by induction from the base row $n=2$, feeding in $M_0=n!$, $M_1$ and $M_2$; the step closes by `linear_combination` with integer coefficients $(n{-}2)$, $2(n{-}1)$, $4(3n{-}1)$ (which clear the $1/12$, $1/2$ denominators of $M_2$, $M_1$).
- **`eulerian_third_central_moment_zero`** — $\sum_k (2k-(n-1))^3\langle n,k\rangle = 0$ for $n\ge 1$: the **third central moment vanishes**, so the skewness is $0$. Proved purely from palindromy $\langle n,k\rangle=\langle n,n{-}1{-}k\rangle$: the reflection $k\mapsto n{-}1{-}k$ negates the odd deviation weight while fixing the Eulerian entry, so the sum is its own negative. The argument uses only oddness of the weight — the odd-central-moment analogue of the parent's mean computation.

## Verification

- **0 axioms** — `#print axioms` on all three theorems reports only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- **0 sorries.** Concrete-row checks (rows 3, 4) use kernel `decide`, **not** `native_decide`, so the entry stays axiom-free.
- 121 lines, 3 theorems, 0 definitions. Type-checks against the prebuilt Mathlib + sibling modules (`lake env lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)