### PR TITLE
Fix: remove dead hasDerivAt_rpow_nat wrapper (area-of-circle-oq-01-oq-02-oq-01)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01.lean
@@ -105,12 +105,6 @@ theorem unitBallVolume_three : unitBallVolume 3 = 4 * π / 3 := by
 
 /- ## Part III: The Derivative Relation d/dr[V_n(r)] = S_n(r) -/
 
-/-- The derivative of r^n is n·r^(n-1) for n ≥ 1.
-    This wraps Mathlib's HasDerivAt for natural number powers. -/
-theorem hasDerivAt_rpow_nat (n : ℕ) (hn : 1 ≤ n) (r : ℝ) :
-    HasDerivAt (fun x => x ^ n) (↑n * r ^ (n - 1)) r :=
-  hasDerivAt_pow n r
-
 /-- **KEY**: The derivative of V_n(r) = ω_n · r^n is S_n(r) = n · ω_n · r^(n-1).
     This is the n-dimensional generalization of dA/dr = C (= 2πr for n=2). -/
 theorem hasDerivAt_nBallVol (n : ℕ) (hn : 1 ≤ n) (r : ℝ) :

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/annotations.json
@@ -64,7 +64,7 @@
     "proofId": "area-of-circle-oq-01-oq-02-oq-01",
     "range": {
       "startLine": 106,
-      "endLine": 131
+      "endLine": 125
     },
     "type": "concept",
     "title": "The Key Derivative: d/dr[V_n(r)] = S_n(r)",
@@ -92,8 +92,8 @@
     "id": "ann-ndvol-main-theorem",
     "proofId": "area-of-circle-oq-01-oq-02-oq-01",
     "range": {
-      "startLine": 133,
-      "endLine": 165
+      "startLine": 127,
+      "endLine": 159
     },
     "type": "concept",
     "title": "Main Theorem: V_n(r) = ∫₀ʳ S_n(ρ) dρ via FTC",
@@ -122,8 +122,8 @@
     "id": "ann-ndvol-special-cases",
     "proofId": "area-of-circle-oq-01-oq-02-oq-01",
     "range": {
-      "startLine": 167,
-      "endLine": 212
+      "startLine": 161,
+      "endLine": 206
     },
     "type": "insight",
     "title": "Special Cases: Recovering Classical Formulas",
@@ -151,8 +151,8 @@
     "id": "ann-ndvol-shell-volumes",
     "proofId": "area-of-circle-oq-01-oq-02-oq-01",
     "range": {
-      "startLine": 213,
-      "endLine": 230
+      "startLine": 207,
+      "endLine": 224
     },
     "type": "concept",
     "title": "Shell/Annulus Volume Generalization",
@@ -180,8 +180,8 @@
     "id": "ann-ndvol-scaling-ratio",
     "proofId": "area-of-circle-oq-01-oq-02-oq-01",
     "range": {
-      "startLine": 232,
-      "endLine": 262
+      "startLine": 226,
+      "endLine": 256
     },
     "type": "concept",
     "title": "Scaling Laws and Surface-to-Volume Ratio",
@@ -210,8 +210,8 @@
     "id": "ann-ndvol-summary-chain",
     "proofId": "area-of-circle-oq-01-oq-02-oq-01",
     "range": {
-      "startLine": 264,
-      "endLine": 290
+      "startLine": 258,
+      "endLine": 284
     },
     "type": "insight",
     "title": "The Open Question Chain: From Circle Area to N-Dimensional Integration",

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
@@ -74,10 +74,10 @@
         "relationship": "Parent of this entry, providing the surface area formulation that this entry integrates"
       }
     ],
