### PR TITLE
research(dirichlets-theorem-oq-03-oq-01-oq-02): base-rescaling law for the Linnik critical exponent [VERIFIED, 0-axiom, 8thm/175L, new entry]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ03OQ01OQ02.lean
@@ -1,0 +1,175 @@
+/-
+  Open Question (derived): The Linnik Critical Exponent under Base Rescaling
+
+  Parent chain:
+  - dirichlets-theorem-oq-03      : the Linnik constant (best exponent in Linnik's theorem).
+  - dirichlets-theorem-oq-03-oq-01: the Linnik constant as a *critical exponent* — the
+    admissible-exponent set is an upward-closed ray, its infimum is the constant, and the
+    constant is monotone under pointwise domination of the growth function.
+  - dirichlets-theorem-oq-03-oq-01-oq-01: the lower bound (Linnik constant ≥ 1).
+
+  This file adds the missing *reparametrization law*: how the critical exponent transforms
+  when the BASE is rescaled by a power. If one measures the growth of `f` against `(b i)^k`
+  instead of `b i` (for a fixed real exponent `k > 0`), then an exponent `L` is admissible
+  for the rescaled base iff `k·L` is admissible for the original base — so the whole
+  admissible ray is scaled by `1/k`, and the critical exponent scales exactly by `1/k`:
+
+        criticalExponent f (fun i => (b i)^k) = criticalExponent f b / k.
+
+  This is the precise sense in which the Linnik constant is a *dimensionless* critical
+  exponent: it is defined relative to a choice of base scale, and changing that scale by a
+  power `k` divides the constant by `k`. In particular measuring the least prime `p(a,q)`
+  against `q²` rather than `q` halves the critical exponent.
+
+  Everything is AXIOM-FREE and SORRY-FREE, stated for an abstract growth function
+  `f : I → ℝ` over a nonnegative base `b : I → ℝ`. As in the sibling files, the deep input
+  (Linnik's theorem: one admissible exponent exists) enters only as a nonemptiness
+  hypothesis, never as an axiom.
+
+  Tags: number-theory, primes, arithmetic-progressions, linnik-constant, critical-exponent,
+        rescaling
+-/
+
+import Mathlib
+
+open Real Set
+
+namespace LinnikBaseRescaling
+
+variable {I : Type*}
+
+/-- The set of admissible exponents for a growth function `f` over a base `b`:
+    those `L > 0` for which `f i ≤ c · (b i) ^ L` holds uniformly for some `c > 0`.
+    (Same definition as the sibling entries; repeated here to keep the file self-contained.) -/
+def admissible (f b : I → ℝ) : Set ℝ :=
+  { L | 0 < L ∧ ∃ c, 0 < c ∧ ∀ i, f i ≤ c * b i ^ L }
+
+/-- The admissible set is bounded below by `0`, so its infimum exists. -/
+theorem admissible_bddBelow (f b : I → ℝ) : BddBelow (admissible f b) :=
+  ⟨0, fun _ hL => le_of_lt hL.1⟩
+
+/-- The critical exponent: the infimum of the admissible set. In the Linnik instance
+    (`f = leastPrimeInAP`, `b = q`) this is the Linnik constant. -/
+noncomputable def criticalExponent (f b : I → ℝ) : ℝ := sInf (admissible f b)
+
+/-!
+## The reparametrization bijection
+
+The heart of the file: admissibility for the rescaled base `b^k` at exponent `L` is
+*exactly* admissibility for `b` at exponent `k·L`, using `(b i ^ k) ^ L = b i ^ (k·L)`
+(valid because `b i ≥ 0`) and `0 < L ↔ 0 < k·L` (valid because `k > 0`).
+-/
+
+/-- Reparametrization: `L` is admissible for the rescaled base `b^k` iff `k·L` is
+    admissible for the original base `b`. -/
+theorem mem_admissible_rpow_base_iff {f b : I → ℝ} {k : ℝ} (hk : 0 < k)
+    (hb : ∀ i, 0 ≤ b i) (L : ℝ) :
+    L ∈ admissible f (fun i => b i ^ k) ↔ k * L ∈ admissible f b := by
+  constructor
+  · rintro ⟨hLpos, c, hc, hbound⟩
+    refine ⟨mul_pos hk hLpos, c, hc, fun i => ?_⟩
+    have h := hbound i
+    rwa [← Real.rpow_mul (hb i)] at h
+  · rintro ⟨hkLpos, c, hc, hbound⟩
+    have hLpos : 0 < L := by
+      by_contra h
+      push_neg at h
+      exact absurd hkLpos (not_lt.mpr (mul_nonpos_of_nonneg_of_nonpos hk.le h))
+    refine ⟨hLpos, c, hc, fun i => ?_⟩
+    have h := hbound i
+    rwa [Real.rpow_mul (hb i)] at h
+
+/-- Nonemptiness transfers along the reparametrization: the rescaled admissible set is
+    nonempty iff the original one is. -/
+theorem admissible_rpow_base_nonempty_iff {f b : I → ℝ} {k : ℝ} (hk : 0 < k)
+    (hb : ∀ i, 0 ≤ b i) :
+    (admissible f (fun i => b i ^ k)).Nonempty ↔ (admissible f b).Nonempty := by
+  constructor
+  · rintro ⟨L, hL⟩
+    exact ⟨k * L, (mem_admissible_rpow_base_iff hk hb L).mp hL⟩
+  · rintro ⟨M, hM⟩
+    refine ⟨M / k, (mem_admissible_rpow_base_iff hk hb (M / k)).mpr ?_⟩
+    rwa [mul_div_cancel₀ M (ne_of_gt hk)]
+
+/-!
+## The rescaling law for the critical exponent
+-/
+
+/-- **Base-rescaling law.** For a fixed real power `k > 0` and a nonnegative base `b`, the
+    critical exponent for the rescaled base `b^k` is the original critical exponent divided
+    by `k`:  `criticalExponent f (b^k) = criticalExponent f b / k`.  Measuring growth
+    against a higher power of the base lowers the critical exponent proportionally. -/
+theorem criticalExponent_rpow_base {f b : I → ℝ} {k : ℝ} (hk : 0 < k)
+    (hb : ∀ i, 0 ≤ b i) (hne : (admissible f b).Nonempty) :
+    criticalExponent f (fun i => b i ^ k) = criticalExponent f b / k := by
+  have hne' : (admissible f (fun i => b i ^ k)).Nonempty :=
+    (admissible_rpow_base_nonempty_iff hk hb).mpr hne
+  apply le_antisymm
+  · -- `crit A' ≤ crit A / k`: for every `M ∈ A`, `M/k ∈ A'`, so `crit A' ≤ M/k`.
+    rw [le_div_iff₀ hk]
+    apply le_csInf hne
+    intro M hM
+    have hMk : M / k ∈ admissible f (fun i => b i ^ k) := by
+      apply (mem_admissible_rpow_base_iff hk hb (M / k)).mpr
+      rwa [mul_div_cancel₀ M (ne_of_gt hk)]
+    have hle : criticalExponent f (fun i => b i ^ k) ≤ M / k :=
+      csInf_le (admissible_bddBelow _ _) hMk
+    calc criticalExponent f (fun i => b i ^ k) * k
+        ≤ (M / k) * k := mul_le_mul_of_nonneg_right hle hk.le
+      _ = M := div_mul_cancel₀ M (ne_of_gt hk)
+  · -- `crit A / k ≤ crit A'`: `crit A / k` is a lower bound for `A'`.
+    apply le_csInf hne'
+    intro L hL
+    have hkL : k * L ∈ admissible f b := (mem_admissible_rpow_base_iff hk hb L).mp hL
+    have hle : criticalExponent f b ≤ k * L :=
+      csInf_le (admissible_bddBelow f b) hkL
+    rw [div_le_iff₀ hk]
+    linarith [mul_comm k L]
+
+/-- Sanity check: rescaling by `k = 1` leaves the critical exponent unchanged
+    (the rescaled base `b^1` and `b` define the same critical exponent). -/
+theorem criticalExponent_rpow_base_one {f b : I → ℝ}
+    (hb : ∀ i, 0 ≤ b i) (hne : (admissible f b).Nonempty) :
+    criticalExponent f (fun i => b i ^ (1 : ℝ)) = criticalExponent f b := by
+  rw [criticalExponent_rpow_base one_pos hb hne, div_one]
+
+/-- Doubling the base scale halves the critical exponent: measuring against `q²` instead of
+    `q` in the Linnik setting gives exactly half the constant. -/
+theorem criticalExponent_rpow_base_two {f b : I → ℝ}
+    (hb : ∀ i, 0 ≤ b i) (hne : (admissible f b).Nonempty) :
+    criticalExponent f (fun i => b i ^ (2 : ℝ)) = criticalExponent f b / 2 :=
+  criticalExponent_rpow_base (by norm_num) hb hne
+
+/-- Monotone in the scale: a larger base power gives a smaller (or equal) critical exponent,
+    for a nonnegative critical exponent. This packages the `1/k` dependence as an order
+    statement. -/
+theorem criticalExponent_rpow_base_antitone {f b : I → ℝ} {k₁ k₂ : ℝ}
+    (hk₁ : 0 < k₁) (hk₁₂ : k₁ ≤ k₂) (hb : ∀ i, 0 ≤ b i)
+    (hne : (admissible f b).Nonempty) (hcpos : 0 ≤ criticalExponent f b) :
+    criticalExponent f (fun i => b i ^ k₂) ≤ criticalExponent f (fun i => b i ^ k₁) := by
+  have hk₂ : 0 < k₂ := lt_of_lt_of_le hk₁ hk₁₂
+  rw [criticalExponent_rpow_base hk₁ hb hne, criticalExponent_rpow_base hk₂ hb hne]
+  apply div_le_div_of_nonneg_left hcpos hk₁ hk₁₂
+
+/-!
+## Linnik specialization
+
+For the arithmetic-progression data (`f = p(·,·)`, `b = q`), the rescaling law says the
+Linnik critical exponent measured against `q^k` is the ordinary Linnik constant divided by
+`k`. The deep Linnik input is again only the nonemptiness hypothesis.
+-/
+
+/-- The Linnik constant measured against the rescaled base `q^k` equals the ordinary Linnik
+    constant divided by `k`. -/
+theorem linnikConstant_rpow_base (p : ℕ × ℕ → ℝ) {k : ℝ} (hk : 0 < k)
+    (hne : (admissible p (fun i => (i.2 : ℝ))).Nonempty) :
+    criticalExponent p (fun i => (i.2 : ℝ) ^ k)
+      = criticalExponent p (fun i => (i.2 : ℝ)) / k :=
+  criticalExponent_rpow_base hk (fun i => by positivity) hne
+
+#check @mem_admissible_rpow_base_iff
+#check @criticalExponent_rpow_base
+#check @criticalExponent_rpow_base_two
+#check @linnikConstant_rpow_base
+
+end LinnikBaseRescaling

--- a/src/data/proofs/dirichlets-theorem-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03-oq-01-oq-02/annotations.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "ann-dir-oq030101-oq02-header",
+    "proofId": "dirichlets-theorem-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "The Critical Exponent as a Dimensionless Quantity",
+    "content": "The sibling entry dirichlets-theorem-oq-03-oq-01 recast the Linnik constant as the critical exponent of the admissible-exponent ray, and dirichlets-theorem-oq-03-oq-01-oq-01 proved the lower bound ≥ 1. Both fix the base at b = q. This file supplies the missing reparametrization law: what happens to the critical exponent when the BASE itself is rescaled by a real power k > 0. The answer is exact — the critical exponent divides by k — which shows the Linnik constant is a dimensionless critical exponent, defined only relative to a chosen base scale. Everything is axiom-free; the deep Linnik input enters solely as a nonemptiness hypothesis.",
+    "mathContext": "For a growth function $f : I \\to \\mathbb{R}$ over a nonnegative base $b$, the admissible set is $\\{L > 0 : \\exists c > 0,\\ \\forall i,\\ f(i) \\leq c\\,b(i)^L\\}$ and the critical exponent is its infimum. Replacing $b$ by $b^k$ (fixed $k > 0$) sends admissibility at $L$ to admissibility at $kL$, hence divides the critical exponent by $k$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "critical exponent",
+      "Linnik constant",
+      "base rescaling",
+      "reparametrization",
+      "dimensional analysis"
+    ],
+    "prerequisites": [
+      "infimum of a set of reals",
+      "real powers (rpow)",
+      "admissible-exponent ray"
+    ]
+  },
+  {
+    "id": "ann-dir-oq030101-oq02-defs",
+    "proofId": "dirichlets-theorem-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 44,
+      "endLine": 53
+    },
+    "type": "definition",
+    "title": "Admissible Set and Critical Exponent (Self-Contained)",
+    "content": "`admissible f b` is the set of exponents L > 0 for which f is dominated by c·bᴸ uniformly for some c > 0; `admissible_bddBelow` records that 0 is a lower bound; `criticalExponent f b` is the infimum. These repeat the sibling entries' definitions verbatim so the file compiles standalone and axiom-free.",
+    "mathContext": "$\\text{admissible}(f,b) = \\{L \\mid 0 < L \\wedge \\exists c>0,\\ \\forall i,\\ f(i) \\le c\\,b(i)^L\\}$; $\\text{criticalExponent}(f,b) = \\inf \\text{admissible}(f,b)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "BddBelow",
+      "sInf",
+      "growth function"
+    ],
+    "prerequisites": [
+      "Set-builder notation in Lean",
+      "csInf / conditionally complete lattice"
+    ]
+  },
+  {
+    "id": "ann-dir-oq030101-oq02-bijection",
+    "proofId": "dirichlets-theorem-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 55,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "The Reparametrization Bijection L ↦ kL",
+    "content": "`mem_admissible_rpow_base_iff` is the technical heart: L is admissible for the rescaled base b^k iff k·L is admissible for b. The forward and backward directions both hinge on the identity (b i ^ k) ^ L = b i ^ (k·L) — valid because b i ≥ 0 — via `Real.rpow_mul`, together with the equivalence 0 < L ↔ 0 < k·L (from k > 0). `admissible_rpow_base_nonempty_iff` transfers nonemptiness across this bijection (needed so the infimum arguments apply to both sets).",
+    "mathContext": "With $b(i) \\ge 0$ and $k > 0$: $f(i) \\le c\\,(b(i)^k)^L = c\\,b(i)^{kL}$, so $L \\in \\text{adm}(f, b^k) \\iff kL \\in \\text{adm}(f, b)$. The map $L \\mapsto kL$ is an order isomorphism scaling the ray by $k$; its inverse $M \\mapsto M/k$ gives nonemptiness transfer.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.rpow_mul",
+      "order isomorphism",
+      "mul_div_cancel",
+      "nonemptiness transfer"
+    ],
+    "prerequisites": [
+      "rpow identities for nonnegative base",
+      "sign of a product",
+      "Set.Nonempty"
+    ]
+  },
+  {
+    "id": "ann-dir-oq030101-oq02-law",
+    "proofId": "dirichlets-theorem-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 94,
+      "endLine": 152
+    },
+    "type": "theorem",
+    "title": "The Base-Rescaling Law and its Corollaries",
+    "content": "`criticalExponent_rpow_base`: for k > 0 and nonnegative base, criticalExponent f (b^k) = criticalExponent f b / k. The proof is a two-sided infimum comparison built purely on the bijection: each direction shows one infimum bounds a scaled version of the other via `le_csInf` and `csInf_le`, then clears the positive factor k with `le_div_iff₀` / `div_le_iff₀`. Corollaries: `criticalExponent_rpow_base_one` (k = 1 is the identity), `criticalExponent_rpow_base_two` (measuring against b² halves the constant), and `criticalExponent_rpow_base_antitone` (larger base power ⟹ smaller-or-equal critical exponent, packaging the 1/k dependence as monotonicity).",
+    "mathContext": "$\\inf \\text{adm}(f, b^k) = \\tfrac{1}{k}\\inf \\text{adm}(f, b)$. Lower: for $M \\in \\text{adm}(f,b)$, $M/k \\in \\text{adm}(f,b^k)$, so $\\text{crit}(b^k)\\cdot k \\le M$; take inf over $M$. Upper: for $L \\in \\text{adm}(f,b^k)$, $kL \\in \\text{adm}(f,b)$, so $\\text{crit}(b)/k \\le L$; take inf over $L$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "le_antisymm",
+      "le_csInf",
+      "csInf_le",
+      "div_le_iff₀",
+      "antitone"
+    ],
+    "prerequisites": [
+      "infimum characterization",
+      "monotone division by a positive",
+      "conditionally complete order"
+    ]
+  },
+  {
+    "id": "ann-dir-oq030101-oq02-linnik",
+    "proofId": "dirichlets-theorem-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 154,
+      "endLine": 175
+    },
+    "type": "insight",
+    "title": "Linnik Specialization: q^k Divides the Constant by k",
+    "content": "`linnikConstant_rpow_base` instantiates the law at the arithmetic-progression data (base b = q ≥ 0). It states that the Linnik critical exponent measured against q^k equals the ordinary Linnik constant divided by k — so measuring the least prime p(a,q) against q² rather than q halves the constant. This makes explicit that the numerical value of 'the Linnik constant' is inseparable from the convention that the base is q to the first power; the underlying arithmetic content is scale-invariant.",
+    "mathContext": "For $p : \\mathbb{N}\\times\\mathbb{N} \\to \\mathbb{R}$ and $k > 0$: $\\text{criticalExponent}(p,\\ q \\mapsto q^k) = \\text{criticalExponent}(p,\\ q \\mapsto q)/k$. The nonnegativity of the base $q$ is automatic (`positivity`); the only nontrivial hypothesis is nonemptiness (Linnik's theorem).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Linnik's theorem",
+      "least prime in AP",
+      "scale invariance",
+      "critical exponent convention"
+    ],
+    "prerequisites": [
+      "arithmetic-progression instance",
+      "positivity tactic"
+    ]
+  }
+]

