### PR TITLE
research(hermite-legendre-factorial-oq-02): Legendre core recursion from scratch [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/HermiteLegendreFactorialOQ02.lean
+++ b/proofs/Proofs/HermiteLegendreFactorialOQ02.lean
@@ -1,0 +1,155 @@
+/-
+# The Legendre Core Recursion, proved from scratch
+
+The parent entry `hermite-legendre-factorial` rewrites *each* Legendre summand
+through Hermite's floor identity, but it still **cites** Mathlib's
+`padicValNat_factorial` for the underlying formula
+$$v_p(n!) = \sum_{i \ge 1} \left\lfloor \frac{n}{p^{\,i}} \right\rfloor .$$
+
+This file removes that dependency.  We give a self-contained proof of the
+**Legendre core recursion**
+$$v_p(n!) \;=\; \left\lfloor \tfrac np \right\rfloor \;+\; v_p\!\left(\left\lfloor \tfrac np\right\rfloor!\right)$$
+(equivalently `v_p((p·m)!) = m + v_p(m!)`), and then *derive* the full Legendre
+formula from it by induction — never touching `padicValNat_factorial`.
+
+## The argument
+
+Write `q = ⌊n/p⌋`.  Factorisation is additive over products, so
+
+$$v_p(n!) \;=\; \sum_{k=1}^{n} v_p(k).$$
+
+A term `v_p(k)` vanishes unless `p ∣ k`.  The multiples of `p` in `[1,n]` are
+exactly `p·1, p·2, …, p·q`, and `v_p(p·j) = 1 + v_p(j)` for `j ≥ 1`.  Hence
+
+$$\sum_{k=1}^{n} v_p(k) \;=\; \sum_{j=1}^{q}\bigl(1 + v_p(j)\bigr)
+   \;=\; q + \sum_{j=1}^{q} v_p(j) \;=\; q + v_p(q!),$$
+
+which is the recursion.  Unfolding it `⌊\log_p n⌋` times gives Legendre's sum.
+
+No axioms beyond Lean/Mathlib's foundations; `0` sorries.  We work with
+`Nat.factorization p` throughout (which agrees with `padicValNat p` on primes,
+`Nat.factorization_def`) because it carries the additive `factorization_mul` /
+`factorization_prod` API.
+-/
+import Mathlib
+
+open Finset
+
+namespace HermiteLegendreFactorialOQ02
+
+/-! ### The factorial as a sum of prime-power valuations -/
+
+/-- `v_p(n!) = ∑_{k=1}^{n} v_p(k)`: the `p`-adic valuation of a factorial is the
+sum of the valuations of its factors.  This is just additivity of
+`Nat.factorization` over the product `n! = ∏_{k=1}^n k`. -/
+theorem factorization_factorial_eq_sum (n p : ℕ) :
+    (Nat.factorial n).factorization p = ∑ k ∈ Icc 1 n, (k.factorization p) := by
+  rw [← Nat.Ico_succ_right]
+  have hS : ∀ x ∈ Ico 1 (n + 1), x ≠ 0 := by
+    intro x hx
+    exact Nat.one_le_iff_ne_zero.mp (Finset.mem_Ico.mp hx).1
+  rw [← Finset.prod_Ico_id_eq_factorial, Nat.factorization_prod hS,
+    Finsupp.finset_sum_apply]
+
+/-! ### The core recursion -/
+
+/-- The multiples of `p` in `Icc 1 n` are exactly the image of `Icc 1 (n / p)`
+under `j ↦ p * j`. -/
+theorem image_mul_eq_filter_dvd {p : ℕ} (hp : 0 < p) (n : ℕ) :
+    (Icc 1 (n / p)).image (fun j => p * j) = (Icc 1 n).filter (fun k => p ∣ k) := by
+  ext k
+  simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_Icc]
+  constructor
+  · rintro ⟨j, ⟨hj1, hj2⟩, rfl⟩
+    refine ⟨⟨?_, ?_⟩, Dvd.intro j rfl⟩
+    · calc 1 ≤ p * 1 := by simpa using hp
+        _ ≤ p * j := by exact Nat.mul_le_mul_left p hj1
+    · rw [mul_comm]; exact (Nat.le_div_iff_mul_le hp).mp hj2
+  · rintro ⟨⟨hk1, hk2⟩, ⟨j, rfl⟩⟩
+    refine ⟨j, ⟨?_, ?_⟩, rfl⟩
+    · rcases Nat.eq_zero_or_pos j with hj | hj
+      · simp [hj] at hk1
+      · exact hj
+    · exact Nat.le_div_iff_mul_le hp |>.mpr (by rw [mul_comm]; exact hk2)
+
+/-- **Legendre core recursion.**  For a prime `p`,
+`v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!)`.  Proved from additivity of `Nat.factorization`
+and the multiples-of-`p` reindexing — *not* from `padicValNat_factorial`. -/
+theorem factorization_factorial_rec (n p : ℕ) (hp : p.Prime) :
+    (Nat.factorial n).factorization p = n / p + (Nat.factorial (n / p)).factorization p := by
+  rw [factorization_factorial_eq_sum n p, factorization_factorial_eq_sum (n / p) p]
+  -- Drop the non-multiples (their valuation is 0), then reindex by `j ↦ p*j`.
+  have hdrop : ∑ k ∈ (Icc 1 n).filter (fun k => p ∣ k), k.factorization p
+             = ∑ k ∈ Icc 1 n, k.factorization p := by
+    apply Finset.sum_filter_of_ne
+    intro x _ hne
+    by_contra hpx
+    exact hne (Nat.factorization_eq_zero_of_not_dvd hpx)
+  rw [← hdrop, ← image_mul_eq_filter_dvd hp.pos n]
+  rw [Finset.sum_image (by
+    intro a _ b _ h
+    exact Nat.eq_of_mul_eq_mul_left hp.pos h)]
+  -- Each factor: `v_p(p*j) = 1 + v_p(j)`.
+  have hterm : ∀ j ∈ Icc 1 (n / p), (p * j).factorization p = 1 + j.factorization p := by
+    intro j hj
+    have hj0 : j ≠ 0 := Nat.one_le_iff_ne_zero.mp (Finset.mem_Icc.mp hj).1
+    rw [Nat.factorization_mul hp.pos.ne' hj0]
+    simp [hp.factorization_self]
+  rw [Finset.sum_congr rfl hterm, Finset.sum_add_distrib]
+  simp [Nat.card_Icc]
+
+/-! ### The `(p · m)!` form and the `padicValNat` bridge -/
+
+/-- The multiplicative form of the core recursion: `v_p((p·m)!) = m + v_p(m!)`. -/
+theorem factorization_factorial_mul (m p : ℕ) (hp : p.Prime) :
+    (Nat.factorial (p * m)).factorization p = m + (Nat.factorial m).factorization p := by
+  have h := factorization_factorial_rec (p * m) p hp
+  rwa [Nat.mul_div_cancel_left m hp.pos] at h
+
+/-- `Nat.factorization p` agrees with `padicValNat p` on primes, so the recursion
+transfers verbatim to the `padicValNat` used by the parent entry. -/
+theorem padicValNat_factorial_rec (n p : ℕ) (hp : p.Prime) :
+    padicValNat p (Nat.factorial n) = n / p + padicValNat p (Nat.factorial (n / p)) := by
+  rw [← Nat.factorization_def _ hp, ← Nat.factorization_def _ hp,
+    factorization_factorial_rec n p hp]
+
+/-! ### Legendre's formula, derived from the recursion -/
+
+/-- **Legendre's formula, without citing `padicValNat_factorial`.**  Unfolding the
+core recursion `b` times (any `b` with `Nat.log p n < b`) yields Legendre's sum
+`v_p(n!) = ∑_{i=0}^{b-1} ⌊n / p^{i+1}⌋ = ⌊n/p⌋ + ⌊n/p²⌋ + …`.  The induction is on
+the unfolding depth `b`.  Each step peels the leading `⌊n/p⌋` off the recursion
+and matches the tail against the induction hypothesis applied to `⌊n/p⌋`, using
+`⌊n/p^{i+2}⌋ = ⌊⌊n/p⌋ / p^{i+1}⌋` (`Nat.div_div_eq_div_mul`). -/
+theorem factorization_factorial_legendre (n p b : ℕ) (hp : p.Prime)
+    (hb : Nat.log p n < b) :
+    (Nat.factorial n).factorization p = ∑ i ∈ range b, n / p ^ (i + 1) := by
+  induction b generalizing n with
+  | zero => omega
+  | succ b ih =>
+    -- The tail identity: v_p((n/p)!) = ∑_{i<b} ⌊n/p / p^{i+1}⌋.
+    have hsub : (Nat.factorial (n / p)).factorization p = ∑ i ∈ range b, n / p / p ^ (i + 1) := by
+      rcases Nat.eq_zero_or_pos (n / p) with h0 | h0
+      · simp [h0, Nat.factorial_zero, Nat.factorization_one]
+      · refine ih (n / p) ?_
+        have hle : Nat.log p n ≤ b := Nat.lt_succ_iff.mp hb
+        have hpn : p ≤ n := (Nat.one_le_div_iff hp.pos).mp h0
+        have hpos : 0 < Nat.log p n := Nat.log_pos hp.one_lt hpn
+        rw [Nat.log_div_base]; omega
+    -- ⌊n/p^{i+2}⌋ = ⌊⌊n/p⌋/p^{i+1}⌋.
+    have hpow : ∀ i, n / p ^ (i + 2) = n / p / p ^ (i + 1) := fun i => by
+      rw [Nat.div_div_eq_div_mul, ← pow_succ']
+    rw [factorization_factorial_rec n p hp,
+      Finset.sum_range_succ' (fun i => n / p ^ (i + 1)) b]
+    simp only [Nat.zero_add, pow_one]
+    rw [Finset.sum_congr rfl (fun i _ => by rw [show i + 1 + 1 = i + 2 from rfl, hpow i]),
+      hsub, add_comm]
+
+/-- Legendre's formula in `padicValNat` form (the shape the parent cites from
+Mathlib), now proved independently of `padicValNat_factorial`. -/
+theorem padicValNat_factorial_legendre (n p b : ℕ) (hp : p.Prime)
+    (hb : Nat.log p n < b) :
+    padicValNat p (Nat.factorial n) = ∑ i ∈ range b, n / p ^ (i + 1) := by
+  rw [← Nat.factorization_def _ hp, factorization_factorial_legendre n p b hp hb]
+
+end HermiteLegendreFactorialOQ02

--- a/src/data/proofs/hermite-legendre-factorial-oq-02/annotations.json
+++ b/src/data/proofs/hermite-legendre-factorial-oq-02/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "ann-hlfoq02-setup",
+    "proofId": "hermite-legendre-factorial-oq-02",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "The Open Question: Remove the Citation of padicValNat_factorial",
+    "content": "The parent entry hermite-legendre-factorial refined each Legendre summand through Hermite's floor identity but still cited Mathlib's `padicValNat_factorial` for the underlying formula v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋. Its second open question asked for an independent proof of the Legendre core recursion v_p((p·m)!) = m + v_p(m!) so that the whole formula is derived rather than cited. This file answers that: it proves the recursion v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!) from first principles and derives Legendre's formula from it by induction. The proof is an elementary multiplicative-valuation argument (not a literal application of Hermite's identity). The file works with Nat.factorization throughout, which carries the additive API padicValNat lacks at the surface, and transports the result back to padicValNat on primes via Nat.factorization_def.",
+    "mathContext": "Target: derive $v_p(n!) = \\sum_i \\lfloor n/p^{i+1}\\rfloor$ from $v_p(n!) = \\lfloor n/p\\rfloor + v_p(\\lfloor n/p\\rfloor!)$, citing no external Legendre formula.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Legendre's formula",
+      "p-adic valuation",
+      "Nat.factorization vs padicValNat",
+      "factorial recursion"
+    ]
+  },
+  {
+    "id": "ann-hlfoq02-factorial-sum",
+    "proofId": "hermite-legendre-factorial-oq-02",
+    "range": { "startLine": 45, "endLine": 51 },
+    "type": "technique",
+    "title": "Valuation of a Factorial as a Sum of Valuations",
+    "content": "factorization_factorial_eq_sum turns v_p(n!) into ∑_{k∈Icc 1 n} v_p(k). The p-adic valuation is additive over products, and n! is the product ∏_{k∈Ico 1 (n+1)} k (Finset.prod_Ico_id_eq_factorial). Applying Nat.factorization_prod (valid because every factor in Icc 1 n is nonzero) turns the valuation of the product into a Finsupp sum of valuations, and Finsupp.finset_sum_apply evaluates that sum at the prime p. This is the additive skeleton on which the whole recursion rests.",
+    "mathContext": "$v_p(n!) = \\sum_{k=1}^n v_p(k)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "additivity of valuations",
+      "Nat.factorization_prod",
+      "Finsupp.finset_sum_apply"
+    ]
+  },
+  {
+    "id": "ann-hlfoq02-multiples",
+    "proofId": "hermite-legendre-factorial-oq-02",
+    "range": { "startLine": 56, "endLine": 73 },
+    "type": "key-step",
+    "title": "The Multiples of p Are the Image of j ↦ p·j",
+    "content": "image_mul_eq_filter_dvd proves (Icc 1 (n/p)).image (p·−) = (Icc 1 n).filter (p ∣ ·). This is the combinatorial heart of the recursion: the multiples of p in [1,n] are exactly p·1, p·2, …, p·⌊n/p⌋. The nontrivial bound is p·j ≤ n ⟺ j ≤ n/p, which is Nat.le_div_iff_mul_le (the Euclidean-division adjunction). Because j ↦ p·j is injective on ℕ (p > 0), this set equality lets a sum over the multiples of p be reindexed as a sum over Icc 1 (n/p).",
+    "mathContext": "Multiples of $p$ in $[1,n]$ $= \\{p\\cdot 1,\\dots,p\\cdot\\lfloor n/p\\rfloor\\}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Euclidean division adjunction",
+      "Nat.le_div_iff_mul_le",
+      "Finset.image / injective reindexing"
+    ]
+  },
+  {
+    "id": "ann-hlfoq02-recursion",
+    "proofId": "hermite-legendre-factorial-oq-02",
+    "range": { "startLine": 75, "endLine": 99 },
+    "type": "key-step",
+    "title": "The Legendre Core Recursion, from Scratch",
+    "content": "factorization_factorial_rec proves v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!). Starting from v_p(n!) = ∑_{k∈Icc 1 n} v_p(k), the terms with p∤k vanish (Nat.factorization_eq_zero_of_not_dvd), so Finset.sum_filter_of_ne restricts the sum to the multiples of p. Those are reindexed by j ↦ p·j (Finset.sum_image via image_mul_eq_filter_dvd), and each term evaluates as v_p(p·j) = v_p(p) + v_p(j) = 1 + v_p(j) (Nat.factorization_mul with p, j ≠ 0, and hp.factorization_self). Summing the constant 1 over Icc 1 (n/p) contributes its cardinality n/p (Nat.card_Icc), and the remaining ∑ v_p(j) folds back into v_p(⌊n/p⌋!). No use of padicValNat_factorial.",
+    "mathContext": "$v_p(n!) = \\lfloor n/p\\rfloor + v_p(\\lfloor n/p\\rfloor!)$, since $v_p(p\\cdot j) = 1 + v_p(j)$ and there are $\\lfloor n/p\\rfloor$ multiples.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Legendre recursion",
+      "Nat.factorization_mul",
+      "Prime.factorization_self",
+      "Finset.sum_filter_of_ne",
+      "Finset.sum_image"
+    ]
+  },
+  {
+    "id": "ann-hlfoq02-mul-form",
+    "proofId": "hermite-legendre-factorial-oq-02",
+    "range": { "startLine": 103, "endLine": 113 },
+    "type": "technique",
+    "title": "The (p·m)! Form and the padicValNat Bridge",
+    "content": "factorization_factorial_mul specializes the recursion to n = p·m: since (p·m)/p = m (Nat.mul_div_cancel_left), it reads v_p((p·m)!) = m + v_p(m!) — the exact statement named in the parent's open question. padicValNat_factorial_rec restates the recursion in padicValNat form using Nat.factorization_def, which identifies Nat.factorization p with padicValNat p on primes, so the result plugs directly into the parent's padicValNat-based development.",
+    "mathContext": "$v_p((p\\cdot m)!) = m + v_p(m!)$; the same in `padicValNat` notation.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.mul_div_cancel_left",
+      "Nat.factorization_def",
+      "padicValNat"
+    ]
+  },
+  {
+    "id": "ann-hlfoq02-legendre",
+    "proofId": "hermite-legendre-factorial-oq-02",
+    "range": { "startLine": 118, "endLine": 152 },
+    "type": "key-step",
+    "title": "Legendre's Formula, Derived by Unfolding the Recursion",
+    "content": "factorization_factorial_legendre proves v_p(n!) = ∑_{i<b} ⌊n/p^{i+1}⌋ for any b with log_p n < b, by induction on the unfolding depth b. Each step applies the core recursion, peels the leading ⌊n/p⌋ = n/p^1 off the sum (Finset.sum_range_succ'), and matches the tail against the induction hypothesis applied to n/p. The bridge ⌊n/p^{i+2}⌋ = ⌊(n/p)/p^{i+1}⌋ (Nat.div_div_eq_div_mul + pow_succ') aligns the tail with the hypothesis, and the log bound Nat.log p (n/p) < b is discharged by Nat.log_div_base and Nat.log_pos (splitting on whether n/p = 0). padicValNat_factorial_legendre gives the same formula in padicValNat form — the shape Mathlib records — now proved independently.",
+    "mathContext": "$v_p(n!) = \\sum_{i=0}^{b-1} \\lfloor n/p^{i+1}\\rfloor$: Legendre's formula, no longer cited but derived.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "induction on unfolding depth",
+      "Finset.sum_range_succ'",
+      "Nat.div_div_eq_div_mul",
+      "Nat.log_div_base",
+      "Nat.log_pos"
+    ]
+  }
+]

