### PR TITLE
Enrich erdos-823-oq-05: annotate uncovered σ-value computations (σ6/σ15/σ957/σ958), 5→8 annotations

### DIFF
--- a/src/data/proofs/erdos-823-oq-05/annotations.json
+++ b/src/data/proofs/erdos-823-oq-05/annotations.json
@@ -2,61 +2,180 @@
   {
     "id": "e823sv-ann-01",
     "proofId": "erdos-823-oq-05",
-    "range": { "startLine": 53, "endLine": 55 },
+    "range": {
+      "startLine": 53,
+      "endLine": 55
+    },
     "type": "tactic",
     "title": "σ on a prime: the only ingredient beyond multiplicativity",
     "content": "`sigma_one_prime` is the whole arithmetic content. For a prime `p`, Mathlib's `Nat.Prime.divisors` gives `divisors p = {1, p}`, so `σ 1 p = ∑ d ∈ {1,p}, d = 1 + p` by `Finset.sum_pair` (using `1 ≠ p`). `omega` flips `1 + p` to `p + 1`. Everything else in the file is coprime multiplicativity applied to this fact.",
     "mathContext": "$\\sigma(p) = \\sum_{d \\mid p} d = 1 + p$ since divisors$(p) = \\{1, p\\}$.",
     "significance": "key",
-    "relatedConcepts": ["sum-of-divisors function σ", "prime divisors", "Finset.sum_pair"],
-    "prerequisites": ["divisors of a prime (Nat.Prime.divisors)", "summing over a two-element finset"]
+    "relatedConcepts": [
+      "sum-of-divisors function σ",
+      "prime divisors",
+      "Finset.sum_pair"
+    ],
+    "prerequisites": [
+      "divisors of a prime (Nat.Prime.divisors)",
+      "summing over a two-element finset"
+    ]
   },
   {
     "id": "e823sv-ann-02",
     "proofId": "erdos-823-oq-05",
-    "range": { "startLine": 72, "endLine": 77 },
+    "range": {
+      "startLine": 72,
+      "endLine": 77
+    },
     "type": "tactic",
     "title": "Reading σ off the factorization, axiom-free",
     "content": "`sigma_14` is the template. Rewrite `14 = 2·7`; `isMultiplicative_sigma.map_mul_of_coprime` splits `σ(2·7) = σ(2)·σ(7)` once the gcd condition `gcd 2 7 = 1` is supplied (here by kernel `decide` — small, no compiled evaluator); `sigma_one_prime` evaluates each prime to `p+1`; `norm_num` finishes `3·8 = 24`. No `native_decide`, so no `Lean.ofReduceBool`. The same five lines, with a different factorization, give every other value.",
     "mathContext": "$\\sigma(14) = \\sigma(2)\\,\\sigma(7) = (2{+}1)(7{+}1) = 3 \\cdot 8 = 24.$",
     "significance": "key",
-    "relatedConcepts": ["multiplicative arithmetic functions", "coprimality", "decide vs native_decide"],
-    "prerequisites": ["isMultiplicative_sigma.map_mul_of_coprime", "kernel decidability of gcd"]
+    "relatedConcepts": [
+      "multiplicative arithmetic functions",
+      "coprimality",
+      "decide vs native_decide"
+    ],
+    "prerequisites": [
+      "isMultiplicative_sigma.map_mul_of_coprime",
+      "kernel decidability of gcd"
+    ]
   },
   {
     "id": "e823sv-ann-03",
     "proofId": "erdos-823-oq-05",
-    "range": { "startLine": 86, "endLine": 92 },
+    "range": {
+      "startLine": 86,
+      "endLine": 92
+    },
     "type": "concept",
     "title": "Prime powers: σ(2²) and the perfect number 28",
     "content": "`sigma_28` needs the one prime power 2² in 28 = 2²·7. There `sigma_one_apply_prime_pow` gives `σ(2²) = ∑_{k<3} 2^k = 1+2+4 = 7`, expanded by `simp [Finset.sum_range_succ]`; multiplicativity then yields `7·8 = 56`. Since 56 = 2·28, `twentyeight_perfect` certifies 28 as the second perfect number — axiom-free.",
     "mathContext": "$\\sigma(2^2) = 1+2+4 = 7,\\quad \\sigma(28) = 7 \\cdot 8 = 56 = 2 \\cdot 28.$",
     "significance": "key",
-    "relatedConcepts": ["prime-power formula for σ", "perfect numbers", "geometric series of divisors"],
-    "prerequisites": ["sigma_one_apply_prime_pow", "definition of a perfect number (σ(n) = 2n)"]
+    "relatedConcepts": [
+      "prime-power formula for σ",
+      "perfect numbers",
+      "geometric series of divisors"
+    ],
+    "prerequisites": [
+      "sigma_one_apply_prime_pow",
+      "definition of a perfect number (σ(n) = 2n)"
+    ]
   },
   {
     "id": "e823sv-ann-04",
     "proofId": "erdos-823-oq-05",
-    "range": { "startLine": 116, "endLine": 130 },
+    "range": {
+      "startLine": 116,
+      "endLine": 130
+    },
     "type": "theorem",
     "title": "Consecutive-integer σ-pairs: the base of Pollack's theorem",
     "content": "`sigma_pair_14_15` and `sigma_pair_957_958` record that 14,15 and 957,958 are pairs of consecutive integers with equal σ — value-collisions of the sum-of-divisors function. These are the simplest instances (ratio n/m ≈ 1) of the phenomenon Erdős #823 / Pollack push to arbitrary ratios α. `fiber_24` packages 14,15 ∈ σ⁻¹(24) as the concrete α = 1 witness.",
     "mathContext": "$\\sigma(14)=\\sigma(15)=24,\\quad \\sigma(957)=\\sigma(958)=1440.$",
     "significance": "supporting",
-    "relatedConcepts": ["Erdős problem #823", "Pollack's theorem", "fibers of σ", "consecutive integers"],
-    "prerequisites": ["the σ-value collision phenomenon", "preimage (fiber) of an arithmetic function"]
+    "relatedConcepts": [
+      "Erdős problem #823",
+      "Pollack's theorem",
+      "fibers of σ",
+      "consecutive integers"
+    ],
+    "prerequisites": [
+      "the σ-value collision phenomenon",
+      "preimage (fiber) of an arithmetic function"
+    ]
   },
   {
     "id": "e823sv-ann-05",
     "proofId": "erdos-823-oq-05",
-    "range": { "startLine": 19, "endLine": 23 },
+    "range": {
+      "startLine": 19,
+      "endLine": 23
+    },
     "type": "warning",
     "title": "A false native_decide claim in the parent",
     "content": "While recomputing the parent's values, σ(206) and σ(210) come out 312 and 576 — so the parent's `sigma_206_210 : σ 206 = σ 210`, asserted by `native_decide`, is false. This entry does not reproduce it. The episode illustrates the policy point: a symbolic proof cannot close a false goal, but `native_decide` will happily certify whatever the compiled evaluator returns — another reason to prefer kernel-checked, axiom-free computation for facts presented as verified.",
     "mathContext": "$\\sigma(206) = \\sigma(2\\cdot 103) = 3\\cdot 104 = 312 \\ne 576 = 3\\cdot 4\\cdot 6\\cdot 8 = \\sigma(210).$",
     "significance": "supporting",
-    "relatedConcepts": ["native_decide soundness", "Lean.ofReduceBool axiom", "axiom integrity", "verification trust"],
-    "prerequisites": ["how native_decide trusts the compiled evaluator", "kernel reduction vs compiled reduction"]
+    "relatedConcepts": [
+      "native_decide soundness",
+      "Lean.ofReduceBool axiom",
+      "axiom integrity",
+      "verification trust"
+    ],
+    "prerequisites": [
+      "how native_decide trusts the compiled evaluator",
+      "kernel reduction vs compiled reduction"
+    ]
+  },
+  {
+    "id": "e823sv-ann-06",
+    "proofId": "erdos-823-oq-05",
+    "range": {
+      "startLine": 65,
+      "endLine": 70
+    },
+    "type": "tactic",
+    "title": "The first fully worked value: σ(6) via one coprime split",
+    "content": "`sigma_6` is the minimal instance of the whole method. Rewrite `6 = 2·3`; because `gcd 2 3 = 1` (checked by kernel `decide`, not `native_decide`), `isMultiplicative_sigma.map_mul_of_coprime` turns `σ(6)` into `σ(2)·σ(3)`; two applications of `sigma_one_prime` replace each prime `p` by `p+1`; `norm_num` closes `3·4 = 12`. Every later value — including σ(28), σ(957) — is this same skeleton with more factors, so reading this proof once explains all of them.",
+    "mathContext": "$\\sigma(6) = \\sigma(2)\\,\\sigma(3) = (2{+}1)(3{+}1) = 3\\cdot 4 = 12.$ Since $12 = 2\\cdot 6$, this already exhibits 6 as a perfect number (see `six_perfect`).",
+    "significance": "key",
+    "relatedConcepts": [
+      "multiplicative arithmetic functions",
+      "sum-of-divisors function",
+      "perfect numbers"
+    ],
+    "prerequisites": [
+      "isMultiplicative_sigma.map_mul_of_coprime",
+      "sigma_one_prime"
+    ]
+  },
+  {
+    "id": "e823sv-ann-07",
+    "proofId": "erdos-823-oq-05",
+    "range": {
+      "startLine": 79,
+      "endLine": 84
+    },
+    "type": "tactic",
+    "title": "σ(15) — the other half of the smallest σ-pair",
+    "content": "`sigma_15` factors the *odd* neighbour of 14 as `15 = 3·5`, a factorization sharing no prime with `14 = 2·7`; yet both land on 24. The proof is again the four-move template (rewrite the factorization, split on `gcd 3 5 = 1`, evaluate each prime with `sigma_one_prime`, finish with `norm_num` on `4·6 = 24`). Pairing this with `sigma_14` is exactly what makes `sigma_pair_14_15` a *consecutive-integer* fiber of σ over 24 — the α = 1 seed of Pollack's theorem.",
+    "mathContext": "$\\sigma(15) = \\sigma(3)\\,\\sigma(5) = (3{+}1)(5{+}1) = 4\\cdot 6 = 24 = \\sigma(14).$ Two coprime-disjoint factorizations, one common value.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multiplicative arithmetic functions",
+      "σ-pairs",
+      "Pollack's theorem"
+    ],
+    "prerequisites": [
+      "isMultiplicative_sigma.map_mul_of_coprime",
+      "sigma_one_prime"
+    ]
+  },
+  {
+    "id": "e823sv-ann-08",
+    "proofId": "erdos-823-oq-05",
+    "range": {
+      "startLine": 94,
+      "endLine": 110
+    },
+    "type": "tactic",
+    "title": "Scaling to more primes: σ(957) and σ(958) = 1440",
+    "content": "These two computations show the method is not limited to two-prime numbers. `sigma_957` handles the *three*-prime factorization `957 = 3·11·29` by nesting `map_mul_of_coprime` twice (split off 3, then split `11·29`), each coprimality discharged by kernel `decide`; the primes evaluate to 4·12·30 = 1440. `sigma_958 = 2·479` is an ordinary two-prime split with 479 verified prime by `norm_num`, giving 3·480 = 1440. Neither uses `native_decide`, so both stay `Lean.ofReduceBool`-free — the whole point of this file over the parent's compiled evaluations. Together they realize the larger consecutive σ-pair `sigma_pair_957_958`.",
+    "mathContext": "$\\sigma(957) = \\sigma(3)\\sigma(11)\\sigma(29) = 4\\cdot 12\\cdot 30 = 1440$ and $\\sigma(958) = \\sigma(2)\\sigma(479) = 3\\cdot 480 = 1440$, so $(957,958)$ is a second consecutive-integer fiber of σ.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicative arithmetic functions",
+      "σ-pairs",
+      "decide vs native_decide"
+    ],
+    "prerequisites": [
+      "isMultiplicative_sigma.map_mul_of_coprime",
+      "sigma_one_prime",
+      "kernel decidability of gcd"
+    ]
   }
 ]


