### PR TITLE
research(dirichlet-approximation-theorem-oq-03-oq-03): reusable |det|·box parallelepiped-volume lemma [VERIFIED 0-axiom 6thm/130L NEW]

### DIFF
--- a/proofs/Proofs/DirichletApproximationOQ03OQ03.lean
+++ b/proofs/Proofs/DirichletApproximationOQ03OQ03.lean
@@ -1,0 +1,130 @@
+/-
+  Volume of a Parallelogram = |det| · (box volume)
+  (research problem: dirichlet-approximation-theorem-oq-03-oq-03)
+
+  The parent entry `dirichlet-approximation-theorem-oq-03` re-derives Dirichlet's
+  approximation theorem from Minkowski's convex-body theorem, but leaves ONE step
+  open: the volume computation `volume (body α N) = 4`.  Its docstring records the
+  intended route — the body `K(α,N)` is the image of a box under a shear of
+  determinant `-1`, so its area is `|det| · (box area) = 1 · 4 = 4` by
+  `MeasureTheory.Measure.addHaar_image_linearMap`.
+
+  This file packages that "determinant–shear volume" technique as the reusable lemma
+  requested by the parent's third open question:
+
+      volume of a parallelogram = |det| · (box volume),   in every dimension.
+
+  Everything here is sorry-free and axiom-free (`import Mathlib` only).
+
+  ## What is established
+
+  * `volume_toLin'_image_Icc`
+      — **the reusable core**: for a matrix `M : Matrix (Fin n) (Fin n) ℝ` and a box
+        `[a, b] ⊆ ℝⁿ`, the image `M · [a,b]` has volume `|det M| · ∏ (bᵢ − aᵢ)`.
+        This is the general-dimension "volume of a parallelepiped = |det| · box".
+  * `volume_unitCube`
+      — the unit cube `[0,1]ⁿ` has volume `1`.
+  * `volume_parallelepiped`
+      — Mathlib's fundamental parallelepiped `parallelepiped v` (spanned by the rows
+        `v : Fin n → (Fin n → ℝ)`) has volume `|det|` of the matrix of coordinates.
+        This gives the *concrete* `volume`/`Matrix.det` statement that Mathlib's
+        abstract `addHaar_parallelepiped` (phrased with `Basis.addHaar`/`Basis.det`)
+        does not directly provide.
+  * `volume_parallelogram_2d`
+      — the concrete 2-D specialisation: the parallelogram spanned by `(a,b)` and
+        `(c,d)` has area `|a·d − b·c|`.
+  * `volume_dirichlet_body`
+      — **closes the parent's open volume step**: the shear image of the box
+        `[−N,N] × [−1/N, 1/N]` under `(x,y) ↦ (x, α·x − y)` has volume exactly `4`,
+        independent of `α` and of `N > 0`.  This is precisely the `2² · covolume(ℤ²)`
+        area that Minkowski's theorem consumes in the parent derivation.
+
+  ## Relation to Mathlib
+
+  Mathlib provides `MeasureTheory.Measure.addHaar_image_linearMap`
+  (`μ (f '' s) = ofReal |det f| · μ s`) and `addHaar_parallelepiped`
+  (`b.addHaar (parallelepiped v) = ofReal |b.det v|`).  The contribution here is to
+  specialise these to the Lebesgue `volume` on `Fin n → ℝ` with the *matrix*
+  determinant `Matrix.det` and to concrete boxes, yielding lemmas directly usable in
+  geometry-of-numbers arguments (Minkowski's linear-forms theorem) without unfolding
+  the `Basis.addHaar`/`Basis.det` machinery each time.
+-/
+import Mathlib
+
+namespace ParallelepipedVolume
+
+open MeasureTheory Matrix Set
+
+variable {n : ℕ}
+
+/-- **Reusable core lemma** ("volume of a parallelogram = |det| · box volume").
+    The image of a box `[a, b] ⊆ ℝⁿ` under the linear map of a matrix `M` has volume
+    `|det M|` times the volume of the box. -/
+theorem volume_toLin'_image_Icc (M : Matrix (Fin n) (Fin n) ℝ) (a b : Fin n → ℝ) :
+    volume (Matrix.toLin' M '' Set.Icc a b)
+      = ENNReal.ofReal |M.det| * ∏ i, ENNReal.ofReal (b i - a i) := by
+  rw [volume.addHaar_image_linearMap (Matrix.toLin' M) (Set.Icc a b),
+      LinearMap.det_toLin', Real.volume_Icc_pi]
+
+/-- The unit cube `[0,1]ⁿ` has Lebesgue volume `1`. -/
+theorem volume_unitCube : volume (Set.Icc (0 : Fin n → ℝ) 1) = 1 := by
+  rw [Real.volume_Icc_pi]
+  simp
+
+/-- The linear map `t ↦ ∑ i, tᵢ • vᵢ` defining `parallelepiped v` is `Matrix.toLin'`
+    of the matrix whose columns are the vectors `vᵢ`. -/
+theorem parallelepiped_eq_toLin'_image (v : Fin n → (Fin n → ℝ)) :
+    parallelepiped v = Matrix.toLin' (Matrix.of fun i j => v j i) '' Set.Icc 0 1 := by
+  have hfun :
+      (fun t : Fin n → ℝ => ∑ i, t i • v i)
+        = Matrix.toLin' (Matrix.of fun i j => v j i) := by
+    ext t k
+    simp only [Matrix.toLin'_apply, Matrix.mulVec, dotProduct, Matrix.of_apply,
+      Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+    exact Finset.sum_congr rfl fun i _ => mul_comm _ _
+  show (fun t : Fin n → ℝ => ∑ i, t i • v i) '' Set.Icc 0 1
+      = Matrix.toLin' (Matrix.of fun i j => v j i) '' Set.Icc 0 1
+  rw [hfun]
+
+/-- **Concrete parallelepiped volume.** The fundamental parallelepiped spanned by the
+    vectors `v : Fin n → (Fin n → ℝ)` has volume `|det|` of the coordinate matrix. -/
+theorem volume_parallelepiped (v : Fin n → (Fin n → ℝ)) :
+    volume (parallelepiped v) = ENNReal.ofReal |(Matrix.of fun i j => v j i).det| := by
+  rw [parallelepiped_eq_toLin'_image,
+      volume.addHaar_image_linearMap (Matrix.toLin' (Matrix.of fun i j => v j i)) (Set.Icc 0 1),
+      LinearMap.det_toLin', volume_unitCube, mul_one]
+
+/-- **2-D specialisation.** The parallelogram spanned by `(a,b)` and `(c,d)` has area
+    `|a·d − b·c|`. -/
+theorem volume_parallelogram_2d (a b c d : ℝ) :
+    volume (parallelepiped ![![a, b], ![c, d]]) = ENNReal.ofReal |a * d - b * c| := by
+  have hdet :
+      (Matrix.of fun i j => (![![a, b], ![c, d]] : Fin 2 → Fin 2 → ℝ) j i).det
+        = a * d - b * c := by
+    rw [Matrix.det_fin_two]
+    simp only [Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one]
+    ring
+  rw [volume_parallelepiped, hdet]
+
+/-- **Closes the parent's open volume step.** The shear image of the box
+    `[−N, N] × [−1/N, 1/N]` under `(x, y) ↦ (x, α·x − y)` has volume exactly `4`,
+    for every `α` and every `N > 0` — the `2² · covolume(ℤ²)` input that Minkowski's
+    convex-body theorem consumes in the Dirichlet re-derivation. -/
+theorem volume_dirichlet_body (α : ℝ) (N : ℝ) (hN : 0 < N) :
+    volume (Matrix.toLin' !![1, 0; α, -1] '' Set.Icc ![-N, -(1 / N)] ![N, 1 / N]) = 4 := by
+  have hNe : N ≠ 0 := hN.ne'
+  rw [volume_toLin'_image_Icc, Fin.prod_univ_two]
+  have hdet : |(!![1, 0; α, -1] : Matrix (Fin 2) (Fin 2) ℝ).det| = 1 := by
+    rw [Matrix.det_fin_two_of]; norm_num
+  have h0 :
+      (![N, 1 / N] : Fin 2 → ℝ) 0 - (![-N, -(1 / N)] : Fin 2 → ℝ) 0 = 2 * N := by
+    simp only [Matrix.cons_val_zero]; ring
+  have h1 :
+      (![N, 1 / N] : Fin 2 → ℝ) 1 - (![-N, -(1 / N)] : Fin 2 → ℝ) 1 = 2 * (1 / N) := by
+    simp only [Matrix.cons_val_one, Matrix.cons_val_zero]; ring
+  have hprod : (2 * N) * (2 * (1 / N)) = 4 := by
+    rw [one_div, mul_mul_mul_comm, mul_inv_cancel₀ hNe, mul_one]; norm_num
+  rw [hdet, h0, h1, ENNReal.ofReal_one, one_mul, ← ENNReal.ofReal_mul (by positivity), hprod]
+  norm_num
+
+end ParallelepipedVolume

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-03-oq-03/annotations.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "ann-dirichlet-oq03-oq03-overview",
+    "proofId": "dirichlet-approximation-theorem-oq-03-oq-03",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "concept",
+    "title": "Packaging the Determinant–Shear Volume Technique",
+    "content": "The docstring frames the entry as the answer to the parent Minkowski re-derivation's third open question: package 'volume of a parallelogram = |det| · (box volume)' as a reusable, general-dimension lemma. The parent (dirichlet-approximation-theorem-oq-03) proves Dirichlet's bound by Minkowski's convex-body theorem but leaves ONE step open — the volume computation volume(body α N) = 4. Mathlib supplies the abstract engine addHaar_image_linearMap (μ(f''s) = ofReal|det f|·μ s) and a basis-phrased parallelepiped volume (addHaar_parallelepiped, in terms of Basis.addHaar/Basis.det); the contribution here is the concrete specialisation to the Lebesgue volume on Fin n → ℝ with the matrix determinant Matrix.det, plus the concrete 2-D area formula and the closing volume(body) = 4 computation.",
+    "mathContext": "$\\operatorname{vol}(M\\cdot[a,b]) = |\\det M|\\,\\prod_i(b_i-a_i)$, specialising Mathlib's $\\mu(f''s)=\\operatorname{ofReal}|\\det f|\\cdot\\mu s$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "geometry of numbers",
+      "Haar measure under linear maps",
+      "Minkowski's convex-body theorem",
+      "fundamental parallelepiped",
+      "determinant as volume scaling"
+    ],
+    "prerequisites": [
+      "Lebesgue measure on ℝⁿ",
+      "linear maps and determinants",
+      "Haar measure"
+    ]
+  },
+  {
+    "id": "ann-dirichlet-oq03-oq03-core",
+    "proofId": "dirichlet-approximation-theorem-oq-03-oq-03",
+    "range": { "startLine": 60, "endLine": 67 },
+    "type": "technique",
+    "title": "The Reusable Core: box-image volume = |det| · box volume",
+    "content": "volume_toLin'_image_Icc is the general-dimension 'volume of a parallelogram = |det| · box volume'. Its proof is three rewrites: addHaar_image_linearMap turns volume (Matrix.toLin' M '' [a,b]) into ENNReal.ofReal |LinearMap.det (Matrix.toLin' M)| · volume [a,b]; LinearMap.det_toLin' replaces the abstract linear-map determinant by the concrete matrix determinant Matrix.det M; and Real.volume_Icc_pi expands the box volume into ∏ ofReal(bᵢ − aᵢ). The Lebesgue volume on Fin n → ℝ is an additive Haar measure (isAddHaarMeasure_volume_pi), so the hypothesis of addHaar_image_linearMap is discharged by instance resolution.",
+    "mathContext": "$\\operatorname{vol}(M\\cdot[a,b]) = |\\det M|\\prod_i (b_i-a_i)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "addHaar_image_linearMap",
+      "LinearMap.det_toLin'",
+      "Real.volume_Icc_pi",
+      "box volume"
+    ],
+    "prerequisites": [
+      "additive Haar measure",
+      "matrix-to-linear-map correspondence"
+    ]
+  },
+  {
+    "id": "ann-dirichlet-oq03-oq03-parallelepiped",
+    "proofId": "dirichlet-approximation-theorem-oq-03-oq-03",
+    "range": { "startLine": 74, "endLine": 95 },
+    "type": "technique",
+    "title": "Concrete Parallelepiped Volume via Matrix.det",
+    "content": "parallelepiped_eq_toLin'_image identifies the defining map t ↦ ∑ i, tᵢ • vᵢ of Mathlib's fundamental parallelepiped with Matrix.toLin' of the coordinate matrix (of fun i j => v j i) whose columns are the vectors vᵢ — a coordinatewise funext whose only arithmetic content is mul_comm (tᵢ · (vᵢ)ₖ = (vᵢ)ₖ · tᵢ). volume_parallelepiped then reuses the core lemma at the unit cube, where volume_unitCube collapses the box factor to 1, giving volume (parallelepiped v) = ENNReal.ofReal |det|. This is the concrete volume/Matrix.det counterpart of Mathlib's basis-phrased addHaar_parallelepiped, ready for use without unfolding the Basis.addHaar machinery.",
+    "mathContext": "$\\operatorname{vol}(\\operatorname{parallelepiped} v) = |\\det ((v_j)_i)|$, with the matrix's columns the spanning vectors.",
+    "significance": "important",
+    "relatedConcepts": [
+      "parallelepiped",
+      "coordinate matrix",
+      "addHaar_parallelepiped",
+      "unit cube volume"
+    ],
+    "prerequisites": [
+      "Mathlib parallelepiped definition",
+      "toLin' / mulVec"
+    ]
+  },
+  {
+    "id": "ann-dirichlet-oq03-oq03-plane",
+    "proofId": "dirichlet-approximation-theorem-oq-03-oq-03",
+    "range": { "startLine": 97, "endLine": 107 },
+    "type": "example",
+    "title": "The Plane: Shoelace Area = |ad − bc|",
+    "content": "volume_parallelogram_2d instantiates n = 2 and evaluates Matrix.det_fin_two on the 2×2 coordinate matrix of the spanning vectors (a,b) and (c,d), recovering the classical parallelogram-area (shoelace) formula |a·d − b·c| as a Lebesgue-volume theorem. The determinant computation is isolated as a `have` closed by ring (handling the c·b vs b·c commutation), then rewritten into the parallelepiped volume.",
+    "mathContext": "Area of the parallelogram spanned by $(a,b),(c,d)$ is $|ad-bc|$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "shoelace formula",
+      "Matrix.det_fin_two",
+      "2×2 determinant"
+    ],
+    "prerequisites": [
+      "2×2 determinant"
+    ]
+  },
+  {
+    "id": "ann-dirichlet-oq03-oq03-dirichlet-body",
+    "proofId": "dirichlet-approximation-theorem-oq-03-oq-03",
+    "range": { "startLine": 109, "endLine": 130 },
+    "type": "key-step",
+    "title": "Closing the Parent's Open Step: volume(K) = 4",
+    "content": "volume_dirichlet_body discharges the single volume computation the parent Dirichlet-via-Minkowski entry left open. The shear (x,y) ↦ (x, α·x − y) is Matrix.toLin' !![1,0; α,−1], of determinant 1·(−1) − 0·α = −1 (Matrix.det_fin_two_of), so |det| = 1. Instantiating the core lemma at this matrix and the box [−N,N]×[−1/N,1/N] gives volume = |det| · (2N)·(2/N); with N > 0 the two positive sides combine (ENNReal.ofReal_mul) to ofReal(4) = 4. The product 2N · 2(1/N) = 4 is closed cleanly via mul_inv_cancel₀. This is exactly the 2²·covolume(ℤ²) area Minkowski's convex-body theorem consumes.",
+    "mathContext": "$\\operatorname{vol}\\big((x,y)\\mapsto(x,\\alpha x - y)\\ ''\\ [-N,N]\\times[-1/N,1/N]\\big) = |-1|\\cdot(2N)(2/N) = 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "shear transformation",
+      "Minkowski's convex-body theorem",
+      "covolume of ℤ²",
+      "Dirichlet approximation"
+    ],
+    "prerequisites": [
+      "2×2 determinant",
+      "ENNReal arithmetic",
+      "geometry of numbers"
+    ]
+  }
+]

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-03-oq-03/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "dirichlet-approximation-theorem-oq-03-oq-03",
+  "title": "Volume of a Parallelogram = |det| · (box volume): the Reusable Minkowski Lemma",
+  "slug": "dirichlet-approximation-theorem-oq-03-oq-03",
+  "description": "Packages the determinant–shear volume technique of the parent Minkowski re-derivation of Dirichlet's theorem as the reusable general-dimension lemma its third open question requested: the image of a box [a,b] ⊆ ℝⁿ under the linear map of a matrix M has Lebesgue volume |det M| · ∏(bᵢ − aᵢ). Specialising Mathlib's abstract addHaar_image_linearMap (μ(f''s) = ofReal|det f|·μ s) to the Lebesgue volume on Fin n → ℝ with the matrix determinant Matrix.det, the entry derives: the unit cube [0,1]ⁿ has volume 1; Mathlib's fundamental parallelepiped `parallelepiped v` (spanned by v : Fin n → (Fin n → ℝ)) has volume |det| of the coordinate matrix — the concrete volume/Matrix.det statement that Mathlib's Basis.addHaar-phrased addHaar_parallelepiped does not directly give; the 2-D parallelogram spanned by (a,b),(c,d) has area |a·d − b·c|; and, closing the parent's single open volume step, the shear (x,y) ↦ (x, α·x − y) carries the box [−N,N]×[−1/N,1/N] to a region of volume exactly 4 for every α and every N > 0 — the 2²·covolume(ℤ²) input Minkowski's convex-body theorem consumes. Sorry-free, axiom-free (import Mathlib only).",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Minkowski%27s_theorem",
+    "date": "1896",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DirichletApproximationOQ03OQ03.lean",
+    "tags": [
+      "number-theory",
+      "geometry-of-numbers",
+      "minkowski-convex-body-theorem",
+      "measure-theory",
+      "haar-measure",
+      "determinant",
+      "linear-algebra",
+      "parallelepiped"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.Measure.addHaar_image_linearMap",
+        "description": "μ (f '' s) = ENNReal.ofReal |LinearMap.det f| · μ s for any additive Haar measure μ and linear map f on a finite-dimensional real space. This is the load-bearing engine: every volume computation here specialises it to the Lebesgue volume on Fin n → ℝ and rewrites LinearMap.det (toLin' M) into the matrix determinant Matrix.det M.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar"
+      },
+      {
+        "theorem": "LinearMap.det_toLin'",
+        "description": "LinearMap.det (Matrix.toLin' M) = Matrix.det M. Turns the abstract linear-map determinant that addHaar_image_linearMap produces into the concrete 2×2 (or n×n) matrix determinant, the whole point of the concrete repackaging.",
+        "module": "Mathlib.LinearAlgebra.Determinant"
+      },
+      {
+        "theorem": "Real.volume_Icc_pi",
+        "description": "volume (Set.Icc a b) = ∏ i, ENNReal.ofReal (b i − a i) for a box a,b : Fin n → ℝ. Supplies the box-volume factor and, at a = 0, b = 1, the unit-cube volume 1.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      },
+      {
+        "theorem": "parallelepiped / image_parallelepiped",
+        "description": "Mathlib's fundamental parallelepiped parallelepiped v = (fun t => ∑ i, tᵢ • vᵢ) '' Icc 0 1. Identifying its defining map with Matrix.toLin' of the coordinate matrix (columns vᵢ) lets addHaar_image_linearMap compute its volume as |det| directly.",
+        "module": "Mathlib.MeasureTheory.Measure.Haar.OfBasis"
+      },
+      {
+        "theorem": "Matrix.det_fin_two / Matrix.det_fin_two_of",
+        "description": "The explicit 2×2 determinant a·d − b·c. Drives the concrete 2-D parallelogram-area formula and the shear determinant 1·(−1) − 0·α = −1 in the Dirichlet body volume.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      }
+    ],
+    "originalContributions": [
+      "volume_toLin'_image_Icc: the reusable core lemma requested by the parent's open question — for a matrix M : Matrix (Fin n) (Fin n) ℝ and a box [a,b] ⊆ ℝⁿ, volume (Matrix.toLin' M '' [a,b]) = ENNReal.ofReal |M.det| · ∏ (bᵢ − aᵢ). This is the general-dimension 'volume of a parallelogram = |det| · box volume', obtained by specialising addHaar_image_linearMap to Lebesgue volume and rewriting via LinearMap.det_toLin' and Real.volume_Icc_pi.",
+      "volume_parallelepiped: the concrete volume/Matrix.det statement for Mathlib's fundamental parallelepiped — volume (parallelepiped v) = ENNReal.ofReal |(Matrix.of fun i j => v j i).det| for v : Fin n → (Fin n → ℝ). Mathlib's addHaar_parallelepiped states the analogous fact abstractly with Basis.addHaar and Basis.det; this entry proves the identification of the parallelepiped's defining map with Matrix.toLin' (parallelepiped_eq_toLin'_image) and lands the result on the Lebesgue volume with the matrix determinant, ready to use without unfolding the Basis.addHaar machinery.",
+      "volume_unitCube: volume (Set.Icc (0 : Fin n → ℝ) 1) = 1, the box-volume specialisation supplying the covolume-1 normalisation.",
+      "volume_parallelogram_2d: the concrete 2-D specialisation — the parallelogram spanned by (a,b) and (c,d) has area |a·d − b·c| — the shoelace determinant made a volume theorem.",
+      "volume_dirichlet_body: closes the parent entry's single remaining open step (volume(body α N) = 4). The shear (x,y) ↦ (x, α·x − y) = Matrix.toLin' !![1,0; α,−1], of determinant −1, carries the box [−N,N]×[−1/N,1/N] (sides 2N and 2/N) to a region of volume |−1| · (2N)(2/N) = 4, for every α and every N > 0 — exactly the 2²·covolume(ℤ²) area Minkowski's convex-body theorem consumes."
+    ],
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "dirichlet-approximation-theorem-oq-03",
+        "relationship": "Parent entry: the Minkowski geometry-of-numbers re-derivation of Dirichlet's theorem, whose third open question asked for exactly this reusable 'volume of a parallelogram = |det| · box volume' lemma and which left volume(body α N) = 4 as its one open volume step (here discharged by volume_dirichlet_body)."
+      },
+      {
+        "id": "dirichlet-approximation-theorem",
+        "relationship": "Grandparent entry: Dirichlet's approximation theorem itself. The reusable determinant-volume lemma is the geometric engine behind the Minkowski route to that bound and to its higher-dimensional generalisations (Minkowski's linear-forms theorem)."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 130,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational propext / Classical.choice / Quot.sound are used (no Lean.ofReduceBool; verifiable with #print axioms). The Dirichlet-body volume lemma assumes N > 0 (so that 1/N is defined and the box sides 2N, 2/N are the genuine interval lengths). The load-bearing Mathlib input is addHaar_image_linearMap; the original in-file content is the specialisation to Lebesgue volume with the matrix determinant, the identification of Mathlib's parallelepiped with Matrix.toLin', the concrete 2-D area formula, and the closing volume(body) = 4 computation. Badge is 'original' because the reusable concrete lemmas (volume/Matrix.det form, the parallelepiped identification, and the shear volume closure) are assembled here rather than borrowed.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Minkowski's geometry of numbers (1896) rests on a single measure-theoretic fact: an invertible linear map scales volume by the absolute value of its determinant. Every application — the convex-body theorem, the linear-forms theorem, the theory of successive minima — computes the volume of a slanted region (a parallelepiped) by realising it as the image of an axis-aligned box under a linear map and reading off |det|. Mathlib has the abstract statement (addHaar_image_linearMap) and a basis-phrased parallelepiped volume (addHaar_parallelepiped), but geometry-of-numbers arguments want the concrete form: Lebesgue volume, a matrix, and Matrix.det. This entry packages exactly that, and uses it to finish the volume computation the parent Dirichlet-via-Minkowski entry had left open.",
+    "problemStatement": "Package the determinant–shear volume technique as a reusable general-dimension lemma: for a matrix $M \\in \\mathbb{R}^{n\\times n}$ and a box $[a,b] \\subseteq \\mathbb{R}^n$,\n\n$$\\operatorname{vol}\\big(M\\cdot[a,b]\\big) = |\\det M|\\,\\prod_{i}(b_i - a_i),$$\n\nspecialise it to the fundamental parallelepiped and to the plane, and apply it to close the parent entry's open step $\\operatorname{vol}(K(\\alpha,N)) = 4$.",
+    "text": "Mathlib's addHaar_image_linearMap gives μ(f '' s) = ofReal|det f|·μ s for an abstract linear map f and Haar measure μ; addHaar_parallelepiped gives the parallelepiped volume in terms of Basis.addHaar and Basis.det. Neither is directly in the 'volume on ℝⁿ, Matrix.det' shape a geometry-of-numbers computation reaches for. This entry supplies volume_toLin'_image_Icc (the box version), volume_parallelepiped (the fundamental-parallelepiped version, via an explicit identification of the defining map with Matrix.toLin'), the plane specialisation volume_parallelogram_2d, and the Dirichlet application volume_dirichlet_body.",
+    "proofStrategy": "The reusable core volume_toLin'_image_Icc is a three-rewrite proof: addHaar_image_linearMap turns volume (toLin' M '' [a,b]) into ofReal|LinearMap.det (toLin' M)|·volume[a,b]; LinearMap.det_toLin' replaces the linear-map determinant by the matrix determinant M.det; Real.volume_Icc_pi expands the box volume into ∏ ofReal(bᵢ − aᵢ). volume_unitCube is Real.volume_Icc_pi at a = 0, b = 1 (each factor ofReal(1) = 1). volume_parallelepiped first proves parallelepiped_eq_toLin'_image — the defining map t ↦ ∑ tᵢ•vᵢ equals Matrix.toLin' of the matrix (of fun i j => v j i) whose columns are the vᵢ (a coordinatewise funext with mul_comm) — then reuses the core lemma at the unit cube, where the box factor is 1. volume_parallelogram_2d instantiates n = 2 and evaluates Matrix.det_fin_two on the coordinate matrix. volume_dirichlet_body instantiates the core lemma at M = !![1,0; α,−1] (det −1 by Matrix.det_fin_two_of) and the box [−N,N]×[−1/N,1/N]: |det| = 1 and the two sides multiply to (2N)(2/N) = 4 (ENNReal.ofReal_mul with N > 0), giving volume 4.",
+    "keyInsights": [
+      "**Volume-scaling is the whole engine**: every geometry-of-numbers volume is |det|·(box volume); once addHaar_image_linearMap is specialised to Lebesgue volume and the matrix determinant, the slanted-region volume is a one-line rewrite with no integration",
+      "**Concrete vs. abstract determinant**: Mathlib's parallelepiped volume is phrased with Basis.det/Basis.addHaar; the reusable form a computation actually wants is Matrix.det against the plain Lebesgue volume — bridging them is exactly the identification parallelepiped v = Matrix.toLin' (columns v) '' unit-cube",
+      "**Columns of the matrix are the spanning vectors**: the defining map t ↦ ∑ tᵢ•vᵢ of parallelepiped v is Matrix.toLin' of the matrix M with Mᵢⱼ = (vⱼ)ᵢ, so |det M| computed against the coordinate basis is the parallelepiped's volume",
+      "**The 2-D shoelace formula is a determinant volume**: the plane parallelogram area |a·d − b·c| is just Matrix.det_fin_two of the 2×2 coordinate matrix, recovered as a special case",
+      "**Closing the Dirichlet gap needs only a 2×2 determinant and two interval lengths**: the shear !![1,0; α,−1] has determinant −1 and the box sides are 2N and 2/N, so volume(K) = 1·(2N)(2/N) = 4 — the parent's remaining open step in three rewrites"
+    ],
+    "prerequisites": [
+      "Haar measure under linear maps (MeasureTheory.Measure.addHaar_image_linearMap) and that Lebesgue volume on Fin n → ℝ is an additive Haar measure",
+      "Matrix ↔ linear map dictionary (Matrix.toLin', LinearMap.det_toLin', Matrix.det_fin_two) and product Lebesgue volume (Real.volume_Icc_pi)",
+      "Mathlib's fundamental parallelepiped (parallelepiped, its defining image over the unit cube)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "reusable-core",
+      "title": "The Reusable Core: volume of a box-image = |det| · box volume",
+      "startLine": 55,
+      "endLine": 71,
+      "mathContext": "$\\operatorname{vol}(M\\cdot[a,b]) = |\\det M|\\,\\prod_i (b_i - a_i)$, and $\\operatorname{vol}([0,1]^n) = 1$.",
+      "summary": "volume_toLin'_image_Icc is the general-dimension 'volume of a parallelogram = |det| · box volume': addHaar_image_linearMap turns the image volume into ofReal|LinearMap.det (toLin' M)|·volume[a,b], LinearMap.det_toLin' replaces it by the matrix determinant M.det, and Real.volume_Icc_pi expands the box volume into ∏ ofReal(bᵢ − aᵢ). volume_unitCube specialises the box volume at [0,1]ⁿ to 1."
+    },
+    {
+      "id": "parallelepiped",
+      "title": "Concrete Parallelepiped Volume via Matrix.det",
+      "startLine": 73,
+      "endLine": 104,
+      "mathContext": "$\\operatorname{vol}(\\operatorname{parallelepiped} v) = |\\det (v_j)_i|$.",
+      "summary": "parallelepiped_eq_toLin'_image identifies the defining map t ↦ ∑ tᵢ•vᵢ of Mathlib's parallelepiped with Matrix.toLin' of the coordinate matrix (of fun i j => v j i) — a coordinatewise funext whose only content is mul_comm. volume_parallelepiped then reuses the core lemma at the unit cube (box factor 1) to give volume (parallelepiped v) = ofReal|det|, the concrete volume/Matrix.det counterpart of Mathlib's basis-phrased addHaar_parallelepiped."
+    },
+    {
+      "id": "plane-and-dirichlet",
+      "title": "The Plane Specialisation and the Dirichlet Body Volume",
+      "startLine": 106,
+      "endLine": 123,
+      "mathContext": "Area of the $(a,b),(c,d)$ parallelogram $= |ad - bc|$; $\\operatorname{vol}(\\text{shear}\\cdot[-N,N]\\times[-1/N,1/N]) = 4$.",
+      "summary": "volume_parallelogram_2d evaluates Matrix.det_fin_two on the 2×2 coordinate matrix to recover the shoelace area |a·d − b·c|. volume_dirichlet_body instantiates the core lemma at the shear !![1,0; α,−1] (determinant −1 by Matrix.det_fin_two_of) and the box [−N,N]×[−1/N,1/N]: |det| = 1 and the sides (2N)(2/N) = 4 (ENNReal.ofReal_mul, N > 0), closing the parent entry's open volume(K) = 4 step."
+    }
+  ],
+  "conclusion": {
+    "summary": "The determinant–shear volume technique is packaged as a reusable, general-dimension lemma: the image of a box under a matrix's linear map has Lebesgue volume |det| times the box volume. Specialisations give the unit-cube volume 1, the fundamental-parallelepiped volume |det| in concrete Matrix.det form, the plane parallelogram area |ad − bc|, and — closing the parent's open step — the Dirichlet convex-body volume 4. Zero sorries, zero axioms.",
+    "implications": "This is the volume engine of the geometry of numbers. Minkowski's linear-forms theorem in general dimension, the theory of successive minima, and lattice-point counting all compute the volume of a symmetric convex body by realising it as a linear image of a box and invoking |det|; having the fact in concrete volume/Matrix.det form (rather than the abstract Basis.addHaar phrasing) makes those derivations one-liners. The lemma directly discharges the parent Dirichlet-via-Minkowski entry's remaining open volume computation.",
+    "openQuestions": [
+      "Can volume_toLin'_image_Icc be promoted to a genuine Minkowski linear-forms corollary — given n linear forms of determinant D and a target product of bounds exceeding |D|·2ⁿ, produce a nonzero integer point — reusing the box-image volume as the sole measure input?",
+      "Does replacing the box by a general symmetric convex body C and combining volume_toLin'_image_Icc with an inner/outer box approximation give clean volume bounds |det|·vol(C) for the images that appear in successive-minima arguments?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-03",
+      "relationship": "extends",
+      "description": "Parent entry: its third open question asked for this reusable 'volume of a parallelogram = |det| · box volume' lemma, and it left volume(body α N) = 4 as its one open volume step. volume_dirichlet_body discharges that step and volume_toLin'_image_Icc is the requested general lemma."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem",
+      "relationship": "related",
+      "description": "Grandparent entry: Dirichlet's approximation theorem, whose Minkowski route is powered by exactly this determinant-volume computation."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/DirichletApproximationOQ03OQ03.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Matrix",
+      "Set"
+    ],
+    "namespace": "ParallelepipedVolume",
+    "lineCount": 130,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 6
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Hermann Minkowski"
+      ],
+      "title": "Geometrie der Zahlen",
+      "year": 1896,
+      "venue": "Teubner, Leipzig",
+      "note": "Founding text of the geometry of numbers; the volume-under-linear-maps principle underlies the convex-body and linear-forms theorems."
+    },
+    {
+      "authors": [
+        "J. W. S. Cassels"
+      ],
+      "title": "An Introduction to the Geometry of Numbers",
+      "year": 1959,
+      "venue": "Springer (Grundlehren 99)",
+      "note": "Volumes of parallelepipeds and symmetric convex bodies via determinants; Minkowski's theorems."
+    },
+    {
+      "authors": [
+        "Peter M. Gruber",
+        "Cornelis G. Lekkerkerker"
+      ],
+      "title": "Geometry of Numbers",
+      "year": 1987,
+      "venue": "North-Holland (2nd ed.)",
+      "note": "Comprehensive modern treatment of lattices, successive minima, and volume computations for convex bodies."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Rescued and repaired an untracked orphan Lean file (left by a reaped agent) and shipped it as a new gallery entry answering **dirichlet-approximation-theorem-oq-03**'s third open question.

Packages the *determinant–shear volume technique* as a reusable general-dimension lemma:
```
volume(M · [a,b]) = |det M| · ∏ᵢ(bᵢ − aᵢ)        (volume_toLin'_image_Icc)
```
and specialises it to:
- `volume_unitCube` — [0,1]ⁿ has volume 1
- `volume_parallelepiped` — Mathlib's fundamental `parallelepiped v` in **concrete Matrix.det form** (Mathlib's `addHaar_parallelepiped` is phrased with `Basis.det`/`Basis.addHaar`); via an explicit identification of its defining map with `Matrix.toLin'`
- `volume_parallelogram_2d` — the 2-D shoelace area |ad − bc|
- `volume_dirichlet_body` — **closes the parent oq-03's single open volume step** `volume(K α N) = 4` (shear `!![1,0; α,−1]`, det −1, box sides 2N·2/N)

## Repair
The orphan was written against slightly stale Mathlib API. Fixed three renames to compile under Mathlib v4.26.0:
- `Matrix.det_toLin'` → `LinearMap.det_toLin'`
- `volume_Icc_pi` → `Real.volume_Icc_pi`
- `Matrix.dotProduct` → `dotProduct`
- removed two confirmed-unused `Matrix.head_cons` simp args

## Verification
- Builds clean under `lake env lean` (rc=0, no output)
- 0 sorries, 6 theorems, 130 lines
- `#print axioms` on all 4 headline theorems: only `[propext, Classical.choice, Quot.sound]` — **0-axiom / verified** (no `Lean.ofReduceBool`, no `sorryAx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)