### PR TITLE
Enrich gauss-wilson-non-cyclic-oq-04: add index.ts, sections, coverage

### DIFF
--- a/src/data/proofs/gauss-wilson-non-cyclic-oq-04/annotations.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic-oq-04/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["Nat.card", "ZMod"]
   },
   {
+    "id": "ann-gw-oq04-base-case-one",
+    "proofId": "gauss-wilson-non-cyclic-oq-04",
+    "range": { "startLine": 48, "endLine": 55 },
+    "type": "technique",
+    "title": "Base Case N(1) = 1",
+    "content": "sqrtOneCount 1 = 1: modulo 1 the ring ZMod 1 is the zero ring, so every element is equal (Subsingleton), and the solution set of x² = 1 is a single point. The proof exhibits both a Subsingleton instance (any two solutions are equal by Subtype.ext + Subsingleton.elim) and a witness (⟨1, one_pow 2⟩) for nonemptiness, then closes via Nat.card_eq_one_iff_unique. This unit value N(1) = 1 is exactly the normalization Nat.multiplicative_factorization requires to reassemble N over the prime factorization.",
+    "mathContext": "For a multiplicative arithmetic function $f$, the value $f(1) = 1$ is the empty-product convention that makes $f(n) = \\prod_{p^k \\| n} f(p^k)$ hold; here $2^{\\omega(1)} = 2^0 = 1$ matches.",
+    "significance": "supporting",
+    "relatedConcepts": ["multiplicative function normalization", "zero ring", "subsingleton"],
+    "prerequisites": ["Nat.card_eq_one_iff_unique", "Subsingleton"]
+  },
+  {
     "id": "ann-gw-oq04-local-classification",
     "proofId": "gauss-wilson-non-cyclic-oq-04",
     "range": { "startLine": 57, "endLine": 103 },
@@ -22,6 +34,18 @@
     "significance": "central",
     "relatedConcepts": ["coprimality", "Chinese Remainder Theorem", "cyclic units"],
     "prerequisites": ["Prime.coprime_iff_not_dvd", "IsCoprime.dvd_of_dvd_mul_right", "ZMod.intCast_zmod_eq_zero_iff_dvd"]
+  },
+  {
+    "id": "ann-gw-oq04-distinctness",
+    "proofId": "gauss-wilson-non-cyclic-oq-04",
+    "range": { "startLine": 105, "endLine": 116 },
+    "type": "technique",
+    "title": "Distinctness: 1 ≠ -1 at an Odd Prime Power",
+    "content": "one_ne_neg_one_prime_pow shows (1 : ZMod (p^k)) ≠ -1 for an odd prime power. If 1 = -1 then 2 = 0 in ZMod (p^k), i.e. p^k ∣ 2, so p^k ≤ 2; but p ≥ 3 (odd prime) gives p^k ≥ 3 (via Nat.le_self_pow with k ≠ 0), a contradiction dispatched by omega. Without this the two roots ±1 could coincide and the count would drop to 1 — this is precisely what happens at p = 2, k = 1 (ZMod 2), the smallest source of the 2-adic anomaly.",
+    "mathContext": "The two square roots $\\pm 1$ are distinct exactly when the modulus exceeds $2$. Since an odd prime power $p^k \\ge 3$, the fibre $\\{x : x^2 = 1\\}$ genuinely has two elements, giving the factor $2$ per odd prime.",
+    "significance": "supporting",
+    "relatedConcepts": ["characteristic of a ring", "two-element set", "odd prime power"],
+    "prerequisites": ["Nat.le_self_pow", "ZMod.natCast_eq_zero_iff", "omega"]
   },
   {
     "id": "ann-gw-oq04-local-count",

--- a/src/data/proofs/gauss-wilson-non-cyclic-oq-04/index.ts
+++ b/src/data/proofs/gauss-wilson-non-cyclic-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GaussWilsonNonCyclicOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const gaussWilsonNonCyclicOq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const gaussWilsonNonCyclicOq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const gaussWilsonNonCyclicOq04Data: ProofData = {
+  proof: gaussWilsonNonCyclicOq04Proof,
+  annotations: gaussWilsonNonCyclicOq04Annotations,
+}

--- a/src/data/proofs/gauss-wilson-non-cyclic-oq-04/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic-oq-04/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "dateAdded": "2026-07-01",
     "axiomCount": 0,
-    "lineCount": 177,
+    "lineCount": 182,
     "theoremCount": 6,
     "definitionCount": 1,
     "assumptions": "None. Fully machine-verified from Mathlib.",
@@ -33,7 +33,7 @@
   },
   "leanFile": {
     "namespace": "GaussWilsonSqrtCount",
-    "lineCount": 177,
+    "lineCount": 182,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,
@@ -47,14 +47,57 @@
     "significance": "Gives a fully verified, axiom-free count for the odd case using an elementary coprimality argument rather than the cyclic-group machinery of the parent, and packages N as a genuine multiplicative arithmetic function. It isolates exactly what the 2-adic prime contributes (the δ correction) by removing it."
   },
   "conclusion": {
-    "summary": "For odd n, the number of square roots of unity modulo n is exactly 2^ω(n), where ω(n) = n.primeFactors.card. 177 lines, 6 theorems, 1 definition, 0 sorries, 0 axioms. The count N is built as a multiplicative arithmetic function: N(p^k) = 2 at every odd prime power (elementary ±1 classification), N is multiplicative via the Chinese Remainder Theorem, and Nat.multiplicative_factorization assembles 2^ω(n).",
+    "summary": "For odd n, the number of square roots of unity modulo n is exactly 2^ω(n), where ω(n) = n.primeFactors.card. 182 lines, 6 theorems, 1 definition, 0 sorries, 0 axioms. The count N is built as a multiplicative arithmetic function: N(p^k) = 2 at every odd prime power (elementary ±1 classification), N is multiplicative via the Chinese Remainder Theorem, and Nat.multiplicative_factorization assembles 2^ω(n).",
     "implications": "This is the δ = 0 slice of the parent's open question 2^(ω_odd(n)+δ). By handling the odd case with a clean elementary argument, it makes precise that all of the non-2^ω behavior in the general formula is 2-adic in origin: the factor of 2, 4 (Klein four-group) refinements only appear from the prime 2. The multiplicative packaging also directly recovers classical facts such as N(n) = 2 iff n is 1, 2, or an odd prime power times at most one factor of 2.",
     "openQuestions": [
       "The 2-adic completion: extend to all n by computing N(2^k) = 1, 2, 4 for k = 1, 2, ≥3 (the Klein four-group (ZMod 2^k)ˣ[2] for k ≥ 3) and combining with the odd part to obtain the full 2^(ω_odd(n)+δ) formula.",
       "The dual Gauss–Wilson product: relate N(n) to the value of the product of all units of ZMod n (the generalized Wilson theorem), whose sign is governed by whether N(n) = 2."
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Statement and Strategy",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Imports and the overview docstring: the goal N(n) = 2^ω(n) for odd n as the δ = 0 slice of the parent's open question, plus the three-step plan (local ±1 count, CRT multiplicativity, factorization assembly)."
+    },
+    {
+      "id": "sec-def-base",
+      "title": "Definition and Base Case",
+      "startLine": 45,
+      "endLine": 55,
+      "summary": "Defines sqrtOneCount n = Nat.card {x : ZMod n // x² = 1} and proves the multiplicative normalization N(1) = 1 via the subsingleton structure of the zero ring ZMod 1."
+    },
+    {
+      "id": "sec-local-classification",
+      "title": "Odd Prime Power: Only ±1",
+      "startLine": 57,
+      "endLine": 116,
+      "summary": "The elementary coprimality argument: in ZMod (p^k) for odd p, x² = 1 ↔ x = ±1 (an odd p cannot divide both a−1 and a+1), together with the distinctness lemma 1 ≠ -1 that keeps the count at two."
+    },
+    {
+      "id": "sec-local-count",
+      "title": "Local Count N(p^k) = 2",
+      "startLine": 118,
+      "endLine": 127,
+      "summary": "Assembles the classification and distinctness into the two-element Finset {1, -1}, giving N(p^k) = 2 for every odd prime power via Finset.card_pair."
+    },
+    {
+      "id": "sec-multiplicativity",
+      "title": "CRT Multiplicativity",
+      "startLine": 129,
+      "endLine": 155,
+      "summary": "For coprime m, n, transports x² = 1 across the Chinese Remainder isomorphism ZMod (m·n) ≃+* ZMod m × ZMod n and splits componentwise to prove N(m·n) = N(m)·N(n)."
+    },
+    {
+      "id": "sec-assembly",
+      "title": "Main Theorem: N(n) = 2^ω(n)",
+      "startLine": 157,
+      "endLine": 182,
+      "summary": "Nat.multiplicative_factorization writes N(n) as the product of local counts over the prime factorization; every prime of an odd n is odd, so each factor is 2 and the product collapses to 2^ω(n)."
+    }
+  ],
   "references": [
     {
       "title": "Gauss's generalization of Wilson's theorem",


### PR DESCRIPTION
Enrichment pass for `gauss-wilson-non-cyclic-oq-04` (Counting Square Roots of Unity mod n, odd case).

## Changes
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site even though it appears in the gallery listing. This is the highest-impact fix.
- **Added `sections`** (was empty `[]`) — a 6-section breakdown covering the full 182-line Lean file: statement/strategy, definition + base case, odd-prime-power ±1 classification, local count N(p^k)=2, CRT multiplicativity, and the main assembly.
- **Added 2 annotations** filling the two uncovered declarations: `sqrtOneCount_one` (base case N(1)=1, the multiplicative normalization) and `one_ne_neg_one_prime_pow` (distinctness 1 ≠ -1 at odd prime powers). Coverage 5 → 7 annotations.
- **Corrected `lineCount`** 177 → 182 in `meta.meta`, `leanFile`, and the conclusion summary to match the actual file.

No mathematical claims changed; status/badge/axiomCount (verified/original/0) are accurate against the Lean source.