### PR TITLE
Enrich Simplicial Reciprocals (triangular-reciprocals-oq-04-oq-01): add annotations.json (0→10, full coverage)

### DIFF
--- a/src/data/proofs/triangular-reciprocals-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/triangular-reciprocals-oq-04-oq-01/annotations.json
@@ -1,0 +1,222 @@
+[
+  {
+    "id": "ann-troq0401-overview",
+    "proofId": "triangular-reciprocals-oq-04-oq-01",
+    "range": {
+      "startLine": 2,
+      "endLine": 36
+    },
+    "type": "concept",
+    "title": "Simplicial Reciprocals Sum to d/(d−1) at Every Depth",
+    "content": "The result: for every depth d = m+2 >= 2, the sum of reciprocals of the d-simplicial (figurate) numbers is d/(d-1). Depth 2 gives triangular numbers n(n+1)/2 (sum 2), depth 3 the tetrahedral numbers (sum 3/2). This generalizes the parent entry, which handled only d = 3, by a SINGLE telescoping argument uniform in d. Reindexing the term to n : N, the summand 1/C(n+d, d) is written as a difference G(n) - G(n+1) of a discrete antiderivative, so the partial sums collapse and the tail G(N) -> 0.",
+    "mathContext": "$\\sum_{n=1}^\\infty \\frac{1}{\\binom{n+d-1}{d}} = \\frac{d}{d-1}$; the telescoping is $\\frac{1}{\\binom{n+d}{d}} = G(n)-G(n+1)$ with $G(n)=\\frac{d}{d-1}\\cdot\\frac{1}{\\binom{n+d-1}{d-1}}$.",
+    "significance": "The whole file is one uniform-in-d telescoping; everything reduces to two binomial absorption identities plus a convergence estimate.",
+    "relatedConcepts": [
+      "figurate numbers",
+      "telescoping series",
+      "binomial coefficients",
+      "Wolstenholme-type identities"
+    ],
+    "prerequisites": [
+      "infinite series",
+      "binomial coefficients",
+      "telescoping sums"
+    ]
+  },
+  {
+    "id": "ann-troq0401-defs",
+    "proofId": "triangular-reciprocals-oq-04-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 54
+    },
+    "type": "definition",
+    "title": "The Summand and Its Telescoping Antiderivative",
+    "content": "simpReciprocal m n = 1/C(n+m+2, m+2) is the reciprocal of the n-th depth-(m+2) simplicial number. gTele m n = (m+2)/(m+1) · 1/C(n+m+1, m+1) is the discrete antiderivative chosen so that the summand equals the forward difference G(n) - G(n+1). Writing d = m+2 keeps the whole argument over N (m >= 0 iff d >= 2), avoiding real-subtraction edge cases at d = 1 where the series diverges.",
+    "mathContext": "$\\mathrm{simpReciprocal}(m,n) = \\binom{n+m+2}{m+2}^{-1}$, $\\ G(m,n) = \\frac{m+2}{m+1}\\binom{n+m+1}{m+1}^{-1}$.",
+    "significance": "Choosing the right antiderivative G is the crux; the rest is verifying G(n)-G(n+1) equals the summand.",
+    "relatedConcepts": [
+      "discrete antiderivative",
+      "finite differences",
+      "reciprocal binomials"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "real reciprocals"
+    ]
+  },
+  {
+    "id": "ann-troq0401-positivity",
+    "proofId": "triangular-reciprocals-oq-04-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 67
+    },
+    "type": "technique",
+    "title": "Positivity of the Three Binomials",
+    "content": "Three one-line helpers establishing C(n+m+2, m+2), C(n+m+1, m+1) and C(n+m+2, m+1) are all positive (each C(a, b) > 0 since a >= b). Positivity is needed to invert the binomials as real numbers and to justify the field_simp / division steps in the telescoping identity.",
+    "mathContext": "$\\binom{a}{b} > 0 \\iff a \\ge b$; here all three indices satisfy $a \\ge b$.",
+    "significance": "Guards every reciprocal and division that follows.",
+    "relatedConcepts": [
+      "Nat.choose_pos",
+      "positivity"
+    ],
+    "prerequisites": [
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-troq0401-absorption",
+    "proofId": "triangular-reciprocals-oq-04-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 95
+    },
+    "type": "technique",
+    "title": "The Two Absorption Identities (R1, R2)",
+    "content": "The arithmetic engine of the telescoping, stated as natural-number equalities. R1: (n+m+2)·C(n+m+1, m+1) = (m+2)·C(n+m+2, m+2), from Nat.add_one_mul_choose_eq. R2: (n+1)·C(n+m+2, m+1) = (m+2)·C(n+m+2, m+2), from Nat.choose_succ_right_eq. Both re-express the same target binomial C(n+m+2, m+2) times (m+2), so dividing them yields the difference of reciprocals used in the telescoping.",
+    "mathContext": "$(n+m+2)\\binom{n+m+1}{m+1}=(m+2)\\binom{n+m+2}{m+2}$ and $(n+1)\\binom{n+m+2}{m+1}=(m+2)\\binom{n+m+2}{m+2}$.",
+    "significance": "Standard Pascal absorption identities are exactly what make the reciprocal difference telescope.",
+    "relatedConcepts": [
+      "Pascal's rule",
+      "absorption identity",
+      "Nat.add_one_mul_choose_eq",
+      "Nat.choose_succ_right_eq"
+    ],
+    "prerequisites": [
+      "binomial identities"
+    ]
+  },
+  {
+    "id": "ann-troq0401-telescope",
+    "proofId": "triangular-reciprocals-oq-04-oq-01",
+    "range": {
+      "startLine": 101,
+      "endLine": 149
+    },
+    "type": "insight",
+    "title": "The Depth-d Telescoping Identity",
+    "content": "The heart of the proof: 1/C(n+m+2, m+2) = G(n) - G(n+1). After casting the three binomials to R and using the shift C(n+1+m+1, m+1) = C(n+m+2, m+1), the two absorption identities give p⁻¹ = (n+m+2)/((m+2)a) and q⁻¹ = (n+1)/((m+2)a) where a = C(n+m+2, m+2). Then field_simp and ring close the identity. This single lemma is where all the combinatorics is spent; the series result is then formal.",
+    "mathContext": "$\\binom{n+d}{d}^{-1} = G(n)-G(n+1)$, reducing to $p^{-1}-q^{-1} = \\frac{m+1}{(m+2)a}$ via R1, R2.",
+    "significance": "Converts a hard-looking reciprocal into a forward difference — the key that makes the series telescope.",
+    "relatedConcepts": [
+      "telescoping",
+      "field_simp",
+      "reciprocal algebra"
+    ],
+    "prerequisites": [
+      "real field arithmetic",
+      "binomial identities"
+    ]
+  },
+  {
+    "id": "ann-troq0401-partialsum",
+    "proofId": "triangular-reciprocals-oq-04-oq-01",
+    "range": {
+      "startLine": 155,
+      "endLine": 169
+    },
+    "type": "insight",
+    "title": "Closed Form for the Partial Sum",
+    "content": "Summing the telescoping identity over i < N and applying Finset.sum_range_sub' collapses the sum to G(0) - G(N). Since G(0) = (m+2)/(m+1)·1/C(m+1, m+1) = (m+2)/(m+1) (as C(m+1, m+1) = 1), the N-th partial sum equals (m+2)/(m+1) - G(N). The infinite sum is now just the limit of G(N).",
+    "mathContext": "$\\sum_{i<N}\\binom{i+d}{d}^{-1} = \\frac{m+2}{m+1} - G(N)$, using $\\binom{m+1}{m+1}=1$.",
+    "significance": "Reduces the whole series to understanding the single tail term G(N).",
+    "relatedConcepts": [
+      "Finset.sum_range_sub'",
+      "telescoping sum",
+      "partial sums"
+    ],
+    "prerequisites": [
+      "finite sums",
+      "telescoping"
+    ]
+  },
+  {
+    "id": "ann-troq0401-lowerbound",
+    "proofId": "triangular-reciprocals-oq-04-oq-01",
+    "range": {
+      "startLine": 175,
+      "endLine": 185
+    },
+    "type": "technique",
+    "title": "Binomial Lower Bound C(N+m+1, m+1) ≥ N+1",
+    "content": "A clean induction on N (using Pascal's rule Nat.choose_succ_succ' and C(K+m+1, m) >= 1) showing the relevant binomial grows at least linearly. This is exactly the estimate needed to squeeze the tail 1/C(N+m+1, m+1) below 1/(N+1), forcing G(N) -> 0.",
+    "mathContext": "$\\binom{N+m+1}{m+1} \\ge N+1$, hence $\\binom{N+m+1}{m+1}^{-1} \\le \\frac{1}{N+1} \\to 0$.",
+    "significance": "Supplies the comparison bound driving convergence of the tail to zero.",
+    "relatedConcepts": [
+      "Pascal's rule",
+      "induction",
+      "squeeze theorem"
+    ],
+    "prerequisites": [
+      "mathematical induction",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-troq0401-tail",
+    "proofId": "triangular-reciprocals-oq-04-oq-01",
+    "range": {
+      "startLine": 191,
+      "endLine": 211
+    },
+    "type": "insight",
+    "title": "The Tail G(N) → 0",
+    "content": "Combines the lower bound with squeeze_zero: 0 <= 1/C(N+m+1, m+1) <= 1/(N+1) -> 0, so the reciprocal binomial tends to 0, and multiplying by the constant (m+2)/(m+1) leaves the limit at 0. This is the analytic input (the only non-algebraic step) that turns the partial-sum closed form into a convergent series value.",
+    "mathContext": "$G(N) = \\frac{m+2}{m+1}\\binom{N+m+1}{m+1}^{-1} \\to 0$ by the squeeze $0 \\le \\binom{N+m+1}{m+1}^{-1} \\le \\frac{1}{N+1}$.",
+    "significance": "The vanishing tail is what pins the infinite sum at exactly (m+2)/(m+1).",
+    "relatedConcepts": [
+      "squeeze theorem",
+      "Filter.Tendsto",
+      "convergence to zero"
+    ],
+    "prerequisites": [
+      "limits of sequences",
+      "squeeze theorem"
+    ]
+  },
+  {
+    "id": "ann-troq0401-main",
+    "proofId": "triangular-reciprocals-oq-04-oq-01",
+    "range": {
+      "startLine": 217,
+      "endLine": 240
+    },
+    "type": "main-result",
+    "title": "Main Theorem: HasSum = (m+2)/(m+1)",
+    "content": "Assembles the pieces: nonnegativity lets HasSum reduce to the limit of partial sums (hasSum_iff_tendsto_nat_of_nonneg), the partial sums equal (m+2)/(m+1) - G(N), and G(N) -> 0, so the series converges to (m+2)/(m+1) = d/(d-1). The companion simplicial_reciprocals_tsum restates this in tsum form. This is the general-depth answer to the parent's open question.",
+    "mathContext": "$\\mathrm{HasSum}\\ \\big(n \\mapsto \\binom{n+d}{d}^{-1}\\big)\\ \\frac{d}{d-1}$, i.e. $\\sum_{n\\ge 1}\\binom{n+d-1}{d}^{-1} = \\frac{d}{d-1}$.",
+    "significance": "The headline general-depth result, uniform in d, generalizing the parent's single d=3 case.",
+    "relatedConcepts": [
+      "HasSum",
+      "tsum",
+      "convergent series",
+      "hasSum_iff_tendsto_nat_of_nonneg"
+    ],
+    "prerequisites": [
+      "infinite series",
+      "limits"
+    ]
+  },
+  {
+    "id": "ann-troq0401-cases",
+    "proofId": "triangular-reciprocals-oq-04-oq-01",
+    "range": {
+      "startLine": 246,
+      "endLine": 261
+    },
+    "type": "context",
+    "title": "Classical Special Cases Recovered",
+    "content": "Instantiating m = 0 recovers the classical triangular-reciprocal sum ∑ 1/C(n+2,2) = 2, and m = 1 recovers the parent's tetrahedral sum ∑ 1/C(n+3,3) = 3/2. A final example checks the summand's first term 1/C(m+2, m+2) = 1 at every depth. These confirm the general theorem specializes correctly to the known cases.",
+    "mathContext": "$m=0$: $\\sum 1/\\binom{n+2}{2} = 2$; $\\ m=1$: $\\sum 1/\\binom{n+3}{3} = 3/2$; first term $=1$.",
+    "significance": "Grounds the abstraction in the two classically known figurate-reciprocal sums.",
+    "relatedConcepts": [
+      "triangular numbers",
+      "tetrahedral numbers",
+      "worked examples"
+    ],
+    "prerequisites": [
+      "binomial coefficients"
+    ]
+  }
+]


### PR DESCRIPTION
Researcher entry landed with a rich meta.json but **no annotations.json**. This adds 10 line-anchored annotations covering the overview and every declaration.

**Annotations added**
- **Overview** — one uniform-in-d telescoping proving ∑ 1/C(n+d−1,d) = d/(d−1) at every figurate depth.
- **Defs** — the summand and its telescoping antiderivative G.
- **Positivity trio** — the three binomials guarding every reciprocal.
- **Two absorption identities (R1, R2)** — the Pascal-absorption arithmetic engine.
- **Depth-d telescoping identity** — the crux: 1/C(n+d,d) = G(n)−G(n+1).
- **Partial-sum closed form** — collapse to (m+2)/(m+1) − G(N).
- **Binomial lower bound** — C(N+m+1,m+1) ≥ N+1.
- **Vanishing tail** — G(N) → 0 by squeeze.
- **Main theorem** — HasSum = d/(d−1), plus tsum form.
- **Classical special cases** — triangular (sum 2) and tetrahedral (sum 3/2) recovered.

Each annotation carries mathContext (LaTeX), significance, relatedConcepts, prerequisites. All 10 validate (validateLineAnnotations: 10 valid, 0 misaligned). meta.json unchanged.