### PR TITLE
Enrich erdos-564-incomplete-01 (tower-height gap): cover 5 tail-gap declarations

### DIFF
--- a/src/data/proofs/erdos-564-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-564-incomplete-01/annotations.json
@@ -2,73 +2,247 @@
   {
     "id": "ann-overview",
     "proofId": "erdos-564-incomplete-01",
-    "range": { "startLine": 1, "endLine": 32 },
+    "range": {
+      "startLine": 1,
+      "endLine": 32
+    },
     "type": "concept",
     "title": "Erdős #564 and the meaning of 'tower height'",
     "content": "Erdős Problem #564 ($500, OPEN) concerns the 3-uniform hypergraph Ramsey number R₃(n). Erdős–Hajnal–Rado (1965) proved 2^{cn²} < R₃(n) < 2^{2^n} — a singly-exponential lower bound and a doubly-exponential upper bound, a gap of one full 'tower level'. The conjecture asks whether the lower bound can be raised to 2^{2^{cn}}, i.e. whether R₃ reaches tower height 2 from below. The parent file axiomatizes R and the bounds and defines tower(k,n) = 2↑↑k but proves no growth theory, so 'tower height' is only notation. This file supplies the verified, 0-axiom growth theory that makes the comparison rigorous; it does NOT touch the open conjecture or import the parent's axioms.",
     "mathContext": "$2^{cn^2} < R_3(n) < 2^{2^n}$; conjecture: $R_3(n) \\ge 2^{2^{cn}}$ (tower height $2$).",
     "significance": "supporting",
-    "relatedConcepts": ["Ramsey theory", "hypergraph Ramsey number", "tower function", "Knuth up-arrow", "Erdős problems"],
-    "prerequisites": ["combinatorics", "Ramsey theory", "iterated exponentials"]
+    "relatedConcepts": [
+      "Ramsey theory",
+      "hypergraph Ramsey number",
+      "tower function",
+      "Knuth up-arrow",
+      "Erdős problems"
+    ],
+    "prerequisites": [
+      "combinatorics",
+      "Ramsey theory",
+      "iterated exponentials"
+    ]
   },
   {
     "id": "ann-tower-succ",
     "proofId": "erdos-564-incomplete-01",
-    "range": { "startLine": 41, "endLine": 43 },
+    "range": {
+      "startLine": 46,
+      "endLine": 48
+    },
     "type": "definition",
     "title": "The tower recursion as a rewrite lemma",
     "content": "tower_succ records the defining recursion tower (k+1) n = 2 ^ tower k n by rfl — definitional unfolding. Recording it as a named rewrite lemma is what lets every subsequent growth proof reduce one tower level to a single base-2 exponentiation, turning facts about iterated exponentials into facts about a single 2^(·).",
     "mathContext": "$\\text{tower}(k+1, n) = 2^{\\text{tower}(k,n)}$",
     "significance": "supporting",
-    "relatedConcepts": ["recursion", "definitional equality", "rewrite lemma"],
-    "prerequisites": ["recursive definitions", "Lean rfl"]
+    "relatedConcepts": [
+      "recursion",
+      "definitional equality",
+      "rewrite lemma"
+    ],
+    "prerequisites": [
+      "recursive definitions",
+      "Lean rfl"
+    ]
   },
   {
     "id": "ann-height-growth",
     "proofId": "erdos-564-incomplete-01",
-    "range": { "startLine": 45, "endLine": 63 },
+    "range": {
+      "startLine": 50,
+      "endLine": 63
+    },
     "type": "insight",
     "title": "Growth in height: each level strictly increases the tower",
     "content": "tower_lt_succ_height proves tower k n < tower (k+1) n by rewriting the successor to 2 ^ tower k n and applying the elementary m < 2^m (Nat.lt_two_pow_self). Crucially this holds even at m = 0 (0 < 1), so no positivity hypothesis on the base n is needed — a clean strengthening over the parent's positivity-gated lemma. strictMono_nat_of_lt_succ then lifts the consecutive inequality to full strict monotonicity of k ↦ tower k n, and self_le_tower follows by applying that monotonicity to 0 ≤ k with tower 0 n = n.",
     "mathContext": "$m < 2^m \\Rightarrow \\text{tower}(k,n) < \\text{tower}(k+1,n)$; hence $n = \\text{tower}(0,n) \\le \\text{tower}(k,n)$.",
     "significance": "key",
-    "relatedConcepts": ["strict monotonicity", "m < 2^m", "strictMono_nat_of_lt_succ", "Nat.lt_two_pow_self"],
-    "prerequisites": ["monotone functions", "natural number induction"]
+    "relatedConcepts": [
+      "strict monotonicity",
+      "m < 2^m",
+      "strictMono_nat_of_lt_succ",
+      "Nat.lt_two_pow_self"
+    ],
+    "prerequisites": [
+      "monotone functions",
+      "natural number induction"
+    ]
   },
   {
     "id": "ann-base-growth",
     "proofId": "erdos-564-incomplete-01",
-    "range": { "startLine": 65, "endLine": 79 },
+    "range": {
+      "startLine": 65,
+      "endLine": 79
+    },
     "type": "tactic",
     "title": "Growth in base: strict monotonicity by induction on height",
     "content": "tower_strictMono_base proves n ↦ tower k n is strictly monotone for each fixed height k, by induction on k. The base case (k = 0) is the identity tower 0 n = n. The successor step assumes the inductive strict inequality ih h : tower k a < tower k b and composes it with the strict monotonicity of base-2 exponentiation (Nat.pow_lt_pow_right) to get 2 ^ tower k a < 2 ^ tower k b = tower (k+1) ·. Together with height-monotonicity, the tower grows strictly in BOTH arguments. tower_mono_base is the non-strict corollary.",
     "mathContext": "$a < b \\Rightarrow \\text{tower}(k,a) < \\text{tower}(k,b)$, by induction on $k$ via strict monotonicity of $2^{(\\cdot)}$.",
     "significance": "key",
-    "relatedConcepts": ["strict monotonicity", "induction", "Nat.pow_lt_pow_right", "monotonicity in two arguments"],
-    "prerequisites": ["mathematical induction", "monotone functions"]
+    "relatedConcepts": [
+      "strict monotonicity",
+      "induction",
+      "Nat.pow_lt_pow_right",
+      "monotonicity in two arguments"
+    ],
+    "prerequisites": [
+      "mathematical induction",
+      "monotone functions"
+    ]
   },
   {
     "id": "ann-crux",
     "proofId": "erdos-564-incomplete-01",
-    "range": { "startLine": 81, "endLine": 97 },
+    "range": {
+      "startLine": 82,
+      "endLine": 97
+    },
     "type": "insight",
     "title": "The crux: tower height 1 is strictly below tower height 2",
     "content": "This is the formal heart of Erdős #564. The known singly-exponential lower bound has tower height 1 (tower 1 n = 2^n); the conjectured doubly-exponential lower bound has tower height 2 (tower 2 n = 2^{2^n}, via tower_two_eq). tower_one_lt_tower_two shows 2^n < 2^{2^n} for every n, by applying strict monotonicity of 2^(·) to the elementary n < 2^n. This makes precise the statement 'the EHR lower bound is one full tower level below the upper bound' — the exact gap the open conjecture asks to close.",
     "mathContext": "$\\text{tower}(1,n) = 2^n < 2^{2^n} = \\text{tower}(2,n)$, since $n < 2^n$.",
     "significance": "key",
-    "relatedConcepts": ["singly vs doubly exponential", "tower height gap", "Erdős #564 conjecture", "Nat.pow_lt_pow_right"],
-    "prerequisites": ["exponential growth", "monotonicity"]
+    "relatedConcepts": [
+      "singly vs doubly exponential",
+      "tower height gap",
+      "Erdős #564 conjecture",
+      "Nat.pow_lt_pow_right"
+    ],
+    "prerequisites": [
+      "exponential growth",
+      "monotonicity"
+    ]
   },
   {
     "id": "ann-examples",
     "proofId": "erdos-564-incomplete-01",
-    "range": { "startLine": 99, "endLine": 108 },
+    "range": {
+      "startLine": 99,
+      "endLine": 108
+    },
     "type": "tactic",
     "title": "Concrete sanity checks via decide",
     "content": "Three concrete evaluations anchor the definitions: tower 2 3 = 2^{2^3} = 2^8 = 256 and tower 3 1 = 2^{2^{2^1}} = 2^4 = 16, both discharged by kernel `decide` (note: not native_decide, so no Lean.ofReduceBool dependency). The third, 5 ≤ tower 4 5, instantiates self_le_tower, demonstrating the base lower bound at a height where the tower value is astronomically large.",
     "mathContext": "$\\text{tower}(2,3)=2^{8}=256,\\ \\text{tower}(3,1)=2^{4}=16,\\ 5 \\le \\text{tower}(4,5)$",
     "significance": "supporting",
-    "relatedConcepts": ["decidability", "kernel decide", "concrete evaluation"],
-    "prerequisites": ["Lean tactics", "natural number arithmetic"]
+    "relatedConcepts": [
+      "decidability",
+      "kernel decide",
+      "concrete evaluation"
+    ],
+    "prerequisites": [
+      "Lean tactics",
+      "natural number arithmetic"
+    ]
+  },
+  {
+    "id": "ann-nsq-lt-two-pow",
+    "proofId": "erdos-564-incomplete-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 122
+    },
+    "type": "tactic",
+    "title": "The arithmetic core: n² < 2ⁿ for n ≥ 5",
+    "content": "The elementary inequality that powers the faithful quadratic lower bound below. It is tight — `4² = 16 = 2⁴` — so the hypothesis `5 ≤ n` cannot be relaxed. The proof is `Nat.le_induction` from the base `5² = 25 < 32 = 2⁵` (closed by `decide`); the successor step writes `2^(m+1) = 2^m + 2^m` and combines the inductive `m² < 2^m` with `2m+1 ≤ m²` (valid for `m ≥ 5`, discharged by `nlinarith`) to clear `(m+1)² = m² + 2m + 1 < 2^m + 2^m`.",
+    "mathContext": "$n^2 < 2^n \\quad (n \\ge 5),\\qquad (m+1)^2 = m^2 + 2m + 1 < 2^m + 2^m = 2^{m+1}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.le_induction",
+      "nlinarith",
+      "exponential vs polynomial growth"
+    ],
+    "prerequisites": [
+      "induction from a base case"
+    ]
+  },
+  {
+    "id": "ann-faithful-quadratic-gap",
+    "proofId": "erdos-564-incomplete-01",
+    "range": {
+      "startLine": 124,
+      "endLine": 136
+    },
+    "type": "insight",
+    "title": "The faithful quadratic form of the gap: 2^{n²} < tower 2 n",
+    "content": "A more honest statement of the Erdős #564 gap than the height-1-vs-height-2 comparison. The genuine Erdős–Hajnal–Rado *lower* bound is `2^{cn²}` — singly exponential but with a **quadratic** exponent — while the conjecture asks for the doubly-exponential `2^{2^{cn}}` (tower height 2). Stripped to its cleanest instance, `ehr_lower_lt_tower_two` shows `2^{n²} < tower 2 n = 2^{2^n}` for every `n ≥ 5`: even the quadratic exponent `n²` is a full tower level below `2^n`. The proof rewrites `tower 2 n = 2^{2^n}` and applies base-2 monotonicity of exponentiation to the core inequality `n² < 2^n`.",
+    "mathContext": "$2^{n^2} < \\mathrm{tower}\\,2\\,n = 2^{2^{n}} \\quad (n \\ge 5),\\qquad \\text{known } 2^{cn^2}\\ \\text{vs conjectured } 2^{2^{cn}}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős–Hajnal–Rado bound",
+      "quadratic exponent",
+      "Nat.pow_lt_pow_right",
+      "tower height"
+    ],
+    "prerequisites": [
+      "monotonicity of exponentiation"
+    ]
+  },
+  {
+    "id": "ann-sanity-checks-tail",
+    "proofId": "erdos-564-incomplete-01",
+    "range": {
+      "startLine": 140,
+      "endLine": 147
+    },
+    "type": "tactic",
+    "title": "Concrete evaluations of the tower",
+    "content": "Three closed-form sanity checks that ground the abstract growth theory in numbers. `tower 2 3 = 256` and `tower 3 1 = 2^(2^(2^1)) = 2^4 = 16` are settled by `decide`, exhibiting the doubly- and triply-exponential regimes explicitly. `self_le_tower_example : 5 ≤ tower 4 5` instantiates the general lower bound `self_le_tower` on concrete arguments, confirming the base-domination lemma fires as expected.",
+    "mathContext": "$\\mathrm{tower}\\,2\\,3 = 256,\\quad \\mathrm{tower}\\,3\\,1 = 16,\\quad 5 \\le \\mathrm{tower}\\,4\\,5.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide",
+      "concrete evaluation",
+      "tower function"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-ramsey-monotonicity",
+    "proofId": "erdos-564-incomplete-01",
+    "range": {
+      "startLine": 166,
+      "endLine": 190
+    },
+    "type": "theorem",
+    "title": "Structural monotonicity of the Ramsey property",
+    "content": "The parent axiomatizes the Ramsey number `R` but proves no theory of the underlying predicate `HasHypergraphRamseyProperty k m n` ('every 2-colouring of the k-subsets of Fin m has a monochromatic n-clique'). These two 0-axiom monotonicities are exactly what makes `R k n` behave as a threshold. **Vertex monotonicity** (`…_mono`): if the property holds on `m` vertices and `m ≤ m'`, restrict a colouring of `Fin m'` along `Fin.castLEEmb`, find the clique downstairs, and push it back up with `Finset.map` (which preserves cardinality and subset structure) — so the set of good `m` is upward-closed. **Clique-size antitonicity** (`…_antitone_clique`): a monochromatic `n`-clique contains a monochromatic `n'`-clique for every `n' ≤ n`, obtained by taking an `n'`-subset (via `Finset.le_card_iff_exists_subset_card`) whose `k`-subsets remain `k`-subsets of the original.",
+    "mathContext": "$P(k,m,n)\\wedge m\\le m' \\Rightarrow P(k,m',n);\\qquad P(k,m,n)\\wedge n'\\le n \\Rightarrow P(k,m,n').$",
+    "significance": "key",
+    "relatedConcepts": [
+      "threshold monotonicity",
+      "Fin.castLEEmb",
+      "Finset.map",
+      "Ramsey number",
+      "upward-closed set"
+    ],
+    "prerequisites": [
+      "embeddings of finite types",
+      "cardinality of Finset.map"
+    ]
+  },
+  {
+    "id": "ann-triviality-boundary",
+    "proofId": "erdos-564-incomplete-01",
+    "range": {
+      "startLine": 208,
+      "endLine": 254
+    },
+    "type": "theorem",
+    "title": "The triviality boundary: R_k(n) = n for n ≤ k",
+    "content": "Where the property *starts*: it holds trivially whenever the target clique is no larger than the edge size. `…_clique_zero`: the empty clique works (`n = 0`, only subset is `∅`). `…_clique_lt_uniformity`: for `n < k` an `n`-clique has no `k`-subsets at all, so monochromaticity is vacuous — any `n`-set works with an arbitrary colour. `…_diagonal_base`: for `n = k` a `k`-set has exactly one `k`-subset (itself), monochromatic for the colour it is already assigned. `…_of_clique_le_uniformity` unifies these into the sharp statement that `R_k(n) = n` for all `n ≤ k`: the Ramsey number is degenerate on and below the diagonal, so the genuine combinatorial content of `R₃` (the Erdős #564 regime) lives strictly above it, at `n > k = 3`. All four are 0-axiom and never touch `R` or the EHR bounds.",
+    "mathContext": "$n \\le k \\ (\\text{and } n \\le m) \\Rightarrow P(k,m,n),\\qquad R_k(n) = n \\text{ for } n \\le k.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "diagonal Ramsey",
+      "vacuous truth",
+      "Finset.eq_of_subset_of_card_le",
+      "degenerate base case"
+    ],
+    "prerequisites": [
+      "counting k-subsets of a finite set"
+    ]
   }
 ]


