### PR TITLE
Enrich banach-fixed-point-oq-01-oq-01-oq-02: add index.ts, sections, crossRef

### DIFF
--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-02/annotations.json
@@ -34,6 +34,18 @@
     "prerequisites": ["interval integrals"]
   },
   {
+    "id": "picard-explicit-oq010102-helpers",
+    "proofId": "banach-fixed-point-oq-01-oq-01-oq-02",
+    "range": { "startLine": 55, "endLine": 74 },
+    "type": "technique",
+    "title": "The Taylor partial sum and the monomial integral",
+    "content": "Three auxiliary pieces feed the induction of picardIter_eq. partialExp n t = ∑_{k∈range(n+1)} tᵏ/k! is the (n+1)-term Taylor partial sum, the explicit target the iterates will match. continuous_partialExp records that each partial sum is continuous (a finite sum of monomials, via continuous_finset_sum + fun_prop), which is what makes it interval-integrable in the induction step. integral_term evaluates a single monomial: ∫₀ᵗ sᵏ/k! ds = tᵏ⁺¹/(k+1)!, pulling out 1/k! with integral_div, applying integral_pow, killing the lower endpoint with zero_pow, and absorbing the extra factor via Nat.factorial_succ and div_div.",
+    "mathContext": "$\\int_0^t \\frac{s^k}{k!}\\,ds = \\frac{t^{k+1}}{(k+1)!}$ — integrating the $k$-th Taylor term raises it to the $(k+1)$-th, which is exactly why one Picard step advances the partial sum by one term.",
+    "significance": "supporting",
+    "relatedConcepts": ["Taylor partial sum", "term-by-term integration", "factorial recursion"],
+    "prerequisites": ["intervalIntegral.integral_div", "intervalIntegral.integral_pow", "Nat.factorial_succ"]
+  },
+  {
     "id": "picard-explicit-oq010102-closed-form",
     "proofId": "banach-fixed-point-oq-01-oq-01-oq-02",
     "range": { "startLine": 75, "endLine": 94 },

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PicardIterationExplicitOQ0102.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const banachFixedPointOq01Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const banachFixedPointOq01Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const banachFixedPointOq01Oq01Oq02Data: ProofData = {
+  proof: banachFixedPointOq01Oq01Oq02Proof,
+  annotations: banachFixedPointOq01Oq01Oq02Annotations,
+}

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-02/meta.json
@@ -90,6 +90,57 @@
       "Package the contraction estimate as a bona fide ContractingWith instance on the space C([0,ε], ℝ) with sup-norm for ε < 1, recovering the parent's Banach fixed point from this concrete operator and matching the two convergence rates."
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Problem: making the Picard fixed point explicit",
+      "startLine": 3,
+      "endLine": 39,
+      "summary": "Docstring framing the parent's open question — expose the Picard operator, its successive approximations, and its contraction constant explicitly — and the answer for the model IVP y' = y, y(0) = 1: the iterates are the Taylor partial sums of exp, they converge, exp is the fixed point, and P contracts with an explicit constant."
+    },
+    {
+      "id": "sec-operator",
+      "title": "The Picard operator and its iterates",
+      "startLine": 46,
+      "endLine": 53,
+      "summary": "Defines the concrete Picard operator (P y)(t) = 1 + ∫₀ᵗ y and the successive approximations picardIter (constant seed 1, picardIter (n+1) = P (picardIter n))."
+    },
+    {
+      "id": "sec-helpers",
+      "title": "Taylor partial sum and its integral",
+      "startLine": 55,
+      "endLine": 74,
+      "summary": "Auxiliary definitions/lemmas: partialExp n = ∑_{k≤n} tᵏ/k!, its continuity (continuous_partialExp), and the term integral ∫₀ᵗ sᵏ/k! ds = tᵏ⁺¹/(k+1)! (integral_term) that drives the induction step."
+    },
+    {
+      "id": "sec-closed-form",
+      "title": "Closed form: iterates are Taylor partial sums",
+      "startLine": 75,
+      "endLine": 94,
+      "summary": "picardIter_eq: by induction, the n-th approximation equals ∑_{k=0}^{n} tᵏ/k!, integrating the partial sum term by term and reindexing via Finset.sum_range_succ'."
+    },
+    {
+      "id": "sec-convergence",
+      "title": "Convergence to exp and the fixed point",
+      "startLine": 96,
+      "endLine": 118,
+      "summary": "picardIter_tendsto (the iterates converge to exp t via the exponential power series), exp_isFixedPoint (exp t = 1 + ∫₀ᵗ exp), and exp_solves (deriv exp = exp, exp 0 = 1)."
+    },
+    {
+      "id": "sec-contraction",
+      "title": "Explicit contraction estimate",
+      "startLine": 120,
+      "endLine": 140,
+      "summary": "picard_contraction: |P y t − P z t| ≤ C·|t| via norm_integral_le_of_norm_le_const, so P contracts on [0, ε] with constant ε; picardIter_succ_eq records the recursion picardIter (n+1) = P (picardIter n)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "banach-fixed-point-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent Picard–Lindelöf entry. This entry answers its second open question by exhibiting the Picard operator, its successive approximations, and its contraction constant explicitly for the model linear IVP y' = y, y(0) = 1."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"


### PR DESCRIPTION
Enrichment pass for `banach-fixed-point-oq-01-oq-01-oq-02` (Picard iteration as an explicit contraction for y' = y).

## Changes
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site. Highest-impact fix.
- **Added `sections`** (absent) — a 6-section breakdown covering the full 140-line Lean file: problem framing, operator + iterates, Taylor-partial-sum helpers, closed form, convergence + fixed point, and the explicit contraction estimate.
- **Added `crossReferences`** (absent) — link to the parent Picard–Lindelöf entry `banach-fixed-point-oq-01-oq-01` (verified present on main) whose second open question this entry answers.
- **Added 1 annotation** filling the 55-74 coverage gap: the `partialExp` definition, `continuous_partialExp`, and `integral_term` helper lemmas that drive the induction. Coverage 6 → 7 annotations.

The already-rich meta (historicalContext, proofStrategy, 4 keyInsights, conclusion) was preserved. meta.json is 14.9 KB, well under the size cap. Status/badge/axiomCount (verified/verified/0) accurately reflect the Lean source (0 sorries, no native_decide).