### PR TITLE
Draft: θ(x)=Θ(x) transfer from ψ=Θ(x) (chebyshev-bounds-oq-02-oq-01-oq-02)

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ02.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ02.lean
@@ -1,0 +1,148 @@
+import Mathlib
+import Proofs.ChebyshevBoundsOQ02OQ01
+
+/-!
+# Chebyshev bounds OQ-02-OQ-01-OQ-02: transferring `ψ = Θ(x)` to `θ = Θ(x)`
+
+The parent entry (`chebyshev-bounds-oq-02-oq-01`) proves the elementary two–sided estimate
+`(log 2 / 3)·m ≤ ψ(m) ≤ (log 4 + 4)·m` for the **second** Chebyshev function, i.e. `ψ(x) = Θ(x)`.
+This entry answers the open question of **transferring that growth rate to the first Chebyshev
+function** `θ`, obtaining `θ(x) = Θ(x)`.
+
+The transfer rests on two Mathlib facts:
+
+* `Chebyshev.theta_le_psi` : `θ x ≤ ψ x` (θ counts only primes, ψ counts prime powers), and
+* `Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log` : `|ψ x − θ x| ≤ 2√x·log x`.
+
+The upper bound is immediate: `θ(x) ≤ ψ(x) ≤ (log 4 + 4)·x`.  For the lower bound we write
+`θ(x) = ψ(x) − (ψ(x) − θ(x)) ≥ ψ(x) − 2√x·log x`.  Since the parent gives `ψ(x) ≥ (log 2 / 6)·x`
+for `x ≥ 2` (bridging real `x` to `⌊x⌋₊`) and the correction `2√x·log x = o(x)`, eventually
+`θ(x) ≥ (log 2 / 12)·x`.  Packaging both bounds as `Asymptotics.IsTheta` gives `θ =Θ[atTop] id`.
+
+## Main results
+
+* `theta_le_linear` : `θ(x) ≤ (log 4 + 4)·x` for `x ≥ 0`.
+* `psi_ge_linear` : `(log 2 / 6)·x ≤ ψ(x)` for `x ≥ 2` (real lower bound via the floor bridge).
+* `two_sqrt_mul_log_isLittleO` : `2√x·log x = o(x)`.
+* `theta_ge_eventually` : eventually `(log 2 / 12)·x ≤ θ(x)`.
+* `theta_isBigO_id` / `id_isBigO_theta` : the two `O`-bounds.
+* `theta_isTheta_id` : **`θ =Θ[atTop] (fun x => x)`**, i.e. `θ(x) = Θ(x)`.
+-/
+
+namespace ChebyshevBoundsOQ02OQ01OQ02
+
+open Filter Asymptotics Chebyshev
+open scoped Topology
+
+/-- `log x / √x → 0` as `x → ∞` (logarithm grows slower than any positive power).  This is the
+Mathlib-only fact behind the `o(x)` correction; also proved in the sibling `ChebyshevBoundsOQ03`
+but inlined here to keep this file's build surface to `Mathlib` + the parent. -/
+theorem log_div_sqrt_tendsto_zero :
+    Tendsto (fun x : ℝ => Real.log x / Real.sqrt x) atTop (𝓝 0) := by
+  have h := (isLittleO_log_rpow_atTop (by norm_num : (0 : ℝ) < 1 / 2)).tendsto_div_nhds_zero
+  refine h.congr' ?_
+  filter_upwards [eventually_ge_atTop (0 : ℝ)] with x hx
+  rw [Real.sqrt_eq_rpow]
+
+/-- **Upper bound.** `θ(x) ≤ (log 4 + 4)·x` for `x ≥ 0`: since `θ ≤ ψ` and `ψ` is bounded by the
+same linear function (`Chebyshev.psi_le_const_mul_self`). -/
+theorem theta_le_linear {x : ℝ} (hx : 0 ≤ x) : θ x ≤ (Real.log 4 + 4) * x :=
+  (Chebyshev.theta_le_psi x).trans (Chebyshev.psi_le_const_mul_self hx)
+
+/-- **Floor bridge.** For real `x`, `ψ(x)` equals the parent's natural-number Chebyshev sum at
+`⌊x⌋₊`, because both are `∑_{n ≤ ⌊x⌋₊} Λ(n)`. -/
+theorem psi_eq_chebyshevPsi_floor (x : ℝ) :
+    ψ x = ChebyshevBoundsOQ02OQ01.chebyshevPsi ⌊x⌋₊ := by
+  rw [ChebyshevBoundsOQ02OQ01.chebyshevPsi_eq_psi, Chebyshev.psi_eq_sum_Icc,
+    Chebyshev.psi_eq_sum_Icc, Nat.floor_natCast]
+
+/-- **Real lower bound.** `(log 2 / 6)·x ≤ ψ(x)` for `x ≥ 2`.  We pass to `n := ⌊x⌋₊ ≥ 2`, use the
+parent's `(log 2 / 3)·n ≤ ψ(n)`, and bound `n ≥ x − 1 ≥ x/2`. -/
+theorem psi_ge_linear {x : ℝ} (hx : 2 ≤ x) : Real.log 2 / 6 * x ≤ ψ x := by
+  set n := ⌊x⌋₊ with hn
+  have hn2 : 2 ≤ n := by rw [hn]; exact Nat.le_floor (by exact_mod_cast hx)
+  have hpsi_eq : ψ x = ChebyshevBoundsOQ02OQ01.chebyshevPsi n := psi_eq_chebyshevPsi_floor x
+  have hlow : Real.log 2 / 3 * (n : ℝ) ≤ ChebyshevBoundsOQ02OQ01.chebyshevPsi n :=
+    ChebyshevBoundsOQ02OQ01.chebyshevPsi_lower_linear hn2
+  have hfloor_ge : x - 1 ≤ (n : ℝ) := by
+    have h := Nat.lt_floor_add_one x
+    rw [← hn] at h; linarith
+  have hxhalf : x / 2 ≤ (n : ℝ) := by linarith
+  have hlog2 : (0 : ℝ) ≤ Real.log 2 := Real.log_nonneg (by norm_num)
+  calc Real.log 2 / 6 * x = Real.log 2 / 3 * (x / 2) := by ring
+    _ ≤ Real.log 2 / 3 * (n : ℝ) := mul_le_mul_of_nonneg_left hxhalf (by linarith)
+    _ ≤ ChebyshevBoundsOQ02OQ01.chebyshevPsi n := hlow
+    _ = ψ x := hpsi_eq.symm
+
+/-- The prime-power correction is `o(x)`: `2√x·log x = o(x)` as `x → ∞`. -/
+theorem two_sqrt_mul_log_isLittleO :
+    (fun x : ℝ => 2 * Real.sqrt x * Real.log x) =o[atTop] (fun x : ℝ => x) := by
+  rw [Asymptotics.isLittleO_iff]
+  intro c hc
+  have hdiv : Tendsto (fun x : ℝ => 2 * Real.log x / Real.sqrt x) atTop (𝓝 0) := by
+    have h := log_div_sqrt_tendsto_zero.const_mul (2 : ℝ)
+    simpa [mul_div_assoc] using h
+  filter_upwards [hdiv.eventually_le_const hc, eventually_ge_atTop (1 : ℝ)] with x hxc hx1
+  have hx0 : (0 : ℝ) < x := by linarith
+  have hsqrt_pos : (0 : ℝ) < Real.sqrt x := Real.sqrt_pos.mpr hx0
+  have hsqrt_sq : Real.sqrt x * Real.sqrt x = x := Real.mul_self_sqrt hx0.le
+  have hlogx : 0 ≤ Real.log x := Real.log_nonneg hx1
+  have hprod_nonneg : (0 : ℝ) ≤ 2 * Real.sqrt x * Real.log x :=
+    mul_nonneg (mul_nonneg (by norm_num) hsqrt_pos.le) hlogx
+  rw [Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg hx0.le, abs_of_nonneg hprod_nonneg]
+  -- from `2 log x / √x ≤ c` (multiply by `√x > 0`) get `2 log x ≤ c·√x`
+  have key : 2 * Real.log x ≤ c * Real.sqrt x := (div_le_iff₀ hsqrt_pos).mp hxc
+  have h2 : 2 * Real.log x * Real.sqrt x ≤ c * Real.sqrt x * Real.sqrt x :=
+    mul_le_mul_of_nonneg_right key hsqrt_pos.le
+  calc 2 * Real.sqrt x * Real.log x
+      = 2 * Real.log x * Real.sqrt x := by ring
+    _ ≤ c * Real.sqrt x * Real.sqrt x := h2
+    _ = c * x := by rw [mul_assoc, hsqrt_sq]
+
+/-- Eventually `2√x·log x ≤ (log 2 / 12)·x`. -/
+theorem two_sqrt_mul_log_le_eventually :
+    ∀ᶠ x : ℝ in atTop, 2 * Real.sqrt x * Real.log x ≤ Real.log 2 / 12 * x := by
+  have hc : (0 : ℝ) < Real.log 2 / 12 := by
+    have := Real.log_pos (by norm_num : (1 : ℝ) < 2); linarith
+  have h := two_sqrt_mul_log_isLittleO
+  rw [Asymptotics.isLittleO_iff] at h
+  filter_upwards [h hc, eventually_ge_atTop (0 : ℝ)] with x hx hx0
+  rw [Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg hx0] at hx
+  linarith [le_abs_self (2 * Real.sqrt x * Real.log x), hx]
+
+/-- **Lower bound, eventual linear form.** Eventually `(log 2 / 12)·x ≤ θ(x)`. -/
+theorem theta_ge_eventually :
+    ∀ᶠ x : ℝ in atTop, Real.log 2 / 12 * x ≤ θ x := by
+  filter_upwards [two_sqrt_mul_log_le_eventually, eventually_ge_atTop (2 : ℝ),
+    eventually_ge_atTop (1 : ℝ)] with x hxbound hx2 hx1
+  have hpsi := psi_ge_linear hx2
+  have habs := Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log hx1
+  have hle : ψ x - θ x ≤ 2 * Real.sqrt x * Real.log x := (le_abs_self _).trans habs
+  linarith [hpsi, hle, hxbound]
+
+/-- **`θ = O(x)`.** -/
+theorem theta_isBigO_id : (fun x : ℝ => θ x) =O[atTop] (fun x : ℝ => x) := by
+  rw [Asymptotics.isBigO_iff]
+  refine ⟨Real.log 4 + 4, ?_⟩
+  filter_upwards [eventually_ge_atTop (0 : ℝ)] with x hx0
+  rw [Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg hx0,
+    abs_of_nonneg (Chebyshev.theta_nonneg x)]
+  exact theta_le_linear hx0
+
+/-- **`x = O(θ)`.** -/
+theorem id_isBigO_theta : (fun x : ℝ => x) =O[atTop] (fun x : ℝ => θ x) := by
+  rw [Asymptotics.isBigO_iff]
+  refine ⟨12 / Real.log 2, ?_⟩
+  have hlog2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  filter_upwards [theta_ge_eventually, eventually_ge_atTop (0 : ℝ)] with x hx hx0
+  rw [Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg hx0,
+    abs_of_nonneg (Chebyshev.theta_nonneg x)]
+  rw [div_mul_eq_mul_div, le_div_iff₀ hlog2]
+  nlinarith [hx, hlog2]
+
+/-- **Main result: `θ(x) = Θ(x)`.** The first Chebyshev function has the same linear growth rate
+as the identity, transferred from `ψ(x) = Θ(x)`. -/
+theorem theta_isTheta_id : (fun x : ℝ => θ x) =Θ[atTop] (fun x : ℝ => x) :=
+  ⟨theta_isBigO_id, id_isBigO_theta⟩
+
+end ChebyshevBoundsOQ02OQ01OQ02

