### PR TITLE
Enrich russell-1-plus-1-oq-02: annotate additive foundation + payoff examples (5→13)

### DIFF
--- a/src/data/proofs/russell-1-plus-1-oq-02/annotations.json
+++ b/src/data/proofs/russell-1-plus-1-oq-02/annotations.json
@@ -1,8 +1,79 @@
 [
   {
+    "id": "russcs-ann-06",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": {
+      "startLine": 51,
+      "endLine": 62
+    },
+    "type": "definition",
+    "title": "The Peano Naturals and the Numerals, Built From Nothing",
+    "content": "Everything begins with a two-constructor inductive type: `zero` and `succ`. No import, no ambient `Nat` — this `ℕ` is defined in the file. The numerals `one` through `four` are then literally iterated successors, so `two` is `succ (succ zero)` by definition. This is the payload behind the entry's namesake claim: `1 + 1 = 2` is ultimately the assertion that `succ zero + succ zero` reduces to `succ (succ zero)`, a statement about these constructors alone.",
+    "mathContext": "$0,\\; S(0),\\; S(S(0)),\\dots$ with $1 := S(0),\\ 2 := S(S(0)),\\ 3 := S(S(S(0))),\\ 4 := S(3)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "inductive types",
+      "Peano's axioms",
+      "successor function",
+      "Principia Mathematica"
+    ],
+    "prerequisites": [
+      "algebraic data types",
+      "the successor/zero presentation of ℕ"
+    ]
+  },
+  {
+    "id": "russcs-ann-07",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 73
+    },
+    "type": "definition",
+    "title": "Addition by Primitive Recursion — Two Rules That Hold by `rfl`",
+    "content": "Addition recurses on its *second* argument: `n + 0 = n` and `n + succ m = succ (n + m)`. Because the equation compiler turns this into the recursor of `ℕ`, both defining equations `add_zero` and `add_succ` are true by `rfl` — they are computation rules, not proved theorems. This right-handed recursion is the single design decision that makes some later facts (`add_zero`) free while forcing others (`zero_add`) to be proved by induction.",
+    "mathContext": "$n + 0 = n, \\qquad n + S(m) = S(n + m).$ Both equations definitional.",
+    "significance": "key",
+    "relatedConcepts": [
+      "primitive recursion",
+      "the recursor ℕ.rec",
+      "iota-reduction",
+      "definitional equality"
+    ],
+    "prerequisites": [
+      "recursion on the second argument",
+      "`rfl` as computation"
+    ]
+  },
+  {
+    "id": "russcs-ann-08",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": {
+      "startLine": 75,
+      "endLine": 93
+    },
+    "type": "concept",
+    "title": "Making Addition Commutative and Associative by Induction",
+    "content": "The recursion gives `add_zero` for free but not `zero_add`; symmetric-looking facts must be earned. `zero_add` and `succ_add` are the two mirror lemmas that the right-recursive definition does not supply, and together they drive the induction for `add_comm`. `add_assoc` then follows by a single induction on the last summand. This block is exactly the additive theory the parent entry stops at — and it certifies `1 + 1 = 2` as a corollary of a genuine commutative monoid, not a lucky reduction.",
+    "mathContext": "$0 + n = n$, $S(n) + m = S(n + m)$, $n + m = m + n$, $(a+b)+c = a+(b+c)$ — each by structural induction.",
+    "significance": "key",
+    "relatedConcepts": [
+      "structural induction",
+      "commutative monoid",
+      "the mirror-lemma bootstrap"
+    ],
+    "prerequisites": [
+      "`add_zero`/`add_succ` as definitional rules",
+      "induction on ℕ"
+    ]
+  },
+  {
     "id": "russcs-ann-01",
     "proofId": "russell-1-plus-1-oq-02",
-    "range": { "startLine": 99, "endLine": 108 },
+    "range": {
+      "startLine": 99,
+      "endLine": 108
+    },
     "type": "concept",
     "title": "Peano's Recursive Multiplication — the Two Definitional Equations",
     "content": "Multiplication is defined by recursion on the second argument, exactly as Peano wrote it in 1889: `n * 0 = 0` and `n * (m+1) = n*m + n`. Because Lean's equation compiler elaborates this to the recursor of ℕ, both defining lemmas `mul_zero` and `mul_succ` hold by `rfl` — they are computation rules, not theorems. Everything algebraic that follows is the work of reconciling this single right-recursion with the symmetric facts (left-recursion, commutativity) that the definition does not give for free.",
@@ -20,9 +91,34 @@
     ]
   },
   {
+    "id": "russcs-ann-09",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": {
+      "startLine": 114,
+      "endLine": 119
+    },
+    "type": "insight",
+    "title": "`zero_mul`: Left Annihilation Is a Theorem, Not a Computation Rule",
+    "content": "Just as with addition, right-recursion makes `mul_zero` (`n * 0 = 0`) definitional but leaves `zero_mul` (`0 * n = 0`) to be proved. The induction is short — `0 * succ n = 0 * n + 0 = 0` using `mul_succ`, the inductive hypothesis, and `add_zero` — but its very existence records the asymmetry baked into the definition. Both annihilation laws are needed before the semiring bundle can be assembled.",
+    "mathContext": "$n \\cdot 0 = 0$ (definitional) versus $0 \\cdot n = 0$ (by induction on $n$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "the recursion asymmetry",
+      "annihilator element",
+      "semiring axioms"
+    ],
+    "prerequisites": [
+      "`mul_succ`",
+      "induction on the exposed argument"
+    ]
+  },
+  {
     "id": "russcs-ann-02",
     "proofId": "russell-1-plus-1-oq-02",
-    "range": { "startLine": 121, "endLine": 129 },
+    "range": {
+      "startLine": 121,
+      "endLine": 129
+    },
     "type": "proof-technique",
     "title": "succ_mul: the Crux Lemma that Unlocks Commutativity",
     "content": "The definition gives `mul_succ` (recursion on the right); its left-recursive mirror `(n+1)*m = n*m + m` is not definitional and must be proved by induction on `m`. The successor step is the one genuinely fiddly computation in the file: expanding both sides via `mul_succ` and the induction hypothesis leaves `succ (n*m + (m + n)) = succ (n*m + (n + m))`, closed by `add_comm m n` after two uses of `add_assoc` to line up the parenthesisation. Once `succ_mul` is available, `mul_comm` is a two-line induction — this lemma is precisely what the commutativity proof needs.",
@@ -39,9 +135,56 @@
     ]
   },
   {
+    "id": "russcs-ann-10",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": {
+      "startLine": 131,
+      "endLine": 135
+    },
+    "type": "concept",
+    "title": "The Multiplicative Unit: `mul_one` and `one_mul`",
+    "content": "With `one` defined as `succ zero`, both identity laws unfold mechanically: `n * one = n * succ zero = n * zero + n = 0 + n = n`, and symmetrically `one * n = n` via `succ_mul` and `zero_mul`. Neither needs its own induction — each is a chain of rewrites through the multiplicative rules already established. They are the multiplicative counterparts of `add_zero`/`zero_add`.",
+    "mathContext": "$n \\cdot 1 = n$ and $1 \\cdot n = n$, unfolding $1 = S(0)$ through `mul_succ`/`succ_mul`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicative identity",
+      "monoid unit",
+      "rewriting chains"
+    ],
+    "prerequisites": [
+      "`mul_succ`, `succ_mul`, `zero_mul`",
+      "`one := succ zero`"
+    ]
+  },
+  {
+    "id": "russcs-ann-11",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": {
+      "startLine": 141,
+      "endLine": 144
+    },
+    "type": "insight",
+    "title": "`mul_comm`: the Pivot That Buys Right Distributivity",
+    "content": "Commutativity of multiplication is proved by induction on `m`, with the successor step leaning on the left-recursive companion `succ_mul` to line up `mul_succ (n) (m)` against `succ_mul (m) (n)`. It is the load-bearing lemma of the multiplicative half: once `mul_comm` is available, right distributivity is obtained from left distributivity for free (`right_distrib` simply commutes the product and reuses `left_distrib`). Ordering matters — `succ_mul` before `mul_comm` before the distributive laws.",
+    "mathContext": "$n \\cdot m = m \\cdot n$ by induction, using $S(n)\\cdot m = n\\cdot m + m$ and $n \\cdot S(m) = n\\cdot m + n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "commutativity",
+      "bootstrapping order",
+      "transporting laws via symmetry"
+    ],
+    "prerequisites": [
+      "`succ_mul` and `mul_succ`",
+      "induction on the second factor"
+    ]
+  },
+  {
     "id": "russcs-ann-03",
     "proofId": "russell-1-plus-1-oq-02",
-    "range": { "startLine": 146, "endLine": 155 },
+    "range": {
+      "startLine": 146,
+      "endLine": 155
+    },
     "type": "proof-technique",
     "title": "Right Distributivity for Free from Left Distributivity",
     "content": "Left distributivity `a*(b+c) = a*b + a*c` is proved by a short induction on `c`. Right distributivity is then obtained without any new induction: `(a+b)*c = c*(a+b) = c*a + c*b = a*c + b*c`, three rewrites using `mul_comm` and the left version. This is a small but characteristic economy — once commutativity is in hand, one distributive law implies the other, so only one of the two needs an inductive proof.",
@@ -60,7 +203,10 @@
   {
     "id": "russcs-ann-04",
     "proofId": "russell-1-plus-1-oq-02",
-    "range": { "startLine": 157, "endLine": 160 },
+    "range": {
+      "startLine": 157,
+      "endLine": 160
+    },
     "type": "proof-technique",
     "title": "Associativity Spends Distributivity",
     "content": "`mul_assoc` is proved by induction on the last factor `c`. Its successor step is where distributivity is used: `(a*b)*(c+1) = (a*b)*c + a*b = a*(b*c) + a*b = a*(b*c + b) = a*(b*(c+1))`, folding the two summands back together with `left_distrib` (read right-to-left). This dependency — associativity resting on distributivity resting on commutativity resting on succ_mul — is the whole reason the lemmas appear in this order.",
@@ -77,9 +223,35 @@
     ]
   },
   {
+    "id": "russcs-ann-12",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": {
+      "startLine": 166,
+      "endLine": 183
+    },
+    "type": "definition",
+    "title": "Packaging the Axioms: a Self-Contained `IsCommSemiring` Predicate",
+    "content": "Rather than leave the result as a scattered list of lemmas, the axioms are bundled into a `Prop`-valued structure parameterised by a carrier and its `zero`, `one`, `add`, `mul`. Inhabiting this structure is a single proposition that means exactly \"these operations form a commutative semiring.\" Because it is defined here (not imported from Mathlib's `CommSemiring`), the file remains fully self-contained while still delivering a bundled, machine-checkable statement.",
+    "mathContext": "A record of the twelve semiring laws: associativity/commutativity/identity/annihilation for $+$ and $\\cdot$, plus both distributive laws.",
+    "significance": "key",
+    "relatedConcepts": [
+      "bundled structures",
+      "Prop-valued records",
+      "axiomatic algebra",
+      "Mathlib's CommSemiring (analogue)"
+    ],
+    "prerequisites": [
+      "structures as conjunctions of propositions",
+      "universally quantified fields"
+    ]
+  },
+  {
     "id": "russcs-ann-05",
     "proofId": "russell-1-plus-1-oq-02",
-    "range": { "startLine": 187, "endLine": 200 },
+    "range": {
+      "startLine": 187,
+      "endLine": 200
+    },
     "type": "concept",
     "title": "Bundling the Axioms: ℕ is a Commutative Semiring, as One Proposition",
     "content": "`IsCommSemiring` is a Prop-valued structure listing all twelve commutative-semiring axioms over an abstract carrier with its zero, one, add, and mul. `peano_isCommSemiring` fills every field with the lemma proved above, so the informal claim 'the from-scratch Peano naturals form a commutative semiring' becomes a single inhabited proposition with a closed proof term. This is the structural-theorem payoff over the parent's scattered arithmetic facts — and `#print axioms` confirms it depends on no axioms at all, not even Quot.sound.",
@@ -93,6 +265,28 @@
     "prerequisites": [
       "all preceding additive and multiplicative lemmas",
       "structures / records in Lean"
+    ]
+  },
+  {
+    "id": "russcs-ann-13",
+    "proofId": "russell-1-plus-1-oq-02",
+    "range": {
+      "startLine": 206,
+      "endLine": 216
+    },
+    "type": "insight",
+    "title": "The Payoff: `2 * 2 = 4` Holds by Pure Computation",
+    "content": "The concrete consequences close the loop. `two_mul_two_eq_four` is proved by `rfl` alone — numerals are closed successor terms, so the product simply reduces to `four`; no lemma is invoked. The other two examples instantiate the general theory on numerals: `distrib_example` is one `rw [left_distrib]`, and `comm_example` is one `rw [mul_comm]`. Together they demonstrate that the abstract semiring laws specialise, on the ground, to the arithmetic Russell set out to justify.",
+    "mathContext": "$2 \\cdot 2 = 4$ by `rfl`; $2\\cdot(1+2) = 2\\cdot1 + 2\\cdot2$ by `left_distrib`; $3\\cdot1 = 1\\cdot3$ by `mul_comm`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "definitional reduction",
+      "specialising general laws",
+      "concrete verification"
+    ],
+    "prerequisites": [
+      "`rfl` on closed numeral terms",
+      "`left_distrib`, `mul_comm`"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Coverage-gap enrichment of `russell-1-plus-1-oq-02` (Peano ℕ is a commutative semiring — the "1+1=2" from-scratch construction).

The 5 existing annotations covered only the **multiplicative half** (lines 99–200). The entire **additive foundation** (the inductive `ℕ`, the numerals, `add`, and the commutativity/associativity lemmas) and the **payoff examples** were unannotated — 19 of 27 declarations had no coverage.

## What changed

Adds **8 annotations** (5 → 13), each anchored to a previously-uncovered declaration:

| Lines | Covers |
|-------|--------|
| 51–62 | The Peano naturals `inductive ℕ` + numerals `one`–`four` |
| 64–73 | Addition by primitive recursion (`add`, `add_zero`, `add_succ`) |
| 75–93 | Additive laws: `zero_add`, `succ_add`, `add_comm`, `add_assoc` |
| 114–119 | `zero_mul` — left annihilation as a theorem, not a rule |
| 131–135 | The multiplicative unit `mul_one` / `one_mul` |
| 141–144 | `mul_comm` — the pivot that buys right distributivity |
| 166–183 | The `IsCommSemiring` bundling predicate |
| 206–216 | Concrete consequences: `two_mul_two_eq_four` (by `rfl`), `distrib_example`, `comm_example` |

Coverage now spans all 27 declarations. Each new annotation has `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`, matching the existing schema. No existing content was modified.

## Validation

`validateLineAnnotations` reports **13 valid, 0 misaligned** against `proofs/Proofs/OnePlusOneOQ02.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)