### PR TITLE
research(fibonacci-identities-oq-03-oq-02-oq-01): parity-indexed Fibonacci partial sums [VERIFIED, 0-axiom, 8thm, new entry]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ03OQ02OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ03OQ02OQ01.lean
@@ -1,0 +1,139 @@
+import Mathlib
+
+/-
+# Parity-indexed partial sums of Fibonacci numbers
+
+The parent entry `FibonacciIdentitiesOQ03OQ02` proves the classical square-sum
+identity `∑ Fᵢ² = Fₙ·Fₙ₊₁`, and its sibling `…OQ03OQ02OQ02` the Lucas analogue
+`∑ Lᵢ² = Lₙ·Lₙ₊₁ − 2`. Both are *closed forms for a Fibonacci partial sum*.
+
+Mathlib records only the **total** partial sum, `Nat.fib_succ_eq_succ_sum`:
+
+  `fib (n+1) = (∑ k ∈ range n, fib k) + 1`,   i.e.   `F₀ + F₁ + ⋯ + Fₙ₋₁ = Fₙ₊₁ − 1`.
+
+This entry supplies the **parity refinement** of that total: the partial sum
+split according to whether the summand's index is odd or even. In Mathlib's
+0-indexed convention (`fib 0 = 0`, `fib 1 = fib 2 = 1`, `fib 3 = 2`, …):
+
+* **Odd indices** telescope to a *single* even-index Fibonacci, with no `−1`:
+
+    `F₁ + F₃ + F₅ + ⋯ + F₂ₙ₋₁ = F₂ₙ`      (`fib_odd_index_sum`)
+
+* **Even indices** carry the `−1` correction, landing one short of an odd-index
+  Fibonacci:
+
+    `F₂ + F₄ + F₆ + ⋯ + F₂ₙ = F₂ₙ₊₁ − 1`   (`fib_even_index_sum`)
+
+The two are genuine complements: they **partition** the full range sum
+(`fib_range_parity_split`), and adding them recovers `F₂ₙ₊₂ − 1`
+(`fib_index_parity_total`, `fib_total_range_sum`) — the `n ↦ 2n` instance of
+Mathlib's total-sum lemma, now split by parity. The `−1` therefore lives
+entirely in the even-index half; the odd-index half is exactly telescoping.
+
+Each identity is the textbook one-line induction: `Finset.sum_range_succ` peels
+the top term and the Fibonacci recurrence `fib (k+2) = fib k + fib (k+1)`
+(`Nat.fib_add_two`) closes the step. Integer forms are given so the even-index
+`−1` is an honest subtraction rather than truncated `ℕ` subtraction.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace FibonacciIdentitiesOQ03OQ02OQ01
+
+open Finset
+
+/-- **Odd-index Fibonacci partial sum.** Summing the Fibonacci numbers at the
+odd indices `1, 3, 5, …, 2n−1` gives a single even-index Fibonacci `F₂ₙ`, with
+no correction term:
+
+  `F₁ + F₃ + ⋯ + F₂ₙ₋₁ = F₂ₙ`.
+
+One-line induction: peel the top summand `F₂ₙ₋₁`, apply the induction
+hypothesis `⋯ = F₂ₙ₋₂`, and close with `F₂ₙ₋₂ + F₂ₙ₋₁ = F₂ₙ`. -/
+theorem fib_odd_index_sum (n : ℕ) :
+    ∑ i ∈ range n, Nat.fib (2 * i + 1) = Nat.fib (2 * n) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ih]
+    have e : 2 * (n + 1) = 2 * n + 2 := by ring
+    rw [e, Nat.fib_add_two]
+
+/-- **Even-index Fibonacci partial sum (additive form).** Summing the Fibonacci
+numbers at the even indices `2, 4, 6, …, 2n` lands one short of an odd-index
+Fibonacci:
+
+  `(F₂ + F₄ + ⋯ + F₂ₙ) + 1 = F₂ₙ₊₁`.
+
+The additive statement sidesteps truncated `ℕ` subtraction; see
+`fib_even_index_sum_sub` for the `F₂ₙ₊₁ − 1` phrasing. -/
+theorem fib_even_index_sum (n : ℕ) :
+    (∑ i ∈ range n, Nat.fib (2 * i + 2)) + 1 = Nat.fib (2 * n + 1) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.sum_range_succ]
+    have hrec : Nat.fib (2 * (n + 1) + 1) = Nat.fib (2 * n + 1) + Nat.fib (2 * n + 2) := by
+      have h : 2 * (n + 1) + 1 = 2 * n + 1 + 2 := by ring
+      rw [h, Nat.fib_add_two]
+    rw [hrec, ← ih]
+    ring
+
+/-- **Even-index partial sum, subtraction form.** `F₂ + F₄ + ⋯ + F₂ₙ = F₂ₙ₊₁ − 1`
+in `ℕ` (honest, since `F₂ₙ₊₁ ≥ 1` for `n ≥ 0`). -/
+theorem fib_even_index_sum_sub (n : ℕ) :
+    ∑ i ∈ range n, Nat.fib (2 * i + 2) = Nat.fib (2 * n + 1) - 1 := by
+  have h := fib_even_index_sum n
+  omega
+
+/-- **Parity partition of the range sum.** The first `2n` Fibonacci numbers
+`F₁, …, F₂ₙ` split exactly into their odd-index and even-index parts — the two
+partial sums above are complementary, covering the full range with no overlap. -/
+theorem fib_range_parity_split (n : ℕ) :
+    ∑ i ∈ range (2 * n), Nat.fib (i + 1)
+      = (∑ i ∈ range n, Nat.fib (2 * i + 1)) + ∑ i ∈ range n, Nat.fib (2 * i + 2) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    have e : 2 * (n + 1) = 2 * n + 2 := by ring
+    rw [e, Finset.sum_range_succ, Finset.sum_range_succ,
+        Finset.sum_range_succ, Finset.sum_range_succ, ih]
+    -- indices `2*n+1+1` and `2*n+2` are defeq; normalise then close by `ring`
+    have i1 : 2 * n + 1 + 1 = 2 * n + 2 := by ring
+    rw [i1]
+    ring
+
+/-- **Consistency: odd + even parts recover `F₂ₙ₊₂`.** Adding the odd-index sum
+(`= F₂ₙ`) and the even-index sum (`+1 = F₂ₙ₊₁`) gives `F₂ₙ + F₂ₙ₊₁ = F₂ₙ₊₂`, so
+the single `−1` correction sits entirely in the even-index half. -/
+theorem fib_index_parity_total (n : ℕ) :
+    (∑ i ∈ range n, Nat.fib (2 * i + 1))
+      + ((∑ i ∈ range n, Nat.fib (2 * i + 2)) + 1) = Nat.fib (2 * n + 2) := by
+  rw [fib_odd_index_sum, fib_even_index_sum, Nat.fib_add_two]
+
+/-- **Total range sum at an even bound.** The parity split, combined with the
+consistency identity, recovers Mathlib's total-sum lemma specialised to `2n`:
+
+  `(F₁ + F₂ + ⋯ + F₂ₙ) + 1 = F₂ₙ₊₂`. -/
+theorem fib_total_range_sum (n : ℕ) :
+    (∑ i ∈ range (2 * n), Nat.fib (i + 1)) + 1 = Nat.fib (2 * n + 2) := by
+  rw [fib_range_parity_split]
+  have := fib_index_parity_total n
+  omega
+
+/-- Integer form of the odd-index sum: `∑ F₂ᵢ₊₁ = F₂ₙ` over `ℤ`. -/
+theorem fib_odd_index_sum_int (n : ℕ) :
+    ∑ i ∈ range n, (Nat.fib (2 * i + 1) : ℤ) = (Nat.fib (2 * n) : ℤ) := by
+  exact_mod_cast fib_odd_index_sum n
+
+/-- Integer form of the even-index sum, with the `−1` as an honest subtraction:
+`∑ F₂ᵢ₊₂ = F₂ₙ₊₁ − 1` over `ℤ`. -/
+theorem fib_even_index_sum_int (n : ℕ) :
+    ∑ i ∈ range n, (Nat.fib (2 * i + 2) : ℤ) = (Nat.fib (2 * n + 1) : ℤ) - 1 := by
+  have h := fib_even_index_sum n
+  have h2 : ((∑ i ∈ range n, Nat.fib (2 * i + 2) : ℕ) : ℤ) + 1
+      = (Nat.fib (2 * n + 1) : ℤ) := by exact_mod_cast h
+  push_cast at h2
+  linarith
+
+end FibonacciIdentitiesOQ03OQ02OQ01

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-fiboq030201-1",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 43 },
+    "type": "concept",
+    "title": "Refining the Total Sum by Index Parity",
+    "content": "**Module framing.** Mathlib records only the *total* Fibonacci partial sum, `Nat.fib_succ_eq_succ_sum`: $F_0 + F_1 + \\cdots + F_{n-1} = F_{n+1} - 1$. This entry splits that sum according to the parity of the summand's index. In Mathlib's $0$-indexed convention ($F_0 = 0$, $F_1 = F_2 = 1$, $F_3 = 2$, …) the two halves are asymmetric: the odd-index terms sum *exactly* to a Fibonacci number, $F_1 + F_3 + \\cdots + F_{2n-1} = F_{2n}$, while the even-index terms fall one short, $F_2 + F_4 + \\cdots + F_{2n} = F_{2n+1} - 1$. The lone $-1$ of the total sum is thus revealed to belong entirely to the even-index half. Both are one-line telescoping inductions; the entry stays subtraction-free over $\\mathbb{N}$ and exposes the $-1$ only over $\\mathbb{Z}$."
+  },
+  {
+    "id": "ann-fiboq030201-2",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-01",
+    "range": { "startLine": 45, "endLine": 60 },
+    "type": "technique",
+    "title": "The Odd-Index Sum Telescopes Exactly",
+    "content": "**No correction term.** `fib_odd_index_sum` proves $\\sum_{i \\in \\mathrm{range}\\,n} F_{2i+1} = F_{2n}$ by induction. `Finset.sum_range_succ` peels the top summand $F_{2n+1}$; the induction hypothesis rewrites the remaining sum to $F_{2n}$; and the recurrence `Nat.fib_add_two` ($F_{k+2} = F_k + F_{k+1}$) merges $F_{2n} + F_{2n+1} = F_{2n+2} = F_{2(n+1)}$. The partial sums are *always* exactly the next even-index Fibonacci — nothing is ever left over, which is why the odd half carries no $-1$."
+  },
+  {
+    "id": "ann-fiboq030201-3",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-01",
+    "range": { "startLine": 62, "endLine": 87 },
+    "type": "technique",
+    "title": "The Even-Index Sum and Its −1",
+    "content": "**Additive form dodges ℕ subtraction.** `fib_even_index_sum` is stated as $\\left(\\sum_{i \\in \\mathrm{range}\\,n} F_{2i+2}\\right) + 1 = F_{2n+1}$ — the additive phrasing keeps every $\\mathbb{N}$ step a genuine equality. The inductive step peels $F_{2n+2}$, uses `Nat.fib_add_two` at index $2n+1$ to unfold $F_{2n+3} = F_{2n+1} + F_{2n+2}$, and closes with `← ih` and `ring`. `fib_even_index_sum_sub` then reads off the classical $\\sum F_{2i+2} = F_{2n+1} - 1$ over $\\mathbb{N}$ (honest, since $F_{2n+1} \\ge 1$) with a single `omega`."
+  },
+  {
+    "id": "ann-fiboq030201-4",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-01",
+    "range": { "startLine": 89, "endLine": 104 },
+    "type": "insight",
+    "title": "The Two Halves Genuinely Partition the Range",
+    "content": "**Complementary, not just consistent.** `fib_range_parity_split` proves $\\sum_{i \\in \\mathrm{range}(2n)} F_{i+1} = \\sum_{i \\in \\mathrm{range}\\,n} F_{2i+1} + \\sum_{i \\in \\mathrm{range}\\,n} F_{2i+2}$ — the odd and even index classes literally partition $\\{1, \\dots, 2n\\}$ at the level of the finite sum. The induction peels the top *two* terms $F_{2n+1}, F_{2n+2}$ of the length-$2n{+}2$ range and the top term of each parity sum, normalises the definitionally-equal index $2n+1+1 = 2n+2$, and matches both sides with `ring`. This is what makes the total-sum recovery a true reconstruction rather than a numerical coincidence."
+  },
+  {
+    "id": "ann-fiboq030201-5",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-01",
+    "range": { "startLine": 106, "endLine": 122 },
+    "type": "concept",
+    "title": "Adding the Halves Recovers Mathlib's Total Sum",
+    "content": "**One recurrence closes it.** `fib_index_parity_total` rewrites both half-sums and then a single `Nat.fib_add_two` turns the goal $F_{2n} + F_{2n+1} = F_{2n+2}$ into reflexivity. Combined with the partition, `fib_total_range_sum` recovers $(F_1 + \\cdots + F_{2n}) + 1 = F_{2n+2}$ — precisely the $n \\mapsto 2n$ instance of Mathlib's total-sum lemma `Nat.fib_succ_eq_succ_sum` — now *derived from the parity split*. The derivation makes visible that the total sum's $-1$ is contributed by the even-index terms alone."
+  },
+  {
+    "id": "ann-fiboq030201-6",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-01",
+    "range": { "startLine": 124, "endLine": 139 },
+    "type": "technique",
+    "title": "Integer Forms: an Honest −1",
+    "content": "**ℕ→ℤ transfer.** `fib_odd_index_sum_int` lifts the odd-index identity to $\\mathbb{Z}$ with a single `exact_mod_cast`. `fib_even_index_sum_int` casts the additive $\\mathbb{N}$ identity, then `push_cast` distributes the cast over the finite sum and `linarith` moves the $+1$ across, yielding $\\sum_{i \\in \\mathrm{range}\\,n} (F_{2i+2} : \\mathbb{Z}) = (F_{2n+1} : \\mathbb{Z}) - 1$ with the $-1$ as a genuine subtraction — the natural home for the correction term."
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-01/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "fibonacci-identities-oq-03-oq-02-oq-01",
+  "title": "Parity-Indexed Fibonacci Partial Sums: ∑F₂ᵢ₋₁ = F₂ₙ and ∑F₂ᵢ = F₂ₙ₊₁ − 1",
+  "slug": "fibonacci-identities-oq-03-oq-02-oq-01",
+  "description": "A parity refinement of Mathlib's total Fibonacci partial-sum lemma. Mathlib records only the total sum Nat.fib_succ_eq_succ_sum (F₀ + ⋯ + Fₙ₋₁ = Fₙ₊₁ − 1); this entry splits that sum by the parity of the summand's index. In Mathlib's 0-indexed convention (fib 0 = 0, fib 1 = fib 2 = 1, fib 3 = 2, …) the two halves behave asymmetrically: summing at the ODD indices telescopes to a single even-index Fibonacci with NO correction term, F₁ + F₃ + ⋯ + F₂ₙ₋₁ = F₂ₙ (fib_odd_index_sum); summing at the EVEN indices carries the −1, landing one short of an odd-index Fibonacci, F₂ + F₄ + ⋯ + F₂ₙ = F₂ₙ₊₁ − 1 (fib_even_index_sum). The two are genuine complements: fib_range_parity_split proves they partition the full range sum with no overlap, and fib_index_parity_total / fib_total_range_sum add them back to recover F₂ₙ₊₂ − 1 — the n ↦ 2n instance of Mathlib's total-sum lemma, now resolved by parity. The single −1 correction therefore lives entirely in the even-index half; the odd-index half is exactly telescoping. Each identity is the textbook one-line induction (Finset.sum_range_succ peels the top term; the recurrence Nat.fib_add_two closes the step), with integer forms so the even-index −1 is an honest subtraction rather than truncated ℕ subtraction. Fully verified with 0 axioms, 0 sorries, no native_decide. This answers open question oq-01 of the parent Fibonacci square-sum entry, taking the sibling direction (its oq-02 gave the Lucas square-sum) toward the parity structure of the linear sum.",
+  "meta": {
+    "author": "Classical (parity-indexed Fibonacci partial sums); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Other_identities",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "finite-sum",
+      "telescoping",
+      "parity",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ03OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{i ∈ range (n+1)} f i = (∑_{i ∈ range n} f i) + f n — peels the top summand off the running sum in every inductive step",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n+2) = fib n + fib (n+1) — the Fibonacci recurrence that closes each telescoping step and merges F₂ₙ + F₂ₙ₊₁ into F₂ₙ₊₂",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_succ_eq_succ_sum",
+        "description": "fib (n+1) = (∑ k ∈ range n, fib k) + 1 — Mathlib's TOTAL partial-sum lemma; this entry supplies its parity refinement (and fib_total_range_sum reproves its n ↦ 2n instance from the split)",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ],
+    "originalContributions": [
+      "fib_odd_index_sum: ∀ n, ∑_{i ∈ range n} fib (2i+1) = fib (2n) — the odd-index partial sum telescopes to a single even-index Fibonacci with no correction term, by one-line induction",
+      "fib_even_index_sum: ∀ n, (∑_{i ∈ range n} fib (2i+2)) + 1 = fib (2n+1) — the even-index partial sum in additive form, landing one short of an odd-index Fibonacci (the −1 phrased additively to stay subtraction-free in ℕ)",
+      "fib_even_index_sum_sub: ∀ n, ∑_{i ∈ range n} fib (2i+2) = fib (2n+1) − 1 — the classical −1 statement over ℕ (honest, since fib (2n+1) ≥ 1)",
+      "fib_range_parity_split: ∀ n, ∑_{i ∈ range (2n)} fib (i+1) = (∑_{i ∈ range n} fib (2i+1)) + ∑_{i ∈ range n} fib (2i+2) — the odd- and even-index sums partition the full range sum with no overlap, by two-term-peel induction",
+      "fib_index_parity_total: ∀ n, (∑_{i ∈ range n} fib (2i+1)) + ((∑_{i ∈ range n} fib (2i+2)) + 1) = fib (2n+2) — adding the two halves recovers F₂ₙ₊₂ via F₂ₙ + F₂ₙ₊₁ = F₂ₙ₊₂, localising the single −1 to the even half",
+      "fib_total_range_sum: ∀ n, (∑_{i ∈ range (2n)} fib (i+1)) + 1 = fib (2n+2) — the n ↦ 2n instance of Mathlib's total-sum lemma, reproved from the parity split and the consistency identity",
+      "fib_odd_index_sum_int: ∀ n, ∑_{i ∈ range n} (fib (2i+1) : ℤ) = fib (2n) — the odd-index sum over ℤ (cast transfer)",
+      "fib_even_index_sum_int: ∀ n, ∑_{i ∈ range n} (fib (2i+2) : ℤ) = (fib (2n+1) : ℤ) − 1 — the even-index sum over ℤ with the −1 as a genuine subtraction (push_cast + linarith)"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 139,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries — confirmed by #print axioms on all eight theorems, each depending only on Mathlib's foundational propext / Classical.choice / Quot.sound. No native_decide, no Lean.ofReduceBool.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The identities ∑_{k=1}^n F_{2k-1} = F_{2n} (odd indices) and ∑_{k=1}^n F_{2k} = F_{2n+1} − 1 (even indices) are classical companions to the total-sum identity ∑_{i=1}^n F_i = F_{n+2} − 1. Together the two parity halves reconstruct the total sum, and their asymmetry — the odd half is exact, the even half carries the −1 — is a small but genuine structural fact about how the −1 in the total sum arises. Mathlib packages the total sum (Nat.fib_succ_eq_succ_sum) but neither parity half, so the split is a real gallery gap. The parent square-sum entry fibonacci-identities-oq-03-oq-02 records the quadratic partial sum ∑ F_i² = F_n F_{n+1}; this entry takes the sibling direction — the parity structure of the LINEAR partial sum — while its cousin fibonacci-identities-oq-03-oq-02-oq-02 took the Lucas square-sum.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-03-oq-02 → oq-01)**: Refine the partial-sum theme of the Fibonacci square-sum entry by resolving the linear partial sum according to the parity of the summand's index, and show the two halves are complementary.\n\n**Result**: fib_odd_index_sum (odd indices telescope to F₂ₙ, no correction), fib_even_index_sum / fib_even_index_sum_sub (even indices give F₂ₙ₊₁ − 1), fib_range_parity_split (the two halves partition the range), fib_index_parity_total and fib_total_range_sum (adding them recovers Mathlib's total sum at 2n), plus integer forms.",
+    "text": "Split the Fibonacci numbers F₁, F₂, …, F₂ₙ by whether their index is odd or even. The odd-index numbers sum to a single Fibonacci number exactly: F₁ + F₃ + ⋯ + F₂ₙ₋₁ = F₂ₙ. The even-index numbers sum to one less than a Fibonacci number: F₂ + F₄ + ⋯ + F₂ₙ = F₂ₙ₊₁ − 1. The two sums have no term in common and together exhaust F₁, …, F₂ₙ, so adding them reproduces the total F₁ + ⋯ + F₂ₙ = F₂ₙ₊₂ − 1 — and the single −1 in that total is seen to come entirely from the even-index half.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Odd-index sum (fib_odd_index_sum).** Induct on n. Base n = 0: the empty sum is fib 0 = 0. Step: Finset.sum_range_succ peels F₂ₙ₊₁; the induction hypothesis rewrites the rest to F₂ₙ; Nat.fib_add_two merges F₂ₙ + F₂ₙ₊₁ = F₂ₙ₊₂ = F₂₍ₙ₊₁₎. No correction term ever appears.\n2. **Even-index sum (fib_even_index_sum).** Induct on n in the additive form (∑) + 1 = F₂ₙ₊₁ to avoid ℕ truncated subtraction. Step: peel F₂ₙ₊₂; a local recurrence lemma rewrites F₂₍ₙ₊₁₎₊₁ = F₂ₙ₊₃ = F₂ₙ₊₁ + F₂ₙ₊₂ (Nat.fib_add_two at index 2n+1); ← ih and ring close it. fib_even_index_sum_sub then reads off ∑ = F₂ₙ₊₁ − 1 in ℕ via omega.\n3. **Parity partition (fib_range_parity_split).** Induct on n. Step: rewrite range(2(n+1)) = range(2n+2) and peel its top two terms F₂ₙ₊₁, F₂ₙ₊₂ with two Finset.sum_range_succ, peel the top of each parity sum likewise, normalise the defeq index 2n+1+1 = 2n+2, and ring matches the two sides.\n4. **Consistency (fib_index_parity_total).** rw fib_odd_index_sum, fib_even_index_sum, then Nat.fib_add_two turns the goal F₂ₙ + F₂ₙ₊₁ = F₂ₙ₊₂ into a reflexivity.\n5. **Total range sum (fib_total_range_sum).** rw fib_range_parity_split, then omega closes using the consistency identity — recovering (∑_{i ∈ range 2n} F_{i+1}) + 1 = F₂ₙ₊₂, the n ↦ 2n case of Mathlib's total-sum lemma, from the split rather than from the library lemma.\n6. **Integer forms.** exact_mod_cast lifts the odd-index sum to ℤ; push_cast + linarith give the even-index sum over ℤ with the literal −1.",
+    "keyInsights": [
+      "**The odd half is exact; the even half owns the −1.** Summing at odd indices telescopes to F₂ₙ with no correction, because the running partial sum is always exactly the next even-index Fibonacci. The −1 in the classical total sum F₁ + ⋯ + Fₘ = F_{m+2} − 1 is therefore not spread across the sum — it is carried entirely by the even-index terms.",
+      "**Two exact telescopes, glued by one recurrence.** Both halves are pure Finset.sum_range_succ inductions whose steps close by the single recurrence Nat.fib_add_two; no Binet formula, generating function, or matrix identity is needed. The consistency theorem is then just F₂ₙ + F₂ₙ₊₁ = F₂ₙ₊₂ — one more application of the same recurrence.",
+      "**Partition, not just addition.** fib_range_parity_split proves the two index classes literally partition {1, …, 2n} at the level of the finite sum, so fib_total_range_sum genuinely reconstructs Mathlib's total-sum lemma at 2n from the parity data — the halves are complementary, not merely numerically consistent.",
+      "**Subtraction-free in ℕ, honest −1 in ℤ.** The even-index headline invites ℕ truncated subtraction; the entry proves the additive +1 forms over ℕ (fib_even_index_sum, fib_index_parity_total, fib_total_range_sum) and exposes the literal −1 only over ℤ (fib_even_index_sum_int), keeping every ℕ step a true equality."
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence fib (n+2) = fib n + fib (n+1) and Mathlib's 0-indexed convention fib 0 = 0, fib 1 = 1",
+      "Finset.sum_range_succ for the inductive unfolding of finite range sums",
+      "Mathlib's total partial-sum lemma Nat.fib_succ_eq_succ_sum for context (the statement this entry refines by parity)",
+      "The ring, omega, push_cast, exact_mod_cast, and linarith tactics for the algebra and the ℕ→ℤ transfer"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 3,
+      "endLine": 43,
+      "summary": "Module docstring: the parity refinement of Mathlib's total Fibonacci partial-sum lemma, the asymmetric odd (exact) / even (−1) split, the partition and consistency results, and the choice to stay subtraction-free in ℕ. Opens Finset.",
+      "mathContext": "$\\sum_{k=1}^{n} F_{2k-1} = F_{2n}$ and $\\sum_{k=1}^{n} F_{2k} = F_{2n+1} - 1$; refines $F_0 + \\cdots + F_{n-1} = F_{n+1} - 1$ by parity."
+    },
+    {
+      "id": "odd",
+      "title": "Odd-Index Partial Sum (Exact)",
+      "startLine": 45,
+      "endLine": 60,
+      "summary": "fib_odd_index_sum: one-line induction. Finset.sum_range_succ peels F₂ₙ₊₁, the IH rewrites the rest to F₂ₙ, and Nat.fib_add_two merges F₂ₙ + F₂ₙ₊₁ = F₂₍ₙ₊₁₎. No correction term appears.",
+      "mathContext": "$\\sum_{i \\in \\mathrm{range}\\,n} F_{2i+1} = F_{2n}$."
+    },
+    {
+      "id": "even",
+      "title": "Even-Index Partial Sum (the −1 Half)",
+      "startLine": 62,
+      "endLine": 87,
+      "summary": "fib_even_index_sum: induction in additive form (∑) + 1 = F₂ₙ₊₁, using Nat.fib_add_two at index 2n+1 to unfold F₂ₙ₊₃ and ← ih + ring to close. fib_even_index_sum_sub reads off the classical ∑ = F₂ₙ₊₁ − 1 over ℕ via omega.",
+      "mathContext": "$\\left(\\sum_{i \\in \\mathrm{range}\\,n} F_{2i+2}\\right) + 1 = F_{2n+1}$, i.e. $\\sum F_{2i+2} = F_{2n+1} - 1$."
+    },
+    {
+      "id": "partition",
+      "title": "Parity Partition of the Range Sum",
+      "startLine": 89,
+      "endLine": 104,
+      "summary": "fib_range_parity_split: the odd- and even-index sums partition ∑_{i ∈ range (2n)} F_{i+1}. Two-term-peel induction — rewrite range(2n+2), peel its top two terms and the top of each parity sum, normalise the defeq index 2n+1+1 = 2n+2, and ring matches both sides.",
+      "mathContext": "$\\sum_{i \\in \\mathrm{range}(2n)} F_{i+1} = \\sum_{i \\in \\mathrm{range}\\,n} F_{2i+1} + \\sum_{i \\in \\mathrm{range}\\,n} F_{2i+2}$."
+    },
+    {
+      "id": "consistency",
+      "title": "Consistency and Total Range Sum",
+      "startLine": 106,
+      "endLine": 122,
+      "summary": "fib_index_parity_total: rw the two half-sums then Nat.fib_add_two turns F₂ₙ + F₂ₙ₊₁ = F₂ₙ₊₂ into reflexivity. fib_total_range_sum: rw the partition then omega recovers (∑_{range 2n} F_{i+1}) + 1 = F₂ₙ₊₂ — the n ↦ 2n instance of Mathlib's total-sum lemma, from the split.",
+      "mathContext": "$(F_1 + \\cdots + F_{2n}) + 1 = F_{2n+2}$; the single $-1$ is the even-index half's."
+    },
+    {
+      "id": "integer",
+      "title": "Integer Forms",
+      "startLine": 124,
+      "endLine": 139,
+      "summary": "fib_odd_index_sum_int (exact_mod_cast) and fib_even_index_sum_int (push_cast + linarith) restate the two half-sums over ℤ, with the even-index −1 as a genuine subtraction rather than truncated ℕ subtraction.",
+      "mathContext": "$\\sum F_{2i+1} = F_{2n}$ and $\\sum F_{2i+2} = F_{2n+1} - 1$ over $\\mathbb{Z}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Answers open question oq-01 of the Fibonacci square-sum entry — the parity structure of the linear partial sum — as the sibling to its oq-02 (Lucas square-sum), reusing the same Finset.sum_range_succ / Nat.fib_add_two telescoping engine"
+    },
+    {
+      "targetId": "fibonacci-identities-oq-03-oq-02-oq-02",
+      "relationship": "complements",
+      "description": "Sibling leaf under the square-sum entry: that one gives the Lucas square-sum ∑ L_i² = L_n L_{n+1} − 2, this one gives the parity split of the linear Fibonacci sum ∑ F_{2i-1} = F_{2n}, ∑ F_{2i} = F_{2n+1} − 1"
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "complements",
+      "description": "The base Fibonacci entry records per-term and total linear-sum identities; this entry refines the total sum by the parity of the summand's index"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) treatment of the parity-indexed Fibonacci partial sums: the odd-index sum ∑ F_{2i-1} = F_{2n} (exact), the even-index sum ∑ F_{2i} = F_{2n+1} − 1, their partition of the full range sum, the consistency identity recovering F_{2n+2}, and integer forms. Answers open question oq-01 of the Fibonacci square-sum entry.",
+    "implications": "Supplies the two parity halves of Mathlib's total Fibonacci partial-sum lemma and proves they are complementary, localising the total sum's −1 to the even-index terms. Both halves are one-line telescoping inductions closed by the single recurrence Nat.fib_add_two, reusable wherever a Fibonacci sum must be split by index parity.",
+    "openQuestions": [
+      "Prove the analogous parity-indexed partial sums for the Lucas numbers (∑ L_{2k-1}, ∑ L_{2k}) and identify how the L_0 = 2 seed shifts the correction constants.",
+      "Give the odd/even split of the SQUARE sum: closed forms for ∑ F_{2i-1}² and ∑ F_{2i}² summing to the parent's F_{2n} F_{2n+1}."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "FibonacciIdentitiesOQ03OQ02OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ03OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Parity-indexed Fibonacci sum identities ∑ F_{2k-1} = F_{2n} and ∑ F_{2k} = F_{2n+1} − 1"
+    },
+    {
+      "authors": "Vorobiev, N. N.",
+      "title": "Fibonacci Numbers",
+      "year": "2002",
+      "venue": "Birkhäuser",
+      "note": "Classical Fibonacci summation identities, including the odd- and even-indexed partial sums"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry answering **open question oq-01** of the Fibonacci square-sum entry (`fibonacci-identities-oq-03-oq-02`). It refines Mathlib's *total* partial-sum lemma `Nat.fib_succ_eq_succ_sum` ($F_0 + \cdots + F_{n-1} = F_{n+1} - 1$) by the **parity of the summand's index**.

In Mathlib's 0-indexed convention the two halves are asymmetric:

- **Odd indices telescope exactly** — `fib_odd_index_sum`: $\sum_{i<n} F_{2i+1} = F_{2n}$ (no correction term)
- **Even indices carry the −1** — `fib_even_index_sum` / `fib_even_index_sum_sub`: $\sum_{i<n} F_{2i+2} = F_{2n+1} - 1$

The two are genuine complements: `fib_range_parity_split` proves they **partition** the range sum, and `fib_index_parity_total` / `fib_total_range_sum` add them back to recover $F_{2n+2} - 1$ — the $n \mapsto 2n$ instance of Mathlib's total-sum lemma — showing the lone $-1$ belongs entirely to the even half. Integer forms (`*_int`) give an honest subtraction.

## Verification

- **8 theorems, 0 definitions, 139 lines**
- **0 axioms, 0 sorries, no `native_decide`** — `#print axioms` on all eight confirms dependence only on `propext / Classical.choice / Quot.sound`
- Built against Mathlib 4.26.0

## Files
- `proofs/Proofs/FibonacciIdentitiesOQ03OQ02OQ01.lean`
- `src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-01/{meta.json,annotations.json}`

Distinct from siblings: `-oq-03-oq-02-oq-02` did the Lucas *square*-sum; this takes the parity structure of the *linear* sum. No overlap with the binomial-transform entry `-oq-06-oq-01-oq-03`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)