### PR TITLE
Enrich Gauss Sum Bound |τ(χ)|=√p: add missing index.ts

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/index.ts
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BoundedPrimeGapsOQ04OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const boundedPrimeGapsOQ04OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const boundedPrimeGapsOQ04OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const boundedPrimeGapsOQ04OQ03Data: ProofData = {
+  proof: boundedPrimeGapsOQ04OQ03Proof,
+  annotations: boundedPrimeGapsOQ04OQ03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-04-oq-03` ("The Gauss Sum Bound |τ(χ)| = √p: Prime-Modulus Case from Mathlib").

## Critical fix
- **Created `index.ts`** — the entry had none (only meta.json + annotations.json). Without it Vite's `import.meta.glob` cannot discover the proof, so the page renders "proof not found" on the live site even though the entry appears in the gallery listing.

Annotations and sections already cover the full Lean file; the only gap was the missing entry point. Verified with `pnpm build` (✓ built).