### PR TITLE
research(erdos-101-oq-01): S20 — extremal function vanishes below size 4 [VERIFIED addition, 0-axiom, +2thm]

### DIFF
--- a/proofs/Proofs/Erdos101OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ01.lean
@@ -1063,4 +1063,52 @@ theorem one_le_maxCountAtSize_four : 1 ≤ maxCountAtSize 4 := by
   rw [hcard4] at hle
   exact le_trans hcount hle
 
+/-! ## S20 ACT: the extremal function vanishes below size four
+
+Section S19 proved the file's first unconditional positive lower bound,
+`one_le_maxCountAtSize_four : 1 ≤ maxCountAtSize 4`.  This section pins the
+*other* side of that threshold.  Below size `4` no point set can host a
+four-point line at all (`fourPointLineCount_lt_four`), so every candidate in
+the supremum defining `maxCountAtSize n` contributes `0`, and hence
+`maxCountAtSize n = 0` for every `n < 4`.
+
+Together with S19 this identifies the exact size at which the extremal function
+first becomes positive: `maxCountAtSize` is `0` at sizes `0,1,2,3` and at least
+`1` at size `4`.  The jump happens precisely at `4`, the smallest cardinality a
+four-point line can occupy — an unconditional, `sorry`-free statement that owes
+nothing to the deferred Solymosi–Stojaković construction.
+
+Sorry count unchanged. Axiom count unchanged (still 0). Theorem count: +2. -/
+
+/-- **The extremal function vanishes below size four.** For every `n < 4` the
+extremal four-point-line count `maxCountAtSize n` is `0`.  No set of fewer than
+four points contains a four-point line (`fourPointLineCount_lt_four`), so every
+element of the set whose supremum defines `maxCountAtSize n` equals `0`; the
+supremum of a subset of `{0}` (or of the empty set) is therefore `0`.  This is
+unconditional and `sorry`-free — the lower companion to
+`one_le_maxCountAtSize_four`. -/
+theorem maxCountAtSize_eq_zero_of_lt_four {n : ℕ} (hn : n < 4) :
+    maxCountAtSize n = 0 := by
+  unfold maxCountAtSize
+  rcases Set.eq_empty_or_nonempty {k : ℕ | ∃ Q : PlanarPointSet,
+      Q.points.card = n ∧ NoFiveCollinear Q ∧ fourPointLineCount Q = k}
+      with he | hne
+  · rw [he]; exact csSup_empty
+  · have hle : sSup {k : ℕ | ∃ Q : PlanarPointSet,
+        Q.points.card = n ∧ NoFiveCollinear Q ∧ fourPointLineCount Q = k} ≤ 0 := by
+      apply csSup_le hne
+      rintro k ⟨Q, hQcard, _, rfl⟩
+      have hlt : Q.points.card < 4 := by rw [hQcard]; exact hn
+      rw [fourPointLineCount_lt_four Q hlt]
+    exact Nat.le_zero.mp hle
+
+/-- **Sharp vanishing threshold of the extremal function.** `maxCountAtSize` is
+`0` at size `3` but at least `1` at size `4`: the extremal four-point-line count
+first becomes positive exactly at the smallest cardinality that can host a
+four-point line.  Combines `maxCountAtSize_eq_zero_of_lt_four` (below) with
+`one_le_maxCountAtSize_four` (at), both unconditional and `sorry`-free. -/
+theorem maxCountAtSize_three_eq_zero_and_four_pos :
+    maxCountAtSize 3 = 0 ∧ 1 ≤ maxCountAtSize 4 :=
+  ⟨maxCountAtSize_eq_zero_of_lt_four (by norm_num), one_le_maxCountAtSize_four⟩
+
 end Erdos101OQ01

--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -24,12 +24,12 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-05-11",
     "axiomCount": 0,
