### PR TITLE
Enrich: minpoly of cos(2π/n) as irreducible factor of Tₙ−1 — annotate integrality step

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-02-oq-02/annotations.json
@@ -67,6 +67,29 @@
     ]
   },
   {
+    "id": "ann-integral",
+    "proofId": "angle-trisection-cos-20-gal-oq-02-oq-02",
+    "range": {
+      "startLine": 70,
+      "endLine": 77
+    },
+    "type": "key-step",
+    "title": "Integrality: The Bridge to the Minimal Polynomial",
+    "content": "cos_isIntegral is the hinge that turns the two preceding evaluation facts into a statement about the minimal polynomial. Because minpoly ℚ (cos 2π/n) is only well-behaved (divides, is irreducible) when cos 2π/n is integral over ℚ, this theorem must be established first. The witness is the very polynomial the rest of the file studies: cos 2π/n is a root of Tₙ − 1 (aeval_cos_cheb gives aeval(Tₙ−1) = 0) and Tₙ − 1 ≠ 0 (chebT_sub_one_ne_zero), so IsAlgebraic holds by definition, and over the field ℚ algebraic ⟹ integral (IsAlgebraic.isIntegral). Everything downstream — minpoly.dvd, minpoly.irreducible, the degree bound — consumes this single integrality hypothesis.",
+    "mathContext": "$\\cos 2\\pi/n$ is a root of the nonzero $T_n - 1 \\in \\mathbb Q[X]$, hence algebraic, hence integral over the field $\\mathbb Q$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "integral element",
+      "algebraic over a field",
+      "IsAlgebraic.isIntegral",
+      "minimal polynomial well-definedness"
+    ],
+    "prerequisites": [
+      "IsIntegral / IsAlgebraic",
+      "a root of a nonzero polynomial is algebraic"
+    ]
+  },
+  {
     "id": "ann-minpoly-dvd",
     "proofId": "angle-trisection-cos-20-gal-oq-02-oq-02",
     "range": {


### PR DESCRIPTION
Enrichment pass for `angle-trisection-cos-20-gal-oq-02-oq-02` (0 prior passes).

## Change
Closed a **genuine annotation-coverage gap**: theorem 3, `cos_isIntegral` (lines 70–77), was previously unannotated — the only substantive theorem in the 6-theorem file with no coverage. Added `ann-integral`, which explains its role as the **hinge**: minpoly ℚ (cos 2π/n) only divides / is irreducible once cos 2π/n is known integral over ℚ, and integrality follows because cos 2π/n is a root of the nonzero Tₙ−1 (algebraic ⟹ integral over a field). Every downstream result (`minpoly.dvd`, `minpoly.irreducible`, the degree bound) consumes this single hypothesis.

All substantive theorems are now annotated.

## Quality
- Annotations: 4 → 5, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- Annotation `type`/`significance` vocabulary matches the file's existing local convention (`key-step`/`important`)
- meta.json **unchanged** — already at its quality ceiling (5 keyInsights, honest-scope conclusion with open questions, sections with mathContext), 13.7 KB, under the 60 KB cap
- No axiom/status changes: remains `verified` / `original` (0 axioms, 0 sorries); the entry is careful to scope to the structural half (irreducible factor), not the still-open sharp degree φ(n)/2
- JSON validated; annotation range within the 101-line file