### PR TITLE
research(prob-method-alteration-oq-03): Caro–Wei bound via min-degree deletion — de-axiomatizes Turán bound [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/ProbMethodAlterationOQ03.lean
+++ b/proofs/Proofs/ProbMethodAlterationOQ03.lean
@@ -1,0 +1,234 @@
+/-
+  Caro–Wei Lower Bound for the Independence Number (verified, 0-axiom)
+
+  Open Question OQ-03 from prob-method-alteration:
+  "Prove the Caro–Wei bound α(G) ≥ ∑_v 1/(deg(v)+1) for a finite simple graph G,
+   then deduce the Turán-type corollary α(G) ≥ n²/(2m+n) by convexity on the
+   degree sequence."
+
+  This DE-AXIOMATIZES the bound `α(G) ≥ n²/(2m+n)` that was previously stated as an
+  `axiom caro_wei` in `ProbMethodAlterationOQ02.lean`.
+
+  Rather than the usual random-permutation / expectation argument, we give the
+  fully constructive **deterministic** proof:
+
+    Induct on the vertex set W.  Pick a vertex v ∈ W of MINIMUM degree (within W),
+    let N = N_W[v] be its closed neighbourhood in W (|N| = deg_W(v)+1), and delete N.
+    A maximum independent set of W \ N, together with v, is independent in W, so
+    α(W) ≥ 1 + α(W \ N).  The weight lost by deleting N is
+        ∑_{u ∈ N} 1/(deg_W(u)+1) ≤ |N| · 1/(deg_W(v)+1) = 1,
+    because every u ∈ N has deg_W(u) ≥ deg_W(v) (v is a minimum-degree vertex).
+    Deleting a vertex can only lower the remaining degrees, so the surviving weights
+    only increase.  Induction closes the bound.
+
+  The Turán corollary follows from the Cauchy–Schwarz (AM–HM) inequality
+        n² = (∑ 1)² ≤ (∑ (deg v + 1)) · (∑ 1/(deg v + 1)) = (2m + n) · S
+  together with the handshake identity ∑ deg v = 2m.
+
+  Status: verified, 0 axioms (only Lean/Mathlib foundations).
+-/
+
+import Mathlib
+
+namespace ProbMethod.CaroWei
+
+open Finset SimpleGraph
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- The independence number `α(G)`: the size of the largest independent set.
+    (Identical to the definition in `ProbMethodAlterationOQ02`.) -/
+noncomputable def independenceNumber (G : SimpleGraph V) : ℕ :=
+  sSup { k : ℕ | ∃ s : Finset V, s.card = k ∧
+    ∀ v ∈ s, ∀ w ∈ s, v ≠ w → ¬G.Adj v w }
+
+/-- Degree of `u` counted only within the finset `W`. -/
+def degIn (G : SimpleGraph V) [DecidableRel G.Adj] (W : Finset V) (u : V) : ℕ :=
+  (W.filter (fun w => G.Adj u w)).card
+
+/-- Restricting to a smaller vertex set can only decrease the degree. -/
+theorem degIn_mono (G : SimpleGraph V) [DecidableRel G.Adj] {W' W : Finset V}
+    (h : W' ⊆ W) (u : V) : degIn G W' u ≤ degIn G W u :=
+  Finset.card_le_card (Finset.filter_subset_filter _ h)
+
+/-- **Core existence lemma.**  For every finset `W`, there is an independent set
+    `I ⊆ W` whose size is at least the Caro–Wei weight `∑_{u∈W} 1/(deg_W(u)+1)`. -/
+theorem exists_indep_card_ge (G : SimpleGraph V) [DecidableRel G.Adj] (W : Finset V) :
+    ∃ I : Finset V, I ⊆ W ∧ (∀ a ∈ I, ∀ b ∈ I, a ≠ b → ¬ G.Adj a b) ∧
+      (∑ u ∈ W, (1 : ℝ) / ((degIn G W u : ℝ) + 1)) ≤ (I.card : ℝ) := by
+  induction W using Finset.strongInductionOn with
+  | _ W ih =>
+    rcases W.eq_empty_or_nonempty with hW | hWne
+    · exact ⟨∅, by simp [hW], by simp, by simp [hW]⟩
+    · -- Pick a vertex `v` of minimum degree in `W`.
+      obtain ⟨v, hvW, hvmin⟩ := W.exists_min_image (degIn G W) hWne
+      -- Closed neighbourhood of `v` inside `W`.
+      set Nb : Finset V := W.filter (fun w => G.Adj v w) with hNb
+      set N : Finset V := insert v Nb with hN
+      set W' : Finset V := W \ N with hW'
+      have hv_notNb : v ∉ Nb := by
+        rw [hNb, Finset.mem_filter]; rintro ⟨_, hadj⟩; exact (G.irrefl hadj)
+      have hNb_sub : Nb ⊆ W := Finset.filter_subset _ _
+      have hNW : N ⊆ W := by rw [hN]; exact Finset.insert_subset_iff.mpr ⟨hvW, hNb_sub⟩
+      have hNcard : N.card = degIn G W v + 1 := by
+        rw [hN, Finset.card_insert_of_not_mem hv_notNb, hNb]; rfl
+      have hNne : N.Nonempty := ⟨v, by rw [hN]; exact Finset.mem_insert_self _ _⟩
+      have hW'ss : W' ⊂ W := by rw [hW']; exact Finset.sdiff_ssubset hNW hNne
+      -- Induction hypothesis on the strictly smaller `W'`.
+      obtain ⟨I', hI'sub, hI'indep, hI'card⟩ := ih W' hW'ss
+      -- Facts about members of `I'` (they lie in `W`, off `N`, hence not adjacent to `v`).
+      have hI'W : I' ⊆ W := hI'sub.trans (by rw [hW']; exact Finset.sdiff_subset)
+      have hmem : ∀ b ∈ I', b ∈ W ∧ ¬ G.Adj v b ∧ b ≠ v := by
+        intro b hb
+        have hbW' : b ∈ W' := hI'sub hb
+        rw [hW', Finset.mem_sdiff, hN, Finset.mem_insert, not_or] at hbW'
+        obtain ⟨hbW, hbne, hbNb⟩ := hbW'
+        rw [hNb, Finset.mem_filter] at hbNb
+        refine ⟨hbW, fun hadj => hbNb ⟨hbW, hadj⟩, hbne⟩
+      -- `v ∉ I'`, so inserting `v` grows the card by exactly one.
+      have hv_notI' : v ∉ I' := by
+        intro h
+        have hvW' := hI'sub h
+        rw [hW', Finset.mem_sdiff] at hvW'
+        exact hvW'.2 (hN ▸ Finset.mem_insert_self v Nb)
+      refine ⟨insert v I', ?_, ?_, ?_⟩
+      · -- `insert v I' ⊆ W`.
+        exact Finset.insert_subset_iff.mpr ⟨hvW, hI'W⟩
+      · -- `insert v I'` is independent.
+        intro a ha b hb hab
+        rw [Finset.mem_insert] at ha hb
+        rcases ha with rfl | haI'
+        · rcases hb with rfl | hbI'
+          · exact absurd rfl hab
+          · exact (hmem b hbI').2.1
+        · rcases hb with rfl | hbI'
+          · exact fun hadj => (hmem a haI').2.1 (G.symm hadj)
+          · exact hI'indep a haI' b hbI' hab
+      · -- The weight bound.
+        have hcard_eq : ((insert v I').card : ℝ) = (I'.card : ℝ) + 1 := by
+          rw [Finset.card_insert_of_not_mem hv_notI']; push_cast; ring
+        rw [hcard_eq]
+        -- Split the sum over `W` as `W' + N`.
+        have hsplit : (∑ u ∈ W, (1 : ℝ) / ((degIn G W u : ℝ) + 1))
+            = (∑ u ∈ W', (1 : ℝ) / ((degIn G W u : ℝ) + 1))
+              + (∑ u ∈ N, (1 : ℝ) / ((degIn G W u : ℝ) + 1)) := by
+          rw [hW', ← Finset.sum_sdiff hNW]
+        -- (a) Surviving weights only increase under deletion.
+        have hstep2 : (∑ u ∈ W', (1 : ℝ) / ((degIn G W u : ℝ) + 1))
+            ≤ (∑ u ∈ W', (1 : ℝ) / ((degIn G W' u : ℝ) + 1)) := by
+          apply Finset.sum_le_sum
+          intro u _
+          have hle : degIn G W' u ≤ degIn G W u :=
+            degIn_mono G (by rw [hW']; exact Finset.sdiff_subset) u
+          apply one_div_le_one_div_of_le
+          · positivity
+          · have : (degIn G W' u : ℝ) ≤ (degIn G W u : ℝ) := by exact_mod_cast hle
+            linarith
+        -- (b) The deleted weight is at most 1.
+        have hstep3 : (∑ u ∈ N, (1 : ℝ) / ((degIn G W u : ℝ) + 1)) ≤ 1 := by
+          have hbound : (∑ u ∈ N, (1 : ℝ) / ((degIn G W u : ℝ) + 1))
+              ≤ (∑ _u ∈ N, (1 : ℝ) / ((degIn G W v : ℝ) + 1)) := by
+            apply Finset.sum_le_sum
+            intro u hu
+            have huW : u ∈ W := hNW hu
+            have : (degIn G W v : ℝ) ≤ (degIn G W u : ℝ) := by
+              exact_mod_cast hvmin u huW
+            apply one_div_le_one_div_of_le
+            · positivity
+            · linarith
+          refine hbound.trans (le_of_eq ?_)
+          rw [Finset.sum_const, hNcard, nsmul_eq_mul]
+          have h1 : ((degIn G W v + 1 : ℕ) : ℝ) = (degIn G W v : ℝ) + 1 := by
+            push_cast; ring
+          rw [h1, mul_one_div, div_self (by positivity)]
+        -- Combine (split) ≤ (a) + (b) ≤ I'.card + 1.
+        calc (∑ u ∈ W, (1 : ℝ) / ((degIn G W u : ℝ) + 1))
+            = (∑ u ∈ W', (1 : ℝ) / ((degIn G W u : ℝ) + 1))
+              + (∑ u ∈ N, (1 : ℝ) / ((degIn G W u : ℝ) + 1)) := hsplit
+          _ ≤ (∑ u ∈ W', (1 : ℝ) / ((degIn G W' u : ℝ) + 1)) + 1 := by
+                gcongr
+          _ ≤ (I'.card : ℝ) + 1 := by linarith [hI'card]
+
+/-- `degIn G univ = G.degree`. -/
+theorem degIn_univ (G : SimpleGraph V) [DecidableRel G.Adj] (u : V) :
+    degIn G Finset.univ u = G.degree u := by
+  rw [degIn, SimpleGraph.degree]
+  congr 1
+  ext w
+  rw [Finset.mem_filter, SimpleGraph.mem_neighborFinset]
+  exact ⟨fun h => h.2, fun h => ⟨Finset.mem_univ _, h⟩⟩
+
+/-- **Caro–Wei bound (weighted form).**  For any finite simple graph `G`,
+    `∑_v 1/(deg(v)+1) ≤ α(G)`. -/
+theorem caro_wei_weighted (G : SimpleGraph V) [DecidableRel G.Adj] :
+    (∑ v, (1 : ℝ) / ((G.degree v : ℝ) + 1)) ≤ (independenceNumber G : ℝ) := by
+  obtain ⟨I, hIsub, hIindep, hIcard⟩ := exists_indep_card_ge G Finset.univ
+  -- Rewrite the sum using `degIn univ = degree`.
+  have hsum : (∑ v, (1 : ℝ) / ((G.degree v : ℝ) + 1))
+      = ∑ u ∈ Finset.univ, (1 : ℝ) / ((degIn G Finset.univ u : ℝ) + 1) := by
+    apply Finset.sum_congr rfl
+    intro u _; rw [degIn_univ]
+  rw [hsum]
+  refine hIcard.trans ?_
+  -- `I.card ≤ α(G)` since `I` is an independent set.
+  have hbdd : BddAbove { k : ℕ | ∃ s : Finset V, s.card = k ∧
+      ∀ v ∈ s, ∀ w ∈ s, v ≠ w → ¬G.Adj v w } := by
+    refine ⟨Fintype.card V, ?_⟩
+    rintro k ⟨s, rfl, _⟩
+    exact Finset.card_le_univ s
+  have hmem : I.card ∈ { k : ℕ | ∃ s : Finset V, s.card = k ∧
+      ∀ v ∈ s, ∀ w ∈ s, v ≠ w → ¬G.Adj v w } := ⟨I, rfl, hIindep⟩
+  have : I.card ≤ independenceNumber G := le_csSup hbdd hmem
+  exact_mod_cast this
+
+/-- **Caro–Wei / Turán bound.**  De-axiomatizes `ProbMethodAlterationOQ02.caro_wei`:
+    for a finite simple graph `G` on `n` vertices with `m` edges,
+    `n²/(2m+n) ≤ α(G)`. -/
+theorem caro_wei {n : ℕ} (G : SimpleGraph (Fin n)) [DecidableRel G.Adj]
+    (m : ℕ) (hm : m = G.edgeFinset.card) (hpos : 0 < 2 * m + n) :
+    (n : ℝ) ^ 2 / (2 * m + n) ≤ (independenceNumber G : ℝ) := by
+  set S : ℝ := ∑ v, (1 : ℝ) / ((G.degree v : ℝ) + 1) with hS
+  -- Denominators are positive.
+  have hpos' : ∀ v : Fin n, (0 : ℝ) < (G.degree v : ℝ) + 1 := fun v => by positivity
+  -- ∑ (deg v + 1) = 2m + n  (handshake identity).
+  have hsum_deg : (∑ v : Fin n, ((G.degree v : ℝ) + 1)) = 2 * m + n := by
+    rw [Finset.sum_add_distrib, Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+    have hhand : ∑ v : Fin n, G.degree v = 2 * G.edgeFinset.card :=
+      SimpleGraph.sum_degrees_eq_twice_card_edges G
+    have : (∑ v : Fin n, (G.degree v : ℝ)) = 2 * (m : ℝ) := by
+      rw [← Nat.cast_sum, hhand, hm]; push_cast; ring
+    rw [this]; push_cast; ring
+  -- Cauchy–Schwarz: n² ≤ (∑ (deg+1)) · S.
+  have hCS : ((n : ℝ)) ^ 2 ≤ (2 * m + n) * S := by
+    -- Use the Finset Cauchy–Schwarz `sum_mul_sq_le_sq_mul_sq`.
+    have cs := Finset.sum_mul_sq_le_sq_mul_sq Finset.univ
+      (fun v : Fin n => Real.sqrt ((G.degree v : ℝ) + 1))
+      (fun v : Fin n => (Real.sqrt ((G.degree v : ℝ) + 1))⁻¹)
+    -- Simplify the three sums appearing in `cs`.
+    have hfg : ∀ v : Fin n,
+        Real.sqrt ((G.degree v : ℝ) + 1) * (Real.sqrt ((G.degree v : ℝ) + 1))⁻¹ = 1 := by
+      intro v
+      have : Real.sqrt ((G.degree v : ℝ) + 1) ≠ 0 :=
+        Real.sqrt_ne_zero'.mpr (hpos' v)
+      field_simp
+    have hf2 : ∀ v : Fin n,
+        (Real.sqrt ((G.degree v : ℝ) + 1)) ^ 2 = (G.degree v : ℝ) + 1 := by
+      intro v; rw [Real.sq_sqrt (hpos' v).le]
+    have hg2 : ∀ v : Fin n,
+        ((Real.sqrt ((G.degree v : ℝ) + 1))⁻¹) ^ 2 = (1 : ℝ) / ((G.degree v : ℝ) + 1) := by
+      intro v
+      rw [inv_pow, Real.sq_sqrt (hpos' v).le, one_div]
+    rw [Finset.sum_congr rfl (fun v _ => hfg v),
+        Finset.sum_congr rfl (fun v _ => hf2 v),
+        Finset.sum_congr rfl (fun v _ => hg2 v)] at cs
+    simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul,
+      mul_one] at cs
+    rw [hsum_deg, ← hS] at cs
+    exact cs
+  -- Turn `n² ≤ (2m+n)·S` into the division form, then chain with the weighted bound.
+  have hden : (0 : ℝ) < 2 * m + n := by exact_mod_cast hpos
+  have hdiv : (n : ℝ) ^ 2 / (2 * m + n) ≤ S := by
+    rw [div_le_iff₀ hden]; linarith [hCS]
+  exact hdiv.trans (caro_wei_weighted G)
+
+end ProbMethod.CaroWei

--- a/src/data/proofs/prob-method-alteration-oq-03/annotations.json
+++ b/src/data/proofs/prob-method-alteration-oq-03/annotations.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "ann-carowei-oq03-overview",
+    "proofId": "prob-method-alteration-oq-03",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "A deterministic Caro–Wei proof that removes the parent's axiom",
+    "content": "The parent entry states the Caro–Wei bound α(G) ≥ n²/(2m+n) as the axiom caro_wei. This file proves it, and proves the stronger weighted form ∑_v 1/(deg(v)+1) ≤ α(G) that it descends from. The classical proof of Caro–Wei is probabilistic (random vertex ordering, keep a vertex if it precedes all neighbours, expected size ∑ 1/(deg+1)); formalizing that would require a uniform distribution over permutations. Instead the proof here is fully constructive: induct on the vertex set, delete the closed neighbourhood of a MINIMUM-degree vertex, recurse, and re-insert the vertex. No probability, measure theory, or permutation counting appears.",
+    "mathContext": "$\\sum_{v} \\frac{1}{\\deg(v)+1} \\le \\alpha(G)$, and by convexity $\\alpha(G) \\ge \\frac{n^2}{2m+n}$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "independence number",
+      "Caro–Wei bound",
+      "probabilistic method",
+      "minimum-degree greedy",
+      "de-axiomatization"
+    ],
+    "prerequisites": [
+      "independent sets in graphs",
+      "vertex degree",
+      "strong induction"
+    ]
+  },
+  {
+    "id": "ann-carowei-oq03-definitions",
+    "proofId": "prob-method-alteration-oq-03",
+    "range": { "startLine": 39, "endLine": 52 },
+    "type": "definition",
+    "title": "Independence number and within-set degree",
+    "content": "independenceNumber G is the supremum of the cardinalities of independent sets, sSup {k | ∃ s : Finset V, s.card = k ∧ s pairwise non-adjacent} — the identical definition used by the parent's axiom, so proving the bound against it genuinely discharges that axiom. degIn G W u := (W.filter (G.Adj u)).card is the degree of u counted only among vertices lying inside the finset W. degIn_mono records that shrinking the vertex set can only shrink this degree (Finset.card_le_card on the filtered subset), the monotonicity that later makes surviving Caro–Wei weights increase under deletion.",
+    "mathContext": "$\\deg_W(u) = |\\{w \\in W : u \\sim w\\}|$; $W' \\subseteq W \\Rightarrow \\deg_{W'}(u) \\le \\deg_W(u)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "independence number",
+      "induced subgraph degree",
+      "Finset.filter"
+    ],
+    "prerequisites": [
+      "Finset cardinality",
+      "graph adjacency"
+    ]
+  },
+  {
+    "id": "ann-carowei-oq03-core-induction",
+    "proofId": "prob-method-alteration-oq-03",
+    "range": { "startLine": 54, "endLine": 150 },
+    "type": "proof-step",
+    "title": "The minimum-degree closed-neighbourhood deletion induction",
+    "content": "exists_indep_card_ge: within any finset W there is an independent set I ⊆ W with |I| ≥ ∑_{u∈W} 1/(deg_W(u)+1). Strong induction on W (Finset.strongInductionOn). For nonempty W, Finset.exists_min_image supplies a minimum-degree vertex v; its closed neighbourhood is N = insert v (W.filter (G.Adj v)) with |N| = deg_W(v)+1, and W' = W∖N is a strict subset. The induction hypothesis gives an independent I' ⊆ W'; inserting v keeps independence (every member of W' is non-adjacent to v, since it lies off N), so |insert v I'| = |I'|+1. The weight bound is the crux: split ∑_W = ∑_{W'} + ∑_N (Finset.sum_sdiff); surviving weights increase because deg_{W'} ≤ deg_W and x↦1/x is antitone (one_div_le_one_div_of_le); and the deleted weight is at most 1, since every u∈N has deg_W(u) ≥ deg_W(v) (minimality of v), so ∑_{u∈N} 1/(deg_W(u)+1) ≤ |N|/(deg_W(v)+1) = 1. Thus ∑_W weight ≤ |I'| + 1 = |I|.",
+    "mathContext": "$\\alpha(W) \\ge 1 + \\alpha(W \\setminus N[v])$ with $\\sum_{u\\in N[v]} \\tfrac{1}{\\deg_W(u)+1} \\le \\tfrac{|N[v]|}{\\deg_W(v)+1} = 1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "strong induction on finsets",
+      "closed neighbourhood",
+      "minimum-degree vertex",
+      "greedy independent set"
+    ],
+    "prerequisites": [
+      "Finset.strongInductionOn",
+      "Finset.sum_sdiff",
+      "monotonicity of reciprocal"
+    ]
+  },
+  {
+    "id": "ann-carowei-oq03-global-weighted",
+    "proofId": "prob-method-alteration-oq-03",
+    "range": { "startLine": 152, "endLine": 182 },
+    "type": "proof-step",
+    "title": "From the finset induction to the weighted bound over the whole graph",
+    "content": "degIn_univ identifies the within-univ degree with the ordinary graph degree, degIn G univ u = G.degree u, because neighborFinset u = univ.filter (G.Adj u) (SimpleGraph.card_neighborFinset_eq_degree). caro_wei_weighted then instantiates exists_indep_card_ge at W = univ: the independent set I it produces has I.card in the set defining independenceNumber, which is bounded above by Fintype.card V, so le_csSup gives I.card ≤ α(G). Chaining with the weight inequality yields ∑_v 1/(G.degree v + 1) ≤ α(G).",
+    "mathContext": "$\\sum_{v} \\frac{1}{\\deg(v)+1} \\le |I| \\le \\alpha(G)$ via $I.\\mathrm{card} \\le \\sup$.",
+    "significance": "major",
+    "relatedConcepts": [
+      "handshake between induced and global degree",
+      "supremum bound",
+      "independence number"
+    ],
+    "prerequisites": [
+      "le_csSup and BddAbove",
+      "neighborFinset"
+    ]
+  },
+  {
+    "id": "ann-carowei-oq03-turan",
+    "proofId": "prob-method-alteration-oq-03",
+    "range": { "startLine": 184, "endLine": 233 },
+    "type": "proof-step",
+    "title": "The Turán bound n²/(2m+n) via Cauchy–Schwarz — discharging the axiom",
+    "content": "caro_wei proves the exact statement axiomatized in ProbMethodAlterationOQ02.lean. The handshake identity SimpleGraph.sum_degrees_eq_twice_card_edges gives ∑(deg v + 1) = 2m + n. Cauchy–Schwarz for finite sums (Finset.sum_mul_sq_le_sq_mul_sq) with fᵥ = √(deg v + 1) and gᵥ = 1/√(deg v + 1) has ∑ fᵥgᵥ = ∑ 1 = n, ∑ fᵥ² = 2m+n, ∑ gᵥ² = ∑ 1/(deg v+1) = S, hence n² ≤ (2m+n)·S. Dividing (div_le_iff₀) gives n²/(2m+n) ≤ S, and chaining with caro_wei_weighted gives n²/(2m+n) ≤ α(G). This is the AM–HM convexity step, and it completes the removal of the parent's caro_wei axiom.",
+    "mathContext": "$n^2 = \\big(\\sum 1\\big)^2 \\le \\big(\\sum (\\deg v + 1)\\big)\\big(\\sum \\tfrac{1}{\\deg v+1}\\big) = (2m+n)\\,S$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Cauchy–Schwarz inequality",
+      "AM–HM inequality",
+      "handshake lemma",
+      "Turán-type bound"
+    ],
+    "prerequisites": [
+      "Finset.sum_mul_sq_le_sq_mul_sq",
+      "sum of degrees = 2·edges",
+      "div_le_iff"
+    ]
+  }
+]

--- a/src/data/proofs/prob-method-alteration-oq-03/meta.json
+++ b/src/data/proofs/prob-method-alteration-oq-03/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "prob-method-alteration-oq-03",
+  "slug": "prob-method-alteration-oq-03",
+  "title": "Caro–Wei Bound for the Independence Number — a Deterministic Proof that De-axiomatizes the Turán Bound",
+  "description": "The parent entry states the Caro–Wei bound α(G) ≥ n²/(2m+n) as an axiom (caro_wei in ProbMethodAlterationOQ02.lean), used in the triangle-free improvement chain. This entry PROVES it, and proves the stronger weighted form it descends from. The headline result caro_wei_weighted shows ∑_v 1/(deg(v)+1) ≤ α(G) for any finite simple graph G. Rather than the usual random-permutation / linearity-of-expectation argument, the proof is fully constructive and finite: induct on the vertex set, pick a vertex v of MINIMUM degree, delete its closed neighbourhood N[v], recurse, and re-insert v. The independent set of G∖N[v] plus v is independent in G, so α(G) ≥ 1 + α(G∖N[v]); the weight deleted with N[v] is ∑_{u∈N[v]} 1/(deg(u)+1) ≤ |N[v]|·1/(deg(v)+1) = 1, precisely because v has minimum degree so every u∈N[v] has deg(u) ≥ deg(v). Deleting vertices only lowers surviving degrees, so the surviving weights only grow, and the induction closes. The Turán-type corollary caro_wei then follows from the Cauchy–Schwarz / AM–HM inequality n² = (∑1)² ≤ (∑(deg v+1))·(∑1/(deg v+1)) = (2m+n)·S together with the handshake identity ∑ deg v = 2m, giving n²/(2m+n) ≤ ∑ 1/(deg v+1) ≤ α(G). This discharges the parent's caro_wei axiom entirely — with no probability, measure theory, or permutation counting. Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Researcher-5",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodAlterationOQ03.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "independence-number",
+      "caro-wei",
+      "probabilistic-method",
+      "extremal-graph-theory",
+      "cauchy-schwarz",
+      "turan-type-bound"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 234,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. Results depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (Classical.choice / Quot.sound enter via the noncomputable sSup defining the independence number). Self-contained: does not import ProbMethodAlterationOQ02, but proves the exact statement of that file's axiom `caro_wei` (same independenceNumber definition), so it discharges that assumption.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.strongInductionOn",
+        "description": "Strong induction on finsets ordered by strict inclusion — the engine of the min-degree-vertex deletion argument, recursing on the strictly smaller vertex set W ∖ N[v]",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.exists_min_image",
+        "description": "A nonempty finset attains a minimum of any ℕ-valued function — supplies the minimum-degree vertex v whose closed neighbourhood is deleted",
+        "module": "Mathlib.Data.Finset.Lattice.Fold"
+      },
+      {
+        "theorem": "Finset.sum_sdiff",
+        "description": "∑_{W∖N} f + ∑_N f = ∑_W f for N ⊆ W — splits the Caro–Wei weight of W into the surviving part and the deleted closed neighbourhood",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "one_div_le_one_div_of_le",
+        "description": "x ↦ 1/x is antitone on the positives — turns 'deleting vertices lowers degree' into 'surviving Caro–Wei weights increase', and 'v has minimum degree' into a per-vertex weight bound",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "Finset.sum_mul_sq_le_sq_mul_sq",
+        "description": "Cauchy–Schwarz for finite sums, (∑ fᵢgᵢ)² ≤ (∑ fᵢ²)(∑ gᵢ²) — with fᵢ=√(deg+1), gᵢ=1/√(deg+1) yields the AM–HM inequality n² ≤ (2m+n)·∑1/(deg+1) behind the Turán corollary",
+        "module": "Mathlib.Analysis.MeanInequalities"
+      },
+      {
+        "theorem": "SimpleGraph.sum_degrees_eq_twice_card_edges",
+        "description": "The handshake identity ∑_v deg(v) = 2·|E(G)| — converts ∑(deg v + 1) into 2m + n, the denominator of the Turán bound",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
+      },
+      {
+        "theorem": "SimpleGraph.card_neighborFinset_eq_degree",
+        "description": "|neighborFinset v| = deg(v) — identifies the within-univ degree degIn G univ with the graph degree G.degree, bridging the finset-relative lemma to the global statement",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "le_csSup",
+        "description": "Any member of a bounded-above set is ≤ its supremum — lifts 'I is an independent set of size ≥ S' to 'α(G) ≥ S', since the independence number is defined as a sSup over independent-set cardinalities",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      },
+      {
+        "theorem": "Finset.sdiff_ssubset",
+        "description": "W ∖ N ⊂ W when ∅ ≠ N ⊆ W — certifies the recursion is on a strictly smaller vertex set, so the strong induction is well-founded",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ],
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "SimpleGraph"
+    ],
+    "namespace": "ProbMethod.CaroWei",
+    "lineCount": 234,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "path": "Proofs/ProbMethodAlterationOQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "caro_wei_weighted",
+      "type": "headline",
+      "statement": "(G : SimpleGraph V) [Fintype V] [DecidableRel G.Adj] → ∑ v, 1/(G.degree v + 1) ≤ (independenceNumber G : ℝ)",
+      "description": "The Caro–Wei bound in its full weighted form: the independence number of any finite simple graph is at least the sum of 1/(deg(v)+1) over all vertices. Proved constructively by min-degree closed-neighbourhood deletion — no probability.",
+      "significance": "The sharpest elementary lower bound on α(G) from the degree sequence alone; it specializes to Turán's bound and is the source of the parent entry's axiomatized inequality."
+    },
+    {
+      "name": "caro_wei",
+      "type": "headline",
+      "statement": "(G : SimpleGraph (Fin n)) [DecidableRel G.Adj] → (m = G.edgeFinset.card) → 0 < 2*m+n → (n : ℝ)^2/(2*m+n) ≤ (independenceNumber G : ℝ)",
+      "description": "The Turán-type bound α(G) ≥ n²/(2m+n). Deduced from caro_wei_weighted via the Cauchy–Schwarz / AM–HM inequality n² ≤ (∑(deg+1))·(∑1/(deg+1)) and the handshake identity ∑ deg = 2m. This is verbatim the statement axiomatized as `caro_wei` in ProbMethodAlterationOQ02.lean, now proved.",
+      "significance": "De-axiomatizes the Caro–Wei bound the parent uses in its triangle-free improvement chain, reducing that chain's assumption count."
+    },
+    {
+      "name": "exists_indep_card_ge",
+      "type": "core",
+      "statement": "(G : SimpleGraph V) [DecidableRel G.Adj] (W : Finset V) → ∃ I ⊆ W, (I independent) ∧ ∑_{u∈W} 1/(degIn G W u + 1) ≤ (I.card : ℝ)",
+      "description": "The finset-relative engine of the whole proof: within any vertex set W there is an independent set whose size is at least the Caro–Wei weight of W (degrees counted inside W). Proved by strong induction on W — delete the closed neighbourhood of a minimum-degree vertex, recurse, re-insert.",
+      "significance": "Carries the induction that the global bound is read off from; the min-degree choice is exactly what makes the deleted weight ≤ 1."
+    },
+    {
+      "name": "degIn_mono",
+      "type": "supporting",
+      "statement": "W' ⊆ W → degIn G W' u ≤ degIn G W u",
+      "description": "Counting neighbours inside a smaller vertex set gives a smaller degree. Combined with the antitonicity of x ↦ 1/x, this is why the surviving Caro–Wei weights only increase when vertices are deleted.",
+      "significance": "The monotonicity that lets the induction hypothesis (weights relative to the smaller W∖N[v]) dominate the weights relative to W."
+    },
+    {
+      "name": "degIn_univ",
+      "type": "supporting",
+      "statement": "degIn G Finset.univ u = G.degree u",
+      "description": "The within-univ degree equals the ordinary graph degree, since neighborFinset u = univ.filter (G.Adj u). Bridges the finset-relative lemma to the global statement over the whole graph.",
+      "significance": "Connects the abstract induction on finsets to the concrete degree sequence appearing in the headline bounds."
+    }
+  ],
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Part I: Independence number and within-set degree",
+      "startLine": 39,
+      "endLine": 52,
+      "summary": "independenceNumber G := sSup {k | ∃ s : Finset V, s.card = k ∧ s is independent} — identical to the definition in ProbMethodAlterationOQ02. degIn G W u := (W.filter (G.Adj u)).card counts u's neighbours lying inside W. degIn_mono: restricting to a smaller vertex set can only decrease the degree (Finset.card_le_card on the filtered subset).",
+      "mathContext": "α(G) as a supremum over independent-set sizes; deg_W(u) as the degree of u in the subgraph induced on W."
+    },
+    {
+      "id": "core-induction",
+      "title": "Part II: The min-degree deletion induction",
+      "startLine": 54,
+      "endLine": 150,
+      "summary": "exists_indep_card_ge, by Finset.strongInductionOn. Empty W: take I = ∅. Nonempty W: pick a minimum-degree vertex v (Finset.exists_min_image), form its closed neighbourhood N = insert v (W.filter (G.Adj v)) with |N| = deg_W(v)+1, and set W' = W ∖ N (a strict subset, so the induction hypothesis applies). Insert v into the independent set I' of W' — it stays independent because members of W' are non-adjacent to v — giving |I| = |I'|+1. The weight bound splits ∑_W = ∑_{W'} + ∑_N (Finset.sum_sdiff); surviving weights increase (degIn_mono + antitone 1/x); and the deleted weight satisfies ∑_{u∈N} 1/(deg_W(u)+1) ≤ |N|·1/(deg_W(v)+1) = 1 because v has minimum degree. Hence ∑_W weight ≤ |I'|+1 = |I|.",
+      "mathContext": "α(G) ≥ 1 + α(G∖N[v]) with the deleted Caro–Wei weight ≤ 1, the crux enabled by choosing v of minimum degree."
+    },
+    {
+      "id": "global-weighted",
+      "title": "Part III: The weighted Caro–Wei bound over the whole graph",
+      "startLine": 152,
+      "endLine": 182,
+      "summary": "degIn_univ rewrites the within-univ degree as G.degree. caro_wei_weighted then instantiates exists_indep_card_ge at W = univ: the resulting independent set I witnesses I.card ∈ the independence-number set, so ∑_v 1/(G.degree v+1) ≤ I.card ≤ α(G) via le_csSup (the set is bounded above by Fintype.card V).",
+      "mathContext": "∑_v 1/(deg(v)+1) ≤ α(G) for the full graph."
+    },
+    {
+      "id": "turan-corollary",
+      "title": "Part IV: The Turán bound n²/(2m+n) — discharging the parent's axiom",
+      "startLine": 184,
+      "endLine": 233,
+      "summary": "caro_wei. The handshake identity ∑ deg v = 2m gives ∑(deg v + 1) = 2m + n. Cauchy–Schwarz (Finset.sum_mul_sq_le_sq_mul_sq with fᵥ = √(deg v+1), gᵥ = 1/√(deg v+1)) yields (∑1)² = n² ≤ (∑(deg v+1))·(∑1/(deg v+1)) = (2m+n)·S. Dividing gives n²/(2m+n) ≤ S, and chaining with caro_wei_weighted gives n²/(2m+n) ≤ α(G) — verbatim the statement of ProbMethodAlterationOQ02's axiom.",
+      "mathContext": "n²/(2m+n) ≤ ∑1/(deg+1) ≤ α(G), the AM–HM convexity step turning the weighted bound into the edge-count bound."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The bound α(G) ≥ ∑_v 1/(d(v)+1), independently due to Yair Caro (1979) and V. K. Wei (1981), is the standard degree-sequence lower bound on the independence number of a graph. Its most famous proof is a jewel of the probabilistic method: order the vertices uniformly at random, keep each vertex that precedes all its neighbours, and observe that vertex v survives with probability exactly 1/(d(v)+1), so by linearity of expectation the expected size of the resulting independent set is ∑_v 1/(d(v)+1). By convexity (Cauchy–Schwarz / AM–HM) the bound implies the earlier Turán-type estimate α(G) ≥ n²/(2m+n) = n/(d̄+1) with d̄ the average degree. In the Lean Genius gallery, the parent entry prob-method-alteration used the n²/(2m+n) form as an explicit axiom (caro_wei) to drive its triangle-free improvement chain. This entry removes that axiom by giving a fully constructive, probability-free proof of the stronger weighted bound and deducing the Turán form.",
+    "problemStatement": "Prove the Caro–Wei bound α(G) ≥ ∑_v 1/(deg(v)+1) for every finite simple graph G, and deduce the Turán-type corollary α(G) ≥ n²/(2m+n), thereby discharging the axiom caro_wei stated in ProbMethodAlterationOQ02.lean.",
+    "proofStrategy": "Avoid the probabilistic argument (which would require formalizing a uniform distribution over permutations and the per-vertex survival probability) in favour of the deterministic min-degree deletion induction. Working with a finset W of vertices and the within-W degree deg_W, prove by strong induction on W that there is an independent set I ⊆ W with |I| ≥ ∑_{u∈W} 1/(deg_W(u)+1). For nonempty W, pick a minimum-degree vertex v, delete its closed neighbourhood N[v] (|N[v]| = deg_W(v)+1), apply the induction hypothesis to the strictly smaller W∖N[v], and re-insert v (still independent, since W∖N[v] contains no neighbour of v). The weight identity ∑_W = ∑_{W∖N[v]} + ∑_{N[v]} together with (a) monotonicity — deleting vertices lowers surviving degrees, so surviving weights increase — and (b) the minimum-degree estimate ∑_{u∈N[v]} 1/(deg_W(u)+1) ≤ |N[v]|/(deg_W(v)+1) = 1 closes the induction. Instantiating at W = univ (where deg_W = G.degree) and using le_csSup gives the weighted bound; a Cauchy–Schwarz step plus the handshake identity ∑ deg = 2m gives the Turán corollary.",
+    "keyInsights": [
+      "The Caro–Wei bound has a fully deterministic proof: the customary random-permutation expectation argument can be replaced by an induction that deletes the closed neighbourhood of a minimum-degree vertex, sidestepping any probability, measure theory, or permutation counting in the formalization.",
+      "Choosing a MINIMUM-degree vertex v is the whole game: it makes every u in the closed neighbourhood N[v] satisfy deg(u) ≥ deg(v), so the total weight lost by deleting N[v] is at most |N[v]|·1/(deg(v)+1) = 1 — exactly the +1 gained by adding v to the independent set.",
+      "Carrying the induction over an arbitrary vertex finset W with W-relative degrees (rather than deleting vertices from the graph type) keeps everything inside a single fixed graph G and reduces the recursion to Finset.strongInductionOn on W∖N[v] ⊂ W.",
+      "Deleting vertices only decreases the remaining degrees (degIn_mono), and x ↦ 1/x is antitone, so the surviving Caro–Wei weights only increase — which is precisely what lets the induction hypothesis for the smaller set dominate the target sum.",
+      "The Turán bound n²/(2m+n) is not a separate theorem but a convexity shadow of the weighted bound: Cauchy–Schwarz gives n² ≤ (∑(deg+1))(∑1/(deg+1)), and the handshake identity turns ∑(deg+1) into 2m+n.",
+      "Because the entry proves the exact statement of the parent's axiom against the same independenceNumber definition, it discharges that axiom without needing to import or edit the parent file."
+    ]
+  },
+  "conclusion": {
+    "summary": "The Caro–Wei lower bound α(G) ≥ ∑_v 1/(deg(v)+1) is proved for every finite simple graph by a constructive minimum-degree closed-neighbourhood deletion induction, with no probabilistic machinery. Its Turán-type corollary α(G) ≥ n²/(2m+n) follows by Cauchy–Schwarz and the handshake identity, giving a full, axiom-free proof of the bound that the parent entry prob-method-alteration had stated as the axiom caro_wei. Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+    "implications": "This reduces the assumption count of the parent's triangle-free improvement chain: the Caro–Wei input to α(G) ≥ 2n/(n+2) for triangle-free graphs is now a theorem rather than an axiom. The deterministic deletion argument is also reusable — it gives the sharp weighted bound directly, and the same min-degree-deletion template underlies several other extremal independence-number estimates.",
+    "openQuestions": [
+      "Can the random-permutation proof itself be formalized — the per-vertex survival probability 1/(deg(v)+1) via a uniform distribution over Equiv.Perm V — and shown to give the same bound, quantifying how much heavier the probabilistic route is than this deterministic one?",
+      "Does the min-degree deletion argument extend to the weighted/fractional independence number, or to hypergraphs, yielding a Caro–Wei-type bound ∑_v 1/(d(v)+1) for k-uniform hypergraphs with an appropriately defined degree?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "prob-method-alteration",
+      "relationship": "parent",
+      "description": "Alteration Method (Probabilistic Method) — states the Caro–Wei bound α(G) ≥ n²/(2m+n) as the axiom caro_wei (in its OQ-02 companion) to drive the triangle-free improvement; this entry proves that exact statement, discharging the axiom."
+    },
+    {
+      "proofId": "prob-method-alteration-oq-02",
+      "relationship": "sibling",
+      "description": "The triangle-free improvement α(G) ≥ 2n/(n+2), whose derivation consumes the caro_wei axiom this entry proves; the two together turn that improvement chain's Caro–Wei input into a theorem."
+    }
+  ]
+}


### PR DESCRIPTION
## Caro–Wei Bound for the Independence Number — a Deterministic, Axiom-Free Proof

Answers open question **oq-03** of `prob-method-alteration`, and **de-axiomatizes** the Caro–Wei bound that the parent entry previously stated as an `axiom`.

### What this proves
- **`caro_wei_weighted`** (headline): for any finite simple graph `G`,
  `∑_v 1/(deg(v)+1) ≤ α(G)` — the weighted Caro–Wei bound.
- **`caro_wei`** (headline): `n²/(2m+n) ≤ α(G)` — the Turán-type corollary.
  This is **verbatim the statement axiomatized as `caro_wei` in `ProbMethodAlterationOQ02.lean`**, now proved against the same `independenceNumber` definition.

### How
Instead of the classical random-permutation / linearity-of-expectation argument (which would need a uniform distribution over permutations formalized), the proof is **fully constructive and finite**:

- Induct on the vertex set (`Finset.strongInductionOn`).
- Pick a **minimum-degree** vertex `v`; delete its closed neighbourhood `N[v]` (`|N[v]| = deg(v)+1`).
- Recurse on `W ∖ N[v]`, re-insert `v` (stays independent), so `α(W) ≥ 1 + α(W∖N[v])`.
- The deleted Caro–Wei weight is `∑_{u∈N[v]} 1/(deg(u)+1) ≤ |N[v]|/(deg(v)+1) = 1`, precisely because `v` has minimum degree.
- Deleting vertices only lowers surviving degrees, so surviving weights only increase — the induction closes.

The Turán corollary follows from **Cauchy–Schwarz / AM–HM** `n² ≤ (∑(deg+1))·(∑1/(deg+1))` and the **handshake identity** `∑ deg = 2m`.

### Status
- **VERIFIED**, 0 axioms, 0 sorries, no `native_decide`.
- 5 theorems, 2 definitions, 234 lines.
- Builds against Mathlib 4.26.0 (`lake env lean`, rc=0; only cosmetic linter warnings).

New gallery entry: `src/data/proofs/prob-method-alteration-oq-03/` (meta + annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)