### PR TITLE
Enrich prime-power deficiency (perfect-numbers-oq-05-oq-01): add annotation metadata

### DIFF
--- a/src/data/proofs/perfect-numbers-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/perfect-numbers-oq-05-oq-01/annotations.json
@@ -8,7 +8,19 @@
       "endLine": 63
     },
     "title": "Module Header: From the inequality to the exact gap",
-    "content": "The parent entry proves the **inequality** $\\sigma(p^k) < 2p^k$ — every prime power is deficient. Its first open question asks for the *exact size* of the deficiency\n$$\\text{deficiency}(n) := 2n - \\sigma(n).$$\nThis file computes it in closed form for every prime power:\n$$2p^k - \\sigma(p^k) = p^k - (1 + p + \\cdots + p^{k-1}) = p^k - \\frac{p^k - 1}{p - 1}.$$\nTwo sharp consequences: the gap is **always $\\ge 1$**, and for $p = 2$ it is **exactly $1$** for every $k$ — the powers of two are the *almost-perfect* numbers $\\sigma(2^k) = 2^{k+1} - 1$."
+    "content": "The parent entry proves the **inequality** $\\sigma(p^k) < 2p^k$ — every prime power is deficient. Its first open question asks for the *exact size* of the deficiency\n$$\\text{deficiency}(n) := 2n - \\sigma(n).$$\nThis file computes it in closed form for every prime power:\n$$2p^k - \\sigma(p^k) = p^k - (1 + p + \\cdots + p^{k-1}) = p^k - \\frac{p^k - 1}{p - 1}.$$\nTwo sharp consequences: the gap is **always $\\ge 1$**, and for $p = 2$ it is **exactly $1$** for every $k$ — the powers of two are the *almost-perfect* numbers $\\sigma(2^k) = 2^{k+1} - 1$.",
+    "mathContext": "$2p^k-\\sigma(p^k)=p^k-\\frac{p^k-1}{p-1}\\ge 1$, with the gap equal to $1$ exactly when $p=2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "deficiency 2n−σ(n)",
+      "prime power p^k",
+      "almost-perfect numbers",
+      "sum-of-divisors σ"
+    ],
+    "prerequisites": [
+      "the parent inequality σ(pᵏ)<2pᵏ",
+      "the sum-of-divisors function σ"
+    ]
   },
   {
     "id": "perfect-numbers-oq-05-oq-01-deficiency-def",
@@ -19,7 +31,19 @@
       "endLine": 73
     },
     "title": "The deficiency gap",
-    "content": "`deficiency n := 2 * n - sigma 1 n`, the amount by which the divisor sum falls short of $2n$. It is $0$ iff $n$ is perfect and positive iff $n$ is deficient — the quantity the open question asks to compute for prime powers."
+    "content": "`deficiency n := 2 * n - sigma 1 n`, the amount by which the divisor sum falls short of $2n$. It is $0$ iff $n$ is perfect and positive iff $n$ is deficient — the quantity the open question asks to compute for prime powers.",
+    "mathContext": "$\\operatorname{deficiency}(n)=2n-\\sigma(n)$; $=0\\iff n$ perfect, $>0\\iff n$ deficient.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "deficiency",
+      "perfect number",
+      "deficient vs abundant numbers",
+      "σ = sigma 1"
+    ],
+    "prerequisites": [
+      "sum-of-divisors σ",
+      "perfect / deficient numbers"
+    ]
   },
   {
     "id": "perfect-numbers-oq-05-oq-01-pred-mul-geomSum",
@@ -30,7 +54,19 @@
       "endLine": 104
     },
     "title": "Division-free meaning of (pᵏ − 1)/(p − 1)",
