### PR TITLE
research(erdos-101-oq-01-oq-02): exact base cases of the four-point-line extremal function [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos101OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos101OQ01OQ02.lean
@@ -1,0 +1,151 @@
+/-
+# Erdős Problem #101 — OQ-01 · OQ-02: exact base cases of the extremal function
+
+Parent `Erdos101OQ01.lean` introduces the genuine size-indexed extremal
+quantity
+
+  `maxCountAtSize n := sSup { fourPointLineCount Q | |Q| = n, NoFiveCollinear Q }`,
+
+the precise function OQ-01 asks to bound by `o(n²)`, and establishes the
+`O(n²)` upper certificate `maxCountAtSize_isBigO_n_squared`. The asymptotic
+statements say nothing about the *small* values of this function, yet those
+values are the anchor points every candidate growth rate must interpolate.
+
+This file pins the base cases exactly:
+
+  * `maxCountAtSize n = 0` for every `n < 4` (a set with fewer than four
+    points has no four-point line — `fourPointLineCount_lt_four`);
+  * `maxCountAtSize 4 = 1` (the first non-trivial value): four collinear
+    points realise a single four-point line, and the elementary bound
+    `improved_upper_bound` (`4·3/12 = 1`) forbids more.
+
+The lower half of `maxCountAtSize 4 = 1` is witnessed by an **explicit**
+no-five-collinear configuration — four points on the `x`-axis — for which
+`fourPointLineCount = 1` is computed directly from the definition (the only
+cardinality-`4` subset of a four-element set is the set itself). This is the
+smallest concrete lower-bound witness for OQ-01, complementing the deferred
+Solymosi–Stojaković near-quadratic construction at the opposite end.
+
+All results here are unconditional and axiom-free: no `sorry`, no `axiom`,
+and no dependence on the parent's two deferred obligations (the open
+conjecture and the Solymosi–Stojaković lower bound).
+-/
+import Proofs.Erdos101OQ01
+
+open Classical
+open Erdos101OQ01
+
+namespace Erdos101OQ01OQ02
+
+/-! ### Base values `n < 4`: the extremal function vanishes -/
+
+/-- For every size `n < 4` the extremal four-point-line function vanishes:
+no set of fewer than four points contains a four-point line, so every
+candidate count is `0`, hence so is their supremum. Proved by pushing the
+uniform bound `fourPointLineCount Q = 0` through `maxCountAtSize_lt_of_forall`
+with the real threshold `X = 1`. -/
+theorem maxCountAtSize_eq_zero_of_lt_four {n : ℕ} (hn : n < 4) :
+    maxCountAtSize n = 0 := by
+  have hlt : (maxCountAtSize n : ℝ) < 1 := by
+    refine maxCountAtSize_lt_of_forall (by norm_num) ?_
+    intro Q hQcard _
+    have hz : fourPointLineCount Q = 0 :=
+      fourPointLineCount_lt_four Q (by rw [hQcard]; exact hn)
+    rw [hz]; norm_num
+  have : maxCountAtSize n < 1 := by exact_mod_cast hlt
+  omega
+
+/-! ### The explicit witness at size 4
+
+Four points on the `x`-axis: `(0,0), (1,0), (2,0), (3,0)`. They are pairwise
+distinct (so the set has cardinality `4`), vacuously no-five-collinear (there
+are only four points), and all lie on the single line `y = 0`, giving exactly
+one four-point line. -/
+
+/-- The witness point set: four distinct collinear points on the `x`-axis. -/
+noncomputable def witness : PlanarPointSet where
+  points := {((0 : ℝ), (0 : ℝ)), (1, 0), (2, 0), (3, 0)}
+  size_pos := by
+    have : ({((0 : ℝ), (0 : ℝ)), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)).Nonempty :=
+      ⟨(0, 0), by simp⟩
+    exact Finset.card_pos.mpr this
+
+/-- The witness has exactly four points. -/
+theorem witness_card : witness.points.card = 4 := by
+  show ({((0 : ℝ), (0 : ℝ)), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)).card = 4
+  rw [Finset.card_insert_of_notMem (by simp [Prod.ext_iff]),
+      Finset.card_insert_of_notMem (by simp [Prod.ext_iff]),
+      Finset.card_insert_of_notMem (by simp [Prod.ext_iff]),
+      Finset.card_singleton]
+
+/-- The witness is (vacuously) no-five-collinear: it has only four points. -/
+theorem witness_noFive : NoFiveCollinear witness :=
+  noFiveCollinear_small witness (le_of_eq witness_card)
+
+/-- Every point of the witness lies on the line `y = 0`, hence is collinear
+with the two anchors `(0,0)` and `(1,0)`. -/
+theorem witness_all_collinear :
+    ∀ p ∈ witness.points, collinear ((0 : ℝ), (0 : ℝ)) (1, 0) p := by
+  intro p hp
+  have hp' : p ∈ ({((0 : ℝ), (0 : ℝ)), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)) := hp
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hp'
+  rcases hp' with rfl | rfl | rfl | rfl <;>
+    · unfold collinear; ring
+
+/-- **The witness realises exactly one four-point line.** The only
+cardinality-`4` subset of a four-element set is the set itself, and that
+subset satisfies the collinearity predicate (anchors `(0,0)`, `(1,0)`), so the
+counted family is the singleton `{witness.points}`. -/
+theorem witness_fourPointLineCount : fourPointLineCount witness = 1 := by
+  have hcard : witness.points.card = 4 := witness_card
+  -- The filtered family is exactly `{witness.points}`.
+  have hset :
+      (witness.points.powerset.filter (fun S =>
+        S.card = 4 ∧ ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧
+          ∀ p ∈ S, collinear a b p)) = {witness.points} := by
+    apply Finset.eq_singleton_iff_unique_mem.mpr
+    refine ⟨?_, ?_⟩
+    · rw [Finset.mem_filter, Finset.mem_powerset]
+      refine ⟨Finset.Subset.refl _, hcard, (0, 0), (1, 0), ?_, ?_, ?_, witness_all_collinear⟩
+      · show ((0 : ℝ), (0 : ℝ)) ∈ witness.points
+        show ((0 : ℝ), (0 : ℝ)) ∈ ({((0 : ℝ), (0 : ℝ)), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ))
+        simp
+      · show ((1 : ℝ), (0 : ℝ)) ∈ witness.points
+        show ((1 : ℝ), (0 : ℝ)) ∈ ({((0 : ℝ), (0 : ℝ)), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ))
+        simp
+      · simp [Prod.ext_iff]
+    · intro S hS
+      rw [Finset.mem_filter, Finset.mem_powerset] at hS
+      exact Finset.eq_of_subset_of_card_le hS.1 (by rw [hcard, hS.2.1])
+  unfold fourPointLineCount
+  rw [hset, Finset.card_singleton]
+
+/-! ### The first non-trivial value: `maxCountAtSize 4 = 1` -/
+
+/-- **The extremal four-point-line function at size 4 equals 1.**
+
+Lower bound `1 ≤ maxCountAtSize 4`: the explicit witness attains
+`fourPointLineCount = 1` (`witness_fourPointLineCount`) at cardinality `4`.
+
+Upper bound `maxCountAtSize 4 ≤ 1`: every no-five-collinear set of four points
+has at most `4·3/12 = 1` four-point line (`improved_upper_bound`), pushed
+through `maxCountAtSize_lt_of_forall` with threshold `X = 2`. -/
+theorem maxCountAtSize_four_eq_one : maxCountAtSize 4 = 1 := by
+  refine le_antisymm ?_ ?_
+  · -- upper bound
+    have hlt : (maxCountAtSize 4 : ℝ) < 2 := by
+      refine maxCountAtSize_lt_of_forall (by norm_num) ?_
+      intro Q hQcard hQ5
+      have hb := improved_upper_bound Q hQ5
+      rw [hQcard] at hb
+      have hb1 : fourPointLineCount Q ≤ 1 := by norm_num at hb; exact hb
+      have : (fourPointLineCount Q : ℝ) ≤ 1 := by exact_mod_cast hb1
+      linarith
+    have : maxCountAtSize 4 < 2 := by exact_mod_cast hlt
+    omega
+  · -- lower bound via the explicit witness
+    have h := le_maxCountAtSize witness witness_noFive
+    rw [witness_fourPointLineCount, witness_card] at h
+    exact h
+
+end Erdos101OQ01OQ02

