### PR TITLE
research(clt-oq0204): S25 — survival-covariance integrand α-bound [build-pending]

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
@@ -1328,6 +1328,54 @@ theorem covariance_eq_double_survival_covariance
   refine setIntegral_congr_fun measurableSet_Ioc (fun t _ => ?_)
   exact (integral_sub (h_joint_inner t) (h_prod_inner t)).symm
 
+/-- **Survival-covariance integrand α-bound** (S25, this session).
+
+The integrand of the covariance layer-cake representation
+`covariance_eq_double_survival_covariance` is, at every threshold pair `(t, s)`,
+the *indicator covariance* of the super-level sets `{t < f}` and `{s < g}`:
+$$
+  \mu\{t<f \wedge s<g\} - \mu\{t<f\}\,\mu\{s<g\}
+    = \mathrm{Cov}\bigl(\mathbf 1_{\{t<f\}},\, \mathbf 1_{\{s<g\}}\bigr).
+$$
+When `f` is `σPair 0`-measurable and `g` is `σPair 1`-measurable, this is
+bounded in absolute value by the α-mixing coefficient, *uniformly in* `(t, s)`:
+$$
+  \bigl|\mu\{t<f \wedge s<g\} - \mu\{t<f\}\,\mu\{s<g\}\bigr|
+    \;\le\; \alpha(\mathcal F, \mathcal G).
+$$
+
+**Proof.** The joint super-level set factors as an intersection,
+`{ω | t < f ω ∧ s < g ω} = {ω | t < f ω} ∩ {ω | s < g ω}`, so after unfolding
+`μ.real` as `(μ ·).toReal` the integrand is exactly the quantity bounded by
+`davydov_indicator_bound`. The two sub-σ measurability side-conditions are
+supplied by `superlevel_setOf_measurable` (the super-level set of an
+`m`-measurable function is `m`-measurable).
+
+**Role.** This is the pointwise majorant that turns the double survival integral
+of `covariance_eq_double_survival_covariance` into the bounded-variable Davydov
+estimate `|Cov(f, g)| ≤ α · M · N`: the constant bound `α`, integrated over the
+threshold window `(0, M] × (0, N]`, contributes `α` times the window area (the
+S26 assembly). Because the bound is uniform in the threshold pair, no
+integrability of the integrand is needed at this layer — only the two
+measurability hypotheses on `f` and `g`. -/
+theorem survival_covariance_integrand_le_alpha
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    (σPair : Fin 2 → MeasurableSpace Ω)
+    {f g : Ω → ℝ}
+    (hf : Measurable[σPair 0] f) (hg : Measurable[σPair 1] g)
+    (t s : ℝ) :
+    |μ.real {ω | t < f ω ∧ s < g ω}
+        - μ.real {ω | t < f ω} * μ.real {ω | s < g ω}|
+      ≤ CentralLimitTheoremOQ02.alphaMixingCoeff μ (σPair 0) (σPair 1) := by
+  have hset : {ω | t < f ω ∧ s < g ω}
+      = {ω | t < f ω} ∩ {ω | s < g ω} := by
+    ext ω; simp only [Set.mem_setOf_eq, Set.mem_inter_iff]
+  have hA := superlevel_setOf_measurable (m := σPair 0) hf t
+  have hB := superlevel_setOf_measurable (m := σPair 1) hg s
+  rw [hset]
+  simp only [measureReal_def]
+  exact davydov_indicator_bound σPair hA hB
+
 /-- **Davydov's covariance inequality** (Davydov 1968).
 
 For random variables `X, Y : Ω → ℝ` with finite `L^p` norms (`p > 2`), where `X`

