### PR TITLE
research(birthday-problem-oq-02-oq-01-oq-02-oq-02): quantitative TV lower bound on collision excess [0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ02OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BirthdayProblemOQ02OQ01OQ02OQ02.lean
@@ -1,0 +1,181 @@
+import Proofs.BirthdayProblemOQ02OQ01OQ02
+import Mathlib
+
+/-
+# A Quantitative Non-Uniform Birthday Bound: Bias Raises Collisions at Least Quadratically in Total Variation (OQ-02-OQ-01-OQ-02-OQ-02)
+
+## What This Proves
+The parent file (`BirthdayProblemOQ02OQ01OQ02`) shows that among all probability
+distributions `p = (p₀, …, p_{d-1})` on `d` outcomes, the uniform distribution
+*minimizes* the two-draw collision probability
+
+  C(p) = ∑ᵢ pᵢ²   ,   with   C(p) ≥ 1/d   and equality iff `p` is uniform.
+
+That is a *qualitative* extremality statement: any bias raises the collision
+probability, but by how much? This file supplies the **quantitative** answer,
+the open question flagged by the parent:
+
+> Quantify how much a given bias raises the collision probability: bound
+> `∑ pᵢ² − 1/d` below in terms of the total-variation distance of `p` from
+> uniform.
+
+Writing the total-variation distance from the uniform law `u = (1/d, …, 1/d)`
+
+  `dTV(p, u) = ½ ∑ᵢ |pᵢ − 1/d|`,
+
+we prove the sharp-in-order lower bound
+
+  **`C(p) − 1/d  ≥  (4/d) · dTV(p, u)²`.**
+
+So the collision excess grows at least *quadratically* in the total-variation
+distance from uniform: a distribution that is `ε` away from uniform in total
+variation has collision probability at least `1/d + 4ε²/d`.
+
+## Key Mathematical Idea
+Two ingredients combine:
+
+1. **Variance identity (parent).** `C(p) − 1/d = ∑ᵢ (pᵢ − 1/d)²`, the squared
+   ℓ² distance of `p` from uniform (`sum_sq_sub_one_div_card`).
+
+2. **Cauchy–Schwarz / power-mean (Mathlib).** For the `d` deviations
+   `gᵢ = |pᵢ − 1/d|`,  `(∑ᵢ gᵢ)² ≤ d · ∑ᵢ gᵢ²` (`sq_sum_le_card_mul_sum_sq`).
+   Since `gᵢ² = (pᵢ − 1/d)²` and `∑ᵢ gᵢ = 2·dTV(p,u)`, this reads
+   `4·dTV(p,u)² ≤ d·(C(p) − 1/d)`, which is the claim.
+
+The bound is order-sharp: it becomes an equality (up to the constant) for a
+"two-spike" perturbation of the uniform law, where all the deviation mass sits on
+two coordinates.
+
+## Scope
+- [x] Definition of total-variation distance from uniform `dTV(p, u)`
+- [x] `dTV(p, u) ≥ 0`
+- [x] ℓ¹ form  `∑ᵢ |pᵢ − 1/d| = 2·dTV(p,u)`
+- [x] Quantitative lower bound  `C(p) − 1/d ≥ (4/d)·dTV(p,u)²`
+- [x] Restated as  `C(p) ≥ 1/d + (4/d)·dTV(p,u)²`
+- [x] `dTV(p,u) = 0 ↔ p uniform`, bridging to the parent's equality case
+- [x] The parent's equality `C(p) = 1/d ↔ p uniform`, re-derived through `dTV`
+
+This is a genuine Pinsker-flavored refinement of the parent's extremality: it
+replaces "bias ⇒ more collisions" with an effective, computable lower bound.
+
+## References
+- T. W. Munford, *A note on the uniformity assumption in the birthday problem*,
+  Amer. Statist. 31 (1977).
+- Parent: `BirthdayProblemOQ02OQ01OQ02` (qualitative extremality).
+-/
+
+open Finset
+
+namespace BirthdayNonUniformQuant
+
+open BirthdayNonUniform
+
+variable {d : ℕ}
+
+/-- **Total-variation distance from the uniform law.** For a probability vector
+`p` on `d` outcomes, the total-variation distance to `u = (1/d, …, 1/d)` is
+`½ ∑ᵢ |pᵢ − 1/d|`. -/
+noncomputable def dTVUnif (p : Fin d → ℝ) : ℝ :=
+  (1 / 2) * ∑ i, |p i - 1 / (d : ℝ)|
+
+/-- The ℓ¹ deviation from uniform is twice the total-variation distance. -/
+theorem sum_abs_dev (p : Fin d → ℝ) :
+    ∑ i, |p i - 1 / (d : ℝ)| = 2 * dTVUnif p := by
+  unfold dTVUnif; ring
+
+/-- Total-variation distance is nonnegative. -/
+theorem dTVUnif_nonneg (p : Fin d → ℝ) : 0 ≤ dTVUnif p := by
+  unfold dTVUnif
+  have : (0 : ℝ) ≤ ∑ i, |p i - 1 / (d : ℝ)| :=
+    Finset.sum_nonneg fun i _ => abs_nonneg _
+  positivity
+
+/-- **Quantitative non-uniform birthday bound.** The excess collision
+probability over the uniform value `1/d` is at least `(4/d)` times the square of
+the total-variation distance from uniform:
+
+  `(4/d) · dTV(p,u)² ≤ ∑ᵢ pᵢ² − 1/d`.
+
+Bias raises the collision probability at least *quadratically* in total
+variation. -/
+theorem collision_excess_ge_tv (p : Fin d → ℝ) (hd : 0 < d)
+    (hsum : ∑ i, p i = 1) :
+    4 / (d : ℝ) * dTVUnif p ^ 2 ≤ (∑ i, p i ^ 2) - 1 / (d : ℝ) := by
+  have hd' : (0 : ℝ) < (d : ℝ) := by exact_mod_cast hd
+  -- Cauchy–Schwarz on the deviations `gᵢ = |pᵢ − 1/d|`.
+  have hcs : (∑ i, |p i - 1 / (d : ℝ)|) ^ 2
+      ≤ (d : ℝ) * ∑ i, |p i - 1 / (d : ℝ)| ^ 2 := by
+    have h := sq_sum_le_card_mul_sum_sq (s := (Finset.univ : Finset (Fin d)))
+      (f := fun i => |p i - 1 / (d : ℝ)|)
+    simpa [Finset.card_univ, Fintype.card_fin] using h
+  -- `gᵢ² = (pᵢ − 1/d)²`, and the sum of those is exactly the collision excess.
+  have habs : ∑ i, |p i - 1 / (d : ℝ)| ^ 2 = ∑ i, (p i - 1 / (d : ℝ)) ^ 2 := by
+    apply Finset.sum_congr rfl; intro i _; rw [sq_abs]
+  have hvar : ∑ i, (p i - 1 / (d : ℝ)) ^ 2 = (∑ i, p i ^ 2) - 1 / (d : ℝ) :=
+    (sum_sq_sub_one_div_card p hd hsum).symm
+  -- Assemble: `(2 dTV)² ≤ d · excess`.
+  rw [habs, hvar] at hcs
+  have hL1 : ∑ i, |p i - 1 / (d : ℝ)| = 2 * dTVUnif p := sum_abs_dev p
+  rw [hL1] at hcs
+  -- `(2 dTV)² = 4 dTV²`, so `4 dTV² ≤ d · excess`, i.e. `(4/d) dTV² ≤ excess`.
+  rw [div_mul_eq_mul_div, div_le_iff₀ hd']
+  nlinarith [hcs]
+
+/-- **Restated collision-probability lower bound.** The collision probability is
+at least the uniform value plus a quadratic-in-total-variation surplus:
+
+  `1/d + (4/d)·dTV(p,u)² ≤ ∑ᵢ pᵢ²`. -/
+theorem collision_prob_ge (p : Fin d → ℝ) (hd : 0 < d) (hsum : ∑ i, p i = 1) :
+    1 / (d : ℝ) + 4 / (d : ℝ) * dTVUnif p ^ 2 ≤ ∑ i, p i ^ 2 := by
+  have h := collision_excess_ge_tv p hd hsum
+  linarith
+
+/-- Total-variation distance from uniform vanishes exactly for the uniform law. -/
+theorem dTVUnif_eq_zero_iff (p : Fin d → ℝ) :
+    dTVUnif p = 0 ↔ ∀ i, p i = 1 / (d : ℝ) := by
+  unfold dTVUnif
+  rw [mul_eq_zero]
+  constructor
+  · rintro (h | h)
+    · norm_num at h
+    · intro i
+      have hz := (Finset.sum_eq_zero_iff_of_nonneg
+        (fun j _ => abs_nonneg (p j - 1 / (d : ℝ)))).mp h i (Finset.mem_univ i)
+      have : p i - 1 / (d : ℝ) = 0 := abs_eq_zero.mp hz
+      linarith
+  · intro h
+    right
+    apply Finset.sum_eq_zero
+    intro i _
+    rw [h i]; simp
+
+/-- **Bridge to the parent's equality case.** The collision probability attains
+its uniform minimum `1/d` exactly when the total-variation distance from uniform
+is zero — recovering the parent's "equality iff uniform" through the
+total-variation refinement. -/
+theorem sum_sq_eq_one_div_card_iff_tv (p : Fin d → ℝ) (hd : 0 < d)
+    (hsum : ∑ i, p i = 1) :
+    (∑ i, p i ^ 2) = 1 / (d : ℝ) ↔ dTVUnif p = 0 := by
+  rw [sum_sq_eq_one_div_card_iff p hd hsum, dTVUnif_eq_zero_iff]
+
+section Examples
+
+-- The bound is vacuous-but-true content check: for the uniform law the excess is
+-- exactly `0` and the total-variation distance is `0`, so both sides vanish.
+example (hd : 0 < d) :
+    dTVUnif (fun _ : Fin d => 1 / (d : ℝ)) = 0 :=
+  (dTVUnif_eq_zero_iff _).mpr (fun _ => rfl)
+
+-- A distribution strictly biased away from uniform has strictly positive
+-- collision excess (the quantitative bound with `dTV > 0`).
+example (p : Fin d → ℝ) (hd : 0 < d) (hsum : ∑ i, p i = 1)
+    (hbias : dTVUnif p ≠ 0) : 1 / (d : ℝ) < ∑ i, p i ^ 2 := by
+  have hpos : 0 < dTVUnif p := lt_of_le_of_ne (dTVUnif_nonneg p) (Ne.symm hbias)
+  have hd' : (0 : ℝ) < (d : ℝ) := by exact_mod_cast hd
+  have h := collision_prob_ge p hd hsum
+  have : 0 < 4 / (d : ℝ) * dTVUnif p ^ 2 := by positivity
+  linarith
+
+end Examples
+
+end BirthdayNonUniformQuant

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-birthday-quant-tv-def",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 75,
+      "endLine": 96
+    },
+    "type": "concept",
+    "title": "Total-Variation Distance from Uniform",
+    "content": "dTVUnif p = ½·∑ᵢ |pᵢ − 1/d| is the standard total-variation distance of a probability vector from the uniform law u = (1/d, …, 1/d). sum_abs_dev records the ℓ¹ identity ∑ᵢ |pᵢ − 1/d| = 2·dTVUnif p (an unfold; ring), which is what lets the factor ½ in the definition surface as the constant 4 in the main bound. dTVUnif_nonneg is immediate from Finset.sum_nonneg over abs_nonneg, closed by positivity.",
+    "mathContext": "For two distributions p, q on a finite set, the total-variation distance is dTV(p,q) = ½∑ᵢ |pᵢ − qᵢ| = sup over events of |p(A) − q(A)|. Here q is uniform, so dTV(p,u) measures how biased p is; it is 0 exactly for the uniform law and at most 1.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "total-variation distance",
+      "probability simplex",
+      "ℓ¹ norm"
+    ],
+    "prerequisites": [
+      "Finset.sum_nonneg",
+      "abs_nonneg",
+      "positivity"
+    ]
+  },
+  {
+    "id": "ann-birthday-quant-main-bound",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 98,
+      "endLine": 138
+    },
+    "type": "insight",
+    "title": "Quantitative Bound: (4/d)·dTV(p,u)² ≤ ∑ pᵢ² − 1/d",
+    "content": "collision_excess_ge_tv is the headline result. The proof chains three facts. (1) Cauchy–Schwarz on the d deviations gᵢ = |pᵢ − 1/d|: Mathlib's sq_sum_le_card_mul_sum_sq gives (∑ gᵢ)² ≤ d·∑ gᵢ² after rewriting #univ = Fintype.card (Fin d) = d. (2) sq_abs turns gᵢ² = |pᵢ − 1/d|² into (pᵢ − 1/d)², and the parent's sum_sq_sub_one_div_card rewrites ∑ (pᵢ − 1/d)² as the collision excess ∑ pᵢ² − 1/d. (3) sum_abs_dev replaces ∑ gᵢ by 2·dTVUnif p. The inequality is now (2·dTV)² ≤ d·(excess); div_mul_eq_mul_div, div_le_iff₀ (d > 0), and nlinarith finish. collision_prob_ge restates it as 1/d + (4/d)·dTV² ≤ ∑ pᵢ².",
+    "mathContext": "The collision excess equals the squared ℓ² distance of p from uniform (parent variance identity), and total variation is half the ℓ¹ distance. The bound is therefore the ℓ¹-vs-ℓ² comparison ‖x‖₁² ≤ d·‖x‖₂² specialized to x = p − u. It is a Pinsker-type inequality: a smooth functional (the ℓ² collision excess) is bounded below by the square of a metric distance (total variation), so any bias incurs a quadratic collision penalty.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy–Schwarz inequality",
+      "Chebyshev sum inequality",
+      "Pinsker inequality",
+      "ℓ¹ vs ℓ² norms"
+    ],
+    "prerequisites": [
+      "sq_sum_le_card_mul_sum_sq",
+      "sq_abs",
+      "sum_sq_sub_one_div_card (parent)",
+      "div_le_iff₀",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-birthday-quant-equality-bridge",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 140,
+      "endLine": 165
+    },
+    "type": "insight",
+    "title": "Bridge to the Parent's Equality Case",
+    "content": "dTVUnif_eq_zero_iff proves dTV(p,u) = 0 ↔ (∀ i, pᵢ = 1/d): after mul_eq_zero discards the ½ factor, Finset.sum_eq_zero_iff_of_nonneg (with abs_nonneg) forces each |pᵢ − 1/d| = 0, and abs_eq_zero extracts pᵢ = 1/d. sum_sq_eq_one_div_card_iff_tv then composes this with the parent's sum_sq_eq_one_div_card_iff to conclude ∑ pᵢ² = 1/d ↔ dTV(p,u) = 0. The quantitative bound thus contains the parent's 'equality iff uniform' as its degenerate dTV = 0 boundary.",
+    "mathContext": "A concentration/deviation inequality of the form (excess) ≥ c·(distance)² automatically recovers the equality characterization of the underlying extremal problem: the excess vanishes only when the distance does. Here that boundary is exactly the uniform distribution, tying the effective bound back to the Munford/Klamkin–Newman minimizer.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "equality characterization",
+      "Finset.sum_eq_zero_iff_of_nonneg",
+      "abs_eq_zero"
+    ],
+    "prerequisites": [
+      "sum_sq_eq_one_div_card_iff (parent)",
+      "mul_eq_zero"
+    ]
+  },
+  {
+    "id": "ann-birthday-quant-examples",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 167,
+      "endLine": 181
+    },
+    "type": "concept",
+    "title": "Uniform vs. Biased: the Bound in Action",
+    "content": "The first example confirms dTVUnif of the uniform law is 0 (via dTVUnif_eq_zero_iff). The second shows the strict form: if dTV(p,u) ≠ 0 then, combining dTVUnif_nonneg (so dTV > 0), positivity ((4/d)·dTV² > 0), and collision_prob_ge, the collision probability ∑ pᵢ² is strictly greater than the uniform value 1/d. Any genuine bias strictly increases collisions.",
+    "mathContext": "The strict inequality is the practical content: real-world seasonal birthday bias, being nonzero in total variation, provably raises the coincidence probability above the textbook uniform value 1/365 by a positive, computable margin.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "strict inequality",
+      "positivity"
+    ],
+    "prerequisites": [
+      "collision_prob_ge",
+      "dTVUnif_nonneg"
+    ]
+  }
+]

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "birthday-problem-oq-02-oq-01-oq-02-oq-02",
+  "title": "Quantitative Non-Uniform Birthday Bound: Bias Raises Collisions Quadratically in Total Variation",
+  "slug": "birthday-problem-oq-02-oq-01-oq-02-oq-02",
+  "description": "Sharpens the parent's qualitative extremality (C(p) ≥ 1/d) into a quantitative lower bound: the collision excess ∑ pᵢ² − 1/d is at least (4/d)·dTV(p,u)², where dTV(p,u) = ½∑|pᵢ − 1/d| is the total-variation distance from uniform. A Pinsker-flavored effective bound: a distribution ε-far from uniform in total variation has collision probability at least 1/d + 4ε²/d.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BirthdayProblemOQ02OQ01OQ02OQ02.lean",
+    "tags": [
+      "probability",
+      "birthday-problem",
+      "total-variation",
+      "cauchy-schwarz",
+      "concentration-inequality",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 181,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "assumptions": "None. Fully machine-verified from Mathlib.",
+    "originalContributions": [
+      "dTVUnif: definition of the total-variation distance ½∑|pᵢ − 1/d| of a probability vector from the uniform law",
+      "collision_excess_ge_tv: the quantitative bound (4/d)·dTV(p,u)² ≤ ∑ pᵢ² − 1/d — the headline effective lower bound answering the parent's open question",
+      "collision_prob_ge: restatement 1/d + (4/d)·dTV(p,u)² ≤ ∑ pᵢ², an explicit surplus over the uniform minimum",
+      "dTVUnif_eq_zero_iff / sum_sq_eq_one_div_card_iff_tv: dTV(p,u) = 0 iff p is uniform, bridging the quantitative bound to the parent's equality-iff-uniform case"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent file (birthday-problem-oq-02-oq-01-oq-02) proves the Munford/Klamkin–Newman extremality in its two-draw form: among all birthday distributions p on d outcomes, the uniform law minimizes the collision probability C(p) = ∑ᵢ pᵢ², with C(p) ≥ 1/d and equality iff p is uniform. That is a purely qualitative statement — it says bias hurts, but not by how much. Its own open-question list explicitly asks to 'quantify how much a given bias raises the collision probability … in terms of the total-variation distance from uniform.' This file answers exactly that.\n\nThe natural yardstick for 'how far p is from uniform' is the total-variation distance dTV(p, u) = ½∑ᵢ |pᵢ − 1/d|, the standard metric on probability distributions. The result here is a clean quadratic lower bound of the collision excess in this metric, in the same spirit as Pinsker's inequality (which lower-bounds a divergence by total variation squared).",
+    "problemStatement": "For every probability vector p on d > 0 outcomes (∑ᵢ pᵢ = 1), bound the collision excess ∑ᵢ pᵢ² − 1/d below by an explicit increasing function of the total-variation distance dTV(p, u) = ½∑ᵢ |pᵢ − 1/d| from the uniform law u = (1/d, …, 1/d). Show the bound degenerates to the parent's equality case exactly when dTV(p, u) = 0.",
+    "proofStrategy": "Two ingredients combine.\n\n**1. Variance identity (inherited from parent).** With ∑ᵢ pᵢ = 1, the parent's sum_sq_sub_one_div_card gives ∑ᵢ pᵢ² − 1/d = ∑ᵢ (pᵢ − 1/d)², i.e. the collision excess equals the squared ℓ² distance of p from uniform.\n\n**2. Cauchy–Schwarz / power-mean (Mathlib).** For the d deviations gᵢ = |pᵢ − 1/d|, Mathlib's sq_sum_le_card_mul_sum_sq (the f = g case of Chebyshev's sum inequality) gives (∑ᵢ gᵢ)² ≤ d·∑ᵢ gᵢ². Since gᵢ² = (pᵢ − 1/d)² (sq_abs) and ∑ᵢ gᵢ = 2·dTV(p, u), this reads 4·dTV(p, u)² ≤ d·(∑ᵢ pᵢ² − 1/d). Dividing by d > 0 (div_le_iff₀, nlinarith) gives the claim (4/d)·dTV(p,u)² ≤ ∑ᵢ pᵢ² − 1/d.\n\n**Bridge to the equality case.** dTV(p, u) = 0 iff ∑ᵢ |pᵢ − 1/d| = 0 iff every pᵢ = 1/d (Finset.sum_eq_zero_iff_of_nonneg, abs_eq_zero), which is exactly the parent's uniform condition. Composing with the parent's sum_sq_eq_one_div_card_iff shows ∑ᵢ pᵢ² = 1/d ⟺ dTV(p, u) = 0.",
+    "keyInsights": [
+      "The collision excess is *exactly* the squared ℓ² distance from uniform (parent identity), so bounding it below in total variation is precisely the ℓ¹-vs-ℓ² comparison delivered by Cauchy–Schwarz: (∑|xᵢ|)² ≤ d·∑xᵢ² on d coordinates.",
+      "The constant 4 is not cosmetic: dTV involves the factor ½ (so ∑|pᵢ − 1/d| = 2·dTV), and squaring turns that into a 4. The final bound (4/d)·dTV² is order-sharp — it is attained up to constants by a two-spike perturbation of uniform that concentrates all the deviation mass on two coordinates.",
+      "This is a Pinsker-type inequality for the collision functional: it lower-bounds a smooth quantity (the ℓ² collision excess) by the square of a metric distance (total variation), turning a bias into an effective, computable penalty.",
+      "The quantitative bound subsumes the parent's qualitative equality case: dTV(p, u) = 0 ⟺ p uniform ⟺ ∑ pᵢ² = 1/d, so the effective inequality recovers 'equality iff uniform' as its degenerate boundary."
+    ],
+    "prerequisites": [
+      "sq_sum_le_card_mul_sum_sq: (∑ f)² ≤ #s · ∑ f² (Chebyshev/Cauchy–Schwarz), Mathlib.Algebra.Order.Chebyshev",
+      "sq_abs: |x|² = x², and Finset.sum_congr for rewriting under a sum",
+      "Finset.sum_eq_zero_iff_of_nonneg and abs_eq_zero: a sum of absolute values vanishes iff each term does",
+      "div_le_iff₀ / nlinarith for the final division by d > 0",
+      "Parent birthday-problem-oq-02-oq-01-oq-02: the variance identity and equality characterization it exposes"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 71,
+      "summary": "Imports the parent (BirthdayProblemOQ02OQ01OQ02) and Mathlib. Module docstring stating the quantitative total-variation refinement of the non-uniform birthday extremality. Opens Finset and the parent's BirthdayNonUniform namespace inside a new BirthdayNonUniformQuant namespace."
+    },
+    {
+      "id": "tv-definition",
+      "title": "Total-Variation Distance from Uniform",
+      "startLine": 73,
+      "endLine": 96,
+      "summary": "dTVUnif: the total-variation distance ½∑ᵢ |pᵢ − 1/d| from the uniform law. sum_abs_dev: ∑ᵢ |pᵢ − 1/d| = 2·dTVUnif p. dTVUnif_nonneg: the distance is nonnegative (sum of absolute values)."
+    },
+    {
+      "id": "quantitative-bound",
+      "title": "Quantitative Lower Bound",
+      "startLine": 98,
+      "endLine": 138,
+      "summary": "collision_excess_ge_tv: (4/d)·dTV(p,u)² ≤ ∑ pᵢ² − 1/d, via Cauchy–Schwarz (sq_sum_le_card_mul_sum_sq) on the deviations, sq_abs to identify gᵢ² = (pᵢ − 1/d)², and the parent's variance identity. collision_prob_ge: the equivalent form 1/d + (4/d)·dTV(p,u)² ≤ ∑ pᵢ²."
+    },
+    {
+      "id": "equality-bridge",
+      "title": "Bridge to the Equality Case",
+      "startLine": 140,
+      "endLine": 165,
+      "summary": "dTVUnif_eq_zero_iff: dTV(p,u) = 0 ↔ every pᵢ = 1/d (Finset.sum_eq_zero_iff_of_nonneg, abs_eq_zero). sum_sq_eq_one_div_card_iff_tv: ∑ pᵢ² = 1/d ↔ dTV(p,u) = 0, composing with the parent's equality characterization."
+    },
+    {
+      "id": "examples",
+      "title": "Examples",
+      "startLine": 167,
+      "endLine": 181,
+      "summary": "The uniform law has dTV = 0; a distribution with dTV(p,u) ≠ 0 has collision probability strictly above 1/d — the strict form of the quantitative bound."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Munford, A.G."
+      ],
+      "title": "A note on the uniformity assumption in the birthday problem",
+      "year": "1977",
+      "venue": "The American Statistician 31 (3), p. 119",
+      "note": "Shows the uniform distribution minimizes birthday-collision probability."
+    },
+    {
+      "authors": [
+        "Klamkin, M.S.",
+        "Newman, D.J."
+      ],
+      "title": "Extensions of the birthday surprise",
+      "year": "1967",
+      "venue": "Journal of Combinatorial Theory 3 (3), pp. 279–282",
+      "note": "Extremality of the uniform distribution for multi-coincidence birthday problems."
+    },
+    {
+      "authors": [
+        "Csiszár, I.",
+        "Körner, J."
+      ],
+      "title": "Information Theory: Coding Theorems for Discrete Memoryless Systems",
+      "year": "2011",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "Standard reference for Pinsker-type inequalities lower-bounding divergences by total-variation distance."
+    }
+  ],
+  "conclusion": {
+    "summary": "Upgraded the parent's qualitative extremality C(p) ≥ 1/d into a quantitative effective bound: the collision excess ∑ᵢ pᵢ² − 1/d is at least (4/d)·dTV(p,u)², where dTV(p,u) = ½∑ᵢ |pᵢ − 1/d| is the total-variation distance from uniform. 181 lines, 6 theorems, 1 definition, 0 sorries, 0 axioms. The proof combines the parent's variance identity with Mathlib's Cauchy–Schwarz (sq_sum_le_card_mul_sum_sq), and the total-variation form recovers 'equality iff uniform' as the dTV = 0 boundary.",
+    "implications": "The bound makes the birthday extremality effective: a birthday distribution ε-far from uniform in total variation has collision probability at least 1/d + 4ε²/d, so the textbook uniform value 1/d is not merely a lower bound but one that any measurable bias provably exceeds by a computable margin. As a Pinsker-flavored inequality for the ℓ² collision functional, it turns 'bias increases collisions' into a quantitative guarantee.",
+    "openQuestions": [
+      "Sharp constant: is the factor 4 optimal, i.e. does the two-spike perturbation attaining (∑|xᵢ|)² = d·∑xᵢ² only in the limit give the true extremal constant, or can a matching upper bound C(p) − 1/d ≤ c·dTV(p,u) (with the ℓ∞ radius) pin the two-sided rate?",
+      "n-draw analogue: is there a quantitative total-variation lower bound for the multi-coincidence excess n!·eₙ(p) − (uniform value), refining the Schur-concavity extremality?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "birthday-problem-oq-02-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent. Answers its open question quantifying the collision excess in terms of the total-variation distance from uniform; reuses its variance identity and equality characterization."
+    },
+    {
+      "targetId": "birthday-problem-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Grandparent non-uniform birthday extremality."
+    }
+  ],
+  "leanFile": {
+    "namespace": "BirthdayNonUniformQuant",
+    "lineCount": 181,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/BirthdayProblemOQ02OQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Quantitative Non-Uniform Birthday Bound (birthday-problem-oq-02-oq-01-oq-02-oq-02)

Answers the parent's open question: **quantify how much a bias raises the collision probability**, in terms of the total-variation distance from uniform.

### Result
For a probability vector `p` on `d > 0` outcomes, with `dTV(p,u) = ½∑ᵢ|pᵢ − 1/d|`:

- **`collision_excess_ge_tv`**: `(4/d)·dTV(p,u)² ≤ ∑ᵢ pᵢ² − 1/d`
- **`collision_prob_ge`**: `1/d + (4/d)·dTV(p,u)² ≤ ∑ᵢ pᵢ²`

A Pinsker-flavored *effective* refinement of the parent's qualitative extremality `C(p) ≥ 1/d`: a distribution `ε`-far from uniform in total variation has collision probability at least `1/d + 4ε²/d`.

### Proof
Combines the parent's variance identity `∑pᵢ² − 1/d = ∑(pᵢ − 1/d)²` with Mathlib's Cauchy–Schwarz `sq_sum_le_card_mul_sum_sq` on the deviations `gᵢ = |pᵢ − 1/d|`. The bridge `dTVUnif = 0 ↔ p uniform` recovers the parent's equality-iff-uniform case.

### Stats
- New entry: 6 theorems + 1 definition, 181 lines, **0 sorries, 0 axioms**
- Builds on `birthday-problem-oq-02-oq-01-oq-02` (on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