--- a/src/data/proofs/erdos-101-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-101-oq-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-erdos101oq0102-overview",
+    "proofId": "erdos-101-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 32 },
+    "type": "concept",
+    "title": "Anchoring the Extremal Function of a $100 Open Problem",
+    "content": "The docstring frames the contribution: the parent OQ-01 scaffold introduces the genuine size-indexed extremal quantity maxCountAtSize n = sSup { fourPointLineCount Q | |Q| = n, NoFiveCollinear Q } — the precise function the $100 open Erdős #101 OQ-01 asks to bound by o(n²) — and certifies its O(n²) upper bound, but the asymptotic statement says nothing about the small values. Those base values are the boundary conditions every candidate growth rate must interpolate. This file pins them exactly: maxCountAtSize n = 0 for all n < 4, and maxCountAtSize 4 = 1, the latter realised by an EXPLICIT no-five-collinear configuration. It does not attack the open o(n²) regime; it anchors the extremal function at its base.",
+    "mathContext": "$\\mathrm{maxCountAtSize}(n) = \\sup\\{\\mathrm{fourPointLineCount}(Q) : |Q| = n,\\ \\text{no five collinear}\\}$; here $\\mathrm{maxCountAtSize}(n) = 0$ for $n<4$ and $\\mathrm{maxCountAtSize}(4)=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Erdős problems", "incidence geometry", "four-point lines", "extremal function", "Solymosi–Stojaković bound"],
+    "prerequisites": ["extremal combinatorics", "suprema in ℕ"]
+  },
+  {
+    "id": "ann-erdos101oq0102-basevalues",
+    "proofId": "erdos-101-oq-01-oq-02",
+    "range": { "startLine": 40, "endLine": 57 },
+    "type": "theorem",
+    "title": "The Extremal Function Vanishes Below Size 4",
+    "content": "maxCountAtSize_eq_zero_of_lt_four proves that for every n < 4 the size-indexed extremal four-point-line function is 0. A set with fewer than four points cannot host a four-point line, so fourPointLineCount Q = 0 for every candidate Q of size n (fourPointLineCount_lt_four). Feeding this uniform bound through the parent's maxCountAtSize_lt_of_forall with the real threshold X = 1 yields (maxCountAtSize n : ℝ) < 1, and a natural number below 1 is 0 (omega). The lemma covers the empty-candidate case n = 0 (where sSup ∅ = 0) uniformly with the nonempty cases n = 1,2,3.",
+    "mathContext": "$n < 4 \\Rightarrow \\forall Q\\,(|Q|=n),\\ \\mathrm{fourPointLineCount}(Q)=0 \\Rightarrow \\mathrm{maxCountAtSize}(n) < 1 \\Rightarrow \\mathrm{maxCountAtSize}(n)=0$.",
+    "significance": "key",
+    "relatedConcepts": ["maxCountAtSize_lt_of_forall", "fourPointLineCount_lt_four", "supremum of zero set", "omega"],
+    "prerequisites": ["ℕ→ℝ casting", "suprema"]
+  },
+  {
+    "id": "ann-erdos101oq0102-witness",
+    "proofId": "erdos-101-oq-01-oq-02",
+    "range": { "startLine": 58, "endLine": 122 },
+    "type": "theorem",
+    "title": "An Explicit Configuration Realising One Four-Point Line",
+    "content": "The witness is the concrete PlanarPointSet of four x-axis points (0,0),(1,0),(2,0),(3,0). witness_card shows it has cardinality 4 (three card_insert_of_notMem steps, distinctness by Prod.ext_iff); witness_noFive is vacuous no-five-collinear via noFiveCollinear_small (only four points); witness_all_collinear shows every point lies on the line y = 0, hence is collinear with the anchors (0,0),(1,0) (each of the four cases closes by ring). The centrepiece witness_fourPointLineCount computes fourPointLineCount witness = 1 directly from the definition: the only cardinality-4 subset of a four-element set is the set itself (Finset.eq_of_subset_of_card_le), and that subset satisfies the collinearity predicate, so the counted family is exactly the singleton {witness.points}.",
+    "mathContext": "Four collinear points on $y=0$: the unique size-4 subset is the whole set, collinear via anchors $(0,0),(1,0)$, so $\\mathrm{fourPointLineCount} = |\\{P.\\mathrm{points}\\}| = 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["explicit construction", "Finset.eq_of_subset_of_card_le", "noFiveCollinear_small", "Finset.eq_singleton_iff_unique_mem", "collinearity"],
+    "prerequisites": ["Finset cardinality", "powerset filtering", "collinearity predicate"]
+  },
+  {
+    "id": "ann-erdos101oq0102-sizefour",
+    "proofId": "erdos-101-oq-01-oq-02",
+    "range": { "startLine": 123, "endLine": 151 },
+    "type": "insight",
+    "title": "The First Non-Trivial Value: maxCountAtSize 4 = 1",
+    "content": "maxCountAtSize_four_eq_one pins the extremal function at its first non-trivial argument, from both sides. Lower bound 1 ≤ maxCountAtSize 4: the explicit witness attains fourPointLineCount = 1 at cardinality 4, so le_maxCountAtSize (with witness_fourPointLineCount and witness_card) delivers it. Upper bound maxCountAtSize 4 ≤ 1: every no-five-collinear set of four points has at most 4·3/12 = 1 four-point line by the framework's elementary packing bound improved_upper_bound; pushing this through maxCountAtSize_lt_of_forall with threshold X = 2 gives (maxCountAtSize 4 : ℝ) < 2, hence ≤ 1 (omega). The two bounds meet at exactly 1 — the smallest positive value of the OQ-01 extremal function, certified against both a concrete realising configuration and the elementary density ceiling.",
+    "mathContext": "$1 \\le \\mathrm{maxCountAtSize}(4)$ (explicit witness) and $\\mathrm{maxCountAtSize}(4) \\le \\lfloor 4\\cdot 3/12\\rfloor = 1$ (packing bound), so $\\mathrm{maxCountAtSize}(4)=1$.",
+    "significance": "critical",
+    "relatedConcepts": ["le_maxCountAtSize", "improved_upper_bound", "le_antisymm", "packing bound", "extremal value"],
+    "prerequisites": ["the explicit witness", "the elementary packing bound"]
+  }
+]

