### PR TITLE
research(lucas-sequence-degree2-identities-oq-01-oq-01): index-tripling formulas U₃ₙ, V₃ₙ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LucasSequenceDegree2IdentitiesOQ01OQ01.lean
+++ b/proofs/Proofs/LucasSequenceDegree2IdentitiesOQ01OQ01.lean
@@ -1,0 +1,108 @@
+import Mathlib.Tactic
+import Proofs.LucasSequenceDegree2Identities
+import Proofs.LucasSequenceDegree2IdentitiesOQ01
+import Proofs.LucasSequenceDegree2IdentitiesOQ02
+
+/-
+# General Lucas-Sequence Index-Tripling Formulas
+
+## Open Question answered (parent OQ-01 → OQ-01)
+
+The parent entry `LucasSequenceDegree2IdentitiesOQ01` establishes the **doubling**
+(index-halving) formulas `U₂ₙ = Uₙ·Vₙ`, `V₂ₙ = Vₙ² − 2·Qⁿ` for the two-parameter
+Lucas sequences `Uₙ(P,Q)`, `Vₙ(P,Q)`.  Its own open question asks for the next rung of
+the index-multiplication ladder: the **tripling** formulas expressing `U₃ₙ` and `V₃ₙ`
+as polynomials in `Uₙ`, `Vₙ`, `Qⁿ` alone.  This file proves them:
+
+  **`U₃ₙ = Uₙ·(Vₙ² − Qⁿ)`**   and   **`V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ)`**.
+
+Together with doubling these give the full `U₂ₙ, U₂ₙ₊₁, U₃ₙ, …` addition toolkit and, in
+particular, the ternary (`3ⁿ`-radix) fast-exponentiation step for Lucas sequences.
+
+## Proof architecture (no Binet closed form, no `√D`)
+
+Both are one-line consequences of the parent's *bilinear addition laws* at the split
+`3n = 2n + n`, after eliminating the doubled-index values through the doubling formulas.
+
+1. `U_three_mul`.  Bilinear law (A) at `(2n, n)` reads
+   `2·U₃ₙ = U₂ₙ·Vₙ + V₂ₙ·Uₙ`.  Substituting `U₂ₙ = Uₙ·Vₙ` and `V₂ₙ = Vₙ² − 2·Qⁿ`
+   collapses the right side to `2·Uₙ·(Vₙ² − Qⁿ)` by `ring`; cancel the factor `2`.
+
+2. `V_three_mul`.  Bilinear law (B) at `(2n, n)` reads
+   `2·V₃ₙ = V₂ₙ·Vₙ + D·U₂ₙ·Uₙ` with `D = P² − 4Q`.  Insert the two doubling formulas,
+   then eliminate the sole remaining `D·Uₙ²` through the master invariant
+   `Vₙ² − D·Uₙ² = 4·Qⁿ` (`V_sq_sub_D_U_sq`) via `linear_combination`; the residue is
+   `2·Vₙ·(Vₙ² − 3·Qⁿ)`.  Cancel the factor `2`.
+
+No new induction is required: the entire tripling layer descends from the degree-2 master
+identity already proved in the parent entry.  The development is uniform in `(P,Q)`, so the
+Fibonacci/Lucas tripling `F₃ₙ = Fₙ·(Lₙ² − (−1)ⁿ)`, `L₃ₙ = Lₙ·(Lₙ² − 3·(−1)ⁿ)` and the
+Pell tripling are the `(1,−1)` and `(2,−1)` instances.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace LucasSequenceDegree2Identities
+
+open LucasSequenceDegree2IdentitiesOQ02
+
+/-! ## Section I: The General Tripling Formulas -/
+
+/-- **Index-tripling formula for `U`.** `U₃ₙ = Uₙ·(Vₙ² − Qⁿ)`.
+
+Bilinear law (A) at the split `3n = 2n + n` gives `2·U₃ₙ = U₂ₙ·Vₙ + V₂ₙ·Uₙ`; substitute
+the doubling formulas `U₂ₙ = Uₙ·Vₙ`, `V₂ₙ = Vₙ² − 2·Qⁿ` and cancel the factor `2`. -/
+theorem U_three_mul (P Q : ℤ) (n : ℕ) :
+    U P Q (3 * n) = U P Q n * ((V P Q n) ^ 2 - Q ^ n) := by
+  have hadd := two_U_add P Q (2 * n) n
+  have hUd := U_doubling P Q n
+  have hVd := V_doubling P Q n
+  have hidx : 2 * n + n = 3 * n := by ring
+  rw [hidx] at hadd
+  have key : 2 * U P Q (3 * n) = 2 * (U P Q n * ((V P Q n) ^ 2 - Q ^ n)) := by
+    rw [hadd, hUd, hVd]; ring
+  exact mul_left_cancel₀ (by norm_num) key
+
+/-- **Index-tripling formula for `V`.** `V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ)`.
+
+Bilinear law (B) at the split `3n = 2n + n` gives `2·V₃ₙ = V₂ₙ·Vₙ + D·U₂ₙ·Uₙ`; substitute
+the doubling formulas, eliminate `D·Uₙ²` through the master identity
+`Vₙ² − D·Uₙ² = 4·Qⁿ`, and cancel the factor `2`. -/
+theorem V_three_mul (P Q : ℤ) (n : ℕ) :
+    V P Q (3 * n) = V P Q n * ((V P Q n) ^ 2 - 3 * Q ^ n) := by
+  have hadd := two_V_add P Q (2 * n) n
+  have hUd := U_doubling P Q n
+  have hVd := V_doubling P Q n
+  have hmaster := V_sq_sub_D_U_sq P Q n
+  have hidx : 2 * n + n = 3 * n := by ring
+  rw [hidx] at hadd
+  have key : 2 * V P Q (3 * n) = 2 * (V P Q n * ((V P Q n) ^ 2 - 3 * Q ^ n)) := by
+    rw [hadd, hUd, hVd]
+    linear_combination (-(V P Q n)) * hmaster
+  exact mul_left_cancel₀ (by norm_num) key
+
+/-! ## Section II: Named Specializations and Numeric Checks -/
+
+/-- Fibonacci tripling `F₃ₙ = Fₙ·(Lₙ² − (−1)ⁿ)`, the `(P,Q) = (1,−1)` instance. -/
+theorem fib_tripling (n : ℕ) :
+    U 1 (-1) (3 * n) = U 1 (-1) n * ((V 1 (-1) n) ^ 2 - (-1 : ℤ) ^ n) :=
+  U_three_mul 1 (-1) n
+
+/-- Lucas tripling `L₃ₙ = Lₙ·(Lₙ² − 3·(−1)ⁿ)`, the `(P,Q) = (1,−1)` instance. -/
+theorem lucas_tripling (n : ℕ) :
+    V 1 (-1) (3 * n) = V 1 (-1) n * ((V 1 (-1) n) ^ 2 - 3 * (-1 : ℤ) ^ n) :=
+  V_three_mul 1 (-1) n
+
+/-- Pell tripling `U₃ₙ = Uₙ·(Vₙ² − (−1)ⁿ)`, the `(P,Q) = (2,−1)` instance. -/
+theorem pell_tripling (n : ℕ) :
+    U 2 (-1) (3 * n) = U 2 (-1) n * ((V 2 (-1) n) ^ 2 - (-1 : ℤ) ^ n) :=
+  U_three_mul 2 (-1) n
+
+/-- Numeric sanity check at `(1,−1)`, `n = 2`: `F₆ = 8`, `F₂·(L₂² − (−1)²) = 1·(9 − 1) = 8`
+and `L₆ = 18`, `L₂·(L₂² − 3·(−1)²) = 3·(9 − 3) = 18`. -/
+example : U 1 (-1) 6 = 8 ∧ V 1 (-1) 6 = 18 ∧
+    U 1 (-1) 6 = U 1 (-1) 2 * ((V 1 (-1) 2) ^ 2 - (-1 : ℤ) ^ 2) ∧
+    V 1 (-1) 6 = V 1 (-1) 2 * ((V 1 (-1) 2) ^ 2 - 3 * (-1 : ℤ) ^ 2) := by
+  refine ⟨by decide, by decide, by decide, by decide⟩
+
+end LucasSequenceDegree2Identities

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/annotations.json
@@ -26,8 +26,8 @@
     "id": "ann-u-tripling",
     "proofId": "lucas-sequence-degree2-identities-oq-01-oq-01",
     "range": {
-      "startLine": 49,
-      "endLine": 62
+      "startLine": 51,
+      "endLine": 64
     },
     "type": "tactic",
     "title": "U₃ₙ = Uₙ·(Vₙ² − Qⁿ): Addition Law meets Doubling",
