### PR TITLE
research(automorphic-number-oq-01-oq-01-oq-01): automorphic residues count squarefree divisors [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/AutomorphicNumberOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AutomorphicNumberOQ01OQ01OQ01.lean
@@ -1,0 +1,149 @@
+import Mathlib
+import Proofs.AutomorphicNumberOQ01OQ01
+
+/-!
+# Automorphic residues count squarefree divisors
+
+## What This Proves
+
+The grandparent file `AutomorphicNumberOQ01` shows `ZMod (10 ^ k)` has exactly four
+idempotents, and the parent `AutomorphicNumberOQ01OQ01` explains the "four" as `2 ^ ω(n)`:
+the number of idempotents of `ZMod n` — equivalently the number of automorphic residues
+`e ^ 2 ≡ e (mod n)` — is `2 ^ ω(n)`, where `ω(n)` is the number of distinct primes
+dividing `n`.
+
+This file gives that count a **divisor-theoretic** meaning.  The number `2 ^ ω(n)` is
+also the number of **squarefree divisors** of `n`, and both are the number of subsets of
+the prime-factor set of `n`:
+
+```
+squarefreeDivisors_card :
+  #{d ∈ n.divisors | Squarefree d} = 2 ^ n.primeFactors.card       (n ≠ 0)
+
+idempotents_eq_squarefreeDivisors :
+  Nat.card {e : ZMod n // e * e = e} = #{d ∈ n.divisors | Squarefree d}   (0 < n)
+```
+
+So the automorphic residues of a modulus `n` are equinumerous with its squarefree
+divisors — the arithmetic shadow of the parent's remark that `2 ^ ω(n)` counts the ways
+to split `n` into complementary coprime factors.  Each idempotent of `ZMod n` selects,
+for every prime power `p ^ k ‖ n`, whether the `p`-component is `0` or `1`; the "support"
+primes assemble into a squarefree divisor `∏ p`, and this is a bijection with the powerset
+of `n.primeFactors`.
+
+## Strategy
+
+The heart is a clean bijection realized by `Finset.card_image_of_injOn`:
+
+* The map `s ↦ ∏ p ∈ s, p` sends `n.primeFactors.powerset` **onto** the squarefree
+  divisors of `n`.  A product of a subset of the distinct primes dividing `n` divides
+  `∏ p ∈ n.primeFactors, p ∣ n` (`Nat.prod_primeFactors_dvd`) and is squarefree
+  (`Finset.squarefree_prod_of_pairwise_isCoprime`, distinct primes being coprime); every
+  squarefree divisor `d` is recovered as `∏ p ∈ d.primeFactors, p`
+  (`Nat.prod_primeFactors_of_squarefree`) with `d.primeFactors ⊆ n.primeFactors`.
+* The map is injective on the powerset because `s ↦ ∏ p ∈ s, p` has the left inverse
+  `primeFactors` on sets of primes (`Nat.primeFactors_prod`).
+
+Then `Finset.card_powerset` gives `2 ^ ω(n)`, and the parent's `idempotent_count` closes
+the loop back to automorphic residues.
+
+## Status
+
+Fully machine-checked: `0` sorries, `0` axioms.  Builds on the verified parent files.
+-/
+
+namespace AutomorphicNumberOQ01OQ01OQ01
+
+open Finset
+
+/-- The finset of squarefree divisors of `n`. -/
+def squarefreeDivisors (n : ℕ) : Finset ℕ := {d ∈ n.divisors | Squarefree d}
+
+@[simp] lemma mem_squarefreeDivisors {n d : ℕ} :
+    d ∈ squarefreeDivisors n ↔ (d ∣ n ∧ n ≠ 0) ∧ Squarefree d := by
+  simp [squarefreeDivisors, Nat.mem_divisors, and_assoc]
+
+/-- The product `∏ p ∈ s, p` over a set `s` of primes dividing `n` is a squarefree divisor
+of `n`.  Divisibility comes from `Nat.prod_primeFactors_dvd`, squarefreeness from the fact
+that distinct primes are pairwise coprime. -/
+lemma prod_mem_squarefreeDivisors {n : ℕ} (hn : n ≠ 0) {s : Finset ℕ}
+    (hs : s ⊆ n.primeFactors) : (∏ p ∈ s, p) ∈ squarefreeDivisors n := by
+  have hprime : ∀ p ∈ s, p.Prime := fun p hp => Nat.prime_of_mem_primeFactors (hs hp)
+  -- Divides `∏ p ∈ n.primeFactors, p`, which in turn divides `n`.
+  have hdvd : (∏ p ∈ s, p) ∣ n :=
+    (Finset.prod_dvd_prod_of_subset s n.primeFactors _ hs).trans (Nat.prod_primeFactors_dvd n)
+  -- Squarefree: a product of distinct primes.
+  have hsq : Squarefree (∏ p ∈ s, p) := by
+    refine Finset.squarefree_prod_of_pairwise_isCoprime ?_ (fun p hp => (hprime p hp).squarefree)
+    intro p hp q hq hpq
+    simp only [Function.onFun]
+    exact Nat.coprime_iff_isRelPrime.mp ((Nat.coprime_primes (hprime p hp) (hprime q hq)).mpr hpq)
+  exact mem_squarefreeDivisors.mpr ⟨⟨hdvd, hn⟩, hsq⟩
+
+/-- **Squarefree divisors are the image of the powerset of the prime factors** under
+`s ↦ ∏ p ∈ s, p`. -/
+lemma squarefreeDivisors_eq_image (n : ℕ) (hn : n ≠ 0) :
+    squarefreeDivisors n = n.primeFactors.powerset.image (fun s => ∏ p ∈ s, p) := by
+  ext d
+  constructor
+  · intro hd
+    rw [mem_squarefreeDivisors] at hd
+    obtain ⟨⟨hdvd, _⟩, hsq⟩ := hd
+    -- `d` is recovered as the product over its own prime factors, a subset of `n`'s.
+    refine Finset.mem_image.mpr ⟨d.primeFactors, ?_, ?_⟩
+    · exact Finset.mem_powerset.mpr (Nat.primeFactors_mono hdvd hn)
+    · exact Nat.prod_primeFactors_of_squarefree hsq
+  · intro hd
+    obtain ⟨s, hs, rfl⟩ := Finset.mem_image.mp hd
+    exact prod_mem_squarefreeDivisors hn (Finset.mem_powerset.mp hs)
+
+/-- The map `s ↦ ∏ p ∈ s, p` is injective on the powerset of `n.primeFactors`: on sets of
+primes it has the left inverse `primeFactors` (`Nat.primeFactors_prod`). -/
+lemma injOn_prod_powerset (n : ℕ) :
+    Set.InjOn (fun s : Finset ℕ => ∏ p ∈ s, p)
+      (n.primeFactors.powerset : Set (Finset ℕ)) := by
+  intro s hs t ht hst
+  have hsp : ∀ p ∈ s, p.Prime := fun p hp =>
+    Nat.prime_of_mem_primeFactors (Finset.mem_powerset.mp (by simpa using hs) hp)
+  have htp : ∀ p ∈ t, p.Prime := fun p hp =>
+    Nat.prime_of_mem_primeFactors (Finset.mem_powerset.mp (by simpa using ht) hp)
+  have := congrArg Nat.primeFactors hst
+  rwa [Nat.primeFactors_prod hsp, Nat.primeFactors_prod htp] at this
+
+/-- **Main counting theorem.** The number of squarefree divisors of `n ≥ 1` is `2 ^ ω(n)`,
+where `ω(n) = n.primeFactors.card`. -/
+theorem squarefreeDivisors_card (n : ℕ) (hn : n ≠ 0) :
+    (squarefreeDivisors n).card = 2 ^ n.primeFactors.card := by
+  rw [squarefreeDivisors_eq_image n hn,
+    Finset.card_image_of_injOn (injOn_prod_powerset n), Finset.card_powerset]
+
+/-- **Bridge to the parent.** The number of idempotents of `ZMod n` — the automorphic
+residues `e ^ 2 ≡ e (mod n)` — equals the number of squarefree divisors of `n`. -/
+theorem idempotents_eq_squarefreeDivisors (n : ℕ) (hn : 0 < n) :
+    Nat.card {e : ZMod n // e * e = e} = (squarefreeDivisors n).card := by
+  rw [AutomorphicNumberOQ01OQ01.idempotent_count n hn, squarefreeDivisors_card n hn.ne']
+
+/-- The count of squarefree divisors is `1` exactly for `n = 1` (no primes, empty product
+only). -/
+theorem squarefreeDivisors_card_eq_one_iff {n : ℕ} (hn : n ≠ 0) :
+    (squarefreeDivisors n).card = 1 ↔ n = 1 := by
+  rw [squarefreeDivisors_card n hn, Nat.pow_eq_one, Finset.card_eq_zero,
+    Nat.primeFactors_eq_empty]
+  omega
+
+/-- The count is `2` exactly when `n` is a prime power `p ^ k` (`k ≥ 1`) — one distinct
+prime, one nonempty proper choice. -/
+theorem squarefreeDivisors_card_prime_pow {p : ℕ} (hp : p.Prime) {k : ℕ} (hk : 0 < k) :
+    (squarefreeDivisors (p ^ k)).card = 2 := by
+  rw [squarefreeDivisors_card _ (pow_ne_zero k hp.pos.ne'),
+    Nat.primeFactors_prime_pow hk.ne' hp, Finset.card_singleton, pow_one]
+
+/-- **Recovers the grandparent's count.** The modulus `10 ^ k` has `2 ^ ω(10^k) = 4`
+squarefree divisors: `1, 2, 5, 10`. -/
+theorem squarefreeDivisors_ten_pow_card (k : ℕ) (hk : 0 < k) :
+    (squarefreeDivisors (10 ^ k)).card = 4 := by
+  rw [squarefreeDivisors_card _ (pow_ne_zero k (by norm_num)),
+    AutomorphicNumberOQ01OQ01.primeFactors_ten_pow hk]
+  norm_num
+
+end AutomorphicNumberOQ01OQ01OQ01

--- a/src/data/proofs/automorphic-number-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-autonum-oq010101-context",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 54
+    },
+    "type": "concept",
+    "title": "From counting automorphic residues to counting squarefree divisors",
+    "content": "The parent entry proves the automorphic residues e²≡e (mod n) — the idempotents of ZMod n — number exactly 2^ω(n), where ω(n) is the count of distinct primes of n. This file gives 2^ω(n) a second, purely divisor-theoretic reading: it is also the number of squarefree divisors of n. Both counts equal the number of subsets of n's prime-factor set, and the file exhibits the honest bijection — subset s ↦ product ∏ p ∈ s, p — rather than merely matching cardinalities. Chaining with the parent then shows automorphic residues and squarefree divisors of n are equinumerous, the arithmetic shadow of splitting n into complementary coprime factors.",
+    "mathContext": "$\\#\\{d \\mid n : \\mathrm{Squarefree}\\,d\\} = 2^{\\omega(n)} = \\#\\{e \\in \\mathbb{Z}/n : e^2=e\\}$, all three counting subsets of the primes of $n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "squarefree divisors",
+      "automorphic residues / idempotents",
+      "ω(n) prime-factor count",
+      "powerset bijection",
+      "unitary factorization"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "squarefree integers",
+      "finite-set cardinality"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq010101-def-and-image-in",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 84
+    },
+    "type": "definition",
+    "title": "Squarefree divisors and the powerset map's well-definedness",
+    "content": "squarefreeDivisors n is the finset {d ∈ n.divisors | Squarefree d}, with mem_squarefreeDivisors unfolding membership to (d ∣ n ∧ n ≠ 0) ∧ Squarefree d. prod_mem_squarefreeDivisors is the well-definedness half of the counting bijection: for s ⊆ n.primeFactors, the product ∏ p ∈ s, p is a squarefree divisor of n. Divisibility comes from Finset.prod_dvd_prod_of_subset (the sub-product divides the radical ∏ p ∈ n.primeFactors, p) composed with Nat.prod_primeFactors_dvd (the radical divides n). Squarefreeness comes from Finset.squarefree_prod_of_pairwise_isCoprime: distinct primes are pairwise coprime (Nat.coprime_primes, transported to IsRelPrime by Nat.coprime_iff_isRelPrime) and each prime is squarefree.",
+    "mathContext": "For $s \\subseteq \\{p : p \\mid n\\}$, $\\prod_{p \\in s} p \\mid \\prod_{p \\mid n} p \\mid n$ and is squarefree as a product of distinct primes.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "radical of n",
+      "Finset.prod_dvd_prod_of_subset",
+      "pairwise coprime primes",
+      "squarefree product"
+    ],
+    "prerequisites": [
+      "Finset products",
+      "coprimality of distinct primes"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq010101-bijection",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 114
+    },
+    "type": "proof-technique",
+    "title": "The bijection: squarefree divisors are the image of the powerset",
+    "content": "squarefreeDivisors_eq_image proves squarefreeDivisors n = (n.primeFactors.powerset).image (fun s => ∏ p ∈ s, p) by mutual membership. Forward: a squarefree divisor d is the image of s = d.primeFactors, since ∏ p ∈ d.primeFactors, p = d (Nat.prod_primeFactors_of_squarefree) and d.primeFactors ⊆ n.primeFactors (Nat.primeFactors_mono, using d ∣ n and n ≠ 0). Backward: any image point ∏ p ∈ s, p with s ⊆ n.primeFactors is a squarefree divisor by prod_mem_squarefreeDivisors. injOn_prod_powerset then shows the map is injective on the powerset: on sets of primes it has the left inverse primeFactors (Nat.primeFactors_prod), so equal products force equal index sets — the inverse map is d ↦ d.primeFactors.",
+    "mathContext": "$s \\mapsto \\prod_{p \\in s} p$ is a bijection $\\mathcal{P}(n.\\mathrm{primeFactors}) \\to \\{\\text{squarefree divisors of } n\\}$ with inverse $d \\mapsto d.\\mathrm{primeFactors}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "bijective counting",
+      "Set.InjOn",
+      "left inverse primeFactors",
+      "Nat.primeFactors_mono"
+    ],
+    "prerequisites": [
+      "injectivity on a set",
+      "image of a finset",
+      "powerset"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq010101-count-bridge",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 115,
+      "endLine": 141
+    },
+    "type": "key-step",
+    "title": "The count 2^ω(n), the bridge to idempotents, and small cases",
+    "content": "squarefreeDivisors_card rewrites by the image description, Finset.card_image_of_injOn (using injOn_prod_powerset), and Finset.card_powerset to get 2 ^ n.primeFactors.card. idempotents_eq_squarefreeDivisors then chains the parent's idempotent_count = 2^ω(n) with this equality to conclude Nat.card {e : ZMod n // e*e=e} = (squarefreeDivisors n).card — automorphic residues and squarefree divisors are equinumerous. squarefreeDivisors_card_eq_one_iff characterizes count 1 ⟺ n = 1 (Nat.pow_eq_one reduces 2^ω = 1 to ω = 0, and Nat.primeFactors_eq_empty with n ≠ 0 forces n = 1); squarefreeDivisors_card_prime_pow gives count 2 for any prime power via Nat.primeFactors_prime_pow.",
+    "mathContext": "$\\#\\,\\mathrm{image} = \\#\\,\\mathrm{powerset} = 2^{\\omega(n)}$; with the parent, $= \\#\\{\\text{idempotents of } \\mathbb{Z}/n\\}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.card_powerset",
+      "Finset.card_image_of_injOn",
+      "idempotent count",
+      "Nat.pow_eq_one"
+    ],
+    "prerequisites": [
+      "cardinality of images",
+      "powerset cardinality 2^k"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq010101-decimal",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 142,
+      "endLine": 149
+    },
+    "type": "example",
+    "title": "The decimal case: four squarefree divisors of 10^k",
+    "content": "squarefreeDivisors_ten_pow_card substitutes the parent's ω(10^k) = 2 (primeFactors_ten_pow) into squarefreeDivisors_card and computes 2^2 = 4. The four squarefree divisors of 10^k are 1, 2, 5, 10 — one for each subset of the prime set {2, 5} — mirroring the four automorphic residues 0, 1, …5, …6 mod 10^k of the grandparent entry.",
+    "mathContext": "$10^k$ has squarefree divisors $\\{1, 2, 5, 10\\}$, matching $2^{\\omega(10^k)} = 2^2 = 4$ automorphic residues.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decimal automorphic numbers",
+      "prime set {2, 5}",
+      "special case"
+    ],
+    "prerequisites": [
+      "prime factorization of 10^k"
+    ]
+  }
+]

