### PR TITLE
Enrich: Acute–Right–Obtuse Trichotomy from the Law of Cosines

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-09/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-09/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-loc09-setup",
+    "proofId": "law-of-cosines-oq-09",
+    "range": {
+      "startLine": 1,
+      "endLine": 24
+    },
+    "type": "context",
+    "title": "Euclid II.12/II.13 as the Signed Converse of Pythagoras",
+    "content": "The header fixes the classical context. Euclid's Elements Book II, Propositions 12 (obtuse) and 13 (acute), quantify how far a triangle departs from right-angled — centuries before trigonometry existed. In modern form both, together with Pythagoras (the right-angle boundary), are the single Law-of-Cosines relation c² = a² + b² − 2ab·cos C. This entry takes that relation as a hypothesis (hlc) and proves the full trichotomy: with a, b > 0 and C ∈ [0, π], the classification of C against π/2 is exactly the comparison of a² + b² against c². The proof needs no synthetic geometry — only the sign of cos C on [0, π], since 2ab > 0 makes a² + b² − c² = 2ab·cos C sign-equal to cos C.",
+    "mathContext": "Law of Cosines: $c^2 = a^2 + b^2 - 2ab\\cos C$. With $2ab>0$, $\\operatorname{sign}(a^2+b^2-c^2)=\\operatorname{sign}(\\cos C)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Euclid Elements II.12 / II.13",
+      "Law of Cosines",
+      "Pythagorean theorem",
+      "converse of Pythagoras"
+    ],
+    "prerequisites": [
+      "Law of Cosines",
+      "triangle angle at a vertex"
+    ]
+  },
+  {
     "id": "ann-loc09-cossign",
     "proofId": "law-of-cosines-oq-09",
     "range": {
@@ -23,26 +46,72 @@
     ]
   },
   {
-    "id": "ann-loc09-trichotomy",
+    "id": "ann-loc09-acute",
     "proofId": "law-of-cosines-oq-09",
     "range": {
       "startLine": 79,
+      "endLine": 90
+    },
+    "type": "insight",
+    "title": "angle_acute_iff — Euclid II.13: C < π/2 ⟺ c² < a² + b²",
+    "content": "The acute case. Rewriting the goal through cos_pos_iff_lt reduces C < π/2 to cos C > 0. With h2ab : 0 < 2ab (by positivity) and the Law of Cosines hlc giving a² + b² − c² = 2ab·cos C, the two directions are short: forward multiplies 2ab > 0 by cos C > 0 (mul_pos) and finishes with linarith; the reverse observes 0 < 2ab·cos C and lets nlinarith divide out the positive 2ab to recover cos C > 0. This is Euclid II.13 — in an acute triangle the square on the opposite side falls short of the sum of the other two squares.",
+    "mathContext": "$C < \\tfrac\\pi2 \\iff \\cos C > 0 \\iff 2ab\\cos C > 0 \\iff c^2 < a^2+b^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euclid Elements II.13",
+      "cos_pos_iff_lt",
+      "nlinarith sign extraction",
+      "acute triangle"
+    ],
+    "prerequisites": [
+      "cos_pos_iff_lt",
+      "positivity of 2ab"
+    ]
+  },
+  {
+    "id": "ann-loc09-right",
+    "proofId": "law-of-cosines-oq-09",
+    "range": {
+      "startLine": 92,
+      "endLine": 107
+    },
+    "type": "insight",
+    "title": "angle_right_iff — Pythagoras as the Boundary cos C = 0",
+    "content": "The right-angle case is the boundary of the trichotomy and is exactly the Pythagorean theorem with its converse. Rewriting through cos_eq_zero_iff_eq turns C = π/2 into cos C = 0. Forward: cos C = 0 makes 2ab·cos C = 0, so hlc collapses to c² = a² + b² (linarith). Reverse: from c² = a² + b² the same identity forces 2ab·cos C = 0, and mul_eq_zero splits it — the factor 2ab ≠ 0 (it is positive) is discharged by absurd, leaving cos C = 0. This is the single point where the deficit a² + b² − c² vanishes.",
+    "mathContext": "$C = \\tfrac\\pi2 \\iff \\cos C = 0 \\iff 2ab\\cos C = 0 \\iff c^2 = a^2+b^2$ (Pythagoras).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pythagorean theorem",
+      "converse of Pythagoras",
+      "mul_eq_zero",
+      "cos_eq_zero_iff_eq"
+    ],
+    "prerequisites": [
+      "cos_eq_zero_iff_eq",
+      "mul_eq_zero"
+    ]
+  },
+  {
+    "id": "ann-loc09-obtuse",
+    "proofId": "law-of-cosines-oq-09",
+    "range": {
+      "startLine": 109,
       "endLine": 122
     },
     "type": "insight",
-    "title": "angle_acute/right/obtuse_iff: Sign of a² + b² - c² Detects the Angle",
-    "content": "Each trichotomy theorem rewrites its angle condition (C < π/2, = π/2, > π/2) to the matching cos-sign condition, then compares the squared sides. The Law of Cosines gives a² + b² - c² = 2ab·cos C with 2ab > 0, so the sign of a² + b² - c² is the sign of cos C. Acute (Euclid II.13) and obtuse (Euclid II.12) close with linarith/nlinarith using 2ab > 0; the right angle (Pythagoras) is the boundary cos C = 0, handled via mul_eq_zero. This is the precise sense in which the Law of Cosines is the signed converse of the Pythagorean theorem.",
-    "mathContext": "$a^2+b^2-c^2 = 2ab\\cos C$, $2ab>0$: $C<\\tfrac\\pi2\\iff c^2<a^2+b^2$; $C=\\tfrac\\pi2\\iff c^2=a^2+b^2$; $C>\\tfrac\\pi2\\iff c^2>a^2+b^2$.",
+    "title": "angle_obtuse_iff — Euclid II.12: C > π/2 ⟺ a² + b² < c²",
+    "content": "The obtuse case, mirror image of the acute one. Rewriting through cos_neg_iff_gt reduces C > π/2 to cos C < 0. Forward: mul_neg_of_pos_of_neg combines 2ab > 0 with cos C < 0 to give 2ab·cos C < 0, and hlc + linarith yield a² + b² < c². Reverse: a² + b² < c² forces 2ab·cos C < 0, and nlinarith divides out the positive 2ab to recover cos C < 0. This is Euclid II.12 — in an obtuse triangle the square on the opposite side exceeds the sum of the other two squares.",
+    "mathContext": "$C > \\tfrac\\pi2 \\iff \\cos C < 0 \\iff 2ab\\cos C < 0 \\iff a^2+b^2 < c^2$.",
     "significance": "key",
     "relatedConcepts": [
-      "Law of Cosines",
-      "Pythagorean theorem",
-      "Euclid Elements II.12 / II.13",
-      "sign analysis"
+      "Euclid Elements II.12",
+      "cos_neg_iff_gt",
+      "mul_neg_of_pos_of_neg",
+      "obtuse triangle"
     ],
     "prerequisites": [
-      "cos-sign helpers",
-      "nlinarith with 2ab > 0"
+      "cos_neg_iff_gt",
+      "positivity of 2ab"
     ]
   }
 ]

