### PR TITLE
research(stars-and-bars-weak-compositions-oq-02-oq-02): reflection symmetry B(k,n,b)=B(k,kb−n,b) via complementation bijection [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/StarsAndBarsWeakCompositionsOQ02OQ02.lean
+++ b/proofs/Proofs/StarsAndBarsWeakCompositionsOQ02OQ02.lean
@@ -1,0 +1,107 @@
+import Mathlib.Data.Sym.Card
+import Mathlib.Tactic
+import Proofs.StarsAndBarsWeakCompositionsOQ02
+
+/-
+# Reflection Symmetry of Bounded Weak Compositions (`n ↦ kb − n`)
+
+## What This Proves
+
+The parent entry (`StarsAndBarsWeakCompositionsOQ02.lean`) counts the *bounded weak
+compositions* of `n` into `k` parts with every part `≤ b`:
+
+  `B(k, n, b) := #{f : Fin k → ℕ | ∑ i, f i = n, ∀ i, f i ≤ b}`,
+
+and gives the inclusion–exclusion closed form
+`B(k,n,b) = ∑_{j} (−1)^j C(k,j) C(n − (b+1)j + k − 1, …)`.
+
+This entry proves the **reflection symmetry**
+
+  `B(k, n, b) = B(k, k·b − n, b)`   (for `n ≤ k·b`),
+
+by exhibiting the explicit bijection
+
+  `f  ↦  (i ↦ b − f i)`,
+
+which sends a composition of `n` (all parts `≤ b`) to a composition of `k·b − n`
+(all parts `≤ b`), and is its own inverse up to the two sum-constraints. The map is
+a genuine involution on the *shape* `i ↦ b − f i`; the two sum constraints `∑ f = n`
+and `∑ f = kb − n` make domain and codomain distinct subtypes, so we package it as an
+`Equiv` (`reflectEquiv`) whose `toFun` and `invFun` are both the reflection.
+
+## Why it matters
+
+`B(k, n, b)` is exactly the coefficient of `qⁿ` in the Gaussian binomial coefficient
+`[k + b ; b]_q` (the `q`-analogue of `C(k+b, b)`). The reflection `n ↦ kb − n` is the
+combinatorial witness of the palindromic symmetry of Gaussian binomial coefficients
+`[m ; r]_q = [m ; r]_{q⁻¹} · q^{r(m−r)}`, specialised to `q = 1`. We do not formalise
+`q`-binomials here; we prove the underlying finite bijection, which is the `q = 1`
+content of that symmetry and is `Mathlib`-gap-free at that level.
+
+## Free corollary
+
+Combining the card symmetry with the parent's closed form yields an identity between
+two inclusion–exclusion alternating sums (`closedForm_reflect`): the alternating sum
+evaluated at `n` equals the one evaluated at `k·b − n`.
+
+**Sorry count**: 0.  **Axiom count**: 0 (only Lean/Mathlib foundational axioms).
+-/
+
+open Finset
+
+namespace StarsAndBarsReflect
+
+/-- Bounded weak compositions of `n` into `k` parts, each part `≤ b`
+(the type counted by the parent entry). -/
+abbrev BC (k n b : ℕ) : Type := {f : Fin k → ℕ // (∑ i, f i = n) ∧ ∀ i, f i ≤ b}
+
+/-- The total budget `∑ i, b = k·b` distributed over `k` parts. -/
+private theorem sum_const_b (k b : ℕ) : ∑ _i : Fin k, b = k * b := by
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+
+/-- **The reflection bijection.**  When `n ≤ k·b`, complementing each part
+`f i ↦ b − f i` is a bijection from the bounded weak compositions of `n` onto those
+of `k·b − n` (parts stay `≤ b`, and the total flips from `n` to `k·b − n`). -/
+def reflectEquiv (k n b : ℕ) (hn : n ≤ k * b) : BC k n b ≃ BC k (k * b - n) b where
+  toFun f := ⟨fun i => b - f.val i, by
+    refine ⟨?_, fun i => Nat.sub_le _ _⟩
+    rw [Finset.sum_tsub_distrib univ (fun i _ => f.2.2 i), sum_const_b, f.2.1]⟩
+  invFun g := ⟨fun i => b - g.val i, by
+    refine ⟨?_, fun i => Nat.sub_le _ _⟩
+    rw [Finset.sum_tsub_distrib univ (fun i _ => g.2.2 i), sum_const_b, g.2.1,
+      Nat.sub_sub_self hn]⟩
+  left_inv f := by
+    apply Subtype.ext; funext i
+    exact Nat.sub_sub_self (f.2.2 i)
+  right_inv g := by
+    apply Subtype.ext; funext i
+    exact Nat.sub_sub_self (g.2.2 i)
+
+/-- **Reflection symmetry of the bounded-composition count.**
+`B(k, n, b) = B(k, k·b − n, b)` whenever `n ≤ k·b`. -/
+theorem card_boundedComposition_reflect (k n b : ℕ) (hn : n ≤ k * b) :
+    Fintype.card (BC k n b) = Fintype.card (BC k (k * b - n) b) :=
+  Fintype.card_congr (reflectEquiv k n b hn)
+
+/-- The reflection is an involution: applying it twice returns to `B(k, n, b)`, since
+`k·b − (k·b − n) = n`.  (Consistency check on `reflectEquiv`.) -/
+theorem card_boundedComposition_reflect_reflect (k n b : ℕ) (hn : n ≤ k * b) :
+    Fintype.card (BC k (k * b - (k * b - n)) b) = Fintype.card (BC k n b) := by
+  rw [Nat.sub_sub_self hn]
+
+/-- **Closed-form corollary.**  The parent's inclusion–exclusion alternating sum is
+invariant under `n ↦ k·b − n`.  Both sides equal `(B(k, n, b) : ℤ)` by the parent's
+`card_boundedComposition` together with the reflection symmetry. -/
+theorem closedForm_reflect (k n b : ℕ) (hn : n ≤ k * b) :
+    (∑ j ∈ Finset.range (k + 1), (k.choose j : ℤ) * ((-1 : ℤ) ^ j *
+        (if (b + 1) * j ≤ n then
+          ((n - (b + 1) * j + k - 1).choose (n - (b + 1) * j) : ℤ) else 0)))
+      = ∑ j ∈ Finset.range (k + 1), (k.choose j : ℤ) * ((-1 : ℤ) ^ j *
+        (if (b + 1) * j ≤ k * b - n then
+          ((k * b - n - (b + 1) * j + k - 1).choose (k * b - n - (b + 1) * j) : ℤ)
+            else 0)) := by
+  rw [← StarsAndBarsBounded.card_boundedComposition k n b,
+      ← StarsAndBarsBounded.card_boundedComposition k (k * b - n) b]
+  exact_mod_cast congrArg (Nat.cast : ℕ → ℤ) (card_boundedComposition_reflect k n b hn)
+
+end StarsAndBarsReflect

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-02-oq-02/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-02-oq-02/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "stars-and-bars-weak-compositions-oq-02-oq-02",
+  "title": "Reflection Symmetry of Bounded Weak Compositions (n ↦ kb − n)",
+  "slug": "stars-and-bars-weak-compositions-oq-02-oq-02",
+  "description": "The parent entry counts the bounded weak compositions of n into k parts with every part ≤ b — functions f : Fin k → ℕ with ∑ᵢ f(i) = n and f(i) ≤ b — and gives the inclusion–exclusion closed form B(k,n,b) = ∑ⱼ (−1)ʲ C(k,j) C(n−(b+1)j+k−1, n−(b+1)j). This entry answers that entry's open question: it proves the reflection symmetry B(k, n, b) = B(k, k·b − n, b) for n ≤ k·b by exhibiting the explicit bijection f ↦ (i ↦ b − f(i)). Complementing every part by b sends a composition of n with all parts ≤ b to a composition of k·b − n with all parts ≤ b; the parts stay in range because 0 ≤ f(i) ≤ b ⇔ 0 ≤ b − f(i) ≤ b, and the total flips because ∑ᵢ (b − f(i)) = k·b − ∑ᵢ f(i). The map is its own inverse on shapes (b − (b − f(i)) = f(i) using f(i) ≤ b via Nat.sub_sub_self), so it is packaged as an Equiv reflectEquiv whose toFun and invFun are both the reflection; the two differing sum-constraints (∑ = n vs ∑ = kb − n) are what make it a bijection between distinct subtypes rather than a literal involution. The card symmetry follows by Fintype.card_congr. Combined with the parent's closed form, a free corollary (closedForm_reflect) shows the inclusion–exclusion alternating sum is itself invariant under n ↦ k·b − n. B(k,n,b) is the coefficient of qⁿ in the Gaussian binomial [k+b; b]_q, and this reflection is the q = 1 content of the palindromic symmetry of Gaussian binomial coefficients; q-binomials are not formalized here, only the underlying finite bijection.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Sym.Card",
+      "Mathlib.Tactic",
+      "Proofs.StarsAndBarsWeakCompositionsOQ02"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "StarsAndBarsReflect",
+    "lineCount": 107,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "path": "Proofs/StarsAndBarsWeakCompositionsOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StarsAndBarsWeakCompositionsOQ02OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "stars-and-bars",
+      "weak-compositions",
+      "bounded-compositions",
+      "bijective-proof",
+      "involution",
+      "gaussian-binomial",
+      "symmetry",
+      "binomial-coefficients"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "stars-and-bars-weak-compositions-oq-02",
+        "relationship": "Direct parent. That entry counts the bounded weak compositions B(k,n,b) of n into k parts with each part ≤ b via inclusion–exclusion, and lists 'prove the symmetry n ↦ k·b − n as an explicit involution recovering the q=1 Gaussian-binomial symmetry' as an open question. This entry answers it: the reflection bijection f ↦ (b − f) gives B(k,n,b) = B(k,kb−n,b), and combined with the parent's closed form yields the invariance of the inclusion–exclusion sum itself."
+      },
+      {
+        "id": "stars-and-bars-weak-compositions",
+        "relationship": "Grandparent: the unrestricted stars-and-bars count C(n+k−1, n). The reflection symmetry here is a genuinely bounded phenomenon (it needs the cap b to define the complement b − f i and the finite budget kb); the unbounded count has no such finite reflection."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 107,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All four theorems (card_boundedComposition_reflect, card_boundedComposition_reflect_reflect, closedForm_reflect, sum_const_b) and the bijection reflectEquiv were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The card symmetry B(k,n,b) = B(k,kb−n,b) is unconditional given the hypothesis n ≤ k·b (needed so that k·b − n is the honest complementary total; for n > k·b both counts are 0 but the ℕ-subtraction kb−n truncates to 0 and the statement would read B(k,n,b) = B(k,0,b), which is false, hence the hypothesis). Sanity check: (k,n,b) = (2,3,2) gives B = 2 and its reflection kb−n = 1 gives B(2,1,2) = 2 (the compositions (0,1),(1,0)); (k,n,b) = (3,5,2) gives B = 3 and reflection kb−n = 1 gives B(3,1,2) = 3.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The number of nonnegative integer solutions of x₁ + ⋯ + x_k = n with each xᵢ ≤ b is the coefficient of qⁿ in the polynomial (1 + q + ⋯ + qᵇ)ᵏ, which is the Gaussian binomial coefficient [k+b; b]_q. Gaussian binomial coefficients are palindromic: the coefficient sequence of [m; r]_q read forwards equals the sequence read backwards, reflecting the symmetry of Young diagrams fitting in an r × (m−r) box under complementation. Specialising to q = 1 collapses the polynomial identity to an equality of the individual coefficients under the index reflection n ↦ r(m−r) − n; for the box interpretation with r = k and side b this is exactly n ↦ k·b − n. The combinatorial witness is the classical complementation bijection on the box: replace each part xᵢ by b − xᵢ.",
+    "problemStatement": "Let B(k, n, b) = #{f : Fin k → ℕ | ∑ᵢ f(i) = n and f(i) ≤ b for all i} be the number of bounded weak compositions of n into k parts, each part at most b. Show that for n ≤ k·b, B(k, n, b) = B(k, k·b − n, b), and exhibit the equality as an explicit bijection (the reflection f ↦ (i ↦ b − f(i))).",
+    "text": "The parent entry (stars-and-bars-weak-compositions-oq-02) counts B(k,n,b) by inclusion–exclusion and closes with the open question of proving its reflection symmetry as an explicit involution. This entry supplies that bijection. The map complements each part against the cap b: a part with 0 ≤ f(i) ≤ b becomes b − f(i), again in [0, b]. Summing, ∑ᵢ (b − f(i)) = k·b − ∑ᵢ f(i) = k·b − n, so the reflection turns a composition of total n into one of total k·b − n. Because complementation is self-inverse on each part (b − (b − f(i)) = f(i) whenever f(i) ≤ b), the two directions are the same formula and assemble into an Equiv.",
+    "proofStrategy": "Work with BC k n b = {f : Fin k → ℕ // (∑ i, f i = n) ∧ ∀ i, f i ≤ b}, the bounded-composition subtype from the parent (a Fintype via the parent's instance). The lemma sum_const_b evaluates the total budget ∑_{i : Fin k} b = k·b (Finset.sum_const with card (Fin k) = k). reflectEquiv is the reflection bijection BC k n b ≃ BC k (k·b − n) b: its toFun sends f to (i ↦ b − f i); range membership is Nat.sub_le, and the new total is computed by Finset.sum_tsub_distrib (valid since f i ≤ b) as ∑ b − ∑ f = k·b − n. Its invFun is the same reflection from BC k (k·b − n) b back to BC k n b, whose total is k·b − (k·b − n) = n by Nat.sub_sub_self using the hypothesis n ≤ k·b. Both round-trips are Nat.sub_sub_self (b − (b − f i) = f i because f i ≤ b), proved pointwise after Subtype.ext and funext. The main theorem card_boundedComposition_reflect is then Fintype.card_congr reflectEquiv. The free corollary closedForm_reflect rewrites both sides with the parent's card_boundedComposition (which equates each ℤ-cast card with its inclusion–exclusion alternating sum) and discharges the remaining card equality by casting card_boundedComposition_reflect.",
+    "keyInsights": [
+      "**Complementation against the cap is the reflection**: bounding parts by b makes each coordinate live in the finite interval [0, b], on which x ↦ b − x is an involution. Applying it coordinatewise reflects the whole box, and the total transforms affinely: ∑ (b − f i) = k·b − ∑ f i. This is what converts the symmetry n ↦ k·b − n from an assertion about coefficients into a concrete bijection.",
+      "**A bijection between distinct subtypes, packaged as an Equiv, not a literal involution**: the reflection map has the same formula in both directions, but the domain fixes ∑ f = n and the codomain fixes ∑ f = k·b − n, so it is an Equiv BC k n b ≃ BC k (kb−n) b rather than an endo-involution. The involutive nature survives as reflectEquiv.symm being the same reflection and as card_boundedComposition_reflect_reflect (reflecting twice returns to n via Nat.sub_sub_self).",
+      "**The hypothesis n ≤ k·b is essential, not cosmetic**: it is exactly what makes k·b − n the honest complementary total (Nat.sub_sub_self needs it) and what keeps the inverse total equal to n. Without it the truncated ℕ subtraction would make the statement B(k,n,b) = B(k, 0, b), which is false for n > k·b (the left side is 0, the right is B(k,0,b) = 1).",
+      "**The closed form inherits the symmetry for free**: because the parent equates the ℤ-cast bounded count with its inclusion–exclusion alternating sum, the card symmetry immediately yields that the alternating sum ∑ⱼ (−1)ʲ C(k,j) C(·+k−1, ·) is itself invariant under n ↦ k·b − n — a non-obvious identity between two different-looking alternating sums, obtained without touching the sums directly.",
+      "**This is the q = 1 shadow of Gaussian-binomial palindromy**: B(k,n,b) is the qⁿ-coefficient of [k+b; b]_q, whose coefficient sequence is a palindrome of length k·b + 1. The reflection bijection is the combinatorial certificate of that palindromy at the level of individual coefficients; the full q-graded statement would need q-binomials, which Mathlib does not yet package, but the q = 1 content is complete and gap-free."
+    ],
+    "prerequisites": [
+      "The bounded-composition count and its Fintype instance from the parent entry (Proofs/StarsAndBarsWeakCompositionsOQ02.lean), including card_boundedComposition for the closed-form corollary",
+      "Truncated natural subtraction facts: Nat.sub_le, Nat.sub_sub_self (a − (a − b) = b when b ≤ a), and Finset.sum_tsub_distrib for distributing subtraction over a Finset sum under a pointwise ≤ hypothesis",
+      "Constructing an Equiv by hand (toFun/invFun/left_inv/right_inv) and transporting cardinality along it with Fintype.card_congr",
+      "Subtype and function extensionality (Subtype.ext, funext) to prove the round-trip identities pointwise",
+      "Casting a ℕ equality into ℤ (exact_mod_cast / congrArg Nat.cast) to combine the card symmetry with the parent's ℤ-valued closed form"
+    ]
+  },
+  "sections": [
+    {
+      "id": "statement-and-idea",
+      "title": "The Reflection Symmetry and the Complementation Idea",
+      "startLine": 1,
+      "endLine": 50,
+      "mathContext": "$B(k, n, b) = B(k, k b - n, b)$ for $n \\le k b$, via $f \\mapsto (i \\mapsto b - f(i))$.",
+      "summary": "The module docstring states the reflection symmetry of the bounded-composition count and the plan: complement each part against the cap b, which keeps parts in [0, b] and flips the total from n to k·b − n. It records the relationship to Gaussian binomial coefficients (B(k,n,b) is the qⁿ-coefficient of [k+b; b]_q, and this is the q=1 palindromy) and defines BC k n b, the bounded-composition subtype reused from the parent."
+    },
+    {
+      "id": "reflect-bijection",
+      "title": "The Reflection Bijection",
+      "startLine": 51,
+      "endLine": 80,
+      "mathContext": "$BC\\,k\\,n\\,b \\simeq BC\\,k\\,(k b - n)\\,b$, with both directions given by $f \\mapsto (i \\mapsto b - f(i))$.",
+      "summary": "sum_const_b evaluates the total budget ∑_{i : Fin k} b = k·b. reflectEquiv is the explicit equivalence: forward and backward are both the coordinatewise complement i ↦ b − f i. Range membership is Nat.sub_le; the forward total ∑ (b − f i) = k·b − n uses Finset.sum_tsub_distrib (valid since f i ≤ b) and sum_const_b; the backward total returns to n via Nat.sub_sub_self and the hypothesis n ≤ k·b. Both round-trips are Nat.sub_sub_self applied pointwise."
+    },
+    {
+      "id": "card-symmetry",
+      "title": "The Cardinality Symmetry and Closed-Form Corollary",
+      "startLine": 81,
+      "endLine": 107,
+      "mathContext": "$\\mathrm{card}(BC\\,k\\,n\\,b) = \\mathrm{card}(BC\\,k\\,(kb-n)\\,b)$; the inclusion–exclusion sum is invariant under $n \\mapsto kb - n$.",
+      "summary": "card_boundedComposition_reflect transports reflectEquiv through Fintype.card_congr to get B(k,n,b) = B(k,kb−n,b). card_boundedComposition_reflect_reflect records the involutive consistency (reflecting twice restores n, via Nat.sub_sub_self). closedForm_reflect combines the card symmetry with the parent's card_boundedComposition to conclude that the inclusion–exclusion alternating sum ∑ⱼ (−1)ʲ C(k,j) C(n−(b+1)j+k−1, n−(b+1)j) is invariant under n ↦ k·b − n."
+    }
+  ],
+  "conclusion": {
+    "summary": "The reflection symmetry of the bounded stars-and-bars count is formalized sorry-free and axiom-free: for n ≤ k·b, the number of weak compositions of n into k parts with all parts ≤ b equals the number for total k·b − n. The proof is the explicit complementation bijection f ↦ (i ↦ b − f(i)), delivered as an Equiv (reflectEquiv) rather than a mere cardinality equation, and the card equality follows by Fintype.card_congr. A free corollary transfers the symmetry to the parent's inclusion–exclusion closed form. This answers the open question posed by the parent entry.",
+    "implications": "Because reflectEquiv is an explicit Equiv, it is reusable wherever the bounded-composition box appears (e.g. pairing a coefficient with its palindromic partner, or reducing a computation at n to one at the smaller of n and k·b − n). The result is the q = 1 content of the palindromic symmetry of Gaussian binomial coefficients; formalizing the full q-graded statement would require q-binomial machinery not yet in Mathlib, making this a natural stepping stone. Together with the parent, it packages the bounded stars-and-bars count with both its inclusion–exclusion closed form and its reflection symmetry.",
+    "openQuestions": [
+      "Lift the q = 1 reflection to the full q-graded palindromy [k+b; b]_q = q^{kb} [k+b; b]_{1/q} by formalizing Gaussian binomial coefficients and showing the coefficient of qⁿ equals that of q^{kb−n}; the bijection here is the combinatorial core of that statement.",
+      "Identify the fixed points and orbit structure of the coordinatewise complement when n = k·b / 2 (k·b even), and relate the count of self-complementary compositions to the central coefficient of [k+b; b]_q."
+    ]
+  },
+  "crossReferences": [
+    "stars-and-bars-weak-compositions-oq-02",
+    "stars-and-bars-weak-compositions"
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **open question** posed by the parent entry `stars-and-bars-weak-compositions-oq-02`: prove the reflection symmetry `n ↦ k·b − n` of the bounded weak-composition count as an explicit involution.

Let `B(k,n,b) = #{f : Fin k → ℕ | ∑ᵢ f(i) = n, ∀i f(i) ≤ b}` be the bounded stars-and-bars count. This entry proves, for `n ≤ k·b`:

```
B(k, n, b) = B(k, k·b − n, b)
```

via the explicit bijection `f ↦ (i ↦ b − f(i))` (complement each part against the cap `b`). Parts stay in `[0,b]`; the total flips because `∑ᵢ (b − f(i)) = k·b − ∑ᵢ f(i)`. Delivered as an `Equiv` (`reflectEquiv`), with the card equality via `Fintype.card_congr`.

**Free corollary** (`closedForm_reflect`): combining with the parent's `card_boundedComposition` shows the inclusion–exclusion alternating sum `∑ⱼ (−1)ʲ C(k,j) C(n−(b+1)j+k−1, ·)` is itself invariant under `n ↦ k·b − n`.

This is the **q = 1 content** of the palindromic symmetry of Gaussian binomial coefficients (`B(k,n,b)` is the `qⁿ`-coefficient of `[k+b; b]_q`); q-binomials are not formalized, only the underlying finite bijection.

## Verification
- **0 sorries, 0 axioms** — `#print axioms` on all results shows only `propext / Classical.choice / Quot.sound`
- Typechecked against Mathlib 4.26.0 via `lake env lean`
- 4 theorems, 2 definitions, 107 lines
- New gallery entry (meta.json)

## Files
- `proofs/Proofs/StarsAndBarsWeakCompositionsOQ02OQ02.lean`
- `src/data/proofs/stars-and-bars-weak-compositions-oq-02-oq-02/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)