--- a/src/data/proofs/hermite-legendre-factorial-oq-02/meta.json
+++ b/src/data/proofs/hermite-legendre-factorial-oq-02/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "hermite-legendre-factorial-oq-02",
+  "title": "The Legendre Core Recursion, Proved from Scratch",
+  "slug": "hermite-legendre-factorial-oq-02",
+  "description": "The parent entry hermite-legendre-factorial rewrites each Legendre summand through Hermite's floor identity but still CITES Mathlib's `padicValNat_factorial` for the underlying formula v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋. This entry answers the parent's open question #2 by removing that dependency: it gives a self-contained proof of the Legendre core recursion v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!) (equivalently v_p((p·m)!) = m + v_p(m!)) and then DERIVES the full Legendre formula from it by induction, never touching `padicValNat_factorial`. The recursion is proved by an elementary multiplicative-valuation argument rather than through Hermite's identity: writing q = ⌊n/p⌋, additivity of Nat.factorization over n! = ∏_{k=1}^n k gives v_p(n!) = ∑_{k=1}^n v_p(k); the terms with p∤k vanish (Nat.factorization_eq_zero_of_not_dvd), the multiples of p in [1,n] are exactly {p·1,…,p·q} (image_mul_eq_filter_dvd), and v_p(p·j) = 1 + v_p(j) (Nat.factorization_mul + Prime.factorization_self), so ∑_{k=1}^n v_p(k) = ∑_{j=1}^q (1 + v_p(j)) = q + v_p(q!). Unfolding the recursion ⌊log_p n⌋ times (induction on the unfolding depth, with ⌊n/p^{i+2}⌋ = ⌊⌊n/p⌋/p^{i+1}⌋ collapsing the iterated quotients) reproduces Legendre's sum ∑_{i} ⌊n/p^{i+1}⌋. Both the factorization form and the padicValNat form (matching the shape Mathlib records) are given, verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "A.-M. Legendre (recursion) / research formalization",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HermiteLegendreFactorialOQ02.lean",
+    "tags": [
+      "number-theory",
+      "p-adic-valuation",
+      "factorial",
+      "legendre-formula",
+      "prime-factorization",
+      "euclidean-division",
+      "induction",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 155,
+    "assumptions": "0 axioms, 0 sorries; kernel-checked at Mathlib (single-file elaboration via `lake env lean Proofs/HermiteLegendreFactorialOQ02.lean`, exit 0; `#print axioms` on factorization_factorial_rec, factorization_factorial_legendre, and padicValNat_factorial_legendre lists only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, so the entry is axiom-free per the project's axiom-integrity policy). Crucially, NONE of the proofs invoke Mathlib's `padicValNat_factorial` (Legendre's formula) or `Nat.Prime.factorization_factorial`: the recursion and the full Legendre formula are both derived from first principles using only the additivity API of Nat.factorization (Nat.factorization_prod, Nat.factorization_mul, Prime.factorization_self, Nat.factorization_eq_zero_of_not_dvd), the factorial-as-product lemma Finset.prod_Ico_id_eq_factorial, and elementary Euclidean-division facts (Nat.le_div_iff_mul_le, Nat.div_div_eq_div_mul, Nat.log_div_base, Nat.log_pos).",
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "factorization_factorial_rec: the Legendre core recursion v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!) for prime p, proved independently of Mathlib's padicValNat_factorial via additivity of Nat.factorization over n! = ∏_{k=1}^n k plus the multiples-of-p reindexing.",
+      "factorization_factorial_legendre: Legendre's formula v_p(n!) = ∑_{i<b} ⌊n/p^{i+1}⌋ (for any b > log_p n), DERIVED from the core recursion by induction on the unfolding depth — the parent cited this from Mathlib; here it is proved from scratch.",
+      "image_mul_eq_filter_dvd: the multiples of p in Icc 1 n are exactly the image of Icc 1 (n/p) under j ↦ p·j, the combinatorial heart of the recursion.",
+      "factorization_factorial_mul: the multiplicative form v_p((p·m)!) = m + v_p(m!), the exact recursion named in the parent's open question, as an immediate specialization.",
+      "padicValNat_factorial_rec / padicValNat_factorial_legendre: the recursion and Legendre's formula transported to the padicValNat form used by the parent (via Nat.factorization_def), so the parent's citation of padicValNat_factorial can be replaced verbatim."
+    ],
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Legendre's formula (de Polignac, 1808) computes v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋. Its standard elementary proof runs through the recursion v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!): among 1,…,n exactly ⌊n/p⌋ are divisible by p, and dividing each by p reduces the count to a factorial of size ⌊n/p⌋. Mathlib records the closed formula as `padicValNat_factorial`, and the parent gallery entry hermite-legendre-factorial cited it while adding a Hermite-identity refinement of each summand. The parent's second open question asked for a proof of the core recursion itself, so that the whole formula is derived rather than cited. This entry supplies exactly that derivation.",
+    "problemStatement": "Prove the Legendre core recursion v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!) (equivalently v_p((p·m)!) = m + v_p(m!)) from first principles, without citing Mathlib's padicValNat_factorial, and use it to derive the full Legendre formula v_p(n!) = ∑_i ⌊n/p^{i+1}⌋.",
+    "text": "Headline results: factorization_factorial_rec (n p : ℕ) (hp : p.Prime) : (n!).factorization p = n/p + ((n/p)!).factorization p, and factorization_factorial_legendre (n p b : ℕ) (hp : p.Prime) (hb : Nat.log p n < b) : (n!).factorization p = ∑ i ∈ range b, n / p^(i+1). Supporting: factorization_factorial_eq_sum (v_p(n!) = ∑_{k∈Icc 1 n} v_p(k)), image_mul_eq_filter_dvd (multiples reindexing), factorization_factorial_mul (the (p·m)! form), and the padicValNat bridges.",
+    "proofStrategy": "Four steps. (1) factorization_factorial_eq_sum: write n! = ∏_{k∈Ico 1 (n+1)} k (Finset.prod_Ico_id_eq_factorial) and apply additivity of Nat.factorization (Nat.factorization_prod, then Finsupp.finset_sum_apply) to get v_p(n!) = ∑_{k∈Icc 1 n} v_p(k). (2) image_mul_eq_filter_dvd: the multiples of p in Icc 1 n biject with Icc 1 (n/p) via j ↦ p·j, using Nat.le_div_iff_mul_le for the range bounds. (3) factorization_factorial_rec: drop the non-multiple terms (they vanish by Nat.factorization_eq_zero_of_not_dvd, via Finset.sum_filter_of_ne), reindex the multiples by the bijection (Finset.sum_image with injectivity of p·−), and evaluate each term v_p(p·j) = 1 + v_p(j) (Nat.factorization_mul + hp.factorization_self); summing the constant 1 over Icc 1 (n/p) contributes the card n/p. (4) factorization_factorial_legendre: induct on the unfolding depth b; the recursion peels the leading ⌊n/p⌋ = n/p^1 (Finset.sum_range_succ'), and the tail matches the induction hypothesis applied to n/p once ⌊n/p^{i+2}⌋ is rewritten as ⌊⌊n/p⌋/p^{i+1}⌋ (Nat.div_div_eq_div_mul), with the log bound Nat.log p (n/p) < b handled by Nat.log_div_base and Nat.log_pos.",
+    "keyInsights": [
+      "The recursion is a pure counting identity, independent of Hermite's floor identity: among 1,…,n exactly ⌊n/p⌋ integers are divisible by p, and factoring one p out of each turns their product into p^{⌊n/p⌋}·(⌊n/p⌋!). Additivity of the p-adic valuation converts this product structure into the additive recursion.",
+      "Working with Nat.factorization rather than padicValNat is what unlocks the elementary proof: Nat.factorization carries the full additive API (factorization_prod / factorization_mul) that padicValNat lacks at the surface, and Nat.factorization_def transports the result back to padicValNat on primes at no cost.",
+      "Deriving the closed formula from the recursion is an induction on unfolding depth, not on n: each unfolding step exposes one Legendre term ⌊n/p^{i+1}⌋ and defers the rest to ⌊n/p⌋, and Nat.div_div_eq_div_mul is exactly the lemma that collapses the iterated quotients ⌊(⌊n/p⌋)/p^i⌋ back into single powers ⌊n/p^{i+1}⌋.",
+      "The parent cited padicValNat_factorial as an external input; this entry shows that citation was avoidable — the whole formula follows from the additive valuation calculus plus one counting bijection, so the gallery's Legendre/Hermite story is now self-contained down to Mathlib's foundational factorization API."
+    ],
+    "prerequisites": [
+      "The p-adic valuation, in the guises padicValNat p and Nat.factorization p (equal on primes, Nat.factorization_def)",
+      "Additivity of Nat.factorization over products (Nat.factorization_prod, Nat.factorization_mul) and Prime.factorization_self",
+      "Factorial as a product Finset.prod_Ico_id_eq_factorial and finite-sum reindexing (Finset.sum_image, Finset.sum_filter_of_ne, Finset.sum_range_succ')",
+      "Euclidean-division facts: Nat.le_div_iff_mul_le, Nat.div_div_eq_div_mul, and the base-p logarithm lemmas Nat.log_div_base / Nat.log_pos"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "§0: Module Setup and Statement",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring recalling that the parent cites Mathlib's padicValNat_factorial and stating this entry's goal: an independent proof of the core recursion v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!) and a from-scratch derivation of Legendre's formula. Outlines the counting argument (multiples of p, valuation additivity) and notes the file works with Nat.factorization throughout. Imports full Mathlib and opens Finset.",
+      "mathContext": "Goal: derive $v_p(n!) = \\sum_i \\lfloor n/p^{i+1}\\rfloor$ from the recursion $v_p(n!) = \\lfloor n/p\\rfloor + v_p(\\lfloor n/p\\rfloor!)$ without citing `padicValNat_factorial`."
+    },
+    {
+      "id": "factorial-sum",
+      "title": "The Factorial as a Sum of Valuations",
+      "startLine": 42,
+      "endLine": 51,
+      "summary": "factorization_factorial_eq_sum: v_p(n!) = ∑_{k∈Icc 1 n} v_p(k). Rewrites n! as ∏_{k∈Ico 1 (n+1)} k (Finset.prod_Ico_id_eq_factorial) and applies additivity of Nat.factorization (Nat.factorization_prod, all factors nonzero) followed by Finsupp.finset_sum_apply to distribute the valuation over the product.",
+      "mathContext": "$v_p(n!) = \\sum_{k=1}^n v_p(k)$ by additivity of the $p$-adic valuation over $n! = \\prod_{k=1}^n k$."
+    },
+    {
+      "id": "multiples-reindex",
+      "title": "The Multiples of p as an Image",
+      "startLine": 54,
+      "endLine": 73,
+      "summary": "image_mul_eq_filter_dvd: (Icc 1 (n/p)).image (p·−) = (Icc 1 n).filter (p ∣ ·). Forward: p·j with 1 ≤ j ≤ n/p satisfies 1 ≤ p·j ≤ n (Nat.le_div_iff_mul_le) and is divisible by p. Backward: a multiple p·j ≤ n gives j ≤ n/p and j ≥ 1. This bijection is what turns the sum over multiples into a sum over Icc 1 (n/p).",
+      "mathContext": "The multiples of $p$ in $[1,n]$ are exactly $\\{p\\cdot 1, \\dots, p\\cdot\\lfloor n/p\\rfloor\\}$."
+    },
+    {
+      "id": "core-recursion",
+      "title": "The Legendre Core Recursion",
+      "startLine": 75,
+      "endLine": 99,
+      "summary": "factorization_factorial_rec: v_p(n!) = n/p + v_p((n/p)!). Applies factorization_factorial_eq_sum to both sides, drops the non-multiple terms (v_p(k) = 0 when p∤k, via Finset.sum_filter_of_ne + Nat.factorization_eq_zero_of_not_dvd), reindexes the multiples by j ↦ p·j (Finset.sum_image, p·− injective), evaluates v_p(p·j) = 1 + v_p(j) (Nat.factorization_mul + hp.factorization_self), and sums the constant 1 over Icc 1 (n/p) to get the card n/p (Nat.card_Icc).",
+      "mathContext": "$v_p(n!) = \\lfloor n/p\\rfloor + v_p(\\lfloor n/p\\rfloor!)$: the standard Legendre recursion, proved from the counting bijection."
+    },
+    {
+      "id": "mul-form-and-bridge",
+      "title": "The (p·m)! Form and the padicValNat Bridge",
+      "startLine": 101,
+      "endLine": 113,
+      "summary": "factorization_factorial_mul: v_p((p·m)!) = m + v_p(m!), the exact recursion named in the parent's open question, obtained from the core recursion by Nat.mul_div_cancel_left. padicValNat_factorial_rec: the same recursion in padicValNat form, via Nat.factorization_def (which identifies Nat.factorization p with padicValNat p on primes).",
+      "mathContext": "$v_p((p\\cdot m)!) = m + v_p(m!)$, and the recursion transported to `padicValNat`."
+    },
+    {
+      "id": "legendre-from-recursion",
+      "title": "Legendre's Formula from the Recursion",
+      "startLine": 116,
+      "endLine": 152,
+      "summary": "factorization_factorial_legendre: v_p(n!) = ∑_{i<b} ⌊n/p^{i+1}⌋ for any b > log_p n, by induction on the unfolding depth b. The recursion peels off ⌊n/p⌋ = n/p^1 (Finset.sum_range_succ'), and the tail v_p((n/p)!) = ∑_{i<b'} ⌊(n/p)/p^{i+1}⌋ comes from the induction hypothesis applied to n/p (log bound via Nat.log_div_base / Nat.log_pos), after rewriting ⌊n/p^{i+2}⌋ = ⌊(n/p)/p^{i+1}⌋ (Nat.div_div_eq_div_mul). padicValNat_factorial_legendre gives the same formula in padicValNat form.",
+      "mathContext": "$v_p(n!) = \\sum_{i=0}^{b-1} \\lfloor n/p^{i+1}\\rfloor$, derived from the recursion — Legendre's formula, no longer cited."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Legendre core recursion v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!) is proved from first principles — additivity of the p-adic valuation over n! = ∏_{k=1}^n k, the counting bijection sending the multiples of p in [1,n] onto {p·1,…,p·⌊n/p⌋}, and the one-step valuation v_p(p·j) = 1 + v_p(j) — and the full Legendre formula v_p(n!) = ∑_i ⌊n/p^{i+1}⌋ is then derived from it by induction on the unfolding depth. No proof invokes Mathlib's padicValNat_factorial or Nat.Prime.factorization_factorial, so the parent entry's citation of Legendre's formula is now fully discharged (0 axioms, 0 sorries). Both the Nat.factorization form and the padicValNat form are provided.",
+    "openQuestions": [
+      "Derive the base-p digit-sum form (p-1)·v_p(n!) = n − s_p(n) from the recursion, giving Kummer's carry count and a second classical route to Legendre's formula.",
+      "Combine this from-scratch recursion with the parent's Hermite refinement to obtain a Legendre/Hermite development of v_p(n!) that cites no external formula at all — a fully self-contained double-sum identity."
+    ],
+    "implications": "The entry closes the parent's open question #2: the gallery's account of Legendre's formula for v_p(n!) is now self-contained down to Mathlib's foundational Nat.factorization API, no longer relying on the black-box `padicValNat_factorial`. The reusable pieces — image_mul_eq_filter_dvd (multiples as an image) and factorization_factorial_eq_sum (valuation of a factorial as a sum) — are standard building blocks for other prime-power counting arguments."
+  },
+  "crossReferences": [
+    {
+      "targetId": "hermite-legendre-factorial",
+      "relationship": "answers-question",
+      "description": "Answers the parent's second open question: proves the Legendre core recursion v_p((p·m)!) = m + v_p(m!) and derives the whole Legendre formula from it, so the parent's citation of Mathlib's padicValNat_factorial is no longer needed. (The proof is an elementary multiplicative-valuation argument rather than a literal application of Hermite's floor identity.)"
+    }
+  ],
+  "references": [
+    {
+      "author": "Legendre, A.-M.",
+      "title": "Théorie des nombres",
+      "year": 1830,
+      "note": "Source of the formula v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋ and its recursion v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!)"
+    },
+    {
+      "author": "Graham, R. L.; Knuth, D. E.; Patashnik, O.",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "note": "Chapter 4 develops the factorial valuation via the multiples-of-p counting argument used here"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "HermiteLegendreFactorialOQ02",
+    "lineCount": 155,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/HermiteLegendreFactorialOQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
New gallery entry **hermite-legendre-factorial-oq-02** answering the parent entry `hermite-legendre-factorial`'s **open question #2**: give a proof of the Legendre core recursion that removes the dependency on Mathlib's `padicValNat_factorial`.

The parent refined each Legendre summand through Hermite's floor identity but still *cited* Mathlib's `padicValNat_factorial` for the formula `v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋`. This entry removes that citation.

## Results (`Proofs/HermiteLegendreFactorialOQ02.lean`, 7 thm / 155 L)
- **`factorization_factorial_rec`** — the core recursion `v_p(n!) = ⌊n/p⌋ + v_p(⌊n/p⌋!)`, proved from first principles: additivity of `Nat.factorization` over `n! = ∏_{k=1}^n k`, the fact that non-multiples of `p` have valuation 0, the bijection `j ↦ p·j` from the multiples onto `Icc 1 (n/p)`, and `v_p(p·j) = 1 + v_p(j)`.
- **`factorization_factorial_legendre`** — Legendre's formula `v_p(n!) = ∑_{i<b} ⌊n/p^{i+1}⌋` (any `b > log_p n`), **derived** from the recursion by induction on the unfolding depth. No `padicValNat_factorial`.
- **`image_mul_eq_filter_dvd`** — the multiples of `p` in `Icc 1 n` are exactly `(Icc 1 (n/p)).image (p··)`.
- **`factorization_factorial_mul`** — the `(p·m)!` form `v_p((p·m)!) = m + v_p(m!)` named verbatim in the parent's open question.
- **`padicValNat_factorial_rec` / `padicValNat_factorial_legendre`** — both results transported to the `padicValNat` form the parent uses (via `Nat.factorization_def`).

## Verification
- Kernel-checked at Mathlib via `lake env lean Proofs/HermiteLegendreFactorialOQ02.lean`, exit 0, 0 sorries.
- `#print axioms` on the three headline theorems lists only `propext` / `Classical.choice` / `Quot.sound` → **VERIFIED, 0 axioms**.
- No proof invokes `padicValNat_factorial` or `Nat.Prime.factorization_factorial`; everything reduces to the additive `Nat.factorization` API + one counting bijection + elementary Euclidean-division lemmas.

## Honesty note
The recursion is proved by an elementary **multiplicative-valuation** argument, not a literal application of Hermite's floor identity. This fully discharges the "no longer cites `padicValNat_factorial` / derives the whole formula" part of the parent's open question; it is arguably cleaner than the Hermite route, and the meta/annotations state this plainly.

## Status
**Outcome**: completed (new VERIFIED 0-axiom entry)

🤖 Generated by researcher-2