### PR TITLE
Enrich Blichfeldt & Minkowski Covolume Threshold (minkowski-theorem-oq-04-oq-02): deepen annotations

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-02/annotations.json
@@ -38,13 +38,49 @@
   {
     "id": "ann-mk04oq02-minkowski",
     "proofId": "minkowski-theorem-oq-04-oq-02",
-    "range": { "startLine": 129, "endLine": 205 },
+    "range": { "startLine": 124, "endLine": 152 },
     "type": "theorem",
     "title": "Minkowski's Convex Body Theorem for a General Lattice",
-    "content": "minkowski_lattice proves the classical Minkowski convex body theorem for an arbitrary full-rank lattice via the half-scaling T = (1/2)·S: measurability of T comes from the doubling-map preimage, and vol(T) = (1/2)ⁿ·vol(S) from Measure.addHaar_smul, so the hypothesis 2ⁿ·volume F < vol(S) becomes volume F < vol(T); blichfeldt_basic_lattice then yields a ≠ b ∈ T with a − b ∈ Λ, and central symmetry + convexity place a − b in S. minkowski_lattice_covolume restates the threshold as vol(S) > 2ⁿ·covol(Λ), the classical Cassels III.2 form. The half-scaling is lattice-agnostic: it acts on S, not Λ, so the ℤⁿ arithmetic (2⁻¹)ⁿ·2ⁿ = 1 carries over verbatim with the constant 1 replaced by volume F.",
-    "mathContext": "$S$ convex, centrally symmetric, $\\mathrm{vol}(S) > 2^n\\cdot\\mathrm{covol}(\\Lambda) \\Rightarrow \\exists\\, p\\in S\\cap\\Lambda,\\ p\\ne 0$.",
+    "content": "minkowski_lattice states and sets up the classical Minkowski convex body theorem for an arbitrary full-rank lattice. The strategy is Minkowski's half-scaling reduction to Blichfeldt: introduce T = (1/2)·S and show blichfeldt_basic_lattice applies to it. This block establishes measurability of T by writing the shrink map (2⁻¹ • ·) as the preimage of s under the doubling map (2 • ·), so measurability of T follows from measurability of s under the continuous linear map measurable_const_smul. The half-scaling is lattice-agnostic — it acts on S, not Λ — so the ℤⁿ argument carries over verbatim with the covolume-1 constant replaced by volume F.",
+    "mathContext": "$S$ convex, centrally symmetric, $\\mathrm{vol}(S) > 2^n\\cdot\\mathrm{covol}(\\Lambda) \\Rightarrow \\exists\\, p\\in S\\cap\\Lambda,\\ p\\ne 0$. Setup: $T = \\tfrac12 S = (2\\,\\cdot)^{-1}[S]$, so $T$ is measurable whenever $S$ is.",
     "significance": "key",
     "relatedConcepts": ["Minkowski's convex body theorem", "half-scaling", "central symmetry", "convexity", "covolume"],
-    "prerequisites": ["blichfeldt_basic_lattice", "Measure.addHaar_smul", "convexity + central symmetry"]
+    "prerequisites": ["blichfeldt_basic_lattice", "measurability of preimages under scaling"]
+  },
+  {
+    "id": "ann-mk04oq02-halfscale-vol",
+    "proofId": "minkowski-theorem-oq-04-oq-02",
+    "range": { "startLine": 153, "endLine": 174 },
+    "type": "technique",
+    "title": "The Half-Scaling Volume Identity",
+    "content": "The analytic heart of the Minkowski reduction: vol(T) = (1/2)ⁿ·vol(S), obtained from the Haar-measure scaling law Measure.addHaar_smul, which gives volume(c • s) = |c|ⁿ · volume s with the exponent n = Module.finrank of (Fin n → ℝ). The threshold hypothesis 2ⁿ·volume F < vol(S) is multiplied through by (2⁻¹)ⁿ (a nonzero, non-⊤ ENNReal, so ENNReal.mul_lt_mul_right applies) and collapsed using the cancellation (2⁻¹)ⁿ·2ⁿ = (2⁻¹·2)ⁿ = 1ⁿ = 1, yielding exactly volume F < vol(T) — the hypothesis blichfeldt_basic_lattice needs. All the fiddly ENNReal.ofReal ↔ (2:ENNReal)⁻¹ conversions and the ≠0 / ≠⊤ side conditions exist only to make this cancellation legal in the extended nonnegative reals, where naive subtraction/division fail.",
+    "mathContext": "$\\mathrm{vol}\\big(\\tfrac12 S\\big) = (\\tfrac12)^n\\,\\mathrm{vol}(S)$ via $\\mathrm{vol}(c\\cdot s) = |c|^n\\mathrm{vol}(s)$; then $(\\tfrac12)^n\\cdot 2^n = 1$ turns $2^n\\,\\mathrm{vol}\\,F < \\mathrm{vol}(S)$ into $\\mathrm{vol}\\,F < \\mathrm{vol}(T)$.",
+    "significance": "technical",
+    "relatedConcepts": ["Haar measure scaling", "Measure.addHaar_smul", "ℝ≥0∞ arithmetic", "finrank"],
+    "prerequisites": ["Lebesgue measure scaling law", "ENNReal multiplication/cancellation"]
+  },
+  {
+    "id": "ann-mk04oq02-midpoint",
+    "proofId": "minkowski-theorem-oq-04-oq-02",
+    "range": { "startLine": 175, "endLine": 188 },
+    "type": "insight",
+    "title": "Midpoint via Convexity + Central Symmetry",
+    "content": "Blichfeldt on T produces distinct x₀/2, y₀/2 ∈ T (so x₀, y₀ ∈ S) whose difference (x₀ − y₀)/2 lies in Λ. The remaining task is to show this lattice vector actually lies in S. This is exactly where the two extra Minkowski hypotheses are spent: central symmetry (−y₀ ∈ S) turns the difference into a genuine convex combination, and convexity of S then places the midpoint (1/2)x₀ + (1/2)(−y₀) = (x₀ − y₀)/2 back in S. Since x₀ ≠ y₀ this lattice point is nonzero (sub_ne_zero), completing the proof. The final coercion uses that membership in the submodule-as-set and in its .toAddSubgroup are definitionally the same (Submodule.mem_toAddSubgroup is Iff.rfl).",
+    "mathContext": "$-y_0\\in S$ (symmetry) and convexity give $\\tfrac12 x_0 + \\tfrac12(-y_0) = \\tfrac{x_0-y_0}{2}\\in S$; it is a nonzero point of $\\Lambda$ because $x_0\\ne y_0$.",
+    "significance": "key",
+    "relatedConcepts": ["central symmetry", "convex combination", "midpoint", "sub_ne_zero"],
+    "prerequisites": ["convexity as closure under convex combinations", "central symmetry of the body"]
+  },
+  {
+    "id": "ann-mk04oq02-covolume-form",
+    "proofId": "minkowski-theorem-oq-04-oq-02",
+    "range": { "startLine": 189, "endLine": 209 },
+    "type": "theorem",
+    "title": "The Covolume Restatement (Cassels III.2)",
+    "content": "minkowski_lattice_covolume repackages minkowski_lattice with the threshold written in the geometry-of-numbers form vol(S) > 2ⁿ·covol(Λ). The whole proof is one application of the covolume bridge: 2ⁿ·volume F = ENNReal.ofReal(2ⁿ·covol Λ), pushing ENNReal.ofReal through the product and the power (both nonnegative) and folding volume F to covol Λ via covolume_eq_toReal_volume_fundamentalDomain. This is the exact statement invoked across algebraic number theory — bounding the shortest vector of an ideal lattice under the Minkowski embedding (covolume 2^{−r₂}√|d_K|), from which finiteness of the class group and the Minkowski bound on ideal norms follow.",
+    "mathContext": "$\\mathrm{vol}(S) > 2^n\\cdot\\mathrm{covol}(\\Lambda) \\Rightarrow \\exists\\,p\\in S\\cap\\Lambda,\\ p\\ne 0$; the sharp constant $2^n$ is Minkowski's, and $\\mathrm{covol}$ of the Minkowski embedding of $\\mathcal{O}_K$ is $2^{-r_2}\\sqrt{|d_K|}$.",
+    "significance": "key",
+    "relatedConcepts": ["covolume", "Minkowski embedding", "class group finiteness", "Minkowski bound", "ideal lattice"],
+    "prerequisites": ["covolume bridge", "ENNReal.ofReal through products and powers"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `minkowski-theorem-oq-04-oq-02`.

**Annotation coverage 4 → 7.** The Minkowski half of the proof (Lean lines 129–209) was previously covered by a single coarse annotation. Split into four focused annotations that expose the substantive internals:

- **Statement + half-scaling setup / measurability** (124–152) — T = (2⁻¹)·S written as the preimage of S under the doubling map.
- **The half-scaling volume identity** (153–174) — `Measure.addHaar_smul`, the (2⁻¹)ⁿ·2ⁿ = 1 ENNReal cancellation, and why the ≠0/≠⊤ side conditions are needed.
- **Midpoint via convexity + central symmetry** (175–188) — how the two extra Minkowski hypotheses turn the lattice difference (x₀−y₀)/2 into a convex combination back in S.
- **Covolume restatement (Cassels III.2)** (189–209) — the classical vol(S) > 2ⁿ·covol(Λ) form and its role in algebraic number theory (Minkowski embedding, class-group finiteness).

Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. All seven annotation line ranges validated against Lean constructs by `pnpm build` (no 'No Lean construct found' warnings for this entry).

No changes to meta.json (already comprehensive at ~22 KB, well under the 60 KB cap) or the Lean source. Axiom/status fields unchanged and remain accurate (0-axiom, verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)