### PR TITLE
Enrich hilbert-17-oq-03-oq-01 (constructive Motzkin SOS): cover 5 interior-gap declarations

### DIFF
--- a/src/data/proofs/hilbert-17-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-01/annotations.json
@@ -11,8 +11,64 @@
     "content": "motzkin is defined exactly as in the parent entry Hilbert17SumOfSquares.lean: M = x⁴y² + x²y⁴ − 3x²y² + 1, the canonical polynomial that is nonnegative on ℝ² yet not a sum of squares of polynomials. The multiplier 4 + 4x² + 4y² is the key auxiliary: it is strictly positive, it is itself a sum of squares (2² + (2x)² + (2y)²), and multiplying M by it lands the product inside the polynomial SOS cone.",
     "mathContext": "$M(x,y) = x^4y^2 + x^2y^4 - 3x^2y^2 + 1,\\qquad D(x,y) = 4 + 4x^2 + 4y^2 = 2^2 + (2x)^2 + (2y)^2.$",
     "significance": "supporting",
-    "relatedConcepts": ["Motzkin polynomial", "nonnegative polynomial", "SOS cone", "AM-GM inequality", "positive multiplier"],
-    "prerequisites": ["multivariate polynomials", "sum of squares", "real nonnegativity"]
+    "relatedConcepts": [
+      "Motzkin polynomial",
+      "nonnegative polynomial",
+      "SOS cone",
+      "AM-GM inequality",
+      "positive multiplier"
+    ],
+    "prerequisites": [
+      "multivariate polynomials",
+      "sum of squares",
+      "real nonnegativity"
+    ]
+  },
+  {
+    "id": "ann-h17-oq0301-sos-predicates",
+    "proofId": "hilbert-17-oq-03-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 86
+    },
+    "type": "definition",
+    "title": "Sum-of-squares predicates and the rational function field",
+    "content": "Two `∃`-predicates fix the exact meaning of 'sum of squares' in each setting. `IsSumOfSquaresMv p` says a two-variable real polynomial equals a finite sum `∑ᵢ qᵢ²` of polynomial squares; `IsSumOfSquaresRF z` says the same for an element of the rational function field, `z = ∑ᵢ gᵢ²`. The field itself is `RF := FractionRing (MvPolynomial (Fin 2) ℝ)`, i.e. ℝ(x, y), and `toRF` is its structural embedding `ℝ[x, y] ↪ ℝ(x, y)` (the `algebraMap`). Framing SOS as an existential over a finite index type `Fin m` — rather than over `Multiset` or `Finset` — is what lets the two witness theorems supply the count (7 and 21) and the explicit vector of roots directly.",
+    "mathContext": "$\\mathrm{IsSumOfSquaresMv}(p)\\iff \\exists m,\\,\\exists q:\\mathrm{Fin}\\,m\\to\\mathbb{R}[x,y],\\ p=\\textstyle\\sum_i q_i^2;\\quad RF=\\mathbb{R}(x,y).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sum of squares",
+      "fraction field",
+      "rational functions",
+      "MvPolynomial",
+      "algebraMap"
+    ],
+    "prerequisites": [
+      "existential quantifiers",
+      "field of fractions"
+    ]
+  },
+  {
+    "id": "ann-h17-oq0301-generators",
+    "proofId": "hilbert-17-oq-03-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 101
+    },
+    "type": "definition",
+    "title": "The five certificate generators and the root vectors",
+    "content": "The concrete data of the certificate. `G0, …, G4` are the five polynomial square-roots that appear in the Positivstellensatz identity, with `G0 = 2xy − x³y − xy³` carrying multiplicity three. They are packaged into `qv : Fin 7 → ℝ[x,y] = ![G0, G0, G0, G1, G2, G3, G4]`, the seven roots of `(4+4x²+4y²)·M`, and `dv : Fin 3 → ℝ[x,y] = ![2, 2x, 2y]`, the three roots of the multiplier `4+4x²+4y² = 2² + (2x)² + (2y)²`. Encoding the roots as `Matrix.of ![…]` vectors indexed by `Fin 7` / `Fin 3` is precisely what makes the SOS witnesses `⟨7, qv, _⟩` and `⟨3, dv, _⟩` land, and it feeds the 7×3 product that yields the 21 rational-function squares.",
+    "mathContext": "$q=(G_0,G_0,G_0,G_1,G_2,G_3,G_4),\\quad d=(2,\\,2x,\\,2y).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "SOS certificate",
+      "Fin-indexed vectors",
+      "Matrix.cons",
+      "multiplicity"
+    ],
+    "prerequisites": [
+      "finite vectors in Lean"
+    ]
   },
   {
     "id": "ann-h17-oq0301-certificate",
@@ -26,8 +82,38 @@
     "content": "The mathematical heart of the entry. A single polynomial identity, with all integer coefficients, certifies that D·M is a sum of squares: (4+4x²+4y²)·M = (2xy−x³y−xy³)² (three copies) + (x³y−xy³)² + (2x−2xy²)² + (2y−2x²y)² + (2−2x²y²)². Because every coefficient is an integer, Lean's ring tactic closes it outright. The five generators and the multiplier were found by solving the associated semidefinite Gram-matrix feasibility problem: Motzkin lies on the boundary of the SOS cone, and the rational boundary Gram matrix factors into exactly these squares.",
     "mathContext": "$(4+4x^2+4y^2)\\,M = 3(2xy-x^3y-xy^3)^2 + (x^3y-xy^3)^2 + (2x-2xy^2)^2 + (2y-2x^2y)^2 + (2-2x^2y^2)^2.$",
     "significance": "critical",
-    "relatedConcepts": ["Positivstellensatz", "SOS certificate", "semidefinite programming", "Gram matrix", "ring tactic"],
-    "prerequisites": ["polynomial identities", "semidefinite programming basics"]
+    "relatedConcepts": [
+      "Positivstellensatz",
+      "SOS certificate",
+      "semidefinite programming",
+      "Gram matrix",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "polynomial identities",
+      "semidefinite programming basics"
+    ]
+  },
+  {
+    "id": "ann-h17-oq0301-mul-sos",
+    "proofId": "hilbert-17-oq-03-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 116
+    },
+    "type": "theorem",
+    "title": "The scaled Motzkin polynomial is a polynomial sum of squares",
+    "content": "The first half of Artin's argument at the polynomial level: `(4+4x²+4y²)·M` is a genuine sum of squares of polynomials, exhibited with seven summands. The proof supplies the witness `⟨7, qv, _⟩`, expands `∑ i, qv i ^ 2` over `Fin 7` via `Fin.sum_univ_seven`, evaluates the vector entries with `Matrix.cons_val`, and closes with the certificate `multiplier_mul_motzkin_eq`. This is the step where the abstract predicate `IsSumOfSquaresMv` is discharged by the concrete integer identity — no positivity reasoning is needed, only the equality of two polynomials.",
+    "mathContext": "$(4+4x^2+4y^2)\\,M = \\sum_{i=0}^{6} q_i^2.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sum of squares",
+      "Fin.sum_univ_seven",
+      "witness construction"
+    ],
+    "prerequisites": [
+      "finite sums over Fin n"
+    ]
   },
   {
     "id": "ann-h17-oq0301-multiplier-sos",
@@ -41,14 +127,68 @@
     "content": "4 + 4x² + 4y² = 2² + (2x)² + (2y)². This is what lets the polynomial certificate become a rational-function certificate: dividing M = (D·M)/D by an SOS denominator D and using that the product of two sums of squares is again a sum of squares ((∑aᵢ²)(∑bⱼ²) = ∑ᵢⱼ(aᵢbⱼ)²) keeps the result a sum of squares, now of rational functions.",
     "mathContext": "$D = 2^2 + (2x)^2 + (2y)^2,\\qquad M = \\frac{D\\cdot M}{D} = \\frac{(\\sum q_i^2)(\\sum d_j^2)}{D^2} = \\sum_{i,j}\\Big(\\frac{q_i d_j}{D}\\Big)^2.$",
     "significance": "key",
-    "relatedConcepts": ["Brahmagupta–Fibonacci / Lagrange identity", "product of sums of squares", "rational functions", "SOS denominator"],
-    "prerequisites": ["sum-of-squares identities", "field of fractions"]
+    "relatedConcepts": [
+      "Brahmagupta–Fibonacci / Lagrange identity",
+      "product of sums of squares",
+      "rational functions",
+      "SOS denominator"
+    ],
+    "prerequisites": [
+      "sum-of-squares identities",
+      "field of fractions"
+    ]
+  },
+  {
+    "id": "ann-h17-oq0301-nonzero",
+    "proofId": "hilbert-17-oq-03-oq-01",
+    "range": {
+      "startLine": 128,
+      "endLine": 139
+    },
+    "type": "insight",
+    "title": "Nonvanishing of the multiplier — the license to divide",
+    "content": "Passing from the scaled identity to the rational-function statement requires dividing by the multiplier, which is only legitimate if it is nonzero in the field. `multiplier_ne_zero` proves `4+4x²+4y² ≠ 0` in `ℝ[x, y]` by evaluating at `(0,0)`, where it equals `4`. `toRF_multiplier_ne_zero` then transports this to `ℝ(x, y)` using that the embedding `toRF = algebraMap` is injective (`IsFractionRing.injective`), so `map_eq_zero_iff` turns nonvanishing of the polynomial into nonvanishing of its image. This is the technical hinge that makes the subsequent `field_simp` sound.",
+    "mathContext": "$D(0,0)=4\\neq 0\\ \\Rightarrow\\ D\\neq 0\\ \\text{in }\\mathbb{R}[x,y]\\ \\xrightarrow{\\ \\mathrm{toRF\\ inj}\\ }\\ \\mathrm{toRF}\\,D\\neq 0.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IsFractionRing.injective",
+      "map_eq_zero_iff",
+      "evaluation homomorphism",
+      "nonzero divisor"
+    ],
+    "prerequisites": [
+      "injectivity into fraction fields"
+    ]
+  },
+  {
+    "id": "ann-h17-oq0301-product-identity",
+    "proofId": "hilbert-17-oq-03-oq-01",
+    "range": {
+      "startLine": 141,
+      "endLine": 149
+    },
+    "type": "theorem",
+    "title": "The 21-term product identity bridging to rational functions",
+    "content": "The bridge that upgrades 'D·M is SOS' to 'M is SOS of rational functions'. Multiplying the seven-square certificate for `D·M` by the three-square decomposition of `D` gives, by the product-of-sums-of-squares rule, a sum of `7·3 = 21` polynomial squares equal to `(D·M)·D`. Formally `∑_{(i,j) : Fin 7 × Fin 3} (qv i · dv j)² = (multiplier·M)·multiplier`, proved by flattening the product sum with `Fintype.sum_prod_type`, unfolding both index vectors, and letting `ring` verify the concrete polynomial equality. Dividing this identity through by `D²` in the field then expresses `M` itself as `∑ (qᵢdⱼ / D)²`, which is exactly `motzkin_isSOS_ratFunc`.",
+    "mathContext": "$\\sum_{i<7,\\,j<3}(q_i d_j)^2 = (D\\cdot M)\\cdot D,\\qquad M = \\sum_{i,j}\\Big(\\tfrac{q_i d_j}{D}\\Big)^2.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "product of sums of squares",
+      "Fintype.sum_prod_type",
+      "ring tactic",
+      "reindexing",
+      "finProdFinEquiv"
+    ],
+    "prerequisites": [
+      "sums over product types",
+      "dividing identities in a field"
+    ]
   },
   {
     "id": "ann-h17-oq0301-ratfunc",
     "proofId": "hilbert-17-oq-03-oq-01",
     "range": {
-      "startLine": 150,
+      "startLine": 151,
       "endLine": 177
     },
     "type": "theorem",
@@ -56,7 +196,17 @@
     "content": "motzkin_isSOS_ratFunc concludes M is a sum of squares of rational functions in ℝ(x,y) = FractionRing ℝ[x,y]. The proof lifts the 21-term polynomial identity Σ_{i<7,j<3}(qᵢdⱼ)² = (D·M)·D through the embedding ℝ[x,y] ↪ ℝ(x,y), divides by D² (legitimate since D ≠ 0, its constant term being 4), and reindexes Fin 7 × Fin 3 ≃ Fin 21. The result is the explicit, 0-axiom witness for the canonical example underlying the parent's axiomatized general Artin theorem artin_hilbert17: where the parent only asserts existence, here a certificate is exhibited and machine-checked.",
     "mathContext": "$M = \\sum_{i=1}^{7}\\sum_{j=1}^{3}\\Big(\\frac{q_i\\,d_j}{4+4x^2+4y^2}\\Big)^2 \\in \\Sigma\\,\\mathbb{R}(x,y)^2.$",
     "significance": "key",
-    "relatedConcepts": ["Artin's theorem", "Hilbert's 17th problem", "fraction ring", "constructive existence witness", "reindexing a finite sum"],
-    "prerequisites": ["FractionRing / field of fractions", "finite sums over product types", "Artin's theorem statement"]
+    "relatedConcepts": [
+      "Artin's theorem",
+      "Hilbert's 17th problem",
+      "fraction ring",
+      "constructive existence witness",
+      "reindexing a finite sum"
+    ],
+    "prerequisites": [
+      "FractionRing / field of fractions",
+      "finite sums over product types",
+      "Artin's theorem statement"
+    ]
   }
 ]


