### PR TITLE
research(erdos-1043): disk constant-width + Pommerenke constant lower bound [VERIFIED, 0 new axioms, +3thm]

### DIFF
--- a/proofs/Proofs/Erdos1043Problem.lean
+++ b/proofs/Proofs/Erdos1043Problem.lean
@@ -177,6 +177,19 @@ noncomputable def pommerenkeConstant : ℝ≥0∞ :=
   ⨆ (f : Polynomial ℂ) (_ : f.Monic) (_ : f.natDegree ≥ 1),
     minProjectionMeasure f
 
+/-- **Pommerenke's lower bound on the constant.** Pommerenke's polynomial has every
+    projection `≥ 2.386`, so its minimum projection measure is `≥ 2.386`; since the
+    Pommerenke constant is the supremum of these minima over all monic polynomials,
+    it is itself `≥ 2.386`. This is the structural content of the `> 2` phenomenon. -/
+theorem pommerenke_constant_lower : pommerenkeConstant ≥ 2.386 := by
+  obtain ⟨f, hMonic, hDeg, hProj⟩ := pommerenke_counterexample
+  -- every direction gives ≥ 2.386, so the infimum over directions is ≥ 2.386
+  have hmin : (2.386 : ℝ≥0∞) ≤ minProjectionMeasure f :=
+    le_iInf (fun u => hProj u)
+  refine le_trans hmin ?_
+  unfold pommerenkeConstant
+  exact le_iSup_of_le f (le_iSup_of_le hMonic (le_iSup_of_le hDeg (le_refl _)))
+
 /- Pommerenke showed this constant is at least 2.386. -/
 /- ## Part VI: Pommerenke's Upper Bound -/
 
@@ -259,6 +272,25 @@ theorem convex_width_bounds (S : Set ℂ) (hConvex : Convex ℝ S) (hCompact : I
     minWidth S ≤ maxWidth S := by
   have hne : Nonempty Direction := ⟨⟨1, norm_one⟩⟩
   exact (iInf_le (width S) hne.some).trans (le_iSup (width S) hne.some)
+
+/-- The closed unit disk has minimum width 2: since every direction's projection has
+    measure exactly 2 (`disk_projection_measure`), the infimum over directions is 2. -/
+theorem disk_minWidth : minWidth (Metric.closedBall (0 : ℂ) 1) = 2 := by
+  haveI : Nonempty Direction := ⟨⟨1, norm_one⟩⟩
+  have h : ∀ u : Direction, width (Metric.closedBall (0 : ℂ) 1) u = 2 :=
+    fun u => disk_projection_measure u
+  simp only [minWidth, h]
+  exact iInf_const
+
+/-- The closed unit disk has maximum width 2 as well: it is a set of **constant width**,
+    the same shadow length 2 in every direction. Together with `disk_minWidth` this
+    shows `minWidth = maxWidth = 2`, the baseline the EHP conjecture asked to match. -/
+theorem disk_maxWidth : maxWidth (Metric.closedBall (0 : ℂ) 1) = 2 := by
+  haveI : Nonempty Direction := ⟨⟨1, norm_one⟩⟩
+  have h : ∀ u : Direction, width (Metric.closedBall (0 : ℂ) 1) u = 2 :=
+    fun u => disk_projection_measure u
+  simp only [maxWidth, h]
+  exact iSup_const
 
 /- ## Part IX: Lemniscates -/
 

--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -46,12 +46,14 @@
       "Upper and lower bounds on projection measures",
       "Connection to Bernoulli lemniscates",
       "Verified proof that the unit disk projects to measure exactly 2 in every direction (disk_projection_measure): the projection map z ↦ Re(z·conj u) sends the closed unit disk onto Set.Icc (-1) 1",
-      "Verified corollary that every monomial z^n level set has all projections equal to 2 (monomial_projection)"
+      "Verified corollary that every monomial z^n level set has all projections equal to 2 (monomial_projection)",
+      "Verified that the closed unit disk is a set of constant width 2 (disk_minWidth, disk_maxWidth): minWidth = maxWidth = 2, computing the width functions and giving the exact baseline the EHP conjecture asked every lemniscate to match",
+      "Verified lower bound on the Pommerenke constant (pommerenke_constant_lower): P ≥ 2.386, the structural content of Pommerenke's counterexample — the supremum over monic f of the minimum projection measure exceeds the disk's value 2"
     ],
     "axiomCount": 2,
