### PR TITLE
Enrich Odd Gaussian Moments (area-of-circle-oq-07-oq-05-oq-01-oq-01): 5th annotation

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/annotations.json
@@ -24,6 +24,28 @@
     ]
   },
   {
+    "id": "ann-preamble",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 45,
+      "endLine": 48
+    },
+    "type": "context",
+    "title": "Notation and the Parent Dependency",
+    "content": "Three setup lines carry real weight. `open Real MeasureTheory` brings `Real.exp`/`Real.sqrt`/`Real.pi` into scope and, crucially, makes the bare `∫ x : ℝ, ...` default to the volume (Lebesgue) measure — the very measure whose negation-invariance drives the odd-moment vanishing. `open scoped Nat` activates the double-factorial notation `‼`, so `(m - 1)‼` in gaussian_moment parses as the odd/even double factorial that indexes the even moments. And `import Proofs.AreaOfCircleOQ07OQ05OQ01` pulls in the parent's even-moment theorem `gaussian_even_moment`, which the full sequence reuses verbatim on its even branch: this file adds only the odd half and the parity-indexed packaging, standing on the parent's integration-by-parts recursion for the even half.",
+    "mathContext": "$(m-1)!! = \\prod_{j\\ge 0,\\, m-1-2j > 0}(m-1-2j)$",
+    "significance": "context",
+    "relatedConcepts": [
+      "double factorial",
+      "volume measure",
+      "Lebesgue measure",
+      "module import"
+    ],
+    "prerequisites": [
+      "Lean namespaces and scoped notation"
+    ]
+  },
+  {
     "id": "ann-odd-moment",
     "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-05-oq-01-oq-01` (Vanishing of the Odd Gaussian Moments).

The entry was already rich (deep historicalContext, 4 keyInsights, conclusion with 3 openQuestions, full section coverage, 3 crossReferences). The one gap against the documented minimums was annotation count: **4 → 5**.

**Change:** Added `ann-preamble` covering lines 45–48 (the `open`/`import` setup), a previously-uncovered range. It teaches three things that actually matter to the proof:
- `open MeasureTheory` makes the bare `∫ x : ℝ, ...` default to the **volume (Lebesgue) measure** — precisely the negation-invariant measure whose symmetry drives the odd-moment vanishing.
- `open scoped Nat` activates the double-factorial notation `‼` used in the even branch of `gaussian_moment`.
- `import Proofs.AreaOfCircleOQ07OQ05OQ01` supplies the parent's `gaussian_even_moment`, reused verbatim on the even branch; this file adds only the odd half and the parity-indexed packaging.

`pnpm build` passes. Only the target entry's `annotations.json` is modified.