### PR TITLE
research(inclusion-exclusion-oq-05): Bonferroni odd/even truncation inequalities [VERIFIED, 0-axiom, 11thm/3def/204L, new entry]

### DIFF
--- a/proofs/Proofs/BonferroniInequalities.lean
+++ b/proofs/Proofs/BonferroniInequalities.lean
@@ -1,0 +1,204 @@
+/-
+# Bonferroni Inequalities
+
+Truncating the inclusion–exclusion series for the cardinality of a finite union
+of finite sets at an **odd** number of terms *overestimates* the true
+cardinality, and at an **even** number of terms *underestimates* it.
+
+This resolves the standing TODO in Mathlib's
+`Mathlib/Combinatorics/Enumerative/InclusionExclusion.lean`:
+
+> Prove that truncating the series alternatively gives an upper/lower bound to
+> the true value.
+
+## Strategy
+
+The engine is a *partial* alternating binomial identity that Mathlib does not
+yet contain (it only has the full sum `Int.alternating_sum_range_choose`):
+`∑_{k=0}^{m} (-1)^k C(n+1, k) = (-1)^m C(n, m)`.
+
+Fix an element `a` lying in exactly `N ≥ 1` of the sets. The truncated
+inclusion–exclusion value *at `a`* is
+`∑_{k=1}^{m} (-1)^{k+1} C(N, k) = 1 - (-1)^m C(N-1, m)`,
+which is `≥ 1` for odd `m` (overestimate) and `≤ 1` for even `m`
+(underestimate). Summing this pointwise bound over all elements of the union,
+the count of size-`k` subsets whose intersection contains `a` becomes
+`C(N, k)` (via `Finset.card_powersetCard`), yielding the set-level inequalities.
+-/
+import Mathlib
+
+open Finset
+
+namespace Bonferroni
+
+/-! ## Part 1: the partial alternating binomial identity -/
+
+/-- **Partial alternating sum of binomial coefficients.**
+`∑_{k=0}^{m} (-1)^k C(n+1, k) = (-1)^m C(n, m)`.
+
+Writing the top argument as `n + 1` (rather than a hypothesis `1 ≤ n`) sidesteps
+natural-number subtraction. Mathlib only provides the *full* sum
+(`Int.alternating_sum_range_choose`); this is the truncated version. -/
+theorem alternating_sum_range_choose_partial (n m : ℕ) :
+    ∑ k ∈ Finset.range (m + 1), (-1 : ℤ) ^ k * ((n + 1).choose k) =
+      (-1) ^ m * (n.choose m) := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.sum_range_succ, ih, Nat.choose_succ_succ' n m]
+    push_cast
+    ring
+
+/-- The truncated inclusion–exclusion value carried by a single element that
+lies in `n + 1` of the sets:
+`∑_{k=1}^{m} (-1)^{k+1} C(n+1, k) = 1 - (-1)^m C(n, m)`. -/
+theorem bonferroni_pointwise (n m : ℕ) :
+    ∑ k ∈ Finset.Icc 1 m, (-1 : ℤ) ^ (k + 1) * ((n + 1).choose k) =
+      1 - (-1) ^ m * (n.choose m) := by
+  have h1 := alternating_sum_range_choose_partial n m
+  have hsplit : Finset.range (m + 1) = insert 0 (Finset.Icc 1 m) := by
+    ext x; simp only [Finset.mem_range, Finset.mem_insert, Finset.mem_Icc]; omega
+  rw [hsplit, Finset.sum_insert (by simp)] at h1
+  simp only [pow_zero, Nat.choose_zero_right, Nat.cast_one, one_mul] at h1
+  -- h1 : 1 + ∑ k ∈ Icc 1 m, (-1)^k * C(n+1,k) = (-1)^m * C(n,m)
+  have hIcc : ∑ k ∈ Finset.Icc 1 m, (-1 : ℤ) ^ k * ((n + 1).choose k) =
+      (-1) ^ m * (n.choose m) - 1 := by linear_combination h1
+  calc ∑ k ∈ Finset.Icc 1 m, (-1 : ℤ) ^ (k + 1) * ((n + 1).choose k)
+      = ∑ k ∈ Finset.Icc 1 m, (-1 : ℤ) * ((-1) ^ k * ((n + 1).choose k)) := by
+        apply Finset.sum_congr rfl; intro k _; rw [pow_succ]; ring
+    _ = (-1) * ∑ k ∈ Finset.Icc 1 m, (-1 : ℤ) ^ k * ((n + 1).choose k) := by
+        rw [← Finset.mul_sum]
+    _ = 1 - (-1) ^ m * (n.choose m) := by rw [hIcc]; ring
+
+/-- Odd truncation overestimates at the level of a single element. -/
+theorem bonferroni_pointwise_odd (n m : ℕ) (hm : Odd m) :
+    (1 : ℤ) ≤ ∑ k ∈ Finset.Icc 1 m, (-1 : ℤ) ^ (k + 1) * ((n + 1).choose k) := by
+  rw [bonferroni_pointwise, hm.neg_one_pow]
+  have : (0 : ℤ) ≤ (n.choose m) := Nat.cast_nonneg _
+  linarith
+
+/-- Even truncation underestimates at the level of a single element. -/
+theorem bonferroni_pointwise_even (n m : ℕ) (hm : Even m) :
+    ∑ k ∈ Finset.Icc 1 m, (-1 : ℤ) ^ (k + 1) * ((n + 1).choose k) ≤ 1 := by
+  rw [bonferroni_pointwise, hm.neg_one_pow]
+  have : (0 : ℤ) ≤ (n.choose m) := Nat.cast_nonneg _
+  linarith
+
+/-! ## Part 2: aggregation to the cardinality of a union -/
+
+variable {ι α : Type*} [DecidableEq ι] [DecidableEq α]
+
+/-- The number of elements of the union `⋃_{i∈s} S i` that lie in every `S i`
+for `i ∈ t`. For a nonempty `t ⊆ s` this is exactly `#(⋂_{i∈t} S i)`; phrasing
+it via a filter over the union avoids `Finset.inf'` bookkeeping. -/
+def interCard (s : Finset ι) (S : ι → Finset α) (t : Finset ι) : ℕ :=
+  ((s.biUnion S).filter (fun a => ∀ i ∈ t, a ∈ S i)).card
+
+/-- The truncated inclusion–exclusion sum for `#(⋃_{i∈s} S i)`, keeping subsets
+of size `1 … m`:
+`∑_{k=1}^{m} (-1)^{k+1} ∑_{t ⊆ s, |t|=k} #(⋂_{i∈t} S i)`. -/
+def truncIE (s : Finset ι) (S : ι → Finset α) (m : ℕ) : ℤ :=
+  ∑ k ∈ Finset.Icc 1 m,
+    (-1) ^ (k + 1) * ∑ t ∈ s.powersetCard k, (interCard s S t : ℤ)
+
+/-- The multiplicity of an element `a`: the number of sets `S i`, `i ∈ s`, that
+contain it. -/
+def mult (s : Finset ι) (S : ι → Finset α) (a : α) : ℕ :=
+  (s.filter (fun i => a ∈ S i)).card
+
+/-- **Counting lemma.** For a fixed element `a`, the number of size-`k` subsets
+`t ⊆ s` all of whose sets contain `a` is `C(mult a, k)`. -/
+theorem card_powersetCard_filter (s : Finset ι) (S : ι → Finset α) (a : α) (k : ℕ) :
+    ((s.powersetCard k).filter (fun t => ∀ i ∈ t, a ∈ S i)).card =
+      (mult s S a).choose k := by
+  rw [mult, ← Finset.card_powersetCard]
+  congr 1
+  ext t
+  simp only [Finset.mem_filter, Finset.mem_powersetCard]
+  constructor
+  · rintro ⟨⟨hts, hcard⟩, hall⟩
+    refine ⟨?_, hcard⟩
+    intro x hx
+    exact Finset.mem_filter.2 ⟨hts hx, hall x hx⟩
+  · rintro ⟨hsub, hcard⟩
+    refine ⟨⟨?_, hcard⟩, ?_⟩
+    · intro x hx
+      exact (Finset.mem_filter.1 (hsub hx)).1
+    · intro x hx
+      exact (Finset.mem_filter.1 (hsub hx)).2
+
+/-- The counting lemma in `if-then-else` (indicator) form. -/
+theorem sum_powersetCard_boole (s : Finset ι) (S : ι → Finset α) (a : α) (k : ℕ) :
+    ∑ t ∈ s.powersetCard k, (if (∀ i ∈ t, a ∈ S i) then (1 : ℤ) else 0) =
+      ((mult s S a).choose k : ℤ) := by
+  rw [Finset.sum_boole, card_powersetCard_filter]
+
+/-- The truncated inclusion–exclusion sum equals the sum over elements of the
+union of their pointwise truncated values. -/
+theorem truncIE_eq_sum_over_union (s : Finset ι) (S : ι → Finset α) (m : ℕ) :
+    truncIE s S m =
+      ∑ a ∈ s.biUnion S,
+        ∑ k ∈ Finset.Icc 1 m, (-1) ^ (k + 1) * ((mult s S a).choose k : ℤ) := by
+  -- Rewrite each interCard as a sum of indicators over the union.
+  have hcard : ∀ t : Finset ι, (interCard s S t : ℤ) =
+      ∑ a ∈ s.biUnion S, (if (∀ i ∈ t, a ∈ S i) then (1 : ℤ) else 0) := by
+    intro t; rw [interCard, ← Finset.sum_boole]
+  -- First rewrite `truncIE` with the outer sum ranging over `k` then `a`.
+  have step1 : truncIE s S m =
+      ∑ k ∈ Finset.Icc 1 m, ∑ a ∈ s.biUnion S,
+        (-1) ^ (k + 1) * ((mult s S a).choose k : ℤ) := by
+    unfold truncIE
+    apply Finset.sum_congr rfl
+    intro k _
+    have hR : ∑ a ∈ s.biUnion S, (-1 : ℤ) ^ (k + 1) * ((mult s S a).choose k) =
+        ∑ a ∈ s.biUnion S, ∑ t ∈ s.powersetCard k,
+          (-1) ^ (k + 1) * (if (∀ i ∈ t, a ∈ S i) then (1 : ℤ) else 0) := by
+      apply Finset.sum_congr rfl
+      intro a _
+      rw [← sum_powersetCard_boole s S a k, Finset.mul_sum]
+    rw [Finset.mul_sum, hR, Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro t _
+    rw [hcard t, Finset.mul_sum]
+  rw [step1, Finset.sum_comm]
+
+/-- Rewriting `#(⋃ S i)` as a sum of ones over the union. -/
+private theorem card_biUnion_eq_sum_ones (s : Finset ι) (S : ι → Finset α) :
+    ((s.biUnion S).card : ℤ) = ∑ _a ∈ s.biUnion S, (1 : ℤ) := by
+  simp
+
+/-- Every element of the union lies in at least one of the sets. -/
+theorem one_le_mult {s : Finset ι} {S : ι → Finset α} {a : α}
+    (ha : a ∈ s.biUnion S) : 1 ≤ mult s S a := by
+  rw [Finset.mem_biUnion] at ha
+  obtain ⟨i, hi, hai⟩ := ha
+  rw [mult, Nat.one_le_iff_ne_zero, Finset.card_ne_zero]
+  exact ⟨i, Finset.mem_filter.2 ⟨hi, hai⟩⟩
+
+/-! ## Part 3: the Bonferroni inequalities -/
+
+/-- **Bonferroni inequality (odd truncation).** Truncating the inclusion–exclusion
+series at an odd number of terms *overestimates* the cardinality of the union. -/
+theorem card_biUnion_le_truncIE_odd (s : Finset ι) (S : ι → Finset α) {m : ℕ}
+    (hm : Odd m) : ((s.biUnion S).card : ℤ) ≤ truncIE s S m := by
+  rw [truncIE_eq_sum_over_union, card_biUnion_eq_sum_ones]
+  apply Finset.sum_le_sum
+  intro a ha
+  obtain ⟨n, hn⟩ : ∃ n, mult s S a = n + 1 :=
+    ⟨mult s S a - 1, by have := one_le_mult ha; omega⟩
+  rw [hn]
+  exact bonferroni_pointwise_odd n m hm
+
+/-- **Bonferroni inequality (even truncation).** Truncating the inclusion–exclusion
+series at an even number of terms *underestimates* the cardinality of the union. -/
+theorem truncIE_le_card_biUnion_even (s : Finset ι) (S : ι → Finset α) {m : ℕ}
+    (hm : Even m) : truncIE s S m ≤ ((s.biUnion S).card : ℤ) := by
+  rw [truncIE_eq_sum_over_union, card_biUnion_eq_sum_ones]
+  apply Finset.sum_le_sum
+  intro a ha
+  obtain ⟨n, hn⟩ : ∃ n, mult s S a = n + 1 :=
+    ⟨mult s S a - 1, by have := one_le_mult ha; omega⟩
+  rw [hn]
+  exact bonferroni_pointwise_even n m hm
+
+end Bonferroni

--- a/src/data/proofs/inclusion-exclusion-oq-05/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-05/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "inclusion-exclusion-oq-05",
+  "title": "Bonferroni Inequalities: Odd/Even Truncation Bounds for Inclusion–Exclusion",
+  "slug": "inclusion-exclusion-oq-05",
+  "description": "Proves the Bonferroni inequalities: truncating the inclusion–exclusion series for the cardinality of a finite union at an ODD number of terms overestimates |⋃ Sᵢ|, and at an EVEN number underestimates it. The engine is a partial alternating binomial identity — ∑_{k=0}^{m} (-1)^k C(n+1,k) = (-1)^m C(n,m) — that Mathlib does not yet contain (it has only the full sum). Aggregating the resulting pointwise bound over the union via Finset.card_powersetCard yields the set-level inequalities. Resolves the standing TODO in Mathlib's InclusionExclusion.lean. 11 theorems, 3 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BonferroniInequalities.lean",
+    "tags": [
+      "combinatorics",
+      "inclusion-exclusion",
+      "bonferroni",
+      "finset",
+      "binomial-coefficients",
+      "cardinality"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using Mathlib's Finset and binomial-coefficient API. No `axiom` declarations, no structure-encoded assumptions, no `native_decide`; depends only on the foundational axioms propext / Classical.choice / Quot.sound.",
+    "lineCount": 204,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "originalContributions": [
+      "alternating_sum_range_choose_partial: the PARTIAL alternating binomial identity ∑_{k=0}^{m} (-1)^k C(n+1,k) = (-1)^m C(n,m), proved by induction with Pascal's rule. Mathlib provides only the full sum (Int.alternating_sum_range_choose); this truncated version is the combinatorial engine of Bonferroni and is not in Mathlib.",
+      "bonferroni_pointwise: the truncated inclusion–exclusion value carried by a single element lying in n+1 sets equals 1 - (-1)^m C(n,m), reducing the whole inequality to a one-line sign check.",
+      "card_biUnion_le_truncIE_odd: the ODD Bonferroni inequality |⋃_{i∈s} Sᵢ| ≤ ∑_{k=1}^{m}(-1)^{k+1}∑_{|t|=k}|⋂_{i∈t}Sᵢ| for odd m — odd truncation overestimates the union cardinality.",
+      "truncIE_le_card_biUnion_even: the EVEN Bonferroni inequality — even truncation underestimates the union cardinality.",
+      "truncIE_eq_sum_over_union: the aggregation identity rewriting the truncated inclusion–exclusion sum as a sum, over each element of the union, of its pointwise truncated value ∑_{k=1}^{m}(-1)^{k+1}C(mult a, k); the counting step uses Finset.card_powersetCard.",
+      "card_powersetCard_filter: for a fixed element a, the number of size-k subsets t ⊆ s whose sets all contain a is C(mult a, k) — the bridge from the powerset sum to binomial coefficients."
+    ],
+    "historicalContext": "The inclusion–exclusion principle computes |⋃ Aᵢ| as a signed sum over all intersections. In applications one rarely evaluates the full alternating sum; instead one TRUNCATES it after a few terms and asks for a one-sided error bound. Carlo Emilio Bonferroni (1936) showed that these truncations bracket the true value: stopping after an odd number of terms overestimates, after an even number underestimates. The classic special cases are Boole's union bound |⋃ Aᵢ| ≤ ∑ |Aᵢ| (m = 1) and the lower bound ∑|Aᵢ| - ∑_{i<j}|Aᵢ∩Aⱼ| ≤ |⋃ Aᵢ| (m = 2). Bonferroni's inequalities are ubiquitous in probability and statistics (simultaneous confidence intervals, the Bonferroni correction for multiple comparisons) and in the probabilistic method. Mathlib's InclusionExclusion.lean carries the full identity and an explicit TODO requesting exactly this truncation bound.",
+    "problemStatement": "**The Open Question**\n\nTruncating the inclusion–exclusion series for |⋃_{i∈s} Sᵢ| after finitely many terms, does the partial sum bound the true cardinality — and on which side?\n\n**Answer**\n\nWrite the truncated sum keeping subsets of size 1…m,\n\n  T_m = ∑_{k=1}^{m} (-1)^{k+1} ∑_{t⊆s, |t|=k} |⋂_{i∈t} Sᵢ|.\n\nThen for every family {Sᵢ}_{i∈s} of finite sets:\n\n  • m odd  ⟹  |⋃_{i∈s} Sᵢ| ≤ T_m   (overestimate),\n  • m even ⟹  T_m ≤ |⋃_{i∈s} Sᵢ|   (underestimate).\n\nThis is proved from a partial alternating binomial identity, aggregated over the elements of the union."
+  },
+  "overview": {
+    "historicalContext": "Bonferroni's inequalities (C. E. Bonferroni, 1936) refine the inclusion–exclusion principle: truncating the alternating sum for |⋃ Aᵢ| after an odd number of summation levels overestimates the true count, and after an even number underestimates it. The two shortest cases are the most famous — the union bound |⋃ Aᵢ| ≤ ∑|Aᵢ| (Boole's inequality) and its second-order companion ∑|Aᵢ| - ∑_{i<j}|Aᵢ∩Aⱼ| ≤ |⋃ Aᵢ|. They pervade probability (the Bonferroni correction controls family-wise error in multiple hypothesis testing) and combinatorics (the probabilistic method routinely uses low-order truncations). Mathlib formalizes the full inclusion–exclusion identity but records a TODO asking precisely for these one-sided truncation bounds; this entry supplies them.",
+    "problemStatement": "Show that truncating the inclusion–exclusion series for the cardinality of a finite union bounds the true value: odd truncation from above, even truncation from below.",
+    "text": "Proves the Bonferroni inequalities for the cardinality of a finite union of finite sets:\n1. **Partial binomial identity** (alternating_sum_range_choose_partial): ∑_{k=0}^{m}(-1)^k C(n+1,k) = (-1)^m C(n,m), the truncated form of the alternating binomial sum, by induction on m using Pascal's rule.\n2. **Pointwise value** (bonferroni_pointwise): an element in n+1 of the sets contributes ∑_{k=1}^{m}(-1)^{k+1}C(n+1,k) = 1 - (-1)^m C(n,m) to the truncated sum.\n3. **Aggregation** (truncIE_eq_sum_over_union): the truncated inclusion–exclusion sum equals the sum over union elements of their pointwise values; the count of size-k subsets containing a fixed element is C(mult a, k) via Finset.card_powersetCard.\n4. **The inequalities** (card_biUnion_le_truncIE_odd, truncIE_le_card_biUnion_even): odd truncation ≥ |⋃ Sᵢ| ≥ even truncation.",
+    "proofStrategy": "**Reduce to a single element.** Fix a ∈ ⋃ Sᵢ and let N = mult a be the number of sets containing it (N ≥ 1). The truncated inclusion–exclusion sum, restricted to a, is ∑_{k=1}^{m}(-1)^{k+1}·#{size-k subsets whose intersection contains a}. Since the k-subsets of s whose every set contains a are exactly the k-subsets of the multiplicity family, that count is C(N,k).\n\n**Partial binomial identity.** Prove ∑_{k=0}^{m}(-1)^k C(n+1,k) = (-1)^m C(n,m) by induction on m; the step is Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1) followed by `ring`. Writing the top index as n+1 avoids ℕ-subtraction. Splitting off the k=0 term gives the pointwise value ∑_{k=1}^{m}(-1)^{k+1}C(n+1,k) = 1 - (-1)^m C(n,m).\n\n**Sign check.** For odd m, (-1)^m = -1 so the value is 1 + C(n,m) ≥ 1; for even m it is 1 - C(n,m) ≤ 1. The union indicator at a is exactly 1, so each element over/under-shoots by C(n,m) ≥ 0.\n\n**Aggregate.** Represent #(⋂_{i∈t} Sᵢ) as ∑_{a∈⋃} [a ∈ ⋂] (a filter over the union, avoiding Finset.inf'), swap the order of summation (Finset.sum_comm), and apply the counting lemma. Summing the pointwise bounds via Finset.sum_le_sum against #(⋃) = ∑_{a∈⋃} 1 gives the two inequalities.",
+    "keyInsights": [
+      "**A partial identity, not the full one.** Mathlib's Int.alternating_sum_range_choose evaluates the COMPLETE alternating binomial sum (which telescopes to 0 or 1). Bonferroni needs the PARTIAL sum ∑_{k=0}^{m}, which equals (-1)^m C(n,m) — a clean closed form that is not in Mathlib and is the crux of the whole argument.",
+      "**Pascal collapses the induction.** The inductive step ∑_{k=0}^{m+1} = ∑_{k=0}^{m} + (-1)^{m+1}C(n+1,m+1) closes immediately once C(n+1,m+1) is expanded by Pascal's rule into C(n,m) + C(n,m+1); `push_cast; ring` finishes.",
+      "**Everything is pointwise.** The set-level inequality is just the elementwise bound `1 ≤ (or ≥) pointwise value` summed over the union. The union indicator is identically 1 on its own support, so the per-element defect is exactly (-1)^m C(mult a - 1, m), whose sign is governed by the parity of m.",
+      "**Counting = choosing.** The number of size-k subsets t ⊆ s all of whose sets contain a equals the number of k-subsets of the multiplicity family {i ∈ s : a ∈ Sᵢ}, i.e. C(mult a, k) — this is Finset.card_powersetCard after identifying the two filtered powersets.",
+      "**Filter over the union beats Finset.inf'.** Writing #(⋂_{i∈t} Sᵢ) as `#((⋃ Sᵢ).filter (∀ i∈t, · ∈ Sᵢ))` sidesteps the nonemptiness bookkeeping of Finset.inf' and makes the double-sum swap a one-liner via Finset.sum_boole and Finset.sum_comm."
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_succ' (Pascal's rule for binomial coefficients)",
+      "Finset.sum_range_succ, Finset.sum_insert (splitting alternating sums)",
+      "Finset.card_powersetCard, Finset.mem_powersetCard (counting fixed-size subsets)",
+      "Finset.sum_boole (a sum of 0/1 indicators equals a filtered cardinality)",
+      "Finset.sum_comm, Finset.mul_sum, Finset.sum_le_sum (reordering and bounding finite sums)",
+      "Odd.neg_one_pow / Even.neg_one_pow (the parity of (-1)^m)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part-1-partial-binomial",
+      "title": "Part I: The Partial Alternating Binomial Identity",
+      "startLine": 34,
+      "endLine": 85,
+      "summary": "alternating_sum_range_choose_partial proves ∑_{k=0}^{m}(-1)^k C(n+1,k) = (-1)^m C(n,m) by induction with Pascal's rule; bonferroni_pointwise derives the single-element truncated value 1 - (-1)^m C(n,m); bonferroni_pointwise_odd/even read off its sign.",
+      "mathContext": "$\\sum_{k=0}^{m}(-1)^k\\binom{n+1}{k} = (-1)^m\\binom{n}{m}, \\qquad \\sum_{k=1}^{m}(-1)^{k+1}\\binom{n+1}{k} = 1-(-1)^m\\binom{n}{m}$"
+    },
+    {
+      "id": "part-2-aggregation",
+      "title": "Part II: Aggregation to the Union Cardinality",
+      "startLine": 87,
+      "endLine": 176,
+      "summary": "Defines interCard, truncIE, mult; card_powersetCard_filter counts size-k subsets containing a fixed element as C(mult a, k); truncIE_eq_sum_over_union rewrites the truncated sum as a sum over union elements of their pointwise values; one_le_mult records that every union element lies in ≥ 1 set.",
+      "mathContext": "$T_m = \\sum_{a\\in\\bigcup S_i}\\ \\sum_{k=1}^{m}(-1)^{k+1}\\binom{\\mathrm{mult}(a)}{k}$"
+    },
+    {
+      "id": "part-3-bonferroni",
+      "title": "Part III: The Bonferroni Inequalities",
+      "startLine": 178,
+      "endLine": 204,
+      "summary": "card_biUnion_le_truncIE_odd and truncIE_le_card_biUnion_even sum the pointwise sign bounds over the union to conclude that odd truncation overestimates and even truncation underestimates |⋃_{i∈s} Sᵢ|.",
+      "mathContext": "$m\\text{ odd}\\Rightarrow |\\textstyle\\bigcup_i S_i| \\le T_m; \\qquad m\\text{ even}\\Rightarrow T_m \\le |\\textstyle\\bigcup_i S_i|$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves 11 theorems (0 axioms, 0 sorries) establishing the Bonferroni inequalities for the cardinality of a finite union: odd-length truncation of the inclusion–exclusion series overestimates |⋃ Sᵢ|, even-length truncation underestimates it. The combinatorial engine is a partial alternating binomial identity ∑_{k=0}^{m}(-1)^k C(n+1,k) = (-1)^m C(n,m) absent from Mathlib, aggregated over union elements via Finset.card_powersetCard.",
+    "implications": "Supplies the truncation bounds requested by the TODO in Mathlib's InclusionExclusion.lean and answers the higher-Bonferroni open question posed by the sibling entry inclusion-exclusion-oq-04 (sieve form). The m = 1 case is Boole's union bound |⋃ Aᵢ| ≤ ∑|Aᵢ|; the m = 2 case is the second-order lower bound. The partial binomial identity is independently reusable wherever a truncated alternating binomial sum appears.",
+    "openQuestions": [
+      "Package the m = 1 and m = 2 cases as named corollaries (Boole's inequality and the second-order Bonferroni bound) with the powerset sums expanded to ∑_i |Sᵢ| and ∑_i|Sᵢ| - ∑_{i<j}|Sᵢ∩Sⱼ|.",
+      "Transport the inequalities to the dual sieve form #(none of Sᵢ) via the bridge identity #(none) = |α| - |⋃ Sᵢ| of inclusion-exclusion-oq-04.",
+      "State the measure-theoretic Bonferroni inequalities for a finite measure (probabilities of unions of events) by replacing cardinality with measure and reusing the same pointwise argument."
+    ]
+  },
+  "references": [
+    {
+      "title": "Bonferroni, C. E. — Teoria statistica delle classi e calcolo delle probabilità (1936)",
+      "url": "https://en.wikipedia.org/wiki/Boole%27s_inequality#Bonferroni_inequalities"
+    },
+    {
+      "title": "Bonferroni inequalities — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Boole%27s_inequality"
+    },
+    {
+      "title": "Mathlib4 — Combinatorics/Enumerative/InclusionExclusion.lean (carries the TODO for truncation bounds)",
+      "url": "https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Combinatorics/Enumerative/InclusionExclusion.lean"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "parent",
+      "description": "Parent entry: the inclusion–exclusion principle |A∪B| = |A|+|B|-|A∩B| and its general form. This entry bounds the truncations of that alternating sum."
+    },
+    {
+      "targetId": "inclusion-exclusion-oq-04",
+      "relationship": "sibling",
+      "description": "OQ-04 (sieve/dual form) explicitly poses the higher Bonferroni inequalities as an open question; this entry answers it for the union form, and its bridge identity #(none) = |α| - |⋃ Sᵢ| transports the bounds to the sieve form."
+    },
+    {
+      "targetId": "inclusion-exclusion-oq-01",
+      "relationship": "sibling",
+      "description": "OQ-01 proves the general n-set union form Σ (-1)^{|t|+1}|⋂|. Bonferroni's inequalities bound the partial sums of exactly that series."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/BonferroniInequalities.lean",
+    "filename": "BonferroniInequalities.lean",
+    "lineCount": 204,
+    "theoremCount": 11,
+    "axiomCount": 0,
+    "defCount": 3,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BonferroniInequalities.lean",
+    "sorries": 0,
+    "definitionCount": 3
+  }
+}

--- a/src/data/research/problems/inclusion-exclusion-oq-05.json
+++ b/src/data/research/problems/inclusion-exclusion-oq-05.json
@@ -1,0 +1,76 @@
+{
+  "slug": "inclusion-exclusion-oq-05",
+  "title": "Bonferroni inequalities: odd/even truncation bounds for inclusion-exclusion",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: Prove the Bonferroni inequalities — truncating inclusion-exclusion at an odd number of terms (sum_{k=1}^{2m-1}) OVERestimates |union A_i|; at an even number (sum_{k=1}^{2m}) UNDERestimates.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": "SOLVED (0 axioms, 0 sorries): both Bonferroni inequalities proved for the union cardinality. Odd truncation overestimates, even underestimates.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: Bonferroni odd/even truncation bounds proved via a partial alternating binomial identity aggregated over union elements.",
+    "builtItems": [
+      "alternating_sum_range_choose_partial (BonferroniInequalities.lean:42)",
+      "bonferroni_pointwise/_odd/_even (BonferroniInequalities.lean:55,74,81)",
+      "card_powersetCard_filter, sum_powersetCard_boole (BonferroniInequalities.lean:111,131)",
+      "truncIE_eq_sum_over_union (BonferroniInequalities.lean:138)",
+      "card_biUnion_le_truncIE_odd, truncIE_le_card_biUnion_even (BonferroniInequalities.lean:182,194)"
+    ],
+    "insights": [
+      "The truncated inclusion-exclusion value at a single element of multiplicity N=n+1 is the sum over k=1..m of (-1)^(k+1)*C(n+1,k) = 1-(-1)^m*C(n,m); the sign is set by parity of m, giving over/underestimate immediately.",
+      "Mathlib has only the FULL alternating binomial sum (Int.alternating_sum_range_choose); the PARTIAL sum equals (-1)^m*C(n,m) and is the missing engine, proved by induction plus Pascal (Nat.choose_succ_succ).",
+      "Writing the binomial top index as n+1 avoids natural-number subtraction throughout.",
+      "Representing the intersection cardinality as a filter over the union (not Finset.inf) makes the double-sum swap trivial via Finset.sum_boole plus Finset.sum_comm."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Package m=1 (Boole union bound) and m=2 as named corollaries with powerset sums expanded.",
+      "Transport to sieve form via inclusion-exclusion-oq-04 bridge identity.",
+      "Measure-theoretic Bonferroni for finite measures."
+    ]
+  },
+  "tags": [
+    "combinatorics",
+    "inclusion-exclusion",
+    "bonferroni",
+    "finset",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "inclusion-exclusion",
+    "inclusion-exclusion-oq-01",
+    "inclusion-exclusion-oq-01-oq-01",
+    "inclusion-exclusion-oq-01-oq-01-oq-02",
+    "inclusion-exclusion-oq-01-oq-03",
+    "inclusion-exclusion-oq-03",
+    "inclusion-exclusion-oq-03-oq-01",
+    "inclusion-exclusion-oq-04",
+    "inclusion-exclusion-oq-04-oq-01",
+    "inclusion-exclusion-oq-04-oq-01-oq-01",
+    "inclusion-exclusion-oq-04-oq-01-oq-02",
+    "inclusion-exclusion-oq-04-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-02T02:48:57.008Z",
+  "lastUpdate": "2026-07-01",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    "proofs/Proofs/BonferroniInequalities.lean"
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **Bonferroni inequalities** for the cardinality of a finite union of finite sets: truncating the inclusion–exclusion series at an **odd** number of terms *overestimates* `|⋃ Sᵢ|`, at an **even** number *underestimates* it.

This resolves the standing **TODO** in Mathlib's `Combinatorics/Enumerative/InclusionExclusion.lean` ("Prove that truncating the series alternatively gives an upper/lower bound to the true value") and answers the higher-Bonferroni open question posed by the sibling entry `inclusion-exclusion-oq-04`.

## Mathematical content

The engine is a **partial alternating binomial identity** that Mathlib does not contain (it has only the full sum `Int.alternating_sum_range_choose`):

```
∑_{k=0}^{m} (-1)^k C(n+1, k) = (-1)^m C(n, m)
```

proved by induction + Pascal's rule. An element lying in `n+1` of the sets then contributes `∑_{k=1}^{m}(-1)^{k+1}C(n+1,k) = 1 - (-1)^m C(n,m)` to the truncated sum — `≥ 1` when `m` is odd, `≤ 1` when even. Summing this pointwise bound over the union (the count of size-`k` subsets whose intersection contains a fixed element is `C(mult a, k)` via `Finset.card_powersetCard`) yields the set-level inequalities.

## Verification

- **11 theorems, 3 definitions, 204 lines, 0 sorries**
- `#print axioms` on all main results: `[propext, Classical.choice, Quot.sound]` only — **0-axiom** (no `Lean.ofReduceBool`, no `native_decide`, no `sorryAx`)
- Compiles against Mathlib v4.26.0

## Files
- `proofs/Proofs/BonferroniInequalities.lean` — the proof
- `src/data/proofs/inclusion-exclusion-oq-05/meta.json` — gallery entry
- `src/data/research/problems/inclusion-exclusion-oq-05.json` — research knowledge

🤖 Generated with [Claude Code](https://claude.com/claude-code)