### PR TITLE
research(shannon-entropy-oq-04): Shannon entropy is a concave functional [VERIFIED, 0-axiom, +5thm]

### DIFF
--- a/proofs/Proofs/ShannonEntropyOQ04.lean
+++ b/proofs/Proofs/ShannonEntropyOQ04.lean
@@ -1,0 +1,134 @@
+/-
+  Shannon Entropy is a Concave Functional
+
+  The parent entry `shannon-entropy` establishes the *value* half of the
+  maximum-entropy principle: `H(p) ≤ log |α|`, with equality iff `p` is
+  uniform (`entropy_le_log_card`, `entropy_eq_log_card_iff_uniform`), proved
+  via the Gibbs inequality.
+
+  This child proves the complementary *structural* half stated in the same
+  open question: the Shannon entropy functional
+
+      H(p) = -∑ₓ p(x) log p(x)
+
+  is a **concave** function of the distribution `p`. Concavity is the reason
+  the maximum is attained at the barycentre of the simplex (the uniform
+  distribution) and underpins every "mixing increases entropy" argument in
+  coding, statistics, and thermodynamics.
+
+  The clean route bridges the file's ad-hoc summand (with the convention
+  `0 log 0 = 0`) to Mathlib's `Real.negMulLog x = -x log x`, which already
+  carries `Real.negMulLog_zero : negMulLog 0 = 0` and, crucially,
+  `Real.concaveOn_negMulLog : ConcaveOn ℝ (Ici 0) negMulLog`. Entropy is then
+  a finite sum of concavities-of-a-coordinate, hence concave.
+
+  Key results:
+  - `shannonEntropy_eq_sum_negMulLog`: `H(p) = ∑ₓ negMulLog (p x)` (the bridge).
+  - `concaveOn_shannonEntropy`: `H` is concave on the non-negative orthant.
+  - `concaveOn_shannonEntropy_stdSimplex`: `H` is concave on the probability
+    simplex — the standard textbook statement.
+
+  Claude Shannon (1948)
+-/
+import Mathlib
+
+namespace InformationTheory.EntropyConcavity
+
+open Finset
+
+-- Shannon entropy for finite distributions (matches the parent `shannon-entropy`).
+-- Convention: 0 log 0 = 0.
+noncomputable def shannonEntropy {α : Type*} [Fintype α] [DecidableEq α]
+    (p : α → ℝ) : ℝ :=
+  -∑ x : α, if p x = 0 then 0 else p x * Real.log (p x)
+
+-- ============================================================
+-- Bridge to Mathlib's `negMulLog`
+-- ============================================================
+
+/-- **Bridge lemma.** The entropy summand `if p x = 0 then 0 else p x log p x`,
+    once negated, is exactly `Real.negMulLog (p x) = -p x log p x`: the `x = 0`
+    branch matches `negMulLog 0 = 0`, the `x ≠ 0` branch matches the definition.
+    Hence `H(p) = ∑ₓ negMulLog (p x)`, connecting the file's convention-based
+    definition to Mathlib's `negMulLog` API. -/
+theorem shannonEntropy_eq_sum_negMulLog {α : Type*} [Fintype α] [DecidableEq α]
+    (p : α → ℝ) :
+    shannonEntropy p = ∑ x : α, Real.negMulLog (p x) := by
+  unfold shannonEntropy
+  rw [← Finset.sum_neg_distrib]
+  refine Finset.sum_congr rfl (fun x _ => ?_)
+  by_cases h : p x = 0
+  · simp [h]
+  · simp only [if_neg h, Real.negMulLog_def]; ring
+
+-- ============================================================
+-- Concavity of a finite sum of concave coordinate functions
+-- ============================================================
+
+/-- A finite sum of functions, each concave on a common convex set `s`, is
+    concave on `s`. Mathlib has `ConcaveOn.add` but no packaged `Finset` sum
+    version; this is the straightforward `Finset.induction` fold. -/
+private theorem concaveOn_finset_sum {ι E : Type*} [AddCommGroup E] [Module ℝ E]
+    {s : Set E} (hs : Convex ℝ s) (g : ι → E → ℝ) :
+    ∀ t : Finset ι, (∀ i ∈ t, ConcaveOn ℝ s (g i)) →
+      ConcaveOn ℝ s (fun x => ∑ i ∈ t, g i x) := by
+  classical
+  intro t
+  induction t using Finset.induction_on with
+  | empty => intro _; simpa using concaveOn_const (0 : ℝ) hs
+  | @insert a u ha ih =>
+      intro hg
+      rw [show (fun x => ∑ i ∈ insert a u, g i x)
+            = g a + (fun x => ∑ i ∈ u, g i x) from by
+              funext x; simp [Finset.sum_insert ha]]
+      exact (hg a (Finset.mem_insert_self a u)).add
+        (ih (fun i hi => hg i (Finset.mem_insert_of_mem hi)))
+
+-- ============================================================
+-- Concavity of Shannon entropy
+-- ============================================================
+
+/-- The non-negative orthant `{p | ∀ i, 0 ≤ p i}` is convex. -/
+theorem convex_nonneg_orthant {α : Type*} [Fintype α] :
+    Convex ℝ {p : α → ℝ | ∀ i, 0 ≤ p i} := by
+  intro p hp q hq a b ha hb _ i
+  simpa only [Pi.add_apply, Pi.smul_apply, smul_eq_mul]
+    using add_nonneg (mul_nonneg ha (hp i)) (mul_nonneg hb (hq i))
+
+/-- **Shannon entropy is concave.** As a function of the distribution `p`, the
+    entropy `H(p) = -∑ₓ p(x) log p(x)` is concave on the non-negative orthant.
+
+    Proof: rewrite `H` as `∑ₓ negMulLog (p x)` (`shannonEntropy_eq_sum_negMulLog`).
+    Each coordinate map `p ↦ negMulLog (p x)` is the concave function
+    `Real.negMulLog` (concave on `Ici 0`) precomposed with the linear coordinate
+    projection `LinearMap.proj x`, restricted to the orthant where every
+    coordinate is `≥ 0`. A finite sum of concave functions is concave. -/
+theorem concaveOn_shannonEntropy {α : Type*} [Fintype α] [DecidableEq α] :
+    ConcaveOn ℝ {p : α → ℝ | ∀ i, 0 ≤ p i} shannonEntropy := by
+  have hconv := convex_nonneg_orthant (α := α)
+  rw [show shannonEntropy = fun p : α → ℝ => ∑ i : α, Real.negMulLog (p i) from
+        funext shannonEntropy_eq_sum_negMulLog]
+  refine concaveOn_finset_sum hconv (fun i p => Real.negMulLog (p i)) Finset.univ
+    (fun i _ => ?_)
+  -- `p ↦ negMulLog (p i)` = `negMulLog ∘ proj i`, concave via comp_linearMap + subset.
+  have hcomp :=
+    Real.concaveOn_negMulLog.comp_linearMap (LinearMap.proj i : (α → ℝ) →ₗ[ℝ] ℝ)
+  have hsub : {p : α → ℝ | ∀ j, 0 ≤ p j}
+      ⊆ (LinearMap.proj i : (α → ℝ) →ₗ[ℝ] ℝ) ⁻¹' Set.Ici 0 := by
+    intro p hp
+    simp only [Set.mem_preimage, Set.mem_Ici, LinearMap.proj_apply]
+    exact hp i
+  have hcongr : (Real.negMulLog ∘ (LinearMap.proj i : (α → ℝ) →ₗ[ℝ] ℝ))
+      = fun p : α → ℝ => Real.negMulLog (p i) := by
+    funext p; simp [Function.comp, LinearMap.proj_apply]
+  have := (hcomp.subset hsub hconv)
+  rwa [hcongr] at this
+
+/-- **Shannon entropy is concave on the probability simplex.** The standard
+    textbook statement: restricting `concaveOn_shannonEntropy` to the standard
+    simplex `stdSimplex ℝ α = {p | (∀ i, 0 ≤ p i) ∧ ∑ i, p i = 1}`. -/
+theorem concaveOn_shannonEntropy_stdSimplex {α : Type*} [Fintype α] [DecidableEq α] :
+    ConcaveOn ℝ (stdSimplex ℝ α) shannonEntropy :=
+  concaveOn_shannonEntropy.subset (fun _ hp => hp.1) (convex_stdSimplex ℝ α)
+
+end InformationTheory.EntropyConcavity

