### PR TITLE
Enrich Trisecting Pascal's Triangle (combinations-formula-oq-05-oq-02): add annotations.json (0→7)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-cf0502-overview",
+    "proofId": "combinations-formula-oq-05-oq-02",
+    "range": { "startLine": 4, "endLine": 47 },
+    "type": "concept",
+    "title": "The roots-of-unity filter, first non-real case",
+    "content": "The parent CombinationsFormulaOQ05 splits a Pascal row by parity: even- and odd-indexed binomial coefficients each sum to 2^{n-1}. That is the mod-2 instance of a general phenomenon — for any modulus m, the sum S_r of C(n,k) over indices k ≡ r (mod m) is extracted from (1+x)^n by averaging its values at the m-th roots of unity (the roots-of-unity / finite Fourier filter). This file formalizes m = 3, the first case where the roots of unity are genuinely complex: a primitive cube root ζ ∈ ℂ is unavoidable, which is what makes the result new rather than a real-number identity.",
+    "mathContext": "$S_r = \\sum_{k \\equiv r \\,(m)} \\binom{n}{k} = \\frac{1}{m}\\sum_{j=0}^{m-1} \\omega^{-jr}(1+\\omega^j)^n$, where $\\omega = e^{2\\pi i/m}$.",
+    "significance": "key",
+    "relatedConcepts": ["roots-of-unity filter", "generating functions", "discrete Fourier transform", "binomial coefficients"],
+    "prerequisites": ["binomial theorem", "primitive roots of unity", "the parent entry combinations-formula-oq-05"]
+  },
+  {
+    "id": "ann-cf0502-orthogonality",
+    "proofId": "combinations-formula-oq-05-oq-02",
+    "range": { "startLine": 58, "endLine": 68 },
+    "type": "lemma",
+    "title": "Orthogonality of cube roots of unity",
+    "content": "The engine of the filter: if w³ = 1 then 1 + w + w² equals 3 when w = 1 and 0 otherwise. The w ≠ 1 case factors w³ − 1 = (w − 1)(w² + w + 1); since w − 1 ≠ 0 in the field ℂ, the second factor vanishes, giving the minimal polynomial w² + w + 1 = 0 of the primitive cube roots. Crucially this needs only w³ = 1, not that w is primitive, so it applies to every power ζ^{(3−r+k)} appearing in the filter.",
+    "mathContext": "$w^3 = 1 \\Rightarrow 1 + w + w^2 = \\begin{cases} 3 & w = 1 \\\\ 0 & w \\neq 1 \\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["cyclotomic polynomial", "geometric sum", "minimal polynomial", "orthogonality relations"],
+    "prerequisites": ["ℂ is a field", "factoring w³ − 1"]
+  },
+  {
+    "id": "ann-cf0502-trisection",
+    "proofId": "combinations-formula-oq-05-oq-02",
+    "range": { "startLine": 75, "endLine": 123 },
+    "type": "theorem",
+    "title": "The trisection identity (main result)",
+    "content": "For a primitive cube root ζ and residue r < 3, three times the residue-class sum equals a three-term combination of (1 + ζ^j)^n. The proof is the classical filter made formal: (1) expand each (1 + ζ^j)^n by the binomial theorem; (2) swap the order of summation to isolate, for each k, the inner geometric sum ∑_{j<3}(ζ^{3−r+k})^j; (3) evaluate that inner sum by orthogonality — it is 3 exactly when k ≡ r (mod 3) and 0 otherwise (using ζ^{3−r+k} = 1 ⟺ 3 ∣ (3−r+k) ⟺ k % 3 = r, discharged by omega); (4) collect the surviving C(n,k) into 3·S_r. Encoding ζ^{−jr} as the all-ℕ exponent ζ^{j(3−r)} (legitimate since ζ^{3j} = 1) is what lets omega handle the divisibility.",
+    "mathContext": "$3\\sum_{k \\equiv r\\,(3)} \\binom{n}{k} = \\sum_{j=0}^{2} \\zeta^{j(3-r)}(1+\\zeta^j)^n$",
+    "significance": "key",
+    "relatedConcepts": ["binomial theorem", "Finset.sum_comm", "roots-of-unity filter", "IsPrimitiveRoot.pow_eq_one_iff_dvd"],
+    "prerequisites": ["orthogonality lemma cube_root_geom_sum", "add_pow (binomial theorem)", "swapping double sums"]
+  },
+  {
+    "id": "ann-cf0502-three-terms",
+    "proofId": "combinations-formula-oq-05-oq-02",
+    "range": { "startLine": 126, "endLine": 132 },
+    "type": "theorem",
+    "title": "Explicit three-term form",
+    "content": "Unfolds the range-3 sum of the trisection identity into its three summands j = 0, 1, 2, giving 2^n + ζ^{3−r}(1 + ζ)^n + ζ^{2(3−r)}(1 + ζ²)^n. The j = 0 term is (1 + 1)^n = 2^n; the other two carry the essential complex contributions. This is the concrete form one evaluates in practice.",
+    "mathContext": "$3S_r = 2^n + \\zeta^{3-r}(1+\\zeta)^n + \\zeta^{2(3-r)}(1+\\zeta^2)^n$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_range_succ", "explicit expansion"],
+    "prerequisites": ["the trisection identity"]
+  },
+  {
+    "id": "ann-cf0502-zeta-relations",
+    "proofId": "combinations-formula-oq-05-oq-02",
+    "range": { "startLine": 135, "endLine": 146 },
+    "type": "lemma",
+    "title": "Primitive cube root relations",
+    "content": "The defining relation zeta_sq_add: 1 + ζ + ζ² = 0 (the orthogonality lemma specialized to w = ζ ≠ 1), and its two rearrangements one_add_zeta (1 + ζ = −ζ²) and one_add_zeta_sq (1 + ζ² = −ζ). These let one rewrite the two complex terms of the three-term form as (−1)^n ζ^{2n} and (−1)^n ζ^n, exposing the eventual real value of S_r.",
+    "mathContext": "$1 + \\zeta + \\zeta^2 = 0,\\quad 1 + \\zeta = -\\zeta^2,\\quad 1 + \\zeta^2 = -\\zeta$",
+    "significance": "supporting",
+    "relatedConcepts": ["cyclotomic identity", "linear_combination"],
+    "prerequisites": ["cube_root_geom_sum", "IsPrimitiveRoot.ne_one"]
+  },
+  {
+    "id": "ann-cf0502-completeness",
+    "proofId": "combinations-formula-oq-05-oq-02",
+    "range": { "startLine": 150, "endLine": 162 },
+    "type": "theorem",
+    "title": "Completeness: the classes partition the row",
+    "content": "A sanity check that the three residue classes mod 3 partition the n-th row, so their sums recover the full row sum 2^n = ∑_k C(n,k). The proof rewrites each filtered sum as an indicator sum, swaps the order, and collapses the inner sum over r via Finset.sum_ite_eq (each k lands in exactly the class r = k % 3), leaving Nat.sum_range_choose. This confirms no coefficient is double-counted or dropped.",
+    "mathContext": "$\\sum_{r=0}^{2} S_r = \\sum_{r=0}^{2}\\sum_{k \\equiv r\\,(3)} \\binom{n}{k} = \\sum_{k} \\binom{n}{k} = 2^n$",
+    "significance": "supporting",
+    "relatedConcepts": ["partition of a finite set", "Nat.sum_range_choose", "Finset.sum_ite_eq"],
+    "prerequisites": ["row sum ∑ C(n,k) = 2^n"]
+  },
+  {
+    "id": "ann-cf0502-examples",
+    "proofId": "combinations-formula-oq-05-oq-02",
+    "range": { "startLine": 166, "endLine": 170 },
+    "type": "example",
+    "title": "Worked verifications (n = 4)",
+    "content": "Two concrete decidable checks for n = 4: the residue-0 class {k ≡ 0 (3)} = {0, 3} gives C(4,0) + C(4,3) = 1 + 4 = 5, and the three classes together sum to 2^4 = 16. Both are closed by decide, grounding the abstract identity in a computation over Pascal's fifth row (1, 4, 6, 4, 1).",
+    "mathContext": "$S_0 = \\binom{4}{0}+\\binom{4}{3} = 5,\\quad S_0 + S_1 + S_2 = 16 = 2^4$",
+    "significance": "context",
+    "relatedConcepts": ["decide", "concrete verification"],
+    "prerequisites": ["Pascal's triangle row 4"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-05-oq-02` (mod-3 trisection of a Pascal row via cube roots of unity).

**Gap:** the entry shipped with a rich meta.json but no `annotations.json`.

**Added:** 7 inline annotations, each with `content`, `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering every declaration:
- overview (the roots-of-unity filter, first non-real case)
- `cube_root_geom_sum` (orthogonality of cube roots)
- `trisection` (main identity)
- `trisection_three_terms` (explicit three-term form)
- `zeta_sq_add` / `one_add_zeta` / `one_add_zeta_sq` (primitive-root relations)
- `sum_trisection_eq_two_pow` (completeness / partition)
- the n=4 worked verifications

All 7 validated by `validateLineAnnotations` (0 misaligned). No changes to meta.json or the Lean file.

Note: a sibling research PR (#32783) proposes a superset rewrite of this entry; if it merges, these line-anchored annotations may need re-anchoring (the coverage scanner will flag it).