### PR TITLE
research(bertrands-postulate-oq-05-oq-02): unramified-prime API — vₚ(n!)=⌊n/p⌋ when p²>n [VERIFIED, 0-axiom, 6thm]

### DIFF
--- a/proofs/Proofs/BertrandsPostulateOQ05OQ02.lean
+++ b/proofs/Proofs/BertrandsPostulateOQ05OQ02.lean
@@ -1,0 +1,116 @@
+import Mathlib.NumberTheory.Bertrand
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Data.Nat.Log
+import Mathlib.Tactic
+
+/-
+# Bertrand's Postulate, oq-05-oq-02: An Unramified-Prime API for Factorials
+
+## Open question (`bertrands-postulate-oq-05-oq-02`)
+
+The parent entry `bertrands-postulate-oq-05` computes the exact `p`-adic valuation
+`vₚ(n!) = 1` for the *single* Bertrand prime `p ∈ (n/2, n]`, exploiting that `p² > n`
+kills every Legendre term beyond the first and that `⌊n/p⌋ = 1` in that narrow window.
+Its second listed open question asks whether the valuation-collapse lemma generalizes:
+
+> Can the valuation-collapse lemma be generalized to `vₚ(n!) = ⌊n/p⌋` whenever `p² > n`
+> (a prime in `(√n, n]`), giving a reusable "unramified prime" API for factorials?
+
+This file answers it. For **any** prime `p` with `p² > n` (equivalently `p > √n`, no upper
+bound on `p` relative to `n` required), Legendre's formula
+`vₚ(n!) = Σ_{i≥1} ⌊n/pⁱ⌋` collapses to its single first term, so
+
+  `vₚ(n!) = ⌊n/p⌋`.
+
+Everything downstream is then controlled by that one floor:
+
+* `factorization_factorial_of_sq_gt` — the exact valuation `vₚ(n!) = ⌊n/p⌋`.
+* `padicValNat_factorial_of_sq_gt` — same statement for the raw `padicValNat`.
+* `prime_pow_dvd_factorial_iff_of_sq_gt` — `pᵏ ∣ n! ↔ k ≤ ⌊n/p⌋`, the full divisibility API.
+* `prime_pow_div_dvd_factorial` — the exact power: `p^⌊n/p⌋ ∣ n!` but `p^(⌊n/p⌋+1) ∤ n!`.
+* `factorization_factorial_eq_one` — recovers the parent's `vₚ(n!) = 1` as the special case
+  `p ≤ n < 2p` (where `⌊n/p⌋ = 1`).
+* `unramified_prime_factorial` — capstone bundling valuation and divisibility.
+
+The generalization is strictly wider than the parent: the parent needs `p ≤ n < 2p`, whereas
+here `p` may be *any* prime above `√n`, including primes far larger than `n` (where
+`⌊n/p⌋ = 0`, correctly giving `vₚ(n!) = 0`). Fully machine-checked; no axioms beyond
+Mathlib's foundations, no `native_decide`.
+-/
+
+namespace BertrandsPostulateOQ05OQ02
+
+open Nat
+
+/-- **Legendre collapse for large primes.** If a prime `p` satisfies `p² > n` (equivalently
+`p > √n`), then only the first term of Legendre's formula survives and the `p`-adic
+valuation of `n!` is exactly `⌊n/p⌋`. No relationship between `p` and `n` beyond `n < p²` is
+needed: for `p > n` this correctly returns `0`, and for `√n < p ≤ n` it returns `⌊n/p⌋ ≥ 1`. -/
+theorem factorization_factorial_of_sq_gt {n p : ℕ} (hp : p.Prime) (hn : n < p ^ 2) :
+    (n !).factorization p = n / p := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  -- `p² > n` forces the base-`p` logarithm of `n` below `2`, so Legendre's sum runs over
+  -- `Ico 1 2 = {1}` only.
+  have hlog : Nat.log p n < 2 := by
+    rcases Nat.eq_zero_or_pos n with h0 | h0
+    · simp [h0]
+    · exact (Nat.log_lt_iff_lt_pow hp.one_lt h0.ne').2 hn
+  rw [Nat.factorization_def _ hp, padicValNat_factorial hlog]
+  have hset : Finset.Ico 1 2 = {1} := by decide
+  rw [hset, Finset.sum_singleton, pow_one]
+
+/-- The same collapse phrased with the raw `padicValNat`. -/
+theorem padicValNat_factorial_of_sq_gt {n p : ℕ} (hp : p.Prime) (hn : n < p ^ 2) :
+    padicValNat p (n !) = n / p := by
+  rw [← Nat.factorization_def _ hp]
+  exact factorization_factorial_of_sq_gt hp hn
+
+/-- **The full divisibility API.** For a prime with `p² > n`, `pᵏ ∣ n!` holds precisely when
+`k ≤ ⌊n/p⌋`: the entire divisibility behaviour of `p` in `n!` is governed by the single
+floor `⌊n/p⌋`. -/
+theorem prime_pow_dvd_factorial_iff_of_sq_gt {n p k : ℕ} (hp : p.Prime) (hn : n < p ^ 2) :
+    p ^ k ∣ n ! ↔ k ≤ n / p := by
+  rw [Nat.Prime.pow_dvd_iff_le_factorization hp (Nat.factorial_ne_zero n),
+      factorization_factorial_of_sq_gt hp hn]
+
+/-- **The exact power.** For a prime with `p² > n`, `p^⌊n/p⌋` divides `n!` while
+`p^(⌊n/p⌋+1)` does not — `⌊n/p⌋` is the precise exponent of `p` in `n!`. -/
+theorem prime_pow_div_dvd_factorial {n p : ℕ} (hp : p.Prime) (hn : n < p ^ 2) :
+    p ^ (n / p) ∣ n ! ∧ ¬ p ^ (n / p + 1) ∣ n ! := by
+  refine ⟨(prime_pow_dvd_factorial_iff_of_sq_gt hp hn).2 le_rfl, ?_⟩
+  rw [prime_pow_dvd_factorial_iff_of_sq_gt hp hn]
+  omega
+
+/-- **Recovering the parent's `vₚ(n!) = 1`** (`bertrands-postulate-oq-05`). The Bertrand
+prime `p ∈ (n/2, n]` satisfies `p ≤ n < 2p`, which forces both `p² > n` and `⌊n/p⌋ = 1`, so
+the general collapse specializes to valuation exactly one. -/
+theorem factorization_factorial_eq_one {n p : ℕ} (hp : p.Prime)
+    (h2p : n < 2 * p) (hpn : p ≤ n) : (n !).factorization p = 1 := by
+  have hn : n < p ^ 2 := by
+    have h2 : 2 ≤ p := hp.two_le
+    calc n < 2 * p := h2p
+      _ ≤ p * p := by nlinarith
+      _ = p ^ 2 := (pow_two p).symm
+  rw [factorization_factorial_of_sq_gt hp hn]
+  exact Nat.div_eq_of_lt_le (by omega) (by omega)
+
+/-- **Capstone: the unramified-prime API.** For any prime `p` with `p² > n`, the entire
+`p`-adic behaviour of `n!` is governed by the single floor `⌊n/p⌋`: the valuation equals
+`⌊n/p⌋`, and `pᵏ ∣ n!` iff `k ≤ ⌊n/p⌋`. -/
+theorem unramified_prime_factorial {n p : ℕ} (hp : p.Prime) (hn : n < p ^ 2) :
+    (n !).factorization p = n / p ∧ ∀ k, (p ^ k ∣ n ! ↔ k ≤ n / p) :=
+  ⟨factorization_factorial_of_sq_gt hp hn,
+    fun _ => prime_pow_dvd_factorial_iff_of_sq_gt hp hn⟩
+
+-- Worked example: `11² = 121 > 100`, and `⌊100/11⌋ = 9`, so `v₁₁(100!) = 9`
+-- (Legendre: `⌊100/11⌋ + ⌊100/121⌋ = 9 + 0`).
+example : (100 !).factorization 11 = 9 := by
+  rw [factorization_factorial_of_sq_gt (by norm_num) (by norm_num)]
+
+-- A prime larger than `n` is unramified with valuation `0`: `13² = 169 > 10`, `⌊10/13⌋ = 0`.
+example : (10 !).factorization 13 = 0 := by
+  rw [factorization_factorial_of_sq_gt (by norm_num) (by norm_num)]
+
+end BertrandsPostulateOQ05OQ02

--- a/src/data/proofs/bertrands-postulate-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/bertrands-postulate-oq-05-oq-02/annotations.json
@@ -1,0 +1,150 @@
+[
+  {
+    "id": "ann-bp-oq0502-01-header",
+    "proofId": "bertrands-postulate-oq-05-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 48
+    },
+    "type": "concept",
+    "title": "Generalizing the Valuation Collapse into an Unramified-Prime API",
+    "content": "The file imports the same Mathlib modules as the parent oq-05 and works in ℕ (open Nat). The header states the goal: the parent computed vₚ(n!) = 1 for the single Bertrand prime p ∈ (n/2, n]; here that valuation-collapse is generalized to vₚ(n!) = ⌊n/p⌋ for ANY prime with p² > n (equivalently p > √n), with no upper bound on p relative to n. The rest of the file turns this single identity into a full divisibility API and recovers the parent as a special case.",
+    "mathContext": "Legendre: $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$. The hypothesis $p^2 > n$ is precisely what forces every term with $i \\geq 2$ to vanish, so the sum degenerates to the single floor $\\lfloor n/p \\rfloor$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Legendre's formula",
+      "p-adic valuation",
+      "unramified prime",
+      "factorials"
+    ],
+    "prerequisites": [
+      "prime number theory",
+      "factorials",
+      "Lean 4 Mathlib"
+    ]
+  },
+  {
+    "id": "ann-bp-oq0502-02-collapse",
+    "proofId": "bertrands-postulate-oq-05-oq-02",
+    "range": {
+      "startLine": 51,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "factorization_factorial_of_sq_gt: vₚ(n!) = ⌊n/p⌋ when p² > n",
+    "content": "The central lemma. From the sole hypothesis n < p² it derives Nat.log p n < 2 (the n = 0 edge case is closed by simp; otherwise Nat.log_lt_iff_lt_pow converts n < p² to log_p n < 2). Rewriting (n!).factorization p through Nat.factorization_def and Legendre's padicValNat_factorial produces a sum over Finset.Ico 1 2; decide rewrites that index set to the singleton {1}, and Finset.sum_singleton with pow_one leave exactly ⌊n/p⌋.",
+    "mathContext": "Only the first Legendre term survives because $p^i \\geq p^2 > n$ makes $\\lfloor n/p^i \\rfloor = 0$ for all $i \\geq 2$; the surviving $\\lfloor n/p \\rfloor$ is the exact exponent of $p$ in $n!$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Legendre's formula",
+      "integer logarithm",
+      "p-adic valuation"
+    ],
+    "prerequisites": [
+      "Legendre's formula",
+      "Nat.log and powers"
+    ]
+  },
+  {
+    "id": "ann-bp-oq0502-03-padicval",
+    "proofId": "bertrands-postulate-oq-05-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 68
+    },
+    "type": "theorem",
+    "title": "padicValNat_factorial_of_sq_gt: the Raw-Valuation Restatement",
+    "content": "Restates the collapse for the underlying padicValNat p (n!) rather than the factorization, by rewriting back through Nat.factorization_def. A convenience wrapper for callers working directly with padicValNat.",
+    "mathContext": "For a prime $p$, $\\text{padicValNat}\\,p\\,(n!) = (n!).\\text{factorization}\\,p$, so both phrasings of $v_p(n!) = \\lfloor n/p \\rfloor$ are available.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "p-adic valuation",
+      "Nat.factorization"
+    ],
+    "prerequisites": [
+      "p-adic valuation in ℕ"
+    ]
+  },
+  {
+    "id": "ann-bp-oq0502-04-dvd-iff",
+    "proofId": "bertrands-postulate-oq-05-oq-02",
+    "range": {
+      "startLine": 70,
+      "endLine": 78
+    },
+    "type": "theorem",
+    "title": "prime_pow_dvd_factorial_iff_of_sq_gt: pᵏ ∣ n! ↔ k ≤ ⌊n/p⌋",
+    "content": "Combines the exact valuation with Nat.Prime.pow_dvd_iff_le_factorization to characterize every prime-power divisor of n! for a large prime p purely by comparing the exponent k with the single floor ⌊n/p⌋. This is the reusable divisibility API the open question requested.",
+    "mathContext": "$p^k \\mid n! \\iff k \\leq v_p(n!) = \\lfloor n/p \\rfloor$: all divisibility behaviour of a prime above $\\sqrt{n}$ is governed by one floor.",
+    "significance": "central",
+    "relatedConcepts": [
+      "prime-power divisibility",
+      "p-adic valuation"
+    ],
+    "prerequisites": [
+      "prime-power divisibility criteria"
+    ]
+  },
+  {
+    "id": "ann-bp-oq0502-05-exact-power",
+    "proofId": "bertrands-postulate-oq-05-oq-02",
+    "range": {
+      "startLine": 80,
+      "endLine": 86
+    },
+    "type": "theorem",
+    "title": "prime_pow_div_dvd_factorial: the Exact Maximal Power",
+    "content": "Reads off from the divisibility iff that p^⌊n/p⌋ divides n! while p^(⌊n/p⌋+1) does not — ⌊n/p⌋ is the precise exponent of the large prime p in n!.",
+    "mathContext": "The maximal power of $p$ dividing $n!$ is $p^{\\lfloor n/p \\rfloor}$; one more factor of $p$ over-counts.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "exact p-adic valuation",
+      "prime-power divisibility"
+    ],
+    "prerequisites": [
+      "prime-power divisibility criteria"
+    ]
+  },
+  {
+    "id": "ann-bp-oq0502-06-recover-parent",
+    "proofId": "bertrands-postulate-oq-05-oq-02",
+    "range": {
+      "startLine": 88,
+      "endLine": 100
+    },
+    "type": "theorem",
+    "title": "factorization_factorial_eq_one: Recovering the Parent's vₚ(n!) = 1",
+    "content": "Specializes the general collapse to the Bertrand window p ≤ n < 2p: this forces p² > n (so factorization_factorial_of_sq_gt applies) and ⌊n/p⌋ = 1 (via Nat.div_eq_of_lt_le), reproducing oq-05's valuation-equals-one. Demonstrates the generalization strictly subsumes the parent result.",
+    "mathContext": "In the window $p \\leq n < 2p$ the single surviving floor $\\lfloor n/p \\rfloor$ evaluates to $1$; the general lemma allows any $\\lfloor n/p \\rfloor \\geq 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bertrand's postulate",
+      "special-case recovery"
+    ],
+    "prerequisites": [
+      "floor division"
+    ]
+  },
+  {
+    "id": "ann-bp-oq0502-07-capstone",
+    "proofId": "bertrands-postulate-oq-05-oq-02",
+    "range": {
+      "startLine": 102,
+      "endLine": 114
+    },
+    "type": "theorem",
+    "title": "unramified_prime_factorial: the Capstone API and Examples",
+    "content": "Bundles the exact valuation (vₚ(n!) = ⌊n/p⌋) with the full divisibility iff (∀ k, pᵏ ∣ n! ↔ k ≤ ⌊n/p⌋) into a single reusable 'unramified prime' statement. Two worked examples confirm the collapse: v₁₁(100!) = 9 (prime present, since 11² = 121 > 100 and ⌊100/11⌋ = 9) and v₁₃(10!) = 0 (prime absent, 13 > 10).",
+    "mathContext": "A prime $p > \\sqrt{n}$ behaves in $n!$ like an unramified prime: its entire contribution is captured by the single number $\\lfloor n/p \\rfloor$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "unramified prime",
+      "reusable API",
+      "worked examples"
+    ],
+    "prerequisites": [
+      "p-adic valuation",
+      "prime-power divisibility"
+    ]
+  }
+]

