### PR TITLE
research(infinitude-primes-4k3-oq-01-oq-01): ∞ primes ≡ 7 (mod 8) via x²−2 quadratic-residue Euclid argument [VERIFIED, 0-axiom, 5thm/163L, new entry]

### DIFF
--- a/proofs/Proofs/InfinitudePrimes4k3OQ01OQ01.lean
+++ b/proofs/Proofs/InfinitudePrimes4k3OQ01OQ01.lean
@@ -1,0 +1,163 @@
+/-
+# Infinitely Many Primes ≡ 7 (mod 8) — An Elementary, L-function-Free Euclid Argument
+
+This file answers open question `infinitude-primes-4k3-oq-01-oq-01`:
+
+> Prove `Set.Infinite {p prime | p ≡ 7 [MOD 8]}` by a purely elementary
+> Euclidean argument, removing the dependence on Dirichlet's theorem for
+> this residue class.
+
+The whole proof rests on a single classical quadratic-residue fact, already in
+Mathlib: for an odd prime `p`, `2` is a square mod `p` **iff** `p ≡ ±1 (mod 8)`
+(`ZMod.exists_sq_eq_two_iff`). Everything else is elementary arithmetic and a
+Euclid-style construction, with no L-functions and no appeal to Dirichlet's
+theorem.
+
+## The mechanism
+
+For any *odd* `a`, put `M = a² − 2`.
+
+* `M ≡ 7 (mod 8)`: an odd square is `≡ 1 (mod 8)`, so `a² − 2 ≡ −1 ≡ 7`.
+* Every prime `p ∣ M` is odd (as `M` is odd) and makes `2 = a²` a square mod `p`,
+  hence `p ≡ 1` or `7 (mod 8)`.
+* A product of numbers all `≡ 1 (mod 8)` is again `≡ 1 (mod 8)`. Since `M ≡ 7`,
+  **not** every prime factor can be `≡ 1`, so `M` has a prime factor `≡ 7 (mod 8)`.
+
+Feeding a Euclid construction into this — take `a = 3 · ∏(known primes ≡ 7)` — the
+resulting new prime `≡ 7 (mod 8)` cannot already be on the list, so the list of
+such primes is never complete.
+-/
+import Mathlib
+
+open scoped BigOperators
+
+namespace InfinitudePrimes4k3OQ01OQ01
+
+/-- An odd natural number has square `≡ 1 (mod 8)`. This is the arithmetic reason
+`a² − 2 ≡ 7 (mod 8)` for odd `a`. -/
+theorem odd_sq_mod_eight {a : ℕ} (ha : Odd a) : a ^ 2 % 8 = 1 := by
+  obtain ⟨k, rfl⟩ := ha
+  obtain ⟨t, ht⟩ := Nat.even_mul_succ_self k
+  have key : (2 * k + 1) ^ 2 = 8 * t + 1 := by
+    have e : (2 * k + 1) ^ 2 = 4 * (k * (k + 1)) + 1 := by ring
+    rw [e, ht]; ring
+  rw [key]; omega
+
+/-- **Quadratic-residue step.** If an odd prime `p` divides `a² − 2` (with
+`a² ≥ 2`), then `2` is a square mod `p`, so `p ≡ 1` or `7 (mod 8)`.
+
+This is the only place quadratic reciprocity enters, through Mathlib's
+`ZMod.exists_sq_eq_two_iff`. -/
+theorem prime_factor_two_qr {p a : ℕ} (hp : p.Prime) (hp2 : p ≠ 2)
+    (hdvd : p ∣ a ^ 2 - 2) (ha2 : 2 ≤ a ^ 2) : p % 8 = 1 ∨ p % 8 = 7 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hcast : ((a ^ 2 - 2 : ℕ) : ZMod p) = 0 :=
+    (ZMod.natCast_eq_zero_iff _ _).mpr hdvd
+  rw [Nat.cast_sub ha2] at hcast
+  push_cast at hcast
+  have h2 : (a : ZMod p) ^ 2 = 2 := by
+    have := sub_eq_zero.mp hcast
+    linear_combination this
+  refine (ZMod.exists_sq_eq_two_iff hp2).mp ⟨(a : ZMod p), ?_⟩
+  rw [← h2]; ring
+
+/-- **The core lemma.** For odd `a ≥ 3`, the number `a² − 2` has a prime factor
+`≡ 7 (mod 8)`.
+
+The prime factors are all `≡ 1` or `7 (mod 8)`; were they *all* `≡ 1`, the product
+`a² − 2` would be `≡ 1 (mod 8)`, contradicting `a² − 2 ≡ 7 (mod 8)`. -/
+theorem exists_prime_factor_seven_mod_eight {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a) :
+    ∃ p, p.Prime ∧ p ∣ a ^ 2 - 2 ∧ p % 8 = 7 := by
+  set M := a ^ 2 - 2 with hM
+  have ha2 : 2 ≤ a ^ 2 := by nlinarith
+  have hM2 : 2 ≤ M := by
+    have : 9 ≤ a ^ 2 := by nlinarith
+    omega
+  have hM7 : M % 8 = 7 := by
+    have h1 : a ^ 2 % 8 = 1 := odd_sq_mod_eight ha
+    omega
+  by_contra hcon
+  push_neg at hcon
+  -- Every prime factor of `M` is `≡ 1 (mod 8)`, hence casts to `1` in `ZMod 8`.
+  have hall : ∀ x ∈ M.primeFactorsList.map (Nat.cast : ℕ → ZMod 8), x = 1 := by
+    intro x hx
+    rw [List.mem_map] at hx
+    obtain ⟨p, hpmem, rfl⟩ := hx
+    have hpp : p.Prime := Nat.prime_of_mem_primeFactorsList hpmem
+    have hpd : p ∣ M := Nat.dvd_of_mem_primeFactorsList hpmem
+    have hp2 : p ≠ 2 := by
+      rintro rfl
+      omega
+    have hcases := prime_factor_two_qr hpp hp2 hpd ha2
+    have hne7 : p % 8 ≠ 7 := hcon p hpp hpd
+    have hp1 : p % 8 = 1 := by tauto
+    have : (p : ZMod 8) = ((p % 8 : ℕ) : ZMod 8) := (ZMod.natCast_mod p 8).symm
+    rw [hp1] at this
+    simpa using this
+  -- Therefore `M ≡ 1 (mod 8)`.
+  have hprod : (M : ZMod 8) = 1 := by
+    conv_lhs => rw [← Nat.prod_primeFactorsList (n := M) (by omega)]
+    rw [Nat.cast_list_prod]
+    exact List.prod_eq_one hall
+  -- But `M ≡ 7 (mod 8)`.
+  have hM7cast : (M : ZMod 8) = 7 := by
+    have : (M : ZMod 8) = ((M % 8 : ℕ) : ZMod 8) := (ZMod.natCast_mod M 8).symm
+    rw [hM7] at this
+    simpa using this
+  rw [hM7cast] at hprod
+  exact absurd hprod (by decide)
+
+/-- **Main theorem.** There are infinitely many primes `≡ 7 (mod 8)`.
+
+Proof by Euclid: were the set finite, take `a = 3 · ∏(all such primes)`. Then `a`
+is odd and `≥ 3`, so `a² − 2` has a prime factor `p ≡ 7 (mod 8)` by
+`exists_prime_factor_seven_mod_eight`. That `p` is on the list, hence divides `a`,
+hence divides `2` — impossible for an odd prime. -/
+theorem primes_seven_mod_eight_infinite :
+    {p : ℕ | p.Prime ∧ p % 8 = 7}.Infinite := by
+  by_contra hcon
+  rw [Set.not_infinite] at hcon
+  set S := hcon.toFinset with hSdef
+  have hmemS : ∀ q, q ∈ S ↔ q.Prime ∧ q % 8 = 7 := by
+    intro q; rw [Set.Finite.mem_toFinset]; rfl
+  set a := 3 * ∏ q ∈ S, q with hadef
+  -- Each factor is odd, so `a` is odd.
+  have ha_odd : Odd a := by
+    rw [Nat.odd_iff]
+    by_contra h
+    have hdvd : (2 : ℕ) ∣ a := Nat.dvd_of_mod_eq_zero (by omega)
+    rw [hadef] at hdvd
+    rcases (Nat.Prime.dvd_mul Nat.prime_two).mp hdvd with h3 | hprod
+    · norm_num at h3
+    · obtain ⟨q, hqS, hq2⟩ := (Prime.dvd_finset_prod_iff Nat.prime_two.prime _).mp hprod
+      have hq := (hmemS q).mp hqS
+      have hqeq : q = 2 := ((Nat.prime_dvd_prime_iff_eq Nat.prime_two hq.1).mp hq2).symm
+      have h7 := hq.2
+      omega
+  have ha3 : 3 ≤ a := by
+    have hp1 : 1 ≤ ∏ q ∈ S, q :=
+      Finset.one_le_prod' (fun q hq => ((hmemS q).mp hq).1.one_lt.le)
+    omega
+  obtain ⟨p, hpp, hpd, hp7⟩ := exists_prime_factor_seven_mod_eight ha_odd ha3
+  -- `p` is on the list, so `p ∣ a`.
+  have hpS : p ∈ S := (hmemS p).mpr ⟨hpp, hp7⟩
+  have hp_dvd_a : p ∣ a := by
+    rw [hadef]; exact Dvd.dvd.mul_left (Finset.dvd_prod_of_mem _ hpS) 3
+  have ha2 : 2 ≤ a ^ 2 := by nlinarith [ha3]
+  -- `p ∣ a²` and `p ∣ a² − 2`, so `p ∣ 2`, forcing `p = 2`, contradicting `p ≡ 7`.
+  have hp_dvd_sq : p ∣ a ^ 2 := Dvd.dvd.pow hp_dvd_a (by norm_num)
+  have hp_dvd_two : p ∣ 2 := by
+    have := Nat.dvd_sub hp_dvd_sq hpd
+    rwa [Nat.sub_sub_self ha2] at this
+  have : p = 2 := (Nat.prime_dvd_prime_iff_eq hpp Nat.prime_two).mp hp_dvd_two
+  omega
+
+/-- Restatement: there is no largest prime `≡ 7 (mod 8)`. -/
+theorem no_largest_prime_seven_mod_eight :
+    ∀ n, ∃ p, p.Prime ∧ p % 8 = 7 ∧ n < p := by
+  intro n
+  have h := primes_seven_mod_eight_infinite
+  obtain ⟨p, hp, hlt⟩ := (Set.Infinite.exists_gt h) n
+  exact ⟨p, hp.1, hp.2, hlt⟩
+
+end InfinitudePrimes4k3OQ01OQ01