### PR DESCRIPTION
## Coverage-gap enrichment

`hilbert-17-oq-03-oq-01` (constructive Hilbert 17th for the Motzkin polynomial) had **4 annotations for 20 declarations** — 15 interior constructs uncovered, leaving the middle of the proof (the SOS predicates, the certificate generators, and the polynomial→rational-function bridge) unexplained.

### Added 5 annotations (4 → 9)
- **SOS predicates & ℝ(x,y)** [73–86] — `IsSumOfSquaresMv` / `IsSumOfSquaresRF` and the fraction field `RF` with embedding `toRF`.
- **Certificate generators** [90–101] — the five roots `G0…G4` (G0 with multiplicity 3) and the root vectors `qv : Fin 7`, `dv : Fin 3`.
- **Scaled Motzkin is SOS** [111–116] — `motzkin_mul_isSumOfSquares`, the 7-square witness discharged by the integer certificate.
- **Multiplier nonvanishing** [128–139] — `multiplier_ne_zero` / `toRF_multiplier_ne_zero`, the injectivity hinge that licenses dividing in the field.
- **21-term product identity** [141–149] — `product_identity`, the product-of-SOS bridge (7×3=21 squares) that upgrades to `motzkin_isSOS_ratFunc`.

### Also
- Realigned pre-existing `ann-h17-oq0301-ratfunc` `startLine` 150→151 (was anchored on a `/-! … -/` section-header line; now on the theorem's doc comment) — clears the sole validator warning on this entry.

Annotations validate clean (`scripts/annotations/build.ts --strict`, no errors for this entry). Single-file change; no Lean source touched.