### PR TITLE
Enrich Normal-Distribution Normalization Family (area-of-circle-oq-05-incomplete-01): add missing index.ts

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "aoc05inc-ann-00",
+    "proofId": "area-of-circle-oq-05-incomplete-01",
+    "range": { "startLine": 27, "endLine": 38 },
+    "type": "context",
+    "title": "Setup: one Gaussian import and the normalization constant √(2π)",
+    "content": "The whole family is built from a single mathematical import, `Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral`, which supplies `integral_gaussian : ∫ e^{-b·x²} = √(π/b)`. Every theorem below is a specialization of this one lemma at a different rate `b`: `b = 1` gives √π, `b = 1/2` gives √(2π), `b = 1/(2σ²)` gives σ√(2π). Opening `Real` and `MeasureTheory` lets `exp`, `sqrt`, `π`, and the Bochner integral `∫` appear unqualified. The helper `sqrt_two_pi_pos : 0 < √(2π)` is proved by `positivity`; it is the nonvanishing side condition that makes the reciprocals `1/√(2π)` and `1/(σ√(2π))` legitimate when the normalization theorems cancel them against the integral value.",
+    "mathContext": "$\\int_{\\mathbb R} e^{-b x^2}\\,dx = \\sqrt{\\pi/b}$; the constant $\\sqrt{2\\pi} > 0$ normalizes the density.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib imports", "integral_gaussian", "positivity", "normalization constant"],
+    "prerequisites": ["Lean 4", "Mathlib", "Bochner integral"]
+  },
+  {
     "id": "aoc05inc-ann-01",
     "proofId": "area-of-circle-oq-05-incomplete-01",
     "range": { "startLine": 39, "endLine": 51 },

--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01/index.ts
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ05Incomplete01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOQ05Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOQ05Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOQ05Incomplete01Data: ProofData = {
+  proof: areaOfCircleOQ05Incomplete01Proof,
+  annotations: areaOfCircleOQ05Incomplete01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-05-incomplete-01`.

## Critical fix
- **Created `index.ts`** — the Vite entry point was missing, so `import.meta.glob` could not discover the proof and the page rendered **'proof not found'** on the live site despite appearing in the gallery listing.

## Coverage
- Added a `setup` context annotation for lines 27–38 (imports/opens/namespace and the `sqrt_two_pi_pos` positivity helper), previously uncovered. It makes explicit that the entire normalization family is a single `integral_gaussian` lemma specialized at rates `b = 1, 1/2, 1/(2σ²)`, and that `√(2π) > 0` is the side condition legitimizing the reciprocal normalizers.
- Annotations now include the setup block (5 → 6); all carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

meta.json already well-developed (12.3 KB, under cap); left unchanged. JSON validated.