### PR TITLE
Enrich Step Count of Binary GCD is O(log) (gcd-algorithm-oq-02-oq-01): add annotations.json (0→7)

### DIFF
--- a/src/data/proofs/gcd-algorithm-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-02-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-gcd0201-overview",
+    "proofId": "gcd-algorithm-oq-02-oq-01",
+    "range": { "startLine": 4, "endLine": 42 },
+    "type": "concept",
+    "title": "Bounding the step count of Stein's binary GCD",
+    "content": "The parent entry GcdAlgorithmOQ02 defines Stein's binary GCD as a well-founded recursion binaryGcd and proves it computes Nat.gcd, but leaves open the complexity question. This entry answers it: it copies the same three-way parity/comparison guard structure into a step-counting function binaryGcdSteps and proves the sharp logarithmic bound binaryGcdSteps a b ≤ size a + size b, hence ≤ 2·size(max a b). Since Nat.size n = ⌊log₂ n⌋ + 1, this is exactly the textbook O(log(max a b)) bound (Knuth TAOCP 4.5.2; Brent 1976). The whole argument rests on one bit-length fact — halving a positive number drops its Nat.size by exactly one — making size a + size b a strictly decreasing potential.",
+    "mathContext": "$\\mathrm{steps}(a,b) \\le \\mathrm{size}(a) + \\mathrm{size}(b) \\le 2\\,\\mathrm{size}(\\max(a,b)) = O(\\log \\max(a,b))$.",
+    "significance": "key",
+    "relatedConcepts": ["binary GCD (Stein's algorithm)", "well-founded recursion", "algorithmic complexity", "Nat.size / bit length"],
+    "prerequisites": ["Stein's binary GCD", "Nat.size = ⌊log₂⌋ + 1", "the parent entry gcd-algorithm-oq-02"]
+  },
+  {
+    "id": "ann-gcd0201-def",
+    "proofId": "gcd-algorithm-oq-02-oq-01",
+    "range": { "startLine": 56, "endLine": 72 },
+    "type": "definition",
+    "title": "binaryGcdSteps: the step-count function",
+    "content": "A step-annotated copy of binaryGcd: identical guards, identical recursive arguments, each recursive case contributing 1. The five interior branches are (both even → halve both), (a even, b odd → halve a), (a odd, b even → halve b), and the odd–odd case which subtracts the smaller from the larger and halves. Termination is by the measure a + b (decreasing_by omega). The base cases binaryGcdSteps 0 _ and _ 0 are 0 (the two @[simp] lemmas below). This faithful mirroring is what lets binaryGcdSteps.induct drive the complexity proof along the algorithm's exact reduction path.",
+    "mathContext": "Recursion on $(a,b)$ with measure $a+b$; each recursive branch contributes $+1$.",
+    "significance": "key",
+    "relatedConcepts": ["termination_by / decreasing_by", "well-founded recursion", "parity case analysis"],
+    "prerequisites": ["binaryGcd from the parent entry", "well-founded recursion in Lean"]
+  },
+  {
+    "id": "ann-gcd0201-bitlength",
+    "proofId": "gcd-algorithm-oq-02-oq-01",
+    "range": { "startLine": 86, "endLine": 105 },
+    "type": "theorem",
+    "title": "The key bit-length lemmas",
+    "content": "size_div_two_succ_le: for n ≥ 1, size(n/2) + 1 ≤ size n — halving drops the bit length by (at least) one, proved via Nat.lt_size (2^(size m) > m) and doubling the bound 2^(size(n/2)−1) ≤ n/2. size_half_lt: if m < n then size(m/2) + 1 ≤ size n, which additionally absorbs the odd–odd branch where the new operand (A−B)/2 may even be 0. These two facts are the entire engine: every recursive branch drops the potential size a + size b by at least one.",
+    "mathContext": "$n \\ge 1 \\Rightarrow \\mathrm{size}(n/2) + 1 \\le \\mathrm{size}(n)$; and $m < n \\Rightarrow \\mathrm{size}(m/2) + 1 \\le \\mathrm{size}(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.lt_size", "Nat.size_le_size", "monovariant / potential function"],
+    "prerequisites": ["Nat.size and its characterization 2^(size n) > n"]
+  },
+  {
+    "id": "ann-gcd0201-master",
+    "proofId": "gcd-algorithm-oq-02-oq-01",
+    "range": { "startLine": 114, "endLine": 139 },
+    "type": "theorem",
+    "title": "Master step bound",
+    "content": "The headline upper bound: binaryGcdSteps a b ≤ size a + size b. The proof is a single induction using binaryGcdSteps.induct, so the induction hypothesis is available exactly on the recursive arguments. Each of the five interior cases discharges by omega after feeding in the relevant bit-length drop (size_div_two_succ_le for the halving branches, size_half_lt for the odd–odd subtract-and-halve branches). Because every branch strictly decreases size a + size b, the recursion depth is bounded by its initial value.",
+    "mathContext": "$\\mathrm{binaryGcdSteps}(a,b) \\le \\mathrm{size}(a) + \\mathrm{size}(b)$",
+    "significance": "key",
+    "relatedConcepts": ["custom induction (.induct)", "monovariant argument", "omega"],
+    "prerequisites": ["size_div_two_succ_le", "size_half_lt", "binaryGcdSteps.induct"]
+  },
+  {
+    "id": "ann-gcd0201-classical",
+    "proofId": "gcd-algorithm-oq-02-oq-01",
+    "range": { "startLine": 144, "endLine": 149 },
+    "type": "theorem",
+    "title": "Classical O(log) form",
+    "content": "The textbook statement: binaryGcdSteps a b ≤ 2·size(max a b). Immediate from the master bound plus size a, size b ≤ size(max a b) (Nat.size_le_size and le_max_left/right). Because size n = ⌊log₂ n⌋ + 1 for n ≥ 1, this is precisely the O(log(max a b)) recursive-step count of the binary GCD.",
+    "mathContext": "$\\mathrm{binaryGcdSteps}(a,b) \\le 2\\,\\mathrm{size}(\\max(a,b))$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.size_le_size", "O(log) complexity", "max"],
+    "prerequisites": ["binaryGcdSteps_le_size_add"]
+  },
+  {
+    "id": "ann-gcd0201-recursion-base",
+    "proofId": "gcd-algorithm-oq-02-oq-01",
+    "range": { "startLine": 157, "endLine": 172 },
+    "type": "theorem",
+    "title": "Diagonal recursion and base case",
+    "content": "Two ingredients for the tightness result. binaryGcdSteps_two_mul_two_mul: on doubled positive inputs (both even) the algorithm takes exactly one extra step: steps(2a, 2b) = 1 + steps(a, b), by unfolding the both-even branch and simplifying (2a+1+1)/2 = a+1. binaryGcdSteps_one_one: steps(1, 1) = 1, the base of the diagonal family (a single odd–odd subtract step to reach (0,1)).",
+    "mathContext": "$\\mathrm{steps}(2a, 2b) = 1 + \\mathrm{steps}(a,b)$ for $a,b>0$; $\\mathrm{steps}(1,1)=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["recursion unfolding", "conv_lhs", "even branch"],
+    "prerequisites": ["definition of binaryGcdSteps"]
+  },
+  {
+    "id": "ann-gcd0201-tightness",
+    "proofId": "gcd-algorithm-oq-02-oq-01",
+    "range": { "startLine": 176, "endLine": 183 },
+    "type": "theorem",
+    "title": "Order tightness on the diagonal",
+    "content": "The bound has the right logarithmic order: on (2^k, 2^k) the step count is exactly k + 1. Induction on k, using steps(1,1) = 1 at the base and the doubling law steps(2·2^k, 2·2^k) = 1 + steps(2^k, 2^k) at the step. Against the upper bound 2·size(2^k) = 2(k+1), this shows the algorithm is Θ(log) — the O(log) bound cannot be improved to o(log).",
+    "mathContext": "$\\mathrm{binaryGcdSteps}(2^k, 2^k) = k + 1$, versus upper bound $2\\,\\mathrm{size}(2^k) = 2(k+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["tightness / lower bound", "Θ(log)", "induction"],
+    "prerequisites": ["binaryGcdSteps_two_mul_two_mul", "binaryGcdSteps_one_one"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `gcd-algorithm-oq-02-oq-01` (logarithmic step-count bound for Stein's binary GCD).

**Gap:** the entry shipped with a rich meta.json but no `annotations.json`.

**Added:** 7 inline annotations, each with `content`, `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering:
- overview (bounding the step count, Knuth/Brent context)
- `binaryGcdSteps` definition
- the key bit-length lemmas (`size_div_two_succ_le`, `size_half_lt`)
- `binaryGcdSteps_le_size_add` (master bound)
- `binaryGcdSteps_le_two_mul_size_max` (classical O(log) form)
- the diagonal recursion + base case
- `binaryGcdSteps_pow_two_self` (Θ(log) tightness)

All 7 validated by `validateLineAnnotations` (0 misaligned). No changes to meta.json or the Lean file.