### PR TITLE
Enrich: Galois group of irreducible poly as transitive subgroup of S_n (abel-ruffini-oq-04-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-motivation-lineage",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
+    "type": "context",
+    "title": "Motivation: Closing the Gap in the Abel–Ruffini Chain",
+    "content": "The header records exactly which link this entry supplies in the concrete-quintic chain. The parent AbelRuffiniOQ04OQ01 computes one Galois group by hand — Gal(x⁵ − 4x + 2) ≅ S₅ — and its sibling AbelRuffiniOQ04OQ01OQ04 proves the abstract group lemma 'a transitive subgroup of S_p (p prime) containing a transposition is all of S_p', but that lemma takes transitivity as a bare hypothesis [IsPretransitive G α]. Neither file justifies the transitivity from anything mathematical. This entry closes that gap over an arbitrary field and arbitrary degree by establishing the classical fact that supplies the hypothesis: the Galois group of an irreducible polynomial genuinely is a transitive subgroup of the symmetric group on its roots. The single import Mathlib pulls in the entire PolynomialGaloisGroup and IntermediateField machinery the three results rest on; gallery proofs may import Mathlib wholesale (unlike Mathlib-bound files).",
+    "mathContext": "Chain: irreducible $p$ $\\implies$ $\\mathrm{Gal}\\,p$ transitive on roots $\\implies$ (with a transposition, prime degree) $\\mathrm{Gal}\\,p = S_p$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Abel–Ruffini theorem",
+      "insolvability of the quintic",
+      "transitive subgroup of the symmetric group",
+      "open-question generalization"
+    ],
+    "prerequisites": [
+      "Galois theory of polynomials",
+      "symmetric group S_n",
+      "irreducible polynomials"
+    ]
+  },
+  {
     "id": "ann-setup-galaction",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
     "range": {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ04OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOq04Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOq04Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOq04Oq01Oq02Data: ProofData = {
+  proof: abelRuffiniOq04Oq01Oq02Proof,
+  annotations: abelRuffiniOq04Oq01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-01-oq-02` (0 prior passes).

## Changes
- **Created missing `index.ts`** — the per-proof Vite shim (matches the convention used by 621 sibling entries). Post-#20993 discovery is via `meta.json` scanning, so this is a legacy artifact but kept for consistency.
- **Added a 5th annotation** (`ann-motivation-lineage`, lines 1–38) covering the previously-unannotated header docstring. It explains the Abel–Ruffini lineage: the parent computes Gal(x⁵−4x+2) ≅ S₅ by hand, the sibling proves 'transitive + transposition ⟹ S_p' but assumes transitivity, and this entry supplies that transitivity from irreducibility over an arbitrary field and degree.

## Quality
- Annotations: 4 → 5, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- meta.json unchanged (already rich at 12.7 KB, well under the 60 KB cap; keyInsights=5, complete conclusion)
- JSON validated; annotation ranges within the 107-line file; size caps pass

No axiom/status changes: entry remains `verified` / `original` (0 axioms, 0 sorries), consistent with the Lean source.