### PR TITLE
research(van-der-waerden-first-moment-oq-02): linear-in-n AP-hypergraph dependency-degree bound k²·n [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/VanDerWaerdenFirstMomentOQ02.lean
+++ b/proofs/Proofs/VanDerWaerdenFirstMomentOQ02.lean
@@ -1,0 +1,197 @@
+/-
+  Bounded dependency degree of the AP-hypergraph
+  (open question van-der-waerden-first-moment-oq-02, the Lovász-Local-Lemma route)
+
+  The base entry `Proofs.VanDerWaerdenFirstMoment` proves the first-moment
+  (union-bound) lower bound `W(k) ≳ 2^((k-1)/2)` by instantiating the gallery's
+  Property-B engine on the AP-hypergraph.  The Seeker's open question asks to push
+  the exponent up to the Lovász-Local-Lemma form `W(k) ≳ 2^k/(e·k)`.  As the
+  question itself notes, the LLL route needs two verified ingredients:
+
+    (1) a symmetric Lovász Local Lemma statement, and
+    (2) **a bound on the AP-overlap ("dependency") degree** of the hypergraph.
+
+  This file supplies ingredient (2) — the concrete, elementary combinatorial
+  input — outright, with 0 axioms.  Ingredient (1) is a genuine build (Mathlib
+  has no symmetric LLL) and remains the open gap; see the closing remarks.
+
+  WHY THE DEGREE BOUND MUST BE LINEAR IN `n`.  In the LLL each event
+  `A_e = "AP e is monochromatic"` is mutually independent of every `A_f` whose AP
+  `f` is disjoint from `e`; the dependency degree is therefore
+  `d = max_e #{f ∈ family : f ≠ e, f ∩ e ≠ ∅}`.  The symmetric LLL then gives a
+  good colouring whenever `e · 2^(1-k) · (d+1) ≤ 1`, i.e. `n ≲ 2^(k-1)/(e·d/n)`.
+  Only a bound `d ≤ C(k)·n` *linear in n* turns this into `W(k) ≳ 2^k/(e·k)`;
+  the trivial `d ≤ |family| ≤ n²` (quadratic) recovers nothing beyond the
+  first-moment `2^(k/2)`.  So the content here is precisely the *linear* bound.
+
+  MAIN RESULTS
+    * `exists_index_of_mem`       — recover the index `i < k` with `x = a + i·d`
+                                    from `x ∈ vdwAP n a d k`.
+    * `card_params_through_le`    — at most `k·n` fitting parameter pairs `(a,d)`
+                                    put a length-`k` AP through a fixed point `x`
+                                    (via the injection `(a,d) ↦ ((x-a)/d, d)`).
+    * `card_family_through_le`    — hence at most `k·n` APs of the family contain
+                                    a fixed point.
+    * `card_vdwFamily_meeting_le` /
+      `vdwHypergraph_degree_le`   — **the dependency-degree bound**: every
+                                    length-`k` AP meets at most `k²·n` members of
+                                    the family (each of its `k` points lies on
+                                    `≤ k·n` APs).
+
+  Everything is elementary counting on the base entry's `vdwAP` / `vdwFamily`;
+  the probabilistic core is untouched.
+
+  Status: 0 sorries, 0 axioms, no `native_decide`.  #print axioms reports only
+  `propext, Classical.choice, Quot.sound`.
+-/
+import Mathlib
+import Proofs.VanDerWaerdenFirstMoment
+
+namespace ProbMethod.VanDerWaerden
+
+open Finset
+open scoped Fin.NatCast
+
+variable {n : ℕ} [NeZero n]
+
+/-- **Index recovery.** If the length-`k` AP with first term `a` and step `d`
+fits in `[n]` (`a + (k-1)d < n`) and the point `x` lies on it, then
+`x = a + i·d` (as underlying naturals) for some index `i < k`. -/
+theorem exists_index_of_mem {a d k : ℕ} (hbound : a + (k - 1) * d < n)
+    {x : Fin n} (hx : x ∈ vdwAP n a d k) : ∃ i < k, (x : Fin n).val = a + i * d := by
+  rw [vdwAP, Finset.mem_image] at hx
+  obtain ⟨i, hi, hxi⟩ := hx
+  rw [Finset.mem_range] at hi
+  refine ⟨i, hi, ?_⟩
+  have hb : a + i * d < n := by
+    have : i * d ≤ (k - 1) * d := Nat.mul_le_mul_right d (by omega)
+    omega
+  rw [← hxi, Fin.val_cast_of_lt hb]
+
+/-- **APs through a fixed point: parameter count.**
+At most `k · n` fitting parameter pairs `(a, d)` produce a length-`k` AP through a
+given point `x`.  The map `(a, d) ↦ ((x - a)/d, d)` sends such a pair to its index
+`i = (x - a)/d < k` together with the step `d ∈ {1, …, n}`, and is injective
+because `a = x - i·d` is recovered from the image. -/
+theorem card_params_through_le (k : ℕ) (x : Fin n) :
+    (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+        (fun p => p.1 + (k - 1) * p.2 < n ∧ x ∈ vdwAP n p.1 p.2 k)).card ≤ k * n := by
+  classical
+  have hcard :
+      (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+        (fun p => p.1 + (k - 1) * p.2 < n ∧ x ∈ vdwAP n p.1 p.2 k)).card
+      ≤ ((Finset.range k) ×ˢ (Finset.Icc 1 n)).card := by
+    apply Finset.card_le_card_of_injOn
+      (fun p => (((x : Fin n).val - p.1) / p.2, p.2))
+    · -- maps into (range k) ×ˢ (Icc 1 n)
+      intro p hp
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_product, Finset.mem_Icc,
+        Finset.mem_range] at hp
+      obtain ⟨⟨-, hd⟩, hbound, hmem⟩ := hp
+      obtain ⟨i, hik, hxi⟩ := exists_index_of_mem hbound hmem
+      have hsub : (x : Fin n).val - p.1 = i * p.2 := by omega
+      simp only [Finset.mem_coe, Finset.mem_product, Finset.mem_range, Finset.mem_Icc]
+      refine ⟨?_, hd⟩
+      rw [hsub, Nat.mul_div_cancel _ hd.1]
+      exact hik
+    · -- injective on the filtered set
+      intro p hp q hq hfeq
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_product, Finset.mem_Icc,
+        Finset.mem_range] at hp hq
+      obtain ⟨⟨-, hdp⟩, hbp, hmp⟩ := hp
+      obtain ⟨⟨-, hdq⟩, hbq, hmq⟩ := hq
+      obtain ⟨ip, hipk, hxp⟩ := exists_index_of_mem hbp hmp
+      obtain ⟨iq, hiqk, hxq⟩ := exists_index_of_mem hbq hmq
+      simp only [Prod.mk.injEq] at hfeq
+      obtain ⟨hfst, hd⟩ := hfeq
+      have hdivp : ((x : Fin n).val - p.1) / p.2 = ip := by
+        have : (x : Fin n).val - p.1 = ip * p.2 := by omega
+        rw [this, Nat.mul_div_cancel _ hdp.1]
+      have hdivq : ((x : Fin n).val - q.1) / q.2 = iq := by
+        have : (x : Fin n).val - q.1 = iq * q.2 := by omega
+        rw [this, Nat.mul_div_cancel _ hdq.1]
+      rw [hdivp, hdivq] at hfst
+      -- hfst : ip = iq ; hd : p.2 = q.2
+      have hprod : ip * p.2 = iq * q.2 := by rw [hfst, hd]
+      have hp1 : p.1 = q.1 := by omega
+      exact Prod.ext hp1 hd
+  calc
+    (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+        (fun p => p.1 + (k - 1) * p.2 < n ∧ x ∈ vdwAP n p.1 p.2 k)).card
+        ≤ ((Finset.range k) ×ˢ (Finset.Icc 1 n)).card := hcard
+    _ = k * n := by
+        rw [Finset.card_product, Finset.card_range, Nat.card_Icc, Nat.add_sub_cancel]
+
+/-- **APs of the family through a fixed point.**
+At most `k · n` length-`k` APs of `vdwFamily n k` contain a given point `x`.
+The family is the image of the fitting parameter set under `vdwAP`, so each member
+through `x` comes from a parameter pair through `x`, of which there are `≤ k·n`. -/
+theorem card_family_through_le (k : ℕ) (x : Fin n) :
+    ((vdwFamily n k).filter (fun f => x ∈ f)).card ≤ k * n := by
+  classical
+  have hsub :
+      (vdwFamily n k).filter (fun f => x ∈ f)
+      ⊆ (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+            (fun p => p.1 + (k - 1) * p.2 < n ∧ x ∈ vdwAP n p.1 p.2 k)).image
+            (fun p => vdwAP n p.1 p.2 k) := by
+    intro f hf
+    rw [Finset.mem_filter] at hf
+    obtain ⟨hfam, hxf⟩ := hf
+    rw [vdwFamily, Finset.mem_image] at hfam
+    obtain ⟨p, hp, rfl⟩ := hfam
+    rw [Finset.mem_filter] at hp
+    obtain ⟨hpmem, hpb⟩ := hp
+    rw [Finset.mem_image]
+    exact ⟨p, Finset.mem_filter.mpr ⟨hpmem, hpb, hxf⟩, rfl⟩
+  calc
+    ((vdwFamily n k).filter (fun f => x ∈ f)).card
+        ≤ ((((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+            (fun p => p.1 + (k - 1) * p.2 < n ∧ x ∈ vdwAP n p.1 p.2 k)).image
+            (fun p => vdwAP n p.1 p.2 k)).card := Finset.card_le_card hsub
+    _ ≤ (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+            (fun p => p.1 + (k - 1) * p.2 < n ∧ x ∈ vdwAP n p.1 p.2 k)).card :=
+          Finset.card_image_le
+    _ ≤ k * n := card_params_through_le k x
+
+/-- **Dependency-degree bound for the AP-hypergraph (product form).**
+Every length-`k` AP `e` of the family meets at most `k · (k · n)` members of the
+family: `e` has exactly `k` points, and each point lies on at most `k · n` APs
+of the family (`card_family_through_le`). -/
+theorem card_vdwFamily_meeting_le {k : ℕ} {e : Finset (Fin n)}
+    (he : e ∈ vdwFamily n k) :
+    ((vdwFamily n k).filter (fun f => (e ∩ f).Nonempty)).card ≤ k * (k * n) := by
+  classical
+  have hecard : e.card = k := vdwFamily_uniform k e he
+  have hsub :
+      (vdwFamily n k).filter (fun f => (e ∩ f).Nonempty)
+      ⊆ e.biUnion (fun x => (vdwFamily n k).filter (fun f => x ∈ f)) := by
+    intro f hf
+    rw [Finset.mem_filter] at hf
+    obtain ⟨hfam, hne⟩ := hf
+    obtain ⟨x, hx⟩ := hne
+    rw [Finset.mem_inter] at hx
+    rw [Finset.mem_biUnion]
+    exact ⟨x, hx.1, Finset.mem_filter.mpr ⟨hfam, hx.2⟩⟩
+  calc
+    ((vdwFamily n k).filter (fun f => (e ∩ f).Nonempty)).card
+        ≤ (e.biUnion (fun x => (vdwFamily n k).filter (fun f => x ∈ f))).card :=
+          Finset.card_le_card hsub
+    _ ≤ ∑ x ∈ e, ((vdwFamily n k).filter (fun f => x ∈ f)).card :=
+          Finset.card_biUnion_le
+    _ ≤ ∑ _x ∈ e, k * n := Finset.sum_le_sum (fun x _ => card_family_through_le k x)
+    _ = e.card * (k * n) := by rw [Finset.sum_const, smul_eq_mul]
+    _ = k * (k * n) := by rw [hecard]
+
+/-- **Dependency-degree bound for the AP-hypergraph, `k²·n` form.**
+The maximum degree of the AP-overlap graph on `vdwFamily n k` is at most `k² · n`.
+This is the linear-in-`n` dependency bound the symmetric Lovász Local Lemma needs
+to upgrade the first-moment `W(k) ≳ 2^((k-1)/2)` to `W(k) ≳ 2^k/(e·k)`. -/
+theorem vdwHypergraph_degree_le {k : ℕ} {e : Finset (Fin n)}
+    (he : e ∈ vdwFamily n k) :
+    ((vdwFamily n k).filter (fun f => (e ∩ f).Nonempty)).card ≤ k ^ 2 * n := by
+  calc
+    ((vdwFamily n k).filter (fun f => (e ∩ f).Nonempty)).card
+        ≤ k * (k * n) := card_vdwFamily_meeting_le he
+    _ = k ^ 2 * n := by ring
+
+end ProbMethod.VanDerWaerden

--- a/src/data/proofs/van-der-waerden-first-moment-oq-02/annotations.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-02/annotations.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "ann-vdw-oq02-context",
+    "proofId": "van-der-waerden-first-moment-oq-02",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "The Lovász-Local-Lemma Route and Why the Degree Bound Must Be Linear",
+    "content": "**Open question OQ-02** to `van-der-waerden-first-moment`: push the union-bound lower bound $W(k) \\gtrsim 2^{(k-1)/2}$ up to the **Lovász-Local-Lemma** form $W(k) \\gtrsim 2^k/(e\\,k)$. The question names two verified ingredients this needs: (1) a **symmetric Lovász Local Lemma**, and (2) **a bound on the AP-overlap ('dependency') degree**. This entry supplies ingredient (2). The critical point is *linearity in $n$*: in the LLL each event $A_e = $ '$e$ monochromatic' is mutually independent of every $A_f$ with $f \\cap e = \\emptyset$, so the dependency degree is $d = \\max_e \\#\\{f : f \\ne e,\\ f \\cap e \\ne \\emptyset\\}$, and the symmetric LLL succeeds when $e \\cdot 2^{1-k}(d+1) \\le 1$. A bound $d \\le k^2 n$ **linear in $n$** gives $n \\lesssim 2^{k-1}/(e k^2)$, i.e. $W(k) \\gtrsim 2^k/(ek)$; the trivial quadratic $d \\le |\\text{family}| \\le n^2$ recovers only $2^{k/2}$.",
+    "mathContext": "The base entry proves $W(k) \\gtrsim 2^{(k-1)/2}$ via Property B (union bound). The LLL improves the exponent from $k/2$ to $k$, and the linear-in-$n$ dependency degree is precisely the quantitative reason.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "van der Waerden numbers",
+      "dependency graph of events",
+      "AP-hypergraph",
+      "union bound vs local lemma"
+    ],
+    "prerequisites": [
+      "First-moment lower bound W(k) ≳ 2^((k-1)/2) (parent van-der-waerden-first-moment)",
+      "vdwAP / vdwFamily / vdwFamily_uniform from the base entry",
+      "Symmetric Lovász Local Lemma condition e·p·(d+1) ≤ 1 (context only; not formalized here)"
+    ]
+  },
+  {
+    "id": "ann-vdw-oq02-index-recovery",
+    "proofId": "van-der-waerden-first-moment-oq-02",
+    "range": { "startLine": 58, "endLine": 73 },
+    "type": "lemma",
+    "title": "exists_index_of_mem — from geometry to arithmetic",
+    "content": "`exists_index_of_mem` bridges membership and parameters: if the length-$k$ AP $\\{a, a+d, \\ldots, a+(k-1)d\\}$ fits in $[n]$ (i.e. $a + (k-1)d < n$) and $x$ lies on it, then $x = a + i\\cdot d$ for some index $i < k$ (equality of underlying naturals). The proof unfolds `vdwAP = (range k).image (i ↦ cast(a + i·d))`, extracts $i < k$ with $\\mathrm{cast}(a+i\\cdot d) = x$, and uses `Fin.val_cast_of_lt` on $a + i\\cdot d \\le a + (k-1)d < n$ to strip the cast. This is the input to the parameter injection.",
+    "mathContext": "Converts 'x is on this AP' into the algebraic relation x = a + i·d, which lets the first term a be recovered from (index, step).",
+    "significance": "standard",
+    "relatedConcepts": ["arithmetic progression", "Fin.val_cast_of_lt", "Finset.mem_image"],
+    "prerequisites": ["vdwAP definition (base entry)"]
+  },
+  {
+    "id": "ann-vdw-oq02-parameter-count",
+    "proofId": "van-der-waerden-first-moment-oq-02",
+    "range": { "startLine": 75, "endLine": 127 },
+    "type": "lemma",
+    "title": "card_params_through_le — the k·n per-point injection (crux)",
+    "content": "**The heart of the entry.** At most $k \\cdot n$ fitting parameter pairs $(a, d)$ produce a length-$k$ AP through a fixed point $x$. Proof: inject such pairs into $\\{0,\\ldots,k-1\\} \\times \\{1,\\ldots,n\\}$ by $(a,d) \\mapsto ((x-a)/d,\\ d)$. By `exists_index_of_mem`, $x = a + i\\cdot d$, so $x - a = i\\cdot d$ and $(x-a)/d = i < k$ (`Nat.mul_div_cancel`), landing the map in `range k ×ˢ Icc 1 n`. Injectivity: from the image $(i, d)$ the first term $a = x - i\\cdot d$ is recovered, so the pair is determined. Hence the count is $\\le |{\\rm range}\\,k \\times {\\rm Icc}\\,1\\,n| = k\\cdot n$. **This is the only step where linearity in $n$ enters** — the step $d$ ranges over $\\le n$ values and the index over $k$.",
+    "mathContext": "The linear factor n is the number of admissible steps; the factor k is the number of positions x can occupy on an AP. Together they give the k·n per-point bound that makes the LLL work.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.card_le_card_of_injOn",
+      "injective parametrization",
+      "Nat.mul_div_cancel",
+      "lattice-point counting"
+    ],
+    "prerequisites": ["exists_index_of_mem", "Finset product cardinality"]
+  },
+  {
+    "id": "ann-vdw-oq02-family-transfer",
+    "proofId": "van-der-waerden-first-moment-oq-02",
+    "range": { "startLine": 129, "endLine": 157 },
+    "type": "lemma",
+    "title": "card_family_through_le — transfer to the family of AP-sets",
+    "content": "`card_family_through_le` lifts the parameter bound to the family of AP-*sets*: at most $k\\cdot n$ members of `vdwFamily n k` contain a fixed point $x$. Since the family is the image of the fitting-parameter set under $(a,d) \\mapsto$ `vdwAP n a d k`, every family member through $x$ is the image of a parameter pair through $x$; so the family-through-$x$ set is contained in the image of the parameter-through-$x$ set, and `Finset.card_image_le` bounds it by the parameter count $k\\cdot n$. (Distinct parameters may yield the same AP-set, but that only *helps* the inequality.)",
+    "mathContext": "Bridges the parameter-space count and the set-space count, since the LLL dependency is between AP-sets, not parameter pairs.",
+    "significance": "standard",
+    "relatedConcepts": ["Finset.card_image_le", "image of a filtered set", "vdwFamily"],
+    "prerequisites": ["card_params_through_le", "vdwFamily definition (base entry)"]
+  },
+  {
+    "id": "ann-vdw-oq02-degree-bound",
+    "proofId": "van-der-waerden-first-moment-oq-02",
+    "range": { "startLine": 159, "endLine": 197 },
+    "type": "theorem",
+    "title": "vdwHypergraph_degree_le — the k²·n dependency-degree bound",
+    "content": "**The main result.** Every length-$k$ AP $e$ of the family meets at most $k^2 n$ other members. Proof (`card_vdwFamily_meeting_le`): $e$ has exactly $k$ points (`vdwFamily_uniform` from the base entry); any family AP $f$ overlapping $e$ shares a point $x \\in e$, so the set of overlapping $f$ injects into $\\bigcup_{x \\in e}\\{f : x \\in f\\}$, and `Finset.card_biUnion_le` bounds its size by $\\sum_{x \\in e} k\\cdot n = e.\\mathrm{card}\\cdot(k n) = k\\cdot(k n)$; `vdwHypergraph_degree_le` restates this as $k^2 n$ via `ring`. This linear-in-$n$ maximum degree is exactly the quantitative dependency input the symmetric Lovász Local Lemma consumes. **Scope:** this entry supplies only LLL ingredient (2); a verified symmetric LLL (ingredient 1, absent from Mathlib) remains the open gap, so $W(k) \\gtrsim 2^k/(ek)$ is not concluded here.",
+    "mathContext": "Union bound over the k points of e, each on ≤ k·n APs, gives degree ≤ k²·n — the verified combinatorial half of the LLL van der Waerden argument.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.card_biUnion_le",
+      "maximum degree of a hypergraph",
+      "dependency degree",
+      "Lovász Local Lemma ingredient"
+    ],
+    "prerequisites": ["card_family_through_le", "vdwFamily_uniform (base entry)"]
+  }
+]

