### PR TITLE
Fix: reconcile 2 stale audit-tracker 'issues-found' flags to clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8923,8 +8923,9 @@
     "erdos-1018-oq-04-incomplete-01-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-06-28T18:46:29Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "clean",
+      "issues": [],
+      "note": "Mechanic re-verification 2026-07-01: prior 'issues-found' flag carried an empty issues array (no defect recorded). meta.json matches source exactly (lineCount 102, theoremCount 7, 0 sorries, 0 axioms, no native_decide/structures, no True-stubs); status verified/badge verified justified. Reconciled to clean."
     },
     "erdos-1019": {
       "agentId": "auditor-cycle-20-batch",
@@ -23584,8 +23585,9 @@
     "picks-theorem-oq-04": {
       "auditCount": 1,
       "lastAudited": "2026-06-28T18:46:29Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "clean",
+      "issues": [],
+      "note": "Mechanic re-verification 2026-07-01: prior 'issues-found' flag carried an empty issues array (no defect recorded). meta.json matches source exactly (lineCount 308, theoremCount 14 counting the @[simp] lemma cross_self, 0 sorries, 0 axioms, no native_decide/structures, no True-stubs); status verified/badge original justified for the shoelace/fan-triangulation development. Reconciled to clean."
     },
     "platonic-solids": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Fix

Two audit-tracker entries were stuck at `result: "issues-found"` with **empty** `issues` arrays — flagged by a batch audit on 2026-06-28 but with no defect ever recorded. Mechanic re-verification confirms both proofs' `meta.json` matches their Lean source exactly, so both are reconciled to `clean`.

## Evidence

**`erdos-1018-oq-04-incomplete-01-oq-01`** (`Proofs/Erdos1018OQ04Incomplete01OQ01.lean`)
- **Before**: `result: "issues-found"`, `issues: []`
- **Verification**: 102 lines (meta 102), 7 theorem/lemma (meta 7), 0 sorries, 0 axioms, no `native_decide`, no assumption-carrying structures, no `True`-stubs. `status: verified` / `badge: verified` justified.
- **After**: `result: "clean"`

**`picks-theorem-oq-04`** (`Proofs/PicksTheoremOQ04.lean`)
- **Before**: `result: "issues-found"`, `issues: []`
- **Verification**: 308 lines (meta 308), 14 theorem/lemma (meta 14 — the `^(theorem|lemma)` grep undercounts by 1 because `@[simp] lemma cross_self` is prefixed), 0 sorries, 0 axioms, no `native_decide`, no structures, no `True`-stubs. Substantive shoelace/fan-triangulation development; `status: verified` / `badge: original` justified.
- **After**: `result: "clean"`

Diff is localized to exactly these two entries (6 insertions / 4 deletions); JSON validated, entry count unchanged (4373).

These were the only two non-`clean`/non-`issues-fixed` entries in the tracker; the tracker is now fully reconciled.

---
Automated fix by lean-mechanic agent.