### PR TITLE
research(cauchy-group-theorem monoid OQ-02): exponent–gcd image equality on a finite commutative monoid [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01OQ02.lean
@@ -1,0 +1,185 @@
+import Mathlib.Tactic
+
+/-
+# The exponent–gcd image equality on a finite commutative monoid
+
+The parent entry proved, **in every group**, the image equality
+
+      range (x ↦ xⁿ)  =  range (x ↦ x^(gcd(n, exp G)))
+
+with the *exponent* `e = exp G` as the governing invariant, and left as an open
+question (parent OQ #2) whether a *correct exponent–gcd statement* survives the
+passage to a finite **commutative monoid**, "restricted to its group of units or
+otherwise."
+
+This file gives the precise answer. It has three parts.
+
+## 1. The crux: the exponent detects group-likeness
+
+For a monoid `M`, `exp M ≠ 0` forces **every** element to be a unit
+(`isUnit_of_exponent_ne_zero`): if `x^e = 1` with `e ≥ 1` then `x^(e-1)` is a
+two-sided inverse of `x`. Contrapositively, a **single** non-unit collapses the
+exponent to `0` (`exponent_eq_zero_of_exists_not_isUnit`). For a finite
+commutative monoid the converse holds too — a finite monoid all of whose elements
+are units transfers its exponent from the finite group of units — giving the
+clean characterization
+
+      exp M ≠ 0  ↔  every element of M is a unit         (`exponent_ne_zero_iff_forall_isUnit`).
+
+So on a finite commutative monoid the exponent is nonzero *exactly* when `M` is a
+group; the moment `M` has a genuine non-unit, `exp M = 0`.
+
+## 2. The positive answer — restricted to the group of units
+
+Since `Mˣ` is always a group, the parent theorem applies verbatim to it
+(`range_pow_units_eq_gcd_exponent`): the `n`-th powers among the units coincide,
+as sets, with the `gcd(n, exp Mˣ)`-th powers. This is the "restricted to its
+group of units" reading, and it is the right home for the equality. (The group
+theorem it invokes, `range_pow_eq_range_pow_gcd_exponent`, is reproved inline here
+so this file is self-contained.)
+
+## 3. The full-monoid readings
+
+* **Against the exponent, "otherwise" degenerates.** For a non-group finite
+  monoid `exp M = 0`, so `gcd(n, exp M) = n` and the equality
+  `range(·ⁿ) = range(·^gcd(n, exp M))` holds — but *vacuously*, as an identity of
+  the map with itself (`range_pow_eq_range_pow_gcd_exponent_of_not_group`). There
+  is no nontrivial exponent–gcd content on the non-unit part.
+* **Against the order `|M|`, the naive surrogate is genuinely false.** In the
+  multiplicative monoid `ZMod 4` (a finite commutative monoid, not a group: `2` is
+  a non-unit, so `exp = 0`) the cube map has image `{0,1,3}`, whereas
+  `gcd(3, |ZMod 4|) = gcd(3,4) = 1` would predict the full monoid — the two images
+  differ (`order_surrogate_fails_zmod4`). This is the concrete obstruction: the
+  cyclic-style `|M|`-based statement cannot extend past groups.
+
+Everything is over `Mathlib.Tactic`; no axioms, no `native_decide`.
+-/
+
+variable {M : Type*}
+
+/-! ### 0. The group image theorem (reproved inline from the parent) -/
+
+/-- `x` raised to the integer-cast exponent is the identity, in any group. -/
+private theorem zpow_exponent_eq_one' [Group M] (x : M) :
+    x ^ (Monoid.exponent M : ℤ) = 1 := by
+  rw [zpow_natCast]
+  exact Monoid.pow_exponent_eq_one x
+
+/-- **Image recovery against the exponent (any group).** As sets, the `n`-th
+powers coincide with the `gcd(n, exp G)`-th powers. Easy inclusion: `gcd(n,e) ∣ n`.
+Hard inclusion: Bézout `gcd(n,e) = n·A + e·B` with `x^e = 1` gives
+`x^(gcd(n,e)) = (x^A)ⁿ`. Reproved here from the parent entry for self-containment. -/
+theorem range_pow_eq_range_pow_gcd_exponent [Group M] (n : ℕ) :
+    Set.range (fun x : M => x ^ n)
+      = Set.range (fun x : M => x ^ Nat.gcd n (Monoid.exponent M)) := by
+  set e := Monoid.exponent M with he
+  set d := Nat.gcd n e with hd
+  apply Set.Subset.antisymm
+  · rintro _ ⟨x, rfl⟩
+    obtain ⟨k, hk⟩ := Nat.gcd_dvd_left n e
+    exact ⟨x ^ k, by show (x ^ k) ^ d = x ^ n; rw [← pow_mul', ← hk]⟩
+  · rintro _ ⟨x, rfl⟩
+    refine ⟨x ^ (Nat.gcdA n e), ?_⟩
+    show (x ^ Nat.gcdA n e) ^ n = x ^ d
+    have hbez : (d : ℤ) = n * Nat.gcdA n e + e * Nat.gcdB n e := by
+      rw [hd]; exact Nat.gcd_eq_gcd_ab n e
+    have hx : x ^ (e : ℤ) = 1 := zpow_exponent_eq_one' x
+    have hxe : x ^ ((e : ℤ) * Nat.gcdB n e) = 1 := by rw [zpow_mul, hx, one_zpow]
+    calc (x ^ Nat.gcdA n e) ^ n
+          = (x ^ Nat.gcdA n e) ^ (n : ℤ) := (zpow_natCast _ n).symm
+      _ = x ^ ((n : ℤ) * Nat.gcdA n e) := by rw [← zpow_mul, mul_comm]
+      _ = x ^ ((n : ℤ) * Nat.gcdA n e) * x ^ ((e : ℤ) * Nat.gcdB n e) := by
+            rw [hxe, mul_one]
+      _ = x ^ ((n : ℤ) * Nat.gcdA n e + (e : ℤ) * Nat.gcdB n e) := (zpow_add x _ _).symm
+      _ = x ^ (d : ℤ) := by rw [← hbez]
+      _ = x ^ d := zpow_natCast x d
+
+/-! ### 1. The crux: `exp M ≠ 0` iff every element is a unit -/
+
+/-- **A nonzero exponent forces units.** If `Monoid.exponent M ≠ 0` then for every
+`x`, the identity `x ^ e = 1` (with `e = exp M ≥ 1`) makes `x^(e-1)` a two-sided
+inverse of `x`, so `x` is a unit. -/
+theorem isUnit_of_exponent_ne_zero [Monoid M] (h : Monoid.exponent M ≠ 0) (x : M) :
+    IsUnit x := by
+  have he1 : 1 ≤ Monoid.exponent M := Nat.one_le_iff_ne_zero.mpr h
+  have hx : x * x ^ (Monoid.exponent M - 1) = 1 := by
+    rw [← pow_succ', Nat.sub_add_cancel he1]; exact Monoid.pow_exponent_eq_one x
+  have hx' : x ^ (Monoid.exponent M - 1) * x = 1 := by
+    rw [← pow_succ, Nat.sub_add_cancel he1]; exact Monoid.pow_exponent_eq_one x
+  exact ⟨⟨x, x ^ (Monoid.exponent M - 1), hx, hx'⟩, rfl⟩
+
+/-- **A single non-unit collapses the exponent.** The contrapositive of
+`isUnit_of_exponent_ne_zero`: if some element of `M` fails to be a unit, then
+`Monoid.exponent M = 0`. This is why no `|M|`- or `exp`-based image statement can
+carry content on a monoid that is not a group. -/
+theorem exponent_eq_zero_of_exists_not_isUnit [Monoid M]
+    (h : ∃ x : M, ¬ IsUnit x) : Monoid.exponent M = 0 := by
+  by_contra hne
+  obtain ⟨x, hx⟩ := h
+  exact hx (isUnit_of_exponent_ne_zero hne x)
+
+/-- **Characterization (finite commutative case).** For a finite commutative
+monoid, `Monoid.exponent M ≠ 0` holds *exactly* when every element is a unit —
+i.e. exactly when `M` is a group. The forward direction is the crux above; the
+converse transfers the (nonzero) exponent of the finite group of units `Mˣ`. -/
+theorem exponent_ne_zero_iff_forall_isUnit
+    [CommMonoid M] [Fintype M] [DecidableEq M] :
+    Monoid.exponent M ≠ 0 ↔ ∀ x : M, IsUnit x := by
+  constructor
+  · intro h x
+    exact isUnit_of_exponent_ne_zero h x
+  · intro hall
+    rw [Monoid.exponent_ne_zero]
+    refine ⟨Monoid.exponent Mˣ, Nat.pos_of_ne_zero (Monoid.exponent_ne_zero_of_finite), ?_⟩
+    intro x
+    obtain ⟨u, rfl⟩ := hall x
+    rw [← Units.val_pow_eq_pow_val, Monoid.pow_exponent_eq_one, Units.val_one]
+
+/-! ### 2. The positive answer: image equality on the group of units -/
+
+/-- **Exponent–gcd image equality on the units (the parent's home for monoids).**
+`Mˣ` is a group, so the parent theorem applies unchanged: as *sets*, the `n`-th
+powers among the units of `M` coincide with the `gcd(n, exp Mˣ)`-th powers. This
+is the "restricted to its group of units" reading of parent OQ #2. -/
+theorem range_pow_units_eq_gcd_exponent [Monoid M] (n : ℕ) :
+    Set.range (fun u : Mˣ => u ^ n)
+      = Set.range (fun u : Mˣ => u ^ Nat.gcd n (Monoid.exponent Mˣ)) :=
+  range_pow_eq_range_pow_gcd_exponent n
+
+/-! ### 3. The full-monoid readings: degeneracy against `exp`, failure against `|M|` -/
+
+/-- **Against the exponent, the "otherwise" reading degenerates.** For a finite
+monoid that is *not* a group (it has a non-unit), `exp M = 0`, hence
+`gcd(n, exp M) = n` and the image equality `range(·ⁿ) = range(·^gcd(n, exp M))`
+holds — but only as the identity of the power map with itself. No content beyond
+the units survives. -/
+theorem range_pow_eq_range_pow_gcd_exponent_of_not_group [Monoid M]
+    (h : ∃ x : M, ¬ IsUnit x) (n : ℕ) :
+    Set.range (fun x : M => x ^ n)
+      = Set.range (fun x : M => x ^ Nat.gcd n (Monoid.exponent M)) := by
+  rw [exponent_eq_zero_of_exists_not_isUnit h, Nat.gcd_zero_right]
+
+/-- `ZMod 4` under multiplication is a finite commutative monoid that is **not** a
+group: `2` is a non-unit (`2 · x ∈ {0,2}` never hits `1`). -/
+theorem not_isUnit_two_zmod4 : ¬ IsUnit (2 : ZMod 4) := by decide
+
+/-- Consequently its exponent is `0` — a witness of the crux above. -/
+theorem exponent_zmod4_eq_zero : Monoid.exponent (ZMod 4) = 0 :=
+  exponent_eq_zero_of_exists_not_isUnit ⟨2, not_isUnit_two_zmod4⟩
+
+/-- **The exponent reading holds, trivially, on `ZMod 4`.** Since `exp = 0`,
+`gcd(n, exp) = n` and both sides are the same map. -/
+theorem exp_statement_trivial_zmod4 (n : ℕ) :
+    Set.range (fun x : ZMod 4 => x ^ n)
+      = Set.range (fun x : ZMod 4 => x ^ Nat.gcd n (Monoid.exponent (ZMod 4))) := by
+  rw [exponent_zmod4_eq_zero, Nat.gcd_zero_right]
+
+/-- **The `|M|`-order surrogate genuinely fails.** With `|ZMod 4| = 4` and
+`gcd(3,4) = 1`, the cyclic-style prediction would equate the cube map with the
+identity map. But the cube map has image `{0,1,3}` (missing `2`), while the
+identity map has image all of `ZMod 4`. So the order-based statement — the direct
+transcription of the parent's cyclic form — is false on this non-group monoid. -/
+theorem order_surrogate_fails_zmod4 :
+    Finset.univ.image (fun x : ZMod 4 => x ^ 3)
+      ≠ Finset.univ.image (fun x : ZMod 4 => x ^ Nat.gcd 3 (Fintype.card (ZMod 4))) := by
+  decide

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 58 },
+    "type": "concept",
+    "title": "From Groups to Monoids: What the Exponent Still Governs",
+    "content": "The parent proved, in every group, range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) with the exponent as the invariant, and asked whether this survives on a finite commutative monoid — on its units 'or otherwise'. The answer is a dichotomy driven by a single fact: the multiplicative exponent detects group-likeness. Restricted to the units Mˣ the equality holds verbatim; on any monoid with a genuine non-unit the exponent collapses to 0 and there is no content left to extend.",
+    "mathContext": "$$\\operatorname{range}(x\\mapsto x^n)=\\operatorname{range}\\!\\left(x\\mapsto x^{\\gcd(n,\\exp M)}\\right)\\ \\text{on } M^\\times;\\qquad \\exp M=0 \\text{ once } M \\text{ has a non-unit.}$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "monoid exponent",
+      "group of units",
+      "power map endomorphism",
+      "group-likeness"
+    ],
+    "prerequisites": [
+      "monoid exponent",
+      "units of a monoid",
+      "gcd of naturals"
+    ]
+  },
+  {
+    "id": "ann-group-image",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 68, "endLine": 95 },
+    "type": "tactic",
+    "title": "The Group Image Theorem, Reproved Inline",
+    "content": "range_pow_eq_range_pow_gcd_exponent is the parent's group result, reproved here so the file is self-contained. The easy inclusion uses gcd(n,e) ∣ n, writing xⁿ = (x^(n/d))^d. The hard inclusion is Bézout: gcd(n,e) = n·A + e·B over ℤ (Nat.gcd_eq_gcd_ab), and since x^e = 1 the term x^(e·B) vanishes, giving x^gcd(n,e) = x^(n·A) = (x^A)ⁿ via zpow_mul and zpow_add. This is the theorem later applied to Mˣ.",
+    "mathContext": "$$x^{\\gcd(n,e)} = x^{nA+eB} = (x^A)^n\\,(x^e)^B = (x^A)^n,\\qquad e=\\exp G,\\ x^e=1.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bézout's identity",
+      "integer powers (zpow)",
+      "image of the power map"
+    ],
+    "prerequisites": [
+      "Nat.gcd_eq_gcd_ab",
+      "zpow_mul",
+      "zpow_add"
+    ]
+  },
+  {
+    "id": "ann-crux",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 99, "endLine": 109 },
+    "type": "insight",
+    "title": "A Nonzero Exponent Forces Units",
+    "content": "The crux of the whole entry. If exp M ≠ 0 then e = exp M ≥ 1 and x^e = 1 for every x (Monoid.pow_exponent_eq_one). Then x·x^(e-1) = x^e = 1 and x^(e-1)·x = x^e = 1, so x^(e-1) is a genuine two-sided inverse and x is a unit. The candidate inverse is a power of x, hence commutes with x automatically — no commutativity or Dedekind-finiteness hypothesis is needed. Contrapositively (exponent_eq_zero_of_exists_not_isUnit), a single non-unit forces exp M = 0.",
+    "mathContext": "$$\\exp M\\ne 0,\\ e=\\exp M\\ge 1 \\;\\Rightarrow\\; x\\cdot x^{e-1}=x^{e-1}\\cdot x=x^{e}=1 \\;\\Rightarrow\\; x\\in M^\\times.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "monoid exponent",
+      "two-sided inverse",
+      "units of a monoid"
+    ],
+    "prerequisites": [
+      "Monoid.pow_exponent_eq_one",
+      "IsUnit",
+      "pow_succ / pow_succ'"
+    ]
+  },
+  {
+    "id": "ann-characterization",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 121, "endLine": 136 },
+    "type": "insight",
+    "title": "Exponent ≠ 0 ⟺ Every Element Is a Unit (finite commutative case)",
+    "content": "The forward direction is the crux above. The converse assumes every element is a unit and produces a positive uniform annihilating power: Mˣ is a finite group, so exp Mˣ ≠ 0 (Monoid.exponent_ne_zero_of_finite); for x = ↑u a unit, x^(exp Mˣ) = ↑(u^(exp Mˣ)) = ↑1 = 1 via Units.val_pow_eq_pow_val, so ExponentExists M holds. Thus for finite commutative M the exponent is nonzero exactly when M is a group.",
+    "mathContext": "$$\\text{finite comm. } M:\\quad \\exp M\\ne 0 \\iff \\forall x,\\ \\mathrm{IsUnit}\\,x.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "group of units",
+      "exponent exists",
+      "finite groups"
+    ],
+    "prerequisites": [
+      "Monoid.exponent_ne_zero",
+      "Monoid.exponent_ne_zero_of_finite",
+      "Units.val_pow_eq_pow_val"
+    ]
+  },
+  {
+    "id": "ann-units-positive",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 140, "endLine": 147 },
+    "type": "concept",
+    "title": "The Positive Answer: Image Equality on the Units",
+    "content": "range_pow_units_eq_gcd_exponent is a one-line corollary: Mˣ is always a group, so the inlined group theorem applies to it directly, giving range(u ↦ uⁿ) = range(u ↦ u^gcd(n, exp Mˣ)) as sets of units. This is the 'restricted to its group of units' reading of parent open question #2 — and the only place the exponent–gcd equality carries genuine content on a monoid.",
+    "mathContext": "$$\\operatorname{range}(u\\mapsto u^n)=\\operatorname{range}\\!\\left(u\\mapsto u^{\\gcd(n,\\exp M^\\times)}\\right)\\quad\\text{on } M^\\times.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "group of units",
+      "power map image",
+      "specialization of a group theorem"
+    ],
+    "prerequisites": [
+      "units form a group",
+      "range_pow_eq_range_pow_gcd_exponent"
+    ]
+  },
+  {
+    "id": "ann-counterexample",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 177, "endLine": 185 },
+    "type": "insight",
+    "title": "The |M|-Order Surrogate Fails on ℤ/4",
+    "content": "The multiplicative monoid ℤ/4 is finite commutative but not a group: 2 is a non-unit (2·x ∈ {0,2} never equals 1), so exp(ℤ/4) = 0 and the exponent statement holds only vacuously. The order-based surrogate — the literal transcription of the parent's cyclic form using |M| = 4 — predicts range(x ↦ x³) = range(x ↦ x^gcd(3,4)) = range(x ↦ x¹) = ℤ/4. But the cube map has image {0,1,3} (2 is missing: 0³=0, 1³=1, 2³=0, 3³=3). Since {0,1,3} ≠ ℤ/4, the surrogate is false — proved by decide, not native_decide.",
+    "mathContext": "$$\\{x^3 : x\\in\\mathbb{Z}/4\\}=\\{0,1,3\\}\\ \\ne\\ \\mathbb{Z}/4=\\{x^{\\gcd(3,4)} : x\\in\\mathbb{Z}/4\\}.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "counterexample",
+      "non-unit elements",
+      "decidable image comparison"
+    ],
+    "prerequisites": [
+      "ZMod multiplicative monoid",
+      "Finset.image",
+      "decide"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02",
+  "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02",
+  "title": "The exponent–gcd image equality on a finite commutative monoid: units carry it, the exponent detects group-likeness, and the order-based surrogate fails",
+  "description": "The parent proved, in EVERY group, the image equality range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) with the exponent e = exp G as the governing invariant, and asked (its open question #2) whether a correct exponent–gcd statement survives the passage to a finite commutative monoid, 'restricted to its group of units or otherwise'. This entry answers it precisely. The crux is that for a monoid the exponent detects group-likeness: exp M ≠ 0 forces every element to be a unit (if x^e = 1 with e ≥ 1 then x^(e-1) is a two-sided inverse of x), so a single non-unit collapses exp M to 0; for a finite commutative monoid this is an iff — exp M ≠ 0 ⇔ every element is a unit — the converse transferring the nonzero exponent of the finite group of units Mˣ. Consequently: (1) restricted to the group of units, the parent theorem applies verbatim to Mˣ (a group), giving range(u ↦ uⁿ) = range(u ↦ u^gcd(n, exp Mˣ)) among the units — the right home for the equality; (2) 'otherwise', on a non-group finite monoid exp M = 0, so gcd(n, exp M) = n and the exponent statement holds but only vacuously, as the identity of the power map with itself — there is no exponent–gcd content on the non-unit part; (3) the naive |M|-order surrogate (the direct transcription of the parent's cyclic form) is genuinely FALSE: in the multiplicative monoid ℤ/4 (2 is a non-unit, exp = 0) the cube map has image {0,1,3} while gcd(3, |ℤ/4|) = gcd(3,4) = 1 would predict the full monoid, and {0,1,3} ≠ ℤ/4. Everything is over Mathlib.Tactic; no axioms, no native_decide.",
+  "leanFile": {
+    "imports": ["Mathlib.Tactic"],
+    "opens": [],
+    "namespace": "",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "In a finite group the power map x ↦ xⁿ is well understood: it is bijective exactly when gcd(n, |G|) = 1, and more generally its kernel is the n-torsion subgroup while its image is the subgroup of n-th powers. The parent line of work traced this through the cyclic case (where the order |G| and the count #range·#ker = |G| do the work), the general finite abelian case, and finally to the observation that the true invariant is the exponent e = exp G, not the order — against the exponent the image equality range(·ⁿ) = range(·^gcd(n,e)) holds in every group. The natural next question, common in semigroup theory, is what remains once inverses are dropped: on a finite commutative monoid the power map is still an endomorphism, but the exponent and the clean torsion picture can break down on the non-unit part (idempotents, nilpotents, absorbing elements).",
+    "problemStatement": "Does the exponent–gcd image equality range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp M)) extend to a finite commutative monoid M — either restricted to its group of units Mˣ, or in some corrected form on all of M? And does the alternative |M|-based (order) form survive?",
+    "proofStrategy": "First isolate the crux: the multiplicative exponent detects group-likeness. If exp M ≠ 0, pick e = exp M ≥ 1; then x^e = 1 for all x (Monoid.pow_exponent_eq_one), and x^(e-1) is a two-sided inverse of x, so every element is a unit (isUnit_of_exponent_ne_zero). Contrapositively a single non-unit forces exp M = 0 (exponent_eq_zero_of_exists_not_isUnit). For finite commutative M the converse holds by transferring the nonzero exponent of the finite group of units Mˣ, giving the characterization exp M ≠ 0 ⇔ ∀ x, IsUnit x. With the crux in hand: on the units, Mˣ is a group so the parent theorem applies unchanged; on a non-group monoid exp M = 0 makes gcd(n, exp M) = n and the exponent statement collapses to reflexivity; and the |M|-order surrogate is refuted by an explicit decidable counterexample in ℤ/4.",
+    "keyInsights": [
+      "The multiplicative exponent is a group-likeness detector for finite monoids: exp M ≠ 0 ⇔ every element is a unit. A single genuine non-unit sends exp M to 0.",
+      "The one-sided-to-two-sided step is free here because the candidate inverse x^(e-1) is a power of x, so it commutes with x automatically — no Dedekind-finiteness or commutativity is needed for isUnit_of_exponent_ne_zero.",
+      "The 'restricted to the group of units' reading is the correct home: Mˣ is always a group, so the parent's exponent–gcd image equality holds there verbatim.",
+      "On the non-unit part the exponent statement is true but vacuous (exp = 0 ⇒ gcd(n,0) = n ⇒ both sides are the same map): there is no genuine exponent–gcd content to extend.",
+      "The order-based |M| surrogate — the literal transcription of the parent's cyclic form — is genuinely false off groups: ℤ/4 under multiplication is an explicit decidable counterexample."
+    ]
+  },
+  "sections": [
+    {
+      "id": "group-image-inline",
+      "title": "The group image theorem (reproved inline from the parent)",
+      "startLine": 62,
+      "endLine": 95,
+      "summary": "range_pow_eq_range_pow_gcd_exponent: in any group, range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)). Easy inclusion from gcd(n,e) ∣ n; hard inclusion from Bézout gcd(n,e) = n·A + e·B with x^e = 1, so x^gcd(n,e) = (x^A)ⁿ. Reproved here (with its zpow helper) so the file is self-contained.",
+      "mathContext": "range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) in every group; x^gcd(n,e) = x^(nA+eB) = (x^A)ⁿ since x^e = 1."
+    },
+    {
+      "id": "exponent-detects-units",
+      "title": "The crux: exp M ≠ 0 iff every element is a unit",
+      "startLine": 99,
+      "endLine": 136,
+      "summary": "isUnit_of_exponent_ne_zero: exp M ≠ 0 ⇒ every x is a unit (x^(e-1) is a two-sided inverse). exponent_eq_zero_of_exists_not_isUnit: a single non-unit ⇒ exp M = 0. exponent_ne_zero_iff_forall_isUnit: for finite commutative M this is an iff, the converse transferring the nonzero exponent of the finite group Mˣ.",
+      "mathContext": "For finite commutative M: Monoid.exponent M ≠ 0 ⇔ (∀ x, IsUnit x); a genuine non-unit forces exp M = 0."
+    },
+    {
+      "id": "units-positive",
+      "title": "The positive answer: image equality on the group of units",
+      "startLine": 138,
+      "endLine": 147,
+      "summary": "range_pow_units_eq_gcd_exponent: since Mˣ is a group, the parent theorem gives range(u ↦ uⁿ) = range(u ↦ u^gcd(n, exp Mˣ)) among the units of M — the 'restricted to its group of units' reading of parent OQ #2.",
+      "mathContext": "range(u ↦ uⁿ) = range(u ↦ u^gcd(n, exp Mˣ)) on Mˣ, directly from the group theorem applied to the units."
+    },
+    {
+      "id": "full-monoid-readings",
+      "title": "Full-monoid readings: degeneracy against exp, failure against |M|",
+      "startLine": 149,
+      "endLine": 185,
+      "summary": "range_pow_eq_range_pow_gcd_exponent_of_not_group: on a non-group monoid exp M = 0, so the exponent equality holds vacuously (gcd(n,0) = n). The ℤ/4 witnesses: not_isUnit_two_zmod4, exponent_zmod4_eq_zero, exp_statement_trivial_zmod4, and order_surrogate_fails_zmod4 — the cube map image {0,1,3} differs from the gcd(3,4)=1 identity-map image, so the |M|-order surrogate is false.",
+      "mathContext": "ℤ/4 (×): image of x↦x³ is {0,1,3} ≠ ℤ/4 = image of x↦x^gcd(3,4); yet the exp form holds trivially since exp(ℤ/4) = 0."
+    }
+  ],
+  "conclusion": {
+    "summary": "The exponent–gcd image equality extends to a finite commutative monoid in exactly one substantive way: restricted to the group of units Mˣ, where the parent theorem applies verbatim because Mˣ is a group. The reason there is nothing more is a clean dichotomy — the multiplicative exponent detects group-likeness: exp M ≠ 0 ⇔ every element of M is a unit. So the moment M has a genuine non-unit, exp M = 0, the exponent statement range(·ⁿ) = range(·^gcd(n, exp M)) degenerates to reflexivity (gcd(n,0) = n), and the order-based |M| surrogate — the literal transcription of the parent's cyclic form — becomes outright false, as the multiplicative monoid ℤ/4 shows (cube image {0,1,3} ≠ ℤ/4). The correct statement lives on the units; on the rest, there is no exponent–gcd content to recover.",
+    "implications": "The result sharpens the meaning of 'exponent' for monoids: Monoid.exponent M is a nonzero, useful invariant only when M is group-like, and its vanishing is a precise obstruction to any coprime-power-map theory on the non-unit part. Any attempt to carry the parent's image equality into monoid or semigroup settings must first pass to the units; the group-of-units restriction is not a convenience but the whole content.",
+    "openQuestions": [
+      "For a finite commutative monoid M, is the image range(x ↦ xⁿ) on all of M controlled by a monoid-theoretic invariant other than exp — e.g. via the eventual idempotent power and the Rees/Clifford decomposition of M into its maximal subgroups — giving a genuine 'range stabilizes to a subgroup' statement in place of the (vacuous) exponent form?",
+      "Quantify the failure margin of the |M|-order surrogate: over finite commutative monoids of order N, how large can the symmetric difference between range(x ↦ xⁿ) and range(x ↦ x^gcd(n, N)) be, and which monoid structures (nilpotent, idempotent-rich, group-plus-zero) maximize it?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Howie, John M.",
+      "title": "Fundamentals of Semigroup Theory",
+      "year": "1995",
+      "venue": "Oxford University Press",
+      "note": "Structure of finite commutative monoids: every element has an idempotent power, and the monoid decomposes over its maximal subgroups (Clifford/Rees theory) — the setting in which the non-unit part obstructs a naive exponent."
+    },
+    {
+      "authors": "Hall, Marshall, Jr.",
+      "title": "The Theory of Groups",
+      "year": "1959",
+      "venue": "Macmillan",
+      "note": "Power maps and coprime automorphisms on finite groups: x ↦ x^n is bijective when gcd(n, |G|) = 1 — the group-side statement whose monoid extension is settled here by restriction to the units."
+    },
+    {
+      "authors": "Lang, Serge",
+      "title": "Algebra (3rd ed.)",
+      "year": "2002",
+      "venue": "Springer GTM 211",
+      "note": "Group exponent, units of a monoid, and the general theory of endomorphisms x ↦ x^n on abelian groups."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Directly answers the parent's open question #2. The parent proved the exponent–gcd image equality in every group; this entry determines what survives on a finite commutative monoid — the units carry it verbatim, while the exponent detects group-likeness and the order-based surrogate fails off groups."
+    },
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02",
+      "relationship": "related",
+      "description": "The grandparent introduced the gcd-with-order form of the power map on cyclic groups; the ℤ/4 counterexample here pinpoints exactly why that order-based form cannot be transcribed to non-group monoids."
+    }
+  ],
+  "meta": {
+    "author": "Lean formalization original (exponent–gcd image equality on a finite commutative monoid: units restriction, group-likeness dichotomy, and failure of the order surrogate)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01OQ02.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "monoid",
+      "finite-monoids",
+      "power-map",
+      "monoid-exponent",
+      "units",
+      "group-of-units",
+      "gcd",
+      "counterexample",
+      "zmod"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Monoid.pow_exponent_eq_one",
+        "description": "g ^ Monoid.exponent M = 1; when exp M ≥ 1 this makes x^(e-1) a two-sided inverse of x, the heart of isUnit_of_exponent_ne_zero.",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "Monoid.exponent_ne_zero",
+        "description": "exponent M ≠ 0 ↔ ExponentExists M; used to prove the converse of the characterization by exhibiting exp Mˣ as a uniform annihilating power.",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "Monoid.exponent_ne_zero_of_finite",
+        "description": "For a finite left-cancel monoid (in particular the finite group Mˣ) the exponent is nonzero; supplies the positive exponent transferred back to M when every element is a unit.",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "Nat.gcd_eq_gcd_ab",
+        "description": "Bézout's identity ↑(gcd a b) = a·gcdA a b + b·gcdB a b over ℤ; drives the hard inclusion of the inlined group image theorem.",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Units.val_pow_eq_pow_val",
+        "description": "↑(u^n) = (↑u)^n for units; transfers x^(exp Mˣ) = 1 from the group of units back to elements of M in the characterization.",
+        "module": "Mathlib.Algebra.Group.Units.Defs"
+      },
+      {
+        "theorem": "Nat.gcd_zero_right",
+        "description": "gcd n 0 = n; makes the exponent statement collapse to reflexivity once exp M = 0 on a non-group monoid.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      }
+    ],
+    "references": []
+  }
+}


