### PR TITLE
Enrich Even Unit-Ball Volume Stirling Asymptotic: fix duplicate references key

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -67,38 +67,6 @@
     "theoremCount": 5,
     "definitionCount": 1
   },
-  "references": [
-    {
-      "authors": "Smith, David J. and Vamanamurthy, Mavina K.",
-      "title": "How Small Is a Unit Ball?",
-      "year": "1989",
-      "venue": "Mathematics Magazine 62(2), 101–107"
-    },
-    {
-      "authors": "Artin, Emil",
-      "title": "The Gamma Function",
-      "year": "1964",
-      "venue": "Holt, Rinehart and Winston (English translation by Michael Butler)"
-    },
-    {
-      "authors": "Robbins, Herbert",
-      "title": "A Remark on Stirling's Formula",
-      "year": "1955",
-      "venue": "American Mathematical Monthly 62(1), 26–29"
-    },
-    {
-      "authors": "The mathlib Community",
-      "title": "Stirling.lean — n! ~ √(2πn)(n/e)^n; Real.Gamma and Real.rpow",
-      "year": "2024",
-      "venue": "Mathlib4 (leanprover-community/mathlib4)"
-    },
-    {
-      "authors": "Ball, Keith",
-      "title": "An Elementary Introduction to Modern Convex Geometry",
-      "year": "1997",
-      "venue": "Flavors of Geometry, MSRI Publications 31, Cambridge University Press, 1–58"
-    }
-  ],
   "overview": {
     "historicalContext": "The unit n-ball volume ω_n = π^(n/2)/Γ(n/2+1) shrinks to 0 in high dimensions — the 'curse of dimensionality'. The ancestor entry proved only ω_n → 0. The sharper question is the exact rate. Stirling's formula resolves it: ω_n decays super-exponentially like (2πe/n)^(n/2) with a polynomial prefactor 1/√(πn). This file pins the exact even-subsequence asymptotic rigorously from Mathlib's Stirling lemma.",
     "problemStatement": "**Question** (as posed): prove ω_n ~ √(2π/n)·(2πe/n)^(n/2) from Stirling.\n\n**Result**: For the even subsequence, ω_{2k} ~[atTop] (πe/k)^k/√(2πk). Equivalently, in terms of n = 2k, ω_n ~ (2πe/n)^(n/2)/√(πn). The correct universal constant is 1/√(πn); the posed √(2π/n) is off by a factor √2·π.",
@@ -178,6 +146,18 @@
       "note": "Growth-then-decay of unit n-ball volume, the n=5 maximum, and monotonicity/shape properties."
     },
     {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston (English translation by Michael Butler)"
+    },
+    {
+      "authors": "Ball, Keith",
+      "title": "An Elementary Introduction to Modern Convex Geometry",
+      "year": "1997",
+      "venue": "Flavors of Geometry, MSRI Publications 31, Cambridge University Press, 1–58"
+    },
+    {
       "authors": "Folland, Gerald B.",
       "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
       "year": "1999",
@@ -186,9 +166,9 @@
     },
     {
       "authors": "The mathlib Community",
-      "title": "Real.Gamma, EuclideanSpace.volume_ball, and Stirling's formula (Mathlib.Analysis.SpecialFunctions.Gamma / .Stirling)",
+      "title": "Real.Gamma, EuclideanSpace.volume_ball, and Stirling's formula; n! ~ √(2πn)(n/e)^n (Mathlib.Analysis.SpecialFunctions.Gamma / .Stirling)",
       "year": "2024",
-      "venue": "Mathlib4"
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02` (pass 0, quality 91).

## Fix
`meta.json` contained **two top-level `references` arrays**. In JSON a duplicate object key is resolved to the last occurrence, so the first array was silently discarded — dropping two legitimate citations:
- Artin, *The Gamma Function* (1964)
- Ball, *An Elementary Introduction to Modern Convex Geometry* (1997)

Merged both arrays into a single deduplicated 6-reference list (Robbins, Smith–Vamanamurthy, Artin, Ball, Folland, Mathlib), preserving all sources and their notes.

The annotations and overview already met quality targets (6 valid-enum annotations with mathContext, 4 keyInsights, full conclusion), so no changes there. JSON validated (no duplicate keys, parses cleanly).