### PR TITLE
Enrich Lucas tripling formulas: add dependency-stack annotation

### DIFF
--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-01-oq-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-dependency-stack",
+    "proofId": "lucas-sequence-degree2-identities-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 5
+    },
+    "type": "context",
+    "title": "A Three-Generation Dependency Stack, No New Definitions",
+    "content": "The imports are the reason this file needs no induction of its own: every ingredient is inherited from three ancestor entries, and this file adds only two ring/linear_combination arguments on top. `Proofs.LucasSequenceDegree2Identities` (grandparent) supplies the definitions of Uₙ(P,Q), Vₙ(P,Q) and the master invariant Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ. `Proofs.LucasSequenceDegree2IdentitiesOQ01` (parent OQ-01) supplies the doubling formulas U₂ₙ = Uₙ·Vₙ, V₂ₙ = Vₙ² − 2·Qⁿ. `Proofs.LucasSequenceDegree2IdentitiesOQ02` (parent OQ-02) supplies the bilinear addition laws two_U_add, two_V_add. The `open LucasSequenceDegree2IdentitiesOQ02` (line 47) is what lets those addition-law lemmas be named unqualified. Because U₃ₙ and V₃ₙ are built entirely from lemmas already proved by structural induction upstream, this entry declares 0 definitions — it is pure algebraic descent from the degree-2 toolkit.",
+    "mathContext": "Stack: master identity $V_n^2-DU_n^2=4Q^n$ (grandparent) $\\to$ doubling $U_{2n}=U_nV_n,\\ V_{2n}=V_n^2-2Q^n$ (OQ-01) $\\to$ addition laws (OQ-02) $\\to$ tripling here.",
+    "significance": "context",
+    "relatedConcepts": [
+      "inheriting definitions and lemmas via imports",
+      "the master identity / doubling / addition-law ancestor entries",
+      "open bringing addition-law lemmas into scope",
+      "descent without new induction (0 definitions)"
+    ],
+    "prerequisites": [
+      "Lean namespaces, imports, and open",
+      "the ancestor Lucas-sequence entries"
+    ]
+  },
+  {
     "id": "ann-programme",
     "proofId": "lucas-sequence-degree2-identities-oq-01-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass (pass 0) for `lucas-sequence-degree2-identities-oq-01-oq-01`.

## Gap addressed
The entry's meta.json was already rich (5 keyInsights, full conclusion, references, cross-references, sections with mathContext), but had only **4 annotations** and the import/namespace-setup region (Lean lines 1–5, 45–47) was uncovered.

## Change
Added a 5th annotation `ann-dependency-stack` (range 1–5) surfacing the structural point of this entry: the **three-generation dependency stack** that lets tripling descend with **no new induction and 0 definitions**:

- grandparent `LucasSequenceDegree2Identities` → master identity Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ
- parent OQ-01 → doubling formulas U₂ₙ = Uₙ·Vₙ, V₂ₙ = Vₙ² − 2·Qⁿ
- parent OQ-02 → bilinear addition laws two_U_add, two_V_add

Also explains why `open LucasSequenceDegree2IdentitiesOQ02` names the addition-law lemmas unqualified.

Annotation carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Verified with `pnpm build`. No changes to Lean source or axiom/status claims (still verified, 0-axiom).