@@ -49,8 +49,8 @@
     "id": "ann-v-tripling",
     "proofId": "lucas-sequence-degree2-identities-oq-01-oq-01",
     "range": {
-      "startLine": 64,
-      "endLine": 80
+      "startLine": 66,
+      "endLine": 82
     },
     "type": "insight",
     "title": "V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ): the Master Identity Clears the Residue",
@@ -72,8 +72,8 @@
     "id": "ann-specializations",
     "proofId": "lucas-sequence-degree2-identities-oq-01-oq-01",
     "range": {
-      "startLine": 82,
-      "endLine": 106
+      "startLine": 84,
+      "endLine": 107
     },
     "type": "concept",
     "title": "Fibonacci/Lucas and Pell Tripling as Instances",

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-programme",
+    "proofId": "lucas-sequence-degree2-identities-oq-01-oq-01",
+    "range": {
+      "startLine": 6,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Tripling Formulas for Every Lucas-Sequence Pair",
+    "content": "The docstring states the target: the doubling entry (parent OQ-01) proved U₂ₙ = Uₙ·Vₙ and V₂ₙ = Vₙ² − 2·Qⁿ and asked, as its own open question, for the next rung of the index-multiplication ladder — the tripling formulas U₃ₙ and V₃ₙ as polynomials in Uₙ, Vₙ, Qⁿ. This file answers it with U₃ₙ = Uₙ·(Vₙ² − Qⁿ) and V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ). The plan uses no new induction: instantiate the parent's bilinear addition laws at the split 3n = 2n + n, then eliminate the doubled-index values U₂ₙ, V₂ₙ through the doubling formulas. Everything stays over ℤ with no Binet closed form.",
+    "mathContext": "$U_{3n}=U_n(V_n^2-Q^n),\\ V_{3n}=V_n(V_n^2-3Q^n)$; at $(P,Q)=(1,-1)$ these are $F_{3n}=F_n(L_n^2-(-1)^n),\\ L_{3n}=L_n(L_n^2-3(-1)^n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lucas-sequence tripling formulas",
+      "index multiplication (kn) from addition + doubling",
+      "the split 3n = 2n + n",
+      "answering a parent open question"
+    ],
+    "prerequisites": [
+      "the general Lucas sequences Uₙ(P,Q), Vₙ(P,Q)",
+      "the doubling formulas and the bilinear addition laws"
+    ]
+  },
+  {
+    "id": "ann-u-tripling",
+    "proofId": "lucas-sequence-degree2-identities-oq-01-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 62
+    },
+    "type": "tactic",
+    "title": "U₃ₙ = Uₙ·(Vₙ² − Qⁿ): Addition Law meets Doubling",
+    "content": "U_three_mul instantiates bilinear addition law (A), 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ, at (m,n) = (2n, n) via two_U_add, giving 2·U₃ₙ = U₂ₙ·Vₙ + V₂ₙ·Uₙ after the index rewrite 2n + n = 3n. Substituting the doubling formulas hUd (U₂ₙ = Uₙ·Vₙ) and hVd (V₂ₙ = Vₙ² − 2·Qⁿ) turns the right side into Uₙ·Vₙ·Vₙ + (Vₙ² − 2·Qⁿ)·Uₙ = 2·Uₙ·(Vₙ² − Qⁿ), which ring proves as the equality 2·U₃ₙ = 2·(Uₙ·(Vₙ² − Qⁿ)). The common factor 2 is stripped by mul_left_cancel₀ (2 ≠ 0 in ℤ), leaving the stated formula. No induction is used — the doubling values are already available from the parent.",
+    "mathContext": "$2U_{3n}=U_{2n}V_n+V_{2n}U_n=U_nV_n^2+(V_n^2-2Q^n)U_n=2U_n(V_n^2-Q^n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "bilinear addition law (A) at (2n, n)",
+      "substituting the doubling formulas",
+      "ring over ℤ",
+      "cancelling the factor 2 by mul_left_cancel₀"
+    ],
+    "prerequisites": [
+      "two_U_add (addition law A) from parent OQ-02",
+      "U_doubling, V_doubling from parent OQ-01"
+    ]
+  },
+  {
+    "id": "ann-v-tripling",
+    "proofId": "lucas-sequence-degree2-identities-oq-01-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 80
+    },
+    "type": "insight",
+    "title": "V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ): the Master Identity Clears the Residue",
+    "content": "V_three_mul instantiates bilinear addition law (B), 2·V_{m+n} = Vₘ·Vₙ + (P²−4Q)·Uₘ·Uₙ, at (2n, n) via two_V_add, giving 2·V₃ₙ = V₂ₙ·Vₙ + D·U₂ₙ·Uₙ with D = P²−4Q. After substituting the doubling formulas the right side is Vₙ³ − 2·Qⁿ·Vₙ + D·Uₙ²·Vₙ; the target 2·Vₙ·(Vₙ² − 3·Qⁿ) = 2·Vₙ³ − 6·Qⁿ·Vₙ differs by exactly Vₙ³ − 4·Qⁿ·Vₙ − D·Uₙ²·Vₙ. This is Vₙ times the master identity Vₙ² − D·Uₙ² = 4·Qⁿ (V_sq_sub_D_U_sq), so linear_combination (−Vₙ)·hmaster discharges it. The factor 2 is then cancelled by mul_left_cancel₀. The master invariant is the single relation that trades the lone D·Uₙ² term for Vₙ² and Qⁿ.",
+    "mathContext": "Need $D\\,U_n^2 V_n=V_n(V_n^2-4Q^n)$; multiply $V_n^2-D\\,U_n^2=4Q^n$ by $-V_n$ — the linear_combination coefficient.",
+    "significance": "key",
+    "relatedConcepts": [
+      "bilinear addition law (B) at (2n, n)",
+      "the master invariant Vₙ² − D·Uₙ² = 4·Qⁿ",
+      "linear_combination with coefficient −Vₙ",
+      "eliminating the residual D·Uₙ² term"
+    ],
+    "prerequisites": [
+      "two_V_add (addition law B) from parent OQ-02",
+      "V_sq_sub_D_U_sq (master identity) from the grandparent entry"
+    ]
+  },
+  {
+    "id": "ann-specializations",
+    "proofId": "lucas-sequence-degree2-identities-oq-01-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 106
+    },
+    "type": "concept",
+    "title": "Fibonacci/Lucas and Pell Tripling as Instances",
+    "content": "The parameter-general theorems specialize with no extra work: fib_tripling gives F₃ₙ = Fₙ·(Lₙ² − (−1)ⁿ) and lucas_tripling gives L₃ₙ = Lₙ·(Lₙ² − 3·(−1)ⁿ) at (P,Q) = (1,−1); pell_tripling gives U₃ₙ = Uₙ·(Vₙ² − (−1)ⁿ) at (2,−1). A kernel-`decide` numeric check confirms the formulas concretely at n = 2: F₆ = 8 = F₂·(L₂² − 1) = 1·(9 − 1) and L₆ = 18 = L₂·(L₂² − 3) = 3·(9 − 3), without native_decide, keeping the file axiom-free.",
+    "mathContext": "$(P,Q)=(1,-1)$: $F_{3n}=F_n(L_n^2-(-1)^n)$, $L_{3n}=L_n(L_n^2-3(-1)^n)$; $(2,-1)$: Pell tripling.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fibonacci/Lucas special case",
+      "Pell/Pell-Lucas special case",
+      "kernel decide numeric verification"
+    ],
+    "prerequisites": [
+      "the general tripling theorems"
+    ]
+  }
+]

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/index.ts
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LucasSequenceDegree2IdentitiesOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lucasSequenceDegree2IdentitiesOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lucasSequenceDegree2IdentitiesOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lucasSequenceDegree2IdentitiesOQ01OQ01Data: ProofData = {
+  proof: lucasSequenceDegree2IdentitiesOQ01OQ01Proof,
+  annotations: lucasSequenceDegree2IdentitiesOQ01OQ01Annotations,
+}

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/meta.json
@@ -27,22 +27,22 @@
     {
       "id": "tripling-formulas",
       "title": "Section I: The General Tripling Formulas",
-      "startLine": 47,
-      "endLine": 80,
+      "startLine": 49,
+      "endLine": 82,
       "summary": "U_three_mul: U₃ₙ = Uₙ·(Vₙ² − Qⁿ) from addition law (A) at (2n, n) plus the doubling formulas, closed by ring after cancelling 2. V_three_mul: V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ) from addition law (B) at (2n, n) plus doubling, eliminating the residual D·Uₙ² by the master identity via linear_combination (−Vₙ), then cancelling 2.",
       "mathContext": "$U_{3n}=U_n(V_n^2-Q^n)$, $V_{3n}=V_n(V_n^2-3Q^n)$; Fibonacci $F_6=8=F_2(L_2^2-1)=1\\cdot 8$."
     },
     {
       "id": "specializations",
       "title": "Section II: Named Specializations and Numeric Checks",
-      "startLine": 82,
-      "endLine": 106,
+      "startLine": 84,
+      "endLine": 108,
       "summary": "fib_tripling F₃ₙ = Fₙ·(Lₙ² − (−1)ⁿ) and lucas_tripling L₃ₙ = Lₙ·(Lₙ² − 3·(−1)ⁿ) at (1,−1), pell_tripling U₃ₙ = Uₙ·(Vₙ² − (−1)ⁿ) at (2,−1), plus a kernel-decide numeric sanity check (F₆=8, L₆=18 against the tripling formulas at n=2).",
       "mathContext": "The $(P,Q)=(1,-1)$ and $(2,-1)$ instances of the general tripling laws."
     }
   ],
   "conclusion": {
-    "summary": "A fully verified (0 sorries, 0 axioms, kernel decide only — no native_decide) 106-line file with 5 theorems establishing the general Lucas-sequence tripling formulas U₃ₙ = Uₙ·(Vₙ² − Qⁿ), V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ) for the two-parameter Lucas sequences over ℤ. Neither needs a new induction: tripling is the bilinear addition law at 3n = 2n + n composed with the doubling formulas — U is closed by ring, V by a single linear_combination over the master invariant Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ. Fibonacci/Lucas (F₃ₙ = Fₙ·(Lₙ²−(−1)ⁿ), L₃ₙ = Lₙ·(Lₙ²−3(−1)ⁿ)) and Pell tripling are corollaries. #print axioms reports only [propext, Classical.choice, Quot.sound].",
+    "summary": "A fully verified (0 sorries, 0 axioms, kernel decide only — no native_decide) 108-line file with 5 theorems establishing the general Lucas-sequence tripling formulas U₃ₙ = Uₙ·(Vₙ² − Qⁿ), V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ) for the two-parameter Lucas sequences over ℤ. Neither needs a new induction: tripling is the bilinear addition law at 3n = 2n + n composed with the doubling formulas — U is closed by ring, V by a single linear_combination over the master invariant Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ. Fibonacci/Lucas (F₃ₙ = Fₙ·(Lₙ²−(−1)ⁿ), L₃ₙ = Lₙ·(Lₙ²−3(−1)ⁿ)) and Pell tripling are corollaries. #print axioms reports only [propext, Classical.choice, Quot.sound].",
     "implications": "Answers the doubling entry's first open question (the tripling formulas). Combined with doubling, tripling extends the index-multiplication toolkit: U and V at 2n and 3n are now polynomials in Uₙ, Vₙ, Qⁿ, giving the ternary fast-exponentiation step and, via U₃ₙ = Uₙ·(Vₙ² − Qⁿ), the divisibility Uₙ ∣ U₃ₙ — the next case toward the strong divisibility property Uₙ ∣ U_{kn} and gcd(Uₘ,Uₙ) = U_{gcd(m,n)}.",
     "openQuestions": [
       "Prove the general index-multiplication statement Uₙ ∣ U_{kn} for all k (equivalently, that U_{kn}/Uₙ is a polynomial in Uₙ, Vₙ, Qⁿ), unifying doubling and tripling as the k = 2, 3 cases and giving the first step of strong divisibility.",
@@ -87,9 +87,11 @@
       "Proofs.LucasSequenceDegree2IdentitiesOQ01",
       "Proofs.LucasSequenceDegree2IdentitiesOQ02"
     ],
-    "opens": [],
+    "opens": [
+      "LucasSequenceDegree2IdentitiesOQ02"
+    ],
     "namespace": "LucasSequenceDegree2Identities",
-    "lineCount": 106,
+    "lineCount": 108,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,
@@ -142,7 +144,7 @@
       "pell_tripling: the (2,−1) Pell tripling specialization"
     ],
     "axiomCount": 0,
