### PR TITLE
research(det-conjugate-transpose-oq-01-oq-03): orthogonal determinant is ±1, SO(n) as kernel of the sign character [VERIFIED, 0-axiom, 11thm/162L, new entry]

### DIFF
--- a/proofs/Proofs/DetConjugateTransposeOQ01OQ03.lean
+++ b/proofs/Proofs/DetConjugateTransposeOQ01OQ03.lean
@@ -1,0 +1,162 @@
+/-
+  The orthogonal analogue of `det : U(n) → U(1)`:  `det O = ±1` for `OᵀO = 1`.
+
+  The parent entry (`det Mᴴ = star (det M)`) derives, over `ℂ`, that a unitary
+  matrix `U` (`Uᴴ U = 1`) has `‖det U‖ = 1` — the determinant map `U(n) → U(1)`.
+  Its open question #3 asks for the *real orthogonal* analogue: what is `det O`
+  when `Oᵀ O = 1`?
+
+  Replacing the conjugate transpose `ᴴ` by the plain transpose `ᵀ` collapses the
+  scalar relation.  Applying `det` to `Oᵀ O = 1` and using `det Oᵀ = det O`
+  (rather than `det Uᴴ = star (det U)`) gives
+
+      (det O)² = 1,
+
+  so over any integral domain `det O = 1` or `det O = -1`, and over `ℝ`
+  `|det O| = 1`.  Where the unitary determinant ranges over the whole unit
+  *circle* `U(1)`, the orthogonal determinant is pinned to the two-element group
+  `{±1}`.  This is the determinant **sign character** `O(n) → {±1}`, whose kernel
+  is exactly the special orthogonal group `SO(n)`.
+
+  Contents:
+    * `det_mul_self_of_orthogonal` — the ring-level identity `(det O)² = 1`
+      (holds over any `CommRing`; this is the shared core).
+    * `isUnit_det_of_orthogonal`   — hence `det O` is a unit.
+    * `det_eq_one_or_neg_one_of_orthogonal` — over an integral domain, `det O = ±1`.
+    * `real_orthogonal_det`, `abs_det_eq_one_of_orthogonal` — the `ℝ` headline.
+    * `orthogonal_mul` — the orthogonal matrices are closed under products, so the
+      sign is multiplicative: `O(n) → {±1}` is a group homomorphism.
+    * `mem_orthogonalGroup_of_transpose_mul`, `mem_specialOrthogonalGroup_iff_det_one`
+      — `SO(n)` is exactly the `det = 1` fibre (the kernel of the sign character).
+    * Worked instances: the identity has sign `+1`; the reflection `diag(-1, 1)`
+      is orthogonal with sign `-1`, so the character hits both values.
+
+  Verified: 0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound;
+  no native_decide, no Lean.ofReduceBool).
+-/
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.LinearAlgebra.UnitaryGroup
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
+
+open Matrix
+
+-- Mathlib's `Matrix.orthogonalGroup` / `specialOrthogonalGroup` are the unitary
+-- groups taken with the trivial `star = id` ring structure on a commutative ring,
+-- so working with them requires that star structure in scope.
+attribute [local instance] starRingOfComm
+
+namespace DetConjugateTransposeOQ01OQ03
+
+/-! ### The shared core: `(det O)² = 1` over any commutative ring -/
+
+/-- **Orthogonal determinant squares to one.**  If `Oᵀ * O = 1` then
+`det O * det O = 1`.  This is the transpose analogue of
+`star (det U) * det U = 1` for the unitary case: applying `det` to `Oᵀ O = 1`
+and using `det Oᵀ = det O` (in place of `det Uᴴ = star (det U)`) removes the
+`star`, leaving a genuine square.  Holds over any `CommRing`. -/
+theorem det_mul_self_of_orthogonal {R : Type*} [CommRing R]
+    {n : Type*} [Fintype n] [DecidableEq n] {O : Matrix n n R}
+    (hO : Oᵀ * O = 1) : det O * det O = 1 := by
+  have h := congrArg det hO
+  rwa [det_mul, det_transpose, det_one] at h
+
+/-- The determinant of an orthogonal matrix is a unit (it is its own inverse). -/
+theorem isUnit_det_of_orthogonal {R : Type*} [CommRing R]
+    {n : Type*} [Fintype n] [DecidableEq n] {O : Matrix n n R}
+    (hO : Oᵀ * O = 1) : IsUnit (det O) :=
+  IsUnit.of_mul_eq_one _ (det_mul_self_of_orthogonal hO)
+
+/-! ### Over an integral domain: `det O = ±1` -/
+
+/-- **Orthogonal determinant is `±1`.**  Over any integral domain, `Oᵀ O = 1`
+forces `det O = 1 ∨ det O = -1`.  Factor `(det O)² - 1 = (det O - 1)(det O + 1)`;
+no zero divisors makes one factor vanish. -/
+theorem det_eq_one_or_neg_one_of_orthogonal {R : Type*} [CommRing R] [IsDomain R]
+    {n : Type*} [Fintype n] [DecidableEq n] {O : Matrix n n R}
+    (hO : Oᵀ * O = 1) : det O = 1 ∨ det O = -1 := by
+  have h : det O * det O = 1 := det_mul_self_of_orthogonal hO
+  have hfac : (det O - 1) * (det O + 1) = 0 := by linear_combination h
+  rcases mul_eq_zero.mp hfac with h1 | h1
+  · exact Or.inl (sub_eq_zero.mp h1)
+  · exact Or.inr (eq_neg_of_add_eq_zero_left h1)
+
+/-! ### The `ℝ` headline -/
+
+/-- **Real orthogonal determinant is `±1`** (open question #3, verbatim).
+For a real matrix with `Oᵀ O = 1`, `det O = 1 ∨ det O = -1`. -/
+theorem real_orthogonal_det {n : Type*} [Fintype n] [DecidableEq n]
+    {O : Matrix n n ℝ} (hO : Oᵀ * O = 1) : det O = 1 ∨ det O = -1 :=
+  det_eq_one_or_neg_one_of_orthogonal hO
+
+/-- **Real orthogonal determinant has absolute value one**: `|det O| = 1`.
+The real shadow of the unitary `‖det U‖ = 1` — but confined to `{±1}` rather
+than the whole unit circle. -/
+theorem abs_det_eq_one_of_orthogonal {n : Type*} [Fintype n] [DecidableEq n]
+    {O : Matrix n n ℝ} (hO : Oᵀ * O = 1) : |det O| = 1 := by
+  rcases real_orthogonal_det hO with h | h <;> rw [h] <;> norm_num
+
+/-! ### Multiplicativity: the sign character `O(n) → {±1}` -/
+
+/-- **Orthogonal matrices are closed under multiplication**: if `Oᵀ O = 1` and
+`Pᵀ P = 1` then `(O P)ᵀ (O P) = 1`.  Together with `det (O P) = det O · det P`
+this makes the sign `det : O(n) → {±1}` a group homomorphism. -/
+theorem orthogonal_mul {R : Type*} [CommRing R]
+    {n : Type*} [Fintype n] [DecidableEq n] {O P : Matrix n n R}
+    (hO : Oᵀ * O = 1) (hP : Pᵀ * P = 1) : (O * P)ᵀ * (O * P) = 1 := by
+  rw [transpose_mul, mul_assoc, ← mul_assoc Oᵀ O P, hO, one_mul, hP]
+
+/-- The sign is multiplicative on orthogonal matrices: `det (O P) = det O · det P`,
+each factor being `±1`.  (This is just `det_mul`, recorded here to make the
+homomorphism `O(n) → {±1}` explicit.) -/
+theorem det_mul_of_orthogonal {R : Type*} [CommRing R]
+    {n : Type*} [Fintype n] [DecidableEq n] (O P : Matrix n n R) :
+    det (O * P) = det O * det P :=
+  det_mul O P
+
+/-! ### `SO(n)` is the kernel of the sign character -/
+
+/-- Bridge to Mathlib's `orthogonalGroup`: `Oᵀ O = 1` means `O ∈ O(n)`. -/
+theorem mem_orthogonalGroup_of_transpose_mul {R : Type*} [CommRing R]
+    {n : Type*} [Fintype n] [DecidableEq n] {O : Matrix n n R}
+    (hO : Oᵀ * O = 1) : O ∈ Matrix.orthogonalGroup n R :=
+  (Matrix.mem_orthogonalGroup_iff' n R).mpr hO
+
+/-- **`SO(n)` is the `det = 1` fibre.**  An orthogonal matrix lies in the special
+orthogonal group iff its determinant is `1` — i.e. `SO(n)` is exactly the kernel
+of the sign character `O(n) → {±1}`. -/
+theorem mem_specialOrthogonalGroup_iff_det_one {R : Type*} [CommRing R]
+    {n : Type*} [Fintype n] [DecidableEq n] {O : Matrix n n R}
+    (hO : Oᵀ * O = 1) : O ∈ Matrix.specialOrthogonalGroup n R ↔ det O = 1 := by
+  rw [Matrix.mem_specialOrthogonalGroup_iff]
+  exact and_iff_right (mem_orthogonalGroup_of_transpose_mul hO)
+
+/-! ### Worked instances: both signs are attained -/
+
+/-- The identity is orthogonal with sign `+1`: it lies in `SO(n)`. -/
+example : det (1 : Matrix (Fin 2) (Fin 2) ℝ) = 1 := det_one
+
+example : (1 : Matrix (Fin 2) (Fin 2) ℝ) ∈ Matrix.specialOrthogonalGroup (Fin 2) ℝ :=
+  (mem_specialOrthogonalGroup_iff_det_one (by simp)).mpr det_one
+
+/-- The reflection `diag(-1, 1)` is orthogonal (`Oᵀ O = 1`)… -/
+theorem reflection_orthogonal :
+    (!![(-1 : ℝ), 0; 0, 1])ᵀ * !![(-1 : ℝ), 0; 0, 1] = 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two]
+
+/-- …with sign `-1`.  So the sign character is onto `{±1}`, and this reflection
+lies in `O(2) \ SO(2)`. -/
+theorem reflection_det : det (!![(-1 : ℝ), 0; 0, 1]) = -1 := by
+  rw [Matrix.det_fin_two_of]; ring
+
+example : det (!![(-1 : ℝ), 0; 0, 1]) = 1 ∨ det (!![(-1 : ℝ), 0; 0, 1]) = -1 :=
+  real_orthogonal_det reflection_orthogonal
+
+/-- The reflection is *not* in `SO(2)`, confirming `SO(2) ⊊ O(2)`. -/
+example : (!![(-1 : ℝ), 0; 0, 1]) ∉ Matrix.specialOrthogonalGroup (Fin 2) ℝ := by
+  rw [mem_specialOrthogonalGroup_iff_det_one reflection_orthogonal, reflection_det]
+  norm_num
+
+end DetConjugateTransposeOQ01OQ03

--- a/src/data/proofs/det-conjugate-transpose-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01-oq-03/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-shared-core",
+    "proofId": "det-conjugate-transpose-oq-01-oq-03",
+    "range": {
+      "startLine": 53,
+      "endLine": 68
+    },
+    "type": "theorem",
+    "title": "The Shared Core: (det O)² = 1 (det_mul_self_of_orthogonal, isUnit_det_of_orthogonal)",
+    "content": "det_mul_self_of_orthogonal applies det to the orthogonality relation OᵀO = 1: rewriting det(Oᵀ * O) = det 1 with Matrix.det_mul, Matrix.det_transpose and Matrix.det_one turns it into det O · det O = 1. This is the exact transpose analogue of the parent's unitary identity star (det U) · det U = 1 — the only change is that det Oᵀ = det O carries no conjugation, so the star is replaced by the identity and a modulus condition becomes a genuine square. It holds over any commutative ring. isUnit_det_of_orthogonal reads off immediately that det O is a unit (its own inverse) via IsUnit.of_mul_eq_one.",
+    "mathContext": "$O^{\\mathsf T}O = 1 \\Rightarrow \\det O \\cdot \\det O = 1$.",
+    "prerequisites": [
+      "The transpose Oᵀ and determinant on square matrices",
+      "Matrix.det_mul, Matrix.det_transpose, Matrix.det_one",
+      "IsUnit.of_mul_eq_one"
+    ],
+    "relatedConcepts": [
+      "determinant",
+      "transpose",
+      "unit element"
+    ],
+    "significance": "foundational"
+  },
+  {
+    "id": "ann-domain-pm-one",
+    "proofId": "det-conjugate-transpose-oq-01-oq-03",
+    "range": {
+      "startLine": 72,
+      "endLine": 82
+    },
+    "type": "theorem",
+    "title": "Over an Integral Domain: det O = ±1 (det_eq_one_or_neg_one_of_orthogonal)",
+    "content": "det_eq_one_or_neg_one_of_orthogonal upgrades the square (det O)² = 1 to the dichotomy det O = 1 ∨ det O = -1 over any integral domain. The proof factors (det O − 1)(det O + 1) = det O² − 1 = 0 by linear_combination, then uses the defining property of a domain — no zero divisors, mul_eq_zero — to conclude one factor vanishes: det O − 1 = 0 gives det O = 1 (sub_eq_zero), and det O + 1 = 0 gives det O = -1 (eq_neg_of_add_eq_zero_left). No order or absolute value is used here; the dichotomy is purely about the absence of zero divisors.",
+    "mathContext": "$(\\det O)^2 = 1 \\Rightarrow \\det O = 1 \\lor \\det O = -1$.",
+    "prerequisites": [
+      "Integral domains and mul_eq_zero (no zero divisors)",
+      "linear_combination for the factorisation",
+      "sub_eq_zero, eq_neg_of_add_eq_zero_left"
+    ],
+    "relatedConcepts": [
+      "integral domain",
+      "roots of X² − 1",
+      "determinant sign"
+    ],
+    "significance": "critical"
+  },
+  {
+    "id": "ann-real-headline",
+    "proofId": "det-conjugate-transpose-oq-01-oq-03",
+    "range": {
+      "startLine": 84,
+      "endLine": 97
+    },
+    "type": "theorem",
+    "title": "The ℝ Headline: det O = ±1 and |det O| = 1 (real_orthogonal_det, abs_det_eq_one_of_orthogonal)",
+    "content": "real_orthogonal_det specialises the dichotomy to real matrices — the verbatim answer to the parent's open question #3: for O : Matrix n n ℝ with OᵀO = 1, det O = 1 ∨ det O = -1. abs_det_eq_one_of_orthogonal turns this into |det O| = 1 by case-splitting on the two values and closing each with norm_num. This is the real shadow of the unitary ‖det U‖ = 1: both say the determinant has absolute value one, but the orthogonal determinant is confined to the two points {±1} where the unitary determinant filled the whole unit circle U(1).",
+    "mathContext": "$O^{\\mathsf T}O = 1 \\Rightarrow \\det O \\in \\{1,-1\\},\\ |\\det O| = 1$.",
+    "prerequisites": [
+      "det_eq_one_or_neg_one_of_orthogonal specialised to ℝ",
+      "The absolute value on ℝ and norm_num"
+    ],
+    "relatedConcepts": [
+      "real orthogonal matrix",
+      "absolute value one",
+      "unit circle vs {±1}"
+    ],
+    "significance": "critical"
+  },
+  {
+    "id": "ann-multiplicativity",
+    "proofId": "det-conjugate-transpose-oq-01-oq-03",
+    "range": {
+      "startLine": 99,
+      "endLine": 115
+    },
+    "type": "theorem",
+    "title": "Multiplicativity: the Sign Character O(n) → {±1} (orthogonal_mul, det_mul_of_orthogonal)",
+    "content": "orthogonal_mul proves the orthogonal matrices are closed under multiplication: (OP)ᵀ(OP) = Pᵀ Oᵀ O P = Pᵀ (OᵀO) P = Pᵀ P = 1, by transpose_mul and reassociation. Together with det_mul_of_orthogonal (det(OP) = det O · det P, i.e. Matrix.det_mul recorded explicitly), this exhibits the sign det : O(n) → {±1} as a group homomorphism — the orientation character. Its multiplicativity is the real counterpart of the unitary det : U(n) → U(1) being a homomorphism onto the circle.",
+    "mathContext": "$(OP)^{\\mathsf T}(OP) = P^{\\mathsf T}(O^{\\mathsf T}O)P = 1$; $\\det(OP) = \\det O\\,\\det P$.",
+    "prerequisites": [
+      "Matrix.transpose_mul and associativity of matrix multiplication",
+      "Matrix.det_mul"
+    ],
+    "relatedConcepts": [
+      "orthogonal group closure",
+      "group homomorphism",
+      "orientation character"
+    ],
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-so-kernel",
+    "proofId": "det-conjugate-transpose-oq-01-oq-03",
+    "range": {
+      "startLine": 117,
+      "endLine": 132
+    },
+    "type": "theorem",
+    "title": "SO(n) is the Kernel of the Sign Character (mem_orthogonalGroup_of_transpose_mul, mem_specialOrthogonalGroup_iff_det_one)",
+    "content": "mem_orthogonalGroup_of_transpose_mul bridges the hypothesis OᵀO = 1 to Mathlib's Matrix.orthogonalGroup membership via mem_orthogonalGroup_iff'. mem_specialOrthogonalGroup_iff_det_one then shows an orthogonal matrix lies in Matrix.specialOrthogonalGroup iff its determinant is 1: SO(n) is exactly the det = 1 fibre, the kernel of the sign character O(n) → {±1}. Mathlib defines orthogonalGroup as the unitary group taken with the trivial star = id structure, so these lemmas require starRingOfComm as a local instance — recorded once at the top of the file.",
+    "mathContext": "$O \\in SO(n) \\iff \\det O = 1$, for orthogonal $O$.",
+    "prerequisites": [
+      "Matrix.mem_orthogonalGroup_iff' (O ∈ O(n) ↔ Oᵀ O = 1)",
+      "Matrix.mem_specialOrthogonalGroup_iff (SO(n) = O(n) ∧ det = 1)",
+      "The local instance starRingOfComm (star = id on a commutative ring)"
+    ],
+    "relatedConcepts": [
+      "special orthogonal group SO(n)",
+      "kernel of a character",
+      "rotations vs reflections"
+    ],
+    "significance": "critical"
+  },
+  {
+    "id": "ann-worked-instances",
+    "proofId": "det-conjugate-transpose-oq-01-oq-03",
+    "range": {
+      "startLine": 134,
+      "endLine": 160
+    },
+    "type": "example",
+    "title": "Worked Instances: Both Signs are Attained",
+    "content": "The identity matrix has determinant 1 and lies in SO(2) — a rotation. reflection_orthogonal verifies that the reflection diag(-1, 1) satisfies OᵀO = 1 (a direct 2×2 computation via mul_apply and Fin.sum_univ_two), and reflection_det computes its determinant as -1 (det_fin_two_of). So this reflection lies in O(2) but not in SO(2): the sign character is surjective onto {±1}, and SO(2) is a proper index-two subgroup of O(2). This is the algebraic form of the rotations-vs-reflections split.",
+    "mathContext": "$\\det \\mathbf 1 = 1$ (rotation, in $SO(2)$); $\\det \\operatorname{diag}(-1,1) = -1$ (reflection, in $O(2)\\setminus SO(2)$).",
+    "prerequisites": [
+      "Matrix.det_fin_two_of and the 2×2 matrix literal notation",
+      "mem_specialOrthogonalGroup_iff_det_one"
+    ],
+    "relatedConcepts": [
+      "reflection matrix",
+      "surjectivity of the sign",
+      "index-two subgroup"
+    ],
+    "significance": "supporting"
+  }
+]

