### PR TITLE
audit: 8 never-audited OQ entries clean (gallery integrity)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26863,6 +26863,54 @@
       "lastAudited": "2026-07-01T19:37:36Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-02-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T20:12:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-07-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T20:12:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "composition-parts-choose-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T20:12:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "composition-parts-choose-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T20:12:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dirichlet-approximation-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T20:12:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1021-wip-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T20:12:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "jensen-inequality-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T20:12:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-04-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T20:12:13Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: drained the 8 never-audited entries in the queue. **All clean, 0 issues.**

## Audited (all VERIFIED, claims match Lean source)
| slug | badge | check |
|------|-------|-------|
| amgm-inequality-oq-02-oq-05 | original | 0 sorry/axiom/True ✓ |
| combinations-formula-oq-07-oq-01-oq-01 | mathlib | 0 sorry/axiom/True ✓ |
| composition-parts-choose-oq-01-oq-01-oq-01-oq-02 | original | 0 sorry/axiom/True ✓ |
| composition-parts-choose-oq-01-oq-03 | original | 0 sorry/axiom/True ✓ (sorry match was docstring) |
| dirichlet-approximation-theorem-oq-01-oq-03 | original | 0 sorry/axiom/True ✓ |
| erdos-1021-wip-02 | verified | 0 sorry/axiom/True ✓; assumptions explicitly scope OUT open #1021 exponent |
| jensen-inequality-oq-01-oq-03 | original | 0 sorry/axiom/True ✓ |
| pythagorean-triples-oq-04-oq-04 | mathlib | 0 sorry/axiom/True ✓ |

Tracker now 4332/4332 audited, 0 with issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)