-    "content": "`pred_mul_geomSum_add_one`: for $p \\ge 1$,\n$$(p - 1)\\sum_{j<k} p^j + 1 = p^k.$$\nThis gives the truncated $\\mathbb{N}$-division $(p^k - 1)/(p - 1)$ a rigorous, side-condition-free meaning. Proved by induction on $k$: the base case is $p^0 = 1$, and the step factors $p^n\\,(1 + (p-1)) = p^n \\cdot p = p^{n+1}$, with `omega` closing the linear recombination."
+    "content": "`pred_mul_geomSum_add_one`: for $p \\ge 1$,\n$$(p - 1)\\sum_{j<k} p^j + 1 = p^k.$$\nThis gives the truncated $\\mathbb{N}$-division $(p^k - 1)/(p - 1)$ a rigorous, side-condition-free meaning. Proved by induction on $k$: the base case is $p^0 = 1$, and the step factors $p^n\\,(1 + (p-1)) = p^n \\cdot p = p^{n+1}$, with `omega` closing the linear recombination.",
+    "mathContext": "$(p-1)\\sum_{j<k}p^j+1=p^k$ for $p\\ge 1$ — a division-free form of $(p^k-1)/(p-1)$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "finite geometric series",
+      "induction on k",
+      "omega tactic",
+      "Nat truncated division"
+    ],
+    "prerequisites": [
+      "finite geometric sums",
+      "induction in Lean 4"
+    ]
   },
   {
     "id": "perfect-numbers-oq-05-oq-01-sigma-split",
@@ -41,7 +77,18 @@
       "endLine": 112
     },
     "title": "σ(pᵏ) as lower tail plus top term",
-    "content": "`sigma_prime_pow_split`: $\\sigma(p^k) = (1 + p + \\cdots + p^{k-1}) + p^k$, obtained by rewriting $\\sigma(p^k) = \\sum_{j \\le k} p^j$ (`sigma_one_apply_prime_pow`) and peeling the top term with `Finset.sum_range_succ`. This algebraic pivot feeds every deficiency statement below."
+    "content": "`sigma_prime_pow_split`: $\\sigma(p^k) = (1 + p + \\cdots + p^{k-1}) + p^k$, obtained by rewriting $\\sigma(p^k) = \\sum_{j \\le k} p^j$ (`sigma_one_apply_prime_pow`) and peeling the top term with `Finset.sum_range_succ`. This algebraic pivot feeds every deficiency statement below.",
+    "mathContext": "$\\sigma(p^k)=\\big(\\sum_{j<k}p^j\\big)+p^k=\\sum_{j\\le k}p^j$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "sigma_one_apply_prime_pow",
+      "Finset.sum_range_succ",
+      "geometric series"
+    ],
+    "prerequisites": [
+      "σ evaluated on prime powers",
+      "finite sums over Finset.range"
+    ]
   },
   {
     "id": "perfect-numbers-oq-05-oq-01-exact-gap",
@@ -52,7 +99,20 @@
       "endLine": 137
     },
     "title": "The exact deficiency and its closed form",
-    "content": "`deficiency_prime_pow_eq`: $2p^k - \\sigma(p^k) = p^k - \\sum_{j<k} p^j$ — the exact gap is the top term minus the geometric lower tail. Since the tail is $< p^k$ (`geomSum_lt_pow`, an instance of `Nat.geomSum_lt`), `omega` computes the $\\mathbb{N}$ subtraction directly. `deficiency_prime_pow_eq_div` then rewrites the tail with `Nat.geomSum_eq` into the open question's literal form $p^k - (p^k - 1)/(p - 1)$."
+    "content": "`deficiency_prime_pow_eq`: $2p^k - \\sigma(p^k) = p^k - \\sum_{j<k} p^j$ — the exact gap is the top term minus the geometric lower tail. Since the tail is $< p^k$ (`geomSum_lt_pow`, an instance of `Nat.geomSum_lt`), `omega` computes the $\\mathbb{N}$ subtraction directly. `deficiency_prime_pow_eq_div` then rewrites the tail with `Nat.geomSum_eq` into the open question's literal form $p^k - (p^k - 1)/(p - 1)$.",
+    "mathContext": "$2p^k-\\sigma(p^k)=p^k-\\sum_{j<k}p^j=p^k-\\frac{p^k-1}{p-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.geomSum_eq",
+      "geomSum_lt_pow",
+      "omega",
+      "closed-form deficiency"
+    ],
+    "prerequisites": [
+      "sigma_prime_pow_split",
+      "Nat truncated subtraction",
+      "geometric-sum closed form"
+    ]
   },
   {
     "id": "perfect-numbers-oq-05-oq-01-one-le",
@@ -63,7 +123,18 @@
       "endLine": 151
     },
     "title": "Deficient by at least 1",
