### PR TITLE
Enrich The British Flag Theorem: add module-header section

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/meta.json
@@ -73,6 +73,14 @@
   ],
   "sections": [
     {
+      "id": "header-and-statement",
+      "title": "Module Header and Statement",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "Imports Mathlib.Tactic and opens the module docstring, which states the theorem PA² + PC² = PB² + PD² and fixes the algebraic encoding of a rectangle: the parallelogram closure hpar (C = B + D − A) and the right angle hperp (edge vectors B − A and D − A orthogonal). The docstring also previews the proof idea — (PA² + PC²) − (PB² + PD²) = 2(u ⬝ v) vanishes by hperp — before the BritishFlagTheorem namespace opens.",
+      "mathContext": "Rectangle encoded by $C = B + D - A$ and $(B-A)\\cdot(D-A) = 0$; the target identity is $PA^2 + PC^2 = PB^2 + PD^2$."
+    },
+    {
       "id": "setup",
       "title": "Coordinate Setup and Squared Distance",
       "startLine": 28,


### PR DESCRIPTION
Enrichment pass for `british-flag-theorem-oq-01` ("The British Flag Theorem").

## Coverage
- **Added `header-and-statement` section** (lines 1–27). The existing two sections started at line 28, leaving the imports and module docstring — which state the theorem and fix the algebraic rectangle encoding (parallelogram closure `C = B + D − A` and right angle `(B−A)·(D−A)=0`) — with no section entry. The section mirrors the existing `ann-intro` annotation covering the same range.

No content deleted. Entry was already well-curated (annotations and keyInsights maxed, conclusion/crossRefs/references present); only the genuine section-coverage gap was filled. Verified with `pnpm build` (✓ built).