--- a/src/data/proofs/shannon-entropy-oq-04/annotations.json
+++ b/src/data/proofs/shannon-entropy-oq-04/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-entconc-bridge",
+    "proofId": "shannon-entropy-oq-04",
+    "range": {
+      "startLine": 49,
+      "endLine": 62
+    },
+    "type": "insight",
+    "title": "shannonEntropy_eq_sum_negMulLog: Bridging the Convention to Mathlib's negMulLog",
+    "content": "The gallery entropy summand is `if p x = 0 then 0 else p x * Real.log (p x)`, encoding 0·log 0 = 0 by hand. Negated, it is exactly Real.negMulLog (p x) = -p x · log p x: on p x = 0 both sides are 0 (Real.negMulLog_zero), and on p x ≠ 0 the else-branch negated is the definition. Hence shannonEntropy p = ∑ₓ negMulLog (p x). The proof turns -∑ into ∑ - via Finset.sum_neg_distrib, then a pointwise by_cases with Real.negMulLog_def and ring. This identification lets every convex-analysis lemma about negMulLog apply to entropy with no special-casing at the simplex boundary.",
+    "mathContext": "$H(p) = -\\sum_x \\big[p(x)=0\\,?\\,0:p(x)\\ln p(x)\\big] = \\sum_x \\operatorname{negMulLog}(p(x))$, where $\\operatorname{negMulLog}(t) = -t\\ln t$ and $\\operatorname{negMulLog}(0)=0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.negMulLog",
+      "Real.negMulLog_zero",
+      "0 log 0 = 0 convention",
+      "Finset.sum_neg_distrib"
+    ],
+    "prerequisites": [
+      "Real.negMulLog",
+      "Finset.sum_congr"
+    ]
+  },
+  {
+    "id": "ann-entconc-sumfold",
+    "proofId": "shannon-entropy-oq-04",
+    "range": {
+      "startLine": 68,
+      "endLine": 85
+    },
+    "type": "technique",
+    "title": "concaveOn_finset_sum: Finite Sum of Concave Functions",
+    "content": "Mathlib has ConcaveOn.add (binary) but no Finset-sum version. This lemma folds it by Finset.induction: the empty sum is the constant 0 (concaveOn_const), and insert a u splits as g a + ∑_{i∈u} g i, concave by ConcaveOn.add of the head with the inductive hypothesis on the tail. Stated for a general convex set s in a real vector space, it is reusable beyond entropy.",
+    "mathContext": "If each $g_i$ is concave on a convex set $s$, then $\\sum_{i\\in t} g_i$ is concave on $s$. Proof by induction on the finite index set $t$, base case the constant $0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ConcaveOn.add",
+      "concaveOn_const",
+      "Finset.induction"
+    ],
+    "prerequisites": [
+      "ConcaveOn",
+      "Finset.sum_insert"
+    ]
+  },
+  {
+    "id": "ann-entconc-orthant",
+    "proofId": "shannon-entropy-oq-04",
+    "range": {
+      "startLine": 98,
+      "endLine": 125
+    },
+    "type": "insight",
+    "title": "concaveOn_shannonEntropy: Entropy is Concave on the Non-negative Orthant",
+    "content": "After rewriting H as ∑ₓ negMulLog (p x), each coordinate map p ↦ negMulLog (p x) is negMulLog (concave on Ici 0 by Real.concaveOn_negMulLog) precomposed with the linear projection LinearMap.proj x. ConcaveOn.comp_linearMap makes it concave on the preimage half-space {p | 0 ≤ p x}, and ConcaveOn.subset restricts to the orthant where every coordinate is ≥ 0. Summing over coordinates with concaveOn_finset_sum yields concavity of H.",
+    "mathContext": "$H$ is concave on $\\{p \\mid \\forall i,\\ 0 \\le p_i\\}$ because $H = \\sum_i \\operatorname{negMulLog}\\circ\\pi_i$ with each $\\operatorname{negMulLog}$ concave on $[0,\\infty)$ and $\\pi_i$ linear.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.concaveOn_negMulLog",
+      "ConcaveOn.comp_linearMap",
+      "ConcaveOn.subset",
+      "LinearMap.proj"
+    ],
+    "prerequisites": [
+      "ConcaveOn.comp_linearMap",
+      "convex_nonneg_orthant"
+    ]
+  },
+  {
+    "id": "ann-entconc-simplex",
+    "proofId": "shannon-entropy-oq-04",
+    "range": {
+      "startLine": 127,
+      "endLine": 132
+    },
+    "type": "insight",
+    "title": "concaveOn_shannonEntropy_stdSimplex: Concavity on the Probability Simplex",
+    "content": "The standard textbook statement. Since stdSimplex ℝ α = {p | (∀ i, 0 ≤ p i) ∧ ∑ i, p i = 1} is a convex subset of the non-negative orthant, ConcaveOn.subset applied to concaveOn_shannonEntropy with convex_stdSimplex gives concavity of entropy on the space of probability distributions in one line.",
+    "mathContext": "Entropy is concave on $\\operatorname{stdSimplex}\\,\\mathbb R\\,\\alpha$, the simplex of probability vectors; this is the concavity used in the maximum-entropy principle.",
+    "significance": "key",
+    "relatedConcepts": [
+      "stdSimplex",
+      "convex_stdSimplex",
+      "ConcaveOn.subset",
+      "maximum entropy principle"
+    ],
+    "prerequisites": [
+      "stdSimplex",
+      "concaveOn_shannonEntropy"
+    ]
+  }
+]

