### PR TITLE
Enrich Even Unit-Ball Stirling Asymptotic (area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02): add import-surface annotation

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["asymptotic analysis", "Mathlib", "n-ball volume"]
   },
   {
+    "id": "ann-imports",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 43, "endLine": 51 },
+    "type": "context",
+    "title": "The Import Surface: Exactly Three Analytic Ingredients",
+    "content": "The proof pulls in precisely the machinery it needs and nothing structural beyond it. `Mathlib.Analysis.SpecialFunctions.Stirling` supplies the single deep input — Stirling's formula $k! \\sim \\sqrt{2\\pi k}\\,(k/e)^k$ in `IsEquivalent` form; `...Gamma.Basic` provides $\\Gamma$, its positivity, and the recurrence $\\Gamma(s+1)=s\\,\\Gamma(s)$ used to define $\\omega$ and prove the dimension recurrence; and `...Asymptotics.AsymptoticEquivalent` gives the $\\sim$ calculus (`IsEquivalent.mul`, `.inv`, `.congr_right`, `isEquivalent_iff_tendsto_one`) that transports Stirling for $k!$ into the statement about $\\omega_{2k}$. `open ... Asymptotics Nat` and `open scoped Topology` let the `~[atTop]` notation and factorial be written unqualified. Notably the file does *not* import `EuclideanSpace.volume_ball`: $\\omega$ is taken as the Gamma closed form directly, keeping the entry self-contained and independent of the non-compiling ancestor.",
+    "mathContext": "Deep input: $k! \\sim_{\\mathrm{atTop}} \\sqrt{2\\pi k}(k/e)^k$. Everything else is the algebra of $\\sim$ and the recurrence $\\Gamma(s+1)=s\\,\\Gamma(s)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Stirling's formula", "asymptotic equivalence calculus", "Gamma function API", "atTop filter"],
+    "prerequisites": ["Lean 4 imports and open scopes", "IsEquivalent and the atTop filter"]
+  },
+  {
     "id": "ann-omega-def",
     "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
     "range": { "startLine": 53, "endLine": 58 },


### PR DESCRIPTION
## Enrichment pass for `area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02`

The entry was already rich (6 annotations, full `overview`/`conclusion`/`references`, `index.ts` present). The one genuine coverage gap was the imports / `open` / `namespace` region (lines 43–51), which the six existing annotations skipped (they cover 1–41, 53–58, 60–76, 78–92, 94–128, 130–147).

**Added `ann-imports`** (`context`, lines 43–51): identifies that the proof rests on exactly three analytic ingredients — `Stirling` (the one deep input, !\sim\sqrt{2\pi k}(k/e)^k$), `Gamma.Basic` (the $\Gamma$ recurrence defining $\omega$), and `AsymptoticEquivalent` (the $\sim$ calculus that transports Stirling) — and notes the deliberate omission of `EuclideanSpace.volume_ball` that keeps the file self-contained and independent of the non-compiling ancestor. Full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

**Axiom integrity:** unchanged — `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`. meta.json is 11.8 KB, well under the ~60 KB cap; no fields deepened beyond the coverage annotation.