### PR TITLE
Enrich Resonance principle for Fourier divergence (banach-steinhaus-theorem-oq-01-oq-01): quality 91→100

### DIFF
--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/annotations.json
@@ -24,6 +24,18 @@
     "prerequisites": ["normed spaces", "completeness", "bounded operators"]
   },
   {
+    "id": "ann-bs-oq0101-bddabove-idiom",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 69 },
+    "type": "tactic",
+    "title": "Encoding \u201Csupremum is +\u221E\u201D as \u00AC BddAbove (range \u2026)",
+    "content": "Both theorems phrase (un)boundedness through `BddAbove (range fun i => \u2016g i\u2016)` rather than an explicit `\u2203 C, \u2200 i, \u2026 \u2264 C`. This is the idiomatic Mathlib encoding of \u2018the set {\u2016g i\u2016} has a finite supremum\u2019, and its negation `\u00AC BddAbove` is exactly \u2018the supremum is +\u221E\u2019 \u2014 the shape both the hypothesis and the conclusion want. The payoff is that the two encodings interconvert with one-liners: `BddAbove (range f)` unpacks to a bound on every `f i` via `mem_range_self i`, and repacks from `\u2200 i, f i \u2264 C` by `rintro _ \u27E8i, rfl\u27E9`. Keeping the statement in `BddAbove`/`range` form (instead of raw quantifiers) is what lets the resonance principle read as a clean contrapositive of `banach_steinhaus` and stay directly composable with Mathlib's order and filter API (e.g. `not_bddAbove_iff`).",
+    "mathContext": "$\\neg\\,\\mathrm{BddAbove}\\,\\{\\|g_i\\|\\}_i \\iff \\sup_i \\|g_i\\| = +\\infty$; the range-membership bridge is $f\\,i \\in \\mathrm{range}\\,f$ via `mem_range_self`.",
+    "significance": "supporting",
+    "relatedConcepts": ["BddAbove", "Set.range", "mem_range_self", "supremum as +\u221E", "idiomatic encoding"],
+    "prerequisites": ["order theory: bounded-above sets", "Set.range and membership"]
+  },
+  {
     "id": "ann-bs-oq0101-resonance",
     "proofId": "banach-steinhaus-theorem-oq-01-oq-01",
     "range": { "startLine": 59, "endLine": 81 },

--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/meta.json
@@ -58,7 +58,8 @@
       "The resonance principle is precisely the contrapositive of uniform boundedness; by_contra + push_neg reduces the goal to the pointwise-bounded hypothesis banach_steinhaus consumes.",
       "Phrasing boundedness as BddAbove (range …) keeps the statements idiomatic and the bridge to '∃ C, ∀ i, … ≤ C' is just mem_range_self / rintro ⟨i, rfl⟩.",
       "Stating the core for an arbitrary index type and a separate ℕ-sequence corollary keeps it reusable: the corollary is what the Fourier divergence proof actually calls with ‖Sₙ‖ → ∞.",
-      "Isolating the analytic input (Lebesgue constants) outside the verified core, rather than baking it into an axiom, keeps the contribution honest and pinpoints the Mathlib gap."
+      "Isolating the analytic input (Lebesgue constants) outside the verified core, rather than baking it into an axiom, keeps the contribution honest and pinpoints the Mathlib gap.",
+      "Completeness of E is the load-bearing hypothesis: the resonance principle inherits `CompleteSpace E` directly from `banach_steinhaus`, which rests on the Baire category theorem. Without completeness the uniform boundedness principle fails — there exist incomplete normed spaces carrying pointwise-bounded families of operators whose norms are unbounded — so the whole argument, and hence the Fourier-divergence application, genuinely needs the Banach (not merely normed) structure of C(𝕋)."
     ],
     "prerequisites": [
       "Banach spaces and continuous linear maps (operator norm)",
@@ -69,12 +70,20 @@
   },
   "sections": [
     {
-      "id": "overview",
-      "title": "Target, scope, and status",
+      "id": "overview-target",
+      "title": "Target and classical strategy",
       "startLine": 1,
-      "endLine": 49,
-      "summary": "Import Mathlibs Banach-Steinhaus; docstring framing the target (a continuous 2pi-periodic function whose Fourier series diverges at a point) and the scope: this file isolates and verifies the FUNCTIONAL-ANALYSIS CORE (the resonance principle), ready to apply once the analytic input the Lebesgue constant tends to infinity is available; honest status note that the full Fourier-divergence theorem is not claimed.",
+      "endLine": 36,
+      "summary": "Import Mathlib's Banach-Steinhaus; docstring framing the target (a continuous 2pi-periodic function whose Fourier series diverges at a point) and the classical route: the partial-sum-at-0 functionals Sn on C(T) have operator norms equal to the Lebesgue constants, which diverge, so the contrapositive of uniform boundedness produces a resonating f.",
       "mathContext": "Partial-sum functionals $S_n f = (S_n f)(0) = \\int f\\,D_n$, $\\|S_n\\| = \\|D_n\\|_{L^1}$ (Lebesgue constants) $\\to \\infty$; uniform boundedness forces a resonance point."
+    },
+    {
+      "id": "overview-scope-status",
+      "title": "Verified core vs. the Mathlib gap: dependencies and status",
+      "startLine": 37,
+      "endLine": 49,
+      "summary": "Honest scope disclosure: Mathlib has `banach_steinhaus` but NOT the Dirichlet kernel, the partial-sum operators, or the Lebesgue-constant divergence. This file verifies only the FUNCTIONAL-ANALYSIS CORE (the resonance principle), ready to apply once the analytic input the Lebesgue constant tends to infinity is available. Lists the two Mathlib dependencies and records status `verified` with the remaining analytic gap documented (not axiomatized).",
+      "mathContext": "Consumed input, still missing from Mathlib: $\\|S_n\\| = \\|D_n\\|_{L^1} \\to \\infty$. Everything else — the contrapositive of `banach_steinhaus` — is machine-checked with 0 sorry / 0 axiom."
     },
     {
       "id": "setup",


### PR DESCRIPTION
## Enrichment pass — banach-steinhaus-theorem-oq-01-oq-01

**Quality 91 → 100** (0 → 1 pass). All additions grounded in the Lean source `Proofs/FourierDivergenceResonance.lean`; no proof, claim, scope, or status changes.

### Changes
- **Sections 4 → 5.** Split the combined overview section (lines 1–49) along the docstring's own headers into `overview-target` (1–36, the mathematical target + classical resonance strategy) and `overview-scope-status` (37–49, the honest scope disclosure, Mathlib dependencies, and `verified` status with the analytic gap documented rather than axiomatized).
- **Key insights 4 → 5.** Added the observation that **completeness of `E` is the load-bearing hypothesis**: the resonance principle inherits `CompleteSpace E` from `banach_steinhaus` (which rests on Baire category); without completeness the UBP — and hence the whole Fourier-divergence argument — fails.
- **Annotations 4 → 5.** Added `ann-bs-oq0101-bddabove-idiom` (lines 67–69): the Lean encoding of "supremum is +∞" as `¬ BddAbove (range …)`, and how it interconverts with explicit quantifier bounds via `mem_range_self` / `rintro ⟨i, rfl⟩` — the idiom that lets the statement read as a clean contrapositive of `banach_steinhaus`.

### Verification
- Both JSON files validated with `python3`.
- Counts confirmed: 5 annotations (all with mathContext/significance/relatedConcepts), 5 key insights, 5 sections → recomputed quality score 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)