### PR TITLE
Repair malformed sections in 51 gallery entries (ids, content→summary, line ranges)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-02-oq-03/meta.json
@@ -130,32 +130,37 @@
     {
       "id": "rationals-negation",
       "title": "Part I: Rationals and negation are constructible",
-      "summary": "isConstructibleFromQ_rat: every rational is a constructible real (witnessed by ⊥, degree 1=2⁰). isConstructibleFromQ_zero/one. isConstructibleFromQ_neg: the constructible reals are closed under negation, reusing the same field K (an intermediate field is closed under negation).",
-      "mathContext": "$q\\in\\mathbb{Q}$ lies in $\\bot$ with $[\\bot:\\mathbb{Q}]=1=2^0$; closure under negation needs no compositum since $\\alpha\\in K\\Rightarrow-\\alpha\\in K$."
+      "startLine": 1,
+      "endLine": 88,
+      "summary": "isConstructibleFromQ_rat: every rational is a constructible real (witnessed by ⊥, degree 1=2⁰). isConstructibleFromQ_zero/one. isConstructibleFromQ_neg: the constructible reals are closed under negation, reusing the same field K (an intermediate field is closed under negation)."
     },
     {
       "id": "complex-constructibility",
       "title": "Part II: Complex constructibility",
-      "summary": "IsConstructibleℂ z := IsConstructibleFromQ z.re ∧ IsConstructibleFromQ z.im. Proves 0, 1, i constructible; the real/imaginary embedding iff; Gaussian rationals; conjugation closure and its iff; closure under multiplication by i (Re(i·z)=−Im z, Im(i·z)=Re z).",
-      "mathContext": "The structural backbone of the complex constructibles obtainable purely from real-part/imaginary-part identities plus negation closure — no field-degree arithmetic."
+      "startLine": 89,
+      "endLine": 151,
+      "summary": "IsConstructibleℂ z := IsConstructibleFromQ z.re ∧ IsConstructibleFromQ z.im. Proves 0, 1, i constructible; the real/imaginary embedding iff; Gaussian rationals; conjugation closure and its iff; closure under multiplication by i (Re(i·z)=−Im z, Im(i·z)=Re z)."
     },
     {
       "id": "analytic-bridge",
       "title": "Part III: The analytic bridge (sin from cos)",
-      "summary": "axiom sin_constructible_of_cos: for n ≥ 3, IsConstructibleFromQ (cos(2π/n)) → IsConstructibleFromQ (sin(2π/n)). The only new assumption, capturing closure of the constructible reals under the non-negative square root sin(2π/n)=√(1−cos²(2π/n)).",
-      "mathContext": "For $n\\ge3$, $2\\pi/n\\in(0,\\pi)$ so $\\sin(2\\pi/n)\\ge0$; the constructible reals form a field closed under square roots, which supplies the imaginary coordinate."
+      "startLine": 152,
+      "endLine": 165,
+      "summary": "axiom sin_constructible_of_cos: for n ≥ 3, IsConstructibleFromQ (cos(2π/n)) → IsConstructibleFromQ (sin(2π/n)). The only new assumption, capturing closure of the constructible reals under the non-negative square root sin(2π/n)=√(1−cos²(2π/n))."
     },
     {
       "id": "headline",
       "title": "Part IV: The headline — planar Gauss–Wantzel",
-      "summary": "rootOfUnity_isConstructibleℂ_iff_cos: vertex constructible ↔ cos(2π/n) constructible. ngon_vertex_isConstructibleℂ_iff: vertex constructible ↔ φ(n) a power of two (combining the cos bridge with the parent's gauss_wantzel_theorem).",
-      "mathContext": "$\\exp(2\\pi i/n)=\\cos(2\\pi/n)+i\\sin(2\\pi/n)$; constructibility of the complex vertex is equivalent to that of its real coordinate, hence to $\\varphi(n)=2^k$."
+      "startLine": 166,
+      "endLine": 188,
+      "summary": "rootOfUnity_isConstructibleℂ_iff_cos: vertex constructible ↔ cos(2π/n) constructible. ngon_vertex_isConstructibleℂ_iff: vertex constructible ↔ φ(n) a power of two (combining the cos bridge with the parent's gauss_wantzel_theorem)."
     },
     {
       "id": "instances",
       "title": "Parts V–VI: Constructible and non-constructible vertices",
-      "summary": "Constructible: 3-, 4-, 5-, 15-, 17-gon vertices (φ = 2,2,4,8,16). Not constructible: 7- and 9-gon vertices (φ(7)=φ(9)=6, not a power of two). All via kernel decide on the totients.",
-      "mathContext": "Worked planar instances derived from the headline equivalence."
+      "startLine": 189,
+      "endLine": 274,
+      "summary": "Constructible: 3-, 4-, 5-, 15-, 17-gon vertices (φ = 2,2,4,8,16). Not constructible: 7- and 9-gon vertices (φ(7)=φ(9)=6, not a power of two). All via kernel decide on the totients."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/arithmetic-series/annotations.json
+++ b/src/data/proofs/arithmetic-series/annotations.json
@@ -74,7 +74,7 @@
       "startLine": 112,
       "endLine": 113
     },
-    "type": "concept",
+    "type": "context",
     "title": "Gauss's Original Problem",
     "content": "**Sum of 1 to 100 = 5050.**\n\nThis is the famous problem Gauss allegedly solved as a schoolboy. The proof uses `native_decide` for computational verification.\n\n50 pairs × 101 = 5050.",
     "mathContext": "$1 + 2 + \\cdots + 100 = 5050$",

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -4,8 +4,13 @@
   "title": "The Magnitude-Bounded Power Band and the Escape/Capture Dichotomy",
   "description": "The parent entry (the line-escapes-a-bounded-power lemma) trapped every power of a magnitude-≤ 1 base inside the fixed band [−1, 1] and concluded that any line of nonzero slope eventually escapes it. This entry answers the parent's own first open question: generalize the trap to a magnitude-≤ B base, whose powers live in the n-dependent band [−Bⁿ, Bⁿ], and characterize exactly which lines escape it. The trap generalizes verbatim (abs_pow_le, neg_pow_le_pow, pow_le_pow_band), as does the escape engine (lt_pow_of_lt_neg_pow, pow_lt_of_pow_lt). The new content is a sharp dichotomy governed by the critical value B = 1: for a shrinking or critical band 0 ≤ B ≤ 1 the band sits inside [−1, 1], so the parent's mechanism survives — a negative-slope line eventually drops below every power (eventually_line_lt_pow_band) and a positive-slope line eventually rises above every power (eventually_pow_lt_line_band), with the parent B = 1 as the boundary case. For a growing band B > 1 the walls ±Bⁿ grow exponentially and dominate any line: beyond an explicit threshold the line is trapped strictly inside (−Bⁿ, Bⁿ) (eventually_line_mem_band), so NO line of any slope escapes. The driver is that the exponential Bⁿ dominates the linear |b| + n·|s|, via Mathlib's tendsto_pow_const_div_const_pow_of_one_lt. The escape (B ≤ 1) versus capture (B > 1) contrast is packaged in escape_or_capture, with the parent's fixed band B = 1 sitting exactly on the knife-edge. Verified: 0 sorries, 0 axioms.",
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Filter", "Topology"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
     "namespace": "BernoulliInequalityOQ01OQ01OQ02OQ01",
     "lineCount": 215,
     "axiomCount": 0,
@@ -100,27 +105,37 @@
     {
       "id": "trap",
       "title": "The generalized trap",
-      "content": "From |x| ≤ B (which forces 0 ≤ B), the identity |xⁿ| = |x|ⁿ (abs_pow) together with pow_le_pow_left₀ gives |xⁿ| ≤ Bⁿ. Splitting this with abs_le yields the two walls −Bⁿ ≤ xⁿ ≤ Bⁿ: every power of a magnitude-≤ B base lives in the n-dependent band [−Bⁿ, Bⁿ]. This is the verbatim generalization of the parent's band [−1, 1]."
+      "startLine": 1,
+      "endLine": 71,
+      "summary": "From |x| ≤ B (which forces 0 ≤ B), the identity |xⁿ| = |x|ⁿ (abs_pow) together with pow_le_pow_left₀ gives |xⁿ| ≤ Bⁿ. Splitting this with abs_le yields the two walls −Bⁿ ≤ xⁿ ≤ Bⁿ: every power of a magnitude-≤ B base lives in the n-dependent band [−Bⁿ, Bⁿ]. This is the verbatim generalization of the parent's band [−1, 1]."
     },
     {
       "id": "engine",
       "title": "The escape engine",
-      "content": "Two one-step comparisons hold for any B: anything strictly below the lower wall, c < −Bⁿ, is beaten by every power (lt_pow_of_lt_neg_pow: c < xⁿ); anything strictly above the upper wall, Bⁿ < c, beats every power (pow_lt_of_pow_lt: xⁿ < c). These are the building blocks for both sides of the dichotomy."
+      "startLine": 72,
+      "endLine": 83,
+      "summary": "Two one-step comparisons hold for any B: anything strictly below the lower wall, c < −Bⁿ, is beaten by every power (lt_pow_of_lt_neg_pow: c < xⁿ); anything strictly above the upper wall, Bⁿ < c, beats every power (pow_lt_of_pow_lt: xⁿ < c). These are the building blocks for both sides of the dichotomy."
     },
     {
       "id": "shrinking",
       "title": "Shrinking / critical band (0 ≤ B ≤ 1): lines escape",
-      "content": "When B ≤ 1 the wall Bⁿ never exceeds 1 (pow_le_one₀), so the band sits inside [−1, 1] and the parent's argument survives unchanged. A negative-slope line b + n·s eventually drops below −1 ≤ −Bⁿ (threshold N > (b+1)/(−s) from exists_nat_gt), hence below every power (eventually_line_lt_pow_band); the positive-slope mirror is eventually_pow_lt_line_band. The parent (B = 1) is the boundary case."
+      "startLine": 84,
+      "endLine": 133,
+      "summary": "When B ≤ 1 the wall Bⁿ never exceeds 1 (pow_le_one₀), so the band sits inside [−1, 1] and the parent's argument survives unchanged. A negative-slope line b + n·s eventually drops below −1 ≤ −Bⁿ (threshold N > (b+1)/(−s) from exists_nat_gt), hence below every power (eventually_line_lt_pow_band); the positive-slope mirror is eventually_pow_lt_line_band. The parent (B = 1) is the boundary case."
     },
     {
       "id": "growing",
       "title": "Growing band (B > 1): the band captures every line",
-      "content": "When B > 1 the walls ±Bⁿ grow exponentially. The quotient (|b| + |s|·n)/Bⁿ → 0 (tendsto_linear_div_pow, built from tendsto_pow_const_div_const_pow_of_one_lt with k = 0, 1), so eventually |b| + |s|·n < Bⁿ (div_lt_one). Bounding the line by its linear envelope (abs_add_le) gives |b + n·s| < Bⁿ, i.e. the line is trapped strictly inside (−Bⁿ, Bⁿ) (eventually_line_mem_band). No line of any slope escapes — the exact opposite of the B ≤ 1 case."
+      "startLine": 134,
+      "endLine": 186,
+      "summary": "When B > 1 the walls ±Bⁿ grow exponentially. The quotient (|b| + |s|·n)/Bⁿ → 0 (tendsto_linear_div_pow, built from tendsto_pow_const_div_const_pow_of_one_lt with k = 0, 1), so eventually |b| + |s|·n < Bⁿ (div_lt_one). Bounding the line by its linear envelope (abs_add_le) gives |b + n·s| < Bⁿ, i.e. the line is trapped strictly inside (−Bⁿ, Bⁿ) (eventually_line_mem_band). No line of any slope escapes — the exact opposite of the B ≤ 1 case."
     },
     {
       "id": "dichotomy",
       "title": "The boundary dichotomy",
-      "content": "escape_or_capture packages the contrast for a fixed negative-slope line: if B > 1 the line is eventually captured inside the band, while if B ≤ 1 it eventually escapes below every power. The single comparison B ≷ 1 flips capture into escape, identifying the parent's fixed band B = 1 as the precise critical threshold the parent's open question asked about."
+      "startLine": 187,
+      "endLine": 215,
+      "summary": "escape_or_capture packages the contrast for a fixed negative-slope line: if B > 1 the line is eventually captured inside the band, while if B ≤ 1 it eventually escapes below every power. The single comparison B ≷ 1 flips capture into escape, identifying the parent's fixed band B = 1 as the precise critical threshold the parent's open question asked about."
     }
   ],
   "overview": {

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/meta.json
@@ -95,25 +95,29 @@
       "title": "Module header and context",
       "startLine": 1,
       "endLine": 30,
-      "summary": "Recalls the parent's slot recurrence R and the closed forms for n = 1, 2, 3, and states the goal: the next term birthdayCount3 4 d = d⁴ − 4d² + 3d = d(d−1)(d²+d−3), proved 0-axiom by symbolic unfolding rather than native_decide."
+      "summary": "Recalls the parent's slot recurrence R and the closed forms for n = 1, 2, 3, and states the goal: the next term birthdayCount3 4 d = d⁴ − 4d² + 3d = d(d−1)(d²+d−3), proved 0-axiom by symbolic unfolding rather than native_decide.",
+      "id": "module-header-and-context"
     },
     {
       "title": "The slot recurrence and base lemmas",
       "startLine": 36,
       "endLine": 49,
-      "summary": "Reproduces the recurrence R n e s (state = empty/single days) and birthdayCount3 n d = R n d 0 for a self-contained, fast-compiling file, with the simp lemmas R_zero, R_succ and the base identity R_one: R 1 e s = e + s."
+      "summary": "Reproduces the recurrence R n e s (state = empty/single days) and birthdayCount3 n d = R n d 0 for a self-contained, fast-compiling file, with the simp lemmas R_zero, R_succ and the base identity R_one: R 1 e s = e + s.",
+      "id": "the-slot-recurrence-and-base-lemmas"
     },
     {
       "title": "The n = 4 closed form",
       "startLine": 51,
       "endLine": 62,
-      "summary": "birthdayCount3_four: d⁴ − 4d² + 3d over ℤ, via small-case evaluation and symbolic unfolding of the recurrence for d = k+3."
+      "summary": "birthdayCount3_four: d⁴ − 4d² + 3d over ℤ, via small-case evaluation and symbolic unfolding of the recurrence for d = k+3.",
+      "id": "the-n-4-closed-form"
     },
     {
       "title": "Factored and ℕ forms",
       "startLine": 64,
       "endLine": 75,
-      "summary": "birthdayCount3_four_factored (d(d−1)(d²+d−3)) and birthdayCount3_four_eq_nat (a truncation-free ℕ identity for d ≥ 1)."
+      "summary": "birthdayCount3_four_factored (d(d−1)(d²+d−3)) and birthdayCount3_four_eq_nat (a truncation-free ℕ identity for d ≥ 1).",
+      "id": "factored-and-forms"
     }
   ],
   "sorries": []

--- a/src/data/proofs/birthday-problem/annotations.json
+++ b/src/data/proofs/birthday-problem/annotations.json
@@ -135,7 +135,7 @@
       "startLine": 165,
       "endLine": 171
     },
-    "type": "concept",
+    "type": "context",
     "title": "Two People: P = 1/365",
     "content": "With 2 people, the probability they share a birthday is:\n\n$$P(2) = 1 - \\frac{365 \\times 364}{365^2} = 1 - \\frac{364}{365} = \\frac{1}{365}$$\n\nThis makes intuitive sense: once person 1's birthday is fixed, person 2 has a 1/365 chance of matching.\n\nIn Lean: `prob_shared_birthday 2 = 1 / 365`",
     "mathContext": "$P(2) = 1/365 \\approx 0.27\\%$",

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
@@ -140,42 +140,42 @@
       "title": "Module Header and Overview",
       "startLine": 1,
       "endLine": 29,
-      "content": "Module docstring for the Kakutani fixed-point theorem (infinite-dimensional): Kakutani (1941) generalizes Brouwer/Schauder from single-valued to upper-hemicontinuous set-valued maps; Fan-Glicksberg extends it to locally convex TVS. Lists applications (Nash equilibrium, Arrow-Debreu, optimal control) and references. Imports Mathlib; opens namespace BrouwerOQ04OQ03 with Set, Filter, Topology."
+      "summary": "Module docstring for the Kakutani fixed-point theorem (infinite-dimensional): Kakutani (1941) generalizes Brouwer/Schauder from single-valued to upper-hemicontinuous set-valued maps; Fan-Glicksberg extends it to locally convex TVS. Lists applications (Nash equilibrium, Arrow-Debreu, optimal control) and references. Imports Mathlib; opens namespace BrouwerOQ04OQ03 with Set, Filter, Topology."
     },
     {
       "id": "set-valued-maps",
       "title": "Part I: Set-Valued Maps and Upper Hemicontinuity",
       "startLine": 30,
       "endLine": 61,
-      "content": "A `SetValuedMap X Y` is simply a function X → Set Y. Upper hemicontinuity (UHC) is defined via the open set condition: F is UHC if for every open U, the set {x | F(x) ⊆ U} is open. This is equivalent to: for every x and every open set U ⊇ F(x), there is a neighborhood V of x such that F(y) ⊆ U for all y ∈ V. For a singleton map F(x) = {f(x)}, UHC reduces to: {x | f(x) ∈ U} = f⁻¹(U) is open, i.e., f is continuous. Also defines HasNonemptyValues, HasConvexValues, HasClosedValues, and IsFixedPoint."
+      "summary": "A `SetValuedMap X Y` is simply a function X → Set Y. Upper hemicontinuity (UHC) is defined via the open set condition: F is UHC if for every open U, the set {x | F(x) ⊆ U} is open. This is equivalent to: for every x and every open set U ⊇ F(x), there is a neighborhood V of x such that F(y) ⊆ U for all y ∈ V. For a singleton map F(x) = {f(x)}, UHC reduces to: {x | f(x) ∈ U} = f⁻¹(U) is open, i.e., f is continuous. Also defines HasNonemptyValues, HasConvexValues, HasClosedValues, and IsFixedPoint."
     },
     {
       "id": "kakutani-axiom",
       "title": "Part II: Kakutani's Theorem, Finite-Dimensional (Axiomatized)",
       "startLine": 62,
       "endLine": 78,
-      "content": "The axiom `kakutani_finite_dim` states the finite-dimensional Kakutani theorem for `EuclideanSpace ℝ (Fin n)`. The four conditions — UHC, nonempty values, closed values, convex values — are each captured by the auxiliary definitions. The proof of Kakutani requires either simplicial approximation (Kakutani's original argument) or degree-theoretic methods. Neither is available as packaged Mathlib results for this setting."
+      "summary": "The axiom `kakutani_finite_dim` states the finite-dimensional Kakutani theorem for `EuclideanSpace ℝ (Fin n)`. The four conditions — UHC, nonempty values, closed values, convex values — are each captured by the auxiliary definitions. The proof of Kakutani requires either simplicial approximation (Kakutani's original argument) or degree-theoretic methods. Neither is available as packaged Mathlib results for this setting."
     },
     {
       "id": "fan-glicksberg-axiom",
       "title": "Part III: Fan-Glicksberg Theorem, Infinite-Dimensional (Axiomatized)",
       "startLine": 79,
       "endLine": 96,
-      "content": "The axiom `fan_glicksberg` generalizes to locally convex topological vector spaces (LCTVS), capturing the most general fixed-point theorem for set-valued maps with convex structure. The Lean type signature uses `[LocallyConvexSpace ℝ E]` — a Mathlib typeclass for spaces where every point has a neighborhood basis of convex sets. This covers all Banach spaces, Hilbert spaces, and Fréchet spaces."
+      "summary": "The axiom `fan_glicksberg` generalizes to locally convex topological vector spaces (LCTVS), capturing the most general fixed-point theorem for set-valued maps with convex structure. The Lean type signature uses `[LocallyConvexSpace ℝ E]` — a Mathlib typeclass for spaces where every point has a neighborhood basis of convex sets. This covers all Banach spaces, Hilbert spaces, and Fréchet spaces."
     },
     {
       "id": "nash-stub",
       "title": "Part IV: Application to Nash Equilibrium (Stub)",
       "startLine": 97,
       "endLine": 121,
-      "content": "The `FiniteGame` structure and `MixedStrategy` type are well-defined. However, `IsNashEquilibrium` is defined as `True` — a placeholder for the full definition which requires computing expected payoffs under mixed strategy profiles. The theorem `nash_equilibrium_existence` is proved trivially via ⟨fun _ _ => 0, trivial⟩. The genuine proof would apply Kakutani to the *best-response correspondence* BR_i(σ) = {σ_i' : player i prefers σ_i' to σ_i given others play σ_{-i}}, which is UHC with nonempty convex values under the mixed extension of payoffs."
+      "summary": "The `FiniteGame` structure and `MixedStrategy` type are well-defined. However, `IsNashEquilibrium` is defined as `True` — a placeholder for the full definition which requires computing expected payoffs under mixed strategy profiles. The theorem `nash_equilibrium_existence` is proved trivially via ⟨fun _ _ => 0, trivial⟩. The genuine proof would apply Kakutani to the *best-response correspondence* BR_i(σ) = {σ_i' : player i prefers σ_i' to σ_i given others play σ_{-i}}, which is UHC with nonempty convex values under the mixed extension of payoffs."
     },
     {
       "id": "brouwer-from-kakutani",
       "title": "Part V: Hierarchy and Derivation of Brouwer from Kakutani (Proved)",
       "startLine": 122,
       "endLine": 156,
-      "content": "A reference table of the fixed-point hierarchy (Brouwer 1911, Schauder 1930, Kakutani 1941, Fan-Glicksberg 1952, Eilenberg-Montgomery 1946), then the genuinely-proved theorem `brouwer_from_kakutani_finite`. Given continuous f : K → K, define F(x) = {f(x)}. The proof verifies:\n- Image condition: {f(x)} ⊆ K since f(x) ∈ K\n- UHC: preimage of open U under x ↦ {f(x)} is {x | f(x) ∈ U} = f⁻¹(U), open by continuity\n- Nonempty: {f(x)} always has f(x)\n- Closed: `isClosed_singleton`\n- Convex: `convex_singleton`\n\nKakutani gives x ∈ K with x ∈ {f(x)}, i.e., f(x) = x."
+      "summary": "A reference table of the fixed-point hierarchy (Brouwer 1911, Schauder 1930, Kakutani 1941, Fan-Glicksberg 1952, Eilenberg-Montgomery 1946), then the genuinely-proved theorem `brouwer_from_kakutani_finite`. Given continuous f : K → K, define F(x) = {f(x)}. The proof verifies:\n- Image condition: {f(x)} ⊆ K since f(x) ∈ K\n- UHC: preimage of open U under x ↦ {f(x)} is {x | f(x) ∈ U} = f⁻¹(U), open by continuity\n- Nonempty: {f(x)} always has f(x)\n- Closed: `isClosed_singleton`\n- Convex: `convex_singleton`\n\nKakutani gives x ∈ K with x ∈ {f(x)}, i.e., f(x) = x."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -41,20 +41,32 @@
   },
   "sections": [
     {
+      "id": "the-exponent-swap-lemma",
       "title": "The exponent-swap lemma",
-      "content": "The headline lemma integral_sin_pow_mul_cos_pow_swap asserts ∫_0^{π/2} sinᵃθ cosᵇθ = ∫_0^{π/2} sinᵇθ cosᵃθ for a, b : ℕ. The proof applies intervalIntegral.integral_comp_sub_left with center π/2 and interval [0, π/2], which is fixed by the reflection (its endpoints map to π/2−π/2 = 0 and π/2−0 = π/2). The complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ rewrite the reflected integrand into cosᵃθ sinᵇθ, and one integral_congr with mul_comm transposes the factors onto the target."
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "The headline lemma integral_sin_pow_mul_cos_pow_swap asserts ∫_0^{π/2} sinᵃθ cosᵇθ = ∫_0^{π/2} sinᵇθ cosᵃθ for a, b : ℕ. The proof applies intervalIntegral.integral_comp_sub_left with center π/2 and interval [0, π/2], which is fixed by the reflection (its endpoints map to π/2−π/2 = 0 and π/2−0 = π/2). The complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ rewrite the reflected integrand into cosᵃθ sinᵇθ, and one integral_congr with mul_comm transposes the factors onto the target."
     },
     {
+      "id": "real-exponents-and-the-beta-function",
       "title": "Real exponents and the Beta function",
-      "content": "Because the reflection rewrites only the bases of the powers, the identical script proves integral_sin_rpow_mul_cos_rpow_swap for arbitrary real exponents (Real.rpow), with no positivity or integrability hypothesis. Instantiating the exponents at 2x−1 and 2y−1 yields integral_beta_trig_symm, the trigonometric form of Euler's Beta symmetry B(x,y)=B(y,x) — obtained without any Gamma-function machinery."
+      "startLine": 65,
+      "endLine": 94,
+      "summary": "Because the reflection rewrites only the bases of the powers, the identical script proves integral_sin_rpow_mul_cos_rpow_swap for arbitrary real exponents (Real.rpow), with no positivity or integrability hypothesis. Instantiating the exponents at 2x−1 and 2y−1 yields integral_beta_trig_symm, the trigonometric form of Euler's Beta symmetry B(x,y)=B(y,x) — obtained without any Gamma-function machinery."
     },
     {
+      "id": "recovering-the-parent",
       "title": "Recovering the parent",
-      "content": "The natural-number lemma at a = 1 (with sin θ ^ 1 = sin θ, cos θ ^ 1 = cos θ) is the parent's single-power reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ, re-proved here as integral_sin_mul_cos_pow_eq_reflect. This confirms the new statement strictly generalizes the parent and supplies the reusable bridge the open question asked for."
+      "startLine": 95,
+      "endLine": 108,
+      "summary": "The natural-number lemma at a = 1 (with sin θ ^ 1 = sin θ, cos θ ^ 1 = cos θ) is the parent's single-power reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ, re-proved here as integral_sin_mul_cos_pow_eq_reflect. This confirms the new statement strictly generalizes the parent and supplies the reusable bridge the open question asked for."
     },
     {
+      "id": "scope-and-boundary",
       "title": "Scope and boundary",
-      "content": "This file isolates the symmetry content of the trigonometric power integrals. The complementary half — the evaluation of ∫ sin^{2x−1}θ cos^{2y−1}θ as a ratio of Gamma values, and the bridge to Mathlib's Real.betaIntegral via t = sin²θ — needs the Gamma recurrence and is left to the Beta/Gamma API, marking the boundary of the elementary reflection method."
+      "startLine": 109,
+      "endLine": 117,
+      "summary": "This file isolates the symmetry content of the trigonometric power integrals. The complementary half — the evaluation of ∫ sin^{2x−1}θ cos^{2y−1}θ as a ratio of Gamma values, and the bridge to Mathlib's Real.betaIntegral via t = sin²θ — needs the Gamma recurrence and is left to the Beta/Gamma API, marking the boundary of the elementary reflection method."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/burnside-counting-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-02-oq-01/meta.json
@@ -127,37 +127,43 @@
       "title": "Module header and scope",
       "startLine": 1,
       "endLine": 55,
-      "summary": "States the goal — the closed evaluation of the rotation half of the parent's bracelet_burnside identity as the gcd-cycle sum — and the structural reason the count is 2^{gcd(n,i)}: fixed colourings are constant on the gcd(n,i) rotation orbits. Records the axiom-hygiene claim (only propext/Classical.choice/Quot.sound)."
+      "summary": "States the goal — the closed evaluation of the rotation half of the parent's bracelet_burnside identity as the gcd-cycle sum — and the structural reason the count is 2^{gcd(n,i)}: fixed colourings are constant on the gcd(n,i) rotation orbits. Records the axiom-hygiene claim (only propext/Classical.choice/Quot.sound).",
+      "id": "module-header-and-scope"
     },
     {
       "title": "Unfolding the rotation action",
       "startLine": 56,
       "endLine": 81,
-      "summary": "rotation_smul_apply: (r i • c) p = c (p - i), reading off the parent's smul_apply with ρ (r i) = Equiv.addRight i and inverse · - i. fixed_iff_periodic: r i • c = c ↔ ∀ p, c (p - i) = c p."
+      "summary": "rotation_smul_apply: (r i • c) p = c (p - i), reading off the parent's smul_apply with ρ (r i) = Equiv.addRight i and inverse · - i. fixed_iff_periodic: r i • c = c ↔ ∀ p, c (p - i) = c p.",
+      "id": "unfolding-the-rotation-action"
     },
     {
       "title": "Invariance under the cyclic subgroup",
       "startLine": 82,
       "endLine": 105,
-      "summary": "periodic_zsmul: an i-periodic colouring satisfies c (a + k • i) = c a for every k : ℤ, by Int.induction_on using periodicity in both the +i and -i directions — the fact that lets a fixed colouring descend to the coset quotient."
+      "summary": "periodic_zsmul: an i-periodic colouring satisfies c (a + k • i) = c a for every k : ℤ, by Int.induction_on using periodicity in both the +i and -i directions — the fact that lets a fixed colouring descend to the coset quotient.",
+      "id": "invariance-under-the-cyclic-subgroup"
     },
     {
       "title": "The bijection with functions on the orbit quotient",
       "startLine": 106,
       "endLine": 140,
-      "summary": "fixedRotationEquiv: ↥(fixedBy (Coloring n) (r i)) ≃ (ZMod n ⧸ ⟨i⟩ → Fin 2). Forward by Quotient.lift of the fixed colouring (well-defined via QuotientAddGroup.leftRel_apply + mem_zmultiples_iff + periodic_zsmul); backward by pullback along QuotientAddGroup.mk; the two are mutually inverse."
+      "summary": "fixedRotationEquiv: ↥(fixedBy (Coloring n) (r i)) ≃ (ZMod n ⧸ ⟨i⟩ → Fin 2). Forward by Quotient.lift of the fixed colouring (well-defined via QuotientAddGroup.leftRel_apply + mem_zmultiples_iff + periodic_zsmul); backward by pullback along QuotientAddGroup.mk; the two are mutually inverse.",
+      "id": "the-bijection-with-functions-on-the-orbit-quotient"
     },
     {
       "title": "Counting the quotient: the index is gcd(n, i)",
       "startLine": 141,
       "endLine": 165,
-      "summary": "card_quotient_zmultiples: Nat.card (ZMod n ⧸ ⟨i⟩) = gcd(n, i.val), from Lagrange (card α = card quotient · card subgroup), Nat.card_zmultiples (subgroup order = addOrderOf i), ZMod.addOrderOf_coe (= n / gcd(n,i)), and the cancellation n / (n / gcd) = gcd."
+      "summary": "card_quotient_zmultiples: Nat.card (ZMod n ⧸ ⟨i⟩) = gcd(n, i.val), from Lagrange (card α = card quotient · card subgroup), Nat.card_zmultiples (subgroup order = addOrderOf i), ZMod.addOrderOf_coe (= n / gcd(n,i)), and the cancellation n / (n / gcd) = gcd.",
+      "id": "counting-the-quotient-the-index-is-gcd-n-i"
     },
     {
       "title": "The per-rotation count and the rotation half",
       "startLine": 166,
       "endLine": 190,
-      "summary": "card_fixedBy_rotation: |Fix(r i)| = 2^{gcd(n, i.val)} via Fintype.card_congr fixedRotationEquiv and Fintype.card_fun. rotation_sum_eq_gcd_cycle_sum: Σ_{i∈ZMod n} |Fix(r i)| = Σ_{i∈ZMod n} 2^{gcd(n, i.val)}, the closed rotation half. Axiom audit confirms only the foundational axioms."
+      "summary": "card_fixedBy_rotation: |Fix(r i)| = 2^{gcd(n, i.val)} via Fintype.card_congr fixedRotationEquiv and Fintype.card_fun. rotation_sum_eq_gcd_cycle_sum: Σ_{i∈ZMod n} |Fix(r i)| = Σ_{i∈ZMod n} 2^{gcd(n, i.val)}, the closed rotation half. Axiom audit confirms only the foundational axioms.",
+      "id": "the-per-rotation-count-and-the-rotation-half"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/burnside-counting-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-02-oq-02/meta.json
@@ -139,43 +139,50 @@
       "title": "Module header and scope",
       "startLine": 1,
       "endLine": 51,
-      "summary": "States the goal — the closed evaluation of the reflection half of the parent's bracelet_burnside identity for both parities — and the structural plan: a reflection acts by the involution refl i : p ↦ -i - p, fixed colourings are constant on its orbits, the orbit count of any involution is (|α| + |Fix|)/2, and f_i = #{p : 2p = -i} splits by parity. Records the axiom-hygiene claim (only propext/Classical.choice/Quot.sound)."
+      "summary": "States the goal — the closed evaluation of the reflection half of the parent's bracelet_burnside identity for both parities — and the structural plan: a reflection acts by the involution refl i : p ↦ -i - p, fixed colourings are constant on its orbits, the orbit count of any involution is (|α| + |Fix|)/2, and f_i = #{p : 2p = -i} splits by parity. Records the axiom-hygiene claim (only propext/Classical.choice/Quot.sound).",
+      "id": "module-header-and-scope"
     },
     {
       "title": "Unfolding the reflection action",
       "startLine": 52,
       "endLine": 77,
-      "summary": "reflection_smul_apply: (sr i • c) p = c (-i - p), reading off the parent's smul_apply with ρ (sr i) = Equiv.subLeft (-i). fixed_iff_symm: sr i • c = c ↔ ∀ p, c (-i - p) = c p — the symmetry condition that makes a fixed colouring constant on refl i-orbits."
+      "summary": "reflection_smul_apply: (sr i • c) p = c (-i - p), reading off the parent's smul_apply with ρ (sr i) = Equiv.subLeft (-i). fixed_iff_symm: sr i • c = c ↔ ∀ p, c (-i - p) = c p — the symmetry condition that makes a fixed colouring constant on refl i-orbits.",
+      "id": "unfolding-the-reflection-action"
     },
     {
       "title": "The reflection involution on positions",
       "startLine": 78,
       "endLine": 88,
-      "summary": "refl i : p ↦ -i - p and refl_involutive: refl i is an involution (-i - (-i - p) = p). This is the involution whose invariant 2-colourings are exactly the colourings fixed by sr i."
+      "summary": "refl i : p ↦ -i - p and refl_involutive: refl i is an involution (-i - (-i - p) = p). This is the involution whose invariant 2-colourings are exactly the colourings fixed by sr i.",
+      "id": "the-reflection-involution-on-positions"
     },
     {
       "title": "Counting invariant 2-colourings of an arbitrary involution",
       "startLine": 89,
       "endLine": 206,
-      "summary": "card_invariant_colorings_involutive: for any involution σ on a finite type α, |{c : α → Fin 2 // ∀ a, c (σ a) = c a}| = 2^{(|α| + |Fix σ|)/2}. Elementary proof: index α by ℕ (Fintype.equivFin), representative = smaller-indexed element of {a, σ a}, invariant colourings ≃ (R → Fin 2), and |R| = (|α| + |Fix σ|)/2 from R = L ∪ Fix (disjoint), R.card + G.card = |α|, and |L| = |G| (Finset.card_nbij' with σ). No group actions, Burnside, or orbit-quotient Fintype instances."
+      "summary": "card_invariant_colorings_involutive: for any involution σ on a finite type α, |{c : α → Fin 2 // ∀ a, c (σ a) = c a}| = 2^{(|α| + |Fix σ|)/2}. Elementary proof: index α by ℕ (Fintype.equivFin), representative = smaller-indexed element of {a, σ a}, invariant colourings ≃ (R → Fin 2), and |R| = (|α| + |Fix σ|)/2 from R = L ∪ Fix (disjoint), R.card + G.card = |α|, and |L| = |G| (Finset.card_nbij' with σ). No group actions, Burnside, or orbit-quotient Fintype instances.",
+      "id": "counting-invariant-2-colourings-of-an-arbitrary-involution"
     },
     {
       "title": "The per-reflection fixed-colouring count",
       "startLine": 207,
       "endLine": 224,
-      "summary": "reflFix i = #{p : refl i p = p} = #{p : 2p = -i} (the fixed-bead count), and card_fixedBy_reflection: |Fix(sr i)| = 2^{(n + reflFix i)/2} via Equiv.subtypeEquivRight to the invariant colourings of refl i and the involution count."
+      "summary": "reflFix i = #{p : refl i p = p} = #{p : 2p = -i} (the fixed-bead count), and card_fixedBy_reflection: |Fix(sr i)| = 2^{(n + reflFix i)/2} via Equiv.subtypeEquivRight to the invariant colourings of refl i and the involution count.",
+      "id": "the-per-reflection-fixed-colouring-count"
     },
     {
       "title": "Odd n: every reflection fixes one bead",
       "startLine": 225,
       "endLine": 268,
-      "summary": "reflFix_odd: for odd n, 2 is a unit in ZMod n (ZMod.isUnit_iff_coprime + Nat.coprime_two_left), so 2p = -i has a unique solution (Units.mulLeft_bijective + Bijective.existsUnique + Finset.card_eq_one) and reflFix i = 1. reflection_sum_odd: Σ_{i∈ZMod n} |Fix(sr i)| = n·2^{(n+1)/2}."
+      "summary": "reflFix_odd: for odd n, 2 is a unit in ZMod n (ZMod.isUnit_iff_coprime + Nat.coprime_two_left), so 2p = -i has a unique solution (Units.mulLeft_bijective + Bijective.existsUnique + Finset.card_eq_one) and reflFix i = 1. reflection_sum_odd: Σ_{i∈ZMod n} |Fix(sr i)| = n·2^{(n+1)/2}.",
+      "id": "odd-n-every-reflection-fixes-one-bead"
     },
     {
       "title": "Even n: reflections split by parity",
       "startLine": 269,
       "endLine": 428,
-      "summary": "two_mul_eq_zero_iff: for even n = 2m the doubling kernel is exactly {0, m}. reflFix_even: reflFix i ∈ {0, 2} (the solution set of 2p = -i is empty or a coset of {0, n/2}). reflFix_sum: Σ_i reflFix i = n for every n, a fiberwise Finset.sum_comm count (each bead is the unique fixed point of one axis). card_even_reflections: exactly n/2 reflections have reflFix i = 2 (omega from Σ reflFix = n and each term ∈ {0,2}). reflection_sum_even: Σ_{i∈ZMod n} |Fix(sr i)| = 3·(n/2)·2^{n/2}, via an additive split of each term that uses only the positive filter. Axiom audit confirms only the foundational axioms."
+      "summary": "two_mul_eq_zero_iff: for even n = 2m the doubling kernel is exactly {0, m}. reflFix_even: reflFix i ∈ {0, 2} (the solution set of 2p = -i is empty or a coset of {0, n/2}). reflFix_sum: Σ_i reflFix i = n for every n, a fiberwise Finset.sum_comm count (each bead is the unique fixed point of one axis). card_even_reflections: exactly n/2 reflections have reflFix i = 2 (omega from Σ reflFix = n and each term ∈ {0,2}). reflection_sum_even: Σ_{i∈ZMod n} |Fix(sr i)| = 3·(n/2)·2^{n/2}, via an additive split of each term that uses only the positive filter. Axiom audit confirms only the foundational axioms.",
+      "id": "even-n-reflections-split-by-parity"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/burnside-counting-oq-04-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-02/meta.json
@@ -118,43 +118,50 @@
       "title": "Module header and scope",
       "startLine": 1,
       "endLine": 55,
-      "summary": "States the goal — generalising the sibling's hard-wired n=4 dihedral bracelet machinery to D_n for every n — and the honesty note that the genuinely new content is the n-uniform construction and Burnside identity, with Burnside's lemma and |Dₙ|=2n taken from Mathlib. Confirms axiom hygiene (only propext/Classical.choice/Quot.sound)."
+      "summary": "States the goal — generalising the sibling's hard-wired n=4 dihedral bracelet machinery to D_n for every n — and the honesty note that the genuinely new content is the n-uniform construction and Burnside identity, with Burnside's lemma and |Dₙ|=2n taken from Mathlib. Confirms axiom hygiene (only propext/Classical.choice/Quot.sound).",
+      "id": "module-header-and-scope"
     },
     {
       "title": "Part I: positions, colourings, and the permutation representation",
       "startLine": 57,
       "endLine": 102,
-      "summary": "Models positions as ZMod n and colourings as ZMod n → Fin 2. Defines posPerm sending r i to x↦x+i and sr i to x↦-i-x, proves it sends 1 to 1 and is multiplicative (posPerm_mul, case-by-case against the dihedral table), and bundles it as the homomorphism ρ : DihedralGroup n →* Equiv.Perm (ZMod n). None of this needs NeZero n."
+      "summary": "Models positions as ZMod n and colourings as ZMod n → Fin 2. Defines posPerm sending r i to x↦x+i and sr i to x↦-i-x, proves it sends 1 to 1 and is multiplicative (posPerm_mul, case-by-case against the dihedral table), and bundles it as the homomorphism ρ : DihedralGroup n →* Equiv.Perm (ZMod n). None of this needs NeZero n.",
+      "id": "part-i-positions-colourings-and-the-permutation-representation"
     },
     {
       "title": "Part II: the induced action on colourings",
       "startLine": 104,
       "endLine": 121,
-      "summary": "Defines the MulAction of DihedralGroup n on colourings by (g•c) p = c((ρ g)⁻¹ p), with one_smul/mul_smul derived from ρ being a homomorphism, plus the pointwise unfolding lemma smul_apply used in the fixed-point computations."
+      "summary": "Defines the MulAction of DihedralGroup n on colourings by (g•c) p = c((ρ g)⁻¹ p), with one_smul/mul_smul derived from ρ being a homomorphism, plus the pointwise unfolding lemma smul_apply used in the fixed-point computations.",
+      "id": "part-ii-the-induced-action-on-colourings"
     },
     {
       "title": "Part III: Fintype/decidability infrastructure",
       "startLine": 123,
       "endLine": 151,
-      "summary": "Under NeZero n, registers DecidablePred for fixed-point sets, Fintype for fixedBy, a DecidableRel for the orbit relation, and the Fintype on the orbit quotient (via Quotient.fintype), so the bracelet count braceletCard n = |orbit quotient| is well-defined."
+      "summary": "Under NeZero n, registers DecidablePred for fixed-point sets, Fintype for fixedBy, a DecidableRel for the orbit relation, and the Fintype on the orbit quotient (via Quotient.fintype), so the bracelet count braceletCard n = |orbit quotient| is well-defined.",
+      "id": "part-iii-fintype-decidability-infrastructure"
     },
     {
       "title": "Part IV: the general Burnside bracelet identity",
       "startLine": 153,
       "endLine": 172,
-      "summary": "bracelet_burnside: for every n, Σ_{g∈Dₙ} |Fix(g)| = braceletCard n · (2n), obtained from Mathlib's sum_card_fixedBy_eq_card_orbits_mul_card_group with |Dₙ|=2n substituted via DihedralGroup.card. The reusable orbit-counting engine for the closed form."
+      "summary": "bracelet_burnside: for every n, Σ_{g∈Dₙ} |Fix(g)| = braceletCard n · (2n), obtained from Mathlib's sum_card_fixedBy_eq_card_orbits_mul_card_group with |Dₙ|=2n substituted via DihedralGroup.card. The reusable orbit-counting engine for the closed form.",
+      "id": "part-iv-the-general-burnside-bracelet-identity"
     },
     {
       "title": "Part V: concrete bracelet counts from the general machinery",
       "startLine": 174,
       "endLine": 210,
-      "summary": "Feeds the general identity to n=3,5,6: each fixed-point sum (24, 80, 156) is discharged by kernel decide, and Burnside plus omega yields b(3)=4, b(5)=8, b(6)=13 (OEIS A000029) — axiom-free, no native_decide."
+      "summary": "Feeds the general identity to n=3,5,6: each fixed-point sum (24, 80, 156) is discharged by kernel decide, and Burnside plus omega yields b(3)=4, b(5)=8, b(6)=13 (OEIS A000029) — axiom-free, no native_decide.",
+      "id": "part-v-concrete-bracelet-counts-from-the-general-machinery"
     },
     {
       "title": "Axiom audit",
       "startLine": 212,
       "endLine": 219,
-      "summary": "#print axioms on bracelet_burnside, bracelet_three, bracelet_five, bracelet_six, confirming only the standard foundational axioms — no Lean.ofReduceBool (no native_decide) and no sorryAx."
+      "summary": "#print axioms on bracelet_burnside, bracelet_three, bracelet_five, bracelet_six, confirming only the standard foundational axioms — no Lean.ofReduceBool (no native_decide) and no sorryAx.",
+      "id": "axiom-audit"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/meta.json
@@ -105,25 +105,29 @@
       "title": "Overview, the continuum function, and the helper",
       "startLine": 1,
       "endLine": 43,
-      "summary": "Docstring positioning the file against the parent (CH + König/Easton at 2^{ℵ₀}) and stating Easton's three constraints; imports Mathlib, opens Cardinal/Ordinal, defines contFn α = 2^{ℵ_α}, and proves the helper two_ne_zero_card ((2:Cardinal) ≠ 0) used by the monotonicity lemma."
+      "summary": "Docstring positioning the file against the parent (CH + König/Easton at 2^{ℵ₀}) and stating Easton's three constraints; imports Mathlib, opens Cardinal/Ordinal, defines contFn α = 2^{ℵ_α}, and proves the helper two_ne_zero_card ((2:Cardinal) ≠ 0) used by the monotonicity lemma.",
+      "id": "overview-the-continuum-function-and-the-helper"
     },
     {
       "title": "Monotonicity",
       "startLine": 44,
       "endLine": 49,
-      "summary": "contFn_monotone (monotone in the index, via power_le_power_left and aleph_le_aleph) — only ≤, not strict, between distinct indices."
+      "summary": "contFn_monotone (monotone in the index, via power_le_power_left and aleph_le_aleph) — only ≤, not strict, between distinct indices.",
+      "id": "monotonicity"
     },
     {
       "title": "Cantor and König constraints",
       "startLine": 61,
       "endLine": 73,
-      "summary": "aleph_lt_contFn (Cantor), aleph_lt_cof_contFn (König, generalized, from lt_cof_power), and the classical aleph0_lt_cof_continuum; plus contFn_ne_aleph (no fixed point)."
+      "summary": "aleph_lt_contFn (Cantor), aleph_lt_cof_contFn (König, generalized, from lt_cof_power), and the classical aleph0_lt_cof_continuum; plus contFn_ne_aleph (no fixed point).",
+      "id": "cantor-and-k-nig-constraints"
     },
     {
       "title": "Packaged admissibility constraints",
       "startLine": 75,
       "endLine": 79,
-      "summary": "contFn_constraints: the three Easton constraints (Cantor, König, monotonicity) bundled as the necessary conditions on any consistent continuum pattern."
+      "summary": "contFn_constraints: the three Easton constraints (Cantor, König, monotonicity) bundled as the necessary conditions on any consistent continuum pattern.",
+      "id": "packaged-admissibility-constraints"
     }
   ],
   "sorries": []

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02-oq-01/meta.json
@@ -72,56 +72,56 @@
       "title": "File Header and Overview",
       "startLine": 1,
       "endLine": 56,
