### PR TITLE
Enrich factorial moment (combinations-formula-oq-09-oq-01): metadata + header annotation

### DIFF
--- a/src/data/proofs/combinations-formula-oq-09-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-09-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "combinations-formula-oq-09-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "context",
+    "title": "The General Factorial Moment of a Binomial Row",
+    "content": "For a fixed row n of Pascal’s triangle and any order j, the j-th falling-factorial moment has the closed form ∑_{k=0}^{n} (k)_j·C(n,k) = (n)_j·2^{n-j}, where (m)_j = Nat.descFactorial m j. This uniformly generalises the parent entry combinations-formula-oq-09, which handled only j=1 (∑ k·C(n,k)=n·2^{n-1}) and j=2. The parent’s open question asked whether the peel-then-absorb pattern extends to all j; the answer is yes, and the cleanest route is a single subset-of-a-subset reindexing rather than iterated peeling. Phrasing the moment in the falling-factorial basis (not ordinary powers) is what avoids Stirling numbers.",
+    "mathContext": "$\\sum_{k=0}^{n}(k)_j\\binom{n}{k}=(n)_j\\,2^{n-j}$, with $(m)_j=\\mathrm{descFactorial}\\,m\\,j$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "falling factorial",
+      "factorial moment",
+      "binomial coefficients",
+      "Stirling numbers (avoided)"
+    ],
+    "prerequisites": [
+      "the parent first/second moments (combinations-formula-oq-09)",
+      "descFactorial",
+      "binomial row sums"
+    ]
+  },
+  {
     "id": "ann-pointwise-shift",
     "proofId": "combinations-formula-oq-09-oq-01",
     "range": {
@@ -8,7 +32,20 @@
     },
     "type": "theorem",
     "title": "Pointwise Reindexed Identity via Subset-of-a-Subset",
-    "content": "descFactorial_choose_shift is the engine of the whole entry: after shifting the summation index by j, the weighted binomial term factors as (j+i)_j·C(n,j+i) = (n)_j·C(n-j,i). The proof expands each falling factorial as (m)_j = j!·C(m,j) (Nat.descFactorial_eq_factorial_mul_choose) and applies the trinomial-revision identity C(n,j+i)·C(j+i,j) = C(n,j)·C(n-j,i) (Nat.choose_mul), using (j+i)-j = i. This one reindexing replaces the j-fold iterated absorption the parent used for j=1,2."
+    "content": "descFactorial_choose_shift is the engine of the whole entry: after shifting the summation index by j, the weighted binomial term factors as (j+i)_j·C(n,j+i) = (n)_j·C(n-j,i). The proof expands each falling factorial as (m)_j = j!·C(m,j) (Nat.descFactorial_eq_factorial_mul_choose) and applies the trinomial-revision identity C(n,j+i)·C(j+i,j) = C(n,j)·C(n-j,i) (Nat.choose_mul), using (j+i)-j = i. This one reindexing replaces the j-fold iterated absorption the parent used for j=1,2.",
+    "mathContext": "$(j+i)_j\\binom{n}{j+i}=(n)_j\\binom{n-j}{i}$, via $(m)_j=j!\\binom{m}{j}$ and $\\binom{n}{k}\\binom{k}{j}=\\binom{n}{j}\\binom{n-j}{k-j}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.descFactorial_eq_factorial_mul_choose",
+      "Nat.choose_mul",
+      "trinomial revision / subset-of-a-subset",
+      "index shift"
+    ],
+    "prerequisites": [
+      "falling factorial as j!·C(m,j)",
+      "the subset-of-a-subset identity",
+      "reindexing a sum"
+    ]
   },
   {
     "id": "ann-factorial-moment",
@@ -19,7 +56,20 @@
     },
     "type": "theorem",
     "title": "The General j-th Factorial Moment",
-    "content": "factorial_moment is the headline result: ∑_{k=0}^{n} (k)_j·C(n,k) = (n)_j·2^{n-j}, holding unconditionally in j. For j ≤ n the head terms k<j vanish (Nat.descFactorial k j = 0), so the sum reduces to Ico j (n+1); shifting k = j+i (Finset.sum_Ico_eq_sum_range) and applying descFactorial_choose_shift pulls the constant (n)_j out, leaving the shorter row sum ∑_i C(n-j,i) = 2^{n-j} (Nat.sum_range_choose). For j > n both sides are 0."
+    "content": "factorial_moment is the headline result: ∑_{k=0}^{n} (k)_j·C(n,k) = (n)_j·2^{n-j}, holding unconditionally in j. For j ≤ n the head terms k<j vanish (Nat.descFactorial k j = 0), so the sum reduces to Ico j (n+1); shifting k = j+i (Finset.sum_Ico_eq_sum_range) and applying descFactorial_choose_shift pulls the constant (n)_j out, leaving the shorter row sum ∑_i C(n-j,i) = 2^{n-j} (Nat.sum_range_choose). For j > n both sides are 0.",
+    "mathContext": "$\\sum_{k\\in\\mathrm{range}(n+1)}(k)_j\\binom{n}{k}=(n)_j\\,2^{n-j}$, unconditional in $j$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_Ico_eq_sum_range",
+      "Nat.sum_range_choose",
+      "descFactorial vanishing for k<j",
+      "row sum 2^{n-j}"
+    ],
+    "prerequisites": [
+      "descFactorial_choose_shift",
+      "vanishing head terms",
+      "∑ C(m,i)=2^m"
+    ]
   },
   {
     "id": "ann-first-moment-recovered",
@@ -30,7 +80,18 @@
     },
     "type": "theorem",
     "title": "First Moment Recovered (j = 1)",
