### PR TITLE
research(harmonic-divergence-oq-01-oq-02): γ = -Γ'(1) Gamma-derivative connection [VERIFIED, 0-axiom, 14thm/152L, new entry]

### DIFF
--- a/proofs/Proofs/HarmonicDivergenceOQ01OQ02.lean
+++ b/proofs/Proofs/HarmonicDivergenceOQ01OQ02.lean
@@ -1,0 +1,152 @@
+/-
+# The Euler-Mascheroni Constant as a Gamma-Function Derivative
+
+## What This Proves
+
+This entry discharges the second open question of the parent Euler-Mascheroni
+entry (`harmonic-divergence-oq-01`): *formalize the connection γ = -Γ'(1).*
+
+The parent documented this connection only as comments, believing the required
+Gamma-derivative infrastructure (`Mathlib.NumberTheory.Harmonic.GammaDeriv`) was
+too costly to import. In fact the Mathlib oleans are precompiled, so the import
+is cheap, and we obtain a fully machine-verified account:
+
+1. γ = -Γ'(1), equivalently `HasDerivAt Γ (-γ) 1`.
+2. The general integer formula Γ'(n+1) = n!·(-γ + H_n).
+3. Concrete values: Γ'(1) = -γ, Γ'(2) = 1 - γ, Γ'(3) = 3 - 2γ.
+4. Sign analysis: Γ'(1) < 0 < Γ'(2), so the (well-known) minimum of Γ on the
+   positive reals lies strictly between 1 and 2.
+5. Sharp enclosure of the derivative from the parent's bounds 1/2 < γ < 2/3:
+   -2/3 < Γ'(1) < -1/2.
+6. The half-integer derivative Γ'(1/2) = -√π(γ + 2 log 2) and its sign.
+
+Every result delegates to Mathlib's `GammaDeriv` file plus the bounds
+1/2 < γ < 2/3, so the entry is 0-axiom and sorry-free.
+
+Tags: analysis, number-theory, euler-mascheroni, gamma-function,
+      digamma, special-functions
+-/
+
+import Mathlib.NumberTheory.Harmonic.GammaDeriv
+import Mathlib.NumberTheory.Harmonic.EulerMascheroni
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+
+namespace EulerMascheroniGammaDeriv
+
+open Real Filter
+
+/-- The Euler-Mascheroni constant γ. -/
+noncomputable def γ : ℝ := Real.eulerMascheroniConstant
+
+/-! ## The defining connection γ = -Γ'(1) -/
+
+/-- The Euler-Mascheroni constant is minus the derivative of Γ at 1. This is the
+central identity requested by the parent entry's open question. -/
+theorem gamma_eq_neg_deriv_Gamma_one : γ = -deriv Gamma 1 :=
+  Real.eulerMascheroniConstant_eq_neg_deriv
+
+/-- Equivalent formulation: Γ has derivative -γ at 1. -/
+theorem hasDerivAt_Gamma_one : HasDerivAt Gamma (-γ) 1 :=
+  Real.hasDerivAt_Gamma_one
+
+/-- The derivative of Γ at 1 equals -γ. -/
+theorem deriv_Gamma_one : deriv Gamma 1 = -γ :=
+  hasDerivAt_Gamma_one.deriv
+
+/-! ## The general integer formula Γ'(n+1) = n!·(-γ + H_n) -/
+
+/-- Explicit derivative of Γ at every positive integer, in terms of the harmonic
+numbers and γ. -/
+theorem deriv_Gamma_nat (n : ℕ) :
+    deriv Gamma (n + 1) = (Nat.factorial n : ℝ) * (-γ + harmonic n) :=
+  Real.deriv_Gamma_nat n
+
+/-- The same formula packaged as a `HasDerivAt` statement. -/
+theorem hasDerivAt_Gamma_nat (n : ℕ) :
+    HasDerivAt Gamma ((Nat.factorial n : ℝ) * (-γ + harmonic n)) (n + 1) :=
+  Real.hasDerivAt_Gamma_nat n
+
+/-! ## Concrete values of Γ' at small integers -/
+
+/-- Γ'(2) = 1 - γ. -/
+theorem deriv_Gamma_two : deriv Gamma 2 = 1 - γ := by
+  have h := deriv_Gamma_nat 1
+  have hh : (harmonic 1 : ℝ) = 1 := by
+    norm_num [harmonic, Finset.sum_range_succ, Finset.sum_range_zero]
+  rw [hh] at h
+  norm_num [Nat.factorial] at h
+  linarith [h]
+
+/-- Γ'(3) = 3 - 2γ. -/
+theorem deriv_Gamma_three : deriv Gamma 3 = 3 - 2 * γ := by
+  have h := deriv_Gamma_nat 2
+  have hh : (harmonic 2 : ℝ) = 3 / 2 := by
+    norm_num [harmonic, Finset.sum_range_succ, Finset.sum_range_zero]
+  rw [hh] at h
+  norm_num [Nat.factorial] at h
+  linarith [h]
+
+/-! ## Sign analysis and the minimum of Γ
+
+Positivity of γ gives Γ'(1) < 0, while γ < 1 gives Γ'(2) > 0. Since Γ is
+smooth on (0, ∞), the sign change forces the minimum of Γ to lie strictly
+between 1 and 2 (numerically near 1.4616). -/
+
+/-- Γ'(1) < 0. -/
+theorem deriv_Gamma_one_neg : deriv Gamma 1 < 0 := by
+  rw [deriv_Gamma_one]
+  have : (0 : ℝ) < γ := by
+    have := Real.one_half_lt_eulerMascheroniConstant
+    simp only [γ]; linarith
+  linarith
+
+/-- Γ'(2) > 0. -/
+theorem deriv_Gamma_two_pos : 0 < deriv Gamma 2 := by
+  rw [deriv_Gamma_two]
+  have : γ < 2 / 3 := by
+    have := Real.eulerMascheroniConstant_lt_two_thirds
+    simp only [γ]; linarith
+  linarith
+
+/-- The derivative of Γ changes sign between 1 and 2: Γ'(1) < 0 < Γ'(2). This
+is the analytic signature of the unique minimum of Γ on the positive reals. -/
+theorem deriv_Gamma_sign_change : deriv Gamma 1 < 0 ∧ 0 < deriv Gamma 2 :=
+  ⟨deriv_Gamma_one_neg, deriv_Gamma_two_pos⟩
+
+/-! ## Sharp enclosure of Γ'(1) from the parent bounds 1/2 < γ < 2/3 -/
+
+/-- Lower and upper bounds on the derivative of Γ at 1, transferred from the
+parent entry's enclosure 1/2 < γ < 2/3. -/
+theorem deriv_Gamma_one_bounds : -2 / 3 < deriv Gamma 1 ∧ deriv Gamma 1 < -1 / 2 := by
+  rw [deriv_Gamma_one]
+  have h1 : (1 : ℝ) / 2 < γ := by
+    have := Real.one_half_lt_eulerMascheroniConstant; simp only [γ]; linarith
+  have h2 : γ < 2 / 3 := by
+    have := Real.eulerMascheroniConstant_lt_two_thirds; simp only [γ]; linarith
+  constructor <;> linarith
+
+/-! ## The half-integer derivative Γ'(1/2) -/
+
+/-- Γ'(1/2) = -√π·(γ + 2 log 2). -/
+theorem hasDerivAt_Gamma_one_half :
+    HasDerivAt Gamma (-√π * (γ + 2 * Real.log 2)) (1 / 2) :=
+  Real.hasDerivAt_Gamma_one_half
+
+/-- The derivative of Γ at 1/2 equals -√π·(γ + 2 log 2). -/
+theorem deriv_Gamma_one_half :
+    deriv Gamma (1 / 2) = -√π * (γ + 2 * Real.log 2) :=
+  hasDerivAt_Gamma_one_half.deriv
+
+/-- Γ'(1/2) < 0: the derivative is negative at the half-integer too. -/
+theorem deriv_Gamma_one_half_neg : deriv Gamma (1 / 2) < 0 := by
+  rw [deriv_Gamma_one_half]
+  have hγ : (0 : ℝ) < γ := by
+    have := Real.one_half_lt_eulerMascheroniConstant; simp only [γ]; linarith
+  have hlog : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  have hpi : (0 : ℝ) < √π := Real.sqrt_pos.mpr Real.pi_pos
+  have hsum : (0 : ℝ) < γ + 2 * Real.log 2 := by linarith
+  nlinarith [mul_pos hpi hsum]
+
+end EulerMascheroniGammaDeriv