--- a/research/problems/chebyshev-bounds-oq-02-oq-01-oq-02/knowledge.md
+++ b/research/problems/chebyshev-bounds-oq-02-oq-01-oq-02/knowledge.md
@@ -1,0 +1,68 @@
+# Knowledge: chebyshev-bounds-oq-02-oq-01-oq-02
+
+**Target**: `θ(x) = Θ(x)` — transfer the parent's `ψ(x) = Θ(x)` to the first Chebyshev function.
+Formalized as `θ =Θ[atTop] (fun x => x)`.
+
+## Summary
+
+Complete elementary proof drafted (`proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ02.lean`, 10 theorems,
+no `sorry`, no `axiom`; depends only on `Mathlib` + the parent `ChebyshevBoundsOQ02OQ01`). The proof
+is **not yet machine-verified** — the shared Docker build environment was saturated (5 concurrent
+`lean-build` containers, host disk 99% / ~10 GiB free) throughout the session, and Aristotle's MCP
+endpoint returned `Resource not found`. All Mathlib lemma names were checked against the pinned
+Mathlib source, and every tactic step was hand-audited. **Next session: build when
+`docker ps | grep lean-build` is empty, then upgrade status to `verified` and add gallery data.**
+
+## Session 2026-07-01 (Session 1) — FRESH → ACT
+
+**Mode**: FRESH
+**Outcome**: progress (complete unverified proof)
+
+### What I Did
+- Surveyed the rich `chebyshev-*` gallery ecosystem; confirmed the two load-bearing Mathlib facts
+  `Chebyshev.theta_le_psi` and `Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log` exist, plus the real
+  bound `Chebyshev.psi_le_const_mul_self : ψ x ≤ (log 4 + 4)·x`.
+- Confirmed the parent `ChebyshevBoundsOQ02OQ01` exports `chebyshevPsi_lower_linear`
+  (`(log 2/3)·n ≤ chebyshevPsi n` for `n ≥ 2`), `chebyshevPsi_eq_psi`, and `chebyshevPsi_mono`.
+- Designed and wrote the full transfer proof (see Key Findings).
+- Verified every non-trivial Mathlib lemma name against the pinned source:
+  `Filter.Tendsto.eventually_le_const`, `Filter.Tendsto.const_mul`, `Real.mul_self_sqrt`,
+  `Nat.le_floor`, `Nat.lt_floor_add_one`, `div_le_iff₀`, `le_div_iff₀`, `div_mul_eq_mul_div`,
+  `Asymptotics.isLittleO_iff` / `isBigO_iff`, `Chebyshev.{psi,theta}_nonneg`,
+  `Chebyshev.psi_eq_sum_Icc`, `Nat.floor_natCast`.
+
+### Key Findings (proof structure)
+1. **Upper bound** `theta_le_linear` : `θ(x) ≤ (log 4 + 4)·x` for `x ≥ 0` — one line:
+   `(theta_le_psi x).trans (psi_le_const_mul_self hx)`.
+2. **Floor bridge** `psi_eq_chebyshevPsi_floor` : `ψ(x) = chebyshevPsi ⌊x⌋₊`, since both unfold to
+   `∑_{n ∈ Icc 0 ⌊x⌋₊} Λ n` (via `psi_eq_sum_Icc` + `Nat.floor_natCast`).
+3. **Real lower bound** `psi_ge_linear` : `(log 2/6)·x ≤ ψ(x)` for `x ≥ 2`. Set `n := ⌊x⌋₊ ≥ 2`;
+   parent gives `(log 2/3)·n ≤ chebyshevPsi n = ψ x`; `n ≥ x − 1 ≥ x/2` gives the factor.
+4. **`o(x)` correction** `two_sqrt_mul_log_isLittleO` : `2√x·log x = o(x)`, from `log x/√x → 0`
+   (`log_div_sqrt_tendsto_zero`, inlined from the verified sibling OQ-03), rearranging
+   `2√x·log x / x = 2 log x/√x` via `√x·√x = x`.
+5. `two_sqrt_mul_log_le_eventually` : eventually `2√x·log x ≤ (log 2/12)·x`.
+6. **Eventual lower bound** `theta_ge_eventually` : eventually `(log 2/12)·x ≤ θ(x)`, from
+   `θ = ψ − (ψ − θ) ≥ ψ − |ψ − θ| ≥ (log 2/6)x − 2√x log x ≥ (log 2/12)x`.
+7. `theta_isBigO_id` (`θ = O(x)`), `id_isBigO_theta` (`x = O(θ)`, constant `12/log 2`), and the
+   capstone `theta_isTheta_id` : **`θ =Θ[atTop] (fun x => x)`**.
+
+### Gotchas Found During Self-Review
+- `positivity` **cannot** prove `0 ≤ 2·√x·log x` (sign of `log x` unknown) — replaced with
+  `mul_nonneg (mul_nonneg _ hsqrt_pos.le) hlogx` under the `x ≥ 1` hypothesis.
+- In `two_sqrt_mul_log_le_eventually`, do **not** strip the LHS `|·|`; use
+  `le_abs_self (2√x log x)` so no `log`-sign hypothesis is needed there.
+- Ended `two_sqrt_mul_log_isLittleO` with an explicit `calc` (× `√x` then `√x·√x = x`) rather than
+  a fragile `nlinarith` over a triple product.
+
+### Files Modified
+- `proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ02.lean` (new, complete, unverified)
+- `research/problems/chebyshev-bounds-oq-02-oq-01-oq-02/{problem.md, state.md, knowledge.md}`
+
+### Next Steps
+- Build `Proofs.ChebyshevBoundsOQ02OQ01OQ02` via `./proofs/scripts/docker-build.sh` when the
+  build host is idle; fix any residual tactic issues; run `#print axioms theta_isTheta_id`
+  (expect only `propext`, `Classical.choice`, `Quot.sound`).
+- On success: mark `status: "verified"`, `axiomCount: 0`, add gallery `meta.json` + annotations.
+- Optional follow-up OQ: explicit two-sided `θ` bounds `(log 2/6)m − 2√m log m ≤ θ(m) ≤ (log 4)m`
+  (the sibling OQ-02-OQ-01-OQ-01, currently unformalized).

