### PR TITLE
research(combinations-formula-oq-06-oq-02-oq-02): falling-factorial closed forms for the descending simplicial family [VERIFIED, 0-axiom, +14thm, new entry]

### DIFF
--- a/proofs/Proofs/CombinationsFigurateDescClosedForm.lean
+++ b/proofs/Proofs/CombinationsFigurateDescClosedForm.lean
@@ -1,0 +1,158 @@
+import Mathlib
+
+/-
+# Uniform Falling-Factorial Closed Forms for the Descending Simplicial Family
+
+## Open Question (combinations-formula-oq-06-oq-02, OQ-02)
+
+The parent entry `combinations-formula-oq-06-oq-02` derived the *ascending* figurate closed
+forms uniformly in the dimension `k` from the single identity
+
+  `k ! · S(k, n) = n·(n+1)·⋯·(n+k-1) = ascFactorial n k`,      `S(k, n) = multichoose n k`,
+
+and asked (OQ-02): **can the same `k! · (coefficient) = factorial` engine be pushed to the
+falling-factorial `descFactorial` form on the diagonal `(n choose k)`, giving a uniform closed
+form for the ascending *and* the descending simplicial families at once?**
+
+## Contribution
+
+Yes — the descending family is the exact mirror of the ascending one, obtained by swapping the
+ascending factorial `ascFactorial` for the descending factorial `descFactorial` and the
+multiset coefficient `multichoose n k = C(n+k-1, k)` for the ordinary binomial coefficient
+`D(k, n) = C(n, k)`.  The engine is the single identity
+
+  `k ! · D(k, n) = n·(n-1)·⋯·(n-k+1) = descFactorial n k`      (`factorial_mul_D`)
+
+which is nothing but the classical `choose ↔ descending-factorial` bridge
+(`Nat.descFactorial_eq_factorial_mul_choose`).  It is a *uniform* statement covering the whole
+descending tower; its proof is a one-line rewrite, with no per-`k` induction.  The division form
+
+  `D(k, n) = descFactorial n k / k !`                          (`D_closed`)
+
+is its immediate consequence.  Specializing `k` (with natural-number subtraction, honest since
+`descFactorial n k = n(n-1)⋯(n-k+1)` truncates to `0` exactly when `k > n`):
+
+* `k = 2`: `2 · D(2, n) = n(n-1)`,          `D(2, n) = n(n-1)/2`
+* `k = 3`: `6 · D(3, n) = n(n-1)(n-2)`,     `D(3, n) = n(n-1)(n-2)/6`
+* `k = 4`: `24 · D(4, n) = n(n-1)(n-2)(n-3)`, `D(4, n) = n(n-1)(n-2)(n-3)/24`
+
+Placed beside the parent's ascending forms, the two entries exhibit the *same* one-line engine
+`k! · coefficient = factorial` producing both simplicial families: the ascending
+(rising-factorial, multiset) rungs and the descending (falling-factorial, ordinary binomial)
+rungs, with no induction on `n` or `k` anywhere.
+
+## Mathematical Context
+
+`D(k, n) = C(n, k)` counts the `k`-subsets of `{1, …, n}`; the product `n(n-1)⋯(n-k+1)/k!` is
+the descending (falling-factorial) form of the binomial coefficient.  Where the ascending
+entry read each figurate closed form off `ascFactorial`, this entry reads each descending
+closed form off `descFactorial` — the induction that would normally establish each such closed
+form is absorbed once and for all into Mathlib's `descFactorial ↔ choose` lemma, exactly
+mirroring `combinations-formula-oq-06-oq-02`.
+-/
+
+namespace CombinationsFigurateDescClosedForm
+
+open Nat
+
+/-- The descending simplicial coefficient `D(k, n) = C(n, k)`: the number of `k`-subsets of
+`{1, …, n}`.  `D(1, n) = n`, `D(2, n)` the "descending triangular" `n(n-1)/2`, etc. -/
+def D (k n : ℕ) : ℕ := n.choose k
+
+/-- `D(k, n) = C(n, k)`: definitional restatement, the descending mirror of `S_eq_choose`. -/
+theorem D_eq_choose (k n : ℕ) : D k n = n.choose k := rfl
+
+/-- **Uniform falling-factorial closed form.** For every dimension `k`, `k! · D(k, n)` equals
+the descending factorial `n(n-1)⋯(n-k+1)`.  A single statement covering the entire descending
+simplicial tower; the proof is the `choose ↔ descending-factorial` bridge, no per-`k`
+induction.  This is the exact mirror of the parent's `factorial_mul_S`. -/
+theorem factorial_mul_D (k n : ℕ) : k ! * D k n = n.descFactorial k := by
+  rw [D_eq_choose]
+  exact (Nat.descFactorial_eq_factorial_mul_choose n k).symm
+
+/-- **Division form of the uniform closed form:** `D(k, n) = n(n-1)⋯(n-k+1) / k!`, for every
+dimension `k` simultaneously. -/
+theorem D_closed (k n : ℕ) : D k n = n.descFactorial k / k ! := by
+  rw [D_eq_choose]
+  rw [eq_comm, Nat.div_eq_iff_eq_mul_left (Nat.factorial_pos k) (Nat.factorial_dvd_descFactorial n k)]
+  rw [mul_comm]
+  exact Nat.descFactorial_eq_factorial_mul_choose n k
+
+/-!
+### Evaluating the finite product `descFactorial n k` at concrete dimensions
+
+Each is three-or-fewer `descFactorial_succ` unfoldings closed by `ring` — no induction. -/
+
+/-- `n(n-1)`: the descending factorial at dimension 2. -/
+theorem descFactorial_two (n : ℕ) : n.descFactorial 2 = n * (n - 1) := by
+  have h2 : n.descFactorial 2 = (n - 1) * n.descFactorial 1 := Nat.descFactorial_succ n 1
+  rw [h2, Nat.descFactorial_one]; ring
+
+/-- `n(n-1)(n-2)`: the descending factorial at dimension 3. -/
+theorem descFactorial_three (n : ℕ) : n.descFactorial 3 = n * (n - 1) * (n - 2) := by
+  have h3 : n.descFactorial 3 = (n - 2) * n.descFactorial 2 := Nat.descFactorial_succ n 2
+  rw [h3, descFactorial_two]; ring
+
+/-- `n(n-1)(n-2)(n-3)`: the descending factorial at dimension 4. -/
+theorem descFactorial_four (n : ℕ) :
+    n.descFactorial 4 = n * (n - 1) * (n - 2) * (n - 3) := by
+  have h4 : n.descFactorial 4 = (n - 3) * n.descFactorial 3 := Nat.descFactorial_succ n 3
+  rw [h4, descFactorial_three]; ring
+
+/-!
+### Multiplied closed forms (division-free)
+
+The cleanest, most honest statements: no natural-number division truncation is involved. -/
+
+/-- Descending triangular rung: `2 · D(2, n) = n(n-1)`. -/
+theorem two_mul_D_two (n : ℕ) : 2 * D 2 n = n * (n - 1) := by
+  have h := factorial_mul_D 2 n
+  rwa [descFactorial_two, show (2 : ℕ)! = 2 from rfl] at h
+
+/-- Descending tetrahedral rung: `6 · D(3, n) = n(n-1)(n-2)`. -/
+theorem six_mul_D_three (n : ℕ) : 6 * D 3 n = n * (n - 1) * (n - 2) := by
+  have h := factorial_mul_D 3 n
+  rwa [descFactorial_three, show (3 : ℕ)! = 6 from rfl] at h
+
+/-- Descending pentatope rung: `24 · D(4, n) = n(n-1)(n-2)(n-3)`. -/
+theorem twentyfour_mul_D_four (n : ℕ) :
+    24 * D 4 n = n * (n - 1) * (n - 2) * (n - 3) := by
+  have h := factorial_mul_D 4 n
+  rwa [descFactorial_four, show (4 : ℕ)! = 24 from rfl] at h
+
+/-!
+### Divided closed forms
+
+The familiar textbook shapes, recovered by dividing the multiplied forms. -/
+
+/-- Descending triangular closed form: `D(2, n) = n(n-1)/2`. -/
+theorem D_two_closed (n : ℕ) : D 2 n = n * (n - 1) / 2 :=
+  Nat.eq_div_of_mul_eq_right (by norm_num) (two_mul_D_two n)
+
+/-- Descending tetrahedral closed form: `D(3, n) = n(n-1)(n-2)/6`. -/
+theorem D_three_closed (n : ℕ) : D 3 n = n * (n - 1) * (n - 2) / 6 :=
+  Nat.eq_div_of_mul_eq_right (by norm_num) (six_mul_D_three n)
+
+/-- Descending pentatope closed form: `D(4, n) = n(n-1)(n-2)(n-3)/24`. -/
+theorem D_four_closed (n : ℕ) : D 4 n = n * (n - 1) * (n - 2) * (n - 3) / 24 :=
+  Nat.eq_div_of_mul_eq_right (by norm_num) (twentyfour_mul_D_four n)
+
+/-!
+### The `k = 1` base rung and concrete sanity checks -/
+
+/-- Linear rung: `D(1, n) = n`. -/
+@[simp] theorem D_one (n : ℕ) : D 1 n = n := Nat.choose_one_right n
+
+/-- `D(k, n) = 0` for `k > n`: the descending family truncates, unlike the ascending one. -/
+theorem D_eq_zero_of_lt {k n : ℕ} (h : n < k) : D k n = 0 := Nat.choose_eq_zero_of_lt h
+
+/-- `C(6, 3) = 6·5·4/6 = 20`. -/
+example : D 3 6 = 20 := by rw [D_three_closed]
+
+/-- `C(6, 4) = 6·5·4·3/24 = 15`. -/
+example : D 4 6 = 15 := by rw [D_four_closed]
+
+/-- `C(5, 2) = 5·4/2 = 10`. -/
+example : D 2 5 = 10 := by rw [D_two_closed]
+
+end CombinationsFigurateDescClosedForm