--- a/src/data/proofs/harmonic-divergence-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-01-oq-02/annotations.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "ann-gamma-deriv-overview",
+    "proofId": "harmonic-divergence-oq-01-oq-02",
+    "type": "insight",
+    "range": { "startLine": 1, "endLine": 40 },
+    "title": "γ = -Γ'(1): The Analytic Face of the Euler-Mascheroni Constant",
+    "content": "This entry answers the second open question of the parent Euler-Mascheroni entry (harmonic-divergence-oq-01): formalize the identity γ = −Γ'(1). The parent left this connection as a comment, believing the Gamma-derivative infrastructure (Mathlib.NumberTheory.Harmonic.GammaDeriv) too costly to compile. In fact the Mathlib oleans are cached, so the import is cheap, and we obtain fully machine-verified theorems: γ = −Γ'(1), the integer formula Γ'(n+1) = n!(−γ + H_n), concrete values, sign analysis for the minimum of Γ, and the half-integer derivative Γ'(1/2) = −√π(γ + 2 log 2).",
+    "mathContext": "The Euler-Mascheroni constant has two classical definitions: the elementary limit γ = lim(H_n − log n), and the analytic value γ = −Γ'(1), equivalently ψ(1) = −γ for the digamma function ψ = Γ'/Γ. This entry is the bridge between them.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler-Mascheroni-constant",
+      "Gamma-function",
+      "digamma-function",
+      "harmonic-numbers"
+    ],
+    "prerequisites": [
+      "Real.Gamma and its differentiability",
+      "Real.eulerMascheroniConstant and Mathlib.NumberTheory.Harmonic.GammaDeriv"
+    ]
+  },
+  {
+    "id": "ann-gamma-deriv-connection",
+    "proofId": "harmonic-divergence-oq-01-oq-02",
+    "type": "concept",
+    "range": { "startLine": 43, "endLine": 56 },
+    "title": "The Central Identity γ = -Γ'(1)",
+    "content": "`gamma_eq_neg_deriv_Gamma_one` states γ = −Γ'(1); `hasDerivAt_Gamma_one` packages this as HasDerivAt Gamma (−γ) 1; and `deriv_Gamma_one` extracts deriv Gamma 1 = −γ. All three delegate to Mathlib's `eulerMascheroniConstant_eq_neg_deriv` and `hasDerivAt_Gamma_one`. This is precisely the parent entry's second open question, now machine-verified rather than documented in a comment.",
+    "mathContext": "Since Γ(1) = 1, the identity Γ'(1) = −γ is the same as ψ(1) = Γ'(1)/Γ(1) = −γ, the base case of the digamma values ψ(n) = −γ + H_{n−1}.",
+    "significance": "key",
+    "relatedConcepts": ["Gamma-function", "Euler-Mascheroni-constant", "digamma-function"]
+  },
+  {
+    "id": "ann-gamma-deriv-integer",
+    "proofId": "harmonic-divergence-oq-01-oq-02",
+    "type": "concept",
+    "range": { "startLine": 58, "endLine": 69 },
+    "title": "The Integer Formula Γ'(n+1) = n!(-γ + H_n)",
+    "content": "`deriv_Gamma_nat` and `hasDerivAt_Gamma_nat` give the derivative of Γ at every positive integer in terms of the factorial, the harmonic number H_n, and γ. Delegates to Mathlib's `Real.deriv_Gamma_nat`, whose proof combines the recurrence deriv(log∘Γ)(x+1) = deriv(log∘Γ)(x) + 1/x with the Bohr-Mollerup convexity of log∘Γ.",
+    "mathContext": "Equivalently, the digamma function satisfies ψ(n+1) = −γ + H_n; differentiating Γ(x+1) = xΓ(x) gives the +1/x recurrence that telescopes into H_n.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gamma-function", "harmonic-numbers", "Bohr-Mollerup-theorem"]
+  },
+  {
+    "id": "ann-gamma-deriv-concrete",
+    "proofId": "harmonic-divergence-oq-01-oq-02",
+    "type": "proof-technique",
+    "range": { "startLine": 71, "endLine": 90 },
+    "title": "Concrete Values Γ'(2) = 1 - γ and Γ'(3) = 3 - 2γ",
+    "content": "Specializing the integer formula: at n = 1, 1! = 1 and H_1 = 1 give Γ'(2) = 1 − γ; at n = 2, 2! = 2 and H_2 = 3/2 give Γ'(3) = 3 − 2γ. The factorial and harmonic value are computed with `norm_num [harmonic, Finset.sum_range_succ, Finset.sum_range_zero, Nat.factorial]`, and the arithmetic is finished with `linarith`.",
+    "mathContext": "These are the first digamma values in disguise: ψ(2) = 1 − γ and ψ(3) = 3/2 − γ, scaled by the factorial.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gamma-function", "harmonic-numbers", "factorial"]
+  },
+  {
+    "id": "ann-gamma-deriv-sign",
+    "proofId": "harmonic-divergence-oq-01-oq-02",
+    "type": "insight",
+    "range": { "startLine": 92, "endLine": 116 },
+    "title": "Sign Change Γ'(1) < 0 < Γ'(2) Locates the Minimum of Γ",
+    "content": "Positivity of γ gives Γ'(1) = −γ < 0; the bound γ < 2/3 < 1 gives Γ'(2) = 1 − γ > 0. The packaged `deriv_Gamma_sign_change` records Γ'(1) < 0 < Γ'(2). Because Γ is smooth and its derivative changes sign on (1,2), the unique minimum of Γ on the positive reals lies strictly between 1 and 2 — numerically near x ≈ 1.4616, with Γ(x) ≈ 0.8856.",
+    "mathContext": "Γ is logarithmically convex on (0,∞) (Bohr-Mollerup), so it has a single interior minimum; the sign change pins it to the interval (1,2).",
+    "significance": "key",
+    "relatedConcepts": ["Gamma-function", "convexity", "critical-point"]
+  },
+  {
+    "id": "ann-gamma-deriv-enclosure",
+    "proofId": "harmonic-divergence-oq-01-oq-02",
+    "type": "concept",
+    "range": { "startLine": 118, "endLine": 128 },
+    "title": "Sharp Enclosure -2/3 < Γ'(1) < -1/2",
+    "content": "The parent entry's bracket 1/2 < γ < 2/3 transfers through Γ'(1) = −γ to −2/3 < Γ'(1) < −1/2. This is a machine-verified numerical enclosure of the Gamma derivative at 1 (whose true value is ≈ −0.5772).",
+    "significance": "supporting",
+    "relatedConcepts": ["Gamma-function", "Euler-Mascheroni-constant", "bounds"]
+  },
+  {
+    "id": "ann-gamma-deriv-half",
+    "proofId": "harmonic-divergence-oq-01-oq-02",
+    "type": "concept",
+    "range": { "startLine": 130, "endLine": 152 },
+    "title": "The Half-Integer Derivative Γ'(1/2) = -√π(γ + 2 log 2)",
+    "content": "Using the Gamma duplication formula, Mathlib computes Γ'(1/2) = −√π(γ + 2 log 2) (`hasDerivAt_Gamma_one_half`, `deriv_Gamma_one_half`). Since √π > 0, log 2 > 0, and γ > 0, the derivative is negative there too (`deriv_Gamma_one_half_neg`), proved with `nlinarith`.",
+    "mathContext": "Equivalently ψ(1/2) = −γ − 2 log 2, the classical digamma value at the half-integer, arising from the reflection/duplication identities of Γ.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gamma-function", "digamma-function", "duplication-formula"]
+  }
+]