--- a/research/problems/chebyshev-bounds-oq-02-oq-01-oq-02/problem.md
+++ b/research/problems/chebyshev-bounds-oq-02-oq-01-oq-02/problem.md
@@ -1,0 +1,62 @@
+# Problem: Transfer Chebyshev bounds from psi(n) to theta(n) = Theta(n)
+
+## Statement
+
+### Plain Language
+The parent entry proves the **second** Chebyshev function satisfies `ψ(x) = Θ(x)` (explicit
+two-sided linear bounds `(log 2/3)·m ≤ ψ(m) ≤ (log 4 + 4)·m`).  Transfer this growth rate to the
+**first** Chebyshev function `θ(x) = ∑_{p ≤ x} log p`, obtaining `θ(x) = Θ(x)`.
+
+### Formal Statement
+$$
+\theta(x) = \Theta(x) \quad\text{as } x \to \infty,
+$$
+formalized as `Asymptotics.IsTheta atTop θ (fun x => x)`, i.e. `θ =Θ[atTop] id`.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - analytic-number-theory
+  - chebyshev
+  - prime-counting
+  - theta-function
+  - asymptotics
+  - seeker-selected
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+`θ(x) = Θ(x)` is the Chebyshev estimate underlying the prime number theorem's order of magnitude:
+it is equivalent (by partial summation) to `π(x) = Θ(x/log x)`.  The parent formalized the analogous
+statement for `ψ`; here we complete the elementary picture by transferring it to `θ`, the more
+directly prime-counting function.
+
+## Approach
+
+The transfer is short given two Mathlib facts:
+
+* `Chebyshev.theta_le_psi : θ x ≤ ψ x`, and
+* `Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log : |ψ x − θ x| ≤ 2√x·log x` (the prime-power
+  correction).
+
+**Upper bound.** `θ(x) ≤ ψ(x) ≤ (log 4 + 4)·x` (`Chebyshev.psi_le_const_mul_self`).
+
+**Lower bound.** `θ(x) = ψ(x) − (ψ(x) − θ(x)) ≥ ψ(x) − 2√x·log x`.  The parent gives
+`ψ(x) ≥ (log 2 / 6)·x` for real `x ≥ 2` (via the floor bridge `ψ(x) = chebyshevPsi ⌊x⌋₊` and
+`⌊x⌋₊ ≥ x − 1 ≥ x/2`), and `2√x·log x = o(x)` (from `log x/√x → 0`), so eventually
+`θ(x) ≥ (log 2 / 12)·x`.  Package both as `IsTheta`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `chebyshev-bounds-oq-02-oq-01` (parent) | Explicit `ψ(m) = Θ(m)` bounds; supplies `chebyshevPsi_lower_linear`, `chebyshevPsi_eq_psi`. |
+| `chebyshev-bounds-oq-03` | `ψ ∼ θ`; supplies the `log x/√x → 0` fact (inlined here). |
+| `chebyshev-bounds-oq-02-oq-01-oq-01` | States explicit two-sided `θ` bounds (not yet formalized). |

