### PR TITLE
research(erdos-10-incomplete-01): foundations for the prime + ≤k powers-of-2 set [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos10Incomplete01.lean
+++ b/proofs/Proofs/Erdos10Incomplete01.lean
@@ -1,0 +1,150 @@
+/-
+# Erdős Problem #10 — Incomplete 01
+## Foundations for the representation set `prime + at most k powers of 2`
+
+Erdős Problem #10 asks whether there is a finite `k` such that every sufficiently large
+integer is the sum of a prime and at most `k` powers of `2`.  Erdős and Graham conjectured
+the answer is *no*.  The parent file `Erdos10Problem.lean` introduces the central object
+
+  `sumPrimeAndTwoPows k = { n | ∃ p (pows : Multiset ℕ),
+                                p.Prime ∧ pows.card ≤ k ∧ n = p + (pows.map (2^·)).sum }`,
+
+the set of integers representable as a prime plus **at most `k`** powers of `2` (the powers'
+exponents are recorded as a multiset, so repeats such as `2^3 + 2^3` are allowed), but proves
+nothing about it.  This file supplies the elementary order- and membership-structure of that
+family, entirely **without axioms or sorries**:
+
+* `prime_mem`      — every prime lies in `sumPrimeAndTwoPows k` (take zero powers);
+* `mem_zero_iff`   — `sumPrimeAndTwoPows 0` is *exactly* the primes;
+* `mem_one_iff`    — `n` uses at most one power of two iff `n` is prime or `n = p + 2^a`;
+* `prime_add_pow_mem`, `add_pow_mem` — how to build members by adjoining a power of `2`;
+* `mem_mono`, `subset_succ` — the family is increasing in `k`;
+* `infinite`       — each `sumPrimeAndTwoPows k` is infinite;
+* `eventuallyRepresentable` and `mem_iUnion_iff` — the union over all `k`, in whose terms
+  the Erdős–Graham conjecture (`erdosGraham`) is stated.
+
+These lemmas make the base definition usable and pin down the two smallest cases exactly;
+the genuinely open content (no finite `k` works) is packaged as `erdosGraham`, left as a
+`Prop`, not asserted.  The sharper *obstruction* results — e.g. the covering-congruence
+argument forcing the prime to be small when `k = 1` — live in the sibling file
+`Erdos10OQ01Incomplete01.lean`.
+
+## References
+- Erdős, P. (1950). "On integers of the form `2^k + p` and some related problems."
+  Summa Brasiliensis Mathematicae 2, 113–123.
+- Erdős, P.; Graham, R. (1980). *Old and New Problems and Results in Combinatorial Number
+  Theory.*  (The conjecture that no finite `k` suffices.)
+- [erdosproblems.com/10](https://www.erdosproblems.com/10)
+-/
+
+import Mathlib.Tactic
+import Mathlib.Data.Nat.Prime.Basic
+
+namespace Erdos10Incomplete01
+
+/-- The set of natural numbers expressible as a prime plus **at most `k`** powers of `2`.
+The powers-of-two component is recorded as a multiset of exponents of cardinality `≤ k`
+(so repeated powers, e.g. `2^3 + 2^3`, are permitted).  This matches the definition in the
+parent file `Erdos10Problem.lean`. -/
+def sumPrimeAndTwoPows (k : ℕ) : Set ℕ :=
+  { n | ∃ (p : ℕ) (pows : Multiset ℕ),
+      p.Prime ∧ pows.card ≤ k ∧ n = p + (pows.map (2 ^ ·)).sum }
+
+/-! ## Membership basics -/
+
+/-- Every prime is a member of `sumPrimeAndTwoPows k` for every `k`: use zero powers of two. -/
+theorem prime_mem {p : ℕ} (hp : p.Prime) (k : ℕ) : p ∈ sumPrimeAndTwoPows k :=
+  ⟨p, 0, hp, by simp, by simp⟩
+
+/-- Adjoining a fresh power `2^a` to a member of `sumPrimeAndTwoPows k` yields a member of
+`sumPrimeAndTwoPows (k+1)`. -/
+theorem add_pow_mem {n k : ℕ} (hn : n ∈ sumPrimeAndTwoPows k) (a : ℕ) :
+    n + 2 ^ a ∈ sumPrimeAndTwoPows (k + 1) := by
+  obtain ⟨p, pows, hp, hcard, rfl⟩ := hn
+  refine ⟨p, a ::ₘ pows, hp, ?_, ?_⟩
+  · rw [Multiset.card_cons]; omega
+  · simp only [Multiset.map_cons, Multiset.sum_cons]; ring
+
+/-- A prime plus a single power of two lies in `sumPrimeAndTwoPows 1`. -/
+theorem prime_add_pow_mem {p : ℕ} (hp : p.Prime) (a : ℕ) :
+    p + 2 ^ a ∈ sumPrimeAndTwoPows 1 :=
+  ⟨p, {a}, hp, by simp, by simp⟩
+
+/-! ## The two smallest cases, exactly -/
+
+/-- `sumPrimeAndTwoPows 0` is precisely the set of primes: with `≤ 0` powers of two the
+multiset of exponents is empty, so `n` must equal its prime part. -/
+theorem mem_zero_iff {n : ℕ} : n ∈ sumPrimeAndTwoPows 0 ↔ n.Prime := by
+  constructor
+  · rintro ⟨p, pows, hp, hcard, rfl⟩
+    rw [Nat.le_zero, Multiset.card_eq_zero] at hcard
+    subst hcard
+    simpa using hp
+  · intro hp; exact prime_mem hp 0
+
+/-- `n` uses at most one power of two exactly when `n` is prime (zero powers) or `n = p + 2^a`
+for a prime `p` and exponent `a` (one power). -/
+theorem mem_one_iff {n : ℕ} :
+    n ∈ sumPrimeAndTwoPows 1 ↔ n.Prime ∨ ∃ p a, p.Prime ∧ n = p + 2 ^ a := by
+  constructor
+  · rintro ⟨p, pows, hp, hcard, rfl⟩
+    have hc : pows.card = 0 ∨ pows.card = 1 := by omega
+    rcases hc with h0 | h1
+    · rw [Multiset.card_eq_zero] at h0; subst h0
+      left; simpa using hp
+    · rw [Multiset.card_eq_one] at h1; obtain ⟨a, ha⟩ := h1; subst ha
+      right; exact ⟨p, a, hp, by simp⟩
+  · rintro (hp | ⟨p, a, hp, rfl⟩)
+    · exact prime_mem hp 1
+    · exact prime_add_pow_mem hp a
+
+/-! ## Monotonicity in `k` -/
+
+/-- The family `sumPrimeAndTwoPows` is increasing in the budget `k`: allowing more powers of
+two can only enlarge the representable set. -/
+theorem mem_mono {k k' : ℕ} (h : k ≤ k') :
+    sumPrimeAndTwoPows k ⊆ sumPrimeAndTwoPows k' := by
+  rintro n ⟨p, pows, hp, hcard, rfl⟩
+  exact ⟨p, pows, hp, hcard.trans h, rfl⟩
+
+/-- Consecutive inclusion, the special case of `mem_mono`. -/
+theorem subset_succ (k : ℕ) : sumPrimeAndTwoPows k ⊆ sumPrimeAndTwoPows (k + 1) :=
+  mem_mono (Nat.le_succ k)
+
+/-! ## Infinitude -/
+
+/-- Every `sumPrimeAndTwoPows k` is infinite: it already contains all (infinitely many)
+primes. -/
+theorem infinite (k : ℕ) : (sumPrimeAndTwoPows k).Infinite := by
+  have hsub : {p : ℕ | p.Prime} ⊆ sumPrimeAndTwoPows k := fun p hp => prime_mem hp k
+  exact Nat.infinite_setOf_prime.mono hsub
+
+/-! ## The union over all budgets, and the conjecture -/
+
+/-- The integers representable as a prime plus finitely many powers of two, for *some* finite
+budget `k`. -/
+def eventuallyRepresentable : Set ℕ := ⋃ k, sumPrimeAndTwoPows k
+
+/-- Membership in the union unfolds to "some finite `k` works". -/
+theorem mem_iUnion_iff {n : ℕ} :
+    n ∈ eventuallyRepresentable ↔ ∃ k, n ∈ sumPrimeAndTwoPows k := by
+  simp [eventuallyRepresentable]
+
+/-- Each level embeds into the union. -/
+theorem subset_eventuallyRepresentable (k : ℕ) :
+    sumPrimeAndTwoPows k ⊆ eventuallyRepresentable :=
+  Set.subset_iUnion _ k
+
+/-- **Erdős–Graham conjecture (open), stated in terms of the base definition.**
+No finite `k` makes every integer `> 1` a prime plus at most `k` powers of two: for each `k`
+there is an integer `n > 1` outside `sumPrimeAndTwoPows k`.  This is *not* proved here (it is
+open); it is recorded as a proposition so downstream files can refer to it. -/
+def erdosGraham : Prop :=
+  ∀ k : ℕ, ∃ n : ℕ, 1 < n ∧ n ∉ sumPrimeAndTwoPows k
+
+#check @prime_mem
+#check @mem_zero_iff
+#check @mem_one_iff
+#check @infinite
+
+end Erdos10Incomplete01

--- a/src/data/proofs/erdos-10-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-10-incomplete-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header-erdos10inc01",
+    "proofId": "erdos-10-incomplete-01",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "The representation set at the heart of Erdős #10",
+    "content": "Erdős Problem #10 asks for a finite k making every large integer a prime plus at most k powers of 2; Erdős and Graham conjectured no such k exists. Every classical result on the problem (Romanoff's k=1 density, Gallagher's k(ε), Crocker's failure of k=2, Granville–Soundararajan's k=3 conjecture) is really a statement about a single object: the set of integers representable with at most k powers of 2. The parent problem file introduces this set but proves nothing about it. This file supplies its elementary order- and membership-structure with no axioms and no sorries, and points to the sibling covering-congruence file for the deeper non-representability results.",
+    "mathContext": "The object of study is $S_k = \\{\\,n : \\exists p\\ (\\text{pows}),\\ p\\text{ prime},\\ |\\text{pows}|\\le k,\\ n = p + \\sum_{a\\in\\text{pows}} 2^a\\,\\}$; the Erdős–Graham conjecture is $\\forall k,\\ \\exists n>1,\\ n\\notin S_k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Erdős problems", "powers of two", "additive number theory", "representation functions", "covering congruences"],
+    "prerequisites": ["prime numbers", "powers of two"]
+  },
+  {
+    "id": "ann-definition-erdos10inc01",
+    "proofId": "erdos-10-incomplete-01",
+    "range": { "startLine": 49, "endLine": 52 },
+    "type": "definition",
+    "title": "sumPrimeAndTwoPows k",
+    "content": "The set of natural numbers expressible as a prime plus at most k powers of 2. The powers-of-two component is a multiset of exponents `pows` with `pows.card ≤ k`, and the value is `p + (pows.map (2^·)).sum`. Encoding the exponents as a multiset (not a set) is deliberate: it allows repeated powers such as 2^3 + 2^3 to be counted with multiplicity, matching the standard 'at most k powers of 2' reading. This definition is copied verbatim from the parent problem file so the entry is self-contained.",
+    "mathContext": "$\\mathrm{sumPrimeAndTwoPows}(k) = \\{\\, n : \\exists p\\ (\\text{pows}:\\text{Multiset }\\mathbb N),\\ p\\text{ prime} \\land |\\text{pows}| \\le k \\land n = p + \\sum_{a\\in\\text{pows}} 2^a \\,\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["multiset", "Multiset.card", "set-builder", "powers of two"],
+    "prerequisites": ["multisets", "prime numbers"]
+  },
+  {
+    "id": "ann-membership-erdos10inc01",
+    "proofId": "erdos-10-incomplete-01",
+    "range": { "startLine": 53, "endLine": 71 },
+    "type": "tactic",
+    "title": "Membership basics: primes and adjoining powers",
+    "content": "`prime_mem`: every prime is a member of every level, witnessed by the empty exponent multiset (0), whose mapped sum is 0. `add_pow_mem`: if n ∈ level k then n + 2^a ∈ level k+1 — cons the new exponent a onto the multiset (`a ::ₘ pows`), so the cardinality rises by one (Multiset.card_cons) and the sum gains 2^a (Multiset.map_cons, Multiset.sum_cons; closed by ring). `prime_add_pow_mem`: the singleton {a} witnesses p + 2^a ∈ level 1. These three lemmas are the constructors for the family.",
+    "mathContext": "$p$ prime $\\Rightarrow p = p + \\sum_{\\varnothing} \\in S_k$; $n\\in S_k \\Rightarrow n+2^a\\in S_{k+1}$ (cons on the exponent multiset); $p$ prime $\\Rightarrow p+2^a\\in S_1$ (singleton).",
+    "significance": "supporting",
+    "relatedConcepts": ["Multiset.card_cons", "Multiset.sum_cons", "Multiset.map_cons", "existential witness"],
+    "prerequisites": ["multiset operations", "existential introduction"]
+  },
+  {
+    "id": "ann-smallest-cases-erdos10inc01",
+    "proofId": "erdos-10-incomplete-01",
+    "range": { "startLine": 73, "endLine": 99 },
+    "type": "insight",
+    "title": "The two smallest budgets, characterized exactly",
+    "content": "`mem_zero_iff` shows sumPrimeAndTwoPows 0 is *precisely* the primes: `pows.card ≤ 0` forces `pows.card = 0`, hence (Multiset.card_eq_zero) the empty multiset, whose sum is 0, so n equals its prime part. `mem_one_iff` shows n uses at most one power of two iff n is prime or n = p + 2^a: from `pows.card ≤ 1`, omega splits into card = 0 (empty ⇒ n prime) and card = 1, where Multiset.card_eq_one produces a singleton {a} and n = p + 2^a. The reverse direction reuses prime_mem and prime_add_pow_mem. The clean dichotomy is exactly what the multiset-cardinality encoding buys.",
+    "mathContext": "$S_0 = \\{p:p\\text{ prime}\\}$ and $n\\in S_1 \\iff n\\text{ prime} \\lor \\exists p\\,a,\\ p\\text{ prime}\\land n=p+2^a$; the proof is a case split on $|\\text{pows}|\\in\\{0,1\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Multiset.card_eq_zero", "Multiset.card_eq_one", "case analysis", "omega"],
+    "prerequisites": ["multiset cardinality", "Nat.le_zero"]
+  },
+  {
+    "id": "ann-monotonicity-erdos10inc01",
+    "proofId": "erdos-10-incomplete-01",
+    "range": { "startLine": 101, "endLine": 112 },
+    "type": "tactic",
+    "title": "Monotonicity of the family in k",
+    "content": "`mem_mono`: if k ≤ k′ then sumPrimeAndTwoPows k ⊆ sumPrimeAndTwoPows k′. The witness (prime p, exponent multiset pows) is kept unchanged; only the cardinality bound is relaxed via `hcard.trans h`. `subset_succ` is the consecutive special case S_k ⊆ S_{k+1}. Thus the representable sets form an increasing tower in the power budget.",
+    "mathContext": "$k \\le k' \\Rightarrow S_k \\subseteq S_{k'}$: a representation with $\\le k$ powers is a fortiori one with $\\le k'$ powers.",
+    "significance": "supporting",
+    "relatedConcepts": ["set inclusion", "monotone family", "le_trans"],
+    "prerequisites": ["set inclusion", "transitivity of ≤"]
+  },
+  {
+    "id": "ann-infinitude-erdos10inc01",
+    "proofId": "erdos-10-incomplete-01",
+    "range": { "startLine": 114, "endLine": 120 },
+    "type": "tactic",
+    "title": "Every level is infinite",
+    "content": "`infinite`: each sumPrimeAndTwoPows k is infinite. The proof embeds the set of primes into the level via prime_mem and invokes Nat.infinite_setOf_prime with Set.Infinite.mono. So emptiness is never the issue for Erdős #10 — the substantive question is whether the *complement* of some level stays nonempty, which is the Erdős–Graham conjecture below.",
+    "mathContext": "$\\{p:p\\text{ prime}\\}\\subseteq S_k$ and $\\{p:p\\text{ prime}\\}$ is infinite (Nat.infinite_setOf_prime), so $S_k$ is infinite.",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.Infinite", "Nat.infinite_setOf_prime", "Set.Infinite.mono"],
+    "prerequisites": ["infinitude of primes", "infinite sets"]
+  },
+  {
+    "id": "ann-union-conjecture-erdos10inc01",
+    "proofId": "erdos-10-incomplete-01",
+    "range": { "startLine": 122, "endLine": 149 },
+    "type": "concept",
+    "title": "The union over all budgets, and the open conjecture",
+    "content": "`eventuallyRepresentable := ⋃ k, sumPrimeAndTwoPows k` collects integers representable with *some* finite budget. `mem_iUnion_iff` unfolds membership to 'there exists a k that works', and `subset_eventuallyRepresentable` embeds each level. `erdosGraham` records the open Erdős–Graham conjecture — ∀ k, ∃ n > 1 with n ∉ sumPrimeAndTwoPows k — as a Prop; it is deliberately NOT proved (it is open). Stated this way, the conjecture is precisely that the complements of the levels never all vanish.",
+    "mathContext": "$\\bigcup_k S_k$ is the eventually-representable set; Erdős–Graham: $\\forall k,\\ \\exists n>1,\\ n\\notin S_k$, equivalently no finite budget covers all $n>1$.",
+    "significance": "key",
+    "relatedConcepts": ["indexed union", "Set.subset_iUnion", "open conjecture", "Erdős–Graham"],
+    "prerequisites": ["indexed unions", "logical quantifiers"]
+  }
+]