### PR DESCRIPTION
## Coverage gap

`erdos-823-oq-05` ('σ Values from Mathlib, Axiom-Free') had 12 declarations but only 5 annotations, leaving **4 σ-value computations uncovered**: `sigma_6` (L66), `sigma_15` (L80), `sigma_957` (L95), `sigma_958` (L105). The existing annotations covered `sigma_14`, `sigma_28`, the σ-pairs/perfect-number wrapup, and the parent's false `native_decide` claim — but not these four base computations.

## Change

Three new `tactic` annotations (5→8), covering all 12 decls with no lumping:

- **ann-06 (σ 6):** the minimal fully-worked multiplicativity instance and first perfect-number witness.
- **ann-07 (σ 15):** the coprime-disjoint partner (15=3·5) completing the smallest σ-pair (14,15), the α=1 seed of Pollack's theorem.
- **ann-08 (σ 957 & σ 958):** scaling the method to a three-prime factorization 957=3·11·29 (nested `map_mul_of_coprime`) and the two-prime 958=2·479, both landing on 1440 — the larger consecutive σ-pair, all `Lean.ofReduceBool`-free.

## Validation

`pnpm annotations:validate` (strict) reports **no errors for this entry**; all new anchors resolve to their `/--` doc-comment construct lines and types match. No Lean source changed.