### PR TITLE
Enrich Fibonacci Summation Identities: add index.ts, correct section ranges

### DIFF
--- a/src/data/proofs/fibonacci-identities/index.ts
+++ b/src/data/proofs/fibonacci-identities/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, ProofReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentities.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+  references?: ProofReference[]
+}
+
+export const fibonacciIdentitiesProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+  references: meta.references,
+}
+
+export const fibonacciIdentitiesAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesData: ProofData = {
+  proof: fibonacciIdentitiesProof,
+  annotations: fibonacciIdentitiesAnnotations,
+}

--- a/src/data/proofs/fibonacci-identities/meta.json
+++ b/src/data/proofs/fibonacci-identities/meta.json
@@ -96,22 +96,22 @@
       "id": "sum-of-squares",
       "title": "Sum of Squares",
       "startLine": 35,
-      "endLine": 46,
+      "endLine": 45,
       "summary": "fib_sum_sq: ∑_{i≤n} Fᵢ² = Fₙ·Fₙ₊₁ by induction. The step rewrites the last square, applies the inductive hypothesis, expands Fₙ₊₂ = Fₙ + Fₙ₊₁, and closes with ring.",
       "mathContext": "$\\sum_{i=0}^{n} F_i^2 = F_n F_{n+1}.$"
     },
     {
       "id": "odd-indexed",
       "title": "Odd-Indexed Sum",
-      "startLine": 48,
-      "endLine": 56,
+      "startLine": 46,
+      "endLine": 55,
       "summary": "fib_sum_odd: ∑_{i<n} F₂ᵢ₊₁ = F₂ₙ by induction; the step adds F₂ₙ₊₁ to F₂ₙ and collapses to F₂ₙ₊₂ = F₂₍ₙ₊₁₎ via the recurrence.",
       "mathContext": "$\\sum_{i=0}^{n-1} F_{2i+1} = F_{2n}.$"
     },
     {
       "id": "even-indexed",
       "title": "Even-Indexed Sum",
-      "startLine": 58,
+      "startLine": 56,
       "endLine": 70,
       "summary": "fib_sum_even: (∑_{i<n} F₂ᵢ₊₂) + 1 = F₂ₙ₊₁ by induction; the step peels the last summand, rewrites F₂₍ₙ₊₁₎₊₁ = F₂ₙ₊₁ + F₂ₙ₊₂ via the recurrence, and closes with omega against the inductive hypothesis.",
       "mathContext": "$\\Big(\\sum_{i=1}^{n} F_{2i}\\Big) + 1 = F_{2n+1}.$"


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities` (passes: 0, quality: 90).

The entry's content was already at quality target — rich `overview` (5 keyInsights, full historicalContext/proofStrategy), 4 full annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`), a substantive `conclusion`, and 4 cross-references. Per the size-guardrail SKIP rule I did **not** inflate it.

Two bounded correctness improvements:

1. **Added `index.ts`** — the per-proof entry point, for consistency with sibling Fibonacci entries (cassini-identity-oq-01, combinations-formula-oq-08). (Note: the runtime loader is now manifest-based (#20993), so this is a consistency/legacy shim rather than a load-blocker.)

2. **Corrected `sections` line ranges** to be contiguous and cover the full 70-line Lean file, matching the annotation ranges. Previously each section bled into the following theorem's docstring:
   - sum-of-squares: 35–46 → **35–45**
   - odd-indexed: 48–56 → **46–55**
   - even-indexed: 58–70 → **56–70**

JSON validated with python; meta.json stays at 12.8 KB (well under the 60 KB cap).