### PR TITLE
research(algebraic-numbers-countable-oq-01-oq-01-oq-01): ℚ̄ is perfect — no inseparable extensions [VERIFIED, 0-axiom, 11thm/146L]

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ01OQ01OQ01.lean
@@ -1,0 +1,146 @@
+/-
+  # The Algebraic Numbers Form a Perfect Field — No Inseparable Extensions
+
+  The parent file (`AlgebraicNumbersCountableOQ01OQ01`) realizes the algebraic numbers
+  concretely as `algebraicNumbersField : IntermediateField ℚ ℂ` and proves it is an
+  **algebraically closed** field — an algebraic closure of `ℚ` sitting inside `ℂ`.
+
+  This file adds the *separability* half of the picture, answering the open question:
+  formalize that `ℚ̄` is **perfect**, so every algebraic extension of `ℚ` is separable,
+  and conclude that `algebraicClosure ℚ ℂ` has **no inseparable extensions**.
+
+  ## What is proved
+
+  1. **`ℚ` is perfect.** A field of characteristic zero is perfect
+     (`PerfectField.ofCharZero`), so `PerfectField ℚ` holds. Consequently every
+     algebraic extension `E / ℚ` is a *separable* extension
+     (`Algebra.IsAlgebraic.isSeparable_of_perfectField`), and the minimal polynomial
+     over `ℚ` of any algebraic number is separable — hence squarefree, with distinct
+     roots.
+
+  2. **`ℚ̄` is perfect, two ways.** The field of algebraic numbers is perfect for two
+     independent reasons: it is *algebraically closed* (so perfect by the general
+     `IsAlgClosed → PerfectField`), and it is an *algebraic extension of the perfect
+     field `ℚ`* (so perfect by `Algebra.IsAlgebraic.perfectField`). The algebraic
+     numbers are themselves a separable extension of `ℚ`.
+
+  3. **No inseparable extensions.** Because `ℚ̄` is perfect, *every* algebraic extension
+     `L / ℚ̄` is separable: the algebraic closure of `ℚ` admits no inseparable algebraic
+     extension. The same holds verbatim for Mathlib's `algebraicClosure ℚ ℂ`.
+
+  4. **Counting embeddings of a number field.** As a concrete arithmetic payoff,
+     separability forces the separable degree to equal the full degree: for a finite
+     extension `E / ℚ`, `finSepDegree ℚ E = [E : ℚ]`. Unwinding the definition of
+     separable degree, this says a number field of degree `n` has exactly `n`
+     embeddings into its algebraic closure — the classical statement that a degree-`n`
+     number field has `n` complex embeddings.
+
+  Tags: field-theory, algebraic-numbers, perfect-field, separability, separable-degree,
+        number-field, embeddings, characteristic-zero
+-/
+import Proofs.AlgebraicNumbersCountableOQ01OQ01
+import Mathlib.FieldTheory.Perfect
+import Mathlib.FieldTheory.SeparableDegree
+import Mathlib.Tactic
+
+open AlgebraicNumbersCountableOQ01OQ01
+
+namespace AlgebraicNumbersCountableOQ01OQ01OQ01
+
+/- ============================================================
+   § 1 : ℚ is perfect; its algebraic extensions are separable
+   ============================================================ -/
+
+/-- `ℚ` is a **perfect field**: every field of characteristic zero is perfect
+    (`PerfectField.ofCharZero`). -/
+theorem perfectField_rat : PerfectField ℚ := inferInstance
+
+/-- **Every algebraic extension of `ℚ` is separable.** Since `ℚ` is perfect, any
+    algebraic extension `E / ℚ` is automatically a separable extension. -/
+theorem isSeparable_of_isAlgebraic_rat {E : Type*} [Field E] [Algebra ℚ E]
+    [Algebra.IsAlgebraic ℚ E] : Algebra.IsSeparable ℚ E := inferInstance
+
+/-- The minimal polynomial over `ℚ` of any algebraic number is **separable** (it has no
+    repeated roots) — the polynomial-level face of `ℚ` being perfect. -/
+theorem minpoly_separable_rat {E : Type*} [Field E] [Algebra ℚ E] (x : E)
+    (hx : IsIntegral ℚ x) : (minpoly ℚ x).Separable :=
+  PerfectField.separable_of_irreducible (minpoly.irreducible hx)
+
+/-- Consequently, the minimal polynomial over `ℚ` of any algebraic number is squarefree. -/
+theorem minpoly_squarefree_rat {E : Type*} [Field E] [Algebra ℚ E] (x : E)
+    (hx : IsIntegral ℚ x) : Squarefree (minpoly ℚ x) :=
+  (minpoly_separable_rat x hx).squarefree
+
+/- ============================================================
+   § 2 : The algebraic numbers ℚ̄ ⊆ ℂ form a perfect field
+   ============================================================ -/
+
+/-- **`ℚ̄` is perfect (via algebraic closedness).** The field of algebraic numbers is
+    algebraically closed (parent result), and every algebraically closed field is
+    perfect. -/
+theorem perfectField_algebraicNumbers : PerfectField algebraicNumbersField :=
+  inferInstance
+
+/-- **`ℚ̄` is perfect (via being algebraic over `ℚ`).** A second, independent argument:
+    `ℚ̄ / ℚ` is an algebraic extension of the perfect field `ℚ`, and an algebraic
+    extension of a perfect field is perfect (`Algebra.IsAlgebraic.perfectField`). -/
+theorem perfectField_algebraicNumbers_of_algebraic :
+    PerfectField algebraicNumbersField :=
+  Algebra.IsAlgebraic.perfectField (K := ℚ)
+
+/-- The algebraic numbers are a **separable** extension of `ℚ`: every algebraic number
+    is separable over `ℚ`. -/
+theorem isSeparable_rat_algebraicNumbers :
+    Algebra.IsSeparable ℚ algebraicNumbersField := inferInstance
+
+/- ============================================================
+   § 3 : No inseparable extensions of ℚ̄
+   ============================================================ -/
+
+/-- **No inseparable extensions.** Every algebraic extension `L` of the field of
+    algebraic numbers is separable — `ℚ̄` admits no inseparable algebraic extension.
+    (Of course `ℚ̄` is algebraically closed, so such an `L` is even trivial; the point
+    is that separability holds for *any* algebraic `L / ℚ̄`, a property of perfectness
+    that does not require algebraic closedness.) -/
+theorem isSeparable_of_isAlgebraic_algebraicNumbers {L : Type*} [Field L]
+    [Algebra algebraicNumbersField L] [Algebra.IsAlgebraic algebraicNumbersField L] :
+    Algebra.IsSeparable algebraicNumbersField L := inferInstance
+
+/-- The same conclusion phrased for Mathlib's relative algebraic closure
+    `algebraicClosure ℚ ℂ`, which coincides with the algebraic numbers
+    (`algebraicNumbersField_eq`): it is a perfect field with no inseparable extensions. -/
+theorem perfectField_algebraicClosure_rat_complex :
+    PerfectField (algebraicClosure ℚ ℂ) := inferInstance
+
+/- ============================================================
+   § 4 : Counting embeddings of a number field
+   ============================================================ -/
+
+/-- **Separable degree equals degree for number fields.** For any finite extension
+    `E / ℚ`, separability (which holds automatically, `ℚ` being perfect) forces the
+    separable degree to equal the full degree. -/
+theorem finSepDegree_eq_finrank_rat {E : Type*} [Field E] [Algebra ℚ E]
+    [FiniteDimensional ℚ E] : Field.finSepDegree ℚ E = Module.finrank ℚ E := by
+  haveI : Algebra.IsAlgebraic ℚ E := Algebra.IsAlgebraic.of_finite ℚ E
+  exact Field.finSepDegree_eq_finrank_of_isSeparable ℚ E
+
+/-- **A number field of degree `n` has exactly `n` embeddings.** Unfolding the
+    definition of separable degree (`finSepDegree ℚ E = Nat.card (Field.Emb ℚ E)`),
+    the previous theorem says the number of `ℚ`-algebra embeddings of a finite extension
+    `E` into its algebraic closure equals `[E : ℚ]`. -/
+theorem card_emb_eq_finrank_rat {E : Type*} [Field E] [Algebra ℚ E]
+    [FiniteDimensional ℚ E] : Nat.card (Field.Emb ℚ E) = Module.finrank ℚ E :=
+  finSepDegree_eq_finrank_rat
+
+section Examples
+
+-- Every algebraic number's minimal polynomial over `ℚ` is squarefree.
+example {z : ℂ} (hz : IsAlgebraic ℚ z) : Squarefree (minpoly ℚ z) :=
+  minpoly_squarefree_rat z hz.isIntegral
+
+-- The algebraic numbers are a separable (indeed perfect) extension of `ℚ`.
+example : Algebra.IsSeparable ℚ algebraicNumbersField := isSeparable_rat_algebraicNumbers
+
+end Examples
+
+end AlgebraicNumbersCountableOQ01OQ01OQ01