--- a/src/data/proofs/bertrands-postulate-oq-05-oq-02/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-05-oq-02/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "bertrands-postulate-oq-05-oq-02",
+  "title": "An Unramified-Prime API for Factorials: vₚ(n!) = ⌊n/p⌋ when p² > n",
+  "slug": "bertrands-postulate-oq-05-oq-02",
+  "description": "The parent entry oq-05 computes vₚ(n!) = 1 for the single Bertrand prime p ∈ (n/2, n]. This entry answers its second open question by generalizing the valuation-collapse lemma: for ANY prime p with p² > n (equivalently p > √n), Legendre's formula collapses to its first term, giving vₚ(n!) = ⌊n/p⌋ exactly. From that single floor follows a complete divisibility API — pᵏ ∣ n! ↔ k ≤ ⌊n/p⌋, the exact power p^⌊n/p⌋, and the parent's vₚ = 1 as the special case p ≤ n < 2p.",
+  "meta": {
+    "author": "Adrien-Marie Legendre (valuation formula, 1808); after Paul Erdős (1932) and the Bertrand's-postulate lineage (Bertrand 1845, Chebyshev 1852)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Legendre%27s_formula",
+    "date": "1808",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BertrandsPostulateOQ05OQ02.lean",
+    "tags": [
+      "number-theory",
+      "prime-numbers",
+      "bertrands-postulate",
+      "factorial",
+      "legendre-formula",
+      "p-adic-valuation",
+      "unramified-prime",
+      "divisibility",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "padicValNat_factorial",
+        "description": "Legendre's theorem: v_p(n!) = Σ_{i∈Ico 1 b} ⌊n/p^i⌋ for any b > log_p n",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.log_lt_iff_lt_pow",
+        "description": "For 1 < b and y ≠ 0: log b y < x ↔ y < b^x — used to bound log_p n < 2 from n < p²",
+        "module": "Mathlib.Data.Nat.Log"
+      },
+      {
+        "theorem": "Nat.factorization_def",
+        "description": "For prime p: n.factorization p = padicValNat p n — bridges factorization and p-adic valuation",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.pow_dvd_iff_le_factorization",
+        "description": "For prime p and n ≠ 0: p^k ∣ n ↔ k ≤ n.factorization p — turns the valuation into a divisibility criterion",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.div_eq_of_lt_le",
+        "description": "k·n ≤ m < (k+1)·n → m / n = k — collapses ⌊n/p⌋ to 1 in the parent special case",
+        "module": "Init.Data.Nat.Div.Basic"
+      }
+    ],
+    "originalContributions": [
+      "factorization_factorial_of_sq_gt: the general valuation-collapse — for any prime p with n < p², (n!).factorization p = ⌊n/p⌋, proved by bounding log_p n < 2 (splitting the n = 0 case cleanly) and reducing Legendre's sum over Ico 1 2 = {1} to its single term",
+      "padicValNat_factorial_of_sq_gt: the same identity for the raw padicValNat p (n!) = ⌊n/p⌋",
+      "prime_pow_dvd_factorial_iff_of_sq_gt: the full divisibility API — p^k ∣ n! ↔ k ≤ ⌊n/p⌋ — reducing all prime-power divisibility of a large prime to one floor comparison",
+      "prime_pow_div_dvd_factorial: the exact power — p^⌊n/p⌋ ∣ n! but p^(⌊n/p⌋+1) ∤ n!",
+      "factorization_factorial_eq_one: recovers the parent oq-05's vₚ(n!) = 1 as the special case p ≤ n < 2p (where the general floor ⌊n/p⌋ evaluates to 1), demonstrating the generalization strictly subsumes the parent",
+      "unramified_prime_factorial: capstone bundling the exact valuation with the full divisibility iff into a single reusable 'unramified prime' statement"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 116,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axioms beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound); verified via #print axioms. No native_decide.",
+    "mathlib_version": "4.26.0",
+    "relatedProblems": [
+      {
+        "id": "bertrands-postulate-oq-05",
+        "relationship": "Parent entry. Its factorization_factorial_eq_one is the p ≤ n < 2p special case of this entry's general vₚ(n!) = ⌊n/p⌋; its second open question is answered here."
+      },
+      {
+        "id": "bertrands-postulate",
+        "relationship": "Grandparent: Bertrand's postulate, the source of the large-prime window that motivates the unramified-prime analysis."
+      }
+    ],
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Legendre's 1808 formula $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$ is the workhorse behind almost every statement about the prime factorization of factorials, from de Polignac's count of trailing zeros to Erdős's 1932 proof that $n!$ is never a perfect square. The sum is finite because $\\lfloor n/p^i \\rfloor = 0$ once $p^i > n$; the number of nonzero terms is exactly $\\lfloor \\log_p n \\rfloor$. When $p > \\sqrt{n}$ only the first term survives, and the formula degenerates to a single floor — the phenomenon the parent entry oq-05 exploited for the one Bertrand prime, and which this entry isolates as a general lemma.",
+    "problemStatement": "The parent entry oq-05 pinned $v_p(n!) = 1$ for the single Bertrand prime $p \\in (n/2, n]$, using that $p \\leq n < 2p$ makes $\\lfloor n/p \\rfloor = 1$ and $p^2 > n$ kills the higher Legendre terms. Its second open question asks: does the collapse survive dropping the $p \\leq n < 2p$ hypothesis? Concretely, for *any* prime $p$ with $p^2 > n$, is $v_p(n!) = \\lfloor n/p \\rfloor$ — a reusable 'unramified prime' API rather than a one-off valuation-equals-one fact?",
+    "proofStrategy": "The single hypothesis $n < p^2$ gives $\\log_p n < 2$ (via `Nat.log_lt_iff_lt_pow`, with the $n = 0$ edge case dispatched by `simp`). Legendre's formula `padicValNat_factorial` then runs its sum over `Finset.Ico 1 2`, which `decide` rewrites to the singleton `{1}`; `Finset.sum_singleton` and `pow_one` leave exactly $\\lfloor n/p \\rfloor$. That single identity is then leveraged: `Nat.Prime.pow_dvd_iff_le_factorization` turns it into the divisibility iff $p^k \\mid n! \\Leftrightarrow k \\leq \\lfloor n/p \\rfloor$, from which the exact power and the parent's $v_p = 1$ (via $\\lfloor n/p \\rfloor = 1$ when $p \\leq n < 2p$) both drop out.",
+    "keyInsights": [
+      "The only hypothesis needed is n < p² (i.e. p > √n) — nothing about p relative to n. The parent's p ≤ n < 2p is a proper special case.",
+      "n < p² is exactly the condition that makes log_p n < 2, so Legendre's sum runs over the single index i = 1.",
+      "The generalization is genuinely wider on both sides: for √n < p ≤ n it gives ⌊n/p⌋ ≥ 1, and for p > n it correctly returns ⌊n/p⌋ = 0 (the prime is absent from n!).",
+      "Once vₚ(n!) = ⌊n/p⌋ is known, every divisibility question about the large prime p becomes a floor comparison k ≤ ⌊n/p⌋ — no further Legendre bookkeeping.",
+      "Recovering factorization_factorial_eq_one from the general lemma is a one-line ⌊n/p⌋ = 1 computation, verifying the API subsumes the parent."
+    ],
+    "prerequisites": [
+      "Legendre's formula for the p-adic valuation of a factorial",
+      "p-adic valuation and prime factorization in ℕ",
+      "the integer logarithm Nat.log and its comparison with powers",
+      "prime-power divisibility criteria"
+    ],
+    "text": "A 116-line, fully verified (0 sorries, 0 axioms, no native_decide) formalization that answers the second open question of bertrands-postulate-oq-05. The central lemma factorization_factorial_of_sq_gt proves vₚ(n!) = ⌊n/p⌋ for every prime p with p² > n, generalizing the parent's vₚ(n!) = 1 (which required the narrow window p ≤ n < 2p). padicValNat_factorial_of_sq_gt restates it for the raw valuation. prime_pow_dvd_factorial_iff_of_sq_gt packages the complete divisibility API pᵏ ∣ n! ↔ k ≤ ⌊n/p⌋, and prime_pow_div_dvd_factorial reads off the exact power p^⌊n/p⌋. factorization_factorial_eq_one recovers the parent result as a corollary, and unramified_prime_factorial bundles the valuation with the divisibility iff. Worked examples confirm v₁₁(100!) = 9 and v₁₃(10!) = 0."
+  },
+  "sections": [
+    {
+      "id": "sec-general-collapse",
+      "title": "The General Valuation Collapse: vₚ(n!) = ⌊n/p⌋",
+      "startLine": 51,
+      "endLine": 68,
+      "summary": "factorization_factorial_of_sq_gt proves the exact valuation for any prime with n < p². The n = 0 case is dispatched by simp; otherwise Nat.log_lt_iff_lt_pow turns n < p² into log_p n < 2, and Legendre's padicValNat_factorial sums over Ico 1 2 = {1}, collapsing (via Finset.sum_singleton and pow_one) to the single term ⌊n/p⌋. padicValNat_factorial_of_sq_gt restates it for the raw padicValNat.",
+      "mathContext": "v_p(n!) = Σ_{i≥1} ⌊n/p^i⌋; the hypothesis p² > n kills every term with i ≥ 2 (since p^i ≥ p² > n forces ⌊n/p^i⌋ = 0), leaving exactly ⌊n/p⌋."
+    },
+    {
+      "id": "sec-divisibility-api",
+      "title": "The Divisibility API: pᵏ ∣ n! ↔ k ≤ ⌊n/p⌋",
+      "startLine": 70,
+      "endLine": 86,
+      "summary": "prime_pow_dvd_factorial_iff_of_sq_gt combines the exact valuation with Nat.Prime.pow_dvd_iff_le_factorization to characterize every prime-power divisor of n! for a large prime p purely by comparison with ⌊n/p⌋. prime_pow_div_dvd_factorial reads off the exact power: p^⌊n/p⌋ ∣ n! but p^(⌊n/p⌋+1) ∤ n!.",
+      "mathContext": "p^k ∣ n! ⟺ k ≤ v_p(n!) = ⌊n/p⌋; the exponent of p in n! is exactly ⌊n/p⌋, so p^⌊n/p⌋ is the maximal power dividing n!."
+    },
+    {
+      "id": "sec-recover-parent",
+      "title": "Recovering the Parent: vₚ(n!) = 1 and the Capstone",
+      "startLine": 88,
+      "endLine": 107,
+      "summary": "factorization_factorial_eq_one specializes the general lemma to the Bertrand window p ≤ n < 2p: this forces p² > n (so the collapse applies) and ⌊n/p⌋ = 1 (by Nat.div_eq_of_lt_le), recovering oq-05's valuation-equals-one. unramified_prime_factorial bundles the exact valuation with the full divisibility iff.",
+      "mathContext": "The parent's p ∈ (n/2, n] is the special case where the single surviving floor ⌊n/p⌋ happens to equal 1; the general lemma allows any ⌊n/p⌋ ≥ 0."
+    },
+    {
+      "id": "sec-examples",
+      "title": "Worked Examples",
+      "startLine": 109,
+      "endLine": 114,
+      "summary": "v₁₁(100!) = 9 (since 11² = 121 > 100 and ⌊100/11⌋ = 9, with ⌊100/121⌋ = 0) and v₁₃(10!) = 0 (13 > 10, so 13 does not divide 10!).",
+      "mathContext": "Both examples verify the collapse on primes above √n: one where the prime is present (11 ≤ 100) and one where it is absent (13 > 10, valuation 0)."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) formalization answering the second open question of bertrands-postulate-oq-05. The central result factorization_factorial_of_sq_gt establishes vₚ(n!) = ⌊n/p⌋ for every prime p with p² > n, generalizing the parent's vₚ(n!) = 1 (which needed the narrow window p ≤ n < 2p). The exact valuation yields a complete 'unramified prime' API: pᵏ ∣ n! ↔ k ≤ ⌊n/p⌋, the exact maximal power p^⌊n/p⌋, and the parent result recovered as a one-line corollary.",
+    "implications": "**Theoretical significance**: This is the reusable form of the valuation-collapse phenomenon. Every 'large prime' above √n contributes to n! exactly ⌊n/p⌋ times, with no higher-power complications — the arithmetic analogue of a prime being unramified. Such a lemma is the natural building block for quantitative statements: counting how many primes in (√n, n] each contribute a given exponent, bounding the squarefree part of n!, or (with a prime-counting input) proving n! is never a perfect k-th power. Isolating it as a standalone API — rather than the one-off vₚ = 1 of the parent — is exactly what the open question asked for, and mirrors the style Mathlib favours for factorial-valuation utilities.",
+    "openQuestions": [
+      "Aggregating over all primes in (√n, n], can one bound Σ_{√n < p ≤ n} ⌊n/p⌋ to control the 'large-prime part' of n! and re-derive the prime-counting asymptotic θ(n) − θ(√n)?",
+      "Does the companion collapse hold one level up — an exact two-term formula vₚ(n!) = ⌊n/p⌋ + ⌊n/p²⌋ whenever p³ > n (a prime in (n^{1/3}, n]) — and can the family be stated uniformly as 'vₚ(n!) is the first ⌊log_p n⌋ Legendre terms'?",
+      "Can factorization_factorial_of_sq_gt be upstreamed to Mathlib as the canonical unramified-prime lemma for factorials, phrased for a general prime with p² > n?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bertrands-postulate-oq-05",
+      "relationship": "extends",
+      "description": "Answers this parent's second open question: generalizes its factorization_factorial_eq_one (vₚ(n!) = 1 for the Bertrand prime p ∈ (n/2, n]) to vₚ(n!) = ⌊n/p⌋ for any prime with p² > n, and recovers the parent as the ⌊n/p⌋ = 1 special case."
+    },
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Grandparent: Bertrand's postulate supplies the large-prime window (n/2, n] ⊂ (√n, n] that first motivated the unramified-prime valuation computation generalized here."
+    }
+  ],
+  "references": [
+    {
+      "authors": "A.-M. Legendre",
+      "title": "Essai sur la théorie des nombres",
+      "year": "1808",
+      "venue": "",
+      "note": "Formula v_p(n!) = Σ ⌊n/p^i⌋ for the p-adic valuation of a factorial"
+    },
+    {
+      "authors": "P. Erdős",
+      "title": "Beweis eines Satzes von Tschebyschef",
+      "year": "1932",
+      "venue": "Acta Sci. Math. (Szeged)",
+      "note": "Elementary proof of Bertrand's postulate; the unramified-large-prime idea underlies the non-squareness of n!"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "The Lean Mathematical Library",
+      "year": "2020",
+      "venue": "CPP 2020",
+      "note": "padicValNat_factorial (Legendre's formula) and the Nat.factorization / padicValNat API"
+    }
+  ],
+  "sorries": [],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Bertrand",
+      "Mathlib.NumberTheory.Padics.PadicVal.Basic",
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Data.Nat.Factorial.Basic",
+      "Mathlib.Data.Nat.Log",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "BertrandsPostulateOQ05OQ02",
+    "lineCount": 116,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BertrandsPostulateOQ05OQ02.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of `bertrands-postulate-oq-05`:

