### PR TITLE
Enrich Fibonacci Divisibility Characterization (fibonacci-identities-oq-07): index.ts + 3 annotations + references

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-07/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-07/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-fib07-header",
+    "proofId": "fibonacci-identities-oq-07",
+    "range": {
+      "startLine": 1,
+      "endLine": 26
+    },
+    "type": "concept",
+    "title": "Fibonacci as a Strong Divisibility Sequence",
+    "content": "A sequence (aₙ) is a *strong divisibility sequence* when gcd(aₘ, aₙ) = a_{gcd(m,n)}. Édouard Lucas (1878) proved the Fibonacci numbers have this property — Mathlib's Nat.fib_gcd — and it is the source of every Fibonacci divisibility fact. The characterization Fₘ ∣ Fₙ ⟺ m ∣ n proved here is its most quotable corollary: divisibility of Fibonacci values mirrors divisibility of indices exactly. Mathlib already had the strong-divisibility identity and the forward implication (Nat.fib_dvd); this entry supplies the reverse implication, packages the biconditional, and pins down the boundary hypothesis m ≥ 3 forced by the unit collision F₁ = F₂ = 1.",
+    "mathContext": "Strong divisibility: $\\gcd(F_m, F_n) = F_{\\gcd(m,n)}$ (Lucas 1878). Corollary for $m \\ge 3$: $F_m \\mid F_n \\iff m \\mid n$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "strong divisibility sequence",
+      "Nat.fib_gcd",
+      "Lucas sequences",
+      "divisibility",
+      "greatest common divisor"
+    ],
+    "prerequisites": [
+      "Fibonacci numbers",
+      "gcd",
+      "divisibility in ℕ"
+    ]
+  },
+  {
     "id": "ann-fib07-reverse",
     "proofId": "fibonacci-identities-oq-07",
     "range": {
@@ -24,6 +49,29 @@
     ]
   },
   {
+    "id": "ann-fib07-boundary",
+    "proofId": "fibonacci-identities-oq-07",
+    "range": {
+      "startLine": 48,
+      "endLine": 54
+    },
+    "type": "technique",
+    "title": "Clearing the Boundary: forcing gcd(m,n) ≥ 2 before injectivity",
+    "content": "Injectivity of fib only holds on [2,∞) — fib repeats the value 1 at indices 1 and 2 and is 0 at index 0. So before invoking Nat.fib_strictMonoOn.injOn the proof must know gcd(m,n) ≥ 2. It gets this from F_{gcd(m,n)} = Fₘ ≥ 2: a by_contra assumes gcd(m,n) < 2, interval_cases splits on gcd(m,n) ∈ {0,1}, decide evaluates fib 0 = 0 and fib 1 = 1 (both ≤ 1), and omega contradicts F_{gcd(m,n)} ≥ 2. This is the technical heart of why m ≥ 3 is exactly the right hypothesis: it guarantees Fₘ ≥ 2, which propagates through the strong-divisibility identity to place the gcd in the injectivity domain.",
+    "mathContext": "$F_{\\gcd(m,n)} = F_m \\ge 2$ rules out $\\gcd(m,n) \\in \\{0,1\\}$ (where $F = 0, 1$), so $\\gcd(m,n) \\ge 2$ lands in $[2,\\infty)$ where $F$ is injective.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "interval_cases",
+      "omega",
+      "Nat.fib_mono",
+      "injectivity domain"
+    ],
+    "prerequisites": [
+      "fib 0 = 0, fib 1 = fib 2 = 1",
+      "by_contra"
+    ]
+  },
+  {
     "id": "ann-fib07-iff",
     "proofId": "fibonacci-identities-oq-07",
     "range": {
@@ -44,6 +92,27 @@
     "prerequisites": [
       "Nat.fib_dvd",
       "dvd_of_fib_dvd"
+    ]
+  },
+  {
+    "id": "ann-fib07-contrapositive",
+    "proofId": "fibonacci-identities-oq-07",
+    "range": {
+      "startLine": 75,
+      "endLine": 78
+    },
+    "type": "technique",
+    "title": "not_fib_dvd_of_not_dvd: the Contrapositive Form",
+    "content": "A convenience restatement of the biconditional in its most-used negative direction: for m ≥ 3, if m ∤ n then Fₘ ∤ Fₙ. It is a one-line contrapositive of fib_dvd_iff — assume Fₘ ∣ Fₙ, feed it through the forward .mp to get m ∣ n, and contradict the hypothesis. This is the shape needed in applications such as Fibonacci primality arguments, where one wants to conclude non-divisibility of values from non-divisibility of indices.",
+    "mathContext": "For $m \\ge 3$: $m \\nmid n \\Rightarrow F_m \\nmid F_n$. Contrapositive of the $\\Leftarrow$ direction of $F_m \\mid F_n \\iff m \\mid n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "contrapositive",
+      "fib_dvd_iff",
+      "Fibonacci primality tests"
+    ],
+    "prerequisites": [
+      "fib_dvd_iff"
     ]
   }
 ]

