### PR TITLE
Enrich Cantor Normal Form via Transfinite Induction: add header section

### DIFF
--- a/src/data/proofs/mathematical-induction-oq-01-oq-01/index.ts
+++ b/src/data/proofs/mathematical-induction-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MathematicalInductionOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const mathematicalInductionOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const mathematicalInductionOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const mathematicalInductionOQ01OQ01Data: ProofData = {
+  proof: mathematicalInductionOQ01OQ01Proof,
+  annotations: mathematicalInductionOQ01OQ01Annotations,
+}

--- a/src/data/proofs/mathematical-induction-oq-01-oq-01/meta.json
+++ b/src/data/proofs/mathematical-induction-oq-01-oq-01/meta.json
@@ -87,6 +87,14 @@
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Module Header, Imports, and the Open Question",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Module docstring restating the parent entry's first open question — can cantor_normal_form_exists be proved non-trivially by transfinite induction using Ordinal.log and Ordinal.div? — and answering it affirmatively via Mathlib's Ordinal.CNF omega o. Imports Mathlib and opens the Ordinal and List namespaces.",
+      "mathContext": "$o = \\omega^{e_1} c_1 + \\dots + \\omega^{e_n} c_n$ produced by $\\mathrm{CNF}\\,\\omega\\,o$, defined by recursion descending along $o \\bmod \\omega^{\\log_\\omega o}$."
+    },
+    {
       "id": "existence",
       "title": "Existence of the Cantor Normal Form",
       "startLine": 43,


### PR DESCRIPTION
Enrichment pass for `mathematical-induction-oq-01-oq-01` ("Cantor Normal Form via Transfinite Induction").

## Coverage
- **Added `header-imports` section** (lines 1–42) covering the module docstring and the open-question restatement (parent OQ-01), which the existing sections (starting at line 43) left uncovered.
- Also added a per-proof `index.ts` shim. **Correction:** I subsequently confirmed these shims are dead legacy code since #20992/#20993 — the runtime loader fetches build-generated data by slug and no longer imports per-proof index.ts (1296 live entries have none). The shim is harmless (matches the ~3068 entries that still carry one) but is not a functional fix; the genuine value here is the header section.