### PR TITLE
Enrich chebyshev-pnt-bridge-oq-05: split lumped π-monotonicity annotation (4→5)

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-05/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-05/annotations.json
@@ -11,14 +11,46 @@
     "content": "The parent bridge proves the Chebyshev lower bound 4^n ≤ (2n+1)·(2n)^{π(2n)} only along even arguments x = 2n — the natural home of the central binomial coefficient C(2n,n) whose prime factorisation drives Chebyshev's 1852 estimate. The parent's fifth open question asks to spread this to every m. Since π is a step function (π(x) = π(⌊x⌋)), the missing ingredient is purely the monotonicity π(m) ≥ π(2⌊m/2⌋): a lower bound at the largest even integer ≤ m already controls π(m). This file performs that elementary 'fill the gaps' step, valid for odd and even m alike. 0 axioms, 0 sorries.",
     "mathContext": "$\\pi(x) = \\pi(\\lfloor x\\rfloor)$ is non-decreasing; a bound at $2\\lfloor m/2\\rfloor \\le m$ transfers to $m$.",
     "significance": "supporting",
-    "relatedConcepts": ["prime-counting function π", "Chebyshev's theorem", "central binomial coefficient", "monotone step function"],
-    "prerequisites": ["the parent even-only Chebyshev bound", "π as a step function", "monotonicity of π"]
+    "relatedConcepts": [
+      "prime-counting function π",
+      "Chebyshev's theorem",
+      "central binomial coefficient",
+      "monotone step function"
+    ],
+    "prerequisites": [
+      "the parent even-only Chebyshev bound",
+      "π as a step function",
+      "monotonicity of π"
+    ]
+  },
+  {
+    "id": "ann-mono",
+    "proofId": "chebyshev-pnt-bridge-oq-05",
+    "type": "tactic",
+    "range": {
+      "startLine": 55,
+      "endLine": 59
+    },
+    "title": "Monotonicity of π: the Engine for Raising the Exponent",
+    "content": "primeCounting_mono restates Nat.monotone_primeCounting as π(a) ≤ π(b) whenever a ≤ b — enlarging the bound can only admit more primes below it. This one-line re-export is the workhorse behind the exponent step in the main bound: it licenses π(2⌊m/2⌋) ≤ π(m), so the parent's even-argument exponent can be raised to π(m) while the base is separately enlarged. It is the only place the even→all-m extension uses a structural property of π rather than its individual values, and it is exactly the ingredient the parent file lacked when it stopped at even arguments.",
+    "mathContext": "$a \\le b \\Rightarrow \\pi(a) \\le \\pi(b)$ ($\\pi$ non-decreasing), from `Nat.monotone_primeCounting`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotone_primeCounting",
+      "prime-counting function π",
+      "monotone step function",
+      "Nat.pow_le_pow_right"
+    ],
+    "prerequisites": [
+      "π(n) as a counting function",
+      "Mathlib Nat.monotone_primeCounting"
+    ]
   },
   {
     "id": "ann-nat-bound",
     "proofId": "chebyshev-pnt-bridge-oq-05",
     "range": {
-      "startLine": 55,
+      "startLine": 60,
       "endLine": 92
     },
     "type": "insight",
@@ -26,8 +58,17 @@
     "content": "four_pow_half_le_mul_pow_primeCounting proves 4^{⌊m/2⌋} ≤ (m+1)·m^{π(m)} for every m ≥ 2. Set n = ⌊m/2⌋, so 2n ≤ m is the even integer just below m and n ≥ 1. Feed n into the parent's even-only bound to get 4^n ≤ (2n+1)·(2n)^{π(2n)}, then make three collapses, each moving the even integer 2n up to m in the right direction: prefactor 2n+1 ≤ m+1 (omega), base (2n)^{π(2n)} ≤ m^{π(2n)} (Nat.pow_le_pow_left from 2n ≤ m), and exponent m^{π(2n)} ≤ m^{π(m)} (Nat.pow_le_pow_right from π(2n) ≤ π(m), i.e. monotonicity of π). Multiplying (Nat.mul_le_mul) gives the bound. Because all three moves are monotone, the transfer is a pure inequality chain with no error term to track.",
     "mathContext": "$4^{\\lfloor m/2\\rfloor} \\le (m+1)\\,m^{\\pi(m)}$, via $2\\lfloor m/2\\rfloor \\le m$ collapsed on prefactor, base, exponent.",
     "significance": "key",
-    "relatedConcepts": ["Nat.pow_le_pow_left / pow_le_pow_right", "monotone_primeCounting", "inequality chain", "floor function"],
-    "prerequisites": ["the parent even-only bound", "monotonicity of powers in base and exponent", "monotonicity of π"]
+    "relatedConcepts": [
+      "Nat.pow_le_pow_left / pow_le_pow_right",
+      "monotone_primeCounting",
+      "inequality chain",
+      "floor function"
+    ],
+    "prerequisites": [
+      "the parent even-only bound",
+      "monotonicity of powers in base and exponent",
+      "monotonicity of π"
+    ]
   },
   {
     "id": "ann-log-form",
@@ -41,8 +82,17 @@
     "content": "primeCounting_mul_log_lower applies Real.log to the cast Nat inequality to get ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m. The work is bookkeeping: cast the Nat bound to ℝ (push_cast, exact_mod_cast), confirm both sides positive (positivity), apply Real.log_le_log (monotonicity), then expand the right side with Real.log_mul and Real.log_pow into log(m+1) + π(m)·log m, and rearrange (linarith). Since log 4 = 2 log 2 and ⌊m/2⌋/m → 1/2 while log(m+1)/log m → 0, the leading term is m·log 2 — so π(m)·log(m)/m ≥ log 2 − o(1) along the FULL integer sequence, the Chebyshev lower density answering OQ-05.",
     "mathContext": "$\\lfloor m/2\\rfloor \\log 4 - \\log(m+1) \\le \\pi(m)\\log m$; with $\\log 4 = 2\\log 2$, density $\\ge \\log 2 - o(1)$.",
     "significance": "key",
-    "relatedConcepts": ["Real.log monotonicity", "log_mul / log_pow", "Chebyshev lower density log 2", "little-o error term"],
-    "prerequisites": ["monotonicity and additivity of Real.log", "casting Nat inequalities to ℝ", "log 4 = 2 log 2"]
+    "relatedConcepts": [
+      "Real.log monotonicity",
+      "log_mul / log_pow",
+      "Chebyshev lower density log 2",
+      "little-o error term"
+    ],
+    "prerequisites": [
+      "monotonicity and additivity of Real.log",
+      "casting Nat inequalities to ℝ",
+      "log 4 = 2 log 2"
+    ]
   },
   {
     "id": "ann-quotient",
@@ -56,7 +106,16 @@
     "content": "primeCounting_ge_div_log divides the logarithmic bound by log m (positive for m ≥ 2, Real.log_pos) to record the lower density in the clean denominator-free form π(m) ≥ (⌊m/2⌋·log 4 − log(m+1))/log m. The step is div_le_iff₀ turning the quotient inequality into the product form already proved. This is the shape most directly comparable to the prime number theorem's π(x) ~ x/log x: the right side is asymptotically (½ log 4)·m/log m = (log 2)·m/log m, the elementary lower half of π(x) = Θ(x/log x). The sharper constant 0.921 and the full PNT limit remain separate open questions of the parent.",
     "mathContext": "$\\pi(m) \\ge \\dfrac{\\lfloor m/2\\rfloor \\log 4 - \\log(m+1)}{\\log m} \\sim (\\log 2)\\dfrac{m}{\\log m}$.",
     "significance": "supporting",
-    "relatedConcepts": ["prime number theorem π(x) ~ x/log x", "div_le_iff₀", "Θ(x/log x)", "Chebyshev constants"],
-    "prerequisites": ["the logarithmic lower bound", "positivity of log m for m ≥ 2", "the PNT asymptotic form"]
+    "relatedConcepts": [
+      "prime number theorem π(x) ~ x/log x",
+      "div_le_iff₀",
+      "Θ(x/log x)",
+      "Chebyshev constants"
+    ],
+    "prerequisites": [
+      "the logarithmic lower bound",
+      "positivity of log m for m ≥ 2",
+      "the PNT asymptotic form"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment: per-declaration annotation coverage

`chebyshev-pnt-bridge-oq-05` (Chebyshev–PNT bridge, lower bound on π(m) for all m) had a single annotation `ann-nat-bound` spanning lines 55–92 that **lumped two theorems**:

- `primeCounting_mono` (L56) — the π-monotonicity re-export (`Nat.monotone_primeCounting`)
- `four_pow_half_le_mul_pow_primeCounting` (L68) — the main all-m Chebyshev bound

### Change
- Added **ann-mono** (55–59): a dedicated annotation for the π-monotonicity helper, explaining it is the engine that raises the exponent π(2⌊m/2⌋) ≤ π(m) — the exact ingredient the parent (even-only) file lacked.
- Narrowed **ann-nat-bound** to 60–92 for the main theorem.

Every declaration now has its own annotation (4 → 5); full line coverage preserved. All annotations retain their `mathContext`/`significance`/`relatedConcepts`/`prerequisites` fields. meta.json unchanged (11 KB, well under cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)