### PR TITLE
Enrich Jordan–von Neumann (law-of-cosines-oq-07-oq-01): add annotations.json

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-07-oq-01/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "law-of-cosines-oq-07-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 54
+    },
+    "type": "context",
+    "title": "Setup: From Necessity to a Full Characterisation",
+    "content": "The parent entry law-of-cosines-oq-07 derives the parallelogram law ‖x+y‖²+‖x−y‖²=2(‖x‖²+‖y‖²) from Apollonius's median identity, showing it is necessary for an inner-product norm. Its open question asks the converse — is the identity also sufficient? This file answers yes, the classical Fréchet–von Neumann–Jordan theorem (1935). The whole development is stated over an arbitrary RCLike field 𝕜 (so ℝ and ℂ at once) with E a normed 𝕜-space; note the norm-squared is written ‖x‖·‖x‖ rather than ‖x‖^2 to match Mathlib's parallelogram_law_with_norm verbatim and avoid a rewrite.",
+    "mathContext": "$\\|x+y\\|^2+\\|x-y\\|^2=2(\\|x\\|^2+\\|y\\|^2)$; characterise when a norm comes from an inner product.",
+    "significance": "context",
+    "relatedConcepts": ["parallelogram law", "Fréchet–von Neumann–Jordan theorem", "RCLike field", "normed space"],
+    "prerequisites": ["normed spaces over ℝ or ℂ", "the parent parallelogram law (law-of-cosines-oq-07)"]
+  },
+  {
+    "id": "ann-necessity",
+    "proofId": "law-of-cosines-oq-07-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 63
+    },
+    "type": "concept",
+    "title": "Necessity: Every Inner-Product Norm Obeys the Law",
+    "content": "parallelogram_of_innerProductSpace is the easy forward half: in any inner-product space the norm satisfies the parallelogram identity. It is a one-line restatement of Mathlib's parallelogram_law_with_norm 𝕜 — the same fact the parent derived geometrically from Apollonius's median theorem. The `omit [NormedSpace 𝕜 E]` clause drops the redundant section variable because the InnerProductSpace instance already supplies the module structure. This direction is the metric fingerprint half: having an inner product forces the identity.",
+    "mathContext": "$\\langle\\cdot,\\cdot\\rangle$ exists $\\implies \\|x+y\\|^2+\\|x-y\\|^2=2(\\|x\\|^2+\\|y\\|^2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["parallelogram_law_with_norm", "inner-product space", "Apollonius median identity", "polarisation identity"],
+    "prerequisites": ["inner-product spaces", "the norm induced by an inner product"]
+  },
+  {
+    "id": "ann-sufficiency",
+    "proofId": "law-of-cosines-oq-07-oq-01",
+    "range": {
+      "startLine": 65,
+      "endLine": 73
+    },
+    "type": "definition",
+    "title": "Sufficiency: Recovering the Inner Product by Polarisation",
+    "content": "innerProductSpaceOfParallelogram is the converse and the mathematical heart of the theorem: from a bare hypothesis that the norm satisfies the parallelogram law, it produces an explicit (noncomputable) InnerProductSpace structure. The inner product is defined from the norm by the polarisation identity, and the genuinely analytic work — proving the recovered form is additive, homogeneous, and positive-definite — is delegated to Mathlib's InnerProductSpace.ofNorm. Exposing it as a named def (not just an existence proof) lets a reader instantiate the concrete inner product a parallelogram norm hides.",
+    "mathContext": "Polarisation: $\\langle x,y\\rangle = \\tfrac14(\\|x+y\\|^2-\\|x-y\\|^2)$ over ℝ; bilinearity is what must be proved.",
+    "significance": "key",
+    "relatedConcepts": ["InnerProductSpace.ofNorm", "polarisation identity", "bilinearity", "positive-definiteness"],
+    "prerequisites": ["polarisation identity", "the parallelogram law", "Lean noncomputable definitions"]
+  },
+  {
+    "id": "ann-characterisation",
+    "proofId": "law-of-cosines-oq-07-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 88
+    },
+    "type": "insight",
+    "title": "The Headline Biconditional",
+    "content": "nonempty_innerProductSpace_iff_parallelogram is the two-sided characterisation: a normed 𝕜-space admits a compatible inner product iff its norm satisfies the parallelogram law. Crucially the statement mentions only the norm — the inner product is hidden behind Nonempty (InnerProductSpace 𝕜 E) and the InnerProductSpaceable typeclass never appears. The forward direction destructs the Nonempty instance (rintro ⟨inst⟩), installs it locally with letI, and applies parallelogram_law_with_norm; the backward direction packages the hypothesis as an InnerProductSpaceable instance (haveI) and invokes nonempty_innerProductSpace. This makes the parallelogram identity a complete invariant of inner-product norms.",
+    "mathContext": "$\\exists\\,\\langle\\cdot,\\cdot\\rangle \\iff \\forall x\\,y,\\ \\|x+y\\|^2+\\|x-y\\|^2=2(\\|x\\|^2+\\|y\\|^2)$.",
+    "significance": "key",
+    "relatedConcepts": ["nonempty_innerProductSpace", "InnerProductSpaceable", "Nonempty", "complete invariant", "letI / haveI"],
+    "prerequisites": ["Lean typeclass manipulation (letI, haveI)", "both prior directions", "existential phrasing via Nonempty"]
+  },
+  {
+    "id": "ann-exists",
+    "proofId": "law-of-cosines-oq-07-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 95
+    },
+    "type": "concept",
+    "title": "The Converse as a Bare Implication",
+    "content": "exists_inner_of_parallelogram restates just the backward implication of the biconditional: the parallelogram identity guarantees that some compatible inner product exists. It is the .2 projection of nonempty_innerProductSpace_iff_parallelogram applied to the hypothesis, offered for readers who want the sufficiency direction in isolation without the iff wrapper.",
+    "mathContext": "parallelogram law $\\implies \\exists\\,\\langle\\cdot,\\cdot\\rangle$ compatible with $\\|\\cdot\\|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["biconditional projection", "sufficiency direction", "Nonempty"],
+    "prerequisites": ["the headline biconditional", "extracting one direction of an iff"]
+  },
+  {
+    "id": "ann-euclidean",
+    "proofId": "law-of-cosines-oq-07-oq-01",
+    "range": {
+      "startLine": 97,
+      "endLine": 102
+    },
+    "type": "context",
+    "title": "Sanity Check on the Euclidean Plane",
+    "content": "A concrete example confirms the characterisation recognises the standard model EuclideanSpace ℝ (Fin 2): being an honest inner-product space it supplies a Nonempty (InnerProductSpace ℝ _) instance via inferInstance, and the forward direction (.1) then yields the parallelogram identity. This closes the loop — the abstract biconditional fires on the very space (the Euclidean plane) whose median geometry motivated the parent entry.",
+    "mathContext": "$\\mathbb{R}^2$ with the dot product satisfies $\\|x+y\\|^2+\\|x-y\\|^2=2(\\|x\\|^2+\\|y\\|^2)$.",
+    "significance": "technical",
+    "relatedConcepts": ["EuclideanSpace", "inferInstance", "concrete instantiation", "Euclidean plane"],
+    "prerequisites": ["EuclideanSpace ℝ (Fin 2)", "the forward direction of the characterisation"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass — `law-of-cosines-oq-07-oq-01`

The entry had **no annotations.json** (quality 41). This adds one with **6 annotations covering the full 104-line file**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

| id | lines | decl |
|----|-------|------|
| ann-overview | 1–54 | module docstring + RCLike/normed-space setup |
| ann-necessity | 56–63 | `parallelogram_of_innerProductSpace` (forward, easy half) |
| ann-sufficiency | 65–73 | `innerProductSpaceOfParallelogram` (converse via polarisation) |
| ann-characterisation | 75–88 | `nonempty_innerProductSpace_iff_parallelogram` (headline iff) |
| ann-exists | 90–95 | `exists_inner_of_parallelogram` (bare implication) |
| ann-euclidean | 97–102 | `EuclideanSpace ℝ (Fin 2)` sanity check |

Coverage spans lines 1–102 (only blank line 103 / `end` 104 uncovered). meta.json unchanged (already rich). No claims altered; status/badge/axiomCount left as-is (verified, 0 axioms).