### PR TITLE
research(triangular-reciprocals-oq-04-oq-01): simplicial reciprocals ∑1/C(n+d-1,d)=d/(d-1) at every depth d≥2 [VERIFIED, 0-axiom, 13thm/2def/263L, new entry]

### DIFF
--- a/proofs/Proofs/TriangularReciprocalsOQ04OQ01.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ04OQ01.lean
@@ -1,0 +1,263 @@
+/-
+  Reciprocals of Simplicial (Figurate) Numbers — the General-Depth Telescoping Sum
+
+  Result.  For every depth `d ≥ 2`,
+
+      ∑_{n=1}^∞  1 / C(n+d-1, d)  =  d / (d-1).
+
+  Here `C(n+d-1, d)` is the `n`-th `d`-simplicial number
+  (`d = 2`: triangular numbers `n(n+1)/2`; `d = 3`: tetrahedral numbers
+  `n(n+1)(n+2)/6`; and so on).  Reindexing the running term to `n : ℕ` (so the
+  term is `1 / C(n+d, d)`), the statement becomes
+
+      ∑_{n=0}^∞  1 / C(n+d, d)  =  d / (d-1).
+
+  This generalizes the parent entry `TriangularReciprocalsOQ04`, which proves the
+  single depth `d = 3` case (tetrahedral reciprocals sum to `3/2`), and the
+  classical depth `d = 2` case (triangular reciprocals sum to `2`).
+
+  The proof is a single depth-`d` telescoping, uniform in `d`.  Writing `d = m+2`
+  (so `m ≥ 0` ⟺ `d ≥ 2`), the summand telescopes as
+
+      1 / C(n+m+2, m+2)  =  G(n) - G(n+1),
+      G(n) := (m+2)/(m+1) · 1 / C(n+m+1, m+1).
+
+  The telescoping identity reduces to two standard binomial absorption identities
+  (`Nat.succ_mul_choose_eq`, `Nat.choose_succ_right_eq`):
+
+      (n+m+2) · C(n+m+1, m+1) = (m+2) · C(n+m+2, m+2)          (R1)
+      (n+1)   · C(n+m+2, m+1) = (m+2) · C(n+m+2, m+2)          (R2)
+
+  from which `C(n+m+1,m+1)⁻¹ - C(n+m+2,m+1)⁻¹ = (m+1) / ((m+2)·C(n+m+2,m+2))`,
+  and multiplying by `(m+2)/(m+1)` gives `C(n+m+2,m+2)⁻¹`.  The partial sums
+  collapse to `(m+2)/(m+1) - G(N)`, and `G(N) → 0` because
+  `C(N+m+1, m+1) ≥ N+1 → ∞`.
+
+  No axioms, no sorries.
+-/
+
+import Mathlib
+
+set_option linter.unusedVariables false
+
+open Finset BigOperators Filter Topology
+
+namespace TriangularReciprocalsOQ04OQ01
+
+/-- The reciprocal of the `n`-th depth-`(m+2)` simplicial number,
+`1 / C(n+m+2, m+2)` (depth `d = m+2 ≥ 2`). -/
+noncomputable def simpReciprocal (m n : ℕ) : ℝ :=
+  ((Nat.choose (n + m + 2) (m + 2) : ℝ))⁻¹
+
+/-- The telescoping antiderivative `G(n) = (m+2)/(m+1) · 1 / C(n+m+1, m+1)`. -/
+noncomputable def gTele (m n : ℕ) : ℝ :=
+  ((m : ℝ) + 2) / ((m : ℝ) + 1) * ((Nat.choose (n + m + 1) (m + 1) : ℝ))⁻¹
+
+-- ═══════════════════════════════════════════════════
+-- Positivity of the binomial coefficients involved
+-- ═══════════════════════════════════════════════════
+
+private theorem choose_pos_a (m n : ℕ) : 0 < Nat.choose (n + m + 2) (m + 2) :=
+  Nat.choose_pos (by omega)
+
+private theorem choose_pos_p (m n : ℕ) : 0 < Nat.choose (n + m + 1) (m + 1) :=
+  Nat.choose_pos (by omega)
+
+private theorem choose_pos_q (m n : ℕ) : 0 < Nat.choose (n + m + 2) (m + 1) :=
+  Nat.choose_pos (by omega)
+
+-- ═══════════════════════════════════════════════════
+-- The two absorption identities (as ℕ equalities)
+-- ═══════════════════════════════════════════════════
+
+/-- (R1)  `(n+m+2) · C(n+m+1, m+1) = (m+2) · C(n+m+2, m+2)`. -/
+private theorem absorb_R1 (m n : ℕ) :
+    (n + m + 2) * Nat.choose (n + m + 1) (m + 1)
+      = (m + 2) * Nat.choose (n + m + 2) (m + 2) := by
+  have h := Nat.add_one_mul_choose_eq (n + m + 1) (m + 1)
+  -- h : (n+m+1+1) * C(n+m+1, m+1) = C(n+m+1+1, m+1+1) * (m+1+1)
+  have e1 : n + m + 1 + 1 = n + m + 2 := by ring
+  have e2 : m + 1 + 1 = m + 2 := by ring
+  rw [e1, e2] at h
+  rw [h]; ring
+
+/-- (R2)  `(n+1) · C(n+m+2, m+1) = (m+2) · C(n+m+2, m+2)`. -/
+private theorem absorb_R2 (m n : ℕ) :
+    (n + 1) * Nat.choose (n + m + 2) (m + 1)
+      = (m + 2) * Nat.choose (n + m + 2) (m + 2) := by
+  have h := Nat.choose_succ_right_eq (n + m + 2) (m + 1)
+  -- h : C(n+m+2, m+1+1) * (m+1+1) = C(n+m+2, m+1) * (n+m+2 - (m+1))
+  have e2 : m + 1 + 1 = m + 2 := by ring
+  have e3 : n + m + 2 - (m + 1) = n + 1 := by omega
+  rw [e2, e3] at h
+  -- h : C(n+m+2, m+2) * (m+2) = C(n+m+2, m+1) * (n+1)
+  rw [mul_comm (m + 2), mul_comm (n + 1)] at *
+  linarith [h]
+
+-- ═══════════════════════════════════════════════════
+-- Lemma: the depth-d telescoping identity
+-- ═══════════════════════════════════════════════════
+
+/-- `1 / C(n+m+2, m+2) = G(n) - G(n+1)`. -/
+theorem simp_telescope (m n : ℕ) :
+    simpReciprocal m n = gTele m n - gTele m (n + 1) := by
+  unfold simpReciprocal gTele
+  -- Real casts of the three (positive) binomials.
+  set a : ℝ := (Nat.choose (n + m + 2) (m + 2) : ℝ) with ha_def
+  set p : ℝ := (Nat.choose (n + m + 1) (m + 1) : ℝ) with hp_def
+  set q : ℝ := (Nat.choose (n + m + 2) (m + 1) : ℝ) with hq_def
+  have ha : 0 < a := by rw [ha_def]; exact_mod_cast choose_pos_a m n
+  have hp : 0 < p := by rw [hp_def]; exact_mod_cast choose_pos_p m n
+  have hq : 0 < q := by rw [hq_def]; exact_mod_cast choose_pos_q m n
+  have hm1 : (0 : ℝ) < (m : ℝ) + 1 := by positivity
+  have hm2 : (0 : ℝ) < (m : ℝ) + 2 := by positivity
+  -- The (n+1)-shifted G uses C(n+1+m+1, m+1) = C(n+m+2, m+1) = q.
+  have hshift : ((Nat.choose (n + 1 + m + 1) (m + 1) : ℝ)) = q := by
+    rw [hq_def]
+    have e : n + 1 + m + 1 = n + m + 2 := by ring
+    rw [e]
+  rw [hshift]
+  -- Cast the two absorption identities to ℝ.
+  have R1 : ((n : ℝ) + m + 2) * p = ((m : ℝ) + 2) * a := by
+    have := absorb_R1 m n
+    rw [ha_def, hp_def]
+    have : ((( n + m + 2) * Nat.choose (n + m + 1) (m + 1) : ℕ) : ℝ)
+        = (((m + 2) * Nat.choose (n + m + 2) (m + 2) : ℕ) : ℝ) := by exact_mod_cast this
+    push_cast at this ⊢
+    linarith [this]
+  have R2 : ((n : ℝ) + 1) * q = ((m : ℝ) + 2) * a := by
+    have := absorb_R2 m n
+    rw [ha_def, hq_def]
+    have : (((n + 1) * Nat.choose (n + m + 2) (m + 1) : ℕ) : ℝ)
+        = (((m + 2) * Nat.choose (n + m + 2) (m + 2) : ℕ) : ℝ) := by exact_mod_cast this
+    push_cast at this ⊢
+    linarith [this]
+  -- p⁻¹ and q⁻¹ in terms of a.
+  have hp_ne : p ≠ 0 := ne_of_gt hp
+  have hq_ne : q ≠ 0 := ne_of_gt hq
+  have ha_ne : a ≠ 0 := ne_of_gt ha
+  have hpinv : p⁻¹ = ((n : ℝ) + m + 2) / (((m : ℝ) + 2) * a) := by
+    rw [eq_div_iff (by positivity)]
+    field_simp
+    nlinarith [R1]
+  have hqinv : q⁻¹ = ((n : ℝ) + 1) / (((m : ℝ) + 2) * a) := by
+    rw [eq_div_iff (by positivity)]
+    field_simp
+    nlinarith [R2]
+  rw [hpinv, hqinv]
+  field_simp
+  ring
+
+-- ═══════════════════════════════════════════════════
+-- Partial sums via telescoping
+-- ═══════════════════════════════════════════════════
+
+/-- `∑_{i<N} 1/C(i+m+2, m+2) = (m+2)/(m+1) - G(N)`. -/
+theorem partial_sum_closed_form (m N : ℕ) :
+    ∑ i ∈ Finset.range N, simpReciprocal m i
+      = ((m : ℝ) + 2) / ((m : ℝ) + 1) - gTele m N := by
+  have htel : ∑ i ∈ Finset.range N, simpReciprocal m i
+      = ∑ i ∈ Finset.range N, (gTele m i - gTele m (i + 1)) :=
+    Finset.sum_congr rfl (fun i _ => simp_telescope m i)
+  rw [htel, Finset.sum_range_sub' (gTele m) N]
+  -- G(0) = (m+2)/(m+1) · 1/C(m+1, m+1) = (m+2)/(m+1).
+  have hG0 : gTele m 0 = ((m : ℝ) + 2) / ((m : ℝ) + 1) := by
+    unfold gTele
+    have : Nat.choose (0 + m + 1) (m + 1) = 1 := by
+      simp [Nat.choose_self]
+    rw [this]; norm_num
+  rw [hG0]
+
+-- ═══════════════════════════════════════════════════
+-- Lower bound on the binomial (for convergence)
+-- ═══════════════════════════════════════════════════
+
+/-- `C(N + (m+1), m+1) ≥ N + 1`.  The tail `1/C(N+m+1, m+1)` is therefore squeezed
+by `1/(N+1)`. -/
+private theorem choose_ge (m N : ℕ) : N + 1 ≤ Nat.choose (N + m + 1) (m + 1) := by
+  induction N with
+  | zero => simp [Nat.choose_self]
+  | succ K ih =>
+    -- C(K+1+m+1, m+1) = C((K+m+1)+1, m+1) = C(K+m+1, m+1) + C(K+m+1, m).
+    have hp : K + 1 + m + 1 = (K + m + 1) + 1 := by ring
+    rw [hp, Nat.choose_succ_succ' (K + m + 1) m]
+    have hpos : 1 ≤ Nat.choose (K + m + 1) m := Nat.choose_pos (by omega)
+    omega
+
+-- ═══════════════════════════════════════════════════
+-- Tail G(N) → 0
+-- ═══════════════════════════════════════════════════
+
+theorem gTele_tendsto_zero (m : ℕ) :
+    Tendsto (fun N : ℕ => gTele m N) atTop (𝓝 0) := by
+  -- G N = c · (C(N+m+1, m+1))⁻¹ with c = (m+2)/(m+1); the reciprocal → 0.
+  have hrec : Tendsto (fun N : ℕ => ((Nat.choose (N + m + 1) (m + 1) : ℝ))⁻¹)
+      atTop (𝓝 0) := by
+    have hbound : Tendsto (fun N : ℕ => (1 : ℝ) / ((N : ℝ) + 1)) atTop (𝓝 0) :=
+      tendsto_one_div_add_atTop_nhds_zero_nat
+    apply squeeze_zero (g := fun N : ℕ => (1 : ℝ) / ((N : ℝ) + 1))
+    · intro N; positivity
+    · intro N
+      have hchoose : (N : ℝ) + 1 ≤ (Nat.choose (N + m + 1) (m + 1) : ℝ) := by
+        have := choose_ge m N
+        have hc : ((N + 1 : ℕ) : ℝ) ≤ ((Nat.choose (N + m + 1) (m + 1) : ℕ) : ℝ) := by
+          exact_mod_cast this
+        push_cast at hc; linarith [hc]
+      have hpos : (0 : ℝ) < (N : ℝ) + 1 := by positivity
+      simpa [one_div] using one_div_le_one_div_of_le hpos hchoose
+    · exact hbound
+  have := hrec.const_mul (((m : ℝ) + 2) / ((m : ℝ) + 1))
+  rw [mul_zero] at this
+  simpa [gTele, mul_comm] using this
+
+-- ═══════════════════════════════════════════════════
+-- Main Theorem
+-- ═══════════════════════════════════════════════════
+
+/-- **General-depth simplicial reciprocals.**  For every depth `d = m+2 ≥ 2`,
+
+      ∑_{n=0}^∞  1 / C(n+d, d)  =  d / (d-1),
+
+    i.e. `HasSum (fun n => 1 / C(n+m+2, m+2)) ((m+2)/(m+1))`.  Reindexing the term to
+    `n ≥ 1` (term `1/C(n+d-1, d)`) this is the classical `∑_{n≥1} 1/C(n+d-1,d) = d/(d-1)`. -/
+theorem simplicial_reciprocals (m : ℕ) :
+    HasSum (simpReciprocal m) (((m : ℝ) + 2) / ((m : ℝ) + 1)) := by
+  have h_nonneg : ∀ n : ℕ, 0 ≤ simpReciprocal m n := by
+    intro n; unfold simpReciprocal; positivity
+  rw [hasSum_iff_tendsto_nat_of_nonneg h_nonneg]
+  rw [show (fun N : ℕ => ∑ i ∈ Finset.range N, simpReciprocal m i)
+        = fun N : ℕ => ((m : ℝ) + 2) / ((m : ℝ) + 1) - gTele m N from
+      funext (partial_sum_closed_form m)]
+  have h_lim : Tendsto
+      (fun N : ℕ => ((m : ℝ) + 2) / ((m : ℝ) + 1) - gTele m N)
+      atTop (𝓝 (((m : ℝ) + 2) / ((m : ℝ) + 1) - 0)) :=
+    tendsto_const_nhds.sub (gTele_tendsto_zero m)
+  rwa [sub_zero] at h_lim
+
+/-- tsum form of the general-depth simplicial reciprocal sum. -/
+theorem simplicial_reciprocals_tsum (m : ℕ) :
+    ∑' n : ℕ, simpReciprocal m n = ((m : ℝ) + 2) / ((m : ℝ) + 1) :=
+  (simplicial_reciprocals m).tsum_eq
+
+-- ═══════════════════════════════════════════════════
+-- Specializations recovering the classical cases
+-- ═══════════════════════════════════════════════════
+
+/-- Depth `d = 2` (triangular reciprocals): `∑ 1/C(n+2, 2) = 2`. -/
+theorem triangular_case : HasSum (simpReciprocal 0) (2 : ℝ) := by
+  have h := simplicial_reciprocals 0
+  norm_num at h
+  simpa using h
+
+/-- Depth `d = 3` (tetrahedral reciprocals, the parent entry): `∑ 1/C(n+3, 3) = 3/2`. -/
+theorem tetrahedral_case : HasSum (simpReciprocal 1) (3 / 2 : ℝ) := by
+  have h := simplicial_reciprocals 1
+  norm_num at h
+  simpa using h
+
+-- Sanity checks of the summand.
+/-- First term at depth `d`: `1/C(m+2, m+2) = 1`. -/
+example (m : ℕ) : simpReciprocal m 0 = 1 := by
+  unfold simpReciprocal; simp [Nat.choose_self]
+
+end TriangularReciprocalsOQ04OQ01

--- a/src/data/proofs/triangular-reciprocals-oq-04-oq-01/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-04-oq-01/meta.json
@@ -1,0 +1,215 @@
+{
+  "id": "triangular-reciprocals-oq-04-oq-01",
+  "title": "Simplicial Reciprocals Sum to d/(d-1) at Every Depth",
+  "slug": "triangular-reciprocals-oq-04-oq-01",
+  "description": "For every depth d ≥ 2 the reciprocals of the d-simplicial numbers sum to d/(d-1): ∑_{n=1}^∞ 1/C(n+d-1,d) = d/(d-1). Reindexed, ∑_{n=0}^∞ 1/C(n+d,d) = d/(d-1). Proved by a single depth-d telescoping uniform in d, generalizing the parent tetrahedral (d=3 → 3/2) and classical triangular (d=2 → 2) cases.",
+  "meta": {
+    "author": "Classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Figurate_number",
+    "date": "Classical",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "series",
+      "figurate-numbers",
+      "telescoping",
+      "binomial-coefficients",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/TriangularReciprocalsOQ04OQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.add_one_mul_choose_eq",
+        "description": "Absorption identity (n+1)·C(n,k) = C(n+1,k+1)·(k+1)",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "Absorption identity C(n,k+1)·(k+1) = C(n,k)·(n-k)",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_sub'",
+        "description": "Telescoping sum ∑_{i<N} (f i - f (i+1)) = f 0 - f N",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "hasSum_iff_tendsto_nat_of_nonneg",
+        "description": "A nonnegative series HasSum its limit iff the partial sums converge",
+        "module": "Mathlib.Topology.Instances.ENNReal.Lemmas"
+      },
+      {
+        "theorem": "tendsto_one_div_add_atTop_nhds_zero_nat",
+        "description": "1/(n+1) → 0 as n → ∞",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "squeeze_zero",
+        "description": "Squeeze theorem for convergence to zero",
+        "module": "Mathlib.Topology.Order.Bornology"
+      }
+    ],
+    "originalContributions": [
+      "General-depth identity ∑_{n≥0} 1/C(n+d,d) = d/(d-1) for every d = m+2 ≥ 2, proved uniformly in d (one telescoping, not depth-by-depth)",
+      "Depth-d telescoping identity 1/C(n+m+2,m+2) = G(n) - G(n+1) with G(n) = (m+2)/(m+1)·1/C(n+m+1,m+1), reduced entirely to two Nat binomial absorption identities",
+      "Casting the absorption identities (n+m+2)·C(n+m+1,m+1) = (m+2)·C(n+m+2,m+2) and (n+1)·C(n+m+2,m+1) = (m+2)·C(n+m+2,m+2) to obtain the real telescope",
+      "Elementary binomial lower bound C(N+m+1,m+1) ≥ N+1 (Pascal induction) giving the vanishing tail G(N) → 0",
+      "Specializations recovering the triangular (d=2 → 2) and parent tetrahedral (d=3 → 3/2) cases as one-line corollaries"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 263,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 13,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The d-simplicial (figurate) numbers C(n+d-1,d) form the (d+1)-st column of Pascal's triangle: d=2 gives the triangular numbers n(n+1)/2, d=3 the tetrahedral numbers n(n+1)(n+2)/6, d=4 the pentatope numbers, and so on. The classical reciprocal sum ∑_{n≥1} 1/C(n+d-1,d) = d/(d-1) for d ≥ 2 was known to Leibniz and the Bernoullis (the d=2 case ∑ 2/(n(n+1)) = 2 is Leibniz's 1673 telescoping triangle; the d=3 case gives 3/2). This entry answers the open question stated by the parent tetrahedral entry (triangular-reciprocals-oq-04) by proving the whole family at once, uniformly in the depth d.",
+    "problemStatement": "**Simplicial Reciprocals at Every Depth**: for every integer $d \\ge 2$,\n\n$$\\sum_{n=1}^{\\infty} \\frac{1}{\\binom{n+d-1}{d}} = \\frac{d}{d-1}.$$\n\nReindexing to $n \\ge 0$ (running term $1/\\binom{n+d}{d}$),\n\n$$\\sum_{n=0}^{\\infty} \\frac{1}{\\binom{n+d}{d}} = \\frac{d}{d-1}.$$",
+    "text": "For every depth d ≥ 2 the reciprocals of the d-simplicial numbers C(n+d-1,d) sum to d/(d-1). This is proved by a single telescoping argument uniform in d, generalizing the depth-2 (triangular, value 2) and depth-3 (tetrahedral, value 3/2) special cases.",
+    "proofStrategy": "Write d = m+2 (so d ≥ 2 ⟺ m ≥ 0), eliminating all natural-number subtraction. The summand telescopes as 1/C(n+m+2,m+2) = G(n) - G(n+1) with G(n) = (m+2)/(m+1)·1/C(n+m+1,m+1). The telescoping identity is reduced to two standard binomial absorption identities: (n+m+2)·C(n+m+1,m+1) = (m+2)·C(n+m+2,m+2) (from Nat.add_one_mul_choose_eq) and (n+1)·C(n+m+2,m+1) = (m+2)·C(n+m+2,m+2) (from Nat.choose_succ_right_eq). Casting both to ℝ and using positivity of the binomials, C(n+m+1,m+1)⁻¹ - C(n+m+2,m+1)⁻¹ = (m+1)/((m+2)·C(n+m+2,m+2)), and multiplying by (m+2)/(m+1) yields C(n+m+2,m+2)⁻¹. The partial sums collapse (Finset.sum_range_sub') to (m+2)/(m+1) - G(N), and G(N) → 0 because C(N+m+1,m+1) ≥ N+1 (Pascal induction) squeezes the reciprocal below 1/(N+1). hasSum_iff_tendsto_nat_of_nonneg finishes.",
+    "keyInsights": [
+      "The whole family is proved uniformly in the depth d — a single telescoping, not a separate induction for each depth. The parent open question asked for 'induction on the telescoping depth'; the sharper observation is that no induction on depth is needed at all, because the telescope is depth-agnostic once the summand is written as a difference of consecutive depth-(d-1) reciprocals.",
+      "The telescoping antiderivative G lives one figurate dimension down (depth d-1) than the summand (depth d) and carries the scalar d/(d-1); the entire analytic content is packaged into two purely combinatorial Nat identities, so no partial-fraction algebra over ℝ is required.",
+      "Both absorption identities are the committee/chair rule k·C(m,k) = m·C(m-1,k-1) read in the two adjacent directions: one lowers the depth (C(n+d,d) ↔ C(n+d-1,d-1)), the other shifts the upper index at fixed depth (C(n+d,d) ↔ C(n+d,d-1)). Their difference telescopes.",
+      "Reindexing d = m+2 removes every ℕ-subtraction (d-1, n-k), so the two absorption identities hold on the nose and cast to ℝ with push_cast + linarith, avoiding truncated-subtraction hazards.",
+      "The limit d/(d-1) decreases monotonically to 1 as d → ∞: triangular 2, tetrahedral 3/2, pentatope 4/3, …; the deeper the simplex, the closer the total to 1 (the first term alone is always exactly 1)."
+    ],
+    "prerequisites": [
+      "Real analysis (series convergence, telescoping sums)",
+      "Binomial coefficients and their absorption identities",
+      "Figurate/simplicial numbers as columns of Pascal's triangle"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Summand and Telescoping Antiderivative",
+      "startLine": 47,
+      "endLine": 54,
+      "summary": "Defines simpReciprocal m n = 1/C(n+m+2,m+2) (depth d=m+2) and the antiderivative gTele m n = (m+2)/(m+1)·1/C(n+m+1,m+1).",
+      "mathContext": "The depth-$(m+2)$ summand $1/\\binom{n+m+2}{m+2}$ and antiderivative $G(n) = \\frac{m+2}{m+1}\\cdot\\frac{1}{\\binom{n+m+1}{m+1}}$, chosen so $f(n) = G(n) - G(n+1)$."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity of the Binomials",
+      "startLine": 56,
+      "endLine": 66,
+      "summary": "The three binomial coefficients C(n+m+2,m+2), C(n+m+1,m+1), C(n+m+2,m+1) are all positive (lower ≤ upper).",
+      "mathContext": "Each $\\binom{a}{b} > 0$ since $b \\le a$, needed to invert the casts in ℝ."
+    },
+    {
+      "id": "absorption",
+      "title": "The Two Absorption Identities",
+      "startLine": 68,
+      "endLine": 98,
+      "summary": "R1: (n+m+2)·C(n+m+1,m+1) = (m+2)·C(n+m+2,m+2) from Nat.add_one_mul_choose_eq. R2: (n+1)·C(n+m+2,m+1) = (m+2)·C(n+m+2,m+2) from Nat.choose_succ_right_eq.",
+      "mathContext": "The committee/chair rule $k\\binom{m}{k} = m\\binom{m-1}{k-1}$ read in two adjacent directions — one lowering depth, one shifting the upper index at fixed depth."
+    },
+    {
+      "id": "telescope",
+      "title": "Depth-d Telescoping Identity",
+      "startLine": 100,
+      "endLine": 153,
+      "summary": "Proves 1/C(n+m+2,m+2) = G(n) - G(n+1) by casting R1, R2 to ℝ, computing the two reciprocals in terms of C(n+m+2,m+2), and clearing denominators.",
+      "mathContext": "$\\frac{1}{\\binom{n+d}{d}} = G(n) - G(n+1)$; from R1, R2 the bracket $\\binom{n+d-1}{d-1}^{-1} - \\binom{n+d}{d-1}^{-1} = \\frac{d-1}{d\\binom{n+d}{d}}$, and $\\frac{d}{d-1}$ times it is $\\binom{n+d}{d}^{-1}$."
+    },
+    {
+      "id": "partial-sum",
+      "title": "Closed Form for the Partial Sum",
+      "startLine": 155,
+      "endLine": 174,
+      "summary": "Uses Finset.sum_range_sub' to collapse the telescope: ∑_{i<N} f(i) = G(0) - G(N) = (m+2)/(m+1) - G(N), with G(0) = (m+2)/(m+1) since C(m+1,m+1)=1.",
+      "mathContext": "$\\sum_{i<N} \\binom{i+d}{d}^{-1} = \\frac{d}{d-1} - G(N)$."
+    },
+    {
+      "id": "choose-bound",
+      "title": "Binomial Lower Bound",
+      "startLine": 176,
+      "endLine": 188,
+      "summary": "Elementary Pascal induction: C(N+m+1,m+1) ≥ N+1 for all N (depth m+1 ≥ 1).",
+      "mathContext": "$\\binom{N+d-1}{d-1} \\ge N+1$, giving the growth needed for the tail to vanish."
+    },
+    {
+      "id": "tail",
+      "title": "Tail Vanishes",
+      "startLine": 190,
+      "endLine": 220,
+      "summary": "G(N) → 0: the reciprocal C(N+m+1,m+1)⁻¹ is squeezed between 0 and 1/(N+1) (using the lower bound) and G is a constant multiple of it.",
+      "mathContext": "$G(N) = \\frac{d}{d-1}\\binom{N+d-1}{d-1}^{-1} \\to 0$ since $\\binom{N+d-1}{d-1} \\ge N+1 \\to \\infty$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem",
+      "startLine": 222,
+      "endLine": 241,
+      "summary": "Combines the closed form and vanishing tail into HasSum (simpReciprocal m) ((m+2)/(m+1)) via hasSum_iff_tendsto_nat_of_nonneg, plus the tsum form.",
+      "mathContext": "$\\sum_{n=0}^{\\infty} \\binom{n+d}{d}^{-1} = \\frac{d}{d-1}$ for every $d = m+2 \\ge 2$."
+    },
+    {
+      "id": "specializations",
+      "title": "Classical Special Cases",
+      "startLine": 243,
+      "endLine": 262,
+      "summary": "Recovers the triangular case ∑1/C(n+2,2) = 2 (m=0) and the parent tetrahedral case ∑1/C(n+3,3) = 3/2 (m=1) as corollaries, plus the first-term sanity check f(0)=1.",
+      "mathContext": "$d=2 \\Rightarrow 2$ (triangular), $d=3 \\Rightarrow 3/2$ (tetrahedral, the parent entry). The first term $1/\\binom{d}{d} = 1$ at every depth."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "triangular-reciprocals-oq-04",
+      "relationship": "extends",
+      "description": "Directly answers the open question stated by the parent tetrahedral entry ('prove ∑1/C(n+d-1,d) = d/(d-1) for arbitrary d ≥ 2'), generalizing its single depth-3 result (3/2) to the whole family, uniformly in d."
+    },
+    {
+      "targetId": "triangular-reciprocals",
+      "relationship": "extends",
+      "description": "The depth-2 case (d=2, value 2) of this family is the classical triangular-reciprocal sum ∑2/(n(n+1)) = 2; here it is a one-line specialization m=0."
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "related",
+      "description": "The d-simplicial numbers are binomial coefficients C(n+d-1,d) (columns of Pascal's triangle); the proof runs entirely on the binomial absorption identities rather than partial fractions."
+    },
+    {
+      "targetId": "triangular-reciprocals-oq-02",
+      "relationship": "related",
+      "description": "That entry sums shifted reciprocal products ∑1/(n(n+k)) = H_k/k via depth-1 partial fractions with an arbitrary shift; this instead increases the depth d at fixed shift and works uniformly in d."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Both evaluate reciprocal series over structured integer sequences in closed form; Basel gives ∑1/n² = π²/6, while this gives a rational value d/(d-1) at every simplicial depth."
+    }
+  ],
+  "conclusion": {
+    "summary": "For every depth d ≥ 2 the d-simplicial reciprocals sum to d/(d-1), fully machine-verified with zero axioms and zero sorries. A single depth-agnostic telescoping — reduced to two Nat binomial absorption identities — proves the entire family at once, subsuming the classical triangular (d=2 → 2) and parent tetrahedral (d=3 → 3/2) cases.",
+    "implications": "One reduction replaces the depth-by-depth induction suggested by the parent open question: because the summand 1/C(n+d,d) is intrinsically a difference of consecutive depth-(d-1) reciprocals scaled by d/(d-1), the telescope needs no recursion on d. The value d/(d-1) decreases monotonically to 1 as d → ∞ (2, 3/2, 4/3, 5/4, …), while the first term is always exactly 1.",
+    "openQuestions": [
+      "Give a closed form for the finite truncation error d/(d-1) - ∑_{n<N} 1/C(n+d,d) = (d/(d-1))·1/C(N+d-1,d-1) and its dependence on d (the tail decays like d/((d-1)·N^{d-1})).",
+      "Evaluate the alternating simplicial reciprocal sum ∑_{n≥0} (-1)^n/C(n+d,d) in closed form and compare with the alternating triangular case (d=2)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "TriangularReciprocalsOQ04OQ01",
+    "lineCount": 263,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 2,
+    "path": "Proofs/TriangularReciprocalsOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **triangular-reciprocals-oq-04-oq-01**, directly answering the open question posed by the parent tetrahedral entry (`triangular-reciprocals-oq-04`):

> *Prove the general figurate-reciprocal identity ∑_{n≥1} 1/C(n+d−1,d) = d/(d−1) for arbitrary d ≥ 2.*

**Result.** For every depth `d ≥ 2`,
```
∑_{n=1}^∞ 1/C(n+d-1, d) = d/(d-1)      (reindexed: ∑_{n=0}^∞ 1/C(n+d,d) = d/(d-1))
```
proved **uniformly in d** by a single depth-agnostic telescoping — no induction on depth.

## Proof architecture
- Write `d = m+2` to eliminate all ℕ-subtraction.
- Telescope `1/C(n+m+2,m+2) = G(n) − G(n+1)` with `G(n) = (m+2)/(m+1)·1/C(n+m+1,m+1)`.
- The telescoping identity reduces to two standard Nat binomial **absorption identities** (`Nat.add_one_mul_choose_eq`, `Nat.choose_succ_right_eq`), cast to ℝ.
- Partial sums collapse via `Finset.sum_range_sub'` to `(m+2)/(m+1) − G(N)`; the tail vanishes because `C(N+m+1,m+1) ≥ N+1` (elementary Pascal induction) squeezes the reciprocal below `1/(N+1)`.
- Specializations recover the triangular (d=2 → **2**) and parent tetrahedral (d=3 → **3/2**) cases as one-line corollaries.

## Verification
- **0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.**
- `#print axioms simplicial_reciprocals` → `propext, Classical.choice, Quot.sound` only (no `Lean.ofReduceBool`, no `sorryAx`).
- Build-verified via `lake env lean Proofs/TriangularReciprocalsOQ04OQ01.lean` (exit 0, reuses repo Mathlib cache).
- 13 theorems, 2 definitions, 263 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)