### PR TITLE
research(geometric-series-oq-06-oq-02): negative-binomial series ∑ binom(n+k,k)·rⁿ = 1/(1−r)^(k+1) [BUILD-PENDING]

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ06OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ06OQ02.lean
@@ -1,0 +1,218 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# The Negative-Binomial Series ∑ binom(n+k, k)·rⁿ = (1 − r)⁻⁽ᵏ⁺¹⁾ (geometric-series-oq-06-oq-02)
+
+The parent entry (`geometric-series-oq-06`) obtains the arithmetico-geometric
+series `∑' n, n·rⁿ = r/(1 − r)²` by differentiating the geometric series once.
+Its open question asks:
+
+  > Does the term-by-term differentiation generalize cleanly to
+  > `∑ binom(n+k, k)·rⁿ = (1 − r)⁻⁽ᵏ⁺¹⁾` for all `k`, via Mathlib's
+  > descending-factorial weighted geometric series?
+
+**Answer: yes.**  Differentiating `∑ rⁿ = 1/(1 − r)` exactly `k` times (and dividing
+by `k!`) produces the **negative-binomial series**
+
+    ∑' n, binom(n+k, k) · rⁿ = 1 / (1 − r)^(k+1)      (‖r‖ < 1),
+
+whose coefficients `binom(n+k, k)` count the weak compositions of `n` into `k+1`
+parts — the generating function `(1 − r)^{-(k+1)}` of the negative-binomial
+distribution.  Mathlib packages exactly this identity as
+`hasSum_choose_mul_geometric_of_norm_lt_one`, so the generalization is available
+off the shelf and this file records the answer, ties it back to the parent, and
+verifies the promised specializations.
+
+What this file adds on top of the raw Mathlib lemma:
+
+* the whole `k`-indexed family in `HasSum` / `Summable` / `tsum` form;
+* the two anchoring specializations `k = 0` (geometric series `1/(1 − r)`) and
+  `k = 1` (shifted companion `∑ (n+1)·rⁿ = 1/(1 − r)²`);
+* a **closed loop back to the parent**: the arithmetico-geometric first moment
+  `∑' n, n·rⁿ = r/(1 − r)²` is re-derived as the `k = 1` family minus the `k = 0`
+  family, exhibiting the parent's result as a genuine special case of the
+  generalization (`tsum_coe_mul_geometric_from_negBinom`);
+* the descending-factorial reformulation `∑' n, (n+k) descFactorial k · rⁿ =
+  k!/(1 − r)^(k+1)`, the exact "descending-factorial weighted geometric series"
+  the open question names;
+* a concrete evaluation `∑' n, binom(n+2, 2)·(1/2)ⁿ = 8`.
+
+Every statement is a thin, named wrapper around Mathlib's negative-binomial
+machinery; the parent-recovering identity and the descending-factorial identity
+are genuine derivations combining several of these wrappers.
+
+Status: 0 axioms, 0 sorries
+-/
+
+namespace GeometricSeriesOQ06OQ02
+
+open scoped Topology
+
+-- ============================================================================
+-- Part I: The negative-binomial series over a normed field
+-- ============================================================================
+
+variable {𝕜 : Type*} [NormedField 𝕜]
+
+/-- **Negative-binomial series, `HasSum` form.** For every `k` and `‖r‖ < 1` the
+partial sums of `binom(n+k, k)·rⁿ` converge to `1/(1 − r)^(k+1)`.  This is the
+`k`-fold term-by-term derivative (÷ `k!`) of the geometric series. -/
+theorem hasSum_choose_mul_geometric (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => ((n + k).choose k : 𝕜) * r ^ n) (1 / (1 - r) ^ (k + 1)) :=
+  hasSum_choose_mul_geometric_of_norm_lt_one k hr
+
+/-- The negative-binomial series is summable when `‖r‖ < 1`. -/
+theorem summable_choose_mul_geometric (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
+    Summable (fun n : ℕ => ((n + k).choose k : 𝕜) * r ^ n) :=
+  (hasSum_choose_mul_geometric k hr).summable
+
+/-- **Negative-binomial series.** For every `k` and `‖r‖ < 1`,
+
+    ∑' n, binom(n+k, k) · rⁿ = 1 / (1 − r)^(k+1). -/
+theorem tsum_choose_mul_geometric (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, ((n + k).choose k : 𝕜) * r ^ n = 1 / (1 - r) ^ (k + 1) :=
+  (hasSum_choose_mul_geometric k hr).tsum_eq
+
+-- ============================================================================
+-- Part II: The anchoring specializations k = 0 and k = 1
+-- ============================================================================
+
+/-- **`k = 0` recovers the geometric series.** Since `binom(n, 0) = 1`, the family
+degenerates to `∑' n, rⁿ = 1/(1 − r)`, the seed of the whole differentiation
+tower. -/
+theorem tsum_geometric_of_negBinom {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, r ^ n = 1 / (1 - r) := by
+  have h := tsum_choose_mul_geometric 0 hr
+  simpa using h
+
+/-- **`k = 1` gives the shifted companion.** Since `binom(n+1, 1) = n + 1`,
+
+    ∑' n, (n + 1) · rⁿ = 1 / (1 − r)². -/
+theorem tsum_succ_mul_geometric {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, ((n : 𝕜) + 1) * r ^ n = 1 / (1 - r) ^ 2 := by
+  have h := tsum_choose_mul_geometric 1 hr
+  have hcongr : (fun n : ℕ => ((n + 1).choose 1 : 𝕜) * r ^ n)
+      = fun n : ℕ => ((n : 𝕜) + 1) * r ^ n := by
+    funext n
+    simp [Nat.choose_one_right, Nat.cast_add, Nat.cast_one]
+  rw [hcongr] at h
+  exact h
+
+-- ============================================================================
+-- Part III: Closing the loop — recover the parent's arithmetico-geometric sum
+-- ============================================================================
+
+/-- **The parent result is the `k = 1` case minus the `k = 0` case.** Subtracting
+the geometric series from the shifted companion strips the `+1`, recovering the
+parent entry's arithmetico-geometric first moment
+
+    ∑' n, n · rⁿ = r / (1 − r)²
+
+purely from the negative-binomial family.  This is the precise sense in which the
+`k`-fold differentiation "generalizes cleanly": the parent is a special case. -/
+theorem tsum_coe_mul_geometric_from_negBinom {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : 𝕜) * r ^ n = r / (1 - r) ^ 2 := by
+  have hne : (1 : 𝕜) - r ≠ 0 := by
+    rcases eq_or_ne r 1 with rfl | hr1
+    · simp at hr
+    · exact sub_ne_zero.mpr (Ne.symm hr1)
+  -- `∑ (n+1)·rⁿ = 1/(1−r)²` and `∑ rⁿ = 1/(1−r)`, both as `HasSum`.
+  have h1 : HasSum (fun n : ℕ => ((n : 𝕜) + 1) * r ^ n) (1 / (1 - r) ^ 2) := by
+    have h := hasSum_choose_mul_geometric 1 hr
+    have hcongr : (fun n : ℕ => ((n + 1).choose 1 : 𝕜) * r ^ n)
+        = fun n : ℕ => ((n : 𝕜) + 1) * r ^ n := by
+      funext n
+      simp [Nat.choose_one_right, Nat.cast_add, Nat.cast_one]
+    rwa [hcongr] at h
+  have h0 : HasSum (fun n : ℕ => r ^ n) (1 / (1 - r)) := by
+    have h := hasSum_choose_mul_geometric 0 hr
+    simpa using h
+  -- Subtract term by term: `(n+1)·rⁿ − rⁿ = n·rⁿ`.
+  have hsub := h1.sub h0
+  have hcongr : (fun n : ℕ => ((n : 𝕜) + 1) * r ^ n - r ^ n)
+      = fun n : ℕ => (n : 𝕜) * r ^ n := by
+    funext n; ring
+  rw [hcongr] at hsub
+  have hval : (1 : 𝕜) / (1 - r) ^ 2 - 1 / (1 - r) = r / (1 - r) ^ 2 := by
+    field_simp
+    ring
+  rw [hval] at hsub
+  exact hsub.tsum_eq
+
+-- ============================================================================
+-- Part IV: The descending-factorial reformulation
+-- ============================================================================
+
+/-- **Descending-factorial weighted geometric series.** Because
+`(n+k) descFactorial k = k! · binom(n+k, k)`, the negative-binomial series
+rescales to
+
+    ∑' n, (n+k) descFactorial k · rⁿ = k! / (1 − r)^(k+1),
+
+the "descending-factorial weighted geometric series" named in the open question.
+For `k = 1` this is again `∑' n, (n+1)·rⁿ = 1/(1 − r)²`. -/
+theorem tsum_descFactorial_mul_geometric (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, ((n + k).descFactorial k : 𝕜) * r ^ n
+      = (k.factorial : 𝕜) / (1 - r) ^ (k + 1) := by
+  have h := (hasSum_choose_mul_geometric k hr).mul_left (k.factorial : 𝕜)
+  have hcongr : (fun n : ℕ => (k.factorial : 𝕜) * (((n + k).choose k : 𝕜) * r ^ n))
+      = fun n : ℕ => ((n + k).descFactorial k : 𝕜) * r ^ n := by
+    funext n
+    rw [Nat.descFactorial_eq_factorial_mul_choose (n + k) k]
+    push_cast
+    ring
+  rw [hcongr] at h
+  rw [h.tsum_eq]
+  rw [one_div, mul_one_div]
+
+-- ============================================================================
+-- Part V: A concrete evaluation
+-- ============================================================================
+
+/-- **Concrete value.** Taking `k = 2`, `r = 1/2` over `ℝ`:
+
+    ∑' n, binom(n+2, 2) · (1/2)ⁿ = 8,
+
+since `1/(1 − 1/2)³ = 2³ = 8`.  The triangular-number weights `binom(n+2, 2) =
+(n+1)(n+2)/2` are exactly the coefficients of the second derivative of the
+geometric series. -/
+theorem tsum_choose_two_half_pow :
+    ∑' n : ℕ, ((n + 2).choose 2 : ℝ) * (1 / 2) ^ n = 8 := by
+  have h : ‖(1 / 2 : ℝ)‖ < 1 := by rw [Real.norm_eq_abs]; norm_num
+  rw [tsum_choose_mul_geometric 2 h]
+  norm_num
+
+-- ============================================================================
+-- Part VI: Summary
+-- ============================================================================
+
+/-
+## Summary
+
+| Result | Statement | Backing |
+|--------|-----------|---------|
+| `hasSum_choose_mul_geometric` | partial sums → 1/(1−r)^(k+1) | `hasSum_choose_mul_geometric_of_norm_lt_one` |
+| `tsum_choose_mul_geometric` | ∑ binom(n+k,k)·rⁿ = 1/(1−r)^(k+1) | `HasSum.tsum_eq` |
+| `summable_choose_mul_geometric` | negative-binomial series summable | `HasSum.summable` |
+| `tsum_geometric_of_negBinom` | `k=0` → ∑ rⁿ = 1/(1−r) | specialize k = 0 |
+| `tsum_succ_mul_geometric` | `k=1` → ∑ (n+1)·rⁿ = 1/(1−r)² | specialize k = 1 |
+| `tsum_coe_mul_geometric_from_negBinom` | ∑ n·rⁿ = r/(1−r)² (parent) | `k=1` − `k=0` |
+| `tsum_descFactorial_mul_geometric` | ∑ (n+k)‿ₖ·rⁿ = k!/(1−r)^(k+1) | rescale by `k!` |
+| `tsum_choose_two_half_pow` | ∑ binom(n+2,2)·(1/2)ⁿ = 8 | specialize k = 2, r = 1/2 |
+
+**Answer to the open question.** The term-by-term differentiation generalizes
+cleanly: the `k`-fold derivative of `∑ rⁿ = 1/(1 − r)`, normalized by `k!`, is the
+negative-binomial series `∑ binom(n+k, k)·rⁿ = 1/(1 − r)^(k+1)`, and the parent's
+arithmetico-geometric first moment `∑ n·rⁿ = r/(1 − r)²` reappears as the `k = 1`
+member of the family (minus the `k = 0` geometric series).  The descending-
+factorial form `∑ (n+k) descFactorial k · rⁿ = k!/(1 − r)^(k+1)` is the same
+statement with the binomial coefficient rescaled by `k!`.
+-/
+
+end GeometricSeriesOQ06OQ02
+
+#check @GeometricSeriesOQ06OQ02.tsum_choose_mul_geometric
+#check @GeometricSeriesOQ06OQ02.tsum_coe_mul_geometric_from_negBinom
+#check @GeometricSeriesOQ06OQ02.tsum_descFactorial_mul_geometric
+#check @GeometricSeriesOQ06OQ02.tsum_choose_two_half_pow

--- a/research/problems/geometric-series-oq-06-oq-02/knowledge.md
+++ b/research/problems/geometric-series-oq-06-oq-02/knowledge.md
@@ -1,0 +1,52 @@
+# geometric-series-oq-06-oq-02 — Negative-Binomial Series
+
+## Problem
+
+Parent `geometric-series-oq-06` differentiates the geometric series once to get
+`∑' n, n·rⁿ = r/(1−r)²`. The open question asks whether term-by-term
+differentiation generalizes cleanly to
+
+    ∑' n, binom(n+k, k)·rⁿ = 1/(1−r)^(k+1)   (‖r‖ < 1),
+
+via a descending-factorial weighted geometric series.
+
+**Answer: yes.**
+
+## Summary
+
+The `k`-fold term-by-term derivative of `∑ rⁿ = 1/(1−r)`, normalized by `k!`, is
+the negative-binomial series above. Mathlib packages exactly this identity as
+`hasSum_choose_mul_geometric_of_norm_lt_one`
+(`Mathlib.Analysis.SpecificLimits.Normed`), so the file records named wrappers
+plus two genuine derivations. 8 theorems, 0 axioms, 0 sorries, ~218 lines.
+
+## Sessions
+
+### Session 2026-07-01 (Session 1) — Adopt orphan + verify
+
+**Mode**: FRESH
+**Outcome**: complete (build verification in progress)
+
+#### What I Did
+- Adopted the untracked orphan draft `proofs/Proofs/GeometricSeriesOQ06OQ02.lean`
+  + gallery data (created by a prior process that died holding the claim lock,
+  never committed, no PR).
+- Confirmed the key Mathlib lemma `hasSum_choose_mul_geometric_of_norm_lt_one`
+  exists at `Mathlib/Analysis/SpecificLimits/Normed.lean:468` over a
+  `NormedDivisionRing 𝕜`; the draft's `[NormedField 𝕜]` extends that and
+  `NormedDivisionRing` auto-supplies `HasSummableGeomSeries` (instance at line
+  368), so the wrappers typecheck.
+- Committed on branch `research/geometric-negbinom-oq0602`; launched docker build.
+
+#### Key Findings
+- The parent result `∑ n·rⁿ = r/(1−r)²` is the `(k=1)` family minus the `(k=0)`
+  geometric series (`HasSum.sub`), so the parent is a genuine special case.
+- Descending-factorial form `∑ (n+k)‿ₖ·rⁿ = k!/(1−r)^(k+1)` follows by rescaling
+  by `k!` via `Nat.descFactorial_eq_factorial_mul_choose`.
+
+#### Files
+- `proofs/Proofs/GeometricSeriesOQ06OQ02.lean`
+- `src/data/proofs/geometric-series-oq-06-oq-02/{meta,annotations}.json`
+
+#### Next Steps
+- Confirm `docker-build.sh Proofs.GeometricSeriesOQ06OQ02` compiles clean, then PR.

--- a/research/problems/geometric-series-oq-06-oq-02/state.md
+++ b/research/problems/geometric-series-oq-06-oq-02/state.md
@@ -1,0 +1,53 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-07-01
+**Iteration**: 3
+
+## Current Focus
+
+Machine-verification of the negative-binomial series formalization
+(`proofs/Proofs/GeometricSeriesOQ06OQ02.lean`, 8 theorems). Draft is complete and
+verified-by-inspection; the ONLY remaining gap is a clean compile.
+
+## Active Approach
+
+Named wrappers over Mathlib's `hasSum_choose_mul_geometric_of_norm_lt_one`
+(non-primed normed-field form, `Mathlib.Analysis.SpecificLimits.Normed:468`) plus
+k=0/k=1 specializations, parent-recovery (∑ n·rⁿ = r/(1−r)² as k=1 − k=0),
+descending-factorial reformulation, and a concrete k=2,r=1/2 evaluation.
+
+## Verification Status
+
+**Verified-by-inspection, machine-compile BLOCKED by infra.** Confirmed by reading
+Mathlib source:
+- `hasSum_choose_mul_geometric_of_norm_lt_one` exists, `{r : 𝕜}` normed field,
+  yields `1/(1-r)^(k+1)` (Normed.lean:468).
+- `HasSummableGeomSeries 𝕜` auto-synthesizes from `[NormedField 𝕜]` via the
+  `NormedDivisionRing` instance (Normed.lean:368) — geometric HasSum holds WITHOUT
+  completeness (explicit closed form (1−ξⁿ)(1−ξ)⁻¹ → (1−ξ)⁻¹). Draft's
+  `[NormedField 𝕜]` is sufficient; NO `[CompleteSpace 𝕜]` needed.
+- `Nat.descFactorial_eq_factorial_mul_choose`, `Nat.choose_one_right` present.
+
+## Blockers
+
+Docker build infra. Attempt 1: shared Mathlib cache corruption (`leantar failed`,
+permission-denied .ltar) under 5-6 concurrent lean-build containers. Attempt 2:
+`LEAN_SKIP_CACHE=true` source build reached **3036/3058** Mathlib targets, then
+Docker Desktop crashed (containerd `meta.db: input/output error`). No error ever
+attributable to GeometricSeriesOQ06OQ02.lean.
+
+## Next Action
+
+When Docker recovers (restart Docker Desktop; wait for `docker ps | grep lean-build`
+empty): `LEAN_SKIP_CACHE=true ./proofs/scripts/docker-build.sh
+Proofs.GeometricSeriesOQ06OQ02` (resumes near 3036/3058, cheap). On clean build:
+flip meta.status → "verified", drop `verificationPending`, badge → "mathlib",
+restore "Fully verified" assumptions, open PR (research label, NO loom:review-requested).
+Branch already pushed: `research/geometric-series-negbinom-oq0602`.
+
+## Attempt Counts
+
+- Total attempts: 3 (2 infra-blocked build attempts this session)
+- Current approach attempts: 3
+- Approaches tried: 1 (Mathlib negative-binomial wrapper — sound)

--- a/src/data/proofs/geometric-series-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-06-oq-02/annotations.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "geomseries-oq0602-ann-header",
+    "proofId": "geometric-series-oq-06-oq-02",
+    "range": { "startLine": 1, "endLine": 55 },
+    "type": "concept",
+    "title": "The negative-binomial series as the k-fold differentiated geometric series",
+    "content": "The parent entry differentiates $\\sum r^n = 1/(1-r)$ once to get $\\sum n\\,r^n = r/(1-r)^2$ and asks whether this generalizes to all orders. It does: differentiating $k$ times and dividing by $k!$ gives the **negative-binomial series** $\\sum_{n} \\binom{n+k}{k} r^n = 1/(1-r)^{k+1}$ for $\\|r\\|<1$. The coefficients $\\binom{n+k}{k}$ count weak compositions of $n$ into $k+1$ parts, and $(1-r)^{-(k+1)}$ is the negative-binomial generating function. Mathlib packages exactly this as `hasSum_choose_mul_geometric_of_norm_lt_one`, so the file records the answer, ties it back to the parent, and verifies the promised specializations.",
+    "mathContext": "$\\sum'_{n} \\binom{n+k}{k}\\,r^n = \\dfrac{1}{(1-r)^{k+1}}, \\quad \\|r\\| < 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "geometric series",
+      "term-by-term differentiation",
+      "negative-binomial distribution",
+      "generating functions"
+    ],
+    "prerequisites": [
+      "infinite series",
+      "normed fields",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "geomseries-oq0602-ann-family",
+    "proofId": "geometric-series-oq-06-oq-02",
+    "range": { "startLine": 56, "endLine": 76 },
+    "type": "concept",
+    "title": "The k-indexed family in HasSum / Summable / tsum form",
+    "content": "`hasSum_choose_mul_geometric`, `summable_choose_mul_geometric`, and `tsum_choose_mul_geometric` are named wrappers of Mathlib's `hasSum_choose_mul_geometric_of_norm_lt_one`, exposing the whole $k$-indexed family $\\sum \\binom{n+k}{k} r^n = 1/(1-r)^{k+1}$ as reusable API. Mathlib states the lemma over a `NormedDivisionRing`; a `NormedField` extends `NormedDivisionRing` and auto-provides the `HasSummableGeomSeries` instance, so the specialization is free.",
+    "mathContext": "$\\sum'_{n} \\binom{n+k}{k}\\,r^n = 1/(1-r)^{k+1}$ over any normed field",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasSum",
+      "Summable",
+      "tsum",
+      "NormedDivisionRing"
+    ],
+    "prerequisites": [
+      "convergent series",
+      "normed fields"
+    ]
+  },
+  {
+    "id": "geomseries-oq0602-ann-anchors",
+    "proofId": "geometric-series-oq-06-oq-02",
+    "range": { "startLine": 77, "endLine": 101 },
+    "type": "insight",
+    "title": "The two ends of the tower: k = 0 and k = 1",
+    "content": "The family degenerates cleanly at both ends. At $k=0$, $\\binom{n}{0}=1$ so `tsum_geometric_of_negBinom` recovers the seed $\\sum r^n = 1/(1-r)$. At $k=1$, $\\binom{n+1}{1}=n+1$ so `tsum_succ_mul_geometric` gives the shifted companion $\\sum(n+1)r^n = 1/(1-r)^2$. These are the same two series whose difference is the parent's arithmetico-geometric sum — proved in the next section.",
+    "mathContext": "$k=0:\\ \\sum r^n = 1/(1-r); \\quad k=1:\\ \\sum(n+1)r^n = 1/(1-r)^2$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "binomial coefficient identities",
+      "index specialization",
+      "geometric series"
+    ],
+    "prerequisites": [
+      "Nat.choose_one_right",
+      "cast lemmas"
+    ]
+  },
+  {
+    "id": "geomseries-oq0602-ann-parent-recovery",
+    "proofId": "geometric-series-oq-06-oq-02",
+    "range": { "startLine": 102, "endLine": 142 },
+    "type": "tactic",
+    "title": "The parent is a special case: k=1 minus k=0",
+    "content": "`tsum_coe_mul_geometric_from_negBinom` is the heart of the entry: it re-derives the parent's arithmetico-geometric first moment $\\sum n\\,r^n = r/(1-r)^2$ purely from the negative-binomial family. Subtracting the $k=0$ `HasSum` (geometric series) from the $k=1$ `HasSum` (shifted companion) strips the $+1$ termwise — $(n+1)r^n - r^n = n r^n$ via `funext`+`ring` — and evaluates $\\frac{1}{(1-r)^2} - \\frac{1}{1-r} = \\frac{r}{(1-r)^2}$ via `field_simp`; `ring` after establishing $1-r\\ne 0$. This is the precise sense in which the differentiation 'generalizes cleanly': the parent is not a separate result but the $k=1$ member of the family.",
+    "mathContext": "$\\sum'_{n} n\\,r^n = \\dfrac{1}{(1-r)^2} - \\dfrac{1}{1-r} = \\dfrac{r}{(1-r)^2}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasSum.sub",
+      "termwise subtraction",
+      "arithmetico-geometric series",
+      "field_simp"
+    ],
+    "prerequisites": [
+      "subtracting convergent series",
+      "sub_ne_zero"
+    ]
+  },
+  {
+    "id": "geomseries-oq0602-ann-descfactorial",
+    "proofId": "geometric-series-oq-06-oq-02",
+    "range": { "startLine": 143, "endLine": 167 },
+    "type": "tactic",
+    "title": "The descending-factorial weighted geometric series",
+    "content": "`tsum_descFactorial_mul_geometric` produces the exact form the open question names: $\\sum (n+k)^{\\underline{k}} r^n = k!/(1-r)^{k+1}$. Because $(n+k)^{\\underline{k}} = k!\\binom{n+k}{k}$ (`Nat.descFactorial_eq_factorial_mul_choose`), scaling the family by $k!$ via `HasSum.mul_left` and a `push_cast`+`ring` congruence converts the binomial weight to a descending-factorial weight. It is the same identity with the coefficient rescaled.",
+    "mathContext": "$\\sum'_{n} (n+k)^{\\underline{k}}\\,r^n = k!/(1-r)^{k+1}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "descending factorial",
+      "HasSum.mul_left",
+      "Nat.descFactorial_eq_factorial_mul_choose",
+      "push_cast"
+    ],
+    "prerequisites": [
+      "factorial identities",
+      "scaling convergent series"
+    ]
+  },
+  {
+    "id": "geomseries-oq0602-ann-concrete",
+    "proofId": "geometric-series-oq-06-oq-02",
+    "range": { "startLine": 168, "endLine": 184 },
+    "type": "concept",
+    "title": "A concrete evaluation: ∑ binom(n+2,2)·(1/2)ⁿ = 8",
+    "content": "`tsum_choose_two_half_pow` specializes $k=2$, $r=1/2$ over $\\mathbb{R}$: the triangular-number weights $\\binom{n+2}{2}=(n+1)(n+2)/2$ are the coefficients of the second derivative of the geometric series, and $1/(1-1/2)^3 = 2^3 = 8$ by `norm_num`. It concretely exhibits the $k=2$ member of the family.",
+    "mathContext": "$\\sum'_{n} \\binom{n+2}{2}(1/2)^n = 1/(1/2)^3 = 8$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangular numbers",
+      "second derivative",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "binomial evaluation",
+      "real geometric series"
+    ]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-06-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-06-oq-02/meta.json
@@ -1,0 +1,153 @@
+{
+  "id": "geometric-series-oq-06-oq-02",
+  "title": "The Negative-Binomial Series ∑ binom(n+k, k)·rⁿ = (1−r)⁻⁽ᵏ⁺¹⁾",
+  "slug": "geometric-series-oq-06-oq-02",
+  "description": "The k-fold term-by-term derivative of ∑ rⁿ = 1/(1−r), normalized by k!, is the negative-binomial series ∑' n, binom(n+k, k)·rⁿ = 1/(1−r)^(k+1) for ‖r‖ < 1 — answering the parent's open question and recovering ∑ n·rⁿ = r/(1−r)² as the k=1 member.",
+  "meta": {
+    "author": "Classical (negative-binomial generating functions), formalized via Mathlib",
+    "sourceUrl": "https://github.com/leanprover-community/mathlib4",
+    "date": "2026-07-01",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ06OQ02.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "negative-binomial",
+      "infinite-series",
+      "generating-functions",
+      "binomial-coefficients",
+      "descending-factorial"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_choose_mul_geometric_of_norm_lt_one",
+        "description": "HasSum (fun n ↦ (n+k).choose k · rⁿ) (1/(1−r)^(k+1)) for ‖r‖ < 1 over a normed division ring",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "tsum_choose_mul_geometric_of_norm_lt_one",
+        "description": "∑' n, (n+k).choose k · rⁿ = 1/(1−r)^(k+1) for ‖r‖ < 1, the tsum form",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Nat.descFactorial_eq_factorial_mul_choose",
+        "description": "n.descFactorial k = k! · n.choose k, rescaling binomial coefficients to descending factorials",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Named normed-field API for the negative-binomial series: HasSum, Summable, and tsum forms of ∑ binom(n+k, k)·rⁿ = 1/(1−r)^(k+1)",
+      "Closed loop back to the parent: the arithmetico-geometric first moment ∑ n·rⁿ = r/(1−r)² is re-derived as the k=1 family minus the k=0 geometric series, exhibiting the parent as a genuine special case",
+      "Descending-factorial reformulation ∑' n, (n+k) descFactorial k · rⁿ = k!/(1−r)^(k+1), the exact 'descending-factorial weighted geometric series' named in the open question",
+      "Concrete evaluation ∑' n, binom(n+2, 2)·(1/2)ⁿ = 8 (triangular-number weights, second derivative of the geometric series)"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 218,
+    "theoremCount": 8,
+    "assumptions": "Build-pending: NOT yet machine-verified. Docker infra crashed mid-build (reached 3036/3058 Mathlib targets, no error attributable to this file). Targets 0 axioms / 0 sorries by construction; every Mathlib dependency (hasSum_choose_mul_geometric_of_norm_lt_one, tsum_choose_mul_geometric_of_norm_lt_one, Nat.descFactorial_eq_factorial_mul_choose) confirmed present with matching signatures by source inspection. Requires a clean compile before status can be raised to verified.",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0,
+    "verificationPending": true
+  },
+  "overview": {
+    "historicalContext": "The geometric series $\\sum_{n=0}^\\infty r^n = \\frac{1}{1-r}$ for $|r|<1$ is the seed of the differentiation tower. Its parent entry (`geometric-series-oq-06`) differentiates once to get $\\sum n r^n = \\frac{r}{(1-r)^2}$ and asks whether this generalizes to arbitrary order. Differentiating $k$ times and dividing by $k!$ produces the **negative-binomial series** $\\sum_{n=0}^\\infty \\binom{n+k}{k} r^n = \\frac{1}{(1-r)^{k+1}}$, whose coefficients $\\binom{n+k}{k}$ count the weak compositions of $n$ into $k+1$ parts. The closed form $(1-r)^{-(k+1)}$ is the generating function of the negative-binomial distribution, the workhorse of probability generating-function calculus.",
+    "problemStatement": "**Theorem**: For $r$ in a normed field with $\\|r\\| < 1$ and every $k \\in \\mathbb{N}$,\n$$\\sum_{n=0}^{\\infty} \\binom{n+k}{k}\\, r^{n} = \\frac{1}{(1-r)^{k+1}}.$$\nThe parent's arithmetico-geometric first moment $\\sum n r^n = r/(1-r)^2$ is the $k=1$ member minus the $k=0$ geometric series; specializing $k=2$, $r=1/2$ over $\\mathbb{R}$ gives $\\sum \\binom{n+2}{2}(1/2)^n = 8$.",
+    "proofStrategy": "**Core identity**: The series is Mathlib's `hasSum_choose_mul_geometric_of_norm_lt_one`, stated over a normed division ring; a `NormedField` instance supplies it directly. The file packages the `HasSum`, `Summable`, and `tsum` forms of the $k$-indexed family.\n\n**Anchoring specializations**: $k=0$ degenerates to $\\sum r^n = 1/(1-r)$ (since $\\binom{n}{0}=1$); $k=1$ gives $\\sum(n+1)r^n = 1/(1-r)^2$ (since $\\binom{n+1}{1}=n+1$).\n\n**Parent recovery**: Subtracting the $k=0$ `HasSum` from the $k=1$ `HasSum` strips the $+1$: $(n+1)r^n - r^n = n r^n$, and $\\frac{1}{(1-r)^2}-\\frac{1}{1-r} = \\frac{r}{(1-r)^2}$ by `field_simp`; `ring`, recovering the parent.\n\n**Descending-factorial form**: Rescaling by $k!$ via `Nat.descFactorial_eq_factorial_mul_choose` gives $\\sum (n+k)^{\\underline{k}} r^n = k!/(1-r)^{k+1}$.\n\n**Concrete value**: At $k=2$, $r=1/2$, $1/(1-1/2)^3 = 2^3 = 8$ by `norm_num`.",
+    "keyInsights": [
+      "**Differentiation tower**: The $k$-fold term-by-term derivative of $\\sum r^n = 1/(1-r)$, normalized by $k!$, is exactly the negative-binomial series — the binomial coefficient $\\binom{n+k}{k}$ is precisely $\\frac{1}{k!}\\frac{d^k}{dr^k} r^{n+k}$ evaluated appropriately.",
+      "**The parent is a special case**: $\\sum n r^n = r/(1-r)^2$ is not a separate phenomenon — it is the $k=1$ member of the family minus the $k=0$ geometric series, making the generalization genuinely closed rather than merely analogous.",
+      "**Combinatorial reading**: $\\binom{n+k}{k}$ counts weak compositions of $n$ into $k+1$ nonnegative parts, so $(1-r)^{-(k+1)} = (\\sum r^n)^{k+1}$ is the $(k+1)$-fold Cauchy product of the geometric series — the generating-function identity underlying stars-and-bars.",
+      "**Descending factorials vs. binomials**: The open question's 'descending-factorial weighted geometric series' $\\sum (n+k)^{\\underline{k}} r^n = k!/(1-r)^{k+1}$ is the same statement with $\\binom{n+k}{k}$ rescaled by $k!$, since $(n+k)^{\\underline{k}} = k!\\binom{n+k}{k}$."
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Docstring answering the parent's open question: the k-fold derivative (÷k!) of ∑ rⁿ = 1/(1−r) is the negative-binomial series ∑ binom(n+k,k)·rⁿ = 1/(1−r)^(k+1), packaged from Mathlib's hasSum_choose_mul_geometric_of_norm_lt_one; imports SpecificLimits.Normed and Tactic.",
+      "mathContext": "∑' n, binom(n+k, k)·rⁿ = 1/(1−r)^(k+1) for ‖r‖ < 1; coefficients count weak compositions of n into k+1 parts."
+    },
+    {
+      "id": "family",
+      "title": "The Negative-Binomial Series over a Normed Field",
+      "startLine": 56,
+      "endLine": 76,
+      "summary": "hasSum_choose_mul_geometric, summable_choose_mul_geometric, tsum_choose_mul_geometric — the HasSum, Summable, and tsum forms of the k-indexed family ∑ binom(n+k,k)·rⁿ = 1/(1−r)^(k+1).",
+      "mathContext": "Thin wrappers of Mathlib's hasSum_choose_mul_geometric_of_norm_lt_one, specialized from NormedDivisionRing to NormedField."
+    },
+    {
+      "id": "anchors",
+      "title": "The Anchoring Specializations k = 0 and k = 1",
+      "startLine": 77,
+      "endLine": 101,
+      "summary": "tsum_geometric_of_negBinom (k=0 → ∑ rⁿ = 1/(1−r)) and tsum_succ_mul_geometric (k=1 → ∑ (n+1)·rⁿ = 1/(1−r)²), the two ends of the differentiation tower.",
+      "mathContext": "binom(n,0)=1 collapses the family to the geometric series; binom(n+1,1)=n+1 gives the shifted companion."
+    },
+    {
+      "id": "parent-recovery",
+      "title": "Closing the Loop — Recovering the Parent",
+      "startLine": 102,
+      "endLine": 142,
+      "summary": "tsum_coe_mul_geometric_from_negBinom: ∑ n·rⁿ = r/(1−r)² recovered as the k=1 family minus the k=0 geometric series via HasSum.sub, exhibiting the parent's result as a special case.",
+      "mathContext": "(n+1)·rⁿ − rⁿ = n·rⁿ and 1/(1−r)² − 1/(1−r) = r/(1−r)² by field_simp; ring."
+    },
+    {
+      "id": "descfactorial",
+      "title": "The Descending-Factorial Reformulation",
+      "startLine": 143,
+      "endLine": 167,
+      "summary": "tsum_descFactorial_mul_geometric: ∑ (n+k) descFactorial k · rⁿ = k!/(1−r)^(k+1), the descending-factorial weighted geometric series named in the open question.",
+      "mathContext": "Rescales binom by k! using Nat.descFactorial_eq_factorial_mul_choose and HasSum.mul_left."
+    },
+    {
+      "id": "concrete",
+      "title": "A Concrete Evaluation",
+      "startLine": 168,
+      "endLine": 184,
+      "summary": "tsum_choose_two_half_pow: ∑ binom(n+2,2)·(1/2)ⁿ = 8 over ℝ.",
+      "mathContext": "Specializes k=2, r=1/2: 1/(1−1/2)³ = 2³ = 8 by norm_num."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent's open question affirmatively: the term-by-term differentiation of the geometric series generalizes cleanly to all orders as the negative-binomial series ∑ binom(n+k, k)·rⁿ = 1/(1−r)^(k+1). It packages the k-indexed family as reusable HasSum/Summable/tsum API, re-derives the parent's ∑ n·rⁿ = r/(1−r)² as the k=1 member, gives the descending-factorial reformulation, and evaluates a concrete case.",
+    "implications": "The closed form (1−r)^{-(k+1)} is the generating function of the negative-binomial distribution and the (k+1)-fold Cauchy product of the geometric series, tying the differentiation tower to the combinatorics of weak compositions (stars-and-bars). Each order k is one term-by-term differentiation of the previous, made rigorous by Mathlib's summability backing.",
+    "openQuestions": [
+      "Does the same negative-binomial family arise as the (k+1)-fold Cauchy product (∑ rⁿ)^{k+1}, and can the stars-and-bars identity binom(n+k,k) = #{weak compositions of n into k+1 parts} be used to give a purely combinatorial proof independent of the analytic differentiation?",
+      "Can the family be summed against a probability weight (1−r)^{k+1} to recover the mean k·r/(1−r) and variance of the negative-binomial distribution as further differentiated moments?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-06",
+      "relationship": "parent",
+      "description": "The arithmetico-geometric series ∑ n·rⁿ = r/(1−r)². This entry answers its second open question and recovers its result as the k=1 member of the negative-binomial family."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "foundation",
+      "description": "The base geometric series ∑ rⁿ = 1/(1−r) (Wiedijk #66), the k=0 seed of the whole differentiation tower."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Topology"
+    ],
+    "namespace": "GeometricSeriesOQ06OQ02",
+    "lineCount": 218,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/GeometricSeriesOQ06OQ02.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Answers the `geometric-series-oq-06` open question: **does term-by-term
differentiation generalize cleanly to `∑ binom(n+k,k)·rⁿ = (1−r)⁻⁽ᵏ⁺¹⁾`?** — **yes.**

An 8-theorem named API over Mathlib's `hasSum_choose_mul_geometric_of_norm_lt_one`
(negative-binomial series), including:
- `HasSum` / `Summable` / `tsum` forms of `∑ binom(n+k,k)·rⁿ = 1/(1−r)^(k+1)` over any normed field;
- `k=0` (geometric series) and `k=1` (`∑ (n+1)·rⁿ = 1/(1−r)²`) specializations;
- **parent-recovery**: `∑ n·rⁿ = r/(1−r)²` re-derived as the `k=1` family minus `k=0`, exhibiting the parent as a genuine special case;
- descending-factorial reformulation `∑ (n+k) descFactorial k · rⁿ = k!/(1−r)^(k+1)`;
- concrete `∑ binom(n+2,2)·(1/2)ⁿ = 8`.

Targets **0 axioms / 0 sorries**.

## ⚠️ BUILD-PENDING — not yet machine-verified

Docker build infra failed this session (shared Mathlib cache corruption; a
`LEAN_SKIP_CACHE=true` source build reached **3036/3058** Mathlib targets before
Docker Desktop crashed with a containerd `meta.db: input/output error` / disk-full).
**No error was ever attributable to `GeometricSeriesOQ06OQ02.lean`.**

Every Mathlib dependency was confirmed present by source inspection:
- `hasSum_choose_mul_geometric_of_norm_lt_one` (non-primed, `{r : 𝕜}` normed field, `1/(1-r)^(k+1)`) — `Mathlib/Analysis/SpecificLimits/Normed.lean:468`;
- `HasSummableGeomSeries 𝕜` auto-synthesized from `[NormedField 𝕜]` via the `NormedDivisionRing` instance (`Normed.lean:368`) — geometric `HasSum` holds without completeness (explicit closed form), so **no `[CompleteSpace 𝕜]` is needed**;
- `Nat.descFactorial_eq_factorial_mul_choose`, `Nat.choose_one_right`.

Gallery meta is honestly marked `status: "formalized"` + `verificationPending: true`
(NOT `verified`). **Do not raise to `verified` until a clean compile.**

### To finish
When Docker recovers (`docker ps | grep lean-build` empty):
`LEAN_SKIP_CACHE=true ./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ06OQ02`
(resumes near 3036/3058, cheap). On clean build → flip `meta.status`→`verified`,
drop `verificationPending`, badge→`mathlib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)