### PR TITLE
research(russell-1-plus-1-oq-02): Peano ℕ is a commutative semiring [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/OnePlusOneOQ02.lean
+++ b/proofs/Proofs/OnePlusOneOQ02.lean
@@ -1,0 +1,218 @@
+/-!
+# Peano ℕ is a Commutative Semiring (Russell 1+1=2, Open Question oq-02)
+
+## What This Proves
+
+The parent entry `russell-1-plus-1` builds the natural numbers and addition
+from Peano's axioms, entirely without Mathlib, and proves that addition is
+commutative and associative.  It stops there: multiplication is never defined,
+and no algebraic structure is established.
+
+This open-question extension **completes the arithmetic story**.  Continuing in
+the same from-scratch, Mathlib-free style, we:
+
+1. Define multiplication `n * m` by primitive recursion (Peano's original
+   definition: `n * 0 = 0`, `n * succ m = n * m + n`).
+2. Prove every commutative-semiring law relating `+` and `*`:
+   left/right identities, `zero_mul`/`mul_zero`, `mul_comm`, `mul_assoc`,
+   and both distributive laws.
+3. Bundle the axioms into a self-contained `CommSemiring` predicate and exhibit
+   a witness, so the statement "the Peano naturals form a commutative
+   semiring" is a single machine-checked proposition — not merely a list of
+   separate lemmas.
+
+## Approach
+
+- **Foundation (from Mathlib):** None.  Like the parent, this file imports
+  nothing.  Every notion — `ℕ`, `+`, `*`, the semiring axioms — is defined here.
+- **Original Contribution:** the multiplicative half of Peano arithmetic and
+  the packaged commutative-semiring structure, absent from the parent.
+- **Techniques:** primitive recursion, structural induction, and the standard
+  bootstrapping order (`succ_mul` before `mul_comm`, `mul_comm` to transport
+  the left distributive law to the right one, distributivity to get `mul_assoc`).
+
+## Status
+- [x] Complete proof (0 sorries)
+- [ ] Uses Mathlib
+- [x] Proves extensions/corollaries of the parent entry
+- [x] Pedagogical example
+
+Historical note: in Principia Mathematica multiplication and its laws sit atop
+the same cardinal-arithmetic machinery used for addition; the recursive,
+type-theoretic development here needs only induction.
+-/
+
+namespace PeanoSemiring
+
+-- ============================================================
+-- PART 1: Peano naturals and addition (recap of the parent)
+-- ============================================================
+
+/-- The Peano naturals, defined inductively. -/
+inductive ℕ where
+  | zero : ℕ
+  | succ : ℕ → ℕ
+  deriving Repr
+
+open ℕ
+
+def one : ℕ := succ zero
+def two : ℕ := succ (succ zero)
+def three : ℕ := succ (succ (succ zero))
+def four : ℕ := succ three
+
+/-- Addition by recursion on the second argument: `n + 0 = n`,
+`n + succ m = succ (n + m)`. -/
+def add : ℕ → ℕ → ℕ
+  | n, zero   => n
+  | n, succ m => succ (add n m)
+
+infixl:65 " + " => add
+
+@[simp] theorem add_zero (n : ℕ) : n + zero = n := rfl
+@[simp] theorem add_succ (n m : ℕ) : n + succ m = succ (n + m) := rfl
+
+@[simp] theorem zero_add (n : ℕ) : zero + n = n := by
+  induction n with
+  | zero => rfl
+  | succ n ih => rw [add_succ, ih]
+
+theorem succ_add (n m : ℕ) : succ n + m = succ (n + m) := by
+  induction m with
+  | zero => rfl
+  | succ m ih => rw [add_succ, ih, add_succ]
+
+theorem add_comm (n m : ℕ) : n + m = m + n := by
+  induction n with
+  | zero => rw [zero_add, add_zero]
+  | succ n ih => rw [succ_add, add_succ, ih]
+
+theorem add_assoc (a b c : ℕ) : (a + b) + c = a + (b + c) := by
+  induction c with
+  | zero => rfl
+  | succ c ih => rw [add_succ, add_succ, add_succ, ih]
+
+-- ============================================================
+-- PART 2: Defining multiplication (the new ingredient)
+-- ============================================================
+
+/-- Multiplication by recursion on the second argument, following Peano:
+`n * 0 = 0` and `n * succ m = n * m + n`. -/
+def mul : ℕ → ℕ → ℕ
+  | _, zero   => zero
+  | n, succ m => mul n m + n
+
+infixl:70 " * " => mul
+
+@[simp] theorem mul_zero (n : ℕ) : n * zero = zero := rfl
+@[simp] theorem mul_succ (n m : ℕ) : n * succ m = n * m + n := rfl
+
+-- ============================================================
+-- PART 3: The multiplicative bootstrapping lemmas
+-- ============================================================
+
+/-- `0 * n = 0`.  (Right multiplication by `0` is definitional; the left
+version needs induction.) -/
+@[simp] theorem zero_mul (n : ℕ) : zero * n = zero := by
+  induction n with
+  | zero => rfl
+  | succ n ih => rw [mul_succ, ih, add_zero]
+
+/-- `succ n * m = n * m + m`: the left-recursive companion to `mul_succ`. -/
+theorem succ_mul (n m : ℕ) : succ n * m = n * m + m := by
+  induction m with
+  | zero => rfl
+  | succ m ih =>
+    rw [mul_succ, mul_succ, ih, add_succ, add_succ,
+        add_assoc, add_assoc]
+    -- goal reduces to `succ (n * m + (m + n)) = succ (n * m + (n + m))`
+    rw [add_comm m n]
+
+@[simp] theorem mul_one (n : ℕ) : n * one = n := by
+  rw [one, mul_succ, mul_zero, zero_add]
+
+@[simp] theorem one_mul (n : ℕ) : one * n = n := by
+  rw [one, succ_mul, zero_mul, zero_add]
+
+-- ============================================================
+-- PART 4: Commutativity, distributivity, associativity
+-- ============================================================
+
+theorem mul_comm (n m : ℕ) : n * m = m * n := by
+  induction m with
+  | zero => rw [mul_zero, zero_mul]
+  | succ m ih => rw [mul_succ, succ_mul, ih]
+
+/-- Left distributivity: `a * (b + c) = a * b + a * c`. -/
+theorem left_distrib (a b c : ℕ) : a * (b + c) = a * b + a * c := by
+  induction c with
+  | zero => rw [add_zero, mul_zero, add_zero]
+  | succ c ih => rw [add_succ, mul_succ, mul_succ, ih, add_assoc]
+
+/-- Right distributivity: `(a + b) * c = a * c + b * c`, obtained from the left
+version via commutativity. -/
+theorem right_distrib (a b c : ℕ) : (a + b) * c = a * c + b * c := by
+  rw [mul_comm (a + b) c, left_distrib, mul_comm c a, mul_comm c b]
+
+theorem mul_assoc (a b c : ℕ) : (a * b) * c = a * (b * c) := by
+  induction c with
+  | zero => rw [mul_zero, mul_zero, mul_zero]
+  | succ c ih => rw [mul_succ, mul_succ, left_distrib, ih]
+
+-- ============================================================
+-- PART 5: Bundling the commutative-semiring structure
+-- ============================================================
+
+/-- A self-contained predicate capturing all commutative-semiring axioms for a
+given carrier with its `zero`, `one`, `add` and `mul`.  Stating the theorem as
+a single inhabited structure makes "these operations form a commutative
+semiring" one machine-checked proposition. -/
+structure IsCommSemiring (α : Type)
+    (z o : α) (a m : α → α → α) : Prop where
+  add_assoc  : ∀ x y c, a (a x y) c = a x (a y c)
+  add_comm   : ∀ x y, a x y = a y x
+  zero_add   : ∀ x, a z x = x
+  add_zero   : ∀ x, a x z = x
+  mul_assoc  : ∀ x y c, m (m x y) c = m x (m y c)
+  mul_comm   : ∀ x y, m x y = m y x
+  one_mul    : ∀ x, m o x = x
+  mul_one    : ∀ x, m x o = x
+  zero_mul   : ∀ x, m z x = z
+  mul_zero   : ∀ x, m x z = z
+  left_distrib  : ∀ x y c, m x (a y c) = a (m x y) (m x c)
+  right_distrib : ∀ x y c, m (a x y) c = a (m x c) (m y c)
+
+/-- **Main theorem.**  The Peano naturals built from scratch, with the addition
+and multiplication defined above, form a commutative semiring. -/
+theorem peano_isCommSemiring :
+    IsCommSemiring ℕ zero one add mul where
+  add_assoc := add_assoc
+  add_comm := add_comm
+  zero_add := zero_add
+  add_zero := add_zero
+  mul_assoc := mul_assoc
+  mul_comm := mul_comm
+  one_mul := one_mul
+  mul_one := mul_one
+  zero_mul := zero_mul
+  mul_zero := mul_zero
+  left_distrib := left_distrib
+  right_distrib := right_distrib
+
+-- ============================================================
+-- PART 6: Concrete consequences
+-- ============================================================
+
+/-- `2 * 2 = 4`: multiplication reproduces the expected small values. -/
+theorem two_mul_two_eq_four : two * two = four := rfl
+
+/-- A worked instance of distributivity on concrete numerals:
+`2 * (1 + 2) = 2 * 1 + 2 * 2`. -/
+theorem distrib_example : two * (one + two) = two * one + two * two := by
+  rw [left_distrib]
+
+/-- `3 * 1 = 1 * 3`, a concrete instance of commutativity. -/
+theorem comm_example : three * one = one * three := by
+  rw [mul_comm]
+
+end PeanoSemiring

--- a/src/data/proofs/russell-1-plus-1-oq-02/annotations.json
+++ b/src/data/proofs/russell-1-plus-1-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "russcs-ann-01",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": { "startLine": 99, "endLine": 108 },
+    "type": "concept",
+    "title": "Peano's Recursive Multiplication — the Two Definitional Equations",
+    "content": "Multiplication is defined by recursion on the second argument, exactly as Peano wrote it in 1889: `n * 0 = 0` and `n * (m+1) = n*m + n`. Because Lean's equation compiler elaborates this to the recursor of ℕ, both defining lemmas `mul_zero` and `mul_succ` hold by `rfl` — they are computation rules, not theorems. Everything algebraic that follows is the work of reconciling this single right-recursion with the symmetric facts (left-recursion, commutativity) that the definition does not give for free.",
+    "mathContext": "$n \\cdot 0 = 0, \\qquad n \\cdot S(m) = n \\cdot m + n.$ Both equations are definitional (`rfl`).",
+    "significance": "key",
+    "relatedConcepts": [
+      "primitive recursion",
+      "the recursor ℕ.rec",
+      "iota-reduction",
+      "Peano arithmetic"
+    ],
+    "prerequisites": [
+      "inductive types and recursion on the second argument",
+      "definitional equality (rfl)"
+    ]
+  },
+  {
+    "id": "russcs-ann-02",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": { "startLine": 121, "endLine": 129 },
+    "type": "proof-technique",
+    "title": "succ_mul: the Crux Lemma that Unlocks Commutativity",
+    "content": "The definition gives `mul_succ` (recursion on the right); its left-recursive mirror `(n+1)*m = n*m + m` is not definitional and must be proved by induction on `m`. The successor step is the one genuinely fiddly computation in the file: expanding both sides via `mul_succ` and the induction hypothesis leaves `succ (n*m + (m + n)) = succ (n*m + (n + m))`, closed by `add_comm m n` after two uses of `add_assoc` to line up the parenthesisation. Once `succ_mul` is available, `mul_comm` is a two-line induction — this lemma is precisely what the commutativity proof needs.",
+    "mathContext": "$(n+1)\\cdot m = n\\cdot m + m$, proved by induction on $m$; the step reduces to $n m + (m+n) = n m + (n+m)$, i.e. $m+n = n+m$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "structural induction",
+      "associativity/commutativity rearrangement",
+      "left- vs right-recursion"
+    ],
+    "prerequisites": [
+      "add_assoc and add_comm from the additive recap",
+      "the definitional mul_succ"
+    ]
+  },
+  {
+    "id": "russcs-ann-03",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": { "startLine": 146, "endLine": 155 },
+    "type": "proof-technique",
+    "title": "Right Distributivity for Free from Left Distributivity",
+    "content": "Left distributivity `a*(b+c) = a*b + a*c` is proved by a short induction on `c`. Right distributivity is then obtained without any new induction: `(a+b)*c = c*(a+b) = c*a + c*b = a*c + b*c`, three rewrites using `mul_comm` and the left version. This is a small but characteristic economy — once commutativity is in hand, one distributive law implies the other, so only one of the two needs an inductive proof.",
+    "mathContext": "$(a+b)c \\overset{\\text{comm}}{=} c(a+b) \\overset{\\text{L-distrib}}{=} ca + cb \\overset{\\text{comm}}{=} ac + bc.$",
+    "significance": "important",
+    "relatedConcepts": [
+      "distributive laws",
+      "commutativity",
+      "proof economy"
+    ],
+    "prerequisites": [
+      "left_distrib",
+      "mul_comm"
+    ]
+  },
+  {
+    "id": "russcs-ann-04",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": { "startLine": 157, "endLine": 160 },
+    "type": "proof-technique",
+    "title": "Associativity Spends Distributivity",
+    "content": "`mul_assoc` is proved by induction on the last factor `c`. Its successor step is where distributivity is used: `(a*b)*(c+1) = (a*b)*c + a*b = a*(b*c) + a*b = a*(b*c + b) = a*(b*(c+1))`, folding the two summands back together with `left_distrib` (read right-to-left). This dependency — associativity resting on distributivity resting on commutativity resting on succ_mul — is the whole reason the lemmas appear in this order.",
+    "mathContext": "$(ab)(c+1) = (ab)c + ab = a(bc) + ab = a(bc+b) = a\\,(b(c+1)).$",
+    "significance": "important",
+    "relatedConcepts": [
+      "associativity",
+      "left distributivity",
+      "lemma dependency order"
+    ],
+    "prerequisites": [
+      "left_distrib",
+      "mul_succ"
+    ]
+  },
+  {
+    "id": "russcs-ann-05",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": { "startLine": 187, "endLine": 200 },
+    "type": "concept",
+    "title": "Bundling the Axioms: ℕ is a Commutative Semiring, as One Proposition",
+    "content": "`IsCommSemiring` is a Prop-valued structure listing all twelve commutative-semiring axioms over an abstract carrier with its zero, one, add, and mul. `peano_isCommSemiring` fills every field with the lemma proved above, so the informal claim 'the from-scratch Peano naturals form a commutative semiring' becomes a single inhabited proposition with a closed proof term. This is the structural-theorem payoff over the parent's scattered arithmetic facts — and `#print axioms` confirms it depends on no axioms at all, not even Quot.sound.",
+    "mathContext": "$(\\mathbb{N}, 0, 1, +, \\cdot)$ is a commutative semiring: additive commutative monoid, multiplicative commutative monoid, and both distributive laws.",
+    "significance": "key",
+    "relatedConcepts": [
+      "commutative semiring",
+      "bundled algebraic structure",
+      "axiom-free verification"
+    ],
+    "prerequisites": [
+      "all preceding additive and multiplicative lemmas",
+      "structures / records in Lean"
+    ]
+  }
+]