--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "algnum-perfect-ann-rat",
+    "proofId": "algebraic-numbers-countable-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 73
+    },
+    "type": "theorem",
+    "title": "ℚ is perfect, so its algebraic extensions are separable",
+    "content": "perfectField_rat records PerfectField ℚ, which holds by PerfectField.ofCharZero: every field of characteristic zero is perfect. Perfectness is defined precisely so that every algebraic extension is separable, and Mathlib packages this as the instance Algebra.IsAlgebraic.isSeparable_of_perfectField — hence isSeparable_of_isAlgebraic_rat: any E with Algebra.IsAlgebraic ℚ E is automatically Algebra.IsSeparable ℚ E. At the polynomial level, minpoly_separable_rat feeds minpoly.irreducible hx into PerfectField.separable_of_irreducible to show the minimal polynomial of any algebraic number is separable; minpoly_squarefree_rat then applies Separable.squarefree. So every algebraic number has a distinct-root minimal polynomial over ℚ.",
+    "mathContext": "A field $K$ is perfect iff every algebraic extension of $K$ is separable; in characteristic zero this is automatic. For $\\mathbb{Q}$ it means irreducible polynomials — in particular minimal polynomials of algebraic numbers — have no repeated roots.",
+    "significance": "core",
+    "relatedConcepts": [
+      "perfect field",
+      "separable extension",
+      "characteristic zero",
+      "minimal polynomial",
+      "squarefree polynomial"
+    ],
+    "prerequisites": [
+      "field extensions",
+      "separable polynomials",
+      "minimal polynomials"
+    ]
+  },
+  {
+    "id": "algnum-perfect-ann-qbar",
+    "proofId": "algebraic-numbers-countable-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 74,
+      "endLine": 95
+    },
+    "type": "theorem",
+    "title": "The algebraic numbers form a perfect field (two ways)",
+    "content": "perfectField_algebraicNumbers derives PerfectField algebraicNumbersField from the parent's IsAlgClosed instance via IsAlgClosed.perfectField: every algebraically closed field is perfect. perfectField_algebraicNumbers_of_algebraic gives a second, independent proof: ℚ̄/ℚ is an algebraic extension (parent instance algebraicIntermediateField_isAlgebraic) of the perfect field ℚ, and Algebra.IsAlgebraic.perfectField shows an algebraic extension of a perfect field is perfect. Neither argument subsumes the other conceptually. Combining perfectness of ℚ with algebraicity of ℚ̄/ℚ, isSeparable_rat_algebraicNumbers records that the algebraic numbers are a separable extension of ℚ.",
+    "mathContext": "Perfectness is inherited two ways here: from algebraic closedness (nothing inseparable can be built when everything already splits) and from being algebraic over a perfect base (perfectness transfers up algebraic extensions).",
+    "significance": "core",
+    "relatedConcepts": [
+      "perfect field",
+      "algebraically closed field",
+      "algebraic extension",
+      "algebraic numbers"
+    ],
+    "prerequisites": [
+      "algebraically closed fields",
+      "algebraic extensions",
+      "perfect fields"
+    ]
+  },
+  {
+    "id": "algnum-perfect-ann-noinsep",
+    "proofId": "algebraic-numbers-countable-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 96,
+      "endLine": 113
+    },
+    "type": "theorem",
+    "title": "No inseparable extensions of ℚ̄",
+    "content": "isSeparable_of_isAlgebraic_algebraicNumbers states that any algebraic extension L of the field of algebraic numbers is separable: with PerfectField algebraicNumbersField (from §2) and Algebra.IsAlgebraic algebraicNumbersField L in scope, Algebra.IsAlgebraic.isSeparable_of_perfectField supplies Algebra.IsSeparable algebraicNumbersField L. This is the answer to the parent's open question — ℚ̄ has no inseparable algebraic extension — and it is a consequence of perfectness, not of algebraic closedness (algebraic closedness would further make L trivial, but is not needed for separability). perfectField_algebraicClosure_rat_complex restates the perfectness for Mathlib's own algebraicClosure ℚ ℂ, which the parent identified with algebraicNumbersField.",
+    "mathContext": "Because $\\overline{\\mathbb{Q}}$ is perfect, every algebraic extension of it is separable — there are no inseparable extensions. The statement holds verbatim for Mathlib's relative algebraic closure $\\mathrm{algebraicClosure}\\,\\mathbb{Q}\\,\\mathbb{C}$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "inseparable extension",
+      "perfect field",
+      "algebraic closure",
+      "separable extension"
+    ],
+    "prerequisites": [
+      "separable and inseparable extensions",
+      "perfect fields",
+      "algebraic closure"
+    ]
+  },
+  {
+    "id": "algnum-perfect-ann-emb",
+    "proofId": "algebraic-numbers-countable-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 114,
+      "endLine": 133
+    },
+    "type": "theorem",
+    "title": "A number field of degree n has exactly n embeddings",
+    "content": "finSepDegree_eq_finrank_rat: for a finite extension E/ℚ, FiniteDimensional gives Algebra.IsAlgebraic ℚ E (Algebra.IsAlgebraic.of_finite), which — ℚ being perfect — gives separability, so Field.finSepDegree_eq_finrank_of_isSeparable yields finSepDegree ℚ E = finrank ℚ E. Since finSepDegree is defined as Nat.card (Field.Emb ℚ E), the separable degree literally counts the ℚ-algebra embeddings of E into its algebraic closure; card_emb_eq_finrank_rat reads this off as Nat.card (Field.Emb ℚ E) = [E : ℚ]. This is the classical fact that a degree-n number field has exactly n embeddings — the arithmetic payoff of perfectness.",
+    "mathContext": "The separable degree $[E : K]_s = \\#\\{K\\text{-embeddings of } E \\text{ into } \\overline{K}\\}$ equals the full degree over a perfect base. For a number field this gives $n$ embeddings for degree $n$, the basis of embedding signatures $(r_1, r_2)$ and the Minkowski embedding.",
+    "significance": "core",
+    "relatedConcepts": [
+      "separable degree",
+      "field embeddings",
+      "number field",
+      "Field.Emb",
+      "degree of extension"
+    ],
+    "prerequisites": [
+      "finite field extensions",
+      "separable degree",
+      "algebraic closure"
+    ]
+  }
+]

