### PR TITLE
Enrich: Third Moment & Vanishing Skewness of the Descent Statistic

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "setup-imports",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 33,
+      "endLine": 41
+    },
+    "type": "context",
+    "title": "Wiring in the transfer engine, the moments, and palindromy",
+    "content": "The four imports and the `open` line bring in exactly the machinery reused below, so this entry adds no new combinatorics of its own. From the parent `GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01` come the transfer operator `moment_transfer` (the engine) together with the zeroth, first and second moments `eulerian_M0`, `eulerian_first_moment`, `eulerian_second_moment`; from the sibling `...OQ05` comes the palindromy `eulerian_palindrome'` ($\\langle n,k\\rangle=\\langle n,n{-}1{-}k\\rangle$); and the grandparent `...OQ01OQ01OQ01OQ01` supplies the Eulerian numbers `eulerian n k` themselves. The third moment is then obtained by specialising `moment_transfer` to $w(k)=k^3$, and the vanishing skewness by feeding an odd weight through `eulerian_palindrome'` — nothing else is imported.",
+    "mathContext": "Reused: $\\texttt{moment\\_transfer}$, $M_0,M_1,M_2$, and palindromy $\\langle n,k\\rangle=\\langle n,n{-}1{-}k\\rangle$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "moment-transfer engine",
+      "Eulerian numbers",
+      "palindromy of the Eulerian row",
+      "reuse of parent lemmas"
+    ],
+    "prerequisites": [
+      "Eulerian numbers",
+      "parent moment computations"
+    ]
+  },
+  {
     "id": "third-moment-recurrence",
     "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -151,6 +151,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Setup: the Imported Moment Machinery",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "The header docstring frames the descent statistic X (Eulerian row) and recalls the parent's mean (n−1)/2 and variance (n+1)/12. The three imports wire in exactly the pieces reused here: the parent oq-01-oq-01 supplies the transfer engine moment_transfer and the lower moments M₀, M₁, M₂; the sibling oq-05 supplies palindromy eulerian_palindrome'; the grandparent supplies the Eulerian numbers ⟨n,k⟩. Everything downstream is a specialisation of these.",
+      "mathContext": "$X$ = number of descents; row $(\\langle n,0\\rangle,\\dots,\\langle n,n-1\\rangle)$ with mean $\\tfrac{n-1}{2}$, variance $\\tfrac{n+1}{12}$."
+    },
+    {
       "id": "third-moment",
       "title": "The Third Moment via the Moment Recurrence",
       "startLine": 43,


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01` (quality 89, passes 0).

The entry was already rich (4 deep annotations, full overview/conclusion, 3 cross-references, 2 references). Two targeted, non-inflationary additions to close the remaining coverage gaps:

- **Setup section** (lines 1–42): covers the header framing (descent statistic, mean (n−1)/2, variance (n+1)/12) and the three imports, so `sections` now span the whole Lean file instead of starting at line 43.
- **5th annotation** (`setup-imports`, lines 33–41): explains exactly which reused lemmas power the results — `moment_transfer` + M₀/M₁/M₂ from the parent, `eulerian_palindrome'` from the sibling, the Eulerian numbers from the grandparent — reaching the ≥5-annotation quality target.

Size: meta.json 17.7 KB, well under the 60 KB cap; keyInsights (4), crossReferences (3), references (2) left as-is to avoid accretion. JSON validated; `gallery:check-size`, `annotations:build`, `research:build`, `research:enrich` build steps all pass on this entry (worktree lacks node_modules so the final `tsc` typecheck is skipped — unrelated to content).