--- a/src/data/proofs/infinitude-primes-4k3-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "header",
+    "proofId": "infinitude-primes-4k3-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "concept",
+    "title": "Open Question and the x² − 2 Mechanism",
+    "content": "The file answers OQ-01-OQ-01: prove Set.Infinite {p prime | p ≡ 7 (mod 8)} elementarily, without Dirichlet's theorem. The header spells out the three-part mechanism for M = a² − 2 with a odd: (1) M ≡ 7 (mod 8) because an odd square is ≡ 1 (mod 8); (2) every prime factor p of M makes 2 = a² a quadratic residue, so p ≡ ±1 (mod 8); (3) a product of numbers all ≡ 1 (mod 8) is ≡ 1, so since M ≡ 7 some factor must be ≡ 7. A Euclid construction then makes the class infinite. The only nontrivial import is Mathlib's supplementary reciprocity law for 2.",
+    "mathContext": "The class $7 \\pmod 8$ equals $-1 \\pmod 8$; among the odd classes mod 8 it is the one where $2$ is a QR but $-1$ and $-2$ are not, which is why the form $x^2 - 2$ (not $x^2 + 1$ or $x^2 + 2$) is the right vehicle.",
+    "significance": "essential",
+    "relatedConcepts": ["Dirichlet's theorem", "quadratic residues", "Euclid's argument", "residue classes mod 8"],
+    "prerequisites": ["modular arithmetic", "infinitude of primes"]
+  },
+  {
+    "id": "odd-sq-mod-eight",
+    "proofId": "infinitude-primes-4k3-oq-01-oq-01",
+    "range": { "startLine": 36, "endLine": 44 },
+    "type": "proof-step",
+    "title": "odd_sq_mod_eight: An Odd Square Is ≡ 1 (mod 8)",
+    "content": "Writing a = 2k + 1, one has a² = 4·k(k+1) + 1. Because k and k+1 are consecutive, their product is even (Nat.even_mul_succ_self gives k(k+1) = 2t), so a² = 8t + 1 and a² % 8 = 1, closed by omega. This is precisely why M = a² − 2 is ≡ 7 (mod 8): the construction lands in the target class for free.",
+    "mathContext": "This refines 'an odd square is $\\equiv 1 \\pmod 4$' to modulus 8; the evenness of $k(k+1)$ supplies the extra factor of 2.",
+    "significance": "supporting",
+    "relatedConcepts": ["odd squares", "parity of consecutive integers", "modular arithmetic"],
+    "prerequisites": ["Nat.even_mul_succ_self", "omega tactic"]
+  },
+  {
+    "id": "prime-factor-two-qr",
+    "proofId": "infinitude-primes-4k3-oq-01-oq-01",
+    "range": { "startLine": 46, "endLine": 62 },
+    "type": "proof-step",
+    "title": "prime_factor_two_qr: The Quadratic-Residue Step",
+    "content": "The single place any residue theory enters. From p ∣ a² − 2 and a² ≥ 2, ZMod.natCast_eq_zero_iff plus Nat.cast_sub give (a : ZMod p)² − 2 = 0, i.e. (a : ZMod p)² = 2, so IsSquare (2 : ZMod p). Mathlib's ZMod.exists_sq_eq_two_iff — the supplementary law (2/p) = (−1)^((p²−1)/8) — then yields p % 8 = 1 or 7. The natural-number subtraction a² − 2 is handled cleanly by requiring a² ≥ 2 so that Nat.cast_sub applies.",
+    "mathContext": "$2$ is a quadratic residue modulo an odd prime $p$ if and only if $p \\equiv \\pm 1 \\pmod 8$. Equivalently, the Legendre symbol $\\left(\\tfrac{2}{p}\\right) = (-1)^{(p^2-1)/8}$.",
+    "significance": "essential",
+    "relatedConcepts": ["quadratic residue", "Legendre symbol", "supplementary reciprocity law", "ZMod p"],
+    "prerequisites": ["ZMod.exists_sq_eq_two_iff", "ZMod.natCast_eq_zero_iff", "Nat.cast_sub"]
+  },
+  {
+    "id": "core-parity",
+    "proofId": "infinitude-primes-4k3-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 108 },
+    "type": "key-insight",
+    "title": "exists_prime_factor_seven_mod_eight: Forcing a Factor ≡ 7 (mod 8)",
+    "content": "The crux. For odd a ≥ 3, M = a² − 2 is ≥ 2 and ≡ 7 (mod 8). Argue by contradiction: suppose no prime factor is ≡ 7 (mod 8). Each prime factor is odd (M is odd) and, by prime_factor_two_qr, ≡ 1 or 7 (mod 8), hence ≡ 1 (mod 8) — so it casts to 1 in ZMod 8. Reconstituting M from its factorization (Nat.prod_primeFactorsList) and casting into ZMod 8, the product of all-1's is 1, so (M : ZMod 8) = 1. But (M : ZMod 8) = 7 from M % 8 = 7. Since 1 ≠ 7 in ZMod 8, the assumption fails: some prime factor is ≡ 7 (mod 8).",
+    "mathContext": "The classes $\\{1, 7\\} = \\{\\pm 1\\}$ form the order-2 subgroup of $(\\mathbb{Z}/8)^\\times$. Reducing $M$'s factorization in $\\mathbb{Z}/8$ turns 'product of factors' into a product in this group; landing at $7 = -1$ forces an odd number of factors (with multiplicity) to be $\\equiv 7$.",
+    "significance": "essential",
+    "relatedConcepts": ["unique factorization", "parity argument", "ZMod 8", "prime factorization product"],
+    "prerequisites": ["Nat.prod_primeFactorsList", "List.prod_eq_one", "Nat.prime_of_mem_primeFactorsList"]
+  },
+  {
+    "id": "euclid-construction",
+    "proofId": "infinitude-primes-4k3-oq-01-oq-01",
+    "range": { "startLine": 110, "endLine": 153 },
+    "type": "proof-step",
+    "title": "primes_seven_mod_eight_infinite: The Euclid Construction",
+    "content": "The main theorem. Suppose {p prime | p ≡ 7 (mod 8)} were finite, with S its finset. Set a = 3·∏(q ∈ S). Each q is an odd prime, so 2 ∤ ∏ and 2 ∤ 3, giving a odd; and ∏ ≥ 1 gives a ≥ 3. Then exists_prime_factor_seven_mod_eight yields a prime p ∣ a² − 2 with p ≡ 7 (mod 8). Being ≡ 7 (mod 8) and prime, p ∈ S, so p ∣ ∏ ∣ a, hence p ∣ a². From p ∣ a² and p ∣ a² − 2 we get p ∣ 2 (Nat.dvd_sub + Nat.sub_sub_self), so p = 2 — contradicting p ≡ 7 (mod 8).",
+    "mathContext": "The Euclid coprimality trick: a prime already on the list would divide both $a^2$ and $a^2 - 2$, hence their difference $2$. The factor $3$ guarantees $a \\ge 3$ (so $a^2 - 2 \\ge 7$) even when $S$ is empty.",
+    "significance": "essential",
+    "relatedConcepts": ["Euclid's argument", "Finset.prod", "coprimality", "proof by contradiction"],
+    "prerequisites": ["Set.not_infinite", "Prime.dvd_finset_prod_iff", "Finset.dvd_prod_of_mem", "Nat.dvd_sub"]
+  },
+  {
+    "id": "corollary",
+    "proofId": "infinitude-primes-4k3-oq-01-oq-01",
+    "range": { "startLine": 155, "endLine": 163 },
+    "type": "concept",
+    "title": "no_largest_prime_seven_mod_eight: Unbounded Witnesses",
+    "content": "The order-theoretic restatement: for every n there is a prime p > n with p ≡ 7 (mod 8), obtained from the Set.Infinite conclusion via Set.Infinite.exists_gt. This is the form most directly usable as a 'given any bound, produce a larger prime in the class' oracle.",
+    "mathContext": "For a subset of $\\mathbb{N}$, being infinite is equivalent to being unbounded above; `Set.Infinite.exists_gt` extracts an explicit witness beyond any given $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["unbounded sets", "Set.Infinite.exists_gt"],
+    "prerequisites": ["Set.Infinite"]
+  }
+]