--- a/src/data/proofs/harmonic-divergence-oq-01-oq-02/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-01-oq-02/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "harmonic-divergence-oq-01-oq-02",
+  "title": "The Euler-Mascheroni Constant as a Gamma-Function Derivative: γ = -Γ'(1)",
+  "slug": "harmonic-divergence-oq-01-oq-02",
+  "description": "A fully machine-verified formalization of the identity γ = -Γ'(1) connecting the Euler-Mascheroni constant to the derivative of the Gamma function, discharging the second open question of the parent Euler-Mascheroni entry. Includes the general integer formula Γ'(n+1) = n!(-γ + H_n), concrete values Γ'(1) = -γ, Γ'(2) = 1 - γ, Γ'(3) = 3 - 2γ, the sign change Γ'(1) < 0 < Γ'(2) that locates the minimum of Γ between 1 and 2, a sharp enclosure -2/3 < Γ'(1) < -1/2 from the parent's bounds, and the half-integer derivative Γ'(1/2) = -√π(γ + 2 log 2).",
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "De progressionibus harmonicis observationes (Comment. Acad. Sci. Petrop. 7)",
+      "year": 1734,
+      "note": "Introduces γ = lim (Hₙ − log n); the derivative γ = −Γ'(1) is the analytic face of the same constant."
+    },
+    {
+      "authors": "Carl Friedrich Gauss",
+      "title": "Disquisitiones generales circa seriem infinitam (the digamma / Gamma-derivative theory)",
+      "year": 1813,
+      "note": "The digamma function ψ = Γ'/Γ satisfies ψ(1) = −γ, equivalently Γ'(1) = −γ, formalized here."
+    },
+    {
+      "authors": "Julian Havil",
+      "title": "Gamma: Exploring Euler's Constant",
+      "year": 2003,
+      "note": "Princeton University Press. Discusses γ = −Γ'(1), Γ'(n+1) = n!(−γ + Hₙ), and the minimum of Γ."
+    },
+    {
+      "authors": "David Loeffler / The mathlib Community",
+      "title": "Mathlib4: Mathlib.NumberTheory.Harmonic.GammaDeriv (derivative of Γ at positive integers)",
+      "year": 2024,
+      "note": "Provides eulerMascheroniConstant_eq_neg_deriv, deriv_Gamma_nat, and hasDerivAt_Gamma_one_half, the Mathlib backbone of this entry."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HarmonicDivergenceOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "number-theory",
+      "euler-mascheroni",
+      "gamma-function",
+      "special-functions",
+      "digamma"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified; depends only on the foundational axioms propext, Classical.choice, and Quot.sound (confirmed via #print axioms).",
+    "lineCount": 152,
+    "theoremCount": 14,
+    "definitionCount": 1,
+    "originalContributions": [
+      "Machine-verified formalization of γ = -Γ'(1) (gamma_eq_neg_deriv_Gamma_one), discharging the parent entry's second open question — previously documented only as a comment",
+      "HasDerivAt Γ (-γ) 1 and deriv Gamma 1 = -γ wrappers",
+      "General integer formula Γ'(n+1) = n!(-γ + H_n) as both deriv and HasDerivAt statements",
+      "Concrete evaluations Γ'(2) = 1 - γ and Γ'(3) = 3 - 2γ",
+      "Sign analysis Γ'(1) < 0 < Γ'(2), the analytic signature of the unique minimum of Γ on (0,∞), which is thereby located strictly between 1 and 2",
+      "Sharp enclosure -2/3 < Γ'(1) < -1/2 transferred from the parent's bound 1/2 < γ < 2/3",
+      "Half-integer derivative Γ'(1/2) = -√π(γ + 2 log 2) and its negativity"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Euler-Mascheroni constant γ ≈ 0.57721566 has two classical faces. Euler (1734) defined it as the limiting gap γ = lim_{n→∞}(H_n − log n) between the harmonic numbers and the logarithm. Independently it is the derivative of the Gamma function at 1: γ = −Γ'(1), equivalently ψ(1) = −γ for the digamma function ψ = Γ'/Γ. This second characterization ties γ directly to the analytic theory of the Gamma function and to the values Γ'(n+1) = n!(−γ + H_n).\n\nThe parent entry (harmonic-divergence-oq-01) formalized the limit definition, bounds 1/2 < γ < 2/3, and Theisinger's theorem, but left the Gamma-derivative connection documented only in comments, believing the required Mathlib infrastructure was too costly to compile. This entry shows the Mathlib file Mathlib.NumberTheory.Harmonic.GammaDeriv compiles cheaply from cached oleans, and turns the documented identity into machine-verified theorems.",
+    "problemStatement": "The parent entry's second open question asks: formalize the connection γ = −Γ'(1). This entry answers it, and develops the surrounding derivative theory:\n\n1. γ = −Γ'(1) (the digamma value ψ(1) = −γ).\n2. Γ'(n+1) = n!(−γ + H_n) for all n.\n3. Concrete values: Γ'(1) = −γ, Γ'(2) = 1 − γ, Γ'(3) = 3 − 2γ.\n4. Sign change Γ'(1) < 0 < Γ'(2): where does the minimum of Γ lie?\n5. How tight an enclosure of Γ'(1) follows from 1/2 < γ < 2/3?\n6. The half-integer value Γ'(1/2) = −√π(γ + 2 log 2).",
+    "proofStrategy": "Every result delegates to Mathlib's GammaDeriv library and elementary arithmetic:\n\n1. **Core identity**: `gamma_eq_neg_deriv_Gamma_one` wraps `Real.eulerMascheroniConstant_eq_neg_deriv`; `hasDerivAt_Gamma_one` wraps `Real.hasDerivAt_Gamma_one`.\n2. **Integer formula**: `deriv_Gamma_nat` and `hasDerivAt_Gamma_nat` wrap `Real.deriv_Gamma_nat` / `Real.hasDerivAt_Gamma_nat`.\n3. **Concrete values**: specialize the integer formula at n = 1, 2, compute the factorial and harmonic number with `norm_num [harmonic, Finset.sum_range_succ, Finset.sum_range_zero, Nat.factorial]`, and finish with `linarith`.\n4. **Sign & bounds**: combine `deriv_Gamma_one`/`deriv_Gamma_two` with the parent's bounds `Real.one_half_lt_eulerMascheroniConstant` and `Real.eulerMascheroniConstant_lt_two_thirds` via `linarith`.\n5. **Half-integer**: wrap `Real.hasDerivAt_Gamma_one_half`; negativity from √π > 0, log 2 > 0, γ > 0 via `nlinarith`.\n\nA `#print axioms` audit confirms only propext, Classical.choice, and Quot.sound are used — the entry is axiom-free in the project's sense."
+  },
+  "conclusion": {
+    "summary": "This entry converts the parent Euler-Mascheroni formalization's documented Gamma-function connection into fully machine-verified theorems: γ = −Γ'(1), the integer formula Γ'(n+1) = n!(−γ + H_n), concrete small-integer and half-integer values, sign analysis locating the minimum of Γ, and a sharp enclosure of Γ'(1).",
+    "implications": "The identity γ = −Γ'(1) is the bridge between the elementary (limit of H_n − log n) and analytic (digamma) theories of the Euler-Mascheroni constant. Formalizing it verified — and cheaply, contrary to the parent's expectation — makes the whole Gamma-derivative toolkit available to the gallery. The sign change Γ'(1) < 0 < Γ'(2) rigorously locates the well-known minimum of the Gamma function between 1 and 2.",
+    "openQuestions": [
+      "Prove existence and uniqueness of the minimizer of Γ on (0,∞) (numerically ≈ 1.4616) by combining the sign change with continuity/convexity of Γ' on [1,2]",
+      "Formalize the digamma function ψ = Γ'/Γ explicitly and its values ψ(n) = −γ + H_{n−1}",
+      "Formalize the Laurent expansion lim_{s→1}(ζ(s) − 1/(s−1)) = γ (parent open question 3, requires ZetaAsymp)",
+      "Prove that γ is irrational (open since Euler, 1734)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-gamma-deriv-connection",
+      "title": "The Defining Connection γ = -Γ'(1)",
+      "startLine": 43,
+      "endLine": 56,
+      "description": "The central identity: `gamma_eq_neg_deriv_Gamma_one` states γ = −Γ'(1), `hasDerivAt_Gamma_one` gives HasDerivAt Gamma (−γ) 1, and `deriv_Gamma_one` extracts deriv Gamma 1 = −γ. This is exactly the parent entry's second open question, delegated to Mathlib's `eulerMascheroniConstant_eq_neg_deriv` and `hasDerivAt_Gamma_one`."
+    },
+    {
+      "id": "sec-gamma-deriv-integer",
+      "title": "The Integer Formula Γ'(n+1) = n!(-γ + H_n)",
+      "startLine": 58,
+      "endLine": 69,
+      "description": "The general formula for the derivative of Γ at every positive integer in terms of harmonic numbers and γ, as both a `deriv` equation (`deriv_Gamma_nat`) and a `HasDerivAt` statement (`hasDerivAt_Gamma_nat`). Delegates to Mathlib's `Real.deriv_Gamma_nat`."
+    },
+    {
+      "id": "sec-gamma-deriv-concrete",
+      "title": "Concrete Values Γ'(2) = 1 - γ and Γ'(3) = 3 - 2γ",
+      "startLine": 71,
+      "endLine": 90,
+      "description": "Specializes the integer formula at n = 1 and n = 2. Since 1! = 1, H_1 = 1, one gets Γ'(2) = 1 − γ; since 2! = 2, H_2 = 3/2, one gets Γ'(3) = 3 − 2γ. Proved by computing the factorial and harmonic value with norm_num and finishing with linarith."
+    },
+    {
+      "id": "sec-gamma-deriv-sign",
+      "title": "Sign Analysis and the Minimum of Γ",
+      "startLine": 92,
+      "endLine": 116,
+      "description": "From γ > 0 we get Γ'(1) < 0, and from γ < 2/3 < 1 we get Γ'(2) > 0. The packaged statement `deriv_Gamma_sign_change` records Γ'(1) < 0 < Γ'(2). Since Γ is smooth on (0,∞), this sign change is the analytic signature of the unique minimum of Γ, which therefore lies strictly between 1 and 2 (numerically near 1.4616)."
+    },
+    {
+      "id": "sec-gamma-deriv-enclosure",
+      "title": "Sharp Enclosure of Γ'(1) from 1/2 < γ < 2/3",
+      "startLine": 118,
+      "endLine": 128,
+      "description": "Transfers the parent entry's enclosure 1/2 < γ < 2/3 through the identity Γ'(1) = −γ to obtain −2/3 < Γ'(1) < −1/2, a machine-verified numerical bracket for the derivative."
+    },
+    {
+      "id": "sec-gamma-deriv-half",
+      "title": "The Half-Integer Derivative Γ'(1/2)",
+      "startLine": 130,
+      "endLine": 152,
+      "description": "The value Γ'(1/2) = −√π(γ + 2 log 2), obtained via the Gamma duplication formula (`hasDerivAt_Gamma_one_half` and `deriv_Gamma_one_half`), together with its negativity `deriv_Gamma_one_half_neg`, proved from √π > 0, log 2 > 0, and γ > 0."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "harmonic-divergence-oq-01",
+      "relationship": "extends",
+      "description": "This entry discharges the second open question of the parent Euler-Mascheroni entry — the connection γ = −Γ'(1) — which the parent documented only as a comment, believing the Gamma-derivative infrastructure too costly to compile."
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "related",
+      "description": "The grandparent entry establishes harmonic series divergence and basic harmonic-number properties; the harmonic numbers H_n reappear here as the values Γ'(n+1)/n! + γ."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Both entries concern special values connected to the Riemann zeta function; γ is the constant term of the Laurent expansion of ζ at s=1, and appears in the Gamma-function machinery underlying ζ."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 152,
+    "path": "Proofs/HarmonicDivergenceOQ01OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 14
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry `harmonic-divergence-oq-01-oq-02` that **discharges the second open question** of the parent Euler-Mascheroni entry (`harmonic-divergence-oq-01`): the identity **γ = −Γ'(1)**.

The parent documented this Gamma-function connection only as a comment, believing the required infrastructure (`Mathlib.NumberTheory.Harmonic.GammaDeriv`) consumed >32GB. In fact the Mathlib oleans are cached, so the import is cheap, and the connection becomes fully machine-verified.

## Contents (14 theorems, 1 def, 152 lines)

All delegate to `Mathlib.NumberTheory.Harmonic.GammaDeriv` plus elementary arithmetic:

- **Core identity**: γ = −Γ'(1); `HasDerivAt Γ (−γ) 1`; `deriv Gamma 1 = −γ`
- **Integer formula**: Γ'(n+1) = n!(−γ + Hₙ), as `deriv` and `HasDerivAt` forms
- **Concrete values**: Γ'(2) = 1 − γ, Γ'(3) = 3 − 2γ
- **Sign analysis**: Γ'(1) < 0 < Γ'(2) — locates the minimum of Γ strictly in (1,2)
- **Sharp enclosure**: −2/3 < Γ'(1) < −1/2 from the parent bound 1/2 < γ < 2/3
- **Half-integer**: Γ'(1/2) = −√π(γ + 2 log 2), and its negativity

## Verification

- Docker build clean: `Build completed successfully (3136 jobs)`
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom** in the project sense (no `sorry`, no `native_decide`)

## Files

- `proofs/Proofs/HarmonicDivergenceOQ01OQ02.lean`
- `src/data/proofs/harmonic-divergence-oq-01-oq-02/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)