### PR TITLE
Enrich bounded-prime-gaps-oq-04-oq-03: add missing index.ts

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/index.ts
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BoundedPrimeGapsOQ04OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const boundedPrimeGapsOq04Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const boundedPrimeGapsOq04Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const boundedPrimeGapsOq04Oq03Data: ProofData = {
+  proof: boundedPrimeGapsOq04Oq03Proof,
+  annotations: boundedPrimeGapsOq04Oq03Annotations,
+}


### PR DESCRIPTION
The entry `bounded-prime-gaps-oq-04-oq-03` (The Gauss Sum Bound |τ(χ)| = √p) had rich metadata already — full section and annotation coverage of the 135-line Lean file plus 3 crossReferences — but was **missing `index.ts`**, so Vite's `import.meta.glob` could not discover it and the proof page rendered "proof not found" on the live site.

This adds the standard Vite entry point importing `Proofs/BoundedPrimeGapsOQ04OQ03.lean`, enabling the proof to load. No content changes.