### PR TITLE
Enrich Scaled Even Moment of the Gaussian (area-of-circle-oq-07-oq-05-oq-01-oq-02): add missing index.ts

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/annotations.json
@@ -1,5 +1,26 @@
 [
   {
+    "id": "aoc-oq07050102-ann-imports",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 3 },
+    "type": "context",
+    "title": "Imports: Reusing the Parent Moment and the Dilation Rule",
+    "content": "The two substantive imports mirror the proof's two-ingredient strategy. `import Proofs.AreaOfCircleOQ07OQ05OQ01` pulls in the *parent gallery entry* itself — this file depends on the parent's Lean theorem, not just its statement, so the unscaled even moment ∫ x^{2n} e^{−x²} = (2n−1)‼·√π/2ⁿ is available as a lemma to be rescaled rather than re-proved. `import Mathlib.MeasureTheory.Measure.Haar.NormedSpace` supplies the linear dilation rule `integral_comp_mul_left : ∫ g(s·x) dx = |s⁻¹|·∫ g` for the Lebesgue integral, the single analytic fact that transports the parent value across all scales a > 0. `open scoped Nat` brings the double-factorial notation `(2n−1)‼` into scope.",
+    "mathContext": "Change of variables $y = s x$ (with $s=\\sqrt a$): $\\int g(sx)\\,dx = |s^{-1}|\\int g(y)\\,dy$ — Mathlib's `integral_comp_mul_left`.",
+    "significance": "context",
+    "relatedConcepts": [
+      "gallery-internal dependency",
+      "integral_comp_mul_left",
+      "linear change of variables",
+      "double factorial notation"
+    ],
+    "prerequisites": [
+      "Lean 4",
+      "Mathlib",
+      "parent entry area-of-circle-oq-07-oq-05-oq-01"
+    ]
+  },
+  {
     "id": "aoc-oq07050102-ann-header",
     "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
     "range": { "startLine": 5, "endLine": 37 },

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ05OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOQ07OQ05OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOQ07OQ05OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOQ07OQ05OQ01OQ02Data: ProofData = {
+  proof: areaOfCircleOQ07OQ05OQ01OQ02Proof,
+  annotations: areaOfCircleOQ07OQ05OQ01OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-05-oq-01-oq-02`.

## Critical fix
- **Created `index.ts`** — the Vite entry point was missing, so `import.meta.glob` could not discover the proof and the page rendered **'proof not found'** on the live site despite appearing in the gallery listing.

## Coverage
- Added an imports context annotation (lines 1–3, previously uncovered) explaining the proof's two-ingredient strategy at the import level: the gallery-internal `import Proofs.AreaOfCircleOQ07OQ05OQ01` reuses the parent's unscaled-moment *theorem* (not just its statement), and `Mathlib.MeasureTheory.Measure.Haar.NormedSpace` supplies the dilation rule `integral_comp_mul_left` that rescales it across all `a > 0`.
- Annotations now 4 → 5, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

meta.json already well-developed (13.6 KB, under cap); left unchanged. JSON validated.