### PR TITLE
Enrich 'Galois group of irreducible polynomial is a transitive subgroup of S_n': index.ts + full section coverage

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, ProofReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ04OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+  references?: ProofReference[]
+}
+
+export const abelRuffiniOq04Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+  references: meta.references,
+}
+
+export const abelRuffiniOq04Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOq04Oq01Oq02Data: ProofData = {
+  proof: abelRuffiniOq04Oq01Oq02Proof,
+  annotations: abelRuffiniOq04Oq01Oq02Annotations,
+}

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/meta.json
@@ -87,25 +87,36 @@
   },
   "sections": [
     {
+      "id": "header-setup",
+      "title": "Framing and Setup",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring framing the open question — generalize the concrete quintic Gal(x⁵−4x+2) ≅ S₅ (parent AbelRuffiniOQ04OQ01) and the abstract sibling lemma to the Galois-theoretic fact that supplies the transitivity hypothesis — then `import Mathlib`, `open Polynomial Polynomial.Gal MulAction` with scoped `IntermediateField` notation, `namespace AbelRuffiniOQ04OQ01OQ02`, and the `variable {F} [Field F] (p : F[X]) (E) [Field E] [Algebra F E]` setup. The central object throughout is Mathlib's permutation representation galActionHom p E.",
+      "mathContext": "$\\mathrm{galActionHom}\\,p\\,E : \\mathrm{Gal}\\,p \\to \\mathrm{Perm}(\\mathrm{rootSet}\\,p\\,E).$"
+    },
+    {
       "id": "transitive-subgroup",
       "title": "Gal as a Transitive Subgroup of S_n",
-      "startLine": 55,
-      "endLine": 69,
-      "summary": "galActionHom_range_isPretransitive: for irreducible p splitting in E, (galActionHom p E).range acts transitively on rootSet p E. Transitivity of the p.Gal-action (galAction_isPretransitive) transfers to the realised permutation subgroup."
+      "startLine": 46,
+      "endLine": 68,
+      "summary": "galActionHom_range_isPretransitive: for irreducible p splitting in E, (galActionHom p E).range acts transitively on rootSet p E. Transitivity of the p.Gal-action (galAction_isPretransitive) transfers to the realised permutation subgroup because the corestriction onto the range is a surjective equivariant map.",
+      "mathContext": "$p \\text{ irreducible} \\implies (\\mathrm{galActionHom}\\,p\\,E).\\mathrm{range}$ acts transitively on the roots."
     },
     {
       "id": "iso-onto-range",
       "title": "Realising Gal as the Permutation Group",
-      "startLine": 71,
+      "startLine": 69,
       "endLine": 75,
-      "summary": "galMulEquivRange: Gal p ≃* (galActionHom p E).range, via MonoidHom.ofInjective applied to galActionHom_injective."
+      "summary": "galMulEquivRange: Gal p ≃* (galActionHom p E).range, via MonoidHom.ofInjective applied to galActionHom_injective — the injectivity that makes 'subgroup' literal rather than figurative.",
+      "mathContext": "$\\mathrm{Gal}\\,p \\;\\simeq^*\\; (\\mathrm{galActionHom}\\,p\\,E).\\mathrm{range}.$"
     },
     {
       "id": "degree-divides-order",
       "title": "Degree Divides |Gal| in Any Degree",
-      "startLine": 85,
-      "endLine": 105,
-      "summary": "natDegree_dvd_card: p.natDegree ∣ Nat.card p.Gal for irreducible p over a characteristic-zero field, generalizing prime_degree_dvd_card; primality is replaced by Irreducible.natDegree_pos."
+      "startLine": 76,
+      "endLine": 107,
+      "summary": "natDegree_dvd_card: p.natDegree ∣ Nat.card p.Gal for irreducible p over a characteristic-zero field, generalizing prime_degree_dvd_card; primality is replaced by Irreducible.natDegree_pos, with the minpoly/finrank-tower argument (card_of_separable, adjoin.finrank, finrank_mul_finrank) otherwise unchanged.",
+      "mathContext": "$p \\text{ irreducible},\\ \\mathrm{char}\\,F = 0 \\implies \\deg p \\mid |\\mathrm{Gal}\\,p|.$"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-01-oq-02` (passes: 0, quality: 91).

The entry's prose was already at quality target — long `historicalContext`, 5 `keyInsights`, 4 full annotations (each with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`), `conclusion` with implications and open questions, and references. Per the size-guardrail SKIP rule I did **not** inflate it.

Two bounded improvements:

1. **Added `index.ts`** entry point, for consistency with sibling abel-ruffini entries.

2. **Completed `sections` coverage.** Previously the three sections covered only lines 55–105, leaving the entire header/setup (lines 1–54) and each theorem's docstring uncovered. Now:
   - **Framing and Setup** (new): 1–45 — module docstring, imports, opens, namespace, `variable` block
   - Gal as a Transitive Subgroup of Sₙ: 55–69 → **46–68** (includes docstring)
   - Realising Gal as the Permutation Group: 71–75 → **69–75**
   - Degree Divides |Gal| in Any Degree: 85–105 → **76–107** (includes docstring + closing namespace)
   Every section now carries a `mathContext`; coverage is contiguous over the full 107-line file.

meta.json is 14.2 KB (well under the 60 KB cap). JSON validated with python.