### PR DESCRIPTION
## Summary

Answers **parent open question #2** of `cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01`: *does the exponent–gcd image equality* `range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp M))` *extend to a finite commutative monoid, restricted to its group of units or otherwise?*

The answer is a clean dichotomy driven by one fact: **the multiplicative exponent detects group-likeness.**

- **Crux** (`isUnit_of_exponent_ne_zero`): if `exp M ≠ 0` then `e = exp M ≥ 1`, `x^e = 1`, and `x^(e-1)` is a two-sided inverse of `x` — so every element is a unit. The candidate inverse is a power of `x`, so it commutes automatically; no commutativity or Dedekind-finiteness is needed. Contrapositively a single non-unit collapses `exp M` to `0`. For finite commutative `M` this is an **iff** (`exponent_ne_zero_iff_forall_isUnit`), the converse transferring the nonzero exponent of the finite group `Mˣ`.
- **Positive answer** (`range_pow_units_eq_gcd_exponent`): `Mˣ` is always a group, so the parent theorem applies verbatim — the equality holds among the **units**. This is the right home for it.
- **Otherwise it degenerates** (`range_pow_eq_range_pow_gcd_exponent_of_not_group`): a non-group finite monoid has `exp M = 0`, so `gcd(n, exp M) = n` and the exponent statement is true but *vacuous* (identity of the power map with itself).
- **The order-based `|M|` surrogate is genuinely false** (`order_surrogate_fails_zmod4`): in the multiplicative monoid `ℤ/4` (2 is a non-unit, `exp = 0`) the cube map has image `{0,1,3}`, while `gcd(3, |ℤ/4|) = gcd(3,4) = 1` predicts all of `ℤ/4`. `{0,1,3} ≠ ℤ/4` — proved by `decide` (not `native_decide`).

## Verification

- **10 theorems, 0 definitions, 185 lines, 0 sorries.**
- `#print axioms` on the key results lists only `[propext, Classical.choice, Quot.sound]` — **0 axioms** (no `Lean.ofReduceBool`, no `sorryAx`).
- The parent's group image theorem is reproved inline so the file is self-contained (`import Mathlib.Tactic` only).

## Files

- `proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01OQ02.lean`
- `src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)