### PR TITLE
enrich(angle-trisection-oq-02-oq-03-oq-03): cover Sections I/V + setup decls (5→10 anns)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-03/annotations.json
@@ -1,62 +1,232 @@
 [
   {
+    "id": "ann-fermat-prime-17",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-03",
+    "range": {
+      "startLine": 55,
+      "endLine": 63
+    },
+    "type": "concept",
+    "title": "17 is a Fermat Prime: φ(17) = 2⁴",
+    "content": "The arithmetic precondition for Gauss's construction. `seventeen_prime` (17 is prime) and `seventeen_fermat` exhibit 17 = 2^(2²) + 1, the Fermat prime with k = 2. Consequently `totient_17` gives φ(17) = 16 and `totient_17_pow2` records the crucial refinement φ(17) = 2⁴ — a *power of two*. By the Gauss–Wantzel criterion this is exactly what makes the regular 17-gon straightedge-and-compass constructible: the degree [ℚ(ζ₁₇):ℚ] = φ(17) is a power of 2, so the cyclotomic field is reachable by a tower of quadratic extensions.",
+    "mathContext": "$17 = 2^{2^2}+1$ is a Fermat prime and $\\varphi(17)=16=2^4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fermat prime",
+      "Euler totient",
+      "Gauss–Wantzel theorem",
+      "Constructible polygon"
+    ],
+    "prerequisites": [
+      "Nat.Prime",
+      "Nat.totient",
+      "decide"
+    ]
+  },
+  {
+    "id": "ann-order-determining-powers",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-03",
+    "range": {
+      "startLine": 73,
+      "endLine": 77
+    },
+    "type": "insight",
+    "title": "The Two Order-Determining Powers: 3¹⁶ = 1 and 3⁸ = −1",
+    "content": "These two decidable facts are the entire input to the primitive-root proof. `three_pow_16` (3¹⁶ ≡ 1) is Fermat's little theorem for p = 17 and forces orderOf(3) ∣ 16. `three_pow_8` (3⁸ ≡ 16 ≡ −1) is the non-vanishing witness at the unique maximal proper divisor 16/2 = 8: because −1 ≠ 1, the order cannot be 8 or any divisor of 8, pinning it at the full 16. Note 3⁸ = −1 also says 3 is a quadratic *non*-residue mod 17, which is why its even/odd powers cleanly separate the residues from the non-residues in Section IV.",
+    "mathContext": "$3^{16}\\equiv1$ and $3^{8}\\equiv-1\\pmod{17}$; the latter is the $16/2$ witness.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Fermat's little theorem",
+      "Order of an element",
+      "Quadratic non-residue"
+    ],
+    "prerequisites": [
+      "ZMod 17",
+      "decide"
+    ]
+  },
+  {
     "id": "ann-primitive-root",
     "proofId": "angle-trisection-oq-02-oq-03-oq-03",
-    "range": { "startLine": 78, "endLine": 93 },
+    "range": {
+      "startLine": 83,
+      "endLine": 91
+    },
     "type": "concept",
     "title": "3 is a Primitive Root mod 17",
     "content": "The unit group (ℤ/17ℤ)ˣ is cyclic of order 16, and `3` generates it: `three_orderOf` proves orderOf (3 : ZMod 17) = 16. The argument is the standard order test — 3¹⁶ = 1 by Fermat, and since 16 = 2⁴ has 2 as its only prime factor, it suffices that 3^(16/2) = 3⁸ = 16 = -1 ≠ 1. Gauss used exactly the powers of a primitive root to order the vertices of the polygon.",
     "mathContext": "$\\mathrm{ord}_{17}(3) = 16$, so $\\langle 3\\rangle = (\\mathbb{Z}/17\\mathbb{Z})^\\times$.",
     "significance": "key",
-    "relatedConcepts": ["Primitive root", "Cyclic group", "Order of an element", "Fermat's little theorem"],
-    "prerequisites": ["multiplicative group of ZMod p", "orderOf_eq_of_pow_and_pow_div_prime"]
+    "relatedConcepts": [
+      "Primitive root",
+      "Cyclic group",
+      "Order of an element",
+      "Fermat's little theorem"
+    ],
+    "prerequisites": [
+      "multiplicative group of ZMod p",
+      "orderOf_eq_of_pow_and_pow_div_prime"
+    ]
   },
   {
     "id": "ann-gauss-ordering",
     "proofId": "angle-trisection-oq-02-oq-03-oq-03",
-    "range": { "startLine": 100, "endLine": 118 },
+    "range": {
+      "startLine": 103,
+      "endLine": 116
+    },
     "type": "insight",
     "title": "Gauss's Vertex Ordering",
     "content": "`gauss_ordering` lists the powers 3⁰,…,3¹⁵ mod 17 as [1,3,9,10,13,5,15,11,16,14,8,7,4,12,2,6] and `gauss_ordering_nodup` shows the list is duplicate-free — so the powers of 3 are a permutation of the sixteen nonzero residues. In Gauss's arrangement the two Gaussian periods, and then the sub-periods, appear as evenly spaced blocks of this list.",
     "mathContext": "The primitive-root ordering makes each Gaussian period a contiguous residue class in the exponent.",
     "significance": "supporting",
-    "relatedConcepts": ["Gaussian periods", "Permutation of residues", "Decidable evaluation"],
-    "prerequisites": ["primitive root 3 mod 17"]
+    "relatedConcepts": [
+      "Gaussian periods",
+      "Permutation of residues",
+      "Decidable evaluation"
+    ],
+    "prerequisites": [
+      "primitive root 3 mod 17"
+    ]
+  },
+  {
+    "id": "ann-period-index-sets",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-03",
+    "range": {
+      "startLine": 129,
+      "endLine": 137
+    },
+    "type": "definition",
+    "title": "The Two Period Index Sets (8 + 8)",
+    "content": "`periodQR` = {1,2,4,8,9,13,15,16} and `periodNQR` = {3,5,6,7,10,11,12,14} are the concrete index sets of Gauss's first pair of periods η₀, η₁ — the even-power and odd-power orbits of the primitive root 3. `periodQR_card` and `periodNQR_card` verify each has exactly eight elements, so the sixteen nonzero residues split evenly 8 + 8. As complex sums η₀ = Σ_{a∈QR} ζ^a, η₁ = Σ_{a∉QR} ζ^a these satisfy η₀+η₁ = −1 and η₀·η₁ = −4, giving the quadratic x²+x−4 = 0 whose roots (−1±√17)/2 introduce the very first surd √17 of the construction.",
+    "mathContext": "$\\eta_0,\\eta_1$ index sets, each of size $8$; roots of $x^2+x-4$ are $(-1\\pm\\sqrt{17})/2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gaussian period",
+      "Quadratic residue",
+      "Cyclotomic field"
+    ],
+    "prerequisites": [
+      "Finset",
+      "Finset.card",
+      "decide"
+    ]
   },
   {
     "id": "ann-gaussian-periods",
     "proofId": "angle-trisection-oq-02-oq-03-oq-03",
-    "range": { "startLine": 141, "endLine": 159 },
+    "range": {
+      "startLine": 140,
+      "endLine": 159
+    },
     "type": "concept",
     "title": "The Two Gaussian Periods = Squares vs. Non-squares",
     "content": "The vertices split into the eight quadratic residues `periodQR` = {1,2,4,8,9,13,15,16} (even powers of 3) and the eight non-residues `periodNQR` = {3,5,6,7,10,11,12,14} (odd powers). `periodQR_eq_squares` confirms periodQR is exactly the nonzero squares mod 17, and `periods_disjoint`/`periods_cover` show they partition the units. As complex sums η₀ = Σ_{a∈QR} ζ^a and η₁ = Σ_{a∉QR} ζ^a, these periods satisfy η₀+η₁ = -1, η₀η₁ = -4, so they are the roots of x² + x − 4 = 0 — the first quadratic, introducing √17.",
     "mathContext": "$\\eta_0,\\eta_1$ are roots of $x^2+x-4=0$, i.e. $\\eta = \\tfrac{-1\\pm\\sqrt{17}}{2}$.",
     "significance": "key",
-    "relatedConcepts": ["Quadratic residues", "Gaussian periods", "Cyclotomic field", "Nested radicals"],
-    "prerequisites": ["quadratic residues mod a prime", "even/odd powers of a primitive root"]
+    "relatedConcepts": [
+      "Quadratic residues",
+      "Gaussian periods",
+      "Cyclotomic field",
+      "Nested radicals"
+    ],
+    "prerequisites": [
+      "quadratic residues mod a prime",
+      "even/odd powers of a primitive root"
+    ]
+  },
+  {
+    "id": "ann-order-chain",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-03",
+    "range": {
+      "startLine": 166,
+      "endLine": 195
+    },
+    "type": "insight",
+    "title": "The Halving Order Chain 16 → 8 → 4 → 2 → 1",
+    "content": "Repeatedly squaring the primitive root walks down the tower one quadratic step at a time. `square_step_1/2/3` compute the generators 3² = 9, 3⁴ = 13, 3⁸ = 16 = −1, and the three order lemmas certify their orders halve at each stage: `nine_orderOf` (orderOf 9 = 8), `thirteen_orderOf` (orderOf 13 = 4), `sixteen_orderOf` (orderOf 16 = 2, the {±1} of complex conjugation). Each order lemma uses the same 2-only-prime-factor test as `three_orderOf`. The resulting chain of element orders 16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1 is the raw data that Section VI packages as a descending tower of index-2 subgroups.",
+    "mathContext": "$\\mathrm{ord}(9)=8,\\ \\mathrm{ord}(13)=4,\\ \\mathrm{ord}(16)=2$; each square halves the order.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Order of an element",
+      "Cyclic subgroup",
+      "Complex conjugation",
+      "Index-2 subgroup"
+    ],
+    "prerequisites": [
+      "orderOf",
+      "orderOf_eq_of_pow_and_pow_div_prime",
+      "orderOf_eq_prime"
+    ]
+  },
+  {
+    "id": "ann-unit-lift",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-03",
+    "range": {
+      "startLine": 211,
+      "endLine": 229
+    },
+    "type": "concept",
+    "title": "Lifting the Primitive Root to a Unit, with Order 16/2ⁱ",
+    "content": "To speak of genuine *subgroups* rather than bare element orders, the primitive root is lifted to a unit `u3 : (ZMod 17)ˣ` via `ZMod.unitOfCoprime 3`. `u3_coe` confirms it reduces back to 3, and `u3_orderOf` transports orderOf(3) = 16 across `orderOf_units` to give orderOf(u3) = 16. The key uniform lemma `u3_pow_orderOf` then computes orderOf(u3^(2ⁱ)) = 16/2ⁱ for every i ≤ 4, via `orderOf_pow_of_dvd` after showing 2ⁱ ∣ 16 = 2⁴. This single formula is what powers the whole tower in Section VI: the i-th subgroup ⟨u3^(2ⁱ)⟩ has cardinality 16/2ⁱ.",
+    "mathContext": "$u_3=\\mathrm{unitOfCoprime}(3)$, $\\mathrm{ord}(u_3^{2^i})=16/2^i$ for $i\\le4$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Unit group",
+      "Order of a power",
+      "zpowers subgroup"
+    ],
+    "prerequisites": [
+      "ZMod.unitOfCoprime",
+      "orderOf_units",
+      "orderOf_pow_of_dvd"
+    ]
   },
   {
     "id": "ann-index2-tower",
     "proofId": "angle-trisection-oq-02-oq-03-oq-03",
-    "range": { "startLine": 230, "endLine": 264 },
+    "range": {
+      "startLine": 230,
+      "endLine": 264
+    },
     "type": "insight",
     "title": "The Index-2 Subgroup Tower",
     "content": "Lifting 3 to a unit u₃, the subgroups ⟨u₃^(2ⁱ)⟩ form a descending chain with cardinalities 16 ⊃ 8 ⊃ 4 ⊃ 2 ⊃ 1 (`tower_cards`), each contained in the previous (`tower_le`) with index 2 (`tower_index_two`). Cardinalities come from `Nat.card_zpowers` (card = orderOf) together with `orderOf_pow_of_dvd` (order of u₃^(2ⁱ) is 16/2ⁱ). Because (ℤ/17ℤ)ˣ ≅ Gal(ℚ(ζ₁₇)/ℚ), this chain of four index-2 subgroups corresponds under the Galois correspondence to a tower ℚ ⊂ K₁ ⊂ K₂ ⊂ K₃ ⊂ ℚ(ζ₁₇) of four quadratic extensions — the algebraic reason the 17-gon needs only nested square roots.",
     "mathContext": "$\\langle 3\\rangle \\supset \\langle 9\\rangle \\supset \\langle 13\\rangle \\supset \\langle 16\\rangle \\supset \\{1\\}$, orders $16\\supset 8\\supset 4\\supset 2\\supset 1$; each $[\\,\\cdot:\\cdot\\,]=2$.",
     "significance": "key",
-    "relatedConcepts": ["Cyclic subgroup tower", "Subgroup index", "Galois correspondence", "Quadratic extensions"],
-    "prerequisites": ["zpowers and Nat.card_zpowers", "orderOf_pow_of_dvd", "Galois group of a cyclotomic field"]
+    "relatedConcepts": [
+      "Cyclic subgroup tower",
+      "Subgroup index",
+      "Galois correspondence",
+      "Quadratic extensions"
+    ],
+    "prerequisites": [
+      "zpowers and Nat.card_zpowers",
+      "orderOf_pow_of_dvd",
+      "Galois group of a cyclotomic field"
+    ]
   },
   {
     "id": "ann-why-17-works",
     "proofId": "angle-trisection-oq-02-oq-03-oq-03",
-    "range": { "startLine": 275, "endLine": 285 },
+    "range": {
+      "startLine": 275,
+      "endLine": 285
+    },
     "type": "conclusion",
     "title": "Why 17 Works: Four Quadratic Steps",
     "content": "`full_tower_steps` records φ(17) = 2⁴ (four quadratic steps for the full cyclotomic tower) and `real_subfield_degree` records φ(17)/2 = 2³ (three steps for the real cosine subfield ℚ(cos 2π/17), the fixed field of complex conjugation ⟨16⟩ = {±1}). Finitely many degree-2 extensions mean every coordinate — in particular cos(2π/17) — is built from nested square roots, so the regular 17-gon is straightedge-and-compass constructible.",
     "mathContext": "$\\varphi(17)=2^4$, $\\varphi(17)/2 = 2^3$: the height of the quadratic tower.",
     "significance": "key",
-    "relatedConcepts": ["Constructible number", "Tower of quadratic extensions", "Real subfield", "Complex conjugation"],
-    "prerequisites": ["constructible ⇔ tower of quadratic extensions", "fixed field of complex conjugation"]
+    "relatedConcepts": [
+      "Constructible number",
+      "Tower of quadratic extensions",
+      "Real subfield",
+      "Complex conjugation"
+    ],
+    "prerequisites": [
+      "constructible ⇔ tower of quadratic extensions",
+      "fixed field of complex conjugation"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment: annotation coverage gap

The 17-gon / Gauss entry had **5 annotations covering only 14 of its 35 declarations** — whole sections were unannotated. This adds **5 new annotations** (5→10) so every declaration is covered, and realigns 3 pre-existing annotations that were anchored on blank lines.

### New annotations
| id | section | covers |
|----|---------|--------|
| `ann-fermat-prime-17` | I | `seventeen_prime`, `seventeen_fermat`, `totient_17`, `totient_17_pow2` — 17 = 2^(2²)+1, φ(17)=2⁴ |
| `ann-order-determining-powers` | II | `three_pow_16`, `three_pow_8` — the 3¹⁶=1 / 3⁸=−1 facts pinning orderOf(3)=16 |
| `ann-period-index-sets` | IV | `periodQR`, `periodNQR`, `periodQR_card`, `periodNQR_card` — the 8+8 vertex split |
| `ann-order-chain` | V | `square_step_1/2/3`, `nine_orderOf`, `thirteen_orderOf`, `sixteen_orderOf` — order chain 16→8→4→2→1 |
| `ann-unit-lift` | VI | `u3`, `u3_coe`, `u3_orderOf`, `u3_pow_orderOf` — unit lift, orderOf(u3^(2ⁱ))=16/2ⁱ |

### Realigned (blank-line anchors → construct lines)
- `ann-primitive-root` 78→83, `ann-gauss-ordering` 100→103, `ann-gaussian-periods` 141→140 — clears 'No Lean construct found' warnings.

No Lean source changes. Annotations validate clean (`annotations/build.ts --strict`).