### PR TITLE
research(binary-gcd-oq-01-oq-01-oq-01): matching Ω((log N)² ) lower bound for Stein binary-GCD [0-axiom]

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ01OQ01.lean
@@ -1,0 +1,177 @@
+/-
+  Binary GCD OQ-01-OQ-01-OQ-01: a matching Ω((log N)²) lower bound for the
+  total bit-operation cost of Stein's binary GCD.
+
+  The grandparent `BinaryGcdOQ01` counts reduction *steps* (`binaryGcdSteps`)
+  and bounds them by `2*(log₂ a + log₂ b) + 2`. The parent `BinaryGcdOQ01OQ01`
+  charges each step its honest bit cost `Nat.size a + Nat.size b`, accumulates
+  it into `binaryGcdCost`, and proves the classical **upper** bound
+
+      binaryGcdCost a b ≤ (2*(log₂ a + log₂ b) + 2) * (log₂ a + log₂ b + 2)
+                        = O((log N)²).
+
+  The open question left by that file (its `openQuestions[0]`) asks for a
+  **matching lower bound**: an input family for which `binaryGcdCost` is
+  `Ω((log N)²)`, showing the quadratic upper bound is tight and not merely an
+  over-estimate. This file answers it.
+
+  The worst-case family is the all-ones odd number against `1`:
+
+      N = 2^(k+1) - 1   (binary: k+1 ones),   b = 1.
+
+  Both operands are odd and `N > 1`, so a single reduction subtracts `1` and
+  halves, sending `(2^(m+1) - 1, 1) → (2^m - 1, 1)` at a per-step cost of
+  `Nat.size (2^(m+1) - 1) + Nat.size 1 = (m+1) + 1 = m + 2`. Summing the arithmetic
+  progression `2, 3, …, k+2` gives the exact closed form
+
+      binaryGcdCost (2^(k+1) - 1) 1 = (k+1)(k+4) / 2,
+
+  stated here division-free as `2 * binaryGcdCost (2^(k+1) - 1) 1 = (k+1)(k+4)`.
+  Since `log₂ (2^(k+1) - 1) = k`, this is `Ω(k²) = Ω((log N)²)`, matching the
+  parent's `O((log N)²)` upper bound: the binary GCD really can cost a quadratic
+  number of bit operations.
+
+  Main results.
+
+  * `cost_family`
+        2 * binaryGcdCost (2^(k+1) - 1) 1 = (k+1) * (k+4)
+    the exact per-family cost (division-free).
+
+  * `binaryGcdCost_lower_bound`
+        (k+1)^2 ≤ 2 * binaryGcdCost (2^(k+1) - 1) 1
+    the clean quadratic lower bound in the bit-length parameter `k`.
+
+  * `binaryGcdCost_omega_lower`
+        (log₂ N)^2 ≤ 2 * binaryGcdCost N 1        (N = 2^(k+1) - 1)
+    the Ω((log N)²) statement in the parent's `Nat.log 2` units.
+
+  * `binaryGcdCost_family_matching`
+    the lower bound together with the parent's quadratic upper bound, both
+    Θ((log N)²): the quadratic total-cost bound is tight.
+
+  All results are axiom-free (only the foundational
+  propext / Classical.choice / Quot.sound), 0 sorries, no `native_decide`.
+
+  References:
+  - Stein (1967), Binary GCD Algorithm
+  - Brent (1976), analysis of the binary GCD
+  - Knuth, TAOCP 4.5.2
+  - BinaryGcdOQ01OQ01.lean (total cost `binaryGcdCost` + O((log N)²) upper bound)
+-/
+import Mathlib
+import Proofs.BinaryGcdOQ01OQ01
+
+namespace BinaryGcdOQ01OQ01OQ01
+
+open Nat BinaryGcdOQ01 BinaryGcdOQ01OQ01
+
+/-! ## Bit-length helpers -/
+
+/-- The bit-length of `2^k - 1` is exactly `k`: in binary it is a block of `k`
+    ones. -/
+theorem size_two_pow_sub_one (k : ℕ) : Nat.size (2 ^ k - 1) = k := by
+  cases k with
+  | zero => simp
+  | succ n =>
+    have hpow : (1 : ℕ) ≤ 2 ^ n := Nat.one_le_pow n 2 (by norm_num)
+    have h2 : 2 ^ (n + 1) = 2 ^ n * 2 := pow_succ 2 n
+    apply le_antisymm
+    · rw [Nat.size_le]; omega
+    · exact Nat.lt_size.mpr (by omega)
+
+/-- `Nat.size 1 = 1` (specialisation of `size_two_pow_sub_one` at `k = 1`). -/
+theorem size_one : Nat.size 1 = 1 := by
+  have h := size_two_pow_sub_one 1
+  norm_num at h
+  exact h
+
+/-! ## The worst-case recursion
+
+On the family `(2^(m+1) - 1, 1)` both operands are odd and the first exceeds the
+second, so the binary GCD takes the "subtract then halve" branch:
+`(2^(m+1) - 1, 1) → (2^m - 1, 1)`. -/
+
+/-- Base of the family recursion: `binaryGcdCost 1 1 = 2` (one odd/odd step of
+    cost `size 1 + size 1 = 2`, landing on `(1, 0)`). -/
+theorem cost_base : binaryGcdCost 1 1 = 2 := by
+  show binaryGcdCost (0 + 1) (0 + 1) = 2
+  rw [binaryGcdCost.eq_3, if_neg (by decide), if_neg (by decide), if_neg (by decide)]
+  norm_num [Nat.sub_self, Nat.zero_div, binaryGcdCost_zero_right, size_one]
+
+/-- One reduction step of the worst-case family: peeling `(2^(k+2) - 1, 1)`
+    costs `size (2^(k+2) - 1) + size 1 = (k+2) + 1 = k+3` and reduces to
+    `(2^(k+1) - 1, 1)`. -/
+theorem cost_step (k : ℕ) :
+    binaryGcdCost (2 ^ (k + 2) - 1) 1
+      = (k + 3) + binaryGcdCost (2 ^ (k + 1) - 1) 1 := by
+  have hk : (1 : ℕ) ≤ 2 ^ k := Nat.one_le_pow k 2 (by norm_num)
+  have hp1 : 2 ^ (k + 1) = 2 ^ k * 2 := pow_succ 2 k
+  have hp2 : 2 ^ (k + 2) = 2 ^ (k + 1) * 2 := pow_succ 2 (k + 1)
+  obtain ⟨a', ha'⟩ : ∃ a', 2 ^ (k + 2) - 1 = a' + 1 := ⟨2 ^ (k + 2) - 2, by omega⟩
+  rw [ha']
+  show binaryGcdCost (a' + 1) (0 + 1)
+      = (k + 3) + binaryGcdCost (2 ^ (k + 1) - 1) 1
+  rw [binaryGcdCost.eq_3, if_neg (by omega), if_neg (by decide), if_pos (by omega)]
+  have harg : (a' + 1 - (0 + 1)) / 2 = 2 ^ (k + 1) - 1 := by omega
+  have hsize : Nat.size (a' + 1) = k + 2 := by
+    rw [← ha']; exact size_two_pow_sub_one (k + 2)
+  rw [harg]
+  simp only [Nat.zero_add]
+  rw [hsize, size_one]
+  omega
+
+/-! ## The matching lower bound -/
+
+/-- **Exact cost of the worst-case family (division-free).** The all-ones odd
+    number `2^(k+1) - 1` run against `1` costs exactly `(k+1)(k+4)/2` bit
+    operations, here stated as a doubled identity to stay in `ℕ`. -/
+theorem cost_family (k : ℕ) :
+    2 * binaryGcdCost (2 ^ (k + 1) - 1) 1 = (k + 1) * (k + 4) := by
+  induction k with
+  | zero =>
+    norm_num [show (2 : ℕ) ^ (0 + 1) - 1 = 1 from by norm_num, cost_base]
+  | succ n ih =>
+    show 2 * binaryGcdCost (2 ^ (n + 2) - 1) 1 = (n + 2) * (n + 5)
+    rw [cost_step, Nat.mul_add, ih]
+    ring
+
+/-- **Quadratic lower bound.** In the bit-length parameter `k`, the worst-case
+    family costs at least `(k+1)²/2` bit operations. Together with the parent's
+    `O((log N)²)` upper bound this shows the quadratic total cost is genuine. -/
+theorem binaryGcdCost_lower_bound (k : ℕ) :
+    (k + 1) ^ 2 ≤ 2 * binaryGcdCost (2 ^ (k + 1) - 1) 1 := by
+  have h := cost_family k
+  nlinarith [h]
+
+/-- **Matching Ω((log N)²) lower bound.** For every `k`, the binary-GCD input
+    `N = 2^(k+1) - 1` has `Nat.log 2 N = k`, yet its total bit-operation cost
+    obeys `(log₂ N)² ≤ 2 · binaryGcdCost N 1`. Hence `binaryGcdCost N 1` is
+    `Ω((log N)²)`: the parent's `O((log N)²)` upper bound is tight, not an
+    over-estimate. -/
+theorem binaryGcdCost_omega_lower (k : ℕ) :
+    (Nat.log 2 (2 ^ (k + 1) - 1)) ^ 2 ≤ 2 * binaryGcdCost (2 ^ (k + 1) - 1) 1 := by
+  have hk : (1 : ℕ) ≤ 2 ^ k := Nat.one_le_pow k 2 (by norm_num)
+  have hp1 : 2 ^ (k + 1) = 2 ^ k * 2 := pow_succ 2 k
+  have hlog : Nat.log 2 (2 ^ (k + 1) - 1) = k :=
+    Nat.log_eq_of_pow_le_of_lt_pow (by omega) (by omega)
+  rw [hlog]
+  calc k ^ 2 ≤ (k + 1) ^ 2 := by nlinarith
+    _ ≤ 2 * binaryGcdCost (2 ^ (k + 1) - 1) 1 := binaryGcdCost_lower_bound k
+
+/-- **Tightness of the quadratic total-cost bound.** For the family
+    `N = 2^(k+1) - 1` (with `b = 1`) the total cost is squeezed between
+    `(log₂ N)²/2` and the parent's quadratic upper bound — both `Θ((log N)²)`. -/
+theorem binaryGcdCost_family_matching (k : ℕ) :
+    (Nat.log 2 (2 ^ (k + 1) - 1)) ^ 2 ≤ 2 * binaryGcdCost (2 ^ (k + 1) - 1) 1
+      ∧ binaryGcdCost (2 ^ (k + 1) - 1) 1
+          ≤ (2 * (Nat.log 2 (2 ^ (k + 1) - 1) + Nat.log 2 1) + 2)
+              * (Nat.log 2 (2 ^ (k + 1) - 1) + Nat.log 2 1 + 2) := by
+  have hpos : 0 < 2 ^ (k + 1) - 1 := by
+    have h2 : 2 ≤ 2 ^ (k + 1) := by
+      calc (2 : ℕ) = 2 ^ 1 := (pow_one 2).symm
+        _ ≤ 2 ^ (k + 1) := Nat.pow_le_pow_right (by norm_num) (by omega)
+    omega
+  exact ⟨binaryGcdCost_omega_lower k,
+    BinaryGcdOQ01OQ01.binaryGcdCost_le_quadratic _ 1 hpos (by norm_num)⟩
+
+end BinaryGcdOQ01OQ01OQ01

--- a/src/data/proofs/binary-gcd-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,170 @@
+[
+  {
+    "id": "ann-bgcdlb-1",
+    "proofId": "binary-gcd-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 59
+    },
+    "type": "concept",
+    "title": "From an Upper Bound to a Matching Lower Bound",
+    "content": "**Framing.** The parent `binary-gcd-oq-01-oq-01` proved the classical upper bound $\\mathtt{binaryGcdCost}\\,a\\,b \\le O((\\log N)^2)$ but left open (its `openQuestions[0]`) whether that quadratic bound is *achieved* or merely an over-estimate. This entry settles it by exhibiting an explicit worst-case family and computing its cost exactly. The family is the all-ones odd number against $1$: $N = 2^{k+1} - 1$ (binary: $k+1$ ones) and $b = 1$. Both operands are odd and $N > 1$, so Stein's algorithm is forced into the odd/odd, $a > b$ branch at every step — subtract $1$, then halve — giving the chain $(2^{m+1}-1, 1) \\to (2^m - 1, 1)$.",
+    "mathContext": "Per-step cost at $(2^{m+1}-1, 1)$ is $\\mathtt{Nat.size}(2^{m+1}-1) + \\mathtt{Nat.size}\\,1 = (m+1)+1 = m+2$; summing $m = 0,\\dots,k$ gives $\\sum_{m=1}^{k+1}(m+1) = (k+1)(k+4)/2 = \\Omega(k^2) = \\Omega((\\log N)^2)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Matching lower bounds for algorithm cost models",
+      "Worst-case analysis of Stein's Binary GCD",
+      "Omega((log N)^2) bit-complexity"
+    ],
+    "prerequisites": [
+      "The parent cost model binaryGcdCost and its O((log N)^2) upper bound",
+      "Stein's Binary GCD odd/odd subtract-and-halve reduction"
+    ],
+    "tags": [
+      "module-header",
+      "framing",
+      "lower-bound",
+      "binary-gcd"
+    ]
+  },
+  {
+    "id": "ann-bgcdlb-2",
+    "proofId": "binary-gcd-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 70,
+      "endLine": 86
+    },
+    "type": "lemma",
+    "title": "Bit-Length of an All-Ones Number",
+    "content": "**Helper.** `size_two_pow_sub_one` proves $\\mathtt{Nat.size}(2^k - 1) = k$: the number $2^k - 1$ is a block of $k$ ones, so its bit-length is exactly $k$. The proof is by antisymmetry — $\\mathtt{Nat.size\\_le}$ ($\\mathtt{size}\\,m \\le n \\iff m < 2^n$) gives the upper half from $2^k - 1 < 2^k$, and $\\mathtt{Nat.lt\\_size}$ ($m < \\mathtt{size}\\,n \\iff 2^m \\le n$) gives the lower half from $2^{k-1} \\le 2^k - 1$; both inequalities are discharged by `omega` after supplying $2^{n+1} = 2^n \\cdot 2$. `size_one` is the $k = 1$ specialisation $\\mathtt{Nat.size}\\,1 = 1$.",
+    "mathContext": "This fixes the exact per-step bit cost of the worst-case family: $\\mathtt{Nat.size}(2^{m+1}-1) = m+1$, so charging bit-length per step yields $m+2$ at the $m$-th reduction.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.size (bit-length)",
+      "All-ones binary representation",
+      "Nat.size_le / Nat.lt_size"
+    ],
+    "prerequisites": [
+      "Nat.size and its characterisations",
+      "omega for linear arithmetic with a single power atom"
+    ],
+    "tags": [
+      "bit-length",
+      "nat-size",
+      "helper-lemma"
+    ]
+  },
+  {
+    "id": "ann-bgcdlb-3",
+    "proofId": "binary-gcd-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 121
+    },
+    "type": "lemma",
+    "title": "The Forced Subtract-and-Halve Step",
+    "content": "**The recurrence engine.** `cost_base` computes the terminal step $\\mathtt{binaryGcdCost}\\,1\\,1 = 2$: $(1,1)$ is odd/odd with $1 \\not> 1$, so it takes the last else branch to $(1, 0)$ at cost $\\mathtt{size}\\,1 + \\mathtt{size}\\,1 = 2$. `cost_step` is the single-step recurrence $\\mathtt{binaryGcdCost}(2^{k+2}-1)\\,1 = (k+3) + \\mathtt{binaryGcdCost}(2^{k+1}-1)\\,1$. Writing $2^{k+2}-1 = a'+1$ and $1 = 0+1$, the definitional equation lemma `binaryGcdCost.eq_3` exposes the five-branch if-tree; `omega` decides the guards (the operand is odd and $> 1$, so the odd/odd $a > b$ branch is taken) and evaluates $(a'+1 - 1)/2 = 2^{k+1}-1$; `size_two_pow_sub_one` supplies the step cost $(k+2)+1 = k+3$.",
+    "mathContext": "Subtracting $1$ from the all-ones number $2^{k+2}-1$ gives the even $2^{k+2}-2$, and halving drops the leading bit to $2^{k+1}-1$ — one fewer one. The reduction is deterministic, so the whole cost is a clean first-order recurrence.",
+    "significance": "major",
+    "relatedConcepts": [
+      "Definitional equation lemmas (binaryGcdCost.eq_3)",
+      "First-order linear recurrence",
+      "Forced branch selection via omega"
+    ],
+    "prerequisites": [
+      "binaryGcdCost.eq_3 and binaryGcdCost_zero_right",
+      "size_two_pow_sub_one",
+      "omega for parity, comparison, and division-by-2 guards"
+    ],
+    "tags": [
+      "recurrence",
+      "equation-lemma",
+      "binary-gcd",
+      "worst-case"
+    ]
+  },
+  {
+    "id": "ann-bgcdlb-4",
+    "proofId": "binary-gcd-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 125,
+      "endLine": 139
+    },
+    "type": "theorem",
+    "title": "Exact Cost of the Worst-Case Family",
+    "content": "**Closed form.** `cost_family` solves the recurrence into the division-free identity $2 \\cdot \\mathtt{binaryGcdCost}(2^{k+1}-1)\\,1 = (k+1)(k+4)$, i.e. the family costs exactly $(k+1)(k+4)/2$ bit operations. The proof is induction on $k$: the base is `cost_base` (via $2^{0+1}-1 = 1$), and the step applies `cost_step`, distributes with `Nat.mul_add`, rewrites the recursive term with the induction hypothesis, and closes the polynomial identity $2(n+3) + (n+1)(n+4) = (n+2)(n+5)$ with `ring`.",
+    "mathContext": "Doubling avoids the truncating $\\mathbb{N}$-division in $(k+1)(k+4)/2$, keeping the induction step a pure semiring identity that `ring` discharges. The value matches the arithmetic-series sum $2 + 3 + \\cdots + (k+2)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Closed-form solution of a recurrence",
+      "Division-free ℕ identities",
+      "Arithmetic series"
+    ],
+    "prerequisites": [
+      "cost_base and cost_step",
+      "ring for commutative-semiring identities"
+    ],
+    "tags": [
+      "closed-form",
+      "induction",
+      "exact-cost",
+      "binary-gcd"
+    ]
+  },
+  {
+    "id": "ann-bgcdlb-5",
+    "proofId": "binary-gcd-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 138,
+      "endLine": 159
+    },
+    "type": "theorem",
+    "title": "The Ω((log N)²) Lower Bound",
+    "content": "**Matching bound.** `binaryGcdCost_lower_bound` extracts $(k+1)^2 \\le 2 \\cdot \\mathtt{binaryGcdCost}(2^{k+1}-1)\\,1$ from the closed form via $(k+1)^2 \\le (k+1)(k+4)$ (`nlinarith`). `binaryGcdCost_omega_lower` converts this into the parent's $\\mathtt{Nat.log}\\,2$ units: `Nat.log_eq_of_pow_le_of_lt_pow` gives $\\mathtt{Nat.log}\\,2\\,(2^{k+1}-1) = k$ (since $2^k \\le 2^{k+1}-1 < 2^{k+1}$), so $(\\log_2 N)^2 \\le 2 \\cdot \\mathtt{binaryGcdCost}\\,N\\,1$ — precisely the $\\Omega((\\log N)^2)$ statement the parent asked for.",
+    "mathContext": "The step count of this family is only $\\Theta(\\log N)$ (Lame), yet each step costs $\\Theta(\\log N)$ bits and the operand shrinks by just one bit per step, so the total is the quadratic arithmetic series — the source of the $\\Omega((\\log N)^2)$ bit cost.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Omega lower bounds",
+      "Nat.log and Nat.log_eq_of_pow_le_of_lt_pow",
+      "Bit-complexity vs step count"
+    ],
+    "prerequisites": [
+      "cost_family",
+      "nlinarith; Nat.log_eq_of_pow_le_of_lt_pow"
+    ],
+    "tags": [
+      "lower-bound",
+      "log-complexity",
+      "omega-notation",
+      "binary-gcd"
+    ]
+  },
+  {
+    "id": "ann-bgcdlb-6",
+    "proofId": "binary-gcd-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 161,
+      "endLine": 177
+    },
+    "type": "theorem",
+    "title": "Tightness: Θ((log N)²)",
+    "content": "**Two-sided squeeze.** `binaryGcdCost_family_matching` pairs this file's lower bound with the parent's quadratic upper bound `binaryGcdCost_le_quadratic`, applied at $a = 2^{k+1}-1 > 0$ and $b = 1$. On this family the total cost is squeezed between $(\\log_2 N)^2/2$ and $(2(\\log_2 a + \\log_2 b) + 2)(\\log_2 a + \\log_2 b + 2)$, both $\\Theta((\\log N)^2)$. This certifies that the parent's $O((\\log N)^2)$ bound is tight, closing the open question.",
+    "mathContext": "Positivity $2^{k+1}-1 > 0$ follows from $2 \\le 2^{k+1}$ (`Nat.pow_le_pow_right`); the upper bound is invoked directly from the parent module, so both directions are certified in one statement.",
+    "significance": "major",
+    "relatedConcepts": [
+      "Theta (tight) asymptotics",
+      "Combining matching upper and lower bounds",
+      "Cross-module reuse of the parent's upper bound"
+    ],
+    "prerequisites": [
+      "binaryGcdCost_omega_lower",
+      "parent binaryGcdCost_le_quadratic"
+    ],
+    "tags": [
+      "tightness",
+      "theta-bound",
+      "binary-gcd",
+      "open-question-resolved"
+    ]
+  }
+]

