### PR TITLE
Enrich Parity-Indexed Fibonacci Partial Sums (fibonacci-identities-oq-03-oq-02-oq-01): structured annotation metadata

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-01/annotations.json
@@ -5,7 +5,19 @@
     "range": { "startLine": 3, "endLine": 43 },
     "type": "concept",
     "title": "Refining the Total Sum by Index Parity",
-    "content": "**Module framing.** Mathlib records only the *total* Fibonacci partial sum, `Nat.fib_succ_eq_succ_sum`: $F_0 + F_1 + \\cdots + F_{n-1} = F_{n+1} - 1$. This entry splits that sum according to the parity of the summand's index. In Mathlib's $0$-indexed convention ($F_0 = 0$, $F_1 = F_2 = 1$, $F_3 = 2$, …) the two halves are asymmetric: the odd-index terms sum *exactly* to a Fibonacci number, $F_1 + F_3 + \\cdots + F_{2n-1} = F_{2n}$, while the even-index terms fall one short, $F_2 + F_4 + \\cdots + F_{2n} = F_{2n+1} - 1$. The lone $-1$ of the total sum is thus revealed to belong entirely to the even-index half. Both are one-line telescoping inductions; the entry stays subtraction-free over $\\mathbb{N}$ and exposes the $-1$ only over $\\mathbb{Z}$."
+    "content": "**Module framing.** Mathlib records only the *total* Fibonacci partial sum, `Nat.fib_succ_eq_succ_sum`: $F_0 + F_1 + \\cdots + F_{n-1} = F_{n+1} - 1$. This entry splits that sum according to the parity of the summand's index. In Mathlib's $0$-indexed convention ($F_0 = 0$, $F_1 = F_2 = 1$, $F_3 = 2$, …) the two halves are asymmetric: the odd-index terms sum *exactly* to a Fibonacci number, $F_1 + F_3 + \\cdots + F_{2n-1} = F_{2n}$, while the even-index terms fall one short, $F_2 + F_4 + \\cdots + F_{2n} = F_{2n+1} - 1$. The lone $-1$ of the total sum is thus revealed to belong entirely to the even-index half. Both are one-line telescoping inductions; the entry stays subtraction-free over $\\mathbb{N}$ and exposes the $-1$ only over $\\mathbb{Z}$.",
+    "mathContext": "$\\sum_{k=1}^{n} F_{2k-1} = F_{2n}$ (odd, exact) and $\\sum_{k=1}^{n} F_{2k} = F_{2n+1} - 1$ (even), refining $\\sum_{i=1}^{n} F_i = F_{n+2} - 1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "index parity",
+      "telescoping sum",
+      "Nat.fib_succ_eq_succ_sum",
+      "strong induction on range sums"
+    ],
+    "prerequisites": [
+      "Fibonacci recurrence and Mathlib's 0-indexed convention",
+      "finite range sums over ℕ"
+    ]
   },
   {
     "id": "ann-fiboq030201-2",
@@ -13,7 +25,19 @@
     "range": { "startLine": 45, "endLine": 60 },
     "type": "technique",
     "title": "The Odd-Index Sum Telescopes Exactly",
-    "content": "**No correction term.** `fib_odd_index_sum` proves $\\sum_{i \\in \\mathrm{range}\\,n} F_{2i+1} = F_{2n}$ by induction. `Finset.sum_range_succ` peels the top summand $F_{2n+1}$; the induction hypothesis rewrites the remaining sum to $F_{2n}$; and the recurrence `Nat.fib_add_two` ($F_{k+2} = F_k + F_{k+1}$) merges $F_{2n} + F_{2n+1} = F_{2n+2} = F_{2(n+1)}$. The partial sums are *always* exactly the next even-index Fibonacci — nothing is ever left over, which is why the odd half carries no $-1$."
+    "content": "**No correction term.** `fib_odd_index_sum` proves $\\sum_{i \\in \\mathrm{range}\\,n} F_{2i+1} = F_{2n}$ by induction. `Finset.sum_range_succ` peels the top summand $F_{2n+1}$; the induction hypothesis rewrites the remaining sum to $F_{2n}$; and the recurrence `Nat.fib_add_two` ($F_{k+2} = F_k + F_{k+1}$) merges $F_{2n} + F_{2n+1} = F_{2n+2} = F_{2(n+1)}$. The partial sums are *always* exactly the next even-index Fibonacci — nothing is ever left over, which is why the odd half carries no $-1$.",
+    "mathContext": "$\\sum_{i \\in \\mathrm{range}\\,n} F_{2i+1} = F_{2n}$; step: $F_{2n} + F_{2n+1} = F_{2n+2}$ via `Nat.fib_add_two`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_range_succ",
+      "Nat.fib_add_two",
+      "telescoping",
+      "even-index Fibonacci"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "Finset.sum_range_succ"
+    ]
   },
   {
     "id": "ann-fiboq030201-3",
@@ -21,7 +45,19 @@
     "range": { "startLine": 62, "endLine": 87 },
     "type": "technique",
     "title": "The Even-Index Sum and Its −1",
-    "content": "**Additive form dodges ℕ subtraction.** `fib_even_index_sum` is stated as $\\left(\\sum_{i \\in \\mathrm{range}\\,n} F_{2i+2}\\right) + 1 = F_{2n+1}$ — the additive phrasing keeps every $\\mathbb{N}$ step a genuine equality. The inductive step peels $F_{2n+2}$, uses `Nat.fib_add_two` at index $2n+1$ to unfold $F_{2n+3} = F_{2n+1} + F_{2n+2}$, and closes with `← ih` and `ring`. `fib_even_index_sum_sub` then reads off the classical $\\sum F_{2i+2} = F_{2n+1} - 1$ over $\\mathbb{N}$ (honest, since $F_{2n+1} \\ge 1$) with a single `omega`."
+    "content": "**Additive form dodges ℕ subtraction.** `fib_even_index_sum` is stated as $\\left(\\sum_{i \\in \\mathrm{range}\\,n} F_{2i+2}\\right) + 1 = F_{2n+1}$ — the additive phrasing keeps every $\\mathbb{N}$ step a genuine equality. The inductive step peels $F_{2n+2}$, uses `Nat.fib_add_two` at index $2n+1$ to unfold $F_{2n+3} = F_{2n+1} + F_{2n+2}$, and closes with `← ih` and `ring`. `fib_even_index_sum_sub` then reads off the classical $\\sum F_{2i+2} = F_{2n+1} - 1$ over $\\mathbb{N}$ (honest, since $F_{2n+1} \\ge 1$) with a single `omega`.",
+    "mathContext": "$\\left(\\sum_{i \\in \\mathrm{range}\\,n} F_{2i+2}\\right) + 1 = F_{2n+1}$, equivalently $\\sum F_{2i+2} = F_{2n+1} - 1$ over $\\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "truncated ℕ subtraction",
+      "additive normal form",
+      "Nat.fib_add_two",
+      "omega"
+    ],
+    "prerequisites": [
+      "ring and omega tactics",
+      "Finset.sum_range_succ"
+    ]
   },
   {
     "id": "ann-fiboq030201-4",
@@ -29,7 +65,19 @@
     "range": { "startLine": 89, "endLine": 104 },
     "type": "insight",
     "title": "The Two Halves Genuinely Partition the Range",
-    "content": "**Complementary, not just consistent.** `fib_range_parity_split` proves $\\sum_{i \\in \\mathrm{range}(2n)} F_{i+1} = \\sum_{i \\in \\mathrm{range}\\,n} F_{2i+1} + \\sum_{i \\in \\mathrm{range}\\,n} F_{2i+2}$ — the odd and even index classes literally partition $\\{1, \\dots, 2n\\}$ at the level of the finite sum. The induction peels the top *two* terms $F_{2n+1}, F_{2n+2}$ of the length-$2n{+}2$ range and the top term of each parity sum, normalises the definitionally-equal index $2n+1+1 = 2n+2$, and matches both sides with `ring`. This is what makes the total-sum recovery a true reconstruction rather than a numerical coincidence."
+    "content": "**Complementary, not just consistent.** `fib_range_parity_split` proves $\\sum_{i \\in \\mathrm{range}(2n)} F_{i+1} = \\sum_{i \\in \\mathrm{range}\\,n} F_{2i+1} + \\sum_{i \\in \\mathrm{range}\\,n} F_{2i+2}$ — the odd and even index classes literally partition $\\{1, \\dots, 2n\\}$ at the level of the finite sum. The induction peels the top *two* terms $F_{2n+1}, F_{2n+2}$ of the length-$2n{+}2$ range and the top term of each parity sum, normalises the definitionally-equal index $2n+1+1 = 2n+2$, and matches both sides with `ring`. This is what makes the total-sum recovery a true reconstruction rather than a numerical coincidence.",
+    "mathContext": "$\\sum_{i \\in \\mathrm{range}(2n)} F_{i+1} = \\sum_{i \\in \\mathrm{range}\\,n} F_{2i+1} + \\sum_{i \\in \\mathrm{range}\\,n} F_{2i+2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "partition of a finite sum",
+      "two-term peel induction",
+      "reindexing by parity",
+      "ring"
+    ],
+    "prerequisites": [
+      "Finset.sum_range_succ",
+      "definitional equality of ℕ successor terms"
+    ]
   },
   {
     "id": "ann-fiboq030201-5",
@@ -37,7 +85,19 @@
     "range": { "startLine": 106, "endLine": 122 },
     "type": "concept",
     "title": "Adding the Halves Recovers Mathlib's Total Sum",
-    "content": "**One recurrence closes it.** `fib_index_parity_total` rewrites both half-sums and then a single `Nat.fib_add_two` turns the goal $F_{2n} + F_{2n+1} = F_{2n+2}$ into reflexivity. Combined with the partition, `fib_total_range_sum` recovers $(F_1 + \\cdots + F_{2n}) + 1 = F_{2n+2}$ — precisely the $n \\mapsto 2n$ instance of Mathlib's total-sum lemma `Nat.fib_succ_eq_succ_sum` — now *derived from the parity split*. The derivation makes visible that the total sum's $-1$ is contributed by the even-index terms alone."
+    "content": "**One recurrence closes it.** `fib_index_parity_total` rewrites both half-sums and then a single `Nat.fib_add_two` turns the goal $F_{2n} + F_{2n+1} = F_{2n+2}$ into reflexivity. Combined with the partition, `fib_total_range_sum` recovers $(F_1 + \\cdots + F_{2n}) + 1 = F_{2n+2}$ — precisely the $n \\mapsto 2n$ instance of Mathlib's total-sum lemma `Nat.fib_succ_eq_succ_sum` — now *derived from the parity split*. The derivation makes visible that the total sum's $-1$ is contributed by the even-index terms alone.",
+    "mathContext": "$(F_1 + \\cdots + F_{2n}) + 1 = F_{2n+2}$, from $F_{2n} + F_{2n+1} = F_{2n+2}$ plus the partition.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.fib_succ_eq_succ_sum",
+      "consistency identity",
+      "reconstruction of the total sum",
+      "omega"
+    ],
+    "prerequisites": [
+      "fib_range_parity_split",
+      "Nat.fib_add_two"
+    ]
   },
   {
     "id": "ann-fiboq030201-6",
@@ -45,6 +105,18 @@
     "range": { "startLine": 124, "endLine": 139 },
     "type": "technique",
     "title": "Integer Forms: an Honest −1",
-    "content": "**ℕ→ℤ transfer.** `fib_odd_index_sum_int` lifts the odd-index identity to $\\mathbb{Z}$ with a single `exact_mod_cast`. `fib_even_index_sum_int` casts the additive $\\mathbb{N}$ identity, then `push_cast` distributes the cast over the finite sum and `linarith` moves the $+1$ across, yielding $\\sum_{i \\in \\mathrm{range}\\,n} (F_{2i+2} : \\mathbb{Z}) = (F_{2n+1} : \\mathbb{Z}) - 1$ with the $-1$ as a genuine subtraction — the natural home for the correction term."
+    "content": "**ℕ→ℤ transfer.** `fib_odd_index_sum_int` lifts the odd-index identity to $\\mathbb{Z}$ with a single `exact_mod_cast`. `fib_even_index_sum_int` casts the additive $\\mathbb{N}$ identity, then `push_cast` distributes the cast over the finite sum and `linarith` moves the $+1$ across, yielding $\\sum_{i \\in \\mathrm{range}\\,n} (F_{2i+2} : \\mathbb{Z}) = (F_{2n+1} : \\mathbb{Z}) - 1$ with the $-1$ as a genuine subtraction — the natural home for the correction term.",
+    "mathContext": "Over $\\mathbb{Z}$: $\\sum F_{2i+1} = F_{2n}$ and $\\sum F_{2i+2} = F_{2n+1} - 1$ (literal subtraction).",
+    "significance": "technical",
+    "relatedConcepts": [
+      "push_cast",
+      "exact_mod_cast",
+      "linarith",
+      "ℕ→ℤ coercion"
+    ],
+    "prerequisites": [
+      "casting finite sums ℕ→ℤ",
+      "linarith"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-03-oq-02-oq-01` (quality 68, 0 prior passes).

The entry's meta.json is already at the quality ceiling (~17 KB: 8 documented contributions, 6 sections covering all 139 lines, references, cross-refs, conclusion) — left **unchanged**. The 6 annotations had rich prose but were **missing the structured schema fields** the gallery renders as metadata. Added to each of the 6 annotations:
- a dedicated `mathContext` field (concise LaTeX identity, distinct from the prose)
- `significance` (context / key / supporting / technical)
- `relatedConcepts` (tactics, lemmas, concepts)
- `prerequisites`

## Guardrails
- No prose deleted; only additive structured fields.
- JSON validated with `json.load`; all 6 annotations now carry mathContext/significance/relatedConcepts/prerequisites.
- meta.json untouched (already at ceiling).