### PR TITLE
Enrich The Canonical Gaussian Generator (pythagorean-theorem-oq-04-oq-01): add annotations.json (0→9)

### DIFF
--- a/src/data/proofs/pythagorean-theorem-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-theorem-oq-04-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-pt040401-overview",
+    "proofId": "pythagorean-theorem-oq-04-oq-01",
+    "range": { "startLine": 5, "endLine": 37 },
+    "type": "concept",
+    "title": "From ‘up to sign’ to a genuine ∃!",
+    "content": "The parent entry pythagorean-theorem-oq-04 shows every primitive Pythagorean triple (x, y, z) with x odd, z > 0 is the square of a Gaussian integer g = m + ni, unique only up to sign: any two generators satisfy g = h or g = −h. This file removes that residual ambiguity. It fixes a canonical sign convention (IsCanonical), proves exactly one of g, −g meets it, and thereby upgrades the up-to-sign statement to a bona-fide existence-and-uniqueness result canonical_generator_existsUnique. The square-root fibre is quantified in passing: the set of Gaussian square roots of x + yi is exactly the two-element set {g, −g}.",
+    "mathContext": "$x + yi = g^2$ with $g$ unique up to the sign group $\\{\\pm 1\\}$; canonicity selects one representative of each pair $\\{g, -g\\}$, giving $\\exists!\\, g$ with $x + yi = g^2$ and $g$ canonical.",
+    "significance": "key",
+    "relatedConcepts": ["Gaussian integers", "primitive Pythagorean triples", "fundamental domain", "unique existence"],
+    "prerequisites": ["Gaussian integers ℤ[i]", "the parent entry pythagorean-theorem-oq-04"]
+  },
+  {
+    "id": "ann-pt040401-iscanonical",
+    "proofId": "pythagorean-theorem-oq-04-oq-01",
+    "range": { "startLine": 50, "endLine": 50 },
+    "type": "definition",
+    "title": "IsCanonical: a fundamental domain for {±1}",
+    "content": "A Gaussian integer a + bi is declared canonical when its real part is positive, or it is purely imaginary with positive imaginary part. This is a lexicographic positivity condition on the pair (a, b): compare real parts first, break ties by the imaginary part. The point of the definition is that it picks a single distinguished representative from each sign pair {g, −g} — a fundamental domain for the order-2 action of {±1} on ℤ[i].",
+    "mathContext": "$\\mathrm{IsCanonical}(a + bi) \\iff a > 0 \\;\\lor\\; (a = 0 \\land b > 0)$.",
+    "significance": "key",
+    "relatedConcepts": ["fundamental domain", "group action {±1}", "lexicographic order", "sign normalization"],
+    "prerequisites": ["Gaussian integers ℤ[i]", "real and imaginary parts of Zsqrtd"]
+  },
+  {
+    "id": "ann-pt040401-notboth",
+    "proofId": "pythagorean-theorem-oq-04-oq-01",
+    "range": { "startLine": 53, "endLine": 57 },
+    "type": "theorem",
+    "title": "g and −g are never both canonical",
+    "content": "If g is canonical then −g is not. The proof is a pure sign case analysis: after rewriting (−g).re = −g.re and (−g).im = −g.im, the four combinations of the two disjuncts are all contradictory and closed by omega. This is the ‘at most one’ half of the fundamental-domain property.",
+    "mathContext": "$\\mathrm{IsCanonical}(g) \\Rightarrow \\lnot\\,\\mathrm{IsCanonical}(-g)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["fundamental domain", "case analysis", "omega"],
+    "prerequisites": ["Zsqrtd.re_neg / Zsqrtd.im_neg"]
+  },
+  {
+    "id": "ann-pt040401-atleastone",
+    "proofId": "pythagorean-theorem-oq-04-oq-01",
+    "range": { "startLine": 60, "endLine": 71 },
+    "type": "theorem",
+    "title": "At least one of g, −g is canonical",
+    "content": "For a nonzero Gaussian integer, at least one of g and −g is canonical. Nonzeroness first gives that re or im is nonzero (via Zsqrtd.ext); unfolding IsCanonical and rewriting the negations, omega then finds a canonical member. This is the ‘at least one’ half, i.e. surjectivity of the sign-selection onto orbits.",
+    "mathContext": "$g \\neq 0 \\Rightarrow \\mathrm{IsCanonical}(g) \\lor \\mathrm{IsCanonical}(-g)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["fundamental domain", "Zsqrtd.ext", "omega"],
+    "prerequisites": ["nonzero Gaussian integer has nonzero re or im"]
+  },
+  {
+    "id": "ann-pt040401-xor",
+    "proofId": "pythagorean-theorem-oq-04-oq-01",
+    "range": { "startLine": 75, "endLine": 79 },
+    "type": "theorem",
+    "title": "Exactly one of g, −g is canonical",
+    "content": "Combining the previous two lemmas: for g ≠ 0, exactly one of g and −g is canonical. This single lemma IS the fundamental-domain property — every orbit {g, −g} of the sign action meets the canonical set in exactly one point. Once this holds, the main ∃! is a short assembly of parent facts.",
+    "mathContext": "$g \\neq 0 \\Rightarrow \\big(\\mathrm{IsCanonical}(g) \\land \\lnot\\mathrm{IsCanonical}(-g)\\big) \\ \\underline{\\lor}\\ \\big(\\lnot\\mathrm{IsCanonical}(g) \\land \\mathrm{IsCanonical}(-g)\\big)$.",
+    "significance": "key",
+    "relatedConcepts": ["fundamental domain", "exclusive or", "orbit of a group action"],
+    "prerequisites": ["not_isCanonical_neg_of_isCanonical", "isCanonical_or_neg"]
+  },
+  {
+    "id": "ann-pt040401-sqroots-pair",
+    "proofId": "pythagorean-theorem-oq-04-oq-01",
+    "range": { "startLine": 84, "endLine": 89 },
+    "type": "theorem",
+    "title": "The square-root fibre is the sign pair {g, −g}",
+    "content": "The set of Gaussian square roots of w = g² is exactly {g, −g}. The proof is set extensionality reducing membership h² = w to the parent's gaussianInt_sq_eq_iff, which states h² = g² ⟺ h = g ∨ h = −g. In the integral domain ℤ[i], having a square root pins you to a single sign pair.",
+    "mathContext": "$\\{h \\in \\mathbb{Z}[i] : h^2 = g^2\\} = \\{g, -g\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["integral domain", "square roots", "set extensionality"],
+    "prerequisites": ["gaussianInt_sq_eq_iff (parent)", "ℤ[i] is an integral domain"]
+  },
+  {
+    "id": "ann-pt040401-ncard-two",
+    "proofId": "pythagorean-theorem-oq-04-oq-01",
+    "range": { "startLine": 104, "endLine": 106 },
+    "type": "theorem",
+    "title": "Squaring is two-to-one",
+    "content": "For a nonzero generator g, the fibre of (· ^ 2) over w = g² has exactly two elements. This rewrites the fibre to {g, −g} and applies Set.ncard_pair, whose hypothesis g ≠ −g is supplied by ne_neg_self (a nonzero Gaussian integer differs from its negative, since g.re = −g.re forces g.re = 0). This is the arithmetic shadow of squaring being a degree-2 map on the domain.",
+    "mathContext": "$g \\neq 0 \\Rightarrow \\#\\{h : h^2 = g^2\\} = 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["fibre cardinality", "degree-2 map", "Set.ncard_pair"],
+    "prerequisites": ["sqRoots_eq_pair", "ne_neg_self"]
+  },
+  {
+    "id": "ann-pt040401-existsunique",
+    "proofId": "pythagorean-theorem-oq-04-oq-01",
+    "range": { "startLine": 117, "endLine": 145 },
+    "type": "theorem",
+    "title": "Existence and uniqueness of the canonical generator",
+    "content": "The main result: every primitive triple (x, y, z) with x odd and z > 0 has EXACTLY ONE canonical Gaussian generator g with x + yi = g². The parent's gaussian_completeness supplies a generator g₀ = m + ni; x odd forces ⟨x, y⟩ ≠ 0, hence g₀ ≠ 0. The proof case-splits on which of g₀, −g₀ is canonical (isCanonical_or_neg) and takes that as the witness. For uniqueness, any rival generator h' satisfies h'² = g₀², so gaussianInt_sq_eq_iff confines it to {g₀, −g₀}; the wrong sign is eliminated because g and −g are never both canonical.",
+    "mathContext": "$\\exists!\\, g \\in \\mathbb{Z}[i].\\ (x + yi = g^2) \\land \\mathrm{IsCanonical}(g)$, for $(x,y,z)$ primitive with $x$ odd, $z > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["unique existence", "completeness of the parameterization", "fundamental domain"],
+    "prerequisites": ["gaussian_completeness (parent)", "gaussianInt_sq_eq_iff (parent)", "isCanonical_xor_neg"]
+  },
+  {
+    "id": "ann-pt040401-example345",
+    "proofId": "pythagorean-theorem-oq-04-oq-01",
+    "range": { "startLine": 156, "endLine": 162 },
+    "type": "example",
+    "title": "Worked example: the (3, 4, 5) triple",
+    "content": "The canonical generator of (3, 4, 5) is 2 + i: it is canonical because its real part 2 > 0, and (2 + i)² = 4 + 4i − 1 = 3 + 4i. The Gaussian square roots of 3 + 4i are exactly the two-element set {2 + i, −2 − i}, confirming the general two-to-one count on the smallest primitive triple.",
+    "mathContext": "$(2 + i)^2 = 3 + 4i$, and $\\{h : h^2 = 3 + 4i\\} = \\{2 + i,\\ -2 - i\\}$.",
+    "significance": "context",
+    "relatedConcepts": ["(3,4,5) triple", "concrete Gaussian generator"],
+    "prerequisites": ["gaussianInt_sq", "sqRoots_ncard_two"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `pythagorean-theorem-oq-04-oq-01` (canonical Gaussian generator of a primitive Pythagorean triple).

**Gap:** the entry shipped with a rich meta.json but no `annotations.json`.

**Added:** 9 inline annotations, each with `content`, `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering every declaration:
- overview (up-to-sign → ∃!)
- `IsCanonical` definition (fundamental domain for {±1})
- the three sign-domain lemmas (`not_isCanonical_neg_of_isCanonical`, `isCanonical_or_neg`, `isCanonical_xor_neg`)
- `sqRoots_eq_pair` / `sqRoots_ncard_two` (square-root fibre is two-to-one)
- `canonical_generator_existsUnique` (main result)
- the (3,4,5) worked example

All 9 validated by `validateLineAnnotations` (0 misaligned). No changes to meta.json or the Lean file.