### PR TITLE
Enrich abel-ruffini-obstruction-oq-06: realign 3 misanchored anns + cover S₃/A₄/S₄ (5→9)

### DIFF
--- a/src/data/proofs/abel-ruffini-obstruction-oq-06/annotations.json
+++ b/src/data/proofs/abel-ruffini-obstruction-oq-06/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-symmetric-not-solvable",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 55, "endLine": 61 },
+    "range": { "startLine": 55, "endLine": 59 },
     "type": "theorem",
     "title": "Sₙ Unsolvable for n ≥ 5",
     "content": "The symmetric group on $n$ symbols is **not solvable** for every $n \\ge 5$. Mathlib supplies only the single case `Equiv.Perm.fin_5_not_solvable` (for `Fin 5`); here it is generalized to the whole range by invoking `Equiv.Perm.not_solvable`, whose hypothesis is a *cardinal* bound $5 \\le \\#X$. Rewriting $\\#(\\mathrm{Fin}\\ n) = n$ with `Cardinal.mk_fin` and casting $5 \\le n$ closes it. The mathematical reason it cannot be solvable: any such group contains $S_5$, and the alternating group $A_5$ is a nonabelian simple group equal to its own commutator subgroup, so the derived series stalls and never reaches the trivial subgroup.",
@@ -24,21 +24,69 @@
     "prerequisites": ["abelian ⟹ solvable (isSolvable_of_comm)", "kernel decidability vs native_decide"]
   },
   {
+    "id": "ann-s3-solvable",
+    "proofId": "abel-ruffini-obstruction-oq-06",
+    "range": { "startLine": 79, "endLine": 89 },
+    "type": "theorem",
+    "title": "S₃ Solvable (Prime-Order Kernel)",
+    "content": "$S_3$ is solvable through the one-step extension $1 \\to A_3 \\to S_3 \\xrightarrow{\\mathrm{sign}} \\mathbb{Z}^\\times \\to 1$. The kernel $A_3 = \\ker(\\mathrm{sign})$ has order $3!/2 = 3$, established via `nat_card_alternatingGroup` and `decide`; being of **prime** order it is cyclic (`isCyclic_of_prime_card`), hence abelian, hence solvable. The image sits inside the abelian $\\mathbb{Z}^\\times$, so both ends of the extension are solvable and `solvable_of_ker_le_range` (with `Subgroup.range_subtype` and `alternatingGroup_eq_sign_ker`) assembles $S_3$. This is the next rung of the solvable side above $S_2$, and the reason the general cubic has Cardano's radical formula.",
+    "mathContext": "$\\mathrm{IsSolvable}(S_3)$; $A_3 \\cong \\mathbb{Z}/3$, $S_3/A_3 \\hookrightarrow \\mathbb{Z}^\\times$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Alternating group A₃", "Cyclic group of prime order", "Group extension", "Sign homomorphism"],
+    "prerequisites": ["prime-order ⟹ cyclic (isCyclic_of_prime_card)", "solvable_of_ker_le_range", "alternatingGroup = ker(sign)"]
+  },
+  {
+    "id": "ann-a4-solvable",
+    "proofId": "abel-ruffini-obstruction-oq-06",
+    "range": { "startLine": 103, "endLine": 126 },
+    "type": "theorem",
+    "title": "A₄ Solvable (Klein-Four Extension)",
+    "content": "The crucial non-abelian-yet-solvable case: $A_4$ is solvable through $1 \\to V_4 \\to A_4 \\to A_4/V_4 \\to 1$. The normal Klein four-subgroup $V_4 = $ `alternatingGroup.kleinFour (Fin 4)` (normality from `alternatingGroup.normal_kleinFour`) has **exponent two**, hence is abelian (`mul_comm_of_exponent_two`) and solvable. The quotient has order $|A_4|/|V_4| = 12/4 = 3$ — computed by `card_eq_card_quotient_mul_card_subgroup` and the concrete cardinalities — so it is cyclic of prime order, hence solvable. `solvable_of_ker_le_range` on $V_4 \\hookrightarrow A_4 \\twoheadrightarrow A_4/V_4$ finishes it. Since $V_4$ is exactly the commutator subgroup of $A_4$, this *is* the derived series $A_4 \\rhd V_4 \\rhd 1$ — and it is precisely why the general quartic is solvable by radicals (Ferrari's resolvent cubic).",
+    "mathContext": "$\\mathrm{IsSolvable}(A_4)$; $V_4 \\lhd A_4$ with $|V_4|=4$, $[A_4:V_4]=3$.",
+    "significance": "key",
+    "relatedConcepts": ["Alternating group A₄", "Klein four-group V₄", "Exponent-two group", "Derived series", "Ferrari's quartic"],
+    "prerequisites": ["exponent two ⟹ abelian", "Lagrange / card_eq_card_quotient_mul_card_subgroup", "solvable_of_ker_le_range"]
+  },
+  {
+    "id": "ann-s4-solvable",
+    "proofId": "abel-ruffini-obstruction-oq-06",
+    "range": { "startLine": 137, "endLine": 143 },
+    "type": "theorem",
+    "title": "S₄ Solvable (Top of the Solvable Range)",
+    "content": "$S_4$ is solvable via the sign sequence $1 \\to A_4 \\to S_4 \\xrightarrow{\\mathrm{sign}} \\mathbb{Z}^\\times \\to 1$: the kernel $A_4$ is solvable (`alt_fin_four_solvable`) and the image is the abelian $\\mathbb{Z}^\\times$, so `solvable_of_ker_le_range` (via `alternatingGroup_eq_sign_ker`) applies. This is the **top** of the solvable range — $S_4$ is the largest symmetric group that is solvable, which is exactly why the general quartic admits a radical formula while the general quintic does not. Structurally the full derived series is $S_4 \\rhd A_4 \\rhd V_4 \\rhd 1$, terminating at the trivial group.",
+    "mathContext": "$\\mathrm{IsSolvable}(S_4)$; $S_4 \\rhd A_4 \\rhd V_4 \\rhd 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Symmetric group S₄", "Sign homomorphism", "Solvable extension", "Radical solvability threshold"],
+    "prerequisites": ["A₄ solvable (previous theorem)", "solvable_of_ker_le_range", "alternatingGroup = ker(sign)"]
+  },
+  {
     "id": "ann-symmetric-threshold",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 79, "endLine": 82 },