--- a/research/problems/chebyshev-bounds-oq-02-oq-01-oq-02/state.md
+++ b/research/problems/chebyshev-bounds-oq-02-oq-01-oq-02/state.md
@@ -1,0 +1,32 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-07-01
+**Iteration**: 1
+
+## Current Focus
+
+Complete elementary proof of `θ(x) = Θ(x)` drafted in
+`proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ02.lean`. Awaiting machine verification.
+
+## Active Approach
+
+Transfer `ψ = Θ(x)` (parent) to `θ = Θ(x)` via `θ ≤ ψ ≤ (log 4+4)x` (upper) and
+`θ = ψ − (ψ−θ) ≥ ψ − 2√x log x ≥ (log 2/12)x` eventually (lower), packaged as `IsTheta`.
+
+## Blockers
+
+Build environment saturated (5 concurrent `lean-build` containers, host disk 99%). Aristotle MCP
+endpoint returning `Resource not found`. Proof is complete and hand-audited but **not yet
+machine-verified**.
+
+## Next Action
+
+Build `Proofs.ChebyshevBoundsOQ02OQ01OQ02` when `docker ps | grep lean-build` is empty; then
+upgrade status to `verified` and add gallery data.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1


### PR DESCRIPTION
## Summary

Answers the open question **`chebyshev-bounds-oq-02-oq-01-oq-02`**: transfer the parent's `ψ(x) = Θ(x)` to the first Chebyshev function, proving **`θ(x) = Θ(x)`** (formalized as `θ =Θ[atTop] (fun x => x)`).

