### PR TITLE
research(sperner-ndim-oq-06): constructive Kuhn path-following — 0-axiom bounded-termination engine

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ06.lean
+++ b/proofs/Proofs/SpernerNDimOQ06.lean
@@ -1,0 +1,251 @@
+/-
+# Constructive Kuhn path-following: bounded termination of the door-pivot walk
+
+Research artifact for `sperner-ndim-oq-06`: *"Formalize the Kuhn path-following
+algorithm constructively: given a boundary door on face `d`, follow the unique
+opposite door to reach a fully-coloured (FC) simplex in at most `O(N^d)` steps."*
+
+## Background
+
+The constructive proof of Sperner's lemma (Kuhn 1960; Scarf; Cottle–Dantzig) does
+not merely *count* fully-coloured simplices modulo 2 — it **walks to one**.  On the
+Kuhn (Freudenthal) triangulation of the `d`-cube / simplex with `N` subdivisions,
+one considers *doors*: `(d-1)`-faces carrying the full label set `{0,…,d-1}`.  The
+pivoting rule is deterministic:
+
+* every simplex that is **not** fully coloured but has a door has **exactly one
+  other** door — its *opposite door* — so from a door one steps to a uniquely
+  determined next door;
+* a **fully-coloured** (FC) simplex is a *terminal* room: entering it, there is no
+  opposite door to leave by;
+* a **boundary** door (on face `d` of the outer boundary) is a *source*: it has no
+  interior predecessor door, so it is where the walk starts.
+
+Because pivoting is *reversible* — the opposite-door relation is symmetric on
+interior doors — the successor rule is **injective wherever it does not terminate**,
+so starting from a source it traces a simple path that cannot loop back on itself
+and therefore must stop at a terminal room (an FC simplex) after visiting each door
+at most once, i.e. in at most `#doors = O(N^d)` steps.
+
+## What this file proves
+
+This file isolates and machine-checks the **combinatorial engine** of Kuhn
+path-following, fully abstractly, with `0` sorries and `0` axioms.  We model the
+pivot rule as a partial successor `f : V → Option V` on a finite type `V` of doors
+(`none` = "entered an FC simplex — terminate"), subject to two hypotheses that
+capture the geometry:
+
+* `hinj : ∀ ⦃x y⦄, f x = f y → f x ≠ none → x = y` — **reversibility of pivoting**
+  away from terminal rooms: a non-terminal door is the opposite door of at most one
+  predecessor.  (Full injectivity would be *false*: several distinct terminal doors
+  all pivot to `none`.)
+* `hsrc : ∀ w, f w ≠ some v₀` — the start door `v₀` is a **source** (no interior
+  predecessor), i.e. a boundary door.
+
+This is the constructive companion of the *parity* engine in
+`SpernerTuckerPathFollowing.lean`: parity proves an FC simplex *exists*; this file
+shows the walk *reaches* one, deterministically and in bounded time.
+
+Main results:
+
+* `PathFollow.reaches_none` — **termination with the `O(N^d)` bound**: iterating the
+  pivot from a source reaches `none` (an FC simplex) in at most `Fintype.card V`
+  steps.
+* `PathFollow.exists_terminal_door` — the last door before termination is a genuine
+  *pivot-terminal* door `x` (`f x = none`): its simplex is fully coloured.
+* `PathFollow.KuhnPivot` / `PathFollow.KuhnPivot.reaches_terminal` — the same,
+  packaged from a symmetric interior-pivot relation `succ`/`pred` (the actual
+  geometric input), so `hinj` and `hsrc` are *derived*, not assumed.
+-/
+import Mathlib
+
+namespace SpernerNDimOQ06.PathFollow
+
+open Function
+
+variable {V : Type*} (f : V → Option V)
+
+/-- One pivot step lifted to `Option V`: from a door `some v` move to `f v`; once
+terminal (`none`), stay terminal.  The `n`-fold Kuhn walk from a start door is
+`(step f)^[n] (some v₀)`. -/
+def step (o : Option V) : Option V := o.bind f
+
+@[simp] theorem step_none : step f none = none := rfl
+
+@[simp] theorem step_some (v : V) : step f (some v) = f v := rfl
+
+/-- The door visited after `n` pivot steps, starting from door `v₀`. -/
+def orbit (v₀ : V) (n : ℕ) : Option V := (step f)^[n] (some v₀)
+
+@[simp] theorem orbit_zero (v₀ : V) : orbit f v₀ 0 = some v₀ := rfl
+
+theorem orbit_succ (v₀ : V) (n : ℕ) :
+    orbit f v₀ (n + 1) = step f (orbit f v₀ n) := by
+  simp only [orbit, Function.iterate_succ_apply']
+
+/-- Once the walk terminates it stays terminated (entering an FC simplex is
+absorbing). -/
+theorem orbit_none_of_le {v₀ : V} {m n : ℕ} (hmn : m ≤ n)
+    (hm : orbit f v₀ m = none) : orbit f v₀ n = none := by
+  induction n with
+  | zero =>
+      obtain rfl : m = 0 := Nat.le_zero.mp hmn
+      exact hm
+  | succ k ih =>
+      rcases hmn.lt_or_eq with h | h
+      · rw [orbit_succ, ih (Nat.lt_succ_iff.mp h), step_none]
+      · exact h ▸ hm
+
+/-- **Backward-collision lemma.**  Suppose the walk has not terminated within the
+first `N` steps, yet two of its doors coincide: `orbit i = orbit (i + d)` with a
+positive gap `d`.  Following the equal doors backwards, injectivity-away-from-`none`
+forces the *start* door `v₀` to have a predecessor.  Contrapositively, a source door
+guarantees the walk is simple. -/
+theorem source_pred_of_collision
+    (hinj : ∀ ⦃x y : V⦄, f x = f y → f x ≠ none → x = y) {v₀ : V} {N d : ℕ}
+    (hd : 1 ≤ d) (hall : ∀ n, n ≤ N → orbit f v₀ n ≠ none) :
+    ∀ i, i + d ≤ N → orbit f v₀ i = orbit f v₀ (i + d) → ∃ w, f w = some v₀ := by
+  intro i
+  induction i with
+  | zero =>
+      intro hbound hcol
+      obtain ⟨x, hx⟩ := Option.ne_none_iff_exists'.mp (hall (d - 1) (by omega))
+      have hstep : orbit f v₀ d = f x := by
+        have hde : d = (d - 1) + 1 := by omega
+        rw [hde, orbit_succ, hx, step_some]
+      rw [Nat.zero_add] at hcol
+      rw [orbit_zero, hstep] at hcol
+      exact ⟨x, hcol.symm⟩
+  | succ k ih =>
+      intro hbound hcol
+      obtain ⟨x, hx⟩ := Option.ne_none_iff_exists'.mp (hall k (by omega))
+      obtain ⟨y, hy⟩ := Option.ne_none_iff_exists'.mp (hall (k + d) (by omega))
+      have e1 : orbit f v₀ (k + 1) = f x := by rw [orbit_succ, hx, step_some]
+      have e2 : orbit f v₀ (k + 1 + d) = f y := by
+        have hkd : k + 1 + d = (k + d) + 1 := by omega
+        rw [hkd, orbit_succ, hy, step_some]
+      rw [e1, e2] at hcol
+      have hfx : f x ≠ none := by rw [← e1]; exact hall (k + 1) (by omega)
+      have hxy : x = y := hinj hcol hfx
+      exact ih (by omega) (by rw [hx, hy, hxy])
+
+/-- **Constructive Kuhn path-following — termination in `O(N^d)` steps.**  On a
+finite door set `V`, if pivoting is reversible away from terminal rooms (`hinj`) and
+`v₀` is a source door (`hsrc`), then iterating the pivot from `v₀` reaches `none` —
+a fully-coloured simplex — within `Fintype.card V` steps.  (`Fintype.card V` is the
+number of doors, which on the `N`-fold Kuhn subdivision of a `d`-simplex is
+`O(N^d)`.) -/
+theorem reaches_none [Fintype V]
+    (hinj : ∀ ⦃x y : V⦄, f x = f y → f x ≠ none → x = y) {v₀ : V}
+    (hsrc : ∀ w, f w ≠ some v₀) :
+    ∃ n ≤ Fintype.card V, orbit f v₀ n = none := by
+  set N := Fintype.card V with hN
+  by_contra hcon
+  push_neg at hcon
+  -- `hcon : ∀ n, n ≤ N → orbit f v₀ n ≠ none`.  The walk avoids termination for
+  -- `N + 1` consecutive steps, so it takes `N + 1` `V`-valued doors in a type of
+  -- only `N` doors.  Pigeonhole gives a repeat, hence (backward collision) a
+  -- source predecessor, contradicting `hsrc`.
+  obtain ⟨i, hi, j, hj, hij, hφ⟩ :=
+    Finset.exists_ne_map_eq_of_card_lt_of_maps_to
+      (s := Finset.range (N + 1)) (t := (Finset.univ : Finset V))
+      (f := fun n => (orbit f v₀ n).getD v₀)
+      (by rw [Finset.card_univ, Finset.card_range, ← hN]; exact Nat.lt_succ_self N)
+      (fun a _ => Finset.mem_univ _)
+  have hiN : i ≤ N := by have := Finset.mem_range.mp hi; omega
+  have hjN : j ≤ N := by have := Finset.mem_range.mp hj; omega
+  obtain ⟨xi, hxi⟩ := Option.ne_none_iff_exists'.mp (hcon i hiN)
+  obtain ⟨xj, hxj⟩ := Option.ne_none_iff_exists'.mp (hcon j hjN)
+  rw [hxi, hxj, Option.getD_some, Option.getD_some] at hφ
+  have hoe : orbit f v₀ i = orbit f v₀ j := by rw [hxi, hxj, hφ]
+  rcases Nat.lt_or_ge i j with hlt | hge
+  · have hcol : orbit f v₀ i = orbit f v₀ (i + (j - i)) := by
+      rw [show i + (j - i) = j by omega]; exact hoe
+    obtain ⟨w, hw⟩ :=
+      source_pred_of_collision f hinj (d := j - i) (by omega) hcon i (by omega) hcol
+    exact hsrc w hw
+  · have hgt : j < i := lt_of_le_of_ne hge (Ne.symm hij)
+    have hcol : orbit f v₀ j = orbit f v₀ (j + (i - j)) := by
+      rw [show j + (i - j) = i by omega]; exact hoe.symm
+    obtain ⟨w, hw⟩ :=
+      source_pred_of_collision f hinj (d := i - j) (by omega) hcon j (by omega) hcol
+    exact hsrc w hw
+
+/-- **The terminal door is a genuine FC door.**  Under the same hypotheses, the last
+door `x` reached before the walk enters `none` satisfies `f x = none`: the room on
+its far side is fully coloured.  This is the constructive existence statement Kuhn's
+algorithm outputs. -/
+theorem exists_terminal_door [Fintype V]
+    (hinj : ∀ ⦃x y : V⦄, f x = f y → f x ≠ none → x = y) {v₀ : V}
+    (hsrc : ∀ w, f w ≠ some v₀) :
+    ∃ x : V, f x = none := by
+  classical
+  obtain ⟨n, _, hn⟩ := reaches_none f hinj hsrc
+  have hex : ∃ m, orbit f v₀ m = none := ⟨n, hn⟩
+  have hmnone : orbit f v₀ (Nat.find hex) = none := Nat.find_spec hex
+  have hmpos : 0 < Nat.find hex := by
+    rcases Nat.eq_zero_or_pos (Nat.find hex) with h0 | hpos
+    · exfalso; rw [h0, orbit_zero] at hmnone; exact Option.some_ne_none _ hmnone
+    · exact hpos
+  obtain ⟨x, hx⟩ : ∃ x, orbit f v₀ (Nat.find hex - 1) = some x :=
+    Option.ne_none_iff_exists'.mp (Nat.find_min hex (by omega))
+  have hstep : orbit f v₀ (Nat.find hex) = f x := by
+    have hfe : Nat.find hex = (Nat.find hex - 1) + 1 := by omega
+    rw [hfe, orbit_succ, hx, step_some]
+  rw [hstep] at hmnone
+  exact ⟨x, hmnone⟩
+
+/-- Abstract data of a **Kuhn door-pivot rule** on a finite door set `V`.  `succ v`
+is the opposite door reached by pivoting out of the room entered through door `v`
+(`none` = that room is fully coloured — terminate); `pred` is the reverse pivot, and
+`symm` records that pivoting is **reversible** (the interior-door adjacency is
+symmetric).  From `symm` alone, both hypotheses of `reaches_none` are derived. -/
+structure KuhnPivot (V : Type*) where
+  /-- Opposite-door successor: pivot forward out of a room. -/
+  succ : V → Option V
+  /-- Reverse pivot: the predecessor door. -/
+  pred : V → Option V
+  /-- Reversibility of pivoting: the interior-door adjacency is symmetric. -/
+  symm : ∀ v w, succ v = some w ↔ pred w = some v
+
+namespace KuhnPivot
+
+variable (K : KuhnPivot V)
+
+/-- A **source** door has no interior predecessor (a boundary door). -/
+def IsSource (v₀ : V) : Prop := K.pred v₀ = none
+
+/-- A **terminal** door pivots into a fully-coloured room. -/
+def IsTerminal (x : V) : Prop := K.succ x = none
+
+/-- Reversibility makes `succ` injective wherever it does not terminate. -/
+theorem injOnSome :
+    ∀ ⦃x y : V⦄, K.succ x = K.succ y → K.succ x ≠ none → x = y := by
+  intro x y hxy hne
+  obtain ⟨w, hw⟩ := Option.ne_none_iff_exists'.mp hne
+  have hx : K.pred w = some x := (K.symm x w).mp hw
+  have hy : K.pred w = some y := (K.symm y w).mp (hxy ▸ hw)
+  exact Option.some.inj (hx ▸ hy)
+
+/-- A source door has no `succ`-predecessor. -/
+theorem no_pred_source {v₀ : V} (h : K.IsSource v₀) : ∀ w, K.succ w ≠ some v₀ := by
+  intro w hw
+  have hp : K.pred v₀ = some w := (K.symm w v₀).mp hw
+  rw [show K.pred v₀ = none from h] at hp
+  exact Option.noConfusion hp
+
+/-- **Kuhn's algorithm terminates.**  From any source door, following opposite doors
+reaches a fully-coloured simplex within `Fintype.card V` pivots. -/
+theorem reaches_terminal [Fintype V] {v₀ : V} (h : K.IsSource v₀) :
+    ∃ n ≤ Fintype.card V, orbit K.succ v₀ n = none :=
+  reaches_none K.succ K.injOnSome (K.no_pred_source h)
+
+/-- **Kuhn's algorithm outputs a fully-coloured simplex.**  From any source door,
+the walk ends at a genuine terminal door. -/
+theorem exists_terminal [Fintype V] {v₀ : V} (h : K.IsSource v₀) :
+    ∃ x : V, K.IsTerminal x :=
+  exists_terminal_door K.succ K.injOnSome (K.no_pred_source h)
+
+end KuhnPivot
+
+end SpernerNDimOQ06.PathFollow

--- a/src/data/proofs/sperner-ndim-oq-06/annotations.json
+++ b/src/data/proofs/sperner-ndim-oq-06/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "ann-oq06-module-overview",
+    "proofId": "sperner-ndim-oq-06",
+    "range": { "startLine": 1, "endLine": 61 },
+    "type": "concept",
+    "title": "The Combinatorial Engine of Constructive Kuhn Path-Following",
+    "content": "Kuhn's constructive proof of Sperner's lemma does not merely count fully-coloured (FC) simplices modulo 2 — it walks to one, following opposite doors from a boundary door. Correctness rests on one fact: the door-pivot graph has maximum degree ≤ 2, so a walk from a degree-1 source cannot loop and must end at a sink (an FC simplex). This file isolates that engine abstractly: the pivot is a partial successor f : V → Option V on a finite door set, with none meaning 'entered an FC simplex, terminate'. Two hypotheses capture the geometry — reversibility of pivoting away from terminal rooms (injectivity wherever f x ≠ none) and the source condition (v₀ has no predecessor).",
+    "mathContext": "This is the constructive counterpart of the parity engine in SpernerTuckerPathFollowing.lean: parity proves an FC simplex EXISTS; this file proves the walk REACHES one, in ≤ Fintype.card V = O(N^d) steps. It supplies the acyclicity/termination step that the geometric entry sperner-ndim-oq-04 leaves axiomatized.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sperner's lemma",
+      "door graph",
+      "complementary pivot algorithms",
+      "PPAD",
+      "constructive proofs"
+    ],
+    "prerequisites": [
+      "sperner-ndim door graph",
+      "sperner-ndim-oq-04 geometric path-following"
+    ]
+  },
+  {
+    "id": "ann-oq06-pivot-model",
+    "proofId": "sperner-ndim-oq-06",
+    "range": { "startLine": 68, "endLine": 84 },
+    "type": "definition",
+    "title": "Modelling the Pivot: step and orbit",
+    "content": "step lifts one pivot to Option V via o.bind f: from a door some v move to f v, and from the terminal none stay at none. orbit f v₀ n = (step f)^[n] (some v₀) is the door reached after n pivots from the start door v₀. The simp lemmas step_none, step_some, orbit_zero and the recurrence orbit_succ give the equational theory used throughout.",
+    "mathContext": "Encoding termination as none in Option V turns 'reaching a sink' into 'the orbit hits none', avoiding well-founded recursion and fuel parameters. orbit_succ (n+1) = step f (orbit n) is proved by Function.iterate_succ_apply'.",
+    "significance": "standard",
+    "relatedConcepts": ["Option monad", "function iteration"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-oq06-absorption",
+    "proofId": "sperner-ndim-oq-06",
+    "range": { "startLine": 86, "endLine": 97 },
+    "type": "lemma",
+    "title": "Termination is Absorbing (orbit_none_of_le)",
+    "content": "Once the walk terminates (orbit m = none) it stays terminated for all n ≥ m. The proof inducts on n, using step_none for the successor step and the m = n case at the boundary. Entering an FC simplex is a one-way door.",
+    "mathContext": "This monotonicity into the terminal state is what lets 'reaches none within N steps' be extended to a genuine stopping time later.",
+    "significance": "supporting",
+    "relatedConcepts": ["absorbing state"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-oq06-backward-collision",
+    "proofId": "sperner-ndim-oq-06",
+    "range": { "startLine": 99, "endLine": 130 },
+    "type": "lemma",
+    "title": "Backward-Collision Lemma: Acyclicity from a Source",
+    "content": "The crux. Suppose the walk runs N+1 steps without terminating yet two doors coincide: orbit i = orbit (i+d) with a positive gap d. Peeling one pivot at a time and using injectivity-away-from-none (f x = f y → f x ≠ none → x = y), the equality propagates backwards until index 0, where it exhibits a predecessor of the start door: ∃ w, f w = some v₀. The proof is an induction on the collision index i: the successor case reduces f x = f y to x = y (both non-terminal) and recurses; the base case reads off the predecessor directly.",
+    "mathContext": "Contrapositively: if v₀ has no predecessor (it is a source), the orbit is SIMPLE — no repeats. This is the abstract acyclicity that the geometric door graph needs, proved here purely from reversibility, with no axiom.",
+    "significance": "key",
+    "relatedConcepts": ["injectivity", "acyclicity", "path graphs"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-oq06-reaches-none",
+    "proofId": "sperner-ndim-oq-06",
+    "range": { "startLine": 132, "endLine": 172 },
+    "type": "theorem",
+    "title": "Main Theorem: reaches_none — Termination in O(N^d) Steps",
+    "content": "From a source door v₀ and reversibility-away-from-none, iterating the pivot reaches none — an FC simplex — within Fintype.card V steps. Proof by contradiction: if the walk avoids termination for N+1 = Fintype.card V + 1 consecutive steps, then the N+1 doors orbit 0, …, orbit N are all V-valued, so pigeonhole (Finset.exists_ne_map_eq_of_card_lt_of_maps_to on n ↦ (orbit n).getD v₀) yields a repeat orbit i = orbit j. The backward-collision lemma turns that repeat into a predecessor of v₀, contradicting hsrc.",
+    "mathContext": "Fintype.card V counts the doors; on the N-fold Kuhn subdivision of a d-simplex this is O(N^d), matching Kuhn's known polynomial running time. This is exactly the 'the walk reaches an FC simplex' step that sperner-ndim-oq-04 axiomatizes.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "path-following", "termination bound"],
+    "prerequisites": ["backward-collision lemma"]
+  },
+  {
+    "id": "ann-oq06-terminal-door",
+    "proofId": "sperner-ndim-oq-06",
+    "range": { "startLine": 174, "endLine": 196 },
+    "type": "theorem",
+    "title": "The Output is a Fully-Coloured Simplex (exists_terminal_door)",
+    "content": "reaches_none gives some stopping index; Nat.find picks the least n with orbit n = none. That n is positive (orbit 0 = some v₀ ≠ none), and minimality gives orbit (n-1) = some x. Since orbit n = step f (orbit (n-1)) = f x = none, the door x is a genuine terminal door: f x = none. This is the constructive existence statement Kuhn's algorithm outputs.",
+    "mathContext": "The last door before the walk enters none sits on the boundary of a fully-coloured simplex — the object Sperner's lemma asserts to exist, now produced by an algorithm.",
+    "significance": "key",
+    "relatedConcepts": ["least witness", "constructive existence"],
+    "prerequisites": ["reaches_none"]
+  },
+  {
+    "id": "ann-oq06-kuhn-pivot",
+    "proofId": "sperner-ndim-oq-06",
+    "range": { "startLine": 198, "endLine": 235 },
+    "type": "definition",
+    "title": "Packaging the Geometric Input: KuhnPivot",
+    "content": "The KuhnPivot structure records the actual geometric datum: forward pivot succ, reverse pivot pred, and the reversibility field symm : succ v = some w ↔ pred w = some v. From symm alone, injOnSome derives injectivity-away-from-none and no_pred_source derives that a source door (pred v₀ = none) has no succ-predecessor. Thus a geometric user supplies only reversibility — both hypotheses of reaches_none become theorems.",
+    "mathContext": "symm is precisely 'the interior-door adjacency is symmetric': crossing a door from either side gives the same door. Reversibility, not full injectivity, is the right hypothesis — distinct terminal doors legitimately share the value none.",
+    "significance": "supporting",
+    "relatedConcepts": ["reversibility", "symmetric adjacency"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-oq06-kuhn-terminates",
+    "proofId": "sperner-ndim-oq-06",
+    "range": { "startLine": 237, "endLine": 247 },
+    "type": "theorem",
+    "title": "Kuhn's Algorithm Terminates at an FC Simplex",
+    "content": "reaches_terminal and exists_terminal instantiate the abstract engine on a KuhnPivot: from any source door the walk terminates within Fintype.card V pivots (reaches_terminal) and its output is a genuine terminal — fully-coloured — door (exists_terminal). Both follow immediately from reaches_none / exists_terminal_door via the derived hypotheses injOnSome and no_pred_source.",
+    "mathContext": "This is the packaged, user-facing statement of Kuhn's algorithm's correctness, with all assumptions reduced to the single reversibility field of KuhnPivot.",
+    "significance": "key",
+    "relatedConcepts": ["Kuhn algorithm", "Sperner's lemma", "termination"],
+    "prerequisites": ["reaches_none", "exists_terminal_door", "KuhnPivot"]
+  }
+]

--- a/src/data/proofs/sperner-ndim-oq-06/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-06/meta.json
@@ -1,0 +1,122 @@
+{
+  "id": "sperner-ndim-oq-06",
+  "title": "Constructive Kuhn Path-Following: Bounded Termination of the Door-Pivot Walk",
+  "slug": "sperner-ndim-oq-06",
+  "description": "Isolates and machine-checks, fully abstractly and with 0 axioms, the combinatorial engine that makes Kuhn's constructive proof of Sperner's lemma terminate. Models the door-pivot rule as a partial successor f : V → Option V on a finite door set (none = entered a fully-coloured simplex). Assuming only that pivoting is reversible away from terminal rooms (injective wherever f x ≠ none) and that the start door v₀ is a source (no predecessor), proves that iterating the pivot from v₀ reaches none — an FC simplex — within Fintype.card V = O(N^d) steps, and that the last door before termination is a genuine terminal (FC) door. This supplies the abstract acyclicity/termination step that the geometric entry sperner-ndim-oq-04 leaves axiomatized.",
+  "meta": {
+    "author": "Kuhn (1960); researcher-2",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma#Constructive_proof",
+    "date": "1960",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SpernerNDimOQ06.lean",
+    "tags": [
+      "combinatorics",
+      "topology",
+      "Sperner-lemma",
+      "algorithms",
+      "constructive-proof",
+      "path-following",
+      "kuhn-algorithm",
+      "door-graph",
+      "termination",
+      "PPAD",
+      "advanced"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "originalContributions": [
+      "Abstract model of the Kuhn door-pivot rule as a partial successor `step`/`orbit` on `Option V` (none = terminate at a fully-coloured simplex)",
+      "`orbit_none_of_le`: termination is absorbing — once the walk enters an FC simplex it stays there",
+      "`source_pred_of_collision`: the backward-collision lemma — any repeat in a non-terminating orbit forces the start door to have a predecessor (proved by induction on the collision index using injectivity-away-from-none)",
+      "`reaches_none`: MAIN THEOREM — from a source door, the pivot walk reaches `none` (an FC simplex) within `Fintype.card V` = O(N^d) steps; proved 0-axiom via pigeonhole + backward collision, giving the acyclicity/termination step that sperner-ndim-oq-04 axiomatizes",
+      "`exists_terminal_door`: the last door before termination is a genuine terminal door `x` with `f x = none` — the constructive output of Kuhn's algorithm",
+      "`KuhnPivot` structure packaging the geometric input (symmetric `succ`/`pred` interior-door adjacency), from which both hypotheses of `reaches_none` are DERIVED rather than assumed",
+      "`KuhnPivot.injOnSome` and `KuhnPivot.no_pred_source`: reversibility (`symm`) yields injectivity-away-from-none and the source-has-no-predecessor property",
+      "`KuhnPivot.reaches_terminal` / `KuhnPivot.exists_terminal`: Kuhn's algorithm terminates and outputs a fully-coloured simplex, stated on the packaged structure"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 252,
+    "assumptions": "None (0 axioms). The two hypotheses of the main theorem — reversibility of pivoting away from terminal rooms (`hinj`) and the source condition (`hsrc`) — are ordinary theorem hypotheses, and on the `KuhnPivot` structure they are DERIVED from a single symmetric-adjacency field (`symm`). `#print axioms` reports only propext, Classical.choice, Quot.sound (the standard foundational axioms, which do not count as assumptions).",
+    "mathlib_version": null,
+    "theoremCount": 12,
+    "definitionCount": 5
+  },
+  "overview": {
+    "historicalContext": "Harold Kuhn (1960, 1968) gave the first algorithmic proof of Sperner's lemma: a fully-coloured simplex can be found by path-following in the door graph rather than merely shown to exist by a parity count (Cohen 1967). Scarf (1967) independently developed a closely related pivoting algorithm for approximate fixed points. These complementary-pivot methods — which also include Lemke–Howson (1964) for Nash equilibria — all follow a unique path from a source vertex to a sink in an implicit graph, the structure later abstracted as the complexity class PPAD (Papadimitriou 1994), of which Sperner's lemma is a complete problem.\n\nThe correctness of every such algorithm rests on one combinatorial fact: the pivot graph has maximum degree ≤ 2 (a disjoint union of paths and cycles), so a walk begun at a degree-1 source door cannot loop and must end at a sink. The existing gallery entry sperner-ndim-oq-04 formalizes the geometric door-degree analysis but leaves the 'the walk actually reaches an FC simplex' step — an acyclicity statement — axiomatized (`bdry_all_even_of_no_fc_walks`). This entry proves that step abstractly and with 0 axioms.",
+    "problemStatement": "Formalize the Kuhn path-following algorithm constructively: given a boundary door that is a source of the door-pivot rule, follow the unique opposite door repeatedly and prove the walk reaches a fully-coloured simplex in at most O(N^d) steps, where N^d is the number of doors.",
+    "text": "Model the pivot as a partial successor f : V → Option V on a finite door set (none = 'entered an FC simplex — terminate'). If pivoting is reversible away from terminal rooms and v₀ has no predecessor, then iterating f from v₀ reaches none within Fintype.card V steps, and the last non-terminal door is a genuine FC door.",
+    "proofStrategy": "The engine is proved in three steps, all 0-axiom:\n\n1. **Absorption** (`orbit_none_of_le`): once the orbit is `none` it stays `none`, since `step f none = none`.\n\n2. **Backward collision** (`source_pred_of_collision`): if the walk runs for N+1 steps without terminating and two doors coincide (`orbit i = orbit (i+d)`, d ≥ 1), then peeling one pivot at a time — using injectivity-away-from-none `f x = f y → f x ≠ none → x = y` — propagates the equality backwards to index 0, exhibiting a predecessor of the start door. This is proved by induction on the collision index.\n\n3. **Termination** (`reaches_none`): suppose for contradiction the walk never terminates within Fintype.card V steps. Then the N+1 doors orbit 0, …, orbit N are all V-valued, so by pigeonhole two coincide; the backward-collision lemma then produces a predecessor of the source v₀, contradicting `hsrc`. Hence some orbit n = none with n ≤ Fintype.card V. `exists_terminal_door` extracts the last door before termination via `Nat.find` and shows it is a true terminal door.\n\nThe `KuhnPivot` structure records the actual geometric input — a symmetric interior-door adjacency `succ v = some w ↔ pred w = some v` — and derives both hypotheses from it, so the geometric user supplies only reversibility.",
+    "keyInsights": [
+      "The single fact powering all complementary-pivot algorithms is that reversibility makes the successor injective *wherever it does not terminate*; full injectivity is false, since several distinct terminal doors all pivot to `none`.",
+      "Acyclicity from a source is not assumed but PROVED: a repeated door in a non-terminating orbit would force the source to have a predecessor, which the source condition forbids.",
+      "Modelling termination as `none` in `Option V` turns 'reaching a sink' into 'the orbit hits none', avoiding well-founded recursion and fuel parameters entirely.",
+      "The step bound is exactly `Fintype.card V` — the number of doors — which on the N-fold Kuhn subdivision of a d-simplex is O(N^d), matching the algorithm's known polynomial running time.",
+      "This is the constructive counterpart of the parity engine in SpernerTuckerPathFollowing.lean: parity proves an FC simplex EXISTS; this engine proves the walk REACHES one, deterministically and in bounded time."
+    ],
+    "prerequisites": [
+      "Finite pigeonhole (Finset.exists_ne_map_eq_of_card_lt_of_maps_to)",
+      "Function iteration (Function.iterate_succ_apply')",
+      "Least-witness search (Nat.find)",
+      "n-dimensional Sperner's lemma and the geometric door graph (sperner-ndim, sperner-ndim-oq-04)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "pivot-model",
+      "title": "The Door-Pivot Rule as a Partial Successor",
+      "startLine": 68,
+      "endLine": 84,
+      "summary": "Models one pivot step lifted to Option V (step), the n-fold walk (orbit), and its defining recurrences.",
+      "mathContext": "A door is a state; f v = the opposite door (none = the room is fully coloured). orbit f v₀ n is the door after n pivots from v₀."
+    },
+    {
+      "id": "absorption",
+      "title": "Termination is Absorbing",
+      "startLine": 86,
+      "endLine": 97,
+      "summary": "Once the walk enters a fully-coloured simplex it stays terminated.",
+      "mathContext": "step f none = none, so orbit is monotone into the terminal state."
+    },
+    {
+      "id": "backward-collision",
+      "title": "Backward-Collision Lemma",
+      "startLine": 99,
+      "endLine": 130,
+      "summary": "Any repeated door in a non-terminating orbit forces the start door to have a predecessor — the combinatorial core of acyclicity.",
+      "mathContext": "Injectivity-away-from-none propagates a collision orbit i = orbit (i+d) backwards to index 0, exhibiting f w = some v₀."
+    },
+    {
+      "id": "reaches-none",
+      "title": "Main Theorem: Termination in O(N^d) Steps",
+      "startLine": 132,
+      "endLine": 172,
+      "summary": "From a source door, the pivot walk reaches none (an FC simplex) within Fintype.card V steps, via pigeonhole + backward collision.",
+      "mathContext": "N+1 non-terminal doors in a card-N type must repeat; the repeat would give the source a predecessor, contradicting hsrc."
+    },
+    {
+      "id": "terminal-door",
+      "title": "The Output is a Fully-Coloured Simplex",
+      "startLine": 174,
+      "endLine": 196,
+      "summary": "Extracts, via Nat.find, the last door before termination and shows it is a genuine terminal door f x = none.",
+      "mathContext": "The least n with orbit n = none is positive, and orbit (n-1) = some x with f x = none."
+    },
+    {
+      "id": "kuhn-pivot",
+      "title": "Packaging the Geometric Input: KuhnPivot",
+      "startLine": 198,
+      "endLine": 235,
+      "summary": "A structure recording symmetric interior-door adjacency; derives injectivity-away-from-none and the source condition from reversibility alone.",
+      "mathContext": "symm : succ v = some w ↔ pred w = some v is exactly reversibility of pivoting on interior doors."
+    },
+    {
+      "id": "kuhn-terminates",
+      "title": "Kuhn's Algorithm Terminates and Outputs an FC Simplex",
+      "startLine": 237,
+      "endLine": 247,
+      "summary": "On the packaged structure, from any source door the walk terminates within Fintype.card V pivots at a fully-coloured simplex.",
+      "mathContext": "reaches_terminal and exists_terminal instantiate the abstract engine with the derived hypotheses."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **sperner-ndim-oq-06**: *formalize the Kuhn path-following algorithm constructively — follow the unique opposite door to reach a fully-coloured (FC) simplex in at most O(N^d) steps.*

This entry isolates and machine-checks, **fully abstractly and with 0 axioms**, the combinatorial engine that makes Kuhn's constructive proof of Sperner's lemma terminate. It supplies exactly the acyclicity/termination step that the geometric sibling entry `sperner-ndim-oq-04` leaves **axiomatized** (`bdry_all_even_of_no_fc_walks`).

## Model

The door-pivot rule is a partial successor `f : V → Option V` on a finite door set (`none` = "entered an FC simplex — terminate"). Two hypotheses capture the geometry:
- `hinj` — **reversibility away from terminal rooms**: `f x = f y → f x ≠ none → x = y`. (Full injectivity is *false*: distinct terminal doors all pivot to `none`.)
- `hsrc` — the start door `v₀` is a **source**: `∀ w, f w ≠ some v₀`.

## Main results (all 0-axiom)

- `source_pred_of_collision` — backward-collision lemma: any repeat in a non-terminating orbit forces the source to have a predecessor (⇒ the orbit from a source is simple/acyclic).
- `reaches_none` — **main theorem**: from a source, the pivot walk reaches `none` within `Fintype.card V` = O(N^d) steps (pigeonhole + backward collision).
- `exists_terminal_door` — the last door before termination is a genuine terminal door `f x = none` (the algorithm's output).
- `KuhnPivot` structure — packages the geometric input as a symmetric `succ`/`pred` adjacency; `injOnSome` and `no_pred_source` **derive** both hypotheses from reversibility alone, so `reaches_terminal` / `exists_terminal` need only a source door.

This is the constructive counterpart of the parity engine in `SpernerTuckerPathFollowing.lean`: parity proves an FC simplex *exists*; this proves the walk *reaches* one, deterministically and in bounded time.

## Verification

- `lake env lean Proofs/SpernerNDimOQ06.lean` → **RC 0**, 0 errors, 0 sorries.
- `#print axioms` on `reaches_none`, `exists_terminal_door`, `KuhnPivot.exists_terminal` → only `propext, Classical.choice, Quot.sound` (standard foundational axioms; **0 assumptions**).
- 12 theorems / 5 defs (incl. `KuhnPivot` structure), 252 lines, new gallery entry.

_(Verified against an intact Mathlib olean cache in a sibling worktree; the shared cache was mid-storm during this session.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)