+    "range": { "startLine": 153, "endLine": 157 },
     "type": "theorem",
     "title": "The Symmetric Threshold (Both Endpoints)",
-    "content": "`symmetric_threshold` bundles the two endpoint facts into one statement: $S_2$ is solvable while $S_n$ is not solvable for any $n \\ge 5$. This is the group-theoretic skeleton of Abel–Ruffini made explicit — solvability of the symmetric group is precisely the dividing line between the radically-solvable degrees ($n \\le 4$: linear, quadratic, Cardano, Ferrari) and the radically-unsolvable degrees ($n \\ge 5$). The proof is a trivial pairing of the two preceding theorems; its value is documentary, stating the frontier as a single mathematical object.",
-    "mathContext": "$\\mathrm{IsSolvable}(S_2) \\,\\wedge\\, \\forall n \\ge 5,\\ \\neg\\,\\mathrm{IsSolvable}(S_n)$.",
+    "content": "`symmetric_threshold` bundles the two endpoint facts into one statement: $S_2$ and $S_3$ are solvable while $S_n$ is not solvable for any $n \\ge 5$. This is the group-theoretic skeleton of Abel–Ruffini made explicit — solvability of the symmetric group is precisely the dividing line between the radically-solvable degrees ($n \\le 4$: linear, quadratic, Cardano, Ferrari) and the radically-unsolvable degrees ($n \\ge 5$). The proof is a trivial pairing of the preceding theorems; its value is documentary, stating the frontier as a single mathematical object.",
+    "mathContext": "$\\mathrm{IsSolvable}(S_2) \\,\\wedge\\, \\mathrm{IsSolvable}(S_3) \\,\\wedge\\, \\forall n \\ge 5,\\ \\neg\\,\\mathrm{IsSolvable}(S_n)$.",
     "significance": "supporting",
     "relatedConcepts": ["Solvable group", "Abel–Ruffini threshold", "Symmetric group", "Radical solvability"],
