### PR TITLE
Enrich Erdős 1016 (pancyclic excess edges): realign annotations, cover model-flaw + grounded model, fix axiom disclosure

### DIFF
--- a/src/data/proofs/erdos-1016/annotations.json
+++ b/src/data/proofs/erdos-1016/annotations.json
@@ -1,43 +1,19 @@
 [
   {
-    "id": "erdos-1016-ann-pancyclic",
+    "id": "erdos-1016-header",
     "proofId": "erdos-1016",
-    "range": {
-      "startLine": 33,
-      "endLine": 34
-    },
-    "type": "definition",
-    "title": "Pancyclic Graph",
-    "content": "A graph on $n$ vertices is pancyclic if it contains cycles of every length $k$ for $3 \\leq k \\leq n$. This is strictly stronger than being Hamiltonian (which only requires a cycle of length $n$). The concept was introduced by Bondy (1971) who proved that sufficiently dense graphs are pancyclic or bipartite.",
-    "mathContext": "A graph $G$ on $n$ vertices is pancyclic if $\\forall k \\in \\{3, 4, \\ldots, n\\}$, $G$ contains a cycle $C_k$. Pancyclicity is a strengthening of Hamiltonicity: Hamiltonian $\\Leftarrow$ pancyclic, but not conversely in general.",
+    "range": { "startLine": 1, "endLine": 22 },
+    "type": "concept",
+    "title": "Problem, Conjecture, and the Known Bounds",
+    "content": "Erdős #1016: let $h(n)$ be the minimum number of edges **beyond** $n$ needed for an $n$-vertex graph to be *pancyclic* (contain cycles of every length $3,4,\\dots,n$ — strictly stronger than Hamiltonian). Estimate $h(n)$; is $h(n)\\ge \\log_2 n+\\log^* n-O(1)$? The literature brackets it: Bondy conjectured (1971) and Griffin first proved (2013) the lower bound $\\lfloor\\log_2(n-1)\\rfloor-1\\le h(n)$ (each extra edge at most doubles the range of achievable cycle lengths, giving a logarithmic floor); George–Khodkar–Wallis (2016) proved the upper bound $h(n)\\le \\lfloor\\log_2 n\\rfloor+\\log^* n+O(1)$ by an explicit hierarchical doubling construction. Even the weaker $h(n)-\\log_2 n\\to\\infty$ is open. Values: OEIS A105206 ($0,1,2,2,2,3,\\dots$).",
+    "mathContext": "$\\lfloor\\log_2(n-1)\\rfloor-1\\le h(n)\\le\\lfloor\\log_2 n\\rfloor+\\log^* n+O(1)$; conjectured $h(n)=\\lfloor\\log_2 n\\rfloor+\\log^* n+\\Theta(1)$",
     "significance": "key",
     "relatedConcepts": [
+      "pancyclic graph",
       "Hamiltonian cycle",
-      "cycle spectrum",
       "Bondy's theorem",
-      "vertex-pancyclic"
-    ],
-    "prerequisites": [
-      "graph theory",
-      "cycle theory"
-    ]
-  },
-  {
-    "id": "erdos-1016-ann-excess",
-    "proofId": "erdos-1016",
-    "range": {
-      "startLine": 39,
-      "endLine": 41
-    },
-    "type": "definition",
-    "title": "Pancyclic Excess h(n)",
-    "content": "The pancyclic excess $h(n) = \\min\\{|E(G)| - n : G \\text{ is pancyclic on } n \\text{ vertices}\\}$ measures how many edges beyond $n$ (the Hamiltonian cycle count) are needed to ensure all cycle lengths. Since a Hamiltonian cycle has $n$ edges but only one cycle length, additional edges are needed to 'fill in' the missing cycle lengths $3, 4, \\ldots, n-1$.",
-    "mathContext": "$h(n) = \\min_{G \\text{ pancyclic}} (|E(G)| - n)$. Known: $\\lfloor\\log_2(n-1)\\rfloor - 1 \\leq h(n) \\leq \\lfloor\\log_2 n\\rfloor + \\log^* n + O(1)$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "edge-minimal graphs",
-      "extremal graph theory",
-      "edge threshold"
+      "iterated logarithm",
+      "OEIS A105206"
     ],
     "prerequisites": [
       "graph theory",
@@ -45,201 +21,156 @@
     ]
   },
   {
-    "id": "erdos-1016-ann-iterlog",
+    "id": "erdos-1016-imports",
     "proofId": "erdos-1016",
-    "range": {
-      "startLine": 45,
-      "endLine": 48
-    },
+    "range": { "startLine": 24, "endLine": 29 },
+    "type": "context",
+    "title": "Imports",
+    "content": "Pulls in Mathlib's `SimpleGraph` basics, paths/walks, and finiteness (`edgeSet`/`edgeFinset`) — needed for the *grounded* model at the end of the file — together with `Nat.Log` for $\\log_2$ and $\\log^*$, and `Real.Basic` for the asymptotic statements.",
+    "mathContext": "`SimpleGraph.Basic`/`Paths`/`Finite` supply the genuine cycle and edge-count API used to repair the abstract model.",
+    "significance": "context",
+    "relatedConcepts": [
+      "SimpleGraph",
+      "Nat.log",
+      "Walk.IsCycle"
+    ],
+    "prerequisites": [
+      "Lean 4 imports"
+    ]
+  },
+  {
+    "id": "erdos-1016-abstract-defs",
+    "proofId": "erdos-1016",
+    "range": { "startLine": 31, "endLine": 43 },
     "type": "definition",
-    "title": "Iterated Logarithm log*",
-    "content": "The iterated logarithm $\\log^* n$ is the number of times $\\log_2$ must be applied to $n$ before the result is $\\leq 1$. It grows incredibly slowly: $\\log^*(2^{65536}) = 5$. Its appearance in the upper bound for $h(n)$ reflects a hierarchical doubling structure in pancyclic graph constructions.",
-    "mathContext": "$\\log^* n = \\min\\{k \\geq 0 : \\log_2^{(k)}(n) \\leq 1\\}$ where $\\log_2^{(k)}$ denotes $k$-fold application of $\\log_2$. For all practical purposes $\\log^* n \\leq 5$.",
+    "title": "The Abstract Model (a Diagnostic Scaffold)",
+    "content": "`IsPancyclic n edgeCount hasCycleOfLength` says every length $3\\le k\\le n$ is realized — but crucially `hasCycleOfLength : ℕ → Prop` is an **unconstrained parameter**, not tied to any graph or to `edgeCount`. `pancyclicExcess n` is then the supremum of all $h$ forced as a lower bound on $\\text{edgeCount}-n$ over pancyclic configurations. As the next section shows, this disconnection is a modeling flaw: it makes the excess collapse. These definitions are kept as an instructive scaffold, later replaced by the grounded model.",
+    "mathContext": "$\\text{IsPancyclic}(n,e,c)\\iff\\forall\\,3\\le k\\le n,\\ c(k)$;\\quad $\\text{pancyclicExcess}(n)=\\sup\\{h:\\forall e\\,c,\\ \\text{IsPancyclic}(n,e,c)\\Rightarrow e\\ge n+h\\}$",
     "significance": "key",
     "relatedConcepts": [
-      "iterated functions",
-      "tower function",
-      "inverse Ackermann",
-      "slowly growing functions"
+      "pancyclic excess h(n)",
+      "sSup over a predicate set",
+      "abstraction / modeling"
     ],
     "prerequisites": [
-      "analysis",
-      "recursive functions"
+      "sSup on ℕ",
+      "set-builder predicate"
     ]
   },
   {
-    "id": "erdos-1016-ann-conjecture",
+    "id": "erdos-1016-iteratedlog-def",
     "proofId": "erdos-1016",
-    "range": {
-      "startLine": 55,
-      "endLine": 57
-    },
-    "type": "concept",
-    "title": "Main Conjecture: h(n) >= log_2 n + log* n - O(1)",
-    "content": "Erdos conjectured that the lower bound on $h(n)$ should match the George-Khodkar-Wallis upper bound up to an additive constant, giving $h(n) = \\lfloor\\log_2 n\\rfloor + \\log^* n + \\Theta(1)$. This would determine $h(n)$ to within a constant. The conjecture implies that the hierarchical construction giving the upper bound is essentially optimal.",
-    "mathContext": "$\\exists C$ such that $h(n) + C \\geq \\lfloor\\log_2 n\\rfloor + \\log^* n$ for all $n \\geq 3$. Combined with the upper bound, this gives $h(n) = \\lfloor\\log_2 n\\rfloor + \\log^* n + \\Theta(1)$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "extremal graph theory",
-      "tight bounds",
-      "additive combinatorics"
-    ],
-    "prerequisites": [
-      "asymptotic analysis",
-      "graph theory"
-    ]
-  },
-  {
-    "id": "erdos-1016-ann-weaker",
-    "proofId": "erdos-1016",
-    "range": {
-      "startLine": 61,
-      "endLine": 63
-    },
-    "type": "concept",
-    "title": "Weaker Question: h(n) - log_2 n -> infinity",
-    "content": "Even the weaker statement that $h(n) - \\lfloor\\log_2 n\\rfloor \\to \\infty$ as $n \\to \\infty$ is open. Erdos noted that he could not prove this, making it a remarkable example of a problem where the answer is known to within $\\log^* n + O(1)$ yet even the first-order correction to the leading term is unproved.",
-    "mathContext": "$\\forall M, \\exists N$ such that $h(n) \\geq \\lfloor\\log_2 n\\rfloor + M$ for all $n \\geq N$. This is strictly weaker than the main conjecture.",
-    "significance": "key",
-    "relatedConcepts": [
-      "divergence",
-      "second-order asymptotics",
-      "slowly growing corrections"
-    ],
-    "prerequisites": [
-      "real analysis",
-      "asymptotic analysis"
-    ]
-  },
-  {
-    "id": "erdos-1016-ann-bondy",
-    "proofId": "erdos-1016",
-    "range": {
-      "startLine": 69,
-      "endLine": 71
-    },
-    "type": "concept",
-    "title": "Bondy's Lower Bound (Griffin 2013)",
-    "content": "The lower bound $h(n) \\geq \\lfloor\\log_2(n-1)\\rfloor - 1$ was conjectured by Bondy in 1971 and first published with proof by Griffin in 2013. The argument uses the fact that each additional edge beyond a Hamiltonian cycle can at most double the range of achievable cycle lengths, leading to the logarithmic bound.",
-    "mathContext": "$h(n) + 1 \\geq \\lfloor\\log_2(n-1)\\rfloor$ for all $n \\geq 3$. The key idea: with $h$ extra edges beyond a Hamiltonian cycle, the number of achievable cycle lengths is at most $2^h$, so $2^h \\geq n - 2$ gives $h \\geq \\log_2(n-2)$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "doubling argument",
-      "cycle insertion",
-      "edge counting"
-    ],
-    "prerequisites": [
-      "graph theory",
-      "logarithmic bounds"
-    ]
-  },
-  {
-    "id": "erdos-1016-ann-gkw",
-    "proofId": "erdos-1016",
-    "range": {
-      "startLine": 76,
-      "endLine": 78
-    },
-    "type": "concept",
-    "title": "George-Khodkar-Wallis Upper Bound (2016)",
-    "content": "George, Khodkar, and Wallis (2016) proved that $h(n) \\leq \\lfloor\\log_2 n\\rfloor + \\log^* n + O(1)$ by explicitly constructing pancyclic graphs with this many excess edges. The construction uses a hierarchical approach: starting with a Hamiltonian cycle, edges are added in $\\log_2 n$ stages to double the range of available cycle lengths, with $\\log^* n$ additional correction stages.",
-    "mathContext": "$\\exists C$ such that $h(n) \\leq \\lfloor\\log_2 n\\rfloor + \\log^* n + C$ for all $n \\geq 3$. The construction is recursive, with each level handling a tower of exponentials.",
-    "significance": "key",
-    "relatedConcepts": [
-      "explicit constructions",
-      "hierarchical graph building",
-      "recursive doubling"
-    ],
-    "prerequisites": [
-      "extremal graph theory",
-      "constructive combinatorics"
-    ]
-  },
-  {
-    "id": "erdos-1016-ann-hamiltonian",
-    "proofId": "erdos-1016",
-    "range": {
-      "startLine": 84,
-      "endLine": 85
-    },
-    "type": "concept",
-    "title": "Hamiltonian Edge Count Baseline",
-    "content": "A Hamiltonian cycle on $n$ vertices has exactly $n$ edges and contains only cycles of length $n$. Therefore $h(n) \\geq 0$: at least $n$ edges are needed, and any pancyclic graph is Hamiltonian. The excess $h(n)$ measures the cost of upgrading from Hamiltonian to pancyclic.",
-    "mathContext": "$h(n) \\geq 0$ since every pancyclic graph is Hamiltonian, and Hamiltonian graphs have at least $n$ edges.",
+    "range": { "startLine": 45, "endLine": 63 },
+    "type": "definition",
+    "title": "The Iterated Logarithm log*",
+    "content": "`iteratedLog n` = the number of times $\\log_2$ must be applied to $n$ before reaching $\\le 1$ — the famously slow-growing $\\log^* n$ ($\\log^*(2^{65536})=5$). It appears in the GKW upper bound, reflecting the hierarchical doubling in their construction. The definition recurses on $\\text{Nat.log}\\,2\\,(n+2)$; the `decreasing_by` block discharges termination using $2^{n+2}>n+2$ (`Nat.lt_two_pow_self`) to rule out the equality case of $\\text{Nat.log}\\,2\\,(n+2)\\le n+2$.",
+    "mathContext": "$\\log^* n=\\min\\{k\\ge 0:\\log_2^{(k)}(n)\\le 1\\}$; termination from $\\text{Nat.log}\\,2\\,(n+2)<n+2$",
     "significance": "supporting",
     "relatedConcepts": [
-      "Hamiltonian cycle",
-      "edge count",
-      "Ore's theorem"
+      "iterated logarithm",
+      "well-founded recursion",
+      "Nat.log",
+      "tower / inverse-Ackermann growth"
     ],
     "prerequisites": [
-      "graph theory"
+      "Nat.log",
+      "termination_by / decreasing_by"
     ]
   },
   {
-    "id": "erdos-1016-ann-bondy-quad",
+    "id": "erdos-1016-iteratedlog-props",
     "proofId": "erdos-1016",
-    "range": {
-      "startLine": 89,
-      "endLine": 90
-    },
-    "type": "concept",
-    "title": "Bondy's Quadratic Threshold for Pancyclicity",
-    "content": "Bondy (1971) proved that any graph with $n$ vertices and at least $n^2/4$ edges is either pancyclic or bipartite (and hence has no odd cycles). This quadratic threshold $n^2/4$ is far from the tight bound of $n + O(\\log n)$, but was historically the first pancyclicity result. The bipartite exception is necessary since $K_{n/2,n/2}$ has $n^2/4$ edges but no odd cycles.",
-    "mathContext": "$|E(G)| \\geq n^2/4 \\implies G$ is pancyclic or bipartite. Note $n^2/4 \\gg n + \\log_2 n$ for large $n$, so this is very far from tight.",
+    "range": { "startLine": 65, "endLine": 101 },
+    "type": "technique",
+    "title": "Structural Properties of log*",
+    "content": "Pure, model-independent facts about `iteratedLog`, usable by any future graph encoding: the defining equations at $0$, $1$, and $n+2$ (`iteratedLog_zero/_one/_add_two`), the characterization of the zero fibre `iteratedLog_eq_zero_iff : iteratedLog n = 0 ↔ n ≤ 1`, and positivity `iteratedLog_pos : 2 ≤ n → 1 ≤ iteratedLog n`. These isolate the arithmetic of $\\log^*$ from the (flawed) pancyclic model so they survive any remodeling.",
+    "mathContext": "$\\log^* n=0\\iff n\\le 1$;\\quad $n\\ge 2\\Rightarrow \\log^* n\\ge 1$",
     "significance": "supporting",
     "relatedConcepts": [
-      "Bondy's theorem",
-      "Turan's theorem",
-      "bipartite graphs",
-      "Ore's theorem"
+      "iterated logarithm",
+      "defining equations",
+      "match / omega"
     ],
     "prerequisites": [
-      "extremal graph theory",
-      "Turan theory"
+      "iteratedLog definition",
+      "Nat.log lemmas"
     ]
   },
   {
-    "id": "erdos-1016-ann-monotone",
+    "id": "erdos-1016-model-flaw",
     "proofId": "erdos-1016",
-    "range": {
-      "startLine": 94,
-      "endLine": 96
-    },
-    "type": "concept",
-    "title": "Monotonicity of Pancyclicity",
-    "content": "Adding edges preserves pancyclicity: if $G$ is pancyclic and $G \\subseteq G'$ (same vertex set, more edges), then $G'$ is pancyclic. This is because adding edges can only create new cycles, never destroy existing ones. This means the set of pancyclic graphs on $n$ vertices is upward-closed in the edge-inclusion order.",
-    "mathContext": "Pancyclicity is a monotone graph property: $G \\subseteq G'$ and $G$ pancyclic $\\implies G'$ pancyclic.",
-    "significance": "supporting",
+    "range": { "startLine": 103, "endLine": 141 },
+    "type": "insight",
+    "title": "The Model Flaw: pancyclicExcess Collapses to 0",
+    "content": "The heart of the entry's honesty. Because `hasCycleOfLength` is disconnected from `edgeCount`, one can take $\\text{edgeCount}=0$ and $\\text{hasCycle}=(\\lambda\\_.\\ \\text{True})$: this satisfies `IsPancyclic` yet violates every edge lower bound, so the defining set is **empty** and `pancyclicExcess_eq_zero` proves $\\text{pancyclicExcess}\\,n=0$ for all $n\\ge 1$ (via $\\sup\\varnothing=0$). Consequently `gkw_upper_bound` is *trivially* true and the intended lower bounds are *false* under this encoding. This is why the five original lower-bound axioms were removed rather than asserted — a deliberate correctness choice, not an omission.",
+    "mathContext": "$\\text{edgeCount}=0,\\ \\text{hasCycle}=\\top\\models\\text{IsPancyclic}\\Rightarrow \\{h:\\dots\\}=\\varnothing\\Rightarrow \\text{pancyclicExcess}\\,n=\\sup\\varnothing=0$",
+    "significance": "key",
     "relatedConcepts": [
-      "monotone graph properties",
-      "upward-closed families",
-      "graph minors"
+      "vacuous supremum (sSup ∅ = 0)",
+      "modeling flaw",
+      "soundness over completeness"
     ],
     "prerequisites": [
-      "graph theory",
-      "order theory"
+      "csSup_empty",
+      "IsPancyclic definition"
     ]
   },
   {
-    "id": "erdos-1016-ann-small",
+    "id": "erdos-1016-disabled-axioms",
     "proofId": "erdos-1016",
-    "range": {
-      "startLine": 99,
-      "endLine": 105
-    },
-    "type": "concept",
-    "title": "Small Cases: h(3) = 0, h(4) = 1",
-    "content": "The triangle $K_3$ is the smallest pancyclic graph with $h(3) = 0$: it has 3 edges = $n$ edges and contains the only required cycle ($C_3$). For $n = 4$, we need cycles of lengths 3 and 4. A 4-cycle plus one diagonal gives 5 = 4 + 1 edges, so $h(4) = 1$. Further values: $h(5) = 2$, $h(6) = 2$, $h(7) = 2$ (OEIS A105206).",
-    "mathContext": "$h(3) = 0$ ($K_3$ is pancyclic), $h(4) = 1$ ($C_4$ plus one diagonal). The sequence begins $0, 1, 2, 2, 2, 3, 3, 3, 3, 4, \\ldots$ (OEIS A105206).",
-    "significance": "supporting",
+    "range": { "startLine": 143, "endLine": 157 },
+    "type": "context",
+    "title": "The Mathematically-Correct Statements, Preserved as Comments",
+    "content": "The genuine results — Erdős's conjecture $h(n)\\ge\\log_2 n+\\log^* n-O(1)$, the weaker open $h(n)-\\log_2 n\\to\\infty$, Bondy/Griffin's lower bound $h(n)\\ge\\lfloor\\log_2(n-1)\\rfloor-1$, and small cases such as $h(4)=1$ — are retained here as commented statements. They are true mathematics but **false against the abstract encoding** (which forces the excess to $0$), so they are documented rather than proved, awaiting the grounded model. This block is the honest bridge between the literature and the current formalization's limits.",
+    "mathContext": "Disabled (FALSE under abstract model, TRUE mathematically): $\\exists C,\\forall n\\ge 3,\\ h(n)+C\\ge\\log_2 n+\\log^* n$; $h(4)=1$; etc.",
+    "significance": "context",
     "relatedConcepts": [
-      "complete graphs",
-      "OEIS A105206",
-      "small extremal examples"
+      "Bondy–Griffin lower bound",
+      "George–Khodkar–Wallis upper bound",
+      "open conjecture bookkeeping"
     ],
     "prerequisites": [
-      "graph theory"
+      "erdos-1016-model-flaw"
+    ]
+  },
+  {
+    "id": "erdos-1016-structural",
+    "proofId": "erdos-1016",
+    "range": { "startLine": 159, "endLine": 211 },
+    "type": "technique",
+    "title": "Structural Properties Under the Abstract Model",
+    "content": "A mix of honest lemmas. `hamiltonian_edge_count` ($h(n)\\ge 0$) and `pancyclic_monotone` are trivially true (the latter because `IsPancyclic` ignores `edgeCount`). `triangle_pancyclic` gives $h(3)=0$ — mathematically correct, but its proof again exploits $\\sup\\varnothing=0$ rather than graph reasoning. The genuinely substantive one is `bondy_quadratic_threshold`: for $n\\ge 7$, $n^2/4\\ge n+\\log_2 n$, proved by `native_decide` on $7\\le n\\le 15$ and by `nlinarith`/`omega` (via $n^2/4\\ge 2n$ and $\\log_2 n\\le n$) for $n\\ge 16$ — this is Bondy's 1971 quadratic pancyclicity threshold, far from the tight $n+O(\\log n)$ but historically first.",
+    "mathContext": "$n\\ge 7\\Rightarrow n^2/4\\ge n+\\log_2 n$ (Bondy threshold; `native_decide` on small cases → `Lean.ofReduceBool`)",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bondy's quadratic threshold",
+      "native_decide (small cases)",
+      "monotone graph property",
+      "vacuous h(3)=0"
+    ],
+    "prerequisites": [
+      "erdos-1016-model-flaw",
+      "nlinarith / interval_cases"
+    ]
+  },
+  {
+    "id": "erdos-1016-grounded-model",
+    "proofId": "erdos-1016",
+    "range": { "startLine": 213, "endLine": 265 },
+    "type": "insight",
+    "title": "The Grounded SimpleGraph Model (the Correction)",
+    "content": "The repair. Working over `SimpleGraph (Fin n)`, `HasCycleOfLength G k` asserts a genuine cycle (`Walk.IsCycle`) of length exactly $k$ in $G$, and `IsPancyclicGraph G` requires one for every $3\\le k\\le n$ — now a real property of the concrete graph. The key lemma `card_edgeFinset_ge_of_hasCycleOfLength` shows a length-$k$ cycle is a trail using $k$ distinct edges, so $k\\le |E(G)|$; specializing to the Hamiltonian ($k=n$) cycle, `pancyclicGraph_card_edgeFinset_ge` recovers the **non-vacuous** baseline $n\\le |E(G)|$ for any pancyclic graph on $n\\ge 3$ vertices. This is exactly the edge–cycle link the abstract model could not express, and the foundation on which the real Bondy/Griffin/GKW bounds could be proved.",
+    "mathContext": "$\\text{HasCycleOfLength}(G,k)\\Rightarrow k\\le|E(G)|$ (cycle = trail of $k$ distinct edges); pancyclic $\\Rightarrow n\\le|E(G)|$",
+    "significance": "key",
+    "relatedConcepts": [
+      "SimpleGraph.Walk.IsCycle",
+      "edgeFinset",
+      "IsTrail.length_le_card_edgeFinset",
+      "grounded formalization"
+    ],
+    "prerequisites": [
+      "SimpleGraph cycle API",
+      "erdos-1016-model-flaw"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -21,9 +21,9 @@
     "erdosNumber": 1016,
     "erdosUrl": "https://erdosproblems.com/1016",
     "erdosProblemStatus": "open",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 265,
-    "assumptions": "0 axioms. All 5 former axioms were removed because the abstract IsPancyclic model is flawed (edgeCount disconnected from hasCycle makes axioms FALSE). The mathematical results (Bondy, Griffin, GKW) are correct but require a proper SimpleGraph-based model to formalize.",
+    "assumptions": "1 assumption: Lean.ofReduceBool, introduced by native_decide in bondy_quadratic_threshold (verifying n^2/4 >= n + log2 n for the small cases 7<=n<=15). No `axiom` declarations remain: the five former lower-bound axioms were removed because the abstract IsPancyclic model is flawed (edgeCount is disconnected from hasCycleOfLength, forcing pancyclicExcess n = 0). The grounded SimpleGraph model at the end recovers a non-vacuous edge lower bound. The mathematical results (Bondy, Griffin, GKW) are correct but their real proofs remain open on top of the grounded model.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
     "definitionCount": 5
@@ -87,6 +87,14 @@
       "startLine": 157,
       "endLine": 209,
       "mathContext": "$n^2/4\\ge n+\\log_2 n$ for $n\\ge 7$ (Bondy's quadratic threshold is far from the $\\log$-scale truth); $h(3)=0$."
+    },
+    {
+      "id": "sec-1016-grounded",
+      "title": "Grounded SimpleGraph Pancyclic Model",
+      "startLine": 213,
+      "endLine": 265,
+      "summary": "Replaces the flawed abstract scaffold with a model on SimpleGraph (Fin n): HasCycleOfLength / IsPancyclicGraph pin cycles to the concrete graph, and pancyclicGraph_card_edgeFinset_ge derives the non-vacuous baseline n <= |E(G)| from the genuine Hamiltonian cycle.",
+      "mathContext": "A length-k cycle is a trail of k distinct edges, so k <= G.edgeFinset.card; pancyclicity yields n <= |E(G)| for n >= 3 — the edge-cycle link the abstract model could not express."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-1016` ($h(n)$ = excess edges to force pancyclicity).

## Problem: misaligned + half-uncovered annotations
The 11 existing annotations were written against an earlier file layout: all anchored in **lines 33–105**, with several pointing at the wrong construct (e.g. `Bondy's Lower Bound` and `Small Cases` landed inside the `iteratedLog` section). The file's most distinctive content — a documented **model flaw** and its **grounded correction** — had no coverage at all.

## Fix
Re-anchored every annotation to its real construct, **preserving the excellent literature content** (Bondy/Griffin/GKW bounds, $\log^*$ growth) at correct locations, and added coverage for the whole second half. Now **9 annotations spanning lines 1–265, no overlaps**:

| Lines | Annotation |
|-------|-----------|
| 1–22 | Problem, conjecture, known bounds (Bondy/Griffin/GKW, OEIS) |
| 24–29 | Imports |
| 31–43 | The abstract model (diagnostic scaffold) |
| 45–63 | `iteratedLog` = $\log^*$ definition + termination |
| 65–101 | Structural properties of $\log^*$ |
| 103–141 | **The model flaw**: `pancyclicExcess` collapses to 0 |
| 143–157 | Mathematically-correct statements preserved as comments |
| 159–211 | Structural lemmas (incl. the genuine Bondy quadratic threshold) |
| 213–265 | **The grounded `SimpleGraph` model** (non-vacuous $n\le|E(G)|$) |

## Also
- **meta.json**: added the missing `Grounded SimpleGraph Pancyclic Model` section (213–265) — sections now cover the full file.
- **Axiom integrity**: the file uses `native_decide` in `bondy_quadratic_threshold` (small cases $7\le n\le 15$), which pulls in `Lean.ofReduceBool`. Disclosed it in `assumptions` and set `meta.axiomCount` 0→1; `leanFile.axiomCount` stays 0 (no literal `axiom` declarations). `status`/`badge` unchanged (`axiomatized`/`wip`, open problem).

## Verification
JSON valid; ranges contiguous, within the 265-line file, anchored on construct/doc-comment lines; gallery data-validation passes (content-only change).