### PR TITLE
Enrich erdos-733-oq-02: annotate uncovered rich-line count theorems (division form + antitone), 5→7 annotations

### DIFF
--- a/src/data/proofs/erdos-733-oq-02/annotations.json
+++ b/src/data/proofs/erdos-733-oq-02/annotations.json
@@ -2,61 +2,163 @@
   {
     "id": "e733rl-ann-01",
     "proofId": "erdos-733-oq-02",
-    "range": { "startLine": 73, "endLine": 82 },
+    "range": {
+      "startLine": 73,
+      "endLine": 82
+    },
     "type": "concept",
     "title": "Disjoint pairs: where linearity enters",
     "content": "`disjoint_pairs` is the only place the geometry is used. Each line `L` carries the family `L.powersetCard 2` of its two-element point-subsets. If a two-element set `s` belonged to both `L₁.powersetCard 2` and `L₂.powersetCard 2`, then `s ⊆ L₁ ∩ L₂` with `|s| = 2`, forcing `|L₁ ∩ L₂| ≥ 2`. But the linear-space hypothesis says two distinct lines meet in at most one point, so the families are disjoint. No point-pair lies on two lines — this is exactly the fact that makes the counting work.",
     "mathContext": "$s \\subseteq L_1 \\cap L_2,\\ |s| = 2 \\Rightarrow |L_1 \\cap L_2| \\ge 2$, contradicting $|L_1 \\cap L_2| \\le 1$.",
     "significance": "key",
-    "relatedConcepts": ["linear space (partial linear space)", "two-element subsets", "Finset.powersetCard", "pairwise disjointness"],
-    "prerequisites": ["the linear-space axiom: two lines meet in ≤ 1 point", "subsets and intersection cardinality"]
+    "relatedConcepts": [
+      "linear space (partial linear space)",
+      "two-element subsets",
+      "Finset.powersetCard",
+      "pairwise disjointness"
+    ],
+    "prerequisites": [
+      "the linear-space axiom: two lines meet in ≤ 1 point",
+      "subsets and intersection cardinality"
+    ]
   },
   {
     "id": "e733rl-ann-02",
     "proofId": "erdos-733-oq-02",
-    "range": { "startLine": 90, "endLine": 112 },
+    "range": {
+      "startLine": 90,
+      "endLine": 112
+    },
     "type": "tactic",
     "title": "Double counting via a disjoint biUnion",
     "content": "`sum_choose_two_le` is the engine. Rewriting `C(|L|,2)` as `(L.powersetCard 2).card` (Finset.card_powersetCard) turns the sum over lines into a sum of cardinalities of pairwise-disjoint finsets. `Finset.card_biUnion` (using the disjointness from `disjoint_pairs`) collapses that sum into the cardinality of their union, and the union sits inside `P.powersetCard 2` because every line is a subset of `P`. Hence `∑_L C(|L|,2) ≤ C(n,2)`. This single inequality powers every rich-line bound below.",
     "mathContext": "$\\sum_{L} \\binom{|L|}{2} = \\Big|\\bigsqcup_L \\binom{L}{2}\\Big| \\le \\Big|\\binom{P}{2}\\Big| = \\binom{n}{2}.$",
     "significance": "key",
-    "relatedConcepts": ["double counting", "Finset.card_biUnion", "disjoint union cardinality", "Finset.card_powersetCard", "handshake principle"],
-    "prerequisites": ["cardinality of a disjoint biUnion", "binomial coefficient as a count of 2-subsets"]
+    "relatedConcepts": [
+      "double counting",
+      "Finset.card_biUnion",
+      "disjoint union cardinality",
+      "Finset.card_powersetCard",
+      "handshake principle"
+    ],
+    "prerequisites": [
+      "cardinality of a disjoint biUnion",
+      "binomial coefficient as a count of 2-subsets"
+    ]
   },
   {
     "id": "e733rl-ann-03",
     "proofId": "erdos-733-oq-02",
-    "range": { "startLine": 124, "endLine": 140 },
+    "range": {
+      "startLine": 124,
+      "endLine": 140
+    },
     "type": "concept",
     "title": "Charging rich lines to point-pairs",
     "content": "`rich_line_bound` is the headline. Over the k-rich lines, the constant estimate `C(k,2) ≤ C(|L|,2)` (Nat.choose_le_choose, since `k ≤ |L|`) sums to `#{k-rich lines} · C(k,2) ≤ ∑_L C(|L|,2) ≤ C(n,2)`. Read combinatorially: every k-rich line is charged the `C(k,2)` pairs it must contain, no pair is charged twice (disjointness), and there are only `C(n,2)` pairs to spend. The count of k-rich lines is therefore at most `C(n,2)/C(k,2) = O(n²/k²)`.",
     "mathContext": "$\\#\\{L : |L| \\ge k\\}\\cdot \\binom{k}{2} \\le \\sum_L \\binom{|L|}{2} \\le \\binom{n}{2}.$",
     "significance": "key",
-    "relatedConcepts": ["rich lines", "monotonicity of binomial coefficients", "Nat.choose_le_choose", "amortized counting argument", "Szemerédi–Trotter baseline"],
-    "prerequisites": ["filtering a Finset by a predicate", "monotonicity C(k,2) ≤ C(m,2) for k ≤ m"]
+    "relatedConcepts": [
+      "rich lines",
+      "monotonicity of binomial coefficients",
+      "Nat.choose_le_choose",
+      "amortized counting argument",
+      "Szemerédi–Trotter baseline"
+    ],
+    "prerequisites": [
+      "filtering a Finset by a predicate",
+      "monotonicity C(k,2) ≤ C(m,2) for k ≤ m"
+    ]
   },
   {
     "id": "e733rl-ann-04",
     "proofId": "erdos-733-oq-02",
-    "range": { "startLine": 157, "endLine": 169 },
+    "range": {
+      "startLine": 157,
+      "endLine": 169
+    },
     "type": "theorem",
     "title": "k = 2: bounding the number of proper lines",
     "content": "`num_proper_lines_le` specializes `rich_line_bound` at `k = 2`. Since `C(2,2) = 1`, the bound becomes `#{lines with ≥ 2 points} ≤ C(n,2)`: each proper line is charged to a distinct point-pair. This is the easy direction of de Bruijn–Erdős-style counting and shows that a linear space on n points has at most quadratically many lines.",
     "mathContext": "$\\binom{2}{2} = 1 \\Rightarrow \\#\\{L : |L| \\ge 2\\} \\le \\binom{n}{2}.$",
     "significance": "supporting",
-    "relatedConcepts": ["de Bruijn–Erdős theorem", "proper lines", "linear space line count", "specialization k = 2"],
-    "prerequisites": ["C(2,2) = 1", "the rich_line_bound inequality"]
+    "relatedConcepts": [
+      "de Bruijn–Erdős theorem",
+      "proper lines",
+      "linear space line count",
+      "specialization k = 2"
+    ],
+    "prerequisites": [
+      "C(2,2) = 1",
+      "the rich_line_bound inequality"
+    ]
   },
   {
     "id": "e733rl-ann-05",
     "proofId": "erdos-733-oq-02",
-    "range": { "startLine": 40, "endLine": 56 },
+    "range": {
+      "startLine": 40,
+      "endLine": 56
+    },
     "type": "warning",
     "title": "Honest scope: weaker than Szemerédi–Trotter, but unconditional and 0-axiom",
     "content": "The bound here is `O(n²/k²)`; Szemerédi–Trotter improves the exponent on k from 2 to 3 (plus an `n/k` term): `O(n²/k³ + n/k)`. That improvement is the genuinely deep content the parent Erdős #733 file axiomatizes, and this entry does NOT discharge those axioms. What it does deliver is the elementary baseline, fully machine-checked with no incidence theorem. The linear-space conditions `hsub` and `hlin` are ordinary hypotheses, not structure-encoded axioms, so the file is genuinely 0-axiom under the project's axiom-integrity policy.",
     "mathContext": "Elementary: $O(n^2/k^2)$. Szemerédi–Trotter: $O(n^2/k^3 + n/k)$.",
     "significance": "supporting",
-    "relatedConcepts": ["Szemerédi–Trotter theorem", "incidence geometry", "axiom-integrity policy", "elementary vs deep bounds"],
-    "prerequisites": ["asymptotic comparison of O(n²/k²) and O(n²/k³ + n/k)", "what it means for a Lean result to be 0-axiom"]
+    "relatedConcepts": [
+      "Szemerédi–Trotter theorem",
+      "incidence geometry",
+      "axiom-integrity policy",
+      "elementary vs deep bounds"
+    ],
+    "prerequisites": [
+      "asymptotic comparison of O(n²/k²) and O(n²/k³ + n/k)",
+      "what it means for a Lean result to be 0-axiom"
+    ]
+  },
+  {
+    "id": "e733rl-ann-06",
+    "proofId": "erdos-733-oq-02",
+    "range": {
+      "startLine": 142,
+      "endLine": 155
+    },
+    "type": "theorem",
+    "title": "The O(n²/k²) estimate: dividing the pair budget by C(k,2)",
+    "content": "`rich_line_count_le` turns the multiplicative bound `rich_line_bound` (each k-rich line consumes C(k,2) disjoint point-pairs, of which there are only C(n,2)) into the familiar *division* form: at most `C(n,2) / k.choose 2` lines are k-rich. The step is purely arithmetic — `Nat.le_div_iff_mul_le` rewrites `x ≤ C(n,2)/C(k,2)` as `x · C(k,2) ≤ C(n,2)`, which is exactly `rich_line_bound`; the hypothesis `2 ≤ k` is what makes `Nat.choose_pos` give a positive divisor so the natural-number division is meaningful. This is the headline `O(n²/k²)` rich-line count in its cleanest closed form.",
+    "mathContext": "With $n = |P|$ and $k \\ge 2$: $\\#\\{L : k\\text{-rich}\\} \\le \\dfrac{\\binom{n}{2}}{\\binom{k}{2}} = O\\!\\left(\\dfrac{n^2}{k^2}\\right).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "incidence geometry",
+      "double counting",
+      "binomial coefficients"
+    ],
+    "prerequisites": [
+      "rich_line_bound",
+      "Nat.le_div_iff_mul_le",
+      "Nat.choose_pos"
+    ]
+  },
+  {
+    "id": "e733rl-ann-07",
+    "proofId": "erdos-733-oq-02",
+    "range": {
+      "startLine": 171,
+      "endLine": 184
+    },
+    "type": "theorem",
+    "title": "Monotonicity in the richness threshold k",
+    "content": "`rich_lines_antitone` records the obvious but essential fact that raising the richness threshold can only shrink the family: if `k ≤ k'` then every `k'`-rich line is already `k`-rich, so `{L : k'-rich} ⊆ {L : k-rich}` and `Finset.card_le_card` gives the count inequality. Structurally it needs none of the geometry (no `hlin`, no point set) — it is monotonicity of `filter` under a weakening predicate, proved by `le_trans hk hL.2`. Its role is leverage: a single pair budget at threshold `k` (via `rich_line_bound`) then controls the count at *every* higher threshold at once.",
+    "mathContext": "For $k \\le k'$: $\\#\\{L : |L| \\ge k'\\} \\le \\#\\{L : |L| \\ge k\\}$, since $|L|\\ge k' \\Rightarrow |L|\\ge k$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotonicity",
+      "Finset.filter",
+      "subset counting"
+    ],
+    "prerequisites": [
+      "Finset.card_le_card",
+      "Finset.mem_filter"
+    ]
   }
 ]


### PR DESCRIPTION
## Coverage gap

`erdos-733-oq-02` ('The Elementary Rich-Line Bound') had 6 declarations but only 5 annotations. Two theorems were uncovered: `rich_line_count_le` (L147) and `rich_lines_antitone` (L176). Existing annotations covered the disjoint-pairs setup, the double-counting core, the charging argument, the k=2 proper-line count, and the honest-scope warning — but not the division-form estimate or the monotonicity lemma.

## Change

Two new `theorem` annotations (5→7), covering all 6 decls:

- **ann-06 (rich_line_count_le):** turning the multiplicative `rich_line_bound` into the closed division form `C(n,2)/C(k,2)` via `Nat.le_div_iff_mul_le` + `Nat.choose_pos` — the headline O(n²/k²) rich-line count.
- **ann-07 (rich_lines_antitone):** monotonicity in the threshold, {k'-rich} ⊆ {k-rich} via `Finset.card_le_card`, letting one pair budget control every higher threshold.

## Validation

`pnpm annotations:validate` (strict) reports **no errors for this entry**; both anchors resolve to their `/--` doc-comment lines and types match. No Lean source changed.