### PR TITLE
research(gcd-algorithm-oq-01-oq-02): finite Chebyshev concentration for Euclidean step counts [VERIFIED, 0-axiom, 7thm+5def/166L, new entry]

### DIFF
--- a/proofs/Proofs/GcdAlgorithmOQ01OQ02.lean
+++ b/proofs/Proofs/GcdAlgorithmOQ01OQ02.lean
@@ -1,0 +1,166 @@
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Tactic
+
+/-
+# Distribution of Euclidean Algorithm Step Counts — Concentration Infrastructure
+
+## Open Question (parent `gcd-algorithm-oq-01-oq-02`)
+"What is the *full distribution* of step counts of the Euclidean algorithm?
+Hensley (1994) computed the variance; can the limiting distribution be formalized?"
+
+## Background
+For coprime inputs the number of division steps `euclideanSteps a b` behaves like a
+random variable. Dixon (1970) proved the mean is `(12 ln 2 / π²) ln N ≈ 0.8427 ln N`;
+Hensley (1994) proved a **central limit theorem**: suitably normalized, the step count
+converges to a Gaussian. Proving that limit theorem in Lean is far out of reach — it
+requires the spectral theory of the Gauss–Kuzmin–Wirsing transfer operator, which is
+not in Mathlib.
+
+## What This File Actually Proves (honest scope)
+This file does **not** formalize Hensley's Gaussian limit. It builds the elementary,
+fully verified probabilistic scaffolding that *any* distributional statement rests on:
+the **finite Chebyshev inequality** for the empirical distribution of step counts over
+a finite sample of input pairs. Concretely, over any finite sample `s` of pairs `(a,b)`,
+the fraction of pairs whose step count deviates from the empirical mean by at least `t`
+is at most `Var / t²`. This is the rigorous "concentration around the mean" content
+underlying a limiting distribution — a genuine but elementary first layer.
+
+## Status
+- [x] Empirical mean / variance of a rational-valued statistic over a finite sample
+- [x] Finite Chebyshev inequality (counting form and normalized fraction form)
+- [x] Specialization to `euclideanSteps` over a canonical sample of input pairs
+- [x] Non-negativity of the empirical variance
+- [ ] Hensley's central limit theorem (requires transfer-operator spectral theory)
+
+All results are `sorry`-free and use no `axiom`/`native_decide` (0 assumptions).
+-/
+
+namespace GcdAlgorithmOQ01OQ02
+
+open Finset
+
+/-!
+## Step Counting
+
+Same definition as the parent entry `GCDAlgorithmOQ01`, restated so this file is
+self-contained.
+-/
+
+/-- Count division steps in the Euclidean algorithm. -/
+def euclideanSteps (a b : ℕ) : ℕ :=
+  if b = 0 then 0
+  else euclideanSteps b (a % b) + 1
+termination_by b
+decreasing_by exact Nat.mod_lt a (Nat.pos_of_ne_zero ‹b ≠ 0›)
+
+theorem euclideanSteps_zero (a : ℕ) : euclideanSteps a 0 = 0 := by
+  rw [euclideanSteps]; simp
+
+/-- The step count as a rational-valued statistic on input pairs. -/
+def stepsQ (p : ℕ × ℕ) : ℚ := (euclideanSteps p.1 p.2 : ℚ)
+
+theorem stepsQ_nonneg (p : ℕ × ℕ) : 0 ≤ stepsQ p := by
+  unfold stepsQ; positivity
+
+/-!
+## Empirical Mean and Variance
+
+We model the uniform distribution over a finite sample `s : Finset ι` and a
+rational-valued statistic `f : ι → ℚ`. All quantities are exact rationals.
+-/
+
+/-- Empirical (sample) mean of `f` over the uniform distribution on `s`. -/
+noncomputable def empMean {ι : Type*} (s : Finset ι) (f : ι → ℚ) : ℚ :=
+  (∑ i ∈ s, f i) / s.card
+
+/-- Empirical (sample) variance of `f` over the uniform distribution on `s`. -/
+noncomputable def empVar {ι : Type*} (s : Finset ι) (f : ι → ℚ) : ℚ :=
+  (∑ i ∈ s, (f i - empMean s f) ^ 2) / s.card
+
+/-- The empirical variance is non-negative. -/
+theorem empVar_nonneg {ι : Type*} (s : Finset ι) (f : ι → ℚ) : 0 ≤ empVar s f := by
+  unfold empVar
+  apply div_nonneg
+  · exact Finset.sum_nonneg fun i _ => sq_nonneg _
+  · exact_mod_cast Nat.zero_le _
+
+/-!
+## Finite Chebyshev Inequality
+
+The core estimate: on the set of points at deviation `≥ t` from a reference value `μ`,
+each squared deviation is at least `t²`, so the count times `t²` is bounded by the total
+sum of squared deviations. This is the finite / uniform-measure Chebyshev inequality.
+-/
+
+/-- **Chebyshev, counting form.** For any reference value `μ` and threshold `t > 0`,
+the number of sample points deviating from `μ` by at least `t`, times `t²`, is bounded
+by the total sum of squared deviations from `μ`. -/
+theorem chebyshev_count {ι : Type*} (s : Finset ι) (f : ι → ℚ) (μ : ℚ)
+    {t : ℚ} (ht : 0 < t) :
+    ((s.filter (fun i => t ≤ |f i - μ|)).card : ℚ) * t ^ 2
+      ≤ ∑ i ∈ s, (f i - μ) ^ 2 := by
+  set T := s.filter (fun i => t ≤ |f i - μ|) with hT
+  have hsub : T ⊆ s := Finset.filter_subset _ _
+  -- `T.card * t² = ∑_{i ∈ T} t²`
+  have h1 : (T.card : ℚ) * t ^ 2 = ∑ _i ∈ T, t ^ 2 := by
+    rw [Finset.sum_const, nsmul_eq_mul]
+  -- On `T` every squared deviation dominates `t²`.
+  have h2 : ∑ _i ∈ T, t ^ 2 ≤ ∑ i ∈ T, (f i - μ) ^ 2 := by
+    apply Finset.sum_le_sum
+    intro i hi
+    have hi' : t ≤ |f i - μ| := (Finset.mem_filter.mp hi).2
+    have hprod : (0 : ℚ) ≤ (|f i - μ| - t) * (|f i - μ| + t) :=
+      mul_nonneg (by linarith) (by linarith [abs_nonneg (f i - μ)])
+    nlinarith [sq_abs (f i - μ), hprod]
+  -- Extend the sum from `T` to all of `s` (extra terms are non-negative).
+  have h3 : ∑ i ∈ T, (f i - μ) ^ 2 ≤ ∑ i ∈ s, (f i - μ) ^ 2 :=
+    Finset.sum_le_sum_of_subset_of_nonneg hsub (fun i _ _ => sq_nonneg _)
+  calc (T.card : ℚ) * t ^ 2 = ∑ _i ∈ T, t ^ 2 := h1
+    _ ≤ ∑ i ∈ T, (f i - μ) ^ 2 := h2
+    _ ≤ ∑ i ∈ s, (f i - μ) ^ 2 := h3
+
+/-- **Chebyshev, normalized form.** For a non-empty sample, the *fraction* of points whose
+statistic deviates from the empirical mean by at least `t` is bounded by `Var / t²`. This
+is the classical `P(|X − μ| ≥ t) ≤ σ²/t²`. -/
+theorem chebyshev_fraction {ι : Type*} (s : Finset ι) (hs : s.Nonempty) (f : ι → ℚ)
+    {t : ℚ} (ht : 0 < t) :
+    ((s.filter (fun i => t ≤ |f i - empMean s f|)).card : ℚ) / s.card
+      ≤ empVar s f / t ^ 2 := by
+  have hcard : (0 : ℚ) < (s.card : ℚ) := by exact_mod_cast Finset.card_pos.mpr hs
+  have hcard' : (s.card : ℚ) ≠ 0 := ne_of_gt hcard
+  have ht2 : (0 : ℚ) < t ^ 2 := by positivity
+  have key := chebyshev_count s f (empMean s f) ht
+  unfold empVar
+  rw [div_le_div_iff₀ hcard ht2, div_mul_eq_mul_div, mul_div_assoc, div_self hcard', mul_one]
+  exact key
+
+/-!
+## Specialization to Euclidean Step Counts
+
+We take as canonical sample the pairs `(a, b)` with `1 ≤ b ≤ a ≤ N`. This is a
+concrete finite universe on which `stepsQ` is an honest random variable; the concentration
+bound holds for it (and, by `chebyshev_fraction`, for *any* other finite sample).
+-/
+
+/-- Canonical sample of input pairs `(a, b)` with `1 ≤ b ≤ a ≤ N`. -/
+def sampleN (N : ℕ) : Finset (ℕ × ℕ) :=
+  (Finset.range (N + 1) ×ˢ Finset.range (N + 1)).filter (fun p => 1 ≤ p.2 ∧ p.2 ≤ p.1)
+
+/-- The canonical sample is non-empty for `N ≥ 1` (it contains `(1, 1)`). -/
+theorem sampleN_nonempty {N : ℕ} (hN : 1 ≤ N) : (sampleN N).Nonempty := by
+  refine ⟨(1, 1), ?_⟩
+  simp only [sampleN, Finset.mem_filter, Finset.mem_product, Finset.mem_range]
+  refine ⟨⟨?_, ?_⟩, ?_, ?_⟩ <;> omega
+
+/-- **Concentration of Euclidean step counts.** Over the canonical sample of input pairs
+with `1 ≤ b ≤ a ≤ N`, the fraction of pairs whose step count deviates from the empirical
+mean by at least `t` is at most `Var / t²`. This is the rigorous concentration statement
+underlying (but far weaker than) Hensley's Gaussian limit law. -/
+theorem euclideanSteps_concentration {N : ℕ} (hN : 1 ≤ N) {t : ℚ} (ht : 0 < t) :
+    ((sampleN N).filter (fun p => t ≤ |stepsQ p - empMean (sampleN N) stepsQ|)).card
+        / ((sampleN N).card : ℚ)
+      ≤ empVar (sampleN N) stepsQ / t ^ 2 :=
+  chebyshev_fraction (sampleN N) (sampleN_nonempty hN) stepsQ ht
+
+end GcdAlgorithmOQ01OQ02

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-02/annotations.json
@@ -1,0 +1,145 @@
+[
+  {
+    "id": "ann-euclidean-steps",
+    "proofId": "gcd-algorithm-oq-01-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 64
+    },
+    "type": "definition",
+    "title": "The Euclidean Step Count as a Rational Statistic",
+    "content": "euclideanSteps a b counts the number of division steps performed by the Euclidean algorithm, defined by well-founded recursion on the second argument b (each step replaces (a,b) by (b, a mod b), and a mod b < b when b ≠ 0 guarantees termination). Restated here so the file is self-contained rather than importing the parent module. stepsQ p = (euclideanSteps p.1 p.2 : ℚ) lifts this integer statistic to the rationals, so that empirical means and variances are exact rational numbers with no rounding; stepsQ_nonneg records that it is non-negative.",
+    "mathContext": "$\\mathrm{euclideanSteps}(a,0) = 0$ and $\\mathrm{euclideanSteps}(a,b) = \\mathrm{euclideanSteps}(b, a \\bmod b) + 1$ for $b \\ne 0$. As $(a,b)$ ranges over a bounded region this count behaves like a random variable; Dixon (1970) showed its mean is $\\sim \\frac{12\\ln 2}{\\pi^2}\\ln N$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Euclidean algorithm",
+      "well-founded recursion",
+      "termination_by / decreasing_by",
+      "rational-valued statistic"
+    ],
+    "prerequisites": [
+      "Nat.mod and Nat.mod_lt",
+      "well-founded recursion in Lean 4"
+    ]
+  },
+  {
+    "id": "ann-emp-mean-var",
+    "proofId": "gcd-algorithm-oq-01-oq-02",
+    "range": {
+      "startLine": 73,
+      "endLine": 79
+    },
+    "type": "definition",
+    "title": "Empirical Mean and Variance over a Finite Sample",
+    "content": "For a finite sample s : Finset ι and a rational-valued statistic f : ι → ℚ, empMean s f = (∑ i ∈ s, f i) / |s| is the average of f under the uniform distribution on s, and empVar s f = (∑ i ∈ s, (f i − empMean s f)²) / |s| is the corresponding variance. Both are exact rationals — there is no measure-theoretic probability space here, just uniform weighting over a Finset, which is all Chebyshev's inequality requires.",
+    "mathContext": "$\\mu = \\frac{1}{|s|}\\sum_{i \\in s} f(i)$, $\\sigma^2 = \\frac{1}{|s|}\\sum_{i \\in s}(f(i)-\\mu)^2$. These are the empirical (sample) moments of $f$ under the uniform law on $s$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "empirical distribution",
+      "uniform measure on a Finset",
+      "sample mean and variance",
+      "exact rational arithmetic"
+    ],
+    "prerequisites": [
+      "Finset.sum",
+      "division in ℚ",
+      "Finset.card"
+    ]
+  },
+  {
+    "id": "ann-empvar-nonneg",
+    "proofId": "gcd-algorithm-oq-01-oq-02",
+    "range": {
+      "startLine": 81,
+      "endLine": 86
+    },
+    "type": "theorem",
+    "title": "Non-negativity of the Empirical Variance",
+    "content": "empVar_nonneg shows 0 ≤ empVar s f. The numerator ∑ (f i − empMean s f)² is a sum of squares, hence non-negative by Finset.sum_nonneg and sq_nonneg; the denominator |s| is a natural number cast to ℚ, hence non-negative. div_nonneg combines the two. A small but necessary sanity fact: a variance is never negative, which the Chebyshev bound implicitly relies on when interpreting Var/t² as a genuine probability bound.",
+    "mathContext": "$\\sigma^2 = \\frac{1}{|s|}\\sum_{i \\in s}(f(i)-\\mu)^2 \\ge 0$ because it is a non-negative sum divided by a non-negative cardinality.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "sum of squares",
+      "Finset.sum_nonneg",
+      "div_nonneg"
+    ],
+    "prerequisites": [
+      "sq_nonneg",
+      "non-negativity of sums"
+    ]
+  },
+  {
+    "id": "ann-chebyshev-count",
+    "proofId": "gcd-algorithm-oq-01-oq-02",
+    "range": {
+      "startLine": 96,
+      "endLine": 121
+    },
+    "type": "theorem",
+    "title": "Chebyshev's Inequality — Counting Form",
+    "content": "chebyshev_count is the analytic heart of the entry: for any reference value μ (not necessarily the mean) and any threshold t > 0, the number of sample points at deviation ≥ t, times t², is bounded by the total sum of squared deviations: (#{i ∈ s : t ≤ |f i − μ|})·t² ≤ ∑_{i∈s}(f i − μ)². The proof introduces the deviation set T = s.filter (t ≤ |f i − μ|), rewrites |T|·t² = ∑_{i∈T} t² via Finset.sum_const, then bounds termwise: on T the factorization |d|² − t² = (|d|−t)(|d|+t) ≥ 0 (both factors non-negative) gives t² ≤ (f i − μ)², closed by nlinarith with sq_abs. Finally Finset.sum_le_sum_of_subset_of_nonneg extends the sum from T to all of s since the omitted terms are squares.",
+    "mathContext": "$\\bigl|\\{i \\in s : t \\le |f(i)-\\mu|\\}\\bigr|\\cdot t^2 \\;\\le\\; \\sum_{i \\in s}(f(i)-\\mu)^2$. Allowing an arbitrary reference $\\mu$ makes this strictly more general than the textbook statement and is what enables the clean extension from the deviation set to the whole sample.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Chebyshev's inequality",
+      "Markov's inequality",
+      "deviation set",
+      "sum of squares bound",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "Finset.filter and Finset.sum_const",
+      "Finset.sum_le_sum, Finset.sum_le_sum_of_subset_of_nonneg",
+      "sq_abs and the factorization a²−b²=(a−b)(a+b)"
+    ]
+  },
+  {
+    "id": "ann-chebyshev-fraction",
+    "proofId": "gcd-algorithm-oq-01-oq-02",
+    "range": {
+      "startLine": 123,
+      "endLine": 136
+    },
+    "type": "theorem",
+    "title": "Chebyshev's Inequality — Normalized Fraction Form",
+    "content": "chebyshev_fraction packages the counting bound into the familiar probabilistic statement: for a non-empty sample, the fraction of points whose statistic deviates from the empirical mean by at least t is at most empVar/t². This is exactly P(|X − μ| ≥ t) ≤ σ²/t² for the uniform distribution on s. The derivation takes μ = empMean s f in chebyshev_count, then clears denominators with div_le_div_iff₀ and uses ∑_{i∈s}(f i − μ)² = |s|·empVar together with div_self on |s| ≠ 0 to land the normalized inequality.",
+    "mathContext": "$\\dfrac{\\bigl|\\{i \\in s : t \\le |f(i)-\\mu|\\}\\bigr|}{|s|} \\;\\le\\; \\dfrac{\\sigma^2}{t^2}$, the classical $P(|X-\\mu| \\ge t) \\le \\sigma^2/t^2$ under the uniform law on $s$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chebyshev's inequality",
+      "concentration of measure",
+      "tail bound",
+      "empirical distribution"
+    ],
+    "prerequisites": [
+      "div_le_div_iff₀, div_self",
+      "the counting-form inequality",
+      "Finset.card_pos"
+    ]
+  },
+  {
+    "id": "ann-concentration",
+    "proofId": "gcd-algorithm-oq-01-oq-02",
+    "range": {
+      "startLine": 146,
+      "endLine": 166
+    },
+    "type": "theorem",
+    "title": "Concentration of Euclidean Step Counts",
+    "content": "The payoff: sampleN N = {(a,b) : 1 ≤ b ≤ a ≤ N} is the canonical finite universe of input pairs, non-empty for N ≥ 1 (it contains (1,1), sampleN_nonempty). euclideanSteps_concentration applies chebyshev_fraction to the statistic stepsQ over sampleN N, giving a rigorous bound: the fraction of pairs whose Euclidean step count deviates from the empirical mean by at least t is at most Var/t². This is the honest concentration-around-the-mean content underlying — but far weaker than — Hensley's (1994) Gaussian limit law, whose proof requires the Gauss–Kuzmin–Wirsing transfer operator's spectral theory, absent from Mathlib.",
+    "mathContext": "Over $\\mathrm{sampleN}\\,N = \\{(a,b) : 1 \\le b \\le a \\le N\\}$, $\\dfrac{\\#\\{p : t \\le |\\mathrm{stepsQ}(p) - \\mu|\\}}{|\\mathrm{sampleN}\\,N|} \\le \\dfrac{\\mathrm{Var}}{t^2}$, where $\\mu, \\mathrm{Var}$ are the empirical mean and variance of the step count.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "average-case complexity",
+      "Euclidean algorithm step count",
+      "Hensley central limit theorem",
+      "Gauss–Kuzmin–Wirsing operator",
+      "concentration bound"
+    ],
+    "prerequisites": [
+      "chebyshev_fraction",
+      "Finset product and filter (sampleN)",
+      "sampleN_nonempty"
+    ]
+  }
+]

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-02/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-02/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "gcd-algorithm-oq-01-oq-02",
+  "title": "Concentration of Euclidean Step Counts: a Finite Chebyshev Inequality",
+  "slug": "gcd-algorithm-oq-01-oq-02",
+  "description": "Toward the full distribution of Euclidean-algorithm step counts (Hensley 1994), this entry formalizes the elementary probabilistic scaffolding that any distributional statement rests on: the finite Chebyshev inequality for the empirical distribution of a rational-valued statistic over a finite sample. In counting form, the number of sample points deviating from a reference value by at least t, times t², is bounded by the total sum of squared deviations; in normalized form, the fraction deviating from the empirical mean by at least t is at most Var/t². Specialized to the step count of the Euclidean algorithm over the canonical sample of pairs 1 ≤ b ≤ a ≤ N, this gives a rigorous concentration-around-the-mean bound. Honest scope: it does NOT prove Hensley's Gaussian limit law (which needs transfer-operator spectral theory absent from Mathlib). 7 theorems, 5 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GcdAlgorithmOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "euclidean-algorithm",
+      "probability",
+      "chebyshev-inequality",
+      "concentration"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (depends only on propext, Classical.choice, Quot.sound). Self-contained: restates euclideanSteps from the parent entry.",
+    "lineCount": 166,
+    "theoremCount": 7,
+    "definitionCount": 5,
+    "originalContributions": [
+      "chebyshev_count: the finite/uniform-measure Chebyshev inequality in counting form — (#{i : t ≤ |f i − μ|})·t² ≤ ∑ (f i − μ)², for any reference μ and any rational-valued statistic f on a finite sample",
+      "chebyshev_fraction: the normalized form — the fraction of points deviating from the empirical mean by ≥ t is at most empVar/t², the classical P(|X−μ| ≥ t) ≤ σ²/t² over a uniform finite sample",
+      "empVar_nonneg: non-negativity of the empirical variance",
+      "euclideanSteps_concentration: specialization to euclideanSteps over the canonical sample {(a,b) : 1 ≤ b ≤ a ≤ N}, a rigorous concentration bound underlying (but far weaker than) Hensley's Gaussian limit",
+      "empMean / empVar: exact rational empirical mean and variance of a statistic over the uniform distribution on a finite sample"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The number of division steps taken by the Euclidean algorithm on a coprime pair $(a,b)$ behaves like a random variable as the inputs range over a bounded region. Gustav Lejeune Dirichlet and later Gabriel Lamé (1844) bounded the worst case; the average-case theory is far deeper. John D. Dixon (1970) proved that the mean number of steps is asymptotically $\\frac{12 \\ln 2}{\\pi^2} \\ln N \\approx 0.8427 \\ln N$, and Hans Heilbronn and Dixon independently established the constant. Douglas Hensley (1994) went further, proving a **central limit theorem**: suitably normalized, the step count converges to a Gaussian distribution, with the variance also growing linearly in $\\ln N$. Hensley's proof rests on the spectral theory of the Gauss–Kuzmin–Wirsing transfer operator acting on a space of holomorphic functions — machinery entirely absent from Mathlib. This entry does not attempt that summit; it formalizes the elementary probabilistic bedrock on which every concentration or limit statement is built.",
+    "problemStatement": "Parent open question (`gcd-algorithm-oq-01-oq-02`): what is the full distribution of Euclidean-algorithm step counts? Hensley (1994) computed the variance and proved a Gaussian limit — can the limiting distribution be formalized? As a rigorous first layer, prove the finite Chebyshev inequality for the empirical distribution of a rational-valued statistic over a finite sample, and specialize it to the Euclidean step count $\\mathrm{euclideanSteps}(a,b)$ over the sample $\\{(a,b) : 1 \\le b \\le a \\le N\\}$: the fraction of pairs whose step count deviates from the empirical mean by at least $t$ is at most $\\mathrm{Var}/t^2$.",
+    "text": "The proof works entirely with exact rationals, so no measure theory is needed. For a finite sample $s : \\mathrm{Finset}\\,\\iota$ and a statistic $f : \\iota \\to \\mathbb{Q}$, the empirical mean is $\\mu = \\frac{1}{|s|}\\sum_{i \\in s} f(i)$ and the empirical variance is $\\sigma^2 = \\frac{1}{|s|}\\sum_{i \\in s}(f(i)-\\mu)^2$.\n\n**Counting form.** Fix any reference value $\\mu$ (not necessarily the mean) and a threshold $t > 0$. Let $T = \\{i \\in s : t \\le |f(i)-\\mu|\\}$. On $T$ each squared deviation dominates $t^2$ because $|f(i)-\\mu|^2 - t^2 = (|f(i)-\\mu|-t)(|f(i)-\\mu|+t) \\ge 0$. Summing, $|T|\\,t^2 = \\sum_{i\\in T} t^2 \\le \\sum_{i\\in T}(f(i)-\\mu)^2 \\le \\sum_{i\\in s}(f(i)-\\mu)^2$, the last step adding back the non-negative terms outside $T$.\n\n**Normalized form.** Take $\\mu$ to be the empirical mean and divide by $|s|\\,t^2$. Since $\\sum_{i\\in s}(f(i)-\\mu)^2 = |s|\\,\\sigma^2$, this yields $\\frac{|T|}{|s|} \\le \\frac{\\sigma^2}{t^2}$ — exactly $P(|X-\\mu| \\ge t) \\le \\sigma^2/t^2$ for the uniform distribution on $s$.\n\n**Specialization.** Take $f = \\mathrm{stepsQ}$, the rational-valued Euclidean step count, and $s = \\mathrm{sampleN}\\,N = \\{(a,b) : 1 \\le b \\le a \\le N\\}$ (non-empty for $N \\ge 1$, containing $(1,1)$). The normalized inequality applies verbatim, giving the concentration bound for Euclidean step counts.",
+    "proofStrategy": "`chebyshev_count`: introduce $T = s.\\mathrm{filter}(\\lambda i,\\ t \\le |f i - \\mu|)$; rewrite $|T|\\,t^2 = \\sum_{i\\in T} t^2$ via `Finset.sum_const`; bound termwise with `Finset.sum_le_sum` using the factorization $(|d|-t)(|d|+t)\\ge 0$ closed by `nlinarith [sq_abs, hprod]`; extend from $T$ to $s$ with `Finset.sum_le_sum_of_subset_of_nonneg`. `chebyshev_fraction`: from the counting form, clear denominators with `div_le_div_iff₀` and simplify using $\\sum(f i - \\mu)^2 = |s|\\cdot\\mathrm{empVar}$ and `div_self` on $|s| \\ne 0$. `empVar_nonneg`: `div_nonneg` of a sum of squares by a cardinality. `euclideanSteps_concentration`: direct application of `chebyshev_fraction` to `stepsQ` and `sampleN N`, with non-emptiness from `sampleN_nonempty`.",
+    "keyInsights": [
+      "Chebyshev's inequality is fundamentally a finite, elementary counting statement: it needs no probability measure, only the algebraic fact that squared deviations at distance $\\ge t$ each dominate $t^2$. Working over $\\mathbb{Q}$ keeps every quantity exact.",
+      "The counting form is strictly more general than the textbook statement — the reference value $\\mu$ is arbitrary, not necessarily the mean — which is what makes the extension-from-$T$-to-$s$ step clean and reusable.",
+      "The factorization $|d|^2 - t^2 = (|d|-t)(|d|+t)$ is the whole analytic content: on the deviation set both factors are non-negative, so the squared deviation dominates $t^2$ pointwise.",
+      "Honest scoping matters: this is the rigorous concentration layer beneath Hensley's Gaussian limit, not the limit itself. Formalizing the CLT would require the Gauss–Kuzmin–Wirsing transfer operator's spectral theory, which Mathlib does not have.",
+      "Specializing to a concrete finite universe $\\{(a,b) : 1 \\le b \\le a \\le N\\}$ turns the abstract statistic into an honest empirical random variable, and the same bound holds for any other finite sample by the general lemma."
+    ],
+    "prerequisites": [
+      "GCDAlgorithmOQ01 concept: euclideanSteps (restated here for self-containment)",
+      "Finset.sum_const, Finset.sum_le_sum, Finset.sum_le_sum_of_subset_of_nonneg",
+      "abs and sq_abs over an ordered field; nlinarith",
+      "div_le_div_iff₀, div_self for rational arithmetic"
+    ]
+  },
+  "conclusion": {
+    "summary": "Machine-verifies the finite Chebyshev inequality in both counting and normalized forms for the empirical distribution of a rational-valued statistic over a finite sample, and specializes it to a rigorous concentration bound for Euclidean-algorithm step counts over the sample $\\{(a,b) : 1 \\le b \\le a \\le N\\}$. 7 theorems, 5 definitions, 0 axioms, 166 lines.",
+    "implications": "This is the first, elementary layer of the average-case analysis of the Euclidean algorithm. Chebyshev concentration is exactly the tool that turns a variance estimate (Hensley computed the variance of the step count) into a quantitative statement about how tightly the step count clusters around its mean. The formalization is deliberately honest about the gap to Hensley's central limit theorem, whose proof needs transfer-operator spectral theory outside Mathlib; but the finite Chebyshev inequality proved here is fully general and reusable for the empirical distribution of any rational-valued statistic, well beyond gcd step counts.",
+    "openQuestions": [
+      "Can Dixon's mean asymptotic $\\mathbb{E}[\\text{steps}] \\sim \\frac{12 \\ln 2}{\\pi^2}\\ln N$ be given even a one-sided effective bound in Lean, e.g. an explicit $O(\\ln N)$ upper bound on the empirical mean over $\\mathrm{sampleN}\\,N$?",
+      "Formalize a Bernstein/Bennett-type concentration bound over the same finite sample, sharpening the $\\mathrm{Var}/t^2$ tail to sub-Gaussian decay when higher moments of the step count are controlled.",
+      "Is there an elementary (transfer-operator-free) proof that the empirical variance of $\\mathrm{stepsQ}$ over $\\mathrm{sampleN}\\,N$ grows like $c\\ln N$, capturing the linear-in-$\\ln N$ variance without the full Gauss–Kuzmin–Wirsing machinery?"
+    ]
+  },
+  "leanFile": {
+    "namespace": "GcdAlgorithmOQ01OQ02",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 5,
+    "path": "Proofs/GcdAlgorithmOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "gcd-algorithm-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry analyzing the Euclidean step count euclideanSteps; this file extends that analysis toward the distribution of step counts."
+    },
+    {
+      "targetId": "gcd-algorithm-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Sibling entry (Binet's formula and Lamé's bound) analyzing the worst-case step count via the golden ratio, complementing this average-case/concentration view."
+    },
+    {
+      "targetId": "gcd-algorithm",
+      "relationship": "related",
+      "description": "The base Euclidean GCD algorithm proof whose step-count statistic this entry studies."
+    }
+  ],
+  "sections": [
+    {
+      "id": "section-header",
+      "title": "Overview and Honest Scope",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Imports Nat.Fib, Nat.GCD and Mathlib.Tactic. The docstring frames the target (Hensley's distribution of Euclidean step counts) and states honestly what is proved: the finite Chebyshev inequality and its specialization to step counts, NOT Hensley's Gaussian limit (which needs Gauss–Kuzmin–Wirsing transfer-operator spectral theory absent from Mathlib). All results are sorry-free and axiom-free."
+    },
+    {
+      "id": "section-step-counting",
+      "title": "Euclidean Step Counting",
+      "startLine": 43,
+      "endLine": 64,
+      "summary": "euclideanSteps a b counts division steps by well-founded recursion on b (termination via Nat.mod_lt); euclideanSteps_zero gives the base case. stepsQ p casts the step count of a pair to ℚ, with stepsQ_nonneg by positivity — the rational-valued statistic to which concentration is applied."
+    },
+    {
+      "id": "section-emp-mean-var",
+      "title": "Empirical Mean and Variance",
+      "startLine": 66,
+      "endLine": 86,
+      "summary": "empMean s f = (∑ f i)/|s| and empVar s f = (∑ (f i − empMean s f)²)/|s| model the uniform distribution over a finite sample s with an exact-rational statistic f. empVar_nonneg proves the empirical variance is non-negative via div_nonneg of a sum of squares by the cardinality."
+    },
+    {
+      "id": "section-chebyshev-count",
+      "title": "Chebyshev Inequality: Counting Form",
+      "startLine": 88,
+      "endLine": 121,
+      "summary": "chebyshev_count: for any reference value μ and threshold t > 0, (#{i ∈ s : t ≤ |f i − μ|})·t² ≤ ∑_{i∈s}(f i − μ)². Proof: on the deviation set T each squared deviation dominates t² via the factorization (|d|−t)(|d|+t) ≥ 0 closed by nlinarith; the bound extends from T to s because the extra terms are non-negative."
+    },
+    {
+      "id": "section-chebyshev-fraction",
+      "title": "Chebyshev Inequality: Normalized Fraction Form",
+      "startLine": 123,
+      "endLine": 136,
+      "summary": "chebyshev_fraction: for a non-empty sample, the fraction of points whose statistic deviates from the empirical mean by at least t is at most empVar/t² — the classical P(|X − μ| ≥ t) ≤ σ²/t². Derived from chebyshev_count by clearing denominators (div_le_div_iff₀) and simplifying ∑(f i − μ)² = |s|·empVar with div_self."
+    },
+    {
+      "id": "section-specialization",
+      "title": "Specialization to Euclidean Step Counts",
+      "startLine": 138,
+      "endLine": 166,
+      "summary": "sampleN N = {(a,b) : 1 ≤ b ≤ a ≤ N} is the canonical finite universe of input pairs, non-empty for N ≥ 1 (contains (1,1), sampleN_nonempty). euclideanSteps_concentration applies chebyshev_fraction to stepsQ over sampleN N, yielding the rigorous concentration bound: the fraction of pairs whose step count deviates from the empirical mean by ≥ t is at most Var/t²."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/gcd-algorithm-oq-01-oq-02.json
+++ b/src/data/research/problems/gcd-algorithm-oq-01-oq-02.json
@@ -1,0 +1,76 @@
+{
+  "slug": "gcd-algorithm-oq-01-oq-02",
+  "title": "Distribution of Euclidean-algorithm step counts: a finite Chebyshev concentration layer",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall\\, s\\ \\text{finite},\\ f:\\iota\\to\\mathbb{Q},\\ t>0:\\quad \\frac{\\#\\{i\\in s: t\\le|f(i)-\\bar f|\\}}{|s|}\\ \\le\\ \\frac{\\operatorname{Var}(f)}{t^2},\\ \\text{specialized to } f=\\text{stepsQ over }\\{(a,b):1\\le b\\le a\\le N\\}.",
+    "plain": "IN-PROGRESS: What is the full distribution of step counts of the Euclidean algorithm? Hensley (1994) computed the variance and proved a Gaussian limit; can the limiting distribution be formalized? First rigorous layer: the finite Chebyshev inequality for the empirical distribution of a rational-valued statistic over a finite sample, specialized to the Euclidean step count over pairs 1 ≤ b ≤ a ≤ N.",
+    "whyMatters": [
+      "Average-case complexity of the Euclidean algorithm",
+      "Rigorous concentration scaffolding underlying any distributional limit law"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": "SOLVED-LAYER (0 axioms, 0 sorries): finite Chebyshev inequality proved in counting and normalized forms and specialized to euclideanSteps over the canonical sample. This is the elementary concentration layer; Hensley's Gaussian limit (Gauss–Kuzmin–Wirsing transfer-operator spectral theory) remains out of Mathlib reach.",
+  "knowledge": {
+    "progressSummary": "COMPLETE (concentration layer): the finite Chebyshev inequality for empirical distributions is formalized and specialized to Euclidean step counts, giving a rigorous Var/t² concentration bound. Honest gap to Hensley's CLT documented.",
+    "builtItems": [
+      "euclideanSteps / stepsQ / stepsQ_nonneg (GcdAlgorithmOQ01OQ02.lean:51,61,63) — rational-valued step-count statistic",
+      "empMean / empVar / empVar_nonneg (GcdAlgorithmOQ01OQ02.lean:74,78,82) — exact-rational empirical moments over a finite sample",
+      "chebyshev_count (GcdAlgorithmOQ01OQ02.lean:99) — counting-form Chebyshev with arbitrary reference μ",
+      "chebyshev_fraction (GcdAlgorithmOQ01OQ02.lean:126) — normalized P(|X−μ|≥t) ≤ σ²/t² over a uniform finite sample",
+      "sampleN / sampleN_nonempty / euclideanSteps_concentration (GcdAlgorithmOQ01OQ02.lean:147,151,160) — specialization to {(a,b):1≤b≤a≤N}"
+    ],
+    "insights": [
+      "Chebyshev's inequality needs no measure theory: over a Finset with uniform weights it is a purely algebraic counting statement, provable entirely over ℚ with exact arithmetic.",
+      "Stating the counting form with an ARBITRARY reference value μ (not forced to be the mean) is what makes the extension from the deviation set T to the whole sample s clean and reusable.",
+      "The single analytic fact is the factorization |d|² − t² = (|d|−t)(|d|+t) ≥ 0 on the deviation set, closed by nlinarith with sq_abs.",
+      "Hensley's Gaussian limit is out of reach: its proof needs the Gauss–Kuzmin–Wirsing transfer operator's spectral theory, absent from Mathlib. The honest deliverable is the concentration layer, not the CLT."
+    ],
+    "mathlibGaps": [
+      "No transfer-operator (Gauss–Kuzmin–Wirsing) spectral theory in Mathlib, blocking Hensley's central limit theorem for continued-fraction / Euclidean step counts.",
+      "No general finite/empirical Chebyshev inequality over a Finset with a uniform measure was found in Mathlib at the time of writing (built locally here)."
+    ],
+    "nextSteps": [
+      "Give an explicit one-sided O(ln N) upper bound on the empirical mean of stepsQ over sampleN N (toward Dixon's mean asymptotic).",
+      "Prove a Bernstein/Bennett-type tail sharpening the Var/t² bound under higher-moment control.",
+      "Investigate an elementary c·ln N lower bound on the empirical variance without transfer-operator machinery."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "euclidean-algorithm",
+    "probability",
+    "chebyshev-inequality",
+    "concentration"
+  ],
+  "relatedProofs": [
+    "gcd-algorithm",
+    "gcd-algorithm-oq-01",
+    "gcd-algorithm-oq-01-oq-01",
+    "gcd-algorithm-oq-01-oq-03",
+    "gcd-algorithm-oq-01-oq-04"
+  ],
+  "references": {
+    "papers": [
+      "J. D. Dixon, The number of steps in the Euclidean algorithm, J. Number Theory 2 (1970) 414–422.",
+      "D. Hensley, The number of steps in the Euclidean algorithm, J. Number Theory 49 (1994) 142–182."
+    ],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-01T20:55:00.000Z",
+  "lastUpdate": "2026-07-01",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    "proofs/Proofs/GcdAlgorithmOQ01OQ02.lean"
+  ]
+}


### PR DESCRIPTION
## Summary
New gallery entry **gcd-algorithm-oq-01-oq-02** — *Concentration of Euclidean Step Counts: a Finite Chebyshev Inequality*.

Answers the in-progress open question "what is the full distribution of step counts of the Euclidean algorithm? Hensley (1994) computed the variance; can the limiting distribution be formalized?" at the rigorous-scaffolding level.

This rescues a **verified but never-committed orphan** (`proofs/Proofs/GcdAlgorithmOQ01OQ02.lean`, left untracked in the shared tree ~6h earlier and abandoned) and ships it as a full gallery entry.

## What is proved (honest scope)
- `chebyshev_count` — finite/uniform-measure Chebyshev inequality, **counting form**: for any reference μ and threshold t>0, `(#{i : t ≤ |f i − μ|})·t² ≤ ∑ (f i − μ)²`.
- `chebyshev_fraction` — **normalized form**: the fraction of points deviating from the empirical mean by ≥ t is at most `empVar/t²` (the classical P(|X−μ|≥t) ≤ σ²/t²).
- `empVar_nonneg`, `empMean`/`empVar` — exact-rational empirical moments over a finite sample.
- `euclideanSteps_concentration` — specialization to `euclideanSteps` over the sample {(a,b) : 1 ≤ b ≤ a ≤ N}.

It does **NOT** prove Hensley's Gaussian limit law (requires Gauss–Kuzmin–Wirsing transfer-operator spectral theory, absent from Mathlib) — the docstring and meta.json state this explicitly.

## Verification
- Machine-checked with host `lake env lean` (rc=0, no errors/warnings).
- **0 axioms**: `#print axioms` on all key theorems shows only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- 0 sorries. 7 theorems, 5 definitions, 166 lines.

## Files
- `proofs/Proofs/GcdAlgorithmOQ01OQ02.lean`
- `src/data/proofs/gcd-algorithm-oq-01-oq-02/{meta.json,annotations.json}`
- `src/data/research/problems/gcd-algorithm-oq-01-oq-02.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)