--- a/src/data/proofs/automorphic-number-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,206 @@
+{
+  "id": "automorphic-number-oq-01-oq-01-oq-01",
+  "slug": "automorphic-number-oq-01-oq-01-oq-01",
+  "title": "Automorphic Residues Count Squarefree Divisors",
+  "description": "The parent entry proves the number of idempotents of ZMod n — equivalently the automorphic residues e²≡e (mod n) — is exactly 2^ω(n), where ω(n) is the number of distinct prime factors of n. This follow-up gives that count a divisor-theoretic meaning: 2^ω(n) is also the number of SQUAREFREE DIVISORS of n, and both are the number of subsets of the prime-factor set of n. The heart is a clean bijection realized by Finset.card_image_of_injOn: the map s ↦ ∏ p ∈ s, p sends the powerset of n.primeFactors onto the squarefree divisors of n. A product of a subset of the distinct primes dividing n divides ∏ p ∈ n.primeFactors, p ∣ n (Nat.prod_primeFactors_dvd) and is squarefree (Finset.squarefree_prod_of_pairwise_isCoprime, distinct primes being coprime); conversely every squarefree divisor d is recovered as ∏ p ∈ d.primeFactors, p (Nat.prod_primeFactors_of_squarefree) with d.primeFactors ⊆ n.primeFactors (Nat.primeFactors_mono). The map is injective on the powerset because s ↦ ∏ p ∈ s, p has the left inverse primeFactors on sets of primes (Nat.primeFactors_prod). Finset.card_powerset then yields 2^ω(n), and the parent's idempotent_count closes the loop: the automorphic residues of a modulus are equinumerous with its squarefree divisors — the arithmetic shadow of the parent's remark that 2^ω(n) counts the ways to split n into complementary coprime factors. The decimal case 10^k has 4 squarefree divisors 1, 2, 5, 10.",
+  "meta": {
+    "author": "Lean Genius Researcher-5",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AutomorphicNumberOQ01OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "automorphic-numbers",
+      "idempotents",
+      "squarefree-divisors",
+      "divisor-function",
+      "prime-factorization",
+      "bijective-counting",
+      "arithmetic-functions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 149,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide, no decide. All results depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms). Builds on the verified parent entry AutomorphicNumberOQ01OQ01.lean, reusing its idempotent_count and primeFactors_ten_pow for the bridge and decimal-recovery theorems.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.squarefree_prod_of_pairwise_isCoprime",
+        "description": "A product ∏ i ∈ s, f i is squarefree when the factors are pairwise relatively prime and each is squarefree — applied to a finset of distinct primes to show ∏ p ∈ s, p is squarefree",
+        "module": "Mathlib.Algebra.Squarefree.Basic"
+      },
+      {
+        "theorem": "Nat.prod_primeFactors_dvd",
+        "description": "∏ p ∈ n.primeFactors, p ∣ n — the radical of n divides n, giving divisibility of any sub-product of distinct prime factors",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.prod_primeFactors_of_squarefree",
+        "description": "For squarefree n, ∏ p ∈ n.primeFactors, p = n — recovers a squarefree divisor as the product over its own prime factors, giving surjectivity of the counting bijection",
+        "module": "Mathlib.Data.Nat.Squarefree"
+      },
+      {
+        "theorem": "Nat.primeFactors_prod",
+        "description": "For a finset s of primes, primeFactors (∏ p ∈ s, p) = s — the left inverse of s ↦ ∏ p ∈ s, p on sets of primes, giving injectivity",
+        "module": "Mathlib.Data.Nat.Squarefree"
+      },
+      {
+        "theorem": "Nat.primeFactors_mono",
+        "description": "m ∣ n and n ≠ 0 imply m.primeFactors ⊆ n.primeFactors — places each squarefree divisor's prime-factor set inside the powerset of n.primeFactors",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "#(s.image f) = #s when f is injective on s — turns the image description of the squarefree divisors into a cardinality equal to that of the powerset",
+        "module": "Mathlib.Data.Finset.Image"
+      },
+      {
+        "theorem": "Finset.card_powerset",
+        "description": "#(s.powerset) = 2 ^ #s — supplies the 2^ω(n) count once the squarefree divisors are identified with the powerset of the prime factors",
+        "module": "Mathlib.Data.Finset.Powerset"
+      }
+    ],
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AutomorphicNumberOQ01OQ01"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "AutomorphicNumberOQ01OQ01OQ01",
+    "lineCount": 149,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/AutomorphicNumberOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "squarefreeDivisors_card",
+      "type": "headline",
+      "statement": "n ≠ 0 → (squarefreeDivisors n).card = 2 ^ n.primeFactors.card",
+      "description": "The number of squarefree divisors of n ≥ 1 is 2^ω(n). Proved by identifying the squarefree divisors with the image of the powerset of n.primeFactors under s ↦ ∏ p ∈ s, p, an injection, then applying Finset.card_powerset.",
+      "significance": "The divisor-theoretic incarnation of the parent's idempotent count: the same 2^ω(n) that counts automorphic residues counts squarefree divisors, both being 2^(number of distinct primes)."
+    },
+    {
+      "name": "idempotents_eq_squarefreeDivisors",
+      "type": "headline",
+      "statement": "0 < n → Nat.card {e : ZMod n // e * e = e} = (squarefreeDivisors n).card",
+      "description": "The number of idempotents of ZMod n — the automorphic residues e²≡e (mod n) — equals the number of squarefree divisors of n. Combines the parent's idempotent_count = 2^ω(n) with squarefreeDivisors_card = 2^ω(n).",
+      "significance": "Makes precise the parent's remark that 2^ω(n) counts the ways to split n into complementary coprime factors: automorphic residues and squarefree divisors of n are equinumerous."
+    },
+    {
+      "name": "squarefreeDivisors_eq_image",
+      "type": "core",
+      "statement": "n ≠ 0 → squarefreeDivisors n = (n.primeFactors.powerset).image (fun s => ∏ p ∈ s, p)",
+      "description": "The squarefree divisors of n are exactly the products ∏ p ∈ s, p over subsets s of the distinct prime factors of n. Forward: a squarefree divisor d equals the product over its own prime factors, a subset of n's. Backward: any such product divides the radical (hence n) and is a product of distinct primes, hence squarefree.",
+      "significance": "The structural bijection with the powerset of the prime factors — the concrete content behind the 2^ω(n) count and the correspondence with CRT idempotent supports."
+    },
+    {
+      "name": "injOn_prod_powerset",
+      "type": "core",
+      "statement": "Set.InjOn (fun s => ∏ p ∈ s, p) ↑n.primeFactors.powerset",
+      "description": "The map s ↦ ∏ p ∈ s, p is injective on the powerset of n.primeFactors: on sets of primes it has the left inverse primeFactors (Nat.primeFactors_prod), so equal products force equal index sets.",
+      "significance": "Injectivity is what upgrades 'squarefree divisors are the image of the powerset' to an exact cardinality equality 2^ω(n)."
+    },
+    {
+      "name": "prod_mem_squarefreeDivisors",
+      "type": "supporting",
+      "statement": "n ≠ 0 → s ⊆ n.primeFactors → (∏ p ∈ s, p) ∈ squarefreeDivisors n",
+      "description": "A product of a subset of the distinct primes dividing n is a squarefree divisor of n: it divides ∏ p ∈ n.primeFactors, p ∣ n (Nat.prod_primeFactors_dvd), and being a product of distinct — hence pairwise coprime — primes it is squarefree.",
+      "significance": "The well-definedness half of the bijection: every point of the powerset lands in the squarefree divisors."
+    },
+    {
+      "name": "squarefreeDivisors_card_prime_pow",
+      "type": "supporting",
+      "statement": "p.Prime → 0 < k → (squarefreeDivisors (p ^ k)).card = 2",
+      "description": "A prime power p^k has exactly two squarefree divisors, 1 and p, matching 2^ω(p^k) = 2^1 = 2 and the parent's two idempotents of ZMod (p^k).",
+      "significance": "The ω = 1 case, consistent with the general formula and the parent's prime-power idempotent count."
+    }
+  ],
+  "sections": [
+    {
+      "id": "squarefree-divisors-def",
+      "title": "Part I: The squarefree divisors and the powerset map",
+      "startLine": 55,
+      "endLine": 84,
+      "summary": "squarefreeDivisors n is the finset {d ∈ n.divisors | Squarefree d}; mem_squarefreeDivisors unfolds membership to (d ∣ n ∧ n ≠ 0) ∧ Squarefree d. prod_mem_squarefreeDivisors shows the product ∏ p ∈ s, p over a subset s ⊆ n.primeFactors is a squarefree divisor: it divides the radical ∏ p ∈ n.primeFactors, p (Nat.prod_primeFactors_dvd), which divides n, and it is squarefree because distinct primes are pairwise coprime (Finset.squarefree_prod_of_pairwise_isCoprime with Nat.coprime_primes / coprime_iff_isRelPrime).",
+      "mathContext": "Each subset of the prime factors of n yields a squarefree divisor; the radical of n bounds divisibility and coprimality of distinct primes gives squarefreeness."
+    },
+    {
+      "id": "bijection-image",
+      "title": "Part II: Squarefree divisors as the image of the powerset",
+      "startLine": 85,
+      "endLine": 114,
+      "summary": "squarefreeDivisors_eq_image proves squarefreeDivisors n = (n.primeFactors.powerset).image (fun s => ∏ p ∈ s, p) by mutual membership: a squarefree divisor d is the image of d.primeFactors (⊆ n.primeFactors by Nat.primeFactors_mono) since ∏ p ∈ d.primeFactors, p = d (Nat.prod_primeFactors_of_squarefree); conversely any image point is a squarefree divisor by Part I. injOn_prod_powerset shows the map is injective on the powerset via the left inverse primeFactors (Nat.primeFactors_prod on sets of primes).",
+      "mathContext": "The map s ↦ ∏ p ∈ s, p is a bijection between subsets of n's distinct primes and squarefree divisors of n, with inverse d ↦ d.primeFactors."
+    },
+    {
+      "id": "counting-and-bridge",
+      "title": "Part III: The count 2^ω(n) and the bridge to idempotents",
+      "startLine": 115,
+      "endLine": 141,
+      "summary": "squarefreeDivisors_card: rewriting by the image description, Finset.card_image_of_injOn, and Finset.card_powerset gives 2 ^ n.primeFactors.card. idempotents_eq_squarefreeDivisors chains the parent's idempotent_count = 2^ω(n) with this to equate automorphic residues and squarefree divisors. squarefreeDivisors_card_eq_one_iff (Nat.pow_eq_one, primeFactors_eq_empty) characterizes count 1 ⟺ n = 1, and squarefreeDivisors_card_prime_pow gives count 2 for prime powers.",
+      "mathContext": "Card of the image = card of the powerset = 2^ω(n); combined with the parent this counts automorphic residues as squarefree divisors."
+    },
+    {
+      "id": "decimal-recovery",
+      "title": "Part IV: The decimal case",
+      "startLine": 142,
+      "endLine": 149,
+      "summary": "squarefreeDivisors_ten_pow_card: substituting the parent's ω(10^k) = 2 (primeFactors_ten_pow) into squarefreeDivisors_card gives 2^2 = 4 — the four squarefree divisors 1, 2, 5, 10 of 10^k, mirroring the four automorphic residues mod 10^k.",
+      "mathContext": "The classical decimal '4' reappears as the count of squarefree divisors of 10^k, one for each subset of {2, 5}."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The number of squarefree divisors of an integer $n$ — equivalently the number of unitary 'complementary' factorizations $n = a \\cdot b$ with $\\gcd(a,b) = 1$ — is one of the oldest multiplicative counting functions in number theory, equal to $2^{\\omega(n)}$ where $\\omega(n)$ counts the distinct prime divisors of $n$. It is the value $|\\mu|\\!*\\!1$ at $n$ (the Dirichlet convolution of $|\\mu|$ with the constant $1$), and its Dirichlet series $\\sum_n 2^{\\omega(n)} n^{-s} = \\zeta(s)^2/\\zeta(2s)$ is a staple of analytic number theory. The parent entry showed that this same $2^{\\omega(n)}$ counts the idempotents of $\\mathbb{Z}/n\\mathbb{Z}$ — the automorphic residues $e^2 \\equiv e \\pmod n$ — through the Chinese Remainder decomposition into local rings. This follow-up makes the coincidence explicit and elementary: it exhibits an honest bijection, not merely an equality of counts, between the squarefree divisors of $n$ and the subsets of its prime-factor set, and hence between squarefree divisors and automorphic residues. The bijection is the arithmetic residue of the fact — noted in the parent's implications — that each idempotent of $\\mathbb{Z}/n\\mathbb{Z}$ selects a 'support' set of primes, assembling a unitary complementary factor of $n$.",
+    "problemStatement": "Give a divisor-theoretic meaning to the automorphic-residue count $2^{\\omega(n)}$. Concretely: prove that for every $n \\geq 1$ the number of squarefree divisors of $n$ is $2^{\\omega(n)}$, exhibit the underlying bijection with the powerset of the prime factors of $n$, and conclude that the automorphic residues of $\\mathbb{Z}/n\\mathbb{Z}$ (idempotents $e^2 \\equiv e$) are equinumerous with the squarefree divisors of $n$. Recover the decimal case: $10^k$ has $4$ squarefree divisors, $1, 2, 5, 10$.",
+    "proofStrategy": "Work with the finite set $\\operatorname{squarefreeDivisors}(n) = \\{d \\in \\operatorname{divisors}(n) : \\operatorname{Squarefree} d\\}$. The key is a bijection realized by the map $\\varphi : s \\mapsto \\prod_{p \\in s} p$ from the powerset of $n.\\!\\operatorname{primeFactors}$. First show $\\varphi$ lands in the squarefree divisors: a product of a subset of the distinct primes of $n$ divides the radical $\\prod_{p \\mid n} p$, which divides $n$ (Nat.prod_primeFactors_dvd), and a product of distinct — pairwise coprime — primes is squarefree (Finset.squarefree_prod_of_pairwise_isCoprime). Then show every squarefree divisor is hit: a squarefree $d \\mid n$ equals $\\prod_{p \\in d.\\!\\operatorname{primeFactors}} p$ (Nat.prod_primeFactors_of_squarefree), and $d.\\!\\operatorname{primeFactors} \\subseteq n.\\!\\operatorname{primeFactors}$ (Nat.primeFactors_mono). This gives $\\operatorname{squarefreeDivisors}(n)$ as the image of the powerset. Injectivity of $\\varphi$ on the powerset follows from the left inverse $\\operatorname{primeFactors}$ on sets of primes (Nat.primeFactors_prod). Finset.card_image_of_injOn and Finset.card_powerset then deliver $2^{\\omega(n)}$. Finally, chaining the parent's $\\operatorname{idempotent\\_count} = 2^{\\omega(n)}$ equates automorphic residues with squarefree divisors, and the parent's $\\omega(10^k) = 2$ recovers the count $4$.",
+    "keyInsights": [
+      "The automorphic-residue count $2^{\\omega(n)}$ is not just numerically equal to the number of squarefree divisors of $n$ — the two are joined by an explicit bijection, both being the number of subsets of the prime-factor set of $n$.",
+      "A squarefree divisor of $n$ is completely determined by which of $n$'s primes it contains: the map $d \\mapsto d.\\!\\operatorname{primeFactors}$ and its inverse $s \\mapsto \\prod_{p \\in s} p$ set up the correspondence with the powerset.",
+      "Divisibility of the sub-products is controlled by the radical: $\\prod_{p \\in s} p$ divides $\\prod_{p \\mid n} p$, which divides $n$ — so no divisor test beyond 'subset of the prime factors' is needed.",
+      "Squarefreeness of $\\prod_{p \\in s} p$ is exactly the pairwise coprimality of distinct primes, packaged by Finset.squarefree_prod_of_pairwise_isCoprime — the same coprimality that drives the CRT splitting behind the idempotent count.",
+      "The equinumerosity of idempotents and squarefree divisors is the arithmetic shadow of a ring fact: an idempotent of $\\mathbb{Z}/n\\mathbb{Z}$ picks out a unitary complementary factorization $n = a \\cdot b$ with $\\gcd(a,b)=1$, whose squarefree part is a squarefree divisor.",
+      "Phrasing the count through a Finset image and Finset.card_powerset avoids any induction on $\\omega(n)$: the powerset carries the $2^{\\omega(n)}$ for free once the bijection is in place."
+    ]
+  },
+  "conclusion": {
+    "summary": "For every $n \\geq 1$ the number of squarefree divisors of $n$ is exactly $2^{\\omega(n)}$, established by an explicit bijection $s \\mapsto \\prod_{p \\in s} p$ between the powerset of $n$'s distinct prime factors and its squarefree divisors (injective by the left inverse $\\operatorname{primeFactors}$, surjective by $\\prod_{p \\in d.\\operatorname{primeFactors}} p = d$ for squarefree $d$). Chaining this with the parent entry's idempotent count $2^{\\omega(n)}$ shows the automorphic residues $e^2 \\equiv e \\pmod n$ of $\\mathbb{Z}/n\\mathbb{Z}$ are equinumerous with the squarefree divisors of $n$. The decimal case reappears: $10^k$ has the four squarefree divisors $1, 2, 5, 10$, mirroring its four automorphic residues. Fully machine-checked: $0$ sorries, $0$ axioms, no `native_decide`, no `decide`.",
+    "implications": "The result upgrades the parent's numerical coincidence to a structural one: automorphic residues, squarefree divisors, and subsets of the prime-factor set are three faces of the same $2^{\\omega(n)}$. The bijection makes the parent's remark about 'splitting $n$ into complementary coprime factors' literal — each squarefree divisor $d$ pairs with the unitary complement supported on the remaining primes. Methodologically it is a template for turning a multiplicative count into a combinatorial one: identify the objects with subsets of the primes, exhibit the product/prime-factor inverse pair, and read off $2^{\\omega(n)}$ from the powerset.",
+    "openQuestions": [
+      "The squarefree divisors of $n$ carry a Boolean-lattice structure (isomorphic to the powerset of $n.\\!\\operatorname{primeFactors}$ under divisibility); can this order isomorphism be formalized and matched to the lattice of idempotents of $\\mathbb{Z}/n\\mathbb{Z}$ under $e \\leq f \\iff ef = e$?",
+      "Beyond counting, can the CRT idempotent-to-squarefree-divisor correspondence be made an explicit map in Lean — sending an idempotent $e$ to the product of the primes $p \\mid n$ at which the local component of $e$ is $1$ — and proven to be the bijection whose existence is here established only through cardinalities?",
+      "Does the same powerset bijection give the count of UNITARY divisors of $n$ (divisors $d$ with $\\gcd(d, n/d)=1$), which is likewise $2^{\\omega(n)}$, and can the two divisor families be related by $d \\mapsto \\operatorname{rad}(d)$?",
+      "Can the partial sums $\\sum_{n \\leq x} (\\text{number of squarefree divisors of } n) = \\sum_{n \\leq x} 2^{\\omega(n)}$ and their $\\zeta(s)^2/\\zeta(2s)$ Dirichlet series be formalized, connecting this exact count to its average order?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "automorphic-number-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Why Exactly Four? Counting Automorphic Residues mod n as 2^ω(n) — proves the idempotent/automorphic-residue count is 2^ω(n); this entry supplies its idempotent_count and primeFactors_ten_pow, and reinterprets the same 2^ω(n) as a squarefree-divisor count."
+    },
+    {
+      "proofId": "automorphic-number-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "The Complementary Pairing of Automorphic Idempotents mod 10^k — the complementary pairing e ↦ 1-e of idempotents mirrors the complementary pairing d ↦ n/d of unitary/squarefree divisors that this entry's bijection makes explicit."
+    },
+    {
+      "proofId": "fundamental-arithmetic",
+      "relationship": "foundation",
+      "description": "Fundamental Theorem of Arithmetic — unique prime factorization underlies ω(n), the radical ∏ p ∈ n.primeFactors, p, and the powerset over which the squarefree-divisor bijection is built."
+    },
+    {
+      "proofId": "euler-totient",
+      "relationship": "related-technique",
+      "description": "Euler's Generalization of Fermat's Little Theorem — another multiplicative arithmetic function evaluated across the prime factorization; the squarefree-divisor count 2^ω(n) is the |μ|*1 convolution, a companion to φ in the same multiplicative-function toolkit."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New OQ-child gallery entry **automorphic-number-oq-01-oq-01-oq-01**: *Automorphic Residues Count Squarefree Divisors*.

The parent (`automorphic-number-oq-01-oq-01`) proves the number of idempotents of `ZMod n` — equivalently the automorphic residues `e² ≡ e (mod n)` — is exactly `2^ω(n)`, where `ω(n)` is the number of distinct prime factors of `n`.

This follow-up gives that count a **divisor-theoretic meaning**: `2^ω(n)` is also the number of **squarefree divisors** of `n`, via an explicit bijection (not just an equality of counts).

## What is proved (0 sorries, 0 axioms)

- `squarefreeDivisors_card` (headline): `#{d ∣ n : Squarefree d} = 2^ω(n)` for `n ≠ 0`.
- `idempotents_eq_squarefreeDivisors` (headline): `Nat.card {e : ZMod n // e*e=e} = #(squarefreeDivisors n)` — automorphic residues and squarefree divisors of `n` are equinumerous.
- `squarefreeDivisors_eq_image` / `injOn_prod_powerset` (core): the bijection `s ↦ ∏ p ∈ s, p` from the powerset of `n.primeFactors` onto the squarefree divisors, with inverse `d ↦ d.primeFactors`.
- `squarefreeDivisors_card_eq_one_iff`, `squarefreeDivisors_card_prime_pow`, `squarefreeDivisors_ten_pow_card` (small cases + decimal recovery: `10^k` has the four squarefree divisors `1, 2, 5, 10`).

## Proof idea

The map `s ↦ ∏ p ∈ s, p` lands in the squarefree divisors (a sub-product of distinct primes divides the radical `∏ p ∈ n.primeFactors, p ∣ n` and is squarefree as a product of pairwise-coprime primes) and hits every squarefree divisor `d = ∏ p ∈ d.primeFactors, p` with `d.primeFactors ⊆ n.primeFactors`. It is injective on the powerset via the left inverse `primeFactors`. `Finset.card_image_of_injOn` + `Finset.card_powerset` give `2^ω(n)`; the parent's `idempotent_count` closes the loop.

## Verification

- `#print axioms` on all main theorems: only `propext, Classical.choice, Quot.sound`. No `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`, no `decide`.
- Builds on the verified parent `Proofs/AutomorphicNumberOQ01OQ01.lean` (reuses `idempotent_count`, `primeFactors_ten_pow`).
- 9 theorems/lemmas + 1 def, 149 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)