### PR TITLE
Add wilsons-theorem-oq-03-oq-01: Legendre for multinomials & Kummer's theorem

### DIFF
--- a/proofs/Proofs/WilsonsTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ03OQ01.lean
@@ -1,0 +1,208 @@
+/-
+Legendre's Formula for Multinomial Coefficients & Kummer's Theorem
+(Wilson's Theorem OQ-03-OQ-01)
+
+Source: Classical number theory — A.-M. Legendre (1808), E. Kummer (1852).
+Status: COMPLETE (0 sorries, 0 axioms)
+
+## Open Question Answered
+Parent entry WilsonsTheoremOQ03 ("Legendre's Formula: p-adic Valuation of n!")
+poses the open question:
+
+  "Can Legendre's formula be generalized to multinomial coefficients
+   n! / (n₁! · n₂! ⋯ n_k!)?"
+
+This file answers YES and, in doing so, formalizes **Kummer's theorem** for
+multinomial coefficients: the p-adic valuation counts the base-p carries.
+
+## What This Proves
+Let `p` be prime, `s` a finite index set, `f : α → ℕ`, and write
+`N = ∑ i ∈ s, f i`. The multinomial coefficient is
+`multinomial s f = N! / ∏ i ∈ s, (f i)!`.
+
+- [x] **Additivity of valuation** (the heart of the generalization):
+        ν_p(N!) = ν_p(multinomial s f) + ∑ i ∈ s, ν_p((f i)!)
+      equivalently  ν_p(multinomial s f) = ν_p(N!) − ∑ i ∈ s, ν_p((f i)!).
+
+- [x] **Legendre / Kummer digit-sum form** (no ℕ-subtraction):
+        (p − 1) · ν_p(multinomial s f) + S_p(N) = ∑ i ∈ s, S_p(f i)
+      where S_p(m) = (Nat.digits p m).sum is the base-p digit sum.
+      Rearranged: (p−1)·ν_p(multinomial) = ∑ S_p(f i) − S_p(N), i.e. the
+      valuation counts base-p carries (each carry drops the digit sum by p−1).
+
+- [x] **Kummer's non-divisibility criterion**:
+        p ∤ multinomial s f  ↔  ∑ i ∈ s, S_p(f i) = S_p(N)
+      (the multinomial is coprime to p exactly when adding the f i in base p
+      produces no carries).
+
+- [x] **Two-term (binomial) specialization**:
+        (p − 1) · ν_p((a+b)!/(a!·b!)) + S_p(a+b) = S_p(a) + S_p(b)
+      — the classical statement of Kummer's theorem for `C(a+b, a)`.
+
+## Mathlib Dependencies
+- `Nat.multinomial`, `Nat.multinomial_spec`, `Nat.multinomial_pos`
+- `padicValNat.mul`            : ν_p(m·n) = ν_p(m) + ν_p(n)   (m,n ≠ 0)
+- `sub_one_mul_padicValNat_factorial` : (p−1)·ν_p(n!) = n − S_p(n)
+- `Nat.digit_sum_le`           : S_p(n) ≤ n
+- `padicValNat.eq_zero_iff`    : ν_p(n) = 0 ↔ p = 1 ∨ n = 0 ∨ ¬ p ∣ n
+
+Parent proof: WilsonsTheoremOQ03.lean (Legendre for a single factorial).
+-/
+
+import Mathlib
+
+namespace WilsonsTheoremMultinomialLegendre
+
+open Nat Finset
+
+variable {α : Type*}
+
+/-! ## Step 1 — `padicValNat` is additive over a product of factorials -/
+
+/-- The p-adic valuation of a finite product of factorials is the sum of the
+individual p-adic valuations. (Factorials are always positive, so no
+non-vanishing hypotheses are needed.) -/
+theorem padicValNat_prod_factorial (p : ℕ) (hp : p.Prime)
+    (s : Finset α) (f : α → ℕ) :
+    padicValNat p (∏ i ∈ s, (f i)!) = ∑ i ∈ s, padicValNat p ((f i)!) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  classical
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons a s ha ih =>
+      rw [Finset.prod_cons, Finset.sum_cons,
+        padicValNat.mul (Nat.factorial_pos _).ne'
+          (Finset.prod_pos (fun i _ => Nat.factorial_pos _)).ne', ih]
+
+/-! ## Step 2 — Additive form of Legendre's formula (avoids ℕ-subtraction) -/
+
+/-- A subtraction-free restatement of Legendre's formula: for a prime `p`,
+`(p − 1) · ν_p(m!) + S_p(m) = m`, where `S_p(m) = (p.digits m).sum`.
+This follows from `sub_one_mul_padicValNat_factorial` together with the bound
+`S_p(m) ≤ m` (`Nat.digit_sum_le`). -/
+theorem legendre_add (p m : ℕ) [Fact p.Prime] :
+    (p - 1) * padicValNat p (m !) + (p.digits m).sum = m := by
+  have h := sub_one_mul_padicValNat_factorial (p := p) m
+  have hle := Nat.digit_sum_le p m
+  omega
+
+/-! ## Step 3 — Legendre's formula for multinomial coefficients -/
+
+/-- **Multinomial Legendre (additive form).** With `N = ∑ i ∈ s, f i`,
+the valuation of `N!` splits as the valuation of the multinomial coefficient
+plus the valuations of the individual factorials:
+`ν_p(N!) = ν_p(multinomial s f) + ∑ i ∈ s, ν_p((f i)!)`.
+
+Proof: apply `padicValNat` to the defining identity
+`(∏ i ∈ s, (f i)!) · multinomial s f = N!` (`Nat.multinomial_spec`) and use
+multiplicativity plus Step 1. -/
+theorem padicValNat_factorial_sum_eq (p : ℕ) (hp : p.Prime)
+    (s : Finset α) (f : α → ℕ) :
+    padicValNat p ((∑ i ∈ s, f i)!)
+      = padicValNat p (Nat.multinomial s f) + ∑ i ∈ s, padicValNat p ((f i)!) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hspec := Nat.multinomial_spec s f
+  have hprod : (0 : ℕ) < ∏ i ∈ s, (f i)! :=
+    Finset.prod_pos (fun i _ => Nat.factorial_pos _)
+  calc padicValNat p ((∑ i ∈ s, f i)!)
+      = padicValNat p ((∏ i ∈ s, (f i)!) * Nat.multinomial s f) := by rw [hspec]
+    _ = padicValNat p (∏ i ∈ s, (f i)!) + padicValNat p (Nat.multinomial s f) :=
+          padicValNat.mul hprod.ne' (Nat.multinomial_pos s f).ne'
+    _ = (∑ i ∈ s, padicValNat p ((f i)!)) + padicValNat p (Nat.multinomial s f) := by
+          rw [padicValNat_prod_factorial p hp]
+    _ = padicValNat p (Nat.multinomial s f) + ∑ i ∈ s, padicValNat p ((f i)!) := by
+          ring
+
+/-- **Multinomial Legendre (subtraction form).** The generalization of
+Legendre's formula requested by the open question:
+`ν_p(multinomial s f) = ν_p(N!) − ∑ i ∈ s, ν_p((f i)!)`. -/
+theorem padicValNat_multinomial (p : ℕ) (hp : p.Prime)
+    (s : Finset α) (f : α → ℕ) :
+    padicValNat p (Nat.multinomial s f)
+      = padicValNat p ((∑ i ∈ s, f i)!) - ∑ i ∈ s, padicValNat p ((f i)!) := by
+  have h := padicValNat_factorial_sum_eq p hp s f
+  omega
+
+/-! ## Step 4 — Kummer's theorem: the digit-sum form -/
+
+/-- **Kummer's theorem (digit-sum form).** For a prime `p` and `N = ∑ i ∈ s, f i`:
+`(p − 1) · ν_p(multinomial s f) + S_p(N) = ∑ i ∈ s, S_p(f i)`.
+
+Equivalently `(p − 1)·ν_p(multinomial) = ∑ S_p(f i) − S_p(N)`: since each base-p
+carry when summing the `f i` decreases the total digit sum by exactly `p − 1`,
+the valuation equals the number of carries. -/
+theorem sub_one_mul_padicValNat_multinomial (p : ℕ) (hp : p.Prime)
+    (s : Finset α) (f : α → ℕ) :
+    (p - 1) * padicValNat p (Nat.multinomial s f) + (p.digits (∑ i ∈ s, f i)).sum
+      = ∑ i ∈ s, (p.digits (f i)).sum := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  -- Additive valuation identity, scaled by (p-1).
+  have hval := padicValNat_factorial_sum_eq p hp s f
+  have hIII : (p - 1) * padicValNat p ((∑ i ∈ s, f i)!)
+      = (p - 1) * padicValNat p (Nat.multinomial s f)
+        + (p - 1) * (∑ i ∈ s, padicValNat p ((f i)!)) := by
+    rw [hval, Nat.mul_add]
+  -- Legendre (additive) for N and, summed, for each f i.
+  have hI := legendre_add p (∑ i ∈ s, f i)
+  have hII : (p - 1) * (∑ i ∈ s, padicValNat p ((f i)!))
+      + (∑ i ∈ s, (p.digits (f i)).sum) = ∑ i ∈ s, f i := by
+    rw [Finset.mul_sum, ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl (fun i _ => legendre_add p (f i))
+  omega
+
+/-! ## Step 5 — Kummer's non-divisibility criterion -/
+
+/-- **Kummer's criterion.** For a prime `p`, the multinomial coefficient is
+coprime to `p` exactly when the base-p digit sums add without loss, i.e. when
+summing the `f i` in base `p` produces no carries:
+`p ∤ multinomial s f  ↔  ∑ i ∈ s, S_p(f i) = S_p(∑ i ∈ s, f i)`. -/
+theorem prime_not_dvd_multinomial_iff (p : ℕ) (hp : p.Prime)
+    (s : Finset α) (f : α → ℕ) :
+    ¬ p ∣ Nat.multinomial s f
+      ↔ (∑ i ∈ s, (p.digits (f i)).sum) = (p.digits (∑ i ∈ s, f i)).sum := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hkummer := sub_one_mul_padicValNat_multinomial p hp s f
+  have hp2 := hp.two_le
+  -- ¬ p ∣ multinomial ↔ ν_p(multinomial) = 0.
+  have hzero : ¬ p ∣ Nat.multinomial s f ↔ padicValNat p (Nat.multinomial s f) = 0 := by
+    rw [padicValNat.eq_zero_iff]
+    constructor
+    · intro h; exact Or.inr (Or.inr h)
+    · rintro (h1 | h2 | h3)
+      · exact absurd h1 hp.ne_one
+      · exact absurd h2 (Nat.multinomial_pos s f).ne'
+      · exact h3
+  rw [hzero]
+  constructor
+  · intro h
+    have hprod : (p - 1) * padicValNat p (Nat.multinomial s f) = 0 := by rw [h]; ring
+    omega
+  · intro h
+    have hprod : (p - 1) * padicValNat p (Nat.multinomial s f) = 0 := by omega
+    rcases Nat.mul_eq_zero.mp hprod with h1 | h2
+    · omega
+    · exact h2
+
+/-! ## Step 6 — The classical binomial case (Kummer for `C(a+b, a)`) -/
+
+/-- **Kummer's theorem for binomial coefficients.** Specializing the multinomial
+identity to two terms `![a, b]` recovers the classical statement: the number of
+carries in adding `a` and `b` base `p`,
+`(p − 1) · ν_p((a+b)!/(a!·b!)) + S_p(a+b) = S_p(a) + S_p(b)`. -/
+theorem sub_one_mul_padicValNat_multinomial_two (p : ℕ) (hp : p.Prime) (a b : ℕ) :
+    (p - 1) * padicValNat p (Nat.multinomial Finset.univ ![a, b])
+        + (p.digits (a + b)).sum
+      = (p.digits a).sum + (p.digits b).sum := by
+  have h := sub_one_mul_padicValNat_multinomial p hp (Finset.univ : Finset (Fin 2)) ![a, b]
+  simpa [Fin.sum_univ_two] using h
+
+/-! ## Step 7 — Concrete sanity checks -/
+
+/-- `ν₂(C(4,1)) = ν₂(4!/(1!·3!)) = 2`: adding `1 + 3` in base 2 produces two
+carries (`01₂ + 11₂ = 100₂`), matching the Kummer count.
+Digit sums: `S₂(1) + S₂(3) = 1 + 2 = 3` and `S₂(4) = 1`, so `(2−1)·ν + 1 = 3`. -/
+example : (2 - 1) * padicValNat 2 (Nat.multinomial Finset.univ ![1, 3])
+      + (Nat.digits 2 (1 + 3)).sum = (Nat.digits 2 1).sum + (Nat.digits 2 3).sum :=
+  sub_one_mul_padicValNat_multinomial_two 2 (by norm_num) 1 3
+
+end WilsonsTheoremMultinomialLegendre

--- a/src/data/proofs/wilsons-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-03-oq-01/annotations.json
@@ -1,0 +1,147 @@
+[
+  {
+    "id": "ann-wilsons-oq03-oq01-overview",
+    "proofId": "wilsons-theorem-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "concept",
+    "title": "Generalizing Legendre from a Factorial to a Multinomial",
+    "content": "The header frames the entry as the answer to the parent (wilsons-theorem-oq-03) open question: can Legendre's formula (p−1)·ν_p(n!) = n − S_p(n) be generalized to multinomial coefficients n!/(n₁!···n_k!)? The answer is yes, and it simultaneously formalizes Kummer's theorem: the p-adic valuation of a multinomial counts the base-p carries incurred when adding the parts. The file lists its four deliverables — additive valuation law, Kummer digit-sum form, non-divisibility criterion, and the classical binomial specialization — together with the small set of Mathlib lemmas it rests on.",
+    "mathContext": "$\\nu_p\\binom{N}{n_1,\\dots,n_k} = \\nu_p(N!) - \\sum_i \\nu_p(n_i!)$ with $N = \\sum_i n_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Legendre's formula",
+      "Kummer's theorem",
+      "p-adic valuation",
+      "multinomial coefficients",
+      "base-p carries"
+    ],
+    "prerequisites": [
+      "p-adic valuation ν_p",
+      "base-p digit sum S_p",
+      "multinomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-wilsons-oq03-oq01-prod-factorial",
+    "proofId": "wilsons-theorem-oq-03-oq-01",
+    "range": { "startLine": 60, "endLine": 75 },
+    "type": "technique",
+    "title": "Additivity of ν_p over a Product of Factorials",
+    "content": "padicValNat_prod_factorial proves ν_p(∏ i ∈ s, (f i)!) = ∑ i ∈ s, ν_p((f i)!) by Finset.cons_induction. The insertion step rewrites Finset.prod_cons / Finset.sum_cons and applies padicValNat.mul, whose two non-vanishing hypotheses are discharged automatically: each factorial is positive (Nat.factorial_pos) and a finite product of positive naturals is positive (Finset.prod_pos). Because factorials are never zero, the final statement carries no side conditions — a small but essential lemma, since the valuation of the multinomial is extracted from a product identity.",
+    "mathContext": "$\\nu_p\\!\\left(\\prod_{i\\in s}(f i)!\\right) = \\sum_{i\\in s}\\nu_p((f i)!)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicativity of p-adic valuation",
+      "Finset induction",
+      "factorials"
+    ],
+    "prerequisites": [
+      "padicValNat.mul",
+      "Finset.prod_pos",
+      "Finset.cons_induction"
+    ]
+  },
+  {
+    "id": "ann-wilsons-oq03-oq01-legendre-add",
+    "proofId": "wilsons-theorem-oq-03-oq-01",
+    "range": { "startLine": 77, "endLine": 88 },
+    "type": "technique",
+    "title": "Subtraction-Free Legendre: the Workhorse",
+    "content": "legendre_add restates Mathlib's sub_one_mul_padicValNat_factorial — which gives (p−1)·ν_p(m!) = m − S_p(m) with truncated ℕ subtraction — in the additive form (p−1)·ν_p(m!) + S_p(m) = m. The recast is legal precisely because S_p(m) ≤ m (Nat.digit_sum_le), and omega assembles the two facts. This additive phrasing is what lets every subsequent Kummer step be a plain linear identity, sidestepping the direction-of-subtraction pitfalls of ℕ.",
+    "mathContext": "$(p-1)\\,\\nu_p(m!) + S_p(m) = m$, valid because $S_p(m) \\le m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Legendre's formula",
+      "digit sum bound",
+      "natural-number subtraction",
+      "omega"
+    ],
+    "prerequisites": [
+      "sub_one_mul_padicValNat_factorial",
+      "Nat.digit_sum_le"
+    ]
+  },
+  {
+    "id": "ann-wilsons-oq03-oq01-multinomial-legendre",
+    "proofId": "wilsons-theorem-oq-03-oq-01",
+    "range": { "startLine": 89, "endLine": 125 },
+    "type": "key-step",
+    "title": "Legendre's Formula for Multinomial Coefficients",
+    "content": "padicValNat_factorial_sum_eq is the crux: applying ν_p to Nat.multinomial_spec — the identity (∏ i ∈ s, (f i)!)·multinomial s f = (∑ i ∈ s, f i)! — and using padicValNat.mul together with the product-additivity lemma yields ν_p(N!) = ν_p(multinomial s f) + ∑ i ∈ s, ν_p((f i)!). The calc block threads the rewrite of the spec, multiplicativity, product additivity, and a final commutation. padicValNat_multinomial then reads off the subtraction form ν_p(multinomial) = ν_p(N!) − ∑ ν_p((f i)!) with omega. This is the literal generalization the parent asked for.",
+    "mathContext": "$\\nu_p(N!) = \\nu_p\\!\\binom{N}{f} + \\sum_{i\\in s}\\nu_p((f i)!)$, so $\\nu_p\\!\\binom{N}{f} = \\nu_p(N!) - \\sum_i \\nu_p((f i)!)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "multinomial coefficient identity",
+      "additivity of valuation",
+      "Legendre generalization"
+    ],
+    "prerequisites": [
+      "Nat.multinomial_spec",
+      "padicValNat.mul",
+      "padicValNat_prod_factorial"
+    ]
+  },
+  {
+    "id": "ann-wilsons-oq03-oq01-kummer",
+    "proofId": "wilsons-theorem-oq-03-oq-01",
+    "range": { "startLine": 126, "endLine": 152 },
+    "type": "key-step",
+    "title": "Kummer's Theorem in Digit-Sum Form",
+    "content": "sub_one_mul_padicValNat_multinomial establishes (p−1)·ν_p(multinomial s f) + S_p(N) = ∑ i ∈ s, S_p(f i). The proof scales the additive valuation law by (p−1) using Nat.mul_add (hypothesis hIII), then supplies legendre_add for the total N (hI) and, summed via Finset.mul_sum and Finset.sum_add_distrib, for each part f i (hII). omega finishes by treating each scaled valuation (p−1)·ν as an opaque nonneg atom that appears identically across the hypotheses. Rearranged, (p−1)·ν_p(multinomial) = ∑ S_p(f i) − S_p(N): the valuation is exactly the number of base-p carries (each carry costs p−1 in digit sum).",
+    "mathContext": "$(p-1)\\,\\nu_p\\!\\binom{N}{f} + S_p(N) = \\sum_{i\\in s} S_p(f i)$ — carries counted by digit-sum loss.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Kummer's theorem",
+      "base-p carries",
+      "digit sums",
+      "linear arithmetic over atoms"
+    ],
+    "prerequisites": [
+      "legendre_add",
+      "padicValNat_factorial_sum_eq",
+      "Finset.mul_sum",
+      "Finset.sum_add_distrib"
+    ]
+  },
+  {
+    "id": "ann-wilsons-oq03-oq01-criterion",
+    "proofId": "wilsons-theorem-oq-03-oq-01",
+    "range": { "startLine": 153, "endLine": 185 },
+    "type": "key-step",
+    "title": "Kummer's Non-Divisibility Criterion",
+    "content": "prime_not_dvd_multinomial_iff proves p ∤ multinomial s f ↔ ∑ i ∈ s, S_p(f i) = S_p(N). First hzero converts ¬ p ∣ multinomial to ν_p(multinomial) = 0 via padicValNat.eq_zero_iff (the p = 1 and multinomial = 0 disjuncts are excluded by hp.ne_one and multinomial_pos). Then, using the Kummer identity and p ≥ 2: the forward direction turns ν = 0 into (p−1)·ν = 0 so the digit sums balance; the reverse uses Nat.mul_eq_zero on (p−1)·ν = 0, ruling out p−1 = 0. This is the multinomial 'no carries' criterion.",
+    "mathContext": "$p \\nmid \\binom{N}{f} \\iff \\sum_{i\\in s} S_p(f i) = S_p(N)$ (no base-$p$ carries).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kummer's criterion",
+      "coprimality to p",
+      "carry-free addition",
+      "zero valuation"
+    ],
+    "prerequisites": [
+      "padicValNat.eq_zero_iff",
+      "Nat.mul_eq_zero",
+      "sub_one_mul_padicValNat_multinomial"
+    ]
+  },
+  {
+    "id": "ann-wilsons-oq03-oq01-binomial",
+    "proofId": "wilsons-theorem-oq-03-oq-01",
+    "range": { "startLine": 186, "endLine": 208 },
+    "type": "concept",
+    "title": "Binomial Specialization and a Worked Instance",
+    "content": "sub_one_mul_padicValNat_multinomial_two specializes the multinomial Kummer identity to two indices — s = Finset.univ over Fin 2, f = ![a,b] — recovering the textbook statement (p−1)·ν_p((a+b)!/(a!·b!)) + S_p(a+b) = S_p(a) + S_p(b); the two-element sums collapse via Fin.sum_univ_two. The closing example instantiates p = 2 with ![1,3]: adding 1 + 3 = 4 in base 2 (01₂ + 11₂ = 100₂) produces two carries, matching S₂(1) + S₂(3) = 3 against S₂(4) = 1. This shows the parent's single-factorial Legendre result is a strict special case.",
+    "mathContext": "$(p-1)\\,\\nu_p\\!\\binom{a+b}{a} + S_p(a+b) = S_p(a) + S_p(b)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "binomial coefficients",
+      "Kummer for C(a+b,a)",
+      "Fin.sum_univ_two",
+      "worked example"
+    ],
+    "prerequisites": [
+      "sub_one_mul_padicValNat_multinomial",
+      "Nat.multinomial_univ_two"
+    ]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-03-oq-01/meta.json
@@ -1,0 +1,215 @@
+{
+  "id": "wilsons-theorem-oq-03-oq-01",
+  "title": "Legendre's Formula for Multinomial Coefficients & Kummer's Theorem",
+  "slug": "wilsons-theorem-oq-03-oq-01",
+  "description": "Generalizes Legendre's formula from a single factorial to multinomial coefficients n!/(n₁!···n_k!): the p-adic valuation splits additively as ν_p(N!) = ν_p(multinomial) + ∑ ν_p((nᵢ)!). In digit-sum form this is Kummer's theorem — (p−1)·ν_p(multinomial) + S_p(N) = ∑ S_p(nᵢ), so the valuation counts base-p carries. Includes Kummer's non-divisibility criterion (p ∤ multinomial ↔ no carries) and the classical binomial specialization. Answers the open question of parent entry wilsons-theorem-oq-03.",
+  "meta": {
+    "author": "A.-M. Legendre (1808) / E. Kummer (1852), formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Kummer%27s_theorem",
+    "date": "1852",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "p-adic",
+      "factorial",
+      "multinomial",
+      "wilsons-theorem",
+      "legendre",
+      "kummer",
+      "digit-sum",
+      "carries",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ03OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None beyond Mathlib's foundational axioms. Every theorem (padicValNat_prod_factorial, legendre_add, padicValNat_factorial_sum_eq, padicValNat_multinomial, sub_one_mul_padicValNat_multinomial, prime_not_dvd_multinomial_iff, sub_one_mul_padicValNat_multinomial_two) is fully machine-checked. `#print axioms` on the main results reports only propext, Classical.choice, and Quot.sound — no `axiom` declarations, no structure-encoded hypotheses, no `sorry`, and no `native_decide` (hence no Lean.ofReduceBool). leanFile.axiomCount = 0.",
+    "dateAdded": "2026-07-01",
+    "lineCount": 208,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.multinomial_spec",
+        "description": "(∏ i ∈ s, (f i)!) · multinomial s f = (∑ i ∈ s, f i)!",
+        "module": "Mathlib.Data.Nat.Choose.Multinomial"
+      },
+      {
+        "theorem": "Nat.multinomial_pos",
+        "description": "0 < multinomial s f",
+        "module": "Mathlib.Data.Nat.Choose.Multinomial"
+      },
+      {
+        "theorem": "padicValNat.mul",
+        "description": "ν_p(m·n) = ν_p(m) + ν_p(n) for m,n ≠ 0",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "sub_one_mul_padicValNat_factorial",
+        "description": "Legendre's digit-sum form: (p-1)·ν_p(n!) = n − S_p(n)",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.digit_sum_le",
+        "description": "(Nat.digits p n).sum ≤ n — the base-p digit sum never exceeds the number",
+        "module": "Mathlib.Data.Nat.Digits.Defs"
+      },
+      {
+        "theorem": "padicValNat.eq_zero_iff",
+        "description": "ν_p(n) = 0 ↔ p = 1 ∨ n = 0 ∨ ¬ p ∣ n",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Defs"
+      }
+    ],
+    "originalContributions": [
+      "Additivity of the p-adic valuation over a Finset product of factorials (padicValNat_prod_factorial)",
+      "Subtraction-free 'additive' restatement of single-factorial Legendre (legendre_add), the workhorse that avoids ℕ-truncation throughout",
+      "Multinomial Legendre formula in both additive and subtraction forms — the direct answer to the parent open question",
+      "Kummer's theorem (digit-sum form) for multinomial coefficients: (p−1)·ν_p(multinomial) + S_p(N) = ∑ S_p(nᵢ)",
+      "Kummer's non-divisibility criterion: p ∤ multinomial ↔ ∑ S_p(nᵢ) = S_p(N) (no base-p carries)",
+      "Classical binomial specialization recovered from the multinomial statement via ![a,b]"
+    ],
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Legendre's 1808 formula computes the exact power of a prime $p$ dividing a factorial: $(p-1)\\,\\nu_p(n!) = n - S_p(n)$, where $S_p(n)$ is the base-$p$ digit sum. In 1852 Ernst Kummer discovered a striking refinement for binomial coefficients: $\\nu_p\\binom{m+n}{m}$ equals the number of carries that occur when $m$ and $n$ are added in base $p$. Kummer's theorem is an immediate consequence of applying Legendre's formula to $\\binom{m+n}{m} = (m+n)!/(m!\\,n!)$, because each base-$p$ carry lowers the total digit sum by exactly $p-1$.\n\nThe parent entry (wilsons-theorem-oq-03) formalized Legendre's formula for a single factorial and explicitly asked: *can it be generalized to multinomial coefficients $n!/(n_1!\\cdots n_k!)$?* This entry answers that question and, in the same stroke, formalizes the multinomial version of Kummer's theorem.",
+    "problemStatement": "Let $p$ be prime, $s$ a finite index set, and $f : \\alpha \\to \\mathbb{N}$, with $N = \\sum_{i\\in s} f(i)$. The multinomial coefficient is $\\binom{N}{f} = N! / \\prod_{i\\in s}(f(i)!)$. Prove:\n\n1. **Additive valuation:** $\\nu_p(N!) = \\nu_p\\binom{N}{f} + \\sum_{i\\in s}\\nu_p(f(i)!)$, equivalently $\\nu_p\\binom{N}{f} = \\nu_p(N!) - \\sum_i \\nu_p(f(i)!)$.\n\n2. **Kummer (digit-sum form):** $(p-1)\\,\\nu_p\\binom{N}{f} + S_p(N) = \\sum_{i\\in s} S_p(f(i))$.\n\n3. **Kummer criterion:** $p \\nmid \\binom{N}{f} \\iff \\sum_{i\\in s} S_p(f(i)) = S_p(N)$ (no base-$p$ carries).",
+    "text": "The generalization is clean because the whole story reduces to two facts. First, the multinomial coefficient satisfies the defining identity $\\bigl(\\prod_{i\\in s} f(i)!\\bigr)\\cdot\\binom{N}{f} = N!$ (Mathlib's `Nat.multinomial_spec`). Applying the $p$-adic valuation to both sides and using that $\\nu_p$ is additive on products of nonzero numbers turns this into $\\sum_i \\nu_p(f(i)!) + \\nu_p\\binom{N}{f} = \\nu_p(N!)$ — the additive valuation law.\n\nSecond, Legendre's single-factorial formula, rearranged into its subtraction-free form $(p-1)\\nu_p(m!) + S_p(m) = m$ (using $S_p(m)\\le m$), lets us multiply the additive valuation law by $p-1$ and read off Kummer's digit-sum identity after cancelling the common $N$. Because $p-1 \\ge 1$, the valuation vanishes exactly when the digit sums balance, giving the classic 'no carries' criterion.\n\nThe formalization is entirely `sorry`-free and `native_decide`-free: it relies only on Mathlib's `Nat.multinomial_spec`, `padicValNat.mul`, `sub_one_mul_padicValNat_factorial`, and `Nat.digit_sum_le`, so the main results depend on nothing beyond `propext`, `Classical.choice`, and `Quot.sound`.",
+    "proofStrategy": "The proof proceeds in six steps:\n\n1. **Product additivity** (`padicValNat_prod_factorial`): by `Finset.cons_induction`, $\\nu_p\\bigl(\\prod_{i\\in s}(f i)!\\bigr) = \\sum_{i\\in s}\\nu_p((f i)!)$, using `padicValNat.mul` at each insertion (factorials are positive, so no side conditions survive).\n\n2. **Additive Legendre** (`legendre_add`): from `sub_one_mul_padicValNat_factorial` giving $(p-1)\\nu_p(m!) = m - S_p(m)$ and the bound `Nat.digit_sum_le` giving $S_p(m)\\le m$, `omega` produces the subtraction-free $(p-1)\\nu_p(m!) + S_p(m) = m$.\n\n3. **Multinomial Legendre** (`padicValNat_factorial_sum_eq`, `padicValNat_multinomial`): apply $\\nu_p$ to `Nat.multinomial_spec`, use `padicValNat.mul` and Step 1, then `omega` for the subtraction form.\n\n4. **Kummer digit-sum form** (`sub_one_mul_padicValNat_multinomial`): scale the additive valuation law by $(p-1)$ via `Nat.mul_add`, feed in `legendre_add` for $N$ and (summed with `Finset.mul_sum`/`Finset.sum_add_distrib`) for each $f(i)$, then discharge with `omega` treating the scaled valuations as atoms.\n\n5. **Non-divisibility criterion** (`prime_not_dvd_multinomial_iff`): convert $p \\nmid \\text{multinomial}$ to $\\nu_p = 0$ via `padicValNat.eq_zero_iff`, then use $p-1\\ge 1$ and `Nat.mul_eq_zero` to turn the Kummer identity into the digit-sum equality.\n\n6. **Binomial case** (`sub_one_mul_padicValNat_multinomial_two`): specialize to $s = \\text{univ}$ over `Fin 2` with $f = ![a,b]$ and simplify the two-element sums with `Fin.sum_univ_two`.",
+    "keyInsights": [
+      "**The multinomial identity does all the work.** `Nat.multinomial_spec` — $(\\prod_i (f i)!)\\cdot\\text{multinomial} = N!$ — turns a statement about a quotient into a statement about a product, where the $p$-adic valuation is simply additive. No divisibility gymnastics are needed.",
+      "**Work additively, not with ℕ-subtraction.** Legendre's native form $(p-1)\\nu_p(m!) = m - S_p(m)$ uses truncated subtraction. Recasting it as $(p-1)\\nu_p(m!) + S_p(m) = m$ (legal because $S_p(m)\\le m$) means every later step is a linear identity that `omega` closes without worrying about which side is larger.",
+      "**Kummer = carry counting.** Each base-$p$ carry when forming $N = \\sum f(i)$ reduces the total digit sum $\\sum_i S_p(f(i))$ down to $S_p(N)$ by exactly $p-1$. Hence $(p-1)\\nu_p(\\text{multinomial}) = \\sum_i S_p(f(i)) - S_p(N)$ literally counts carries, and $p\\nmid\\text{multinomial}$ exactly when there are none.",
+      "**`omega` handles the scaled valuations as opaque atoms.** The Kummer derivation multiplies unknown valuations by $p-1$. `omega` cannot expand $(p-1)\\cdot\\nu$, but it does not need to: as long as each product term appears syntactically identically across the hypotheses, `omega` treats it as a single nonneg integer and the linear algebra goes through.",
+      "**The binomial theorem is a corollary, not a separate result.** Specializing to two indices recovers the textbook Kummer statement for $\\binom{a+b}{a}$, showing the multinomial form is a genuine strengthening rather than a repackaging."
+    ],
+    "prerequisites": [
+      "p-adic valuations: ν_p(n) = highest power of p dividing n",
+      "base-p digit representations and digit sums S_p(n)",
+      "multinomial coefficients n!/(n₁!···n_k!) and their factorial identity",
+      "Legendre's formula for a single factorial (parent entry wilsons-theorem-oq-03)",
+      "Lean 4: padicValNat, Nat.digits, Nat.multinomial, Finset induction, omega"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Documentation",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "File header stating the open question answered, the full list of results (multinomial Legendre, Kummer digit-sum form, non-divisibility criterion, binomial specialization), and Mathlib dependencies."
+    },
+    {
+      "id": "prod-factorial",
+      "title": "Valuation is Additive over a Product of Factorials",
+      "startLine": 60,
+      "endLine": 75,
+      "summary": "padicValNat_prod_factorial: by Finset.cons_induction, ν_p(∏ (f i)!) = ∑ ν_p((f i)!), using padicValNat.mul at each step (factorials are positive so no non-vanishing conditions remain)."
+    },
+    {
+      "id": "legendre-add",
+      "title": "Additive Form of Legendre's Formula",
+      "startLine": 77,
+      "endLine": 88,
+      "summary": "legendre_add: the subtraction-free restatement (p−1)·ν_p(m!) + S_p(m) = m, obtained from sub_one_mul_padicValNat_factorial and the bound Nat.digit_sum_le via omega. This is the workhorse used throughout."
+    },
+    {
+      "id": "multinomial-legendre",
+      "title": "Legendre's Formula for Multinomial Coefficients",
+      "startLine": 89,
+      "endLine": 125,
+      "summary": "padicValNat_factorial_sum_eq (additive) and padicValNat_multinomial (subtraction): applying ν_p to Nat.multinomial_spec gives ν_p(N!) = ν_p(multinomial) + ∑ ν_p((f i)!). This is the direct answer to the parent open question."
+    },
+    {
+      "id": "kummer-digit-sum",
+      "title": "Kummer's Theorem — Digit-Sum Form",
+      "startLine": 126,
+      "endLine": 152,
+      "summary": "sub_one_mul_padicValNat_multinomial: (p−1)·ν_p(multinomial) + S_p(N) = ∑ S_p(f i). Scales the additive valuation law by (p−1) and combines legendre_add for N and for each f i; the valuation counts base-p carries."
+    },
+    {
+      "id": "kummer-criterion",
+      "title": "Kummer's Non-Divisibility Criterion",
+      "startLine": 153,
+      "endLine": 185,
+      "summary": "prime_not_dvd_multinomial_iff: p ∤ multinomial ↔ ∑ S_p(f i) = S_p(N). Converts non-divisibility to ν_p = 0 via padicValNat.eq_zero_iff, then uses p−1 ≥ 1 and Nat.mul_eq_zero on the Kummer identity."
+    },
+    {
+      "id": "binomial-case",
+      "title": "Classical Binomial Specialization",
+      "startLine": 186,
+      "endLine": 198,
+      "summary": "sub_one_mul_padicValNat_multinomial_two: specializing to ![a,b] over Fin 2 recovers the textbook Kummer statement (p−1)·ν_p((a+b)!/(a!·b!)) + S_p(a+b) = S_p(a) + S_p(b)."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Sanity Check",
+      "startLine": 199,
+      "endLine": 208,
+      "summary": "A worked instance: ν₂ of multinomial ![1,3] with the two carries of 1 + 3 = 4 in base 2, matching the digit-sum bookkeeping S₂(1) + S₂(3) = 3 vs S₂(4) = 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "Legendre's formula extends cleanly from a single factorial to arbitrary multinomial coefficients: the p-adic valuation is additive over the defining product, and in digit-sum form it becomes Kummer's theorem — the valuation counts base-p carries. The formalization is fully verified (0 sorries, 0 axioms beyond Mathlib's foundations, no native_decide).",
+    "implications": "The additive valuation law and the Kummer digit-sum identity give exact prime-power content of any multinomial coefficient, which underlies algorithms for computing multinomials modulo prime powers and for testing p-divisibility purely from base-p digit expansions. The non-divisibility criterion is the multinomial generalization of Kummer's classical carry count, and the binomial corollary shows the parent's Legendre result is a strict special case.",
+    "openQuestions": [
+      "Can the carry interpretation be made literal in Lean — proving (p−1)·ν_p(multinomial) = (number of base-p carries when summing the fᵢ) · (p−1) with an explicit carry-counting function?",
+      "Does the additive valuation law extend to a Lucas-style congruence for multinomial coefficients modulo p?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "wilsons-theorem-oq-03",
+      "relationship": "parent",
+      "description": "Legendre's formula for a single factorial — this entry answers its open question by generalizing to multinomial coefficients"
+    },
+    {
+      "targetId": "wilsons-theorem",
+      "relationship": "ancestor",
+      "description": "Wilson's theorem — the ν_p((p−1)!) = 0 special case of Legendre that motivates the whole chain"
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "related",
+      "description": "Binomial coefficients — the two-term specialization here is exactly Kummer's carry count for C(a+b, a)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "WilsonsTheoremMultinomialLegendre",
+    "lineCount": 208,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/WilsonsTheoremOQ03OQ01.lean"
+  },
+  "references": [
+    {
+      "authors": "A.-M. Legendre",
+      "title": "Essai sur la théorie des nombres",
+      "year": 1808,
+      "note": "Legendre's formula for the p-adic valuation ν_p(n!) = (n − S_p(n))/(p−1)."
+    },
+    {
+      "authors": "E. E. Kummer",
+      "title": "Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen",
+      "year": 1852,
+      "venue": "Journal für die reine und angewandte Mathematik",
+      "note": "Kummer's theorem: ν_p(C(m+n,m)) equals the number of carries when adding m and n in base p."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.multinomial, padicValNat, sub_one_mul_padicValNat_factorial, and Nat.digit_sum_le used throughout."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question posed by **wilsons-theorem-oq-03** ("Legendre's Formula: p-adic Valuation of n!"):

> *Can Legendre's formula be generalized to multinomial coefficients n!/(n₁!·n₂!···n_k!)?*

Yes — and doing so formalizes **Kummer's theorem** for multinomial coefficients: the p-adic valuation counts the base-p carries incurred when summing the parts.

Let `p` be prime, `s` finite, `f : α → ℕ`, and `N = ∑ i ∈ s, f i`.

- `padicValNat_prod_factorial` — ν_p is additive over a product of factorials
- `legendre_add` — subtraction-free Legendre `(p−1)·ν_p(m!) + S_p(m) = m`
- `padicValNat_factorial_sum_eq` / `padicValNat_multinomial` — **multinomial Legendre**: `ν_p(N!) = ν_p(multinomial) + ∑ ν_p((f i)!)`, i.e. `ν_p(multinomial) = ν_p(N!) − ∑ ν_p((f i)!)`
- `sub_one_mul_padicValNat_multinomial` — **Kummer (digit-sum form)**: `(p−1)·ν_p(multinomial) + S_p(N) = ∑ S_p(f i)`
- `prime_not_dvd_multinomial_iff` — **Kummer criterion**: `p ∤ multinomial ↔ ∑ S_p(f i) = S_p(N)` (no base-p carries)
- `sub_one_mul_padicValNat_multinomial_two` — classical binomial specialization for `C(a+b, a)`

## Verification

- **0 sorries, 0 axioms** — `#print axioms` on the main results lists only `propext`, `Classical.choice`, `Quot.sound`. No `axiom` declarations, no structure-encoded hypotheses, **no `native_decide`** (hence no `Lean.ofReduceBool`).
- 7 theorems / 208 lines.
- Typechecked with `lake env lean` against the repo Mathlib cache.

Rests only on Mathlib's `Nat.multinomial_spec`, `padicValNat.mul`, `sub_one_mul_padicValNat_factorial`, and `Nat.digit_sum_le`.

## Files
- `proofs/Proofs/WilsonsTheoremOQ03OQ01.lean`
- `src/data/proofs/wilsons-theorem-oq-03-oq-01/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)