### PR TITLE
research(cauchy-group-theorem-oq-01-oq-03): prime spectrum = element-order spectrum [VERIFIED, 0-axiom, 15thm, new entry]

### DIFF
--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ03.lean
@@ -1,0 +1,195 @@
+import Mathlib.GroupTheory.Perm.Cycle.Type
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.Data.Nat.PrimeFin
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic
+
+/-
+# The prime spectrum of a finite group via element orders
+
+*Follow-up to `cauchy-group-theorem-oq-01` (Open Question 2).*
+
+The parent entry formalises **Cauchy's theorem** — if a prime `p` divides `|G|`
+then `G` has an element of order `p` — together with a *one-way* contrapositive
+certificate: the absence of an order-`p` element proves `p ∤ |G|`
+(`not_dvd_card_of_no_orderOf_eq`).
+
+Open Question 2 asks to turn that certificate into a **decidable test on the
+prime set of `|G|`**: an algorithm that, for a concrete finite group, certifies
+exactly which primes divide the order by exhibiting order-`p` elements (presence)
+or ruling them out (absence).
+
+The mathematical heart of such a test is the **biconditional** that the parent
+stops short of stating. Cauchy gives the hard `(→)` direction; the elementary
+Lagrange fact `orderOf x ∣ |G|` gives the easy `(←)` direction. Together:
+
+> For a prime `p`, `p ∣ |G|` **if and only if** `G` has an element of order `p`.
+
+Equivalently, the set of primes dividing `|G|` is *exactly* the set of primes
+that occur as an element order:
+
+> `p ∈ (Fintype.card G).primeFactors ↔ ∃ x : G, orderOf x = p`   (for `p` prime).
+
+Because both sides are decidable predicates on a `Fintype`, this **is** the
+decidable prime certificate: to certify the full prime spectrum of a concrete
+group one checks, prime by prime, whether an order-`p` witness exists.
+
+We prove the biconditional (multiplicative and additive), the two-way absence
+certificate that generalises the parent's one-way version, the prime-spectrum
+characterisation, and then run the certificate end-to-end on `ZMod 12`
+(order `12 = 2² · 3`): primes `2, 3` are present, prime `5` is absent — all
+discharged through the general theorems, with kernel `decide` only on `ℕ`
+(no `native_decide`, so no `Lean.ofReduceBool`).
+
+Everything is verified from Mathlib; the file introduces no axioms.
+-/
+
+variable {G : Type*}
+
+/-! ## The Cauchy biconditional -/
+
+/-- **Cauchy biconditional (multiplicative).** For a prime `p`, the prime `p`
+divides `|G|` *if and only if* `G` contains an element of order exactly `p`.
+
+The forward direction is Cauchy's theorem (`exists_prime_orderOf_dvd_card`); the
+reverse is Lagrange's theorem in the form `orderOf x ∣ |G|` (`orderOf_dvd_card`).
+The parent entry proves only the forward direction and a one-way contrapositive —
+this biconditional is the missing piece that makes the prime test *decidable*. -/
+theorem prime_dvd_card_iff_exists_orderOf [Group G] [Fintype G] (p : ℕ) [Fact p.Prime] :
+    p ∣ Fintype.card G ↔ ∃ x : G, orderOf x = p := by
+  refine ⟨exists_prime_orderOf_dvd_card p, ?_⟩
+  rintro ⟨x, rfl⟩
+  exact orderOf_dvd_card
+
+/-- **Cauchy biconditional (additive).** The additive-group form of
+`prime_dvd_card_iff_exists_orderOf`, using additive orders. -/
+theorem prime_dvd_card_iff_exists_addOrderOf [AddGroup G] [Fintype G] (p : ℕ) [Fact p.Prime] :
+    p ∣ Fintype.card G ↔ ∃ x : G, addOrderOf x = p := by
+  refine ⟨exists_prime_addOrderOf_dvd_card p, ?_⟩
+  rintro ⟨x, rfl⟩
+  exact addOrderOf_dvd_card
+
+/-! ## The two-way absence certificate -/
+
+/-- **Two-way absence certificate (multiplicative).** For a prime `p`, `p` does
+**not** divide `|G|` *if and only if* `G` has *no* element of order `p`.
+
+This upgrades the parent's `not_dvd_card_of_no_orderOf_eq` (which proves only
+`(no order-p element) → p ∤ |G|`) to a biconditional: the *absence* of an
+order-`p` witness is not merely sufficient but *equivalent* to `p ∤ |G|`. It is
+the formal statement that "search for an order-`p` element" is a *complete*
+decision procedure for `p ∣ |G|`. -/
+theorem not_dvd_card_iff_forall_orderOf_ne [Group G] [Fintype G] (p : ℕ) [Fact p.Prime] :
+    ¬ p ∣ Fintype.card G ↔ ∀ x : G, orderOf x ≠ p := by
+  rw [prime_dvd_card_iff_exists_orderOf]
+  push_neg
+  rfl
+
+/-- **Two-way absence certificate (additive).** Additive-group form of
+`not_dvd_card_iff_forall_orderOf_ne`. -/
+theorem not_dvd_card_iff_forall_addOrderOf_ne [AddGroup G] [Fintype G] (p : ℕ) [Fact p.Prime] :
+    ¬ p ∣ Fintype.card G ↔ ∀ x : G, addOrderOf x ≠ p := by
+  rw [prime_dvd_card_iff_exists_addOrderOf]
+  push_neg
+  rfl
+
+/-! ## The prime spectrum as an order spectrum -/
+
+/-- **Prime spectrum = order spectrum (multiplicative).** A prime `p` lies in the
+set of prime factors of `|G|` *iff* it is realised as the order of some element.
+
+This is the set-level packaging of the Cauchy biconditional: the prime factors of
+`|G|` are exactly the primes appearing in the "order spectrum" `{orderOf x : x ∈ G}`.
+It is the object OQ 2 calls the *certified prime set* of the group. -/
+theorem mem_primeFactors_card_iff_exists_orderOf [Group G] [Fintype G] (p : ℕ)
+    (hp : p.Prime) : p ∈ (Fintype.card G).primeFactors ↔ ∃ x : G, orderOf x = p := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Nonempty G := ⟨1⟩
+  rw [Nat.mem_primeFactors]
+  refine ⟨fun h => (prime_dvd_card_iff_exists_orderOf p).1 h.2.1, fun h => ?_⟩
+  exact ⟨hp, (prime_dvd_card_iff_exists_orderOf p).2 h, Fintype.card_ne_zero⟩
+
+/-- **Prime spectrum = order spectrum (additive).** Additive-group form of
+`mem_primeFactors_card_iff_exists_orderOf`. -/
+theorem mem_primeFactors_card_iff_exists_addOrderOf [AddGroup G] [Fintype G] (p : ℕ)
+    (hp : p.Prime) : p ∈ (Fintype.card G).primeFactors ↔ ∃ x : G, addOrderOf x = p := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Nonempty G := ⟨0⟩
+  rw [Nat.mem_primeFactors]
+  refine ⟨fun h => (prime_dvd_card_iff_exists_addOrderOf p).1 h.2.1, fun h => ?_⟩
+  exact ⟨hp, (prime_dvd_card_iff_exists_addOrderOf p).2 h, Fintype.card_ne_zero⟩
+
+/-! ## Running the certificate on `ZMod 12`
+
+The additive group `ZMod 12` has order `12 = 2² · 3`, so its certified prime set
+is `{2, 3}`. We drive the general theorems above to certify the whole spectrum:
+`2` and `3` are present (with explicit witnesses), and `5` is absent — the
+prototypical output of the algorithm OQ 2 asks for. The presence/absence of each
+prime in `(card).primeFactors` is obtained *through* the spectrum theorem, so the
+concrete facts are corollaries of the general result rather than raw `ℕ`-trivia;
+every step reduces to a `decide` on divisibility of `ℕ` only, keeping the file
+free of `Lean.ofReduceBool`. -/
+
+/-- **Presence at `p = 2`.** `ZMod 12` has an element of additive order `2`,
+obtained from the Cauchy biconditional and `2 ∣ 12`. -/
+theorem exists_addOrderOf_two_zmod12 : ∃ x : ZMod 12, addOrderOf x = 2 := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  refine (prime_dvd_card_iff_exists_addOrderOf 2).1 ?_
+  rw [ZMod.card]; decide
+
+/-- **Presence at `p = 3`.** `ZMod 12` has an element of additive order `3`. -/
+theorem exists_addOrderOf_three_zmod12 : ∃ x : ZMod 12, addOrderOf x = 3 := by
+  haveI : Fact (Nat.Prime 3) := ⟨Nat.prime_three⟩
+  refine (prime_dvd_card_iff_exists_addOrderOf 3).1 ?_
+  rw [ZMod.card]; decide
+
+/-- The explicit order-`2` witness: `6 : ZMod 12` satisfies `6 ≠ 0` and `6+6 = 0`,
+so `addOrderOf 6 = 2`. Confirms the abstract presence certificate concretely. -/
+theorem addOrderOf_six_zmod12 : addOrderOf (6 : ZMod 12) = 2 := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  exact addOrderOf_eq_prime (by decide) (by decide)
+
+/-- The explicit order-`3` witness: `4 : ZMod 12` satisfies `4 ≠ 0` and `4+4+4 = 0`,
+so `addOrderOf 4 = 3`. -/
+theorem addOrderOf_four_zmod12 : addOrderOf (4 : ZMod 12) = 3 := by
+  haveI : Fact (Nat.Prime 3) := ⟨Nat.prime_three⟩
+  exact addOrderOf_eq_prime (by decide) (by decide)
+
+/-- **Absence at `p = 5`.** Since `5 ∤ 12`, the two-way absence certificate proves
+`ZMod 12` has *no* element of additive order `5` — a universally quantified
+non-existence obtained *without* enumerating all `12` elements, straight from the
+general theorem. This is the "certified absence" half of OQ 2's algorithm. -/
+theorem no_addOrderOf_five_zmod12 : ∀ x : ZMod 12, addOrderOf x ≠ 5 := by
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  rw [← not_dvd_card_iff_forall_addOrderOf_ne, ZMod.card]
+  decide
+
+/-- **`2` is in the certified prime spectrum of `ZMod 12`** — *because* an
+order-`2` element exists. A direct corollary of the spectrum theorem, reading the
+concrete membership off the presence certificate. -/
+theorem two_mem_spectrum_zmod12 : (2 : ℕ) ∈ (Fintype.card (ZMod 12)).primeFactors :=
+  (mem_primeFactors_card_iff_exists_addOrderOf 2 Nat.prime_two).2 exists_addOrderOf_two_zmod12
+
+/-- **`3` is in the certified prime spectrum of `ZMod 12`** — because an order-`3`
+element exists. -/
+theorem three_mem_spectrum_zmod12 : (3 : ℕ) ∈ (Fintype.card (ZMod 12)).primeFactors :=
+  (mem_primeFactors_card_iff_exists_addOrderOf 3 Nat.prime_three).2 exists_addOrderOf_three_zmod12
+
+/-- **`5` is *not* in the certified prime spectrum of `ZMod 12`** — because no
+order-`5` element exists. The absence certificate feeds the spectrum theorem to
+rule the prime out. Together with the two memberships this pins the spectrum down
+to exactly `{2, 3}`, prime by prime, entirely through the general theorem. -/
+theorem five_not_mem_spectrum_zmod12 : (5 : ℕ) ∉ (Fintype.card (ZMod 12)).primeFactors := by
+  rw [mem_primeFactors_card_iff_exists_addOrderOf 5 (by norm_num)]
+  rintro ⟨x, hx⟩
+  exact no_addOrderOf_five_zmod12 x hx
+
+/-- **Full certified spectrum of `ZMod 12`.** Packaging the three certificates:
+`5` is absent while `2` and `3` are present — the certified prime set is `{2, 3}`,
+exactly the prime factors of `12`, obtained one prime at a time via the
+biconditional rather than by trusting a `native_decide` computation. -/
+theorem certified_spectrum_zmod12 :
+    (5 : ℕ) ∉ (Fintype.card (ZMod 12)).primeFactors ∧
+      (2 : ℕ) ∈ (Fintype.card (ZMod 12)).primeFactors ∧
+        (3 : ℕ) ∈ (Fintype.card (ZMod 12)).primeFactors :=
+  ⟨five_not_mem_spectrum_zmod12, two_mem_spectrum_zmod12, three_mem_spectrum_zmod12⟩

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "cauchy-group-theorem-oq-01-oq-03",
+    "range": { "startLine": 7, "endLine": 45 },
+    "type": "concept",
+    "title": "Overview: From a One-Way Certificate to a Decidable Prime Test",
+    "content": "The docstring frames Open Question 2 of the parent entry. The parent proves Cauchy's theorem (p ∣ |G| ⟹ ∃ order-p element) and a ONE-WAY contrapositive certificate (no order-p element ⟹ p ∤ |G|), but leaves the prime test incomplete. The missing piece is the biconditional: p ∣ |G| if and only if G has an element of order p. Cauchy supplies the hard forward direction; Lagrange's orderOf x ∣ |G| supplies the easy reverse. Because both sides are decidable on a finite group, this equivalence IS a decision procedure for membership in the prime spectrum of |G|.",
+    "mathContext": "For a prime $p$: $p \\mid |G| \\iff \\exists x \\in G,\\ \\mathrm{ord}(x) = p$. Equivalently $p \\in (\\mathrm{card}\\,G).\\mathrm{primeFactors} \\iff \\exists x,\\ \\mathrm{ord}(x) = p$.",
+    "significance": "key",
+    "prerequisites": ["finite groups", "order of an element", "Cauchy's theorem", "Lagrange's theorem"],
+    "relatedConcepts": ["Cauchy's theorem", "Lagrange's theorem", "prime factors", "decidability", "Sylow theory"]
+  },
+  {
+    "id": "ann-biconditional",
+    "proofId": "cauchy-group-theorem-oq-01-oq-03",
+    "range": { "startLine": 51, "endLine": 70 },
+    "type": "theorem",
+    "title": "The Cauchy Biconditional",
+    "content": "`prime_dvd_card_iff_exists_orderOf` states p ∣ |G| ↔ ∃ x, orderOf x = p for a prime p, with an additive twin. The forward direction is Mathlib's Cauchy theorem (exists_prime_orderOf_dvd_card); the reverse is Lagrange's theorem in element form (orderOf_dvd_card: orderOf x ∣ |G|), applied after substituting orderOf x = p. The parent entry proves only the forward direction and a one-way contrapositive — recording the full equivalence is what turns 'search for an order-p element' into a complete, not merely sound, decision procedure.",
+    "mathContext": "Cauchy is the prime-case converse of Lagrange. Chaining $\\mathrm{ord}(x)\\mid|G|$ (Lagrange) with $p\\mid|G|\\Rightarrow\\exists x,\\mathrm{ord}(x)=p$ (Cauchy) closes the loop into an iff.",
+    "significance": "key",
+    "prerequisites": ["orderOf / addOrderOf", "Fact p.Prime", "Fintype.card"],
+    "relatedConcepts": ["exists_prime_orderOf_dvd_card", "orderOf_dvd_card", "to_additive", "biconditional"]
+  },
+  {
+    "id": "ann-absence",
+    "proofId": "cauchy-group-theorem-oq-01-oq-03",
+    "range": { "startLine": 74, "endLine": 94 },
+    "type": "theorem",
+    "title": "The Two-Way Absence Certificate",
+    "content": "`not_dvd_card_iff_forall_orderOf_ne` states ¬ p ∣ |G| ↔ ∀ x, orderOf x ≠ p — the contrapositive of the biconditional, obtained by rewriting and push_neg. This upgrades the parent's not_dvd_card_of_no_orderOf_eq, which proves only (no order-p element) → p ∤ |G|. As an equivalence it certifies that the absence of an order-p witness is not merely sufficient but precisely equivalent to p ∤ |G|: exhaustively failing to find an order-p element is a valid proof that p does not divide the order.",
+    "mathContext": "$\\lnot(p\\mid|G|) \\iff \\forall x,\\ \\mathrm{ord}(x)\\neq p$. The negation of an existential over a Fintype is a decidable universal.",
+    "significance": "important",
+    "prerequisites": ["push_neg", "contrapositive", "decidable existentials"],
+    "relatedConcepts": ["not_dvd_card_of_no_orderOf_eq", "decision procedure", "completeness"]
+  },
+  {
+    "id": "ann-spectrum",
+    "proofId": "cauchy-group-theorem-oq-01-oq-03",
+    "range": { "startLine": 98, "endLine": 120 },
+    "type": "theorem",
+    "title": "The Prime Spectrum Is the Order Spectrum",
+    "content": "`mem_primeFactors_card_iff_exists_orderOf` lifts the biconditional to the set level: a prime p lies in (Fintype.card G).primeFactors iff it is realised as an element order. The proof rewrites by Nat.mem_primeFactors (p ∈ n.primeFactors ↔ p.Prime ∧ p ∣ n ∧ n ≠ 0); the middle conjunct is exactly the biconditional, primality is the hypothesis, and n ≠ 0 is Fintype.card_ne_zero (a group is nonempty via its identity 1 / 0). So the prime factors of |G| ARE the prime part of the element-order spectrum — the certified prime set OQ 2 asks for.",
+    "mathContext": "$p \\in (\\mathrm{card}\\,G).\\mathrm{primeFactors} \\iff \\exists x,\\ \\mathrm{ord}(x)=p$ for $p$ prime. Reframes a number-theoretic invariant of $|G|$ as an intrinsic group-theoretic one.",
+    "significance": "key",
+    "prerequisites": ["Nat.primeFactors", "Nat.mem_primeFactors", "Fintype.card_ne_zero"],
+    "relatedConcepts": ["prime spectrum", "order spectrum", "Sylow index set"]
+  },
+  {
+    "id": "ann-zmod-witnesses",
+    "proofId": "cauchy-group-theorem-oq-01-oq-03",
+    "range": { "startLine": 133, "endLine": 166 },
+    "type": "example",
+    "title": "Running the Certificate on ZMod 12: Presence and Certified Absence",
+    "content": "ZMod 12 has order 12 = 2²·3. The biconditional fires at p = 2 and p = 3 (since 2, 3 ∣ 12, by decide), yielding elements of those orders; explicit witnesses 6 (order 2) and 4 (order 3) are certified through addOrderOf_eq_prime from decidable facts, since addOrderOf itself does not reduce under the kernel. At p = 5 the two-way absence certificate proves ∀ x, addOrderOf x ≠ 5 from the single fact 5 ∤ 12 — a universally quantified non-existence over all 12 elements obtained WITHOUT enumeration. Every step is kernel `decide` on ℕ, so the file avoids native_decide and Lean.ofReduceBool.",
+    "mathContext": "$\\mathrm{card}(\\mathbb{Z}/12) = 12$ via ZMod.card; presence from $2,3\\mid 12$, absence from $5\\nmid 12$. The order-5 non-existence is a corollary of a divisibility check, not a 12-fold search.",
+    "significance": "important",
+    "prerequisites": ["ZMod n and addOrderOf", "addOrderOf_eq_prime", "kernel decide vs native_decide"],
+    "relatedConcepts": ["ZMod.card", "concrete witnesses", "certified absence"]
+  },
+  {
+    "id": "ann-zmod-spectrum",
+    "proofId": "cauchy-group-theorem-oq-01-oq-03",
+    "range": { "startLine": 167, "endLine": 195 },
+    "type": "example",
+    "title": "The Full Certified Prime Spectrum {2, 3} of ZMod 12",
+    "content": "The three spectrum memberships are read off the general theorem prime by prime: 2 and 3 lie in (card ZMod 12).primeFactors because order-2 and order-3 elements exist (two_mem/three_mem_spectrum_zmod12), and 5 does not because no order-5 element exists (five_not_mem_spectrum_zmod12). certified_spectrum_zmod12 packages all three, pinning the prime spectrum to exactly {2, 3} = the prime factors of 12. Crucially each membership is a corollary of mem_primeFactors_card_iff_exists_addOrderOf applied to a presence/absence certificate — not raw ℕ-trivia and not a native_decide computation of primeFactors (which does not kernel-reduce).",
+    "mathContext": "$(\\mathrm{card}\\,\\mathbb{Z}/12).\\mathrm{primeFactors} = \\{2,3\\}$, established via the spectrum theorem one prime at a time. This is OQ 2's algorithm output: the certified prime set of the group.",
+    "significance": "key",
+    "prerequisites": ["the spectrum theorem", "presence and absence certificates"],
+    "relatedConcepts": ["prime spectrum", "certified computation", "Lean.ofReduceBool avoidance"]
+  }
+]

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-03/index.ts
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchyGroupTheoremOQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchyGroupTheoremOQ01OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchyGroupTheoremOQ01OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchyGroupTheoremOQ01OQ03Data: ProofData = {
+  proof: cauchyGroupTheoremOQ01OQ03Proof,
+  annotations: cauchyGroupTheoremOQ01OQ03Annotations,
+}

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-03/meta.json
@@ -1,0 +1,237 @@
+{
+  "id": "cauchy-group-theorem-oq-01-oq-03",
+  "title": "The prime spectrum of a finite group is its element-order spectrum",
+  "slug": "cauchy-group-theorem-oq-01-oq-03",
+  "description": "The parent's one-way contrapositive certificate upgraded to a decidable prime test: for a prime p, p ∣ |G| if and only if G has an element of order p (Cauchy plus Lagrange), so the prime factors of |G| are exactly the primes realised as element orders. The certificate is run end-to-end on ZMod 12, certifying its prime set {2,3} — presence of 2, 3 and absence of 5 — one prime at a time, with kernel decide only.",
+  "meta": {
+    "author": "Cauchy (1845), Lagrange; Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyGroupTheoremOQ01OQ03.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "finite-groups",
+      "cauchy-theorem",
+      "lagrange-theorem",
+      "order-of-element",
+      "prime-factors",
+      "decidability"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "exists_prime_orderOf_dvd_card",
+        "description": "Cauchy's theorem: prime p ∣ Fintype.card G yields x : G with orderOf x = p. Supplies the hard (→) direction of the multiplicative biconditional.",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "exists_prime_addOrderOf_dvd_card",
+        "description": "Additive form of Cauchy's theorem (to_additive). Supplies the (→) direction of the additive biconditional.",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "orderOf_dvd_card",
+        "description": "Lagrange's theorem in element form: orderOf x ∣ Fintype.card G. Supplies the easy (←) direction of the multiplicative biconditional.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "addOrderOf_dvd_card",
+        "description": "Additive Lagrange (to_additive of orderOf_dvd_card): addOrderOf x ∣ Fintype.card G. Supplies the (←) direction of the additive biconditional.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Nat.mem_primeFactors",
+        "description": "p ∈ n.primeFactors ↔ p.Prime ∧ p ∣ n ∧ n ≠ 0. Turns the divisibility biconditional into the set-level statement that primeFactors of |G| equals the prime order-spectrum.",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Fintype.card_ne_zero",
+        "description": "For a nonempty Fintype, card ≠ 0. Discharges the n ≠ 0 side condition of Nat.mem_primeFactors (a group is nonempty via its identity).",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "ZMod.card",
+        "description": "Fintype.card (ZMod n) = n. Reduces the concrete ZMod 12 spectrum computations to divisibility of the natural number 12.",
+        "module": "Mathlib.Data.ZMod.Defs"
+      },
+      {
+        "theorem": "addOrderOf_eq_prime",
+        "description": "For prime p, p • x = 0 and x ≠ 0 imply addOrderOf x = p. Certifies the explicit order-2 witness 6 and order-3 witness 4 in ZMod 12 via kernel decide (no native_decide).",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      }
+    ],
+    "originalContributions": [
+      "prime_dvd_card_iff_exists_orderOf / prime_dvd_card_iff_exists_addOrderOf: the Cauchy BICONDITIONAL — for a prime p, p ∣ |G| iff G has an element of order p — combining Mathlib's Cauchy (→) with Lagrange's orderOf_dvd_card (←). The parent proves only (→) and a one-way contrapositive; the biconditional is the piece that makes the prime test a complete decision procedure.",
+      "not_dvd_card_iff_forall_orderOf_ne / not_dvd_card_iff_forall_addOrderOf_ne: the TWO-WAY absence certificate, upgrading the parent's not_dvd_card_of_no_orderOf_eq (one direction only) to an iff — the absence of an order-p element is equivalent, not merely sufficient, to p ∤ |G|.",
+      "mem_primeFactors_card_iff_exists_orderOf / mem_primeFactors_card_iff_exists_addOrderOf: the set-level packaging — a prime p lies in (Fintype.card G).primeFactors iff p is realised as an element order. The prime spectrum of |G| IS the prime part of the element-order spectrum; this is the certified prime set OQ 2 asks for.",
+      "exists_addOrderOf_two_zmod12 / exists_addOrderOf_three_zmod12 / addOrderOf_six_zmod12 / addOrderOf_four_zmod12 / no_addOrderOf_five_zmod12: the certificate run on ZMod 12 (order 12 = 2²·3) — presence of orders 2 (witness 6) and 3 (witness 4), and universally-quantified ABSENCE of order 5 obtained from the general theorem without enumerating the 12 elements.",
+      "two_mem_spectrum_zmod12 / three_mem_spectrum_zmod12 / five_not_mem_spectrum_zmod12 / certified_spectrum_zmod12: the full certified prime spectrum {2,3} of ZMod 12, read prime by prime through the spectrum theorem (each membership is a corollary of the biconditional, not raw ℕ-trivia), keeping the file free of native_decide."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries. Concrete ZMod 12 facts use kernel `decide` on natural-number divisibility (not `native_decide`), so the file does not depend on Lean.ofReduceBool. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 195,
+    "theoremCount": 15,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Perm.Cycle.Type",
+      "Mathlib.GroupTheory.OrderOfElement",
+      "Mathlib.Data.Nat.PrimeFin",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 195,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyGroupTheoremOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "prime_dvd_card_iff_exists_orderOf",
+      "type": "main",
+      "description": "The Cauchy biconditional: for a prime p, p ∣ |G| if and only if G contains an element of order exactly p. Forward is Cauchy (exists_prime_orderOf_dvd_card); reverse is Lagrange (orderOf_dvd_card). The parent records only the forward direction and a one-way contrapositive — this iff makes 'search for an order-p element' a complete decision procedure for p ∣ |G|.",
+      "leanType": "[Group G] [Fintype G] (p : ℕ) [Fact p.Prime] : p ∣ Fintype.card G ↔ ∃ x : G, orderOf x = p"
+    },
+    {
+      "name": "mem_primeFactors_card_iff_exists_orderOf",
+      "type": "main",
+      "description": "Prime spectrum = order spectrum: a prime p lies in (Fintype.card G).primeFactors iff it is realised as the order of some element. The set of prime divisors of |G| is exactly the prime part of the element-order spectrum — the certified prime set of the group.",
+      "leanType": "[Group G] [Fintype G] (p : ℕ) (hp : p.Prime) : p ∈ (Fintype.card G).primeFactors ↔ ∃ x : G, orderOf x = p"
+    },
+    {
+      "name": "not_dvd_card_iff_forall_orderOf_ne",
+      "type": "lemma",
+      "description": "Two-way absence certificate: p ∤ |G| iff G has no element of order p. Upgrades the parent's one-way not_dvd_card_of_no_orderOf_eq to a biconditional — absence of an order-p witness is equivalent to, not merely sufficient for, p ∤ |G|.",
+      "leanType": "[Group G] [Fintype G] (p : ℕ) [Fact p.Prime] : ¬ p ∣ Fintype.card G ↔ ∀ x : G, orderOf x ≠ p"
+    },
+    {
+      "name": "no_addOrderOf_five_zmod12",
+      "type": "example",
+      "description": "Certified absence: ZMod 12 has no element of additive order 5, since 5 ∤ 12 — a universally quantified non-existence over all 12 elements obtained straight from the two-way certificate, without enumeration. The 'absence' half of OQ 2's algorithm.",
+      "leanType": "∀ x : ZMod 12, addOrderOf x ≠ 5"
+    },
+    {
+      "name": "certified_spectrum_zmod12",
+      "type": "example",
+      "description": "The full certified prime spectrum of ZMod 12: 5 ∉ primeFactors while 2, 3 ∈ primeFactors — the prime set {2,3} of 12, established one prime at a time through the spectrum theorem rather than by trusting a native_decide computation.",
+      "leanType": "(5 : ℕ) ∉ (Fintype.card (ZMod 12)).primeFactors ∧ (2 : ℕ) ∈ (Fintype.card (ZMod 12)).primeFactors ∧ (3 : ℕ) ∈ (Fintype.card (ZMod 12)).primeFactors"
+    }
+  ],
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "File-level docstring framing OQ 2: turning the parent's one-way contrapositive certificate into a decidable prime test whose mathematical heart is the Cauchy biconditional p ∣ |G| ↔ ∃ order-p element. Imports the Mathlib Cauchy file, OrderOfElement (Lagrange), Nat.PrimeFin, ZMod basics, and Tactic.",
+      "mathContext": "Cauchy's theorem, Lagrange's theorem, and the prime factorisation of the group order."
+    },
+    {
+      "id": "biconditional",
+      "title": "The Cauchy Biconditional",
+      "startLine": 49,
+      "endLine": 70,
+      "summary": "prime_dvd_card_iff_exists_orderOf and its additive form: p ∣ |G| ↔ ∃ x, orderOf x = p. Forward is Cauchy (exists_prime_orderOf_dvd_card), reverse is Lagrange (orderOf_dvd_card / addOrderOf_dvd_card). This is the biconditional the parent stops short of.",
+      "mathContext": "Combining the prime-divisor converse of Lagrange (Cauchy) with Lagrange itself yields a clean equivalence."
+    },
+    {
+      "id": "absence-certificate",
+      "title": "The Two-Way Absence Certificate",
+      "startLine": 72,
+      "endLine": 94,
+      "summary": "not_dvd_card_iff_forall_orderOf_ne and its additive form: p ∤ |G| ↔ ∀ x, orderOf x ≠ p. The contrapositive of the biconditional (push_neg), upgrading the parent's one-way certificate to an equivalence — a complete decision procedure.",
+      "mathContext": "The absence of an order-p witness is equivalent to p ∤ |G|."
+    },
+    {
+      "id": "prime-spectrum",
+      "title": "The Prime Spectrum as an Order Spectrum",
+      "startLine": 96,
+      "endLine": 120,
+      "summary": "mem_primeFactors_card_iff_exists_orderOf and its additive form: p ∈ (card G).primeFactors ↔ ∃ x, orderOf x = p (p prime). The set-level packaging via Nat.mem_primeFactors and Fintype.card_ne_zero — the prime factors of |G| are exactly the prime element-orders.",
+      "mathContext": "Nat.mem_primeFactors: p ∈ n.primeFactors ↔ p.Prime ∧ p ∣ n ∧ n ≠ 0."
+    },
+    {
+      "id": "zmod12-certificate",
+      "title": "Running the Certificate on ZMod 12",
+      "startLine": 122,
+      "endLine": 195,
+      "summary": "The certificate applied to ZMod 12 (order 12 = 2²·3): presence of orders 2 (witness 6) and 3 (witness 4) from the biconditional, absence of order 5 from the two-way certificate, and the full certified prime spectrum {2,3} read off the spectrum theorem prime by prime — all with kernel decide, no native_decide.",
+      "mathContext": "ZMod.card gives Fintype.card (ZMod 12) = 12; each prime's membership is decided via divisibility of 12."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Cauchy's theorem (1845) — a prime p dividing |G| forces an element of order p — is the prime-case converse of Lagrange's theorem (1770s), which says every subgroup order divides |G|. Read together the two theorems bracket the multiplicative structure of a finite group: Lagrange bounds which numbers can be element orders (they divide |G|), Cauchy guarantees that every prime divisor is actually achieved. The primes dividing |G| — the 'prime spectrum' of the group — govern its p-local structure (Sylow theory, nilpotency, solvability), so a clean, checkable description of that prime set is a natural computational primitive.",
+    "problemStatement": "The parent entry (cauchy-group-theorem-oq-01) records Cauchy's existence theorem and a ONE-WAY contrapositive certificate — the absence of an order-p element proves p ∤ |G| — but leaves open (its Open Question 2) whether this can be turned into a decidable test on the prime set of |G|: an algorithm certifying exactly which primes divide the order by exhibiting order-p elements or ruling them out.\n\n**Answer:** Yes. The mathematical heart is the biconditional the parent stops short of: for a prime p, p ∣ |G| if and only if G has an element of order p (Cauchy gives the hard ⟹, Lagrange's orderOf x ∣ |G| gives ⟸). Both sides are decidable predicates on a finite group, so this IS the decision procedure. At the set level, (Fintype.card G).primeFactors equals the prime part of the element-order spectrum. Run on ZMod 12 the certificate outputs the prime set {2,3}: orders 2 and 3 are present, order 5 is provably absent — each prime decided through the general theorem, with kernel decide only.",
+    "text": "The Cauchy existence theorem and Lagrange's order-divides-card theorem are combined into a biconditional p ∣ |G| ↔ ∃ order-p element, upgraded to a two-way absence certificate and a set-level statement identifying (card G).primeFactors with the prime element-order spectrum, then run end-to-end on ZMod 12 to certify its prime set {2,3}.",
+    "proofStrategy": "1. prime_dvd_card_iff_exists_orderOf: forward is Mathlib's exists_prime_orderOf_dvd_card; reverse substitutes orderOf x = p into orderOf_dvd_card. Additive version identical with addOrderOf_dvd_card.\n2. not_dvd_card_iff_forall_orderOf_ne: rewrite by the biconditional and push_neg — the contrapositive is definitionally the ∀-negation.\n3. mem_primeFactors_card_iff_exists_orderOf: rewrite by Nat.mem_primeFactors (p.Prime ∧ p ∣ card ∧ card ≠ 0); the middle conjunct is the biconditional, card ≠ 0 is Fintype.card_ne_zero (a group is nonempty via 1 / 0).\n4. ZMod 12: ZMod.card reduces Fintype.card (ZMod 12) to 12; presence of 2, 3 from the biconditional and 2,3 ∣ 12 (decide); explicit witnesses 6, 4 via addOrderOf_eq_prime; absence of 5 from the two-way certificate and 5 ∤ 12 (decide). Spectrum memberships are corollaries of the spectrum theorem applied to these existence facts.",
+    "keyInsights": [
+      "**The biconditional is the decision procedure**: Cauchy (⟹) and Lagrange (⟸) together make 'does G have an order-p element?' — a decidable search over a finite group — logically equivalent to 'does p divide |G|?'. The parent had only the ⟹ half and a one-way contrapositive; closing the loop is what makes the prime test complete.",
+      "**The prime spectrum is the order spectrum**: (Fintype.card G).primeFactors equals the set of primes occurring as element orders. This reframes a number-theoretic invariant of |G| as an intrinsic group-theoretic one, computed by inspecting element orders rather than factoring the cardinality.",
+      "**Absence is certified without enumeration**: no_addOrderOf_five_zmod12 asserts a property of all 12 elements of ZMod 12, yet is proved in one step from 5 ∤ 12 via the two-way certificate — the universally quantified non-existence is a corollary of a divisibility fact, not a 12-fold case check.",
+      "**Kernel decide, not native_decide**: primeFactors of 12 does not reduce under kernel computation (well-founded recursion), and addOrderOf does not reduce either — so each concrete prime is certified through the general theorem plus decidable divisibility of ℕ, and each explicit order through addOrderOf_eq_prime, keeping the file free of Lean.ofReduceBool."
+    ],
+    "prerequisites": [
+      "Finite groups, Lagrange's theorem, and the order of an element (orderOf / addOrderOf)",
+      "Cauchy's theorem: every prime divisor of |G| is realised as an element order",
+      "The prime factorisation of a natural number and Nat.primeFactors",
+      "Decidable predicates on a Fintype and the distinction between kernel decide and native_decide"
+    ]
+  },
+  "conclusion": {
+    "summary": "Cauchy's existence theorem and Lagrange's order-divides-card theorem are combined into the biconditional p ∣ |G| ↔ ∃ element of order p, upgrading the parent's one-way contrapositive to a complete decision procedure. At the set level this identifies (Fintype.card G).primeFactors with the prime part of the element-order spectrum, and the certificate is run on ZMod 12 to certify its prime set {2,3} — presence of 2, 3 and absence of 5 — one prime at a time, entirely with kernel decide.",
+    "implications": [
+      "The prime spectrum of a finite group is an intrinsic order-theoretic invariant: the primes dividing |G| are exactly the primes realised as element orders, so the p-local structure can be certified by inspecting elements rather than factoring the cardinality.",
+      "The two-way absence certificate makes 'search for an order-p element' a sound AND complete decision procedure for p ∣ |G|, delivering universally quantified non-existence results (no element of order 5 in ZMod 12) from a single divisibility check, without enumerating the group.",
+      "Genuine 0-axiom certification of a concrete prime spectrum requires routing through the general theorem: neither primeFactors nor addOrderOf reduces under the kernel, so each prime is decided via divisibility of ℕ and each explicit order via addOrderOf_eq_prime — avoiding native_decide and hence Lean.ofReduceBool."
+    ],
+    "openQuestions": [
+      "Package the prime spectrum as a computable Finset-valued function orderSpectrumPrimes G with a proof that it equals (Fintype.card G).primeFactors, turning the prime-by-prime certificate into a single decidable object.",
+      "Extend the certified spectrum to a non-abelian example (e.g. the symmetric group S₃ or the quaternion group Q₈), where element orders must be exhibited without the cyclic-group shortcut, stress-testing the certificate beyond ZMod n."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-group-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry proving Cauchy's theorem and the one-way contrapositive certificate not_dvd_card_of_no_orderOf_eq. This entry answers its Open Question 2 by upgrading that certificate to the decidable prime-spectrum biconditional."
+    },
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling entry answering the parent's Open Question 1 (the Cauchy→Sylow tower). Where that entry climbs from an order-p element to the full p-Sylow subgroup, this one characterises the set of primes p for which such an element exists at all."
+    },
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "related",
+      "description": "The reverse direction of the biconditional is Lagrange's theorem in element form (orderOf x ∣ |G|); together with Cauchy's converse it yields the equivalence p ∣ |G| ↔ ∃ order-p element."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cauchy, Augustin-Louis",
+      "title": "Mémoire sur les arrangements que l'on peut former avec des lettres données",
+      "year": "1845",
+      "note": "Exercices d'analyse et de physique mathématique 3, 151–252 — a prime dividing the order of a group yields an element of that order."
+    },
+    {
+      "authors": "Lagrange, Joseph-Louis",
+      "title": "Réflexions sur la résolution algébrique des équations",
+      "year": "1771",
+      "note": "The origin of the theorem that the order of a subgroup (hence of an element) divides the order of the group — the reverse direction of the biconditional."
+    },
+    {
+      "authors": "Isaacs, I. Martin",
+      "title": "Finite Group Theory",
+      "year": "2008",
+      "note": "Graduate Studies in Mathematics 92, AMS — element orders, the prime spectrum of a finite group, and Sylow theory."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **`cauchy-group-theorem-oq-01-oq-03`** answering **Open Question 2** of the parent `cauchy-group-theorem-oq-01`: turn the parent's *one-way* contrapositive certificate into a **decidable prime test** on the order of a finite group.

## Result

The mathematical heart is the **Cauchy biconditional** the parent stops short of:

> For a prime `p`,  `p ∣ |G|`  **iff**  `G` has an element of order `p`.

- Forward `(→)` = Cauchy (`exists_prime_orderOf_dvd_card`)
- Reverse `(←)` = Lagrange in element form (`orderOf_dvd_card`)

From it:
- **Two-way absence certificate**: `p ∤ |G| ↔ ∀ x, orderOf x ≠ p` — upgrades the parent's one-way `not_dvd_card_of_no_orderOf_eq` to an equivalence (a *complete* decision procedure).
- **Prime spectrum = order spectrum**: `p ∈ (Fintype.card G).primeFactors ↔ ∃ x, orderOf x = p` — the prime factors of `|G|` are exactly the primes realised as element orders.
- Multiplicative **and** additive forms throughout.

**Certificate run on `ZMod 12`** (order `12 = 2²·3`): presence of orders 2 (witness `6`) and 3 (witness `4`), certified **absence** of order 5 (from `5 ∤ 12`, no enumeration of the 12 elements), and the full prime spectrum `{2,3}` read off the spectrum theorem one prime at a time.

## Verification

- **15 theorems, 0 defs, 0 sorries, 195 lines.**
- `#print axioms` → `propext, Classical.choice, Quot.sound` only. Concrete facts use kernel `decide` on ℕ (not `native_decide`), so **no `Lean.ofReduceBool`** — genuinely 0-axiom `verified`.
- Built via `lake env lean` (docker build currently broken in env).

## Notes

- Slug is `-oq-03` (fresh sibling): the parent's OQ#1 (Cauchy→Sylow tower) is already the existing `cauchy-group-theorem-oq-01-oq-02` entry — this PR answers the *distinct, unanswered* OQ#2 and does **not** touch that entry. (Branch name says `oq-01-oq-02` for cosmetic reasons; the entry is `oq-01-oq-03`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)