### PR TITLE
research(frobenius-number-oq-02-oq-02): combinatorial Gorenstein criterion 2·genus = F+1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/FrobeniusNumberOQ02OQ02.lean
+++ b/proofs/Proofs/FrobeniusNumberOQ02OQ02.lean
@@ -1,0 +1,162 @@
+/-
+  OQ-02-OQ-02: The Combinatorial Gorenstein Criterion for Symmetric
+  Numerical Semigroups   (frobenius-number-oq-02-oq-02)
+
+  Kunz (1970): a numerical semigroup ring k[S] is *Gorenstein* if and only if
+  the semigroup S is *symmetric*, meaning the involution  z ↦ F − z  (F the
+  Frobenius number) swaps the gaps and the non-gaps inside the window [0, F].
+  The purely numerical signature of this symmetry is
+
+        2 · (number of gaps in [0,F])  =  F + 1,
+
+  i.e. "exactly half of the integers 0, …, F are gaps".  This is the number the
+  commutative algebra ultimately detects (the type of the Gorenstein ring is 1).
+
+  ## Infrastructure assessment
+  Mathlib currently has *no* development of Gorenstein rings or of numerical
+  semigroup rings k[t^a, t^b] (a `grep` for `gorenstein` over Mathlib returns
+  nothing).  Building that machinery is a >1000-line foundational effort, so the
+  ring-theoretic half of Kunz's theorem is genuinely out of reach here.  What
+  we formalize instead is the full *combinatorial* content of the duality —
+  the piece that carries the actual mathematics:
+
+    * abstract:  symmetry of the gap involution  ⟹  2·(#gaps in [0,F]) = F+1;
+    * concrete:  the two–generator semigroup ⟨a,b⟩ is symmetric (reusing the
+                 parent's involution `frobenius_symmetry`), hence its genus is
+                 exactly (F+1)/2 — the Gorenstein / type-one criterion.
+
+  This bridges the parent's representability involution to the numerical
+  criterion that a commutative-algebra proof of Gorenstein-ness would consume.
+
+  ## Status: 0 sorries, 0 axioms
+-/
+import Mathlib.Tactic
+import Proofs.FrobeniusNumberOQ02
+
+namespace FrobeniusGorenstein
+
+open FrobeniusNumber FrobeniusSymmetry
+
+/-! ## Abstract combinatorial core: the gap-involution criterion
+
+We work with an arbitrary decidable membership predicate `S` on `ℕ` and an
+integer `F` (thought of as the Frobenius number).  All counting happens in the
+window `[0, F] = Finset.range (F+1)`.  For a numerical semigroup `F` is the
+largest gap, so *every* gap lies in this window and `#gaps` is the genus. -/
+
+variable (F : ℕ) (S : ℕ → Prop) [DecidablePred S]
+
+/-- Non-gaps (elements of `S`) inside the window `[0, F]`. -/
+def nonGaps : Finset ℕ := (Finset.range (F + 1)).filter (fun z => S z)
+
+/-- Gaps (non-elements of `S`) inside the window `[0, F]`. -/
+def gaps : Finset ℕ := (Finset.range (F + 1)).filter (fun z => ¬ S z)
+
+@[simp] theorem mem_nonGaps_iff {z : ℕ} : z ∈ nonGaps F S ↔ z ≤ F ∧ S z := by
+  rw [nonGaps, Finset.mem_filter, Finset.mem_range, Nat.lt_succ_iff]
+
+@[simp] theorem mem_gaps_iff {z : ℕ} : z ∈ gaps F S ↔ z ≤ F ∧ ¬ S z := by
+  rw [gaps, Finset.mem_filter, Finset.mem_range, Nat.lt_succ_iff]
+
+/-- The window `[0, F]` splits into its non-gaps and its gaps. -/
+theorem nonGaps_card_add_gaps_card :
+    (nonGaps F S).card + (gaps F S).card = F + 1 := by
+  rw [nonGaps, gaps, Finset.filter_card_add_filter_neg_card_eq_card,
+    Finset.card_range]
+
+/-- The gap involution is *symmetric* on `[0, F]`: membership at `z` is the
+negation of membership at `F − z`.  For a numerical semigroup this is exactly
+the classical symmetry condition. -/
+def SymmetricSet : Prop := ∀ z ≤ F, (S z ↔ ¬ S (F - z))
+
+/-- Under symmetry, the involution `z ↦ F − z` sends non-gaps to gaps. -/
+theorem card_nonGaps_le (h : SymmetricSet F S) :
+    (nonGaps F S).card ≤ (gaps F S).card := by
+  apply Finset.card_le_card_of_injOn (fun z => F - z)
+  · intro z hz
+    simp only [Finset.mem_coe, mem_nonGaps_iff] at hz
+    simp only [Finset.mem_coe, mem_gaps_iff]
+    exact ⟨Nat.sub_le _ _, (h z hz.1).mp hz.2⟩
+  · intro x hx y hy hxy
+    simp only [Finset.mem_coe, mem_nonGaps_iff] at hx hy
+    simp only at hxy
+    omega
+
+/-- Under symmetry, the involution `z ↦ F − z` sends gaps to non-gaps. -/
+theorem card_gaps_le (h : SymmetricSet F S) :
+    (gaps F S).card ≤ (nonGaps F S).card := by
+  apply Finset.card_le_card_of_injOn (fun z => F - z)
+  · intro z hz
+    simp only [Finset.mem_coe, mem_gaps_iff] at hz
+    simp only [Finset.mem_coe, mem_nonGaps_iff]
+    refine ⟨Nat.sub_le _ _, ?_⟩
+    -- symmetry at `F - z`: `S (F - z) ↔ ¬ S (F - (F - z))`, and `F - (F - z) = z`.
+    have hle : F - z ≤ F := Nat.sub_le _ _
+    have hback : F - (F - z) = z := Nat.sub_sub_self hz.1
+    have hsym := h (F - z) hle
+    rw [hback] at hsym
+    exact hsym.mpr hz.2
+  · intro x hx y hy hxy
+    simp only [Finset.mem_coe, mem_gaps_iff] at hx hy
+    simp only at hxy
+    omega
+
+/-- **Combinatorial Gorenstein criterion.**  If the gap involution `z ↦ F − z`
+is symmetric on `[0, F]`, then exactly half of `{0, 1, …, F}` are gaps:
+`2 · #gaps = F + 1`.  This is the numerical shadow of `k[S]` being Gorenstein
+(Kunz 1970). -/
+theorem card_gaps_two_mul (h : SymmetricSet F S) :
+    2 * (gaps F S).card = F + 1 := by
+  have hle₁ := card_nonGaps_le F S h
+  have hle₂ := card_gaps_le F S h
+  have hsum := nonGaps_card_add_gaps_card F S
+  omega
+
+/-! ## Concrete instance: the two-generator semigroup ⟨a, b⟩
+
+We reuse the parent's involution `frobenius_symmetry` and extend it across the
+boundary points `0` and `g` to obtain `SymmetricSet` for the whole window. -/
+
+variable {a b : ℕ}
+
+open Classical
+
+/-- The representability involution of ⟨a,b⟩ satisfies the abstract symmetry
+condition on the whole window `[0, g]` (parent covered only `0 < n < g`). -/
+theorem frob_symmetricSet (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprime a b) :
+    SymmetricSet (frobeniusNumber a b) (Representable a b) := by
+  intro z hz
+  rcases Nat.eq_zero_or_pos z with hz0 | hzpos
+  · -- z = 0 : `0` is representable, `g` is not.
+    subst hz0
+    rw [Nat.sub_zero]
+    have hg : ¬ Representable a b (frobeniusNumber a b) := by
+      simpa [frobeniusNumber] using frobenius_not_representable hab ha hb
+    exact ⟨fun _ => hg, fun _ => representable_zero a b⟩
+  · rcases eq_or_lt_of_le hz with hzg | hzlt
+    · -- z = g : `g` is not representable, `0` is.
+      subst hzg
+      rw [Nat.sub_self]
+      have hg : ¬ Representable a b (frobeniusNumber a b) := by
+        simpa [frobeniusNumber] using frobenius_not_representable hab ha hb
+      exact ⟨fun hrep => absurd hrep hg,
+             fun h0 => absurd (representable_zero a b) h0⟩
+    · -- interior : the parent theorem applies verbatim.
+      exact frobenius_symmetry ha hb hab hzpos hzlt
+
+/-- **Gorenstein criterion for ⟨a, b⟩.**  For coprime `a, b ≥ 2` with Frobenius
+number `g = ab − a − b`, exactly half of `{0, …, g}` are non-representable:
+`2 · #{gaps in [0,g]} = g + 1`.  Equivalently the numerical semigroup ⟨a,b⟩ is
+symmetric, so (by Kunz's theorem) the ring `k[t^a, t^b]` is Gorenstein. -/
+theorem frob_gorenstein_criterion (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprime a b) :
+    2 * (gaps (frobeniusNumber a b) (Representable a b)).card
+      = frobeniusNumber a b + 1 :=
+  card_gaps_two_mul _ _ (frob_symmetricSet ha hb hab)
+
+/-- Sanity check: for ⟨3, 5⟩ the Frobenius number is `7` and there are `4` gaps
+(`1, 2, 4, 7`), and indeed `2 · 4 = 8 = 7 + 1`. -/
+example : 2 * (gaps (frobeniusNumber 3 5) (Representable 3 5)).card
+    = frobeniusNumber 3 5 + 1 :=
+  frob_gorenstein_criterion (by norm_num) (by norm_num) (by norm_num)
+
+end FrobeniusGorenstein

--- a/src/data/proofs/frobenius-number-oq-02-oq-02/meta.json
+++ b/src/data/proofs/frobenius-number-oq-02-oq-02/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "frobenius-number-oq-02-oq-02",
+  "title": "The Combinatorial Gorenstein Criterion: 2·genus = F + 1 for Symmetric Semigroups",
+  "slug": "frobenius-number-oq-02-oq-02",
+  "description": "Formalizes the combinatorial half of Kunz's Gorenstein duality for numerical semigroups. Kunz (1970): the numerical semigroup ring k[S] is Gorenstein ⟺ S is symmetric, meaning the involution z ↦ F − z swaps gaps and non-gaps in the window [0,F]. The numerical signature of this symmetry is 2·(#gaps in [0,F]) = F + 1 — exactly half the integers below the Frobenius number are gaps. We prove this criterion abstractly for any decidable membership predicate whose gap involution is symmetric (via a cardinality-matching argument on the two halves of the window), then instantiate it to the two-generator semigroup ⟨a,b⟩ by extending the parent's representability involution frobenius_symmetry across the boundary points 0 and g. Mathlib has no Gorenstein-ring or numerical-semigroup-ring machinery, so the ring-theoretic side is documented as out of reach; the combinatorial criterion is the mathematics a commutative-algebra proof would ultimately consume.",
+  "meta": {
+    "author": "Kunz (1970, criterion); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Numerical_semigroup",
+    "date": "2026-07-01",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "numerical-semigroups",
+      "frobenius",
+      "kunz",
+      "gorenstein",
+      "symmetric-semigroup",
+      "combinatorics",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FrobeniusNumberOQ02OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.filter_card_add_filter_neg_card_eq_card",
+        "description": "(s.filter p).card + (s.filter (¬p ·)).card = s.card. Splits the window Finset.range (F+1) into its non-gaps and gaps, giving #nonGaps + #gaps = F + 1.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "An injection-on-a-set from s into t forces s.card ≤ t.card. Applied twice with the involution z ↦ F − z to show #nonGaps ≤ #gaps and #gaps ≤ #nonGaps, hence equality.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.sub_sub_self",
+        "description": "n ≤ m → m - (m - n) = n. Shows the truncated involution z ↦ F − z is its own inverse on [0,F], the crux of the surjectivity/back direction.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "nonGaps / gaps: the non-gaps and gaps of a decidable membership predicate S inside the counting window [0,F] = Finset.range (F+1), with membership lemmas mem_nonGaps_iff / mem_gaps_iff",
+      "nonGaps_card_add_gaps_card: the window partition #nonGaps + #gaps = F + 1",
+      "SymmetricSet: the abstract symmetry predicate ∀ z ≤ F, (S z ↔ ¬ S (F − z)) — the gap involution z ↦ F − z swaps membership",
+      "card_nonGaps_le / card_gaps_le: under symmetry the involution z ↦ F − z injects non-gaps into gaps and vice versa (using Nat.sub_sub_self for the inverse), giving equal cardinalities",
+      "card_gaps_two_mul: the COMBINATORIAL GORENSTEIN CRITERION — SymmetricSet ⟹ 2·#gaps = F + 1 (exactly half of {0,…,F} are gaps), the numerical shadow of k[S] being Gorenstein / type one",
+      "frob_symmetricSet: the two-generator semigroup ⟨a,b⟩ satisfies SymmetricSet on the whole window, extending the parent's frobenius_symmetry (valid only for 0 < n < g) across the boundary cases n = 0 and n = g via representable_zero and frobenius_not_representable",
+      "frob_gorenstein_criterion: instantiation to ⟨a,b⟩ — 2·#{non-representable n ≤ g} = g + 1, so ⟨a,b⟩ is symmetric and (by Kunz) k[t^a,t^b] is Gorenstein"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "lineCount": 162,
+    "assumptions": "None beyond the foundational axioms. #print axioms on frob_gorenstein_criterion and card_gaps_two_mul reports only propext, Classical.choice, Quot.sound (none of which count as assumptions). `open Classical` supplies decidability for the Representable predicate in the concrete filter; no native_decide, so no Lean.ofReduceBool; no sorries; no structure-encoded hypotheses. The commutative-algebra direction of Kunz's theorem (that symmetry implies the ring k[t^a,t^b] is Gorenstein) is NOT formalized — Mathlib has no Gorenstein-ring development — and is stated honestly as an infrastructure gap; only the equivalent combinatorial criterion is proved.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 3
+  },
+  "leanFile": {
+    "namespace": "FrobeniusGorenstein",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "path": "Proofs/FrobeniusNumberOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "window-and-symmetry",
+      "title": "Gaps, non-gaps, and the symmetry predicate",
+      "startLine": 47,
+      "endLine": 70,
+      "summary": "For a decidable predicate S and Frobenius bound F, nonGaps/gaps are the members/non-members inside [0,F] = range (F+1), with membership lemmas mem_nonGaps_iff / mem_gaps_iff. nonGaps_card_add_gaps_card gives the window partition #nonGaps + #gaps = F + 1. SymmetricSet := ∀ z ≤ F, (S z ↔ ¬ S (F − z)) is the gap involution's symmetry condition."
+    },
+    {
+      "id": "involution-bijection",
+      "title": "The gap involution matches the two halves",
+      "startLine": 72,
+      "endLine": 102,
+      "summary": "card_nonGaps_le and card_gaps_le: under SymmetricSet the map z ↦ F − z injects non-gaps into gaps and gaps into non-gaps. Injectivity is truncated-subtraction cancellation (omega); the target-membership uses the symmetry equivalence, and Nat.sub_sub_self makes z ↦ F − z its own inverse."
+    },
+    {
+      "id": "criterion",
+      "title": "Combinatorial Gorenstein criterion (abstract)",
+      "startLine": 104,
+      "endLine": 113,
+      "summary": "card_gaps_two_mul: from the two inequalities #nonGaps = #gaps, combined with the window partition, omega yields 2·#gaps = F + 1 — exactly half of {0,…,F} are gaps. This is the numerical signature Kunz's theorem detects (type one / Gorenstein)."
+    },
+    {
+      "id": "concrete-symmetry",
+      "title": "⟨a,b⟩ is symmetric on the whole window",
+      "startLine": 115,
+      "endLine": 145,
+      "summary": "frob_symmetricSet: the representability predicate of ⟨a,b⟩ satisfies SymmetricSet g. The parent's frobenius_symmetry covers 0 < n < g; the boundary n = 0 (0 representable, g not) and n = g (g not representable, 0 is) are discharged with representable_zero and frobenius_not_representable."
+    },
+    {
+      "id": "gorenstein-criterion",
+      "title": "Gorenstein criterion for ⟨a,b⟩",
+      "startLine": 147,
+      "endLine": 160,
+      "summary": "frob_gorenstein_criterion: instantiating the abstract criterion, 2·#{non-representable n ≤ g} = g + 1 for coprime a,b ≥ 2 — so ⟨a,b⟩ is a symmetric numerical semigroup and (Kunz) k[t^a,t^b] is Gorenstein. A sanity example checks ⟨3,5⟩: g = 7, 4 gaps {1,2,4,7}, 2·4 = 8 = 7+1."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Symmetric numerical semigroups and Gorenstein rings.** A numerical semigroup $S \\subseteq \\mathbb{N}$ is a cofinite, additively closed set containing $0$; its largest gap is the Frobenius number $g = F(S)$, and its *genus* is the number of gaps. Kunz (1970) proved a landmark duality: the numerical semigroup ring $k[S] = k[t^s : s \\in S]$ is *Gorenstein* if and only if $S$ is *symmetric* — meaning the involution $z \\mapsto g - z$ exchanges gaps and non-gaps, equivalently for every integer $z$ exactly one of $z, g-z$ lies in $S$. The purely numerical fingerprint of symmetry is that the genus equals $(g+1)/2$: exactly half of $\\{0,1,\\dots,g\\}$ are gaps. For two coprime generators $a,b$ the semigroup $\\langle a,b\\rangle$ is always symmetric (indeed a complete intersection), with $g = ab-a-b$ and genus $(a-1)(b-1)/2 = (g+1)/2$.",
+    "problemStatement": "**Bridge the combinatorial symmetry to the Gorenstein property.** The parent problem established the representability involution $\\mathrm{Rep}(n) \\iff \\lnot\\mathrm{Rep}(g-n)$ for two coprime generators. The open question asks to connect this to Gorenstein-ness of $k[t^a,t^b]$. Since Mathlib has no Gorenstein-ring or numerical-semigroup-ring development, we formalize the equivalent *combinatorial* criterion — $2\\cdot(\\#\\text{gaps in }[0,g]) = g+1$ — abstractly, and instantiate it to $\\langle a,b\\rangle$, capturing the mathematical content that the ring-theoretic statement encodes.",
+    "proofStrategy": "**Cardinality matching under the gap involution.** Work in the window $[0,F] = \\mathrm{range}(F{+}1)$, split into non-gaps (members of $S$) and gaps (non-members); their cardinalities sum to $F+1$. The symmetry predicate says $z \\mapsto F-z$ sends members to non-members and back. Two applications of `Finset.card_le_card_of_injOn` with this involution (its self-inverse property is `Nat.sub_sub_self`, injectivity is truncated-subtraction cancellation via `omega`) give $\\#\\text{nonGaps} = \\#\\text{gaps}$; with the partition, `omega` concludes $2\\cdot\\#\\text{gaps} = F+1$. For the concrete instance, the parent's `frobenius_symmetry` supplies the interior $0<n<g$; the endpoints $n=0$ ($0$ representable, $g$ not) and $n=g$ ($g$ not representable, $0$ is) are handled by `representable_zero` and `frobenius_not_representable`, yielding `SymmetricSet` on all of $[0,g]$.",
+    "keyInsights": [
+      "**Symmetry is a bijection between the two halves of $[0,g]$.** The single equivalence $S z \\iff \\lnot S(F-z)$ makes $z \\mapsto F-z$ carry non-gaps onto gaps; equal cardinality of the halves is exactly $2\\cdot\\text{genus} = F+1$.",
+      "**The truncated involution is self-inverse.** Over $\\mathbb{N}$, $F-(F-z)=z$ for $z \\le F$ (`Nat.sub_sub_self`), so the same map $z \\mapsto F-z$ witnesses both inequalities $\\#\\text{nonGaps}\\le\\#\\text{gaps}$ and the reverse — no separate inverse construction is needed.",
+      "**The parent's involution needs boundary completion.** `frobenius_symmetry` is stated only for $0<n<g$; the abstract criterion needs the full window, so $n=0$ and $n=g$ must be added — and they hold precisely because $0$ is always representable and $g$ never is.",
+      "**Gorenstein-ness reduces to a gap count.** $2\\cdot\\text{genus}=g+1$ is the whole numerical content of $k[S]$ being Gorenstein (type one); the commutative algebra is a wrapper Mathlib cannot yet express, but the combinatorial statement is fully machine-checked here.",
+      "**Abstract-then-instantiate keeps it reusable.** The criterion is proved for any decidable $S$ with a symmetric gap involution, so it applies verbatim to any numerical semigroup once its symmetry is known — not just to two generators."
+    ],
+    "prerequisites": [
+      "Frobenius representability: Representable, frobeniusNumber, representable_zero, frobenius_not_representable (frobenius-number base)",
+      "The parent's involution frobenius_symmetry: Rep(n) ↔ ¬Rep(g−n) for 0 < n < g (frobenius-number-oq-02)",
+      "Finite cardinality: Finset.filter, Finset.card_le_card_of_injOn, Finset.filter_card_add_filter_neg_card_eq_card",
+      "Truncated natural subtraction and Nat.sub_sub_self"
+    ]
+  },
+  "conclusion": {
+    "summary": "Formalizes the combinatorial Gorenstein criterion for symmetric numerical semigroups. Abstractly: for any decidable predicate whose gap involution z ↦ F − z is symmetric on [0,F], exactly half of {0,…,F} are gaps (2·#gaps = F + 1), proved by matching the two halves via Finset.card_le_card_of_injOn. Concretely: the two-generator semigroup ⟨a,b⟩ is symmetric on its whole window (extending the parent's involution across n = 0 and n = g), so 2·#{non-representable n ≤ g} = g + 1 and — by Kunz's theorem — k[t^a,t^b] is Gorenstein. 6 theorems, 3 definitions, 162 lines, 0 axioms, 0 sorries.",
+    "implications": [
+      "Bridges the parent's representability involution to the numerical Gorenstein/type-one criterion, the combinatorial content of Kunz's duality.",
+      "Provides a reusable abstract lemma: any numerical semigroup with a symmetric gap involution has genus (F+1)/2, applicable beyond two generators once symmetry is established.",
+      "Documents a concrete Mathlib infrastructure gap — no Gorenstein rings or numerical semigroup rings — so the ring-theoretic half is honestly deferred rather than overclaimed."
+    ],
+    "openQuestions": [
+      "Formalize the genus closed form for two generators: #{non-representable n ≤ g} = (a−1)(b−1)/2 = numNonRepresentable a b, i.e. prove g + 1 = (a−1)(b−1) and combine with the criterion to recover Sylvester's genus theorem as a corollary.",
+      "Once Mathlib gains numerical semigroup rings and a Gorenstein predicate, complete the ring-theoretic direction of Kunz's theorem: symmetric ⟹ k[t^a,t^b] Gorenstein, closing the bridge this entry only sets up combinatorially."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "frobenius-number-oq-02",
+      "relationship": "parent",
+      "description": "The parent proved the representability symmetry Rep(n) ↔ ¬Rep(g−n) for 0 < n < g; this child extends it to the full window and derives the numerical Gorenstein criterion 2·genus = g + 1."
+    },
+    {
+      "targetId": "frobenius-number-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Companion Apéry/Kunz-criterion entry (forward direction) for the same open question; this entry gives the complementary gap-counting / Gorenstein signature rather than the Apéry-set involution."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the open question **frobenius-number-oq-02-oq-02** (child of the Frobenius symmetry problem) by formalizing the *combinatorial* half of **Kunz's Gorenstein duality** for numerical semigroups.

**Kunz (1970):** the numerical semigroup ring `k[S]` is Gorenstein ⟺ `S` is *symmetric* (the involution `z ↦ F − z` swaps gaps and non-gaps in `[0,F]`). The numerical signature of symmetry is

> **2 · (#gaps in [0,F]) = F + 1** — exactly half of `{0,…,F}` are gaps.

## Infrastructure assessment (honest scope)

Mathlib has **no** Gorenstein-ring or numerical-semigroup-ring development (`grep gorenstein` over Mathlib returns nothing). Building that is >1000 lines of foundational commutative algebra, so the ring-theoretic side of Kunz's theorem is genuinely out of reach here. This entry formalizes the equivalent **combinatorial criterion**, which carries the actual mathematical content a commutative-algebra proof would consume. This is stated plainly in the docstring, `assumptions`, and `openQuestions`.

## What's proved (`Proofs/FrobeniusNumberOQ02OQ02.lean`)

- **Abstract** (any decidable predicate `S` with a symmetric gap involution):
  - `nonGaps` / `gaps` in the window `[0,F] = range (F+1)` + membership lemmas
  - `nonGaps_card_add_gaps_card`: the window partition `#nonGaps + #gaps = F+1`
  - `card_nonGaps_le` / `card_gaps_le`: `z ↦ F − z` injects each half into the other (`Finset.card_le_card_of_injOn`, self-inverse via `Nat.sub_sub_self`)
  - **`card_gaps_two_mul`**: `SymmetricSet ⟹ 2·#gaps = F + 1` — the criterion
- **Concrete** (two generators `⟨a,b⟩`):
  - `frob_symmetricSet`: extends the parent's `frobenius_symmetry` (only `0<n<g`) across the boundary `n=0`, `n=g` to the full window
  - **`frob_gorenstein_criterion`**: `2·#{non-representable n ≤ g} = g + 1`, so `⟨a,b⟩` is symmetric and (Kunz) `k[t^a,t^b]` is Gorenstein
  - sanity example on `⟨3,5⟩` (g=7, 4 gaps, 2·4 = 8 = 7+1)

## Verification

- **8 theorems, 3 definitions, 162 lines, 0 sorries.**
- `lake env lean Proofs/FrobeniusNumberOQ02OQ02.lean` → **exit 0** (full Docker build not run: host disk was critically full this session; verified via non-destructive `lake env lean` against the shared olean cache).
- `#print axioms frob_gorenstein_criterion` / `card_gaps_two_mul` → only `propext, Classical.choice, Quot.sound`. **No `Lean.ofReduceBool`, no `sorryAx`** → **verified, 0-axiom** per the Axiom Integrity Policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)