### PR TITLE
research(dissection-of-cubes-oq-04-oq-02): 5-cell dihedral angle arccos(1/4) is irrational × π [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DissectionOfCubesOQ04OQ02.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ04OQ02.lean
@@ -1,0 +1,187 @@
+/-
+# Dissection of Cubes — OQ-04 — OQ-02
+## Dehn-style irrationality for a higher-dimensional dihedral angle: the 5-cell arccos(1/4)
+
+The parent entry `DissectionOfCubesOQ04.lean` proves that the dihedral angles of the
+dodecahedron and icosahedron are irrational multiples of `π`, via the Niven/Chebyshev
+integer-sequence technique, and asks (OQ-02):
+
+  *Can this technique be applied to prove irrationality results for other dihedral angles
+   arising in higher-dimensional polytopes?*
+
+This file answers **yes** for the first genuinely higher-dimensional example.  The regular
+`4`-simplex — the **5-cell**, the 4-dimensional analogue of the tetrahedron — has dihedral
+angle `arccos(1/4)` (the regular `n`-simplex has dihedral angle `arccos(1/n)`).  We prove
+
+  **`arccos(1/4)` is an irrational multiple of `π`** (`simplex4Angle_irrational`),
+
+so, exactly as in the Dehn–Hilbert theory, the 5-cell has a nonzero Dehn invariant and cannot
+be scissors-congruent to a 4-cube cross-section built from right dihedral angles alone.
+
+## The technique, adapted
+
+Because `2·cos(arccos(1/4)) = 1/2` has denominator a power of `2`, the right scaling is `2^n`
+(not `4^n`): set `f_n = 2^n · 2cos(n·θ)` with `θ = arccos(1/4)`.  The Chebyshev recurrence
+`2cos((n+2)θ) = (2cosθ)·2cos((n+1)θ) − 2cos(nθ)` becomes the **integer** recurrence
+
+  `f_0 = 2,  f_1 = 1,  f_{n+2} = f_{n+1} − 4·f_n`.
+
+Modulo `2` this is `f_{n+2} ≡ f_{n+1}`, and `f_1 = 1` is odd, so **`f_n` is odd for every
+`n ≥ 1`** (`two_ndvd_cosQuarterSeq_pos`).  But if `θ = (p/q)·π` then
+`cos(q·θ) = cos(p·π) = ±1`, so `f_q = ±2^{q+1}` is even for `q ≥ 1` — a contradiction.
+
+The parity obstruction (prime `2`) replaces the mod-`5` / mod-`3` obstructions of the parent
+file; the `2^n` scaling is what makes the prime `2` available even though `4` is not squarefree.
+
+All results are over `ℝ`, elementary, and axiom-free.
+
+## References
+- Hilbert's third problem; Dehn (1901); Sydler (1965).
+- Niven, I. (1956). *Irrational Numbers.* Carus Math. Monographs 11 (Niven's theorem: the only
+  rational values of `cos(rπ)` for rational `r` are `0, ±1/2, ±1`).
+- Coxeter, H. S. M. *Regular Polytopes.* (Dihedral angle `arccos(1/n)` of the regular `n`-simplex.)
+-/
+
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
+
+namespace DissectionOfCubesOQ04OQ02
+
+open Real
+
+/-! ## Trigonometric helper lemmas (restated for self-containment) -/
+
+/-- Cosine three-term recurrence: `cos((k+2)θ) = 2cosθ·cos((k+1)θ) − cos(kθ)`. -/
+theorem cos_step (θ : ℝ) (k : ℕ) :
+    Real.cos ((↑(k + 2)) * θ) =
+    2 * Real.cos θ * Real.cos ((↑(k + 1)) * θ) - Real.cos (↑k * θ) := by
+  have h1 : (↑(k + 2) : ℝ) * θ = (↑(k + 1)) * θ + θ := by push_cast; ring
+  have h2 : (↑k : ℝ) * θ = (↑(k + 1)) * θ - θ := by push_cast; ring
+  rw [h1, Real.cos_add, h2, Real.cos_sub]
+  ring
+
+/-- `cos(n·π) = (-1)^n` for natural `n`. -/
+theorem cos_nat_mul_pi (n : ℕ) : Real.cos (↑n * Real.pi) = (-1 : ℝ) ^ n := by
+  induction n with
+  | zero => simp [Real.cos_zero]
+  | succ k ih =>
+    have : (↑(k + 1) : ℝ) * Real.pi = ↑k * Real.pi + Real.pi := by push_cast; ring
+    rw [this, Real.cos_add, ih, Real.cos_pi, Real.sin_pi]
+    ring
+
+/-- `cos(n·π) = (-1)^|n|` for integer `n`. -/
+theorem cos_int_mul_pi (n : ℤ) : Real.cos (↑n * Real.pi) = (-1 : ℝ) ^ n.natAbs := by
+  cases n with
+  | ofNat m => exact cos_nat_mul_pi m
+  | negSucc m =>
+    have : (↑(Int.negSucc m) : ℝ) * Real.pi = -((↑(m + 1) : ℝ) * Real.pi) := by
+      push_cast; ring
+    rw [this, Real.cos_neg]
+    exact cos_nat_mul_pi (m + 1)
+
+/-! ## The integer sequence for `arccos(1/4)` -/
+
+/-- Integer sequence for the `arccos(1/4)/π` irrationality proof.
+`f_0 = 2, f_1 = 1, f_{n+2} = f_{n+1} − 4·f_n`.  Key: `f_n = 2^n · 2cos(n·arccos(1/4))`. -/
+def cosQuarterSeq : ℕ → ℤ
+  | 0     => 2
+  | 1     => 1
+  | (n+2) => cosQuarterSeq (n+1) - 4 * cosQuarterSeq n
+
+@[simp] theorem cosQuarterSeq_zero : cosQuarterSeq 0 = 2 := rfl
+@[simp] theorem cosQuarterSeq_one  : cosQuarterSeq 1 = 1 := rfl
+theorem cosQuarterSeq_succ (n : ℕ) :
+    cosQuarterSeq (n+2) = cosQuarterSeq (n+1) - 4 * cosQuarterSeq n := rfl
+
+/-- **Parity obstruction (successor form).** `2` never divides `f_{k+1}`: mod `2` the recurrence
+is `f_{n+2} ≡ f_{n+1}`, and `f_1 = 1` is odd, so all later terms are odd. -/
+theorem two_ndvd_cosQuarterSeq_succ : ∀ k : ℕ, ¬((2 : ℤ) ∣ cosQuarterSeq (k + 1)) := by
+  intro k
+  induction k with
+  | zero => norm_num [cosQuarterSeq]
+  | succ n ih =>
+    rw [cosQuarterSeq_succ]
+    intro h
+    obtain ⟨c, hc⟩ := h
+    -- `f_{n+1} = (f_{n+1} − 4 f_n) + 4 f_n = 2c + 4 f_n = 2(c + 2 f_n)`, so `2 ∣ f_{n+1}`.
+    exact ih ⟨c + 2 * cosQuarterSeq n, by omega⟩
+
+/-- **Parity obstruction.** `2` never divides `f_n` for `n ≥ 1`. -/
+theorem two_ndvd_cosQuarterSeq_pos {n : ℕ} (hn : 1 ≤ n) : ¬((2 : ℤ) ∣ cosQuarterSeq n) := by
+  obtain ⟨k, rfl⟩ : ∃ k, n = k + 1 := ⟨n - 1, by omega⟩
+  exact two_ndvd_cosQuarterSeq_succ k
+
+/-- **Arithmetic backbone.** `f_n = 2^n · 2cos(n·arccos(1/4))`. -/
+theorem cosQuarterSeq_eq_cos (k : ℕ) :
+    (cosQuarterSeq k : ℝ) = (2 : ℝ) ^ k * (2 * Real.cos (↑k * Real.arccos (1 / 4))) := by
+  suffices h : ∀ n : ℕ,
+      (cosQuarterSeq n : ℝ) = (2 : ℝ) ^ n * (2 * Real.cos (↑n * Real.arccos (1 / 4))) ∧
+      (cosQuarterSeq (n + 1) : ℝ) =
+        (2 : ℝ) ^ (n + 1) * (2 * Real.cos (↑(n + 1) * Real.arccos (1 / 4)))
+    from (h k).1
+  intro n
+  induction n with
+  | zero =>
+    refine ⟨by simp [cosQuarterSeq, Real.cos_zero], ?_⟩
+    simp only [cosQuarterSeq_one, Nat.cast_one, pow_one, one_mul, Nat.zero_add,
+      Real.cos_arccos (by norm_num : (-1 : ℝ) ≤ 1 / 4) (by norm_num : (1 / 4 : ℝ) ≤ 1)]
+    norm_num
+  | succ m ih =>
+    refine ⟨ih.2, ?_⟩
+    have hrec : (cosQuarterSeq (m + 2) : ℝ) =
+        (cosQuarterSeq (m + 1) : ℝ) - 4 * (cosQuarterSeq m : ℝ) := by
+      simp only [cosQuarterSeq_succ]; push_cast; ring
+    rw [hrec, ih.2, ih.1, cos_step,
+        Real.cos_arccos (by norm_num : (-1 : ℝ) ≤ 1 / 4) (by norm_num : (1 / 4 : ℝ) ≤ 1)]
+    push_cast; ring
+
+/-! ## The 5-cell dihedral angle -/
+
+/-- The dihedral angle of the regular `4`-simplex (the **5-cell**): `arccos(1/4)`. -/
+noncomputable def simplex4Angle : ℝ := Real.arccos (1 / 4)
+
+/-- **Main result.** The 5-cell's dihedral angle `arccos(1/4)` is an irrational multiple of `π`.
+
+If `arccos(1/4) = (p/q)·π` then `f_q = ±2^{q+1}` is even for `q ≥ 1`, contradicting that `f_n`
+is odd for all `n ≥ 1`. -/
+theorem simplex4Angle_irrational : ¬∃ q : ℚ, simplex4Angle = q * Real.pi := by
+  rintro ⟨q, hq⟩
+  rw [simplex4Angle] at hq
+  have hb_pos : 0 < q.den := q.pos
+  have hmul : (q.den : ℝ) * Real.arccos (1 / 4) = (q.num : ℝ) * Real.pi := by
+    rw [hq, Rat.cast_def]; field_simp
+  have hcos_eq : Real.cos ((↑q.den : ℝ) * Real.arccos (1 / 4)) = (-1 : ℝ) ^ q.num.natAbs := by
+    rw [hmul]; exact cos_int_mul_pi q.num
+  have hseq := cosQuarterSeq_eq_cos q.den
+  rw [hcos_eq] at hseq
+  have hden_pos : 1 ≤ q.den := hb_pos
+  have hpm : (-1 : ℝ) ^ q.num.natAbs = 1 ∨ (-1 : ℝ) ^ q.num.natAbs = -1 := by
+    rcases Nat.even_or_odd q.num.natAbs with h | h
+    · exact Or.inl h.neg_one_pow
+    · exact Or.inr h.neg_one_pow
+  rcases hpm with h1 | h1
+  · rw [h1] at hseq
+    have hval : cosQuarterSeq q.den = 2 * (2 : ℤ) ^ q.den := by
+      have h : (cosQuarterSeq q.den : ℝ) = ↑(2 * (2 : ℤ) ^ q.den) := by
+        rw [hseq]; push_cast; ring
+      exact_mod_cast h
+    exact two_ndvd_cosQuarterSeq_pos hden_pos
+      (hval ▸ Dvd.intro _ rfl)
+  · rw [h1] at hseq
+    have hval : cosQuarterSeq q.den = -(2 * (2 : ℤ) ^ q.den) := by
+      have h : (cosQuarterSeq q.den : ℝ) = ↑(-(2 * (2 : ℤ) ^ q.den)) := by
+        rw [hseq]; push_cast; ring
+      exact_mod_cast h
+    exact two_ndvd_cosQuarterSeq_pos hden_pos
+      (hval ▸ (Dvd.intro _ rfl).neg_right)
+
+/-- Restatement: `arccos(1/4)` is not a rational multiple of `π`. -/
+theorem arccos_quarter_irrational : ¬∃ q : ℚ, Real.arccos (1 / 4 : ℝ) = q * Real.pi :=
+  simplex4Angle_irrational
+
+#check @simplex4Angle_irrational
+#check @cosQuarterSeq_eq_cos
+#check @two_ndvd_cosQuarterSeq_pos
+
+end DissectionOfCubesOQ04OQ02

--- a/src/data/proofs/dissection-of-cubes-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header-doc0402",
+    "proofId": "dissection-of-cubes-oq-04-oq-02",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "concept",
+    "title": "Extending the Dehn irrationality technique to 4 dimensions",
+    "content": "The parent entry proves the dodecahedron and icosahedron dihedral angles are irrational multiples of π and asks (OQ-02) whether the Niven/Chebyshev integer-sequence technique extends to higher-dimensional polytopes. This file answers yes for the first genuinely 4-dimensional case: the regular 4-simplex — the 5-cell, the 4D analogue of the tetrahedron — has dihedral angle arccos(1/4) (the regular n-simplex has dihedral angle arccos(1/n)), and this is proved irrational × π. Because 2cos(arccos(1/4)) = 1/2 has a power-of-2 denominator, the correct scaling is 2^n and the obstruction becomes a mod-2 parity argument. The consequence is a nonzero Dehn invariant for the 5-cell.",
+    "mathContext": "Regular $n$-simplex dihedral angle $=\\arccos(1/n)$; the 5-cell is $n=4$, angle $\\arccos(1/4)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Dehn invariant", "Hilbert's third problem", "scissors congruence", "regular polytopes", "Niven's theorem"],
+    "prerequisites": ["dihedral angles", "rational multiples of π"]
+  },
+  {
+    "id": "ann-trig-helpers-doc0402",
+    "proofId": "dissection-of-cubes-oq-04-oq-02",
+    "range": { "startLine": 53, "endLine": 81 },
+    "type": "tactic",
+    "title": "Trigonometric helper lemmas",
+    "content": "cos_step is the Chebyshev three-term recurrence cos((k+2)θ) = 2cosθ·cos((k+1)θ) − cos(kθ), obtained by writing the indices as (k+1)θ ± θ and expanding with cos_add/cos_sub. cos_nat_mul_pi and cos_int_mul_pi record cos(nπ) = (-1)^n for natural and integer n (induction; the integer case splits off the negSucc branch via cos_neg). These are restated locally so the file needs no imports from the parent's Dehn infrastructure.",
+    "mathContext": "$\\cos((k+2)\\theta)=2\\cos\\theta\\cos((k+1)\\theta)-\\cos(k\\theta)$; $\\cos(n\\pi)=(-1)^{|n|}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Chebyshev polynomials", "cos_add", "cos_sub", "cos(nπ)"],
+    "prerequisites": ["trigonometric addition formulas", "induction"]
+  },
+  {
+    "id": "ann-integer-sequence-doc0402",
+    "proofId": "dissection-of-cubes-oq-04-oq-02",
+    "range": { "startLine": 83, "endLine": 114 },
+    "type": "insight",
+    "title": "The integer sequence and its parity obstruction",
+    "content": "cosQuarterSeq is the integer sequence f_0=2, f_1=1, f_{n+2}=f_{n+1}−4f_n arising from scaling 2cos(nθ) by 2^n. The heart of the argument: two_ndvd_cosQuarterSeq_succ/_pos show 2 never divides f_n for n≥1. Modulo 2 the recurrence collapses to f_{n+2} ≡ f_{n+1} (since 4 ≡ 0), and the base f_1=1 is odd, so every later term is odd (induction; the divisibility step rewrites f_{n+1} = (f_{n+1}−4f_n) + 4f_n = 2(c+2f_n) and closes by omega). Choosing the prime 2 — available precisely because we scaled by 2^n, not 4^n — is the key idea.",
+    "mathContext": "$f_{n+2}\\equiv f_{n+1}\\pmod 2$ and $f_1=1$ odd $\\Rightarrow$ $2\\nmid f_n$ for all $n\\ge 1$.",
+    "significance": "key",
+    "relatedConcepts": ["linear recurrences", "modular arithmetic", "parity argument", "omega"],
+    "prerequisites": ["integer sequences", "divisibility mod a prime"]
+  },
+  {
+    "id": "ann-backbone-doc0402",
+    "proofId": "dissection-of-cubes-oq-04-oq-02",
+    "range": { "startLine": 116, "endLine": 137 },
+    "type": "tactic",
+    "title": "The cosine identity f_n = 2^n · 2cos(nθ)",
+    "content": "cosQuarterSeq_eq_cos proves the sequence equals 2^n · 2cos(n·arccos(1/4)), the bridge between the integer recurrence and the geometry. The proof is a paired induction (carrying the n and n+1 statements together): the successor step rewrites the recurrence over ℝ, applies cos_step and Real.cos_arccos (which evaluates cos(arccos(1/4)) = 1/4), then finishes with push_cast; ring.",
+    "mathContext": "$f_n = 2^n\\cdot 2\\cos(n\\arccos(1/4))$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.cos_arccos", "paired induction", "push_cast", "ring"],
+    "prerequisites": ["induction with strengthened hypothesis", "arccos"]
+  },
+  {
+    "id": "ann-main-doc0402",
+    "proofId": "dissection-of-cubes-oq-04-oq-02",
+    "range": { "startLine": 139, "endLine": 186 },
+    "type": "insight",
+    "title": "The 5-cell dihedral angle is an irrational multiple of π",
+    "content": "simplex4Angle := arccos(1/4). The main theorem simplex4Angle_irrational argues by contradiction: if arccos(1/4) = (p/q)π then cos(q·arccos(1/4)) = cos(pπ) = ±1 (cos_int_mul_pi), so by cosQuarterSeq_eq_cos, f_q = ±2^q·2 = ±2^{q+1}, which is even for q≥1 — contradicting that f_q is odd (two_ndvd_cosQuarterSeq_pos). The ±1 case split uses Even.neg_one_pow / Odd.neg_one_pow. arccos_quarter_irrational restates the result without the geometric wrapper. This is the OQ-02 answer and yields the 5-cell's nonzero Dehn invariant.",
+    "mathContext": "$\\arccos(1/4)=(p/q)\\pi \\Rightarrow f_q=\\pm 2^{q+1}$ even, contradicting $f_q$ odd; hence $\\arccos(1/4)\\notin\\pi\\mathbb Q$.",
+    "significance": "key",
+    "relatedConcepts": ["proof by contradiction", "Rat.num/den", "Even.neg_one_pow", "Dehn invariant nonvanishing"],
+    "prerequisites": ["rational number representation", "irrationality proofs"]
+  }
+]

