### PR TITLE
research(fibonacci-oq-07-oq-01): every Lucas sequence is a divisibility sequence — m∣n ⟹ Uₘ∣Uₙ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ07OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ07OQ01.lean
@@ -1,0 +1,146 @@
+import Mathlib.Tactic
+import Proofs.LucasSequenceDegree2Identities
+import Proofs.LucasSequenceDegree2IdentitiesOQ02
+
+/-
+# Divisibility of General Lucas Sequences: `m ∣ n ⟹ Uₘ ∣ Uₙ`
+
+## Open Question (answered — forward direction)
+
+The parent entry `FibonacciIdentitiesOQ07` records the Fibonacci divisibility
+*characterization* `Fₘ ∣ Fₙ ⟺ m ∣ n` (for `m ≥ 3`).  Its genuinely original half is the
+**reverse** implication; the **forward** implication `m ∣ n ⟹ Fₘ ∣ Fₙ` is already in
+Mathlib as `Nat.fib_dvd`.  This gallery line asks whether the forward divisibility — the
+defining property of a *divisibility sequence* — generalizes from the Fibonacci numbers to
+the **fundamental Lucas sequence** `Uₙ(P,Q)` for arbitrary integer parameters `P, Q`:
+
+  `U₀ = 0,  U₁ = 1,  Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ`     (`(P,Q) = (1,−1)` is Fibonacci).
+
+Mathlib has **nothing** about divisibility of the general two-parameter sequence, so this
+result is new infrastructure.  We prove, with no hypothesis on `P, Q` whatsoever:
+
+  **`U_dvd_of_dvd`  :  m ∣ n  →  Uₘ ∣ Uₙ`.**
+
+Thus every fundamental Lucas sequence — Fibonacci `(1,−1)`, Pell `(2,−1)`, the Mersenne-like
+`(3,2)` with `Uₙ = 2ⁿ − 1`, … — is a divisibility sequence.
+
+## Proof architecture
+
+The Fibonacci proof leans on `Nat.fib_dvd`, which does not exist here, so we build from the
+recurrence.  The engine is a **factor-of-2-free convolution identity**
+
+  **`U_conv`  :  U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ`.**
+
+The sibling entry `LucasSequenceDegree2IdentitiesOQ02` proves the *bilinear* addition law
+`2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ`, but the factor `2` obstructs a divisibility induction over `ℤ`
+(one cannot divide by `2`).  We eliminate both `V` and the factor `2`: substitute the
+companion-from-fundamental relation `Vₙ = 2·Uₙ₊₁ − P·Uₙ` (`V_eq`) into the bilinear law and
+cancel `2` against the `2`'s introduced, leaving the clean quadratic recurrence above.
+
+With `U_conv` in hand, divisibility is a one-line induction.  Writing `d = e + 1`,
+
+  `U_{(k+1)d} = U_{kd+1}·U_d − Q·U_{kd}·U_e`,
+
+so `U_d` divides the first term outright and, by the induction hypothesis `U_d ∣ U_{kd}`, the
+second term as well.  Hence `U_d ∣ U_{kd}` for all `k`, i.e. `m ∣ n ⟹ Uₘ ∣ Uₙ`.
+
+## Results
+
+* `U_conv`          — `U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ` (factor-of-2-free convolution).
+* `U_dvd_U_mul`     — `U_d ∣ U_{k·d}` (divisibility along multiples).
+* `U_dvd_of_dvd`    — `m ∣ n → Uₘ ∣ Uₙ` (the divisibility-sequence property, any `P, Q`).
+* `U_one_neg_one`   — `U 1 (−1) n = Fₙ` (the Fibonacci specialization of the sequence).
+* Fibonacci and Pell divisibility corollaries.
+
+## Not proved here (remaining open)
+
+The full *strong* divisibility `gcd(Uₘ, Uₙ) = U_{gcd(m,n)}` — equivalently the reverse
+implication `Uₘ ∣ Uₙ → m ∣ n` — holds only under `gcd(P, Q) = 1` and needs the coprimality
+`gcd(Uₙ, Uₙ₊₁) = 1`; that is left for a follow-up.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace FibonacciIdentitiesOQ07OQ01
+
+open LucasSequenceDegree2Identities LucasSequenceDegree2IdentitiesOQ02
+
+/-- **Factor-of-2-free convolution.** `U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ`.
+
+Derived from the bilinear addition law `2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ` (`two_U_add`) by
+substituting `V_eq` (`Vₖ = 2·Uₖ₊₁ − P·Uₖ`) and the recurrence to eliminate both the
+companion sequence `V` and the leading factor `2`. -/
+theorem U_conv (P Q : ℤ) (m n : ℕ) :
+    U P Q (m + n + 1) = U P Q (m + 1) * U P Q (n + 1) - Q * U P Q m * U P Q n := by
+  have h2 : 2 * U P Q (m + (n + 1)) =
+      U P Q m * V P Q (n + 1) + V P Q m * U P Q (n + 1) := two_U_add P Q m (n + 1)
+  have hVn1 : V P Q (n + 1) = 2 * U P Q (n + 1 + 1) - P * U P Q (n + 1) := V_eq P Q (n + 1)
+  have hVm : V P Q m = 2 * U P Q (m + 1) - P * U P Q m := V_eq P Q m
+  have hUn2 : U P Q (n + 1 + 1) = P * U P Q (n + 1) - Q * U P Q n := U_add_two P Q n
+  have hidx : m + (n + 1) = m + n + 1 := by omega
+  rw [hidx] at h2
+  have key : 2 * U P Q (m + n + 1) =
+      2 * (U P Q (m + 1) * U P Q (n + 1) - Q * U P Q m * U P Q n) := by
+    linear_combination h2 + U P Q m * hVn1 + U P Q (n + 1) * hVm + 2 * U P Q m * hUn2
+  exact mul_left_cancel₀ (by norm_num : (2 : ℤ) ≠ 0) key
+
+/-- **Divisibility along multiples.** `U_d ∣ U_{k·d}` for every `k`, with no hypothesis on
+`P, Q`.  Induction on `k` closed by the convolution `U_conv`. -/
+theorem U_dvd_U_mul (P Q : ℤ) (d k : ℕ) : U P Q d ∣ U P Q (k * d) := by
+  induction k with
+  | zero => simp
+  | succ j ih =>
+    rcases d with _ | e
+    · simp
+    · -- `d = e + 1`; expand `U_{(j+1)(e+1)}` via the convolution at `(m, n) = (j(e+1), e)`.
+      have hconv := U_conv P Q (j * (e + 1)) e
+      have hidx : (j + 1) * (e + 1) = j * (e + 1) + e + 1 := by ring
+      rw [hidx, hconv]
+      have h1 : U P Q (e + 1) ∣ U P Q (j * (e + 1) + 1) * U P Q (e + 1) := dvd_mul_left _ _
+      have h2 : U P Q (e + 1) ∣ Q * U P Q (j * (e + 1)) * U P Q e :=
+        (ih.mul_left Q).mul_right _
+      exact dvd_sub h1 h2
+
+/-- **The divisibility-sequence property.** `m ∣ n → Uₘ ∣ Uₙ` for the fundamental Lucas
+sequence of *any* parameters `P, Q`.  Generalizes `Nat.fib_dvd` (the `(P,Q) = (1,−1)` case). -/
+theorem U_dvd_of_dvd (P Q : ℤ) {m n : ℕ} (h : m ∣ n) : U P Q m ∣ U P Q n := by
+  obtain ⟨k, rfl⟩ := h
+  rw [mul_comm]
+  exact U_dvd_U_mul P Q m k
+
+/-- **Fibonacci specialization of the sequence.** `U 1 (−1) n = Fₙ`.  Proved by the two-step
+(consecutive-pair) induction, since `Uₙ₊₂ = Uₙ₊₁ + Uₙ` matches `Nat.fib_add_two`. -/
+theorem U_one_neg_one (n : ℕ) : U 1 (-1) n = (Nat.fib n : ℤ) := by
+  suffices key : ∀ m : ℕ,
+      U 1 (-1) m = (Nat.fib m : ℤ) ∧ U 1 (-1) (m + 1) = (Nat.fib (m + 1) : ℤ) from (key n).1
+  intro m
+  induction m with
+  | zero => exact ⟨by simp, by simp⟩
+  | succ k ih =>
+    obtain ⟨ih0, ih1⟩ := ih
+    refine ⟨ih1, ?_⟩
+    have hrec : U 1 (-1) (k + 2) = 1 * U 1 (-1) (k + 1) - (-1) * U 1 (-1) k := U_add_two 1 (-1) k
+    rw [show k + 1 + 1 = k + 2 from rfl, hrec, ih0, ih1, Nat.fib_add_two]
+    push_cast; ring
+
+/-- Fibonacci divisibility recovered from the general theorem: `m ∣ n → Fₘ ∣ Fₙ` over `ℤ`. -/
+theorem fib_dvd_of_dvd {m n : ℕ} (h : m ∣ n) : (Nat.fib m : ℤ) ∣ (Nat.fib n : ℤ) := by
+  rw [← U_one_neg_one, ← U_one_neg_one]
+  exact U_dvd_of_dvd 1 (-1) h
+
+/-- Pell divisibility: the Pell numbers `Pₙ = U 2 (−1) n` form a divisibility sequence. -/
+theorem pell_dvd_of_dvd {m n : ℕ} (h : m ∣ n) : U 2 (-1) m ∣ U 2 (-1) n :=
+  U_dvd_of_dvd 2 (-1) h
+
+/-- Numeric sanity check of `U_conv` at `(1,−1)`, `m = 3, n = 4`:
+`F₈ = 21` and `F₄·F₅ − (−1)·F₃·F₄ = 3·5 + 2·3 = 21`. -/
+example : U 1 (-1) (3 + 4 + 1) =
+    U 1 (-1) (3 + 1) * U 1 (-1) (4 + 1) - (-1) * U 1 (-1) 3 * U 1 (-1) 4 := by decide
+
+/-- Numeric sanity check of divisibility: `F₃ = 2 ∣ F₆ = 8`. -/
+example : U 1 (-1) 3 ∣ U 1 (-1) 6 := by decide
+
+/-- Numeric sanity check of Pell divisibility: `P₂ = 2 ∣ P₆ = 70`. -/
+example : U 2 (-1) 2 ∣ U 2 (-1) 6 := by decide
+
+end FibonacciIdentitiesOQ07OQ01

