### PR TITLE
audit: rebadge algebraic-numbers-countable-oq-01-oq-01-oq-01 (original→mathlib)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
       "characteristic-zero",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 146,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: algebraic-numbers-countable-oq-01-oq-01-oq-01
**Severity**: MEDIUM — Mathlib wrapper badged \`original\`
**Fix**: \`badge: "original"\` → \`badge: "mathlib"\` (status stays \`verified\`)

## Evidence

The Lean file obtains its core results directly from Mathlib instances via \`inferInstance\`:

- \`perfectField_rat := inferInstance\` (PerfectField.ofCharZero)
- \`perfectField_algebraicNumbers := inferInstance\` (IsAlgClosed.perfectField)
- \`perfectField_algebraicNumbers_of_algebraic := Algebra.IsAlgebraic.perfectField (K := ℚ)\`
- \`isSeparable_of_isAlgebraic_rat := inferInstance\`, \`isSeparable_rat_algebraicNumbers := inferInstance\`
- \`isSeparable_of_isAlgebraic_algebraicNumbers := inferInstance\`, \`perfectField_algebraicClosure_rat_complex := inferInstance\`

\`mathlibDependencies\` lists the major theorems (PerfectField.ofCharZero, IsAlgClosed.perfectField, Algebra.IsAlgebraic.perfectField/.isSeparable_of_perfectField, PerfectField.separable_of_irreducible, Field.finSepDegree_eq_finrank_of_isSeparable) and the file calls them directly for its main results. This matches auditor check #3 (Mathlib Wrapper Detection) and failure mode #5, for which the correct badge is \`mathlib\`.

The gallery convention for this case is \`badge: mathlib\` + \`status: verified\` (698 of 705 mathlib-badged entries).

## Not changed (already accurate)

- \`status: verified\` — genuinely 0 sorries, 0 axioms, 0 native_decide, 0 True-stubs (kernel-checked).
- \`description\`, \`originalContributions\`, \`mathlibDependencies\` — already credit every Mathlib theorem transparently; no delegation opacity, only the badge label was overclaiming.

---
Discovered during gallery integrity audit.