### PR TITLE
Enrich fibonacci-identities-oq-07: originality keyInsight (post-#32520 rebase)

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-07/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-07/meta.json
@@ -45,7 +45,8 @@
       "The reverse direction is exactly the injectivity of fib composed with the strong-divisibility identity — no new recurrence manipulation is needed",
       "The boundary collision F₁ = F₂ = 1 is the sole obstruction; requiring Fₘ ≥ 2 (i.e. m ≥ 3) removes it and is provably necessary",
       "gcd(m,n) ≥ 2 must be established before invoking injectivity on [2,∞): F_{gcd} = Fₘ ≥ 2 rules out gcd ∈ {0,1} via interval_cases",
-      "gcd(m,n) = m is definitionally m ∣ n (gcd_dvd_right after the rewrite)"
+      "gcd(m,n) = m is definitionally m ∣ n (gcd_dvd_right after the rewrite)",
+      "All the arithmetic weight sits in Mathlib's Nat.fib_gcd; the entry's originality is the extraction — turning strong divisibility into a clean biconditional and pinning the sharp m ≥ 3 boundary that Mathlib's one-directional fib_dvd leaves implicit"
     ],
     "prerequisites": [
       "Nat.fib and Nat.fib_gcd (strong divisibility sequence)",


### PR DESCRIPTION
Rebased onto main after concurrent PR #32520 fully enriched this entry's annotations + references. This PR now contributes only the one non-redundant addition: a 5th `keyInsight` noting that all arithmetic weight lives in Mathlib's `Nat.fib_gcd`, so the entry's originality is the *extraction* — a clean biconditional plus the sharp m ≥ 3 boundary that Mathlib's one-directional `fib_dvd` leaves implicit.

meta.json 8.7 KB (well under cap); keyInsights 4→5 (within 4–12). No content deleted; JSON validated.