### PR TITLE
Enrich The Wilf–Zeilberger Method: cross-reference falling-factorial Vandermonde

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/meta.json
@@ -129,6 +129,11 @@
       "targetId": "arithmetic-series-oq-02-oq-02-oq-03-oq-02",
       "relationship": "related",
       "description": "Sibling generating-function generalization (multivariate Vandermonde); both descend from the same parent and treat the Vandermonde convolution by different machinery."
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01",
+      "relationship": "related",
+      "description": "A different Vandermonde convolution — the falling-factorial (x+y)^{underline r} = Σⱼ C(r,j) x^{underline j} y^{underline (r−j)} over an arbitrary commutative ring, proved by the sign reflection x^{underline k} = (−1)ᵏ(−x)^{(k)} rather than by creative telescoping. Contrasts the certificate-check pipeline used here with an algebraic-identity route; the two-variable Vandermonde certificate this entry's open question 1 seeks would give a WZ proof of a companion binomial-coefficient Vandermonde."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-02-oq-02-oq-03-oq-04` (The Wilf–Zeilberger Method in Lean; quality 91, passes 0).

The entry was already near-saturated (7 fully-populated annotations, 4 keyInsights, 3-part sections with mathContext, conclusion with 3 open questions). Rather than inflate an already-rich page (per the size-guardrail / diminishing-returns rule), this pass adds **one** genuinely missing, high-value cross-reference:

- **→ `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01`** (Falling-Factorial Vandermonde Convolution over an Arbitrary Commutative Ring): a different Vandermonde convolution proved by the sign reflection $x^{\underline k} = (-1)^k(-x)^{(k)}$ rather than by creative telescoping. It contrasts the certificate-check pipeline with an algebraic-identity route and connects directly to this entry's open question 1 (the two-variable WZ Vandermonde certificate).

meta.json remains well under the 60 KB cap (~13 KB). Verified with `pnpm build`.