### PR TITLE
Fix: sync stale lineCount (293→300) for cayley-hamilton-minpoly-oq-03-oq-03-oq-01

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03-oq-01/meta.json
@@ -22,7 +22,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 293,
+    "lineCount": 300,
     "assumptions": "No axioms, no sorries. All theorems fully machine-checked over an arbitrary field K, for any monic polynomial of positive degree. Reuses the Krylov expansion lemma pattern from OQ-03-OQ-01. Determinant-free: χ_C = p is obtained from μ_C = p plus Mathlib's Matrix.aeval_self_charpoly (Cayley–Hamilton) and charpoly degree/monic lemmas.",
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
@@ -53,7 +53,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "MinpolyComplexity.RCF",
-    "lineCount": 293,
+    "lineCount": 300,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` metadata for `cayley-hamilton-minpoly-oq-03-oq-03-oq-01`.

## Evidence

**Before**: both `meta.lineCount` and `leanFile.lineCount` = `293`.
**After**: both = `300`, matching the actual source file (`wc -l` of `Proofs/CayleyHamiltonMinpolyOQ03OQ03OQ01.lean` = 300).

Other numeric fields verified correct and left unchanged:
- `theoremCount = 14` — confirmed (7 public + 7 `private theorem` declarations; the naive `^(theorem|lemma) ` counter undercounts private ones, but the stored value is right).
- `definitionCount = 3`, `sorries = 0`, `axiomCount = 0` — all match source.
- `status = verified` / `badge = mathlib` unchanged.

Metadata-only fix (Fix Type A). No Lean code or status change; no build required.

---
Automated fix by lean-mechanic agent.