### PR TITLE
research(chebyshev-bounds-oq-03-oq-02): ψ−θ=O(√x), removing the log factor [VERIFIED, 0-axiom, new entry, 4thm/157L]

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ03OQ02.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ03OQ02.lean
@@ -1,0 +1,158 @@
+import Mathlib.NumberTheory.Chebyshev
+import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
+import Mathlib.Tactic
+
+/-
+# Chebyshev bounds OQ-03 → OQ-02: the prime-power correction is `O(√x)`
+
+The parent entry (`chebyshev-bounds-oq-03`) shows the second Chebyshev function
+`ψ(x) = Σ_{pᵏ ≤ x} log p` is asymptotically equivalent to the first,
+`θ(x) = Σ_{p ≤ x} log p`, using Mathlib's estimate
+
+  `|ψ(x) − θ(x)| ≤ 2·√x·log x`   (`Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log`).
+
+That bound carries a spurious `log x` factor; indeed Mathlib annotates the lemma with
+"*a more careful argument could remove the `log x` in the following with a worse constant.*"
+This file carries out that careful argument, answering the parent's second open question:
+
+  **`ψ(x) − θ(x) = O(√x)`**   (no `log` factor).
+
+## Proof architecture (elementary prime-power count)
+
+Mathlib's `Chebyshev.psi_eq_theta_add_sum_theta` gives, for `x ≥ 2`,
+
+  `ψ(x) − θ(x) = Σ_{n = 2}^{K} θ(x^{1/n})`,     `K = ⌊log x / log 2⌋`.
+
+The naive bound `θ(x^{1/n}) ≤ log 4 · x^{1/n} ≤ log 4 · √x` for every `n ≥ 2`, summed over
+the `≈ log x / log 2` terms, reproduces the `√x·log x` estimate.  The `log` factor is removed
+by splitting off the single dominant term `n = 2`:
+
+* **`n = 2`.**  `θ(√x) ≤ log 4 · √x`  (`Chebyshev.theta_le_log4_mul_x`).
+* **`n ≥ 3`.**  Here `x^{1/n} ≤ x^{1/3}`, so each term is `≤ log 4 · x^{1/3}`, and there are
+  at most `K ≤ log x / log 2` of them.  Their total is
+  `≤ (log 4 / log 2) · (log x · x^{1/3})`.  The elementary decay bound
+  `log x ≤ 6 · x^{1/6}`  (`Real.log_le_rpow_div` at `ε = 1/6`) turns `log x · x^{1/3}` into
+  `6 · x^{1/2} = 6·√x`, and `log 4 / log 2 = 2`, so the whole tail is `≤ 12·√x`.
+
+Adding the two pieces gives `ψ(x) − θ(x) ≤ (log 4 + 12)·√x`, an explicit `O(√x)` bound.
+The `log`-free error term is exactly what distinguishes the second Chebyshev function's
+prime-power correction from the trivial `√x·log x` estimate.
+
+## Main results
+
+* `psi_sub_theta_le_const_mul_sqrt` : `ψ(x) − θ(x) ≤ (log 4 + 12)·√x` for `x ≥ 2`.
+* `psi_sub_theta_isBigO_sqrt` : `(ψ − θ) =O[atTop] √`  — the `O(√x)` statement itself.
+-/
+
+namespace ChebyshevBoundsOQ03OQ02
+
+open Filter Asymptotics Finset
+open Chebyshev
+open scoped Topology
+
+/-- Elementary decay bound `log x ≤ 6·x^{1/6}` for `x > 0`, the special case of
+`Real.log_le_rpow_div` at exponent `1/6` that turns `log x · x^{1/3}` into `6·√x`. -/
+theorem log_le_six_mul_rpow {x : ℝ} (hx : 0 < x) :
+    Real.log x ≤ 6 * x ^ ((1 : ℝ) / 6) := by
+  have h := Real.log_le_rpow_div hx.le (by norm_num : (0 : ℝ) < 1 / 6)
+  rw [div_div_eq_mul_div, one_mul] at h  -- x ^ (1/6) / (1/6)
+  simpa using h
+
+/-- `log x · x^{1/3} ≤ 6·√x` for `x > 0`: the key `log`-eating step. -/
+theorem logx_mul_rpow_third_le {x : ℝ} (hx : 0 < x) :
+    Real.log x * x ^ ((1 : ℝ) / 3) ≤ 6 * Real.sqrt x := by
+  have h13 : (0 : ℝ) ≤ x ^ ((1 : ℝ) / 3) := Real.rpow_nonneg hx.le _
+  calc
+    Real.log x * x ^ ((1 : ℝ) / 3)
+        ≤ (6 * x ^ ((1 : ℝ) / 6)) * x ^ ((1 : ℝ) / 3) :=
+          mul_le_mul_of_nonneg_right (log_le_six_mul_rpow hx) h13
+    _ = 6 * (x ^ ((1 : ℝ) / 6) * x ^ ((1 : ℝ) / 3)) := by ring
+    _ = 6 * x ^ ((1 : ℝ) / 6 + (1 : ℝ) / 3) := by rw [← Real.rpow_add hx]
+    _ = 6 * x ^ ((1 : ℝ) / 2) := by norm_num
+    _ = 6 * Real.sqrt x := by rw [Real.sqrt_eq_rpow]
+
+/-- **The prime-power correction is `O(√x)` with an explicit constant.**
+For `x ≥ 2`, `ψ(x) − θ(x) ≤ (log 4 + 12)·√x`. -/
+theorem psi_sub_theta_le_const_mul_sqrt {x : ℝ} (hx : 2 ≤ x) :
+    ψ x - θ x ≤ (Real.log 4 + 12) * Real.sqrt x := by
+  have hx0 : (0 : ℝ) < x := by linarith
+  have hx1 : (1 : ℝ) ≤ x := by linarith
+  have hsx : (0 : ℝ) ≤ Real.sqrt x := Real.sqrt_nonneg x
+  have hlog4 : (0 : ℝ) ≤ Real.log 4 := Real.log_nonneg (by norm_num)
+  set K : ℕ := ⌊Real.log x / Real.log 2⌋₊ with hKdef
+  -- ψ x - θ x = Σ_{n = 2}^{K} θ (x ^ (1/n))
+  rw [psi_eq_theta_add_sum_theta hx, add_sub_cancel_left]
+  rcases Nat.lt_or_ge K 2 with hK | hK
+  · -- K < 2 : the sum is empty
+    rw [Finset.Icc_eq_empty (by omega : ¬ 2 ≤ K), Finset.sum_empty]
+    positivity
+  · -- 2 ≤ K : peel off the dominant n = 2 term
+    have h2mem : (2 : ℕ) ∈ Finset.Icc 2 K := by rw [Finset.mem_Icc]; omega
+    rw [← Finset.add_sum_erase _ (fun n => θ (x ^ ((1 : ℝ) / (n : ℝ)))) h2mem,
+      Finset.Icc_erase_left]
+    -- goal: θ (x ^ (1/2)) + Σ_{n ∈ Ioc 2 K} θ (x ^ (1/n)) ≤ (log 4 + 12) √x
+    -- bound the n = 2 term: θ(√x) ≤ log 4 · √x
+    have hn2 : θ (x ^ ((1 : ℝ) / ((2 : ℕ) : ℝ))) ≤ Real.log 4 * Real.sqrt x := by
+      have e2 : x ^ ((1 : ℝ) / ((2 : ℕ) : ℝ)) = Real.sqrt x := by
+        rw [Real.sqrt_eq_rpow]; norm_num
+      rw [e2]
+      exact theta_le_log4_mul_x hsx
+    -- bound the tail n ≥ 3 by 12·√x
+    have htail : ∑ n ∈ Finset.Ioc 2 K, θ (x ^ ((1 : ℝ) / (n : ℝ))) ≤ 12 * Real.sqrt x := by
+      -- each term ≤ log 4 · x^{1/3}
+      have hterm : ∀ n ∈ Finset.Ioc 2 K,
+          θ (x ^ ((1 : ℝ) / (n : ℝ))) ≤ Real.log 4 * x ^ ((1 : ℝ) / 3) := by
+        intro n hn
+        rw [Finset.mem_Ioc] at hn
+        have hn3 : (3 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn.1
+        calc θ (x ^ ((1 : ℝ) / (n : ℝ)))
+            ≤ Real.log 4 * x ^ ((1 : ℝ) / (n : ℝ)) :=
+              theta_le_log4_mul_x (Real.rpow_nonneg hx0.le _)
+          _ ≤ Real.log 4 * x ^ ((1 : ℝ) / 3) := by
+              apply mul_le_mul_of_nonneg_left _ hlog4
+              apply Real.rpow_le_rpow_of_exponent_le hx1
+              apply one_div_le_one_div_of_le (by norm_num) hn3
+      calc ∑ n ∈ Finset.Ioc 2 K, θ (x ^ ((1 : ℝ) / (n : ℝ)))
+          ≤ ∑ _n ∈ Finset.Ioc 2 K, Real.log 4 * x ^ ((1 : ℝ) / 3) :=
+            Finset.sum_le_sum hterm
+        _ = (K - 2 : ℕ) * (Real.log 4 * x ^ ((1 : ℝ) / 3)) := by
+            rw [Finset.sum_const, Nat.card_Ioc, nsmul_eq_mul]
+        _ ≤ (Real.log x / Real.log 2) * (Real.log 4 * x ^ ((1 : ℝ) / 3)) := by
+            apply mul_le_mul_of_nonneg_right _
+              (mul_nonneg hlog4 (Real.rpow_nonneg hx0.le _))
+            -- (K - 2 : ℕ) ≤ K ≤ log x / log 2
+            have hKle : (K : ℝ) ≤ Real.log x / Real.log 2 :=
+              Nat.floor_le (by positivity)
+            have : ((K - 2 : ℕ) : ℝ) ≤ (K : ℝ) := by
+              exact_mod_cast Nat.sub_le K 2
+            linarith
+        _ = (Real.log 4 / Real.log 2) * (Real.log x * x ^ ((1 : ℝ) / 3)) := by ring
+        _ = 2 * (Real.log x * x ^ ((1 : ℝ) / 3)) := by
+            rw [show (4 : ℝ) = 2 ^ 2 by norm_num, Real.log_pow]
+            have hl2 : Real.log 2 ≠ 0 := by
+              have : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+              linarith
+            field_simp
+            ring
+        _ ≤ 2 * (6 * Real.sqrt x) := by
+            apply mul_le_mul_of_nonneg_left (logx_mul_rpow_third_le hx0) (by norm_num)
+        _ = 12 * Real.sqrt x := by ring
+    -- combine the two pieces
+    calc θ (x ^ ((1 : ℝ) / ((2 : ℕ) : ℝ))) + ∑ n ∈ Finset.Ioc 2 K, θ (x ^ ((1 : ℝ) / (n : ℝ)))
+        ≤ Real.log 4 * Real.sqrt x + 12 * Real.sqrt x := by
+          exact add_le_add hn2 htail
+      _ = (Real.log 4 + 12) * Real.sqrt x := by ring
+
+/-- **`ψ − θ = O(√x)`.**  The prime-power correction to the second Chebyshev function is
+`O(√x)` — no `log` factor, sharpening Mathlib's `|ψ − θ| ≤ 2√x·log x`. -/
+theorem psi_sub_theta_isBigO_sqrt :
+    (fun x => ψ x - θ x) =O[atTop] fun x => Real.sqrt x := by
+  rw [Asymptotics.isBigO_iff]
+  refine ⟨Real.log 4 + 12, ?_⟩
+  filter_upwards [Filter.eventually_ge_atTop (2 : ℝ)] with x hx
+  have hnn : 0 ≤ ψ x - θ x := by have := theta_le_psi x; linarith
+  rw [Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg hnn,
+    abs_of_nonneg (Real.sqrt_nonneg x)]
+  exact psi_sub_theta_le_const_mul_sqrt hx
+
+end ChebyshevBoundsOQ03OQ02

--- a/src/data/proofs/chebyshev-bounds-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-03-oq-02/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-cb030202-overview",
+    "proofId": "chebyshev-bounds-oq-03-oq-02",
+    "range": {
+      "startLine": 5,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "Removing the log Factor from ψ − θ",
+    "content": "The two Chebyshev functions θ(x) = Σ_{p≤x} log p and ψ(x) = Σ_{p^k≤x} log p differ only by proper prime powers p^k (k ≥ 2). Mathlib proves the crude estimate |ψ(x) − θ(x)| ≤ 2√x·log x and its source explicitly notes that 'a more careful argument could remove the log x … with a worse constant.' This file carries out that argument, proving ψ(x) − θ(x) = O(√x). The gain is genuine: the log factor is a bookkeeping artefact of bounding all ≈ log x/log 2 terms of the decomposition ψ − θ = Σ_{n≥2} θ(x^{1/n}) by the single dominant term θ(√x).",
+    "mathContext": "$\\psi(x)-\\theta(x)=\\sum_{k\\ge 2}\\theta\\!\\left(x^{1/k}\\right)=O(\\sqrt{x})$, sharpening $|\\psi-\\theta|\\le 2\\sqrt{x}\\log x$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Chebyshev functions θ and ψ",
+      "prime powers",
+      "big-O asymptotics",
+      "power-savings error terms"
+    ],
+    "prerequisites": [
+      "Chebyshev's prime-sum functions",
+      "the parent ψ ∼ θ result",
+      "big-O notation"
+    ]
+  },
+  {
+    "id": "ann-cb030202-decay",
+    "proofId": "chebyshev-bounds-oq-03-oq-02",
+    "range": {
+      "startLine": 53,
+      "endLine": 74
+    },
+    "type": "technique",
+    "title": "The log-Eating Decay Bound log x · x^{1/3} ≤ 6√x",
+    "content": "The only analytic input is that the logarithm grows slower than any positive power. log_le_six_mul_rpow specializes Mathlib's Real.log_le_rpow_div at ε = 1/6 to get log x ≤ 6·x^{1/6}. Multiplying by x^{1/3} and using the exponent law x^{1/6}·x^{1/3} = x^{1/6+1/3} = x^{1/2} = √x gives logx_mul_rpow_third_le: log x · x^{1/3} ≤ 6√x. This is exactly what converts the tail's leftover log factor (times the x^{1/3}-sized terms) into a clean multiple of √x — the crux of removing the log.",
+    "mathContext": "$\\log x\\le 6\\,x^{1/6}\\ \\Rightarrow\\ \\log x\\cdot x^{1/3}\\le 6\\,x^{1/6+1/3}=6\\,x^{1/2}=6\\sqrt{x}.$",
+    "significance": "central",
+    "relatedConcepts": [
+      "Real.log_le_rpow_div",
+      "real power functions rpow",
+      "exponent addition law",
+      "logarithmic growth"
+    ],
+    "prerequisites": [
+      "log = O(x^ε) for ε > 0",
+      "properties of x^t for real t"
+    ]
+  },
+  {
+    "id": "ann-cb030202-peel",
+    "proofId": "chebyshev-bounds-oq-03-oq-02",
+    "range": {
+      "startLine": 76,
+      "endLine": 145
+    },
+    "type": "technique",
+    "title": "Peeling the Dominant n = 2 Term",
+    "content": "From Mathlib's ψ(x) = θ(x) + Σ_{n=2}^{K} θ(x^{1/n}) (K = ⌊log x/log 2⌋), the difference is the sum over Icc 2 K. The proof splits it with Finset.add_sum_erase and Finset.Icc_erase_left: the n = 2 term is θ(x^{1/2}) = θ(√x) ≤ log 4·√x by Chebyshev's linear bound θ(y) ≤ log 4·y. The tail (Ioc 2 K, i.e. n ≥ 3) has each term θ(x^{1/n}) ≤ log 4·x^{1/n} ≤ log 4·x^{1/3} (since 1/n ≤ 1/3 and x ≥ 1), and at most K ≤ log x/log 2 of them; using log 4/log 2 = 2 and the decay lemma, the tail is ≤ 12√x. The whole correction is thus ≤ (log 4 + 12)√x. The empty-sum case K < 2 (x < 4) is handled by positivity.",
+    "mathContext": "$\\psi-\\theta=\\theta(\\sqrt x)+\\!\\!\\sum_{n=3}^{K}\\!\\theta\\!\\left(x^{1/n}\\right)\\le \\log 4\\,\\sqrt x + 12\\sqrt x=(\\log 4+12)\\sqrt x.$",
+    "significance": "central",
+    "relatedConcepts": [
+      "Chebyshev.psi_eq_theta_add_sum_theta",
+      "Finset.add_sum_erase",
+      "Chebyshev.theta_le_log4_mul_x",
+      "rpow monotonicity in the exponent"
+    ],
+    "prerequisites": [
+      "the ψ = θ + Σθ decomposition",
+      "Finset sum manipulation",
+      "monotonicity of x^t in t for x ≥ 1"
+    ]
+  },
+  {
+    "id": "ann-cb030202-bigo",
+    "proofId": "chebyshev-bounds-oq-03-oq-02",
+    "range": {
+      "startLine": 147,
+      "endLine": 155
+    },
+    "type": "concept",
+    "title": "Packaging as (ψ − θ) = O(√x)",
+    "content": "The explicit bound ψ(x) − θ(x) ≤ (log 4 + 12)√x for x ≥ 2, combined with θ(x) ≤ ψ(x) (so ψ − θ ≥ 0), yields the two-sided estimate |ψ(x) − θ(x)| ≤ (log 4 + 12)|√x| eventually, which is exactly the Asymptotics.IsBigO statement (ψ − θ) =O[atTop] √. This is the headline result, and its shape — a big-O with a concrete witness constant — makes it directly reusable wherever the O(√x·log x) estimate previously forced a spurious log.",
+    "mathContext": "$(\\psi-\\theta)=O(\\sqrt{x})$ with witness constant $\\log 4+12\\approx 13.4$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Asymptotics.IsBigO",
+      "Chebyshev.theta_le_psi",
+      "eventual bounds atTop"
+    ],
+    "prerequisites": [
+      "big-O via isBigO_iff",
+      "nonnegativity of ψ − θ"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-bounds-oq-03-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-03-oq-02/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "chebyshev-bounds-oq-03-oq-02",
+  "title": "The Prime-Power Correction Is O(√x): Removing the log Factor from ψ − θ",
+  "slug": "chebyshev-bounds-oq-03-oq-02",
+  "description": "The parent (chebyshev-bounds-oq-03) proves ψ ∼ θ using Mathlib's estimate |ψ(x) − θ(x)| ≤ 2√x·log x, and asks (OQ-02) for the sharper bound ψ(x) − θ(x) = O(√x) without the log factor. Mathlib itself annotates its lemma 'a more careful argument could remove the log x … with a worse constant.' This entry carries out that argument: from the decomposition ψ(x) − θ(x) = Σ_{n=2}^{⌊log x/log 2⌋} θ(x^{1/n}), splitting off the dominant n = 2 term θ(√x) ≤ log 4·√x and bounding the n ≥ 3 tail via log x ≤ 6·x^{1/6} gives ψ(x) − θ(x) ≤ (log 4 + 12)·√x, an explicit O(√x) bound. All 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevBoundsOQ03OQ02.lean",
+    "tags": [
+      "analytic-number-theory",
+      "prime-counting",
+      "chebyshev",
+      "asymptotics",
+      "prime-number-theorem",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Chebyshev.psi_eq_theta_add_sum_theta",
+        "description": "ψ(x) = θ(x) + Σ_{n=2}^{⌊log x/log 2⌋} θ(x^{1/n}), the prime-power decomposition of ψ into shrinking θ-values",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Chebyshev.theta_le_log4_mul_x",
+        "description": "θ(x) ≤ log 4 · x, Chebyshev's linear upper bound on the first Chebyshev function",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Chebyshev.theta_le_psi",
+        "description": "θ(x) ≤ ψ(x), so ψ − θ ≥ 0 and the O(√x) bound gives an absolute-value estimate",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Real.log_le_rpow_div",
+        "description": "log x ≤ x^ε/ε for ε > 0; at ε = 1/6 gives log x ≤ 6·x^{1/6}, the log-eating decay bound",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow_of_exponent_le",
+        "description": "x^y ≤ x^z for 1 ≤ x, y ≤ z; gives x^{1/n} ≤ x^{1/3} for n ≥ 3, collapsing the tail terms",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Finset.add_sum_erase / Finset.Icc_erase_left",
+        "description": "Peels the dominant n = 2 term off Σ_{Icc 2 K}, leaving the n ≥ 3 tail Σ_{Ioc 2 K}",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "log_le_six_mul_rpow: log x ≤ 6·x^{1/6} for x > 0, the ε = 1/6 specialization of Real.log_le_rpow_div packaged for the tail bound",
+      "logx_mul_rpow_third_le: log x · x^{1/3} ≤ 6·√x, the key step turning the tail's log-factor into a bare √x via x^{1/6}·x^{1/3} = x^{1/2}",
+      "psi_sub_theta_le_const_mul_sqrt: ψ(x) − θ(x) ≤ (log 4 + 12)·√x for x ≥ 2 — the explicit-constant O(√x) bound, proved by splitting off the n = 2 term and collapsing the n ≥ 3 tail",
+      "psi_sub_theta_isBigO_sqrt: (ψ − θ) =O[atTop] √ — the O(√x) statement itself, sharpening Mathlib's O(√x·log x)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 157,
+    "assumptions": "None. All theorems fully proved with 0 axioms and 0 sorries (no native_decide); only the standard [propext, Classical.choice, Quot.sound] are used. The bound is stated with an explicit (non-optimal) constant log 4 + 12 ≈ 13.4; sharpening the constant is not attempted. SCOPE: this bounds only the prime-power correction ψ − θ; it does not address the size of ψ or θ individually or the transfer to π(x).",
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "prerequisites": [
+      "Chebyshev functions ψ (von Mangoldt sum) and θ (prime log sum)",
+      "The decomposition of ψ into shrinking θ-values over dyadic index ranges",
+      "Real power functions x^{1/n} and the decay bound log x = O(x^ε)",
+      "Big-O asymptotics"
+    ],
+    "relatedProblems": [
+      {
+        "id": "chebyshev-bounds-oq-03",
+        "relationship": "Parent: proves ψ ∼ θ using Mathlib's O(√x·log x) estimate and lists as OQ-02 the sharper O(√x) bound proved here."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The two Chebyshev functions θ(x) = Σ_{p ≤ x} log p and ψ(x) = Σ_{p^k ≤ x} log p = Σ_{n ≤ x} Λ(n) differ only by the contribution of proper prime powers p^k with k ≥ 2. That difference is small, and quantifying exactly how small is a classical exercise: ψ(x) − θ(x) = Σ_{k ≥ 2} θ(x^{1/k}), a sum whose leading term is θ(√x) ≈ √x and whose remaining terms are much smaller. The crude estimate |ψ(x) − θ(x)| ≤ 2√x·log x — which is what Mathlib proves and what the parent entry uses for ψ ∼ θ — overcounts by bounding every one of the ≈ log x/log 2 terms by θ(√x) and multiplying by the number of terms. Mathlib's own source flags this: 'a more careful argument could remove the log x in the following with a worse constant.' The sharper truth, standard in analytic number theory (Apostol, Montgomery–Vaughan), is that ψ(x) − θ(x) = O(√x): the tail beyond the n = 2 term is genuinely of lower order.",
+    "problemStatement": "Sharpen the parent's estimate |ψ(x) − θ(x)| ≤ 2√x·log x to the log-free bound ψ(x) − θ(x) = O(√x): exhibit an explicit constant C with ψ(x) − θ(x) ≤ C·√x for all large x, and package the result as (ψ − θ) =O[atTop] √.",
+    "proofStrategy": "Start from Mathlib's decomposition ψ(x) = θ(x) + Σ_{n=2}^{K} θ(x^{1/n}) with K = ⌊log x/log 2⌋, so ψ(x) − θ(x) = Σ_{n=2}^{K} θ(x^{1/n}). Peel off the dominant term n = 2: since x^{1/2} = √x, it is θ(√x) ≤ log 4·√x by Chebyshev's linear bound θ(y) ≤ log 4·y. For the tail n ≥ 3, use x^{1/n} ≤ x^{1/3} (rpow monotone in the exponent) to bound every term by log 4·x^{1/3}; there are at most K ≤ log x/log 2 of them, so the tail is ≤ (log 4/log 2)·(log x·x^{1/3}). The decay bound log x ≤ 6·x^{1/6} (Real.log_le_rpow_div at ε = 1/6) gives log x·x^{1/3} ≤ 6·x^{1/6}·x^{1/3} = 6·x^{1/2} = 6·√x, and log 4/log 2 = 2, so the tail is ≤ 12·√x. Adding the two pieces: ψ(x) − θ(x) ≤ (log 4 + 12)·√x. Since θ ≤ ψ, the difference is nonnegative, so this is also an absolute-value bound and yields (ψ − θ) =O[atTop] √.",
+    "keyInsights": [
+      "ψ − θ = Σ_{n≥2} θ(x^{1/n}) is dominated by its single n = 2 term θ(√x); the log factor in the crude bound comes only from lazily bounding the whole tail by that same leading term.",
+      "For n ≥ 3 the exponents 1/n ≤ 1/3 make x^{1/n} ≤ x^{1/3}, so the tail terms are individually of order x^{1/3} — small enough that even ≈ log x of them sum to o(√x).",
+      "The log-factor is killed by the elementary decay log x ≤ 6·x^{1/6}: then log x·x^{1/3} ≤ 6·x^{1/2}, exactly √x up to a constant, because 1/6 + 1/3 = 1/2.",
+      "The whole argument is finite and explicit — a Finset peel plus two rpow monotonicity facts — with no analysis beyond a single application of log = O(x^ε), giving a concrete constant log 4 + 12.",
+      "The bound is exactly the 'worse constant' improvement Mathlib's source comment anticipates: trading the log factor for a larger multiplicative constant."
+    ],
+    "prerequisites": [
+      "Chebyshev functions ψ, θ and the von Mangoldt function",
+      "The prime-power decomposition ψ = θ + Σ θ(x^{1/n})",
+      "Real power functions and monotonicity of x^t in t for x ≥ 1",
+      "The growth bound log x = O(x^ε) and big-O notation"
+    ]
+  },
+  "sections": [
+    {
+      "id": "decay-lemmas",
+      "title": "Section I: The log-Eating Decay Bounds",
+      "startLine": 55,
+      "endLine": 74,
+      "summary": "log_le_six_mul_rpow (log x ≤ 6·x^{1/6}, from Real.log_le_rpow_div at ε = 1/6) and logx_mul_rpow_third_le (log x·x^{1/3} ≤ 6·√x, using x^{1/6}·x^{1/3} = x^{1/2}).",
+      "mathContext": "The single analytic input — the logarithm grows slower than x^{1/6} — repackaged so that the tail's log·x^{1/3} collapses to a bare √x."
+    },
+    {
+      "id": "explicit-bound",
+      "title": "Section II: ψ − θ ≤ (log 4 + 12)·√x",
+      "startLine": 76,
+      "endLine": 145,
+      "summary": "psi_sub_theta_le_const_mul_sqrt: from ψ − θ = Σ_{n=2}^{K} θ(x^{1/n}), peel the n = 2 term (θ(√x) ≤ log 4·√x) and bound the n ≥ 3 tail by 12·√x via x^{1/n} ≤ x^{1/3} and the decay lemma.",
+      "mathContext": "The explicit-constant O(√x) bound on the prime-power correction, with the log factor removed."
+    },
+    {
+      "id": "bigo",
+      "title": "Section III: (ψ − θ) = O(√x)",
+      "startLine": 147,
+      "endLine": 155,
+      "summary": "psi_sub_theta_isBigO_sqrt: the explicit bound plus θ ≤ ψ (nonnegativity) packaged as (ψ − θ) =O[atTop] √.",
+      "mathContext": "The headline statement: the prime-power correction is O(√x), sharpening Mathlib's O(√x·log x)."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 157 lines and 4 theorems proving ψ(x) − θ(x) ≤ (log 4 + 12)·√x for x ≥ 2 and hence (ψ − θ) =O[atTop] √. It sharpens Mathlib's own estimate |ψ(x) − θ(x)| ≤ 2√x·log x by removing the log factor, exactly the improvement flagged in Mathlib's source comment 'a more careful argument could remove the log x … with a worse constant.'",
+    "implications": "This answers OQ-02 of the parent chebyshev-bounds-oq-03: the difference between the second and first Chebyshev functions is O(√x), not merely o(x) or O(√x·log x). The proof is a clean template for turning a Finset decomposition plus log = O(x^ε) into a sharp power-savings error term, and the reusable lemma log x·x^{1/3} ≤ 6·√x (and its pattern) applies to other prime-power tail estimates. The explicit constant log 4 + 12 is deliberately non-optimal; the true constant is closer to log 4.",
+    "openQuestions": [
+      "Sharpen the constant: the honest asymptotic tail is θ(√x) ∼ √x, so ψ(x) − θ(x) = √x + O(x^{1/3}·log x); formalize the true leading constant rather than log 4 + 12.",
+      "Refine to an asymptotic: prove ψ(x) − θ(x) ∼ √x (equivalently ψ(x) − θ(x) − √x = O(x^{1/3}·log x)), isolating the exact main term of the prime-power correction."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Chebyshev",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Asymptotics",
+      "Finset",
+      "Chebyshev",
+      "Topology"
+    ],
+    "namespace": "ChebyshevBoundsOQ03OQ02",
+    "lineCount": 157,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/ChebyshevBoundsOQ03OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-bounds-oq-03",
+      "relationship": "extends",
+      "description": "Parent: proves ψ ∼ θ using Mathlib's |ψ − θ| ≤ 2√x·log x. This entry answers its OQ-02 by removing the log factor: ψ − θ = O(√x)."
+    },
+    {
+      "targetId": "chebyshev-bounds",
+      "relationship": "related",
+      "description": "Grandparent: bounds on the first Chebyshev function θ, whose linear upper bound θ(x) ≤ log 4·x is the workhorse of this tail estimate."
+    }
+  ],
+  "references": [
+    {
+      "key": "Apostol",
+      "citation": "Apostol, T.M., Introduction to Analytic Number Theory, Springer (1976), Chapter 4 (Chebyshev functions ψ and θ; ψ(x) − θ(x) estimates).",
+      "type": "book"
+    },
+    {
+      "key": "MV07",
+      "citation": "Montgomery, H.L. and Vaughan, R.C., Multiplicative Number Theory I: Classical Theory, Cambridge University Press (2007).",
+      "type": "book"
+    },
+    {
+      "key": "Ch1852",
+      "citation": "Chebyshev, P.L., Mémoire sur les nombres premiers, J. Math. Pures Appl. 17 (1852), 366–390.",
+      "type": "paper"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-02** of `chebyshev-bounds-oq-03`: sharpen the prime-power correction from Mathlib's `|ψ(x) − θ(x)| ≤ 2√x·log x` to the **log-free bound `ψ(x) − θ(x) = O(√x)`**.

This is exactly the improvement Mathlib's own source comment anticipates, sitting right above `Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log`:

> `--Note that a more careful argument could remove the log x in the following with a worse constant.`

## Result

- `psi_sub_theta_le_const_mul_sqrt` : `ψ x − θ x ≤ (log 4 + 12)·√x` for `x ≥ 2`  (explicit constant)
- `psi_sub_theta_isBigO_sqrt` : `(fun x => ψ x − θ x) =O[atTop] (fun x => √x)`  (the O(√x) statement)

## Proof (elementary, finite, explicit)

From Mathlib's decomposition `ψ(x) = θ(x) + Σ_{n=2}^{K} θ(x^{1/n})`, `K = ⌊log x/log 2⌋`:

1. **Peel the dominant `n = 2` term.** `x^{1/2} = √x`, so it is `θ(√x) ≤ log 4·√x` (`Chebyshev.theta_le_log4_mul_x`).
2. **Collapse the `n ≥ 3` tail.** Each term `≤ log 4·x^{1/n} ≤ log 4·x^{1/3}` (rpow monotone in the exponent), and there are `≤ K ≤ log x/log 2` of them, so the tail is `≤ (log 4/log 2)·(log x·x^{1/3})`.
3. **Eat the log.** `log x ≤ 6·x^{1/6}` (`Real.log_le_rpow_div` at `ε = 1/6`) gives `log x·x^{1/3} ≤ 6·x^{1/6}·x^{1/3} = 6·x^{1/2} = 6√x`; with `log 4/log 2 = 2` the tail is `≤ 12√x`.

Adding: `ψ(x) − θ(x) ≤ (log 4 + 12)·√x`. Since `θ ≤ ψ` the difference is `≥ 0`, giving the two-sided big-O.

## Verification

- **0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions, no `native_decide`.**
- Full-file typecheck passes against Mathlib (`lake env lean Proofs/ChebyshevBoundsOQ03OQ02.lean`, zero diagnostics). Source contains no `sorry`/`native_decide`/`decide`/`axiom` — 0-axiom by construction (only `propext`/`Classical.choice`/`Quot.sound` from Mathlib deps, which do not count).
- Only the standard Mathlib Chebyshev + rpow API is used; no new infrastructure.

## Files

- `proofs/Proofs/ChebyshevBoundsOQ03OQ02.lean` (157 lines, 4 theorems, 0 defs)
- `src/data/proofs/chebyshev-bounds-oq-03-oq-02/meta.json`
- `src/data/proofs/chebyshev-bounds-oq-03-oq-02/annotations.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)