### PR TITLE
research(mean-value-theorem-oq-04-oq-01): the gradient theorem — multivariable FTC from 1D FTC [VERIFIED, 0-axiom, new entry, 6thm]

### DIFF
--- a/proofs/Proofs/MeanValueTheoremOQ04OQ01.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ04OQ01.lean
@@ -1,0 +1,182 @@
+/-
+Mean Value Theorem OQ-04-OQ-01: The Gradient Theorem — Multivariable FTC from 1D FTC
+
+**Question (parent `mean-value-theorem-oq-04`, open question 1).** Can a
+multivariable fundamental theorem of calculus — the differential-forms Stokes'
+theorem `∫_M dω = ∫_{∂M} ω` — be *derived* from the one-dimensional FTC?
+
+**Answer (this entry).** The full differential-forms Stokes' theorem for
+`k`-manifolds is far beyond a single formalization step (it requires an
+oriented-manifold / differential-forms library). But the honestly-scaled,
+directly-derivable case is the **gradient theorem** (a.k.a. the *fundamental
+theorem for line integrals* / the fundamental theorem of calculus for line
+integrals): the `0`-form / `1`-form instance of Stokes on a curve. It says that
+the line integral of a gradient (exact) field along a path depends only on the
+endpoints,
+$$
+  \int_a^b \langle \nabla g(\gamma(t)),\, \gamma'(t)\rangle \, dt
+    = g(\gamma(b)) - g(\gamma(a)),
+$$
+and it is a *one-line corollary* of the 1D FTC composed with the chain rule:
+setting `h := g ∘ γ`, the chain rule gives `h'(t) = Dg(γ(t))[γ'(t)]`, and the 1D
+FTC `∫_a^b h' = h(b) - h(a)` finishes.
+
+This file formalizes exactly that derivation, in two flavors:
+
+1. A general **Fréchet-derivative** form `line_integral_fderiv_eq_sub` over an
+   arbitrary real normed space `E`, where the "gradient" is the Fréchet
+   derivative `Dg t : E →L[ℝ] ℝ` and the integrand is `Dg t (γ' t)`. The proof
+   is `HasFDerivAt.comp_hasDerivAt` (chain rule) piped into
+   `intervalIntegral.integral_eq_sub_of_hasDerivAt` (the 1D FTC).
+
+2. The classical **inner-product / gradient** form `gradient_theorem` over a
+   real Hilbert space, where the integrand is the genuine inner product
+   `⟪∇g(γ(t)), γ'(t)⟫`. This is obtained from the Fréchet form by identifying
+   `HasGradientAt g (grad t) (γ t)` with `HasFDerivAt g (toDual ℝ F (grad t))`
+   and rewriting `toDual ℝ F v w = ⟪v, w⟫` (`InnerProductSpace.toDual_apply_apply`).
+
+From each we read off the two structural corollaries that make "exact field ⇒
+path only depends on endpoints" precise: the circulation of a gradient field
+around any **closed** loop vanishes (`*_closed`), and the line integral is
+**path-independent** (`*_path_independent`). These are the conservative-field
+laws of vector calculus, here proved as pure consequences of the 1D FTC.
+
+No axioms, no sorries; every result is a corollary of Mathlib's 1D FTC and the
+chain rule.
+-/
+import Mathlib
+
+open MeasureTheory intervalIntegral
+open scoped RealInnerProductSpace
+
+namespace MeanValueTheoremOQ04OQ01
+
+/-! ## Part I: The gradient theorem in Fréchet-derivative form
+
+Over an arbitrary real normed space `E`, the "gradient field" of `g : E → ℝ` is
+its Fréchet derivative `Dg t : E →L[ℝ] ℝ` at the point `γ t`, and the line
+integral of the field along `γ` is `∫ Dg t (γ' t)`. -/
+
+section FDeriv
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- **Gradient theorem (Fréchet form) / fundamental theorem for line integrals.**
+
+For `g : E → ℝ` with Fréchet derivative `Dg t` at `γ t`, along a path `γ` with
+velocity `γ' t`, the line integral of the exact `1`-form `Dg` pulls back to the
+endpoint difference:
+`∫_a^b Dg(t)[γ'(t)] dt = g(γ b) - g(γ a)`.
+
+**This is the `0`-form case of Stokes' theorem** `∫_M dω = ∫_{∂M} ω`: the curve
+`γ : [a,b] → E` is the `1`-chain `M`, its oriented boundary `∂M` is the point
+pair `{γ b} - {γ a}`, and `ω = g` is a `0`-form with `dω = Dg`.
+
+*Proof.* The composite `g ∘ γ` has derivative `t ↦ Dg(t)[γ'(t)]` by the chain
+rule (`HasFDerivAt.comp_hasDerivAt`); the claim is then the 1D FTC
+(`intervalIntegral.integral_eq_sub_of_hasDerivAt`) applied to `g ∘ γ`. -/
+theorem line_integral_fderiv_eq_sub
+    {g : E → ℝ} {Dg : ℝ → (E →L[ℝ] ℝ)} {γ γ' : ℝ → E} {a b : ℝ}
+    (hg : ∀ t ∈ Set.uIcc a b, HasFDerivAt g (Dg t) (γ t))
+    (hγ : ∀ t ∈ Set.uIcc a b, HasDerivAt γ (γ' t) t)
+    (hint : IntervalIntegrable (fun t => Dg t (γ' t)) volume a b) :
+    ∫ t in a..b, Dg t (γ' t) = g (γ b) - g (γ a) := by
+  have hcomp : ∀ t ∈ Set.uIcc a b, HasDerivAt (g ∘ γ) (Dg t (γ' t)) t :=
+    fun t ht => (hg t ht).comp_hasDerivAt t (hγ t ht)
+  have h := integral_eq_sub_of_hasDerivAt hcomp hint
+  simpa only [Function.comp] using h
+
+/-- **Vanishing circulation of a gradient field around a closed loop.** If the
+path is closed (`γ a = γ b`), the line integral of the exact `1`-form `Dg`
+vanishes: a conservative field does no net work around any loop. -/
+theorem line_integral_fderiv_closed
+    {g : E → ℝ} {Dg : ℝ → (E →L[ℝ] ℝ)} {γ γ' : ℝ → E} {a b : ℝ}
+    (hg : ∀ t ∈ Set.uIcc a b, HasFDerivAt g (Dg t) (γ t))
+    (hγ : ∀ t ∈ Set.uIcc a b, HasDerivAt γ (γ' t) t)
+    (hint : IntervalIntegrable (fun t => Dg t (γ' t)) volume a b)
+    (hclosed : γ a = γ b) :
+    ∫ t in a..b, Dg t (γ' t) = 0 := by
+  rw [line_integral_fderiv_eq_sub hg hγ hint, hclosed, sub_self]
+
+/-- **Path independence of the line integral of a gradient field.** Two paths
+`γ₁`, `γ₂` with matching endpoints (`γ₁ a = γ₂ c`, `γ₁ b = γ₂ d`) give the same
+line integral of the exact `1`-form `Dg` of the *same* potential `g` — because
+each integral equals the endpoint difference `g(end) - g(start)`. -/
+theorem line_integral_fderiv_path_independent
+    {g : E → ℝ} {Dg₁ Dg₂ : ℝ → (E →L[ℝ] ℝ)} {γ₁ γ₁' γ₂ γ₂' : ℝ → E} {a b c d : ℝ}
+    (hg₁ : ∀ t ∈ Set.uIcc a b, HasFDerivAt g (Dg₁ t) (γ₁ t))
+    (hγ₁ : ∀ t ∈ Set.uIcc a b, HasDerivAt γ₁ (γ₁' t) t)
+    (hint₁ : IntervalIntegrable (fun t => Dg₁ t (γ₁' t)) volume a b)
+    (hg₂ : ∀ t ∈ Set.uIcc c d, HasFDerivAt g (Dg₂ t) (γ₂ t))
+    (hγ₂ : ∀ t ∈ Set.uIcc c d, HasDerivAt γ₂ (γ₂' t) t)
+    (hint₂ : IntervalIntegrable (fun t => Dg₂ t (γ₂' t)) volume c d)
+    (hstart : γ₁ a = γ₂ c) (hend : γ₁ b = γ₂ d) :
+    ∫ t in a..b, Dg₁ t (γ₁' t) = ∫ t in c..d, Dg₂ t (γ₂' t) := by
+  rw [line_integral_fderiv_eq_sub hg₁ hγ₁ hint₁,
+      line_integral_fderiv_eq_sub hg₂ hγ₂ hint₂, hstart, hend]
+
+end FDeriv
+
+/-! ## Part II: The classical gradient theorem (inner-product form)
+
+Over a real Hilbert space `F`, the gradient `grad t = ∇g(γ t) : F` and the
+integrand is the genuine inner product `⟪grad t, γ' t⟫`. This is the vector
+calculus statement `∫ ∇g · dr = g(end) - g(start)`. -/
+
+section Inner
+
+variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] [CompleteSpace F]
+
+/-- **The gradient theorem** (fundamental theorem for line integrals, classical
+inner-product form). Over a real Hilbert space `F`, for a potential `g : F → ℝ`
+with gradient `grad t = ∇g(γ t)` along a path `γ` with velocity `γ' t`,
+`∫_a^b ⟪∇g(γ t), γ'(t)⟫ dt = g(γ b) - g(γ a)`.
+
+*Proof.* `HasGradientAt g (grad t) (γ t)` is by definition
+`HasFDerivAt g (toDual ℝ F (grad t)) (γ t)`, and
+`toDual ℝ F (grad t) (γ' t) = ⟪grad t, γ' t⟫`
+(`InnerProductSpace.toDual_apply_apply`), so this is
+`line_integral_fderiv_eq_sub` with `Dg t = toDual ℝ F (grad t)`. -/
+theorem gradient_theorem
+    {g : F → ℝ} {grad γ γ' : ℝ → F} {a b : ℝ}
+    (hg : ∀ t ∈ Set.uIcc a b, HasGradientAt g (grad t) (γ t))
+    (hγ : ∀ t ∈ Set.uIcc a b, HasDerivAt γ (γ' t) t)
+    (hint : IntervalIntegrable (fun t => ⟪grad t, γ' t⟫) volume a b) :
+    ∫ t in a..b, ⟪grad t, γ' t⟫ = g (γ b) - g (γ a) := by
+  have hg' : ∀ t ∈ Set.uIcc a b,
+      HasFDerivAt g (InnerProductSpace.toDual ℝ F (grad t)) (γ t) :=
+    fun t ht => hasGradientAt_iff_hasFDerivAt.mp (hg t ht)
+  have hint' : IntervalIntegrable
+      (fun t => InnerProductSpace.toDual ℝ F (grad t) (γ' t)) volume a b := by
+    simpa only [InnerProductSpace.toDual_apply_apply] using hint
+  have h := line_integral_fderiv_eq_sub hg' hγ hint'
+  simpa only [InnerProductSpace.toDual_apply_apply] using h
+
+/-- **Zero circulation of a conservative field.** The line integral of a gradient
+field `∇g` around a closed loop (`γ a = γ b`) is zero. -/
+theorem gradient_theorem_closed
+    {g : F → ℝ} {grad γ γ' : ℝ → F} {a b : ℝ}
+    (hg : ∀ t ∈ Set.uIcc a b, HasGradientAt g (grad t) (γ t))
+    (hγ : ∀ t ∈ Set.uIcc a b, HasDerivAt γ (γ' t) t)
+    (hint : IntervalIntegrable (fun t => ⟪grad t, γ' t⟫) volume a b)
+    (hclosed : γ a = γ b) :
+    ∫ t in a..b, ⟪grad t, γ' t⟫ = 0 := by
+  rw [gradient_theorem hg hγ hint, hclosed, sub_self]
+
+/-- **Path independence of a gradient (conservative) field.** Two paths with
+matching endpoints give equal line integrals of `∇g`. -/
+theorem gradient_theorem_path_independent
+    {g : F → ℝ} {grad₁ γ₁ γ₁' grad₂ γ₂ γ₂' : ℝ → F} {a b c d : ℝ}
+    (hg₁ : ∀ t ∈ Set.uIcc a b, HasGradientAt g (grad₁ t) (γ₁ t))
+    (hγ₁ : ∀ t ∈ Set.uIcc a b, HasDerivAt γ₁ (γ₁' t) t)
+    (hint₁ : IntervalIntegrable (fun t => ⟪grad₁ t, γ₁' t⟫) volume a b)
+    (hg₂ : ∀ t ∈ Set.uIcc c d, HasGradientAt g (grad₂ t) (γ₂ t))
+    (hγ₂ : ∀ t ∈ Set.uIcc c d, HasDerivAt γ₂ (γ₂' t) t)
+    (hint₂ : IntervalIntegrable (fun t => ⟪grad₂ t, γ₂' t⟫) volume c d)
+    (hstart : γ₁ a = γ₂ c) (hend : γ₁ b = γ₂ d) :
+    ∫ t in a..b, ⟪grad₁ t, γ₁' t⟫ = ∫ t in c..d, ⟪grad₂ t, γ₂' t⟫ := by
+  rw [gradient_theorem hg₁ hγ₁ hint₁, gradient_theorem hg₂ hγ₂ hint₂, hstart, hend]
+
+end Inner
+
+end MeanValueTheoremOQ04OQ01

--- a/src/data/proofs/mean-value-theorem-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-04-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-line-integral-fderiv-eq-sub",
+    "proofId": "mean-value-theorem-oq-04-oq-01",
+    "range": { "startLine": 78, "endLine": 90 },
+    "type": "theorem",
+    "title": "line_integral_fderiv_eq_sub: Gradient Theorem (Fréchet form)",
+    "content": "Over an arbitrary real normed space E, the line integral of an exact 1-form equals the endpoint difference of its potential: ∫ₐᵇ Dg(t)[γ'(t)] dt = g(γ b) − g(γ a), where Dg t : E →L[ℝ] ℝ is the Fréchet derivative of g at γ t. This is the 0-form case of Stokes' theorem ∫_M dω = ∫_{∂M} ω. Proof: HasFDerivAt.comp_hasDerivAt (chain rule) yields HasDerivAt (g ∘ γ) (Dg t (γ' t)) t on [a,b], then intervalIntegral.integral_eq_sub_of_hasDerivAt (the 1D FTC) applied to g ∘ γ finishes. The multivariable content is entirely carried by the chain rule — no inner product or finite dimension.",
+    "mathContext": "$\\int_a^b Dg(\\gamma t)[\\gamma'(t)]\\,dt = g(\\gamma b) - g(\\gamma a)$, with the curve as a 1-chain and $g$ a 0-form potential ($d g = Dg$).",
+    "significance": "critical",
+    "relatedConcepts": ["HasFDerivAt.comp_hasDerivAt", "intervalIntegral.integral_eq_sub_of_hasDerivAt", "chain rule", "exact 1-form", "Stokes' theorem"],
+    "prerequisites": ["HasFDerivAt", "HasDerivAt", "intervalIntegral", "IntervalIntegrable"]
+  },
+  {
+    "id": "ann-line-integral-fderiv-closed",
+    "proofId": "mean-value-theorem-oq-04-oq-01",
+    "range": { "startLine": 92, "endLine": 103 },
+    "type": "theorem",
+    "title": "line_integral_fderiv_closed: Vanishing Circulation (Fréchet form)",
+    "content": "If the path is closed (γ a = γ b), the line integral of the exact 1-form Dg vanishes: ∫ₐᵇ Dg(t)[γ'(t)] = 0. A conservative field does no net work around any loop. One-line corollary of line_integral_fderiv_eq_sub: substitute γ a = γ b into g(γ b) − g(γ a) and apply sub_self.",
+    "mathContext": "$\\gamma a = \\gamma b \\Rightarrow \\oint Dg(\\gamma t)[\\gamma'(t)] = 0$ — exact forms have zero circulation.",
+    "significance": "important",
+    "relatedConcepts": ["conservative field", "closed loop", "circulation", "sub_self"],
+    "prerequisites": ["line_integral_fderiv_eq_sub"]
+  },
+  {
+    "id": "ann-line-integral-fderiv-path-independent",
+    "proofId": "mean-value-theorem-oq-04-oq-01",
+    "range": { "startLine": 105, "endLine": 117 },
+    "type": "theorem",
+    "title": "line_integral_fderiv_path_independent: Path Independence (Fréchet form)",
+    "content": "Two paths with matching endpoints (γ₁ a = γ₂ c, γ₁ b = γ₂ d) give the same line integral of the exact 1-form of the same potential g — each integral equals the endpoint difference g(end) − g(start). One-line corollary rewriting both sides via line_integral_fderiv_eq_sub and the endpoint equalities.",
+    "mathContext": "Equal endpoints $\\Rightarrow$ equal line integrals: the integral depends only on $\\partial\\gamma$, not on the path.",
+    "significance": "important",
+    "relatedConcepts": ["path independence", "conservative field", "endpoint difference"],
+    "prerequisites": ["line_integral_fderiv_eq_sub"]
+  },
+  {
+    "id": "ann-gradient-theorem",
+    "proofId": "mean-value-theorem-oq-04-oq-01",
+    "range": { "startLine": 140, "endLine": 155 },
+    "type": "theorem",
+    "title": "gradient_theorem: Fundamental Theorem for Line Integrals (inner-product form)",
+    "content": "Over a real Hilbert space F, the classical vector-calculus gradient theorem: ∫ₐᵇ ⟪∇g(γ t), γ'(t)⟫ dt = g(γ b) − g(γ a). Derived from the Fréchet form line_integral_fderiv_eq_sub with Dg t := InnerProductSpace.toDual ℝ F (grad t): hasGradientAt_iff_hasFDerivAt converts HasGradientAt g (grad t) (γ t) to HasFDerivAt g (toDual ℝ F (grad t)) (γ t), and InnerProductSpace.toDual_apply_apply (toDual ℝ F v w = ⟪v,w⟫, definitional rfl and a simp lemma) rewrites the integrand between the functional and inner-product presentations. Recovers ∮ ∇g · dr = Δg for conservative fields.",
+    "mathContext": "$\\int_a^b \\langle \\nabla g(\\gamma t), \\gamma'(t)\\rangle\\,dt = g(\\gamma b) - g(\\gamma a)$ — the line integral of a gradient field is the potential difference.",
+    "significance": "critical",
+    "relatedConcepts": ["HasGradientAt", "InnerProductSpace.toDual", "Riesz representation", "gradient field", "hasGradientAt_iff_hasFDerivAt"],
+    "prerequisites": ["line_integral_fderiv_eq_sub", "HasGradientAt", "InnerProductSpace", "inner product"]
+  },
+  {
+    "id": "ann-gradient-theorem-closed",
+    "proofId": "mean-value-theorem-oq-04-oq-01",
+    "range": { "startLine": 157, "endLine": 166 },
+    "type": "theorem",
+    "title": "gradient_theorem_closed: Zero Circulation of a Conservative Field",
+    "content": "The line integral of a gradient field ∇g around a closed loop (γ a = γ b) is zero: ∫ₐᵇ ⟪∇g(γ t), γ'(t)⟫ = 0. The vector-calculus statement that conservative fields have vanishing circulation — the standard test for conservativeness. One-line corollary of gradient_theorem.",
+    "mathContext": "$\\oint \\langle \\nabla g, d\\mathbf r\\rangle = 0$ around any closed loop.",
+    "significance": "important",
+    "relatedConcepts": ["conservative field", "circulation", "closed loop"],
+    "prerequisites": ["gradient_theorem"]
+  },
+  {
+    "id": "ann-gradient-theorem-path-independent",
+    "proofId": "mean-value-theorem-oq-04-oq-01",
+    "range": { "startLine": 168, "endLine": 179 },
+    "type": "theorem",
+    "title": "gradient_theorem_path_independent: Path Independence of a Gradient Field",
+    "content": "Two paths with matching endpoints give equal line integrals of ∇g: both equal the endpoint difference g(end) − g(start). The defining property distinguishing conservative fields. One-line corollary rewriting both sides via gradient_theorem and the endpoint equalities.",
+    "mathContext": "Matching endpoints $\\Rightarrow$ equal $\\int \\langle \\nabla g, d\\mathbf r\\rangle$ — path independence of conservative fields.",
+    "significance": "important",
+    "relatedConcepts": ["path independence", "conservative field", "gradient field"],
+    "prerequisites": ["gradient_theorem"]
+  }
+]

--- a/src/data/proofs/mean-value-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-04-oq-01/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "mean-value-theorem-oq-04-oq-01",
+  "title": "The Gradient Theorem: Multivariable FTC from the 1D FTC",
+  "slug": "mean-value-theorem-oq-04-oq-01",
+  "description": "Answers open question 1 of mean-value-theorem-oq-04 (can a multivariable FTC be derived from the 1D FTC?) at the honestly-scaled level: the gradient theorem / fundamental theorem for line integrals — the 0-form case of Stokes' theorem — is a one-line corollary of the 1D FTC composed with the chain rule. Proves the line integral of an exact 1-form (gradient field) depends only on endpoints, in both a general Fréchet-derivative form over a normed space and the classical inner-product form ∫ ⟪∇g, γ'⟫ = g(γ(b)) − g(γ(a)) over a Hilbert space, plus the conservative-field corollaries (zero circulation around closed loops, path independence).",
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/MeanValueTheoremOQ04OQ01.lean",
+    "badge": "original",
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "lineCount": 182,
+    "imports": [
+      "Mathlib"
+    ],
+    "tags": [
+      "calculus",
+      "mean-value-theorem",
+      "fundamental-theorem-calculus",
+      "line-integral",
+      "gradient-theorem",
+      "stokes-theorem",
+      "vector-calculus",
+      "analysis",
+      "open-question"
+    ],
+    "assumptions": [],
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Header: Gradient Theorem as the 0-form Case of Stokes",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring framing the entry as the honestly-scaled answer to the parent's open question 'can a multivariable FTC be derived from the 1D FTC?'. Full differential-forms Stokes is out of scope, but the gradient theorem (fundamental theorem for line integrals) is the 0-form/1-form instance and a one-line corollary of the 1D FTC via the chain rule (h := g∘γ ⟹ h'(t) = Dg(γ t)[γ'(t)], then ∫h' = h(b)−h(a)). Opens MeasureTheory, intervalIntegral, and the RealInnerProductSpace inner-product notation.",
+      "mathContext": "Stokes: $\\int_M d\\omega = \\int_{\\partial M}\\omega$. For a curve $\\gamma:[a,b]\\to E$ as the 1-chain $M$ (boundary $\\{\\gamma b\\}-\\{\\gamma a\\}$) and a 0-form $\\omega = g$ with $d\\omega = Dg$, this reduces to $\\int_a^b Dg(\\gamma t)[\\gamma'(t)]\\,dt = g(\\gamma b)-g(\\gamma a)$."
+    },
+    {
+      "id": "fderiv-form",
+      "title": "Part I: Gradient Theorem in Fréchet-Derivative Form",
+      "startLine": 54,
+      "endLine": 118,
+      "summary": "Three theorems over an arbitrary real normed space E. line_integral_fderiv_eq_sub: ∫_a^b Dg(t)[γ'(t)] = g(γ b)−g(γ a), where the exact 1-form is the Fréchet derivative Dg t : E →L[ℝ] ℝ; proof is HasFDerivAt.comp_hasDerivAt (chain rule) piped into intervalIntegral.integral_eq_sub_of_hasDerivAt (1D FTC). line_integral_fderiv_closed: closed path (γ a = γ b) ⟹ integral = 0. line_integral_fderiv_path_independent: two paths with matching endpoints give equal integrals of the same potential's 1-form.",
+      "mathContext": "Chain rule $HasFDerivAt\\;g\\;(Dg\\,t)\\;(\\gamma t)$ and $HasDerivAt\\;\\gamma\\;(\\gamma' t)\\;t$ give $HasDerivAt\\;(g\\circ\\gamma)\\;(Dg\\,t[\\gamma' t])\\;t$; the 1D FTC then yields $\\int_a^b Dg\\,t[\\gamma' t] = g(\\gamma b)-g(\\gamma a)$."
+    },
+    {
+      "id": "inner-form",
+      "title": "Part II: Classical Gradient Theorem (Inner-Product Form)",
+      "startLine": 120,
+      "endLine": 182,
+      "summary": "Three theorems over a real Hilbert space F where the integrand is the genuine inner product ⟪grad t, γ' t⟫. gradient_theorem: ∫_a^b ⟪∇g(γ t), γ'(t)⟫ = g(γ b)−g(γ a); derived from the Fréchet form by identifying HasGradientAt g (grad t) (γ t) with HasFDerivAt g (toDual ℝ F (grad t)) and rewriting toDual ℝ F v w = ⟪v,w⟫ (InnerProductSpace.toDual_apply_apply). gradient_theorem_closed: zero circulation of a conservative field around a closed loop. gradient_theorem_path_independent: path independence of ∇g.",
+      "mathContext": "$HasGradientAt\\;g\\;g'\\;x := HasFDerivAt\\;g\\;(\\mathrm{toDual}_{\\mathbb R}\\,g')\\;x$ and $\\mathrm{toDual}_{\\mathbb R}\\,v\\,(w)=\\langle v,w\\rangle$, so $\\int_a^b \\langle\\nabla g(\\gamma t),\\gamma'(t)\\rangle = g(\\gamma b)-g(\\gamma a)$; closed loop $\\Rightarrow 0$, matching endpoints $\\Rightarrow$ equal integrals."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The gradient theorem — the fundamental theorem of calculus for line integrals — states that the line integral of a gradient field ∇g along a curve depends only on the endpoints: ∮ ∇g · dr = g(end) − g(start). It is the lowest-dimensional case of the generalized Stokes' theorem ∫_M dω = ∫_{∂M} ω (Poincaré, Volterra, Cartan; the modern differential-forms formulation crystallized in the early 20th century), specializing to a 0-form potential g pulled back along a 1-chain γ. Historically it underlies the 19th-century theory of conservative force fields and potential energy (a force F = ∇g does work equal to the potential difference, independent of path), central to Hamiltonian mechanics and electrostatics. The result is a direct corollary of the 1D Newton–Leibniz theorem (Barrow 1670, Newton 1666, Leibniz 1675) once combined with the multivariable chain rule, exactly the derivation formalized here. This entry answers the first open question posed by the parent FTC-via-MVT entry: the multivariable FTC (in its gradient/exact-1-form case) is genuinely downstream of the 1D FTC.",
+    "problemStatement": "Given a potential g : E → ℝ on a real normed space (resp. a real Hilbert space) that is (Fréchet-, resp. gradient-) differentiable along a C¹ path γ : [a,b] → E with velocity γ', show that the line integral of the induced exact 1-form equals the endpoint difference: (1) Fréchet form ∫_a^b Dg(γ t)[γ'(t)] dt = g(γ b) − g(γ a); (2) inner-product form ∫_a^b ⟪∇g(γ t), γ'(t)⟫ dt = g(γ b) − g(γ a); and derive the conservative-field corollaries: (3) the circulation around any closed loop (γ a = γ b) vanishes; (4) the integral is path-independent (paths with equal endpoints give equal integrals).",
+    "proofStrategy": "Everything reduces to the 1D FTC via the chain rule. For the Fréchet form, HasFDerivAt.comp_hasDerivAt turns HasFDerivAt g (Dg t) (γ t) and HasDerivAt γ (γ' t) t into HasDerivAt (g ∘ γ) (Dg t (γ' t)) t; feeding this pointwise family into intervalIntegral.integral_eq_sub_of_hasDerivAt (with an integrability hypothesis on t ↦ Dg t (γ' t)) yields ∫ Dg t (γ' t) = (g∘γ) b − (g∘γ) a = g(γ b) − g(γ a). The inner-product form specializes E := F Hilbert and Dg t := InnerProductSpace.toDual ℝ F (grad t): the definitional equality hasGradientAt_iff_hasFDerivAt converts the gradient hypotheses, and the simp lemma InnerProductSpace.toDual_apply_apply (toDual ℝ F v w = ⟪v, w⟫, definitionally rfl) rewrites the integrand between the toDual and inner-product presentations. The closed-loop and path-independence corollaries are one-line rewrites: substitute the endpoint equalities into g(γ b) − g(γ a) and use sub_self / transitivity.",
+    "keyInsights": [
+      "The gradient theorem is not a new axiom but a corollary of the 1D FTC: the multivariable content is entirely carried by the chain rule HasFDerivAt.comp_hasDerivAt, which converts a path-derivative into the ordinary derivative of the scalar composite g ∘ γ. This makes precise the sense in which 'multivariable FTC follows from 1D FTC' — at least for exact 1-forms (0-form potentials).",
+      "Working with the abstract Fréchet derivative Dg t : E →L[ℝ] ℝ rather than a coordinate gradient keeps the core theorem valid over any real normed space, with no inner-product or finite-dimensionality assumption. The classical ∫ ∇g · dr form is then recovered for free on a Hilbert space via InnerProductSpace.toDual, which is the Riesz isomorphism identifying the derivative functional with a gradient vector.",
+      "InnerProductSpace.toDual_apply_apply (toDual ℝ F v w = ⟪v, w⟫) holds by rfl and is a simp lemma, so the passage between the functional-analytic (fderiv) and vector-calculus (gradient · velocity) presentations of the line integral is definitional — no analytic content is lost in the translation.",
+      "The conservative-field laws of vector calculus — zero net work around a closed loop and path independence — are exposed here as immediate structural corollaries (pure rewrites of the endpoint difference), emphasizing that they encode no more than the fundamental theorem: an exact form integrates to a boundary evaluation.",
+      "The gradient theorem is the k = 1 rung of Stokes' theorem ∫_M dω = ∫_{∂M} ω; formalizing it as an FTC corollary isolates exactly the ingredient (the boundary ∂[a,b] = {b} − {a} and the pullback of a 0-form) that a full differential-forms Stokes library would need to generalize to higher-dimensional oriented manifolds."
+    ]
+  },
+  "conclusion": {
+    "summary": "Six machine-checked theorems establishing the gradient theorem (fundamental theorem for line integrals) as a corollary of the 1D FTC and the chain rule: a general Fréchet-derivative form over a real normed space, the classical inner-product form ∫ ⟪∇g, γ'⟫ = g(γ b) − g(γ a) over a Hilbert space, and the conservative-field corollaries (vanishing circulation around closed loops and path independence) in both forms. Zero axioms, zero sorries.",
+    "implications": "The gradient theorem is the foundation of the theory of conservative fields: it certifies that a force derived from a potential does work equal to the potential difference regardless of path, the mathematical backbone of potential energy in mechanics and of electrostatic/gravitational potentials in physics. As the 0-form case of Stokes' theorem, this entry marks the entry point for a formalized generalized Stokes theory in Lean; the same chain-rule-into-1D-FTC pattern, replayed against an oriented-manifold differential-forms library, is what a higher-dimensional formalization would extend. The path-independence and closed-loop corollaries are the criteria used in practice to detect whether a given field is conservative (exact).",
+    "openQuestions": [
+      "Can the next rung of Stokes — Green's theorem ∮_{∂D} (P dx + Q dy) = ∬_D (∂Q/∂x − ∂P/∂y) dA on a rectangle — be derived by applying this 1D-FTC-plus-Fubini pattern to a non-exact 1-form?",
+      "Does Mathlib's InnerProductSpace.toDual (Riesz representation) support a coordinate-free statement and proof of the gradient theorem on infinite-dimensional Hilbert spaces with unbounded potentials, given suitable integrability of ⟪∇g, γ'⟫?",
+      "Can path independence be strengthened to a converse — a field whose line integral is path-independent on a simply connected domain is exact (has a potential) — using Mathlib's emerging results on connectedness and antiderivatives?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "mean-value-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Answers open question 1 of the parent (deriving a multivariable FTC from the 1D FTC) at the level of the gradient theorem / exact 1-forms, using the parent's key tool intervalIntegral.integral_eq_sub_of_hasDerivAt."
+    },
+    {
+      "proofId": "mean-value-theorem",
+      "relationship": "related",
+      "description": "Builds on the mean-value / FTC circle of ideas: the gradient theorem is the line-integral generalization of the Newton–Leibniz formula."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/MeanValueTheoremOQ04OQ01.lean",
+    "lineCount": 182,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "imports": [
+      "import Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "intervalIntegral",
+      "RealInnerProductSpace"
+    ],
+    "namespace": "MeanValueTheoremOQ04OQ01"
+  },
+  "mainTheorems": [
+    {
+      "name": "line_integral_fderiv_eq_sub",
+      "type": "core",
+      "statement": "$\\int_a^b Dg(t)[\\gamma'(t)]\\,dt = g(\\gamma b) - g(\\gamma a)$, for $HasFDerivAt\\;g\\;(Dg\\,t)\\;(\\gamma t)$ and $HasDerivAt\\;\\gamma\\;(\\gamma' t)\\;t$ on $[a,b]$ with $t\\mapsto Dg\\,t[\\gamma' t]$ interval-integrable",
+      "significance": "The gradient theorem in Fréchet-derivative form over an arbitrary real normed space — the 0-form case of Stokes' theorem. Proof: HasFDerivAt.comp_hasDerivAt (chain rule) gives HasDerivAt (g∘γ) (Dg t (γ' t)) t, then intervalIntegral.integral_eq_sub_of_hasDerivAt (1D FTC) applied to g∘γ. The multivariable content is carried entirely by the chain rule; no inner product or finite dimension is needed.",
+      "description": "Line integral of an exact 1-form equals the endpoint difference of its potential."
+    },
+    {
+      "name": "gradient_theorem",
+      "type": "core",
+      "statement": "$\\int_a^b \\langle \\nabla g(\\gamma t), \\gamma'(t)\\rangle\\,dt = g(\\gamma b) - g(\\gamma a)$ on a real Hilbert space, for $HasGradientAt\\;g\\;(\\mathrm{grad}\\,t)\\;(\\gamma t)$ and $HasDerivAt\\;\\gamma\\;(\\gamma' t)\\;t$",
+      "significance": "The classical fundamental theorem for line integrals (vector-calculus form). Specializes the Fréchet form with Dg t := InnerProductSpace.toDual ℝ F (grad t); hasGradientAt_iff_hasFDerivAt converts the gradient hypotheses and InnerProductSpace.toDual_apply_apply (toDual ℝ F v w = ⟪v,w⟫, definitional rfl) rewrites the integrand. Recovers ∮ ∇g · dr = Δg for conservative fields.",
+      "description": "Line integral of a gradient field equals the potential difference between endpoints."
+    },
+    {
+      "name": "gradient_theorem_closed",
+      "type": "supporting",
+      "statement": "$\\gamma a = \\gamma b \\Rightarrow \\int_a^b \\langle \\nabla g(\\gamma t), \\gamma'(t)\\rangle\\,dt = 0$",
+      "significance": "Zero circulation of a conservative field around a closed loop — a gradient field does no net work around any cycle. One-line corollary: substitute γ a = γ b into g(γ b) − g(γ a) and apply sub_self. This is the standard test for conservativeness of a field.",
+      "description": "Vanishing circulation of a gradient field around a closed loop."
+    },
+    {
+      "name": "gradient_theorem_path_independent",
+      "type": "supporting",
+      "statement": "Matching endpoints ($\\gamma_1 a = \\gamma_2 c$, $\\gamma_1 b = \\gamma_2 d$) $\\Rightarrow \\int_a^b \\langle\\nabla g(\\gamma_1 t),\\gamma_1'(t)\\rangle = \\int_c^d \\langle\\nabla g(\\gamma_2 t),\\gamma_2'(t)\\rangle$",
+      "significance": "Path independence of a gradient (conservative) field: both integrals equal the same endpoint difference g(end) − g(start). One-line corollary rewriting both sides via gradient_theorem and the endpoint equalities. The defining property that distinguishes conservative fields.",
+      "description": "Path independence of the line integral of a gradient field."
+    }
+  ],
+  "references": [
+    {
+      "text": "Spivak, M. (1971). Calculus on Manifolds. Benjamin. Develops the generalized Stokes theorem ∫_M dω = ∫_{∂M} ω for differential forms; the gradient theorem is its 0-form/1-chain case.",
+      "url": "https://en.wikipedia.org/wiki/Gradient_theorem"
+    },
+    {
+      "text": "Rudin, W. (1976). Principles of Mathematical Analysis (3rd ed.). McGraw-Hill. Chapter 10 treats integration of forms and Stokes' theorem; the fundamental theorem for line integrals is the base case.",
+      "url": "https://en.wikipedia.org/wiki/Conservative_vector_field"
+    },
+    {
+      "text": "Mathlib4: intervalIntegral.integral_eq_sub_of_hasDerivAt (1D FTC), HasFDerivAt.comp_hasDerivAt (chain rule), InnerProductSpace.toDual_apply_apply (Riesz identification of derivative functional with gradient). The verified ingredients of the derivation.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## The Gradient Theorem: Multivariable FTC from the 1D FTC

New gallery entry (`mean-value-theorem-oq-04-oq-01`) answering **open question 1**
of the parent `mean-value-theorem-oq-04` (*Fundamental Theorem of Calculus via MVT
Structure*):

> Can the multivariable FTC — Stokes' theorem `∫_M dω = ∫_{∂M} ω` — be derived
> from this one-dimensional FTC?

Full differential-forms Stokes is far beyond one step, but the honestly-scaled,
directly-derivable case is the **gradient theorem** (fundamental theorem for line
integrals) — the **0-form / 1-form case of Stokes** — which is a *one-line
corollary of the 1D FTC composed with the chain rule*: for `h := g ∘ γ`, the
chain rule gives `h'(t) = Dg(γ t)[γ'(t)]`, and the 1D FTC `∫ h' = h(b) − h(a)`
finishes.

### Theorems (6, all VERIFIED · 0-axiom · 0-sorry)

**Part I — Fréchet form (any real normed space `E`):**
- `line_integral_fderiv_eq_sub`: `∫_a^b Dg(t)[γ'(t)] dt = g(γ b) − g(γ a)`, via
  `HasFDerivAt.comp_hasDerivAt` (chain rule) → `intervalIntegral.integral_eq_sub_of_hasDerivAt` (1D FTC).
- `line_integral_fderiv_closed`: closed loop (`γ a = γ b`) ⇒ integral `= 0`.
- `line_integral_fderiv_path_independent`: matching endpoints ⇒ equal integrals.

**Part II — classical inner-product form (real Hilbert space `F`):**
- `gradient_theorem`: `∫_a^b ⟪∇g(γ t), γ'(t)⟫ dt = g(γ b) − g(γ a)`, via
  `hasGradientAt_iff_hasFDerivAt` + `InnerProductSpace.toDual_apply_apply`
  (`toDual ℝ F v w = ⟪v, w⟫`, definitional `rfl`).
- `gradient_theorem_closed`: zero circulation of a conservative field.
- `gradient_theorem_path_independent`: path independence of `∇g`.

### Notes
- The multivariable content is carried entirely by the chain rule; the Fréchet
  form needs no inner product or finite dimension, and the classical `∮ ∇g · dr = Δg`
  form is recovered for free on a Hilbert space via the Riesz isomorphism
  `InnerProductSpace.toDual`.
- `import Mathlib`; namespace `MeanValueTheoremOQ04OQ01`; 182 LOC, 6 theorems,
  0 definitions, **0 axioms, 0 sorries**.
- Type-checked clean via `lake env lean`; gallery entry validated through
  `annotations:build` (listings generation), with normalization side-effects on
  unrelated entries restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)