### PR TITLE
research(chebyshev-polynomials-oq-01-oq-02): composition theory for Uₙ and Dickson polynomials — survives for Dickson, fails for Uₙ [VERIFIED, 0-axiom, 10thm/146L]

### DIFF
--- a/proofs/Proofs/ChebyshevPolynomialsOQ01OQ02.lean
+++ b/proofs/Proofs/ChebyshevPolynomialsOQ01OQ02.lean
@@ -1,0 +1,146 @@
+/-
+  Composition/commutation theory for the *second kind* Chebyshev polynomials `Uₙ`
+  and the Dickson polynomials — which structural laws survive?
+
+  The parent entry records the composition law for the first kind,
+  `T_{m·n} = T_m ∘ T_n` (`Polynomial.Chebyshev.T_mul`), and derives from it that
+  the `Tₙ` form a **commutative compositional monoid**: `X` is the identity, the
+  `Tₙ` commute under `∘`, and composition is associative.  Open question #2 asks
+  for the analogous story for the second-kind polynomials `Uₙ` and for the Dickson
+  polynomials, *identifying which structural laws survive*.
+
+  The answer splits sharply along the first-kind / second-kind divide.
+
+  **Dickson polynomials of the first kind (parameter `a = 1`): the law SURVIVES.**
+  The Dickson polynomials `Dₙ = dickson 1 1 n` are the `x ↦ 2x`-conjugate normal
+  form of the first-kind Chebyshev polynomials (`dickson 1 1 n = Chebyshev.C n`,
+  and `Cₙ(2x) = 2 Tₙ(x)`).  Conjugation is a monoid isomorphism of the
+  compositional monoid, so the entire first-kind picture transports verbatim:
+
+      D_{m·n} = D_m ∘ D_n     (`dickson_one_one_mul`)
+      D₁ = X                  (compositional identity)
+      D_m ∘ D_n = D_n ∘ D_m   (commutation)
+      associativity of `∘`.
+
+  So `n ↦ Dₙ` is again a monoid homomorphism `(ℕ, ·, 1) → (R[X], ∘, X)`.
+
+  **Chebyshev polynomials of the second kind `Uₙ`: the law FAILS.**
+  Here `U₁ = 2X ≠ X`.  Since `X` is the identity of the compositional monoid and
+  `1` is the identity of `(ℕ, ·)`, any composition law `U_{m·n} = U_m ∘ U_n`
+  would force `U₁ = U_{1·1} = U₁ ∘ U₁`, i.e. `2X = 4X` — false over `ℤ`.  The
+  obstruction is intrinsic: `n ↦ Uₙ` cannot even be a monoid homomorphism into
+  `(R[X], ∘, X)` because it does not send `1` to the identity.  A concrete
+  higher-degree witness (via the evaluation homomorphism `Uₙ(1) = n+1`) is
+  `U₄ ≠ U₂ ∘ U₂`: evaluating at `1` gives `5` on the left and `U₂(3) = 35` on the
+  right.  The same failure holds for the second-kind Dickson polynomials
+  `dickson 2 1 n = Chebyshev.S n` (with `Uₙ = Sₙ(2x)`): the compositional monoid
+  structure is a phenomenon of the *first-kind* family alone.
+
+  Contents:
+    * `dickson_comp`, `dickson_one_eq_X`, `dickson_comp_one`, `dickson_one_comp`,
+      `dickson_comp_comm`, `dickson_comp_assoc` — the surviving compositional
+      monoid for the first-kind Dickson polynomials.
+    * `dickson_eq_chebyshev_C` — the bridge explaining *why* it survives.
+    * `U_one_ne_X`, `U_comp_law_fails_at_one`, `U_comp_law_fails_deg_two` — the
+      three faces of the second-kind failure (identity, trivial case, quantitative
+      witness).
+
+  Verified: 0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound;
+  no native_decide, no Lean.ofReduceBool).
+-/
+import Mathlib
+
+open Polynomial
+
+namespace ChebyshevPolynomialsOQ01OQ02
+
+open Polynomial.Chebyshev
+
+variable (R : Type*) [CommRing R]
+
+/-! ### Part 1: first-kind Dickson polynomials — the compositional monoid SURVIVES
+
+The Dickson polynomials `Dₙ := dickson 1 1 n` inherit the full first-kind picture
+because they are the `x ↦ 2x`-conjugate of the Chebyshev `Tₙ`. -/
+
+/-- **Composition law for Dickson polynomials** (first kind, `a = 1`):
+`D_{m·n} = D_m ∘ D_n`.  This is Mathlib's `dickson_one_one_mul`, the surviving
+analogue of `T_{m·n} = T_m ∘ T_n`. -/
+theorem dickson_comp (m n : ℕ) :
+    dickson 1 (1 : R) (m * n) = (dickson 1 1 m).comp (dickson 1 1 n) :=
+  dickson_one_one_mul R m n
+
+/-- `D₁ = X`: the first Dickson polynomial is the identity for composition. -/
+theorem dickson_one_eq_X : dickson 1 (1 : R) 1 = X :=
+  dickson_one 1 (1 : R)
+
+/-- Right identity: `D_m ∘ D₁ = D_m` (since `D₁ = X`). -/
+theorem dickson_comp_one (m : ℕ) :
+    (dickson 1 (1 : R) m).comp (dickson 1 1 1) = dickson 1 1 m := by
+  rw [dickson_one, comp_X]
+
+/-- Left identity: `D₁ ∘ p = p` for any polynomial `p` (since `D₁ = X`). -/
+theorem dickson_one_comp (p : R[X]) :
+    (dickson 1 (1 : R) 1).comp p = p := by
+  rw [dickson_one, X_comp]
+
+/-- **Commutation under composition**: `D_m ∘ D_n = D_n ∘ D_m`.  The Dickson
+polynomials form a commuting family, exactly as the `Tₙ` do. -/
+theorem dickson_comp_comm (m n : ℕ) :
+    (dickson 1 (1 : R) m).comp (dickson 1 1 n)
+      = (dickson 1 1 n).comp (dickson 1 1 m) :=
+  dickson_one_one_comp_comm R m n
+
+/-- **Associativity** of Dickson composition: `D_{l·m·n}` is the triple composite
+`(D_l ∘ D_m) ∘ D_n`. -/
+theorem dickson_comp_assoc (l m n : ℕ) :
+    dickson 1 (1 : R) (l * m * n)
+      = ((dickson 1 1 l).comp (dickson 1 1 m)).comp (dickson 1 1 n) := by
+  rw [dickson_comp, dickson_comp]
+
+/-- **The bridge that explains survival.**  `Dₙ = Cₙ`, the first-kind Chebyshev
+polynomial in its `2cos`-normalised form.  Together with `Cₙ(2x) = 2 Tₙ(x)`
+(`Chebyshev.C_comp_two_mul_X`) this exhibits `Dₙ` as the `x ↦ 2x`-conjugate of
+`Tₙ`; conjugation preserves the compositional monoid, which is why every
+first-kind composition law transports to the Dickson polynomials. -/
+theorem dickson_eq_chebyshev_C (n : ℕ) :
+    dickson 1 (1 : R) n = Chebyshev.C R (n : ℤ) :=
+  dickson_one_one_eq_chebyshev_C R n
+
+/-! ### Part 2: second-kind Chebyshev polynomials `Uₙ` — the law FAILS
+
+`U₁ = 2X ≠ X`, so `n ↦ Uₙ` does not send the multiplicative identity to the
+compositional identity — the composition law cannot hold. -/
+
+/-- `U₁ = 2X`, which is **not** the compositional identity `X`.  This is the root
+obstruction: over `ℤ` the constant `2` is not `1`. -/
+theorem U_one_ne_X : U ℤ 1 ≠ X := by
+  rw [U_one]
+  intro h
+  have h1 := congrArg (Polynomial.eval 1) h
+  simp at h1
+
+/-- **The composition law fails already at the multiplicative identity.**
+If `U_{m·n} = U_m ∘ U_n` held, then at `m = n = 1` it would say `U₁ = U₁ ∘ U₁`,
+i.e. `2X = (2X) ∘ (2X) = 4X`.  Evaluating at `1` gives `2 = 4`, a contradiction.
+Thus `n ↦ Uₙ` is not a homomorphism into the compositional monoid at all. -/
+theorem U_comp_law_fails_at_one :
+    U ℤ (1 * 1) ≠ (U ℤ 1).comp (U ℤ 1) := by
+  intro h
+  have h1 := congrArg (Polynomial.eval 1) h
+  rw [eval_comp] at h1
+  simp at h1
+
+/-- **A quantitative higher-degree witness**: `U₄ ≠ U₂ ∘ U₂`.  Applying the
+evaluation-at-`1` homomorphism and `Uₙ(1) = n + 1` (`U_eval_one`): the left side
+gives `U₄(1) = 5`, while the right side gives `U₂(U₂(1)) = U₂(3) = 4·9 − 1 = 35`.
+Since `5 ≠ 35` the two polynomials differ — the composition law fails on genuine
+positive-degree inputs, not merely at the identity. -/
+theorem U_comp_law_fails_deg_two :
+    U ℤ 4 ≠ (U ℤ 2).comp (U ℤ 2) := by
+  intro h
+  have h1 := congrArg (Polynomial.eval 1) h
+  rw [eval_comp, U_eval_one, U_eval_one, U_two] at h1
+  simp at h1
+
+end ChebyshevPolynomialsOQ01OQ02

