### PR TITLE
Enrich Gauss sum bound (bounded-prime-gaps-oq-04-oq-03): add annotation titles

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/annotations.json
@@ -7,6 +7,7 @@
       "endLine": 68
     },
     "type": "concept",
+    "title": "OQ-03: making the Gauss sum bound axiom-free for prime modulus",
     "significance": "key",
     "content": "The module header frames a precise question inherited from the sibling catalog BoundedPrimeGapsOQ04OQ02, which records gaussSumBound (|τ(χ)| = √q) as Addition 1 of the six Mathlib additions needed for Bombieri–Vinogradov, states it as an axiom, and asks in its own open-questions list whether it is provable from Mathlib's existing ZMod.gaussSum infrastructure. This file answers: for prime modulus, yes, with no axioms; for composite modulus, the obstruction is isolated to a single field hypothesis. The header is honest about scope — it neither overclaims the general primitive-character bound nor treats the prime case as trivial.",
     "mathContext": "The Gauss sum is $\\tau(\\chi) = \\sum_{a \\in \\mathbb{Z}/q} \\chi(a)\\, e(a/q)$ with $e(t) = e^{2\\pi i t}$. Classically $|\\tau(\\chi)| = \\sqrt{q}$ for primitive $\\chi$. Here $q = p$ is prime and $\\chi \\neq 1$, so $\\chi$ is automatically primitive.",
@@ -21,6 +22,7 @@
       "endLine": 110
     },
     "type": "insight",
+    "title": "The crux: where the prime hypothesis enters (the [Field] requirement)",
     "significance": "key",
     "content": "gaussSum_mul_conj is where the prime hypothesis is actually used. Mathlib's gaussSum_mul_gaussSum_eq_card requires the character domain R to be a [Field] — and ZMod q is a field exactly when q is prime. This single typeclass requirement is the entire reason the general composite-modulus bound is not obtainable from Mathlib as-is. The rest of the argument (conjugation, norm extraction) is modulus-agnostic. So the annotation pins the gap precisely: it is not a missing conjugation lemma or a missing orthogonality fact, but the absence of the primitive-Dirichlet-character reduction that would replace the field hypothesis for composite q.",
     "mathContext": "gaussSum_mul_gaussSum_eq_card: for $\\chi \\neq 1$ and $\\psi$ primitive over a field $R$, $\\mathrm{gaussSum}\\,\\chi\\,\\psi \\cdot \\mathrm{gaussSum}\\,\\chi^{-1}\\,\\psi^{-1} = \\#R$. Over $\\mathbb{Z}/p$ (a field) with $\\psi = $ stdAddChar (primitive), this gives $\\tau(\\chi)\\overline{\\tau(\\chi)} = p$.",
@@ -35,6 +37,7 @@
       "endLine": 95
     },
     "type": "technique",
+    "title": "Conjugation identity conj τ(χ) = τ(χ⁻¹) — proved for every modulus",
     "significance": "supporting",
     "content": "The conjugation identity conj(gaussSum χ ψ) = gaussSum χ⁻¹ ψ⁻¹ is assembled from two unitarity facts already in Mathlib: MulChar.star_apply' (conj(χ a) = χ⁻¹ a, because Dirichlet character values are roots of unity or 0) and conj_stdAddChar (conj of the standard additive character equals its inverse, because stdAddChar a = ↑(toCircle a) lies on the unit circle, via Circle.coe_inv_eq_conj and AddChar.map_neg_eq_inv). Crucially this step holds for every modulus, not just primes — it is deliberately proved in that generality so that only gaussSum_mul_conj carries the prime restriction.",
     "mathContext": "$\\overline{\\chi(a)} = \\chi^{-1}(a)$ and $\\overline{\\psi(a)} = \\psi(-a) = \\psi^{-1}(a)$; summing termwise, $\\overline{\\tau(\\chi)} = \\sum_a \\chi^{-1}(a)\\psi^{-1}(a) = \\mathrm{gaussSum}\\,\\chi^{-1}\\,\\psi^{-1}$.",
@@ -49,6 +52,7 @@
       "endLine": 135
     },
     "type": "insight",
+    "title": "Verified, not axiomatized: extracting |τ(χ)| = √p under #print axioms discipline",
     "significance": "supporting",
     "content": "Unlike the sibling catalog OQ04-OQ02 (which is axiomatized, badge 'axiom', 7 axioms including native_decide's Lean.ofReduceBool), this file is fully verified: #print axioms reports only propext, Classical.choice, Quot.sound for every credited theorem — no sorryAx, no Lean.ofReduceBool. The final norm extraction is a two-line calc: normSq τ(χ) = p (cast from the complex product) then |τ(χ)| = √(normSq τ(χ)) = √p via Complex.norm_def. gaussSum_ne_zero falls out as a corollary since √p > 0. This is a genuine axiom-to-theorem conversion of the prime part of gaussSumBound.",
     "mathContext": "$z\\overline{z} = \\mathrm{normSq}(z)$ as a real number, and $\\|z\\| = \\sqrt{\\mathrm{normSq}(z)}$; with $\\mathrm{normSq}(\\tau(\\chi)) = p$ this yields $\\|\\tau(\\chi)\\| = \\sqrt{p}$.",


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-04-oq-03` (0 prior passes).

**Gap addressed:** all 4 annotations had rich `content`/`mathContext`/`significance`/`relatedConcepts`/`prerequisites` but **no `title` field**, so they rendered without headers. Added a concise, accurate title to each, tracing the argument: OQ-03 framing → the modulus-agnostic conjugation identity → the `[Field]`/prime crux → the verified (not axiomatized) √p extraction.

meta.json was already comprehensive (5 keyInsights, full conclusion with 3 openQuestions, 3 crossReferences, ~12 KB — under cap); no changes there.

Verified with `pnpm build` (✓ built).