New file `proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ02.lean` — 10 theorems, **no `sorry`, no `axiom`**, depending only on `Mathlib` + the parent `Proofs.ChebyshevBoundsOQ02OQ01`.

### Proof structure
- `theta_le_linear`: `θ(x) ≤ (log 4 + 4)·x` — from `Chebyshev.theta_le_psi` + `Chebyshev.psi_le_const_mul_self`.
- `psi_eq_chebyshevPsi_floor`: `ψ(x) = chebyshevPsi ⌊x⌋₊` (both are `∑_{n ≤ ⌊x⌋₊} Λ n`).
- `psi_ge_linear`: `(log 2/6)·x ≤ ψ(x)` for `x ≥ 2` — parent's `(log 2/3)·n ≤ ψ(n)` with `⌊x⌋₊ ≥ x − 1 ≥ x/2`.
- `two_sqrt_mul_log_isLittleO`: `2√x·log x = o(x)` (from `log x/√x → 0`).
- `theta_ge_eventually`: eventually `(log 2/12)·x ≤ θ(x)` — via `θ = ψ − (ψ−θ) ≥ ψ − 2√x·log x`.
- `theta_isBigO_id`, `id_isBigO_theta`, and the capstone `theta_isTheta_id`.

## ⚠️ Verification status: NOT machine-verified yet

The shared Docker build host was saturated for the entire session (5 concurrent `lean-build` containers, host disk at 99% / ~10 GiB free), and the Aristotle MCP endpoint was returning `Resource not found`, so I could not compile the file. Instead I:
- checked **every** non-trivial Mathlib lemma name against the pinned Mathlib source, and
- hand-audited each tactic step (see `knowledge.md` for the gotchas caught in review, e.g. `positivity` cannot prove `0 ≤ 2√x·log x`).

**Do not mark verified or add gallery data until this builds.** Next step: `./proofs/scripts/docker-build.sh Proofs.ChebyshevBoundsOQ02OQ01OQ02` when the host is idle, then `#print axioms theta_isTheta_id` (expect only `propext`/`Classical.choice`/`Quot.sound`), upgrade to `status: verified`, `axiomCount: 0`, and add `meta.json` + annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)