### PR TITLE
Enrich Lucas divisibility entry: full section coverage + 5th annotation

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-07-oq-01/annotations.json
@@ -65,10 +65,10 @@
   {
     "id": "ann-fib0701-specializations",
     "proofId": "fibonacci-identities-oq-07-oq-01",
-    "range": { "startLine": 111, "endLine": 146 },
+    "range": { "startLine": 111, "endLine": 133 },
     "type": "technique",
     "title": "Recovering Fibonacci and Pell",
-    "content": "A two-step (consecutive-pair) induction identifies U 1 (−1) n with the Fibonacci number Fₙ (U_one_neg_one), since Uₙ₊₂ = Uₙ₊₁ + Uₙ matches Nat.fib_add_two. Rewriting the general theorem through this identity yields m ∣ n → Fₘ ∣ Fₙ over ℤ (fib_dvd_of_dvd), reproducing Mathlib's Nat.fib_dvd from the Lucas-sequence result; the parameter choice (2,−1) gives the Pell divisibility sequence (pell_dvd_of_dvd). Kernel-decided numeric checks (F₃ = 2 ∣ F₆ = 8, P₂ = 2 ∣ P₆ = 70) pin the statements to concrete values.",
+    "content": "A two-step (consecutive-pair) induction identifies U 1 (−1) n with the Fibonacci number Fₙ (U_one_neg_one), since Uₙ₊₂ = Uₙ₊₁ + Uₙ matches Nat.fib_add_two. Rewriting the general theorem through this identity yields m ∣ n → Fₘ ∣ Fₙ over ℤ (fib_dvd_of_dvd), reproducing Mathlib's Nat.fib_dvd from the Lucas-sequence result; the parameter choice (2,−1) gives the Pell divisibility sequence (pell_dvd_of_dvd).",
     "mathContext": "$U_{1,-1}(n) = F_n$ by two-step induction; specializations at $(1,-1)$ and $(2,-1)$ recover Fibonacci and Pell divisibility.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -81,6 +81,26 @@
       "Nat.fib_add_two",
       "casting ℕ → ℤ",
       "U_dvd_of_dvd"
+    ]
+  },
+  {
+    "id": "ann-fib0701-numeric-checks",
+    "proofId": "fibonacci-identities-oq-07-oq-01",
+    "range": { "startLine": 135, "endLine": 144 },
+    "type": "context",
+    "title": "Kernel-decided sanity checks (axiom-free)",
+    "content": "Three `example ... := by decide` statements close the file by evaluating the abstract results at concrete integers: the convolution U_conv at (P,Q) = (1,−1) with m = 3, n = 4 (giving F₈ = 21 = F₄·F₅ + F₃·F₄ = 3·5 + 2·3), Fibonacci divisibility F₃ = 2 ∣ F₆ = 8, and Pell divisibility P₂ = 2 ∣ P₆ = 70. Crucially these use ordinary `decide`, which forces full evaluation in the trusted kernel, rather than `native_decide` — so they add no `Lean.ofReduceBool` dependency and the entry stays genuinely axiom-free. They serve as an independent cross-check that the algebraic identities were transcribed correctly, catching sign or index slips that a purely symbolic proof could still hide.",
+    "mathContext": "Kernel evaluation of decidable propositions: $U_{1,-1}(8) = 21$ and $U_{1,-1}(4)U_{1,-1}(5) - (-1)U_{1,-1}(3)U_{1,-1}(4) = 15 + 6 = 21$; $F_3 = 2 \\mid F_6 = 8$; $P_2 = 2 \\mid P_6 = 70$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide vs native_decide",
+      "kernel reduction",
+      "axiom-free verification",
+      "concrete sanity check"
+    ],
+    "prerequisites": [
+      "Decidable propositions",
+      "kernel evaluation of Nat/Int arithmetic"
     ]
   }
 ]

