### PR TITLE
research(law-of-cosines-oq-09): acute/right/obtuse trichotomy from Law of Cosines [VERIFIED, 0-axiom, +6thm]

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ09.lean
+++ b/proofs/Proofs/LawOfCosinesOQ09.lean
@@ -1,0 +1,124 @@
+/-
+  Acute–Right–Obtuse Trichotomy from the Law of Cosines (Euclid II.12 / II.13)
+
+  The Law of Cosines `c² = a² + b² - 2ab·cos C` turns the classification of a
+  triangle's angle into a purely algebraic comparison of the squared sides:
+
+      C < π/2  ⟺  c² < a² + b²    (acute — Euclid II.13)
+      C = π/2  ⟺  c² = a² + b²    (right  — Pythagoras)
+      C > π/2  ⟺  c² > a² + b²    (obtuse — Euclid II.12)
+
+  This is the converse-and-refinement of the Pythagorean theorem that Euclid
+  states as propositions II.12 and II.13: the sign of `a² + b² - c²` records
+  whether the angle opposite `c` is acute, right, or obtuse.
+
+  The engine is the sign of `cos C` on `[0, π]` (positive below π/2, zero at π/2,
+  negative above), multiplied by the positive quantity `2ab`; the Law of Cosines
+  hypothesis then transfers that sign to `a² + b² - c²`.
+
+  Key results:
+  - `angle_acute_iff`, `angle_right_iff`, `angle_obtuse_iff`: the three
+    equivalences.
+
+  Euclid, *Elements* Book II, Propositions 12–13 (c. 300 BCE)
+-/
+import Mathlib
+
+namespace LawOfCosinesOQ09
+
+open Real
+
+variable {a b c C : ℝ}
+
+-- ============================================================
+-- Sign of cos C against π/2 on [0, π]
+-- ============================================================
+
+/-- On `[0, π]`, `cos C > 0` exactly when `C < π/2`. -/
+private theorem cos_pos_iff_lt (hC0 : 0 ≤ C) (hCpi : C ≤ π) :
+    0 < Real.cos C ↔ C < π / 2 := by
+  constructor
+  · intro h
+    by_contra hle
+    push_neg at hle
+    have : Real.cos C ≤ 0 :=
+      Real.cos_nonpos_of_pi_div_two_le_of_le hle (by linarith [Real.pi_pos])
+    linarith
+  · intro h
+    exact Real.cos_pos_of_mem_Ioo ⟨by linarith [Real.pi_pos], h⟩
+
+/-- On `[0, π]`, `cos C = 0` exactly when `C = π/2`. -/
+private theorem cos_eq_zero_iff_eq (hC0 : 0 ≤ C) (hCpi : C ≤ π) :
+    Real.cos C = 0 ↔ C = π / 2 := by
+  constructor
+  · intro h
+    refine Real.strictAntiOn_cos.injOn ⟨hC0, hCpi⟩
+      ⟨by linarith [Real.pi_pos], by linarith [Real.pi_pos]⟩ ?_
+    rw [h, Real.cos_pi_div_two]
+  · intro h; rw [h, Real.cos_pi_div_two]
+
+/-- On `[0, π]`, `cos C < 0` exactly when `C > π/2`. -/
+private theorem cos_neg_iff_gt (hC0 : 0 ≤ C) (hCpi : C ≤ π) :
+    Real.cos C < 0 ↔ π / 2 < C := by
+  constructor
+  · intro h
+    by_contra hle
+    push_neg at hle
+    have : 0 ≤ Real.cos C := by
+      rcases eq_or_lt_of_le hle with heq | hlt
+      · simp [heq, Real.cos_pi_div_two]
+      · exact le_of_lt (Real.cos_pos_of_mem_Ioo ⟨by linarith [Real.pi_pos], hlt⟩)
+    linarith
+  · intro h
+    exact Real.cos_neg_of_pi_div_two_lt_of_lt h (by linarith [Real.pi_pos])
+
+-- ============================================================
+-- The trichotomy
+-- ============================================================
+
+/-- **Acute angle (Euclid II.13).** With `a, b > 0`, `C ∈ [0, π]`, and the Law of
+    Cosines `c² = a² + b² - 2ab·cos C`, the angle `C` is acute iff `c² < a² + b²`. -/
+theorem angle_acute_iff (ha : 0 < a) (hb : 0 < b) (hC0 : 0 ≤ C) (hCpi : C ≤ π)
+    (hlc : c ^ 2 = a ^ 2 + b ^ 2 - 2 * a * b * Real.cos C) :
+    C < π / 2 ↔ c ^ 2 < a ^ 2 + b ^ 2 := by
+  rw [← cos_pos_iff_lt hC0 hCpi]
+  have h2ab : (0 : ℝ) < 2 * a * b := by positivity
+  constructor
+  · intro h; linarith [mul_pos h2ab h, hlc]
+  · intro h
+    have hpos : 0 < 2 * a * b * Real.cos C := by linarith [hlc]
+    nlinarith [hpos, h2ab]
+
+/-- **Right angle (Pythagoras).** Under the same hypotheses, `C` is a right angle
+    iff `c² = a² + b²`. -/
+theorem angle_right_iff (ha : 0 < a) (hb : 0 < b) (hC0 : 0 ≤ C) (hCpi : C ≤ π)
+    (hlc : c ^ 2 = a ^ 2 + b ^ 2 - 2 * a * b * Real.cos C) :
+    C = π / 2 ↔ c ^ 2 = a ^ 2 + b ^ 2 := by
+  rw [← cos_eq_zero_iff_eq hC0 hCpi]
+  have h2ab : (0 : ℝ) < 2 * a * b := by positivity
+  constructor
+  · intro h
+    have hz : 2 * a * b * Real.cos C = 0 := by rw [h]; ring
+    linarith [hlc, hz]
+  · intro h
+    have hz : 2 * a * b * Real.cos C = 0 := by linarith [hlc]
+    rcases mul_eq_zero.mp hz with h2 | hcos
+    · exact absurd h2 (ne_of_gt h2ab)
+    · exact hcos
+
+/-- **Obtuse angle (Euclid II.12).** Under the same hypotheses, `C` is obtuse iff
+    `c² > a² + b²`. -/
+theorem angle_obtuse_iff (ha : 0 < a) (hb : 0 < b) (hC0 : 0 ≤ C) (hCpi : C ≤ π)
+    (hlc : c ^ 2 = a ^ 2 + b ^ 2 - 2 * a * b * Real.cos C) :
+    π / 2 < C ↔ a ^ 2 + b ^ 2 < c ^ 2 := by
+  rw [← cos_neg_iff_gt hC0 hCpi]
+  have h2ab : (0 : ℝ) < 2 * a * b := by positivity
+  constructor
+  · intro h
+    have hneg : 2 * a * b * Real.cos C < 0 := mul_neg_of_pos_of_neg h2ab h
+    linarith [hlc, hneg]
+  · intro h
+    have hneg : 2 * a * b * Real.cos C < 0 := by linarith [hlc]
+    nlinarith [hneg, h2ab]
+
+end LawOfCosinesOQ09

