### PR TITLE
Enrich inclusion-exclusion-oq-05: add 8 annotations (0→8 coverage)

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-05/annotations.json
+++ b/src/data/proofs/inclusion-exclusion-oq-05/annotations.json
@@ -1,0 +1,188 @@
+[
+  {
+    "id": "iebonf-ann-01",
+    "proofId": "inclusion-exclusion-oq-05",
+    "range": {
+      "startLine": 36,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "The engine: a partial alternating binomial identity",
+    "content": "`alternating_sum_range_choose_partial` is the combinatorial heart of the whole file. Mathlib already has `Int.alternating_sum_range_choose`, but that evaluates the *complete* alternating sum, which telescopes to 0 or 1. Bonferroni needs the *partial* sum truncated after `m+1` terms, and this has a clean closed form: ∑_{k=0}^{m} (-1)^k C(n+1, k) = (-1)^m C(n, m). The proof is a one-step induction on `m`: `Finset.sum_range_succ` peels off the top term, the induction hypothesis rewrites the rest, and Pascal's rule `Nat.choose_succ_succ'` expands C(n+1, m+1) = C(n, m) + C(n, m+1) so that `push_cast; ring` closes the goal. Writing the upper index as `n + 1` (rather than assuming `1 ≤ n`) is a deliberate trick to dodge natural-number subtraction entirely.",
+    "mathContext": "$\\sum_{k=0}^{m}(-1)^k\\binom{n+1}{k} = (-1)^m\\binom{n}{m}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "alternating binomial sums",
+      "Pascal's rule (Nat.choose_succ_succ')",
+      "induction on truncation length",
+      "Int.alternating_sum_range_choose (the full-sum analogue in Mathlib)"
+    ],
+    "prerequisites": [
+      "Finset.sum_range_succ",
+      "binomial coefficients and Pascal's rule",
+      "push_cast / ring for ℤ-arithmetic identities"
+    ]
+  },
+  {
+    "id": "iebonf-ann-02",
+    "proofId": "inclusion-exclusion-oq-05",
+    "range": {
+      "startLine": 52,
+      "endLine": 71
+    },
+    "type": "tactic",
+    "title": "Pointwise truncated value at a single element",
+    "content": "`bonferroni_pointwise` converts the closed form of the previous lemma into the quantity that actually appears in inclusion–exclusion: the contribution of a single element lying in `n+1` sets, namely ∑_{k=1}^{m} (-1)^{k+1} C(n+1, k). The proof splits `range (m+1)` as `insert 0 (Icc 1 m)` to peel off the k=0 term (which is 1), then a short `calc` factors the sign shift (-1)^{k+1} = (-1)·(-1)^k out of the sum via `Finset.mul_sum` and substitutes the partial identity. The result 1 - (-1)^m C(n, m) is exactly the truncated series minus its constant term, and its deviation from 1 is what the inequalities will bound.",
+    "mathContext": "$\\sum_{k=1}^{m}(-1)^{k+1}\\binom{n+1}{k} = 1-(-1)^m\\binom{n}{m}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "splitting off the k=0 term (Finset.sum_insert)",
+      "Finset.mul_sum",
+      "linear_combination",
+      "sign shift (-1)^{k+1}"
+    ],
+    "prerequisites": [
+      "alternating_sum_range_choose_partial",
+      "Finset.Icc and range manipulation",
+      "calc-style rewriting"
+    ]
+  },
+  {
+    "id": "iebonf-ann-03",
+    "proofId": "inclusion-exclusion-oq-05",
+    "range": {
+      "startLine": 73,
+      "endLine": 85
+    },
+    "type": "concept",
+    "title": "The parity sign check: over- vs under-estimate",
+    "content": "`bonferroni_pointwise_odd` and `bonferroni_pointwise_even` read the sign off the pointwise value. Both apply `Odd.neg_one_pow` / `Even.neg_one_pow` to collapse (-1)^m to ∓1, leaving 1 + C(n, m) ≥ 1 for odd `m` (overestimate) and 1 - C(n, m) ≤ 1 for even `m` (underestimate); `linarith` finishes using C(n, m) ≥ 0. This is where the entire odd/even dichotomy of the Bonferroni inequalities originates — everything downstream is just summing these two elementwise facts over the union.",
+    "mathContext": "$m\\text{ odd}\\Rightarrow 1+\\binom{n}{m}\\ge 1;\\quad m\\text{ even}\\Rightarrow 1-\\binom{n}{m}\\le 1$",
+    "significance": "high",
+    "relatedConcepts": [
+      "Odd.neg_one_pow / Even.neg_one_pow",
+      "nonnegativity of binomial coefficients",
+      "parity governs the direction of the bound"
+    ],
+    "prerequisites": [
+      "bonferroni_pointwise",
+      "Nat.cast_nonneg",
+      "linarith"
+    ]
+  },
+  {
+    "id": "iebonf-ann-04",
+    "proofId": "inclusion-exclusion-oq-05",
+    "range": {
+      "startLine": 91,
+      "endLine": 107
+    },
+    "type": "definition",
+    "title": "Set-up: interCard, truncIE, and mult",
+    "content": "Three definitions set the stage for aggregation. `interCard s S t` counts the union elements lying in every `S i` for `i ∈ t` — for nonempty `t ⊆ s` this equals #(⋂_{i∈t} S i), but phrasing it as a *filter over the union* deliberately avoids the nonemptiness bookkeeping of `Finset.inf'`. `truncIE s S m` is the truncated inclusion–exclusion sum keeping subsets of size 1…m, summed over `s.powersetCard k`. `mult s S a` is the multiplicity of `a`: how many of the `S i` contain it. These three notions turn the set-level statement into a double sum that the counting lemmas can attack.",
+    "mathContext": "$T_m = \\sum_{k=1}^{m}(-1)^{k+1}\\sum_{t\\subseteq s,\\,|t|=k}\\#\\!\\left(\\textstyle\\bigcap_{i\\in t}S_i\\right)$",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Finset.biUnion",
+      "Finset.powersetCard",
+      "filter-over-union vs Finset.inf'",
+      "multiplicity of an element"
+    ],
+    "prerequisites": [
+      "Finset.filter and Finset.card",
+      "inclusion–exclusion series"
+    ]
+  },
+  {
+    "id": "iebonf-ann-05",
+    "proofId": "inclusion-exclusion-oq-05",
+    "range": {
+      "startLine": 109,
+      "endLine": 134
+    },
+    "type": "tactic",
+    "title": "Counting = choosing: card_powersetCard_filter",
+    "content": "`card_powersetCard_filter` is the bridge from the powerset sum to binomial coefficients: the number of size-`k` subsets `t ⊆ s` all of whose sets contain `a` equals C(mult a, k). The proof identifies two filtered powersets — the size-k subsets of `s` whose every element `i` has `a ∈ S i`, versus the size-k subsets of the multiplicity family `{i ∈ s : a ∈ S i}` — via `Finset.card_powersetCard` and an `ext` argument. `sum_powersetCard_boole` restates it in indicator form using `Finset.sum_boole`, which is the shape needed when the count appears inside a signed sum.",
+    "mathContext": "$\\#\\{t\\subseteq s : |t|=k,\\ \\forall i\\in t,\\ a\\in S_i\\} = \\binom{\\mathrm{mult}(a)}{k}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.card_powersetCard",
+      "Finset.sum_boole",
+      "filtered powersets",
+      "extensionality of finsets"
+    ],
+    "prerequisites": [
+      "Finset.mem_powersetCard, Finset.mem_filter",
+      "the definition of mult"
+    ]
+  },
+  {
+    "id": "iebonf-ann-06",
+    "proofId": "inclusion-exclusion-oq-05",
+    "range": {
+      "startLine": 136,
+      "endLine": 163
+    },
+    "type": "tactic",
+    "title": "Aggregation: rewrite the truncated sum over union elements",
+    "content": "`truncIE_eq_sum_over_union` is the pivot that turns the set-level sum into a sum of pointwise values. Each `interCard` is expanded as a sum of 0/1 indicators over the union (`Finset.sum_boole` in reverse), the counting lemma replaces the inner powerset sum by C(mult a, k), and `Finset.sum_comm` swaps the order so that the outer sum ranges over union elements `a` and the inner over truncation levels `k`. After this rewrite, `truncIE s S m = ∑_{a∈⋃} ∑_{k=1}^{m} (-1)^{k+1} C(mult a, k)` — precisely the pointwise value analysed in Part 1, one copy per element.",
+    "mathContext": "$T_m = \\sum_{a\\in\\bigcup_i S_i}\\ \\sum_{k=1}^{m}(-1)^{k+1}\\binom{\\mathrm{mult}(a)}{k}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_comm (swapping summation order)",
+      "Finset.mul_sum",
+      "indicator sums",
+      "double counting"
+    ],
+    "prerequisites": [
+      "card_powersetCard_filter / sum_powersetCard_boole",
+      "definitions of truncIE and interCard"
+    ]
+  },
+  {
+    "id": "iebonf-ann-07",
+    "proofId": "inclusion-exclusion-oq-05",
+    "range": {
+      "startLine": 165,
+      "endLine": 176
+    },
+    "type": "tactic",
+    "title": "Bridging lemmas for the union cardinality",
+    "content": "Two small lemmas prepare the final comparison. `card_biUnion_eq_sum_ones` rewrites #(⋃_{i∈s} S i) as ∑_{a∈⋃} 1, so both sides of the target inequality become sums over the same index set and `Finset.sum_le_sum` applies termwise. `one_le_mult` records the obvious but essential fact that every element of the union lies in at least one set (mult a ≥ 1), which lets us write mult a = n + 1 and invoke the `n+1`-indexed pointwise lemmas from Part 1.",
+    "mathContext": "$\\#\\!\\left(\\textstyle\\bigcup_i S_i\\right) = \\sum_{a\\in\\bigcup_i S_i} 1,\\qquad a\\in\\textstyle\\bigcup_i S_i \\Rightarrow \\mathrm{mult}(a)\\ge 1$",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Finset.mem_biUnion",
+      "Finset.card_ne_zero",
+      "termwise comparison of finite sums"
+    ],
+    "prerequisites": [
+      "definition of mult",
+      "Finset.sum_le_sum"
+    ]
+  },
+  {
+    "id": "iebonf-ann-08",
+    "proofId": "inclusion-exclusion-oq-05",
+    "range": {
+      "startLine": 178,
+      "endLine": 202
+    },
+    "type": "concept",
+    "title": "The Bonferroni inequalities, assembled",
+    "content": "`card_biUnion_le_truncIE_odd` and `truncIE_le_card_biUnion_even` are the payoff. Each rewrites both sides as sums over the union (aggregation lemma + `card_biUnion_eq_sum_ones`), applies `Finset.sum_le_sum`, and for each element `a` writes mult a = n + 1 (via `one_le_mult` + `omega`) to reduce the termwise goal to the pointwise sign lemma of Part 1. The conclusion: odd truncation of the inclusion–exclusion series overestimates |⋃ Sᵢ| and even truncation underestimates it. The m = 1 case is Boole's union bound |⋃ Aᵢ| ≤ ∑ |Aᵢ|; the m = 2 case is the classical second-order lower bound. Together they resolve the standing TODO in Mathlib's InclusionExclusion.lean.",
+    "mathContext": "$m\\text{ odd}\\Rightarrow \\#\\!\\left(\\textstyle\\bigcup_i S_i\\right)\\le T_m;\\qquad m\\text{ even}\\Rightarrow T_m\\le \\#\\!\\left(\\textstyle\\bigcup_i S_i\\right)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Boole's inequality (m = 1)",
+      "second-order Bonferroni bound (m = 2)",
+      "Finset.sum_le_sum",
+      "the probabilistic method / multiple-comparison correction"
+    ],
+    "prerequisites": [
+      "bonferroni_pointwise_odd / bonferroni_pointwise_even",
+      "truncIE_eq_sum_over_union",
+      "one_le_mult"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

The gallery entry `inclusion-exclusion-oq-05` (Bonferroni inequalities, 11 theorems / 3 definitions, merged in #32686) shipped with a rich `meta.json` but **no annotations file at all** (quality 41, annotations 0 — the top enrichment target).

This PR adds a fresh `annotations.json` with **8 annotations giving full declaration coverage**:

1. **Partial alternating binomial identity** — the engine (`alternating_sum_range_choose_partial`)
2. **Pointwise truncated value** at a single element (`bonferroni_pointwise`)
3. **Parity sign check** — over- vs under-estimate (`bonferroni_pointwise_odd/even`)
4. **Set-up definitions** (`interCard`, `truncIE`, `mult`)
5. **Counting = choosing** bridge lemma (`card_powersetCard_filter`, `sum_powersetCard_boole`)
6. **Aggregation pivot** over union elements (`truncIE_eq_sum_over_union`)
7. **Bridging lemmas** for the union cardinality (`card_biUnion_eq_sum_ones`, `one_le_mult`)
8. **The two Bonferroni inequalities** assembled (`card_biUnion_le_truncIE_odd`, `truncIE_le_card_biUnion_even`)

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, and is anchored on the `/--` doc-comment line of its declaration.

## Verification

`pnpm annotations:build` resolves all 8 annotations against `proofs/Proofs/BonferroniInequalities.lean` with **zero errors for this entry** (the gallery-wide pre-existing noise is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)