-    "lineCount": 1066,
-    "assumptions": "2 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize, primary ε–N form); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred). S5 (2026-07-01) adds four_point_line_count_not_O_rpow: the strong refutation that the four-point line count is not O(nᵝ) for ANY β < 2 (the witness exponent 2 − C/√(log n) → 2 beats every fixed β < 2), of which erdos_three_halves_conjecture_refuted is the β = 3/2 special case. Its proof is itself sorry-free (adds no new sorry; file remains at 2) but, like the existing refutation theorems, transitively consumes the deferred solymosi_stojakovic_lower_bound (so #print axioms lists sorryAx until that obligation is discharged). The Mathlib-idiom form erdos_101_oq_01_isLittleO is no longer an independent sorry: it is *derived* from the main conjecture via the chain erdos_101_oq_01_conjecture → rate_form ↔ isLittleO_form (lemmas erdos_101_oq_01_conjecture_iff_rate_form and erdos_101_oq_01_rate_form_iff_isLittleO), so the file's open content is the single primary conjecture plus the deferred Solymosi–Stojaković construction. S14 (2026-06-03) unifies the S12 surrogate `maxFourPointLines` with the S13 genuine sup `maxCountAtSize` via the pointwise bridge `maxCountAtSize_le_maxFourPointLines` (uniform lift of `improved_upper_bound`) and propagates the `O(n²)` certificate to the sup via `maxCountAtSize_isBigO_n_squared`. S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness, IsBigO certificates for surrogate + true sup, isLittleOh ↔ Mathlib IsLittleO bridge) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
+    "lineCount": 1114,
+    "assumptions": "2 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize, primary ε–N form); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred). S5 (2026-07-01) adds four_point_line_count_not_O_rpow: the strong refutation that the four-point line count is not O(nᵝ) for ANY β < 2 (the witness exponent 2 − C/√(log n) → 2 beats every fixed β < 2), of which erdos_three_halves_conjecture_refuted is the β = 3/2 special case. Its proof is itself sorry-free (adds no new sorry; file remains at 2) but, like the existing refutation theorems, transitively consumes the deferred solymosi_stojakovic_lower_bound (so #print axioms lists sorryAx until that obligation is discharged). The Mathlib-idiom form erdos_101_oq_01_isLittleO is no longer an independent sorry: it is *derived* from the main conjecture via the chain erdos_101_oq_01_conjecture → rate_form ↔ isLittleO_form (lemmas erdos_101_oq_01_conjecture_iff_rate_form and erdos_101_oq_01_rate_form_iff_isLittleO), so the file's open content is the single primary conjecture plus the deferred Solymosi–Stojaković construction. S14 (2026-06-03) unifies the S12 surrogate `maxFourPointLines` with the S13 genuine sup `maxCountAtSize` via the pointwise bridge `maxCountAtSize_le_maxFourPointLines` (uniform lift of `improved_upper_bound`) and propagates the `O(n²)` certificate to the sup via `maxCountAtSize_isBigO_n_squared`. S20 (2026-07-01) pins the vanishing threshold of the extremal function: `maxCountAtSize_eq_zero_of_lt_four` proves `maxCountAtSize n = 0` for every `n < 4` (no set of fewer than four points hosts a four-point line, via `fourPointLineCount_lt_four`), and `maxCountAtSize_three_eq_zero_and_four_pos` packages it with the S19 bound `one_le_maxCountAtSize_four` to show the count is `0` at size `3` but `≥ 1` at size `4` — the extremal function first becomes positive exactly at size `4`. Both are unconditional and sorry-free, adding no new sorry. S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness, IsBigO certificates for surrogate + true sup, isLittleOh ↔ Mathlib IsLittleO bridge) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 21,
+    "theoremCount": 23,
     "definitionCount": 7,
-    "substantiveTheoremCount": 18
+    "substantiveTheoremCount": 20
   },
   "sections": [
     {
@@ -169,9 +169,9 @@
       "Classical"
     ],
     "namespace": "Erdos101OQ01",
-    "lineCount": 1066,
+    "lineCount": 1114,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 27,
     "definitionCount": 7,
     "path": "Proofs/Erdos101OQ01.lean",
     "sorries": 2


### PR DESCRIPTION
## Summary

Extends the Erdős #101 OQ-01 formalization (four-point lines in no-five-collinear planar sets) with **S20**, complementing the S19 lower bound.

- **S19** (already in the file): `one_le_maxCountAtSize_four : 1 ≤ maxCountAtSize 4` — the first unconditional positive lower bound on the extremal function.
- **S20** (this PR): pins the *other* side of that threshold.

**New theorems:**

- **`maxCountAtSize_eq_zero_of_lt_four`** — `maxCountAtSize n = 0` for every `n < 4`. No set of fewer than four points can host a four-point line (`fourPointLineCount_lt_four`), so every candidate in the supremum defining `maxCountAtSize n` contributes `0`; the sup of a subset of `{0}` (or of `∅`) is `0`.
- **`maxCountAtSize_three_eq_zero_and_four_pos`** — packages it with S19: `maxCountAtSize 3 = 0 ∧ 1 ≤ maxCountAtSize 4`. The extremal four-point-line count first becomes positive **exactly at size 4**, the smallest cardinality a four-point line can occupy.

## Verification

- `lean` compiled `Proofs/Erdos101OQ01.lean` against Mathlib + `Proofs.Erdos101Problem` with **exit code 0**.
- Both new theorems are **unconditional, sorry-free, and axiom-free** — they do not touch the file's two pre-existing sorries (the primary open conjecture `erdos_101_oq_01` and the deferred `solymosi_stojakovic_lower_bound`), which remain unchanged. The `sorry` warnings at lines 113/588 are those pre-existing obligations.
- Entry status stays `axiomatized` (2 deferred sorries). Meta updated: `theoremCount` 21→23, `substantiveTheoremCount` 18→20, `lineCount`→1114; `leanFile` counts 25→27 theorems.

## Scope

Modifies only `Erdos101OQ01.lean` (adds the S20 section) and its `meta.json`. No other entries touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)