### PR TITLE
Enrich Reflection Symmetry of Bounded Weak Compositions (stars-and-bars-weak-compositions-oq-02-oq-02): add annotations.json (0→7, full coverage)

### DIFF
--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-02-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-sbwc0202-overview",
+    "proofId": "stars-and-bars-weak-compositions-oq-02-oq-02",
+    "range": { "startLine": 6, "endLine": 47 },
+    "type": "concept",
+    "title": "Reflection Symmetry via Part-Complementation",
+    "content": "The parent entry counts bounded weak compositions B(k, n, b) = number of tuples f : Fin k -> N with sum n and every part <= b, and gives an inclusion-exclusion closed form. This entry proves the reflection symmetry B(k, n, b) = B(k, k*b - n, b) for n <= k*b, by the explicit part-complementation f_i |-> b - f_i. Complementing each part sends a composition summing to n into one summing to k*b - n while keeping every part in [0, b]; doing it twice returns the original, so it is an involution packaged as an Equiv. This is the q = 1 shadow of the palindromic symmetry of Gaussian binomial coefficients.",
+    "mathContext": "$B(k,n,b)$ is the coefficient of $q^n$ in the Gaussian binomial $\\binom{k+b}{b}_q$; the map $f_i \\mapsto b - f_i$ realises the palindrome $[m;r]_q = [m;r]_{q^{-1}} q^{r(m-r)}$ at $q=1$.",
+    "significance": "Sets up the whole file: a single bijection proves a cardinality identity and, via the parent, an alternating-sum identity.",
+    "relatedConcepts": ["weak composition", "Gaussian binomial coefficient", "palindromic symmetry", "involution", "stars and bars"],
+    "prerequisites": ["binomial coefficients", "bijective combinatorics", "q-analogues"]
+  },
+  {
+    "id": "ann-sbwc0202-bc",
+    "proofId": "stars-and-bars-weak-compositions-oq-02-oq-02",
+    "range": { "startLine": 54, "endLine": 56 },
+    "type": "definition",
+    "title": "BC k n b — Bounded Weak Compositions as a Subtype",
+    "content": "The object counted throughout: the subtype of functions f : Fin k -> N whose parts sum to n and are each at most b. Encoding the two constraints (sum = n, and pointwise <= b) into the subtype means the reflection map must be shown to land in a DIFFERENT subtype (sum = k*b - n), which is exactly why the symmetry is packaged as an equivalence between two such types rather than a self-map.",
+    "mathContext": "$BC(k,n,b) = \\{\\, f : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\sum_i f_i = n,\\ \\forall i,\\ f_i \\le b \\,\\}$.",
+    "significance": "The carrier type whose cardinality is B(k, n, b).",
+    "relatedConcepts": ["subtype", "Fin k", "weak composition"],
+    "prerequisites": ["dependent types", "finite sums"]
+  },
+  {
+    "id": "ann-sbwc0202-sumconst",
+    "proofId": "stars-and-bars-weak-compositions-oq-02-oq-02",
+    "range": { "startLine": 58, "endLine": 60 },
+    "type": "technique",
+    "title": "The Total Budget ∑ b = k·b",
+    "content": "A one-line helper: summing the constant b over the k indices gives k*b, the total 'budget' being redistributed by complementation. This is what turns sum (b - f_i) into k*b - sum f_i via Finset.sum_tsub_distrib, the algebraic heart of why the complemented parts sum to k*b - n.",
+    "mathContext": "$\\sum_{i : \\mathrm{Fin}\\,k} b = k \\cdot b$.",
+    "significance": "Supplies the constant whose subtraction flips the total from n to k*b - n.",
+    "relatedConcepts": ["Finset.sum_const", "natural-number subtraction", "telescoping"],
+    "prerequisites": ["finite sums"]
+  },
+  {
+    "id": "ann-sbwc0202-equiv",
+    "proofId": "stars-and-bars-weak-compositions-oq-02-oq-02",
+    "range": { "startLine": 62, "endLine": 78 },
+    "type": "definition",
+    "title": "reflectEquiv — the Complementation Bijection",
+    "content": "The explicit Equiv from BC k n b to BC k (k*b - n) b. Both toFun and invFun are the same map f_i |-> b - f_i; the forward direction uses Finset.sum_tsub_distrib and sum_const_b to check the sum flips to k*b - n, the inverse additionally applies Nat.sub_sub_self hn to recover n. Both round-trips reduce to Nat.sub_sub_self (b - (b - f_i) = f_i since f_i <= b), so the map is a genuine involution. Truncated natural subtraction is well-behaved here precisely because every part is bounded by b.",
+    "mathContext": "$f \\mapsto (i \\mapsto b - f_i)$; well-defined because $f_i \\le b \\Rightarrow b - (b - f_i) = f_i$ and $\\sum_i (b - f_i) = kb - \\sum_i f_i = kb - n$.",
+    "significance": "The single construction that yields the entire symmetry; everything else is a corollary.",
+    "relatedConcepts": ["Equiv", "involution", "Nat.sub_sub_self", "Finset.sum_tsub_distrib"],
+    "prerequisites": ["equivalences of types", "natural-number subtraction lemmas"]
+  },
+  {
+    "id": "ann-sbwc0202-cardreflect",
+    "proofId": "stars-and-bars-weak-compositions-oq-02-oq-02",
+    "range": { "startLine": 80, "endLine": 84 },
+    "type": "insight",
+    "title": "Cardinality Symmetry B(k, n, b) = B(k, k·b − n, b)",
+    "content": "The headline result: transporting the bijection reflectEquiv through Fintype.card_congr gives equal cardinalities. Because the equivalence is explicit, this is a one-liner — the combinatorial content lives entirely in reflectEquiv.",
+    "mathContext": "$B(k,n,b) = B(k, kb - n, b)$ for $n \\le kb$.",
+    "significance": "The reflection identity for the counts, the q = 1 case of Gaussian-binomial palindromy.",
+    "relatedConcepts": ["Fintype.card_congr", "bijective proof", "counting"],
+    "prerequisites": ["cardinality of finite types"]
+  },
+  {
+    "id": "ann-sbwc0202-involution",
+    "proofId": "stars-and-bars-weak-compositions-oq-02-oq-02",
+    "range": { "startLine": 86, "endLine": 90 },
+    "type": "context",
+    "title": "Double Reflection Returns to n",
+    "content": "A consistency check: reflecting twice, k*b - (k*b - n) = n, recovers the original count. Proved by Nat.sub_sub_self hn. This confirms the symmetry is an honest involution on the parameter n rather than an accidental one-way equality.",
+    "mathContext": "$kb - (kb - n) = n$ when $n \\le kb$.",
+    "significance": "Verifies the reflection is self-inverse at the level of counts.",
+    "relatedConcepts": ["involution", "Nat.sub_sub_self"],
+    "prerequisites": ["natural-number subtraction"]
+  },
+  {
+    "id": "ann-sbwc0202-closedform",
+    "proofId": "stars-and-bars-weak-compositions-oq-02-oq-02",
+    "range": { "startLine": 92, "endLine": 105 },
+    "type": "corollary",
+    "title": "Alternating-Sum Identity from the Parent's Closed Form",
+    "content": "Combining the cardinality symmetry with the parent's inclusion-exclusion closed form card_boundedComposition yields a nontrivial identity between two alternating binomial sums: the sum evaluated at n equals the one evaluated at k*b - n. Neither side is obviously equal to the other term-by-term — the equality is forced by both counting the same (up to reflection) bounded compositions. This is the free algebraic payoff of the bijective argument.",
+    "mathContext": "$\\sum_j (-1)^j \\binom{k}{j}\\binom{n-(b+1)j+k-1}{n-(b+1)j} = \\sum_j (-1)^j \\binom{k}{j}\\binom{kb-n-(b+1)j+k-1}{kb-n-(b+1)j}$.",
+    "significance": "Turns a combinatorial symmetry into a concrete, non-obvious summation identity.",
+    "relatedConcepts": ["inclusion-exclusion", "alternating sum", "binomial identity"],
+    "prerequisites": ["inclusion-exclusion", "binomial coefficients"]
+  }
+]


### PR DESCRIPTION
Researcher entry landed with a rich meta.json but **no annotations.json**. This adds 7 line-anchored annotations covering the overview and all 6 declarations.

**Annotations added**
- **Overview** — part-complementation `f_i ↦ b − f_i` as the q=1 shadow of Gaussian-binomial palindromy.
- **BC k n b** — the bounded-weak-composition subtype (two constraints ⇒ symmetry is an Equiv between distinct subtypes).
- **sum_const_b** — the total budget ∑ b = k·b that flips the sum from n to k·b−n.
- **reflectEquiv** — the complementation bijection; both directions are the same map, an involution via `Nat.sub_sub_self`.
- **card_boundedComposition_reflect** — the cardinality symmetry B(k,n,b)=B(k,k·b−n,b).
- **card_boundedComposition_reflect_reflect** — double-reflection consistency check.
- **closedForm_reflect** — the free alternating-sum identity from the parent's closed form.

Each annotation carries mathContext (LaTeX), significance, relatedConcepts, prerequisites. All 7 validate (validateLineAnnotations: 7 valid, 0 misaligned). meta.json unchanged.