### PR TITLE
research(burnside-counting-oq-03-oq-03): entry already axiom-free; map kernel-verification route

### DIFF
--- a/research/problems/burnside-counting-oq-03-oq-03/drafts/BurnsideCountingVerified.draft.lean
+++ b/research/problems/burnside-counting-oq-03-oq-03/drafts/BurnsideCountingVerified.draft.lean
@@ -1,0 +1,99 @@
+/-
+DRAFT — UNVERIFIED (researcher-6, 2026-07-01). NOT built this session: the shared
+docker `.lake/build` cache volume was contended by 5–7 concurrent `lean-build`
+containers all session (SIGBUS risk), so this could not be compiled. Do NOT copy into
+`proofs/Proofs/` or change gallery meta to `verified` until this compiles cleanly via
+`./proofs/scripts/docker-build.sh Proofs.BurnsideCounting` with an EMPTY build queue.
+
+Goal: replace the two `native_decide` calls in `proofs/Proofs/BurnsideCounting.lean`
+(`fixed_point_sum_binary_4`, `binary_necklaces_4`) with kernel-checked proofs, removing
+the `Lean.ofReduceBool` assumption and upgrading the entry from `axiomatized` to `verified`.
+
+Two routes are sketched. Route A (quick) is preferred IF kernel `decide` handles the
+16-element `Fin 4 → Fin 2` enumeration; Route B (bijection) is the fallback that reuses
+the file's already-proved count lemmas and does not depend on `decide` performance.
+
+Names/lemmas confirmed present in vendored Mathlib (see ../knowledge.md).
+-/
+
+-- ===========================================================================
+-- ROUTE A (quick): try kernel `decide` for the finite counts, additive Burnside
+-- for the necklace count.  Drop-in replacements for the two theorems.
+-- ===========================================================================
+
+-- theorem fixed_point_sum_binary_4 :
+--     Fintype.card { c : Coloring 4 2 // IsFixedByRotation 0 c } +
+--     Fintype.card { c : Coloring 4 2 // IsFixedByRotation 1 c } +
+--     Fintype.card { c : Coloring 4 2 // IsFixedByRotation 2 c } +
+--     Fintype.card { c : Coloring 4 2 // IsFixedByRotation 3 c } = 24 := by
+--   decide   -- replaces `native_decide`; only valid if the kernel enumeration is feasible
+
+-- theorem binary_necklaces_4 :
+--     @Fintype.card (Quotient (@coloringSetoid 4 2 _)) (coloringQuotientFintype 4 2) = 6 := by
+--   -- additive Burnside: ∑ a, card (fixedBy X a) = card (orbitRel.Quotient) * card G
+--   have hb := AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup (ZMod 4) (Coloring 4 2)
+--   -- Each `AddAction.fixedBy (Coloring 4 2) r` is the subtype `{c // IsFixedByRotation r c}`
+--   -- because `AddAction.mem_fixedBy` is `Iff.rfl` and `IsFixedByRotation r c := r +ᵥ c = c`.
+--   -- Rewrite the sum over `ZMod 4 ≡ Fin 4` with `Fin.sum_univ_four`, use `fixed_point_sum_binary_4`
+--   -- to get LHS = 24, and `ZMod.card 4` to get `card (ZMod 4) = 4`; then `omega`.
+--   -- (Fintype-instance mismatch on the quotient is closed by `Subsingleton.elim`/`Fintype.card_eq`.)
+--   sorry
+
+-- ===========================================================================
+-- ROUTE B (fallback, decide-independent): characterize each fixed-point set and
+-- reuse the file's proved bijection lemmas, then additive Burnside as in Route A.
+-- Insert AFTER `period2_count` and BEFORE `fixed_point_sum_binary_4`.
+-- ===========================================================================
+
+-- /-- Per-index evaluation of a rotation on `Coloring 4 2`. -/
+-- lemma rotate_eval (r : ZMod 4) (c : Coloring 4 2) (i : Fin 4) :
+--     (r +ᵥ c) i = c ⟨(i.val + 4 - r.val) % 4, Nat.mod_lt _ (by norm_num)⟩ := by
+--   show rotateColoring 4 2 r c i = _
+--   unfold rotateColoring
+--   simp only [Nat.mod_eq_of_lt (ZMod.val_lt r)]
+
+-- /-- Rotation by 1 fixes exactly the constant colorings. -/
+-- theorem isFixedByRotation_one_iff (c : Coloring 4 2) :
+--     IsFixedByRotation (1 : ZMod 4) c ↔ IsConstant c := by
+--   have hv : (1 : ZMod 4).val = 1 := by decide
+--   unfold IsFixedByRotation
+--   rw [funext_iff]
+--   constructor
+--   · intro h i j
+--     have e0 := h 0; have e1 := h 1; have e2 := h 2; have e3 := h 3
+--     rw [rotate_eval, hv] at e0 e1 e2 e3
+--     -- e1 : c 0 = c 1, e2 : c 1 = c 2, e3 : c 2 = c 3 (indices reduce definitionally)
+--     have h01 : c 0 = c 1 := e1
+--     have h12 : c 1 = c 2 := e2
+--     have h23 : c 2 = c 3 := e3
+--     have key : ∀ k : Fin 4, c k = c 0 := by
+--       intro k; fin_cases k
+--       · rfl
+--       · exact h01.symm
+--       · exact (h12.symm.trans h01.symm)
+--       · exact (h23.symm.trans (h12.symm.trans h01.symm))
+--     rw [key i, key j]
+--   · intro h i
+--     rw [rotate_eval, hv]; exact h _ i
+
+-- /-- Rotation by 3 also fixes exactly the constant colorings (same as rotation by 1). -/
+-- theorem isFixedByRotation_three_iff (c : Coloring 4 2) :
+--     IsFixedByRotation (3 : ZMod 4) c ↔ IsConstant c := by
+--   -- analogous to `isFixedByRotation_one_iff` with `(3 : ZMod 4).val = 3`;
+--   -- adjacency chain c3=c(3+3 mod4)=c2, etc.
+--   sorry
+
+-- /-- Rotation by 2 fixes exactly the period-2 colorings. -/
+-- theorem isFixedByRotation_two_iff (c : Coloring 4 2) :
+--     IsFixedByRotation (2 : ZMod 4) c ↔ HasPeriod2 c := by
+--   -- `(2 : ZMod 4).val = 2`; c(i) = c(i+2 mod 4) ⟺ c0=c2 ∧ c1=c3 = HasPeriod2.
+--   sorry
+
+-- Then, with the four characterizations, each count reuses an existing lemma via
+-- `Fintype.card_congr (Equiv.subtypeEquivRight ·)`:
+--   card {c // IsFixedByRotation 0 c} = 16  (Equiv.subtypeUnivEquiv; 0 +ᵥ c = c by zero_vadd)
+--   card {c // IsFixedByRotation 1 c} = 2   (subtypeEquivRight isFixedByRotation_one_iff; constant_4_2)
+--   card {c // IsFixedByRotation 2 c} = 4   (subtypeEquivRight isFixedByRotation_two_iff; period2_count)
+--   card {c // IsFixedByRotation 3 c} = 2   (subtypeEquivRight isFixedByRotation_three_iff; constant_4_2)
+-- giving `fixed_point_sum_binary_4 = 24` with no `native_decide`, and `binary_necklaces_4`
+-- via the additive-Burnside chain of Route A.

--- a/research/problems/burnside-counting-oq-03-oq-03/knowledge.md
+++ b/research/problems/burnside-counting-oq-03-oq-03/knowledge.md
@@ -6,16 +6,74 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The problem asks to eliminate 5 axioms from `BurnsideCounting.lean` by bridging
+`AddAction (ZMod n)` to the `MulAction` orbit-counting API.
 
----
+**KEY FINDING (researcher-6, 2026-07-01):** All 5 axioms are ALREADY eliminated in
+the current `proofs/Proofs/BurnsideCounting.lean` (0 `axiom` declarations, 0 sorries):
+
+1. `rotatedIndex_add` — full unconditional Nat-modular proof (8-leaf case split, PR #21148 / S1)
+2. `coloringSetoid` — now `def ... := AddAction.orbitRel (ZMod n) (Coloring n k)` (S2)
+3. `coloringQuotientFintype` — now `def` via `Quotient.fintype` + a decidable-orbit-relation instance (S2)
+4. `fixed_point_sum_binary_4` — `native_decide` (S3)
+5. `binary_necklaces_4` — `native_decide` on the computable orbit-quotient card (S4)
+
+So the *literal* goal ("collapse to native_decide or Mathlib lemmas") is DONE. The
+gallery meta correctly reports `status: axiomatized`, `axiomCount: 1`, `badge: axiom`,
+because the two `native_decide` calls introduce `Lean.ofReduceBool` (per the project's
+Axiom Integrity Policy).
+
+## The only remaining upgrade: native_decide → kernel-checked (badge → verified)
+
+To reach `badge: verified` the two `native_decide` calls must become kernel-checked.
+Mapped route (all API confirmed present in the vendored Mathlib):
+
+- **No MulAction bridge is needed.** Mathlib has the *additive* Burnside lemma directly:
+  `AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup (G) (X)` (the `to_additive`
+  image of `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`,
+  `Mathlib/GroupTheory/GroupAction/Quotient.lean:257`). It states
+  `∑ a : G, card (AddAction.fixedBy X a) = card (AddAction.orbitRel.Quotient G X) * card G`.
+- `AddAction.orbitRel.Quotient G X` is *definitionally* `Quotient (AddAction.orbitRel G X)`
+  (`orbitRel.Quotient` is an `abbrev := _root_.Quotient (orbitRel G α)`,
+  `Mathlib/GroupTheory/GroupAction/Defs.lean:344`), i.e. exactly `Quotient (coloringSetoid 4 2)`.
+- `AddAction.mem_fixedBy : a ∈ fixedBy X g ↔ g +ᵥ a = a` is `Iff.rfl` (to_additive of
+  `mem_fixedBy`, `Defs.lean:138`), so `fixedBy (Coloring 4 2) r` is the same subtype as
+  `{c // IsFixedByRotation r c}` (recall `IsFixedByRotation r c := r +ᵥ c = c`).
+- `ZMod.card 4 : Fintype.card (ZMod 4) = 4` (`Mathlib/Data/ZMod/Defs.lean:168`).
+- `Fin.sum_univ_four` decomposes the sum over `ZMod 4 ≡ Fin 4`.
+- Then `24 = card(quotient) * 4 ⟹ card(quotient) = 6` by `omega`.
+
+The four fixed-point counts (16, 2, 4, 2) can be obtained WITHOUT `native_decide` by
+reusing the file's already-fully-proved bijection lemmas
+(`binary_4_colorings_count = 16`, `constant_coloring_count = 2`, `period2_count = 4`)
+through characterization iffs and `Equiv.subtypeEquivRight`:
+- `IsFixedByRotation 0 c ↔ True`      (Fix(0) = all colorings, via `zero_vadd`) → 16
+- `IsFixedByRotation 1 c ↔ IsConstant c`   → 2
+- `IsFixedByRotation 2 c ↔ HasPeriod2 c`   → 4
+- `IsFixedByRotation 3 c ↔ IsConstant c`   → 2
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- The whole "AddAction → MulAction bridge" framing in problem.md is a NON-issue:
+  Mathlib's `to_additive` already provides the entire additive orbit-counting API,
+  including Burnside. Future necklace/orbit-counting formalizations should use the
+  `AddAction.*` names directly rather than constructing a `MonoidHom` bridge.
+- `orbitRel.Quotient`/`AddAction.orbitRel.Quotient` being a plain `abbrev` for
+  `Quotient (orbitRel …)` means the file's `coloringSetoid`/`coloringQuotientFintype`
+  line up definitionally with Mathlib's Burnside statement — no `Fintype`-diamond
+  rewriting beyond `Subsingleton (Fintype _)` / `Fintype.card_eq`.
 
----
+## Open experiment (build-gated)
+
+Does *kernel* `decide` (not `native_decide`) evaluate `Fintype.card {c : Fin 4 → Fin 2 // P c}`
+(16-element function-space enumeration)? If yes, `fixed_point_sum_binary_4` closes by
+`decide` with a one-token change and `binary_necklaces_4` closes via the additive-Burnside
+chain above — the whole entry becomes kernel-verified. If kernel `decide` blows up on
+the Pi-type enumeration (the likely reason S3/S4 chose `native_decide`), the bijection
+route above is the fallback. Draft scaffold: `drafts/BurnsideCountingVerified.draft.lean`.
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Building was blocked this session: 5–7 concurrent `lean-build` docker containers share
+  one `.lake/build` cache volume; building concurrently causes SIGBUS (see r6 memory notes).
+  Build only when `docker ps | grep lean-build` is empty.

--- a/research/problems/burnside-counting-oq-03-oq-03/state.md
+++ b/research/problems/burnside-counting-oq-03-oq-03/state.md
@@ -1,30 +1,45 @@
 # Research State: burnside-counting-oq-03-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: SUMMARIZE
 **Path**: full
-**Since**: 2026-04-05T21:00:00-07:00
-**Iteration**: 1
+**Since**: 2026-07-01
+**Iteration**: 2
 
 ## Current Focus
-Eliminate all 5 axioms in BurnsideCounting.lean by bridging AddAction (ZMod n)
-to MulAction and using native_decide for finite computation axioms.
+The literal problem goal (eliminate all 5 axioms in BurnsideCounting.lean) is ALREADY
+ACHIEVED in the codebase. Remaining optional upgrade: native_decide → kernel-checked
+to reach `badge: verified`.
+
+## Findings (researcher-6, 2026-07-01, iteration 2)
+- All 5 originally-axiomatized facts are now discharged in `proofs/Proofs/BurnsideCounting.lean`
+  (0 `axiom` declarations, 0 sorries): rotatedIndex_add (full proof), coloringSetoid +
+  coloringQuotientFintype (AddAction.orbitRel + Quotient.fintype), fixed_point_sum_binary_4
+  + binary_necklaces_4 (native_decide). Gallery meta correctly = `axiomatized` / `axiomCount:1`
+  (Lean.ofReduceBool from native_decide).
+- The "AddAction → MulAction bridge" in problem.md is unnecessary: Mathlib provides the
+  additive Burnside lemma `AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup` and
+  the full additive orbit API by `to_additive`. `AddAction.orbitRel.Quotient` is defeq to
+  `Quotient (coloringSetoid …)`.
+- Complete, API-verified route to `badge: verified` recorded in knowledge.md; draft Lean
+  scaffold in drafts/BurnsideCountingVerified.draft.lean (UNVERIFIED — not built).
 
 ## Active Approach
-Three-track approach:
-1. Prove `rotatedIndex_add` via modular arithmetic (omega / Nat.mod lemmas)
-2. Build MulAction bridge: ZMod n →+ Equiv.Perm (Coloring n k)
-3. Use native_decide for finite-computation axioms (fixed_point_sum_binary_4, binary_necklaces_4)
+Kernel-verification upgrade (native_decide → decide / additive-Burnside + bijections).
+Build-gated: could not compile this session (see Blockers).
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1 (research/mapping; no build)
+- Approaches tried: API survey + route mapping
 
 ## Blockers
-None.
+- Build environment contended all session: 5–7 concurrent `lean-build` docker containers
+  share one `.lake/build` cache volume (SIGBUS risk). Build only when `docker ps | grep
+  lean-build` is empty. Kernel-`decide` feasibility on `Fin 4 → Fin 2` remains untested.
 
 ## Next Action
-1. Read proofs/Proofs/BurnsideCounting.lean to understand current axiom structure
-2. Identify which Mathlib lemmas cover ZMod addition as MulAction
-3. Try omega for rotatedIndex_add, native_decide for finite axioms
+1. When the build queue is empty, test kernel `decide` on a fixed-point-set cardinality
+   (Route A). If it compiles, apply the drop-in `decide` + additive-Burnside replacements.
+2. Otherwise complete Route B (three characterization iffs + subtypeEquivRight) and build.
+3. On a clean build, update meta.json to status `verified` / badge `verified` /
+   axiomCount 0 and drop the Lean.ofReduceBool disclosure.


### PR DESCRIPTION
## Summary

Research on **burnside-counting-oq-03-oq-03** ("Interface Burnside's Lemma with Mathlib MulAction Framework").

**Main finding:** the problem's literal goal — eliminate the 5 axioms in `proofs/Proofs/BurnsideCounting.lean` — is **already achieved** in the codebase. The file has 0 `axiom` declarations and 0 sorries; `rotatedIndex_add` is a full proof, `coloringSetoid`/`coloringQuotientFintype` are derived from `AddAction.orbitRel` + `Quotient.fintype`, and the two finite counts use `native_decide`. The gallery meta correctly reports `axiomatized` / `axiomCount: 1` (the `Lean.ofReduceBool` assumption from `native_decide`, per the Axiom Integrity Policy).

**Contribution of this PR (docs/research only — no Lean in `proofs/` changed):**
- Documents that no `AddAction → MulAction` bridge is needed: Mathlib provides the additive Burnside lemma `AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup` and the full additive orbit API via `to_additive`. This corrects the framing in `problem.md`.
- Maps the complete, API-verified route to upgrade the entry to `badge: verified` (replace the two `native_decide` calls with kernel-checked proofs), with two options: kernel `decide` (if the `Fin 4 → Fin 2` enumeration is feasible) or a `decide`-independent bijection route reusing the file's existing `binary_4_colorings_count`/`constant_coloring_count`/`period2_count` lemmas.
- Adds an **UNVERIFIED** draft scaffold under `drafts/` (clearly marked; not in `proofs/`, so it cannot affect the build).

**Not done / why:** the kernel-verification upgrade could not be compiled this session — the shared docker `.lake/build` cache volume was contended by 5–7 concurrent `lean-build` containers the entire session (SIGBUS risk). Gallery meta status is deliberately **left unchanged** (no unverifiable `verified` claim). Next-session steps are in `state.md`.

## Files
- `research/problems/burnside-counting-oq-03-oq-03/knowledge.md` — findings + route map
- `research/problems/burnside-counting-oq-03-oq-03/state.md` — updated state (phase SUMMARIZE)
- `research/problems/burnside-counting-oq-03-oq-03/drafts/BurnsideCountingVerified.draft.lean` — unverified scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)