### PR TITLE
research(gauss-wilson-non-cyclic-oq-04): count square roots of unity mod n — odd case N(n)=2^ω(n)

### DIFF
--- a/proofs/Proofs/GaussWilsonNonCyclicOQ04.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ04.lean
@@ -1,0 +1,182 @@
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Nat.Factorization.Induction
+import Mathlib.RingTheory.PrincipalIdealDomain
+import Mathlib.RingTheory.Int.Basic
+import Mathlib.SetTheory.Cardinal.Finite
+import Mathlib.Tactic
+
+/-
+# Counting the square roots of unity modulo `n` (odd case)
+
+For a modulus `n`, let `N(n) = #{x : ZMod n | x² = 1}` be the number of square roots
+of unity.  This file proves, for **odd** `n`, the exact count
+
+$$N(n) = 2^{\omega(n)},$$
+
+where `ω(n) = n.primeFactors.card` is the number of distinct prime factors of `n`.
+
+This is the odd-modulus half of `gauss-wilson-non-cyclic` openQuestions[2], which asks for
+`N(n) = 2^{ω_odd(n) + δ}` with a 2-adic correction `δ ∈ {0,1,2}`.  For odd `n` we have
+`δ = 0` and `ω_odd(n) = ω(n)`, and this is the case treated here.  The full even case is
+left as a follow-up.
+
+## Strategy
+
+1. **Local count at an odd prime power** (`sq_eq_one_iff_prime_pow`, `sqrtOneCount_prime_pow`).
+   In `ZMod (p^k)` with `p` an odd prime, `x² = 1 ↔ x = 1 ∨ x = -1`.  The forward direction
+   is elementary: lifting `x` to an integer `a`, `p^k ∣ (a-1)(a+1)`; since `p` is odd it cannot
+   divide both `a-1` and `a+1` (their difference is `2`), so `p^k` divides one of them.
+   As `1 ≠ -1` (because `p^k ≥ 3`), this gives exactly two roots.
+
+2. **Multiplicativity via CRT** (`sqrtOneCount_mul`).  For coprime `m, n` the ring isomorphism
+   `ZMod (m*n) ≃+* ZMod m × ZMod n` (`ZMod.chineseRemainder`) transports `x² = 1` componentwise,
+   so `N(m*n) = N(m) · N(n)`.
+
+3. **Assembly** (`sqrtOneCount_odd`).  `N` is multiplicative with `N(1) = 1`, so by
+   `Nat.multiplicative_factorization`, `N(n) = ∏_{p^k ‖ n} N(p^k)`.  For odd `n` every prime is
+   odd, each factor is `2`, and the product is `2^{ω(n)}`.
+-/
+
+namespace GaussWilsonSqrtCount
+
+open scoped Classical
+open Finset
+
+/-- The number of square roots of unity modulo `n`, i.e. `#{x : ZMod n | x² = 1}`. -/
+noncomputable def sqrtOneCount (n : ℕ) : ℕ := Nat.card {x : ZMod n // x ^ 2 = 1}
+
+/-- `sqrtOneCount 1 = 1`: modulo `1` everything collapses to a point. -/
+theorem sqrtOneCount_one : sqrtOneCount 1 = 1 := by
+  rw [sqrtOneCount]
+  have : Subsingleton {x : ZMod 1 // x ^ 2 = 1} := by
+    constructor; intro a b; apply Subtype.ext; apply Subsingleton.elim
+  have hne : Nonempty {x : ZMod 1 // x ^ 2 = 1} := ⟨⟨1, one_pow 2⟩⟩
+  rw [Nat.card_eq_one_iff_unique]
+  exact ⟨this, hne⟩
+
+/-- **Odd prime power, local classification.**  In `ZMod (p^k)` with `p` an odd prime and
+`k ≥ 1`, the only square roots of unity are `1` and `-1`. -/
+theorem sq_eq_one_iff_prime_pow {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) {k : ℕ} (_hk : k ≠ 0)
+    (x : ZMod (p ^ k)) : x ^ 2 = 1 ↔ x = 1 ∨ x = -1 := by
+  haveI : NeZero (p ^ k) := ⟨pow_ne_zero k hp.pos.ne'⟩
+  constructor
+  · intro hx
+    -- Integer lift `a` of `x`.
+    set a : ℤ := (x.val : ℤ) with ha
+    have hxa : ((a : ℤ) : ZMod (p ^ k)) = x := by
+      rw [ha]; push_cast; rw [ZMod.natCast_zmod_val]
+    -- `(p^k : ℤ) ∣ (a-1)(a+1)`.
+    have hpk_cast : ((p ^ k : ℕ) : ℤ) = (p : ℤ) ^ k := by push_cast; ring
+    have hdvd : ((p : ℤ) ^ k) ∣ (a - 1) * (a + 1) := by
+      have hx0 : (x - 1) * (x + 1) = 0 := by linear_combination hx
+      have hz : (((a - 1) * (a + 1) : ℤ) : ZMod (p ^ k)) = 0 := by
+        push_cast; rw [hxa]; exact hx0
+      have := (ZMod.intCast_zmod_eq_zero_iff_dvd ((a - 1) * (a + 1)) (p ^ k)).mp hz
+      rwa [hpk_cast] at this
+    have hp_int : Prime (p : ℤ) := Nat.prime_iff_prime_int.mp hp
+    -- `p ∤ 2`.
+    have hp_not2 : ¬ (p : ℤ) ∣ (2 : ℤ) := by
+      intro h
+      have h2 : p ∣ 2 := by
+        have : (p : ℤ) ∣ ((2 : ℕ) : ℤ) := by exact_mod_cast h
+        exact_mod_cast (Int.natCast_dvd_natCast.mp this)
+      exact hp2 ((Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp h2)
+    by_cases hL : (p : ℤ) ∣ (a - 1)
+    · by_cases hR : (p : ℤ) ∣ (a + 1)
+      · exact absurd (by simpa using dvd_sub hR hL) hp_not2
+      · left
+        have hco : IsCoprime ((p : ℤ) ^ k) (a + 1) :=
+          (hp_int.coprime_iff_not_dvd.mpr hR).pow_left
+        have hdvd1 : ((p : ℤ) ^ k) ∣ (a - 1) := hco.dvd_of_dvd_mul_right hdvd
+        have hz1 : ((a - 1 : ℤ) : ZMod (p ^ k)) = 0 := by
+          rw [ZMod.intCast_zmod_eq_zero_iff_dvd, hpk_cast]; exact hdvd1
+        have : x - 1 = 0 := by push_cast at hz1; rwa [hxa] at hz1
+        exact sub_eq_zero.mp this
+    · right
+      have hco : IsCoprime ((p : ℤ) ^ k) (a - 1) :=
+        (hp_int.coprime_iff_not_dvd.mpr hL).pow_left
+      have hdvd2 : ((p : ℤ) ^ k) ∣ (a + 1) := hco.dvd_of_dvd_mul_left hdvd
+      have hz2 : ((a + 1 : ℤ) : ZMod (p ^ k)) = 0 := by
+        rw [ZMod.intCast_zmod_eq_zero_iff_dvd, hpk_cast]; exact hdvd2
+      have : x + 1 = 0 := by push_cast at hz2; rwa [hxa] at hz2
+      exact eq_neg_of_add_eq_zero_left this
+  · rintro (rfl | rfl) <;> ring
+
+/-- `1 ≠ -1` in `ZMod (p^k)` for an odd prime power (since the modulus is `≥ 3`). -/
+theorem one_ne_neg_one_prime_pow {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) {k : ℕ} (hk : k ≠ 0) :
+    (1 : ZMod (p ^ k)) ≠ -1 := by
+  haveI : NeZero (p ^ k) := ⟨pow_ne_zero k hp.pos.ne'⟩
+  have hp3 : 3 ≤ p := by have := hp.two_le; omega
+  have hpk3 : 3 ≤ p ^ k := le_trans hp3 (Nat.le_self_pow hk p)
+  intro h
+  have h2 : (2 : ZMod (p ^ k)) = 0 := by linear_combination h
+  have h2n : ((2 : ℕ) : ZMod (p ^ k)) = 0 := by exact_mod_cast h2
+  have hdvd : p ^ k ∣ 2 := (ZMod.natCast_eq_zero_iff 2 (p ^ k)).mp h2n
+  have := Nat.le_of_dvd (by norm_num) hdvd
+  omega
+
+/-- **Odd prime power count.**  `#{x : ZMod (p^k) | x² = 1} = 2` for an odd prime power. -/
+theorem sqrtOneCount_prime_pow {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) {k : ℕ} (hk : k ≠ 0) :
+    sqrtOneCount (p ^ k) = 2 := by
+  haveI : NeZero (p ^ k) := ⟨pow_ne_zero k hp.pos.ne'⟩
+  rw [sqrtOneCount, Nat.card_eq_fintype_card, Fintype.card_subtype]
+  have hset : (univ.filter (fun x : ZMod (p ^ k) => x ^ 2 = 1)) = {1, -1} := by
+    ext x
+    simp only [mem_filter, mem_univ, true_and, mem_insert, mem_singleton]
+    exact sq_eq_one_iff_prime_pow hp hp2 hk x
+  rw [hset, Finset.card_pair (one_ne_neg_one_prime_pow hp hp2 hk)]
+
+/-- **Multiplicativity via CRT.**  For coprime `m, n`, the count of square roots of unity is
+multiplicative. -/
+theorem sqrtOneCount_mul {m n : ℕ} (h : m.Coprime n) :
+    sqrtOneCount (m * n) = sqrtOneCount m * sqrtOneCount n := by
+  rw [sqrtOneCount, sqrtOneCount, sqrtOneCount, ← Nat.card_prod]
+  refine Nat.card_congr ?_
+  -- CRT ring isomorphism.
+  let e := ZMod.chineseRemainder h
+  -- Step 1: transport the predicate `x² = 1` across `e`.
+  have e1 : {x : ZMod (m * n) // x ^ 2 = 1} ≃ {x : ZMod m × ZMod n // x ^ 2 = 1} :=
+    Equiv.subtypeEquiv e.toEquiv (by
+      intro x
+      constructor
+      · intro hx
+        have : e (x ^ 2) = e 1 := by rw [hx]
+        rwa [map_pow, map_one] at this
+      · intro hx
+        have hx' : e (x ^ 2) = e 1 := by rw [map_pow, map_one]; exact hx
+        exact e.injective hx')
+  -- Step 2: split the product predicate componentwise.
+  have e2 : {x : ZMod m × ZMod n // x ^ 2 = 1} ≃
+      {a : ZMod m // a ^ 2 = 1} × {b : ZMod n // b ^ 2 = 1} := by
+    refine (Equiv.subtypeEquivRight ?_).trans (Equiv.subtypeProdEquivProd)
+    intro x
+    rw [Prod.pow_def, Prod.ext_iff]
+    simp [Prod.one_eq_mk]
+  exact e1.trans e2
+
+/-- **Main theorem (odd case).**  For odd `n`, the number of square roots of unity modulo `n`
+is `2^{ω(n)}`, where `ω(n)` is the number of distinct prime factors of `n`. -/
+theorem sqrtOneCount_odd {n : ℕ} (hn : Odd n) :
+    sqrtOneCount n = 2 ^ n.primeFactors.card := by
+  have hn0 : n ≠ 0 := by rintro rfl; rw [Nat.odd_iff] at hn; omega
+  rw [Nat.multiplicative_factorization sqrtOneCount
+        (fun x y hxy => sqrtOneCount_mul hxy) sqrtOneCount_one hn0]
+  calc n.factorization.prod (fun p k => sqrtOneCount (p ^ k))
+      = ∏ p ∈ n.factorization.support, 2 := by
+        rw [Finsupp.prod]
+        refine Finset.prod_congr rfl (fun p hp => ?_)
+        rw [Nat.support_factorization] at hp
+        have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+        have hpdvd : p ∣ n := Nat.dvd_of_mem_primeFactors hp
+        have hk : n.factorization p ≠ 0 := by
+          have : p ∈ n.factorization.support := by rwa [Nat.support_factorization]
+          rwa [Finsupp.mem_support_iff] at this
+        have hp2 : p ≠ 2 := by
+          rintro rfl
+          rw [Nat.odd_iff] at hn
+          omega
+        exact sqrtOneCount_prime_pow hpp hp2 hk
+    _ = 2 ^ n.factorization.support.card := by rw [Finset.prod_const]
+    _ = 2 ^ n.primeFactors.card := by rw [Nat.support_factorization]
+
+end GaussWilsonSqrtCount

--- a/src/data/proofs/gauss-wilson-non-cyclic-oq-04/annotations.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic-oq-04/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-gw-oq04-count-def",
+    "proofId": "gauss-wilson-non-cyclic-oq-04",
+    "range": { "startLine": 45, "endLine": 46 },
+    "type": "concept",
+    "title": "The Square-Root-of-Unity Count N(n)",
+    "content": "sqrtOneCount n = Nat.card {x : ZMod n // x² = 1} is the number of solutions of x² = 1 modulo n. A root of x² = 1 is automatically a unit (its own inverse), so this counts the 2-torsion of (ZMod n)ˣ — exactly the object the parent entry studies — while working in the ring ZMod n, which is what lets the Chinese Remainder Theorem act on it directly. It is declared noncomputable because Nat.card is defined via cardinality, not by a decidable enumeration.",
+    "mathContext": "For finite n the set {x : x² = 1} is the fibre over 1 of the squaring map on units. Over a field it has ≤ 2 elements; over ZMod n it can be larger because ZMod n has zero divisors, and its size is the arithmetic function computed here.",
+    "significance": "foundational",
+    "relatedConcepts": ["roots of unity", "2-torsion subgroup", "arithmetic function"],
+    "prerequisites": ["Nat.card", "ZMod"]
+  },
+  {
+    "id": "ann-gw-oq04-local-classification",
+    "proofId": "gauss-wilson-non-cyclic-oq-04",
+    "range": { "startLine": 57, "endLine": 103 },
+    "type": "key-step",
+    "title": "Odd Prime Power: Only ±1 Are Square Roots of Unity",
+    "content": "In ZMod (p^k) with p an odd prime, x² = 1 ↔ x = 1 ∨ x = -1. The proof is elementary and avoids cyclic-group theory: lift x to an integer a, so p^k ∣ (a-1)(a+1). Since p is odd it cannot divide both a-1 and a+1 (their difference is 2), so p is coprime to one factor; then IsCoprime.pow_left and IsCoprime.dvd_of_dvd_mul make p^k divide the other, forcing a ≡ 1 or a ≡ -1 (mod p^k). The reverse direction is a one-line ring computation.",
+    "mathContext": "This is the statement that the ring ZMod (p^k) has no nontrivial square roots of unity for odd p — equivalently the 2-torsion of (ZMod (p^k))ˣ is {±1}. It fails for p = 2 (e.g. ZMod 8 has four square roots of unity: 1, 3, 5, 7), which is exactly the source of the 2-adic correction δ in the full formula.",
+    "significance": "central",
+    "relatedConcepts": ["coprimality", "Chinese Remainder Theorem", "cyclic units"],
+    "prerequisites": ["Prime.coprime_iff_not_dvd", "IsCoprime.dvd_of_dvd_mul_right", "ZMod.intCast_zmod_eq_zero_iff_dvd"]
+  },
+  {
+    "id": "ann-gw-oq04-local-count",
+    "proofId": "gauss-wilson-non-cyclic-oq-04",
+    "range": { "startLine": 118, "endLine": 127 },
+    "type": "key-step",
+    "title": "Local Count N(p^k) = 2",
+    "content": "Combining the ±1 classification with 1 ≠ -1 (which holds because the odd prime power p^k ≥ 3, proved in one_ne_neg_one_prime_pow via p^k ∤ 2), the filtered set {x : x² = 1} equals the two-element Finset {1, -1}. Finset.card_pair then gives N(p^k) = 2.",
+    "mathContext": "Every odd prime contributes exactly a factor of 2 to the count — the two square roots ±1. This is the per-prime input to the multiplicative assembly.",
+    "significance": "central",
+    "relatedConcepts": ["Finset.card_pair", "two-element set"],
+    "prerequisites": ["Fintype.card_subtype", "Finset.card_pair"]
+  },
+  {
+    "id": "ann-gw-oq04-crt-multiplicative",
+    "proofId": "gauss-wilson-non-cyclic-oq-04",
+    "range": { "startLine": 129, "endLine": 155 },
+    "type": "key-step",
+    "title": "Multiplicativity via the Chinese Remainder Theorem",
+    "content": "For coprime m, n, N(m·n) = N(m)·N(n). The CRT ring isomorphism e : ZMod (m·n) ≃+* ZMod m × ZMod n transports x² = 1 across e (using map_pow and injectivity), so {x : ZMod (m·n) // x²=1} ≃ {p : ZMod m × ZMod n // p²=1}. Since (a,b)² = 1 ↔ a²=1 ∧ b²=1, Equiv.subtypeProdEquivProd splits this into a product of the two local solution sets, and Nat.card_prod delivers the product formula.",
+    "mathContext": "This is the arithmetic-function multiplicativity of N: it is the exact statement that solving x² = 1 mod m·n is independent solving mod m and mod n when gcd(m,n) = 1. It reduces the global count to prime-power counts.",
+    "significance": "central",
+    "relatedConcepts": ["Chinese Remainder Theorem", "multiplicative function", "product of subtypes"],
+    "prerequisites": ["ZMod.chineseRemainder", "Equiv.subtypeProdEquivProd", "Nat.card_prod"]
+  },
+  {
+    "id": "ann-gw-oq04-main-assembly",
+    "proofId": "gauss-wilson-non-cyclic-oq-04",
+    "range": { "startLine": 157, "endLine": 181 },
+    "type": "key-step",
+    "title": "Assembly: N(n) = 2^ω(n) for Odd n",
+    "content": "N is multiplicative with N(1) = 1, so Nat.multiplicative_factorization writes N(n) as the product of N(p^k) over the prime factorization of n. For odd n every prime factor p is odd (p = 2 would make n even, contradicting Odd n — dispatched by omega on n % 2), so each factor is 2, and Finset.prod_const collapses the product to 2^(number of distinct prime factors) = 2^ω(n), where ω(n) = n.primeFactors.card.",
+    "mathContext": "The identity N(n) = 2^ω(n) is the classical count of square roots of unity modulo an odd n. Setting δ = 0 in the parent's conjectured 2^(ω_odd(n)+δ), this is exactly the odd-modulus case; the even case adds the 2-adic contribution from the prime 2.",
+    "significance": "central",
+    "relatedConcepts": ["multiplicative functions", "prime factorization", "omega function"],
+    "prerequisites": ["Nat.multiplicative_factorization", "Finset.prod_const", "Nat.support_factorization"]
+  }
+]

--- a/src/data/proofs/gauss-wilson-non-cyclic-oq-04/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic-oq-04/meta.json
@@ -1,0 +1,73 @@
+{
+  "slug": "gauss-wilson-non-cyclic-oq-04",
+  "id": "gauss-wilson-non-cyclic-oq-04",
+  "title": "Counting Square Roots of Unity mod n: the Odd Case 2^ω(n)",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GaussWilsonNonCyclicOQ04.lean",
+    "tags": [
+      "number-theory",
+      "zmod",
+      "chinese-remainder-theorem",
+      "prime-factorization",
+      "multiplicative-functions",
+      "wilson-gauss"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 177,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "assumptions": "None. Fully machine-verified from Mathlib.",
+    "originalContributions": [
+      "sqrtOneCount: the counting function N(n) = #{x : ZMod n | x² = 1}, the number of square roots of unity modulo n",
+      "sq_eq_one_iff_prime_pow: elementary local classification — in ZMod (p^k) with p an odd prime, x² = 1 ↔ x = 1 ∨ x = -1, proved via the coprimality of (a-1) and (a+1) rather than cyclic-group structure",
+      "sqrtOneCount_prime_pow: the local count N(p^k) = 2 for every odd prime power",
+      "sqrtOneCount_mul: multiplicativity N(m·n) = N(m)·N(n) for coprime m, n, transported across the CRT ring isomorphism ZMod (m·n) ≃+* ZMod m × ZMod n",
+      "sqrtOneCount_odd: the headline result — for odd n, N(n) = 2^ω(n) where ω(n) = n.primeFactors.card, assembled from multiplicativity via Nat.multiplicative_factorization"
+    ]
+  },
+  "leanFile": {
+    "namespace": "GaussWilsonSqrtCount",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/GaussWilsonNonCyclicOQ04.lean",
+    "sorries": 0
+  },
+  "description": "Counts the square roots of unity modulo an odd n. For N(n) = #{x : ZMod n | x² = 1}, proves N(n) = 2^ω(n), where ω(n) is the number of distinct prime factors. The argument is elementary and structural: at each odd prime power p^k the only solutions of x² = 1 are ±1 (because p, being odd, cannot divide both x−1 and x+1), giving N(p^k) = 2; the Chinese Remainder Theorem makes N multiplicative; and Nat.multiplicative_factorization assembles the product 2·2·…·2 = 2^ω(n) over the distinct primes.",
+  "overview": {
+    "problem": "The parent entry studies the 2-torsion of (ZMod n)ˣ — the square roots of unity. Its open question asks for the exact count N(n) = #{x : x² = 1} in the form 2^(ω_odd(n) + δ), where ω_odd counts odd prime factors and δ ∈ {0,1,2} is a 2-adic correction. This entry resolves the odd-modulus case, where δ = 0 and ω_odd(n) = ω(n).",
+    "approach": "Work with roots of unity in the ring ZMod n (a root of x²=1 is automatically a unit, so this counts the same set). Three steps: (1) a self-contained elementary proof that ZMod (p^k) has exactly the two square roots ±1 for odd p; (2) CRT transports x²=1 componentwise, so N is multiplicative on coprime arguments; (3) the standard multiplicative-function factorization collapses the product over the prime factorization to 2^ω(n).",
+    "significance": "Gives a fully verified, axiom-free count for the odd case using an elementary coprimality argument rather than the cyclic-group machinery of the parent, and packages N as a genuine multiplicative arithmetic function. It isolates exactly what the 2-adic prime contributes (the δ correction) by removing it."
+  },
+  "conclusion": {
+    "summary": "For odd n, the number of square roots of unity modulo n is exactly 2^ω(n), where ω(n) = n.primeFactors.card. 177 lines, 6 theorems, 1 definition, 0 sorries, 0 axioms. The count N is built as a multiplicative arithmetic function: N(p^k) = 2 at every odd prime power (elementary ±1 classification), N is multiplicative via the Chinese Remainder Theorem, and Nat.multiplicative_factorization assembles 2^ω(n).",
+    "implications": "This is the δ = 0 slice of the parent's open question 2^(ω_odd(n)+δ). By handling the odd case with a clean elementary argument, it makes precise that all of the non-2^ω behavior in the general formula is 2-adic in origin: the factor of 2, 4 (Klein four-group) refinements only appear from the prime 2. The multiplicative packaging also directly recovers classical facts such as N(n) = 2 iff n is 1, 2, or an odd prime power times at most one factor of 2.",
+    "openQuestions": [
+      "The 2-adic completion: extend to all n by computing N(2^k) = 1, 2, 4 for k = 1, 2, ≥3 (the Klein four-group (ZMod 2^k)ˣ[2] for k ≥ 3) and combining with the odd part to obtain the full 2^(ω_odd(n)+δ) formula.",
+      "The dual Gauss–Wilson product: relate N(n) to the value of the product of all units of ZMod n (the generalized Wilson theorem), whose sign is governed by whether N(n) = 2."
+    ]
+  },
+  "sections": [],
+  "references": [
+    {
+      "title": "Gauss's generalization of Wilson's theorem",
+      "type": "textbook",
+      "note": "The structure of (ZMod n)ˣ and its 2-torsion underlies the count of square roots of unity."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gauss-wilson-non-cyclic",
+      "relationship": "extends",
+      "description": "Parent. Resolves the odd-modulus case of its open question on the exact number of square roots of unity, N(n) = 2^(ω_odd(n)+δ), by proving the δ = 0 formula N(n) = 2^ω(n)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the **odd-modulus case** of `gauss-wilson-non-cyclic` openQuestions[2], which asks for the exact number of square roots of unity `N(n) = #{x : ZMod n | x² = 1}` in the form `2^(ω_odd(n) + δ)` with a 2-adic correction `δ ∈ {0,1,2}`. For **odd** `n`, `δ = 0` and `ω_odd(n) = ω(n)`, and this entry proves

```
N(n) = 2^ω(n)     (n odd),   ω(n) = n.primeFactors.card.
```

## Proof structure (elementary, 0-axiom)

1. **Local classification** (`sq_eq_one_iff_prime_pow`): in `ZMod (p^k)` with `p` an odd prime, `x² = 1 ↔ x = 1 ∨ x = -1`. Lift `x` to an integer `a`; then `p^k ∣ (a-1)(a+1)`, and since `p` is odd it cannot divide both factors (their difference is `2`), so `p^k` divides one of them. No cyclic-group theory needed.
2. **Local count** (`sqrtOneCount_prime_pow`): `N(p^k) = 2` (the two roots `±1`, distinct since `p^k ≥ 3`).
3. **Multiplicativity** (`sqrtOneCount_mul`): the CRT ring isomorphism `ZMod (m·n) ≃+* ZMod m × ZMod n` transports `x²=1` componentwise, so `N(m·n) = N(m)·N(n)` for coprime `m, n`.
4. **Assembly** (`sqrtOneCount_odd`): `Nat.multiplicative_factorization` collapses the product `2·2·…·2` over the distinct odd primes to `2^ω(n)`.

## Verification

- **0 sorries, 0 axioms** (no `sorry`/`native_decide`/`axiom`; only standard Mathlib lemmas).
- Compiles clean via `lake env lean` (no errors, no warnings).
- 6 theorems, 1 definition, 182 lines. New gallery entry with `meta.json` + 5 annotations.

## Follow-up

The full even case (computing `N(2^k) = 1, 2, 4` for `k = 1, 2, ≥3` — the Klein four-group `(ZMod 2^k)ˣ[2]` — and combining with the odd part) is registered as the entry's open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)