### PR TITLE
Enrich Even Unit-Ball Stirling Asymptotic: fix ancestor cross-reference + add siblings

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -112,9 +112,19 @@
   ],
   "crossReferences": [
     {
-      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01",
       "relationship": "extends",
-      "description": "Sharpens the ancestor's ω_n → 0 to the exact even-subsequence decay rate ω_{2k} ~ (πe/k)^k/√(2πk), and re-derives its infrastructure in a form that compiles under Mathlib v4.26."
+      "description": "The direct ancestor: it establishes only that ω_n → 0 (via ω_{2k} = π^k/k! → 0 and the odd bound ω_{2k+1} ≤ 2·ω_{2k}). This entry sharpens that qualitative statement to the exact even-subsequence decay rate ω_{2k} ~ (πe/k)^k/√(2πk)."
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Supplies the dimension recurrence ω_{n+2} = (2π/(n+2))·ω_n. This entry re-derives that recurrence in a drift-corrected form that compiles under Mathlib v4.26; the recurrence is the engine behind the exact even closed form ω_{2k} = π^k/k! that powers the asymptotic."
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The complementary finite-dimensional result: ω_n attains its global maximum at n = 5 (turning point n+2 = 2π). Together the two entries bracket the growth-then-decay profile of ω_n — this entry pins the large-n tail addressed by open question 3."
     },
     {
       "targetId": "area-of-circle",


### PR DESCRIPTION
## Enrichment pass: `area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02`

This entry (The Exact Stirling Asymptotic of the Even Unit-Ball Volumes) was already richly annotated (7 annotations, full overview/conclusion). The one genuine defect was in its cross-references.

### The bug
The entry's ID ends `…-oq-01-oq-01-oq-01-oq-02`, so its **direct parent** (drop the trailing `-oq-02`) is `area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01` = **"Unit n-Ball Volumes Tend to Zero: ω_n → 0"** — the exact result this entry sharpens. But the existing `"extends"` cross-reference instead pointed to the **grandparent** recurrence entry (`…-oq-01-oq-01`) while its description talked about "ω_n → 0". So the true ancestor was unlinked and the label was misattributed.

### Changes
- **Retargeted** the `"extends"` link to the true direct parent `…-oq-01-oq-01-oq-01` (ω_n → 0).
- **Re-linked** the recurrence entry `…-oq-01-oq-01` as `"related"`, accurately described as the source of the dimension recurrence `ω_{n+2} = (2π/(n+2))·ω_n` that this entry re-derives.
- **Added** the complementary "n=5 maximizes ω_n" sibling `…-oq-01-oq-01-oq-02`; together they bracket the growth-then-decay profile referenced in open question 3.

### Verification
- All 4 cross-reference targets confirmed to exist on disk.
- `meta.json` is valid JSON, 12.7 KB (well under the 60 KB cap; 4 crossReferences ≤ 20 cap).
- The gallery data-enrichment build step processed the entry without error. (The `tsc` app-typecheck step is unrunnable in this worktree — `node_modules` is not installed here — and is unrelated to this pure-JSON change.)