### PR TITLE
Enrich Instantiating the Abstract First-Moment Engine (prob-method-applications-wip-01-oq-01)

### DIFF
--- a/src/data/proofs/prob-method-applications-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "wipoq01-framing",
+    "proofId": "prob-method-applications-wip-01-oq-01",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "context",
+    "title": "The Missing Bridge: From Abstract Engine to Erdős's Bound",
+    "content": "The module docstring frames the whole entry. The companion file ProbMethodApplicationsWIP.lean proves the abstract first-moment / union-bound avoidance engine ProbMethod.Core.ramsey_avoidance over an arbitrary finite 'edge' set E: if a family of bad blocks is few enough relative to 2^{|E|}, some subset S avoids every block (no block is entirely inside S or entirely outside it). That engine's docstring asserts — but never proves — that instantiating E as the edges of K_n recovers Erdős's 1947 lower bound R(k,k) > n. This file is the missing instantiation: it takes E to be the C(n,2) edges of K_n, the blocks to be the induced clique-edge sets EdgesIn n K, reduces the abstract counting hypothesis to the classical criterion 2·C(n,k) < 2^{C(k,2)}, and translates the resulting avoiding set back into an edge colouring — reproducing exactly RamseyFirstMoment.first_moment_ramsey, now as a genuine corollary of the abstract engine rather than a bespoke count.",
+    "mathContext": "$\\text{engine: } |\\text{cliques}|\\cdot 2^{|E|-m+1} < 2^{|E|} \\Rightarrow \\exists S \\text{ avoiding all blocks};\\quad \\text{here } E = \\text{edges}(K_n),\\ m = \\binom{k}{2},\\ |E| = \\binom{n}{2}.$",
+    "significance": "context",
+    "prerequisites": ["Ramsey numbers R(k,k)", "the probabilistic / first-moment method", "union bound"],
+    "relatedConcepts": ["abstract avoidance engine", "instantiation vs. bespoke proof", "Erdős 1947 lower bound", "monochromatic clique"]
+  },
+  {
     "id": "wipoq01-blocks",
     "proofId": "prob-method-applications-wip-01-oq-01",
     "range": { "startLine": 64, "endLine": 82 },

--- a/src/data/proofs/prob-method-applications-wip-01-oq-01/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-01/meta.json
@@ -92,6 +92,14 @@
   },
   "sections": [
     {
+      "id": "framing",
+      "title": "Open Question and the Abstract Avoidance Engine",
+      "startLine": 1,
+      "endLine": 58,
+      "mathContext": "$|\\text{cliques}|\\cdot 2^{|E|-m+1} < 2^{|E|} \\ \\Rightarrow\\ \\exists S,\\ \\forall K,\\ \\neg(K\\subseteq S \\vee K\\cap S = \\varnothing)$",
+      "summary": "Module docstring, imports (the companion ProbMethodApplicationsWIP and RamseyFirstMoment), and the statement of ramsey_avoidance_Kn. Records the open question — instantiate the abstract engine ProbMethod.Core.ramsey_avoidance to K_n and recover Erdős's R(k,k) > n — and explains that the companion file proves the abstract union-bound engine over an arbitrary edge set E but only asserts (never carries out) the K_n instantiation this file supplies. Also notes the omitted-as-redundant 2 ≤ k side condition."
+    },
+    {
       "id": "instantiation",
       "title": "Instantiating the Abstract Engine over K_n",
       "startLine": 59,


### PR DESCRIPTION
Enrichment pass for `prob-method-applications-wip-01-oq-01` (passes: 0).

**Changes**
- **Covered the header.** Sections and annotations both previously started at line 59/64, leaving the module docstring + setup (lines 1–58) uncovered. Added a framing section (1–58) and a `context`-significance annotation over the docstring, giving full line coverage (1–133).
- The framing annotation states the entry's purpose crisply: the companion `ProbMethodApplicationsWIP.lean` proves the *abstract* union-bound avoidance engine `ramsey_avoidance` but only *asserts* the `K_n` instantiation; this file supplies the missing bridge to Erdős's 1947 bound `R(k,k) > n`.
- Annotations 4 → 5, sections 2 → 3.

**Integrity**: content accurate to the Lean source; `status: verified`, `axiomCount: 0` unchanged and correct. meta.json ~19 KB, under the 60 KB cap; JSON validated and `gallery:check-size` passes.