### PR TITLE
audit: 21 never-audited OQ entries clean (gallery integrity)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26911,8 +26911,134 @@
       "lastAudited": "2026-07-01T20:12:13Z",
       "result": "clean",
       "issues": []
+    },
+    "algebraic-numbers-countable-oq-07-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-03-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-02-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-group-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-04-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-06-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cramers-rule-oq-01-oq-04-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-101-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-101-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-totient-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fourth-root-2-irrational-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hermite-legendre-factorial-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inverse-galois-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mean-value-theorem-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "polynomial-derivative-leibniz-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "prob-method-lovasz-local-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shannon-entropy-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T22:34:45Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-01T17:43:53Z"
+  "lastUpdated": "2026-07-01T22:34:45Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Verified meta.json claims against Lean source for **21 never-audited** gallery entries. All records marked **clean** in \`audit-tracker.json\`.

### Checks performed per entry
- sorry count (proof-term, not docstring mentions) vs \`meta.sorries\`
- \`axiom\` declarations + \`native_decide\` vs \`axiomCount\`
- theorem/def counts vs \`leanFile\`
- badge/status vs tier (original / mathlib / verified)
- True-stub and assumption-carrying-structure detection

### Notable findings (all resolved as compliant)
- **angle-trisection-oq-03-oq-02-oq-03**: 7 \`native_decide\` calls are confined to illustrative \`example\` blocks (Part VI, "In example blocks only"). Presented theorems (\`pHalvings_*\`) use \`omega\` and are axiom-free, so \`axiomCount: 0\` / \`verified\` is policy-compliant. (Could be hardened by swapping the examples to \`decide\`.)
- **erdos-101-oq-01-oq-01/02, fibonacci-identities-oq-03-oq-02-oq-01, geometric-series-oq-07…**: apparent "sorry" hits were docstring mentions ("no \`sorry\`"), not proof-term sorries — clean.
- **algebraic-numbers-countable-oq-07-oq-03, cauchy-group-theorem-oq-01-oq-03**: \`mathlib\` badge correctly discloses Mathlib reliance.

### Entries audited (21)
algebraic-numbers-countable-oq-07-oq-03, angle-trisection-oq-03-oq-02-oq-03, binomial-theorem-oq-02-oq-01-oq-02-oq-02, cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01-oq-02, cauchy-group-theorem-oq-01-oq-03, cauchy-schwarz-oq-04-oq-02-oq-01, combinations-formula-oq-06-oq-02-oq-02, cramers-rule-oq-01-oq-04-oq-03, erdos-101-oq-01-oq-01, erdos-101-oq-01-oq-02, euler-totient-oq-02-oq-02-oq-01, fibonacci-identities-oq-03-oq-02-oq-01, fibonacci-identities-oq-07, fourth-root-2-irrational-oq-01, geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01, hermite-legendre-factorial-oq-02, inverse-galois-oq-05, mean-value-theorem-oq-04-oq-01, polynomial-derivative-leibniz-oq-01, prob-method-lovasz-local-oq-03, shannon-entropy-oq-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)