### PR TITLE
research(triangle-inequality-oq-07): ultrametric balls of a fixed radius partition the space

### DIFF
--- a/proofs/Proofs/TriangleInequalityOQ07.lean
+++ b/proofs/Proofs/TriangleInequalityOQ07.lean
@@ -1,0 +1,137 @@
+/-
+# Ultrametric balls of a fixed radius partition the space (OQ-07)
+
+The parent `triangle-inequality` proves the *forward* inequality
+`d(x, z) ≤ d(x, y) + d(y, z)`.  In a **non-Archimedean (ultrametric)** space the
+*strong* triangle inequality
+
+  `d(x, z) ≤ max (d(x, y)) (d(y, z))`
+
+holds, and it forces a rigid geometry of balls.  The literal OQ-07 question asks to
+derive that *every point of an open ball is its center*:
+
+  `y ∈ ball x r  →  ball x r = ball y r`.
+
+Mathlib already records this single fact (`IsUltrametricDist.ball_eq_of_mem`).  The
+**genuinely new content** of this file is the *structural* upgrade that Mathlib does
+**not** bundle:
+
+* the fixed-radius relation `SameBall r x y := d(x, y) < r` is an **equivalence
+  relation** (for `r > 0`) — reflexivity is `d(x,x) = 0 < r`, symmetry is `dist_comm`,
+  and **transitivity is exactly the strong triangle inequality** `max_lt`;
+* its equivalence classes are *precisely* the open balls of radius `r`
+  (`ballSetoid_class`, `balls_eq_classes`);
+* therefore the radius-`r` balls form a **partition** of the whole space
+  (`balls_isPartition` : `Setoid.IsPartition`), from which pairwise-disjointness and
+  the covering property drop out (`balls_pairwiseDisjoint`, `balls_sUnion_eq_univ`).
+
+So in an ultrametric space "being within `r`" is a *transitive* notion — which is the
+conceptual reason a ball has no distinguished centre.  We close with the concrete
+instantiation on the `p`-adic numbers `ℚ_[p]` (an ultrametric field), where the
+radius-`1` balls are the residue discs partitioning the field.
+
+This is distinct from the existing siblings, which treat the *inequality itself*
+(`triangle-inequality-oq-02` p-adic, `triangle-inequality-oq-03` abstract "every
+triangle is isosceles"); here the object of study is the induced **ball partition**.
+
+**Status**: Complete — 0 sorries, 0 axioms.
+-/
+
+import Mathlib
+
+namespace TriangleInequalityOQ07
+
+open Metric Set
+
+variable {X : Type*} [MetricSpace X] [IsUltrametricDist X]
+
+/-- The "same radius-`r` ball" relation: two points are related when they lie within
+distance `< r`.  Equivalently `x ∈ ball y r`. -/
+def SameBall (r : ℝ) (x y : X) : Prop := dist x y < r
+
+omit [IsUltrametricDist X] in
+lemma sameBall_iff_mem_ball {r : ℝ} {x y : X} : SameBall r x y ↔ x ∈ ball y r :=
+  mem_ball.symm
+
+/-- **The fixed-radius "same ball" relation is an equivalence relation.**  The three
+axioms are, respectively, `d(x,x) = 0 < r`, `dist_comm`, and the *strong* triangle
+inequality (transitivity is what fails in a general metric space). -/
+def ballSetoid (r : ℝ) (hr : 0 < r) : Setoid X where
+  r := SameBall r
+  iseqv :=
+    { refl := fun x => by simp only [SameBall, dist_self]; exact hr
+      symm := fun {x y} h => by
+        show dist y x < r
+        rwa [dist_comm]
+      trans := fun {x y z} hxy hyz =>
+        lt_of_le_of_lt (IsUltrametricDist.dist_triangle_max x y z) (max_lt hxy hyz) }
+
+/-- The equivalence class of `y` under `ballSetoid r` is exactly the open ball
+`ball y r`. -/
+lemma ballSetoid_class (r : ℝ) (hr : 0 < r) (y : X) :
+    {x | (ballSetoid r hr) x y} = ball y r := by
+  ext x
+  simp only [Set.mem_setOf_eq, mem_ball]
+  rfl
+
+/-- The equivalence classes of `ballSetoid r` are *precisely* the open balls of
+radius `r`. -/
+lemma balls_eq_classes (r : ℝ) (hr : 0 < r) :
+    (ballSetoid r hr).classes = {s : Set X | ∃ y : X, s = ball y r} := by
+  ext s
+  simp only [Setoid.classes, Set.mem_setOf_eq, ballSetoid_class r hr]
+
+/-- **Ultrametric balls partition the space.**  For any `r > 0`, the collection of
+open balls of radius `r` is a partition of `X`: every point lies in a unique such
+ball.  This is the structural heart of OQ-07. -/
+theorem balls_isPartition (r : ℝ) (hr : 0 < r) :
+    Setoid.IsPartition {s : Set X | ∃ y : X, s = ball y r} := by
+  rw [← balls_eq_classes r hr]
+  exact Setoid.isPartition_classes _
+
+/-- The radius-`r` balls are pairwise disjoint (as distinct blocks of the partition).
+Equivalently: two open balls of the same radius are equal or disjoint. -/
+theorem balls_pairwiseDisjoint (r : ℝ) (hr : 0 < r) :
+    {s : Set X | ∃ y : X, s = ball y r}.PairwiseDisjoint id :=
+  (balls_isPartition r hr).pairwiseDisjoint
+
+/-- The radius-`r` balls cover the whole space. -/
+theorem balls_sUnion_eq_univ (r : ℝ) (hr : 0 < r) :
+    ⋃₀ {s : Set X | ∃ y : X, s = ball y r} = Set.univ :=
+  (balls_isPartition r hr).sUnion_eq_univ
+
+/-- **Every point of an open ball is its center** — the literal OQ-07 statement,
+now seen as the "class representatives are interchangeable" facet of the partition. -/
+theorem ball_eq_of_mem (r : ℝ) {x y : X} (h : y ∈ ball x r) : ball x r = ball y r :=
+  IsUltrametricDist.ball_eq_of_mem h
+
+/-- Two open balls of the same radius are equal or disjoint (the dichotomy underlying
+the partition). -/
+theorem ball_eq_or_disjoint (r : ℝ) (x y : X) :
+    ball x r = ball y r ∨ Disjoint (ball x r) (ball y r) :=
+  IsUltrametricDist.ball_eq_or_disjoint x y r
+
+/-- Each radius-`r` ball is clopen — the topological shadow of the partition (an
+ultrametric space is totally disconnected). -/
+theorem isClopen_ball (r : ℝ) (x : X) : IsClopen (ball x r) :=
+  IsUltrametricDist.isClopen_ball x r
+
+/-! ### Concrete instance: the `p`-adic numbers `ℚ_[p]`
+
+`ℚ_[p]` carries an `IsUltrametricDist` instance, so the radius-`1` balls (the residue
+discs `{y : ‖y - a‖ < 1}`) partition the field. -/
+
+section Padic
+variable (p : ℕ) [Fact p.Prime]
+
+/-- In `ℚ_[p]`, the radius-`1` balls partition the field. -/
+example : Setoid.IsPartition {s : Set ℚ_[p] | ∃ y : ℚ_[p], s = ball y 1} :=
+  balls_isPartition 1 one_pos
+
+/-- In `ℚ_[p]`, any point of a unit ball is its center. -/
+example {x y : ℚ_[p]} (h : y ∈ ball x 1) : ball x 1 = ball y 1 :=
+  ball_eq_of_mem 1 h
+
+end Padic
+
+end TriangleInequalityOQ07

--- a/src/data/proofs/triangle-inequality-oq-07/annotations.json
+++ b/src/data/proofs/triangle-inequality-oq-07/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "triangle-inequality-oq-07",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "concept",
+    "title": "Ultrametric Balls Partition the Space",
+    "content": "The parent triangle-inequality proves the FORWARD bound d(x,z) ≤ d(x,y) + d(y,z). In a non-Archimedean (ultrametric) space this is strengthened to the STRONG inequality d(x,z) ≤ max(d(x,y), d(y,z)), which rigidifies the geometry of balls. The literal OQ-07 question asks to derive that every point of an open ball is its centre (y ∈ ball x r ⟹ ball x r = ball y r), a single fact Mathlib already records. The NEW content of this file is the structural upgrade Mathlib does not bundle: the fixed-radius relation d(x,y) < r is an EQUIVALENCE RELATION whose classes are exactly the radius-r balls, so those balls PARTITION the space. Everything is 0-axiom (only propext, Classical.choice, Quot.sound).",
+    "mathContext": "$d(x,z) \\le \\max(d(x,y), d(y,z))$ — the strong triangle inequality reshapes the ball geometry.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ultrametric space",
+      "strong triangle inequality",
+      "non-archimedean",
+      "partition"
+    ],
+    "prerequisites": [
+      "metric spaces",
+      "ultrametric inequality"
+    ]
+  },
+  {
+    "id": "ann-same-ball-setoid",
+    "proofId": "triangle-inequality-oq-07",
+    "range": {
+      "startLine": 48,
+      "endLine": 67
+    },
+    "type": "definition",
+    "title": "The Fixed-Radius Relation is an Equivalence Relation",
+    "content": "SameBall r x y := d(x,y) < r is the relation 'x and y lie within distance r', equivalently x ∈ ball y r (sameBall_iff_mem_ball, from mem_ball). ballSetoid packages the proof that for r > 0 this is an EQUIVALENCE RELATION: reflexivity is d(x,x) = 0 < r, symmetry is dist_comm, and — the only non-trivial axiom — transitivity is EXACTLY the strong triangle inequality, since d(x,z) ≤ max(d(x,y), d(y,z)) < r whenever both distances are < r (max_lt applied to IsUltrametricDist.dist_triangle_max). Transitivity of 'within r' is precisely what fails in a general metric space; it is the sole reason ultrametric balls tile the space.",
+    "mathContext": "$x \\sim_r y \\iff d(x,y) < r$; transitive because $d(x,z) \\le \\max(d(x,y), d(y,z)) < r$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsUltrametricDist.dist_triangle_max",
+      "Setoid",
+      "equivalence relation",
+      "max_lt"
+    ],
+    "prerequisites": [
+      "equivalence relations",
+      "ultrametric inequality"
+    ]
+  },
+  {
+    "id": "ann-classes-partition",
+    "proofId": "triangle-inequality-oq-07",
+    "range": {
+      "startLine": 69,
+      "endLine": 90
+    },
+    "type": "theorem",
+    "title": "Classes are Balls; the Balls Partition the Space",
+    "content": "ballSetoid_class: the class of y, {x | SameBall r x y}, unfolds definitionally to {x | d(x,y) < r} = ball y r (mem_ball). balls_eq_classes then rewrites Mathlib's generic description of Setoid.classes to identify the classes with exactly the radius-r balls {s | ∃ y, s = ball y r}. The structural heart, balls_isPartition, applies Setoid.isPartition_classes to conclude Setoid.IsPartition of the radius-r balls: every point lies in a UNIQUE radius-r ball. This is the structural upgrade of the single Mathlib fact ball_eq_of_mem.",
+    "mathContext": "$\\{B(y,r) : y \\in X\\}$ = classes of $\\sim_r$; $\\mathrm{Setoid.IsPartition}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Setoid.classes",
+      "Setoid.isPartition_classes",
+      "mem_ball",
+      "partition"
+    ],
+    "prerequisites": [
+      "setoids",
+      "partitions",
+      "open balls"
+    ]
+  },
+  {
+    "id": "ann-consequences",
+    "proofId": "triangle-inequality-oq-07",
+    "range": {
+      "startLine": 92,
+      "endLine": 117
+    },
+    "type": "theorem",
+    "title": "Disjointness, Covering, and Centre-Freeness",
+    "content": "From balls_isPartition drop out balls_pairwiseDisjoint (distinct radius-r balls are disjoint, via IsPartition.pairwiseDisjoint) and balls_sUnion_eq_univ (the radius-r balls cover X, via IsPartition.sUnion_eq_univ). Three re-exports tie the structure back to Mathlib's ultrametric API: ball_eq_of_mem (every point of a ball is its centre — the literal OQ-07 statement, now the representative-independence facet of the partition), ball_eq_or_disjoint (the equal-or-disjoint dichotomy), and isClopen_ball (each ball is clopen, hence the space is totally disconnected).",
+    "mathContext": "pairwise-disjoint blocks; $\\bigcup = X$; $y \\in B(x,r) \\Rightarrow B(x,r) = B(y,r)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IsPartition.pairwiseDisjoint",
+      "ball_eq_of_mem",
+      "ball_eq_or_disjoint",
+      "isClopen_ball"
+    ],
+    "prerequisites": [
+      "partitions",
+      "clopen sets",
+      "total disconnectedness"
+    ]
+  },
+  {
+    "id": "ann-padic",
+    "proofId": "triangle-inequality-oq-07",
+    "range": {
+      "startLine": 119,
+      "endLine": 137
+    },
+    "type": "example",
+    "title": "Concrete Instance: the p-adic Numbers",
+    "content": "ℚ_[p] carries an IsUltrametricDist instance, so the abstract results instantiate directly: the radius-1 balls (the residue discs {y : ‖y − a‖ < 1}) partition the field, and any point of a unit ball is its centre. This is the motivating concrete model — the tiling of ℚ_[p] by discs is the geometric picture behind p-adic analysis and the tree structure of the p-adics.",
+    "mathContext": "$\\mathbb{Q}_p$: the radius-1 balls partition the field.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "p-adic numbers",
+      "residue discs",
+      "IsUltrametricDist instance"
+    ],
+    "prerequisites": [
+      "p-adic numbers"
+    ]
+  }
+]