--- a/src/data/proofs/fibonacci-identities-oq-07-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-07-oq-01/meta.json
@@ -59,6 +59,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Imports and Reused Lucas Infrastructure",
+      "summary": "Imports Mathlib and the two gallery entries supplying the Lucas-sequence machinery, then opens their namespaces so the fundamental/companion sequences U, V, the recurrence U_add_two, the relation V_eq, and the bilinear law two_U_add are all in scope. No new definitions are introduced — this entry is a pure divisibility layer over existing infrastructure.",
+      "startLine": 1,
+      "endLine": 66,
+      "mathContext": "Brings into scope $U_n(P,Q)$, $V_n(P,Q)$, the recurrence $U_{n+2} = P U_{n+1} - Q U_n$ (`U_add_two`), the companion relation $V_k = 2U_{k+1} - P U_k$ (`V_eq`), and the bilinear addition law $2U_{m+n} = U_m V_n + V_m U_n$ (`two_U_add`) from `LucasSequenceDegree2Identities` and `LucasSequenceDegree2IdentitiesOQ02`."
+    },
+    {
       "id": "convolution",
       "title": "The Factor-of-2-Free Convolution",
       "summary": "U_conv: U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ, derived from the bilinear law two_U_add by eliminating V (via V_eq) and cancelling the factor 2.",
@@ -79,8 +87,16 @@
       "title": "Fibonacci and Pell Corollaries",
       "summary": "U_one_neg_one identifies U 1 (−1) n = Fₙ; fib_dvd_of_dvd and pell_dvd_of_dvd specialize the general divisibility to the Fibonacci and Pell numbers.",
       "startLine": 112,
+      "endLine": 133,
+      "mathContext": "A two-step induction shows $U_{1,-1}(n) = F_n$ (`U_one_neg_one`), since $U_{n+2} = U_{n+1} + U_n$ matches `Nat.fib_add_two`. Rewriting through it turns the general theorem into $m \\mid n \\Rightarrow F_m \\mid F_n$ (`fib_dvd_of_dvd`), while $(P,Q) = (2,-1)$ gives the Pell divisibility sequence (`pell_dvd_of_dvd`)."
+    },
+    {
+      "id": "numeric-checks",
+      "title": "Kernel-Decided Numeric Sanity Checks",
+      "summary": "Three `example ... := by decide` statements pin the abstract results to concrete integers: the convolution U_conv at (1,−1), Fibonacci divisibility F₃ ∣ F₆, and Pell divisibility P₂ ∣ P₆, each closed by kernel decision (no axioms).",
+      "startLine": 135,
       "endLine": 146,
-      "mathContext": "A two-step induction shows $U_{1,-1}(n) = F_n$ (`U_one_neg_one`), since $U_{n+2} = U_{n+1} + U_n$ matches `Nat.fib_add_two`. Rewriting through it turns the general theorem into $m \\mid n \\Rightarrow F_m \\mid F_n$ (`fib_dvd_of_dvd`), while $(P,Q) = (2,-1)$ gives the Pell divisibility sequence (`pell_dvd_of_dvd`). Numeric checks confirm $F_3 = 2 \\mid F_6 = 8$ and $P_2 = 2 \\mid P_6 = 70$."
+      "mathContext": "`decide` evaluates the fully concrete propositions in the kernel: $U_{1,-1}(8) = 21 = 3\\cdot 5 + 2\\cdot 3$, $F_3 = 2 \\mid F_6 = 8$, and $P_2 = 2 \\mid P_6 = 70$. Because these use ordinary `decide` (not `native_decide`), they add no `Lean.ofReduceBool` dependency and the entry remains axiom-free."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-07-oq-01` (Lucas-sequence divisibility m ∣ n ⟹ Uₘ ∣ Uₙ, quality 89, passes 0).

The entry was already strong (rich overview, 3 sections, 4 fully-populated annotations). Two genuine gaps against the role minimums:

1. **Section coverage** — the `sections` array started at line 62, leaving the imports + reused Lucas infrastructure (lines 1–66) uncovered. Added a `setup` section so `sections` now span the full 146-line file.
2. **Annotation count** — only 4 annotations (minimum is 5). The three closing `by decide` numeric checks (lines 135–144) were a distinct, under-covered region, so they now get their own `numeric-checks` section and a 5th annotation (`ann-fib0701-numeric-checks`). The new annotation explains the `decide` vs `native_decide` distinction and why the entry stays genuinely axiom-free (ordinary `decide` adds no `Lean.ofReduceBool`).

Tightened the `specializations` section/annotation to lines 111–133 accordingly.

JSON-only change; both files validated with a JSON parser and all section line ranges lie within the file. meta.json is 12.9 KB (well under the ~60 KB cap). No content deleted; no over-claiming — `status`/`badge`/`axiomCount: 0` are unchanged and consistent with the Lean source (only `decide`, no `native_decide`).

Note: a repo-wide `pnpm build` could not run to completion in this environment due to a disk-full (ENOSPC) condition in an unrelated research-enrichment pre-step and a missing `node_modules`; the JSON was validated directly instead.