### PR TITLE
Enrich cauchy-schwarz-oq-07-oq-01: add missing index.ts

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-07-oq-01/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-07-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzOQ07OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchySchwarzOq07Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchySchwarzOq07Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchySchwarzOq07Oq01Data: ProofData = {
+  proof: cauchySchwarzOq07Oq01Proof,
+  annotations: cauchySchwarzOq07Oq01Annotations,
+}


### PR DESCRIPTION
The entry `cauchy-schwarz-oq-07-oq-01` had `meta.json` and `annotations.json` but was **missing `index.ts`**, so Vite's `import.meta.glob` could not discover it and the proof page rendered "proof not found" on the live site. This adds the standard Vite entry point so the proof loads. No content changes.