--- a/src/data/proofs/fibonacci-identities-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-07-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-fib0701-header",
+    "proofId": "fibonacci-identities-oq-07-oq-01",
+    "range": { "startLine": 1, "endLine": 62 },
+    "type": "concept",
+    "title": "From Fibonacci to every Lucas sequence",
+    "content": "A sequence (aₙ) is a divisibility sequence when m ∣ n implies aₘ ∣ aₙ. The Fibonacci numbers are the archetype — Mathlib records m ∣ n → Fₘ ∣ Fₙ as Nat.fib_dvd — but Fibonacci is just the (P,Q) = (1,−1) member of the two-parameter Lucas family Uₙ(P,Q): U₀ = 0, U₁ = 1, Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ. Mathlib has no divisibility results for the general family. This entry proves m ∣ n ⟹ Uₘ ∣ Uₙ for arbitrary integer P, Q, with no coprimality hypothesis, so Fibonacci, Pell (2,−1), and Uₙ = 2ⁿ − 1 at (3,2) are all divisibility sequences by one theorem.",
+    "mathContext": "Fundamental Lucas sequence $U_0 = 0,\\ U_1 = 1,\\ U_{n+2} = P U_{n+1} - Q U_n$. Goal: $m \\mid n \\Rightarrow U_m \\mid U_n$ for all $P, Q \\in \\mathbb{Z}$, generalizing $\\texttt{Nat.fib\\_dvd}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "divisibility sequence",
+      "Lucas sequence Uₙ(P,Q)",
+      "Nat.fib_dvd",
+      "Pell numbers",
+      "second-order linear recurrence"
+    ],
+    "prerequisites": [
+      "Lucas sequences",
+      "divisibility in a commutative ring",
+      "induction on ℕ"
+    ]
+  },
+  {
+    "id": "ann-fib0701-convolution",
+    "proofId": "fibonacci-identities-oq-07-oq-01",
+    "range": { "startLine": 68, "endLine": 85 },
+    "type": "insight",
+    "title": "Killing the factor of 2: the convolution U_conv",
+    "content": "The gallery's bilinear addition law gives 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ, but the leading 2 is fatal for a divisibility induction over ℤ — one cannot divide a divisibility statement by 2. The fix is to eliminate both the companion sequence V and that factor 2 at once. Substituting V_eq (Vₖ = 2·Uₖ₊₁ − P·Uₖ) for Vₙ₊₁ and Vₘ, then the recurrence for Uₙ₊₂, collapses the right-hand side to exactly 2·(U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ); a single mul_left_cancel₀ removes the 2, leaving the clean quadratic convolution U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ. This is the (2,1)-entry of Mᵐ⁺ⁿ for the companion matrix M = [[P,−Q],[1,0]], obtained here purely algebraically.",
+    "mathContext": "$U_{m+n+1} = U_{m+1}U_{n+1} - Q\\,U_m U_n$, proved via $\\texttt{linear\\_combination}$ over $\\texttt{two\\_U\\_add}$, two instances of $\\texttt{V\\_eq}$, and $\\texttt{U\\_add\\_two}$, then $\\texttt{mul\\_left\\_cancel}_0$ by $2 \\ne 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "convolution / addition formula",
+      "companion matrix",
+      "linear_combination",
+      "mul_left_cancel₀"
+    ],
+    "prerequisites": [
+      "bilinear addition law two_U_add",
+      "companion-from-fundamental relation V_eq",
+      "ring arithmetic over ℤ"
+    ]
+  },
+  {
+    "id": "ann-fib0701-divisibility",
+    "proofId": "fibonacci-identities-oq-07-oq-01",
+    "range": { "startLine": 87, "endLine": 109 },
+    "type": "insight",
+    "title": "One-line induction to the divisibility-sequence property",
+    "content": "With U_conv in hand the divisibility is immediate. Writing d = e+1, U_conv at (m,n) = (kd, e) reads U_{(k+1)d} = U_{kd+1}·U_d − Q·U_{kd}·U_e. The first summand is a multiple of U_d outright; the second is Q·U_{kd}·U_e, and U_d ∣ U_{kd} by the induction hypothesis, so U_d divides it too. Hence U_d ∣ U_{(k+1)d}, closing the induction: U_d ∣ U_{k·d} for all k (U_dvd_U_mul), equivalently m ∣ n → Uₘ ∣ Uₙ (U_dvd_of_dvd). No constraint on P, Q enters — the forward divisibility direction is unconditional.",
+    "mathContext": "$U_{(k+1)d} = U_{kd+1}U_d - Q\\,U_{kd}U_e$ with $d = e+1$; $U_d \\mid$ both terms, so $U_d \\mid U_{kd}$ by induction on $k$. Then $n = km \\Rightarrow U_m \\mid U_{km}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "divisibility sequence",
+      "induction on multiples",
+      "dvd_sub",
+      "Nat.fib_dvd generalization"
+    ],
+    "prerequisites": [
+      "U_conv",
+      "dvd_mul_left, Dvd.dvd.mul_left/mul_right, dvd_sub"
+    ]
+  },
+  {
+    "id": "ann-fib0701-specializations",
+    "proofId": "fibonacci-identities-oq-07-oq-01",
+    "range": { "startLine": 111, "endLine": 146 },
+    "type": "technique",
+    "title": "Recovering Fibonacci and Pell",
+    "content": "A two-step (consecutive-pair) induction identifies U 1 (−1) n with the Fibonacci number Fₙ (U_one_neg_one), since Uₙ₊₂ = Uₙ₊₁ + Uₙ matches Nat.fib_add_two. Rewriting the general theorem through this identity yields m ∣ n → Fₘ ∣ Fₙ over ℤ (fib_dvd_of_dvd), reproducing Mathlib's Nat.fib_dvd from the Lucas-sequence result; the parameter choice (2,−1) gives the Pell divisibility sequence (pell_dvd_of_dvd). Kernel-decided numeric checks (F₃ = 2 ∣ F₆ = 8, P₂ = 2 ∣ P₆ = 70) pin the statements to concrete values.",
+    "mathContext": "$U_{1,-1}(n) = F_n$ by two-step induction; specializations at $(1,-1)$ and $(2,-1)$ recover Fibonacci and Pell divisibility.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fibonacci numbers Nat.fib",
+      "Pell numbers",
+      "two-step induction",
+      "decide"
+    ],
+    "prerequisites": [
+      "Nat.fib_add_two",
+      "casting ℕ → ℤ",
+      "U_dvd_of_dvd"
+    ]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-07-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-07-oq-01/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "fibonacci-identities-oq-07-oq-01",
+  "title": "Every Lucas Sequence is a Divisibility Sequence: m ∣ n ⟹ Uₘ ∣ Uₙ",
+  "slug": "fibonacci-identities-oq-07-oq-01",
+  "description": "Generalizes the forward Fibonacci divisibility Nat.fib_dvd (m ∣ n → Fₘ ∣ Fₙ) from the Fibonacci numbers to the fundamental Lucas sequence Uₙ(P,Q) for arbitrary integer parameters P, Q, with no coprimality hypothesis. The engine is a new factor-of-2-free convolution identity U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ, obtained by eliminating the companion sequence and the leading factor 2 from the gallery's bilinear addition law. Mathlib has no divisibility results for the general two-parameter Lucas sequence.",
+  "meta": {
+    "author": "Édouard Lucas (1878)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_sequence#Divisibility_properties",
+    "date": "1878",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ07OQ01.lean",
+    "tags": [
+      "number-theory",
+      "lucas-sequences",
+      "fibonacci",
+      "pell-numbers",
+      "divisibility",
+      "divisibility-sequence",
+      "recurrence",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 146,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-verified from Mathlib (only the foundational propext / Classical.choice / Quot.sound). Builds on the gallery's LucasSequenceDegree2Identities (the sequences U, V, the recurrence, V_eq) and LucasSequenceDegree2IdentitiesOQ02 (the bilinear addition law two_U_add).",
+    "originalContributions": [
+      "U_conv: the factor-of-2-free convolution U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ, derived from the bilinear law 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ by eliminating V (via V_eq) and cancelling the factor 2 — the form needed for an integer divisibility induction",
+      "U_dvd_U_mul: U_d ∣ U_{k·d} for all k, any P, Q (divisibility along multiples)",
+      "U_dvd_of_dvd: the divisibility-sequence property m ∣ n → Uₘ ∣ Uₙ for every fundamental Lucas sequence, generalizing Mathlib's Nat.fib_dvd (the (P,Q) = (1,−1) case)",
+      "U_one_neg_one: identifies U 1 (−1) n = Fₙ, recovering Fibonacci divisibility as a corollary (fib_dvd_of_dvd) and Pell divisibility (pell_dvd_of_dvd) as another"
+    ],
+    "prerequisites": [
+      "Fundamental and companion Lucas sequences Uₙ(P,Q), Vₙ(P,Q) and their recurrence",
+      "The bilinear addition law 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ (gallery: two_U_add)",
+      "The companion-from-fundamental relation Vₙ = 2·Uₙ₊₁ − P·Uₙ (gallery: V_eq)",
+      "Divisibility in a commutative ring; induction on ℕ"
+    ]
+  },
+  "overview": {
+    "historicalContext": "A sequence (aₙ) is a divisibility sequence when m ∣ n ⟹ aₘ ∣ aₙ, and a strong divisibility sequence when gcd(aₘ, aₙ) = a_{gcd(m,n)}. Lucas (1878) discovered that the sequences bearing his name — governed by xₙ₊₂ = P·xₙ₊₁ − Q·xₙ — have these properties, with the Fibonacci numbers (P,Q) = (1,−1) as the archetype. Mathlib records the Fibonacci case (Nat.fib_dvd, Nat.fib_gcd) but nothing for the general two-parameter family. The parent entry FibonacciIdentitiesOQ07 proved the sharp Fibonacci biconditional Fₘ ∣ Fₙ ⟺ m ∣ n; this entry answers its first open question by lifting the forward (divisibility-sequence) direction to all Lucas sequences.",
+    "problemStatement": "Prove, fully verified in Lean/Mathlib, that for the fundamental Lucas sequence Uₙ(P,Q) with arbitrary integer parameters P, Q, m ∣ n implies Uₘ ∣ Uₙ, and recover the Fibonacci and Pell divisibility facts as corollaries.",
+    "proofStrategy": "The Fibonacci argument uses Nat.fib_dvd, which has no general-parameter analogue, so we work from the recurrence. The gallery's bilinear addition law two_U_add gives 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ, but the factor 2 blocks an integer divisibility induction. Substituting the companion-from-fundamental relation Vₙ = 2·Uₙ₊₁ − P·Uₙ into that law and cancelling the 2 yields the clean quadratic convolution U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ (U_conv). With d = e+1, U_conv gives U_{(k+1)d} = U_{kd+1}·U_d − Q·U_{kd}·U_e, so U_d divides the first term outright and — by the induction hypothesis U_d ∣ U_{kd} — the second term too; hence U_d ∣ U_{kd} for all k (U_dvd_U_mul), i.e. m ∣ n → Uₘ ∣ Uₙ (U_dvd_of_dvd). Identifying U 1 (−1) with Nat.fib (U_one_neg_one) recovers Fibonacci divisibility.",
+    "keyInsights": [
+      "The obstruction to reusing the gallery's bilinear addition law is purely the leading factor 2: over ℤ one cannot divide a divisibility statement by 2, so a factor-of-2-free convolution is required",
+      "That convolution U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ is exactly the (2,1)-entry of Mᵐ⁺ⁿ for the companion matrix M = [[P,−Q],[1,0]]; here it is obtained algebraically without matrices, by eliminating V and the factor 2 in one linear_combination",
+      "No hypothesis on P, Q is needed for the divisibility-sequence (forward) direction — coprimality gcd(P,Q) = 1 is only required for the stronger gcd identity, which is left open",
+      "The single identity covers every classical case at once: Fibonacci (1,−1), Pell (2,−1), and Uₙ = 2ⁿ − 1 at (3,2) are all divisibility sequences by the same theorem"
+    ],
+    "prerequisites": [
+      "LucasSequenceDegree2Identities: U, V, U_add_two, V_eq",
+      "LucasSequenceDegree2IdentitiesOQ02: two_U_add (bilinear addition law)",
+      "Nat.fib_add_two and casting ℕ → ℤ",
+      "dvd_mul_left, Dvd.dvd.mul_left/mul_right, dvd_sub, mul_left_cancel₀"
+    ]
+  },
+  "sections": [
+    {
+      "id": "convolution",
+      "title": "The Factor-of-2-Free Convolution",
+      "summary": "U_conv: U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ, derived from the bilinear law two_U_add by eliminating V (via V_eq) and cancelling the factor 2.",
+      "startLine": 62,
+      "endLine": 84,
+      "mathContext": "The gallery's bilinear law is $2 U_{m+n} = U_m V_n + V_m U_n$. Substituting $V_k = 2U_{k+1} - P U_k$ (`V_eq`) for $V_{n+1}$ and $V_m$, then the recurrence $U_{n+2} = P U_{n+1} - Q U_n$, collapses the right side to $2(U_{m+1}U_{n+1} - Q U_m U_n)$; cancelling the common factor $2$ (`mul_left_cancel₀`) yields the quadratic convolution $U_{m+n+1} = U_{m+1}U_{n+1} - Q U_m U_n$."
+    },
+    {
+      "id": "divisibility",
+      "title": "The Divisibility-Sequence Property",
+      "summary": "U_dvd_U_mul (U_d ∣ U_{k·d} by induction on k via U_conv) and U_dvd_of_dvd (m ∣ n → Uₘ ∣ Uₙ), generalizing Nat.fib_dvd to all Lucas sequences.",
+      "startLine": 86,
+      "endLine": 110,
+      "mathContext": "Writing $d = e+1$, `U_conv` at $(m,n) = (kd, e)$ gives $U_{(k+1)d} = U_{kd+1}\\,U_d - Q\\,U_{kd}\\,U_e$. The first summand is divisible by $U_d$; the second is $Q\\,U_{kd}\\,U_e$ with $U_d \\mid U_{kd}$ by the induction hypothesis, so $U_d \\mid U_{(k+1)d}$. Induction gives $U_d \\mid U_{kd}$ for all $k$, equivalently $m \\mid n \\Rightarrow U_m \\mid U_n$ — no constraint on $P, Q$."
+    },
+    {
+      "id": "specializations",
+      "title": "Fibonacci and Pell Corollaries",
+      "summary": "U_one_neg_one identifies U 1 (−1) n = Fₙ; fib_dvd_of_dvd and pell_dvd_of_dvd specialize the general divisibility to the Fibonacci and Pell numbers.",
+      "startLine": 112,
+      "endLine": 146,
+      "mathContext": "A two-step induction shows $U_{1,-1}(n) = F_n$ (`U_one_neg_one`), since $U_{n+2} = U_{n+1} + U_n$ matches `Nat.fib_add_two`. Rewriting through it turns the general theorem into $m \\mid n \\Rightarrow F_m \\mid F_n$ (`fib_dvd_of_dvd`), while $(P,Q) = (2,-1)$ gives the Pell divisibility sequence (`pell_dvd_of_dvd`). Numeric checks confirm $F_3 = 2 \\mid F_6 = 8$ and $P_2 = 2 \\mid P_6 = 70$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Lifts the forward Fibonacci divisibility Nat.fib_dvd to the fundamental Lucas sequence Uₙ(P,Q) of arbitrary integer parameters, with no coprimality hypothesis: m ∣ n ⟹ Uₘ ∣ Uₙ. The proof introduces a factor-of-2-free convolution identity U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ that the gallery's bilinear addition law could not supply directly. 146 lines, 6 theorems, 0 sorries, 0 axioms.",
+    "implications": "Establishes that every fundamental Lucas sequence — Fibonacci, Pell, and the Mersenne-like Uₙ = 2ⁿ − 1 among them — is a divisibility sequence, from a single reusable convolution. The convolution U_conv is the natural entry point for the remaining strong-divisibility result and for entry-point (rank of apparition) theory.",
+    "openQuestions": [
+      "Prove the strong divisibility gcd(Uₘ, Uₙ) = U_{gcd(m,n)} under gcd(P,Q) = 1, and hence the reverse implication Uₘ ∣ Uₙ → m ∣ n (the hard half, requiring gcd(Uₙ, Uₙ₊₁) = 1)",
+      "Establish the companion divisibility relations Uₙ ∣ U_{kn} refinements, e.g. the exact power of Uₙ dividing U_{kn} (the Lucas-sequence lifting-the-exponent phenomenon)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-07",
+      "relationship": "extends",
+      "description": "Parent: the Fibonacci divisibility characterization Fₘ ∣ Fₙ ⟺ m ∣ n. This entry answers its first open question by generalizing the forward direction to arbitrary Lucas sequences Uₙ(P,Q)."
+    },
+    {
+      "targetId": "lucas-sequence-degree2-identities",
+      "relationship": "extends",
+      "description": "Reuses the fundamental/companion sequences U, V, the recurrence, and V_eq from the master degree-2 identity entry, adding the divisibility layer built on the convolution U_conv."
+    },
+    {
+      "targetId": "lucas-sequence-degree2-identities-oq-02",
+      "relationship": "builds-on",
+      "description": "The convolution U_conv is derived from that entry's bilinear addition law two_U_add (2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ) by eliminating V and the leading factor 2."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lucas, Édouard",
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "venue": "American Journal of Mathematics 1(3), pp. 184–240 and 1(4), pp. 289–321",
+      "note": "Origin of the Lucas sequences and their divisibility / strong-divisibility properties"
+    },
+    {
+      "authors": "Ribenboim, Paulo",
+      "title": "The New Book of Prime Number Records",
+      "year": "1996",
+      "venue": "Springer, §2.IV (Lucas sequences)",
+      "note": "Divisibility sequences Uₙ(P,Q), the addition formulas, and the rank-of-apparition theory"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Fibonacci and Pell divisibility as special cases of Lucas-sequence divisibility"
+    }
+  ],
+  "leanFile": {
+    "namespace": "FibonacciIdentitiesOQ07OQ01",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ07OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of **fibonacci-identities-oq-07** ("Fibonacci Divisibility Characterization Fₘ ∣ Fₙ ⟺ m ∣ n"): generalize the **forward** divisibility direction from the Fibonacci numbers to the **fundamental Lucas sequence** `Uₙ(P,Q)` (U₀=0, U₁=1, Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ) for **arbitrary integer parameters P, Q**, with **no coprimality hypothesis**:

> **`U_dvd_of_dvd` : m ∣ n → Uₘ ∣ Uₙ**  (any P, Q).

Mathlib has this only for Fibonacci (`Nat.fib_dvd`); it has **nothing** about divisibility of the general two-parameter Lucas family. So every fundamental Lucas sequence — Fibonacci (1,−1), Pell (2,−1), Uₙ = 2ⁿ−1 at (3,2), … — is a divisibility sequence, by one theorem.

## Key new infrastructure

The Fibonacci proof rests on `Nat.fib_dvd`, which has no general analogue, so we build from the recurrence. The gallery's sibling entry provides the *bilinear* addition law `2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ` (`two_U_add`), but the leading **factor 2** blocks a divisibility induction over ℤ. We eliminate both the companion sequence V and that 2:

> **`U_conv` : U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ**  (factor-of-2-free convolution)

derived by substituting `V_eq` (Vₖ = 2·Uₖ₊₁ − P·Uₖ) into the bilinear law and cancelling the 2 (`mul_left_cancel₀`). This is the (2,1)-entry of Mᵐ⁺ⁿ for the companion matrix M = [[P,−Q],[1,0]], obtained purely algebraically. With it, divisibility is a one-line induction: writing d = e+1, `U_conv` gives U_{(k+1)d} = U_{kd+1}·U_d − Q·U_{kd}·U_e, so U_d divides both terms.

## Theorems (6, 0 sorries, 0 axioms)

- `U_conv` — factor-of-2-free convolution identity.
- `U_dvd_U_mul` — U_d ∣ U_{k·d} for all k, any P, Q.
- `U_dvd_of_dvd` — **m ∣ n → Uₘ ∣ Uₙ** (the divisibility-sequence property).
- `U_one_neg_one` — U 1 (−1) n = Fₙ (Fibonacci specialization).
- `fib_dvd_of_dvd`, `pell_dvd_of_dvd` — Fibonacci and Pell corollaries.

## Verification

`./proofs/scripts/docker-build.sh Proofs.FibonacciIdentitiesOQ07OQ01` → **Build succeeded (3060 jobs)**, `Built Proofs.FibonacciIdentitiesOQ07OQ01 (16s)`. 146 lines, 0 sorries, 0 `axiom` declarations; builds only on the two gallery Lucas-sequence entries + Mathlib.

## Not included (remaining open)

The **strong** divisibility gcd(Uₘ,Uₙ) = U_{gcd(m,n)} (equivalently the reverse Uₘ∣Uₙ → m∣n) holds only under gcd(P,Q)=1 and needs gcd(Uₙ,Uₙ₊₁)=1 — left as a documented follow-up.

Gallery data: `src/data/proofs/fibonacci-identities-oq-07-oq-01/` (meta.json + annotations.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)