--- a/src/data/proofs/law-of-cosines-oq-09/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-09/annotations.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": "ann-loc09-cossign",
+    "proofId": "law-of-cosines-oq-09",
+    "range": {
+      "startLine": 37,
+      "endLine": 73
+    },
+    "type": "technique",
+    "title": "Sign of cos C on [0, π] Pins the Angle Relative to π/2",
+    "content": "Three private helpers isolate all the trigonometry. cos_pos_iff_lt: cos C > 0 ↔ C < π/2 (forward from Real.cos_pos_of_mem_Ioo since C ≥ 0 > -π/2; reverse by contraposition via Real.cos_nonpos_of_pi_div_two_le_of_le). cos_eq_zero_iff_eq: cos C = 0 ↔ C = π/2 (injectivity of cos on [0,π] from Real.strictAntiOn_cos.injOn, with cos(π/2) = 0). cos_neg_iff_gt: cos C < 0 ↔ C > π/2 (Real.cos_neg_of_pi_div_two_lt_of_lt). After these, the trichotomy is pure ordered-field algebra.",
+    "mathContext": "$\\cos$ is strictly antitone on $[0,\\pi]$ with $\\cos(\\pi/2)=0$, so its sign against $0$ records $C$ against $\\pi/2$: positive below, zero at, negative above.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.cos_pos_of_mem_Ioo",
+      "Real.strictAntiOn_cos",
+      "Real.cos_neg_of_pi_div_two_lt_of_lt",
+      "Real.cos_pi_div_two"
+    ],
+    "prerequisites": [
+      "monotonicity of cos on [0, π]",
+      "Real.pi_pos"
+    ]
+  },
+  {
+    "id": "ann-loc09-trichotomy",
+    "proofId": "law-of-cosines-oq-09",
+    "range": {
+      "startLine": 79,
+      "endLine": 122
+    },
+    "type": "insight",
+    "title": "angle_acute/right/obtuse_iff: Sign of a² + b² - c² Detects the Angle",
+    "content": "Each trichotomy theorem rewrites its angle condition (C < π/2, = π/2, > π/2) to the matching cos-sign condition, then compares the squared sides. The Law of Cosines gives a² + b² - c² = 2ab·cos C with 2ab > 0, so the sign of a² + b² - c² is the sign of cos C. Acute (Euclid II.13) and obtuse (Euclid II.12) close with linarith/nlinarith using 2ab > 0; the right angle (Pythagoras) is the boundary cos C = 0, handled via mul_eq_zero. This is the precise sense in which the Law of Cosines is the signed converse of the Pythagorean theorem.",
+    "mathContext": "$a^2+b^2-c^2 = 2ab\\cos C$, $2ab>0$: $C<\\tfrac\\pi2\\iff c^2<a^2+b^2$; $C=\\tfrac\\pi2\\iff c^2=a^2+b^2$; $C>\\tfrac\\pi2\\iff c^2>a^2+b^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Law of Cosines",
+      "Pythagorean theorem",
+      "Euclid Elements II.12 / II.13",
+      "sign analysis"
+    ],
+    "prerequisites": [
+      "cos-sign helpers",
+      "nlinarith with 2ab > 0"
+    ]
+  }
+]