-    "content": "`one_le_deficiency`: $1 \\le 2p^k - \\sigma(p^k)$ for every prime power. A quantitative refinement of the parent's strict inequality: not merely deficient, but deficient by a definite amount. The next theorem shows this bound is attained."
+    "content": "`one_le_deficiency`: $1 \\le 2p^k - \\sigma(p^k)$ for every prime power. A quantitative refinement of the parent's strict inequality: not merely deficient, but deficient by a definite amount. The next theorem shows this bound is attained.",
+    "mathContext": "$1\\le 2p^k-\\sigma(p^k)$ for every prime power $p^k$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "deficiency lower bound",
+      "refinement of a strict inequality",
+      "prime power"
+    ],
+    "prerequisites": [
+      "the exact deficiency formula",
+      "geomSum_lt_pow"
+    ]
   },
   {
     "id": "perfect-numbers-oq-05-oq-01-almost-perfect",
@@ -74,7 +145,19 @@
       "endLine": 170
     },
     "title": "Powers of two are almost perfect",
-    "content": "`deficiency_two_pow_eq_one`: $2 \\cdot 2^k - \\sigma(2^k) = 1$ for every $k$, equivalently $\\sigma(2^k) = 2^{k+1} - 1$. For $p = 2$ the lower tail collapses to $1 + 2 + \\cdots + 2^{k-1} = 2^k - 1$, one unit short of $2^k$, so the gap is exactly $1$ — the tightest possible deficiency, attaining `one_le_deficiency`. These are the classical *almost-perfect* numbers."
+    "content": "`deficiency_two_pow_eq_one`: $2 \\cdot 2^k - \\sigma(2^k) = 1$ for every $k$, equivalently $\\sigma(2^k) = 2^{k+1} - 1$. For $p = 2$ the lower tail collapses to $1 + 2 + \\cdots + 2^{k-1} = 2^k - 1$, one unit short of $2^k$, so the gap is exactly $1$ — the tightest possible deficiency, attaining `one_le_deficiency`. These are the classical *almost-perfect* numbers.",
+    "mathContext": "$2\\cdot 2^k-\\sigma(2^k)=1$, equivalently $\\sigma(2^k)=2^{k+1}-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "almost-perfect numbers",
+      "Mersenne number 2^{k+1}−1",
+      "σ(2ᵏ)",
+      "tightest deficiency"
+    ],
+    "prerequisites": [
+      "the exact deficiency formula",
+      "geometric sum at p=2"
+    ]
   },
   {
     "id": "perfect-numbers-oq-05-oq-01-concrete",
@@ -85,7 +168,18 @@
       "endLine": 183
     },
     "title": "Concrete gaps without native_decide",
