### PR TITLE
Enrich Shannon Entropy Concavity (shannon-entropy-oq-04): add missing index.ts + annotation + references

### DIFF
--- a/src/data/proofs/shannon-entropy-oq-04/annotations.json
+++ b/src/data/proofs/shannon-entropy-oq-04/annotations.json
@@ -45,6 +45,30 @@
     ]
   },
   {
+    "id": "ann-entconc-orthant-convex",
+    "proofId": "shannon-entropy-oq-04",
+    "range": {
+      "startLine": 91,
+      "endLine": 97
+    },
+    "type": "definition",
+    "title": "convex_nonneg_orthant: The Domain of Concavity",
+    "content": "Concavity is only meaningful relative to a convex domain, so the argument first records that the non-negative orthant {p | ∀ i, 0 ≤ p i} is convex. The proof is pointwise: a convex combination a·p + b·q (with a, b ≥ 0) is non-negative in each coordinate i because add_nonneg (mul_nonneg ha (hp i)) (mul_nonneg hb (hq i)) gives a·p i + b·q i ≥ 0. This is the common convex set s over which every coordinate concavity and the finite-sum fold are stated; the simplex result then follows because stdSimplex is a convex *subset* of this orthant.",
+    "mathContext": "$\\{p : \\alpha \\to \\mathbb R \\mid \\forall i,\\ p_i \\ge 0\\}$ is convex: if $p_i, q_i \\ge 0$ and $a,b \\ge 0$ then $(a p + b q)_i = a p_i + b q_i \\ge 0$. Working over the whole orthant rather than just the simplex yields the stronger statement and makes $\\operatorname{stdSimplex}\\,\\mathbb R\\,\\alpha$ a one-line restriction.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Convex",
+      "non-negative orthant",
+      "add_nonneg",
+      "mul_nonneg",
+      "stdSimplex"
+    ],
+    "prerequisites": [
+      "Convex set",
+      "convex combination"
+    ]
+  },
+  {
     "id": "ann-entconc-orthant",
     "proofId": "shannon-entropy-oq-04",
     "range": {

--- a/src/data/proofs/shannon-entropy-oq-04/index.ts
+++ b/src/data/proofs/shannon-entropy-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ShannonEntropyOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const shannonEntropyOq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const shannonEntropyOq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const shannonEntropyOq04Data: ProofData = {
+  proof: shannonEntropyOq04Proof,
+  annotations: shannonEntropyOq04Annotations,
+}

--- a/src/data/proofs/shannon-entropy-oq-04/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-04/meta.json
@@ -105,6 +105,29 @@
       "description": "Continuous analogue: concavity and Gaussian maximum entropy for differential entropy"
     }
   ],
+  "references": [
+    {
+      "authors": "Shannon, Claude E.",
+      "title": "A Mathematical Theory of Communication",
+      "year": "1948",
+      "venue": "Bell System Technical Journal 27, pp. 379–423 and 623–656",
+      "note": "Introduces the entropy functional; concavity underlies the maximum-entropy characterisation of the uniform distribution"
+    },
+    {
+      "authors": "Cover, Thomas M. and Thomas, Joy A.",
+      "title": "Elements of Information Theory",
+      "year": "2006",
+      "venue": "Wiley, 2nd ed., Theorem 2.7.3 (concavity of entropy)",
+      "note": "Standard reference stating H(p) is a concave function of p on the probability simplex"
+    },
+    {
+      "authors": "Boyd, Stephen and Vandenberghe, Lieven",
+      "title": "Convex Optimization",
+      "year": "2004",
+      "venue": "Cambridge University Press, §3.5 (negative entropy is convex)",
+      "note": "The convex-analysis viewpoint: -H is a sum of x log x terms, each convex; negMulLog is the concave negation"
+    }
+  ],
   "leanFile": {
     "namespace": "InformationTheory.EntropyConcavity",
     "lineCount": 134,


### PR DESCRIPTION
Enrichment pass for `shannon-entropy-oq-04` (0 prior passes, quality 89).

## Critical fix
- **Created the missing `index.ts`** (Vite entry point). Without it, `import.meta.glob` cannot discover the proof, so the page rendered **"proof not found"** on the live site even though the entry appeared in the gallery listing. Uses the standard template; camelCase export prefix `shannonEntropyOq04`, Lean source `Proofs/ShannonEntropyOQ04.lean`.

## Enrichment
- **+1 annotation** (`ann-entconc-orthant-convex`, lines 91–97) covering `convex_nonneg_orthant`, the convex-domain lemma that was previously unannotated — it sat in the gap between the sum-fold (68–85) and orthant (98–125) annotations. Annotation count 4 → 5 (meets the 5-annotation target); carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **Added a `references` array**: Shannon (1948), Cover & Thomas (2006, Thm 2.7.3), Boyd & Vandenberghe (2004, §3.5) — the entry previously had only a `sourceUrl`.

## Guardrails
- `meta.json` is 11.5 KB, well under the 60 KB cap; no collection near its cap.
- JSON validated (parses; every annotation has `mathContext`/`significance`/`relatedConcepts`); annotation ranges checked against the Lean source.
- Preserved all existing content; additions only.

Math agent PR — no `loom:review-requested` label (deployer merges directly).