### PR TITLE
Add missing section summaries: menelaus-theorem family (Menelaus, Desargues, Routh)

### DIFF
--- a/src/data/proofs/menelaus-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/menelaus-theorem-oq-01-oq-02/meta.json
@@ -105,48 +105,42 @@
       "title": "Overview and Imports",
       "startLine": 4,
       "endLine": 55,
-      "description": "Module docstring stating Desargues's theorem, the homogeneous-coordinate strategy, and how it reuses the parent's incidence-as-vanishing-determinant idea. Imports only Mathlib.",
-      "mathContext": "Perspective from a point $\\iff$ perspective from a line, encoded by vanishing $3\\times3$ determinants in $\\mathbb{R}^3$."
+      "summary": "Module docstring and imports for the projective-duality extension: Desargues's two-triangle perspectivity theorem and its self-duality, developed in homogeneous coordinates."
     },
     {
       "id": "calculus",
       "title": "Cross Product and 3×3 Determinant",
       "startLine": 63,
       "endLine": 79,
-      "description": "Defines the homogeneous-coordinate vector type Vec, the cross product (join of points / meet of lines by duality), and the scalar-triple-product determinant det3 whose vanishing detects collinearity and concurrence.",
-      "mathContext": "$\\det_3(P,Q,R)=P\\cdot(Q\\times R)$; vanishes $\\iff$ the three points are collinear / three lines concurrent."
+      "summary": "Vec := ℝ × ℝ × ℝ gives homogeneous coordinates on the real projective plane. cross is the vector cross product — simultaneously the join of two points and the meet of two lines in the projective dictionary — and det3 P Q R = P · (Q × R) is the scalar triple product, vanishing exactly when the three are collinear (or concurrent)."
     },
     {
       "id": "configuration",
       "title": "Configuration and Perspectivity Conditions",
       "startLine": 81,
       "endLine": 119,
-      "description": "DesarguesConfig packages two triangles with non-degeneracy hypotheses. Defines the side-intersections pointP, pointQ, pointR as double cross products, the determinants concurDet and collDet, and the predicates PerspectiveFromPoint and PerspectiveFromLine.",
-      "mathContext": "$P=(B\\times C)\\times(B'\\times C')$; concurrence $\\det_3(A\\times A',B\\times B',C\\times C')=0$; collinearity $\\det_3(P,Q,R)=0$."
+      "summary": "DesarguesConfig fixes two non-degenerate triangles A B C and A′ B′ C′. pointP, pointQ, pointR are the intersections of corresponding sides (meets of crosses); concurDet and collDet measure concurrence of the connectors and collinearity of the side-intersections; PerspectiveFromPoint and PerspectiveFromLine name the two perspectivity conditions."
     },
     {
       "id": "bracket-identity",
       "title": "The Desargues Bracket Identity",
       "startLine": 127,
       "endLine": 135,
-      "description": "desargues_bracket_identity: the geometric heart. The collinearity determinant factors as the product of the two triangle determinants and the concurrence determinant — a degree-12 polynomial identity in the 18 coordinates, discharged by ring.",
-      "mathContext": "$\\det_3(P,Q,R)=\\det_3(A,B,C)\\,\\det_3(A',B',C')\\,\\det_3(A\\times A',B\\times B',C\\times C')$."
+      "summary": "desargues_bracket_identity is the algebraic content — a bracket (determinant) identity relating the concurrence and collinearity determinants — closed by ring."
     },
     {
       "id": "desargues",
       "title": "Desargues's Theorem and Self-Duality",
       "startLine": 137,
       "endLine": 172,
-      "description": "desargues: perspective from a point ↔ perspective from a line, read off the bracket identity by dividing out the two nonzero triangle determinants (mul_eq_zero). Directional corollaries and desargues_self_dual record the point↔line symmetry.",
-      "mathContext": "With $\\det_3(A,B,C)\\neq0$ and $\\det_3(A',B',C')\\neq0$: $\\det_3(P,Q,R)=0 \\iff \\det_3(A\\times A',B\\times B',C\\times C')=0$."
+      "summary": "desargues proves perspective-from-a-point ↔ perspective-from-a-line, with the two directional lemmas, and desargues_self_dual records the theorem's invariance under swapping the roles of points and lines."
     },
     {
       "id": "example",
       "title": "Concrete Perspective Configuration",
       "startLine": 174,
       "endLine": 186,
-      "description": "desargues_example: centre (0,0,1) with connectors along the x-axis, y-axis, and the line y=x gives two perspective triangles; Desargues forces the three side-intersections to be collinear. Checked by norm_num.",
-      "mathContext": "$A=(1,0,1),B=(0,1,1),C=(1,1,1)$, $A'=(3,0,1),B'=(0,2,1),C'=(2,2,1)$: concurrent connectors $\\Rightarrow$ collinear $P,Q,R$."
+      "summary": "desargues_example gives a concrete perspective configuration with centre (0,0,1), verifying the biconditional on explicit coordinates."
     }
   ]
 }

