### PR TITLE
Enrich harmonic-divergence-oq-01-oq-02: add missing index.ts + header section

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-01-oq-02/index.ts
+++ b/src/data/proofs/harmonic-divergence-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HarmonicDivergenceOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const harmonicDivergenceOq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const harmonicDivergenceOq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const harmonicDivergenceOq01Oq02Data: ProofData = {
+  proof: harmonicDivergenceOq01Oq02Proof,
+  annotations: harmonicDivergenceOq01Oq02Annotations,
+}

--- a/src/data/proofs/harmonic-divergence-oq-01-oq-02/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-01-oq-02/meta.json
@@ -77,6 +77,13 @@
   },
   "sections": [
     {
+      "id": "sec-header",
+      "title": "Overview: γ = -Γ'(1)",
+      "startLine": 1,
+      "endLine": 42,
+      "description": "Docstring and imports. Frames the entry as discharging the parent Euler–Mascheroni entry's second open question — identifying the Euler–Mascheroni constant γ as the negative derivative of the Gamma function at 1 — and states the results proved: the defining identity, its integer-argument generalization, and supporting positivity/monotonicity facts."
+    },
+    {
       "id": "sec-gamma-deriv-connection",
       "title": "The Defining Connection γ = -Γ'(1)",
       "startLine": 43,


### PR DESCRIPTION
Enrichment pass for `harmonic-divergence-oq-01-oq-02` (The Euler–Mascheroni Constant as a Gamma-Function Derivative, γ = −Γ'(1)).

## Changes
- **Created missing `index.ts`** — without it the proof rendered "proof not found" on the live site. Highest-impact fix.
- **Added an overview/header section** (lines 1-42) so the `sections` array covers the full 152-line file rather than starting at line 43.

The entry already had strong metadata (full annotation coverage, 3 crossReferences). No content changes beyond the additions above.