### PR TITLE
Enrich divisibility-by-three-oq-01-oq-03: full declaration coverage (6→11 anns)

### DIFF
--- a/src/data/proofs/divisibility-by-three-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-03/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "ann-oq0103-base1000-tests",
     "proofId": "divisibility-by-three-oq-01-oq-03",
-    "range": { "startLine": 111, "endLine": 132 },
+    "range": { "startLine": 112, "endLine": 132 },
     "type": "concept",
     "title": "Base-1000 Group Tests: 7, 11, 13, 1001 via 1001 = 7·11·13",
     "content": "Because 1001 = 7·11·13, we have 1000 ≡ -1 modulo each of 7, 11, 13 and 1001. Applying the general alternating divisibility test in base 1000 therefore yields simultaneous divisibility tests for all four moduli: group the decimal digits into blocks of three and alternately add and subtract the blocks. This is exactly the classical hand rule for divisibility by 7. The parent extension only remarked on this factorization in a comment; here each rule is a proven theorem obtained by a one-line application with a norm_num proof of d ∣ 1001.",
@@ -70,5 +70,65 @@
     "significance": "supporting",
     "relatedConcepts": ["summary theorem", "divisibility rules"],
     "prerequisites": ["all preceding theorems in the file"]
+  },
+  {
+    "id": "ann-oq0103-module-overview",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "concept",
+    "title": "Scope: the alternating dual of casting out nines",
+    "content": "The module docstring situates the entry against its parent `DivisibilityByThreeOQ01`, which developed the ADDITIVE theory (base b ≡ 1 mod d, packaged by Mathlib as `Nat.modEq_digits_sum` / `Nat.dvd_iff_dvd_digits_sum`, with casting out nines the case b=10, d=9). This file handles the DUAL regime b ≡ -1 (mod d), where the alternating digit sum a₀-a₁+a₂-⋯ governs divisibility. Mathlib only records the single classical instance `Nat.modEq_eleven_digits_sum` / `Nat.eleven_dvd_iff` (base 10, mod 11); everything here generalizes it to arbitrary (b,d) with d ∣ b+1 by reducing to the master congruence `Nat.zmodeq_ofDigits_digits` at residue c = -1. The imports `import Mathlib.Data.Nat.Digits.Div` and `import Mathlib.Tactic` are gallery conventions.",
+    "mathContext": "Additive rule needs $b \\equiv 1 \\pmod d$ ($n \\equiv \\sum a_i$); this entry's alternating rule needs $b \\equiv -1 \\pmod d$ ($n \\equiv \\sum (-1)^i a_i$). Both are the $c = \\pm 1$ specializations of $n \\equiv \\text{ofDigits}_b(c)$-style congruences.",
+    "significance": "context",
+    "relatedConcepts": ["casting out nines", "casting out elevens", "parent entry DivisibilityByThreeOQ01", "Nat.zmodeq_ofDigits_digits", "positional notation"],
+    "prerequisites": ["modular arithmetic", "positional numeral systems", "Nat.digits API"]
+  },
+  {
+    "id": "ann-oq0103-classical-instances",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 98, "endLine": 107 },
+    "type": "theorem",
+    "title": "Classical instances: 11 (base 10) and 101 (base 100)",
+    "content": "Two direct specializations of the general divisibility test. `eleven_dvd_iff_alt` recovers Mathlib's classical `Nat.eleven_dvd_iff`: 11 ∣ n iff 11 divides the alternating decimal digit sum, since 11 ∣ 10+1. `onehundredone_dvd_iff_alt` is the base-100 analogue: grouping decimal digits into two-digit blocks and alternately adding/subtracting tests divisibility by 101, since 101 ∣ 100+1. Each proof is a one-liner: apply `dvd_iff_dvd_alternating_digits` with a `norm_num` discharge of the hypothesis d ∣ b+1.",
+    "mathContext": "$11 \\mid n \\iff 11 \\mid \\text{altDigitSum}_{10}(n)$ (since $11 \\mid 11$); $101 \\mid n \\iff 101 \\mid \\text{altDigitSum}_{100}(n)$ (since $101 \\mid 101$).",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.eleven_dvd_iff", "two-digit grouping", "general alternating divisibility test"],
+    "prerequisites": ["general alternating divisibility test", "norm_num"]
+  },
+  {
+    "id": "ann-oq0103-binary-hex",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 132, "endLine": 142 },
+    "type": "theorem",
+    "title": "Non-decimal instances: 3 in binary, 17 in hexadecimal",
+    "content": "Two instances of the universal corollary in non-decimal bases. `three_dvd_iff_alt_binary` uses 2 ≡ -1 (mod 3): a number is divisible by 3 iff the alternating sum of its BITS is (e.g. the popcount parity of even/odd bit positions). `seventeen_dvd_iff_alt_hex` uses 16 ≡ -1 (mod 17): divisibility by 17 is decided by the alternating sum of hexadecimal digits. Both illustrate that the b+1 test is a genuinely base-relative phenomenon, not special to base 10.",
+    "mathContext": "$3 \\mid n \\iff 3 \\mid \\text{altDigitSum}_2(n)$ (bit alternation, $2 \\equiv -1 \\bmod 3$); $17 \\mid n \\iff 17 \\mid \\text{altDigitSum}_{16}(n)$ ($16 \\equiv -1 \\bmod 17$).",
+    "significance": "supporting",
+    "relatedConcepts": ["binary representation", "hexadecimal", "universal corollary", "base-relative divisibility"],
+    "prerequisites": ["universal corollary", "non-decimal bases"]
+  },
+  {
+    "id": "ann-oq0103-casting-out-congruences",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 148, "endLine": 156 },
+    "type": "theorem",
+    "title": "Congruence (casting-out) form of the instances",
+    "content": "Where the earlier instances give the yes/no divisibility test, these give the finer CONGRUENCE: `casting_out_elevens` states n ≡ altDigitSum₁₀(n) (mod 11), the exact analogue of casting out nines that lets one compute a number's residue mod 11 by hand; `casting_out_sevens_base1000` gives the residue mod 7 from the alternating three-digit group sum. Both specialize the general congruence theorem `modEq_alternating_digits`, retaining the remainder information that the divisibility form discards.",
+    "mathContext": "$n \\equiv \\text{altDigitSum}_{10}(n) \\pmod{11}$ and $n \\equiv \\text{altDigitSum}_{1000}(n) \\pmod 7$ — congruences, not just divisibility tests.",
+    "significance": "supporting",
+    "relatedConcepts": ["casting out nines", "residue computation", "modEq_alternating_digits", "Int.ModEq"],
+    "prerequisites": ["general alternating casting-out (congruence form)"]
+  },
+  {
+    "id": "ann-oq0103-numerical-verification",
+    "proofId": "divisibility-by-three-oq-01-oq-03",
+    "range": { "startLine": 163, "endLine": 180 },
+    "type": "insight",
+    "title": "Numerical verification of the rules",
+    "content": "Concrete sanity checks discharged by `decide`/`native_decide`/`norm_num`. The key witness is 1002001, whose base-1000 digit blocks are [001, 002, 001] with alternating sum 1 - 2 + 1 = 0, so it is simultaneously divisible by 7, 11, 13 and 1001 — a single computation exhibiting the four-in-one base-1000 test. Likewise 1331 has alternating decimal digit sum 1 - 3 + 3 - 1 = 0, confirming 11 ∣ 1331. The arithmetic fact 1001 = 7·11·13 underpinning the base-1000 grouping is checked directly.",
+    "mathContext": "$\\text{altDigitSum}_{1000}(1002001) = 1-2+1 = 0 \\Rightarrow 7,11,13,1001 \\mid 1002001$; $\\text{altDigitSum}_{10}(1331) = 1-3+3-1 = 0 \\Rightarrow 11 \\mid 1331$.",
+    "significance": "context",
+    "relatedConcepts": ["decide / native_decide", "1001 = 7·11·13", "worked examples"],
+    "prerequisites": ["the alternating divisibility tests"]
   }
 ]


### PR DESCRIPTION
Coverage-gap fill for `divisibility-by-three-oq-01-oq-03` (*General Alternating Digit-Sum Rule, base b ≡ -1 mod d*).

Before: 6 annotations, 6 declarations uncovered.

After: 11 annotations — **all declarations covered**.

New annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
- **Module overview** — the alternating dual of casting out nines; relation to parent `DivisibilityByThreeOQ01` and to Mathlib's lone base-10/mod-11 instance.
- **Classical instances** — `eleven_dvd_iff_alt` (base 10) and `onehundredone_dvd_iff_alt` (base 100).
- **Non-decimal instances** — `three_dvd_iff_alt_binary` (2 ≡ -1 mod 3) and `seventeen_dvd_iff_alt_hex` (16 ≡ -1 mod 17).
- **Congruence form** — `casting_out_elevens` and `casting_out_sevens_base1000` (residue-preserving versions).
- **Numerical verification** — the 1002001 four-in-one and 1331 worked examples.

**Bonus fix:** the pre-existing `ann-oq0103-base1000-tests` was anchored on blank line 111 (no Lean construct → would fail `--strict` validation); moved to doc line 112.

Existing annotations otherwise preserved. Validated with `validateLineAnnotations` (11 valid, 0 misaligned).