### PR TITLE
research(pythagorean-theorem-oq-04-oq-01): canonical Gaussian generator — promote up-to-sign uniqueness to ∃! [VERIFIED, 0-axiom, 7thm+1def]

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ04OQ01.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ04OQ01.lean
@@ -1,0 +1,164 @@
+import Proofs.PythagoreanTheoremOQ04
+import Mathlib.Tactic
+
+/-!
+# The canonical Gaussian generator of a primitive triple (pythagorean-theorem-oq-04-oq-01)
+
+## What this proves
+
+`pythagorean-theorem-oq-04` establishes that every primitive Pythagorean triple `(x, y, z)`
+(with `x` odd, `z > 0`) is the square of a Gaussian integer `g = m + ni`, and that this
+generator is unique *up to sign*: any two generators `g, h` of the same triple satisfy
+`g = h` or `g = -h` (`generator_unique_up_to_sign`).
+
+This file **promotes the up-to-sign uniqueness to a genuine `∃!`** by pinning the sign.
+
+* **Canonical sign form.** Call `g = a + bi` *canonical* (`IsCanonical`) when `a > 0`, or
+  `a = 0` and `b > 0`. For every nonzero `g`, exactly one of `g` and `-g` is canonical
+  (`isCanonical_or_neg`, `not_isCanonical_neg_of_isCanonical`) — so canonicity selects a
+  distinguished representative of the sign pair `{g, -g}`.
+
+* **Existence & uniqueness of the canonical generator** (`canonical_generator_existsUnique`).
+  Combining completeness (`gaussian_completeness`) with up-to-sign uniqueness, every
+  primitive triple has *exactly one* canonical Gaussian generator `g` with `x + yi = g²`.
+
+* **The fibre has exactly two points** (`sqRoots_eq_pair`, `sqRoots_ncard_two`). The set of
+  Gaussian square roots of `x + yi` is precisely `{g, -g}`, a two-element set (squaring is
+  two-to-one in the domain `ℤ[i]`). Fixing the sign picks one of the two.
+
+Together these upgrade "unique up to `{±1}`" into a bona-fide classification: primitive
+triples correspond bijectively to *canonical* Gaussian generators.
+
+## Status
+
+- [x] Complete proof, no sorries
+- [x] 0 `axiom` declarations, no structure-encoded assumptions
+- [x] Reuses only the verified parent entry `PythagoreanTheoremOQ04`
+-/
+
+namespace PythagoreanTheoremOQ04OQ01
+
+open Zsqrtd PythagoreanTheoremOQ04
+
+local notation "ℤ[i]" => GaussianInt
+
+/-! ## Canonical sign form -/
+
+/-- A Gaussian integer `a + bi` is in **canonical sign form** when its real part is
+positive, or it is purely imaginary with positive imaginary part. This picks out a
+distinguished representative of each sign pair `{g, -g}`. -/
+def IsCanonical (g : ℤ[i]) : Prop := 0 < g.re ∨ (g.re = 0 ∧ 0 < g.im)
+
+/-- `g` and `-g` are never both canonical. -/
+theorem not_isCanonical_neg_of_isCanonical {g : ℤ[i]} (h : IsCanonical g) :
+    ¬ IsCanonical (-g) := by
+  rcases h with hre | ⟨hre0, him⟩ <;>
+    rintro (hre' | ⟨hre0', him'⟩) <;>
+      simp only [Zsqrtd.re_neg, Zsqrtd.im_neg] at * <;> omega
+
+/-- For a nonzero Gaussian integer, at least one of `g` and `-g` is canonical. -/
+theorem isCanonical_or_neg {g : ℤ[i]} (hg : g ≠ 0) :
+    IsCanonical g ∨ IsCanonical (-g) := by
+  have hne : g.re ≠ 0 ∨ g.im ≠ 0 := by
+    by_contra h
+    push_neg at h
+    apply hg
+    apply Zsqrtd.ext
+    · simpa using h.1
+    · simpa using h.2
+  unfold IsCanonical
+  simp only [Zsqrtd.re_neg, Zsqrtd.im_neg]
+  omega
+
+/-- Exactly one of `g` and `-g` is canonical (for `g ≠ 0`): canonicity is a genuine
+sign-selection. -/
+theorem isCanonical_xor_neg {g : ℤ[i]} (hg : g ≠ 0) :
+    (IsCanonical g ∧ ¬ IsCanonical (-g)) ∨ (¬ IsCanonical g ∧ IsCanonical (-g)) := by
+  rcases isCanonical_or_neg hg with h | h
+  · exact Or.inl ⟨h, not_isCanonical_neg_of_isCanonical h⟩
+  · refine Or.inr ⟨fun hc => not_isCanonical_neg_of_isCanonical hc h, h⟩
+
+/-! ## The square-root fibre `{g, -g}` -/
+
+/-- The set of Gaussian square roots of `w = g²` is exactly the sign pair `{g, -g}`. -/
+theorem sqRoots_eq_pair (w g : ℤ[i]) (hg : w = g ^ 2) :
+    {h : ℤ[i] | h ^ 2 = w} = {g, -g} := by
+  ext h
+  simp only [Set.mem_setOf_eq, Set.mem_insert_iff, Set.mem_singleton_iff]
+  rw [hg]
+  exact gaussianInt_sq_eq_iff h g
+
+/-- A nonzero Gaussian integer differs from its negative. -/
+theorem ne_neg_self {g : ℤ[i]} (hg : g ≠ 0) : g ≠ -g := by
+  intro hgg
+  apply hg
+  have hre := congrArg Zsqrtd.re hgg
+  have him := congrArg Zsqrtd.im hgg
+  simp only [Zsqrtd.re_neg, Zsqrtd.im_neg] at hre him
+  apply Zsqrtd.ext
+  · simpa using (by omega : g.re = 0)
+  · simpa using (by omega : g.im = 0)
+
+/-- **Squaring is two-to-one.** For a nonzero generator `g`, the fibre of `· ^ 2` over
+`w = g²` has exactly two elements, namely `g` and `-g`. -/
+theorem sqRoots_ncard_two (w g : ℤ[i]) (hg : w = g ^ 2) (hg0 : g ≠ 0) :
+    {h : ℤ[i] | h ^ 2 = w}.ncard = 2 := by
+  rw [sqRoots_eq_pair w g hg, Set.ncard_pair (ne_neg_self hg0)]
+
+/-! ## Existence and uniqueness of the canonical generator -/
+
+/-- **The canonical generator: existence and uniqueness.** Every primitive Pythagorean
+triple `(x, y, z)` with `x` odd and `z > 0` has *exactly one* canonical Gaussian generator:
+a unique `g : ℤ[i]` in canonical sign form with `x + yi = g²`.
+
+This promotes the up-to-sign uniqueness of `pythagorean-theorem-oq-04` to a genuine `∃!`:
+completeness supplies a generator, up-to-sign uniqueness confines it to `{g, -g}`, and
+canonicity singles out one of the two. -/
+theorem canonical_generator_existsUnique {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) (hodd : x % 2 = 1) (hpos : 0 < z) :
+    ∃! g : ℤ[i], (⟨x, y⟩ : ℤ[i]) = g ^ 2 ∧ IsCanonical g := by
+  obtain ⟨m, n, hsq, _, _⟩ := gaussian_completeness h hco hodd hpos
+  set g₀ : ℤ[i] := ⟨m, n⟩ with hg0def
+  -- `⟨x, y⟩ ≠ 0` because `x` is odd, hence `g₀ ≠ 0`.
+  have hxy_ne : (⟨x, y⟩ : ℤ[i]) ≠ 0 := by
+    intro hz
+    rw [Zsqrtd.ext_iff] at hz
+    simp only [Zsqrtd.re_zero, Zsqrtd.im_zero] at hz
+    omega
+  have hg0_ne : g₀ ≠ 0 := by
+    intro hz; apply hxy_ne; rw [hsq, hz]; ring
+  rcases isCanonical_or_neg hg0_ne with hcan | hcan
+  · -- `g₀` itself is canonical.
+    refine ⟨g₀, ⟨hsq, hcan⟩, ?_⟩
+    rintro h' ⟨hh'sq, hh'can⟩
+    rcases (gaussianInt_sq_eq_iff h' g₀).mp (by rw [← hh'sq, ← hsq]) with he | he
+    · exact he
+    · exact absurd (he ▸ hh'can) (not_isCanonical_neg_of_isCanonical hcan)
+  · -- `-g₀` is the canonical generator.
+    have hsq' : (⟨x, y⟩ : ℤ[i]) = (-g₀) ^ 2 := by rw [neg_sq]; exact hsq
+    refine ⟨-g₀, ⟨hsq', hcan⟩, ?_⟩
+    rintro h' ⟨hh'sq, hh'can⟩
+    rcases (gaussianInt_sq_eq_iff h' (-g₀)).mp (by rw [← hh'sq, ← hsq']) with he | he
+    · exact he
+    · rw [neg_neg] at he
+      rw [he] at hh'can
+      exact absurd hcan (not_isCanonical_neg_of_isCanonical hh'can)
+
+/-! ## Worked example: the (3, 4, 5) triple -/
+
+/-- The canonical generator of `(3, 4, 5)` is `2 + i`: it is canonical (`re = 2 > 0`) and
+squares to `3 + 4i`. -/
+example : IsCanonical (⟨2, 1⟩ : ℤ[i]) := Or.inl (by decide)
+
+example : (⟨3, 4⟩ : ℤ[i]) = (⟨2, 1⟩ : ℤ[i]) ^ 2 := by rw [gaussianInt_sq]; norm_num
+
+/-- The Gaussian square roots of `3 + 4i` are exactly `{2 + i, -2 - i}` — a two-point set. -/
+example : {h : ℤ[i] | h ^ 2 = (⟨3, 4⟩ : ℤ[i])}.ncard = 2 := by
+  refine sqRoots_ncard_two _ (⟨2, 1⟩ : ℤ[i]) ?_ ?_
+  · rw [gaussianInt_sq]; norm_num
+  · intro hz
+    rw [Zsqrtd.ext_iff] at hz
+    simp only [Zsqrtd.re_zero, Zsqrtd.im_zero] at hz
+    omega
+
+end PythagoreanTheoremOQ04OQ01

--- a/src/data/proofs/pythagorean-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-04-oq-01/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "pythagorean-theorem-oq-04-oq-01",
+  "title": "The Canonical Gaussian Generator: Promoting Up-to-Sign Uniqueness to ∃!",
+  "slug": "pythagorean-theorem-oq-04-oq-01",
+  "description": "Answers the first open question of pythagorean-theorem-oq-04: promote the up-to-sign uniqueness of the Gaussian generator of a primitive Pythagorean triple to a genuine ∃! by choosing a fundamental domain of the sign action {±1}. A Gaussian integer a + bi is 'canonical' when a > 0, or a = 0 and b > 0; for every nonzero g exactly one of g, −g is canonical (isCanonical_xor_neg). Combining the parent's completeness with up-to-sign uniqueness, every primitive triple (x,y,z) with x odd and z > 0 has exactly one canonical generator g with x + yi = g² (canonical_generator_existsUnique). The two-to-one nature of squaring is made quantitative: the set of Gaussian square roots of x + yi is precisely {g, −g}, a two-element set (sqRoots_ncard_two). 7 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTheoremOQ04OQ01.lean",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "gaussian-integers",
+      "uniqueness",
+      "fundamental-domain",
+      "algebraic-number-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Builds only on the verified parent entry PythagoreanTheoremOQ04 (gaussian_completeness, gaussianInt_sq_eq_iff, gaussianInt_sq) and standard Mathlib (Set.ncard_pair, Zsqrtd projections). Depends only on propext, Classical.choice, and Quot.sound.",
+    "lineCount": 164,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "originalContributions": [
+      "IsCanonical: a fundamental domain for the sign action {±1} on ℤ[i] — a Gaussian integer a + bi is canonical when a > 0, or a = 0 and b > 0",
+      "not_isCanonical_neg_of_isCanonical: g and −g are never both canonical",
+      "isCanonical_or_neg: for a nonzero Gaussian integer, at least one of g, −g is canonical",
+      "isCanonical_xor_neg: EXACTLY one of g, −g is canonical for g ≠ 0 — canonicity is a genuine sign-selection, i.e. a fundamental domain of {±1}",
+      "sqRoots_eq_pair: the set of Gaussian square roots of w = g² is exactly the sign pair {g, −g}",
+      "sqRoots_ncard_two: squaring is two-to-one — the fibre of (· ^ 2) over a nonzero square has exactly two elements",
+      "canonical_generator_existsUnique: MAIN RESULT — every primitive triple (x,y,z) with x odd, z > 0 has EXACTLY ONE canonical Gaussian generator g with x + yi = g², promoting the parent's up-to-sign uniqueness to a genuine ∃!"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The (m,n) parameterization of Pythagorean triples is, in the language of the Gaussian integers ℤ[i], the statement that a primitive triple is (up to a unit) the square of a Gaussian integer — Gauss's viewpoint from the Disquisitiones and his work on biquadratic residues. The unit group of ℤ[i] is the cyclic group {1, i, −1, −i} of order 4, but only the subgroup {±1} fixes squares: (i·g)² = −g² ≠ g² for g ≠ 0. So the generator of a primitive triple is well-defined precisely up to {±1}. The classical way to remove this residual ambiguity is to choose a fundamental domain for the {±1} action — a lexicographic sign convention that picks a distinguished representative from each pair {g, −g}. This is the same device that fixes the sign of a square root, orients a lattice basis, or normalizes a projective representative.",
+    "problemStatement": "The parent entry pythagorean-theorem-oq-04 proves that a primitive Pythagorean triple determines its Gaussian generator only up to sign (generator_unique_up_to_sign: two generators differ by ±1). Its first open question asks to promote this to a genuine bijection by packaging the {±1} ambiguity as a quotient / choosing a fundamental domain of generators. Formalize a canonical sign convention, prove it selects exactly one representative of each pair {g, −g}, and upgrade the up-to-sign uniqueness to a bona-fide existence-and-uniqueness (∃!) statement.",
+    "text": "Define a Gaussian integer a + bi to be canonical (IsCanonical) when a > 0, or a = 0 and b > 0 — a lexicographic positivity condition on (a, b). The key structural fact is that this is a fundamental domain for the sign action: for every nonzero g, exactly one of g and −g is canonical (isCanonical_xor_neg). Given a primitive triple (x, y, z) with x odd and z > 0, the parent's gaussian_completeness supplies a generator g₀ with x + yi = g₀², and g₀ ≠ 0 because x is odd. Selecting the canonical representative of {g₀, −g₀} gives a canonical generator; up-to-sign uniqueness confines any other generator to that same pair, and canonicity singles out one of the two. This yields canonical_generator_existsUnique: there is a unique canonical g with x + yi = g². The two-to-one nature of squaring is made explicit alongside: the set {h : h² = x + yi} equals {g, −g} (sqRoots_eq_pair) and, since g ≠ −g in the domain ℤ[i], has exactly two elements (sqRoots_ncard_two).",
+    "proofStrategy": "IsCanonical g := 0 < g.re ∨ (g.re = 0 ∧ 0 < g.im). not_isCanonical_neg_of_isCanonical and isCanonical_or_neg are pure case analyses on the signs of g.re, g.im, discharged by omega after rewriting Zsqrtd.re_neg / Zsqrtd.im_neg; together they give isCanonical_xor_neg. ne_neg_self derives g ≠ −g for g ≠ 0 by taking real/imaginary parts (g.re = −g.re ⇒ g.re = 0, likewise for im). sqRoots_eq_pair is a set extensionality reducing to the parent's gaussianInt_sq_eq_iff; sqRoots_ncard_two then applies Set.ncard_pair with ne_neg_self. The main theorem obtains g₀ from gaussian_completeness, establishes ⟨x,y⟩ ≠ 0 (hence g₀ ≠ 0) from x odd via Zsqrtd.ext_iff, then case-splits on which of g₀, −g₀ is canonical; uniqueness in each branch uses gaussianInt_sq_eq_iff to reduce a rival generator to ±g₀ and eliminates the wrong sign with not_isCanonical_neg_of_isCanonical.",
+    "keyInsights": [
+      "Removing 'up to sign' is exactly choosing a fundamental domain for the order-2 sign action {±1} on ℤ[i] — a lexicographic positivity condition on (re, im) does this, selecting one representative per orbit",
+      "The fundamental-domain property is the single lemma isCanonical_xor_neg (exactly one of g, −g is canonical); once it holds, the ∃! is a short assembly of parent facts",
+      "Squaring in the integral domain ℤ[i] is genuinely two-to-one on nonzero elements: the fibre over a square is the pair {g, −g}, of cardinality exactly 2, because g ≠ −g whenever g ≠ 0",
+      "x odd is what forces the generator to be nonzero: ⟨x, y⟩ ≠ 0 because its real part x is odd, so the sign-selection has something to act on",
+      "The residual {±1} (not the full unit group {±1, ±i}) is the whole obstruction: i does not fix squares, so no finer normalization is needed beyond a sign"
+    ],
+    "prerequisites": [
+      "The verified parent entry PythagoreanTheoremOQ04 (gaussian_completeness, gaussianInt_sq_eq_iff, gaussianInt_sq)",
+      "Gaussian integers ℤ[i] = Zsqrtd (−1), their projections re/im, and the fact that ℤ[i] is an integral domain",
+      "Set.ncard and Set.ncard_pair for two-element sets",
+      "The notion of a fundamental domain for a group action"
+    ]
+  },
+  "conclusion": {
+    "summary": "A fully machine-verified, axiom-free resolution of the first open question of pythagorean-theorem-oq-04: the up-to-sign uniqueness of the Gaussian generator of a primitive Pythagorean triple is promoted to a genuine ∃!. A lexicographic sign convention (IsCanonical) is proved to be a fundamental domain for the sign action {±1} — exactly one of g, −g is canonical — and combining this with the parent's completeness and up-to-sign uniqueness yields a unique canonical generator for every primitive triple with x odd and z > 0. The two-to-one nature of squaring is quantified: the square-root fibre is a two-element set {g, −g}. Zero axioms, zero sorries.",
+    "implications": "Choosing a fundamental domain converts an 'up to a group' uniqueness into an honest function from primitive triples to canonical generators — the classification is now bijective rather than merely surjective-up-to-units. The reusable device is isCanonical_xor_neg: a lexicographic positivity condition is a fundamental domain for the sign action on any Zsqrtd, applicable to sign-normalizing square roots, orienting bases, or normalizing associates in ℤ[i]. The explicit two-element fibre count (sqRoots_ncard_two) is the arithmetic shadow of squaring being a degree-2 map on the domain.",
+    "openQuestions": [
+      "Assemble canonical_generator_existsUnique into an explicit Equiv between the set of primitive triples (x,y,z) with x odd, z > 0 and the set of canonical coprime Gaussian integers, realizing the bijection as a term rather than an ∃!",
+      "Remove the x-odd / z > 0 normalization by tracking all four units of ℤ[i], obtaining a canonical generator for every primitive triple regardless of parity",
+      "Transport the coordinate form: state the canonical generator uniqueness directly for the pair (m, n) ∈ ℤ × ℤ, giving the classical Euclid normalization m > n > 0"
+    ]
+  },
+  "leanFile": {
+    "namespace": "PythagoreanTheoremOQ04OQ01",
+    "lineCount": 164,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/PythagoreanTheoremOQ04OQ01.lean",
+    "imports": [
+      "Proofs.PythagoreanTheoremOQ04",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Zsqrtd",
+      "PythagoreanTheoremOQ04"
+    ],
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Directly answers the parent's first open question. The parent proves the Gaussian generator is unique only up to the sign subgroup {±1} (generator_unique_up_to_sign); this entry chooses a fundamental domain (IsCanonical) for that action and promotes the up-to-sign uniqueness to a genuine ∃! (canonical_generator_existsUnique), reusing gaussian_completeness and gaussianInt_sq_eq_iff."
+    },
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "related",
+      "description": "The base classification of Pythagorean triples via the (m,n) parameterization. Fixing a canonical sign of the Gaussian generator corresponds to the classical Euclid normalization m > n > 0 of the parameterizing pair."
+    }
+  ],
+  "sections": [
+    {
+      "id": "canonical-sign-form",
+      "title": "Part I: The canonical sign form as a fundamental domain",
+      "startLine": 45,
+      "endLine": 79,
+      "summary": "Defines IsCanonical g := 0 < g.re ∨ (g.re = 0 ∧ 0 < g.im). not_isCanonical_neg_of_isCanonical (g and −g never both canonical) and isCanonical_or_neg (at least one is, for g ≠ 0) are sign case-analyses closed by omega; together they give isCanonical_xor_neg — EXACTLY one of g, −g is canonical, i.e. a fundamental domain for the sign action {±1}."
+    },
+    {
+      "id": "square-root-fibre",
+      "title": "Part II: The square-root fibre is a two-element set",
+      "startLine": 81,
+      "endLine": 105,
+      "summary": "sqRoots_eq_pair: the set of Gaussian square roots of w = g² is exactly {g, −g}, by set extensionality via the parent's gaussianInt_sq_eq_iff. ne_neg_self: g ≠ −g for g ≠ 0 (take real/imaginary parts). sqRoots_ncard_two: squaring is two-to-one — the fibre over a nonzero square has cardinality exactly 2 (Set.ncard_pair)."
+    },
+    {
+      "id": "existence-uniqueness",
+      "title": "Part III: Existence and uniqueness of the canonical generator",
+      "startLine": 108,
+      "endLine": 145,
+      "summary": "canonical_generator_existsUnique: every primitive triple (x,y,z) with x odd and z > 0 has EXACTLY ONE canonical Gaussian generator g with x + yi = g². Obtains g₀ from gaussian_completeness, shows ⟨x,y⟩ ≠ 0 (hence g₀ ≠ 0) from x odd, selects the canonical member of {g₀, −g₀}, and proves uniqueness by confining any rival generator to that pair via gaussianInt_sq_eq_iff and eliminating the wrong sign."
+    },
+    {
+      "id": "examples",
+      "title": "Part IV: Worked example — the (3, 4, 5) triple",
+      "startLine": 147,
+      "endLine": 164,
+      "summary": "The canonical generator of (3, 4, 5) is 2 + i (canonical since re = 2 > 0) with (2 + i)² = 3 + 4i, and the Gaussian square roots of 3 + 4i form the two-element set {2 + i, −2 − i}."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `pythagorean-theorem-oq-04`:

> *"Promote the up-to-sign uniqueness (`generator_unique_up_to_sign`) to a genuine bijection between primitive triples and a chosen fundamental domain of generators, packaging the {±1} ambiguity as a quotient."*

The parent proves that a primitive Pythagorean triple determines its Gaussian generator only up to the sign subgroup `{±1}`. This entry **chooses a fundamental domain** for that action and upgrades the up-to-sign uniqueness to a bona-fide `∃!`.

## Results (7 theorems, 1 definition)

- **`IsCanonical`** `g := 0 < g.re ∨ (g.re = 0 ∧ 0 < g.im)` — a lexicographic sign convention.
- **`isCanonical_xor_neg`** — for every `g ≠ 0`, *exactly one* of `g`, `−g` is canonical. This is the fundamental-domain property for the `{±1}` action.
- **`sqRoots_eq_pair` / `sqRoots_ncard_two`** — the set of Gaussian square roots of `x + yi` is exactly `{g, −g}`, a **two-element** set: squaring is genuinely two-to-one on the domain `ℤ[i]`.
- **`canonical_generator_existsUnique`** (main) — every primitive triple `(x, y, z)` with `x` odd and `z > 0` has **exactly one** canonical Gaussian generator `g` with `x + yi = g²`.

The proof reuses only the verified parent (`gaussian_completeness`, `gaussianInt_sq_eq_iff`, `gaussianInt_sq`) plus standard Mathlib (`Set.ncard_pair`, `Zsqrtd` projections); the fundamental-domain lemmas are pure sign case-analyses closed by `omega`.

## Verification

- Build-verified via `./proofs/scripts/docker-build.sh Proofs.PythagoreanTheoremOQ04OQ01` — **clean build, no warnings**.
- **0 axioms** (only `propext` / `Classical.choice` / `Quot.sound`), **0 sorries**, no `native_decide`.
- New file `proofs/Proofs/PythagoreanTheoremOQ04OQ01.lean` (164 lines) + gallery entry `src/data/proofs/pythagorean-theorem-oq-04-oq-01/meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)