-    "lineCount": 106,
+    "lineCount": 108,
     "assumptions": "0 axioms, 0 sorries, no native_decide. The numeric check uses kernel `decide` (not `native_decide`), so #print axioms reports only [propext, Classical.choice, Quot.sound]. Compiled against Mathlib v4.26.0. The tripling formulas are classical (Lucas, 1878); the contribution is the parameter-general, axiom-free formalization answering the doubling entry's open question, reusing the parent addition laws and doubling formulas with no new induction.",
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "lucas-sequence-degree2-identities-oq-01-oq-01",
+  "slug": "lucas-sequence-degree2-identities-oq-01-oq-01",
+  "title": "General Lucas-Sequence Tripling Formulas: U₃ₙ = Uₙ·(Vₙ² − Qⁿ) and V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ)",
+  "status": "verified",
+  "badge": "original",
+  "description": "The index-tripling formulas for the general two-parameter Lucas sequences Uₙ(P,Q), Vₙ(P,Q) over ℤ, answering the doubling entry's own open question. Both are one-line consequences of the parent's bilinear addition laws at the split 3n = 2n + n, once the doubled-index values are eliminated through the doubling formulas. For U: the law 2·U₃ₙ = U₂ₙ·Vₙ + V₂ₙ·Uₙ, after substituting U₂ₙ = Uₙ·Vₙ and V₂ₙ = Vₙ² − 2·Qⁿ, collapses by ring to 2·Uₙ·(Vₙ² − Qⁿ); cancel the 2. For V: the law 2·V₃ₙ = V₂ₙ·Vₙ + D·U₂ₙ·Uₙ (D = P²−4Q), after the same substitutions, has its sole remaining D·Uₙ² eliminated by the master invariant Vₙ² − D·Uₙ² = 4·Qⁿ via linear_combination, leaving 2·Vₙ·(Vₙ² − 3·Qⁿ). No new induction is required — the whole tripling layer descends from the degree-2 master identity. Specializes to Fibonacci/Lucas tripling F₃ₙ = Fₙ·(Lₙ² − (−1)ⁿ), L₃ₙ = Lₙ·(Lₙ² − 3·(−1)ⁿ) and to Pell. Fully verified: 5 theorems, 0 definitions, 0 sorries, 0 axioms, kernel decide only (no native_decide).",
+  "overview": {
+    "historicalContext": "Index-multiplication formulas are the backbone of fast Lucas-sequence arithmetic. Doubling (2n) enables O(log n) binary fast-exponentiation on the index; tripling (3n) is the next rung, giving the ternary (base-3) step and, more importantly, showing that U and V at any multiplied index kn are polynomials in Uₙ, Vₙ, Qⁿ. For the Fibonacci/Lucas pair (P,Q) = (1,−1) tripling reads F₃ₙ = Fₙ·(Lₙ² − (−1)ⁿ) and L₃ₙ = Lₙ·(Lₙ² − 3·(−1)ⁿ), classical identities going back to Lucas (1878). This entry proves them once for every (P,Q), building directly on the doubling entry (parent OQ-01) and the master-identity entry.",
+    "problemStatement": "Prove, over ℤ for arbitrary parameters P, Q, the general index-tripling formulas U₃ₙ = Uₙ·(Vₙ² − Qⁿ) and V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ) for the fundamental and companion Lucas sequences, as polynomials in Uₙ, Vₙ, Qⁿ, without a Binet closed form or √D. Recover the Fibonacci/Lucas and Pell tripling identities as instances.",
+    "proofStrategy": "Descend from the bilinear addition laws (parent OQ-02) at the split 3n = 2n + n, eliminating the doubled index via doubling (parent OQ-01). (1) U_three_mul: instantiate addition law (A) 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ at (m,n) = (2n, n), giving 2·U₃ₙ = U₂ₙ·Vₙ + V₂ₙ·Uₙ; rewrite U₂ₙ = Uₙ·Vₙ and V₂ₙ = Vₙ² − 2·Qⁿ (doubling), and ring reduces the right side to 2·Uₙ·(Vₙ² − Qⁿ). Cancel the factor 2 with mul_left_cancel₀. (2) V_three_mul: instantiate addition law (B) 2·V_{m+n} = Vₘ·Vₙ + (P²−4Q)·Uₘ·Uₙ at (2n, n), giving 2·V₃ₙ = V₂ₙ·Vₙ + D·U₂ₙ·Uₙ; substitute the two doubling formulas, then eliminate the sole surviving D·Uₙ² term through the master invariant Vₙ² − D·Uₙ² = 4·Qⁿ via linear_combination with coefficient −Vₙ; the residue is 2·Vₙ·(Vₙ² − 3·Qⁿ). Cancel the factor 2.",
+    "keyInsights": [
+      "Tripling needs no induction of its own: it is the addition law at 3n = 2n + n composed with the doubling formulas, so the entire content is one ring identity (for U) and one linear_combination over the master invariant (for V).",
+      "The split 3n = 2n + n is the economical one: it reuses the already-proved doubling values U₂ₙ, V₂ₙ rather than re-deriving them, so tripling is a genuine one-step descent from the degree-2 toolkit.",
+      "For V the only obstruction after substitution is a lone D·Uₙ² term (D = P²−4Q); the master identity Vₙ² − D·Uₙ² = 4·Qⁿ is exactly the relation that trades it for Vₙ² and Qⁿ, which is why linear_combination (−Vₙ)·(master) closes the goal.",
+      "The doubling law U₂ₙ = Uₙ·Vₙ already gives Uₙ ∣ U₂ₙ; tripling gives Uₙ ∣ U₃ₙ (U₃ₙ = Uₙ·(Vₙ² − Qⁿ)), the next case of the strong divisibility Uₙ ∣ U_{kn}.",
+      "The development is uniform in (P,Q): Fibonacci/Lucas tripling F₃ₙ = Fₙ·(Lₙ² − (−1)ⁿ), L₃ₙ = Lₙ·(Lₙ² − 3·(−1)ⁿ) and Pell tripling are the (1,−1) and (2,−1) instances of one parameter-general proof."
+    ],
+    "prerequisites": [
+      "The general Lucas sequences Uₙ(P,Q), Vₙ(P,Q) and the master identity Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ (parent master-identity entry)",
+      "The doubling formulas U₂ₙ = Uₙ·Vₙ, V₂ₙ = Vₙ² − 2·Qⁿ (parent OQ-01)",
+      "The bilinear addition laws 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ and 2·V_{m+n} = Vₘ·Vₙ + (P²−4Q)·Uₘ·Uₙ (parent OQ-02)",
+      "Lean tactics linear_combination, ring, and mul_left_cancel₀ over ℤ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "tripling-formulas",
+      "title": "Section I: The General Tripling Formulas",
+      "startLine": 47,
+      "endLine": 80,
+      "summary": "U_three_mul: U₃ₙ = Uₙ·(Vₙ² − Qⁿ) from addition law (A) at (2n, n) plus the doubling formulas, closed by ring after cancelling 2. V_three_mul: V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ) from addition law (B) at (2n, n) plus doubling, eliminating the residual D·Uₙ² by the master identity via linear_combination (−Vₙ), then cancelling 2.",
+      "mathContext": "$U_{3n}=U_n(V_n^2-Q^n)$, $V_{3n}=V_n(V_n^2-3Q^n)$; Fibonacci $F_6=8=F_2(L_2^2-1)=1\\cdot 8$."
+    },
+    {
+      "id": "specializations",
+      "title": "Section II: Named Specializations and Numeric Checks",
+      "startLine": 82,
+      "endLine": 106,
+      "summary": "fib_tripling F₃ₙ = Fₙ·(Lₙ² − (−1)ⁿ) and lucas_tripling L₃ₙ = Lₙ·(Lₙ² − 3·(−1)ⁿ) at (1,−1), pell_tripling U₃ₙ = Uₙ·(Vₙ² − (−1)ⁿ) at (2,−1), plus a kernel-decide numeric sanity check (F₆=8, L₆=18 against the tripling formulas at n=2).",
+      "mathContext": "The $(P,Q)=(1,-1)$ and $(2,-1)$ instances of the general tripling laws."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, kernel decide only — no native_decide) 106-line file with 5 theorems establishing the general Lucas-sequence tripling formulas U₃ₙ = Uₙ·(Vₙ² − Qⁿ), V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ) for the two-parameter Lucas sequences over ℤ. Neither needs a new induction: tripling is the bilinear addition law at 3n = 2n + n composed with the doubling formulas — U is closed by ring, V by a single linear_combination over the master invariant Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ. Fibonacci/Lucas (F₃ₙ = Fₙ·(Lₙ²−(−1)ⁿ), L₃ₙ = Lₙ·(Lₙ²−3(−1)ⁿ)) and Pell tripling are corollaries. #print axioms reports only [propext, Classical.choice, Quot.sound].",
+    "implications": "Answers the doubling entry's first open question (the tripling formulas). Combined with doubling, tripling extends the index-multiplication toolkit: U and V at 2n and 3n are now polynomials in Uₙ, Vₙ, Qⁿ, giving the ternary fast-exponentiation step and, via U₃ₙ = Uₙ·(Vₙ² − Qⁿ), the divisibility Uₙ ∣ U₃ₙ — the next case toward the strong divisibility property Uₙ ∣ U_{kn} and gcd(Uₘ,Uₙ) = U_{gcd(m,n)}.",
+    "openQuestions": [
+      "Prove the general index-multiplication statement Uₙ ∣ U_{kn} for all k (equivalently, that U_{kn}/Uₙ is a polynomial in Uₙ, Vₙ, Qⁿ), unifying doubling and tripling as the k = 2, 3 cases and giving the first step of strong divisibility.",
+      "Derive the quintupling / general odd-multiple formulas U_{(2j+1)n} from the addition law at (2jn, n) by induction on j, exhibiting the Chebyshev-like recursion in the multiplier."
+    ]
+  },
+  "references": [
+    {
+      "key": "Lucas1878",
+      "citation": "Lucas, É., Théorie des fonctions numériques simplement périodiques, American Journal of Mathematics 1 (1878), 184–240, 289–321.",
+      "type": "article"
+    },
+    {
+      "key": "Ribenboim",
+      "citation": "Ribenboim, P., The New Book of Prime Number Records, Springer (1996), Ch. on Lucas sequences U_n(P,Q), V_n(P,Q): addition, doubling and multiplication formulas.",
+      "type": "book"
+    },
+    {
+      "key": "Williams",
+      "citation": "Williams, H. C., Édouard Lucas and Primality Testing, Canadian Mathematical Society Monographs, Wiley (1998).",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "lucas-sequence-degree2-identities-oq-01",
+      "relation": "Parent entry: proves the doubling formulas U₂ₙ = Uₙ·Vₙ, V₂ₙ = Vₙ² − 2·Qⁿ used to eliminate the doubled index; this entry answers its first open question (the tripling formulas)."
+    },
+    {
+      "proofId": "lucas-sequence-degree2-identities-oq-02",
+      "relation": "Supplies the bilinear addition laws 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ and 2·V_{m+n} = Vₘ·Vₙ + (P²−4Q)·Uₘ·Uₙ, instantiated here at the split 3n = 2n + n."
+    },
+    {
+      "proofId": "lucas-sequence-degree2-identities",
+      "relation": "Grandparent entry: proves the master identity Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ, the sole relation eliminating the residual D·Uₙ² term in the V-tripling proof."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.LucasSequenceDegree2Identities",
+      "Proofs.LucasSequenceDegree2IdentitiesOQ01",
+      "Proofs.LucasSequenceDegree2IdentitiesOQ02"
+    ],
+    "opens": [],
+    "namespace": "LucasSequenceDegree2Identities",
+    "lineCount": 106,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/LucasSequenceDegree2IdentitiesOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_sequence",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LucasSequenceDegree2IdentitiesOQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "lucas-sequences",
+      "fibonacci",
+      "pell",
+      "recurrence",
+      "tripling-formula",
+      "index-multiplication",
+      "addition-law",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "linear_combination",
+        "description": "Eliminates the residual (P²−4Q)·Uₙ² in V_three_mul through the master invariant Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ (coefficient −Vₙ) over ℤ",
+        "module": "Mathlib.Tactic.LinearCombination"
+      },
+      {
+        "theorem": "ring",
+        "description": "Collapses the right side of the U-tripling identity after the addition law and doubling formulas are substituted",
+        "module": "Mathlib.Tactic.Ring"
+      },
+      {
+        "theorem": "mul_left_cancel₀",
+        "description": "Cancels the common factor 2 from 2·U₃ₙ = 2·(…) and 2·V₃ₙ = 2·(…) over the integral domain ℤ",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      }
+    ],
+    "originalContributions": [
+      "U_three_mul: the fundamental tripling formula U₃ₙ = Uₙ·(Vₙ² − Qⁿ), from the addition law at 3n = 2n + n and doubling, closed by ring",
+      "V_three_mul: the companion tripling formula V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ), eliminating the residual D·Uₙ² via the master invariant by linear_combination",
+      "fib_tripling, lucas_tripling: the (1,−1) Fibonacci/Lucas tripling identities",
+      "pell_tripling: the (2,−1) Pell tripling specialization"
+    ],
+    "axiomCount": 0,
+    "lineCount": 106,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The numeric check uses kernel `decide` (not `native_decide`), so #print axioms reports only [propext, Classical.choice, Quot.sound]. Compiled against Mathlib v4.26.0. The tripling formulas are classical (Lucas, 1878); the contribution is the parameter-general, axiom-free formalization answering the doubling entry's open question, reusing the parent addition laws and doubling formulas with no new induction.",
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "prerequisites": [
+      "The doubling formulas U₂ₙ = Uₙ·Vₙ, V₂ₙ = Vₙ² − 2·Qⁿ (parent OQ-01) and the bilinear addition laws (parent OQ-02)",
+      "The master identity Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ (grandparent entry)",
+      "Lean tactics linear_combination, ring, mul_left_cancel₀ over ℤ"
+    ],
+    "relatedProblems": [
+      "lucas-sequence-degree2-identities-oq-01",
+      "lucas-sequence-degree2-identities-oq-02",
+      "lucas-sequence-degree2-identities"
+    ]
+  },
+  "theoremCount": 5,
+  "axiomCount": 0
+}