--- a/src/data/proofs/menelaus-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/menelaus-theorem-oq-01-oq-03/meta.json
@@ -104,40 +104,35 @@
       "title": "Overview and Imports",
       "startLine": 1,
       "endLine": 64,
-      "description": "Module docstring framing the cevian triangle PQR as the natural successor to the parent's transversal Menelaus theorem: a general concurrency criterion plus Routh's signed-area formula, both from the parent's collinearDet.",
-      "mathContext": "Cevian triangle of $AX,BY,CZ$; concurrency iff $tuv=(1-t)(1-u)(1-v)$; Routh area $\\frac{(tuv-(1-t)(1-u)(1-v))^2}{(1-u+tu)(1-v+uv)(1-t+vt)}$."
+      "summary": "Module docstring and imports for the concurrency/area extension: cevian intersections, the Ceva concurrency criterion, and Routh's theorem for a general triangle."
     },
     {
       "id": "intersection",
       "title": "Cevian Line Intersection (General Triangle)",
       "startLine": 65,
       "endLine": 108,
-      "description": "detLines (cross product of two line directions — the parallelism denominator) and interPt (the intersection point by Cramer's rule). cevP = AX∩BY, with detP its denominator; cevP_on_AX and cevP_on_BY certify cevP lies on both cevians.",
-      "mathContext": "$P=AX\\cap BY$ with $\\det_P=(X-A)\\times(Y-B)$; $P=\\bigl(\\tfrac{c_1\\Delta x_2-c_2\\Delta x_1}{\\det_P},\\dots\\bigr)$."
+      "summary": "detLines is the cross of two cevian direction vectors and interPt their intersection point; cevP = AX ∩ BY with parallelism denominator detP. cevP_on_AX and cevP_on_BY certify that the vertex lies on both cevians whenever they are not parallel."
     },
     {
       "id": "concurrency",
       "title": "Concurrency Criterion (General Triangle)",
       "startLine": 109,
       "endLine": 155,
-      "description": "concurrency_defect: the polynomial identity collinearDet C Z P · detP = ((1-t)(1-u)(1-v) - tuv)·(collinearDet A B C)², valid for any triangle. cevians_concurrent_iff cancels the squared nonzero area factor to conclude the cevians concur iff t·u·v = (1-t)(1-u)(1-v).",
-      "mathContext": "$AX,BY,CZ$ concurrent $\\iff tuv=(1-t)(1-u)(1-v)$ — the cevian companion of Menelaus's $tuv=-(1-t)(1-u)(1-v)$."
+      "summary": "concurrency_defect expresses the signed area of the cevian triangle as a defect term, and cevians_concurrent_iff turns it into the Ceva concurrency criterion for an arbitrary non-degenerate triangle."
     },
     {
       "id": "routh-vertices",
       "title": "Cevian-Triangle Vertices (Reference Triangle)",
       "startLine": 156,
       "endLine": 191,
-      "description": "Closed-form vertices vP, vQ, vR of the cevian triangle on the reference triangle A=(0,0),B=(1,0),C=(0,1), each certified to lie on its two cevians by the six on-line lemmas vP_on_AX, vP_on_BY, vQ_on_BY, vQ_on_CZ, vR_on_CZ, vR_on_AX.",
-      "mathContext": "$P=\\bigl(\\tfrac{(1-t)(1-u)}{D_1},\\tfrac{t(1-u)}{D_1}\\bigr)$, $D_1=1-u+tu$; similarly $Q,R$ with $D_2=1-v+uv$, $D_3=1-t+vt$."
+      "summary": "For the reference triangle, vP, vQ, vR give closed-form coordinates of the three cevian-triangle vertices, each verified to lie on its two defining cevians (vP_on_AX/BY, vQ_on_BY/CZ, vR_on_CZ/AX)."
     },
     {
       "id": "routh-theorem",
       "title": "Routh's Theorem (Signed-Area Formula)",
       "startLine": 192,
       "endLine": 239,
-      "description": "routh_area: collinearDet P Q R = (tuv-(1-t)(1-u)(1-v))² / ((1-u+tu)(1-v+uv)(1-t+vt)). routh_area_zero_iff reads off the Ceva degeneracy (squared numerator), and routh_one_seventh instantiates t=u=v=1/3 to the classical one-seventh-area triangle.",
-      "mathContext": "$[PQR]=\\frac{(tuv-(1-t)(1-u)(1-v))^2}{(1-u+tu)(1-v+uv)(1-t+vt)}\\,[ABC]$; $t=u=v=\\tfrac13\\Rightarrow\\tfrac17$."
+      "summary": "routh_area is Routh's signed-area formula for the inner cevian triangle; routh_area_zero_iff shows it degenerates exactly when the cevians concur; and routh_one_seventh recovers the classical one-seventh-area triangle at t = u = v = 1/3."
     }
   ]
 }