-    "content": "`deficiency 8 = 1` (as $2^3$, an almost-perfect number, $\\sigma(8) = 15$) and `deficiency 9 = 5` (as $3^2$, $\\sigma(9) = 13 = 18 - 5$). Each is a substitution into the general theorem, kernel-checked with $0$ axioms rather than trusted to `native_decide`."
+    "content": "`deficiency 8 = 1` (as $2^3$, an almost-perfect number, $\\sigma(8) = 15$) and `deficiency 9 = 5` (as $3^2$, $\\sigma(9) = 13 = 18 - 5$). Each is a substitution into the general theorem, kernel-checked with $0$ axioms rather than trusted to `native_decide`.",
+    "mathContext": "$\\operatorname{deficiency}(8)=1\\ (\\sigma(8)=15)$, $\\operatorname{deficiency}(9)=5\\ (\\sigma(9)=13)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked examples",
+      "kernel-checked computation",
+      "avoiding native_decide"
+    ],
+    "prerequisites": [
+      "the general deficiency theorem",
+      "substituting concrete prime powers"
+    ]
   },
   {
     "id": "perfect-numbers-oq-05-oq-01-abundancy-geom",
@@ -96,7 +190,20 @@
       "endLine": 209
     },
     "title": "Abundancy index as a geometric partial sum",
-    "content": "`abundancy_eq_geom_sum`: over the reals, $\\sigma(p^k)/p^k = \\sum_{j\\le k} (1/p)^j$. The key step reflects the sum — $\\sigma(p^k)/p^k = \\sum_{j\\le k} p^j/p^k$ and each term $p^j/p^k = (1/p)^{k-j}$, so `Finset.sum_range_reflect` turns $\\sum_j (1/p)^{k-j}$ back into $\\sum_j (1/p)^j$. This bridges the natural-number divisor sum $\\sigma$ to the real geometric series, setting up the limit."
+    "content": "`abundancy_eq_geom_sum`: over the reals, $\\sigma(p^k)/p^k = \\sum_{j\\le k} (1/p)^j$. The key step reflects the sum — $\\sigma(p^k)/p^k = \\sum_{j\\le k} p^j/p^k$ and each term $p^j/p^k = (1/p)^{k-j}$, so `Finset.sum_range_reflect` turns $\\sum_j (1/p)^{k-j}$ back into $\\sum_j (1/p)^j$. This bridges the natural-number divisor sum $\\sigma$ to the real geometric series, setting up the limit.",
+    "mathContext": "$\\dfrac{\\sigma(p^k)}{p^k}=\\sum_{j\\le k}\\left(\\tfrac1p\\right)^j$ over $\\mathbb{R}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "abundancy index",
+      "Finset.sum_range_reflect",
+      "geometric series",
+      "ℕ→ℝ bridge"
+    ],
+    "prerequisites": [
+      "σ on prime powers",
+      "real geometric sums",
+      "sum reindexing"
+    ]
   },
   {
     "id": "perfect-numbers-oq-05-oq-01-tendsto-abundancy",
@@ -107,7 +214,20 @@
       "endLine": 231
     },
     "title": "The abundancy limit σ(pᵏ)/pᵏ → p/(p−1)",
-    "content": "`tendsto_abundancy`: the abundancy index converges to $p/(p-1)$ as $k\\to\\infty$ (a `Filter.Tendsto` to $\\mathcal N(p/(p-1))$). From `abundancy_eq_geom_sum` the index is the partial sum $\\sum_{j\\le k}(1/p)^j$; `hasSum_geometric_of_lt_one` (valid since $1/p<1$) gives `HasSum` with value $(1-1/p)^{-1}$, `HasSum.tendsto_sum_nat` turns it into a limit of partial sums over `range n`, and `tendsto_add_atTop_iff_nat` shifts `range n → range (k+1)`. Finally $(1-1/p)^{-1} = p/(p-1)$ by `field_simp`. This is the real-analytic companion of the integer deficiency gap."
+    "content": "`tendsto_abundancy`: the abundancy index converges to $p/(p-1)$ as $k\\to\\infty$ (a `Filter.Tendsto` to $\\mathcal N(p/(p-1))$). From `abundancy_eq_geom_sum` the index is the partial sum $\\sum_{j\\le k}(1/p)^j$; `hasSum_geometric_of_lt_one` (valid since $1/p<1$) gives `HasSum` with value $(1-1/p)^{-1}$, `HasSum.tendsto_sum_nat` turns it into a limit of partial sums over `range n`, and `tendsto_add_atTop_iff_nat` shifts `range n → range (k+1)`. Finally $(1-1/p)^{-1} = p/(p-1)$ by `field_simp`. This is the real-analytic companion of the integer deficiency gap.",
+    "mathContext": "$\\dfrac{\\sigma(p^k)}{p^k}\\to\\dfrac{p}{p-1}$ as $k\\to\\infty$, since $(1-1/p)^{-1}=p/(p-1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Filter.Tendsto",
+      "hasSum_geometric_of_lt_one",
+      "HasSum.tendsto_sum_nat",
+      "abundancy limit"
+    ],
+    "prerequisites": [
+      "convergence of geometric series",
+      "abundancy_eq_geom_sum",
+      "filters and limits"
+    ]
   },
   {
     "id": "perfect-numbers-oq-05-oq-01-abundancy-ceiling",
@@ -118,6 +238,19 @@
       "endLine": 262
     },
     "title": "The sharp abundancy ceiling ≤ 2",