--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,242 @@
+{
+  "id": "algebraic-numbers-countable-oq-01-oq-01-oq-01",
+  "title": "The Algebraic Numbers Form a Perfect Field — No Inseparable Extensions",
+  "slug": "algebraic-numbers-countable-oq-01-oq-01-oq-01",
+  "description": "Answers the parent's first open question: the field of algebraic numbers is perfect, so every algebraic extension of ℚ is separable and algebraicClosure ℚ ℂ has no inseparable extensions. ℚ is perfect because it has characteristic zero (PerfectField.ofCharZero); hence every algebraic extension E/ℚ is separable and the minimal polynomial over ℚ of any algebraic number is separable, so squarefree with distinct roots. The algebraic numbers ℚ̄ are shown perfect two independent ways — as an algebraically closed field (IsAlgClosed → PerfectField) and as an algebraic extension of the perfect field ℚ (Algebra.IsAlgebraic.perfectField) — and are a separable extension of ℚ. Because ℚ̄ is perfect, every algebraic extension L/ℚ̄ is separable: no inseparable algebraic extension exists. As an arithmetic payoff, separability forces finSepDegree ℚ E = [E : ℚ] for finite E/ℚ, i.e. a number field of degree n has exactly n embeddings into its algebraic closure.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Perfect_field",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ01OQ01OQ01.lean",
+    "tags": [
+      "field-theory",
+      "algebraic-numbers",
+      "perfect-field",
+      "separability",
+      "separable-degree",
+      "number-field",
+      "embeddings",
+      "characteristic-zero",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 146,
+    "assumptions": "",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "perfectField_rat + isSeparable_of_isAlgebraic_rat: ℚ is a perfect field (characteristic zero, PerfectField.ofCharZero), so every algebraic extension E/ℚ is automatically a separable extension",
+      "minpoly_separable_rat / minpoly_squarefree_rat: the minimal polynomial over ℚ of any algebraic number is separable (via PerfectField.separable_of_irreducible ∘ minpoly.irreducible) and hence squarefree — the polynomial-level face of perfectness, i.e. algebraic numbers have distinct-root minimal polynomials",
+      "perfectField_algebraicNumbers + perfectField_algebraicNumbers_of_algebraic: the field of algebraic numbers ℚ̄ is perfect via two independent arguments — it is algebraically closed (IsAlgClosed → PerfectField) and it is an algebraic extension of the perfect field ℚ (Algebra.IsAlgebraic.perfectField)",
+      "isSeparable_rat_algebraicNumbers: the algebraic numbers are a separable extension of ℚ — every algebraic number is separable over ℚ",
+      "isSeparable_of_isAlgebraic_algebraicNumbers: no inseparable extensions — every algebraic extension L/ℚ̄ is separable, a consequence of ℚ̄ being perfect that does not use algebraic closedness; also stated for Mathlib's algebraicClosure ℚ ℂ (perfectField_algebraicClosure_rat_complex)",
+      "finSepDegree_eq_finrank_rat + card_emb_eq_finrank_rat: for any finite extension E/ℚ, separability forces finSepDegree ℚ E = [E : ℚ]; unfolding finSepDegree = Nat.card (Field.Emb ℚ E), a number field of degree n has exactly n embeddings into its algebraic closure"
+    ],
+    "prerequisites": [
+      "algebraic-numbers-countable-oq-01-oq-01: realizes the algebraic numbers as algebraicNumbersField : IntermediateField ℚ ℂ, algebraically closed and equal to algebraicClosure ℚ ℂ (this entry adds the separability/perfectness half)",
+      "PerfectField.ofCharZero: every field of characteristic zero is perfect",
+      "Algebra.IsAlgebraic.isSeparable_of_perfectField: an algebraic extension of a perfect field is separable",
+      "Algebra.IsAlgebraic.perfectField: an algebraic extension of a perfect field is itself perfect",
+      "Field.finSepDegree_eq_finrank_of_isSeparable: for a separable extension, separable degree equals degree"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "PerfectField.ofCharZero",
+        "description": "Every field of characteristic zero is perfect; supplies PerfectField ℚ and, transported through the extension, the perfectness of the algebraic numbers",
+        "module": "Mathlib.FieldTheory.Perfect"
+      },
+      {
+        "theorem": "Algebra.IsAlgebraic.isSeparable_of_perfectField",
+        "description": "If K is perfect and L/K is algebraic then L/K is separable; the instance turning perfectness of ℚ (and of ℚ̄) into separability of algebraic extensions",
+        "module": "Mathlib.FieldTheory.Perfect"
+      },
+      {
+        "theorem": "Algebra.IsAlgebraic.perfectField",
+        "description": "An algebraic extension of a perfect field is perfect; the second route to perfectness of ℚ̄, via ℚ̄/ℚ being algebraic",
+        "module": "Mathlib.FieldTheory.Perfect"
+      },
+      {
+        "theorem": "PerfectField.separable_of_irreducible",
+        "description": "Over a perfect field an irreducible polynomial is separable; applied to minpoly ℚ x to show algebraic numbers have separable (distinct-root) minimal polynomials",
+        "module": "Mathlib.FieldTheory.Perfect"
+      },
+      {
+        "theorem": "IsAlgClosed.perfectField",
+        "description": "Every algebraically closed field is perfect; the first route to perfectness of ℚ̄ (which is algebraically closed by the parent entry)",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Field.finSepDegree_eq_finrank_of_isSeparable",
+        "description": "For a separable extension the separable degree equals the degree; combined with automatic separability over ℚ this gives finSepDegree ℚ E = [E : ℚ] and hence the count of embeddings of a number field",
+        "module": "Mathlib.FieldTheory.SeparableDegree"
+      }
+    ],
+    "theoremCount": 11,
+    "relatedProblems": [
+      {
+        "id": "algebraic-numbers-countable-oq-01-oq-01",
+        "relationship": "Parent: builds the algebraically closed field of algebraic numbers algebraicNumbersField = algebraicClosure ℚ ℂ. This entry answers its first open question by adding the perfect-field / separability structure."
+      },
+      {
+        "id": "algebraic-numbers-countable-oq-01",
+        "relationship": "Grandparent: assembles the algebraic elements into a subfield. This entry adds separability of that field over ℚ."
+      }
+    ],
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "A field is *perfect* if every algebraic extension of it is separable — equivalently (Steinitz, 1910) if it has characteristic zero or, in characteristic $p$, the Frobenius is surjective. Characteristic-zero fields are automatically perfect, so $\\mathbb{Q}$ and every number field are perfect, and their algebraic extensions are separable: irreducible polynomials over $\\mathbb{Q}$ have distinct roots. The parent entry realized the algebraic numbers $\\overline{\\mathbb{Q}}$ as an algebraically closed field inside $\\mathbb{C}$; the natural companion fact is that $\\overline{\\mathbb{Q}}$ is *perfect*, so it has no inseparable algebraic extensions. Separability is exactly the property that makes the Galois theory of number fields work — it is why a degree-$n$ number field has exactly $n$ embeddings into $\\mathbb{C}$, the starting point of the theory of the discriminant, the different, and complex/real embeddings.",
+    "problemStatement": "Answer the parent's first open question. Formalize that the algebraic numbers $\\overline{\\mathbb{Q}}$ form a *perfect* field, so every algebraic extension of $\\mathbb{Q}$ is separable, and conclude that $\\mathrm{algebraicClosure}\\,\\mathbb{Q}\\,\\mathbb{C}$ has no inseparable extensions. As an arithmetic payoff, deduce that a finite extension $E/\\mathbb{Q}$ has separable degree equal to its degree — a number field of degree $n$ has exactly $n$ embeddings into its algebraic closure.",
+    "proofStrategy": "**$\\mathbb{Q}$ is perfect.** `PerfectField.ofCharZero` makes `PerfectField ℚ` an instance, so `Algebra.IsAlgebraic.isSeparable_of_perfectField` gives `Algebra.IsSeparable ℚ E` for any algebraic `E/ℚ`, and `PerfectField.separable_of_irreducible (minpoly.irreducible hx)` shows the minimal polynomial of any algebraic number is separable, hence squarefree (`Separable.squarefree`).\n\n**$\\overline{\\mathbb{Q}}$ is perfect, two ways.** Route A: the parent gives `IsAlgClosed algebraicNumbersField`, and every algebraically closed field is perfect (`IsAlgClosed.perfectField`). Route B: `algebraicNumbersField / ℚ` is algebraic (parent instance) and $\\mathbb{Q}$ is perfect, so `Algebra.IsAlgebraic.perfectField` applies. Both are recorded to expose the two independent mechanisms. Perfectness plus algebraicity gives `Algebra.IsSeparable ℚ algebraicNumbersField`.\n\n**No inseparable extensions.** For any algebraic `L / ℚ̄`, perfectness of `ℚ̄` yields `Algebra.IsSeparable algebraicNumbersField L` by `isSeparable_of_perfectField` — every algebraic extension of the algebraic numbers is separable. The statement is echoed for Mathlib's `algebraicClosure ℚ ℂ`.\n\n**Embedding count.** For finite `E/ℚ`, `FiniteDimensional ⇒ Algebra.IsAlgebraic` (`Algebra.IsAlgebraic.of_finite`) ⇒ separable, so `Field.finSepDegree_eq_finrank_of_isSeparable` gives `finSepDegree ℚ E = finrank ℚ E`. Since `finSepDegree = Nat.card (Field.Emb ℚ E)` by definition, `card_emb_eq_finrank_rat` reads off that $E$ has exactly $[E:\\mathbb{Q}]$ embeddings.",
+    "keyInsights": [
+      "**Perfectness of $\\mathbb{Q}$ is a one-instance fact, but its payoff is separability of *all* number fields.** From `PerfectField.ofCharZero` alone, every algebraic extension of $\\mathbb{Q}$ is separable and every algebraic number has a distinct-root minimal polynomial — no case analysis, no characteristic-$p$ Frobenius argument needed.",
+      "**$\\overline{\\mathbb{Q}}$ is perfect for two genuinely different reasons.** Algebraic closedness (any polynomial already splits, so there is nothing inseparable to build) and being algebraic over the perfect $\\mathbb{Q}$ (perfectness transfers up algebraic extensions). The entry records both; neither subsumes the other conceptually.",
+      "**'No inseparable extensions' is a perfectness statement, not an algebraic-closedness one.** The separability of every algebraic $L/\\overline{\\mathbb{Q}}$ follows from $\\overline{\\mathbb{Q}}$ being perfect; algebraic closedness would additionally make such $L$ trivial, but the separability half needs only perfectness — which is why it holds already at the level of $\\mathbb{Q}$.",
+      "**Separable degree $=$ degree is the arithmetic cash value.** For a number field $E$, `finSepDegree ℚ E = [E : ℚ]`, and unfolding `finSepDegree = Nat.card (Field.Emb ℚ E)` turns this into the classical count: a degree-$n$ number field has exactly $n$ embeddings into its algebraic closure — the fact underlying signatures $(r_1, r_2)$ and the Minkowski embedding."
+    ]
+  },
+  "sections": [
+    {
+      "id": "rat-perfect",
+      "title": "§1: ℚ is perfect; its algebraic extensions are separable",
+      "startLine": 50,
+      "endLine": 73,
+      "summary": "perfectField_rat: ℚ is perfect (PerfectField.ofCharZero, characteristic zero). isSeparable_of_isAlgebraic_rat: every algebraic extension E/ℚ is separable. minpoly_separable_rat / minpoly_squarefree_rat: the minimal polynomial over ℚ of any algebraic number is separable, hence squarefree.",
+      "mathContext": "A field is perfect iff every algebraic extension is separable; characteristic-zero fields are perfect. So ℚ is perfect and its algebraic extensions are separable, with irreducible (in particular minimal) polynomials having distinct roots."
+    },
+    {
+      "id": "qbar-perfect",
+      "title": "§2: The algebraic numbers ℚ̄ ⊆ ℂ form a perfect field",
+      "startLine": 74,
+      "endLine": 95,
+      "summary": "perfectField_algebraicNumbers: ℚ̄ is perfect because it is algebraically closed (IsAlgClosed → PerfectField). perfectField_algebraicNumbers_of_algebraic: a second, independent proof — ℚ̄/ℚ is algebraic over the perfect ℚ, so ℚ̄ is perfect (Algebra.IsAlgebraic.perfectField). isSeparable_rat_algebraicNumbers: the algebraic numbers are a separable extension of ℚ.",
+      "mathContext": "Perfectness is inherited both from algebraic closedness and from being an algebraic extension of a perfect field. The algebraic numbers satisfy both, and are in particular separable over ℚ."
+    },
+    {
+      "id": "no-inseparable",
+      "title": "§3: No inseparable extensions of ℚ̄",
+      "startLine": 96,
+      "endLine": 113,
+      "summary": "isSeparable_of_isAlgebraic_algebraicNumbers: every algebraic extension L/ℚ̄ is separable — the algebraic closure of ℚ has no inseparable algebraic extension (a consequence of perfectness, not of algebraic closedness). perfectField_algebraicClosure_rat_complex restates perfectness for Mathlib's algebraicClosure ℚ ℂ.",
+      "mathContext": "Because ℚ̄ is perfect, separability of L/ℚ̄ holds for any algebraic L. Algebraic closedness would further force L trivial, but the no-inseparable-extensions statement needs only perfectness."
+    },
+    {
+      "id": "embeddings",
+      "title": "§4: Counting embeddings of a number field",
+      "startLine": 114,
+      "endLine": 133,
+      "summary": "finSepDegree_eq_finrank_rat: for finite E/ℚ, separability (automatic, ℚ perfect) forces finSepDegree ℚ E = [E : ℚ]. card_emb_eq_finrank_rat: unfolding finSepDegree = Nat.card (Field.Emb ℚ E), a number field of degree n has exactly n embeddings into its algebraic closure.",
+      "mathContext": "The separable degree counts embeddings into an algebraic closure. Over a perfect base it equals the full degree, giving the classical count of n embeddings for a degree-n number field."
+    }
+  ],
+  "conclusion": {
+    "summary": "The field of algebraic numbers ℚ̄ = algebraicClosure ℚ ℂ is perfect: ℚ is perfect because it has characteristic zero, so every algebraic extension of ℚ (including ℚ̄ itself) is separable, and the minimal polynomial of any algebraic number is separable and squarefree. ℚ̄ is shown perfect two independent ways — as an algebraically closed field and as an algebraic extension of the perfect ℚ — and consequently has no inseparable algebraic extension: every algebraic L/ℚ̄ is separable. The arithmetic payoff is that a finite extension E/ℚ has separable degree equal to its degree, i.e. a number field of degree n has exactly n embeddings into its algebraic closure.",
+    "implications": [
+      "Completes the perfect-field / separability half of the algebraic-numbers picture begun by the parent (algebraic closedness), directly answering its first open question.",
+      "Separates the two mechanisms that make ℚ̄ perfect — algebraic closedness and algebraicity over a perfect base — and shows that 'no inseparable extensions' is a perfectness phenomenon already present at ℚ.",
+      "Delivers the concrete number-theoretic consequence that a degree-n number field has exactly n embeddings into its algebraic closure (finSepDegree = degree), the foundation of embedding signatures and the Minkowski embedding."
+    ],
+    "openQuestions": [
+      "Refine the embedding count for E ⊆ ℝ vs E ⊆ ℂ: split the n embeddings of a number field into r₁ real and r₂ conjugate-pairs of complex embeddings, formalizing the signature (r₁, r₂) with r₁ + 2r₂ = n.",
+      "Package the perfectness as a Galois statement: since ℚ̄/ℚ is separable and normal, it is Galois — formalize Gal(ℚ̄/ℚ) as the absolute Galois group of ℚ and its fixed field being ℚ."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "algebraic-numbers-countable-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Parent: builds the algebraically closed field of algebraic numbers algebraicNumbersField = algebraicClosure ℚ ℂ. This entry answers its first open question by adding perfectness and separability."
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent: assembles the algebraic elements into a subfield. This entry proves that field is a separable (indeed perfect) extension of ℚ."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "isSeparable_of_isAlgebraic_algebraicNumbers",
+      "type": "core",
+      "description": "No inseparable extensions: every algebraic extension L of the field of algebraic numbers is separable, because ℚ̄ is perfect.",
+      "leanType": "[Algebra algebraicNumbersField L] → [Algebra.IsAlgebraic algebraicNumbersField L] → Algebra.IsSeparable algebraicNumbersField L"
+    },
+    {
+      "name": "perfectField_algebraicNumbers_of_algebraic",
+      "type": "core",
+      "description": "The algebraic numbers form a perfect field, proved via ℚ̄/ℚ being an algebraic extension of the perfect field ℚ (a route independent of algebraic closedness).",
+      "leanType": "PerfectField algebraicNumbersField"
+    },
+    {
+      "name": "perfectField_algebraicNumbers",
+      "type": "core",
+      "description": "The algebraic numbers form a perfect field, proved via algebraic closedness (IsAlgClosed → PerfectField).",
+      "leanType": "PerfectField algebraicNumbersField"
+    },
+    {
+      "name": "finSepDegree_eq_finrank_rat",
+      "type": "core",
+      "description": "For a finite extension E/ℚ, separability forces the separable degree to equal the degree: finSepDegree ℚ E = [E : ℚ].",
+      "leanType": "[FiniteDimensional ℚ E] → Field.finSepDegree ℚ E = Module.finrank ℚ E"
+    },
+    {
+      "name": "card_emb_eq_finrank_rat",
+      "type": "core",
+      "description": "A number field of degree n has exactly n embeddings into its algebraic closure: Nat.card (Field.Emb ℚ E) = [E : ℚ].",
+      "leanType": "[FiniteDimensional ℚ E] → Nat.card (Field.Emb ℚ E) = Module.finrank ℚ E"
+    },
+    {
+      "name": "minpoly_separable_rat",
+      "type": "supporting",
+      "description": "The minimal polynomial over ℚ of any algebraic number is separable — it has no repeated roots.",
+      "leanType": "IsIntegral ℚ x → (minpoly ℚ x).Separable"
+    },
+    {
+      "name": "perfectField_rat",
+      "type": "supporting",
+      "description": "ℚ is a perfect field (characteristic zero).",
+      "leanType": "PerfectField ℚ"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Ernst Steinitz"
+      ],
+      "title": "Algebraische Theorie der Körper",
+      "year": "1910",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 137, pp. 167–309",
+      "note": "Introduces perfect fields and separability; establishes that characteristic-zero fields are perfect, the engine of this entry."
+    },
+    {
+      "authors": [
+        "Jürgen Neukirch"
+      ],
+      "title": "Algebraic Number Theory",
+      "year": "1999",
+      "venue": "Grundlehren der mathematischen Wissenschaften 322, Springer",
+      "note": "Standard reference for number fields: a degree-n number field has exactly n embeddings into ℂ (separable degree = degree), split into real and complex embeddings."
+    }
+  ],
+  "sorries": [],
+  "leanFile": {
+    "imports": [
+      "Proofs.AlgebraicNumbersCountableOQ01OQ01",
+      "Mathlib.FieldTheory.Perfect",
+      "Mathlib.FieldTheory.SeparableDegree",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "AlgebraicNumbersCountableOQ01OQ01"
+    ],
+    "namespace": "AlgebraicNumbersCountableOQ01OQ01OQ01",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/AlgebraicNumbersCountableOQ01OQ01OQ01.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's (`algebraic-numbers-countable-oq-01-oq-01`) **first open question**: formalize that the algebraic numbers $\overline{\mathbb{Q}}$ form a **perfect field**, so every algebraic extension of $\mathbb{Q}$ is separable and `algebraicClosure ℚ ℂ` has **no inseparable extensions**.

New gallery entry: **The Algebraic Numbers Form a Perfect Field — No Inseparable Extensions**. New Lean file `Proofs/AlgebraicNumbersCountableOQ01OQ01OQ01.lean` (11 theorems, 146 lines), plus `meta.json` + `annotations.json`.

## What is proved

1. **$\mathbb{Q}$ is perfect** (characteristic zero, `PerfectField.ofCharZero`) ⇒ every algebraic extension $E/\mathbb{Q}$ is separable, and the minimal polynomial of any algebraic number is separable, hence squarefree.
2. **$\overline{\mathbb{Q}}$ is perfect, two independent ways** — as an algebraically closed field (`IsAlgClosed → PerfectField`) and as an algebraic extension of the perfect $\mathbb{Q}$ (`Algebra.IsAlgebraic.perfectField`). The algebraic numbers are a separable extension of $\mathbb{Q}$.
3. **No inseparable extensions**: every algebraic $L/\overline{\mathbb{Q}}$ is separable — a consequence of perfectness, not of algebraic closedness. Restated for Mathlib's `algebraicClosure ℚ ℂ`.
4. **Arithmetic payoff**: for finite $E/\mathbb{Q}$, `finSepDegree ℚ E = [E : ℚ]`; unfolding `finSepDegree = Nat.card (Field.Emb ℚ E)`, a number field of degree $n$ has exactly $n$ embeddings into its algebraic closure.

## Verification

- Compiles clean via `lake env lean` against the pinned Mathlib (4.26.0).
- `#print axioms` on all main theorems: depends only on `propext`, `Classical.choice`, `Quot.sound` — **0-axiom, VERIFIED**. No `sorryAx`, no `Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)