--- a/src/data/proofs/dirichlets-theorem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03-oq-01-oq-02/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "dirichlets-theorem-oq-03-oq-01-oq-02",
+  "title": "The Linnik Critical Exponent under Base Rescaling",
+  "slug": "dirichlets-theorem-oq-03-oq-01-oq-02",
+  "description": "A follow-up to dirichlets-theorem-oq-03-oq-01 (the Linnik constant as a critical exponent of the admissible-exponent ray). Both that entry and its lower-bound sibling fix the base at b = q. This entry proves the reparametrization law for the base itself: measuring a growth function f against (b i)^k instead of b i (for a fixed real power k > 0) sends admissibility at exponent L to admissibility at k·L, so the whole admissible ray scales by 1/k and the critical exponent divides exactly by k — criticalExponent f (b^k) = criticalExponent f b / k. In the Linnik setting, measuring the least prime p(a,q) against q² rather than q halves the constant. Verified, axiom-free, sorry-free; the deep Linnik input enters only as a nonemptiness hypothesis.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DirichletsTheoremOQ03OQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "arithmetic-progressions",
+      "linnik-constant",
+      "critical-exponent",
+      "rescaling",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All results depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound); there are no axiom declarations, no sorries, and no structure-encoded assumptions. The critical exponent is defined for an abstract growth function over a nonnegative base; Linnik's theorem (existence of one admissible exponent) is used only as an ordinary nonemptiness hypothesis, never as an axiom.",
+    "lineCount": 175,
+    "theoremCount": 8,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "**Making the Linnik Constant Scale-Explicit**\n\nDirichlet's theorem guarantees infinitely many primes in each admissible arithmetic progression a mod q; Linnik's theorem quantifies the *least* such prime as p(a,q) ≤ c·q^L, and the Linnik constant is the least admissible exponent L (conjectured 1, best unconditional bound ≤ 5, Xylouris 2011).\n\nThe entry dirichlets-theorem-oq-03-oq-01 abstracted this into the critical exponent of an admissible-exponent ray, and dirichlets-theorem-oq-03-oq-01-oq-01 pinned the lower bound at 1. Both hold the base fixed at q. But a critical exponent is only meaningful relative to a chosen base scale: if we instead compare growth against a power q^k of the base, the exponent must change. This entry proves precisely how — the critical exponent divides by k — establishing that the Linnik constant is a *dimensionless* quantity whose numerical value encodes the convention 'base = q to the first power'.",
+    "problemStatement": "**Goal**\n\nDetermine how the critical exponent of the admissible-exponent set transforms when the base b is replaced by a fixed real power b^k (k > 0), and specialize to the Linnik setting.\n\n**Result**: criticalExponent f (fun i => (b i)^k) = criticalExponent f b / k.",
+    "text": "Proves the base-rescaling law for the Linnik critical exponent: raising the base to a power k > 0 divides the critical exponent by k.",
+    "proofStrategy": "**Approach**\n\n1. Re-state the admissible set / critical exponent (self-contained, axiom-free).\n2. `mem_admissible_rpow_base_iff`: L admissible for b^k ⟺ k·L admissible for b, via (b i^k)^L = b i^(k·L) (Real.rpow_mul, b i ≥ 0) and 0 < L ⟺ 0 < k·L (k > 0).\n3. `admissible_rpow_base_nonempty_iff`: transfer nonemptiness across the bijection.\n4. `criticalExponent_rpow_base`: two-sided infimum comparison (le_csInf / csInf_le) clearing the positive factor k, giving crit(b^k) = crit(b)/k.\n5. Corollaries: k = 1 identity, k = 2 halving, and antitonicity in k.\n6. `linnikConstant_rpow_base`: specialize to base q (nonnegativity via positivity).",
+    "keyInsights": [
+      "**The critical exponent is dimensionless**: Its numerical value is meaningless without a base convention. Raising the base to the power k rescales the entire admissible ray by 1/k, so the critical exponent divides by k. The Linnik constant '1' is really '1 relative to base q'.",
+      "**One bijection does all the work**: The order isomorphism L ↦ k·L between the two admissible sets is the single nontrivial fact; every quantitative statement (the law, its corollaries, the Linnik specialization) is a formal consequence of it plus infimum monotonicity.",
+      "**Nonnegativity of the base is exactly what rpow needs**: The identity (b i^k)^L = b i^(k·L) requires b i ≥ 0 (Real.rpow_mul). This is automatic for the Linnik base q, so the specialization needs no extra hypothesis beyond nonemptiness.",
+      "**Sharper bounds via richer bases**: Antitonicity in k (criticalExponent_rpow_base_antitone) formalizes that comparing against a higher power of the base can only lower the measured exponent — a structural counterpart to the monotonicity-under-domination result of the parent entry.",
+      "**Scale invariance of the arithmetic content**: The rescaling law shows the genuinely open question (the value of the Linnik constant) is scale-covariant: any theorem about the exponent against q transports mechanically to q^k, so no generality is lost by fixing the base to the first power."
+    ],
+    "prerequisites": [
+      "Real powers (rpow) and the identity x^(yz) = (x^y)^z for x ≥ 0",
+      "Infimum of a bounded-below set (csInf, le_csInf, csInf_le)",
+      "The admissible-exponent / critical-exponent framework of the parent entry"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Motivation: The Critical Exponent Depends on the Base Scale",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Explains that the Linnik constant is a critical exponent relative to a base scale, and that raising the base to a power k > 0 divides the exponent by k.",
+      "mathContext": "criticalExponent f (b^k) = criticalExponent f b / k for k > 0, b ≥ 0."
+    },
+    {
+      "id": "defs",
+      "title": "Admissible Set and Critical Exponent",
+      "startLine": 44,
+      "endLine": 53,
+      "summary": "Self-contained restatement of admissible, admissible_bddBelow, and criticalExponent (matching the sibling entries).",
+      "mathContext": "$\\text{adm}(f,b) = \\{L>0 : \\exists c>0, \\forall i, f(i) \\le c\\,b(i)^L\\}$, $\\text{crit} = \\inf$."
+    },
+    {
+      "id": "bijection",
+      "title": "The Reparametrization Bijection L ↦ kL",
+      "startLine": 55,
+      "endLine": 92,
+      "summary": "mem_admissible_rpow_base_iff (L admissible for b^k ⟺ kL admissible for b) and admissible_rpow_base_nonempty_iff (nonemptiness transfer).",
+      "mathContext": "$(b(i)^k)^L = b(i)^{kL}$ via Real.rpow_mul; $0<L \\iff 0<kL$ via $k>0$."
+    },
+    {
+      "id": "law",
+      "title": "The Base-Rescaling Law and Corollaries",
+      "startLine": 94,
+      "endLine": 152,
+      "summary": "criticalExponent_rpow_base (crit(b^k) = crit(b)/k) plus k=1 identity, k=2 halving, and antitonicity in k.",
+      "mathContext": "$\\inf \\text{adm}(f,b^k) = \\tfrac1k \\inf \\text{adm}(f,b)$ by two-sided csInf comparison."
+    },
+    {
+      "id": "linnik",
+      "title": "Linnik Specialization",
+      "startLine": 154,
+      "endLine": 175,
+      "summary": "linnikConstant_rpow_base: the Linnik constant against q^k equals the ordinary constant divided by k; nonnegativity of q is automatic.",
+      "mathContext": "$\\text{crit}(p,\\ q\\mapsto q^k) = \\text{crit}(p,\\ q\\mapsto q)/k$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves the exact base-rescaling law for the Linnik critical exponent: for a fixed real power k > 0 and a nonnegative base, raising the base to the power k divides the critical exponent by k. Corollaries cover the k = 1 identity, the k = 2 halving, antitonicity in k, and the Linnik specialization against q^k. Fully verified, axiom-free.",
+    "implications": "Establishes that the Linnik constant is a dimensionless critical exponent tied to a base-scale convention (base = q^1). Any statement about the exponent against q transports mechanically to q^k, confirming that fixing the base to the first power loses no generality and that the genuinely open value question is scale-covariant.",
+    "openQuestions": [
+      "Does an analogous transformation law hold for base reparametrizations that are not pure powers (e.g. b ↦ b·log b), and does it perturb the critical exponent continuously?",
+      "Can the rescaling law combine with the monotonicity-under-domination result to give two-parameter families of critical-exponent bounds?"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "mem_admissible_rpow_base_iff",
+      "type": "core",
+      "description": "L admissible for base b^k ⟺ k·L admissible for base b",
+      "leanType": "0 < k → (∀ i, 0 ≤ b i) → (L ∈ admissible f (fun i => b i ^ k) ↔ k * L ∈ admissible f b)"
+    },
+    {
+      "name": "criticalExponent_rpow_base",
+      "type": "core",
+      "description": "Base-rescaling law: raising the base to the power k divides the critical exponent by k",
+      "leanType": "0 < k → (∀ i, 0 ≤ b i) → (admissible f b).Nonempty → criticalExponent f (fun i => b i ^ k) = criticalExponent f b / k"
+    },
+    {
+      "name": "linnikConstant_rpow_base",
+      "type": "core",
+      "description": "Linnik constant against q^k equals the ordinary Linnik constant divided by k",
+      "leanType": "0 < k → (admissible p (fun i => i.2)).Nonempty → criticalExponent p (fun i => (i.2)^k) = criticalExponent p (fun i => i.2) / k"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "dirichlets-theorem-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "Adds the base-rescaling transformation law to the critical-exponent framework introduced there"
+    },
+    {
+      "targetId": "dirichlets-theorem-oq-03-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling structural result: that entry proves the lower bound ≥ 1 for the fixed base q; this one shows how the constant transforms under base rescaling"
+    },
+    {
+      "targetId": "dirichlets-theorem-oq-03",
+      "relationship": "extends",
+      "description": "Clarifies that the Linnik constant of the base problem is defined relative to a base-scale convention"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Yu. V. Linnik"
+      ],
+      "title": "On the least prime in an arithmetic progression",
+      "year": "1944",
+      "note": "Existence of the Linnik constant (least admissible exponent)"
+    },
+    {
+      "authors": [
+        "T. Xylouris"
+      ],
+      "title": "On the least prime in an arithmetic progression and estimates for the zeros of Dirichlet L-functions",
+      "year": "2011",
+      "note": "Best unconditional bound L ≤ 5"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Set"
+    ],
+    "namespace": "LinnikBaseRescaling",
+    "lineCount": 175,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "substantiveTheoremCount": 8,
+    "sorryTheorems": 0,
+    "definitionCount": 2,
+    "mainTheorems": [
+      {
+        "name": "mem_admissible_rpow_base_iff",
+        "type": "proved",
+        "description": "Reparametrization bijection L ↦ kL"
+      },
+      {
+        "name": "criticalExponent_rpow_base",
+        "type": "proved",
+        "description": "Base-rescaling law crit(b^k) = crit(b)/k"
+      },
+      {
+        "name": "linnikConstant_rpow_base",
+        "type": "proved",
+        "description": "Linnik specialization against q^k"
+      }
+    ],
+    "path": "Proofs/DirichletsTheoremOQ03OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/dirichlets-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-03-oq-01.json
@@ -29,11 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED (2026-06-27): new axiom-free file DirichletsTheoremOQ03OQ01.lean (namespace LinnikAdmissible, 11 theorems / 3 defs, 0 axioms / 0 sorries, machine-checked vs Mathlib v4.26.0). Isolates the structural skeleton of the Linnik constant: the admissible-exponent set is an upward-closed below-bounded ray, its infimum (criticalExponent) is non-negative and satisfies the sandwich Ioi(c) ⊆ admissible ⊆ Ici(c), and is monotone under pointwise domination of the growth function. Key separation: well-definedness of L* is elementary (rpow-monotonicity + conditional-infimum API); the deep number theory enters only via nonemptiness of the admissible set (Linnik's theorem), kept as an explicit hypothesis so the file is axiom-free.",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SOLVED (parent already complete). Extended outward: shipped verified 0-axiom base-rescaling law entry dirichlets-theorem-oq-03-oq-01-oq-02 (PR #32644).",
+    "builtItems": [
+      "New file Proofs/DirichletsTheoremOQ03OQ01OQ02.lean (8 thm, 2 def, 0 axiom, 0 sorry): mem_admissible_rpow_base_iff, criticalExponent_rpow_base, +corollaries, linnikConstant_rpow_base (PR #32644)"
+    ],
+    "insights": [
+      "Claimed problem dirichlets-theorem-oq-03-oq-01 was already SOLVED (verified, 0-axiom, 11thm, merged+enriched) with grandchild -oq-01-oq-01 (lower bound ≥1); pool listed it only because its knowledge JSON was empty.",
+      "Looked outward per SOLVED strategy: the critical-exponent framework fixed the base at b=q; the missing structural result is the reparametrization law under base rescaling b ↦ b^k.",
+      "Shipped NEW sibling entry dirichlets-theorem-oq-03-oq-01-oq-02: criticalExponent f (b^k) = criticalExponent f b / k for k>0, b≥0 — the Linnik constant is dimensionless (base=q^1 convention)."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Transformation law for non-power base reparametrizations (b ↦ b·log b) and continuity of the critical exponent under such perturbations.",
+      "Combine base-rescaling with monotonicity-under-domination for two-parameter critical-exponent bound families."
+    ],
     "markdown": "# Knowledge Base: dirichlets-theorem-oq-03-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

New **verified, 0-axiom** gallery entry `dirichlets-theorem-oq-03-oq-01-oq-02`, a follow-up to `dirichlets-theorem-oq-03-oq-01` (the Linnik constant recast as the critical exponent of the admissible-exponent ray). That entry and its lower-bound sibling `-oq-01-oq-01` both fix the base at `b = q`. This entry supplies the missing **base-reparametrization law**:

> For a fixed real power `k > 0` and a nonnegative base `b`,
> `criticalExponent f (fun i => b i ^ k) = criticalExponent f b / k`.

Measuring the least prime `p(a,q)` against `q²` instead of `q` therefore **halves** the constant — making explicit that the Linnik constant is a *dimensionless* critical exponent tied to the `base = q¹` convention.

## Theorems (8, all proved, 0 sorries)

- `mem_admissible_rpow_base_iff` — `L` admissible for `b^k` ⟺ `k·L` admissible for `b` (via `(b i ^ k)^L = b i ^ (k·L)`, `Real.rpow_mul`, and `0 < L ⟺ 0 < k·L`)
- `admissible_rpow_base_nonempty_iff` — nonemptiness transfer across the bijection
- `criticalExponent_rpow_base` — the rescaling law (two-sided `csInf` comparison)
- `criticalExponent_rpow_base_one` / `_two` — `k = 1` identity, `k = 2` halving
- `criticalExponent_rpow_base_antitone` — larger base power ⟹ smaller-or-equal exponent
- `linnikConstant_rpow_base` — Linnik specialization (base `q`, nonnegativity automatic)

## Verification

- `lake env lean Proofs/DirichletsTheoremOQ03OQ01OQ02.lean` — compiles clean (Mathlib-only import).
- `#print axioms` on all 8 theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no custom axioms.
- 175 lines, 8 theorems, 2 definitions, 0 axiom declarations.

## Files
- `proofs/Proofs/DirichletsTheoremOQ03OQ01OQ02.lean`
- `src/data/proofs/dirichlets-theorem-oq-03-oq-01-oq-02/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)