### PR TITLE
Enrich Gorenstein criterion (frobenius-number-oq-02-oq-02): add annotations.json

### DIFF
--- a/src/data/proofs/frobenius-number-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/frobenius-number-oq-02-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "frobenius-number-oq-02-oq-02",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "context",
+    "title": "Kunz's Duality and the Combinatorial Half",
+    "content": "Kunz (1970): the numerical semigroup ring k[S] is Gorenstein iff S is symmetric — the involution z ↦ F − z (F the Frobenius number) swaps gaps and non-gaps in the window [0,F]. The numerical fingerprint of symmetry is 2·(#gaps in [0,F]) = F + 1, i.e. exactly half of {0,…,F} are gaps (the Gorenstein ring has type 1). Mathlib has NO Gorenstein-ring or numerical-semigroup-ring machinery (a grep for 'gorenstein' returns nothing; building it is a >1000-line effort), so the ring-theoretic direction is honestly out of reach. This file formalizes the full combinatorial content of the duality — the piece carrying the actual mathematics — abstractly and then for the two-generator semigroup ⟨a,b⟩.",
+    "mathContext": "$k[S]$ Gorenstein $\\iff S$ symmetric $\\iff 2\\cdot\\#\\{\\text{gaps in }[0,F]\\}=F+1$.",
+    "significance": "context",
+    "relatedConcepts": ["Kunz's theorem", "Gorenstein ring", "symmetric numerical semigroup", "genus of a semigroup", "Mathlib infrastructure gap"],
+    "prerequisites": ["numerical semigroups and the Frobenius number", "the parent representability involution (frobenius-number-oq-02)"]
+  },
+  {
+    "id": "ann-defs",
+    "proofId": "frobenius-number-oq-02-oq-02",
+    "range": { "startLine": 47, "endLine": 59 },
+    "type": "definition",
+    "title": "Gaps and Non-Gaps in the Window [0,F]",
+    "content": "For a decidable membership predicate S and bound F, nonGaps and gaps filter the window [0,F] = Finset.range (F+1) into members of S and non-members. The membership lemmas mem_nonGaps_iff / mem_gaps_iff unfold each to z ≤ F ∧ (¬)S z (via Nat.lt_succ_iff to turn z < F+1 into z ≤ F). For a genuine numerical semigroup F is the largest gap, so every gap lies in this window and #gaps is exactly the genus.",
+    "mathContext": "$\\mathrm{nonGaps}=\\{z\\le F: S\\,z\\}$, $\\mathrm{gaps}=\\{z\\le F: \\lnot S\\,z\\}$, over $[0,F]=\\mathrm{range}(F{+}1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.filter", "Finset.range", "Nat.lt_succ_iff", "genus = #gaps", "decidable predicate"],
+    "prerequisites": ["Finset filtering", "decidable membership predicates"]
+  },
+  {
+    "id": "ann-partition",
+    "proofId": "frobenius-number-oq-02-oq-02",
+    "range": { "startLine": 61, "endLine": 65 },
+    "type": "lemma",
+    "title": "The Window Partition: #nonGaps + #gaps = F + 1",
+    "content": "nonGaps_card_add_gaps_card records that the window [0,F] splits cleanly into its members and non-members: #nonGaps + #gaps = F + 1. This is Finset.filter_card_add_filter_neg_card_eq_card (a set and its complement under a decidable predicate exhaust the whole) applied to range (F+1), whose cardinality is F+1 (Finset.card_range). This partition is the linear equation the final omega step combines with the two involution inequalities.",
+    "mathContext": "$\\#\\mathrm{nonGaps}+\\#\\mathrm{gaps}=|[0,F]|=F+1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.filter_card_add_filter_neg_card_eq_card", "Finset.card_range", "complementary filters", "partition of a finite set"],
+    "prerequisites": ["cardinality of a filter and its negation", "Finset.card_range"]
+  },
+  {
+    "id": "ann-symmetric-def",
+    "proofId": "frobenius-number-oq-02-oq-02",
+    "range": { "startLine": 67, "endLine": 70 },
+    "type": "definition",
+    "title": "The Symmetry Predicate",
+    "content": "SymmetricSet F S := ∀ z ≤ F, (S z ↔ ¬ S (F − z)) is the abstract symmetry condition: membership at z is the negation of membership at the mirror point F − z. For a numerical semigroup this is exactly the classical definition of a symmetric semigroup — for every z ≤ F, exactly one of z and F − z is a gap. Everything downstream is proved from this single equivalence.",
+    "mathContext": "$\\mathrm{SymmetricSet}\\ F\\ S :\\iff \\forall z\\le F,\\ (S\\,z \\iff \\lnot S(F-z))$.",
+    "significance": "key",
+    "relatedConcepts": ["symmetric numerical semigroup", "gap involution z ↦ F − z", "self-dual predicate"],
+    "prerequisites": ["truncated natural subtraction", "the notion of a symmetric semigroup"]
+  },
+  {
+    "id": "ann-involution",
+    "proofId": "frobenius-number-oq-02-oq-02",
+    "range": { "startLine": 72, "endLine": 102 },
+    "type": "theorem",
+    "title": "The Gap Involution Matches the Two Halves",
+    "content": "card_nonGaps_le and card_gaps_le show the involution z ↦ F − z injects non-gaps into gaps and gaps into non-gaps, so the two halves have equal cardinality. Both use Finset.card_le_card_of_injOn with the SAME map: target-membership comes from the symmetry equivalence (h z hz.1), and injectivity is truncated-subtraction cancellation closed by omega. The back direction (card_gaps_le) is the subtler one — it applies symmetry at F − z and rewrites F − (F − z) = z via Nat.sub_sub_self, exploiting that z ↦ F − z is its own inverse on [0,F], so no separate inverse map is needed.",
+    "mathContext": "$z\\mapsto F-z$ injects nonGaps↪gaps and gaps↪nonGaps; $F-(F-z)=z$ (self-inverse) $\\Rightarrow \\#\\mathrm{nonGaps}=\\#\\mathrm{gaps}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_le_card_of_injOn", "Nat.sub_sub_self", "involution", "injectivity via omega", "cardinality matching"],
+    "prerequisites": ["injection-on-a-set cardinality bound", "self-inverse of z ↦ F − z", "the symmetry predicate"]
+  },
+  {
+    "id": "ann-criterion",
+    "proofId": "frobenius-number-oq-02-oq-02",
+    "range": { "startLine": 104, "endLine": 113 },
+    "type": "theorem",
+    "title": "The Abstract Combinatorial Gorenstein Criterion",
+    "content": "card_gaps_two_mul is the headline abstract result: SymmetricSet F S ⟹ 2·#gaps = F + 1. The proof is a three-line linear combination — the two inequalities #nonGaps ≤ #gaps and #gaps ≤ #nonGaps force #nonGaps = #gaps, and combining with the window partition #nonGaps + #gaps = F + 1 gives 2·#gaps = F + 1 (omega). Proving it for an ARBITRARY decidable predicate makes it reusable for any numerical semigroup once symmetry is known, not just two generators. This is the numerical shadow Kunz's theorem detects: type-one / Gorenstein.",
+    "mathContext": "$\\mathrm{SymmetricSet}\\ F\\ S \\implies 2\\cdot\\#\\mathrm{gaps}=F+1$, i.e. genus $=(F+1)/2$.",
+    "significance": "key",
+    "relatedConcepts": ["genus (F+1)/2", "Gorenstein type one", "omega", "abstract-then-instantiate", "Kunz's criterion"],
+    "prerequisites": ["the two involution inequalities", "the window partition", "linear arithmetic (omega)"]
+  },
+  {
+    "id": "ann-concrete-symmetry",
+    "proofId": "frobenius-number-oq-02-oq-02",
+    "range": { "startLine": 115, "endLine": 145 },
+    "type": "theorem",
+    "title": "⟨a,b⟩ Is Symmetric — Completing the Boundary",
+    "content": "frob_symmetricSet proves the representability predicate of ⟨a,b⟩ satisfies SymmetricSet on the whole window [0,g]. The parent's frobenius_symmetry covers only the interior 0 < n < g, so the two boundary points must be added: at n = 0, 0 is always representable while g never is (representable_zero, frobenius_not_representable); at n = g, symmetrically g is not representable while 0 is. The interior case delegates verbatim to the parent theorem. This boundary completion is precisely what upgrades the parent's partial involution into the full-window hypothesis the abstract criterion demands.",
+    "mathContext": "$\\mathrm{Rep}(n)\\iff\\lnot\\mathrm{Rep}(g-n)$ on all of $[0,g]$; endpoints: $\\mathrm{Rep}(0)$, $\\lnot\\mathrm{Rep}(g)$.",
+    "significance": "key",
+    "relatedConcepts": ["frobenius_symmetry", "representable_zero", "frobenius_not_representable", "boundary cases", "coprime generators"],
+    "prerequisites": ["the parent involution (0 < n < g)", "representability of 0 and non-representability of g", "case split on z"]
+  },
+  {
+    "id": "ann-gorenstein",
+    "proofId": "frobenius-number-oq-02-oq-02",
+    "range": { "startLine": 147, "endLine": 160 },
+    "type": "theorem",
+    "title": "Gorenstein Criterion for ⟨a,b⟩, and the ⟨3,5⟩ Check",
+    "content": "frob_gorenstein_criterion instantiates the abstract criterion at the representability predicate: for coprime a,b ≥ 2 with g = ab − a − b, exactly half of {0,…,g} are non-representable, 2·#{gaps in [0,g]} = g + 1. So ⟨a,b⟩ is symmetric and — by Kunz's theorem — k[t^a,t^b] is Gorenstein. The proof is a single application of card_gaps_two_mul to frob_symmetricSet. A concrete example verifies ⟨3,5⟩: g = 7, gaps {1,2,4,7}, and 2·4 = 8 = 7+1 — kernel-checked, not native_decide.",
+    "mathContext": "coprime $a,b\\ge2$: $2\\cdot\\#\\{\\text{non-representable }n\\le g\\}=g+1$; ⟨3,5⟩: $g=7$, 4 gaps, $2\\cdot4=8$.",
+    "significance": "key",
+    "relatedConcepts": ["numerical semigroup ⟨a,b⟩", "Gorenstein ring k[tᵃ,tᵇ]", "instantiation of abstract lemma", "Sylvester genus (a−1)(b−1)/2"],
+    "prerequisites": ["the abstract criterion card_gaps_two_mul", "frob_symmetricSet", "the Frobenius number ab−a−b"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass — `frobenius-number-oq-02-oq-02`

The entry had a rich `meta.json` but **no `annotations.json`** (quality 45). This adds one with **8 annotations covering the full 162-line file** (lines 1–160), each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

| id | lines | covers |
|----|-------|--------|
| ann-header | 1–45 | Kunz's duality + Mathlib infrastructure gap |
| ann-defs | 47–59 | `nonGaps`/`gaps` + membership lemmas |
| ann-partition | 61–65 | `#nonGaps + #gaps = F + 1` |
| ann-symmetric-def | 67–70 | the `SymmetricSet` predicate |
| ann-involution | 72–102 | `z ↦ F−z` matches the two halves (self-inverse) |
| ann-criterion | 104–113 | abstract `2·#gaps = F+1` |
| ann-concrete-symmetry | 115–145 | ⟨a,b⟩ symmetric via boundary completion |
| ann-gorenstein | 147–160 | instantiation + ⟨3,5⟩ sanity check |

meta.json untouched (already rich; status/badge/axiomCount left as verified/original/0).