-    "lineCount": 290,
+    "lineCount": 284,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 26,
+    "theoremCount": 25,
     "definitionCount": 3
   },
   "overview": {
@@ -130,47 +130,47 @@
       "id": "derivative-relation",
       "title": "The Derivative Relation",
       "startLine": 106,
-      "endLine": 132,
+      "endLine": 126,
       "summary": "d/dr[V_n(r)] = S_n(r) via the power rule (hasDerivAt_pow), plus continuity of V_n and S_n. This is the n-dimensional 'onion peeling' principle.",
       "mathContext": "Mathematical content: d/dr[V_n(r)] = S_n(r) via the power rule (hasDerivAt_pow), plus continuity of V_n and S_n. This is the n-dimensional 'onion peeling' principle."
     },
     {
       "id": "integral-formula",
       "title": "The Integral Formula (Main Theorem)",
-      "startLine": 133,
-      "endLine": 166,
+      "startLine": 127,
+      "endLine": 160,
       "summary": "V_n(r) = ∫₀ʳ S_n(ρ) dρ via FTC Part 2, using V_n(0) = 0. Also proves FTC Part 1 recovery: d/dr[∫₀ʳ S_n] = S_n(r).",
       "mathContext": "Verified: V_n(r) = ∫₀ʳ S_n(ρ) dρ via FTC Part 2, using V_n(0) = 0. Also proves FTC Part 1 recovery: d/dr[∫₀ʳ S_n] = S_n(r)."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "startLine": 167,
-      "endLine": 212,
+      "startLine": 161,
+      "endLine": 206,
       "summary": "n=1,2,3 special cases recovering classical formulas. Explicit formulas S₂=2πr, S₃=4πr², V₂=πr², V₃=(4π/3)r³ confirmed by substituting ω_n values.",
       "mathContext": "Mathematical content: n=1,2,3 special cases recovering classical formulas. Explicit formulas S₂=2πr, S₃=4πr², V₂=πr², V₃=(4π/3)r³ confirmed by substituting ω_n values."
     },
     {
       "id": "shell-volumes",
       "title": "Shell/Annulus Generalization",
-      "startLine": 213,
-      "endLine": 231,
+      "startLine": 207,
+      "endLine": 225,
       "summary": "∫_{r₁}^{r₂} S_n = V_n(r₂) - V_n(r₁) for shells. The 3D spherical shell formula is given as a corollary.",
       "mathContext": "Mathematical content: ∫_{r₁}^{r₂} S_n = V_n(r₂) - V_n(r₁) for shells. The 3D spherical shell formula is given as a corollary."
     },
     {
       "id": "scaling",
       "title": "Scaling Properties and Surface-to-Volume Ratio",
-      "startLine": 232,
-      "endLine": 263,
+      "startLine": 226,
+      "endLine": 257,
       "summary": "Scaling laws V_n(cr) = c^n·V_n(r), S_n(cr) = c^(n-1)·S_n(r), and the key ratio S_n/V_n = n/r explaining concentration of measure in high dimensions.",
       "mathContext": "Mathematical content: Scaling laws V_n(cr) = c^n·V_n(r), S_n(cr) = c^(n-1)·S_n(r), and the key ratio S_n/V_n = n/r explaining concentration of measure in high dimensions."
     },
     {
       "id": "summary",
       "title": "Summary and Open Question Chain",
-      "startLine": 264,
-      "endLine": 290,
+      "startLine": 258,
+      "endLine": 284,
       "summary": "Recapitulates all results and traces the open question chain: Wiedijk #9 (A=πr²) → OQ01 (C=dA/dr) → OQ02 (A=∫C) → this file (V_n=∫S_n).",
       "mathContext": "Recapitulates all results and traces the open question chain: Wiedijk #9 (A=πr²) $\\to$ OQ01 (C=dA/dr) $\\to$ OQ02 (A=∫C) $\\to$ this file (V_n=∫S_n)."
     }
@@ -225,9 +225,9 @@
       "MeasureTheory"
     ],
     "namespace": "NDimVolumeIntegral",
-    "lineCount": 290,
+    "lineCount": 284,
     "axiomCount": 0,
-    "theoremCount": 26,
+    "theoremCount": 25,
     "definitionCount": 3,
     "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/review.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/review.json
@@ -73,7 +73,8 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove hasDerivAt_rpow_nat (line 110-112) which is a pure Mathlib re-export of hasDerivAt_pow. The only caller (hasDerivAt_nBallVol, line 119) already calls hasDerivAt_pow directly, making the wrapper dead code.",
-      "status": "resolved"
+      "status": "resolved",
+      "result": "issues-fixed"
     },
     {
       "id": "ai-2",


### PR DESCRIPTION
## Fix

Remove the dead-code theorem `hasDerivAt_rpow_nat` from `AreaOfCircleOQ01OQ02OQ01.lean` and reconcile the gallery metadata.

## Evidence

**Before**: `hasDerivAt_rpow_nat (n : ℕ) (hn : 1 ≤ n) (r : ℝ)` was a pure re-export of Mathlib's `hasDerivAt_pow n r` — its `hn` hypothesis was unused and it had **zero callers**. The one place computing this derivative, `hasDerivAt_nBallVol`, already calls `hasDerivAt_pow n r` directly. meta.json advertised 26 theorems / 290 lines.

**After**: wrapper removed (leaf theorem, no dependents → build-safe). File is now 284 lines / 25 theorems. Updated `meta.json`:
- `.meta.theoremCount` and `.leanFile.theoremCount`: 26 → 25
- `.meta.lineCount` and `.leanFile.lineCount`: 290 → 284
- `sections[]` line ranges after line 113 shifted −6 (each section start still lands exactly on its `Part N` header)

Marked the corresponding peer-review action item (`review.json` `actionItems[0]`, target: researcher) as `issues-fixed`.

Addresses the peer-review finding in `src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/review.json`.

---
Automated fix by lean-mechanic agent.