### PR TITLE
research(fibonacci-identities-oq-02-oq-01-oq-01-oq-01): exact gcd(Fₙ,Lₙ)=2⟺3∣n via Fibonacci parity 3-periodicity [VERIFIED, 0-axiom, 11thm/134L]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ01.lean
@@ -1,0 +1,134 @@
+import Proofs.FibonacciIdentitiesOQ02OQ01OQ01
+import Mathlib.Tactic
+
+/-
+# The Exact `gcd(Fₙ, Lₙ)`: `2 ⟺ 3 ∣ n`, and `1` otherwise
+
+## Open Question OQ-02-OQ-01-OQ-01-OQ-01
+
+The parent entry (`fibonacci-identities-oq-02-oq-01-oq-01`) proved the
+Fibonacci–Lucas quadratic identity `Lₙ² − 5·Fₙ² = 4·(−1)ⁿ` and used it to pin
+the same-index interaction down to a *factor of two*:
+
+    gcd(Fₙ, Lₙ) ∣ 2        so   gcd(Fₙ, Lₙ) ∈ {1, 2}.
+
+The parent left **which** of the two values occurs as an open question. This
+entry settles it as a universally quantified biconditional:
+
+    gcd(Fₙ, Lₙ) = 2   ⟺   3 ∣ n                    (`gcd_fib_lucas_eq_two_iff`)
+    gcd(Fₙ, Lₙ) = 1   ⟺   ¬ 3 ∣ n                  (`gcd_fib_lucas_eq_one_iff`)
+    gcd(Fₙ, Lₙ) = if 3 ∣ n then 2 else 1           (`gcd_fib_lucas`)
+
+## How It's Proved
+
+Since `gcd(Fₙ, Lₙ) ∈ {1, 2}`, the value is `2` **exactly when the gcd is even**,
+i.e. exactly when *both* `Fₙ` and `Lₙ` are even. So the whole question collapses
+to a **parity** computation, and the two sequences share the *same* parity:
+
+* **`2 ∣ Fₙ ⟺ 3 ∣ n`** (`fib_even_iff`). The parity of the Fibonacci sequence
+  is `3`-periodic — `0,1,1,0,1,1,…` — because
+  `Fₙ₊₃ = Fₙ + 2·Fₙ₊₁ ≡ Fₙ (mod 2)` (`fib_add_three`). A three-residue
+  induction closes the biconditional.
+
+* **`2 ∣ Lₙ ⟺ 2 ∣ Fₙ`** (`lucas_even_iff_fib_even`). Immediate from the
+  parent's subtraction-free bridge `2·Fₙ₊₁ = Lₙ + Fₙ`: modulo `2` this says
+  `Lₙ ≡ −Fₙ ≡ Fₙ`, so the companion sequences have identical parity.
+
+Combining, `Lₙ` is even `⟺ 3 ∣ n` as well, so both are even together precisely
+on the multiples of `3`, which is exactly where the gcd hits `2`.
+-/
+
+namespace FibonacciIdentitiesOQ02OQ01OQ01OQ01
+
+open Nat FibonacciIdentitiesOQ02OQ01OQ01
+
+/-! ## Fibonacci parity is `3`-periodic -/
+
+/-- The parity-carrying step `Fₙ₊₃ = Fₙ + 2·Fₙ₊₁`. Modulo `2` this is
+`Fₙ₊₃ ≡ Fₙ`, the engine of the `3`-periodicity of Fibonacci parity. -/
+theorem fib_add_three (n : ℕ) : fib (n + 3) = fib n + 2 * fib (n + 1) := by
+  have h1 : fib (n + 3) = fib (n + 1) + fib (n + 2) := fib_add_two
+  have h2 : fib (n + 2) = fib n + fib (n + 1) := fib_add_two
+  omega
+
+/-- **Fibonacci parity criterion:** `Fₙ` is even iff `3 ∣ n`. The parity
+sequence `0,1,1,0,1,1,…` has period `3`; proved by induction over the three
+residues using `Fₙ₊₃ ≡ Fₙ (mod 2)`. -/
+theorem fib_even_iff : ∀ n, (2 ∣ fib n ↔ 3 ∣ n)
+  | 0 => by decide
+  | 1 => by decide
+  | 2 => by decide
+  | (n + 3) => by
+      have hper : fib (n + 3) = fib n + 2 * fib (n + 1) := fib_add_three n
+      have ih := fib_even_iff n
+      have h3 : (3 ∣ n + 3) ↔ 3 ∣ n := by omega
+      rw [hper, h3, ← ih]
+      constructor <;> intro h <;> omega
+
+/-! ## Lucas and Fibonacci share their parity -/
+
+/-- **`2 ∣ Lₙ ⟺ 2 ∣ Fₙ`.** The companion sequences have identical parity,
+directly from the parent's bridge `2·Fₙ₊₁ = Lₙ + Fₙ`. -/
+theorem lucas_even_iff_fib_even (n : ℕ) : 2 ∣ lucas n ↔ 2 ∣ fib n := by
+  have h := two_mul_fib_succ n
+  omega
+
+/-- **Lucas parity criterion:** `Lₙ` is even iff `3 ∣ n`. -/
+theorem lucas_even_iff (n : ℕ) : 2 ∣ lucas n ↔ 3 ∣ n := by
+  rw [lucas_even_iff_fib_even]; exact fib_even_iff n
+
+/-! ## The exact gcd value -/
+
+/-- **`gcd(Fₙ, Lₙ) = 2 ⟺ 3 ∣ n`.** The factor `2` in the parent's bound
+`gcd(Fₙ, Lₙ) ∣ 2` is attained *exactly* on the multiples of `3`. -/
+theorem gcd_fib_lucas_eq_two_iff (n : ℕ) :
+    Nat.gcd (fib n) (lucas n) = 2 ↔ 3 ∣ n := by
+  constructor
+  · intro h
+    have hdf : (2 : ℕ) ∣ fib n := by
+      rw [← h]; exact Nat.gcd_dvd_left (fib n) (lucas n)
+    exact (fib_even_iff n).mp hdf
+  · intro h
+    have hf : 2 ∣ fib n := (fib_even_iff n).mpr h
+    have hl : 2 ∣ lucas n := (lucas_even_iff n).mpr h
+    have hg2 : 2 ∣ Nat.gcd (fib n) (lucas n) := Nat.dvd_gcd hf hl
+    rcases gcd_fib_lucas_eq_one_or_two n with h1 | h2
+    · rw [h1] at hg2; exact absurd hg2 (by decide)
+    · exact h2
+
+/-- **`gcd(Fₙ, Lₙ) = 1 ⟺ ¬ 3 ∣ n`.** The coprime case is exactly the
+non-multiples of `3`. -/
+theorem gcd_fib_lucas_eq_one_iff (n : ℕ) :
+    Nat.gcd (fib n) (lucas n) = 1 ↔ ¬ 3 ∣ n := by
+  constructor
+  · intro h1 hdvd
+    have h2 : Nat.gcd (fib n) (lucas n) = 2 := (gcd_fib_lucas_eq_two_iff n).mpr hdvd
+    omega
+  · intro h
+    rcases gcd_fib_lucas_eq_one_or_two n with h1 | h2
+    · exact h1
+    · exact absurd ((gcd_fib_lucas_eq_two_iff n).mp h2) h
+
+/-- **The exact gcd, in closed form:** `gcd(Fₙ, Lₙ) = if 3 ∣ n then 2 else 1`.
+This is the full answer to the parent's open question. -/
+theorem gcd_fib_lucas (n : ℕ) :
+    Nat.gcd (fib n) (lucas n) = if 3 ∣ n then 2 else 1 := by
+  by_cases h : 3 ∣ n
+  · rw [if_pos h]; exact (gcd_fib_lucas_eq_two_iff n).mpr h
+  · rw [if_neg h]; exact (gcd_fib_lucas_eq_one_iff n).mpr h
+
+/-! ## Concrete sanity checks -/
+
+/-- `gcd(F₆, L₆) = gcd(8, 18) = 2`, and `3 ∣ 6`. -/
+theorem check_six : Nat.gcd (fib 6) (lucas 6) = 2 := by decide
+
+/-- `gcd(F₉, L₉) = gcd(34, 76) = 2`, and `3 ∣ 9`. -/
+theorem check_nine : Nat.gcd (fib 9) (lucas 9) = 2 := by decide
+
+/-- `gcd(F₅, L₅) = gcd(5, 11) = 1`, and `¬ 3 ∣ 5`. -/
+theorem check_five : Nat.gcd (fib 5) (lucas 5) = 1 := by decide
+
+/-- `gcd(F₇, L₇) = gcd(13, 29) = 1`, and `¬ 3 ∣ 7`. -/
+theorem check_seven : Nat.gcd (fib 7) (lucas 7) = 1 := by decide
+
+end FibonacciIdentitiesOQ02OQ01OQ01OQ01

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "fib-lucas-gcd-parity-reduction",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 39 },
+    "type": "concept",
+    "title": "Reducing the Exact gcd to a Parity Question",
+    "content": "The parent bounded gcd(Fₙ, Lₙ) ∣ 2, so the same-index gcd is always 1 or 2. Because the value is one of just two numbers, 'gcd = 2' is exactly 'the gcd is even', i.e. 'both Fₙ and Lₙ are even'. The entire value question therefore collapses to parity — no further gcd machinery is needed. The answer turns out to be perfectly periodic: gcd(Fₙ, Lₙ) = 2 exactly when 3 ∣ n, and = 1 otherwise.",
+    "mathContext": "$\\gcd(F_n, L_n) \\in \\{1,2\\}$, so $\\gcd = 2 \\iff 2 \\mid \\gcd \\iff (2 \\mid F_n \\wedge 2 \\mid L_n)$; the value is decided entirely by parity.",
+    "significance": "key",
+    "relatedConcepts": ["greatest common divisor", "Fibonacci numbers", "Lucas numbers", "parity", "periodicity"],
+    "prerequisites": ["elementary number theory", "gcd basics"]
+  },
+  {
+    "id": "fib-lucas-gcd-fib-periodicity",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 66 },
+    "type": "insight",
+    "title": "Fibonacci Parity Has Period 3",
+    "content": "Applying Fₙ₊₂ = Fₙ + Fₙ₊₁ twice gives Fₙ₊₃ = Fₙ + 2·Fₙ₊₁ (fib_add_three), so Fₙ₊₃ ≡ Fₙ (mod 2): the parity sequence is 0,1,1,0,1,1,… with period 3. A three-residue induction — base cases n = 0,1,2 discharged by `decide`, inductive step folding n+3 back to n — yields the criterion 2 ∣ Fₙ ⟺ 3 ∣ n. Mathlib has no such Fibonacci-parity lemma, so it is proved here from scratch.",
+    "mathContext": "$F_{n+3} = F_n + 2F_{n+1} \\equiv F_n \\pmod 2$, so the even Fibonacci numbers are exactly those with $3 \\mid n$: $2 \\mid F_n \\iff 3 \\mid n$.",
+    "significance": "key",
+    "relatedConcepts": ["Fibonacci recurrence", "parity periodicity", "Pisano period", "induction", "modular arithmetic"],
+    "prerequisites": ["Fibonacci recurrence", "induction over residues"]
+  },
+  {
+    "id": "fib-lucas-gcd-shared-parity",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 68, "endLine": 78 },
+    "type": "insight",
+    "title": "Lucas Inherits Fibonacci's Parity for Free",
+    "content": "No separate Lucas periodicity argument is needed. The parent's subtraction-free bridge 2·Fₙ₊₁ = Lₙ + Fₙ says Lₙ + Fₙ is even, hence Lₙ ≡ Fₙ (mod 2): the companion sequence has identical parity at every index. `omega` closes 2 ∣ Lₙ ⟺ 2 ∣ Fₙ directly from the bridge, and composing with the Fibonacci criterion gives 2 ∣ Lₙ ⟺ 3 ∣ n.",
+    "mathContext": "$2F_{n+1} = L_n + F_n \\Rightarrow L_n \\equiv -F_n \\equiv F_n \\pmod 2$, so $2 \\mid L_n \\iff 2 \\mid F_n \\iff 3 \\mid n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lucas numbers", "companion sequence", "Fibonacci–Lucas bridge", "parity", "omega tactic"],
+    "prerequisites": ["Lucas sequence definition", "linear arithmetic over ℕ"]
+  },
+  {
+    "id": "fib-lucas-gcd-exact-value",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 80, "endLine": 118 },
+    "type": "tactic",
+    "title": "From Parity to the Exact gcd via the {1,2} Bound",
+    "content": "The two directions use the parent's bound in complementary ways. If gcd = 2, then gcd_dvd_left gives 2 ∣ Fₙ, so 3 ∣ n by the Fibonacci criterion. Conversely if 3 ∣ n, then 2 ∣ Fₙ and 2 ∣ Lₙ, so Nat.dvd_gcd gives 2 ∣ gcd; since gcd ∈ {1,2} (parent) and 2 ∤ 1, the gcd must equal 2. The coprime case gcd = 1 ⟺ ¬ 3 ∣ n and the closed form gcd = if 3 ∣ n then 2 else 1 are immediate corollaries.",
+    "mathContext": "$3 \\mid n \\Rightarrow 2 \\mid F_n, 2 \\mid L_n \\Rightarrow 2 \\mid \\gcd$, and $\\gcd \\in \\{1,2\\}$ forces $\\gcd = 2$; the converse uses $\\gcd \\mid F_n$.",
+    "significance": "key",
+    "relatedConcepts": ["dvd_gcd", "gcd_dvd_left", "two-element bound", "biconditional proof", "closed form"],
+    "prerequisites": ["gcd divisibility lemmas", "case analysis"]
+  },
+  {
+    "id": "fib-lucas-gcd-checks",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 120, "endLine": 132 },
+    "type": "tactic",
+    "title": "Numeric Confirmation on Both Cases",
+    "content": "Kernel `decide` confirms the dichotomy on small indices: gcd(F₆,L₆) = gcd(8,18) = 2 and gcd(F₉,L₉) = gcd(34,76) = 2 at multiples of 3 (the factor 2 is attained), while gcd(F₅,L₅) = gcd(5,11) = 1 and gcd(F₇,L₇) = gcd(13,29) = 1 at non-multiples (coprime). These use kernel reduction only — no native_decide, so no Lean.ofReduceBool enters the axiom set.",
+    "mathContext": "$\\gcd(F_6,L_6)=\\gcd(8,18)=2$, $\\gcd(F_9,L_9)=\\gcd(34,76)=2$; $\\gcd(F_5,L_5)=\\gcd(5,11)=1$, $\\gcd(F_7,L_7)=\\gcd(13,29)=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide tactic", "kernel reduction", "worked examples", "sanity checks"],
+    "prerequisites": ["Fibonacci and Lucas values", "gcd computation"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "fibonacci-identities-oq-02-oq-01-oq-01-oq-01",
+  "title": "The Exact gcd(Fₙ, Lₙ): 2 ⟺ 3 ∣ n, and 1 Otherwise",
+  "slug": "fibonacci-identities-oq-02-oq-01-oq-01-oq-01",
+  "description": "Settles the parent (OQ-02-OQ-01-OQ-01)'s first open question with a universally quantified biconditional for the exact same-index gcd of the Fibonacci and Lucas sequences: gcd(Fₙ, Lₙ) = 2 exactly when 3 ∣ n, and = 1 otherwise. The parent bounded gcd(Fₙ, Lₙ) ∣ 2 (so the value lies in {1, 2}) but left which value occurs open. Since the gcd is 1 or 2, it equals 2 iff it is even iff both Fₙ and Lₙ are even, collapsing the whole question to parity. Fibonacci parity is 3-periodic — 0,1,1,0,1,1,… — because Fₙ₊₃ = Fₙ + 2·Fₙ₊₁ ≡ Fₙ (mod 2), giving 2 ∣ Fₙ ⟺ 3 ∣ n by a three-residue induction; and the parent's bridge 2·Fₙ₊₁ = Lₙ + Fₙ forces Lₙ ≡ Fₙ (mod 2), so Lₙ shares Fibonacci's parity and is even ⟺ 3 ∣ n too. Both are even together precisely on the multiples of 3, which is exactly where the gcd attains 2.",
+  "meta": {
+    "author": "Lean Genius researcher-13",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 134,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "assumptions": "None. The biconditional holds for every n : ℕ and is fully machine-checked over ℕ. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the numeric sanity checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "fibonacci",
+      "lucas-numbers",
+      "gcd",
+      "parity",
+      "periodicity",
+      "biconditional",
+      "number-theory"
+    ],
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "gcd_fib_lucas_eq_two_iff: the exact biconditional gcd(Fₙ, Lₙ) = 2 ⟺ 3 ∣ n, upgrading the parent's divisibility bound gcd ∣ 2 to a precise value criterion",
+      "gcd_fib_lucas_eq_one_iff: the coprime companion gcd(Fₙ, Lₙ) = 1 ⟺ ¬ 3 ∣ n",
+      "gcd_fib_lucas: the closed form gcd(Fₙ, Lₙ) = if 3 ∣ n then 2 else 1, the full answer to the parent's first open question",
+      "fib_even_iff: the Fibonacci parity criterion 2 ∣ Fₙ ⟺ 3 ∣ n, from the 3-periodicity of Fibonacci parity — absent from Mathlib",
+      "fib_add_three: the parity-step Fₙ₊₃ = Fₙ + 2·Fₙ₊₁ that drives the 3-periodicity (Fₙ₊₃ ≡ Fₙ mod 2)",
+      "lucas_even_iff_fib_even: Lₙ and Fₙ have identical parity (2 ∣ Lₙ ⟺ 2 ∣ Fₙ), immediate from the parent's bridge 2·Fₙ₊₁ = Lₙ + Fₙ; hence lucas_even_iff: 2 ∣ Lₙ ⟺ 3 ∣ n",
+      "Worked checks gcd(F₆,L₆)=gcd(8,18)=2, gcd(F₉,L₉)=gcd(34,76)=2 (multiples of 3), gcd(F₅,L₅)=gcd(5,11)=1, gcd(F₇,L₇)=gcd(13,29)=1 (non-multiples)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "FibonacciIdentitiesOQ02OQ01OQ01.two_mul_fib_succ",
+        "description": "The parent's subtraction-free bridge 2·Fₙ₊₁ = Lₙ + Fₙ. Modulo 2 it forces Lₙ ≡ Fₙ, giving lucas_even_iff_fib_even in one omega step and pinning the two sequences to the same parity.",
+        "module": "Proofs.FibonacciIdentitiesOQ02OQ01OQ01"
+      },
+      {
+        "theorem": "FibonacciIdentitiesOQ02OQ01OQ01.gcd_fib_lucas_eq_one_or_two",
+        "description": "The parent's bound gcd(Fₙ, Lₙ) ∈ {1, 2}. Reducing the value to a two-way choice is what turns 'which value?' into the parity question 'is the gcd even?'.",
+        "module": "Proofs.FibonacciIdentitiesOQ02OQ01OQ01"
+      },
+      {
+        "theorem": "FibonacciIdentitiesOQ02OQ01OQ01.lucas",
+        "description": "The parent's self-contained Lucas sequence L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁ (Mathlib has no Lucas numbers), the object whose parity this entry determines.",
+        "module": "Proofs.FibonacciIdentitiesOQ02OQ01OQ01"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "Fₙ₊₂ = Fₙ + Fₙ₊₁, applied twice to derive the parity-step Fₙ₊₃ = Fₙ + 2·Fₙ₊₁.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.gcd_dvd_left",
+        "description": "gcd(Fₙ, Lₙ) ∣ Fₙ, used so that gcd = 2 forces 2 ∣ Fₙ and hence 3 ∣ n via the Fibonacci parity criterion.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_gcd",
+        "description": "From 2 ∣ Fₙ and 2 ∣ Lₙ (both holding when 3 ∣ n) conclude 2 ∣ gcd(Fₙ, Lₙ), which with the {1,2} bound forces gcd = 2.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ01.lean",
+    "namespace": "FibonacciIdentitiesOQ02OQ01OQ01OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 134,
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Fibonacci and Lucas numbers of the same index are almost coprime: gcd(Fₙ, Lₙ) is always 1 or 2, never larger. The parent entry proved the bound gcd(Fₙ, Lₙ) ∣ 2 from the quadratic identity Lₙ² − 5Fₙ² = 4(−1)ⁿ, but the classical fact is sharper — the gcd is 2 exactly on the multiples of 3 and 1 everywhere else. This periodic dichotomy is a shadow of the parity structure of the two sequences: both Fₙ and Lₙ reduce mod 2 to the period-3 pattern that is even precisely at indices divisible by 3 (Fₙ: 0,1,1,0,…; Lₙ: 2,1,3,4,… i.e. 0,1,1,0,… mod 2). Mathlib formalizes Fibonacci (Nat.fib) but has no Lucas sequence and no Fibonacci-parity lemma, so both the parity criterion and the Lucas half are supplied here.",
+    "problemStatement": "Open Question OQ-02-OQ-01-OQ-01 (first open question of the parent): prove as a universally quantified biconditional that gcd(Fₙ, Lₙ) = 2 when 3 ∣ n and = 1 otherwise, using the 3-periodicity of parity in the Lucas sequence (L_{3k} even) together with the bound gcd(Fₙ, Lₙ) ∈ {1, 2}.",
+    "proofStrategy": "Reduce the value question to parity. Because the parent gives gcd(Fₙ, Lₙ) ∈ {1, 2}, the gcd equals 2 iff it is even iff both Fₙ and Lₙ are even. First, Fibonacci parity is 3-periodic: applying Nat.fib_add_two twice gives Fₙ₊₃ = Fₙ + 2·Fₙ₊₁ (fib_add_three), so Fₙ₊₃ ≡ Fₙ (mod 2); a three-residue induction (base cases n = 0,1,2 by decide) yields fib_even_iff: 2 ∣ Fₙ ⟺ 3 ∣ n. Second, the parent's bridge 2·Fₙ₊₁ = Lₙ + Fₙ makes Lₙ + Fₙ even, so Lₙ ≡ Fₙ (mod 2) and omega gives lucas_even_iff_fib_even: 2 ∣ Lₙ ⟺ 2 ∣ Fₙ, hence lucas_even_iff: 2 ∣ Lₙ ⟺ 3 ∣ n. For the main biconditional: if gcd = 2 then 2 ∣ Fₙ (gcd_dvd_left) so 3 ∣ n; conversely if 3 ∣ n then 2 ∣ Fₙ and 2 ∣ Lₙ, so 2 ∣ gcd (dvd_gcd), and with the {1,2} bound the gcd must be 2. The coprime case and the if-then-else closed form follow immediately.",
+    "keyInsights": [
+      "The value of gcd(Fₙ, Lₙ) is decided entirely by parity: since the gcd is 1 or 2 (parent bound), 'gcd = 2' is literally the statement 'the gcd is even', i.e. 'both Fₙ and Lₙ are even'. No further gcd theory is needed — the arithmetic of the greatest common divisor collapses to a mod-2 count.",
+      "Fibonacci parity has period 3 because Fₙ₊₃ = Fₙ + 2·Fₙ₊₁, so the even indices are exactly the multiples of 3. This single recurrence step, iterated by a three-residue induction, is the whole content of 2 ∣ Fₙ ⟺ 3 ∣ n.",
+      "Lucas parity needs no separate periodicity argument: the parent's subtraction-free bridge 2·Fₙ₊₁ = Lₙ + Fₙ says Lₙ + Fₙ is even, so Lₙ and Fₙ have identical parity. The companion sequence inherits Fibonacci's even/odd pattern for free.",
+      "The factor 2 in the parent's bound gcd ∣ 2 is attained on a set of density 1/3 (the multiples of 3) and missed on the remaining 2/3 — a clean periodic answer, not a sporadic one.",
+      "The argument is purely elementary (parity + a two-element bound), avoiding the quadratic identity entirely for the value question; the identity's role was only to produce the {1,2} bound the parent already established."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the Parity Reduction",
+      "startLine": 4,
+      "endLine": 39,
+      "summary": "Header stating OQ-02-OQ-01-OQ-01-OQ-01: the exact gcd(Fₙ, Lₙ) = 2 ⟺ 3 ∣ n and = 1 otherwise, and how the {1,2} bound reduces the value question to the shared parity of Fₙ and Lₙ."
+    },
+    {
+      "id": "fib-parity",
+      "title": "Fibonacci Parity is 3-Periodic",
+      "startLine": 45,
+      "endLine": 66,
+      "summary": "fib_add_three: Fₙ₊₃ = Fₙ + 2·Fₙ₊₁ from two applications of Nat.fib_add_two, giving Fₙ₊₃ ≡ Fₙ (mod 2); fib_even_iff: 2 ∣ Fₙ ⟺ 3 ∣ n by three-residue induction (base cases n = 0,1,2 by decide)."
+    },
+    {
+      "id": "lucas-parity",
+      "title": "Lucas and Fibonacci Share Their Parity",
+      "startLine": 68,
+      "endLine": 78,
+      "summary": "lucas_even_iff_fib_even: 2 ∣ Lₙ ⟺ 2 ∣ Fₙ, immediate from the parent's bridge 2·Fₙ₊₁ = Lₙ + Fₙ (omega); lucas_even_iff: 2 ∣ Lₙ ⟺ 3 ∣ n, combining with the Fibonacci criterion."
+    },
+    {
+      "id": "exact-gcd",
+      "title": "The Exact gcd Value",
+      "startLine": 80,
+      "endLine": 118,
+      "summary": "gcd_fib_lucas_eq_two_iff: gcd = 2 ⟺ 3 ∣ n (gcd_dvd_left forces 2 ∣ Fₙ one way; dvd_gcd plus the {1,2} bound forces gcd = 2 the other); gcd_fib_lucas_eq_one_iff: gcd = 1 ⟺ ¬ 3 ∣ n; gcd_fib_lucas: the closed form gcd = if 3 ∣ n then 2 else 1."
+    },
+    {
+      "id": "checks",
+      "title": "Concrete Sanity Checks",
+      "startLine": 120,
+      "endLine": 132,
+      "summary": "Numeric checks: gcd(F₆,L₆)=2 and gcd(F₉,L₉)=2 (multiples of 3, factor 2 attained); gcd(F₅,L₅)=1 and gcd(F₇,L₇)=1 (non-multiples, coprime)."
+    }
+  ],
+  "conclusion": {
+    "summary": "11 theorems, 0 sorries, 0 axioms. The exact value gcd(Fₙ, Lₙ) = if 3 ∣ n then 2 else 1 answers the parent's first open question as a universally quantified biconditional. The proof reduces the value question to parity: since gcd(Fₙ, Lₙ) ∈ {1, 2} (parent bound), the gcd is 2 iff both Fₙ and Lₙ are even; Fibonacci parity is 3-periodic (Fₙ₊₃ ≡ Fₙ mod 2, so 2 ∣ Fₙ ⟺ 3 ∣ n), and the parent's bridge 2·Fₙ₊₁ = Lₙ + Fₙ forces Lₙ to share Fibonacci's parity — so both are even exactly on the multiples of 3.",
+    "implications": "Upgrades the parent's divisibility bound gcd ∣ 2 to a sharp, fully periodic value criterion, completing the same-index gcd story for the Fibonacci–Lucas pair. The technique — reduce a bounded gcd to a parity/periodicity computation, and transport parity across companion sequences through a subtraction-free bridge — applies to any Lucas sequence pair (Uₙ, Vₙ) and to residue questions modulo other small primes. It also supplies the Fibonacci parity criterion 2 ∣ Fₙ ⟺ 3 ∣ n that Mathlib lacks, reusable wherever Fibonacci divisibility by 2 arises.",
+    "openQuestions": [
+      "Determine gcd(Fₙ, Lₘ) for independent indices m, n (the cross-index gcd), or the exact gcd(Lₙ, Lₘ) of two Lucas numbers, generalizing the same-index result proved here.",
+      "Give the analogous exact gcd(Uₙ, Vₙ) for a general Lucas sequence (P, Q): identify, in terms of P and Q, the periodic set of indices on which the companion gcd exceeds 1, recovering the 3 ∣ n criterion at P = 1, Q = −1."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-02-oq-01-oq-01",
+      "relationship": "parent — proved gcd(Fₙ, Lₙ) ∣ 2 (so the value is in {1,2}) and posed the exact value gcd = 2 ⟺ 3 ∣ n as its first open question; supplies two_mul_fib_succ, gcd_fib_lucas_eq_one_or_two, and the Lucas sequence this entry reuses"
+    },
+    {
+      "targetId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02",
+      "relationship": "sibling — completes the degree-2 Fibonacci–Lucas relations (sum-of-squares and cross identity); its second open question explicitly asks for the exact gcd value proved here"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent `fibonacci-identities-oq-02-oq-01-oq-01` (which proved only the bound `gcd(Fₙ,Lₙ) ∣ 2`, leaving the exact value open) as a universally quantified biconditional:

```
gcd(Fₙ, Lₙ) = 2  ⟺  3 ∣ n        (gcd_fib_lucas_eq_two_iff)
gcd(Fₙ, Lₙ) = 1  ⟺  ¬ 3 ∣ n      (gcd_fib_lucas_eq_one_iff)
gcd(Fₙ, Lₙ) = if 3 ∣ n then 2 else 1   (gcd_fib_lucas)
```

## Mathematical content

Since the parent gives `gcd ∈ {1,2}`, the value equals 2 **iff the gcd is even iff both Fₙ and Lₙ are even** — the whole question collapses to parity.

- **Fibonacci parity is 3-periodic** (`fib_even_iff`): `Fₙ₊₃ = Fₙ + 2·Fₙ₊₁` (from `Nat.fib_add_two` twice) gives `Fₙ₊₃ ≡ Fₙ (mod 2)`, so `2 ∣ Fₙ ⟺ 3 ∣ n` by a three-residue induction. Mathlib has no such lemma.
- **Lucas shares Fibonacci's parity** (`lucas_even_iff_fib_even`): the parent's subtraction-free bridge `2·Fₙ₊₁ = Lₙ + Fₙ` forces `Lₙ ≡ Fₙ (mod 2)` — one `omega` step, no separate periodicity argument.
- Both even together exactly on multiples of 3, which is where the gcd hits 2.

## Verification

- Build: `✔ Built Proofs.FibonacciIdentitiesOQ02OQ01OQ01OQ01` (3059 jobs, exit 0) via docker wrapper.
- **0 axioms** (kernel `decide` only — no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`); 0 sorries; 11 theorems, 0 definitions, 134 lines.
- Reuses parent's `lucas`, `two_mul_fib_succ`, `gcd_fib_lucas_eq_one_or_two` via `import Proofs.FibonacciIdentitiesOQ02OQ01OQ01`.

## Files
- `proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ01.lean` (new)
- `src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-01/{meta,annotations}.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)