### PR TITLE
Enrich: Log-Concavity of Unit Ball Volume — index.ts + omega_sq_ge annotation

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03/annotations.json
@@ -55,6 +55,25 @@
   ]
  },
  {
+  "id": "ann-index-form",
+  "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03",
+  "range": {
+   "startLine": 133,
+   "endLine": 140
+  },
+  "type": "tactic",
+  "title": "Recentring the Index with obtain ⟨m, rfl⟩",
+  "content": "omega_sq_ge restates log-concavity in the symmetric centred form ω_{n-1}·ω_{n+1} ≤ ω_n² for n ≥ 1, which is the shape most references state. The subtlety is purely ℕ-arithmetic: n-1 is truncated subtraction, awkward to reason with directly. The proof sidesteps it by destructuring the positivity hypothesis: `obtain ⟨m, rfl⟩ : ∃ m, n = m + 1` (from Nat.succ_pred_eq_of_pos) rewrites n as m+1 everywhere, so n-1 becomes m, n becomes m+1, n+1 becomes m+2 — turning the goal into ω_m·ω_{m+2} ≤ ω_{m+1}², which is exactly omega_log_concave m, closed by `simpa`. This 'obtain ⟨m, rfl⟩ to eliminate a predecessor' idiom is the standard way to convert a centred-index statement to the base recurrence without wrestling with ℕ subtraction.",
+  "mathContext": "Set $n = m+1$: then $n-1 = m$, so $\\omega_{n-1}\\omega_{n+1} \\le \\omega_n^2$ becomes $\\omega_m\\,\\omega_{m+2} \\le \\omega_{m+1}^2$ — the base form.",
+  "significance": "supporting",
+  "relatedConcepts": [
+   "truncated ℕ subtraction",
+   "obtain ⟨m, rfl⟩ reindexing",
+   "Nat.succ_pred_eq_of_pos",
+   "simpa"
+  ]
+ },
+ {
   "id": "ann-ratios",
   "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03",
   "range": {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03/index.ts
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02OQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq01Oq02Oq01Oq01Oq02Oq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq01Oq02Oq01Oq01Oq02Oq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq01Oq02Oq01Oq01Oq02Oq01Oq03Data: ProofData = {
+  proof: areaOfCircleOq01Oq02Oq01Oq01Oq02Oq01Oq03Proof,
+  annotations: areaOfCircleOq01Oq02Oq01Oq01Oq02Oq01Oq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03` (0 prior passes).

## Changes
- **Created missing `index.ts`** — the per-proof Vite shim (matches sibling convention). Post-#20993 discovery is via `meta.json` scanning, so this is a legacy artifact but kept for consistency.
- **Added a 5th annotation** (`ann-index-form`, lines 133–140) for the theorem `omega_sq_ge`, the centred-index restatement ω_{n-1}·ω_{n+1} ≤ ω_n². It was previously only *implicitly* inside another annotation's range with no content describing it. The new annotation documents the `obtain ⟨m, rfl⟩` reindexing idiom (via `Nat.succ_pred_eq_of_pos`) that eliminates truncated ℕ subtraction and reduces the goal to `omega_log_concave m` — a reusable formalization pattern.

## Quality
- Annotations: 4 → 5, each with `mathContext`, `significance`, `relatedConcepts` (type/significance vocabulary matches the file's existing convention)
- meta.json **unchanged** — already at its quality ceiling (5 keyInsights, full conclusion with 3 open questions, 4 references, 2 crossReferences, mainTheorems, sections with mathContext), 12.3 KB, under the 60 KB cap
- No axiom/status changes: remains `verified` / `original` (0 axioms, 0 sorries); non-strict log-concavity correctly scoped (strict form noted as open, blocked on Mathlib's non-strict Hölder bound)
- JSON validated; annotation range within the file