### PR TITLE
research(triangular-reciprocals-oq-04-oq-01): ∑ 1/C(n+d-1,d)=d/(d-1) for all d≥2 [VERIFIED, 0-axiom, 15thm/3def/282L]

### DIFF
--- a/proofs/Proofs/TriangularReciprocalsOQ04OQ01.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ04OQ01.lean
@@ -1,37 +1,34 @@
 /-
-  Reciprocals of Simplicial (Figurate) Numbers — the General-Depth Telescoping Sum
+  Reciprocals of Binomial Coefficients — General Depth-d Telescoping
 
-  Result.  For every depth `d ≥ 2`,
+  Result:  for every integer depth d ≥ 2,
 
-      ∑_{n=1}^∞  1 / C(n+d-1, d)  =  d / (d-1).
+      ∑_{n=1}^∞ 1/C(n+d-1, d) = d/(d-1).
 
-  Here `C(n+d-1, d)` is the `n`-th `d`-simplicial number
-  (`d = 2`: triangular numbers `n(n+1)/2`; `d = 3`: tetrahedral numbers
-  `n(n+1)(n+2)/6`; and so on).  Reindexing the running term to `n : ℕ` (so the
-  term is `1 / C(n+d, d)`), the statement becomes
+  Equivalently, shifting the running index to n : ℕ (term at n being the reciprocal
+  of the binomial C(n+d, d)),
 
-      ∑_{n=0}^∞  1 / C(n+d, d)  =  d / (d-1).
+      ∑_{n=0}^∞ 1/C(n+d, d) = d/(d-1).
 
-  This generalizes the parent entry `TriangularReciprocalsOQ04`, which proves the
-  single depth `d = 3` case (tetrahedral reciprocals sum to `3/2`), and the
-  classical depth `d = 2` case (triangular reciprocals sum to `2`).
+  This is the general-depth analogue of the classical results
+    • depth 1 (triangular):    ∑ 2/(n(n+1))            = 2,
+    • depth 2 (tetrahedral):   ∑ 6/((n+1)(n+2)(n+3))   = 3/2   (`TriangularReciprocalsOQ04.lean`).
+  The parent handles the single case d = 3 (value 3/2) by an explicit depth-2 partial
+  fraction; here we prove the entire family d = 2, 3, 4, … at once.
 
-  The proof is a single depth-`d` telescoping, uniform in `d`.  Writing `d = m+2`
-  (so `m ≥ 0` ⟺ `d ≥ 2`), the summand telescopes as
+  Method.  Write d = k+2 with k : ℕ (so d ≥ 2 and d-1 = k+1 is a unit).  Let
 
-      1 / C(n+m+2, m+2)  =  G(n) - G(n+1),
-      G(n) := (m+2)/(m+1) · 1 / C(n+m+1, m+1).
+      P(n, m) = (n+1)(n+2)⋯(n+m)   (an ascending product of m consecutive integers),
 
-  The telescoping identity reduces to two standard binomial absorption identities
-  (`Nat.succ_mul_choose_eq`, `Nat.choose_succ_right_eq`):
+  so that 1/C(n+d, d) = d! / P(n, d).  The key telescoping identity is
 
-      (n+m+2) · C(n+m+1, m+1) = (m+2) · C(n+m+2, m+2)          (R1)
-      (n+1)   · C(n+m+2, m+1) = (m+2) · C(n+m+2, m+2)          (R2)
+      d! / P(n, d) = g(n) - g(n+1),   g(n) = d! / ((d-1) · P(n, d-1)),
 
-  from which `C(n+m+1,m+1)⁻¹ - C(n+m+2,m+1)⁻¹ = (m+1) / ((m+2)·C(n+m+2,m+2))`,
-  and multiplying by `(m+2)/(m+1)` gives `C(n+m+2,m+2)⁻¹`.  The partial sums
-  collapse to `(m+2)/(m+1) - G(N)`, and `G(N) → 0` because
-  `C(N+m+1, m+1) ≥ N+1 → ∞`.
+  which follows from the two one-step product recurrences
+      P(n, m+1) = P(n, m) · (n+m+1)      (peel the last factor),
+      P(n, m+1) = (n+1) · P(n+1, m)      (peel the first factor).
+  Summing telescopes to g(0) = d!/((d-1)·(d-1)!) = d/(d-1), and the tail g(N) → 0
+  since P(N, d-1) ≥ N+1.  Finally P(n, d) = C(n+d, d) · d!, giving the binomial form.
 
   No axioms, no sorries.
 -/
@@ -44,220 +41,242 @@ open Finset BigOperators Filter Topology
 
 namespace TriangularReciprocalsOQ04OQ01
 
-/-- The reciprocal of the `n`-th depth-`(m+2)` simplicial number,
-`1 / C(n+m+2, m+2)` (depth `d = m+2 ≥ 2`). -/
-noncomputable def simpReciprocal (m n : ℕ) : ℝ :=
-  ((Nat.choose (n + m + 2) (m + 2) : ℝ))⁻¹
+variable (k : ℕ)
 
-/-- The telescoping antiderivative `G(n) = (m+2)/(m+1) · 1 / C(n+m+1, m+1)`. -/
-noncomputable def gTele (m n : ℕ) : ℝ :=
-  ((m : ℝ) + 2) / ((m : ℝ) + 1) * ((Nat.choose (n + m + 1) (m + 1) : ℝ))⁻¹
+/-- The ascending product `P(n, m) = (n+1)(n+2)⋯(n+m)` as a real number. -/
+noncomputable def pochProd (n m : ℕ) : ℝ :=
+  ∏ j ∈ Finset.range m, ((n : ℝ) + 1 + (j : ℝ))
 
--- ═══════════════════════════════════════════════════
--- Positivity of the binomial coefficients involved
--- ═══════════════════════════════════════════════════
+/-- The reciprocal-binomial summand `1/C(n+d, d) = d!/P(n, d)` with `d = k+2`. -/
+noncomputable def term (n : ℕ) : ℝ :=
+  ((k + 2).factorial : ℝ) / pochProd n (k + 2)
 
-private theorem choose_pos_a (m n : ℕ) : 0 < Nat.choose (n + m + 2) (m + 2) :=
-  Nat.choose_pos (by omega)
-
-private theorem choose_pos_p (m n : ℕ) : 0 < Nat.choose (n + m + 1) (m + 1) :=
-  Nat.choose_pos (by omega)
-
-private theorem choose_pos_q (m n : ℕ) : 0 < Nat.choose (n + m + 2) (m + 1) :=
-  Nat.choose_pos (by omega)
+/-- The telescoping antiderivative `g(n) = d!/((d-1)·P(n, d-1))` with `d = k+2`. -/
+noncomputable def gAnti (n : ℕ) : ℝ :=
+  ((k + 2).factorial : ℝ) / (((k : ℝ) + 1) * pochProd n (k + 1))
 
 -- ═══════════════════════════════════════════════════
--- The two absorption identities (as ℕ equalities)
+-- Product recurrences
 -- ═══════════════════════════════════════════════════
 
-/-- (R1)  `(n+m+2) · C(n+m+1, m+1) = (m+2) · C(n+m+2, m+2)`. -/
-private theorem absorb_R1 (m n : ℕ) :
-    (n + m + 2) * Nat.choose (n + m + 1) (m + 1)
-      = (m + 2) * Nat.choose (n + m + 2) (m + 2) := by
-  have h := Nat.add_one_mul_choose_eq (n + m + 1) (m + 1)
-  -- h : (n+m+1+1) * C(n+m+1, m+1) = C(n+m+1+1, m+1+1) * (m+1+1)
-  have e1 : n + m + 1 + 1 = n + m + 2 := by ring
-  have e2 : m + 1 + 1 = m + 2 := by ring
-  rw [e1, e2] at h
-  rw [h]; ring
+/-- Peel the last factor: `P(n, m+1) = P(n, m) · (n+m+1)`. -/
+theorem poch_rec2 (n m : ℕ) :
+    pochProd n (m + 1) = pochProd n m * ((n : ℝ) + 1 + (m : ℝ)) := by
+  unfold pochProd
+  rw [Finset.prod_range_succ]
 