--- a/src/data/proofs/fibonacci-identities-oq-07/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-07/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ07.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOq07Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOq07Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOq07Data: ProofData = {
+  proof: fibonacciIdentitiesOq07Proof,
+  annotations: fibonacciIdentitiesOq07Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-07/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-07/meta.json
@@ -88,6 +88,29 @@
       "description": "Parent: Fibonacci identities; this entry adds the divisibility characterization"
     }
   ],
+  "references": [
+    {
+      "authors": "Lucas, Édouard",
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "venue": "American Journal of Mathematics 1(3), pp. 184–240 and 1(4), pp. 289–321",
+      "note": "Origin of the strong-divisibility property of Fibonacci and Lucas sequences and the divisibility characterization"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Standard reference; Ch. 16 covers divisibility properties including gcd(Fₘ,Fₙ) = F_{gcd(m,n)}"
+    },
+    {
+      "authors": "Ribenboim, Paulo",
+      "title": "The New Book of Prime Number Records",
+      "year": "1996",
+      "venue": "Springer, §2.IV (Lucas sequences)",
+      "note": "Strong divisibility sequences and the rank-of-apparition / entry-point theory that the characterization underlies"
+    }
+  ],
   "leanFile": {
     "namespace": "FibonacciIdentitiesOQ07",
     "lineCount": 80,


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-07` (1 prior pass, quality 65).

## Critical fix
- **Created the missing `index.ts`** (Vite entry point). Without it the page rendered **"proof not found"** on the live site despite appearing in the gallery listing. Standard template; camelCase export prefix `fibonacciIdentitiesOq07`, Lean source `Proofs/FibonacciIdentitiesOQ07.lean`.

## Enrichment (annotations 2 → 5)
- **`ann-fib07-header`** (concept, 1–26): Fibonacci as a *strong divisibility sequence* — gcd(Fₘ,Fₙ) = F_{gcd(m,n)} (Lucas 1878), the identity the whole characterization derives from.
- **`ann-fib07-boundary`** (technical, 48–54): the `gcd(m,n) ≥ 2` step via `interval_cases`/`omega` — the technical heart that clears the fib injectivity boundary (fib repeats 1 at indices 1,2) before `Nat.fib_strictMonoOn.injOn`, and shows why m ≥ 3 is exactly right.
- **`ann-fib07-contrapositive`** (supporting, 75–78): `not_fib_dvd_of_not_dvd`, the negative-direction convenience form used in primality arguments.
- All carry `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Added `references`
- Lucas (1878, origin), Koshy (2001, Ch. 16), Ribenboim (1996, Lucas sequences) — the entry previously had only a `sourceUrl`.

## Guardrails
- `meta.json` 8.5 KB, well under the 60 KB cap.
- JSON validated (parses; every annotation has the four enrichment fields); ranges checked against the 80-line Lean source.
- Additions only; existing content preserved.

Math agent PR — no `loom:review-requested` (deployer merges directly).