### PR TITLE
research(euler-totient-oq-05-oq-02): Carmichael's λ(n) is the least universal exponent [VERIFIED, 0-axiom, 13thm/1def/142L]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ05OQ02.lean
+++ b/proofs/Proofs/EulerTotientOQ05OQ02.lean
@@ -1,0 +1,142 @@
+/-
+# Carmichael's λ(n): the least universal exponent of (ℤ/nℤ)ˣ
+
+Euler's theorem gives, for every unit `a` of `ZMod n`, the identity `a ^ φ(n) = 1`;
+equivalently the multiplicative order of any unit divides `φ(n)` (proved in the
+parent entry `euler-totient-oq-05` as `orderOf_dvd_totient`). But `φ(n)` is in
+general *not* the smallest exponent that annihilates every unit simultaneously.
+The *least* such exponent is **Carmichael's function** `λ(n)`, defined here as the
+exponent of the group `(ZMod n)ˣ`.
+
+This entry answers the open question left by the parent
+(`euler-totient-oq-05`, openQuestions[1]):
+
+  > Formalize the converse refinement: Carmichael's λ(n) is the exact (least)
+  > universal exponent, sharpening `orderOf u ∣ φ(n)`.
+
+We prove:
+
+* `pow_carmichael`      — `λ(n)` is a universal exponent: `a ^ λ(n) = 1` for every unit `a`.
+* `carmichael_dvd_iff`  — the universal exponents are *exactly* the multiples of `λ(n)`.
+* `carmichael_isLeast`  — `λ(n)` is the least positive universal exponent (the headline).
+* `order_dvd_carmichael`— every unit's order divides `λ(n)`.
+* `carmichael_dvd_totient` — `λ(n) ∣ φ(n)`, so `λ` refines Euler's exponent.
+* `orderOf_dvd_totient` — the parent divisibility factors through `λ`: `ord(a) ∣ λ(n) ∣ φ(n)`.
+* `carmichael_eq_arithmeticFunction` — agreement with Mathlib's `ArithmeticFunction.Carmichael`.
+
+Finally, the concrete gap `n = 8`: every unit satisfies `a² = 1`, so `λ(8) = 2`,
+strictly below `φ(8) = 4`. Hence Euler's exponent `φ(n)` is genuinely non-minimal
+(`euler_exponent_not_minimal`), and `λ` is the sharp replacement.
+
+All results are machine-checked with no axioms; the `ZMod 8` computations use
+`decide` (no `native_decide`), so there is no `Lean.ofReduceBool` dependency.
+-/
+
+import Mathlib.NumberTheory.ArithmeticFunction.Carmichael
+import Mathlib.GroupTheory.Exponent
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Nat.Totient
+import Mathlib.Tactic
+
+namespace EulerTotientOQ0502
+
+open Monoid
+
+/-- **Carmichael's function** `λ(n)`, defined as the exponent of the unit group
+`(ZMod n)ˣ`: the smallest `N` with `a ^ N = 1` for every unit `a` (see
+`carmichael_isLeast`). -/
+noncomputable def carmichaelLambda (n : ℕ) : ℕ := Monoid.exponent (ZMod n)ˣ
+
+/-- `λ(n)` is a *universal exponent*: every unit of `ZMod n` is annihilated by it.
+This is Euler's `a ^ φ(n) = 1` with `φ(n)` replaced by the smaller `λ(n)`. -/
+theorem pow_carmichael {n : ℕ} (a : (ZMod n)ˣ) : a ^ carmichaelLambda n = 1 :=
+  Monoid.pow_exponent_eq_one a
+
+/-- The universal exponents of `(ZMod n)ˣ` are *exactly* the multiples of `λ(n)`:
+`λ(n) ∣ N` iff `a ^ N = 1` for every unit `a`. -/
+theorem carmichael_dvd_iff {n N : ℕ} :
+    carmichaelLambda n ∣ N ↔ ∀ a : (ZMod n)ˣ, a ^ N = 1 :=
+  Monoid.exponent_dvd_iff_forall_pow_eq_one
+
+/-- For `n ≠ 0` the unit group is finite, so `λ(n)` is positive. -/
+theorem carmichael_pos (n : ℕ) [NeZero n] : 0 < carmichaelLambda n :=
+  Nat.pos_of_ne_zero Monoid.exponent_ne_zero_of_finite
+
+/-- **Carmichael's λ(n) is the least universal exponent.** Among all positive `N`
+with `a ^ N = 1` for every unit `a`, `λ(n)` is the minimum: it is itself such an
+exponent (`pow_carmichael`), and it divides — hence is `≤` — any other one. This is
+the exact sharpening of the parent's `orderOf u ∣ φ(n)`. -/
+theorem carmichael_isLeast (n : ℕ) [NeZero n] :
+    IsLeast {N | 0 < N ∧ ∀ a : (ZMod n)ˣ, a ^ N = 1} (carmichaelLambda n) := by
+  refine ⟨⟨carmichael_pos n, fun a => pow_carmichael a⟩, ?_⟩
+  rintro N ⟨hN, hall⟩
+  exact Nat.le_of_dvd hN (carmichael_dvd_iff.mpr hall)
+
+/-- Every unit's multiplicative order divides `λ(n)`. Combined with
+`carmichael_dvd_totient` this recovers the parent's `orderOf u ∣ φ(n)`. -/
+theorem order_dvd_carmichael {n : ℕ} (a : (ZMod n)ˣ) :
+    orderOf a ∣ carmichaelLambda n :=
+  Monoid.order_dvd_exponent a
+
+/-- **`λ(n) ∣ φ(n)`**: Carmichael's exponent divides Euler's, since `λ(n)` is the
+exponent of a group of order `φ(n) = |(ZMod n)ˣ|`. This is the divisibility that
+makes `λ` a refinement of `φ` rather than an unrelated quantity. -/
+theorem carmichael_dvd_totient (n : ℕ) [NeZero n] :
+    carmichaelLambda n ∣ n.totient := by
+  have h := Group.exponent_dvd_card (G := (ZMod n)ˣ)
+  rwa [ZMod.card_units_eq_totient] at h
+
+/-- The parent divisibility `orderOf u ∣ φ(n)` factors through `λ(n)`:
+`orderOf a ∣ λ(n) ∣ φ(n)`. -/
+theorem orderOf_dvd_totient (n : ℕ) [NeZero n] (a : (ZMod n)ˣ) :
+    orderOf a ∣ n.totient :=
+  (order_dvd_carmichael a).trans (carmichael_dvd_totient n)
+
+/-- Agreement with Mathlib's official arithmetic function `ArithmeticFunction.Carmichael`:
+our `λ(n)` is exactly that value for `n ≠ 0`. -/
+theorem carmichael_eq_arithmeticFunction (n : ℕ) [NeZero n] :
+    carmichaelLambda n = ArithmeticFunction.Carmichael n :=
+  (ArithmeticFunction.carmichael_eq_exponent' n).symm
+
+/-! ## The gap at `n = 8`: `λ(8) = 2 < 4 = φ(8)`
+
+The group `(ZMod 8)ˣ ≅ ℤ/2 × ℤ/2` is elementary abelian of exponent `2`, so every
+unit already squares to `1`. Thus Carmichael's `λ(8) = 2` is strictly smaller than
+Euler's exponent `φ(8) = 4`: Euler's theorem is not sharp, and `λ` is the sharp bound.
+-/
+
+/-- Every unit of `ZMod 8` squares to `1` — a finite check over the four units. -/
+theorem sq_eq_one_zmod_eight : ∀ a : (ZMod 8)ˣ, a ^ 2 = 1 := by decide
+
+/-- `φ(8) = 4`. -/
+theorem totient_eight : Nat.totient 8 = 4 := by decide
+
+/-- `λ(8) = 2`. Upper bound: `a² = 1` for all units gives `λ(8) ∣ 2`. Lower bound:
+`λ(8) ≠ 1` because some unit (e.g. `3`) is not the identity, so it cannot have
+exponent `1`. With `0 < λ(8) ≤ 2` and `λ(8) ≠ 1`, we get `λ(8) = 2`. -/
+theorem carmichael_eight : carmichaelLambda 8 = 2 := by
+  have hdvd : carmichaelLambda 8 ∣ 2 := carmichael_dvd_iff.mpr sq_eq_one_zmod_eight
+  have hle : carmichaelLambda 8 ≤ 2 := Nat.le_of_dvd (by norm_num) hdvd
+  have hpos : 0 < carmichaelLambda 8 := carmichael_pos 8
+  have hne1 : carmichaelLambda 8 ≠ 1 := by
+    intro h
+    obtain ⟨a, ha⟩ : ∃ a : (ZMod 8)ˣ, a ≠ 1 := by decide
+    have hpow := pow_carmichael (n := 8) a
+    rw [h, pow_one] at hpow
+    exact ha hpow
+  omega
+
+/-- **`λ(8) = 2 < 4 = φ(8)`.** Carmichael's exponent is strictly smaller than Euler's. -/
+theorem carmichael_lt_totient_eight : carmichaelLambda 8 < Nat.totient 8 := by
+  rw [carmichael_eight, totient_eight]; norm_num
+
+/-- **Euler's exponent `φ(n)` is not minimal.** At `n = 8` there is a positive
+`N = 2` strictly below `φ(8) = 4` that already annihilates every unit — so the
+exponent `φ(n)` from Euler's theorem is not the least universal exponent, and the
+minimal one is Carmichael's `λ(8) = 2` (`carmichael_isLeast`, `carmichael_eight`). -/
+theorem euler_exponent_not_minimal :
+    ∃ N, 0 < N ∧ N < Nat.totient 8 ∧ ∀ a : (ZMod 8)ˣ, a ^ N = 1 := by
+  refine ⟨2, by norm_num, ?_, sq_eq_one_zmod_eight⟩
+  rw [totient_eight]; norm_num
+
+end EulerTotientOQ0502

--- a/src/data/proofs/euler-totient-oq-05-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-05-oq-02/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "euler-totient-oq-05-oq-02",
+  "title": "Carmichael's λ(n): the Least Universal Exponent of (ℤ/nℤ)ˣ",
+  "slug": "euler-totient-oq-05-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ArithmeticFunction.Carmichael",
+      "Mathlib.GroupTheory.Exponent",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Data.Nat.Totient",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Monoid"
+    ],
+    "namespace": "EulerTotientOQ0502",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "path": "Proofs/EulerTotientOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "description": "Answers the parent entry's open question: Carmichael's function λ(n), defined as the exponent of the unit group (ZMod n)ˣ, is the exact least universal exponent, sharpening Euler's a^φ(n)=1 and the parent's orderOf u | φ(n). Proves λ(n) is a universal exponent (a^λ(n)=1 for all units), that the universal exponents are exactly the multiples of λ(n), that λ(n) is the LEAST positive universal exponent (IsLeast), that every unit's order divides λ(n), and that λ(n) | φ(n) so the parent's orderOf u | φ(n) factors as orderOf u | λ(n) | φ(n). Includes agreement with Mathlib's ArithmeticFunction.Carmichael and the concrete gap λ(8)=2 < 4=φ(8), witnessing that Euler's exponent φ(n) is genuinely non-minimal. 13 theorems, 1 definition, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ05OQ02.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "carmichael-function",
+      "group-exponent",
+      "modular-arithmetic",
+      "order"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using Mathlib's Monoid.exponent API (pow_exponent_eq_one, exponent_dvd_iff_forall_pow_eq_one, order_dvd_exponent, exponent_ne_zero_of_finite, Group.exponent_dvd_card), ZMod.card_units_eq_totient, and ArithmeticFunction.Carmichael. The n=8 gap computations use decide (no native_decide), so there is no Lean.ofReduceBool dependency. #print axioms lists only propext, Classical.choice, Quot.sound.",
+    "lineCount": 142,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "originalContributions": [
+      "carmichaelLambda: Carmichael's function λ(n) := Monoid.exponent (ZMod n)ˣ, the exponent of the unit group",
+      "pow_carmichael: a^λ(n) = 1 for every unit a — λ(n) is a universal exponent, refining Euler's a^φ(n)=1 to a smaller exponent",
+      "carmichael_dvd_iff: λ(n) | N iff a^N = 1 for all units a — the universal exponents are exactly the multiples of λ(n)",
+      "carmichael_isLeast: IsLeast {N | 0 < N ∧ ∀ a, a^N = 1} (λ(n)) — the headline: λ(n) is the least positive universal exponent, the exact sharpening the parent left open",
+      "order_dvd_carmichael: orderOf a | λ(n) for every unit a",
+      "carmichael_dvd_totient: λ(n) | φ(n) via Group.exponent_dvd_card and ZMod.card_units_eq_totient — λ refines Euler's exponent φ",
+      "orderOf_dvd_totient: the parent's orderOf u | φ(n) factors through λ as orderOf a | λ(n) | φ(n)",
+      "carmichael_eq_arithmeticFunction: agreement with Mathlib's official ArithmeticFunction.Carmichael n",
+      "carmichael_eight / carmichael_lt_totient_eight / euler_exponent_not_minimal: the concrete gap λ(8)=2 < 4=φ(8), exhibiting a universal exponent (N=2) strictly below Euler's φ(8)=4 — Euler's exponent is not minimal, λ is the sharp bound"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euler's theorem (1763) states a^φ(n) ≡ 1 (mod n) for gcd(a,n)=1, exhibiting φ(n) as an exponent annihilating the whole unit group (ℤ/nℤ)ˣ. But φ(n) is usually not the smallest such exponent. Robert Carmichael introduced the function λ(n) in 1910 as the least universal exponent — the largest order occurring among units, equivalently the exponent (lcm of all element orders) of the group (ℤ/nℤ)ˣ. Carmichael's λ satisfies λ(n) | φ(n) with equality precisely when (ℤ/nℤ)ˣ is cyclic (n = 1,2,4,p^k,2p^k for odd prime p). The gap can be large: for n = 2^k with k ≥ 3 the unit group is ℤ/2 × ℤ/2^{k-2}, so λ(2^k) = 2^{k-2} while φ(2^k) = 2^{k-1}. Carmichael's λ is the sharp exponent underlying the strong pseudoprime / Carmichael-number theory and gives the tightest exponent reduction a^k ≡ a^{k mod λ(n)} (mod n) for RSA-style computation.",
+    "problemStatement": "The parent entry euler-totient-oq-05 proves orderOf u | φ(n): the order of any unit divides Euler's φ(n), framing φ(n) as a universal exponent, and leaves open the converse refinement — that Carmichael's λ(n) is the exact least universal exponent. Formalize λ(n) as the exponent of (ZMod n)ˣ, prove it is a universal exponent, that the universal exponents are exactly its multiples, that it is the least positive one, that λ(n) | φ(n) (so the parent divisibility factors through λ), and exhibit the strict gap λ(8) = 2 < 4 = φ(8).",
+    "text": "Carmichael's function λ(n) is defined here as Monoid.exponent (ZMod n)ˣ, the exponent of the multiplicative group of units modulo n. Mathlib's Monoid.exponent API does most of the structural work: pow_exponent_eq_one gives that λ(n) is a universal exponent (a^λ(n)=1 for every unit), and exponent_dvd_iff_forall_pow_eq_one characterizes the universal exponents as exactly the multiples of λ(n). The headline carmichael_isLeast packages these into an IsLeast statement: among all positive N with a^N=1 for every unit, λ(n) is the minimum — it is itself such an exponent and divides (hence is ≤) any other. This is the exact 'least universal exponent' refinement the parent left open. The link to Euler is carmichael_dvd_totient: λ(n) | φ(n), obtained from Group.exponent_dvd_card together with ZMod.card_units_eq_totient (|(ZMod n)ˣ| = φ(n)); consequently the parent's orderOf u | φ(n) factors as orderOf a | λ(n) | φ(n). We also record agreement with Mathlib's official ArithmeticFunction.Carmichael. The entry closes with the smallest gap: (ZMod 8)ˣ ≅ ℤ/2 × ℤ/2 is elementary abelian of exponent 2, so a^2 = 1 for every unit (a finite decide over the four units), forcing λ(8) = 2, strictly below φ(8) = 4. Thus euler_exponent_not_minimal exhibits N = 2, a universal exponent strictly less than Euler's φ(8) = 4 — Euler's exponent is not minimal, and Carmichael's λ is the sharp replacement.",
+    "proofStrategy": "λ(n) := Monoid.exponent (ZMod n)ˣ. pow_carmichael = Monoid.pow_exponent_eq_one. carmichael_dvd_iff = Monoid.exponent_dvd_iff_forall_pow_eq_one. carmichael_pos = Nat.pos_of_ne_zero Monoid.exponent_ne_zero_of_finite (finiteness from NeZero n). carmichael_isLeast: membership is ⟨carmichael_pos, pow_carmichael⟩; the lower bound is Nat.le_of_dvd applied to carmichael_dvd_iff.mpr. order_dvd_carmichael = Monoid.order_dvd_exponent. carmichael_dvd_totient rewrites Group.exponent_dvd_card through ZMod.card_units_eq_totient. orderOf_dvd_totient chains the previous two via Dvd.trans. carmichael_eq_arithmeticFunction = (ArithmeticFunction.carmichael_eq_exponent' n).symm. The n=8 facts: sq_eq_one_zmod_eight and totient_eight by decide; carmichael_eight combines λ(8) | 2 (from carmichael_dvd_iff.mpr), λ(8) > 0, and λ(8) ≠ 1 (a non-identity unit cannot have exponent 1) via omega; the strict inequality and non-minimality follow by rewriting and norm_num.",
+    "keyInsights": [
+      "Carmichael's λ(n) IS the group exponent of (ℤ/nℤ)ˣ: the least positive N with a^N=1 for every unit, equivalently the lcm of all element orders",
+      "The universal exponents form exactly the set of multiples of λ(n) (exponent_dvd_iff_forall_pow_eq_one); minimality is then Nat.le_of_dvd since λ(n) is itself a universal exponent",
+      "λ(n) | φ(n) because λ(n) is the exponent of a finite group of order φ(n); the parent's orderOf u | φ(n) factors as orderOf u | λ(n) | φ(n)",
+      "Euler's φ(n) is generally NOT the least universal exponent: at n=8 the unit group is ℤ/2×ℤ/2, so every unit already squares to 1 and λ(8)=2 < 4=φ(8)",
+      "Equality λ(n)=φ(n) holds precisely when (ℤ/nℤ)ˣ is cyclic (a primitive root exists); the n=8 gap is the smallest witness of failure"
+    ],
+    "prerequisites": [
+      "Euler's totient function and the unit group: Nat.totient, (ZMod n)ˣ, ZMod.card_units_eq_totient",
+      "Group exponent: Monoid.exponent and its API (pow_exponent_eq_one, exponent_dvd_iff_forall_pow_eq_one, order_dvd_exponent, Group.exponent_dvd_card)",
+      "Order of an element and the least-element predicate IsLeast",
+      "Parent entry euler-totient-oq-05: orderOf u | φ(n) and Euler's theorem in Nat.ModEq form"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Carmichael's λ(n) as the exponent of (ℤ/nℤ)ˣ",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Motivates the entry as the converse refinement left open by the parent: Euler's φ(n) is a universal exponent for the unit group but usually not the least. Defines carmichaelLambda n := Monoid.exponent (ZMod n)ˣ and lists the results, including the concrete gap λ(8)=2<4=φ(8).",
+      "mathContext": "$\\lambda(n) := \\exp\\bigl((\\mathbb{Z}/n\\mathbb{Z})^\\times\\bigr)$."
+    },
+    {
+      "id": "universal-exponent",
+      "title": "λ(n) is a universal exponent and its multiples characterize all of them",
+      "startLine": 50,
+      "endLine": 63,
+      "summary": "pow_carmichael: a^λ(n)=1 for every unit a (Monoid.pow_exponent_eq_one) — Euler's a^φ(n)=1 with the smaller exponent λ(n). carmichael_dvd_iff: λ(n) | N iff a^N=1 for all units a. carmichael_pos: λ(n)>0 for n≠0 via finiteness.",
+      "mathContext": "$a^{\\lambda(n)}=1;\\quad \\lambda(n)\\mid N \\iff \\forall a,\\ a^N=1.$"
+    },
+    {
+      "id": "is-least",
+      "title": "λ(n) is the least universal exponent",
+      "startLine": 65,
+      "endLine": 73,
+      "summary": "carmichael_isLeast: IsLeast {N | 0 < N ∧ ∀ a, a^N=1} (λ(n)). Membership from carmichael_pos and pow_carmichael; the lower bound from Nat.le_of_dvd applied to carmichael_dvd_iff. This is the exact 'least universal exponent' sharpening the parent posed as an open question.",
+      "mathContext": "$\\lambda(n)=\\min\\{N>0 : \\forall a,\\ a^N=1\\}.$"
+    },
+    {
+      "id": "refines-totient",
+      "title": "λ(n) | φ(n): refining Euler's exponent",
+      "startLine": 75,
+      "endLine": 99,
+      "summary": "order_dvd_carmichael: orderOf a | λ(n). carmichael_dvd_totient: λ(n) | φ(n) from Group.exponent_dvd_card and ZMod.card_units_eq_totient. orderOf_dvd_totient: the parent's orderOf u | φ(n) factors as orderOf a | λ(n) | φ(n). carmichael_eq_arithmeticFunction: agreement with Mathlib's ArithmeticFunction.Carmichael.",
+      "mathContext": "$\\mathrm{ord}(a)\\mid \\lambda(n)\\mid \\varphi(n).$"
+    },
+    {
+      "id": "gap-at-8",
+      "title": "The gap λ(8)=2 < 4=φ(8): Euler's exponent is not minimal",
+      "startLine": 101,
+      "endLine": 142,
+      "summary": "(ZMod 8)ˣ ≅ ℤ/2 × ℤ/2 has exponent 2. sq_eq_one_zmod_eight (decide over the 4 units) and totient_eight (φ(8)=4). carmichael_eight: λ(8)=2 combining λ(8)|2, λ(8)>0, λ(8)≠1 via omega. carmichael_lt_totient_eight: λ(8)<φ(8). euler_exponent_not_minimal: N=2 is a universal exponent strictly below φ(8)=4.",
+      "mathContext": "$\\lambda(8)=2<4=\\varphi(8).$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Carmichael's function λ(n), defined as the exponent of (ZMod n)ˣ, is proved to be the least universal exponent: it annihilates every unit, the universal exponents are exactly its multiples, and it is the minimum positive such exponent (IsLeast). It divides Euler's φ(n), so the parent's orderOf u | φ(n) factors as orderOf u | λ(n) | φ(n), and the concrete gap λ(8)=2 < 4=φ(8) shows Euler's exponent is not minimal. 13 theorems, 1 definition, 0 axioms, 142 lines.",
+    "implications": "This settles the parent entry's open question (openQuestions[1]): Carmichael's λ is the exact least universal exponent sharpening orderOf u | φ(n). λ(n) is the tightest exponent for exponent reduction a^k ≡ a^{k mod λ(n)} (mod n) and underlies Carmichael-number and strong-pseudoprime theory.",
+    "openQuestions": [
+      "Prove λ(n)=φ(n) iff (ℤ/nℤ)ˣ is cyclic (n ∈ {1,2,4,p^k,2p^k}), characterizing when Euler's exponent is already sharp",
+      "Formalize Carmichael's explicit formula λ(n) = lcm over prime powers p^k ‖ n of λ(p^k), with λ(2^k)=2^{k-2} for k≥3",
+      "Define Carmichael numbers via λ(n) | n-1 and formalize Korselt's criterion"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-05",
+      "relationship": "extends",
+      "description": "Parent entry; proves orderOf u | φ(n) framing φ(n) as a universal exponent and poses the least-universal-exponent refinement as an open question, which this entry answers."
+    },
+    {
+      "targetId": "euler-totient-oq-05-oq-01",
+      "relationship": "related",
+      "description": "Sibling entry on Carmichael's λ; this entry establishes the least-universal-exponent (IsLeast) characterization and the strict gap λ(8)<φ(8)."
+    }
+  ],
+  "references": [
+    {
+      "authors": "R. D. Carmichael",
+      "title": "Note on a new number theory function",
+      "year": 1910,
+      "venue": "Bull. Amer. Math. Soc. 16",
+      "note": "Introduces λ(n), the least universal exponent of the group of units modulo n."
+    },
+    {
+      "authors": "L. Euler",
+      "title": "Theoremata arithmetica nova methodo demonstrata",
+      "year": 1763,
+      "venue": "Novi Comment. Acad. Sci. Petrop. 8",
+      "note": "Proves a^φ(n) ≡ 1 (mod n); φ(n) is a universal exponent but generally not the least."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Monoid.exponent, ArithmeticFunction.Carmichael, and ZMod.card_units_eq_totient."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's open question (`euler-totient-oq-05`, openQuestions[1]): **Carmichael's function λ(n), defined as the exponent of the unit group (ℤ/nℤ)ˣ, is the exact _least_ universal exponent**, sharpening Euler's `a^φ(n)=1` and the parent's `orderOf u ∣ φ(n)`.

New entry: `euler-totient-oq-05-oq-02` — **13 theorems, 1 definition, 142 lines, 0 axioms** (VERIFIED).

## Results

- `carmichaelLambda n := Monoid.exponent (ZMod n)ˣ` — Carmichael's λ(n).
- `pow_carmichael`: `a^λ(n)=1` for every unit — λ(n) is a universal exponent (Euler with a smaller exponent).
- `carmichael_dvd_iff`: `λ(n) ∣ N ↔ ∀ a, a^N=1` — the universal exponents are exactly the multiples of λ(n).
- **`carmichael_isLeast`** (headline): `IsLeast {N | 0 < N ∧ ∀ a, a^N=1} (λ(n))` — λ(n) is the least positive universal exponent.
- `order_dvd_carmichael`, `carmichael_dvd_totient`: `orderOf a ∣ λ(n) ∣ φ(n)`.
- `orderOf_dvd_totient`: the parent's `orderOf u ∣ φ(n)` factors through λ.
- `carmichael_eq_arithmeticFunction`: agreement with Mathlib's `ArithmeticFunction.Carmichael`.
- **The gap at n=8**: `(ℤ/8)ˣ ≅ ℤ/2 × ℤ/2` has exponent 2, so `λ(8)=2 < 4=φ(8)` — `euler_exponent_not_minimal` exhibits `N=2` strictly below Euler's φ(8)=4. Euler's exponent is not minimal; λ is the sharp replacement.

## Verification

- Typechecked with `lake env lean` against cached Mathlib (clean, exit 0).
- `#print axioms` on `carmichael_isLeast`, `carmichael_eight`, `euler_exponent_not_minimal`, `carmichael_dvd_totient` lists only `propext, Classical.choice, Quot.sound` — **0 axioms**. The n=8 computations use `decide` (no `native_decide`), so no `Lean.ofReduceBool` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)