### PR TITLE
research(picks-theorem-oq-04-oq-02): shoelace orientation reversal + cyclic rotation invariance [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PicksTheoremOQ04OQ02.lean
+++ b/proofs/Proofs/PicksTheoremOQ04OQ02.lean
@@ -1,0 +1,271 @@
+import Mathlib
+
+/-
+# Pick's Theorem OQ-04-OQ-02: Orientation and cyclic-rotation symmetry of the shoelace sum
+
+## What This Proves
+
+The signed shoelace (surveyor's) sum of a lattice polygon,
+
+    S(v₀, …, v_{m-1}) = Σ_k (x_k · y_{k+1} − x_{k+1} · y_k)     (indices mod m),
+
+carries the two structural symmetries that make "signed area" meaningful.  This
+file gives a *fully verified, axiom-free* Lean proof of both, answering the
+second open question left by `PicksTheoremOQ04` (the general shoelace / fan
+bridge file):
+
+1.  **Orientation reversal** (`shoelace_reverse`):
+        S(reverse vs) = − S(vs).
+    Traversing the boundary in the opposite direction flips the sign of the
+    signed area.  This is the formal statement that the shoelace sum *orients*
+    the polygon.
+
+2.  **Cyclic-rotation invariance** (`shoelace_rotate_one`, `shoelace_rotl`,
+    `shoelace_rotl_iterate`):
+        S(rotate vs) = S(vs).
+    Relabelling which vertex is "first" — a cyclic rotation of the vertex list —
+    leaves the sum unchanged, because a closed polygon has no distinguished
+    starting vertex.
+
+## Method
+
+Both results factor through a single clean device.  We introduce the **open
+edge sum** `edgeSum` of a polyline (the sum of `cross` over consecutive pairs,
+*without* the closing edge) and prove the bridge
+
+    shoelaceAux first l = edgeSum (l ++ [first])                (`shoelaceAux_eq_edgeSum`)
+
+so the closed shoelace loop is exactly the open edge sum of the list with its
+starting vertex appended as the closing vertex.  Then:
+
+* `edgeSum_snoc` : appending a vertex adds exactly one edge term;
+* `edgeSum_reverse` : `edgeSum (reverse l) = − edgeSum l`, from the antisymmetry
+  `cross a b = − cross b a` of the wedge product;
+* rotation-by-one is a re-association of the same closed edge multiset.
+
+Everything is `Int`-valued and decidable, so the closing examples reduce by
+`decide`.
+
+## Relation to the gallery
+- `PicksTheoremOQ04.lean` — the general shoelace sum, fan-triangulation bridge,
+  translation invariance, and the integrality bridge to Pick.  This file reuses
+  its `cross` / `shoelace` primitives and answers its open question (2).
+- `PicksTheorem.lean` — the base Pick relation `A = i + b/2 − 1`.
+
+0 sorries, 0 axioms.
+-/
+
+set_option linter.unusedVariables false
+set_option linter.unusedSectionVars false
+
+namespace PicksTheoremOQ04OQ02
+
+/-- A lattice point: a pair of integers. -/
+abbrev Pt := ℤ × ℤ
+
+-- ============================================================
+-- PART 1: The wedge product and its antisymmetry
+-- ============================================================
+
+/-- The 2D wedge / cross product of two position vectors,
+    `cross a b = x_a · y_b − y_a · x_b`.  This is the per-edge term of the
+    shoelace sum. -/
+def cross (a b : Pt) : ℤ := a.1 * b.2 - a.2 * b.1
+
+@[simp] lemma cross_self (a : Pt) : cross a a = 0 := by unfold cross; ring
+
+/-- The wedge product is antisymmetric: `cross a b = − cross b a`.  This single
+    algebraic fact is what forces the sign flip under orientation reversal. -/
+lemma cross_antisymm (a b : Pt) : cross a b = - cross b a := by unfold cross; ring
+
+-- ============================================================
+-- PART 2: The closed shoelace sum and the open edge sum
+-- ============================================================
+
+/-- `shoelaceAux first vs` sums `cross` over consecutive vertices of `vs`, then
+    closes the loop with the edge from the last vertex of `vs` back to `first`. -/
+def shoelaceAux (first : Pt) : List Pt → ℤ
+  | [] => 0
+  | [a] => cross a first
+  | a :: b :: t => cross a b + shoelaceAux first (b :: t)
+
+/-- The signed shoelace sum of a closed polygon given by its vertex list in
+    cyclic order: `shoelace [v₀, …, v_{m-1}] = Σ_k cross(v_k, v_{k+1 mod m})`. -/
+def shoelace : List Pt → ℤ
+  | [] => 0
+  | v0 :: rest => shoelaceAux v0 (v0 :: rest)
+
+/-- The **open** edge sum of a polyline: the sum of `cross` over consecutive
+    pairs, with *no* closing edge.  `edgeSum [a, b, c] = cross a b + cross b c`. -/
+def edgeSum : List Pt → ℤ
+  | [] => 0
+  | [_] => 0
+  | a :: b :: t => cross a b + edgeSum (b :: t)
+
+-- ============================================================
+-- PART 3: The bridge  shoelaceAux first l = edgeSum (l ++ [first])
+-- ============================================================
+
+/-- **Bridge.**  The closed shoelace chain based at `first` equals the open edge
+    sum of the list with `first` appended as the closing vertex.  This is the
+    single fact that lets us transport reversal and rotation results between the
+    closed loop and the (much more flexible) open polyline. -/
+lemma shoelaceAux_eq_edgeSum (first : Pt) (l : List Pt) :
+    shoelaceAux first l = edgeSum (l ++ [first]) := by
+  induction l with
+  | nil => rfl
+  | cons a t ih =>
+    cases t with
+    | nil => simp [shoelaceAux, edgeSum]
+    | cons b t' =>
+      simp only [List.cons_append] at ih ⊢
+      simp only [shoelaceAux, edgeSum]
+      rw [ih]
+
+/-- Specialisation of the bridge to the public `shoelace` entry point. -/
+lemma shoelace_eq_edgeSum (v0 : Pt) (rest : List Pt) :
+    shoelace (v0 :: rest) = edgeSum ((v0 :: rest) ++ [v0]) :=
+  shoelaceAux_eq_edgeSum v0 (v0 :: rest)
+
+-- ============================================================
+-- PART 4: The snoc law for the open edge sum
+-- ============================================================
+
+/-- **Snoc law.**  Appending a vertex `x` after a polyline that currently ends in
+    `y` adds exactly the single edge term `cross y x`. -/
+lemma edgeSum_snoc (l : List Pt) (y x : Pt) :
+    edgeSum (l ++ [y] ++ [x]) = edgeSum (l ++ [y]) + cross y x := by
+  induction l with
+  | nil => simp [edgeSum]
+  | cons a t ih =>
+    cases t with
+    | nil => simp [edgeSum]
+    | cons b t' =>
+      simp only [List.cons_append] at ih ⊢
+      simp only [edgeSum]
+      rw [ih]; ring
+
+-- ============================================================
+-- PART 5: Orientation reversal  (edgeSum, then shoelace)
+-- ============================================================
+
+/-- **Reversal of the open edge sum.**  Reversing a polyline reverses every edge,
+    and `cross` is antisymmetric, so the whole open edge sum negates. -/
+lemma edgeSum_reverse (l : List Pt) : edgeSum l.reverse = - edgeSum l := by
+  induction l with
+  | nil => rfl
+  | cons a t ih =>
+    cases t with
+    | nil => rfl
+    | cons b t' =>
+      -- (a :: b :: t').reverse = ((b :: t').reverse) ++ [a] = (t'.reverse ++ [b]) ++ [a]
+      rw [List.reverse_cons, List.reverse_cons, edgeSum_snoc t'.reverse b a,
+        ← List.reverse_cons, ih]
+      -- goal: - edgeSum (b :: t') + cross b a = - edgeSum (a :: b :: t')
+      show - edgeSum (b :: t') + cross b a = - edgeSum (a :: b :: t')
+      rw [show edgeSum (a :: b :: t') = cross a b + edgeSum (b :: t') from rfl,
+        cross_antisymm b a]
+      ring
+
+/-- Auxiliary reversal identity keeping the base vertex `v0` fixed at the front:
+    reversing only the *tail* negates the shoelace sum.  Proved by pulling the
+    closed loop through `edgeSum_reverse`. -/
+lemma shoelace_reverse_tail (v0 : Pt) (rest : List Pt) :
+    shoelace (v0 :: rest.reverse) = - shoelace (v0 :: rest) := by
+  rw [shoelace_eq_edgeSum, shoelace_eq_edgeSum, ← edgeSum_reverse]
+  congr 1
+  -- ((v0 :: rest) ++ [v0]).reverse = v0 :: (rest.reverse ++ [v0]) = (v0 :: rest.reverse) ++ [v0]
+  simp [List.reverse_append]
+
+-- ============================================================
+-- PART 6: Cyclic rotation invariance
+-- ============================================================
+
+/-- **Rotation by one.**  Moving the first vertex to the back of the list leaves
+    the shoelace sum unchanged: a closed polygon has no distinguished start. -/
+theorem shoelace_rotate_one (v0 : Pt) (rest : List Pt) :
+    shoelace (rest ++ [v0]) = shoelace (v0 :: rest) := by
+  cases rest with
+  | nil => rfl
+  | cons r0 rest' =>
+    have hL : shoelace ((r0 :: rest') ++ [v0])
+        = edgeSum ((r0 :: rest') ++ [v0]) + cross v0 r0 := by
+      have hbridge : shoelace ((r0 :: rest') ++ [v0])
+          = edgeSum (((r0 :: rest') ++ [v0]) ++ [r0]) := by
+        show shoelace (r0 :: (rest' ++ [v0]))
+            = edgeSum ((r0 :: (rest' ++ [v0])) ++ [r0])
+        exact shoelace_eq_edgeSum r0 (rest' ++ [v0])
+      rw [hbridge, edgeSum_snoc (r0 :: rest') v0 r0]
+    have hR : shoelace (v0 :: r0 :: rest')
+        = cross v0 r0 + edgeSum ((r0 :: rest') ++ [v0]) := by
+      rw [shoelace_eq_edgeSum]
+      show edgeSum (v0 :: r0 :: (rest' ++ [v0]))
+          = cross v0 r0 + edgeSum ((r0 :: rest') ++ [v0])
+      rfl
+    -- reassemble: LHS list `(r0 :: rest') ++ [v0]` is defeq to `r0 :: (rest' ++ [v0])`
+    show shoelace ((r0 :: rest') ++ [v0]) = shoelace (v0 :: r0 :: rest')
+    rw [hL, hR]; ring
+
+/-- One step of cyclic rotation: move the first vertex to the back. -/
+def rotl : List Pt → List Pt
+  | [] => []
+  | v0 :: rest => rest ++ [v0]
+
+/-- Rotation invariance in terms of the explicit one-step rotation `rotl`. -/
+theorem shoelace_rotl (vs : List Pt) : shoelace (rotl vs) = shoelace vs := by
+  cases vs with
+  | nil => rfl
+  | cons v0 rest => exact shoelace_rotate_one v0 rest
+
+/-- Rotation invariance under any number of one-step rotations: the shoelace sum
+    is a genuine invariant of the cyclic vertex order. -/
+theorem shoelace_rotl_iterate (n : ℕ) (vs : List Pt) :
+    shoelace (rotl^[n] vs) = shoelace vs := by
+  induction n generalizing vs with
+  | zero => rfl
+  | succ k ih => rw [Function.iterate_succ_apply, ih, shoelace_rotl]
+
+-- ============================================================
+-- PART 7: Orientation reversal for the full polygon
+-- ============================================================
+
+/-- **Orientation reversal (headline result).**  Reversing the vertex order of a
+    closed polygon negates its shoelace sum:  `S(reverse vs) = − S(vs)`.
+
+    Combines the tail-reversal identity `shoelace_reverse_tail` with rotation
+    invariance to move the fixed base vertex back into place. -/
+theorem shoelace_reverse (vs : List Pt) : shoelace vs.reverse = - shoelace vs := by
+  cases vs with
+  | nil => rfl
+  | cons v0 rest =>
+    -- (v0 :: rest).reverse = rest.reverse ++ [v0], a rotation of v0 :: rest.reverse
+    rw [List.reverse_cons, shoelace_rotate_one v0 rest.reverse]
+    exact shoelace_reverse_tail v0 rest
+
+-- ============================================================
+-- PART 8: Concrete verification
+-- ============================================================
+
+/-- Unit right triangle, counter-clockwise: `S = 1`. -/
+example : shoelace [(0, 0), (1, 0), (0, 1)] = 1 := by decide
+
+/-- The same triangle reversed (clockwise): `S = −1`. -/
+example : shoelace [(0, 1), (1, 0), (0, 0)] = -1 := by decide
+
+/-- Reversal law on the concrete triangle. -/
+example : shoelace ([(0, 0), (1, 0), (0, 1)] : List Pt).reverse
+    = - shoelace [(0, 0), (1, 0), (0, 1)] := by decide
+
+/-- Cyclic rotation of the triangle keeps `S = 1`. -/
+example : shoelace [(1, 0), (0, 1), (0, 0)] = 1 := by decide
+
+/-- Rotation law on the concrete triangle, one step. -/
+example :
+    shoelace ([(1, 0), (0, 1)] ++ [((0, 0) : Pt)]) = shoelace [(0, 0), (1, 0), (0, 1)] := by
+  decide
+
+/-- `3 × 4` rectangle, counter-clockwise: `S = 24`; reversed: `S = −24`. -/
+example : shoelace [(0, 0), (3, 0), (3, 4), (0, 4)] = 24 := by decide
+example : shoelace ([(0, 0), (3, 0), (3, 4), (0, 4)] : List Pt).reverse = -24 := by decide
+
+end PicksTheoremOQ04OQ02

--- a/src/data/proofs/picks-theorem-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/picks-theorem-oq-04-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-pt0402-overview",
+    "proofId": "picks-theorem-oq-04-oq-02",
+    "range": { "startLine": 3, "endLine": 61 },
+    "type": "concept",
+    "title": "The Two Symmetries of the Shoelace Sum",
+    "content": "The signed shoelace sum S(v0, ..., v_{m-1}) = Sum_k (x_k y_{k+1} - x_{k+1} y_k) computes twice the oriented area of a lattice polygon. Two structural facts make it 'oriented area' rather than an encoding artefact: reversing the traversal direction negates it (S(reverse vs) = -S(vs)), and relabelling which vertex is first — a cyclic rotation — leaves it unchanged (S(rotate vs) = S(vs)). This file proves both, axiom-free, answering open question (2) of PicksTheoremOQ04. The method factors every result through an open-polyline edge sum edgeSum, which is agnostic to the loop's distinguished basepoint.",
+    "mathContext": "Reversal encodes orientation; rotation encodes basepoint-independence. Together with the parent file's translation invariance, they exhibit the full symmetry action on the coordinate area.",
+    "significance": "Confirms |S|/2 is a well-defined oriented area, not an artefact of the chosen vertex list.",
+    "relatedConcepts": ["shoelace formula", "signed area", "orientation", "cyclic symmetry"],
+    "prerequisites": ["wedge product", "signed polygon area"]
+  },
+  {
+    "id": "ann-pt0402-edgesum-bridge",
+    "proofId": "picks-theorem-oq-04-oq-02",
+    "range": { "startLine": 100, "endLine": 128 },
+    "type": "technique",
+    "title": "The edgeSum Bridge: Decoupling Symmetry from Basepoint",
+    "content": "edgeSum sums cross over consecutive pairs of a list with NO closing edge — the open polyline sum. The bridge shoelaceAux_eq_edgeSum proves shoelaceAux first l = edgeSum (l ++ [first]): the closed shoelace loop is exactly the open edge sum of the list with its start appended as the closing vertex. This is the pivotal move. On the closed loop the head vertex plays a double role (start and loop-close), which entangles reversal and rotation; on the open polyline there is no distinguished basepoint, so each symmetry becomes a clean structural induction. Every later theorem transports its result back to shoelace through this one lemma.",
+    "mathContext": "Proved by two-step list induction: the a :: b :: t recursion of shoelaceAux matches that of edgeSum after cons_append normalization.",
+    "significance": "A reusable pattern: to prove symmetries of a based cyclic structure, factor through a basepoint-free open version.",
+    "relatedConcepts": ["open vs closed polyline", "structural recursion", "basepoint independence"],
+    "prerequisites": ["list induction"]
+  },
+  {
+    "id": "ann-pt0402-reversal",
+    "proofId": "picks-theorem-oq-04-oq-02",
+    "range": { "startLine": 148, "endLine": 244 },
+    "type": "theorem",
+    "title": "Orientation Reversal: S(reverse vs) = -S(vs)",
+    "content": "edgeSum_reverse proves edgeSum (reverse l) = -edgeSum l: reversing a polyline reverses every edge, and since cross a b = -cross b a (cross_antisymm), the whole sum negates. The induction uses edgeSum_snoc to peel the edge newly exposed at the end of the reversed list. Transporting to the full polygon is subtle: reversing vs changes which vertex is first, so the naive bridge mismatches basepoints. shoelace_reverse_tail first handles reversal with the base vertex held fixed (via edgeSum_reverse on the closed loop), and shoelace_reverse then uses rotation invariance to slide the base vertex back into place — so the reversal law genuinely depends on the rotation law.",
+    "mathContext": "Orientation reversal is the single algebraic fact cross_antisymm lifted along the reverse induction; the basepoint realignment is where rotation invariance enters.",
+    "significance": "Formalizes that clockwise vs counter-clockwise traversal is exactly the sign of the shoelace area.",
+    "relatedConcepts": ["antisymmetry", "orientation", "list reversal"],
+    "prerequisites": ["cross antisymmetry", "edgeSum bridge"]
+  },
+  {
+    "id": "ann-pt0402-rotation",
+    "proofId": "picks-theorem-oq-04-oq-02",
+    "range": { "startLine": 180, "endLine": 227 },
+    "type": "theorem",
+    "title": "Cyclic Rotation Invariance: S(rotate vs) = S(vs)",
+    "content": "shoelace_rotate_one proves that moving the first vertex to the back of the list (rest ++ [v0] vs v0 :: rest) leaves the shoelace sum unchanged: both loops are expanded through the edgeSum bridge and matched via edgeSum_snoc, exhibiting them as the same edge multiset re-associated. The explicit one-step rotation rotl packages this, and shoelace_rotl_iterate lifts it to any number of one-step rotations by induction on the iterate count, so the shoelace sum is a genuine invariant of the cyclic vertex order. A closed polygon has no distinguished starting vertex.",
+    "mathContext": "Rotation invariance is combinatorial, not analytic: it is a re-association of the closed edge sum, formalized entirely by the bridge plus the snoc law.",
+    "significance": "Justifies treating a polygon as a cyclic (not linear) list of vertices when computing area.",
+    "relatedConcepts": ["cyclic order", "rotation", "invariance"],
+    "prerequisites": ["edgeSum bridge", "snoc law"]
+  }
+]

--- a/src/data/proofs/picks-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-04-oq-02/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "picks-theorem-oq-04-oq-02",
+  "title": "Orientation and Cyclic-Rotation Symmetry of the Shoelace Sum",
+  "slug": "picks-theorem-oq-04-oq-02",
+  "description": "A fully verified, axiom-free Lean 4 proof that the signed shoelace (surveyor's) sum of a lattice polygon negates under reversal of the vertex order (orientation) and is invariant under cyclic rotation of the vertex list. Answers open question (2) of PicksTheoremOQ04 via an open-polyline `edgeSum` bridge.",
+  "meta": {
+    "author": "Lean Genius Researcher; the two structural symmetries of the classical shoelace/surveyor's formula formalized in Lean 4 with Mathlib",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PicksTheoremOQ04OQ02.lean",
+    "tags": [
+      "geometry",
+      "combinatorics",
+      "lattice",
+      "area",
+      "shoelace",
+      "orientation",
+      "symmetry",
+      "picks-theorem",
+      "wiedijk-100",
+      "connection"
+    ],
+    "badge": "original",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 271,
+    "theoremCount": 10,
+    "definitionCount": 5,
+    "dateAdded": "2026-07-01",
+    "mathlibDependencies": [
+      "List.reverse_cons",
+      "List.reverse_append",
+      "List.cons_append",
+      "Function.iterate_succ_apply"
+    ],
+    "assumptions": "0 sorries, 0 axioms. Only the foundational Lean axioms (propext / Classical.choice / Quot.sound) can appear via the decidable closing examples; no native_decide is used, so Lean.ofReduceBool is NOT present. Fully machine-verified.",
+    "prerequisites": [
+      "The signed shoelace (surveyor's) area formula",
+      "The 2D wedge/cross product and its antisymmetry",
+      "Structural list recursion and induction in Lean 4"
+    ],
+    "originalContributions": [
+      "edgeSum: the open-polyline edge sum (cross summed over consecutive pairs, no closing edge) — the pivot abstraction that decouples the two symmetries from the loop's distinguished basepoint.",
+      "shoelaceAux_eq_edgeSum: the bridge shoelaceAux first l = edgeSum (l ++ [first]), realizing the closed shoelace loop as the open edge sum of the list with its start appended as the closing vertex.",
+      "edgeSum_snoc: appending one vertex adds exactly one edge term (cross y x), proved by structural induction.",
+      "edgeSum_reverse: edgeSum (reverse l) = -edgeSum l, the open-polyline sign flip driven entirely by the antisymmetry cross a b = -cross b a.",
+      "shoelace_rotate_one / shoelace_rotl / shoelace_rotl_iterate: cyclic-rotation invariance, first for one step (moving the head vertex to the back) and then for arbitrarily many one-step rotations.",
+      "shoelace_reverse: the headline orientation law S(reverse vs) = -S(vs), obtained by combining a fixed-basepoint tail-reversal identity with rotation invariance to realign the basepoint."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The shoelace (Gauss / surveyor's) formula computes the signed area of a polygon from its vertex coordinates. Its sign encodes orientation — counter-clockwise traversal gives positive area, clockwise negative — and its value is independent of which vertex is listed first, since a closed polygon has no distinguished starting point. These two facts are what make the formula compute a genuine oriented area rather than an artefact of the chosen encoding. The companion entry PicksTheoremOQ04 formalized the general n-gon shoelace sum, its fan-triangulation bridge, and the integrality bridge to Pick's theorem, but left the orientation and rotation symmetries as an explicit open question. This entry closes it.",
+    "problemStatement": "For a lattice polygon given by its vertex list vs in cyclic order, prove in Lean 4 that (i) reversing the vertex order negates the signed shoelace sum, S(reverse vs) = -S(vs), and (ii) cyclically rotating the vertex list leaves it unchanged, S(rotate vs) = S(vs). Both must be fully machine-checked and axiom-free.",
+    "proofStrategy": "Introduce the open edge sum edgeSum (cross over consecutive pairs, no closing edge) and prove the bridge shoelaceAux first l = edgeSum (l ++ [first]), so the closed shoelace loop is the open edge sum of the list with its start appended as its close. On the open polyline, reversal is clean: edgeSum_reverse follows from cross_antisymm by structural induction (using the snoc law edgeSum_snoc to peel the newly-exposed end edge). Rotation-by-one is a re-association of the same closed edge multiset, proved by expanding both loops through the bridge and matching them via edgeSum_snoc. The full polygon reversal law then combines a fixed-basepoint tail-reversal identity with rotation invariance to move the base vertex back into place.",
+    "keyInsights": [
+      "The distinguished basepoint of shoelace (its head serves as both start and loop-close) is exactly what couples reversal and rotation; factoring through the basepoint-agnostic edgeSum decouples them.",
+      "Orientation reversal is, at bottom, the single algebraic fact cross a b = -cross b a lifted along a structural induction.",
+      "Cyclic rotation invariance is not an analytic statement but a re-association: the reversed/rotated loop sums the same edges in a different order.",
+      "Reversing the whole polygon changes the basepoint, so the reversal law genuinely needs rotation invariance as a lemma — the two symmetries are proved together, not independently."
+    ],
+    "prerequisites": [
+      "PicksTheoremOQ04 (the general shoelace sum and its cross/shoelace primitives)",
+      "The 2D wedge product cross a b = x_a y_b - y_a x_b and its antisymmetry",
+      "List induction, List.reverse / List.reverse_cons / List.reverse_append in Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "wedge-antisymmetry",
+      "title": "Part 1: The Wedge Product and its Antisymmetry",
+      "startLine": 66,
+      "endLine": 80,
+      "summary": "cross a b = x_a y_b - y_a x_b, with cross_self = 0 and the antisymmetry cross a b = -cross b a that drives the sign flip under orientation reversal.",
+      "mathContext": "The per-edge term of the shoelace sum. Its antisymmetry is the single algebraic input to the reversal theorem."
+    },
+    {
+      "id": "shoelace-and-edgesum",
+      "title": "Part 2: The Closed Shoelace Sum and the Open Edge Sum",
+      "startLine": 81,
+      "endLine": 104,
+      "summary": "shoelaceAux/shoelace define the closed cyclic edge sum; edgeSum defines the open-polyline sum (no closing edge) that is the pivot abstraction for both symmetries.",
+      "mathContext": "edgeSum is basepoint-agnostic, which is precisely what lets reversal and rotation be handled cleanly before transporting back to the closed loop."
+    },
+    {
+      "id": "the-bridge",
+      "title": "Part 3: The Bridge shoelaceAux first l = edgeSum (l ++ [first])",
+      "startLine": 105,
+      "endLine": 129,
+      "summary": "shoelaceAux_eq_edgeSum realizes the closed shoelace loop as the open edge sum of the list with its starting vertex appended as the closing vertex; shoelace_eq_edgeSum specializes it to the public entry point.",
+      "mathContext": "The transport lemma between the closed loop and the flexible open polyline — every later result factors through it."
+    },
+    {
+      "id": "snoc-law",
+      "title": "Part 4: The Snoc Law for the Open Edge Sum",
+      "startLine": 130,
+      "endLine": 147,
+      "summary": "edgeSum_snoc: appending a vertex x after a polyline ending in y adds exactly the single edge term cross y x, by structural induction.",
+      "mathContext": "The workhorse identity used both to peel end edges in the reversal induction and to re-associate loops in the rotation proof."
+    },
+    {
+      "id": "reversal-edgesum",
+      "title": "Part 5: Orientation Reversal (edgeSum, then shoelace)",
+      "startLine": 148,
+      "endLine": 179,
+      "summary": "edgeSum_reverse: edgeSum (reverse l) = -edgeSum l from cross_antisymm; shoelace_reverse_tail negates the shoelace sum when only the tail is reversed (base vertex fixed).",
+      "mathContext": "The open-polyline sign flip, and its first transport to the closed loop keeping the basepoint fixed."
+    },
+    {
+      "id": "rotation-invariance",
+      "title": "Part 6: Cyclic Rotation Invariance",
+      "startLine": 180,
+      "endLine": 227,
+      "summary": "shoelace_rotate_one (moving the head vertex to the back preserves S), the explicit one-step rotation rotl, and shoelace_rotl_iterate (invariance under any number of one-step rotations).",
+      "mathContext": "A closed polygon has no distinguished start: rotation is a re-association of the same edge multiset, established via the bridge and the snoc law."
+    },
+    {
+      "id": "reversal-full",
+      "title": "Part 7: Orientation Reversal for the Full Polygon",
+      "startLine": 228,
+      "endLine": 244,
+      "summary": "shoelace_reverse: S(reverse vs) = -S(vs), combining the fixed-basepoint tail-reversal identity with rotation invariance to realign the base vertex.",
+      "mathContext": "The headline symmetry; requires rotation invariance because reversing the whole polygon changes which vertex is first."
+    },
+    {
+      "id": "concrete-verification",
+      "title": "Part 8: Concrete Verification",
+      "startLine": 245,
+      "endLine": 271,
+      "summary": "decide-checked instances on the unit triangle and the 3x4 rectangle confirming the sign flip under reversal and invariance under rotation.",
+      "mathContext": "Ground-truth numeric checks anchoring the abstract laws to explicit polygons."
+    }
+  ],
+  "conclusion": {
+    "summary": "The signed shoelace sum of a lattice polygon negates under reversal of the vertex order and is invariant under cyclic rotation, both proved axiom-free in Lean 4. The proofs factor through the open-polyline edge sum edgeSum: reversal reduces to the antisymmetry of the wedge product, and rotation reduces to a re-association of the closed edge multiset. This completes the structural characterization of the shoelace object begun in PicksTheoremOQ04, confirming that it computes a genuine oriented area.",
+    "implications": [
+      "Confirms that the shoelace sum is an invariant of the oriented cyclic vertex order, not of its list encoding — the prerequisite for treating |S|/2 as a well-defined area.",
+      "Supplies reusable, axiom-free list lemmas (edgeSum, edgeSum_snoc, edgeSum_reverse) for any polyline/polygon formalization.",
+      "Together with PicksTheoremOQ04's translation invariance and fan bridge, pins down the full symmetry group action (orientation, rotation, translation) on the coordinate area."
+    ],
+    "openQuestions": [
+      "Can rotation invariance be upgraded to the standard-library List.rotate, giving shoelace (vs.rotate n) = shoelace vs directly, by proving rotl vs = vs.rotate 1?",
+      "Does the edgeSum bridge give a clean Lean proof that the shoelace area is invariant under the full orientation-preserving lattice isometry group (rotations by 90 degrees and reflections composed with orientation), not just translation?",
+      "Can the orientation law be combined with the fan-triangulation bridge to prove that a consistently counter-clockwise simple polygon has strictly positive shoelace sum?"
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "PicksTheoremOQ04OQ02",
+    "lineCount": 271,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 5,
+    "path": "Proofs/PicksTheoremOQ04OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "picks-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry: the general shoelace sum and fan bridge. This entry answers its open question (2) on orientation reversal and cyclic-rotation invariance, reusing its cross/shoelace primitives."
+    },
+    {
+      "targetId": "picks-theorem-oq-01",
+      "relationship": "related",
+      "description": "The triangle shoelace formula whose signed value these symmetries orient and rotate."
+    },
+    {
+      "targetId": "picks-theorem",
+      "relationship": "related",
+      "description": "Parent gallery proof of Pick's relation A = i + b/2 - 1, whose area side the shoelace sum computes."
+    }
+  ],
+  "references": [
+    {
+      "title": "Shoelace formula",
+      "url": "https://en.wikipedia.org/wiki/Shoelace_formula",
+      "note": "The signed surveyor's area formula, its orientation sign, and rotation independence."
+    },
+    {
+      "title": "Formalizing 100 Theorems (Wiedijk) — #92 Pick's Theorem",
+      "url": "https://www.cs.ru.nl/~freek/100/",
+      "note": "The parent theorem this shoelace development supports."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **picks-theorem-oq-04-oq-02**: *Orientation and Cyclic-Rotation Symmetry of the Shoelace Sum*. Answers **open question (2)** of `PicksTheoremOQ04`, which asked whether the fan/edge machinery extends to prove the shoelace sum changes sign under vertex-order reversal and is invariant under cyclic rotation.

Both are now proved **fully machine-checked, 0-axiom** in Lean 4:

- `shoelace_reverse : shoelace vs.reverse = - shoelace vs`  — **orientation**
- `shoelace_rotate_one`, `shoelace_rotl`, `shoelace_rotl_iterate` — **cyclic-rotation invariance** (one step, packaged, and iterated)

## Method

Everything factors through a single device: the **open-polyline edge sum** `edgeSum` (cross over consecutive pairs, *no* closing edge) and the bridge

```
shoelaceAux first l = edgeSum (l ++ [first])          -- shoelaceAux_eq_edgeSum
```

so the closed shoelace loop is the open edge sum of the list with its start appended as the close. On the basepoint-free open polyline:

- **Reversal** (`edgeSum_reverse`) is the antisymmetry `cross a b = -cross b a` lifted along a structural induction (peeling the newly-exposed end edge with `edgeSum_snoc`).
- **Rotation-by-one** is a re-association of the same closed edge multiset, matched via `edgeSum_snoc`.

Reversing the *whole* polygon changes the basepoint, so `shoelace_reverse` genuinely combines a fixed-basepoint tail-reversal identity with rotation invariance to realign the base vertex — the two symmetries are proved together.

## Verification

- `lake env lean Proofs/PicksTheoremOQ04OQ02.lean` against prebuilt Mathlib oleans: **clean typecheck, 0 diagnostics**.
- Source free of `sorry` / `native_decide` / `axiom` (only plain `decide` in the closing numeric examples → no `Lean.ofReduceBool`).
- 10 theorems/lemmas, 5 defs, 271 lines, 0 sorries, 0 axioms.
- `decide`-checked instances on the unit triangle and 3×4 rectangle confirm the sign flip and rotation invariance concretely.

## Files
- `proofs/Proofs/PicksTheoremOQ04OQ02.lean` (new)
- `src/data/proofs/picks-theorem-oq-04-oq-02/meta.json` (new)
- `src/data/proofs/picks-theorem-oq-04-oq-02/annotations.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)