### PR TITLE
Enrich Bezout explicit factorization over 𝔽_p and ℚ: annotate the 𝔽_p specialization

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/annotations.json
@@ -39,6 +39,23 @@
     "prerequisites": ["finite fields", "polynomial roots", "monic polynomials"]
   },
   {
+    "id": "ann-bezout-fp-zmod",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 74, "endLine": 90 },
+    "type": "technique",
+    "title": "Specializing to 𝔽_p in One Rewrite",
+    "content": "fermat_factorization_zmod is the concrete-prime form X^p − X = ∏_{a:ZMod p}(X − a) the parent explicitly advertised, and it costs a single rewrite: instantiate the general finite-field theorem at K = ZMod p and replace the abstract cardinality Fintype.card (ZMod p) by p via ZMod.card p. The `Fact p.Prime` instance is what makes ZMod p a field (so the [Field K] hypothesis of fermat_factorization is discharged automatically) — for composite n, ZMod n is only a ring and the statement fails. This is the model for how an abstract finite-field result is turned into the usable 𝔽_p statement, and it sets up the Section II Frobenius theorems that follow, which live specifically over ZMod p.",
+    "mathContext": "$X^p - X = \\prod_{a \\in \\mathbb{F}_p}(X - a)$, from the general form at $K = \\mathbb{Z}/p$ with $|\\mathbb{Z}/p| = p$; needs $p$ prime for $\\mathbb{Z}/p$ to be a field.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ZMod.card (|ZMod p| = p)",
+      "ZMod p as the canonical 𝔽_p",
+      "Fact p.Prime giving the field instance",
+      "specializing an abstract theorem to a concrete type"
+    ],
+    "prerequisites": ["ZMod p and modular arithmetic", "prime p makes ZMod p a field", "the general Fermat factorization"]
+  },
+  {
     "id": "ann-bezout-fp-frobenius",
     "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
     "range": { "startLine": 91, "endLine": 100 },


### PR DESCRIPTION
Enrichment pass (pass 0) for `bezout-identity-oq-02-oq-01-oq-01-oq-02`.

## Gap addressed
meta.json was already rich, but the entry had only **4 annotations** and Lean lines 74–90 — the `fermat_factorization_zmod` result (one of the five named main results) plus the Section II header — were uncovered, a gap between the general Fermat-factorization annotation (51–73) and the Frobenius annotation (91–100).

## Change
Added `ann-bezout-fp-zmod` (range 74–90) covering the 𝔽_p specialization:
- `X^p − X = ∏_{a:ZMod p}(X − a)` obtained from the general finite-field theorem in one rewrite via `ZMod.card p`
- why `Fact p.Prime` is essential (it supplies the field instance; for composite n, ZMod n is only a ring and the statement fails)
- how this sets up the Section II Frobenius theorems, which live over `ZMod p`

Annotation carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Verified with `pnpm build`. No changes to Lean source or axiom/status claims (still verified, 0-axiom).