### PR TITLE
Enrich minkowski-fundamental-theorem-oq-01-oq-01: cover Part I extreme indices (4→5)

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-01/annotations.json
@@ -18,6 +18,24 @@
     ]
   },
   {
+    "id": "ann-mft-oq01oq01-extreme-indices",
+    "proofId": "minkowski-fundamental-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 80
+    },
+    "type": "definition",
+    "title": "The Extreme Indices of Fin n",
+    "content": "Part I names the two endpoints of the index set `Fin n` and pins down their order-theoretic role. `botIndex = ⟨0, _⟩` and `topIndex = ⟨n-1, _⟩` are well-defined because `n ≠ 0` (supplied by the `NeZero n` instance via `Nat.pos_of_ne_zero (NeZero.ne n)`). The two lemmas `botIndex_le` and `le_topIndex` establish that these are genuinely the minimum and maximum of `Fin n`: every index `i` satisfies `botIndex ≤ i ≤ topIndex`, proved by unfolding `Fin.le_def` to a comparison of underlying naturals and closing with `Nat.zero_le` / `omega` (using `i.isLt : i.val < n`). These are the concrete handles for `λ₀ = λ_{botIndex}` (the first minimum) and `λ_{n-1} = λ_{topIndex}` (the last minimum) that the extreme-minima bracketing is stated in terms of.",
+    "mathContext": "botIndex = 0, topIndex = n-1 in Fin n (n ≠ 0); ∀ i, botIndex ≤ i ≤ topIndex — the bottom/top elements of the linear order on Fin n.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fin n order structure",
+      "NeZero instance",
+      "extreme elements of a finite linear order"
+    ]
+  },
+  {
     "id": "ann-mft-oq01oq01-attainment",
     "proofId": "minkowski-fundamental-theorem-oq-01-oq-01",
     "range": {


### PR DESCRIPTION
## Enrichment: minkowski-fundamental-theorem-oq-01-oq-01

Part I of the Lean file (`botIndex`, `topIndex`, `botIndex_le`, `le_topIndex` — the extreme indices of `Fin n`) was entirely unannotated. These four declarations are a coherent unit: they name the bottom/top elements of `Fin n` and prove they bound every index, giving the concrete handles for λ₀ (first minimum) and λ_{n-1} (last minimum) that the extreme-minima bracketing is built on.

### Change (4 → 5 annotations, all decls now covered)
- **`ann-mft-oq01oq01-extreme-indices`** [66-80] — one `definition`-type annotation covering `botIndex`/`topIndex` (well-defined via the `NeZero n` instance) and the order lemmas `botIndex_le`/`le_topIndex` (proved by `Fin.le_def` + `omega`/`Nat.zero_le`).

Annotation resolver passes cleanly for this entry (`scripts/annotations/build.ts --strict`). No Lean source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)