--- a/src/data/proofs/van-der-waerden-first-moment-oq-02/meta.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-02/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "van-der-waerden-first-moment-oq-02",
+  "slug": "van-der-waerden-first-moment-oq-02",
+  "title": "Linear-in-n Dependency-Degree Bound for the AP-Hypergraph (the Lovász-Local-Lemma Ingredient)",
+  "description": "The gallery's first-moment lower bound for van der Waerden numbers (van-der-waerden-first-moment) gives W(k) ≳ 2^((k-1)/2) by instantiating the Property-B engine on the AP-hypergraph. Its open question oq-02 asks to push the exponent up to the Lovász-Local-Lemma form W(k) ≳ 2^k/(e·k). As the question itself states, the LLL route needs two verified ingredients: (1) a symmetric Lovász Local Lemma statement, and (2) a bound on the AP-overlap ('dependency') degree of the hypergraph. This entry supplies ingredient (2) outright, with 0 axioms. The crux is that the bound must be LINEAR in n. In the LLL each event A_e = 'AP e is monochromatic' is mutually independent of every A_f whose AP f is disjoint from e, so the dependency degree is d = max_e #{f ∈ family : f ≠ e, f ∩ e ≠ ∅}, and the symmetric LLL yields a good colouring whenever e·2^(1-k)·(d+1) ≤ 1. Only a bound d ≤ C(k)·n LINEAR in n turns this into W(k) ≳ 2^k/(e·k); the trivial d ≤ |family| ≤ n² (quadratic) recovers nothing beyond the first-moment 2^(k/2). The content here is exactly the linear bound d ≤ k²·n (vdwHypergraph_degree_le). It is proved in three elementary steps on the base entry's vdwAP/vdwFamily: (a) exists_index_of_mem recovers the index i < k with x = a + i·d from membership x ∈ vdwAP n a d k; (b) card_params_through_le bounds by k·n the fitting parameter pairs (a,d) whose AP passes through a fixed point x, via the injection (a,d) ↦ ((x-a)/d, d) — the index i = (x-a)/d < k and step d determine the pair since a = x - i·d is recovered; (c) card_family_through_le transfers this to at most k·n family APs through x (the family is the image of the parameter set under vdwAP); and finally each length-k AP e, having exactly k points, meets at most k·(k·n) = k²·n others (card_vdwFamily_meeting_le, a Finset.card_biUnion_le over the k points of e). HONESTY: this is elementary lattice-point counting on the base entry's verified AP combinatorics; it delivers ONLY the second of the two LLL ingredients. A verified symmetric Lovász Local Lemma (ingredient 1) is not in Mathlib and remains the open gap, so the full W(k) ≳ 2^k/(e·k) bound is not established here. #print axioms reports only propext, Classical.choice, Quot.sound for all theorems; 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius researcher-5",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VanDerWaerdenFirstMomentOQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 197,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only propext, Classical.choice, Quot.sound for vdwHypergraph_degree_le, card_vdwFamily_meeting_le, and card_params_through_le. The AP combinatorics (vdwAP, vdwFamily, vdwFamily_uniform) are reused from the verified base entry van-der-waerden-first-moment as a black box; this entry contributes the linear-in-n dependency-degree bound on top of them. This entry delivers only the second of the two LLL ingredients named in open question oq-02 (the overlap-degree bound); the first ingredient, a verified symmetric Lovász Local Lemma, is a genuine build absent from Mathlib and remains open, so the target W(k) ≳ 2^k/(ek) is NOT established here. Badged 'original' because the linear dependency-degree bound is new content layered on a verified base entry, not a Mathlib headline theorem.",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "lovasz-local-lemma",
+      "van-der-waerden",
+      "arithmetic-progressions",
+      "hypergraph-degree",
+      "lattice-point-counting",
+      "open-question"
+    ],
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "vdwHypergraph_degree_le: the maximum degree of the AP-overlap graph on vdwFamily n k is at most k²·n — the LINEAR-in-n dependency bound the symmetric Lovász Local Lemma consumes to upgrade the first-moment W(k) ≳ 2^((k-1)/2) toward W(k) ≳ 2^k/(ek); the linearity (versus the trivial quadratic |family| ≤ n²) is the entire point",
+      "card_params_through_le: at most k·n fitting parameter pairs (a,d) put a length-k AP through a fixed point x, proved by the injection (a,d) ↦ ((x-a)/d, d) into {0,…,k-1} × {1,…,n} — the index i = (x-a)/d and step d recover a = x - i·d, giving injectivity",
+      "card_family_through_le: at most k·n length-k APs of the family contain a fixed point x — transferring the parameter count through the image map vdwAP that defines the family",
+      "card_vdwFamily_meeting_le: every length-k AP e meets at most k·(k·n) members of the family, a Finset.card_biUnion_le over the exactly-k points of e (e.card = k from the base entry's vdwFamily_uniform)",
+      "exists_index_of_mem: from x ∈ vdwAP n a d k with a fitting AP (a + (k-1)d < n), recover the index i < k with x = a + i·d as underlying naturals — the membership-to-parameter bridge underlying the injection"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "bounds the fitting-parameter-through-a-point set by (range k) ×ˢ (Icc 1 n) via the injection (a,d) ↦ ((x-a)/d, d), giving the crucial k·n per-point count.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_biUnion_le",
+        "description": "bounds the number of family APs meeting e by the sum, over the k points of e, of the per-point counts — turning the point-degree bound into the AP-overlap-degree bound.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_image_le",
+        "description": "the family-through-a-point set is the image of the parameter-through-a-point set under vdwAP, so its cardinality is at most the parameter count.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel",
+        "description": "recovers the index i = (x-a)/d = (i·d)/d from the exact ℕ-division, both to land the map in range k and to establish its injectivity.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/VanDerWaerdenFirstMomentOQ02.lean",
+    "namespace": "ProbMethod.VanDerWaerden",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 197,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "sorries": 0,
+  "overview": {
+    "problemStatement": "Van der Waerden's theorem gives, for each k, a least N = W(k) such that every 2-colouring of {0,…,N-1} contains a monochromatic length-k arithmetic progression. The gallery's first-moment entry proves the union-bound lower bound W(k) ≳ 2^((k-1)/2). Its open question oq-02 asks for the sharper Lovász-Local-Lemma bound W(k) ≳ 2^k/(ek), which needs (1) a verified symmetric Lovász Local Lemma and (2) a bound on the dependency degree of the AP-hypergraph — the maximum number of length-k APs overlapping a given one. This entry proves ingredient (2): the dependency degree is at most k²·n.",
+    "keyInsights": [
+      "The dependency-degree bound must be LINEAR in n. The symmetric LLL needs e·2^(1-k)·(d+1) ≤ 1; a linear bound d ≤ k²·n gives n ≲ 2^(k-1)/(e·k²), i.e. W(k) ≳ 2^k/(ek), whereas the trivial quadratic d ≤ |family| ≤ n² recovers only the first-moment 2^(k/2). Linearity is the whole content.",
+      "The number of length-k APs through a fixed point is at most k·n: an AP through x is pinned down by the index i < k at which x sits and the step d ∈ {1,…,n}, and these recover the first term a = x - i·d. The map (a,d) ↦ ((x-a)/d, d) makes this an injection.",
+      "The AP-overlap degree follows by a union bound over points: a length-k AP e has exactly k points (base entry's vdwFamily_uniform), each on ≤ k·n family APs, so e overlaps ≤ k·(k·n) = k²·n others (Finset.card_biUnion_le).",
+      "The whole argument is elementary counting layered on the base entry's vdwAP/vdwFamily; the probabilistic core is untouched, and no LLL machinery is used — this entry is deliberately scoped to the combinatorial ingredient alone."
+    ],
+    "proofStrategy": "Recover the index (exists_index_of_mem): x ∈ vdwAP n a d k with a fitting AP forces x = a + i·d for some i < k, by unfolding the image definition and using Fin.val_cast_of_lt on the below-n terms. Count parameters through a point (card_params_through_le): inject the fitting (a,d) with x on their AP into (range k) ×ˢ (Icc 1 n) via (a,d) ↦ ((x-a)/d, d); the map lands correctly because (x-a)/d = i < k, and is injective because a = x - i·d is recovered once i and d are known; conclude card ≤ k·n. Transfer to the family (card_family_through_le): the family is the image of the parameter set under vdwAP, so family APs through x are ≤ parameters through x ≤ k·n (Finset.card_image_le). Union-bound over points (card_vdwFamily_meeting_le): the APs meeting e inject into the biUnion over x ∈ e of the family-through-x sets, so their count is ≤ ∑_{x∈e} k·n = e.card·(k·n) = k·(k·n); restate as k²·n (vdwHypergraph_degree_le).",
+    "historicalContext": "The Lovász Local Lemma (Erdős–Lovász 1975) improved probabilistic lower bounds for van der Waerden numbers from the union-bound W(k) ≳ 2^(k/2) to W(k) ≳ 2^k/(ek), by exploiting that a monochromatic-AP event depends only on the colours of that AP's k points and hence is independent of the events for APs disjoint from it. The quantitative input is precisely a bound on how many APs can overlap a given one — the dependency degree formalized here. The symmetric-LLL half of the argument (a positive-probability statement about events of bounded probability and bounded dependency) is classical but not yet in Mathlib; this entry isolates and verifies the combinatorial half."
+  },
+  "sections": [
+    {
+      "id": "index-recovery",
+      "title": "Recovering the AP index from membership",
+      "content": "exists_index_of_mem turns geometric membership into an arithmetic parameter. If the length-k AP with first term a and step d fits in [n] (a + (k-1)d < n) and the point x lies on it, then unfolding vdwAP = (range k).image (i ↦ cast(a + i·d)) yields an index i < k with cast(a + i·d) = x; since a + i·d ≤ a + (k-1)d < n, Fin.val_cast_of_lt gives x = a + i·d as underlying naturals. This is the bridge from 'x is on this AP' to 'x = a + i·d', enabling the parameter injection."
+    },
+    {
+      "id": "parameter-count",
+      "title": "At most k·n parameter pairs put an AP through a fixed point",
+      "content": "card_params_through_le is the crux. Among fitting pairs (a,d) whose length-k AP passes through a fixed point x, map (a,d) ↦ ((x-a)/d, d). By exists_index_of_mem, x = a + i·d, so x - a = i·d and (x-a)/d = i < k (Nat.mul_div_cancel) — the map lands in (range k) ×ˢ (Icc 1 n). It is injective: if two pairs share image (i, d), then a = x - i·d is the same for both, so the pairs coincide. Hence the count is at most |(range k) ×ˢ (Icc 1 n)| = k·n. This is the sole place linearity in n enters: the step d ranges over ≤ n values and the index over k."
+    },
+    {
+      "id": "family-transfer",
+      "title": "Transferring the count to the AP family",
+      "content": "card_family_through_le lifts the parameter count to the family of AP-sets. Since vdwFamily n k is the image of the fitting-parameter set under (a,d) ↦ vdwAP n a d k, every family member containing x is the image of a parameter pair whose AP contains x. So the family-through-x set is contained in the image of the parameter-through-x set, and Finset.card_image_le bounds its cardinality by the parameter count k·n."
+    },
+    {
+      "id": "degree-bound",
+      "title": "The dependency-degree bound k²·n",
+      "content": "card_vdwFamily_meeting_le / vdwHypergraph_degree_le assemble the answer. A length-k AP e has exactly k points (vdwFamily_uniform from the base entry). Any family AP f overlapping e shares a point x ∈ e, so the overlapping-f set injects into the biUnion over x ∈ e of the family-through-x sets; Finset.card_biUnion_le then bounds its size by ∑_{x∈e} k·n = e.card·(k·n) = k·(k·n) = k²·n. This linear-in-n maximum degree is exactly the quantitative dependency input the symmetric Lovász Local Lemma consumes."
+    },
+    {
+      "id": "scope",
+      "title": "Scope and the remaining open gap",
+      "content": "This entry deliberately proves only the combinatorial ingredient (2) of open question oq-02. The remaining ingredient (1), a verified symmetric Lovász Local Lemma — a positive-probability guarantee for finitely many events of probability ≤ p with dependency degree ≤ d satisfying e·p·(d+1) ≤ 1 — is not in Mathlib and is a genuine build (conditional-probability induction). Only once it is available can k²·n be fed in to conclude W(k) ≳ 2^k/(ek). Reporting honestly: the exponent-doubling target of oq-02 is not reached here; the linear dependency-degree bound is the verified step toward it."
+    }
+  ],
+  "conclusion": {
+    "summary": "The AP-overlap (dependency) degree of the length-k AP-hypergraph on [n] is at most k²·n — a bound linear in n, which is exactly what the symmetric Lovász Local Lemma needs to upgrade the first-moment van der Waerden bound W(k) ≳ 2^((k-1)/2) toward W(k) ≳ 2^k/(ek). The proof is elementary lattice-point counting on the base entry's verified AP combinatorics: each point lies on ≤ k·n APs (an injection into index × step), and each length-k AP has k points. 0 axioms, 0 sorries, no native_decide.",
+    "implications": [
+      "Supplies the second of the two ingredients named in open question oq-02 for the LLL lower bound on van der Waerden numbers, verified with 0 axioms.",
+      "The linear-in-n dependency degree k²·n (versus the trivial quadratic n²) is the quantitative gap between the union-bound exponent k/2 and the LLL exponent k.",
+      "The per-point count k·n and the injection technique (parametrize an AP through x by its index and step) are reusable for other AP-counting and hypergraph-degree arguments in the gallery."
+    ],
+    "openQuestions": [
+      "Build a verified symmetric Lovász Local Lemma in Lean (finitely many events of probability ≤ p, dependency degree ≤ d, e·p·(d+1) ≤ 1 ⟹ positive probability none occur) — the missing ingredient (1) that, combined with this entry's k²·n bound, would yield W(k) ≳ 2^k/(ek).",
+      "Sharpen the per-point count from k·n to ~k·n/(k-1) by bounding the step d ≤ (n-1)/(k-1) (as done for the total count in sibling oq-01), improving the dependency degree from k²·n to ~k²·n/(k-1) and the resulting LLL constant.",
+      "Prove the matching lower bound on the maximum degree (some AP is met by ≳ k²·n/(k-1) others) to show the k²·n bound is tight up to the constant."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "van-der-waerden-first-moment",
+      "relationship": "parent — this entry answers that entry's open question oq-02 by supplying the AP-overlap dependency-degree bound, reusing its vdwAP/vdwFamily/vdwFamily_uniform"
+    },
+    {
+      "targetId": "van-der-waerden-first-moment-oq-01",
+      "relationship": "sibling — oq-01 sharpens the TOTAL AP count (n² → n²/(2(k-1))); this oq-02 bounds the per-AP overlap degree (k²·n), the complementary quantity the Lovász Local Lemma needs"
+    },
+    {
+      "targetId": "property-b-first-moment",
+      "relationship": "engine — the base entry's probabilistic core (Erdős 1963 Property B via the first moment method); the LLL route this entry serves would replace that union-bound engine with a stronger local-lemma engine"
+    },
+    {
+      "targetId": "erdos-138",
+      "relationship": "related — the gallery's van der Waerden entry, which axiomatizes growth/lower-bound statements; the LLL lower bound this ingredient targets is one such statement"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers open question **oq-02** of `van-der-waerden-first-moment` by supplying the concrete combinatorial ingredient of the **Lovász-Local-Lemma** route to $W(k) \gtrsim 2^k/(ek)$.

The base entry proves the union-bound bound $W(k) \gtrsim 2^{(k-1)/2}$. Its oq-02 asks to reach the LLL exponent, which (per the question itself) needs two verified ingredients: **(1)** a symmetric Lovász Local Lemma, and **(2)** a bound on the AP-overlap **dependency degree**. This PR delivers **(2)** with 0 axioms.

**Main result** (`vdwHypergraph_degree_le`): every length-$k$ AP of the family meets at most $k^2 n$ other members.

### Why linear in $n$ is the whole point
The symmetric LLL succeeds when $e \cdot 2^{1-k}(d+1) \le 1$. A degree bound $d \le k^2 n$ **linear in $n$** gives $n \lesssim 2^{k-1}/(ek^2)$, i.e. $W(k) \gtrsim 2^k/(ek)$. The trivial quadratic $d \le |\text{family}| \le n^2$ recovers only the first-moment $2^{k/2}$ — so linearity is the entire content.

### Proof (elementary counting on the base entry's `vdwAP`/`vdwFamily`)
1. `exists_index_of_mem` — from $x \in$ vdwAP recover $x = a + i\cdot d$, $i < k$.
2. `card_params_through_le` — $\le k\cdot n$ fitting $(a,d)$ put an AP through a fixed point, via the injection $(a,d) \mapsto ((x-a)/d,\, d)$ (index $i=(x-a)/d<k$ and step $d$ recover $a = x - i\cdot d$).
3. `card_family_through_le` — transfer to $\le k\cdot n$ family APs through a point (`Finset.card_image_le`).
4. `card_vdwFamily_meeting_le` / `vdwHypergraph_degree_le` — each length-$k$ AP has $k$ points (`vdwFamily_uniform`), so degree $\le k\cdot(k n) = k^2 n$ (`Finset.card_biUnion_le`).

### Verification
- **0 axioms, 0 sorries, no `native_decide`.** `#print axioms vdwHypergraph_degree_le` → `[propext, Classical.choice, Quot.sound]`.
- Compiles against Lean `v4.26.0` / Mathlib (single-file `lake env lean`, warm cache).
- 5 theorems / 197 lines; new gallery entry (`meta.json` + `annotations.json`).

### Honest scope
This PR supplies **only ingredient (2)**. A verified symmetric Lovász Local Lemma (ingredient 1) is not in Mathlib and remains the open gap, so the full $W(k) \gtrsim 2^k/(ek)$ bound is **not** established here. The entry states this plainly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)