### PR TITLE
research(konigsberg-oq-02-oq-01-oq-02): Undirected Eulerian necessity + Königsberg obstruction [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/KonigsbergOQ02OQ01OQ02.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01OQ02.lean
@@ -1,0 +1,109 @@
+/-
+# Undirected Eulerian Circuit Theorem — Degree Characterization (Necessity)
+
+This file formalizes the **necessity** half of Euler's theorem on Eulerian trails
+and circuits for *undirected* simple graphs, and the general **obstruction**
+theorem that resolves the Königsberg Seven Bridges problem.
+
+Euler's theorem states, for a connected undirected graph `G`:
+
+* `G` has an Eulerian **circuit** (a closed trail using every edge exactly once)
+  iff every vertex has **even** degree;
+* `G` has an Eulerian **trail** from `u` to `v` (with `u ≠ v`) iff `u` and `v`
+  are the only two vertices of **odd** degree.
+
+Mathlib (`Mathlib.Combinatorics.SimpleGraph.Trails`) provides the core degree
+book-keeping for Eulerian trails: `SimpleGraph.Walk.IsEulerian.even_degree_iff`
+and `SimpleGraph.Walk.IsEulerian.card_odd_degree`. Here we package these into the
+classical necessity statements and, crucially, prove the two results that are
+*not* directly available as single Mathlib lemmas:
+
+1. `eulerian_circuit_forall_even` — a closed Eulerian trail forces **all**
+   degrees even.
+2. `eulerian_trail_odd_iff_endpoint` — for an open Eulerian trail `u → v`
+   (`u ≠ v`) the odd-degree vertices are **exactly** `{u, v}`. This pins the two
+   endpoints, strengthening the mere cardinality bound.
+3. `no_eulerian_trail_of_card_odd_ne` — if the number of odd-degree vertices is
+   anything other than `0` or `2`, **no** Eulerian trail (of any endpoints)
+   exists. This is the general Königsberg obstruction: the bridges graph has four
+   odd-degree land masses, so no Eulerian trail can exist.
+
+The **sufficiency** direction (connectivity + the degree condition implies an
+Eulerian circuit exists — undirected Hierholzer) is not proved here; the directed
+analogue is formalized in `KonigsbergOQ02OQ01.lean`
+(`directed_euler_circuit_sufficient_corrected`). Undirected sufficiency remains
+the open direction for this entry.
+
+All results are machine-checked with no `sorry` and no additional axioms beyond
+Mathlib's foundational ones.
+-/
+import Mathlib.Combinatorics.SimpleGraph.Trails
+import Mathlib.Tactic
+
+open SimpleGraph SimpleGraph.Walk
+
+namespace UndirectedEuler
+
+variable {V : Type*} {G : SimpleGraph V} [Fintype V] [DecidableEq V] [DecidableRel G.Adj]
+
+/-- **Necessity for Eulerian circuits.**
+A closed Eulerian trail (an Eulerian circuit) visits every edge exactly once and
+returns to its start; consequently *every* vertex must have even degree. This is
+the "all degrees even" half of Euler's characterization of Eulerian circuits. -/
+theorem eulerian_circuit_forall_even {u : V} {p : G.Walk u u}
+    (h : p.IsEulerian) (x : V) : Even (G.degree x) := by
+  rw [h.even_degree_iff]
+  intro huu
+  exact absurd rfl huu
+
+/-- **Endpoint identification for Eulerian trails.**
+For an *open* Eulerian trail from `u` to `v` with `u ≠ v`, a vertex has odd degree
+**iff** it is one of the two endpoints. In particular the odd-degree vertices are
+exactly `{u, v}`, strengthening the cardinality statement
+`IsEulerian.card_odd_degree`. -/
+theorem eulerian_trail_odd_iff_endpoint {u v : V} {p : G.Walk u v}
+    (h : p.IsEulerian) (hne : u ≠ v) (x : V) :
+    Odd (G.degree x) ↔ x = u ∨ x = v := by
+  rw [← Nat.not_even_iff_odd, h.even_degree_iff]
+  constructor
+  · intro hnot
+    by_contra hc
+    push_neg at hc
+    exact hnot (fun _ => hc)
+  · rintro (rfl | rfl) hall
+    · exact (hall hne).1 rfl
+    · exact (hall hne).2 rfl
+
+/-- The odd-degree endpoints of an open Eulerian trail are distinct and are
+precisely the trail's start and finish, as a `Finset` equality. -/
+theorem eulerian_trail_oddFinset_eq {u v : V} {p : G.Walk u v}
+    (h : p.IsEulerian) (hne : u ≠ v) :
+    (Finset.univ.filter fun x => Odd (G.degree x)) = {u, v} := by
+  ext x
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert,
+    Finset.mem_singleton]
+  exact eulerian_trail_odd_iff_endpoint h hne x
+
+/-- **General Königsberg obstruction.**
+If the number of odd-degree vertices is neither `0` nor `2`, then the graph admits
+no Eulerian trail whatsoever (regardless of endpoints). The Königsberg bridges
+graph has four vertices of odd degree, so this rules out any Eulerian trail — the
+resolution of Euler's 1736 problem. -/
+theorem no_eulerian_trail_of_card_odd_ne
+    (h0 : Fintype.card {v : V | Odd (G.degree v)} ≠ 0)
+    (h2 : Fintype.card {v : V | Odd (G.degree v)} ≠ 2) :
+    ¬ ∃ (u v : V) (p : G.Walk u v), p.IsEulerian := by
+  rintro ⟨u, v, p, h⟩
+  rcases h.card_odd_degree with hc | hc
+  · exact h0 hc
+  · exact h2 hc
+
+/-- **Circuit form of the obstruction.**
+If some vertex has odd degree, there is no Eulerian *circuit* (closed Eulerian
+trail). Contrapositive of `eulerian_circuit_forall_even`. -/
+theorem no_eulerian_circuit_of_odd_degree {x : V} (hx : Odd (G.degree x)) :
+    ¬ ∃ (u : V) (p : G.Walk u u), p.IsEulerian := by
+  rintro ⟨u, p, h⟩
+  exact (Nat.not_even_iff_odd.mpr hx) (eulerian_circuit_forall_even h x)
+
+end UndirectedEuler

