### PR TITLE
research(isosceles-triangle-oq-02-oq-02): law of sines in spherical & hyperbolic geometry [VERIFIED, 0-axiom, 10thm+2def/223L, new entry]

### DIFF
--- a/proofs/Proofs/IsoscelesTriangleOQ02OQ02.lean
+++ b/proofs/Proofs/IsoscelesTriangleOQ02OQ02.lean
@@ -1,0 +1,223 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+import Mathlib.Tactic
+
+/-!
+# Isosceles triangle OQ-02-OQ-02: the law of sines in hyperbolic and spherical geometry
+
+The parent entry (`isosceles-triangle-oq-02`) proves **Pons Asinorum** in spherical and
+hyperbolic geometry, and its converse (`isosceles-triangle-oq-02-oq-01`) proves the converse,
+both working purely from the *laws of cosines* with no inner product space. Both list as an
+open question:
+
+> *Derive the spherical and hyperbolic laws of sines in the same coordinate-free framework and
+> combine them with these results toward a full non-Euclidean triangle-congruence toolkit.*
+
+This file does so. As in the sibling entries, we take the (ordinary) **law of cosines** as the
+only input — no inner product space, no coordinates. The two laws of cosines are
+
+* spherical:   `cos a = cos b · cos c + sin b · sin c · cos A`,
+* hyperbolic:  `cosh a = cosh b · cosh c − sinh b · sinh c · cos A`,
+
+where `A` is the angle opposite side `a`. From either one we solve for `cos A` and compute
+`sin² A = 1 − cos² A`. The key algebraic miracle is that the resulting product
+
+* spherical:   `(sin A · sin b · sin c)²`,
+* hyperbolic:  `(sin A · sinh b · sinh c)²`,
+
+equals a **fully symmetric** function of the three sides — the *sine discriminant*
+
+* spherical:   `Δ = 1 − cos²a − cos²b − cos²c + 2·cos a·cos b·cos c`,
+* hyperbolic:  `Δ = 1 − cosh²a − cosh²b − cosh²c + 2·cosh a·cosh b·cosh c`,
+
+which is manifestly invariant under permuting `a, b, c`. Comparing the expressions coming from
+angle `A` and angle `B` and cancelling the common factor gives the **law of sines**:
+
+* spherical:   `sin A / sin a = sin B / sin b`,
+* hyperbolic:  `sin A / sinh a = sin B / sinh b`.
+
+The two derivations are *identical* line for line — only `cos ↔ cosh`, `sin ↔ sinh` on the sides
+change. This is exactly the "same coordinate-free framework" the open question asks for.
+
+## Main results
+
+* `sphSineDisc` / `hypSineDisc` : the symmetric sine discriminant `Δ`.
+* `sphSineDisc_symm_ab` / `hypSineDisc_symm_ab` : `Δ` is symmetric in the sides.
+* `sph_sinSq_eq_disc` / `hyp_sinSq_eq_disc` : `(sin A · sin b · sin c)² = Δ` (the core identity).
+* `sph_law_of_sines_sq` / `hyp_law_of_sines_sq` : squared law of sines
+  `(sin A · sin b)² = (sin B · sin a)²`.
+* `sph_law_of_sines` / `hyp_law_of_sines` : the law of sines `sin A / sin a = sin B / sin b`
+  (resp. `sin A / sinh a = sin B / sinh b`) under the usual positivity ranges.
+
+No inner product space and no axioms are used.
+-/
+
+namespace IsoscelesTriangleOQ02OQ02
+
+open Real Set
+
+/-! ## Spherical geometry -/
+
+/-- The **spherical sine discriminant**
+    `Δ = 1 − cos²a − cos²b − cos²c + 2·cos a·cos b·cos c`.
+    This is the symmetric quantity that the law of sines makes visible: it equals
+    `(sin A · sin b · sin c)²` no matter which angle `A` we start from. -/
+noncomputable def sphSineDisc (a b c : ℝ) : ℝ :=
+  1 - cos a ^ 2 - cos b ^ 2 - cos c ^ 2 + 2 * cos a * cos b * cos c
+
+/-- The spherical sine discriminant is symmetric under swapping the first two sides. -/
+theorem sphSineDisc_symm_ab (a b c : ℝ) : sphSineDisc a b c = sphSineDisc b a c := by
+  unfold sphSineDisc; ring
+
+/-- The spherical sine discriminant is symmetric under swapping the last two sides. -/
+theorem sphSineDisc_symm_bc (a b c : ℝ) : sphSineDisc a b c = sphSineDisc a c b := by
+  unfold sphSineDisc; ring
+
+/-- **Core identity (spherical).** From the spherical law of cosines
+    `cos a = cos b · cos c + sin b · sin c · cos A`, the quantity `(sin A · sin b · sin c)²`
+    equals the symmetric sine discriminant `Δ(a, b, c)`.
+
+    The proof uses only the Pythagorean identity `sin² + cos² = 1` on `A`, `b`, `c` and the law
+    of cosines; no division is required, so no nonvanishing hypotheses are needed. -/
+theorem sph_sinSq_eq_disc {a b c A : ℝ}
+    (hA : cos a = cos b * cos c + sin b * sin c * cos A) :
+    (sin A * sin b * sin c) ^ 2 = sphSineDisc a b c := by
+  have pA : sin A ^ 2 = 1 - cos A ^ 2 := by
+    have := sin_sq_add_cos_sq A; linarith
+  have pb : sin b ^ 2 = 1 - cos b ^ 2 := by
+    have := sin_sq_add_cos_sq b; linarith
+  have pc : sin c ^ 2 = 1 - cos c ^ 2 := by
+    have := sin_sq_add_cos_sq c; linarith
+  -- The law of cosines gives `sin b · sin c · cos A = cos a − cos b · cos c`; squaring and
+  -- using `sin² = 1 − cos²` turns `(sin A sin b sin c)²` into the symmetric discriminant.
+  have hcosA : sin b * sin c * cos A = cos a - cos b * cos c := by linarith
+  have hsq : (sin b * sin c * cos A) ^ 2 = (cos a - cos b * cos c) ^ 2 := by rw [hcosA]
+  calc (sin A * sin b * sin c) ^ 2
+      = sin b ^ 2 * sin c ^ 2 * sin A ^ 2 := by ring
+    _ = sin b ^ 2 * sin c ^ 2 * (1 - cos A ^ 2) := by rw [pA]
+    _ = sin b ^ 2 * sin c ^ 2 - (sin b * sin c * cos A) ^ 2 := by ring
+    _ = sin b ^ 2 * sin c ^ 2 - (cos a - cos b * cos c) ^ 2 := by rw [hsq]
+    _ = (1 - cos b ^ 2) * (1 - cos c ^ 2) - (cos a - cos b * cos c) ^ 2 := by rw [pb, pc]
+    _ = sphSineDisc a b c := by unfold sphSineDisc; ring
+
+/-- **Squared law of sines (spherical).** From the spherical laws of cosines for angles `A`
+    and `B` (opposite sides `a` and `b`), the products `sin A · sin b` and `sin B · sin a`
+    have equal squares — provided the third side has `sin c ≠ 0`, so the common factor
+    `sin² c` can be cancelled. -/
+theorem sph_law_of_sines_sq {a b c A B : ℝ}
+    (hA : cos a = cos b * cos c + sin b * sin c * cos A)
+    (hB : cos b = cos a * cos c + sin a * sin c * cos B)
+    (hc : sin c ≠ 0) :
+    (sin A * sin b) ^ 2 = (sin B * sin a) ^ 2 := by
+  have eA : (sin A * sin b * sin c) ^ 2 = sphSineDisc a b c := sph_sinSq_eq_disc hA
+  have eB : (sin B * sin a * sin c) ^ 2 = sphSineDisc b a c := sph_sinSq_eq_disc hB
+  rw [← sphSineDisc_symm_ab] at eB
+  -- both equal `Δ(a,b,c)`; strip the common `sin² c`.
+  have hc2 : sin c ^ 2 ≠ 0 := pow_ne_zero 2 hc
+  have : (sin A * sin b) ^ 2 * sin c ^ 2 = (sin B * sin a) ^ 2 * sin c ^ 2 := by
+    have e : (sin A * sin b) ^ 2 * sin c ^ 2 = (sin A * sin b * sin c) ^ 2 := by ring
+    have e' : (sin B * sin a) ^ 2 * sin c ^ 2 = (sin B * sin a * sin c) ^ 2 := by ring
+    rw [e, e', eA, eB]
+  exact mul_right_cancel₀ hc2 this
+
+/-- **Law of sines, spherical geometry.** In a spherical triangle whose sides `a, b` and angles
+    `A, B, C` satisfy the laws of cosines, with all relevant sines positive (the standard range
+    `0 < ·, · < π` for sides and angles), the ratios of angle-sine to opposite-side-sine agree:
+    `sin A / sin a = sin B / sin b`. No inner product space is used. -/
+theorem sph_law_of_sines {a b c A B : ℝ}
+    (hA : cos a = cos b * cos c + sin b * sin c * cos A)
+    (hB : cos b = cos a * cos c + sin a * sin c * cos B)
+    (ha : 0 < sin a) (hb : 0 < sin b) (hc : 0 < sin c)
+    (hA' : 0 < sin A) (hB' : 0 < sin B) :
+    sin A / sin a = sin B / sin b := by
+  have hsq : (sin A * sin b) ^ 2 = (sin B * sin a) ^ 2 :=
+    sph_law_of_sines_sq hA hB (ne_of_gt hc)
+  -- both bases positive, so equal squares give equal values, then divide.
+  have hpos1 : 0 < sin A * sin b := mul_pos hA' hb
+  have hpos2 : 0 < sin B * sin a := mul_pos hB' ha
+  have heq : sin A * sin b = sin B * sin a := by
+    nlinarith [hsq, hpos1, hpos2, sq_nonneg (sin A * sin b - sin B * sin a)]
+  rw [div_eq_div_iff ha.ne' hb.ne']
+  linarith [heq]
+
+/-! ## Hyperbolic geometry
+
+The derivation is line-for-line identical to the spherical one, with `cos ↔ cosh` and
+`sin ↔ sinh` on the *sides* (angles stay ordinary `cos`/`sin`). The discriminant flips the sign
+convention through `sinh² = cosh² − 1`, but comes out with the same symmetric shape. -/
+
+/-- The **hyperbolic sine discriminant**
+    `Δ = 1 − cosh²a − cosh²b − cosh²c + 2·cosh a·cosh b·cosh c`. -/
+noncomputable def hypSineDisc (a b c : ℝ) : ℝ :=
+  1 - cosh a ^ 2 - cosh b ^ 2 - cosh c ^ 2 + 2 * cosh a * cosh b * cosh c
+
+/-- The hyperbolic sine discriminant is symmetric under swapping the first two sides. -/
+theorem hypSineDisc_symm_ab (a b c : ℝ) : hypSineDisc a b c = hypSineDisc b a c := by
+  unfold hypSineDisc; ring
+
+/-- The hyperbolic sine discriminant is symmetric under swapping the last two sides. -/
+theorem hypSineDisc_symm_bc (a b c : ℝ) : hypSineDisc a b c = hypSineDisc a c b := by
+  unfold hypSineDisc; ring
+
+/-- **Core identity (hyperbolic).** From the hyperbolic law of cosines
+    `cosh a = cosh b · cosh c − sinh b · sinh c · cos A`, the quantity
+    `(sin A · sinh b · sinh c)²` equals the symmetric hyperbolic sine discriminant `Δ(a, b, c)`.
+
+    Uses `sin² A = 1 − cos² A` for the angle and `sinh² = cosh² − 1` for the sides. -/
+theorem hyp_sinSq_eq_disc {a b c A : ℝ}
+    (hA : cosh a = cosh b * cosh c - sinh b * sinh c * cos A) :
+    (sin A * sinh b * sinh c) ^ 2 = hypSineDisc a b c := by
+  have pA : sin A ^ 2 = 1 - cos A ^ 2 := by
+    have := sin_sq_add_cos_sq A; linarith
+  have pb : sinh b ^ 2 = cosh b ^ 2 - 1 := by
+    have := cosh_sq_sub_sinh_sq b; linarith
+  have pc : sinh c ^ 2 = cosh c ^ 2 - 1 := by
+    have := cosh_sq_sub_sinh_sq c; linarith
+  have hcosA : sinh b * sinh c * cos A = cosh b * cosh c - cosh a := by linarith
+  have hsq : (sinh b * sinh c * cos A) ^ 2 = (cosh b * cosh c - cosh a) ^ 2 := by rw [hcosA]
+  calc (sin A * sinh b * sinh c) ^ 2
+      = sinh b ^ 2 * sinh c ^ 2 * sin A ^ 2 := by ring
+    _ = sinh b ^ 2 * sinh c ^ 2 * (1 - cos A ^ 2) := by rw [pA]
+    _ = sinh b ^ 2 * sinh c ^ 2 - (sinh b * sinh c * cos A) ^ 2 := by ring
+    _ = sinh b ^ 2 * sinh c ^ 2 - (cosh b * cosh c - cosh a) ^ 2 := by rw [hsq]
+    _ = (cosh b ^ 2 - 1) * (cosh c ^ 2 - 1) - (cosh b * cosh c - cosh a) ^ 2 := by rw [pb, pc]
+    _ = hypSineDisc a b c := by unfold hypSineDisc; ring
+
+/-- **Squared law of sines (hyperbolic).** Analogue of `sph_law_of_sines_sq`, cancelling the
+    common factor `sinh² c` (needs `sinh c ≠ 0`, i.e. `c ≠ 0`). -/
+theorem hyp_law_of_sines_sq {a b c A B : ℝ}
+    (hA : cosh a = cosh b * cosh c - sinh b * sinh c * cos A)
+    (hB : cosh b = cosh a * cosh c - sinh a * sinh c * cos B)
+    (hc : sinh c ≠ 0) :
+    (sin A * sinh b) ^ 2 = (sin B * sinh a) ^ 2 := by
+  have eA : (sin A * sinh b * sinh c) ^ 2 = hypSineDisc a b c := hyp_sinSq_eq_disc hA
+  have eB : (sin B * sinh a * sinh c) ^ 2 = hypSineDisc b a c := hyp_sinSq_eq_disc hB
+  rw [← hypSineDisc_symm_ab] at eB
+  have hc2 : sinh c ^ 2 ≠ 0 := pow_ne_zero 2 hc
+  have : (sin A * sinh b) ^ 2 * sinh c ^ 2 = (sin B * sinh a) ^ 2 * sinh c ^ 2 := by
+    have e : (sin A * sinh b) ^ 2 * sinh c ^ 2 = (sin A * sinh b * sinh c) ^ 2 := by ring
+    have e' : (sin B * sinh a) ^ 2 * sinh c ^ 2 = (sin B * sinh a * sinh c) ^ 2 := by ring
+    rw [e, e', eA, eB]
+  exact mul_right_cancel₀ hc2 this
+
+/-- **Law of sines, hyperbolic geometry.** In a hyperbolic triangle whose sides `a, b` and
+    angles `A, B` satisfy the hyperbolic laws of cosines, with positive side-`sinh`s (`a,b,c > 0`)
+    and positive angle-`sin`s, `sin A / sinh a = sin B / sinh b`. No inner product space is used. -/
+theorem hyp_law_of_sines {a b c A B : ℝ}
+    (hA : cosh a = cosh b * cosh c - sinh b * sinh c * cos A)
+    (hB : cosh b = cosh a * cosh c - sinh a * sinh c * cos B)
+    (ha : 0 < sinh a) (hb : 0 < sinh b) (hc : 0 < sinh c)
+    (hA' : 0 < sin A) (hB' : 0 < sin B) :
+    sin A / sinh a = sin B / sinh b := by
+  have hsq : (sin A * sinh b) ^ 2 = (sin B * sinh a) ^ 2 :=
+    hyp_law_of_sines_sq hA hB (ne_of_gt hc)
+  have hpos1 : 0 < sin A * sinh b := mul_pos hA' hb
+  have hpos2 : 0 < sin B * sinh a := mul_pos hB' ha
+  have heq : sin A * sinh b = sin B * sinh a := by
+    nlinarith [hsq, hpos1, hpos2, sq_nonneg (sin A * sinh b - sin B * sinh a)]
+  rw [div_eq_div_iff ha.ne' hb.ne']
+  linarith [heq]
+
+end IsoscelesTriangleOQ02OQ02

--- a/src/data/proofs/isosceles-triangle-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/isosceles-triangle-oq-02-oq-02/annotations.json
@@ -1,0 +1,150 @@
+[
+  {
+    "id": "iso-oq0202-concept",
+    "proofId": "isosceles-triangle-oq-02-oq-02",
+    "range": {
+      "startLine": 7,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "The Law of Sines from the Law of Cosines, Uniformly",
+    "content": "This file derives the **law of sines** in spherical and hyperbolic geometry from the ordinary **law of cosines** alone:\n$$\\cos a = \\cos b\\cos c + \\sin b\\sin c\\cos A\\ (\\text{spherical}),\\qquad \\cosh a = \\cosh b\\cosh c - \\sinh b\\sinh c\\cos A\\ (\\text{hyperbolic}).$$\nSolving for $\\cos A$ and using $\\sin^2A = 1-\\cos^2A$ shows that $(\\sin A\\,\\sin b\\,\\sin c)^2$ (resp. $(\\sin A\\,\\sinh b\\,\\sinh c)^2$) equals a **fully symmetric** sine discriminant\n$$\\Delta = 1 - \\cos^2 a - \\cos^2 b - \\cos^2 c + 2\\cos a\\cos b\\cos c$$\n(resp. with $\\cosh$). Symmetry of $\\Delta$ under permuting the sides is exactly the law of sines $\\sin A/\\sin a = \\sin B/\\sin b$ (resp. $\\sin A/\\sinh a = \\sin B/\\sinh b$).",
+    "mathContext": "Answers the shared open question of isosceles-triangle-oq-02 / -oq-01: derive both non-Euclidean laws of sines in one coordinate-free framework. No inner product space, 0 axioms.",
+    "significance": "key",
+    "prerequisites": [
+      "spherical and hyperbolic laws of cosines",
+      "Pythagorean identities sin²+cos²=1 and cosh²−sinh²=1"
+    ],
+    "relatedConcepts": [
+      "law of sines",
+      "law of cosines",
+      "non-Euclidean geometry",
+      "Cayley–Menger discriminant"
+    ]
+  },
+  {
+    "id": "iso-oq0202-disc",
+    "proofId": "isosceles-triangle-oq-02-oq-02",
+    "range": {
+      "startLine": 61,
+      "endLine": 82
+    },
+    "type": "definition",
+    "title": "The Symmetric Sine Discriminant Δ",
+    "content": "`sphSineDisc a b c` $= 1-\\cos^2a-\\cos^2b-\\cos^2c+2\\cos a\\cos b\\cos c$ (and its $\\cosh$-analogue `hypSineDisc`, further down) is the invariant driving the whole entry. The symmetry lemmas `sphSineDisc_symm_ab` / `sphSineDisc_symm_bc` prove — by a one-line `ring` — that $\\Delta$ is unchanged under any transposition of the sides, hence under any permutation. This permutation invariance is what makes $(\\sin A\\,\\sin b\\,\\sin c)^2 = \\Delta$ into the law of sines.",
+    "mathContext": "Δ is the spherical/hyperbolic Cayley–Menger-type discriminant; its positivity is the non-degeneracy of the triangle and (via l'Huilier) it encodes the area.",
+    "significance": "key",
+    "prerequisites": [
+      "symmetric polynomials"
+    ],
+    "relatedConcepts": [
+      "Cayley–Menger determinant",
+      "symmetric function",
+      "l'Huilier's theorem"
+    ]
+  },
+  {
+    "id": "iso-oq0202-sph-core",
+    "proofId": "isosceles-triangle-oq-02-oq-02",
+    "range": {
+      "startLine": 84,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "Spherical Core Identity (sin A·sin b·sin c)² = Δ (division-free)",
+    "content": "`sph_sinSq_eq_disc` establishes the key identity by a `calc` chain that never divides: from the law of cosines, $\\sin b\\sin c\\cos A = \\cos a-\\cos b\\cos c$, so\n$$(\\sin A\\sin b\\sin c)^2 = \\sin^2b\\,\\sin^2c\\,(1-\\cos^2A) = \\sin^2b\\,\\sin^2c - (\\sin b\\sin c\\cos A)^2 = (1-\\cos^2b)(1-\\cos^2c) - (\\cos a-\\cos b\\cos c)^2 = \\Delta.$$\nBecause no step requires a denominator, the identity holds **unconditionally** — no side needs to be assumed nonzero.",
+    "mathContext": "The value of (sin A·sin b·sin c)² does not depend on which angle A is chosen; that angle-independence is the content of the law of sines.",
+    "significance": "critical",
+    "prerequisites": [
+      "sin²+cos²=1",
+      "polynomial algebra (ring)"
+    ],
+    "relatedConcepts": [
+      "law of cosines",
+      "Pythagorean identity"
+    ]
+  },
+  {
+    "id": "iso-oq0202-sph-sines",
+    "proofId": "isosceles-triangle-oq-02-oq-02",
+    "range": {
+      "startLine": 109,
+      "endLine": 143
+    },
+    "type": "theorem",
+    "title": "Spherical Law of Sines: Cancel the Common Factor",
+    "content": "`sph_law_of_sines_sq` writes the core identity for angles $A$ and $B$ — giving $\\Delta(a,b,c)$ and $\\Delta(b,a,c)$, equal by symmetry — and cancels the shared factor $\\sin^2 c$ (via `mul_right_cancel₀`, needing $\\sin c\\neq 0$) to obtain $(\\sin A\\sin b)^2 = (\\sin B\\sin a)^2$. `sph_law_of_sines` then adds positivity of the sines to pass from equal squares to $\\sin A\\sin b = \\sin B\\sin a$ and finishes with `div_eq_div_iff`, yielding $\\sin A/\\sin a = \\sin B/\\sin b$.",
+    "mathContext": "The nonvanishing and positivity hypotheses are the natural triangle ranges (sides and angles strictly between 0 and π); they enter only here, not in the core identity.",
+    "significance": "key",
+    "prerequisites": [
+      "cancellation of a nonzero factor",
+      "equal squares of positive reals are equal"
+    ],
+    "relatedConcepts": [
+      "law of sines",
+      "spherical geometry"
+    ]
+  },
+  {
+    "id": "iso-oq0202-hyp-disc",
+    "proofId": "isosceles-triangle-oq-02-oq-02",
+    "range": {
+      "startLine": 145,
+      "endLine": 167
+    },
+    "type": "definition",
+    "title": "Hyperbolic Mirror: The cosh-Discriminant",
+    "content": "The hyperbolic block repeats the spherical development verbatim with $\\cos\\to\\cosh$, $\\sin\\to\\sinh$ on the *sides* (angles keep ordinary $\\cos,\\sin$). `hypSineDisc a b c` $= 1-\\cosh^2a-\\cosh^2b-\\cosh^2c+2\\cosh a\\cosh b\\cosh c$ has the identical symmetric shape, and `hypSineDisc_symm_ab` / `_bc` record its permutation symmetry by `ring`.",
+    "mathContext": "Demonstrates the 'same coordinate-free framework' the open question asked for: one algebraic engine, two geometries.",
+    "significance": "key",
+    "prerequisites": [
+      "cosh²−sinh²=1"
+    ],
+    "relatedConcepts": [
+      "hyperbolic geometry",
+      "sphere–hyperbolic duality"
+    ]
+  },
+  {
+    "id": "iso-oq0202-hyp-core",
+    "proofId": "isosceles-triangle-oq-02-oq-02",
+    "range": {
+      "startLine": 169,
+      "endLine": 188
+    },
+    "type": "theorem",
+    "title": "Hyperbolic Core Identity (sin A·sinh b·sinh c)² = Δ",
+    "content": "`hyp_sinSq_eq_disc` proves $(\\sin A\\,\\sinh b\\,\\sinh c)^2 = \\Delta$ by the same division-free `calc` as the spherical case; the only algebraic change is the sign convention $\\sinh^2 = \\cosh^2-1$ replacing $\\sin^2 = 1-\\cos^2$, which leaves $\\Delta$ symmetric.",
+    "mathContext": "The hyperbolic mirror of the spherical core identity; holds unconditionally (no nonvanishing hypotheses).",
+    "significance": "critical",
+    "prerequisites": [
+      "cosh²−sinh²=1",
+      "polynomial algebra (ring)"
+    ],
+    "relatedConcepts": [
+      "law of cosines",
+      "hyperbolic geometry"
+    ]
+  },
+  {
+    "id": "iso-oq0202-hyp-sines",
+    "proofId": "isosceles-triangle-oq-02-oq-02",
+    "range": {
+      "startLine": 190,
+      "endLine": 222
+    },
+    "type": "theorem",
+    "title": "Hyperbolic Law of Sines",
+    "content": "`hyp_law_of_sines_sq` cancels the common $\\sinh^2 c$ to give $(\\sin A\\sinh b)^2 = (\\sin B\\sinh a)^2$, and `hyp_law_of_sines` adds positivity of the side-$\\sinh$s and angle-$\\sin$s to conclude $\\sin A/\\sinh a = \\sin B/\\sinh b$ — the hyperbolic law of sines, proved line-for-line as in the spherical case.",
+    "mathContext": "Completes the unified derivation; together with the parent Pons Asinorum and its converse, the non-Euclidean congruence toolkit now has its sine law.",
+    "significance": "key",
+    "prerequisites": [
+      "cancellation of a nonzero factor",
+      "positivity of sinh on (0,∞)"
+    ],
+    "relatedConcepts": [
+      "law of sines",
+      "hyperbolic geometry"
+    ]
+  }
+]

--- a/src/data/proofs/isosceles-triangle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/isosceles-triangle-oq-02-oq-02/meta.json
@@ -1,0 +1,255 @@
+{
+  "id": "isosceles-triangle-oq-02-oq-02",
+  "title": "The Law of Sines in Hyperbolic and Spherical Geometry",
+  "slug": "isosceles-triangle-oq-02-oq-02",
+  "description": "The parent (isosceles-triangle-oq-02) proves Pons Asinorum in spherical and hyperbolic geometry from the laws of cosines, and its sibling (isosceles-triangle-oq-02-oq-01) proves the converse; both list 'derive the spherical and hyperbolic laws of sines in the same coordinate-free framework' as an open question. This entry answers it. Taking only the ordinary law of cosines as input (cos a = cos b·cos c + sin b·sin c·cos A spherically, cosh a = cosh b·cosh c − sinh b·sinh c·cos A hyperbolically), it solves for cos A, computes sin²A = 1 − cos²A, and shows the product (sin A·sin b·sin c)² — resp. (sin A·sinh b·sinh c)² — equals a fully symmetric 'sine discriminant' Δ = 1 − cos²a − cos²b − cos²c + 2·cos a·cos b·cos c (resp. with cosh). Symmetry of Δ under permuting the sides gives the law of sines sin A/sin a = sin B/sin b (resp. sin A/sinh a = sin B/sinh b). The spherical and hyperbolic derivations are identical line-for-line under cos↔cosh, sin↔sinh on the sides. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "classical (spherical/hyperbolic trigonometry)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/IsoscelesTriangleOQ02OQ02.lean",
+    "badge": "original",
+    "tags": [
+      "geometry",
+      "non-euclidean",
+      "spherical-geometry",
+      "hyperbolic-geometry",
+      "law-of-sines",
+      "law-of-cosines",
+      "trigonometry",
+      "pons-asinorum",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 223,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp"
+    ],
+    "assumptions": "None. Fully machine-checked: #print axioms on all four core theorems (sph_sinSq_eq_disc, hyp_sinSq_eq_disc, sph_law_of_sines, hyp_law_of_sines) reports only propext, Classical.choice, Quot.sound (the standard foundational axioms). 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. As in the parent and sibling entries, the laws of cosines enter as explicit hypotheses (hA, hB) — the theorems are conditional on the triangle satisfying the non-Euclidean law of cosines. The law-of-sines theorems additionally assume the natural positivity ranges (positive side-sines/sinhs and angle-sines, i.e. sides and angles strictly between 0 and π), needed to cancel a common factor and to pass from equal squares to equal ratios.",
+    "originalContributions": [
+      "A coordinate-free Lean proof of the law of sines in both spherical and hyperbolic geometry, derived purely from the ordinary law of cosines with no inner product space, answering the shared OQ of isosceles-triangle-oq-02 / -oq-01.",
+      "Isolates the fully symmetric 'sine discriminant' Δ = 1 − cos²a − cos²b − cos²c + 2·cos a·cos b·cos c (spherical) and its cosh-analogue (hyperbolic) as the invariant that makes the law of sines transparent: (sin A·sin b·sin c)² = Δ for every angle, so symmetry of Δ is the law of sines.",
+      "Proves the core identity (sin A·sin b·sin c)² = Δ by a division-free algebraic chain using only the Pythagorean identities sin²+cos²=1 and cosh²−sinh²=1 — so the identity itself needs no nonvanishing hypotheses.",
+      "Exhibits the spherical and hyperbolic derivations as line-for-line identical under the substitution cos↔cosh, sin↔sinh on the sides (angles keep ordinary cos/sin), unifying the two geometries in a single framework as the open question requested."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The law of sines is, with the law of cosines, one of the two pillars of triangle trigonometry. In the Euclidean plane it reads sin A / a = sin B / b = sin C / c; on the unit sphere it becomes sin A / sin a = sin B / sin b = sin C / sin c, and in the hyperbolic plane sin A / sinh a = sin B / sinh b = sin C / sinh c. All three share the same structure — the ratio of the sine of an angle to a (hyperbolic) sine of the opposite side is constant across the triangle — and all three can be extracted from the corresponding law of cosines by solving for the cosine of an angle and squaring. The common algebraic engine is a symmetric function of the three sides (a spherical/hyperbolic Cayley–Menger-type discriminant, related to the volume of the underlying simplex and, via l'Huilier's theorem, to the triangle's area). This entry formalizes that classical passage from cosines to sines uniformly for the sphere and the hyperbolic plane, staying entirely within the coordinate-free, inner-product-free framework of the parent Pons-Asinorum entries.",
+    "problemStatement": "**Law of sines in non-Euclidean geometry.** Let a triangle have angles A, B, C opposite sides a, b, c and suppose the (ordinary) law of cosines holds:\n- spherical:  cos a = cos b·cos c + sin b·sin c·cos A (and cyclically),\n- hyperbolic: cosh a = cosh b·cosh c − sinh b·sinh c·cos A (and cyclically).\nThen sin A / sin a = sin B / sin b (spherical) and sin A / sinh a = sin B / sinh b (hyperbolic), under the natural positivity of the sines/sinhs involved.",
+    "text": "A Lean 4 / Mathlib formalization (223 lines, 0 sorries, 0 axioms) of the law of sines in spherical and hyperbolic geometry. For each geometry a definition packages the symmetric sine discriminant Δ (sphSineDisc / hypSineDisc), and permutation-symmetry lemmas record that Δ is unchanged when the sides are swapped. The core identities sph_sinSq_eq_disc and hyp_sinSq_eq_disc prove (sin A·sin b·sin c)² = Δ (resp. (sin A·sinh b·sinh c)² = Δ) from the law of cosines by a division-free calc using sin²+cos²=1 and cosh²−sinh²=1. Comparing the identity for angle A with the one for angle B and cancelling the common factor gives the squared law of sines (sph_law_of_sines_sq / hyp_law_of_sines_sq); adding positivity of the relevant sines upgrades equal squares to the law of sines proper (sph_law_of_sines / hyp_law_of_sines).",
+    "proofStrategy": "1. **Symmetric discriminant.** Define Δ(a,b,c) = 1 − cos²a − cos²b − cos²c + 2·cos a·cos b·cos c (spherical) and the cosh-analogue (hyperbolic). sphSineDisc_symm_ab / _bc and their hyperbolic twins record that Δ is symmetric under permuting the sides (proved by ring).\n\n2. **Core identity (no division).** From the law of cosines, sin b·sin c·cos A = cos a − cos b·cos c. Then (sin A·sin b·sin c)² = sin²b·sin²c·sin²A = sin²b·sin²c·(1 − cos²A) = sin²b·sin²c − (sin b·sin c·cos A)² = sin²b·sin²c − (cos a − cos b·cos c)² = (1 − cos²b)(1 − cos²c) − (cos a − cos b·cos c)² = Δ(a,b,c). Every step is ring or a Pythagorean rewrite, so no side needs to be assumed nonzero for the identity itself.\n\n3. **Cancel the common factor.** The identity for angle A gives (sin A·sin b·sin c)² = Δ(a,b,c); for angle B it gives (sin B·sin a·sin c)² = Δ(b,a,c) = Δ(a,b,c) by symmetry. Both share the factor sin²c, so with sin c ≠ 0 mul_right_cancel₀ yields (sin A·sin b)² = (sin B·sin a)².\n\n4. **Equal squares to equal ratios.** With all relevant sines positive, equal squares of positive quantities are equal (an nlinarith step), giving sin A·sin b = sin B·sin a, i.e. sin A / sin a = sin B / sin b via div_eq_div_iff.\n\n5. **Hyperbolic mirror.** The hyperbolic development is identical with cos↔cosh, sin↔sinh on the sides; the only algebraic change is the sign convention sinh² = cosh² − 1 in place of sin² = 1 − cos², which leaves the symmetric shape of Δ intact.",
+    "keyInsights": [
+      "**One symmetric invariant is the whole law of sines.** The quantity (sin A·sin b·sin c)² is independent of which angle you start from because it equals the fully symmetric discriminant Δ(a,b,c). The law of sines is then just the statement that Δ does not care about the order of the sides.",
+      "**The core identity needs no nonvanishing hypotheses.** Because it is proved by a division-free chain — solve the law of cosines for sin b·sin c·cos A, square, substitute Pythagoras — the equality (sin A·sin b·sin c)² = Δ holds unconditionally. Nonvanishing is only needed later, to cancel the shared factor and to take a square root.",
+      "**Sphere and hyperbolic plane are the same proof.** Swapping cos↔cosh and sin↔sinh on the sides turns the spherical derivation into the hyperbolic one verbatim; the discriminant keeps its symmetric form despite the sign flip sinh² = cosh² − 1. This is exactly the unified framework the open question asked for.",
+      "**No inner product, no coordinates.** As in the parent entries the laws of cosines enter as hypotheses and the only analytic facts used are the Pythagorean identities and positivity of sines — no vectors, derivatives, or integrals.",
+      "**Discriminant = simplex content.** Δ is the spherical/hyperbolic analogue of the Cayley–Menger determinant; its positivity is the non-degeneracy of the triangle, and (via l'Huilier) it encodes the area, tying the law of sines to the geometry of the underlying simplex."
+    ],
+    "prerequisites": [
+      "Spherical and hyperbolic trigonometry (laws of cosines and sines)",
+      "Pythagorean identities sin²+cos²=1 and cosh²−sinh²=1",
+      "Basic real algebra: cancellation of a nonzero factor, equal squares of positive reals",
+      "Parent context: isosceles-triangle-oq-02 and isosceles-triangle-oq-02-oq-01 (Pons Asinorum and its converse in non-Euclidean geometry)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring: Cosines to Sines, Uniformly",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "States the open question, recalls the spherical and hyperbolic laws of cosines, and explains the plan: solve for cos A, compute sin²A = 1 − cos²A, and observe that (sin A·sin b·sin c)² (resp. with sinh) equals a symmetric sine discriminant Δ, whose symmetry is the law of sines. Notes that the two geometries give line-for-line identical derivations under cos↔cosh, sin↔sinh.",
+      "mathContext": "The law of sines as a corollary of the law of cosines via a symmetric discriminant."
+    },
+    {
+      "id": "sph-disc",
+      "title": "Spherical Sine Discriminant and Its Symmetry",
+      "startLine": 61,
+      "endLine": 82,
+      "summary": "sphSineDisc a b c := 1 − cos²a − cos²b − cos²c + 2·cos a·cos b·cos c defines the symmetric invariant; sphSineDisc_symm_ab and sphSineDisc_symm_bc prove (by ring) that it is unchanged under swapping the first two or the last two sides.",
+      "mathContext": "A spherical Cayley–Menger-type discriminant, symmetric in the sides."
+    },
+    {
+      "id": "sph-core",
+      "title": "Spherical Core Identity (sin A·sin b·sin c)² = Δ",
+      "startLine": 84,
+      "endLine": 107,
+      "summary": "sph_sinSq_eq_disc: from cos a = cos b·cos c + sin b·sin c·cos A, a division-free calc chain — using sin²+cos²=1 on A, b, c and the squared law-of-cosines relation (sin b·sin c·cos A)² = (cos a − cos b·cos c)² — shows (sin A·sin b·sin c)² = sphSineDisc a b c. No nonvanishing hypotheses are needed.",
+      "mathContext": "The angle-independent value of (sin A·sin b·sin c)²."
+    },
+    {
+      "id": "sph-sines",
+      "title": "Spherical Law of Sines",
+      "startLine": 109,
+      "endLine": 143,
+      "summary": "sph_law_of_sines_sq compares the core identity for angles A and B, uses symmetry of Δ, and cancels the common sin²c (needs sin c ≠ 0) to get (sin A·sin b)² = (sin B·sin a)². sph_law_of_sines then adds positivity of the sines to conclude sin A / sin a = sin B / sin b.",
+      "mathContext": "sin A / sin a = sin B / sin b on the sphere."
+    },
+    {
+      "id": "hyp-disc",
+      "title": "Hyperbolic Sine Discriminant and Its Symmetry",
+      "startLine": 145,
+      "endLine": 167,
+      "summary": "hypSineDisc a b c := 1 − cosh²a − cosh²b − cosh²c + 2·cosh a·cosh b·cosh c, with hypSineDisc_symm_ab / _bc recording its permutation symmetry. Same shape as the spherical discriminant with cos replaced by cosh.",
+      "mathContext": "The hyperbolic analogue of the sine discriminant."
+    },
+    {
+      "id": "hyp-core",
+      "title": "Hyperbolic Core Identity (sin A·sinh b·sinh c)² = Δ",
+      "startLine": 169,
+      "endLine": 188,
+      "summary": "hyp_sinSq_eq_disc: from cosh a = cosh b·cosh c − sinh b·sinh c·cos A, the identical division-free calc — now using cosh²−sinh²=1 for the sides — shows (sin A·sinh b·sinh c)² = hypSineDisc a b c.",
+      "mathContext": "The hyperbolic mirror of the spherical core identity."
+    },
+    {
+      "id": "hyp-sines",
+      "title": "Hyperbolic Law of Sines",
+      "startLine": 190,
+      "endLine": 222,
+      "summary": "hyp_law_of_sines_sq cancels the common sinh²c to get (sin A·sinh b)² = (sin B·sinh a)²; hyp_law_of_sines adds positivity to conclude sin A / sinh a = sin B / sinh b. The proof is line-for-line the spherical one with sin↔sinh on the sides.",
+      "mathContext": "sin A / sinh a = sin B / sinh b in the hyperbolic plane."
+    }
+  ],
+  "conclusion": {
+    "summary": "The law of sines is verified in Lean 4 / Mathlib for both spherical (sin A/sin a = sin B/sin b) and hyperbolic (sin A/sinh a = sin B/sinh b) geometry (223 lines, 0 sorries, 0 axioms), derived purely from the ordinary law of cosines via a single symmetric sine discriminant Δ. The spherical and hyperbolic proofs are identical under cos↔cosh, sin↔sinh on the sides, realizing the unified coordinate-free framework requested by the parent and sibling entries.",
+    "implications": "With Pons Asinorum (parent), its converse (sibling), and now the law of sines all established coordinate-free from the laws of cosines, the non-Euclidean triangle-congruence toolkit is substantially assembled: the law of sines supplies the ambiguous-case (ASS) and AAS relations and, combined with the (dual) laws of cosines, the remaining SSS/SAS/ASA/AAA relations. The symmetric discriminant Δ isolated here is also the natural handle for spherical/hyperbolic area (l'Huilier) and for non-degeneracy of the triangle.",
+    "openQuestions": [
+      "Combine the law of sines with the (dual) laws of cosines to formalize the full non-Euclidean congruence toolkit (SSS, SAS, ASA, AAS, and the AAA/ambiguous cases) as explicit theorems.",
+      "Show the sine discriminant Δ is nonnegative exactly when a genuine (non-degenerate) spherical/hyperbolic triangle exists, and relate Δ to the triangle's area via l'Huilier's theorem.",
+      "Derive the constant common ratio sin A/sin a = sin B/sin b = sin C/sin c in one statement (all three angles at once) and connect it to the circumradius / the polar triangle."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Set"
+    ],
+    "namespace": "IsoscelesTriangleOQ02OQ02",
+    "lineCount": 223,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "path": "Proofs/IsoscelesTriangleOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "isosceles-triangle-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "The sibling proves the converse Pons Asinorum via the dual law of cosines and lists 'derive the spherical and hyperbolic laws of sines in the same coordinate-free framework' as its first open question. This entry answers exactly that question."
+    },
+    {
+      "targetId": "isosceles-triangle-oq-02",
+      "relationship": "extends",
+      "description": "The parent proves the forward Pons Asinorum in spherical and hyperbolic geometry from the laws of cosines and lists the law of sines among its open questions; this entry supplies the missing sine law in the same inner-product-free style."
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related",
+      "description": "The Euclidean law of cosines whose spherical and hyperbolic analogues are the sole input to this derivation of the law of sines."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Marvin Jay Greenberg",
+      "title": "Euclidean and Non-Euclidean Geometries: Development and History",
+      "year": "2008",
+      "venue": "W. H. Freeman (4th ed.)",
+      "note": "Develops spherical and hyperbolic trigonometry, including the laws of cosines and sines."
+    },
+    {
+      "authors": "John Stillwell",
+      "title": "Geometry of Surfaces",
+      "year": "1992",
+      "venue": "Springer, Universitext",
+      "note": "Treats the hyperbolic and spherical laws of cosines and sines and side–angle duality."
+    },
+    {
+      "authors": "I. Todhunter",
+      "title": "Spherical Trigonometry",
+      "year": "1886",
+      "venue": "Macmillan",
+      "note": "Classical reference deriving the spherical law of sines from the law of cosines via the symmetric side function."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sph_law_of_sines",
+      "type": "core",
+      "description": "Law of sines, spherical geometry: from the laws of cosines for angles A and B with positive sines, sin A / sin a = sin B / sin b.",
+      "leanType": "{a b c A B : ℝ} (hA : cos a = cos b * cos c + sin b * sin c * cos A) (hB : cos b = cos a * cos c + sin a * sin c * cos B) (ha : 0 < sin a) (hb : 0 < sin b) (hc : 0 < sin c) (hA' : 0 < sin A) (hB' : 0 < sin B) : sin A / sin a = sin B / sin b"
+    },
+    {
+      "name": "hyp_law_of_sines",
+      "type": "core",
+      "description": "Law of sines, hyperbolic geometry: from the hyperbolic laws of cosines for angles A and B with positive side-sinhs and angle-sines, sin A / sinh a = sin B / sinh b.",
+      "leanType": "{a b c A B : ℝ} (hA : cosh a = cosh b * cosh c - sinh b * sinh c * cos A) (hB : cosh b = cosh a * cosh c - sinh a * sinh c * cos B) (ha : 0 < sinh a) (hb : 0 < sinh b) (hc : 0 < sinh c) (hA' : 0 < sin A) (hB' : 0 < sin B) : sin A / sinh a = sin B / sinh b"
+    },
+    {
+      "name": "sph_sinSq_eq_disc",
+      "type": "core",
+      "description": "Spherical core identity: (sin A·sin b·sin c)² equals the symmetric sine discriminant Δ(a,b,c). Division-free; no nonvanishing hypotheses.",
+      "leanType": "{a b c A : ℝ} (hA : cos a = cos b * cos c + sin b * sin c * cos A) : (sin A * sin b * sin c) ^ 2 = sphSineDisc a b c"
+    },
+    {
+      "name": "hyp_sinSq_eq_disc",
+      "type": "core",
+      "description": "Hyperbolic core identity: (sin A·sinh b·sinh c)² equals the symmetric hyperbolic sine discriminant Δ(a,b,c).",
+      "leanType": "{a b c A : ℝ} (hA : cosh a = cosh b * cosh c - sinh b * sinh c * cos A) : (sin A * sinh b * sinh c) ^ 2 = hypSineDisc a b c"
+    },
+    {
+      "name": "sph_law_of_sines_sq",
+      "type": "lemma",
+      "description": "Squared spherical law of sines: (sin A·sin b)² = (sin B·sin a)², obtained by cancelling the common factor sin²c (needs sin c ≠ 0).",
+      "leanType": "{a b c A B : ℝ} (hA : ...) (hB : ...) (hc : sin c ≠ 0) : (sin A * sin b) ^ 2 = (sin B * sin a) ^ 2"
+    },
+    {
+      "name": "hyp_law_of_sines_sq",
+      "type": "lemma",
+      "description": "Squared hyperbolic law of sines: (sin A·sinh b)² = (sin B·sinh a)², cancelling the common sinh²c.",
+      "leanType": "{a b c A B : ℝ} (hA : ...) (hB : ...) (hc : sinh c ≠ 0) : (sin A * sinh b) ^ 2 = (sin B * sinh a) ^ 2"
+    },
+    {
+      "name": "sphSineDisc",
+      "type": "definition",
+      "description": "The symmetric spherical sine discriminant Δ = 1 − cos²a − cos²b − cos²c + 2·cos a·cos b·cos c.",
+      "leanType": "(a b c : ℝ) : ℝ"
+    },
+    {
+      "name": "hypSineDisc",
+      "type": "definition",
+      "description": "The symmetric hyperbolic sine discriminant Δ = 1 − cosh²a − cosh²b − cosh²c + 2·cosh a·cosh b·cosh c.",
+      "leanType": "(a b c : ℝ) : ℝ"
+    },
+    {
+      "name": "sphSineDisc_symm_ab",
+      "type": "lemma",
+      "description": "The spherical sine discriminant is symmetric under swapping the first two sides.",
+      "leanType": "(a b c : ℝ) : sphSineDisc a b c = sphSineDisc b a c"
+    },
+    {
+      "name": "hypSineDisc_symm_ab",
+      "type": "lemma",
+      "description": "The hyperbolic sine discriminant is symmetric under swapping the first two sides.",
+      "leanType": "(a b c : ℝ) : hypSineDisc a b c = hypSineDisc b a c"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the shared open question of **isosceles-triangle-oq-02** (Pons Asinorum in non-Euclidean geometry) and its sibling **-oq-01** (the converse):

> *Derive the spherical and hyperbolic laws of sines in the same coordinate-free framework.*

Taking only the ordinary **law of cosines** as input (as the parent entries do — no inner product space), this new entry derives the **law of sines** for both geometries:

- spherical:  `sin A / sin a = sin B / sin b`
- hyperbolic: `sin A / sinh a = sin B / sinh b`

## The idea

Solve the law of cosines for `cos A`, use `sin²A = 1 − cos²A`, and observe that the product

- `(sin A · sin b · sin c)²`  (spherical)
- `(sin A · sinh b · sinh c)²` (hyperbolic)

equals a **fully symmetric sine discriminant**

`Δ = 1 − cos²a − cos²b − cos²c + 2·cos a·cos b·cos c`  (resp. with `cosh`).

Because `Δ` is symmetric in the three sides, `(sin A · sin b · sin c)²` does not depend on which angle you start from — and that angle-independence **is** the law of sines. The core identity is proved by a **division-free** `calc` chain (only `sin²+cos²=1` / `cosh²−sinh²=1`), so it needs no nonvanishing hypotheses; positivity of the sines enters only to cancel the shared factor and take a square root.

The spherical and hyperbolic derivations are **line-for-line identical** under `cos↔cosh, sin↔sinh` on the sides — exactly the unified framework the OQ requested.

## Verification

- **0 axioms** — `#print axioms` on all four core theorems reports only `propext, Classical.choice, Quot.sound`.
- **0 sorries**, 10 theorems + 2 definitions, 223 lines.
- Compiles against Mathlib (`lake env lean`, exit 0).
- Gallery `annotations:validate`: clean for this entry.

## Scope / honesty

As in the parent and sibling entries, the laws of cosines enter as **explicit hypotheses** (the theorems are conditional on the triangle satisfying the non-Euclidean law of cosines). The law-of-sines theorems additionally assume the natural triangle ranges (positive side/angle sines). This is disclosed in `meta.json` `assumptions`.

## Files

- `proofs/Proofs/IsoscelesTriangleOQ02OQ02.lean` (new)
- `src/data/proofs/isosceles-triangle-oq-02-oq-02/{meta.json,annotations.json}` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)