### PR TITLE
research(angle-trisection-oq-03-oq-02-oq-03): halvings count IS the p-adic valuation, Θ(logₚ d) for every prime [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ03OQ02OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ03OQ02OQ03.lean
@@ -1,0 +1,223 @@
+/-
+  Angle Trisection OQ-03 OQ-02 OQ-03: The Halvings Count IS the p-adic Valuation
+
+  The parent (AngleTrisectionOQ03OQ02) introduced an ad-hoc `halvings` step counter:
+  repeatedly halve d until it becomes odd, and count the steps. That entry proved the
+  count is Θ(log d) — exactly k on inputs d = 2^k.
+
+  This entry answers the open question by IDENTIFYING that ad-hoc counter with a
+  standard arithmetic object:
+
+      halvings n = padicValNat 2 n        (the 2-adic valuation v₂(n))
+
+  and then GENERALIZES the entire complexity story to an arbitrary prime p. We define
+  a p-adic halving counter `pHalvings p` — repeatedly divide by p while divisible —
+  and prove:
+
+    * pHalvings p n = padicValNat p n            (the counter is the p-adic valuation)
+    * halvings n    = pHalvings 2 n              (the parent is the p = 2 instance)
+    * pHalvings p (p^k) = k = Nat.log p (p^k)    (Θ(logₚ d): the count is tight)
+    * the count is unbounded, and separates p^k from the immediately-rejected p^k − 1.
+
+  Everything below is fully machine-checked with no axioms or sorries.
+
+  Companion to AngleTrisectionOQ03OQ02.lean (the p = 2 special case).
+-/
+
+import Mathlib.Data.Nat.Log
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+import Mathlib.Tactic
+import Proofs.AngleTrisectionOQ03OQ02
+
+namespace AngleTrisectionOQ03OQ02OQ03
+
+open AngleTrisectionOQ03OQ02 Nat
+
+/-!
+## Part I: The Halvings Count is the 2-adic Valuation
+
+The parent's `halvings` function counts how many times 2 divides its input. That is
+precisely the definition of the 2-adic valuation `padicValNat 2`. We prove the two
+agree on every input by strong induction, using the parent's own recursion lemmas.
+-/
+
+/-- **Central identification**: the ad-hoc halvings step counter equals the standard
+    2-adic valuation `v₂(n) = padicValNat 2 n`.
+
+    Strong induction with a three-way split on `n`:
+    * `n = 0`: both are `0`;
+    * `n` odd: both are `0` (odd numbers carry no factor of `2`);
+    * `n = 2·k` with `k > 0`: both peel one factor, reducing to `1 + (value at k)`. -/
+theorem halvings_eq_padicValNat_two (n : ℕ) : halvings n = padicValNat 2 n := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rcases Nat.eq_zero_or_pos n with hn | hn
+    · subst hn; simp
+    · rcases Nat.even_or_odd n with he | ho
+      · -- even and positive: write n = 2 * k with k > 0
+        obtain ⟨k, rfl⟩ := he.two_dvd
+        have hk : 0 < k := by omega
+        rw [halvings_two_mul hk, ih k (by omega),
+            padicValNat.mul two_ne_zero (by omega), padicValNat.self (by norm_num)]
+      · -- odd: neither counts a factor of 2
+        have hodd : n % 2 = 1 := Nat.odd_iff.mp ho
+        rw [halvings_odd hodd, padicValNat.eq_zero_of_not_dvd (by omega)]
+
+/-- Restated with the classical `v₂` name: the constructibility algorithm's step count
+    on input `n` is exactly the 2-adic valuation of `n`. -/
+theorem halvings_eq_two_adic_valuation (n : ℕ) :
+    halvings n = padicValNat 2 n := halvings_eq_padicValNat_two n
+
+/-!
+## Part II: A p-adic Halving Counter for an Arbitrary Prime
+
+We generalize the parent's algorithm: `pHalvings p n` repeatedly divides `n` by `p`
+while `p ∣ n`, counting the steps. The guard `1 < p` in the recursion is what makes
+the quotient strictly smaller, so the definition terminates for every `p` (and is a
+harmless constant `0` for the degenerate `p ≤ 1`).
+-/
+
+/-- Count the p-adic halvings of `n`: how many times `p` divides out of `n`. -/
+def pHalvings (p : ℕ) : ℕ → ℕ
+  | 0 => 0
+  | (n + 1) =>
+      if p ∣ (n + 1) ∧ 1 < p then 1 + pHalvings p ((n + 1) / p) else 0
+  termination_by n => n
+  decreasing_by exact Nat.div_lt_self (Nat.succ_pos n) (by omega)
+
+@[simp] theorem pHalvings_zero (p : ℕ) : pHalvings p 0 = 0 := by rw [pHalvings]
+
+/-- Equation lemma for the successor case. -/
+theorem pHalvings_succ (p n : ℕ) :
+    pHalvings p (n + 1)
+      = if p ∣ (n + 1) ∧ 1 < p then 1 + pHalvings p ((n + 1) / p) else 0 := by
+  rw [pHalvings]
+
+/-- If `p` does not divide `m`, the algorithm stops immediately with count `0`. -/
+theorem pHalvings_eq_zero_of_not_dvd {p m : ℕ} (hd : ¬ p ∣ m) : pHalvings p m = 0 := by
+  cases m with
+  | zero => simp
+  | succ n => rw [pHalvings_succ, if_neg (fun h => hd h.1)]
+
+/-- The recursion step: for `1 < p`, `p ∣ m` and `m > 0`, one halving is peeled off. -/
+theorem pHalvings_of_dvd {p m : ℕ} (hp : 1 < p) (hd : p ∣ m) (hm : 0 < m) :
+    pHalvings p m = 1 + pHalvings p (m / p) := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hm.ne'
+  rw [pHalvings_succ, if_pos ⟨hd, hp⟩]
+
+/-!
+## Part III: The Counter is the p-adic Valuation
+
+The same three-way strong induction now identifies `pHalvings p` with `padicValNat p`
+for every prime `p`. This is the exact generalization of Part I.
+-/
+
+/-- **Main generalization**: for a prime `p`, the p-adic halving count equals the
+    p-adic valuation `padicValNat p n`. -/
+theorem pHalvings_eq_padicValNat {p : ℕ} (hp : p.Prime) (n : ℕ) :
+    pHalvings p n = padicValNat p n := by
+  have hp1 : 1 < p := hp.one_lt
+  haveI : Fact p.Prime := ⟨hp⟩
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rcases Nat.eq_zero_or_pos n with hn | hn
+    · subst hn; simp
+    · by_cases hd : p ∣ n
+      · -- p ∣ n: write n = p * k with k > 0, peel one factor from each side
+        obtain ⟨k, rfl⟩ := hd
+        have hk : 0 < k := by
+          rcases Nat.eq_zero_or_pos k with h | h
+          · simp [h] at hn
+          · exact h
+        rw [pHalvings_of_dvd hp1 ⟨k, rfl⟩ hn, Nat.mul_div_cancel_left k (by omega),
+            ih k (lt_mul_of_one_lt_left hk hp1), padicValNat.mul (by omega) (by omega),
+            padicValNat.self hp1]
+      · -- p ∤ n: both sides are 0
+        rw [pHalvings_eq_zero_of_not_dvd hd, padicValNat.eq_zero_of_not_dvd hd]
+
+/-- The parent's 2-adic algorithm is exactly the `p = 2` instance of the general one. -/
+theorem halvings_eq_pHalvings_two (n : ℕ) : halvings n = pHalvings 2 n := by
+  rw [halvings_eq_padicValNat_two n, pHalvings_eq_padicValNat Nat.prime_two n]
+
+/-!
+## Part IV: Θ(logₚ d) — the Generalized Tightness Bound
+
+For inputs `d = p^k` the counter returns exactly `k`, matching the floor logarithm
+`Nat.log p (p^k) = k`. This is the direct analogue of the parent's Ω(log d) result,
+now for every prime base `p`.
+-/
+
+/-- **Exact step count**: `pHalvings p (p^k) = k`. -/
+theorem pHalvings_prime_pow {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    pHalvings p (p ^ k) = k := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  rw [pHalvings_eq_padicValNat hp, padicValNat.prime_pow]
+
+/-- The count matches the base-`p` floor logarithm on inputs `p^k`. -/
+theorem pHalvings_eq_log_prime_pow {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    pHalvings p (p ^ k) = Nat.log p (p ^ k) := by
+  rw [pHalvings_prime_pow hp, Nat.log_pow hp.one_lt]
+
+/-- **Θ(logₚ d) tightness**: the count and the floor logarithm agree exactly on `p^k`,
+    and both equal `k`. -/
+theorem pHalvings_complexity_tight {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    pHalvings p (p ^ k) = Nat.log p (p ^ k) ∧ Nat.log p (p ^ k) = k :=
+  ⟨pHalvings_eq_log_prime_pow hp k, Nat.log_pow hp.one_lt k⟩
+
+/-- The step count is unbounded: no constant bounds the p-adic halving count. -/
+theorem pHalvings_unbounded {p : ℕ} (hp : p.Prime) (c : ℕ) :
+    ∃ d : ℕ, pHalvings p d ≥ c :=
+  ⟨p ^ c, by rw [pHalvings_prime_pow hp]⟩
+
+/-- Larger powers of `p` require more halvings (monotone in the exponent). -/
+theorem pHalvings_monotone_prime_pow {p : ℕ} (hp : p.Prime) {i j : ℕ} (h : i ≤ j) :
+    pHalvings p (p ^ i) ≤ pHalvings p (p ^ j) := by
+  rw [pHalvings_prime_pow hp, pHalvings_prime_pow hp]; exact h
+
+/-!
+## Part V: Separation of Powers from Non-Powers
+
+Just as `2^k − 1` is odd and rejected immediately, `p^k − 1` is never divisible by `p`
+(for `k ≥ 1`), so the counter rejects it at the first step while accepting `p^k` after
+`k` halvings. This confirms the `Θ(logₚ d)` cost is inherent to the YES-path.
+-/
+
+/-- For `k ≥ 1`, `p ∤ (p^k − 1)`, so the counter returns `0` immediately. -/
+theorem pHalvings_pred_prime_pow {p : ℕ} (hp : p.Prime) {k : ℕ} (hk : 1 ≤ k) :
+    pHalvings p (p ^ k - 1) = 0 := by
+  apply pHalvings_eq_zero_of_not_dvd
+  intro hdvd
+  have hpk : p ∣ p ^ k := dvd_pow_self p (by omega : k ≠ 0)
+  have hge : 1 ≤ p ^ k := Nat.one_le_pow _ _ hp.pos
+  have h1 : p ∣ p ^ k - (p ^ k - 1) := Nat.dvd_sub hpk hdvd
+  rw [show p ^ k - (p ^ k - 1) = 1 from by omega] at h1
+  have := Nat.le_of_dvd one_pos h1
+  have := hp.one_lt
+  omega
+
+/-- The halving count separates `p^k` from `p^k − 1` for `k ≥ 1`. -/
+theorem pHalvings_separates_pred {p : ℕ} (hp : p.Prime) {k : ℕ} (hk : 1 ≤ k) :
+    pHalvings p (p ^ k - 1) < pHalvings p (p ^ k) := by
+  rw [pHalvings_pred_prime_pow hp hk, pHalvings_prime_pow hp]
+  omega
+
+/-!
+## Part VI: Concrete Computations
+
+Numerical verification across several prime bases. (In `example` blocks only.)
+-/
+
+-- p = 2 recovers the parent's halvings values
+example : pHalvings 2 (2 ^ 5) = 5 := by native_decide
+example : halvings 12 = pHalvings 2 12 := by native_decide
+
+-- p = 3
+example : pHalvings 3 (3 ^ 4) = 4 := by native_decide
+example : pHalvings 3 54 = 3 := by native_decide   -- 54 = 2 · 27 = 2 · 3^3
+example : pHalvings 3 10 = 0 := by native_decide    -- 3 ∤ 10
+
+-- p = 5
+example : pHalvings 5 (5 ^ 3) = 3 := by native_decide
+example : pHalvings 5 (5 ^ 3 - 1) = 0 := by native_decide  -- 124 not divisible by 5
+
+end AngleTrisectionOQ03OQ02OQ03

--- a/src/data/proofs/angle-trisection-oq-03-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02-oq-03/annotations.json
@@ -1,0 +1,150 @@
+[
+  {
+    "id": "ann-oq030203-context",
+    "proofId": "angle-trisection-oq-03-oq-02-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "concept",
+    "title": "From an Ad-hoc Counter to a Named Arithmetic Invariant",
+    "content": "The parent entry (OQ-03-OQ-02) defined halvings : ℕ → ℕ, counting how many times 2 divides d before it becomes odd, and proved the constructibility check runs in Θ(log d). Its own keyInsights conjectured that halvings(d) 'is exactly the 2-adic valuation v₂(d)', and the open question asked to generalize the complexity to any prime p. This file answers both: it turns the conjectured identity into a theorem (halvings = padicValNat 2), defines a genuine p-adic halving algorithm pHalvings p, proves pHalvings p = padicValNat p for every prime p, and transfers the tight complexity bound to Θ(logₚ d).",
+    "mathContext": "$\\mathrm{halvings}(d) = v_2(d)$; generalize to $\\mathrm{pHalvings}\\,p = v_p$ and $\\Theta(\\log_p d)$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "p-adic valuation",
+      "constructibility complexity",
+      "well-founded recursion"
+    ],
+    "prerequisites": [
+      "2-adic valuation",
+      "Nat.log"
+    ]
+  },
+  {
+    "id": "ann-oq030203-halvings-v2",
+    "proofId": "angle-trisection-oq-03-oq-02-oq-03",
+    "range": {
+      "startLine": 36,
+      "endLine": 70
+    },
+    "type": "insight",
+    "title": "halvings(n) = padicValNat 2 n: The Central Identification",
+    "content": "The proof is a three-way strong induction on n. For n = 0 both sides are 0. For odd n, halvings_odd gives 0 and padicValNat.eq_zero_of_not_dvd gives 0 (2 ∤ n). For n = 2k with k > 0, the parent's recursion halvings(2k) = 1 + halvings(k) matches padicValNat 2 (2k) = padicValNat 2 2 + padicValNat 2 k = 1 + padicValNat 2 k, using padicValNat.mul (multiplicativity) and padicValNat.self (padicValNat 2 2 = 1). This promotes the parent's bespoke recursion to a standard object with all of Mathlib's valuation API attached.",
+    "mathContext": "$v_2(2k) = v_2(2) + v_2(k) = 1 + v_2(k)$ for $k>0$; odd $\\Rightarrow v_2 = 0$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "strong induction",
+      "padicValNat.mul",
+      "2-adic valuation"
+    ],
+    "prerequisites": [
+      "padicValNat",
+      "strong induction on ℕ"
+    ]
+  },
+  {
+    "id": "ann-oq030203-pcounter",
+    "proofId": "angle-trisection-oq-03-oq-02-oq-03",
+    "range": {
+      "startLine": 71,
+      "endLine": 108
+    },
+    "type": "definition",
+    "title": "pHalvings p: A Terminating p-adic Division Counter",
+    "content": "pHalvings p n repeatedly divides n by p while p ∣ n, counting steps. Well-founded recursion needs (n+1)/p < n+1, which fails when p ≤ 1; baking the guard 1 < p into the branch condition makes Nat.div_lt_self apply, so the definition terminates for every p (returning a harmless 0 when p ≤ 1). Because rfl-unfolding of well-founded recursion is unavailable under the module-system PadicVal import, the equation lemmas pHalvings_zero and pHalvings_succ are proved by rw [pHalvings]. pHalvings_of_dvd peels one step, and pHalvings_eq_zero_of_not_dvd is the immediate-stop case.",
+    "mathContext": "$\\mathrm{pHalvings}\\,p\\,m = 1 + \\mathrm{pHalvings}\\,p\\,(m/p)$ if $p\\mid m,\\,m>0,\\,1<p$; else $0$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "well-founded recursion",
+      "termination_by",
+      "Nat.div_lt_self"
+    ],
+    "prerequisites": [
+      "well-founded recursion in Lean 4"
+    ]
+  },
+  {
+    "id": "ann-oq030203-counter-val",
+    "proofId": "angle-trisection-oq-03-oq-02-oq-03",
+    "range": {
+      "startLine": 109,
+      "endLine": 142
+    },
+    "type": "insight",
+    "title": "pHalvings p = padicValNat p, and halvings = pHalvings 2",
+    "content": "pHalvings_eq_padicValNat runs the identical three-way strong induction as Part I, now for an arbitrary prime p: zero, not-divisible (both 0), and n = p·k (peel one factor via pHalvings_of_dvd on the left and padicValNat.mul + padicValNat.self on the right). No new mathematical idea is needed beyond replacing the concrete halvings_two_mul with multiplicativity of the valuation. Combining Part I and Part III at p = 2 gives halvings = pHalvings 2: the parent's algorithm is literally the p = 2 instance of the general counter.",
+    "mathContext": "$\\mathrm{pHalvings}\\,p = v_p$ for prime $p$; $\\mathrm{halvings} = \\mathrm{pHalvings}\\,2 = v_2$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "p-adic valuation",
+      "generalization",
+      "strong induction"
+    ],
+    "prerequisites": [
+      "padicValNat",
+      "Nat.prime_two"
+    ]
+  },
+  {
+    "id": "ann-oq030203-theta",
+    "proofId": "angle-trisection-oq-03-oq-02-oq-03",
+    "range": {
+      "startLine": 143,
+      "endLine": 177
+    },
+    "type": "concept",
+    "title": "Θ(logₚ d): Tight Step Count on Prime Powers",
+    "content": "Once pHalvings p = padicValNat p, the exact count on p^k is padicValNat.prime_pow = k, and matching the floor logarithm is Nat.log_pow: Nat.log p (p^k) = k. pHalvings_complexity_tight packages both equalities; pHalvings_unbounded (witness d = p^c) shows no constant bounds the count; pHalvings_monotone_prime_pow gives monotonicity in the exponent. This is the exact base-p analogue of the parent's Ω(log d) result — now two Mathlib one-liners after the identification.",
+    "mathContext": "$\\mathrm{pHalvings}\\,p\\,(p^k) = k = \\lfloor\\log_p(p^k)\\rfloor$; unbounded and monotone in $k$.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Nat.log_pow",
+      "padicValNat.prime_pow",
+      "asymptotic tightness"
+    ],
+    "prerequisites": [
+      "Nat.log",
+      "prime powers"
+    ]
+  },
+  {
+    "id": "ann-oq030203-separation",
+    "proofId": "angle-trisection-oq-03-oq-02-oq-03",
+    "range": {
+      "startLine": 178,
+      "endLine": 204
+    },
+    "type": "insight",
+    "title": "YES/NO Separation: p^k − 1 is Rejected in 0 Steps",
+    "content": "For k ≥ 1, p ∤ (p^k − 1): if it did, then since p ∣ p^k we would get p ∣ (p^k − (p^k − 1)) = 1 (via Nat.dvd_sub), forcing p ≤ 1 and contradicting primality. Hence pHalvings p (p^k − 1) = 0, while pHalvings p (p^k) = k, giving the strict separation pHalvings_separates_pred. The parent's 'odd numbers rejected immediately' is exactly the p = 2 shadow of this base-uniform fact.",
+    "mathContext": "$p \\mid p^k,\\ p \\nmid (p^k-1) \\Rightarrow \\mathrm{pHalvings}\\,p\\,(p^k-1)=0 < k$.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Nat.dvd_sub",
+      "divisibility",
+      "separation of instances"
+    ],
+    "prerequisites": [
+      "divisibility in ℕ"
+    ]
+  },
+  {
+    "id": "ann-oq030203-compute",
+    "proofId": "angle-trisection-oq-03-oq-02-oq-03",
+    "range": {
+      "startLine": 205,
+      "endLine": 223
+    },
+    "type": "concept",
+    "title": "Concrete Verifications across Bases 2, 3, 5",
+    "content": "native_decide checks (in example blocks only, so the entry remains 0-axiom): pHalvings 2 (2^5) = 5 and halvings 12 = pHalvings 2 12 (recovering the parent), pHalvings 3 (3^4) = 4, pHalvings 3 54 = 3 (54 = 2·3^3), pHalvings 3 10 = 0 (3 ∤ 10), pHalvings 5 (5^3) = 3, and pHalvings 5 124 = 0 (5 ∤ 124). These confirm the formula and the separation on small inputs across several prime bases.",
+    "mathContext": "$\\mathrm{pHalvings}\\,3\\,54=3$ ($54=2\\cdot3^3$); $\\mathrm{pHalvings}\\,5\\,124=0$ ($5\\nmid124$).",
+    "significance": "low",
+    "relatedConcepts": [
+      "native_decide",
+      "computation"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02-oq-03/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "angle-trisection-oq-03-oq-02-oq-03",
+  "title": "The Halvings Count IS the p-adic Valuation: Θ(logₚ d) for Every Prime",
+  "slug": "angle-trisection-oq-03-oq-02-oq-03",
+  "description": "Identifies the parent's ad-hoc halvings step counter with the 2-adic valuation, halvings(n) = padicValNat 2 n = v₂(n), and generalizes the whole complexity story to an arbitrary prime p. A p-adic halving counter pHalvings p is defined and proved equal to padicValNat p; on inputs p^k it returns exactly k = Nat.log p (p^k), giving the tight Θ(logₚ d) bound, and it separates p^k from the immediately-rejected p^k − 1. Fully machine-checked, no axioms.",
+  "meta": {
+    "author": "Formalized in Lean 4 (researcher-4)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/P-adic_valuation",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/AngleTrisectionOQ03OQ02OQ03.lean",
+    "tags": [
+      "number-theory",
+      "p-adic-valuation",
+      "complexity",
+      "constructibility",
+      "logarithm",
+      "lower-bound",
+      "algorithm-analysis",
+      "prime-powers",
+      "tight-bound"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 223,
+    "theoremCount": 15,
+    "definitionCount": 1
+  },
+  "references": [
+    {
+      "authors": "Gouvêa, Fernando Q.",
+      "title": "p-adic Numbers: An Introduction",
+      "year": "1997",
+      "venue": "Universitext, Springer"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "padicValNat and the p-adic valuation; Mathlib.NumberTheory.Padics.PadicVal.Basic",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The parent entry (OQ-03-OQ-02) proved that the halvings-based constructibility check — repeatedly halve d until it becomes odd, counting the steps — runs in Θ(log d) time, exactly k steps on inputs d = 2^k. Its keyInsights already conjectured that halvings(d) 'is exactly the 2-adic valuation v₂(d)', and the open question asked whether the Θ(log d) result generalizes to an arbitrary prime p, counting p-adic halvings in Θ(logₚ d) steps. This entry answers both. First it makes the conjectured identity a theorem: halvings(n) = padicValNat 2 n, tying the parent's bespoke recursion to Mathlib's standard p-adic valuation. Then it defines a genuine p-adic halving algorithm pHalvings p (divide by p while divisible, count steps) and proves it equals padicValNat p for every prime p — so the parent's function is literally the p = 2 instance. The complexity results (exact count on p^k, floor-log identification, unboundedness, monotonicity, YES/NO separation) then transfer verbatim to every prime base.",
+    "problemStatement": "Let halvings : ℕ → ℕ be the parent's 2-adic step counter, and for a prime p let pHalvings p : ℕ → ℕ count divisions by p while p ∣ n. Prove: (1) halvings(n) = padicValNat 2 n for all n; (2) pHalvings p (n) = padicValNat p n for every prime p; (3) halvings = pHalvings 2; (4) pHalvings p (p^k) = k = Nat.log p (p^k) (the tight Θ(logₚ d) bound); (5) the count is unbounded and monotone in k; (6) pHalvings p (p^k − 1) = 0 < pHalvings p (p^k), the YES/NO separation.",
+    "proofStrategy": "The two identification theorems share one three-way strong induction on n: (i) n = 0, both sides 0; (ii) p ∤ n (odd, when p = 2), both sides 0 via padicValNat.eq_zero_of_not_dvd; (iii) n = p·k with k > 0, peel one factor from each side — pHalvings via the recursion lemma pHalvings_of_dvd, and padicValNat via padicValNat.mul together with padicValNat.self (padicValNat p p = 1). The termination of pHalvings is secured by baking the guard 1 < p into the recursion, so Nat.div_lt_self applies. Because rfl-unfolding of the well-founded recursion is unavailable under the module-system import, the equation lemmas are proved by rw [pHalvings]. The Θ(logₚ d) block reduces pHalvings p (p^k) to padicValNat.prime_pow = k and matches Nat.log via Nat.log_pow. Separation uses that p ∣ p^k but p ∤ (p^k − 1) (else p ∣ 1), via Nat.dvd_sub.",
+    "keyInsights": [
+      "**The bespoke counter is a standard invariant**: the parent's halvings(d) is not an ad-hoc gadget — it is exactly the 2-adic valuation v₂(d) = padicValNat 2 d. Proving this promotes a one-off recursion to a named arithmetic function with all of Mathlib's valuation API behind it.",
+      "**One induction, two theorems**: the 2-adic identity (Part I) and the general p-adic identity (Part III) are the *same* three-way strong induction — zero / not-divisible / divisible-peel-one — instantiated at p = 2 and at an arbitrary prime. The generalization costs no new mathematical idea, only the multiplicativity lemma padicValNat.mul in place of the concrete halvings_two_mul.",
+      "**Termination by guarding the quotient**: defining pHalvings p by well-founded recursion needs (n+1)/p < n+1, which fails for p ≤ 1. Baking 1 < p into the branch condition makes Nat.div_lt_self apply and leaves the degenerate p ≤ 1 as a harmless constant 0 — a clean way to define a parametrized division-counter without a side hypothesis.",
+      "**Θ(logₚ d) is padicValNat.prime_pow + Nat.log_pow**: once pHalvings p = padicValNat p, the exact step count on p^k is padicValNat p (p^k) = k, and matching the floor logarithm is Nat.log p (p^k) = k. The tight bound for every prime base is two Mathlib one-liners after the identification.",
+      "**YES/NO separation is base-uniform**: p^k − 1 ≡ −1 (mod p) is never divisible by p, so pHalvings p (p^k − 1) = 0 while pHalvings p (p^k) = k. The parent's 'odd numbers rejected in 0 steps' is the p = 2 shadow of 'p ∤ (p^k − 1)'."
+    ]
+  },
+  "sections": [
+    {
+      "id": "halvings-is-v2",
+      "title": "The Halvings Count is the 2-adic Valuation",
+      "startLine": 36,
+      "endLine": 70,
+      "summary": "halvings_eq_padicValNat_two: halvings(n) = padicValNat 2 n, by strong induction with a three-way split (zero / odd / n = 2k). halvings_eq_two_adic_valuation restates it with the classical v₂ name.",
+      "mathContext": "$\\mathrm{halvings}(n) = v_2(n) = \\mathrm{padicValNat}\\,2\\,n$. Even step: $v_2(2k) = 1 + v_2(k)$ via $\\mathrm{padicValNat.mul}$ and $\\mathrm{padicValNat.self}$."
+    },
+    {
+      "id": "p-adic-counter",
+      "title": "A p-adic Halving Counter",
+      "startLine": 71,
+      "endLine": 108,
+      "summary": "Defines pHalvings p by well-founded recursion (divide by p while p ∣ n and 1 < p), with the guard 1 < p securing termination via Nat.div_lt_self. Proves the equation lemmas pHalvings_zero, pHalvings_succ, the stop lemma pHalvings_eq_zero_of_not_dvd, and the peel lemma pHalvings_of_dvd.",
+      "mathContext": "$\\mathrm{pHalvings}\\,p\\,m = 1 + \\mathrm{pHalvings}\\,p\\,(m/p)$ when $p \\mid m$, $m>0$, $1<p$; else $0$."
+    },
+    {
+      "id": "counter-is-valuation",
+      "title": "The Counter is the p-adic Valuation",
+      "startLine": 109,
+      "endLine": 142,
+      "summary": "pHalvings_eq_padicValNat: for prime p, pHalvings p n = padicValNat p n (same three-way induction as Part I). halvings_eq_pHalvings_two: the parent's algorithm is the p = 2 instance, halvings = pHalvings 2.",
+      "mathContext": "$\\mathrm{pHalvings}\\,p\\,n = \\mathrm{padicValNat}\\,p\\,n$ for prime $p$; $\\mathrm{halvings} = \\mathrm{pHalvings}\\,2$."
+    },
+    {
+      "id": "theta-logp-tightness",
+      "title": "Θ(logₚ d) — the Generalized Tightness Bound",
+      "startLine": 143,
+      "endLine": 177,
+      "summary": "pHalvings_prime_pow: pHalvings p (p^k) = k (via padicValNat.prime_pow). pHalvings_eq_log_prime_pow and pHalvings_complexity_tight match Nat.log p (p^k) = k. pHalvings_unbounded and pHalvings_monotone_prime_pow give the unbounded, monotone step count.",
+      "mathContext": "$\\mathrm{pHalvings}\\,p\\,(p^k) = k = \\lfloor \\log_p(p^k) \\rfloor$: the count is $\\Theta(\\log_p d)$ on $d = p^k$."
+    },
+    {
+      "id": "separation",
+      "title": "Separation: Prime Powers vs Their Predecessors",
+      "startLine": 178,
+      "endLine": 204,
+      "summary": "pHalvings_pred_prime_pow: pHalvings p (p^k − 1) = 0 for k ≥ 1, since p ∤ (p^k − 1) (else p ∣ 1). pHalvings_separates_pred: pHalvings p (p^k − 1) < pHalvings p (p^k).",
+      "mathContext": "$p \\nmid (p^k - 1)$, so $\\mathrm{pHalvings}\\,p\\,(p^k-1) = 0 < k = \\mathrm{pHalvings}\\,p\\,(p^k)$."
+    },
+    {
+      "id": "concrete-computations",
+      "title": "Concrete Computations",
+      "startLine": 205,
+      "endLine": 223,
+      "summary": "native_decide verification across bases p = 2, 3, 5: pHalvings 2 (2^5) = 5, halvings 12 = pHalvings 2 12, pHalvings 3 (3^4) = 4, pHalvings 3 54 = 3, pHalvings 3 10 = 0, pHalvings 5 (5^3) = 3, pHalvings 5 (5^3 − 1) = 0. (In example blocks only.)",
+      "mathContext": "$\\mathrm{pHalvings}\\,3\\,54 = 3$ since $54 = 2 \\cdot 3^3$; $\\mathrm{pHalvings}\\,5\\,124 = 0$ since $5 \\nmid 124$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry proves that the parent's halvings step counter is exactly the 2-adic valuation padicValNat 2, defines a p-adic halving counter pHalvings p and proves it equals padicValNat p for every prime p, and transfers the whole Θ(log d) complexity picture to Θ(logₚ d) for arbitrary prime bases. All results are fully machine-checked with no axioms or sorries.",
+    "implications": "Recasting the parent's bespoke recursion as a named p-adic valuation makes the complexity claim structural rather than ad-hoc: the number of halvings is an intrinsic arithmetic invariant, v_p(d), and its Θ(logₚ d) behaviour on prime powers is a direct consequence of padicValNat.prime_pow and Nat.log_pow. The p = 2 case recovers the parent exactly, so the constructibility-check lower bound is one slice of a base-uniform phenomenon. The separation pHalvings p (p^k − 1) = 0 < pHalvings p (p^k) shows the YES/NO cost gap persists for every prime, connecting the algorithmic lower bound to the p-adic Gauss–Wantzel divisibility structure d | 2^k · 3 · 5 · 17 · ⋯ that governs constructible polygons.",
+    "openQuestions": [
+      "The counter equals padicValNat p only for prime p. What is pHalvings p n for composite p, and how does it relate to the largest power of p dividing n versus the p-adic valuations of p's prime factors?",
+      "Can the base-uniform Θ(logₚ d) bound be assembled into a single statement about the full radical-tower step count for the Gauss–Wantzel condition, where d is stripped of all Fermat-prime factors simultaneously rather than one prime at a time?"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/AngleTrisectionOQ03OQ02OQ03.lean",
+    "imports": [
+      "Mathlib.Data.Nat.Log",
+      "Mathlib.NumberTheory.Padics.PadicVal.Basic",
+      "Mathlib.Tactic",
+      "Proofs.AngleTrisectionOQ03OQ02"
+    ],
+    "opens": [
+      "AngleTrisectionOQ03OQ02",
+      "Nat"
+    ],
+    "namespace": "AngleTrisectionOQ03OQ02OQ03",
+    "lineCount": 223,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 15
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-03-oq-02",
+      "relationship": "parent",
+      "description": "The parent proves halvings(2^k) = k and the Ω(log d) lower bound; this entry identifies halvings with padicValNat 2 and generalizes the whole story to every prime p"
+    },
+    {
+      "targetId": "angle-trisection-oq-03",
+      "relationship": "related",
+      "description": "OQ-03 builds the O(log d) constructibility algorithm whose step count is the halvings function analyzed here as a p-adic valuation"
+    },
+    {
+      "targetId": "angle-trisection",
+      "relationship": "ancestor",
+      "description": "The root angle-trisection proof establishes constructibility via Galois theory; the p-adic valuation viewpoint underlies the Gauss–Wantzel divisibility condition on constructible polygons"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry answering the parent's open question OQ-03-OQ-02-OQ-03:
*"The halvings function is exactly the 2-adic valuation v₂(d). Can the Θ(log d) complexity result be generalized to any prime p?"*

Both parts are proved:

1. **Identification** — the parent's ad-hoc step counter is a standard invariant:
   `halvings n = padicValNat 2 n` (= v₂(n)).
2. **Generalization** — a genuine p-adic halving counter `pHalvings p` is defined and proved equal to `padicValNat p` for every prime p; the parent's function is literally the p = 2 instance (`halvings = pHalvings 2`), and the tight bound `pHalvings p (p^k) = k = Nat.log p (p^k)` transfers to every prime base (Θ(logₚ d)), together with unboundedness, monotonicity, and the YES/NO separation `pHalvings p (p^k − 1) = 0 < pHalvings p (p^k)`.

## Proof design

- One three-way strong induction (zero / not-divisible / peel-one-factor) serves both the 2-adic and the general p-adic identity; the even step is `padicValNat.mul` + `padicValNat.self` in place of the parent's concrete `halvings_two_mul`.
- `pHalvings p` terminates because the guard `1 < p` in the recursion makes `Nat.div_lt_self` apply; the degenerate `p ≤ 1` is a harmless constant 0.
- Θ(logₚ d) reduces to `padicValNat.prime_pow` and `Nat.log_pow`.

## Verification

- **15 theorems, 1 definition, 223 lines, 0 sorries, 0 axioms.**
- `native_decide` appears only in `example` blocks (bases 2, 3, 5), so the entry is 0-axiom.
- Verified with `lake env lean` against Mathlib via a self-contained copy that inlines the parent's `halvings` lemmas (identical statements). The Docker wrapper and a full parent-chain rebuild were unavailable this session due to host disk pressure / a corrupted containerd blob store; the real file differs from the verified copy only by importing the parent's already-compiled `halvings` lemmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)