### PR TITLE
Enrich euler-totient-oq-02-oq-02-oq-01: annotate λ(n) positivity (5→6)

### DIFF
--- a/src/data/proofs/euler-totient-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-02-oq-01/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-bridge",
     "proofId": "euler-totient-oq-02-oq-02-oq-01",
-    "range": { "startLine": 60, "endLine": 62 },
+    "range": {
+      "startLine": 60,
+      "endLine": 62
+    },
     "type": "insight",
     "title": "The Arithmetic ⇄ Group Dictionary",
     "content": "Every congruence in this file is translated into an equation in `ZMod n` by one lemma:\n```\ntheorem modEq_one_iff_cast_pow {a m : ℕ} :\n    a ^ m ≡ 1 [MOD n] ↔ (a : ZMod n) ^ m = 1 := by\n  rw [← ZMod.natCast_eq_natCast_iff, Nat.cast_pow, Nat.cast_one]\n```\nThe parent entry lives in the number-theoretic world of `Nat.ModEq`; Mathlib's Carmichael function `pow_carmichael` lives in the group `(ℤ/nℤ)ˣ`. This lemma is the hinge between them, letting us pull Mathlib's group facts down to `a^m ≡ 1 (mod n)` and push arithmetic hypotheses up to units.",
@@ -13,12 +16,17 @@
       "Nat.ModEq",
       "ZMod"
     ],
-    "prerequisites": ["euler-totient-oq-02-oq-02"]
+    "prerequisites": [
+      "euler-totient-oq-02-oq-02"
+    ]
   },
   {
     "id": "ann-universal",
     "proofId": "euler-totient-oq-02-oq-02-oq-01",
-    "range": { "startLine": 71, "endLine": 75 },
+    "range": {
+      "startLine": 71,
+      "endLine": 75
+    },
     "type": "insight",
     "title": "λ(n) is a Universal Exponent, in ModEq Form",
     "content": "The number-theoretic shadow of Mathlib's group statement `pow_carmichael`:\n```\ntheorem carmichael_modEq {a : ℕ} (h : Nat.Coprime a n) :\n    a ^ Carmichael n ≡ 1 [MOD n] := by\n  rw [modEq_one_iff_cast_pow]\n  have hu : IsUnit (a : ZMod n) := (ZMod.isUnit_iff_coprime a n).mpr h\n  rw [← hu.unit_spec, ← Units.val_pow_eq_pow_val, pow_carmichael, Units.val_one]\n```\nA coprime residue `a` is a unit of `ℤ/nℤ`, and the group exponent λ(n) kills every unit. This is the Carmichael analogue of the parent's `euler_modEq` — but with the *minimal* exponent λ(n) in place of φ(n).",
@@ -30,12 +38,40 @@
       "ZMod.isUnit_iff_coprime",
       "universal exponent"
     ],
-    "prerequisites": ["euler-totient-oq-02-oq-02"]
+    "prerequisites": [
+      "euler-totient-oq-02-oq-02"
+    ]
+  },
+  {
+    "id": "ann-euler-carmichael-positive",
+    "proofId": "euler-totient-oq-02-oq-02-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 85
+    },
+    "type": "theorem",
+    "title": "λ(n) Is Positive: the Unit Group Is Finite",
+    "content": "For n ≠ 0, the Carmichael function λ(n) is nonzero, and hence strictly positive. The proof routes through carmichael_eq_exponent': λ(n) is the exponent of the finite group (ZMod n)ˣ, and a finite monoid always has nonzero exponent (Monoid.exponent_ne_zero_of_finite). Positivity (carmichael_pos) is then the one-line corollary Nat.pos_of_ne_zero. This basic fact is a silent prerequisite for everything that follows: it is what makes λ(n) a legitimate modulus in the reductions a^k mod λ(n), and what lets the divisibility characterisation λ(n) ∣ m speak about a genuine positive generator rather than a degenerate zero.",
+    "mathContext": "The exponent of a finite group is the lcm of all element orders, a positive integer; NeZero n is exactly the hypothesis that makes (ZMod n)ˣ a nonempty finite group.",
+    "significance": "Guarantees λ(n) is a well-defined positive exponent, so the later least-universal-exponent and a^k mod λ(n) results are non-vacuous.",
+    "relatedConcepts": [
+      "group exponent",
+      "finite group",
+      "Carmichael function",
+      "order of an element"
+    ],
+    "prerequisites": [
+      "exponent of a finite group",
+      "NeZero typeclass"
+    ]
   },
   {
     "id": "ann-least",
     "proofId": "euler-totient-oq-02-oq-02-oq-01",
-    "range": { "startLine": 98, "endLine": 134 },
+    "range": {
+      "startLine": 98,
+      "endLine": 134
+    },
     "type": "insight",
     "title": "The Exact Characterisation: λ(n) is the Least Universal Exponent",
     "content": "The heart of the entry. Universal exponents are exactly the multiples of λ(n):\n```\ntheorem carmichael_dvd_iff [NeZero n] {m : ℕ} :\n    Carmichael n ∣ m ↔ ∀ a : ℕ, Nat.Coprime a n → a ^ m ≡ 1 [MOD n]\n```\nThe backward direction is the crux: to conclude `exponent ∣ m` from `Monoid.exponent_dvd_iff_forall_pow_eq_one`, one must show `u^m = 1` for every unit `u`. Each unit is realised by the coprime natural `u.val` (`ZMod.val_coe_unit_coprime`), and `natCast_zmod_val` closes `(u.val : ZMod n) = u`. `carmichael_isLeast_universal` then packages this as an `IsLeast` statement — λ(n) is genuinely the least positive universal exponent, the sense in which it is the *true* universal exponent that the parent's φ(n) only approximates.",
@@ -47,12 +83,17 @@
       "IsLeast",
       "least universal exponent"
     ],
