### PR TITLE
research(factorial-telescoping-sum-oq-01-oq-01): universal telescoping engine [FORMALIZED, verification-pending]

### DIFF
--- a/proofs/Proofs/TelescopingEngineOQ010101.lean
+++ b/proofs/Proofs/TelescopingEngineOQ010101.lean
@@ -1,0 +1,122 @@
+/-
+  The Universal Telescoping Engine  (generalizing the factorial telescoping sum)
+
+  Source / context: open-question generalization of the gallery entry
+    "Factorial Telescoping Sum:  ∑_{k=1}^{n} k·k! = (n+1)! − 1"
+  (`factorial-telescoping-sum-oq-01`).  That entry proves one concrete telescoping
+  identity by a bespoke induction.  The open question asks:
+
+    Generalize the telescoping engine to
+        ∑_{k} (a_{k+1} − a_k)  =  a_{n+1} − a_1
+    over an arbitrary (commutative) group, and *recover* the factorial identity
+    as the instance a_k = k!.
+
+  Status: VERIFIED target (0 sorries, 0 axioms, no native_decide).
+
+  What this file does:
+    1. States the universal additive telescoping law over *any* abelian group,
+       both over `range n` (a thin wrapper on Mathlib's `Finset.sum_range_sub`)
+       and over the interval `[1,n]` in the exact `a_{n+1} − a_1` shape of the OQ.
+    2. Records the multiplicative dual over any commutative group
+       (telescoping *products* `∏ a_{k+1}/a_k = a_{n+1}/a_1`).
+    3. Recovers the factorial identity `∑_{k=1}^{n} k·k! = (n+1)! − 1` as the
+       single instance `a_k = (k! : ℤ)`, then transfers it back to ℕ so that the
+       recovered statement is *literally* the gallery parent's identity.
+
+  The point is structural: the parent's hand-rolled induction is not special —
+  it is one evaluation of a universal law, with the telescoping cancellation
+  supplied once and for all by the abelian-group engine.
+-/
+
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Tactic
+
+open Finset
+
+namespace TelescopingEngine
+
+/-! ### The universal additive telescoping law (arbitrary abelian group) -/
+
+variable {G : Type*} [AddCommGroup G]
+
+/-- **Telescoping over `range n`.**  In any abelian group,
+    `∑_{i<n} (a(i+1) − a i) = a n − a 0`.
+
+    This is the engine in its cleanest form; it is exactly Mathlib's
+    `Finset.sum_range_sub`, exposed here under a telescoping-specific name. -/
+theorem telescope_range (a : ℕ → G) (n : ℕ) :
+    ∑ i ∈ range n, (a (i + 1) - a i) = a n - a 0 :=
+  Finset.sum_range_sub a n
+
+/-- **Telescoping over the interval `[1,n]`.**  In any abelian group,
+    `∑_{k=1}^{n} (a(k+1) − a k) = a(n+1) − a 1`.
+
+    This is the exact shape asked for by the open question: the lower index is
+    `k = 1` and the collapsed value is `a_{n+1} − a_1`. -/
+theorem telescope_Icc (a : ℕ → G) (n : ℕ) :
+    ∑ k ∈ Icc 1 n, (a (k + 1) - a k) = a (n + 1) - a 1 := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [Finset.sum_Icc_succ_top (by omega : 1 ≤ n + 1), ih]
+      abel
+
+/-! ### The multiplicative dual (arbitrary commutative group) -/
+
+/-- **Telescoping products over `[1,n]`.**  In any commutative group,
+    `∏_{k=1}^{n} (a(k+1) / a k) = a(n+1) / a 1`.
+
+    The multiplicative mirror of `telescope_Icc`; together they show the engine
+    is really a statement about a group operation, not about numbers. -/
+theorem telescope_prod_Icc {H : Type*} [CommGroup H] (a : ℕ → H) (n : ℕ) :
+    ∏ k ∈ Icc 1 n, (a (k + 1) / a k) = a (n + 1) / a 1 := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [Finset.prod_Icc_succ_top (by omega : 1 ≤ n + 1), ih]
+      group
+
+/-! ### Recovering the factorial identity as an instance -/
+
+/-- The factorial difference, over ℤ: `(k+1)! − k! = k·k!`.
+    This is the pointwise cancellation term that makes `a_k = k!` telescope. -/
+theorem factorial_diff (k : ℕ) :
+    ((k + 1)! : ℤ) - (k ! : ℤ) = (k : ℤ) * (k ! : ℤ) := by
+  have : ((k + 1)! : ℤ) = (k + 1 : ℤ) * (k ! : ℤ) := by
+    rw [Nat.factorial_succ]; push_cast; ring
+  rw [this]; ring
+
+/-- **Factorial identity over ℤ, as a telescoping instance.**
+    Setting `a_k = (k! : ℤ)` in `telescope_Icc` gives
+    `∑_{k=1}^{n} k·k! = (n+1)! − 1`. -/
+theorem sum_Icc_mul_factorial_int (n : ℕ) :
+    ∑ k ∈ Icc 1 n, ((k : ℤ) * (k ! : ℤ)) = ((n + 1)! : ℤ) - 1 := by
+  have h := telescope_Icc (fun k => ((k ! : ℤ))) n
+  calc ∑ k ∈ Icc 1 n, ((k : ℤ) * (k ! : ℤ))
+      = ∑ k ∈ Icc 1 n, (((k + 1)! : ℤ) - (k ! : ℤ)) := by
+        refine Finset.sum_congr rfl (fun k _ => ?_)
+        rw [factorial_diff]
+    _ = ((n + 1)! : ℤ) - (1 ! : ℤ) := h
+    _ = ((n + 1)! : ℤ) - 1 := by norm_num
+
+/-- **Recovered gallery identity (over ℕ).**  `∑_{k=1}^{n} k·k! = (n+1)! − 1`.
+
+    This is verbatim the statement of the parent entry
+    `factorial-telescoping-sum-oq-01`, now obtained purely as the `a_k = k!`
+    instance of the universal telescoping engine rather than by a bespoke
+    induction. -/
+theorem sum_Icc_mul_factorial (n : ℕ) :
+    ∑ k ∈ Icc 1 n, k * k ! = (n + 1)! - 1 := by
+  have hz := sum_Icc_mul_factorial_int n
+  have key : ((∑ k ∈ Icc 1 n, k * k ! : ℕ) : ℤ) = ((n + 1)! : ℤ) - 1 := by
+    push_cast
+    exact hz
+  have hpos : 1 ≤ (n + 1)! := Nat.one_le_iff_ne_zero.mpr (Nat.factorial_ne_zero _)
+  omega
+
+-- Sanity checks (small concrete values), matching the parent entry.
+example : ∑ k ∈ Icc 1 4, k * k ! = 119 := by decide   -- 5! − 1 = 119
+example : ∑ k ∈ Icc 1 5, k * k ! = 719 := by decide    -- 6! − 1 = 719
+
+end TelescopingEngine

--- a/proofs/Proofs/TelescopingEngineOQ010101.lean
+++ b/proofs/Proofs/TelescopingEngineOQ010101.lean
@@ -98,7 +98,7 @@ theorem sum_Icc_mul_factorial_int (n : ℕ) :
         refine Finset.sum_congr rfl (fun k _ => ?_)
         rw [factorial_diff]
     _ = ((n + 1)! : ℤ) - (1 ! : ℤ) := h
-    _ = ((n + 1)! : ℤ) - 1 := by norm_num
+    _ = ((n + 1)! : ℤ) - 1 := by simp
 
 /-- **Recovered gallery identity (over ℕ).**  `∑_{k=1}^{n} k·k! = (n+1)! − 1`.
 

--- a/research/problems/factorial-telescoping-sum-oq-01-oq-01/knowledge.md
+++ b/research/problems/factorial-telescoping-sum-oq-01-oq-01/knowledge.md
@@ -1,0 +1,55 @@
+# factorial-telescoping-sum-oq-01-oq-01 — Universal Telescoping Engine
+
+**Open question (from `factorial-telescoping-sum-oq-01`):** Generalize the telescoping
+engine to ∑_{k} (a_{k+1} − a_k) = a_{n+1} − a_1 over a commutative group and recover the
+factorial identity ∑_{k=1}^{n} k·k! = (n+1)! − 1 as the instance a_k = k!.
+
+## Summary
+
+The engine is essentially a Mathlib lemma. `Finset.sum_range_sub` already gives
+∑_{i<n} (f(i+1) − f i) = f n − f 0 over any `AddCommGroup`. The contribution is to
+(a) reshape it to the interval [1,n] in the exact a_{n+1} − a_1 form, (b) record the
+multiplicative dual over a `CommGroup`, and (c) recover the parent's factorial identity as
+the single a_k = (k!:ℤ) instance, transferred back to ℕ. Routine mathematically; the value
+is structural (the parent's bespoke induction is unnecessary).
+
+## Session 2026-07-01 (Session 1) — FRESH — Outcome: progress (draft, UNVERIFIED)
+
+### What I did
+- Wrote `proofs/Proofs/TelescopingEngineOQ010101.lean` (122 lines, 5 theorems, targets 0 axioms):
+  - `telescope_range` = `Finset.sum_range_sub` re-exposed.
+  - `telescope_Icc`: ∑_{k=1}^{n} (a(k+1) − a k) = a(n+1) − a 1 over any AddCommGroup;
+    2-line induction (`sum_Icc_succ_top` + `abel`).
+  - `telescope_prod_Icc`: ∏_{k=1}^{n} a(k+1)/a k = a(n+1)/a 1 over any CommGroup
+    (`prod_Icc_succ_top` + `group`).
+  - `factorial_diff`: (k+1)! − k! = k·k! over ℤ (`Nat.factorial_succ` + ring).
+  - `sum_Icc_mul_factorial_int` (ℤ) and `sum_Icc_mul_factorial` (ℕ, via push_cast + omega):
+    recover ∑_{k=1}^{n} k·k! = (n+1)! − 1 verbatim as the a_k = k! instance.
+- Wrote gallery data `src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/` (meta + 6 annotations),
+  status **formalized** (NOT verified), with an explicit verification-pending caveat annotation.
+- Branch `research/telescoping-engine-oq010101` pushed. NO merge-ready PR (see below).
+
+### Key findings / insights
+- Mathlib **already** has the additive engine as `Finset.sum_range_sub` (AddCommGroup). The OQ's
+  "commutative monoid" is really an abelian **group** — the a_{n+1} − a_1 collapse needs inverses.
+- Cleanest factorial recovery is over **ℤ** (genuine subtraction), then a single push_cast + omega
+  cast back to ℕ (valid since (n+1)! ≥ 1). Avoids all ℕ-truncated-subtraction bookkeeping.
+- Additive and multiplicative telescoping are the same theorem in two notations.
+
+### BLOCKER: verification
+- Build env broken 3 ways at authoring: (1) host `.lake` missing `Aesop.Tree.ExtractProof.olean`
+  (pulled in transitively by `import Mathlib.Tactic`) from a concurrently-interrupted build — only
+  that one olean gone (its `.c` + source present); (2) no `lean-mathlib-cache` docker volume, so
+  docker-build would rebuild all of Mathlib into a full disk → crash; (3) disk at 100% (1.2Gi free).
+- `lake env lean` single-file typecheck (whitelisted, safe) FAILED only at the missing aesop olean,
+  not on my proof. Regenerating that olean by hand needs aesop's exact experimental-module lakefile
+  flags; getting them wrong risks writing a mismatched olean into the SHARED aesop package (poisons
+  all agents) — declined as too risky.
+
+### Next steps
+1. When a clean build window opens (docker cache volume present OR host `.lake` repaired), build
+   `Proofs.TelescopingEngineOQ010101` and `#print axioms` the 5 theorems.
+2. If clean: flip meta/annotations status formalized → verified, badge original, drop the
+   verification-pending caveat, open a normal research PR, mark pool completed.
+3. Watch tactic-robustness spots (unverified): base-case `simp`s for empty Icc, `group` in the
+   multiplicative dual, the calc `:= h` beta-defeq step in `sum_Icc_mul_factorial_int`.

--- a/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-programme",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "From One Instance to the Universal Engine",
+    "content": "The docstring frames the open question: the gallery entry factorial-telescoping-sum-oq-01 proves ∑_{k=1}^{n} k·k! = (n+1)! − 1 by a bespoke induction, but that identity is really one evaluation of a universal law — the telescoping collapse ∑_{k=1}^{n} (a_{k+1} − a_k) = a_{n+1} − a_1, valid over any abelian group. This file states that engine (over arbitrary AddCommGroup, plus a multiplicative dual over CommGroup) and then recovers the factorial identity as the single instance a_k = k!. The message is structural: the cancellation is not special to factorials — it belongs to the group operation.",
+    "mathContext": "$\\sum_{k=1}^{n} (a_{k+1} - a_k) = a_{n+1} - a_1$ over any abelian group; the factorial identity is the case $a_k = k!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping sum",
+      "abelian group",
+      "finite differences",
+      "generalization"
+    ],
+    "prerequisites": [
+      "Finset.sum over range and Icc",
+      "abelian groups"
+    ]
+  },
+  {
+    "id": "ann-additive-law",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": { "startLine": 39, "endLine": 63 },
+    "type": "insight",
+    "title": "The Universal Additive Telescoping Law",
+    "content": "telescope_range is the engine in its purest form: ∑_{i<n} (a(i+1) − a i) = a n − a 0 over any AddCommGroup, and it is literally Mathlib's Finset.sum_range_sub re-exposed under a telescoping name — no induction needed, the cancellation is already a library fact. telescope_Icc reshapes it to the interval [1,n] that practitioners use: ∑_{k=1}^{n} (a(k+1) − a k) = a(n+1) − a 1, exactly the a_{n+1} − a_1 shape of the open question. Its proof is a two-line induction: Finset.sum_Icc_succ_top peels the top summand and abel discharges the abelian-group regrouping (a(n+1) − a 1) + (a(n+2) − a(n+1)) = a(n+2) − a 1.",
+    "mathContext": "$\\sum_{k=1}^{n} (a_{k+1} - a_k) = a_{n+1} - a_1$; step: $(a_{n+1}-a_1) + (a_{n+2}-a_{n+1}) = a_{n+2}-a_1$, closed by $\\texttt{abel}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_range_sub",
+      "Finset.sum_Icc_succ_top",
+      "abel tactic",
+      "AddCommGroup"
+    ],
+    "prerequisites": [
+      "induction over ℕ",
+      "abelian-group arithmetic"
+    ]
+  },
+  {
+    "id": "ann-multiplicative-dual",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": { "startLine": 65, "endLine": 79 },
+    "type": "insight",
+    "title": "The Multiplicative Dual",
+    "content": "telescope_prod_Icc records the same theorem written multiplicatively: ∏_{k=1}^{n} (a(k+1) / a k) = a(n+1) / a 1 over any commutative group. The proof mirrors telescope_Icc exactly — Finset.prod_Icc_succ_top peels the top factor and the group tactic normalizes (a(n+1)/a 1) · (a(n+2)/a(n+1)) = a(n+2)/a 1. Presenting both forms side by side makes the real content visible: telescoping is a fact about a group operation, and the additive and multiplicative statements are one theorem in two notations.",
+    "mathContext": "$\\prod_{k=1}^{n} a_{k+1}/a_k = a_{n+1}/a_1$ over any commutative group; the exact dual of $\\texttt{telescope\\_Icc}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.prod_Icc_succ_top",
+      "group tactic",
+      "CommGroup",
+      "additive-multiplicative duality"
+    ],
+    "prerequisites": [
+      "commutative groups",
+      "finite products"
+    ]
+  },
+  {
+    "id": "ann-factorial-diff",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": { "startLine": 80, "endLine": 91 },
+    "type": "insight",
+    "title": "The Factorial Cancellation Term",
+    "content": "factorial_diff supplies the pointwise term that makes a_k = k! telescope: over ℤ, (k+1)! − k! = k·k!. The proof rewrites (k+1)! = (k+1)·k! via Nat.factorial_succ (pushed through the ℤ cast) and finishes with ring, since (k+1)·k! − k! = k·k!. Working over ℤ rather than ℕ is deliberate — the difference (k+1)! − k! is a genuine subtraction here, so no truncated-subtraction bookkeeping is needed before the telescoping law applies.",
+    "mathContext": "$(k+1)! - k! = (k+1)k! - k! = k\\cdot k!$ over $\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.factorial_succ",
+      "push_cast",
+      "ring tactic",
+      "ℤ vs ℕ subtraction"
+    ],
+    "prerequisites": [
+      "factorial recurrence",
+      "integer arithmetic"
+    ]
+  },
+  {
+    "id": "ann-factorial-recovery",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 117 },
+    "type": "insight",
+    "title": "Recovering the Parent Identity as an Instance",
+    "content": "sum_Icc_mul_factorial_int instantiates telescope_Icc at a_k = (k!:ℤ): each summand becomes (k+1)! − k! = k·k! by factorial_diff, and the boundary collapses to (n+1)! − 1! = (n+1)! − 1, giving ∑_{k=1}^{n} k·k! = (n+1)! − 1 over ℤ. sum_Icc_mul_factorial then transfers this back to ℕ — push_cast moves the ℕ sum into ℤ to match the integer statement, and omega discharges the truncated subtraction using (n+1)! ≥ 1. The result is verbatim the parent entry's identity, now obtained with zero bespoke induction: the whole proof is 'evaluate the universal engine at a_k = k!'.",
+    "mathContext": "$a_k=(k!{:}\\mathbb{Z}) \\Rightarrow \\sum_{k=1}^{n} k\\cdot k! = a_{n+1}-a_1 = (n+1)! - 1$; cast to $\\mathbb{N}$ via push_cast + omega since $(n+1)!\\ge 1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "telescope_Icc instantiation",
+      "push_cast",
+      "omega",
+      "ℕ↔ℤ transfer"
+    ],
+    "prerequisites": [
+      "the telescoping law telescope_Icc",
+      "casting between ℕ and ℤ"
+    ]
+  },
+  {
+    "id": "ann-verification-status",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": { "startLine": 118, "endLine": 122 },
+    "type": "caveat",
+    "title": "Verification Status: Pending",
+    "content": "The two `example` lines are kernel-`decide` sanity checks (∑_{Icc 1 4} k·k! = 119 = 5!−1, ∑_{Icc 1 5} k·k! = 719 = 6!−1). IMPORTANT: at authoring time the file had not been machine-checked. The host build environment was blocked — a dependency olean (Aesop.Tree.ExtractProof, pulled in transitively by import Mathlib.Tactic) was missing from a concurrently-interrupted build, the Mathlib docker cache volume was absent, and the disk was full — so neither a docker build nor a single-file `lake env lean` typecheck could complete. The proof is thin over well-established Mathlib lemmas and standard tactics, so confidence is high, but the entry is marked 'formalized' rather than 'verified' until a clean build confirms 0 sorries / 0 axioms.",
+    "mathContext": "Sanity: $\\sum_{k=1}^{4} k\\cdot k! = 119 = 5!-1$, $\\sum_{k=1}^{5} k\\cdot k! = 719 = 6!-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "decide",
+      "build verification",
+      "axiom auditing"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/meta.json
+++ b/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/meta.json
@@ -1,0 +1,154 @@
+{
+  "id": "factorial-telescoping-sum-oq-01-oq-01",
+  "slug": "factorial-telescoping-sum-oq-01-oq-01",
+  "title": "The Universal Telescoping Engine: ∑ (a_{k+1} − a_k) = a_{n+1} − a_1",
+  "status": "formalized",
+  "badge": "original",
+  "description": "The open-question generalization of the factorial telescoping sum. Instead of proving ∑_{k=1}^{n} k·k! = (n+1)! − 1 by a bespoke induction, this entry states the universal additive telescoping law ∑_{k=1}^{n} (a_{k+1} − a_k) = a_{n+1} − a_1 over an ARBITRARY abelian group (thin wrapper on Mathlib's Finset.sum_range_sub plus an Icc-interval version in the exact a_{n+1} − a_1 shape), records the multiplicative dual ∏ (a_{k+1}/a_k) = a_{n+1}/a_1 over any commutative group, and then recovers the factorial identity as the single instance a_k = (k! : ℤ). The point is structural: the parent's hand-rolled induction is one evaluation of a universal group-theoretic law. 5 theorems, 0 sorries, 0 axioms by design. VERIFICATION PENDING: the Lean file is written and pushed but has not yet been machine-checked (host build environment was blocked by a missing dependency olean and full disk at authoring time).",
+  "overview": {
+    "historicalContext": "Telescoping is the observation that a sum of consecutive differences collapses to its boundary terms: ∑_{k} (a_{k+1} − a_k) = a_{n+1} − a_1. It is one of the oldest summation techniques (Concrete Mathematics, Ch. 2) and underlies the finite-difference calculus, Abel summation, and the factorial number system. The gallery entry factorial-telescoping-sum-oq-01 proves one concrete instance — the factorial identity ∑_{k=1}^{n} k·k! = (n+1)! − 1 — by a dedicated induction; its open question asks for the general engine of which that identity is a mere instance.",
+    "problemStatement": "State and prove the telescoping law ∑_{k=1}^{n} (a_{k+1} − a_k) = a_{n+1} − a_1 over an arbitrary abelian group (and its multiplicative dual over a commutative group), then recover the factorial identity ∑_{k=1}^{n} k·k! = (n+1)! − 1 purely as the a_k = k! instance, transferred back to ℕ so that the recovered statement is verbatim the parent entry's identity.",
+    "proofStrategy": "The range-form engine telescope_range is exactly Mathlib's Finset.sum_range_sub, re-exposed under a telescoping name. The interval form telescope_Icc is a two-line induction: Finset.sum_Icc_succ_top peels the top term and abel discharges the abelian-group cancellation. The multiplicative dual telescope_prod_Icc mirrors this with Finset.prod_Icc_succ_top and the group tactic. To recover the factorial identity, instantiate telescope_Icc at a_k = (k! : ℤ); the pointwise cancellation term is factorial_diff: (k+1)! − k! = k·k! (from the factorial recurrence, over ℤ to avoid truncated subtraction). This gives sum_Icc_mul_factorial_int over ℤ, which is cast back to ℕ (push_cast + omega, valid since (n+1)! ≥ 1) to obtain the parent's exact ℕ statement sum_Icc_mul_factorial.",
+    "keyInsights": [
+      "The factorial identity is not special: it is the a_k = k! evaluation of a universal abelian-group law, with the telescoping cancellation supplied once and for all by abel / Finset.sum_range_sub.",
+      "Working over ℤ (rather than ℕ) makes the instance clean — the pointwise term (k+1)! − k! = k·k! is a genuine subtraction, not a truncated one — and the ℕ statement is then recovered by a single push_cast + omega cast, since (n+1)! ≥ 1.",
+      "The engine is really a statement about a group operation: the additive law over an abelian group and the multiplicative law ∏ a_{k+1}/a_k = a_{n+1}/a_1 over a commutative group are the same theorem written two ways.",
+      "The interval [1,n] form (lower index k = 1, boundary value a_{n+1} − a_1) is the shape practitioners actually use; it follows from the range form by a one-step induction with sum_Icc_succ_top."
+    ],
+    "prerequisites": [
+      "Finite sums/products over Finset.range and Finset.Icc, with sum_range_sub, sum_Icc_succ_top, prod_Icc_succ_top",
+      "Abelian and commutative groups and the abel / group normalization tactics",
+      "The factorial recurrence (k+1)! = (k+1)·k! and ℕ↔ℤ casting (push_cast, omega)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "additive-law",
+      "title": "Section I: The Universal Additive Telescoping Law",
+      "startLine": 39,
+      "endLine": 63,
+      "summary": "telescope_range (= Finset.sum_range_sub) gives ∑_{i<n} (a(i+1) − a i) = a n − a 0 over any abelian group; telescope_Icc gives the interval form ∑_{k=1}^{n} (a(k+1) − a k) = a(n+1) − a 1 in the exact shape of the open question.",
+      "mathContext": "Over any AddCommGroup: ∑_{k=1}^{n} (a_{k+1} − a_k) = a_{n+1} − a_1. The Icc form is a one-step induction via sum_Icc_succ_top closed by abel."
+    },
+    {
+      "id": "multiplicative-dual",
+      "title": "Section II: The Multiplicative Dual",
+      "startLine": 65,
+      "endLine": 79,
+      "summary": "telescope_prod_Icc: ∏_{k=1}^{n} (a(k+1)/a k) = a(n+1)/a 1 over any commutative group — the same theorem written multiplicatively, via prod_Icc_succ_top and the group tactic.",
+      "mathContext": "Over any CommGroup: ∏_{k=1}^{n} a_{k+1}/a_k = a_{n+1}/a_1. Shows the engine is about a group operation, not about numbers."
+    },
+    {
+      "id": "factorial-instance",
+      "title": "Section III: Recovering the Factorial Identity",
+      "startLine": 80,
+      "endLine": 117,
+      "summary": "factorial_diff: (k+1)! − k! = k·k! over ℤ is the cancellation term; instantiating telescope_Icc at a_k = (k!:ℤ) yields sum_Icc_mul_factorial_int over ℤ, cast back to ℕ (push_cast + omega) as sum_Icc_mul_factorial — verbatim the parent identity.",
+      "mathContext": "a_k = (k!:ℤ) ⟹ a_{k+1} − a_k = k·k!, so ∑_{k=1}^{n} k·k! = a_{n+1} − a_1 = (n+1)! − 1! = (n+1)! − 1; recovered in ℕ since (n+1)! ≥ 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 122-line, 5-theorem file that lifts the gallery's factorial telescoping identity to its universal source: the abelian-group law ∑_{k=1}^{n} (a_{k+1} − a_k) = a_{n+1} − a_1 (with a multiplicative dual over commutative groups), from which ∑_{k=1}^{n} k·k! = (n+1)! − 1 falls out as the a_k = k! instance. Targets 0 sorries, 0 axioms, no native_decide. NOTE: verification is pending — the file is authored and pushed but not yet machine-checked because the local build environment was blocked (missing dependency olean, full disk) at authoring time.",
+    "implications": "Reframes an elementary identity as an instance of a reusable engine: telescope_range / telescope_Icc / telescope_prod_Icc are drop-in lemmas for any telescoping sum or product over a group, and the factorial recovery is a template for deriving concrete closed forms by choosing the sequence a_k. The mathematical content is routine (the engine is one Mathlib lemma plus a short induction); the value is the structural demonstration that the parent's bespoke induction was unnecessary.",
+    "openQuestions": [
+      "Recover further classical closed forms as telescope_Icc instances by choosing a_k: e.g. a_k = k² for ∑ (2k−1), a_k = r^k for the geometric sum, or a_k = 1/k for ∑ 1/(k(k+1)).",
+      "Formalize a monoid-level telescoping statement that does not assume inverses (e.g. over an ordered cancellative monoid with a partial subtraction), clarifying exactly how much group structure the a_{n+1} − a_1 collapse requires."
+    ]
+  },
+  "references": [
+    {
+      "key": "ConcreteMath",
+      "citation": "Graham, R.L., Knuth, D.E., Patashnik, O., Concrete Mathematics, 2nd ed., Addison-Wesley (1994), Ch. 2 (sums, telescoping, finite differences).",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "factorial-telescoping-sum-oq-01",
+      "relationship": "generalizes",
+      "description": "The parent entry: this file lifts its factorial identity ∑ k·k! = (n+1)! − 1 to the universal abelian-group telescoping law and recovers it as the a_k = k! instance."
+    },
+    {
+      "targetId": "telescoping-product-oq-01",
+      "relationship": "relatedTo",
+      "description": "A companion telescoping entry on the multiplicative side; telescope_prod_Icc here is the general ∏ a_{k+1}/a_k = a_{n+1}/a_1 law over a commutative group."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.BigOperators.Intervals",
+      "Mathlib.Data.Nat.Factorial.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "TelescopingEngine",
+    "lineCount": 122,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/TelescopingEngineOQ010101.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Telescoping_series",
+    "date": "2026",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/TelescopingEngineOQ010101.lean",
+    "tags": [
+      "algebra",
+      "combinatorics",
+      "telescoping",
+      "finite-sums",
+      "abelian-group",
+      "factorial",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_sub",
+        "description": "∑_{i<n} (f(i+1) − f i) = f n − f 0 over an AddCommGroup — the telescoping engine in range form",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_Icc_succ_top",
+        "description": "a ≤ b+1 → ∑_{k ∈ Icc a (b+1)} f k = (∑_{k ∈ Icc a b} f k) + f (b+1) — peels the top term for the interval induction",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.prod_Icc_succ_top",
+        "description": "a ≤ b+1 → ∏_{k ∈ Icc a (b+1)} f k = (∏_{k ∈ Icc a b} f k) · f (b+1) — multiplicative analogue for the product dual",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Nat.factorial_succ",
+        "description": "(n+1)! = (n+1)·n! — the recurrence giving the factorial cancellation (k+1)! − k! = k·k!",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      }
+    ],
+    "originalContributions": [
+      "telescope_range and telescope_Icc: the universal additive telescoping law over an arbitrary abelian group, the latter in the exact ∑_{k=1}^{n} (a_{k+1} − a_k) = a_{n+1} − a_1 shape of the open question",
+      "telescope_prod_Icc: the multiplicative dual ∏_{k=1}^{n} a_{k+1}/a_k = a_{n+1}/a_1 over any commutative group",
+      "factorial_diff: the pointwise cancellation (k+1)! − k! = k·k! over ℤ",
+      "sum_Icc_mul_factorial_int and sum_Icc_mul_factorial: recovery of the parent's factorial identity ∑_{k=1}^{n} k·k! = (n+1)! − 1 as the a_k = k! instance, over ℤ and then transferred back to ℕ"
+    ],
+    "axiomCount": 0,
+    "lineCount": 122,
+    "assumptions": "Targets 0 axioms, 0 sorries, no native_decide (the two `example` sanity checks use kernel `decide`). VERIFICATION PENDING: the Lean file has not yet been machine-checked. At authoring time the host build environment was blocked — a dependency olean (Aesop.Tree.ExtractProof.olean, needed transitively via import Mathlib.Tactic) was missing from a concurrently-interrupted build, the Mathlib docker cache volume was absent, and the disk was full (1.2Gi free), so neither a docker build nor a single-file `lake env lean` typecheck could complete. The proof is thin over well-established Mathlib lemmas (Finset.sum_range_sub, sum_Icc_succ_top, prod_Icc_succ_top, Nat.factorial_succ) and standard tactics (abel, group, omega, push_cast, simp), so confidence is high, but the status is 'formalized' (not 'verified') until a clean build confirms it.",
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "prerequisites": [
+      "Finite sums/products over Finset.range and Finset.Icc",
+      "Abelian and commutative groups; abel and group tactics",
+      "The factorial recurrence and ℕ↔ℤ casting"
+    ],
+    "relatedProblems": []
+  }
+}


### PR DESCRIPTION
## Summary

Generalizes the gallery entry **factorial-telescoping-sum-oq-01** per its open question: lifts the concrete factorial identity ∑_{k=1}^{n} k·k! = (n+1)! − 1 to the **universal telescoping law** and recovers it as an instance.

- `telescope_range` — ∑_{i<n} (a(i+1) − a i) = a n − a 0 over any `AddCommGroup` (thin re-export of Mathlib's `Finset.sum_range_sub`).
- `telescope_Icc` — ∑_{k=1}^{n} (a(k+1) − a k) = a(n+1) − a 1, the exact `a_{n+1} − a_1` shape of the OQ (2-line induction: `sum_Icc_succ_top` + `abel`).
- `telescope_prod_Icc` — multiplicative dual ∏_{k=1}^{n} a(k+1)/a k = a(n+1)/a 1 over any `CommGroup`.
- `factorial_diff` — (k+1)! − k! = k·k! over ℤ.
- `sum_Icc_mul_factorial_int` / `sum_Icc_mul_factorial` — recover ∑_{k=1}^{n} k·k! = (n+1)! − 1 as the `a_k = k!` instance, over ℤ then transferred to ℕ (`push_cast` + `omega`).

5 theorems, 0 sorries, 0 axioms **by design**. Mathematically routine; the value is structural — the parent's bespoke induction is one evaluation of a group-theoretic law.

## ⚠️ Verification pending — DRAFT

**This proof has NOT been machine-checked.** At authoring time the build environment was blocked three ways: a dependency olean (`Aesop.Tree.ExtractProof`, pulled in via `import Mathlib.Tactic`) was missing from a concurrently-interrupted build; no Mathlib docker cache volume existed; and the disk was full (1.2Gi free). A single-file `lake env lean` typecheck failed only at the missing aesop olean, not on the proof itself.

Gallery status is set to **`formalized`** (not `verified`), with an explicit verification-pending caveat annotation. **Do not merge as verified** until a clean build confirms 0 sorries / 0 axioms and `#print axioms` is inspected. Kept as a draft for that reason.

Branch: `research/telescoping-engine-oq010101`