### PR TITLE
research(fibonacci-identities-oq-08): Lucas-number summation identities [verified 0-axiom, 4thm+1def/109L, new entry]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ08.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ08.lean
@@ -1,0 +1,109 @@
+import Mathlib
+
+/-!
+# Lucas-number summation identities
+
+Mathlib records the Fibonacci sequence `Nat.fib` together with a rich collection of
+pointwise identities (`Nat.fib_add_two`, `Nat.fib_add`, `Nat.fib_two_mul`, …), but it
+carries **no Lucas sequence** at all. The Lucas numbers `Lₙ` obey the same recurrence
+as the Fibonacci numbers, `Lₙ₊₂ = Lₙ₊₁ + Lₙ`, but start from the seed `L₀ = 2`,
+`L₁ = 1`; they are the companion sequence to `Fₙ` and satisfy `Lₙ = Fₙ₋₁ + Fₙ₊₁`.
+
+This entry (following the parent `FibonacciIdentities` summation template) builds the
+Lucas sequence from scratch and proves the classical summation and mixed identities,
+each a fully self-contained induction — no axioms, no `native_decide`:
+
+* `lucas_add_fib` — the **Lucas–Fibonacci bridge** `Lₙ + Fₙ = 2·Fₙ₊₁`, equivalently
+  `Lₙ = 2Fₙ₊₁ − Fₙ = Fₙ₊₁ + Fₙ₋₁`. Proved by two-step induction on the shared
+  recurrence; it is the sole link we need between the two sequences.
+
+* `lucas_sum` — the **partial sums of the Lucas numbers**:
+  `(L₀ + L₁ + ⋯ + Lₙ) + 1 = Lₙ₊₂` (stated additively to stay inside `ℕ`). The exact
+  analogue of the Fibonacci partial-sum law `∑ Fᵢ = Fₙ₊₂ − 1`.
+
+* `fib_mul_lucas` — the **doubling identity** `Fₙ · Lₙ = F₂ₙ`. This is Mathlib's
+  `Nat.fib_two_mul` reread through the bridge: `2Fₙ₊₁ − Fₙ = Lₙ`.
+
+* `fib_mul_lucas_sum` — the **mixed partial sum** `(∑ᵢ Fᵢ·Lᵢ) + 1 = F₂ₙ₊₁`, obtained
+  by summing the doubling identity `Fᵢ·Lᵢ = F₂ᵢ` and telescoping through the Fibonacci
+  recurrence.
+
+The only Fibonacci facts used are the recurrence `Nat.fib_add_two` and the doubling
+formula `Nat.fib_two_mul`; everything else is `Finset.sum_range_succ`, the Lucas
+recurrence, and `omega`.
+
+No axioms, no sorries.
+-/
+
+namespace FibonacciIdentitiesOQ08
+
+open Finset
+
+/-- The **Lucas numbers** `Lₙ`: the same recurrence as the Fibonacci numbers,
+`Lₙ₊₂ = Lₙ₊₁ + Lₙ`, but with the seed `L₀ = 2`, `L₁ = 1`. Mathlib has `Nat.fib`
+but no Lucas sequence, so we define it here. -/
+def lucas : ℕ → ℕ
+  | 0 => 2
+  | 1 => 1
+  | (n + 2) => lucas (n + 1) + lucas n
+
+@[simp] theorem lucas_zero : lucas 0 = 2 := rfl
+
+@[simp] theorem lucas_one : lucas 1 = 1 := rfl
+
+/-- Defining recurrence of the Lucas numbers: `Lₙ₊₂ = Lₙ₊₁ + Lₙ`. -/
+theorem lucas_add_two (n : ℕ) : lucas (n + 2) = lucas (n + 1) + lucas n := rfl
+
+/-- **Lucas–Fibonacci bridge.** `Lₙ + Fₙ = 2·Fₙ₊₁`, equivalently `Lₙ = Fₙ₊₁ + Fₙ₋₁`.
+Both sequences obey the same recurrence, so the identity propagates by two-step
+induction from the two seed values. -/
+theorem lucas_add_fib (n : ℕ) : lucas n + Nat.fib n = 2 * Nat.fib (n + 1) := by
+  induction n using Nat.twoStepInduction with
+  | zero => rfl
+  | one => rfl
+  | more n ih1 ih2 =>
+    have hf2 : Nat.fib (n + 2) = Nat.fib n + Nat.fib (n + 1) := Nat.fib_add_two
+    have hf3 : Nat.fib (n + 3) = Nat.fib (n + 1) + Nat.fib (n + 2) :=
+      Nat.fib_add_two (n := n + 1)
+    have ih2' : lucas (n + 1) + Nat.fib (n + 1) = 2 * Nat.fib (n + 2) := ih2
+    have hl : lucas (n + 2) = lucas (n + 1) + lucas n := lucas_add_two n
+    show lucas (n + 2) + Nat.fib (n + 2) = 2 * Nat.fib (n + 3)
+    omega
+
+/-- **Sum of the Lucas numbers** (additive form, to stay in `ℕ`):
+`(L₀ + L₁ + ⋯ + Lₙ) + 1 = Lₙ₊₂`. The Lucas analogue of `∑ Fᵢ = Fₙ₊₂ − 1`. -/
+theorem lucas_sum (n : ℕ) :
+    (∑ i ∈ Finset.range (n + 1), lucas i) + 1 = lucas (n + 2) := by
+  induction n with
+  | zero => simp [lucas]
+  | succ k ih =>
+    rw [Finset.sum_range_succ, lucas_add_two (k + 1)]
+    have hy : lucas (k + 1 + 1) = lucas (k + 2) := rfl
+    omega
+
+/-- **Doubling identity** `Fₙ · Lₙ = F₂ₙ`. This is Mathlib's `Nat.fib_two_mul`
+(`F₂ₙ = Fₙ · (2Fₙ₊₁ − Fₙ)`) read through the bridge `Lₙ = 2Fₙ₊₁ − Fₙ`. -/
+theorem fib_mul_lucas (n : ℕ) : Nat.fib n * lucas n = Nat.fib (2 * n) := by
+  have h := lucas_add_fib n
+  rw [Nat.fib_two_mul]
+  have hl : lucas n = 2 * Nat.fib (n + 1) - Nat.fib n := by omega
+  rw [hl]
+
+/-- **Mixed partial sum** `(F₀L₀ + F₁L₁ + ⋯ + FₙLₙ) + 1 = F₂ₙ₊₁`. Each term is an
+even-indexed Fibonacci number (`Fᵢ·Lᵢ = F₂ᵢ`), and the sum telescopes through the
+Fibonacci recurrence. -/
+theorem fib_mul_lucas_sum (n : ℕ) :
+    (∑ i ∈ Finset.range (n + 1), Nat.fib i * lucas i) + 1 = Nat.fib (2 * n + 1) := by
+  induction n with
+  | zero => simp [lucas]
+  | succ k ih =>
+    rw [Finset.sum_range_succ, fib_mul_lucas]
+    have e : Nat.fib (2 * (k + 1) + 1) = Nat.fib (2 * k + 1) + Nat.fib (2 * (k + 1)) := by
+      have h := Nat.fib_add_two (n := 2 * k + 1)
+      have h2 : 2 * k + 1 + 2 = 2 * (k + 1) + 1 := by ring
+      have h1 : 2 * k + 1 + 1 = 2 * (k + 1) := by ring
+      rw [h2, h1] at h
+      omega
+    omega
+
+end FibonacciIdentitiesOQ08