### PR DESCRIPTION
## General Lucas-Sequence Index-Tripling Formulas

Answers the doubling entry's (parent OQ-01) open question with the next rung of the index-multiplication ladder for the two-parameter Lucas sequences `Uₙ(P,Q)`, `Vₙ(P,Q)` over ℤ:

- **`U₃ₙ = Uₙ·(Vₙ² − Qⁿ)`**
- **`V₃ₙ = Vₙ·(Vₙ² − 3·Qⁿ)`**

### Proof architecture (no Binet closed form, no √D)
Both descend from the parent's **bilinear addition laws** at the split `3n = 2n + n`, after eliminating the doubled-index values via the doubling formulas `U₂ₙ = Uₙ·Vₙ`, `V₂ₙ = Vₙ² − 2·Qⁿ` — **no new induction**. `U` closes by `ring`; `V` eliminates the residual `(P²−4Q)·Uₙ²` term through the master invariant `Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ` via `linear_combination` (coefficient `−Vₙ`).

Specializes to Fibonacci/Lucas tripling `F₃ₙ = Fₙ·(Lₙ²−(−1)ⁿ)`, `L₃ₙ = Lₙ·(Lₙ²−3(−1)ⁿ)` and Pell as the `(1,−1)` and `(2,−1)` instances.

### Verification
- **5 theorems, 0 definitions, 0 sorries, 0 axioms**
- Docker build succeeds (3061 jobs); kernel `decide` only (no `native_decide`)
- `#print axioms`: `[propext, Classical.choice, Quot.sound]` (ordinary foundational only)

Rescued from a crashed research session that committed the work locally but never pushed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)