### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-02-oq-02): gallery entry for verified multinomial covariance

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-mcov-header",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-02",
+    "range": { "startLine": 2, "endLine": 44 },
+    "type": "concept",
+    "title": "Goal: the off-diagonal multinomial covariance",
+    "content": "For (X₁,…,X_k) ~ Multinomial(n, p₁,…,p_k) and i≠j, the covariance Cov(Xᵢ,Xⱼ) = −n·pᵢ·pⱼ is negative: the components compete for the fixed total n, so an excess in one coordinate depresses the others. This answers the second open question of the parent (BinomialTheoremOQ02OQ01OQ02, 'marginals are binomial'). The whole file stays inside the parent's self-contained combinatorial framework — explicit PMF values multinomialProb over s.piAntidiag n and expectations written as finite sums E[f(X)] = ∑_k multinomialProb·f(k) — deliberately avoiding Mathlib's measure-theoretic ProbabilityTheory.covariance. Moments are extracted by differentiating probability generating functions rather than by a k↦k−eᵢ−eⱼ reindexing bijection.",
+    "mathContext": "$\\mathrm{Cov}(X_i,X_j) = E[X_iX_j] - E[X_i]E[X_j] = -n\\,p_i p_j$ for $i\\neq j$.",
+    "significance": "key",
+    "relatedConcepts": ["multinomial distribution", "covariance matrix", "probability generating function", "moments"],
+    "prerequisites": ["the multinomial distribution", "covariance", "probability generating functions"]
+  },
+  {
+    "id": "ann-mcov-pairpgf",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-02",
+    "range": { "startLine": 59, "endLine": 111 },
+    "type": "theorem",
+    "title": "Pair PGF: the two-variable joint generating function",
+    "content": "multinomial_pair_pgf proves ∑_k P(X=k)·x^{kᵢ}·y^{kⱼ} = (pᵢx + pⱼy + (1−pᵢ−pⱼ))ⁿ. It is the parent's MGF collapse specialised to the test function g(a) = x if a=i, y if a=j, 1 otherwise. Two telescoping lemmas do the work: the product collapse ∏_{a∈s} g(a)^{k a} = x^{kᵢ}·y^{kⱼ} (via Finset.prod_subset restricting to {i,j} then Finset.prod_pair, since g≡1 off {i,j}), and the base-sum collapse ∑_{a∈s} p(a)·g(a) = pᵢx + pⱼy + (1−pᵢ−pⱼ) (via rewriting each summand as p(a) + indicator corrections and Finset.sum_ite_eq'). Feeding both into multinomial_mgf_real gives the trinomial power.",
+    "mathContext": "$\\sum_k P(X=k)\\,x^{k_i}y^{k_j} = (p_i x + p_j y + (1-p_i-p_j))^n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["multinomial_mgf_real", "Finset.prod_subset", "Finset.prod_pair", "Finset.sum_ite_eq'"],
+    "prerequisites": ["generating functions", "Finset product/sum manipulation"]
+  },
+  {
+    "id": "ann-mcov-mean",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-02",
+    "range": { "startLine": 115, "endLine": 143 },
+    "type": "theorem",
+    "title": "Mean E[Xᵢ] = n·pᵢ by differentiating the marginal PGF",
+    "content": "multinomial_mean gets E[Xᵢ] = ∑_k P(X=k)·kᵢ = n·pᵢ. The parent's multinomial_marginal_pgf gives the identity of functions ∑_k P(X=k)·t^{kᵢ} = (pᵢt + (1−pᵢ))ⁿ for all t. Differentiating the left side term-by-term (HasDerivAt.sum with hasDerivAt_pow) produces ∑_k P(X=k)·kᵢ·t^{kᵢ−1}, which at t=1 is the mean; differentiating the right side (HasDerivAt.pow of the affine base) gives n·(pᵢ·1+(1−pᵢ))^{n−1}·pᵢ = n·pᵢ. HasDerivAt.unique equates the two derivatives at t=1.",
+    "mathContext": "$\\frac{d}{dt}\\Big|_{t=1}(p_i t + (1-p_i))^n = n\\,p_i = E[X_i]$.",
+    "significance": "key",
+    "relatedConcepts": ["multinomial_marginal_pgf", "HasDerivAt.sum", "HasDerivAt.pow", "HasDerivAt.unique", "first moment"],
+    "prerequisites": ["differentiation of power series", "the marginal PGF"]
+  },
+  {
+    "id": "ann-mcov-mixed",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-02",
+    "range": { "startLine": 147, "endLine": 221 },
+    "type": "theorem",
+    "title": "Mixed second moment E[XᵢXⱼ] = n(n−1)·pᵢpⱼ via two differentiations",
+    "content": "multinomial_mixed_moment is the technical heart. Stage 1 differentiates the pair PGF in y at y=1 with x held as a parameter, giving a whole family of identities ∑_k P(X=k)·x^{kᵢ}·kⱼ = n·(pᵢx+(1−pᵢ))^{n−1}·pⱼ (one per x). Stage 2 differentiates that identity in x at x=1, giving ∑_k P(X=k)·kᵢ·kⱼ = n(n−1)·pᵢpⱼ. Each stage is HasDerivAt.sum term-by-term on the finite sum against HasDerivAt.pow / const_mul / mul_const on the analytic closed form, closed by HasDerivAt.unique. A final n=0 / n=succ m case split reconciles the Nat cast ((n−1:ℕ):ℝ) that the second derivative produces with the real (n:ℝ)−1.",
+    "mathContext": "$\\partial_x\\partial_y\\big|_{x=y=1}(p_i x + p_j y + (1-p_i-p_j))^n = n(n-1)p_i p_j = E[X_iX_j]$.",
+    "significance": "key",
+    "relatedConcepts": ["factorial moments", "HasDerivAt.sum", "HasDerivAt.pow", "iterated differentiation", "Nat cast"],
+    "prerequisites": ["partial differentiation", "the pair PGF", "casting ℕ to ℝ"]
+  },
+  {
+    "id": "ann-mcov-headline",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-02",
+    "range": { "startLine": 225, "endLine": 240 },
+    "type": "theorem",
+    "title": "Headline: Cov(Xᵢ,Xⱼ) = −n·pᵢ·pⱼ",
+    "content": "multinomial_covariance combines the two moments through the definition Cov = E[XᵢXⱼ] − E[Xᵢ]·E[Xⱼ]. Substituting the mixed moment n(n−1)pᵢpⱼ and two copies of the mean npᵢ, npⱼ, the goal reduces to the ring identity n(n−1)pᵢpⱼ − (npᵢ)(npⱼ) = −n·pᵢpⱼ, closed by ring. The negative sign quantifies the trade-off imposed by the constraint ∑ᵢXᵢ = n.",
+    "mathContext": "$n(n-1)p_ip_j - (np_i)(np_j) = -n\\,p_ip_j$.",
+    "significance": "key",
+    "relatedConcepts": ["covariance", "ring", "negative dependence", "constraint ∑Xᵢ=n"],
+    "prerequisites": ["the mean and mixed-moment lemmas", "definition of covariance"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "binomial-theorem-oq-02-oq-01-oq-02-oq-02",
+  "title": "Multinomial Covariance: Cov(Xᵢ, Xⱼ) = −n·pᵢ·pⱼ",
+  "slug": "binomial-theorem-oq-02-oq-01-oq-02-oq-02",
+  "description": "Proves the off-diagonal entries of the multinomial covariance matrix: for a Multinomial(n, p₁,…,p_k) vector and i≠j, Cov(Xᵢ,Xⱼ) = −n·pᵢ·pⱼ. The covariance is negative because the components compete for the fixed total n — an excess in one coordinate depresses the others. This answers the parent entry's second open question, using the PGF/differentiation route rather than a reindexing bijection.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ02OQ02.lean",
+    "tags": [
+      "probability",
+      "multinomial distribution",
+      "covariance",
+      "generating functions",
+      "moments",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 242,
+    "assumptions": "None. All 4 theorems are fully machine-checked with 0 sorries; the proof uses only differentiation (HasDerivAt) and finite-sum algebra, so #print axioms reports only propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool).",
+    "theoremCount": 4,
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The multinomial covariance structure Cov(Xᵢ,Xⱼ) = −n·pᵢ·pⱼ (i≠j) and Var(Xᵢ) = n·pᵢ·(1−pᵢ) is a classical result in probability, known implicitly since Laplace and stated in every mathematical-statistics text. The negativity of the off-diagonal terms — the defining feature of the multinomial as opposed to independent binomials — reflects the linear constraint ∑ᵢXᵢ = n: fixing the total forces the coordinates to trade off against one another. The covariance matrix n·(diag(p) − p·pᵀ) is singular precisely because of this constraint, and its off-diagonal negativity underlies the χ² goodness-of-fit statistic and the asymptotic normality of multinomial cell counts.",
+    "problemStatement": "If (X₁,…,X_k) ~ Multinomial(n, p₁,…,p_k), what is the covariance Cov(Xᵢ,Xⱼ) between two distinct coordinates? Can it be derived from the parent's marginal-is-binomial framework by differentiating generating functions, avoiding an explicit combinatorial reindexing bijection?",
+    "text": "Proves multinomial_covariance: for i≠j, E[XᵢXⱼ] − E[Xᵢ]·E[Xⱼ] = −n·pᵢ·pⱼ, working entirely in the parent's self-contained combinatorial setup (explicit PMF values over s.piAntidiag n, expectations as finite sums), with no measure-theoretic ProbabilityTheory.covariance. The two moments feeding the covariance — the mean E[Xᵢ]=n·pᵢ and the mixed second moment E[XᵢXⱼ]=n(n−1)·pᵢpⱼ — are extracted by differentiating probability generating functions.",
+    "proofStrategy": "Rather than the finicky k ↦ k−eᵢ−eⱼ reindexing bijection, extract moments by differentiating PGFs, reusing the parent's multinomial_mgf_real engine. (1) multinomial_pair_pgf establishes the two-variable joint PGF E[x^{Xᵢ}·y^{Xⱼ}] = (pᵢx + pⱼy + (1−pᵢ−pⱼ))ⁿ, obtained by specialising the parent's MGF collapse to the test function that is x at i, y at j, and 1 elsewhere. (2) multinomial_mean differentiates the parent's single-coordinate marginal PGF (pᵢt + (1−pᵢ))ⁿ once at t=1 to get E[Xᵢ]=n·pᵢ. (3) multinomial_mixed_moment differentiates the pair PGF once in y (giving an intermediate identity parametrised by x) and then once in x, both at 1, to get E[XᵢXⱼ]=n(n−1)·pᵢpⱼ. (4) multinomial_covariance is then pure algebra: n(n−1)pᵢpⱼ − (npᵢ)(npⱼ) = −n·pᵢpⱼ. Each differentiation is HasDerivAt.sum term-by-term over the finite sum, HasDerivAt.pow / chain rule on the power tower, and HasDerivAt.unique to equate the analytic and combinatorial sides.",
+    "keyInsights": [
+      "The PGF/differentiation route sidesteps the k ↦ k−eᵢ−eⱼ reindexing bijection that a direct combinatorial computation of E[XᵢXⱼ] would require: moments fall out as derivatives of the joint generating function evaluated at 1.",
+      "The joint pair PGF (pᵢx + pⱼy + (1−pᵢ−pⱼ))ⁿ is just the parent's marginal-MGF collapse one level up — the test function 'x at i, y at j, 1 elsewhere' makes the product ∏ g(a)^{k a} telescope to x^{kᵢ}·y^{kⱼ} and the base sum ∑ p(a)·g(a) telescope to pᵢx + pⱼy + (1−pᵢ−pⱼ).",
+      "The mixed second moment needs two sequential differentiations of a two-variable function: first in y (with x held as a parameter, yielding a one-parameter family of identities), then in x. HasDerivAt.unique pins the combinatorial sum to the closed form at each stage.",
+      "The (n−1) factor in E[XᵢXⱼ]=n(n−1)pᵢpⱼ tracks the Nat-to-Real cast carefully: the derivative of tⁿ contributes n·tⁿ⁻¹, and the second differentiation contributes the (n−1) via (n−1 : ℕ) cast to ℝ, reconciled with (n:ℝ)−1 by a n=0 / n=succ m case split.",
+      "The negative sign is the whole point: Cov = n(n−1)pᵢpⱼ − n²pᵢpⱼ = −n·pᵢpⱼ < 0, quantifying the competition among coordinates forced by the constraint ∑ᵢXᵢ = n."
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Module Overview and Proof Strategy",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "States the result Cov(Xᵢ,Xⱼ)=−n·pᵢpⱼ, the inherited combinatorial (non-measure-theoretic) framework from the parent, and the PGF/differentiation strategy: pair PGF → mean → mixed moment → covariance. Notes the choice to keep the explicit E[XY]−E[X]E[Y] difference rather than Mathlib's ProbabilityTheory.covariance, matching the parent's self-contained setup."
+    },
+    {
+      "id": "pair-pgf",
+      "title": "Joint PGF of a Pair of Coordinates",
+      "startLine": 57,
+      "endLine": 111,
+      "summary": "multinomial_pair_pgf: ∑_k P(X=k)·x^{kᵢ}·y^{kⱼ} = (pᵢx + pⱼy + (1−pᵢ−pⱼ))ⁿ. Proved by applying the parent's multinomial_mgf_real to the test function g = (x at i, y at j, 1 elsewhere); a product-collapse lemma (Finset.prod_subset + Finset.prod_pair) telescopes ∏ g(a)^{k a} to x^{kᵢ}·y^{kⱼ}, and a base-sum-collapse lemma (Finset.sum_ite_eq') telescopes ∑ p(a)·g(a) to pᵢx + pⱼy + (1−pᵢ−pⱼ)."
+    },
+    {
+      "id": "mean",
+      "title": "First Moment (Mean) of a Single Coordinate",
+      "startLine": 113,
+      "endLine": 143,
+      "summary": "multinomial_mean: E[Xᵢ] = ∑_k P(X=k)·kᵢ = n·pᵢ. The parent's multinomial_marginal_pgf gives ∑_k P(X=k)·t^{kᵢ} = (pᵢt + (1−pᵢ))ⁿ for all t; both sides are differentiated at t=1 (left side via HasDerivAt.sum + hasDerivAt_pow, right side via HasDerivAt.pow) and equated with HasDerivAt.unique, yielding n·pᵢ."
+    },
+    {
+      "id": "mixed-moment",
+      "title": "Mixed Second Moment",
+      "startLine": 145,
+      "endLine": 221,
+      "summary": "multinomial_mixed_moment: E[XᵢXⱼ] = ∑_k P(X=k)·kᵢ·kⱼ = n(n−1)·pᵢpⱼ for i≠j. Stage 1 differentiates the pair PGF in y at y=1 (x a parameter) to get the intermediate identity ∑_k P(X=k)·x^{kᵢ}·kⱼ = n·(pᵢx+(1−pᵢ))^{n−1}·pⱼ; Stage 2 differentiates that in x at x=1 to get n(n−1)pᵢpⱼ. A n=0 / n=succ m case split reconciles the (n−1:ℕ) cast with (n:ℝ)−1."
+    },
+    {
+      "id": "covariance",
+      "title": "Headline: Off-Diagonal Covariance",
+      "startLine": 223,
+      "endLine": 242,
+      "summary": "multinomial_covariance: E[XᵢXⱼ] − E[Xᵢ]·E[Xⱼ] = −n·pᵢ·pⱼ. Immediate from the mixed moment and the mean via the algebra n(n−1)pᵢpⱼ − (npᵢ)(npⱼ) = −n·pᵢpⱼ (closed by ring)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The headline multinomial_covariance proves Cov(Xᵢ,Xⱼ) = −n·pᵢ·pⱼ for i≠j, built from the mean E[Xᵢ]=n·pᵢ and the mixed second moment E[XᵢXⱼ]=n(n−1)·pᵢpⱼ, both extracted by differentiating probability generating functions rather than by combinatorial reindexing. All 4 theorems are machine-verified with 0 sorries in the parent's self-contained combinatorial framework, depending only on the foundational axioms (propext, Classical.choice, Quot.sound).",
+    "implications": "Together with the diagonal Var(Xᵢ)=n·pᵢ(1−pᵢ), the negative off-diagonal covariance completes the multinomial covariance matrix n·(diag(p)−p·pᵀ), whose singularity encodes the constraint ∑ᵢXᵢ=n. This is the input to the χ² goodness-of-fit test, to confidence ellipsoids for multinomial proportions, and to the multivariate CLT for cell counts. The differentiation-of-PGF technique demonstrated here — extracting factorial moments as derivatives at 1 — is the general moment-generating method for any distribution with a tractable PGF.",
+    "openQuestions": [
+      "Assemble the full covariance matrix statement: package the diagonal Var(Xᵢ)=n·pᵢ(1−pᵢ) and this off-diagonal Cov(Xᵢ,Xⱼ)=−n·pᵢpⱼ into a single k×k matrix identity Σ = n·(diag(p) − p·pᵀ), and prove it is positive-semidefinite of rank k−1 (singular along the all-ones vector).",
+      "Bridge to Mathlib's measure-theoretic ProbabilityTheory.covariance: exhibit the multinomial as a genuine measure on (Fin k → ℕ) and show the combinatorial E[XᵢXⱼ]−E[Xᵢ]E[Xⱼ] here agrees with the integral definition.",
+      "Derive the covariance as the n-fold sum of single-trial (categorical) covariances via independence of trials, giving a second, additive-decomposition proof that complements the generating-function route."
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/BinomialTheoremOQ02OQ01OQ02OQ02.lean",
+    "theorems": [
+      "multinomial_pair_pgf",
+      "multinomial_mean",
+      "multinomial_mixed_moment",
+      "multinomial_covariance"
+    ],
+    "lineCount": 242,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Proves each marginal of a multinomial is binomial; its second open question asks exactly for this covariance formula, and this file reuses its multinomial_mgf_real and multinomial_marginal_pgf engines."
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-02-oq-03",
+      "relationship": "sibling",
+      "description": "The parent's third open question — the Poisson limit theorem (multinomial → independent Poissons). Complements this covariance result: asymptotic independence in the rare-event regime versus the exact negative dependence quantified here."
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-01-oq-04",
+      "relationship": "related",
+      "description": "The full multinomial covariance matrix (variance plus diagonal); this entry supplies the off-diagonal entries via the generating-function route."
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01",
+      "relationship": "related",
+      "description": "The multinomial MGF/PGF framework on which the pair PGF used here is based."
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "W. Feller",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. 1",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Multinomial distribution, its moments, and the covariance structure Cov(Xᵢ,Xⱼ)=−n·pᵢpⱼ."
+    },
+    {
+      "authors": "N. L. Johnson, S. Kotz, N. Balakrishnan",
+      "title": "Discrete Multivariate Distributions",
+      "year": 1997,
+      "venue": "Wiley",
+      "note": "The multinomial covariance matrix n·(diag(p)−p·pᵀ) and its singularity."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.multinomial, Finset.piAntidiag, and the HasDerivAt differentiation API underlying the moment extraction."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The multinomial covariance proof `Cov(Xᵢ,Xⱼ) = −n·pᵢ·pⱼ` (`BinomialTheoremOQ02OQ01OQ02OQ02.lean`, 4 theorems / 242 lines, **verified, 0-axiom**) was merged in #32516 **without any gallery data** — so the verified result is currently invisible in the web gallery (no `meta.json`, no annotations, renders as *proof not found*).

This PR adds the missing gallery entry **only** — no Lean changes:
- `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-02/meta.json`
- `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-02/annotations.json` (5 annotations)

## The result

For `(X₁,…,X_k) ~ Multinomial(n, p₁,…,p_k)` and `i≠j`, the off-diagonal covariance is **negative** — the coordinates compete for the fixed total `n`. Answers the parent entry's 2nd open question. Proof route (PGF / differentiation, no reindexing bijection):

1. `multinomial_pair_pgf` — joint PGF `(pᵢx + pⱼy + (1−pᵢ−pⱼ))ⁿ`
2. `multinomial_mean` — `E[Xᵢ] = n·pᵢ` (differentiate marginal PGF at 1)
3. `multinomial_mixed_moment` — `E[XᵢXⱼ] = n(n−1)·pᵢpⱼ` (two differentiations of the pair PGF)
4. `multinomial_covariance` — `n(n−1)pᵢpⱼ − (npᵢ)(npⱼ) = −n·pᵢpⱼ`

## Verification

Gallery JSON validated with Python; theorem list, `proofId`, and `significance` enum cross-checked against the merged Lean source. Line ranges in sections/annotations map to the actual file. No `native_decide`; `#print axioms` reports only the foundational three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)