-/-- (R2)  `(n+1) · C(n+m+2, m+1) = (m+2) · C(n+m+2, m+2)`. -/
-private theorem absorb_R2 (m n : ℕ) :
-    (n + 1) * Nat.choose (n + m + 2) (m + 1)
-      = (m + 2) * Nat.choose (n + m + 2) (m + 2) := by
-  have h := Nat.choose_succ_right_eq (n + m + 2) (m + 1)
-  -- h : C(n+m+2, m+1+1) * (m+1+1) = C(n+m+2, m+1) * (n+m+2 - (m+1))
-  have e2 : m + 1 + 1 = m + 2 := by ring
-  have e3 : n + m + 2 - (m + 1) = n + 1 := by omega
-  rw [e2, e3] at h
-  -- h : C(n+m+2, m+2) * (m+2) = C(n+m+2, m+1) * (n+1)
-  rw [mul_comm (m + 2), mul_comm (n + 1)] at *
-  linarith [h]
+/-- Peel the first factor: `P(n, m+1) = (n+1) · P(n+1, m)`. -/
+theorem poch_rec (n m : ℕ) :
+    pochProd n (m + 1) = ((n : ℝ) + 1) * pochProd (n + 1) m := by
+  unfold pochProd
+  rw [Finset.prod_range_succ', Nat.cast_zero, add_zero, mul_comm]
+  congr 1
+  apply Finset.prod_congr rfl
+  intro i _
+  push_cast
+  ring
 
--- ═══════════════════════════════════════════════════
--- Lemma: the depth-d telescoping identity
--- ═══════════════════════════════════════════════════
+/-- Every factor is positive, so the product is positive. -/
+theorem pochProd_pos (n m : ℕ) : 0 < pochProd n m := by
+  unfold pochProd
+  apply Finset.prod_pos
+  intro i _
+  positivity
 
-/-- `1 / C(n+m+2, m+2) = G(n) - G(n+1)`. -/
-theorem simp_telescope (m n : ℕ) :
-    simpReciprocal m n = gTele m n - gTele m (n + 1) := by
-  unfold simpReciprocal gTele
-  -- Real casts of the three (positive) binomials.
-  set a : ℝ := (Nat.choose (n + m + 2) (m + 2) : ℝ) with ha_def
-  set p : ℝ := (Nat.choose (n + m + 1) (m + 1) : ℝ) with hp_def
-  set q : ℝ := (Nat.choose (n + m + 2) (m + 1) : ℝ) with hq_def
-  have ha : 0 < a := by rw [ha_def]; exact_mod_cast choose_pos_a m n
-  have hp : 0 < p := by rw [hp_def]; exact_mod_cast choose_pos_p m n
-  have hq : 0 < q := by rw [hq_def]; exact_mod_cast choose_pos_q m n
-  have hm1 : (0 : ℝ) < (m : ℝ) + 1 := by positivity
-  have hm2 : (0 : ℝ) < (m : ℝ) + 2 := by positivity
-  -- The (n+1)-shifted G uses C(n+1+m+1, m+1) = C(n+m+2, m+1) = q.
-  have hshift : ((Nat.choose (n + 1 + m + 1) (m + 1) : ℝ)) = q := by
-    rw [hq_def]
-    have e : n + 1 + m + 1 = n + m + 2 := by ring
+/-- Every factor is `≥ 1`, so the product is `≥ 1`. -/
+theorem pochProd_one_le (n m : ℕ) : 1 ≤ pochProd n m := by
+  induction m with
+  | zero => simp [pochProd]
+  | succ p ih =>
+    rw [poch_rec2 n p]
+    have h1 : (1 : ℝ) ≤ (n : ℝ) + 1 + (p : ℝ) := by
+      have : (0 : ℝ) ≤ (n : ℝ) + (p : ℝ) := by positivity
+      linarith
+    nlinarith [ih, h1, mul_nonneg (sub_nonneg.mpr ih) (sub_nonneg.mpr h1)]
+
+/-- `P(0, m) = m!`. -/
+theorem pochProd_zero (m : ℕ) : pochProd 0 m = ((m.factorial : ℝ)) := by
+  induction m with
+  | zero => simp [pochProd]
+  | succ p ih =>
+    rw [poch_rec2 0 p, ih]
+    have hfac : (p + 1).factorial = (p + 1) * p.factorial := Nat.factorial_succ p
+    rw [hfac]; push_cast; ring
+
+/-- `P(n, m) · n! = (n+m)!`, an integer identity cast to `ℝ`. -/
+theorem pochProd_mul_factorial (n m : ℕ) :
+    pochProd n m * (n.factorial : ℝ) = ((n + m).factorial : ℝ) := by
+  induction m with
+  | zero => simp [pochProd]
+  | succ p ih =>
+    rw [poch_rec2 n p, mul_right_comm, ih]
+    have e : n + (p + 1) = (n + p) + 1 := by ring
     rw [e]
-  rw [hshift]
-  -- Cast the two absorption identities to ℝ.
-  have R1 : ((n : ℝ) + m + 2) * p = ((m : ℝ) + 2) * a := by
-    have := absorb_R1 m n
-    rw [ha_def, hp_def]
-    have : ((( n + m + 2) * Nat.choose (n + m + 1) (m + 1) : ℕ) : ℝ)
-        = (((m + 2) * Nat.choose (n + m + 2) (m + 2) : ℕ) : ℝ) := by exact_mod_cast this
-    push_cast at this ⊢
-    linarith [this]
-  have R2 : ((n : ℝ) + 1) * q = ((m : ℝ) + 2) * a := by
-    have := absorb_R2 m n
-    rw [ha_def, hq_def]
-    have : (((n + 1) * Nat.choose (n + m + 2) (m + 1) : ℕ) : ℝ)
-        = (((m + 2) * Nat.choose (n + m + 2) (m + 2) : ℕ) : ℝ) := by exact_mod_cast this
-    push_cast at this ⊢
-    linarith [this]
-  -- p⁻¹ and q⁻¹ in terms of a.
-  have hp_ne : p ≠ 0 := ne_of_gt hp
-  have hq_ne : q ≠ 0 := ne_of_gt hq
-  have ha_ne : a ≠ 0 := ne_of_gt ha
-  have hpinv : p⁻¹ = ((n : ℝ) + m + 2) / (((m : ℝ) + 2) * a) := by
-    rw [eq_div_iff (by positivity)]
-    field_simp
-    nlinarith [R1]
-  have hqinv : q⁻¹ = ((n : ℝ) + 1) / (((m : ℝ) + 2) * a) := by
-    rw [eq_div_iff (by positivity)]
-    field_simp
-    nlinarith [R2]
-  rw [hpinv, hqinv]
+    have hfac : ((n + p) + 1).factorial = ((n + p) + 1) * (n + p).factorial :=
+      Nat.factorial_succ (n + p)
+    rw [hfac]; push_cast; ring
+
+-- ═══════════════════════════════════════════════════
+-- Telescoping identity
+-- ═══════════════════════════════════════════════════
+
+/-- The depth-`d` telescoping identity `term n = g(n) - g(n+1)`. -/
+theorem telescope (n : ℕ) : term k n = gAnti k n - gAnti k (n + 1) := by
+  unfold term gAnti
+  have hp2 : (0 : ℝ) < pochProd n (k + 2) := pochProd_pos _ _
+  have hn1 : (0 : ℝ) < (n : ℝ) + 1 := by positivity
+  have hnk2 : (0 : ℝ) < (n : ℝ) + 1 + ((k : ℝ) + 1) := by positivity
+  have hk1 : (0 : ℝ) < (k : ℝ) + 1 := by positivity
+  -- P(n, k+2) = (n+1) · P(n+1, k+1)
+  have hA : pochProd n (k + 2) = ((n : ℝ) + 1) * pochProd (n + 1) (k + 1) := poch_rec n (k + 1)
+  -- P(n, k+2) = P(n, k+1) · (n+k+2)
+  have hB : pochProd n (k + 2) = pochProd n (k + 1) * ((n : ℝ) + 1 + ((k : ℝ) + 1)) := by
+    have h := poch_rec2 n (k + 1)
+    push_cast at h
+    linear_combination h
+  -- express both (k+1)-products through P(n, k+2)
+  have hXA : pochProd (n + 1) (k + 1) = pochProd n (k + 2) / ((n : ℝ) + 1) := by
+    rw [eq_div_iff hn1.ne']; rw [hA]; ring
+  have hXB : pochProd n (k + 1) = pochProd n (k + 2) / ((n : ℝ) + 1 + ((k : ℝ) + 1)) := by
+    rw [eq_div_iff hnk2.ne']; rw [hB]
+  rw [hXA, hXB]
   field_simp
   ring
 
 -- ═══════════════════════════════════════════════════
--- Partial sums via telescoping
+-- Partial sums and limit
 -- ═══════════════════════════════════════════════════
 
-/-- `∑_{i<N} 1/C(i+m+2, m+2) = (m+2)/(m+1) - G(N)`. -/
-theorem partial_sum_closed_form (m N : ℕ) :
-    ∑ i ∈ Finset.range N, simpReciprocal m i
-      = ((m : ℝ) + 2) / ((m : ℝ) + 1) - gTele m N := by
-  have htel : ∑ i ∈ Finset.range N, simpReciprocal m i
-      = ∑ i ∈ Finset.range N, (gTele m i - gTele m (i + 1)) :=
-    Finset.sum_congr rfl (fun i _ => simp_telescope m i)
-  rw [htel, Finset.sum_range_sub' (gTele m) N]
-  -- G(0) = (m+2)/(m+1) · 1/C(m+1, m+1) = (m+2)/(m+1).
-  have hG0 : gTele m 0 = ((m : ℝ) + 2) / ((m : ℝ) + 1) := by
-    unfold gTele
-    have : Nat.choose (0 + m + 1) (m + 1) = 1 := by
-      simp [Nat.choose_self]
-    rw [this]; norm_num
-  rw [hG0]
-
--- ═══════════════════════════════════════════════════
--- Lower bound on the binomial (for convergence)
--- ═══════════════════════════════════════════════════
-
-/-- `C(N + (m+1), m+1) ≥ N + 1`.  The tail `1/C(N+m+1, m+1)` is therefore squeezed
-by `1/(N+1)`. -/
-private theorem choose_ge (m N : ℕ) : N + 1 ≤ Nat.choose (N + m + 1) (m + 1) := by
+/-- Telescoped closed form: `∑_{i<N} term i = g(0) - g(N)`. -/
+theorem partial_sum (N : ℕ) :
+    ∑ i ∈ Finset.range N, term k i = gAnti k 0 - gAnti k N := by
   induction N with
-  | zero => simp [Nat.choose_self]
-  | succ K ih =>
-    -- C(K+1+m+1, m+1) = C((K+m+1)+1, m+1) = C(K+m+1, m+1) + C(K+m+1, m).
-    have hp : K + 1 + m + 1 = (K + m + 1) + 1 := by ring
-    rw [hp, Nat.choose_succ_succ' (K + m + 1) m]
-    have hpos : 1 ≤ Nat.choose (K + m + 1) m := Nat.choose_pos (by omega)
-    omega
+  | zero => simp
+  | succ M ih =>
+    rw [Finset.sum_range_succ, ih, telescope k M]; ring
+
+/-- `g(0) = d/(d-1) = (k+2)/(k+1)`. -/
+theorem gAnti_zero : gAnti k 0 = ((k : ℝ) + 2) / ((k : ℝ) + 1) := by
+  unfold gAnti
+  rw [pochProd_zero (k + 1)]
+  have h1 : ((k + 2).factorial : ℝ) = ((k : ℝ) + 2) * ((k + 1).factorial : ℝ) := by
+    have hfac : (k + 2).factorial = (k + 2) * (k + 1).factorial := Nat.factorial_succ (k + 1)
+    rw [hfac]; push_cast; ring
+  rw [h1]
+  have hf : (0 : ℝ) < ((k + 1).factorial : ℝ) := by exact_mod_cast (k + 1).factorial_pos
+  have hk1 : (0 : ℝ) < (k : ℝ) + 1 := by positivity
+  field_simp
+
+/-- The tail `g(N) → 0` as `N → ∞`. -/
+theorem gAnti_tendsto : Tendsto (fun N : ℕ => gAnti k N) atTop (𝓝 0) := by
+  set C : ℝ := ((k + 2).factorial : ℝ) / ((k : ℝ) + 1) with hC
+  have hg0 : Tendsto (fun N : ℕ => (1 : ℝ) / ((N : ℝ) + 1)) atTop (𝓝 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat
+  have hlim : Tendsto (fun N : ℕ => C / ((N : ℝ) + 1)) atTop (𝓝 0) := by
+    have h := hg0.const_mul C
+    rw [mul_zero] at h
+    simpa [mul_one_div] using h
+  apply squeeze_zero (g := fun N : ℕ => C / ((N : ℝ) + 1))
+  · intro N
+    unfold gAnti
+    apply div_nonneg (by positivity)
+    exact mul_nonneg (by positivity) (pochProd_pos N (k + 1)).le
+  · intro N
+    have hge : ((N : ℝ) + 1) ≤ pochProd N (k + 1) := by
+      rw [poch_rec]
+      have := mul_le_mul_of_nonneg_left (pochProd_one_le (N + 1) k)
+        (by positivity : (0 : ℝ) ≤ (N : ℝ) + 1)
+      simpa using this
+    unfold gAnti
+    rw [hC, div_mul_eq_div_div, ← hC]
+    gcongr
+  · exact hlim
 
 -- ═══════════════════════════════════════════════════
--- Tail G(N) → 0
+-- Main theorem
 -- ═══════════════════════════════════════════════════
 
-theorem gTele_tendsto_zero (m : ℕ) :
-    Tendsto (fun N : ℕ => gTele m N) atTop (𝓝 0) := by
-  -- G N = c · (C(N+m+1, m+1))⁻¹ with c = (m+2)/(m+1); the reciprocal → 0.
-  have hrec : Tendsto (fun N : ℕ => ((Nat.choose (N + m + 1) (m + 1) : ℝ))⁻¹)
-      atTop (𝓝 0) := by
-    have hbound : Tendsto (fun N : ℕ => (1 : ℝ) / ((N : ℝ) + 1)) atTop (𝓝 0) :=
-      tendsto_one_div_add_atTop_nhds_zero_nat
-    apply squeeze_zero (g := fun N : ℕ => (1 : ℝ) / ((N : ℝ) + 1))
-    · intro N; positivity
-    · intro N
-      have hchoose : (N : ℝ) + 1 ≤ (Nat.choose (N + m + 1) (m + 1) : ℝ) := by
-        have := choose_ge m N
-        have hc : ((N + 1 : ℕ) : ℝ) ≤ ((Nat.choose (N + m + 1) (m + 1) : ℕ) : ℝ) := by
-          exact_mod_cast this
-        push_cast at hc; linarith [hc]
-      have hpos : (0 : ℝ) < (N : ℝ) + 1 := by positivity
-      simpa [one_div] using one_div_le_one_div_of_le hpos hchoose
-    · exact hbound
-  have := hrec.const_mul (((m : ℝ) + 2) / ((m : ℝ) + 1))
-  rw [mul_zero] at this
-  simpa [gTele, mul_comm] using this
+/-- The reciprocal binomial series sums to `g(0)`. -/
+theorem hasSum_term : HasSum (term k) (gAnti k 0) := by
+  have hnn : ∀ n, 0 ≤ term k n := by
+    intro n; unfold term
+    exact div_nonneg (by positivity) (pochProd_pos n (k + 2)).le
+  rw [hasSum_iff_tendsto_nat_of_nonneg hnn]
+  have hps : (fun N => ∑ i ∈ Finset.range N, term k i) = fun N => gAnti k 0 - gAnti k N :=
+    funext (partial_sum k)
+  rw [hps]
+  have h := (tendsto_const_nhds (x := gAnti k 0)).sub (gAnti_tendsto k)
+  simpa using h
+
+/-- `term n = 1/C(n+k+2, k+2)`, connecting the product form to binomial coefficients. -/
+theorem term_eq_inv_choose (n : ℕ) :
+    term k n = 1 / ((Nat.choose (n + k + 2) (k + 2) : ℕ) : ℝ) := by
+  have hle : k + 2 ≤ n + k + 2 := by omega
+  have hn : Nat.choose (n + k + 2) (k + 2) * (k + 2).factorial * n.factorial
+      = (n + k + 2).factorial := by
+    have h := Nat.choose_mul_factorial_mul_factorial hle
+    rwa [show (n + k + 2) - (k + 2) = n by omega] at h
+  have hp : pochProd n (k + 2) * (n.factorial : ℝ) = ((n + k + 2).factorial : ℝ) := by
+    have h := pochProd_mul_factorial n (k + 2)
+    rwa [show n + (k + 2) = n + k + 2 from by ring] at h
+  have hnR : ((Nat.choose (n + k + 2) (k + 2) : ℝ)) * ((k + 2).factorial : ℝ) * (n.factorial : ℝ)
+      = ((n + k + 2).factorial : ℝ) := by exact_mod_cast hn
+  have hn0 : (n.factorial : ℝ) ≠ 0 := by exact_mod_cast n.factorial_pos.ne'
+  have hpoch : pochProd n (k + 2)
+      = (Nat.choose (n + k + 2) (k + 2) : ℝ) * ((k + 2).factorial : ℝ) := by
+    have h2 : (Nat.choose (n + k + 2) (k + 2) : ℝ) * ((k + 2).factorial : ℝ) * (n.factorial : ℝ)
+        = pochProd n (k + 2) * (n.factorial : ℝ) := by rw [hnR, hp]
+    exact (mul_right_cancel₀ hn0 h2).symm
+  unfold term
+  rw [hpoch]
+  have hc : (0 : ℝ) < (Nat.choose (n + k + 2) (k + 2) : ℝ) := by
+    exact_mod_cast Nat.choose_pos hle
+  have hf : (0 : ℝ) < ((k + 2).factorial : ℝ) := by exact_mod_cast (k + 2).factorial_pos
+  field_simp
+
+/-- **Reciprocal binomial sum (k-form).**  `∑_{n≥0} 1/C(n+k+2, k+2) = (k+2)/(k+1)`. -/
+theorem reciprocal_binomial_hasSum :
+    HasSum (fun n => 1 / ((Nat.choose (n + k + 2) (k + 2) : ℕ) : ℝ))
+      (((k : ℝ) + 2) / ((k : ℝ) + 1)) := by
+  have h := hasSum_term k
+  rw [gAnti_zero] at h
+  have he : (fun n => 1 / ((Nat.choose (n + k + 2) (k + 2) : ℕ) : ℝ)) = term k := by
+    funext n; rw [term_eq_inv_choose]
+  rw [he]; exact h
+
+/-- **Reciprocal binomial sum (d-form).**  For every depth `d ≥ 2`,
+
+      ∑_{n=0}^∞ 1/C(n+d, d) = d/(d-1),
+
+    equivalently `∑_{m≥1} 1/C(m+d-1, d) = d/(d-1)`. -/
+theorem reciprocal_binomial_sum_d (d : ℕ) (hd : 2 ≤ d) :
+    HasSum (fun n => 1 / ((Nat.choose (n + d) d : ℕ) : ℝ)) ((d : ℝ) / ((d : ℝ) - 1)) := by
+  obtain ⟨k, rfl⟩ : ∃ k, d = k + 2 := ⟨d - 2, by omega⟩
+  have h := reciprocal_binomial_hasSum k
+  have e2 : (((k + 2 : ℕ) : ℝ)) / (((k + 2 : ℕ) : ℝ) - 1) = ((k : ℝ) + 2) / ((k : ℝ) + 1) := by
+    push_cast; ring
+  rw [e2]
+  exact h
+
+/-- tsum form of the general reciprocal-binomial identity. -/
+theorem reciprocal_binomial_tsum (d : ℕ) (hd : 2 ≤ d) :
+    ∑' n : ℕ, 1 / ((Nat.choose (n + d) d : ℕ) : ℝ) = (d : ℝ) / ((d : ℝ) - 1) :=
+  (reciprocal_binomial_sum_d d hd).tsum_eq
 
 -- ═══════════════════════════════════════════════════
--- Main Theorem
+-- Sanity checks
 -- ═══════════════════════════════════════════════════
 
-/-- **General-depth simplicial reciprocals.**  For every depth `d = m+2 ≥ 2`,
-
-      ∑_{n=0}^∞  1 / C(n+d, d)  =  d / (d-1),
-
-    i.e. `HasSum (fun n => 1 / C(n+m+2, m+2)) ((m+2)/(m+1))`.  Reindexing the term to
-    `n ≥ 1` (term `1/C(n+d-1, d)`) this is the classical `∑_{n≥1} 1/C(n+d-1,d) = d/(d-1)`. -/
-theorem simplicial_reciprocals (m : ℕ) :
-    HasSum (simpReciprocal m) (((m : ℝ) + 2) / ((m : ℝ) + 1)) := by
-  have h_nonneg : ∀ n : ℕ, 0 ≤ simpReciprocal m n := by
-    intro n; unfold simpReciprocal; positivity
-  rw [hasSum_iff_tendsto_nat_of_nonneg h_nonneg]
-  rw [show (fun N : ℕ => ∑ i ∈ Finset.range N, simpReciprocal m i)
-        = fun N : ℕ => ((m : ℝ) + 2) / ((m : ℝ) + 1) - gTele m N from
-      funext (partial_sum_closed_form m)]
-  have h_lim : Tendsto
-      (fun N : ℕ => ((m : ℝ) + 2) / ((m : ℝ) + 1) - gTele m N)
-      atTop (𝓝 (((m : ℝ) + 2) / ((m : ℝ) + 1) - 0)) :=
-    tendsto_const_nhds.sub (gTele_tendsto_zero m)
-  rwa [sub_zero] at h_lim
-
-/-- tsum form of the general-depth simplicial reciprocal sum. -/
-theorem simplicial_reciprocals_tsum (m : ℕ) :
-    ∑' n : ℕ, simpReciprocal m n = ((m : ℝ) + 2) / ((m : ℝ) + 1) :=
-  (simplicial_reciprocals m).tsum_eq
-
--- ═══════════════════════════════════════════════════
--- Specializations recovering the classical cases
--- ═══════════════════════════════════════════════════
-
-/-- Depth `d = 2` (triangular reciprocals): `∑ 1/C(n+2, 2) = 2`. -/
-theorem triangular_case : HasSum (simpReciprocal 0) (2 : ℝ) := by
-  have h := simplicial_reciprocals 0
+/-- Depth `d = 3` recovers the parent tetrahedral value `3/2`. -/
+example : HasSum (fun n => 1 / ((Nat.choose (n + 3) 3 : ℕ) : ℝ)) (3 / 2 : ℝ) := by
+  have h := reciprocal_binomial_sum_d 3 (by norm_num)
   norm_num at h
   simpa using h
 
-/-- Depth `d = 3` (tetrahedral reciprocals, the parent entry): `∑ 1/C(n+3, 3) = 3/2`. -/
-theorem tetrahedral_case : HasSum (simpReciprocal 1) (3 / 2 : ℝ) := by
-  have h := simplicial_reciprocals 1
+/-- Depth `d = 2` gives `∑ 1/C(n+2,2) = 2`, the classical triangular value. -/
+example : HasSum (fun n => 1 / ((Nat.choose (n + 2) 2 : ℕ) : ℝ)) (2 : ℝ) := by
+  have h := reciprocal_binomial_sum_d 2 (by norm_num)
   norm_num at h
   simpa using h
-
--- Sanity checks of the summand.
-/-- First term at depth `d`: `1/C(m+2, m+2) = 1`. -/
-example (m : ℕ) : simpReciprocal m 0 = 1 := by
-  unfold simpReciprocal; simp [Nat.choose_self]
 
 end TriangularReciprocalsOQ04OQ01

--- a/src/data/proofs/triangular-reciprocals-oq-04-oq-01/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-04-oq-01/meta.json
@@ -1,196 +1,163 @@
 {
   "id": "triangular-reciprocals-oq-04-oq-01",
-  "title": "Simplicial Reciprocals Sum to d/(d-1) at Every Depth",
+  "title": "Reciprocals of Binomial Coefficients Sum to d/(d-1)",
   "slug": "triangular-reciprocals-oq-04-oq-01",
-  "description": "For every depth d ≥ 2 the reciprocals of the d-simplicial numbers sum to d/(d-1): ∑_{n=1}^∞ 1/C(n+d-1,d) = d/(d-1). Reindexed, ∑_{n=0}^∞ 1/C(n+d,d) = d/(d-1). Proved by a single depth-d telescoping uniform in d, generalizing the parent tetrahedral (d=3 → 3/2) and classical triangular (d=2 → 2) cases.",
+  "description": "For every depth d ≥ 2, the reciprocals of the binomial coefficients C(n+d-1,d) sum to d/(d-1): ∑_{n≥1} 1/C(n+d-1,d) = d/(d-1). This is the general-depth figurate-reciprocal identity; d=2 gives 2 (triangular), d=3 gives 3/2 (tetrahedral), d=4 gives 4/3 (pentatope), with limit 1 as d→∞. Proved by depth-d telescoping over an ascending product of consecutive integers.",
   "meta": {
-    "author": "Classical (formalized in Lean 4 with Mathlib)",
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Figurate_number",
-    "date": "Classical",
+    "date": "2026-07-01",
     "status": "verified",
     "tags": [
       "analysis",
       "series",
       "figurate-numbers",
-      "telescoping",
       "binomial-coefficients",
+      "telescoping",
       "intermediate"
     ],
     "proofRepoPath": "Proofs/TriangularReciprocalsOQ04OQ01.lean",
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only propext, Classical.choice, Quot.sound.",
     "mathlibDependencies": [
       {
-        "theorem": "Nat.add_one_mul_choose_eq",
-        "description": "Absorption identity (n+1)·C(n,k) = C(n+1,k+1)·(k+1)",
-        "module": "Mathlib.Data.Nat.Choose.Basic"
-      },
-      {
-        "theorem": "Nat.choose_succ_right_eq",
-        "description": "Absorption identity C(n,k+1)·(k+1) = C(n,k)·(n-k)",
-        "module": "Mathlib.Data.Nat.Choose.Basic"
-      },
-      {
-        "theorem": "Finset.sum_range_sub'",
-        "description": "Telescoping sum ∑_{i<N} (f i - f (i+1)) = f 0 - f N",
-        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
-      },
-      {
         "theorem": "hasSum_iff_tendsto_nat_of_nonneg",
         "description": "A nonnegative series HasSum its limit iff the partial sums converge",
-        "module": "Mathlib.Topology.Instances.ENNReal.Lemmas"
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Order"
       },
       {
         "theorem": "tendsto_one_div_add_atTop_nhds_zero_nat",
         "description": "1/(n+1) → 0 as n → ∞",
-        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+        "module": "Mathlib.Order.Filter.AtTopBot"
       },
       {
         "theorem": "squeeze_zero",
         "description": "Squeeze theorem for convergence to zero",
         "module": "Mathlib.Topology.Order.Bornology"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "C(n,k)·k!·(n-k)! = n!, used to identify the ascending product with C(n+d,d)·d!",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.prod_range_succ'",
+        "description": "Peel the first factor of a range product, used for the first-factor product recurrence",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
       }
     ],
     "originalContributions": [
-      "General-depth identity ∑_{n≥0} 1/C(n+d,d) = d/(d-1) for every d = m+2 ≥ 2, proved uniformly in d (one telescoping, not depth-by-depth)",
-      "Depth-d telescoping identity 1/C(n+m+2,m+2) = G(n) - G(n+1) with G(n) = (m+2)/(m+1)·1/C(n+m+1,m+1), reduced entirely to two Nat binomial absorption identities",
-      "Casting the absorption identities (n+m+2)·C(n+m+1,m+1) = (m+2)·C(n+m+2,m+2) and (n+1)·C(n+m+2,m+1) = (m+2)·C(n+m+2,m+2) to obtain the real telescope",
-      "Elementary binomial lower bound C(N+m+1,m+1) ≥ N+1 (Pascal induction) giving the vanishing tail G(N) → 0",
-      "Specializations recovering the triangular (d=2 → 2) and parent tetrahedral (d=3 → 3/2) cases as one-line corollaries"
+      "General figurate-reciprocal identity ∑_{n≥1} 1/C(n+d-1,d) = d/(d-1) for ALL d ≥ 2 (parent proved only d=3), answering the parent's open question",
+      "Depth-d telescoping term(n) = g(n) - g(n+1) with g(n) = d!/((d-1)·P(n,d-1)), where P(n,m) = (n+1)⋯(n+m) is an ascending product of consecutive integers",
+      "Two one-step product recurrences P(n,m+1) = P(n,m)·(n+m+1) (peel last) and P(n,m+1) = (n+1)·P(n+1,m) (peel first), which reduce the telescoping to field_simp/ring",
+      "Identification P(n,d) = C(n+d,d)·d! via P(n,m)·n! = (n+m)!, giving the binomial form of the sum",
+      "HasSum and tsum forms parametrized by d, plus d=2 (value 2) and d=3 (value 3/2) recovered as instances"
     ],
     "dateAdded": "2026-07-01",
-    "lineCount": 263,
+    "lineCount": 282,
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
-    "definitionCount": 2
+    "theoremCount": 15,
+    "definitionCount": 3
   },
   "overview": {
-    "historicalContext": "The d-simplicial (figurate) numbers C(n+d-1,d) form the (d+1)-st column of Pascal's triangle: d=2 gives the triangular numbers n(n+1)/2, d=3 the tetrahedral numbers n(n+1)(n+2)/6, d=4 the pentatope numbers, and so on. The classical reciprocal sum ∑_{n≥1} 1/C(n+d-1,d) = d/(d-1) for d ≥ 2 was known to Leibniz and the Bernoullis (the d=2 case ∑ 2/(n(n+1)) = 2 is Leibniz's 1673 telescoping triangle; the d=3 case gives 3/2). This entry answers the open question stated by the parent tetrahedral entry (triangular-reciprocals-oq-04) by proving the whole family at once, uniformly in the depth d.",
-    "problemStatement": "**Simplicial Reciprocals at Every Depth**: for every integer $d \\ge 2$,\n\n$$\\sum_{n=1}^{\\infty} \\frac{1}{\\binom{n+d-1}{d}} = \\frac{d}{d-1}.$$\n\nReindexing to $n \\ge 0$ (running term $1/\\binom{n+d}{d}$),\n\n$$\\sum_{n=0}^{\\infty} \\frac{1}{\\binom{n+d}{d}} = \\frac{d}{d-1}.$$",
-    "text": "For every depth d ≥ 2 the reciprocals of the d-simplicial numbers C(n+d-1,d) sum to d/(d-1). This is proved by a single telescoping argument uniform in d, generalizing the depth-2 (triangular, value 2) and depth-3 (tetrahedral, value 3/2) special cases.",
-    "proofStrategy": "Write d = m+2 (so d ≥ 2 ⟺ m ≥ 0), eliminating all natural-number subtraction. The summand telescopes as 1/C(n+m+2,m+2) = G(n) - G(n+1) with G(n) = (m+2)/(m+1)·1/C(n+m+1,m+1). The telescoping identity is reduced to two standard binomial absorption identities: (n+m+2)·C(n+m+1,m+1) = (m+2)·C(n+m+2,m+2) (from Nat.add_one_mul_choose_eq) and (n+1)·C(n+m+2,m+1) = (m+2)·C(n+m+2,m+2) (from Nat.choose_succ_right_eq). Casting both to ℝ and using positivity of the binomials, C(n+m+1,m+1)⁻¹ - C(n+m+2,m+1)⁻¹ = (m+1)/((m+2)·C(n+m+2,m+2)), and multiplying by (m+2)/(m+1) yields C(n+m+2,m+2)⁻¹. The partial sums collapse (Finset.sum_range_sub') to (m+2)/(m+1) - G(N), and G(N) → 0 because C(N+m+1,m+1) ≥ N+1 (Pascal induction) squeezes the reciprocal below 1/(N+1). hasSum_iff_tendsto_nat_of_nonneg finishes.",
+    "historicalContext": "The identity ∑_{n≥1} 1/C(n+d-1,d) = d/(d-1) for d ≥ 2 was known to Leibniz and the Bernoullis and follows from telescoping. Its low-depth cases are the classical figurate-reciprocal sums: d=2 gives the triangular sum ∑ 2/(n(n+1)) = 2 (Leibniz, 1673), d=3 gives the tetrahedral sum ∑ 1/Tet_n = 3/2, and d=4 gives the pentatope sum 4/3. As the simplex dimension d → ∞ the sum decreases monotonically to 1. The parent entry (triangular-reciprocals-oq-04) formalized only the single case d=3; its stated open question was to prove the whole family by induction on the telescoping depth, which this entry does.",
+    "problemStatement": "**General figurate reciprocals**: for every integer $d \\ge 2$,\n\n$$\\sum_{n=1}^{\\infty} \\frac{1}{\\binom{n+d-1}{d}} = \\frac{d}{d-1}, \\qquad \\text{equivalently} \\qquad \\sum_{n=0}^{\\infty} \\frac{1}{\\binom{n+d}{d}} = \\frac{d}{d-1}.$$",
+    "text": "For every depth d ≥ 2, the reciprocals of the binomial coefficients C(n+d-1,d) sum to d/(d-1). This generalizes the parent's tetrahedral case (d=3, value 3/2) to all depths at once.",
+    "proofStrategy": "Write d = k+2 (k : ℕ) so d ≥ 2 and d-1 = k+1 is a unit. Work with the real ascending product P(n,m) = ∏_{j<m}(n+1+j) = (n+1)(n+2)⋯(n+m). Then the summand is term(n) = d!/P(n,d) and the telescoping antiderivative is g(n) = d!/((d-1)·P(n,d-1)). The key identity term(n) = g(n) - g(n+1) is proved by expressing both P(n,d-1) and P(n+1,d-1) through P(n,d) using the two one-step recurrences (peel first / peel last factor), then clearing denominators with field_simp and ring. The partial sums telescope (Finset.sum induction) to g(0) - g(N); g(0) = d!/((d-1)·(d-1)!) = d/(d-1) and the tail g(N) → 0 because P(N,d-1) ≥ N+1 (squeeze). Finally P(n,d) = C(n+d,d)·d! (from P(n,m)·n! = (n+m)! and Nat.choose_mul_factorial_mul_factorial) converts the product form to the binomial form.",
     "keyInsights": [
-      "The whole family is proved uniformly in the depth d — a single telescoping, not a separate induction for each depth. The parent open question asked for 'induction on the telescoping depth'; the sharper observation is that no induction on depth is needed at all, because the telescope is depth-agnostic once the summand is written as a difference of consecutive depth-(d-1) reciprocals.",
-      "The telescoping antiderivative G lives one figurate dimension down (depth d-1) than the summand (depth d) and carries the scalar d/(d-1); the entire analytic content is packaged into two purely combinatorial Nat identities, so no partial-fraction algebra over ℝ is required.",
-      "Both absorption identities are the committee/chair rule k·C(m,k) = m·C(m-1,k-1) read in the two adjacent directions: one lowers the depth (C(n+d,d) ↔ C(n+d-1,d-1)), the other shifts the upper index at fixed depth (C(n+d,d) ↔ C(n+d,d-1)). Their difference telescopes.",
-      "Reindexing d = m+2 removes every ℕ-subtraction (d-1, n-k), so the two absorption identities hold on the nose and cast to ℝ with push_cast + linarith, avoiding truncated-subtraction hazards.",
-      "The limit d/(d-1) decreases monotonically to 1 as d → ∞: triangular 2, tetrahedral 3/2, pentatope 4/3, …; the deeper the simplex, the closer the total to 1 (the first term alone is always exactly 1)."
+      "Reparametrizing the depth as d = k+2 avoids all ℕ-subtraction: d-1 = k+1 and d-2 = k are honest naturals, so (d-1) is manifestly a nonzero unit and every field_simp is clean.",
+      "The whole telescoping reduces to two one-step product recurrences: peeling the LAST factor gives P(n,m+1) = P(n,m)·(n+m+1) (Finset.prod_range_succ), and peeling the FIRST gives P(n,m+1) = (n+1)·P(n+1,m) (Finset.prod_range_succ' with a reindexing congruence).",
+      "Both depth-(d-1) products appearing in g(n) - g(n+1) can be written as P(n,d)/(linear factor): P(n+1,d-1) = P(n,d)/(n+1) and P(n,d-1) = P(n,d)/(n+d). Substituting collapses the difference to d!·(d-1)/((d-1)·P(n,d)) = d!/P(n,d) = term(n) by pure ring arithmetic.",
+      "The bridge to binomials is the single integer identity P(n,d)·n! = (n+d)!, proved by induction; combined with C(n+d,d)·d!·n! = (n+d)! and cancellation of n! it yields P(n,d) = C(n+d,d)·d!, hence term(n) = 1/C(n+d,d).",
+      "The value d/(d-1) is strictly decreasing in d with limit 1: triangular (d=2)→2, tetrahedral (d=3)→3/2, pentatope (d=4)→4/3, so higher-dimensional simplex reciprocals converge to a sum barely above 1."
     ],
     "prerequisites": [
-      "Real analysis (series convergence, telescoping sums)",
-      "Binomial coefficients and their absorption identities",
-      "Figurate/simplicial numbers as columns of Pascal's triangle"
+      "Real analysis (series convergence, telescoping sums, squeeze theorem)",
+      "Finset products and the range-product recurrences",
+      "Binomial coefficients and the factorial identity C(n,k)·k!·(n-k)! = n!",
+      "Figurate numbers (triangular, tetrahedral, pentatope, and higher simplices)"
     ]
   },
   "sections": [
     {
       "id": "definitions",
-      "title": "Summand and Telescoping Antiderivative",
-      "startLine": 47,
-      "endLine": 54,
-      "summary": "Defines simpReciprocal m n = 1/C(n+m+2,m+2) (depth d=m+2) and the antiderivative gTele m n = (m+2)/(m+1)·1/C(n+m+1,m+1).",
-      "mathContext": "The depth-$(m+2)$ summand $1/\\binom{n+m+2}{m+2}$ and antiderivative $G(n) = \\frac{m+2}{m+1}\\cdot\\frac{1}{\\binom{n+m+1}{m+1}}$, chosen so $f(n) = G(n) - G(n+1)$."
+      "title": "Ascending Product, Summand, and Antiderivative",
+      "startLine": 46,
+      "endLine": 55,
+      "summary": "Defines the real ascending product pochProd n m = (n+1)⋯(n+m), the summand term n = d!/P(n,d), and the telescoping antiderivative gAnti n = d!/((d-1)·P(n,d-1)) with d = k+2.",
+      "mathContext": "$P(n,m) = \\prod_{j<m}(n+1+j)$, $\\mathrm{term}(n) = d!/P(n,d) = 1/\\binom{n+d}{d}$, and $g(n) = d!/((d-1)P(n,d-1))$, chosen so $\\mathrm{term}(n) = g(n) - g(n+1)$."
     },
     {
-      "id": "positivity",
-      "title": "Positivity of the Binomials",
-      "startLine": 56,
-      "endLine": 66,
-      "summary": "The three binomial coefficients C(n+m+2,m+2), C(n+m+1,m+1), C(n+m+2,m+1) are all positive (lower ≤ upper).",
-      "mathContext": "Each $\\binom{a}{b} > 0$ since $b \\le a$, needed to invert the casts in ℝ."
+      "id": "product-recurrences",
+      "title": "Product Recurrences and Positivity",
+      "startLine": 62,
+      "endLine": 117,
+      "summary": "Proves the two one-step recurrences (peel last / peel first factor), positivity and ≥1 bounds for the product, P(0,m) = m!, and the integer identity P(n,m)·n! = (n+m)!.",
+      "mathContext": "$P(n,m+1) = P(n,m)(n+m+1)$, $P(n,m+1) = (n+1)P(n+1,m)$, $P(0,m) = m!$, and $P(n,m)\\,n! = (n+m)!$."
     },
     {
-      "id": "absorption",
-      "title": "The Two Absorption Identities",
-      "startLine": 68,
-      "endLine": 98,
-      "summary": "R1: (n+m+2)·C(n+m+1,m+1) = (m+2)·C(n+m+2,m+2) from Nat.add_one_mul_choose_eq. R2: (n+1)·C(n+m+2,m+1) = (m+2)·C(n+m+2,m+2) from Nat.choose_succ_right_eq.",
-      "mathContext": "The committee/chair rule $k\\binom{m}{k} = m\\binom{m-1}{k-1}$ read in two adjacent directions — one lowering depth, one shifting the upper index at fixed depth."
-    },
-    {
-      "id": "telescope",
+      "id": "telescoping",
       "title": "Depth-d Telescoping Identity",
-      "startLine": 100,
-      "endLine": 153,
-      "summary": "Proves 1/C(n+m+2,m+2) = G(n) - G(n+1) by casting R1, R2 to ℝ, computing the two reciprocals in terms of C(n+m+2,m+2), and clearing denominators.",
-      "mathContext": "$\\frac{1}{\\binom{n+d}{d}} = G(n) - G(n+1)$; from R1, R2 the bracket $\\binom{n+d-1}{d-1}^{-1} - \\binom{n+d}{d-1}^{-1} = \\frac{d-1}{d\\binom{n+d}{d}}$, and $\\frac{d}{d-1}$ times it is $\\binom{n+d}{d}^{-1}$."
+      "startLine": 123,
+      "endLine": 144,
+      "summary": "Proves term n = g(n) - g(n+1) by expressing both depth-(d-1) products through P(n,d) via the recurrences, then field_simp and ring.",
+      "mathContext": "$\\dfrac{d!}{P(n,d)} = \\dfrac{d!}{(d-1)P(n,d-1)} - \\dfrac{d!}{(d-1)P(n+1,d-1)}$, the depth-$d$ analogue of the tetrahedral partial fraction."
     },
     {
-      "id": "partial-sum",
-      "title": "Closed Form for the Partial Sum",
-      "startLine": 155,
-      "endLine": 174,
-      "summary": "Uses Finset.sum_range_sub' to collapse the telescope: ∑_{i<N} f(i) = G(0) - G(N) = (m+2)/(m+1) - G(N), with G(0) = (m+2)/(m+1) since C(m+1,m+1)=1.",
-      "mathContext": "$\\sum_{i<N} \\binom{i+d}{d}^{-1} = \\frac{d}{d-1} - G(N)$."
-    },
-    {
-      "id": "choose-bound",
-      "title": "Binomial Lower Bound",
-      "startLine": 176,
-      "endLine": 188,
-      "summary": "Elementary Pascal induction: C(N+m+1,m+1) ≥ N+1 for all N (depth m+1 ≥ 1).",
-      "mathContext": "$\\binom{N+d-1}{d-1} \\ge N+1$, giving the growth needed for the tail to vanish."
-    },
-    {
-      "id": "tail",
-      "title": "Tail Vanishes",
-      "startLine": 190,
-      "endLine": 220,
-      "summary": "G(N) → 0: the reciprocal C(N+m+1,m+1)⁻¹ is squeezed between 0 and 1/(N+1) (using the lower bound) and G is a constant multiple of it.",
-      "mathContext": "$G(N) = \\frac{d}{d-1}\\binom{N+d-1}{d-1}^{-1} \\to 0$ since $\\binom{N+d-1}{d-1} \\ge N+1 \\to \\infty$."
+      "id": "partial-sum-limit",
+      "title": "Partial Sum, Endpoint, and Vanishing Tail",
+      "startLine": 150,
+      "endLine": 193,
+      "summary": "Telescopes the partial sum to g(0) - g(N), evaluates g(0) = (k+2)/(k+1) = d/(d-1), and proves g(N) → 0 by squeezing below (d!/(d-1))·(1/(N+1)).",
+      "mathContext": "$\\sum_{i<N}\\mathrm{term}(i) = g(0) - g(N)$, $g(0) = d/(d-1)$, and $g(N) \\to 0$ since $P(N,d-1) \\ge N+1$."
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem",
-      "startLine": 222,
-      "endLine": 241,
-      "summary": "Combines the closed form and vanishing tail into HasSum (simpReciprocal m) ((m+2)/(m+1)) via hasSum_iff_tendsto_nat_of_nonneg, plus the tsum form.",
-      "mathContext": "$\\sum_{n=0}^{\\infty} \\binom{n+d}{d}^{-1} = \\frac{d}{d-1}$ for every $d = m+2 \\ge 2$."
+      "title": "Main Theorem and Binomial Form",
+      "startLine": 199,
+      "endLine": 263,
+      "summary": "Assembles HasSum term (g 0), identifies term n = 1/C(n+k+2,k+2), and states the general d-form HasSum and tsum results ∑ 1/C(n+d,d) = d/(d-1) for d ≥ 2.",
+      "mathContext": "$\\sum_{n=0}^{\\infty} 1/\\binom{n+d}{d} = d/(d-1)$ for all $d \\ge 2$, in both HasSum and tsum form."
     },
     {
-      "id": "specializations",
-      "title": "Classical Special Cases",
-      "startLine": 243,
-      "endLine": 262,
-      "summary": "Recovers the triangular case ∑1/C(n+2,2) = 2 (m=0) and the parent tetrahedral case ∑1/C(n+3,3) = 3/2 (m=1) as corollaries, plus the first-term sanity check f(0)=1.",
-      "mathContext": "$d=2 \\Rightarrow 2$ (triangular), $d=3 \\Rightarrow 3/2$ (tetrahedral, the parent entry). The first term $1/\\binom{d}{d} = 1$ at every depth."
+      "id": "examples",
+      "title": "Sanity Checks",
+      "startLine": 270,
+      "endLine": 281,
+      "summary": "Recovers d=3 (∑ 1/C(n+3,3) = 3/2, the parent tetrahedral value) and d=2 (∑ 1/C(n+2,2) = 2, the classical triangular value) as instances.",
+      "mathContext": "$\\sum 1/\\binom{n+3}{3} = 3/2$ and $\\sum 1/\\binom{n+2}{2} = 2$."
     }
   ],
   "crossReferences": [
     {
       "targetId": "triangular-reciprocals-oq-04",
       "relationship": "extends",
-      "description": "Directly answers the open question stated by the parent tetrahedral entry ('prove ∑1/C(n+d-1,d) = d/(d-1) for arbitrary d ≥ 2'), generalizing its single depth-3 result (3/2) to the whole family, uniformly in d."
+      "description": "Directly answers this parent's stated open question: generalizes the single tetrahedral case ∑1/C(n+2,3) = 3/2 (d=3) to the full family ∑_{n≥1} 1/C(n+d-1,d) = d/(d-1) for every d ≥ 2, by induction-free depth-d telescoping over an ascending product."
     },
     {
       "targetId": "triangular-reciprocals",
-      "relationship": "extends",
-      "description": "The depth-2 case (d=2, value 2) of this family is the classical triangular-reciprocal sum ∑2/(n(n+1)) = 2; here it is a one-line specialization m=0."
+      "relationship": "related",
+      "description": "The depth-1 case: ∑ 2/(n(n+1)) = 2 is the d=2 instance ∑1/C(n+1,2) = 2 of the general identity proved here."
     },
     {
       "targetId": "combinations-formula",
       "relationship": "related",
-      "description": "The d-simplicial numbers are binomial coefficients C(n+d-1,d) (columns of Pascal's triangle); the proof runs entirely on the binomial absorption identities rather than partial fractions."
-    },
-    {
-      "targetId": "triangular-reciprocals-oq-02",
-      "relationship": "related",
-      "description": "That entry sums shifted reciprocal products ∑1/(n(n+k)) = H_k/k via depth-1 partial fractions with an arbitrary shift; this instead increases the depth d at fixed shift and works uniformly in d."
+      "description": "The summand 1/C(n+d,d) is the reciprocal of a binomial coefficient (the d-th column of Pascal's triangle); the proof uses C(n,k)·k!·(n-k)! = n! to convert the ascending product to a binomial."
     },
     {
       "targetId": "basel-problem",
       "relationship": "related",
-      "description": "Both evaluate reciprocal series over structured integer sequences in closed form; Basel gives ∑1/n² = π²/6, while this gives a rational value d/(d-1) at every simplicial depth."
+      "description": "Both evaluate reciprocal series over structured integer sequences in closed form; Basel gives ∑1/n² = π²/6 while this gives the rational family ∑1/C(n+d,d) = d/(d-1)."
     }
   ],
   "conclusion": {
-    "summary": "For every depth d ≥ 2 the d-simplicial reciprocals sum to d/(d-1), fully machine-verified with zero axioms and zero sorries. A single depth-agnostic telescoping — reduced to two Nat binomial absorption identities — proves the entire family at once, subsuming the classical triangular (d=2 → 2) and parent tetrahedral (d=3 → 3/2) cases.",
-    "implications": "One reduction replaces the depth-by-depth induction suggested by the parent open question: because the summand 1/C(n+d,d) is intrinsically a difference of consecutive depth-(d-1) reciprocals scaled by d/(d-1), the telescope needs no recursion on d. The value d/(d-1) decreases monotonically to 1 as d → ∞ (2, 3/2, 4/3, 5/4, …), while the first term is always exactly 1.",
+    "summary": "For every depth d ≥ 2, ∑_{n≥1} 1/C(n+d-1,d) = d/(d-1), fully machine-verified with zero axioms and zero sorries. The proof uses depth-d telescoping over the ascending product P(n,m) = (n+1)⋯(n+m): each summand is g(n) - g(n+1) for g(n) = d!/((d-1)P(n,d-1)), so the partial sums collapse to g(0) = d/(d-1), and the tail vanishes. The identity P(n,d) = C(n+d,d)·d! yields the binomial form.",
+    "implications": "This closes the parent's open question in full generality — not just d=3 but all d ≥ 2 in a single theorem parametrized by depth. The values d/(d-1) decrease monotonically to 1 as the simplex dimension grows: 2 (triangular), 3/2 (tetrahedral), 4/3 (pentatope), 5/4, …. The reusable core (ascending-product recurrences + product-to-binomial bridge) applies to other hypergeometric-style reciprocal sums.",
     "openQuestions": [
-      "Give a closed form for the finite truncation error d/(d-1) - ∑_{n<N} 1/C(n+d,d) = (d/(d-1))·1/C(N+d-1,d-1) and its dependence on d (the tail decays like d/((d-1)·N^{d-1})).",
-      "Evaluate the alternating simplicial reciprocal sum ∑_{n≥0} (-1)^n/C(n+d,d) in closed form and compare with the alternating triangular case (d=2)."
+      "Evaluate the alternating general figurate reciprocal ∑_{n≥1} (-1)^{n+1}/C(n+d-1,d) in closed form for d ≥ 2, and determine for which d the value is rational versus transcendental.",
+      "Prove the two-parameter generalization ∑_{n≥0} 1/C(n+a+b, a) type identities (shifted / partial reciprocal-binomial sums) and relate them to the Beta function B(a,b)."
     ]
   },
   "leanFile": {
@@ -204,10 +171,10 @@
       "Topology"
     ],
     "namespace": "TriangularReciprocalsOQ04OQ01",
-    "lineCount": 263,
+    "lineCount": 282,
     "axiomCount": 0,
-    "theoremCount": 13,
-    "definitionCount": 2,
+    "theoremCount": 15,
+    "definitionCount": 3,
     "path": "Proofs/TriangularReciprocalsOQ04OQ01.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Generalizes the parent **triangular-reciprocals-oq-04** (single tetrahedral case $\sum 1/\mathrm{Tet}_n = 3/2$, i.e. $d=3$) to the **entire family** in one theorem parametrized by depth:

$$\sum_{n=1}^{\infty} \frac{1}{\binom{n+d-1}{d}} = \frac{d}{d-1} \qquad \text{for every } d \ge 2.$$

This **directly answers the parent's stated open question** ("prove the general figurate-reciprocal identity … for arbitrary d ≥ 2 by telescoping").

## Method

Write $d = k+2$ (avoids all ℕ-subtraction; $d-1=k+1$ is a unit). Work with the real ascending product $P(n,m) = \prod_{j<m}(n+1+j) = (n+1)\cdots(n+m)$.

- **Telescoping identity** $\mathrm{term}(n) = g(n) - g(n+1)$ with $g(n) = d!/((d-1)P(n,d-1))$, proved by writing both depth-$(d-1)$ products through $P(n,d)$ via two one-step recurrences (peel first / peel last factor), then `field_simp; ring`.
- **Partial sums** telescope to $g(0) - g(N)$; $g(0) = d/(d-1)$ and the tail $g(N)\to 0$ since $P(N,d-1)\ge N+1$ (squeeze).
- **Binomial bridge**: $P(n,d) = \binom{n+d}{d}\cdot d!$ from $P(n,m)\,n! = (n+m)!$ and `Nat.choose_mul_factorial_mul_factorial`.

Instances recovered: $d=2 \to 2$ (triangular), $d=3 \to 3/2$ (tetrahedral, parent value).

## Verification

- **0 sorries, 0 axioms** — `#print axioms` reports only `propext, Classical.choice, Quot.sound`.
- Typechecked against Mathlib 4.26.0 via `lake env lean`.
- 15 theorems, 3 definitions, 282 lines.
- New gallery entry `triangular-reciprocals-oq-04-oq-01` with full meta.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)