### PR TITLE
research(area-of-circle-oq-03-oq-03-oq-01): rigorous ellipse area via change of variables [VERIFIED, 0-axiom, 5thm]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ03OQ03OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ03OQ03OQ01.lean
@@ -1,0 +1,108 @@
+import Mathlib
+
+/-
+# Area of a Circle, oq-03-oq-03-oq-01 — The Ellipse Area Formula, Rigorously
+
+Parent entry `area-of-circle-oq-03-oq-03` ("Method of Exhaustion for Ellipses and
+Parabolas") states the ellipse area `π·a·b`, but its Lean proof is — in its own
+words — an *algebraic placeholder* (`ring`/`rfl`), asserting only tautologies like
+`a*b*π = π*a*b`. Its first open question (`area-of-circle-oq-03-oq-03-oq-01`) asks:
+
+> Prove the ellipse area formula rigorously using Mathlib's measure-theoretic
+> change of variables. The `integral_comp_mul_right`/`MeasurePreserving` API may
+> provide the right tools. The current proof is an algebraic placeholder.
+
+This file supplies the rigorous proof, following exactly the suggested route:
+the change-of-variables lemma `intervalIntegral.integral_comp_div`.
+
+## What is proved
+
+The area enclosed by the ellipse `x²/a² + y²/b² = 1` is the integral of its
+vertical extent `2·b·√(1 − (x/a)²)` over `x ∈ [−a, a]`:
+
+* `ellipse_halfheight_integral` — `∫ x in −a..a, √(1 − (x/a)²) = a·(π/2)`, obtained
+  from Mathlib's unit-circle integral `∫_{−1}^{1} √(1 − x²) = π/2`
+  (`integral_sqrt_one_sub_sq`) by the substitution `x ↦ x/a`
+  (`intervalIntegral.integral_comp_div`). This is the genuine change of variables.
+* `ellipse_area_integral` — `∫ x in −a..a, 2·b·√(1 − (x/a)²) = π·a·b`, the ellipse
+  area formula.
+* `circle_area_special` — specialising `a = b = r` recovers `π·r²`, the area of a
+  disc of radius `r`.
+* `ellipse_area_pos` — the area is positive for `a, b > 0`.
+
+Every step is a real integral computation; nothing is a tautological placeholder.
+Fully machine-checked, no axioms beyond Mathlib's foundations, no `native_decide`.
+
+Tags: geometry, ellipse, area, integral, change-of-variables, method-of-exhaustion
+-/
+
+namespace AreaOfCircleOQ03OQ03OQ01
+
+open Real MeasureTheory intervalIntegral
+
+/-- **Half-height integral of the ellipse via change of variables.** The integral
+of the normalized half-height `√(1 − (x/a)²)` over `[−a, a]` equals `a·(π/2)`. This
+is the crux: the substitution `x ↦ x/a` (`intervalIntegral.integral_comp_div`)
+reduces it to Mathlib's unit-circle integral `∫_{−1}^{1} √(1 − x²) = π/2`. -/
+theorem ellipse_halfheight_integral (a : ℝ) (ha : 0 < a) :
+    ∫ x in (-a)..a, Real.sqrt (1 - (x / a) ^ 2) = a * (π / 2) := by
+  have e1 : -a / a = -1 := by rw [neg_div, div_self ha.ne']
+  have e2 : a / a = 1 := div_self ha.ne'
+  have key := intervalIntegral.integral_comp_div (a := -a) (b := a)
+    (fun t => Real.sqrt (1 - t ^ 2)) ha.ne'
+  simp only [e1, e2] at key
+  rw [key, integral_sqrt_one_sub_sq, smul_eq_mul]
+
+/-- **The ellipse area formula, rigorously.** The area enclosed by the ellipse
+`x²/a² + y²/b² = 1`, computed as `∫ 2·b·√(1 − (x/a)²) dx` over `[−a, a]`, equals
+`π·a·b`. -/
+theorem ellipse_area_integral (a b : ℝ) (ha : 0 < a) :
+    ∫ x in (-a)..a, 2 * b * Real.sqrt (1 - (x / a) ^ 2) = π * a * b := by
+  rw [intervalIntegral.integral_const_mul, ellipse_halfheight_integral a ha]
+  ring
+
+/-- **Circle as the special case `a = b = r`.** Setting both semi-axes to `r`
+recovers the area `π·r²` of a disc of radius `r`. -/
+theorem circle_area_special (r : ℝ) (hr : 0 < r) :
+    ∫ x in (-r)..r, 2 * r * Real.sqrt (1 - (x / r) ^ 2) = π * r ^ 2 := by
+  rw [ellipse_area_integral r r hr]; ring
+
+/-- The ellipse area is strictly positive for positive semi-axes. -/
+theorem ellipse_area_pos (a b : ℝ) (ha : 0 < a) (hb : 0 < b) :
+    0 < ∫ x in (-a)..a, 2 * b * Real.sqrt (1 - (x / a) ^ 2) := by
+  rw [ellipse_area_integral a b ha]
+  have := Real.pi_pos
+  positivity
+
+/-- **The filled ellipse as a genuine 2D region, with its Lebesgue measure.** The
+solid ellipse — the planar region between the lower arc `y = −b·√(1 − (x/a)²)` and
+the upper arc `y = +b·√(1 − (x/a)²)` for `x ∈ [−a, a]` — has 2D Lebesgue measure
+exactly `π·a·b`. This upgrades the 1D area integral to the true 2D measure of the
+region, via `volume_regionBetween_eq_integral` and the interval integral above. -/
+theorem ellipse_volume (a b : ℝ) (ha : 0 < a) (hb : 0 ≤ b) :
+    volume (regionBetween
+        (fun x => -(b * Real.sqrt (1 - (x / a) ^ 2)))
+        (fun x => b * Real.sqrt (1 - (x / a) ^ 2))
+        (Set.Icc (-a) a)) = ENNReal.ofReal (π * a * b) := by
+  have hcont : Continuous fun x : ℝ => b * Real.sqrt (1 - (x / a) ^ 2) := by fun_prop
+  have hhi : IntegrableOn (fun x => b * Real.sqrt (1 - (x / a) ^ 2)) (Set.Icc (-a) a) volume :=
+    hcont.integrableOn_Icc
+  have hlo : IntegrableOn (fun x => -(b * Real.sqrt (1 - (x / a) ^ 2))) (Set.Icc (-a) a) volume :=
+    hcont.neg.integrableOn_Icc
+  have hfg : ∀ x ∈ Set.Icc (-a) a,
+      -(b * Real.sqrt (1 - (x / a) ^ 2)) ≤ b * Real.sqrt (1 - (x / a) ^ 2) := by
+    intro x _
+    have : 0 ≤ b * Real.sqrt (1 - (x / a) ^ 2) := by positivity
+    linarith
+  rw [MeasureTheory.Measure.volume_eq_prod ℝ ℝ,
+    volume_regionBetween_eq_integral hlo hhi measurableSet_Icc hfg]
+  congr 1
+  have hsimp : (fun y => ((fun x => b * Real.sqrt (1 - (x / a) ^ 2))
+        - fun x => -(b * Real.sqrt (1 - (x / a) ^ 2))) y)
+      = fun y => 2 * b * Real.sqrt (1 - (y / a) ^ 2) := by
+    funext y; simp only [Pi.sub_apply]; ring
+  rw [MeasureTheory.integral_Icc_eq_integral_Ioc,
+    ← intervalIntegral.integral_of_le (by linarith : (-a) ≤ a), hsimp]
+  exact ellipse_area_integral a b ha
+
+end AreaOfCircleOQ03OQ03OQ01

--- a/proofs/Proofs/Erdos634MedialCoveringOQ02.lean
+++ b/proofs/Proofs/Erdos634MedialCoveringOQ02.lean
@@ -1,0 +1,186 @@
+/-
+# Erdős Problem #634, oq-02 — The Medial Subdivision is a Covering
+
+Source: Erdős Problem #634 (erdosproblems.com/634). Parent entry
+`erdos-634-medial-congruence` proves that the four medial triangles of any
+triangle `A B C` — obtained by joining the midpoints of the sides — are pairwise
+congruent (isometry-congruent, half-scale copies). That entry deliberately left
+the *analytic* half of the dissection unformalized, and posed as its second open
+question (`erdos-634-medial-congruence-oq-02`):
+
+> Add the covering and interior-disjointness conditions to upgrade the congruence
+> statement to a genuine tiling, completing the dissection claim rather than only
+> the congruence of pieces.
+
+This file supplies the **covering** condition, unconditionally and axiom-free.
+
+## What is proved
+
+Working in an arbitrary real vector space `V` (so the result specialises to the
+Euclidean plane), write `mAB = midpoint A B`, `mBC = midpoint B C`,
+`mCA = midpoint C A`. Model the solid triangle on an ordered vertex triple by the
+barycentric set
+
+  `triHull p₁ p₂ p₃ = { a•p₁ + b•p₂ + c•p₃ | a,b,c ≥ 0, a+b+c = 1 }`,
+
+and identify it with Mathlib's `convexHull` (`triHull_eq_convexHull`), so the
+statements below are genuinely about the convex hulls of the vertex triples.
+
+* `piece{1,2,3,4}_subset` — each of the four medial triangles is contained in the
+  original triangle `A B C` (the pieces stay inside).
+* `whole_subset_pieces` — every point of `A B C` lies in at least one medial
+  triangle: a point with barycentric coordinates `(α,β,γ)` lands in the corner
+  piece whose coordinate is `≥ 1/2`, and in the central piece when all three are
+  `≤ 1/2`.
+* `medial_covering` — the exact set equality: `A B C` is the union of its four
+  medial triangles.
+* `medial_covering_convexHull` — the same equality phrased directly with Mathlib's
+  `convexHull`, the citable form of the covering.
+
+Interior-disjointness and the measure/area accounting remain open (see the entry's
+open questions); this file closes the covering half of oq-02.
+
+Tags: geometry, erdos, dissection, tiling, covering, convex-hull, barycentric
+-/
+
+import Mathlib
+
+set_option linter.unusedSectionVars false
+
+namespace Erdos634MedialCoveringOQ02
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-
+## Part I: The solid triangle as a barycentric set
+-/
+
+/-- The **solid triangle** on an ordered vertex triple `p₁ p₂ p₃`: all convex
+combinations `a•p₁ + b•p₂ + c•p₃` with `a,b,c ≥ 0` and `a+b+c = 1`. This is the
+barycentric parametrization of the filled triangle; `triHull_eq_convexHull`
+identifies it with Mathlib's `convexHull`. -/
+def triHull (p₁ p₂ p₃ : V) : Set V :=
+  {x | ∃ a b c : ℝ, 0 ≤ a ∧ 0 ≤ b ∧ 0 ≤ c ∧ a + b + c = 1 ∧ x = a • p₁ + b • p₂ + c • p₃}
+
+/-- `triHull` is exactly the convex hull of its three vertices, so every result
+below is a statement about genuine convex hulls. -/
+theorem triHull_eq_convexHull (p₁ p₂ p₃ : V) :
+    triHull p₁ p₂ p₃ = convexHull ℝ {p₁, p₂, p₃} := by
+  apply Set.Subset.antisymm
+  · -- A barycentric combination is a convex combination of the three vertices.
+    rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+    refine mem_convexHull_of_exists_fintype ![a, b, c] ![p₁, p₂, p₃] ?_ ?_ ?_ ?_
+    · intro i; fin_cases i <;> simp_all
+    · simpa [Fin.sum_univ_three] using hs
+    · intro i; fin_cases i <;> simp
+    · simp [Fin.sum_univ_three]
+  · -- `triHull` is convex and contains the three vertices.
+    apply convexHull_min
+    · intro x hx
+      simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+      rcases hx with rfl | rfl | rfl
+      · exact ⟨1, 0, 0, by norm_num, le_refl _, le_refl _, by norm_num, by simp⟩
+      · exact ⟨0, 1, 0, le_refl _, by norm_num, le_refl _, by norm_num, by simp⟩
+      · exact ⟨0, 0, 1, le_refl _, le_refl _, by norm_num, by norm_num, by simp⟩
+    · rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩ y ⟨a', b', c', ha', hb', hc', hs', rfl⟩
+        u v hu hv huv
+      exact ⟨u * a + v * a', u * b + v * b', u * c + v * c',
+        by positivity, by positivity, by positivity,
+        by linear_combination u * hs + v * hs' + huv, by module⟩
+
+/-
+## Part II: The pieces sit inside the original triangle
+-/
+
+/-- The corner piece at `A` is contained in the triangle `A B C`. -/
+theorem piece1_subset (A B C : V) :
+    triHull A (midpoint ℝ A B) (midpoint ℝ C A) ⊆ triHull A B C := by
+  rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+  refine ⟨a + b / 2 + c / 2, b / 2, c / 2, by positivity, by positivity, by positivity,
+    by linarith, ?_⟩
+  simp only [midpoint_eq_smul_add, invOf_eq_inv]; module
+
+/-- The corner piece at `B` is contained in the triangle `A B C`. -/
+theorem piece2_subset (A B C : V) :
+    triHull (midpoint ℝ A B) B (midpoint ℝ B C) ⊆ triHull A B C := by
+  rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+  refine ⟨a / 2, a / 2 + b + c / 2, c / 2, by positivity, by positivity, by positivity,
+    by linarith, ?_⟩
+  simp only [midpoint_eq_smul_add, invOf_eq_inv]; module
+
+/-- The corner piece at `C` is contained in the triangle `A B C`. -/
+theorem piece3_subset (A B C : V) :
+    triHull (midpoint ℝ C A) (midpoint ℝ B C) C ⊆ triHull A B C := by
+  rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+  refine ⟨a / 2, b / 2, a / 2 + b / 2 + c, by positivity, by positivity, by positivity,
+    by linarith, ?_⟩
+  simp only [midpoint_eq_smul_add, invOf_eq_inv]; module
+
+/-- The central (medial) piece is contained in the triangle `A B C`. -/
+theorem piece4_subset (A B C : V) :
+    triHull (midpoint ℝ B C) (midpoint ℝ C A) (midpoint ℝ A B) ⊆ triHull A B C := by
+  rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+  refine ⟨b / 2 + c / 2, a / 2 + c / 2, a / 2 + b / 2, by positivity, by positivity,
+    by positivity, by linarith, ?_⟩
+  simp only [midpoint_eq_smul_add, invOf_eq_inv]; module
+
+/-
+## Part III: The four pieces cover the whole triangle
+-/
+
+/-- **Covering.** Every point of the triangle `A B C` lies in one of the four medial
+triangles. A point with barycentric coordinates `(a,b,c)` falls into the corner
+piece whose coordinate is `≥ 1/2`; if all three are `< 1/2` it falls into the
+central piece. -/
+theorem whole_subset_pieces (A B C : V) :
+    triHull A B C ⊆
+      triHull A (midpoint ℝ A B) (midpoint ℝ C A) ∪
+      triHull (midpoint ℝ A B) B (midpoint ℝ B C) ∪
+      triHull (midpoint ℝ C A) (midpoint ℝ B C) C ∪
+      triHull (midpoint ℝ B C) (midpoint ℝ C A) (midpoint ℝ A B) := by
+  rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+  by_cases h1 : 1 / 2 ≤ a
+  · refine Or.inl (Or.inl (Or.inl ⟨2 * a - 1, 2 * b, 2 * c, by linarith, by linarith,
+      by linarith, by linarith, ?_⟩))
+    simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+  · by_cases h2 : 1 / 2 ≤ b
+    · refine Or.inl (Or.inl (Or.inr ⟨2 * a, 2 * b - 1, 2 * c, by linarith, by linarith,
+        by linarith, by linarith, ?_⟩))
+      simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+    · by_cases h3 : 1 / 2 ≤ c
+      · refine Or.inl (Or.inr ⟨2 * a, 2 * b, 2 * c - 1, by linarith, by linarith,
+          by linarith, by linarith, ?_⟩)
+        simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+      · refine Or.inr ⟨1 - 2 * a, 1 - 2 * b, 1 - 2 * c, by linarith, by linarith,
+          by linarith, by linarith, ?_⟩
+        simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+
+/-- **The medial subdivision is a covering.** The triangle `A B C` is exactly the
+union of its four medial triangles. -/
+theorem medial_covering (A B C : V) :
+    triHull A B C =
+      triHull A (midpoint ℝ A B) (midpoint ℝ C A) ∪
+      triHull (midpoint ℝ A B) B (midpoint ℝ B C) ∪
+      triHull (midpoint ℝ C A) (midpoint ℝ B C) C ∪
+      triHull (midpoint ℝ B C) (midpoint ℝ C A) (midpoint ℝ A B) := by
+  refine Set.Subset.antisymm (whole_subset_pieces A B C) ?_
+  refine Set.union_subset (Set.union_subset (Set.union_subset ?_ ?_) ?_) ?_
+  · exact piece1_subset A B C
+  · exact piece2_subset A B C
+  · exact piece3_subset A B C
+  · exact piece4_subset A B C
+
+/-- **Covering, in Mathlib's `convexHull`.** The convex hull of `A B C` is the union
+of the convex hulls of the four medial vertex triples — the citable form of the
+covering condition of oq-02. -/
+theorem medial_covering_convexHull (A B C : V) :
+    convexHull ℝ ({A, B, C} : Set V) =
+      convexHull ℝ {A, midpoint ℝ A B, midpoint ℝ C A} ∪
+      convexHull ℝ {midpoint ℝ A B, B, midpoint ℝ B C} ∪
+      convexHull ℝ {midpoint ℝ C A, midpoint ℝ B C, C} ∪
+      convexHull ℝ {midpoint ℝ B C, midpoint ℝ C A, midpoint ℝ A B} := by
+  rw [← triHull_eq_convexHull, ← triHull_eq_convexHull, ← triHull_eq_convexHull,
+    ← triHull_eq_convexHull, ← triHull_eq_convexHull]
+  exact medial_covering A B C
+
+end Erdos634MedialCoveringOQ02

--- a/src/data/proofs/area-of-circle-oq-03-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03-oq-01/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "ann-aoc-oq030301-01-header",
+    "proofId": "area-of-circle-oq-03-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "From Algebraic Placeholder to a Real Integral",
+    "content": "The header recalls that the parent entry stated the ellipse area π·a·b but proved only the tautology a·b·π = π·a·b, and that its first open question asks for a rigorous proof via Mathlib's change-of-variables API. This file follows exactly that route: the substitution x ↦ x/a reduces the ellipse arc integral to the unit-circle integral, and the result is upgraded to the genuine 2D Lebesgue measure of the filled ellipse.",
+    "mathContext": "The area of an ellipse with semi-axes a, b is π·a·b, classically by Archimedes' exhaustion and modernly by the affine rescaling of the unit disc; the analytic heart is the unit-circle integral ∫√(1−x²) = π/2.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ellipse area",
+      "change of variables",
+      "method of exhaustion"
+    ],
+    "prerequisites": [
+      "definite integrals",
+      "Lean 4 Mathlib"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq030301-02-halfheight",
+    "proofId": "area-of-circle-oq-03-oq-03-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 57
+    },
+    "type": "theorem",
+    "title": "ellipse_halfheight_integral: the Change of Variables",
+    "content": "Proves ∫ x in −a..a, √(1 − (x/a)²) = a·(π/2). The substitution x ↦ x/a (intervalIntegral.integral_comp_div, with f = √(1 − ·²) and divisor a) rescales the limits (−a/a = −1, a/a = 1) and extracts the factor a, reducing the integral to Mathlib's integral_sqrt_one_sub_sq = π/2. This is the genuine change of variables the open question requested.",
+    "mathContext": "∫_{−a}^{a} √(1 − (x/a)²) dx = a ∫_{−1}^{1} √(1 − u²) du = a·(π/2): u = x/a turns the ellipse's normalized arc into the unit circle's.",
+    "significance": "central",
+    "relatedConcepts": [
+      "change of variables",
+      "unit-circle integral"
+    ],
+    "prerequisites": [
+      "interval integrals",
+      "substitution"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq030301-03-area",
+    "proofId": "area-of-circle-oq-03-oq-03-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 64
+    },
+    "type": "theorem",
+    "title": "ellipse_area_integral: the Ellipse Area Formula",
+    "content": "Proves ∫ x in −a..a, 2b·√(1 − (x/a)²) = π·a·b. The constant 2b is pulled out with intervalIntegral.integral_const_mul, and the half-height integral supplies a·(π/2); ring finishes. This is the rigorous ellipse area formula replacing the parent's algebraic placeholder.",
+    "mathContext": "Area = ∫ (upper − lower) dx = ∫ 2b·√(1 − (x/a)²) dx = 2b · a·(π/2) = π·a·b.",
+    "significance": "central",
+    "relatedConcepts": [
+      "ellipse area",
+      "integral linearity"
+    ],
+    "prerequisites": [
+      "interval integrals"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq030301-04-circle-pos",
+    "proofId": "area-of-circle-oq-03-oq-03-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 78
+    },
+    "type": "theorem",
+    "title": "circle_area_special and ellipse_area_pos",
+    "content": "circle_area_special sets a = b = r to recover the disc area π·r² from the ellipse formula, reconnecting to the parent circle result. ellipse_area_pos records that the area is strictly positive for positive semi-axes (positivity, using π > 0).",
+    "mathContext": "The circle is the ellipse with equal semi-axes: π·r·r = π·r². The area is manifestly positive.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "circle area",
+      "special case"
+    ],
+    "prerequisites": [
+      "the ellipse area formula"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq030301-05-volume",
+    "proofId": "area-of-circle-oq-03-oq-03-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "ellipse_volume: the True 2D Lebesgue Measure",
+    "content": "Upgrades the 1D area to the genuine planar measure. The filled ellipse is the region between the arcs ∓b·√(1 − (x/a)²) over Icc(−a,a); both arcs are continuous (hence integrable on the compact interval), the lower ≤ the upper, and volume_regionBetween_eq_integral reduces the 2D Lebesgue measure to ∫ (upper − lower) = ∫ 2b·√(1 − (x/a)²), which equals π·a·b by ellipse_area_integral after bridging the Icc set integral to the interval integral.",
+    "mathContext": "The honest 'area' is the 2D Lebesgue measure of the solid ellipse; volume_regionBetween_eq_integral certifies it equals the integral of the vertical extent, namely π·a·b.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Lebesgue measure",
+      "region between functions",
+      "2D area"
+    ],
+    "prerequisites": [
+      "Lebesgue measure",
+      "integrability from continuity"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03-oq-01/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "area-of-circle-oq-03-oq-03-oq-01",
+  "title": "The Ellipse Area Formula, Rigorously via Change of Variables",
+  "slug": "area-of-circle-oq-03-oq-03-oq-01",
+  "description": "The parent entry states the ellipse area π·a·b but proves only an algebraic tautology (a·b·π = π·a·b). This entry answers its first open question by giving the rigorous proof along the suggested route: the change-of-variables lemma intervalIntegral.integral_comp_div reduces ∫ 2b·√(1−(x/a)²) dx to Mathlib's unit-circle integral ∫√(1−x²) = π/2, yielding the area π·a·b. It also upgrades the 1D area integral to the genuine 2D Lebesgue measure of the filled ellipse via volume_regionBetween_eq_integral.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Ellipse#Area",
+    "date": null,
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ03OQ01.lean",
+    "tags": [
+      "geometry",
+      "analysis",
+      "ellipse",
+      "area",
+      "integral",
+      "change-of-variables",
+      "measure-theory",
+      "method-of-exhaustion",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_sqrt_one_sub_sq",
+        "description": "The unit-circle integral ∫ x in (-1)..1, √(1 - x²) = π/2 — the analytic input the ellipse formula is reduced to",
+        "module": "Mathlib.Analysis.SpecialFunctions.Integrals.Basic"
+      },
+      {
+        "theorem": "intervalIntegral.integral_comp_div",
+        "description": "Change of variables ∫ x in a..b, f (x/c) = c • ∫ x in a/c..b/c, f x (c ≠ 0) — the substitution x ↦ x/a suggested by the open question",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "intervalIntegral.integral_const_mul",
+        "description": "∫ x in a..b, r * f x = r * ∫ x in a..b, f x — pulls the constant 2b out of the area integral",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "volume_regionBetween_eq_integral",
+        "description": "The 2D Lebesgue measure of the region between two integrable functions equals ∫ (upper − lower) — turns the area integral into the true planar measure of the filled ellipse",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Integral"
+      },
+      {
+        "theorem": "MeasureTheory.integral_Icc_eq_integral_Ioc",
+        "description": "∫ over Icc equals ∫ over Ioc (endpoints are null) — bridges the set integral of volume_regionBetween to the interval integral",
+        "module": "Mathlib.MeasureTheory.Integral.SetIntegral"
+      }
+    ],
+    "originalContributions": [
+      "ellipse_halfheight_integral: the crux — ∫ x in −a..a, √(1 − (x/a)²) = a·(π/2), proved by the substitution x ↦ x/a (intervalIntegral.integral_comp_div) reducing to Mathlib's unit-circle integral ∫_{−1}^{1} √(1 − x²) = π/2. This is the genuine change of variables the open question asked for",
+      "ellipse_area_integral: the ellipse area formula ∫ x in −a..a, 2b·√(1 − (x/a)²) = π·a·b, replacing the parent's algebraic placeholder with a real integral computation",
+      "circle_area_special: specialising a = b = r recovers the disc area π·r², reconnecting to the parent circle result",
+      "ellipse_area_pos: the area is strictly positive for positive semi-axes",
+      "ellipse_volume: upgrades the 1D area to the true 2D Lebesgue measure — the filled ellipse, as the region between the lower and upper arcs over [−a,a], has volume ENNReal.ofReal (π·a·b), via volume_regionBetween_eq_integral and the interval integral above"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 108,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axioms beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound); verified via #print axioms. No native_decide.",
+    "mathlib_version": "4.26.0",
+    "relatedProblems": [
+      {
+        "id": "area-of-circle-oq-03-oq-03",
+        "relationship": "Parent entry (Method of Exhaustion for Ellipses and Parabolas). Its ellipse area proof was an algebraic placeholder; this entry supplies the rigorous integral proof its first open question requested."
+      },
+      {
+        "id": "area-of-circle",
+        "relationship": "Ancestor: the circle area π·r² is recovered here as the a = b = r special case of the ellipse formula."
+      }
+    ],
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The area of an ellipse with semi-axes a and b is π·a·b — a formula older than calculus, provable by Archimedes' method of exhaustion and, in modern terms, by the affine change of variables (x,y) ↦ (a·x, b·y) carrying the unit disc onto the ellipse and scaling area by the Jacobian a·b. The parent entry (Method of Exhaustion for Ellipses and Parabolas) stated the formula but formalized only the algebraic identity a·b·π = π·a·b, leaving the analytic content — the actual integral — unproved. Mathlib supplies the missing ingredient: the unit-circle integral ∫_{−1}^{1} √(1 − x²) = π/2, from which a single change of variables delivers the ellipse area.",
+    "problemStatement": "The parent's ellipse proof is, in its own comments, an algebraic placeholder. Its first open question asks to prove the ellipse area formula rigorously using Mathlib's change-of-variables API (explicitly suggesting integral_comp_mul_right / the MeasurePreserving tools). Concretely: compute ∫ x in −a..a, 2b·√(1 − (x/a)²) and show it equals π·a·b — and, ideally, exhibit the filled ellipse as a genuine 2D region of that Lebesgue measure.",
+    "proofStrategy": "The half-height integral ∫ x in −a..a, √(1 − (x/a)²) is handled by intervalIntegral.integral_comp_div with f = √(1 − ·²) and divisor a: the substitution x ↦ x/a rescales the limits −a, a to −1, 1 and pulls out a factor a, reducing to Mathlib's integral_sqrt_one_sub_sq = π/2; hence the half-height integral is a·(π/2). Pulling the constant 2b out with integral_const_mul gives the area π·a·b. The circle case is a = b = r. For the 2D upgrade, the filled ellipse is the region between the arcs ∓b·√(1 − (x/a)²) over Icc(−a,a); both arcs are continuous hence integrable on the compact interval, the lower arc is ≤ the upper, and volume_regionBetween_eq_integral turns the planar measure into ∫ (upper − lower) = ∫ 2b·√(1 − (x/a)²), which the interval-integral computation evaluates to π·a·b (bridging Icc→Ioc→interval integral).",
+    "keyInsights": [
+      "The single substitution x ↦ x/a is the whole content: it simultaneously rescales the limits [−a,a] → [−1,1] and factors out the semi-axis a, landing on the one integral Mathlib already knows.",
+      "The vertical semi-axis b enters only as a constant multiplier (integral_const_mul), so the area is linear in b — no second change of variables needed.",
+      "integral_sqrt_one_sub_sq = π/2 is exactly the 'area of a half-disc of radius 1' packaged as an interval integral, making it the right analytic primitive.",
+      "The 2D upgrade uses volume_regionBetween_eq_integral to certify that the number π·a·b is not just an integral but the actual Lebesgue measure of the filled ellipse — the honest sense of 'area'.",
+      "Bridging the region-between set integral (over Icc) to the interval integral needs only that endpoints are null (integral_Icc_eq_integral_Ioc), a routine but necessary step."
+    ],
+    "prerequisites": [
+      "definite (interval) integrals and change of variables",
+      "the unit-circle integral ∫√(1−x²) = π/2",
+      "Lebesgue measure and the region between two functions",
+      "continuity ⟹ integrability on compact intervals"
+    ],
+    "text": "A 108-line, fully verified (0 sorries, 0 axioms, no native_decide) formalization that answers the first open question of area-of-circle-oq-03-oq-03 by replacing its algebraic placeholder with a rigorous proof of the ellipse area formula. ellipse_halfheight_integral reduces ∫ √(1 − (x/a)²) over [−a,a] to Mathlib's unit-circle integral via the change of variables intervalIntegral.integral_comp_div, giving a·(π/2). ellipse_area_integral pulls out the constant 2b to conclude the area is π·a·b; circle_area_special recovers π·r²; ellipse_area_pos records positivity. Finally ellipse_volume upgrades the result to the genuine 2D Lebesgue measure of the filled ellipse via volume_regionBetween_eq_integral."
+  },
+  "sections": [
+    {
+      "id": "sec-changeofvars",
+      "title": "The Change of Variables: Half-Height Integral",
+      "startLine": 44,
+      "endLine": 57,
+      "summary": "ellipse_halfheight_integral proves ∫ x in −a..a, √(1 − (x/a)²) = a·(π/2). The substitution x ↦ x/a via intervalIntegral.integral_comp_div rescales the limits (−a/a = −1, a/a = 1) and extracts the factor a, reducing to Mathlib's integral_sqrt_one_sub_sq = π/2.",
+      "mathContext": "∫_{−a}^{a} √(1 − (x/a)²) dx = a ∫_{−1}^{1} √(1 − u²) du = a · (π/2): the substitution u = x/a turns the ellipse's normalized arc into the unit circle's."
+    },
+    {
+      "id": "sec-areaformula",
+      "title": "The Ellipse Area Formula and the Circle Special Case",
+      "startLine": 58,
+      "endLine": 78,
+      "summary": "ellipse_area_integral pulls the constant 2b out of ∫ 2b·√(1 − (x/a)²) (integral_const_mul) and applies the half-height integral to get π·a·b. circle_area_special sets a = b = r to recover π·r², and ellipse_area_pos records strict positivity.",
+      "mathContext": "Area = ∫_{−a}^{a} [upper − lower] dx = ∫_{−a}^{a} 2b·√(1 − (x/a)²) dx = 2b · a·(π/2) = π·a·b; with a = b = r this is π·r²."
+    },
+    {
+      "id": "sec-2dvolume",
+      "title": "Upgrading to the 2D Lebesgue Measure",
+      "startLine": 80,
+      "endLine": 107,
+      "summary": "ellipse_volume shows the filled ellipse — the region between the arcs ∓b·√(1 − (x/a)²) over Icc(−a,a) — has 2D Lebesgue measure ENNReal.ofReal (π·a·b). Both arcs are continuous (hence integrable on the compact interval), the lower ≤ upper, and volume_regionBetween_eq_integral reduces the planar measure to ∫ (upper − lower), evaluated by the interval integral (after Icc→Ioc→interval bridging).",
+      "mathContext": "The genuine area is the 2D Lebesgue measure of the solid ellipse, and volume_regionBetween_eq_integral certifies it equals the integral of the vertical extent — π·a·b."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) formalization answering the first open question of area-of-circle-oq-03-oq-03: it replaces the parent's algebraic-placeholder ellipse area with a rigorous proof. Following the suggested route, ellipse_halfheight_integral uses the change of variables intervalIntegral.integral_comp_div to reduce the ellipse arc integral to Mathlib's unit-circle integral, and ellipse_area_integral concludes the area is π·a·b. ellipse_volume further certifies this as the true 2D Lebesgue measure of the filled ellipse.",
+    "implications": "**Theoretical significance**: This closes the gap between the stated ellipse formula and a machine-checked proof, demonstrating the change-of-variables path (unit-circle integral + affine rescaling) that the parent's open question pointed to. The same template — reduce a normalized special-function integral by a linear substitution, then read off the measure via volume_regionBetween_eq_integral — applies verbatim to areas under any rescaled curve, and is the analytic backbone of the method of exhaustion the parent studies.",
+    "openQuestions": [
+      "Prove the ellipse area via the 2D affine change of variables (x,y) ↦ (a·x, b·y) directly, using MeasureTheory.Measure.addHaar_image_linearMap and EuclideanSpace.volume_ball_fin_two, to obtain volume(ellipse) = |det| · volume(unit disc) = a·b·π without reducing to a 1D integral.",
+      "Formalize the parabolic-segment area (Archimedes' 4/3 rule) rigorously, the parent's second open question, to complement this ellipse result.",
+      "Extend ellipse_volume to the ellipsoid volume (4/3)π·a·b·c in three dimensions via the analogous change of variables from the unit ball."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-03-oq-03",
+      "relationship": "extends",
+      "description": "Answers this parent's first open question: replaces its algebraic-placeholder ellipse area (a·b·π = π·a·b) with a rigorous integral proof via the change of variables intervalIntegral.integral_comp_div, and upgrades it to the 2D Lebesgue measure."
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "related",
+      "description": "The circle area π·r² is recovered here as the a = b = r special case (circle_area_special)."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Archimedes",
+      "title": "On Conoids and Spheroids",
+      "year": "-225",
+      "venue": "",
+      "note": "Area of an ellipse by the method of exhaustion"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "The Lean Mathematical Library",
+      "year": "2020",
+      "venue": "CPP 2020",
+      "note": "integral_sqrt_one_sub_sq, intervalIntegral.integral_comp_div, and volume_regionBetween_eq_integral"
+    }
+  ],
+  "sorries": [],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory",
+      "intervalIntegral"
+    ],
+    "namespace": "AreaOfCircleOQ03OQ03OQ01",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ03OQ03OQ01.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `area-of-circle-oq-03-oq-03` (Method of Exhaustion for Ellipses and Parabolas):

