### PR TITLE
Enrich Jordan–Hölder for modules: dedicate annotation to symmetry theorem

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-02/annotations.json
@@ -47,11 +47,11 @@
     "proofId": "abel-ruffini-galois-extensions-oq-04-oq-02",
     "range": {
       "startLine": 64,
-      "endLine": 80
+      "endLine": 71
     },
     "type": "theorem",
     "title": "The Composition-Factor Bijection",
-    "content": "exists_factor_bijection unfolds the Equivalent predicate into its concrete data: a bijection f : Fin s₁.length ≃ Fin s₂.length together with, for each index i, a JordanHolderLattice isomorphism between the i-th factor of s₁ and the f(i)-th factor of s₂. Under the Submodule instance this Iso is a linear equivalence of the successive quotients, so the multiset of composition factors is permutation-invariant. jordanHolder_module_symm records that the equivalence is symmetric.",
+    "content": "exists_factor_bijection unfolds the Equivalent predicate into its concrete data: a bijection f : Fin s₁.length ≃ Fin s₂.length together with, for each index i, a JordanHolderLattice isomorphism between the i-th factor of s₁ and the f(i)-th factor of s₂. Under the Submodule instance this Iso is a linear equivalence of the successive quotients, so the multiset of composition factors is permutation-invariant. The bijection is what upgrades bare length equality to the full Jordan–Hölder statement — 'same factors up to reordering', the module analogue of the group composition-factor multiset.",
     "mathContext": "$\\mathrm{Equivalent}(s_1,s_2) = \\exists f: \\mathrm{Fin}\\,s_1.\\mathrm{length} \\simeq \\mathrm{Fin}\\,s_2.\\mathrm{length},\\ \\forall i,\\ \\mathrm{Iso}\\,(s_1\\,i, s_1\\,i^+)\\,(s_2\\,(f i), s_2\\,(f i)^+).$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -61,6 +61,27 @@
     ],
     "prerequisites": [
       "CompositionSeries.Equivalent"
+    ]
+  },
+  {
+    "id": "ann-jordanholder-symm",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-02",
+    "range": {
+      "startLine": 73,
+      "endLine": 78
+    },
+    "type": "theorem",
+    "title": "Symmetry of the Equivalence",
+    "content": "jordanHolder_module_symm records that the Jordan–Hölder equivalence of composition series is symmetric: if s₁ is equivalent to s₂ then s₂ is equivalent to s₁, inherited from CompositionSeries.Equivalent.symm on the abstract theory. Combined with the reflexivity and transitivity of Equivalent, this makes 'has the same composition factors as' an equivalence relation on composition series with fixed endpoints, so the factor data is a genuine invariant of M rather than of a chosen series.",
+    "mathContext": "$s_1 \\sim s_2 \\Rightarrow s_2 \\sim s_1$; together with reflexivity and transitivity, $\\sim$ is an equivalence relation on the composition series of $M$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "equivalence relation",
+      "symmetry",
+      "composition factors"
+    ],
+    "prerequisites": [
+      "CompositionSeries.Equivalent.symm"
     ]
   },
   {


### PR DESCRIPTION
## Enrichment: abel-ruffini-galois-extensions-oq-04-oq-02

Target claimed via enricher tracker (quality 43, passes 0). The entry was already content-rich (full overview, 4 sections, cross-refs), but one substantive theorem — `jordanHolder_module_symm` — had **no dedicated annotation**: it was buried as a trailing sentence in the factor-bijection note and invisible in the gallery.

### Change
- **Split** the factor-bijection annotation (previously L64–80, spanning two theorems) so it now covers only `exists_factor_bijection` (L64–71).
- **Added** `ann-jordanholder-symm` (L73–78) for `jordanHolder_module_symm`, explaining that symmetry + reflexivity + transitivity make composition-series equivalence a genuine equivalence relation, so the composition-factor data is an invariant of M.
- Tightened the factor-bijection content to foreground the 'same factors up to reordering' reading.

**Result:** 5 → 6 annotations, one per substantive theorem; no range overlaps or gaps. Metadata-only change (annotations.json); JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)