-      "content": "Module documentation stating the open question being answered, the five results (club top, binary intersection, finite intersection, the nonstationary ideal, duality), and references (Jech §8 Theorem 8.3, Kunen Ch. II §6). Imports Mathlib and the parent file Proofs.CantorDiagonalizationOQ02OQ03OQ02, reusing its IsClub / IsStationary / IsUnboundedBelow / IsClosedBelow definitions and not_isStationary_iff; opens namespace FodorLemma with Cardinal Order Ordinal Set."
+      "summary": "Module documentation stating the open question being answered, the five results (club top, binary intersection, finite intersection, the nonstationary ideal, duality), and references (Jech §8 Theorem 8.3, Kunen Ch. II §6). Imports Mathlib and the parent file Proofs.CantorDiagonalizationOQ02OQ03OQ02, reusing its IsClub / IsStationary / IsUnboundedBelow / IsClosedBelow definitions and not_isStationary_iff; opens namespace FodorLemma with Cardinal Order Ordinal Set."
     },
     {
       "id": "club-univ",
       "title": "§1. The Whole Space is a Club",
       "startLine": 57,
       "endLine": 72,
-      "content": "isClub_univ: Set.univ is a club. Closed trivially; unbounded because κ.ord is a successor-limit (isSuccLimit_ord from κ ≥ ℵ₀), so α ↦ α+1 stays below κ.ord. This is the top element of the club filter."
+      "summary": "isClub_univ: Set.univ is a club. Closed trivially; unbounded because κ.ord is a successor-limit (isSuccLimit_ord from κ ≥ ℵ₀), so α ↦ α+1 stays below κ.ord. This is the top element of the club filter."
     },
     {
       "id": "inter-closed",
       "title": "§2. Intersection of Two Clubs is Closed",
       "startLine": 73,
       "endLine": 90,
-      "content": "inter_isClosedBelow: the easy half. A point cofinal in C ∩ D is cofinal in C and in D separately, so closedness of each factor places it in both."
+      "summary": "inter_isClosedBelow: the easy half. A point cofinal in C ∩ D is cofinal in C and in D separately, so closedness of each factor places it in both."
     },
     {
       "id": "inter-unbounded",
       "title": "§3. Intersection of Two Clubs is Unbounded",
       "startLine": 91,
       "endLine": 160,
-      "content": "inter_isUnbounded: the genuine content. From α₀ the proof builds a single increasing ω-chain via Choice: cElt steps into C above the current point, dElt steps into D above that c; the recursion seq carries the proof that each term is < κ.ord. The supremum γ = ⨆ s is < κ.ord by iSup_lt_ord_lift_of_isRegular. The cElt-values are cofinal in γ giving γ ∈ C (closedness of C), and the s(n+1) = dElt-values are cofinal in γ giving γ ∈ D, so γ ∈ C ∩ D lies above α₀."
+      "summary": "inter_isUnbounded: the genuine content. From α₀ the proof builds a single increasing ω-chain via Choice: cElt steps into C above the current point, dElt steps into D above that c; the recursion seq carries the proof that each term is < κ.ord. The supremum γ = ⨆ s is < κ.ord by iSup_lt_ord_lift_of_isRegular. The cElt-values are cofinal in γ giving γ ∈ C (closedness of C), and the s(n+1) = dElt-values are cofinal in γ giving γ ∈ D, so γ ∈ C ∩ D lies above α₀."
     },
     {
       "id": "inter-club",
       "title": "§3 (cont). Binary Intersection is a Club",
       "startLine": 161,
       "endLine": 166,
-      "content": "inter_isClub: combines the closed and unbounded halves — the club filter is closed under binary intersection."
+      "summary": "inter_isClub: combines the closed and unbounded halves — the club filter is closed under binary intersection."
     },
     {
       "id": "finite-inter",
       "title": "§4. Finite Intersection of Clubs is a Club",
       "startLine": 167,
       "endLine": 186,
-      "content": "isClub_biInter: by Finset induction, ⋂ i ∈ t, C i is a club. Empty case is isClub_univ; the insert case rewrites via Finset.set_biInter_insert and applies inter_isClub. This is the defining filter-closure property."
+      "summary": "isClub_biInter: by Finset induction, ⋂ i ∈ t, C i is a club. Empty case is isClub_univ; the insert case rewrites via Finset.set_biInter_insert and applies inter_isClub. This is the defining filter-closure property."
     },
     {
       "id": "ns-ideal",
       "title": "§5. The Nonstationary Ideal and Duality",
       "startLine": 187,
       "endLine": 247,
-      "content": "IsNonStationary κ S := ∃ club C disjoint from S (the dual ideal NS(κ)). isStationary_iff_not_isNonStationary: stationary ⟺ not nonstationary (via not_isStationary_iff). isNonStationary_subset (downward closed), isNonStationary_union (closed under ∪, using inter_isClub on the two avoiding clubs), isNonStationary_empty (∅ ∈ NS), and isStationary_univ (the whole space is stationary, so Club(κ) is proper)."
+      "summary": "IsNonStationary κ S := ∃ club C disjoint from S (the dual ideal NS(κ)). isStationary_iff_not_isNonStationary: stationary ⟺ not nonstationary (via not_isStationary_iff). isNonStationary_subset (downward closed), isNonStationary_union (closed under ∪, using inter_isClub on the two avoiding clubs), isNonStationary_empty (∅ ∈ NS), and isStationary_univ (the whole space is stationary, so Club(κ) is proper)."
     },
     {
       "id": "implications",
       "title": "§6. Implications and Mathematical Notes",
       "startLine": 1,
       "endLine": 247,
-      "content": "The finite filter/ideal theory underpins the σ-complete (indeed κ-complete) club filter. The binary intersection theorem is the base case of the κ-indexed diagonal-intersection theorem the parent used for Fodor's lemma; closure of NS(κ) under finite unions is the dual statement. Natural next steps: κ-completeness of the club filter (countable / <κ intersections), the normality of NS(κ) via the diagonal intersection, and Solovay's stationary-set splitting."
+      "summary": "The finite filter/ideal theory underpins the σ-complete (indeed κ-complete) club filter. The binary intersection theorem is the base case of the κ-indexed diagonal-intersection theorem the parent used for Fodor's lemma; closure of NS(κ) under finite unions is the dual statement. Natural next steps: κ-completeness of the club filter (countable / <κ intersections), the normality of NS(κ) via the diagonal intersection, and Solovay's stationary-set splitting."
     }
   ],
   "references": [

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -124,63 +124,63 @@
       "title": "File Header and Overview",
       "startLine": 1,
       "endLine": 50,
-      "content": "Module documentation explaining Fodor's lemma, its place in set theory, and the proof architecture (§1-6). Lists key techniques (Ordinal.bsup, iSup_lt_ord_lift_of_isRegular, IsSuccLimit) and references (Fodor 1956, Jech). Imports SetTheory.Cardinal.Cofinality/Regular, SetTheory.Ordinal.Arithmetic/Topology, and Mathlib.Tactic; opens namespace FodorLemma with Cardinal Order Ordinal Set."
+      "summary": "Module documentation explaining Fodor's lemma, its place in set theory, and the proof architecture (§1-6). Lists key techniques (Ordinal.bsup, iSup_lt_ord_lift_of_isRegular, IsSuccLimit) and references (Fodor 1956, Jech). Imports SetTheory.Cardinal.Cofinality/Regular, SetTheory.Ordinal.Arithmetic/Topology, and Mathlib.Tactic; opens namespace FodorLemma with Cardinal Order Ordinal Set."
     },
     {
       "id": "club-sets",
       "title": "§1. Club Sets",
       "startLine": 52,
       "endLine": 72,
-      "content": "Definitions of IsUnboundedBelow (cofinal in κ.ord), IsClosedBelow (contains all limit points below κ.ord), and IsClub (closed unbounded) for ordinals below κ.ord."
+      "summary": "Definitions of IsUnboundedBelow (cofinal in κ.ord), IsClosedBelow (contains all limit points below κ.ord), and IsClub (closed unbounded) for ordinals below κ.ord."
     },
     {
       "id": "stationary-sets",
       "title": "§2. Stationary Sets",
       "startLine": 74,
       "endLine": 93,
-      "content": "IsStationary: a set S that intersects every club. not_isStationary_iff: S is non-stationary iff some club avoids S entirely."
+      "summary": "IsStationary: a set S that intersects every club. not_isStationary_iff: S is non-stationary iff some club avoids S entirely."
     },
     {
       "id": "diagonal-intersection",
       "title": "§3. Diagonal Intersection",
       "startLine": 95,
       "endLine": 112,
-      "content": "diagInter f = {α | ∀ β < α, α ∈ f β}, the key diagonalization tool that makes Fodor's lemma work, plus the @[simp] membership characterization mem_diagInter."
+      "summary": "diagInter f = {α | ∀ β < α, α ∈ f β}, the key diagonalization tool that makes Fodor's lemma work, plus the @[simp] membership characterization mem_diagInter."
     },
     {
       "id": "closed-part",
       "title": "§4. Diagonal Intersection is Closed (PROVED)",
       "startLine": 114,
       "endLine": 147,
-      "content": "diagInter_isClosedBelow: if every f(β) is a club, then diagInter f satisfies the closed condition. Proof uses cofinality of diagInter f in a limit ordinal γ to show each f(β) is cofinal in γ, then applies the closed condition of f(β)."
+      "summary": "diagInter_isClosedBelow: if every f(β) is a club, then diagInter f satisfies the closed condition. Proof uses cofinality of diagInter f in a limit ordinal γ to show each f(β) is cofinal in γ, then applies the closed condition of f(β)."
     },
     {
       "id": "unbounded-part",
       "title": "§5. Diagonal Intersection is Unbounded (PROVED)",
       "startLine": 149,
       "endLine": 244,
-      "content": "diagInter_isUnbounded: if every f(β) is a club, then diagInter f is unbounded below κ.ord. PROVED: builds an ω-sequence using regularity of κ via a bump operator (bsup over β < δ+1), takes the sup (< κ.ord by iSup_lt_ord_lift_of_isRegular), and shows the sup lies in the diagonal intersection."
+      "summary": "diagInter_isUnbounded: if every f(β) is a club, then diagInter f is unbounded below κ.ord. PROVED: builds an ω-sequence using regularity of κ via a bump operator (bsup over β < δ+1), takes the sup (< κ.ord by iSup_lt_ord_lift_of_isRegular), and shows the sup lies in the diagonal intersection."
     },
     {
       "id": "diaginter-isclub",
       "title": "§6. Diagonal Intersection of Clubs is a Club",
       "startLine": 246,
       "endLine": 256,
-      "content": "diagInter_isClub: for a regular uncountable κ, the diagonal intersection of a κ-indexed family of clubs is itself a club, combining the proved closed part (§4) with the proved unbounded part (§5)."
+      "summary": "diagInter_isClub: for a regular uncountable κ, the diagonal intersection of a κ-indexed family of clubs is itself a club, combining the proved closed part (§4) with the proved unbounded part (§5)."
     },
     {
       "id": "fodors-lemma",
       "title": "§7. Fodor's Pressing-Down Lemma (PROVED)",
       "startLine": 258,
       "endLine": 331,
-      "content": "fodors_pressing_down: the main theorem. Proved by contradiction: assume no fiber is stationary, use Classical.choose to build a club family avoiding each preimage, form the diagonal intersection D (a club by §6), intersect with stationary S, take α ∈ S ∩ D, derive a contradiction from f(α) < α and α ∈ C_{f(α)}."
+      "summary": "fodors_pressing_down: the main theorem. Proved by contradiction: assume no fiber is stationary, use Classical.choose to build a club family avoiding each preimage, form the diagonal intersection D (a club by §6), intersect with stationary S, take α ∈ S ∩ D, derive a contradiction from f(α) < α and α ∈ C_{f(α)}."
     },
     {
       "id": "implications",
       "title": "§8. Implications and Mathematical Notes",
       "startLine": 333,
       "endLine": 382,
-      "content": "Docstring on consequences: the club filter is not principal, stationary sets cannot be covered by fewer than κ non-stationary sets, the connection to the parent proof (regular_sup_bounded), and future work (isClub_inter, the club filter / stationary ideal). Closes with #check type-checks of the main results."
+      "summary": "Docstring on consequences: the club filter is not principal, stationary sets cannot be covered by fewer than κ non-stationary sets, the connection to the parent proof (regular_sup_bounded), and future work (isClub_inter, the club filter / stationary ideal). Closes with #check type-checks of the main results."
     }
   ],
   "sorries": 0

--- a/src/data/proofs/cantor-diagonalization/annotations.json
+++ b/src/data/proofs/cantor-diagonalization/annotations.json
@@ -56,7 +56,7 @@
       "startLine": 55,
       "endLine": 62
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Diagonal Differs at Each Position",
     "content": "The key lemma: our constructed diagonal sequence differs from $f(n)$ specifically at position $n$.\n\nSince `diagonal f n = !(f n n)`, we have `diagonal f n != f n n` by the fact that `!b != b` for any boolean.\n\nThis one-line observation is the heart of the proof.",
     "mathContext": "The Lean proof: `unfold diagonal` replaces `diagonal f n` with `!(f n n)`, then `cases f n n <;> simp` performs case analysis on both `Bool.true` and `Bool.false`. In each case `simp` discharges the goal: `!true ≠ true` becomes `false ≠ true` (true by `Bool.false_ne_true`), and `!false ≠ false` becomes `true ≠ false` (true by `Bool.true_ne_false`). The `<;>` combinator applies `simp` to both cases simultaneously. This lemma encapsulates the one-line core of Cantor's argument: $\\lnot b \\neq b$ for any $b \\in \\{0, 1\\}$, which holds because boolean negation is a fixed-point-free involution.",
@@ -128,7 +128,7 @@
       "startLine": 66,
       "endLine": 86
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Constructing the Witness",
     "content": "We exhibit the diagonal sequence as our witness. The `use` tactic provides this existential witness.\n\nNow we must prove this sequence differs from every $f(n)$.",
     "mathContext": "The `use diagonal f` tactic in Lean 4 discharges the `∃ s : BinarySeq, ...` goal by substituting `s := diagonal f`, leaving the goal `∀ n : ℕ, f n ≠ diagonal f`. This is a *constructive* witness — the diagonal sequence is given explicitly as `fun n => !(f n n)`. Classical logic would allow a non-constructive existence proof (by excluded middle, assuming no such sequence and deriving a contradiction), but this proof constructs the witness directly. The `use` tactic corresponds to the existential introduction rule: from `P(t)`, conclude `∃ x, P(x)`.",
@@ -152,7 +152,7 @@
       "startLine": 88,
       "endLine": 98
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Deriving the Contradiction",
     "content": "Suppose for contradiction that $f(n) = \\text{diagonal}(f)$ for some $n$.\n\nThen at position $n$: $f(n)(n) = \\text{diagonal}(f)(n)$.\n\nBut $\\text{diagonal}(f)(n) = \\neg f(n)(n)$ by definition.\n\nSo $f(n)(n) = \\neg f(n)(n)$, which is impossible for any boolean.\n\nContradiction! Therefore $f(n) \\neq \\text{diagonal}(f)$ for all $n$.",
     "mathContext": "In `no_surjection_nat_to_binary`: `intro ⟨f, hf⟩` destructs the assumed surjection; `obtain ⟨s, hs⟩ := cantor_diagonalization f` gives the diagonal sequence not in range; `obtain ⟨n, hn⟩ := hf s` uses surjectivity to find $n$ with $f(n) = s$; `exact hs n hn` applies `hs : ∀ n, f n ≠ s` to `hn : f n = s`, deriving `False` from `f n ≠ s` and `f n = s`. The key tactic pattern is `exact hs n hn`: `hs n : f n ≠ s` is a function `f n = s → False`, and `hn : f n = s` is the input. The `exact` tactic applies the former to the latter. This is a 4-line proof that neatly separates concerns: Cantor proves non-surjectivity for any enumeration; this theorem packages it as '¬∃ surjection'.",
@@ -201,7 +201,7 @@
       "startLine": 102,
       "endLine": 107
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Proof of Uncountability",
     "content": "Assume for contradiction that some surjective $f$ exists.\n\nBy Cantor's theorem, there exists $s$ with $f(n) \\neq s$ for all $n$.\n\nBut surjectivity says every $s$ equals some $f(n)$.\n\nThese contradict: $s = f(n)$ but also $f(n) \\neq s$.",
     "mathContext": "`reals_uncountable` is a one-line alias: `no_surjection_nat_to_binary`. Its docstring explains the informal bridge: binary sequences $(b_n) \\in \\{0,1\\}^{\\mathbb{N}}$ map to reals via $\\sum b_n/2^{n+1} \\in [0,1]$, and $|[0,1]| = |\\mathbb{R}|$. But the Lean type is `¬∃ f : ℕ → BinarySeq, Function.Surjective f` — not a statement about $\\mathbb{R}$. The peer review (ai-3) flagged this equivocation; as a resolution, the theorem's name signals the *informal* interpretation while the type gives the *formal* content. This honest naming pattern is common in proof galleries: the formal statement is technically narrower than its name suggests.",

--- a/src/data/proofs/cantors-theorem/annotations.json
+++ b/src/data/proofs/cantors-theorem/annotations.json
@@ -100,7 +100,7 @@
       "startLine": 96,
       "endLine": 96
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "The Self-Reference Paradox",
     "content": "The **diagonal paradox** is the heart of the argument:\n\nIf f(b) = D where D = {x | x not in f(x)}, then:\n$$b \\in D \\iff b \\notin D$$\n\nThis is a **self-referential contradiction** - b's membership in D depends on whether b is in D.\n\nThis paradox is closely related to:\n- **Russell's Paradox**: Consider R = {x | x not in x}. Is R in R?\n- **The Liar Paradox**: 'This statement is false'\n- **Godel's Incompleteness**: Self-referential sentences about provability\n\nIn type theory, we avoid Russell's paradox by stratifying types into universes.",
     "mathContext": "$b \\in D \\iff b \\notin D$",

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/meta.json
@@ -100,16 +100,25 @@
   },
   "sections": [
     {
-      "title": "The Coordinate Isometry",
-      "content": "The natural basis vectors e_{j.succAbove i} of the coordinate hyperplane are orthonormal (orthonormal_hyperplaneBasis) and span it (span_hyperplaneBasis_top), so OrthonormalBasis.mk assembles them into coordBasis : OrthonormalBasis (Fin n) 𝕜 H. Its inverse representation coordEquiv := coordBasis.repr.symm is the linear isometry equivalence EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H sending the standard basis vector e_i to e_{j.succAbove i}; reading any coordinate of an image against the basis returns the input coordinate (coordBasis_inner_coordEquiv)."
-    },
-    {
-      "title": "The Intertwining: Compression Is the Submatrix Operator",
-      "content": "On a single coordinate vector, coordBasis.repr.injective reduces the intertwining to one submodule inner product, evaluated by the previous entry's compress_inner_eq_principalSubmatrix as an entry of the principal submatrix (compress_coordBasis). Expanding a general x in the standard basis and pushing compress, toEuclideanLin A' and coordEquiv through the sum with map_sum/map_smul yields the full intertwining compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin A' x) (compress_intertwine)."
-    },
-    {
+      "id": "the-transfer-engine-and-the-eigenvalue-corollary",
       "title": "The Transfer Engine and the Eigenvalue Corollary",
-      "content": "interlacing_of_intertwine is a reusable abstract theorem: an isometric intertwining of the compression with a symmetric operator T' transports T''s antitone eigenbasis onto an eigenbasis of the compression with the same eigenvalues, which — with the orthogonal compression's Rayleigh agreement — feeds the gallery's abstract cauchy_interlacing. Instantiating it with the coordinate isometry yields the operator form principalSubmatrix_eigenvalues_interlacing; the bookkeeping lemma eigenvalues_finrank_congr then re-expresses it in Mathlib's Matrix.IsHermitian.eigenvalues₀ indexing as eigenvalues₀_principalSubmatrix_interlacing: λ_{k+1} ≤ μ_k ≤ λ_k."
+      "startLine": 74,
+      "endLine": 110,
+      "summary": "interlacing_of_intertwine is a reusable abstract theorem: an isometric intertwining of the compression with a symmetric operator T' transports T''s antitone eigenbasis onto an eigenbasis of the compression with the same eigenvalues, which — with the orthogonal compression's Rayleigh agreement — feeds the gallery's abstract cauchy_interlacing. Instantiating it with the coordinate isometry yields the operator form principalSubmatrix_eigenvalues_interlacing; the bookkeeping lemma eigenvalues_finrank_congr then re-expresses it in Mathlib's Matrix.IsHermitian.eigenvalues₀ indexing as eigenvalues₀_principalSubmatrix_interlacing: λ_{k+1} ≤ μ_k ≤ λ_k."
+    },
+    {
+      "id": "the-coordinate-isometry",
+      "title": "The Coordinate Isometry",
+      "startLine": 111,
+      "endLine": 164,
+      "summary": "The natural basis vectors e_{j.succAbove i} of the coordinate hyperplane are orthonormal (orthonormal_hyperplaneBasis) and span it (span_hyperplaneBasis_top), so OrthonormalBasis.mk assembles them into coordBasis : OrthonormalBasis (Fin n) 𝕜 H. Its inverse representation coordEquiv := coordBasis.repr.symm is the linear isometry equivalence EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H sending the standard basis vector e_i to e_{j.succAbove i}; reading any coordinate of an image against the basis returns the input coordinate (coordBasis_inner_coordEquiv)."
+    },
+    {
+      "id": "the-intertwining-compression-is-the-submatrix-operator",
+      "title": "The Intertwining: Compression Is the Submatrix Operator",
+      "startLine": 165,
+      "endLine": 294,
+      "summary": "On a single coordinate vector, coordBasis.repr.injective reduces the intertwining to one submodule inner product, evaluated by the previous entry's compress_inner_eq_principalSubmatrix as an entry of the principal submatrix (compress_coordBasis). Expanding a general x in the standard basis and pushing compress, toEuclideanLin A' and coordEquiv through the sum with map_sum/map_smul yields the full intertwining compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin A' x) (compress_intertwine)."
     }
   ],
   "references": [

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
@@ -89,16 +89,25 @@
   },
   "sections": [
     {
+      "id": "the-ky-fan-sum-bounds-over-an-arbitrary-index-set",
       "title": "The Ky Fan Sum Bounds over an Arbitrary Index Set",
-      "content": "sum_mu_le_sum_top_lam and sum_bot_lam_le_sum_mu apply Finset.sum_le_sum to the two halves of the parent's Poincaré separation theorem. For any s : Finset (Fin n), the upper half μ_k ≤ λ_⟨k⟩ sums to ∑_{k∈s} μ_k ≤ ∑_{k∈s} λ_⟨k⟩, and the lower half λ_⟨k+m⟩ ≤ μ_k sums to ∑_{k∈s} λ_⟨k+m⟩ ≤ ∑_{k∈s} μ_k. Leaving s free is the design choice that makes every later corollary a specialisation."
+      "startLine": 1,
+      "endLine": 77,
+      "summary": "sum_mu_le_sum_top_lam and sum_bot_lam_le_sum_mu apply Finset.sum_le_sum to the two halves of the parent's Poincaré separation theorem. For any s : Finset (Fin n), the upper half μ_k ≤ λ_⟨k⟩ sums to ∑_{k∈s} μ_k ≤ ∑_{k∈s} λ_⟨k⟩, and the lower half λ_⟨k+m⟩ ≤ μ_k sums to ∑_{k∈s} λ_⟨k+m⟩ ≤ ∑_{k∈s} μ_k. Leaving s free is the design choice that makes every later corollary a specialisation."
     },
     {
+      "id": "weak-majorization-top-j-partial-sums",
       "title": "Weak Majorization: Top-j Partial Sums",
-      "content": "partial_sum_mu_le_partial_sum_lam specialises s to the initial segment {k : Fin n | (k : ℕ) < j}, giving ∑_{k<j} μ_k ≤ ∑_{k<j} λ_k for every j : ℕ. This is the Ky Fan weak-majorization statement: the descending spectrum of the compression is weakly majorized by the largest eigenvalues of the full operator."
+      "startLine": 78,
+      "endLine": 92,
+      "summary": "partial_sum_mu_le_partial_sum_lam specialises s to the initial segment {k : Fin n | (k : ℕ) < j}, giving ∑_{k<j} μ_k ≤ ∑_{k<j} λ_k for every j : ℕ. This is the Ky Fan weak-majorization statement: the descending spectrum of the compression is weakly majorized by the largest eigenvalues of the full operator."
     },
     {
+      "id": "trace-trapping",
       "title": "Trace Trapping",
-      "content": "trace_compress_le and trace_compress_ge specialise s to Finset.univ: the trace of the compression (the sum of all n of its eigenvalues) is at most the sum of the n largest eigenvalues of T and at least the sum of the n smallest (those with index m … n+m-1). trace_interlacing bundles the two as ∑_{j=m}^{n+m-1} λ_j ≤ ∑_k μ_k ≤ ∑_{j=0}^{n-1} λ_j."
+      "startLine": 93,
+      "endLine": 116,
+      "summary": "trace_compress_le and trace_compress_ge specialise s to Finset.univ: the trace of the compression (the sum of all n of its eigenvalues) is at most the sum of the n largest eigenvalues of T and at least the sum of the n smallest (those with index m … n+m-1). trace_interlacing bundles the two as ∑_{j=m}^{n+m-1} λ_j ≤ ∑_k μ_k ≤ ∑_{j=0}^{n-1} λ_j."
     }
   ],
   "references": [

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -118,16 +118,25 @@
   },
   "sections": [
     {
+      "id": "the-doubly-stochastic-change-of-basis-matrix",
       "title": "The Doubly Stochastic Change-of-Basis Matrix",
-      "content": "dsWeight defines D i j = ‖⟪v j, e i⟫‖², the squared moduli of the inner products between the orthonormal eigenbasis v of T and the chosen orthonormal basis e. dsWeight_nonneg is sq_nonneg. dsWeight_row_sum and dsWeight_col_sum prove ∑ j, D i j = 1 and ∑ i, D i j = 1 by Parseval — OrthonormalBasis.sum_sq_norm_inner_right for v (rows, giving ‖e i‖² = 1) and sum_sq_norm_inner_left for e (columns, giving ‖v j‖² = 1) — so D is doubly stochastic."
+      "startLine": 1,
+      "endLine": 93,
+      "summary": "dsWeight defines D i j = ‖⟪v j, e i⟫‖², the squared moduli of the inner products between the orthonormal eigenbasis v of T and the chosen orthonormal basis e. dsWeight_nonneg is sq_nonneg. dsWeight_row_sum and dsWeight_col_sum prove ∑ j, D i j = 1 and ∑ i, D i j = 1 by Parseval — OrthonormalBasis.sum_sq_norm_inner_right for v (rows, giving ‖e i‖² = 1) and sum_sq_norm_inner_left for e (columns, giving ‖v j‖² = 1) — so D is doubly stochastic."
     },
     {
+      "id": "diagonal-as-doubly-stochastic-image-of-the-spectrum",
       "title": "Diagonal as Doubly-Stochastic Image of the Spectrum",
-      "content": "diag_decomp proves re ⟪T (e i), e i⟫ = ∑ⱼ λⱼ · D i j. Expand ⟪T(e i), e i⟫ = ∑ⱼ ⟪T(e i), v j⟫⟪v j, e i⟫ by OrthonormalBasis.sum_inner_mul_inner. Each cross term is rewritten using eigenvectorBasis_apply_self_apply (⟪v j, T(e i)⟫ = (λ j)·⟪v j, e i⟫), inner_conj_symm, RCLike.conj_ofReal (the eigenvalue is real, so its conjugate is itself), and RCLike.conj_mul (conj z · z = ‖z‖²), giving (λ j)·‖⟪v j, e i⟫‖² = (λ j)·D i j; taking real parts term by term yields the claim. This exhibits each diagonal entry as a convex combination of eigenvalues."
+      "startLine": 94,
+      "endLine": 128,
+      "summary": "diag_decomp proves re ⟪T (e i), e i⟫ = ∑ⱼ λⱼ · D i j. Expand ⟪T(e i), e i⟫ = ∑ⱼ ⟪T(e i), v j⟫⟪v j, e i⟫ by OrthonormalBasis.sum_inner_mul_inner. Each cross term is rewritten using eigenvectorBasis_apply_self_apply (⟪v j, T(e i)⟫ = (λ j)·⟪v j, e i⟫), inner_conj_symm, RCLike.conj_ofReal (the eigenvalue is real, so its conjugate is itself), and RCLike.conj_mul (conj z · z = ‖z‖²), giving (λ j)·‖⟪v j, e i⟫‖² = (λ j)·D i j; taking real parts term by term yields the claim. This exhibits each diagonal entry as a convex combination of eigenvalues."
     },
     {
+      "id": "majorization-by-jensen-and-specializations",
       "title": "Majorization by Jensen, and Specializations",
-      "content": "schur_majorization_convexOn: for convex φ on s ⊇ spectrum, ConvexOn.map_sum_le applied with weights D i j (nonnegative, summing to 1 by the row sums) and points λ j ∈ s gives φ(d i) ≤ ∑ⱼ D i j • φ(λ j); summing over i, swapping the order (Finset.sum_comm), and collapsing each column with ∑ᵢ D i j = 1 (Finset.sum_smul, one_smul) yields ∑ᵢ φ(d i) ≤ ∑ⱼ φ(λ j). schur_trace_eq specializes to the equality case ∑ d i = ∑ λ j directly from diag_decomp and the column sums (no convexity), and schur_sum_sq_le applies the master theorem with φ = (·)² (Even.convexOn_pow at n=2) to bound ∑ d i² ≤ ∑ λ j²."
+      "startLine": 129,
+      "endLine": 178,
+      "summary": "schur_majorization_convexOn: for convex φ on s ⊇ spectrum, ConvexOn.map_sum_le applied with weights D i j (nonnegative, summing to 1 by the row sums) and points λ j ∈ s gives φ(d i) ≤ ∑ⱼ D i j • φ(λ j); summing over i, swapping the order (Finset.sum_comm), and collapsing each column with ∑ᵢ D i j = 1 (Finset.sum_smul, one_smul) yields ∑ᵢ φ(d i) ≤ ∑ⱼ φ(λ j). schur_trace_eq specializes to the equality case ∑ d i = ∑ λ j directly from diag_decomp and the column sums (no convexity), and schur_sum_sq_le applies the master theorem with φ = (·)² (Even.convexOn_pow at n=2) to bound ∑ d i² ≤ ∑ λ j²."
     }
   ],
   "references": [

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/meta.json
@@ -105,16 +105,25 @@
   },
   "sections": [
     {
+      "id": "positivity-of-compressions-operator-form",
       "title": "Positivity of Compressions (Operator Form)",
-      "content": "compress_isPositive proves that for a positive operator T (Mathlib's LinearMap.IsPositive: symmetric with re ⟪T x, x⟫ ≥ 0 for all x) and any subspace H, the orthogonal compression compress T H is again positive. Symmetry comes from isSymmetric_compress applied to hT.isSymmetric. For the Rayleigh nonnegativity, the inner product ⟪compress T H y, y⟫_H rewrites to ⟪T ↑y, ↑y⟫_V via compress_apply and the orthogonal-projection adjoint identity Submodule.inner_orthogonalProjection_eq_of_mem_right, so 0 ≤ re ⟪T ↑y, ↑y⟫ (from hT) finishes. No eigenvalues, no spectral theorem, and the subspace H is arbitrary."
+      "startLine": 1,
+      "endLine": 93,
+      "summary": "compress_isPositive proves that for a positive operator T (Mathlib's LinearMap.IsPositive: symmetric with re ⟪T x, x⟫ ≥ 0 for all x) and any subspace H, the orthogonal compression compress T H is again positive. Symmetry comes from isSymmetric_compress applied to hT.isSymmetric. For the Rayleigh nonnegativity, the inner product ⟪compress T H y, y⟫_H rewrites to ⟪T ↑y, ↑y⟫_V via compress_apply and the orthogonal-projection adjoint identity Submodule.inner_orthogonalProjection_eq_of_mem_right, so 0 ≤ re ⟪T ↑y, ↑y⟫ (from hT) finishes. No eigenvalues, no spectral theorem, and the subspace H is arbitrary."
     },
     {
+      "id": "nonnegative-eigenvalues-and-trace",
       "title": "Nonnegative Eigenvalues and Trace",
-      "content": "compress_eigenvalues_nonneg reads the eigenvalue form of positivity off the Poincaré lower bound: if every eigenvalue λ i of T is nonnegative, then for each k the chain 0 ≤ λ_{k+m} ≤ μ_k gives 0 ≤ μ_k. trace_compress_nonneg then lifts this through Finset.sum_nonneg to conclude the trace ∑_k μ_k of a PSD compression is nonnegative — the eigenvalue-side companion of trace nonnegativity for positive operators."
+      "startLine": 94,
+      "endLine": 102,
+      "summary": "compress_eigenvalues_nonneg reads the eigenvalue form of positivity off the Poincaré lower bound: if every eigenvalue λ i of T is nonnegative, then for each k the chain 0 ≤ λ_{k+m} ≤ μ_k gives 0 ≤ μ_k. trace_compress_nonneg then lifts this through Finset.sum_nonneg to conclude the trace ∑_k μ_k of a PSD compression is nonnegative — the eigenvalue-side companion of trace nonnegativity for positive operators."
     },
     {
+      "id": "spectral-range-containment",
       "title": "Spectral-Range Containment",
-      "content": "compress_eigenvalue_mem_Icc sandwiches every compression eigenvalue inside the spectral range of T: μ_k ∈ [λ_{n+m-1}, λ_0] = [λ_min, λ_max]. The lower endpoint comes from λ_{n+m-1} ≤ λ_{k+m} ≤ μ_k and the upper from μ_k ≤ λ_k ≤ λ_0, each endpoint comparison supplied by antitonicity of λ on the Fin indices and the matching Poincaré bound. This is the uniform two-sided statement that the compression spectrum never escapes the full spectrum's range."
+      "startLine": 103,
+      "endLine": 130,
+      "summary": "compress_eigenvalue_mem_Icc sandwiches every compression eigenvalue inside the spectral range of T: μ_k ∈ [λ_{n+m-1}, λ_0] = [λ_min, λ_max]. The lower endpoint comes from λ_{n+m-1} ≤ λ_{k+m} ≤ μ_k and the upper from μ_k ≤ λ_k ≤ λ_0, each endpoint comparison supplied by antitonicity of λ on the Fin indices and the matching Poincaré bound. This is the uniform two-sided statement that the compression spectrum never escapes the full spectrum's range."
     }
   ],
   "references": [

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
@@ -5,34 +5,32 @@
   "description": "Formalizes Parseval's identity — ∑|ĉₙ(f)|² = ∫|f|²dμ — as a consequence of the L² structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness (Bessel's inequality is equality in total), Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L² convergence of Fourier series, and completeness (zero-kernel). 10 theorems, 0 sorries.",
   "references": [
     {
-      "authors": "Marc-Antoine Parseval",
-      "title": "Mémoire sur les séries et sur l'intégration complète d'une équation aux différences partielles linéaires du second ordre",
+      "authors": "M.-A. Parseval",
+      "title": "Mémoire sur les séries et sur l'intégration complète d'une équation aux différences partielles linéaires du second ordre, à coefficients constants",
       "year": 1806,
-      "note": "The energy identity ∑|ĉₙ|² = ∫|f|² for Fourier coefficients, formalized in this entry."
+      "venue": "Mém. prés. par divers savants, Acad. des Sciences",
+      "note": "Original statement of the energy identity."
     },
     {
-      "authors": "Friedrich Wilhelm Bessel",
-      "title": "Bessel's inequality (as developed in Fourier theory)",
-      "year": 1828,
-      "note": "The one-sided bound ∑|ĉₙ|² ≤ ∫|f|² that becomes equality (Parseval) on a complete orthonormal system."
-    },
-    {
-      "authors": "Walter Rudin",
-      "title": "Real and Complex Analysis (3rd ed.)",
-      "year": 1987,
-      "note": "McGraw-Hill. L² Fourier theory, orthonormal bases, and the Riesz–Fischer completeness behind Parseval."
-    },
-    {
-      "authors": "Elias M. Stein and Rami Shakarchi",
+      "authors": "E. M. Stein, R. Shakarchi",
       "title": "Fourier Analysis: An Introduction",
       "year": 2003,
-      "note": "Princeton University Press. Parseval's identity and mean-square convergence of Fourier series."
+      "venue": "Princeton University Press",
+      "note": "Parseval/Bessel theory for Fourier series in the L² setting."
+    },
+    {
+      "authors": "W. Rudin",
+      "title": "Real and Complex Analysis",
+      "year": 1987,
+      "venue": "McGraw-Hill",
+      "note": "Hilbert-space Parseval identity and orthonormal bases."
     },
     {
       "authors": "The mathlib Community",
-      "title": "Mathlib4: Mathlib.Analysis.InnerProductSpace.l2Space (Orthonormal, HilbertBasis)",
-      "year": 2024,
-      "note": "The L² inner-product structure and orthonormality used to state Parseval and Bessel tightness."
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides the RCLike inner-product-space API (norm_inner_le_norm, inner_self_eq_norm_sq_to_K) underlying this formalization."
     }
   ],
   "meta": {
@@ -116,62 +114,37 @@
       "startLine": 1,
       "endLine": 52,
       "summary": "Imports Fourier analysis, inner product spaces, L² spaces, and l² sequence spaces from Mathlib. Documentation header describes the conceptual chain: CauchySchwarzOQ02's Pythagorean theorem + Fourier orthonormality -> Parseval's identity as 'energy conservation' of Fourier analysis. Lists all 10 main results including parseval_energy, fourier_completeness_L2, and fourier_pythagorean_partial.",
-      "mathContext": "Conceptual chain: $\\text{Pythagorean}_{L^2} + \\langle e_n, e_m \\rangle = \\delta_{nm} \\Rightarrow \\|\\sum c_i e_i\\|^2 = \\sum |c_i|^2 \\xrightarrow{\\text{limit}} \\sum_{n \\in \\mathbb{Z}} |\\hat{c}_n(f)|^2 = \\|f\\|^2_{L^2}$"
+      "mathContext": "Conceptual chain: $\\text{Pythagorean}_{L^2} + \\langle e_n, e_m \\rangle = \\delta_{nm} \\Rightarrow \\|\\sum c_i e_i\\|^2 = \\sum |c_i|^2 \\xrightarrow{\\text{limit}} \\sum_{n \\in \\mathbb{Z}} |\\hat{c}_n(f)|^2 = \\|f\\|^2_{L^2}$",
+      "id": "module-header-parseval-from-l-structure"
     },
     {
       "title": "Part I: Parseval's Identity (Energy Equality)",
       "startLine": 53,
       "endLine": 95,
-      "summary": "parseval_energy (tsum_sq_fourierCoeff wrapper), parseval_hassum (hasSum_sq_fourierCoeff wrapper), fourier_coeff_sq_summable (summability from HasSum), bessel_fourier (partial sums ≤ L² norm via sum_le_hasSum). All four are one-liners wrapping Mathlib."
+      "summary": "parseval_energy (tsum_sq_fourierCoeff wrapper), parseval_hassum (hasSum_sq_fourierCoeff wrapper), fourier_coeff_sq_summable (summability from HasSum), bessel_fourier (partial sums ≤ L² norm via sum_le_hasSum). All four are one-liners wrapping Mathlib.",
+      "id": "part-i-parseval-s-identity-energy-equality"
     },
     {
       "title": "Part II: Fourier Orthonormality",
       "startLine": 97,
       "endLine": 119,
-      "summary": "fourier_orthonormal (exact orthonormal_fourier), fourier_modes_orthogonal (Orthonormal.2 hnm for distinct modes), fourier_modes_norm_one (Orthonormal.1 n for unit norm). Three one-liners exposing the Orthonormal structure components."
+      "summary": "fourier_orthonormal (exact orthonormal_fourier), fourier_modes_orthogonal (Orthonormal.2 hnm for distinct modes), fourier_modes_norm_one (Orthonormal.1 n for unit norm). Three one-liners exposing the Orthonormal structure components.",
+      "id": "part-ii-fourier-orthonormality"
     },
     {
       "title": "Part III: Pythagorean Theorem for Finite Fourier Sums",
       "startLine": 121,
       "endLine": 176,
-      "summary": "fourier_pythagorean_partial (original, 30-line proof): ‖∑_{n∈S} cₙeₙ‖² = ∑|cₙ|². Step 1: Kronecker delta via case split. Step 2: expand inner product with sum_inner/inner_smul_left/right, apply delta, collapse with sum_ite_eq, reduce mul_conj. Step 3: inner_self_eq_norm_sq_to_K + congr_arg Complex.re + norm_cast."
+      "summary": "fourier_pythagorean_partial (original, 30-line proof): ‖∑_{n∈S} cₙeₙ‖² = ∑|cₙ|². Step 1: Kronecker delta via case split. Step 2: expand inner product with sum_inner/inner_smul_left/right, apply delta, collapse with sum_ite_eq, reduce mul_conj. Step 3: inner_self_eq_norm_sq_to_K + congr_arg Complex.re + norm_cast.",
+      "id": "part-iii-pythagorean-theorem-for-finite-fourier-sums"
     },
     {
       "title": "Parts IV-V: Completeness and L² Convergence",
       "startLine": 178,
       "endLine": 223,
-      "summary": "parseval_implies_completeness: all ĉₙ = 0 → f = 0, via hasSum_fourier_series_L2 + hf_zero substitution + HasSum.unique with hasSum_zero. fourier_series_L2_convergence: exact hasSum_fourier_series_L2 (one-liner). Together: Fourier system is a Hilbert basis."
+      "summary": "parseval_implies_completeness: all ĉₙ = 0 → f = 0, via hasSum_fourier_series_L2 + hf_zero substitution + HasSum.unique with hasSum_zero. fourier_series_L2_convergence: exact hasSum_fourier_series_L2 (one-liner). Together: Fourier system is a Hilbert basis.",
+      "id": "parts-iv-v-completeness-and-l-convergence"
     }
   ],
