### PR TITLE
Enrich Cauchy Interlacing Compression: annotate ambient RCLike/finite-dim setting

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-setup",
+    "proofId": "cauchy-interlacing-theorem-oq-01",
+    "range": { "startLine": 58, "endLine": 61 },
+    "type": "context",
+    "title": "The Ambient Setting: RCLike, Finite-Dimensional Inner Product Space",
+    "content": "The whole development is stated over an abstract scalar field `𝕜` with `[RCLike 𝕜]`, so a single proof covers both the real (`ℝ`) and complex (`ℂ`) cases at once — Hermitian and real-symmetric interlacing are the same theorem here. `[FiniteDimensional 𝕜 V]` is essential: Mathlib's spectral theorem (`LinearMap.IsSymmetric.eigenvalues` / `eigenvectorBasis`) only produces a full orthonormal eigenbasis and an ordered eigenvalue tuple in finite dimensions. The preceding `open CauchyInterlacing.Assembly` brings the parent file's abstract `cauchy_interlacing` into scope, and `open scoped InnerProductSpace` enables the `⟪·, ·⟫_𝕜` inner-product notation on which every step relies.",
+    "mathContext": "`RCLike 𝕜` axiomatizes exactly the fields ℝ and ℂ; finite-dimensionality guarantees the spectral theorem yields a complete eigenbasis with eigenvalues indexed by `Fin (finrank 𝕜 V)`.",
+    "significance": "context",
+    "relatedConcepts": ["RCLike", "finite-dimensional inner product space", "spectral theorem", "real vs complex symmetry"],
+    "prerequisites": ["typeclass assumptions in Lean", "inner product space over ℝ or ℂ"]
+  },
+  {
     "id": "ann-compress-def",
     "proofId": "cauchy-interlacing-theorem-oq-01",
     "range": { "startLine": 66, "endLine": 70 },


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01` (*Cauchy Interlacing: the Self-Contained Compression Corollary*).

## Change
Adds a 5th annotation (`ann-setup`, type `context`) covering the previously-unannotated setup region (lines 58–61): the `[RCLike 𝕜]` / `[FiniteDimensional 𝕜 V]` typeclass assumptions and the `open` directives. Brings the entry 4 → 5 annotations, meeting the ≥5-annotations-with-mathContext quality target.

## Why it's substantive
- **`RCLike 𝕜`** lets a *single* proof cover both real-symmetric (ℝ) and Hermitian (ℂ) interlacing — same theorem.
- **`FiniteDimensional`** is essential: Mathlib's spectral theorem only yields a complete orthonormal eigenbasis and an ordered eigenvalue tuple in finite dimensions.
- Notes the role of `open CauchyInterlacing.Assembly` (parent `cauchy_interlacing`) and `open scoped InnerProductSpace` (⟪·,·⟫ notation).

Annotation anchored on the `namespace` line so it passes `annotations:validate`. meta.json well under size caps (14 KB). No content deleted; single-file diff (12 insertions).