### PR TITLE
Enrich wilsons-theorem-oq-02-oq-02 (Gauss-Wilson non-cyclic): cover Sections 1–6 + realign (5→11)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-oq-02/annotations.json
@@ -4,120 +4,250 @@
     "proofId": "wilsons-theorem-oq-02-oq-02",
     "range": {
       "startLine": 1,
-      "endLine": 52
+      "endLine": 48
     },
     "type": "concept",
     "title": "A Direct Single-Involution Argument, Self-Contained",
-    "content": "Gauss generalized Wilson's theorem to all moduli: ∏ of the units of ZMod n is −1 when (ZMod n)ˣ is cyclic and +1 otherwise. The classical proof pairs each unit with its inverse, leaving the 2-torsion S = {x | x² = 1}, so the product depends only on S. The parent entry proves the non-cyclic half (∏ = 1) using two companion files and a 'two-involution trick' (a constant-product involution applied three times, then cancelled). This entry answers the open question for a DIRECT argument in a single file: the 2-torsion S is itself a 2-group, so |S| is a power of 2; when non-cyclicity forces |S| ≥ 3 it is in fact ≥ 4, hence 4 ∣ |S|, and then ONE involution x ↦ a·x gives ∏ S = a^(|S|/2) = (a²)^(|S|/4) = 1.",
-    "mathContext": "For $n \\ge 3$, $\\prod_{u \\in (\\mathbb{Z}/n)^\\times} u = -1 \\iff (\\mathbb{Z}/n)^\\times$ is cyclic. The product reduces to that of the 2-torsion $S = \\{x : x^2 = 1\\}$; since $S$ is a 2-group, $|S| = 2^m$, and $|S| \\ge 3 \\Rightarrow 4 \\mid |S| \\Rightarrow \\prod S = a^{|S|/2} = 1$.",
+    "mathContext": "The Gauss-Wilson theorem states $\\prod_{u \\in (\\mathbb{Z}/n)^\\times} u = -1$ iff $(\\mathbb{Z}/n)^\\times$ is cyclic. The non-cyclic half ($\\prod u = 1$) is proved here by a **single** involution: the 2-torsion $S = \\{x : x^2 = 1\\}$ of a finite commutative group is a 2-group, so $|S|$ is a power of 2; when $|S| \\ge 3$ (equivalently $\\ge 4$), the involution $x \\mapsto a\\cdot x$ (any nontrivial $a \\in S$) gives $\\prod S = a^{|S|/2} = (a^2)^{|S|/4} = 1$. This replaces the parent entry's three-involution cancellation and its two companion files with one self-contained argument.",
     "significance": "key",
     "relatedConcepts": [
       "Gauss-Wilson theorem",
-      "Wilson's theorem",
-      "two-torsion / square roots of unity",
-      "p-group cardinality",
-      "fixed-point-free involution"
+      "2-torsion subgroup",
+      "fixed-point-free involution",
+      "power-of-two cardinality",
+      "cyclic unit group"
     ],
     "prerequisites": [
-      "units of ZMod n",
       "finite commutative groups",
-      "cyclic groups and IsCyclic",
-      "the order of a p-group is a power of p"
+      "(ZMod n)ˣ",
+      "Wilson's theorem"
+    ]
+  },
+  {
+    "id": "wilson-coercion-small-facts",
+    "proofId": "wilsons-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 54,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "Section 1: units-coercion and $-1 \\ne 1$ for $n \\ge 3$",
+    "mathContext": "Three plumbing facts. `units_val_prod` pushes the units-to-ring coercion through a finite product (`map_prod (Units.coeHom M)`), used to convert the abstract group product into the $\\mathbb{Z}/n$ statement. `neg_one_ne_one_zmod`/`neg_one_ne_one_units`: $-1 \\ne 1$ in $\\mathbb{Z}/n$ (and its units) whenever $n \\ge 3$ — proved by showing $-1 = 1$ forces $2 \\equiv 0$, i.e. $n \\mid 2$, contradicting $n \\ge 3$. This inequality is what makes $\\{1,-1\\}$ genuinely two elements in the cyclic case and $\\prod u = -1 \\ne 1$ in `gaussWilson`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Units.coeHom",
+      "map_prod",
+      "ZMod.natCast_eq_zero_iff",
+      "characteristic 2"
+    ],
+    "prerequisites": [
+      "ZMod n arithmetic",
+      "Units coercion"
     ]
   },
   {
     "id": "prod-eq-two-torsion",
     "proofId": "wilsons-theorem-oq-02-oq-02",
     "range": {
-      "startLine": 93,
+      "startLine": 83,
       "endLine": 111
     },
     "type": "theorem",
-    "title": "Reducing to the 2-Torsion",
-    "content": "prod_eq_prod_two_torsion shows ∏_{x ∈ G} x = ∏_{x : x² = 1} x in any finite commutative group. The involution x ↦ x⁻¹ is fixed-point-free off the 2-torsion (x = x⁻¹ ⟺ x² = 1), and pairs each such element with its distinct inverse, whose product is 1; Mathlib's Finset.prod_involution collapses that part of the product to 1, leaving exactly the self-inverse elements. This is the classical first step of every Wilson-type proof and isolates the only part of the product that can be non-trivial.",
-    "mathContext": "$\\prod_{x \\in G} x = \\prod_{x^2 = 1} x$: outside the 2-torsion, $x$ and $x^{-1}$ are distinct and cancel in pairs.",
+    "title": "Reducing to the 2-Torsion via the inverse involution",
+    "mathContext": "`sq_eq_one_iff_eq_inv`: in a commutative group $x^2 = 1 \\iff x = x^{-1}$. `prod_eq_prod_two_torsion`: $\\prod_{x \\in G} x = \\prod_{x : x^2=1} x$. Proof splits the product over the filter $\\{x^2 = 1\\}$ and its complement; on the complement the involution $x \\mapsto x^{-1}$ is fixed-point-free (its fixed points are exactly the 2-torsion), so `Finset.prod_involution` collapses that factor to $1$. This is the first reduction: the entire unit product is determined by the 2-torsion.",
     "significance": "key",
     "relatedConcepts": [
       "Finset.prod_involution",
-      "inverse involution",
-      "2-torsion subgroup",
-      "pairing argument"
+      "Finset.prod_filter_mul_prod_filter_not",
+      "x = x⁻¹ ⇔ x²=1",
+      "involution pairing"
     ],
     "prerequisites": [
-      "finite commutative group",
-      "x² = 1 ⟺ x = x⁻¹"
+      "Finset.prod_involution goal order",
+      "commutative group inverse"
+    ]
+  },
+  {
+    "id": "involution-infrastructure",
+    "proofId": "wilsons-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 113,
+      "endLine": 208
+    },
+    "type": "theorem",
+    "title": "Involution infrastructure: even cardinality and constant-pair product",
+    "mathContext": "The two abstract engines behind the single-involution count, both by strong induction on the finset (peel off a pair $\\{a, \\sigma a\\}$, recurse on $S \\setminus \\{a,\\sigma a\\}$). `even_card_of_fpf_involution`: a fixed-point-free involution $\\sigma$ on a finset forces $|S|$ even. `prod_involution_const`: if additionally every pair has the same product $x \\cdot \\sigma x = c$, then $\\prod_{x \\in S} x = c^{|S|/2}$. Helper `mem_sdiff_pair` unpacks membership in $S \\setminus \\{a,b\\}$. These are stated for a general $\\sigma$/$c$, then instantiated in Section 4 with $\\sigma x = a\\cdot x$, $c = a$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "fixed-point-free involution",
+      "Finset.strongInduction",
+      "Finset.prod_sdiff",
+      "constant pair product",
+      "c^(|S|/2)"
+    ],
+    "prerequisites": [
+      "strong induction on Finset",
+      "Finset.card_sdiff_of_subset",
+      "pairing arguments"
+    ]
+  },
+  {
+    "id": "two-torsion-subgroup-pgroup",
+    "proofId": "wilsons-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 210,
+      "endLine": 236
+    },
+    "type": "definition",
+    "title": "The 2-torsion subgroup and why it is a 2-group",
+    "mathContext": "`twoTorsion G` packages $\\{x : x^2 = 1\\}$ as a `Subgroup G` (closure under $1$, product via `mul_pow`, inverse via `inv_pow` in the commutative setting). `mem_twoTorsion` is the definitional membership `simp` lemma. `isPGroup_twoTorsion`: every element $g$ of the subgroup satisfies $g^{2^1} = 1$, so by definition it is an `IsPGroup 2` — a 2-group. This is the structural fact that upgrades \"square-one elements\" into a group whose order is forced to be a power of 2.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Subgroup construction",
+      "IsPGroup",
+      "mul_pow / inv_pow",
+      "2-torsion as a subgroup"
+    ],
+    "prerequisites": [
+      "Subgroup structure fields",
+      "IsPGroup definition",
+      "commutative group"
     ]
   },
   {
     "id": "two-torsion-pow-two",
     "proofId": "wilsons-theorem-oq-02-oq-02",
     "range": {
-      "startLine": 239,
+      "startLine": 238,
       "endLine": 249
     },
     "type": "theorem",
     "title": "The 2-Torsion Has Power-of-Two Cardinality",
-    "content": "card_two_torsion_eq_pow_two is the structural heart of the simplification: |{x | x² = 1}| = 2^n. The set {x | x² = 1} is packaged as an honest Subgroup (twoTorsion), and since every element squares to 1 it is a 2-group (isPGroup_twoTorsion : IsPGroup 2). IsPGroup.iff_card then forces its order to be a power of 2, transported from Nat.card of the subgroup to the Finset.filter cardinality via a subtype-card bridge. This is exactly what the parent proof avoids paying for — and exactly what lets a single involution suffice below.",
-    "mathContext": "$S = \\{x : x^2 = 1\\}$ is a subgroup of exponent dividing 2, hence a 2-group, so $|S| = 2^m$. Consequently $|S| \\ge 3 \\Rightarrow |S| \\ge 4 \\Rightarrow 4 \\mid |S|$.",
+    "mathContext": "`card_two_torsion_eq_pow_two`: $|\\{x : x^2 = 1\\}| = 2^n$ for some $n$. Combines `isPGroup_twoTorsion` with `IsPGroup.iff_card` (a finite $p$-group has order $p^n$), transporting cardinality across the equivalence `{x // x²=1} ≃ ↥(twoTorsion G)`. This is the crux that makes the single-involution argument work: knowing $|S|$ is a power of 2 turns $|S| \\ge 3$ into $4 \\mid |S|$.",
     "significance": "critical",
     "relatedConcepts": [
       "IsPGroup.iff_card",
-      "elementary abelian 2-group",
-      "subgroup of square roots of unity",
-      "Nat.card vs Fintype.card"
+      "Nat.card_congr",
+      "Fintype.card_subtype",
+      "order of a p-group"
     ],
     "prerequisites": [
-      "p-groups have prime-power order",
-      "subgroups and IsPGroup",
-      "Subgroup.coe_pow"
+      "IsPGroup cardinality theorem",
+      "subtype/subgroup cardinality"
     ]
   },
   {
     "id": "direct-single-involution",
     "proofId": "wilsons-theorem-oq-02-oq-02",
     "range": {
-      "startLine": 265,
+      "startLine": 251,
       "endLine": 300
     },
     "type": "theorem",
-    "title": "The Direct Single-Involution Lemma",
-    "content": "prod_two_torsion_eq_one is the answer to the open question: in a finite commutative group, if the 2-torsion S = {x | x² = 1} has at least 3 elements then ∏ S = 1, proved with ONE involution. Power-of-two cardinality (card_two_torsion_eq_pow_two) upgrades |S| ≥ 3 to 4 ∣ |S|. Pick any a ∈ S with a ≠ 1; the map x ↦ a·x is a fixed-point-free involution of S (a² = 1) whose pairs each multiply to the constant a, so prod_involution_const gives ∏ S = a^(|S|/2). Since 4 ∣ |S|, the exponent |S|/2 is even, and a^(|S|/2) = (a²)^(|S|/4) = 1. No second or third involution, no cancellation step.",
-    "mathContext": "With $4 \\mid |S|$ and any $a \\in S \\setminus \\{1\\}$: $\\prod_{x \\in S} x = \\prod_{\\text{pairs}} x(ax) = a^{|S|/2} = (a^2)^{|S|/4} = 1$.",
+    "title": "The Direct Single-Involution Lemma: $|S| \\ge 3 \\Rightarrow \\prod S = 1$",
+    "mathContext": "`prod_two_torsion_eq_one`: if the 2-torsion has $\\ge 3$ elements then $\\prod S = 1$. Since $|S| = 2^n$ and $|S| \\ge 3$, we get $n \\ge 2$, so $4 \\mid |S|$. Pick any $a \\in S$ with $a \\ne 1$ (`Finset.exists_mem_ne`); the map $x \\mapsto a\\cdot x$ is a fixed-point-free involution ($a^2 = 1$) with constant pair product $x\\cdot(a x) = a$, so `prod_involution_const` gives $\\prod S = a^{|S|/2}$. As $4 \\mid |S|$, $|S|/2 = 2m$ is even, whence $a^{|S|/2} = (a^2)^m = 1$. This is the paper's single-involution replacement for the classical three-involution cancellation.",
     "significance": "critical",
     "relatedConcepts": [
-      "constant-product involution",
+      "single involution x↦a·x",
+      "4 ∣ |S|",
       "prod_involution_const",
-      "4 ∣ |S| from 2-group structure",
-      "single-involution argument"
+      "a^(|S|/2) = (a²)^(|S|/4)"
     ],
     "prerequisites": [
-      "the 2-torsion is a 2-group",
-      "fixed-point-free involutions and pair products",
-      "a² = 1 ⟹ aⁿ ∈ {1, a}"
+      "prod_involution_const",
+      "card_two_torsion_eq_pow_two",
+      "divisibility by 4"
+    ]
+  },
+  {
+    "id": "unit-lifting",
+    "proofId": "wilsons-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 302,
+      "endLine": 323
+    },
+    "type": "definition",
+    "title": "Section 5: lifting $x^2 = 1$ from $\\mathbb{Z}/n$ to its units",
+    "mathContext": "`unitOfSqEqOne x hx` turns a ring element $x$ with $x^2 = 1$ into a unit (it is its own inverse). The `@[simp]` value lemma and `unitOfSqEqOne_sq`/`ne_one`/`ne_neg_one` transport the square-root, $\\ne 1$, and $\\ne -1$ properties across the lift. This bridges the number-theoretic search for a \"third square root of unity\" (carried out in $\\mathbb{Z}/n$) to the group-theoretic 2-torsion of the unit group $(\\mathbb{Z}/n)^\\times$ used in the cardinality bound.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Units as self-inverse elements",
+      "square roots of unity",
+      "ZMod n → (ZMod n)ˣ lift",
+      "property transport"
+    ],
+    "prerequisites": [
+      "Units structure",
+      "congr_arg Units.val"
+    ]
+  },
+  {
+    "id": "third-sqrt-existence",
+    "proofId": "wilsons-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 325,
+      "endLine": 431
+    },
+    "type": "theorem",
+    "title": "Section 6a: a third square root of unity — CRT split and the $2^k$ case",
+    "mathContext": "The mechanism producing a square root of unity other than $\\pm 1$, in the two hard shapes of a non-cyclic modulus. `exists_third_sqrt_coprime`: for coprime $a, b \\ge 3$, the CRT isomorphism $\\mathbb{Z}/(ab) \\cong \\mathbb{Z}/a \\times \\mathbb{Z}/b$ pulls back $(1, -1)$ to an element that squares to $1$ but is neither $1$ nor $-1$ (its two components differ). `exists_third_sqrt_pow2`: for $2^k$ with $k \\ge 3$, the explicit witness $2^{k-1}+1$ works — the arithmetic lemmas `pow2_sq_sub_one_dvd`, `pow2_cast_sq_eq_one`, `pow2_cast_ne_one`, `pow2_cast_ne_neg_one` verify $x^2 \\equiv 1$, $x \\ne 1$, $x \\ne -1$ via `ZMod.val` bounds.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ZMod.chineseRemainder",
+      "square root of unity ≠ ±1",
+      "explicit witness 2^{k-1}+1",
+      "ZMod.val bounds"
+    ],
+    "prerequisites": [
+      "Chinese Remainder Theorem",
+      "ZMod.val_natCast / val_neg_one",
+      "Nat divisibility"
+    ]
+  },
+  {
+    "id": "not-cyclic-implies-three",
+    "proofId": "wilsons-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 433,
+      "endLine": 542
+    },
+    "type": "theorem",
+    "title": "Section 6b: non-cyclic $\\Rightarrow |S| \\ge 3$ via the classification of moduli",
+    "mathContext": "Assembles the number theory using `ZMod.isCyclic_units_iff`: $(\\mathbb{Z}/n)^\\times$ is non-cyclic exactly when $n$ is not $1,2,4,p^k,2p^k$. `is_pow2_of_no_odd_prime_factor` handles the no-odd-prime branch ($n = 2^k$, $k \\ge 3$, via `Nat.ordProj_mul_ordCompl`); `coprime_split_of_odd_factor` handles the odd-prime branch, extracting a coprime factorisation $n = a\\cdot b$ with $a, b \\ge 3$. `exists_third_sqrt_of_not_cyclic` dispatches to Section 6a in each branch, and `card_two_torsion_units_ge_three` lifts the third root to a unit, exhibiting $\\{1, -1, u\\}$ as three distinct 2-torsion units — the $|S| \\ge 3$ hypothesis the involution lemma needs.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "ZMod.isCyclic_units_iff",
+      "ordProj / ordCompl factorization",
+      "coprime factor extraction",
+      "three distinct 2-torsion units"
+    ],
+    "prerequisites": [
+      "classification of cyclic unit groups",
+      "Nat.factorization",
+      "prime factorization case split"
     ]
   },
   {
     "id": "gauss-wilson-assembled",
     "proofId": "wilsons-theorem-oq-02-oq-02",
     "range": {
-      "startLine": 551,
+      "startLine": 544,
       "endLine": 602
     },
     "type": "theorem",
     "title": "Gauss-Wilson, Assembled Self-Contained",
-    "content": "prod_units_one_of_not_cyclic derives the non-cyclic case ∏ units = 1 by combining prod_eq_prod_two_torsion with the direct lemma, using the inlined card_two_torsion_units_ge_three (¬cyclic ⟹ |S| ≥ 3, via the CRT and 2^(k−1)+1 third-root constructions). prod_units_neg_one_of_cyclic handles the cyclic case: IsCyclic.card_pow_eq_one_le pins the 2-torsion to exactly {1, −1}, so the product is −1. gaussWilson combines them into the biconditional ∏ units = −1 ↔ (ZMod n)ˣ cyclic — all from Mathlib alone, with no Proofs.* companion dependency.",
-    "mathContext": "$\\prod_{u} u = -1 \\iff (\\mathbb{Z}/n)^\\times$ cyclic: cyclic gives 2-torsion $\\{1,-1\\}$ (product $-1$); non-cyclic gives $|S| \\ge 4$ (product $1$).",
+    "mathContext": "The three headline results. `prod_units_one_of_not_cyclic`: non-cyclic $\\Rightarrow \\prod u = 1$ — reduce to the 2-torsion, then apply the single-involution lemma with $|S| \\ge 3$. `prod_units_neg_one_of_cyclic`: cyclic $\\Rightarrow \\prod u = -1$ — here the 2-torsion is exactly $\\{1, -1\\}$ (a cyclic group has $\\le 2$ solutions of $x^2=1$), so the product is $1\\cdot(-1) = -1$. `gaussWilson`: packages both directions into the biconditional $\\prod u = -1 \\iff \\text{IsCyclic}$, using $-1 \\ne 1$ to rule out the non-cyclic case.",
     "significance": "key",
     "relatedConcepts": [
-      "ZMod.isCyclic_units_iff",
-      "ZMod.chineseRemainder",
+      "prod_units_one_of_not_cyclic",
+      "prod_units_neg_one_of_cyclic",
       "IsCyclic.card_pow_eq_one_le",
-      "Gauss-Wilson biconditional"
+      "biconditional assembly"
     ],
     "prerequisites": [
-      "cyclic units of ZMod n",
-      "Chinese Remainder Theorem",
-      "the direct single-involution lemma"
+      "prod_eq_prod_two_torsion",
+      "prod_two_torsion_eq_one",
+      "cyclic ⇒ ≤2 square roots"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment of `wilsons-theorem-oq-02-oq-02` (Gauss-Wilson, Non-Cyclic Case: A Direct Single-Involution Argument) — a **verified, 0-axiom, 602-line** self-contained proof.

Only 5 annotations existed, covering the header, the 2-torsion reduction, the power-of-2 cardinality fact, the single-involution lemma, and the assembled theorems — leaving **~350 lines unannotated**, including the mathematical heart of the argument.

### Added coverage (6 new annotations)
- **Section 1** — units-coercion + `-1 ≠ 1` for `n ≥ 3`
- **Section 2 (infrastructure)** — `even_card_of_fpf_involution` and `prod_involution_const` (the strong-induction pairing engines)
- **Section 3** — the `twoTorsion` subgroup and why it is a 2-group (`isPGroup_twoTorsion`)
- **Section 5** — lifting `x² = 1` from `ZMod n` to its units (`unitOfSqEqOne`)
- **Section 6a** — a third square root of unity: CRT coprime split + the `2^k` explicit witness `2^{k-1}+1`
- **Section 6b** — non-cyclic ⇒ `|S| ≥ 3` via `ZMod.isCyclic_units_iff` and the modulus classification (the previously-unannotated ~210-line number-theoretic core)

### Realigned
The 4 existing content annotations were re-anchored to current section boundaries (e.g. reduction 93–111 → 83–111 to include `sq_eq_one_iff_eq_inv`; assembly 551–602 → 544–602).

**Result:** 5 → 11 annotations; **all 27 declarations covered, no gaps.** Annotations-only change; no Lean source touched.