### PR TITLE
Enrich Hadamard Three-Lines axiom discharge: annotate uncovered header/setup

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-cs-framing-axiom-discharge",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "context",
+    "title": "What This File Discharges: an Axiom, Not a Conjecture",
+    "content": "The parent entry *Riesz–Thorin Interpolation from Hölder's Inequality* (`cauchy-schwarz-integral-oq-01-oq-02`) reaches the interpolation theorem but leaves two links stated as `axiom`s: `hadamard_three_lines` (the analytic maximum-principle heart) and `riesz_thorin` itself. This file answers the open question 'is the three-lines lemma actually available in Lean, or must it be assumed?' by **discharging the first axiom** — proving it as a genuine theorem from Mathlib's complete `Complex.HadamardThreeLines` formalization. The single import `import Mathlib` and `open ... Complex.HadamardThreeLines` (line 48) expose that API; the `namespace` (line 50) scopes local copies of the strip definitions so the proved statement is *syntactically identical* to the parent's axiom and can replace it verbatim. Crucially, nothing new is assumed: the file inherits only the standard Mathlib axiom triple (`propext`, `Classical.choice`, `Quot.sound`), so this is a strict reduction in the parent's assumption count.",
+    "mathContext": "Axiom $\\Rightarrow$ theorem: $\\|F(t+iy)\\|\\le M_0^{1-t}M_1^{t}$ is *derived*, not assumed. Assumption count for the Riesz–Thorin development drops by one.",
+    "significance": "context",
+    "relatedConcepts": ["Axiom discharge", "Riesz–Thorin theorem", "Hadamard three-lines theorem", "Mathlib reuse", "Assumption minimization"],
+    "prerequisites": ["what a Lean axiom is", "the Riesz–Thorin interpolation theorem", "the maximum modulus principle"]
+  },
+  {
     "id": "ann-cs-hadamard-strips",
     "proofId": "cauchy-schwarz-integral-oq-01-oq-02-oq-01",
     "range": { "startLine": 52, "endLine": 65 },


### PR DESCRIPTION
Enrichment coverage pass for `cauchy-schwarz-integral-oq-01-oq-02-oq-01`.

**Gap fixed:** annotations previously began at line 52, leaving the entire module header (lines 1–50: docstring, `import Mathlib`, `open ... Complex.HadamardThreeLines`, `namespace`) with no annotation coverage.

**Added:** one `context`-type annotation (`ann-cs-framing-axiom-discharge`, range 1–50, anchored on the line-1 `/-` doc-comment) that frames the entry for a reader before the definitions begin — namely that this file *discharges* the parent Riesz–Thorin entry's `hadamard_three_lines` axiom into a proved theorem (from Mathlib's `Complex.HadamardThreeLines`), a strict reduction in the parent's assumption count. Includes full `mathContext` / `significance` / `relatedConcepts` / `prerequisites` per schema.

No changes to the Lean source, meta.json, or existing annotations. JSON validated; meta.json within size caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)