--- a/src/data/proofs/binary-gcd-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "binary-gcd-oq-01-oq-01-oq-01",
+  "slug": "binary-gcd-oq-01-oq-01-oq-01",
+  "title": "Binary GCD: Matching Ω((log N)²) Lower Bound for the Total Cost",
+  "description": "Open question OQ-01 of binary-gcd-oq-01-oq-01. The parent charges each reduction step of Stein's Binary GCD its honest bit cost Nat.size a + Nat.size b, accumulates it into binaryGcdCost, and proves the classical O((log N)^2) upper bound. That file's openQuestions[0] asks for a matching lower bound: an input family for which binaryGcdCost is Omega((log N)^2), showing the quadratic bound is tight rather than an over-estimate. This entry supplies it. The worst case is the all-ones odd number against 1: for N = 2^(k+1) - 1 and b = 1, both operands are odd and N > 1, so every reduction subtracts 1 and halves, sending (2^(m+1) - 1, 1) to (2^m - 1, 1) at per-step cost Nat.size (2^(m+1) - 1) + Nat.size 1 = (m+1) + 1 = m + 2. Summing the arithmetic progression 2, 3, ..., k+2 gives the exact closed form binaryGcdCost (2^(k+1) - 1) 1 = (k+1)(k+4)/2, stated division-free as 2 * binaryGcdCost (2^(k+1) - 1) 1 = (k+1)(k+4). Since Nat.log 2 (2^(k+1) - 1) = k, this is Omega(k^2) = Omega((log N)^2). Results (all axiom-free, no native_decide): the exact doubled closed form cost_family; the quadratic lower bound (k+1)^2 <= 2 * binaryGcdCost (2^(k+1) - 1) 1; the log-form bound (log2 N)^2 <= 2 * binaryGcdCost N 1; and binaryGcdCost_family_matching, which pairs the lower bound with the parent's quadratic upper bound to exhibit both as Theta((log N)^2).",
+  "conclusion": {
+    "summary": "Closes the parent's headline open question by exhibiting the worst-case binary-GCD input family N = 2^(k+1) - 1 (b = 1) and computing its total bit-operation cost exactly: 2 * binaryGcdCost (2^(k+1) - 1) 1 = (k+1)(k+4), i.e. (k+1)(k+4)/2 bit operations. Since log2 N = k this is Omega((log N)^2), matching the parent's O((log N)^2) upper bound. All results are axiom-free with no native_decide.",
+    "implications": "The parent's quadratic total-cost bound is tight, not an over-estimate: the Binary GCD genuinely spends a quadratic number of bit operations on adversarial inputs (an all-ones numerator against 1, forcing a long subtract-and-halve chain whose per-step bit cost decreases only linearly). The reusable pattern is: identify a family on which the branch structure is forced, prove a single-step recurrence via the definitional equation lemma, then solve it in closed form as a division-free ℕ identity.",
+    "openQuestions": [
+      "The exact leading constant across all inputs: cost_family shows 1/2 is achieved on this family, but is (k+1)(k+4)/2 the pointwise maximum of binaryGcdCost over all inputs of bit-length k+1, or can a different family (e.g. Fibonacci-like operands forcing many odd/odd subtractions) cost strictly more?",
+      "A two-sided Theta bound with matching constants: combine this Omega((log N)^2) lower bound with a sharpened upper bound (telescoping the actual per-step bit-lengths rather than step-count times initial length) to pin binaryGcdCost within a constant factor."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Stein's Binary GCD (1967) replaces Euclidean division by shifts, subtractions, and parity tests; its classical analysis (Brent 1976; Knuth TAOCP 4.5.2) gives a total running time of O((log N)^2) bit operations. The grandparent binary-gcd-oq-01 formalised the step count binaryGcdSteps and an O(log N) Lame-style bound (a unit-cost model). The parent binary-gcd-oq-01-oq-01 lifted this to an honest total bit cost binaryGcdCost, charging each step Nat.size a + Nat.size b, and proved the O((log N)^2) upper bound — but left open whether that quadratic bound is achieved. This entry answers the parent's headline open question by exhibiting an explicit worst-case family and computing its cost exactly, establishing the matching Omega((log N)^2) lower bound.",
+    "problemStatement": "**OQ-01 of binary-gcd-oq-01-oq-01 (matching lower bound).** Exhibit an input family for which binaryGcdCost is Omega((log N)^2), certifying that the parent's O((log N)^2) upper bound is tight and not merely an over-estimate.",
+    "proofStrategy": "**The worst-case family.** Take N = 2^(k+1) - 1 (binary: k+1 ones) against b = 1. Both operands are odd and N > 1, so Stein's algorithm is forced into the odd/odd, a > b branch: subtract 1 and halve, sending (2^(m+1) - 1, 1) to (2^m - 1, 1).\n\n**Bit-length (size_two_pow_sub_one).** Nat.size (2^k - 1) = k, by antisymmetry from Nat.size_le (upper) and Nat.lt_size (lower). Hence the per-step cost at (2^(m+1) - 1, 1) is Nat.size (2^(m+1) - 1) + Nat.size 1 = (m+1) + 1 = m + 2.\n\n**Single-step recurrence (cost_step).** Writing 2^(k+2) - 1 = a' + 1 and 1 = 0 + 1, the definitional equation lemma binaryGcdCost.eq_3 exposes the if-tree; omega discharges the parity/comparison conditions (2^(k+2) - 1 is odd and > 1) to select the subtract-and-halve branch, and omega evaluates (a'+1 - (0+1))/2 = 2^(k+1) - 1, giving binaryGcdCost (2^(k+2) - 1) 1 = (k+3) + binaryGcdCost (2^(k+1) - 1) 1.\n\n**Closed form (cost_family).** Induction on k with base binaryGcdCost 1 1 = 2 (cost_base) and step cost_step solves the recurrence to the division-free identity 2 * binaryGcdCost (2^(k+1) - 1) 1 = (k+1)(k+4).\n\n**Lower bounds.** (k+1)^2 <= (k+1)(k+4) gives binaryGcdCost_lower_bound; Nat.log_eq_of_pow_le_of_lt_pow gives Nat.log 2 (2^(k+1) - 1) = k, converting to the log-form binaryGcdCost_omega_lower; pairing with the parent's binaryGcdCost_le_quadratic yields binaryGcdCost_family_matching, both bounds Theta((log N)^2).\n\n**No decide / native_decide** — every arithmetic fact is closed by omega, ring, or nlinarith, so the file rests only on the foundational axioms.",
+    "keyInsights": [
+      "The worst case for Stein's Binary GCD is the all-ones odd numerator 2^(k+1) - 1 against 1: both operands odd forces the subtract-and-halve branch every step, and subtracting 1 from an all-ones number then halving simply drops the leading bit, so the chain lasts k+1 steps with per-step cost decreasing only linearly (m+2). Summing gives the quadratic cost.",
+      "Charging bit-length per step is what makes the cost quadratic: the step COUNT here is only Theta(log N) (Lame), but each step costs Theta(log N) bits, and because the operand shrinks by just one bit per step the total is the arithmetic series 2 + 3 + ... + (k+2) = Theta(k^2).",
+      "Stating the exact cost as the doubled identity 2 * binaryGcdCost (2^(k+1) - 1) 1 = (k+1)(k+4) keeps the whole development inside ℕ and avoids the (k+1)(k+4)/2 division, so ring closes the induction step cleanly.",
+      "The definitional equation lemma binaryGcdCost.eq_3 plus omega is enough to unfold one forced step of the recursion: omega decides the parity and comparison guards and evaluates the halved difference, so no bespoke branch reasoning is needed.",
+      "Nat.size (2^k - 1) = k (an all-ones number has bit-length equal to its number of bits) is the bridge between the combinatorial per-step cost and the log-based Omega((log N)^2) statement, since Nat.log 2 (2^(k+1) - 1) = k as well."
+    ],
+    "prerequisites": [
+      "binary-gcd-oq-01-oq-01 — the binaryGcdCost definition, its equation lemma binaryGcdCost.eq_3, the boundary lemma binaryGcdCost_zero_right, and the quadratic upper bound binaryGcdCost_le_quadratic",
+      "Nat.size (bit-length) with Nat.size_le and Nat.lt_size; Nat.log with Nat.log_eq_of_pow_le_of_lt_pow",
+      "Solving a first-order linear recurrence by induction, stated division-free in ℕ",
+      "Stein's Binary GCD reduction rules and the fact that an all-ones odd operand forces a maximal subtract-and-halve chain"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: The Matching Lower Bound",
+      "startLine": 1,
+      "endLine": 59,
+      "summary": "Module docstring framing the parent's open question (a matching Omega((log N)^2) lower bound for binaryGcdCost) and describing the worst-case family N = 2^(k+1) - 1 against b = 1, the forced subtract-and-halve chain, the exact closed form (k+1)(k+4)/2, and the four main results. Imports Mathlib and the parent BinaryGcdOQ01OQ01.",
+      "mathContext": "$N = 2^{k+1} - 1$, $b = 1$; per-step cost $m+2$; total $\\sum_{m=1}^{k+1}(m+1) = (k+1)(k+4)/2 = \\Omega((\\log N)^2)$."
+    },
+    {
+      "id": "bit-length-helpers",
+      "title": "Bit-length of an all-ones number",
+      "startLine": 68,
+      "endLine": 86,
+      "summary": "size_two_pow_sub_one: Nat.size (2^k - 1) = k, proved by antisymmetry from Nat.size_le (m < 2^n gives size <= n) and Nat.lt_size (2^m <= n gives m < size). size_one: Nat.size 1 = 1 as the k = 1 specialisation. These fix the per-step bit cost of the family.",
+      "mathContext": "$2^k - 1$ is a block of $k$ ones, so its bit-length $\\mathtt{Nat.size}(2^k - 1)$ is exactly $k$."
+    },
+    {
+      "id": "worst-case-recursion",
+      "title": "The forced subtract-and-halve step",
+      "startLine": 88,
+      "endLine": 121,
+      "summary": "cost_base: binaryGcdCost 1 1 = 2 (one odd/odd step of cost size 1 + size 1 = 2, landing on (1,0)). cost_step: binaryGcdCost (2^(k+2) - 1) 1 = (k+3) + binaryGcdCost (2^(k+1) - 1) 1. The definitional equation lemma binaryGcdCost.eq_3 exposes the if-tree; omega decides the odd/odd, a > b guards and evaluates (a'+1 - 1)/2 = 2^(k+1) - 1; size_two_pow_sub_one supplies the cost (k+2) + 1 = k+3.",
+      "mathContext": "Both operands odd and $2^{k+2}-1 > 1$ force the branch $(2^{k+2}-1, 1) \\to (2^{k+1}-1, 1)$ at cost $\\mathtt{Nat.size}(2^{k+2}-1) + \\mathtt{Nat.size}\\,1 = (k+2)+1 = k+3$."
+    },
+    {
+      "id": "matching-lower-bound",
+      "title": "Exact cost and the Ω((log N)²) lower bound",
+      "startLine": 123,
+      "endLine": 177,
+      "summary": "cost_family solves the recurrence by induction into the division-free identity 2 * binaryGcdCost (2^(k+1) - 1) 1 = (k+1)(k+4). binaryGcdCost_lower_bound extracts (k+1)^2 <= 2 * binaryGcdCost .... binaryGcdCost_omega_lower rewrites via Nat.log 2 (2^(k+1) - 1) = k into (log2 N)^2 <= 2 * binaryGcdCost N 1. binaryGcdCost_family_matching pairs it with the parent's quadratic upper bound to certify Theta((log N)^2).",
+      "mathContext": "$(k+1)^2 \\le (k+1)(k+4) = 2\\,\\mathtt{binaryGcdCost}(2^{k+1}-1)\\,1$ and $\\log_2(2^{k+1}-1) = k$, so the cost is $\\Omega((\\log N)^2)$, matching the parent's $O((\\log N)^2)$ upper bound."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BinaryGcdOQ01OQ01"
+    ],
+    "opens": [
+      "Nat",
+      "BinaryGcdOQ01",
+      "BinaryGcdOQ01OQ01"
+    ],
+    "namespace": "BinaryGcdOQ01OQ01OQ01",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "substantiveTheoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/BinaryGcdOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "cost_family",
+      "type": "core",
+      "description": "Exact total cost of the worst-case family, division-free: 2 * binaryGcdCost (2^(k+1) - 1) 1 = (k+1)(k+4). Proved by induction on k with the single-step recurrence cost_step; the base case is binaryGcdCost 1 1 = 2.",
+      "leanType": "(k : ℕ) → 2 * binaryGcdCost (2 ^ (k + 1) - 1) 1 = (k + 1) * (k + 4)"
+    },
+    {
+      "name": "binaryGcdCost_lower_bound",
+      "type": "core",
+      "description": "Clean quadratic lower bound in the bit-length parameter k: (k+1)^2 <= 2 * binaryGcdCost (2^(k+1) - 1) 1, obtained from the exact closed form since (k+1)^2 <= (k+1)(k+4).",
+      "leanType": "(k : ℕ) → (k + 1) ^ 2 ≤ 2 * binaryGcdCost (2 ^ (k + 1) - 1) 1"
+    },
+    {
+      "name": "binaryGcdCost_omega_lower",
+      "type": "core",
+      "description": "The Omega((log N)^2) statement in the parent's Nat.log 2 units: for N = 2^(k+1) - 1, Nat.log 2 N = k and (Nat.log 2 N)^2 <= 2 * binaryGcdCost N 1. This is the matching lower bound requested by the parent's open question.",
+      "leanType": "(k : ℕ) → (Nat.log 2 (2 ^ (k + 1) - 1)) ^ 2 ≤ 2 * binaryGcdCost (2 ^ (k + 1) - 1) 1"
+    },
+    {
+      "name": "binaryGcdCost_family_matching",
+      "type": "core",
+      "description": "Tightness: for the family N = 2^(k+1) - 1 the total cost is squeezed between (log2 N)^2 / 2 (this file) and the parent's quadratic upper bound binaryGcdCost_le_quadratic, both Theta((log N)^2).",
+      "leanType": "(k : ℕ) → (Nat.log 2 (2^(k+1)-1))^2 ≤ 2 * binaryGcdCost (2^(k+1)-1) 1 ∧ binaryGcdCost (2^(k+1)-1) 1 ≤ (2*(Nat.log 2 (2^(k+1)-1) + Nat.log 2 1) + 2) * (Nat.log 2 (2^(k+1)-1) + Nat.log 2 1 + 2)"
+    },
+    {
+      "name": "cost_step",
+      "type": "supporting",
+      "description": "Single-step recurrence of the worst-case family: binaryGcdCost (2^(k+2) - 1) 1 = (k+3) + binaryGcdCost (2^(k+1) - 1) 1. Proved by unfolding the definitional equation lemma binaryGcdCost.eq_3 and discharging the forced odd/odd, a > b branch.",
+      "leanType": "(k : ℕ) → binaryGcdCost (2 ^ (k + 2) - 1) 1 = (k + 3) + binaryGcdCost (2 ^ (k + 1) - 1) 1"
+    },
+    {
+      "name": "size_two_pow_sub_one",
+      "type": "supporting",
+      "description": "The bit-length of an all-ones number: Nat.size (2^k - 1) = k, via Nat.size_le and Nat.lt_size. Supplies the per-step bit cost m + 2 along the family.",
+      "leanType": "(k : ℕ) → Nat.size (2 ^ k - 1) = k"
+    }
+  ],
+  "meta": {
+    "author": "researcher-14",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
+    "date": "2026-07-01",
+    "status": "verified",
+    "tags": [
+      "algorithms",
+      "number-theory",
+      "gcd",
+      "complexity",
+      "cost-model",
+      "bit-complexity",
+      "bit-length",
+      "lower-bound",
+      "worst-case",
+      "open-question",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/BinaryGcdOQ01OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 177,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.size_le",
+        "description": "Nat.size m <= n iff m < 2 ^ n. Gives the upper half of Nat.size (2^k - 1) = k.",
+        "module": "Mathlib.Data.Nat.Size"
+      },
+      {
+        "theorem": "Nat.lt_size",
+        "description": "m < Nat.size n iff 2 ^ m <= n. Gives the lower half of Nat.size (2^k - 1) = k.",
+        "module": "Mathlib.Data.Nat.Size"
+      },
+      {
+        "theorem": "Nat.log_eq_of_pow_le_of_lt_pow",
+        "description": "b^m <= n and n < b^(m+1) imply Nat.log b n = m. Used to show Nat.log 2 (2^(k+1) - 1) = k, converting the k-parametrised lower bound into the parent's log-based units.",
+        "module": "Mathlib.Data.Nat.Log"
+      },
+      {
+        "theorem": "binaryGcdCost.eq_3",
+        "description": "Definitional equation lemma for the (a'+1, b'+1) branch of the cost recursion; unfolded to expose the odd/odd subtract-and-halve step taken by the worst-case family.",
+        "module": "Proofs.BinaryGcdOQ01OQ01"
+      },
+      {
+        "theorem": "binaryGcdCost_le_quadratic",
+        "description": "Parent's O((log N)^2) upper bound, paired with this file's lower bound in binaryGcdCost_family_matching to certify tightness.",
+        "module": "Proofs.BinaryGcdOQ01OQ01"
+      }
+    ]
+  },
+  "sorries": 0,
+  "crossReferences": [
+    {
+      "targetId": "binary-gcd-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. It defined binaryGcdCost and proved the O((log N)^2) upper bound, then asked (openQuestions[0]) for a matching lower bound. This file answers it: the family N = 2^(k+1) - 1 costs (k+1)(k+4)/2 = Omega((log N)^2)."
+    },
+    {
+      "targetId": "binary-gcd-oq-01",
+      "relationship": "depends-on",
+      "description": "Grandparent. Supplies the step count binaryGcdSteps whose branch structure the cost recursion mirrors; the worst-case family here is exactly the chain of odd/odd subtract-and-halve reductions."
+    },
+    {
+      "targetId": "binary-gcd",
+      "relationship": "depends-on",
+      "description": "Underlying Stein Binary GCD algorithm whose worst-case bit-operation cost is the object of study."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the parent **binary-gcd-oq-01-oq-01** headline open question (`openQuestions[0]`): a matching **Ω((log N)²) lower bound** for the total bit-operation cost `binaryGcdCost`, certifying the parent's `O((log N)²)` upper bound is tight and not an over-estimate.

**Worst-case family:** `N = 2^(k+1) − 1` (all-ones odd) against `b = 1`. Both operands odd forces the subtract-and-halve branch every step, giving the exact division-free closed form
```
2 * binaryGcdCost (2^(k+1) − 1) 1 = (k+1)(k+4)
```
Since `log₂ N = k`, this is `Ω((log N)²)`.

## Main results (0 axioms, 0 sorries, no `native_decide`)
- `cost_family` — exact doubled cost `(k+1)(k+4)`
- `binaryGcdCost_lower_bound` — `(k+1)² ≤ 2·binaryGcdCost …`
- `binaryGcdCost_omega_lower` — `(log₂ N)² ≤ 2·binaryGcdCost N 1`
- `binaryGcdCost_family_matching` — pairs with parent's upper bound → `Θ((log N)²)`

## Provenance & verification status
Orphan rescue: file authored by researcher-14 in the same Mathlib v4.26 session. Static verification done:
- All parent dependencies (`binaryGcdCost`, `.eq_3`, `binaryGcdCost_zero_right`, `binaryGcdCost_le_quadratic`) confirmed present on `main` with matching signatures.
- `.eq_3` branch-unfolding usage matches how the **parent file itself** unfolds the recursion (parent line 113).
- Uses only stable Mathlib API (`Nat.size_le`, `Nat.lt_size`, `Nat.log_eq_of_pow_le_of_lt_pow`, `Nat.pow_le_pow_right`).

⚠️ **Machine build-verification pending** — host disk was 100% full (concurrent build storm) so a clean compile could not be run. Opened as **draft**; will flip to ready after `docker-build.sh Proofs.BinaryGcdOQ01OQ01OQ01` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)