### PR DESCRIPTION
## Coverage-gap enrichment

`erdos-564-incomplete-01` (the tower-height gap for the Erdős–Hajnal–Rado bounds) had **6 annotations reaching only line 108** of a 259-line file — the entire second half was unannotated, including the faithful quadratic lower bound and both structural sections on the Ramsey-property predicate.

### Added 5 annotations (6 → 11)
- **Arithmetic core** [111–122] — `nsq_lt_two_pow_self`: the tight `n² < 2ⁿ` (n ≥ 5) by `Nat.le_induction`.
- **Faithful quadratic gap** [124–136] — `ehr_lower_lt_tower_two`: `2^{n²} < tower 2 n`, the honest EHR-lower-bound-vs-conjecture statement (quadratic exponent, still a full tower level below `2^n`).
- **Concrete evaluations** [140–147] — `tower 2 3 = 256`, `tower 3 1 = 16`, `5 ≤ tower 4 5`.
- **Ramsey-property monotonicity** [166–190] — vertex-monotonicity (`…_mono`) and clique-size antitonicity (`…_antitone_clique`), the two 0-axiom facts that make `R k n` a well-behaved threshold.
- **Triviality boundary** [208–254] — `…_clique_zero / _clique_lt_uniformity / _diagonal_base / _of_clique_le_uniformity`: the sharp `R_k(n) = n` for `n ≤ k`.

### Also
- Realigned 3 pre-existing annotations (`ann-tower-succ` 41→46, `ann-height-growth` 45→50, `ann-crux` 81→82) that were anchored on blank/import lines onto their `/--` doc-comment lines — clears all validator warnings for this entry.

Annotations validate clean (`scripts/annotations/build.ts --strict`, no errors for this entry). Single-file change; no Lean source touched.