--- a/src/data/proofs/konigsberg-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-ue-header",
+    "proofId": "konigsberg-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Euler's Theorem: The Necessity Direction",
+    "content": "Euler's 1736 analysis of the Königsberg bridges gives the founding theorem of graph theory. Its modern statement has two halves. The **necessity** (Euler) direction — formalized here — says that the parity of vertex degrees obstructs Eulerian trails: an Eulerian circuit needs every degree even, and an Eulerian trail needs all but at most two degrees even. The **sufficiency** (Hierholzer) direction — the converse, that a connected graph meeting the degree condition actually has an Eulerian trail — is not proved here; its directed analogue lives in the parent entry KonigsbergOQ02OQ01.\n\nThis file works over Mathlib's `SimpleGraph.Walk.IsEulerian` predicate rather than the bespoke `Digraph` development of the directed parent, so the necessity results follow from Mathlib's degree book-keeping.",
+    "mathContext": "For a finite undirected simple graph $G$: if $G$ has an Eulerian circuit then $\\deg(v)$ is even for every $v$; if $G$ has an Eulerian trail then the number of odd-degree vertices is $0$ or $2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "euler-circuit",
+      "euler-trail",
+      "degree-parity",
+      "konigsberg-bridges"
+    ],
+    "prerequisites": [
+      "simple-graph",
+      "vertex-degree",
+      "Eulerian-trail"
+    ]
+  },
+  {
+    "id": "ann-ue-circuit-even",
+    "proofId": "konigsberg-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 49,
+      "endLine": 57
+    },
+    "type": "proof-technique",
+    "title": "Circuit Necessity via a Vacuous Implication",
+    "content": "`eulerian_circuit_forall_even` shows that a closed Eulerian trail forces every vertex to have even degree. The proof is a clean specialization of Mathlib's `IsEulerian.even_degree_iff`, which states\n\n    Even (G.degree x) ↔ (u ≠ v → x ≠ u ∧ x ≠ v)\n\nfor an Eulerian trail `p : G.Walk u v`. For a **circuit** the endpoints coincide (`u = v`), so the hypothesis `u ≠ u` on the right is false and the implication is vacuously true. Hence `Even (G.degree x)` holds for every `x`. Notably this needs no connectivity assumption — parity necessity is unconditional.",
+    "mathContext": "With $u = v$, the biconditional's right side is $(u \\neq u \\to \\ldots)$, whose premise is false, so it is trivially true; therefore $\\mathrm{Even}(\\deg x)$ for all $x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "euler-circuit",
+      "even-degree",
+      "vacuous-truth"
+    ],
+    "prerequisites": [
+      "Eulerian-circuit",
+      "degree-parity"
+    ]
+  },
+  {
+    "id": "ann-ue-endpoints",
+    "proofId": "konigsberg-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 59,
+      "endLine": 85
+    },
+    "type": "key-insight",
+    "title": "The Odd-Degree Vertices Are Exactly the Endpoints",
+    "content": "Mathlib's `IsEulerian.card_odd_degree` only tells us *how many* vertices have odd degree (0 or 2). `eulerian_trail_odd_iff_endpoint` says *which* ones: for an open Eulerian trail from `u` to `v` with `u ≠ v`, a vertex has odd degree **iff** it is `u` or `v`. Instantiating `even_degree_iff` at `u ≠ v` collapses the right-hand side to `x ≠ u ∧ x ≠ v`; negating this biconditional (a short `by_contra` / `push_neg` argument) yields `Odd (G.degree x) ↔ x = u ∨ x = v`. `eulerian_trail_oddFinset_eq` repackages this as the Finset identity `filter Odd univ = {u, v}`.",
+    "mathContext": "For $u \\neq v$: $\\mathrm{Odd}(\\deg x) \\iff x = u \\lor x = v$, hence $\\{x : \\mathrm{Odd}(\\deg x)\\} = \\{u, v\\}$. This sharpens the cardinality statement $|\\{x : \\mathrm{Odd}(\\deg x)\\}| \\in \\{0, 2\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "euler-trail",
+      "odd-degree",
+      "endpoints"
+    ],
+    "prerequisites": [
+      "Eulerian-trail",
+      "finset",
+      "degree-parity"
+    ]
+  },
+  {
+    "id": "ann-ue-obstruction",
+    "proofId": "konigsberg-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 87,
+      "endLine": 109
+    },
+    "type": "concept",
+    "title": "The Königsberg Obstruction, in General",
+    "content": "`no_eulerian_trail_of_card_odd_ne` is the theorem that resolves Euler's original problem: if the number of odd-degree vertices is anything other than 0 or 2, then no Eulerian trail exists at all. It is the contrapositive of Mathlib's `IsEulerian.card_odd_degree`. The Seven Bridges of Königsberg is exactly the instance with four odd-degree land masses — outside `{0, 2}` — so no bridge-crossing trail can visit each bridge once. `no_eulerian_circuit_of_odd_degree` records the circuit form: a single odd-degree vertex already rules out an Eulerian circuit.",
+    "mathContext": "If $|\\{v : \\mathrm{Odd}(\\deg v)\\}| \\notin \\{0, 2\\}$ then $G$ has no Eulerian trail. Königsberg has four vertices of odd degree, so it admits no Eulerian trail — Euler's 1736 conclusion.",
+    "significance": "key",
+    "relatedConcepts": [
+      "konigsberg-bridges",
+      "obstruction",
+      "odd-degree",
+      "non-existence"
+    ],
+    "prerequisites": [
+      "Eulerian-trail",
+      "degree-parity"
+    ]
+  }
+]