-  "sorries": 0,
-  "references": [
-    {
-      "authors": "M.-A. Parseval",
-      "title": "Mémoire sur les séries et sur l'intégration complète d'une équation aux différences partielles linéaires du second ordre, à coefficients constants",
-      "year": 1806,
-      "venue": "Mém. prés. par divers savants, Acad. des Sciences",
-      "note": "Original statement of the energy identity."
-    },
-    {
-      "authors": "E. M. Stein, R. Shakarchi",
-      "title": "Fourier Analysis: An Introduction",
-      "year": 2003,
-      "venue": "Princeton University Press",
-      "note": "Parseval/Bessel theory for Fourier series in the L² setting."
-    },
-    {
-      "authors": "W. Rudin",
-      "title": "Real and Complex Analysis",
-      "year": 1987,
-      "venue": "McGraw-Hill",
-      "note": "Hilbert-space Parseval identity and orthonormal bases."
-    },
-    {
-      "authors": "The mathlib Community",
-      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
-      "year": 2020,
-      "venue": "CPP",
-      "note": "Provides the RCLike inner-product-space API (norm_inner_le_norm, inner_self_eq_norm_sq_to_K) underlying this formalization."
-    }
-  ]
+  "sorries": 0
 }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-02/meta.json
@@ -124,25 +124,29 @@
       "title": "Polynomials in f commute",
       "startLine": 51,
       "endLine": 64,
-      "summary": "Any two elements of the subalgebra K[f] = adjoin K {f} are polynomials in f and therefore commute; in particular each commutes with f. This supplies the commutation clause [s, n] = 0 for free."
+      "summary": "Any two elements of the subalgebra K[f] = adjoin K {f} are polynomials in f and therefore commute; in particular each commutes with f. This supplies the commutation clause [s, n] = 0 for free.",
+      "id": "polynomials-in-f-commute"
     },
     {
       "title": "Existence of the decomposition",
       "startLine": 68,
       "endLine": 81,
-      "summary": "jordan_chevalley_decomposition: wrapping Mathlib's Newton-iteration result, f = s + n with s semisimple, n nilpotent, s and n commuting, and explicit polynomial witnesses s = aeval f p, n = aeval f q."
+      "summary": "jordan_chevalley_decomposition: wrapping Mathlib's Newton-iteration result, f = s + n with s semisimple, n nilpotent, s and n commuting, and explicit polynomial witnesses s = aeval f p, n = aeval f q.",
+      "id": "existence-of-the-decomposition"
     },
     {
       "title": "Uniqueness of the decomposition",
       "startLine": 83,
       "endLine": 110,
-      "summary": "jordan_chevalley_unique: from s₁ - s₂ = n₂ - n₁ the common value is both semisimple (difference of commuting semisimples over a perfect field) and nilpotent, hence zero; so the two polynomial-in-f decompositions agree."
+      "summary": "jordan_chevalley_unique: from s₁ - s₂ = n₂ - n₁ the common value is both semisimple (difference of commuting semisimples over a perfect field) and nilpotent, hence zero; so the two polynomial-in-f decompositions agree.",
+      "id": "uniqueness-of-the-decomposition"
     },
     {
       "title": "Existence and uniqueness, packaged",
       "startLine": 112,
       "endLine": 129,
-      "summary": "jordan_chevalley_existsUnique: the unique commuting pair (s, n) in K[f] with s semisimple, n nilpotent, f = s + n, stated as an ExistsUnique."
+      "summary": "jordan_chevalley_existsUnique: the unique commuting pair (s, n) in K[f] with s semisimple, n nilpotent, f = s + n, stated as an ExistsUnique.",
+      "id": "existence-and-uniqueness-packaged"
     }
   ],
   "sorries": []

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01/meta.json
@@ -120,37 +120,43 @@
       "title": "Part I: Eigenvalues and the Minimal Polynomial",
       "startLine": 52,
       "endLine": 91,
-      "summary": "eigenvalue_iff_root_minpoly wraps hasEigenvalue_iff_isRoot: eigenvalue ↔ root of minpoly. eigenvalue_linear_factor_dvd_minpoly: (X - C μ) | minpoly via dvd_iff_isRoot. minpoly_dvd_charpoly wraps Matrix.minpoly_dvd_charpoly. finite_eigenvalues: eigenvalue set is finite. minpoly_annihilates: aeval f (minpoly K f) = 0. minpoly_monic: minpoly is monic. Note: degree bound natDegree ≤ finrank K V not proved here due to whnf timeout in Lean 4.26.0 when computing finrank K (End K V)."
+      "summary": "eigenvalue_iff_root_minpoly wraps hasEigenvalue_iff_isRoot: eigenvalue ↔ root of minpoly. eigenvalue_linear_factor_dvd_minpoly: (X - C μ) | minpoly via dvd_iff_isRoot. minpoly_dvd_charpoly wraps Matrix.minpoly_dvd_charpoly. finite_eigenvalues: eigenvalue set is finite. minpoly_annihilates: aeval f (minpoly K f) = 0. minpoly_monic: minpoly is monic. Note: degree bound natDegree ≤ finrank K V not proved here due to whnf timeout in Lean 4.26.0 when computing finrank K (End K V).",
+      "id": "part-i-eigenvalues-and-the-minimal-polynomial"
     },
     {
       "title": "Part II: Generalized Eigenspace Structure",
       "startLine": 93,
       "endLine": 124,
-      "summary": "generalized_eigenspaces_span_top: over algebraically closed K, ⨆ (genEigenspace μ k) = ⊤, proved via iSup_genEigenspace_eq + iSup_maxGenEigenspace_eq_top. disjoint_generalized_eigenspaces: distinct eigenvalues give disjoint genEigenspaces (disjoint_genEigenspace). nilpotent_shift_on_genEigenspace: (f - μI) restricted to genEigenspace μ k is nilpotent (isNilpotent_restrict_sub_algebraMap). genEigenspace_stabilizes: the chain stabilizes at maxGenEigenspaceIndex (genEigenspace_eq_genEigenspace_maxUnifEigenspaceIndex_of_le)."
+      "summary": "generalized_eigenspaces_span_top: over algebraically closed K, ⨆ (genEigenspace μ k) = ⊤, proved via iSup_genEigenspace_eq + iSup_maxGenEigenspace_eq_top. disjoint_generalized_eigenspaces: distinct eigenvalues give disjoint genEigenspaces (disjoint_genEigenspace). nilpotent_shift_on_genEigenspace: (f - μI) restricted to genEigenspace μ k is nilpotent (isNilpotent_restrict_sub_algebraMap). genEigenspace_stabilizes: the chain stabilizes at maxGenEigenspaceIndex (genEigenspace_eq_genEigenspace_maxUnifEigenspaceIndex_of_le).",
+      "id": "part-ii-generalized-eigenspace-structure"
     },
     {
       "title": "Part III: Nilpotent Endomorphisms and the Minimal Polynomial",
       "startLine": 126,
       "endLine": 194,
-      "summary": "eigenvalue_zero_of_nilpotent: nilpotent f has only eigenvalue 0 (proof: μ^k•v = f^k(v) = 0, v≠0, so μ^k = 0, so μ = 0 in a field). minpoly_dvd_pow_of_nilpotent: f^n = 0 ⇒ minpoly | X^n via minpoly.dvd. minpoly_pow_X_of_nilpotent: nilpotent ⇒ minpoly = X^j by UFD: X is prime, dvd_prime_pow, Associated monic polynomials are equal. nilpotent_of_minpoly_pow_X: converse via aeval f (X^k) = f^k = 0. nilpotent_iff_minpoly_pow_X: full iff combining both directions."
+      "summary": "eigenvalue_zero_of_nilpotent: nilpotent f has only eigenvalue 0 (proof: μ^k•v = f^k(v) = 0, v≠0, so μ^k = 0, so μ = 0 in a field). minpoly_dvd_pow_of_nilpotent: f^n = 0 ⇒ minpoly | X^n via minpoly.dvd. minpoly_pow_X_of_nilpotent: nilpotent ⇒ minpoly = X^j by UFD: X is prime, dvd_prime_pow, Associated monic polynomials are equal. nilpotent_of_minpoly_pow_X: converse via aeval f (X^k) = f^k = 0. nilpotent_iff_minpoly_pow_X: full iff combining both directions.",
+      "id": "part-iii-nilpotent-endomorphisms-and-the-minimal-polynomial"
     },
     {
       "title": "Part IV: Diagonalizability and the Minimal Polynomial",
       "startLine": 196,
       "endLine": 217,
-      "summary": "minpoly_squarefree_of_semisimple: IsSemisimple f ⇒ Squarefree (minpoly K f) via IsSemisimple.minpoly_squarefree. isSemisimple_iff_squarefree_minpoly: full iff, backward direction uses isSemisimple_of_squarefree_aeval_eq_zero. semisimple_nilpotent_eq_zero: semisimple + nilpotent = 0 (eq_zero_of_isNilpotent_isSemisimple) — the uniqueness core of Jordan-Chevalley."
+      "summary": "minpoly_squarefree_of_semisimple: IsSemisimple f ⇒ Squarefree (minpoly K f) via IsSemisimple.minpoly_squarefree. isSemisimple_iff_squarefree_minpoly: full iff, backward direction uses isSemisimple_of_squarefree_aeval_eq_zero. semisimple_nilpotent_eq_zero: semisimple + nilpotent = 0 (eq_zero_of_isNilpotent_isSemisimple) — the uniqueness core of Jordan-Chevalley.",
+      "id": "part-iv-diagonalizability-and-the-minimal-polynomial"
     },
     {
       "title": "Part V: Jordan Normal Form (Axiomatic)",
       "startLine": 218,
       "endLine": 257,
-      "summary": "Three axioms for JCF results not yet in Mathlib 4.26.0. jordan_normal_form_basis: existence of a Jordan basis (sigma-indexed family with Jordan block action). minpoly_product_formula: minpoly K f = Π_{μ∈s} (X - C μ)^(maxGenEigenspaceIndex f μ). maxGenEigenspaceIndex_exact: the exponent is tight — there exists v in maxGenEigenspace μ with (f - μ)^{e-1}(v) ≠ 0. The placeholder condition LinearMap.ker (LinearMap.id - f) ≤ ⊤ in jordan_normal_form_basis acknowledges the sigma-family linear independence encoding challenge."
+      "summary": "Three axioms for JCF results not yet in Mathlib 4.26.0. jordan_normal_form_basis: existence of a Jordan basis (sigma-indexed family with Jordan block action). minpoly_product_formula: minpoly K f = Π_{μ∈s} (X - C μ)^(maxGenEigenspaceIndex f μ). maxGenEigenspaceIndex_exact: the exponent is tight — there exists v in maxGenEigenspace μ with (f - μ)^{e-1}(v) ≠ 0. The placeholder condition LinearMap.ker (LinearMap.id - f) ≤ ⊤ in jordan_normal_form_basis acknowledges the sigma-family linear independence encoding challenge.",
+      "id": "part-v-jordan-normal-form-axiomatic"
     },
     {
       "title": "Part VI: Corollaries and Summary",
       "startLine": 258,
       "endLine": 307,
-      "summary": "jordan_block_power_dvd_minpoly: (X - C μ)^{e_μ} | minpoly K f by Finset.dvd_prod_of_mem applied to the product formula. diagonalizable_iff_squarefree_minpoly: alias of isSemisimple_iff_squarefree_minpoly. Summary docstring synthesizes the four key equivalences and the two-tier structure (Parts I-IV fully verified, Part V axiomatized pending Mathlib JNF block matrix)."
+      "summary": "jordan_block_power_dvd_minpoly: (X - C μ)^{e_μ} | minpoly K f by Finset.dvd_prod_of_mem applied to the product formula. diagonalizable_iff_squarefree_minpoly: alias of isSemisimple_iff_squarefree_minpoly. Summary docstring synthesizes the four key equivalences and the two-tier structure (Parts I-IV fully verified, Part V axiomatized pending Mathlib JNF block matrix).",
+      "id": "part-vi-corollaries-and-summary"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
@@ -137,55 +137,64 @@
       "title": "Module Header and Imports",
       "startLine": 1,
       "endLine": 52,
-      "summary": "Documentation header stating the main theorem (a matrix M is nonderogatory, μ_M = χ_M, iff it has a cyclic vector v with {v, Mv, ..., M^{n-1}v} a basis), the four main results, the forward-direction proof strategy, references (Horn & Johnson, Hoffman & Kunze), and dependencies. Imports Mathlib charpoly/minpoly, linear independence, and opens the Nonderogatory namespace over a field K."
+      "summary": "Documentation header stating the main theorem (a matrix M is nonderogatory, μ_M = χ_M, iff it has a cyclic vector v with {v, Mv, ..., M^{n-1}v} a basis), the four main results, the forward-direction proof strategy, references (Horn & Johnson, Hoffman & Kunze), and dependencies. Imports Mathlib charpoly/minpoly, linear independence, and opens the Nonderogatory namespace over a field K.",
+      "id": "module-header-and-imports"
     },
     {
       "title": "Part I: Definitions",
       "startLine": 53,
       "endLine": 88,
-      "summary": "IsCyclicVector M v (annihilator formulation): every polynomial of degree < n annihilating v must be 0. IsCyclicVectorLI M v (linear independence formulation): Krylov vectors {M^k v : k < n} are linearly independent. IsNonderogatory M: minpoly K M = M.charpoly. The annihilator formulation is used throughout proofs; IsCyclicVectorLI is included for reference. The docstring explains the K[X]-module perspective: IsCyclicVector says the annihilator ideal has no low-degree elements."
+      "summary": "IsCyclicVector M v (annihilator formulation): every polynomial of degree < n annihilating v must be 0. IsCyclicVectorLI M v (linear independence formulation): Krylov vectors {M^k v : k < n} are linearly independent. IsNonderogatory M: minpoly K M = M.charpoly. The annihilator formulation is used throughout proofs; IsCyclicVectorLI is included for reference. The docstring explains the K[X]-module perspective: IsCyclicVector says the annihilator ideal has no low-degree elements.",
+      "id": "part-i-definitions"
     },
     {
       "title": "Part II: Bridge Lemma",
       "startLine": 89,
       "endLine": 133,
-      "summary": "minpoly_eq_charpoly_of_natDegree_eq: natDeg(minpoly) = natDeg(charpoly) ⇒ minpoly = charpoly. Proof: write charpoly = minpoly * r via minpoly_dvd_charpoly; degree additivity forces natDeg(r) = 0; r is monic (leadingCoeff = 1 from charpoly monic and minpoly monic); monic degree-0 polynomial must be 1; so charpoly = minpoly * 1 = minpoly."
+      "summary": "minpoly_eq_charpoly_of_natDegree_eq: natDeg(minpoly) = natDeg(charpoly) ⇒ minpoly = charpoly. Proof: write charpoly = minpoly * r via minpoly_dvd_charpoly; degree additivity forces natDeg(r) = 0; r is monic (leadingCoeff = 1 from charpoly monic and minpoly monic); monic degree-0 polynomial must be 1; so charpoly = minpoly * 1 = minpoly.",
+      "id": "part-ii-bridge-lemma"
     },
     {
       "title": "Part III: Forward Direction (Cyclic → Nonderogatory)",
       "startLine": 134,
       "endLine": 168,
-      "summary": "cyclic_implies_nonderogatory: applies bridge lemma after proving natDeg(minpoly) = n. Key steps: (1) natDeg(minpoly) ≤ natDeg(charpoly) = n from minpoly | charpoly; (2) by contradiction assume natDeg(minpoly) < n; (3) minpoly.aeval gives (aeval M (minpoly K M)).mulVec v = 0; (4) IsCyclicVector forces minpoly = 0; (5) contradiction with Monic.ne_zero. Clean by_contra + omega proof."
+      "summary": "cyclic_implies_nonderogatory: applies bridge lemma after proving natDeg(minpoly) = n. Key steps: (1) natDeg(minpoly) ≤ natDeg(charpoly) = n from minpoly | charpoly; (2) by contradiction assume natDeg(minpoly) < n; (3) minpoly.aeval gives (aeval M (minpoly K M)).mulVec v = 0; (4) IsCyclicVector forces minpoly = 0; (5) contradiction with Monic.ne_zero. Clean by_contra + omega proof.",
+      "id": "part-iii-forward-direction-cyclic-nonderogatory"
     },
     {
       "title": "Part IV: Backward Direction (Nonderogatory → Cyclic, Axiomatized)",
       "startLine": 169,
       "endLine": 207,
-      "summary": "Comment discusses three approaches: (1) PID structure theorem V ≅ K[X]/(d₁) ⊕ ... ⊕ K[X]/(d_k), minpoly = charpoly forces k = 1; (2) Jordan Normal Form for alg. closed fields; (3) union of proper subspaces for infinite fields. axiom nonderogatory_has_cyclic_vector: IsNonderogatory M → ∃ v, IsCyclicVector M v. Holds over ALL fields (finite included), ruling out Approach 3 for the general statement."
+      "summary": "Comment discusses three approaches: (1) PID structure theorem V ≅ K[X]/(d₁) ⊕ ... ⊕ K[X]/(d_k), minpoly = charpoly forces k = 1; (2) Jordan Normal Form for alg. closed fields; (3) union of proper subspaces for infinite fields. axiom nonderogatory_has_cyclic_vector: IsNonderogatory M → ∃ v, IsCyclicVector M v. Holds over ALL fields (finite included), ruling out Approach 3 for the general statement.",
+      "id": "part-iv-backward-direction-nonderogatory-cyclic-axiomatized"
     },
     {
       "title": "Part V: Full Characterization",
       "startLine": 208,
       "endLine": 224,
-      "summary": "nonderogatory_iff_cyclic_vector: full iff combining the proved forward direction and the axiomatized backward direction. nonderogatory_has_cyclic_vector provides the → direction, cyclic_implies_nonderogatory provides the ← direction."
+      "summary": "nonderogatory_iff_cyclic_vector: full iff combining the proved forward direction and the axiomatized backward direction. nonderogatory_has_cyclic_vector provides the → direction, cyclic_implies_nonderogatory provides the ← direction.",
+      "id": "part-v-full-characterization"
     },
     {
       "title": "Part VI: Corollaries",
       "startLine": 225,
       "endLine": 253,
-      "summary": "minpoly_natDegree_eq_dim_of_cyclic: cyclic → natDeg(minpoly) = n (repackages intermediate step from forward direction). nonderogatory_algebra_dim: nonderogatory → natDeg(minpoly) = n (same via IsNonderogatory). nonderogatory_minpoly_dvd_charpoly: minpoly | charpoly for nonderogatory M (trivially, since they're equal)."
+      "summary": "minpoly_natDegree_eq_dim_of_cyclic: cyclic → natDeg(minpoly) = n (repackages intermediate step from forward direction). nonderogatory_algebra_dim: nonderogatory → natDeg(minpoly) = n (same via IsNonderogatory). nonderogatory_minpoly_dvd_charpoly: minpoly | charpoly for nonderogatory M (trivially, since they're equal).",
+      "id": "part-vi-corollaries"
     },
     {
       "title": "Part VII: Degree Characterization",
       "startLine": 254,
       "endLine": 281,
-      "summary": "nonderogatory_iff_natDegree_eq: IsNonderogatory M ↔ natDeg(minpoly) = n. derogatory_iff_natDegree_lt: ¬IsNonderogatory M ↔ natDeg(minpoly) < n (requires Nontrivial hypothesis). Both proved cleanly by combining bridge lemma with charpoly_natDegree_eq_dim."
+      "summary": "nonderogatory_iff_natDegree_eq: IsNonderogatory M ↔ natDeg(minpoly) = n. derogatory_iff_natDegree_lt: ¬IsNonderogatory M ↔ natDeg(minpoly) < n (requires Nontrivial hypothesis). Both proved cleanly by combining bridge lemma with charpoly_natDegree_eq_dim.",
+      "id": "part-vii-degree-characterization"
     },
     {
       "title": "Summary",
       "startLine": 282,
       "endLine": 316,
-      "summary": "Closing summary docstring recapping the definitions (IsCyclicVector, IsNonderogatory), main results (cyclic_implies_nonderogatory proved; nonderogatory_has_cyclic_vector axiom; nonderogatory_iff_cyclic_vector), the degree characterizations, the bridge lemma, and the proof status: 0 sorries with a single axiom (nonderogatory_has_cyclic_vector, requiring the PID module structure theorem)."
+      "summary": "Closing summary docstring recapping the definitions (IsCyclicVector, IsNonderogatory), main results (cyclic_implies_nonderogatory proved; nonderogatory_has_cyclic_vector axiom; nonderogatory_iff_cyclic_vector), the degree characterizations, the bridge lemma, and the proof status: 0 sorries with a single axiom (nonderogatory_has_cyclic_vector, requiring the PID module structure theorem).",
+      "id": "summary"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/central-limit-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-03/meta.json
@@ -151,60 +151,55 @@
       "title": "Header: Question, Answer, and Imports",
       "startLine": 1,
       "endLine": 50,
-      "summary": "Module docstring stating the question (next-weakest dependence beyond independence with vanishing mixing coefficients), the answer (m-dependence, α(n) = 0 for n > m), and the five proven results. Imports the parent CentralLimitTheoremOQ02 α-mixing infrastructure plus Mathlib; opens MeasureTheory/Filter/Topology and the parent namespace.",
-      "mathContext": "An m-dependent sequence has $\\alpha(n) = 0$ for $n > m$; independence is $m = 0$."
+      "summary": "Module docstring stating the question (next-weakest dependence beyond independence with vanishing mixing coefficients), the answer (m-dependence, α(n) = 0 for n > m), and the five proven results. Imports the parent CentralLimitTheoremOQ02 α-mixing infrastructure plus Mathlib; opens MeasureTheory/Filter/Topology and the parent namespace."
     },
     {
       "id": "mdependence",
       "title": "Part I: m-Dependence",
       "startLine": 53,
       "endLine": 73,
-      "summary": "Defines MDependent μ σ_k m: for events A measurable w.r.t. σ_k k and B measurable w.r.t. σ_k (k+n) with n > m, μ(A∩B) = μA·μB. The m = 0 case is the gap-≥-1 independence hypothesis of the parent.",
-      "mathContext": "$\\mu(A\\cap B)=\\mu(A)\\,\\mu(B)$ whenever the index gap $n>m$."
+      "summary": "Defines MDependent μ σ_k m: for events A measurable w.r.t. σ_k k and B measurable w.r.t. σ_k (k+n) with n > m, μ(A∩B) = μA·μB. The m = 0 case is the gap-≥-1 independence hypothesis of the parent."
     },
     {
       "id": "alpha-zero",
       "title": "Part II: m-Dependence ⇒ α(n) = 0 for n > m",
       "startLine": 75,
       "endLine": 117,
-      "summary": "The headline mDependent_alpha_zero. Mirrors the parent's independent_implies_zero_mixing: every term of the defining nested supremum vanishes by independence (ENNReal.toReal_mul), and a Prop-indexed nested supremum of the constant 0 over ℝ collapses via a Nonempty/IsEmpty case split, sidestepping the lack of CompleteLattice ℝ.",
-      "mathContext": "$\\alpha(\\sigma_k(k),\\sigma_k(k+n)) = \\sup_{A,B}|\\mu(A\\cap B)-\\mu A\\,\\mu B| = 0$ for $n>m$."
+      "summary": "The headline mDependent_alpha_zero. Mirrors the parent's independent_implies_zero_mixing: every term of the defining nested supremum vanishes by independence (ENNReal.toReal_mul), and a Prop-indexed nested supremum of the constant 0 over ℝ collapses via a Nonempty/IsEmpty case split, sidestepping the lack of CompleteLattice ℝ."
     },
     {
       "id": "independence",
       "title": "Part III: m = 0 Recovers Independence",
       "startLine": 119,
       "endLine": 134,
-      "summary": "mZeroDependent_recovers_independence: specializing the headline to m = 0 (gap n ≥ 1) re-derives the conclusion of the parent's independent_implies_zero_mixing.",
-      "mathContext": "Independence $\\iff$ 0-dependence; $\\alpha(n)=0$ for all $n\\ge 1$."
+      "summary": "mZeroDependent_recovers_independence: specializing the headline to m = 0 (gap n ≥ 1) re-derives the conclusion of the parent's independent_implies_zero_mixing."
     },
     {
       "id": "decay",
       "title": "Part IV: Mixing Decay is Trivial",
       "startLine": 136,
       "endLine": 150,
-      "summary": "mDependent_mixing_decay: the lag-indexed coefficient n ↦ α(n) tends to 0, because it is eventually identically 0 (past lag m), via tendsto_atTop_of_eventually_const.",
-      "mathContext": "$\\alpha(n)\\to 0$ since $\\alpha(n)=0$ for all $n>m$."
+      "summary": "mDependent_mixing_decay: the lag-indexed coefficient n ↦ α(n) tends to 0, because it is eventually identically 0 (past lag m), via tendsto_atTop_of_eventually_const."
     },
     {
       "id": "summable",
       "title": "Part V: Ibragimov's Series Converges for Every Exponent",
       "startLine": 152,
       "endLine": 185,
-      "summary": "summable_rpow_of_eventually_zero (reusable: eventually-zero ⇒ summable rpow powers, finite support, θ ≠ 0) and mDependent_summable_mixing_rpow (Ibragimov's series ∑ₙ α(n)^θ converges for every θ ≠ 0, so the OQ-02-OQ-04 CLT applies with no rate constraint).",
-      "mathContext": "$\\sum_n \\alpha(n)^\\theta < \\infty$ for every $\\theta>0$, since $\\alpha(n)=0$ for $n>m$."
+      "summary": "summable_rpow_of_eventually_zero (reusable: eventually-zero ⇒ summable rpow powers, finite support, θ ≠ 0) and mDependent_summable_mixing_rpow (Ibragimov's series ∑ₙ α(n)^θ converges for every θ ≠ 0, so the OQ-02-OQ-04 CLT applies with no rate constraint)."
     },
     {
       "id": "hierarchy",
       "title": "Part VI: Hierarchy Placement",
       "startLine": 187,
       "endLine": 208,
-      "summary": "Places m-dependence strictly between independence and general α-mixing: Independent (= 0-dependent) ⊊ m-dependent ⊊ α-mixing with summable rate ⊊ α-mixing. Notes the strictness witnesses (MA(1) is 1-dependent but not independent; long-memory α-mixing is not m-dependent) and the necessity of θ ≠ 0.",
-      "mathContext": "Independent $\\subsetneq$ $m$-dependent $\\subsetneq$ summable-rate $\\alpha$-mixing $\\subsetneq$ $\\alpha$-mixing."
+      "summary": "Places m-dependence strictly between independence and general α-mixing: Independent (= 0-dependent) ⊊ m-dependent ⊊ α-mixing with summable rate ⊊ α-mixing. Notes the strictness witnesses (MA(1) is 1-dependent but not independent; long-memory α-mixing is not m-dependent) and the necessity of θ ≠ 0."
     },
     {
       "id": "bounds-mono",
       "title": "Coefficient Bound and m-Monotonicity",
+      "startLine": 209,
+      "endLine": 256,
       "summary": "alphaMixingCoeff_le_one: on a probability space the α-mixing coefficient is ≤ 1 (every term |x−yz| with x,y,z∈[0,1]; proved via Real.iSup_le whose 0≤a side-condition absorbs the empty-index sup) — the upper bound the parent omits. mDependent_mono: m-dependence is monotone in m, nesting the finite-range classes upward."
     }
   ],

