### PR TITLE
research(combinations-formula-oq-02-oq-02): Catalan closed form C_n=C(2n,n)/(n+1) via factorial cancellation [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ02OQ02.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ02OQ02.lean
@@ -1,0 +1,189 @@
+import Mathlib.Combinatorics.Enumerative.Catalan
+import Mathlib.Data.Nat.Choose.Basic
+import Mathlib.Data.Nat.Choose.Central
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Tactic
+
+/-
+# The Catalan Closed Form via Factorials
+
+Open Question: combinations-formula-oq-02-oq-02
+
+The parent entry (`combinations-formula-oq-02`) defines the Catalan number by the
+ballot-style subtraction
+
+  C_n = C(2n, n) - C(2n, n+1)
+
+and establishes the closed form `C_n = C(2n,n)/(n+1)` **through** the multiplicative
+identity `catalan_mul_succ : C_n * (n+1) = C(2n,n)`, which it proves from the pure
+binomial absorption identity (`Nat.succ_mul_choose_eq`).
+
+This entry answers the open question:
+
+> "Prove the closed form C_n = C(2n,n)/(n+1) directly without going through
+>  catalan_mul_succ."
+
+We take a genuinely different route: **factorials**. The only external inputs are
+`Nat.choose_mul_factorial_mul_factorial` (the factorial expansion of a single binomial
+coefficient) and `Nat.choose_le_middle` (row-maximality of the central coefficient).
+From these we prove, by cancelling a common factorial factor, the *cross identity*
+
+  C(2n,n) * n = C(2n,n+1) * (n+1),
+
+and everything else — the multiplicative identity, the requested division form
+`C_n = C(2n,n)/(n+1)`, the divisibility `(n+1) ∣ C(2n,n)`, and the fully-factorial
+closed form `C_n = (2n)! / ((n+1)! · n!)` — falls out as a consequence.
+
+Main results:
+- `choose_cross`        : C(2n,n) · n = C(2n,n+1) · (n+1)          [factorial cancellation]
+- `catalan_mul_succ'`   : C_n · (n+1) = C(2n,n)                     [re-derived, not assumed]
+- `catalan_eq_choose_div` : C_n = C(2n,n) / (n+1)                   [**the requested form**]
+- `succ_dvd_centralBinom` : (n+1) ∣ C(2n,n)
+- `catalan_mul_factorial_factorial` : C_n · ((n+1)! · n!) = (2n)!   [factorial closed form]
+- `catalan_eq_factorial_div` : C_n = (2n)! / ((n+1)! · n!)
+
+References:
+- Stanley (2015), "Catalan Numbers", Cambridge Univ. Press (Eq. for C_n via factorials)
+- Parent: CombinationsFormulaOQ02.lean
+-/
+
+open Nat
+
+namespace CatalanClosedForm
+
+/-- The n-th Catalan number, defined (as in the parent entry) by the ballot
+    subtraction `C_n = C(2n, n) - C(2n, n+1)`. -/
+def catalan (n : ℕ) : ℕ :=
+  Nat.choose (2 * n) n - Nat.choose (2 * n) (n + 1)
+
+/-
+## Part I: The factorial cross identity (keystone)
+
+The single fact from which every closed form below is derived. We prove it by
+expanding both `C(2n,n)` and `C(2n,n+1)` into factorials and cancelling the common
+factor `(n+1)! · n!` — this never touches the multiplicative Catalan identity.
+-/
+
+/-- **Cross identity**: `C(2n, n) · n = C(2n, n+1) · (n+1)`.
+
+    Proof: both `C(2n,n) · n · (n+1)! · n!` and `C(2n,n+1) · (n+1) · (n+1)! · n!`
+    equal `(2n)!` (via `Nat.choose_mul_factorial_mul_factorial`), so they are equal;
+    cancel the positive factor `(n+1)! · n!`. -/
+theorem choose_cross (n : ℕ) :
+    Nat.choose (2 * n) n * n = Nat.choose (2 * n) (n + 1) * (n + 1) := by
+  rcases n with _ | m
+  · decide
+  · -- n = m + 1
+    have hAle : m + 1 ≤ 2 * (m + 1) := by omega
+    have hBle : m + 2 ≤ 2 * (m + 1) := by omega
+    -- C(2n, n) · (n)! · (n)! = (2n)!   with n = m+1
+    have hA : Nat.choose (2 * (m + 1)) (m + 1) * (m + 1)! * (m + 1)! = (2 * (m + 1))! := by
+      have h := Nat.choose_mul_factorial_mul_factorial hAle
+      rwa [show 2 * (m + 1) - (m + 1) = m + 1 from by omega] at h
+    -- C(2n, n+1) · (n+1)! · (n-1)! = (2n)!   with n = m+1, so n+1 = m+2, n-1 = m
+    have hB : Nat.choose (2 * (m + 1)) (m + 2) * (m + 2)! * m ! = (2 * (m + 1))! := by
+      have h := Nat.choose_mul_factorial_mul_factorial hBle
+      rwa [show 2 * (m + 1) - (m + 2) = m from by omega] at h
+    have hQ : 0 < (m + 1)! * m ! := by positivity
+    apply Nat.eq_of_mul_eq_mul_right hQ
+    calc Nat.choose (2 * (m + 1)) (m + 1) * (m + 1) * ((m + 1)! * m !)
+        = Nat.choose (2 * (m + 1)) (m + 1) * (m + 1)! * (m + 1)! := by
+          rw [Nat.factorial_succ m]; ring
+      _ = (2 * (m + 1))! := hA
+      _ = Nat.choose (2 * (m + 1)) (m + 2) * (m + 2)! * m ! := hB.symm
+      _ = Nat.choose (2 * (m + 1)) (m + 2) * (m + 2) * ((m + 1)! * m !) := by
+          rw [Nat.factorial_succ (m + 1)]; ring
+
+/-
+## Part II: The multiplicative identity, re-derived from the cross identity
+-/
+
+/-- `C(2n, n+1) ≤ C(2n, n)`: the entry just past the centre of an even row does not
+    exceed the central (maximal) entry. Makes the ballot subtraction non-truncating. -/
+theorem choose_succ_le_central (n : ℕ) :
+    Nat.choose (2 * n) (n + 1) ≤ Nat.choose (2 * n) n := by
+  have h := Nat.choose_le_middle (n + 1) (2 * n)
+  rwa [show 2 * n / 2 = n from by omega] at h
+
+/-- **Multiplicative identity, re-derived**: `C_n · (n+1) = C(2n, n)`.
+
+    Unlike the parent's `catalan_mul_succ`, this is obtained purely from the factorial
+    cross identity `choose_cross`. -/
+theorem catalan_mul_succ' (n : ℕ) :
+    catalan n * (n + 1) = Nat.choose (2 * n) n := by
+  rcases n with _ | m
+  · decide
+  · have hle := choose_succ_le_central (m + 1)
+    have hc := choose_cross (m + 1)
+    -- hc : C(2n,n) · n = C(2n,n+1) · (n+1),  with n = m+1
+    -- Abbreviate the two coefficients; `hc`, `hle` are the only facts needed.
+    have key : (Nat.choose (2 * (m + 1)) (m + 1) - Nat.choose (2 * (m + 1)) (m + 2))
+        * (m + 1 + 1) = Nat.choose (2 * (m + 1)) (m + 1) := by
+      rw [Nat.sub_mul]
+      -- C(2n,n)·(n+1) - C(2n,n+1)·(n+1); replace C(2n,n+1)·(n+1) by C(2n,n)·n via hc
+      rw [← hc]
+      -- goal: C(2n,n)·(m+2) - C(2n,n)·(m+1) = C(2n,n)
+      have : Nat.choose (2 * (m + 1)) (m + 1) * (m + 1 + 1)
+           = Nat.choose (2 * (m + 1)) (m + 1) * (m + 1)
+             + Nat.choose (2 * (m + 1)) (m + 1) := by ring
+      omega
+    -- Fold the definition of `catalan (m+1)`.
+    simpa [catalan, show 2 * (m + 1) = 2 * (m + 1) from rfl] using key
+
+/-
+## Part III: The closed forms
+-/
+
+/-- **The requested closed form**: `C_n = C(2n, n) / (n+1)` (natural-number division),
+    established without invoking the parent's `catalan_mul_succ`. -/
+theorem catalan_eq_choose_div (n : ℕ) :
+    catalan n = Nat.choose (2 * n) n / (n + 1) := by
+  have h : Nat.choose (2 * n) n = (n + 1) * catalan n := by
+    rw [← catalan_mul_succ' n]; ring
+  rw [h, Nat.mul_div_cancel_left _ (Nat.succ_pos n)]
+
+/-- Divisibility corollary: `(n+1) ∣ C(2n, n)`. -/
+theorem succ_dvd_centralBinom (n : ℕ) : (n + 1) ∣ Nat.choose (2 * n) n :=
+  ⟨catalan n, by rw [← catalan_mul_succ' n]; ring⟩
+
+/-- **Factorial closed form**: `C_n · ((n+1)! · n!) = (2n)!`.
+
+    This is the most symmetric closed form; it follows from the multiplicative identity
+    and the factorial expansion of the central coefficient. Valid for all `n` (no case
+    split), since `(n+1)! = (n+1)·n!` and `C(2n,n)·n!·n! = (2n)!`. -/
+theorem catalan_mul_factorial_factorial (n : ℕ) :
+    catalan n * ((n + 1)! * n !) = (2 * n)! := by
+  have hmul := catalan_mul_succ' n
+  have hcf := Nat.choose_mul_factorial_mul_factorial (show n ≤ 2 * n by omega)
+  rw [show 2 * n - n = n from by omega] at hcf
+  calc catalan n * ((n + 1)! * n !)
+      = (catalan n * (n + 1)) * (n ! * n !) := by rw [Nat.factorial_succ n]; ring
+    _ = Nat.choose (2 * n) n * (n ! * n !) := by rw [hmul]
+    _ = Nat.choose (2 * n) n * n ! * n ! := by ring
+    _ = (2 * n)! := hcf
+
+/-- `C_n = (2n)! / ((n+1)! · n!)` (natural-number division). -/
+theorem catalan_eq_factorial_div (n : ℕ) :
+    catalan n = (2 * n)! / ((n + 1)! * n !) := by
+  have h : (2 * n)! = ((n + 1)! * n !) * catalan n := by
+    rw [← catalan_mul_factorial_factorial n]; ring
+  have hpos : 0 < (n + 1)! * n ! := by positivity
+  rw [h, Nat.mul_div_cancel_left _ hpos]
+
+/-
+## Part IV: Consistency checks
+-/
+
+/-- The closed forms reproduce the standard initial values. -/
+theorem catalan_values :
+    catalan 0 = 1 ∧ catalan 1 = 1 ∧ catalan 2 = 2 ∧
+    catalan 3 = 5 ∧ catalan 4 = 14 ∧ catalan 5 = 42 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
+
+/-- Our `catalan` agrees with Mathlib's `catalan`, confirming the definition and the
+    derived closed forms describe the genuine Catalan sequence. -/
+theorem catalan_eq_mathlib (n : ℕ) : catalan n = _root_.catalan n := by
+  have hmul : catalan n * (n + 1) = Nat.centralBinom n := catalan_mul_succ' n
+  rw [_root_.catalan_eq_centralBinom_div, ← hmul, Nat.mul_div_cancel _ (Nat.succ_pos n)]
+
+end CatalanClosedForm

--- a/src/data/proofs/combinations-formula-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-02-oq-02/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-cfoq0202-def",
+    "proofId": "combinations-formula-oq-02-oq-02",
+    "range": { "startLine": 54, "endLine": 57 },
+    "type": "definition",
+    "title": "The Catalan Number (Ballot Form)",
+    "content": "Defines catalan n = C(2n,n) - C(2n,n+1), the same reflection/ballot closed form used in the parent entry. Truncated natural-number subtraction is used deliberately; the later lemma choose_succ_le_central guarantees it does not clamp to zero. This is the starting point from which the division and factorial closed forms are derived.",
+    "mathContext": "$C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "central binomial coefficient", "ballot problem", "reflection principle"],
+    "prerequisites": ["binomial coefficients"]
+  },
+  {
+    "id": "ann-cfoq0202-cross",
+    "proofId": "combinations-formula-oq-02-oq-02",
+    "range": { "startLine": 67, "endLine": 95 },
+    "type": "theorem",
+    "title": "The Factorial Cross Identity",
+    "content": "The keystone of the entry. Nat.choose_mul_factorial_mul_factorial expands C(2n,n) into C(2n,n)*n!*n! = (2n)! and C(2n,n+1) into C(2n,n+1)*(n+1)!*(n-1)! = (2n)!. Both products equal (2n)!, so they are equal to each other; after rewriting (n+1)! = (n+1)*n! (Nat.factorial_succ) the two left-hand sides share the positive factor (n+1)!*n!, and cancelling it with Nat.eq_of_mul_eq_mul_right yields C(2n,n)*n = C(2n,n+1)*(n+1). Crucially this never uses the binomial absorption identity Nat.succ_mul_choose_eq that the parent's catalan_mul_succ relies on — the whole point of the open question.",
+    "mathContext": "$\\binom{2n}{n}\\,n = \\binom{2n}{n+1}\\,(n+1)$",
+    "significance": "critical",
+    "relatedConcepts": ["factorial expansion", "cancellation", "Pascal row-ratio", "central binomial coefficient"],
+    "prerequisites": ["factorials", "Nat.choose_mul_factorial_mul_factorial"]
+  },
+  {
+    "id": "ann-cfoq0202-rowmax",
+    "proofId": "combinations-formula-oq-02-oq-02",
+    "range": { "startLine": 103, "endLine": 106 },
+    "type": "theorem",
+    "title": "Row-Maximality of the Central Coefficient",
+    "content": "Records C(2n,n+1) <= C(2n,n): the entry just past the centre of the even row 2n does not exceed the central (maximal) entry. Proved from Mathlib's Nat.choose_le_middle after rewriting (2n)/2 = n. This is what makes the truncated subtraction defining C_n a genuine subtraction, so that catalan n + C(2n,n+1) = C(2n,n) holds on the nose.",
+    "mathContext": "$\\binom{2n}{n+1} \\le \\binom{2n}{n}$",
+    "significance": "supporting",
+    "relatedConcepts": ["unimodality of Pascal's triangle", "central binomial coefficient", "Nat.choose_le_middle"],
+    "prerequisites": ["binomial coefficients", "truncated subtraction"]
+  },
+  {
+    "id": "ann-cfoq0202-mulsucc",
+    "proofId": "combinations-formula-oq-02-oq-02",
+    "range": { "startLine": 108, "endLine": 131 },
+    "type": "theorem",
+    "title": "The Multiplicative Identity, Re-derived",
+    "content": "Re-derives C_n*(n+1) = C(2n,n) from the cross identity alone. Writing C_n = C(2n,n) - C(2n,n+1), Nat.sub_mul distributes the product, the cross identity replaces C(2n,n+1)*(n+1) by C(2n,n)*n, and omega finishes: C(2n,n)*(n+2) - C(2n,n)*(n+1) telescopes to C(2n,n). This is the same statement as the parent's catalan_mul_succ but with a factorial-based proof that avoids Nat.succ_mul_choose_eq.",
+    "mathContext": "$C_n\\,(n+1) = \\binom{2n}{n}$",
+    "significance": "critical",
+    "relatedConcepts": ["multiplicative identity", "Nat.sub_mul", "telescoping"],
+    "prerequisites": ["truncated subtraction", "cross identity"]
+  },
+  {
+    "id": "ann-cfoq0202-choosediv",
+    "proofId": "combinations-formula-oq-02-oq-02",
+    "range": { "startLine": 137, "endLine": 144 },
+    "type": "theorem",
+    "title": "The Requested Closed Form C_n = C(2n,n)/(n+1)",
+    "content": "The direct answer to the open question. From the multiplicative identity, C(2n,n) = (n+1)*C_n, so Nat.mul_div_cancel_left gives C(2n,n)/(n+1) = C_n exactly (natural-number division, no rounding). Because the derivation of the multiplicative identity went through the factorial cross identity rather than catalan_mul_succ, the closed form is obtained 'directly without going through catalan_mul_succ' as requested.",
+    "mathContext": "$C_n = \\dfrac{\\binom{2n}{n}}{n+1}$",
+    "significance": "critical",
+    "relatedConcepts": ["closed form", "exact natural-number division", "Nat.mul_div_cancel_left"],
+    "prerequisites": ["multiplicative identity"]
+  },
+  {
+    "id": "ann-cfoq0202-dvd",
+    "proofId": "combinations-formula-oq-02-oq-02",
+    "range": { "startLine": 146, "endLine": 147 },
+    "type": "theorem",
+    "title": "Divisibility (n+1) | C(2n,n)",
+    "content": "The divisibility that makes the division exact: (n+1) divides the central binomial coefficient, with quotient exactly C_n. It is read straight off the multiplicative identity C_n*(n+1) = C(2n,n) as the witness Dvd.intro. This is the classical statement that the central binomial coefficients are (n+1)-fold multiples of Catalan numbers.",
+    "mathContext": "$(n+1) \\mid \\binom{2n}{n}$",
+    "significance": "supporting",
+    "relatedConcepts": ["divisibility", "integrality of Catalan numbers"],
+    "prerequisites": ["multiplicative identity"]
+  },
+  {
+    "id": "ann-cfoq0202-factform",
+    "proofId": "combinations-formula-oq-02-oq-02",
+    "range": { "startLine": 149, "endLine": 164 },
+    "type": "theorem",
+    "title": "The Symmetric Factorial Closed Form",
+    "content": "Proves C_n*((n+1)!*n!) = (2n)! for all n with no case split. Rewriting (n+1)! = (n+1)*n! turns the left side into (C_n*(n+1))*(n!*n!); the multiplicative identity replaces C_n*(n+1) by C(2n,n), and Nat.choose_mul_factorial_mul_factorial (with 2n - n = n) collapses C(2n,n)*n!*n! to (2n)!. This is the most symmetric of the closed forms and exhibits C_n's integrality as an exact factorial identity.",
+    "mathContext": "$C_n\\,\\big((n+1)!\\,n!\\big) = (2n)!$",
+    "significance": "key",
+    "relatedConcepts": ["factorial closed form", "Nat.factorial_succ", "Nat.choose_mul_factorial_mul_factorial"],
+    "prerequisites": ["multiplicative identity", "factorials"]
+  },
+  {
+    "id": "ann-cfoq0202-factdiv",
+    "proofId": "combinations-formula-oq-02-oq-02",
+    "range": { "startLine": 166, "endLine": 171 },
+    "type": "theorem",
+    "title": "The Fully-Factorial Closed Form C_n = (2n)!/((n+1)! n!)",
+    "content": "The division form of the factorial identity: since (2n)! = ((n+1)!*n!)*C_n and (n+1)!*n! > 0, Nat.mul_div_cancel_left gives C_n = (2n)!/((n+1)!*n!). This is the textbook factorial expression for the Catalan numbers, now derived entirely from factorial arithmetic.",
+    "mathContext": "$C_n = \\dfrac{(2n)!}{(n+1)!\\,n!}$",
+    "significance": "key",
+    "relatedConcepts": ["factorial closed form", "exact natural-number division"],
+    "prerequisites": ["factorial closed form"]
+  },
+  {
+    "id": "ann-cfoq0202-consistency",
+    "proofId": "combinations-formula-oq-02-oq-02",
+    "range": { "startLine": 176, "endLine": 187 },
+    "type": "theorem",
+    "title": "Consistency: Values and Agreement with Mathlib",
+    "content": "Two sanity checks. catalan_values reproduces C_0..C_5 = 1,1,2,5,14,42 by decide, and catalan_eq_mathlib proves the local catalan agrees with Mathlib's catalan by combining the multiplicative identity with Nat.catalan_eq_centralBinom_div. Together they confirm the definition and all derived closed forms describe the genuine Catalan sequence.",
+    "mathContext": "$C_0,\\ldots,C_5 = 1,1,2,5,14,42;\\quad \\mathrm{catalan} = \\texttt{Nat.catalan}$",
+    "significance": "supporting",
+    "relatedConcepts": ["initial values", "definitional agreement", "Nat.catalan_eq_centralBinom_div"],
+    "prerequisites": ["Catalan numbers"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-02-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02-oq-02/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "combinations-formula-oq-02-oq-02",
+  "slug": "combinations-formula-oq-02-oq-02",
+  "title": "The Catalan Closed Form via Factorials",
+  "description": "Answers the second open question of combinations-formula-oq-02: prove the closed form C_n = C(2n,n)/(n+1) directly, without going through the parent's multiplicative identity catalan_mul_succ. We take a genuinely different route via factorials. From Nat.choose_mul_factorial_mul_factorial applied to C(2n,n) and C(2n,n+1) — both expand to (2n)! — we cancel the common factor (n+1)!*n! to obtain the cross identity C(2n,n)*n = C(2n,n+1)*(n+1). Everything then follows: the multiplicative identity C_n*(n+1) = C(2n,n) (re-derived, not assumed), the requested division form C_n = C(2n,n)/(n+1), the divisibility (n+1) | C(2n,n), and the fully-factorial closed form C_n = (2n)!/((n+1)!*n!). A final check reconciles the local definition with Mathlib's catalan.",
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number#Properties",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ02OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "binomial-coefficients",
+      "central-binomial",
+      "factorials"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "",
+    "lineCount": 189,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "originalContributions": [
+      "choose_cross: the cross identity C(2n,n)*n = C(2n,n+1)*(n+1), proved by factorial cancellation and used as the keystone for every closed form below",
+      "choose_succ_le_central: C(2n,n+1) <= C(2n,n), making the ballot subtraction defining C_n non-truncating",
+      "catalan_mul_succ': the multiplicative identity C_n*(n+1) = C(2n,n) re-derived purely from the factorial cross identity, not assumed from the parent",
+      "catalan_eq_choose_div: the requested closed form C_n = C(2n,n)/(n+1), obtained without the parent's catalan_mul_succ",
+      "succ_dvd_centralBinom: the divisibility (n+1) | C(2n,n) that makes the natural-number division exact",
+      "catalan_mul_factorial_factorial: the symmetric factorial closed form C_n*((n+1)!*n!) = (2n)!",
+      "catalan_eq_factorial_div: the fully-factorial closed form C_n = (2n)!/((n+1)!*n!)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Catalan numbers $C_n = 1, 1, 2, 5, 14, 42, \\ldots$ admit two celebrated closed forms. The reflection form $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$ (Andr\\'e's reflection / the ballot problem) counts Dyck paths directly, while the division form $C_n = \\frac{1}{n+1}\\binom{2n}{n}$ is the shape in which the sequence is most often quoted. Passing between them is a classical exercise: the naive route multiplies through by $n+1$ and reduces to a binomial absorption identity. The purely factorial statement $C_n = \\frac{(2n)!}{(n+1)!\\,n!}$ is the form that makes the integrality of $C_n$ most transparent, since it exhibits $C_n$ as a ratio of factorials whose denominator is the product of the two block sizes $n+1$ and $n$. This entry establishes all three forms from a single factorial cancellation, avoiding the binomial absorption lemma the parent entry uses.",
+    "problemStatement": "The parent entry combinations-formula-oq-02 defines $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$ and proves $C_n = \\binom{2n}{n}/(n+1)$ by first establishing the multiplicative identity $C_n\\,(n+1) = \\binom{2n}{n}$ (`catalan_mul_succ`) via the binomial absorption identity `Nat.succ_mul_choose_eq`. The open question asks for a proof of the closed form $C_n = \\binom{2n}{n}/(n+1)$ that does not route through `catalan_mul_succ`.",
+    "proofStrategy": "**Keystone (factorial cross identity).** Apply `Nat.choose_mul_factorial_mul_factorial` to $\\binom{2n}{n}$ and to $\\binom{2n}{n+1}$: the first gives $\\binom{2n}{n}\\,n!\\,n! = (2n)!$ and the second $\\binom{2n}{n+1}\\,(n+1)!\\,(n-1)! = (2n)!$. Both right-hand sides are $(2n)!$, so after rewriting $(n+1)! = (n+1)\\,n!$ and $n! = n\\,(n-1)!$ the two left-hand sides share the positive factor $(n+1)!\\,n!$; cancelling it (`Nat.eq_of_mul_eq_mul_right`) yields $\\binom{2n}{n}\\,n = \\binom{2n}{n+1}\\,(n+1)$.\n\n**Multiplicative identity.** With $\\binom{2n}{n+1} \\le \\binom{2n}{n}$ (row-maximality, `Nat.choose_le_middle`) the ballot subtraction is non-truncating, and $(\\binom{2n}{n} - \\binom{2n}{n+1})(n+1) = \\binom{2n}{n}$ follows from the cross identity by `Nat.sub_mul` and `omega`.\n\n**Closed forms.** Dividing the multiplicative identity gives $C_n = \\binom{2n}{n}/(n+1)$ (`Nat.mul_div_cancel_left`) and the divisibility $(n+1)\\mid\\binom{2n}{n}$. Multiplying it by $n!\\,n!$ and folding $(n+1)\\,n! = (n+1)!$ gives the symmetric factorial form $C_n\\,((n+1)!\\,n!) = (2n)!$, hence $C_n = (2n)!/((n+1)!\\,n!)$.",
+    "keyInsights": [
+      "The whole family of closed forms rests on one fact: $\\binom{2n}{n}$ and $\\binom{2n}{n+1}$ have the *same* factorial numerator $(2n)!$. Writing both binomials as $\\binom{2n}{k}=\\tfrac{(2n)!}{k!\\,(2n-k)!}$ and clearing denominators turns the identity $C_n(n+1)=\\binom{2n}{n}$ into pure factorial bookkeeping, with no appeal to the binomial absorption recurrence the parent uses.",
+      "The cross identity $\\binom{2n}{n}\\,n = \\binom{2n}{n+1}\\,(n+1)$ is exactly the statement that adjacent entries of row $2n$ are related by the ratio $\\tfrac{n+1}{n}$; it is the multiplicative shadow of Pascal's row-ratio recurrence $\\binom{m}{k+1} = \\binom{m}{k}\\tfrac{m-k}{k+1}$ specialized at $m=2n$, $k=n$.",
+      "Cancellation is the crux. Both binomial expansions equal $(2n)!$, so their left-hand sides are equal; the only nontrivial step is to recognize the shared positive factor $(n+1)!\\,n!$ and strike it. This is why `Nat.eq_of_mul_eq_mul_right` (right cancellation by a positive natural) carries the entire proof.",
+      "Row-maximality of the central coefficient, $\\binom{2n}{n+1}\\le\\binom{2n}{n}$, is what makes the truncated natural-number subtraction $\\binom{2n}{n}-\\binom{2n}{n+1}$ behave like a genuine subtraction; without it the ballot definition of $C_n$ would silently clamp to zero and the multiplicative identity would fail.",
+      "The factorial form $C_n = (2n)!/((n+1)!\\,n!)$ is the most symmetric of the three: it displays $C_n$ as the number of ways to interleave two blocks of sizes $n+1$ and $n$ inside $2n$ positions divided out correctly, and it makes the integrality of $C_n$ a consequence of the exact identity $C_n\\,((n+1)!\\,n!) = (2n)!$ rather than a divisibility to be checked separately."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Catalan Number (Ballot Form)",
+      "startLine": 54,
+      "endLine": 57,
+      "summary": "Defines catalan n = C(2n,n) - C(2n,n+1), the reflection / ballot closed form used in the parent entry, as the starting point from which the division and factorial forms are derived.",
+      "mathContext": "$C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$"
+    },
+    {
+      "id": "cross-identity",
+      "title": "The Factorial Cross Identity",
+      "startLine": 67,
+      "endLine": 95,
+      "summary": "The keystone. Expands both C(2n,n) and C(2n,n+1) into factorials via Nat.choose_mul_factorial_mul_factorial; both products equal (2n)!, so after rewriting (n+1)! = (n+1)*n! the two sides share the positive factor (n+1)!*n!, and cancelling it (Nat.eq_of_mul_eq_mul_right) yields C(2n,n)*n = C(2n,n+1)*(n+1). This never touches the binomial absorption identity the parent uses.",
+      "mathContext": "$\\binom{2n}{n}\\,n = \\binom{2n}{n+1}\\,(n+1)$"
+    },
+    {
+      "id": "multiplicative-identity",
+      "title": "The Multiplicative Identity, Re-derived",
+      "startLine": 97,
+      "endLine": 131,
+      "summary": "First records C(2n,n+1) <= C(2n,n) (row-maximality via Nat.choose_le_middle), making the ballot subtraction non-truncating. Then re-derives C_n*(n+1) = C(2n,n) from the cross identity alone using Nat.sub_mul and omega — the parent's catalan_mul_succ is never invoked.",
+      "mathContext": "$C_n\\,(n+1) = \\binom{2n}{n}$, with $\\binom{2n}{n+1}\\le\\binom{2n}{n}$"
+    },
+    {
+      "id": "closed-forms",
+      "title": "The Closed Forms",
+      "startLine": 133,
+      "endLine": 171,
+      "summary": "The requested division form C_n = C(2n,n)/(n+1) (Nat.mul_div_cancel_left), the divisibility (n+1) | C(2n,n), the symmetric factorial closed form C_n*((n+1)!*n!) = (2n)!, and its division form C_n = (2n)!/((n+1)!*n!). Each follows from the multiplicative identity by elementary arithmetic.",
+      "mathContext": "$C_n = \\dfrac{\\binom{2n}{n}}{n+1} = \\dfrac{(2n)!}{(n+1)!\\,n!}$"
+    },
+    {
+      "id": "consistency",
+      "title": "Consistency Checks",
+      "startLine": 173,
+      "endLine": 187,
+      "summary": "Reproduces the initial values C_0..C_5 = 1,1,2,5,14,42 by decide, and proves the local catalan agrees with Mathlib's catalan (via catalan_eq_centralBinom_div), confirming the derived closed forms describe the genuine Catalan sequence.",
+      "mathContext": "$C_0,\\ldots,C_5 = 1,1,2,5,14,42$ and $\\mathrm{catalan} = \\texttt{Nat.catalan}$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Starting from the ballot definition C_n = C(2n,n) - C(2n,n+1), a single factorial cancellation yields the cross identity C(2n,n)*n = C(2n,n+1)*(n+1), from which the multiplicative identity C_n*(n+1) = C(2n,n), the requested division form C_n = C(2n,n)/(n+1), the divisibility (n+1) | C(2n,n), and the symmetric factorial closed form C_n = (2n)!/((n+1)!*n!) all follow. The derivation deliberately avoids the parent's catalan_mul_succ (and the binomial absorption identity behind it), answering the open question. Verified with 0 sorries and 0 axioms.",
+    "implications": [
+      "The closed form C_n = C(2n,n)/(n+1) is obtained without the binomial absorption identity Nat.succ_mul_choose_eq, showing the division form is a direct consequence of factorial expansion rather than of the Catalan multiplicative recurrence.",
+      "The exact identity C_n*((n+1)!*n!) = (2n)! makes the integrality of the Catalan numbers a byproduct rather than a separate divisibility check: (n+1) | C(2n,n) is read off from the multiplicative identity.",
+      "The cross identity C(2n,n)*n = C(2n,n+1)*(n+1) is a reusable row-ratio fact for the central binomial coefficients, complementing the parent entry's absorption-based choose_2n_succ with a factorial-based proof."
+    ],
+    "openQuestions": [
+      "Does the factorial cancellation method extend to the Fuss-Catalan numbers C^{(p)}_n = \\frac{1}{pn+1}\\binom{pn+1}{n}, whose closed form is likewise a ratio of factorials, without invoking a p-fold absorption identity?",
+      "Can the exact identity C_n*((n+1)!*n!) = (2n)! be used to give a factorial proof of Kummer/Legendre-style results on the prime factorization of Catalan numbers (e.g. which primes divide C_n)?"
+    ]
+  },
+  "leanFile": {
+    "namespace": "CatalanClosedForm",
+    "lineCount": 189,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/CombinationsFormulaOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry: defines the Catalan numbers by the ballot subtraction and proves C_n = C(2n,n)/(n+1) through the multiplicative identity catalan_mul_succ. This entry answers its second open question by re-deriving the closed form via factorials instead."
+    },
+    {
+      "targetId": "combinations-formula-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Answers the first open question of the same parent (the generating function C = (1 - sqrt(1-4x))/(2x) as a formal power series). This entry answers the second (the factorial / division closed form)."
+    },
+    {
+      "targetId": "catalan-numbers-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Proves the reflection form catalan n = C(2n,n) - C(2n,n+1) used here as the definition; this entry supplies the complementary division and factorial closed forms."
+    },
+    {
+      "targetId": "ballot-problem-oq-03",
+      "relationship": "related",
+      "description": "The ballot / lattice-path count is the combinatorial source of the reflection form C(2n,n) - C(2n,n+1) that this entry converts into the division closed form."
+    }
+  ],
+  "references": [
+    {
+      "authors": "R. P. Stanley",
+      "title": "Catalan Numbers",
+      "year": 2015,
+      "venue": "Cambridge University Press",
+      "note": "Standard reference collecting the closed forms C_n = C(2n,n)/(n+1) = (2n)!/((n+1)! n!)."
+    },
+    {
+      "authors": "R. L. Graham, D. E. Knuth, O. Patashnik",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "venue": "Addison-Wesley",
+      "note": "Binomial-coefficient absorption and row-ratio identities underlying the cross identity."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.choose_mul_factorial_mul_factorial, Nat.choose_le_middle, and Nat.catalan used in this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of `combinations-formula-oq-02`:

> "Prove the closed form C_n = C(2n,n)/(n+1) directly without going through `catalan_mul_succ`."

The parent entry proves the closed form via the multiplicative identity `catalan_mul_succ : C_n·(n+1) = C(2n,n)`, itself obtained from the binomial absorption identity `Nat.succ_mul_choose_eq`. This entry takes a **genuinely different route via factorials**.

## Approach (factorial cancellation)

`Nat.choose_mul_factorial_mul_factorial` expands both `C(2n,n)` and `C(2n,n+1)` to `(2n)!`. Since both products equal `(2n)!`, cancelling the common positive factor `(n+1)!·n!` (`Nat.eq_of_mul_eq_mul_right`) yields the **cross identity**

```
C(2n,n) · n = C(2n,n+1) · (n+1).
```

Everything follows from this keystone:
- `catalan_mul_succ'` — the multiplicative identity `C_n·(n+1) = C(2n,n)`, **re-derived** (never assumed from the parent)
- `catalan_eq_choose_div` — **the requested form** `C_n = C(2n,n)/(n+1)`
- `succ_dvd_centralBinom` — the divisibility `(n+1) ∣ C(2n,n)`
- `catalan_mul_factorial_factorial` — the symmetric factorial closed form `C_n·((n+1)!·n!) = (2n)!`
- `catalan_eq_factorial_div` — `C_n = (2n)!/((n+1)!·n!)`

Consistency checks reproduce `C_0..C_5 = 1,1,2,5,14,42` and prove the local `catalan` agrees with Mathlib's `catalan`.

## Verification

- **0 sorries, 0 axioms** (`#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`)
- 9 theorems, 1 definition, 189 lines
- Compiles against Mathlib (single-file `lake env lean`, exit 0)

## Files
- `proofs/Proofs/CombinationsFormulaOQ02OQ02.lean`
- `src/data/proofs/combinations-formula-oq-02-oq-02/{meta.json,annotations.json}` (new gallery entry, 9 annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)