--- a/src/data/proofs/fibonacci-identities-oq-08/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-08/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-fib08-header",
+    "proofId": "fibonacci-identities-oq-08",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "concept",
+    "title": "Lucas Numbers: Fibonacci's Companion Sequence",
+    "content": "The Lucas numbers 2, 1, 3, 4, 7, 11, 18, … obey the same recurrence as the Fibonacci numbers, Lₙ₊₂ = Lₙ₊₁ + Lₙ, but start from the seed L₀ = 2, L₁ = 1. They are the canonical companion of the Fibonacci sequence, linked to it by Lₙ = Fₙ₋₁ + Fₙ₊₁ and Fₙ Lₙ = F₂ₙ. Mathlib formalizes Nat.fib in depth but records no Lucas sequence, so this entry builds the sequence and its classical summation identities from scratch — each a self-contained induction with no axioms and no native_decide.",
+    "mathContext": "Lucas recurrence $L_{n+2}=L_{n+1}+L_n$, seed $L_0=2,\\ L_1=1$; bridge $L_n=F_{n+1}+F_{n-1}$; doubling $F_nL_n=F_{2n}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lucas numbers", "Fibonacci numbers", "linear recurrence", "companion sequence", "Nat.fib"],
+    "prerequisites": ["second-order linear recurrences", "Fibonacci numbers"]
+  },
+  {
+    "id": "ann-fib08-definition-bridge",
+    "proofId": "fibonacci-identities-oq-08",
+    "range": { "startLine": 42, "endLine": 71 },
+    "type": "definition",
+    "title": "The Lucas Sequence and the Fibonacci Bridge",
+    "content": "The Lucas sequence is defined by structural recursion with the two-value seed (L₀ = 2, L₁ = 1) and the shared recurrence Lₙ₊₂ = Lₙ₊₁ + Lₙ. The key link to Mathlib's Fibonacci library is the bridge lucas_add_fib: Lₙ + Fₙ = 2·Fₙ₊₁ (equivalently Lₙ = Fₙ₊₁ + Fₙ₋₁). Because both sequences satisfy xₙ₊₂ = xₙ₊₁ + xₙ, a linear relation between them holding at two consecutive seeds holds for all n — exactly the payload of Nat.twoStepInduction. Each inductive step is closed by omega after unfolding both recurrences to a common index form.",
+    "mathContext": "Bridge $L_n+F_n=2F_{n+1}$ by two-step induction: base $n=0,1$, step propagates the linear relation through the shared recurrence.",
+    "significance": "central",
+    "relatedConcepts": ["Nat.twoStepInduction", "structural recursion", "Lucas–Fibonacci bridge", "Nat.fib_add_two"],
+    "prerequisites": ["two-step induction", "Fibonacci recurrence", "omega"]
+  },
+  {
+    "id": "ann-fib08-lucas-sum",
+    "proofId": "fibonacci-identities-oq-08",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "insight",
+    "title": "lucas_sum: Partial Sums of the Lucas Numbers",
+    "content": "The Lucas analogue of the Fibonacci partial-sum law ∑ Fᵢ = Fₙ₊₂ − 1: here (L₀ + L₁ + ⋯ + Lₙ) + 1 = Lₙ₊₂. Stated additively to stay inside ℕ (no truncated subtraction). The proof is a single-step induction — peel the top term with Finset.sum_range_succ, apply the Lucas recurrence lucas_add_two, and let omega telescope, taking care to normalise lucas (k+1+1) to lucas (k+2) so omega sees a single atom.",
+    "mathContext": "$\\sum_{i=0}^{n} L_i = L_{n+2}-1$, telescoping via $L_{n+2}=L_{n+1}+L_n$.",
+    "significance": "central",
+    "relatedConcepts": ["Finset.sum_range_succ", "telescoping sum", "partial sums", "induction"],
+    "prerequisites": ["range sums", "Lucas recurrence"]
+  },
+  {
+    "id": "ann-fib08-doubling",
+    "proofId": "fibonacci-identities-oq-08",
+    "range": { "startLine": 84, "endLine": 90 },
+    "type": "insight",
+    "title": "fib_mul_lucas: The Doubling Identity Fₙ·Lₙ = F₂ₙ",
+    "content": "The product of matched Fibonacci and Lucas terms is an even-indexed Fibonacci number. This is not new arithmetic — it is Mathlib's Nat.fib_two_mul, F₂ₙ = Fₙ·(2Fₙ₊₁ − Fₙ), with the parenthesised factor 2Fₙ₊₁ − Fₙ recognised as Lₙ through the bridge lucas_add_fib. The ℕ-subtraction 2Fₙ₊₁ − Fₙ is discharged by omega using the bridge equation, then a single rewrite finishes the identity.",
+    "mathContext": "$F_n L_n = F_{2n}$ from `Nat.fib_two_mul` $F_{2n}=F_n(2F_{n+1}-F_n)$ and $L_n=2F_{n+1}-F_n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.fib_two_mul", "doubling formula", "Lucas–Fibonacci bridge"],
+    "prerequisites": ["Fibonacci doubling formula", "truncated subtraction in ℕ"]
+  },
+  {
+    "id": "ann-fib08-mixed-sum",
+    "proofId": "fibonacci-identities-oq-08",
+    "range": { "startLine": 92, "endLine": 108 },
+    "type": "insight",
+    "title": "fib_mul_lucas_sum: The Mixed Partial Sum",
+    "content": "Summing the doubling identity gives (F₀L₀ + F₁L₁ + ⋯ + FₙLₙ) + 1 = F₂ₙ₊₁. Each term Fᵢ·Lᵢ equals the even-indexed F₂ᵢ (fib_mul_lucas), so the mixed sum is ∑ᵢ F₂ᵢ, which telescopes through the Fibonacci recurrence F₂ₖ₊₃ = F₂ₖ₊₁ + F₂ₖ₊₂. The induction peels the top term, rewrites it via the doubling identity, and closes with omega after aligning the doubled indices 2(k+1), 2k+1 to a common form.",
+    "mathContext": "$\\sum_{i=0}^{n} F_i L_i = \\sum_{i=0}^{n} F_{2i} = F_{2n+1}-1$, telescoping via the Fibonacci recurrence at even/odd indices.",
+    "significance": "central",
+    "relatedConcepts": ["Finset.sum_range_succ", "even-indexed Fibonacci", "telescoping sum", "doubling identity"],
+    "prerequisites": ["range sums", "Fibonacci recurrence", "doubling identity FₙLₙ = F₂ₙ"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-08/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-08/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ08.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOq08Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOq08Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOq08Data: ProofData = {
+  proof: fibonacciIdentitiesOq08Proof,
+  annotations: fibonacciIdentitiesOq08Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-08/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-08/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "fibonacci-identities-oq-08",
+  "title": "Lucas-Number Summation Identities",
+  "slug": "fibonacci-identities-oq-08",
+  "description": "Mathlib carries the Fibonacci sequence (Nat.fib) with a rich pointwise identity library but no Lucas sequence at all. This entry builds the Lucas numbers Lₙ (same recurrence, seed L₀=2, L₁=1) from scratch and proves the classical summation identities: the Lucas–Fibonacci bridge Lₙ + Fₙ = 2Fₙ₊₁, the partial sum (∑ᵢ Lᵢ)+1 = Lₙ₊₂, the doubling identity Fₙ·Lₙ = F₂ₙ, and the mixed partial sum (∑ᵢ Fᵢ·Lᵢ)+1 = F₂ₙ₊₁. Each is a self-contained induction, no axioms, no native_decide.",
+  "meta": {
+    "author": "Édouard Lucas (1878)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_number",
+    "date": "1878",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ08.lean",
+    "tags": ["number-theory", "fibonacci", "lucas-numbers", "summation-identities", "induction", "open-question"],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 109,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "assumptions": "None. Fully machine-verified from Mathlib (only the foundational propext / Classical.choice / Quot.sound; no native_decide, no sorry). The Lucas sequence is defined locally; the only Fibonacci facts used are Nat.fib_add_two and Nat.fib_two_mul.",
+    "originalContributions": [
+      "lucas: a local definition of the Lucas sequence Lₙ (Lₙ₊₂ = Lₙ₊₁ + Lₙ, seed L₀ = 2, L₁ = 1) — Mathlib has Nat.fib but no Lucas sequence",
+      "lucas_add_fib: the Lucas–Fibonacci bridge Lₙ + Fₙ = 2·Fₙ₊₁ (equivalently Lₙ = Fₙ₊₁ + Fₙ₋₁), by two-step induction on the shared recurrence",
+      "lucas_sum: the partial-sum identity (L₀ + ⋯ + Lₙ) + 1 = Lₙ₊₂, the Lucas analogue of ∑ Fᵢ = Fₙ₊₂ − 1",
+      "fib_mul_lucas: the doubling identity Fₙ · Lₙ = F₂ₙ, Nat.fib_two_mul reread through the bridge",
+      "fib_mul_lucas_sum: the mixed partial sum (∑ᵢ Fᵢ·Lᵢ) + 1 = F₂ₙ₊₁, summing the doubling identity and telescoping"
+    ],
+    "prerequisites": [
+      "Fibonacci numbers Nat.fib and the recurrence Nat.fib_add_two",
+      "the doubling formula Nat.fib_two_mul: F₂ₙ = Fₙ(2Fₙ₊₁ − Fₙ)",
+      "Nat.twoStepInduction and Finset.sum_range_succ"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Lucas numbers 2, 1, 3, 4, 7, 11, 18, … are the companion sequence to the Fibonacci numbers: same recurrence, different seed. Introduced by Édouard Lucas (1878) alongside his general theory of second-order linear recurrences, they are tied to the Fibonacci numbers by the bridge Lₙ = Fₙ₋₁ + Fₙ₊₁ and the doubling law Fₙ Lₙ = F₂ₙ, and they enjoy the same style of telescoping summation identities. Mathlib formalizes Nat.fib in depth but records no Lucas sequence, so both the sequence and its identities are built here from the ground up.",
+    "problemStatement": "Define the Lucas numbers in Lean and prove, fully verified, the classical summation identities: the Lucas–Fibonacci bridge, the partial sum ∑ Lᵢ = Lₙ₊₂ − 1, the doubling identity Fₙ Lₙ = F₂ₙ, and the mixed partial sum ∑ Fᵢ Lᵢ = F₂ₙ₊₁ − 1.",
+    "proofStrategy": "The Lucas sequence is defined by structural recursion with the two-value seed L₀ = 2, L₁ = 1. The bridge Lₙ + Fₙ = 2Fₙ₊₁ is proved by Nat.twoStepInduction: it holds at n = 0, 1, and both sequences share the recurrence, so the additive relation propagates linearly (closed by omega once the recurrences are unfolded). The partial-sum identity lucas_sum is a single-step induction using Finset.sum_range_succ and the Lucas recurrence. The doubling identity fib_mul_lucas is Mathlib's Nat.fib_two_mul (F₂ₙ = Fₙ(2Fₙ₊₁ − Fₙ)) with the parenthesised factor rewritten as Lₙ via the bridge. Finally fib_mul_lucas_sum sums the doubling identity term by term: each Fᵢ Lᵢ becomes F₂ᵢ, and the sum telescopes through the Fibonacci recurrence.",
+    "keyInsights": [
+      "The bridge Lₙ + Fₙ = 2Fₙ₊₁ is the single fact that links the freshly-defined Lucas sequence to Mathlib's Fibonacci library; everything else follows from it plus the two recurrences",
+      "Because both sequences satisfy xₙ₊₂ = xₙ₊₁ + xₙ, any linear relation between them that holds at two consecutive seeds holds everywhere — the payload of Nat.twoStepInduction",
+      "The doubling identity Fₙ Lₙ = F₂ₙ is not new arithmetic: it is exactly Nat.fib_two_mul with 2Fₙ₊₁ − Fₙ recognised as Lₙ, so the ℕ-subtraction is discharged by omega through the bridge",
+      "Additive phrasing ((∑ …) + 1 = …) keeps the partial-sum identities inside ℕ, avoiding truncated subtraction while stating exactly ∑ Lᵢ = Lₙ₊₂ − 1 and ∑ Fᵢ Lᵢ = F₂ₙ₊₁ − 1",
+      "Aligning every Fibonacci/Lucas argument to a canonical n, n+1, n+2, n+3 form is what lets omega finish the inductive steps — it treats fib/lucas at differently-written indices as distinct atoms"
+    ],
+    "prerequisites": [
+      "Nat.fib and its recurrence Nat.fib_add_two",
+      "Nat.fib_two_mul (Fibonacci doubling formula)",
+      "Nat.twoStepInduction (two-seed induction)",
+      "Finset.sum_range_succ (peeling the top term of a range sum)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "lucas-definition",
+      "title": "The Lucas Sequence and the Fibonacci Bridge",
+      "summary": "Defines lucas (Lₙ₊₂ = Lₙ₊₁ + Lₙ, seed 2, 1) and proves the bridge lucas_add_fib: Lₙ + Fₙ = 2Fₙ₊₁ by two-step induction.",
+      "startLine": 42,
+      "endLine": 71,
+      "mathContext": "The Lucas numbers share the Fibonacci recurrence $L_{n+2}=L_{n+1}+L_n$ but start from $L_0=2,\\ L_1=1$. The bridge $L_n+F_n=2F_{n+1}$ (equivalently $L_n=F_{n+1}+F_{n-1}$) is proved by `Nat.twoStepInduction`: it holds at $n=0,1$, and since both sequences obey the same recurrence, the linear relation propagates — `omega` closes each step once the recurrences are unfolded to a common index form."
+    },
+    {
+      "id": "summation-identities",
+      "title": "Partial Sums and the Doubling Identity",
+      "summary": "lucas_sum: (∑ᵢ Lᵢ)+1 = Lₙ₊₂; fib_mul_lucas: Fₙ·Lₙ = F₂ₙ; fib_mul_lucas_sum: (∑ᵢ Fᵢ·Lᵢ)+1 = F₂ₙ₊₁.",
+      "startLine": 73,
+      "endLine": 108,
+      "mathContext": "The Lucas partial sum $\\sum_{i\\le n} L_i = L_{n+2}-1$ telescopes by the recurrence (single-step induction). The doubling identity $F_n L_n = F_{2n}$ is Mathlib's `Nat.fib_two_mul`, $F_{2n}=F_n(2F_{n+1}-F_n)$, with the factor $2F_{n+1}-F_n$ recognised as $L_n$ via the bridge. Summing it gives $\\sum_{i\\le n} F_i L_i = \\sum_{i\\le n} F_{2i} = F_{2n+1}-1$, telescoping through the Fibonacci recurrence."
+    }
+  ],
+  "conclusion": {
+    "summary": "Builds the Lucas sequence from scratch (absent from Mathlib) and proves the classical Lucas summation identities fully verified: the Lucas–Fibonacci bridge Lₙ + Fₙ = 2Fₙ₊₁, the partial sum (∑ᵢ Lᵢ)+1 = Lₙ₊₂, the doubling identity Fₙ·Lₙ = F₂ₙ, and the mixed partial sum (∑ᵢ Fᵢ·Lᵢ)+1 = F₂ₙ₊₁. 109 lines, 1 definition, 7 theorems, 0 sorries, 0 axioms.",
+    "implications": "Establishes a reusable local Lucas sequence and the one bridge lemma (Lₙ + Fₙ = 2Fₙ₊₁) that connects it to Mathlib's Fibonacci library, from which the standard summation and doubling identities follow. The same template (two-step induction for cross-sequence relations, sum_range_succ + omega for partial sums) transfers to further Lucas identities.",
+    "openQuestions": [
+      "Prove the Lucas analogue of the sum-of-squares identity ∑ Lᵢ² and the Lucas Cassini-type relation Lₙ₋₁Lₙ₊₁ − Lₙ² = ±5(−1)ⁿ",
+      "Establish L₂ₙ = Lₙ² − 2(−1)ⁿ and L²ₙ − 5F²ₙ = 4(−1)ⁿ, the Lucas–Fibonacci Pell-type relation",
+      "Contribute the Lucas sequence (or the general Lucas sequence Uₙ, Vₙ of a second-order recurrence) to Mathlib, so that these identities become library lemmas rather than local constructions"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "extends",
+      "description": "Parent: Fibonacci summation identities. This entry supplies the companion Lucas sequence and the analogous Lucas summation identities, reusing the same sum_range_succ + induction template."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-07",
+      "relationship": "related",
+      "description": "Sibling on the Fibonacci divisibility characterization, which likewise notes the Lucas connection; that entry works with Nat.fib_gcd while this one builds the Lucas sequence itself and its summation laws."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lucas, Édouard",
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "venue": "American Journal of Mathematics 1(3), pp. 184–240 and 1(4), pp. 289–321",
+      "note": "Introduces the Lucas numbers and the general theory of second-order recurrences, including the Fibonacci–Lucas bridge and doubling laws"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Comprehensive treatment of Fibonacci and Lucas summation identities, including ∑ Lᵢ = Lₙ₊₂ − 1 and Fₙ Lₙ = F₂ₙ"
+    },
+    {
+      "authors": "Vajda, Steven",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood",
+      "note": "Develops the Lucas sequence and the bridge Lₙ = Fₙ₋₁ + Fₙ₊₁ used to connect it to the Fibonacci numbers"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Finset"],
+    "namespace": "FibonacciIdentitiesOQ08",
+    "lineCount": 109,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 4,
+    "trivialSpecializations": 0,
+    "definitionCount": 1,
+    "path": "Proofs/FibonacciIdentitiesOQ08.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry answering an open question of the **fibonacci-identities** family: Mathlib formalizes `Nat.fib` in depth but carries **no Lucas sequence**. This entry defines the Lucas numbers `Lₙ` locally (same recurrence `Lₙ₊₂ = Lₙ₊₁ + Lₙ`, seed `L₀ = 2, L₁ = 1`) and proves the classical summation and doubling identities, each a self-contained induction.

## Results (all verified, 0-axiom — no `native_decide`, no `sorry`)

| Theorem | Statement |
|---|---|
| `lucas_add_fib` | **Lucas–Fibonacci bridge** `Lₙ + Fₙ = 2·Fₙ₊₁` (≡ `Lₙ = Fₙ₊₁ + Fₙ₋₁`), by `Nat.twoStepInduction` |
| `lucas_sum` | **Partial sum** `(L₀ + ⋯ + Lₙ) + 1 = Lₙ₊₂` (additive form, stays in ℕ) |
| `fib_mul_lucas` | **Doubling identity** `Fₙ · Lₙ = F₂ₙ`, from `Nat.fib_two_mul` via the bridge |
| `fib_mul_lucas_sum` | **Mixed partial sum** `(∑ᵢ Fᵢ·Lᵢ) + 1 = F₂ₙ₊₁` |

## Method

The bridge is the single fact linking the fresh Lucas sequence to Mathlib's Fibonacci library; because both obey `xₙ₊₂ = xₙ₊₁ + xₙ`, a linear relation holding at two seeds holds everywhere (two-step induction, closed by `omega`). The partial sums telescope via `Finset.sum_range_succ`. The doubling identity is `Nat.fib_two_mul` with `2Fₙ₊₁ − Fₙ` recognised as `Lₙ`.

## Verification

- `lake env lean Proofs/FibonacciIdentitiesOQ08.lean` — compiles clean, RC=0, no warnings
- `#print axioms` on all four theorems: only `propext` / `Classical.choice` / `Quot.sound` (foundational). No `Lean.ofReduceBool`, no `sorryAx`.

109 lines · 1 definition · 7 theorems (4 substantive) · 0 sorries · 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)