### PR TITLE
Enrich Fibonacci Summation Identities (fibonacci-identities)

### DIFF
--- a/src/data/proofs/fibonacci-identities/meta.json
+++ b/src/data/proofs/fibonacci-identities/meta.json
@@ -119,12 +119,37 @@
   ],
   "references": [
     {
-      "title": "Fibonacci sequence — other identities",
-      "url": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Other_identities"
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Comprehensive reference for Fibonacci summation identities, including the sum of squares ∑Fᵢ² = FₙFₙ₊₁ and the odd/even-indexed sums ∑F₂ᵢ₋₁ = F₂ₙ and ∑F₂ᵢ = F₂ₙ₊₁ − 1 formalized here."
     },
     {
-      "title": "Mathlib: Nat.fib",
-      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Nat/Fib/Basic.html"
+      "authors": "Vajda, Steven",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood",
+      "note": "Systematic catalogue of Fibonacci/Lucas identities; the three summation formulas of this entry appear as standard entries proved by induction on the recurrence."
+    },
+    {
+      "authors": "Graham, R. L.; Knuth, D. E.; Patashnik, O.",
+      "title": "Concrete Mathematics: A Foundation for Computer Science, §6.6",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "note": "Develops Fibonacci summation and telescoping identities; the sum-of-squares identity is the classic dissection of an Fₙ×Fₙ₊₁ rectangle into squares of side F₀,…,Fₙ."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Data.Nat.Fib.Basic",
+      "year": "2026",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Nat/Fib/Basic.html",
+      "note": "Supplies Nat.fib and the pointwise identities (fib_add_two, fib_add, doubling, Cassini, fib_gcd); the summation identities proved here are absent from it and are the contribution of this entry."
+    },
+    {
+      "title": "Fibonacci sequence — other identities (Wikipedia)",
+      "url": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Other_identities",
+      "note": "Overview of the standard Fibonacci summation identities and their combinatorial interpretations."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities` (passes: 0).

**Change**
- **Upgraded the references.** The entry had only 2 references, both stubs (bare `title`+`url`, no authors or years). Replaced with 5 properly-attributed sources: Koshy, *Fibonacci and Lucas Numbers with Applications* (2001); Vajda (1989); Graham–Knuth–Patashnik, *Concrete Mathematics* §6.6 (1994); `Mathlib.Data.Nat.Fib.Basic`; and the Wikipedia identities page — each with a note tying it to the three summation identities formalized here (∑Fᵢ² = FₙFₙ₊₁, ∑F₂ᵢ₋₁ = F₂ₙ, ∑F₂ᵢ = F₂ₙ₊₁ − 1).

Annotations (4) already map cleanly to the module docstring + the file's 3 theorems with full line coverage, so I left them as-is rather than padding to a 5th.

**Integrity**: content accurate to the Lean source; `status`/`axiomCount` unchanged. meta.json under the 60 KB cap; JSON validated and `gallery:check-size` passes.