### PR TITLE
Enrich Simplicity of Aₙ via 3-Cycle Criterion (abel-ruffini-galois-extensions-oq-03): environment annotation

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-03/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-03/annotations.json
@@ -21,6 +21,26 @@
     ]
   },
   {
+    "id": "ann-oq03-setup",
+    "proofId": "abel-ruffini-galois-extensions-oq-03",
+    "range": { "startLine": 46, "endLine": 55 },
+    "type": "context",
+    "title": "Environment: the Mathlib API Surface and the General-`α` Setup",
+    "content": "The proof needs only the public alternating-group API: `import Mathlib.GroupTheory.SpecificGroups.Alternating` brings in `alternatingGroup`, `IsThreeCycle.alternating_normalClosure`, `isThreeCycle_isConj`, and `nontrivial_of_three_le_card`, while `import Mathlib.Tactic` supplies `omega` (used to derive `3 ≤ card α` from `5 ≤ card α`). Opening `Equiv Equiv.Perm Subgroup` and `alternatingGroup` lets 3-cycles, permutations, and `normalClosure`/`Normal` be written without qualification. Crucially the type is left general — `variable {α : Type*} [Fintype α] [DecidableEq α]` — rather than fixed to `Fin n`; `[DecidableEq α]` is what the alternating group and its cycle-type API require, and generality over `α` is exactly what makes the reduction reusable for any concrete alternating group, including the `Fin 5` instance Mathlib already proves.",
+    "mathContext": "Works over an arbitrary finite $\\alpha$ with decidable equality, matching Mathlib's `alternating_normalClosure` API rather than specializing to $\\mathrm{Fin}\\,n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "alternatingGroup API",
+      "DecidableEq typeclass",
+      "generality over a finite type",
+      "open namespaces"
+    ],
+    "prerequisites": [
+      "Lean 4 imports, `open`, and `variable` declarations",
+      "Typeclass assumptions Fintype / DecidableEq"
+    ]
+  },
+  {
     "id": "ann-oq03-core-lemma",
     "proofId": "abel-ruffini-galois-extensions-oq-03",
     "range": { "startLine": 57, "endLine": 79 },


### PR DESCRIPTION
## Enrichment pass for `abel-ruffini-galois-extensions-oq-03`

Added one focused `context` annotation (`ann-oq03-setup`, lines 46–55) for the imports / `open` / `namespace` / `variable` region — the exact Mathlib API surface (`SpecificGroups.Alternating`, `omega`) and the deliberate generality over an arbitrary finite type `α` (rather than `Fin n`) that makes the reduction reusable. Full `mathContext` / `significance` / `relatedConcepts` / `prerequisites`. The four existing annotations already cover lines 1–55, 57–79, 81–109, 111–126.

**Note:** an earlier revision of this PR also created a per-proof `index.ts` shim. That was removed — per the phase-2 loader refactor (#20993/#20992), `index.ts` shims are obsolete: proofs load at runtime from `data-manifest.json` + `public/data/proofs/` (built from meta.json/annotations.json), not from per-dir shims. The entry was never broken; only the annotation adds value.

**Axiom integrity:** unchanged — `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`. meta.json is 20 KB (under the ~60 KB cap).