-    "prerequisites": ["the two endpoint theorems above", "solvable Galois group ⟺ solvable by radicals (context)"]
+    "prerequisites": ["the endpoint theorems above", "solvable Galois group ⟺ solvable by radicals (context)"]
+  },
+  {
+    "id": "ann-symmetric-threshold-full",
+    "proofId": "abel-ruffini-obstruction-oq-06",
+    "range": { "startLine": 170, "endLine": 176 },
+    "type": "theorem",
+    "title": "The Full Threshold: Sₙ Solvable ⟺ n ≤ 4",
+    "content": "`symmetric_threshold_full` is the sharp classification at the level of the concrete small groups: $S_2$, $S_3$, and $S_4$ are **each** solvable (the entire solvable side, now proved for every $2 \\le n \\le 4$; the cases $n \\le 1$ are trivial), while $S_n$ is not solvable for any $n \\ge 5$ (`symmetricGroup_not_solvable`). This upgrades `symmetric_threshold` from the two visible endpoints to the *complete* dividing line and is the precise group-theoretic content of Abel–Ruffini: degrees $\\le 4$ have radical formulas (quadratic, Cardano, Ferrari) exactly because $S_2, S_3, S_4$ are solvable, and degree $\\ge 5$ does not because $S_n$ is not.",
+    "mathContext": "$\\mathrm{IsSolvable}(S_2)\\wedge\\mathrm{IsSolvable}(S_3)\\wedge\\mathrm{IsSolvable}(S_4)\\wedge\\forall n\\ge 5,\\ \\neg\\,\\mathrm{IsSolvable}(S_n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Solvable group", "Abel–Ruffini classification", "Symmetric group", "Radical solvability"],
+    "prerequisites": ["all four small-group theorems above", "symmetricGroup_not_solvable"]
   },
   {
     "id": "ann-radical-criterion",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 103, "endLine": 107 },
+    "range": { "startLine": 197, "endLine": 200 },
     "type": "theorem",
     "title": "Abel–Ruffini Criterion",
     "content": "The Galois bridge from groups to equations: if $\\alpha$ is a root of an **irreducible** polynomial $q \\in F[X]$ whose Galois group $\\mathrm{Gal}(q)$ is **not solvable**, then $\\alpha$ is **not solvable by radicals** over $F$. This is the contrapositive of Mathlib's `solvableByRad.isSolvable'` (radicals $\\Rightarrow$ solvable Galois group) and is the precise implication used to certify a concrete unsolvable quintic: exhibit an irreducible degree-5 polynomial with Galois group $S_5$ (unsolvable by the theorem above), and its roots provably cannot be written with radicals.",
@@ -50,7 +98,7 @@
   {
     "id": "ann-converse-criterion",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 116, "endLine": 119 },
+    "range": { "startLine": 210, "endLine": 213 },
     "type": "theorem",
     "title": "Converse: Radicals Force a Solvable Galois Group",
     "content": "`solvable_gal_of_solvableByRad` re-exposes the forward direction of Galois' theorem under a local name: a root $\\alpha$ that *is* solvable by radicals, being a root of irreducible $q$, forces $\\mathrm{Gal}(q)$ to be solvable. It is definitionally Mathlib's `solvableByRad.isSolvable'`; stating it here lets the criterion and its converse sit side by side, making the underlying equivalence (radical solvability $\\Leftrightarrow$ solvable Galois group) visible as two implications used for opposite purposes — one to *prove impossibility*, the other to *extract structure*.",


### PR DESCRIPTION
## Enrichment: abel-ruffini-obstruction-oq-06

The Lean file `Proofs/AbelRuffiniObstructionOQ06.lean` grew after its annotations were written — the theorems `perm_fin_three_solvable` (S₃), `alt_fin_four_solvable` (A₄), and `perm_fin_four_solvable` (S₄) were inserted, shifting three existing annotations off their true declarations (their ranges pointed mid-proof at unrelated theorems while their content still described the criterion/converse/threshold).

### Changes (5 → 9 annotations, all 9 decls now covered)

**Realigned 3 misanchored annotations** to their current source lines:
- `ann-symmetric-threshold` → `symmetric_threshold` (was [79-82], now [153-157])
- `ann-radical-criterion` → `not_solvableByRad_of_not_solvable_gal` (was [103-107], now [197-200])
- `ann-converse-criterion` → `solvable_gal_of_solvableByRad` (was [116-119], now [210-213])

**Added 4 annotations** for the uncovered theorems:
- `ann-s3-solvable` — S₃ solvable via prime-order kernel A₃ [79-89]
- `ann-a4-solvable` — A₄ solvable via Klein-four extension (derived series A₄▷V₄▷1) [103-126]
- `ann-s4-solvable` — S₄ solvable, top of the radical-solvable range [137-143]
- `ann-symmetric-threshold-full` — the sharp classification Sₙ solvable ⟺ n ≤ 4 [170-176]

Annotation resolver passes cleanly for this entry (`scripts/annotations/build.ts --strict`). No Lean source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)