### PR TITLE
research(wilsons-theorem-oq-03-oq-03): Kummer digit-sum — ν₂(C(2n,n)) = popcount(n) [VERIFIED, 0-axiom, 7thm/165L]

### DIFF
--- a/proofs/Proofs/WilsonsTheoremOQ03OQ03.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ03OQ03.lean
@@ -1,0 +1,165 @@
+/-
+Kummer's Theorem in Digit-Sum Form: the 2-adic Valuation of Central
+Binomial Coefficients (Wilson's Theorem OQ-03-OQ-03)
+
+Source: Classical number theory — Ernst Kummer, 1852; the 2-adic
+central-binomial identity is folklore (Legendre/Kummer + the popcount).
+Status: COMPLETE
+
+## Motivation
+The parent entry (WilsonsTheoremOQ03) proves **Legendre's formula** in
+digit-sum form:  (p - 1) · ν_p(n!) = n − S_p(n).  Applying it three times
+to the factorization  n! = C(n,k) · k! · (n-k)!  yields **Kummer's theorem**:
+
+  (p - 1) · ν_p(C(n,k)) = S_p(k) + S_p(n-k) − S_p(n),
+
+i.e. ν_p(C(n,k)) equals the number of carries when adding k and n−k in
+base p.  Mathlib already contains this identity
+(`sub_one_mul_padicValNat_choose_eq_sub_sum_digits`).  This entry pushes it
+to the *consequences* Mathlib does **not** record:
+
+## What This Proves (new relative to Mathlib)
+- [x] `digit_sum_two_mul`   : S₂(2n) = S₂(n)  (a left binary shift adds a 0 digit)
+- [x] `digit_two_sum_pos`   : 0 < S₂(n) for n ≥ 1
+- [x] `digit_sum_two_pow`   : S₂(2^m) = 1
+- [x] **`padicValNat_centralBinom_two`** : ν₂(C(2n,n)) = S₂(n)
+      — the 2-adic valuation of the central binomial coefficient equals the
+      binary digit sum (popcount) of n.  This is the sharp form of the
+      classical fact "C(2n,n) is even"; Mathlib has no exact-valuation result.
+- [x] `centralBinom_two_dvd_iff` : 2 ∣ C(2n,n) ↔ n ≠ 0  (even except at n = 0)
+- [x] `centralBinom_two_pow_valuation` : ν₂(C(2^{m+1}, 2^m)) = 1
+      — the popcount bound is sharp: at powers of two the central binomial
+      is divisible by 2 exactly once, hence ≡ 2 (mod 4).
+- [x] `not_dvd_choose_iff` : Kummer's no-carry criterion —
+      p ∤ C(n,k) ↔ S_p(k) + S_p(n-k) ≤ S_p(n)  (k ≤ n).
+
+## Mathlib Dependencies
+- `sub_one_mul_padicValNat_choose_eq_sub_sum_digits` : Kummer (digit-sum form)
+- `Nat.centralBinom_eq_two_mul_choose` : C(2n,n) = choose (2n) n
+- `Nat.digits_def'`, `Nat.getLast_digit_ne_zero`, `Nat.digits_ne_nil_iff_ne_zero`
+- `padicValNat.eq_zero_of_not_dvd`, `one_le_padicValNat_of_dvd`, `pow_padicValNat_dvd`
+
+Parent proof: WilsonsTheoremOQ03.lean (Legendre's formula)
+Open question answered: "What does Legendre's formula say about binomial
+coefficients — in particular, exactly how even is C(2n,n)?"
+-/
+
+import Mathlib
+
+namespace WilsonsTheoremCentralBinom
+
+open Nat
+
+/-! ## Base-2 Digit-Sum Infrastructure -/
+
+/-- **Left binary shift**: multiplying by 2 prepends a `0` digit in base 2,
+    so the digit sum is unchanged:  S₂(2n) = S₂(n). -/
+theorem digit_sum_two_mul (n : ℕ) :
+    (Nat.digits 2 (2 * n)).sum = (Nat.digits 2 n).sum := by
+  rcases Nat.eq_zero_or_pos n with h | h
+  · simp [h]
+  · rw [Nat.digits_def' (by norm_num : (1 : ℕ) < 2) (by omega : 0 < 2 * n)]
+    have h0 : 2 * n % 2 = 0 := Nat.mul_mod_right 2 n
+    have hd : 2 * n / 2 = n := Nat.mul_div_cancel_left n (by norm_num)
+    rw [h0, hd, List.sum_cons, Nat.zero_add]
+
+/-- The base-2 digit sum is positive for every `n ≥ 1` (the top digit is
+    nonzero and sits inside the digit list). -/
+theorem digit_two_sum_pos (n : ℕ) (hn : 0 < n) : 0 < (Nat.digits 2 n).sum := by
+  have hnil : Nat.digits 2 n ≠ [] := Nat.digits_ne_nil_iff_ne_zero.mpr hn.ne'
+  have hlast : 0 < (Nat.digits 2 n).getLast hnil :=
+    Nat.pos_of_ne_zero (Nat.getLast_digit_ne_zero 2 hn.ne')
+  calc (0 : ℕ) < (Nat.digits 2 n).getLast hnil := hlast
+    _ ≤ (Nat.digits 2 n).sum :=
+        List.single_le_sum (fun _ _ => Nat.zero_le _) _ (List.getLast_mem hnil)
+
+/-- **Digit sum of a power of two**: S₂(2^m) = 1, since 2^m is a single 1-bit.
+    Proved by induction, each step being a binary left shift. -/
+theorem digit_sum_two_pow (m : ℕ) : (Nat.digits 2 (2 ^ m)).sum = 1 := by
+  induction m with
+  | zero =>
+      have h1 : Nat.digits 2 (2 ^ 0) = [1] := by
+        rw [pow_zero, Nat.digits_def' (by norm_num : (1 : ℕ) < 2) (by norm_num : 0 < 1)]
+        simp
+      rw [h1]; rfl
+  | succ k ih => rw [pow_succ, mul_comm, digit_sum_two_mul, ih]
+
+/-! ## The 2-adic Valuation of the Central Binomial Coefficient -/
+
+/-- **ν₂(C(2n,n)) = popcount(n)**.  The 2-adic valuation of the central
+    binomial coefficient `C(2n, n)` equals the number of `1`s in the binary
+    expansion of `n` (the base-2 digit sum S₂(n)).
+
+    **Proof.**  Kummer's digit-sum identity for `choose (2n) n` gives
+    `(2-1)·ν₂ = S₂(n) + S₂(2n - n) − S₂(2n) = 2·S₂(n) − S₂(2n)`, and a binary
+    left shift gives `S₂(2n) = S₂(n)`, so the right side collapses to `S₂(n)`. -/
+theorem padicValNat_centralBinom_two (n : ℕ) :
+    padicValNat 2 (Nat.centralBinom n) = (Nat.digits 2 n).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  rw [Nat.centralBinom_eq_two_mul_choose]
+  have key := sub_one_mul_padicValNat_choose_eq_sub_sum_digits
+    (p := 2) (k := n) (n := 2 * n) (by omega)
+  rw [show (2 * n - n) = n by omega, digit_sum_two_mul] at key
+  -- key : (2 - 1) * ν₂(choose (2n) n) = S₂(n) + S₂(n) − S₂(n)
+  simpa using key
+
+/-- **C(2n,n) is even, except at n = 0**:  `2 ∣ C(2n,n) ↔ n ≠ 0`.
+    A sharp, exact-parity statement following directly from
+    `padicValNat_centralBinom_two`: the valuation is `S₂(n)`, which is
+    positive iff `n ≠ 0`. -/
+theorem centralBinom_two_dvd_iff (n : ℕ) :
+    2 ∣ Nat.centralBinom n ↔ n ≠ 0 := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  constructor
+  · rintro hd rfl
+    rw [Nat.centralBinom_zero] at hd
+    exact absurd hd (by norm_num)
+  · intro hn
+    have hval : padicValNat 2 (Nat.centralBinom n) = (Nat.digits 2 n).sum :=
+      padicValNat_centralBinom_two n
+    have hs : 0 < padicValNat 2 (Nat.centralBinom n) := by
+      rw [hval]; exact digit_two_sum_pos n (Nat.pos_of_ne_zero hn)
+    have hne : padicValNat 2 (Nat.centralBinom n) ≠ 0 := hs.ne'
+    exact dvd_trans (dvd_pow_self 2 hne) (pow_padicValNat_dvd)
+
+/-- **Sharpness of the popcount bound at powers of two**:
+    `ν₂(C(2·2^m, 2^m)) = 1`.  Since `S₂(2^m) = 1`, the central binomial
+    coefficient at a power of two is divisible by 2 exactly once — hence
+    `C(2^{m+1}, 2^m) ≡ 2 (mod 4)`. -/
+theorem centralBinom_two_pow_valuation (m : ℕ) :
+    padicValNat 2 (Nat.centralBinom (2 ^ m)) = 1 := by
+  rw [padicValNat_centralBinom_two, digit_sum_two_pow]
+
+/-! ## Kummer's No-Carry Criterion (general prime) -/
+
+/-- **Kummer's no-carry criterion (digit-sum form)**: for a prime `p` and
+    `k ≤ n`, the prime `p` does *not* divide `C(n,k)` iff there are no carries
+    when adding `k` and `n − k` in base `p`, expressed as
+    `S_p(k) + S_p(n-k) ≤ S_p(n)`.
+
+    (Together with the always-valid reverse inequality `S_p(n) ≤ S_p(k) +
+    S_p(n-k)`, this is the classical equality `S_p(k)+S_p(n-k) = S_p(n)`.)
+
+    **Proof.**  `p ∤ C(n,k)` iff `ν_p(C(n,k)) = 0`, iff `(p-1)·ν_p = 0`; by
+    Kummer's identity the latter is `S_p(k) + S_p(n-k) − S_p(n) = 0`. -/
+theorem not_dvd_choose_iff (p k n : ℕ) [hp : Fact p.Prime] (h : k ≤ n) :
+    ¬ p ∣ n.choose k ↔
+      (p.digits k).sum + (p.digits (n - k)).sum ≤ (p.digits n).sum := by
+  have hpos : n.choose k ≠ 0 := (Nat.choose_pos h).ne'
+  have key := sub_one_mul_padicValNat_choose_eq_sub_sum_digits (p := p) (k := k) (n := n) h
+  have hp1 : 0 < p - 1 := Nat.sub_pos_of_lt hp.out.one_lt
+  constructor
+  · intro hnd
+    have hv : padicValNat p (n.choose k) = 0 := padicValNat.eq_zero_of_not_dvd hnd
+    rw [hv, Nat.mul_zero] at key
+    omega
+  · intro hle
+    have hz : (p.digits k).sum + (p.digits (n - k)).sum - (p.digits n).sum = 0 := by omega
+    rw [hz] at key
+    have hv : padicValNat p (n.choose k) = 0 :=
+      (Nat.mul_eq_zero.mp key).resolve_left hp1.ne'
+    intro hd
+    have := one_le_padicValNat_of_dvd hpos hd
+    omega
+
+end WilsonsTheoremCentralBinom

--- a/src/data/proofs/wilsons-theorem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-03-oq-03/meta.json
@@ -1,0 +1,174 @@
+{
+  "id": "wilsons-theorem-oq-03-oq-03",
+  "slug": "wilsons-theorem-oq-03-oq-03",
+  "title": "Kummer in Digit-Sum Form: ν₂(C(2n,n)) = popcount(n)",
+  "description": "Applying the parent's Legendre digit-sum formula to n! = C(n,k)·k!·(n-k)! yields Kummer's theorem. This entry proves the exact-valuation consequences Mathlib omits: the 2-adic valuation of the central binomial coefficient C(2n,n) equals the number of 1-bits in the binary expansion of n (its popcount S₂(n)); C(2n,n) is even except at n=0; the bound is sharp at powers of two (ν₂ = 1, so C(2^{m+1},2^m) ≡ 2 mod 4); and Kummer's no-carry divisibility criterion p ∤ C(n,k) ↔ S_p(k)+S_p(n−k) ≤ S_p(n).",
+  "overview": {
+    "historicalContext": "Legendre (1808) gave the exact power of a prime dividing n! in digit-sum form, (p−1)·ν_p(n!) = n − S_p(n). Ernst Kummer (1852) observed that dividing three such identities — for n!, k!, and (n−k)! — expresses ν_p of a binomial coefficient as a difference of digit sums, equivalently the number of carries when k and n−k are added in base p. The parent gallery entry (WilsonsTheoremOQ03) formalizes Legendre's formula; Mathlib in turn records Kummer's identity as `sub_one_mul_padicValNat_choose_eq_sub_sum_digits`. What neither records is the sharp exact-valuation folklore that falls out of it — most famously that the 2-adic valuation of the central binomial coefficient C(2n,n) equals the binary digit sum (popcount) of n, a fact underlying the classical statement that C(2n,n) is always even.",
+    "problemStatement": "Parent open question (`wilsons-theorem-oq-03`): what does Legendre's digit-sum formula say about binomial coefficients — in particular, exactly how even is the central binomial coefficient C(2n,n)? Concretely: give the exact 2-adic valuation of C(2n,n), characterize when 2 divides it, exhibit where the bound is sharp, and state the general no-carry divisibility criterion for C(n,k).",
+    "text": "Kummer's digit-sum identity, specialized to the central binomial coefficient C(2n,n) = choose (2n) n with p = 2, gives (2−1)·ν₂(C(2n,n)) = S₂(n) + S₂(2n − n) − S₂(2n) = 2·S₂(n) − S₂(2n). A binary left shift multiplies by 2 by prepending a 0 digit, so S₂(2n) = S₂(n); the right side collapses to S₂(n). Since p − 1 = 1, this is the clean identity ν₂(C(2n,n)) = S₂(n) — the 2-adic valuation of the central binomial coefficient equals the number of 1-bits in n. Two corollaries make the result sharp on both sides: S₂(n) is positive exactly when n ≠ 0, so 2 ∣ C(2n,n) ↔ n ≠ 0 (even except at n = 0); and S₂(2^m) = 1, so ν₂(C(2^{m+1}, 2^m)) = 1 — at a power of two the central binomial is divisible by 2 exactly once, i.e. C(2^{m+1}, 2^m) ≡ 2 (mod 4). Finally, for a general prime the same machinery gives Kummer's no-carry criterion: p ∤ C(n,k) iff ν_p = 0 iff (p−1)·ν_p = 0 iff S_p(k) + S_p(n−k) ≤ S_p(n) — no carries occur when adding k and n−k in base p.",
+    "proofStrategy": "`digit_sum_two_mul`: unfold one step of `Nat.digits_def'` at 2n>0; the units digit is 2n%2 = 0 and the tail is `digits 2 n`, so the sum is unchanged. `digit_two_sum_pos`: the top digit is nonzero (`Nat.getLast_digit_ne_zero`) and lies in the digit list, so `List.single_le_sum` bounds it below the sum. `digit_sum_two_pow`: induction on m, each step a binary left shift via `digit_sum_two_mul`, base `S₂(1) = 1` from `Nat.digits_def'`. `padicValNat_centralBinom_two`: rewrite to `choose (2n) n`, apply Mathlib's `sub_one_mul_padicValNat_choose_eq_sub_sum_digits`, substitute 2n−n = n and `digit_sum_two_mul`, then `simpa`. `centralBinom_two_dvd_iff`: forward is `centralBinom 0 = 1`; reverse turns positivity of the valuation (from `digit_two_sum_pos`) into divisibility via `pow_padicValNat_dvd` and `dvd_pow_self`. `centralBinom_two_pow_valuation`: the flagship identity plus `digit_sum_two_pow`. `not_dvd_choose_iff`: `p ∤ C ↔ ν_p = 0` (via `padicValNat.eq_zero_of_not_dvd` and `one_le_padicValNat_of_dvd`), and Kummer's identity turns ν_p = 0 into the digit-sum inequality; `omega` handles the ℕ truncated subtraction.",
+    "keyInsights": [
+      "The 2-adic valuation of the central binomial coefficient is not merely positive (\"C(2n,n) is even\") but exactly the popcount of n: ν₂(C(2n,n)) = S₂(n). This is the sharp form of a classical evenness fact, and Mathlib has no exact-valuation result for it.",
+      "The whole argument rests on one trivial base-2 lemma — a left shift prepends a 0 digit, so S₂(2n) = S₂(n) — which makes the general Kummer expression 2·S₂(n) − S₂(2n) collapse to S₂(n). No carry analysis is needed once Legendre's formula is available.",
+      "Sharpness comes for free from the same shift lemma: S₂(2^m) = 1 by induction, so the valuation is exactly 1 at powers of two, giving C(2^{m+1}, 2^m) ≡ 2 (mod 4).",
+      "Kummer's classical no-carry criterion is exactly the statement that (p−1)·ν_p(C(n,k)) = 0, and in ℕ that is the digit-sum inequality S_p(k) + S_p(n−k) ≤ S_p(n); the divisibility question reduces to a linear-arithmetic fact once the valuation is expressed through digit sums.",
+      "Everything is symbolic and axiom-free: unlike the parent entry, which uses `native_decide` for its concrete numeric valuations, these are structural theorems proved by rewriting, induction, and `omega`, so the entry carries no `Lean.ofReduceBool` dependency."
+    ],
+    "prerequisites": [
+      "WilsonsTheoremOQ03 (Legendre's formula) — the parent digit-sum machinery",
+      "Mathlib `sub_one_mul_padicValNat_choose_eq_sub_sum_digits` (Kummer's identity)",
+      "Nat.digits API: `Nat.digits_def'`, `Nat.getLast_digit_ne_zero`, `Nat.digits_ne_nil_iff_ne_zero`",
+      "padicValNat divisibility API: `padicValNat.eq_zero_of_not_dvd`, `one_le_padicValNat_of_dvd`, `pow_padicValNat_dvd`",
+      "Nat.centralBinom and `Nat.centralBinom_eq_two_mul_choose`"
+    ]
+  },
+  "sections": [
+    {
+      "id": "section-header",
+      "title": "Motivation and Honest Scope",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "File docstring deriving Kummer's identity from the parent's Legendre digit-sum formula via n! = C(n,k)·k!·(n-k)!, and stating precisely what is new relative to Mathlib: the exact-valuation consequences (2-adic central-binomial popcount, evenness characterization, power-of-two sharpness, no-carry criterion) rather than Kummer's identity itself, which Mathlib already has. Imports Mathlib, namespace WilsonsTheoremCentralBinom, open Nat."
+    },
+    {
+      "id": "section-digit-infra",
+      "title": "Base-2 Digit-Sum Infrastructure",
+      "startLine": 53,
+      "endLine": 86,
+      "summary": "digit_sum_two_mul: a binary left shift leaves the digit sum unchanged, S₂(2n) = S₂(n). digit_two_sum_pos: the base-2 digit sum is positive for n ≥ 1 (top digit nonzero and in the list). digit_sum_two_pow: S₂(2^m) = 1 by induction, each step a left shift."
+    },
+    {
+      "id": "section-central-binom",
+      "title": "The 2-adic Valuation of the Central Binomial Coefficient",
+      "startLine": 87,
+      "endLine": 132,
+      "summary": "padicValNat_centralBinom_two (flagship): ν₂(C(2n,n)) = S₂(n), the popcount identity, via Mathlib's Kummer digit-sum lemma and the left-shift collapse 2·S₂(n) − S₂(2n) = S₂(n). centralBinom_two_dvd_iff: 2 ∣ C(2n,n) ↔ n ≠ 0. centralBinom_two_pow_valuation: ν₂(C(2^{m+1},2^m)) = 1, so the popcount bound is sharp at powers of two."
+    },
+    {
+      "id": "section-no-carry",
+      "title": "Kummer's No-Carry Criterion (general prime)",
+      "startLine": 133,
+      "endLine": 165,
+      "summary": "not_dvd_choose_iff: for k ≤ n and prime p, p ∤ C(n,k) ↔ S_p(k) + S_p(n−k) ≤ S_p(n) — no carries when adding k and n−k in base p. Reduces divisibility to a digit-sum inequality via ν_p = 0 ⟺ (p−1)·ν_p = 0 and Kummer's identity, closed by omega."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verifies, axiom-free, the exact-valuation consequences of Kummer's digit-sum theorem that Mathlib does not record: the 2-adic valuation of the central binomial coefficient C(2n,n) equals the popcount S₂(n) of n; C(2n,n) is even iff n ≠ 0; the valuation is exactly 1 at powers of two (C(2^{m+1},2^m) ≡ 2 mod 4); and Kummer's no-carry divisibility criterion p ∤ C(n,k) ↔ S_p(k)+S_p(n−k) ≤ S_p(n). 7 theorems, 0 definitions, 0 axioms, 165 lines.",
+    "implications": "This closes the loop opened by the parent entry's cross-reference to Kummer's theorem: Legendre's digit-sum formula, applied to a binomial coefficient, gives not just Kummer's identity (already in Mathlib) but sharp exact-valuation facts. The central-binomial popcount identity ν₂(C(2n,n)) = S₂(n) is the quantitative refinement of \"C(2n,n) is even\" and is the kind of statement that appears in analytic number theory (e.g. lower bounds on C(2n,n) used in elementary proofs of Bertrand's postulate) and in the study of the Stern–Brocot / ruler sequences. The general no-carry criterion is the classical route to Lucas-type divisibility results.",
+    "openQuestions": [
+      "Prove Lucas's theorem digitwise from the same machinery: C(n,k) ≡ ∏_i C(n_i, k_i) (mod p) where n_i, k_i are the base-p digits, sharpening the no-carry criterion from a divisibility statement to a congruence.",
+      "Give the exact p-adic valuation of the central binomial for odd primes, ν_p(C(2n,n)) = (2·S_p(n) − S_p(2n))/(p−1), and characterize the primes p ≤ 2n that divide C(2n,n) (the carry set), as used in elementary Bertrand-postulate arguments.",
+      "Formalize digit-sum subadditivity S_p(a+b) ≤ S_p(a) + S_p(b) to upgrade the no-carry criterion from the inequality form to the classical equality S_p(k) + S_p(n−k) = S_p(n)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "wilsons-theorem-oq-03",
+      "relationship": "parent",
+      "description": "Legendre's formula (p−1)·ν_p(n!) = n − S_p(n); applied to n! = C(n,k)·k!·(n−k)! it yields the Kummer digit-sum identity this entry builds on."
+    },
+    {
+      "targetId": "wilsons-theorem",
+      "relationship": "ancestor",
+      "description": "Wilson's theorem — the root of this OQ chain; Legendre's formula gives its non-divisibility direction."
+    },
+    {
+      "targetId": "kummer-theorem-oq-01",
+      "relationship": "sibling",
+      "description": "Kummer's theorem on ν_p(C(m+n,m)) as a base-p carry count; this entry supplies the exact-valuation corollaries (central-binomial popcount, no-carry criterion)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Kummer, Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen (1852)",
+      "url": "https://en.wikipedia.org/wiki/Kummer%27s_theorem"
+    },
+    {
+      "title": "Legendre's formula",
+      "url": "https://en.wikipedia.org/wiki/Legendre%27s_formula"
+    },
+    {
+      "title": "Central binomial coefficient",
+      "url": "https://en.wikipedia.org/wiki/Central_binomial_coefficient"
+    }
+  ],
+  "sorries": [],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Nat"],
+    "namespace": "WilsonsTheoremCentralBinom",
+    "lineCount": 165,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/WilsonsTheoremOQ03OQ03.lean"
+  },
+  "meta": {
+    "author": "Ernst Kummer (1852) / classical folklore, formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Kummer%27s_theorem",
+    "date": "1852",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "p-adic",
+      "binomial-coefficients",
+      "central-binomial",
+      "kummer",
+      "legendre",
+      "digit-sum",
+      "popcount",
+      "wilsons-theorem",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ03OQ03.lean",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All seven theorems are fully proved from Mathlib and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (confirmed by #print axioms). There are no literal `axiom` declarations, no structure-encoded assumptions, and — unlike the parent entry — no `native_decide`, so the entry does not depend on `Lean.ofReduceBool`.",
+    "dateAdded": "2026-07-01",
+    "lineCount": 165,
+    "definitionCount": 0,
+    "theoremCount": 7,
+    "mathlibDependencies": [
+      {
+        "theorem": "sub_one_mul_padicValNat_choose_eq_sub_sum_digits",
+        "description": "Kummer's identity: (p-1)·ν_p(C(n,k)) = S_p(k) + S_p(n-k) - S_p(n)",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom n = choose (2n) n",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.digits_def'",
+        "description": "recursive base-b digit expansion m = m%b :: digits b (m/b)",
+        "module": "Mathlib.Data.Nat.Digits.Defs"
+      },
+      {
+        "theorem": "Nat.getLast_digit_ne_zero",
+        "description": "the top base-b digit of a nonzero number is nonzero",
+        "module": "Mathlib.Data.Nat.Digits.Lemmas"
+      },
+      {
+        "theorem": "pow_padicValNat_dvd",
+        "description": "p ^ ν_p(n) ∣ n",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "one_le_padicValNat_of_dvd",
+        "description": "p ∣ n, n ≠ 0 ⟹ 1 ≤ ν_p(n)",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      }
+    ],
+    "originalContributions": [
+      "ν₂(C(2n,n)) = S₂(n): the 2-adic valuation of the central binomial coefficient equals the binary popcount of n (exact-valuation refinement of the classical evenness fact; not in Mathlib)",
+      "Characterization 2 ∣ C(2n,n) ↔ n ≠ 0 (central binomial is even except at n = 0)",
+      "Sharpness at powers of two: ν₂(C(2^{m+1},2^m)) = 1, hence C(2^{m+1},2^m) ≡ 2 (mod 4)",
+      "Kummer's no-carry divisibility criterion in digit-sum form: p ∤ C(n,k) ↔ S_p(k) + S_p(n-k) ≤ S_p(n)",
+      "Reusable base-2 digit-sum lemmas: left-shift invariance S₂(2n) = S₂(n), positivity for n ≥ 1, and S₂(2^m) = 1"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers a distinct facet of the open question posed by **wilsons-theorem-oq-03** ("Legendre's Formula: p-adic Valuation of n!"):

> *What does Legendre's digit-sum formula say about binomial coefficients — in particular, exactly how even is the central binomial coefficient C(2n,n)?*

Applying the parent's Legendre identity `(p−1)·ν_p(n!) = n − S_p(n)` three times to `n! = C(n,k)·k!·(n−k)!` gives **Kummer's theorem** (already in Mathlib as `sub_one_mul_padicValNat_choose_eq_sub_sum_digits`). This entry supplies the **exact-valuation consequences Mathlib does not record**:

- **`padicValNat_centralBinom_two`** — `ν₂(C(2n,n)) = S₂(n)`: the 2-adic valuation of the central binomial coefficient equals the number of 1-bits in the binary expansion of n (its popcount). The sharp form of the classical fact "C(2n,n) is even".
- `centralBinom_two_dvd_iff` — `2 ∣ C(2n,n) ↔ n ≠ 0` (even except at n = 0).
- `centralBinom_two_pow_valuation` — `ν₂(C(2^{m+1},2^m)) = 1`, so the popcount bound is sharp at powers of two: `C(2^{m+1},2^m) ≡ 2 (mod 4)`.
- `not_dvd_choose_iff` — Kummer's no-carry criterion (general prime): `p ∤ C(n,k) ↔ S_p(k) + S_p(n−k) ≤ S_p(n)`.
- Reusable base-2 digit-sum infrastructure: left-shift invariance `S₂(2n) = S₂(n)`, positivity for n ≥ 1, and `S₂(2^m) = 1`.

## Verification

- **7 theorems, 0 definitions, 165 lines, 0 sorries.**
- Fully symbolic — **no `native_decide`**, so unlike the parent entry this carries **no `Lean.ofReduceBool` dependency**.
- `#print axioms` on all four headline theorems: `propext / Classical.choice / Quot.sound` only → **0-axiom, verified**.
- Compiled non-destructively against the repo-root Mathlib cache (`lake env lean`).

## Relation to concurrent work

This is a **distinct sibling** of the multinomial-Legendre/Kummer entries (#32752, #32760), which answer the *multinomial coefficient* facet of the same parent question under slug `oq-03-oq-01`. This entry takes the disjoint *central-binomial / no-carry* facet and uses a fresh slug `oq-03-oq-03` (`oq-03-oq-02` is the merged composite-converse entry) — no file, slug, or content overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)