### PR TITLE
research(cayley-hamilton-minpoly-oq-06-oq-02): minpoly degree = size of largest Jordan block (single-eigenvalue) [VERIFIED, 0-axiom, 8thm/148L]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ06OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ06OQ02.lean
@@ -1,0 +1,148 @@
+import Mathlib
+
+/-
+# OQ-06 → OQ-02: Minimal-polynomial degree = size of the largest Jordan block
+
+The parent entry `CayleyHamiltonMinpolyOQ06` shows conjugation preserves the minimal
+polynomial (similar matrices are minpoly-invariant).  Its open question asks to
+**relate the degree of the minimal polynomial to the size of the largest Jordan
+block**.
+
+Over an algebraically closed field the Jordan normal form of an operator is a direct
+sum of Jordan blocks `J_{s}(λ)`, and the classical theorem states
+
+  `minpoly = ∏_{λ} (X − λ)^{m(λ)}`,   `m(λ) = size of the largest Jordan block at λ`,
+
+so `deg (minpoly) = ∑_λ m(λ)`.  Mathlib (v4.26.0) has **no** Jordan normal form and no
+`jordanBlock` matrix, so the full multi-eigenvalue statement is out of reach without
+building that theory (>1000 lines).  What *is* both provable and coordinate-free is the
+**single-eigenvalue heart** of the statement, which is exactly the content that ties the
+minimal polynomial to a *single* Jordan block size:
+
+> If `x − λ` is nilpotent with nilpotency class `m`, then
+> **`minpoly K x = (X − C λ)^m`**, hence **`deg (minpoly K x) = m`**.
+
+For a single Jordan block `J_s(λ)` the difference `J_s(λ) − λ·I` is the nilpotent shift
+of nilpotency class `s`, so `m = s`: the degree of the minimal polynomial is *exactly*
+the block size.  Taking `λ = 0` gives the pure-nilpotent statement
+`minpoly K x = X^{nilpotencyClass x}`, itself absent from Mathlib.
+
+## Proof architecture (no Jordan form, no eigenspace decomposition)
+
+Let `y = x − λ`, nilpotent with `y^m = 0` and `m = nilpotencyClass y` minimal.
+
+1. `(X − C λ)^m` annihilates `x` (`aeval x` of it is `y^m = 0`), so `x` is integral and
+   `minpoly K x ∣ (X − C λ)^m`.
+2. `X − C λ` is prime in `K[X]`, so a monic divisor of its `m`-th power is `(X − C λ)^d`
+   for a unique `d ≤ m` (`dvd_prime_pow` + `eq_of_monic_of_associated`).
+3. `aeval x (minpoly K x) = 0` forces `y^d = 0`, and minimality of the nilpotency class
+   (`Nat.sInf_le`) gives `m ≤ d`.  Hence `d = m`.
+
+No induction, no coordinates: the whole result descends from `dvd_prime_pow` and the
+`sInf`-minimality of the nilpotency class.  The development is uniform in `(K, B)`, so the
+matrix case (`B = Matrix n n K`) is a one-line specialisation.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+open Polynomial
+
+namespace CayleyHamiltonMinpolyOQ06OQ02
+
+variable {K B : Type*} [Field K] [Ring B] [Algebra K B]
+
+/-! ## Section I: Nilpotent generalized eigenvectors are integral -/
+
+/-- A nilpotent element of a `K`-algebra is integral: `X ^ m` (with `x ^ m = 0`) is a
+monic annihilating polynomial. -/
+theorem isIntegral_of_isNilpotent {x : B} (hx : IsNilpotent x) : IsIntegral K x := by
+  obtain ⟨m, hm⟩ := hx
+  refine ⟨X ^ m, monic_X_pow m, ?_⟩
+  show (aeval x) (X ^ m) = 0
+  rw [map_pow, aeval_X]
+  exact hm
+
+/-! ## Section II: The single-eigenvalue minimal polynomial -/
+
+/-- **Minimal polynomial of a single-eigenvalue operator.**  If `x − λ` is nilpotent
+with nilpotency class `m`, then `minpoly K x = (X − C λ) ^ m`.  In Jordan-normal-form
+language `m` is the size of the largest Jordan block of `x` at the eigenvalue `λ`; this
+identifies the minimal polynomial (hence its degree) with that block size. -/
+theorem minpoly_eq_X_sub_C_pow (x : B) (l : K)
+    (hx : IsNilpotent (x - algebraMap K B l)) :
+    minpoly K x = (X - C l) ^ (nilpotencyClass (x - algebraMap K B l)) := by
+  set y := x - algebraMap K B l with hy
+  have hym : y ^ (nilpotencyClass y) = 0 := pow_nilpotencyClass hx
+  -- `(X − C l)^m` annihilates `x`.
+  have haeval : (aeval x) ((X - C l) ^ (nilpotencyClass y)) = 0 := by
+    rw [map_pow, map_sub, aeval_X, aeval_C]
+    exact hym
+  -- `x` is integral, and `minpoly K x ∣ (X − C l)^m`.
+  have hInt : IsIntegral K x :=
+    ⟨(X - C l) ^ (nilpotencyClass y), (monic_X_sub_C l).pow _, haeval⟩
+  have hdvd : minpoly K x ∣ (X - C l) ^ (nilpotencyClass y) := minpoly.dvd K x haeval
+  -- A monic divisor of `(X − C l)^m` is `(X − C l)^d` for some `d ≤ m`.
+  obtain ⟨d, hd_le, hassoc⟩ :=
+    (dvd_prime_pow (prime_X_sub_C l) (nilpotencyClass y)).mp hdvd
+  have hxd : minpoly K x = (X - C l) ^ d :=
+    eq_of_monic_of_associated (minpoly.monic hInt) ((monic_X_sub_C l).pow d) hassoc
+  -- `minpoly` annihilates `x`, so `y^d = 0`; minimality of the class gives `m ≤ d`.
+  have haevald : y ^ d = 0 := by
+    have h0 := minpoly.aeval K x
+    rw [hxd, map_pow, map_sub, aeval_X, aeval_C] at h0
+    exact h0
+  have hmd : nilpotencyClass y ≤ d := Nat.sInf_le haevald
+  rw [hxd, le_antisymm hd_le hmd]
+
+/-- **Degree form.**  `deg (minpoly K x)` equals the nilpotency class of `x − λ`, i.e. the
+size of the largest Jordan block of `x` at `λ`. -/
+theorem natDegree_minpoly_eq (x : B) (l : K)
+    (hx : IsNilpotent (x - algebraMap K B l)) :
+    (minpoly K x).natDegree = nilpotencyClass (x - algebraMap K B l) := by
+  rw [minpoly_eq_X_sub_C_pow x l hx, natDegree_pow, natDegree_X_sub_C, mul_one]
+
+/-! ## Section III: The pure-nilpotent case (`λ = 0`) -/
+
+/-- **Pure nilpotent operator.**  `minpoly K x = X ^ (nilpotencyClass x)`.  (Absent from
+Mathlib.)  This is the eigenvalue-`0` Jordan block: the minimal polynomial is `X` raised to
+the size of the largest block. -/
+theorem minpoly_eq_X_pow (x : B) (hx : IsNilpotent x) :
+    minpoly K x = X ^ (nilpotencyClass x) := by
+  have h := minpoly_eq_X_sub_C_pow x (0 : K) (by simpa using hx)
+  simpa using h
+
+/-- Degree form of the pure-nilpotent case: `deg (minpoly K x) = nilpotencyClass x`. -/
+theorem natDegree_minpoly_eq_nilpotencyClass (x : B) (hx : IsNilpotent x) :
+    (minpoly K x).natDegree = nilpotencyClass x := by
+  rw [minpoly_eq_X_pow x hx, natDegree_X_pow]
+
+/-! ## Section IV: Matrix specialisation -/
+
+section Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **Nilpotent matrix.**  For a nilpotent matrix `M` over a field, `minpoly K M`
+is `X` to the nilpotency class of `M`. -/
+theorem minpoly_nilpotent_matrix (M : Matrix n n K) (hM : IsNilpotent M) :
+    minpoly K M = X ^ (nilpotencyClass M) :=
+  minpoly_eq_X_pow M hM
+
+/-- **Nilpotent matrix, degree form.**  The degree of the minimal polynomial of a
+nilpotent matrix equals its nilpotency class — equivalently, the size of its largest
+Jordan block (the single-eigenvalue content of the classical Jordan theorem, which
+Mathlib cannot yet state in full). -/
+theorem natDegree_minpoly_nilpotent_matrix (M : Matrix n n K) (hM : IsNilpotent M) :
+    (minpoly K M).natDegree = nilpotencyClass M :=
+  natDegree_minpoly_eq_nilpotencyClass M hM
+
+/-- **Scalar-plus-nilpotent matrix.**  If `M − λ·I` is nilpotent (single eigenvalue `λ`),
+the minimal polynomial is `(X − λ)` to the size of the largest Jordan block. -/
+theorem natDegree_minpoly_single_eigenvalue_matrix (M : Matrix n n K) (l : K)
+    (hM : IsNilpotent (M - algebraMap K (Matrix n n K) l)) :
+    (minpoly K M).natDegree = nilpotencyClass (M - algebraMap K (Matrix n n K) l) :=
+  natDegree_minpoly_eq M l hM
+
+end Matrix
+
+end CayleyHamiltonMinpolyOQ06OQ02

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-02/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "chm-oq0602-ann-header",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "concept",
+    "title": "Minimal polynomial vs. largest Jordan block, and what Mathlib is missing",
+    "content": "The module docstring frames the classical Jordan-form corollary: over an algebraically closed field an operator's minimal polynomial is $\\prod_\\lambda (X-\\lambda)^{m(\\lambda)}$, where $m(\\lambda)$ is the size of the LARGEST Jordan block at the eigenvalue $\\lambda$; so $\\deg(\\text{minpoly})$ is the sum of the largest block sizes. Mathlib v4.26.0 has no Jordan normal form and no `jordanBlock` matrix, so the multi-eigenvalue statement is out of reach. What is provable coordinate-free is the single-eigenvalue heart: if $x-\\lambda$ is nilpotent of nilpotency class $m$ then $\\text{minpoly}\\,K\\,x = (X - C\\,\\lambda)^m$, hence $\\deg = m$ — exactly the block size at $\\lambda$.",
+    "mathContext": "$\\text{minpoly} = \\prod_\\lambda (X-\\lambda)^{m(\\lambda)}$, $\\ m(\\lambda) = $ largest Jordan block size at $\\lambda$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Jordan normal form",
+      "minimal polynomial",
+      "nilpotency class",
+      "generalized eigenspace"
+    ],
+    "prerequisites": [
+      "Lean 4",
+      "Mathlib",
+      "minimal polynomial of a matrix"
+    ]
+  },
+  {
+    "id": "chm-oq0602-ann-integral",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-02",
+    "range": {
+      "startLine": 56,
+      "endLine": 63
+    },
+    "type": "technique",
+    "title": "Nilpotent elements are integral",
+    "content": "`isIntegral_of_isNilpotent` observes that a nilpotent $x$ (with $x^m = 0$) is a root of the monic polynomial $X^m$, so it is integral over the base field $K$. Integrality is exactly what makes the minimal polynomial monic — the hypothesis that later lets `eq_of_monic_of_associated` pin the divisor down to an exact power rather than merely up to a unit.",
+    "mathContext": "$x^m = 0 \\implies X^m$ is a monic annihilator $\\implies$ `IsIntegral K x` $\\implies$ $\\text{minpoly}\\,K\\,x$ is monic.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "integral element",
+      "monic polynomial",
+      "nilpotent element"
+    ],
+    "prerequisites": [
+      "integral elements over a field",
+      "monic polynomials"
+    ]
+  },
+  {
+    "id": "chm-oq0602-ann-single-eigenvalue",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-02",
+    "range": {
+      "startLine": 67,
+      "endLine": 102
+    },
+    "type": "insight",
+    "title": "The exponent is squeezed to the nilpotency class from both sides",
+    "content": "`minpoly_eq_X_sub_C_pow` is the core theorem. Set $y = x - \\lambda$, nilpotent with $y^m = 0$ and $m = \\text{nilpotencyClass}\\,y$ minimal. First, $(X - C\\,\\lambda)^m$ annihilates $x$, so $\\text{minpoly}\\,K\\,x \\mid (X - C\\,\\lambda)^m$. Because $X - C\\,\\lambda$ is PRIME in $K[X]$, `dvd_prime_pow` forces the (monic) minimal polynomial to be $(X - C\\,\\lambda)^d$ for a unique $d \\le m$. Finally the minimal polynomial annihilates $x$, giving $y^d = 0$, and the minimality of the nilpotency class ($\\text{nilpotencyClass} = \\inf\\{k : y^k = 0\\}$, via `Nat.sInf_le`) gives $m \\le d$. Hence $d = m$: divisibility bounds the exponent above, minimality bounds it below. No eigenspace decomposition or Jordan form is used — primality alone fixes the SHAPE.",
+    "mathContext": "$\\text{minpoly}\\,K\\,x \\mid (X-C\\lambda)^m \\Rightarrow \\text{minpoly} = (X-C\\lambda)^d,\\ d \\le m$; and $y^d = 0 \\Rightarrow m \\le d$. So $\\text{minpoly}\\,K\\,x = (X-C\\lambda)^m$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "prime power divisors",
+      "nilpotency class",
+      "minimal polynomial degree"
+    ],
+    "prerequisites": [
+      "prime elements in a polynomial ring",
+      "minimal polynomial divides any annihilator",
+      "infimum characterization of nilpotency class"
+    ]
+  },
+  {
+    "id": "chm-oq0602-ann-pure-nilpotent",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-02",
+    "range": {
+      "startLine": 106,
+      "endLine": 117
+    },
+    "type": "concept",
+    "title": "The λ = 0 case: minpoly of a nilpotent operator is X^(nilpotency class)",
+    "content": "Specialising the eigenvalue to $\\lambda = 0$ gives `minpoly_eq_X_pow`: for any nilpotent $x$, $\\text{minpoly}\\,K\\,x = X^{\\text{nilpotencyClass}\\,x}$, and `natDegree_minpoly_eq_nilpotencyClass` reads off $\\deg = \\text{nilpotencyClass}\\,x$. This clean statement about nilpotent operators is itself absent from Mathlib v4.26.0. It is the eigenvalue-0 Jordan block: the minimal polynomial is $X$ raised to the size of the largest block.",
+    "mathContext": "$x$ nilpotent $\\implies \\text{minpoly}\\,K\\,x = X^{\\text{nilpotencyClass}\\,x}$, $\\ \\deg = \\text{nilpotencyClass}\\,x$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "nilpotent operator",
+      "nilpotency class",
+      "minimal polynomial"
+    ],
+    "prerequisites": [
+      "nilpotent elements",
+      "the single-eigenvalue theorem above"
+    ]
+  },
+  {
+    "id": "chm-oq0602-ann-matrix",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-02",
+    "range": {
+      "startLine": 125,
+      "endLine": 145
+    },
+    "type": "concept",
+    "title": "Matrix specialisations: block size = nilpotency class",
+    "content": "Because the algebra results assume nothing beyond `[Field K] [Ring B] [Algebra K B]` and no commutativity, the matrix ring $\\mathrm{Matrix}\\,n\\,n\\,K$ is a direct instance. `minpoly_nilpotent_matrix` and `natDegree_minpoly_nilpotent_matrix` give the degree of a nilpotent matrix's minimal polynomial as its nilpotency class; `natDegree_minpoly_single_eigenvalue_matrix` handles $M - \\lambda I$ nilpotent. For a single Jordan block $J_s(\\lambda)$, $J_s(\\lambda) - \\lambda I$ is the nilpotent shift of class $s$, so the degree is exactly $s$ — the block size.",
+    "mathContext": "$M - \\lambda I$ nilpotent of class $m \\implies \\deg(\\text{minpoly}\\,K\\,M) = m = $ Jordan block size at $\\lambda$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "nilpotent matrix",
+      "Jordan block",
+      "matrix minimal polynomial"
+    ],
+    "prerequisites": [
+      "matrices as a K-algebra",
+      "the algebra-level results above"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-02/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-06-oq-02",
+  "title": "Minimal Polynomial Degree = Size of the Largest Jordan Block (Single-Eigenvalue Case)",
+  "slug": "cayley-hamilton-minpoly-oq-06-oq-02",
+  "description": "Relates the degree of the minimal polynomial to the size of the largest Jordan block. The full multi-eigenvalue statement needs Jordan normal form, which Mathlib v4.26.0 lacks; this entry proves its coordinate-free single-eigenvalue heart: if x − λ is nilpotent with nilpotency class m then minpoly K x = (X − C λ)^m, so deg(minpoly K x) = m — exactly the size of the (unique) Jordan block at λ. The λ = 0 case gives minpoly K x = X^(nilpotencyClass x) for any nilpotent x, itself absent from Mathlib.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Minimal_polynomial_(linear_algebra)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ06OQ02.lean",
+    "tags": [
+      "linear-algebra",
+      "abstract-algebra",
+      "minimal-polynomial",
+      "nilpotent",
+      "jordan-normal-form",
+      "nilpotency-class",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "minpoly.dvd",
+        "description": "If a polynomial annihilates an element, the minimal polynomial divides it — used to show minpoly K x ∣ (X − C λ)^m",
+        "module": "Mathlib.FieldTheory.Minpoly.Field"
+      },
+      {
+        "theorem": "dvd_prime_pow",
+        "description": "A divisor of a prime power p^n is associated to p^k for a unique k ≤ n — applied with the prime X − C λ",
+        "module": "Mathlib.Algebra.GroupWithZero.Associated"
+      },
+      {
+        "theorem": "Polynomial.prime_X_sub_C",
+        "description": "X − C r is prime in the polynomial ring over a field, so its power's monic divisors are its own powers",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      },
+      {
+        "theorem": "Polynomial.eq_of_monic_of_associated",
+        "description": "Two monic associates are equal — pins the associated divisor down to (X − C λ)^d exactly",
+        "module": "Mathlib.Algebra.Polynomial.Monic"
+      },
+      {
+        "theorem": "pow_nilpotencyClass",
+        "description": "x ^ (nilpotencyClass x) = 0 for nilpotent x — supplies the annihilating exponent",
+        "module": "Mathlib.RingTheory.Nilpotent.Defs"
+      },
+      {
+        "theorem": "Nat.sInf_le",
+        "description": "sInf S ≤ n for n ∈ S — the minimality of the nilpotency class (nilpotencyClass = sInf {k | x^k = 0}) that forces d = m",
+        "module": "Mathlib.Order.Bounds.Basic"
+      }
+    ],
+    "originalContributions": [
+      "isIntegral_of_isNilpotent: a nilpotent element of a K-algebra is integral, witnessed by the monic annihilator X^m",
+      "minpoly_eq_X_sub_C_pow: the single-eigenvalue minimal-polynomial theorem — if x − λ is nilpotent with nilpotency class m then minpoly K x = (X − C λ)^m, proved uniformly over any K-algebra (no commutativity, no coordinates) via prime-power divisor classification plus sInf-minimality",
+      "minpoly_eq_X_pow: the pure-nilpotent specialisation minpoly K x = X^(nilpotencyClass x), missing from Mathlib v4.26.0",
+      "natDegree_minpoly_eq / natDegree_minpoly_eq_nilpotencyClass: the degree readout deg(minpoly K x) = nilpotency class = size of the largest Jordan block at the relevant eigenvalue",
+      "Matrix specialisations (natDegree_minpoly_nilpotent_matrix, natDegree_minpoly_single_eigenvalue_matrix): the block-size statement for nilpotent and scalar-plus-nilpotent matrices"
+    ],
+    "dateAdded": "2026-07-01",
+    "prerequisites": [
+      "Minimal polynomial of an algebra element / matrix",
+      "Nilpotent elements and the nilpotency class (= smallest k with x^k = 0)",
+      "Prime elements and prime-power divisors in a polynomial ring over a field",
+      "Jordan normal form (conceptual background)"
+    ],
+    "relatedProblems": [
+      {
+        "id": "cayley-hamilton-minpoly-oq-06",
+        "relationship": "Parent: conjugation preserves the minimal polynomial; this answers its open question relating the minpoly degree to the largest Jordan block size"
+      },
+      {
+        "id": "cayley-hamilton-minpoly-oq-06-oq-01",
+        "relationship": "Sibling: the rational-canonical-form readout (minpoly is the largest invariant factor); both compute minimal polynomials of structured operators without full canonical-form machinery"
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 148,
+    "assumptions": "0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound (standard Mathlib foundations). Proves the single-eigenvalue case: if x − λ is nilpotent with nilpotency class m then minpoly = (X − C λ)^m and deg = m. The general multi-eigenvalue statement (minpoly = ∏_λ (X − λ)^{m(λ)} with m(λ) the largest block size at λ) requires Jordan normal form, which is not in Mathlib v4.26.0; that reduction is left as future work.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Jordan normal form classifies operators over an algebraically closed field up to similarity as a direct sum of Jordan blocks J_s(λ). A classical corollary reads the minimal polynomial off that decomposition: minpoly = ∏_λ (X − λ)^{m(λ)}, where m(λ) is the size of the LARGEST Jordan block for the eigenvalue λ. In particular the degree of the minimal polynomial is the sum of the largest block sizes over the distinct eigenvalues, and for a single eigenvalue it is exactly that block size. This ties an easily computed invariant (the minimal polynomial) to fine structural data (block sizes) that otherwise require the full canonical form.",
+    "problemStatement": "Relate the degree of the minimal polynomial to the size of the largest Jordan block. Because Mathlib v4.26.0 has no Jordan normal form (and no jordanBlock matrix), establish the coordinate-free single-eigenvalue content: for x with x − λ nilpotent of nilpotency class m, show minpoly K x = (X − C λ)^m and hence deg(minpoly K x) = m, the size of the Jordan block at λ.",
+    "text": "If x − λ is nilpotent with nilpotency class m, then minpoly K x = (X − C λ)^m, so deg(minpoly K x) = m. Taking λ = 0 gives minpoly K x = X^(nilpotencyClass x) for any nilpotent x.",
+    "proofStrategy": "Write y = x − λ, nilpotent with y^m = 0 and m = nilpotencyClass y minimal. (1) (X − C λ)^m annihilates x (aeval x sends it to y^m = 0), so x is integral and minpoly K x ∣ (X − C λ)^m. (2) X − C λ is prime in K[X], so by dvd_prime_pow the minimal polynomial — being monic — is (X − C λ)^d for a unique d ≤ m (eq_of_monic_of_associated pins the associate down). (3) minpoly annihilates x, so y^d = 0; the minimality of the nilpotency class (nilpotencyClass = sInf {k | y^k = 0}, so Nat.sInf_le) gives m ≤ d. Hence d = m. The whole argument is uniform in the K-algebra, so nilpotent and scalar-plus-nilpotent matrices are one-line specialisations.",
+    "keyInsights": [
+      "The minimal polynomial of a single-eigenvalue operator is forced to be a pure prime power (X − C λ)^d because X − C λ is prime and minpoly is monic — no eigenspace or Jordan-form machinery is needed to see the SHAPE of the minimal polynomial",
+      "The exponent is pinned to the nilpotency class from both sides: divisibility gives d ≤ m, and minimality of the class (sInf) gives m ≤ d",
+      "The result needs no commutativity of the ambient algebra and no coordinates, so it applies verbatim to matrices (B = Matrix n n K) as a specialisation rather than a re-proof",
+      "The λ = 0 instance, minpoly = X^(nilpotencyClass), is a clean statement about nilpotent operators that Mathlib v4.26.0 does not provide",
+      "For a single Jordan block J_s(λ), J_s(λ) − λ·I is the nilpotent shift of class s, so m = s: this is genuinely the 'degree of minpoly = largest block size' theorem, restricted to one eigenvalue — the multi-eigenvalue sum needs the (absent) Jordan/primary decomposition"
+    ],
+    "prerequisites": [
+      "Minimal polynomial of an algebra element / matrix",
+      "Nilpotent elements and the nilpotency class",
+      "Prime-power divisors in a polynomial ring over a field",
+      "Jordan normal form (conceptual background)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Documentation and Setup",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Header explaining the Jordan-block/minimal-polynomial correspondence, why the full multi-eigenvalue statement is out of reach (no Jordan normal form in Mathlib v4.26.0), and the single-eigenvalue content proved here. Sets up a field K and a K-algebra B.",
+      "mathContext": "Over an algebraically closed field minpoly = ∏_λ (X − λ)^{m(λ)} with m(λ) the largest Jordan block size at λ; this file proves the single-eigenvalue heart coordinate-free."
+    },
+    {
+      "id": "integral",
+      "title": "Nilpotent Elements are Integral",
+      "startLine": 54,
+      "endLine": 63,
+      "summary": "isIntegral_of_isNilpotent: a nilpotent element is annihilated by the monic polynomial X^m (with x^m = 0), hence is integral and has a monic minimal polynomial.",
+      "mathContext": "Integrality is what makes the minimal polynomial monic — the hypothesis that lets eq_of_monic_of_associated pin the divisor down exactly."
+    },
+    {
+      "id": "single-eigenvalue",
+      "title": "The Single-Eigenvalue Minimal Polynomial",
+      "startLine": 65,
+      "endLine": 102,
+      "summary": "minpoly_eq_X_sub_C_pow: if x − λ is nilpotent with class m then minpoly K x = (X − C λ)^m, via prime-power divisor classification plus sInf-minimality. natDegree_minpoly_eq reads off the degree m.",
+      "mathContext": "This is the theorem tying the minimal polynomial (and its degree) to a single Jordan block size, proved without any canonical form."
+    },
+    {
+      "id": "pure-nilpotent",
+      "title": "The Pure-Nilpotent Case (λ = 0)",
+      "startLine": 104,
+      "endLine": 117,
+      "summary": "minpoly_eq_X_pow and natDegree_minpoly_eq_nilpotencyClass: for any nilpotent x, minpoly K x = X^(nilpotencyClass x) and deg(minpoly K x) = nilpotencyClass x.",
+      "mathContext": "The eigenvalue-0 Jordan block: the minimal polynomial is X to the size of the largest block. Missing from Mathlib v4.26.0."
+    },
+    {
+      "id": "matrix",
+      "title": "Matrix Specialisations",
+      "startLine": 119,
+      "endLine": 148,
+      "summary": "minpoly_nilpotent_matrix, natDegree_minpoly_nilpotent_matrix, and natDegree_minpoly_single_eigenvalue_matrix instantiate the K-algebra results at B = Matrix n n K.",
+      "mathContext": "For a nilpotent (resp. scalar-plus-nilpotent) matrix the degree of the minimal polynomial is its nilpotency class — the size of its largest Jordan block."
+    }
+  ],
+  "conclusion": {
+    "summary": "For an operator with a single eigenvalue λ (x − λ nilpotent of nilpotency class m), the minimal polynomial is exactly (X − C λ)^m, so its degree is m — the size of the Jordan block at λ. The λ = 0 case yields minpoly = X^(nilpotencyClass x) for any nilpotent operator, and matrix corollaries give the block-size statement for nilpotent and scalar-plus-nilpotent matrices. All 8 theorems are fully verified with 0 sorries and 0 axioms.",
+    "implications": "This is the coordinate-free single-eigenvalue heart of the classical fact deg(minpoly) = Σ_λ (largest Jordan block size at λ). It shows the SHAPE and exact exponent of the minimal polynomial for one eigenvalue from nothing more than primality of X − C λ and the minimality of the nilpotency class. The general multi-eigenvalue statement requires the Jordan (or primary) decomposition, which — like full Jordan normal form — is not yet available in Mathlib v4.26.0 and remains the principal gap.",
+    "openQuestions": [
+      "Combine with a primary/generalized-eigenspace decomposition to obtain the multi-eigenvalue statement minpoly = ∏_λ (X − λ)^{m(λ)} and deg(minpoly) = Σ_λ m(λ).",
+      "Build a jordanBlock matrix and prove nilpotencyClass (jordanBlock 0 n) = n, making 'size of the largest Jordan block' a literal matrix invariant rather than a nilpotency-class proxy."
+    ]
+  },
+  "status": "verified",
+  "badge": "mathlib",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "CayleyHamiltonMinpolyOQ06OQ02",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ06OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-06",
+      "relationship": "extends",
+      "description": "Parent formalization (conjugation preserves the minimal polynomial); this answers its open question relating the minpoly degree to the largest Jordan block size."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-06-oq-01",
+      "relationship": "related",
+      "description": "Sibling: the rational-canonical-form readout (minpoly = largest invariant factor); both compute minimal polynomials of structured operators without full canonical-form machinery."
+    }
+  ],
+  "references": [
+    {
+      "key": "HJ13",
+      "citation": "Horn, R.A. and Johnson, C.R., Matrix Analysis, 2nd ed., Cambridge University Press (2013), Chapter 3: Canonical forms.",
+      "type": "book"
+    },
+    {
+      "key": "DF04",
+      "citation": "Dummit, D.S. and Foote, R.M., Abstract Algebra, 3rd ed., Wiley (2004), Section 12.3: The Jordan Canonical Form.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry answering **oq-06**'s open question: relate the degree of the minimal polynomial to the size of the largest Jordan block.

Mathlib v4.26.0 has no Jordan normal form (and no `jordanBlock` matrix), so the full multi-eigenvalue statement is out of reach. This entry proves the **coordinate-free single-eigenvalue heart**:

> If `x − λ` is nilpotent with nilpotency class `m`, then `minpoly K x = (X − C λ)^m`, hence `deg(minpoly K x) = m` — exactly the size of the Jordan block at `λ`.

The `λ = 0` case gives `minpoly K x = X^(nilpotencyClass x)` for any nilpotent `x`, itself absent from Mathlib. Matrix specialisations follow as one-line instantiations.

## Proof architecture (no Jordan form, no eigenspace decomposition)

1. `(X − C λ)^m` annihilates `x`, so `x` is integral and `minpoly K x ∣ (X − C λ)^m`.
2. `X − C λ` is prime in `K[X]`, so `dvd_prime_pow` forces the monic `minpoly` to be `(X − C λ)^d` with `d ≤ m` (`eq_of_monic_of_associated`).
3. `minpoly` annihilates `x`, giving `y^d = 0`; `Nat.sInf_le` minimality of the nilpotency class gives `m ≤ d`. Hence `d = m`.

Uniform over any `K`-algebra `B` (no commutativity, no coordinates).

## Verification

- **8 theorems, 0 definitions, 148 lines, 0 sorries.**
- `#print axioms` on the main results: only `propext`, `Classical.choice`, `Quot.sound` (**0 extra axioms**).
- Single-file verified via `lake env lean` against Mathlib v4.26.0 (EXIT=0).
- Annotations pass `pnpm annotations:validate` (0 errors for this entry).

## Note

This is a **rescue** of a crashed session: the untracked file did not compile as found (the integrality goal was in `eval₂` form so `map_pow` missed the pattern; the `λ = 0` literal defaulted to `ℕ` instead of `K`). Both bugs fixed (`show`-refold + explicit `(0 : K)`); meta/annotation line ranges realigned to the corrected file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)