### PR TITLE
Enrich halls-theorem-oq-02-oq-01: split lumped hall_defect proof into phase-aligned annotations (3→7)

### DIFF
--- a/src/data/proofs/halls-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/halls-theorem-oq-02-oq-01/annotations.json
@@ -24,23 +24,106 @@
   {
     "id": "hall-defect-main",
     "proofId": "halls-theorem-oq-02-oq-01",
-    "range": { "startLine": 47, "endLine": 160 },
+    "range": { "startLine": 47, "endLine": 59 },
     "type": "theorem",
-    "title": "hall_defect: the Dummy-Augmentation Reduction",
-    "content": "The main theorem. The proof adjoins d universal dummy targets by working in α ⊕ Fin d, with t' i = (t i).image Sum.inl ∪ D and D = univ.image Sum.inr the set of all d dummies. For nonempty S the augmented biUnion contains the disjoint union (S.biUnion t).image inl ⊍ D, so its cardinality is at least #(S.biUnion t) + d ≥ #S — exactly the exact Hall condition for t'. Mathlib's all_card_le_biUnion_card_iff_exists_injective then yields an injective g : ι → α ⊕ Fin d. The matched set s = {x | g x ∉ D} carries f (where g factors as Sum.inl (f x)); the complement injects via g into the d dummies, so |complement| ≤ d and Fintype.card ι ≤ #s + d.",
-    "mathContext": "Adjoin $d$ dummies: $t'(i) = \\iota_{\\mathrm{inl}}(t\\,i) \\cup D$, $D = \\{\\mathrm{inr}\\,j : j \\in \\mathrm{Fin}\\,d\\}$. Then $\\#(S.\\mathrm{biUnion}\\ t') \\ge \\#(S.\\mathrm{biUnion}\\ t) + d \\ge \\#S$, so Hall applies to $t'$.",
+    "title": "hall_defect: Statement of the Defect Form",
+    "content": "The main theorem. From the defect Hall hypothesis hcond (∀ S, #S ≤ #(S.biUnion t) + d) it produces a subset s : Finset ι together with a choice function f : ι → α such that Fintype.card ι ≤ #s + d, f x ∈ t x for every x ∈ s, and f is injective on s. The size bound is the crux: s omits at most d of the indices, so all but d are matched. The proof (unfolded in the following annotations) reduces this to the exact d = 0 case via a dummy-augmentation trick.",
+    "mathContext": "$\\exists\\, s : \\mathrm{Finset}\\ \\iota,\\ f : \\iota \\to \\alpha,\\ \\ \\mathrm{Fintype.card}\\ \\iota \\le \\#s + d \\ \\wedge\\ (\\forall x \\in s,\\ f\\,x \\in t\\,x) \\ \\wedge\\ \\mathrm{Set.InjOn}\\ f\\ s.$",
     "significance": "central",
     "relatedConcepts": [
-      "dummy augmentation",
-      "coproduct α ⊕ Fin d",
-      "disjoint union cardinality",
-      "injective transversal",
-      "pigeonhole"
+      "deficiency version",
+      "partial injective transversal",
+      "Set.InjOn",
+      "matching all but d indices"
     ],
     "prerequisites": [
       "Finset.biUnion and card",
-      "Sum types and Sum.inl/inr injectivity",
-      "Mathlib's Hall theorem"
+      "Set.InjOn",
+      "the exact Hall theorem"
+    ]
+  },
+  {
+    "id": "hall-defect-dummies",
+    "proofId": "halls-theorem-oq-02-oq-01",
+    "range": { "startLine": 60, "endLine": 66 },
+    "type": "step",
+    "title": "Adjoining d Universal Dummy Targets",
+    "content": "The reduction works in the coproduct α ⊕ Fin d. The set D = univ.image Sum.inr collects the d dummy targets living in the right summand; since Sum.inr is injective and Fin d has d elements, D.card = d exactly. These dummies will be made available to every index, absorbing the +d slack so that the augmented family satisfies the exact (rather than defect) Hall condition.",
+    "mathContext": "$D = \\{\\mathrm{inr}\\,j : j \\in \\mathrm{Fin}\\,d\\} \\subseteq \\alpha \\oplus \\mathrm{Fin}\\,d,\\qquad \\#D = d.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "coproduct α ⊕ Fin d",
+      "Sum.inr injectivity",
+      "Finset.card_image_of_injective",
+      "dummy augmentation"
+    ],
+    "prerequisites": [
+      "Sum types",
+      "Finset.image and card_image_of_injective"
+    ]
+  },
+  {
+    "id": "hall-defect-exact-hall",
+    "proofId": "halls-theorem-oq-02-oq-01",
+    "range": { "startLine": 67, "endLine": 105 },
+    "type": "step",
+    "title": "The Augmented Family Satisfies the Exact Hall Condition",
+    "content": "The combinatorial heart of the reduction. For the augmented family t' i = (t i).image Sum.inl ∪ D one shows ∀ S, #S ≤ #(S.biUnion t'). The empty family is trivial; for nonempty S the disjoint union (S.biUnion t).image Sum.inl ⊍ D embeds into the augmented biUnion (hsub), and its two halves are disjoint because inl-values never equal inr-values (hdisj). The final calc chains #S ≤ #(S.biUnion t) + d = #((S.biUnion t).image inl) + #D = #(that disjoint union) ≤ #(S.biUnion t'), converting the defect slack d into the exact Hall inequality.",
+    "mathContext": "$\\#S \\le \\#(S.\\mathrm{biUnion}\\ t) + d = \\#\\big((S.\\mathrm{biUnion}\\ t).\\mathrm{image}\\ \\mathrm{inl} \\ \\sqcup\\ D\\big) \\le \\#(S.\\mathrm{biUnion}\\ t').$",
+    "significance": "central",
+    "relatedConcepts": [
+      "exact Hall condition",
+      "disjoint union cardinality",
+      "Finset.card_union_of_disjoint",
+      "Finset.card_le_card",
+      "biUnion monotonicity"
+    ],
+    "prerequisites": [
+      "Finset.disjoint_left",
+      "Finset.card_union_of_disjoint",
+      "calc-style cardinality bounds"
+    ]
+  },
+  {
+    "id": "hall-defect-extract",
+    "proofId": "halls-theorem-oq-02-oq-01",
+    "range": { "startLine": 106, "endLine": 124 },
+    "type": "step",
+    "title": "Extracting the Matching from Exact Hall",
+    "content": "Mathlib's all_card_le_biUnion_card_iff_exists_injective, applied to the augmented family, yields an injective g : ι → α ⊕ Fin d with g x ∈ t' x. The matched set is s = {x | g x ∉ D} — the indices whose value avoids the dummies — and the choice function f x = Sum.elim id (const arbitrary) (g x) reads off the left component. The key structural fact hform shows that on s the value g z genuinely factors as Sum.inl (f z), so g restricted to matched indices really lands in the original target type α.",
+    "mathContext": "$g$ injective, $g\\,x \\in t'(x)$; $\\ s = \\{x : g\\,x \\notin D\\}$, $\\ f\\,x = \\mathrm{elim}\\ \\mathrm{id}\\ (\\lambda\\_. a_0)\\ (g\\,x)$, and $\\forall z \\in s,\\ g\\,z = \\mathrm{inl}(f\\,z).$",
+    "significance": "central",
+    "relatedConcepts": [
+      "all_card_le_biUnion_card_iff_exists_injective",
+      "Sum.elim",
+      "Finset.filter",
+      "factoring through Sum.inl"
+    ],
+    "prerequisites": [
+      "Mathlib's Hall theorem",
+      "Sum.elim / Sum.inl",
+      "Finset.filter and mem_filter"
+    ]
+  },
+  {
+    "id": "hall-defect-obligations",
+    "proofId": "halls-theorem-oq-02-oq-01",
+    "range": { "startLine": 125, "endLine": 160 },
+    "type": "step",
+    "title": "Discharging the Three Obligations",
+    "content": "The three parts of the existential are verified in turn. Size bound: the complement {x | g x ∈ D} injects into D via the injective g, so its cardinality is ≤ #D = d; combined with filter_card_add_filter_neg_card_eq_card and omega this gives Fintype.card ι ≤ #s + d. Membership: for x ∈ s the union membership g x ∈ t' x cannot be a dummy, so it comes from (t x).image inl, giving f x ∈ t x. Injectivity: for x, y ∈ s, hform rewrites g x = inl (f x) and g y = inl (f y); equal f-values force equal g-values, and injectivity of g closes the goal.",
+    "mathContext": "$\\#\\{x : g\\,x \\in D\\} = \\#(\\mathrm{image}\\ g) \\le \\#D = d \\Rightarrow \\mathrm{card}\\ \\iota \\le \\#s + d$; membership and $\\mathrm{InjOn}$ follow from $g\\,z = \\mathrm{inl}(f\\,z)$ on $s$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pigeonhole on the dummies",
+      "Finset.card_image_of_injOn",
+      "filter_card_add_filter_neg_card_eq_card",
+      "Set.InjOn"
+    ],
+    "prerequisites": [
+      "Finset.card_le_card via injective image",
+      "omega",
+      "Function.Injective.injOn"
     ]
   },
   {


### PR DESCRIPTION
## Summary

The defect-Hall entry `halls-theorem-oq-02-oq-01` had its main theorem `hall_defect` — a 106-line proof — covered by a **single** annotation spanning lines [47–160]. This PR splits that lumped annotation into the theorem statement plus four proof-phase steps, giving 1:1 alignment between annotations and the actual proof structure.

## Annotations: 3 → 7

Kept: `hall-defect-context` (concept) and `hall-defect-recovers-hall` (d=0 ⇒ classical Hall).

The old `hall-defect-main` [47–160] becomes:
| Range | Type | Content |
|-------|------|---------|
| 47–59 | theorem | `hall_defect` statement of the defect form |
| 60–66 | step | Adjoining `d` universal dummy targets (D ⊆ α ⊕ Fin d, #D = d) |
| 67–105 | step | The augmented family satisfies the **exact** Hall condition (core +d-slack argument) |
| 106–124 | step | Extracting the matching from Mathlib's Hall theorem |
| 125–160 | step | Discharging the three obligations (size bound, membership, injectivity) |

Coverage of [47–160] is contiguous with no overlaps; all ranges lie within the 179-line source file.

## Validation
- JSON parses; unique ids; every `range` within file bounds (1–179); no overlapping spans.
- No changes to `meta.json` or the Lean source — annotations only.