### PR TITLE
Enrich: Quadratic Convergence of the AGM — add √-algebra technique annotation

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-04/annotations.json
@@ -69,6 +69,29 @@
     ]
   },
   {
+    "id": "ann-sqrt-technique",
+    "proofId": "amgm-inequality-oq-04-oq-04",
+    "range": {
+      "startLine": 36,
+      "endLine": 76
+    },
+    "type": "technique",
+    "title": "Reifying √ as an Opaque Variable with (√x)² = x",
+    "content": "All three analytic theorems (agm_gap_eq, agm_gap_quadratic, agm_gap_le) share one Lean tactic idiom worth isolating: rather than reasoning about √ directly, each proof first asserts the two defining facts `Real.sq_sqrt : (√a)² = a` and `(√b)² = b` as hypotheses, then hands the goal to `nlinarith` (or `field_simp` then `nlinarith`). This lets the nonlinear arithmetic engine treat √a and √b as fresh opaque variables constrained only by those two quadratic equations — the transcendental content of the square root is fully captured by (√x)² = x, and the rest is polynomial algebra. The one extra ingredient needed for inequalities is monotonicity/positivity of √ (Real.sqrt_le_sqrt, Real.sqrt_pos), used in agm_gap_le to bound (√a+√b)² ≥ 4b before `gcongr`. Recognizing this 'reify the root, then nlinarith' pattern is the practical key to formalizing square-root identities of this kind.",
+    "mathContext": "Replace $\\sqrt a, \\sqrt b$ by variables $s, t \\ge 0$ with $s^2 = a$, $t^2 = b$; every gap identity becomes a polynomial identity in $s, t$ that $\\texttt{nlinarith}$/$\\texttt{field\\_simp}$ can discharge.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.sq_sqrt",
+      "nlinarith with auxiliary hypotheses",
+      "field_simp",
+      "reification of transcendental terms"
+    ],
+    "prerequisites": [
+      "nonlinear arithmetic tactics",
+      "algebra of square roots over ℝ"
+    ]
+  },
+  {
     "id": "ann-doubly-exp",
     "proofId": "amgm-inequality-oq-04-oq-04",
     "range": {


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-04-oq-04` (0 prior passes).

## Change
Added a 5th annotation (`ann-sqrt-technique`, type `technique`, spanning lines 36–76) that isolates the reusable Lean tactic idiom shared by all three analytic theorems (`agm_gap_eq`, `agm_gap_quadratic`, `agm_gap_le`): assert the two defining facts `Real.sq_sqrt : (√x)² = x`, then let `nlinarith`/`field_simp` treat `√a`, `√b` as opaque variables constrained only by those quadratics — reducing each square-root identity to polynomial algebra. The inequality case additionally uses monotonicity/positivity of √ before `gcongr`. None of the existing (mathematically-focused) annotations name this cross-cutting formalization pattern.

## Quality
- Annotations: 4 → 5, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- meta.json **unchanged** — already at its quality ceiling (5 keyInsights, full overview + conclusion with open questions, 3 references, 2 crossReferences, sections with mathContext), 11.4 KB, well under the 60 KB cap
- No axiom/status changes: remains `verified` / `original` (0 axioms, 0 sorries)
- JSON validated; annotation range within the 100-line file