--- a/src/data/proofs/central-limit-theorem/annotations.json
+++ b/src/data/proofs/central-limit-theorem/annotations.json
@@ -75,7 +75,7 @@
       "startLine": 12,
       "endLine": 52
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Characteristic Function at Zero",
     "content": "At $t = 0$, the characteristic function equals 1 for any probability measure: $\\varphi(0) = \\mathbb{E}[e^{i \\cdot 0 \\cdot X}] = \\mathbb{E}[1] = 1$. This normalization anchors the Fourier representation.",
     "mathContext": "This simple fact is essential: it means all characteristic functions pass through the same point, allowing us to compare different distributions on a common scale.",
@@ -119,7 +119,7 @@
       "startLine": 75,
       "endLine": 85
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Taylor Expansion with Error Bound",
     "content": "For small $t$, the characteristic function is well-approximated by its quadratic Taylor polynomial. The error is $O(t^3)$, controlled by the third moment. This approximation is sharp enough to extract the limiting behavior.",
     "mathContext": "The third moment condition $\\mathbb{E}[|X|^3] < \\infty$ ensures the remainder is well-controlled. Without it, convergence may fail (leading to stable distributions instead).",

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02/meta.json
@@ -109,37 +109,43 @@
       "title": "Background: Algebraic Universality of Ceva's Theorem",
       "startLine": 5,
       "endLine": 42,
-      "summary": "Module docstring establishing the central insight: the geometric cancellation in Ceva's theorem is independent of the ambient geometry. In Euclidean, spherical (sin), and hyperbolic (sinh) cases, the cevian-point ratio always reduces to β/α. The hyperboloid model is introduced with the Minkowski bilinear form B(x,y) = x₁y₁ + x₂y₂ − x₃y₃ and the identity cosh(d(B,C)) = −B(B,C)."
+      "summary": "Module docstring establishing the central insight: the geometric cancellation in Ceva's theorem is independent of the ambient geometry. In Euclidean, spherical (sin), and hyperbolic (sinh) cases, the cevian-point ratio always reduces to β/α. The hyperboloid model is introduced with the Minkowski bilinear form B(x,y) = x₁y₁ + x₂y₂ − x₃y₃ and the identity cosh(d(B,C)) = −B(B,C).",
+      "id": "background-algebraic-universality-of-ceva-s-theorem"
     },
     {
       "title": "HyperbolicCevianConfig: Packaging the Hyperboloid Geometry",
       "startLine": 50,
       "endLine": 113,
-      "summary": "The HyperbolicCevianConfig structure bundles: the Minkowski parameter m = cosh(d(B,C)) > 1, positive weight parameters α and β with their positivity proofs, and n_sq = α² + 2αβm + β². Key lemmas hyp_key_identity_BD/DC prove (α+βm)² − n² = β²(m²−1) and (αm+β)² − n² = α²(m²−1) by ring, realizing cosh²−1 = sinh² algebraically."
+      "summary": "The HyperbolicCevianConfig structure bundles: the Minkowski parameter m = cosh(d(B,C)) > 1, positive weight parameters α and β with their positivity proofs, and n_sq = α² + 2αβm + β². Key lemmas hyp_key_identity_BD/DC prove (α+βm)² − n² = β²(m²−1) and (αm+β)² − n² = α²(m²−1) by ring, realizing cosh²−1 = sinh² algebraically.",
+      "id": "hyperboliccevianconfig-packaging-the-hyperboloid-geometry"
     },
     {
       "title": "The Sinh-Ratio Formula: Algebraic Cancellation",
       "startLine": 114,
       "endLine": 162,
-      "summary": "The heart of the proof: hyp_sinh_ratio proves sinh(d(B,D))/sinh(d(D,C)) = β/α in two steps. First, unfold both sinh expressions (β·√(m²−1)/n and α·√(m²−1)/n respectively). Then field_simp cancels the common √(m²−1) factor. The n normalization also cancels, leaving only β/α. Positivity lemmas ensure division is well-defined."
+      "summary": "The heart of the proof: hyp_sinh_ratio proves sinh(d(B,D))/sinh(d(D,C)) = β/α in two steps. First, unfold both sinh expressions (β·√(m²−1)/n and α·√(m²−1)/n respectively). Then field_simp cancels the common √(m²−1) factor. The n normalization also cancels, leaving only β/α. Positivity lemmas ensure division is well-defined.",
+      "id": "the-sinh-ratio-formula-algebraic-cancellation"
     },
     {
       "title": "The Triple Product Formula",
       "startLine": 163,
       "endLine": 181,
-      "summary": "hyp_ceva_product_eq_weight_ratio rewrites all three cevian sinh-ratios via hyp_sinh_ratio, collapsing the product of sinh-ratios to (βD·βE·βF)/(αD·αE·αF). The geometry-specific √(m²−1)/n factors have already cancelled in hyp_sinh_ratio, so the triple product reduces to the same weight-product ratio as the spherical (sin) case."
+      "summary": "hyp_ceva_product_eq_weight_ratio rewrites all three cevian sinh-ratios via hyp_sinh_ratio, collapsing the product of sinh-ratios to (βD·βE·βF)/(αD·αE·αF). The geometry-specific √(m²−1)/n factors have already cancelled in hyp_sinh_ratio, so the triple product reduces to the same weight-product ratio as the spherical (sin) case.",
+      "id": "the-triple-product-formula"
     },
     {
       "title": "The Weight Balance Criterion for Concurrency",
       "startLine": 182,
       "endLine": 228,
-      "summary": "hyp_weight_balance_iff proves (βD/αD)·(βE/αE)·(βF/αF) = 1 ↔ αD·αE·αF = βD·βE·βF by field_simp + linarith. hyp_ceva_iff_weight_balance composes this with the triple-product formula to conclude the cevians are concurrent iff αD·αE·αF = βD·βE·βF — algebraically identical to the spherical criterion, since sin vs sinh is irrelevant once the ratios are formed."
+      "summary": "hyp_weight_balance_iff proves (βD/αD)·(βE/αE)·(βF/αF) = 1 ↔ αD·αE·αF = βD·βE·βF by field_simp + linarith. hyp_ceva_iff_weight_balance composes this with the triple-product formula to conclude the cevians are concurrent iff αD·αE·αF = βD·βE·βF — algebraically identical to the spherical criterion, since sin vs sinh is irrelevant once the ratios are formed.",
+      "id": "the-weight-balance-criterion-for-concurrency"
     },
     {
       "title": "Universality and Summary Answer to OQ-02-OQ-01-OQ-02",
       "startLine": 230,
       "endLine": 301,
-      "summary": "universal_weight_balance is a purely algebraic theorem (no geometry): αD·αE·αF = βD·βE·βF iff (βD/αD)·(βE/αE)·(βF/αF) = 1, proved by field_simp + linarith. equal_weight_hyp_ceva handles the trivial equal-weight case, and summary_answer_oq02oq01oq02 bundles all three geometries into a conjunction. The universality confirms that the weight-parameter criterion is independent of the metric, hinting at the projective foundations of Ceva's theorem."
+      "summary": "universal_weight_balance is a purely algebraic theorem (no geometry): αD·αE·αF = βD·βE·βF iff (βD/αD)·(βE/αE)·(βF/αF) = 1, proved by field_simp + linarith. equal_weight_hyp_ceva handles the trivial equal-weight case, and summary_answer_oq02oq01oq02 bundles all three geometries into a conjunction. The universality confirms that the weight-parameter criterion is independent of the metric, hinting at the projective foundations of Ceva's theorem.",
+      "id": "universality-and-summary-answer-to-oq-02-oq-01-oq-02"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
@@ -72,16 +72,18 @@
       "summary": "crt_list_unique: any two values below ms.prod agreeing modulo every m ∈ ms are equal. Equal residues give m ∣ (difference) for all m, hence ms.prod ∣ (difference); but the difference is below ms.prod, so it vanishes."
     },
     {
-      "id": "existence",
-      "title": "The n-Modulus Existence Half",
-      "summary": "crt_list_exists: for pairwise-coprime ms and any residues r, ∃ x, ∀ m∈ms, x ≡ r m [MOD m]. List induction; the cons step combines the head (coprime to the tail product) with the tail solution via Nat.chineseRemainder, then restricts the tail-product congruence to each tail modulus by Nat.ModEq.of_dvd. With crt_list_unique this is the full CRT. crt_345_exists is the worked [3,4,5] instance."
-    },
-    {
       "id": "example",
       "title": "Worked Instance over [3, 4, 5]",
       "startLine": 79,
       "endLine": 88,
       "summary": "crt_345_unique: two values below 60 with the same residues mod 3, 4, 5 coincide. Pairwise coprimality and the product 60 are decided; the residue hypotheses are dispatched by fin_cases on list membership."
+    },
+    {
+      "id": "existence",
+      "title": "The n-Modulus Existence Half",
+      "startLine": 89,
+      "endLine": 123,
+      "summary": "crt_list_exists: for pairwise-coprime ms and any residues r, ∃ x, ∀ m∈ms, x ≡ r m [MOD m]. List induction; the cons step combines the head (coprime to the tail product) with the tail solution via Nat.chineseRemainder, then restricts the tail-product congruence to each tail modulus by Nat.ModEq.of_dvd. With crt_list_unique this is the full CRT. crt_345_exists is the worked [3,4,5] instance."
     }
   ],
   "overview": {

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-02/meta.json
@@ -113,43 +113,50 @@
       "title": "Part I: CRT for EuclideanDomains",
       "startLine": 34,
       "endLine": 123,
-      "summary": "Necessity (ed_crt_necessary): gcd(m,n) divides both m and n, so it divides (x-a)-(x-b) = a-b. Sufficiency (ed_crt_sufficient): explicit construction x = a - m·(gcdA·q) via Bézout. Uniqueness (ed_crt_unique): lcm(m,n) divides any x-y satisfying both congruences. Specializations to ℤ are one-liners. Three-moduli necessity, weakening, and combining lemmas round out the section."
+      "summary": "Necessity (ed_crt_necessary): gcd(m,n) divides both m and n, so it divides (x-a)-(x-b) = a-b. Sufficiency (ed_crt_sufficient): explicit construction x = a - m·(gcdA·q) via Bézout. Uniqueness (ed_crt_unique): lcm(m,n) divides any x-y satisfying both congruences. Specializations to ℤ are one-liners. Three-moduli necessity, weakening, and combining lemmas round out the section.",
+      "id": "part-i-crt-for-euclideandomains"
     },
     {
       "title": "Parts II-III: Polynomial CRT and Lagrange Interpolation",
       "startLine": 125,
       "endLine": 214,
-      "summary": "linear_factors_coprime proves IsCoprime (X-C a) (X-C b) for a≠b by explicit Bézout: C(b-a)⁻¹·(X-a) + (-C(b-a)⁻¹)·(X-b) = 1. polynomial_crt_two_points constructs the Lagrange interpolant. polynomial_crt_two_degree_bound proves degree ≤ 1. poly_crt_extend gives the inductive Newton step: given solution p₀ mod m, adjust to hit value b at point a."
+      "summary": "linear_factors_coprime proves IsCoprime (X-C a) (X-C b) for a≠b by explicit Bézout: C(b-a)⁻¹·(X-a) + (-C(b-a)⁻¹)·(X-b) = 1. polynomial_crt_two_points constructs the Lagrange interpolant. polynomial_crt_two_degree_bound proves degree ≤ 1. poly_crt_extend gives the inductive Newton step: given solution p₀ mod m, adjust to hit value b at point a.",
+      "id": "parts-ii-iii-polynomial-crt-and-lagrange-interpolation"
     },
     {
       "title": "Part IV: Ideal Bridge — IsCoprime ↔ Ideal.span sup = ⊤",
       "startLine": 216,
       "endLine": 274,
-      "summary": "isCoprime_iff_span_sup_eq_top: s·a + t·b = 1 ↔ 1 ∈ ⟨a⟩ + ⟨b⟩. Euclid's lemma (euclid_lemma_from_coprimality) and coprime multiplication (coprime_mul_dvd_iff) follow. coprime_crt_unique_ideal: IsCoprime m n → m·n ∣ (x₁-x₂) for two solutions. Summary theorem (crt_oq02_summary) bundles existence, uniqueness, and ideal characterization."
+      "summary": "isCoprime_iff_span_sup_eq_top: s·a + t·b = 1 ↔ 1 ∈ ⟨a⟩ + ⟨b⟩. Euclid's lemma (euclid_lemma_from_coprimality) and coprime multiplication (coprime_mul_dvd_iff) follow. coprime_crt_unique_ideal: IsCoprime m n → m·n ∣ (x₁-x₂) for two solutions. Summary theorem (crt_oq02_summary) bundles existence, uniqueness, and ideal characterization.",
+      "id": "part-iv-ideal-bridge-iscoprime-ideal-span-sup"
     },
     {
       "title": "Parts V-X: Structural and Multi-Moduli Results",
       "startLine": 276,
       "endLine": 501,
-      "summary": "Part V: crt_oq02_summary bundles existence + uniqueness + ideal bridge. Part VI: PID principal ideal lemma, Bézout existence, coprime CRT solvability and uniqueness. Part VII: degree bounds for 1-point and 2-point interpolation. Part VIII: coprime chain properties (IsCoprime transitivity, symmetry, self-coprimality). Part IX: structural lemmas (coprime subsumes non-coprime, contrapositive impossibility, reflexivity, transitivity). Part X: three-moduli coprime CRT with explicit CRT basis elements."
+      "summary": "Part V: crt_oq02_summary bundles existence + uniqueness + ideal bridge. Part VI: PID principal ideal lemma, Bézout existence, coprime CRT solvability and uniqueness. Part VII: degree bounds for 1-point and 2-point interpolation. Part VIII: coprime chain properties (IsCoprime transitivity, symmetry, self-coprimality). Part IX: structural lemmas (coprime subsumes non-coprime, contrapositive impossibility, reflexivity, transitivity). Part X: three-moduli coprime CRT with explicit CRT basis elements.",
+      "id": "parts-v-x-structural-and-multi-moduli-results"
     },
     {
       "title": "Part XI: Ideal-Theoretic CRT — The Most General Formulation",
       "startLine": 503,
       "endLine": 592,
-      "summary": "ideal_crt_iff: ∃ x, (x-a)∈I ∧ (x-b)∈J ↔ (a-b)∈I⊔J, for any ideals in any commutative ring. Necessity decomposes a-b = -(x-a) + (x-b). Sufficiency sets x = a-i from the I-component. Uniqueness: (x₁-x₂) ∈ I⊓J. Three-ideal extensions by pairwise application. Coprime case (I⊔J=⊤) gives automatic solvability."
+      "summary": "ideal_crt_iff: ∃ x, (x-a)∈I ∧ (x-b)∈J ↔ (a-b)∈I⊔J, for any ideals in any commutative ring. Necessity decomposes a-b = -(x-a) + (x-b). Sufficiency sets x = a-i from the I-component. Uniqueness: (x₁-x₂) ∈ I⊓J. Three-ideal extensions by pairwise application. Coprime case (I⊔J=⊤) gives automatic solvability.",
+      "id": "part-xi-ideal-theoretic-crt-the-most-general-formulation"
     },
     {
       "title": "Part XII: Closing the Loop — Ideal CRT Recovers Element CRT",
       "startLine": 594,
       "endLine": 647,
-      "summary": "mem_span_singleton_iff_dvd: x ∈ ⟨m⟩ ↔ m ∣ x. element_crt_from_ideal specializes ideal CRT to principal ideals. span_sup_top_of_isCoprime: IsCoprime m n → span{m} ⊔ span{n} = ⊤. element_coprime_crt_from_ideal shows coprime elements always give solvable systems."
+      "summary": "mem_span_singleton_iff_dvd: x ∈ ⟨m⟩ ↔ m ∣ x. element_crt_from_ideal specializes ideal CRT to principal ideals. span_sup_top_of_isCoprime: IsCoprime m n → span{m} ⊔ span{n} = ⊤. element_coprime_crt_from_ideal shows coprime elements always give solvable systems.",
+      "id": "part-xii-closing-the-loop-ideal-crt-recovers-element-crt"
     },
     {
       "title": "Part XIII: Non-Coprime CRT for PIDs — The Final Synthesis",
       "startLine": 649,
       "endLine": 705,
-      "summary": "pid_span_sup_principal: in a PID, span{m} ⊔ span{n} is principal (= ⟨gcd⟩). pid_noncoprime_crt_iff: element solvability ↔ (a-b) ∈ span{m} ⊔ span{n}. pid_noncoprime_crt_unique: uniqueness mod span{m} ⊓ span{n} (= ⟨lcm⟩). pid_noncoprime_crt_full: combined existence + uniqueness. Covers ℤ, k[X], ℤ[i] and all PIDs."
+      "summary": "pid_span_sup_principal: in a PID, span{m} ⊔ span{n} is principal (= ⟨gcd⟩). pid_noncoprime_crt_iff: element solvability ↔ (a-b) ∈ span{m} ⊔ span{n}. pid_noncoprime_crt_unique: uniqueness mod span{m} ⊓ span{n} (= ⟨lcm⟩). pid_noncoprime_crt_full: combined existence + uniqueness. Covers ℤ, k[X], ℤ[i] and all PIDs.",
+      "id": "part-xiii-non-coprime-crt-for-pids-the-final-synthesis"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-01/meta.json
@@ -110,25 +110,29 @@
       "title": "Part 0: Binary CRT core and binary GCD–LCM distributive law",
       "startLine": 46,
       "endLine": 219,
-      "summary": "ed_crt_sufficient: binary CRT sufficiency via Bézout (from parent). gcd_lcm_dvd_lcm_gcd: the hard binary GCD–LCM distributive law gcd(lcm(a,b),c)∣lcm(gcd(a,c),gcd(b,c)), reproduced verbatim from ChineseRemainderNonCoprimeOQ03 — a Bézout decomposition with nested coprime factoring through gcd(a,b) and gcd(gcd(a,b),c)."
+      "summary": "ed_crt_sufficient: binary CRT sufficiency via Bézout (from parent). gcd_lcm_dvd_lcm_gcd: the hard binary GCD–LCM distributive law gcd(lcm(a,b),c)∣lcm(gcd(a,c),gcd(b,c)), reproduced verbatim from ChineseRemainderNonCoprimeOQ03 — a Bézout decomposition with nested coprime factoring through gcd(a,b) and gcd(gcd(a,b),c).",
+      "id": "part-0-binary-crt-core-and-binary-gcd-lcm-distributive-law"
     },
     {
       "title": "Part I: lcm over a list of moduli",
       "startLine": 220,
       "endLine": 247,
-      "summary": "lcmList (foldr EuclideanDomain.lcm 1) with simp lemmas lcmList_nil/lcmList_cons; dvd_lcmList (each element divides the list lcm) and lcmList_dvd (the list lcm divides any common multiple)."
+      "summary": "lcmList (foldr EuclideanDomain.lcm 1) with simp lemmas lcmList_nil/lcmList_cons; dvd_lcmList (each element divides the list lcm) and lcmList_dvd (the list lcm divides any common multiple).",
+      "id": "part-i-lcm-over-a-list-of-moduli"
     },
     {
       "title": "Part II: Generalized GCD–LCM distributive law",
       "startLine": 248,
       "endLine": 268,
-      "summary": "gcd_lcmList_dvd: gcd(lcmList l, c) ∣ lcmList (l.map (gcd · c)), proved by induction on l. The cons step applies the binary distributive law gcd_lcm_dvd_lcm_gcd to the head and the lcm of the tail, then monotonicity of lcm with the inductive hypothesis."
+      "summary": "gcd_lcmList_dvd: gcd(lcmList l, c) ∣ lcmList (l.map (gcd · c)), proved by induction on l. The cons step applies the binary distributive law gcd_lcm_dvd_lcm_gcd to the head and the lcm of the tail, then monotonicity of lcm with the inductive hypothesis.",
+      "id": "part-ii-generalized-gcd-lcm-distributive-law"
     },
     {
       "title": "Part III: n-Moduli list-indexed CRT",
       "startLine": 269,
       "endLine": 380,
-      "summary": "Solves and Compat predicates over List (R × R). crt_list_necessary (solvable ⟹ pairwise compatible). crt_list_sufficient (induction on the list; merge head with lcm of tail via gcd_lcmList_dvd and the binary solver). crt_list_iff (full characterization). crt_list_unique (lcm of all moduli divides the difference of any two solutions). Summary of the nine results."
+      "summary": "Solves and Compat predicates over List (R × R). crt_list_necessary (solvable ⟹ pairwise compatible). crt_list_sufficient (induction on the list; merge head with lcm of tail via gcd_lcmList_dvd and the binary solver). crt_list_iff (full characterization). crt_list_unique (lcm of all moduli divides the difference of any two solutions). Summary of the nine results.",
+      "id": "part-iii-n-moduli-list-indexed-crt"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "chinese-remainder-non-coprime-oq-03",
   "title": "Chinese Remainder Theorem for Three Non-Coprime Moduli",
   "slug": "chinese-remainder-non-coprime-oq-03",
-  "description": "Extends the non-coprime CRT from 2 to 3 moduli in any Euclidean domain: the system m\u2081\u2223(x-a\u2081), m\u2082\u2223(x-a\u2082), m\u2083\u2223(x-a\u2083) has a solution iff gcd(m\u1d62,m\u2c7c)\u2223(a\u1d62-a\u2c7c) for all pairs. Proves necessity (inherited), sufficiency via iterated 2-moduli reduction, and solution uniqueness modulo lcm(m\u2081,lcm(m\u2082,m\u2083)). 13 theorems, 0 axioms.",
+  "description": "Extends the non-coprime CRT from 2 to 3 moduli in any Euclidean domain: the system m₁∣(x-a₁), m₂∣(x-a₂), m₃∣(x-a₃) has a solution iff gcd(mᵢ,mⱼ)∣(aᵢ-aⱼ) for all pairs. Proves necessity (inherited), sufficiency via iterated 2-moduli reduction, and solution uniqueness modulo lcm(m₁,lcm(m₂,m₃)). 13 theorems, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
@@ -19,7 +19,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified. (Previously had 1 axiom gcd_lcm_distrib, later replaced by direct B\u00e9zout proof.)",
+    "assumptions": "None. Fully machine-verified. (Previously had 1 axiom gcd_lcm_distrib, later replaced by direct Bézout proof.)",
     "lineCount": 391,
     "theoremCount": 13,
     "definitionCount": 0,
@@ -27,42 +27,42 @@
       "Proofs/ChineseRemainderNonCoprimeOQ03Aristotle.lean"
     ],
     "originalContributions": [
-      "gcd_dvd_of_dvd_sub: gcd(m\u2081,m\u2082) divides any linear combination of m\u2081 and m\u2082 differences",
+      "gcd_dvd_of_dvd_sub: gcd(m₁,m₂) divides any linear combination of m₁ and m₂ differences",
       "gcd_dvd_sub_of_congr: pairwise GCD condition transfers through the constructed solution",
       "lcm_gcd_dvd_gcd_lcm: easy direction of GCD-LCM distributive law in Euclidean domains",
-      "gcd_lcm_dvd_lcm_gcd: hard direction \u2014 gcd(lcm(a,b),c) \u2223 lcm(gcd(a,c),gcd(b,c)) via B\u00e9zout",
-      "ed_crt_three_sufficient: sufficiency direction \u2014 pairwise GCD conditions imply 3-moduli solution",
+      "gcd_lcm_dvd_lcm_gcd: hard direction — gcd(lcm(a,b),c) ∣ lcm(gcd(a,c),gcd(b,c)) via Bézout",
+      "ed_crt_three_sufficient: sufficiency direction — pairwise GCD conditions imply 3-moduli solution",
       "ed_crt_three_iff: full iff characterization for 3-moduli non-coprime CRT",
-      "ed_crt_three_unique: uniqueness \u2014 any two solutions agree modulo lcm(m\u2081,lcm(m\u2082,m\u2083))"
+      "ed_crt_three_unique: uniqueness — any two solutions agree modulo lcm(m₁,lcm(m₂,m₃))"
     ]
   },
   "overview": {
-    "historicalContext": "The 3-moduli non-coprime CRT was known classically for \u2124: pairwise GCD compatibility is necessary and sufficient for the system of congruences to be solvable. The algebraic extension to general EuclideanDomains requires the GCD-LCM distributive identity gcd(lcm(a,b),c) = lcm(gcd(a,c),gcd(b,c)). This identity is classical in lattice theory (Birkhoff, 1935) \u2014 it characterizes distributive lattices \u2014 but its proof in the divisibility lattice of a Euclidean domain requires nontrivial work. The Lean proof went through three stages: first using an axiom gcd_lcm_distrib, then a sorry placeholder, and finally a complete 185-line B\u00e9zout-based proof. This proof trajectory exemplifies the gap between 'known to be true' and 'formally verified': the distributive law is obvious in \u2124 but requires a careful argument in general EuclideanDomains where there is no canonical representative for gcd.",
-    "problemStatement": "In a Euclidean domain R, given moduli m\u2081, m\u2082, m\u2083 and remainders a\u2081, a\u2082, a\u2083, does the system m\u2081\u2223(x-a\u2081), m\u2082\u2223(x-a\u2082), m\u2083\u2223(x-a\u2083) have a solution? Prove it is equivalent to pairwise GCD compatibility.",
-    "text": "The sufficiency proof uses a constructive 2-step reduction. Step 1: solve the first pair (m\u2081, m\u2082) using the 2-moduli CRT to get x\u2080 with m\u2081\u2223(x\u2080-a\u2081) and m\u2082\u2223(x\u2080-a\u2082). Step 2: the key is showing gcd(lcm(m\u2081,m\u2082), m\u2083)\u2223(x\u2080-a\u2083), which reduces to the GCD-LCM distributive law. Then apply the 2-moduli CRT again for (lcm(m\u2081,m\u2082), m\u2083). The hard direction of the distributive law gcd_lcm_dvd_lcm_gcd is proved by B\u00e9zout decomposition: write gcd(a,b) = u\u00b7a + v\u00b7b, then expand gcd(a,b)\u00b7gcd(a\u00b7b/(gcd(a,b)),c) using coprime factoring.",
+    "historicalContext": "The 3-moduli non-coprime CRT was known classically for ℤ: pairwise GCD compatibility is necessary and sufficient for the system of congruences to be solvable. The algebraic extension to general EuclideanDomains requires the GCD-LCM distributive identity gcd(lcm(a,b),c) = lcm(gcd(a,c),gcd(b,c)). This identity is classical in lattice theory (Birkhoff, 1935) — it characterizes distributive lattices — but its proof in the divisibility lattice of a Euclidean domain requires nontrivial work. The Lean proof went through three stages: first using an axiom gcd_lcm_distrib, then a sorry placeholder, and finally a complete 185-line Bézout-based proof. This proof trajectory exemplifies the gap between 'known to be true' and 'formally verified': the distributive law is obvious in ℤ but requires a careful argument in general EuclideanDomains where there is no canonical representative for gcd.",
+    "problemStatement": "In a Euclidean domain R, given moduli m₁, m₂, m₃ and remainders a₁, a₂, a₃, does the system m₁∣(x-a₁), m₂∣(x-a₂), m₃∣(x-a₃) have a solution? Prove it is equivalent to pairwise GCD compatibility.",
+    "text": "The sufficiency proof uses a constructive 2-step reduction. Step 1: solve the first pair (m₁, m₂) using the 2-moduli CRT to get x₀ with m₁∣(x₀-a₁) and m₂∣(x₀-a₂). Step 2: the key is showing gcd(lcm(m₁,m₂), m₃)∣(x₀-a₃), which reduces to the GCD-LCM distributive law. Then apply the 2-moduli CRT again for (lcm(m₁,m₂), m₃). The hard direction of the distributive law gcd_lcm_dvd_lcm_gcd is proved by Bézout decomposition: write gcd(a,b) = u·a + v·b, then expand gcd(a,b)·gcd(a·b/(gcd(a,b)),c) using coprime factoring.",
     "proofStrategy": "Inherit necessity from ChineseRemainderNonCoprimeOQ02.lean. Prove GCD-LCM distributive law (both directions). Use iterated 2-moduli CRT application. Prove uniqueness via divisibility of the LCM.",
     "keyInsights": [
       "The 3-moduli case reduces to two applications of the 2-moduli CRT via iterated reduction",
       "The GCD-LCM distributive law gcd(lcm(a,b), c) = lcm(gcd(a,c), gcd(b,c)) is the essential algebraic engine",
-      "B\u00e9zout's identity in Euclidean domains enables the 185-line hard direction of the distributive law",
-      "Solution uniqueness follows from divisibility by the iterated LCM lcm(m\u2081, lcm(m\u2082, m\u2083))",
-      "The proof went axiom \u2192 sorry \u2192 full proof: illustrating the gap between 'classical' and 'formally verified'",
+      "Bézout's identity in Euclidean domains enables the 185-line hard direction of the distributive law",
+      "Solution uniqueness follows from divisibility by the iterated LCM lcm(m₁, lcm(m₂, m₃))",
+      "The proof went axiom → sorry → full proof: illustrating the gap between 'classical' and 'formally verified'",
       "Coprime factoring through gcd(a,b) and gcd(gcd(a,b),c) creates two independent IsCoprime instances whose joint cancellation yields the final decomposition"
     ],
     "prerequisites": [
-      "Euclidean domains: GCD, LCM, B\u00e9zout's identity",
+      "Euclidean domains: GCD, LCM, Bézout's identity",
       "Non-coprime CRT for 2 moduli (ChineseRemainderNonCoprimeOQ02.lean)",
       "Divisibility arithmetic in commutative rings"
     ]
   },
   "conclusion": {
-    "summary": "The 3-moduli non-coprime CRT is fully verified: solution exists iff pairwise GCD conditions hold, and is unique modulo lcm(m\u2081, lcm(m\u2082, m\u2083)). The GCD-LCM distributive law is proved by a 185-line direct B\u00e9zout decomposition with nested coprime factoring. 13 theorems, 391 lines, 0 axioms. Previously required 1 axiom, now axiom-free.",
-    "implications": "This completes the non-coprime CRT hierarchy: 2-moduli (OQ02) and 3-moduli (OQ03) cases are both verified for all Euclidean domains. The proof technique \u2014 iterated 2-moduli reduction + GCD-LCM distributive law \u2014 generalizes to n moduli by induction. The distributive law proof also contributes independently: it verifies a classical lattice identity in the divisibility poset of Euclidean domains.",
+    "summary": "The 3-moduli non-coprime CRT is fully verified: solution exists iff pairwise GCD conditions hold, and is unique modulo lcm(m₁, lcm(m₂, m₃)). The GCD-LCM distributive law is proved by a 185-line direct Bézout decomposition with nested coprime factoring. 13 theorems, 391 lines, 0 axioms. Previously required 1 axiom, now axiom-free.",
+    "implications": "This completes the non-coprime CRT hierarchy: 2-moduli (OQ02) and 3-moduli (OQ03) cases are both verified for all Euclidean domains. The proof technique — iterated 2-moduli reduction + GCD-LCM distributive law — generalizes to n moduli by induction. The distributive law proof also contributes independently: it verifies a classical lattice identity in the divisibility poset of Euclidean domains.",
     "openQuestions": [
-      "Generalize to n moduli by induction: solvable iff all pairwise GCD conditions hold, unique mod lcm(m\u2081,...,m\u2099)",
+      "Generalize to n moduli by induction: solvable iff all pairwise GCD conditions hold, unique mod lcm(m₁,...,mₙ)",
       "Formalize the GCD-LCM distributive law as a standalone Mathlib lemma for EuclideanDomains",
       "Module-theoretic version: CRT for modules over PIDs (Chinese Remainder for module decomposition)",
-      "Computational complexity: how many B\u00e9zout steps does the iterated 3-moduli construction require?"
+      "Computational complexity: how many Bézout steps does the iterated 3-moduli construction require?"
     ]
   },
   "leanFile": {
@@ -126,25 +126,29 @@
       "title": "Part 0: Self-Contained 2-Moduli CRT",
       "startLine": 25,
       "endLine": 65,
-      "summary": "Private copies of ed_crt_necessary, ed_crt_sufficient, and ed_crt_three_necessary from OQ02. Self-contained so this file can be imported independently. The necessity proof deduces gcd \u2223 (a-b) by dvd_sub; sufficiency constructs x = a - m\u00b7(gcdA\u00b7q) via B\u00e9zout; three-moduli necessity applies the pairwise version three times."
+      "summary": "Private copies of ed_crt_necessary, ed_crt_sufficient, and ed_crt_three_necessary from OQ02. Self-contained so this file can be imported independently. The necessity proof deduces gcd ∣ (a-b) by dvd_sub; sufficiency constructs x = a - m·(gcdA·q) via Bézout; three-moduli necessity applies the pairwise version three times.",
+      "id": "part-0-self-contained-2-moduli-crt"
     },
     {
       "title": "Part I: Intermediate Lemmas",
       "startLine": 67,
       "endLine": 84,
-      "summary": "gcd_dvd_of_dvd_sub: m \u2223 (x-a) implies gcd(m,p) \u2223 (x-a) by gcd_dvd_left composition. gcd_dvd_sub_of_congr: congruence transfer \u2014 m \u2223 (x\u2080-a\u2081) and gcd(m,m\u2083) \u2223 (a\u2081-a\u2083) give gcd(m,m\u2083) \u2223 (x\u2080-a\u2083) by x\u2080-a\u2083 = (x\u2080-a\u2081) + (a\u2081-a\u2083)."
+      "summary": "gcd_dvd_of_dvd_sub: m ∣ (x-a) implies gcd(m,p) ∣ (x-a) by gcd_dvd_left composition. gcd_dvd_sub_of_congr: congruence transfer — m ∣ (x₀-a₁) and gcd(m,m₃) ∣ (a₁-a₃) give gcd(m,m₃) ∣ (x₀-a₃) by x₀-a₃ = (x₀-a₁) + (a₁-a₃).",
+      "id": "part-i-intermediate-lemmas"
     },
     {
       "title": "Part II: GCD-LCM Distributive Law",
       "startLine": 86,
       "endLine": 321,
-      "summary": "Easy direction (lcm_gcd_dvd_gcd_lcm): lattice chain reasoning via dvd_gcd and dvd_lcm. Helper lemmas: lcm_dvd_mul (lcm(a,b) \u2223 a\u00b7b) and gcd_lcm_dvd_mul (gcd(lcm(a,b),c) \u2223 a\u00b7b). Hard direction (gcd_lcm_dvd_lcm_gcd): 185-line B\u00e9zout argument. Set g=gcd(a,b), factor a=g\u03b1, b=g\u03b2 (IsCoprime \u03b1 \u03b2). Set d'=gcd(g,c), factor g=d'g', c=d'c' (IsCoprime g' c'). Write M as linear combination of a,c and b,c; subtract to get g(r\u2081\u03b1-r\u2082\u03b2)=(s\u2082-s\u2081)c; cancel d'; use IsCoprime g' c' to get c'\u2223(r\u2081\u03b1-r\u2082\u03b2); use IsCoprime \u03b1 \u03b2 to get \u03b2\u2223(r\u2081-p_b\u00b7c'\u00b7w); decompose M=m\u00b7(g\u03b1\u03b2)+T\u00b7c."
+      "summary": "Easy direction (lcm_gcd_dvd_gcd_lcm): lattice chain reasoning via dvd_gcd and dvd_lcm. Helper lemmas: lcm_dvd_mul (lcm(a,b) ∣ a·b) and gcd_lcm_dvd_mul (gcd(lcm(a,b),c) ∣ a·b). Hard direction (gcd_lcm_dvd_lcm_gcd): 185-line Bézout argument. Set g=gcd(a,b), factor a=gα, b=gβ (IsCoprime α β). Set d'=gcd(g,c), factor g=d'g', c=d'c' (IsCoprime g' c'). Write M as linear combination of a,c and b,c; subtract to get g(r₁α-r₂β)=(s₂-s₁)c; cancel d'; use IsCoprime g' c' to get c'∣(r₁α-r₂β); use IsCoprime α β to get β∣(r₁-p_b·c'·w); decompose M=m·(gαβ)+T·c.",
+      "id": "part-ii-gcd-lcm-distributive-law"
     },
     {
       "title": "Part III: Three-Moduli CRT and Summary",
       "startLine": 322,
       "endLine": 391,
-      "summary": "ed_crt_three_sufficient: (1) solve (m\u2081,m\u2082) to get x\u2080; (2) transfer pairwise conditions to x\u2080; (3) apply lcm_dvd and gcd_lcm_dvd_lcm_gcd; (4) apply ed_crt_sufficient for (lcm(m\u2081,m\u2082), m\u2083); (5) recover m\u2081 and m\u2082 conditions via dvd_lcm_left/right. ed_crt_three_iff combines with necessity. ed_crt_three_unique: lcm(m\u2081,lcm(m\u2082,m\u2083)) \u2223 (x-y) by nested EuclideanDomain.lcm_dvd. Summary: proof history (axiom \u2192 sorry \u2192 verified), 7 theorems listed."
+      "summary": "ed_crt_three_sufficient: (1) solve (m₁,m₂) to get x₀; (2) transfer pairwise conditions to x₀; (3) apply lcm_dvd and gcd_lcm_dvd_lcm_gcd; (4) apply ed_crt_sufficient for (lcm(m₁,m₂), m₃); (5) recover m₁ and m₂ conditions via dvd_lcm_left/right. ed_crt_three_iff combines with necessity. ed_crt_three_unique: lcm(m₁,lcm(m₂,m₃)) ∣ (x-y) by nested EuclideanDomain.lcm_dvd. Summary: proof history (axiom → sorry → verified), 7 theorems listed.",
+      "id": "part-iii-three-moduli-crt-and-summary"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -83,25 +83,29 @@
       "title": "Module header and context",
       "startLine": 1,
       "endLine": 44,
-      "summary": "States the goal — the parent's open question on the Lucas analogue of Cassini's identity — notes that Mathlib has neither a Lucas sequence nor a Fibonacci Cassini/Catalan lemma, lists the four results, and imports the parent."
+      "summary": "States the goal — the parent's open question on the Lucas analogue of Cassini's identity — notes that Mathlib has neither a Lucas sequence nor a Fibonacci Cassini/Catalan lemma, lists the four results, and imports the parent.",
+      "id": "module-header-and-context"
     },
     {
       "title": "Fibonacci Catalan/Cassini identity (helper)",
       "startLine": 46,
       "endLine": 65,
-      "summary": "fib_catalan_int: F(n+1)² − F(n)·F(n+2) = (−1)^n over ℤ, proved by a one-step induction whose step substitutes both Fibonacci recurrences and collapses to the negation of the inductive hypothesis (linear_combination -ih)."
+      "summary": "fib_catalan_int: F(n+1)² − F(n)·F(n+2) = (−1)^n over ℤ, proved by a one-step induction whose step substitutes both Fibonacci recurrences and collapses to the negation of the inductive hypothesis (linear_combination -ih).",
+      "id": "fibonacci-catalan-cassini-identity-helper"
     },
     {
       "title": "The Lucas analogue of Cassini's identity",
       "startLine": 67,
       "endLine": 96,
-      "summary": "lucas_cassini_int: the subtraction-free reindexed form L(n)·L(n+2) − L(n+1)² = (−1)^n·5, by the same sign-flipping induction using the parent's lucas_add_two. lucas_cassini: the literal n−1 open-question form for n ≥ 1, obtained by writing n = 1 + m and normalising indices with omega."
+      "summary": "lucas_cassini_int: the subtraction-free reindexed form L(n)·L(n+2) − L(n+1)² = (−1)^n·5, by the same sign-flipping induction using the parent's lucas_add_two. lucas_cassini: the literal n−1 open-question form for n ≥ 1, obtained by writing n = 1 + m and normalising indices with omega.",
+      "id": "the-lucas-analogue-of-cassini-s-identity"
     },
     {
       "title": "Structural consequence: the discriminant identity",
       "startLine": 98,
       "endLine": 120,
-      "summary": "lucas_sq_sub_five_fib_sq: L(n)² − 5·F(n)² = 4·(−1)^n, derived algebraically from fib_catalan_int and the parent's bridge L(n)=2·F(n+1)−F(n) via linear_combination, exhibiting the Cassini constant 5 as the discriminant of x²−x−1."
+      "summary": "lucas_sq_sub_five_fib_sq: L(n)² − 5·F(n)² = 4·(−1)^n, derived algebraically from fib_catalan_int and the parent's bridge L(n)=2·F(n+1)−F(n) via linear_combination, exhibiting the Cassini constant 5 as the discriminant of x²−x−1.",
+      "id": "structural-consequence-the-discriminant-identity"
     }
   ],
   "sorries": [],

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01/meta.json
@@ -85,37 +85,43 @@
       "title": "Module header and context",
       "startLine": 1,
       "endLine": 43,
