### PR TITLE
research(pell-equation-oq-07-oq-01-oq-01): Cassini/Catalan identities from det(Mⁿ)=(det M)ⁿ [VERIFIED, 0-axiom, 8thm/183L, new entry]

### DIFF
--- a/proofs/Proofs/PellEquationOQ07OQ01OQ01.lean
+++ b/proofs/Proofs/PellEquationOQ07OQ01OQ01.lean
@@ -1,0 +1,183 @@
+/-
+Pell's Equation OQ-07 → OQ-01 → OQ-01: Cassini / Catalan Identities from `det(Mⁿ) = (det M)ⁿ`
+
+The grandparent entry (`pell-equation-oq-07`) extracted the second-order recurrence
+of the coordinate sequences of the power chain `aⁿ` of a quadratic integer
+`a = ⟨x₁, y₁⟩ ∈ ℤ√d`; the parent (`pell-equation-oq-07-oq-01`,
+`PellEquationOQ07OQ01.lean`, verified) supplied the two **closed forms** — the Binet
+formula and the **companion-matrix power** `Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)]`
+for `M = !![x₁, d·y₁; y₁, x₁]`, with `tr M = 2x₁`, `det M = N(a)`.
+
+This entry closes the open question left by the parent: **the multiplicative content
+of the companion form**. Because determinant is multiplicative,
+
+    det(Mⁿ) = (det M)ⁿ = N(a)ⁿ,                              (`det_companion_pow`)
+
+and reading `det(Mⁿ)` off the explicit power form gives the **quadratic Pell
+invariant** — the classical Cassini identity for Pell chains:
+
+    re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ.                             (`re_sq_sub_d_im_sq`)
+
+For a Pell generator (`N(a) = 1`) this says *every power of a Pell solution is again a
+Pell solution* (`pow_isPell`). From the one-step recurrence
+`re(aⁿ⁺¹) = x₁·re(aⁿ) + d·y₁·im(aⁿ)`, `im(aⁿ⁺¹) = y₁·re(aⁿ) + x₁·im(aⁿ)`
+(the shadow of `aⁿ⁺¹ = a·aⁿ`) together with that invariant, the genuine three-term
+Cassini/Catalan identities fall out:
+
+    re(aⁿ)·im(aⁿ⁺¹) − re(aⁿ⁺¹)·im(aⁿ) = y₁·N(a)ⁿ,             (`cross_cassini`)
+    re(aⁿ)·re(aⁿ⁺²) − re(aⁿ⁺¹)²        =  d·y₁²·N(a)ⁿ,        (`cassini_re`)
+    im(aⁿ)·im(aⁿ⁺²) − im(aⁿ⁺¹)²        = −y₁²·N(a)ⁿ.          (`cassini_im`)
+
+The three-term identities are the Catalan-type invariants `uₙ₋₁uₙ₊₁ − uₙ² = c·N(a)ⁿ⁻¹`
+(re-indexed to start at `n`) for the two coordinate sequences, with the constant `c`
+determined by the seed `y₁ = im(a)`. All of this is pure integer algebra in `ℤ√d` and
+`Matrix (Fin 2) (Fin 2) ℤ`; no passage to `ℝ` or `√d` is needed.
+
+## Main results
+
+* `det_companion_pow` — `det(Mⁿ) = N(a)ⁿ` (`Matrix.det_pow` + parent `companion_det`).
+* `re_sq_sub_d_im_sq` — the Pell quadratic invariant `re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ`,
+  obtained by evaluating `det(Mⁿ)` two ways.
+* `pow_isPell` — powers of a Pell solution (`N(a) = 1`) are Pell solutions.
+* `cross_cassini` — the mixed two-coordinate Cassini invariant `y₁·N(a)ⁿ`.
+* `cassini_re` / `cassini_im` — the three-term Cassini/Catalan identities for the real
+  and `√d` coordinate sequences.
+* Concrete `D = 2` checks against `(3 + 2√2)ⁿ` (`re: 1,3,17,99,…`, `im: 0,2,12,70,…`,
+  `N = 1`).
+
+References:
+- Parent: `pell-equation-oq-07-oq-01` (`companion_pow`, `companion_det`).
+- Grandparent: `pell-equation-oq-07` (the recurrence).
+- Mathlib `Matrix.det_pow`, `Matrix.det_fin_two_of`; `Zsqrtd.norm`, `re_mul`, `im_mul`.
+-/
+
+import Proofs.PellEquationOQ07OQ01
+
+namespace PellEquationOQ07OQ01OQ01
+
+open Zsqrtd PellEquationOQ07OQ01
+
+variable {d : ℤ}
+
+/-
+## The determinant identity `det(Mⁿ) = N(a)ⁿ`
+
+Determinant is a monoid homomorphism, so `det(Mⁿ) = (det M)ⁿ`; the parent computed
+`det M = N(a)`.
+-/
+
+/-- **`det(Mⁿ) = N(a)ⁿ`.** The determinant of the `n`-th power of the multiplication
+matrix is the `n`-th power of the norm, since `det` is multiplicative and
+`det M = N(a)` (parent `companion_det`). -/
+theorem det_companion_pow (a : ℤ√d) (n : ℕ) :
+    ((companion a) ^ n).det = a.norm ^ n := by
+  rw [Matrix.det_pow, companion_det]
+
+/-
+## The quadratic Pell invariant (Cassini for Pell chains)
+
+Evaluating `det(Mⁿ)` on the explicit power form `!![rₙ, d·sₙ; sₙ, rₙ]` gives
+`rₙ² − d·sₙ²`; equating with `N(a)ⁿ` yields the invariant. Here
+`rₙ = re(aⁿ)`, `sₙ = im(aⁿ)`.
+-/
+
+/-- **The Pell quadratic invariant.** `re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ`: reading the
+determinant of `Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)]` off the explicit power form
+and equating with `det(Mⁿ) = N(a)ⁿ`. (This is `Zsqrtd.norm (aⁿ) = N(a)ⁿ` recovered
+through the companion determinant.) -/
+theorem re_sq_sub_d_im_sq (a : ℤ√d) (n : ℕ) :
+    (a ^ n).re ^ 2 - d * (a ^ n).im ^ 2 = a.norm ^ n := by
+  have h := det_companion_pow a n
+  rw [companion_pow, Matrix.det_fin_two_of] at h
+  linear_combination h
+
+/-- **Powers of a Pell solution are Pell solutions.** If `N(a) = 1` then
+`re(aⁿ)² − d·im(aⁿ)² = 1` for every `n`: the norm-`1` locus is closed under powers. -/
+theorem pow_isPell (a : ℤ√d) (h : a.norm = 1) (n : ℕ) :
+    (a ^ n).re ^ 2 - d * (a ^ n).im ^ 2 = 1 := by
+  rw [re_sq_sub_d_im_sq, h, one_pow]
+
+/-
+## The three-term Cassini / Catalan identities
+
+The one-step recurrence `aⁿ⁺¹ = a·aⁿ` reads, on coordinates,
+`re(aⁿ⁺¹) = re(a)·re(aⁿ) + d·im(a)·im(aⁿ)` and
+`im(aⁿ⁺¹) = re(a)·im(aⁿ) + im(a)·re(aⁿ)`. Combining these with the quadratic invariant
+gives the Cassini invariants.
+-/
+
+/-- One-step real-coordinate recurrence `re(aⁿ⁺¹) = re(a)·re(aⁿ) + d·im(a)·im(aⁿ)`. -/
+private theorem re_succ (a : ℤ√d) (n : ℕ) :
+    (a ^ (n + 1)).re = a.re * (a ^ n).re + d * a.im * (a ^ n).im := by
+  rw [pow_succ, re_mul]; ring
+
+/-- One-step `√d`-coordinate recurrence `im(aⁿ⁺¹) = re(a)·im(aⁿ) + im(a)·re(aⁿ)`. -/
+private theorem im_succ (a : ℤ√d) (n : ℕ) :
+    (a ^ (n + 1)).im = a.re * (a ^ n).im + a.im * (a ^ n).re := by
+  rw [pow_succ, im_mul]; ring
+
+/-- **Mixed two-coordinate Cassini invariant.**
+`re(aⁿ)·im(aⁿ⁺¹) − re(aⁿ⁺¹)·im(aⁿ) = im(a)·N(a)ⁿ`. The cross-term of the two
+coordinate sequences collapses — via the one-step recurrence and the quadratic
+invariant — onto `im(a)·(re(aⁿ)² − d·im(aⁿ)²) = im(a)·N(a)ⁿ`. -/
+theorem cross_cassini (a : ℤ√d) (n : ℕ) :
+    (a ^ n).re * (a ^ (n + 1)).im - (a ^ (n + 1)).re * (a ^ n).im
+      = a.im * a.norm ^ n := by
+  have hinv := re_sq_sub_d_im_sq a n
+  rw [re_succ, im_succ]
+  linear_combination a.im * hinv
+
+/-- **Three-term Cassini/Catalan identity, real coordinate.**
+`re(aⁿ)·re(aⁿ⁺²) − re(aⁿ⁺¹)² = d·im(a)²·N(a)ⁿ`. -/
+theorem cassini_re (a : ℤ√d) (n : ℕ) :
+    (a ^ n).re * (a ^ (n + 2)).re - (a ^ (n + 1)).re ^ 2
+      = d * a.im ^ 2 * a.norm ^ n := by
+  have hinv := re_sq_sub_d_im_sq a n
+  rw [show n + 2 = (n + 1) + 1 from rfl, re_succ a (n + 1), re_succ a n, im_succ a n]
+  linear_combination (d * a.im ^ 2) * hinv
+
+/-- **Three-term Cassini/Catalan identity, `√d` coordinate.**
+`im(aⁿ)·im(aⁿ⁺²) − im(aⁿ⁺¹)² = −im(a)²·N(a)ⁿ`. -/
+theorem cassini_im (a : ℤ√d) (n : ℕ) :
+    (a ^ n).im * (a ^ (n + 2)).im - (a ^ (n + 1)).im ^ 2
+      = - a.im ^ 2 * a.norm ^ n := by
+  have hinv := re_sq_sub_d_im_sq a n
+  rw [show n + 2 = (n + 1) + 1 from rfl, im_succ a (n + 1), re_succ a n, im_succ a n]
+  linear_combination (- a.im ^ 2) * hinv
+
+/-
+## Concrete `D = 2` checks
+
+The fundamental norm-`1` unit of `ℤ[√2]` is `3 + 2√2 = ⟨3,2⟩`, with
+`re: 1, 3, 17, 99, …`, `im: 0, 2, 12, 70, …`, and `N = 1`. The Cassini constants are
+`d·im(a)² = 2·4 = 8` (real) and `−im(a)² = −4` (`√d`), independent of `n` since
+`N(a) = 1`.
+-/
+
+/-- Quadratic invariant at `D = 2`, `n = 3`: `re = 99`, `im = 70`, and
+`99² − 2·70² = 9801 − 9800 = 1 = N(⟨3,2⟩)³`. -/
+example : ((⟨3, 2⟩ : ℤ√2) ^ 3).re ^ 2 - 2 * ((⟨3, 2⟩ : ℤ√2) ^ 3).im ^ 2 = 1 := by
+  decide
+
+/-- Real three-term Cassini at `D = 2`, `n = 0`: `re₀·re₂ − re₁² = 1·17 − 3² = 8
+= 2·2²·1`. -/
+example : ((⟨3, 2⟩ : ℤ√2) ^ 0).re * ((⟨3, 2⟩ : ℤ√2) ^ 2).re
+    - ((⟨3, 2⟩ : ℤ√2) ^ 1).re ^ 2 = 8 := by decide
+
+/-- `√d` three-term Cassini at `D = 2`, `n = 1`: `im₁·im₃ − im₂² = 2·70 − 12² = −4
+= −2²·1`. -/
+example : ((⟨3, 2⟩ : ℤ√2) ^ 1).im * ((⟨3, 2⟩ : ℤ√2) ^ 3).im
+    - ((⟨3, 2⟩ : ℤ√2) ^ 2).im ^ 2 = -4 := by decide
+
+/-- Mixed Cassini at `D = 2`, `n = 2`: `re₂·im₃ − re₃·im₂ = 17·70 − 99·12 = 2 = im(a)·N³`. -/
+example : ((⟨3, 2⟩ : ℤ√2) ^ 2).re * ((⟨3, 2⟩ : ℤ√2) ^ 3).im
+    - ((⟨3, 2⟩ : ℤ√2) ^ 3).re * ((⟨3, 2⟩ : ℤ√2) ^ 2).im = 2 := by decide
+
+#check @det_companion_pow
+#check @re_sq_sub_d_im_sq
+#check @pow_isPell
+#check @cross_cassini
+#check @cassini_re
+#check @cassini_im
+
+end PellEquationOQ07OQ01OQ01