-    "lineCount": 344,
-    "assumptions": "2 axioms: pommerenke_counterexample (Pommerenke — monic poly s.t. every projection of level set has measure ≥ 2.386), pommerenke_upper_bound (measure 3.3 is achievable as upper bound). 2 sorries remain in complex-analysis supporting lemmas (levelSet_connected_iff, levelSet_compact). disk_projection_measure and monomial_projection are now fully proved (0-axiom, only propext/Classical.choice/Quot.sound). The file now compiles cleanly (previously failed to elaborate due to missing scoped notation for `conj`/`ℝ≥0∞` and orphaned docstrings).",
-    "theoremCount": 12,
+    "lineCount": 375,
+    "assumptions": "2 axioms: pommerenke_counterexample (Pommerenke — monic poly s.t. every projection of level set has measure ≥ 2.386), pommerenke_upper_bound (measure 3.3 is achievable as upper bound). 0 sorries. disk_projection_measure, monomial_projection, disk_minWidth, disk_maxWidth are fully proved (0-axiom, only propext/Classical.choice/Quot.sound); pommerenke_constant_lower depends only on the intentional pommerenke_counterexample axiom. The file compiles cleanly.",
+    "theoremCount": 15,
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos1043Aristotle.lean"
@@ -258,9 +260,9 @@
       "Complex"
     ],
     "namespace": "Erdos1043",
-    "lineCount": 344,
+    "lineCount": 375,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 15,
     "definitionCount": 15,
     "sorries": 0,
     "path": "Proofs/Erdos1043Problem.lean",


### PR DESCRIPTION
## Summary

Adds 3 provable structural consequences to the (already-complete, 2-axiom) Erdős #1043 formalization on **polynomial level-set projections**. The core file was already at 0 sorries with 2 genuinely deep Pommerenke axioms (the counterexample and the 3.3 upper bound — real research results, not routine). Per the researcher methodology for a SOLVED problem, this session looks outward for provable structural consequences rather than manufacturing scaffolding on the deep axioms.

### New theorems (all compile; `lake env lean` exit 0)

1. **`disk_minWidth`** / **`disk_maxWidth`** — the closed unit disk is a set of **constant width 2**: `minWidth = maxWidth = 2`. This actually *computes* the width functions (`minWidth`/`maxWidth`) that were previously only defined, using the existing verified `disk_projection_measure` (every direction's projection has measure exactly 2). It pins down the precise baseline — width 2 in every direction — that the EHP conjecture asked every monic lemniscate to match. **0-axiom** (only propext/Classical.choice/Quot.sound).

2. **`pommerenke_constant_lower`** — the Pommerenke constant $\mathcal{P} = \sup_f \inf_u \mu(\pi_u(L_f)) \ge 2.386$. This is the structural content of Pommerenke's counterexample: since that polynomial has *every* projection $\ge 2.386$, its minimum projection measure is $\ge 2.386$, and the supremum over all monic $f$ inherits the bound. Makes explicit why $\mathcal{P} > 2$. Depends only on the intentional `pommerenke_counterexample` axiom (no new assumptions).

### Axiom integrity
- **No new axioms, no sorries.** Still exactly 2 intentional Pommerenke axioms (`pommerenke_counterexample`, `pommerenke_upper_bound`).
- Status remains `axiomatized` / badge `axiom`.

### Verification
- `lake env lean proofs/Proofs/Erdos1043Problem.lean` → exit 0 (only pre-existing unused-variable warnings in `convex_width_bounds`/`levelSet_compact`, untouched by this PR).

### Gallery metadata
- `theoremCount` 12 → 15, `lineCount` 344 → 375 (both blocks).
- Added `originalContributions` entries; refreshed stale `assumptions` text (it wrongly still claimed "2 sorries remain").

🤖 Generated with [Claude Code](https://claude.com/claude-code)