-      "summary": "States the goal — the parent's second open question on companion Lucas-number diagonal identities — and notes that Mathlib has Nat.fib but no Lucas sequence (only the unrelated Lucas–Lehmer test). Lists the five results and imports Mathlib."
+      "summary": "States the goal — the parent's second open question on companion Lucas-number diagonal identities — and notes that Mathlib has Nat.fib but no Lucas sequence (only the unrelated Lucas–Lehmer test). Lists the five results and imports Mathlib.",
+      "id": "module-header-and-context"
     },
     {
       "title": "The Lucas sequence",
       "startLine": 44,
       "endLine": 53,
-      "summary": "Defines lucas by L(0)=2, L(1)=1, L(n+2)=L(n)+L(n+1), with the base evaluations and the recurrence lucas_add_two as definitional (rfl) facts."
+      "summary": "Defines lucas by L(0)=2, L(1)=1, L(n+2)=L(n)+L(n+1), with the base evaluations and the recurrence lucas_add_two as definitional (rfl) facts.",
+      "id": "the-lucas-sequence"
     },
     {
       "title": "The Lucas–Fibonacci bridge",
       "startLine": 55,
       "endLine": 76,
-      "summary": "lucas_add_fib: L(n)+F(n)=2·F(n+1), proved subtraction-free by two-step induction. lucas_eq: the Lucas–Fibonacci relation L(n+1)=F(n+2)+F(n), read off from the bridge via Nat.fib_add_two and omega."
+      "summary": "lucas_add_fib: L(n)+F(n)=2·F(n+1), proved subtraction-free by two-step induction. lucas_eq: the Lucas–Fibonacci relation L(n+1)=F(n+2)+F(n), read off from the bridge via Nat.fib_add_two and omega.",
+      "id": "the-lucas-fibonacci-bridge"
     },
     {
       "title": "Shallow-diagonal sums of Pascal's triangle",
       "startLine": 78,
       "endLine": 98,
-      "summary": "fib_shallow_diagonal_alt and fib_shallow_diagonal: the parent's Fibonacci diagonal identity ∑_j C(n−j, j) = F(n+1) in both index conventions, replicated so the file is self-contained."
+      "summary": "fib_shallow_diagonal_alt and fib_shallow_diagonal: the parent's Fibonacci diagonal identity ∑_j C(n−j, j) = F(n+1) in both index conventions, replicated so the file is self-contained.",
+      "id": "shallow-diagonal-sums-of-pascal-s-triangle"
     },
     {
       "title": "Companion Lucas-number diagonal identities",
       "startLine": 100,
       "endLine": 133,
-      "summary": "lucas_shallow_diagonal and lucas_shallow_diagonal_alt: L(n+2) equals the sum of the (n+2)-nd and n-th shallow diagonals of Pascal's triangle, obtained from L(n+2)=F(n+3)+F(n+1) by expanding each Fibonacci term as a shallow diagonal."
+      "summary": "lucas_shallow_diagonal and lucas_shallow_diagonal_alt: L(n+2) equals the sum of the (n+2)-nd and n-th shallow diagonals of Pascal's triangle, obtained from L(n+2)=F(n+3)+F(n+1) by expanding each Fibonacci term as a shallow diagonal.",
+      "id": "companion-lucas-number-diagonal-identities"
     },
     {
       "title": "Mixed Fibonacci–Lucas identity",
       "startLine": 135,
       "endLine": 146,
-      "summary": "fib_two_mul_lucas: F(2n)=F(n)·L(n), obtained from Mathlib's Nat.fib_two_mul together with the bridge identifying 2·F(n+1)−F(n) as L(n)."
+      "summary": "fib_two_mul_lucas: F(2n)=F(n)·L(n), obtained from Mathlib's Nat.fib_two_mul together with the bridge identifying 2·F(n+1)−F(n) as L(n).",
+      "id": "mixed-fibonacci-lucas-identity"
     }
   ],
   "sorries": [],

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-02/meta.json
@@ -82,43 +82,50 @@
       "title": "Module header and context",
       "startLine": 1,
       "endLine": 51,
-      "summary": "States the p-step shallow-diagonal generalization (the parent's second open question), the step parametrization q = p−1, the main results (recurrence, base segment, Fibonacci corollary), and the worked specializations q=0 (powers of two), q=1 (Fibonacci), q=2 (Narayana's cows). Imports Mathlib."
+      "summary": "States the p-step shallow-diagonal generalization (the parent's second open question), the step parametrization q = p−1, the main results (recurrence, base segment, Fibonacci corollary), and the worked specializations q=0 (powers of two), q=1 (Fibonacci), q=2 (Narayana's cows). Imports Mathlib.",
+      "id": "module-header-and-context"
     },
     {
       "title": "The p-step shallow-diagonal sum",
       "startLine": 56,
       "endLine": 60,
-      "summary": "pbonacci q n := ∑_{j ∈ range (n+1)} C(n − q·j, j), the p-step diagonal sum; q=1 is the parent's Fibonacci diagonal."
+      "summary": "pbonacci q n := ∑_{j ∈ range (n+1)} C(n − q·j, j), the p-step diagonal sum; q=1 is the parent's Fibonacci diagonal.",
+      "id": "the-p-step-shallow-diagonal-sum"
     },
     {
       "title": "Range extension",
       "startLine": 62,
       "endLine": 73,
-      "summary": "pbonacci_extend: terms vanish once j outruns n − q·j, so the summation range may be enlarged above n without changing the value. Used to make the recurrence bookkeeping linear."
+      "summary": "pbonacci_extend: terms vanish once j outruns n − q·j, so the summation range may be enlarged above n without changing the value. Used to make the recurrence bookkeeping linear.",
+      "id": "range-extension"
     },
     {
       "title": "Pascal's rule on a diagonal term",
       "startLine": 77,
       "endLine": 106,
-      "summary": "diag_pascal (private helper): C(n+q+1 − q(j+1), j+1) = C(n − q·j, j+1) + C(n − q·j, j) for j ≥ 1, splitting by whether the subtraction truncates. This is the engine of the recurrence."
+      "summary": "diag_pascal (private helper): C(n+q+1 − q(j+1), j+1) = C(n − q·j, j+1) + C(n − q·j, j) for j ≥ 1, splitting by whether the subtraction truncates. This is the engine of the recurrence.",
+      "id": "pascal-s-rule-on-a-diagonal-term"
     },
     {
       "title": "The p-bonacci recurrence",
       "startLine": 108,
       "endLine": 155,
-      "summary": "pbonacci_rec: S q (n+q+1) = S q (n+q) + S q n. Peels the j=0 term, applies diag_pascal termwise, identifies the two resulting sums as S q (n+q) and S q n via pbonacci_extend, and closes with omega."
+      "summary": "pbonacci_rec: S q (n+q+1) = S q (n+q) + S q n. Peels the j=0 term, applies diag_pascal termwise, identifies the two resulting sums as S q (n+q) and S q n via pbonacci_extend, and closes with omega.",
+      "id": "the-p-bonacci-recurrence"
     },
     {
       "title": "Constant base segment",
       "startLine": 157,
       "endLine": 174,
-      "summary": "pbonacci_base: S q n = 1 for n ≤ q. Every term beyond j=0 vanishes because n − q(j+1) = 0, leaving the single leading C(n,0) = 1."
+      "summary": "pbonacci_base: S q n = 1 for n ≤ q. Every term beyond j=0 vanishes because n − q(j+1) = 0, leaving the single leading C(n,0) = 1.",
+      "id": "constant-base-segment"
     },
     {
       "title": "Recovering the parent Fibonacci identity",
       "startLine": 176,
       "endLine": 195,
-      "summary": "pbonacci_one_eq_fib: S 1 n = F(n+1), proved by two-step induction from pbonacci_rec at q=1 and Nat.fib_add_two — the parent result as a corollary of the general recurrence."
+      "summary": "pbonacci_one_eq_fib: S 1 n = F(n+1), proved by two-step induction from pbonacci_rec at q=1 and Nat.fib_add_two — the parent result as a corollary of the general recurrence.",
+      "id": "recovering-the-parent-fibonacci-identity"
     }
   ],
   "sorries": [],

--- a/src/data/proofs/combinations-formula-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01/meta.json
@@ -97,31 +97,36 @@
       "title": "Part I: Vandermonde's Identity",
       "startLine": 24,
       "endLine": 40,
-      "summary": "vandermonde proves C(m+n,r) = Σ C(m,k)·C(n,r-k) in two lines: rw [Nat.add_choose_eq] then exact with Finset.Nat.sum_antidiagonal_eq_sum_range_succ. Verified by native_decide for C(8,4)=70 and the matching sum."
+      "summary": "vandermonde proves C(m+n,r) = Σ C(m,k)·C(n,r-k) in two lines: rw [Nat.add_choose_eq] then exact with Finset.Nat.sum_antidiagonal_eq_sum_range_succ. Verified by native_decide for C(8,4)=70 and the matching sum.",
+      "id": "part-i-vandermonde-s-identity"
     },
     {
       "title": "Part II: Hockey Stick Identity",
       "startLine": 42,
       "endLine": 65,
-      "summary": "hockey_stick proves Σ_{i=0}^{n} C(i+r,r) = C(n+r+1,r+1) by induction. Base: simp [Nat.choose_self]. Step: Finset.sum_range_succ + induction hypothesis + Nat.choose_succ_succ (Pascal's rule) + omega. Verified by native_decide for r=0,1,2."
+      "summary": "hockey_stick proves Σ_{i=0}^{n} C(i+r,r) = C(n+r+1,r+1) by induction. Base: simp [Nat.choose_self]. Step: Finset.sum_range_succ + induction hypothesis + Nat.choose_succ_succ (Pascal's rule) + omega. Verified by native_decide for r=0,1,2.",
+      "id": "part-ii-hockey-stick-identity"
     },
     {
       "title": "Part III: Product/Double Counting Identity",
       "startLine": 67,
       "endLine": 109,
-      "summary": "choose_product proves C(n,k)·C(k,j) = C(n,j)·C(n-j,k-j) for j≤k≤n. Strategy: multiply by j!·(k-j)!·(n-k)! and show both sides equal n! using Nat.choose_mul_factorial_mul_factorial. Cancel with mul_right_cancel₀ (positivity shows denominator ≠ 0). 30 lines of ring arithmetic."
+      "summary": "choose_product proves C(n,k)·C(k,j) = C(n,j)·C(n-j,k-j) for j≤k≤n. Strategy: multiply by j!·(k-j)!·(n-k)! and show both sides equal n! using Nat.choose_mul_factorial_mul_factorial. Cancel with mul_right_cancel₀ (positivity shows denominator ≠ 0). 30 lines of ring arithmetic.",
+      "id": "part-iii-product-double-counting-identity"
     },
     {
       "title": "Parts IV-VI: Row Sums and Binomial Bounds",
       "startLine": 111,
       "endLine": 158,
-      "summary": "choose_row_sum: exact Nat.sum_range_choose n (1 line). choose_alternating_sum: exact Int.alternating_sum_range_choose_of_ne. choose_le_pow2: C(n,k) ≤ Σ C(n,i) = 2ⁿ via Finset.single_le_sum; k>n case by Nat.choose_eq_zero_of_lt. central_binom_le: C(2n,n) ≤ 2^{2n} = 4ⁿ via choose_le_pow2 + pow_mul."
+      "summary": "choose_row_sum: exact Nat.sum_range_choose n (1 line). choose_alternating_sum: exact Int.alternating_sum_range_choose_of_ne. choose_le_pow2: C(n,k) ≤ Σ C(n,i) = 2ⁿ via Finset.single_le_sum; k>n case by Nat.choose_eq_zero_of_lt. central_binom_le: C(2n,n) ≤ 2^{2n} = 4ⁿ via choose_le_pow2 + pow_mul.",
+      "id": "parts-iv-vi-row-sums-and-binomial-bounds"
     },
     {
       "title": "Parts VII-VIII: Fibonacci Diagonals and Summary",
       "startLine": 160,
       "endLine": 185,
-      "summary": "Fibonacci diagonals Σ C(n-j,j) = F(n+1) verified by native_decide for n=5 (=8=F(6)) and n=6 (=13=F(7)). General proof is open. identities_summary bundles four identities as a conjunction: ⟨Nat.sum_range_choose, hockey_stick, vandermonde, choose_le_pow2⟩."
+      "summary": "Fibonacci diagonals Σ C(n-j,j) = F(n+1) verified by native_decide for n=5 (=8=F(6)) and n=6 (=13=F(7)). General proof is open. identities_summary bundles four identities as a conjunction: ⟨Nat.sum_range_choose, hockey_stick, vandermonde, choose_le_pow2⟩.",
+      "id": "parts-vii-viii-fibonacci-diagonals-and-summary"
     }
   ],
   "sorries": 0,

--- a/src/data/proofs/de-moivre-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-02-oq-02/meta.json
@@ -27,25 +27,29 @@
       "title": "Header and Open Question",
       "startLine": 1,
       "endLine": 35,
-      "summary": "States the parent's OQ #2 — does the $T_n$ cos/cosh unification extend to $U_n$ and the sine ratios? — and the answer: yes, via the purely algebraic Laurent identity $U_n((w+w^{-1})/2)(w-w^{-1}) = w^{n+1}-w^{-(n+1)}$."
+      "summary": "States the parent's OQ #2 — does the $T_n$ cos/cosh unification extend to $U_n$ and the sine ratios? — and the answer: yes, via the purely algebraic Laurent identity $U_n((w+w^{-1})/2)(w-w^{-1}) = w^{n+1}-w^{-(n+1)}$.",
+      "id": "header-and-open-question"
     },
     {
       "title": "Part 1 — The unifying algebraic Laurent identity (★)",
       "startLine": 37,
       "endLine": 92,
-      "summary": "`U_resolvent_aux` proves the two-variable identity for $wv=1$ by paired induction on the Chebyshev recurrence, the constraint entering once via `linear_combination`. `U_resolvent` specializes $v=w^{-1}$. No transcendental functions appear — this is the common algebraic root of both analytic ratios."
+      "summary": "`U_resolvent_aux` proves the two-variable identity for $wv=1$ by paired induction on the Chebyshev recurrence, the constraint entering once via `linear_combination`. `U_resolvent` specializes $v=w^{-1}$. No transcendental functions appear — this is the common algebraic root of both analytic ratios.",
+      "id": "part-1-the-unifying-algebraic-laurent-identity"
     },
     {
       "title": "Part 2 — Both ratios as specializations of (★)",
       "startLine": 94,
       "endLine": 126,
-      "summary": "`U_resolvent_sinh`: setting $w=e^{z}$ turns ($\\star$) into $\\sinh((n+1)z)=U_n(\\cosh z)\\sinh z$. `U_resolvent_sin`: substituting $z\\mapsto xi$ recovers $\\sin((n+1)x)=U_n(\\cos x)\\sin x$. One identity yields both."
+      "summary": "`U_resolvent_sinh`: setting $w=e^{z}$ turns ($\\star$) into $\\sinh((n+1)z)=U_n(\\cosh z)\\sinh z$. `U_resolvent_sin`: substituting $z\\mapsto xi$ recovers $\\sin((n+1)x)=U_n(\\cos x)\\sin x$. One identity yields both.",
+      "id": "part-2-both-ratios-as-specializations-of"
     },
     {
       "title": "Part 3 — Packaged 'one Uₙ, both ratios' statement",
       "startLine": 128,
       "endLine": 139,
-      "summary": "`U_eval_cos_and_cosh` bundles the circular and hyperbolic sine ratios into one statement, the direct $U$-analogue of the parent's `T_eval_cos_and_cosh`."
+      "summary": "`U_eval_cos_and_cosh` bundles the circular and hyperbolic sine ratios into one statement, the direct $U$-analogue of the parent's `T_eval_cos_and_cosh`.",
+      "id": "part-3-packaged-one-u-both-ratios-statement"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/de-moivre-oq-01-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-02/meta.json
@@ -27,43 +27,50 @@
       "title": "Header and Open Question",
       "startLine": 1,
       "endLine": 40,
-      "summary": "States the parent's open question — does the real Chebyshev–De Moivre dictionary extend to $\\mathbb{C}$? — and the answer: it does, and over $\\mathbb{C}$ a single $T_n$ governs both the circular ($\\cos z$) and hyperbolic ($\\cosh z$) maps because $\\cos(iw)=\\cosh w$."
+      "summary": "States the parent's open question — does the real Chebyshev–De Moivre dictionary extend to $\\mathbb{C}$? — and the answer: it does, and over $\\mathbb{C}$ a single $T_n$ governs both the circular ($\\cos z$) and hyperbolic ($\\cosh z$) maps because $\\cos(iw)=\\cosh w$.",
+      "id": "header-and-open-question"
     },
     {
       "title": "Part 1 — Complex Chebyshev–De Moivre dictionary",
       "startLine": 42,
       "endLine": 65,
-      "summary": "Thin wrappers around Mathlib's analytic cores: `cos_intMul_eq_eval_T` ($\\cos(nz)=T_n(\\cos z)$), `sin_succMul_eq_eval_U`, and their hyperbolic twins `cosh_intMul_eq_eval_T`, `sinh_succMul_eq_eval_U` — the same $T_n,U_n$ in both settings."
+      "summary": "Thin wrappers around Mathlib's analytic cores: `cos_intMul_eq_eval_T` ($\\cos(nz)=T_n(\\cos z)$), `sin_succMul_eq_eval_U`, and their hyperbolic twins `cosh_intMul_eq_eval_T`, `sinh_succMul_eq_eval_U` — the same $T_n,U_n$ in both settings.",
+      "id": "part-1-complex-chebyshev-de-moivre-dictionary"
     },
     {
       "title": "Part 2 — Existence: cos(nz), cosh(nz) are polynomial",
       "startLine": 67,
       "endLine": 80,
-      "summary": "`cos_intMul_isPolyInCos` / `cosh_intMul_isPolyInCosh` witness the Chebyshev polynomial $T_n$ as the explicit polynomial expressing $\\cos(nz)$ in $\\cos z$ (resp. $\\cosh$), with the *same* witness serving both."
+      "summary": "`cos_intMul_isPolyInCos` / `cosh_intMul_isPolyInCosh` witness the Chebyshev polynomial $T_n$ as the explicit polynomial expressing $\\cos(nz)$ in $\\cos z$ (resp. $\\cosh$), with the *same* witness serving both.",
+      "id": "part-2-existence-cos-nz-cosh-nz-are-polynomial"
     },
     {
       "title": "Part 3 — Explicit Chebyshev polynomials over ℂ",
       "startLine": 82,
       "endLine": 114,
-      "summary": "Computes $T_3,T_4,T_5$ and $U_3,U_4$ over $\\mathbb{C}$ from the recurrence $T_{n+2}=2X\\,T_{n+1}-T_n$ (and the $U$ analogue), the polynomials feeding the explicit angle formulas."
+      "summary": "Computes $T_3,T_4,T_5$ and $U_3,U_4$ over $\\mathbb{C}$ from the recurrence $T_{n+2}=2X\\,T_{n+1}-T_n$ (and the $U$ analogue), the polynomials feeding the explicit angle formulas.",
+      "id": "part-3-explicit-chebyshev-polynomials-over"
     },
     {
       "title": "Part 4 — Explicit complex multiple-angle formulas (deg 4,5)",
       "startLine": 116,
       "endLine": 155,
-      "summary": "`cos_four_mul`, `cos_five_mul`, `sin_four_mul`, `sin_five_mul`: evaluate the explicit polynomial at $\\cos z$, reduce with `simp`, normalize the $\\mathbb{Z}\\to\\mathbb{C}$ cast, and close with `linear_combination`. Degrees 4–5 are absent from Mathlib (which stops at 3)."
+      "summary": "`cos_four_mul`, `cos_five_mul`, `sin_four_mul`, `sin_five_mul`: evaluate the explicit polynomial at $\\cos z$, reduce with `simp`, normalize the $\\mathbb{Z}\\to\\mathbb{C}$ cast, and close with `linear_combination`. Degrees 4–5 are absent from Mathlib (which stops at 3).",
+      "id": "part-4-explicit-complex-multiple-angle-formulas-deg-4-5"
     },
     {
       "title": "Part 5 — Explicit hyperbolic multiple-angle formulas",
       "startLine": 157,
       "endLine": 198,
-      "summary": "`cosh_four_mul`,`cosh_five_mul`,`sinh_four_mul`,`sinh_five_mul`: the same polynomials $T_4,T_5,U_3,U_4$ evaluated at $\\cosh z$ — the hyperbolic formulas come essentially for free from the circular ones."
+      "summary": "`cosh_four_mul`,`cosh_five_mul`,`sinh_four_mul`,`sinh_five_mul`: the same polynomials $T_4,T_5,U_3,U_4$ evaluated at $\\cosh z$ — the hyperbolic formulas come essentially for free from the circular ones.",
+      "id": "part-5-explicit-hyperbolic-multiple-angle-formulas"
     },
     {
       "title": "Part 6 — Unification and De Moivre composition",
       "startLine": 200,
       "endLine": 222,
-      "summary": "`T_eval_cos_and_cosh`: one polynomial realizes both trigonometries. `cos_mul_eq_T_comp` / `cosh_mul_eq_T_comp`: the composition law $\\cos(mn\\cdot z)=T_m(T_n(\\cos z))$, the analytic shadow of $T_{mn}=T_m\\circ T_n$ (`T_mul`)."
+      "summary": "`T_eval_cos_and_cosh`: one polynomial realizes both trigonometries. `cos_mul_eq_T_comp` / `cosh_mul_eq_T_comp`: the composition law $\\cos(mn\\cdot z)=T_m(T_n(\\cos z))$, the analytic shadow of $T_{mn}=T_m\\circ T_n$ (`T_mul`).",
+      "id": "part-6-unification-and-de-moivre-composition"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/meta.json
@@ -70,21 +70,29 @@
     {
       "id": "module-header",
       "title": "Module: Boundary Exact Count via IVT",
+      "startLine": 1,
+      "endLine": 64,
       "summary": "Module docstring framing the boundary cases of Descartes' Rule, why the parity refinement is unavailable (hard FTA content, only ever assumed in the gallery), and how root existence — not parity — settles signVariations ∈ {0,1}. Notes the ℝ-only scope (X²−2 counterexample over ℚ)."
     },
     {
       "id": "zero-case",
       "title": "Part 1: Zero Sign Variations ⟹ No Positive Roots",
+      "startLine": 65,
+      "endLine": 74,
       "summary": "no_pos_roots_of_signVariations_zero: from Mathlib's Descartes bound, signVariations = 0 forces the positive-root count to 0. No parity, no analysis."
     },
     {
       "id": "ivt-existence",
       "title": "Part 2: Opposite Leading/Trailing Signs Force a Positive Root (IVT)",
+      "startLine": 75,
+      "endLine": 165,
       "summary": "exists_pos_root_of_sign_opposition: the analytic heart. Deflate P = Xᵐ·Q (largest power of X), establish Q.eval 0 = trailingCoeff ≠ 0, Q.leadingCoeff = P.leadingCoeff, and positive degree of Q. Use the ±∞ asymptotics to find a far point carrying the leading sign, then the Intermediate Value Theorem to cross zero in (0, ∞)."
     },
     {
       "id": "boundary-count",
       "title": "Part 3: One Sign Variation ⟹ Exactly One Positive Root",
+      "startLine": 166,
+      "endLine": 192,
       "summary": "exactly_one_pos_root_of_sign_opposition: combine Descartes' upper bound (≤ 1) with the IVT existence (≥ 1) to pin the count at exactly 1, conditional on the combinatorial sign opposition. No parity refinement used."
     }
   ],
@@ -105,35 +113,6 @@
       "description": "The classical Descartes Rule of Signs at the root of the OQ chain"
     }
   ],
-  "references": [
-    {
-      "authors": [
-        "Descartes, R."
-      ],
-      "title": "La Géométrie",
-      "year": "1637",
-      "venue": "Appendix to Discours de la méthode, Leiden",
-      "note": "Original statement of the rule of signs."
-    },
-    {
-      "authors": [
-        "Prasolov, V.V."
-      ],
-      "title": "Polynomials",
-      "year": "2004",
-      "venue": "Algorithms and Computation in Mathematics 11, Springer",
-      "note": "Modern reference covering Descartes' rule, the Budan–Fourier theorem, Sturm's theorem and root-localization bounds."
-    }
-  ],
-  "conclusion": {
-    "summary": "In the boundary cases the exact positive-root count is recovered without the parity refinement: signVariations = 0 gives 0 roots from Descartes' bound, and signVariations = 1 gives exactly one root from the bound (≤ 1) together with the Intermediate Value Theorem (≥ 1). The IVT existence argument — deflate by Xᵐ, then cross zero between the trailing sign at 0 and the leading sign at +∞ — is fully machine-checked with 0 sorries and 0 axioms. The only non-analytic input, that one sign variation forces opposite leading/trailing signs, is taken as an explicit combinatorial hypothesis.",
-    "implications": "Shows the boundary cases of Descartes' Rule are strictly easier than the general parity refinement: they require only existence of a sign-change root, a completeness/IVT phenomenon, not the odd-multiplicity FTA argument the gallery has consistently left open. The deflate-then-IVT pattern (P = Xᵐ·Q with nonzero constant term, sign at 0 vs sign at +∞) is reusable for other sign-change root-existence facts. Reduces the open unconditional boundary count to a single, analysis-free combinatorial lemma about List.destutter.",
-    "openQuestions": [
-      "Prove the combinatorial bridge signVariations P = 1 ⟹ sign(leadingCoeff) ≠ sign(trailingCoeff) (the destuttered nonzero-sign list has length 2, so its endpoints differ), making exactly_one_pos_root unconditional.",
-      "Generalize the existence argument from sign-change endpoints to an arbitrary real-closed field, replacing the IVT with the order-completeness available there.",
-      "Combine with a Sturm-style oddness count to extend the exact count beyond the boundary cases signVariations ∈ {0,1}."
-    ]
-  },
   "references": [
     {
       "authors": "Descartes, René",
@@ -163,6 +142,15 @@
       "venue": "Mathlib4"
     }
   ],
+  "conclusion": {
+    "summary": "In the boundary cases the exact positive-root count is recovered without the parity refinement: signVariations = 0 gives 0 roots from Descartes' bound, and signVariations = 1 gives exactly one root from the bound (≤ 1) together with the Intermediate Value Theorem (≥ 1). The IVT existence argument — deflate by Xᵐ, then cross zero between the trailing sign at 0 and the leading sign at +∞ — is fully machine-checked with 0 sorries and 0 axioms. The only non-analytic input, that one sign variation forces opposite leading/trailing signs, is taken as an explicit combinatorial hypothesis.",
+    "implications": "Shows the boundary cases of Descartes' Rule are strictly easier than the general parity refinement: they require only existence of a sign-change root, a completeness/IVT phenomenon, not the odd-multiplicity FTA argument the gallery has consistently left open. The deflate-then-IVT pattern (P = Xᵐ·Q with nonzero constant term, sign at 0 vs sign at +∞) is reusable for other sign-change root-existence facts. Reduces the open unconditional boundary count to a single, analysis-free combinatorial lemma about List.destutter.",
+    "openQuestions": [
+      "Prove the combinatorial bridge signVariations P = 1 ⟹ sign(leadingCoeff) ≠ sign(trailingCoeff) (the destuttered nonzero-sign list has length 2, so its endpoints differ), making exactly_one_pos_root unconditional.",
+      "Generalize the existence argument from sign-change endpoints to an arbitrary real-closed field, replacing the IVT with the order-completeness available there.",
+      "Combine with a Sturm-style oddness count to extend the exact count beyond the boundary cases signVariations ∈ {0,1}."
+    ]
+  },
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/meta.json
@@ -78,26 +78,36 @@
     {
       "id": "module-header",
       "title": "Module: Genericity and Map-Invariance",
+      "startLine": 1,
+      "endLine": 59,
       "summary": "Frames the two loose threads of the parent — the ℚ-pinned coefficient field and the merely-rational root bound — and states the hinge result: signVariations is invariant under strictly monotone ring homs."
     },
     {
       "id": "generic-count",
       "title": "Part I: The Computable Count over an Arbitrary Ordered Field",
+      "startLine": 60,
+      "endLine": 94,
       "summary": "signVarList : List F → ℕ for [Field F] [LinearOrder F] [IsStrictOrderedRing F], the rfl bridge signVarList_coeffList, the transported bound posRoots_le_signVarList, and the no-positive-roots certificate — all field-generic."
     },
     {
       "id": "map-invariance",
       "title": "Part II: Invariance under a Strictly Monotone Ring Homomorphism",
+      "startLine": 95,
+      "endLine": 143,
       "summary": "coeffList_map_of_injective (the coefficient list commutes with an injective hom), sign_map_of_strictMono (signs are preserved), and the headline signVariations_map combining them: (P.map φ).signVariations = P.signVariations."
     },
     {
       "id": "rat-real-bridge",
       "title": "Part III: The ℚ → ℝ Bridge — Seeing the Real Roots",
+      "startLine": 144,
+      "endLine": 174,
       "summary": "signVarList_eq_signVariations_ratCast: the computable ℚ count equals the real polynomial's sign-variation count. realRoots_countP_pos_le_signVarList: Descartes' bound for positive REAL roots, computed from rational coefficients."
     },
     {
       "id": "worked-examples",
       "title": "Part IV: Worked Computable Examples",
+      "startLine": 175,
+      "endLine": 202,
       "summary": "The parent's ℚ examples recovered as instances of the now field-generic definition, discharged by kernel decide (no native_decide)."
     }
   ],
@@ -118,46 +128,6 @@
       "description": "The classical Descartes rule of signs — root of the OQ chain studied here."
     }
   ],
-  "references": [
-    {
-      "authors": [
-        "Basu, S.",
-        "Pollack, R.",
-        "Roy, M.-F."
-      ],
-      "title": "Algorithms in Real Algebraic Geometry",
-      "year": "2006",
-      "venue": "Algorithms and Computation in Mathematics 10, 2nd ed., Springer",
-      "note": "Standard algorithmic reference for sign variations, Sturm sequences, and real-root isolation (Vincent/VAS/VCA)."
-    },
-    {
-      "authors": [
-        "Prasolov, V.V."
-      ],
-      "title": "Polynomials",
-      "year": "2004",
-      "venue": "Algorithms and Computation in Mathematics 11, Springer",
-      "note": "Modern reference covering Descartes' rule, the Budan–Fourier theorem, Sturm's theorem and root-localization bounds."
-    },
-    {
-      "authors": [
-        "The mathlib community"
-      ],
-      "title": "Mathlib.Analysis.SpecialFunctions.Polynomials / Polynomial.signVariations",
-      "year": "2020",
-      "venue": "Mathlib4, Lean 4 mathematical library",
-      "url": "https://leanprover-community.github.io/mathlib4_docs/",
-      "note": "Mathlib's abstract signVariations and roots API that these entries bridge to a computable form."
-    }
-  ],
-  "conclusion": {
-    "summary": "YES: the computable sign-variation count generalizes verbatim to any ordered field with decidable order, with the rfl bridge intact, because Mathlib's signVariations already lives at that generality and the count is purely combinatorial on signs. The substantive new result is that signVariations is invariant under any strictly monotone ring homomorphism (signVariations_map) — a fact not in Mathlib. Specializing to ℚ ↪ ℝ shows the kernel-reducible rational count equals the real polynomial's count, so it bounds the positive REAL roots, repairing the gap left by the parent (whose bound only constrained rational roots). All with 0 axioms; examples by kernel decide.",
-    "implications": "Map-invariance of signVariations is reusable infrastructure: it lets any computable subfield (ℚ, computable algebraic reals) certify sign-variation facts about polynomials over a larger ordered field by pushing forward along an order embedding. It is also exactly the lemma needed to make the constructive Descartes bound a statement about real roots rather than coefficient-field roots. The trichotomy proof that a strict-mono ring hom preserves SignType.sign is a small lemma of independent use for any sign-driven polynomial invariant.",
-    "openQuestions": [
-      "Can map-invariance be strengthened to an order-reflecting equivalence, characterizing exactly which (not-necessarily-injective) ring homs preserve signVariations?",
-      "Combined with a formalization of Sturm's theorem over ℚ, does the real-root bound realRoots_countP_pos_le_signVarList upgrade to an exact computable count of positive real roots?"
-    ]
-  },
   "references": [
     {
       "authors": "Basu, Saugata; Pollack, Richard; Roy, Marie-Françoise",
@@ -187,6 +157,14 @@
       "venue": "Mathlib4"
     }
   ],
+  "conclusion": {
+    "summary": "YES: the computable sign-variation count generalizes verbatim to any ordered field with decidable order, with the rfl bridge intact, because Mathlib's signVariations already lives at that generality and the count is purely combinatorial on signs. The substantive new result is that signVariations is invariant under any strictly monotone ring homomorphism (signVariations_map) — a fact not in Mathlib. Specializing to ℚ ↪ ℝ shows the kernel-reducible rational count equals the real polynomial's count, so it bounds the positive REAL roots, repairing the gap left by the parent (whose bound only constrained rational roots). All with 0 axioms; examples by kernel decide.",
+    "implications": "Map-invariance of signVariations is reusable infrastructure: it lets any computable subfield (ℚ, computable algebraic reals) certify sign-variation facts about polynomials over a larger ordered field by pushing forward along an order embedding. It is also exactly the lemma needed to make the constructive Descartes bound a statement about real roots rather than coefficient-field roots. The trichotomy proof that a strict-mono ring hom preserves SignType.sign is a small lemma of independent use for any sign-driven polynomial invariant.",
+    "openQuestions": [
+      "Can map-invariance be strengthened to an order-reflecting equivalence, characterizing exactly which (not-necessarily-injective) ring homs preserve signVariations?",
+      "Combined with a formalization of Sturm's theorem over ℚ, does the real-root bound realRoots_countP_pos_le_signVarList upgrade to an exact computable count of positive real roots?"
+    ]
+  },
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04/meta.json
@@ -68,26 +68,36 @@
     {
       "id": "module-header",
       "title": "Module: Constructive Sign-Variation Count",
+      "startLine": 1,
+      "endLine": 58,
       "summary": "Module docstring framing the OQ: Mathlib's signVariations is noncomputable over ℝ/ℚ (coeffList and the real sign map do not reduce). Spells out which half of Descartes' Rule is constructive (the bound) and which is not (the root count, needing Sturm)."
     },
     {
       "id": "computable-count",
       "title": "Part 1: The Computable Core",
+      "startLine": 59,
+      "endLine": 72,
       "summary": "signVarList : List ℚ → ℕ, a decidable mirror of Polynomial.signVariations on an explicit rational coefficient list. Every operation reduces in the kernel, so the function #evals and is provable by decide."
     },
     {
       "id": "bridge-and-bound",
       "title": "Part 2: Correctness Bridge and Transported Bound",
+      "startLine": 73,
+      "endLine": 92,
       "summary": "signVarList_coeffList: signVarList P.coeffList = P.signVariations by rfl, certifying the algorithm. posRoots_le_signVarList: Mathlib's Descartes bound restated with the computable count on the right."
     },
     {
       "id": "decidable-certificate",
       "title": "Part 3: Decidable Certificate of No Positive Roots",
+      "startLine": 93,
+      "endLine": 104,
       "summary": "no_pos_roots_of_signVarList_zero: the decidable test signVarList P.coeffList = 0 soundly proves P has no positive roots. signVarList_pos_of_pos_roots: the contrapositive — a positive root forces a positive variation count."
     },
     {
       "id": "worked-examples",
       "title": "Part 4: Worked Computable Examples",
+      "startLine": 105,
+      "endLine": 134,
       "summary": "Seven explicit coefficient lists discharged by kernel decide: [1,-1,-1,1]→2, [1,3,2]→0 (certificate fires), [1,0,-1]→1, interior zeros never count, fully alternating lists realise the maximum, and the empty/singleton lists give 0."
     }
   ],
