### PR TITLE
research(fermat-defect-one-oq-06-oq-01): even-exponent obstruction to the sign-flip map [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FermatDefectOneOQ06OQ01.lean
+++ b/proofs/Proofs/FermatDefectOneOQ06OQ01.lean
@@ -1,0 +1,185 @@
+/-
+  Fermat Defect-One — OQ-06-OQ-01: the even-exponent obstruction to the sign-flip map
+
+  Parent (`Proofs.FermatDefectOneOQ06`, "The Sign-Flip Involution of the
+  Defect-One Conjecture"): for every **odd** exponent `n` the involution
+  `Ψ(a, b, c) = (c, -b, a)` negates the defect `a^n + b^n - c^n` and hence
+  exchanges the two defect signs (`signFlip_negates_defect_odd`).  The parent
+  observed that at **even** `n` this same `Ψ` fails to negate the defect —
+  because `(-b)^n = +b^n`, `Ψ` sends `a^n + b^n - c^n` to `c^n + b^n - a^n`,
+  an `a ↔ c` **swap** rather than a sign flip.
+
+  OQ-06-OQ-01 asks: at even `n`, is there some *other* structural map exchanging
+  the two defect signs, or is the absence of a sign-flip map a genuine even/odd
+  asymmetry?
+
+  ## Answer: a genuine even/odd asymmetry (for the natural class of maps)
+
+  We work with the coordinate vector `v : Fin 3 → ℤ` and the defect form
+  `defect n v = v 0 ^ n + v 1 ^ n - v 2 ^ n`.  The parent's `Ψ` belongs to the
+  natural class of **signed coordinate permutations**
+
+      (signedPerm σ s) v = fun i => s i * v (σ i),   σ ∈ S₃,  s i ∈ {±1},
+
+  the maps that permute the three coordinates and independently flip their signs.
+  (`Ψ(a,b,c) = (c,-b,a)` is `signedPerm (swap 0 2) ![1,-1,1]`.)  A map *negates
+  the defect* when `defect n (φ v) = -defect n v` for all `v`.
+
+  * **Odd `n` — a sign-flip map exists.**  The `Ψ`-analogue
+    `signedPerm (Equiv.swap 0 2) ![1,-1,1]` negates the defect for every odd `n`
+    (`signFlipFin_negates_odd`), recovering the parent involution in this
+    framework.
+
+  * **Even `n` — NO signed permutation negates the defect** (`no_signFlip_even`).
+    The reason is *sign-blindness*: at even `n`, `(s i)^n = 1` for every sign
+    `s i = ±1`, so the action of a signed permutation on the defect factors
+    through the pure coordinate permutation `σ` — the signs `s` become invisible.
+    A pure permutation only shuffles the three summands `v 0 ^ n, v 1 ^ n,
+    v 2 ^ n`, so it fixes the value of the defect at the symmetric point
+    `v = (1,1,1)`, where `defect = 1 + 1 - 1 = 1 > 0`.  A sign flip would need
+    that value to become `-1`.  Since `1 ≠ -1`, no signed permutation can negate
+    the even-exponent defect.  Evaluating at `(1,1,1)` makes this a one-line
+    contradiction.
+
+  Packaged as `even_odd_asymmetry`: for odd `n` a sign-flip map exists, for even
+  `n ≥ 2` none does.  So the parent's `Ψ` has no even-exponent analogue within
+  the class it belongs to — the absence is genuine, not an artefact of the
+  particular map `Ψ`.
+
+  ## Scope (honest statement)
+
+  This resolves the question for the class of signed coordinate permutations —
+  precisely the structural maps `Ψ` is drawn from.  The obstruction is the
+  sign-blindness of even powers; it does not, by itself, rule out exotic
+  non-linear or non-coordinate maps, which the parent OQ did not consider either.
+
+  Everything is a polynomial identity / finite sign computation over `ℤ`, closed
+  by `ring`, `simp`, `Even.neg_one_pow`, and `Odd.neg_pow`.  No `axiom`, no
+  `sorry`, no `native_decide`: a fully verified, 0-axiom result.
+-/
+
+import Mathlib
+import Proofs.FermatDefectOne
+import Proofs.FermatDefectOneOQ06
+
+namespace FermatDefectOneOQ06OQ01
+
+open scoped BigOperators
+
+/-! ## The defect form and the class of signed coordinate permutations -/
+
+/-- The **defect form** at exponent `n` on a coordinate vector `v : Fin 3 → ℤ`,
+with the canonical sign pattern `(+, +, -)`: `defect n v = v 0 ^ n + v 1 ^ n - v 2 ^ n`.
+Matches the parent's `a^n + b^n - c^n` under `(a,b,c) ↦ ![a,b,c]`. -/
+def defect (n : ℕ) (v : Fin 3 → ℤ) : ℤ := v 0 ^ n + v 1 ^ n - v 2 ^ n
+
+/-- A **signed coordinate permutation**: permute the coordinates by `σ ∈ S₃`
+and multiply coordinate `i` by the sign `s i`.  This is the natural class of
+structural maps the parent's involution `Ψ(a,b,c) = (c,-b,a)` belongs to. -/
+def signedPerm (σ : Equiv.Perm (Fin 3)) (s : Fin 3 → ℤ) (v : Fin 3 → ℤ) : Fin 3 → ℤ :=
+  fun i => s i * v (σ i)
+
+/-- `s` is a **sign vector**: each entry is `±1`. -/
+def IsSign (s : Fin 3 → ℤ) : Prop := ∀ i, s i = 1 ∨ s i = -1
+
+/-- A map `φ` **negates the defect** at exponent `n` when `defect n (φ v) = -defect n v`
+for every `v`.  This is exactly the sign-flip property OQ-06 asks about. -/
+def NegatesDefect (n : ℕ) (φ : (Fin 3 → ℤ) → (Fin 3 → ℤ)) : Prop :=
+  ∀ v, defect n (φ v) = -defect n v
+
+/-! ## Sign-blindness of even powers -/
+
+/-- A `±1` sign raised to an **even** power is `1`.  This is the source of the
+even-exponent obstruction: even powers erase the sign. -/
+theorem sign_even_pow {x : ℤ} (hx : x = 1 ∨ x = -1) {n : ℕ} (hn : Even n) : x ^ n = 1 := by
+  rcases hx with h | h
+  · simp [h]
+  · simp [h, hn.neg_one_pow]
+
+/-! ## Even `n`: no signed permutation negates the defect -/
+
+/-- **Main obstruction.** For every **even** exponent `n`, no signed coordinate
+permutation negates the defect form.
+
+The proof is one evaluation: at the symmetric point `v = (1,1,1)` a signed
+permutation `φ` outputs the sign vector `s` itself (`φ 1 = s`), and since `n`
+is even every `(s i)^n = 1`, so `defect n (φ 1) = 1 + 1 - 1 = 1`.  But negation
+demands `defect n (φ 1) = -defect n 1 = -1`.  As `1 ≠ -1`, no such `φ` exists. -/
+theorem no_signFlip_even {n : ℕ} (hn : Even n) (σ : Equiv.Perm (Fin 3))
+    {s : Fin 3 → ℤ} (hs : IsSign s) : ¬ NegatesDefect n (signedPerm σ s) := by
+  intro h
+  have key := h (fun _ => 1)
+  -- At the all-ones vector, `(signedPerm σ s) 1 i = s i`, and `(s i)^n = 1`.
+  have e0 : s 0 ^ n = 1 := sign_even_pow (hs 0) hn
+  have e1 : s 1 ^ n = 1 := sign_even_pow (hs 1) hn
+  have e2 : s 2 ^ n = 1 := sign_even_pow (hs 2) hn
+  simp only [defect, signedPerm, mul_one] at key
+  rw [e0, e1, e2] at key
+  norm_num at key
+
+/-! ## Odd `n`: the parent involution `Ψ` survives as a signed permutation -/
+
+/-- The `Fin 3` incarnation of the parent's sign-flip involution
+`Ψ(a,b,c) = (c,-b,a)`: permute by the swap `0 ↔ 2` and negate the middle
+coordinate.  As a signed permutation this is `signedPerm (Equiv.swap 0 2) ![1,-1,1]`. -/
+def signFlipFin : (Fin 3 → ℤ) → (Fin 3 → ℤ) := signedPerm (Equiv.swap 0 2) ![1, -1, 1]
+
+/-- `![1,-1,1]` is a sign vector. -/
+theorem isSign_signFlipFin : IsSign (![1, -1, 1] : Fin 3 → ℤ) := by
+  intro i; fin_cases i <;> simp
+
+/-- Explicit coordinates of `signFlipFin v = (v 2, -v 1, v 0)`, matching
+`Ψ(a,b,c) = (c,-b,a)`. -/
+theorem signFlipFin_apply (v : Fin 3 → ℤ) :
+    signFlipFin v 0 = v 2 ∧ signFlipFin v 1 = -v 1 ∧ signFlipFin v 2 = v 0 := by
+  refine ⟨?_, ?_, ?_⟩ <;>
+    · simp only [signFlipFin, signedPerm]
+      simp [Equiv.swap_apply_left, Equiv.swap_apply_right,
+        show (Equiv.swap (0 : Fin 3) 2) 1 = 1 from by decide]
+
+/-- **Odd `n` admits a sign-flip map.** For every **odd** exponent `n`, the
+`Ψ`-analogue `signFlipFin` negates the defect, exactly as the parent's
+`signFlip_negates_defect_odd` does on triples. -/
+theorem signFlipFin_negates_odd {n : ℕ} (hn : Odd n) : NegatesDefect n signFlipFin := by
+  intro v
+  obtain ⟨h0, h1, h2⟩ := signFlipFin_apply v
+  simp only [defect, h0, h1, h2, hn.neg_pow]
+  ring
+
+/-! ## The even/odd asymmetry, packaged -/
+
+/-- **Even/odd asymmetry (OQ-06-OQ-01).**  Within the class of signed coordinate
+permutations — precisely the structural maps the parent's `Ψ` belongs to — a
+defect-sign-flip map exists at every **odd** exponent but at **no even** exponent:
+
+* (odd) there is an explicit signed permutation `signFlipFin` negating the defect;
+* (even) *no* signed permutation `signedPerm σ s` negates the defect.
+
+So the parent's involution `Ψ` has no even-exponent analogue in its own class:
+the absence is a genuine even/odd asymmetry, forced by the sign-blindness of
+even powers, not an artefact of the particular map `Ψ`. -/
+theorem even_odd_asymmetry :
+    (∀ {n : ℕ}, Odd n → NegatesDefect n signFlipFin) ∧
+    (∀ {n : ℕ}, Even n → ∀ (σ : Equiv.Perm (Fin 3)) {s : Fin 3 → ℤ},
+      IsSign s → ¬ NegatesDefect n (signedPerm σ s)) := by
+  refine ⟨?_, ?_⟩
+  · intro n hn
+    exact signFlipFin_negates_odd hn
+  · intro n hn σ s hs
+    exact no_signFlip_even hn σ hs
+
+/-! ## Bridge to the parent `Ψ` on triples
+
+The parent defines `Ψ` on `ℤ × ℤ × ℤ`.  Under the correspondence
+`(a,b,c) ↦ ![a,b,c]`, `Ψ` is exactly `signFlipFin`, so the two frameworks agree. -/
+
+/-- Under `(a,b,c) ↦ ![a,b,c]`, the parent's `Ψ` and the `Fin 3` map `signFlipFin`
+compute the same coordinates: both send `(a,b,c)` to `(c,-b,a)`. -/
+theorem signFlipFin_eq_parent (a b c : ℤ) :
+    (signFlipFin ![a, b, c] 0, signFlipFin ![a, b, c] 1, signFlipFin ![a, b, c] 2)
+      = FermatDefectOneOQ06.signFlip (a, b, c) := by
+  obtain ⟨h0, h1, h2⟩ := signFlipFin_apply (![a, b, c])
+  rw [h0, h1, h2]
+  simp [FermatDefectOneOQ06.signFlip]
+
+end FermatDefectOneOQ06OQ01

--- a/src/data/proofs/fermat-defect-one-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/fermat-defect-one-oq-06-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-fdo0601-overview",
+    "proofId": "fermat-defect-one-oq-06-oq-01",
+    "range": { "startLine": 1, "endLine": 59 },
+    "type": "concept",
+    "title": "The Even-Exponent Question (OQ-06-OQ-01)",
+    "content": "The parent entry showed the involution Ψ(a,b,c) = (c,-b,a) negates the Fermat defect aⁿ+bⁿ-cⁿ at every ODD exponent, exchanging the two defect signs. At even n it fails: (-b)ⁿ = +bⁿ, so Ψ produces cⁿ+bⁿ-aⁿ, an a↔c swap rather than a sign flip. This entry asks whether the failure is specific to Ψ or genuine, and answers: within the natural class of signed coordinate permutations (permute the three coordinates, flip signs) NO map negates the even-exponent defect. The mechanism is sign-blindness — even powers erase the ±1 signs — so the analysis reduces to permutations, which cannot flip a sign.",
+    "mathContext": "Even $n$: no signed permutation $\\varphi$ satisfies $\\mathrm{defect}\\,n\\,(\\varphi v) = -\\mathrm{defect}\\,n\\,v$; odd $n$: the $\\Psi$-analogue does.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fermat defect-one conjecture", "involution", "signed permutation", "parity", "no-go theorem"],
+    "prerequisites": ["parent Sign-Flip entry", "integer Fermat defect aⁿ+bⁿ-cⁿ"]
+  },
+  {
+    "id": "ann-fdo0601-framework",
+    "proofId": "fermat-defect-one-oq-06-oq-01",
+    "range": { "startLine": 69, "endLine": 88 },
+    "type": "definition",
+    "title": "The Defect Form and Signed Coordinate Permutations",
+    "content": "The defect form defect n v = v0ⁿ+v1ⁿ-v2ⁿ carries the parent's (+,+,-) sign pattern on a coordinate vector v : Fin 3 → ℤ. signedPerm σ s builds the natural class of structural maps: permute the coordinates by σ ∈ S₃ and multiply coordinate i by the sign s i, so (signedPerm σ s) v i = s i · v (σ i). IsSign s pins each s i to ±1, and NegatesDefect n φ is the sign-flip property to be tested. The parent's Ψ(a,b,c)=(c,-b,a) is exactly signedPerm (swap 0 2) ![1,-1,1], so the whole finite group {±1}³ ⋊ S₃ (order 48) contains it.",
+    "mathContext": "$(\\mathrm{signedPerm}\\,\\sigma\\,s)\\,v\\,i = s_i \\cdot v_{\\sigma(i)}$, with $s_i \\in \\{\\pm 1\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic and higher forms", "wreath product {±1}³ ⋊ S₃", "coordinate symmetry"],
+    "prerequisites": ["Fin 3 vectors", "Equiv.Perm"]
+  },
+  {
+    "id": "ann-fdo0601-sign-blindness",
+    "proofId": "fermat-defect-one-oq-06-oq-01",
+    "range": { "startLine": 90, "endLine": 97 },
+    "type": "theorem",
+    "title": "Sign-Blindness of Even Powers",
+    "content": "sign_even_pow is the lemma that drives everything: a ±1 sign raised to an even power is 1. It is a two-case split — 1ⁿ = 1 always, and (-1)ⁿ = 1 for even n by Mathlib's Even.neg_one_pow. Its consequence is decisive: at even n, the value of the defect on a signed permutation cannot see the signs s at all, so the map behaves like a pure permutation of the summands v0ⁿ, v1ⁿ, v2ⁿ.",
+    "mathContext": "$x \\in \\{1,-1\\},\\; n \\text{ even} \\;\\Rightarrow\\; x^n = 1$ (via $(-1)^n = 1$).",
+    "significance": "key",
+    "relatedConcepts": ["parity", "Even.neg_one_pow", "sign-blindness"],
+    "prerequisites": ["even/odd powers of -1"]
+  },
+  {
+    "id": "ann-fdo0601-no-go",
+    "proofId": "fermat-defect-one-oq-06-oq-01",
+    "range": { "startLine": 99, "endLine": 118 },
+    "type": "theorem",
+    "title": "No Signed Permutation Negates the Even Defect",
+    "content": "no_signFlip_even is the main no-go: for every even n and every signed coordinate permutation signedPerm σ s, the map fails to negate the defect. The proof is a single evaluation at the symmetric point v = (1,1,1). There each output coordinate is s i · 1 = s i, so the defect is (s0)ⁿ + (s1)ⁿ - (s2)ⁿ = 1 + 1 - 1 = 1 by sign-blindness. But a negating map would force this to equal -defect n (1,1,1) = -1. Since 1 ≠ -1 (norm_num), no such map exists. Conceptually: permutations of {v0ⁿ,v1ⁿ,v2ⁿ} fix the value at the all-equal point, and there the defect is positive — a flip would need it negative.",
+    "mathContext": "$\\mathrm{defect}\\,n\\,(\\mathrm{signedPerm}\\,\\sigma\\,s\\,\\mathbf{1}) = 1+1-1 = 1 \\neq -1$.",
+    "significance": "key",
+    "relatedConcepts": ["evaluation / specialization argument", "fixed point of a permutation action", "no-go theorem"],
+    "prerequisites": ["quantifier elimination by a witness", "sign_even_pow"]
+  },
+  {
+    "id": "ann-fdo0601-odd",
+    "proofId": "fermat-defect-one-oq-06-oq-01",
+    "range": { "startLine": 120, "endLine": 147 },
+    "type": "theorem",
+    "title": "The Odd-Exponent Map Survives (signFlipFin)",
+    "content": "signFlipFin = signedPerm (swap 0 2) ![1,-1,1] is the Fin-3 incarnation of the parent's Ψ; signFlipFin_apply computes signFlipFin v = (v2, -v1, v0). signFlipFin_negates_odd shows that for every ODD n this map negates the defect: (-v1)ⁿ = -v1ⁿ by Odd.neg_pow, so the defect becomes v2ⁿ - v1ⁿ - v0ⁿ = -(v0ⁿ+v1ⁿ-v2ⁿ) by ring. This is the positive half of the asymmetry — the same construction that fails at even n succeeds at odd n precisely because a sign can now flip a term.",
+    "mathContext": "Odd $n$: $\\mathrm{defect}\\,n\\,(\\mathrm{signFlipFin}\\,v) = v_2^n - v_1^n - v_0^n = -(v_0^n+v_1^n-v_2^n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Odd.neg_pow", "Equiv.swap", "involution"],
+    "prerequisites": ["odd powers of -1", "matrix/vector literals ![·]"]
+  },
+  {
+    "id": "ann-fdo0601-asymmetry",
+    "proofId": "fermat-defect-one-oq-06-oq-01",
+    "range": { "startLine": 149, "endLine": 185 },
+    "type": "theorem",
+    "title": "The Even/Odd Asymmetry, Packaged, and the Bridge to Ψ",
+    "content": "even_odd_asymmetry bundles the full answer: a defect-sign-flip signed permutation exists at every odd exponent (signFlipFin) and at no even exponent (no signedPerm σ s). So the parent's Ψ has no even-exponent analogue within its own class — the absence is a genuine parity phenomenon, not a limitation of Ψ. signFlipFin_eq_parent closes the loop, verifying signFlipFin agrees coordinate-for-coordinate with the parent's Ψ(a,b,c) = (c,-b,a) under (a,b,c) ↦ ![a,b,c].",
+    "mathContext": "$\\text{Odd } n \\Rightarrow \\exists$ negating signed perm; $\\text{Even } n \\Rightarrow \\nexists$; and $\\mathrm{signFlipFin}\\,![a,b,c] = (c,-b,a) = \\Psi(a,b,c)$.",
+    "significance": "key",
+    "relatedConcepts": ["parity dichotomy", "packaged theorem", "framework bridge"],
+    "prerequisites": ["the odd and even halves above", "the parent's signFlip"]
+  }
+]