--- a/src/data/proofs/dissection-of-cubes-oq-04-oq-02/index.ts
+++ b/src/data/proofs/dissection-of-cubes-oq-04-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DissectionOfCubesOQ04OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const dissectionOfCubesOq04Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const dissectionOfCubesOq04Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const dissectionOfCubesOq04Oq02Data: ProofData = {
+  proof: dissectionOfCubesOq04Oq02Proof,
+  annotations: dissectionOfCubesOq04Oq02Annotations,
+}

--- a/src/data/proofs/dissection-of-cubes-oq-04-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04-oq-02/meta.json
@@ -1,0 +1,153 @@
+{
+  "id": "dissection-of-cubes-oq-04-oq-02",
+  "title": "The 5-cell Dihedral Angle arccos(1/4) is an Irrational Multiple of π",
+  "slug": "dissection-of-cubes-oq-04-oq-02",
+  "description": "Answers OQ-02 of the Dehn-invariant parent entry (extend the Niven/Chebyshev irrationality technique to higher-dimensional polytopes) for the first genuinely 4-dimensional case: the regular 4-simplex — the 5-cell, 4D analogue of the tetrahedron — has dihedral angle arccos(1/4), and this is proved to be an irrational multiple of π. Because 2·cos(arccos(1/4)) = 1/2 has a power-of-2 denominator, the right scaling is 2^n (not 4^n), giving the integer recurrence f_0=2, f_1=1, f_{n+2}=f_{n+1}−4f_n whose terms are odd for all n≥1 (a mod-2 parity obstruction); but a rational angle would force f_q = ±2^{q+1} even, a contradiction. Consequently the 5-cell has a nonzero Dehn invariant. Fully machine-checked, 0 axioms.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://en.wikipedia.org/wiki/5-cell",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DissectionOfCubesOQ04OQ02.lean",
+    "tags": [
+      "geometry",
+      "dehn-invariant",
+      "scissors-congruence",
+      "hilbert-third-problem",
+      "irrationality",
+      "niven-theorem",
+      "polytopes",
+      "4-dimensional"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 187,
+    "assumptions": "None. Fully machine-checked: 0 axiom declarations, 0 sorries, no native_decide. All theorems depend only on the standard foundational axioms (propext, Classical.choice, Quot.sound), confirmed by #print axioms. The integer-sequence facts use omega/norm_num over ℤ; the trigonometric backbone uses Mathlib's cos_add/cos_arccos.",
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Hilbert's third problem asks whether two polyhedra of equal volume are scissors-congruent; Dehn (1901) answered no, via the Dehn invariant, whose vanishing requires the dihedral angles to be rational multiples of π (modulo the Q-span). The tetrahedron's angle arccos(1/3) and the dodecahedron/icosahedron angles are irrational multiples of π, proved in the parent entries by a Niven/Chebyshev integer-sequence method. In four dimensions the same scissors-congruence obstruction operates, and the regular 4-simplex (5-cell) — the direct analogue of the tetrahedron — has dihedral angle arccos(1/4) (the regular n-simplex has dihedral angle arccos(1/n)).",
+    "problemStatement": "Parent OQ-04 asks (OQ-02): can the integer-sequence irrationality technique be applied to dihedral angles arising in higher-dimensional polytopes? Here: prove arccos(1/4) — the 5-cell's dihedral angle — is an irrational multiple of π.",
+    "text": "Proves that the 5-cell (regular 4-simplex) dihedral angle arccos(1/4) is an irrational multiple of π, extending the parent's Niven/Chebyshev technique to the first higher-dimensional polytope. The scaling 2^n (dictated by 2cos(θ)=1/2) turns the Chebyshev recurrence into an integer recurrence with a clean mod-2 parity obstruction.",
+    "proofStrategy": "(1) Restate the three trig helpers: cos_step (Chebyshev three-term recurrence), cos_nat_mul_pi and cos_int_mul_pi (cos(nπ) = (-1)^n). (2) Define the integer sequence cosQuarterSeq: f_0=2, f_1=1, f_{n+2}=f_{n+1}−4f_n. (3) two_ndvd_cosQuarterSeq_succ/_pos: mod 2 the recurrence is f_{n+2} ≡ f_{n+1}, and f_1=1 is odd, so f_n is odd for all n≥1 (induction; the divisibility step is closed by omega). (4) cosQuarterSeq_eq_cos: f_n = 2^n · 2cos(n·arccos(1/4)) (paired induction using cos_step and cos_arccos, then push_cast; ring). (5) simplex4Angle_irrational: if arccos(1/4) = (p/q)π then cos(q·arccos(1/4)) = cos(pπ) = ±1, so f_q = ±2^{q+1} is even for q≥1 — contradicting oddness. The ±1 split uses Even/Odd.neg_one_pow.",
+    "keyInsights": [
+      "**Right scaling is 2^n, not 4^n**: since 2cos(arccos(1/4)) = 1/2 has denominator a power of 2, scaling by 2^n keeps the sequence integral and, crucially, makes the prime 2 available as an obstruction — even though N=4 is not squarefree.",
+      "**Parity obstruction**: modulo 2 the recurrence collapses to f_{n+2} ≡ f_{n+1}, so a single odd base value (f_1=1) forces all subsequent terms odd; the endpoint f_q = ±2^{q+1} is even, giving the contradiction.",
+      "**n-simplex dihedral angle arccos(1/n)**: the 4-simplex value arccos(1/4) sits in the same arithmetic family as the tetrahedron's arccos(1/3), so the technique transports almost verbatim, differing only in the modulus of the obstruction (2 instead of 3).",
+      "**Higher-dimensional Dehn obstruction**: irrationality of arccos(1/4)/π means the 5-cell has a nonzero Dehn invariant, so it is not scissors-congruent to any assembly built from right (π/2) dihedral angles — the 4D echo of the tetrahedron/cube dichotomy.",
+      "**Self-contained**: the three trig helper lemmas are restated so the file does not depend on the parent's Dehn infrastructure imports."
+    ],
+    "prerequisites": [
+      "Dehn invariant and Hilbert's third problem",
+      "Niven's theorem / rational values of cos(rπ)",
+      "Chebyshev cosine recurrence",
+      "Integer sequences and modular (parity) arguments",
+      "Dihedral angles of regular polytopes (arccos(1/n) for the n-simplex)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Header and Overview",
+      "summary": "Frames OQ-02 (extend the irrationality technique to higher-dimensional polytopes) and states the target: the 5-cell (regular 4-simplex) dihedral angle arccos(1/4) is an irrational multiple of π. Explains the 2^n scaling and the mod-2 parity obstruction, and the Dehn-invariant consequence.",
+      "startLine": 1,
+      "endLine": 43,
+      "mathContext": "Regular n-simplex dihedral angle = arccos(1/n); for n=4 (the 5-cell) this is arccos(1/4)."
+    },
+    {
+      "id": "trig-helpers",
+      "title": "Trigonometric helper lemmas",
+      "summary": "cos_step: the Chebyshev three-term recurrence cos((k+2)θ) = 2cosθ·cos((k+1)θ) − cos(kθ) (via cos_add/cos_sub). cos_nat_mul_pi / cos_int_mul_pi: cos(nπ) = (-1)^n for natural and integer n. Restated locally so the entry is self-contained.",
+      "startLine": 53,
+      "endLine": 81,
+      "mathContext": "cos((k+2)θ) = 2cosθ cos((k+1)θ) − cos(kθ); cos(nπ) = (-1)^{|n|}."
+    },
+    {
+      "id": "integer-sequence",
+      "title": "The integer sequence and its parity obstruction",
+      "summary": "cosQuarterSeq: f_0=2, f_1=1, f_{n+2}=f_{n+1}−4f_n. two_ndvd_cosQuarterSeq_succ / _pos: 2 never divides f_n for n≥1 — mod 2 the recurrence is f_{n+2} ≡ f_{n+1}, and f_1=1 is odd (induction, divisibility step by omega).",
+      "startLine": 83,
+      "endLine": 114,
+      "mathContext": "f_{n+2} ≡ f_{n+1} (mod 2), f_1 = 1 odd ⟹ f_n odd for all n≥1."
+    },
+    {
+      "id": "arithmetic-backbone",
+      "title": "The cosine identity f_n = 2^n · 2cos(nθ)",
+      "summary": "cosQuarterSeq_eq_cos: the sequence equals 2^n · 2cos(n·arccos(1/4)), by paired induction using cos_step and Real.cos_arccos (cos(arccos(1/4)) = 1/4), then push_cast; ring. This links the integer recurrence to the geometry.",
+      "startLine": 116,
+      "endLine": 137,
+      "mathContext": "f_n = 2^n · 2cos(n·arccos(1/4)) — the arithmetic/analytic bridge."
+    },
+    {
+      "id": "main-irrationality",
+      "title": "The 5-cell dihedral angle is irrational × π",
+      "summary": "simplex4Angle := arccos(1/4). simplex4Angle_irrational: if arccos(1/4) = (p/q)π then cos(q·arccos(1/4)) = cos(pπ) = ±1, so f_q = ±2^{q+1} is even for q≥1, contradicting oddness. arccos_quarter_irrational restates it. The ±1 case split uses Even/Odd.neg_one_pow.",
+      "startLine": 139,
+      "endLine": 186,
+      "mathContext": "arccos(1/4) = (p/q)π ⟹ f_q = ±2^{q+1} even, contradicting f_q odd; hence irrational × π."
+    }
+  ],
+  "conclusion": {
+    "summary": "The 5-cell (regular 4-simplex) dihedral angle arccos(1/4) is proved to be an irrational multiple of π, giving the first higher-dimensional instance of the parent entry's OQ-02. The proof transports the Niven/Chebyshev integer-sequence method to four dimensions, with two changes forced by arithmetic: the scaling is 2^n rather than 4^n (because 2cos(arccos(1/4)) = 1/2 has a power-of-2 denominator), and the obstruction is a mod-2 parity argument (f_n is odd for all n≥1) rather than the mod-5/mod-3 arguments of the dodecahedron/tetrahedron cases. As with the classical Dehn theory, this means the 5-cell carries a nonzero Dehn invariant and is not scissors-congruent to any figure assembled from right dihedral angles alone.",
+    "implications": "Confirms that the elementary integer-sequence technique scales to higher-dimensional polytopes, and isolates exactly what changes: the modulus of the obstruction tracks a prime dividing the scaling denominator, and non-squarefree denominators (here 4) are handled by scaling with the prime (2) rather than the full denominator. This gives a reusable recipe for arccos(1/n)-type dihedral angles of regular n-simplices in every dimension.",
+    "openQuestions": [
+      "Prove the general statement: for every n ≥ 3, arccos(1/n) is an irrational multiple of π (regular n-simplex), unifying the mod-p obstructions into a single argument (Niven's theorem).",
+      "Extend to the 600-cell and 120-cell dihedral angles, arccos(−(1+3√5)/8)-type values requiring a √5 half-angle reduction analogous to the parent's dodecahedron chain.",
+      "Formalize the Dehn-invariant nonvanishing for the 5-cell explicitly, using the tmul/flatness infrastructure of DissectionOfCubesOQ02OQ02 as the parent does for the Platonic solids."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dissection-of-cubes-oq-04",
+      "relationship": "extends",
+      "description": "Parent OQ-04 proves irrationality for the dodecahedron/icosahedron and asks (OQ-02) whether the technique extends to higher-dimensional polytopes; this file answers it for the 5-cell."
+    },
+    {
+      "targetId": "dissection-of-cubes",
+      "relationship": "extends",
+      "description": "Root entry: Dehn invariant and scissors-congruence obstruction."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Dehn, M.",
+      "title": "Über den Rauminhalt",
+      "year": "1901",
+      "venue": "Math. Ann. 55:465–478",
+      "note": "The Dehn invariant; dihedral angles must be rational multiples of π for it to vanish."
+    },
+    {
+      "authors": "Niven, I.",
+      "title": "Irrational Numbers",
+      "year": "1956",
+      "venue": "Carus Mathematical Monographs 11",
+      "note": "Niven's theorem: the only rational values of cos(rπ) for rational r are 0, ±1/2, ±1."
+    },
+    {
+      "authors": "Coxeter, H. S. M.",
+      "title": "Regular Polytopes",
+      "year": "1973",
+      "venue": "Dover (3rd ed.)",
+      "note": "The regular n-simplex has dihedral angle arccos(1/n); the 5-cell is the 4-simplex."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse"
+    ],
+    "namespace": "DissectionOfCubesOQ04OQ02",
+    "lineCount": 187,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "path": "Proofs/DissectionOfCubesOQ04OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 2
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **dissection-of-cubes-oq-04-oq-02** — answers **OQ-02** of the Dehn-invariant parent (`dissection-of-cubes-oq-04`): *can the Niven/Chebyshev irrationality technique be applied to dihedral angles of higher-dimensional polytopes?*

**Yes.** The regular **4-simplex** — the **5-cell**, the 4D analogue of the tetrahedron — has dihedral angle `arccos(1/4)` (the regular `n`-simplex has dihedral angle `arccos(1/n)`), and this is proved to be an **irrational multiple of π**. Hence the 5-cell has a nonzero Dehn invariant.

## The technique, adapted to 4D

`2·cos(arccos(1/4)) = 1/2` has a **power-of-2 denominator**, so the correct scaling is `2^n` (not `4^n`). Setting `f_n = 2^n · 2cos(n·θ)` turns the Chebyshev recurrence into the integer recurrence

```
f_0 = 2,  f_1 = 1,  f_{n+2} = f_{n+1} − 4·f_n
```

Modulo 2 this is `f_{n+2} ≡ f_{n+1}`, and `f_1 = 1` is odd, so **`f_n` is odd for every `n ≥ 1`**. But if `arccos(1/4) = (p/q)·π` then `cos(q·θ) = cos(pπ) = ±1`, so `f_q = ±2^{q+1}` is **even** for `q ≥ 1` — contradiction.

The **mod-2 parity obstruction** replaces the parent's mod-5 / mod-3 arguments. Scaling by the prime `2` (rather than by the full, non-squarefree `4`) is exactly what makes the prime available.

## Results (`Proofs/DissectionOfCubesOQ04OQ02.lean`)

| lemma | statement |
|---|---|
| `cos_step`, `cos_int_mul_pi` | Chebyshev recurrence; `cos(nπ) = (-1)^n` (restated, self-contained) |
| `cosQuarterSeq` | the integer sequence `f_0=2, f_1=1, f_{n+2}=f_{n+1}−4f_n` |
| `two_ndvd_cosQuarterSeq_pos` | `2 ∤ f_n` for all `n ≥ 1` (parity obstruction) |
| `cosQuarterSeq_eq_cos` | `f_n = 2^n · 2cos(n·arccos(1/4))` |
| `simplex4Angle_irrational` | **`arccos(1/4)` is an irrational multiple of `π`** |

## Verification

- **0 sorries, 0 axiom declarations.** `#print axioms` on every theorem shows only the standard foundational trio (`propext`, `Classical.choice`, `Quot.sound`).
- Typechecked with `lake env lean` against Mathlib 4.26.0 (warm cache), no warnings.
- 11 theorems, 2 definitions, 187 lines. `pnpm annotations:build` passes clean for this entry.

Extends `dissection-of-cubes-oq-04` (dodecahedron/icosahedron irrationality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)