@@ -108,48 +118,6 @@
       "description": "Sibling OQ exploring the complex-root-theory route to the parity result; this file instead pursues constructivity"
     }
   ],
-  "references": [
-    {
-      "authors": [
-        "Collins, G.E.",
-        "Akritas, A.G."
-      ],
-      "title": "Polynomial real root isolation using Descartes' rule of signs",
-      "year": "1976",
-      "venue": "Proc. ACM Symposium on Symbolic and Algebraic Computation (SYMSAC), pp. 272–275",
-      "note": "The Descartes/Vincent-based real-root isolation algorithm behind the computable sign-variation count."
-    },
-    {
-      "authors": [
-        "Basu, S.",
-        "Pollack, R.",
-        "Roy, M.-F."
-      ],
-      "title": "Algorithms in Real Algebraic Geometry",
-      "year": "2006",
-      "venue": "Algorithms and Computation in Mathematics 10, 2nd ed., Springer",
-      "note": "Standard algorithmic reference for sign variations, Sturm sequences, and real-root isolation (Vincent/VAS/VCA)."
-    },
-    {
-      "authors": [
-        "The mathlib community"
-      ],
-      "title": "Mathlib.Analysis.SpecialFunctions.Polynomials / Polynomial.signVariations",
-      "year": "2020",
-      "venue": "Mathlib4, Lean 4 mathematical library",
-      "url": "https://leanprover-community.github.io/mathlib4_docs/",
-      "note": "Mathlib's abstract signVariations and roots API that these entries bridge to a computable form."
-    }
-  ],
-  "conclusion": {
-    "summary": "YES, the bound side of Descartes' Rule can be made constructive. Mathlib's signVariations is noncomputable as a function of the polynomial, but its combinatorial core is a computable function on the coefficient list. This file builds that function (signVarList over ℚ), proves by rfl that it agrees with the abstract count, transports Descartes' upper bound to it, and extracts a decidable sound certificate of no positive roots — all with 0 axioms, examples checked by kernel decide.",
-    "implications": "Separates the genuinely algorithmic part of Descartes' Rule (counting sign variations) from the genuinely noncomputable part (locating real roots, which needs Sturm). The signVarList / signVarList_coeffList pattern — a computable list mirror certified by rfl against a noncomputable polynomial-level definition — is reusable for other coefficient-driven polynomial invariants. The decidable no-positive-roots certificate is a small but genuinely constructive decision procedure: sound, terminating, and checkable.",
-    "openQuestions": [
-      "Can an exact constructive root-count certificate be built by combining signVarList with a formalization of Sturm's theorem over ℚ?",
-      "Does the parity refinement (signVariations ≡ positive roots mod 2, proved over ℝ in the parent chain) lift to give a computable exact count when signVarList returns 0 or 1?",
-      "Can signVarList be generalized from ℚ to an arbitrary computable LinearOrderedField (e.g. computable algebraic reals) while keeping the rfl bridge?"
-    ]
-  },
   "references": [
     {
       "authors": "Basu, Saugata; Pollack, Richard; Roy, Marie-Françoise",
@@ -179,6 +147,15 @@
       "venue": "Mathlib4"
     }
   ],
