### PR TITLE
research(erdos-31-primes-density-oq-03): Mertens' lower bound Σ 1/p ≥ log log(N+1) − 1 [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/Erdos31PrimesDensityReciprocalOQ03.lean
+++ b/proofs/Proofs/Erdos31PrimesDensityReciprocalOQ03.lean
@@ -1,0 +1,259 @@
+/-
+Erdős Problem #31 Follow-up (OQ-03): Mertens' Lower Bound for Σ 1/p
+
+The parent entry `erdos-31-primes-density` proves that the primes have natural
+density zero via the Chebyshev upper bound π(N) = O(N/log N).  Its third open
+question asks for the *rate* at which the primes accumulate on the logarithmic
+scale — Mertens' second theorem, Σ_{p ≤ N} 1/p ~ log log N.
+
+Mathlib supplies only the *qualitative* divergence of Σ 1/p
+(`not_summable_one_div_on_primes`, via Erdős's rough-number argument), which
+gives no rate.  Here we prove the quantitative **lower** half of Mertens'
+theorem with an explicit constant, by the classical Euler-product argument:
+
+    Σ_{p ≤ N} 1/p  ≥  log log (N + 1) − 1     (for N ≥ 1).
+
+Proof architecture (Euler product):
+
+1. `harmonic_le_euler_product`  —  ∑_{k=1}^N 1/k ≤ ∏_{p ≤ N} (1 − 1/p)⁻¹.
+   (Unique factorisation: every k ≤ N is a product of primes ≤ N, so 1/k
+   appears in the expansion of the geometric factors.)
+2. `sum_log_euler_factor_le`  —  ∑_{p ≤ N} log((1 − 1/p)⁻¹) ≤ ∑_{p ≤ N} 1/p + 1.
+   (Per prime, −log(1 − 1/p) − 1/p ≤ 1/(p(p−1)); the tail sums to < 1.)
+3. Assembly: chain `log_add_one_le_harmonic` (Mathlib) with (1), take logs, and
+   bound with (2).
+
+Status: work in progress — steps (1),(2) isolated; assembly complete.
+Dependencies: Only Mathlib.
+-/
+
+import Mathlib
+
+open Finset
+
+namespace Erdos31PrimesDensityReciprocal
+
+/-- The primes `≤ N`, as a `Finset`. -/
+def primesLe (N : ℕ) : Finset ℕ := (Finset.range (N + 1)).filter Nat.Prime
+
+lemma mem_primesLe {N p : ℕ} : p ∈ primesLe N ↔ p ≤ N ∧ p.Prime := by
+  simp only [primesLe, Finset.mem_filter, Finset.mem_range]
+  constructor
+  · rintro ⟨h, hp⟩; exact ⟨by omega, hp⟩
+  · rintro ⟨h, hp⟩; exact ⟨by omega, hp⟩
+
+/-- Each Euler factor `(1 - 1/p)⁻¹` is strictly positive for a prime `p`. -/
+lemma euler_factor_pos {p : ℕ} (hp : p.Prime) : 0 < (1 - 1 / (p : ℝ))⁻¹ := by
+  have hp2 : (2 : ℝ) ≤ (p : ℝ) := by exact_mod_cast hp.two_le
+  have h1 : 0 < 1 - 1 / (p : ℝ) := by
+    have : 1 / (p : ℝ) ≤ 1 / 2 := by
+      apply div_le_div_of_nonneg_left (by norm_num) (by norm_num) hp2
+    linarith
+  positivity
+
+lemma euler_factor_ne {p : ℕ} (hp : p.Prime) : (1 - 1 / (p : ℝ))⁻¹ ≠ 0 :=
+  ne_of_gt (euler_factor_pos hp)
+
+/-- The Euler product `∏_{p ≤ N} (1 - 1/p)⁻¹` is strictly positive. -/
+lemma euler_product_pos (N : ℕ) :
+    0 < ∏ p ∈ primesLe N, (1 - 1 / (p : ℝ))⁻¹ := by
+  apply Finset.prod_pos
+  intro p hp
+  exact euler_factor_pos (mem_primesLe.mp hp).2
+
+/-! ## Step 1: harmonic partial sum ≤ Euler product (crux, combinatorial) -/
+
+/-- The reciprocal map `n ↦ (n : ℝ)⁻¹` as a multiplicative monoid homomorphism.
+Multiplicativity holds because `(ab)⁻¹ = a⁻¹ b⁻¹` in the field `ℝ` (with `0⁻¹ = 0`). -/
+noncomputable def invHom : ℕ →* ℝ where
+  toFun n := (n : ℝ)⁻¹
+  map_one' := by simp
+  map_mul' a b := by push_cast; rw [mul_inv]
+
+@[simp] lemma invHom_apply (n : ℕ) : invHom n = (n : ℝ)⁻¹ := rfl
+
+/-- `primesLe N` is exactly `Nat.primesBelow (N + 1)`. -/
+lemma primesLe_eq_primesBelow (N : ℕ) : primesLe N = Nat.primesBelow (N + 1) := rfl
+
+/-- Every `k ∈ [1, N]` is `(N+1)`-smooth: nonzero with all prime factors `≤ N < N+1`. -/
+lemma Icc_subset_smoothNumbers (N : ℕ) :
+    ↑(Finset.Icc 1 N) ⊆ Nat.smoothNumbers (N + 1) := by
+  intro k hk
+  simp only [Finset.coe_Icc, Set.mem_Icc] at hk
+  obtain ⟨hk1, hkN⟩ := hk
+  rw [Nat.mem_smoothNumbers]
+  refine ⟨by omega, ?_⟩
+  intro p hp
+  have hpd : p ∣ k := Nat.dvd_of_mem_primeFactorsList hp
+  have hple : p ≤ k := Nat.le_of_dvd (by omega) hpd
+  omega
+
+/-- **Euler product lower bound.**  The `N`-th harmonic partial sum is dominated
+by the finite Euler product over primes `≤ N`.  Every `k ∈ [1, N]` factors into
+primes `≤ N`, so `1/k` occurs in the expansion of `∏_{p ≤ N} ∑_{e ≥ 0} p^{-e}`;
+since all terms are nonnegative, the sum of the diagonal `1/k` is at most the
+product. -/
+lemma harmonic_le_euler_product (N : ℕ) :
+    ∑ k ∈ Finset.Icc 1 N, (1 / k : ℝ) ≤ ∏ p ∈ primesLe N, (1 - 1 / (p : ℝ))⁻¹ := by
+  -- ‖f p‖ < 1 for each prime p, so the smooth-number Euler product converges.
+  have hnorm : ∀ {p : ℕ}, p.Prime → ‖invHom p‖ < 1 := by
+    intro p hp
+    have hp2 : (2 : ℝ) ≤ (p : ℝ) := by exact_mod_cast hp.two_le
+    rw [invHom_apply, Real.norm_eq_abs, abs_of_nonneg (by positivity)]
+    rw [inv_lt_one_iff₀]; right; linarith
+  obtain ⟨hsummable, hhassum⟩ :=
+    EulerProduct.summable_and_hasSum_smoothNumbers_prod_primesBelow_geometric hnorm (N + 1)
+  -- The Euler product on smooth numbers equals our product over primesLe N.
+  set S : Set ℕ := Nat.smoothNumbers (N + 1) with hS
+  have hprod_eq : (∏ p ∈ Nat.primesBelow (N + 1), (1 - invHom p)⁻¹)
+      = ∏ p ∈ primesLe N, (1 - 1 / (p : ℝ))⁻¹ := by
+    rw [primesLe_eq_primesBelow]
+    apply Finset.prod_congr rfl
+    intro p _; simp [one_div]
+  rw [← hprod_eq]
+  -- Move to the indicator formulation on all of ℕ.
+  have hsummable_sub : Summable (fun m : S ↦ invHom (m : ℕ)) := hhassum.summable
+  have hsum_ind : Summable (S.indicator (fun n => invHom n)) :=
+    summable_subtype_iff_indicator.mp hsummable_sub
+  have hRHS : (∏ p ∈ Nat.primesBelow (N + 1), (1 - invHom p)⁻¹)
+      = ∑' n, S.indicator (fun n => invHom n) n := by
+    rw [← hhassum.tsum_eq]; exact tsum_subtype S (fun n => invHom n)
+  -- The harmonic sum equals the indicator sum over Icc 1 N.
+  have hsub := Icc_subset_smoothNumbers N
+  have heq : ∑ k ∈ Finset.Icc 1 N, (1 / k : ℝ)
+      = ∑ k ∈ Finset.Icc 1 N, S.indicator (fun n => invHom n) k := by
+    apply Finset.sum_congr rfl
+    intro k hk
+    have hkS : k ∈ S := hsub (by simpa using hk)
+    rw [Set.indicator_of_mem hkS, invHom_apply, one_div]
+  rw [hRHS, heq]
+  -- Finite subsum ≤ full nonnegative tsum.
+  exact Summable.sum_le_tsum (Finset.Icc 1 N)
+    (fun i _ => Set.indicator_nonneg (fun n _ => by simp [invHom_apply, inv_nonneg]) i) hsum_ind
+
+/-! ## Step 2: sum of log Euler factors ≤ Σ 1/p + 1 (crux, analytic) -/
+
+/-- Telescoping identity `∑_{n=2}^{N+1} 1/(n(n-1)) = 1 - 1/(N+1)`. -/
+lemma tail_sum_Icc (N : ℕ) :
+    ∑ n ∈ Finset.Icc 2 (N + 1), (1 : ℝ) / ((n : ℝ) * ((n : ℝ) - 1)) = 1 - 1 / ((N : ℝ) + 1) := by
+  induction N with
+  | zero => simp
+  | succ M ih =>
+    rw [Finset.sum_Icc_succ_top (by omega), ih]
+    have h1 : ((M : ℝ) + 1) ≠ 0 := by positivity
+    have h2 : ((M : ℝ) + 2) ≠ 0 := by positivity
+    have hT : ((M + 1 + 1 : ℕ) : ℝ) * (((M + 1 + 1 : ℕ) : ℝ) - 1)
+        = ((M : ℝ) + 2) * ((M : ℝ) + 1) := by push_cast; ring
+    have hR : ((M + 1 : ℕ) : ℝ) + 1 = (M : ℝ) + 2 := by push_cast; ring
+    rw [hT, hR]
+    field_simp
+    ring
+
+/-- The tail sum over primes `≤ N` is bounded by `1`: `∑_{p ≤ N} 1/(p(p-1)) ≤ 1`. -/
+lemma tail_bound (N : ℕ) :
+    ∑ p ∈ primesLe N, (1 : ℝ) / ((p : ℝ) * ((p : ℝ) - 1)) ≤ 1 := by
+  have hsub : primesLe N ⊆ Finset.Icc 2 N := by
+    intro p hp
+    rw [mem_primesLe] at hp
+    rw [Finset.mem_Icc]
+    exact ⟨hp.2.two_le, hp.1⟩
+  have hle : ∑ p ∈ primesLe N, (1 : ℝ) / ((p : ℝ) * ((p : ℝ) - 1)) ≤
+      ∑ n ∈ Finset.Icc 2 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) - 1)) := by
+    apply Finset.sum_le_sum_of_subset_of_nonneg hsub
+    intro n hn _
+    have hn2 : (2 : ℝ) ≤ (n : ℝ) := by
+      rw [Finset.mem_Icc] at hn; exact_mod_cast hn.1
+    apply div_nonneg (by norm_num)
+    nlinarith [hn2]
+  refine hle.trans ?_
+  cases N with
+  | zero => simp
+  | succ M =>
+    rw [tail_sum_Icc M]
+    have : (0 : ℝ) ≤ 1 / ((M : ℝ) + 1) := by positivity
+    linarith
+
+/-- **Log-tail bound.**  Summing `log((1 - 1/p)⁻¹) = −log(1 − 1/p)` over primes
+`p ≤ N` exceeds `Σ 1/p` by at most `1`, because per prime
+`log((1 − 1/p)⁻¹) ≤ (1 − 1/p)⁻¹ − 1 = 1/(p−1) = 1/p + 1/(p(p−1))`
+(Mathlib `Real.log_le_sub_one_of_pos`) and `Σ_p 1/(p(p−1)) ≤ 1`. -/
+lemma sum_log_euler_factor_le (N : ℕ) :
+    ∑ p ∈ primesLe N, Real.log ((1 - 1 / (p : ℝ))⁻¹) ≤
+      (∑ p ∈ primesLe N, (1 / (p : ℝ))) + 1 := by
+  have hterm : ∀ p ∈ primesLe N,
+      Real.log ((1 - 1 / (p : ℝ))⁻¹) ≤ 1 / (p : ℝ) + 1 / ((p : ℝ) * ((p : ℝ) - 1)) := by
+    intro p hp
+    have hpp := (mem_primesLe.mp hp).2
+    have hp2 : (2 : ℝ) ≤ (p : ℝ) := by exact_mod_cast hpp.two_le
+    have hpos : 0 < (1 - 1 / (p : ℝ))⁻¹ := euler_factor_pos hpp
+    have hlog := Real.log_le_sub_one_of_pos hpos
+    have hp0 : (p : ℝ) ≠ 0 := by positivity
+    have hp1 : (p : ℝ) - 1 ≠ 0 := by
+      have : (0 : ℝ) < (p : ℝ) - 1 := by linarith
+      exact ne_of_gt this
+    have hval : (1 - 1 / (p : ℝ))⁻¹ - 1 = 1 / (p : ℝ) + 1 / ((p : ℝ) * ((p : ℝ) - 1)) := by
+      have hpne : (1 - 1 / (p : ℝ)) ≠ 0 := by
+        have : (0 : ℝ) < 1 - 1 / (p : ℝ) := by
+          have : 1 / (p : ℝ) ≤ 1 / 2 := by
+            apply div_le_div_of_nonneg_left (by norm_num) (by norm_num) hp2
+          linarith
+        exact ne_of_gt this
+      field_simp
+      ring
+    rw [hval] at hlog
+    exact hlog
+  calc ∑ p ∈ primesLe N, Real.log ((1 - 1 / (p : ℝ))⁻¹)
+      ≤ ∑ p ∈ primesLe N, (1 / (p : ℝ) + 1 / ((p : ℝ) * ((p : ℝ) - 1))) :=
+        Finset.sum_le_sum hterm
+    _ = (∑ p ∈ primesLe N, (1 / (p : ℝ))) +
+          ∑ p ∈ primesLe N, (1 : ℝ) / ((p : ℝ) * ((p : ℝ) - 1)) := by
+        rw [Finset.sum_add_distrib]
+    _ ≤ (∑ p ∈ primesLe N, (1 / (p : ℝ))) + 1 := by
+        gcongr
+        exact tail_bound N
+
+/-! ## Main result: Mertens lower bound -/
+
+/-- **Mertens' lower bound.**  For all `N ≥ 1`,
+`Σ_{p ≤ N} 1/p ≥ log log (N + 1) − 1`.  This exhibits the `log log N` growth
+rate of the prime reciprocal sum (the lower half of Mertens' second theorem),
+answering the lower-bound direction of erdos-31 OQ-03. -/
+theorem mertens_reciprocal_lower_bound (N : ℕ) (hN : 1 ≤ N) :
+    Real.log (Real.log ((N : ℝ) + 1)) - 1 ≤ ∑ p ∈ primesLe N, (1 / (p : ℝ)) := by
+  -- log(N+1) > 0 since N + 1 ≥ 2
+  have hNR : (2 : ℝ) ≤ (N : ℝ) + 1 := by
+    have : (1 : ℝ) ≤ (N : ℝ) := by exact_mod_cast hN
+    linarith
+  have hlogpos : 0 < Real.log ((N : ℝ) + 1) :=
+    Real.log_pos (by linarith)
+  -- Step A: log(N+1) ≤ harmonic N = ∑_{k=1}^N 1/k
+  have hHarm : Real.log ((N : ℝ) + 1) ≤ ∑ k ∈ Finset.Icc 1 N, (1 / k : ℝ) := by
+    have h := log_add_one_le_harmonic N
+    have hcast : ((harmonic N : ℚ) : ℝ) = ∑ k ∈ Finset.Icc 1 N, (1 / k : ℝ) := by
+      rw [harmonic_eq_sum_Icc]
+      push_cast
+      simp only [one_div]
+    calc Real.log ((N : ℝ) + 1)
+        = Real.log ((↑(N + 1) : ℝ)) := by push_cast; ring_nf
+      _ ≤ ((harmonic N : ℚ) : ℝ) := h
+      _ = ∑ k ∈ Finset.Icc 1 N, (1 / k : ℝ) := hcast
+  -- Step B: ∑ 1/k ≤ Euler product
+  set P := ∏ p ∈ primesLe N, (1 - 1 / (p : ℝ))⁻¹ with hP
+  have hProdPos : 0 < P := euler_product_pos N
+  have hLeProd : Real.log ((N : ℝ) + 1) ≤ P :=
+    le_trans hHarm (harmonic_le_euler_product N)
+  -- Step C: take logs
+  have hlogmono : Real.log (Real.log ((N : ℝ) + 1)) ≤ Real.log P :=
+    Real.log_le_log hlogpos hLeProd
+  -- Step D: log of product = sum of logs
+  have hlogprod : Real.log P = ∑ p ∈ primesLe N, Real.log ((1 - 1 / (p : ℝ))⁻¹) := by
+    rw [hP, Real.log_prod]
+    intro p hp
+    exact euler_factor_ne (mem_primesLe.mp hp).2
+  -- Step E: bound by Σ 1/p + 1
+  have hbound := sum_log_euler_factor_le N
+  -- Assemble
+  rw [hlogprod] at hlogmono
+  linarith [hlogmono, hbound]
+
+end Erdos31PrimesDensityReciprocal

--- a/src/data/proofs/erdos-31-primes-density-oq-03/annotations.json
+++ b/src/data/proofs/erdos-31-primes-density-oq-03/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-e31r-setup",
+    "proofId": "erdos-31-primes-density-oq-03",
+    "range": {
+      "startLine": 36,
+      "endLine": 62
+    },
+    "type": "definition",
+    "title": "Primes ≤ N and positivity of the Euler factors",
+    "content": "Defines `primesLe N = (range (N+1)).filter Nat.Prime`, the primes ≤ N, with membership lemma `mem_primesLe`. Each Euler factor (1 − 1/p)⁻¹ is strictly positive: for a prime p ≥ 2 we have 1/p ≤ 1/2 so 1 − 1/p ≥ 1/2 > 0 (euler_factor_pos, euler_factor_ne), whence the finite product ∏_{p ≤ N}(1 − 1/p)⁻¹ is positive (euler_product_pos). Positivity is needed later to take logarithms of the product.",
+    "mathContext": "The Euler factor (1 − 1/p)⁻¹ = Σ_{e ≥ 0} p^{-e} is the sum of the geometric series of reciprocal prime powers. Over primes p ≤ N these multiply to the finite Euler product, the classical device linking multiplicative (product over primes) and additive (sum over integers) structure via unique factorisation.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euler product",
+      "geometric series",
+      "Nat.Prime",
+      "Finset.filter"
+    ],
+    "prerequisites": [
+      "Finset.filter",
+      "Nat.Prime.two_le",
+      "div_le_div_of_nonneg_left"
+    ]
+  },
+  {
+    "id": "ann-e31r-euler-product",
+    "proofId": "erdos-31-primes-density-oq-03",
+    "range": {
+      "startLine": 64,
+      "endLine": 133
+    },
+    "type": "theorem",
+    "title": "Step 1 — harmonic partial sum ≤ Euler product",
+    "content": "The crux combinatorial step: Σ_{k=1}^{N} 1/k ≤ ∏_{p ≤ N}(1 − 1/p)⁻¹ (harmonic_le_euler_product). The reciprocal map n ↦ (n:ℝ)⁻¹ is packaged as a monoid homomorphism `invHom : ℕ →* ℝ` (multiplicative since (ab)⁻¹ = a⁻¹b⁻¹). Applying Mathlib's `EulerProduct.summable_and_hasSum_smoothNumbers_prod_primesBelow_geometric` — which needs only ‖invHom p‖ = 1/p < 1 per prime, not global summability — the product ∏_{p ≤ N}(1 − 1/p)⁻¹ equals the convergent tsum of 1/m over (N+1)-smooth numbers m. Since every k ∈ [1,N] is (N+1)-smooth (Icc_subset_smoothNumbers) and all terms are nonnegative, `Summable.sum_le_tsum` gives the finite subsum ≤ the total.",
+    "mathContext": "This is the formal content of 'unique factorisation expands ∏_{p ≤ N} Σ_{e ≥ 0} p^{-e} into Σ 1/n over all N-smooth n, which covers {1,…,N}'. The key subtlety is that the harmonic series is NOT globally summable, so the standard Euler product theorem (requiring Summable f) does not apply; Mathlib's smooth-number variant, requiring only ‖f p‖ < 1, is exactly what makes the finite product converge to a smooth-number tsum.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Euler product",
+      "smooth numbers",
+      "unique factorisation",
+      "Nat.smoothNumbers",
+      "Summable.sum_le_tsum"
+    ],
+    "prerequisites": [
+      "EulerProduct.summable_and_hasSum_smoothNumbers_prod_primesBelow_geometric",
+      "Nat.smoothNumbers",
+      "summable_subtype_iff_indicator",
+      "tsum_subtype"
+    ]
+  },
+  {
+    "id": "ann-e31r-telescope",
+    "proofId": "erdos-31-primes-density-oq-03",
+    "range": {
+      "startLine": 136,
+      "endLine": 178
+    },
+    "type": "theorem",
+    "title": "Telescoping tail bound Σ 1/(p(p−1)) ≤ 1",
+    "content": "Proves the telescoping identity Σ_{n=2}^{N+1} 1/(n(n−1)) = 1 − 1/(N+1) by induction (tail_sum_Icc), using 1/(n(n−1)) = 1/(n−1) − 1/n. Since the primes ≤ N form a subset of {2,…,N} and all terms are nonnegative, this yields Σ_{p ≤ N} 1/(p(p−1)) ≤ 1 (tail_bound). This bounds the error between −log(1−1/p) and 1/p summed over primes.",
+    "mathContext": "The convergence of Σ 1/(n(n−1)) = 1 is the prototypical telescoping series. Here it controls the correction term in the expansion −log(1 − 1/p) = 1/p + 1/(2p²) + ⋯, ensuring the difference between the log-Euler-product and Σ 1/p stays bounded by an absolute constant.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "telescoping series",
+      "Finset.sum_Icc_succ_top",
+      "convergent series"
+    ],
+    "prerequisites": [
+      "Finset.sum_Icc_succ_top",
+      "Finset.sum_le_sum_of_subset_of_nonneg"
+    ]
+  },
+  {
+    "id": "ann-e31r-logtail",
+    "proofId": "erdos-31-primes-density-oq-03",
+    "range": {
+      "startLine": 180,
+      "endLine": 218
+    },
+    "type": "theorem",
+    "title": "Step 2 — Σ log((1−1/p)⁻¹) ≤ Σ 1/p + 1",
+    "content": "Bounds the sum of log-Euler-factors by the reciprocal-prime sum plus a constant (sum_log_euler_factor_le). Per prime, the elementary inequality log x ≤ x − 1 (Mathlib `Real.log_le_sub_one_of_pos`) applied to x = (1 − 1/p)⁻¹ gives log((1−1/p)⁻¹) ≤ (1−1/p)⁻¹ − 1, which equals exactly 1/(p−1) = 1/p + 1/(p(p−1)). Summing and applying the telescoping tail bound Σ 1/(p(p−1)) ≤ 1 completes the estimate.",
+    "mathContext": "This replaces the usual power-series manipulation −log(1−x) − x = Σ_{m ≥ 2} x^m/m ≤ x²/(1−x) with the slicker one-line bound log x ≤ x − 1, giving the clean closed form 1/(p−1) and an absolute-constant tail. It is the analytic heart of the Euler-product proof of Mertens' lower bound.",
+    "significance": "central",
+    "relatedConcepts": [
+      "logarithm inequality",
+      "Mertens' theorem",
+      "Real.log_le_sub_one_of_pos"
+    ],
+    "prerequisites": [
+      "Real.log_le_sub_one_of_pos",
+      "Finset.sum_le_sum",
+      "Finset.sum_add_distrib"
+    ]
+  },
+  {
+    "id": "ann-e31r-main",
+    "proofId": "erdos-31-primes-density-oq-03",
+    "range": {
+      "startLine": 219,
+      "endLine": 259
+    },
+    "type": "theorem",
+    "title": "Mertens' lower bound: Σ 1/p ≥ log log(N+1) − 1",
+    "content": "The main theorem mertens_reciprocal_lower_bound assembles the pieces. From Mathlib's `Real.log_add_one_le_harmonic`, log(N+1) ≤ H_N = Σ_{k=1}^{N} 1/k; by Step 1 this is ≤ ∏_{p ≤ N}(1 − 1/p)⁻¹. Taking logarithms (monotone, `Real.log_le_log`, positivity of both sides) and expanding log of the product (`Real.log_prod`) gives log log(N+1) ≤ Σ_{p ≤ N} log((1−1/p)⁻¹), which by Step 2 is ≤ Σ_{p ≤ N} 1/p + 1. Rearranging yields Σ_{p ≤ N} 1/p ≥ log log(N+1) − 1 for all N ≥ 1.",
+    "mathContext": "This is the lower half of Mertens' second theorem with an explicit effective constant. It shows the prime reciprocal sum grows at rate log log N — the slowest divergence encountered in elementary number theory — and is a genuine quantitative strengthening of Euler's Σ 1/p = ∞ that Mathlib's qualitative divergence lemma does not provide.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Mertens' second theorem",
+      "prime reciprocal sum",
+      "harmonic series",
+      "Real.log_add_one_le_harmonic"
+    ],
+    "prerequisites": [
+      "Real.log_add_one_le_harmonic",
+      "Real.log_le_log",
+      "Real.log_prod",
+      "harmonic_eq_sum_Icc"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-31-primes-density-oq-03/meta.json
+++ b/src/data/proofs/erdos-31-primes-density-oq-03/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "erdos-31-primes-density-oq-03",
+  "title": "Mertens' Lower Bound for the Prime Reciprocal Sum",
+  "slug": "erdos-31-primes-density-oq-03",
+  "description": "A machine-checked proof of the quantitative lower half of Mertens' second theorem: for every N ≥ 1, Σ_{p ≤ N} 1/p ≥ log log(N+1) − 1. This exhibits the log log N growth rate of the prime reciprocal sum, answering the lower-bound direction of the third open question of the parent entry erdos-31-primes-density. Mathlib supplies only the qualitative divergence of Σ 1/p (not_summable_one_div_on_primes, via Erdős's rough-number argument), which gives no rate; the proof here follows the classical Euler-product route. Fully axiom-free from Mathlib.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Mertens%27_theorems",
+    "date": "2026",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/Erdos31PrimesDensityReciprocalOQ03.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "lineCount": 259,
+    "tags": [
+      "number-theory",
+      "analytic-number-theory",
+      "prime-density",
+      "mertens",
+      "euler-product",
+      "erdos",
+      "research"
+    ],
+    "assumptions": [],
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Franz Mertens proved in 1874 three theorems on the distribution of primes, of which the second states Σ_{p ≤ x} 1/p = log log x + M + o(1), where M ≈ 0.2615 is the Meissel–Mertens constant. It is a genuine quantitative refinement of Euler's 1737 observation that Σ 1/p diverges: not only is the sum unbounded, it grows like log log x — extraordinarily slowly. The classical elementary proof passes through the Euler product ∏_{p ≤ N}(1 − 1/p)⁻¹, which by unique factorisation dominates the harmonic partial sum H_N, itself ≥ log(N+1). Taking logarithms and controlling the tail Σ (−log(1−1/p) − 1/p) yields the lower bound with an explicit constant. Mathlib formalises only the qualitative divergence (Erdős's rough-number proof from 'Proofs from THE BOOK'), giving no rate; this entry supplies the quantitative lower half.",
+    "problemStatement": "The parent entry erdos-31-primes-density proves the primes have natural density zero and asks (open question 3) whether the logarithmic accumulation rate Σ_{p ≤ N} 1/p ~ log log N can be established. This entry proves the lower half with an explicit constant: for all $N \\geq 1$, $$\\sum_{p \\leq N} \\frac{1}{p} \\;\\geq\\; \\log\\log(N+1) - 1.$$ In particular the prime reciprocal sum is unbounded and grows at least as fast as $\\log\\log N$.",
+    "proofStrategy": "The proof is the classical Euler-product argument in three steps. (1) Euler product lower bound (harmonic_le_euler_product): the harmonic partial sum Σ_{k=1}^{N} 1/k is dominated by the finite Euler product ∏_{p ≤ N}(1 − 1/p)⁻¹. This is obtained from Mathlib's smooth-number Euler product `EulerProduct.summable_and_hasSum_smoothNumbers_prod_primesBelow_geometric` applied to the reciprocal monoid homomorphism n ↦ (n:ℝ)⁻¹: the product equals the tsum of 1/m over (N+1)-smooth numbers m, and every k ∈ [1,N] is (N+1)-smooth, so the finite subsum of nonnegative terms is ≤ the total. (2) Log-tail bound (sum_log_euler_factor_le): Σ_{p ≤ N} log((1−1/p)⁻¹) ≤ Σ_{p ≤ N} 1/p + 1, using per prime log((1−1/p)⁻¹) ≤ (1−1/p)⁻¹ − 1 = 1/(p−1) = 1/p + 1/(p(p−1)) (Mathlib's `Real.log_le_sub_one_of_pos`), and a telescoping bound Σ_p 1/(p(p−1)) ≤ Σ_{n=2}^{N} 1/(n(n−1)) = 1 − 1/N ≤ 1. (3) Assembly: chain log(N+1) ≤ H_N (Mathlib's `Real.log_add_one_le_harmonic`) with step (1) to get log(N+1) ≤ ∏; take logarithms (monotonicity) and apply `Real.log_prod` and step (2) to conclude log log(N+1) ≤ Σ 1/p + 1.",
+    "keyInsights": [
+      "Mathlib provides the divergence of Σ 1/p only qualitatively (`not_summable_one_div_on_primes`), via Erdős's rough-number counting argument, which yields no growth rate. Recovering the log log N rate requires a genuinely different route — the Euler product — not a repackaging of the existing result.",
+      "The reciprocal map n ↦ (n:ℝ)⁻¹ is a multiplicative monoid homomorphism ℕ →* ℝ (with 0⁻¹ = 0), because (ab)⁻¹ = a⁻¹b⁻¹ in a field. This lets Mathlib's `EulerProduct.summable_and_hasSum_smoothNumbers_prod_primesBelow_geometric` apply directly — crucially it needs only ‖f p‖ < 1 per prime, NOT global summability (the harmonic series is not summable), so the finite product over primes ≤ N equals the convergent tsum of 1/m over smooth numbers.",
+      "The bridge from the finite harmonic sum to the smooth-number tsum is `Summable.sum_le_tsum`: every k ∈ [1,N] is (N+1)-smooth, and all terms 1/m ≥ 0, so the finite subsum is ≤ the total. This is the formal content of 'unique factorisation expands the product to cover all of {1,…,N}'.",
+      "The tail Σ_p (−log(1−1/p) − 1/p) is bounded by the elementary inequality log x ≤ x − 1 (Mathlib `Real.log_le_sub_one_of_pos`) applied to x = (1−1/p)⁻¹, giving the clean per-prime bound 1/(p−1) = 1/p + 1/(p(p−1)) with a telescoping tail summing to < 1.",
+      "The result is the lower half of Mertens' second theorem. The matching upper bound (Σ 1/p ≤ log log N + O(1)) and the sharp constant M require partial summation against a Chebyshev bound and are not proved here — see the open questions."
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Primes ≤ N and Euler Factor Positivity",
+      "startLine": 34,
+      "endLine": 62,
+      "summary": "Defines primesLe N = primes ≤ N as a Finset, with membership lemma mem_primesLe. Proves each Euler factor (1 − 1/p)⁻¹ is strictly positive (euler_factor_pos, euler_factor_ne) and hence the finite Euler product is positive (euler_product_pos)."
+    },
+    {
+      "id": "euler-product",
+      "title": "Step 1 — Euler Product Lower Bound",
+      "startLine": 64,
+      "endLine": 133,
+      "summary": "Constructs the reciprocal monoid homomorphism invHom : ℕ →* ℝ, identifies primesLe N with Nat.primesBelow (N+1), and shows every k ∈ [1,N] is (N+1)-smooth (Icc_subset_smoothNumbers). The crux harmonic_le_euler_product proves Σ_{k=1}^{N} 1/k ≤ ∏_{p ≤ N}(1 − 1/p)⁻¹ via Mathlib's smooth-number Euler product and Summable.sum_le_tsum."
+    },
+    {
+      "id": "log-tail",
+      "title": "Step 2 — Log-Tail Bound",
+      "startLine": 134,
+      "endLine": 218,
+      "summary": "Proves the telescoping identity Σ_{n=2}^{N+1} 1/(n(n−1)) = 1 − 1/(N+1) (tail_sum_Icc) and hence Σ_{p ≤ N} 1/(p(p−1)) ≤ 1 (tail_bound). Combines with the per-prime bound log((1−1/p)⁻¹) ≤ 1/p + 1/(p(p−1)) (from Real.log_le_sub_one_of_pos) to prove sum_log_euler_factor_le: Σ log((1−1/p)⁻¹) ≤ Σ 1/p + 1."
+    },
+    {
+      "id": "main-result",
+      "title": "Mertens' Lower Bound",
+      "startLine": 219,
+      "endLine": 259,
+      "summary": "Main theorem mertens_reciprocal_lower_bound: for N ≥ 1, log log(N+1) − 1 ≤ Σ_{p ≤ N} 1/p. Chains Real.log_add_one_le_harmonic (log(N+1) ≤ H_N) with Step 1, takes logarithms via Real.log_le_log and Real.log_prod, and bounds using Step 2."
+    }
+  ],
+  "conclusion": {
+    "summary": "For every N ≥ 1, the prime reciprocal sum satisfies Σ_{p ≤ N} 1/p ≥ log log(N+1) − 1, the quantitative lower half of Mertens' second theorem. The proof is fully machine-checked and axiom-free, deriving the log log N growth rate from the classical Euler-product argument where Mathlib supplies only qualitative divergence.",
+    "implications": "The bound makes precise how slowly the primes accumulate on the logarithmic scale: the reciprocal sum diverges, but only at rate log log N. This is a genuine strengthening of Euler's divergence Σ 1/p = ∞ and complements the parent entry's natural-density-zero result — the primes are so thin that even Σ 1/p, weighting small primes heavily, grows doubly-logarithmically. The explicit constant −1 gives a fully effective lower bound valid from N = 1.",
+    "openQuestions": [
+      "Can the matching upper bound Σ_{p ≤ N} 1/p ≤ log log N + O(1) be formalized? This requires partial (Abel) summation of 1/p against a Chebyshev-type bound on θ(N) or π(N), for which the parent entry and the chebyshev-bounds entry already supply the ingredients.",
+      "Can the sharp asymptotic Σ_{p ≤ N} 1/p = log log N + M + o(1) with the Meissel–Mertens constant M ≈ 0.2615 be established, pinning down the constant rather than the O(1) error?",
+      "Can Mertens' third theorem ∏_{p ≤ N}(1 − 1/p) ~ e^{−γ}/log N be derived from the Euler-product infrastructure built here, connecting to the Euler–Mascheroni constant γ?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-31-primes-density",
+      "relationship": "extends",
+      "description": "Directly answers the lower-bound direction of the parent entry's third open question (Σ_{p ≤ N} 1/p ~ log log N). Where the parent proves the primes have natural density zero via the Chebyshev upper bound π(N) = O(N/log N), this entry establishes the complementary quantitative accumulation rate of the reciprocal sum on the logarithmic scale."
+    },
+    {
+      "targetId": "chebyshev-bounds",
+      "relationship": "shares-technique",
+      "description": "Chebyshev's two-sided estimate π(n) = Θ(n/log n) provides the θ(N)/π(N) bounds needed for the matching upper half of Mertens' theorem (via partial summation), which is left open here. Both entries quantify prime distribution beyond mere divergence/infinitude."
+    },
+    {
+      "targetId": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Dirichlet's theorem uses Σ_{p ≡ a (q)} 1/p = ∞ (a Mertens-type divergence in arithmetic progressions) to prove infinitude of primes in residue classes. The log log N rate proved here is the unconditional global version underlying such reciprocal-sum arguments."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/Erdos31PrimesDensityReciprocalOQ03.lean",
+    "lineCount": 259,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "imports": [
+      "import Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos31PrimesDensityReciprocal"
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry answering the **lower-bound direction of open question 3** of the parent entry `erdos-31-primes-density` (the logarithmic accumulation rate of the primes, Mertens' second theorem).

Mathlib supplies only the **qualitative** divergence of Σ 1/p (`not_summable_one_div_on_primes`, via Erdős's rough-number argument), which gives no growth rate. This entry proves the **quantitative lower half** of Mertens' second theorem with an explicit constant, via the classical Euler-product argument:

$$\forall N \geq 1,\quad \sum_{p \leq N} \frac{1}{p} \;\geq\; \log\log(N+1) - 1.$$

## Proof architecture (3 steps)

1. **`harmonic_le_euler_product`** — Σ_{k=1}^N 1/k ≤ ∏_{p ≤ N}(1−1/p)⁻¹. Uses Mathlib's `EulerProduct.summable_and_hasSum_smoothNumbers_prod_primesBelow_geometric` applied to the reciprocal monoid hom `invHom : ℕ →* ℝ` — crucially it needs only ‖f p‖ < 1 per prime, **not** global summability (the harmonic series is not summable). Every k ≤ N is (N+1)-smooth, so `Summable.sum_le_tsum` gives the finite subsum ≤ the smooth-number tsum = the product.
2. **`sum_log_euler_factor_le`** — Σ log((1−1/p)⁻¹) ≤ Σ 1/p + 1. Per prime, `Real.log_le_sub_one_of_pos` on x = (1−1/p)⁻¹ gives the clean closed form 1/(p−1) = 1/p + 1/(p(p−1)); a telescoping tail Σ 1/(p(p−1)) ≤ Σ_{n=2}^N 1/(n(n−1)) = 1 − 1/N ≤ 1.
3. **Assembly** — chain `Real.log_add_one_le_harmonic` (log(N+1) ≤ H_N) with Step 1, take logs (`Real.log_le_log`, `Real.log_prod`), bound with Step 2.

## Verification

- **0 axioms**: `#print axioms mertens_reciprocal_lower_bound` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`)
- **0 sorries**, 12 theorems/lemmas, 259 lines, imports only Mathlib
- Verified via `lake env lean Proofs/Erdos31PrimesDensityReciprocalOQ03.lean` (0 errors, 0 warnings)

## Files
- `proofs/Proofs/Erdos31PrimesDensityReciprocalOQ03.lean`
- `src/data/proofs/erdos-31-primes-density-oq-03/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)