### PR TITLE
Enrich Constructive Kuhn Path-Following (sperner-ndim-oq-06): add conclusion

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-06/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-06/meta.json
@@ -118,5 +118,15 @@
       "summary": "On the packaged structure, from any source door the walk terminates within Fintype.card V pivots at a fully-coloured simplex.",
       "mathContext": "reaches_terminal and exists_terminal instantiate the abstract engine with the derived hypotheses."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "The entry isolates and machine-checks, with 0 axioms, the purely combinatorial engine that makes Kuhn's constructive proof of Sperner's lemma terminate. The door-pivot rule is abstracted as a partial successor f : V → Option V on a finite door set (none = an FC simplex has been entered). From just two hypotheses — reversibility of pivoting away from terminal rooms (injectivity wherever f x ≠ none) and a source start door (v₀ has no predecessor) — the main theorem reaches_none proves the walk hits none within Fintype.card V steps, and exists_terminal_door extracts the last door before termination as a genuine fully-coloured door. The KuhnPivot structure then derives both hypotheses from a single symmetric-adjacency field, so a geometric user supplies only reversibility.",
+    "implications": "This supplies exactly the acyclicity/termination step that the geometric entry sperner-ndim-oq-04 leaves axiomatized (bdry_all_even_of_no_fc_walks): the abstract 'the walk actually reaches an FC simplex' fact is now a theorem rather than an assumption, and the step bound Fintype.card V is O(N^d) on the N-fold Kuhn subdivision of a d-simplex, matching the algorithm's known polynomial running time. The same engine underlies every complementary-pivot method — Scarf's fixed-point pivoting, Lemke–Howson for Nash equilibria — whose correctness rests on the degree-≤-2 structure of the pivot graph, the combinatorial signature of the complexity class PPAD for which Sperner's lemma is complete. It is the constructive counterpart of the parity engine (SpernerTuckerPathFollowing.lean): parity proves an FC simplex EXISTS; this engine proves the walk REACHES one, deterministically and in bounded time.",
+    "openQuestions": [
+      "Can the abstract engine be linked to the concrete geometric door graph of sperner-ndim-oq-04 to fully de-axiomatize that entry, by exhibiting the geometric succ/pred as a KuhnPivot instance?",
+      "Does the same Option-valued successor framework capture Scarf's algorithm and Lemke–Howson path-following, giving a single reusable PPAD termination lemma?",
+      "Can the O(N^d) door-count bound be sharpened to the actual path length, or shown tight by exhibiting a subdivision whose walk visits a constant fraction of all doors (the exponential-path phenomenon known for some complementary-pivot instances)?",
+      "Is there a formal reduction certifying that this constructive walk and the mod-2 parity count locate the same FC simplex, connecting the algorithmic and enumerative proofs of Sperner's lemma?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `sperner-ndim-oq-06`.

**Gap found:** the entry already ships a rich `meta.json` (long historicalContext, proofStrategy, 5 keyInsights, prerequisites, 7 sections) and a complete `annotations.json` (8 annotations, all with mathContext/significance/relatedConcepts). The one missing quality-target field was **`conclusion`**.

**Added `conclusion` to meta.json:**
- `summary` — recaps the 0-axiom combinatorial termination engine (partial successor on Option V, source + reversibility hypotheses, KuhnPivot packaging)
- `implications` — ties it to the axiomatized step in sperner-ndim-oq-04, the O(N^d) door bound, PPAD, and complementary-pivot algorithms (Scarf, Lemke–Howson); frames it as the constructive counterpart of the parity engine
- `openQuestions` (4) — de-axiomatize oq-04 via a concrete KuhnPivot instance, unify Scarf/Lemke–Howson under one termination lemma, sharpen/tighten the O(N^d) bound, formally link the walk to the mod-2 parity count

meta.json 10.9KB → 13.5KB (well under the ~60KB cap). Annotations unchanged; content preserved byte-for-byte. Status/badge/axiomCount unchanged (verified, 0 axioms — accurate).