### PR TITLE
Enrich Even Unit-Ball Volume asymptotic: link parent ω_n→0 and n=5 maximizer

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -117,6 +117,16 @@
       "description": "Sharpens the ancestor's ω_n → 0 to the exact even-subsequence decay rate ω_{2k} ~ (πe/k)^k/√(2πk), and re-derives its infrastructure in a form that compiles under Mathlib v4.26."
     },
     {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The direct-parent qualitative result 'Unit n-Ball Volumes Tend to Zero: ω_n → 0', proved from the two-step recurrence with a geometric decay bound. This entry sharpens that mere convergence-to-zero into the exact even-subsequence rate ω_{2k} ~ (πe/k)^k/√(2πk) via Stirling."
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "'n=5 Maximizes Unit Ball Volume' — resolves this entry's third open question (which dimension maximizes ω_{2k}): the sequence increases to ω_5 = 8π²/15 then strictly decreases, with the turning point at n+2 = 2π. Complements the asymptotic tail here with the exact location of the peak."
+    },
+    {
       "targetId": "area-of-circle",
       "relationship": "related",
       "description": "Part of the area-of-circle / ball-volume lineage: the n-dimensional generalization of the circle-area computation, here analyzed asymptotically in high dimension."


### PR DESCRIPTION
## Enrichment pass — area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02 (passes: 0, quality: 91)

'The Exact Stirling Asymptotic of the Even Unit-Ball Volumes' is already richly curated (meta ~12 KB under cap, all 147 lines annotated, thorough overview/conclusion). The genuine gap was **gallery navigation** in `crossReferences` (was 2 → now 4):

- **area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01** (`extends`) — the *direct parent* 'Unit n-Ball Volumes Tend to Zero: ω_n → 0', i.e. the exact qualitative result this entry sharpens to a precise rate. It was previously uncross-referenced: the existing `extends` link points at the *grandparent* (Recursive Computation infrastructure), so the result actually being sharpened wasn't linked.
- **area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02** (`related`) — 'n=5 Maximizes Unit Ball Volume', which **resolves this entry's own third open question** (the dimension maximizing ω_{2k}, peak at n≈5).

Both targets verified present on `origin/main`; descriptions checked against their meta. No Lean-source, claim, or status changes. Only `meta.json` touched (+10 lines); build churn discarded.