### PR TITLE
enrich(hilbert-4-oq-04): cover fixed-point/positivity/iteration gaps (9→13 anns)

### DIFF
--- a/src/data/proofs/hilbert-4-oq-04/annotations.json
+++ b/src/data/proofs/hilbert-4-oq-04/annotations.json
@@ -2,109 +2,296 @@
   {
     "id": "ann-overview",
     "proofId": "hilbert-4-oq-04",
-    "range": { "startLine": 1, "endLine": 55 },
+    "range": {
+      "startLine": 1,
+      "endLine": 55
+    },
     "type": "concept",
     "title": "Hilbert Metric, Birkhoff Contraction, Perron–Frobenius",
     "content": "Birkhoff's theorem: a positive matrix strictly contracts the Hilbert projective metric, so its normalized power iteration converges geometrically to the Perron (dominant positive) eigenvector. We formalize the 2×2 case, where the cone is one-dimensional: A = !![a,b;c,d] acts on the projective coordinate t = x/y ∈ (0,∞) by the Möbius map φ(t) = (a·t+b)/(c·t+d), and the Hilbert metric is d_H(t₁,t₂) = |log t₁ − log t₂|. Instead of the analytic tanh(Δ/4) estimate we use the exact cross-ratio multiplier ρ = λ₂/λ₁.",
     "mathContext": "$d_H(t_1,t_2) = |\\log t_1 - \\log t_2|$ on $(0,\\infty)$; $\\varphi(t) = \\frac{at+b}{ct+d}$ is the projective action of $A$.",
     "significance": "supporting",
-    "relatedConcepts": ["Hilbert projective metric", "Birkhoff contraction theorem", "Perron–Frobenius theorem", "power iteration", "Möbius transformation"],
-    "prerequisites": ["positive matrices", "projective coordinates", "geometric convergence"]
+    "relatedConcepts": [
+      "Hilbert projective metric",
+      "Birkhoff contraction theorem",
+      "Perron–Frobenius theorem",
+      "power iteration",
+      "Möbius transformation"
+    ],
+    "prerequisites": [
+      "positive matrices",
+      "projective coordinates",
+      "geometric convergence"
+    ]
+  },
+  {
+    "id": "ann-mobius-disc-defs",
+    "proofId": "hilbert-4-oq-04",
+    "range": {
+      "startLine": 56,
+      "endLine": 60
+    },
+    "type": "definition",
+    "title": "The Möbius Map and Its Fixed-Point Discriminant",
+    "content": "The two foundational objects of the projective dynamics. `mobius a b c d t = (a·t+b)/(c·t+d)` is the action of the positive matrix A = !![a,b;c,d] on the projective coordinate t = x/y — the increasing Möbius map whose iteration IS the normalized power iteration. `fpDisc a b c d = (d−a)²+4bc` is the discriminant of the fixed-point quadratic c·t²+(d−a)·t−b = 0; for a positive matrix it is strictly positive (proved next), so the two fixed points t⋆, t† are real and distinct. Note Δ = (a−d)²+4bc coincides with the discriminant of the matrix's characteristic polynomial, tying the projective fixed points to the eigenvalues.",
+    "mathContext": "$\\varphi(t)=\\frac{at+b}{ct+d}$, $\\Delta=(d-a)^2+4bc$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Möbius transformation",
+      "Projective coordinate",
+      "Discriminant",
+      "Characteristic polynomial"
+    ],
+    "prerequisites": [
+      "noncomputable def",
+      "real division"
+    ]
   },
   {
     "id": "ann-defs",
     "proofId": "hilbert-4-oq-04",
-    "range": { "startLine": 62, "endLine": 92 },
+    "range": {
+      "startLine": 62,
+      "endLine": 92
+    },
     "type": "definition",
     "title": "The Projective-Dynamics Setup",
     "content": "mobius is φ. fpDisc is the discriminant Δ = (d−a)² + 4bc of the fixed-point quadratic c·t² + (d−a)·t − b. perronRatio (t⋆) and subRatio (t†) are its two roots — the eigenvector ratios. contractionRatio is the multiplier ρ = (a+d−√Δ)/(a+d+√Δ). cross is the cross-ratio coordinate g(t) = (t−t⋆)/(t−t†) in which φ will become exact multiplication by ρ.",
     "mathContext": "$t_\\star, t_\\dagger = \\frac{a-d\\pm\\sqrt{\\Delta}}{2c}$, $\\rho = \\frac{a+d-\\sqrt\\Delta}{a+d+\\sqrt\\Delta}$, $g(t) = \\frac{t-t_\\star}{t-t_\\dagger}$.",
     "significance": "supporting",
-    "relatedConcepts": ["fixed points of a Möbius map", "cross-ratio", "eigenvector ratio", "Möbius multiplier"],
-    "prerequisites": ["quadratic formula", "linear-fractional transformations"]
+    "relatedConcepts": [
+      "fixed points of a Möbius map",
+      "cross-ratio",
+      "eigenvector ratio",
+      "Möbius multiplier"
+    ],
+    "prerequisites": [
+      "quadratic formula",
+      "linear-fractional transformations"
+    ]
+  },
+  {
+    "id": "ann-locate-fixed-points",
+    "proofId": "hilbert-4-oq-04",
+    "range": {
+      "startLine": 95,
+      "endLine": 144
+    },
+    "type": "theorem",
+    "title": "Locating and Signing the Two Fixed Points: t† < 0 < t⋆",
+    "content": "The geometric backbone: the two fixed points straddle 0, which is what makes the cross-ratio coordinate a genuine contraction later. The pivotal inequality `abs_lt_sqrt_fpDisc` (√Δ > |a−d|, because Δ = (a−d)²+4bc strictly exceeds (a−d)²) forces the signs: `perronRatio_pos` (t⋆ > 0, the Perron/dominant ratio) and `subRatio_neg` (t† < 0), hence `sub_lt_perron` (t† < t⋆, distinct). The linear relations `two_c_perron`/`two_c_sub` (2c·t⋆ = a−d+√Δ, 2c·t† = a−d−√Δ) and their eigenvalue repackagings `two_a_sub_c_perron`/`two_a_sub_c_sub` (2(a−c·t⋆) = a+d−√Δ = 2λ₂, 2(a−c·t†) = a+d+√Δ = 2λ₁) express the fixed points and eigenvalues in the shared √Δ coordinate; `a_sub_c_sub_pos` records λ₁ = a−c·t† > 0, the dominant eigenvalue that drives the eventual convergence.",
+    "mathContext": "$\\sqrt{\\Delta}>|a-d|\\Rightarrow t^\\dagger<0<t^\\star$; $2\\lambda_{1,2}=a+d\\pm\\sqrt\\Delta$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fixed point",
+      "Perron eigenvector",
+      "Eigenvalue",
+      "Sign analysis"
+    ],
+    "prerequisites": [
+      "Real.sqrt",
+      "abs_lt",
+      "linarith",
+      "nlinarith"
+    ]
   },
   {
     "id": "ann-quadratic",
     "proofId": "hilbert-4-oq-04",
-    "range": { "startLine": 142, "endLine": 167 },
+    "range": {
+      "startLine": 147,
+      "endLine": 167
+    },
     "type": "theorem",
     "title": "The Fixed-Point Quadratic at Both Roots",
     "content": "perron_quadratic / sub_quadratic: each fixed point satisfies b = c·t² + (d−a)·t, the eigenvalue quadratic. Proved from the explicit quadratic-formula roots by squaring 2c·t − (a−d) = ±√Δ and using √Δ ^ 2 = Δ, then cancelling 4c. These relations drive every later algebraic identity (the factorizations and the semiconjugacy).",
     "mathContext": "$c\\,t^2 + (d-a)\\,t - b = 0$ at $t = t_\\star, t_\\dagger$; equivalently $A\\,(t,1)^\\top \\parallel (t,1)^\\top$.",
     "significance": "key",
-    "relatedConcepts": ["characteristic equation", "eigenvalue quadratic", "fixed-point equation"],
-    "prerequisites": ["Real.sq_sqrt", "quadratic roots"]
+    "relatedConcepts": [
+      "characteristic equation",
+      "eigenvalue quadratic",
+      "fixed-point equation"
+    ],
+    "prerequisites": [
+      "Real.sq_sqrt",
+      "quadratic roots"
+    ]
+  },
+  {
+    "id": "ann-positive-ray-invariance",
+    "proofId": "hilbert-4-oq-04",
+    "range": {
+      "startLine": 170,
+      "endLine": 183
+    },
+    "type": "theorem",
+    "title": "φ Preserves the Positive Ray and Fixes t⋆",
+    "content": "Two facts that make the dynamical system well-posed on (0,∞). `den_pos` and `mobius_pos` show that for t > 0 the denominator c·t+d and the value φ(t) = (a·t+b)/(c·t+d) are both positive — the positive ray is forward-invariant, so the whole power iteration stays where the Hilbert metric lives. `mobius_perron` verifies φ(t⋆) = t⋆ directly from the fixed-point quadratic (`perron_quadratic`): the Perron ratio is a genuine fixed point, the limit the iteration will be shown to approach.",
+    "mathContext": "$t>0\\Rightarrow\\varphi(t)>0$; $\\varphi(t^\\star)=t^\\star$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Forward invariance",
+      "Fixed point",
+      "Positive ray",
+      "Hilbert metric"
+    ],
+    "prerequisites": [
+      "positivity",
+      "div_pos",
+      "div_eq_iff"
+    ]
   },
   {
     "id": "ann-factor",
     "proofId": "hilbert-4-oq-04",
-    "range": { "startLine": 184, "endLine": 205 },
+    "range": {
+      "startLine": 185,
+      "endLine": 205
+    },
     "type": "theorem",
     "title": "Exact Factorizations of φ(t) − t⋆ and φ(t) − t†",
     "content": "mobius_factor_perron / mobius_factor_sub: φ(t) − t⋆ = (a−c·t⋆)(t−t⋆)/(c·t+d), and the same at t†. The displacement from a fixed point factors as a constant (the local multiplier numerator) times (t − fixed point), over the common denominator c·t+d. This is what makes the cross-ratio collapse to a constant.",
     "mathContext": "$\\varphi(t) - t_\\star = \\dfrac{(a-c\\,t_\\star)(t-t_\\star)}{c\\,t+d}$.",
     "significance": "key",
-    "relatedConcepts": ["local linearization", "Möbius fixed-point factorization"],
-    "prerequisites": ["the fixed-point quadratic", "field algebra"]
+    "relatedConcepts": [
+      "local linearization",
+      "Möbius fixed-point factorization"
+    ],
+    "prerequisites": [
+      "the fixed-point quadratic",
+      "field algebra"
+    ]
   },
   {
     "id": "ann-semiconjugacy",
     "proofId": "hilbert-4-oq-04",
-    "range": { "startLine": 207, "endLine": 235 },
+    "range": {
+      "startLine": 207,
+      "endLine": 235
+    },
     "type": "theorem",
     "title": "The Semiconjugacy g(φ(t)) = ρ·g(t) — the Birkhoff/Perron Heart",
     "content": "cross_mobius: dividing the two factorizations cancels the common denominator c·t+d (div_div_div_cancel_right₀), leaving (a−c·t⋆)(t−t⋆) / ((a−c·t†)(t−t†)). The eigenvalue identity a−c·t⋆ = ρ·(a−c·t†) (a_sub_c_perron_eq) turns this into ρ·g(t). So in the cross-ratio coordinate, the Möbius map φ is EXACTLY multiplication by the constant ρ — the exact algebraic form of Birkhoff's strict-contraction theorem, with rate ρ = λ₂/λ₁ instead of the analytic tanh(Δ/4).",
     "mathContext": "$g(\\varphi(t)) = \\rho\\,g(t)$ with $\\rho = \\lambda_2/\\lambda_1$; $\\varphi$ is conjugate to $w \\mapsto \\rho w$.",
     "significance": "key",
-    "relatedConcepts": ["semiconjugacy", "Möbius multiplier", "Birkhoff contraction", "spectral gap"],
-    "prerequisites": ["the factorizations", "the eigenvalue identity λ₂ = ρ·λ₁"]
+    "relatedConcepts": [
+      "semiconjugacy",
+      "Möbius multiplier",
+      "Birkhoff contraction",
+      "spectral gap"
+    ],
+    "prerequisites": [
+      "the factorizations",
+      "the eigenvalue identity λ₂ = ρ·λ₁"
+    ]
   },
   {
     "id": "ann-contraction",
     "proofId": "hilbert-4-oq-04",
-    "range": { "startLine": 237, "endLine": 245 },
+    "range": {
+      "startLine": 237,
+      "endLine": 245
+    },
     "type": "theorem",
     "title": "|ρ| < 1: the Genuine Contraction",
     "content": "abs_contractionRatio_lt_one: because a+d > 0 and √Δ > 0, one always has |a+d−√Δ| < a+d+√Δ, so |ρ| < 1 for EVERY positive matrix — no determinant hypothesis needed. This is the contraction property that powers geometric convergence.",
     "mathContext": "$|\\rho| = \\dfrac{|a+d-\\sqrt\\Delta|}{a+d+\\sqrt\\Delta} < 1$.",
     "significance": "key",
-    "relatedConcepts": ["contraction constant", "spectral gap", "Perron dominance"],
-    "prerequisites": ["absolute value inequalities"]
+    "relatedConcepts": [
+      "contraction constant",
+      "spectral gap",
+      "Perron dominance"
+    ],
+    "prerequisites": [
+      "absolute value inequalities"
+    ]
+  },
+  {
+    "id": "ann-iterate-positive",
+    "proofId": "hilbert-4-oq-04",
+    "range": {
+      "startLine": 251,
+      "endLine": 257
+    },
+    "type": "theorem",
+    "title": "Iterates Stay on the Positive Ray",
+    "content": "`iterate_pos`: a one-line induction lifting `mobius_pos` to all iterates — φⁿ(t) > 0 for every n whenever t > 0. This is the hypothesis that every later step (the cross-ratio straightening `cross_iterate`, the closed form, the limit) needs in order to apply the positive-ray lemmas at each stage of the orbit.",
+    "mathContext": "$t>0\\Rightarrow \\varphi^{[n]}(t)>0$ for all $n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Function iteration",
+      "Induction",
+      "Forward invariance"
+    ],
+    "prerequisites": [
+      "Function.iterate_succ_apply'",
+      "Nat.rec"
+    ]
   },
   {
     "id": "ann-iterate",
     "proofId": "hilbert-4-oq-04",
-    "range": { "startLine": 256, "endLine": 311 },
+    "range": {
+      "startLine": 256,
+      "endLine": 311
+    },
     "type": "theorem",
     "title": "Geometric Straightening and the Closed Form",
     "content": "cross_iterate: iterating the semiconjugacy gives g(φⁿ(t)) = ρⁿ·g(t) — the cross-ratio coordinate decays exactly geometrically. iterate_closed_form inverts this to the explicit rational form φⁿ(t) = t⋆ + ρⁿ·g(t)·(t⋆−t†)/(1 − ρⁿ·g(t)), valid because the iterates stay positive (iterate_pos) and g never hits 1.",
     "mathContext": "$g(\\varphi^n(t)) = \\rho^n g(t)$; $\\varphi^n(t) = t_\\star + \\dfrac{\\rho^n g(t)\\,(t_\\star - t_\\dagger)}{1 - \\rho^n g(t)}$.",
     "significance": "key",
-    "relatedConcepts": ["geometric decay", "conjugation to linear map", "orbit closed form"],
-    "prerequisites": ["induction on iterates", "field algebra"]
+    "relatedConcepts": [
+      "geometric decay",
+      "conjugation to linear map",
+      "orbit closed form"
+    ],
+    "prerequisites": [
+      "induction on iterates",
+      "field algebra"
+    ]
   },
   {
     "id": "ann-main",
     "proofId": "hilbert-4-oq-04",
-    "range": { "startLine": 313, "endLine": 330 },
+    "range": {
+      "startLine": 313,
+      "endLine": 330
+    },
     "type": "theorem",
     "title": "Main: Power Iteration Converges to the Perron Eigenvector",
     "content": "power_iteration_tendsto: since |ρ| < 1 gives ρⁿ → 0, the closed form tends to t⋆ (Tendsto.div with denominator limit 1). So from ANY positive start, φⁿ(t) → t⋆ geometrically — the Birkhoff → Perron–Frobenius conclusion: the normalized power iteration converges to the dominant positive eigenvector direction.",
     "mathContext": "$\\varphi^n(t) \\to t_\\star$ as $n \\to \\infty$, geometrically at rate $|\\rho| = \\lambda_2/\\lambda_1$.",
     "significance": "key",
-    "relatedConcepts": ["Perron–Frobenius convergence", "power method", "contraction-mapping theorem"],
-    "prerequisites": ["tendsto_pow_atTop_nhds_zero_of_abs_lt_one", "Filter.Tendsto.div"]
+    "relatedConcepts": [
+      "Perron–Frobenius convergence",
+      "power method",
+      "contraction-mapping theorem"
+    ],
+    "prerequisites": [
+      "tendsto_pow_atTop_nhds_zero_of_abs_lt_one",
+      "Filter.Tendsto.div"
+    ]
   },
   {
     "id": "ann-perron",
     "proofId": "hilbert-4-oq-04",
-    "range": { "startLine": 331, "endLine": 363 },
+    "range": {
+      "startLine": 331,
+      "endLine": 363
+    },
     "type": "theorem",
     "title": "Identifying the Perron Eigenvector and the Rate",
     "content": "perron_eigenvector: (t⋆, 1) is a genuine eigenvector of A, with eigenvalue λ₁ = c·t⋆+d = (a+d+√Δ)/2 (perron_eigenvalue) — so the limit really is the Perron direction. contractionRatio_eq_eigenvalue_ratio: ρ·λ₁ = λ₂, so the metric contraction rate equals the spectral-gap ratio λ₂/λ₁. The metric and spectral faces of Perron–Frobenius coincide.",
     "mathContext": "$A\\,(t_\\star,1)^\\top = \\lambda_1\\,(t_\\star,1)^\\top$, $\\lambda_1 = \\tfrac{a+d+\\sqrt\\Delta}{2}$, $\\rho\\lambda_1 = \\lambda_2$.",
     "significance": "key",
-    "relatedConcepts": ["Perron eigenvector", "dominant eigenvalue", "spectral gap", "convergence rate"],
-    "prerequisites": ["eigenvalue/eigenvector definitions"]
+    "relatedConcepts": [
+      "Perron eigenvector",
+      "dominant eigenvalue",
+      "spectral gap",
+      "convergence rate"
+    ],
+    "prerequisites": [
+      "eigenvalue/eigenvector definitions"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment: annotation coverage gap

The Birkhoff / Perron–Frobenius 2×2 power-iteration entry had **9 annotations covering 22 of its 37 declarations** — the entire fixed-point-location and positivity machinery (lines 56–183) was largely unannotated, with one existing annotation lumping 3 unrelated theorems. This adds **4 new annotations** (9→13) so every declaration is covered, and realigns 2 pre-existing annotations anchored off a construct line.

### New annotations
| id | covers |
|----|--------|
| `ann-mobius-disc-defs` | `mobius`, `fpDisc` — the Möbius map and fixed-point discriminant |
| `ann-locate-fixed-points` | `abs_lt_sqrt_fpDisc`, `two_c_perron`/`two_c_sub`, `perronRatio_pos`, `subRatio_neg`, `sub_lt_perron`, `two_a_sub_c_perron`/`two_a_sub_c_sub`, `a_sub_c_sub_pos` — signing t†<0<t⋆ and the √Δ eigenvalue relations |
| `ann-positive-ray-invariance` | `den_pos`, `mobius_pos`, `mobius_perron` — forward invariance of (0,∞) and φ(t⋆)=t⋆ |
| `ann-iterate-positive` | `iterate_pos` — iterates stay positive |

### Realigned (off-construct anchors → construct lines)
- `ann-quadratic` 142→147 (was inside `a_sub_c_sub_pos`'s proof body), `ann-factor` 184→185 (blank line) — clears 'No Lean construct found' warnings.

No Lean source changes. Annotations validate clean (`annotations/build.ts --strict`).