### PR TITLE
Enrich Ultra-Log-Concavity of a Pascal Row (combinations-formula-oq-04-oq-01): add annotations.json (0→7)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-04-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-cf0401-overview",
+    "proofId": "combinations-formula-oq-04-oq-01",
+    "range": { "startLine": 4, "endLine": 55 },
+    "type": "concept",
+    "title": "From bare log-concavity to an exact defect",
+    "content": "The parent combinations-formula-oq-04 proves the bare log-concavity C(n,k)·C(n,k+2) ≤ C(n,k+1)² by cancelling a common positive factor — keeping only the SIGN of the difference. This entry asks how large the log-concavity gap actually is. Substituting n = k+2+t and a=C(n,k), b=C(n,k+1), c=C(n,k+2), the parent's own mechanism yields the exact product identity a·c·(t+2)(k+2) = b²·(k+1)(t+1). The key observation is that the discarded difference (t+2)(k+2) − (k+1)(t+1) is not merely positive — it equals exactly t+k+3 = n+1. Feeding this back gives the sharp identity (b² − a·c)·(k+1)(n−k−1) = (n+1)·a·c: the defect is governed exactly by n+1.",
+    "mathContext": "$(t+2)(k+2) - (k+1)(t+1) = n+1$, hence $(b^2 - ac)\\,(k{+}1)(n{-}k{-}1) = (n+1)\\,ac$.",
+    "significance": "key",
+    "relatedConcepts": ["log-concavity", "ultra-log-concavity", "Newton's inequalities", "binomial coefficients"],
+    "prerequisites": ["Pascal's triangle", "the parent entry combinations-formula-oq-04", "Nat.choose_succ_right_eq"]
+  },
+  {
+    "id": "ann-cf0401-prod",
+    "proofId": "combinations-formula-oq-04-oq-01",
+    "range": { "startLine": 65, "endLine": 80 },
+    "type": "theorem",
+    "title": "The adjacent-ratio product identity (★)",
+    "content": "The subtraction-free heart of the whole file. Writing n = k+2+t, the two adjacent-ratio relations from Nat.choose_succ_right_eq — a(t+2) = b(k+1) and c(k+2) = b(t+1) — are multiplied together. Regrouping a·c·(t+2)(k+2) as (a(t+2))·(c(k+2)) and substituting both relations collapses everything to b²·(k+1)(t+1). Staying over ℕ (no subtraction) is what lets later steps use exact identities rather than inequalities.",
+    "mathContext": "$C(n,k)\\,C(n,k{+}2)\\,(t{+}2)(k{+}2) = C(n,k{+}1)^2\\,(k{+}1)(t{+}1)$, with $n = k+2+t$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.choose_succ_right_eq", "adjacent binomial ratios", "subtraction-free identities"],
+    "prerequisites": ["binomial recurrence C(n,k+1)(k+1) = C(n,k)(n−k)"]
+  },
+  {
+    "id": "ann-cf0401-defect",
+    "proofId": "combinations-formula-oq-04-oq-01",
+    "range": { "startLine": 89, "endLine": 102 },
+    "type": "theorem",
+    "title": "Exact log-concavity defect identity",
+    "content": "The additive, subtraction-free defect identity for k+2 ≤ n: C(n,k+1)²·(k+1)(n−k−1) = C(n,k)·C(n,k+2)·((k+1)(n−k−1) + (n+1)). After substituting n = k+2+t, the crucial algebraic split is (t+2)(k+2) = (k+1)(t+1) + (n+1), which exhibits the surplus n+1 explicitly. The right multiplier exceeds the left by exactly n+1 — that surplus is the quantitative content the parent's inequality throws away.",
+    "mathContext": "$C(n,k{+}1)^2\\,M = C(n,k)\\,C(n,k{+}2)\\,(M + (n{+}1))$, where $M = (k{+}1)(n{-}k{-}1)$.",
+    "significance": "key",
+    "relatedConcepts": ["log-concavity defect", "exact identity", "calc proof"],
+    "prerequisites": ["choose_adjacent_ratio_prod"]
+  },
+  {
+    "id": "ann-cf0401-gap",
+    "proofId": "combinations-formula-oq-04-oq-01",
+    "range": { "startLine": 111, "endLine": 122 },
+    "type": "theorem",
+    "title": "Log-concavity gap identity",
+    "content": "The gap form: (C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2). Starting from the defect identity B·M = A·(M + (n+1)), rewrite as B·M = A·M + A·(n+1), then Nat.sub_mul plus Nat.add_sub_cancel_left extract the truncated subtraction exactly (the subtrahend is the smaller by log-concavity, so ℕ-subtraction loses nothing). The defect is a fixed (n+1)-multiple of the outer product, scaled by (k+1)(n−k−1).",
+    "mathContext": "$(C(n,k{+}1)^2 - C(n,k)C(n,k{+}2))\\,(k{+}1)(n{-}k{-}1) = (n{+}1)\\,C(n,k)C(n,k{+}2)$",
+    "significance": "key",
+    "relatedConcepts": ["truncated subtraction (Nat.sub)", "Nat.sub_mul", "Nat.add_sub_cancel_left"],
+    "prerequisites": ["choose_logConcavity_defect"]
+  },
+  {
+    "id": "ann-cf0401-recovered",
+    "proofId": "combinations-formula-oq-04-oq-01",
+    "range": { "startLine": 127, "endLine": 148 },
+    "type": "theorem",
+    "title": "Parent inequalities recovered (≤ and strict <)",
+    "content": "Both the parent's log-concavity and its strict interior version fall out of the exact identity in one step each. choose_logConcave_le holds for all n, k: outside the interior (n < k+2) a binomial vanishes and the bound is trivial; inside, nlinarith closes it from the defect identity and non-negativity. choose_logConcave_lt sharpens it to strict < for k+2 ≤ n, since the surplus (n+1)·C(n,k)·C(n,k+2) is strictly positive when both binomials are positive in the interior.",
+    "mathContext": "$C(n,k)C(n,k{+}2) \\le C(n,k{+}1)^2$ always; $<$ strictly when $k+2 \\le n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["nlinarith", "Nat.choose_pos", "Nat.choose_eq_zero_of_lt"],
+    "prerequisites": ["choose_logConcavity_defect"]
+  },
+  {
+    "id": "ann-cf0401-centered",
+    "proofId": "combinations-formula-oq-04-oq-01",
+    "range": { "startLine": 154, "endLine": 162 },
+    "type": "theorem",
+    "title": "Centered restatement at index j",
+    "content": "Reindexing k = j−1 recasts the defect identity at the interior index j (1 ≤ j, j+1 ≤ n): C(n,j)²·j(n−j) = C(n,j−1)·C(n,j+1)·(j(n−j) + (n+1)). This centered form, symmetric about j, is the shape in which the ultra-log-concavity of a Pascal row is usually stated, matching the j(n−j) weighting of Newton's inequalities.",
+    "mathContext": "$C(n,j)^2\\,j(n{-}j) = C(n,j{-}1)C(n,j{+}1)\\,(j(n{-}j) + (n{+}1))$",
+    "significance": "supporting",
+    "relatedConcepts": ["reindexing", "Newton's inequalities", "centered form"],
+    "prerequisites": ["choose_logConcavity_defect"]
+  },
+  {
+    "id": "ann-cf0401-ratio",
+    "proofId": "combinations-formula-oq-04-oq-01",
+    "range": { "startLine": 171, "endLine": 192 },
+    "type": "theorem",
+    "title": "Rational ultra-log-concavity excess",
+    "content": "The headline over ℚ: C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)) > 1. The proof casts the product identity (★) to ℚ (keyQ), clears denominators with div_eq_div_iff after rewriting the RHS as a single fraction (eq_div_iff, div_mul_cancel₀), and finishes with linear_combination -keyQ. The explicit excess (n+1)/((k+1)(n−k−1)) over the geometric value 1 is exactly what makes the row ULTRA-log-concave rather than merely log-concave.",
+    "mathContext": "$\\dfrac{C(n,k{+}1)^2}{C(n,k)C(n,k{+}2)} = 1 + \\dfrac{n+1}{(k{+}1)(n{-}k{-}1)} > 1$",
+    "significance": "key",
+    "relatedConcepts": ["ultra-log-concavity", "linear_combination", "div_eq_div_iff", "rational excess"],
+    "prerequisites": ["choose_adjacent_ratio_prod", "casting ℕ identities to ℚ"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-04-oq-01` (exact log-concavity defect of a Pascal row, governed by n+1).

**Gap:** the entry shipped with a rich meta.json but no `annotations.json`.

**Added:** 7 inline annotations, each with `content`, `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering every theorem:
- overview (bare log-concavity → exact defect = n+1)
- `choose_adjacent_ratio_prod` (the product identity ★)
- `choose_logConcavity_defect` (exact defect identity)
- `choose_logConcavity_gap` (gap form)
- `choose_logConcave_le` / `choose_logConcave_lt` (recovered inequalities)
- `choose_logConcavity_defect'` (centered restatement)
- `choose_ratio_rat` (rational ultra-log-concavity excess)

All 7 validated by `validateLineAnnotations` (0 misaligned). No changes to meta.json or the Lean file.