### PR TITLE
audit: 13 new OQ-extension gallery entries verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -27039,6 +27039,84 @@
       "lastAudited": "2026-07-01T22:34:45Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq-04-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-06-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-bounds-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cramers-rule-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dirichlet-approximation-theorem-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fermat-two-squares-oq-06-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-07-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-number-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-06-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "konigsberg-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lucas-sequence-degree2-identities-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "picks-theorem-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bertrands-postulate-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-02T01:18:34Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited all **13 never-audited** gallery entries. All are **clean** — every structural claim in `meta.json` matches the Lean source.

### Checks performed (per entry)
- Sorry count (meta vs source, comment mentions excluded)
- Axiom declarations & `native_decide` usage
- `True`-stub detection
- Theorem / definition counts
- Line counts
- Badge/status vs Mathlib reliance (Tier B `mathlib`-badged entries correctly credit their Mathlib dependencies)

### Entries audited (all clean)
| Slug | Badge | Result |
|------|-------|--------|
| bertrands-postulate-oq-05-oq-02 | verified | clean |
| bezout-identity-oq-04-oq-02-oq-01 | mathlib | clean |
| cayley-hamilton-minpoly-oq-06-oq-02 | mathlib | clean |
| chebyshev-bounds-oq-03-oq-02 | original | clean |
| cramers-rule-oq-03-oq-01 | mathlib | clean |
| dirichlet-approximation-theorem-oq-04-oq-02 | mathlib | clean |
| fermat-two-squares-oq-06-oq-02 | verified | clean |
| fibonacci-identities-oq-07-oq-01 | original | clean |
| frobenius-number-oq-01-oq-01 | original | clean |
| geometric-series-oq-06-oq-02 | mathlib | clean |
| konigsberg-oq-02-oq-01-oq-02 | mathlib | clean |
| lucas-sequence-degree2-identities-oq-01-oq-01 | original | clean |
| picks-theorem-oq-04-oq-02 | original | clean |

Result: **4367/4367 audited, 0 with issues, 0 critical.**

Updates `src/data/proofs/audit-tracker.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)