### PR TITLE
Enrich Non-Crossing Partitions = Catalan (ballot-problem-oq-04-oq-02-oq-01): add missing index.ts

### DIFF
--- a/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/annotations.json
@@ -91,5 +91,30 @@
       "catalan_succ'",
       "Finset.mem_antidiagonal"
     ]
+  },
+  {
+    "id": "ballot-oq040201-ann-unconditional",
+    "proofId": "ballot-problem-oq-04-oq-02-oq-01",
+    "range": {
+      "startLine": 166,
+      "endLine": 200
+    },
+    "type": "insight",
+    "title": "Unconditional Verification for n ≤ 3 (Independent of the Open Bijection)",
+    "content": "nonCrossingCount_eq_catalan above is proved only *modulo* the still-open first-return bijection nonempty_firstReturnEquiv. This corollary, nonCrossingCount_eq_catalan_of_le_three, discharges nonCrossingCount n = catalan n **unconditionally** for every n ≤ 3 — assuming no bijection at all. The mechanism: for n ≤ 3 every partition of Fin n is already non-crossing (nonCrossingCount_eq_card_of_n_le_three), so the count is literally the Bell number Fintype.card (Finpartition (Fin n)), which kernel `decide` evaluates; and Bell and Catalan agree exactly up to n = 3 (1, 1, 2, 5). This is the regime *just before* the first divergence — Bell 4 = 15 > 14 = catalan 4, isolated separately as nonCrossingCount_four_lt — so the two results pin the conjecture on both sides of its first nontrivial test. `set_option maxRecDepth 8000` accommodates the deep `decide` on Finpartition cardinalities.",
+    "mathContext": "For $n \\le 3$: $\\mathrm{nonCrossingCount}\\,n = \\mathrm{Bell}\\,n = \\mathrm{catalan}\\,n$ (values $1,1,2,5$). First divergence at $n=4$: $\\mathrm{Bell}\\,4 = 15 > 14 = \\mathrm{catalan}\\,4$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bell numbers",
+      "Catalan numbers",
+      "kernel decide",
+      "interval_cases",
+      "unconditional verification"
+    ],
+    "prerequisites": [
+      "Bell vs Catalan numbers",
+      "decidable finite computation",
+      "Finpartition cardinality"
+    ]
   }
 ]

--- a/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/index.ts
+++ b/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const ballotProblemOQ04OQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const ballotProblemOQ04OQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const ballotProblemOQ04OQ02OQ01Data: ProofData = {
+  proof: ballotProblemOQ04OQ02OQ01Proof,
+  annotations: ballotProblemOQ04OQ02OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-04-oq-02-oq-01`.

## Critical fix
- **Created `index.ts`** — the Vite entry point was missing, so `import.meta.glob` could not discover the proof and the page rendered **'proof not found'** on the live site despite appearing in the gallery listing.

## Coverage
- Added an annotation for the **unconditional n ≤ 3 verification** (lines 166–200, previously uncovered). It explains `nonCrossingCount_eq_catalan_of_le_three`: for n ≤ 3 every partition is non-crossing, so the count is the Bell number evaluated by kernel `decide`, and Bell = Catalan (1,1,2,5) up to n=3 — sandwiching the (otherwise bijection-conditional) conjecture just before its first divergence, Bell 4 = 15 > 14 = catalan 4.
- Annotations now 4 → 5, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

## Axiom integrity
- Confirmed the entry honestly carries `status: formalized`, `badge: wip`, `sorries: 1` — the main theorem is proved *modulo* the open first-return bijection `nonempty_firstReturnEquiv` (the lone `sorry`). Left unchanged.

meta.json already well-developed (16.3 KB, under cap); left unchanged. JSON validated.