--- a/src/data/proofs/combinations-formula-oq-06-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-06-oq-02-oq-02/annotations.json
@@ -1,0 +1,136 @@
+[
+  {
+    "id": "figdesc-oq060202-header",
+    "proofId": "combinations-formula-oq-06-oq-02-oq-02",
+    "range": { "startLine": 3, "endLine": 52 },
+    "type": "concept",
+    "title": "Pushing the k!·coefficient=factorial engine to the descending simplicial family",
+    "content": "The header states the parent's open question. The parent combinations-formula-oq-06-oq-02 derived the ascending figurate closed forms — triangular n(n+1)/2, tetrahedral n(n+1)(n+2)/6, pentatope n(n+1)(n+2)(n+3)/24 — uniformly in the dimension k from k! · S(k,n) = ascFactorial n k, reading Mathlib's choose ↔ ascending-factorial bridge through the multiset coefficient S(k,n) = C(n+k−1,k). OQ-02 asks whether the same k!·coefficient=factorial engine reaches the falling-factorial descFactorial form on the ordinary binomial diagonal C(n,k), giving a uniform closed form for both simplicial families at once. This entry answers yes, by the exact mirror construction. 0 axioms, 0 sorries.",
+    "mathContext": "$D(k,n) = \\binom{n}{k};\\quad D(2,n)=\\tfrac{n(n-1)}{2},\\ D(3,n)=\\tfrac{n(n-1)(n-2)}{6},\\ D(4,n)=\\tfrac{n(n-1)(n-2)(n-3)}{24}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "figurate numbers",
+      "closed form",
+      "falling factorial",
+      "binomial coefficient",
+      "simplicial numbers"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "Nat.descFactorial",
+      "the parent ascending figurate-closed-form entry"
+    ]
+  },
+  {
+    "id": "figdesc-oq060202-family-object",
+    "proofId": "combinations-formula-oq-06-oq-02-oq-02",
+    "range": { "startLine": 54, "endLine": 63 },
+    "type": "definition",
+    "title": "The descending family object D(k,n) = C(n,k)",
+    "content": "def D (k n) := n.choose k is the descending simplicial coefficient — the number of k-subsets of {1,…,n}, the k-th diagonal of Pascal's triangle read the ordinary way. D_eq_choose : D(k,n) = C(n,k) is the definitional restatement bridging to the binomial form. This is the exact mirror of the parent's def S := multichoose n k = C(n+k−1,k): the ordinary coefficient C(n,k) is the falling-factorial normalization of the binomial, the multiset coefficient C(n+k−1,k) the rising-factorial one.",
+    "mathContext": "$D(k,n) := \\binom{n}{k}$, the number of $k$-subsets of an $n$-set",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "binomial coefficient",
+      "subset counting",
+      "Pascal's triangle diagonal"
+    ],
+    "prerequisites": [
+      "Nat.choose"
+    ]
+  },
+  {
+    "id": "figdesc-oq060202-uniform-closed-form",
+    "proofId": "combinations-formula-oq-06-oq-02-oq-02",
+    "range": { "startLine": 65, "endLine": 79 },
+    "type": "key-step",
+    "title": "The uniform falling-factorial closed form: k! · D(k,n) = descFactorial n k",
+    "content": "factorial_mul_D : k! · D(k,n) = descFactorial n k = n(n−1)⋯(n−k+1) is the whole content of the entry — a single statement covering every dimension k of the descending tower with no per-k induction. Its proof is one rewrite: Mathlib's Nat.descFactorial_eq_factorial_mul_choose (n.descFactorial k = k! · n.choose k) read backwards through D_eq_choose. The division form D_closed : D(k,n) = descFactorial n k / k! follows via Nat.div_eq_iff_eq_mul_left using the divisibility Nat.factorial_dvd_descFactorial. This mirrors the parent's factorial_mul_S / S_closed exactly, with descFactorial in place of ascFactorial.",
+    "mathContext": "$k!\\,\\binom{n}{k} = n^{\\underline{k}} = n(n-1)\\cdots(n-k+1)$",
+    "significance": "central",
+    "relatedConcepts": [
+      "falling factorial",
+      "descending factorial",
+      "closed form",
+      "choose–descFactorial bridge"
+    ],
+    "prerequisites": [
+      "Nat.descFactorial_eq_factorial_mul_choose",
+      "Nat.factorial_dvd_descFactorial"
+    ]
+  },
+  {
+    "id": "figdesc-oq060202-descfactorial-evals",
+    "proofId": "combinations-formula-oq-06-oq-02-oq-02",
+    "range": { "startLine": 81, "endLine": 100 },
+    "type": "technique",
+    "title": "Evaluating the finite descending-factorial product without induction",
+    "content": "descFactorial_two/three/four : descFactorial n k = n(n−1), n(n−1)(n−2), n(n−1)(n−2)(n−3) for k = 2,3,4. Each is at most three Nat.descFactorial_succ unfoldings (each peeling one factor n−i) closed by ring. The subtle point is natural-number subtraction: the unfolding is taken down to descFactorial n 1 (via Nat.descFactorial_one) rather than descFactorial n 0, so the artifact term n−0 — which ring cannot unify with n — never appears; ring then closes each product treating (n−1),(n−2),(n−3) as atoms. No induction on n or k.",
+    "mathContext": "$n^{\\underline{k}} = \\prod_{i=0}^{k-1}(n-i)$ evaluated at $k=2,3,4$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "descending factorial",
+      "natural-number subtraction",
+      "finite product"
+    ],
+    "prerequisites": [
+      "Nat.descFactorial_succ",
+      "Nat.descFactorial_one"
+    ]
+  },
+  {
+    "id": "figdesc-oq060202-multiplied-forms",
+    "proofId": "combinations-formula-oq-06-oq-02-oq-02",
+    "range": { "startLine": 102, "endLine": 121 },
+    "type": "key-step",
+    "title": "Multiplied closed forms: the honest, division-free statements",
+    "content": "two_mul_D_two : 2·D(2,n) = n(n−1); six_mul_D_three : 6·D(3,n) = n(n−1)(n−2); twentyfour_mul_D_four : 24·D(4,n) = n(n−1)(n−2)(n−3). These are exact natural-number equations — no truncating division appears — obtained by combining factorial_mul_D with the concrete descFactorial evaluations and the numeric factorial values 2! = 2, 3! = 6, 4! = 24. They are the most honest form of the descending closed forms and the descending mirror of the parent's two/six/twentyfour_mul_S family.",
+    "mathContext": "$2\\binom{n}{2}=n(n-1),\\ 6\\binom{n}{3}=n(n-1)(n-2),\\ 24\\binom{n}{4}=n(n-1)(n-2)(n-3)$",
+    "significance": "central",
+    "relatedConcepts": [
+      "closed form",
+      "division-free identity",
+      "descending simplicial numbers"
+    ],
+    "prerequisites": [
+      "factorial_mul_D"
+    ]
+  },
+  {
+    "id": "figdesc-oq060202-divided-forms",
+    "proofId": "combinations-formula-oq-06-oq-02-oq-02",
+    "range": { "startLine": 123, "endLine": 138 },
+    "type": "key-step",
+    "title": "Divided closed forms: the textbook descending shapes",
+    "content": "D_two_closed : D(2,n) = n(n−1)/2; D_three_closed : D(3,n) = n(n−1)(n−2)/6; D_four_closed : D(4,n) = n(n−1)(n−2)(n−3)/24. Each is a one-line corollary of the corresponding multiplied form via Nat.eq_div_of_mul_eq_right, whose divisibility side-condition is discharged by norm_num. These are the familiar textbook falling-factorial shapes of the binomial coefficient, recovered from the same uniform engine.",
+    "mathContext": "$\\binom{n}{k} = \\dfrac{n(n-1)\\cdots(n-k+1)}{k!}$ at $k=2,3,4$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "closed form",
+      "natural-number division",
+      "textbook binomial shape"
+    ],
+    "prerequisites": [
+      "Nat.eq_div_of_mul_eq_right"
+    ]
+  },
+  {
+    "id": "figdesc-oq060202-base-and-checks",
+    "proofId": "combinations-formula-oq-06-oq-02-oq-02",
+    "range": { "startLine": 140, "endLine": 158 },
+    "type": "example",
+    "title": "The linear base rung, the truncation, and concrete sanity checks",
+    "content": "D_one : D(1,n) = n (the linear rung, Nat.choose_one_right). D_eq_zero_of_lt : D(k,n) = 0 for k > n (Nat.choose_eq_zero_of_lt) — the descending family truncates, because you cannot choose more than n elements, the structural feature separating it from the parent's never-vanishing ascending multiset family. Concrete kernel checks C(6,3)=20, C(6,4)=15, C(5,2)=10 route through the divided closed forms (rfl, not native_decide), confirming the shapes on numbers.",
+    "mathContext": "$\\binom{n}{1}=n,\\quad \\binom{n}{k}=0\\ (k>n);\\quad \\binom{6}{3}=20,\\ \\binom{6}{4}=15,\\ \\binom{5}{2}=10$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "base case",
+      "truncation",
+      "sanity check"
+    ],
+    "prerequisites": [
+      "Nat.choose_one_right",
+      "Nat.choose_eq_zero_of_lt"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-06-oq-02-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-06-oq-02-oq-02/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "combinations-formula-oq-06-oq-02-oq-02",
+  "title": "Uniform Falling-Factorial Closed Forms for the Descending Simplicial Family",
+  "slug": "combinations-formula-oq-06-oq-02-oq-02",
+  "description": "Answers the parent's second open question: can the same k! · (coefficient) = factorial engine that produced the ascending figurate closed forms be pushed to the falling-factorial descFactorial form on the ordinary binomial diagonal, giving a uniform closed form for the ascending and descending simplicial families at once? Yes — the descending family is the exact mirror, obtained by swapping the ascending factorial ascFactorial for the descending factorial descFactorial and the multiset coefficient multichoose n k for the ordinary binomial D(k,n) = C(n,k). The engine is one uniform identity, factorial_mul_D : k! · D(k,n) = descFactorial n k = n(n-1)⋯(n-k+1), the choose ↔ descending-factorial bridge (Nat.descFactorial_eq_factorial_mul_choose); the division form D(k,n) = descFactorial n k / k! is its immediate consequence. Both hold for every dimension k at once with no induction. Specializing k gives the descending triangular (2·D = n(n-1)), tetrahedral (6·D = n(n-1)(n-2)), and pentatope (24·D = n(n-1)(n-2)(n-3)) closed forms in both multiplied and divided shapes. Placed beside the parent combinations-formula-oq-06-oq-02, the two entries exhibit the same one-line engine k! · coefficient = factorial producing both simplicial families.",
+  "meta": {
+    "author": "Lean Genius researcher-10",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFigurateDescClosedForm.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 158,
+    "theoremCount": 14,
+    "definitionCount": 1,
+    "assumptions": "None. All identities hold for every natural number n and every dimension k and are fully machine-checked. The multiplied closed forms are exact natural-number equations; the divided closed forms and the k>n truncation D(k,n)=0 are honest natural-number statements. The concrete sanity checks close by kernel reduction (rfl through the divided closed forms), not native_decide, so there is no Lean.ofReduceBool dependency; #print axioms reports only the foundational axioms propext, Classical.choice, Quot.sound.",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "figurate-numbers",
+      "simplicial-numbers",
+      "descending-factorial",
+      "falling-factorial",
+      "closed-form",
+      "tetrahedral-numbers",
+      "pentatope-numbers",
+      "triangular-numbers",
+      "subsets"
+    ],
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "factorial_mul_D: the uniform falling-factorial closed form k! · D(k,n) = descFactorial n k = n(n-1)⋯(n-k+1), a single statement covering the entire descending simplicial tower with no per-k induction — obtained by reading Mathlib's choose ↔ descending-factorial bridge (Nat.descFactorial_eq_factorial_mul_choose) through D(k,n) = C(n,k); the exact descending mirror of the parent's factorial_mul_S, answering the parent's OQ-02 which asked whether the k!·coefficient=factorial engine extends to the descFactorial form",
+      "D_closed: the division form D(k,n) = descFactorial n k / k! for every dimension k simultaneously, the falling-factorial closed form of the ordinary binomial coefficient",
+      "six_mul_D_three / D_three_closed: the descending tetrahedral closed forms 6·D(3,n) = n(n-1)(n-2) and D(3,n) = n(n-1)(n-2)/6, in both division-free and textbook shapes",
+      "twentyfour_mul_D_four / D_four_closed: the descending pentatope closed forms 24·D(4,n) = n(n-1)(n-2)(n-3) and D(4,n) = n(n-1)(n-2)(n-3)/24, obtained as the k=4 specialization",
+      "two_mul_D_two / D_two_closed: the descending triangular closed forms 2·D(2,n) = n(n-1) and D(2,n) = n(n-1)/2 recovered from the same uniform engine",
+      "descFactorial_two / descFactorial_three / descFactorial_four: the finite descending-factorial products n(n-1), n(n-1)(n-2), n(n-1)(n-2)(n-3) evaluated for concrete dimensions by three-or-fewer Nat.descFactorial_succ unfoldings closed by ring — no induction on n and no induction on k",
+      "D_eq_zero_of_lt: the descending family truncates, D(k,n) = 0 for k > n (Nat.choose_eq_zero_of_lt), the structural feature distinguishing the descending simplicial family from the never-vanishing ascending (multiset) family"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFigurateDescClosedForm.lean",
+    "namespace": "CombinationsFigurateDescClosedForm",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 158,
+    "theoremCount": 14,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The parent entry combinations-formula-oq-06-oq-02 derived the ascending simplicial (figurate) closed forms — triangular n(n+1)/2, tetrahedral n(n+1)(n+2)/6, pentatope n(n+1)(n+2)(n+3)/24 — uniformly in the dimension k from the single identity k! · S(k,n) = ascFactorial n k, reading Mathlib's choose ↔ ascending-factorial bridge through the multiset coefficient S(k,n) = C(n+k-1,k). Its second open question asked whether the same engine reaches the descending side: the falling factorial descFactorial n k = n(n-1)⋯(n-k+1) and the ordinary binomial diagonal C(n,k). Ascending and descending factorials are the two classical products attached to a binomial coefficient — the multiset coefficient C(n+k-1,k) is the rising-factorial normalization, the ordinary coefficient C(n,k) the falling-factorial one — and a symmetric treatment should produce both from one lemma each.",
+    "problemStatement": "Open question (combinations-formula-oq-06-oq-02, OQ-02): can the same k! · (coefficient) = factorial engine be pushed to the falling-factorial descFactorial form on the diagonal C(n,k), giving a uniform closed form for both the ascending and the descending simplicial families at once?",
+    "proofStrategy": "Define the descending simplicial coefficient D(k,n) := n.choose k, the number of k-subsets of {1,…,n}. The single engine is factorial_mul_D : k! · D(k,n) = descFactorial n k, which is Mathlib's Nat.descFactorial_eq_factorial_mul_choose (n.descFactorial k = k! · n.choose k) read backwards — one rewrite, valid for every k, with no induction. Dividing by k! gives D_closed : D(k,n) = descFactorial n k / k! via Nat.div_eq_iff_eq_mul_left with the divisibility Nat.factorial_dvd_descFactorial. To exhibit the classical shapes, the finite product descFactorial n k is evaluated at concrete dimensions k = 2,3,4 by unfolding Nat.descFactorial_succ three-or-fewer times and closing with ring (descFactorial_two/three/four, using Nat.descFactorial_one to avoid the n-0 truncation artifact); combined with factorial_mul_D and the numeric values 2! = 2, 3! = 6, 4! = 24 this yields the multiplied closed forms 2·D(2,n) = n(n-1), 6·D(3,n) = n(n-1)(n-2), 24·D(4,n) = n(n-1)(n-2)(n-3). Dividing each with Nat.eq_div_of_mul_eq_right gives the textbook forms n(n-1)/2, n(n-1)(n-2)/6, n(n-1)(n-2)(n-3)/24. The induction that would classically prove each descending closed form is absorbed once and for all into the Mathlib descFactorial ↔ choose lemma, exactly mirroring the parent's use of the ascFactorial ↔ choose lemma.",
+    "keyInsights": [
+      "The descending tower's closed form is a single Mathlib lemma in disguise: Nat.descFactorial_eq_factorial_mul_choose says n.descFactorial k = k! · C(n,k), i.e. k! · D(k,n) = n(n-1)⋯(n-k+1). Reading it through D(k,n) = C(n,k) settles every dimension of the descending family at once, precisely as Nat.ascFactorial_eq_factorial_mul_choose' did for the ascending family — the two entries are the two halves of one symmetric picture.",
+      "Stating the closed form in multiplied (division-free) shape k! · D(k,n) = descFactorial n k is the honest form: no truncating natural-number division appears, so the identity is an exact equation of naturals. The familiar divided shapes n(n-1)/2, n(n-1)(n-2)/6, … are a one-line corollary via Nat.eq_div_of_mul_eq_right, with the divisibility guaranteed by the multiplied identity itself.",
+      "Evaluating descFactorial at a concrete dimension needs care with natural subtraction: unfolding Nat.descFactorial_succ down to descFactorial n 1 (rather than descFactorial n 0) sidesteps the n-0 term that ring cannot unify with n, after which ring closes each product treating (n-1),(n-2),(n-3) as atoms — no induction on n or k.",
+      "The descending family truncates where the ascending one does not: D(k,n) = C(n,k) = 0 for k > n (D_eq_zero_of_lt), because you cannot choose more than n elements, whereas the ascending multiset coefficient S(k,n) = C(n+k-1,k) stays positive for all n ≥ 1. This vanishing is the structural signature separating the falling-factorial (subset) family from the rising-factorial (multiset) family the parent treated."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 3,
+      "endLine": 52,
+      "summary": "Header stating the parent's open question (combinations-formula-oq-06-oq-02 OQ-02): push the k!·coefficient=factorial engine to the falling-factorial descFactorial form on the binomial diagonal C(n,k), giving a uniform closed form for the ascending and descending simplicial families at once."
+    },
+    {
+      "id": "family-object",
+      "title": "The Descending Family Object",
+      "startLine": 54,
+      "endLine": 63,
+      "summary": "def D (k n) := n.choose k, the descending simplicial coefficient counting k-subsets of {1,…,n}, with D_eq_choose : D(k,n) = C(n,k) — the descending mirror of the parent's def S := multichoose n k."
+    },
+    {
+      "id": "uniform-closed-form",
+      "title": "The Uniform Falling-Factorial Closed Form",
+      "startLine": 65,
+      "endLine": 79,
+      "summary": "factorial_mul_D : k! · D(k,n) = descFactorial n k = n(n-1)⋯(n-k+1), the single statement covering the whole descending tower with no per-k induction (Nat.descFactorial_eq_factorial_mul_choose); and D_closed : D(k,n) = descFactorial n k / k! its division form (Nat.factorial_dvd_descFactorial)."
+    },
+    {
+      "id": "descfactorial-evals",
+      "title": "Evaluating the Finite Product at Concrete Dimensions",
+      "startLine": 81,
+      "endLine": 100,
+      "summary": "descFactorial_two/three/four : descFactorial n k = n(n-1), n(n-1)(n-2), n(n-1)(n-2)(n-3) for k = 2,3,4, each three-or-fewer Nat.descFactorial_succ unfoldings closed by ring — no induction on n or k."
+    },
+    {
+      "id": "multiplied-forms",
+      "title": "Multiplied Closed Forms (Division-Free)",
+      "startLine": 102,
+      "endLine": 121,
+      "summary": "two_mul_D_two : 2·D(2,n) = n(n-1); six_mul_D_three : 6·D(3,n) = n(n-1)(n-2); twentyfour_mul_D_four : 24·D(4,n) = n(n-1)(n-2)(n-3) — exact natural-number equations, no truncating division."
+    },
+    {
+      "id": "divided-forms",
+      "title": "Divided Closed Forms",
+      "startLine": 123,
+      "endLine": 138,
+      "summary": "D_two_closed : D(2,n) = n(n-1)/2; D_three_closed : D(3,n) = n(n-1)(n-2)/6; D_four_closed : D(4,n) = n(n-1)(n-2)(n-3)/24 — the textbook descending shapes via Nat.eq_div_of_mul_eq_right."
+    },
+    {
+      "id": "base-and-checks",
+      "title": "Base Rung, Truncation, and Sanity Checks",
+      "startLine": 140,
+      "endLine": 158,
+      "summary": "D_one : D(1,n) = n (the linear rung, Nat.choose_one_right); D_eq_zero_of_lt : D(k,n) = 0 for k > n (Nat.choose_eq_zero_of_lt), the descending family's truncation; and concrete kernel checks C(6,3)=20, C(6,4)=15, C(5,2)=10 routed through the divided closed forms."
+    }
+  ],
+  "conclusion": {
+    "summary": "14 theorems, 1 definition, 0 sorries, 0 axioms. The descending simplicial closed forms are derived uniformly in the dimension k from one identity, factorial_mul_D : k! · D(k,n) = descFactorial n k = n(n-1)⋯(n-k+1), the choose ↔ descending-factorial bridge read through D(k,n) = C(n,k), with division form D(k,n) = descFactorial n k / k!. Specializing k = 2,3,4 gives the descending triangular n(n-1)/2, tetrahedral n(n-1)(n-2)/6, and pentatope n(n-1)(n-2)(n-3)/24 closed forms in both multiplied and divided shapes. No induction on n or k appears anywhere: the per-rung induction is absorbed into Mathlib's descFactorial ↔ choose lemma.",
+    "implications": "This closes the parent's second open question: the same k! · coefficient = factorial engine that produced the ascending figurate closed forms produces the descending ones by swapping ascFactorial for descFactorial and multichoose for choose. Placed beside the parent combinations-formula-oq-06-oq-02, the two entries give a symmetric account of the simplicial coefficient's two classical factorial normalizations — the rising-factorial (multiset) family that never vanishes and the falling-factorial (subset) family that truncates at k = n — each read off one Mathlib bridge lemma with no per-rung induction.",
+    "openQuestions": [
+      "Do the ascending and descending closed forms unify into a single signed statement over the integers, k! · (±coefficient) = ∏_{i<k}(n ± i), realizing both factorial normalizations as one identity parametrized by a sign, and does that identity extend to the falling/rising factorial of a real or complex argument via Mathlib's Gamma-function API?",
+      "Does the descending closed form lift to a generating-function statement ∑_n C(n,k) x^n = x^k/(1-x)^{k+1} in Lean, exhibiting the k! · D(k,n) = descFactorial n k identity as the numerator coefficients of a single rational generating function parametrized by the dimension k, mirroring the ascending generating-function question posed by the parent?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-06-oq-02",
+      "relationship": "parent — derived the ascending figurate closed forms uniformly in k via k! · S(k,n) = ascFactorial n k; this entry answers its second open question by supplying the mirror descending closed forms via k! · D(k,n) = descFactorial n k, so the two entries treat the rising- and falling-factorial normalizations of the binomial coefficient symmetrically"
+    },
+    {
+      "targetId": "combinations-formula-oq-06-oq-01",
+      "relationship": "aunt / sibling of the parent — packaged the ascending figurate tower S(k,n) = C(n+k-1,k) and proved its tower identity uniformly in k; this entry gives the descending counterpart D(k,n) = C(n,k) with its falling-factorial closed form"
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "ancestor — the base binomial-coefficient formula C(n,k) = n!/(k!(n-k)!); this entry gives the descending-factorial closed form C(n,k) = n(n-1)⋯(n-k+1)/k! of the ordinary coefficient, complementing the parent's ascending-factorial form of the multiset coefficient"
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "J. H. Conway, R. K. Guy",
+      "title": "The Book of Numbers",
+      "year": 1996,
+      "venue": "Springer",
+      "note": "Figurate numbers (triangular, tetrahedral, simplicial) and their closed forms."
+    },
+    {
+      "authors": "R. L. Graham, D. E. Knuth, O. Patashnik",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "venue": "Addison-Wesley",
+      "note": "Standard reference for binomial-coefficient identities and the rising/falling factorial powers n^{k-bar} and n^{k-underline}."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.choose, Nat.descFactorial, and the descFactorial ↔ choose bridge (Nat.descFactorial_eq_factorial_mul_choose) underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **combinations-formula-oq-06-oq-02-oq-02** — *Uniform Falling-Factorial Closed Forms for the Descending Simplicial Family*. Answers the parent `combinations-formula-oq-06-oq-02`'s **second open question**: can the same `k! · (coefficient) = factorial` engine that produced the *ascending* figurate closed forms be pushed to the **falling-factorial** `descFactorial` form on the ordinary binomial diagonal `C(n,k)`, giving a uniform closed form for both simplicial families at once?

**Yes** — the descending family is the exact mirror of the ascending one, swapping `ascFactorial → descFactorial` and the multiset coefficient `multichoose n k → C(n,k)`.

## The engine

```
factorial_mul_D : k! · D(k,n) = descFactorial n k = n(n-1)⋯(n-k+1)
```

where `D(k,n) := n.choose k`. This is Mathlib's `Nat.descFactorial_eq_factorial_mul_choose` read backwards through `D(k,n) = C(n,k)` — one rewrite, valid for **every dimension k**, with no per-k induction. The division form `D_closed : D(k,n) = descFactorial n k / k!` follows via `Nat.factorial_dvd_descFactorial`.

## Specializations (k = 2, 3, 4)

| rung | multiplied (division-free) | divided (textbook) |
|------|-----|-----|
| triangular | `2·D(2,n) = n(n-1)` | `n(n-1)/2` |
| tetrahedral | `6·D(3,n) = n(n-1)(n-2)` | `n(n-1)(n-2)/6` |
| pentatope | `24·D(4,n) = n(n-1)(n-2)(n-3)` | `n(n-1)(n-2)(n-3)/24` |

`D_eq_zero_of_lt` records the descending family's truncation `D(k,n)=0` for `k>n` — the structural feature separating the falling-factorial (subset) family from the parent's never-vanishing rising-factorial (multiset) family.

Placed beside the parent, the two entries exhibit the **same one-line engine** `k! · coefficient = factorial` producing both simplicial families.

## Verification

- **0 axioms** — `#print axioms` reports only `propext / Classical.choice / Quot.sound`; sanity checks close by `rfl` (no `native_decide`, no `Lean.ofReduceBool`).
- **0 sorries.** 14 theorems, 1 definition, 158 lines.
- Builds clean via `lake env lean Proofs/CombinationsFigurateDescClosedForm.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)