### PR TITLE
Enrich pac-learning-bounds-wip-01: split lumped VC-lemma annotations into per-theorem (4→8)

### DIFF
--- a/src/data/proofs/pac-learning-bounds-wip-01/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01/annotations.json
@@ -2,10 +2,7 @@
   {
     "id": "ann-pac-wip01-01-header",
     "proofId": "pac-learning-bounds-wip-01",
-    "range": {
-      "startLine": 1,
-      "endLine": 40
-    },
+    "range": { "startLine": 1, "endLine": 40 },
     "type": "concept",
     "title": "Replacing the Placeholder with Real VC Combinatorics",
     "content": "The header explains that the parent entry's growthFunction is a placeholder (:= 0), so no genuine statement about shattering is expressible, and that this file supplies proper definitions of the trace of a hypothesis class and of shattering, together with the foundational VC-dimension lemmas. A hypothesis class is modelled as a Finset (Finset α).",
@@ -26,14 +23,11 @@
   {
     "id": "ann-pac-wip01-02-defs",
     "proofId": "pac-learning-bounds-wip-01",
-    "range": {
-      "startLine": 42,
-      "endLine": 62
-    },
+    "range": { "startLine": 43, "endLine": 53 },
     "type": "definition",
     "title": "trace and Shatters",
-    "content": "trace H S := H.image (· ∩ S) is the family of restrictions of H to S — the genuine growth quantity Π_H(S). Shatters H S := (trace H S = S.powerset): H shatters S when its trace realises every subset of S. trace_subset_powerset proves each restriction h ∩ S is a subset of S, so the trace lies in the powerset.",
-    "mathContext": "Π_H(S) = {h ∩ S : h ∈ H} ⊆ 2^S; shattering means Π_H(S) = 2^S.",
+    "content": "trace H S := H.image (· ∩ S) is the family of restrictions of H to S — the genuine growth quantity Π_H(S) that replaces the parent's placeholder growthFunction := 0. Shatters H S := (trace H S = S.powerset): H shatters S precisely when its trace realises every subset of S, i.e. the restriction map H → 2^S is surjective.",
+    "mathContext": "$\\Pi_H(S) = \\{h \\cap S : h \\in H\\} \\subseteq 2^S$; shattering means $\\Pi_H(S) = 2^S$.",
     "significance": "central",
     "relatedConcepts": [
       "trace / restriction",
@@ -45,46 +39,117 @@
     ]
   },
   {
-    "id": "ann-pac-wip01-03-bounds",
+    "id": "ann-pac-wip01-03-trace-subset",
     "proofId": "pac-learning-bounds-wip-01",
-    "range": {
-      "startLine": 64,
-      "endLine": 89
-    },
+    "range": { "startLine": 54, "endLine": 61 },
     "type": "theorem",
-    "title": "Growth Bound, Shattering Criterion, and the |H| Lower Bound",
-    "content": "trace_card_le_pow: the trace has at most 2^|S| members (containment in the powerset + card_powerset) — the correct growth bound the placeholder could not express. shatters_iff_card: H shatters S iff the trace has exactly 2^|S| members (eq_of_subset_of_card_le upgrades maximal size to equality). shatters_card_le: shattering S forces 2^|S| ≤ |H|, since the trace is an image of H (card_image_le).",
-    "mathContext": "|Π_H(S)| ≤ 2^|S|, equality iff H shatters S; shattering a d-set needs at least 2^d hypotheses.",
+    "title": "trace_subset_powerset: the Trace Lives in the Powerset",
+    "content": "Every element of the trace is a restriction h ∩ S, which is a subset of S, so it belongs to S.powerset. Unfolding trace to the image and using Finset.inter_subset_right discharges the goal. This containment is the workhorse behind both the growth bound and the shattering criterion below.",
+    "mathContext": "$\\Pi_H(S) \\subseteq 2^S$, since $h \\cap S \\subseteq S$ for every $h \\in H$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "trace / restriction",
+      "Finset.mem_powerset",
+      "inter_subset_right"
+    ],
+    "prerequisites": [
+      "Finset.image and mem_image",
+      "Finset.mem_powerset"
+    ]
+  },
+  {
+    "id": "ann-pac-wip01-04-growth",
+    "proofId": "pac-learning-bounds-wip-01",
+    "range": { "startLine": 62, "endLine": 68 },
+    "type": "theorem",
+    "title": "trace_card_le_pow: the Growth Bound ≤ 2^|S|",
+    "content": "The trace of H on S has at most 2^|S| members — the correct growth-function bound the parent's placeholder growthFunction H n := 0 could not express. A one-line calc: the trace is contained in S.powerset (trace_subset_powerset), whose cardinality is exactly 2^|S| by Finset.card_powerset.",
+    "mathContext": "$|\\Pi_H(S)| \\le |2^S| = 2^{|S|}$.",
     "significance": "central",
     "relatedConcepts": [
       "growth function",
       "cardinality bound",
-      "image cardinality"
+      "Finset.card_powerset"
     ],
     "prerequisites": [
-      "Finset cardinality lemmas"
+      "Finset.card_le_card",
+      "Finset.card_powerset"
     ]
   },
   {
-    "id": "ann-pac-wip01-04-log-mono",
+    "id": "ann-pac-wip01-05-shatters-iff",
     "proofId": "pac-learning-bounds-wip-01",
-    "range": {
-      "startLine": 91,
-      "endLine": 109
-    },
+    "range": { "startLine": 69, "endLine": 79 },
     "type": "theorem",
-    "title": "The VC-vs-Size Bound and Monotonicity",
-    "content": "shatters_card_le_log: any shattered set has size |S| ≤ log₂|H|, via Nat.le_log_iff_pow_le applied to 2^|S| ≤ |H| — the elementary VC-dimension–vs–size bound (the finite half of Sauer–Shelah). shatters_mono: shattering is preserved when the hypothesis class grows (image_subset_image).",
-    "mathContext": "VC dimension ≤ log₂|H| for a finite class; a larger class shatters at least as many sets.",
+    "title": "shatters_iff_card: Shattering ⟺ Maximal Trace",
+    "content": "H shatters S exactly when its trace attains the maximal possible size 2^|S|. Forward is immediate from the definition; the converse upgrades a size-2^|S| trace to full equality with the powerset via Finset.eq_of_subset_of_card_le (a subset of the powerset whose card reaches |powerset| must be the whole powerset).",
+    "mathContext": "$H \\text{ shatters } S \\iff |\\Pi_H(S)| = 2^{|S|}$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "shattering criterion",
+      "Finset.eq_of_subset_of_card_le",
+      "maximal cardinality"
+    ],
+    "prerequisites": [
+      "trace_subset_powerset",
+      "Finset.card_powerset"
+    ]
+  },
+  {
+    "id": "ann-pac-wip01-06-lower-bound",
+    "proofId": "pac-learning-bounds-wip-01",
+    "range": { "startLine": 80, "endLine": 87 },
+    "type": "theorem",
+    "title": "shatters_card_le: Shattering Needs 2^|S| ≤ |H|",
+    "content": "If H shatters S then 2^|S| ≤ |H|: realising all 2^|S| subsets requires at least that many distinct hypotheses. The trace is an image of H, so |trace| ≤ |H| (Finset.card_image_le); combined with shatters_iff_card (|trace| = 2^|S|) this gives the bound.",
+    "mathContext": "$H \\text{ shatters } S \\implies 2^{|S|} \\le |H|$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "cardinality lower bound",
+      "Finset.card_image_le",
+      "shattering"
+    ],
+    "prerequisites": [
+      "shatters_iff_card",
+      "Finset.card_image_le"
+    ]
+  },
+  {
+    "id": "ann-pac-wip01-07-log-bound",
+    "proofId": "pac-learning-bounds-wip-01",
+    "range": { "startLine": 88, "endLine": 98 },
+    "type": "theorem",
+    "title": "shatters_card_le_log: VC Dimension ≤ log₂|H|",
+    "content": "Any set shattered by H has size |S| ≤ log₂|H| — the elementary, finite half of the Sauer–Shelah circle of results, and the genuine VC-dimension bound. From 2^|S| ≤ |H| (shatters_card_le), Nat.le_log_iff_pow_le converts the exponential inequality into |S| ≤ Nat.log 2 |H|; the nonzero-|H| side condition follows since 2^|S| ≥ 1.",
+    "mathContext": "$H \\text{ shatters } S \\implies |S| \\le \\log_2 |H|$, hence $\\mathrm{VCdim}(H) \\le \\log_2 |H|$.",
     "significance": "central",
     "relatedConcepts": [
       "VC dimension bound",
-      "integer logarithm",
-      "monotonicity"
+      "Nat.log",
+      "Sauer–Shelah"
     ],
     "prerequisites": [
-      "Nat.log",
-      "monotonicity of Finset image"
+      "shatters_card_le",
+      "Nat.le_log_iff_pow_le"
+    ]
+  },
+  {
+    "id": "ann-pac-wip01-08-mono",
+    "proofId": "pac-learning-bounds-wip-01",
+    "range": { "startLine": 99, "endLine": 109 },
+    "type": "theorem",
+    "title": "shatters_mono: Monotonicity of Shattering",
+    "content": "Enlarging the hypothesis class preserves shattering: if H ⊆ H' and H shatters S, then H' shatters S. Since trace is monotone in H (Finset.image_subset_image), the larger trace still reaches size 2^|S|, and shatters_iff_card promotes this back to full shattering.",
+    "mathContext": "$H \\subseteq H' \\text{ and } H \\text{ shatters } S \\implies H' \\text{ shatters } S$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotonicity",
+      "Finset.image_subset_image",
+      "shattering"
+    ],
+    "prerequisites": [
+      "shatters_iff_card",
+      "trace_subset_powerset"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

The VC-foundations entry `pac-learning-bounds-wip-01` lumped five theorems across just two annotations: `[64–89]` covered *three* results (growth bound, shattering criterion, |H| lower bound) and `[91–109]` covered *two* (VC-vs-size, monotonicity). The definition annotation `[42–62]` also mixed both defs with `trace_subset_powerset`. This PR realigns annotations 1:1 with the source declarations.

## Annotations: 4 → 8

Kept: `ann-pac-wip01-01-header` (concept).

| Range | Type | Declaration |
|-------|------|-------------|
| 43–53 | definition | `trace`, `Shatters` |
| 54–61 | theorem | `trace_subset_powerset` |
| 62–68 | theorem | `trace_card_le_pow` (growth bound ≤ 2^\|S\|) |
| 69–79 | theorem | `shatters_iff_card` (shattering ⟺ maximal trace) |
| 80–87 | theorem | `shatters_card_le` (needs 2^\|S\| ≤ \|H\|) |
| 88–98 | theorem | `shatters_card_le_log` (VC dim ≤ log₂\|H\|) |
| 99–109 | theorem | `shatters_mono` (monotonicity) |

## Validation
- JSON parses; unique ids; every `range` within file bounds (1–110); no overlapping spans; contiguous over the split region.
- No changes to `meta.json` or the Lean source — annotations only.