--- a/src/data/proofs/konigsberg-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "konigsberg-oq-02-oq-01-oq-02",
+  "title": "Undirected Eulerian Theorem — Degree Characterization (Necessity)",
+  "slug": "konigsberg-oq-02-oq-01-oq-02",
+  "description": "Formalizes the necessity half of Euler's theorem on Eulerian trails and circuits for undirected simple graphs, building on Mathlib's SimpleGraph.Walk.IsEulerian. Proves that an Eulerian circuit forces every vertex to have even degree, that the odd-degree vertices of an open Eulerian trail are exactly its two endpoints, and the general Königsberg obstruction: if the number of odd-degree vertices is anything other than 0 or 2, no Eulerian trail can exist. The sufficiency direction (undirected Hierholzer) is documented as the remaining open direction; the directed analogue is in KonigsbergOQ02OQ01.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KonigsbergOQ02OQ01OQ02.lean",
+    "tags": [
+      "graph-theory",
+      "euler-paths",
+      "konigsberg",
+      "combinatorics",
+      "undirected-graphs",
+      "degree-sequence"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "",
+    "lineCount": 109,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "eulerian_circuit_forall_even: a closed Eulerian trail (Eulerian circuit) forces every vertex to have even degree — the 'all degrees even' necessity for undirected Eulerian circuits, specialized from Mathlib's IsEulerian.even_degree_iff to the closed case",
+      "eulerian_trail_odd_iff_endpoint: for an open Eulerian trail u → v with u ≠ v, a vertex has odd degree iff it is one of the two endpoints — pins the odd-degree vertices as exactly {u, v}, strengthening the mere cardinality bound of IsEulerian.card_odd_degree",
+      "eulerian_trail_oddFinset_eq: packages the endpoint identification as a Finset equality (filter Odd = {u, v})",
+      "no_eulerian_trail_of_card_odd_ne: general Königsberg obstruction — if the number of odd-degree vertices is neither 0 nor 2, no Eulerian trail exists (the four odd-degree land masses of the Königsberg bridges rule out any Eulerian trail)",
+      "no_eulerian_circuit_of_odd_degree: circuit form of the obstruction — a single odd-degree vertex rules out any Eulerian circuit"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Leonhard Euler's 1736 analysis of the Seven Bridges of Königsberg founded graph theory: he observed that a walk crossing every bridge exactly once and returning to its start requires every land mass to be met by an even number of bridges, and that Königsberg's four land masses each had an odd number, so no such walk exists. The full characterization — a connected graph has an Eulerian circuit iff every vertex has even degree, and an Eulerian trail iff at most two vertices have odd degree — is the modern statement of Euler's theorem, with the constructive converse supplied by Hierholzer (1873).\n\nThis entry formalizes the necessity (Euler) direction for undirected simple graphs, together with the general obstruction that resolves the original bridges problem, on top of Mathlib's Eulerian-trail infrastructure.",
+    "problemStatement": "Let $G$ be a finite undirected simple graph.\n\n**Necessity (circuit):** If $G$ has an Eulerian circuit (a closed trail using every edge exactly once), then every vertex has even degree.\n\n**Endpoint identification (trail):** If $G$ has an Eulerian trail from $u$ to $v$ with $u \\neq v$, then a vertex has odd degree if and only if it is $u$ or $v$; the odd-degree vertices are exactly $\\{u, v\\}$.\n\n**Obstruction:** If the number of odd-degree vertices of $G$ is not $0$ and not $2$, then $G$ admits no Eulerian trail. In particular the Königsberg bridges graph, with four odd-degree land masses, has no Eulerian trail.",
+    "proofStrategy": "All results reduce to Mathlib's SimpleGraph.Walk.IsEulerian.even_degree_iff, which states that for an Eulerian trail p : G.Walk u v, `Even (G.degree x) ↔ (u ≠ v → x ≠ u ∧ x ≠ v)`.\n\n1. Circuit necessity: instantiate at u = v. The hypothesis `u ≠ u` is false, so the implication is vacuously true and every degree is even.\n2. Endpoint identification: with u ≠ v the right-hand side becomes `x ≠ u ∧ x ≠ v`; negating gives `Odd (G.degree x) ↔ x = u ∨ x = v`. A short propositional argument (by_contra + push_neg) discharges both directions.\n3. Obstruction: apply Mathlib's IsEulerian.card_odd_degree (the odd-degree count is 0 or 2) contrapositively.",
+    "keyInsights": [
+      "**Even degree is necessary, connectivity is not** — the necessity direction needs no connectivity hypothesis: any Eulerian circuit, in any graph, forces all degrees even. Connectivity is only needed for the converse (sufficiency).",
+      "**The endpoints are pinned, not just counted** — Mathlib's card_odd_degree only says there are 0 or 2 odd-degree vertices. eulerian_trail_odd_iff_endpoint identifies *which* vertices: precisely the trail's start and finish. This is the sharper necessity statement.",
+      "**Königsberg as a parity obstruction** — the Seven Bridges result is the special case of no_eulerian_trail_of_card_odd_ne where four vertices have odd degree; the general theorem covers any odd count outside {0, 2}.",
+      "**Directed vs undirected** — the directed sufficiency (Hierholzer) is formalized in the parent entry KonigsbergOQ02OQ01 with a bespoke Digraph development; the undirected necessity leverages Mathlib's SimpleGraph.Walk trail API directly.",
+      "**Vacuous-implication trick** — the circuit case falls out by feeding the false hypothesis `u ≠ u` into even_degree_iff, a clean instance of specializing a biconditional at equal endpoints."
+    ]
+  },
+  "conclusion": {
+    "summary": "The necessity direction of Euler's undirected Eulerian theorem is formalized with 0 sorries and no extra axioms: Eulerian circuits force all-even degrees, open Eulerian trails have their two endpoints as the exact odd-degree vertices, and any odd-degree count outside {0, 2} obstructs every Eulerian trail — resolving the Königsberg bridges problem in general form.",
+    "implications": [
+      "Completes the undirected necessity companion to the directed Hierholzer sufficiency proof in KonigsbergOQ02OQ01",
+      "eulerian_trail_odd_iff_endpoint sharpens Mathlib's cardinality-only IsEulerian.card_odd_degree by identifying the endpoints",
+      "no_eulerian_trail_of_card_odd_ne gives a reusable parity obstruction for non-existence of Eulerian trails"
+    ],
+    "openQuestions": [
+      "Undirected sufficiency (Hierholzer): connected graph with all-even degrees has an Eulerian circuit — the converse remains open in the gallery for the undirected case",
+      "Mixed-graph Eulerian characterization when both directed and undirected edges are present"
+    ]
+  },
+  "references": [
+    {
+      "authors": [
+        "Euler, L."
+      ],
+      "title": "Solutio problematis ad geometriam situs pertinentis",
+      "year": 1736,
+      "venue": "Commentarii Academiae Scientiarum Petropolitanae 8, 128–140",
+      "note": "The Seven Bridges of Königsberg; origin of the even-degree necessity condition."
+    },
+    {
+      "authors": [
+        "Bondy, J. A.",
+        "Murty, U. S. R."
+      ],
+      "title": "Graph Theory",
+      "year": 2008,
+      "venue": "Springer, Graduate Texts in Mathematics 244",
+      "note": "Modern treatment of the Eulerian degree characterization for undirected graphs."
+    }
+  ],
+  "leanFile": {
+    "namespace": "UndirectedEuler",
+    "lineCount": 109,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/KonigsbergOQ02OQ01OQ02.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib.Combinatorics.SimpleGraph.Trails",
+      "Mathlib.Tactic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring stating Euler's theorem, the necessity scope, and the open sufficiency direction; imports Mathlib's SimpleGraph.Walk.Trails API"
+    },
+    {
+      "id": "sec-circuit-necessity",
+      "title": "Circuit Necessity",
+      "startLine": 49,
+      "endLine": 57,
+      "summary": "eulerian_circuit_forall_even — a closed Eulerian trail forces every vertex to have even degree, via even_degree_iff at equal endpoints"
+    },
+    {
+      "id": "sec-endpoint-identification",
+      "title": "Endpoint Identification",
+      "startLine": 59,
+      "endLine": 85,
+      "summary": "eulerian_trail_odd_iff_endpoint and eulerian_trail_oddFinset_eq — the odd-degree vertices of an open Eulerian trail are exactly its two endpoints"
+    },
+    {
+      "id": "sec-obstruction",
+      "title": "Königsberg Obstruction",
+      "startLine": 87,
+      "endLine": 109,
+      "summary": "no_eulerian_trail_of_card_odd_ne and no_eulerian_circuit_of_odd_degree — parity obstructions ruling out Eulerian trails/circuits, generalizing the Seven Bridges impossibility"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "konigsberg-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "Directed Eulerian circuit sufficiency (Hierholzer); this entry supplies the undirected necessity companion"
+    },
+    {
+      "targetId": "konigsberg",
+      "relationship": "ancestor",
+      "description": "Original Königsberg bridges undirected impossibility result"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **necessity** half of Euler's theorem on Eulerian trails/circuits for undirected simple graphs, over Mathlib's `SimpleGraph.Walk.IsEulerian`, together with the general parity obstruction that resolves the Seven Bridges of Königsberg.

This is the undirected companion to the directed Hierholzer *sufficiency* proof in `konigsberg-oq-02-oq-01` (whose own `openQuestions` explicitly list "Undirected Eulerian circuit theorem").

## Theorems (`proofs/Proofs/KonigsbergOQ02OQ01OQ02.lean`, namespace `UndirectedEuler`)

1. `eulerian_circuit_forall_even` — a closed Eulerian trail forces **every** vertex to have even degree (no connectivity needed). Specializes `IsEulerian.even_degree_iff` to equal endpoints.
2. `eulerian_trail_odd_iff_endpoint` — for an open Eulerian trail `u → v` (`u ≠ v`), a vertex has odd degree **iff** it is an endpoint. Pins the odd-degree set as exactly `{u, v}`, sharpening Mathlib's cardinality-only `IsEulerian.card_odd_degree`.
3. `eulerian_trail_oddFinset_eq` — Finset form: `filter Odd univ = {u, v}`.
4. `no_eulerian_trail_of_card_odd_ne` — **Königsberg obstruction**: if `#odd-degree vertices ∉ {0, 2}` then no Eulerian trail exists. Königsberg's four odd-degree land masses ⇒ impossible.
5. `no_eulerian_circuit_of_odd_degree` — circuit form: a single odd-degree vertex rules out any Eulerian circuit.

## Scope / honesty

- **Necessity only.** Undirected *sufficiency* (Hierholzer) is **not** proved here; it is documented as the remaining open direction in `meta.json`. The directed analogue is formalized in `KonigsbergOQ02OQ01.lean`.
- Results 2–4 have content beyond a single Mathlib lemma (endpoint identification; general obstruction); results 1 and 5 are clean specializations.

## Verification

- 0 sorries.
- `#print axioms` on all five theorems shows only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no custom axioms → `status: verified`, `axiomCount: 0`, `badge: mathlib`.
- Compiled to a valid `.olean` (`lake env lean -o`, exit 0) against the warm Mathlib cache (Lean v4.26.0). Local Docker full-build was avoided due to heavy concurrent build contention; the single-file typecheck-to-olean is authoritative for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)