--- a/src/data/proofs/shannon-entropy-oq-04/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-04/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "shannon-entropy-oq-04",
+  "title": "Shannon Entropy is a Concave Functional",
+  "slug": "shannon-entropy-oq-04",
+  "description": "The Shannon entropy H(p) = -∑ p(x) log p(x) is a concave function of the distribution p. Bridges the gallery's convention-based entropy to Mathlib's negMulLog and proves concavity on the non-negative orthant and on the probability simplex — the structural half of the maximum-entropy principle whose value half (H ≤ log n) lives in the parent.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Entropy_(information_theory)#Further_properties",
+    "date": "1948",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonEntropyOQ04.lean",
+    "tags": [
+      "information-theory",
+      "entropy",
+      "concavity",
+      "convex-analysis",
+      "negMulLog",
+      "jensen",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 134,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "assumptions": "None. Fully machine-verified from Mathlib (only the foundational propext / Classical.choice / Quot.sound). Uses Real.concaveOn_negMulLog and the linear-map composition / subset lemmas of convex analysis.",
+    "originalContributions": [
+      "shannonEntropy_eq_sum_negMulLog: bridges the gallery's if-then-else entropy summand (0 log 0 = 0 convention) to Mathlib's Real.negMulLog, giving H(p) = ∑ₓ negMulLog (p x)",
+      "concaveOn_finset_sum: reusable Finset-sum fold of ConcaveOn.add (Mathlib has the binary but not the finite-sum version)",
+      "convex_nonneg_orthant: the non-negative orthant {p | ∀ i, 0 ≤ p i} is convex",
+      "concaveOn_shannonEntropy: H is concave on the non-negative orthant, via comp_linearMap of negMulLog with coordinate projections",
+      "concaveOn_shannonEntropy_stdSimplex: H is concave on the probability simplex stdSimplex ℝ α — the standard textbook statement"
+    ],
+    "prerequisites": [
+      "Shannon entropy and the 0 log 0 = 0 convention (parent entry)",
+      "Real.negMulLog and its concavity Real.concaveOn_negMulLog",
+      "ConcaveOn, ConcaveOn.comp_linearMap, ConcaveOn.subset, ConcaveOn.add",
+      "stdSimplex and convex_stdSimplex"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Concavity of the entropy functional is, alongside the bound H(p) ≤ log n, one of the two foundational facts about Shannon entropy (Shannon 1948). It is the reason mixing distributions never decreases entropy, the reason the uniform distribution (the barycentre of the simplex) is the unique maximiser, and the analytic engine behind the maximum-entropy principle, channel-capacity arguments, and the second law in statistical mechanics.\n\nThe parent gallery entry `shannon-entropy` proves the value half of the maximum-entropy principle — H(p) ≤ log |α| with equality iff p is uniform — via the Gibbs inequality (KL divergence ≥ 0). This child supplies the complementary structural half: that H itself is a concave function of p. The two together give the complete elementary theory of the maximum.",
+    "problemStatement": "Prove, fully verified in Lean/Mathlib, that the Shannon entropy functional H(p) = -∑ₓ p(x) log p(x) is concave as a function of the distribution p, on the non-negative orthant and on the probability simplex.",
+    "proofStrategy": "**Bridge.** The negated entropy summand `if p x = 0 then 0 else p x · log (p x)` equals Mathlib's `Real.negMulLog (p x) = -p x · log p x`: the zero branch matches `negMulLog 0 = 0`, the nonzero branch matches the definition. Hence H(p) = ∑ₓ negMulLog (p x).\n\n**Coordinatewise concavity.** `Real.negMulLog` is concave on `Ici 0`. Composing with the linear coordinate projection `LinearMap.proj x` (via `ConcaveOn.comp_linearMap`) makes `p ↦ negMulLog (p x)` concave on the half-space {p | 0 ≤ p x}; restricting (`ConcaveOn.subset`) to the non-negative orthant, where every coordinate is ≥ 0, keeps it concave.\n\n**Sum.** A finite sum of functions concave on a common convex set is concave (`concaveOn_finset_sum`, a `Finset.induction` fold of `ConcaveOn.add`). Summing the coordinate concavities gives concavity of H on the non-negative orthant, and restricting to `stdSimplex ℝ α ⊆ orthant` gives concavity on the probability simplex.",
+    "keyInsights": [
+      "The gallery's ad-hoc summand with the 0 log 0 = 0 convention is definitionally Mathlib's negMulLog once negated — no epsilon/limit argument is needed to handle the boundary of the simplex",
+      "Concavity of a functional of p reduces to concavity of a single scalar function (negMulLog) composed with linear coordinate evaluations — the composition and subset lemmas of ConcaveOn do all the work",
+      "Mathlib provides ConcaveOn.add but no finite-sum version; the reusable concaveOn_finset_sum fold fills that small gap",
+      "Working on the whole non-negative orthant (not just the simplex) gives the stronger statement and makes the simplex version a one-line restriction via convex_stdSimplex"
+    ],
+    "prerequisites": [
+      "Convex analysis: ConcaveOn, ConvexOn, and their behaviour under composition with linear maps and restriction to subsets",
+      "Real.negMulLog and Real.concaveOn_negMulLog",
+      "stdSimplex ℝ α and convex_stdSimplex",
+      "Finset.induction for the sum fold"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition-and-bridge",
+      "title": "Definition and Bridge to negMulLog",
+      "summary": "shannonEntropy p = -∑ (if p x = 0 then 0 else p x log p x); shannonEntropy_eq_sum_negMulLog rewrites it as ∑ₓ negMulLog (p x).",
+      "startLine": 41,
+      "endLine": 62,
+      "mathContext": "The entry restates the parent's entropy definition $H(p) = -\\sum_x \\big[\\,p(x)=0 \\,?\\, 0 : p(x)\\ln p(x)\\,\\big]$, encoding the convention $0\\ln 0 = 0$ by an explicit `if`. The bridge lemma `shannonEntropy_eq_sum_negMulLog` proves $H(p) = \\sum_x \\operatorname{negMulLog}(p(x))$ where Mathlib's $\\operatorname{negMulLog}(t) = -t\\ln t$ with $\\operatorname{negMulLog}(0)=0$. Pointwise: on $p(x)=0$ both sides are $0$ (via `negMulLog_zero`), and on $p(x)\\neq 0$ the negated `if`-branch $-(p(x)\\ln p(x))$ equals $\\operatorname{negMulLog}(p(x))$ by definition. This identification is what lets every convex-analysis lemma about `negMulLog` apply to entropy without special-casing the simplex boundary."
+    },
+    {
+      "id": "sum-of-concave",
+      "title": "Finite Sums of Concave Functions",
+      "summary": "concaveOn_finset_sum: a Finset-indexed sum of functions concave on a common convex set is concave — an induction fold of ConcaveOn.add.",
+      "startLine": 68,
+      "endLine": 85,
+      "mathContext": "Mathlib provides the binary `ConcaveOn.add` (sum of two concave functions is concave) but no packaged `Finset`-sum version. `concaveOn_finset_sum` supplies it by `Finset.induction`: the empty sum is the constant $0$ (concave via `concaveOn_const`), and `insert a u` splits as $g_a + \\sum_{i\\in u} g_i$, concave by `ConcaveOn.add` on the head and the inductive hypothesis on the tail. Stating it for a general convex set $s$ in a real vector space makes it reusable beyond entropy."
+    },
+    {
+      "id": "concavity",
+      "title": "Concavity of Entropy",
+      "summary": "convex_nonneg_orthant; concaveOn_shannonEntropy (concave on {p | ∀ i, 0 ≤ p i}); concaveOn_shannonEntropy_stdSimplex (concave on the probability simplex).",
+      "startLine": 91,
+      "endLine": 132,
+      "mathContext": "The non-negative orthant $\\{p \\mid \\forall i,\\ 0 \\le p_i\\}$ is convex (`convex_nonneg_orthant`, from pointwise `add_nonneg`/`mul_nonneg`). For each coordinate $i$, the map $p \\mapsto \\operatorname{negMulLog}(p_i)$ is $\\operatorname{negMulLog}$ (concave on $[0,\\infty)$ by `Real.concaveOn_negMulLog`) precomposed with the linear projection `LinearMap.proj i`; `ConcaveOn.comp_linearMap` makes it concave on the preimage half-space $\\{p \\mid 0 \\le p_i\\}$, and `ConcaveOn.subset` restricts it to the orthant. Summing over $i$ with `concaveOn_finset_sum` and rewriting through the bridge yields `concaveOn_shannonEntropy`: $H$ is concave on the orthant. Since $\\operatorname{stdSimplex}\\,\\mathbb R\\,\\alpha = \\{p \\mid (\\forall i,\\ 0 \\le p_i) \\wedge \\sum_i p_i = 1\\}$ is a convex subset of the orthant, `concaveOn_shannonEntropy_stdSimplex` follows in one line via `ConcaveOn.subset` and `convex_stdSimplex` — the standard statement that entropy is concave on the space of probability distributions."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves that the Shannon entropy functional H(p) = -∑ p(x) log p(x) is concave: a bridge lemma H(p) = ∑ₓ negMulLog (p x) connecting the gallery convention to Mathlib's negMulLog, a reusable finite-sum-of-concave fold, and concavity on both the non-negative orthant and the probability simplex. 134 lines, 5 theorems, 1 definition, 0 sorries, 0 axioms.",
+    "implications": "Concavity is the structural counterpart to the parent's H ≤ log n bound: it explains why the uniform distribution is the unique maximiser and is the analytic basis of the maximum-entropy principle. The negMulLog bridge makes the whole Mathlib convex-analysis toolkit available to the gallery's entropy definition.",
+    "openQuestions": [
+      "Strengthen to strict concavity on the simplex (via Real.strictConcaveOn_negMulLog), recovering uniqueness of the maximiser without the KL route",
+      "Derive H(p) ≤ log n directly from concavity by evaluating Jensen at the barycentre, giving an alternative to the parent's Gibbs proof",
+      "Prove concavity of the conditional entropy and mutual-information functionals",
+      "Establish concavity of the more general Rényi and Tsallis entropies"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-entropy",
+      "relationship": "extends",
+      "description": "Parent: defines H and proves the value half H(p) ≤ log |α| (equality iff uniform) via Gibbs"
+    },
+    {
+      "targetId": "shannon-entropy-oq-01",
+      "relationship": "related",
+      "description": "Continuous analogue: concavity and Gaussian maximum entropy for differential entropy"
+    }
+  ],
+  "leanFile": {
+    "namespace": "InformationTheory.EntropyConcavity",
+    "lineCount": 134,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/ShannonEntropyOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry `shannon-entropy-oq-04`. Proves the **structural half** of the maximum-entropy principle: the Shannon entropy functional $H(p) = -\sum_x p(x)\log p(x)$ is **concave** in the distribution $p$.

### Context / honest scoping
The open question as written asks for $H(p) \le \log n$ (maximised by uniform) **and** "entropy is a concave function of $p$". While reviewing, I found the **value half** — `entropy_le_log_card` (H ≤ log |α|) and even the equality-case iff `entropy_eq_log_card_iff_uniform` — is **already fully proven in the parent** `ShannonEntropy.lean` (via the Gibbs inequality). Re-proving it would be redundant. So this entry delivers the genuinely missing **concavity** half instead.

### Contributions
- `shannonEntropy_eq_sum_negMulLog` — bridge lemma: the gallery's `if p x = 0 then 0 else p x log p x` convention equals Mathlib's `Real.negMulLog`, giving $H(p) = \sum_x \operatorname{negMulLog}(p_x)$. Makes Mathlib's convex-analysis toolkit apply to entropy with no simplex-boundary special-casing.
- `concaveOn_finset_sum` — reusable `Finset`-sum fold of `ConcaveOn.add` (Mathlib has only the binary version).
- `convex_nonneg_orthant`, `concaveOn_shannonEntropy` — H is concave on the non-negative orthant, via `ConcaveOn.comp_linearMap` of `negMulLog` with coordinate projections + `ConcaveOn.subset`.
- `concaveOn_shannonEntropy_stdSimplex` — H is concave on the probability simplex `stdSimplex ℝ α` (the standard textbook statement), a one-line restriction.

### Verification
- Compiled clean against Mathlib (pinned `v4.26.0`) via `lake env lean`.
- `#print axioms` on all three public results: only `propext, Classical.choice, Quot.sound` — **0-axiom / verified**, 0 sorries.
- 134 lines, 5 theorems, 1 definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)