### PR TITLE
research(euler-totient-oq-02-oq-02-oq-01): Carmichael λ(n) is the TRUE minimal universal exponent [VERIFIED, 0-axiom, 16thm]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ02OQ02OQ01.lean
@@ -1,0 +1,223 @@
+/-
+# The Carmichael Function λ(n) is the TRUE Universal Exponent of (ℤ/nℤ)ˣ  (OQ02-OQ02-OQ01)
+
+The parent entry `euler-totient-oq-02-oq-02` proves that **`φ(n)` is a universal
+exponent**: the multiplicative order of every unit of `ℤ/nℤ` divides `φ(n)`, so
+`a^φ(n) ≡ 1 (mod n)` for every `a` coprime to `n` (`orderOf_unit_dvd_totient`).
+But `φ(n)` is *not* the smallest such exponent in general. The genuinely minimal
+universal exponent is the **Carmichael function** (reduced totient)
+
+    λ(n) := exponent of the group (ℤ/nℤ)ˣ,
+
+which Mathlib packages as `ArithmeticFunction.Carmichael`. Mathlib develops λ
+purely group-theoretically (a formula through the prime factorisation). This file
+supplies the piece the parent's number-theoretic world needs: the **arithmetic
+`ModEq` characterisation of λ as the least universal exponent**, and the sharp
+**λ = φ ⟺ (ℤ/nℤ)ˣ cyclic** boundary that separates the Carmichael function from
+Euler's totient.
+
+## Main results
+
+1. `carmichael_modEq` — λ(n) *is* a universal exponent, in `ℕ`/`ModEq` form:
+   `a^λ(n) ≡ 1 (mod n)` for every `a` coprime to `n`. (The arithmetic shadow of
+   Mathlib's group statement `pow_carmichael`.)
+2. `carmichael_dvd_iff` — the **exact characterisation**: `λ(n) ∣ m` **iff** `m`
+   is a universal exponent (`∀ a coprime, a^m ≡ 1 (mod n)`). This says λ(n) is
+   the generator of the ideal of all universal exponents.
+3. `carmichael_isLeast_universal` — packaged conclusion: λ(n) is the **least**
+   positive universal exponent. This is precisely "λ(n) is the *true* universal
+   exponent", the content the parent's `φ(n)` only approximates.
+4. `orderOf_unit_dvd_totient_via_carmichael` — the parent's main theorem
+   re-derived *through* the sharper λ: `orderOf a ∣ λ(n) ∣ φ(n)`.
+5. `pow_mod_carmichael_modEq` — exponents reduce modulo λ(n) (not just φ(n)):
+   `a^k ≡ a^(k % λ(n)) (mod n)`. The sharpest form of fast modular exponentiation.
+6. `carmichael_eq_totient_iff_isCyclic` — the **boundary phenomenon**:
+   `λ(n) = φ(n)` **iff** `(ℤ/nℤ)ˣ` is cyclic (iff `n` has a primitive root).
+7. `carmichael_lt_totient_of_not_isCyclic` — hence λ is *strictly* smaller than φ
+   exactly when the unit group is non-cyclic.
+8. `carmichael_prime` / `carmichael_eight_lt_totient` — the sharp examples:
+   λ(p) = φ(p) at every prime, but λ(8) = 2 < 4 = φ(8).
+
+Only the foundational axioms `propext`, `Classical.choice`, `Quot.sound` are
+used; confirmed via `#print axioms`. No `sorryAx`, no `Lean.ofReduceBool`.
+-/
+
+import Mathlib
+
+namespace EulerTotientOQ02OQ02OQ01
+
+open Nat Monoid ArithmeticFunction
+
+variable {n : ℕ}
+
+-- ============================================================
+-- SECTION I: The arithmetic ⇄ group dictionary
+-- ============================================================
+
+/-- **The `ModEq`/`ZMod` bridge.** A power congruence `a^m ≡ 1 (mod n)` is the
+same data as the equation `(a : ℤ/nℤ)^m = 1`. Every arithmetic statement below
+is routed through this lemma. -/
+theorem modEq_one_iff_cast_pow {a m : ℕ} :
+    a ^ m ≡ 1 [MOD n] ↔ (a : ZMod n) ^ m = 1 := by
+  rw [← ZMod.natCast_eq_natCast_iff, Nat.cast_pow, Nat.cast_one]
+
+-- ============================================================
+-- SECTION II: λ(n) is a universal exponent (arithmetic form)
+-- ============================================================
+
+/-- **λ(n) is a universal exponent.** For `a` coprime to `n`, `a^λ(n) ≡ 1 (mod n)`.
+This is the number-theoretic shadow of Mathlib's group-level `pow_carmichael`:
+a coprime residue is a unit, and every unit is killed by the group exponent λ(n). -/
+theorem carmichael_modEq {a : ℕ} (h : Nat.Coprime a n) :
+    a ^ Carmichael n ≡ 1 [MOD n] := by
+  rw [modEq_one_iff_cast_pow]
+  have hu : IsUnit (a : ZMod n) := (ZMod.isUnit_iff_coprime a n).mpr h
+  rw [← hu.unit_spec, ← Units.val_pow_eq_pow_val, pow_carmichael, Units.val_one]
+
+/-- **λ(n) is nonzero** (for `n ≠ 0`): the unit group is finite, so its exponent
+is positive. -/
+theorem carmichael_ne_zero [NeZero n] : Carmichael n ≠ 0 := by
+  rw [carmichael_eq_exponent']
+  exact Monoid.exponent_ne_zero_of_finite
+
+/-- **λ(n) is positive** (for `n ≠ 0`). -/
+theorem carmichael_pos [NeZero n] : 0 < Carmichael n :=
+  Nat.pos_of_ne_zero carmichael_ne_zero
+
+-- ============================================================
+-- SECTION III: λ(n) is the *least* universal exponent
+-- ============================================================
+
+/-- **The exact characterisation of λ(n).** `λ(n) ∣ m` **iff** `m` is a universal
+exponent, i.e. `a^m ≡ 1 (mod n)` for every `a` coprime to `n`. In other words the
+universal exponents are exactly the multiples of `λ(n)`; `λ(n)` generates them.
+
+This is the sharp upgrade of the parent entry, where `φ(n)` is shown to be *one*
+universal exponent. Here every universal exponent — `φ(n)` included — is forced
+to be a multiple of `λ(n)`. -/
+theorem carmichael_dvd_iff [NeZero n] {m : ℕ} :
+    Carmichael n ∣ m ↔ ∀ a : ℕ, Nat.Coprime a n → a ^ m ≡ 1 [MOD n] := by
+  rw [carmichael_eq_exponent']
+  constructor
+  · -- Multiples of the exponent kill every unit, hence every coprime residue.
+    intro hdvd a ha
+    rw [modEq_one_iff_cast_pow]
+    have hu : IsUnit (a : ZMod n) := (ZMod.isUnit_iff_coprime a n).mpr ha
+    have hpow : hu.unit ^ m = 1 :=
+      Monoid.exponent_dvd_iff_forall_pow_eq_one.mp hdvd hu.unit
+    rw [← hu.unit_spec, ← Units.val_pow_eq_pow_val, hpow, Units.val_one]
+  · -- If every coprime residue is killed by `m`, so is every unit, forcing
+    -- `exponent ∣ m`.  Each unit `u` is realised by the coprime natural `u.val`.
+    intro huniv
+    rw [Monoid.exponent_dvd_iff_forall_pow_eq_one]
+    intro u
+    have hmod := huniv (u : ZMod n).val (ZMod.val_coe_unit_coprime u)
+    rw [modEq_one_iff_cast_pow, ZMod.natCast_zmod_val] at hmod
+    ext
+    rw [Units.val_pow_eq_pow_val, Units.val_one]
+    exact hmod
+
+/-- **Minimality.** Any *positive* universal exponent is `≥ λ(n)`. -/
+theorem carmichael_le_of_universal [NeZero n] {m : ℕ} (hm : 0 < m)
+    (h : ∀ a : ℕ, Nat.Coprime a n → a ^ m ≡ 1 [MOD n]) : Carmichael n ≤ m :=
+  Nat.le_of_dvd hm (carmichael_dvd_iff.mpr h)
+
+/-- **λ(n) is the TRUE universal exponent.** It is the *least* element of the set
+of positive universal exponents: it is itself universal (`carmichael_modEq`) and
+divides — hence is `≤` — every other one (`carmichael_le_of_universal`). This is
+the precise sense in which λ(n), not φ(n), is the canonical exponent of `ℤ/nℤ`. -/
+theorem carmichael_isLeast_universal [NeZero n] :
+    IsLeast {m : ℕ | 0 < m ∧ ∀ a : ℕ, Nat.Coprime a n → a ^ m ≡ 1 [MOD n]}
+      (Carmichael n) := by
+  refine ⟨⟨carmichael_pos, fun a ha => carmichael_modEq ha⟩, ?_⟩
+  rintro m ⟨hm, h⟩
+  exact carmichael_le_of_universal hm h
+
+-- ============================================================
+-- SECTION IV: λ refines the parent's φ (universal-exponent chain)
+-- ============================================================
+
+/-- **The order of a unit divides λ(n)** — the group-level refinement, sharper
+than the parent's `orderOf a ∣ φ(n)` because `λ(n) ∣ φ(n)`. -/
+theorem orderOf_unit_dvd_carmichael [NeZero n] (a : (ZMod n)ˣ) :
+    orderOf a ∣ Carmichael n := by
+  rw [carmichael_eq_exponent']
+  exact Monoid.order_dvd_exponent a
+
+/-- **The parent's theorem, re-derived through λ.** `orderOf a ∣ φ(n)` factors as
+`orderOf a ∣ λ(n) ∣ φ(n)`, exhibiting λ(n) as the true bottleneck between an
+element's order and `φ(n)`. -/
+theorem orderOf_unit_dvd_totient_via_carmichael [NeZero n] (a : (ZMod n)ˣ) :
+    orderOf a ∣ n.totient :=
+  (orderOf_unit_dvd_carmichael a).trans (ArithmeticFunction.carmichael_dvd_totient n)
+
+/-- **Exponents reduce modulo λ(n).** For `a` coprime to `n`,
+`a^k ≡ a^(k % λ(n)) (mod n)`. This is strictly sharper than the parent's
+reduction modulo `φ(n)`, since `λ(n) ∣ φ(n)`: it is the *smallest* period of the
+sequence `k ↦ a^k (mod n)` guaranteed uniformly over all coprime bases. -/
+theorem pow_mod_carmichael_modEq {a : ℕ} (h : Nat.Coprime a n) (k : ℕ) :
+    a ^ k ≡ a ^ (k % Carmichael n) [MOD n] := by
+  conv_lhs => rw [← Nat.mod_add_div k (Carmichael n)]
+  calc a ^ (k % Carmichael n + Carmichael n * (k / Carmichael n))
+      = a ^ (k % Carmichael n) * (a ^ Carmichael n) ^ (k / Carmichael n) := by
+        rw [pow_add, pow_mul]
+    _ ≡ a ^ (k % Carmichael n) * 1 ^ (k / Carmichael n) [MOD n] :=
+        (Nat.ModEq.refl _).mul ((carmichael_modEq h).pow _)
+    _ = a ^ (k % Carmichael n) := by rw [one_pow, mul_one]
+
+-- ============================================================
+-- SECTION V: The sharp boundary  λ(n) = φ(n) ⟺ (ℤ/nℤ)ˣ cyclic
+-- ============================================================
+
+/-- **The Carmichael–Euler boundary.** `λ(n) = φ(n)` **iff** `(ℤ/nℤ)ˣ` is cyclic
+(equivalently, iff `n` admits a primitive root). Cyclic groups are exactly those
+whose exponent equals their order, so the Carmichael function collapses onto
+Euler's totient precisely on the moduli with primitive roots. -/
+theorem carmichael_eq_totient_iff_isCyclic [NeZero n] :
+    Carmichael n = n.totient ↔ IsCyclic (ZMod n)ˣ := by
+  rw [carmichael_eq_exponent',
+    show n.totient = Nat.card (ZMod n)ˣ from by
+      rw [← ZMod.card_units_eq_totient, Fintype.card_eq_nat_card]]
+  exact IsCyclic.iff_exponent_eq_card.symm
+
+/-- **Strictness off the cyclic locus.** When `(ℤ/nℤ)ˣ` is non-cyclic, the
+Carmichael function is *strictly* smaller than Euler's totient: `λ(n) < φ(n)`.
+This is why λ, not φ, is the sharp universal exponent — φ is genuinely wasteful
+whenever `n` has no primitive root. -/
+theorem carmichael_lt_totient_of_not_isCyclic [NeZero n]
+    (h : ¬ IsCyclic (ZMod n)ˣ) : Carmichael n < n.totient := by
+  have hne : Carmichael n ≠ n.totient := fun heq =>
+    h (carmichael_eq_totient_iff_isCyclic.mp heq)
+  have hpos : 0 < n.totient := Nat.totient_pos.mpr (Nat.pos_of_ne_zero (NeZero.ne n))
+  exact lt_of_le_of_ne
+    (Nat.le_of_dvd hpos (ArithmeticFunction.carmichael_dvd_totient n)) hne
+
+-- ============================================================
+-- SECTION VI: Sharp examples — equality at primes, strict at n = 8
+-- ============================================================
+
+/-- **λ(p) = φ(p) at every prime.** The unit group of a prime field is cyclic, so
+the Carmichael function agrees with Euler's totient on primes: `λ(p) = φ(p)`. -/
+theorem carmichael_prime {p : ℕ} (hp : p.Prime) : Carmichael p = p.totient := by
+  rcases eq_or_ne p 2 with rfl | h2
+  · simpa using carmichael_two_pow_of_le_two_eq_totient (n := 1) (by norm_num)
+  · simpa using carmichael_pow_of_prime_ne_two 1 hp h2
+
+/-- Explicit prime value: `λ(p) = p - 1`. -/
+theorem carmichael_prime_eq_sub_one {p : ℕ} (hp : p.Prime) :
+    Carmichael p = p - 1 := by
+  rw [carmichael_prime hp, Nat.totient_prime hp]
+
+/-- **λ(8) = 2** — strictly below `φ(8) = 4`. The group `(ℤ/8ℤ)ˣ ≅ ℤ/2 × ℤ/2`
+is non-cyclic (`8` has no primitive root), so every unit already squares to `1`. -/
+theorem carmichael_eight : Carmichael 8 = 2 := by
+  rw [show (8 : ℕ) = 2 ^ 3 by norm_num, carmichael_two_pow_of_ne_two (by norm_num)]
+  norm_num
+
+/-- **The witness of strictness.** `λ(8) = 2 < 4 = φ(8)`: the Carmichael function
+genuinely improves on Euler's exponent, obtained here from the abstract
+`carmichael_lt_totient_of_not_isCyclic` and the non-cyclicity of `(ℤ/8ℤ)ˣ`. -/
+theorem carmichael_eight_lt_totient : Carmichael 8 < Nat.totient 8 :=
+  carmichael_lt_totient_of_not_isCyclic ZMod.not_isCyclic_units_eight
+
+end EulerTotientOQ02OQ02OQ01

--- a/src/data/proofs/euler-totient-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "ann-bridge",
+    "proofId": "euler-totient-oq-02-oq-02-oq-01",
+    "range": { "startLine": 60, "endLine": 62 },
+    "type": "insight",
+    "title": "The Arithmetic ⇄ Group Dictionary",
+    "content": "Every congruence in this file is translated into an equation in `ZMod n` by one lemma:\n```\ntheorem modEq_one_iff_cast_pow {a m : ℕ} :\n    a ^ m ≡ 1 [MOD n] ↔ (a : ZMod n) ^ m = 1 := by\n  rw [← ZMod.natCast_eq_natCast_iff, Nat.cast_pow, Nat.cast_one]\n```\nThe parent entry lives in the number-theoretic world of `Nat.ModEq`; Mathlib's Carmichael function `pow_carmichael` lives in the group `(ℤ/nℤ)ˣ`. This lemma is the hinge between them, letting us pull Mathlib's group facts down to `a^m ≡ 1 (mod n)` and push arithmetic hypotheses up to units.",
+    "mathContext": "$a^m \\equiv 1 \\pmod n \\iff (a \\bmod n)^m = 1$. `ZMod.natCast_eq_natCast_iff` turns the congruence into equality of casts; `Nat.cast_pow` / `Nat.cast_one` normalise the sides.",
+    "significance": "important",
+    "relatedConcepts": [
+      "ZMod.natCast_eq_natCast_iff",
+      "Nat.ModEq",
+      "ZMod"
+    ],
+    "prerequisites": ["euler-totient-oq-02-oq-02"]
+  },
+  {
+    "id": "ann-universal",
+    "proofId": "euler-totient-oq-02-oq-02-oq-01",
+    "range": { "startLine": 71, "endLine": 75 },
+    "type": "insight",
+    "title": "λ(n) is a Universal Exponent, in ModEq Form",
+    "content": "The number-theoretic shadow of Mathlib's group statement `pow_carmichael`:\n```\ntheorem carmichael_modEq {a : ℕ} (h : Nat.Coprime a n) :\n    a ^ Carmichael n ≡ 1 [MOD n] := by\n  rw [modEq_one_iff_cast_pow]\n  have hu : IsUnit (a : ZMod n) := (ZMod.isUnit_iff_coprime a n).mpr h\n  rw [← hu.unit_spec, ← Units.val_pow_eq_pow_val, pow_carmichael, Units.val_one]\n```\nA coprime residue `a` is a unit of `ℤ/nℤ`, and the group exponent λ(n) kills every unit. This is the Carmichael analogue of the parent's `euler_modEq` — but with the *minimal* exponent λ(n) in place of φ(n).",
+    "mathContext": "$a^{\\lambda(n)} \\equiv 1 \\pmod n$ for $\\gcd(a,n)=1$. `ZMod.isUnit_iff_coprime` makes $a$ a unit; Mathlib's `pow_carmichael` annihilates every unit with $\\lambda(n) = \\operatorname{exponent}(\\mathbb{Z}/n\\mathbb{Z})^\\times$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ArithmeticFunction.Carmichael",
+      "pow_carmichael",
+      "ZMod.isUnit_iff_coprime",
+      "universal exponent"
+    ],
+    "prerequisites": ["euler-totient-oq-02-oq-02"]
+  },
+  {
+    "id": "ann-least",
+    "proofId": "euler-totient-oq-02-oq-02-oq-01",
+    "range": { "startLine": 98, "endLine": 134 },
+    "type": "insight",
+    "title": "The Exact Characterisation: λ(n) is the Least Universal Exponent",
+    "content": "The heart of the entry. Universal exponents are exactly the multiples of λ(n):\n```\ntheorem carmichael_dvd_iff [NeZero n] {m : ℕ} :\n    Carmichael n ∣ m ↔ ∀ a : ℕ, Nat.Coprime a n → a ^ m ≡ 1 [MOD n]\n```\nThe backward direction is the crux: to conclude `exponent ∣ m` from `Monoid.exponent_dvd_iff_forall_pow_eq_one`, one must show `u^m = 1` for every unit `u`. Each unit is realised by the coprime natural `u.val` (`ZMod.val_coe_unit_coprime`), and `natCast_zmod_val` closes `(u.val : ZMod n) = u`. `carmichael_isLeast_universal` then packages this as an `IsLeast` statement — λ(n) is genuinely the least positive universal exponent, the sense in which it is the *true* universal exponent that the parent's φ(n) only approximates.",
+    "mathContext": "$\\lambda(n) \\mid m \\iff \\forall a\\ \\text{coprime},\\ a^m \\equiv 1 \\pmod n$; hence $\\lambda(n) = \\min\\{m>0 : \\forall a\\ \\text{coprime},\\ a^m \\equiv 1\\}$. Key Mathlib lever: `Monoid.exponent_dvd_iff_forall_pow_eq_one`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Monoid.exponent_dvd_iff_forall_pow_eq_one",
+      "ZMod.val_coe_unit_coprime",
+      "IsLeast",
+      "least universal exponent"
+    ],
+    "prerequisites": ["euler-totient-oq-02-oq-02"]
+  },
+  {
+    "id": "ann-refines",
+    "proofId": "euler-totient-oq-02-oq-02-oq-01",
+    "range": { "startLine": 142, "endLine": 167 },
+    "type": "insight",
+    "title": "λ Refines the Parent: orderOf a ∣ λ(n) ∣ φ(n)",
+    "content": "The parent's main theorem factors through λ:\n```\ntheorem orderOf_unit_dvd_totient_via_carmichael [NeZero n] (a : (ZMod n)ˣ) :\n    orderOf a ∣ n.totient :=\n  (orderOf_unit_dvd_carmichael a).trans (ArithmeticFunction.carmichael_dvd_totient n)\n```\nThe parent proved `orderOf a ∣ φ(n)` directly. Here it is a *consequence* of the sharper `orderOf a ∣ λ(n)` composed with `λ(n) ∣ φ(n)`, exhibiting λ(n) as the true bottleneck. `pow_mod_carmichael_modEq` correspondingly sharpens exponent reduction to `a^k ≡ a^(k % λ(n))` — the smallest period valid uniformly over all coprime bases.",
+    "mathContext": "$\\operatorname{ord}(a) \\mid \\lambda(n) \\mid \\varphi(n)$ and $a^k \\equiv a^{k \\bmod \\lambda(n)} \\pmod n$. Sharper than the parent's reduction modulo $\\varphi(n)$ since $\\lambda(n) \\mid \\varphi(n)$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Monoid.order_dvd_exponent",
+      "carmichael_dvd_totient",
+      "exponent reduction"
+    ],
+    "prerequisites": ["euler-totient-oq-02-oq-02"]
+  },
+  {
+    "id": "ann-boundary",
+    "proofId": "euler-totient-oq-02-oq-02-oq-01",
+    "range": { "startLine": 176, "endLine": 221 },
+    "type": "insight",
+    "title": "The Boundary: λ(n) = φ(n) ⟺ Cyclic, Strict at n = 8",
+    "content": "When do the Carmichael and Euler exponents agree?\n```\ntheorem carmichael_eq_totient_iff_isCyclic [NeZero n] :\n    Carmichael n = n.totient ↔ IsCyclic (ZMod n)ˣ\n```\nExactly when `(ℤ/nℤ)ˣ` is cyclic — i.e. when `n` has a primitive root (`n ∈ {1,2,4,pᵏ,2pᵏ}`) — via `IsCyclic.iff_exponent_eq_card`. Off this locus λ is strictly smaller. The sharp examples: `carmichael_prime` gives `λ(p) = φ(p) = p-1` at every prime, while `carmichael_eight_lt_totient` gives `λ(8) = 2 < 4 = φ(8)`, the smallest witness, obtained from the abstract non-cyclic criterion and `ZMod.not_isCyclic_units_eight` — no `native_decide`, so still 0-axiom.",
+    "mathContext": "$\\lambda(n) = \\varphi(n) \\iff (\\mathbb{Z}/n\\mathbb{Z})^\\times$ cyclic (a finite abelian group is cyclic iff exponent $=$ order). $(\\mathbb{Z}/8\\mathbb{Z})^\\times \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ is non-cyclic, so $\\lambda(8) = 2 < 4 = \\varphi(8)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsCyclic.iff_exponent_eq_card",
+      "ZMod.not_isCyclic_units_eight",
+      "primitive root",
+      "carmichael_two_pow_of_ne_two"
+    ],
+    "prerequisites": ["euler-totient-oq-02-oq-02"]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-02-oq-01/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "euler-totient-oq-02-oq-02-oq-01",
+  "title": "The Carmichael Function λ(n) as the True Universal Exponent of (ℤ/nℤ)ˣ",
+  "slug": "euler-totient-oq-02-oq-02-oq-01",
+  "description": "The parent entry shows φ(n) is *a* universal exponent (orderOf a ∣ φ(n)); this entry pins down the *minimal* one. The Carmichael function λ(n) = exponent (ℤ/nℤ)ˣ (Mathlib's ArithmeticFunction.Carmichael) is proved to be the TRUE universal exponent in number-theoretic ModEq form: a^λ(n) ≡ 1 (mod n) for coprime a, and — the exact characterisation — λ(n) ∣ m iff a^m ≡ 1 (mod n) for every coprime a. Hence λ(n) is the least positive universal exponent (IsLeast), it divides φ(n), and it sharpens the parent's exponent-reduction to a^k ≡ a^(k mod λ(n)). The boundary phenomenon λ(n) = φ(n) ⟺ (ℤ/nℤ)ˣ cyclic ⟺ n has a primitive root is proved, with the sharp examples λ(p) = φ(p) at primes but λ(8) = 2 < 4 = φ(8). 16 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "group-theory",
+      "modular-arithmetic",
+      "carmichael-function",
+      "totient",
+      "exponent",
+      "primitive-root"
+    ],
+    "proofRepoPath": "Proofs/EulerTotientOQ02OQ02OQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide`. The key theorems `carmichael_isLeast_universal`, `carmichael_dvd_iff`, `carmichael_eq_totient_iff_isCyclic`, and `carmichael_eight_lt_totient` were confirmed via `#print axioms` to depend only on the ordinary foundational axioms propext, Classical.choice, Quot.sound; there is no `sorryAx` and no `Lean.ofReduceBool`. The single concrete evaluation λ(8) = 2 is obtained from Mathlib's closed-form `carmichael_two_pow_of_ne_two` (not a decision procedure), and Mathlib's `ZMod.not_isCyclic_units_eight` uses only kernel `decide`, so no `Lean.ofReduceBool` enters.",
+    "lineCount": 223,
+    "theoremCount": 16,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-07-01"
+  },
+  "overview": {
+    "historicalContext": "Euler's theorem gives $\\varphi(n)$ as an exponent that annihilates every unit of $\\mathbb{Z}/n\\mathbb{Z}$: $a^{\\varphi(n)} \\equiv 1 \\pmod n$ whenever $\\gcd(a,n)=1$. But $\\varphi(n)$ is usually *not* the smallest such exponent. In 1910 Robert Carmichael introduced the **reduced totient**, or **Carmichael function** $\\lambda(n)$, defined as the exponent of the group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ — the least $m$ with $a^m \\equiv 1 \\pmod n$ for all coprime $a$. It satisfies $\\lambda(n) \\mid \\varphi(n)$, with equality exactly when $n$ possesses a primitive root ($n = 1,2,4,p^k,2p^k$). The gap can be large: $\\lambda(2^k) = 2^{k-2}$ for $k \\ge 3$ while $\\varphi(2^k) = 2^{k-1}$.\n\nMathlib formalises $\\lambda$ as `ArithmeticFunction.Carmichael`, defined group-theoretically as `Monoid.exponent (ZMod n)ˣ`, and develops its multiplicative structure (a formula through the prime factorisation). What Mathlib does **not** state is the number-theoretic characterisation that motivates the definition — that $\\lambda(n)$ is the least universal exponent in the $\\bmod n$ / `Nat.ModEq` world where the parent entry [Euler's Theorem via the Group Structure](euler-totient-oq-02-oq-02) lives. This entry supplies exactly that bridge.",
+    "problemStatement": "**Open Question (OQ-02-OQ-02-OQ-01)**: The parent entry proves $\\varphi(n)$ is *a* universal exponent for $(\\mathbb{Z}/n\\mathbb{Z})^\\times$. Is there a canonical *minimal* universal exponent, and can it be characterised $0$-axiom in number-theoretic `ModEq` terms — not merely group-theoretically — together with the precise conditions under which it improves on $\\varphi(n)$?\n\n**Answer: YES — it is the Carmichael function $\\lambda(n)$.** In `Nat.ModEq` form, $a^{\\lambda(n)} \\equiv 1 \\pmod n$ for every coprime $a$, and the sharp statement holds: $\\lambda(n) \\mid m$ **if and only if** $a^m \\equiv 1 \\pmod n$ for every coprime $a$. Thus $\\lambda(n)$ is the least positive universal exponent (`IsLeast`), it divides $\\varphi(n)$, and it drives the sharpest exponent reduction $a^k \\equiv a^{k \\bmod \\lambda(n)}$. Finally $\\lambda(n) = \\varphi(n) \\iff (\\mathbb{Z}/n\\mathbb{Z})^\\times$ is cyclic, so $\\lambda$ is *strictly* smaller than $\\varphi$ precisely off the primitive-root locus — witnessed by $\\lambda(8)=2<4=\\varphi(8)$.",
+    "proofStrategy": "The file routes every arithmetic statement through one dictionary lemma and then imports Mathlib's group-level Carmichael facts.\n\n**Section I (the bridge):** `modEq_one_iff_cast_pow` shows `a^m ≡ 1 [MOD n] ↔ (a : ZMod n)^m = 1`, converting congruences into equations in `ZMod n`.\n\n**Section II (λ is universal):** `carmichael_modEq` proves `a^λ(n) ≡ 1 [MOD n]` for coprime `a`, the `ℕ`-shadow of Mathlib's `pow_carmichael` obtained by realising `a` as a unit via `ZMod.isUnit_iff_coprime`. `carmichael_ne_zero` / `carmichael_pos` record positivity from `Monoid.exponent_ne_zero_of_finite`.\n\n**Section III (λ is least):** `carmichael_dvd_iff` is the core theorem — `λ(n) ∣ m ↔ ∀ coprime a, a^m ≡ 1 [MOD n]` — proved through `Monoid.exponent_dvd_iff_forall_pow_eq_one`, with the backward direction realising each unit `u` by the coprime natural `u.val` (`ZMod.val_coe_unit_coprime`, `ZMod.natCast_zmod_val`). `carmichael_le_of_universal` and `carmichael_isLeast_universal` package this as `IsLeast`: λ(n) is the least element of the set of positive universal exponents.\n\n**Section IV (refines the parent):** `orderOf_unit_dvd_carmichael` gives `orderOf a ∣ λ(n)`, and `orderOf_unit_dvd_totient_via_carmichael` re-derives the parent's `orderOf a ∣ φ(n)` through the factorisation `orderOf a ∣ λ(n) ∣ φ(n)`. `pow_mod_carmichael_modEq` sharpens exponent reduction to `a^k ≡ a^(k % λ(n))`.\n\n**Section V (the boundary):** `carmichael_eq_totient_iff_isCyclic` proves `λ(n) = φ(n) ↔ IsCyclic (ZMod n)ˣ` from `IsCyclic.iff_exponent_eq_card`, and `carmichael_lt_totient_of_not_isCyclic` deduces strict inequality off the cyclic locus.\n\n**Section VI (sharp examples):** `carmichael_prime` shows `λ(p) = φ(p)` at every prime (unit group cyclic), while `carmichael_eight` computes `λ(8) = 2` and `carmichael_eight_lt_totient` exhibits `λ(8) = 2 < 4 = φ(8)` via the abstract non-cyclic criterion and `ZMod.not_isCyclic_units_eight`.",
+    "keyInsights": [
+      "The definition of λ(n) is group-theoretic (exponent of (ℤ/nℤ)ˣ), but its meaning is number-theoretic: it is the least m with a^m ≡ 1 (mod n) for all coprime a. carmichael_dvd_iff makes this precise as an iff — the universal exponents are exactly the multiples of λ(n) — turning 'least universal exponent' from an informal description into a proved IsLeast statement.",
+      "λ(n) is the sharp version of the parent's φ(n). The parent showed orderOf a ∣ φ(n); here orderOf a ∣ λ(n) ∣ φ(n), so λ(n) is the genuine bottleneck. Every universal exponent the parent could offer — φ(n) included — is forced to be a multiple of λ(n).",
+      "The backward direction of carmichael_dvd_iff is the crux: passing from 'a^m ≡ 1 for all coprime naturals a' to 'u^m = 1 for all units u'. Each unit u is hit by the coprime natural u.val (ZMod.val_coe_unit_coprime), and natCast_zmod_val closes the loop (u.val : ZMod n) = u. This is what lets Monoid.exponent_dvd_iff_forall_pow_eq_one fire.",
+      "λ(n) = φ(n) is not an accident but a structural dichotomy: it holds exactly when (ℤ/nℤ)ˣ is cyclic, i.e. when n has a primitive root (n ∈ {1,2,4,p^k,2p^k}). carmichael_eq_totient_iff_isCyclic captures this via IsCyclic.iff_exponent_eq_card (cyclic ⟺ exponent = order), converting a delicate number-theoretic classification into a one-line group fact.",
+      "The strict improvement is real and elementary: λ(8) = 2 < 4 = φ(8) because (ℤ/8ℤ)ˣ ≅ ℤ/2 × ℤ/2 has every element of order ≤ 2. Obtaining this from Mathlib's closed form carmichael_two_pow_of_ne_two (rather than native_decide) keeps the witness 0-axiom, so even the concrete example avoids Lean.ofReduceBool."
+    ],
+    "prerequisites": [
+      "Euler's theorem and the parent entry euler-totient-oq-02-oq-02 (orderOf a ∣ φ(n))",
+      "The Carmichael function as the group exponent: ArithmeticFunction.Carmichael, carmichael_eq_exponent', pow_carmichael, carmichael_dvd_totient",
+      "Monoid.exponent API: exponent_dvd_iff_forall_pow_eq_one, order_dvd_exponent, exponent_ne_zero_of_finite",
+      "The cyclic characterisation IsCyclic.iff_exponent_eq_card and ZMod.card_units_eq_totient",
+      "The ZMod ⇄ ℕ dictionary: ZMod.isUnit_iff_coprime, val_coe_unit_coprime, natCast_zmod_val, natCast_eq_natCast_iff"
+    ]
+  },
+  "sections": [
+    {
+      "id": "bridge",
+      "title": "Section I: The Arithmetic ⇄ Group Dictionary",
+      "startLine": 60,
+      "endLine": 62,
+      "summary": "modEq_one_iff_cast_pow: a^m ≡ 1 [MOD n] ↔ (a : ZMod n)^m = 1. The single lemma through which every arithmetic statement is routed into the group (ℤ/nℤ)ˣ.",
+      "mathContext": "$a^m \\equiv 1 \\pmod n \\iff (a \\bmod n)^m = 1$ in $\\mathbb{Z}/n\\mathbb{Z}$. Proof: `ZMod.natCast_eq_natCast_iff` turns the congruence into an equality of casts, then `Nat.cast_pow` / `Nat.cast_one` normalise."
+    },
+    {
+      "id": "universal",
+      "title": "Section II: λ(n) is a Universal Exponent (Arithmetic Form)",
+      "startLine": 71,
+      "endLine": 85,
+      "summary": "carmichael_modEq: a^λ(n) ≡ 1 [MOD n] for coprime a — the ℕ-shadow of Mathlib's group-level pow_carmichael. carmichael_ne_zero / carmichael_pos record positivity of λ(n) for n ≠ 0.",
+      "mathContext": "$a^{\\lambda(n)} \\equiv 1 \\pmod n$ for $\\gcd(a,n)=1$. A coprime residue is a unit (`ZMod.isUnit_iff_coprime`), and Mathlib's `pow_carmichael` kills every unit with the group exponent $\\lambda(n)$. Positivity follows from finiteness of $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ via `Monoid.exponent_ne_zero_of_finite`."
+    },
+    {
+      "id": "least",
+      "title": "Section III: λ(n) is the Least Universal Exponent",
+      "startLine": 98,
+      "endLine": 134,
+      "summary": "carmichael_dvd_iff: λ(n) ∣ m ↔ (∀ coprime a, a^m ≡ 1 [MOD n]) — universal exponents are exactly the multiples of λ(n). carmichael_le_of_universal and carmichael_isLeast_universal package this as IsLeast: λ(n) is the least positive universal exponent.",
+      "mathContext": "$\\lambda(n) \\mid m \\iff \\forall a\\ \\text{coprime},\\ a^m \\equiv 1 \\pmod n$. Forward: multiples of the exponent kill every unit (`Monoid.exponent_dvd_iff_forall_pow_eq_one`). Backward: each unit $u$ is realised by the coprime natural $u.\\mathrm{val}$, so the arithmetic hypothesis forces $u^m = 1$ and hence $\\mathrm{exponent} \\mid m$. Consequently $\\lambda(n) = \\min\\{m > 0 : \\forall a\\ \\text{coprime},\\ a^m \\equiv 1\\}$."
+    },
+    {
+      "id": "refines",
+      "title": "Section IV: λ Refines the Parent's φ",
+      "startLine": 142,
+      "endLine": 167,
+      "summary": "orderOf_unit_dvd_carmichael (orderOf a ∣ λ(n)) and orderOf_unit_dvd_totient_via_carmichael re-derive the parent's orderOf a ∣ φ(n) through orderOf a ∣ λ(n) ∣ φ(n). pow_mod_carmichael_modEq sharpens exponent reduction to a^k ≡ a^(k % λ(n)).",
+      "mathContext": "$\\operatorname{ord}(a) \\mid \\lambda(n) \\mid \\varphi(n)$: $\\lambda(n)$ is the true bottleneck between an element's order and $\\varphi(n)$. The reduction $a^k \\equiv a^{k \\bmod \\lambda(n)} \\pmod n$ uses the smallest period guaranteed uniformly over all coprime bases — strictly sharper than the parent's reduction modulo $\\varphi(n)$."
+    },
+    {
+      "id": "boundary",
+      "title": "Section V: The Sharp Boundary λ(n) = φ(n) ⟺ (ℤ/nℤ)ˣ Cyclic",
+      "startLine": 176,
+      "endLine": 194,
+      "summary": "carmichael_eq_totient_iff_isCyclic: λ(n) = φ(n) ↔ IsCyclic (ℤ/nℤ)ˣ (iff n has a primitive root). carmichael_lt_totient_of_not_isCyclic: off the cyclic locus, λ(n) < φ(n) strictly.",
+      "mathContext": "$\\lambda(n) = \\varphi(n) \\iff (\\mathbb{Z}/n\\mathbb{Z})^\\times$ is cyclic, via `IsCyclic.iff_exponent_eq_card` (a finite abelian group is cyclic iff its exponent equals its order) and $|(\\mathbb{Z}/n\\mathbb{Z})^\\times| = \\varphi(n)$. Since $\\lambda(n) \\mid \\varphi(n)$ with both positive, non-cyclicity forces strict inequality $\\lambda(n) < \\varphi(n)$."
+    },
+    {
+      "id": "examples",
+      "title": "Section VI: Sharp Examples — Equality at Primes, Strict at n = 8",
+      "startLine": 201,
+      "endLine": 221,
+      "summary": "carmichael_prime (λ(p) = φ(p) = p-1 at every prime, unit group cyclic) versus carmichael_eight (λ(8) = 2) and carmichael_eight_lt_totient (λ(8) = 2 < 4 = φ(8)), the latter via the abstract non-cyclic criterion.",
+      "mathContext": "At a prime $p$ the field $\\mathbb{Z}/p\\mathbb{Z}$ has cyclic unit group, so $\\lambda(p) = \\varphi(p) = p-1$. At $n = 8$, $(\\mathbb{Z}/8\\mathbb{Z})^\\times \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ is non-cyclic with every element of order $\\le 2$, giving $\\lambda(8) = 2 < 4 = \\varphi(8)$ — the smallest modulus witnessing $\\lambda \\ne \\varphi$."
+    }
+  ],
+  "conclusion": "The Carmichael function λ(n) = exponent (ℤ/nℤ)ˣ is the true universal exponent that the parent entry's φ(n) only approximates: in number-theoretic ModEq form it is the least positive m with a^m ≡ 1 (mod n) for all coprime a (carmichael_isLeast_universal), characterised exactly by λ(n) ∣ m ↔ (∀ coprime a, a^m ≡ 1). It divides φ(n) and refines the parent's order-divisibility to orderOf a ∣ λ(n) ∣ φ(n), sharpening exponent reduction to a^k ≡ a^(k mod λ(n)). The two functions coincide exactly on the primitive-root locus — λ(n) = φ(n) ⟺ (ℤ/nℤ)ˣ cyclic — with λ(p) = φ(p) at every prime but λ(8) = 2 < 4 = φ(8). All 16 theorems are 0-axiom (propext, Classical.choice, Quot.sound only; no native_decide, no Lean.ofReduceBool).",
+  "references": [
+    {
+      "title": "R. D. Carmichael, Note on a new number theory function (1910)",
+      "url": "https://www.ams.org/journals/bull/1910-16-05/S0002-9904-1910-01892-9/"
+    },
+    {
+      "title": "Carmichael function — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Carmichael_function"
+    },
+    {
+      "title": "Mathlib: ArithmeticFunction.Carmichael",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/ArithmeticFunction/Carmichael.html"
+    },
+    {
+      "title": "Mathlib: Monoid.exponent",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/Exponent.html"
+    }
+  ],
+  "crossReferences": [
+    "euler-totient-oq-02-oq-02",
+    "euler-totient"
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **`euler-totient-oq-02-oq-02-oq-01`**. The parent entry proves `φ(n)` is *a* universal exponent (`orderOf a ∣ φ(n)`); this entry pins down the **minimal** one — the **Carmichael function** `λ(n) = exponent (ℤ/nℤ)ˣ` (Mathlib's `ArithmeticFunction.Carmichael`).

Mathlib develops λ only group-theoretically. This entry supplies the missing **number-theoretic `ModEq` characterisation** that ties λ to the parent's world:

- `carmichael_modEq` — `a^λ(n) ≡ 1 (mod n)` for coprime `a` (ℕ-shadow of `pow_carmichael`)
- `carmichael_dvd_iff` — the **exact characterisation**: `λ(n) ∣ m ↔ ∀ coprime a, a^m ≡ 1 (mod n)` (universal exponents = multiples of λ(n))
- `carmichael_isLeast_universal` — **`IsLeast`** packaging: λ(n) is the least positive universal exponent (the *true* universal exponent)
- `orderOf_unit_dvd_totient_via_carmichael` — re-derives the parent's theorem through `orderOf a ∣ λ(n) ∣ φ(n)`
- `pow_mod_carmichael_modEq` — sharper exponent reduction `a^k ≡ a^(k mod λ(n))`
- `carmichael_eq_totient_iff_isCyclic` — the boundary: `λ(n) = φ(n) ⟺ (ℤ/nℤ)ˣ cyclic ⟺ n has a primitive root`
- `carmichael_prime` / `carmichael_eight_lt_totient` — sharp examples: `λ(p) = φ(p)` at primes, but `λ(8) = 2 < 4 = φ(8)`

## Verification

- **16 theorems, 0 sorries, 0 `axiom` declarations, no `native_decide`**
- Builds under `./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ02OQ02OQ01` (7743 jobs, Build succeeded)
- `#print axioms` on the key theorems: only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`
- The concrete value `λ(8) = 2` comes from Mathlib's closed form `carmichael_two_pow_of_ne_two` (not a decision procedure); `ZMod.not_isCyclic_units_eight` uses only kernel `decide`

## Files
- `proofs/Proofs/EulerTotientOQ02OQ02OQ01.lean` (223 lines)
- `src/data/proofs/euler-totient-oq-02-oq-02-oq-01/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)