### PR TITLE
Enrich The Wilf–Zeilberger Method: ℚ-certificate keyInsight + correct mate-value annotation

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/annotations.json
@@ -50,11 +50,11 @@
     "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-04",
     "range": { "startLine": 114, "endLine": 123 },
     "type": "tactic",
-    "title": "Boundary lemmas: G vanishes at both window ends",
-    "content": "G_zero (G(n,0) = 0 by rfl, from the guard) and G_top (G(n,N) = 0 when n+1 < N) supply the two hypotheses wz_telescope needs. G_top uses Nat.choose_eq_zero_of_lt: above the binomial support C(n,N−1) = 0, so the mate vanishes past the diagonal. These are exactly the two boundary conditions that make the telescoped right-hand side collapse to 0.",
-    "mathContext": "$G(n,0)=0$ (guard); for $n+1<N$, $\\binom{n}{N-1}=0$ so $G(n,N)=0$. Together: $G(n,N)-G(n,0)=0$.",
+    "title": "Values of the mate G: two vanishing endpoints and the nonzero k=1 value",
+    "content": "Three small lemmas pin down the values of G that later proofs consume. Two are the boundary conditions wz_telescope needs: G_zero (G(n,0) = 0 by rfl, straight from the guard) and G_top (G(n,N) = 0 when n+1 < N, via Nat.choose_eq_zero_of_lt — above the binomial support C(n,N−1) = 0, so the mate vanishes past the diagonal). Together they make the telescoped right-hand side collapse to G(n,N) − G(n,0) = 0. The third, G_one, is not a vanishing lemma at all: it records the *nonzero* value G(n,1) = −1/2ⁿ⁺¹ (the guard is off since k = 1 ≠ 0, and C(n,0) = 1). It is exactly the mate value that wz_equation needs at its k = 0 base case, where G(n,k+1) = G(n,1) must be evaluated explicitly.",
+    "mathContext": "$G(n,0)=0$ (guard) and, for $n+1<N$, $\\binom{n}{N-1}=0$ so $G(n,N)=0$ — together $G(n,N)-G(n,0)=0$. But $G(n,1)=-\\dfrac{1}{2^{n+1}}\\neq 0$, the value used in the $k=0$ case of the WZ equation.",
     "significance": "supporting",
-    "relatedConcepts": ["binomial support", "vanishing above the diagonal", "boundary conditions"],
+    "relatedConcepts": ["binomial support", "vanishing above the diagonal", "boundary conditions", "ℕ-subtraction guard"],
     "prerequisites": ["binomial coefficients"]
   },
   {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/meta.json
@@ -76,7 +76,8 @@
       "Creative telescoping is, at bottom, a one-line telescoping sum: Finset.sum_range_sub collapses ∑(G(n,k+1)−G(n,k)) to the boundary difference G(n,N)−G(n,0).",
       "The certificate verification — the only nontrivial pointwise identity — is exactly what a computer-algebra WZ implementation outputs; Lean then checks it independently.",
       "ℕ-subtraction forces a guard on the mate at k=0: without `if k = 0 then 0` the WZ equation would fail at the boundary because C(n, 0−1) collapses to C(n,0) instead of 0.",
-      "Because the binomial support [0,n] grows with n, the window is taken as N = n+2 and trimmed by F(n,n+1)=0, so each telescoping step relates exactly rowSum(n+1) and rowSum(n)."
+      "Because the binomial support [0,n] grows with n, the window is taken as N = n+2 and trimmed by F(n,n+1)=0, so each telescoping step relates exactly rowSum(n+1) and rowSum(n).",
+      "The certificate is a *rational* function, so the whole argument lives over ℚ, not ℕ: F(n,k)=C(n,k)/2ⁿ and the mate G(n,k)=−C(n,k−1)/2ⁿ⁺¹ genuinely require division, and only the final integer identity ∑ₖ C(n,k)=2ⁿ is transported back to ℕ (by exact_mod_cast, after field_simp clears 2ⁿ). This 'work in a characteristic-0 field, cast to ℕ at the very end' pattern is intrinsic to the WZ method — a hypergeometric certificate R(n,k) is rational by construction, so no purely-ℕ formalization of the telescoping step is available."
     ],
     "prerequisites": [
       "Hypergeometric terms and normalized summands",


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-02-oq-02-oq-03-oq-04` (The Wilf–Zeilberger Method in Lean). Two complementary, targeted improvements to a genuinely comprehensive entry (quality 91) — accuracy/coverage fixes, not accretion. meta.json 13.3 KB, well under caps.

## 1. Corrected mate-value annotation (annotations.json)
The annotation `wz-ann-boundary` (range 114–123) was titled *"Boundary lemmas: G vanishes at both window ends"* and described only `G_zero` and `G_top`. That range also covers **`G_one`** (lines 116–117), which is *not* a vanishing lemma — it records the **nonzero** mate value `G(n,1) = −1/2ⁿ⁺¹`, genuinely consumed by `wz_equation` at its `k=0` base case (line 142: `simp only [..., G_zero, G_one]`). The old title mischaracterized a lemma in its own range, and `G_one` had no description.
- Retitled to "Values of the mate G: two vanishing endpoints and the nonzero k=1 value"
- Expanded `content` + `mathContext` to cover all three helper lemmas and surface `G_one`'s role; added ℕ-subtraction-guard to `relatedConcepts`

## 2. Added ℚ-certificate keyInsight (meta.json)
5th `keyInsight` (4→5, within the ≤12 cap): the WZ certificate `R(n,k)` is *rational*, so the whole argument lives over ℚ (F and G genuinely require division) and only the final integer identity is cast back to ℕ — a "work in a characteristic-0 field, cast at the very end" pattern intrinsic to the method. Distinct from the existing ℕ-subtraction-guard insight. (Recovers a prior unmerged commit on this branch.)

## Verification
- `pnpm build` passes (gallery data + tsc + vite)
- Both JSON files validated