--- a/src/data/proofs/law-of-cosines-oq-09/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-09/meta.json
@@ -1,0 +1,105 @@
+{
+  "id": "law-of-cosines-oq-09",
+  "title": "Acute–Right–Obtuse Trichotomy from the Law of Cosines",
+  "slug": "law-of-cosines-oq-09",
+  "description": "Euclid's Elements II.12 and II.13: the Law of Cosines c² = a² + b² - 2ab·cos C makes classifying a triangle's angle a purely algebraic comparison — C is acute, right, or obtuse exactly as a² + b² exceeds, equals, or falls below c². Proved from the sign of cos C on [0, π].",
+  "meta": {
+    "author": "Euclid (c. 300 BCE)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Law_of_cosines",
+    "date": "-300",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ09.lean",
+    "tags": [
+      "geometry",
+      "law-of-cosines",
+      "euclidean-geometry",
+      "trigonometry",
+      "pythagorean-theorem",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 124,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-verified from Mathlib (only the foundational propext / Classical.choice / Quot.sound). The Law of Cosines relation is taken as a hypothesis; the sign analysis uses Real.cos_pos_of_mem_Ioo, Real.cos_nonpos_of_pi_div_two_le_of_le, Real.cos_neg_of_pi_div_two_lt_of_lt, and Real.strictAntiOn_cos.",
+    "originalContributions": [
+      "angle_acute_iff: C < π/2 ↔ c² < a² + b² (Euclid II.13)",
+      "angle_right_iff: C = π/2 ↔ c² = a² + b² (Pythagoras)",
+      "angle_obtuse_iff: C > π/2 ↔ c² > a² + b² (Euclid II.12)",
+      "Sign helpers on [0, π]: cos C is positive below π/2, zero at π/2, negative above, from Mathlib's cos monotonicity and cos_pos_of_mem_Ioo"
+    ],
+    "prerequisites": [
+      "Law of Cosines c² = a² + b² - 2ab·cos C (parent entry)",
+      "Sign and monotonicity of cos on [0, π]: Real.cos_pos_of_mem_Ioo, Real.strictAntiOn_cos, Real.cos_pi_div_two",
+      "Elementary ordered-field reasoning (linarith / nlinarith with 2ab > 0)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euclid's Elements Book II, Propositions 12 and 13, predate trigonometry: II.12 shows that in an obtuse triangle the square on the side opposite the obtuse angle exceeds the sum of the squares on the other two sides (by twice a certain rectangle), and II.13 is the acute counterpart. In modern terms both are captured by the Law of Cosines c² = a² + b² - 2ab·cos C: the extra term 2ab·cos C carries exactly the sign information that distinguishes acute, right, and obtuse angles. The right-angle case is Pythagoras. This entry formalizes the full trichotomy as the sign of a² + b² - c².",
+    "problemStatement": "Given a triangle with sides a, b, c and angle C opposite c, related by the Law of Cosines, prove the three equivalences: C is acute iff c² < a² + b², right iff c² = a² + b², and obtuse iff c² > a² + b².",
+    "proofStrategy": "The whole result is the transfer of the sign of cos C to a² + b² - c², since the Law of Cosines gives a² + b² - c² = 2ab·cos C with 2ab > 0. Three private helper lemmas establish, for C ∈ [0, π], that cos C > 0 ↔ C < π/2 (from Real.cos_pos_of_mem_Ioo and Real.cos_nonpos_of_pi_div_two_le_of_le), cos C = 0 ↔ C = π/2 (from injectivity of cos on [0, π] via Real.strictAntiOn_cos), and cos C < 0 ↔ C > π/2 (from Real.cos_neg_of_pi_div_two_lt_of_lt). Each trichotomy theorem rewrites its angle condition to the corresponding cos-sign condition, then closes the sides-comparison with linarith/nlinarith using 2ab > 0.",
+    "keyInsights": [
+      "The entire trichotomy is one fact — sign(a² + b² - c²) = sign(cos C) — because 2ab > 0",
+      "cos is strictly antitone on [0, π], so its sign relative to cos(π/2) = 0 pins the angle relative to π/2 in both directions",
+      "The right-angle case is Pythagoras, recovered as the boundary cos C = 0 via injectivity of cos on [0, π]",
+      "Extracting cos C > 0 from 2ab·cos C > 0 (and the negative analogue) is handled by nlinarith multiplying the positivity of 2ab against the negated goal"
+    ],
+    "prerequisites": [
+      "Real.cos_pos_of_mem_Ioo, Real.cos_nonpos_of_pi_div_two_le_of_le, Real.cos_neg_of_pi_div_two_lt_of_lt",
+      "Real.strictAntiOn_cos and its injOn, Real.cos_pi_div_two, Real.pi_pos",
+      "linarith / nlinarith over ordered fields"
+    ]
+  },
+  "sections": [
+    {
+      "id": "cos-sign",
+      "title": "Sign of cos C against π/2 on [0, π]",
+      "summary": "Private helpers: cos C > 0 ↔ C < π/2, cos C = 0 ↔ C = π/2, cos C < 0 ↔ C > π/2, for C ∈ [0, π].",
+      "startLine": 33,
+      "endLine": 73,
+      "mathContext": "On $[0,\\pi]$ the cosine is strictly decreasing from $1$ to $-1$, crossing $0$ at $\\pi/2$. `cos_pos_iff_lt` proves $\\cos C > 0 \\iff C < \\pi/2$: the forward direction from `Real.cos_pos_of_mem_Ioo` (as $C \\ge 0 > -\\pi/2$), the reverse by contraposition through `Real.cos_nonpos_of_pi_div_two_le_of_le`. `cos_eq_zero_iff_eq` proves $\\cos C = 0 \\iff C = \\pi/2$ using injectivity of $\\cos$ on $[0,\\pi]$ (`Real.strictAntiOn_cos.injOn`) and $\\cos(\\pi/2)=0$. `cos_neg_iff_gt` proves $\\cos C < 0 \\iff C > \\pi/2$ via `Real.cos_neg_of_pi_div_two_lt_of_lt`. These three lemmas isolate all the trigonometry; the trichotomy theorems are then pure algebra."
+    },
+    {
+      "id": "trichotomy",
+      "title": "The Acute–Right–Obtuse Trichotomy",
+      "summary": "angle_acute_iff (II.13), angle_right_iff (Pythagoras), angle_obtuse_iff (II.12): C ≶ π/2 ⟺ a²+b² ≶ c².",
+      "startLine": 75,
+      "endLine": 124,
+      "mathContext": "Each theorem rewrites its angle condition using the matching cos-sign helper, leaving a comparison of $a^2+b^2$ and $c^2$. Since the Law of Cosines gives $a^2 + b^2 - c^2 = 2ab\\cos C$ with $2ab > 0$, the sign of $a^2+b^2-c^2$ equals the sign of $\\cos C$. `angle_acute_iff` ($C < \\pi/2 \\iff c^2 < a^2+b^2$, Euclid II.13) and `angle_obtuse_iff` ($C > \\pi/2 \\iff a^2+b^2 < c^2$, Euclid II.12) close by `linarith`/`nlinarith` using $2ab>0$; `angle_right_iff` ($C = \\pi/2 \\iff c^2 = a^2+b^2$) is the Pythagorean boundary, where $\\cos C = 0$ forces $2ab\\cos C = 0$ and hence $c^2 = a^2+b^2$ (and conversely via `mul_eq_zero`)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes Euclid II.12–II.13: the acute/right/obtuse classification of a triangle's angle equals the comparison of a² + b² with c², via the Law of Cosines and the sign of cos C on [0, π]. 124 lines, 6 theorems (3 public trichotomy + 3 sign helpers), 0 sorries, 0 axioms.",
+    "implications": "This is the exact sense in which the Law of Cosines generalizes and provides the converse to the Pythagorean theorem: the deficit a² + b² - c² is a signed detector of the angle type. The clean reduction to the sign of cos C on [0, π] is reusable for any angle-classification argument.",
+    "openQuestions": [
+      "Derive the trichotomy directly for the geometric angle ∠(v, w) between two vectors in an inner-product space, connecting to the parent's inner-product form",
+      "Formalize the sharper Euclid II.12/II.13 statement quantifying the excess/deficit as twice a specific rectangle (2ab·|cos C|)",
+      "Extend to the spherical Law of Cosines: classify a spherical triangle's angle from cos c versus cos a·cos b"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "extends",
+      "description": "Parent: the Law of Cosines c² = a² + b² - 2ab·cos C"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The right-angle case C = π/2 is exactly the Pythagorean theorem"
+    }
+  ],
+  "leanFile": {
+    "namespace": "LawOfCosinesOQ09",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/LawOfCosinesOQ09.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry `law-of-cosines-oq-09`. Formalizes **Euclid's Elements II.12 and II.13**: the Law of Cosines $c^2 = a^2+b^2-2ab\cos C$ turns the classification of a triangle's angle into a purely algebraic comparison of the squared sides.

$$C < \tfrac\pi2 \iff c^2 < a^2+b^2 \quad(\text{acute, II.13}), \qquad C = \tfrac\pi2 \iff c^2 = a^2+b^2 \quad(\text{Pythagoras}), \qquad C > \tfrac\pi2 \iff c^2 > a^2+b^2 \quad(\text{obtuse, II.12}).$$

### Contributions
- `angle_acute_iff`, `angle_right_iff`, `angle_obtuse_iff` — the three equivalences, taking the Law of Cosines relation as hypothesis.
- Three private sign helpers on $[0,\pi]$: $\cos C > 0 \iff C < \pi/2$, $\cos C = 0 \iff C = \pi/2$, $\cos C < 0 \iff C > \pi/2$, from `Real.cos_pos_of_mem_Ioo`, `Real.strictAntiOn_cos`, and `Real.cos_neg_of_pi_div_two_lt_of_lt`.

**Engine:** $a^2+b^2-c^2 = 2ab\cos C$ with $2ab>0$, so $\operatorname{sign}(a^2+b^2-c^2) = \operatorname{sign}(\cos C)$; $\cos$ is strictly antitone on $[0,\pi]$, pinning the angle against $\pi/2$. This is the precise sense in which the Law of Cosines is the signed converse of the Pythagorean theorem.

### Verification
- Compiled clean against Mathlib (pinned `v4.26.0`) via `lake env lean`.
- `#print axioms` on all three trichotomy theorems: only `propext, Classical.choice, Quot.sound` — **0-axiom / verified**, 0 sorries.
- 124 lines, 6 theorems.

### Note on pool status
Pool marked this slug `completed`, but no Lean file, gallery entry, or PR existed (dead-session artifact) — adopted and completed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)