--- a/src/data/proofs/pell-equation-oq-07-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01-oq-01/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "pell-equation-oq-07-oq-01-oq-01",
+  "title": "Cassini / Catalan Identities for Pell Chains from det(Mⁿ) = (det M)ⁿ",
+  "slug": "pell-equation-oq-07-oq-01-oq-01",
+  "description": "The parent entry (pell-equation-oq-07-oq-01) supplied the companion-matrix closed form Mⁿ = ⟨⟨re(aⁿ), d·im(aⁿ)⟩, ⟨im(aⁿ), re(aⁿ)⟩⟩ for the power sequence aⁿ of a generator a = ⟨x₁,y₁⟩ ∈ ℤ[√d], with det M = N(a), and left as its first open question the Cassini/Catalan identity xₙ₋₁xₙ₊₁ − xₙ² = (const)·N(a)ⁿ derived from det(Mⁿ) = (det M)ⁿ. This entry answers that question. Because determinant is a monoid homomorphism, det(Mⁿ) = (det M)ⁿ = N(a)ⁿ (det_companion_pow). Reading det(Mⁿ) off the explicit power form gives the quadratic Pell invariant re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ (re_sq_sub_d_im_sq) — the classical Cassini identity for Pell chains, equivalently Zsqrtd.norm(aⁿ) = N(a)ⁿ recovered through the companion determinant. For a Pell generator (N(a) = 1) this says every power of a Pell solution is again a Pell solution (pow_isPell). Combining the one-step recurrence re(aⁿ⁺¹) = x₁·re(aⁿ) + d·y₁·im(aⁿ), im(aⁿ⁺¹) = x₁·im(aⁿ) + y₁·re(aⁿ) (the coordinate shadow of aⁿ⁺¹ = a·aⁿ) with the quadratic invariant yields the genuine three-term Cassini/Catalan identities: the mixed invariant re(aⁿ)·im(aⁿ⁺¹) − re(aⁿ⁺¹)·im(aⁿ) = y₁·N(a)ⁿ (cross_cassini), and the coordinate-wise re(aⁿ)·re(aⁿ⁺²) − re(aⁿ⁺¹)² = d·y₁²·N(a)ⁿ (cassini_re), im(aⁿ)·im(aⁿ⁺²) − im(aⁿ⁺¹)² = −y₁²·N(a)ⁿ (cassini_im). All of it is pure integer algebra in ℤ[√d] and Matrix (Fin 2) (Fin 2) ℤ — no passage to ℝ or √d is needed. Concrete D = 2 checks against (3+2√2)ⁿ (re: 1,3,17,99; im: 0,2,12,70; N = 1) confirm the constants d·y₁² = 8 and −y₁² = −4.",
+  "leanFile": {
+    "path": "Proofs/PellEquationOQ07OQ01OQ01.lean",
+    "lineCount": 183,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "sorryCount": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius (Cassini/Catalan identities via companion-determinant multiplicativity in ℤ[√d]); Cassini / Catalan (classical Fibonacci/Lucas identity theory)",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ07OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "pell-equation",
+      "quadratic-integers",
+      "zsqrtd",
+      "cassini-identity",
+      "catalan-identity",
+      "companion-matrix",
+      "determinant",
+      "recurrence",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-01",
+    "lineCount": 183,
+    "originalContributions": [
+      "det_companion_pow: det(Mⁿ) = N(a)ⁿ, the determinant identity obtained from Matrix.det_pow (det is multiplicative) and the parent's companion_det (det M = N(a)) — the multiplicative content of the companion-matrix closed form",
+      "re_sq_sub_d_im_sq: the quadratic Pell invariant re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ, obtained by evaluating det(Mⁿ) two ways — off the explicit companion power form (Matrix.det_fin_two_of gives re(aⁿ)² − d·im(aⁿ)²) and via det(Mⁿ) = N(a)ⁿ — the Cassini identity for Pell chains, i.e. Zsqrtd.norm(aⁿ) = N(a)ⁿ recovered through the companion determinant",
+      "pow_isPell: powers of a Pell solution are Pell solutions — if N(a) = 1 then re(aⁿ)² − d·im(aⁿ)² = 1 for all n, exhibiting the norm-1 locus as closed under powers",
+      "cross_cassini: the mixed two-coordinate Cassini invariant re(aⁿ)·im(aⁿ⁺¹) − re(aⁿ⁺¹)·im(aⁿ) = y₁·N(a)ⁿ, from the one-step coordinate recurrence and the quadratic invariant (linear_combination)",
+      "cassini_re / cassini_im: the three-term Cassini/Catalan identities re(aⁿ)·re(aⁿ⁺²) − re(aⁿ⁺¹)² = d·y₁²·N(a)ⁿ and im(aⁿ)·im(aⁿ⁺²) − im(aⁿ⁺¹)² = −y₁²·N(a)ⁿ, the Catalan-type invariants c·N(a)ⁿ for the two coordinate sequences with the constant fixed by the seed y₁ = im(a) — derived by fully expanding the two-step recurrence and reducing to the quadratic invariant"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide (the four `decide` uses are kernel `decide` on concrete ℤ[√2] computations, not `native_decide`, so no Lean.ofReduceBool). Everything is integer algebra in ℤ[√d] and 2×2 integer matrices — no passage to ℝ or Real.sqrt. Uses Mathlib's Matrix.det_pow, Matrix.det_fin_two_of, Zsqrtd re_mul/im_mul/norm, the parent's companion/companion_pow/companion_det, and standard tactics (rw, ring, linear_combination, decide).",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pell-equation-oq-07-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the companion-matrix closed form Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)] with det M = N(a), and lists as its first open question the Cassini/Catalan identity derived from det(Mⁿ) = (det M)ⁿ = N(a)ⁿ. This entry proves exactly that: det_companion_pow gives the determinant identity, re_sq_sub_d_im_sq the quadratic Pell invariant, and cassini_re/cassini_im the three-term Cassini/Catalan identities."
+    },
+    {
+      "targetId": "pell-equation-oq-07",
+      "relationship": "related",
+      "description": "The grandparent derives the second-order recurrence uₙ₊₂ = 2x₁·uₙ₊₁ − N(a)·uₙ that the coordinate sequences obey. The three-term Cassini identities here are the Catalan-type invariants uₙ₋₁uₙ₊₁ − uₙ² = c·N(a)ⁿ⁻¹ (re-indexed) of exactly that recurrence, with c fixed by the seed."
+    },
+    {
+      "targetId": "pell-equation",
+      "relationship": "related",
+      "description": "The root entry classifies Pell solutions as powers of a fundamental unit. pow_isPell makes the closure explicit: the quadratic invariant re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ specializes at N(a) = 1 to show every power of a Pell solution is again a Pell solution."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Cassini's identity Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ (1680) and its Catalan generalization are the archetypal 'quadratic invariants' of a second-order linear recurrence, and are most cleanly proved by the matrix determinant identity det(Qⁿ) = (det Q)ⁿ, where Q = [[1,1],[1,0]] is the Fibonacci companion matrix. For the Pell coordinate sequences xₙ = re(aⁿ), yₙ = im(aⁿ) of a generator a = x₁ + y₁√d, the companion matrix is M = [[x₁, d·y₁],[y₁, x₁]] with determinant N(a) = x₁² − d·y₁², so det(Mⁿ) = N(a)ⁿ gives at once the norm identity re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ and, through the recurrence, the three-term Catalan invariants xₙ₋₁xₙ₊₁ − xₙ² = d·y₁²·N(a)ⁿ⁻¹ and yₙ₋₁yₙ₊₁ − yₙ² = −y₁²·N(a)ⁿ⁻¹. This entry formalizes the whole package inside Mathlib's quadratic-integer ring ℤ[√d] for arbitrary d, staying entirely within integer arithmetic.",
+    "problemStatement": "The parent entry proved the companion-matrix power form but left as an open question the Cassini/Catalan identity xₙ₋₁xₙ₊₁ − xₙ² = (constant)·N(a)ⁿ, to be derived directly from det(Mⁿ) = (det M)ⁿ = N(a)ⁿ. Can one establish the determinant identity from the explicit companion power, read off the quadratic Pell invariant, and thence the three-term Cassini/Catalan invariants of both coordinate sequences — all within integer arithmetic?",
+    "proofStrategy": "Work in ℤ√d = Zsqrtd d and Matrix (Fin 2) (Fin 2) ℤ. (1) det_companion_pow: apply Matrix.det_pow and the parent's companion_det to get det(Mⁿ) = N(a)ⁿ. (2) re_sq_sub_d_im_sq: rewrite (companion a)ⁿ by the parent's companion_pow, expand the 2×2 determinant with Matrix.det_fin_two_of to obtain re(aⁿ)² − d·im(aⁿ)², and equate with det(Mⁿ) = N(a)ⁿ via linear_combination. (3) pow_isPell: specialize at N(a) = 1. (4) Establish the one-step coordinate recurrences re_succ, im_succ from pow_succ + Zsqrtd.re_mul/im_mul. (5) cross_cassini: substitute the recurrences into re(aⁿ)·im(aⁿ⁺¹) − re(aⁿ⁺¹)·im(aⁿ) and reduce to a.im·(quadratic invariant) by linear_combination a.im · hinv. (6) cassini_re/cassini_im: expand the two-step recurrence fully to level n and finish with linear_combination (±·)·hinv against the quadratic invariant. (7) Concrete D = 2 numeric checks for a = ⟨3,2⟩ ∈ ℤ[√2] by kernel decide.",
+    "keyInsights": [
+      "Determinant multiplicativity det(Mⁿ) = (det M)ⁿ is the whole engine: the parent already computed det M = N(a), so Matrix.det_pow instantly yields det(Mⁿ) = N(a)ⁿ. Reading this determinant off the explicit companion power form Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)] gives re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ with no computation beyond a 2×2 determinant.",
+      "The quadratic invariant re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ is precisely the Cassini identity for Pell chains and coincides with Zsqrtd.norm(aⁿ) = N(a)ⁿ, but derived here through the companion determinant rather than norm multiplicativity — the matrix route the parent asked for.",
+      "At N(a) = 1 the invariant reads re(aⁿ)² − d·im(aⁿ)² = 1: every power of a Pell solution is again a Pell solution, the closure property underlying the multiplicative classification of Pell solutions.",
+      "The three-term Cassini/Catalan identities need no new determinant: substituting the one-step recurrences re(aⁿ⁺¹) = x₁·re(aⁿ) + d·y₁·im(aⁿ), im(aⁿ⁺¹) = x₁·im(aⁿ) + y₁·re(aⁿ) collapses the cross- and coordinate-wise Cassini expressions onto (constant)·(re(aⁿ)² − d·im(aⁿ)²), so they follow from the quadratic invariant by linear_combination alone.",
+      "Everything is integer arithmetic in ℤ[√d]: unlike the parent's Binet forms (which pass through Real.sqrt), the determinant/Cassini identities never leave ℤ, so the file is axiom-free with only kernel decide on the concrete D = 2 examples."
+    ]
+  },
+  "sections": [
+    {
+      "id": "det-identity",
+      "title": "The Determinant Identity det(Mⁿ) = N(a)ⁿ",
+      "startLine": 62,
+      "endLine": 77,
+      "summary": "Determinant is a monoid homomorphism, so det(Mⁿ) = (det M)ⁿ; the parent's companion_det gives det M = N(a). det_companion_pow assembles these into det(Mⁿ) = N(a)ⁿ.",
+      "mathContext": "$\\det(M^n) = (\\det M)^n = N(a)^n.$"
+    },
+    {
+      "id": "quadratic-invariant",
+      "title": "The Quadratic Pell Invariant (Cassini for Pell Chains)",
+      "startLine": 79,
+      "endLine": 103,
+      "summary": "Reading det(Mⁿ) off the explicit companion power form gives re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ (re_sq_sub_d_im_sq). Specializing to N(a) = 1 shows powers of a Pell solution are Pell solutions (pow_isPell).",
+      "mathContext": "$\\mathrm{re}(a^n)^2 - d\\,\\mathrm{im}(a^n)^2 = N(a)^n$; at $N(a)=1$, $\\mathrm{re}(a^n)^2 - d\\,\\mathrm{im}(a^n)^2 = 1.$"
+    },
+    {
+      "id": "three-term-cassini",
+      "title": "The Three-Term Cassini / Catalan Identities",
+      "startLine": 105,
+      "endLine": 162,
+      "summary": "The one-step recurrences re_succ, im_succ (from pow_succ + re_mul/im_mul) combine with the quadratic invariant to give the mixed Cassini invariant cross_cassini (re(aⁿ)·im(aⁿ⁺¹) − re(aⁿ⁺¹)·im(aⁿ) = y₁·N(a)ⁿ) and the coordinate-wise three-term identities cassini_re (= d·y₁²·N(a)ⁿ) and cassini_im (= −y₁²·N(a)ⁿ).",
+      "mathContext": "$\\mathrm{re}(a^n)\\mathrm{re}(a^{n+2}) - \\mathrm{re}(a^{n+1})^2 = d\\,y_1^2 N(a)^n,\\quad \\mathrm{im}(a^n)\\mathrm{im}(a^{n+2}) - \\mathrm{im}(a^{n+1})^2 = -y_1^2 N(a)^n.$"
+    },
+    {
+      "id": "d2-checks",
+      "title": "Concrete D = 2 Checks against (3+2√2)ⁿ",
+      "startLine": 164,
+      "endLine": 183,
+      "summary": "Numeric verification for the fundamental unit 3 + 2√2 = ⟨3,2⟩ of ℤ[√2] (re: 1,3,17,99; im: 0,2,12,70; N = 1): the quadratic invariant 99² − 2·70² = 1, the real Cassini 1·17 − 3² = 8 = 2·2², the √d Cassini 2·70 − 12² = −4 = −2², and the mixed Cassini 17·70 − 99·12 = 2 = im(a)·N³, all by kernel decide.",
+      "mathContext": "$3+2\\sqrt2$: $99^2-2\\cdot70^2=1$, $1\\cdot17-3^2=8$, $2\\cdot70-12^2=-4$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 183-line file (0 sorries, 0 axioms, no native_decide) answers the parent entry's first open question by deriving the Cassini/Catalan identities of the Pell coordinate sequences from det(Mⁿ) = (det M)ⁿ = N(a)ⁿ. The determinant identity (det_companion_pow) plus the explicit companion power form yields the quadratic Pell invariant re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ (re_sq_sub_d_im_sq), which at N(a) = 1 shows powers of Pell solutions are Pell solutions (pow_isPell). Combined with the one-step coordinate recurrences it gives the mixed invariant cross_cassini and the three-term Cassini/Catalan identities cassini_re = d·y₁²·N(a)ⁿ, cassini_im = −y₁²·N(a)ⁿ. Everything stays inside integer arithmetic in ℤ[√d].",
+    "implications": "The Cassini/Catalan identities complete the multiplicative picture of the companion-matrix closed form: the determinant identity, the quadratic norm invariant, and the three-term Catalan invariants are three readings of det(Mⁿ) = N(a)ⁿ. The technique — take a determinant identity of a companion power, read off a quadratic invariant, and push a linear recurrence through it — is the standard route to Cassini/Catalan identities for any Lucas-type sequence, and here shows the Pell power sequence never leaves the norm-N(a)ⁿ level set.",
+    "openQuestions": [
+      "Prove the general Catalan identity xₙ₋ᵣxₙ₊ᵣ − xₙ² = (function of r)·N(a)ⁿ⁻ʳ by the same determinant route applied to Mʳ, recovering the r = 1 Cassini identities as a special case.",
+      "Derive the Vajda / d'Ocagne mixed identities relating re(aᵐ), im(aⁿ) at different indices from det(Mᵐ · adj(Mⁿ)) or det(Mᵐ⁻ⁿ), extending cross_cassini to arbitrary index gaps.",
+      "Show the Cassini constants d·y₁² and −y₁² determine the discriminant of the coordinate sequence, and relate them to the regulator / fundamental-unit data of the real quadratic field ℚ(√d)."
+    ]
+  },
+  "references": [
+    {
+      "authors": "G. D. Cassini",
+      "title": "Une nouvelle progression des nombres (Cassini's identity Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ)",
+      "year": 1680,
+      "venue": "Académie Royale des Sciences, Paris",
+      "note": "The archetypal quadratic invariant of a second-order recurrence, generalized here to Pell chains."
+    },
+    {
+      "authors": "E. C. Catalan",
+      "title": "Notes sur la théorie des fractions continues et sur certaines séries (Catalan's identity)",
+      "year": 1879,
+      "venue": "Mém. Acad. R. Sci. Belg.",
+      "note": "The r-parameter generalization uₙ₋ᵣuₙ₊ᵣ − uₙ² of Cassini's identity."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Matrix.det_pow, Matrix.det_fin_two_of and the Zsqrtd (ℤ[√d]) API underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **pell-equation-oq-07-oq-01-oq-01** answering the parent (`pell-equation-oq-07-oq-01`) open question **verbatim**: derive the Cassini/Catalan identity `xₙ₋₁xₙ₊₁ − xₙ² = const·N(a)ⁿ` directly from the companion-matrix determinant `det(Mⁿ) = (det M)ⁿ = N(a)ⁿ`.

The parent supplied the companion power form `Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)]` with `det M = N(a)` for a generator `a = ⟨x₁,y₁⟩ ∈ ℤ[√d]`. Determinant multiplicativity does the rest.

## Results (8 theorems, 0 def, 183 lines)

- `det_companion_pow`: `det(Mⁿ) = N(a)ⁿ` — `Matrix.det_pow` + parent `companion_det`.
- `re_sq_sub_d_im_sq`: the **quadratic Pell invariant** `re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ`, read off `det(Mⁿ)` two ways — the Cassini identity for Pell chains (= `Zsqrtd.norm(aⁿ) = N(a)ⁿ` via the companion determinant).
- `pow_isPell`: powers of a Pell solution are Pell solutions (`N(a)=1 ⟹ re(aⁿ)² − d·im(aⁿ)² = 1`).
- `cross_cassini`: mixed invariant `re(aⁿ)·im(aⁿ⁺¹) − re(aⁿ⁺¹)·im(aⁿ) = y₁·N(a)ⁿ`.
- `cassini_re` / `cassini_im`: the three-term Cassini/Catalan identities `= d·y₁²·N(a)ⁿ` and `= −y₁²·N(a)ⁿ`.

All **pure integer algebra** in `ℤ[√d]` and `Matrix (Fin 2) (Fin 2) ℤ` — no passage to `ℝ`/`√d`. Concrete `D=2` checks against `(3+2√2)ⁿ` (`re: 1,3,17,99`, `im: 0,2,12,70`, `N=1`).

## Verification

- Build-verified via `lake env lean` (exit 0, reused repo Mathlib cache).
- **0 axioms**, 0 sorries, no `native_decide` (the four `decide` uses are kernel decide on concrete ℤ[√2] values).

## Files
- `proofs/Proofs/PellEquationOQ07OQ01OQ01.lean` (new)
- `src/data/proofs/pell-equation-oq-07-oq-01-oq-01/meta.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)