### PR TITLE
research(gcd-algorithm-oq-02-oq-01): step count of binary GCD is O(log) [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/GcdAlgorithmOQ02OQ01.lean
+++ b/proofs/Proofs/GcdAlgorithmOQ02OQ01.lean
@@ -1,0 +1,185 @@
+import Mathlib
+
+/-
+# Step Count of Binary GCD (Stein's Algorithm)
+
+## What This Proves
+
+The parent entry (`Proofs.GcdAlgorithmOQ02`) defines Stein's binary GCD as a
+well-founded recursion `binaryGcd` and proves it computes `Nat.gcd`.  Its guard
+structure (the three parity/comparison cases below) is reproduced verbatim here
+as `binaryGcdSteps`.  The parent leaves open the *complexity* question:
+
+> Can the step count of binary GCD be formally bounded?  The algorithm should
+> take at most `2·log₂(max a b)` recursive steps.
+
+This entry answers it.  We define `binaryGcdSteps`, the number of recursive
+calls performed by the *same* case analysis that drives `binaryGcd`, and prove
+the sharp logarithmic bound:
+
+* `binaryGcdSteps_le_size_add` — the master bound
+    `binaryGcdSteps a b ≤ Nat.size a + Nat.size b`,
+  proved by a single induction on the recursion: **every** recursive branch
+  strictly decreases the total bit length `size a + size b`.
+* `binaryGcdSteps_le_two_mul_size_max` — the classical form
+    `binaryGcdSteps a b ≤ 2 · Nat.size (max a b)`.
+
+Since `Nat.size n = ⌊log₂ n⌋ + 1` for `n ≥ 1`, this is exactly the textbook
+`O(log(max a b))` step count (Knuth, TAOCP 4.5.2; Brent 1976).  We also record
+`binaryGcdSteps_pow_two_self`, showing the bound has the right order: on the
+diagonal `(2^k, 2^k)` the algorithm uses exactly `k + 1` steps.
+
+## Mathematical Content
+
+The whole argument rests on one bit-length fact, `size_div_two_succ_le`:
+halving a positive number drops its `Nat.size` by exactly one, i.e.
+`(n / 2).size + 1 ≤ n.size`.  Each of the five recursive branches of the
+algorithm either halves an operand (drops `size` by 1) or, in the odd–odd
+branch, replaces the larger operand `A` by `(A - B)/2 ≤ A/2`, whose size is
+again strictly smaller than `size A`.  Hence `size a + size b` is a decreasing
+potential that starts below `size a + size b` and reaches `0` in at most that
+many steps.
+-/
+
+namespace BinaryGcd
+
+open Nat
+
+/-! ## Part I: The step-count function
+
+`binaryGcdSteps a b` counts the recursive calls of `binaryGcd a b`.  It is the
+literal step-annotated copy of `binaryGcd`: identical guards, identical
+recursive arguments, with each recursive case contributing `1`. -/
+
+/-- Number of recursive calls made by `binaryGcd a b` (its recursion depth
+along the actual reduction path). -/
+def binaryGcdSteps : ℕ → ℕ → ℕ
+  | 0, _ => 0
+  | _ + 1, 0 => 0
+  | a + 1, b + 1 =>
+    if ha : (a + 1) % 2 = 0 then
+      if hb : (b + 1) % 2 = 0 then
+        1 + binaryGcdSteps ((a + 1) / 2) ((b + 1) / 2)
+      else
+        1 + binaryGcdSteps ((a + 1) / 2) (b + 1)
+    else if hb : (b + 1) % 2 = 0 then
+      1 + binaryGcdSteps (a + 1) ((b + 1) / 2)
+    else if a + 1 > b + 1 then
+      1 + binaryGcdSteps ((a + 1 - (b + 1)) / 2) (b + 1)
+    else
+      1 + binaryGcdSteps (a + 1) ((b + 1 - (a + 1)) / 2)
+  termination_by a b => a + b
+  decreasing_by all_goals omega
+
+@[simp] theorem binaryGcdSteps_zero_left (b : ℕ) : binaryGcdSteps 0 b = 0 := by
+  simp [binaryGcdSteps]
+
+@[simp] theorem binaryGcdSteps_zero_right (a : ℕ) : binaryGcdSteps a 0 = 0 := by
+  cases a <;> simp [binaryGcdSteps]
+
+/-! ## Part II: The key bit-length lemma
+
+Halving a positive natural number decreases `Nat.size` by exactly one. -/
+
+/-- For `n ≥ 1`, `Nat.size (n / 2) + 1 ≤ Nat.size n`.  (Equivalently
+`size (n/2) = size n - 1`; the inequality form is all we need.) -/
+theorem size_div_two_succ_le {n : ℕ} (hn : 1 ≤ n) : (n / 2).size + 1 ≤ n.size := by
+  rw [Nat.add_one_le_iff, Nat.lt_size]
+  -- Goal: `2 ^ (n / 2).size ≤ n`.
+  rcases Nat.eq_zero_or_pos (n / 2).size with hs | hs
+  · rw [hs]; simpa using hn
+  · -- `2 ^ (size (n/2) - 1) ≤ n/2`, then double.
+    have h1 : 2 ^ ((n / 2).size - 1) ≤ n / 2 :=
+      Nat.lt_size.mp (by omega)
+    have hpow : (2 : ℕ) ^ (n / 2).size = 2 * 2 ^ ((n / 2).size - 1) := by
+      rw [← pow_succ']; congr 1; omega
+    omega
+
+/-- If `m < n` then `Nat.size (m / 2) + 1 ≤ Nat.size n`.  This absorbs the
+odd–odd branch, where the new operand `(A - B)/2` can even be `0`. -/
+theorem size_half_lt {m n : ℕ} (h : m < n) : (m / 2).size + 1 ≤ n.size := by
+  rcases Nat.eq_zero_or_pos m with hm | hm
+  · subst hm
+    simpa [Nat.size_zero] using Nat.size_pos.mpr (by omega : 0 < n)
+  · calc (m / 2).size + 1 ≤ m.size := size_div_two_succ_le hm
+      _ ≤ n.size := Nat.size_le_size (le_of_lt h)
+
+/-! ## Part III: The logarithmic step bound
+
+Master bound: the recursion depth never exceeds the total bit length. -/
+
+/-- **Master step bound.**  `binaryGcd a b` performs at most `size a + size b`
+recursive calls.  Proof: every recursive branch drops the potential
+`size a + size b` by at least one. -/
+theorem binaryGcdSteps_le_size_add (a b : ℕ) :
+    binaryGcdSteps a b ≤ a.size + b.size := by
+  induction a, b using binaryGcdSteps.induct with
+  | case1 b => simp
+  | case2 a => simp
+  | case3 a b ha hb ih =>
+    simp only [binaryGcdSteps, Nat.succ_eq_add_one, ha, hb, ↓reduceDIte]
+    have h1 := size_div_two_succ_le (show 1 ≤ a + 1 by omega)
+    have h2 := size_div_two_succ_le (show 1 ≤ b + 1 by omega)
+    omega
+  | case4 a b ha hb ih =>
+    simp only [binaryGcdSteps, Nat.succ_eq_add_one, ha, hb, ↓reduceDIte]
+    have h1 := size_div_two_succ_le (show 1 ≤ a + 1 by omega)
+    omega
+  | case5 a b ha hb ih =>
+    simp only [binaryGcdSteps, Nat.succ_eq_add_one, ha, hb, ↓reduceDIte]
+    have h2 := size_div_two_succ_le (show 1 ≤ b + 1 by omega)
+    omega
+  | case6 a b ha hb hgt ih =>
+    simp only [binaryGcdSteps, Nat.succ_eq_add_one, ha, hb, hgt, ↓reduceDIte, ↓reduceIte]
+    have h1 := size_half_lt (show a + 1 - (b + 1) < a + 1 by omega)
+    omega
+  | case7 a b ha hb hle ih =>
+    simp only [binaryGcdSteps, Nat.succ_eq_add_one, ha, hb, ↓reduceDIte, ↓reduceIte, show ¬(a + 1 > b + 1) from by omega]
+    have h1 := size_half_lt (show b + 1 - (a + 1) < b + 1 by omega)
+    omega
+
+/-- **Classical form.**  `binaryGcd a b` uses at most `2 · size (max a b)`
+recursive steps.  Because `size n = ⌊log₂ n⌋ + 1` for `n ≥ 1`, this is the
+textbook `O(log (max a b))` bound. -/
+theorem binaryGcdSteps_le_two_mul_size_max (a b : ℕ) :
+    binaryGcdSteps a b ≤ 2 * (max a b).size := by
+  have h := binaryGcdSteps_le_size_add a b
+  have ha : a.size ≤ (max a b).size := Nat.size_le_size (le_max_left a b)
+  have hb : b.size ≤ (max a b).size := Nat.size_le_size (le_max_right a b)
+  omega
+
+/-! ## Part IV: Order tightness on the diagonal
+
+The bound is of the right logarithmic order: on `(2^k, 2^k)` the algorithm
+takes exactly `k + 1` steps, versus the upper bound `2·size (2^k) = 2(k+1)`. -/
+
+/-- The recursion equation on doubled, positive inputs (both even). -/
+theorem binaryGcdSteps_two_mul_two_mul (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
+    binaryGcdSteps (2 * a) (2 * b) = 1 + binaryGcdSteps a b := by
+  obtain ⟨a, rfl⟩ := Nat.exists_eq_succ_of_ne_zero ha.ne'
+  obtain ⟨b, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hb.ne'
+  rw [show 2 * (a + 1) = (2 * a + 1) + 1 by ring,
+      show 2 * (b + 1) = (2 * b + 1) + 1 by ring]
+  conv_lhs => rw [binaryGcdSteps]
+  simp only [show (2 * a + 1 + 1) % 2 = 0 by omega,
+             show (2 * b + 1 + 1) % 2 = 0 by omega, ↓reduceDIte]
+  rw [show (2 * a + 1 + 1) / 2 = a + 1 by omega,
+      show (2 * b + 1 + 1) / 2 = b + 1 by omega]
+
+/-- `binaryGcdSteps 1 1 = 1` (the base of the diagonal family). -/
+theorem binaryGcdSteps_one_one : binaryGcdSteps 1 1 = 1 := by
+  conv_lhs => rw [show (1 : ℕ) = 0 + 1 from rfl, binaryGcdSteps]
+  norm_num
+
+/-- **Tightness.**  On the diagonal `(2^k, 2^k)` the step count is exactly
+`k + 1`, matching the `Θ(log)` order of the upper bound. -/
+theorem binaryGcdSteps_pow_two_self (k : ℕ) :
+    binaryGcdSteps (2 ^ k) (2 ^ k) = k + 1 := by
+  induction k with
+  | zero => simpa using binaryGcdSteps_one_one
+  | succ k ih =>
+    rw [pow_succ, mul_comm (2 ^ k) 2,
+        binaryGcdSteps_two_mul_two_mul _ _ (by positivity) (by positivity), ih]
+    omega
+
+end BinaryGcd

--- a/src/data/proofs/gcd-algorithm-oq-02-oq-01/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-02-oq-01/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "gcd-algorithm-oq-02-oq-01",
+  "title": "Step Count of Binary GCD is O(log)",
+  "slug": "gcd-algorithm-oq-02-oq-01",
+  "description": "Answers the open question of the parent Binary GCD entry: the number of recursive steps performed by Stein's algorithm is bounded by the total bit length. Defines binaryGcdSteps mirroring the algorithm's recursion and proves binaryGcdSteps a b <= size a + size b, hence <= 2 * size (max a b), the textbook 2*log_2(max a b) bound. A diagonal family shows the bound has the right logarithmic order.",
+  "meta": {
+    "author": "Robb Walters (Lean Genius researcher), after Stein (1967), Knuth TAOCP 4.5.2",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GcdAlgorithmOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "algorithms",
+      "gcd",
+      "binary-arithmetic",
+      "complexity",
+      "logarithmic-bound",
+      "open-question",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Only propext, Classical.choice, Quot.sound (the standard Mathlib foundation). No native_decide.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.lt_size",
+        "description": "m < size n iff 2^m <= n; the defining property of Nat.size",
+        "module": "Mathlib.Data.Nat.Size"
+      },
+      {
+        "theorem": "Nat.size_le_size",
+        "description": "Monotonicity of bit length: m <= n implies size m <= size n",
+        "module": "Mathlib.Data.Nat.Size"
+      },
+      {
+        "theorem": "Nat.size_pos",
+        "description": "0 < size n iff 0 < n",
+        "module": "Mathlib.Data.Nat.Size"
+      }
+    ],
+    "originalContributions": [
+      "binaryGcdSteps: a step-count function mirroring the parent's binaryGcd recursion verbatim",
+      "size_div_two_succ_le: halving a positive number drops Nat.size by exactly one",
+      "size_half_lt: (m/2).size + 1 <= n.size whenever m < n (absorbs the odd-odd branch where the new operand may be 0)",
+      "binaryGcdSteps_le_size_add: master bound binaryGcdSteps a b <= size a + size b, one functional induction",
+      "binaryGcdSteps_le_two_mul_size_max: the classical 2*log_2(max a b) step bound",
+      "binaryGcdSteps_pow_two_self: on the diagonal (2^k, 2^k) the step count is exactly k+1, proving the bound is of the right logarithmic order"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 185,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "prerequisites": [
+      "Nat.size (bit length) and its characterization via powers of two",
+      "Well-founded recursion and functional induction (the .induct principle)",
+      "Stein's binary GCD algorithm (parent entry gcd-algorithm-oq-02)"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The parent entry defines Stein's binary GCD (1967) and proves it computes Nat.gcd, but leaves its complexity unproved. Knuth (TAOCP 4.5.2) and Brent (1976) analyze the algorithm and record that it terminates in O(log(max(a,b))) recursive steps: each step either halves an operand (removing one bit) or, in the odd-odd branch, subtracts and halves (again shrinking bit length). This entry supplies a machine-checked version of that step-count bound.",
+    "problemStatement": "Bound the number of recursive steps of Stein's binary GCD. Concretely, defining binaryGcdSteps a b as the number of recursive calls made on input (a, b), prove:\n\n$$\\text{binaryGcdSteps}(a, b) \\le \\operatorname{size}(a) + \\operatorname{size}(b) \\le 2\\,\\operatorname{size}(\\max(a,b)),$$\n\nwhere $\\operatorname{size}(n) = \\lfloor \\log_2 n \\rfloor + 1$ is the bit length. This is the textbook $2\\log_2(\\max(a,b))$ bound.",
+    "text": "A 185-line, 0-axiom formalization answering open question [0] of the Binary GCD parent entry. We define binaryGcdSteps as the step-annotated copy of the parent's binaryGcd: identical guards (both even / one even / both odd with comparison), identical recursive arguments, each recursive branch contributing 1. The master theorem binaryGcdSteps_le_size_add proves binaryGcdSteps a b <= Nat.size a + Nat.size b by a single functional induction: every recursive branch drops the potential size a + size b by at least one. The corollary binaryGcdSteps_le_two_mul_size_max restates this as the classical 2 * size (max a b) bound. Finally binaryGcdSteps_pow_two_self shows the count is exactly k+1 on (2^k, 2^k), so the logarithmic order is sharp (the upper bound 2(k+1) is off by at most a factor 2).",
+    "proofStrategy": "The argument rests on one bit-length fact. size_div_two_succ_le proves (n/2).size + 1 <= n.size for n >= 1 by unwinding Nat.lt_size: 2^(size(n/2)-1) <= n/2, doubled, gives 2^(size(n/2)) <= n. size_half_lt generalizes this to (m/2).size + 1 <= n.size whenever m < n, which is exactly what the odd-odd branch needs (there the surviving operand (A-B)/2 satisfies A-B < A, and may even be 0). With these, the master bound follows by functional induction on binaryGcdSteps.induct: in each of the five recursive branches, the recursive arguments a', b' satisfy size a' + size b' <= size a + size b - 1, so 1 + (steps on a', b') <= size a + size b by the induction hypothesis and omega.",
+    "keyInsights": [
+      "The single potential function size a + size b strictly decreases at every recursive branch, which is exactly the statement that the recursion depth is at most its initial value",
+      "The odd-odd branch is the only subtle case: the new operand (A-B)/2 can be 0 (when A = B), so the halving lemma must be stated for m < n rather than m >= 1 -- size_half_lt handles this uniformly",
+      "Nat.size (bit length) is the natural measure: halving removes exactly one bit, and Nat.lt_size gives the clean two-sided characterization 2^m <= n <=> m < size n used throughout",
+      "Functional induction (binaryGcdSteps.induct) delivers precisely one case per recursive branch, so the whole master bound is one induction with a five-line-per-case omega discharge",
+      "The diagonal family (2^k, 2^k) attains exactly k+1 steps, certifying that the O(log) upper bound cannot be improved to o(log)"
+    ],
+    "prerequisites": [
+      "Nat.size (bit length) and its characterization via powers of two",
+      "Well-founded recursion and functional induction (the .induct principle)",
+      "Stein's binary GCD algorithm (parent entry gcd-algorithm-oq-02)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "step-function",
+      "title": "The Step-Count Function",
+      "startLine": 48,
+      "endLine": 78,
+      "summary": "Defines binaryGcdSteps mirroring binaryGcd's recursion (same guards and recursive arguments, +1 per recursive call), with zero base cases.",
+      "mathContext": "binaryGcdSteps counts recursive calls; binaryGcdSteps 0 b = binaryGcdSteps a 0 = 0"
+    },
+    {
+      "id": "bit-length-lemma",
+      "title": "The Key Bit-Length Lemma",
+      "startLine": 80,
+      "endLine": 105,
+      "summary": "size_div_two_succ_le: halving a positive number drops Nat.size by one. size_half_lt: (m/2).size + 1 <= n.size when m < n, covering the odd-odd branch.",
+      "mathContext": "$\\operatorname{size}(n/2) + 1 \\le \\operatorname{size}(n)$ for $n \\ge 1$"
+    },
+    {
+      "id": "log-bound",
+      "title": "The Logarithmic Step Bound",
+      "startLine": 107,
+      "endLine": 149,
+      "summary": "binaryGcdSteps_le_size_add: the master bound size a + size b via functional induction. binaryGcdSteps_le_two_mul_size_max: the classical 2 * size (max a b) form.",
+      "mathContext": "$\\text{binaryGcdSteps}(a,b) \\le \\operatorname{size}(a)+\\operatorname{size}(b) \\le 2\\operatorname{size}(\\max(a,b))$"
+    },
+    {
+      "id": "tightness",
+      "title": "Order Tightness on the Diagonal",
+      "startLine": 151,
+      "endLine": 183,
+      "summary": "binaryGcdSteps_two_mul_two_mul: recursion equation on doubled inputs. binaryGcdSteps_pow_two_self: exactly k+1 steps on (2^k, 2^k), matching the Theta(log) order.",
+      "mathContext": "$\\text{binaryGcdSteps}(2^k, 2^k) = k + 1$"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gcd-algorithm-oq-02",
+      "relationship": "extends",
+      "description": "Answers open question [0] of the Binary GCD parent: formally bounding the algorithm's step count by 2*log_2(max(a,b))"
+    },
+    {
+      "targetId": "binary-gcd-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The sibling binaryGcdCost chain bounds a bit-operation cost model (O(log^2)); this entry bounds the recursion depth (O(log)), a distinct complexity measure"
+    }
+  ],
+  "conclusion": {
+    "summary": "The number of recursive steps of Stein's binary GCD is bounded by the total bit length size a + size b, hence by 2 * size (max a b) = 2*log_2(max(a,b)) + O(1). The bound is proved by a single functional induction on a step-count function that mirrors the algorithm, using one bit-length lemma. A diagonal family shows the logarithmic order is sharp.",
+    "implications": "This closes the complexity question left open by the parent entry with a fully machine-checked, 0-axiom proof. The technique -- instrument the algorithm with a step counter, then bound it via the same functional induction that proved correctness, using a bit-length potential -- transfers to other divide-and-halve recursions (Lehmer GCD, binary exponentiation).",
+    "openQuestions": [
+      "Can the average-case step count of binary GCD (Knuth's O(log) with explicit constant ~0.705 log_2 N) be formalized, not just the worst case?",
+      "Can the recursion-depth bound be transferred to the parent's binaryGcd itself via a formal proof that binaryGcd and binaryGcdSteps share the same reduction path?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Stein, Josef",
+      "title": "Computational problems associated with Racah algebra",
+      "year": "1967",
+      "venue": "Journal of Computational Physics 1(3), 397-405",
+      "note": "Introduced the binary GCD algorithm using only subtraction and division by 2"
+    },
+    {
+      "authors": "Knuth, Donald E.",
+      "title": "The Art of Computer Programming, Vol. 2: Seminumerical Algorithms",
+      "year": "1997",
+      "venue": "Addison-Wesley, 3rd edition, Section 4.5.2",
+      "note": "Worst-case and average-case step-count analysis of binary GCD"
+    },
+    {
+      "authors": "Brent, Richard P.",
+      "title": "Analysis of the binary Euclidean algorithm",
+      "year": "1976",
+      "venue": "Algorithms and Complexity: New Directions and Recent Results, Academic Press, 321-355",
+      "note": "Detailed complexity analysis of the binary GCD algorithm"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "BinaryGcd",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/GcdAlgorithmOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "binaryGcdSteps_le_size_add",
+      "type": "core",
+      "description": "Master bound: binaryGcd performs at most size a + size b recursive steps",
+      "leanType": "∀ a b : ℕ, binaryGcdSteps a b ≤ a.size + b.size"
+    },
+    {
+      "name": "binaryGcdSteps_le_two_mul_size_max",
+      "type": "core",
+      "description": "Classical form: at most 2 * size (max a b) = 2*log_2(max a b) steps",
+      "leanType": "∀ a b : ℕ, binaryGcdSteps a b ≤ 2 * (max a b).size"
+    },
+    {
+      "name": "binaryGcdSteps_pow_two_self",
+      "type": "supporting",
+      "description": "Tightness: exactly k+1 steps on the diagonal (2^k, 2^k)",
+      "leanType": "∀ k : ℕ, binaryGcdSteps (2 ^ k) (2 ^ k) = k + 1"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry answering **open question [0]** of the Binary GCD parent (`gcd-algorithm-oq-02`):

> *Can the step count of binary GCD be formally bounded? The algorithm takes at most 2·log₂(max(a,b)) steps.*

The parent defines Stein's `binaryGcd` and proves correctness but leaves complexity open. This entry defines `binaryGcdSteps` — the step-annotated copy of the same recursion — and proves the logarithmic step bound.

## Results (`proofs/Proofs/GcdAlgorithmOQ02OQ01.lean`)

- **`binaryGcdSteps_le_size_add`** — master bound `binaryGcdSteps a b ≤ Nat.size a + Nat.size b`, one functional induction: every recursive branch drops the bit-length potential `size a + size b` by ≥ 1.
- **`binaryGcdSteps_le_two_mul_size_max`** — classical form `≤ 2 · Nat.size (max a b)`, i.e. the textbook `2·log₂(max a b)` bound (since `size n = ⌊log₂ n⌋ + 1`).
- **`binaryGcdSteps_pow_two_self`** — on the diagonal `(2^k, 2^k)` the count is exactly `k+1`, so the O(log) order is sharp.

Supporting: `size_div_two_succ_le` (halving drops `Nat.size` by one) and `size_half_lt` (the odd–odd branch, where the surviving operand may be 0).

## Verification

- **9 theorems, 1 definition, 185 lines**
- **0 sorries, 0 axioms** — `#print axioms` shows only `propext, Classical.choice, Quot.sound`. No `native_decide`.
- Typechecked with `lake env lean` against Mathlib v4.26.0.

Distinct from the sibling `binaryGcdCost` chain, which bounds a **bit-operation cost** model (O(log²)); this bounds **recursion depth** (O(log)) — a different complexity measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)