--- a/src/data/proofs/det-conjugate-transpose-oq-01-oq-03/meta.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01-oq-03/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "det-conjugate-transpose-oq-01-oq-03",
+  "title": "The Orthogonal Determinant is ±1: det O = ±1 for OᵀO = 1, and SO(n) as the Kernel of the Sign Character",
+  "slug": "det-conjugate-transpose-oq-01-oq-03",
+  "description": "Open question #3 of the conjugate-transpose determinant entry: what is the real orthogonal analogue of the unitary det : U(n) → U(1) picture? Replacing the conjugate transpose ᴴ by the plain transpose ᵀ collapses the scalar relation. Applying det to OᵀO = 1 and using det Oᵀ = det O (in place of det Uᴴ = star det U) removes the conjugation and leaves a genuine square, (det O)² = 1. Over any integral domain this forces det O = 1 or det O = -1, and over ℝ, |det O| = 1. Where the unitary determinant ranges over the whole unit circle U(1), the orthogonal determinant is pinned to the two-element group {±1}: this is the determinant sign character O(n) → {±1} (the orientation character), whose kernel is exactly the special orthogonal group SO(n). The entry proves the ring-level core (det O)² = 1 over any CommRing, the ±1 dichotomy over an integral domain, the ℝ statements det O = ±1 and |det O| = 1, closure of the orthogonal matrices under products (making the sign multiplicative), and the characterisation of SO(n) as the det = 1 fibre. Worked instances: the identity has sign +1 (in SO), while the reflection diag(-1, 1) is orthogonal with sign -1 (in O(2) \\ SO(2)), so the character is onto {±1}.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
+      "Mathlib.LinearAlgebra.UnitaryGroup",
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix"
+    ],
+    "namespace": "DetConjugateTransposeOQ01OQ03",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/DetConjugateTransposeOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Orthogonal_group",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DetConjugateTransposeOQ01OQ03.lean",
+    "tags": [
+      "linear-algebra",
+      "matrix",
+      "determinant",
+      "orthogonal-group",
+      "special-orthogonal-group",
+      "transpose",
+      "sign-character"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "det_mul_self_of_orthogonal: the ring-level core (det O)² = 1 from OᵀO = 1 over any commutative ring, via det Oᵀ = det O (the transpose analogue of star (det U) · det U = 1)",
+      "isUnit_det_of_orthogonal: hence det O is a unit (its own inverse)",
+      "det_eq_one_or_neg_one_of_orthogonal: over an integral domain, det O = 1 ∨ det O = -1, by factoring (det O − 1)(det O + 1) = 0 with no zero divisors",
+      "real_orthogonal_det / abs_det_eq_one_of_orthogonal: the ℝ headline answering the open question — det O = ±1 and |det O| = 1 for a real matrix with OᵀO = 1",
+      "orthogonal_mul: the orthogonal matrices are closed under products, (OP)ᵀ(OP) = 1, so the sign det : O(n) → {±1} is a group homomorphism",
+      "mem_orthogonalGroup_of_transpose_mul / mem_specialOrthogonalGroup_iff_det_one: SO(n) is exactly the det = 1 fibre — the kernel of the sign character — bridging to Mathlib's Matrix.specialOrthogonalGroup",
+      "reflection_orthogonal / reflection_det: the reflection diag(-1, 1) witnesses sign -1, so the character is surjective onto {±1} and SO(2) ⊊ O(2)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_transpose",
+        "description": "det Oᵀ = det O — the transpose analogue of det_conjTranspose; applied to OᵀO = 1 it produces (det O)² = 1 (with no star).",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_mul / Matrix.det_one",
+        "description": "Multiplicativity of det and det 1 = 1; used to apply det to the orthogonality relation OᵀO = 1 and to make the sign character multiplicative.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.mem_orthogonalGroup_iff' / Matrix.mem_specialOrthogonalGroup_iff",
+        "description": "Membership characterisations O ∈ orthogonalGroup n R ↔ Oᵀ O = 1 and O ∈ specialOrthogonalGroup n R ↔ (O ∈ orthogonalGroup ∧ det O = 1); used to identify SO(n) as the det = 1 fibre. Requires the trivial star-ring structure starRingOfComm in scope.",
+        "module": "Mathlib.LinearAlgebra.UnitaryGroup"
+      },
+      {
+        "theorem": "Matrix.det_fin_two_of",
+        "description": "det !![a,b;c,d] = a*d − b*c; used to compute det of the 2×2 reflection witness as -1.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      }
+    ],
+    "relatedProblems": [
+      {
+        "id": "det-conjugate-transpose-oq-01",
+        "relationship": "Parent entry. This answers its open question #3: the real orthogonal analogue of the unitary det : U(n) → U(1) result. The unitary determinant lies on the whole unit circle U(1); the orthogonal determinant is confined to the two-point group {±1}, because the plain transpose (det Oᵀ = det O) replaces the conjugate transpose (det Uᴴ = star det U), turning a modulus-one condition into a genuine square."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 162,
+    "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All 11 theorems depend only on the foundational propext / Classical.choice / Quot.sound. The core identity (det O)² = 1 applies det to OᵀO = 1 using Matrix.det_mul, Matrix.det_transpose, Matrix.det_one — the plain transpose (det Oᵀ = det O) is what distinguishes this from the unitary case (det Uᴴ = star det U). The ±1 dichotomy over an integral domain factors (det O − 1)(det O + 1) = 0 (linear_combination) and uses no zero divisors (mul_eq_zero, sub_eq_zero, eq_neg_of_add_eq_zero_left); the ℝ absolute-value statement is a two-case norm_num. The SO(n) characterisation uses Matrix.mem_orthogonalGroup_iff' and Matrix.mem_specialOrthogonalGroup_iff, which require the trivial star structure starRingOfComm as a local instance (Mathlib defines orthogonalGroup as the unitary group with star = id). The genuine hypothesis throughout is OᵀO = 1.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Orthogonal matrices (OᵀO = 1) are the real analogue of unitary matrices: they preserve the Euclidean inner product and model rigid rotations and reflections of ℝⁿ. The determinant splits the orthogonal group O(n) into two pieces by its sign: the rotations, with det = +1, form the special orthogonal group SO(n) (a connected group), and the orientation-reversing motions, with det = -1, form the other coset. This sign is the orientation character O(n) → {±1}, the real counterpart of the determinant homomorphism U(n) → U(1) whose image is the whole unit circle. The contrast is structural: over ℂ the determinant of a length-preserving map can be any phase; over ℝ it can only be ±1, because a real number whose square is 1 is ±1.",
+    "problemStatement": "Prove the real orthogonal analogue of the unitary determinant result: if a real matrix O satisfies OᵀO = 1 then det O = ±1 (equivalently |det O| = 1), the sign det : O(n) → {±1} is a group homomorphism, and its kernel is exactly the special orthogonal group SO(n).",
+    "text": "The parent entry showed that a unitary matrix has ‖det U‖ = 1 — its determinant lies on the unit circle U(1). Its open question #3 asks for the orthogonal analogue. This entry establishes it: the plain transpose satisfies det Oᵀ = det O (no conjugation), so applying det to OᵀO = 1 gives (det O)² = 1 rather than star(det O)·det O = 1. Over ℝ this pins det O to {±1}, confining the orthogonal determinant to a two-element group where the unitary determinant filled a circle.",
+    "proofStrategy": "det_mul_self_of_orthogonal applies det to OᵀO = 1 and rewrites with Matrix.det_mul, Matrix.det_transpose, Matrix.det_one to obtain det O · det O = 1 over any commutative ring — the shared core, and the exact transpose analogue of the unitary star (det U) · det U = 1 with star replaced by the identity. isUnit_det_of_orthogonal reads off that det O is a unit. det_eq_one_or_neg_one_of_orthogonal upgrades the square to a dichotomy over an integral domain: (det O − 1)(det O + 1) = det O² − 1 = 0 (linear_combination), and the absence of zero divisors (mul_eq_zero) makes one factor vanish, giving det O = 1 (sub_eq_zero) or det O = -1 (eq_neg_of_add_eq_zero_left). real_orthogonal_det specialises to ℝ and abs_det_eq_one_of_orthogonal turns the dichotomy into |det O| = 1 by norm_num on the two cases. orthogonal_mul proves closure, (OP)ᵀ(OP) = Pᵀ(OᵀO)P = 1, so with det_mul the sign is a homomorphism O(n) → {±1}. mem_orthogonalGroup_of_transpose_mul and mem_specialOrthogonalGroup_iff_det_one connect to Mathlib's groups: an orthogonal O lies in SO(n) iff det O = 1 — SO(n) is the kernel of the sign character. Finally reflection_orthogonal and reflection_det exhibit diag(-1, 1) as an orthogonal matrix of sign -1, showing the character is onto {±1} and SO(2) ⊊ O(2).",
+    "keyInsights": [
+      "**Transpose vs conjugate transpose is exactly the difference between {±1} and the unit circle.** The unitary proof used det Uᴴ = star (det U) to get star(det U)·det U = ‖det U‖² = 1, a modulus condition solved by the whole circle. The orthogonal proof uses det Oᵀ = det O — the same argument with star replaced by the identity — giving det O·det O = (det O)² = 1, a genuine square whose only real solutions are ±1.",
+      "**The ±1 dichotomy is a statement about zero divisors, not about ℝ.** (det O)² = 1 holds over any commutative ring; the conclusion det O ∈ {±1} needs only an integral domain, where (det O − 1)(det O + 1) = 0 forces a factor to vanish. Over ℝ this additionally reads as |det O| = 1, matching the unitary ‖det U‖ = 1 but confined to two points.",
+      "**The sign is the orientation character O(n) → {±1}.** Closure of orthogonal matrices under products plus multiplicativity of det make det a group homomorphism onto {±1}; its kernel is SO(n). This is the real shadow of det : U(n) → U(1) with kernel SU(n) — but the image is the two-element group rather than the circle.",
+      "**Both signs occur, so the splitting is genuine.** The identity (rotation) has det +1 and lies in SO(n); the reflection diag(-1, 1) has det -1 and lies in O(2) \\ SO(2). The character is surjective, so SO(2) is a proper index-two subgroup of O(2) — the algebraic form of 'rotations vs reflections'."
+    ],
+    "prerequisites": [
+      "The transpose Oᵀ and determinant det on square matrices (Matrix.det)",
+      "Matrix.det_transpose (det Oᵀ = det O), Matrix.det_mul, Matrix.det_one",
+      "Integral domains and mul_eq_zero (no zero divisors); over ℝ, the absolute value",
+      "Mathlib's Matrix.orthogonalGroup / specialOrthogonalGroup (the unitary groups with star = id, via starRingOfComm) and their membership characterisations"
+    ]
+  },
+  "sections": [
+    {
+      "id": "shared-core",
+      "title": "The Shared Core: (det O)² = 1 over any Commutative Ring",
+      "startLine": 51,
+      "endLine": 68,
+      "mathContext": "$O^{\\mathsf T}O = 1 \\Rightarrow (\\det O)^2 = 1$.",
+      "summary": "det_mul_self_of_orthogonal applies det to OᵀO = 1 and rewrites with det_mul, det_transpose, det_one to get det O · det O = 1 — the transpose analogue of the unitary star(det U)·det U = 1, with the conjugation replaced by the identity. isUnit_det_of_orthogonal reads off that det O is a unit."
+    },
+    {
+      "id": "domain-pm-one",
+      "title": "Over an Integral Domain: det O = ±1",
+      "startLine": 70,
+      "endLine": 82,
+      "mathContext": "$(\\det O)^2 = 1 \\Rightarrow \\det O = 1 \\lor \\det O = -1$ (no zero divisors).",
+      "summary": "det_eq_one_or_neg_one_of_orthogonal factors (det O − 1)(det O + 1) = 0 (linear_combination) and uses the absence of zero divisors (mul_eq_zero) to force det O = 1 (sub_eq_zero) or det O = -1 (eq_neg_of_add_eq_zero_left)."
+    },
+    {
+      "id": "real-headline",
+      "title": "The ℝ Headline: det O = ±1 and |det O| = 1",
+      "startLine": 84,
+      "endLine": 97,
+      "mathContext": "$O^{\\mathsf T}O=1 \\Rightarrow \\det O \\in \\{1,-1\\},\\ |\\det O| = 1$.",
+      "summary": "real_orthogonal_det specialises the dichotomy to real matrices (the verbatim answer to open question #3), and abs_det_eq_one_of_orthogonal turns it into |det O| = 1 by norm_num on the two cases — the real shadow of ‖det U‖ = 1, confined to {±1}."
+    },
+    {
+      "id": "multiplicativity",
+      "title": "Multiplicativity: the Sign Character O(n) → {±1}",
+      "startLine": 99,
+      "endLine": 115,
+      "mathContext": "$(OP)^{\\mathsf T}(OP) = P^{\\mathsf T}(O^{\\mathsf T}O)P = 1$; $\\det(OP)=\\det O\\,\\det P$.",
+      "summary": "orthogonal_mul proves closure of orthogonal matrices under products, (OP)ᵀ(OP) = 1, by reassociating Pᵀ(OᵀO)P. Together with det_mul_of_orthogonal (det(OP) = det O · det P), the sign det : O(n) → {±1} is a group homomorphism."
+    },
+    {
+      "id": "so-kernel",
+      "title": "SO(n) is the Kernel of the Sign Character",
+      "startLine": 117,
+      "endLine": 132,
+      "mathContext": "$O \\in SO(n) \\iff \\det O = 1$ (for orthogonal $O$).",
+      "summary": "mem_orthogonalGroup_of_transpose_mul bridges OᵀO = 1 to Mathlib's orthogonalGroup membership, and mem_specialOrthogonalGroup_iff_det_one shows an orthogonal matrix lies in specialOrthogonalGroup iff det O = 1 — SO(n) is exactly the det = 1 fibre, the kernel of the sign character."
+    },
+    {
+      "id": "worked-instances",
+      "title": "Worked Instances: Both Signs are Attained",
+      "startLine": 134,
+      "endLine": 160,
+      "mathContext": "$\\det \\mathbf 1 = 1$ (in $SO$); $\\det\\operatorname{diag}(-1,1) = -1$ (in $O(2)\\setminus SO(2)$).",
+      "summary": "The identity has sign +1 and lies in SO(2); reflection_orthogonal / reflection_det exhibit diag(-1, 1) as orthogonal with sign -1, hence in O(2) \\ SO(2). The sign character is onto {±1}, so SO(2) ⊊ O(2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The real orthogonal analogue of the unitary det : U(n) → U(1) result is formalised sorry-free and axiom-free. From OᵀO = 1 and det Oᵀ = det O one gets (det O)² = 1, hence det O = ±1 over any integral domain and |det O| = 1 over ℝ. The sign det : O(n) → {±1} is a group homomorphism whose kernel is the special orthogonal group SO(n), and the reflection diag(-1, 1) witnesses that both signs occur.",
+    "implications": "Where the unitary determinant fills the unit circle U(1), the orthogonal determinant is pinned to the two-element group {±1} — the single difference being that the plain transpose (det Oᵀ = det O) replaces the conjugate transpose (det Uᴴ = star det U). The sign character O(n) → {±1} splits O(n) into rotations (SO(n), det +1) and orientation-reversing motions (det -1), the real counterpart of U(n)/SU(n).",
+    "openQuestions": [
+      "Does the sign character realise the quotient O(n)/SO(n) ≅ ℤ/2ℤ as a short exact sequence 1 → SO(n) → O(n) → {±1} → 1, formalised at the level of groups?",
+      "What is the analogous statement over a field of characteristic 2, where +1 = -1 collapses the dichotomy and the sign character becomes trivial?"
+    ]
+  },
+  "crossReferences": [
+    "det-conjugate-transpose-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **open question #3** of `det-conjugate-transpose-oq-01`: *"What is the analogous orthogonal statement det O = ±1 for OᵀO = 1 over ℝ?"* — the real orthogonal analogue of the parent's unitary `det : U(n) → U(1)` result.

**The one-line difference from the unitary case:** the plain transpose satisfies `det Oᵀ = det O` (no conjugation), so applying `det` to `OᵀO = 1` gives `(det O)² = 1` rather than `‖det U‖² = 1`. Over ℝ this pins the orthogonal determinant to the two-element group `{±1}`, where the unitary determinant ranged over the whole unit circle `U(1)`.

## Contents (11 theorems, 162 lines, new gallery entry)

| Theorem | Statement |
|---|---|
| `det_mul_self_of_orthogonal` | `(det O)² = 1` over any `CommRing` (shared core) |
| `isUnit_det_of_orthogonal` | `det O` is a unit |
| `det_eq_one_or_neg_one_of_orthogonal` | `det O = ±1` over an integral domain |
| `real_orthogonal_det`, `abs_det_eq_one_of_orthogonal` | the ℝ headline: `det O = ±1`, `\|det O\| = 1` |
| `orthogonal_mul` | orthogonal matrices closed under products → sign character `O(n) → {±1}` |
| `mem_specialOrthogonalGroup_iff_det_one` | `SO(n)` is the `det = 1` fibre (kernel of the sign character) |
| `reflection_orthogonal` / `reflection_det` | `diag(-1,1)` has sign `-1`, so `SO(2) ⊊ O(2)` |

## Verification

`#print axioms` on all theorems → only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). 0 axioms, 0 sorries. Compiled against Mathlib 4.26.0 via `lake env lean`.

## Files
- `proofs/Proofs/DetConjugateTransposeOQ01OQ03.lean`
- `src/data/proofs/det-conjugate-transpose-oq-01-oq-03/{meta,annotations}.json`

## Honesty note
The `SO(n)` characterisation relies on Mathlib's `Matrix.orthogonalGroup`, defined as the unitary group with the trivial `star = id` structure (`starRingOfComm`) — this is recorded as a local instance and disclosed in `assumptions`. No mathematical assumptions beyond the stated hypothesis `OᵀO = 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)