+  "conclusion": {
+    "summary": "YES, the bound side of Descartes' Rule can be made constructive. Mathlib's signVariations is noncomputable as a function of the polynomial, but its combinatorial core is a computable function on the coefficient list. This file builds that function (signVarList over ℚ), proves by rfl that it agrees with the abstract count, transports Descartes' upper bound to it, and extracts a decidable sound certificate of no positive roots — all with 0 axioms, examples checked by kernel decide.",
+    "implications": "Separates the genuinely algorithmic part of Descartes' Rule (counting sign variations) from the genuinely noncomputable part (locating real roots, which needs Sturm). The signVarList / signVarList_coeffList pattern — a computable list mirror certified by rfl against a noncomputable polynomial-level definition — is reusable for other coefficient-driven polynomial invariants. The decidable no-positive-roots certificate is a small but genuinely constructive decision procedure: sound, terminating, and checkable.",
+    "openQuestions": [
+      "Can an exact constructive root-count certificate be built by combining signVarList with a formalization of Sturm's theorem over ℚ?",
+      "Does the parity refinement (signVariations ≡ positive roots mod 2, proved over ℝ in the parent chain) lift to give a computable exact count when signVarList returns 0 or 1?",
+      "Can signVarList be generalized from ℚ to an arbitrary computable LinearOrderedField (e.g. computable algebraic reals) while keeping the rfl bridge?"
+    ]
+  },
   "leanFile": {
     "imports": [
       "Mathlib.Algebra.Polynomial.RuleOfSigns",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -44,24 +44,39 @@
   },
   "sections": [
     {
+      "id": "the-grid-transpose-and-its-sign-the-combinatorial-gap",
       "title": "The grid transpose and its sign (the combinatorial gap)",
-      "content": "gridTranspose m n is the row-major ↔ column-major reindexing of Fin (m*n); gridTranspose_apply / gridTranspose_val confirm it sends n·i+j to m·j+i. Supporting mixed-radix facts fpe_val, fpe_symm, fpe_divNat, fpe_modNat, finCongr_lt, encode_lt, and card_strict_pairs (#{(i,j) : i<j over Fin k} = C(k,2)) feed sign_gridTranspose: its sign is (-1)^(C(m,2)·C(n,2)), proved by sign_eq_prod_prod_Iio and a Finset.card_bij' bijection onto the inversion set."
+      "startLine": 1,
+      "endLine": 394,
+      "summary": "gridTranspose m n is the row-major ↔ column-major reindexing of Fin (m*n); gridTranspose_apply / gridTranspose_val confirm it sends n·i+j to m·j+i. Supporting mixed-radix facts fpe_val, fpe_symm, fpe_divNat, fpe_modNat, finCongr_lt, encode_lt, and card_strict_pairs (#{(i,j) : i<j over Fin k} = C(k,2)) feed sign_gridTranspose: its sign is (-1)^(C(m,2)·C(n,2)), proved by sign_eq_prod_prod_Iio and a Finset.card_bij' bijection onto the inversion set."
     },
     {
+      "id": "parity-bridge-and-the-classical-form-transpose-sign",
       "title": "Parity bridge and the classical-form transpose sign",
-      "content": "neg_one_pow_choose_two_mul_odd: for odd m,n, (-1)^(C(m,2)·C(n,2)) = (-1)^(((m-1)/2)·((n-1)/2)) — the elementary number-theory step turning the inversion count into the textbook reciprocity exponent (independent of sign_gridTranspose). sign_gridTranspose_odd: sign(gridTranspose m n) = (-1)^(((m-1)/2)·((n-1)/2)) for odd m,n."
+      "startLine": 395,
+      "endLine": 433,
+      "summary": "neg_one_pow_choose_two_mul_odd: for odd m,n, (-1)^(C(m,2)·C(n,2)) = (-1)^(((m-1)/2)·((n-1)/2)) — the elementary number-theory step turning the inversion count into the textbook reciprocity exponent (independent of sign_gridTranspose). sign_gridTranspose_odd: sign(gridTranspose m n) = (-1)^(((m-1)/2)·((n-1)/2)) for odd m,n."
     },
     {
+      "id": "the-three-transition-skeleton",
       "title": "The three-transition skeleton",
-      "content": "rowOrder = finProdFinEquiv and colOrder its mirror; gridTranspose = rowOrder⁻¹∘colOrder (gridTranspose_eq). transRC = colOrder⁻¹∘rowOrder is conjugate to gridTranspose (sign_transRC). quadratic_reciprocity_of_transition_signs: given any diagonal order D and the per-line hypotheses sign(rowOrder∘D⁻¹) = (q/p), sign(colOrder∘D⁻¹) = (p/q), the tautology τ_cd⁻¹∘τ_rd = τ_rc plus multiplicativity of sign and sign_gridTranspose_odd yield (q/p)·(p/q) = (-1)^((p-1)/2·(q-1)/2)."
+      "startLine": 434,
+      "endLine": 522,
+      "summary": "rowOrder = finProdFinEquiv and colOrder its mirror; gridTranspose = rowOrder⁻¹∘colOrder (gridTranspose_eq). transRC = colOrder⁻¹∘rowOrder is conjugate to gridTranspose (sign_transRC). quadratic_reciprocity_of_transition_signs: given any diagonal order D and the per-line hypotheses sign(rowOrder∘D⁻¹) = (q/p), sign(colOrder∘D⁻¹) = (p/q), the tautology τ_cd⁻¹∘τ_rd = τ_rc plus multiplicativity of sign and sign_gridTranspose_odd yield (q/p)·(p/q) = (-1)^((p-1)/2·(q-1)/2)."
     },
     {
+      "id": "per-line-zolotarev-sign-discharging-the-transition-sign-hypotheses",
       "title": "Per-line Zolotarev sign: discharging the transition-sign hypotheses",
-      "content": "sign_addLeft_odd: translation x ↦ b+x of ℤ/n is even for odd n (order divides n, sign in order-2 group). sign_addLeft_mul: composing with a translation leaves the sign unchanged. sign_affineLine_eq_legendreSym: sign(x ↦ a·x + b on ℤ/p) = (A/p) for A ≡ a (mod p), via the parent's Frobenius identity. sign_prodCongrLeft_affineLine: a fiberwise-affine permutation of ℤ/p × ℤ/q has total sign the single Legendre symbol (A/p), since the q-fold product collapses (q odd)."
+      "startLine": 523,
+      "endLine": 622,
+      "summary": "sign_addLeft_odd: translation x ↦ b+x of ℤ/n is even for odd n (order divides n, sign in order-2 group). sign_addLeft_mul: composing with a translation leaves the sign unchanged. sign_affineLine_eq_legendreSym: sign(x ↦ a·x + b on ℤ/p) = (A/p) for A ≡ a (mod p), via the parent's Frobenius identity. sign_prodCongrLeft_affineLine: a fiberwise-affine permutation of ℤ/p × ℤ/q has total sign the single Legendre symbol (A/p), since the q-fold product collapses (q odd)."
     },
     {
+      "id": "closing-the-gap-the-concrete-crt-order",
       "title": "Closing the gap: the concrete CRT order",
-      "content": "arrEquiv : Fin p × Fin q ≃ ℤ/p × ℤ/q via ZMod.finEquiv; crtOrder is the diagonal order whose inverse is the Chinese-remainder map. sign_rowTransition / sign_colTransition conjugate crtOrder⁻¹∘rowOrder (resp. ∘colOrder) by arrEquiv (resp. arrEquiv∘swap) to realize each transition as prodCongrLeft of the affine line maps x ↦ q·x + j (resp. x ↦ p·x + i), discharging the hypotheses. zolotarev_quadratic_reciprocity assembles the unconditional law with D := crtOrder."
+      "startLine": 623,
+      "endLine": 817,
+      "summary": "arrEquiv : Fin p × Fin q ≃ ℤ/p × ℤ/q via ZMod.finEquiv; crtOrder is the diagonal order whose inverse is the Chinese-remainder map. sign_rowTransition / sign_colTransition conjugate crtOrder⁻¹∘rowOrder (resp. ∘colOrder) by arrEquiv (resp. arrEquiv∘swap) to realize each transition as prodCongrLeft of the affine line maps x ↦ q·x + j (resp. x ↦ p·x + i), discharging the hypotheses. zolotarev_quadratic_reciprocity assembles the unconditional law with D := crtOrder."
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -43,20 +43,32 @@
   },
   "sections": [
     {
+      "id": "negation-is-an-involution",
       "title": "Negation is an involution",
-      "content": "ringMulPerm_neg_one_sq: the Zolotarev permutation for a = -1 is multiplication by -1, i.e. negation x ↦ -x, and (ringMulPerm (-1))² = 1 because (-1)·(-1) = 1 in the units (ringMulPerm_mul, neg_one_mul, neg_neg, ringMulPerm_one)."
+      "startLine": 1,
+      "endLine": 71,
+      "summary": "ringMulPerm_neg_one_sq: the Zolotarev permutation for a = -1 is multiplication by -1, i.e. negation x ↦ -x, and (ringMulPerm (-1))² = 1 because (-1)·(-1) = 1 in the units (ringMulPerm_mul, neg_one_mul, neg_neg, ringMulPerm_one)."
     },
     {
+      "id": "for-odd-n-negation-fixes-exactly-one-point",
       "title": "For odd n, negation fixes exactly one point",
-      "content": "card_fixedPoints_neg_one: via Fintype.card_eq_one_iff, the fixed-point set of negation is {0}. From -x = x one gets 2x = 0 (linear_combination); since n is odd, 2 is coprime to n (Nat.prime_two.coprime_iff_not_dvd + Nat.two_dvd_ne_zero + Nat.odd_iff) hence a unit mod n (ZMod.isUnit_iff_coprime), so x = 0 (IsUnit.mul_right_eq_zero)."
+      "startLine": 72,
+      "endLine": 105,
+      "summary": "card_fixedPoints_neg_one: via Fintype.card_eq_one_iff, the fixed-point set of negation is {0}. From -x = x one gets 2x = 0 (linear_combination); since n is odd, 2 is coprime to n (Nat.prime_two.coprime_iff_not_dvd + Nat.two_dvd_ne_zero + Nat.odd_iff) hence a unit mod n (ZMod.isUnit_iff_coprime), so x = 0 (IsUnit.mul_right_eq_zero)."
     },
     {
+      "id": "the-parity-of-the-negation-permutation",
       "title": "The parity of the negation permutation",
-      "content": "sign_neg_one: Equiv.Perm.sign_of_pow_two_eq_one applied to the involution gives sign(ringMulPerm (-1)) = (-1)^((|ℤ/n| - |fixedPoints|)/2); substituting ZMod.card n = n and card_fixedPoints_neg_one = 1 yields (-1)^((n-1)/2)."
+      "startLine": 106,
+      "endLine": 124,
+      "summary": "sign_neg_one: Equiv.Perm.sign_of_pow_two_eq_one applied to the involution gives sign(ringMulPerm (-1)) = (-1)^((|ℤ/n| - |fixedPoints|)/2); substituting ZMod.card n = n and card_fixedPoints_neg_one = 1 yields (-1)^((n-1)/2)."
     },
     {
+      "id": "the-first-supplement-and-its-specializations",
       "title": "The first supplement and its specializations",
-      "content": "jacobiSym_neg_one: J(-1 | n) = (-1)^((n-1)/2) by rewriting through the parent's sign_ringMulPerm_eq_jacobiSym_odd (a = -1, A = -1) and sign_neg_one. jacobiSym_neg_one_eq_chi4: the same value equals χ₄ n (jacobiSym.at_neg_one), recovering ZMod.χ₄_eq_neg_one_pow. legendreSym_neg_one: the Legendre/Euler-criterion case (-1 / p) = (-1)^((p-1)/2) at an odd prime, via jacobiSym.legendreSym.to_jacobiSym and Nat.Prime.odd_of_ne_two."
+      "startLine": 125,
+      "endLine": 153,
+      "summary": "jacobiSym_neg_one: J(-1 | n) = (-1)^((n-1)/2) by rewriting through the parent's sign_ringMulPerm_eq_jacobiSym_odd (a = -1, A = -1) and sign_neg_one. jacobiSym_neg_one_eq_chi4: the same value equals χ₄ n (jacobiSym.at_neg_one), recovering ZMod.χ₄_eq_neg_one_pow. legendreSym_neg_one: the Legendre/Euler-criterion case (-1 / p) = (-1)^((p-1)/2) at an odd prime, via jacobiSym.legendreSym.to_jacobiSym and Nat.Prime.odd_of_ne_two."
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -45,20 +45,32 @@
   },
   "sections": [
     {
+      "id": "the-power-form-of-the-combined-supplement-j-2-n",
       "title": "The power form of the combined supplement J(-2 | n)",
-      "content": "jacobiSym_neg_two: J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8) for odd n. Split -2 = (-1)·2 (jacobiSym.mul_left), rewrite the two factors by the sibling supplements J(-1|n) = (-1)^((n-1)/2) and J(2|n) = (-1)^((n²-1)/8), and fuse the exponents with pow_add. jacobiSym_neg_two_eq: the value form, J(-2|n) = (if n % 8 = 1 ∨ n % 8 = 3 then 1 else -1), read off Mathlib's χ₈' via jacobiSym.at_neg_two and χ₈'_nat_eq_if_mod_eight (the n-even branch discarded by oddness)."
+      "startLine": 1,
+      "endLine": 113,
+      "summary": "jacobiSym_neg_two: J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8) for odd n. Split -2 = (-1)·2 (jacobiSym.mul_left), rewrite the two factors by the sibling supplements J(-1|n) = (-1)^((n-1)/2) and J(2|n) = (-1)^((n²-1)/8), and fuse the exponents with pow_add. jacobiSym_neg_two_eq: the value form, J(-2|n) = (if n % 8 = 1 ∨ n % 8 = 3 then 1 else -1), read off Mathlib's χ₈' via jacobiSym.at_neg_two and χ₈'_nat_eq_if_mod_eight (the n-even branch discarded by oddness)."
     },
     {
+      "id": "closed-form-power-formula-for",
       "title": "Closed-form power formula for χ₈'",
-      "content": "chi8'_eq_neg_one_pow: χ₈' n = (-1)^((n-1)/2 + (n²-1)/8) for odd n — the -2 analogue of the second supplement's chi8_eq_neg_one_pow, absent from Mathlib (which carries χ₈' only as the mod-8 case split χ₈'_nat_eq_if_mod_eight). Proved by chaining jacobiSym_neg_two_eq and jacobiSym_neg_two. neg_one_pow_neg_two records the dual reading: the fused exponent evaluates to +1 at n ≡ 1,3 (mod 8) and -1 at n ≡ 5,7 (mod 8)."
+      "startLine": 114,
+      "endLine": 139,
+      "summary": "chi8'_eq_neg_one_pow: χ₈' n = (-1)^((n-1)/2 + (n²-1)/8) for odd n — the -2 analogue of the second supplement's chi8_eq_neg_one_pow, absent from Mathlib (which carries χ₈' only as the mod-8 case split χ₈'_nat_eq_if_mod_eight). Proved by chaining jacobiSym_neg_two_eq and jacobiSym_neg_two. neg_one_pow_neg_two records the dual reading: the fused exponent evaluates to +1 at n ≡ 1,3 (mod 8) and -1 at n ≡ 5,7 (mod 8)."
     },
     {
+      "id": "the-zolotarev-permutation-x-2-x",
       "title": "The Zolotarev permutation x ↦ -2·x",
-      "content": "sign_ringMulPerm_neg_two and sign_neg_two: the grandparent's full odd-modulus identity sign_ringMulPerm_eq_jacobiSym_odd (with a unit of residue -2 and integer representative -2) gives sign(x ↦ -2·x on ℤ/n) = J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8). The canonical hypothesis-free form builds the unit as -(ZMod.unitOfCoprime 2 _), using Nat.Coprime 2 n from oddness and Units.val_neg. This reads the combined supplement off the composition of Zolotarev's negation and doubling permutations."
+      "startLine": 140,
+      "endLine": 166,
+      "summary": "sign_ringMulPerm_neg_two and sign_neg_two: the grandparent's full odd-modulus identity sign_ringMulPerm_eq_jacobiSym_odd (with a unit of residue -2 and integer representative -2) gives sign(x ↦ -2·x on ℤ/n) = J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8). The canonical hypothesis-free form builds the unit as -(ZMod.unitOfCoprime 2 _), using Nat.Coprime 2 n from oddness and Units.val_neg. This reads the combined supplement off the composition of Zolotarev's negation and doubling permutations."
     },
     {
+      "id": "legendre-special-case-and-the-qr-characterization",
       "title": "Legendre special case and the QR characterization",
-      "content": "legendreSym_neg_two: for an odd prime p, (-2 / p) = (-1)^((p-1)/2 + (p²-1)/8), via jacobiSym.legendreSym.to_jacobiSym and Nat.Prime.odd_of_ne_two. legendreSym_neg_two_eq gives the prime mod-8 indicator, and neg_two_qr_iff packages the classical statement: legendreSym p (-2) = 1 ↔ p ≡ 1 or 3 (mod 8) — i.e. -2 is a quadratic residue mod p exactly for those residues."
+      "startLine": 167,
+      "endLine": 201,
+      "summary": "legendreSym_neg_two: for an odd prime p, (-2 / p) = (-1)^((p-1)/2 + (p²-1)/8), via jacobiSym.legendreSym.to_jacobiSym and Nat.Prime.odd_of_ne_two. legendreSym_neg_two_eq gives the prime mod-8 indicator, and neg_two_qr_iff packages the classical statement: legendreSym p (-2) = 1 ↔ p ≡ 1 or 3 (mod 8) — i.e. -2 is a quadratic residue mod p exactly for those residues."
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -46,25 +46,29 @@
       "title": "Parity of the supplement exponent",
       "startLine": 80,
       "endLine": 113,
-      "content": "exponent_parity: for odd n, ((n²-1)/8) % 2 = (if n % 8 = 1 ∨ n % 8 = 7 then 0 else 1). With n = 2m+1, (n²-1)/8 = m(m+1)/2 = T_m (the m-th triangular number), proved by omega from (2m+1)² = 4·m(m+1)+1. Decomposing m = 4j+s and rewriting m(m+1) = 2·(8j²+…) per residue, split_ifs + omega finish both the exponent parity and the n-mod-8 side condition."
+      "summary": "exponent_parity: for odd n, ((n²-1)/8) % 2 = (if n % 8 = 1 ∨ n % 8 = 7 then 0 else 1). With n = 2m+1, (n²-1)/8 = m(m+1)/2 = T_m (the m-th triangular number), proved by omega from (2m+1)² = 4·m(m+1)+1. Decomposing m = 4j+s and rewriting m(m+1) = 2·(8j²+…) per residue, split_ifs + omega finish both the exponent parity and the n-mod-8 side condition.",
+      "id": "parity-of-the-supplement-exponent"
     },
     {
       "title": "The supplement value as a signed power",
       "startLine": 114,
       "endLine": 126,
-      "content": "neg_one_pow_exponent: (-1)^((n²-1)/8) = (if n % 8 = 1 ∨ n % 8 = 7 then 1 else -1), obtained from exponent_parity via Even.neg_one_pow / Odd.neg_one_pow: +1 when n ≡ ±1 (mod 8), -1 when n ≡ ±3 (mod 8)."
+      "summary": "neg_one_pow_exponent: (-1)^((n²-1)/8) = (if n % 8 = 1 ∨ n % 8 = 7 then 1 else -1), obtained from exponent_parity via Even.neg_one_pow / Odd.neg_one_pow: +1 when n ≡ ±1 (mod 8), -1 when n ≡ ±3 (mod 8).",
+      "id": "the-supplement-value-as-a-signed-power"
     },
     {
       "title": "Closed-form power formula for χ₈",
       "startLine": 127,
       "endLine": 141,
-      "content": "chi8_eq_neg_one_pow: χ₈ n = (-1)^((n²-1)/8) for odd n — the octic analogue of ZMod.χ₄_eq_neg_one_pow, absent from Mathlib (which has only the case split χ₈_nat_eq_if_mod_eight). Proved by rewriting χ₈ via the case split and matching it to neg_one_pow_exponent, the n-even branch being killed by oddness."
+      "summary": "chi8_eq_neg_one_pow: χ₈ n = (-1)^((n²-1)/8) for odd n — the octic analogue of ZMod.χ₄_eq_neg_one_pow, absent from Mathlib (which has only the case split χ₈_nat_eq_if_mod_eight). Proved by rewriting χ₈ via the case split and matching it to neg_one_pow_exponent, the n-even branch being killed by oddness.",
+      "id": "closed-form-power-formula-for"
     },
     {
       "title": "The second supplement and the doubling permutation",
       "startLine": 142,
       "endLine": 197,
-      "content": "jacobiSym_two: J(2 | n) = (-1)^((n²-1)/8) by jacobiSym.at_two (J(2 | n) = χ₈ n) and chi8_eq_neg_one_pow. sign_ringMulPerm_two / sign_doubling: the parent's sign_ringMulPerm_eq_jacobiSym_odd gives sign(x ↦ 2·x on ℤ/n) = J(2 | n) = (-1)^((n²-1)/8), in a unit-hypothesis form and a canonical hypothesis-free form using ZMod.unitOfCoprime 2. legendreSym_two: the Legendre/Euler-criterion case (2 / p) = (-1)^((p²-1)/8) at an odd prime."
+      "summary": "jacobiSym_two: J(2 | n) = (-1)^((n²-1)/8) by jacobiSym.at_two (J(2 | n) = χ₈ n) and chi8_eq_neg_one_pow. sign_ringMulPerm_two / sign_doubling: the parent's sign_ringMulPerm_eq_jacobiSym_odd gives sign(x ↦ 2·x on ℤ/n) = J(2 | n) = (-1)^((n²-1)/8), in a unit-hypothesis form and a canonical hypothesis-free form using ZMod.unitOfCoprime 2. legendreSym_two: the Legendre/Euler-criterion case (2 / p) = (-1)^((p²-1)/8) at an odd prime.",
+      "id": "the-second-supplement-and-the-doubling-permutation"
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -43,20 +43,32 @@
   },
   "sections": [
     {
+      "id": "generic-bridges-units-reduction-crt-components-legendresym-congruence",
       "title": "Generic bridges: units reduction, CRT components, legendreSym congruence",
-      "content": "coe_unitsMap: (ZMod.unitsMap h u : ℤ/m) = castHom h (u : ℤ/n). chineseRemainder_fst / chineseRemainder_snd: the two projections of ZMod.chineseRemainder are the canonical casts to ℤ/m and ℤ/n — proved by RingHom.ext_zmod (any two ring homs out of ℤ/(m·n) are equal). legendreSym_congr: equal residues mod p give equal Legendre symbols (legendreSym.mod + ZMod.intCast_eq_intCast_iff)."
+      "startLine": 1,
+      "endLine": 112,
+      "summary": "coe_unitsMap: (ZMod.unitsMap h u : ℤ/m) = castHom h (u : ℤ/n). chineseRemainder_fst / chineseRemainder_snd: the two projections of ZMod.chineseRemainder are the canonical casts to ℤ/m and ℤ/n — proved by RingHom.ext_zmod (any two ring homs out of ℤ/(m·n) are equal). legendreSym_congr: equal residues mod p give equal Legendre symbols (legendreSym.mod + ZMod.intCast_eq_intCast_iff)."
     },
     {
+      "id": "the-prime-power-base-in-representative-free-form",
       "title": "The prime-power base in representative-free form",
-      "content": "sign_ringMulPerm_eq_jacobiSym_of_cast: for an odd prime p, k ≥ 1, a unit a : (ℤ/pᵏ)ˣ and any integer A ≡ a (mod pᵏ), sign(ringMulPerm a) = J(A | pᵏ). Repackages the parent's sign_ringMulPerm_eq_legendre_pow and jacobiSym_prime_pow, reducing both legendre symbols (of (a mod p).val and of A) to the same residue mod p via legendreSym_congr and one cast of the hypothesis A ≡ a down to ℤ/p."
+      "startLine": 113,
+      "endLine": 137,
+      "summary": "sign_ringMulPerm_eq_jacobiSym_of_cast: for an odd prime p, k ≥ 1, a unit a : (ℤ/pᵏ)ˣ and any integer A ≡ a (mod pᵏ), sign(ringMulPerm a) = J(A | pᵏ). Repackages the parent's sign_ringMulPerm_eq_legendre_pow and jacobiSym_prime_pow, reducing both legendre symbols (of (a mod p).val and of A) to the same residue mod p via legendreSym_congr and one cast of the hypothesis A ≡ a down to ℤ/p."
     },
     {
+      "id": "multiplicative-induction-over-the-odd-modulus",
       "title": "Multiplicative induction over the odd modulus",
-      "content": "main_aux: Nat.recOnPosPrimePosCoprime. zero excluded by NeZero; one is ℤ/1 trivial (jacobiSym.one_right); prime_pow derives p ≠ 2 from Odd (pᵏ) and applies the base; coprime n = u·v takes a₁, a₂ = unitsMap a, proves the CRT-component and numerator-cast hypotheses, splits the sign by sign_ringMulPerm_mul_of_odd, applies both inductive hypotheses, and recombines with jacobiSym.mul_right."
+      "startLine": 138,
+      "endLine": 193,
+      "summary": "main_aux: Nat.recOnPosPrimePosCoprime. zero excluded by NeZero; one is ℤ/1 trivial (jacobiSym.one_right); prime_pow derives p ≠ 2 from Odd (pᵏ) and applies the base; coprime n = u·v takes a₁, a₂ = unitsMap a, proves the CRT-component and numerator-cast hypotheses, splits the sign by sign_ringMulPerm_mul_of_odd, applies both inductive hypotheses, and recombines with jacobiSym.mul_right."
     },
     {
+      "id": "the-full-odd-modulus-zolotarev-frobenius-identity",
       "title": "The full odd-modulus Zolotarev–Frobenius identity",
-      "content": "sign_ringMulPerm_eq_jacobiSym_odd: for every odd n > 0, unit a, and representative A ≡ a (mod n), sign(ringMulPerm a) = J(A | n). sign_ringMulPerm_eq_jacobiSym_val: the canonical-representative form J((a).val | n). signRingHom_eq_jacobiSym: through ZolotarevCRT.signRingHom, the Zolotarev sign CHARACTER on (ℤ/n)ˣ IS the Jacobi symbol for odd n."
+      "startLine": 194,
+      "endLine": 216,
+      "summary": "sign_ringMulPerm_eq_jacobiSym_odd: for every odd n > 0, unit a, and representative A ≡ a (mod n), sign(ringMulPerm a) = J(A | n). sign_ringMulPerm_eq_jacobiSym_val: the canonical-representative form J((a).val | n). signRingHom_eq_jacobiSym: through ZolotarevCRT.signRingHom, the Zolotarev sign CHARACTER on (ℤ/n)ˣ IS the Jacobi symbol for odd n."
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -43,20 +43,32 @@
   },
   "sections": [
     {
+      "id": "the-p-multiplication-bridge-on-p",
       "title": "The p-multiplication bridge on ℤ/pⁿ⁺¹",
-      "content": "mul_p_eq_zero_iff: p·z = 0 in ℤ/pⁿ⁺¹ iff z reduces to 0 in ℤ/pⁿ (both express pⁿ ∣ z.val), via ZMod.natCast_eq_zero_iff and cancelling one factor of p (Nat.mul_dvd_mul_iff_left). mul_p_of_castHom_eq and castHom_eq_of_mul_p_eq promote this to p·u = p·v ⟺ castHom u = castHom v — the single fact behind both the non-unit isomorphism and its intertwining."
+      "startLine": 1,
+      "endLine": 115,
+      "summary": "mul_p_eq_zero_iff: p·z = 0 in ℤ/pⁿ⁺¹ iff z reduces to 0 in ℤ/pⁿ (both express pⁿ ∣ z.val), via ZMod.natCast_eq_zero_iff and cancelling one factor of p (Nat.mul_dvd_mul_iff_left). mul_p_of_castHom_eq and castHom_eq_of_mul_p_eq promote this to p·u = p·v ⟺ castHom u = castHom v — the single fact behind both the non-unit isomorphism and its intertwining."
     },
     {
+      "id": "the-non-unit-block-is-p",
       "title": "The non-unit block is ℤ/pⁿ⁻¹",
-      "content": "not_isUnit_mul_p: p·z is never a unit (ZMod.isUnit_iff_coprime). nonUnitsFun / nonUnitsFun_bijective / nonUnitsEquiv: y ↦ p·(lift y) is a bijection ℤ/pⁿ ≃ {non-units of ℤ/pⁿ⁺¹}, injective by the bridge and surjective by counting (pⁿ⁺¹ − φ(pⁿ⁺¹) = pⁿ)."
+      "startLine": 116,
+      "endLine": 175,
+      "summary": "not_isUnit_mul_p: p·z is never a unit (ZMod.isUnit_iff_coprime). nonUnitsFun / nonUnitsFun_bijective / nonUnitsEquiv: y ↦ p·(lift y) is a bijection ℤ/pⁿ ≃ {non-units of ℤ/pⁿ⁺¹}, injective by the bridge and surjective by counting (pⁿ⁺¹ − φ(pⁿ⁺¹) = pⁿ)."
     },
     {
+      "id": "the-prime-power-recursion-for-the-whole-ring-sign",
       "title": "The prime-power recursion for the whole-ring sign",
-      "content": "sign_ringMulPerm_succ: for a unit a : (ℤ/pⁿ⁺¹)ˣ, sign(ringMulPerm a) = legendreSym p (a mod p) · sign(ringMulPerm ā on ℤ/pⁿ). Proof: sign_subtypeCongr factors the sign over the units / non-units partition; the units block is sign(Equiv.mulLeft a) = legendreSym p (a mod p) (parent lemma, transported via units↔IsUnit-subtype equiv); the non-unit block is sign(ringMulPerm ā) (transported via the μ-bijection, intertwining from the bridge)."
+      "startLine": 176,
+      "endLine": 263,
+      "summary": "sign_ringMulPerm_succ: for a unit a : (ℤ/pⁿ⁺¹)ˣ, sign(ringMulPerm a) = legendreSym p (a mod p) · sign(ringMulPerm ā on ℤ/pⁿ). Proof: sign_subtypeCongr factors the sign over the units / non-units partition; the units block is sign(Equiv.mulLeft a) = legendreSym p (a mod p) (parent lemma, transported via units↔IsUnit-subtype equiv); the non-unit block is sign(ringMulPerm ā) (transported via the μ-bijection, intertwining from the bridge)."
     },
     {
+      "id": "the-prime-power-zolotarev-frobenius-identity",
       "title": "The prime-power Zolotarev–Frobenius identity",
-      "content": "sign_ringMulPerm_eq_legendre_pow: iterating the recursion, sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ. jacobiSym_prime_pow + sign_ringMulPerm_eq_jacobiSym: J(A | pⁿ) = (legendreSym p A)ⁿ (jacobiSym.mul_right), so the sign equals the Jacobi symbol J(a | pⁿ) — closing the prime-power case."
+      "startLine": 264,
+      "endLine": 318,
+      "summary": "sign_ringMulPerm_eq_legendre_pow: iterating the recursion, sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ. jacobiSym_prime_pow + sign_ringMulPerm_eq_jacobiSym: J(A | pⁿ) = (legendreSym p A)ⁿ (jacobiSym.mul_right), so the sign equals the Jacobi symbol J(a | pⁿ) — closing the prime-power case."
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -43,16 +43,25 @@
   },
   "sections": [
     {
+      "id": "the-left-regular-representation-of-a-finite-group-generic",
       "title": "The left regular representation of a finite group (generic)",
-      "content": "mulLeftHom : G →* Perm G packages left translation as a monoid hom. mulLeft_no_fixed: translation by a ≠ 1 has no fixed point (mul_right_cancel). mulLeft_generator_isCycle / mulLeft_support_eq_univ: a generator's translation is a single full-support cycle. sign_mulLeft_generator: its sign is -1 when |G| is even. sign_mulLeft_pow: sign of translation is multiplicative under powers. These hold for any finite group and isolate the group-theoretic core."
+      "startLine": 1,
+      "endLine": 129,
+      "summary": "mulLeftHom : G →* Perm G packages left translation as a monoid hom. mulLeft_no_fixed: translation by a ≠ 1 has no fixed point (mul_right_cancel). mulLeft_generator_isCycle / mulLeft_support_eq_univ: a generator's translation is a single full-support cycle. sign_mulLeft_generator: its sign is -1 when |G| is even. sign_mulLeft_pow: sign of translation is multiplicative under powers. These hold for any finite group and isolate the group-theoretic core."
     },
     {
+      "id": "the-prime-power-unit-group-has-even-order",
       "title": "The prime-power unit group has even order",
-      "content": "card_units_prime_pow_even: |(ℤ/pⁿ)ˣ| = pⁿ⁻¹(p-1) via ZMod.card_units_eq_totient and Nat.totient_prime_pow, which is even because p-1 is even for an odd prime p."
+      "startLine": 130,
+      "endLine": 144,
+      "summary": "card_units_prime_pow_even: |(ℤ/pⁿ)ˣ| = pⁿ⁻¹(p-1) via ZMod.card_units_eq_totient and Nat.totient_prime_pow, which is even because p-1 is even for an odd prime p."
     },
     {
+      "id": "the-units-level-prime-power-zolotarev-lemma",
       "title": "The units-level prime-power Zolotarev lemma",
-      "content": "sign_mulLeft_eq_quadraticChar and sign_mulLeft_eq_legendre: for an odd prime p and n ≥ 1, the sign of left multiplication by u on (ℤ/pⁿ)ˣ equals the quadratic character (resp. Legendre symbol mod p) of the reduction ρ u. Proof: instantiate the generic machinery on the cyclic group (ℤ/pⁿ)ˣ; both sides are -1 at a generator g (single even cycle; ρ g a non-residue), and u = gᵏ makes both (-1)ᵏ."
+      "startLine": 145,
+      "endLine": 198,
+      "summary": "sign_mulLeft_eq_quadraticChar and sign_mulLeft_eq_legendre: for an odd prime p and n ≥ 1, the sign of left multiplication by u on (ℤ/pⁿ)ˣ equals the quadratic character (resp. Legendre symbol mod p) of the reduction ρ u. Proof: instantiate the generic machinery on the cyclic group (ℤ/pⁿ)ˣ; both sides are -1 at a generator g (single even cycle; ρ g a non-residue), and u = gᵏ makes both (-1)ᵏ."
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01/meta.json
@@ -44,16 +44,25 @@
   },
   "sections": [
     {
+      "id": "the-integer-unit-from-a-coprimality-hypothesis",
       "title": "The integer unit from a coprimality hypothesis",
-      "content": "intCast_isUnit_of_isCoprime: if an integer c is coprime to k, then (c : ℤ/k) is a unit. Bezout's x·c + y·k = 1 reduces mod k (where k = 0) to x·c = 1, exhibiting the inverse. This manufactures the CRT component units at each prime factor."
+      "startLine": 1,
+      "endLine": 87,
+      "summary": "intCast_isUnit_of_isCoprime: if an integer c is coprime to k, then (c : ℤ/k) is a unit. Bezout's x·c + y·k = 1 reduces mod k (where k = 0) to x·c = 1, exhibiting the inverse. This manufactures the CRT component units at each prime factor."
     },
     {
+      "id": "the-main-induction",
       "title": "The main induction",
-      "content": "main: strong induction on n via its smallest prime factor. The n = 1 base uses the subsingleton structure of ℤ/1; the inductive step splits n = p·m coprimely, applies the grandparent's CRT multiplicativity, the parent's prime base case, the inductive hypothesis on the cofactor, and jacobiSym.mul_right to assemble J(a | n)."
+      "startLine": 88,
+      "endLine": 167,
+      "summary": "main: strong induction on n via its smallest prime factor. The n = 1 base uses the subsingleton structure of ℤ/1; the inductive step splits n = p·m coprimely, applies the grandparent's CRT multiplicativity, the parent's prime base case, the inductive hypothesis on the cofactor, and jacobiSym.mul_right to assemble J(a | n)."
     },
     {
+      "id": "clean-statement",
       "title": "Clean statement",
-      "content": "sign_ringMulPerm_eq_jacobiSym: the result in ordinary binder form — for n odd squarefree, c coprime to n, and the unit u representing c, sign(ringMulPerm u) = J(c | n)."
+      "startLine": 168,
+      "endLine": 211,
+      "summary": "sign_ringMulPerm_eq_jacobiSym: the result in ordinary binder form — for n odd squarefree, c coprime to n, and the unit u representing c, sign(ringMulPerm u) = J(c | n)."
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/meta.json
@@ -42,24 +42,39 @@
   },
   "sections": [
     {
+      "id": "multiplication-by-a-unit-as-a-permutation-of-the-whole-ring",
       "title": "Multiplication by a unit as a permutation of the whole ring",
-      "content": "ringMulPerm a is the permutation x ↦ a·x of all of ℤ/n (not just the units), assembled into a group homomorphism ringMulPermHom : (ℤ/n)ˣ →* Perm (ℤ/n)."
+      "startLine": 1,
+      "endLine": 74,
+      "summary": "ringMulPerm a is the permutation x ↦ a·x of all of ℤ/n (not just the units), assembled into a group homomorphism ringMulPermHom : (ℤ/n)ˣ →* Perm (ℤ/n)."
     },
     {
+      "id": "the-zolotarev-sign-character-for-any-modulus",
       "title": "The Zolotarev sign character for any modulus",
-      "content": "signRingHom = sign ∘ ringMulPermHom : (ℤ/n)ˣ →* ℤˣ, a quadratic character (squares to 1) defined for every positive modulus."
+      "startLine": 75,
+      "endLine": 103,
+      "summary": "signRingHom = sign ∘ ringMulPermHom : (ℤ/n)ˣ →* ℤˣ, a quadratic character (squares to 1) defined for every positive modulus."
     },
     {
+      "id": "sign-of-a-product-permutation",
       "title": "Sign of a product permutation",
-      "content": "sign_prodCongr: sign(σ ×ₚ τ) = sign σ ^ |β| · sign τ ^ |α|, plus units_pow_odd (u^k = u for u ∈ ℤˣ and odd k). General lemmas not in Mathlib."
+      "startLine": 104,
+      "endLine": 135,
+      "summary": "sign_prodCongr: sign(σ ×ₚ τ) = sign σ ^ |β| · sign τ ^ |α|, plus units_pow_odd (u^k = u for u ∈ ℤˣ and odd k). General lemmas not in Mathlib."
     },
     {
+      "id": "the-crt-decomposition",
       "title": "The CRT decomposition",
-      "content": "sign_ringMulPerm_crt factors the sign through ZMod.chineseRemainder; sign_ringMulPerm_mul_of_odd specializes to odd coprime moduli, where the character is multiplicative — the permutation image of jacobiSym.mul_right."
+      "startLine": 136,
+      "endLine": 185,
+      "summary": "sign_ringMulPerm_crt factors the sign through ZMod.chineseRemainder; sign_ringMulPerm_mul_of_odd specializes to odd coprime moduli, where the character is multiplicative — the permutation image of jacobiSym.mul_right."
     },
     {
+      "id": "parallel-with-the-jacobi-symbol",
       "title": "Parallel with the Jacobi symbol",
-      "content": "jacobiSym_mul_right_mirror restates Mathlib's jacobiSym.mul_right (the value-level statement mirrored by the sign decomposition); legendre_eq_jacobi records the prime base case legendreSym.to_jacobiSym."
+      "startLine": 186,
+      "endLine": 262,
+      "summary": "jacobiSym_mul_right_mirror restates Mathlib's jacobiSym.mul_right (the value-level statement mirrored by the sign decomposition); legendre_eq_jacobi records the prime base case legendreSym.to_jacobiSym."
     }
   ],
   "meta": {

--- a/src/data/proofs/erdos-1000-oq-03-oq-02/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-02/meta.json
@@ -20,49 +20,57 @@
       "title": "Header and Open Question",
       "startLine": 1,
       "endLine": 57,
-      "summary": "Frames the goal: take the honest combinatorial definition of Jordan's totient $J_k(n)$ as the count of $k$-tuples setwise coprime to $n$, and derive its explicit arithmetic values (divisor-sum identity, prime-power closed form, Euler/Gauss recovery) self-containedly from the geometry."
+      "summary": "Frames the goal: take the honest combinatorial definition of Jordan's totient $J_k(n)$ as the count of $k$-tuples setwise coprime to $n$, and derive its explicit arithmetic values (divisor-sum identity, prime-power closed form, Euler/Gauss recovery) self-containedly from the geometry.",
+      "id": "header-and-open-question"
     },
     {
       "title": "Definition and the scaling lemma",
       "startLine": 64,
       "endLine": 75,
-      "summary": "`jordanCount k n` filters $\\{0,\\dots,n-1\\}^k$ by the entrywise-gcd coprimality condition $\\gcd(\\gcd(a),n)=1$. `gcd_smul` records that scaling a tuple coordinatewise by $d$ multiplies its `Finset.gcd` by $d$ (from `Finset.gcd_mul_left`)."
+      "summary": "`jordanCount k n` filters $\\{0,\\dots,n-1\\}^k$ by the entrywise-gcd coprimality condition $\\gcd(\\gcd(a),n)=1$. `gcd_smul` records that scaling a tuple coordinatewise by $d$ multiplies its `Finset.gcd` by $d$ (from `Finset.gcd_mul_left`).",
+      "id": "definition-and-the-scaling-lemma"
     },
     {
       "title": "The fibre bijection",
       "startLine": 77,
       "endLine": 148,
-      "summary": "`fiber_card`: a `Finset.card_bij'` with the mutually-inverse rescaling maps $a\\mapsto(a_j/d)$ and $b\\mapsto(d\\,b_j)$ proving that tuples with $\\gcd(\\gcd(a),n)=d$ biject with the coprime tuples mod $n/d$, so the fibre over $d$ has $\\mathrm{jordanCount}\\,k\\,(n/d)$ elements."
+      "summary": "`fiber_card`: a `Finset.card_bij'` with the mutually-inverse rescaling maps $a\\mapsto(a_j/d)$ and $b\\mapsto(d\\,b_j)$ proving that tuples with $\\gcd(\\gcd(a),n)=d$ biject with the coprime tuples mod $n/d$, so the fibre over $d$ has $\\mathrm{jordanCount}\\,k\\,(n/d)$ elements.",
+      "id": "the-fibre-bijection"
     },
     {
       "title": "Headline: the geometric Gauss identity",
       "startLine": 150,
       "endLine": 172,
-      "summary": "`jordan_count_divisor_sum`: partitioning all $n^k$ tuples by $d=\\gcd(\\gcd(a),n)\\in\\mathrm{divisors}(n)$ via `card_eq_sum_card_fiberwise`, applying `fiber_card`, and reindexing with `Nat.sum_div_divisors` yields $\\sum_{d\\mid n}\\mathrm{jordanCount}\\,k\\,d = n^k$."
+      "summary": "`jordan_count_divisor_sum`: partitioning all $n^k$ tuples by $d=\\gcd(\\gcd(a),n)\\in\\mathrm{divisors}(n)$ via `card_eq_sum_card_fiberwise`, applying `fiber_card`, and reindexing with `Nat.sum_div_divisors` yields $\\sum_{d\\mid n}\\mathrm{jordanCount}\\,k\\,d = n^k$.",
+      "id": "headline-the-geometric-gauss-identity"
     },
     {
       "title": "Immediate corollaries: J_k(1) and the bound",
       "startLine": 174,
       "endLine": 184,
-      "summary": "`jordan_count_one` ($J_k(1)=1$) and `jordan_count_le_pow` ($J_k(n)\\le n^k$, since one divisor term is bounded by the full sum) drop straight out of the headline identity."
+      "summary": "`jordan_count_one` ($J_k(1)=1$) and `jordan_count_le_pow` ($J_k(n)\\le n^k$, since one divisor term is bounded by the full sum) drop straight out of the headline identity.",
+      "id": "immediate-corollaries-j-k-1-and-the-bound"
     },
     {
       "title": "Euler recovery at k = 1",
       "startLine": 186,
       "endLine": 219,
-      "summary": "`gcd_fin_one` (the gcd of a length-one tuple is its entry) and `jordan_count_eq_totient`: a length-one `card_bij'` identifying the coprimality condition with $\\gcd(a_0,n)=1$, proving $\\mathrm{jordanCount}\\,1\\,n = \\varphi(n)$."
+      "summary": "`gcd_fin_one` (the gcd of a length-one tuple is its entry) and `jordan_count_eq_totient`: a length-one `card_bij'` identifying the coprimality condition with $\\gcd(a_0,n)=1$, proving $\\mathrm{jordanCount}\\,1\\,n = \\varphi(n)$.",
+      "id": "euler-recovery-at-k-1"
     },
     {
       "title": "Gauss's classical totient identity",
       "startLine": 221,
       "endLine": 229,
-      "summary": "`sum_totient_eq_self`: specialising the headline to $k=1$ and rewriting by the Euler recovery gives a combinatorial proof of Gauss's $\\sum_{d\\mid n}\\varphi(d) = n$."
+      "summary": "`sum_totient_eq_self`: specialising the headline to $k=1$ and rewriting by the Euler recovery gives a combinatorial proof of Gauss's $\\sum_{d\\mid n}\\varphi(d) = n$.",
+      "id": "gauss-s-classical-totient-identity"
     },
     {
       "title": "Prime-power closed form",
       "startLine": 231,
       "endLine": 246,
-      "summary": "`jordan_count_prime_pow` telescopes the divisor sum over $\\{p^0,\\dots,p^{m+1}\\}$ (via `Nat.sum_divisors_prime_pow` and `sum_range_succ`); `jordan_count_prime_pow_sub` rearranges to $J_k(p^{m+1}) = p^{(m+1)k}-p^{mk}$, which is $\\varphi(p^{m+1})=p^{m+1}-p^m$ at $k=1$."
+      "summary": "`jordan_count_prime_pow` telescopes the divisor sum over $\\{p^0,\\dots,p^{m+1}\\}$ (via `Nat.sum_divisors_prime_pow` and `sum_range_succ`); `jordan_count_prime_pow_sub` rearranges to $J_k(p^{m+1}) = p^{(m+1)k}-p^{mk}$, which is $\\varphi(p^{m+1})=p^{m+1}-p^m$ at $k=1$.",
+      "id": "prime-power-closed-form"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1000-oq-03-oq-03/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-03/meta.json
@@ -19,37 +19,43 @@
       "title": "Header and open question",
       "startLine": 1,
       "endLine": 61,
-      "summary": "Frames the goal and locates it in the gallery: prove the Gauss divisor-sum identity $\\sum_{d\\mid n}J_k(d)=n^k$ for the abstract arithmetic function $J_k=\\mu*\\mathrm{pow}\\,k$, working inside Mathlib's Dirichlet convolution ring, and add the uniqueness characterisation absent from the combinatorial siblings. Opens `Finset`, `ArithmeticFunction`, and the `ArithmeticFunction.zeta` scope."
+      "summary": "Frames the goal and locates it in the gallery: prove the Gauss divisor-sum identity $\\sum_{d\\mid n}J_k(d)=n^k$ for the abstract arithmetic function $J_k=\\mu*\\mathrm{pow}\\,k$, working inside Mathlib's Dirichlet convolution ring, and add the uniqueness characterisation absent from the combinatorial siblings. Opens `Finset`, `ArithmeticFunction`, and the `ArithmeticFunction.zeta` scope.",
+      "id": "header-and-open-question"
     },
     {
       "title": "Definition of Jordan's totient",
       "startLine": 63,
       "endLine": 65,
-      "summary": "`jordan k := moebius * (pow k : ArithmeticFunction Z)` — Jordan's totient as a Dirichlet convolution in the ring $\\mathrm{ArithmeticFunction}\\ \\mathbb{Z}$, the same object studied by the sibling erdos-1000-oq-03-oq-01-oq-01."
+      "summary": "`jordan k := moebius * (pow k : ArithmeticFunction Z)` — Jordan's totient as a Dirichlet convolution in the ring $\\mathrm{ArithmeticFunction}\\ \\mathbb{Z}$, the same object studied by the sibling erdos-1000-oq-03-oq-01-oq-01.",
+      "id": "definition-of-jordan-s-totient"
     },
     {
       "title": "Reconstruction identity J_k * zeta = pow k",
       "startLine": 67,
       "endLine": 74,
-      "summary": "`jordan_mul_zeta`: the arithmetic-function identity $J_k*\\zeta=\\mathrm{pow}\\,k$, proved in one `rw` via `mul_right_comm` and $\\mu*\\zeta=1$ (`moebius_mul_coe_zeta`). This is the reconstruction dual of the gallery's Möbius inversion $J_k=\\mu*\\mathrm{pow}\\,k$."
+      "summary": "`jordan_mul_zeta`: the arithmetic-function identity $J_k*\\zeta=\\mathrm{pow}\\,k$, proved in one `rw` via `mul_right_comm` and $\\mu*\\zeta=1$ (`moebius_mul_coe_zeta`). This is the reconstruction dual of the gallery's Möbius inversion $J_k=\\mu*\\mathrm{pow}\\,k$.",
+      "id": "reconstruction-identity-j-k-zeta-pow-k"
     },
     {
       "title": "Headline: Gauss's divisor-sum identity",
       "startLine": 76,
       "endLine": 84,
-      "summary": "`jordan_divisor_sum`: $\\sum_{d\\mid n}J_k(d)=n^k$ for $n\\neq 0$, the pointwise reading of `jordan_mul_zeta` through `coe_mul_zeta_apply` and `pow_apply`."
+      "summary": "`jordan_divisor_sum`: $\\sum_{d\\mid n}J_k(d)=n^k$ for $n\\neq 0$, the pointwise reading of `jordan_mul_zeta` through `coe_mul_zeta_apply` and `pow_apply`.",
+      "id": "headline-gauss-s-divisor-sum-identity"
     },
     {
       "title": "Uniqueness: the divisor-sum characterises J_k",
       "startLine": 86,
       "endLine": 102,
-      "summary": "`jordan_unique`: any $f:\\mathbb{N}\\to\\mathbb{Z}$ with $\\sum_{d\\mid n}f(d)=n^k$ for all $n>0$ equals $J_k$ on the positives. Möbius-inverts the hypothesis with `sum_eq_iff_sum_smul_moebius_eq` and matches the result to $(\\mu*\\mathrm{pow}\\,k)\\,n$ termwise via `mul_apply`."
+      "summary": "`jordan_unique`: any $f:\\mathbb{N}\\to\\mathbb{Z}$ with $\\sum_{d\\mid n}f(d)=n^k$ for all $n>0$ equals $J_k$ on the positives. Möbius-inverts the hypothesis with `sum_eq_iff_sum_smul_moebius_eq` and matches the result to $(\\mu*\\mathrm{pow}\\,k)\\,n$ termwise via `mul_apply`.",
+      "id": "uniqueness-the-divisor-sum-characterises-j-k"
     },
     {
       "title": "Euler recovery and Gauss's classical identity (k = 1)",
       "startLine": 104,
       "endLine": 123,
-      "summary": "`jordan_one_apply` ($J_1=\\varphi$, from uniqueness plus `Nat.sum_totient`) and `sum_totient_eq_self` (Gauss's $\\sum_{d\\mid n}\\varphi(d)=n$, the $k=1$ case of the headline)."
+      "summary": "`jordan_one_apply` ($J_1=\\varphi$, from uniqueness plus `Nat.sum_totient`) and `sum_totient_eq_self` (Gauss's $\\sum_{d\\mid n}\\varphi(d)=n$, the $k=1$ case of the headline).",
+      "id": "euler-recovery-and-gauss-s-classical-identity-k-1"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1047/annotations.json
+++ b/src/data/proofs/erdos-1047/annotations.json
@@ -70,7 +70,7 @@
       "startLine": 47,
       "endLine": 54
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "The Explicit Counterexample",
     "content": "The existential form of the result, packaging the explicit witness: a monic polynomial of positive degree (`goodmanPolynomial`), a positive level (`goodmanCriticalValue`, positive by `positivity`), and a point $z_0$ on the lemniscate whose component is non-convex. The final witness is supplied directly by the certificate `goodman_counterexample_proof`.",
     "mathContext": "$\\exists f \\text{ monic}, \\deg f > 0, \\exists c > 0, \\exists z_0 \\in \\{|f| \\le c\\}$ with the component of $z_0$ non-convex. Instantiated at $f = (z^2+1)(z-2)^2$, $c = 5^{3/2}/4$.",
@@ -91,7 +91,7 @@
       "startLine": 56,
       "endLine": 60
     },
-    "type": "concept",
+    "type": "context",
     "title": "The Answer, Stated Cleanly",
     "content": "A streamlined existential restatement of the answer, dropping the monic/degree bookkeeping to leave just the essential claim: there is a polynomial, a level, and a boundary point whose lemniscate component is not convex. Derived in two lines from `erdos_1047_counterexample`.",
     "mathContext": "$\\exists f, \\exists c > 0, \\exists z_0 \\in \\{|f| \\le c\\}$ with a non-convex component — the minimal form of \"some lemniscate component is non-convex\".",

--- a/src/data/proofs/erdos-816-oq-01/meta.json
+++ b/src/data/proofs/erdos-816-oq-01/meta.json
@@ -98,25 +98,29 @@
       "title": "Overview and imports",
       "startLine": 1,
       "endLine": 35,
-      "summary": "Docstring stating the two structural facts the parent left as prose — the K_{n,n+1} counterexample mechanism (Part V) and the degree pigeonhole (Part VII) — and the parity intuition (a length-3 odd path joins opposite parts). Imports Mathlib, opens SimpleGraph, and fixes the vertex type V."
+      "summary": "Docstring stating the two structural facts the parent left as prose — the K_{n,n+1} counterexample mechanism (Part V) and the degree pigeonhole (Part VII) — and the parity intuition (a length-3 odd path joins opposite parts). Imports Mathlib, opens SimpleGraph, and fixes the vertex type V.",
+      "id": "overview-and-imports"
     },
     {
       "title": "Inlined definitions",
       "startLine": 36,
       "endLine": 62,
-      "summary": "Self-contained copies of hasPath3, sameDegree, hasEqualDegreePath3Pair (the parent file does not compile on v4.26.0) and the Boolean bipartition predicate IsBipartition."
+      "summary": "Self-contained copies of hasPath3, sameDegree, hasEqualDegreePath3Pair (the parent file does not compile on v4.26.0) and the Boolean bipartition predicate IsBipartition.",
+      "id": "inlined-definitions"
     },
     {
       "title": "Parity of length-3 paths and the counterexample",
       "startLine": 64,
       "endLine": 114,
-      "summary": "hasPath3_opposite_color (odd path joins opposite parts) and the obstruction theorems no_equalDegreePath3_of_bipartition / _distinctDegrees / _partDegrees — the K_{n,n+1} mechanism."
+      "summary": "hasPath3_opposite_color (odd path joins opposite parts) and the obstruction theorems no_equalDegreePath3_of_bipartition / _distinctDegrees / _partDegrees — the K_{n,n+1} mechanism.",
+      "id": "parity-of-length-3-paths-and-the-counterexample"
     },
     {
       "title": "Degree pigeonhole",
       "startLine": 116,
       "endLine": 161,
-      "summary": "exists_sameDegree_pair: any graph on ≥ 2 vertices has two vertices of equal degree, via injective-implies-surjective degree packaging and the degree-0 / degree-(card−1) clash."
+      "summary": "exists_sameDegree_pair: any graph on ≥ 2 vertices has two vertices of equal degree, via injective-implies-surjective degree packaging and the degree-0 / degree-(card−1) clash.",
+      "id": "degree-pigeonhole"
     }
   ],
   "sorries": []

--- a/src/data/proofs/euler-identity/annotations.json
+++ b/src/data/proofs/euler-identity/annotations.json
@@ -69,7 +69,7 @@
       "startLine": 86,
       "endLine": 92
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Key Values at π",
     "content": "The proof hinges on two fundamental facts about trigonometric functions at $\\pi$ radians (180°):\n\n$$\\cos(\\pi) = -1$$\n$$\\sin(\\pi) = 0$$\n\nGeometrically: at angle $\\pi$, we're at the leftmost point of the unit circle, which is $(-1, 0)$.\n\nThese values follow from the unit circle definition of sine and cosine, where $\\cos(\\theta)$ is the x-coordinate and $\\sin(\\theta)$ is the y-coordinate.",
     "mathContext": "$(\\cos \\pi, \\sin \\pi) = (-1, 0)$; Lean: `Real.cos_pi : cos π = -1`, `Real.sin_pi : sin π = 0` from `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic`",
@@ -160,7 +160,7 @@
       "startLine": 183,
       "endLine": 185
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "The Taylor Series Proof",
     "content": "The classical proof of Euler's formula compares Taylor series:\n\n$$e^{ix} = 1 + ix + \\frac{(ix)^2}{2!} + \\frac{(ix)^3}{3!} + ...$$\n\nUsing $i^2 = -1$, $i^3 = -i$, $i^4 = 1$, etc.:\n\n$$= \\underbrace{1 - \\frac{x^2}{2!} + \\frac{x^4}{4!} - ...}_{\\cos x} + i\\underbrace{\\left(x - \\frac{x^3}{3!} + \\frac{x^5}{5!} - ...\\right)}_{\\sin x}$$\n\nThe series magically separate into the Taylor series for cosine (even powers) and sine (odd powers)!\n\nThis 'coincidence' reflects deep structural connections between $e$, $\\sin$, and $\\cos$.",
     "mathContext": "$e^{ix} = \\sum_{n=0}^\\infty \\frac{(ix)^n}{n!}$; even-power terms give $\\cos x = \\sum \\frac{(-1)^n x^{2n}}{(2n)!}$, odd-power terms give $\\sin x = \\sum \\frac{(-1)^n x^{2n+1}}{(2n+1)!}$",
@@ -207,7 +207,7 @@
       "startLine": 233,
       "endLine": 251
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Quarter Turn: e^(iπ/2) = i",
     "content": "At $\\theta = \\pi/2$ (90°), we get:\n\n$$e^{i\\pi/2} = \\cos(\\pi/2) + i\\sin(\\pi/2) = 0 + i \\cdot 1 = i$$\n\nThis confirms the geometric interpretation: rotating 1 by 90° gives $i$ (the 'up' direction in the complex plane).\n\nSimilarly:\n- $e^{i\\pi} = -1$ (180° rotation)\n- $e^{i \\cdot 3\\pi/2} = -i$ (270° rotation)\n- $e^{2\\pi i} = 1$ (360° = back to start)",
     "mathContext": "$e^{i\\pi/2} = i$; Lean: `theorem quarter_rotation : Complex.exp (Real.pi / 2 * Complex.I) = Complex.I` proved with `Real.cos_pi_div_two` and `Real.sin_pi_div_two`",

--- a/src/data/proofs/fermat-two-squares/annotations.json
+++ b/src/data/proofs/fermat-two-squares/annotations.json
@@ -95,7 +95,7 @@
       "startLine": 55,
       "endLine": 87
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "The Prime 2: A Special Case",
     "content": "2 = 1² + 1² is trivially a sum of two squares.\n\nNote that 2 ≡ 2 (mod 4), so it's neither in the \"1 mod 4\" nor the \"3 mod 4\" category. The theorem correctly handles this edge case.",
     "mathContext": "2 is the only even prime, making it unique in many ways.",

--- a/src/data/proofs/fermats-last-theorem/annotations.json
+++ b/src/data/proofs/fermats-last-theorem/annotations.json
@@ -78,7 +78,7 @@
       "startLine": 85,
       "endLine": 88
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Semi-stability of Frey Curves",
     "content": "An elliptic curve is **semi-stable** if at every prime of bad reduction, the reduction is multiplicative (nodes, not cusps). Frey curves are semi-stable, which is crucial because Wiles' modularity theorem applies specifically to semi-stable curves.",
     "mathContext": "Semi-stability is a technical condition on how the curve reduces modulo primes. The Frey curve has multiplicative reduction at the primes dividing $abc$, and good reduction elsewhere.",
@@ -197,7 +197,7 @@
       "startLine": 158,
       "endLine": 170
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Reduction to Primes",
     "content": "If FLT holds for exponent $n$, it holds for all multiples of $n$. Why? If $a^{nm} + b^{nm} = c^{nm}$, then $(a^m)^n + (b^m)^n = (c^m)^n$, contradicting FLT for $n$.",
     "mathContext": "This means we only need to prove FLT for n=4 and all odd primes. Since every n ≥ 3 is divisible by 4 or an odd prime, this covers everything.",

--- a/src/data/proofs/fibonacci-divisibility-oq-07/meta.json
+++ b/src/data/proofs/fibonacci-divisibility-oq-07/meta.json
@@ -86,7 +86,7 @@
       "title": "Module Header and Framing",
       "startLine": 1,
       "endLine": 31,
-      "content": "The file imports Mathlib and situates itself: Nat.fib_dvd and Nat.fib_gcd are present, but the converse and the full biconditional are not. It flags the F₁ = F₂ = 1 coincidence as the source of the single exceptional index m = 2, and notes that only kernel-reducible `decide` (no native_decide) is used on the closed numerals fib 2/3/4."
+      "summary": "The file imports Mathlib and situates itself: Nat.fib_dvd and Nat.fib_gcd are present, but the converse and the full biconditional are not. It flags the F₁ = F₂ = 1 coincidence as the source of the single exceptional index m = 2, and notes that only kernel-reducible `decide` (no native_decide) is used on the closed numerals fib 2/3/4."
     },
     {
       "id": "converse",

--- a/src/data/proofs/fundamental-theorem-algebra/annotations.json
+++ b/src/data/proofs/fundamental-theorem-algebra/annotations.json
@@ -6,7 +6,7 @@
       "startLine": 6,
       "endLine": 40
     },
-    "type": "concept",
+    "type": "context",
     "title": "Degree of a Polynomial",
     "content": "The **degree** of a polynomial is the highest power of the variable with a non-zero coefficient.\n\nFor $z^2 + 1$, the degree is 2. The polynomial $z^3 - 2z + 5$ has degree 3.\n\nDegree 0 means a constant polynomial. The fundamental theorem requires degree at least 1 (non-constant).",
     "mathContext": "$\\deg(z^n + \\text{lower terms}) = n$\n\n$\\deg(c) = 0$ for constant $c \\neq 0$\n\n$\\deg(0) = -\\infty$ (by convention)",
@@ -145,7 +145,7 @@
       "startLine": 174,
       "endLine": 208
     },
-    "type": "concept",
+    "type": "context",
     "title": "Quadratics Always Have Roots",
     "content": "As a special case: **every quadratic $az^2 + bz + c$ (with $a \\neq 0$) has roots.**\n\nThe famous quadratic formula gives them explicitly:\n$z = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$\n\nIn the complex numbers, $\\sqrt{b^2 - 4ac}$ always exists (complex square roots exist), so roots always exist.\n\nThe proof here derives this from the general FTA.",
     "mathContext": "Quadratic formula: $z = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$\n\nDiscriminant $\\Delta = b^2 - 4ac$:\n- $\\Delta > 0$: two real roots\n- $\\Delta = 0$: one repeated root\n- $\\Delta < 0$: two complex conjugate roots",

--- a/src/data/proofs/fundamental-theorem-calculus/annotations.json
+++ b/src/data/proofs/fundamental-theorem-calculus/annotations.json
@@ -132,7 +132,7 @@
       "startLine": 124,
       "endLine": 128
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Zero Derivative Implies Constant",
     "content": "**If F'(x) = 0 for all x, then F is constant.**\n\nThis is a consequence of the Mean Value Theorem:\n\nFor any two points x and y, there exists c between them with\n$F(y) - F(x) = F'(c)(y - x) = 0 \\cdot (y - x) = 0$\n\nSo F(y) = F(x) for all x, y.\n\nThis lemma is essential for proving uniqueness of antiderivatives.",
     "mathContext": "Mean Value Theorem: $F(y) - F(x) = F'(c)(y - x)$ for some $c \\in (x, y)$\n\nIf $F' \\equiv 0$, then $F(y) = F(x)$ for all $x, y$.",

--- a/src/data/proofs/gcd-algorithm/annotations.json
+++ b/src/data/proofs/gcd-algorithm/annotations.json
@@ -319,7 +319,7 @@
       "startLine": 185,
       "endLine": 185
     },
-    "type": "concept",
+    "type": "context",
     "title": "Worked Examples",
     "content": "**Tracing gcd(48, 18)**:\n\n```\ngcd(48, 18) = gcd(18, 48 mod 18) = gcd(18, 12)\ngcd(18, 12) = gcd(12, 18 mod 12) = gcd(12, 6)\ngcd(12, 6)  = gcd(6, 12 mod 6)   = gcd(6, 0)\ngcd(6, 0)   = 6\n```\n\nOnly 4 steps! The algorithm is remarkably efficient.\n\nEach step is verified in Lean using `native_decide` to compute the result directly.",
     "mathContext": "In Lean: each step is verified by `native_decide`, which compiles the decision to native code and evaluates. For `gcd(48, 18) = 6`: the algorithm runs $48 = 2 \\cdot 18 + 12$, $18 = 1 \\cdot 12 + 6$, $12 = 2 \\cdot 6 + 0$, terminating in 3 steps. `native_decide` calls `Nat.decEq` on the reduced expression. Step-tracing examples serve as `#eval`-style tests within the proof system, confirmed by the kernel.",

--- a/src/data/proofs/godel-incompleteness/annotations.json
+++ b/src/data/proofs/godel-incompleteness/annotations.json
@@ -199,7 +199,7 @@
       "startLine": 150,
       "endLine": 160
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "G Is Not Provable",
     "content": "This is the heart of the argument. Assume for contradiction that $G$ is provable.\n\n1. By representability, $\\vdash\\text{Prov}(\\ulcorner G\\urcorner)$\n2. But $G \\iff \\neg\\text{Prov}(\\ulcorner G\\urcorner)$, so $\\vdash\\neg\\text{Prov}(\\ulcorner G\\urcorner)$\n3. We've proved both $\\text{Prov}(\\ulcorner G\\urcorner)$ and $\\neg\\text{Prov}(\\ulcorner G\\urcorner)$\n4. This contradicts consistency!\n\nTherefore, if the system is consistent, $G$ cannot be provable. But $G$ *says* \"I am not provable\"—so $G$ is true! A true sentence that cannot be proved.",
     "mathContext": "$\\text{Consistent}(F) \\implies \\neg\\vdash G$",

--- a/src/data/proofs/halting-problem/annotations.json
+++ b/src/data/proofs/halting-problem/annotations.json
@@ -122,7 +122,7 @@
       "startLine": 48,
       "endLine": 54
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Diagonal Differs from Oracle",
     "content": "**Key Lemma**: The diagonal behavior always differs from the oracle's prediction at self-application points.\n\nFor any program code $n$:\n$\\text{diagonal}(H)(n) \\neq H(n, n)$\n\nThis follows immediately from the fact that $\\neg b \\neq b$ for any boolean.",
     "mathContext": "$\\text{diagonal}(H)(n) = \\neg H(n, n) \\neq H(n, n)$\n\nBecause $\\neg \\text{true} = \\text{false} \\neq \\text{true}$\nand $\\neg \\text{false} = \\text{true} \\neq \\text{false}$",
@@ -166,7 +166,7 @@
       "startLine": 59,
       "endLine": 87
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Case: Oracle Says Halt",
     "content": "**Case 1**: Suppose $H(c, c) = \\text{true}$ (oracle predicts halt).\n\nThen by definition of diagonal:\n$\\text{diagonal}(H)(c) = \\neg H(c, c) = \\text{false}$\n\nBut the hypothesis says $c$ correctly implements diagonal, so $c$ halting means diagonal returns true.\n\nContradiction: $\\text{false} = \\text{true}$.",
     "mathContext": "$H(c,c) = \\text{true}$\n$\\Rightarrow \\text{diagonal}(H)(c) = \\text{false}$\n$\\Rightarrow c(c)$ loops\n$\\Rightarrow H(c,c)$ should be $\\text{false}$ (contradiction)",
@@ -188,7 +188,7 @@
       "startLine": 59,
       "endLine": 87
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Case: Oracle Says Loop",
     "content": "**Case 2**: Suppose $H(c, c) = \\text{false}$ (oracle predicts loop).\n\nThen by definition of diagonal:\n$\\text{diagonal}(H)(c) = \\neg H(c, c) = \\text{true}$\n\nBut the hypothesis says $c$ correctly implements diagonal, so diagonal returning true means $c$ halts.\n\nContradiction: $H$ said $c$ loops but $c$ halts.",
     "mathContext": "$H(c,c) = \\text{false}$\n$\\Rightarrow \\text{diagonal}(H)(c) = \\text{true}$\n$\\Rightarrow c(c)$ halts\n$\\Rightarrow H(c,c)$ should be $\\text{true}$ (contradiction)",

--- a/src/data/proofs/harmonic-divergence/annotations.json
+++ b/src/data/proofs/harmonic-divergence/annotations.json
@@ -86,7 +86,7 @@
       "startLine": 75,
       "endLine": 87
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Terms are Positive",
     "content": "A simple but necessary fact: $1/n > 0$ for all $n > 0$. This ensures all our terms contribute positively to the sum, enabling downward comparison: each term in a group is bounded below by the reciprocal of the group's largest element.",
     "mathContext": "The Lean proof uses `simp [Nat.pos_iff_ne_zero.mpr hn]`: since $n \\neq 0$ we have $n \\geq 1$, so $(n : \\mathbb{R}) > 0$, and $1 / (n : \\mathbb{R}) > 0$ by `div_pos`. This positivity fact is a prerequisite for applying comparison inequalities in the grouping argument: we need each term $1/i \\geq 1/2^{k+1} > 0$ when establishing the lower bound on the group sum.",

--- a/src/data/proofs/infinitude-primes/annotations.json
+++ b/src/data/proofs/infinitude-primes/annotations.json
@@ -65,7 +65,7 @@
       "startLine": 50,
       "endLine": 54
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "n! + 1 Is at Least 2",
     "content": "For any $n$, we have $n! + 1 \\geq 2$. Since $n! \\geq 1$ (factorials are always positive), adding 1 gives us at least 2. This ensures that $n! + 1$ has at least one prime divisor, which is needed for the existence step in Euclid's argument. The proof uses the `omega` tactic — Lean's decision procedure for Presburger arithmetic (the first-order theory of $(\\mathbb{Z}, +, <)$) — which handles the linear inequality $n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$ automatically.",
     "mathContext": "$n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$. Combined with `Nat.exists_prime_and_dvd`: $n! + 1 \\geq 2 \\Rightarrow \\exists p$ prime, $p \\mid (n! + 1)$.",
@@ -86,7 +86,7 @@
       "startLine": 56,
       "endLine": 61
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "The Key Divisibility Lemma",
     "content": "If $p$ divides both $a$ and $a+1$, then $p$ divides 1. This is the heart of Euclid's proof. The proof: if $p \\mid a$ and $p \\mid (a+1)$, then $p \\mid ((a+1) - a) = 1$. Since no prime divides 1 (primes satisfy $p \\geq 2$), this creates the contradiction we need. The Lean proof applies `Nat.dvd_sub'` (if $p \\mid b$ and $p \\mid a$ with $a \\leq b$, then $p \\mid (b - a)$) and simplifies $(a+1) - a = 1$.",
     "mathContext": "$p \\mid a \\land p \\mid (a+1) \\Rightarrow p \\mid ((a+1) - a) = 1$. Equivalently: consecutive integers are coprime. This is the structural reason why $n!$ and $n! + 1$ cannot share any prime factors.",

--- a/src/data/proofs/intermediate-value-theorem/annotations.json
+++ b/src/data/proofs/intermediate-value-theorem/annotations.json
@@ -96,7 +96,7 @@
       "startLine": 114,
       "endLine": 134
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Bolzano Proof Strategy",
     "content": "The proof has two parts:\n\n1. **Get existence in [a, b]**: Since 0 is between f(a) and f(b), IVT gives us some x in [a, b] with f(x) = 0.\n\n2. **Show x is in (a, b)**: We prove x ≠ a because f(a) < 0 ≠ f(x) = 0, and similarly x ≠ b because f(b) > 0 ≠ f(x) = 0.\n\nThis is a common pattern: use IVT for the closed interval, then refine to the open interval using the hypothesis values.",
     "mathContext": "Strategy:\n1. $0 \\in [f(a), f(b)]$ since $f(a) < 0 < f(b)$\n2. Apply IVT to get $x \\in [a, b]$\n3. $x \\neq a$ since $f(x) = 0 \\neq f(a)$\n4. $x \\neq b$ since $f(x) = 0 \\neq f(b)$",

--- a/src/data/proofs/lagrange-four-squares/annotations.json
+++ b/src/data/proofs/lagrange-four-squares/annotations.json
@@ -61,7 +61,7 @@
       "startLine": 50,
       "endLine": 63
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "The ring Tactic",
     "content": "The `ring` tactic is Lean's automated prover for polynomial ring identities. It expands both sides and verifies they're equal.\n\nThis 8-term polynomial identity would be tedious to prove by hand, but `ring` handles it instantly by normalizing both sides to a canonical form.",
     "mathContext": "Ring arithmetic in any commutative ring R.",
@@ -97,7 +97,7 @@
       "startLine": 50,
       "endLine": 70
     },
-    "type": "concept",
+    "type": "context",
     "title": "The Notorious Seven",
     "content": "7 is the smallest number that requires all four squares:\n$$7 = 1^2 + 1^2 + 1^2 + 2^2 = 1 + 1 + 1 + 4$$\n\nYou can verify: there's no way to write 7 = a² + b² + c² with integers.",
     "mathContext": "7 = 4⁰(8·0 + 7) fits Legendre's obstruction.",

--- a/src/data/proofs/law-of-cosines/annotations.json
+++ b/src/data/proofs/law-of-cosines/annotations.json
@@ -140,7 +140,7 @@
       "startLine": 179,
       "endLine": 185
     },
-    "type": "concept",
+    "type": "context",
     "title": "Worked Examples",
     "content": "**60° angle (equilateral triangle)**:\n- $a = b = 1$, $\\cos(60°) = 1/2$\n- $c^2 = 1 + 1 - 2(1)(1)(1/2) = 1$\n- So $c = 1$ (equilateral!)\n\n**90° angle (Pythagorean)**:\n- $a = 3$, $b = 4$, $\\cos(90°) = 0$\n- $c^2 = 9 + 16 - 0 = 25$\n- So $c = 5$ (the 3-4-5 triangle)\n\n**120° angle (obtuse)**:\n- $a = b = 1$, $\\cos(120°) = -1/2$\n- $c^2 = 1 + 1 - 2(1)(1)(-1/2) = 3$\n- So $c = \\sqrt{3}$",
     "mathContext": "The four examples in the Lean file cover the full range: equilateral ($C = 60°$, $c = 1$), right-angle (3-4-5, $C = 90°$), obtuse ($C = 120°$, $c = \\sqrt{3}$), and degenerate ($C = 0°$, $c = |a-b|$, proved by `ring`). The degenerate case shows $c^2 = a^2 + b^2 - 2ab = (a-b)^2$ algebraically without needing numerical values — the only example requiring a general parameter proof.",

--- a/src/data/proofs/navier-stokes/annotations.json
+++ b/src/data/proofs/navier-stokes/annotations.json
@@ -82,7 +82,7 @@
       "startLine": 150,
       "endLine": 163
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Bernoulli's Inequality",
     "content": "The classical Bernoulli inequality $(1+x)^n \\geq 1 + nx$ for $x \\geq -1$ is proved by induction. This elementary result becomes surprisingly powerful when applied to backward-time energy growth, establishing that solutions cannot remain bounded while growing at a positive rate.",
     "mathContext": "**Bernoulli's inequality**: For $x \\geq -1$ and $n \\in \\mathbb{N}$, $(1+x)^n \\geq 1 + nx$. Proof by induction: base $n=0$ trivial; step uses $(1+x)^{n+1} = (1+x)^n(1+x) \\geq (1+nx)(1+x) = 1+(n+1)x+nx^2 \\geq 1+(n+1)x$. In the enstrophy argument: starting from $E_0 > 0$ with discrete growth step $h = 1/(\\lambda_1)$, after $n$ steps $E_n = E_0(1+\\lambda_1 h)^n = E_0 \\cdot 2^n$. Bernoulli gives $E_n \\geq E_0(1+n)$, providing the linear lower bound needed to show $E_n \\to \\infty$.",

--- a/src/data/proofs/partition-theorem-oq-03/meta.json
+++ b/src/data/proofs/partition-theorem-oq-03/meta.json
@@ -80,14 +80,16 @@
       "startLine": 43,
       "endLine": 47,
       "summary": "axiom numOverpartitions : ℕ → ℕ axiomatizes the count of overpartitions. Small values documented in comments: p̄(0)=1, p̄(1)=2, p̄(2)=4. Computing requires enumeration of all partitions and their subsets.",
-      "mathContext": "Generating function: $\\bar{p}(n): \\prod_{k=1}^\\infty \\frac{1+x^k}{1-x^k} = 1 + 2x + 4x^2 + 8x^3 + \\ldots$. Asymptotics: $\\bar{p}(n) \\sim \\frac{1}{4n}e^{\\pi\\sqrt{n}}$ (faster growth than ordinary partitions $p(n) \\sim \\frac{1}{4n\\sqrt{3}}e^{\\pi\\sqrt{2n/3}}$)."
+      "mathContext": "Generating function: $\\bar{p}(n): \\prod_{k=1}^\\infty \\frac{1+x^k}{1-x^k} = 1 + 2x + 4x^2 + 8x^3 + \\ldots$. Asymptotics: $\\bar{p}(n) \\sim \\frac{1}{4n}e^{\\pi\\sqrt{n}}$ (faster growth than ordinary partitions $p(n) \\sim \\frac{1}{4n\\sqrt{3}}e^{\\pi\\sqrt{2n/3}}$).",
+      "id": "numoverpartitions-axiom-and-small-values"
     },
     {
       "title": "Distinct-to-Overpartition Embedding",
       "startLine": 51,
       "endLine": 54,
       "summary": "distinctToOverpartition embeds partitions with distinct parts into overpartitions by choosing the empty overline set. The condition p.parts.toFinset.card = p.parts.length checks distinctness (no repeated parts).",
-      "mathContext": "Distinct partition $p \\vdash n$ (all parts appear once) maps to overpartition $(p, \\emptyset)$: zero overlined parts. This shows distinct partitions are overpartitions of 'type 0'. With overpartition_choices: each distinct partition admits $2^{|p|}$ overpartitions (one per overline-subset)."
+      "mathContext": "Distinct partition $p \\vdash n$ (all parts appear once) maps to overpartition $(p, \\emptyset)$: zero overlined parts. This shows distinct partitions are overpartitions of 'type 0'. With overpartition_choices: each distinct partition admits $2^{|p|}$ overpartitions (one per overline-subset).",
+      "id": "distinct-to-overpartition-embedding"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/perfect-numbers/annotations.json
+++ b/src/data/proofs/perfect-numbers/annotations.json
@@ -161,7 +161,7 @@
       "startLine": 129,
       "endLine": 136
     },