--- a/src/data/proofs/menelaus-theorem-oq-01/meta.json
+++ b/src/data/proofs/menelaus-theorem-oq-01/meta.json
@@ -99,48 +99,42 @@
       "title": "Overview and Imports",
       "startLine": 1,
       "endLine": 49,
-      "description": "Module docstring framing Menelaus as the transversal companion of Ceva: instead of concurrency (product +1), collinearity of three transversal points is characterised by the signed-ratio product equalling -1, proved through a signed-area determinant factorisation.",
-      "mathContext": "Menelaus: for triangle $ABC$ with transversal points $X,Y,Z$ on lines $BC,CA,AB$, collinearity holds iff $\\frac{t}{1-t}\\cdot\\frac{u}{1-u}\\cdot\\frac{v}{1-v} = -1$."
+      "summary": "Module docstring framing Menelaus's theorem — three transversal points are collinear iff the product of signed side ratios equals −1, the transversal companion of Ceva's concurrency criterion (+1) — plus imports, the MenelausTheorem namespace, and the affine-point abbreviation Pt := ℝ × ℝ."
     },
     {
       "id": "determinant-and-collinearity",
       "title": "Signed-Area Determinant and Collinearity",
       "startLine": 50,
       "endLine": 58,
-      "description": "Primitives: `Pt := ℝ×ℝ`, `collinearDet P Q R = (Q.1-P.1)(R.2-P.2) - (Q.2-P.2)(R.1-P.1)` (twice the signed area of triangle PQR), and `Collinear3 P Q R := collinearDet P Q R = 0`.",
-      "mathContext": "Three points are collinear iff $\\det\\begin{pmatrix} Q-P & R-P\\end{pmatrix}=0$, i.e. the signed area of $\\triangle PQR$ vanishes."
+      "summary": "collinearDet P Q R is the 2×2 signed-area determinant of the edge vectors Q−P and R−P; the predicate Collinear3 holds exactly when this determinant vanishes."
     },
     {
       "id": "configuration",
       "title": "Menelaus Configuration and Division Points",
       "startLine": 59,
       "endLine": 93,
-      "description": "`MenelausConfig` bundles a triangle A,B,C with transversal parameters t,u,v (each ≠ 1 so signed ratios are defined) and a non-degeneracy hypothesis `collinearDet A B C ≠ 0`. Division points `ptX=(1-t)B+tC`, `ptY=(1-u)C+uA`, `ptZ=(1-v)A+vB`, and `menelausProduct = (t/(1-t))·(u/(1-u))·(v/(1-v))`.",
-      "mathContext": "$X=(1-t)B+tC$, $Y=(1-u)C+uA$, $Z=(1-v)A+vB$; signed ratios $\\tfrac{BX}{XC}=\\tfrac{t}{1-t}$ etc."
+      "summary": "MenelausConfig bundles a triangle A B C with division parameters t, u, v (each ≠ 1, so each signed ratio t/(1−t) is defined) and a non-degeneracy hypothesis. ptX, ptY, ptZ place the transversal points on BC, CA, AB by affine interpolation, and menelausProduct is the signed-ratio product (t/(1−t))·(u/(1−u))·(v/(1−v))."
     },
     {
       "id": "determinant-factorisation",
       "title": "Determinant Factorisation (Geometric Content)",
       "startLine": 95,
       "endLine": 102,
-      "description": "`collinearDet_factor`: the collinearity determinant of the three division points factors as the Menelaus scalar times the triangle's signed area — `collinearDet X Y Z = (t·u·v + (1-t)(1-u)(1-v)) · collinearDet A B C` — a pure polynomial identity discharged by `ring`.",
-      "mathContext": "$\\det(XYZ) = \\big(tuv + (1-t)(1-u)(1-v)\\big)\\,\\det(ABC)$."
+      "summary": "collinearDet_factor is the geometric heart: the collinearity determinant of X, Y, Z factors as (t·u·v + (1−t)(1−u)(1−v)) · collinearDet A B C, a pure polynomial identity discharged by ring."
     },
     {
       "id": "main-theorem",
       "title": "Menelaus's Theorem (Main Biconditional)",
       "startLine": 104,
       "endLine": 128,
-      "description": "`menelaus`: for a non-degenerate triangle, `Collinear3 X Y Z ↔ menelausProduct = -1`. Proof factors the determinant, cancels the non-zero base area via `mul_eq_zero`/`or_iff_left`, then matches `tuv + (1-t)(1-u)(1-v) = 0` to the product form via `div_eq_iff` and `linear_combination`. Corollaries `product_of_collinear` and `collinear_of_product` give the two directions.",
-      "mathContext": "$X,Y,Z$ collinear $\\iff tuv = -(1-t)(1-u)(1-v) \\iff \\tfrac{t}{1-t}\\tfrac{u}{1-u}\\tfrac{v}{1-v} = -1$."
+      "summary": "menelaus: for a non-degenerate triangle, X, Y, Z are collinear ↔ menelausProduct = −1. The proof rewrites through the factorisation, kills the nonzero triangle area with mul_eq_zero, clears denominators, and closes both directions by linear_combination. product_of_collinear and collinear_of_product package the two implications."
     },
     {
       "id": "example",
       "title": "Concrete Numerical Instance",
       "startLine": 130,
       "endLine": 139,
-      "description": "`menelaus_example`: the triangle (0,0),(1,0),(0,1) with t=u=2, v=-1/3 yields menelausProduct = -1 and hence, by the main theorem, collinear division points — a concrete witness that the characterisation is non-vacuous.",
-      "mathContext": "$t=u=2,\\ v=-\\tfrac13:\\ (-2)(-2)(-\\tfrac14) = -1$, so $X,Y,Z$ are collinear."
+      "summary": "menelaus_example exhibits a concrete witness — triangle (0,0),(1,0),(0,1) with t = u = 2, v = −1/3 — whose signed-ratio product is −1 and whose three division points are therefore collinear, all discharged by norm_num."
     }
   ]
 }


### PR DESCRIPTION
Three gallery entries had sections with valid `id`/`title`/`startLine`/`endLine` but **no `summary`**, so the Table of Contents rendered blank section descriptions (`TableOfContents.tsx:71`). Synthesized accurate per-section summaries by reading each Lean file:

- **menelaus-theorem-oq-01** — the `collinearDet` factorisation and the collinearity ↔ (signed side-ratio product = −1) biconditional, with a concrete numerical witness.
- **menelaus-theorem-oq-01-oq-02** — projective-coordinate **Desargues** theorem (perspective-from-a-point ↔ perspective-from-a-line) and its self-duality via the bracket identity.
- **menelaus-theorem-oq-01-oq-03** — cevian intersections, the **Ceva** concurrency criterion, and **Routh's** signed-area theorem (including the classical 1/7-area triangle).

Part of the malformed-sections sweep (see #32654 for the schema-repair phases). `pnpm build` passes; all sections now satisfy the full `ProofSection` schema.