### PR TITLE
Enrich Odd Gaussian Moments: cross-reference scaled even-moment sibling

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/meta.json
@@ -137,6 +137,11 @@
       "targetId": "area-of-circle-oq-07-oq-05",
       "relationship": "related",
       "description": "Grandparent. The second moment ∫ x² e^{-x²} = √π/2 is the first nontrivial even moment; together with the vanishing first odd moment ∫ x e^{-x²} = 0 proved here it illustrates the even/odd dichotomy."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling (same parent). Lifts the even moments to an arbitrary Gaussian scale, ∫ x^{2n} e^{-a x²} = (2n-1)‼·√(π/a)/(2a)ⁿ, by the dilation x ↦ √a·x. It generalizes the even branch of this entry's full moment sequence in the scale parameter a; the odd moments proved here vanish at every scale by the same symmetry, so the two together give the complete scaled moment table."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-05-oq-01-oq-01` (Vanishing of the Odd Gaussian Moments; quality 91, passes 0).

The entry was already saturated (4 keyInsights, 4 sections with mathContext, conclusion with 3 open questions, rich originalContributions). Per the size-guardrail / diminishing-returns rule, this pass adds **one** genuinely missing, high-value cross-reference rather than inflating existing fields:

- **→ `area-of-circle-oq-07-oq-05-oq-01-oq-02`** (The Scaled Even Moment of the Gaussian): the same-parent sibling that lifts the even moments to an arbitrary Gaussian scale $a>0$ via the dilation $x\mapsto\sqrt a\,x$. It generalizes the even branch of this entry's full moment sequence; the odd moments proved here vanish at every scale by the same symmetry, so the two together give the complete scaled moment table.

Previously only the parent and grandparent were linked. meta.json remains well under the 60 KB cap. Verified with `pnpm build`.