### PR TITLE
Enrich Binary GCD Total Bit-Operation Cost Model: add module-header section

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-01/meta.json
@@ -75,6 +75,14 @@
   },
   "sections": [
     {
+      "id": "header-and-cost-model",
+      "title": "Module Header: Unit-Cost Steps vs. Honest Bit Cost",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Module docstring framing the open question: the parent binary-gcd-oq-01 counts reduction steps under a unit-cost model, but a Stein step touches every bit of the current pair, so its honest cost is Nat.size a + Nat.size b. Includes a fully worked trace for (12,8) giving binaryGcdCost 12 8 = 8+6+4+3+2 = 23, and states the two main results (bound by steps times initial bit-length, and the classical O((log N)^2) quadratic bound). Imports Mathlib and the parent BinaryGcdOQ01.",
+      "mathContext": "$\\text{step cost} = \\mathtt{Nat.size}\\,a + \\mathtt{Nat.size}\\,b$; worked trace $(12,8)$: $8+6+4+3+2 = 23$."
+    },
+    {
       "id": "cost-definition",
       "title": "The total bit-operation cost model",
       "startLine": 59,


### PR DESCRIPTION
Enrichment pass for `binary-gcd-oq-01-oq-01` ("Binary GCD: Total Bit-Operation Cost Model").

## Coverage
- **Added `header-and-cost-model` section** (lines 1–58). The existing three sections started at line 59, leaving the module docstring unsectioned — including the framing of the unit-cost vs honest-bit-cost distinction and the fully worked `(12,8)` trace (`binaryGcdCost 12 8 = 8+6+4+3+2 = 23`). The header annotation already covered this range; the section array now mirrors it.

No content deleted. Entry was already well-curated (keyInsights maxed, historicalContext/conclusion/crossRefs maxed); only the genuine section-coverage gap was filled. Verified with `pnpm build` (✓ built).