### PR TITLE
research(dirichlet-approximation-theorem-oq-04-oq-02): inhomogeneous Kronecker / minimality of the irrational rotation [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DirichletApproximationOQ04OQ02.lean
+++ b/proofs/Proofs/DirichletApproximationOQ04OQ02.lean
@@ -1,0 +1,102 @@
+/-
+  Inhomogeneous Kronecker Approximation: Minimality of the Irrational Rotation
+  (research problem: dirichlet-approximation-theorem-oq-04-oq-02)
+
+  The parent entry `dirichlet-approximation-theorem-oq-04` proves the *homogeneous* form of
+  Kronecker's density theorem: for a real number `a`, the integer multiples `{n • a : n ∈ ℤ}`,
+  viewed on the circle `ℝ/ℤ = AddCircle 1`, are dense iff `a` is irrational, and consequently the
+  fractional parts `{n·a}` accumulate at the single point `0` (the multiples come arbitrarily
+  close to *integers*).
+
+  This entry upgrades that to the *inhomogeneous* theorem — the genuine one-dimensional case of
+  Kronecker's approximation theorem, and equivalently the statement that an irrational rotation of
+  the circle is **minimal** (every orbit is dense, not just the orbit of `0`):
+
+  **Topological form (minimality).**  For irrational `a` and *any* base point `b : AddCircle 1`,
+  the shifted orbit is still dense:
+
+        DenseRange (fun n : ℤ => (n • a : AddCircle 1) + b).
+
+  This is strictly stronger than `oq-04`, which is the special case `b = 0`.  It says the closure
+  of every orbit is the whole circle, i.e. the rotation `x ↦ x + a` has no proper closed invariant
+  subset — it is minimal.
+
+  **Diophantine form (inhomogeneous approximation).**  For irrational `a`, *any* target real
+  number `β`, and every `ε > 0` there is an integer `n` whose multiple `n·a` approximates `β`
+  modulo `1`:
+
+        ∃ n : ℤ,  |n·a − β − round (n·a − β)|  <  ε.
+
+  Here `|x − round x|` is the distance from `x` to the nearest integer, i.e. the circle-norm
+  `‖(x : AddCircle 1)‖` (`AddCircle.norm_eq` at period `1`).  The homogeneous `oq-04` corollary is
+  the case `β = 0`; the inhomogeneous statement says the fractional parts `{n·a}` are dense in the
+  whole interval, not merely accumulating at `0`.
+
+  **Proof idea.**  Both statements descend from the homogeneous density
+  `DenseRange (fun n : ℤ => (n • a : AddCircle 1))` proved in `oq-04`.
+  * Minimality: translation `x ↦ x + b` on the circle is a continuous surjection, so it has dense
+    range; composing a dense-range map with it (via `DenseRange.comp`) keeps the range dense.
+  * Approximation: a dense set meets every ball, in particular the `ε`-ball around the point
+    `(β : AddCircle 1)`; reading the resulting circle-distance back as distance-to-nearest-integer
+    gives the bound.
+
+  No new axioms; everything reduces to the `oq-04` density statement and Mathlib's `AddCircle` API.
+-/
+import Mathlib
+
+open Metric
+
+namespace DirichletApproximationOQ04OQ02
+
+/-- **Homogeneous Kronecker density** (imported from `oq-04`).  The integer multiples of an
+irrational `a`, taken on the circle `ℝ/ℤ = AddCircle 1`, are dense.  This is the period-`1` case of
+`AddCircle.denseRange_zsmul_coe_iff` (`a / 1 = a`). -/
+theorem denseRange_zsmul_of_irrational {a : ℝ} (ha : Irrational a) :
+    DenseRange (fun n : ℤ => (↑(n • a) : AddCircle (1 : ℝ))) := by
+  have h := AddCircle.denseRange_zsmul_coe_iff (a := a) (p := (1 : ℝ))
+  rw [div_one] at h
+  exact h.mpr ha
+
+/-- **Minimality of the irrational rotation.**  For irrational `a` and *any* base point
+`b : AddCircle 1`, the shifted orbit `{n • a + b : n ∈ ℤ}` is dense.  Equivalently, the rotation
+`x ↦ x + a` of the circle is minimal: every orbit is dense, not just the orbit of `0`
+(which is `oq-04`, the case `b = 0`). -/
+theorem denseRange_zsmul_add_of_irrational {a : ℝ} (ha : Irrational a) (b : AddCircle (1 : ℝ)) :
+    DenseRange (fun n : ℤ => (↑(n • a) : AddCircle (1 : ℝ)) + b) := by
+  -- Translation `x ↦ x + b` is a continuous surjection, hence has dense range.
+  have hsurj : Function.Surjective (fun x : AddCircle (1 : ℝ) => x + b) :=
+    fun y => ⟨y - b, by simp⟩
+  have hgdense : DenseRange (fun x : AddCircle (1 : ℝ) => x + b) := hsurj.denseRange
+  have hgcont : Continuous (fun x : AddCircle (1 : ℝ) => x + b) := by fun_prop
+  -- Compose the dense homogeneous orbit with the translation.
+  have := hgdense.comp (denseRange_zsmul_of_irrational ha) hgcont
+  simpa [Function.comp] using this
+
+/-- **Inhomogeneous Kronecker / Dirichlet approximation.**  If `a` is irrational then its integer
+multiples approximate *every* real number `β` modulo `1`: for every `ε > 0` there is an integer `n`
+with `|n·a − β − round (n·a − β)| < ε`.  The quantity `|x − round x|` is the distance from `x` to
+the nearest integer, equivalently the circle-norm `‖(x : AddCircle 1)‖`.  The homogeneous `oq-04`
+corollary is the special case `β = 0`. -/
+theorem exists_int_zsmul_sub_round_lt {a : ℝ} (ha : Irrational a) (β : ℝ) {ε : ℝ} (hε : 0 < ε) :
+    ∃ n : ℤ, |(n : ℝ) * a - β - round ((n : ℝ) * a - β)| < ε := by
+  -- The homogeneous orbit is dense on the circle.
+  have hd : DenseRange (fun n : ℤ => (↑(n • a) : AddCircle (1 : ℝ))) :=
+    denseRange_zsmul_of_irrational ha
+  -- The `ε`-ball around the target point `(β : AddCircle 1)` is open and nonempty.
+  have hUopen : IsOpen (ball (↑β : AddCircle (1 : ℝ)) ε) := isOpen_ball
+  have hUne : (ball (↑β : AddCircle (1 : ℝ)) ε).Nonempty := ⟨_, mem_ball_self hε⟩
+  -- Density meets the ball: some `k • a` lands within `ε` of `β`.
+  obtain ⟨k, hk⟩ := hd.exists_mem_open hUopen hUne
+  -- Turn the circle-distance into the circle-norm of `↑(k·a − β)`.
+  have hdist : ‖(↑((k : ℝ) * a - β) : AddCircle (1 : ℝ))‖ < ε := by
+    have hmem := hk
+    simp only [mem_ball, dist_eq_norm] at hmem
+    rwa [zsmul_eq_mul, ← AddCircle.coe_sub] at hmem
+  refine ⟨k, ?_⟩
+  -- Read the circle-norm back as distance to the nearest integer.
+  have key : ‖(↑((k : ℝ) * a - β) : AddCircle (1 : ℝ))‖
+      = |(k : ℝ) * a - β - round ((k : ℝ) * a - β)| := by
+    rw [AddCircle.norm_eq, inv_one, one_mul, mul_one]
+  rwa [key] at hdist
+
+end DirichletApproximationOQ04OQ02

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04-oq-02/annotations.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": "ann-dirichlet-oq04oq02-header",
+    "proofId": "dirichlet-approximation-theorem-oq-04-oq-02",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "concept",
+    "title": "From One Dense Orbit to a Minimal Rotation",
+    "content": "The docstring frames this entry as the inhomogeneous upgrade of the parent OQ-04. OQ-04 proves HOMOGENEOUS density: the orbit {n·a} of the base point 0 is dense mod 1 iff a is irrational, so multiples accumulate only at integers. This entry proves the two stronger inhomogeneous statements: (topological) minimality — for ANY base point b the shifted orbit {n·a + b} is dense, so the irrational rotation x ↦ x + a has no proper closed invariant subset; and (Diophantine) inhomogeneous approximation — the multiples approach ANY target β modulo 1. Both descend from the OQ-04 homogeneous density with no new axioms, minimality by composing with the translation x ↦ x + b and approximation by feeding density the ε-ball around ↑β.",
+    "mathContext": "Minimality: $\\operatorname{DenseRange}(n \\mapsto n\\cdot a + b)$ for every $b$; approximation: $\\exists n,\\ |na - \\beta - \\operatorname{round}(na - \\beta)| < \\varepsilon$.",
+    "prerequisites": [
+      "The circle ℝ/ℤ = AddCircle 1 and irrational rotations",
+      "Homogeneous Kronecker density (parent OQ-04)"
+    ],
+    "relatedConcepts": [
+      "Kronecker's approximation theorem",
+      "minimal dynamical systems",
+      "irrational rotation",
+      "inhomogeneous Diophantine approximation"
+    ],
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-dirichlet-oq04oq02-seed",
+    "proofId": "dirichlet-approximation-theorem-oq-04-oq-02",
+    "range": { "startLine": 51, "endLine": 58 },
+    "type": "technique",
+    "title": "Homogeneous Density Seed (period-1 specialisation)",
+    "content": "denseRange_zsmul_of_irrational re-establishes the homogeneous density both upgrades rely on. Mathlib's AddCircle.denseRange_zsmul_coe_iff says the multiples of a are dense on the circle of length p iff a/p is irrational; specialising to p = 1 and rewriting div_one collapses the side condition a/1 = a to Irrational a. This is exactly the parent OQ-04 headline, reused here as the seed for the minimality and approximation upgrades.",
+    "mathContext": "$\\operatorname{DenseRange}\\,(n \\mapsto n \\cdot a : \\mathbb{Z} \\to \\mathbb{R}/\\mathbb{Z})$ for $a \\notin \\mathbb{Q}$, via $a/1 = a$.",
+    "prerequisites": [
+      "AddCircle.denseRange_zsmul_coe_iff",
+      "div_one rewriting"
+    ],
+    "relatedConcepts": [
+      "Kronecker density",
+      "AddCircle API"
+    ],
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-dirichlet-oq04oq02-minimality",
+    "proofId": "dirichlet-approximation-theorem-oq-04-oq-02",
+    "range": { "startLine": 60, "endLine": 73 },
+    "type": "key-insight",
+    "title": "Minimality: Density Transports Along the Translation",
+    "content": "denseRange_zsmul_add_of_irrational is the core original result. It upgrades single-orbit density (of the point 0) to ALL-orbit density using the group structure of the circle: every point is a translate of 0, so post-composing the dense homogeneous orbit with the translation x ↦ x + b keeps density. Concretely the translation is surjective (explicit inverse y ↦ y − b gives Function.Surjective.denseRange) and continuous (fun_prop), so DenseRange.comp of the homogeneous orbit with it yields DenseRange (n ↦ ↑(n • a) + b) after simp [Function.comp]. This is the topological statement that the irrational rotation is MINIMAL — no proper closed invariant subset — and it contains the parent OQ-04 as the special case b = 0. The pattern (transport density along a transitive continuous group action by a single composition) needs no new metric analysis.",
+    "mathContext": "For irrational $a$ and any $b$: $\\operatorname{DenseRange}\\,(n \\mapsto n\\cdot a + b)$; equivalently the rotation $x \\mapsto x + a$ is minimal.",
+    "prerequisites": [
+      "DenseRange.comp and Function.Surjective.denseRange",
+      "Continuity of circle translation (fun_prop)"
+    ],
+    "relatedConcepts": [
+      "minimal systems",
+      "topological transitivity",
+      "group actions on compact spaces"
+    ],
+    "significance": "central"
+  },
+  {
+    "id": "ann-dirichlet-oq04oq02-approximation",
+    "proofId": "dirichlet-approximation-theorem-oq-04-oq-02",
+    "range": { "startLine": 75, "endLine": 100 },
+    "type": "key-insight",
+    "title": "Inhomogeneous Approximation: the Circle Norm is Distance to ℤ",
+    "content": "exists_int_zsmul_sub_round_lt turns density into a concrete inhomogeneous bound. The ε-ball ball (↑β) ε around the target point is open (isOpen_ball) and nonempty (mem_ball_self hε), so DenseRange.exists_mem_open meets it at some ↑(k • a). Unfolding mem_ball / dist_eq_norm and rewriting zsmul_eq_mul and ← AddCircle.coe_sub turns membership into ‖(↑(k·a − β) : AddCircle 1)‖ < ε. The final step reads this circle norm back as distance to the nearest integer: AddCircle.norm_eq at period 1 (with inv_one, one_mul, mul_one) gives ‖(x : AddCircle 1)‖ = |x − round x|, so the goal |k·a − β − round(k·a − β)| < ε follows with witness n = k. Setting β = 0 recovers the parent OQ-04's homogeneous one-sided bound; general β is the genuine inhomogeneous Kronecker approximation.",
+    "mathContext": "For irrational $a$, any $\\beta$, $\\varepsilon > 0$: $\\exists n,\\ |na - \\beta - \\operatorname{round}(na - \\beta)| < \\varepsilon$; the circle norm $\\|(x:\\mathbb{R}/\\mathbb{Z})\\| = |x - \\operatorname{round} x|$.",
+    "prerequisites": [
+      "DenseRange.exists_mem_open",
+      "AddCircle.norm_eq and AddCircle.coe_sub"
+    ],
+    "relatedConcepts": [
+      "inhomogeneous Diophantine approximation",
+      "circle norm as distance to nearest integer",
+      "Kronecker's theorem"
+    ],
+    "significance": "central"
+  }
+]

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04-oq-02/index.ts
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DirichletApproximationOQ04OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const dirichletApproximationTheoremOq04Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const dirichletApproximationTheoremOq04Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const dirichletApproximationTheoremOq04Oq02Data: ProofData = {
+  proof: dirichletApproximationTheoremOq04Oq02Proof,
+  annotations: dirichletApproximationTheoremOq04Oq02Annotations,
+}

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04-oq-02/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "dirichlet-approximation-theorem-oq-04-oq-02",
+  "slug": "dirichlet-approximation-theorem-oq-04-oq-02",
+  "title": "Dirichlet Approximation OQ-04-OQ-02: Minimality of the Irrational Rotation (Inhomogeneous Kronecker)",
+  "description": "Upgrades the homogeneous Kronecker density of the parent OQ-04 — where {n·a} accumulates only at the single point 0 — to the inhomogeneous theorem: for irrational a and ANY base point b on the circle ℝ/ℤ = AddCircle 1, the shifted orbit {n·a + b : n ∈ ℤ} is still dense. Equivalently, the irrational rotation x ↦ x + a is MINIMAL — every orbit is dense, not just the orbit of 0. The Diophantine reading is inhomogeneous Dirichlet approximation: for any target β and every ε > 0 there is an integer n with |n·a − β − round(n·a − β)| < ε, i.e. the multiples of a approximate every real modulo 1, not merely integers. Both statements descend from the OQ-04 homogeneous density DenseRange (n ↦ ↑(n • a)) on AddCircle 1: minimality by composing the dense homogeneous orbit with the continuous surjective translation x ↦ x + b (DenseRange.comp), and the approximation bound by intersecting the dense orbit with the ε-ball around ↑β and reading the circle-norm ‖(x : AddCircle 1)‖ back as distance-to-nearest-integer |x − round x| (AddCircle.norm_eq at period 1). Verified sorry-free and axiom-free.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Metric"],
+    "namespace": "DirichletApproximationOQ04OQ02",
+    "lineCount": 102,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/DirichletApproximationOQ04OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Kronecker%27s_theorem",
+    "date": "1884",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DirichletApproximationOQ04OQ02.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-approximation",
+      "kronecker-density",
+      "inhomogeneous-approximation",
+      "irrational-rotation",
+      "minimality",
+      "topological-dynamics",
+      "equidistribution"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "denseRange_zsmul_add_of_irrational: MINIMALITY of the irrational rotation — for irrational a and ANY base point b : AddCircle 1 the shifted orbit {n·a + b} is dense — obtained by composing the homogeneous OQ-04 density with the continuous surjective translation x ↦ x + b (DenseRange.comp). This is strictly stronger than OQ-04, which is the special case b = 0, and expresses that the rotation has no proper closed invariant subset.",
+      "exists_int_zsmul_sub_round_lt: the INHOMOGENEOUS Dirichlet/Kronecker approximation corollary — for irrational a, ANY target β, and every ε > 0 there is an integer n with |n·a − β − round(n·a − β)| < ε — proved by meeting the dense homogeneous orbit with the ε-ball around ↑β and reading the circle-norm ‖(↑(k·a − β) : AddCircle 1)‖ back as distance to the nearest integer via AddCircle.norm_eq at period 1 (inv_one, one_mul, mul_one). The homogeneous OQ-04 bound is the special case β = 0.",
+      "denseRange_zsmul_of_irrational: the period-1 specialisation of AddCircle.denseRange_zsmul_coe_iff (a/1 = a) supplying the homogeneous density seed both upgrades rest on."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "AddCircle.denseRange_zsmul_coe_iff",
+        "description": "Multiples of a are dense on the circle of length p iff a/p is irrational. Specialised at p = 1 (a/1 = a) to give the homogeneous density seed denseRange_zsmul_of_irrational.",
+        "module": "Mathlib.Dynamics.Circle.RotationNumber.TranslationNumber"
+      },
+      {
+        "theorem": "DenseRange.comp",
+        "description": "The composition of a dense-range map with a continuous dense-range (here surjective) map has dense range; the engine of the minimality upgrade — post-composing the homogeneous orbit with the translation x ↦ x + b.",
+        "module": "Mathlib.Topology.DenseEmbedding"
+      },
+      {
+        "theorem": "Function.Surjective.denseRange",
+        "description": "A surjective map has dense range; applied to the circle translation x ↦ x + b (surjective with explicit inverse y ↦ y − b) to feed DenseRange.comp.",
+        "module": "Mathlib.Topology.DenseEmbedding"
+      },
+      {
+        "theorem": "DenseRange.exists_mem_open",
+        "description": "A dense range meets every nonempty open set; applied to the ε-ball B(↑β, ε) to extract the approximating multiple ↑(k·a) within ε of the target point ↑β.",
+        "module": "Mathlib.Topology.DenseEmbedding"
+      },
+      {
+        "theorem": "AddCircle.norm_eq / AddCircle.coe_sub",
+        "description": "The AddCircle normed-group API: at period 1, ‖(x : AddCircle 1)‖ = |x − round x|, and ↑(u − v) = ↑u − ↑v; used to convert the ball-membership distance into the circle-norm of ↑(k·a − β) and then read it back as distance to the nearest integer.",
+        "module": "Mathlib.Topology.Instances.AddCircle"
+      }
+    ],
+    "relatedProblems": [
+      {
+        "id": "dirichlet-approximation-theorem-oq-04",
+        "relationship": "Parent entry: proves the HOMOGENEOUS Kronecker density — the orbit {n·a} of the base point 0 is dense mod 1 iff a is irrational, so {n·a} accumulates only at integers. This OQ-04-OQ-02 upgrades that to MINIMALITY: every orbit {n·a + b} is dense (the b = 0 case is exactly OQ-04), and derives the inhomogeneous approximation |n·a − β − round(n·a − β)| < ε for arbitrary target β (the β = 0 case is OQ-04's homogeneous bound)."
+      },
+      {
+        "id": "dirichlet-approximation-theorem-oq-05",
+        "relationship": "Sibling entry: the dual SHARPNESS lower bound (the golden ratio is badly approximable). This entry shows every irrational rotation is minimal so every target is approximable modulo 1; OQ-05 shows for φ the approximation cannot be too fast — bounding orbit behaviour qualitatively and quantitatively."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 102,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational propext / Classical.choice / Quot.sound are used (no Lean.ofReduceBool, no native_decide; verifiable with #print axioms denseRange_zsmul_add_of_irrational and #print axioms exists_int_zsmul_sub_round_lt). All three results are unconditional. Mathlib supplies AddCircle.denseRange_zsmul_coe_iff (density of multiples on a circle ⟺ irrationality of a/p), the DenseRange API (DenseRange.comp, Function.Surjective.denseRange, DenseRange.exists_mem_open), and the AddCircle normed-group API (AddCircle.norm_eq giving ‖(x : AddCircle 1)‖ = |x − round x|, AddCircle.coe_sub). The original in-file content is the minimality upgrade via composition with the translation and the inhomogeneous approximation extraction reading the circle norm back as distance to the nearest integer.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Kronecker's approximation theorem (1884) in its full one-dimensional form is inhomogeneous: for irrational a and any real β, the multiples n·a approach β modulo 1 arbitrarily closely. The homogeneous case β = 0 (the multiples approach integers) is the qualitative seed of uniform distribution refined by Weyl (1916). Dynamically the two forms correspond to the two faces of the same map x ↦ x + a on the circle ℝ/ℤ: the homogeneous density is that the orbit of 0 is dense, while the inhomogeneous density is the stronger statement that EVERY orbit is dense — that the irrational rotation is minimal (has no proper closed invariant subset). A rational rotation a = p/q is periodic with a finite orbit of q evenly spaced points, so minimality exactly detects irrationality.",
+    "problemStatement": "Upgrade the parent OQ-04 (homogeneous Kronecker density, the orbit of 0) to the inhomogeneous theorem. Show that for irrational $a$ and ANY base point $b \\in \\mathbb{R}/\\mathbb{Z}$ the shifted orbit $\\{n a + b : n \\in \\mathbb{Z}\\}$ is dense — i.e. the irrational rotation is minimal — and deduce inhomogeneous Dirichlet approximation: for any target $\\beta$ and every $\\varepsilon > 0$ there is an integer $n$ with\n\n$$\\left| n a - \\beta - \\operatorname{round}(n a - \\beta) \\right| < \\varepsilon,$$\n\ni.e. $\\{n a\\}$ comes within $\\varepsilon$ of $\\beta$ modulo $1$.",
+    "text": "The parent OQ-04 formalised the homogeneous density DenseRange (n ↦ ↑(n • a)) on AddCircle 1 and its β = 0 approximation corollary. This entry closes the inhomogeneous gap in two short but genuinely stronger steps that Mathlib does not package together: (1) minimality, by post-composing the homogeneous orbit with the continuous surjective translation x ↦ x + b and invoking DenseRange.comp; (2) inhomogeneous approximation, by meeting the dense orbit with the ε-ball around the target point ↑β and reading the circle norm ‖(x : AddCircle 1)‖ back as the distance |x − round x| from x to the nearest integer.",
+    "proofStrategy": "denseRange_zsmul_of_irrational is AddCircle.denseRange_zsmul_coe_iff at p = 1 rewritten with a/1 = a. denseRange_zsmul_add_of_irrational: the translation x ↦ x + b is surjective (explicit inverse y ↦ y − b), hence dense-range (Function.Surjective.denseRange) and continuous (fun_prop); DenseRange.comp of the homogeneous orbit with this translation gives density of n ↦ ↑(n • a) + b (simp [Function.comp]). exists_int_zsmul_sub_round_lt: from homogeneous density hd, the ε-ball ball (↑β) ε is open (isOpen_ball) and nonempty (mem_ball_self); DenseRange.exists_mem_open yields k with ↑(k • a) in the ball; unfolding mem_ball / dist_eq_norm and rewriting zsmul_eq_mul and ← AddCircle.coe_sub gives ‖(↑(k·a − β) : AddCircle 1)‖ < ε; finally AddCircle.norm_eq at period 1 (inv_one, one_mul, mul_one) rewrites this norm as |k·a − β − round(k·a − β)|, closing the goal with witness n = k.",
+    "keyInsights": [
+      "**Minimality is the inhomogeneous face of Kronecker density**: OQ-04 shows the orbit of the single point 0 is dense; this entry shows the orbit of EVERY point b is dense, which is the dynamical statement that the irrational rotation x ↦ x + a has no proper closed invariant subset — strictly stronger than the homogeneous case it specialises to at b = 0.",
+      "**Translation transports density for free**: the group structure of the circle means every point is a translate of 0, so post-composing the homogeneous dense orbit with the continuous surjective translation x ↦ x + b (via DenseRange.comp) upgrades density-of-one-orbit to density-of-all-orbits without any new analysis.",
+      "**The circle norm IS distance to the nearest integer**: on AddCircle 1, AddCircle.norm_eq gives ‖(x : AddCircle 1)‖ = |x − round x|, so the metric statement 'some k·a lands in the ε-ball around ↑β' is literally the Diophantine statement |k·a − β − round(k·a − β)| < ε — an inhomogeneous approximation.",
+      "**Inhomogeneous ⊋ homogeneous**: setting β = 0 recovers the parent's one-sided bound and setting b = 0 recovers the parent's density, so OQ-04 sits inside this entry as the two special cases at the origin."
+    ],
+    "prerequisites": [
+      "Mathlib's AddCircle API: AddCircle.denseRange_zsmul_coe_iff (multiples dense on the length-p circle ⟺ a/p irrational), the normed-group structure on AddCircle, AddCircle.norm_eq (‖(x:AddCircle p)‖ as distance to the nearest lattice point), and AddCircle.coe_sub",
+      "The DenseRange API: DenseRange.comp (composition with a continuous dense-range map stays dense), Function.Surjective.denseRange, and DenseRange.exists_mem_open (a dense range meets every nonempty open set)",
+      "Elementary facts: round x as the nearest integer, that a circle translation x ↦ x + b is a homeomorphism with inverse y ↦ y − b, and the identification of ball-membership distance with the circle norm"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: From One Dense Orbit to a Minimal Rotation",
+      "startLine": 1,
+      "endLine": 44,
+      "mathContext": "$\\operatorname{DenseRange}(n \\mapsto n\\cdot a + b)$ for every $b$, with the inhomogeneous corollary $\\exists n,\\ |na - \\beta - \\operatorname{round}(na - \\beta)| < \\varepsilon$.",
+      "summary": "Module docstring: frames OQ-04-OQ-02 as the inhomogeneous upgrade of the parent's homogeneous Kronecker density. States both results — minimality (every orbit {n·a + b} dense) and inhomogeneous approximation (multiples approach any target β mod 1) — and the proof idea: both descend from the OQ-04 homogeneous density, minimality by composing with the translation x ↦ x + b and approximation by feeding density the ε-ball around ↑β. Imports Mathlib, opens Metric."
+    },
+    {
+      "id": "homogeneous-seed",
+      "title": "Homogeneous Density Seed (period-1 specialisation of OQ-04)",
+      "startLine": 51,
+      "endLine": 58,
+      "mathContext": "$\\operatorname{DenseRange}\\,(n \\mapsto n \\cdot a : \\mathbb{Z} \\to \\mathbb{R}/\\mathbb{Z})$ for $a \\notin \\mathbb{Q}$.",
+      "summary": "denseRange_zsmul_of_irrational re-establishes the homogeneous density both upgrades rely on: AddCircle.denseRange_zsmul_coe_iff specialised to the unit circle via a/1 = a. The orbit {n·a} of the base point 0 is dense mod 1 exactly when a is irrational."
+    },
+    {
+      "id": "minimality",
+      "title": "Minimality: Every Orbit of the Irrational Rotation is Dense",
+      "startLine": 60,
+      "endLine": 73,
+      "mathContext": "For irrational $a$ and any $b : \\mathbb{R}/\\mathbb{Z}$: $\\operatorname{DenseRange}\\,(n \\mapsto n \\cdot a + b)$.",
+      "summary": "denseRange_zsmul_add_of_irrational upgrades single-orbit density to all-orbit density. The circle translation x ↦ x + b is surjective (explicit inverse y ↦ y − b, Function.Surjective.denseRange) and continuous (fun_prop); DenseRange.comp of the homogeneous orbit with this translation gives density of n ↦ ↑(n • a) + b (simp [Function.comp]). This says the irrational rotation is minimal — no proper closed invariant subset — and contains OQ-04 as the special case b = 0."
+    },
+    {
+      "id": "inhomogeneous-approximation",
+      "title": "Inhomogeneous Dirichlet Approximation from Orbit Density",
+      "startLine": 75,
+      "endLine": 100,
+      "mathContext": "For irrational $a$, any $\\beta$, and $\\varepsilon > 0$: $\\exists\\, n,\\ |n a - \\beta - \\operatorname{round}(n a - \\beta)| < \\varepsilon$.",
+      "summary": "exists_int_zsmul_sub_round_lt turns density into a concrete inhomogeneous bound. The ε-ball ball (↑β) ε is open (isOpen_ball) and nonempty (mem_ball_self); DenseRange.exists_mem_open meets it at some ↑(k • a). Unfolding mem_ball / dist_eq_norm and rewriting zsmul_eq_mul and ← AddCircle.coe_sub gives ‖(↑(k·a − β) : AddCircle 1)‖ < ε. Reading the circle norm back as distance to the nearest integer (AddCircle.norm_eq at period 1: inv_one, one_mul, mul_one) yields |k·a − β − round(k·a − β)| < ε with witness n = k. The homogeneous OQ-04 bound is the special case β = 0."
+    }
+  ],
+  "conclusion": {
+    "summary": "The inhomogeneous form of Kronecker's approximation theorem is formalised sorry-free and axiom-free. For irrational a the irrational rotation x ↦ x + a of the circle ℝ/ℤ is minimal: every orbit {n·a + b} is dense, obtained by composing the homogeneous OQ-04 orbit with the continuous surjective translation x ↦ x + b. Equivalently, the multiples of a approximate every real β modulo 1 — for every ε > 0 some integer n has |n·a − β − round(n·a − β)| < ε — by meeting the dense orbit with the ε-ball around ↑β and reading the circle norm as distance to the nearest integer. The parent OQ-04 is recovered as the two special cases b = 0 (density) and β = 0 (approximation).",
+    "implications": [
+      "Establishes that an irrational rotation of the circle is topologically minimal, the qualitative foundation on which unique ergodicity and equidistribution (Weyl) are built.",
+      "Provides the inhomogeneous Dirichlet/Kronecker approximation bound |n·a − β − round(n·a − β)| < ε for arbitrary targets β, generalising the parent's homogeneous β = 0 statement.",
+      "Shows the group structure of the circle reduces all-orbit density to single-orbit density by a single translation, a reusable pattern for transporting density along a transitive group action."
+    ],
+    "openQuestions": [
+      "Quantify the inhomogeneous rate: for badly-approximable a (e.g. the golden ratio of oq-05) and target β, bound below how close n·a − β can get to ℤ for |n| ≤ N, an inhomogeneous analogue of the three-distance / bounded-partial-quotient theory.",
+      "Formalise minimality of the multidimensional torus rotation: for a = (a₁,…,a_k) with 1, a₁,…,a_k linearly independent over ℚ, every orbit {n·a + b} is dense in (ℝ/ℤ)^k, and conversely rational dependence confines the orbit to a proper closed subgroup.",
+      "Upgrade minimality to unique ergodicity: show the Lebesgue measure is the unique rotation-invariant Borel probability measure on the circle, from which Weyl equidistribution follows."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry: proves the HOMOGENEOUS Kronecker density (the orbit of 0 is dense mod 1 iff a is irrational) and its β = 0 approximation corollary. This entry upgrades both to the inhomogeneous case — minimality of every orbit {n·a + b} (b = 0 recovers the parent's density) and approximation of any target β (β = 0 recovers the parent's bound)."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-05",
+      "relationship": "sibling",
+      "description": "The dual SHARPNESS lower bound (the golden ratio is badly approximable). This entry shows every target is approximable modulo 1 (minimality); OQ-05 shows for φ the approximation cannot be too fast — the qualitative and quantitative sides of the irrational rotation's orbit."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem",
+      "relationship": "extends",
+      "description": "Grandparent entry: the pigeonhole existence of good rational approximations |qα − p| < 1/N. This entry supplies the topological-dynamics route to the strongest qualitative statement — every orbit of the irrational rotation is dense, so every target is approximable modulo 1."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **dirichlet-approximation-theorem-oq-04-oq-02**: *Minimality of the Irrational Rotation (Inhomogeneous Kronecker)*. Answers the parent OQ-04's open question by upgrading the **homogeneous** Kronecker density (orbit of `0` dense mod 1) to the **inhomogeneous** theorem.

**Topological form (minimality).** For irrational `a` and *any* base point `b : AddCircle 1`, the shifted orbit `{n·a + b : n ∈ ℤ}` is dense — the irrational rotation `x ↦ x + a` is minimal (no proper closed invariant subset). OQ-04 is the special case `b = 0`.

**Diophantine form (inhomogeneous approximation).** For irrational `a`, any target `β`, and every `ε > 0` there is `n : ℤ` with
`|n·a − β − round(n·a − β)| < ε`. OQ-04's homogeneous bound is the case `β = 0`.

## Theorems (3, all axiom-free)

- `denseRange_zsmul_of_irrational` — period-1 seed from `AddCircle.denseRange_zsmul_coe_iff` (`a/1 = a`).
- `denseRange_zsmul_add_of_irrational` — minimality via `DenseRange.comp` with the continuous surjective translation `x ↦ x + b`.
- `exists_int_zsmul_sub_round_lt` — inhomogeneous approximation: meet the dense orbit with the `ε`-ball around `↑β`, read the circle norm back as distance-to-nearest-integer via `AddCircle.norm_eq` at period 1.

## Verification

- `lake env lean Proofs/DirichletApproximationOQ04OQ02.lean` → **EXIT 0**, 0 sorries.
- `#print axioms` on all three → only `propext, Classical.choice, Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`). **0-axiom, status: verified.**
- 102 lines, imports Mathlib only. Mathlib v4.26.0.

Rescues completed-but-uncommitted work left untracked by a prior crashed session (an earlier draft lived on `research/dirichlet-kronecker-oq040402` with no PR; this PR carries the corrected proof + full gallery entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)