### PR TITLE
research(erdos-634-medial-congruence-oq-02): medial subdivision is a genuine covering [VERIFIED, 0-axiom, +7thm]

### DIFF
--- a/proofs/Proofs/Erdos634MedialCongruenceOQ02.lean
+++ b/proofs/Proofs/Erdos634MedialCongruenceOQ02.lean
@@ -1,0 +1,199 @@
+/-
+# Erdős Problem #634 (OQ-02) — The medial subdivision is a genuine COVERING
+
+Source: open question `erdos-634-medial-congruence-oq-02`, the analytic
+companion of the base entry `Proofs.Erdos634MedialCongruence`.
+
+## The gap this closes
+
+The base entry proves that the four medial triangles obtained by joining the
+side midpoints of `A B C`,
+
+  * `T₁ = (A,   mAB, mCA)`  (corner at `A`)
+  * `T₂ = (mAB, B,   mBC)`  (corner at `B`)
+  * `T₃ = (mCA, mBC, C)`    (corner at `C`)
+  * `T₄ = (mBC, mCA, mAB)`  (central / medial)
+
+are **pairwise congruent**.  It explicitly disclaims the *covering* half of the
+dissection statement: "We do not formalise the covering/disjointness of the
+dissection (the analytic part of #634)".
+
+This file supplies the covering half.  Writing `tri A B C` for the filled
+triangle (all convex combinations `a•A + b•B + c•C`, `a,b,c ≥ 0`, `a+b+c = 1`),
+the main result is
+
+  `medial_covering :  tri A B C = tri A mAB mCA ∪ tri mAB B mBC
+                                  ∪ tri mCA mBC C ∪ tri mBC mCA mAB`
+
+i.e. the four medial triangles together cover the whole triangle, with no point
+left out.  Combined with the base entry's congruence result, this promotes the
+medial subdivision from "four congruent pieces" to "four congruent pieces that
+tile the triangle" (covering being the analytic ingredient the base entry left
+open).
+
+## What is proved (0 axioms, fully verified)
+
+Working over an arbitrary real vector space `V` (`AddCommGroup V`, `Module ℝ V`)
+— no norm or metric is needed, since covering is a purely affine/convex
+property:
+
+  * `triBary_convex`        : the barycentric triangle region is convex;
+  * `triBary_eq_convexHull` : it is exactly the convex hull of the three
+    vertices — so `tri A B C` is genuinely *the* triangle, in Mathlib's sense;
+  * `medial_covering`       : the four medial sub-triangles cover `tri A B C`
+    exactly (set equality), the covering half of the dissection;
+  * `medial_covering_convexHull` : the same statement phrased with `convexHull`.
+
+The covering direction is the barycentric case analysis: a point with
+barycentric coordinates `(a,b,c)` lies in the corner triangle at `A` when
+`a ≥ ½` (symmetrically for `B`, `C`), and in the central medial triangle when
+all three coordinates are `≤ ½`; the explicit reweightings are given.
+
+The remaining ingredient for a *measure-theoretic* tiling — interior
+disjointness (the pairwise overlaps of the four pieces are the shared edges,
+hence Lebesgue-null in the plane) — is not formalised here; it requires fixing
+`V = ℝ²` and the planar area measure, and is recorded as future work.
+
+Tags: geometry, erdos, dissection, tiling, covering, convexity, barycentric
+-/
+
+import Mathlib.Data.Real.Basic
+import Mathlib.Algebra.CharP.Invertible
+import Mathlib.Analysis.Convex.Combination
+import Mathlib.Analysis.Convex.Hull
+import Mathlib.LinearAlgebra.AffineSpace.Midpoint
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Tactic.Module
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+
+set_option linter.unusedSectionVars false
+
+namespace Erdos634MedialCongruenceOQ02
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-- The filled triangle with vertices `A B C`, in barycentric form: all convex
+combinations `a•A + b•B + c•C` with `a, b, c ≥ 0` and `a + b + c = 1`. -/
+def triBary (A B C : V) : Set V :=
+  {p | ∃ a b c : ℝ, 0 ≤ a ∧ 0 ≤ b ∧ 0 ≤ c ∧ a + b + c = 1 ∧ p = a • A + b • B + c • C}
+
+/-- Each vertex belongs to its own triangle. -/
+theorem left_mem_triBary (A B C : V) : A ∈ triBary A B C :=
+  ⟨1, 0, 0, by norm_num, le_refl 0, le_refl 0, by norm_num, by module⟩
+
+theorem middle_mem_triBary (A B C : V) : B ∈ triBary A B C :=
+  ⟨0, 1, 0, le_refl 0, by norm_num, le_refl 0, by norm_num, by module⟩
+
+theorem right_mem_triBary (A B C : V) : C ∈ triBary A B C :=
+  ⟨0, 0, 1, le_refl 0, le_refl 0, by norm_num, by norm_num, by module⟩
+
+/-- The barycentric triangle region is convex. -/
+theorem triBary_convex (A B C : V) : Convex ℝ (triBary A B C) := by
+  rintro p ⟨a₁, b₁, c₁, ha₁, hb₁, hc₁, hsum₁, rfl⟩
+    q ⟨a₂, b₂, c₂, ha₂, hb₂, hc₂, hsum₂, rfl⟩ s t hs ht hst
+  refine ⟨s * a₁ + t * a₂, s * b₁ + t * b₂, s * c₁ + t * c₂,
+    add_nonneg (mul_nonneg hs ha₁) (mul_nonneg ht ha₂),
+    add_nonneg (mul_nonneg hs hb₁) (mul_nonneg ht hb₂),
+    add_nonneg (mul_nonneg hs hc₁) (mul_nonneg ht hc₂), ?_, ?_⟩
+  · have h : s * a₁ + t * a₂ + (s * b₁ + t * b₂) + (s * c₁ + t * c₂)
+      = s * (a₁ + b₁ + c₁) + t * (a₂ + b₂ + c₂) := by ring
+    rw [h, hsum₁, hsum₂]; linarith
+  · module
+
+/-- `tri A B C` is exactly the convex hull of its three vertices: the
+barycentric description agrees with Mathlib's `convexHull`. -/
+theorem triBary_eq_convexHull (A B C : V) :
+    triBary A B C = convexHull ℝ ({A, B, C} : Set V) := by
+  apply le_antisymm
+  · rintro p ⟨a, b, c, ha, hb, hc, hsum, rfl⟩
+    have hA : A ∈ convexHull ℝ ({A, B, C} : Set V) := subset_convexHull ℝ _ (by simp)
+    have hB : B ∈ convexHull ℝ ({A, B, C} : Set V) := subset_convexHull ℝ _ (by simp)
+    have hC : C ∈ convexHull ℝ ({A, B, C} : Set V) := subset_convexHull ℝ _ (by simp)
+    have h0 : ∀ i ∈ (Finset.univ : Finset (Fin 3)), 0 ≤ ![a, b, c] i := by
+      intro i _; fin_cases i <;> assumption
+    have h1 : ∑ i : Fin 3, ![a, b, c] i = 1 := by
+      simp only [Fin.sum_univ_three, Matrix.cons_val_zero, Matrix.cons_val_one,
+        Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons]
+      linarith
+    have h2 : ∀ i ∈ (Finset.univ : Finset (Fin 3)),
+        ![A, B, C] i ∈ convexHull ℝ ({A, B, C} : Set V) := by
+      intro i _; fin_cases i
+      · exact hA
+      · exact hB
+      · exact hC
+    have hmem := (convex_convexHull ℝ ({A, B, C} : Set V)).sum_mem h0 h1 h2
+    simpa only [Fin.sum_univ_three, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons] using hmem
+  · refine convexHull_min ?_ (triBary_convex A B C)
+    intro x hx
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+    rcases hx with rfl | rfl | rfl
+    · exact left_mem_triBary _ _ _
+    · exact middle_mem_triBary _ _ _
+    · exact right_mem_triBary _ _ _
+
+/-- **The medial subdivision covers the triangle.**  With `mAB, mBC, mCA` the
+three side midpoints, the four medial sub-triangles
+
+  `(A, mAB, mCA)`, `(mAB, B, mBC)`, `(mCA, mBC, C)`, `(mBC, mCA, mAB)`
+
+cover `tri A B C` exactly — every point of the triangle lies in at least one of
+them, and each of them lies inside the triangle. -/
+theorem medial_covering (A B C : V) :
+    triBary A B C =
+      triBary A (midpoint ℝ A B) (midpoint ℝ C A) ∪
+      triBary (midpoint ℝ A B) B (midpoint ℝ B C) ∪
+      triBary (midpoint ℝ C A) (midpoint ℝ B C) C ∪
+      triBary (midpoint ℝ B C) (midpoint ℝ C A) (midpoint ℝ A B) := by
+  ext p
+  constructor
+  · -- Covering: every point of the triangle lands in one of the four pieces.
+    rintro ⟨a, b, c, ha, hb, hc, hsum, rfl⟩
+    rcases le_or_gt (1 / 2 : ℝ) a with hA | hA
+    · -- corner triangle at `A`
+      refine Or.inl (Or.inl (Or.inl ⟨2 * a - 1, 2 * b, 2 * c,
+        by linarith, by linarith, by linarith, by linarith, ?_⟩))
+      simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+    · rcases le_or_gt (1 / 2 : ℝ) b with hB | hB
+      · -- corner triangle at `B`
+        refine Or.inl (Or.inl (Or.inr ⟨2 * a, 2 * b - 1, 2 * c,
+          by linarith, by linarith, by linarith, by linarith, ?_⟩))
+        simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+      · rcases le_or_gt (1 / 2 : ℝ) c with hC | hC
+        · -- corner triangle at `C`
+          refine Or.inl (Or.inr ⟨2 * a, 2 * b, 2 * c - 1,
+            by linarith, by linarith, by linarith, by linarith, ?_⟩)
+          simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+        · -- central medial triangle
+          refine Or.inr ⟨1 - 2 * a, 1 - 2 * b, 1 - 2 * c,
+            by linarith, by linarith, by linarith, by linarith, ?_⟩
+          simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+  · -- Each of the four pieces sits inside the triangle.
+    rintro (((⟨a, b, c, ha, hb, hc, hsum, rfl⟩ | ⟨a, b, c, ha, hb, hc, hsum, rfl⟩) |
+      ⟨a, b, c, ha, hb, hc, hsum, rfl⟩) | ⟨a, b, c, ha, hb, hc, hsum, rfl⟩)
+    · exact ⟨a + b / 2 + c / 2, b / 2, c / 2, by linarith, by linarith, by linarith,
+        by linarith, by simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith⟩
+    · exact ⟨a / 2, a / 2 + b + c / 2, c / 2, by linarith, by linarith, by linarith,
+        by linarith, by simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith⟩
+    · exact ⟨a / 2, b / 2, a / 2 + b / 2 + c, by linarith, by linarith, by linarith,
+        by linarith, by simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith⟩
+    · exact ⟨(b + c) / 2, (a + c) / 2, (a + b) / 2, by linarith, by linarith, by linarith,
+        by linarith, by simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith⟩
+
+/-- The covering statement phrased with Mathlib's `convexHull`: the convex hull
+of the three vertices is the union of the convex hulls of the four medial
+sub-triangles. -/
+theorem medial_covering_convexHull (A B C : V) :
+    convexHull ℝ ({A, B, C} : Set V) =
+      convexHull ℝ ({A, midpoint ℝ A B, midpoint ℝ C A} : Set V) ∪
+      convexHull ℝ ({midpoint ℝ A B, B, midpoint ℝ B C} : Set V) ∪
+      convexHull ℝ ({midpoint ℝ C A, midpoint ℝ B C, C} : Set V) ∪
+      convexHull ℝ ({midpoint ℝ B C, midpoint ℝ C A, midpoint ℝ A B} : Set V) := by
+  have h := medial_covering A B C
+  simp only [triBary_eq_convexHull] at h
+  exact h
+
+end Erdos634MedialCongruenceOQ02