--- a/src/data/proofs/erdos-101-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-101-oq-01-oq-02/meta.json
@@ -1,0 +1,109 @@
+{
+  "id": "erdos-101-oq-01-oq-02",
+  "title": "Erdős #101 OQ-01: exact base cases of the extremal four-point-line function",
+  "slug": "erdos-101-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Proofs.Erdos101OQ01"
+    ],
+    "opens": [
+      "Classical",
+      "Erdos101OQ01"
+    ],
+    "namespace": "Erdos101OQ01OQ02",
+    "lineCount": 151,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos101OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "description": "The parent OQ-01 scaffold introduces the genuine size-indexed extremal quantity maxCountAtSize n = sSup { fourPointLineCount Q | |Q| = n, NoFiveCollinear Q } — the precise function the $100 open problem asks to bound by o(n^2) — and certifies its O(n^2) upper bound, but says nothing about its small values. This entry pins the base cases exactly: maxCountAtSize n = 0 for every n < 4 (a set of fewer than four points has no four-point line), and maxCountAtSize 4 = 1 (the first non-trivial value). The lower half of the size-4 value is witnessed by an EXPLICIT no-five-collinear configuration — the four points (0,0),(1,0),(2,0),(3,0) on the x-axis — for which fourPointLineCount = 1 is computed directly from the definition (the only cardinality-4 subset of a four-element set is the set itself, and it lies on the single line y=0); the upper half is forced by the framework's elementary packing bound improved_upper_bound (4*3/12 = 1). This is the smallest concrete lower-bound witness for OQ-01, anchoring the extremal function at the opposite end from the deferred Solymosi-Stojakovic near-quadratic construction. 6 theorems, 1 definition, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos101OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "incidence-geometry",
+      "erdos-problems",
+      "extremal-combinatorics",
+      "four-point-lines",
+      "explicit-construction"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked with Lean v4.26.0 (Mathlib pin). 0 sorries, 0 axiom declarations, no native_decide. `#print axioms` on maxCountAtSize_eq_zero_of_lt_four, maxCountAtSize_four_eq_one, and witness_fourPointLineCount lists only the standard foundational axioms [propext, Classical.choice, Quot.sound] — in particular NO sorryAx. Although this file imports the sorry-bearing OQ-01 scaffold Erdos101OQ01.lean (to reuse its extremal-function API maxCountAtSize / le_maxCountAtSize / maxCountAtSize_lt_of_forall), every theorem here uses only the scaffold's sorry-free content and the framework's sorry-free improved_upper_bound; the file does NOT depend on the still-open conjecture (erdos_101_oq_01) or the deferred Solymosi-Stojakovic lower bound, as the axiom prints confirm. The contribution is honest: it settles the exact base values of the extremal function, not any new progress on the open o(n^2) regime.",
+    "lineCount": 151,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "originalContributions": [
+      "maxCountAtSize_eq_zero_of_lt_four: the size-indexed extremal four-point-line function vanishes for every n < 4 — no set of fewer than four points contains a four-point line, so the supremum of the (all-zero) candidate counts is 0 (proved via maxCountAtSize_lt_of_forall with real threshold 1).",
+      "witness: an explicit no-five-collinear PlanarPointSet — the four x-axis points (0,0),(1,0),(2,0),(3,0) — serving as the smallest concrete positive configuration for OQ-01.",
+      "witness_fourPointLineCount: the explicit configuration realises exactly one four-point line, computed directly from the definition (the unique cardinality-4 subset of the four-element set is the set itself, and it satisfies the collinearity predicate with anchors (0,0),(1,0)).",
+      "maxCountAtSize_four_eq_one: the first non-trivial value of the extremal function is exactly 1 — lower bound from the explicit witness (le_maxCountAtSize), upper bound from the elementary packing bound improved_upper_bound (4*3/12 = 1) via maxCountAtSize_lt_of_forall with threshold 2."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #101 asks for the maximum number of lines containing exactly four points of an n-point planar set with no five collinear, and OQ-01 — carrying a $100 prize — conjectures this is o(n^2). Erdős originally conjectured Theta(n^{3/2}), but Solymosi and Stojaković (2013) constructed sets with n^{2 - O(1/sqrt(log n))} four-point lines, disproving the 3/2 exponent. The trivial double-counting / Szemerédi-Trotter bound gives O(n^2); closing the gap to o(n^2) is open. The parent OQ-01 scaffold packages the exact extremal quantity as maxCountAtSize n, proves its O(n^2) certificate, and records both the open conjecture and the Solymosi-Stojaković lower bound as deferred obligations.",
+    "problemStatement": "For the extremal function maxCountAtSize n = sSup { fourPointLineCount Q | |Q| = n, NoFiveCollinear Q } — the precise quantity OQ-01 asks to bound by o(n^2) — what are its exact small values? This entry computes them: 0 for every n < 4, and exactly 1 at n = 4.",
+    "proofStrategy": "For n < 4: every candidate set has fewer than four points, so fourPointLineCount Q = 0 (fourPointLineCount_lt_four); feeding this uniform bound through the parent's maxCountAtSize_lt_of_forall with real threshold 1 shows maxCountAtSize n < 1, hence = 0 in the naturals. For n = 4: the lower bound 1 <= maxCountAtSize 4 is attained by an explicit witness — four collinear points on the x-axis, vacuously no-five-collinear (noFiveCollinear_small), with fourPointLineCount = 1 computed from the definition (the only size-4 subset of a four-element set is the set itself, established via Finset.eq_of_subset_of_card_le). The upper bound maxCountAtSize 4 <= 1 comes from improved_upper_bound (4*3/12 = 1) applied to every candidate, pushed through maxCountAtSize_lt_of_forall with threshold 2.",
+    "keyInsights": [
+      "maxCountAtSize is the genuine extremal function OQ-01 asks about; the asymptotic O(n^2) certificate says nothing about its small values, which are the anchor points every candidate growth rate must interpolate.",
+      "For n < 4 the extremal function vanishes identically — the first four-point line cannot appear until there are four points to host it.",
+      "The first non-trivial value maxCountAtSize 4 = 1 is pinned from both sides: an explicit realising configuration below and the elementary packing constant 1/12 above (4*3/12 = 1).",
+      "The four x-axis points give the smallest concrete positive witness for OQ-01 — a fully-checked lower-bound configuration complementing the deferred, far more intricate Solymosi-Stojaković near-quadratic construction.",
+      "Computing fourPointLineCount on a concrete real point set reduces cleanly to a subset-counting fact (only the whole set has cardinality 4) plus a one-line collinearity check (all points share y = 0)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "base-values",
+      "title": "Base Values n < 4: the extremal function vanishes",
+      "summary": "maxCountAtSize_eq_zero_of_lt_four: for every n < 4 the size-indexed extremal four-point-line function is 0, since every candidate set of fewer than four points has fourPointLineCount = 0.",
+      "startLine": 40,
+      "endLine": 57,
+      "mathContext": "n < 4 implies fourPointLineCount Q = 0 for all candidates (fourPointLineCount_lt_four), so maxCountAtSize n < 1 (via maxCountAtSize_lt_of_forall, threshold 1), hence = 0."
+    },
+    {
+      "id": "explicit-witness",
+      "title": "The Explicit Witness at Size 4",
+      "summary": "witness (four x-axis points), witness_card (= 4), witness_noFive (vacuous no-five-collinear), witness_all_collinear (all on y = 0), and witness_fourPointLineCount: the configuration realises exactly one four-point line, computed directly from the definition.",
+      "startLine": 58,
+      "endLine": 122,
+      "mathContext": "The only cardinality-4 subset of a four-element set is the set itself (Finset.eq_of_subset_of_card_le); it satisfies the collinearity predicate with anchors (0,0),(1,0) since every point has y = 0, so the counted family is the singleton {witness.points}."
+    },
+    {
+      "id": "size-four-value",
+      "title": "The First Non-Trivial Value: maxCountAtSize 4 = 1",
+      "summary": "maxCountAtSize_four_eq_one pins the extremal function at size 4: lower bound from the explicit witness (le_maxCountAtSize), upper bound from the elementary packing bound improved_upper_bound (4*3/12 = 1).",
+      "startLine": 123,
+      "endLine": 151,
+      "mathContext": "1 <= maxCountAtSize 4 (witness attains fourPointLineCount = 1) and maxCountAtSize 4 <= 1 (every candidate is <= 4*3/12 = 1, via maxCountAtSize_lt_of_forall with threshold 2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The extremal four-point-line function maxCountAtSize n — the precise quantity the open $100 Erdős #101 OQ-01 asks to bound by o(n^2) — has its base cases pinned exactly here: it vanishes for every n < 4 and equals 1 at n = 4. The size-4 value is realised by an explicit, fully-checked no-five-collinear configuration (four collinear x-axis points) below and forced by the elementary packing bound 1/12 above. This does not attack the open asymptotic regime; it anchors the extremal function at its base.",
+    "implications": "The base values are the boundary conditions any conjectured growth rate for maxCountAtSize must satisfy, and the explicit size-4 witness is the smallest concrete lower-bound configuration for OQ-01, complementing the deferred Solymosi-Stojaković near-quadratic construction at the large-n end. The witness and the direct fourPointLineCount computation are reusable as building blocks for assembling larger configurations (e.g. disjoint copies) whose four-point-line counts can be computed from the definition.",
+    "openQuestions": [
+      "Compute or bound maxCountAtSize n exactly for small n > 4 (e.g. the first n at which two disjoint four-point lines force maxCountAtSize n >= 2, and the growth of the exact extremal values).",
+      "Formalize a family of explicit configurations realising a linear lower bound maxCountAtSize (4k) >= k (k disjoint four-point lines placed in general position, verifying no five collinear).",
+      "Settle the open o(n^2) regime itself — the $100 problem — by improving the elementary density constant 1/12 to an o(1) factor."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-101-oq-01",
+      "relationship": "parent",
+      "description": "The OQ-01 scaffold, which introduces the extremal function maxCountAtSize n and its API (le_maxCountAtSize, maxCountAtSize_lt_of_forall, maxCountAtSize_bddAbove) and its O(n^2) certificate. This entry computes the exact base values of that function (n < 4 gives 0, n = 4 gives 1), reusing only the scaffold's sorry-free content."
+    },
+    {
+      "targetId": "erdos-101",
+      "relationship": "foundational",
+      "description": "The base Erdős #101 framework (PlanarPointSet, collinear, NoFiveCollinear, fourPointLineCount, noFiveCollinear_small, fourPointLineCount_lt_four) and its sorry-free elementary packing bound improved_upper_bound (fourPointLineCount P <= n(n-1)/12), on which the upper bound maxCountAtSize 4 <= 1 rests."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New child leaf under **Erdős #101 OQ-01** (the open \$100 problem: is the number of four-point lines in a no-five-collinear planar set $o(n^2)$?).

The parent scaffold introduces the genuine size-indexed extremal function
$$\text{maxCountAtSize}(n) = \sup\{\text{fourPointLineCount}(Q) : |Q|=n,\ \text{no five collinear}\}$$
— the precise quantity OQ-01 asks to bound by $o(n^2)$ — and certifies its $O(n^2)$ upper bound, but says nothing about its small values. This entry pins the **base cases exactly**:

- `maxCountAtSize_eq_zero_of_lt_four` — $\text{maxCountAtSize}(n) = 0$ for every $n < 4$ (a set of fewer than four points hosts no four-point line).
- `maxCountAtSize_four_eq_one` — $\text{maxCountAtSize}(4) = 1$, the first non-trivial value, pinned from both sides.

The size-4 **lower** bound is witnessed by an **explicit** no-five-collinear configuration — the four collinear $x$-axis points $(0,0),(1,0),(2,0),(3,0)$ — for which `fourPointLineCount = 1` is computed directly from the definition (`witness_fourPointLineCount`: the only cardinality-4 subset of a four-element set is the set itself). The **upper** bound is forced by the framework's elementary packing bound `improved_upper_bound` ($4\cdot 3/12 = 1$). This is the smallest concrete lower-bound witness for OQ-01, anchoring the extremal function at the opposite end from the deferred Solymosi–Stojaković near-quadratic construction.

## Verification

- **6 theorems, 1 definition, 151 lines, 0 sorries, 0 axiom declarations.**
- `lake env lean Proofs/Erdos101OQ01OQ02.lean` compiles green (Lean v4.26.0, Mathlib pin). *(Docker wrapper unavailable this session — host disk full / containerd I/O error — so verified via `lake env lean` against the shared build cache.)*
- `#print axioms` on `maxCountAtSize_four_eq_one`, `maxCountAtSize_eq_zero_of_lt_four`, `witness_fourPointLineCount` lists only `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `Lean.ofReduceBool`.**
- Although the file imports the sorry-bearing OQ-01 scaffold `Erdos101OQ01.lean` for its extremal-function API (`maxCountAtSize`, `le_maxCountAtSize`, `maxCountAtSize_lt_of_forall`), every theorem uses only the scaffold's sorry-free content and the framework's sorry-free `improved_upper_bound`; it does **not** depend on the open conjecture or the deferred Solymosi–Stojaković lower bound, as the axiom prints confirm.

## Gallery

Adds `src/data/proofs/erdos-101-oq-01-oq-02/` (meta.json + annotations.json), status `verified`, badge `original`, cross-referenced to parent `erdos-101-oq-01` and foundational `erdos-101`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)