### PR TITLE
Enrich Γ(1/2)=√π (area-of-circle-oq-07-oq-03): add missing index.ts + setup annotation

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "imports-and-framing",
+    "proofId": "area-of-circle-oq-07-oq-03",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "Setup: One Import Carries Both Γ(1/2) and the Gaussian",
+    "content": "The single mathematical import is `Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral` — deliberately, because that one module supplies *both* halves of the bridge this entry builds: the Gamma special value `Real.Gamma_one_half_eq` and the parametrized Gaussian integrals `integral_gaussian` / `integral_gaussian_Ioi`. That they live in the same file is itself the point: Mathlib proves `Γ(1/2) = √π` precisely by reducing it, via the substitution `u = x²`, to the Gaussian. Opening `Real` lets `Gamma`, `sqrt`, `exp`, and `pi` appear unqualified; opening `MeasureTheory` brings the Bochner integral `∫` and `Set.Ioi` into scope. The docstring records the open question (oq-03) and its affirmative answer, framing the four theorems that follow as explicit bridges rather than new mathematics.",
+    "mathContext": "$\\Gamma(s) = \\int_0^\\infty u^{s-1}e^{-u}\\,du$; the substitution $u = x^2$ sends $\\Gamma(1/2)$ to $2\\int_0^\\infty e^{-x^2}\\,dx = \\int_{\\mathbb{R}} e^{-x^2}\\,dx$.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib imports", "Gaussian integral module", "Gamma-Gaussian bridge"],
+    "prerequisites": ["Lean 4", "Mathlib", "Bochner integral"]
+  },
+  {
     "id": "special-value",
     "proofId": "area-of-circle-oq-07-oq-03",
     "range": { "startLine": 35, "endLine": 37 },

--- a/src/data/proofs/area-of-circle-oq-07-oq-03/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOQ07OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOQ07OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOQ07OQ03Data: ProofData = {
+  proof: areaOfCircleOQ07OQ03Proof,
+  annotations: areaOfCircleOQ07OQ03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-03`.

## Critical fix
- **Created `index.ts`** — the Vite entry point was missing, so `import.meta.glob` could not discover the proof and the page rendered **'proof not found'** on the live site despite appearing in the gallery listing.

## Coverage
- Added an `imports-and-framing` context annotation for lines 1–33 (previously uncovered). It explains that the single `Mathlib.…Gaussian.GaussianIntegral` import supplies *both* halves of the entry's bridge — the Gamma special value `Real.Gamma_one_half_eq` and the parametrized Gaussians `integral_gaussian`/`integral_gaussian_Ioi` — which is itself the mathematical point (Mathlib proves Γ(1/2)=√π via the `u=x²` substitution onto the Gaussian).
- Annotations now cover the full 62-line file (4 → 5), all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

meta.json already well-developed (11.8 KB, under cap); left unchanged. JSON validated.