### PR TITLE
Enrich n-Dimensional Gaussian Integral (area-of-circle-oq-07-oq-04-oq-01-oq-01): add missing index.ts

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-aoc07oq040101-imports",
+    "proofId": "area-of-circle-oq-07-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 3
+    },
+    "type": "context",
+    "title": "The Non-Obvious Import: Product-Measure Fubini",
+    "content": "Three imports carry the proof. `Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral` supplies the one-dimensional closed form `integral_gaussian : ∫_ℝ e^{-b x²} = √(π/b)`. The load-bearing but non-obvious one is `Mathlib.MeasureTheory.Integral.Pi`, which provides `integral_fintype_prod_volume_eq_pow` — the lemma stating that the integral of a product `∏ᵢ f(xᵢ)` over `Fin n → ℝ` (with the product Lebesgue measure) equals `(∫ f)^{card}`. That single lemma is the `n`-dimensional Fubini engine; without it the separable-integrand argument could not collapse to a power. `Mathlib.Tactic` brings `ring`, `positivity`, and `simp`.",
+    "mathContext": "$\\int_{\\mathbb R^n} \\prod_{i=1}^n f(x_i)\\,dx = \\left(\\int_{\\mathbb R} f\\right)^n$ — Fubini/Tonelli for the product measure on $\\mathbb R^n = \\mathrm{Fin}\\,n \\to \\mathbb R$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "product Lebesgue measure",
+      "integral_fintype_prod_volume_eq_pow",
+      "Fubini-Tonelli",
+      "Mathlib imports"
+    ],
+    "prerequisites": [
+      "Lean 4",
+      "Mathlib",
+      "product measures"
+    ]
+  },
+  {
     "id": "ann-aoc07oq040101-context",
     "proofId": "area-of-circle-oq-07-oq-04-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ04OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOQ07OQ04OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOQ07OQ04OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOQ07OQ04OQ01OQ01Data: ProofData = {
+  proof: areaOfCircleOQ07OQ04OQ01OQ01Proof,
+  annotations: areaOfCircleOQ07OQ04OQ01OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-04-oq-01-oq-01`.

## Critical fix
- **Created `index.ts`** — the Vite entry point was missing, so `import.meta.glob` could not discover the proof and the page rendered **'proof not found'** on the live site despite appearing in the gallery listing.

## Coverage
- Added an imports context annotation (lines 1–3, previously uncovered) highlighting the load-bearing `Mathlib.MeasureTheory.Integral.Pi` import that provides `integral_fintype_prod_volume_eq_pow` — the product-measure Fubini lemma that is the `n`-dimensional engine of the proof.
- Annotations now 4 → 5, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

meta.json already well-developed (13.7 KB, under cap); left unchanged. JSON validated.