### PR TITLE
research(alternating-series-boole-summation-oq-01): Boole identity at the limit m→∞ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AlternatingSeriesBooleSummationOQ01.lean
+++ b/proofs/Proofs/AlternatingSeriesBooleSummationOQ01.lean
@@ -1,0 +1,163 @@
+/-
+# Alternating-Series Boole Summation — OQ-01
+## Passing the finite Boole identity to the limit `m → ∞`
+
+The parent entry `AlternatingSeriesBooleSummation.lean` proves the exact **finite** Boole
+summation identity
+
+  `altSum a n m = ½·((-1)^n a_n - (-1)^m a_m) - ½·altSum (Δa) n m`   (`boole_first`),
+
+where `altSum a n m = ∑_{j=n}^{m-1} (-1)^j a_j` and `Δa_j = a_{j+1} - a_j`, valid on every
+finite window `n ≤ m` with no convergence assumed.  Its first open question asks whether
+letting `m → ∞` for a convergent alternating series gives a clean *limit-level* statement
+tying the finite engine to Mathlib's notion of convergence.
+
+This file answers that.  For a null sequence `a → 0`, the endpoint term `(-1)^m a_m → 0`
+(`sign_mul_tendsto_zero`), so passing `boole_first` to the limit shows:
+
+* if the alternating series converges, `altSum a n m → S`, then the **forward-difference
+  alternating series converges too**, to `(-1)^n a_n - 2S` (`fdiff_altSum_tendsto`); and
+* the two limits obey the limit form of Boole's identity,
+  `S = ½·(-1)^n a_n - ½·T`   (`boole_tendsto`).
+
+Combined with Mathlib's alternating-series test (`Antitone.tendsto_alternating_series_of_
+tendsto_zero`) we get an unconditional statement for antitone null sequences: every tail
+converges (`altSum_tendsto_of_antitone`) and its forward-difference series converges to the
+Boole value (`boole_tendsto_of_antitone`).
+
+**A deliberate subtlety.**  The correct limit object here is the limit of the *partial sums*
+`altSum a n m` as `m → ∞`, i.e. `Filter.Tendsto`, **not** `HasSum`/`∑'`.  An alternating
+series such as `∑ (-1)^j / (j+1)` converges conditionally but is not summable, so `HasSum`
+(unconditional net convergence) genuinely fails; there is no honest `tsum`-level restatement.
+That is why every result below is phrased with `Tendsto … atTop`.
+
+All results are over `ℝ` and axiom-free.
+-/
+
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecificLimits.Normed
+
+namespace AlternatingSeriesBooleSummationOQ01
+
+open Finset Filter Topology
+
+/-- The forward difference `Δa_j = a_{j+1} - a_j` (as in the parent file). -/
+def fdiff (a : ℕ → ℝ) (j : ℕ) : ℝ := a (j + 1) - a j
+
+/-- The alternating partial sum `∑_{j=n}^{m-1} (-1)^j a_j` (as in the parent file). -/
+def altSum (a : ℕ → ℝ) (n m : ℕ) : ℝ := ∑ j ∈ Finset.Ico n m, (-1 : ℝ) ^ j * a j
+
+/-! ## The finite engine (restated for self-containment) -/
+
+theorem altSum_succ (a : ℕ → ℝ) {n m : ℕ} (h : n ≤ m) :
+    altSum a n (m + 1) = altSum a n m + (-1 : ℝ) ^ m * a m := by
+  simp only [altSum]
+  rw [Finset.sum_Ico_succ_top h]
+
+/-- **First-order Boole summation formula** (parent `boole_first`). -/
+theorem boole_first (a : ℕ → ℝ) (n m : ℕ) (h : n ≤ m) :
+    altSum a n m
+      = (1 / 2) * ((-1 : ℝ) ^ n * a n - (-1 : ℝ) ^ m * a m)
+        - (1 / 2) * altSum (fdiff a) n m := by
+  induction m, h using Nat.le_induction with
+  | base => simp only [altSum, Finset.Ico_self, Finset.sum_empty]; ring
+  | succ k hk ih =>
+    rw [altSum_succ a hk, altSum_succ (fdiff a) hk, ih, fdiff, pow_succ]
+    ring
+
+/-- Consecutive-window additivity: `altSum a 0 n + altSum a n m = altSum a 0 m` for `n ≤ m`. -/
+theorem altSum_zero_add (a : ℕ → ℝ) {n m : ℕ} (h : n ≤ m) :
+    altSum a 0 n + altSum a n m = altSum a 0 m := by
+  simp only [altSum]
+  rw [Finset.sum_Ico_consecutive _ (Nat.zero_le n) h]
+
+/-! ## The endpoint term vanishes -/
+
+/-- The absolute value of the signed term is just `|a m|`. -/
+theorem abs_sign_mul (a : ℕ → ℝ) (m : ℕ) : |(-1 : ℝ) ^ m * a m| = |a m| := by
+  rw [abs_mul, abs_pow, abs_neg, abs_one, one_pow, one_mul]
+
+/-- For a null sequence, the alternating endpoint term `(-1)^m a_m` tends to `0`. -/
+theorem sign_mul_tendsto_zero {a : ℕ → ℝ} (ha0 : Tendsto a atTop (𝓝 0)) :
+    Tendsto (fun m => (-1 : ℝ) ^ m * a m) atTop (𝓝 0) := by
+  have hupper : Tendsto (fun m => |a m|) atTop (𝓝 0) := by
+    simpa using ha0.abs
+  have hlower : Tendsto (fun m => -|a m|) atTop (𝓝 0) := by
+    simpa using hupper.neg
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le hlower hupper (fun m => ?_) (fun m => ?_)
+  · have := neg_abs_le ((-1 : ℝ) ^ m * a m)
+    rwa [abs_sign_mul a m] at this
+  · have := le_abs_self ((-1 : ℝ) ^ m * a m)
+    rwa [abs_sign_mul a m] at this
+
+/-! ## Passing Boole's identity to the limit -/
+
+/-- **Limit of the forward-difference alternating series.**  If `a → 0` and the alternating
+series converges (`altSum a n m → S` as `m → ∞`), then the *forward-difference* alternating
+series converges as well, and its limit is `(-1)^n a_n - 2S`. -/
+theorem fdiff_altSum_tendsto {a : ℕ → ℝ} {n : ℕ} {S : ℝ}
+    (ha0 : Tendsto a atTop (𝓝 0))
+    (hS : Tendsto (fun m => altSum a n m) atTop (𝓝 S)) :
+    Tendsto (fun m => altSum (fdiff a) n m) atTop (𝓝 ((-1 : ℝ) ^ n * a n - 2 * S)) := by
+  -- From `boole_first`, `altSum (Δa) n m = (-1)^n a_n - (-1)^m a_m - 2·altSum a n m` for `m ≥ n`.
+  have heq : (fun m => altSum (fdiff a) n m)
+      =ᶠ[atTop] (fun m => ((-1 : ℝ) ^ n * a n - (-1 : ℝ) ^ m * a m) - 2 * altSum a n m) := by
+    filter_upwards [eventually_ge_atTop n] with m hm
+    have := boole_first a n m hm
+    -- solve the identity for `altSum (Δa) n m`
+    linarith [this]
+  rw [tendsto_congr' heq]
+  have hend : Tendsto (fun m => (-1 : ℝ) ^ n * a n - (-1 : ℝ) ^ m * a m) atTop
+      (𝓝 ((-1 : ℝ) ^ n * a n - 0)) :=
+    tendsto_const_nhds.sub (sign_mul_tendsto_zero ha0)
+  have := hend.sub (hS.const_mul 2)
+  simpa using this
+
+/-- **Limit form of Boole's identity.**  If `a → 0`, the alternating series converges to `S`
+and the forward-difference alternating series converges to `T`, then `S = ½·(-1)^n a_n - ½·T`.
+This is exactly the parent's `boole_first` after `m → ∞`. -/
+theorem boole_tendsto {a : ℕ → ℝ} {n : ℕ} {S T : ℝ}
+    (ha0 : Tendsto a atTop (𝓝 0))
+    (hS : Tendsto (fun m => altSum a n m) atTop (𝓝 S))
+    (hT : Tendsto (fun m => altSum (fdiff a) n m) atTop (𝓝 T)) :
+    S = (1 / 2) * ((-1 : ℝ) ^ n * a n) - (1 / 2) * T := by
+  have hT' := fdiff_altSum_tendsto ha0 hS
+  have : T = (-1 : ℝ) ^ n * a n - 2 * S := tendsto_nhds_unique hT hT'
+  rw [this]; ring
+
+/-! ## Unconditional version for antitone null sequences (via the alternating-series test) -/
+
+/-- Every tail of an antitone null sequence's alternating series converges.  From Mathlib's
+alternating-series test applied to the full series, then the consecutive-window identity. -/
+theorem altSum_tendsto_of_antitone {a : ℕ → ℝ} (ha : Antitone a)
+    (ha0 : Tendsto a atTop (𝓝 0)) (n : ℕ) :
+    ∃ S, Tendsto (fun m => altSum a n m) atTop (𝓝 S) := by
+  obtain ⟨L, hL⟩ := ha.tendsto_alternating_series_of_tendsto_zero ha0
+  -- `hL : Tendsto (fun m => ∑ i ∈ range m, (-1)^i * a i) atTop (𝓝 L)`, i.e. `altSum a 0 m → L`.
+  have hL' : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L) := by
+    refine hL.congr (fun m => ?_)
+    rw [altSum, Finset.range_eq_Ico]
+  refine ⟨L - altSum a 0 n, ?_⟩
+  have heq : (fun m => altSum a n m) =ᶠ[atTop]
+      (fun m => altSum a 0 m - altSum a 0 n) := by
+    filter_upwards [eventually_ge_atTop n] with m hm
+    have := altSum_zero_add a hm
+    linarith [this]
+  rw [tendsto_congr' heq]
+  exact hL'.sub_const _
+
+/-- **Boole's identity at the limit, unconditionally, for antitone null sequences.**  The
+forward-difference alternating series converges to the Boole value `(-1)^n a_n - 2S`, where
+`S` is the sum of the alternating series from `n`. -/
+theorem boole_tendsto_of_antitone {a : ℕ → ℝ} (ha : Antitone a)
+    (ha0 : Tendsto a atTop (𝓝 0)) (n : ℕ) :
+    ∃ S, Tendsto (fun m => altSum a n m) atTop (𝓝 S) ∧
+      Tendsto (fun m => altSum (fdiff a) n m) atTop (𝓝 ((-1 : ℝ) ^ n * a n - 2 * S)) := by
+  obtain ⟨S, hS⟩ := altSum_tendsto_of_antitone ha ha0 n
+  exact ⟨S, hS, fdiff_altSum_tendsto ha0 hS⟩
+
+#check @fdiff_altSum_tendsto
+#check @boole_tendsto
+#check @boole_tendsto_of_antitone
+
+end AlternatingSeriesBooleSummationOQ01

--- a/src/data/proofs/alternating-series-boole-summation-oq-01/annotations.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header-asbsoq01",
+    "proofId": "alternating-series-boole-summation-oq-01",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "concept",
+    "title": "Passing the finite Boole identity to the limit",
+    "content": "The parent entry proves the exact finite Boole summation identity boole_first on every window n ≤ m, with no convergence assumed. Its first open question asks for the limit-level statement obtained as m → ∞ for a convergent alternating series. This file answers it: for a null sequence a → 0 the signed endpoint term (-1)^m a_m vanishes, so boole_first passes to the limit, giving the convergence of the forward-difference alternating series and the limit form of Boole's identity — unconditionally for antitone null sequences. Crucially, the correct convergence object is Filter.Tendsto of the partial sums, not HasSum/∑', since alternating series are only conditionally convergent.",
+    "mathContext": "$\\operatorname{altSum}(a,n,m)=\\sum_{j=n}^{m-1}(-1)^j a_j$, $\\Delta a_j=a_{j+1}-a_j$; boole_first: $\\operatorname{altSum}(a,n,m)=\\tfrac12((-1)^n a_n-(-1)^m a_m)-\\tfrac12\\operatorname{altSum}(\\Delta a,n,m)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Boole summation", "Euler–Maclaurin", "alternating series", "conditional convergence", "Filter.Tendsto"],
+    "prerequisites": ["alternating series", "limits of sequences"]
+  },
+  {
+    "id": "ann-definitions-asbsoq01",
+    "proofId": "alternating-series-boole-summation-oq-01",
+    "range": { "startLine": 45, "endLine": 48 },
+    "type": "definition",
+    "title": "Forward difference and alternating partial sum",
+    "content": "`fdiff a j = a(j+1) − a j` is the forward difference Δa, and `altSum a n m = ∑_{j ∈ [n,m)} (-1)^j a_j` is the alternating partial sum over the half-open window [n,m). Both are copied verbatim from the parent file so this entry stands alone.",
+    "mathContext": "$\\Delta a_j = a_{j+1}-a_j$ and $\\operatorname{altSum}(a,n,m)=\\sum_{j\\in\\mathrm{Ico}(n,m)}(-1)^j a_j$.",
+    "significance": "supporting",
+    "relatedConcepts": ["forward difference", "finite differences", "alternating sum"],
+    "prerequisites": ["finite sums over intervals"]
+  },
+  {
+    "id": "ann-finite-engine-asbsoq01",
+    "proofId": "alternating-series-boole-summation-oq-01",
+    "range": { "startLine": 50, "endLine": 72 },
+    "type": "tactic",
+    "title": "The finite engine: recurrence, Boole identity, window additivity",
+    "content": "`altSum_succ` extends the window by one top index. `boole_first` re-proves the parent's first-order Boole identity by Nat.le_induction (base: empty window; step: expand both sides and ring). `altSum_zero_add` glues consecutive windows, altSum a 0 n + altSum a n m = altSum a 0 m, via Finset.sum_Ico_consecutive — the bridge that transfers convergence of the full series to every tail.",
+    "mathContext": "$\\operatorname{altSum}(a,0,n)+\\operatorname{altSum}(a,n,m)=\\operatorname{altSum}(a,0,m)$ for $n\\le m$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.le_induction", "Finset.sum_Ico_consecutive", "Finset.sum_Ico_succ_top"],
+    "prerequisites": ["induction on natural numbers", "sums over intervals"]
+  },
+  {
+    "id": "ann-endpoint-asbsoq01",
+    "proofId": "alternating-series-boole-summation-oq-01",
+    "range": { "startLine": 74, "endLine": 91 },
+    "type": "tactic",
+    "title": "The signed endpoint term vanishes",
+    "content": "`abs_sign_mul` shows |(-1)^m a_m| = |a_m| (the sign has modulus 1). `sign_mul_tendsto_zero` then concludes (-1)^m a_m → 0 for a null sequence by the squeeze theorem, sandwiching the term between −|a_m| and |a_m|, both of which tend to 0 (from a → 0 via Tendsto.abs / .neg). This single analytic fact is all that is needed to pass Boole's finite identity to the limit.",
+    "mathContext": "$-|a_m| \\le (-1)^m a_m \\le |a_m|$ and $|a_m|\\to 0$, hence $(-1)^m a_m\\to 0$.",
+    "significance": "key",
+    "relatedConcepts": ["squeeze theorem", "tendsto_of_tendsto_of_tendsto_of_le_of_le", "Tendsto.abs", "absolute value"],
+    "prerequisites": ["squeeze theorem", "limits and absolute values"]
+  },
+  {
+    "id": "ann-limit-passage-asbsoq01",
+    "proofId": "alternating-series-boole-summation-oq-01",
+    "range": { "startLine": 93, "endLine": 126 },
+    "type": "insight",
+    "title": "Boole's identity at the limit",
+    "content": "`fdiff_altSum_tendsto` is the heart: rearranging boole_first gives altSum(Δa) n m = (-1)^n a_n − (-1)^m a_m − 2·altSum a n m (holding eventually, for m ≥ n, via filter_upwards + linarith), so if a → 0 and altSum a n m → S then the forward-difference alternating series converges to (-1)^n a_n − 2S — no separate convergence test on Δa is needed. `boole_tendsto` then reads off the limit form S = ½(-1)^n a_n − ½T by uniqueness of limits (tendsto_nhds_unique) and ring.",
+    "mathContext": "$\\lim_m\\operatorname{altSum}(\\Delta a,n,m)=(-1)^n a_n-2S$; equivalently $S=\\tfrac12(-1)^n a_n-\\tfrac12 T$.",
+    "significance": "key",
+    "relatedConcepts": ["tendsto_congr'", "Filter.Tendsto.sub", "Tendsto.const_mul", "tendsto_nhds_unique", "eventually_ge_atTop"],
+    "prerequisites": ["algebra of limits", "eventual equality of sequences"]
+  },
+  {
+    "id": "ann-antitone-asbsoq01",
+    "proofId": "alternating-series-boole-summation-oq-01",
+    "range": { "startLine": 128, "endLine": 162 },
+    "type": "insight",
+    "title": "Unconditional version for antitone null sequences",
+    "content": "`altSum_tendsto_of_antitone` discharges the convergence hypothesis: Mathlib's alternating-series test Antitone.tendsto_alternating_series_of_tendsto_zero gives convergence of the full series altSum a 0 m, and the window identity altSum_zero_add transfers it to every tail altSum a n m. `boole_tendsto_of_antitone` packages this with fdiff_altSum_tendsto: for any antitone null sequence, the forward-difference alternating series converges to the Boole value (-1)^n a_n − 2S. This is the fully unconditional, Mathlib-grounded answer to the parent's OQ-01.",
+    "mathContext": "Antitone $a$ with $a\\to 0$: $\\exists S,\\ \\operatorname{altSum}(a,n,\\cdot)\\to S \\wedge \\operatorname{altSum}(\\Delta a,n,\\cdot)\\to (-1)^n a_n-2S$.",
+    "significance": "key",
+    "relatedConcepts": ["alternating-series test", "Antitone.tendsto_alternating_series_of_tendsto_zero", "Tendsto.sub_const", "tail of a series"],
+    "prerequisites": ["alternating-series test", "monotone convergence"]
+  }
+]