--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-02/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "chebyshev-polynomials-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 49
+    },
+    "type": "concept",
+    "title": "Which structural laws survive for Uₙ and the Dickson polynomials",
+    "content": "The parent entry proved the first-kind composition law T_{m·n} = T_m ∘ T_n and the commutative compositional monoid it generates. Open question #2 asks the same for the second-kind Chebyshev Uₙ and the Dickson polynomials. The answer splits along the first-kind / second-kind divide: the monoid survives for the first-kind Dickson polynomials Dₙ = dickson 1 1 n (they are the x ↦ 2x-conjugate of Tₙ), but fails for the second-kind Uₙ, whose U₁ = 2X is not the compositional identity X.",
+    "mathContext": "$D_{mn} = D_m \\circ D_n$ but $U_{mn} \\neq U_m \\circ U_n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Chebyshev polynomials",
+      "Dickson polynomials",
+      "polynomial composition",
+      "commuting polynomials",
+      "Ritt's theorem"
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the first and second kind",
+      "Dickson polynomials"
+    ]
+  },
+  {
+    "id": "ann-dickson-survives",
+    "proofId": "chebyshev-polynomials-oq-01-oq-02",
+    "range": {
+      "startLine": 61,
+      "endLine": 99
+    },
+    "type": "insight",
+    "title": "First-kind Dickson polynomials form a commutative compositional monoid",
+    "content": "The surviving structure. dickson_comp records Mathlib's dickson_one_one_mul (D_{m·n} = D_m ∘ D_n); dickson_one_eq_X gives D₁ = X, and with comp_X / X_comp this makes 1 the two-sided compositional unit (dickson_comp_one, dickson_one_comp). dickson_comp_comm (Mathlib's dickson_one_one_comp_comm) gives commutation, and dickson_comp_assoc iterates the composition law with mul_assoc. Together these are exactly the monoid laws the parent proved for Tₙ — transported intact to the Dickson family.",
+    "mathContext": "$D_{m\\cdot n} = D_m \\circ D_n$, $D_1 = X$, $D_m \\circ D_n = D_n \\circ D_m$, $D_{lmn} = (D_l \\circ D_m) \\circ D_n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Dickson polynomials",
+      "polynomial composition",
+      "monoid morphism",
+      "commuting polynomials"
+    ],
+    "prerequisites": [
+      "polynomial composition",
+      "Dickson polynomials"
+    ]
+  },
+  {
+    "id": "ann-dickson-bridge",
+    "proofId": "chebyshev-polynomials-oq-01-oq-02",
+    "range": {
+      "startLine": 101,
+      "endLine": 108
+    },
+    "type": "insight",
+    "title": "The bridge: Dₙ = Cₙ is the conjugate of Tₙ",
+    "content": "dickson_eq_chebyshev_C exhibits Dₙ = Cₙ, the C-normalisation of the first-kind Chebyshev polynomials (with Cₙ(2x) = 2Tₙ(x)). This means Dₙ is nothing but Tₙ conjugated by the affine map x ↦ 2x. Conjugation by an affine map is an isomorphism of the compositional monoid, so every composition law valid for Tₙ transports verbatim to Dₙ — this is precisely why the first-kind laws survive.",
+    "mathContext": "$D_n = C_n$, $C_n(2x) = 2T_n(x)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Dickson polynomials",
+      "Chebyshev polynomials",
+      "conjugation",
+      "polynomial composition"
+    ],
+    "prerequisites": [
+      "affine conjugation",
+      "Chebyshev polynomials"
+    ]
+  },
+  {
+    "id": "ann-u-fails",
+    "proofId": "chebyshev-polynomials-oq-01-oq-02",
+    "range": {
+      "startLine": 110,
+      "endLine": 146
+    },
+    "type": "insight",
+    "title": "Second-kind Chebyshev Uₙ: the composition law fails",
+    "content": "The negative result. U_one_ne_X shows U₁ = 2X ≠ X — the root obstruction, since a monoid morphism into (R[X], ∘, X) must send the multiplicative unit to X. U_comp_law_fails_at_one turns this into a failure of the composition law already at m = n = 1: (2X) ∘ (2X) = 4X ≠ 2X. U_comp_law_fails_deg_two gives a positive-degree witness U₄ ≠ U₂ ∘ U₂, proved by the evaluation-at-1 homomorphism and Uₙ(1) = n+1: the left side is 5, the right side U₂(3) = 35.",
+    "mathContext": "$U_1 = 2X \\neq X$; $(2X)\\circ(2X) = 4X$; $U_4(1) = 5 \\neq 35 = U_2(U_2(1))$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Chebyshev polynomials of the second kind",
+      "polynomial composition",
+      "evaluation homomorphism",
+      "counterexample"
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the second kind",
+      "polynomial evaluation"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-02/index.ts
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevPolynomialsOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevPolynomialsOq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevPolynomialsOq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevPolynomialsOq01Oq02Data: ProofData = {
+  proof: chebyshevPolynomialsOq01Oq02Proof,
+  annotations: chebyshevPolynomialsOq01Oq02Annotations,
+}

--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-02/meta.json
@@ -1,0 +1,211 @@
+{
+  "id": "chebyshev-polynomials-oq-01-oq-02",
+  "title": "Composition theory for second-kind Chebyshev Uₙ and Dickson polynomials: the law survives for Dickson, fails for Uₙ",
+  "slug": "chebyshev-polynomials-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Polynomial.Chebyshev"
+    ],
+    "namespace": "ChebyshevPolynomialsOQ01OQ02",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/ChebyshevPolynomialsOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "description": "The parent entry establishes the composition law T_{m·n} = T_m ∘ T_n and the commutative compositional monoid it generates for the first-kind Chebyshev polynomials. Its open question #2 asks for the analogous theory for the second-kind polynomials Uₙ and the Dickson polynomials, identifying which structural laws survive. The answer splits sharply along the first-kind / second-kind divide: the composition law SURVIVES for the first-kind Dickson polynomials Dₙ = dickson 1 1 n — they form a commutative compositional monoid (D_{m·n} = D_m ∘ D_n, D₁ = X, commutation, associativity) — because Dₙ is the x ↦ 2x-conjugate normal form of Tₙ (Dₙ = Cₙ, Cₙ(2x) = 2Tₙ(x)). It FAILS for the second-kind Chebyshev Uₙ: since U₁ = 2X ≠ X, the map n ↦ Uₙ cannot send the multiplicative identity to the compositional identity, so U_{m·n} = U_m ∘ U_n breaks already at m = n = 1 (2X ≠ 4X); a quantitative degree-2 witness is U₄ ≠ U₂ ∘ U₂ (evaluating at 1 gives 5 ≠ 35 via Uₙ(1) = n+1).",
+  "references": [
+    {
+      "authors": "Pafnuty Chebyshev",
+      "title": "Théorie des mécanismes connus sous le nom de parallélogrammes (Mém. Acad. Sci. St.-Pétersbourg)",
+      "year": 1854,
+      "note": "Introduces the Chebyshev polynomials; the first- and second-kind families studied here."
+    },
+    {
+      "authors": "Leonard Eugene Dickson",
+      "title": "The analytic representation of substitutions on a power of a prime number of letters with a discussion of the linear group",
+      "year": 1897,
+      "note": "Ann. of Math. Introduces the Dickson polynomials, whose first-kind composition law D_{mn} = D_m ∘ D_n is the surviving structure here."
+    },
+    {
+      "authors": "Rudolf Lidl, Gary L. Mullen, Gerhard Turnwald",
+      "title": "Dickson Polynomials",
+      "year": 1993,
+      "note": "Pitman Monographs 65, Longman. Composition and functional properties of Dickson polynomials and their relation to Chebyshev polynomials."
+    },
+    {
+      "authors": "Theodore J. Rivlin",
+      "title": "Chebyshev Polynomials: From Approximation Theory to Algebra and Number Theory (2nd ed.)",
+      "year": 1990,
+      "note": "Wiley. First- and second-kind Chebyshev polynomials and their identities."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Polynomial.dickson_one_one_mul and Polynomial.Chebyshev.U_eval_one",
+      "year": 2024,
+      "note": "Mathlib supplies the Dickson composition law and the Uₙ(1)=n+1 evaluation used for the negative witness."
+    }
+  ],
+  "meta": {
+    "author": "Robb Walters (researcher agent)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevPolynomialsOQ01OQ02.lean",
+    "tags": [
+      "polynomials",
+      "chebyshev-polynomials",
+      "dickson-polynomials",
+      "ring-theory",
+      "function-composition",
+      "commuting-polynomials"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.dickson_one_one_mul",
+        "description": "dickson 1 1 (m*n) = (dickson 1 1 m).comp (dickson 1 1 n): the composition law for first-kind Dickson polynomials — the surviving analogue of T_mul",
+        "module": "Mathlib.RingTheory.Polynomial.Dickson"
+      },
+      {
+        "theorem": "Polynomial.dickson_one_one_comp_comm",
+        "description": "(dickson 1 1 m).comp (dickson 1 1 n) = (dickson 1 1 n).comp (dickson 1 1 m): commutation under composition for the Dickson family",
+        "module": "Mathlib.RingTheory.Polynomial.Dickson"
+      },
+      {
+        "theorem": "Polynomial.dickson_one",
+        "description": "dickson k a 1 = X: the first Dickson polynomial is X, the compositional identity",
+        "module": "Mathlib.RingTheory.Polynomial.Dickson"
+      },
+      {
+        "theorem": "Polynomial.dickson_one_one_eq_chebyshev_C",
+        "description": "dickson 1 1 n = Chebyshev.C n: the bridge exhibiting Dₙ as the C-normalisation (x ↦ 2x conjugate) of Tₙ — why the first-kind composition law transports",
+        "module": "Mathlib.RingTheory.Polynomial.Dickson"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.U_one",
+        "description": "U R 1 = 2*X: the root obstruction for the second kind — U₁ is not the compositional identity X",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.U_eval_one",
+        "description": "(U R n).eval 1 = n + 1: the evaluation-at-1 homomorphism supplying the quantitative degree-2 counterexample U₄ ≠ U₂ ∘ U₂",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.U_two",
+        "description": "U R 2 = 4*X^2 - 1: used to compute U₂(3) = 35 in the counterexample",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.eval_comp",
+        "description": "(p.comp q).eval x = p.eval (q.eval x): reduces composition-law equalities to nested evaluation in the negative witnesses",
+        "module": "Mathlib.Algebra.Polynomial.Eval"
+      },
+      {
+        "theorem": "Polynomial.comp_X",
+        "description": "p.comp X = p: right-identity law once D₁ = X",
+        "module": "Mathlib.Algebra.Polynomial.Eval"
+      },
+      {
+        "theorem": "Polynomial.X_comp",
+        "description": "X.comp p = p: left-identity law once D₁ = X",
+        "module": "Mathlib.Algebra.Polynomial.Eval"
+      }
+    ],
+    "originalContributions": [
+      "dickson_comp / dickson_comp_comm / dickson_comp_assoc / dickson_one_eq_X / dickson_comp_one / dickson_one_comp: the surviving structure — the first-kind Dickson polynomials Dₙ = dickson 1 1 n form a commutative compositional monoid, the exact analogue of the parent's first-kind Chebyshev picture, packaged here as the answer to 'which laws survive'",
+      "dickson_eq_chebyshev_C: the bridge that explains the survival — Dₙ = Cₙ is the C-normalisation of Tₙ, so the x ↦ 2x conjugacy transports the entire first-kind composition monoid to the Dickson polynomials",
+      "U_one_ne_X: the root obstruction for the second kind — U₁ = 2X ≠ X, so n ↦ Uₙ cannot map the multiplicative identity to the compositional identity",
+      "U_comp_law_fails_at_one: the composition law U_{m·n} = U_m ∘ U_n fails already at m = n = 1 (2X ≠ 4X), so Uₙ is not even a monoid morphism into (R[X], ∘, X)",
+      "U_comp_law_fails_deg_two: a quantitative positive-degree witness U₄ ≠ U₂ ∘ U₂, proved via the evaluation-at-1 homomorphism and Uₙ(1) = n+1 (5 ≠ 35)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound. No native_decide, so no Lean.ofReduceBool.",
+    "lineCount": 146,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Polynomial.Chebyshev"
+    ],
+    "namespace": "ChebyshevPolynomialsOQ01OQ02",
+    "path": "Proofs/ChebyshevPolynomialsOQ01OQ02.lean"
+  },
+  "overview": {
+    "historicalContext": "The parent entry proved that the first-kind Chebyshev polynomials Tₙ compose (T_{mn} = T_m ∘ T_n) and hence commute under composition — the property that, alongside the power maps xⁿ, places them at the centre of Ritt's 1923 classification of commuting polynomials. Two natural cousins invite the same question: the second-kind Chebyshev polynomials Uₙ (defined by Uₙ(cos θ) sin θ = sin((n+1)θ)) and the Dickson polynomials Dₙ, introduced by L. E. Dickson in 1897. The Dickson polynomials of the first kind are the classical 'x + a/x' companions of the Chebyshev Tₙ, and it is well known that they, too, satisfy a composition law. The Uₙ, by contrast, are only quasi-multiplicative and do not compose. This entry formalises exactly which of the parent's structural laws survive the passage to each family.",
+    "problemStatement": "Open question #2 of the parent entry: establish the analogous composition/commutation theory for the second-kind Chebyshev polynomials Uₙ and the Dickson polynomials, identifying which structural laws survive.\n\n**Answer:** The composition law survives for the first-kind Dickson polynomials Dₙ = dickson 1 1 n — they form a commutative compositional monoid (D_{m·n} = D_m ∘ D_n, D₁ = X, commutation, associativity), because Dₙ = Cₙ is the x ↦ 2x-conjugate normal form of Tₙ. It fails for the second-kind Chebyshev Uₙ: U₁ = 2X ≠ X, so U_{m·n} = U_m ∘ U_n breaks already at m = n = 1, and U₄ ≠ U₂ ∘ U₂ is a positive-degree witness.",
+    "text": "The first-kind Dickson polynomials Dₙ inherit the entire compositional monoid of the Chebyshev Tₙ, since Dₙ = Cₙ is nothing but Tₙ conjugated by x ↦ 2x, and conjugation is an isomorphism of the compositional monoid. Thus D_{m·n} = D_m ∘ D_n, the Dₙ commute under composition, D₁ = X is the identity, and composition is associative. The second-kind Chebyshev Uₙ enjoy no such structure: because U₁ = 2X differs from the compositional identity X, the indexing n ↦ Uₙ is not a monoid morphism into (R[X], ∘, X), and the composition law fails already at the multiplicative unit and, quantitatively, at U₄ vs U₂ ∘ U₂.",
+    "proofStrategy": "1. dickson_comp: record Mathlib's dickson_one_one_mul as the surviving composition law.\n2. dickson_one_eq_X / dickson_comp_one / dickson_one_comp: D₁ = X (dickson_one) makes 1 the compositional unit via comp_X and X_comp.\n3. dickson_comp_comm: Mathlib's dickson_one_one_comp_comm gives commutation; dickson_comp_assoc iterates the composition law with mul_assoc.\n4. dickson_eq_chebyshev_C: dickson_one_one_eq_chebyshev_C exhibits the T-conjugacy that explains why the first-kind laws transport.\n5. U_one_ne_X: evaluate U₁ = 2X and X at 1 (2 ≠ 1).\n6. U_comp_law_fails_at_one: assume the law at m = n = 1, evaluate (2X) ∘ (2X) = 4X at 1 against 2X (2 ≠ 4).\n7. U_comp_law_fails_deg_two: assume U₄ = U₂ ∘ U₂, apply eval-at-1 and Uₙ(1) = n+1 to get 5 = U₂(3) = 35, a contradiction.",
+    "keyInsights": [
+      "**Which laws survive is decided by conjugacy, not by kind alone.** The first-kind Dickson polynomials survive precisely because Dₙ = Cₙ is the x ↦ 2x conjugate of Tₙ, and conjugation preserves the compositional monoid. The composition law is a property of the *first-kind* structure, transported intact to any affine reparametrisation of it.",
+      "**The obstruction for Uₙ is the identity, not the degree.** The cleanest reason U_{m·n} = U_m ∘ U_n fails is that U₁ = 2X is not the compositional identity X. A homomorphism into (R[X], ∘, X) must send the multiplicative unit 1 to X; Uₙ cannot, so the law breaks at the most trivial case m = n = 1, before any question of degree arises.",
+      "**Evaluation at 1 is a clean certificate of failure.** Since Uₙ(1) = n + 1, the ring homomorphism p ↦ p(1) turns the putative composition law into an arithmetic identity mn + 1 = U_m(n+1). At m = n = 2 this reads 5 = 35, an unconditional numerical refutation of U₄ = U₂ ∘ U₂.",
+      "**The second-kind failure is uniform.** The same obstruction applies to the second-kind Dickson polynomials dickson 2 1 n = Sₙ (with Uₙ = Sₙ(2x)); the compositional monoid is a phenomenon of the first-kind family, and both second-kind normalisations lie outside it."
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the first and second kind",
+      "Dickson polynomials",
+      "Polynomial composition over a commutative ring",
+      "The evaluation homomorphism p ↦ p(a)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: which structural laws survive",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Docstring stating open question #2 and its answer: the composition/commutation monoid survives for the first-kind Dickson polynomials (via the x ↦ 2x conjugacy to Tₙ) but fails for the second-kind Chebyshev Uₙ (whose U₁ = 2X is not the compositional identity).",
+      "mathContext": "$D_{mn} = D_m \\circ D_n$ but $U_{mn} \\neq U_m \\circ U_n$."
+    },
+    {
+      "id": "dickson-survives",
+      "title": "First-kind Dickson polynomials: the compositional monoid survives",
+      "startLine": 61,
+      "endLine": 99,
+      "summary": "dickson_comp / dickson_one_eq_X / dickson_comp_one / dickson_one_comp / dickson_comp_comm / dickson_comp_assoc: the Dickson polynomials Dₙ = dickson 1 1 n form a commutative compositional monoid — composition law, X = D₁ as two-sided identity, commutation, and associativity — the exact analogue of the parent's first-kind picture.",
+      "mathContext": "$D_{m\\cdot n} = D_m \\circ D_n$, $D_1 = X$, $D_m \\circ D_n = D_n \\circ D_m$."
+    },
+    {
+      "id": "dickson-bridge",
+      "title": "The bridge: why the first-kind law transports",
+      "startLine": 101,
+      "endLine": 108,
+      "summary": "dickson_eq_chebyshev_C: Dₙ = Cₙ, the C-normalisation of the first-kind Chebyshev polynomials, with Cₙ(2x) = 2Tₙ(x). This exhibits Dₙ as the x ↦ 2x-conjugate of Tₙ; conjugation is a monoid isomorphism of composition, which is exactly why every first-kind composition law survives for the Dickson polynomials.",
+      "mathContext": "$D_n = C_n$ and $C_n(2x) = 2 T_n(x)$."
+    },
+    {
+      "id": "u-fails",
+      "title": "Second-kind Chebyshev Uₙ: the composition law fails",
+      "startLine": 110,
+      "endLine": 146,
+      "summary": "U_one_ne_X / U_comp_law_fails_at_one / U_comp_law_fails_deg_two: since U₁ = 2X ≠ X, the map n ↦ Uₙ is not a monoid morphism into (R[X], ∘, X); the law breaks at m = n = 1 (2X ≠ 4X) and, quantitatively, U₄ ≠ U₂ ∘ U₂ (evaluate at 1: 5 ≠ 35 via Uₙ(1) = n+1).",
+      "mathContext": "$U_1 = 2X \\neq X$; $U_4 \\neq U_2 \\circ U_2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers open question #2 of the parent by separating the two cousins of the first-kind Chebyshev polynomials. The composition/commutation monoid survives verbatim for the first-kind Dickson polynomials Dₙ = dickson 1 1 n (D_{m·n} = D_m ∘ D_n, D₁ = X, commutation, associativity), because Dₙ = Cₙ is the x ↦ 2x-conjugate of Tₙ and conjugation preserves the compositional monoid. It fails for the second-kind Chebyshev Uₙ: U₁ = 2X ≠ X obstructs the morphism property, so U_{m·n} = U_m ∘ U_n breaks already at m = n = 1, with U₄ ≠ U₂ ∘ U₂ a concrete positive-degree witness. 146 lines, 10 theorems, 0 axioms, 0 sorries.",
+    "implications": "The surviving structure locates the Dickson polynomials, alongside the Chebyshev Tₙ and the monomials xⁿ, among Ritt's commuting polynomial families — a fact the Dₙ = Cₙ bridge makes transparent. The negative results sharpen the boundary: composability is a first-kind phenomenon, invariant under affine conjugation but not shared by the second-kind normalisations Uₙ or Sₙ. The evaluation-at-1 certificate Uₙ(1) = n+1 gives a reusable, purely arithmetic obstruction to spurious composition laws for the second kind.",
+    "openQuestions": [
+      "Formalise the affine-conjugation principle abstractly: if q = ℓ⁻¹ ∘ p ∘ ℓ for an affine ℓ, then p and q generate isomorphic compositional monoids, recovering the Dickson survival as an instance rather than a Mathlib black box.",
+      "Characterise the actual composition/multiplication identities the second-kind Uₙ do satisfy (the product-to-sum and index-addition formulas), pinning down the algebraic structure that replaces the failed compositional monoid."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "chebyshev-polynomials-oq-01",
+      "relationship": "Parent entry: proves the first-kind composition law T_{m·n} = T_m ∘ T_n and the commuting monoid; this entry answers its open question #2 on the second-kind and Dickson analogues."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question #2** of `chebyshev-polynomials-oq-01`: establish the analogous composition/commutation theory for the **second-kind Chebyshev polynomials Uₙ** and the **Dickson polynomials**, identifying *which structural laws survive*.

The answer splits sharply along the first-kind / second-kind divide.

### The law SURVIVES for the first-kind Dickson polynomials
`Dₙ = dickson 1 1 n` form a commutative compositional monoid, the exact analogue of the parent's first-kind Chebyshev picture:
- `dickson_comp`: `D_{m·n} = D_m ∘ D_n` (Mathlib's `dickson_one_one_mul`)
- `dickson_one_eq_X` / `dickson_comp_one` / `dickson_one_comp`: `D₁ = X` is the two-sided compositional identity
- `dickson_comp_comm`: commutation under composition
- `dickson_comp_assoc`: associativity
- `dickson_eq_chebyshev_C`: **the bridge** — `Dₙ = Cₙ` is the `x ↦ 2x`-conjugate of `Tₙ`, and conjugation preserves the compositional monoid, which is *why* the first-kind laws transport.

### The law FAILS for the second-kind Chebyshev Uₙ
- `U_one_ne_X`: `U₁ = 2X ≠ X` — the root obstruction; a morphism into `(R[X], ∘, X)` must send `1` to `X`.
- `U_comp_law_fails_at_one`: the composition law breaks already at `m = n = 1` (`(2X)∘(2X) = 4X ≠ 2X`).
- `U_comp_law_fails_deg_two`: a positive-degree witness `U₄ ≠ U₂ ∘ U₂`, via the evaluation-at-1 homomorphism and `Uₙ(1) = n+1` (5 ≠ 35).

## Verification
- **0 sorries, 0 axioms** — depends only on `propext` / `Classical.choice` / `Quot.sound`. No `native_decide`, no `Lean.ofReduceBool`.
- 10 theorems, 146 lines. Single-file build verified with `lake env lean`; `#print axioms` confirmed on all 10 results.

## Files
- `proofs/Proofs/ChebyshevPolynomialsOQ01OQ02.lean`
- `src/data/proofs/chebyshev-polynomials-oq-01-oq-02/{meta.json,annotations.json,index.ts}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)