--- a/src/data/proofs/fermat-defect-one-oq-06-oq-01/index.ts
+++ b/src/data/proofs/fermat-defect-one-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FermatDefectOneOQ06OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fermatDefectOneOq06Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fermatDefectOneOq06Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fermatDefectOneOq06Oq01Data: ProofData = {
+  proof: fermatDefectOneOq06Oq01Proof,
+  annotations: fermatDefectOneOq06Oq01Annotations,
+}

--- a/src/data/proofs/fermat-defect-one-oq-06-oq-01/meta.json
+++ b/src/data/proofs/fermat-defect-one-oq-06-oq-01/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "fermat-defect-one-oq-06-oq-01",
+  "title": "The Even-Exponent Obstruction to the Sign-Flip Map",
+  "slug": "fermat-defect-one-oq-06-oq-01",
+  "description": "Answers the parent Sign-Flip entry's open question — at even exponents the involution Ψ(a,b,c)=(c,-b,a) gives an a↔c swap rather than a sign flip, so is there some other structural map exchanging the two defect signs when n is even, or is the absence genuine? — with a clean negative result for the natural class of maps Ψ belongs to. Working with coordinate vectors v : Fin 3 → ℤ and the defect form v0ⁿ+v1ⁿ-v2ⁿ, the signed coordinate permutations (signedPerm σ s) v = fun i => s i · v (σ i) (permute by σ ∈ S₃, flip signs by s ∈ {±1}³) contain Ψ = signedPerm (swap 0 2) ![1,-1,1]. For every ODD n the Ψ-analogue signFlipFin negates the defect (recovering the parent map). For every EVEN n NO signed permutation negates the defect: even powers are sign-blind — (s i)ⁿ = 1 — so the action factors through the pure permutation σ, which only shuffles the summands v0ⁿ,v1ⁿ,v2ⁿ and therefore fixes the defect's value at the symmetric point (1,1,1), where it equals 1; a sign flip would need that value to be -1. Evaluating at (1,1,1) makes it a one-line contradiction. So the even/odd asymmetry is genuine, not an artefact of Ψ. Fully verified: 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat%27s_Last_Theorem",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FermatDefectOneOQ06OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "fermat",
+      "defect-one",
+      "involution",
+      "symmetry",
+      "signed-permutation",
+      "parity",
+      "no-go",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Even.neg_one_pow",
+        "description": "For even n, (-1)ⁿ = 1. This is the exact source of the even-exponent obstruction: it makes every ±1 sign vanish under an even power, so a signed permutation's action on the defect becomes independent of its signs.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Odd.neg_pow",
+        "description": "For odd n, (-x)ⁿ = -xⁿ. This is what lets the odd-exponent map signFlipFin negate the defect, providing the positive half of the even/odd asymmetry.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Equiv.swap_apply_left / Equiv.swap_apply_right",
+        "description": "Evaluates the coordinate transposition swap 0 2 used to build the Fin-3 incarnation of the parent's Ψ.",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      }
+    ],
+    "originalContributions": [
+      "defect / signedPerm / IsSign / NegatesDefect: a clean Fin-3 framework — the defect form v0ⁿ+v1ⁿ-v2ⁿ, the group of signed coordinate permutations (signedPerm σ s) the parent's Ψ belongs to, and the sign-flip property to be tested",
+      "sign_even_pow: the sign-blindness lemma — a ±1 raised to an even power is 1 (via Even.neg_one_pow); this is the entire mechanism of the obstruction",
+      "no_signFlip_even: the main no-go — for EVERY even n and EVERY signed coordinate permutation signedPerm σ s, the map does NOT negate the defect; proved by one evaluation at the symmetric point (1,1,1), where the defect is 1 but a flip would need -1",
+      "signFlipFin / signFlipFin_negates_odd: the odd-n positive half — the Ψ-analogue signedPerm (swap 0 2) ![1,-1,1] negates the defect for every odd n, matching the parent's signFlip_negates_defect_odd in the Fin-3 framework",
+      "even_odd_asymmetry: the packaged answer — a defect-sign-flip signed permutation exists at every odd exponent and at no even exponent, so the absence is a genuine parity phenomenon rather than a limitation of the specific map Ψ",
+      "signFlipFin_eq_parent: bridge showing the Fin-3 map signFlipFin agrees coordinate-for-coordinate with the parent's Ψ(a,b,c)=(c,-b,a) under (a,b,c) ↦ ![a,b,c]"
+    ],
+    "axiomCount": 0,
+    "lineCount": 185,
+    "assumptions": "None. All 7 theorems are fully proved with 0 axioms and 0 sorries. No native_decide; a single `decide` discharges the decidable equality (Equiv.swap 0 2) 1 = 1 (a fixed-point computation over Fin 3), which does NOT introduce Lean.ofReduceBool. #print axioms reports only [propext, Classical.choice, Quot.sound] for every result. SCOPE (honest): the no-go theorem resolves the question for the class of signed COORDINATE PERMUTATIONS — precisely the structural maps the parent's Ψ is drawn from. The obstruction is the sign-blindness of even powers. It does not, by itself, rule out exotic non-linear or non-coordinate maps, which the parent open question did not consider either. This entry does NOT resolve the parent defect-one existence conjecture.",
+    "theoremCount": 7,
+    "definitionCount": 5,
+    "prerequisites": [
+      "The integer Fermat defect aⁿ+bⁿ-cⁿ and the ±1 'defect-one' question (parent entries)",
+      "The parent involution Ψ(a,b,c)=(c,-b,a) and why it negates the defect at odd n but only swaps a↔c at even n",
+      "Signed permutations: the group {±1}³ ⋊ S₃ acting on coordinate triples",
+      "The identity (-1)ⁿ = 1 for even n versus (-x)ⁿ = -xⁿ for odd n"
+    ],
+    "relatedProblems": [
+      {
+        "id": "fermat-defect-one-oq-06",
+        "relationship": "Parent: 'The Sign-Flip Involution of the Defect-One Conjecture'. That entry gives the odd-exponent involution Ψ and observes that at even n it becomes an a↔c swap; this entry answers its open question by proving no signed coordinate permutation can negate the even-exponent defect, so the sign-flip is intrinsically an odd-exponent phenomenon."
+      },
+      {
+        "id": "fermat-defect-one",
+        "relationship": "Grandparent: the Fermat defect-one conjecture |aⁿ+bⁿ-cⁿ|=1."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Fermat defect-one conjecture asks whether, for every n ≥ 3, some primitive coprime triple has |aⁿ + bⁿ - cⁿ| = 1. The parent entry 'The Sign-Flip Involution' answered a symmetry question about it: over ℤ the linear involution Ψ(a,b,c) = (c,-b,a) negates the defect at every ODD exponent, so it exchanges negative-defect solutions aⁿ+bⁿ+1=cⁿ with positive-defect solutions aⁿ+bⁿ=cⁿ+1. That entry also flagged the even case: because (-b)ⁿ = +bⁿ when n is even, the same Ψ sends aⁿ+bⁿ-cⁿ to cⁿ+bⁿ-aⁿ — an a↔c swap, not a sign flip.\n\nThis raises the natural follow-up: is the failure a limitation of the particular map Ψ, or is there no sign-flip map at all at even exponents? The question matters because a sign-flip symmetry would collapse 'realise both signs at n' into 'realise one sign at n'; its absence at even n would mean the two even-exponent signs are structurally independent.",
+    "problemStatement": "Fix an even exponent n. Working with coordinate vectors v : Fin 3 → ℤ and the defect form defect n v = v 0 ^ n + v 1 ^ n - v 2 ^ n, consider the class of signed coordinate permutations φ = signedPerm σ s (permute coordinates by σ ∈ S₃, then multiply coordinate i by s i ∈ {±1}) — the class the parent's Ψ belongs to. Does any such φ NEGATE the defect, i.e. satisfy defect n (φ v) = -defect n v for all v? Answer the same for odd n, and compare.",
+    "proofStrategy": "Even case (no-go). For any signs s ∈ {±1}³ and even n, each (s i)ⁿ = 1 (sign_even_pow, from Even.neg_one_pow): even powers are sign-blind. Evaluate a hypothetical negating φ = signedPerm σ s at the all-ones vector v = (1,1,1): then (φ v) i = s i · 1 = s i, so defect n (φ v) = (s 0)ⁿ + (s 1)ⁿ - (s 2)ⁿ = 1 + 1 - 1 = 1. But negation demands defect n (φ v) = -defect n (1,1,1) = -(1+1-1) = -1. Since 1 ≠ -1, no signed permutation negates the even defect (no_signFlip_even) — a one-line contradiction after the sign-blindness rewrite. Conceptually: at even n the signed-permutation action factors through the pure permutation σ, which merely shuffles the three summands v0ⁿ,v1ⁿ,v2ⁿ and hence fixes the defect at the symmetric point where all three are equal.\n\nOdd case (existence). Take σ = swap 0 2 and s = ![1,-1,1], giving signFlipFin v = (v2, -v1, v0), the Fin-3 form of Ψ. For odd n, (-v1)ⁿ = -v1ⁿ (Odd.neg_pow), so defect n (signFlipFin v) = v2ⁿ - v1ⁿ - v0ⁿ = -(v0ⁿ+v1ⁿ-v2ⁿ) by ring. Packaging both halves gives even_odd_asymmetry.",
+    "keyInsights": [
+      "The whole obstruction is sign-blindness: at even n a ±1 sign raised to the n-th power is 1, so a signed permutation's effect on the defect cannot depend on its signs — it can only permute the summands.",
+      "A pure permutation of {v0ⁿ, v1ⁿ, v2ⁿ} fixes the defect's value at the symmetric point v = (1,1,1), where the defect is 1+1-1 = 1 > 0. A sign flip would have to turn that 1 into -1, which no permutation can do — this is the crisp reason a flip is impossible.",
+      "Evaluating at a single well-chosen point (1,1,1) turns a statement quantified over all maps and all inputs into one arithmetic inequality 1 ≠ -1 — the proof is one line once the sign-blindness lemma is in hand.",
+      "The parity split is exact: for odd n the identical construction succeeds because (-1)ⁿ = -1 lets a sign genuinely flip a term, so the odd-n map signFlipFin negates the defect. The asymmetry is therefore intrinsic to parity, not to the shape of Ψ.",
+      "Honest scope: this rules out the natural finite class of signed coordinate permutations (order 48), the class Ψ lives in. It leaves open — as did the parent — whether some exotic non-linear map could exchange the even-exponent signs; the sign-blindness argument is specific to maps sending ±1 vectors to ±1 vectors."
+    ],
+    "prerequisites": [
+      "The integer Fermat defect and the ±1 'defect-one' question (parent entries)",
+      "The parent involution Ψ(a,b,c) = (c,-b,a) and its odd-exponent defect negation",
+      "Signed coordinate permutations {±1}³ ⋊ S₃ acting on triples",
+      "The parity identities (-1)ⁿ = 1 (even) and (-x)ⁿ = -xⁿ (odd)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "framework",
+      "title": "Section I: The Defect Form and Signed Coordinate Permutations",
+      "startLine": 69,
+      "endLine": 88,
+      "summary": "defect n v = v0ⁿ+v1ⁿ-v2ⁿ carries the canonical (+,+,-) sign pattern of the parent's aⁿ+bⁿ-cⁿ. signedPerm σ s permutes coordinates by σ ∈ S₃ and multiplies coordinate i by s i — the natural class of structural maps Ψ belongs to. IsSign s says each s i is ±1, and NegatesDefect n φ is the sign-flip property defect n (φ v) = -defect n v to be tested.",
+      "mathContext": "defect n v = v0ⁿ+v1ⁿ-v2ⁿ; (signedPerm σ s) v i = s i · v (σ i); Ψ = signedPerm (swap 0 2) ![1,-1,1]."
+    },
+    {
+      "id": "sign-blindness",
+      "title": "Section II: Sign-Blindness of Even Powers",
+      "startLine": 90,
+      "endLine": 97,
+      "summary": "sign_even_pow proves that a ±1 sign raised to an even power is 1: 1ⁿ = 1 always, and (-1)ⁿ = 1 for even n by Even.neg_one_pow. This single lemma is the entire mechanism of the even-exponent obstruction — it makes a signed permutation's action on the defect independent of its signs.",
+      "mathContext": "x = ±1 and n even ⟹ xⁿ = 1."
+    },
+    {
+      "id": "no-go-even",
+      "title": "Section III: No Signed Permutation Negates the Even Defect",
+      "startLine": 99,
+      "endLine": 118,
+      "summary": "no_signFlip_even is the main result: for every even n and every signed coordinate permutation signedPerm σ s, the map does not negate the defect. The proof evaluates a hypothetical negating map at the all-ones vector (1,1,1): there (signedPerm σ s) outputs the sign vector s itself, and since each (s i)ⁿ = 1 the defect is 1+1-1 = 1, whereas negation demands -1. The contradiction 1 = -1 is closed by norm_num.",
+      "mathContext": "At v=(1,1,1): defect n (signedPerm σ s v) = 1+1-1 = 1 ≠ -1 = -defect n v."
+    },
+    {
+      "id": "odd-existence",
+      "title": "Section IV: The Odd-Exponent Map Survives",
+      "startLine": 120,
+      "endLine": 147,
+      "summary": "signFlipFin = signedPerm (swap 0 2) ![1,-1,1] is the Fin-3 incarnation of the parent's Ψ; isSign_signFlipFin and signFlipFin_apply give signFlipFin v = (v2,-v1,v0). signFlipFin_negates_odd shows that for every odd n this map negates the defect (via Odd.neg_pow then ring), recovering the parent's odd-exponent sign flip in this framework and supplying the positive half of the asymmetry.",
+      "mathContext": "For odd n: defect n (signFlipFin v) = v2ⁿ - v1ⁿ - v0ⁿ = -(v0ⁿ+v1ⁿ-v2ⁿ)."
+    },
+    {
+      "id": "asymmetry",
+      "title": "Section V: The Even/Odd Asymmetry, Packaged",
+      "startLine": 149,
+      "endLine": 185,
+      "summary": "even_odd_asymmetry bundles the answer: a defect-sign-flip signed permutation exists at every odd exponent (signFlipFin) and at no even exponent (no signedPerm σ s). So the parent's Ψ has no even-exponent analogue within its own class — the absence is a genuine parity phenomenon. signFlipFin_eq_parent bridges the Fin-3 map to the parent's Ψ(a,b,c)=(c,-b,a) coordinate-for-coordinate.",
+      "mathContext": "Odd n ⟹ ∃ negating signed permutation; Even n ⟹ ∄ negating signed permutation."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) formalization, in 185 lines with 7 theorems and 5 definitions, answering the parent Sign-Flip entry's open question. Within the natural class of signed coordinate permutations {±1}³ ⋊ S₃ — the class the parent's involution Ψ(a,b,c)=(c,-b,a) belongs to — a defect-sign-flip map exists at every ODD exponent (the Ψ-analogue signFlipFin) and at NO EVEN exponent (no_signFlip_even). The even-exponent obstruction is a one-line consequence of sign-blindness: even powers erase the ±1 signs, so a signed permutation can only shuffle the summands v0ⁿ,v1ⁿ,v2ⁿ, and permutations fix the defect at the symmetric point (1,1,1) where it equals 1 — a value a sign flip would have to send to -1.",
+    "implications": "The even/odd asymmetry the parent entry noticed is genuine, not an artefact of the specific map Ψ: no relabelling-and-sign-changing of the three coordinates can turn a positive even-exponent defect into its negative. Structurally, the sign symmetry that collapses 'both signs' into 'one sign' at odd exponents has no counterpart at even exponents within this class of maps — so the two even-exponent defect signs are, as far as coordinate symmetries go, independent. This sharpens the parent's observation into a proved no-go and isolates parity as the responsible mechanism.",
+    "openQuestions": [
+      "Does some non-linear or non-coordinate map (outside the signed-permutation class) exchange the two defect signs at an even exponent, or can the no-go be extended to all polynomial maps of bounded degree? For n = 2 the defect a²+b²-c² is a quadratic form of signature (2,1) while its negation has signature (1,2), so Sylvester's law of inertia already forbids any invertible real LINEAR map — can this inertia obstruction be formalized and pushed to a general even-n statement?",
+      "For even n, are both defect signs actually realised by primitive coprime triples (so that the question of a map between them is non-vacuous), and if so does the proved absence of a signed-permutation bijection reflect a genuine difference in the density or growth of the two sign classes?"
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.FermatDefectOne",
+      "Proofs.FermatDefectOneOQ06"
+    ],
+    "opens": [
+      "scoped BigOperators"
+    ],
+    "namespace": "FermatDefectOneOQ06OQ01",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 5,
+    "path": "Proofs/FermatDefectOneOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "fermat-defect-one-oq-06",
+      "relationship": "extends",
+      "description": "Parent: 'The Sign-Flip Involution of the Defect-One Conjecture' gives the odd-exponent involution Ψ(a,b,c)=(c,-b,a) and observes that at even n it degenerates to an a↔c swap. This entry answers that entry's open question by proving no signed coordinate permutation negates the even-exponent defect, so the sign flip is intrinsically an odd-exponent phenomenon."
+    },
+    {
+      "targetId": "fermat-defect-one",
+      "relationship": "related",
+      "description": "Grandparent: the Fermat defect-one conjecture |aⁿ+bⁿ-cⁿ|=1. The sign-flip symmetry (and its even-exponent failure proved here) concerns how the two signs of the ±1 defect relate at fixed n."
+    }
+  ],
+  "references": [
+    {
+      "key": "GuyUPNT",
+      "citation": "Guy, R.K., Unsolved Problems in Number Theory, 3rd ed., Springer (2004), D1–D2 (sums of like powers, near-misses to Fermat's equation).",
+      "type": "book"
+    },
+    {
+      "key": "SylvInertia",
+      "citation": "Sylvester, J.J., A demonstration of the theorem that every homogeneous quadratic polynomial is reducible by real orthogonal substitutions to the form of a sum of positive and negative squares, Philos. Mag. 4 (1852), 138–142 (law of inertia).",
+      "type": "paper"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry answering the open question of the parent **"The Sign-Flip Involution of the Defect-One Conjecture"** (`fermat-defect-one-oq-06`).

The parent gives an involution Ψ(a,b,c)=(c,-b,a) that negates the Fermat defect aⁿ+bⁿ-cⁿ at every **odd** exponent, and noted that at **even** n it degenerates to an a↔c swap rather than a sign flip. The OQ asked: *is there a different structural map exchanging the two defect signs at even n, or is the absence genuine?*

**Answer (negative, for the natural class of maps Ψ belongs to).** Within the signed coordinate permutations {±1}³ ⋊ S₃ — the class Ψ lives in — **no** map negates the even-exponent defect, whereas at every odd exponent the Ψ-analogue does. So the even/odd asymmetry is genuine, not an artefact of Ψ.

**Mechanism — sign-blindness.** At even n, each ±1 sign raised to the n-th power is 1, so a signed permutation's effect on the defect cannot depend on its signs: it factors through the pure permutation σ, which merely shuffles the summands v0ⁿ, v1ⁿ, v2ⁿ. Permutations fix the defect at the symmetric point (1,1,1), where it equals 1+1-1 = 1 > 0; a sign flip would need that value to be -1. Evaluating a hypothetical negating map at (1,1,1) is a one-line contradiction 1 ≠ -1.

## Contents (`Proofs/FermatDefectOneOQ06OQ01.lean`, 185 lines, 7 theorems, 5 defs)

- `defect / signedPerm / IsSign / NegatesDefect` — Fin-3 framework; Ψ = `signedPerm (swap 0 2) ![1,-1,1]`
- `sign_even_pow` — a ±1 to an even power is 1 (via `Even.neg_one_pow`)
- `no_signFlip_even` — **main no-go**: no signed permutation negates the even defect
- `signFlipFin_negates_odd` — odd-n positive half (via `Odd.neg_pow`)
- `even_odd_asymmetry` — packaged parity dichotomy
- `signFlipFin_eq_parent` — bridge showing the Fin-3 map equals the parent's Ψ(a,b,c)=(c,-b,a)

## Verification

- Built with `./proofs/scripts/docker-build.sh Proofs.FermatDefectOneOQ06OQ01` — **Build succeeded (7746 jobs)**.
- `#print axioms` on all key theorems reports **only `[propext, Classical.choice, Quot.sound]`** — no `sorryAx`, no `Lean.ofReduceBool` (the single `decide` computes a Fin-3 fixed point and does not use `native_decide`).
- **Status: `verified`, badge `original`, axiomCount 0, 0 sorries.**

## Scope (honest)

This resolves the question for the class of **signed coordinate permutations** (order 48), precisely the structural maps Ψ is drawn from. The obstruction is the sign-blindness of even powers; it does not by itself rule out exotic non-linear or non-coordinate maps (the parent OQ did not consider these either). Recorded as a follow-up open question in the entry, along with the n=2 Sylvester's-law-of-inertia angle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)