### PR TITLE
research(combinations-formula-oq-04-oq-01): ultra-log-concavity — exact log-concavity defect governed by n+1 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ04OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ04OQ01.lean
@@ -1,0 +1,215 @@
+import Mathlib
+
+/-
+# Combinations Formula — OQ-04-OQ-01: Ultra-Log-Concavity of a Pascal Row
+
+## Research Problem: combinations-formula-oq-04-oq-01
+
+The parent (`combinations-formula-oq-04`) proves the *bare* log-concavity inequality for a
+Pascal row,
+
+      C(n,k) · C(n,k+2)  ≤  C(n,k+1)² ,
+
+by cancelling the common positive factor in the product of the two adjacent-ratio relations
+(Mathlib's `Nat.choose_succ_right_eq`).  This open question asks to **strengthen the inequality
+to an exact quantitative statement**: how large is the log-concavity gap
+`C(n,k+1)² − C(n,k)·C(n,k+2)`?
+
+Substituting `n = k + 2 + t` and writing `a = C(n,k)`, `b = C(n,k+1)`, `c = C(n,k+2)`, the
+parent's mechanism gives the exact product identity
+
+      a · c · (t+2)(k+2)  =  b² · (k+1)(t+1).                              (★)
+
+The parent throws away all information except the *sign* of the difference
+`(t+2)(k+2) − (k+1)(t+1)`.  But that difference is not merely positive — it is **exactly**
+
+      (t+2)(k+2) − (k+1)(t+1)  =  t + k + 3  =  n + 1 .
+
+Feeding this back into (★) turns the inequality into the sharp identity
+
+      ( b² − a·c ) · (k+1)(n−k−1)  =  (n+1) · a·c ,
+
+i.e. the log-concavity defect is governed *exactly* by `n + 1`.  Equivalently, over `ℚ`,
+
+      b² / (a·c)  =  1  +  (n+1) / ((k+1)(n−k−1))  >  1 ,
+
+which is precisely the ultra-log-concavity excess factor: the Pascal row is not just
+log-concave, its consecutive-ratio deviation from a geometric sequence is the explicit rational
+`1 + (n+1)/((k+1)(n−k−1))`.  This strictly strengthens the parent (the parent's `≤`, and the
+strict interior `<`, both drop out of the identity immediately).
+
+## What is proved
+
+* `choose_adjacent_ratio_prod` — the subtraction-free product identity (★) in `n, k`.
+* `choose_logConcavity_defect` — the **exact defect identity** (additive, subtraction-free):
+  `C(n,k+1)² · (k+1)(n−k−1) = C(n,k)·C(n,k+2) · ((k+1)(n−k−1) + (n+1))`.
+* `choose_logConcavity_gap` — the same in gap form:
+  `(C(n,k+1)² − C(n,k)·C(n,k+2)) · (k+1)(n−k−1) = (n+1) · C(n,k)·C(n,k+2)`.
+* `choose_logConcave_le` / `choose_logConcave_lt` — the parent inequality and its strict
+  interior form, both recovered from the identity.
+* `choose_ratio_rat` — the rational ultra-log-concavity excess:
+  `(C(n,k+1):ℚ)² / (C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1))`.
+
+Tags: combinatorics, binomial-coefficients, pascals-triangle, log-concavity, ultra-log-concave,
+newton-inequality
+-/
+
+namespace CombinationsFormulaOQ04OQ01
+
+open Nat
+
+/-- **Adjacent-ratio product identity (★).**  Writing `n = k + 2 + t`, the two relations from
+    `Nat.choose_succ_right_eq` combine into the subtraction-free identity
+    `C(n,k)·C(n,k+2)·(t+2)(k+2) = C(n,k+1)²·(k+1)(t+1)`.  This is the exact form behind the
+    parent's log-concavity inequality. -/
+theorem choose_adjacent_ratio_prod (k t : ℕ) :
+    (k + 2 + t).choose k * (k + 2 + t).choose (k + 2) * ((t + 2) * (k + 2))
+      = ((k + 2 + t).choose (k + 1)) ^ 2 * ((k + 1) * (t + 1)) := by
+  have R1 : (k + 2 + t).choose (k + 1) * (k + 1) = (k + 2 + t).choose k * (t + 2) := by
+    have := Nat.choose_succ_right_eq (k + 2 + t) k
+    simpa [show (k + 2 + t) - k = t + 2 by omega] using this
+  have R2 : (k + 2 + t).choose (k + 2) * (k + 2) = (k + 2 + t).choose (k + 1) * (t + 1) := by
+    have := Nat.choose_succ_right_eq (k + 2 + t) (k + 1)
+    simpa [show (k + 2 + t) - (k + 1) = t + 1 by omega] using this
+  set a := (k + 2 + t).choose k
+  set b := (k + 2 + t).choose (k + 1)
+  set c := (k + 2 + t).choose (k + 2)
+  have e1 : a * (t + 2) = b * (k + 1) := R1.symm
+  have e2 : c * (k + 2) = b * (t + 1) := R2
+  have step : a * c * ((t + 2) * (k + 2)) = (a * (t + 2)) * (c * (k + 2)) := by ring
+  rw [step, e1, e2]; ring
+
+/-- **Exact log-concavity defect identity (additive, subtraction-free).**  For `k + 2 ≤ n`,
+
+      C(n,k+1)² · (k+1)(n−k−1)  =  C(n,k)·C(n,k+2) · ( (k+1)(n−k−1) + (n+1) ).
+
+The multiplier `(k+1)(n−k−1) + (n+1)` on the right *exceeds* the multiplier `(k+1)(n−k−1)` on the
+left by exactly `n+1`; that surplus is the quantitative content the parent's inequality
+discards. -/
+theorem choose_logConcavity_defect (n k : ℕ) (h : k + 2 ≤ n) :
+    (n.choose (k + 1)) ^ 2 * ((k + 1) * (n - k - 1))
+      = n.choose k * n.choose (k + 2) * ((k + 1) * (n - k - 1) + (n + 1)) := by
+  obtain ⟨t, rfl⟩ : ∃ t, n = k + 2 + t := ⟨n - (k + 2), by omega⟩
+  have key := choose_adjacent_ratio_prod k t
+  -- `n - k - 1 = t + 1` and `(t+2)(k+2) = (k+1)(t+1) + (n+1)` (subtraction-free after rewrite)
+  have hnk : (k + 2 + t) - k - 1 = t + 1 := by omega
+  rw [hnk]
+  have expand : (t + 2) * (k + 2) = (k + 1) * (t + 1) + ((k + 2 + t) + 1) := by ring
+  -- rewrite (★) using the split of (t+2)(k+2)
+  calc (k + 2 + t).choose (k + 1) ^ 2 * ((k + 1) * (t + 1))
+        = (k + 2 + t).choose k * (k + 2 + t).choose (k + 2) * ((t + 2) * (k + 2)) := key.symm
+    _ = (k + 2 + t).choose k * (k + 2 + t).choose (k + 2)
+          * ((k + 1) * (t + 1) + ((k + 2 + t) + 1)) := by rw [expand]
+
+/-- **Log-concavity gap identity.**  The gap form of the defect identity: for `k + 2 ≤ n`,
+
+      ( C(n,k+1)² − C(n,k)·C(n,k+2) ) · (k+1)(n−k−1)  =  (n+1) · C(n,k)·C(n,k+2).
+
+Here the truncated subtraction `C(n,k+1)² − C(n,k)·C(n,k+2)` is exact (the subtrahend is the
+smaller by log-concavity), and the identity shows the defect is a fixed `(n+1)`-multiple of the
+outer product, scaled down by `(k+1)(n−k−1)`. -/
+theorem choose_logConcavity_gap (n k : ℕ) (h : k + 2 ≤ n) :
+    ((n.choose (k + 1)) ^ 2 - n.choose k * n.choose (k + 2)) * ((k + 1) * (n - k - 1))
+      = (n + 1) * (n.choose k * n.choose (k + 2)) := by
+  have hd := choose_logConcavity_defect n k h
+  -- from  b²·M = ac·(M + (n+1))  with M = (k+1)(n-k-1), derive (b² - ac)·M = (n+1)·ac
+  set M := (k + 1) * (n - k - 1)
+  set A := n.choose k * n.choose (k + 2)
+  set B := (n.choose (k + 1)) ^ 2
+  -- hd : B * M = A * (M + (n + 1))
+  have hBM : B * M = A * M + A * (n + 1) := by rw [hd]; ring
+  rw [Nat.sub_mul, hBM, Nat.add_sub_cancel_left]
+  ring
+
+/-- **Parent inequality, recovered.**  `C(n,k)·C(n,k+2) ≤ C(n,k+1)²` for all `n, k`
+    (the log-concavity of a Pascal row), obtained from the exact defect identity in the
+    interior and trivially outside it. -/
+theorem choose_logConcave_le (n k : ℕ) :
+    n.choose k * n.choose (k + 2) ≤ (n.choose (k + 1)) ^ 2 := by
+  rcases lt_or_ge n (k + 2) with h | h
+  · rw [Nat.choose_eq_zero_of_lt h]; simp
+  · have hd := choose_logConcavity_defect n k h
+    have hMpos : 0 < (k + 1) * (n - k - 1) := by
+      have : 0 < n - k - 1 := by omega
+      positivity
+    nlinarith [Nat.zero_le (n.choose k * n.choose (k + 2)), Nat.zero_le (n + 1)]
+
+/-- **Strict log-concavity in the interior.**  For `k + 2 ≤ n` the inequality is strict:
+    `C(n,k)·C(n,k+2) < C(n,k+1)²`.  The exact defect identity makes this immediate — the surplus
+    `(n+1)·C(n,k)·C(n,k+2)` is strictly positive since `C(n,k), C(n,k+2) > 0` in the interior. -/
+theorem choose_logConcave_lt (n k : ℕ) (h : k + 2 ≤ n) :
+    n.choose k * n.choose (k + 2) < (n.choose (k + 1)) ^ 2 := by
+  have hd := choose_logConcavity_defect n k h
+  have hMpos : 0 < (k + 1) * (n - k - 1) := by
+    have : 0 < n - k - 1 := by omega
+    positivity
+  have hApos : 0 < n.choose k * n.choose (k + 2) :=
+    Nat.mul_pos (Nat.choose_pos (by omega)) (Nat.choose_pos (by omega))
+  nlinarith [hApos, hMpos]
+
+/-- **Centered restatement.**  Rewriting `k = j − 1`, the exact defect identity holds at the
+    interior index `j` (`1 ≤ j`, `j + 1 ≤ n`):
+
+      C(n,j)² · j(n−j)  =  C(n,j−1)·C(n,j+1) · ( j(n−j) + (n+1) ). -/
+theorem choose_logConcavity_defect' (n j : ℕ) (hj : 1 ≤ j) (h : j + 1 ≤ n) :
+    (n.choose j) ^ 2 * (j * (n - j))
+      = n.choose (j - 1) * n.choose (j + 1) * (j * (n - j) + (n + 1)) := by
+  obtain ⟨k, rfl⟩ : ∃ k, j = k + 1 := ⟨j - 1, by omega⟩
+  have hd := choose_logConcavity_defect n k (by omega)
+  have h1 : k + 1 - 1 = k := by omega
+  have h2 : n - (k + 1) = n - k - 1 := by omega
+  rw [h1, h2]
+  exact hd
+
+/-- **Rational ultra-log-concavity excess.**  For `k + 2 ≤ n`, the exact consecutive-square
+    ratio is
+
+      C(n,k+1)² / ( C(n,k)·C(n,k+2) )  =  1  +  (n+1) / ( (k+1)(n−k−1) )  >  1 .
+
+The explicit excess `(n+1)/((k+1)(n−k−1))` over the geometric value `1` is what makes the row
+*ultra*-log-concave, not merely log-concave. -/
+theorem choose_ratio_rat (n k : ℕ) (h : k + 2 ≤ n) :
+    ((n.choose (k + 1) : ℚ)) ^ 2 / (n.choose k * n.choose (k + 2))
+      = 1 + (n + 1) / ((k + 1) * (n - k - 1) : ℕ) := by
+  obtain ⟨t, rfl⟩ : ∃ t, n = k + 2 + t := ⟨n - (k + 2), by omega⟩
+  have hnk : (k + 2 + t) - k - 1 = t + 1 := by omega
+  rw [hnk]
+  have key := choose_adjacent_ratio_prod k t
+  have hac : 0 < (k + 2 + t).choose k * (k + 2 + t).choose (k + 2) :=
+    Nat.mul_pos (Nat.choose_pos (by omega)) (Nat.choose_pos (by omega))
+  have hkt : 0 < (k + 1) * (t + 1) := by positivity
+  have hacQ : ((k + 2 + t).choose k : ℚ) * (k + 2 + t).choose (k + 2) ≠ 0 := by
+    exact_mod_cast hac.ne'
+  have hktQ : (((k + 1) * (t + 1) : ℕ) : ℚ) ≠ 0 := by exact_mod_cast hkt.ne'
+  have keyQ : ((k + 2 + t).choose k : ℚ) * (k + 2 + t).choose (k + 2) * ((t + 2) * (k + 2))
+      = ((k + 2 + t).choose (k + 1) : ℚ) ^ 2 * ((k + 1) * (t + 1)) := by exact_mod_cast key
+  have hRHS : (1 : ℚ) + ((k + 2 + t : ℕ) + 1) / ((k + 1) * (t + 1) : ℕ)
+      = (((k + 1) * (t + 1) : ℕ) + ((k + 2 + t : ℕ) + 1)) / ((k + 1) * (t + 1) : ℕ) := by
+    rw [eq_div_iff hktQ, add_mul, one_mul, div_mul_cancel₀ _ hktQ]
+  rw [hRHS, div_eq_div_iff hacQ hktQ]
+  push_cast
+  push_cast at keyQ
+  linear_combination -keyQ
+
+#check @choose_adjacent_ratio_prod
+#check @choose_logConcavity_defect
+#check @choose_logConcavity_gap
+#check @choose_logConcave_le
+#check @choose_logConcave_lt
+#check @choose_logConcavity_defect'
+#check @choose_ratio_rat
+
+/-
+## Summary
+
+The parent proves the Pascal row is log-concave.  This entry upgrades that qualitative
+inequality to the **exact** defect identity
+
+      ( C(n,k+1)² − C(n,k)·C(n,k+2) ) · (k+1)(n−k−1)  =  (n+1) · C(n,k)·C(n,k+2),
+
+equivalently the rational ratio `C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1))`.  Both
+the parent's `≤` and its strict interior `<` fall out as one-line corollaries.  The whole file
+rests only on Mathlib's `Nat.choose_succ_right_eq`; no new axioms.
+-/
+
+end CombinationsFormulaOQ04OQ01

--- a/src/data/proofs/combinations-formula-oq-04-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-04-oq-01/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "combinations-formula-oq-04-oq-01",
+  "title": "Ultra-Log-Concavity of a Pascal Row",
+  "slug": "combinations-formula-oq-04-oq-01",
+  "description": "Sharpens the parent's log-concavity inequality C(n,k)·C(n,k+2) ≤ C(n,k+1)² to an exact quantitative identity: the log-concavity defect is governed precisely by n+1, namely (C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2), equivalently the consecutive-square ratio C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)) > 1. Both the parent's ≤ and its strict interior < drop out as one-line corollaries. Formalized in Lean 4 over Mathlib's Nat.choose, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ04OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "pascals-triangle",
+      "log-concavity",
+      "ultra-log-concave",
+      "newton-inequality",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 215,
+    "assumptions": "None. Fully machine-verified: `lake env lean` builds Proofs/CombinationsFormulaOQ04OQ01.lean to exit 0 against the pinned Mathlib (v4.26.0). The proof uses only Nat.choose lemmas, ring/omega/positivity/field_simp/linear_combination — no native_decide, so no Lean.ofReduceBool and no sorryAx; #print axioms would report only the foundational propext / Classical.choice / Quot.sound. The file imports only Mathlib and is self-contained, building on Mathlib's Nat.choose_succ_right_eq adjacent-ratio relation.",
+    "dateAdded": "2026-07-01",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "C(n,k+1)·(k+1) = C(n,k)·(n−k), the adjacent-coefficient ratio relation. Applied at k and k+1 (after substituting n = k+2+t to clear truncated subtraction) it gives the two relations that multiply to the exact product identity a·c·(t+2)(k+2) = b²·(k+1)(t+1).",
+        "module": "Mathlib.Combinatorics.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_pos",
+        "description": "C(n,k) > 0 for k ≤ n — supplies positivity of the outer product C(n,k)·C(n,k+2) in the interior, needed for the strict inequality and to clear the ℚ denominator in the ratio form.",
+        "module": "Mathlib.Combinatorics.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_eq_zero_of_lt",
+        "description": "C(n,k) = 0 for n < k — discharges the trivial out-of-row branch of the recovered parent inequality.",
+        "module": "Mathlib.Combinatorics.Choose.Basic"
+      },
+      {
+        "theorem": "div_eq_div_iff",
+        "description": "cross-multiplication a/b = c/d ↔ a·d = c·b over ℚ — turns the rational ratio statement into the polynomial identity that linear_combination closes against the cast Nat identity.",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "choose_logConcavity_defect: the exact, subtraction-free log-concavity defect identity C(n,k+1)²·(k+1)(n−k−1) = C(n,k)·C(n,k+2)·((k+1)(n−k−1) + (n+1)) for k+2 ≤ n — the parent throws away everything except the sign of the surplus multiplier; this records that the surplus is exactly n+1",
+      "choose_logConcavity_gap: the gap form (C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2), exhibiting the log-concavity gap as a fixed (n+1)-multiple of the outer product",
+      "choose_ratio_rat: the rational ultra-log-concavity excess C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)) > 1 — the explicit deviation from a geometric sequence that makes the row ultra-log-concave, not merely log-concave",
+      "choose_logConcave_le and choose_logConcave_lt: the parent's inequality and its strict interior form both recovered as immediate corollaries of the defect identity, confirming this is a strict strengthening",
+      "choose_adjacent_ratio_prod and choose_logConcavity_defect': the underlying subtraction-free product identity (★) and the centered restatement at index j"
+    ],
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry proves the qualitative fact that each Pascal row is log-concave — C(n,k)·C(n,k+2) ≤ C(n,k+1)² — the binomial case of Newton's inequalities. Its listed open question asks to strengthen this to ultra-log-concavity. Ultra-log-concavity is the sharper phenomenon that a sequence's consecutive-square ratio dominates the geometric value 1 by an explicit, index-dependent factor; for the binomial row that factor turns out to be an exact rational governed by a single parameter, n+1.",
+    "problemStatement": "Quantify the log-concavity gap of a Pascal row: give an exact closed form for C(n,k+1)² − C(n,k)·C(n,k+2), and exhibit the ultra-log-concavity excess of the consecutive-square ratio.",
+    "text": "The parent's mechanism already yields the exact product identity a·c·(t+2)(k+2) = b²·(k+1)(t+1) with a = C(n,k), b = C(n,k+1), c = C(n,k+2) and n = k+2+t. The parent then discards everything but the sign of (t+2)(k+2) − (k+1)(t+1). That difference, however, is exactly t+k+3 = n+1. Feeding this back turns the inequality into the identity (b² − a·c)·(k+1)(n−k−1) = (n+1)·a·c, equivalently b²/(a·c) = 1 + (n+1)/((k+1)(n−k−1)). The parent's ≤, and its strict interior <, are one-line consequences.",
+    "proofStrategy": "Work in ℕ and never divide until the final rational restatement. The subtraction-free product identity choose_adjacent_ratio_prod repackages the parent's mechanism: substitute n = k+2+t, apply Nat.choose_succ_right_eq at k and k+1, and multiply. To get the defect identity, split the factor (t+2)(k+2) = (k+1)(t+1) + (n+1) — a pure ring identity in k,t — and rewrite. The gap form follows by Nat.sub_mul and Nat.add_sub_cancel_left. The parent inequality and its strict form are then nlinarith one-liners against the defect identity (positivity of the outer product supplies strictness). The rational ratio is obtained by casting the defect identity to ℚ, clearing the two positive denominators with div_eq_div_iff, and closing with linear_combination.",
+    "keyInsights": [
+      "**The parent kept only a sign; the defect is an exact value.** Log-concavity comes from (t+2)(k+2) > (k+1)(t+1). That difference is not just positive — it equals t+k+3 = n+1 identically, so the log-concavity gap has a closed form rather than a mere bound.",
+      "**One ring split upgrades the inequality to an identity.** Rewriting (t+2)(k+2) = (k+1)(t+1) + (n+1) inside the parent's product identity a·c·(t+2)(k+2) = b²·(k+1)(t+1) immediately gives b²·M = a·c·(M + (n+1)) with M = (k+1)(n−k−1); the parent's ≤ is now visibly the (n+1)·a·c ≥ 0 surplus.",
+      "**Ultra-log-concavity is the explicit ratio excess.** Over ℚ the statement becomes C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)): the consecutive-square ratio exceeds the geometric value 1 by the concrete positive rational (n+1)/((k+1)(n−k−1)). That explicit excess is exactly what 'ultra'-log-concave names.",
+      "**Strictness and the base inequality are free.** Because the surplus (n+1)·C(n,k)·C(n,k+2) is strictly positive in the interior, both the parent's ≤ and its strict < fall out of the single defect identity — the strengthening subsumes the original."
+    ],
+    "prerequisites": [
+      "Binomial coefficients and Mathlib's Nat.choose",
+      "The adjacent-coefficient ratio relation Nat.choose_succ_right_eq",
+      "Natural-number arithmetic and truncated subtraction; casting ℕ identities to ℚ",
+      "Log-concavity, ultra-log-concavity, and Newton's inequalities (conceptual background)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "product-identity",
+      "title": "Adjacent-Ratio Product Identity",
+      "summary": "choose_adjacent_ratio_prod: the subtraction-free identity C(n,k)·C(n,k+2)·(t+2)(k+2) = C(n,k+1)²·(k+1)(t+1) with n = k+2+t, from two applications of Nat.choose_succ_right_eq. This is the exact form behind the parent's log-concavity inequality.",
+      "startLine": 65,
+      "endLine": 87
+    },
+    {
+      "id": "defect",
+      "title": "Exact Log-Concavity Defect",
+      "summary": "choose_logConcavity_defect: C(n,k+1)²·(k+1)(n−k−1) = C(n,k)·C(n,k+2)·((k+1)(n−k−1) + (n+1)) for k+2 ≤ n. The surplus multiplier on the right exceeds the left by exactly n+1 — the quantitative content the parent's inequality discards.",
+      "startLine": 89,
+      "endLine": 109
+    },
+    {
+      "id": "gap",
+      "title": "Gap Form",
+      "summary": "choose_logConcavity_gap: (C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2), the log-concavity gap as a fixed (n+1)-multiple of the outer product.",
+      "startLine": 111,
+      "endLine": 125
+    },
+    {
+      "id": "corollaries",
+      "title": "Recovered Inequalities",
+      "summary": "choose_logConcave_le and choose_logConcave_lt: the parent's inequality C(n,k)·C(n,k+2) ≤ C(n,k+1)² and its strict interior form, both immediate from the defect identity — confirming the strengthening subsumes the original.",
+      "startLine": 127,
+      "endLine": 152
+    },
+    {
+      "id": "centered-and-ratio",
+      "title": "Centered Form and Rational Excess",
+      "summary": "choose_logConcavity_defect' (the identity at a centered index j) and choose_ratio_rat: C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)) over ℚ, the explicit ultra-log-concavity excess over the geometric value 1.",
+      "startLine": 154,
+      "endLine": 213
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; imports only Mathlib): the log-concavity gap of a Pascal row is exact, (C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2), equivalently the ratio C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)). The parent's ≤ and strict < are corollaries.",
+    "implications": "Answers the parent's open question by promoting qualitative log-concavity to an exact quantitative identity — the ultra-log-concavity excess of the binomial row is the explicit rational (n+1)/((k+1)(n−k−1)). This is the sharp form of the binomial case of Newton's inequalities and pins down precisely how far a Pascal row is from a geometric sequence.",
+    "openQuestions": [
+      "Extend the exact defect identity to the r-fold spacing C(n,k)·C(n,k+2r) vs C(n,k+r)², computing the analogous surplus polynomial.",
+      "Derive strict unimodality and the interlacing/real-rootedness of the row polynomial from the explicit ratio, comparing with Mathlib's Nat.choose_le_middle.",
+      "Formulate ultra-log-concavity for general binomial-type sequences (e.g. Gaussian binomial coefficients) and identify the analogue of the n+1 surplus."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-04",
+      "relationship": "parent-problem",
+      "description": "Parent: the bare log-concavity inequality C(n,k)·C(n,k+2) ≤ C(n,k+1)². This entry answers its open question by making the log-concavity gap exact (ultra-log-concavity)."
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "related",
+      "description": "Root of the combinations-formula family: the basic count C(n,k) = n!/(k!(n−k)!)."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Richard P. Stanley"
+      ],
+      "title": "Log-concave and unimodal sequences in algebra, combinatorics, and geometry",
+      "year": "1989",
+      "venue": "Annals of the New York Academy of Sciences 576, 500-535",
+      "note": "Survey of log-concavity and ultra-log-concavity; the binomial row is the prototypical example"
+    },
+    {
+      "authors": [
+        "June Huh"
+      ],
+      "title": "Combinatorial applications of the Hodge–Riemann relations",
+      "year": "2018",
+      "venue": "Proceedings of the ICM 2018, Vol. IV, 3093-3111",
+      "note": "Modern context for log-concavity and ultra-log-concavity of combinatorial sequences"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "CombinationsFormulaOQ04OQ01",
+    "lineCount": 215,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/CombinationsFormulaOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of the parent entry `combinations-formula-oq-04` ("Strengthen to ultra-log-concavity"). The parent proves the bare log-concavity inequality `C(n,k)·C(n,k+2) ≤ C(n,k+1)²`; this entry upgrades it to the **exact** quantitative identity governing the log-concavity gap.

## The result

The parent's mechanism yields the product identity `a·c·(t+2)(k+2) = b²·(k+1)(t+1)` (with `a=C(n,k), b=C(n,k+1), c=C(n,k+2), n=k+2+t`) and then discards everything but the *sign* of `(t+2)(k+2) − (k+1)(t+1)`. But that difference is exactly `t+k+3 = n+1`. Feeding it back gives:

- **Exact defect identity** `choose_logConcavity_defect`:
  `C(n,k+1)²·(k+1)(n−k−1) = C(n,k)·C(n,k+2)·((k+1)(n−k−1) + (n+1))`
- **Gap form** `choose_logConcavity_gap`:
  `(C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2)`
- **Rational ultra-log-concavity excess** `choose_ratio_rat`:
  `C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)) > 1`
- Parent's `≤` (`choose_logConcave_le`) and strict `<` (`choose_logConcave_lt`) recovered as one-line corollaries — the strengthening subsumes the original.

7 theorems, 0 definitions, 215 lines.

## Verification

- `lake env lean Proofs/CombinationsFormulaOQ04OQ01.lean` → exit 0 against pinned Mathlib v4.26.0
- 0 sorries, 0 `axiom` declarations
- No `native_decide` — no `Lean.ofReduceBool`; only foundational `propext`/`Classical.choice`/`Quot.sound`. **Status: verified, 0-axiom.**
- Rests only on Mathlib's `Nat.choose_succ_right_eq`.

New gallery entry: `src/data/proofs/combinations-formula-oq-04-oq-01/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)