### PR TITLE
research(quadratic-reciprocity-oq-04-oq-02): Euler liars form a subgroup → Solovay–Strassen ½-bound

### DIFF
--- a/proofs/Proofs/QuadraticReciprocityOQ04OQ02.lean
+++ b/proofs/Proofs/QuadraticReciprocityOQ04OQ02.lean
@@ -1,0 +1,248 @@
+import Mathlib
+
+/-!
+# Euler liars form a subgroup, and the Solovay–Strassen ½-bound (quadratic-reciprocity-oq-04-oq-01)
+
+## What this proves
+
+The parent entry `quadratic-reciprocity-oq-04` exhibited a single failure of the Jacobi
+symbol to detect quadratic residues: `J(2 | 15) = 1` yet `2` is not a square mod `15`.
+This file upgrades that single counterexample into the structural theorem that powers the
+**Solovay–Strassen primality test**.
+
+Fix an odd modulus `n > 1`. Call a unit `a ∈ (ℤ/nℤ)ˣ` an **Euler liar** when it satisfies
+the Euler congruence
+`a^((n-1)/2) ≡ J(a | n)  (mod n)`,
+the identity that holds for *every* unit when `n` is prime (Euler's criterion). The set of
+Euler liars is denoted `E(n)`.
+
+* **Structural core (any odd `n > 1`).** `E(n)` is a *subgroup* of `(ℤ/nℤ)ˣ`. The proof is
+  the observation that the Euler congruence equates two homomorphisms: `a ↦ a^((n-1)/2)`
+  and `a ↦ J(a | n)` (multiplicativity of the Jacobi symbol in the numerator). Consequently,
+  the moment `E(n)` is a *proper* subgroup — i.e. one Euler *witness* exists — Lagrange's
+  theorem forces `|E(n)| ≤ φ(n)/2`. This is the "one reduction beats a thousand cases" heart
+  of the test: half of all residues expose compositeness, so `k` independent trials fail with
+  probability `≤ 2^{-k}`.
+
+* **Unconditional witness (odd `n = p·m`, `p` an odd prime, `gcd(p,m)=1`, `m > 1`).** Every
+  such `n` — in particular every squarefree odd composite — admits an Euler witness, so the
+  `½`-bound holds unconditionally there. The witness is built by CRT: pick a non-residue `b`
+  mod `p` and lift `(b, 1)` to `(ℤ/nℤ)ˣ`. Its Jacobi symbol is `(-1)·1 = -1`, but its
+  `((n-1)/2)`-th power is `≡ 1 (mod m)`, and `1 ≠ -1` in `ℤ/mℤ` (as `m ≥ 3`), so the Euler
+  congruence fails mod `m`.
+
+## Status
+
+- [x] Complete proof, no sorries
+- [x] 0 `axiom` declarations, no structure-encoded assumptions, no `native_decide`
+- [x] Structural: `E(n)` is a `Subgroup`; proper ⟹ `|E(n)| ≤ φ(n)/2`
+- [x] Number-theoretic witness for `n = p·m` (covers all squarefree odd composites)
+-/
+
+namespace QuadraticReciprocityOQ04OQ02
+
+open scoped BigOperators
+
+/-- `1 < n` supplies `NeZero n`, so all the `ZMod n` machinery is available from `Fact (1 < n)`
+alone. -/
+instance factNeZero (n : ℕ) [Fact (1 < n)] : NeZero n :=
+  ⟨by have := (Fact.out : 1 < n); omega⟩
+
+/-! ## The Jacobi symbol of a unit, and its multiplicativity -/
+
+/-- `jUnit u` is the Jacobi symbol `J(a | n)` where `a` is the canonical representative of the
+unit `u ∈ (ℤ/nℤ)ˣ`. Because `u` is a unit, `gcd(a, n) = 1`, so the value is `±1`. -/
+def jUnit {n : ℕ} [NeZero n] (u : (ZMod n)ˣ) : ℤ :=
+  jacobiSym ((u : ZMod n).val : ℤ) n
+
+/-- The Jacobi symbol of a unit is `1` or `-1`. -/
+theorem jUnit_eq_one_or {n : ℕ} [NeZero n] (u : (ZMod n)ˣ) :
+    jUnit u = 1 ∨ jUnit u = -1 := by
+  apply jacobiSym.eq_one_or_neg_one
+  have h : Nat.gcd (u : ZMod n).val n = 1 := ZMod.val_coe_unit_coprime u
+  unfold Int.gcd
+  simp only [Int.natAbs_natCast]
+  exact h
+
+/-- `jUnit` sends `1` to `1`. -/
+theorem jUnit_one {n : ℕ} [Fact (1 < n)] :
+    jUnit (1 : (ZMod n)ˣ) = 1 := by
+  unfold jUnit
+  simp [ZMod.val_one n, jacobiSym.one_left]
+
+/-- **Multiplicativity.** `jUnit` is a homomorphism to `{±1}`: `J(uv) = J(u)·J(v)`. This is
+the multiplicativity of the Jacobi symbol in the numerator, transported through the fact that
+the Jacobi symbol only depends on the numerator mod `n`. -/
+theorem jUnit_mul {n : ℕ} [NeZero n] (u v : (ZMod n)ˣ) :
+    jUnit (u * v) = jUnit u * jUnit v := by
+  unfold jUnit
+  rw [← jacobiSym.mul_left]
+  refine jacobiSym.mod_left' ?_
+  have hval : (↑(u * v) : ZMod n) = (↑u : ZMod n) * (↑v : ZMod n) := by
+    push_cast; ring
+  rw [hval, ZMod.val_mul]
+  push_cast [Int.natCast_mod]
+  rw [Int.emod_emod_of_dvd _ dvd_rfl]
+
+/-! ## Euler liars form a subgroup -/
+
+/-- The set of **Euler liars** mod `n`: units satisfying the Euler congruence
+`a^((n-1)/2) ≡ J(a | n) (mod n)`, packaged as a subgroup of `(ℤ/nℤ)ˣ`.
+
+Membership equates the two homomorphisms `a ↦ a^((n-1)/2)` and `a ↦ J(a | n)`, so it is
+closed under multiplication and inversion. -/
+def eulerLiars (n : ℕ) [Fact (1 < n)] : Subgroup (ZMod n)ˣ where
+  carrier := {u | ((u : ZMod n)) ^ ((n - 1) / 2) = ((jUnit u : ℤ) : ZMod n)}
+  one_mem' := by
+    simp only [Set.mem_setOf_eq, Units.val_one, one_pow, jUnit_one, Int.cast_one]
+  mul_mem' := by
+    intro a b ha hb
+    simp only [Set.mem_setOf_eq] at ha hb ⊢
+    rw [Units.val_mul, mul_pow, ha, hb, jUnit_mul]
+    push_cast
+    ring
+  inv_mem' := by
+    intro a ha
+    simp only [Set.mem_setOf_eq] at ha ⊢
+    -- `J a⁻¹ = J a` because both are `±1` and their product is `J 1 = 1`.
+    have hja : jUnit a⁻¹ = jUnit a := by
+      have hmul : jUnit (a * a⁻¹) = jUnit a * jUnit a⁻¹ := jUnit_mul a a⁻¹
+      rw [mul_inv_cancel, jUnit_one] at hmul
+      rcases jUnit_eq_one_or a with h | h <;> rcases jUnit_eq_one_or a⁻¹ with h' | h' <;>
+        rw [h, h'] at hmul ⊢ <;> omega
+    -- `a^k` squares to `1` (its value is `±1`), so `(a^k)⁻¹ = a^k`; hence `(↑a⁻¹)^k = ↑(a^k)`.
+    have hsq : (a ^ ((n - 1) / 2)) * (a ^ ((n - 1) / 2)) = 1 := by
+      apply Units.ext
+      rw [Units.val_mul, Units.val_one]
+      simp only [Units.val_pow_eq_pow_val, ha]
+      rcases jUnit_eq_one_or a with h | h <;> rw [h] <;> push_cast <;> ring
+    have hinv : (a ^ ((n - 1) / 2))⁻¹ = a ^ ((n - 1) / 2) := inv_eq_of_mul_eq_one_right hsq
+    calc ((a⁻¹ : (ZMod n)ˣ) : ZMod n) ^ ((n - 1) / 2)
+        = ((a⁻¹ ^ ((n - 1) / 2) : (ZMod n)ˣ) : ZMod n) := by
+          rw [Units.val_pow_eq_pow_val]
+      _ = (((a ^ ((n - 1) / 2))⁻¹ : (ZMod n)ˣ) : ZMod n) := by rw [inv_pow]
+      _ = ((a ^ ((n - 1) / 2) : (ZMod n)ˣ) : ZMod n) := by rw [hinv]
+      _ = ((a : ZMod n)) ^ ((n - 1) / 2) := by rw [Units.val_pow_eq_pow_val]
+      _ = ((jUnit a : ℤ) : ZMod n) := ha
+      _ = ((jUnit a⁻¹ : ℤ) : ZMod n) := by rw [hja]
+
+/-- Membership in `eulerLiars` unfolds to the Euler congruence. -/
+theorem mem_eulerLiars {n : ℕ} [Fact (1 < n)] {u : (ZMod n)ˣ} :
+    u ∈ eulerLiars n ↔ ((u : ZMod n)) ^ ((n - 1) / 2) = ((jUnit u : ℤ) : ZMod n) :=
+  Iff.rfl
+
+/-! ## The density bound: a proper subgroup has index ≥ 2 -/
+
+/-- **Structural Solovay–Strassen bound.** If `E(n)` is a proper subgroup — equivalently, at
+least one Euler *witness* exists — then the Euler liars number at most half the units:
+`|E(n)| ≤ φ(n)/2`. Pure group theory: a proper subgroup of a finite group has index `≥ 2`. -/
+theorem eulerLiars_card_le {n : ℕ} [Fact (1 < n)] (h : eulerLiars n ≠ ⊤) :
+    Nat.card (eulerLiars n) ≤ Nat.card (ZMod n)ˣ / 2 := by
+  have hidx : 1 < (eulerLiars n).index := Subgroup.one_lt_index_of_ne_top h
+  have hmul : (eulerLiars n).index * Nat.card (eulerLiars n) = Nat.card (ZMod n)ˣ :=
+    (eulerLiars n).index_mul_card
+  rw [Nat.le_div_iff_mul_le (by norm_num)]
+  calc Nat.card (eulerLiars n) * 2
+      ≤ Nat.card (eulerLiars n) * (eulerLiars n).index := by
+        apply Nat.mul_le_mul_left; omega
+    _ = (eulerLiars n).index * Nat.card (eulerLiars n) := by ring
+    _ = Nat.card (ZMod n)ˣ := hmul
+
+/-! ## An unconditional Euler witness for `n = p · m`
+
+For `n = p · m` with `p` an odd prime coprime to an odd `m > 1`, we exhibit a concrete Euler
+witness, so `eulerLiars n` is proper and the `½`-bound above applies unconditionally. This
+covers every squarefree odd composite modulus (and more). -/
+
+section Witness
+
+variable {p m : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) (hcop : Nat.Coprime p m)
+  (hm1 : 1 < m) (hmodd : Odd m)
+
+include hp hp2 hcop hm1 hmodd in
+/-- **Euler witnesses exist for `n = p·m`.** The Euler-liar subgroup is proper: there is a unit
+whose Euler congruence fails. Concretely, lift `(non-residue mod p, 1 mod m)` through the CRT
+isomorphism; its Jacobi symbol is `-1` but its power is `≡ 1 (mod m)`. -/
+theorem eulerLiars_ne_top [Fact (1 < p * m)] :
+    eulerLiars (p * m) ≠ ⊤ := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : NeZero p := ⟨hp.pos.ne'⟩
+  haveI : NeZero m := ⟨by omega⟩
+  -- a non-residue `b` mod `p`
+  obtain ⟨b, hb⟩ := FiniteField.exists_nonsquare
+    (by simpa [ZMod.ringChar_zmod_n] using hp2 : ringChar (ZMod p) ≠ 2)
+  have hb0 : b ≠ 0 := by rintro rfl; exact hb ⟨0, by ring⟩
+  -- the CRT preimage of `(b, 1)`, and its residues mod `p` and mod `m`
+  set a₀ : ZMod (p * m) := (ZMod.chineseRemainder hcop).symm (b, 1) with ha₀
+  have hcrt : (ZMod.chineseRemainder hcop) a₀ = (b, 1) :=
+    (ZMod.chineseRemainder hcop).apply_symm_apply _
+  have hfst : (ZMod.castHom (dvd_mul_right p m) (ZMod p)) a₀ = b := by
+    have hc := RingHom.congr_fun
+      (Subsingleton.elim (ZMod.castHom (dvd_mul_right p m) (ZMod p))
+        ((RingHom.fst (ZMod p) (ZMod m)).comp (ZMod.chineseRemainder hcop).toRingHom)) a₀
+    rw [hc]; simp [hcrt]
+  have hsnd : (ZMod.castHom (dvd_mul_left m p) (ZMod m)) a₀ = 1 := by
+    have hc := RingHom.congr_fun
+      (Subsingleton.elim (ZMod.castHom (dvd_mul_left m p) (ZMod m))
+        ((RingHom.snd (ZMod p) (ZMod m)).comp (ZMod.chineseRemainder hcop).toRingHom)) a₀
+    rw [hc]; simp [hcrt]
+  -- `a₀` is a unit
+  have hbunit : IsUnit ((b, 1) : ZMod p × ZMod m) :=
+    Prod.isUnit_iff.mpr ⟨isUnit_iff_ne_zero.mpr hb0, isUnit_one⟩
+  have hunit : IsUnit a₀ := by
+    have := hbunit.map (ZMod.chineseRemainder hcop).symm
+    rwa [ha₀]
+  set u : (ZMod (p * m))ˣ := hunit.unit with hu
+  have hval : (u : ZMod (p * m)) = a₀ := hunit.unit_spec
+  -- the representative and its residues
+  set A : ℕ := (u : ZMod (p * m)).val with hA
+  have hAp : ((A : ℤ) : ZMod p) = b := by
+    rw [hA, Int.cast_natCast, ZMod.natCast_val, ← ZMod.castHom_apply (h := dvd_mul_right p m),
+      hval]
+    exact hfst
+  have hAm : ((A : ℤ) : ZMod m) = 1 := by
+    rw [hA, Int.cast_natCast, ZMod.natCast_val, ← ZMod.castHom_apply (h := dvd_mul_left m p),
+      hval]
+    exact hsnd
+  -- `J(u | p·m) = -1`
+  have hJ : jUnit u = -1 := by
+    unfold jUnit
+    rw [show ((u : ZMod (p * m)).val : ℤ) = (A : ℤ) from rfl,
+      jacobiSym.mul_right (A : ℤ) p m]
+    have hJp : jacobiSym (A : ℤ) p = -1 := by
+      rw [← jacobiSym.legendreSym.to_jacobiSym p (A : ℤ), legendreSym.eq_neg_one_iff]
+      rw [hAp]; exact hb
+    have hJm : jacobiSym (A : ℤ) m = 1 := by
+      have hmod : (A : ℤ) % (m : ℤ) = (1 : ℤ) % (m : ℤ) :=
+        (ZMod.intCast_eq_intCast_iff _ _ _).mp (by rw [Int.cast_one]; exact hAm)
+      rw [jacobiSym.mod_left' hmod, jacobiSym.one_left]
+    rw [hJp, hJm]; ring
+  -- projecting the Euler congruence mod `m` forces `1 = -1`, impossible since `m ≥ 3`
+  intro htop
+  have hmem : u ∈ eulerLiars (p * m) := htop ▸ Subgroup.mem_top u
+  rw [mem_eulerLiars, hJ, Int.cast_neg, Int.cast_one] at hmem
+  -- apply the ring hom `ZMod (p*m) → ZMod m`
+  have hproj := congrArg (ZMod.castHom (dvd_mul_left m p) (ZMod m)) hmem
+  rw [map_pow, map_neg, map_one, hval, hsnd, one_pow] at hproj
+  -- `hproj : (1 : ZMod m) = -1`
+  have hne : (1 : ZMod m) ≠ -1 := by
+    intro h
+    have h2 : ((2 : ℕ) : ZMod m) = 0 := by push_cast; linear_combination h
+    rw [ZMod.natCast_eq_zero_iff] at h2
+    have hle : m ≤ 2 := Nat.le_of_dvd (by norm_num) h2
+    have hm2 : m = 2 := by omega
+    rw [hm2] at hmodd
+    exact (by decide : ¬ Odd 2) hmodd
+  exact hne hproj
+
+include hp hp2 hcop hm1 hmodd in
+/-- **Solovay–Strassen ½-bound for `n = p·m`.** For `p` an odd prime coprime to an odd `m > 1`,
+at most half of the units of `ℤ/(p·m)ℤ` are Euler liars. Every squarefree odd composite `n`
+factors this way, so its Euler witnesses number at least `φ(n)/2`. -/
+theorem solovay_strassen_card_le [Fact (1 < p * m)] :
+    Nat.card (eulerLiars (p * m)) ≤ Nat.card (ZMod (p * m))ˣ / 2 :=
+  eulerLiars_card_le (eulerLiars_ne_top hp hp2 hcop hm1 hmodd)
+
+end Witness
+
+end QuadraticReciprocityOQ04OQ02

--- a/src/data/proofs/quadratic-reciprocity-oq-04-oq-02/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-04-oq-02/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "quadratic-reciprocity-oq-04-oq-02",
+  "title": "Euler Liars Form a Subgroup: the Solovay–Strassen ½-Bound",
+  "slug": "quadratic-reciprocity-oq-04-oq-02",
+  "description": "The sibling leaf quadratic-reciprocity-oq-04-oq-01 proved that Euler liars EXIST for odd composite n. This leaf proves the complementary DENSITY statement — the theorem behind the Solovay–Strassen primality test. The parent entry exhibited a single Euler liar (J(2 | 15) = 1 while 2 is not a square mod 15). This leaf upgrades that lone counterexample into the structural theorem behind the Solovay–Strassen primality test: the set E(n) of Euler liars — units satisfying a^((n-1)/2) ≡ J(a | n) (mod n) — is a SUBGROUP of (ℤ/nℤ)ˣ, because the Euler congruence equates two homomorphisms (the power map and the Jacobi character). Hence the moment one Euler witness exists, Lagrange's theorem forces |E(n)| ≤ φ(n)/2. A concrete CRT construction then produces a witness for every n = p·m with p an odd prime coprime to an odd m > 1 (covering all squarefree odd composites), making the ½-bound unconditional there.",
+  "meta": {
+    "author": "Lean formalization (research leaf: quadratic-reciprocity-oq-04-oq-02, Solovay–Strassen density bound)",
+    "sourceUrl": "https://erdosproblems.com",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticReciprocityOQ04OQ02.lean",
+    "tags": [
+      "quadratic-reciprocity",
+      "jacobi-symbol",
+      "solovay-strassen",
+      "euler-liars",
+      "primality-testing",
+      "group-theory",
+      "lagrange-theorem",
+      "chinese-remainder-theorem",
+      "number-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "jacobiSym.mul_left",
+        "description": "J(a₁·a₂ | b) = J(a₁ | b)·J(a₂ | b) — numerator multiplicativity, the engine that makes the Jacobi character a homomorphism on units",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "jacobiSym.mul_right",
+        "description": "J(a | b₁·b₂) = J(a | b₁)·J(a | b₂) — used to split J(a | p·m) into a Legendre factor and a trivial factor",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "legendreSym.eq_neg_one_iff",
+        "description": "legendreSym p a = -1 ↔ ¬ IsSquare (a : ZMod p) — turns the chosen non-residue into a Jacobi value of -1",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "Subgroup.one_lt_index_of_ne_top",
+        "description": "A proper subgroup of a finite group has index > 1, i.e. ≥ 2 — the Lagrange input for the ½-bound",
+        "module": "Mathlib.GroupTheory.Index"
+      },
+      {
+        "theorem": "Subgroup.index_mul_card",
+        "description": "H.index · |H| = |G| — combined with index ≥ 2 gives |E(n)| ≤ |G|/2",
+        "module": "Mathlib.GroupTheory.Index"
+      },
+      {
+        "theorem": "ZMod.chineseRemainder",
+        "description": "ZMod (p·m) ≃+* ZMod p × ZMod m for coprime p, m — builds the witness unit with prescribed residues",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "FiniteField.exists_nonsquare",
+        "description": "A finite field of characteristic ≠ 2 has a non-square element — supplies the non-residue mod p",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "RingHom.ext_zmod",
+        "description": "Ring homomorphisms out of ZMod n are unique — identifies the CRT projections with the canonical cast maps",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "eulerLiars: the Euler-liar set E(n) = {u ∈ (ℤ/nℤ)ˣ : u^((n-1)/2) ≡ J(u | n)} packaged as a genuine Subgroup of (ℤ/nℤ)ˣ, with full one_mem/mul_mem/inv_mem proofs — the key structural observation that the Euler congruence equates two homomorphisms",
+      "jUnit_mul: the Jacobi symbol of a unit is multiplicative, J(uv) = J(u)·J(v), proved by transporting jacobiSym.mul_left through mod-n invariance of the numerator (the fact that makes E(n) closed under multiplication)",
+      "eulerLiars_card_le: the structural Solovay–Strassen bound — if E(n) is a proper subgroup (one Euler witness exists) then |E(n)| ≤ φ(n)/2, via index ≥ 2 and Lagrange's theorem; a single reduction that subsumes the whole 'at least half the residues expose compositeness' statement",
+      "eulerLiars_ne_top: an unconditional Euler witness for every n = p·m (p an odd prime, gcd(p,m)=1, m odd > 1), built by lifting (non-residue mod p, 1 mod m) through the CRT isomorphism; its Jacobi symbol is (-1)·1 = -1 while its ((n-1)/2)-th power is ≡ 1 (mod m), so the Euler congruence fails mod m since 1 ≠ -1 there (m ≥ 3)",
+      "solovay_strassen_card_le: the unconditional ½-bound |E(p·m)| ≤ φ(p·m)/2, covering every squarefree odd composite modulus, obtained by feeding the CRT witness into the structural bound"
+    ],
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "0 axiom declarations, 0 sorries, 0 structure-encoded assumptions. All 7 theorems depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms on eulerLiars_card_le, solovay_strassen_card_le, and eulerLiars_ne_top; no sorryAx, no Lean.ofReduceBool — no native_decide is used). Builds clean against pinned Mathlib v4.26.0. Scope note: the unconditional witness (and hence the unconditional ½-bound) is established for moduli n = p·m with p an odd prime coprime to an odd m > 1, which includes every squarefree odd composite; the structural subgroup theorem and the 'proper ⟹ ≤ φ(n)/2' reduction hold for every odd n > 1.",
+    "lineCount": 248,
+    "theoremCount": 7,
+    "prerequisites": [
+      "Legendre and Jacobi symbols and Euler's criterion",
+      "Quadratic residues modulo composite numbers",
+      "Subgroups, Lagrange's theorem, and subgroup index",
+      "The Chinese Remainder Theorem for ℤ/nℤ",
+      "The Solovay–Strassen primality test and Euler liars"
+    ],
+    "definitionCount": 3,
+    "lastUpdated": "2026-07-01"
+  },
+  "overview": {
+    "historicalContext": "Euler's criterion says that for a prime p and a coprime to p, a^((p-1)/2) ≡ (a | p) (mod p), so the Legendre symbol exactly certifies quadratic residues. For composite n this identity can still hold for some units — those units are the 'Euler liars', and the residues for which it fails are 'Euler witnesses' to compositeness. Solovay and Strassen (1977) observed that for every odd composite n at least half of the units are Euler witnesses, which turns 'test a random unit' into a Monte-Carlo primality test with error ≤ 2^{-k} after k trials — one of the first randomized algorithms and a landmark in complexity theory. The mathematical core of the test is a subgroup argument: the liars are trapped inside a proper subgroup, so Lagrange bounds their number by half.",
+    "problemStatement": "The parent leaf produced one Euler liar for n = 15. Can the phenomenon be made structural: is the set of Euler liars a subgroup, and can one prove the Solovay–Strassen density bound |E(n)| ≤ φ(n)/2 for composite n rather than just exhibiting a single liar?",
+    "text": "Yes. The Euler congruence a^((n-1)/2) ≡ J(a | n) equates the power homomorphism with the Jacobi character, so its solution set E(n) is a subgroup of (ℤ/nℤ)ˣ. A proper subgroup of a finite group has index ≥ 2, so as soon as one Euler witness exists, |E(n)| ≤ φ(n)/2. A CRT construction supplies such a witness for every n = p·m (p an odd prime coprime to an odd m > 1), making the bound unconditional for all squarefree odd composites.",
+    "proofStrategy": "First show jUnit (the Jacobi symbol of a unit's representative) is ±1-valued and multiplicative, using numerator multiplicativity of jacobiSym plus mod-n invariance. This makes E(n) a subgroup: membership is 'power map = Jacobi character', closed under products (multiplicativity) and inverses (both maps land in ±1, which is self-inverse). For the density bound, a proper subgroup has index ≥ 2 (Subgroup.one_lt_index_of_ne_top), and index · |E(n)| = |(ℤ/nℤ)ˣ| gives |E(n)| ≤ φ(n)/2. For properness, take n = p·m: choose a non-residue b mod p (FiniteField.exists_nonsquare), lift (b, 1) through ZMod.chineseRemainder to a unit u; then J(u | p·m) = J(u | p)·J(u | m) = (-1)·1 = -1, while projecting the Euler congruence to ℤ/mℤ would force 1 = u^((n-1)/2) ≡ -1, impossible since m ≥ 3. Hence u is an Euler witness and E(p·m) is proper.",
+    "keyInsights": [
+      "The Euler congruence is an equation between two group homomorphisms (a ↦ a^((n-1)/2) and the Jacobi character a ↦ J(a | n)), so its solution set is automatically a subgroup — this is the single observation that turns a counterexample into a density theorem",
+      "Once E(n) is a subgroup, the ½-bound is pure Lagrange: a proper subgroup has index ≥ 2, so it captures at most half the group",
+      "The Jacobi character is multiplicative on units precisely because jacobiSym is multiplicative in its numerator and only depends on the numerator mod n",
+      "A CRT witness that is a non-residue mod one prime factor but ≡ 1 mod the cofactor has Jacobi symbol -1 yet power ≡ 1 mod the cofactor, so it must be an Euler witness — the cofactor being ≥ 3 is exactly what separates 1 from -1",
+      "The subgroup framing explains WHY at least half (not merely some) residues witness compositeness, which is what makes the probabilistic test's error decay geometrically"
+    ],
+    "prerequisites": [
+      "Legendre/Jacobi symbols, Euler's criterion, and the Jacobi character",
+      "Subgroups, Lagrange's theorem, and index",
+      "Chinese Remainder Theorem for ℤ/nℤ and non-residues in finite fields"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Docstring framing the upgrade from a single Euler liar to the subgroup structure and the Solovay–Strassen ½-bound; imports Mathlib; namespace QuadraticReciprocityOQ04OQ01; the factNeZero instance deriving NeZero n from Fact (1 < n)",
+      "mathContext": "E(n) = {a ∈ (ℤ/nℤ)ˣ : a^((n-1)/2) ≡ J(a | n)}; the Euler congruence equates two homomorphisms."
+    },
+    {
+      "id": "jacobi-character",
+      "title": "The Jacobi Symbol of a Unit and Its Multiplicativity",
+      "startLine": 51,
+      "endLine": 86,
+      "summary": "jUnit u = J(a | n) for a the representative of u; jUnit_eq_one_or (value is ±1 since units are coprime to n); jUnit_one; jUnit_mul (J(uv) = J(u)·J(v) via jacobiSym.mul_left transported through mod-n invariance)",
+      "mathContext": "$J(uv \\mid n) = J(u \\mid n)\\,J(v \\mid n)$, $J(u \\mid n) \\in \\{\\pm 1\\}$."
+    },
+    {
+      "id": "subgroup",
+      "title": "Euler Liars Form a Subgroup",
+      "startLine": 87,
+      "endLine": 133,
+      "summary": "eulerLiars n : Subgroup (ℤ/nℤ)ˣ with full one_mem/mul_mem/inv_mem proofs (inv uses that a^k squares to 1 because its value is ±1, so (a^k)⁻¹ = a^k); mem_eulerLiars unfolds membership to the Euler congruence",
+      "mathContext": "$E(n) \\le (\\mathbb{Z}/n\\mathbb{Z})^\\times$: closed under product (multiplicativity) and inverse (values in $\\{\\pm1\\}$)."
+    },
+    {
+      "id": "density-bound",
+      "title": "The Density Bound via Lagrange",
+      "startLine": 134,
+      "endLine": 150,
+      "summary": "eulerLiars_card_le: if E(n) is a proper subgroup then |E(n)| ≤ φ(n)/2, from index ≥ 2 (Subgroup.one_lt_index_of_ne_top) and index · |E(n)| = |(ℤ/nℤ)ˣ|",
+      "mathContext": "$E(n) \\ne \\top \\Rightarrow [\\,(\\mathbb{Z}/n\\mathbb{Z})^\\times : E(n)\\,] \\ge 2 \\Rightarrow |E(n)| \\le \\varphi(n)/2$."
+    },
+    {
+      "id": "witness",
+      "title": "An Unconditional CRT Euler Witness for n = p·m",
+      "startLine": 151,
+      "endLine": 248,
+      "summary": "eulerLiars_ne_top: for n = p·m (p odd prime, gcd(p,m)=1, m odd > 1), lift (non-residue mod p, 1 mod m) through ZMod.chineseRemainder to a unit with J = -1 but power ≡ 1 mod m, an Euler witness; solovay_strassen_card_le: the resulting unconditional ½-bound |E(p·m)| ≤ φ(p·m)/2",
+      "mathContext": "Witness $u$: $u \\equiv b\\ (\\mathrm{non\\text{-}residue}) \\bmod p$, $u \\equiv 1 \\bmod m$; $J(u \\mid n) = -1$ yet $u^{(n-1)/2} \\equiv 1 \\bmod m$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Euler liars mod n form a subgroup E(n) of (ℤ/nℤ)ˣ, because the Euler congruence a^((n-1)/2) ≡ J(a | n) equates the power homomorphism with the multiplicative Jacobi character. A proper subgroup of a finite group has index ≥ 2, so a single Euler witness already forces |E(n)| ≤ φ(n)/2 — the Solovay–Strassen density bound. A Chinese-Remainder construction exhibits such a witness for every n = p·m with p an odd prime coprime to an odd m > 1, making the ½-bound unconditional for all squarefree odd composite moduli.",
+    "implications": "This is the rigorous mathematical heart of the Solovay–Strassen probabilistic primality test: because at least half the residues are Euler witnesses, k independent trials fail to detect a composite with probability ≤ 2^{-k}. It promotes the parent's single n = 15 counterexample into a structural theorem (E(n) is a subgroup) and quantifies exactly how often the Jacobi symbol's residue-detection fails.",
+    "openQuestions": [
+      "Can the unconditional witness be extended from n = p·m to the remaining odd composites — the powerful numbers (all prime exponents ≥ 2, e.g. n = 9, 45), whose witness uses an element of order p in (ℤ/nℤ)ˣ rather than the CRT non-residue construction — to close the ½-bound for every odd composite n?",
+      "Can |E(n)| ≤ φ(n)/2 be sharpened to the exact liar count (in terms of the prime factorization of n) that distinguishes Solovay–Strassen from the stronger Miller–Rabin test?",
+      "Can the geometric error decay of the k-round Solovay–Strassen test be formalized as a corollary, packaging the density bound into a probabilistic-algorithm statement?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "scoped BigOperators"
+    ],
+    "namespace": "QuadraticReciprocityOQ04OQ02",
+    "lineCount": 248,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "path": "Proofs/QuadraticReciprocityOQ04OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "quadratic-reciprocity-oq-04",
+      "relationship": "extends",
+      "description": "Grandparent: upgrades its single Euler liar (J(2 | 15) = 1, 2 not a square mod 15) into the subgroup structure and the Solovay–Strassen density bound its open questions asked for."
+    },
+    {
+      "targetId": "quadratic-reciprocity-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Complementary sibling: oq-04-oq-01 establishes EXISTENCE of Euler liars for odd composite n; this leaf establishes the ½-DENSITY bound |E(n)| ≤ φ(n)/2 via the subgroup structure."
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The Jacobi/Legendre reciprocity law and Euler's criterion underlying the Euler-liar condition."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **quadratic-reciprocity-oq-04-oq-02**: the structural theorem behind the **Solovay–Strassen primality test**.

The parent `quadratic-reciprocity-oq-04` exhibited a single Euler liar (`J(2 | 15) = 1` while `2` is not a square mod `15`) and its open questions asked for (1) existence of liars for all odd composite `n` and (2) *the ≤ ½ density of liars*. Sibling leaf `oq-04-oq-01` (already merged, #32772) answered **existence**. This leaf answers the **density** question — a genuinely distinct, deeper result.

## What it proves

- **`eulerLiars n : Subgroup (ℤ/nℤ)ˣ`** — the set `E(n)` of units satisfying the Euler congruence `a^((n-1)/2) ≡ J(a | n) (mod n)` is a *subgroup*, because the congruence equates two homomorphisms (the power map and the multiplicative Jacobi character `jUnit`). This is the "one reduction beats a thousand cases" observation.
- **`eulerLiars_card_le`** — if `E(n)` is a proper subgroup (one Euler *witness* exists), then `|E(n)| ≤ φ(n)/2`, via index ≥ 2 (`Subgroup.one_lt_index_of_ne_top`) and Lagrange (`index_mul_card`). Holds for every odd `n > 1`.
- **`eulerLiars_ne_top`** — an unconditional Euler witness for every `n = p·m` with `p` an odd prime coprime to an odd `m > 1`, built by lifting `(non-residue mod p, 1 mod m)` through `ZMod.chineseRemainder`. Its Jacobi symbol is `(-1)·1 = -1` but its `((n-1)/2)`-th power is `≡ 1 (mod m)`, so the Euler congruence fails mod `m` (as `1 ≠ -1` there, `m ≥ 3`). Covers **every squarefree odd composite** modulus.
- **`solovay_strassen_card_le`** — the resulting unconditional bound `|E(p·m)| ≤ φ(p·m)/2`.

## Verification

- **0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.**
- `#print axioms` on the three headline theorems → only `propext / Classical.choice / Quot.sound`. No `sorryAx`, no `Lean.ofReduceBool` (no `native_decide`).
- Builds clean against pinned Mathlib **v4.26.0**.
- 7 theorems, 2 defs, 1 instance, 248 lines.

## Scope note

The structural subgroup theorem and the `proper ⟹ ≤ φ(n)/2` reduction hold for every odd `n > 1`. The *unconditional* witness (hence unconditional bound) is established for `n = p·m` (odd prime `p` coprime to odd `m > 1`) — all squarefree odd composites. Powerful numbers (all prime exponents ≥ 2, e.g. `9`, `45`) are flagged as the remaining case in the open questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)