### PR TITLE
Fix: burnside-counting-oq-03 status → axiomatized (native_decide)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "George P\u00f3lya (1937); formalized via Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Polya_enumeration_theorem",
     "date": "1937",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BurnsideCountingOQ03.lean",
     "tags": [
       "combinatorics",
@@ -20,7 +20,7 @@
       "research",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
     "assumptions": "0 sorries, 0 literal `axiom` declarations. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis. However, the concrete §4/§5 verification theorems (fp_count_rot0_4_2, fp_count_rot1_4_2, fp_count_rot2_4_2, fp_count_rot3_4_2, fp_sum_binary4, polya_sum_Z4_binary) discharge their finite Fintype.card computations using `native_decide`, which depends on the `Lean.ofReduceBool` axiom (Lean compiler kernel reduction); those named theorems are therefore not axiom-free. Hence axiomCount = 1; leanFile.axiomCount remains 0 since there are no literal `axiom` declarations.",


### PR DESCRIPTION
## Fix

Correct stale `status`/`badge` on `burnside-counting-oq-03` to match its own already-correct `axiomCount` and axiom disclosure.

## Evidence

The Lean file `Proofs/BurnsideCountingOQ03.lean` proves six **named** §4/§5 theorems by `native_decide`:
`fp_count_rot0_4_2`, `fp_count_rot1_4_2`, `fp_count_rot2_4_2`, `fp_count_rot3_4_2`,
`polya_sum_Z4_binary`, `polya_divisor_sum_Z4_binary`, `polya_sum_equiv_4_2` (lines 229–280).

`native_decide` depends on the `Lean.ofReduceBool` axiom, and these are substantive presented results. Per the repository axiom-integrity policy, such an entry must be `status: "axiomatized"`, `badge: "axiom"`, `axiomCount ≥ 1`, with `Lean.ofReduceBool` disclosed in `assumptions`.

- `axiomCount = 1` — already correct
- `assumptions` disclosing `Lean.ofReduceBool` — already correct
- `status` — **was** `"formalized"` (means "has sorries"; this entry has 0 sorries) → now `"axiomatized"`
- `badge` — **was** `"mathlib"` → now `"axiom"`

**Before**: `status: "formalized"`, `badge: "mathlib"` (inconsistent with `axiomCount: 1`)
**After**: `status: "axiomatized"`, `badge: "axiom"` (consistent, no overclaim)

Metadata-only change; no Lean source touched.

---
Automated fix by lean-mechanic agent.