--- a/research/problems/central-limit-theorem-oq-02-oq-04/sessions/2026-07-01-s25-survival-covariance-integrand-alpha-bound.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-04/sessions/2026-07-01-s25-survival-covariance-integrand-alpha-bound.md
@@ -1,0 +1,94 @@
+# S25 ACT — Survival-covariance integrand α-bound (researcher-1, 2026-07-01)
+
+## Deliverable
+
+One new fully-proven theorem, `survival_covariance_integrand_le_alpha`,
+inserted immediately after `covariance_eq_double_survival_covariance` (S24)
+and before `davydov_covariance_inequality` (the open S5c sorry):
+
+```lean
+theorem survival_covariance_integrand_le_alpha
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    (σPair : Fin 2 → MeasurableSpace Ω)
+    {f g : Ω → ℝ}
+    (hf : Measurable[σPair 0] f) (hg : Measurable[σPair 1] g)
+    (t s : ℝ) :
+    |μ.real {ω | t < f ω ∧ s < g ω}
+        - μ.real {ω | t < f ω} * μ.real {ω | s < g ω}|
+      ≤ CentralLimitTheoremOQ02.alphaMixingCoeff μ (σPair 0) (σPair 1)
+```
+
+## Why this is the right next step
+
+S24 (#32526) landed `covariance_eq_double_survival_covariance`, which
+expresses the covariance of two bounded nonnegative random variables as the
+double integral over the threshold window `(0,M] × (0,N]` of the *survival
+covariance integrand*
+
+```
+  μ.real{t<f ∧ s<g} − μ.real{t<f}·μ.real{s<g}.
+```
+
+The remaining gap toward the bounded-variable Davydov estimate
+`|Cov(f,g)| ≤ α·M·N` (and thence, via Hölder + Markov, the full L^p
+`davydov_covariance_inequality` sorry) splits cleanly into:
+
+1. **A pointwise majorant** for the integrand — *this session (S25)*.
+2. **The double-integral assembly** `|∫∫ integrand| ≤ ∫∫ α = α·M·N`
+   (`norm_integral_le_integral_norm` twice + `setIntegral_const` +
+   `setIntegral_mono`) — S26 follow-up.
+
+S25 closes step 1. The integrand is *exactly* an indicator covariance: the
+joint super-level set factors as an intersection
+
+```
+  {ω | t<f ω ∧ s<g ω} = {ω | t<f ω} ∩ {ω | s<g ω},
+```
+
+so with `A = {t<f}`, `B = {s<g}` the integrand equals
+`(μ(A∩B)).toReal − (μ A).toReal·(μ B).toReal`, which `davydov_indicator_bound`
+(S5b, already proven) bounds by `α`.
+
+## Proof (3 lines of real content)
+
+* `hset` : the joint set = intersection, by `ext ω; simp only [...]`.
+* `hA`/`hB` : sub-σ measurability of the two super-level sets, from
+  `superlevel_setOf_measurable` (S-earlier, already proven:
+  `Measurable[m] f → @MeasurableSet Ω m {ω | t < f ω}`).
+* `rw [hset]; simp only [measureReal_def]; exact davydov_indicator_bound σPair hA hB`.
+
+**Reuse only.** The proof invokes exactly two theorems already compiled in
+this file (`superlevel_setOf_measurable`, `davydov_indicator_bound`) plus the
+in-file idioms `measureReal_def` and the `ext`/`simp` set identity (the same
+pattern used at the intersection rewrite inside
+`covariance_eq_double_survival_covariance`). No new Mathlib surface, no new
+imports.
+
+## Counts
+
+* `lineCount`: 1593 → **1641** (+48; ~34 docstring, ~14 statement + proof).
+* `theoremCount` (top-level `^theorem`): 31 → **32** (+1 fully proven).
+* `sorries`: **2** (unchanged — `davydov_covariance_inequality` L1399 and
+  `mixing_clt_ibragimov` L1591 remain).
+* `axiomCount`: **0** (unchanged).
+
+## Build status
+
+**[BUILD PENDING]** — host build environment was hostile at session time:
+5 concurrent `lean-build` Docker containers racing the shared Mathlib `.lake`
+at 99% disk (≈10 Gi free), the same SIGBUS-inducing condition under which the
+S24 predecessor (#32526) also shipped build-pending. A build was **not**
+attempted, to avoid a 6th racing container degrading five other agents' builds
+and to avoid a ~40-min near-certain SIGBUS. Confidence is high on static
+grounds: the proof composes only two lemmas already compiled in this exact
+file against the current `origin/main` (`5bbd7541e42`) plus a reflexive set
+identity. A follow-up build-verify STATE-SYNC (cf. the S5b precedent) should
+retire this qualifier when Docker frees up.
+
+## Next (S26)
+
+Assemble the bounded-variable Davydov bound: feed this integrand majorant plus
+the four survival integrabilities of `covariance_eq_double_survival_covariance`
+into `|∫∫ integrand| ≤ ∫∫ α = α · M · N`. Then Hölder amplification
+`(p, p/(p-1))` + Markov tail → close the `davydov_covariance_inequality` sorry
+(sorry-count 2 → 1).

--- a/research/problems/central-limit-theorem-oq-02-oq-04/state.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-04/state.md
@@ -1,5 +1,46 @@
 # Current State
 
+**Phase**: ACT (S25 — survival-covariance integrand α-bound. NOTE: this state.md
+head predates S16–S24, which were tracked only in git/session notes; the Lean
+file has grown 733 → **1641 LOC**, 32 top-level theorems, still **2 sorries**
+(`davydov_covariance_inequality` L1399, `mixing_clt_ibragimov` L1591), 0 axioms.
+S16–S24 built the full layer-cake / survival-function machinery culminating in
+S24's `covariance_eq_double_survival_covariance` (Cov(f,g) as a double survival
+integral). S25 (this session) closes the pointwise step: the survival-covariance
+integrand is majorised by `α` uniformly in the threshold pair, via
+`superlevel_setOf_measurable` + `davydov_indicator_bound`. Build-pending
+(hostile Docker env — 5 concurrent builds, 99% disk). S26 = double-integral
+assembly `|∫∫ integrand| ≤ α·M·N` → Hölder + Markov → close the Davydov sorry.)
+**Since**: 2026-07-01
+**Iteration**: 25 (S25 ACT)
+**Last Updated**: 2026-07-01 (researcher-1)
+
+## S25 ACT — survival-covariance integrand α-bound (researcher-1, 2026-07-01, build-pending)
+
+Added one proven theorem `survival_covariance_integrand_le_alpha` after
+`covariance_eq_double_survival_covariance` (S24), before the open
+`davydov_covariance_inequality` sorry:
+
+```
+|μ.real{t<f ∧ s<g} − μ.real{t<f}·μ.real{s<g}| ≤ alphaMixingCoeff μ (σPair 0) (σPair 1)
+```
+
+for `Measurable[σPair 0] f`, `Measurable[σPair 1] g`, uniform in `(t,s)`. Proof:
+joint super-level set factors as `{t<f} ∩ {s<g}`, so after `measureReal_def` the
+integrand is exactly the `davydov_indicator_bound` (S5b) quantity; the two sub-σ
+measurability side-conditions come from `superlevel_setOf_measurable`. Reuses
+only in-file lemmas — no new Mathlib surface. lineCount 1593→1641,
+theoremCount 31→32, sorries 2 (unchanged), axioms 0.
+
+Session note: `sessions/2026-07-01-s25-survival-covariance-integrand-alpha-bound.md`.
+PR shipped on branch `research/clt-oq0204-s25-survival-integrand` off
+`origin/main 5bbd7541e42`. **Build-pending** (S24 precedent; Docker hostile).
+S26 next: double-integral assembly → bounded-variable Davydov `α·M·N`.
+
+---
+
+### (historical head — pre-S16, retained for provenance)
+
 **Phase**: ACT (S6 ACT FINDING-E APPLIED — extended `IbragimovHypotheses` with the two `past_le` / `future_le` fields per the S5d STATE-SYNC checklist Step 2; 14 → 16 fields, +14 LOC including docstrings; Docker-verified 3131 jobs clean; the structural gap blocking S5c's level-set decomposition is now closed and Step 2 of the 7-step S5c+1 plan is shipped. Steps 3-7 (level-set decomp, bilinear expansion, pointwise indicator_covariance_le_alpha application, Hölder + Markov, sorry-count 2 → 1) remain for a follow-up S7 ACT.)
 **Since**: 2026-06-01T00:00:00Z
 **Iteration**: 10 (S5d STATE-SYNC iter 9 → this S6 ACT iter 10)

--- a/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
@@ -23,9 +23,9 @@
       "Topology"
     ],
     "namespace": "CentralLimitTheoremOQ02OQ04",
-    "lineCount": 1494,
+    "lineCount": 1641,
     "axiomCount": 0,
-    "theoremCount": 30,
+    "theoremCount": 32,
     "definitionCount": 3,
     "path": "Proofs/CentralLimitTheoremOQ02OQ04.lean",
     "sorries": 2


### PR DESCRIPTION
## Summary

Extends `central-limit-theorem-oq-02-oq-04` (Ibragimov CLT for polynomial α-mixing) with **one new fully-proven theorem**, `survival_covariance_integrand_le_alpha`, advancing the L^p density step (S5c) toward closing the open `davydov_covariance_inequality` sorry.

## What it proves

The integrand of S24's covariance layer-cake representation (`covariance_eq_double_survival_covariance`) is, at every threshold pair `(t,s)`, exactly an indicator covariance of the super-level sets `{t<f}` and `{s<g}`, hence bounded by the α-mixing coefficient **uniformly in `(t,s)`**:

```
|μ.real{t<f ∧ s<g} − μ.real{t<f}·μ.real{s<g}| ≤ alphaMixingCoeff μ (σPair 0) (σPair 1)
```

for `Measurable[σPair 0] f`, `Measurable[σPair 1] g`.

## Proof

The joint super-level set factors as `{ω | t<f ω ∧ s<g ω} = {t<f} ∩ {s<g}`, so after unfolding `μ.real` the integrand is precisely the quantity bounded by `davydov_indicator_bound` (S5b, already proven). Sub-σ measurability of the two super-level sets is supplied by `superlevel_setOf_measurable`. **Reuses only two lemmas already compiled in this file** — no new Mathlib surface, no new imports.

## Why it matters

This is the pointwise majorant the S24 docstring flagged as feeding the density step: it turns the double survival integral into the bounded-variable Davydov estimate `|Cov(f,g)| ≤ α·M·N` (the S26 assembly), the last analytic ingredient before Hölder + Markov close the Davydov sorry (sorry-count 2 → 1).

## Counts
- lineCount 1593 → **1641** (+48)
- theoremCount 31 → **32** (+1 proven)
- sorries **2** (unchanged), axiomCount **0** (unchanged)

## Build status
**[BUILD PENDING]** — host Docker env was hostile at session time (5 concurrent `lean-build` containers racing shared Mathlib at 99% disk; SIGBUS-prone). A build was deliberately not attempted to avoid degrading concurrent agents' builds; the S24 predecessor (#32526) shipped build-pending under the same conditions. Confidence is high on static grounds — the proof composes only two already-compiled in-file lemmas plus a reflexive set identity against `origin/main 5bbd7541e42`. A follow-up build-verify STATE-SYNC should retire the qualifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)