### PR TITLE
Enrich Poincaré Separation (self-contained compression): add section mathContext

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -99,15 +99,18 @@
   "sections": [
     {
       "title": "The Self-Contained Poincaré Separation Theorem",
-      "content": "poincare_separation_compression takes only a symmetric T on V (finrank V = n+m) and a subspace H (finrank H = n). It sets the spectral data of T (eigenbasis b, antitone eigenvalues lam) and of the explicit compression compress T H (symmetry from isSymmetric_compress, eigenbasis bH, antitone eigenvalues mu), supplies the Rayleigh-agreement hypothesis from rayleigh_compress_eq, and applies the gallery's abstract poincare_separation. The result is λ_{k+m} ≤ μ_k ≤ λ_k for every k : Fin n, with no Rayleigh side condition and no abstract compression operator."
+      "content": "poincare_separation_compression takes only a symmetric T on V (finrank V = n+m) and a subspace H (finrank H = n). It sets the spectral data of T (eigenbasis b, antitone eigenvalues lam) and of the explicit compression compress T H (symmetry from isSymmetric_compress, eigenbasis bH, antitone eigenvalues mu), supplies the Rayleigh-agreement hypothesis from rayleigh_compress_eq, and applies the gallery's abstract poincare_separation. The result is λ_{k+m} ≤ μ_k ≤ λ_k for every k : Fin n, with no Rayleigh side condition and no abstract compression operator.",
+      "mathContext": "For $T$ symmetric on $V$ with $\\dim V = n+m$ and $H \\le V$ with $\\dim H = n$: $\\lambda_{k+m} \\le \\mu_k \\le \\lambda_k$ for all $k$, where $\\mu$ are the descending eigenvalues of $\\operatorname{compress} T H = P_H \\circ T \\circ \\iota_H$."
     },
     {
       "title": "Recovering Codimension One",
-      "content": "cauchy_interlacing_compression_of_poincare specialises to m=1 and re-expresses the index bounds ⟨k+1⟩ and ⟨k⟩ as k.succ and k.castSucc through Fin.ext, reproducing the codimension-one compression corollary λ_{k+1} ≤ μ_k ≤ λ_k. This confirms the arbitrary-codimension theorem is a faithful generalisation of the merged codimension-one entry."
+      "content": "cauchy_interlacing_compression_of_poincare specialises to m=1 and re-expresses the index bounds ⟨k+1⟩ and ⟨k⟩ as k.succ and k.castSucc through Fin.ext, reproducing the codimension-one compression corollary λ_{k+1} ≤ μ_k ≤ λ_k. This confirms the arbitrary-codimension theorem is a faithful generalisation of the merged codimension-one entry.",
+      "mathContext": "Setting $m=1$: $\\lambda_{k+1} \\le \\mu_k \\le \\lambda_k$ (with indices $k.\\mathrm{succ}$, $k.\\mathrm{castSucc}$) — the codimension-one Cauchy interlacing corollary."
     },
     {
       "title": "Compression onto an Orthonormal Frame",
-      "content": "poincare_separation_compression_span replaces the explicit dimension hypothesis with an arbitrary orthonormal family f : Fin n → V, compressing onto H = span (range f). The dimension finrank H = n is discharged inline by finrank_span_eq_card hf.linearIndependent composed with Fintype.card_fin, giving the 'compression onto a k-dimensional subspace' form directly from an orthonormal frame."
+      "content": "poincare_separation_compression_span replaces the explicit dimension hypothesis with an arbitrary orthonormal family f : Fin n → V, compressing onto H = span (range f). The dimension finrank H = n is discharged inline by finrank_span_eq_card hf.linearIndependent composed with Fintype.card_fin, giving the 'compression onto a k-dimensional subspace' form directly from an orthonormal frame.",
+      "mathContext": "For an orthonormal frame $f : \\mathrm{Fin}\\,n \\to V$, take $H = \\operatorname{span}(\\operatorname{range} f)$; then $\\dim H = n$ (finrank\\_span\\_eq\\_card) and $\\lambda_{k+m} \\le \\mu_k \\le \\lambda_k$ holds for the compression onto $H$."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-02` (Poincaré Separation, Self-Contained via the Explicit Orthogonal Compression; quality 91, passes 0).

The overview, conclusion, and cross-references were already rich, but the 3 `sections` carried **no** `mathContext` fields — the one structural gap. This pass adds accurate LaTeX to each so the governing inequality surfaces at the section level:

- **Self-contained separation theorem**: $\lambda_{k+m} \le \mu_k \le \lambda_k$ for $\dim V = n+m$, $\dim H = n$, $\mu$ = eigenvalues of $\operatorname{compress} T H = P_H \circ T \circ \iota_H$.
- **Codimension one**: $m=1$ gives $\lambda_{k+1} \le \mu_k \le \lambda_k$.
- **Orthonormal frame**: $H = \operatorname{span}(\operatorname{range} f)$, $\dim H = n$.

Formulas drawn from the existing overview/originalContributions. No fields inflated; well under the 60 KB cap. Verified with `pnpm build`.