### PR TITLE
Enrich erdos-1012-oq-05: cover base case + derived decidable predicates (3→5 annotations)

### DIFF
--- a/src/data/proofs/erdos-1012-oq-05/annotations.json
+++ b/src/data/proofs/erdos-1012-oq-05/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "ann-e1012oq05-basecase",
+    "proofId": "erdos-1012-oq-05",
+    "range": {
+      "startLine": 60,
+      "endLine": 63
+    },
+    "type": "theorem",
+    "title": "The ℓ = 0 Base Case: No Cycle Has Length Zero",
+    "content": "`not_hasCycleOfLength_zero` records the recursion's base case: a cycle of length `0` cannot exist, since `hasCycleOfLength G 0` unfolds (via `simp [hasCycleOfLength]`) to a claim about an injective closed walk on the empty index type `Fin 0`, which is vacuously unsatisfiable in the form required. This is exactly the fact the `ℓ = 0` branch of `decidableHasCycleOfLength` leans on when it returns `decidable_of_iff False`. Small as it is, it anchors the well-founded definition: every decidability and search-space statement below is a statement about the `l + 1` successor case, with this providing the floor.",
+    "mathContext": "A cycle has at least three distinct vertices; in particular there is no cycle of length $0$, so $\\neg\\,\\mathrm{hasCycleOfLength}\\,G\\,0$ holds for every graph $G$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "base case of a recursion",
+      "vacuous existential",
+      "hasCycleOfLength"
+    ],
+    "prerequisites": [
+      "cycle length",
+      "simp normalization"
+    ]
+  },
+  {
     "id": "ann-e1012oq05-decidable",
     "proofId": "erdos-1012-oq-05",
     "range": {
@@ -20,6 +42,31 @@
     "prerequisites": [
       "Decidable instances in Lean 4",
       "Fintype-bounded existentials"
+    ]
+  },
+  {
+    "id": "ann-e1012oq05-derived",
+    "proofId": "erdos-1012-oq-05",
+    "range": {
+      "startLine": 76,
+      "endLine": 89
+    },
+    "type": "insight",
+    "title": "Decidability Propagates to Hamiltonicity and Pancyclicity",
+    "content": "Once cycle-length detection is decidable, the natural derived graph predicates inherit it for free. `decidableIsHamiltonian` observes that Hamiltonicity is just `hasCycleOfLength G |V|` — a single instance of the core predicate — so it reuses `decidableHasCycleOfLength` directly. Pancyclicity needs one reformulation first: `isPancyclicUpTo_iff` rewrites `isPancyclicUpTo G m` as the bounded conjunction `∀ l ∈ Finset.Icc 3 m, hasCycleOfLength G l`, a finite `∀` over a decidable family; `decidableIsPancyclicUpTo` then transports decidability across that equivalence with `decidable_of_iff`. The pattern is the workhorse of computable mathematics: express each new predicate as a `Fintype`-bounded quantifier over an already-decidable one, and its decision procedure assembles automatically.",
+    "mathContext": "$G$ is Hamiltonian iff it has a cycle of length $|V|$; $G$ is pancyclic up to $m$ iff it has a cycle of every length $\\ell \\in [3,m]$ — each a finite combination of decidable cycle-length tests, hence decidable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "decidable_of_iff",
+      "Hamiltonian cycle",
+      "pancyclic graph",
+      "bounded quantifier decidability",
+      "Finset.Icc"
+    ],
+    "prerequisites": [
+      "Decidable instances in Lean 4",
+      "predicate reformulation",
+      "bounded ∀ over a Finset"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Fills an **interior annotation-coverage gap** in `erdos-1012-oq-05` (Erdős #1012, decidability & brute-force search space for (n−k)-cycle detection). The entry had 3 annotations covering 7 of its 11 declarations, leaving the base case and the entire derived-decidability cluster unannotated.

## Added annotations (2)

- **The ℓ = 0 Base Case** (L60–63) — `not_hasCycleOfLength_zero`: the recursion floor that the `ℓ = 0` branch of `decidableHasCycleOfLength` (`decidable_of_iff False`) relies on.
- **Decidability Propagates to Hamiltonicity and Pancyclicity** (L76–89) — `decidableIsHamiltonian` (Hamiltonicity = `hasCycleOfLength G |V|`), `isPancyclicUpTo_iff` (reformulation as a bounded `∀ l ∈ Finset.Icc 3 m`), and `decidableIsPancyclicUpTo` (transport via `decidable_of_iff`). Highlights the computable-math workhorse pattern: express each new predicate as a `Fintype`-bounded quantifier over an already-decidable one.

## Coverage

All **11 declarations** now annotated (**3 → 5** annotations). No Lean source changes; annotations-only. startLines anchored on `/--` doc-comments; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)