### PR TITLE
research(basel-problem-oq-10-oq-03): alternating harmonic series ∑(-1)ⁿ/(n+1)=log 2 via Abel's limit theorem [VERIFIED, 0-axiom, new entry, 5thm/157L]

### DIFF
--- a/proofs/Proofs/BaselProblemOQ10OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ10OQ03.lean
@@ -1,0 +1,157 @@
+import Mathlib
+
+/-
+# Basel Problem OQ-10·OQ-03: The alternating harmonic series — and why it is only conditional
+
+## Open Question
+The parent entry (`basel-problem-oq-10`) formalized Leibniz's series `∑ (-1)^k/(2k+1) = π/4`
+and the cautionary fact that the naive `tsum` reading collapses to the junk value `0`. This
+follow-up establishes the *analogous cautionary pair* for the **alternating harmonic series**
+
+  1 − 1/2 + 1/3 − 1/4 + ⋯ = log 2,   i.e.  ∑_n (-1)^n/(n+1) = log 2,
+
+and unifies the underlying conditional-convergence pitfall into a reusable lemma.
+
+## The subtlety (identical to the Leibniz case)
+The alternating harmonic series is only *conditionally* convergent: the terms `(-1)^n/(n+1)`
+are not absolutely summable (their magnitudes `1/(n+1)` form the divergent harmonic series).
+Mathlib's `Summable` demands *unconditional* convergence, so:
+
+  * the family `fun n => (-1)^n/(n+1)` is **not** `Summable`, and consequently
+  * `∑' n, (-1)^n/(n+1) = 0` (the junk value for non-summable families), which is `≠ log 2`.
+
+The correct statement is the convergence of the **ordered** partial sums, a `Tendsto` of
+`∑_{i<n}`.
+
+## New content vs. the parent
+Unlike the Leibniz case — where Mathlib already provides `Real.tendsto_sum_pi_div_four` — Mathlib
+does **not** contain the value of the alternating harmonic series. So the ordered-limit theorem
+`tendsto_alternating_harmonic_log_two` is proved here *from scratch*, by the same Abel-limit route
+Mathlib uses for Leibniz:
+  1. the alternating series test gives convergence to *some* limit `l`;
+  2. Abel's limit theorem (`Real.tendsto_tsum_powerSeries_nhdsWithin_lt`) transfers that to the
+     boundary behaviour of the power series `∑ (-1)^n/(n+1) · x^n = log(1+x)/x` as `x → 1⁻`;
+  3. continuity of `x ↦ log(1+x)/x` at `1` pins the limit to `log 2 / 1 = log 2`.
+
+## Contents
+* `tendsto_alternating_harmonic_log_two` — the correct statement (ordered partial sums → log 2).
+* `not_summable_alternating_harmonic` — the family is not `Summable` (conditional convergence).
+* `tsum_alternating_harmonic_eq_zero` / `tsum_alternating_harmonic_ne_log_two` — the cautionary
+  `tsum` corollaries.
+* `ordered_ne_tsum_of_not_summable` — the *reusable* pitfall lemma: for any real family that is
+  not `Summable`, the unordered `tsum` is `0`, so it differs from any nonzero ordered limit.
+  Both this entry and the parent Leibniz entry are instances.
+
+## Status
+Fully machine-checked, 0 axioms, 0 sorries.
+-/
+
+namespace BaselOQ10OQ03
+
+open Filter Topology BigOperators Real Finset
+
+/-- **The alternating harmonic series (correct form).** The *ordered* partial sums
+`∑_{i<n} (-1)^i/(i+1)` converge to `log 2`. This is the statement that actually holds — the
+series is conditionally convergent.
+
+Mathlib has no ready-made value for this series (contrast `Real.tendsto_sum_pi_div_four` for
+Leibniz), so we reconstruct it via Abel's limit theorem: the alternating series test gives a
+limit `l`, Abel transfers convergence to the boundary of the power series
+`∑ (-1)^n/(n+1)·x^n = log(1+x)/x`, and continuity at `1` identifies `l = log 2`. -/
+theorem tendsto_alternating_harmonic_log_two :
+    Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i / (i + 1)) atTop (𝓝 (Real.log 2)) := by
+  -- The series is alternating with terms of decreasing magnitude, so it converges to some limit.
+  obtain ⟨l, h⟩ :
+      ∃ l, Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i / (i + 1)) atTop (𝓝 l) := by
+    apply Antitone.tendsto_alternating_series_of_tendsto_zero
+    · exact antitone_iff_forall_lt.mpr fun _ _ _ => by gcongr
+    · have : Tendsto (fun i : ℕ => (i : ℝ) + 1) atTop atTop :=
+        tendsto_atTop_add_const_right _ 1 tendsto_natCast_atTop_atTop
+      exact this.inv_tendsto_atTop
+  -- Abel's limit theorem: the corresponding power series has the same limit as `x → 1⁻`.
+  have abel := Real.tendsto_tsum_powerSeries_nhdsWithin_lt h
+  -- Identify the power-series function with `log(1+x)/x` on a left-neighbourhood of `1`.
+  replace abel : Tendsto (fun x => Real.log (1 + x) / x) (𝓝[<] (1 : ℝ)) (𝓝 l) := by
+    apply abel.congr'
+    rw [eventuallyEq_nhdsWithin_iff, Metric.eventually_nhds_iff]
+    refine ⟨1, one_pos, ?_⟩
+    intro y hy1 hy2
+    rw [dist_eq, abs_sub_lt_iff] at hy1
+    rw [Set.mem_Iio] at hy2
+    have hy0 : (0 : ℝ) < y := by linarith [hy1.2]
+    have ny : |y| < 1 := by rw [abs_lt]; exact ⟨by linarith, hy2⟩
+    -- Power series of `log`: `∑ (-y)^(n+1)/(n+1) = -log(1+y)`.
+    have hs := Real.hasSum_pow_div_log_of_abs_lt_one (x := -y) (by rwa [abs_neg])
+    rw [sub_neg_eq_add] at hs
+    -- Rewrite each term so the sum becomes `∑ (g n) * y` with `g n = (-1)^n/(n+1) · y^n`.
+    have hfun : (fun n : ℕ => (-1 : ℝ) * ((-y) ^ (n + 1) / ((n : ℝ) + 1)))
+              = (fun n : ℕ => ((-1 : ℝ) ^ n / ((n : ℝ) + 1) * y ^ n) * y) := by
+      funext n; rw [neg_pow]; ring
+    have hsy : HasSum (fun n : ℕ => ((-1 : ℝ) ^ n / ((n : ℝ) + 1) * y ^ n) * y)
+        (Real.log (1 + y)) := by
+      have hm := hs.mul_left (-1)
+      rw [hfun] at hm
+      convert hm using 1
+      ring
+    -- Divide out the common factor `y ≠ 0`.
+    have hy0' : y ≠ 0 := hy0.ne'
+    have hg : HasSum (fun n : ℕ => (-1 : ℝ) ^ n / ((n : ℝ) + 1) * y ^ n)
+        (Real.log (1 + y) / y) := by
+      apply (hasSum_mul_right_iff hy0').mp
+      rwa [div_mul_cancel₀ _ hy0']
+    exact hg.tsum_eq
+  -- `x ↦ log(1+x)/x` is continuous at `1`, with value `log 2 / 1 = log 2`.
+  have m : 𝓝[<] (1 : ℝ) ≤ 𝓝 1 := nhdsWithin_le_nhds
+  have hcont : Tendsto (fun x : ℝ => Real.log (1 + x) / x) (𝓝[<] (1 : ℝ)) (𝓝 (Real.log 2)) := by
+    have hct : ContinuousAt (fun x : ℝ => Real.log (1 + x) / x) 1 := by
+      apply ContinuousAt.div
+      · exact (Real.continuousAt_log (by norm_num)).comp (by fun_prop)
+      · fun_prop
+      · norm_num
+    simpa [one_add_one_eq_two] using hct.tendsto.mono_left m
+  rwa [tendsto_nhds_unique abel hcont] at h
+
+/-- **The alternating-harmonic family is not summable.** The terms `(-1)^n/(n+1)` are not
+unconditionally summable: their absolute values `1/(n+1)` are the divergent harmonic series.
+Hence the convergence above is *conditional*. -/
+theorem not_summable_alternating_harmonic :
+    ¬ Summable (fun n : ℕ => (-1 : ℝ) ^ n / (n + 1)) := by
+  rw [← summable_abs_iff]
+  have habs : (fun n : ℕ => |(-1 : ℝ) ^ n / (n + 1)|)
+            = (fun n : ℕ => 1 / ((n : ℝ) + 1)) := by
+    funext n
+    rw [abs_div, abs_pow, abs_neg, abs_one, one_pow, abs_of_pos (by positivity)]
+  rw [habs]
+  intro h
+  have hfull : Summable (fun n : ℕ => 1 / (n : ℝ)) := by
+    rw [← summable_nat_add_iff 1]
+    refine (summable_congr (fun n => ?_)).mp h
+    push_cast; ring
+  exact not_summable_one_div_natCast hfull
+
+/-- **Cautionary corollary.** Because the family is not summable, its `tsum` collapses to the
+junk value `0` — it is *not* `log 2`. -/
+theorem tsum_alternating_harmonic_eq_zero :
+    ∑' n : ℕ, (-1 : ℝ) ^ n / (n + 1) = 0 :=
+  tsum_eq_zero_of_not_summable not_summable_alternating_harmonic
+
+/-- The `tsum` reading is `0 ≠ log 2`: the naive unconditional interpretation of the alternating
+harmonic series is false. -/
+theorem tsum_alternating_harmonic_ne_log_two :
+    ∑' n : ℕ, (-1 : ℝ) ^ n / (n + 1) ≠ Real.log 2 := by
+  rw [tsum_alternating_harmonic_eq_zero]
+  exact (Real.log_pos (by norm_num)).ne
+
+/-- **The reusable conditional-convergence pitfall.** For any real family `f` that is *not*
+`Summable`, the unordered `tsum` is the junk value `0`. Hence it disagrees with any nonzero
+ordered limit `L`: `∑' n, f n = 0 ≠ L`.
+
+Both this entry (`L = log 2`) and the parent Leibniz entry (`L = π/4`) are instances: a
+conditionally convergent series carries a meaningful *ordered* value that the `Summable`/`tsum`
+machinery, being unconditional, discards. -/
+theorem ordered_ne_tsum_of_not_summable {f : ℕ → ℝ} {L : ℝ}
+    (hL : L ≠ 0) (hns : ¬ Summable f) : ∑' n, f n ≠ L := by
+  rw [tsum_eq_zero_of_not_summable hns]
+  exact fun h => hL h.symm
+
+end BaselOQ10OQ03

--- a/src/data/proofs/basel-problem-oq-10-oq-03/annotations.json
+++ b/src/data/proofs/basel-problem-oq-10-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-basel-oq10-oq03-overview",
+    "proofId": "basel-problem-oq-10-oq-03",
+    "range": { "startLine": 3, "endLine": 47 },
+    "type": "concept",
+    "title": "The Alternating Harmonic Series and the tsum Trap",
+    "content": "The docstring frames the entry as the direct analogue of the parent Leibniz entry (basel-problem-oq-10), answering its third listed open question. The alternating harmonic series 1 − 1/2 + 1/3 − 1/4 + ⋯ = log 2 is true only as an ORDERED limit of partial sums. Mathlib's Summable, tsum, and HasSum encode UNCONDITIONAL convergence, equivalent over ℝ to absolute convergence; since the terms are not absolutely summable, the family is not Summable and its tsum is the junk value 0 ≠ log 2. Crucially, and unlike the Leibniz case, Mathlib supplies NO value for this series — so the ordered limit log 2 is proved from scratch via Abel's limit theorem.",
+    "mathContext": "$\\sum_n \\frac{(-1)^n}{n+1} = \\log 2$ as $\\lim_n \\sum_{i<n}$, but $\\sum'_n \\frac{(-1)^n}{n+1} = 0$ since the family is not absolutely summable.",
+    "significance": "key",
+    "relatedConcepts": ["conditional convergence", "unconditional convergence", "Mercator series", "Riemann rearrangement theorem", "tsum semantics"],
+    "prerequisites": ["infinite series", "summability", "logarithm series"]
+  },
+  {
+    "id": "ann-basel-oq10-oq03-alt-test",
+    "proofId": "basel-problem-oq-10-oq-03",
+    "range": { "startLine": 61, "endLine": 71 },
+    "type": "tactic",
+    "title": "Step 1: Convergence to Some Limit via the Alternating Series Test",
+    "content": "The main theorem first secures convergence to an unknown limit l. Antitone.tendsto_alternating_series_of_tendsto_zero is applied with coefficient family f i = 1/(i+1): antitonicity is discharged by gcongr, and the decay f i → 0 by writing 1/(i+1) = ((i:ℝ)+1)⁻¹ and applying Tendsto.inv_tendsto_atTop to the divergence of i+1. The Leibniz test guarantees a limit exists but says nothing about its value — that identification is deferred to Abel's theorem.",
+    "mathContext": "$1/(n+1)\\downarrow 0 \\Rightarrow \\sum_{i<n}(-1)^i/(i+1)\\to l$ for some $l$; the value is not yet known.",
+    "significance": "supporting",
+    "relatedConcepts": ["alternating series test", "Antitone.tendsto_alternating_series_of_tendsto_zero", "Tendsto.inv_tendsto_atTop"],
+    "prerequisites": ["monotone sequences", "limits at infinity"]
+  },
+  {
+    "id": "ann-basel-oq10-oq03-abel",
+    "proofId": "basel-problem-oq-10-oq-03",
+    "range": { "startLine": 72, "endLine": 104 },
+    "type": "insight",
+    "title": "Step 2: Abel's Limit Theorem and the Closed Form log(1+x)/x",
+    "content": "The analytic heart of the entry. Abel's limit theorem (Real.tendsto_tsum_powerSeries_nhdsWithin_lt) converts convergence of the partial sums at 1 into: the power series x ↦ ∑' n, (-1)^n/(n+1)·xⁿ tends to l as x → 1 from the left. On a left-neighbourhood of 1 this series is identified with log(1+x)/x. The identification uses Mathlib's hasSum_pow_div_log_of_abs_lt_one (the Maclaurin series ∑ xⁿ⁺¹/(n+1) = −log(1−x)) evaluated at −x, giving ∑ (-1)^n·xⁿ⁺¹/(n+1) = log(1+x); each term is (g n)·x where g n = (-1)^n/(n+1)·xⁿ, so hasSum_mul_right_iff (valid since x ≠ 0 near 1) divides out the factor x to yield ∑ g n = log(1+x)/x. The eventual equality is established on a metric ball intersected with (−∞,1).",
+    "mathContext": "For $0<x<1$: $\\displaystyle\\sum_n \\frac{(-1)^n}{n+1}x^n = \\frac{\\log(1+x)}{x}$; Abel then gives $\\frac{\\log(1+x)}{x}\\to l$ as $x\\to 1^-$.",
+    "significance": "critical",
+    "relatedConcepts": ["Abel's limit theorem", "power series boundary value", "hasSum_pow_div_log_of_abs_lt_one", "hasSum_mul_right_iff"],
+    "prerequisites": ["power series", "radius of convergence", "one-sided limits"]
+  },
+  {
+    "id": "ann-basel-oq10-oq03-continuity",
+    "proofId": "basel-problem-oq-10-oq-03",
+    "range": { "startLine": 105, "endLine": 112 },
+    "type": "tactic",
+    "title": "Step 3: Continuity Pins the Limit to log 2",
+    "content": "Having shown the boundary function equals log(1+x)/x, continuity finishes the job. x ↦ log(1+x)/x is continuous at 1 (log(1+x) is continuous since 1+1 = 2 ≠ 0, and division by x is continuous since x = 1 ≠ 0), so its left-limit is log(1+1)/1 = log 2. Uniqueness of limits (tendsto_nhds_unique) forces the unknown l to equal log 2, completing the ordered-limit theorem.",
+    "mathContext": "$\\displaystyle\\lim_{x\\to 1^-}\\frac{\\log(1+x)}{x} = \\frac{\\log 2}{1} = \\log 2 \\Rightarrow l = \\log 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["continuity", "tendsto_nhds_unique", "ContinuousAt.div"],
+    "prerequisites": ["continuity of elementary functions", "uniqueness of limits"]
+  },
+  {
+    "id": "ann-basel-oq10-oq03-not-summable",
+    "proofId": "basel-problem-oq-10-oq-03",
+    "range": { "startLine": 117, "endLine": 130 },
+    "type": "theorem",
+    "title": "not_summable_alternating_harmonic: Only Conditionally Convergent",
+    "content": "Proves the family is not Summable. Via ← summable_abs_iff the question reduces to absolute summability; the absolute values simplify to |(-1)^n/(n+1)| = 1/(n+1) (abs_div, abs_pow, abs_neg, abs_one, one_pow, abs_of_pos). Assuming summability of 1/(n+1), an index shift (summable_nat_add_iff 1) and push_cast turn it into summability of ∑ 1/n, contradicting not_summable_one_div_natCast — the divergence of the harmonic series. This is the exact analogue of the parent's non-summability lemma, and simpler here since the absolute values ARE the harmonic series (no half-harmonic comparison needed).",
+    "mathContext": "$\\left|\\frac{(-1)^n}{n+1}\\right| = \\frac{1}{n+1}$; summability would force $\\sum 1/n$ to converge, contradicting harmonic divergence.",
+    "significance": "key",
+    "relatedConcepts": ["summable_abs_iff", "harmonic series divergence", "not_summable_one_div_natCast", "conditional convergence"],
+    "prerequisites": ["absolute value identities", "summability over ℝ", "index reindexing"]
+  },
+  {
+    "id": "ann-basel-oq10-oq03-tsum-zero",
+    "proofId": "basel-problem-oq-10-oq-03",
+    "range": { "startLine": 134, "endLine": 137 },
+    "type": "theorem",
+    "title": "tsum_alternating_harmonic_eq_zero: The Junk Value",
+    "content": "Because the family is not summable, tsum_eq_zero_of_not_summable gives ∑' n, (-1)^n/(n+1) = 0 — the default value Mathlib assigns to a non-summable tsum (the identity of the topological additive monoid). A value with no analytic meaning, and the formal trap the entry warns against.",
+    "mathContext": "$\\sum'_n \\frac{(-1)^n}{n+1} = 0$ by `tsum_eq_zero_of_not_summable`.",
+    "significance": "supporting",
+    "relatedConcepts": ["junk value", "tsum convention", "tsum_eq_zero_of_not_summable"],
+    "prerequisites": ["definition of tsum"]
+  },
+  {
+    "id": "ann-basel-oq10-oq03-tsum-ne",
+    "proofId": "basel-problem-oq-10-oq-03",
+    "range": { "startLine": 140, "endLine": 143 },
+    "type": "theorem",
+    "title": "tsum_alternating_harmonic_ne_log_two: The Naive Reading Is False",
+    "content": "Concludes ∑' n, (-1)^n/(n+1) ≠ log 2 by rewriting with the junk value 0 and noting 0 < log 2 (Real.log_pos, since 2 > 1). The cautionary punchline: the unconditional reading of the alternating harmonic series is literally false in Mathlib's tsum semantics — only the ordered Tendsto form holds.",
+    "mathContext": "$0 = \\sum'_n \\frac{(-1)^n}{n+1} \\ne \\log 2$ since $\\log 2 > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.log_pos", "conditional convergence pitfall"],
+    "prerequisites": ["positivity of log"]
+  },
+  {
+    "id": "ann-basel-oq10-oq03-pitfall",
+    "proofId": "basel-problem-oq-10-oq-03",
+    "range": { "startLine": 145, "endLine": 156 },
+    "type": "insight",
+    "title": "ordered_ne_tsum_of_not_summable: The Reusable Pitfall Lemma",
+    "content": "The moral, packaged once for reuse. For ANY real family f that is not Summable, ∑' n, f n = 0, so it disagrees with every nonzero ordered limit L. This unifies the conditional-convergence pitfall across the cluster: the Leibniz series (L = π/4) and the alternating harmonic series (L = log 2) are both instances. Conceptually it records that a conditionally convergent series carries a genuine ORDERED value which the order-free tsum/Summable machinery — being unconditional — discards, returning 0 instead.",
+    "mathContext": "$\\neg\\,\\mathrm{Summable}\\,f \\Rightarrow \\sum'_n f_n = 0 \\ne L$ for every $L \\ne 0$; instantiates at $L=\\pi/4$ and $L=\\log 2$.",
+    "significance": "key",
+    "relatedConcepts": ["reusable abstraction", "conditional vs unconditional convergence", "Riemann rearrangement theorem", "tsum semantics"],
+    "prerequisites": ["tsum_eq_zero_of_not_summable"]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-10-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-10-oq-03/meta.json
@@ -1,0 +1,257 @@
+{
+  "id": "basel-problem-oq-10-oq-03",
+  "slug": "basel-problem-oq-10-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "BigOperators",
+      "Real",
+      "Finset"
+    ],
+    "namespace": "BaselOQ10OQ03",
+    "lineCount": 157,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/BaselProblemOQ10OQ03.lean",
+    "sorries": 0
+  },
+  "title": "The Alternating Harmonic Series ∑ (-1)ⁿ/(n+1) = log 2 — and Why It Is Only Conditional",
+  "description": "The alternating harmonic series 1 − 1/2 + 1/3 − 1/4 + ⋯ converges to log 2, but only as an ordered limit of partial sums. Unlike the parent Leibniz entry, Mathlib provides no value for this series, so the ordered limit is proved from scratch via Abel's limit theorem on the power series of log(1+x). The series is conditionally (not absolutely) convergent, so its Mathlib tsum value is the junk value 0, not log 2.",
+  "overview": {
+    "historicalContext": "The alternating harmonic series 1 − 1/2 + 1/3 − 1/4 + ⋯ = ln 2 is the value at x = 1 of the Mercator–Newton series log(1 + x) = x − x²/2 + x³/3 − ⋯, published by Nicholas Mercator in his 1668 Logarithmotechnia (the series itself was known to Newton and Gregory around the same time). Like the Leibniz series for π/4, it converges only conditionally and painfully slowly, and it became a textbook example of the Riemann rearrangement phenomenon: rearranging its terms can produce any real sum. This entry is the direct analogue of its sibling basel-problem-oq-10 (Leibniz for π/4), and answers that entry's third listed open question.",
+    "problemStatement": "The naive unconditional reading $\\sum'_{n} \\frac{(-1)^n}{n+1} = \\log 2$ is FALSE in Mathlib. The family $n \\mapsto \\frac{(-1)^n}{n+1}$ is only conditionally convergent — its absolute values $\\frac{1}{n+1}$ form the divergent harmonic series. Since Mathlib's `Summable` / `tsum` / `HasSum` demand unconditional (net) convergence, the family is not `Summable`, and `tsum` returns the junk value $0 \\ne \\log 2$. Moreover — unlike the Leibniz case, where Mathlib supplies `tendsto_sum_pi_div_four` — Mathlib contains no value for this series, so the correct ordered-limit statement must be proved from scratch.",
+    "proofStrategy": "Five results. (1) `tendsto_alternating_harmonic_log_two` is the substantive new content: the ORDERED partial sums ∑_{i<n} (-1)^i/(i+1) → log 2. Since Mathlib has no ready value, it is reconstructed by the same Abel-limit route Mathlib uses for Leibniz: the alternating series test (`Antitone.tendsto_alternating_series_of_tendsto_zero`) yields convergence to SOME limit l; Abel's limit theorem (`Real.tendsto_tsum_powerSeries_nhdsWithin_lt`) transfers this to the boundary behaviour of the power series ∑ (-1)^n/(n+1)·xⁿ; that power series is identified with log(1+x)/x on (0,1) using Mathlib's `hasSum_pow_div_log_of_abs_lt_one` (with x ↦ −x), after dividing out the common factor x via `hasSum_mul_right_iff`; finally continuity of x ↦ log(1+x)/x at 1 pins l = log 2/1 = log 2. (2) `not_summable_alternating_harmonic`: via `summable_abs_iff`, absolute values are 1/(n+1), a reindexed harmonic series, contradicting `not_summable_one_div_natCast`. (3) `tsum_alternating_harmonic_eq_zero` and (4) `tsum_alternating_harmonic_ne_log_two` are the cautionary tsum corollaries. (5) `ordered_ne_tsum_of_not_summable` abstracts the pitfall into a reusable lemma covering both this entry and the Leibniz parent.",
+    "keyInsights": [
+      "The headline result required real work: unlike the Leibniz case (a one-line re-export of Mathlib's tendsto_sum_pi_div_four), Mathlib has NO value for the alternating harmonic series, so the ordered limit log 2 is proved here from scratch via Abel's limit theorem — the analytic core of the entry.",
+      "Abel's theorem is the right tool: the alternating series test gives convergence to an unknown limit l, and Abel's limit theorem identifies l with the one-sided boundary value lim_{x→1⁻} of the associated power series, which here is log(1+x)/x → log 2.",
+      "The power series is supplied by Mathlib's hasSum_pow_div_log_of_abs_lt_one (∑ xⁿ⁺¹/(n+1) = −log(1−x) for |x|<1); substituting x ↦ −x and dividing by x (hasSum_mul_right_iff, valid since x ≠ 0 near 1) yields ∑ (-1)ⁿ/(n+1)·xⁿ = log(1+x)/x — exactly the coefficient family Abel's theorem consumes.",
+      "The conditional-convergence pitfall is identical to the Leibniz case: |(-1)ⁿ/(n+1)| = 1/(n+1) is the harmonic series, so the family is not Summable, tsum returns the junk value 0, and the naive unconditional reading is literally false.",
+      "ordered_ne_tsum_of_not_summable packages the moral once and for all: any non-Summable real family has tsum 0, so it disagrees with every nonzero ordered limit — the Leibniz series (L = π/4) and this one (L = log 2) are both instances."
+    ]
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ10OQ03.lean",
+    "tags": [
+      "analysis",
+      "infinite-series",
+      "conditional-convergence",
+      "alternating-harmonic-series",
+      "logarithm",
+      "abel-summation",
+      "summability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 157,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "verified",
+    "originalContributions": [
+      "tendsto_alternating_harmonic_log_two: the ordered partial sums ∑_{i<n} (-1)^i/(i+1) converge to log 2. Because Mathlib has no value for this series (contrast the Leibniz case), this is proved from scratch via Abel's limit theorem applied to the power series of log(1+x) — the substantive analytic content.",
+      "not_summable_alternating_harmonic: the family (-1)^n/(n+1) is NOT Summable — its absolute values are the divergent harmonic series 1/(n+1), so convergence is only conditional.",
+      "tsum_alternating_harmonic_eq_zero: consequently the unconditional tsum ∑' n, (-1)^n/(n+1) equals the junk value 0, not log 2.",
+      "tsum_alternating_harmonic_ne_log_two: the naive 'unconditional' reading 1 − 1/2 + 1/3 − ⋯ = log 2 is false (0 ≠ log 2); only the ordered limit holds.",
+      "ordered_ne_tsum_of_not_summable: a reusable lemma unifying the conditional-convergence pitfall — any non-Summable real family has tsum 0, hence differs from every nonzero ordered limit L. Both this entry (L = log 2) and the parent Leibniz entry (L = π/4) are instances."
+    ],
+    "prerequisites": [
+      "Mathlib's Real.tendsto_tsum_powerSeries_nhdsWithin_lt (Abel's limit theorem for real power series)",
+      "Mathlib's Real.hasSum_pow_div_log_of_abs_lt_one (power series ∑ xⁿ⁺¹/(n+1) = −log(1−x) for |x|<1)",
+      "Antitone.tendsto_alternating_series_of_tendsto_zero (the alternating series test)",
+      "hasSum_mul_right_iff (dividing a HasSum by a nonzero constant)",
+      "summable_abs_iff and not_summable_one_div_natCast (harmonic divergence)",
+      "Parent: basel-problem-oq-10 (Leibniz's series for π and its conditional convergence)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.tendsto_tsum_powerSeries_nhdsWithin_lt",
+        "description": "Abel's limit theorem: if the ordered partial sums ∑_{i<n} f i converge to l, then the power series x ↦ ∑' n, f n · xⁿ tends to l as x → 1 from the left. The bridge that identifies the unknown alternating-series limit with the boundary value of log(1+x)/x.",
+        "module": "Mathlib.Analysis.Complex.AbelLimit"
+      },
+      {
+        "theorem": "Real.hasSum_pow_div_log_of_abs_lt_one",
+        "description": "The Maclaurin series of the logarithm: for |x|<1, ∑ n, xⁿ⁺¹/(n+1) = −log(1−x). Substituting x ↦ −x and dividing by x supplies the closed form log(1+x)/x for the power series Abel's theorem produces.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Deriv"
+      },
+      {
+        "theorem": "Antitone.tendsto_alternating_series_of_tendsto_zero",
+        "description": "The Leibniz alternating series test: if f is antitone and tends to 0, then ∑_{i<n} (-1)^i · f i converges to some limit. Supplies the existence of the limit that Abel's theorem then identifies.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "not_summable_one_div_natCast",
+        "description": "The harmonic series ∑ 1/n diverges; the divergent series behind non-summability of the absolute values.",
+        "module": "Mathlib.Analysis.PSeries"
+      }
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring: The Conditional-Convergence Subtlety",
+      "startLine": 3,
+      "endLine": 47,
+      "summary": "States the open question (the analogous cautionary pair for the alternating harmonic series) and flags the trap: the naive tsum reading ∑' (-1)^n/(n+1) = log 2 is false because the series is only conditionally convergent. Emphasizes the key difference from the parent: Mathlib supplies NO value for this series, so the ordered limit log 2 must be proved from scratch via Abel's limit theorem. Lists the five results and confirms 0 axioms / 0 sorries.",
+      "mathContext": "$\\sum_n \\frac{(-1)^n}{n+1} = \\log 2$ holds only as $\\lim_n \\sum_{i<n}$; the unordered $\\sum'_n$ is $0$ because the family is not absolutely summable."
+    },
+    {
+      "id": "setup",
+      "title": "Namespace and Opens",
+      "startLine": 49,
+      "endLine": 51,
+      "summary": "Opens the Filter, Topology, BigOperators, Real, and Finset namespaces — supplying Tendsto/atTop/𝓝/𝓝[<] notation, Real.log, the range-sum notation, and the summability API used throughout.",
+      "mathContext": "Brings `Tendsto`, `atTop`, `𝓝`, `𝓝[<]`, `Real.log`, `∑ i ∈ range n`, and `Summable` into scope."
+    },
+    {
+      "id": "alternating-series-test",
+      "title": "Step 1 — Convergence to Some Limit via the Alternating Series Test",
+      "startLine": 53,
+      "endLine": 71,
+      "summary": "The main theorem opens by establishing that the ordered partial sums converge to SOME limit l. This applies Antitone.tendsto_alternating_series_of_tendsto_zero with f i = 1/(i+1): the coefficients are antitone (gcongr) and tend to 0 (the reciprocal of i+1 → ∞ via Tendsto.inv_tendsto_atTop). At this stage the value l is unknown — the Leibniz test alone cannot identify it.",
+      "mathContext": "Since $1/(n+1) \\downarrow 0$, the series $\\sum_{i<n}(-1)^i/(i+1)$ converges to some limit $l$; identifying $l = \\log 2$ requires more."
+    },
+    {
+      "id": "abel-identify",
+      "title": "Step 2 — Abel's Limit Theorem and the log(1+x)/x Closed Form",
+      "startLine": 72,
+      "endLine": 104,
+      "summary": "The analytic heart. Abel's limit theorem (Real.tendsto_tsum_powerSeries_nhdsWithin_lt) turns convergence at 1 into the statement that the power series x ↦ ∑' n, (-1)^n/(n+1)·xⁿ tends to l as x → 1⁻. On a left-neighbourhood of 1 this power series is identified with log(1+x)/x: Mathlib's hasSum_pow_div_log_of_abs_lt_one (with x ↦ −x) gives ∑ (-1)^n·xⁿ⁺¹/(n+1) = log(1+x); factoring out x and dividing (hasSum_mul_right_iff, valid since x ≠ 0 near 1) produces the closed form. The eventuallyEq is proved on a metric ball intersected with (−∞,1).",
+      "mathContext": "For $0<x<1$: $\\displaystyle \\sum_{n} \\frac{(-1)^n}{n+1}x^n = \\frac{\\log(1+x)}{x}$, and Abel gives $\\frac{\\log(1+x)}{x} \\to l$ as $x\\to 1^-$."
+    },
+    {
+      "id": "continuity-pin",
+      "title": "Step 3 — Continuity Pins the Limit to log 2",
+      "startLine": 105,
+      "endLine": 112,
+      "summary": "Since x ↦ log(1+x)/x is continuous at 1 (numerator log(1+x) continuous, denominator x ≠ 0), its left-limit is log(1+1)/1 = log 2. Uniqueness of limits (tendsto_nhds_unique) forces l = log 2, completing the ordered-limit theorem.",
+      "mathContext": "$\\displaystyle \\lim_{x\\to 1^-}\\frac{\\log(1+x)}{x} = \\frac{\\log 2}{1} = \\log 2$, so $l = \\log 2$."
+    },
+    {
+      "id": "not-summable",
+      "title": "not_summable_alternating_harmonic: The Conditional-Convergence Lemma",
+      "startLine": 114,
+      "endLine": 130,
+      "summary": "Proves the family is not Summable. Uses summable_abs_iff to reduce to absolute summability; rewrites |(-1)^n/(n+1)| = 1/(n+1) via abs_div/abs_pow/abs_neg; then assumes summability and derives a contradiction by reindexing (summable_nat_add_iff, push_cast) to the harmonic series ∑ 1/n, contradicting not_summable_one_div_natCast.",
+      "mathContext": "$\\left|\\frac{(-1)^n}{n+1}\\right| = \\frac{1}{n+1}$, the harmonic series (shifted), which diverges — so the family is not summable."
+    },
+    {
+      "id": "tsum-zero",
+      "title": "tsum_alternating_harmonic_eq_zero: The Junk Value",
+      "startLine": 132,
+      "endLine": 137,
+      "summary": "Because the family is not summable, tsum_eq_zero_of_not_summable gives ∑' n, (-1)^n/(n+1) = 0 — the default value Mathlib assigns to the tsum of a non-summable family.",
+      "mathContext": "$\\sum'_n \\frac{(-1)^n}{n+1} = 0$ by the non-summable convention, NOT $\\log 2$."
+    },
+    {
+      "id": "tsum-ne",
+      "title": "tsum_alternating_harmonic_ne_log_two: The Naive Reading Is False",
+      "startLine": 138,
+      "endLine": 143,
+      "summary": "Concludes ∑' n, (-1)^n/(n+1) ≠ log 2 by rewriting with the junk value 0 and noting 0 < log 2 (log_pos). The cautionary punchline: the unconditional reading of the alternating harmonic series is literally false in Mathlib's tsum semantics.",
+      "mathContext": "$0 = \\sum'_n \\frac{(-1)^n}{n+1} \\ne \\log 2$ since $\\log 2 > 0$."
+    },
+    {
+      "id": "pitfall-lemma",
+      "title": "ordered_ne_tsum_of_not_summable: The Reusable Pitfall",
+      "startLine": 145,
+      "endLine": 156,
+      "summary": "Abstracts the moral: for any real family f that is not Summable, ∑' n, f n = 0, so it disagrees with every nonzero ordered limit L. Both this entry (L = log 2) and the parent Leibniz entry (L = π/4) are instances — a conditionally convergent series carries a meaningful ordered value that the unconditional tsum machinery discards.",
+      "mathContext": "$\\neg\\,\\mathrm{Summable}\\,f \\;\\Rightarrow\\; \\sum'_n f_n = 0 \\ne L$ for any $L \\ne 0$."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "tendsto_alternating_harmonic_log_two",
+      "type": "main",
+      "description": "The correct statement: the ordered partial sums ∑_{i<n} (-1)^i/(i+1) converge to log 2. Proved from scratch (Mathlib has no value for this series) via Abel's limit theorem on the power series of log(1+x). The substantive original contribution.",
+      "leanType": "Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i / (i + 1)) atTop (𝓝 (Real.log 2))"
+    },
+    {
+      "name": "not_summable_alternating_harmonic",
+      "type": "main",
+      "description": "The family (-1)^n/(n+1) is not Summable: its absolute values are the divergent harmonic series 1/(n+1), so convergence is only conditional.",
+      "leanType": "¬ Summable (fun n : ℕ => (-1 : ℝ) ^ n / (n + 1))"
+    },
+    {
+      "name": "tsum_alternating_harmonic_eq_zero",
+      "type": "corollary",
+      "description": "Because the family is not summable, its tsum collapses to the junk value 0.",
+      "leanType": "∑' n : ℕ, (-1 : ℝ) ^ n / (n + 1) = 0"
+    },
+    {
+      "name": "tsum_alternating_harmonic_ne_log_two",
+      "type": "corollary",
+      "description": "The naive unconditional reading 1 − 1/2 + 1/3 − ⋯ = log 2 is false: the tsum is 0 ≠ log 2; only the ordered limit holds.",
+      "leanType": "∑' n : ℕ, (-1 : ℝ) ^ n / (n + 1) ≠ Real.log 2"
+    },
+    {
+      "name": "ordered_ne_tsum_of_not_summable",
+      "type": "corollary",
+      "description": "The reusable conditional-convergence pitfall: any non-Summable real family has tsum 0, hence differs from every nonzero ordered limit L. Instantiates for both this entry (L = log 2) and the Leibniz parent (L = π/4).",
+      "leanType": "∀ {f : ℕ → ℝ} {L : ℝ}, L ≠ 0 → ¬ Summable f → ∑' n, f n ≠ L"
+    }
+  ],
+  "conclusion": {
+    "summary": "The alternating harmonic series 1 − 1/2 + 1/3 − ⋯ = log 2 is formalized correctly as an ordered limit of partial sums. Unlike the parent Leibniz entry, Mathlib provides no value for this series, so the ordered limit is proved from scratch via Abel's limit theorem: the alternating series test gives convergence to some l, Abel transfers this to the boundary value of the power series log(1+x)/x, and continuity pins l = log 2. The substantive negative half — non-summability of the family, tsum = 0, and tsum ≠ log 2 — mirrors the Leibniz case, and a reusable lemma packages the pitfall for both entries. Fully machine-checked, 0 axioms, 0 sorries.",
+    "implications": "This entry completes the conditional-convergence pair started by basel-problem-oq-10: where Leibniz gives π/4 for the alternating odd reciprocals, the alternating harmonic series gives log 2, and both are only conditionally convergent, so both have Mathlib tsum 0. The proof also demonstrates the full Abel-summation toolkit (alternating series test + Real.tendsto_tsum_powerSeries_nhdsWithin_lt + a Mathlib log power series + limit uniqueness) for identifying the value of a conditionally convergent series when Mathlib supplies no ready-made answer — a template reusable for other boundary evaluations of Maclaurin series.",
+    "openQuestions": [
+      "Quantify the rate: prove the alternating-series error bound |∑_{i<n} (-1)^i/(i+1) − log 2| ≤ 1/(n+1), giving an explicit slow convergence rate.",
+      "Formalize a Riemann-rearrangement instance for this series: exhibit a permutation of ℕ whose rearranged ordered partial sums converge to a value other than log 2 (e.g. the classical (3/2)·log 2 rearrangement).",
+      "Generalize log(1+x)/x-style boundary evaluation into a reusable lemma: given a Mathlib Maclaurin HasSum on (−1,1) and continuity at 1, conclude the value of the conditionally convergent series at x = 1 via Abel + limit uniqueness."
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "basel-problem-oq-10-oq-03-oq-01",
+      "question": "Quantify the conditional convergence: prove the alternating-series error bound |∑_{i<n} (-1)^i/(i+1) − log 2| ≤ 1/(n+1), giving an explicit (slow) convergence rate for the alternating harmonic approximation of log 2.",
+      "significance": "low"
+    },
+    {
+      "id": "basel-problem-oq-10-oq-03-oq-02",
+      "question": "Generalize the Abel-summation boundary evaluation used here into a reusable lemma: given a Mathlib Maclaurin HasSum valid on (−1,1) plus continuity of the target at 1, derive the value of the conditionally convergent series at x = 1 via Abel's limit theorem and limit uniqueness.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-10",
+      "relationship": "extends",
+      "description": "Direct analogue and answer to the parent's third open question. Where the parent formalizes Leibniz's series for π/4 (using Mathlib's ready-made tendsto_sum_pi_div_four), this entry does the same for the alternating harmonic series log 2 — but proves the ordered limit from scratch since Mathlib has no value for it. The reusable pitfall lemma ordered_ne_tsum_of_not_summable covers both."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "extends",
+      "description": "Part of the Basel cluster on the tsum/ordered-limit distinction. ζ(2) = ∑ 1/n² = π²/6 is absolutely convergent (its tsum genuinely equals π²/6), whereas the alternating harmonic series is only conditionally convergent — hence tsum 0."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.Complex.AbelLimit",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.tendsto_tsum_powerSeries_nhdsWithin_lt (Abel's limit theorem for real power series), the tool that identifies the alternating-series limit with the boundary value of log(1+x)/x."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Log.Deriv",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of hasSum_pow_div_log_of_abs_lt_one, the Maclaurin series ∑ xⁿ⁺¹/(n+1) = −log(1−x) for |x|<1."
+    },
+    {
+      "title": "Logarithmotechnia",
+      "author": "Nicholas Mercator",
+      "year": "1668",
+      "venue": "Classical",
+      "description": "First publication of the Mercator series log(1 + x) = x − x²/2 + x³/3 − ⋯; the alternating harmonic series is its value at x = 1."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry answering the **third open question** of the parent Leibniz entry (`basel-problem-oq-10`): the analogous cautionary pair for the **alternating harmonic series** `1 − 1/2 + 1/3 − 1/4 + ⋯ = log 2`.

The key contrast with the parent: Mathlib provides `tendsto_sum_pi_div_four` for Leibniz, but has **no value for the alternating harmonic series**, so the ordered limit `log 2` is proved **from scratch** via Abel's limit theorem.

## Proof of `tendsto_alternating_harmonic_log_two`
1. **Alternating series test** (`Antitone.tendsto_alternating_series_of_tendsto_zero`) → ordered partial sums converge to *some* limit `l`.
2. **Abel's limit theorem** (`Real.tendsto_tsum_powerSeries_nhdsWithin_lt`) → the power series `∑ (-1)ⁿ/(n+1)·xⁿ → l` as `x → 1⁻`.
3. **Closed form**: that power series equals `log(1+x)/x` on `(0,1)`, via Mathlib's `hasSum_pow_div_log_of_abs_lt_one` (with `x ↦ -x`) and `hasSum_mul_right_iff` (dividing out `x ≠ 0`).
4. **Continuity** of `x ↦ log(1+x)/x` at `1` pins `l = log 2 / 1 = log 2`.

## Theorems (5, VERIFIED 0-axiom)
- `tendsto_alternating_harmonic_log_two` — ordered partial sums → log 2 (substantive new content)
- `not_summable_alternating_harmonic` — the family is not `Summable` (its magnitudes are the harmonic series)
- `tsum_alternating_harmonic_eq_zero` — tsum collapses to the junk value 0
- `tsum_alternating_harmonic_ne_log_two` — the naive unconditional reading is false (0 ≠ log 2)
- `ordered_ne_tsum_of_not_summable` — reusable pitfall lemma unifying this entry (L = log 2) and the Leibniz parent (L = π/4)

## Verification
- `lake env lean Proofs/BaselProblemOQ10OQ03.lean` — exit 0, no errors/warnings
- `#print axioms` on all theorems: only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `ofReduceBool`)
- 157 lines, 0 sorries, 0 axioms

## Files
- `proofs/Proofs/BaselProblemOQ10OQ03.lean`
- `src/data/proofs/basel-problem-oq-10-oq-03/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)