--- a/src/data/proofs/erdos-634-medial-congruence-oq-02/annotations.json
+++ b/src/data/proofs/erdos-634-medial-congruence-oq-02/annotations.json
@@ -1,0 +1,108 @@
+[
+  {
+    "id": "oq02-intro",
+    "proofId": "erdos-634-medial-congruence-oq-02",
+    "range": { "startLine": 1, "endLine": 77 },
+    "type": "concept",
+    "title": "From congruent pieces to a genuine covering",
+    "content": "The base entry erdos-634-medial-congruence proves the four medial triangles are pairwise congruent, but explicitly disclaims the covering/disjointness of the dissection — 'We do not formalise the covering/disjointness of the dissection (the analytic part of #634)'. A dissection into congruent pieces is only a tiling once the pieces are shown to cover the region and to overlap only on their boundaries. This open question, OQ-02, asks for that upgrade; this entry supplies the covering half.",
+    "mathContext": "Covering is a purely affine/convex property, so the entry works over an arbitrary real vector space $(V,\\ \\text{AddCommGroup}\\ V,\\ \\text{Module}\\ \\mathbb{R}\\ V)$ with no metric — strictly weaker than the base entry's normed-space hypotheses.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangle dissection",
+      "tiling vs congruence",
+      "covering condition",
+      "Erdős problems",
+      "barycentric coordinates"
+    ],
+    "prerequisites": [
+      "convex geometry",
+      "affine combinations",
+      "tilings and dissections"
+    ]
+  },
+  {
+    "id": "oq02-tribary",
+    "proofId": "erdos-634-medial-congruence-oq-02",
+    "range": { "startLine": 80, "endLine": 105 },
+    "type": "definition",
+    "title": "The filled triangle in barycentric form, and its convexity",
+    "content": "triBary A B C is defined as the set of convex combinations a·A + b·B + c·C with a,b,c ≥ 0 and a+b+c = 1 — the filled triangle described barycentrically. Each vertex belongs to it (take one weight equal to 1), and the region is convex: a convex combination s·p + t·q of two barycentric points p, q is again a barycentric point with weights s·(coords of p) + t·(coords of q), the vector identity being closed by the `module` tactic.",
+    "mathContext": "$\\mathrm{triBary}(A,B,C) = \\{\\, a\\,A + b\\,B + c\\,C : a,b,c \\ge 0,\\ a+b+c = 1 \\,\\}$, and $\\mathrm{Convex}_{\\mathbb{R}}(\\mathrm{triBary}(A,B,C))$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "barycentric coordinates",
+      "convex set",
+      "convex combination",
+      "triangle interior"
+    ],
+    "prerequisites": [
+      "convex sets",
+      "affine combinations",
+      "module tactic"
+    ]
+  },
+  {
+    "id": "oq02-convexhull",
+    "proofId": "erdos-634-medial-congruence-oq-02",
+    "range": { "startLine": 108, "endLine": 137 },
+    "type": "technique",
+    "title": "The barycentric region is exactly the convex hull",
+    "content": "triBary_eq_convexHull proves triBary A B C = convexHull ℝ {A,B,C}, certifying that the hand-rolled barycentric region is genuinely THE triangle in Mathlib's sense. The forward inclusion places a·A + b·B + c·C inside the hull using Convex.sum_mem over a Fin 3 index (weights ![a,b,c], points ![A,B,C]); the reverse inclusion uses convexHull_min — the hull is the smallest convex set containing the vertices, and triBary is convex and contains them.",
+    "mathContext": "$\\mathrm{triBary}(A,B,C) = \\mathrm{convexHull}_{\\mathbb{R}}\\{A,B,C\\}$, via `Convex.sum_mem` (⊆) and `convexHull_min` (⊇).",
+    "significance": "important",
+    "relatedConcepts": [
+      "convex hull",
+      "Convex.sum_mem",
+      "convexHull_min",
+      "finite convex combination"
+    ],
+    "prerequisites": [
+      "convex hull",
+      "convex combinations over a finite index"
+    ]
+  },
+  {
+    "id": "oq02-covering",
+    "proofId": "erdos-634-medial-congruence-oq-02",
+    "range": { "startLine": 145, "endLine": 185 },
+    "type": "key-step",
+    "title": "The medial subdivision covers the triangle",
+    "content": "medial_covering is the main result: tri A B C equals the union of the four medial sub-triangles tri A mAB mCA ∪ tri mAB B mBC ∪ tri mCA mBC C ∪ tri mBC mCA mAB, an exact set equality. The covering direction takes a point p = a·A + b·B + c·C and case-splits on its barycentric coordinates: a ≥ ½ places p in the corner triangle at A (with weights 2a−1, 2b, 2c); symmetrically for b ≥ ½ and c ≥ ½; and when a, b, c are all ≤ ½, p lies in the central medial triangle (weights 1−2a, 1−2b, 1−2c). The reverse inclusion places each piece back inside the triangle by the analogous reweighting. Every vertex identity reduces, after expanding the midpoints via midpoint_eq_smul_add, to linear scalar equations closed by `match_scalars <;> linarith`.",
+    "mathContext": "Barycentric threshold: a coordinate $\\ge \\tfrac12$ pins $p$ to the corner piece at that vertex; all three coordinates $\\le \\tfrac12$ is exactly the central medial triangle. E.g. $a \\ge \\tfrac12$ gives $p = (2a-1)\\,A + (2b)\\,m_{AB} + (2c)\\,m_{CA}$ with nonnegative weights summing to 1.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "covering",
+      "triangle tiling",
+      "barycentric case analysis",
+      "medial triangle",
+      "match_scalars"
+    ],
+    "prerequisites": [
+      "barycentric coordinates",
+      "midpoints and convex combinations",
+      "case analysis"
+    ]
+  },
+  {
+    "id": "oq02-convexhull-covering",
+    "proofId": "erdos-634-medial-congruence-oq-02",
+    "range": { "startLine": 189, "endLine": 199 },
+    "type": "concept",
+    "title": "The covering restated with convexHull, and what remains",
+    "content": "medial_covering_convexHull restates the covering entirely in Mathlib's convexHull vocabulary — the convex hull of {A,B,C} is the union of the convex hulls of the four medial vertex-triples — obtained by rewriting each triBary through triBary_eq_convexHull. Together with the base entry's congruence result, this promotes the medial subdivision from 'four congruent pieces' to 'four congruent pieces that cover the triangle'. The one remaining ingredient for a measure-theoretic tiling is interior-disjointness: the pairwise overlaps are the shared edges (segments), hence area-zero in the plane, which requires fixing V = ℝ² and the planar area measure.",
+    "mathContext": "$\\mathrm{convexHull}_{\\mathbb{R}}\\{A,B,C\\} = \\bigcup$ of the convex hulls of the four medial vertex-triples; interior-disjointness (Lebesgue-null overlaps) is left as future work.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "convex hull",
+      "tiling",
+      "interior-disjointness",
+      "measure zero",
+      "future work"
+    ],
+    "prerequisites": [
+      "convex hull",
+      "Lebesgue measure (for the open direction)"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-634-medial-congruence-oq-02/index.ts
+++ b/src/data/proofs/erdos-634-medial-congruence-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos634MedialCongruenceOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos634MedialCongruenceOQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos634MedialCongruenceOQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos634MedialCongruenceOQ02Data: ProofData = {
+  proof: erdos634MedialCongruenceOQ02Proof,
+  annotations: erdos634MedialCongruenceOQ02Annotations,
+}

--- a/src/data/proofs/erdos-634-medial-congruence-oq-02/meta.json
+++ b/src/data/proofs/erdos-634-medial-congruence-oq-02/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "erdos-634-medial-congruence-oq-02",
+  "slug": "erdos-634-medial-congruence-oq-02",
+  "title": "Erdős #634 (OQ-02): The Medial Subdivision is a Genuine Covering",
+  "description": "Open question OQ-02 of erdos-634-medial-congruence asks to upgrade the medial (k=2) subdivision from 'four congruent pieces' to a genuine tiling by adding the covering and interior-disjointness conditions the base entry explicitly left open. This entry supplies the covering half. Writing tri A B C for the filled triangle (all convex combinations a·A + b·B + c·C with a,b,c ≥ 0 and a+b+c = 1), it proves medial_covering: tri A B C equals the union of the four medial sub-triangles tri A mAB mCA ∪ tri mAB B mBC ∪ tri mCA mBC C ∪ tri mBC mCA mAB — every point of the triangle lies in at least one piece, and each piece lies inside the triangle. The covering direction is the barycentric case analysis: a point with barycentric coordinates (a,b,c) lies in the corner triangle at A when a ≥ ½ (symmetrically for B, C) and in the central medial triangle when all three are ≤ ½, with explicit reweightings given. The region tri is shown convex and equal to Mathlib's convexHull of the three vertices (triBary_eq_convexHull), so the statement is also given in convexHull form. Fully machine-checked, 0 axioms (only foundational propext/Classical.choice/Quot.sound), over an arbitrary real vector space.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos634MedialCongruenceOQ02.lean",
+    "tags": [
+      "geometry",
+      "erdos",
+      "dissection",
+      "tiling",
+      "covering",
+      "convexity",
+      "barycentric"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 199,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "assumptions": "None. Results are unconditional theorems over an arbitrary real vector space (AddCommGroup V, Module ℝ V) — no norm or metric is used, since covering is a purely affine/convex property. #print axioms reports only propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Convex.sum_mem",
+        "description": "A convex set is closed under finite convex combinations; used to place a·A + b·B + c·C inside the convex hull of {A,B,C}",
+        "module": "Mathlib.Analysis.Convex.Combination"
+      },
+      {
+        "theorem": "convexHull_min",
+        "description": "The convex hull is the smallest convex set containing a given set; used for the reverse inclusion convexHull {A,B,C} ⊆ triBary A B C",
+        "module": "Mathlib.Analysis.Convex.Hull"
+      },
+      {
+        "theorem": "subset_convexHull",
+        "description": "A set is contained in its convex hull; supplies membership of the three vertices",
+        "module": "Mathlib.Analysis.Convex.Hull"
+      },
+      {
+        "theorem": "midpoint_eq_smul_add",
+        "description": "midpoint R x y = (⅟2)·(x + y); expands the three side midpoints into ℝ-linear combinations closed by match_scalars",
+        "module": "Mathlib.LinearAlgebra.AffineSpace.Midpoint"
+      }
+    ],
+    "originalContributions": [
+      "Supplies the covering half of the medial dissection that the base entry and OQ-01 explicitly disclaimed ('We do not formalise the covering/disjointness of the dissection').",
+      "triBary: a barycentric model of the filled triangle (convex combinations of the three vertices), proven convex (triBary_convex) and shown equal to Mathlib's convexHull of the vertices (triBary_eq_convexHull) — so tri A B C is genuinely THE triangle.",
+      "medial_covering: an exact set equality proving the four medial sub-triangles cover the whole triangle. The covering direction is a clean barycentric case split — corner triangle at A when a ≥ ½ (symmetrically B, C), central medial triangle when all three coordinates are ≤ ½ — with explicit convex-combination reweightings; each vertex identity is discharged by match_scalars <;> linarith after expanding midpoints.",
+      "medial_covering_convexHull: the same covering statement phrased entirely with Mathlib's convexHull, obtained by rewriting through triBary_eq_convexHull.",
+      "Works over an arbitrary real vector space (AddCommGroup V, Module ℝ V) with no metric assumptions, since covering is a purely affine/convex property; this is strictly weaker than the base entry's normed-space hypotheses."
+    ],
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "Convex sets and convex hulls (Convex.sum_mem, convexHull_min, subset_convexHull)",
+      "Barycentric / affine combinations of triangle vertices",
+      "Midpoint API (midpoint_eq_smul_add)",
+      "The module / match_scalars tactics for ℝ-linear vector identities"
+    ],
+    "relatedNote": "Companion to the k = 2 base entry erdos-634-medial-congruence and its OQ-01 (the square reptiling for all k). Both prove CONGRUENCE of the pieces but explicitly leave the covering/disjointness (analytic) part open; this entry closes the covering direction. Interior-disjointness (measure-zero overlaps in the plane) remains open and would require fixing V = ℝ² and the area measure."
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #634 (a $25 problem) asks to understand all triples (T, R, N) such that a triangle T can be tiled by N congruent copies of a triangle R. The medial subdivision — joining the three side midpoints — is the base case k = 2 of the square reptiling. The base gallery entry proved the four medial pieces are pairwise congruent but deliberately did not formalise that they actually tile (cover, with disjoint interiors) the triangle. A dissection into congruent pieces is only a tiling once one verifies the pieces cover the region and overlap only on their boundaries.",
+    "problemStatement": "Open question OQ-02: upgrade the medial congruence statement to a genuine tiling by adding the covering (and interior-disjointness) conditions. This entry proves the covering condition: the four medial sub-triangles of A B C together contain every point of triangle A B C, and each lies inside it — an exact set equality tri A B C = union of the four pieces.",
+    "proofStrategy": "Model the filled triangle barycentrically: triBary A B C = { a·A + b·B + c·C : a,b,c ≥ 0, a+b+c = 1 }. First show triBary is convex and equals the convex hull of {A,B,C} (via Convex.sum_mem for one inclusion and convexHull_min for the other), certifying it is the standard triangle. For the covering, take a point p = a·A + b·B + c·C in the triangle and case-split on its barycentric coordinates: if a ≥ ½ it lies in the corner triangle (A, mAB, mCA) with weights (2a−1, 2b, 2c); symmetrically for b ≥ ½ and c ≥ ½; and if a, b, c are all ≤ ½ it lies in the central medial triangle (mBC, mCA, mAB) with weights (1−2a, 1−2b, 1−2c). The reverse inclusion (each piece sits inside the triangle) is the analogous explicit reweighting. All vertex identities reduce, after expanding midpoints via midpoint_eq_smul_add, to linear scalar equations closed by match_scalars <;> linarith.",
+    "keyInsights": [
+      "Covering is purely affine/convex — no metric is needed — so the result holds over any real vector space, strictly weakening the base entry's normed-space hypotheses.",
+      "The barycentric ½-threshold cleanly partitions the triangle: a coordinate ≥ ½ pins a point to the corner piece at that vertex, and 'all coordinates ≤ ½' is exactly the central medial triangle. This is the geometric content of the covering.",
+      "The explicit reweightings (e.g. weights (2a−1, 2b, 2c) for the corner-A piece) make each membership a finite, checkable convex combination, so the whole covering is a case analysis with no existentials left implicit.",
+      "Identifying the barycentric region with Mathlib's convexHull (triBary_eq_convexHull) turns the hand-rolled triangle into the canonical one and lets the covering be restated verbatim for convexHull.",
+      "What remains for a measure-theoretic tiling is interior-disjointness: the pairwise overlaps of the four pieces are shared edges (segments), Lebesgue-null in the plane. That step needs the planar area measure and is left as future work."
+    ],
+    "prerequisites": [
+      "Convex sets, convex combinations, and convex hulls",
+      "Barycentric coordinates of a triangle",
+      "Affine geometry over a vector space (no metric required)",
+      "Triangle reptiling / dissection background for Erdős #634"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-setup",
+      "title": "Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 77,
+      "summary": "Module docstring framing OQ-02 (the covering half of the medial dissection that the base entry left open) and its place in Erdős #634. Imports only the specific Mathlib convex-analysis, midpoint, and tactic modules needed, and works over an arbitrary real vector space (AddCommGroup V, Module ℝ V) — no norm is used, since covering is affine/convex.",
+      "mathContext": "Setting: AddCommGroup V, Module ℝ V. Covering is a purely affine/convex property, so no metric hypotheses are needed."
+    },
+    {
+      "id": "triangle-region",
+      "title": "The Barycentric Triangle Region and its Convexity",
+      "startLine": 78,
+      "endLine": 105,
+      "summary": "Defines triBary A B C = { a·A + b·B + c·C : a,b,c ≥ 0, a+b+c = 1 }, the filled triangle in barycentric form; proves each vertex belongs to it (left/middle/right_mem_triBary) and that the region is convex (triBary_convex) — a convex combination of two barycentric points is again barycentric, with the vector identity closed by module.",
+      "mathContext": "triBary A B C = { a·A + b·B + c·C : a,b,c ≥ 0, a+b+c = 1 }; Convex ℝ (triBary A B C)."
+    },
+    {
+      "id": "eq-convexhull",
+      "title": "The Region is the Convex Hull of the Vertices",
+      "startLine": 106,
+      "endLine": 137,
+      "summary": "triBary_eq_convexHull: the barycentric region equals Mathlib's convexHull ℝ {A,B,C}. Forward inclusion places a·A + b·B + c·C in the hull via Convex.sum_mem over a Fin 3 index; reverse inclusion uses convexHull_min with the convexity of triBary and membership of the three vertices. This certifies that tri A B C is genuinely the standard triangle.",
+      "mathContext": "triBary A B C = convexHull ℝ {A, B, C}; via Convex.sum_mem and convexHull_min."
+    },
+    {
+      "id": "medial-covering",
+      "title": "The Medial Subdivision Covers the Triangle",
+      "startLine": 138,
+      "endLine": 185,
+      "summary": "medial_covering: tri A B C = tri A mAB mCA ∪ tri mAB B mBC ∪ tri mCA mBC C ∪ tri mBC mCA mAB (exact set equality). The covering direction case-splits on the barycentric coordinates (a,b,c): corner triangle at A when a ≥ ½ (weights 2a−1, 2b, 2c), symmetrically at B, C, and the central medial triangle when all ≤ ½ (weights 1−2a, 1−2b, 1−2c). The reverse inclusion places each piece inside the triangle by the analogous reweighting. All vertex identities close by match_scalars <;> linarith after expanding midpoints.",
+      "mathContext": "Covering by barycentric threshold: coordinate ≥ ½ ⇒ corner piece at that vertex; all coordinates ≤ ½ ⇒ central medial piece."
+    },
+    {
+      "id": "covering-convexhull",
+      "title": "The Covering Restated with convexHull",
+      "startLine": 186,
+      "endLine": 199,
+      "summary": "medial_covering_convexHull: the covering equality phrased entirely with Mathlib's convexHull, obtained by rewriting each triBary through triBary_eq_convexHull and applying medial_covering — the convex hull of the three vertices is the union of the convex hulls of the four medial sub-triangles.",
+      "mathContext": "convexHull ℝ {A,B,C} = union of convexHull of the four medial vertex-triples."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "Erdős Problem #634 (tiling a triangle by N congruent copies of a triangle)",
+      "year": "1990s",
+      "venue": "erdosproblems.com/634",
+      "note": "The $25 problem asking to characterize all triples (T, R, N) with T tileable by N congruent copies of R; a genuine tiling requires both congruence and covering with disjoint interiors."
+    },
+    {
+      "authors": "Snover, Stephen L.; Waiveris, Charles; Williams, John K.",
+      "title": "Rep-tiling for triangles",
+      "year": "1991",
+      "venue": "Discrete Mathematics 91(2), 193–200",
+      "note": "Standard reference on triangle rep-tilings and the square-reptiling subdivision whose covering (k = 2 medial case) is formalized here."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully machine-checked, axiom-free formalization (0 sorries; only propext/Classical.choice/Quot.sound) over an arbitrary real vector space that the medial subdivision of any triangle A B C is a genuine COVERING: the filled triangle tri A B C equals the union of its four medial sub-triangles. The triangle is modeled barycentrically as triBary, proven convex and shown equal to Mathlib's convexHull of the vertices; the covering is a barycentric case analysis (a coordinate ≥ ½ ⇒ the corner piece at that vertex; all coordinates ≤ ½ ⇒ the central medial piece) with explicit convex-combination reweightings, and the statement is also given in convexHull form.",
+    "implications": "Together with the base entry's congruence result, this promotes the medial subdivision from 'four congruent pieces' to 'four congruent pieces that cover the triangle', supplying the covering ingredient of a tiling that the base entry and OQ-01 explicitly left open. Because covering is purely affine/convex, the result holds without any metric assumption. The one remaining ingredient for a measure-theoretic tiling is interior-disjointness — the pairwise overlaps are shared edges, hence area-zero in the plane — which requires fixing V = ℝ² and the planar area measure.",
+    "openQuestions": [
+      "Formalize interior-disjointness of the four medial pieces in V = ℝ²: the pairwise intersections are shared edges (segments), hence Lebesgue-measure zero, completing the medial subdivision to a genuine measure-theoretic tiling.",
+      "Prove the analogous covering for the full k-subdivision of OQ-01 (the k² upward/downward cells cover the triangle), generalizing the barycentric threshold argument from the four medial pieces to all k."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-634-medial-congruence",
+      "relationship": "extends",
+      "description": "The k = 2 base entry proves the four medial pieces are pairwise congruent but explicitly does not formalise covering/disjointness. This entry supplies the covering half, directly answering its open question OQ-02."
+    },
+    {
+      "targetId": "erdos-634-medial-congruence-oq-01",
+      "relationship": "relatedTo",
+      "description": "OQ-01 generalizes the congruence + scaling + count to the full square reptiling for all k, but likewise leaves covering/disjointness open; this entry closes the covering direction for the k = 2 medial case."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers open question **OQ-02** of `erdos-634-medial-congruence` by supplying the **covering** half of the Erdős #634 medial dissection — the analytic ingredient the base entry explicitly disclaimed (*"We do not formalise the covering/disjointness of the dissection (the analytic part of #634)"*).

The base entry (and OQ-01) prove the four medial triangles are pairwise **congruent**. A dissection into congruent pieces is only a *tiling* once one also shows the pieces **cover** the region (and overlap only on boundaries). This entry proves the covering.

## What is proved (0 axioms, fully verified)

Over an arbitrary real vector space `V` (`AddCommGroup V`, `Module ℝ V`) — no norm/metric, since covering is purely affine/convex:

- **`triBary`** — barycentric model of the filled triangle `{ a•A + b•B + c•C : a,b,c ≥ 0, a+b+c = 1 }`; proven **convex** and shown **equal to Mathlib's `convexHull ℝ {A,B,C}`** (`triBary_eq_convexHull`), certifying it is genuinely the triangle.
- **`medial_covering`** (main result) — the exact set equality
  `tri A B C = tri A mAB mCA ∪ tri mAB B mBC ∪ tri mCA mBC C ∪ tri mBC mCA mAB`,
  via a barycentric ½-threshold case analysis: a coordinate `≥ ½` pins a point to the corner piece at that vertex (weights `2a−1, 2b, 2c`, symmetrically for `B`, `C`); all coordinates `≤ ½` gives the central medial piece (weights `1−2a, 1−2b, 1−2c`). Each vertex identity closes by `match_scalars <;> linarith` after expanding midpoints.
- **`medial_covering_convexHull`** — the same restated in Mathlib's `convexHull` vocabulary.

## Verification

`#print axioms` on all three theorems reports only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Compiles against Mathlib 4.26.0.

## Remaining / future work

Interior-disjointness (the pairwise overlaps are shared edges, hence Lebesgue-null in the plane) is **not** formalised here — it requires fixing `V = ℝ²` and the planar area measure — and is recorded in the entry's open questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)