### PR TITLE
Enrich Simplicity of Aₙ 3-cycle criterion (abel-ruffini-galois-extensions-oq-03): quality 91→100

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-03/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-03/annotations.json
@@ -61,6 +61,26 @@
     ]
   },
   {
+    "id": "ann-oq03-witness-construction",
+    "proofId": "abel-ruffini-galois-extensions-oq-03",
+    "range": { "startLine": 104, "endLine": 109 },
+    "type": "tactic",
+    "title": "Manufacturing the 3-Cycle Witness Inside the Subtype",
+    "content": "The converse must exhibit an element of the *subtype* `alternatingGroup α`, not merely a permutation. The construction has three moving parts. (1) `isThreeCycle_swap_mul_swap_same ab ac bc` proves the underlying `Perm α` element `swap a b * swap a c` is a 3-cycle — this product form (two transpositions sharing the point `a`) is exactly the standard presentation of the cycle `(a c b)`, and Mathlib packages it as a lemma rather than making you compute the cycle type. (2) The subtype element is assembled as `⟨_, htc.mem_alternatingGroup⟩`: `IsThreeCycle.mem_alternatingGroup` witnesses that a 3-cycle is even (sign `+1`), which is the membership proof the anonymous constructor needs. (3) Membership in `H` is discharged by `rw [h]; exact Subgroup.mem_top _` — after rewriting `H = ⊤` everything lies in `⊤`. The pattern (build the raw object, certify it, repackage into the subtype, then land it in the target subgroup) is the reusable recipe for producing concrete elements of `alternatingGroup α`.",
+    "mathContext": "$(a\\,b)(a\\,c) = (a\\,c\\,b)$ is even, hence in $A_\\alpha$; and $A_\\alpha = \\top = H$ so it lies in $H$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IsThreeCycle.mem_alternatingGroup",
+      "swap_mul_swap as a 3-cycle presentation",
+      "subtype anonymous constructor",
+      "Subgroup.mem_top"
+    ],
+    "prerequisites": [
+      "A 3-cycle is an even permutation",
+      "Elements of a subgroup as subtype terms ⟨value, proof⟩"
+    ]
+  },
+  {
     "id": "ann-oq03-characterization",
     "proofId": "abel-ruffini-galois-extensions-oq-03",
     "range": { "startLine": 111, "endLine": 126 },

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-03/meta.json
@@ -92,7 +92,8 @@
       "**The open content is one criterion.** The classical simplicity proof has exactly one hard, combinatorial step — 'a nontrivial normal subgroup contains a 3-cycle' — while the rest (3-cycles generate, all 3-cycles are conjugate, normal closure of a 3-cycle is everything) is already in Mathlib for general $n$. The iff makes this precise: simplicity is *logically equivalent* to that one criterion, so a future general-$n$ simplicity proof needs only to supply it.",
       "**Upgrading singleton normal closure to arbitrary normal subgroups.** Mathlib computes the normal closure of a *single* 3-cycle but never states the directly useful consequence: any normal subgroup that merely *contains* a 3-cycle is the whole group. `threeCycle_normal_eq_top` is that one-line-of-mathematics, several-lines-of-Lean upgrade, and is the reusable workhorse for both the reduction and any concrete simplicity argument.",
       "**The converse is not vacuous.** That a simple $A_n$ forces every nontrivial normal subgroup to contain a 3-cycle is only interesting because 3-cycles actually exist — which needs $|\\alpha| \\ge 3$. The proof exhibits a concrete witness $(a\\,b)(a\\,c)$ rather than appealing to existence abstractly, keeping the statement constructive.",
-      "**Generality over `α`, not just `Fin n`.** Working with an arbitrary finite type with a decidable equality (rather than `Fin n`) matches Mathlib's `alternating_normalClosure` API and makes the result directly reusable for any concrete alternating group, including the `Fin 5` instance Mathlib already proves."
+      "**Generality over `α`, not just `Fin n`.** Working with an arbitrary finite type with a decidable equality (rather than `Fin n`) matches Mathlib's `alternating_normalClosure` API and makes the result directly reusable for any concrete alternating group, including the `Fin 5` instance Mathlib already proves.",
+      "**A reduction, not a simplicity proof.** The headline result is a *biconditional*, and it is unconditional: it asserts nothing about whether $A_n$ actually is simple. `isSimpleGroup_alternating_iff` is true even in a hypothetical world where the 3-cycle-containment criterion failed — both sides would simply be false together. The value is diagnostic: it certifies that the entire remaining gap between Mathlib's `Fin 5` instance and general-$n$ simplicity is *exactly* one lemma, `∀ normal H ≠ ⊥, ∃ 3-cycle ∈ H`, with no hidden side conditions. This is why the forward direction `isSimpleGroup_of_forall_normal_contains_threeCycle` is packaged separately — it is the piece a future proof plugs its combinatorial lemma into."
     ],
     "prerequisites": [
       "Mathlib.GroupTheory.SpecificGroups.Alternating (alternatingGroup, IsThreeCycle.alternating_normalClosure, isThreeCycle_isConj, nontrivial_of_three_le_card)",
@@ -120,12 +121,20 @@
       "mathContext": "Stage (i) of the classical argument: $\\langle\\!\\langle g \\rangle\\!\\rangle = A_n$ and $\\langle\\!\\langle g \\rangle\\!\\rangle \\le H$ force $H = A_n$."
     },
     {
-      "id": "reduction",
-      "title": "Simplicity reduction and its converse",
+      "id": "reduction-forward",
+      "title": "Forward reduction: the 3-cycle criterion implies simplicity",
       "startLine": 81,
+      "endLine": 93,
+      "summary": "`isSimpleGroup_of_forall_normal_contains_threeCycle`: assuming every nontrivial normal subgroup contains a 3-cycle, `IsSimpleGroup (alternatingGroup α)` follows. `nontrivial_of_three_le_card` (via `omega` from `5 ≤ card α`) supplies the `Nontrivial` field; for a normal `H` the proof case-splits on `H = ⊥` (`eq_or_ne`), and in the nontrivial branch feeds the hypothesized 3-cycle to the core lemma `threeCycle_normal_eq_top` to force `H = ⊤`.",
+      "mathContext": "The `⊥`-or-`⊤` dichotomy: `H = ⊥ ∨ (∃ 3-cycle ∈ H ⇒ H = ⊤)`. This is the direction a future general-`n` proof plugs its combinatorial lemma into."
+    },
+    {
+      "id": "reduction-converse",
+      "title": "Converse: simplicity yields an explicit 3-cycle",
+      "startLine": 95,
       "endLine": 109,
-      "summary": "`isSimpleGroup_of_forall_normal_contains_threeCycle`: the 3-cycle-containment criterion implies `IsSimpleGroup (alternatingGroup α)`, using `nontrivial_of_three_le_card` for the `Nontrivial` field and the core lemma for the `⊥`-or-`⊤` dichotomy. `forall_normal_contains_threeCycle_of_isSimpleGroup`: conversely, simplicity makes a nontrivial normal subgroup `⊤`, which contains the explicit 3-cycle `(a b)(a c)` built from three distinct points via `isThreeCycle_swap_mul_swap_same`.",
-      "mathContext": "Both implications between simplicity and the 3-cycle-containment criterion."
+      "summary": "`forall_normal_contains_threeCycle_of_isSimpleGroup`: given `[IsSimpleGroup (alternatingGroup α)]`, a nontrivial normal `H` is `⊤` by `Normal.eq_bot_or_eq_top`. Since `5 ≤ card α ⇒ 2 < card α`, `Fintype.two_lt_card_iff` extracts three distinct points `a, b, c`, and `isThreeCycle_swap_mul_swap_same` certifies `(a b)(a c)` a 3-cycle; it lies in `⊤ = H` via `mem_top`.",
+      "mathContext": "Not vacuous: the witness `(a\\,b)(a\\,c)` is built concretely from three distinct points, which exist precisely because `card α ≥ 3`."
     },
     {
       "id": "characterization",


### PR DESCRIPTION
## Enrichment pass — abel-ruffini-galois-extensions-oq-03

**Quality 91 → 100** (0 → 1 pass). All additions are grounded in the Lean source `Proofs/AbelRuffiniGaloisExtensionsOQ03.lean`; no proof, claim, or status changes.

### Changes
- **Sections 4 → 5.** Split the combined `reduction` section (lines 81–109, "Simplicity reduction and its converse") into two: `reduction-forward` (81–93, `isSimpleGroup_of_forall_normal_contains_threeCycle`) and `reduction-converse` (95–109, `forall_normal_contains_threeCycle_of_isSimpleGroup`). These are two distinct, substantial theorems and now get individual summaries + math context.
- **Key insights 4 → 5.** Added "**A reduction, not a simplicity proof**" — clarifies that the headline `isSimpleGroup_alternating_iff` is an *unconditional biconditional* that asserts nothing about whether Aₙ is actually simple; its value is diagnostic (it pins the entire remaining gap to one combinatorial lemma), which is why the forward direction is packaged as a separate, pluggable lemma.
- **Annotations 4 → 5.** Added `ann-oq03-witness-construction` (lines 104–109): the mechanics of manufacturing the explicit `(a b)(a c)` 3-cycle witness inside the `alternatingGroup α` subtype — `isThreeCycle_swap_mul_swap_same`, `IsThreeCycle.mem_alternatingGroup` for the evenness membership proof, and `rw [h]; mem_top` to land it in `H = ⊤`.

### Verification
- Both JSON files validated with `python3 -m json`.
- Counts confirmed: 5 annotations, 5 key insights, 5 sections → recomputed quality score 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)