-    "prerequisites": ["euler-totient-oq-02-oq-02"]
+    "prerequisites": [
+      "euler-totient-oq-02-oq-02"
+    ]
   },
   {
     "id": "ann-refines",
     "proofId": "euler-totient-oq-02-oq-02-oq-01",
-    "range": { "startLine": 142, "endLine": 167 },
+    "range": {
+      "startLine": 142,
+      "endLine": 167
+    },
     "type": "insight",
     "title": "λ Refines the Parent: orderOf a ∣ λ(n) ∣ φ(n)",
     "content": "The parent's main theorem factors through λ:\n```\ntheorem orderOf_unit_dvd_totient_via_carmichael [NeZero n] (a : (ZMod n)ˣ) :\n    orderOf a ∣ n.totient :=\n  (orderOf_unit_dvd_carmichael a).trans (ArithmeticFunction.carmichael_dvd_totient n)\n```\nThe parent proved `orderOf a ∣ φ(n)` directly. Here it is a *consequence* of the sharper `orderOf a ∣ λ(n)` composed with `λ(n) ∣ φ(n)`, exhibiting λ(n) as the true bottleneck. `pow_mod_carmichael_modEq` correspondingly sharpens exponent reduction to `a^k ≡ a^(k % λ(n))` — the smallest period valid uniformly over all coprime bases.",
@@ -63,12 +104,17 @@
       "carmichael_dvd_totient",
       "exponent reduction"
     ],
-    "prerequisites": ["euler-totient-oq-02-oq-02"]
+    "prerequisites": [
+      "euler-totient-oq-02-oq-02"
+    ]
   },
   {
     "id": "ann-boundary",
     "proofId": "euler-totient-oq-02-oq-02-oq-01",
-    "range": { "startLine": 176, "endLine": 221 },
+    "range": {
+      "startLine": 176,
+      "endLine": 221
+    },
     "type": "insight",
     "title": "The Boundary: λ(n) = φ(n) ⟺ Cyclic, Strict at n = 8",
     "content": "When do the Carmichael and Euler exponents agree?\n```\ntheorem carmichael_eq_totient_iff_isCyclic [NeZero n] :\n    Carmichael n = n.totient ↔ IsCyclic (ZMod n)ˣ\n```\nExactly when `(ℤ/nℤ)ˣ` is cyclic — i.e. when `n` has a primitive root (`n ∈ {1,2,4,pᵏ,2pᵏ}`) — via `IsCyclic.iff_exponent_eq_card`. Off this locus λ is strictly smaller. The sharp examples: `carmichael_prime` gives `λ(p) = φ(p) = p-1` at every prime, while `carmichael_eight_lt_totient` gives `λ(8) = 2 < 4 = φ(8)`, the smallest witness, obtained from the abstract non-cyclic criterion and `ZMod.not_isCyclic_units_eight` — no `native_decide`, so still 0-axiom.",
@@ -80,6 +126,8 @@
       "primitive root",
       "carmichael_two_pow_of_ne_two"
     ],
-    "prerequisites": ["euler-totient-oq-02-oq-02"]
+    "prerequisites": [
+      "euler-totient-oq-02-oq-02"
+    ]
   }
 ]


### PR DESCRIPTION
## Coverage-gap enrichment

`euler-totient-oq-02-oq-02-oq-01` (Carmichael function λ(n) as the least universal exponent) had 5 annotations leaving a SECTION-II interior gap: `carmichael_ne_zero` and `carmichael_pos` were the only uncovered declarations. This adds one annotation (5→6) covering both.

### New annotation
| Lines | Type | Covers |
|-------|------|--------|
| 79–85 | theorem | `carmichael_ne_zero`, `carmichael_pos` — λ(n) is nonzero/positive for n ≠ 0, because it is the exponent of the finite unit group (ZMod n)ˣ |

The annotation notes this is a silent prerequisite for the later `a^k mod λ(n)` reductions and the divisibility characterisation to be non-vacuous. Carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

### Validation
`validateLineAnnotations`: all 6 annotations valid, 0 misaligned. No changes to the Lean proof, meta.json, sorries, or axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)