### PR TITLE
Enrich: Fibonacci Summation Identities — add shared-induction-template annotation

### DIFF
--- a/src/data/proofs/fibonacci-identities/annotations.json
+++ b/src/data/proofs/fibonacci-identities/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["Fibonacci recurrence", "finite sums over Finset.range"]
   },
   {
+    "id": "fibid-ann-template",
+    "proofId": "fibonacci-identities",
+    "range": { "startLine": 35, "endLine": 70 },
+    "type": "technique",
+    "title": "The Shared Induction Template",
+    "content": "All three theorems are instances of one reusable proof skeleton, which is worth isolating on its own: `induction n with | zero => simp | succ k ih => rw [Finset.sum_range_succ, ih, …, Nat.fib_add_two]; <closer>`. Every proof (a) reduces the empty/singleton base case by `simp`, (b) peels the final summand with `Finset.sum_range_succ`, (c) rewrites with the inductive hypothesis, (d) normalizes the doubled/successor index (`show 2*(k+1) = 2*k+2 from by ring`, etc.) so that (e) the single Fibonacci fact `Nat.fib_add_two` fires. Only the *closer* varies with the algebraic degree of the identity: `ring` for the quadratic sum of squares, the bare recurrence rewrite for the linear odd-indexed sum, and `omega` for the even-indexed sum's off-by-one linear bookkeeping. Recognizing this template is the practical lesson: a whole family of Fibonacci summation identities is formalizable by filling in one slot of a fixed induction.",
+    "mathContext": "Uniform skeleton: peel last term ($\\texttt{sum\\_range\\_succ}$) $\\to$ apply IH $\\to$ collapse via $F_{n+2}=F_{n+1}+F_n$ ($\\texttt{fib\\_add\\_two}$) $\\to$ close with $\\texttt{ring}$ / recurrence / $\\texttt{omega}$.",
+    "significance": "key",
+    "relatedConcepts": ["proof template", "induction over Finset.range", "ring vs omega", "reusable tactic skeleton"],
+    "prerequisites": ["structural induction in Lean", "Finset.sum_range_succ", "Nat.fib_add_two"]
+  },
+  {
     "id": "fibid-ann-sum-sq",
     "proofId": "fibonacci-identities",
     "range": { "startLine": 35, "endLine": 44 },


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities` (0 prior passes).

## Change
Added a 5th annotation (`fibid-ann-template`, type `technique`, spanning the three-theorem region lines 35–70) that isolates the **reusable induction skeleton** shared by all three proofs:

```
induction n with
| zero => simp
| succ k ih => rw [Finset.sum_range_succ, ih, …index rewrite…, Nat.fib_add_two]; <closer>
```

Only the *closer* varies with the algebraic degree of the identity — `ring` (quadratic sum of squares), the bare recurrence rewrite (linear odd-indexed sum), and `omega` (even-indexed off-by-one). None of the existing per-theorem annotations articulate this cross-cutting formalization pattern, so it is genuinely additive rather than a split.

## Quality
- Annotations: 4 → 5, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- meta.json **unchanged** — already at its quality ceiling (5 keyInsights, 5 references, 4 crossReferences, full conclusion with implications + open questions, mainTheorems), 12.8 KB, well under the 60 KB cap
- No axiom/status changes: remains `verified` / `original` (0 axioms, 0 sorries), consistent with the Lean source
- JSON validated; annotation ranges within the 70-line file