### PR TITLE
Enrich Stirling Asymptotic of Beta Diagonal (beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01): add missing index.ts

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,5 +1,26 @@
 [
   {
+    "id": "betadiagasymp-ann-imports",
+    "proofId": "beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 4 },
+    "type": "context",
+    "title": "Imports: Two Gallery Parents Feed This Asymptotic",
+    "content": "Beyond the blanket `import Mathlib`, this file draws on two *gallery-internal* parents, and the proof is exactly the composition of what they provide. `import Proofs.BetaIntegralRecurrenceOQ01OQ02OQ01` supplies the exact closed form of the half-integer Beta diagonal B(n+1/2, n+1/2) (a ratio of central binomial / factorial terms). `import Proofs.StirlingFormulaOQ03OQ02` supplies the Stirling asymptotic for the factorials/central binomials appearing in that closed form. The headline `IsEquivalent` result B(n+1/2,n+1/2) ~ √(π/n)·4⁻ⁿ is obtained by feeding the parent's exact value into the parent Stirling estimate — no independent analysis, only the algebra of combining the two.",
+    "mathContext": "$B(n+\\tfrac12, n+\\tfrac12) \\sim \\sqrt{\\pi/n}\\,\\cdot 4^{-n}$, obtained by substituting Stirling's asymptotic into the exact half-integer Beta closed form.",
+    "significance": "context",
+    "relatedConcepts": [
+      "gallery-internal dependency",
+      "Beta function closed form",
+      "Stirling's approximation",
+      "asymptotic equivalence"
+    ],
+    "prerequisites": [
+      "Lean 4",
+      "Mathlib",
+      "parent Beta and Stirling entries"
+    ]
+  },
+  {
     "id": "betadiagasymp-ann-header",
     "proofId": "beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BetaIntegralRecurrenceOQ01OQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const betaIntegralRecurrenceOQ01OQ02OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const betaIntegralRecurrenceOQ01OQ02OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const betaIntegralRecurrenceOQ01OQ02OQ01OQ01Data: ProofData = {
+  proof: betaIntegralRecurrenceOQ01OQ02OQ01OQ01Proof,
+  annotations: betaIntegralRecurrenceOQ01OQ02OQ01OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01`.

## Critical fix
- **Created `index.ts`** — the Vite entry point was missing, so `import.meta.glob` could not discover the proof and the page rendered **'proof not found'** on the live site despite appearing in the gallery listing.

## Coverage
- Added an imports context annotation (lines 1–4, previously uncovered) explaining that the result composes two *gallery-internal* parents: `Proofs.BetaIntegralRecurrenceOQ01OQ02OQ01` (the exact half-integer Beta closed form) and `Proofs.StirlingFormulaOQ03OQ02` (the Stirling asymptotic) — the headline `IsEquivalent` B(n+½,n+½) ~ √(π/n)·4⁻ⁿ is just their algebraic combination.
- Annotations now 4 → 5, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

meta.json already well-developed (12.6 KB, under cap); left unchanged. JSON validated.