### PR TITLE
research(fibonacci-identities-oq-07): Fₘ ∣ Fₙ ⟺ m ∣ n divisibility characterization [VERIFIED, 0-axiom, +4thm]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ07.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ07.lean
@@ -1,0 +1,80 @@
+/-
+  Fibonacci Divisibility Characterization: Fₘ ∣ Fₙ ⟺ m ∣ n  (for m ≥ 3)
+
+  The Fibonacci numbers form a *strong divisibility sequence*:
+  `gcd(Fₘ, Fₙ) = F_{gcd(m,n)}` (Mathlib's `Nat.fib_gcd`). A classical corollary
+  is the full divisibility characterisation
+
+      Fₘ ∣ Fₙ  ⟺  m ∣ n.
+
+  Mathlib provides only the **forward** implication `Nat.fib_dvd : m ∣ n → Fₘ ∣ Fₙ`.
+  This entry proves the **reverse** implication — the substantive half — and
+  packages the biconditional.
+
+  A subtlety fixes the exact hypothesis: because `F₁ = F₂ = 1` divides every
+  Fibonacci number, the equivalence can only hold for `m ≥ 3` (equivalently
+  `Fₘ ≥ 2`). We prove necessity of that hypothesis with an explicit witness.
+
+  Key results:
+  - `dvd_of_fib_dvd`: for `3 ≤ m`, `Fₘ ∣ Fₙ → m ∣ n` (the reverse direction).
+  - `fib_dvd_iff`: the characterisation `Fₘ ∣ Fₙ ↔ m ∣ n` for `3 ≤ m`.
+  - `fib_dvd_iff_needs_three`: the `m ≥ 3` hypothesis is necessary.
+  - `not_fib_dvd_of_not_dvd`: contrapositive convenience form.
+
+  Édouard Lucas (1878)
+-/
+import Mathlib
+
+namespace FibonacciIdentitiesOQ07
+
+/-- **Reverse divisibility** (the new content). For `3 ≤ m`, if `Fₘ ∣ Fₙ` then
+    `m ∣ n`.
+
+    Proof. `Fₘ ∣ Fₙ` gives `gcd(Fₘ, Fₙ) = Fₘ`, and Mathlib's strong-divisibility
+    identity `Nat.fib_gcd` rewrites the left side as `F_{gcd(m,n)}`, so
+    `F_{gcd(m,n)} = Fₘ`. Since `m ≥ 3` we have `Fₘ ≥ F₃ = 2`, which forces
+    `gcd(m,n) ≥ 2` (otherwise `F_{gcd(m,n)} ∈ {F₀, F₁} = {0, 1} < 2`). Fibonacci
+    is strictly monotone — hence injective — on `[2, ∞)` (`Nat.fib_strictMonoOn`),
+    so `F_{gcd(m,n)} = Fₘ` yields `gcd(m,n) = m`, i.e. `m ∣ n`. -/
+theorem dvd_of_fib_dvd {m n : ℕ} (hm : 3 ≤ m) (h : Nat.fib m ∣ Nat.fib n) :
+    m ∣ n := by
+  -- `F_{gcd(m,n)} = Fₘ`.
+  have hgcd : Nat.fib (Nat.gcd m n) = Nat.fib m := by
+    rw [Nat.fib_gcd]; exact Nat.gcd_eq_left h
+  -- `Fₘ ≥ F₃ = 2`.
+  have hfm2 : 2 ≤ Nat.fib m :=
+    calc 2 = Nat.fib 3 := by decide
+      _ ≤ Nat.fib m := Nat.fib_mono hm
+  -- Hence `gcd(m,n) ≥ 2`.
+  have hg2 : 2 ≤ Nat.gcd m n := by
+    by_contra hlt
+    push_neg at hlt
+    have hle1 : Nat.fib (Nat.gcd m n) ≤ 1 := by
+      interval_cases (Nat.gcd m n) <;> decide
+    omega
+  -- Injectivity of `fib` on `[2, ∞)` gives `gcd(m,n) = m`.
+  have hmgcd : Nat.gcd m n = m :=
+    Nat.fib_strictMonoOn.injOn (Set.mem_Ici.mpr hg2)
+      (Set.mem_Ici.mpr (le_trans (by norm_num) hm)) hgcd
+  exact hmgcd ▸ Nat.gcd_dvd_right m n
+
+/-- **Fibonacci divisibility characterisation.** For `3 ≤ m`,
+
+        Fₘ ∣ Fₙ  ↔  m ∣ n.
+
+    The forward direction is Mathlib's `Nat.fib_dvd`; the reverse is
+    `dvd_of_fib_dvd`. -/
+theorem fib_dvd_iff {m n : ℕ} (hm : 3 ≤ m) : Nat.fib m ∣ Nat.fib n ↔ m ∣ n :=
+  ⟨dvd_of_fib_dvd hm, fun h => Nat.fib_dvd m n h⟩
+
+/-- **Necessity of `m ≥ 3`.** The characterisation fails for `m = 2`: since
+    `F₂ = 1` divides every Fibonacci number, `F₂ ∣ F₃` holds while `2 ∤ 3`.
+    (The same obstruction rules out `m = 1`, as `F₁ = 1`.) -/
+theorem fib_dvd_iff_needs_three : Nat.fib 2 ∣ Nat.fib 3 ∧ ¬ (2 ∣ 3) := by decide
+
+/-- Contrapositive convenience form: for `3 ≤ m`, if `m ∤ n` then `Fₘ ∤ Fₙ`. -/
+theorem not_fib_dvd_of_not_dvd {m n : ℕ} (hm : 3 ≤ m) (h : ¬ m ∣ n) :
+    ¬ Nat.fib m ∣ Nat.fib n :=
+  fun hd => h ((fib_dvd_iff hm).mp hd)
+
+end FibonacciIdentitiesOQ07

--- a/src/data/proofs/fibonacci-identities-oq-07/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-07/annotations.json
@@ -1,0 +1,49 @@
+[
+  {
+    "id": "ann-fib07-reverse",
+    "proofId": "fibonacci-identities-oq-07",
+    "range": {
+      "startLine": 30,
+      "endLine": 59
+    },
+    "type": "insight",
+    "title": "dvd_of_fib_dvd: Reverse Divisibility via Strong-Divisibility + Injectivity",
+    "content": "The substantive half of the characterization. From Fₘ ∣ Fₙ, Nat.gcd_eq_left gives gcd(Fₘ,Fₙ) = Fₘ, and Nat.fib_gcd (the strong divisibility identity gcd(Fₘ,Fₙ) = F_{gcd(m,n)}) rewrites it to F_{gcd(m,n)} = Fₘ. Because m ≥ 3 gives Fₘ ≥ F₃ = 2, the value F_{gcd(m,n)} ≥ 2 forces gcd(m,n) ≥ 2 (interval_cases rules out 0 and 1, whose fib values are 0 and 1). Fib is strictly monotone on [2,∞) (Nat.fib_strictMonoOn), so its injectivity there turns F_{gcd(m,n)} = Fₘ into gcd(m,n) = m — which is m ∣ n via gcd_dvd_right.",
+    "mathContext": "$F_m \\mid F_n \\Rightarrow \\gcd(F_m,F_n)=F_m \\overset{\\text{fib\\_gcd}}{=} F_{\\gcd(m,n)}$; with $F_m \\ge 2$ and injectivity of $F$ on $[2,\\infty)$ this gives $\\gcd(m,n)=m$, i.e. $m \\mid n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.fib_gcd",
+      "Nat.fib_strictMonoOn",
+      "StrictMonoOn.injOn",
+      "strong divisibility sequence"
+    ],
+    "prerequisites": [
+      "Nat.fib_gcd",
+      "Nat.gcd_eq_left",
+      "Nat.fib_strictMonoOn"
+    ]
+  },
+  {
+    "id": "ann-fib07-iff",
+    "proofId": "fibonacci-identities-oq-07",
+    "range": {
+      "startLine": 61,
+      "endLine": 73
+    },
+    "type": "insight",
+    "title": "fib_dvd_iff and the Necessity of m ≥ 3",
+    "content": "fib_dvd_iff packages the biconditional Fₘ ∣ Fₙ ↔ m ∣ n (m ≥ 3) from the forward Nat.fib_dvd and the reverse dvd_of_fib_dvd. The m ≥ 3 hypothesis is sharp: fib_dvd_iff_needs_three exhibits F₂ = 1 ∣ F₃ = 2 together with 2 ∤ 3, a counterexample decided by kernel computation. The collision F₁ = F₂ = 1 (a unit dividing everything) is exactly what the hypothesis excludes.",
+    "mathContext": "For $m \\ge 3$: $F_m \\mid F_n \\iff m \\mid n$. Sharp, since $F_2 = 1 \\mid F_3$ but $2 \\nmid 3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.fib_dvd",
+      "biconditional",
+      "counterexample",
+      "decide"
+    ],
+    "prerequisites": [
+      "Nat.fib_dvd",
+      "dvd_of_fib_dvd"
+    ]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-07/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-07/meta.json
@@ -1,0 +1,101 @@
+{
+  "id": "fibonacci-identities-oq-07",
+  "title": "Fibonacci Divisibility Characterization: Fₘ ∣ Fₙ ⟺ m ∣ n",
+  "slug": "fibonacci-identities-oq-07",
+  "description": "The full divisibility characterization for Fibonacci numbers: for m ≥ 3, Fₘ ∣ Fₙ iff m ∣ n. Mathlib supplies only the forward direction (Nat.fib_dvd); this entry proves the substantive reverse direction from the strong-divisibility identity Nat.fib_gcd plus injectivity of fib on [2,∞), and shows the m ≥ 3 hypothesis is necessary.",
+  "meta": {
+    "author": "Édouard Lucas (1878)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Divisibility_properties",
+    "date": "1878",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ07.lean",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "divisibility",
+      "strong-divisibility-sequence",
+      "gcd",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 80,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-verified from Mathlib (only the foundational propext / Classical.choice / Quot.sound). Builds on Nat.fib_gcd, Nat.fib_dvd, and Nat.fib_strictMonoOn.",
+    "originalContributions": [
+      "dvd_of_fib_dvd: the reverse divisibility Fₘ ∣ Fₙ → m ∣ n for m ≥ 3 (Mathlib has only the forward Nat.fib_dvd)",
+      "fib_dvd_iff: the full characterization Fₘ ∣ Fₙ ↔ m ∣ n for m ≥ 3",
+      "fib_dvd_iff_needs_three: an explicit witness that the m ≥ 3 hypothesis is necessary (F₂ = 1 ∣ F₃ but 2 ∤ 3)",
+      "not_fib_dvd_of_not_dvd: contrapositive convenience form"
+    ],
+    "prerequisites": [
+      "Fibonacci numbers Nat.fib and the strong-divisibility identity Nat.fib_gcd",
+      "Nat.fib_dvd (forward divisibility) and Nat.fib_strictMonoOn (strict monotonicity on [2,∞))",
+      "gcd manipulation: Nat.gcd_eq_left, Nat.gcd_dvd_right"
+    ]
+  },
+  "overview": {
+    "historicalContext": "That Fibonacci numbers form a strong divisibility sequence — gcd(Fₘ, Fₙ) = F_{gcd(m,n)} — goes back to Lucas (1878) and is one of the oldest results in the arithmetic theory of linear recurrences. Its most quotable corollary is the divisibility characterization Fₘ ∣ Fₙ ⟺ m ∣ n, which underlies primality tests (a prime p ≥ 5 satisfies F_p ≡ ±1 mod p) and the study of Fibonacci entry points.\n\nMathlib already contains the strong-divisibility identity (Nat.fib_gcd) and the forward implication (Nat.fib_dvd). This entry completes the picture with the reverse implication and packages the biconditional, taking care of the boundary subtlety that F₁ = F₂ = 1 forces the m ≥ 3 hypothesis.",
+    "problemStatement": "Prove, fully verified in Lean/Mathlib, that for m ≥ 3 the divisibility Fₘ ∣ Fₙ holds if and only if m ∣ n, and that the m ≥ 3 restriction cannot be dropped.",
+    "proofStrategy": "The forward direction is Mathlib's Nat.fib_dvd. For the reverse: from Fₘ ∣ Fₙ we get gcd(Fₘ, Fₙ) = Fₘ (Nat.gcd_eq_left), and Nat.fib_gcd rewrites the left side as F_{gcd(m,n)}, giving F_{gcd(m,n)} = Fₘ. Since m ≥ 3 gives Fₘ ≥ F₃ = 2, the value F_{gcd(m,n)} ≥ 2 forces gcd(m,n) ≥ 2 (otherwise it would be F₀ = 0 or F₁ = 1). Fibonacci is strictly monotone — hence injective — on [2,∞) (Nat.fib_strictMonoOn), so F_{gcd(m,n)} = Fₘ yields gcd(m,n) = m, i.e. m ∣ n. Necessity of m ≥ 3 is witnessed by F₂ = 1 ∣ F₃ = 2 with 2 ∤ 3, decided by kernel computation.",
+    "keyInsights": [
+      "The reverse direction is exactly the injectivity of fib composed with the strong-divisibility identity — no new recurrence manipulation is needed",
+      "The boundary collision F₁ = F₂ = 1 is the sole obstruction; requiring Fₘ ≥ 2 (i.e. m ≥ 3) removes it and is provably necessary",
+      "gcd(m,n) ≥ 2 must be established before invoking injectivity on [2,∞): F_{gcd} = Fₘ ≥ 2 rules out gcd ∈ {0,1} via interval_cases",
+      "gcd(m,n) = m is definitionally m ∣ n (gcd_dvd_right after the rewrite)"
+    ],
+    "prerequisites": [
+      "Nat.fib and Nat.fib_gcd (strong divisibility sequence)",
+      "Nat.fib_dvd, Nat.fib_mono, Nat.fib_strictMonoOn",
+      "Set.InjOn from StrictMonoOn.injOn",
+      "Nat.gcd_eq_left, Nat.gcd_dvd_right"
+    ]
+  },
+  "sections": [
+    {
+      "id": "reverse-divisibility",
+      "title": "Reverse Divisibility (the new content)",
+      "summary": "dvd_of_fib_dvd: for m ≥ 3, Fₘ ∣ Fₙ → m ∣ n, via fib_gcd and injectivity of fib on [2,∞).",
+      "startLine": 30,
+      "endLine": 59,
+      "mathContext": "From $F_m \\mid F_n$ we obtain $\\gcd(F_m, F_n) = F_m$; the strong-divisibility identity $\\gcd(F_m, F_n) = F_{\\gcd(m,n)}$ (`Nat.fib_gcd`) turns this into $F_{\\gcd(m,n)} = F_m$. As $m \\ge 3$ gives $F_m \\ge F_3 = 2$, the equality forces $\\gcd(m,n) \\ge 2$ (otherwise the left side would be $F_0 = 0$ or $F_1 = 1$). Fibonacci is strictly monotone on $[2,\\infty)$ (`Nat.fib_strictMonoOn`), hence injective there, so $\\gcd(m,n) = m$, which is $m \\mid n$."
+    },
+    {
+      "id": "characterization",
+      "title": "The Characterization and its Sharpness",
+      "summary": "fib_dvd_iff: Fₘ ∣ Fₙ ↔ m ∣ n for m ≥ 3; fib_dvd_iff_needs_three: the hypothesis is necessary; not_fib_dvd_of_not_dvd: contrapositive form.",
+      "startLine": 61,
+      "endLine": 78,
+      "mathContext": "Combining the forward `Nat.fib_dvd` with `dvd_of_fib_dvd` gives the biconditional $F_m \\mid F_n \\leftrightarrow m \\mid n$ for $m \\ge 3$ (`fib_dvd_iff`). The restriction is sharp: at $m = 2$, $F_2 = 1$ divides every Fibonacci number, so $F_2 \\mid F_3$ holds while $2 \\nmid 3$ (`fib_dvd_iff_needs_three`, decided by computation); the same obstruction rules out $m = 1$. The contrapositive `not_fib_dvd_of_not_dvd` records that $m \\nmid n$ implies $F_m \\nmid F_n$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Completes the Fibonacci divisibility characterization Fₘ ∣ Fₙ ⟺ m ∣ n (m ≥ 3): the reverse direction from Nat.fib_gcd + injectivity of fib on [2,∞), the packaged biconditional, and a proof that the m ≥ 3 hypothesis is necessary. 80 lines, 4 theorems, 0 sorries, 0 axioms.",
+    "implications": "The biconditional is the workhorse divisibility fact for Fibonacci numbers, underpinning entry-point arguments and Fibonacci primality tests. The reverse direction was previously absent from Mathlib despite fib_gcd and fib_dvd both being present.",
+    "openQuestions": [
+      "Generalize to Lucas sequences Uₙ(P,Q): the strong-divisibility property and its divisibility corollary hold for a broad class of second-order recurrences",
+      "Prove the entry-point (rank of apparition) results: the least n with p ∣ Fₙ divides every such n",
+      "Establish F_p ≡ (5/p) mod p (Legendre symbol) for primes p, sharpening the divisibility characterization into a congruence"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "extends",
+      "description": "Parent: Fibonacci identities; this entry adds the divisibility characterization"
+    }
+  ],
+  "leanFile": {
+    "namespace": "FibonacciIdentitiesOQ07",
+    "lineCount": 80,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ07.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry `fibonacci-identities-oq-07`. Completes the classical Fibonacci **divisibility characterization**: for $m \ge 3$,
$$F_m \mid F_n \iff m \mid n.$$

Mathlib already provides the strong-divisibility identity `Nat.fib_gcd` ($\gcd(F_m,F_n)=F_{\gcd(m,n)}$) and the **forward** implication `Nat.fib_dvd` ($m\mid n \Rightarrow F_m\mid F_n$), but **not** the reverse direction or the biconditional. This entry supplies them.

### Contributions
- `dvd_of_fib_dvd` — the substantive reverse direction: $F_m \mid F_n \Rightarrow m \mid n$ for $m \ge 3$. Proof: $F_m\mid F_n \Rightarrow \gcd(F_m,F_n)=F_m \overset{\text{fib\_gcd}}{=} F_{\gcd(m,n)}$; since $F_m \ge F_3 = 2$ forces $\gcd(m,n)\ge 2$, injectivity of `fib` on $[2,\infty)$ (`Nat.fib_strictMonoOn`) gives $\gcd(m,n)=m$.
- `fib_dvd_iff` — the packaged biconditional.
- `fib_dvd_iff_needs_three` — proves the $m \ge 3$ hypothesis is **necessary** ($F_2 = 1 \mid F_3$ yet $2 \nmid 3$; the collision $F_1=F_2=1$ is the sole obstruction).
- `not_fib_dvd_of_not_dvd` — contrapositive convenience form.

### Verification
- Compiled clean against Mathlib (pinned `v4.26.0`) via `lake env lean`.
- `#print axioms` on all four results: only `propext, Classical.choice, Quot.sound` — **0-axiom / verified**, 0 sorries.
- 80 lines, 4 theorems.

### Note on pool status
The candidate pool marked this slug `completed`, but no Lean file, gallery entry, or PR existed (a dead-session artifact) — adopted and completed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)