### PR TITLE
Enrich Buffon Crossing Factor Closed Form (buffons-needle-oq-02-oq-02-oq-01-oq-01): add missing index.ts

### DIFF
--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "crossingFactor-overview",
+    "proofId": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 47 },
+    "type": "concept",
+    "title": "Solving the Crossing-Factor Recurrence in Closed Form",
+    "content": "The n-dimensional Buffon noodle formula E[crossings] = αₙ·L/d is governed by the crossing factor αₙ = E_{Sⁿ⁻¹}[|u₁|], which satisfies the two-step recurrence α_{n+2} = (n/(n+1))·αₙ with base values α₂ = 2/π, α₃ = 1/2. The parent entry proved only the *structural* behaviour of αₙ (strict two-step decrease, maximum 2/π, uniform sub-one bound) directly from the recurrence, without ever solving it. This entry *solves* the recurrence by telescoping: unfolding the ratio factors gives every even/odd dimension as its base value times a finite product — α_{2m+2} = (2/π)·∏_{j<m}(2j+2)/(2j+3) and α_{2m+3} = (1/2)·∏_{j<m}(2j+3)/(2j+4). From the closed form it re-derives positivity and the maximum 2/π, and evaluates the first higher concrete values α₄ = 4/(3π), α₆ = 16/(15π), α₅ = 3/8, α₇ = 5/16 (none computed in the parent). Fully self-contained over Mathlib: 0 sorries, 0 axioms, no native_decide.",
+    "mathContext": "$\\alpha_{n+2} = \\dfrac{n}{n+1}\\,\\alpha_n$, $\\ \\alpha_{2m+2} = \\dfrac{2}{\\pi}\\prod_{j<m}\\dfrac{2j+2}{2j+3}$, $\\ \\alpha_{2m+3} = \\dfrac12\\prod_{j<m}\\dfrac{2j+3}{2j+4}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Buffon's noodle",
+      "two-step recurrence",
+      "telescoping product",
+      "Wallis-type products",
+      "crossing factor"
+    ],
+    "prerequisites": [
+      "recurrence relations",
+      "finite products (Finset.prod)",
+      "the parent structural bounds"
+    ]
+  },
+  {
     "id": "crossingFactor-def",
     "proofId": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
     "range": { "startLine": 48, "endLine": 65 },

--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BuffonsNeedleOQ02OQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const buffonsNeedleOQ02OQ02OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const buffonsNeedleOQ02OQ02OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const buffonsNeedleOQ02OQ02OQ01OQ01Data: ProofData = {
+  proof: buffonsNeedleOQ02OQ02OQ01OQ01Proof,
+  annotations: buffonsNeedleOQ02OQ02OQ01OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `buffons-needle-oq-02-oq-02-oq-01-oq-01`.

## Critical fix
- **Created `index.ts`** — the Vite entry point was missing, so `import.meta.glob` could not discover the proof and the page rendered **'proof not found'** on the live site despite appearing in the gallery listing.

## Coverage
- Added an overview context annotation covering the docstring (lines 3–47, previously uncovered — existing annotations started at line 48). It explains the crossing factor αₙ = E_{Sⁿ⁻¹}[|u₁|], its two-step recurrence α_{n+2}=(n/(n+1))αₙ, and how this entry *solves* it into telescoping products α_{2m+2}=(2/π)∏(2j+2)/(2j+3) and α_{2m+3}=(1/2)∏(2j+3)/(2j+4), re-deriving positivity/maximum and the concrete values α₄,α₅,α₆,α₇.
- Annotations now 6 → 7, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

meta.json already well-developed (12.4 KB, under cap); left unchanged. JSON validated.