> Can the valuation-collapse lemma be generalized to `vₚ(n!) = ⌊n/p⌋` whenever `p² > n` (a prime in `(√n, n]`), giving a reusable "unramified prime" API for factorials?

**Yes.** The parent computed `vₚ(n!) = 1` for the *single* Bertrand prime `p ∈ (n/2, n]`, using the narrow window `p ≤ n < 2p`. This entry drops that window entirely: for **any** prime `p` with `p² > n` (equivalently `p > √n`), Legendre's formula `vₚ(n!) = Σ_{i≥1} ⌊n/pⁱ⌋` collapses to its first term, giving

```
vₚ(n!) = ⌊n/p⌋.
```

## New entry: `bertrands-postulate-oq-05-oq-02`

`proofs/Proofs/BertrandsPostulateOQ05OQ02.lean` — 116 lines, 6 theorems, **0 axioms, 0 sorries, no native_decide**.

| Theorem | Statement |
|---|---|
| `factorization_factorial_of_sq_gt` | `(n!).factorization p = n / p` for `n < p²` (central lemma) |
| `padicValNat_factorial_of_sq_gt` | same for raw `padicValNat` |
| `prime_pow_dvd_factorial_iff_of_sq_gt` | `pᵏ ∣ n! ↔ k ≤ ⌊n/p⌋` (full divisibility API) |
| `prime_pow_div_dvd_factorial` | exact power: `p^⌊n/p⌋ ∣ n!` but `p^(⌊n/p⌋+1) ∤ n!` |
| `factorization_factorial_eq_one` | recovers parent's `vₚ(n!)=1` as the `p ≤ n < 2p` special case |
| `unramified_prime_factorial` | capstone: valuation + divisibility iff |

The generalization is strictly wider on both sides: `√n < p ≤ n` gives `⌊n/p⌋ ≥ 1`, and `p > n` correctly gives `⌊n/p⌋ = 0` (prime absent). Worked examples: `v₁₁(100!) = 9`, `v₁₃(10!) = 0`.

## Verification

- Built with `lake env lean` against Mathlib 4.26.0 (warm cache): compiles clean.
- `#print axioms` on all main theorems: `[propext, Classical.choice, Quot.sound]` only — **no `sorryAx`, no `Lean.ofReduceBool`**. Genuinely 0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)