--- a/src/data/proofs/infinitude-primes-4k3-oq-01-oq-01/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-01-oq-01/meta.json
@@ -1,0 +1,241 @@
+{
+  "id": "infinitude-primes-4k3-oq-01-oq-01",
+  "title": "Infinitely Many Primes ≡ 7 (mod 8) via the x² − 2 Quadratic-Residue Euclid Argument",
+  "slug": "infinitude-primes-4k3-oq-01-oq-01",
+  "description": "Answers OQ-01-OQ-01 from infinitude-primes-4k3: proves Set.Infinite {p prime | p ≡ 7 (mod 8)} by a purely elementary, L-function-free Euclid argument, removing the dependence on Dirichlet's theorem for this residue class. The engine is a single classical quadratic-residue fact (Mathlib's ZMod.exists_sq_eq_two_iff): 2 is a square mod an odd prime p iff p ≡ ±1 (mod 8). For odd a, every prime factor of M = a² − 2 makes 2 = a² a square, hence lies in {1, 7} mod 8; but M ≡ 7 (mod 8), and a product of numbers all ≡ 1 (mod 8) is ≡ 1 (mod 8), so M must have a prime factor ≡ 7 (mod 8). Feeding a = 3·∏(known primes ≡ 7) into this produces a new such prime, so the class is infinite. 5 theorems/lemmas, 0 new axioms, 0 sorries, 163 lines.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions",
+    "date": "formalized 2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "elementary",
+      "primes",
+      "modular-arithmetic",
+      "quadratic-reciprocity",
+      "quadratic-residues"
+    ],
+    "proofRepoPath": "Proofs/InfinitudePrimes4k3OQ01OQ01.lean",
+    "parentProofId": "infinitude-primes-4k3-oq-01",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "newAxiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.exists_sq_eq_two_iff",
+        "description": "For an odd prime p, IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7 — the supplementary law of quadratic reciprocity for 2, and the single nontrivial ingredient of the whole proof.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod n) = 0 ↔ n ∣ a — bridges the natural-number divisibility p ∣ a² − 2 to the equation (a : ZMod p)² = 2.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.prod_primeFactorsList",
+        "description": "n ≠ 0 → n.primeFactorsList.prod = n — reconstitutes M from its prime factorization, used to reduce M mod 8 to the product of its prime factors mod 8.",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Prime.dvd_finset_prod_iff",
+        "description": "For prime p, p ∣ ∏ i ∈ s, f i ↔ ∃ i ∈ s, p ∣ f i — extracts the offending factor in the Euclid step (a new prime cannot already divide the product of the assumed-complete list).",
+        "module": "Mathlib.Algebra.BigOperators.Associated"
+      },
+      {
+        "theorem": "Nat.even_mul_succ_self",
+        "description": "Even (k · (k + 1)) — the parity of consecutive integers, giving a² ≡ 1 (mod 8) for odd a.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "odd_sq_mod_eight: an odd natural number has square ≡ 1 (mod 8) — the arithmetic that makes a² − 2 ≡ 7 (mod 8)",
+      "prime_factor_two_qr: any odd prime dividing a² − 2 is ≡ 1 or 7 (mod 8), the one place quadratic reciprocity enters",
+      "exists_prime_factor_seven_mod_eight: for odd a ≥ 3, the number a² − 2 has a prime factor ≡ 7 (mod 8) — the core parity/factorization argument",
+      "primes_seven_mod_eight_infinite: {p prime | p ≡ 7 (mod 8)} is Set.Infinite — direct answer to OQ-01-OQ-01, by a Euclid construction with a = 3·∏(known primes ≡ 7)",
+      "no_largest_prime_seven_mod_eight: for every n there is a prime p > n with p ≡ 7 (mod 8)"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 163,
+    "assumptions": "0 new axioms. Depends only on propext, Classical.choice, Quot.sound (the standard Lean/Mathlib foundational axioms, which do not count as assumptions). No sorryAx, no Lean.ofReduceBool — verified by #print axioms.",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The infinitude of primes in a residue class a (mod q) with gcd(a, q) = 1 is **Dirichlet's theorem** (1837), whose general proof needs L-functions and their non-vanishing at s = 1. Many *individual* classes, however, admit fully elementary Euclid-style proofs. The classes detected by a quadratic residue are the historically first examples after Euclid: ≡ 1 (mod 4) via x² + 1 (−1 is a QR), ≡ 3 (mod 4) via a product argument. The residue class ≡ 7 (mod 8) — equivalently ≡ −1 (mod 8) — is the subtlest of the four odd classes mod 8, because none of the usual single-residue tricks pin it down directly: for p ≡ 7 (mod 8), 2 *is* a QR while −1 and −2 are *not*.\n\nThe classical elementary route uses the form x² − 2, whose odd prime divisors are exactly the primes with 2 a quadratic residue, i.e. p ≡ ±1 (mod 8). The extra idea needed to isolate ≡ 7 from ≡ 1 is a **parity argument on the factorization**: since an odd square is ≡ 1 (mod 8), the number a² − 2 is ≡ 7 (mod 8), and a product of factors all ≡ 1 (mod 8) can never be ≡ 7, so at least one factor is ≡ 7. This file formalizes exactly that argument.",
+    "problemStatement": "**Open Question (infinitude-primes-4k3-OQ-01-OQ-01)**: The parent chain proved infinitely many primes in several residue classes (≡ 3 mod 4, ≡ 1 mod 4, ≡ −1 mod 12 and mod 24) by Euclid/Dirichlet-specialization arguments. Can a purely elementary Euclidean argument — using only that 2 is a quadratic residue mod p iff p ≡ ±1 (mod 8) — prove `Set.Infinite {p prime | p ≡ 7 (mod 8)}`, removing the dependence on Dirichlet's theorem for this class?\n\n**Answer**: Yes. For odd a, put M = a² − 2. An odd square is ≡ 1 (mod 8), so M ≡ 7 (mod 8). Every prime p ∣ M satisfies (a)² ≡ 2 (mod p), so 2 is a QR mod p and p ≡ 1 or 7 (mod 8). A product of numbers all ≡ 1 (mod 8) is ≡ 1 (mod 8); since M ≡ 7, some prime factor is ≡ 7 (mod 8). Taking a = 3·∏(all assumed-complete primes ≡ 7 mod 8) yields a new such prime coprime to the list, contradicting completeness.",
+    "proofStrategy": "**Step 1** `odd_sq_mod_eight`: writing a = 2k + 1, a² = 4·k(k+1) + 1, and k(k+1) is even (Nat.even_mul_succ_self), so a² = 8t + 1, i.e. a² ≡ 1 (mod 8). Hence M = a² − 2 ≡ 7 (mod 8).\n\n**Step 2** `prime_factor_two_qr`: reduce p ∣ a² − 2 to (a : ZMod p)² = 2 (via ZMod.natCast_eq_zero_iff and Nat.cast_sub), exhibiting 2 as a square in ZMod p. Mathlib's `ZMod.exists_sq_eq_two_iff` then gives p % 8 ∈ {1, 7}.\n\n**Step 3** `exists_prime_factor_seven_mod_eight`: assume, for contradiction, that no prime factor of M is ≡ 7 (mod 8). Every prime factor is odd (M is odd) and by Step 2 lies in {1, 7} mod 8, hence is ≡ 1 (mod 8), so casts to 1 in ZMod 8. Then (M : ZMod 8) = ∏(factors) = 1 (Nat.prod_primeFactorsList + List.prod_eq_one), contradicting (M : ZMod 8) = 7 from Step 1.\n\n**Step 4** `primes_seven_mod_eight_infinite`: Euclid. If the set were finite, let a = 3·∏(its elements). Each element is odd so a is odd, and a ≥ 3, so Step 3 gives a prime p ∣ a² − 2 with p ≡ 7 (mod 8). Then p is on the list, so p ∣ ∏ ∣ a, so p ∣ gcd(a², a² − 2) ∣ 2, forcing p = 2 — impossible for a prime ≡ 7 (mod 8).",
+    "keyInsights": [
+      "**Why x² − 2 and not x² + 2**: the prime divisors of x² − 2 are exactly the odd primes with 2 a quadratic residue, i.e. p ≡ ±1 (mod 8). This selects the pair {1, 7}; the parity argument then separates 7 from 1. (x² + 2 would select {1, 3} mod 8 via −2, the wrong pair for this class.)",
+      "**The parity argument is the whole point**: knowing every prime factor is ≡ 1 or 7 (mod 8) is not enough — one must *force* a factor ≡ 7. Since {1, 7} is the order-2 subgroup {±1} of (ℤ/8)ˣ and M ≡ 7 = −1 lies in the nontrivial coset-representative, an odd number of factors (counted with multiplicity) must be ≡ 7. The clean Lean encoding is: cast the factorization to ZMod 8; if all factors were 1 the product would be 1, not 7.",
+      "**An odd square is ≡ 1 (mod 8)**: this elementary fact (from k(k+1) even) is what makes M ≡ 7 (mod 8) and is the reason the construction lands in the class ≡ 7 rather than ≡ 1. It is the mod-8 refinement of 'an odd square is ≡ 1 (mod 4)'.",
+      "**No L-functions, no Dirichlet, no Frobenius**: the only imported number theory beyond arithmetic is the supplementary reciprocity law for 2 (ZMod.exists_sq_eq_two_iff). Everything else — the parity of k(k+1), the factorization product, the Euclid coprimality — is fully elementary. This is exactly the kind of individual class that predates and sidesteps the analytic Dirichlet machinery.",
+      "**Contrast with the cyclotomic siblings**: the classes ≡ 1 (mod q) are handled by the q-th cyclotomic polynomial and a multiplicative-order argument (see infinitude-primes-4k3-oq-03-oq-01 for q = 3). The class ≡ 7 (mod 8) = ≡ −1 (mod 8) is *not* of the form ≡ 1 (mod q); it needs the quadratic-residue form x² − 2 together with the mod-8 parity refinement, a genuinely different (and older) mechanism."
+    ],
+    "prerequisites": [
+      "Euclid's infinitude of primes (build a number with a prime factor outside any finite set)",
+      "Modular arithmetic and the ring ZMod p for p prime",
+      "Quadratic residues and the supplementary reciprocity law: 2 is a QR mod p iff p ≡ ±1 (mod 8)",
+      "Unique factorization into primes (Nat.primeFactorsList and its product)",
+      "The elementary fact that an odd square is ≡ 1 (mod 8)"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "prime_factor_two_qr",
+      "type": "core",
+      "statement": "$\\forall p, a,\\; p$ prime $\\wedge\\, p \\neq 2 \\wedge p \\mid a^2 - 2 \\wedge 2 \\le a^2 \\;\\Rightarrow\\; p \\equiv 1 \\text{ or } 7 \\pmod 8$",
+      "significance": "The quadratic-residue heart. A prime p ∣ a² − 2 makes (a : ZMod p)² = 2, so 2 is a square mod p; the supplementary reciprocity law ZMod.exists_sq_eq_two_iff then forces p ≡ ±1 (mod 8). This is the sole place any reciprocity/residue theory enters the proof.",
+      "description": "Any odd prime dividing a² − 2 is ≡ 1 or 7 (mod 8), because it makes 2 a quadratic residue."
+    },
+    {
+      "name": "exists_prime_factor_seven_mod_eight",
+      "type": "core",
+      "statement": "$\\forall a,\\; a \\text{ odd} \\wedge a \\ge 3 \\;\\Rightarrow\\; \\exists p,\\; p$ prime $\\wedge\\, p \\mid a^2 - 2 \\wedge p \\equiv 7 \\pmod 8$",
+      "significance": "The parity/factorization argument that isolates the class ≡ 7 from ≡ 1. Since a² − 2 ≡ 7 (mod 8) while every prime factor is ≡ 1 or 7, not all factors can be ≡ 1 (their product would be ≡ 1), so some factor is ≡ 7. Formalized by casting the prime factorization into ZMod 8.",
+      "description": "For odd a ≥ 3, the number a² − 2 has a prime factor ≡ 7 (mod 8)."
+    },
+    {
+      "name": "primes_seven_mod_eight_infinite",
+      "type": "main",
+      "statement": "$\\{p \\mid p \\text{ prime} \\wedge p \\equiv 7 \\pmod 8\\}$ is $\\texttt{Set.Infinite}$",
+      "significance": "The direct answer to OQ-01-OQ-01: infinitely many primes ≡ 7 (mod 8) by a purely elementary Euclid argument, with no appeal to Dirichlet's theorem or L-functions. If the set were finite, a = 3·∏(its elements) is odd and ≥ 3, so a² − 2 supplies a prime ≡ 7 (mod 8) that is coprime to the list — a contradiction.",
+      "description": "There are infinitely many primes ≡ 7 (mod 8), proved elementarily via x² − 2 and a mod-8 parity argument."
+    },
+    {
+      "name": "no_largest_prime_seven_mod_eight",
+      "type": "corollary",
+      "statement": "$\\forall n,\\; \\exists p,\\; p$ prime $\\wedge\\, p \\equiv 7 \\pmod 8 \\wedge n < p$",
+      "significance": "The explicit unbounded-witness restatement of infinitude, obtained from Set.Infinite via Set.Infinite.exists_gt.",
+      "description": "For every n there is a prime p > n with p ≡ 7 (mod 8)."
+    },
+    {
+      "name": "odd_sq_mod_eight",
+      "type": "supporting",
+      "statement": "$a \\text{ odd} \\;\\Rightarrow\\; a^2 \\equiv 1 \\pmod 8$",
+      "significance": "The arithmetic fact that places the construction in the class ≡ 7 (mod 8): with a odd, a² ≡ 1 so a² − 2 ≡ 7 (mod 8). Proved from a = 2k + 1 and the evenness of k(k + 1).",
+      "description": "An odd natural number has square ≡ 1 (mod 8)."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Open Question Statement",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "States OQ-01-OQ-01 and lays out the mechanism: for odd a, M = a² − 2 is ≡ 7 (mod 8), its prime factors are ≡ ±1 (mod 8), and a parity argument forces a factor ≡ 7. Imports Mathlib (for ZMod.exists_sq_eq_two_iff) and opens BigOperators for the Euclid product.",
+      "mathContext": "The single nontrivial import is the supplementary quadratic-reciprocity law for 2; everything else is elementary arithmetic and unique factorization."
+    },
+    {
+      "id": "odd-sq",
+      "title": "odd_sq_mod_eight: An Odd Square Is ≡ 1 (mod 8)",
+      "startLine": 36,
+      "endLine": 44,
+      "summary": "Writes a = 2k + 1, expands a² = 4·k(k+1) + 1, and uses Nat.even_mul_succ_self (k(k+1) = 2t) to get a² = 8t + 1, closed by omega. This is why a² − 2 ≡ 7 (mod 8).",
+      "mathContext": "The mod-8 refinement of 'odd² ≡ 1 (mod 4)'; the evenness of consecutive integers upgrades the modulus from 4 to 8."
+    },
+    {
+      "id": "qr-step",
+      "title": "prime_factor_two_qr: The Quadratic-Residue Step",
+      "startLine": 46,
+      "endLine": 62,
+      "summary": "Reduces p ∣ a² − 2 to (a : ZMod p)² = 2 via ZMod.natCast_eq_zero_iff and Nat.cast_sub, exhibiting IsSquare (2 : ZMod p), then applies ZMod.exists_sq_eq_two_iff to conclude p % 8 ∈ {1, 7}.",
+      "mathContext": "The only appeal to residue theory: 2 is a quadratic residue mod an odd prime p iff p ≡ ±1 (mod 8)."
+    },
+    {
+      "id": "core-lemma",
+      "title": "exists_prime_factor_seven_mod_eight: The Parity Argument",
+      "startLine": 64,
+      "endLine": 108,
+      "summary": "Proves M = a² − 2 has a prime factor ≡ 7 (mod 8) for odd a ≥ 3. By contradiction: every prime factor is ≡ 1 or 7 (mod 8) and, if none is ≡ 7, all are ≡ 1, so cast into ZMod 8 the whole factorization is a product of 1's, giving (M : ZMod 8) = 1 — contradicting (M : ZMod 8) = 7.",
+      "mathContext": "Encodes 'a product of numbers ≡ 1 (mod 8) is ≡ 1 (mod 8)' via Nat.prod_primeFactorsList and List.prod_eq_one in ZMod 8; the subgroup {1, 7} = {±1} of (ℤ/8)ˣ makes 7 the nontrivial class."
+    },
+    {
+      "id": "euclid",
+      "title": "primes_seven_mod_eight_infinite: The Euclid Construction",
+      "startLine": 110,
+      "endLine": 153,
+      "summary": "Assumes the set finite, forms a = 3·∏(its elements), proves a odd (each element is an odd prime; 2 ∤ a) and a ≥ 3, extracts a prime p ∣ a² − 2 with p ≡ 7 (mod 8), notes p is on the list so p ∣ a, hence p ∣ 2, forcing p = 2 — contradiction.",
+      "mathContext": "The classical Euclid coprimality trick: a new prime in the class cannot divide the product of the supposedly complete list, since it would then have to divide the small correction term 2."
+    },
+    {
+      "id": "corollary",
+      "title": "no_largest_prime_seven_mod_eight: Unbounded Witnesses",
+      "startLine": 155,
+      "endLine": 163,
+      "summary": "Repackages Set.Infinite as: for every n there is a prime p > n with p ≡ 7 (mod 8), via Set.Infinite.exists_gt.",
+      "mathContext": "The order-theoretic restatement of infinitude for an unbounded subset of ℕ."
+    }
+  ],
+  "conclusion": {
+    "summary": "There are infinitely many primes ≡ 7 (mod 8), proved by a fully elementary Euclid argument built on the single quadratic-residue fact that 2 is a square mod p iff p ≡ ±1 (mod 8). The construction M = a² − 2 (odd a) lives in the class ≡ 7 (mod 8), its prime factors are constrained to ≡ ±1 (mod 8), and a mod-8 parity argument on the factorization forces a factor ≡ 7. This removes the dependence on Dirichlet's theorem for this residue class. 0 axioms, 0 sorries, verified by #print axioms.",
+    "implications": [
+      "Completes the elementary picture mod 8 for the quadratic-residue-detectable class ≡ 7 (mod 8) = ≡ −1 (mod 8), complementing the cyclotomic ≡ 1 (mod q) family (e.g. infinitude-primes-4k3-oq-03-oq-01 for q = 3).",
+      "Demonstrates the parity-on-factorization technique for isolating a single class from a residue-pair {±1} that a quadratic-residue condition selects — reusable for other ± classes.",
+      "Provides a self-contained, L-function-free instance of Dirichlet's theorem for (q, a) = (8, 7), one of the harder classes to reach elementarily."
+    ],
+    "openQuestions": []
+  },
+  "references": [
+    {
+      "type": "research-paper",
+      "citation": "Dirichlet, P.G.L. (1837). \"Beweis des Satzes, dass jede unbegrenzte arithmetische Progression, deren erstes Glied und Differenz ganze Zahlen ohne gemeinschaftlichen Factor sind, unendlich viele Primzahlen enthält.\" Abhandlungen der Königlich Preussischen Akademie der Wissenschaften, 45-81.",
+      "relevance": "The general theorem on primes in arithmetic progressions, of which 'infinitely many primes ≡ 7 (mod 8)' is the special case (q, a) = (8, 7) proved here elementarily. Dirichlet's proof uses L-functions; this file avoids all analytic machinery via the quadratic-residue form x² − 2 and a parity argument."
+    },
+    {
+      "type": "textbook",
+      "citation": "Hardy, G.H., and Wright, E.M. (2008). \"An Introduction to the Theory of Numbers,\" 6th ed., revised by D.R. Heath-Brown and J.H. Silverman. Oxford University Press. §2.2 (Euclid's proof and variants), §6.5–6.6 (quadratic residues), §16.1.",
+      "relevance": "Standard reference for the Euclid-style elementary infinitude proofs in special residue classes and for the supplementary reciprocity law giving 2 as a QR precisely for p ≡ ±1 (mod 8), which is the sole nontrivial input here."
+    },
+    {
+      "type": "textbook",
+      "citation": "Ireland, K., and Rosen, M. (1990). \"A Classical Introduction to Modern Number Theory,\" 2nd ed. Springer GTM 84. Ch. 5 (Quadratic reciprocity), §5.2 (the supplementary laws for −1 and 2).",
+      "relevance": "Develops the quadratic-reciprocity framework, including the value of the Legendre symbol (2/p) = (−1)^((p²−1)/8), i.e. 2 is a QR iff p ≡ ±1 (mod 8). This is exactly Mathlib's ZMod.exists_sq_eq_two_iff used in prime_factor_two_qr."
+    },
+    {
+      "type": "research-paper",
+      "citation": "Murty, M. Ram (1988). \"Primes in certain arithmetic progressions.\" Functiones et Approximatio Commentarii Mathematici, 35, 249-259.",
+      "relevance": "Characterizes which arithmetic progressions {a + kq} admit Euclid-style elementary infinitude proofs: essentially those with a² ≡ 1 (mod q). The class a = 7 mod 8 satisfies 7² = 49 ≡ 1 (mod 8), so it qualifies — consistent with the elementary proof formalized here."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity\" — `ZMod.exists_sq_eq_two_iff`. (accessed 2026)",
+      "relevance": "Supplies the supplementary reciprocity law for 2: IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7 for odd primes p. This single lemma is the only nontrivial number-theoretic input to the entire proof."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.NumberTheory.PrimesCongruentOne\" and quadratic-residue infrastructure. (accessed 2026)",
+      "relevance": "Mathlib provides the cyclotomic ≡ 1 (mod k) infinitude theorem but not a general elementary treatment of the quadratic-residue-detectable classes like ≡ 7 (mod 8); this file supplies the explicit, self-contained x² − 2 instance with the mod-8 parity argument spelled out."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "infinitude-primes-4k3-oq-01",
+      "relationship": "parent",
+      "description": "The Dirichlet-specialization entry (≡ −1 mod 12 and mod 24) whose open-question list called for an elementary, L-function-free proof for the class ≡ 7 (mod 8); this file answers it."
+    },
+    {
+      "proofId": "infinitude-primes-4k3",
+      "relationship": "ancestor",
+      "description": "The base mod-4 entry (≡ 3 mod 4 via N = 4(n+1)! − 1) whose OQ-01 chain this file extends to the quadratic-residue mod-8 setting."
+    },
+    {
+      "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "The cyclotomic counterpart: infinitely many primes ≡ 1 (mod 3) via Φ₃ and a multiplicative-order argument. Together they illustrate the two elementary mechanisms — cyclotomic (for ≡ 1 mod q) versus quadratic-residue + parity (for the ±1 classes mod 8)."
+    },
+    {
+      "proofId": "infinitude-primes",
+      "relationship": "ancestor",
+      "description": "Euclid's original infinitude of primes; the Euclid construction here (a = 3·∏ of known primes) adapts its 'build a number with a new prime factor' skeleton."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/InfinitudePrimes4k3OQ01OQ01.lean",
+    "theoremCount": 5,
+    "axiomCount": 0,
+    "sorryCount": 0
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers open question **infinitude-primes-4k3-oq-01-oq-01**: proves `Set.Infinite {p prime | p ≡ 7 (mod 8)}` by a purely elementary, **L-function-free Euclid argument**, removing the dependence on Dirichlet's theorem for this residue class.

The whole proof rests on a single classical quadratic-residue fact from Mathlib (`ZMod.exists_sq_eq_two_iff`): for an odd prime `p`, `2` is a square mod `p` iff `p ≡ ±1 (mod 8)`.

## Mechanism (`M = a² − 2` for odd `a`)

- **`odd_sq_mod_eight`** — an odd square is `≡ 1 (mod 8)`, so `M ≡ 7 (mod 8)`.
- **`prime_factor_two_qr`** — every prime `p ∣ M` makes `2 = a²` a quadratic residue, so `p ≡ ±1 (mod 8)`. *(the sole reciprocity input)*
- **`exists_prime_factor_seven_mod_eight`** — a product of factors all `≡ 1 (mod 8)` is `≡ 1`, but `M ≡ 7`, so some prime factor is `≡ 7 (mod 8)`. Formalized by casting the prime factorization into `ZMod 8`.
- **`primes_seven_mod_eight_infinite`** — Euclid: if the class were finite, `a = 3·∏(known primes ≡ 7)` yields a new such prime coprime to the list.
- **`no_largest_prime_seven_mod_eight`** — unbounded-witness restatement.

## Verification

- **0 axioms**: `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.
- **5 theorems/lemmas, 0 defs, 0 sorries, 163 lines.**
- Single-file build (`lake env lean`) passes clean with no warnings.

## Files

- `proofs/Proofs/InfinitudePrimes4k3OQ01OQ01.lean` (new)
- `src/data/proofs/infinitude-primes-4k3-oq-01-oq-01/meta.json` (new)
- `src/data/proofs/infinitude-primes-4k3-oq-01-oq-01/annotations.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)