-    "content": "Three bounds pin the ceiling. `abundancy_lt_two`: every *finite* abundancy $\\sigma(p^k)/p^k < 2$ — the real-valued form of the parent's deficiency $\\sigma(p^k)<2p^k$. `abundancy_limit_le_two`: the *limit* $p/(p-1)\\le 2$, with equality exactly at $p=2$ (the abundancy of $2^k$ climbs to $2$ but never reaches it — the almost-perfect boundary). `abundancy_limit_lt_two_of_odd`: for every odd prime $p\\ge 3$ the ceiling is *strictly* below $2$. Factored over prime powers by multiplicativity of $\\sigma$, this $p/(p-1)$ bound is the classical input to abundancy arguments about perfect and multiply-perfect numbers."
+    "content": "Three bounds pin the ceiling. `abundancy_lt_two`: every *finite* abundancy $\\sigma(p^k)/p^k < 2$ — the real-valued form of the parent's deficiency $\\sigma(p^k)<2p^k$. `abundancy_limit_le_two`: the *limit* $p/(p-1)\\le 2$, with equality exactly at $p=2$ (the abundancy of $2^k$ climbs to $2$ but never reaches it — the almost-perfect boundary). `abundancy_limit_lt_two_of_odd`: for every odd prime $p\\ge 3$ the ceiling is *strictly* below $2$. Factored over prime powers by multiplicativity of $\\sigma$, this $p/(p-1)$ bound is the classical input to abundancy arguments about perfect and multiply-perfect numbers.",
+    "mathContext": "$\\dfrac{\\sigma(p^k)}{p^k}<2$ (finite); limit $\\dfrac{p}{p-1}\\le 2$, $=2\\iff p=2$; $<2$ for odd $p\\ge 3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "abundancy ceiling",
+      "multiplicativity of σ",
+      "perfect and multiply-perfect numbers",
+      "the p=2 boundary"
+    ],
+    "prerequisites": [
+      "the abundancy limit p/(p−1)",
+      "multiplicativity of σ",
+      "the parent deficiency bound"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass — `perfect-numbers-oq-05-oq-01`

All **11 annotations** had rich `content`/`title`/`type` but were missing the structured metadata fields. This adds to every annotation:

- **`mathContext`** — LaTeX summary of the formula (e.g. $2\cdot 2^k-\sigma(2^k)=1$, $\sigma(p^k)/p^k\to p/(p-1)$)
- **`significance`** — key / supporting / technical / context
- **`relatedConcepts`** — e.g. almost-perfect numbers, `hasSum_geometric_of_lt_one`, multiplicativity of σ
- **`prerequisites`** — the concepts a reader needs

Existing `content`/`title`/`type`/`range` are left **byte-for-byte unchanged** (verified programmatically); only the four fields are added. meta.json untouched (already rich, 20 KB, under cap).