### PR TITLE
research(binomial-theorem-oq-06): Vandermonde range form + diagonal corollaries ∑C(n,k)²=C(2n,n) [VERIFIED, 0-axiom, +6thm]

### DIFF
--- a/proofs/Proofs/VandermondeConvolutionOQ06.lean
+++ b/proofs/Proofs/VandermondeConvolutionOQ06.lean
@@ -1,0 +1,110 @@
+/-
+# Vandermonde's convolution identity and its diagonal corollaries
+
+Parent: `binomial-theorem` (open question — Vandermonde's identity).
+
+Mathlib proves Vandermonde's identity in *antidiagonal* form,
+`Nat.add_choose_eq`:
+
+  (m + n).choose k = ∑ ij ∈ antidiagonal k, m.choose ij.1 * n.choose ij.2,
+
+obtained by comparing the `X^k` coefficient in (X+1)^m·(X+1)^n = (X+1)^(m+n)
+(the generating-function / algebraic proof).
+
+This entry does two things Mathlib does not.
+
+1. It repackages the identity in the *classical textbook range form*
+
+     C(m+n, r) = ∑_{k=0}^{r} C(m, k)·C(n, r−k),                (`vandermonde_range`)
+
+   a single-index convolution over `Finset.range (r+1)`, which is the shape in
+   which the identity is normally stated and used.
+
+2. It derives the two famous *diagonal* corollaries that are **absent from
+   Mathlib**:
+
+     ∑_{k=0}^{n} C(m, k)·C(n, k) = C(m+n, n),                  (`sum_choose_mul_choose`)
+     ∑_{k=0}^{n} C(n, k)²       = C(2n, n) = centralBinom n.   (`sum_sq_choose`)
+
+   The second says: summing the squares of a row of Pascal's triangle gives the
+   central binomial coefficient. It is the `m = n` case of the first, which is
+   itself Vandermonde after flipping one factor with the symmetry C(n,k)=C(n,n−k).
+
+Verified: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/
+import Mathlib
+
+open Finset BigOperators
+
+namespace VandermondeConvolutionOQ06
+
+/-! ## Vandermonde's identity: antidiagonal and range forms -/
+
+/-- Vandermonde's identity in antidiagonal form, restating Mathlib's
+`Nat.add_choose_eq` (proved by coefficient comparison in (X+1)^m·(X+1)^n) for
+reference and as the bridge to the range form below. -/
+theorem vandermonde_antidiagonal (m n r : ℕ) :
+    (m + n).choose r
+      = ∑ ij ∈ Finset.antidiagonal r, m.choose ij.1 * n.choose ij.2 :=
+  Nat.add_choose_eq m n r
+
+/-- **Vandermonde's identity, classical range form.**
+`C(m+n, r) = ∑_{k=0}^{r} C(m,k)·C(n, r−k)`. This is the single-index convolution
+statement; we obtain it from the antidiagonal form by reindexing the
+antidiagonal of `r` as `k ↦ (k, r−k)` over `range (r+1)`. -/
+theorem vandermonde_range (m n r : ℕ) :
+    (m + n).choose r
+      = ∑ k ∈ range (r + 1), m.choose k * n.choose (r - k) := by
+  rw [vandermonde_antidiagonal,
+    Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk
+      (fun ij => m.choose ij.1 * n.choose ij.2) r]
+
+/-! ## Diagonal corollaries (not in Mathlib) -/
+
+/-- **Symmetric product form.** `∑_{k=0}^{n} C(m,k)·C(n,k) = C(m+n, n)`.
+Apply Vandermonde with `r = n` and flip the second factor with the symmetry
+`C(n, n−k) = C(n, k)` (valid since `k ≤ n` on the summation range). -/
+theorem sum_choose_mul_choose (m n : ℕ) :
+    ∑ k ∈ range (n + 1), m.choose k * n.choose k = (m + n).choose n := by
+  rw [vandermonde_range m n n]
+  refine Finset.sum_congr rfl (fun k hk => ?_)
+  rw [mem_range, Nat.lt_succ_iff] at hk
+  rw [Nat.choose_symm hk]
+
+/-- The symmetric product form with the split written as `C(m+n, m)`, using
+`C(m+n, m) = C(m+n, n)`. -/
+theorem sum_choose_mul_choose' (m n : ℕ) :
+    ∑ k ∈ range (n + 1), m.choose k * n.choose k = (m + n).choose m := by
+  rw [sum_choose_mul_choose, Nat.choose_symm_add]
+
+/-- **Sum of squares of a Pascal row is the central binomial coefficient:**
+`∑_{k=0}^{n} C(n,k)² = C(2n, n)`. The `m = n` diagonal case of
+`sum_choose_mul_choose`. -/
+theorem sum_sq_choose (n : ℕ) :
+    ∑ k ∈ range (n + 1), (n.choose k) ^ 2 = (2 * n).choose n := by
+  rw [two_mul, ← sum_choose_mul_choose n n]
+  exact Finset.sum_congr rfl (fun k _ => pow_two (n.choose k))
+
+/-- The sum-of-squares identity phrased through Mathlib's `Nat.centralBinom`:
+`∑_{k=0}^{n} C(n,k)² = centralBinom n`. -/
+theorem sum_sq_choose_centralBinom (n : ℕ) :
+    ∑ k ∈ range (n + 1), (n.choose k) ^ 2 = n.centralBinom := by
+  rw [sum_sq_choose]
+  rfl
+
+/-! ## Worked examples -/
+
+/-- `C(5,2) = C(2,0)C(3,2) + C(2,1)C(3,1) + C(2,2)C(3,0) = 0 + 6 + 1 = ...`,
+the range form for `m=2, n=3, r=2`. -/
+example : (2 + 3).choose 2 = ∑ k ∈ range 3, (2 : ℕ).choose k * (3 : ℕ).choose (2 - k) :=
+  vandermonde_range 2 3 2
+
+/-- `∑_{k=0}^{3} C(3,k)² = C(6,3)` (equals 20): the sum-of-squares corollary. -/
+example : ∑ k ∈ range 4, ((3 : ℕ).choose k) ^ 2 = (2 * 3).choose 3 :=
+  sum_sq_choose 3
+
+/-- Numeric check of the sum-of-squares value: `1² + 3² + 3² + 1² = 20`. -/
+example : ∑ k ∈ range 4, ((3 : ℕ).choose k) ^ 2 = 20 := by
+  rw [sum_sq_choose 3]; rfl
+
+end VandermondeConvolutionOQ06

--- a/src/data/proofs/binomial-theorem-oq-06/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-06/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "vandermonde-oq06-header",
+    "proofId": "binomial-theorem-oq-06",
+    "range": { "startLine": 2, "endLine": 33 },
+    "type": "concept",
+    "title": "What this entry adds beyond Mathlib's Vandermonde",
+    "content": "Mathlib proves Vandermonde's identity only in antidiagonal form (Nat.add_choose_eq), obtained by comparing the X^k coefficient of (X+1)^m·(X+1)^n and (X+1)^{m+n} — the algebraic / generating-function proof. This file does two things Mathlib does not: it repackages the identity in the classical single-index range form C(m+n,r) = ∑_{k=0}^{r} C(m,k)·C(n,r−k) (the shape actually used in practice), and it derives the two famous diagonal corollaries that are absent from Mathlib — the symmetric product form ∑ C(m,k)C(n,k) = C(m+n,n) and the sum-of-squares identity ∑ C(n,k)² = C(2n,n). Verified: 0 sorries, 0 axioms.",
+    "mathContext": "$C(m+n,r) = \\sum_{k=0}^{r} C(m,k)\\,C(n,r-k)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Vandermonde's identity",
+      "Chu–Vandermonde identity",
+      "generating functions",
+      "central binomial coefficient",
+      "Pascal's triangle"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "finite sums over Finset.range",
+      "the parent binomial-theorem entry"
+    ]
+  },
+  {
+    "id": "vandermonde-oq06-antidiagonal",
+    "proofId": "binomial-theorem-oq-06",
+    "range": { "startLine": 43, "endLine": 49 },
+    "type": "theorem",
+    "title": "Vandermonde, antidiagonal form (bridge to Mathlib)",
+    "content": "vandermonde_antidiagonal restates Mathlib's Nat.add_choose_eq: (m+n).choose r = ∑_{ij∈antidiagonal r} C(m,ij.1)·C(n,ij.2). This is Mathlib's algebraic proof (coefficient comparison in (X+1)^m·(X+1)^n = (X+1)^{m+n}), reproduced here as the starting point that the next theorem reindexes into the classical form. The proof is a direct application of the Mathlib lemma.",
+    "mathContext": "$C(m+n,r) = \\sum_{(i,j)\\in\\mathrm{antidiagonal}\\,r} C(m,i)\\,C(n,j)$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.add_choose_eq", "antidiagonal", "coefficient comparison"],
+    "prerequisites": ["Finset.antidiagonal", "the binomial theorem for polynomials"]
+  },
+  {
+    "id": "vandermonde-oq06-range",
+    "proofId": "binomial-theorem-oq-06",
+    "range": { "startLine": 51, "endLine": 60 },
+    "type": "theorem",
+    "title": "Vandermonde's identity, classical range form",
+    "content": "vandermonde_range gives the textbook single-index statement C(m+n,r) = ∑_{k=0}^{r} C(m,k)·C(n,r−k). It is obtained from the antidiagonal form by Finset.Nat.sum_antidiagonal_eq_sum_range_succ, which reindexes a sum over the antidiagonal of r as a single sum over range (r+1) via k ↦ (k, r−k). This is the shape in which Vandermonde is normally used and which Mathlib does not provide directly.",
+    "mathContext": "$C(m+n,r) = \\sum_{k=0}^{r} C(m,k)\\,C(n,r-k)$",
+    "significance": "central",
+    "relatedConcepts": ["Vandermonde's identity", "convolution", "reindexing sums"],
+    "prerequisites": ["Finset.Nat.sum_antidiagonal_eq_sum_range_succ"]
+  },
+  {
+    "id": "vandermonde-oq06-symmetric-product",
+    "proofId": "binomial-theorem-oq-06",
+    "range": { "startLine": 64, "endLine": 78 },
+    "type": "theorem",
+    "title": "Symmetric product form ∑ C(m,k)C(n,k) = C(m+n,n)",
+    "content": "sum_choose_mul_choose proves ∑_{k=0}^{n} C(m,k)·C(n,k) = C(m+n,n), a diagonal form absent from Mathlib. Take Vandermonde with r=n; on the summation range k ≤ n the symmetry Nat.choose_symm turns the factor C(n, n−k) into C(n, k), converting the convolution into the diagonal product. sum_choose_mul_choose' records the same identity with the split written as C(m+n,m) via Nat.choose_symm_add.",
+    "mathContext": "$\\sum_{k=0}^{n} C(m,k)\\,C(n,k) = C(m+n,n) = C(m+n,m)$",
+    "significance": "central",
+    "relatedConcepts": ["Nat.choose_symm", "Nat.choose_symm_add", "diagonal identity"],
+    "prerequisites": ["symmetry of binomial coefficients"]
+  },
+  {
+    "id": "vandermonde-oq06-sum-squares",
+    "proofId": "binomial-theorem-oq-06",
+    "range": { "startLine": 80, "endLine": 86 },
+    "type": "theorem",
+    "title": "Sum of squares of a Pascal row: ∑ C(n,k)² = C(2n,n)",
+    "content": "sum_sq_choose proves the classical central identity ∑_{k=0}^{n} C(n,k)² = C(2n,n) — the sum of the squares of a row of Pascal's triangle is the central binomial coefficient. It is the m=n case of sum_choose_mul_choose: rewrite 2n as n+n, apply the symmetric product form, and collapse C(n,k)·C(n,k) to C(n,k)². This identity is not in Mathlib.",
+    "mathContext": "$\\sum_{k=0}^{n} \\binom{n}{k}^2 = \\binom{2n}{n}$",
+    "significance": "central",
+    "relatedConcepts": ["central binomial coefficient", "diagonal Vandermonde", "double counting"],
+    "prerequisites": ["the symmetric product form"]
+  },
+  {
+    "id": "vandermonde-oq06-centralBinom",
+    "proofId": "binomial-theorem-oq-06",
+    "range": { "startLine": 88, "endLine": 93 },
+    "type": "theorem",
+    "title": "Restatement through Nat.centralBinom",
+    "content": "sum_sq_choose_centralBinom phrases the sum-of-squares identity through Mathlib's Nat.centralBinom: ∑_{k=0}^{n} C(n,k)² = centralBinom n. Since centralBinom n is defined as (2n).choose n, the final step is definitional (rfl), connecting the new corollary to existing Mathlib infrastructure. The following worked examples check the range form (m=2,n=3,r=2) and the value ∑ C(3,k)² = C(6,3) = 20.",
+    "mathContext": "$\\sum_{k=0}^{n} \\binom{n}{k}^2 = \\mathrm{centralBinom}\\,n$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.centralBinom", "definitional equality"],
+    "prerequisites": ["Nat.centralBinom"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-06/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-06/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "binomial-theorem-oq-06",
+  "title": "Vandermonde's convolution identity and its diagonal corollaries: ∑ C(n,k)² = C(2n,n)",
+  "slug": "binomial-theorem-oq-06",
+  "description": "Mathlib proves Vandermonde's identity only in antidiagonal form (Nat.add_choose_eq: (m+n).choose k = ∑_{(i,j)∈antidiagonal k} C(m,i)·C(n,j), via coefficient comparison in (X+1)^m·(X+1)^n = (X+1)^{m+n}). This entry, answering an open question of the parent binomial-theorem entry, does two things Mathlib does not. (1) It repackages Vandermonde in the classical single-index range form C(m+n,r) = ∑_{k=0}^{r} C(m,k)·C(n,r−k) (vandermonde_range), the shape in which the identity is normally stated and applied, obtained by reindexing the antidiagonal as k ↦ (k, r−k) over Finset.range (r+1). (2) It derives the two famous DIAGONAL corollaries that are absent from Mathlib: the symmetric product form ∑_{k=0}^{n} C(m,k)·C(n,k) = C(m+n,n) (sum_choose_mul_choose, obtained from Vandermonde by flipping one factor with C(n,n−k)=C(n,k)), and its m=n specialization ∑_{k=0}^{n} C(n,k)² = C(2n,n) = centralBinom n (sum_sq_choose / sum_sq_choose_centralBinom) — summing the squares of a row of Pascal's triangle yields the central binomial coefficient. Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Classical (Vandermonde 1772; Chu 1303); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VandermondeConvolutionOQ06.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "vandermonde-identity",
+      "convolution",
+      "central-binomial-coefficient",
+      "pascals-triangle",
+      "generating-functions",
+      "finset-sum",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.add_choose_eq",
+        "description": "Vandermonde's identity in antidiagonal form, (m+n).choose k = ∑_{ij∈antidiagonal k} C(m,ij.1)·C(n,ij.2), Mathlib's algebraic (generating-function) proof by comparing the X^k coefficient of (X+1)^m·(X+1)^n and (X+1)^{m+n}. The starting point that this entry reindexes into the classical range form.",
+        "module": "Mathlib.Data.Nat.Choose.Vandermonde"
+      },
+      {
+        "theorem": "Finset.Nat.sum_antidiagonal_eq_sum_range_succ",
+        "description": "∑_{ij∈antidiagonal n} f ij.1 ij.2 = ∑_{k∈range (n+1)} f k (n−k): reindexes a sum over the additive antidiagonal of n as a single-index sum over range (n+1). The one combinatorial step turning the antidiagonal Vandermonde into the classical range form.",
+        "module": "Mathlib.Algebra.BigOperators.NatAntidiagonal"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "For k ≤ n, C(n, n−k) = C(n, k). Applied on the summation range k ≤ n to flip the second factor C(n, n−k) into C(n, k), turning Vandermonde (r=n) into the symmetric product form and the sum-of-squares corollary.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_symm_add",
+        "description": "C(m+n, m) = C(m+n, n). Used to present the symmetric product form with either split of the total.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.centralBinom",
+        "description": "The central binomial coefficient, defined as (2n).choose n. The sum-of-squares identity is restated through it (sum_sq_choose_centralBinom), the defeq (2n).choose n = centralBinom n closing the last step by rfl.",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      }
+    ],
+    "originalContributions": [
+      "vandermonde_range: Vandermonde's identity in the classical single-index range form C(m+n,r) = ∑_{k=0}^{r} C(m,k)·C(n,r−k), reindexing Mathlib's antidiagonal Nat.add_choose_eq via k ↦ (k, r−k) — the shape in which the identity is stated in textbooks and absent from Mathlib.",
+      "sum_choose_mul_choose: the symmetric product (diagonal) form ∑_{k=0}^{n} C(m,k)·C(n,k) = C(m+n,n), derived from vandermonde_range with r=n by flipping the second factor with C(n,n−k)=C(n,k) on the range k ≤ n. Not in Mathlib.",
+      "sum_choose_mul_choose': the same identity written with the other split of the total, ∑_{k=0}^{n} C(m,k)·C(n,k) = C(m+n,m), via C(m+n,m)=C(m+n,n).",
+      "sum_sq_choose: the classical central identity ∑_{k=0}^{n} C(n,k)² = C(2n,n) — summing the squares of a Pascal row gives the central binomial coefficient, the m=n case of sum_choose_mul_choose. Not in Mathlib.",
+      "sum_sq_choose_centralBinom: the sum-of-squares identity phrased through Mathlib's Nat.centralBinom, ∑_{k=0}^{n} C(n,k)² = centralBinom n, connecting the corollary to existing Mathlib infrastructure."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries, no native_decide (hence no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 110,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Vandermonde's convolution identity C(m+n,r) = ∑_{k} C(m,k)C(n,r−k) is named for Alexandre-Théophile Vandermonde (1772), though it was known to Zhu Shijie (Chu Shih-chieh) in China in 1303 (hence 'Chu–Vandermonde'). It is one of the most-used binomial identities: combinatorially, choosing r objects from a set split into blocks of sizes m and n; algebraically, comparing coefficients in (1+x)^m(1+x)^n = (1+x)^{m+n}. Its diagonal case ∑_k C(n,k)² = C(2n,n) — the sum of the squares of a row of Pascal's triangle is the central binomial coefficient — is a staple of enumerative combinatorics and appears throughout the theory of lattice paths, Catalan numbers, and hypergeometric series.",
+    "problemStatement": "The parent binomial-theorem entry proves the binomial theorem and asks, among its open questions, to formalize Vandermonde's convolution identity. Mathlib provides only the antidiagonal form Nat.add_choose_eq.\n\n**Answer:** Vandermonde in the classical range form C(m+n,r) = ∑_{k=0}^{r} C(m,k)·C(n,r−k), plus the two diagonal corollaries missing from Mathlib — the symmetric product form ∑_{k=0}^{n} C(m,k)·C(n,k) = C(m+n,n) and the sum-of-squares identity ∑_{k=0}^{n} C(n,k)² = C(2n,n) = centralBinom n.",
+    "text": "Vandermonde's convolution C(m+n,r) = ∑_{k=0}^{r} C(m,k)C(n,r−k) in its classical range form, and the diagonal corollaries ∑ C(m,k)C(n,k) = C(m+n,n) and ∑ C(n,k)² = C(2n,n) — both absent from Mathlib — with 0 axioms.",
+    "proofStrategy": "1. vandermonde_antidiagonal: restate Mathlib's Nat.add_choose_eq (the generating-function proof) as the bridge.\n2. vandermonde_range: rewrite with the antidiagonal form, then apply Finset.Nat.sum_antidiagonal_eq_sum_range_succ with f i j = C(m,i)·C(n,j) to reindex the antidiagonal of r as k ↦ (k, r−k) over range (r+1).\n3. sum_choose_mul_choose: specialize vandermonde_range to r=n, then Finset.sum_congr rewrites each C(n, n−k) to C(n, k) via Nat.choose_symm (k ≤ n from mem_range/Nat.lt_succ_iff).\n4. sum_choose_mul_choose': compose with Nat.choose_symm_add to change the split.\n5. sum_sq_choose: rewrite 2n = n+n, apply sum_choose_mul_choose (m=n) backwards, and collapse C(n,k)·C(n,k) to C(n,k)² with sq via Finset.sum_congr.\n6. sum_sq_choose_centralBinom: rewrite by sum_sq_choose; (2n).choose n = centralBinom n holds by rfl.",
+    "keyInsights": [
+      "**Mathlib has only the antidiagonal form.** Nat.add_choose_eq states Vandermonde as a sum over antidiagonal k; the textbook single-index form over range (r+1) — the way the identity is actually used — required a reindexing step (sum_antidiagonal_eq_sum_range_succ) and was not available.",
+      "**The diagonal corollaries are absent from Mathlib.** Neither ∑ C(m,k)C(n,k) = C(m+n,n) nor the famous ∑ C(n,k)² = C(2n,n) appears in Mathlib; both fall out of the range form once one factor is flipped by the symmetry C(n,n−k)=C(n,k) on the summation range.",
+      "**Sum of squares of a Pascal row is the central binomial coefficient.** ∑_{k=0}^{n} C(n,k)² = C(2n,n) is the m=n diagonal case: counting n-subsets of a 2n-set by how many come from each half. The Lean proof is a two-line specialization once the symmetric product form is available.",
+      "**Symmetry does the combinatorial work.** The single lemma Nat.choose_symm (C(n,n−k)=C(n,k) for k≤n), applied inside Finset.sum_congr on the range where k≤n holds, is what turns the convolution r−k index into the diagonal k index."
+    ],
+    "exampleSections": [
+      {
+        "title": "Row 3 of Pascal's triangle",
+        "mathContext": "The squares of row 3, (1,3,3,1), sum to 1+9+9+1 = 20 = C(6,3), the central binomial coefficient — the n=3 case of ∑_{k=0}^{n} C(n,k)² = C(2n,n)."
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Vandermonde, Alexandre-Théophile",
+      "title": "Mémoire sur des irrationnelles de différents ordres avec une application au cercle",
+      "year": "1772",
+      "note": "Mém. Acad. Roy. Sci. Paris — the convolution identity now bearing his name."
+    },
+    {
+      "authors": "Zhu Shijie (Chu Shih-chieh)",
+      "title": "Siyuan yujian (Jade Mirror of the Four Unknowns)",
+      "year": "1303",
+      "note": "Contains the identity centuries before Vandermonde; hence 'Chu–Vandermonde'."
+    },
+    {
+      "authors": "Graham, Ronald L.; Knuth, Donald E.; Patashnik, Oren",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Addison–Wesley — Vandermonde's convolution (§5.1) and the diagonal identity ∑ C(n,k)² = C(2n,n)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "extends",
+      "description": "The parent entry proves the binomial theorem; this entry answers its open question on Vandermonde's convolution identity, adding the classical range form and the diagonal corollaries missing from Mathlib."
+    }
+  ],
+  "conclusion": {
+    "summary": "Vandermonde's convolution identity is given in the classical range form C(m+n,r) = ∑_{k=0}^{r} C(m,k)·C(n,r−k) (vandermonde_range), reindexed from Mathlib's antidiagonal Nat.add_choose_eq. From it follow the two diagonal corollaries absent from Mathlib: the symmetric product form ∑_{k=0}^{n} C(m,k)·C(n,k) = C(m+n,n) (sum_choose_mul_choose) and the sum-of-squares identity ∑_{k=0}^{n} C(n,k)² = C(2n,n) = centralBinom n (sum_sq_choose, sum_sq_choose_centralBinom). Verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the textbook single-index Vandermonde and the central sum-of-squares identity as reusable, machine-checked lemmas, filling gaps in Mathlib's binomial-coefficient library and complementing the parent binomial-theorem entry.",
+    "openQuestions": [
+      "Prove the alternating Vandermonde / Chu–Vandermonde variants, e.g. ∑_{k} (−1)^k C(m,k) C(n,r−k) and the general upper-negation form, extending the convolution to signed sums.",
+      "Formalize the hockey-stick and Li Jen-Shu identities as further diagonal sums, and connect ∑ C(n,k)² = C(2n,n) to the lattice-path / Catalan-number interpretation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module header and statement",
+      "startLine": 2,
+      "endLine": 34,
+      "summary": "Frames the gap: Mathlib proves Vandermonde only in antidiagonal form; this entry gives the classical range form and the diagonal corollaries (symmetric product and sum of squares) that Mathlib lacks.",
+      "mathContext": "$C(m+n,r) = \\sum_{k=0}^{r} C(m,k)\\,C(n,r-k)$"
+    },
+    {
+      "id": "vandermonde",
+      "title": "Vandermonde's identity: antidiagonal and range forms",
+      "startLine": 41,
+      "endLine": 60,
+      "summary": "vandermonde_antidiagonal restates Mathlib's Nat.add_choose_eq; vandermonde_range reindexes it to the classical single-index form over range (r+1) via Finset.Nat.sum_antidiagonal_eq_sum_range_succ.",
+      "mathContext": "$C(m+n,r) = \\sum_{k=0}^{r} C(m,k)\\,C(n,r-k)$"
+    },
+    {
+      "id": "corollaries",
+      "title": "Diagonal corollaries (not in Mathlib)",
+      "startLine": 62,
+      "endLine": 93,
+      "summary": "sum_choose_mul_choose proves ∑_{k=0}^{n} C(m,k)C(n,k) = C(m+n,n) by flipping the second factor with Nat.choose_symm; sum_choose_mul_choose' changes the split; sum_sq_choose gives ∑ C(n,k)² = C(2n,n); sum_sq_choose_centralBinom phrases it via Nat.centralBinom.",
+      "mathContext": "$\\sum_{k=0}^{n} \\binom{n}{k}^2 = \\binom{2n}{n} = \\mathrm{centralBinom}\\,n$"
+    },
+    {
+      "id": "examples",
+      "title": "Worked examples",
+      "startLine": 95,
+      "endLine": 108,
+      "summary": "The range form for m=2, n=3, r=2; the sum-of-squares corollary for n=3 (∑ C(3,k)² = C(6,3)); and the numeric value 1²+3²+3²+1² = 20.",
+      "mathContext": "$1^2 + 3^2 + 3^2 + 1^2 = 20 = \\binom{6}{3}$"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "VandermondeConvolutionOQ06",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/VandermondeConvolutionOQ06.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry for **binomial-theorem-oq-06**: Vandermonde's convolution identity in classical range form plus the two diagonal corollaries that are **absent from Mathlib**.

Mathlib proves Vandermonde only in *antidiagonal* form (`Nat.add_choose_eq`). This entry:

1. **Range form** — `vandermonde_range`: `C(m+n,r) = ∑_{k=0}^r C(m,k)·C(n,r−k)`, reindexing the antidiagonal via `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk`.
2. **Symmetric product** — `sum_choose_mul_choose`: `∑_{k=0}^n C(m,k)·C(n,k) = C(m+n,n)` (Vandermonde with `r=n` + `Nat.choose_symm`).
3. **Sum of squares of a Pascal row** — `sum_sq_choose`: `∑_{k=0}^n C(n,k)² = C(2n,n) = centralBinom n`, the `m=n` diagonal case.

Plus worked numeric examples.

## Verification
- 6 theorems, 110 lines, 0 sorries, 0 `axiom` declarations, no `native_decide`.
- Typechecked clean against Mathlib v4.26 (`lake env lean`, exit 0).
- `status: verified`, `badge: verified`, `axiomCount: 0`.

## Provenance
Supersedes stale draft **#32709** — a mega-branch that also bundled already-merged Picard (#32692) and Birthday work, so it could never merge cleanly. This PR is the clean single-entry version, with the Lean file build-verified now that the Mathlib olean cache is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)