--- a/src/data/proofs/law-of-cosines-oq-09/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-09/meta.json
@@ -84,12 +84,35 @@
     {
       "targetId": "law-of-cosines",
       "relationship": "extends",
-      "description": "Parent: the Law of Cosines c² = a² + b² - 2ab·cos C"
+      "description": "Parent: the Law of Cosines c² = a² + b² - 2ab·cos C, taken here as the hypothesis hlc that drives the whole trichotomy."
     },
     {
       "targetId": "pythagorean-theorem",
       "relationship": "related",
-      "description": "The right-angle case C = π/2 is exactly the Pythagorean theorem"
+      "description": "The right-angle case C = π/2 (angle_right_iff) is exactly the Pythagorean theorem and its converse — the boundary cos C = 0 where the deficit a² + b² - c² vanishes."
+    }
+  ],
+  "references": [
+    {
+      "title": "The Thirteen Books of Euclid's Elements (Book II, Propositions 12 and 13)",
+      "author": "Euclid; trans. Thomas L. Heath",
+      "year": "1908",
+      "venue": "Cambridge University Press (Dover reprint 1956)",
+      "description": "The original obtuse (II.12) and acute (II.13) propositions quantifying the excess/deficit of the square on the opposite side, the pre-trigonometric form of the trichotomy formalized here."
+    },
+    {
+      "title": "A History of Greek Mathematics, Vol. I",
+      "author": "Thomas L. Heath",
+      "year": "1921",
+      "venue": "Clarendon Press",
+      "description": "Historical account placing Elements II.12–II.13 as the 'geometric algebra' precursors of the Law of Cosines and the analytic classification of triangles by angle."
+    },
+    {
+      "title": "Law of cosines",
+      "author": "Wikipedia contributors",
+      "year": "2024",
+      "venue": "Wikipedia",
+      "description": "Modern statement of the Law of Cosines, its equivalence to the Euclidean propositions, and the derivation of the acute/right/obtuse classification from the sign of a² + b² - c²."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `law-of-cosines-oq-09` (quality 65, passes 0).

The entry had strong prose but only 2 blanket annotations and no references. Additions:

- **Annotations 2 → 5**: a *setup* annotation framing Euclid II.12/II.13 as the signed converse of Pythagoras, and a split of the single blanket trichotomy annotation into three tightly-scoped per-theorem annotations — `angle_acute_iff` (Euclid II.13), `angle_right_iff` (the Pythagoras boundary cos C = 0, via `mul_eq_zero`), and `angle_obtuse_iff` (Euclid II.12) — each explaining its own `linarith`/`nlinarith`/sign-extraction closing. The cos-sign helper annotation is retained.
- **References array added** (Euclid/Heath *Elements* Book II, Heath's *History of Greek Mathematics*, Law of Cosines) — previously absent.

Size: meta.json 9.1 KB, well under the 60 KB cap; all annotation line ranges within the 124-line source; JSON validated.

Note: committed via git plumbing — the worktree was reaped by infra-guardian (disk at 99%).