--- a/src/data/proofs/erdos-10-incomplete-01/index.ts
+++ b/src/data/proofs/erdos-10-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos10Incomplete01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos10Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos10Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos10Incomplete01Data: ProofData = {
+  proof: erdos10Incomplete01Proof,
+  annotations: erdos10Incomplete01Annotations,
+}

--- a/src/data/proofs/erdos-10-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-10-incomplete-01/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "erdos-10-incomplete-01",
+  "title": "Foundations for the Representation Set of Erdős #10 (prime + ≤ k powers of 2)",
+  "slug": "erdos-10-incomplete-01",
+  "description": "An axiom-free foundational theory of the central object of Erdős Problem #10: the set sumPrimeAndTwoPows k of integers expressible as a prime plus at most k powers of 2. The parent problem file introduces this set but proves nothing about it; here its order- and membership-structure is pinned down completely. The two smallest budgets are characterized exactly — sumPrimeAndTwoPows 0 is precisely the primes (mem_zero_iff), and n uses at most one power of two iff n is prime or n = p + 2^a (mem_one_iff) — together with monotonicity in k, the power-adjunction building lemmas, infinitude of every level, and the union over all budgets in whose terms the open Erdős–Graham conjecture is stated. Fully machine-checked: 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://erdosproblems.com/10",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos10Incomplete01.lean",
+    "tags": [
+      "number-theory",
+      "erdos",
+      "primes",
+      "additive-combinatorics",
+      "powers-of-2",
+      "multiset",
+      "representation-functions"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 150,
+    "assumptions": "None. Fully machine-checked: 0 axiom declarations, 0 sorries, no native_decide. All results depend only on the standard foundational axioms (propext, Classical.choice, Quot.sound), confirmed by #print axioms. The open Erdős–Graham conjecture is recorded as a Prop (erdosGraham) and is NOT asserted.",
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #10 asks whether some finite k makes every sufficiently large integer a prime plus at most k powers of 2; Erdős and Graham conjectured no such k exists. Progress splits by k: Romanoff (1934) showed a positive proportion of integers are already a prime plus a single power of 2 (k=1); Gallagher (1975) showed the representable set has lower density ≥ 1−ε for k=k(ε); Granville–Soundararajan (1998) conjectured k=3 suffices for odd integers; Crocker (1971) showed k=2 is insufficient. All of this is phrased in terms of one object — the set of integers representable with at most k powers of 2 — which the parent problem file defines but leaves unstudied.",
+    "problemStatement": "Supply the elementary structural theory of sumPrimeAndTwoPows k = { n | ∃ p (pows : Multiset ℕ), p.Prime ∧ pows.card ≤ k ∧ n = p + (pows.map (2^·)).sum }: identify the smallest cases exactly, show the family is increasing in k, that each level is infinite, and package the open conjecture in these terms.",
+    "text": "Provides the axiom-free foundations for the representation set at the heart of Erdős #10. Characterizes the two smallest budgets exactly (k=0 is the primes; k=1 is 'prime or prime + one power of 2'), proves monotonicity in the power budget k and the power-adjunction lemmas that build members, shows every level is infinite (it contains all primes), and forms the union over all k in whose complement the Erdős–Graham conjecture lives.",
+    "proofStrategy": "The multiset-of-exponents encoding makes the small cases a cardinality analysis. For k=0, pows.card ≤ 0 forces pows = 0 (Multiset.card_eq_zero), so n equals its prime part. For k=1, pows.card ≤ 1 splits into card = 0 (prime) and card = 1 (Multiset.card_eq_one gives a singleton {a}, so n = p + 2^a). Membership building uses the empty multiset (prime_mem), a singleton (prime_add_pow_mem), and cons (add_pow_mem, via Multiset.card_cons / map_cons / sum_cons). Monotonicity keeps the same witness and relaxes the cardinality bound (hcard.trans h). Infinitude embeds the (infinite) set of primes via prime_mem and Nat.infinite_setOf_prime. The open conjecture is a Prop, not a theorem.",
+    "keyInsights": [
+      "**Exact smallest case**: sumPrimeAndTwoPows 0 is *exactly* the primes — the k=0 layer adds nothing to the prime part (mem_zero_iff).",
+      "**k=1 dichotomy**: 'at most one power of 2' means either zero powers (n prime) or one power (n = p + 2^a); the multiset cardinality bound is what forces this clean split (mem_one_iff).",
+      "**Multiset encoding**: recording exponents as a multiset (not a set) lets repeated powers such as 2^3 + 2^3 count, and turns the small-k analysis into Multiset.card_eq_zero / card_eq_one lemmas.",
+      "**Monotone tower**: allowing more powers only enlarges the set (mem_mono, subset_succ), so the representable integers form an increasing chain whose union is eventuallyRepresentable.",
+      "**Infinitude for free**: each level already contains every prime, so is infinite — the interesting question is never emptiness but whether the *complement* stays nonempty for all k, which is the Erdős–Graham conjecture."
+    ],
+    "prerequisites": [
+      "Prime numbers and divisibility",
+      "Multisets and their cardinality (Multiset.card)",
+      "Powers of two",
+      "Asymptotic/representation functions in additive number theory",
+      "Set inclusion and indexed unions"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Header and Overview",
+      "summary": "Frames Erdős #10 and the object of study: the set of integers expressible as a prime plus at most k powers of 2, encoded with a multiset of exponents. Lists the results supplied here (exact k=0 and k=1 cases, monotonicity, infinitude, the union and the conjecture) and points to the sibling covering-obstruction file for the deeper non-representability results.",
+      "startLine": 1,
+      "endLine": 48,
+      "mathContext": "sumPrimeAndTwoPows k collects n = p + Σ 2^(a_i) with p prime and at most k exponents a_i; the Erdős–Graham conjecture asserts no finite k covers all n > 1."
+    },
+    {
+      "id": "definition",
+      "title": "The representation set",
+      "summary": "`sumPrimeAndTwoPows k` is defined exactly as in the parent problem file: n is a member iff n = p + (pows.map (2^·)).sum for some prime p and some multiset of exponents pows with pows.card ≤ k. The multiset (rather than set) encoding permits repeated powers of two.",
+      "startLine": 49,
+      "endLine": 52,
+      "mathContext": "$\\mathrm{sumPrimeAndTwoPows}(k) = \\{\\, n : \\exists p\\ (\\text{pows}:\\text{Multiset }\\mathbb N),\\ p\\text{ prime},\\ |\\text{pows}|\\le k,\\ n = p + \\textstyle\\sum_{a\\in\\text{pows}} 2^a \\,\\}$."
+    },
+    {
+      "id": "membership-basics",
+      "title": "Membership basics",
+      "summary": "`prime_mem`: every prime lies in every level (take zero powers). `add_pow_mem`: adjoining a fresh power 2^a to a member of level k gives a member of level k+1 (cons on the exponent multiset; Multiset.card_cons/map_cons/sum_cons). `prime_add_pow_mem`: a prime plus one power of two lies in level 1.",
+      "startLine": 53,
+      "endLine": 71,
+      "mathContext": "$p$ prime $\\Rightarrow p \\in S_k$; $n \\in S_k \\Rightarrow n + 2^a \\in S_{k+1}$; $p$ prime $\\Rightarrow p + 2^a \\in S_1$."
+    },
+    {
+      "id": "smallest-cases",
+      "title": "The two smallest cases, exactly",
+      "summary": "`mem_zero_iff`: sumPrimeAndTwoPows 0 = the primes — card ≤ 0 forces the exponent multiset empty, so n equals its prime part. `mem_one_iff`: n ∈ sumPrimeAndTwoPows 1 iff n is prime or n = p + 2^a for a prime p — card ≤ 1 splits into the empty (Multiset.card_eq_zero) and singleton (Multiset.card_eq_one) cases.",
+      "startLine": 73,
+      "endLine": 99,
+      "mathContext": "$S_0 = \\{p : p\\text{ prime}\\}$; $n \\in S_1 \\iff n\\text{ prime} \\lor \\exists p\\ a,\\ p\\text{ prime} \\land n = p + 2^a$."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Monotonicity in k",
+      "summary": "`mem_mono`: k ≤ k′ ⟹ sumPrimeAndTwoPows k ⊆ sumPrimeAndTwoPows k′ (same witness, relax the cardinality bound). `subset_succ`: the consecutive inclusion S_k ⊆ S_{k+1}.",
+      "startLine": 101,
+      "endLine": 112,
+      "mathContext": "The family $k \\mapsto S_k$ is monotone increasing under set inclusion."
+    },
+    {
+      "id": "infinitude",
+      "title": "Infinitude of each level",
+      "summary": "`infinite`: every sumPrimeAndTwoPows k is infinite, since it already contains the infinitely many primes (prime_mem together with Nat.infinite_setOf_prime).",
+      "startLine": 114,
+      "endLine": 120,
+      "mathContext": "$\\{p : p\\text{ prime}\\} \\subseteq S_k$ and the primes are infinite, so $S_k$ is infinite for every $k$."
+    },
+    {
+      "id": "union-and-conjecture",
+      "title": "The union over all budgets, and the conjecture",
+      "summary": "`eventuallyRepresentable := ⋃ k, sumPrimeAndTwoPows k`, with `mem_iUnion_iff` unfolding membership to 'some finite k works' and `subset_eventuallyRepresentable` embedding each level. `erdosGraham` records, as a Prop (not a theorem), the open conjecture that no finite k represents every n > 1.",
+      "startLine": 122,
+      "endLine": 149,
+      "mathContext": "$\\bigcup_k S_k$ is the set of integers representable with *some* finite budget; Erdős–Graham: $\\forall k,\\ \\exists n>1,\\ n \\notin S_k$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file makes the defining object of Erdős Problem #10 — the set of integers expressible as a prime plus at most k powers of 2 — usable, with zero axioms and zero sorries. It characterizes the two smallest budgets exactly (k=0 is precisely the primes; k=1 is 'prime, or prime plus a single power of two'), establishes monotonicity of the family in k and the power-adjunction lemmas that construct members, shows every level is infinite because it already contains all primes, and assembles the union over all budgets in whose complement the open Erdős–Graham conjecture is phrased (recorded here as a proposition, not asserted).",
+    "implications": "These foundations turn the parent file's bare definition into a workable theory: the exact k=0 and k=1 descriptions let downstream non-representability arguments (e.g. the sibling covering-congruence obstruction) be stated directly against sumPrimeAndTwoPows rather than against an ad hoc 'n = 2^a + p' predicate, and monotonicity reduces claims about small k to claims about larger k. The multiset-cardinality technique used for k=0,1 extends verbatim to any fixed k, giving a template for the finite-case membership decisions that underlie all quantitative work on the problem.",
+    "openQuestions": [
+      "Prove the exact characterization for k=2 (mem_two_iff): n ∈ sumPrimeAndTwoPows 2 iff n is prime, or n = p + 2^a, or n = p + 2^a + 2^b, by the same Multiset.card ≤ 2 case analysis.",
+      "Bridge to the covering obstruction: restate the sibling file's prime_forced_small directly in terms of membership in sumPrimeAndTwoPows 1, yielding an explicit infinite family outside level 1.",
+      "Quantify infinitude: strengthen `infinite` to a positive lower-density statement for sumPrimeAndTwoPows 1 (Romanoff's theorem), connecting these foundations to the density results of Gallagher and Romanoff."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-10-oq-01-incomplete-01",
+      "relationship": "related",
+      "description": "The sibling covering-congruence obstruction works with the raw predicate n = 2^a + p; mem_one_iff here is the base-set restatement of exactly that k=1 form."
+    },
+    {
+      "targetId": "erdos-10",
+      "relationship": "extends",
+      "description": "Erdős Problem #10: supplies the structural theory of the parent file's sumPrimeAndTwoPows definition."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, P.; Graham, R.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "Enseign. Math. Monograph 28",
+      "note": "The conjecture that no finite k makes every large integer a prime plus at most k powers of 2."
+    },
+    {
+      "authors": "Romanoff, N. P.",
+      "title": "Über einige Sätze der additiven Zahlentheorie",
+      "year": "1934",
+      "venue": "Math. Ann. 109:668–678",
+      "note": "A positive proportion of integers are a prime plus a single power of 2 (the k=1 density result)."
+    },
+    {
+      "authors": "Gallagher, P. X.",
+      "title": "Primes and powers of 2",
+      "year": "1975",
+      "venue": "Invent. Math. 29:125–142",
+      "note": "For any ε>0 some finite k makes the representable set have lower density ≥ 1−ε."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Nat.Prime.Basic"
+    ],
+    "namespace": "Erdos10Incomplete01",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "path": "Proofs/Erdos10Incomplete01.lean",
+    "sorries": 0,
+    "definitionCount": 3
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **erdos-10-incomplete-01** — an axiom-free foundational theory of the central object of **Erdős Problem #10** (is every large integer a prime plus at most `k` powers of 2? Erdős–Graham: no finite `k` works).

The parent problem file `Erdos10Problem.lean` *defines* the set `sumPrimeAndTwoPows k` (integers = prime + at most `k` powers of 2, exponents as a multiset) but proves nothing about it. This entry pins down its order- and membership-structure.

## Results (`Proofs/Erdos10Incomplete01.lean`, namespace `Erdos10Incomplete01`)

| lemma | statement |
|---|---|
| `mem_zero_iff` | `sumPrimeAndTwoPows 0` is **exactly** the primes |
| `mem_one_iff` | `n ∈ level 1 ↔ n.Prime ∨ ∃ p a, p.Prime ∧ n = p + 2^a` |
| `prime_mem` | every prime is in every level |
| `prime_add_pow_mem`, `add_pow_mem` | constructors: adjoin a power of 2 |
| `mem_mono`, `subset_succ` | monotone tower in the budget `k` |
| `infinite` | every level is infinite (contains all primes) |
| `eventuallyRepresentable`, `mem_iUnion_iff`, `subset_eventuallyRepresentable` | the union over all `k` |
| `erdosGraham` | the **open** conjecture, recorded as a `Prop` (not asserted) |

The two smallest budgets are characterized exactly via the multiset-cardinality lemmas (`Multiset.card_eq_zero` / `card_eq_one`).

## Verification

- **0 sorries, 0 axiom declarations.** `#print axioms` on every theorem shows only the standard foundational trio (`propext`, `Classical.choice`, `Quot.sound`) — no `sorryAx`, no `Lean.ofReduceBool`.
- Type-checked with `lake env lean` against Mathlib 4.26.0 (warm cache).
- 10 theorems, 3 definitions, 150 lines. `pnpm annotations:build` passes clean for this entry.

Complements the sibling `erdos-10-oq-01-incomplete-01` (covering-congruence obstruction for the raw `n = 2^a + p` form); `mem_one_iff` is the base-set restatement of that k=1 case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)