### PR TITLE
research(fibonacci-identities-oq-08): Lucas partial-sum identities [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ08.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ08.lean
@@ -1,0 +1,159 @@
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.Tactic
+
+/-
+# Lucas-number Partial-Sum Identities
+
+## What This Proves
+
+The parent gallery family formalizes the **Fibonacci telescoping sum**
+`∑_{i≤n} Fᵢ = F_{n+2} − 1`. This entry establishes the exact **Lucas-number**
+analogues, for the companion sequence `L₀ = 2, L₁ = 1, Lₙ₊₂ = Lₙ + Lₙ₊₁`:
+
+* `lucas_sum`      —  `∑_{i=0}^{n} Lᵢ = L_{n+2} − 1`.
+* `fib_mul_lucas_sum` —  `∑_{i=0}^{n} Fᵢ·Lᵢ = F_{2n+1} − 1`, the *mixed*
+  Fibonacci–Lucas telescoping sum.
+
+Along the way we prove the fundamental **product identity**
+`Fₙ · Lₙ = F_{2n}` (`fib_mul_lucas`), the multiplicative bridge that turns the
+mixed sum into a sum of even-indexed Fibonacci numbers.
+
+## The telescoped constant
+
+Both sums telescope with correction `−1`. For the Lucas sum,
+`Lᵢ = L_{i+2} − L_{i+1}`, so `∑_{i=0}^{n} Lᵢ = L_{n+2} − L₁ = L_{n+2} − 1`
+(the constant is `L₁ = 1`, exactly as `F₁ = 1` gives the `−1` in the Fibonacci
+sum, despite `L₀ = 2`). We record the subtraction-free form
+`lucas_sum_add_one` first, from which the truncated-subtraction statement
+follows by `omega`.
+
+## How It's Proved
+
+Both partial sums close under a **one-step induction** using
+`Finset.sum_range_succ`, stated in the subtraction-free `(∑ …) + c = …` form so
+`omega` can finish each step from the defining recurrence.
+
+The mixed sum needs the product identity `Fₙ·Lₙ = F_{2n}`. We prove the
+subtraction-free bridge `2·Fₙ₊₁ = Lₙ + Fₙ` by two-step induction, giving
+`Lₙ = 2·Fₙ₊₁ − Fₙ` over `ℕ`; substituting into Mathlib's
+`Nat.fib_two_mul` (`F_{2n} = Fₙ·(2·Fₙ₊₁ − Fₙ)`) yields `Fₙ·Lₙ = F_{2n}`
+immediately.
+
+## References
+
+- The Fibonacci telescoping sum `∑_{i≤n} Fᵢ = F_{n+2} − 1` (parent family).
+- Lucas numbers and the identity `Fₙ·Lₙ = F_{2n}` (Vajda, *Fibonacci & Lucas
+  Numbers*, identities (17a), (23)).
+-/
+
+namespace FibonacciIdentitiesOQ08
+
+open Nat Finset
+
+/-! ## Definition of the Lucas numbers
+
+We use the same structural pair recursion as the sibling Lucas entries so this
+file is self-contained; `lucas` reduces by `rfl`. -/
+
+/-- The pair `(Lₙ, Lₙ₊₁)`. -/
+def lucasPair : ℕ → ℕ × ℕ
+  | 0 => (2, 1)
+  | n + 1 => ((lucasPair n).2, (lucasPair n).1 + (lucasPair n).2)
+
+/-- The Lucas numbers `Lₙ`: `L₀ = 2`, `L₁ = 1`, `Lₙ₊₂ = Lₙ + Lₙ₊₁`. -/
+def lucas (n : ℕ) : ℕ := (lucasPair n).1
+
+@[simp] theorem lucas_zero : lucas 0 = 2 := rfl
+@[simp] theorem lucas_one : lucas 1 = 1 := rfl
+
+/-- The defining recurrence `Lₙ₊₂ = Lₙ + Lₙ₊₁`. -/
+theorem lucas_add_two (n : ℕ) : lucas (n + 2) = lucas n + lucas (n + 1) := rfl
+
+/-! ## The Lucas telescoping sum `∑_{i≤n} Lᵢ = L_{n+2} − 1` -/
+
+/-- **Subtraction-free Lucas partial sum:** `(∑_{i=0}^{n} Lᵢ) + 1 = L_{n+2}`.
+One-step induction: the new term `L_{k+1}` combines with the inductive
+`L_{k+2}` via `L_{k+3} = L_{k+1} + L_{k+2}`. -/
+theorem lucas_sum_add_one (n : ℕ) :
+    (∑ i ∈ range (n + 1), lucas i) + 1 = lucas (n + 2) := by
+  induction n with
+  | zero => decide
+  | succ k ih =>
+      rw [Finset.sum_range_succ]
+      have hr : lucas (k + 3) = lucas (k + 1) + lucas (k + 2) := lucas_add_two (k + 1)
+      -- goal: (∑_{range (k+1)} Lᵢ) + L_{k+1} + 1 = L_{k+3}
+      show (∑ i ∈ range (k + 1), lucas i) + lucas (k + 1) + 1 = lucas (k + 3)
+      omega
+
+/-- **Lucas telescoping sum:** `∑_{i=0}^{n} Lᵢ = L_{n+2} − 1` (truncated
+subtraction over `ℕ`; well-defined since `L_{n+2} ≥ 1`). -/
+theorem lucas_sum (n : ℕ) :
+    (∑ i ∈ range (n + 1), lucas i) = lucas (n + 2) - 1 := by
+  have h := lucas_sum_add_one n
+  omega
+
+/-! ## The product identity `Fₙ · Lₙ = F_{2n}` -/
+
+/-- The subtraction-free Fibonacci–Lucas bridge `2·Fₙ₊₁ = Lₙ + Fₙ`,
+by two-step induction. -/
+theorem two_mul_fib_succ (n : ℕ) : 2 * fib (n + 1) = lucas n + fib n := by
+  induction n using Nat.twoStepInduction with
+  | zero => rfl
+  | one => rfl
+  | more n ih1 ih2 =>
+      have h1 : fib (n + 2) = fib n + fib (n + 1) := fib_add_two
+      have h2 : fib (n + 3) = fib (n + 1) + fib (n + 2) := fib_add_two
+      have h3 : lucas (n + 2) = lucas n + lucas (n + 1) := lucas_add_two n
+      have e1 : 2 * fib (n + 1) = lucas n + fib n := ih1
+      have e2 : 2 * fib (n + 2) = lucas (n + 1) + fib (n + 1) := ih2
+      show 2 * fib (n + 3) = lucas (n + 2) + fib (n + 2)
+      omega
+
+/-- **The product identity `Fₙ · Lₙ = F_{2n}`.** Substitute the bridge
+`Lₙ = 2·Fₙ₊₁ − Fₙ` into `Nat.fib_two_mul`. -/
+theorem fib_mul_lucas (n : ℕ) : fib n * lucas n = fib (2 * n) := by
+  have hb := two_mul_fib_succ n                         -- 2·F_{n+1} = Lₙ + Fₙ
+  have hl : lucas n = 2 * fib (n + 1) - fib n := by omega
+  rw [fib_two_mul, hl]
+
+/-! ## The mixed Fibonacci–Lucas telescoping sum `∑_{i≤n} Fᵢ·Lᵢ = F_{2n+1} − 1` -/
+
+/-- **Subtraction-free mixed sum:** `(∑_{i=0}^{n} Fᵢ·Lᵢ) + 1 = F_{2n+1}`.
+Using `Fᵢ·Lᵢ = F_{2i}`, this is the sum of even-indexed Fibonacci numbers;
+the induction step glues `F_{2k+1} + F_{2k+2} = F_{2k+3}`. -/
+theorem fib_mul_lucas_sum_add_one (n : ℕ) :
+    (∑ i ∈ range (n + 1), fib i * lucas i) + 1 = fib (2 * n + 1) := by
+  induction n with
+  | zero => decide
+  | succ k ih =>
+      rw [Finset.sum_range_succ]
+      -- normalise the new term to `F_{2k+2}` (defeq `F_{2(k+1)}`)
+      have hp : fib (k + 1) * lucas (k + 1) = fib (2 * k + 2) := by
+        rw [show 2 * k + 2 = 2 * (k + 1) from by ring]; exact fib_mul_lucas (k + 1)
+      -- `F_{2k+3} = F_{2k+1} + F_{2k+2}` (defeq of `fib_add_two` at `2k+1`)
+      have hf : fib (2 * k + 3) = fib (2 * k + 1) + fib (2 * k + 2) :=
+        fib_add_two (n := 2 * k + 1)
+      -- goal: (∑_{range (k+1)} Fᵢ·Lᵢ) + F_{k+1}·L_{k+1} + 1 = F_{2(k+1)+1}
+      show (∑ i ∈ range (k + 1), fib i * lucas i) + fib (k + 1) * lucas (k + 1) + 1
+          = fib (2 * k + 3)
+      omega
+
+/-- **Mixed Fibonacci–Lucas telescoping sum:** `∑_{i=0}^{n} Fᵢ·Lᵢ = F_{2n+1} − 1`
+(truncated subtraction; well-defined since `F_{2n+1} ≥ 1`). -/
+theorem fib_mul_lucas_sum (n : ℕ) :
+    (∑ i ∈ range (n + 1), fib i * lucas i) = fib (2 * n + 1) - 1 := by
+  have h := fib_mul_lucas_sum_add_one n
+  omega
+
+/-! ## Numerical sanity checks -/
+
+/-- `L₀ + L₁ + L₂ + L₃ = 2 + 1 + 3 + 4 = 10 = L₅ − 1 = 11 − 1`. -/
+theorem lucas_sum_example : (∑ i ∈ range 4, lucas i) = 10 := by decide
+
+/-- `F₀L₀ + … + F₃L₃ = 0 + 1 + 3 + 8 = 12 = F₇ − 1 = 13 − 1`. -/
+theorem fib_mul_lucas_sum_example : (∑ i ∈ range 4, fib i * lucas i) = 12 := by decide
+
+/-- The product identity on a sample index: `F₆·L₆ = 8·18 = 144 = F₁₂`. -/
+theorem fib_mul_lucas_example : fib 6 * lucas 6 = fib 12 := by decide
+
+end FibonacciIdentitiesOQ08

--- a/src/data/proofs/fibonacci-identities-oq-08/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-08/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-lucas-def",
+    "proofId": "fibonacci-identities-oq-08",
+    "range": { "startLine": 58, "endLine": 70 },
+    "type": "concept",
+    "title": "The Lucas Numbers via Pair Recursion",
+    "content": "`lucasPair n = (Lₙ, Lₙ₊₁)` and `lucas n = (lucasPair n).1` define the Lucas numbers L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁ by a single structural (pair) recursion, so `lucas` reduces by `rfl` and the recurrence `lucas_add_two` holds definitionally. This is the same self-contained encoding used by the sibling Lucas entries, avoiding any dependence on a Mathlib Lucas sequence (there is none — Mathlib has `Nat.fib` but no Lucas numbers).",
+    "mathContext": "$L_0=2,\\ L_1=1,\\ L_{n+2}=L_n+L_{n+1}$ — the companion sequence to the Fibonacci numbers, defined by pair recursion so $L_{n+2}=L_n+L_{n+1}$ is a `rfl`.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lucas numbers", "pair recursion", "linear recurrence"],
+    "prerequisites": ["structural recursion", "Fibonacci numbers"]
+  },
+  {
+    "id": "ann-lucas-sum",
+    "proofId": "fibonacci-identities-oq-08",
+    "range": { "startLine": 74, "endLine": 93 },
+    "type": "concept",
+    "title": "The Lucas Telescoping Sum ∑ Lᵢ = L_{n+2} − 1",
+    "content": "`lucas_sum_add_one` proves the subtraction-free form (∑_{i≤n} Lᵢ) + 1 = L_{n+2} by one-step induction: `Finset.sum_range_succ` peels the last term and `omega` finishes from L_{k+3} = L_{k+1} + L_{k+2}. The truncated-subtraction statement `lucas_sum : ∑ Lᵢ = L_{n+2} − 1` then follows by `omega`. This mirrors the parent's Fibonacci sum ∑ Fᵢ = F_{n+2} − 1; the correction is the telescope constant L₁ = 1 (from Lᵢ = L_{i+2} − L_{i+1}), not something read off from L₀ = 2.",
+    "mathContext": "$\\sum_{i=0}^{n} L_i = L_{n+2} - 1$; telescoping $L_i = L_{i+2}-L_{i+1}$ gives $\\sum_{i=0}^{n} L_i = L_{n+2} - L_1$ with $L_1 = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping sum", "Fibonacci summation identity", "induction"],
+    "prerequisites": ["Finset range sums", "induction over ℕ"]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "fibonacci-identities-oq-08",
+    "range": { "startLine": 97, "endLine": 110 },
+    "type": "technique",
+    "title": "The Subtraction-Free Bridge 2·Fₙ₊₁ = Lₙ + Fₙ",
+    "content": "`two_mul_fib_succ` proves 2·Fₙ₊₁ = Lₙ + Fₙ by two-step induction (`Nat.twoStepInduction`, cases zero/one/more). This is the ℕ-safe encoding of the classical bridge Lₙ = 2·Fₙ₊₁ − Fₙ between the Fibonacci and Lucas sequences; stating it additively keeps everything inside ℕ so the inductive step closes by `omega` from the two recurrences.",
+    "mathContext": "$2F_{n+1} = L_n + F_n$, i.e. $L_n = 2F_{n+1} - F_n$ — the linear bridge relating the Lucas and Fibonacci sequences, proved by two-step induction.",
+    "significance": "supporting",
+    "relatedConcepts": ["two-step induction", "Fibonacci–Lucas bridge", "subtraction-free framing"],
+    "prerequisites": ["Nat.twoStepInduction", "Lucas recurrence"]
+  },
+  {
+    "id": "ann-product-identity",
+    "proofId": "fibonacci-identities-oq-08",
+    "range": { "startLine": 112, "endLine": 117 },
+    "type": "insight",
+    "title": "The Product Identity Fₙ·Lₙ = F_{2n}",
+    "content": "`fib_mul_lucas` proves the fundamental identity Fₙ·Lₙ = F_{2n} in three lines: from the bridge, Lₙ = 2·Fₙ₊₁ − Fₙ (over ℕ, via `omega`), and Mathlib's `Nat.fib_two_mul` states exactly F_{2n} = Fₙ·(2·Fₙ₊₁ − Fₙ). Substituting gives the result with no further induction — an economical reuse of existing Mathlib infrastructure. This bilinear identity is what collapses the mixed sum into a single-sequence sum.",
+    "mathContext": "$F_n \\cdot L_n = F_{2n}$ — the Fibonacci–Lucas product (doubling) identity, obtained from $L_n = 2F_{n+1}-F_n$ and $F_{2n} = F_n(2F_{n+1}-F_n)$ (Mathlib's `Nat.fib_two_mul`).",
+    "significance": "key",
+    "relatedConcepts": ["doubling identity", "Nat.fib_two_mul", "index-doubling"],
+    "prerequisites": ["Fibonacci–Lucas bridge", "Nat.fib_two_mul"]
+  },
+  {
+    "id": "ann-mixed-sum",
+    "proofId": "fibonacci-identities-oq-08",
+    "range": { "startLine": 121, "endLine": 146 },
+    "type": "concept",
+    "title": "The Mixed Sum ∑ Fᵢ·Lᵢ = F_{2n+1} − 1",
+    "content": "`fib_mul_lucas_sum_add_one` proves (∑_{i≤n} Fᵢ·Lᵢ) + 1 = F_{2n+1}. Because Fᵢ·Lᵢ = F_{2i} (the product identity), the mixed sum is really a sum of even-indexed Fibonacci numbers; the induction step rewrites the new term Fₖ₊₁·Lₖ₊₁ as F_{2k+2} and glues F_{2k+1} + F_{2k+2} = F_{2k+3} (a definitional instance of `fib_add_two`), letting `omega` finish. `fib_mul_lucas_sum` gives the subtraction form ∑ Fᵢ·Lᵢ = F_{2n+1} − 1.",
+    "mathContext": "$\\sum_{i=0}^{n} F_i L_i = \\sum_{i=0}^{n} F_{2i} = F_{2n+1} - 1$ — the mixed bilinear sum collapsed via $F_iL_i=F_{2i}$ into a sum of even-indexed Fibonacci numbers.",
+    "significance": "key",
+    "relatedConcepts": ["mixed sum", "even-indexed Fibonacci sum", "product identity", "telescoping"],
+    "prerequisites": ["product identity Fₙ·Lₙ=F_{2n}", "Finset.sum_range_succ"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-08/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-08/meta.json
@@ -1,0 +1,86 @@
+{
+  "id": "fibonacci-identities-oq-08",
+  "title": "Lucas-Number Partial-Sum Identities",
+  "slug": "fibonacci-identities-oq-08",
+  "description": "The Lucas-number analogues of the Fibonacci telescoping sum: ∑_{i≤n} Lᵢ = L_{n+2} − 1 and the mixed Fibonacci–Lucas sum ∑_{i≤n} Fᵢ·Lᵢ = F_{2n+1} − 1. The mixed sum rests on the fundamental product identity Fₙ·Lₙ = F_{2n}, itself derived from the subtraction-free bridge 2·Fₙ₊₁ = Lₙ + Fₙ and Mathlib's Nat.fib_two_mul. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lucas (1878) / Vajda (1989) (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_number",
+    "date": "1878",
+    "status": "verified",
+    "tags": ["number-theory", "fibonacci", "lucas-numbers", "telescoping-sum", "induction", "research"],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ08.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {"theorem": "Nat.fib_two_mul", "description": "F_{2n} = Fₙ·(2·Fₙ₊₁ − Fₙ); the engine behind the product identity Fₙ·Lₙ = F_{2n}", "module": "Mathlib.Data.Nat.Fib.Basic"},
+      {"theorem": "Nat.fib_add_two", "description": "The Fibonacci recurrence F_{n+2} = Fₙ + Fₙ₊₁, used in the mixed-sum induction step", "module": "Mathlib.Data.Nat.Fib.Basic"},
+      {"theorem": "Finset.sum_range_succ", "description": "Peeling the last term of a range sum — the engine of both telescoping inductions", "module": "Mathlib.Algebra.BigOperators.Basic"}
+    ],
+    "originalContributions": [
+      "lucas_sum_add_one / lucas_sum: the Lucas telescoping sum ∑_{i=0}^{n} Lᵢ = L_{n+2} − 1, in subtraction-free and truncated-subtraction forms",
+      "two_mul_fib_succ: the subtraction-free Fibonacci–Lucas bridge 2·Fₙ₊₁ = Lₙ + Fₙ, by two-step induction",
+      "fib_mul_lucas: the fundamental product identity Fₙ·Lₙ = F_{2n}, obtained by substituting the bridge into Nat.fib_two_mul",
+      "fib_mul_lucas_sum_add_one / fib_mul_lucas_sum: the mixed telescoping sum ∑_{i=0}^{n} Fᵢ·Lᵢ = F_{2n+1} − 1 (a sum of even-indexed Fibonacci numbers via the product identity)",
+      "Self-contained Lucas-number definition via pair recursion (reducing by rfl), reused from the sibling Lucas entries"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 159,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms); no sorryAx and no Lean.ofReduceBool — the three numerical examples use kernel `decide`, not `native_decide`. Both partial sums are established by ordinary induction via Finset.sum_range_succ; the product identity uses Mathlib's Nat.fib_two_mul.",
+    "theoremCount": 12,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Fibonacci numbers Fₙ and their companion Lucas numbers Lₙ (L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁, introduced by Édouard Lucas in the 1870s) satisfy a rich web of summation identities. The Fibonacci telescoping sum ∑_{i≤n} Fᵢ = F_{n+2} − 1 is one of the first identities a student meets; its Lucas analogue ∑_{i≤n} Lᵢ = L_{n+2} − 1 has the same shape, with the telescoped constant being L₁ = 1 rather than being read off from L₀ = 2. The two sequences are linked by the product identity Fₙ·Lₙ = F_{2n}, which turns the mixed sum ∑ Fᵢ·Lᵢ into a sum of even-indexed Fibonacci numbers.",
+    "problemStatement": "**Open question (fibonacci-identities-oq-08)**: The gallery establishes the Fibonacci telescoping sum ∑_{i≤n} Fᵢ = F_{n+2} − 1. Prove the Lucas-number analogue ∑_{i≤n} Lᵢ = L_{n+2} − 1 and the mixed Fibonacci–Lucas sum ∑_{i≤n} Fᵢ·Lᵢ, reusing the telescoping induction template.\n\n**Result**: A fully verified (0 sorries, 0 axioms) development of ∑_{i≤n} Lᵢ = L_{n+2} − 1, the product identity Fₙ·Lₙ = F_{2n}, and the mixed sum ∑_{i≤n} Fᵢ·Lᵢ = F_{2n+1} − 1.",
+    "text": "Two Lucas telescoping identities — ∑ Lᵢ = L_{n+2} − 1 and ∑ Fᵢ·Lᵢ = F_{2n+1} − 1 — proved by one-step induction, the mixed sum bridged by the product identity Fₙ·Lₙ = F_{2n}.",
+    "proofStrategy": "**Proof Strategy:**\n\n1. **Lucas telescoping sum**: Stated subtraction-free as (∑_{i≤n} Lᵢ) + 1 = L_{n+2} (`lucas_sum_add_one`) so `omega` can finish the induction step from L_{k+3} = L_{k+1} + L_{k+2}. The truncated-subtraction form `lucas_sum` follows by `omega`.\n\n2. **The bridge 2·Fₙ₊₁ = Lₙ + Fₙ**: Proved by two-step induction (`Nat.twoStepInduction`); this is the subtraction-free encoding of Lₙ = 2·Fₙ₊₁ − Fₙ.\n\n3. **Product identity Fₙ·Lₙ = F_{2n}**: Substitute Lₙ = 2·Fₙ₊₁ − Fₙ (from the bridge, via `omega`) into Mathlib's `Nat.fib_two_mul` (F_{2n} = Fₙ·(2·Fₙ₊₁ − Fₙ)).\n\n4. **Mixed sum**: Since Fᵢ·Lᵢ = F_{2i}, the sum ∑_{i≤n} Fᵢ·Lᵢ is a sum of even-indexed Fibonacci numbers; the induction step glues F_{2k+1} + F_{2k+2} = F_{2k+3} (a defeq instance of `fib_add_two`), giving (∑) + 1 = F_{2n+1}.",
+    "keyInsights": [
+      "**Same constant −1, different reason**: The Fibonacci sum telescopes to F_{n+2} − 1 with the constant F₁ = 1; the Lucas sum telescopes to L_{n+2} − 1 with constant L₁ = 1 — from Lᵢ = L_{i+2} − L_{i+1}, so ∑_{i≤n} Lᵢ = L_{n+2} − L₁. The correction is L₁, not something read off from L₀ = 2.",
+      "**The product identity turns the mixed sum into an even-index Fibonacci sum**: Fₙ·Lₙ = F_{2n} converts ∑ Fᵢ·Lᵢ into ∑ F_{2i} = F_{2n+1} − 1, the sum of even-indexed Fibonacci numbers — a clean example of using a bilinear identity to collapse a mixed sum.",
+      "**Subtraction-free framing keeps everything in ℕ**: Every inductive identity is stated in the form (∑ …) + c = …, so `omega` closes each step over ℕ without truncated-subtraction hazards; the ∑ = … − c forms are recovered afterward, again by `omega`.",
+      "**Reusing Mathlib's fib_two_mul avoids a second induction**: Rather than proving Fₙ·Lₙ = F_{2n} directly by (two-step) induction, we reduce it to the single subtraction-free bridge and Mathlib's existing `Nat.fib_two_mul`, an economical decomposition."
+    ],
+    "prerequisites": [
+      "Fibonacci and Lucas number recurrences",
+      "Induction and two-step induction over ℕ",
+      "Finset range sums (Finset.sum_range_succ)"
+    ]
+  },
+  "sections": [
+    {"id": "setup", "title": "Imports, Docstring, and Lucas Definition", "startLine": 1, "endLine": 71, "summary": "Module docstring framing the Lucas telescoping analogues; imports Mathlib.Data.Nat.Fib.Basic and Mathlib.Tactic; opens namespace FibonacciIdentitiesOQ08. Defines the Lucas numbers via pair recursion (lucasPair / lucas) with base facts lucas_zero, lucas_one, and the recurrence lucas_add_two.", "mathContext": "Lucas numbers L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁, the companion sequence to the Fibonacci numbers."},
+    {"id": "lucas-sum", "title": "The Lucas Telescoping Sum ∑ Lᵢ = L_{n+2} − 1", "startLine": 72, "endLine": 93, "summary": "lucas_sum_add_one proves (∑_{i≤n} Lᵢ) + 1 = L_{n+2} by one-step induction (Finset.sum_range_succ + omega using L_{k+3}=L_{k+1}+L_{k+2}); lucas_sum gives the truncated-subtraction form ∑ Lᵢ = L_{n+2} − 1.", "mathContext": "The Lucas analogue of ∑ Fᵢ = F_{n+2} − 1; telescopes with constant L₁ = 1."},
+    {"id": "product", "title": "The Product Identity Fₙ·Lₙ = F_{2n}", "startLine": 95, "endLine": 117, "summary": "two_mul_fib_succ proves the subtraction-free bridge 2·Fₙ₊₁ = Lₙ + Fₙ by two-step induction; fib_mul_lucas substitutes Lₙ = 2·Fₙ₊₁ − Fₙ into Nat.fib_two_mul to obtain Fₙ·Lₙ = F_{2n}.", "mathContext": "The fundamental Fibonacci–Lucas product identity, the multiplicative bridge between index n and index 2n."},
+    {"id": "mixed-sum", "title": "The Mixed Sum ∑ Fᵢ·Lᵢ = F_{2n+1} − 1", "startLine": 119, "endLine": 146, "summary": "fib_mul_lucas_sum_add_one proves (∑_{i≤n} Fᵢ·Lᵢ) + 1 = F_{2n+1} by induction, using Fₖ₊₁·Lₖ₊₁ = F_{2k+2} and F_{2k+3} = F_{2k+1} + F_{2k+2}; fib_mul_lucas_sum gives the subtraction form.", "mathContext": "Since Fᵢ·Lᵢ = F_{2i}, the mixed sum equals the sum of even-indexed Fibonacci numbers F_{2n+1} − 1."},
+    {"id": "examples", "title": "Numerical Sanity Checks", "startLine": 148, "endLine": 159, "summary": "Three decidable checks: ∑_{i<4} Lᵢ = 10 (= L₅ − 1), ∑_{i<4} Fᵢ·Lᵢ = 12 (= F₇ − 1), and F₆·L₆ = 144 = F₁₂. All by kernel `decide` (no native_decide, so no Lean.ofReduceBool).", "mathContext": "Concrete instances confirming the two telescoping formulas and the product identity."}
+  ],
+  "crossReferences": [
+    {"targetId": "fibonacci-identities", "relationship": "extends", "description": "Provides the Lucas-number analogue ∑ Lᵢ = L_{n+2} − 1 of the parent's Fibonacci telescoping sum ∑ Fᵢ = F_{n+2} − 1, plus the mixed Fibonacci–Lucas sum, reusing the same telescoping induction template."},
+    {"targetId": "fibonacci-identities-oq-02-oq-01-oq-01", "relationship": "related", "description": "Shares the pair-recursion Lucas definition and the bridge 2·Fₙ₊₁ = Lₙ + Fₙ; that entry proves the quadratic identity Lₙ² − 5Fₙ² = 4(−1)ⁿ, this one the linear and mixed partial-sum identities and the product identity Fₙ·Lₙ = F_{2n}."}
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) formalization of the Lucas telescoping sum ∑_{i≤n} Lᵢ = L_{n+2} − 1, the fundamental product identity Fₙ·Lₙ = F_{2n}, and the mixed Fibonacci–Lucas telescoping sum ∑_{i≤n} Fᵢ·Lᵢ = F_{2n+1} − 1, together with three decidable numerical checks.",
+    "implications": "**Theoretical Significance**: These are the exact Lucas-number counterparts of the classical Fibonacci summation identities, obtained by the same one-step telescoping induction. The development highlights two reusable techniques: (i) stating each identity in subtraction-free form so `omega` discharges the inductive step over ℕ, and (ii) collapsing a mixed bilinear sum ∑ Fᵢ·Lᵢ into a single-sequence sum via the product identity Fₙ·Lₙ = F_{2n}, itself reduced to Mathlib's Nat.fib_two_mul through the subtraction-free bridge 2·Fₙ₊₁ = Lₙ + Fₙ.",
+    "openQuestions": [
+      "Prove the alternating Lucas sum ∑_{i≤n} (−1)ⁱ Lᵢ and the odd/even-indexed partial sums (∑ L_{2i}, ∑ L_{2i+1}) in closed form, over ℤ to handle sign alternation.",
+      "Establish the Lucas generating function / Binet-type closed form Lₙ = φⁿ + ψⁿ and rederive these partial sums analytically as a cross-check on the inductive proofs."
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib.Data.Nat.Fib.Basic", "Mathlib.Tactic"],
+    "opens": ["Nat", "Finset"],
+    "namespace": "FibonacciIdentitiesOQ08",
+    "lineCount": 159,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/FibonacciIdentitiesOQ08.lean",
+    "sorries": 0
+  },
+  "references": [
+    {"authors": "Édouard Lucas", "title": "Théorie des fonctions numériques simplement périodiques", "year": "1878", "venue": "American Journal of Mathematics", "note": "Introduction and systematic study of the Lucas numbers Lₙ"},
+    {"authors": "Steven Vajda", "title": "Fibonacci and Lucas Numbers, and the Golden Section", "year": "1989", "venue": "Ellis Horwood", "note": "Catalogue of Fibonacci–Lucas identities including Fₙ·Lₙ = F_{2n} and the partial-sum formulas"}
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **fibonacci-identities-oq-08** — the Lucas-number analogues of the Fibonacci telescoping sum, plus the mixed Fibonacci–Lucas sum.

Answers the parent (`fibonacci-identities`) open question: extend the Fibonacci telescoping sum `∑ Fᵢ = F_{n+2} − 1` to the companion Lucas sequence.

## Results (all 0-axiom, 0-sorry)

- **`lucas_sum`** — `∑_{i=0}^{n} Lᵢ = L_{n+2} − 1` (Lucas telescoping sum; constant is `L₁ = 1`).
- **`fib_mul_lucas`** — the product identity `Fₙ·Lₙ = F_{2n}`, derived from the subtraction-free bridge `2·Fₙ₊₁ = Lₙ + Fₙ` (two-step induction) and Mathlib's `Nat.fib_two_mul`.
- **`fib_mul_lucas_sum`** — the mixed sum `∑_{i=0}^{n} Fᵢ·Lᵢ = F_{2n+1} − 1` (a sum of even-indexed Fibonacci numbers, via the product identity).
- Three kernel-`decide` numerical checks (no `native_decide`).

## Method

Both sums close by one-step induction stated subtraction-free (`(∑ …) + 1 = …`) so `omega` discharges each step; the mixed sum uses `Fᵢ·Lᵢ = F_{2i}` to collapse into an even-index Fibonacci sum.

## Distinctness

Distinct from sibling Lucas entries: `fibonacci-identities-oq-03-oq-02-oq-02` proves the sum of **squares** `∑ Lᵢ²`, and `-oq-02-oq-01-oq-01` proves the quadratic identity `Lₙ² − 5Fₙ² = 4(−1)ⁿ`. The **linear** partial sum, the mixed sum, and the product identity are new. Mathlib has `Nat.fib` but no Lucas sequence.

## Verification

`#print axioms` on `lucas_sum`, `fib_mul_lucas_sum`, `fib_mul_lucas` reports only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Typechecked via `lake env lean` (EXIT 0) against the Mathlib v4.26 cache.

- 12 theorems, 2 definitions, 159 lines
- File: `proofs/Proofs/FibonacciIdentitiesOQ08.lean`
- Gallery: `src/data/proofs/fibonacci-identities-oq-08/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)