### PR TITLE
research(law-of-cosines-oq-07-oq-01): Jordan–von Neumann theorem — parallelogram law characterises inner-product norms [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ07OQ01.lean
+++ b/proofs/Proofs/LawOfCosinesOQ07OQ01.lean
@@ -1,0 +1,104 @@
+import Mathlib
+
+/-
+# Law of Cosines — OQ-07-OQ-01: The Jordan–von Neumann Theorem
+  (the parallelogram law characterises inner-product norms)
+
+## Research Problem: law-of-cosines-oq-07-oq-01
+
+Parent `law-of-cosines-oq-07` proves the **parallelogram law** as a consequence
+of Apollonius's median identity:
+
+    ‖x + y‖² + ‖x − y‖² = 2 · (‖x‖² + ‖y‖²)
+
+holds in every real (or complex) inner-product space.  Its first open question
+asks for the **converse**: the parallelogram law is not merely *necessary* for a
+norm to come from an inner product — it is *sufficient*.  This is the classical
+**Fréchet–von Neumann–Jordan theorem** (Jordan–von Neumann 1935): a normed space
+whose norm satisfies the parallelogram identity carries a compatible inner
+product, recovered from the norm by polarisation.
+
+Mathlib supplies the hard analytic content as `InnerProductSpace.ofNorm`
+(the polarisation construction, together with the additivity and homogeneity of
+the resulting form).  This entry packages the two directions into a single
+**characterisation**:
+
+  * `parallelogram_of_innerProductSpace` — the forward (easy) direction: every
+    inner-product norm obeys the parallelogram law.
+  * `innerProductSpaceOfParallelogram`  — the converse, as an explicit
+    (noncomputable) `InnerProductSpace` structure built from a parallelogram
+    hypothesis.
+  * `nonempty_innerProductSpace_iff_parallelogram` — the headline biconditional:
+    a norm admits a *compatible inner product* **iff** it satisfies the
+    parallelogram law.  No `InnerProductSpaceable` typeclass appears in the
+    statement — it is phrased purely in terms of the norm.
+
+The forward direction is `parallelogram_law_with_norm`; the converse is
+`nonempty_innerProductSpace`.  Both are Mathlib lemmas; the contribution here is
+the clean two-sided packaging answering the parent's open question, plus a
+concrete confirmation on the Euclidean plane.
+
+DISTINCT from `law-of-cosines-oq-07-oq-02` (sum of the squared medians), which
+develops the *metric/affine* side of the parent; this entry develops its
+*functional-analytic* side.
+
+Tags: functional-analysis, inner-product-space, parallelogram-law,
+jordan-von-neumann, law-of-cosines
+-/
+
+open RCLike
+
+namespace LawOfCosinesOQ07OQ01
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+
+omit [NormedSpace 𝕜 E] in
+/-- **Forward direction (necessity).** In any inner-product space the norm
+satisfies the parallelogram identity.  This is the statement the parent entry
+`law-of-cosines-oq-07` derives from Apollonius's median identity; here it is the
+easy half of the Jordan–von Neumann characterisation. -/
+theorem parallelogram_of_innerProductSpace [InnerProductSpace 𝕜 E] (x y : E) :
+    ‖x + y‖ * ‖x + y‖ + ‖x - y‖ * ‖x - y‖ = 2 * (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖) :=
+  parallelogram_law_with_norm 𝕜 x y
+
+/-- **Converse direction (sufficiency): the Fréchet–von Neumann–Jordan theorem.**
+A normed `𝕜`-space whose norm satisfies the parallelogram identity can be endowed
+with a compatible inner product, obtained from the norm by polarisation.  This is
+a thin wrapper around Mathlib's `InnerProductSpace.ofNorm`, exposed here as the
+explicit answer to the parent's open question. -/
+noncomputable def innerProductSpaceOfParallelogram
+    (h : ∀ x y : E, ‖x + y‖ * ‖x + y‖ + ‖x - y‖ * ‖x - y‖ = 2 * (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖)) :
+    InnerProductSpace 𝕜 E :=
+  InnerProductSpace.ofNorm (𝕜 := 𝕜) h
+
+/-- **The Jordan–von Neumann characterisation.**  A normed `𝕜`-space admits a
+compatible inner product **if and only if** its norm satisfies the parallelogram
+identity.  The statement mentions only the norm — the inner product is existentially
+quantified via `Nonempty (InnerProductSpace 𝕜 E)`. -/
+theorem nonempty_innerProductSpace_iff_parallelogram :
+    Nonempty (InnerProductSpace 𝕜 E) ↔
+      ∀ x y : E, ‖x + y‖ * ‖x + y‖ + ‖x - y‖ * ‖x - y‖ = 2 * (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖) := by
+  constructor
+  · rintro ⟨inst⟩
+    letI := inst
+    exact fun x y => parallelogram_law_with_norm 𝕜 x y
+  · intro h
+    haveI : InnerProductSpaceable E := ⟨h⟩
+    exact nonempty_innerProductSpace 𝕜 E
+
+/-- Restated for the reader who wants the converse as a bare implication:
+the parallelogram identity guarantees *some* compatible inner product exists. -/
+theorem exists_inner_of_parallelogram
+    (h : ∀ x y : E, ‖x + y‖ * ‖x + y‖ + ‖x - y‖ * ‖x - y‖ = 2 * (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖)) :
+    Nonempty (InnerProductSpace 𝕜 E) :=
+  (nonempty_innerProductSpace_iff_parallelogram (𝕜 := 𝕜)).2 h
+
+/-- Concrete confirmation on the Euclidean plane `EuclideanSpace ℝ (Fin 2)`:
+being an honest inner-product space, its norm satisfies the parallelogram law,
+so the characterisation recognises it. -/
+example : ∀ x y : EuclideanSpace ℝ (Fin 2),
+    ‖x + y‖ * ‖x + y‖ + ‖x - y‖ * ‖x - y‖ = 2 * (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖) :=
+  (nonempty_innerProductSpace_iff_parallelogram (𝕜 := ℝ)).1 ⟨inferInstance⟩
+
+end LawOfCosinesOQ07OQ01

--- a/src/data/proofs/law-of-cosines-oq-07-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-07-oq-01/meta.json
@@ -1,0 +1,123 @@
+{
+  "id": "law-of-cosines-oq-07-oq-01",
+  "title": "The Jordan–von Neumann Theorem: Parallelogram Law Characterises Inner-Product Norms",
+  "slug": "law-of-cosines-oq-07-oq-01",
+  "description": "A normed space admits a compatible inner product if and only if its norm satisfies the parallelogram law ‖x+y‖²+‖x−y‖²=2(‖x‖²+‖y‖²). This is the Fréchet–von Neumann–Jordan theorem: the parallelogram identity the parent entry law-of-cosines-oq-07 proved to be necessary is also sufficient. Packaged coordinate-free over any RCLike field as a two-sided characterisation Nonempty (InnerProductSpace 𝕜 E) ↔ (parallelogram law), built on Mathlib's polarisation construction InnerProductSpace.ofNorm. Answers the openQuestion of law-of-cosines-oq-07.",
+  "meta": {
+    "author": "Robb Walters (researcher-6)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ07OQ01.lean",
+    "tags": [
+      "functional-analysis",
+      "inner-product-space",
+      "parallelogram-law",
+      "jordan-von-neumann",
+      "law-of-cosines",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 104,
+    "assumptions": "No axioms or sorries. All results depend only on the foundational axioms propext, Classical.choice, Quot.sound (the Lean/Mathlib standard, which do not count as assumptions). Verified with #print axioms.",
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "The Jordan–von Neumann characterisation packaged as a single biconditional Nonempty (InnerProductSpace 𝕜 E) ↔ (∀ x y, ‖x+y‖·‖x+y‖ + ‖x−y‖·‖x−y‖ = 2·(‖x‖·‖x‖ + ‖y‖·‖y‖)), phrased purely in terms of the norm with the InnerProductSpaceable typeclass hidden",
+      "The converse (sufficiency) direction exposed as an explicit noncomputable InnerProductSpace structure innerProductSpaceOfParallelogram built from a bare parallelogram hypothesis via Mathlib's InnerProductSpace.ofNorm",
+      "Answers the functional-analytic openQuestion of law-of-cosines-oq-07 (whether the parallelogram law the parent proved necessary is also sufficient), complementing sibling oq-02 which develops the metric/affine side"
+    ],
+    "theoremCount": 3,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The parallelogram law ‖x+y‖²+‖x−y‖²=2(‖x‖²+‖y‖²) is the defining metric fingerprint of Euclidean geometry, going back to Apollonius's median theorem (the parent entry law-of-cosines-oq-07). That it is not merely necessary but sufficient — every norm obeying it is secretly an inner-product norm — was established by Pascual Jordan and John von Neumann in 1935 (\"On inner products in linear, metric spaces\", Annals of Mathematics). The inner product is recovered from the norm by the polarisation identity, and the content of the theorem is that this recovered form is bilinear and positive-definite. Mathlib formalises the hard analytic core as InnerProductSpace.ofNorm; this entry packages the necessity and sufficiency directions into the clean two-sided characterisation.",
+    "problemStatement": "Prove that a normed space $E$ over $\\mathbb{R}$ or $\\mathbb{C}$ admits a compatible inner product if and only if its norm satisfies the parallelogram identity $\\|x+y\\|^2 + \\|x-y\\|^2 = 2(\\|x\\|^2 + \\|y\\|^2)$ for all $x, y$, and expose the converse (the Fréchet–von Neumann–Jordan theorem) as an explicit inner-product structure built from the norm.",
+    "text": "Glues Mathlib's forward lemma parallelogram_law_with_norm and its converse construction nonempty_innerProductSpace / InnerProductSpace.ofNorm into a single characterisation, phrased purely in terms of the norm, and confirms it on the Euclidean plane.",
+    "proofStrategy": "1. parallelogram_of_innerProductSpace: the forward (necessity) direction is exactly parallelogram_law_with_norm 𝕜; the ambient NormedSpace section variable is omitted since InnerProductSpace supplies it. 2. innerProductSpaceOfParallelogram: the converse (sufficiency) is a thin wrapper around InnerProductSpace.ofNorm, exposing the recovered inner product as an explicit noncomputable structure. 3. nonempty_innerProductSpace_iff_parallelogram: the headline biconditional. Forward destructs a Nonempty instance, upgrades it locally, and applies parallelogram_law_with_norm; backward installs an InnerProductSpaceable instance from the hypothesis and invokes nonempty_innerProductSpace. 4. exists_inner_of_parallelogram restates the backward implication. 5. A concrete example confirms EuclideanSpace ℝ (Fin 2) is recognised by the characterisation.",
+    "keyInsights": [
+      "The parallelogram law is a complete invariant: among all normed spaces, exactly the inner-product ones satisfy it, so the identity the parent proved necessary is a full characterisation, not just a one-way test.",
+      "The converse is genuinely analytic — the inner product is defined from the norm by polarisation and one must prove additivity and homogeneity of the resulting form — which is why the heavy lifting is delegated to Mathlib's InnerProductSpace.ofNorm rather than reproved.",
+      "Phrasing the biconditional with Nonempty (InnerProductSpace 𝕜 E) keeps the statement about the norm alone: no inner product is named, and the InnerProductSpaceable typeclass is confined to the proof, so a reader sees only norms and the parallelogram equation.",
+      "The whole entry is axiom-clean (only propext / Classical.choice / Quot.sound), and works over an arbitrary RCLike field 𝕜, covering both the real and complex cases uniformly."
+    ],
+    "prerequisites": [
+      "Normed spaces over an RCLike field (ℝ or ℂ)",
+      "The parallelogram law and its role for inner-product norms (law-of-cosines-oq-07)",
+      "Polarisation and Mathlib's InnerProductSpace.ofNorm / InnerProductSpaceable",
+      "Lean 4 typeclass manipulation (letI, haveI, Nonempty)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-necessity",
+      "title": "Part I: Necessity (Forward Direction)",
+      "startLine": 56,
+      "endLine": 63,
+      "summary": "parallelogram_of_innerProductSpace: every inner-product norm satisfies the parallelogram identity, a restatement of parallelogram_law_with_norm and the fact the parent derived from Apollonius."
+    },
+    {
+      "id": "part2-sufficiency",
+      "title": "Part II: Sufficiency — Fréchet–von Neumann–Jordan",
+      "startLine": 65,
+      "endLine": 73,
+      "summary": "innerProductSpaceOfParallelogram: the converse as an explicit noncomputable InnerProductSpace structure recovered from a parallelogram hypothesis by polarisation, wrapping InnerProductSpace.ofNorm."
+    },
+    {
+      "id": "part3-characterisation",
+      "title": "Part III: The Two-Sided Characterisation",
+      "startLine": 75,
+      "endLine": 95,
+      "summary": "nonempty_innerProductSpace_iff_parallelogram: the headline biconditional (compatible inner product exists ⟺ parallelogram law), with exists_inner_of_parallelogram restating the converse as a bare implication."
+    },
+    {
+      "id": "part4-instantiation",
+      "title": "Part IV: Euclidean Plane Instantiation",
+      "startLine": 97,
+      "endLine": 103,
+      "summary": "Confirms the characterisation recognises the standard model EuclideanSpace ℝ (Fin 2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Fréchet–von Neumann–Jordan theorem is packaged as a clean two-sided characterisation: a normed space over an RCLike field carries a compatible inner product if and only if its norm satisfies the parallelogram law. This answers the functional-analytic openQuestion of law-of-cosines-oq-07 — the parallelogram identity the parent proved necessary is also sufficient — with the converse exposed as an explicit inner-product structure. Verified, 0 axioms, 0 sorries.",
+    "openQuestions": [
+      "Can one exhibit a concrete normed space where the parallelogram law fails (e.g. ℝ² under the sup or ℓ¹ norm) and hence, by this characterisation, carries no compatible inner product — turning the necessity direction into a formal non-embeddability witness?",
+      "Does the constructed inner product from InnerProductSpace.ofNorm agree, up to the polarisation identity, with any pre-existing inner product on the space, i.e. is the recovered structure canonical?"
+    ],
+    "implications": "Closes the necessity/sufficiency loop opened by the parent: the parallelogram law is not just a consequence of having an inner product but a complete characterisation of inner-product norms. It situates the classical Euclidean median identity of law-of-cosines-oq-07 as one face of a sharp dividing line in functional analysis between inner-product spaces and general normed spaces."
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines-oq-07",
+      "relationship": "parent-problem",
+      "description": "Answers the parent's functional-analytic openQuestion: the parallelogram law the parent derived from Apollonius (necessity) is upgraded here to a full characterisation via its converse, the Fréchet–von Neumann–Jordan theorem."
+    },
+    {
+      "targetId": "law-of-cosines-oq-07-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling extension of the same parent developing the metric/affine side (sum of squared medians); this entry develops the functional-analytic side (parallelogram law as a characterisation of inner-product norms)."
+    }
+  ],
+  "references": [
+    {
+      "author": "P. Jordan and J. von Neumann",
+      "title": "On Inner Products in Linear, Metric Spaces",
+      "year": 1935,
+      "note": "Annals of Mathematics 36(3), 719–723 — the original characterisation of inner-product norms by the parallelogram law"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "LawOfCosinesOQ07OQ01",
+    "lineCount": 104,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "path": "Proofs/LawOfCosinesOQ07OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **functional-analytic openQuestion** of `law-of-cosines-oq-07`: the parallelogram law that the parent proved *necessary* for a norm to come from an inner product is also *sufficient*. This is the **Fréchet–von Neumann–Jordan theorem** (Jordan–von Neumann, 1935).

New gallery entry `law-of-cosines-oq-07-oq-01` — the functional-analytic counterpart of sibling `-oq-02` (sum of squared medians, the metric/affine side of the same parent).

## Result

Headline characterisation, phrased purely in terms of the norm over any `RCLike` field `𝕜`:

```
Nonempty (InnerProductSpace 𝕜 E)  ↔  ∀ x y, ‖x+y‖·‖x+y‖ + ‖x−y‖·‖x−y‖ = 2·(‖x‖·‖x‖ + ‖y‖·‖y‖)
```

- `parallelogram_of_innerProductSpace` — necessity (forward), from `parallelogram_law_with_norm`.
- `innerProductSpaceOfParallelogram` — sufficiency (converse) as an explicit noncomputable `InnerProductSpace` structure, wrapping Mathlib's `InnerProductSpace.ofNorm` (the polarisation construction).
- `nonempty_innerProductSpace_iff_parallelogram` — the two-sided biconditional.
- `exists_inner_of_parallelogram` — converse as a bare implication.
- Concrete `EuclideanSpace ℝ (Fin 2)` instantiation.

## Verification

- 3 theorems + 1 definition, 104 lines, **0 sorries, 0 axioms**.
- Typechecks cleanly against Mathlib 4.26 (`lake env lean`, EXIT 0, no warnings).
- `#print axioms` on both main results: only `propext, Classical.choice, Quot.sound`.

## Files
- `proofs/Proofs/LawOfCosinesOQ07OQ01.lean`
- `src/data/proofs/law-of-cosines-oq-07-oq-01/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)