> Prove the ellipse area formula rigorously using Mathlib's measure-theoretic change of variables (`integral_comp_mul_right`/`MeasurePreserving`). **The current proof is an algebraic placeholder.**

The parent's ellipse "proof" asserts only tautologies like `a*b*π = π*a*b` (`by ring`). This entry supplies the genuine proof along exactly the suggested route.

## New entry: `area-of-circle-oq-03-oq-03-oq-01`

`proofs/Proofs/AreaOfCircleOQ03OQ03OQ01.lean` — 108 lines, 5 theorems, **0 axioms, 0 sorries, no native_decide**.

- `ellipse_halfheight_integral` — `∫ x in −a..a, √(1 − (x/a)²) = a·(π/2)`, the crux: the substitution `x ↦ x/a` (`intervalIntegral.integral_comp_div`) rescales the limits to `[−1,1]` and factors out `a`, reducing to Mathlib's `integral_sqrt_one_sub_sq = π/2`.
- `ellipse_area_integral` — `∫ x in −a..a, 2b·√(1 − (x/a)²) = π·a·b`, the area formula.
- `circle_area_special` — `a = b = r` recovers `π·r²`.
- `ellipse_area_pos` — positivity.
- `ellipse_volume` — **upgrades to the true 2D Lebesgue measure**: the filled ellipse (region between the two arcs over `Icc(−a,a)`) has `volume = ENNReal.ofReal (π·a·b)`, via `volume_regionBetween_eq_integral`.

## Verification
- Built with `lake env lean` against Mathlib 4.26.0 (warm cache): compiles clean.
- `#print axioms` on `ellipse_area_integral`, `ellipse_halfheight_integral`, `ellipse_volume`, `circle_area_special`: `[propext, Classical.choice, Quot.sound]` only — **no `sorryAx`, no `Lean.ofReduceBool`**. Genuinely 0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)