-    "content": "sum_range_choose_mul_id specializes the general theorem to j = 1, recovering the parent entry's first moment ∑ k·C(n,k) = n·2^{n-1} through (m)_1 = m (Nat.descFactorial_one). This exhibits the parent's result as a single instance of the uniform identity."
+    "content": "sum_range_choose_mul_id specializes the general theorem to j = 1, recovering the parent entry's first moment ∑ k·C(n,k) = n·2^{n-1} through (m)_1 = m (Nat.descFactorial_one). This exhibits the parent's result as a single instance of the uniform identity.",
+    "mathContext": "$j=1$: $(m)_1=m$, so $\\sum k\\binom{n}{k}=n\\,2^{n-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.descFactorial_one",
+      "first moment",
+      "specialisation of the general theorem"
+    ],
+    "prerequisites": [
+      "the general factorial moment",
+      "(m)_1 = m"
+    ]
   },
   {
     "id": "ann-second-factorial-moment",
@@ -41,7 +102,19 @@
     },
     "type": "theorem",
     "title": "Second Factorial Moment (j = 2)",
-    "content": "sum_range_choose_mul_pred_mul gives the expanded j = 2 instance ∑ (k-1)·k·C(n,k) = (n-1)·n·2^{n-2}, using descFactorial_two: (m)_2 = (m-1)·m. Together with the first moment and k² = (k-1)·k + k this reconstructs the parent's ordinary second moment ∑ k²·C(n,k)."
+    "content": "sum_range_choose_mul_pred_mul gives the expanded j = 2 instance ∑ (k-1)·k·C(n,k) = (n-1)·n·2^{n-2}, using descFactorial_two: (m)_2 = (m-1)·m. Together with the first moment and k² = (k-1)·k + k this reconstructs the parent's ordinary second moment ∑ k²·C(n,k).",
+    "mathContext": "$j=2$: $(m)_2=(m-1)m$, so $\\sum (k-1)k\\binom{n}{k}=(n-1)n\\,2^{n-2}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "descFactorial_two",
+      "second factorial moment",
+      "reconstructing ∑ k²C(n,k)",
+      "k²=(k-1)k+k"
+    ],
+    "prerequisites": [
+      "the general factorial moment",
+      "(m)_2 = (m-1)m"
+    ]
   },
   {
     "id": "ann-checks",
@@ -52,6 +125,18 @@
     },
     "type": "example",
     "title": "Higher-Order Numerical Verifications",
-    "content": "The base case j=0 recovers ∑ C(n,k) = 2^n, and the worked instances ∑_{k≤4} (k)_2·C(4,k) = 48 = (4)_2·2² and ∑_{k≤5} (k)_3·C(5,k) = 240 = (5)_3·2² confirm the closed form at orders the parent's first/second-moment results cannot reach. All are decided, adding no Lean.ofReduceBool axiom."
+    "content": "The base case j=0 recovers ∑ C(n,k) = 2^n, and the worked instances ∑_{k≤4} (k)_2·C(4,k) = 48 = (4)_2·2² and ∑_{k≤5} (k)_3·C(5,k) = 240 = (5)_3·2² confirm the closed form at orders the parent's first/second-moment results cannot reach. All are decided, adding no Lean.ofReduceBool axiom.",
+    "mathContext": "$j=0$: $\\sum\\binom{n}{k}=2^n$; e.g. $\\sum_{k\\le4}(k)_2\\binom{4}{k}=48$, $\\sum_{k\\le5}(k)_3\\binom{5}{k}=240$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "base case j=0",
+      "worked numerical instances",
+      "decide without native_decide",
+      "higher-order moments"
+    ],
+    "prerequisites": [
+      "the general factorial moment",
+      "evaluating small cases"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass — `combinations-formula-oq-09-oq-01`

Two gaps addressed:

1. **Missing metadata** — the 5 existing annotations had only `content`/`title`/`type`. Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to each. Existing `content`/`title` left unchanged (verified programmatically).
2. **Uncovered header** — lines 1–56 (the module docstring explaining the falling-factorial-moment closed form and its subset-of-a-subset mechanism) had no annotation. Added `ann-header`.

Coverage now spans lines 1–155. meta.json untouched.