-    "type": "concept",
+    "type": "context",
     "title": "First Perfect Number: 6",
     "content": "$6 = 2^1 \\times 3$ where $3 = 2^2 - 1$ is prime.\n\n**Verification**: Proper divisors of 6 are $1, 2, 3$. Their sum is $1 + 2 + 3 = 6$. ✓\n\nThe proof uses `native_decide` to verify that $3$ is prime, then applies Euclid's theorem.",
     "mathContext": "$6 = 2^1 \\cdot M_2 = 2 \\cdot 3$",
@@ -179,7 +179,7 @@
       "startLine": 138,
       "endLine": 145
     },
-    "type": "concept",
+    "type": "context",
     "title": "Second Perfect Number: 28",
     "content": "$28 = 2^2 \\times 7$ where $7 = 2^3 - 1$ is prime.\n\n**Verification**: Proper divisors of 28 are $1, 2, 4, 7, 14$. Their sum is $1 + 2 + 4 + 7 + 14 = 28$. ✓",
     "mathContext": "$28 = 2^2 \\cdot M_3 = 4 \\cdot 7$",
@@ -196,7 +196,7 @@
       "startLine": 147,
       "endLine": 154
     },
-    "type": "concept",
+    "type": "context",
     "title": "Third Perfect Number: 496",
     "content": "$496 = 2^4 \\times 31$ where $31 = 2^5 - 1$ is prime.\n\nThis is the largest perfect number the ancient Greeks knew. Nicomachus of Gerasa listed 6, 28, and 496 in his *Introduction to Arithmetic* (c. 100 CE).",
     "mathContext": "$496 = 2^4 \\cdot M_5 = 16 \\cdot 31$",
@@ -213,7 +213,7 @@
       "startLine": 156,
       "endLine": 163
     },
-    "type": "concept",
+    "type": "context",
     "title": "Fourth Perfect Number: 8128",
     "content": "$8128 = 2^6 \\times 127$ where $127 = 2^7 - 1$ is prime.\n\nDiscovered in antiquity, 8128 remained the largest known perfect number for over 1,000 years until the Renaissance.",
     "mathContext": "$8128 = 2^6 \\cdot M_7 = 64 \\cdot 127$",

--- a/src/data/proofs/prob-method-expectation-oq-02-oq-02/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-02-oq-02/meta.json
@@ -52,37 +52,43 @@
       "title": "Edges and Colorings",
       "startLine": 1,
       "endLine": 47,
-      "summary": "Edges of K_n as 2-element subsets of Fin n (card C(n,2)); a coloring assigns a Bool to each edge (true = red, false = blue)."
+      "summary": "Edges of K_n as 2-element subsets of Fin n (card C(n,2)); a coloring assigns a Bool to each edge (true = red, false = blue).",
+      "id": "edges-and-colorings"
     },
     {
       "title": "Induced Clique Edges",
       "startLine": 49,
       "endLine": 79,
-      "summary": "The C(k,2) edges contained in a vertex set K, in bijection with the 2-subsets of K."
+      "summary": "The C(k,2) edges contained in a vertex set K, in bijection with the 2-subsets of K.",
+      "id": "induced-clique-edges"
     },
     {
       "title": "Color-Fixed Monochromatic Cliques",
       "startLine": 81,
       "endLine": 89,
-      "summary": "MonoColor c K col holds when every induced edge of K has the fixed color col; this separates red cliques (true) from blue cliques (false)."
+      "summary": "MonoColor c K col holds when every induced edge of K has the fixed color col; this separates red cliques (true) from blue cliques (false).",
+      "id": "color-fixed-monochromatic-cliques"
     },
     {
       "title": "Crux Count (Union-Bound Term)",
       "startLine": 91,
       "endLine": 131,
-      "summary": "Colorings constant of a fixed color on a fixed clique number at most 2^(C(n,2)−C(k,2)) — no factor of 2 — by an explicit injection into (off-clique edges → Bool)."
+      "summary": "Colorings constant of a fixed color on a fixed clique number at most 2^(C(n,2)−C(k,2)) — no factor of 2 — by an explicit injection into (off-clique edges → Bool).",
+      "id": "crux-count-union-bound-term"
     },
     {
       "title": "Off-Diagonal First-Moment Bound",
       "startLine": 133,
       "endLine": 245,
-      "summary": "Union bound over the C(n,s) red s-cliques and C(n,t) blue t-cliques yields a good coloring whenever C(n,s)·2^(C(t,2)) + C(n,t)·2^(C(s,2)) < 2^(C(s,2)+C(t,2))."
+      "summary": "Union bound over the C(n,s) red s-cliques and C(n,t) blue t-cliques yields a good coloring whenever C(n,s)·2^(C(t,2)) + C(n,t)·2^(C(s,2)) < 2^(C(s,2)+C(t,2)).",
+      "id": "off-diagonal-first-moment-bound"
     },
     {
       "title": "Ramsey Number Lower Bound and Concrete Witnesses",
       "startLine": 247,
       "endLine": 287,
-      "summary": "Witness form R(s,t) > n; the diagonal recovery R(4,4) > 6 and the off-diagonal instance R(3,4) > 4."
+      "summary": "Witness form R(s,t) > n; the diagonal recovery R(4,4) > 6 and the off-diagonal instance R(3,4) > 4.",
+      "id": "ramsey-number-lower-bound-and-concrete-witnesses"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/product-of-segments-of-chords/annotations.json
+++ b/src/data/proofs/product-of-segments-of-chords/annotations.json
@@ -73,7 +73,7 @@
       "startLine": 198,
       "endLine": 220
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Algebraic Approach",
     "content": "**Vieta's Formulas Approach**:\n\nParameterize points on a chord through P in direction $\\vec{d}$:\n$$Q(t) = P + t\\vec{d}$$\n\nA point is on the circle of radius r centered at origin iff:\n$$|P + t\\vec{d}|^2 = r^2$$\n\nExpanding (with $|\\vec{d}| = 1$):\n$$t^2 + 2t\\langle P, \\vec{d}\\rangle + |P|^2 - r^2 = 0$$\n\nBy **Vieta's formulas**, the product of roots is:\n$$t_1 \\cdot t_2 = |P|^2 - r^2$$\n\nSince distances are $|t_1|$ and $|t_2|$, we get $|t_1| \\cdot |t_2| = r^2 - |P|^2$ for interior points.",
     "mathContext": "Parametrize the chord as $Q(t) = P + t\\vec{d}$. Circle equation gives $t^2 + 2t\\langle P, \\vec{d}\\rangle + (\\|P\\|^2 - r^2) = 0$. By Vieta: $t_1 t_2 = \\|P\\|^2 - r^2 = \\text{pow}(P)$.",
@@ -96,7 +96,7 @@
       "startLine": 427,
       "endLine": 439
     },
-    "type": "concept",
+    "type": "context",
     "title": "Special Case: Center",
     "content": "When P is at the **center** of the circle:\n\n- Every chord through P is a diameter\n- Both segments have length r (the radius)\n- The product is $r \\cdot r = r^2$\n\nThis confirms our formula since pow(center) = $0^2 - r^2 = -r^2$, and $|\\text{pow}| = r^2$.\n\nThis is the *maximum* value of PA * PB for any interior point.",
     "mathContext": "When $P = O$: $\\text{pow}(O) = -r^2$, so $PA \\cdot PB = r^2$ for every chord (which is a diameter). This is maximal since $r^2 - \\|P-O\\|^2 \\leq r^2$.",
@@ -140,7 +140,7 @@
       "startLine": 469,
       "endLine": 470
     },
-    "type": "concept",
+    "type": "context",
     "title": "Worked Examples",
     "content": "**Example 1**: Circle of radius 5, point P at distance 3 from center.\n- Power = $5^2 - 3^2 = 16$\n- For any chord: $PA \\cdot PB = 16$\n- If PA = 2, then PB = 8\n\n**Example 2**: If one chord gives segments 2 and 8:\n- Product = 16\n- Other chord: if PC = 4, then PD = 4\n- (The chord is bisected at P!)\n\n**Example 3**: Segments 1 and 12:\n- Product = 12\n- Other chord: segments could be 2 and 6, or 3 and 4",
     "significance": "supporting",

--- a/src/data/proofs/pythagorean-theorem/annotations.json
+++ b/src/data/proofs/pythagorean-theorem/annotations.json
@@ -136,7 +136,7 @@
       "startLine": 86,
       "endLine": 107
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Bilinearity of Inner Product",
     "content": "The inner product is **bilinear**, meaning it distributes over addition in both arguments:\n\n$$\\langle \\vec{u} + \\vec{v}, \\vec{w} \\rangle = \\langle \\vec{u}, \\vec{w} \\rangle + \\langle \\vec{v}, \\vec{w} \\rangle$$\n$$\\langle \\vec{u}, \\vec{v} + \\vec{w} \\rangle = \\langle \\vec{u}, \\vec{v} \\rangle + \\langle \\vec{u}, \\vec{w} \\rangle$$\n\nThis property is what makes the Pythagorean theorem work: when we expand $\\|\\vec{v} + \\vec{w}\\|^2$, the bilinearity gives us all four terms.\n\nThe theorem states: if $\\vec{v} \\perp \\vec{w}$, then\n\n$$\\|\\vec{v} + \\vec{w}\\|^2 = \\|\\vec{v}\\|^2 + \\|\\vec{w}\\|^2$$\n\nThe proof is a beautiful application of bilinearity:\n\n1. $\\|\\vec{v} + \\vec{w}\\|^2 = \\langle \\vec{v} + \\vec{w}, \\vec{v} + \\vec{w} \\rangle$ (by definition)\n2. $= \\langle \\vec{v}, \\vec{v} \\rangle + \\langle \\vec{v}, \\vec{w} \\rangle + \\langle \\vec{w}, \\vec{v} \\rangle + \\langle \\vec{w}, \\vec{w} \\rangle$ (bilinearity)\n3. $= \\|\\vec{v}\\|^2 + 0 + 0 + \\|\\vec{w}\\|^2$ (perpendicularity!)\n4. $= \\|\\vec{v}\\|^2 + \\|\\vec{w}\\|^2$\n\nThe cross terms vanish because the vectors are perpendicular.",
     "mathContext": "Bilinearity: linear in each argument",
@@ -253,7 +253,7 @@
       "startLine": 171,
       "endLine": 209
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Computational Verification",
     "content": "Lean can **compute** that these are valid Pythagorean triples using `native_decide`. This tactic evaluates the arithmetic and checks that both sides equal the same value.\n\nFor $(3, 4, 5)$:\n- Left side: $3^2 + 4^2 = 9 + 16 = 25$\n- Right side: $5^2 = 25$\n- Equal? Yes! Proof complete.\n\nThis is one of Lean's strengths: verifiable computation meets rigorous proof.\n\nThe **converse** of the Pythagorean theorem states:\n\n*If the sides of a triangle satisfy $a^2 + b^2 = c^2$, then the angle opposite $c$ is a right angle.*\n\nThis appears as Proposition 48 in Book I of Euclid's Elements. It means we can *test* whether an angle is 90° using only length measurements—no protractor needed!\n\nThe converse is crucial in surveying, construction, and navigation.\n\nThe Pythagorean theorem has an extraordinary history:\n\n**Ancient Origins:**\n- ~1800 BCE: Babylonian tablet Plimpton 322 lists Pythagorean triples\n- ~1100 BCE: Chinese mathematicians knew the $(3, 4, 5)$ triple\n- ~570 BCE: Pythagoras (or his school) gave a general proof\n\n**Mathematical Developments:**\n- ~300 BCE: Euclid's *Elements* includes the theorem (I.47) and converse (I.48)\n- 1876: James Garfield discovers a new proof (later becomes US President!)\n- 1940: Elisha Loomis catalogs 367 distinct proofs\n\n**Generalizations:**\n- **Law of Cosines:** $c^2 = a^2 + b^2 - 2ab\\cos(C)$\n- **Higher dimensions:** $\\|\\vec{v}\\|^2 = \\sum_i v_i^2$\n- **Non-Euclidean:** The theorem *fails* in hyperbolic/spherical geometry—it's a defining property of flat space!",
     "mathContext": "Lean's `native_decide` tactic evaluates decidable propositions by computation, e.g., $3^2 + 4^2 = 25 = 5^2$ is verified by reduction.",

--- a/src/data/proofs/quadratic-reciprocity/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity/annotations.json
@@ -131,7 +131,7 @@
       "startLine": 207,
       "endLine": 210
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Euler's Criterion",
     "content": "**Euler's Criterion** provides a computational formula for the Legendre symbol:\n\n$$\\left(\\frac{a}{p}\\right) \\equiv a^{(p-1)/2} \\pmod{p}$$\n\n**Proof sketch**: By Fermat, $a^{p-1} \\equiv 1 \\pmod{p}$. Factor: $a^{p-1} - 1 = (a^{(p-1)/2} - 1)(a^{(p-1)/2} + 1)$. So $a^{(p-1)/2} \\equiv \\pm 1 \\pmod{p}$. If $a \\equiv x^2$ then $a^{(p-1)/2} \\equiv x^{p-1} \\equiv 1$; conversely one shows QNRs give $-1$.\n\n**Computational use**: Euler's criterion reduces Legendre symbol evaluation to a single modular exponentiation computable in $O(\\log p)$ multiplications — much faster than trial and error.\n\n**In Lean**: `euler_criterion` is proved using `legendreSym.eq_pow p a` from Mathlib. The statement `(legendreSym p a : ZMod p) = (a : ZMod p) ^ (p / 2)` uses Lean integer division, where `p / 2` equals $(p-1)/2$ for odd prime $p$.\n\n**Historical note**: Euler stated this criterion (without the Legendre symbol notation) in 1748. Legendre introduced the symbol notation in 1798.",
     "mathContext": "$(a/p) = a^{(p-1)/2} \\mod p$",
@@ -156,7 +156,7 @@
       "startLine": 217,
       "endLine": 220
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Multiplicativity",
     "content": "The Legendre symbol is **completely multiplicative**:\n\n$$\\left(\\frac{ab}{p}\\right) = \\left(\\frac{a}{p}\\right) \\cdot \\left(\\frac{b}{p}\\right)$$\n\nThis means the map $a \\mapsto (a/p)$ is a **group homomorphism** from $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ to $\\{\\pm 1\\}$. Its kernel is precisely the subgroup of quadratic residues (index 2).\n\n**Computational power**: Together with reciprocity and the supplementary laws, multiplicativity reduces $\\left(\\frac{a}{p}\\right)$ for any $a$ to a sequence of smaller reciprocity applications — an algorithm analogous to the Euclidean algorithm.\n\n**Example**: $(6/7) = (2/7)(3/7)$. We have $(2/7) = 1$ (since $7 \\equiv 7 \\pmod{8}$) and $(3/7) = -(7/3) = -(1/3) = -1$ (since $7 \\equiv 3 \\pmod{4}$ and $3 \\equiv 3 \\pmod{4}$). So $(6/7) = -1$.\n\n**Jacobi symbol generalization**: The multiplicativity property extends to the Jacobi symbol $(a/n)$ for odd $n$, enabling efficient computation without factoring $n$ first.\n\n**In Lean**: `legendre_mul` is proved by `legendreSym.mul p a b` from Mathlib.",
     "mathContext": "$(ab/p) = (a/p)(b/p)$",

--- a/src/data/proofs/ramanujan-sum-fallacy/annotations.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/annotations.json
@@ -169,7 +169,7 @@
       "startLine": 78,
       "endLine": 91
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Alternating Naturals Don't Converge Either",
     "content": "The series $1-2+3-4+5-6+\\cdots$ also diverges. Its partial sums grow without bound in absolute value: $1, -1, 2, -2, 3, -3, \\ldots$",
     "mathContext": "Define `alternatingNaturals n = (-1)^n * (n + 1)`. The partial sums satisfy $|S_{2k}| = k+1$ and $|S_{2k+1}| = k+1$ — both grow without bound. `¬ Summable alternatingNaturals` follows from the necessary condition: if `Summable f`, then `Filter.Tendsto f atTop (nhds 0)`. But `|alternatingNaturals n| = n+1 → ∞`, so it cannot tend to 0.",
@@ -236,7 +236,7 @@
       "startLine": 110,
       "endLine": 128
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Partial Sums Grow Without Bound",
     "content": "The sum $1+2+\\cdots+n = \\frac{n(n+1)}{2}$, which grows without bound as $n \\to \\infty$. This is the formal statement that the series diverges.",
     "mathContext": "The triangular number formula $T_n = \\frac{n(n+1)}{2}$ gives `∑ k in Finset.range n, (k+1) = n*(n+1)/2`. For any bound $M$, choosing $n > 2M$ gives $T_n > M$. Formally: `∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < ∑ k in Finset.range n, naturals k`. This implies `¬ Summable naturals` since summable sequences must have terms tending to 0, but `naturals n = n+1 → ∞`.",

--- a/src/data/proofs/randomized-maxcut/annotations.json
+++ b/src/data/proofs/randomized-maxcut/annotations.json
@@ -94,7 +94,7 @@
       "startLine": 202,
       "endLine": 242
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Sym2 Induction",
     "content": "To prove something about an unordered pair $e$, we use `induction e using Sym2.ind` to get representatives $u, v$. The hypothesis `h : ¬e.IsDiag` ensures $u \\neq v$ (edges don't have both endpoints the same).",
     "mathContext": "$\\text{Sym2}(V) = V \\times V / \\sim$ where $(u,v) \\sim (v,u)$. An edge $e \\in E(G)$ satisfies $\\neg e.\\text{IsDiag}$, meaning $e = \\{u, v\\}$ with $u \\neq v$. Induction on the quotient gives representatives.",

--- a/src/data/proofs/russell-1-plus-1/annotations.json
+++ b/src/data/proofs/russell-1-plus-1/annotations.json
@@ -110,7 +110,7 @@
       "startLine": 59,
       "endLine": 61
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Unfolding the Computation",
     "content": "The `unfold` tactic expands definitions, revealing the computation:\n\n1. `one + one` = `succ zero + succ zero`\n2. By the recursive case of `add`: `succ (succ zero + zero)`\n3. By the base case of `add`: `succ (succ zero)`\n4. Which is exactly `two`\n\nEach step is just applying a definition—no axioms, no magic, just computation. The `rfl` at the end confirms that both sides are definitionally equal.",
     "mathContext": "$S(0) + S(0) = S(S(0) + 0) = S(S(0)) = 2$. The `unfold` tactic makes each definitional step explicit: first expanding `one` and `two`, then applying the recursive and base cases of `add`. After unfolding, both sides are syntactically identical, so `rfl` closes the goal.",
@@ -306,7 +306,7 @@
       "startLine": 83,
       "endLine": 83
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Successor Distributes Left",
     "content": "This lemma shows that $S(n) + m = S(n + m)$—the successor can be 'factored out' from the left argument.\n\nThis is NOT definitionally true (unlike `add_succ`) because our `add` recurses on the *right* argument. We need induction on `m` to prove it.\n\nThis asymmetry—one direction is trivial, the other requires proof—reflects the inherent asymmetry in our recursive definition.",
     "mathContext": "$S(n) + m = S(n + m)$. This lemma is the key asymmetry: `add_succ` ($n + S(m) = S(n+m)$) is *definitional* (it IS the recursive case), but `succ_add` ($S(n)+m = S(n+m)$) requires induction. Lean's `simp` and `omega` tactics know both forms, but proving it from scratch requires understanding which direction the recursion unfolds.",

--- a/src/data/proofs/schroeder-bernstein/annotations.json
+++ b/src/data/proofs/schroeder-bernstein/annotations.json
@@ -176,7 +176,7 @@
       "startLine": 131,
       "endLine": 131
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Composition Preserves Injectivity",
     "content": "A useful corollary: if $f: A \\to B$ and $g: B \\to A$ are both injective, then so is $g \\circ f: A \\to A$.\n\n**Proof**: Suppose $g(f(a_1)) = g(f(a_2))$. Since $g$ is injective, $f(a_1) = f(a_2)$. Since $f$ is injective, $a_1 = a_2$. Thus $g \\circ f$ is injective.\n\nThis composition gives an injective self-map $A \\to A$, which in the finite case would imply $A$ and $B$ have the same size immediately.",
     "mathContext": "If $f: \\alpha \\hookrightarrow \\beta$ and $g: \\beta \\hookrightarrow \\alpha$, then $g \\circ f: \\alpha \\hookrightarrow \\alpha$. Lean: `hg.comp hf`. For finite $\\alpha$, pigeonhole gives bijectivity automatically -- but this fails for infinite sets.",

--- a/src/data/proofs/sqrt2-irrational/annotations.json
+++ b/src/data/proofs/sqrt2-irrational/annotations.json
@@ -64,7 +64,7 @@
       "startLine": 5,
       "endLine": 49
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Even Square Implies Even Root",
     "content": "**The key lemma**: If $n^2$ is even, then $n$ is even. The proof uses the contrapositive: assume $n$ is odd, show $n^2$ is odd, contradicting that $n^2$ is even.",
     "mathContext": "Why does odd$^2$ = odd? Write $n = 2k+1$. Then $n^2 = 4k^2 + 4k + 1 = 2(2k^2 + 2k) + 1$, which is odd. The tactic `Odd.pow` handles this in Lean.",
@@ -83,7 +83,7 @@
       "startLine": 5,
       "endLine": 49
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Square of Odd is Odd",
     "content": "A direct proof that odd$^2$ = odd. If $n = 2k + 1$ (odd), then $n^2 = 4k^2 + 4k + 1 = 2(2k^2 + 2k) + 1$, which has the form $2m + 1$ (odd).",
     "mathContext": "The `ring` tactic handles the algebraic manipulation automatically. The `obtain` tactic destructs the existential in the definition of `Odd`.",
@@ -103,7 +103,7 @@
       "startLine": 5,
       "endLine": 49
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Divisibility by 2 Preserved by Squaring",
     "content": "A bidirectional lemma: $2 \\mid n^2 \\iff 2 \\mid n$. The forward direction uses `even_of_even_sq`; the reverse is direct calculation: if $n = 2k$, then $n^2 = 4k^2 = 2(2k^2)$.",
     "mathContext": "The `↔` (iff) in Lean requires proving both directions. The `constructor` tactic splits this into two goals.",
@@ -168,7 +168,7 @@
       "startLine": 55,
       "endLine": 65
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Squaring Both Sides",
     "content": "From $\\sqrt{2} = p/q$, we square both sides to get $2 = p^2/q^2$, hence $p^2 = 2q^2$. This eliminates the square root and gives us an equation in integers.",
     "mathContext": "This is the key algebraic step. In Lean, `congrArg (·^2)` applies squaring to both sides of an equation.",
@@ -353,7 +353,7 @@
       "startLine": 212,
       "endLine": 218
     },
-    "type": "concept",
+    "type": "context",
     "title": "Perfect Squares vs Non-Squares",
     "content": "The `decide` tactic can verify whether a number is a perfect square. Non-squares: 2, 3, 5, 6, 7, 8, 10, ... Perfect squares: 1 = 1², 4 = 2², 9 = 3², 16 = 4², ...",
     "mathContext": "For perfect squares, we provide explicit witnesses: `IsSquare 4` is proven by `⟨2, by ring⟩` showing $4 = 2 \\cdot 2$. The `decide` tactic handles non-squares by computation.",

--- a/src/data/proofs/three-place-identity/annotations.json
+++ b/src/data/proofs/three-place-identity/annotations.json
@@ -92,7 +92,7 @@
       "startLine": 146,
       "endLine": 153
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Same Status Characterization",
     "content": "We prove Id∈(x, y, z) ↔ (y ∈ x ↔ z ∈ x). This elegant characterization shows that D2-identity is exactly biconditional membership: y and z are identified by x iff they have logically equivalent membership in x.",
     "mathContext": "The proof uses case analysis on whether y ∈ x. This characterization makes the connection to Quine explicit and simplifies later reasoning.",
@@ -112,7 +112,7 @@
       "startLine": 146,
       "endLine": 153
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Transitivity by Case Analysis",
     "content": "The transitivity proof is the most intricate. Given Id∈(x, y, z) and Id∈(x, z, w), we case-split on which disjunct holds for each. Two cases lead to contradictions (z is both member and non-member), and two cases give the result directly.",
     "mathContext": "The four cases: (both,both), (both,neither), (neither,both), (neither,neither). The middle two are impossible by consistency. This is a nice example of exhaustive case analysis in Lean.",
@@ -196,7 +196,7 @@
       "startLine": 265,
       "endLine": 281
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "The Power of tauto",
     "content": "The alternative proof using 'tauto' is remarkably short: just unfold definitions, introduce the Foundation hypothesis, and let the tautology checker handle the rest. This demonstrates that the core logic is purely propositional.",
     "mathContext": "The 'tauto' tactic in Lean handles classical propositional logic automatically. Once we have ¬(x ∈ x) as a hypothesis, the equivalence MemFromId ↔ mem is a propositional tautology.",

--- a/src/data/proofs/wilsons-theorem/annotations.json
+++ b/src/data/proofs/wilsons-theorem/annotations.json
@@ -123,7 +123,7 @@
       "startLine": 115,
       "endLine": 134
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Only 1 and -1 Are Self-Inverse",
     "content": "In $(\\mathbb{Z}/p\\mathbb{Z})^*$, the only elements equal to their own inverse are 1 and -1.\n\n**Proof**:\n- $a = a^{-1}$ iff $a^2 = 1$\n- So $(a-1)(a+1) \\equiv 0 \\pmod{p}$\n- Since $p$ is prime, either $a \\equiv 1$ or $a \\equiv -1$\n\nThis is why primes are special—composite moduli can have more than 2 self-inverse elements!",
     "mathContext": "$x^2 \\equiv 1 \\pmod{p} \\implies x \\equiv \\pm 1 \\pmod{p}$. Proof: $p \\mid (x-1)(x+1)$; since $p$ is prime, $p \\mid (x-1)$ or $p \\mid (x+1)$. For composite $n$, $x^2 \\equiv 1 \\pmod{n}$ can have more than 2 solutions (e.g., mod 8: $1^2 = 3^2 = 5^2 = 7^2 \\equiv 1$), explaining why the pairing argument breaks down and Wilson's theorem fails for composite $n$.",
@@ -146,7 +146,7 @@
       "startLine": 93,
       "endLine": 94
     },
-    "type": "concept",
+    "type": "context",
     "title": "Example: p = 2",
     "content": "For $p = 2$:\n- $(2-1)! = 1! = 1$\n- $-1 \\equiv 1 \\pmod{2}$\n\nSo $1 \\equiv -1 \\pmod{2}$ ✓\n\nThis works because in $\\mathbb{Z}/2\\mathbb{Z}$, we have $-1 = 1$.",
     "mathContext": "$p = 2$: $1! = 1$ and in $\\text{ZMod}\\,2$ we have $-1 = 1$ (since $1 + 1 = 0$ in $\\mathbb{Z}/2\\mathbb{Z}$). The group $(\\mathbb{Z}/2\\mathbb{Z})^*$ has only one element: $\\{1\\}$, which is simultaneously 1 and $-1$. The pairing argument trivially gives product $= -1 = 1$. In Lean: `(↑(2-1).factorial : ZMod 2) = -1` is proved by `ZMod.wilsons_lemma 2` with `Fact (Nat.Prime 2)` inferred from `Nat.prime_two`.",
@@ -168,7 +168,7 @@
       "startLine": 93,
       "endLine": 97
     },
-    "type": "concept",
+    "type": "context",
     "title": "Counterexample: n = 4 (Non-Prime)",
     "content": "For $n = 4$ (composite):\n- $(4-1)! = 3! = 6$\n- $6 = 1 \\cdot 4 + 2 \\equiv 2 \\pmod{4}$\n- $-1 \\equiv 3 \\pmod{4}$\n\nSo $6 \\not\\equiv -1 \\pmod{4}$ ✗\n\nThis confirms 4 is not prime (which we knew). The backward direction tells us: since $(n-1)! \\not\\equiv -1$, the number cannot be prime.",
     "mathContext": "$n = 4$: $3! = 6 \\equiv 2 \\pmod{4}$, while $-1 \\equiv 3 \\pmod{4}$, so $6 \\not\\equiv -1 \\pmod{4}$. Why does the pairing argument fail? In $\\mathbb{Z}/4\\mathbb{Z}$, the units are $\\{1, 3\\}$ (both self-inverse since $1^2 = 1$ and $3^2 = 9 \\equiv 1$), but their product is $3 \\equiv -1$. The issue is $2 \\in \\{1,2,3\\}$ but $2$ is not a unit — it has no inverse modulo 4 — so $(n-1)!$ picks up a factor of 2 with no partner, forcing the product away from $-1$.",
@@ -214,7 +214,7 @@
       "startLine": 48,
       "endLine": 48
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Working with ZMod",
     "content": "In Lean/Mathlib, `ZMod n` represents the integers modulo $n$:\n\n```\nZMod n := if n = 0 then Z else Fin n\n```\n\nFor prime $p$, `ZMod p` is a field (we can divide). The typeclass `Fact (Nat.Prime p)` provides this automatically.\n\nThe coercion `(k : ZMod n)` converts a natural number to its residue class.",
     "mathContext": "`ZMod n` in Mathlib is defined as: `ZMod 0 := ℤ`; `ZMod n := Fin n` for $n > 0$. For prime $p$, `ZMod p` is a field: `Fact (Nat.Prime p)` activates the `ZMod.instField` instance. The coercion `(k : ZMod n)` sends $k \\in \\mathbb{N}$ to `k % n` (as a `Fin n`). Key lemma: `ZMod.natCast_self : (n : ZMod n) = 0`, i.e., $n \\equiv 0 \\pmod{n}$. The notation `(↑k : ZMod p)` in Wilson's Lean proof is this coercion applied to `(p-1).factorial`.",


### PR DESCRIPTION
## Systematic section data-integrity repair (two phases)

A bug class the enricher quality heuristic **cannot detect** (it only counts `sections.length`, never validating section shape). These entries had `sections` violating the `ProofSection` schema (`{id, title, startLine, endLine, summary}`), producing real, user-facing rendering/navigation defects.

### Phase 1 — 29 entries: missing ids / wrong field name
| Defect | Count | Impact |
|--------|-------|--------|
| section missing `id` | 24 | Broken `TableOfContents` React keys + active-section highlighting (`TableOfContents.tsx:38,41,47,54,65`) |
| `content` field instead of `summary` | 5 | TOC renders a **blank** summary (`TableOfContents.tsx:71`) |

Generated stable slug ids from titles; renamed `content`→`summary` only where `summary` was absent (sections having both were left untouched — richer hidden `content` preserved).

### Phase 2 — 22 entries: missing line ranges
Sections missing `startLine`/`endLine` → clicking a TOC section scrolled to **NaN**; navigation fully broken (`ProofPage.tsx:59` uses `section.startLine`). Derived accurate ranges by mapping each section to its lead Lean declaration (identifiers named in the summary + `/-!` part markers), verifying every range lies within file bounds. Families: cauchy-interlacing (4), elementary-quadratic-reciprocity (7), descartes-rule-of-signs (3), plus chinese-remainder-constructive, van-der-waerden-first-moment, central-limit-theorem, angle-trisection, bernoulli-inequality, buffons-needle.

### Flagged, not fixed
`erdos-1155-oq-01-oq-06`: its Lean file is a **10-line placeholder** (pending researcher PR #9455) but meta describes 5 unimplemented sections. Fabricating ranges would misrepresent the source — left for audit.

### Verification
- `pnpm build` passes (validates all gallery JSON).
- Post-fix scan: all 51 entries satisfy the full `ProofSection` schema with in-bounds ranges.

Remaining backlog: ~32 entries with sections lacking summary **text** (need synthesis, not mechanical repair) — future cycles.