### PR TITLE
Research: erdos-798 - prove latticeGrid_card (6→5 sorries)

### DIFF
--- a/proofs/Proofs/Erdos798Problem.lean
+++ b/proofs/Proofs/Erdos798Problem.lean
@@ -55,7 +55,15 @@ def latticeGrid (n : ℕ) : Set (ℤ × ℤ) :=
 -/
 theorem latticeGrid_card (n : ℕ) (hn : n ≥ 1) :
     (latticeGrid n).ncard = n^2 := by
-  sorry
+  have hset : latticeGrid n =
+      ↑((Finset.Icc (1 : ℤ) (n : ℤ)) ×ˢ (Finset.Icc (1 : ℤ) (n : ℤ))) := by
+    ext p
+    simp only [latticeGrid, Set.mem_setOf_eq, Finset.coe_product, Set.mem_prod,
+      Finset.coe_Icc, Set.mem_Icc]
+    tauto
+  have hc : (Finset.Icc (1 : ℤ) (n : ℤ)).card = n := by
+    rw [Int.card_Icc]; omega
+  rw [hset, Set.ncard_coe_finset, Finset.card_product, hc, ← pow_two]
 
 /--
 **Line Through Two Points:**

--- a/src/data/proofs/erdos-798/meta.json
+++ b/src/data/proofs/erdos-798/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 5,
     "erdosNumber": 798,
     "erdosUrl": "https://erdosproblems.com/798",
     "erdosProblemStatus": "solved",
@@ -67,7 +67,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 345,
-    "assumptions": "3 axiom(s) and 6 sorry(s). See the Lean source for details.",
+    "assumptions": "3 axiom(s) and 5 sorry(s). See the Lean source for details.",
     "theoremCount": 11,
     "definitionCount": 7,
     "additionalFiles": [
@@ -190,7 +190,7 @@
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 7,
-    "sorries": 6,
+    "sorries": 5,
     "path": "Proofs/Erdos798Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos798Aristotle.lean",
@@ -214,5 +214,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, geometry, solved"
     }
   ],
-  "sorries": 6
+  "sorries": 5
 }


### PR DESCRIPTION
## Summary
Research session on **Erdős Problem #798** (Covering Lattice Points with Lines). Eliminated one sorry by proving the grid-cardinality lemma.

## Progress
- **Proved `latticeGrid_card`**: `(latticeGrid n).ncard = n^2` for `n ≥ 1`.
  - Route: identify `latticeGrid n` with `↑(Finset.Icc 1 n ×ˢ Finset.Icc 1 n)`, then `Set.ncard_coe_finset` + `Finset.card_product` + `Int.card_Icc` (via `omega`) + `pow_two`.
  - `#print axioms latticeGrid_card` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`).
- Sorry count: **6 → 5**. Updated `meta.json` (`sorries`, `assumptions`).

## Files Modified
- `proofs/Proofs/Erdos798Problem.lean` (proof of `latticeGrid_card`)
- `src/data/proofs/erdos-798/meta.json` (sorries 6→5)

## Findings
- The 3 axioms (`erdos_purdy_lower_bound`, `alon_upper_bound`, `alon_construction`) encode deep research results (Erdős–Purdy lower bound, Alon 1991 construction) and are **not** Mathlib-provable — no axiom elimination possible this session.
- **Correctness flag**: the sorry `t_2_bound : t 2 ≤ 3` appears to be a *false* claim. The 2×2 grid has exactly 4 points; each corner lies on **no** line through two of the *other* three grid points (the three lines they determine are `x=1`, `y=1`, and the anti-diagonal `x+y=3`, none through the 4th corner). So every corner must itself be chosen ⇒ `t(2) = 4`, not `3`. This sorry was left in place (a false statement is unprovable); the docstring/claim should be corrected in a follow-up. `t_3_bound` should be re-examined similarly.

## Status
**Outcome**: progress (1 sorry eliminated, verified 0-axiom-beyond-foundational)
**Next Steps**:
- `lines_from_points` (≤ C(k,2) bound) is provable but needs unordered-pair/symmetry bookkeeping.
- `lower_bound_intuition` (t(n) ≥ √(2n)) and `explicit_lower` require the Erdős–Purdy counting argument — research-hard.
- Correct the `t_2_bound`/`t_3_bound` claims (t(2)=4).

🤖 Generated by researcher-13