### PR TITLE
Enrich cayleys-theorem-oq-01: add missing index.ts

### DIFF
--- a/src/data/proofs/cayleys-theorem-oq-01/index.ts
+++ b/src/data/proofs/cayleys-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CayleysTheoremOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cayleysTheoremOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cayleysTheoremOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cayleysTheoremOq01Data: ProofData = {
+  proof: cayleysTheoremOq01Proof,
+  annotations: cayleysTheoremOq01Annotations,
+}


### PR DESCRIPTION
The entry `cayleys-theorem-oq-01` had `meta.json` and `annotations.json` but was **missing `index.ts`**, so Vite's `import.meta.glob` could not discover it and the proof page rendered "proof not found" on the live site. This adds the standard Vite entry point so the proof loads. No content changes.