--- a/src/data/proofs/triangle-inequality-oq-07/index.ts
+++ b/src/data/proofs/triangle-inequality-oq-07/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/TriangleInequalityOQ07.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const triangleInequalityOq07Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const triangleInequalityOq07Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const triangleInequalityOq07Data: ProofData = {
+  proof: triangleInequalityOq07Proof,
+  annotations: triangleInequalityOq07Annotations,
+}

--- a/src/data/proofs/triangle-inequality-oq-07/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-07/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "triangle-inequality-oq-07",
+  "title": "Ultrametric Balls of a Fixed Radius Partition the Space",
+  "slug": "triangle-inequality-oq-07",
+  "description": "In a non-Archimedean (ultrametric) space the strong triangle inequality d(x,z) ≤ max(d(x,y), d(y,z)) makes the fixed-radius relation SameBall r x y := d(x,y) < r an EQUIVALENCE RELATION — reflexivity is d(x,x)=0<r, symmetry is dist_comm, and transitivity is exactly the strong inequality. Its equivalence classes are precisely the open balls of radius r, so the radius-r balls form a partition of the whole space (Setoid.IsPartition), from which pairwise-disjointness and the covering property drop out. This packages the literal OQ-07 fact 'every point of an open ball is its center' (y ∈ ball x r ⟹ ball x r = ball y r) into the structural statement Mathlib does not bundle: 'being within r' is a transitive notion, which is the conceptual reason an ultrametric ball has no distinguished centre. Instantiated concretely on the p-adic numbers ℚ_[p].",
+  "meta": {
+    "author": "Classical (non-Archimedean geometry); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/MetricSpace/Ultra/Basic.html",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "metric-spaces",
+      "ultrametric",
+      "non-archimedean",
+      "p-adic",
+      "triangle-inequality",
+      "partition",
+      "equivalence-relation"
+    ],
+    "proofRepoPath": "Proofs/TriangleInequalityOQ07.lean",
+    "badge": "verified",
+    "packagingNote": "Tier B bundle with an original structural layer. The atomic facts are re-exports of named Mathlib lemmas (IsUltrametricDist.dist_triangle_max, ball_eq_of_mem, ball_eq_or_disjoint, isClopen_ball) and the general Setoid/partition API (Setoid.classes, isPartition_classes, IsPartition.pairwiseDisjoint/sUnion_eq_univ). The genuinely new content — which Mathlib does NOT provide — is the equivalence-relation packaging: SameBall (the fixed-radius relation), ballSetoid (proof that it is an equivalence relation, with transitivity supplied by the strong triangle inequality), ballSetoid_class (each class equals a ball), balls_eq_classes (the classes are exactly the radius-r balls), and balls_isPartition (the radius-r balls partition the space). Status is verified (0 sorries, 0 axioms — only propext/Classical.choice/Quot.sound).",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 137,
+    "mathlibDependencies": [
+      {
+        "theorem": "IsUltrametricDist.dist_triangle_max",
+        "description": "The strong (ultrametric) triangle inequality d(x,z) ≤ max(d(x,y), d(y,z)) — supplies transitivity of the SameBall relation",
+        "module": "Mathlib.Topology.MetricSpace.Ultra.Basic"
+      },
+      {
+        "theorem": "IsUltrametricDist.ball_eq_of_mem",
+        "description": "Every point of an open ball is its center: y ∈ ball x r ⟹ ball x r = ball y r",
+        "module": "Mathlib.Topology.MetricSpace.Ultra.Basic"
+      },
+      {
+        "theorem": "IsUltrametricDist.ball_eq_or_disjoint",
+        "description": "Two open balls of the same radius are equal or disjoint",
+        "module": "Mathlib.Topology.MetricSpace.Ultra.Basic"
+      },
+      {
+        "theorem": "Setoid.isPartition_classes",
+        "description": "The equivalence classes of any setoid form a partition — applied to ballSetoid to conclude the radius-r balls partition the space",
+        "module": "Mathlib.Data.Setoid.Partition"
+      },
+      {
+        "theorem": "IsUltrametricDist.isClopen_ball",
+        "description": "Each open ball is clopen; hence an ultrametric space is totally disconnected",
+        "module": "Mathlib.Topology.MetricSpace.Ultra.Basic"
+      }
+    ],
+    "originalContributions": [
+      "ballSetoid: proof that the fixed-radius relation SameBall r x y := d(x,y) < r is an EQUIVALENCE RELATION on any ultrametric space (r > 0), with transitivity supplied precisely by the strong triangle inequality via max_lt — the fact that fails in a general metric space",
+      "balls_eq_classes: the equivalence classes of ballSetoid are exactly the open balls of radius r",
+      "balls_isPartition: the radius-r balls form a Setoid.IsPartition of the whole space, a structural upgrade of the single Mathlib fact ball_eq_of_mem that Mathlib does not bundle",
+      "balls_pairwiseDisjoint and balls_sUnion_eq_univ: pairwise-disjointness and covering as immediate consequences of the partition",
+      "Concrete instantiation on the p-adic numbers ℚ_[p]: the radius-1 balls (residue discs) partition the field"
+    ],
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "In an ultrametric (non-Archimedean) space the ordinary triangle inequality is strengthened to d(x,z) ≤ max(d(x,y), d(y,z)). This single strengthening reshapes the geometry entirely: every triangle is isosceles, every point of a ball is its centre, and — the theme of this entry — the balls of a fixed radius tile the space. Non-Archimedean metrics arise from p-adic valuations, function fields, and more generally any absolute value satisfying the strong inequality; the tiling of the space by balls is the geometric picture behind p-adic analysis, the tree structure of ℚ_[p], and the total disconnectedness that distinguishes p-adic from real analysis.",
+    "problemStatement": "Let $X$ be a metric space whose distance satisfies the strong triangle inequality $d(x,z) \\le \\max(d(x,y), d(y,z))$ (an `IsUltrametricDist`). Fix $r > 0$. Then the relation $x \\sim_r y \\iff d(x,y) < r$ is an equivalence relation, its classes are exactly the open balls $B(y, r)$, and consequently the collection $\\{B(y,r) : y \\in X\\}$ is a partition of $X$: every point lies in a unique radius-$r$ ball, and distinct such balls are disjoint. The literal statement '$y \\in B(x,r) \\Rightarrow B(x,r) = B(y,r)$' is the representative-independence facet of this partition.",
+    "proofStrategy": "The relation SameBall r x y := d(x,y) < r is reflexive because d(x,x) = 0 < r, symmetric because d is symmetric (dist_comm), and — the only non-trivial axiom — transitive because d(x,z) ≤ max(d(x,y), d(y,z)) < r whenever both d(x,y) < r and d(y,z) < r (max_lt applied to the strong triangle inequality). This packages as a Setoid, ballSetoid. Its class of y, {x | SameBall r x y}, unfolds definitionally to {x | d(x,y) < r} = ball y r (mem_ball), giving ballSetoid_class; rewriting the general description of Setoid.classes yields balls_eq_classes, identifying the classes with the radius-r balls. The master fact Setoid.isPartition_classes then gives balls_isPartition, and IsPartition.pairwiseDisjoint / sUnion_eq_univ give disjointness and covering. The centre-freeness ball_eq_of_mem and the clopen property isClopen_ball are recorded as re-exports tying the structure back to Mathlib's ultrametric API. Finally ℚ_[p], which carries an IsUltrametricDist instance, instantiates everything.",
+    "keyInsights": [
+      "The strong triangle inequality is exactly the statement that 'within distance r' is a TRANSITIVE relation — this is the one setoid axiom that fails in a general metric space, and it is the sole reason ultrametric balls tile the space.",
+      "Mathlib records the pointwise facts (ball_eq_of_mem, ball_eq_or_disjoint) but not the packaging as an equivalence relation / partition; exposing the Setoid makes the 'a ball has no distinguished centre' phenomenon a corollary of representative-independence.",
+      "Identifying the setoid classes with balls is definitional: {x | r x y} is literally {x | d(x,y) < r} = ball y r, so the partition theorem is obtained by rewriting Mathlib's generic Setoid.classes description.",
+      "The p-adic numbers ℚ_[p] are the motivating concrete model: the radius-1 balls are the residue discs, and the tiling is the geometric shadow of the valuation."
+    ],
+    "prerequisites": [
+      "Metric spaces and the ultrametric (strong) triangle inequality (IsUltrametricDist)",
+      "Open balls and the mem_ball characterization",
+      "Equivalence relations / setoids and the notion of a partition (Setoid.IsPartition)",
+      "p-adic numbers ℚ_[p] as a concrete ultrametric field"
+    ]
+  },
+  "conclusion": {
+    "summary": "We proved that in any ultrametric space the fixed-radius relation d(x,y) < r is an equivalence relation whose classes are exactly the open balls of that radius, so the radius-r balls partition the space. Transitivity of the relation is supplied precisely by the strong triangle inequality; the classical fact that every point of a ball is its centre is recovered as the representative-independence of the partition. All nine theorems and two definitions are fully machine-checked with 0 sorries and 0 axioms, and the structure is instantiated on the p-adic field ℚ_[p].",
+    "implications": "The equivalence-relation packaging turns a collection of pointwise Mathlib lemmas into a single reusable structural object (ballSetoid) and its partition, which is the natural home for later results on p-adic ball combinatorics, the tree/quotient structure of ℚ_[p] and ℤ_[p], and total disconnectedness. It isolates the strong triangle inequality as the exact hypothesis responsible for the tiling.",
+    "openQuestions": [
+      "For the p-adic integers ℤ_[p], identify the radius-p^{-n} ball partition with the cosets of p^n ℤ_[p] and prove there are exactly p^n blocks (ℤ_[p] / p^n ℤ_[p] ≅ ZMod (p^n)).",
+      "Formalize the refinement order: the radius-r ball partition refines the radius-r' partition whenever r ≤ r', giving the inverse system whose limit is the profinite tree structure of an ultrametric space."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Imports, expository docstring laying out the strong triangle inequality and flagging the equivalence-relation / partition packaging as the new content, and namespace setup."
+    },
+    {
+      "id": "same-ball-relation",
+      "title": "Part I: The Fixed-Radius Relation and its Setoid",
+      "startLine": 48,
+      "endLine": 67,
+      "summary": "SameBall r (the relation d(x,y) < r), its equivalence with membership in a ball (sameBall_iff_mem_ball), and ballSetoid — the proof that SameBall r is an equivalence relation, with transitivity supplied by the strong triangle inequality.",
+      "mathContext": "$x \\sim_r y \\iff d(x,y) < r$; reflexive/symmetric/transitive via $d(x,z) \\le \\max(d(x,y),d(y,z))$"
+    },
+    {
+      "id": "classes-are-balls",
+      "title": "Part II: Classes are Balls, and the Partition",
+      "startLine": 69,
+      "endLine": 90,
+      "summary": "ballSetoid_class (each class equals a ball), balls_eq_classes (the classes are exactly the radius-r balls), and balls_isPartition — the structural heart: the radius-r balls partition the space.",
+      "mathContext": "$\\{B(y,r) : y\\} = $ classes of $\\sim_r$; $\\mathrm{Setoid.IsPartition}$"
+    },
+    {
+      "id": "consequences",
+      "title": "Part III: Disjointness, Covering, and Centre-Freeness",
+      "startLine": 92,
+      "endLine": 117,
+      "summary": "balls_pairwiseDisjoint and balls_sUnion_eq_univ from the partition; ball_eq_of_mem (every point is a centre), ball_eq_or_disjoint, and isClopen_ball tying the structure back to Mathlib's ultrametric API.",
+      "mathContext": "pairwise-disjoint blocks; $\\bigcup = X$; $y \\in B(x,r) \\Rightarrow B(x,r) = B(y,r)$"
+    },
+    {
+      "id": "padic",
+      "title": "Part IV: Concrete Instance — the p-adic Numbers",
+      "startLine": 119,
+      "endLine": 137,
+      "summary": "ℚ_[p] carries an IsUltrametricDist instance, so the radius-1 balls (residue discs) partition the field, and any point of a unit ball is its centre.",
+      "mathContext": "$\\mathbb{Q}_p$: radius-1 balls partition the field"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "extends",
+      "description": "Triangle Inequality (parent: the forward bound)"
+    },
+    {
+      "targetId": "triangle-inequality-oq-03",
+      "relationship": "related",
+      "description": "Ultrametric Triangle Inequality (abstract: every triangle is isosceles)"
+    },
+    {
+      "targetId": "triangle-inequality-oq-02",
+      "relationship": "related",
+      "description": "Ultrametric Triangle Inequality in p-adic Analysis (the inequality and its equality case)"
+    }
+  ],
+  "references": [
+    {
+      "text": "Ultrametric space — balls, partition into discs, and total disconnectedness.",
+      "url": "https://en.wikipedia.org/wiki/Ultrametric_space"
+    },
+    {
+      "text": "Mathlib4: Topology.MetricSpace.Ultra.Basic (ball_eq_of_mem, ball_eq_or_disjoint, isClopen_ball) and Data.Setoid.Partition.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/MetricSpace/Ultra/Basic.html"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Metric",
+      "Set"
+    ],
+    "namespace": "TriangleInequalityOQ07",
+    "lineCount": 137,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/TriangleInequalityOQ07.lean",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **triangle-inequality-oq-07**: in a non-Archimedean (ultrametric) space the strong triangle inequality `d(x,z) ≤ max(d(x,y), d(y,z))` makes the fixed-radius relation `SameBall r x y := d(x,y) < r` an **equivalence relation** whose classes are exactly the open balls of radius `r` — so the radius-`r` balls **partition** the space.

## What's new (beyond Mathlib)

Mathlib already records the pointwise facts (`ball_eq_of_mem`, `ball_eq_or_disjoint`, `isClopen_ball`). The literal OQ-07 question — 'every point of an open ball is its center' — is one of them. The **genuinely new content**, which Mathlib does *not* bundle, is the structural packaging:

- `ballSetoid`: proof that `SameBall r` is an **equivalence relation** on any ultrametric space (`r > 0`). Reflexivity is `d(x,x)=0<r`, symmetry is `dist_comm`, and **transitivity is exactly the strong triangle inequality** (`max_lt` on `IsUltrametricDist.dist_triangle_max`) — the one setoid axiom that fails in a general metric space.
- `balls_eq_classes`: the setoid classes are precisely the radius-`r` balls.
- `balls_isPartition` : `Setoid.IsPartition` of the radius-`r` balls — every point lies in a unique such ball.
- `balls_pairwiseDisjoint`, `balls_sUnion_eq_univ`: disjointness + covering.
- Concrete instantiation on the **p-adic numbers** `ℚ_[p]`.

## Verification

- `lake env lean` typecheck: **rc=0, no warnings**
- `#print axioms balls_isPartition` → `[propext, Classical.choice, Quot.sound]` only — **0-axiom / verified** (no `sorryAx`, no `Lean.ofReduceBool`)
- 9 theorems / 2 definitions / 137 lines

Distinct from siblings oq-02 (p-adic inequality + equality case) and oq-03 (abstract 'every triangle is isosceles'); here the object of study is the induced **ball partition**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)