--- a/src/data/proofs/alternating-series-boole-summation-oq-01/index.ts
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AlternatingSeriesBooleSummationOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const alternatingSeriesBooleSummationOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const alternatingSeriesBooleSummationOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const alternatingSeriesBooleSummationOq01Data: ProofData = {
+  proof: alternatingSeriesBooleSummationOq01Proof,
+  annotations: alternatingSeriesBooleSummationOq01Annotations,
+}

--- a/src/data/proofs/alternating-series-boole-summation-oq-01/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "alternating-series-boole-summation-oq-01",
+  "title": "Boole Summation at the Limit m→∞ (Alternating-Series Boole OQ-01)",
+  "slug": "alternating-series-boole-summation-oq-01",
+  "description": "Answers open question OQ-01 of the parent finite Boole summation entry: passing the exact finite identity boole_first to the limit m→∞. For a null sequence a→0 the alternating endpoint term (-1)^m a_m vanishes, so if the alternating series converges (altSum a n m → S) then the forward-difference alternating series converges as well, to (-1)^n a_n − 2S, and the two limits obey the limit form of Boole's identity S = ½(-1)^n a_n − ½T. Combined with Mathlib's alternating-series test this is unconditional for antitone null sequences. Deliberately phrased with Filter.Tendsto rather than HasSum/tsum, because conditionally convergent alternating series are not summable. Fully machine-checked, 0 axioms.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Boole_summation",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlternatingSeriesBooleSummationOQ01.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "alternating-series",
+      "boole-summation",
+      "euler-maclaurin",
+      "limits",
+      "convergence"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 163,
+    "assumptions": "None. Fully machine-checked: 0 axiom declarations, 0 sorries, no native_decide. All theorems depend only on the standard foundational axioms (propext, Classical.choice, Quot.sound), confirmed by #print axioms. Uses Mathlib's alternating-series test Antitone.tendsto_alternating_series_of_tendsto_zero.",
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Boole summation is the alternating-series analogue of the Euler–Maclaurin formula: it expresses an alternating partial sum through boundary terms in the forward differences of the summand, with the Euler/Boole weights (-1)^k/2^{k+1}. The parent entry formalizes the exact finite engine on every window n ≤ m, with no convergence assumed. The classical use of Boole summation, however, is asymptotic — one lets the window grow and reads off the value and the remainder of a convergent alternating series. This entry supplies exactly that limit passage.",
+    "problemStatement": "Parent OQ-01 asks: does letting m→∞ in the finite Boole identity boole_first give a clean limit-level statement tying the finite engine to Mathlib's notion of convergence? Here altSum a n m = ∑_{j=n}^{m-1} (-1)^j a_j and Δa_j = a_{j+1}−a_j.",
+    "text": "For a null sequence a→0, passes the finite first-order Boole identity to the limit m→∞. The endpoint term (-1)^m a_m tends to 0, so a convergent alternating series (altSum a n m → S) forces the forward-difference alternating series to converge to (-1)^n a_n − 2S, and the limits satisfy S = ½(-1)^n a_n − ½T. An unconditional corollary for antitone null sequences follows from Mathlib's alternating-series test.",
+    "proofStrategy": "(1) abs_sign_mul: |(-1)^m a_m| = |a_m|, so (2) sign_mul_tendsto_zero: the endpoint term is squeezed to 0 between ±|a_m| (tendsto_of_tendsto_of_tendsto_of_le_of_le). (3) fdiff_altSum_tendsto: rearrange boole_first to altSum(Δa) n m = (-1)^n a_n − (-1)^m a_m − 2·altSum a n m (holds eventually, for m ≥ n, via filter_upwards + linarith), then take limits with Tendsto.sub / Tendsto.const_mul, using tendsto_congr' on the eventual equality. (4) boole_tendsto: uniqueness of limits (tendsto_nhds_unique) pins T = (-1)^n a_n − 2S, then ring. (5) altSum_tendsto_of_antitone: Mathlib's Antitone.tendsto_alternating_series_of_tendsto_zero gives convergence of altSum a 0 m; the consecutive-window identity altSum a 0 n + altSum a n m = altSum a 0 m transfers it to every tail. (6) boole_tendsto_of_antitone packages (5)+(3).",
+    "keyInsights": [
+      "**Endpoint vanishes**: for a→0 the signed boundary term (-1)^m a_m → 0 because its absolute value is exactly |a_m|; this is the only analytic input needed to pass boole_first to the limit.",
+      "**Forward-difference series converges for free**: one does not need a separate convergence test on Δa — boole_first expresses altSum(Δa) as a linear combination of the (convergent) alternating sum and the (vanishing) endpoint, so its limit exists and equals (-1)^n a_n − 2S.",
+      "**Limit form of Boole's identity**: S = ½(-1)^n a_n − ½T is the m→∞ shadow of the finite identity, connecting the finite engine to genuine convergence.",
+      "**Tendsto, not tsum**: the correct object is the limit of partial sums, not HasSum/∑'. A conditionally convergent alternating series (e.g. ∑(-1)^j/(j+1)) is not summable, so HasSum genuinely fails; every statement is phrased with Filter.Tendsto to stay honest.",
+      "**Unconditional for antitone null sequences**: Mathlib's alternating-series test discharges the convergence hypothesis, and the consecutive-window identity moves it from the full series to every tail."
+    ],
+    "prerequisites": [
+      "Alternating series and conditional convergence",
+      "Boole / Euler–Maclaurin summation (finite form)",
+      "Filter.Tendsto and limits of sequences",
+      "The squeeze theorem and uniqueness of limits",
+      "Mathlib's alternating-series test"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Header and Overview",
+      "summary": "States OQ-01 — passing the finite Boole identity boole_first to the limit m→∞ — and the plan: the endpoint term vanishes for a null sequence, giving the convergence of the forward-difference series and the limit form of Boole's identity, unconditionally for antitone null sequences. Flags the deliberate use of Tendsto (not HasSum/tsum) since alternating series are only conditionally convergent.",
+      "startLine": 1,
+      "endLine": 35,
+      "mathContext": "boole_first: altSum a n m = ½((-1)^n a_n − (-1)^m a_m) − ½ altSum(Δa) n m; goal is its m→∞ limit."
+    },
+    {
+      "id": "definitions",
+      "title": "Definitions (restated from parent)",
+      "summary": "`fdiff a j = a(j+1) − a j` (forward difference Δa) and `altSum a n m = ∑_{j∈[n,m)} (-1)^j a_j` (alternating partial sum), copied from the parent file so the entry is self-contained.",
+      "startLine": 45,
+      "endLine": 48,
+      "mathContext": "$\\Delta a_j = a_{j+1}-a_j$, $\\operatorname{altSum}(a,n,m)=\\sum_{j=n}^{m-1}(-1)^j a_j$."
+    },
+    {
+      "id": "finite-engine",
+      "title": "The finite engine (restated)",
+      "summary": "`altSum_succ` (one-step recurrence), `boole_first` (the first-order finite Boole identity, re-proved by Nat.le_induction), and `altSum_zero_add` (consecutive-window additivity altSum a 0 n + altSum a n m = altSum a 0 m via Finset.sum_Ico_consecutive).",
+      "startLine": 50,
+      "endLine": 72,
+      "mathContext": "Finite identity valid on every window $n\\le m$; window additivity glues $[0,n)$ and $[n,m)$."
+    },
+    {
+      "id": "endpoint-vanishes",
+      "title": "The endpoint term vanishes",
+      "summary": "`abs_sign_mul`: |(-1)^m a_m| = |a_m|. `sign_mul_tendsto_zero`: for a→0 the boundary term (-1)^m a_m → 0, proved by squeezing between −|a_m| and |a_m| (tendsto_of_tendsto_of_tendsto_of_le_of_le).",
+      "startLine": 74,
+      "endLine": 91,
+      "mathContext": "$|(-1)^m a_m| = |a_m|\\to 0$, so $(-1)^m a_m \\to 0$ by the squeeze theorem."
+    },
+    {
+      "id": "limit-passage",
+      "title": "Passing Boole's identity to the limit",
+      "summary": "`fdiff_altSum_tendsto`: if a→0 and altSum a n m → S then altSum(Δa) n m → (-1)^n a_n − 2S (rearrange boole_first, then Tendsto.sub / const_mul on the eventual equality). `boole_tendsto`: given both limits, S = ½(-1)^n a_n − ½T, by uniqueness of limits.",
+      "startLine": 93,
+      "endLine": 126,
+      "mathContext": "$\\lim_m \\operatorname{altSum}(\\Delta a,n,m) = (-1)^n a_n - 2S$ and $S = \\tfrac12(-1)^n a_n - \\tfrac12 T$."
+    },
+    {
+      "id": "antitone-unconditional",
+      "title": "Unconditional version for antitone null sequences",
+      "summary": "`altSum_tendsto_of_antitone`: every tail of an antitone null sequence's alternating series converges (Mathlib's alternating-series test on the full series + the window identity). `boole_tendsto_of_antitone`: packages this with the limit passage — the forward-difference series converges to the Boole value (-1)^n a_n − 2S.",
+      "startLine": 128,
+      "endLine": 162,
+      "mathContext": "Antitone $a$, $a\\to 0$ $\\Rightarrow$ $\\exists S$, tail $\\to S$ and $\\operatorname{altSum}(\\Delta a,n,\\cdot)\\to(-1)^n a_n-2S$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers OQ-01 of the parent finite Boole summation file by carrying the exact identity boole_first to the limit m→∞. The single analytic ingredient is that the signed endpoint term (-1)^m a_m vanishes for a null sequence. From it: a convergent alternating series (altSum a n m → S) forces the forward-difference alternating series to converge to (-1)^n a_n − 2S, and the two limits satisfy the limit form of Boole's identity S = ½(-1)^n a_n − ½T. Mathlib's alternating-series test makes the whole package unconditional for antitone null sequences. Everything is stated with Filter.Tendsto rather than HasSum/∑', because alternating series are only conditionally convergent and hence not summable.",
+    "implications": "Turns the parent's finite Boole engine into a genuine convergence tool: the value of a convergent alternating series and the value of its forward-difference series are linked by an exact rational identity, obtained purely by limit passage with no new analytic estimates. The Tendsto-vs-HasSum distinction is a reusable cautionary example — the natural 'tsum-level' phrasing is unavailable here, and the correct object is the limit of partial sums.",
+    "openQuestions": [
+      "Pass the general order-K identity boole_general to the limit, expressing the remainder of a convergent alternating series through the limits of the K-th forward-difference series and the Boole/Euler weights (-1)^k/2^{k+1}.",
+      "Identify the limit S = ½(-1)^n a_n − ½T with Mathlib's tail-remainder bounds (Antitone.tendsto_le_alternating_series etc.) to obtain sharp two-sided estimates on S.",
+      "Relate the forward-difference limit (-1)^n a_n − 2S to a closed form for concrete families (e.g. a_j = 1/(j+1), the alternating harmonic series with limit related to log 2)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "alternating-series-boole-summation",
+      "relationship": "extends",
+      "description": "Parent: the exact finite Boole summation identity. This OQ-01 passes boole_first to the limit m→∞, answering the parent's first open question."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Boole, G.",
+      "title": "A Treatise on the Calculus of Finite Differences",
+      "year": "1860",
+      "venue": "Macmillan",
+      "note": "Origin of Boole summation, the alternating analogue of Euler–Maclaurin."
+    },
+    {
+      "authors": "The Mathlib Community",
+      "title": "The alternating-series test (Antitone.tendsto_alternating_series_of_tendsto_zero)",
+      "year": "2024",
+      "venue": "Mathlib.Analysis.SpecificLimits.Normed",
+      "note": "Used to discharge convergence of the alternating series for antitone null sequences."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Analysis.SpecificLimits.Normed"
+    ],
+    "namespace": "AlternatingSeriesBooleSummationOQ01",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "path": "Proofs/AlternatingSeriesBooleSummationOQ01.lean",
+    "sorries": 0,
+    "definitionCount": 2
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **alternating-series-boole-summation-oq-01** — answers **OQ-01** of the parent finite Boole summation entry: *does letting `m → ∞` in the finite identity `boole_first` give a clean limit-level statement tying the finite engine to Mathlib's convergence?*

Yes. For a null sequence `a → 0`, the signed endpoint term `(-1)^m a_m` vanishes, so `boole_first` passes to the limit.

## Results (`Proofs/AlternatingSeriesBooleSummationOQ01.lean`)

| lemma | statement |
|---|---|
| `sign_mul_tendsto_zero` | `a → 0 ⟹ (-1)^m a_m → 0` (squeeze on `\|(-1)^m a_m\| = \|a_m\|`) |
| `fdiff_altSum_tendsto` | if `a → 0` and `altSum a n m → S` then `altSum (Δa) n m → (-1)^n a_n − 2S` |
| `boole_tendsto` | the limits obey `S = ½·(-1)^n a_n − ½·T` |
| `altSum_tendsto_of_antitone` | every tail of an antitone null sequence's alternating series converges |
| `boole_tendsto_of_antitone` | unconditional package: `Δa`-series → `(-1)^n a_n − 2S` |

The forward-difference series converges **for free** — `boole_first` expresses it as a linear combination of the (convergent) alternating sum and the (vanishing) endpoint, so no separate convergence test on `Δa` is needed. The antitone case is discharged with Mathlib's alternating-series test `Antitone.tendsto_alternating_series_of_tendsto_zero` plus the consecutive-window identity.

### A deliberate subtlety

Every statement uses `Filter.Tendsto` of the partial sums, **not** `HasSum`/`∑'`. A conditionally convergent alternating series (e.g. `∑ (-1)^j/(j+1)`) is not summable, so `HasSum` (unconditional net convergence) genuinely fails — there is no honest `tsum`-level restatement. This is called out in the entry.

## Verification

- **0 sorries, 0 axiom declarations.** `#print axioms` on every theorem shows only the standard foundational trio (`propext`, `Classical.choice`, `Quot.sound`) — no `sorryAx`, no `Lean.ofReduceBool`.
- Typechecked with `lake env lean` against Mathlib 4.26.0 (warm cache).
- 9 theorems, 2 definitions, 163 lines. `pnpm annotations:build` passes clean for this entry.

Extends `alternating-series-boole-summation` (parent finite engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)