### PR TITLE
Enrich Erdős 700 (gcd of n with binomial coefficients): realign annotations to full coverage + fix axiom disclosure

### DIFF
--- a/src/data/proofs/erdos-700/annotations.json
+++ b/src/data/proofs/erdos-700/annotations.json
@@ -1,134 +1,211 @@
 [
   {
-    "id": "erdos-700-largest-pf",
+    "id": "erdos-700-header",
     "proofId": "erdos-700",
+    "range": { "startLine": 1, "endLine": 18 },
+    "type": "concept",
+    "title": "Problem Statement: f(n) = min gcd(n, C(n,k))",
+    "content": "Erdős–Szekeres study $f(n)=\\min_{1<k\\le n/2}\\gcd\\!\\big(n,\\binom{n}{k}\\big)$ and pose three questions: (1) which composite $n$ satisfy $f(n)=n/P(n)$ (with $P(n)$ the largest prime factor)? (2) are there infinitely many composite $n$ with $f(n)>\\sqrt n$? (3) is $f(n)\\ll_A n/(\\log n)^A$ for every $A>0$? The formalization proves the surrounding structure: $f(n)\\le n/P(n)$ and $f(n)\\ge p(n)$ (smallest prime factor), the exact values $f(pq)=p$ and $f(30)=6$, and $f(p^2)\\ge p=\\sqrt n$; the three questions themselves stay open (two are stated as axioms).",
+    "mathContext": "$f(n)=\\min_{1<k\\le n/2}\\gcd(n,\\binom nk)$; known $p(n)\\le f(n)\\le n/P(n)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial coefficients",
+      "greatest common divisor",
+      "largest/smallest prime factor",
+      "Kummer's theorem"
+    ],
+    "prerequisites": [
+      "number theory",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "erdos-700-imports",
+    "proofId": "erdos-700",
+    "range": { "startLine": 20, "endLine": 26 },
+    "type": "context",
+    "title": "Imports",
+    "content": "Brings in Mathlib's `Nat.GCD`, `Nat.Choose`, `Nat.Prime`, and crucially `Nat.Multiplicity` — the latter supplies `Nat.Prime.multiplicity_choose` (Kummer's theorem), the engine behind the upper-bound non-divisibility lemma. `Real.Log` is used for the asymptotic Question 3.",
+    "mathContext": "`Nat.Multiplicity` provides Kummer's carry-counting formula for $v_p\\binom NK$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Nat.Multiplicity",
+      "Kummer's theorem",
+      "Nat.choose"
+    ],
+    "prerequisites": [
+      "Lean 4 imports"
+    ]
+  },
+  {
+    "id": "erdos-700-defs",
+    "proofId": "erdos-700",
+    "range": { "startLine": 28, "endLine": 48 },
     "type": "definition",
-    "range": { "startLine": 28, "endLine": 32 },
-    "title": "Largest Prime Factor P(n)",
-    "content": "Defines `largestPrimeFactor n` as the supremum of prime divisors of $n$ within `Finset.range (n+1)`, returning $0$ for $n \\leq 1$. This is $P(n)$, the largest prime in the factorization of $n$. By the Hardy-Ramanujan theorem, $P(n) \\sim \\log n$ for typical $n$, but $P(n)$ can be as large as $n$ (when $n$ is prime) or as small as $O(n^{1/\\omega(n)})$.",
-    "mathContext": "$P(n) = \\max\\{p \\text{ prime} : p \\mid n\\}$",
+    "title": "Core Definitions: P(n), p(n), and f(n)",
+    "content": "`largestPrimeFactor n` = $P(n)$ (a `Finset.sup` of prime divisors, $0$ for $n\\le 1$), `smallestPrimeFactor n` = $p(n)$ (Mathlib's `Nat.minFac`), and `fBinom n` = $f(n)$, the minimum of $\\gcd(n,\\binom nk)$ over $k\\in[2,n/2]$ (defined for $n\\ge 4$ where that range is nonempty, else $0$). The nonemptiness proof for `Finset.min'` is discharged inline by exhibiting $k=2$.",
+    "mathContext": "$P(n)=\\sup\\{p\\ \\text{prime}: p\\mid n\\}$, $p(n)=\\text{minFac}(n)$, $f(n)=\\min_{k\\in[2,n/2]}\\gcd(n,\\binom nk)$",
     "significance": "key",
-    "relatedConcepts": ["Finset.sup", "prime factorization", "Hardy-Ramanujan theorem", "smooth numbers"],
-    "prerequisites": ["prime numbers", "Finset operations", "supremum"]
+    "relatedConcepts": [
+      "Nat.minFac",
+      "Finset.min' / Finset.sup",
+      "prime factorization"
+    ],
+    "prerequisites": [
+      "Nat.minFac",
+      "Finset aggregation"
+    ]
   },
   {
-    "id": "erdos-700-smallest-pf",
+    "id": "erdos-700-minfac-helpers",
     "proofId": "erdos-700",
-    "type": "definition",
-    "range": { "startLine": 34, "endLine": 36 },
-    "title": "Smallest Prime Factor p(n)",
-    "content": "Defines `smallestPrimeFactor n` as `Nat.minFac n`, the smallest prime dividing $n$. For composite $n$, we always have $p(n) \\leq \\sqrt{n}$ since if all prime factors exceeded $\\sqrt{n}$, then $n$ would be prime. This gives the lower bound in the sandwich $p(n) \\leq f(n) \\leq n/P(n)$.",
-    "mathContext": "$p(n) = \\min\\{p \\text{ prime} : p \\mid n\\} = \\texttt{Nat.minFac}(n)$",
-    "significance": "key",
-    "relatedConcepts": ["Nat.minFac", "trial division", "prime factorization"],
-    "prerequisites": ["prime numbers", "divisibility"]
-  },
-  {
-    "id": "erdos-700-fbinom",
-    "proofId": "erdos-700",
-    "type": "concept",
-    "range": { "startLine": 38, "endLine": 46 },
-    "title": "The Function f(n)",
-    "content": "Defines `fBinom n` as $f(n) = \\min_{1 < k \\leq n/2} \\gcd(n, \\binom{n}{k})$ using `Finset.min'` over `Finset.Icc 2 (n/2)`. The range is proved nonempty for $n \\geq 4$ (since $2 \\leq n/2$). Returns $0$ for $n < 4$. Previously axiomatized; now a proper definition that captures the mathematical content directly.",
-    "mathContext": "$f(n) = \\min_{1 < k \\leq n/2} \\gcd\\bigl(n, \\binom{n}{k}\\bigr)$",
-    "significance": "key",
-    "relatedConcepts": ["gcd", "binomial coefficients", "Nat.choose", "Pascal's triangle"],
-    "prerequisites": ["gcd", "binomial coefficients", "well-ordering"]
-  },
-  {
-    "id": "erdos-700-upper",
-    "proofId": "erdos-700",
-    "type": "concept",
-    "range": { "startLine": 44, "endLine": 46 },
-    "title": "Upper Bound f(n) ≤ n/P(n)",
-    "content": "Axiomatizes `f_upper_bound`: $f(n) \\leq n/P(n)$ for composite $n \\geq 2$. This follows from Kummer's theorem: for $k = n/P(n)$, the base-$P(n)$ addition of $k$ and $n-k$ has exactly one carry, so $v_{P(n)}(\\binom{n}{k}) = 1$, giving $\\gcd(n, \\binom{n}{k}) \\leq n/P(n)$.",
-    "mathContext": "$f(n) \\leq n/P(n)$ for composite $n$, since $v_{P(n)}\\bigl(\\binom{n}{n/P(n)}\\bigr) = 1$",
-    "significance": "key",
-    "relatedConcepts": ["Kummer's theorem", "p-adic valuation", "carries in base-p addition"],
-    "prerequisites": ["Kummer's theorem", "p-adic valuation", "prime factorization"]
-  },
-  {
-    "id": "erdos-700-lower",
-    "proofId": "erdos-700",
-    "type": "concept",
-    "range": { "startLine": 48, "endLine": 50 },
-    "title": "Lower Bound f(n) ≥ p(n)",
-    "content": "Axiomatizes `f_lower_bound`: $f(n) \\geq p(n)$ for $n \\geq 2$. The smallest prime factor $p(n)$ divides both $n$ and every $\\binom{n}{k}$ for $0 < k < n$ (since $p(n) \\mid n$ implies $p(n) \\mid n \\cdot \\binom{n-1}{k-1}/k$, and careful analysis shows $p(n) \\mid \\gcd(n, \\binom{n}{k})$).",
-    "mathContext": "$p(n) \\leq f(n)$ for $n \\geq 2$, establishing the lower bound of the sandwich",
+    "range": { "startLine": 50, "endLine": 82 },
+    "type": "technique",
+    "title": "Prime-Factor Helper Lemmas",
+    "content": "Arithmetic support: `minFac_prime_sq` ($\\text{minFac}(p^2)=p$) and `minFac_mul_prime` ($\\text{minFac}(pq)=p$ for $p\\le q$) pin the smallest prime factor of the two structured inputs used later, while `le_largestPrimeFactor` shows every prime divisor is $\\le P(n)$ (needed to bound $n/P(n)$ from above in the semiprime case).",
+    "mathContext": "$\\text{minFac}(p^2)=p$;\\ $\\text{minFac}(pq)=p\\ (p\\le q)$;\\ $r\\ \\text{prime},\\ r\\mid n\\Rightarrow r\\le P(n)$",
     "significance": "supporting",
-    "relatedConcepts": ["Nat.minFac", "divisibility of binomial coefficients", "Vandermonde identity"],
-    "prerequisites": ["prime divisibility", "binomial coefficient properties"]
+    "relatedConcepts": [
+      "Nat.minFac_prime",
+      "Finset.le_sup",
+      "prime divisibility"
+    ],
+    "prerequisites": [
+      "Nat.minFac lemmas"
+    ]
   },
   {
-    "id": "erdos-700-semiprime",
+    "id": "erdos-700-absorption-lowerbound",
     "proofId": "erdos-700",
-    "type": "concept",
-    "range": { "startLine": 54, "endLine": 56 },
-    "title": "Semiprime Exact Value",
-    "content": "Axiomatizes `f_semiprime`: $f(pq) = p$ for primes $p \\leq q$. When $n = pq$, the upper bound gives $f(n) \\leq n/P(n) = pq/q = p$, and the lower bound gives $f(n) \\geq p(n) = p$, so $f(pq) = p$. This is the simplest nontrivial exact computation, showing the sandwich is tight for semiprimes.",
-    "mathContext": "$f(pq) = p = pq/q = n/P(n)$ for primes $p \\leq q$",
+    "range": { "startLine": 84, "endLine": 142 },
+    "type": "technique",
+    "title": "Absorption Identity and the Lower-Bound Core",
+    "content": "`n_dvd_k_mul_choose` derives $n\\mid k\\binom nk$ from Mathlib's absorption identity $(n{+}1)\\binom nk=\\binom{n+1}{k+1}(k{+}1)$. `gcd_choose_ge_minFac` then proves $\\text{minFac}(n)\\le \\gcd(n,\\binom nk)$ for $k\\in[2,n/2]$: writing $g=\\gcd(n,k)$, coprime cancellation ($n/g$ coprime to $k/g$) forces $n/g\\mid \\binom nk$, so $n/g\\mid\\gcd(n,\\binom nk)$; and since $g\\le k\\le n/2<n$ gives $n/g\\ge \\text{minFac}(n)$, the bound follows. This is the whole content of the $f(n)\\ge p(n)$ lower bound.",
+    "mathContext": "$n\\mid k\\binom nk$;\\ $g=\\gcd(n,k),\\ n/g\\mid\\binom nk\\Rightarrow \\text{minFac}(n)\\le n/g\\le\\gcd(n,\\binom nk)$",
     "significance": "key",
-    "relatedConcepts": ["semiprimes", "sandwich theorem", "Kummer's theorem"],
-    "prerequisites": ["prime factorization of semiprimes", "upper and lower bounds for f"]
+    "relatedConcepts": [
+      "Nat.succ_mul_choose_eq (absorption)",
+      "coprime cancellation",
+      "Nat.coprime_div_gcd_div_gcd"
+    ],
+    "prerequisites": [
+      "gcd / coprimality",
+      "Nat.choose"
+    ]
   },
   {
-    "id": "erdos-700-f30",
+    "id": "erdos-700-kummer",
     "proofId": "erdos-700",
-    "type": "concept",
-    "range": { "startLine": 58, "endLine": 59 },
-    "title": "f(30) = 6",
-    "content": "Axiomatizes `f_30`: $f(30) = 6 = 30/5$. Since $30 = 2 \\cdot 3 \\cdot 5$ is not a semiprime, this shows that $f(n) = n/P(n)$ can hold beyond the semiprime case. One verifies $\\gcd(30, \\binom{30}{k}) \\geq 6$ for all $1 < k \\leq 15$ and equality holds for some $k$.",
-    "mathContext": "$f(30) = 6 = 30/5 = n/P(n)$, where $30 = 2 \\cdot 3 \\cdot 5$",
+    "range": { "startLine": 144, "endLine": 232 },
+    "type": "technique",
+    "title": "Kummer's Theorem: p ∤ C(p^a·m−1, p^a−1)",
+    "content": "The technical heart of the upper bound. `prime_not_dvd_choose_shift` proves $p\\nmid\\binom{p^a m-1}{p^a-1}$ via Kummer's theorem: $v_p\\binom NK$ equals the number of carries when adding $K$ and $N-K$ in base $p$. Here $K=p^a-1$ occupies base-$p$ digit positions $0,\\dots,a-1$ while $N-K=p^a(m-1)$ occupies positions $\\ge a$, so the digit supports are disjoint and there are **zero carries** — hence $v_p=0$. The proof formalizes this by showing the carry-filter set is empty (`h_no_carry` case-splitting on $i\\le a$ vs $i>a$) and feeding it to `Nat.Prime.multiplicity_choose`.",
+    "mathContext": "$v_p\\binom NK=\\#\\{\\text{carries adding }K,\\,N-K\\text{ base }p\\}=0$ when digit supports are disjoint $\\Rightarrow p\\nmid\\binom NK$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kummer's theorem",
+      "Legendre / digit-sum formula",
+      "p-adic valuation",
+      "carries in base-p addition"
+    ],
+    "prerequisites": [
+      "Nat.Prime.multiplicity_choose",
+      "base-p representation"
+    ]
+  },
+  {
+    "id": "erdos-700-prime-power-gcd",
+    "proofId": "erdos-700",
+    "range": { "startLine": 234, "endLine": 271 },
+    "type": "technique",
+    "title": "Prime-Power GCD Evaluation",
+    "content": "`choose_eq_mul_choose_pred` restates the absorption identity as $\\binom nk=(n/k)\\binom{n-1}{k-1}$ when $k\\mid n$. Combined with `coprime_prime_pow_of_not_dvd` and the Kummer lemma, `gcd_choose_prime_pow_eq` computes the exact value $\\gcd\\big(p^a m,\\ \\binom{p^a m}{p^a}\\big)=m$: the $p^a$-part cancels (coprime, since $p\\nmid\\binom{p^a m-1}{p^a-1}$), leaving $m$. This is the identity that makes the upper bound tight at $k=P(n)$.",
+    "mathContext": "$\\gcd\\big(p^a m,\\binom{p^a m}{p^a}\\big)=m$, via $\\binom nk=(n/k)\\binom{n-1}{k-1}$ + coprimality of the $p^a$-part",
     "significance": "supporting",
-    "relatedConcepts": ["explicit computation", "non-semiprime examples", "gcd computation"],
-    "prerequisites": ["binomial coefficient computation", "gcd"]
+    "relatedConcepts": [
+      "absorption identity",
+      "Nat.gcd_mul_left",
+      "coprime prime powers"
+    ],
+    "prerequisites": [
+      "erdos-700-kummer",
+      "gcd factoring"
+    ]
   },
   {
-    "id": "erdos-700-q1",
+    "id": "erdos-700-sandwich",
     "proofId": "erdos-700",
-    "type": "concept",
-    "range": { "startLine": 90, "endLine": 98 },
-    "title": "Question 1: Characterization Problem (OPEN)",
-    "content": "Documents the open characterization problem: which composite $n$ satisfy $f(n) = n/P(n)$? Known examples: all semiprimes $pq$ and $n = 30$. A previous axiom falsely claimed this held for ALL composite $n$ (using a placeholder $\\leftrightarrow \\text{True}$); this has been corrected by removing the false axiom and replacing it with a comment documenting the open status.",
-    "mathContext": "$\\{n \\text{ composite} : f(n) = n/P(n)\\} \\supseteq \\{pq : p, q \\text{ prime}\\} \\cup \\{30\\}$",
+    "range": { "startLine": 273, "endLine": 334 },
+    "type": "insight",
+    "title": "The Sandwich Bounds: p(n) ≤ f(n) ≤ n/P(n)",
+    "content": "The two headline bounds. `f_upper_bound`: for composite $n$, taking $k=P(n)$ (exponent 1) — which lies in $[2,n/2]$ because $n/P(n)\\ge 2$ — gives $\\gcd(n,\\binom n{P})=n/P$ by the prime-power evaluation, so $f(n)\\le n/P(n)$. `f_lower_bound`: for $n\\ge 4$, every $k\\in[2,n/2]$ satisfies $\\gcd(n,\\binom nk)\\ge \\text{minFac}(n)$ by `gcd_choose_ge_minFac`, so $f(n)\\ge p(n)$. Together $p(n)\\le f(n)\\le n/P(n)$ — the sandwich that pins several exact values.",
+    "mathContext": "$p(n)\\le f(n)\\le n/P(n)$ for composite $n\\ge 4$",
     "significance": "key",
-    "relatedConcepts": ["characterization theorem", "digit structure", "Kummer's theorem"],
-    "prerequisites": ["upper bound for f", "semiprime result"]
+    "relatedConcepts": [
+      "sandwich / squeeze bound",
+      "Finset.min'_le / le_min'",
+      "largest prime factor"
+    ],
+    "prerequisites": [
+      "gcd_choose_prime_pow_eq",
+      "gcd_choose_ge_minFac"
+    ]
   },
   {
-    "id": "erdos-700-prime-sq",
+    "id": "erdos-700-exact-values",
     "proofId": "erdos-700",
-    "type": "concept",
-    "range": { "startLine": 102, "endLine": 112 },
-    "title": "Prime Square Lower Bound (PROVED)",
-    "content": "PROVES `f_prime_square`: $f(p^2) \\geq p = \\sqrt{p^2}$ for primes $p$, using `f_lower_bound` and the helper lemma `minFac_prime_sq`. The proof chain: $\\text{minFac}(p^2) = p$ (by `dvd_of_dvd_pow` and prime uniqueness), then $p = \\text{minFac}(p^2) \\leq f(p^2)$ (by `f_lower_bound`). Previously axiomatized; now machine-checked.",
-    "mathContext": "$f(p^2) \\geq p = \\sqrt{p^2}$ for prime $p$",
-    "significance": "supporting",
-    "relatedConcepts": ["Lucas' theorem", "prime squares", "base-p representation"],
-    "prerequisites": ["Lucas' theorem", "prime squares"]
-  },
-  {
-    "id": "erdos-700-q2",
-    "proofId": "erdos-700",
-    "type": "concept",
-    "range": { "startLine": 114, "endLine": 120 },
-    "title": "Question 2: Infinitely Many Large Values",
-    "content": "Formalizes `erdos_700_question2`: for every $N$, there exists composite $n \\geq N$ with $f(n) > \\sqrt{n}$. The prime square result provides infinitely many examples ($n = p^2$ for arbitrarily large primes $p$), so the deeper open content is whether non-prime-square composites can also achieve $f(n) > \\sqrt{n}$. Uses `Real.sqrt` for the comparison.",
-    "mathContext": "$\\forall N,\\; \\exists n \\geq N \\text{ composite}: f(n) > \\sqrt{n}$",
+    "range": { "startLine": 336, "endLine": 387 },
+    "type": "insight",
+    "title": "Known Exact Values: f(pq) = p and f(30) = 6",
+    "content": "`f_semiprime`: for a product of two primes $n=pq$ ($p\\le q$), the sandwich closes exactly — $p=\\text{minFac}(pq)\\le f(pq)\\le pq/P(pq)\\le pq/q=p$ — so $f(pq)=p$. `f_30`: $f(30)=30/5=6$, proved by `native_decide` (equality is realized at $k=5$: $\\gcd(30,\\binom{30}{5})=\\gcd(30,142506)=6$, and every $\\gcd(30,\\binom{30}k)\\ge 6$ over $k\\in[2,15]$). The `native_decide` for these concrete GCDs is why the entry carries `Lean.ofReduceBool`.",
+    "mathContext": "$f(pq)=p$ (sandwich collapses); $f(30)=6$ (min realized at $k=5$, checked by `native_decide`)",
     "significance": "key",
-    "relatedConcepts": ["Real.sqrt", "prime squares", "density of composites"],
-    "prerequisites": ["prime square lower bound", "real-valued comparisons"]
+    "relatedConcepts": [
+      "semiprime",
+      "native_decide (concrete gcd)",
+      "sandwich equality"
+    ],
+    "prerequisites": [
+      "erdos-700-sandwich",
+      "minFac_mul_prime"
+    ]
   },
   {
-    "id": "erdos-700-q3",
+    "id": "erdos-700-q1-primesquare",
     "proofId": "erdos-700",
+    "range": { "startLine": 389, "endLine": 410 },
     "type": "concept",
-    "range": { "startLine": 122, "endLine": 128 },
-    "title": "Question 3: Upper Bound Conjecture",
-    "content": "Formalizes `erdos_700_question3`: for every $A > 0$, there exists $C > 0$ such that $f(n) \\leq C \\cdot n / (\\log n)^A$ for all composite $n \\geq 4$. This is a strong growth restriction: it implies $f(n) = o(n/P(n))$ for typical $n$ (since $P(n) \\sim \\log n$ for most $n$ by the Hardy-Ramanujan theorem). The formalization uses `Real.log` and casts `fBinom n` to $\\mathbb{R}$.",
-    "mathContext": "$\\forall A > 0,\\; \\exists C > 0,\\; \\forall n \\geq 4 \\text{ composite}: f(n) \\leq \\frac{Cn}{(\\log n)^A}$",
+    "title": "Question 1 (Characterization) and f(p²) ≥ √n",
+    "content": "Question 1 asks *which* composite $n$ satisfy $f(n)=n/P(n)$; known instances are all semiprimes and $n=30$, but the general characterization is open (it fails once $n$ has many prime factors of varying size, letting a different $k$ achieve a smaller gcd). `f_prime_square` records a proved fact aimed at Question 2: $f(p^2)\\ge p=\\sqrt{p^2}$, immediate from the lower bound and $\\text{minFac}(p^2)=p$.",
+    "mathContext": "Open: characterize $\\{n\\ \\text{composite}: f(n)=n/P(n)\\}$. Proved: $f(p^2)\\ge p=\\sqrt{p^2}$",
     "significance": "key",
-    "relatedConcepts": ["asymptotic bounds", "Real.log", "Hardy-Ramanujan theorem", "typical order"],
-    "prerequisites": ["real analysis", "logarithmic bounds", "casting to reals"]
+    "relatedConcepts": [
+      "characterization problem",
+      "prime squares",
+      "f(n) = n/P(n)"
+    ],
+    "prerequisites": [
+      "f_lower_bound",
+      "minFac_prime_sq"
+    ]
+  },
+  {
+    "id": "erdos-700-open-axioms",
+    "proofId": "erdos-700",
+    "range": { "startLine": 412, "endLine": 427 },
+    "type": "concept",
+    "title": "Questions 2 & 3: The Open Axioms",
+    "content": "The two genuinely open questions are stated as axioms (marking exactly what is *not* proved). `erdos_700_question2`: infinitely many composite $n$ have $f(n)>\\sqrt n$ — prime squares give $f(p^2)\\ge p=\\sqrt n$ (equality, not strict), while $n=30$ gives the first strict example $6>\\lfloor\\sqrt{30}\\rfloor=5$. `erdos_700_question3`: $f(n)\\ll_A n/(\\log n)^A$ for every $A>0$, connecting to Hardy–Ramanujan ($P(n)\\sim \\log n$ typically, so $n/P(n)\\sim n/\\log n$ and $f(n)$ should be much smaller). These two axioms are the entry's only assumptions.",
+    "mathContext": "Axioms: $|\\{n\\ \\text{composite}: \\sqrt n<f(n)\\}|=\\infty$;\\ $\\forall A>0,\\exists C,\\ f(n)\\le C\\,n/(\\log n)^A$",
+    "significance": "key",
+    "relatedConcepts": [
+      "open conjecture (axiomatized)",
+      "Hardy–Ramanujan",
+      "largest prime factor asymptotics"
+    ],
+    "prerequisites": [
+      "f_prime_square",
+      "f_30"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -19,11 +19,11 @@
     "sourceUrl": "https://erdosproblems.com/700",
     "erdosUrl": "https://erdosproblems.com/700",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 427,
     "theoremCount": 14,
     "definitionCount": 3,
-    "assumptions": "2 axioms: (1) erdos_700_question2 — there are infinitely many composite n with f(n) > √n (open; n=30 is a known example); (2) erdos_700_question3 — f(n) ≪_A n/(log n)^A for every A > 0 (open; connects to Hardy-Ramanujan). 14 theorems proved: bounds, f(pq)=p, f(30)=6, f(p²)≥p. 0 sorries.",
+    "assumptions": "3 assumptions: (1) axiom erdos_700_question2 — infinitely many composite n with f(n) > sqrt(n) (open; n=30 is the first strict example); (2) axiom erdos_700_question3 — f(n) <<_A n/(log n)^A for every A>0 (open; connects to Hardy-Ramanujan); (3) Lean.ofReduceBool, from native_decide verifying the concrete GCDs in f_30 (f(30)=6). 14 theorems otherwise proved: the sandwich bounds p(n) <= f(n) <= n/P(n), f(pq)=p, f(p^2)>=p, the Kummer non-divisibility lemma. 0 sorries. (leanFile.axiomCount stays 2 — literal axiom declarations only.)",
     "mathlib_version": "4.26.0"
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `erdos-700` ($f(n)=\min_{1<k\le n/2}\gcd(n,\binom nk)$).

## Problem
The 11 existing annotations were misanchored (all clustered in lines 28–128, written for an earlier layout), leaving the **entire proof body (144–427)** uncovered at its true locations — including the Kummer-theorem non-divisibility lemma, the sandwich bounds, and the exact-value proofs.

## Fix
Re-anchored every annotation to its actual construct and covered the whole file. **11 annotations spanning lines 1–427, no overlaps:**

| Lines | Annotation |
|-------|-----------|
| 1–18 | Problem statement + the three questions |
| 20–26 | Imports (incl. `Nat.Multiplicity` = Kummer) |
| 28–48 | Definitions P(n), p(n), f(n) |
| 50–82 | Prime-factor helper lemmas |
| 84–142 | Absorption identity + lower-bound core |
| 144–232 | **Kummer's theorem**: $p\nmid\binom{p^a m-1}{p^a-1}$ via zero carries |
| 234–271 | Prime-power gcd evaluation |
| 273–334 | The sandwich bounds $p(n)\le f(n)\le n/P(n)$ |
| 336–387 | Exact values $f(pq)=p$, $f(30)=6$ |
| 389–410 | Question 1 + $f(p^2)\ge\sqrt n$ |
| 412–427 | Questions 2 & 3 (the open axioms) |

## Axiom integrity
The file uses `native_decide` in `f_30` (the headline exact value $f(30)=6$), pulling in `Lean.ofReduceBool`. Disclosed it and set `meta.axiomCount` 2→3; `leanFile.axiomCount` stays 2 (the two literal open-question `axiom` declarations). `status`/`badge` unchanged (`axiomatized`/`axiom`).

## Verification
JSON valid; ranges contiguous, within the 427-line file, anchored on construct/doc-comment lines; content-only change.