--- a/src/data/proofs/russell-1-plus-1-oq-02/meta.json
+++ b/src/data/proofs/russell-1-plus-1-oq-02/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "russell-1-plus-1-oq-02",
+  "title": "The Peano Naturals Form a Commutative Semiring",
+  "slug": "russell-1-plus-1-oq-02",
+  "description": "The parent entry russell-1-plus-1 builds ℕ and addition from Peano's axioms without Mathlib and stops at add_comm / add_assoc — multiplication is never defined and no algebraic structure is established. This follow-up completes the arithmetic: still Mathlib-free, it defines multiplication by primitive recursion (n·0 = 0, n·(m+1) = n·m + n) and proves every commutative-semiring law — zero_mul, mul_one/one_mul, mul_comm, both distributive laws, and mul_assoc — then bundles all twelve axioms into a self-contained IsCommSemiring predicate and exhibits ℕ as a witness. So 'the from-scratch Peano naturals form a commutative semiring' becomes one machine-checked proposition. 0 sorries, 0 axioms (not even Quot.sound — pure structural induction).",
+  "meta": {
+    "author": "Peano (recursive multiplication, 1889); Dedekind (1888) — formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Peano_axioms#Arithmetic",
+    "date": "1889",
+    "status": "verified",
+    "tags": [
+      "foundations",
+      "peano-arithmetic",
+      "type-theory",
+      "commutative-semiring",
+      "multiplication",
+      "structural-induction"
+    ],
+    "proofRepoPath": "Proofs/OnePlusOneOQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [],
+    "originalContributions": [
+      "Self-contained, Mathlib-free definition of multiplication on the Peano naturals by primitive recursion, extending the parent entry which defined only addition",
+      "Complete proof of every commutative-semiring axiom for the from-scratch ℕ: zero_mul, mul_one, one_mul, mul_comm, left/right distributivity, and mul_assoc, in the correct bootstrapping order (succ_mul before mul_comm; distributivity before associativity)",
+      "A reusable, dependency-free IsCommSemiring predicate that bundles all twelve axioms so 'these operations form a commutative semiring' is a single inhabited proposition rather than a scattered list of lemmas",
+      "The whole development is axiom-free in the strongest sense: #print axioms reports no dependence on any axiom at all (not even Quot.sound), since every proof is rfl or structural induction"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 218,
+    "assumptions": "None. #print axioms reports that peano_isCommSemiring and all supporting theorems 'do not depend on any axioms' — no sorryAx, no Lean.ofReduceBool, and not even the ordinary foundational axioms propext / Classical.choice / Quot.sound, because no proof uses funext, choice, or propositional extensionality.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 20,
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "Peano's 1889 Arithmetices principia defined not only successor and addition but multiplication, by the two recursion equations n·0 = 0 and n·S(m) = n·m + n, and it is from these that the ring-theoretic laws of arithmetic follow by induction. The parent gallery entry russell-1-plus-1 reconstructs the additive fragment of this development in Lean with no Mathlib, proving 1+1=2 by rfl and then add_comm and add_assoc — but it halts before multiplication, leaving the algebraic structure of ℕ unstated. Its open question asks for that structure. This entry supplies it: the multiplicative half of Peano arithmetic and a proof that the resulting (ℕ, 0, 1, +, ·) is a commutative semiring, the algebraic skeleton on which all of elementary number theory rests.",
+    "problemStatement": "Continuing the parent's from-scratch, Mathlib-free construction of the Peano naturals ℕ and addition, define multiplication and prove that ℕ with 0, 1, addition, and multiplication satisfies every commutative-semiring axiom: additive commutative monoid, multiplicative commutative monoid, both distributive laws, and annihilation by zero. Package the axioms into a single predicate so the semiring claim is one proposition.",
+    "text": "The file redefines the inductive ℕ, addition, and the additive lemmas needed downstream (zero_add, succ_add, add_comm, add_assoc), reproducing just enough of the parent to stand alone. It then defines mul by recursion on the second argument, matching Peano: mul_zero (n·0 = 0) and mul_succ (n·(m+1) = n·m + n) hold by rfl. The multiplicative theory is bootstrapped in the standard order. First zero_mul (0·n = 0) and succ_mul ((n+1)·m = n·m + m) are proved by induction — succ_mul is the delicate one, needing add_assoc and add_comm to reconcile the two recursion directions. These unlock mul_one and one_mul. Then mul_comm follows by a two-line induction using mul_succ and succ_mul; left_distrib a·(b+c) = a·b + a·c by induction on c; right_distrib by transporting left_distrib across mul_comm; and finally mul_assoc by induction on c using left_distrib. Part 5 defines IsCommSemiring, a Prop-valued structure listing all twelve axioms over an abstract carrier with its zero, one, add, mul, and peano_isCommSemiring assembles the proved lemmas into a witness for ℕ. Part 6 records concrete consequences: 2·2 = 4 by rfl and worked instances of distributivity and commutativity on numerals.",
+    "proofStrategy": "Everything is primitive recursion and structural induction — no Mathlib, no classical logic. The only subtlety is ordering: succ_mul must precede mul_comm (it is what makes the commutativity induction close), left distributivity must precede associativity (associativity's successor step expands b·(c+1) and reassociates via left_distrib), and right distributivity is cheapest to obtain from left distributivity by commutativity rather than by a fresh induction. Because no step invokes funext, choice, or propext, the resulting proofs depend on literally no axioms.",
+    "keyInsights": [
+      "Peano's recursive multiplication makes n·0 = 0 and n·(m+1) = n·m + n definitional (rfl); all algebraic content is in reconciling this right-recursion with the symmetric facts.",
+      "succ_mul, (n+1)·m = n·m + m, is the crux: it is the left-recursive companion of the definitional mul_succ, and proving it requires add_assoc and add_comm to rearrange n·m + m + (n+1) into n·m + (n+1) + m. Once available, commutativity is a two-liner.",
+      "Right distributivity need not be proved by induction: (a+b)·c = c·(a+b) = c·a + c·b = a·c + b·c is a three-rewrite consequence of mul_comm and left_distrib, illustrating how commutativity halves the distributive work.",
+      "Associativity is where distributivity is spent: (a·b)·(c+1) = (a·b)·c + a·b = a·(b·c) + a·b = a·(b·c + b) = a·(b·(c+1)), so left_distrib is the load-bearing lemma for mul_assoc.",
+      "Bundling the axioms into the IsCommSemiring predicate turns 'ℕ is a commutative semiring' from an informal summary of a lemma list into a single closed proposition with a checkable proof term — the structural-theorem analogue of the parent's scattered arithmetic facts.",
+      "The development is axiom-free in the strongest gallery sense: #print axioms reports no dependence on any axiom whatsoever, because pure inductive arithmetic never needs propositional extensionality, choice, or quotient soundness."
+    ],
+    "prerequisites": [
+      "Inductive types and definition by primitive recursion in dependent type theory",
+      "Proof by structural induction on an inductive type",
+      "The commutative-semiring axioms (additive commutative monoid, multiplicative commutative monoid, distributivity)",
+      "The parent entry's additive development (zero_add, succ_add, add_comm, add_assoc)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "peano-recap",
+      "title": "Peano naturals and addition (recap)",
+      "startLine": 52,
+      "endLine": 93,
+      "summary": "Reproduces the parent's foundation so the file stands alone: the inductive ℕ, addition by recursion on the second argument, and the additive lemmas zero_add, succ_add, add_comm, add_assoc used later by the multiplicative theory.",
+      "mathContext": "$n + 0 = n,\\; n + S m = S(n+m)$; addition is a commutative monoid on $\\mathbb{N}$."
+    },
+    {
+      "id": "defining-mul",
+      "title": "Defining multiplication",
+      "startLine": 95,
+      "endLine": 108,
+      "summary": "Defines mul by recursion on the second argument in Peano's original form. The equations mul_zero (n·0 = 0) and mul_succ (n·(m+1) = n·m + n) hold by rfl.",
+      "mathContext": "$n \\cdot 0 = 0,\\qquad n \\cdot S m = n \\cdot m + n.$"
+    },
+    {
+      "id": "bootstrapping",
+      "title": "Multiplicative bootstrapping lemmas",
+      "startLine": 110,
+      "endLine": 135,
+      "summary": "Proves zero_mul (0·n = 0) and the left-recursive companion succ_mul ((n+1)·m = n·m + m) by induction — succ_mul needs add_assoc and add_comm — then derives mul_one and one_mul.",
+      "mathContext": "$0 \\cdot n = 0,\\quad (n+1)\\cdot m = n\\cdot m + m,\\quad n\\cdot 1 = n = 1 \\cdot n.$"
+    },
+    {
+      "id": "comm-distrib-assoc",
+      "title": "Commutativity, distributivity, associativity",
+      "startLine": 137,
+      "endLine": 160,
+      "summary": "mul_comm by induction using mul_succ and succ_mul; left_distrib by induction on c; right_distrib by transporting left_distrib across commutativity; mul_assoc by induction on c using left_distrib.",
+      "mathContext": "$nm = mn,\\; a(b+c) = ab+ac,\\; (a+b)c = ac+bc,\\; (ab)c = a(bc).$"
+    },
+    {
+      "id": "bundling-semiring",
+      "title": "Bundling the commutative-semiring structure",
+      "startLine": 162,
+      "endLine": 200,
+      "summary": "Defines IsCommSemiring, a Prop-valued structure listing all twelve commutative-semiring axioms over an abstract carrier, and proves peano_isCommSemiring: the Peano naturals with 0, 1, add, mul satisfy them all.",
+      "mathContext": "$(\\mathbb{N}, 0, 1, +, \\cdot)$ is a commutative semiring — a single inhabited proposition."
+    },
+    {
+      "id": "consequences",
+      "title": "Concrete consequences",
+      "startLine": 202,
+      "endLine": 218,
+      "summary": "Records small checkable instances: 2·2 = 4 by rfl, and worked applications of distributivity and commutativity on concrete numerals.",
+      "mathContext": "$2 \\cdot 2 = 4;\\quad 2\\cdot(1+2) = 2\\cdot 1 + 2\\cdot 2;\\quad 3 \\cdot 1 = 1 \\cdot 3.$"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "russell-1-plus-1",
+      "relationship": "extends",
+      "description": "The parent builds ℕ and addition from Peano's axioms and stops at add_comm / add_assoc; this entry answers its open question by defining multiplication and proving the full commutative-semiring structure in the same Mathlib-free style."
+    },
+    {
+      "targetId": "russell-1-plus-1-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 recovers addition and multiplication as the unique maps named by ℕ's universal property but proves only their defining equations; this entry instead proves the algebraic laws (commutativity, distributivity, associativity) those operations satisfy."
+    },
+    {
+      "targetId": "russell-1-plus-1-oq-04",
+      "relationship": "related",
+      "description": "OQ-04 studies why 1+1=2 is definitional across encodings of ℕ; this entry stays with one encoding and develops its multiplicative algebra."
+    }
+  ],
+  "conclusion": {
+    "summary": "Extending the parent's additive development, this entry defines multiplication on the from-scratch Peano naturals and proves every commutative-semiring axiom — zero_mul, mul_one, one_mul, mul_comm, both distributive laws, and mul_assoc — bundling them into a single IsCommSemiring witness for ℕ. The proofs are pure structural induction, correctly ordered (succ_mul before mul_comm, left distributivity before associativity, right distributivity from commutativity), and the file imports nothing.",
+    "implications": "The algebraic skeleton of elementary number theory — a commutative semiring — is reconstructed from Peano's axioms alone, with no reliance on Mathlib and, remarkably, no dependence on any Lean axiom whatsoever (not even Quot.sound). This shows how much of arithmetic is genuinely constructive and definitional, and it turns the parent's scattered arithmetic facts into a single structural theorem: ℕ is a commutative semiring."
+  },
+  "leanFile": {
+    "imports": [],
+    "opens": [
+      "ℕ"
+    ],
+    "namespace": "PeanoSemiring",
+    "lineCount": 218,
+    "axiomCount": 0,
+    "theoremCount": 20,
+    "definitionCount": 6,
+    "path": "Proofs/OnePlusOneOQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Peano, Giuseppe",
+      "title": "Arithmetices principia, nova methodo exposita",
+      "year": "1889",
+      "venue": "Fratres Bocca, Turin",
+      "note": "Defines successor, addition, and multiplication recursively; the source of the recursion equations n·0 = 0 and n·S(m) = n·m + n."
+    },
+    {
+      "authors": "Dedekind, Richard",
+      "title": "Was sind und was sollen die Zahlen?",
+      "year": "1888",
+      "venue": "Vieweg, Braunschweig",
+      "note": "The recursion theorem underlying well-defined recursive multiplication and the proofs of its algebraic laws by induction."
+    },
+    {
+      "authors": "Whitehead, Alfred North; Russell, Bertrand",
+      "title": "Principia Mathematica",
+      "year": "1910",
+      "venue": "Cambridge University Press, Vol. I-II",
+      "note": "The logicist route to arithmetic whose cardinal-arithmetic machinery the type-theoretic recursion here replaces; the parent entry's namesake."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "peano_isCommSemiring",
+      "type": "core",
+      "description": "The Peano naturals with zero, one, add, and mul satisfy every commutative-semiring axiom, packaged as one inhabited IsCommSemiring proposition.",
+      "leanType": "IsCommSemiring ℕ zero one add mul"
+    },
+    {
+      "name": "mul_comm",
+      "type": "supporting",
+      "description": "Multiplication on the Peano naturals is commutative, proved by structural induction using mul_succ and succ_mul.",
+      "leanType": "∀ (n m : ℕ), n * m = m * n"
+    },
+    {
+      "name": "left_distrib",
+      "type": "supporting",
+      "description": "Left distributivity of multiplication over addition, by induction on the right summand; the load-bearing lemma for associativity.",
+      "leanType": "∀ (a b c : ℕ), a * (b + c) = a * b + a * c"
+    },
+    {
+      "name": "mul_assoc",
+      "type": "supporting",
+      "description": "Associativity of multiplication, by induction on the last factor using left distributivity.",
+      "leanType": "∀ (a b c : ℕ), (a * b) * c = a * (b * c)"
+    },
+    {
+      "name": "succ_mul",
+      "type": "corollary",
+      "description": "The left-recursive companion of the definitional mul_succ; the key lemma that makes the commutativity induction close.",
+      "leanType": "∀ (n m : ℕ), succ n * m = n * m + m"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of parent entry **russell-1-plus-1**, which builds ℕ and addition from Peano's axioms (no Mathlib) but stops at `add_comm`/`add_assoc` — multiplication is never defined and no algebraic structure is established.

This follow-up **completes the arithmetic**, staying Mathlib-free:

- Defines multiplication by primitive recursion, Peano-style: `n * 0 = 0`, `n * (m+1) = n*m + n`.
- Proves every commutative-semiring law: `zero_mul`, `mul_one`/`one_mul`, `mul_comm`, both distributive laws, `mul_assoc`.
- Bundles all twelve axioms into a self-contained `IsCommSemiring` predicate and exhibits ℕ as a witness (`peano_isCommSemiring`), so *'the from-scratch Peano naturals form a commutative semiring'* is a single machine-checked proposition.

## Verification

- **0 sorries**, builds under Lean v4.26.0.
- **0 axioms** — `#print axioms peano_isCommSemiring` reports it *"does not depend on any axioms"*, not even `Quot.sound`: every proof is `rfl` or structural induction (no funext, choice, or propext).
- 20 theorems, 6 defs (+ inductive ℕ, structure `IsCommSemiring`), 218 lines.

## Proof-order notes

`succ_mul` (left-recursive companion of the definitional `mul_succ`) is the crux lemma that makes the `mul_comm` induction close; right distributivity is derived from left distributivity via commutativity (no fresh induction); `mul_assoc` then spends left distributivity in its successor step.

## Files

- `proofs/Proofs/OnePlusOneOQ02.lean` — new proof
- `src/data/proofs/russell-1-plus-1-oq-02/` — gallery meta + 5 annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)