### PR TITLE
Enrich The Wilf-Zeilberger Method (arithmetic-series-oq-02-oq-02-oq-03-oq-04): add missing index.ts

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "wz-ann-overview",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-04",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "concept",
+    "title": "What the WZ Method Is, and What This File Proves",
+    "content": "The Wilf–Zeilberger method turns a summation identity ∑ₖ F(n,k) = RHS(n) into a mechanical certificate check. First normalize to ∑ₖ F(n,k) = 1 (divide by the RHS); then exhibit a companion G(n,k) — the *WZ mate*, built from a rational *certificate* R(n,k) as G = R·F — satisfying the WZ equation F(n+1,k) − F(n,k) = G(n,k+1) − G(n,k). Summing that over k telescopes the right side to zero when G has finite k-support, so the row sum s(n) = ∑ₖ F(n,k) is constant, and one base case s(0) = 1 closes the identity. This file delivers two things: (1) `wz_telescope`, the abstract engine stated over any `AddCommGroup`, reusable for any WZ pair; and (2) a fully machine-checked worked example — the prototypical ∑ₖ C(n,k) = 2ⁿ with explicit mate G(n,k) = −C(n,k−1)/2ⁿ⁺¹ — deriving 2ⁿ purely from telescoping + base case, *without* Mathlib's `Nat.sum_range_choose`. The `import Mathlib` line pulls in the full library; `open Finset BigOperators` supplies `∑` and windowed `Finset.range` sums. The full parallel-Vandermonde certificate is honestly deferred; the same `wz_telescope` accepts it unchanged once supplied.",
+    "mathContext": "WZ equation: $F(n+1,k) - F(n,k) = G(n,k+1) - G(n,k)$; summing over the window telescopes to $G(n,N) - G(n,0) = 0$, forcing $s(n+1) = s(n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "creative telescoping",
+      "hypergeometric identities",
+      "WZ certificate",
+      "Petkovšek–Wilf–Zeilberger A=B",
+      "binomial theorem"
+    ],
+    "prerequisites": [
+      "finite sums (Finset.sum)",
+      "binomial coefficients",
+      "telescoping sums"
+    ]
+  },
+  {
     "id": "wz-ann-telescope-engine",
     "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-04",
     "range": { "startLine": 80, "endLine": 94 },

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/index.ts
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const arithmeticSeriesOQ02OQ02OQ03OQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const arithmeticSeriesOQ02OQ02OQ03OQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const arithmeticSeriesOQ02OQ02OQ03OQ04Data: ProofData = {
+  proof: arithmeticSeriesOQ02OQ02OQ03OQ04Proof,
+  annotations: arithmeticSeriesOQ02OQ02OQ03OQ04Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-02-oq-02-oq-03-oq-04`.

## Critical fix
- **Created `index.ts`** — the Vite entry point was missing, so `import.meta.glob` could not discover the proof and the page rendered **'proof not found'** on the live site despite appearing in the gallery listing.

## Coverage
- Added an overview context annotation covering the docstring/imports (lines 1–58, previously uncovered — the six existing annotations started at line 80). It explains the WZ method end-to-end (normalize to ∑F=1, build the WZ mate G from a certificate, telescope the WZ equation to force a constant row sum) and what the file delivers: the reusable `wz_telescope` engine plus a fully machine-checked ∑ₖ C(n,k)=2ⁿ example derived without `Nat.sum_range_choose`.
- Annotations now 6 → 7, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

meta.json already well-developed (12.1 KB, under cap); left unchanged. JSON validated.