### PR TITLE
Enrich 'Galois group of irreducible polynomial is a transitive subgroup of S_n': +1 lineage annotation

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-docstring-lineage",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 36
+    },
+    "type": "concept",
+    "title": "Why This File Exists: the Missing Transitivity Input",
+    "content": "The module docstring locates this file precisely within the Abel–Ruffini concrete-quintic branch. The parent AbelRuffiniOQ04OQ01 computes a SINGLE Galois group by hand (Gal(x⁵−4x+2) ≅ S₅). The sibling AbelRuffiniOQ04OQ01OQ04 proves the abstract group-theory lemma 'a transitive subgroup of S_p (p prime) containing a transposition is all of S_p' — but takes transitivity as a bare hypothesis [IsPretransitive G α]. The gap neither file closes is the Galois-theoretic fact that SUPPLIES that hypothesis: the Galois group of an irreducible polynomial genuinely is a transitive subgroup of the symmetric group on its roots. This file fills exactly that gap, axiom-free, over an arbitrary base field and arbitrary degree — turning the concrete n=5 computation into the general principle 'every irreducible polynomial hands you a transitive subgroup of Sₙ with n ∣ |Gal|'. Reading the file as three results (transitive-subgroup, isomorphism-onto-range, degree-divides-order) is reading the three sentences of this docstring in order.",
+    "mathContext": "Lineage: parent (one Galois group, by hand) → this entry (irreducible ⟹ transitive subgroup of Sₙ, any n) → sibling (transitive + transposition ⟹ S_p). This entry is the Galois-theoretic hinge between the concrete computation and the abstract group theory.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Abel–Ruffini theorem",
+      "open-question lineage",
+      "transitive subgroup of Sₙ",
+      "irreducibility and transitivity"
+    ],
+    "prerequisites": [
+      "Galois group of a polynomial",
+      "transitive group actions"
+    ]
+  },
+  {
     "id": "ann-setup-galaction",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
     "range": {


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-01-oq-02` (quality 91, passes 0).

## Assessment
Already well-curated: 5 keyInsights, 3 sections, full conclusion (2 open questions), 2 references, 2 cross-references, 4 detailed annotations. `meta.json` is 12.7 KB — under all caps. Meta fields left as-is per curation-not-accretion.

## Change
Genuine coverage gap: the module docstring (lines 1–36) had no annotation — the first annotation began at line 40. Added `ann-docstring-lineage` (type `concept`, range 1–36):

- Frames the file's place in the Abel–Ruffini concrete-quintic branch: parent computes one Galois group by hand; sibling proves the abstract 'transitive + transposition ⟹ S_p' lemma but *assumes* transitivity; this entry supplies the missing Galois-theoretic input (irreducible ⟹ transitive subgroup of Sₙ) over arbitrary field and degree.
- Maps the three docstring sentences onto the file's three results.

meta.json unchanged. JSON validated (5 annotations, `significance` ∈ {critical, key, supporting}, unique ids, ranges within the 107-line file).