### PR TITLE
research(cauchy-schwarz-oq-07-oq-02): full complex polarization identity — roots-of-unity form + orthogonality criterion [VERIFIED, 0-axiom, 7thm/149L]

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ07OQ02.lean
+++ b/proofs/Proofs/CauchySchwarzOQ07OQ02.lean
@@ -1,0 +1,149 @@
+/-
+  The full complex polarization identity (cauchy-schwarz-oq-07-oq-02).
+
+  Open question (from cauchy-schwarz-oq-07, "The Parallelogram Law").  The parent
+  entry recovers the *real* inner product from the norm via the diagonals of a
+  parallelogram,
+      ⟪x, y⟫_ℝ = (‖x + y‖² − ‖x − y‖²) / 4,
+  and asks to "extend the polarization corollary to the full complex form including
+  the imaginary part".  Over ℂ the real diagonals alone no longer determine the inner
+  product: one also needs the two *rotated* diagonals ‖x ± i·y‖, which read off the
+  imaginary part.
+
+  This file packages the full complex polarization identity in several equivalent
+  shapes over an arbitrary complex inner-product space `G`:
+
+  * the **complex form**
+      ⟪x, y⟫ = (‖x+y‖² − ‖x−y‖² + (‖x − i•y‖² − ‖x + i•y‖²)·i) / 4,
+    the ℂ specialization of Mathlib's `inner_eq_sum_norm_sq_div_four`;
+  * the **split form**
+      ⟪x, y⟫ = (‖x+y‖² − ‖x−y‖²)/4  +  i·(‖x − i•y‖² − ‖x + i•y‖²)/4,
+    real part = the parent's diagonal formula, imaginary part = the rotated diagonals;
+  * the **roots-of-unity form**
+      ⟪x, y⟫ = (1/4) · Σ_{k<4} (−i)^k · ‖x + i^k • y‖²,
+    a single cyclic sum over the four fourth-roots of unity 1, i, −1, −i — the discrete
+    Fourier / character-sum packaging that makes the appearance of `i` structural rather
+    than ad hoc;
+  * the separated **real and imaginary parts** in the parent's squared (`^2`) style.
+
+  As corollaries we record that the inner product is completely determined by the four
+  diagonal norms ‖x±y‖, ‖x±i•y‖, and the resulting **orthogonality-from-norms** criterion
+      ⟪x, y⟫ = 0  ↔  ‖x+y‖ = ‖x−y‖ ∧ ‖x + i•y‖ = ‖x − i•y‖,
+  the complex refinement of the fact that in a real space perpendicularity is the single
+  equal-diagonals condition ‖x+y‖ = ‖x−y‖.
+
+  Everything is derived from Mathlib's `inner_eq_sum_norm_sq_div_four`; the value added
+  over that lemma is the cyclic roots-of-unity reformulation, the clean split/`^2`
+  packaging matching the parent entry, and the orthogonality criterion.
+
+  Sorry-free and axiom-free.
+-/
+import Mathlib
+
+open scoped InnerProductSpace
+
+namespace CauchySchwarzOQ07OQ02
+
+variable {G : Type*} [NormedAddCommGroup G] [InnerProductSpace ℂ G]
+
+/-- **The full complex polarization identity, complex form.**  The ℂ specialization of
+Mathlib's `inner_eq_sum_norm_sq_div_four`, with the imaginary unit written as
+`Complex.I`:
+`⟪x, y⟫ = (‖x+y‖² − ‖x−y‖² + (‖x − i•y‖² − ‖x + i•y‖²)·i) / 4`. -/
+theorem inner_eq_polarization_complex (x y : G) :
+    ⟪x, y⟫_ℂ =
+      ((‖x + y‖ : ℂ) ^ 2 - (‖x - y‖ : ℂ) ^ 2
+        + ((‖x - Complex.I • y‖ : ℂ) ^ 2 - (‖x + Complex.I • y‖ : ℂ) ^ 2) * Complex.I) / 4 := by
+  rw [inner_eq_sum_norm_sq_div_four (𝕜 := ℂ), show (RCLike.I : ℂ) = Complex.I from rfl]
+  norm_cast
+
+/-- **The full complex polarization identity, split form.**  The inner product is
+recovered from the norm as its real part (ordinary diagonals) plus `i` times its
+imaginary part (rotated diagonals):
+`⟪x, y⟫ = (‖x+y‖² − ‖x−y‖²)/4 + i·(‖x − i•y‖² − ‖x + i•y‖²)/4`. -/
+theorem inner_eq_polarization_split (x y : G) :
+    ⟪x, y⟫_ℂ =
+      (((‖x + y‖ ^ 2 - ‖x - y‖ ^ 2) / 4 : ℝ) : ℂ)
+        + Complex.I * (((‖x - Complex.I • y‖ ^ 2 - ‖x + Complex.I • y‖ ^ 2) / 4 : ℝ) : ℂ) := by
+  rw [inner_eq_polarization_complex]; push_cast; ring
+
+/-- **Real part of the complex inner product**, in the parent entry's squared form:
+`re ⟪x, y⟫ = (‖x + y‖² − ‖x − y‖²) / 4`.  Identical to the real polarization identity
+of the parent — the real part sees only the two ordinary diagonals. -/
+theorem re_inner_eq_diag_sq_div_four (x y : G) :
+    (⟪x, y⟫_ℂ).re = (‖x + y‖ ^ 2 - ‖x - y‖ ^ 2) / 4 := by
+  rw [inner_eq_polarization_split]
+  simp only [Complex.add_re, Complex.mul_re, Complex.I_re, Complex.I_im,
+    Complex.ofReal_re, Complex.ofReal_im]
+  ring
+
+/-- **Imaginary part of the complex inner product**, in squared form:
+`im ⟪x, y⟫ = (‖x − i•y‖² − ‖x + i•y‖²) / 4`.  The imaginary part is read off from the
+two *rotated* diagonals ‖x ± i•y‖ — the genuinely complex content of polarization. -/
+theorem im_inner_eq_rot_diag_sq_div_four (x y : G) :
+    (⟪x, y⟫_ℂ).im = (‖x - Complex.I • y‖ ^ 2 - ‖x + Complex.I • y‖ ^ 2) / 4 := by
+  rw [inner_eq_polarization_split]
+  simp only [Complex.add_im, Complex.mul_im, Complex.I_re, Complex.I_im,
+    Complex.ofReal_re, Complex.ofReal_im]
+  ring
+
+/-- **The full complex polarization identity, roots-of-unity form.**  The inner product
+is a single cyclic sum over the four fourth-roots of unity `1, i, −1, −i`:
+`⟪x, y⟫ = (1/4) · Σ_{k<4} (−i)^k · ‖x + i^k • y‖²`.
+Expanding the sum recovers the split form: the coefficients `(−i)^k = 1, −i, −1, i`
+weight the four diagonals `‖x+y‖, ‖x+i•y‖, ‖x−y‖, ‖x−i•y‖`.  This is the discrete
+Fourier / character-sum packaging of polarization — the shape that generalizes to the
+recovery of a sesquilinear form from its associated quadratic form. -/
+theorem inner_eq_sum_fourth_roots (x y : G) :
+    ⟪x, y⟫_ℂ =
+      (∑ k ∈ Finset.range 4,
+        (-Complex.I) ^ k * ((‖x + Complex.I ^ k • y‖ : ℂ) ^ 2)) / 4 := by
+  have hI2 : (Complex.I) ^ 2 = -1 := Complex.I_sq
+  have hI3 : (Complex.I) ^ 3 = -Complex.I := by rw [pow_succ, hI2]; ring
+  have hnI2 : (-Complex.I) ^ 2 = -1 := by
+    rw [show (-Complex.I) ^ 2 = Complex.I ^ 2 by ring, hI2]
+  have hnI3 : (-Complex.I) ^ 3 = Complex.I := by
+    rw [show (-Complex.I) ^ 3 = -(Complex.I ^ 3) by ring, hI3]; ring
+  have hI2s : Complex.I ^ 2 • y = -y := by rw [hI2, neg_one_smul]
+  have hI3s : Complex.I ^ 3 • y = -(Complex.I • y) := by rw [hI3, neg_smul]
+  rw [Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_succ,
+    Finset.sum_range_succ, Finset.sum_range_zero]
+  simp only [pow_zero, pow_one, one_smul, one_mul, zero_add]
+  rw [hI2s, hI3s, ← sub_eq_add_neg x y, ← sub_eq_add_neg x (Complex.I • y),
+    hnI2, hnI3, inner_eq_polarization_complex]
+  ring
+
+/-- **The inner product is determined by the norm.**  If two pairs of vectors realize the
+same four diagonal lengths `‖x+y‖, ‖x−y‖, ‖x + i•y‖, ‖x − i•y‖`, their inner products
+coincide.  This is the precise sense in which polarization *recovers* the inner product
+from the norm alone. -/
+theorem inner_eq_of_diag_norms_eq {x y x' y' : G}
+    (h₁ : ‖x + y‖ = ‖x' + y'‖) (h₂ : ‖x - y‖ = ‖x' - y'‖)
+    (h₃ : ‖x + Complex.I • y‖ = ‖x' + Complex.I • y'‖)
+    (h₄ : ‖x - Complex.I • y‖ = ‖x' - Complex.I • y'‖) :
+    ⟪x, y⟫_ℂ = ⟪x', y'⟫_ℂ := by
+  rw [inner_eq_polarization_split x y, inner_eq_polarization_split x' y',
+    h₁, h₂, h₃, h₄]
+
+/-- **Orthogonality from norms** (complex form).  Two vectors are orthogonal exactly when
+both the ordinary diagonals *and* the rotated diagonals are equal:
+`⟪x, y⟫ = 0 ↔ ‖x+y‖ = ‖x−y‖ ∧ ‖x + i•y‖ = ‖x − i•y‖`.
+Over a real space perpendicularity is the single equal-diagonals condition
+`‖x+y‖ = ‖x−y‖`; the complex case needs the rotated diagonals as well, to kill the
+imaginary part. -/
+theorem inner_eq_zero_iff_diags (x y : G) :
+    ⟪x, y⟫_ℂ = 0 ↔ ‖x + y‖ = ‖x - y‖ ∧ ‖x + Complex.I • y‖ = ‖x - Complex.I • y‖ := by
+  have hsq : ∀ a b : ℝ, 0 ≤ a → 0 ≤ b → (a ^ 2 = b ^ 2 ↔ a = b) := by
+    intro a b ha hb
+    constructor
+    · intro h; nlinarith [sq_nonneg (a - b), sq_nonneg (a + b)]
+    · intro h; rw [h]
+  rw [Complex.ext_iff, Complex.zero_re, Complex.zero_im,
+    re_inner_eq_diag_sq_div_four, im_inner_eq_rot_diag_sq_div_four,
+    div_eq_zero_iff, div_eq_zero_iff]
+  simp only [sub_eq_zero, OfNat.ofNat_ne_zero, or_false]
+  rw [hsq _ _ (norm_nonneg _) (norm_nonneg _), hsq _ _ (norm_nonneg _) (norm_nonneg _)]
+  exact and_congr_right' ⟨Eq.symm, Eq.symm⟩
+
+end CauchySchwarzOQ07OQ02
+

--- a/src/data/proofs/cauchy-schwarz-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-07-oq-02/annotations.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "csoq0702-header",
+    "proofId": "cauchy-schwarz-oq-07-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Module Header: from Real to Complex Polarization",
+    "content": "The parent entry (cauchy-schwarz-oq-07) recovered the *real* inner product from the norm by the polarization identity $\\langle x,y\\rangle_\\mathbb{R} = (\\|x+y\\|^2-\\|x-y\\|^2)/4$ — the two diagonals of the parallelogram spanned by $x,y$. Over $\\mathbb{C}$ those diagonals only recover the real part of $\\langle x,y\\rangle$. This file answers the second open question of the parent: recover the *full* complex inner product, real and imaginary parts, by also probing the two rotated diagonals $\\|x \\pm i\\!\\cdot\\! y\\|$. The four terms combine with the fourth-root-of-unity weights $1,-i,-1,i$.",
+    "mathContext": "Ambient space: `[NormedAddCommGroup G] [InnerProductSpace ℂ G]`. Goal: express $\\langle x,y\\rangle_\\mathbb{C}$ as a function of $\\|x\\pm y\\|$ and $\\|x\\pm i y\\|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["polarization identity", "parallelogram law", "complex inner product", "rotated diagonals", "fourth-roots of unity"],
+    "prerequisites": ["complex inner-product spaces", "the real polarization identity (parent entry)"]
+  },
+  {
+    "id": "csoq0702-polarization-forms",
+    "proofId": "cauchy-schwarz-oq-07-oq-02",
+    "range": {
+      "startLine": 49,
+      "endLine": 68
+    },
+    "type": "theorem",
+    "title": "The Complex Polarization Identity: Complex and Split Forms",
+    "content": "`inner_eq_polarization_complex` specializes Mathlib's `inner_eq_sum_norm_sq_div_four` to $\\mathbb{C}$, writing the abstract `RCLike.I` as `Complex.I` (equal by `rfl`): $\\langle x,y\\rangle = \\tfrac14(\\|x+y\\|^2-\\|x-y\\|^2+(\\|x-iy\\|^2-\\|x+iy\\|^2)i)$. `inner_eq_polarization_split` regroups this into the real/imaginary split form, coercing each real quotient into $\\mathbb{C}$ and closing by `push_cast`/`ring`. The real summand is exactly the parent's real polarization formula; the imaginary summand carries the rotated-diagonal contribution.",
+    "mathContext": "$\\langle x,y\\rangle = \\tfrac14(\\|x+y\\|^2-\\|x-y\\|^2) + \\tfrac{i}{4}(\\|x-iy\\|^2-\\|x+iy\\|^2).$",
+    "significance": "critical",
+    "relatedConcepts": ["inner_eq_sum_norm_sq_div_four", "Complex.I", "polarization identity", "push_cast"],
+    "prerequisites": ["InnerProductSpace ℂ G", "Mathlib's complex polarization identity"]
+  },
+  {
+    "id": "csoq0702-re-im-parts",
+    "proofId": "cauchy-schwarz-oq-07-oq-02",
+    "range": {
+      "startLine": 70,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "Separated Real and Imaginary Parts",
+    "content": "`re_inner_eq_diag_sq_div_four` shows the real part sees only the ordinary diagonals: $\\operatorname{re}\\langle x,y\\rangle = (\\|x+y\\|^2-\\|x-y\\|^2)/4$ — verbatim the parent's real polarization corollary. `im_inner_eq_rot_diag_sq_div_four` shows the imaginary part needs the rotated diagonals: $\\operatorname{im}\\langle x,y\\rangle = (\\|x-iy\\|^2-\\|x+iy\\|^2)/4$. Both follow from the split form by extracting the appropriate component, with `Complex.I_re/I_im/ofReal_re/ofReal_im` collapsing the imaginary unit and the real coercions.",
+    "mathContext": "$\\operatorname{re}\\langle x,y\\rangle = \\tfrac14(\\|x+y\\|^2-\\|x-y\\|^2),\\quad \\operatorname{im}\\langle x,y\\rangle = \\tfrac14(\\|x-iy\\|^2-\\|x+iy\\|^2).$",
+    "significance": "key",
+    "relatedConcepts": ["Complex.re", "Complex.im", "ordinary vs rotated diagonals", "polarization"],
+    "prerequisites": ["the split form above", "real and imaginary parts of complex numbers"]
+  },
+  {
+    "id": "csoq0702-roots-of-unity",
+    "proofId": "cauchy-schwarz-oq-07-oq-02",
+    "range": {
+      "startLine": 90,
+      "endLine": 114
+    },
+    "type": "theorem",
+    "title": "The Roots-of-Unity Form",
+    "content": "`inner_eq_sum_fourth_roots` is the headline reformulation: $\\langle x,y\\rangle = \\tfrac14\\sum_{k=0}^{3}(-i)^k\\|x+i^k y\\|^2$, a single cyclic sum over the four fourth-roots of unity. The proof expands the range-4 sum with `Finset.sum_range_succ`, reduces the coefficients $(-i)^k = 1,-i,-1,i$ and the shifts $i^k\\!\\cdot\\!y = y,\\,iy,\\,-y,\\,-iy$ (using $i^2=-1$, $i^3=-i$), rewrites the resulting $\\pm y$ and $\\pm iy$ arguments as ordinary/rotated diagonals, and matches the complex-form identity by `ring`. The weights $1,-i,-1,i$ are the characters of $\\mathbb{Z}/4$ acting by multiplication by $i$ — the discrete-Fourier packaging of polarization, which is not present in Mathlib.",
+    "mathContext": "$\\langle x,y\\rangle = \\tfrac14\\sum_{k=0}^{3}(-i)^k\\,\\|x + i^k y\\|^2.$",
+    "significance": "critical",
+    "relatedConcepts": ["fourth-roots of unity", "discrete Fourier transform", "Finset.sum_range_succ", "Complex.I_sq", "character sum"],
+    "prerequisites": ["the complex-form identity", "arithmetic of i (i²=−1, i³=−i)"]
+  },
+  {
+    "id": "csoq0702-corollaries",
+    "proofId": "cauchy-schwarz-oq-07-oq-02",
+    "range": {
+      "startLine": 116,
+      "endLine": 146
+    },
+    "type": "theorem",
+    "title": "Determination by Norms and Complex Orthogonality",
+    "content": "`inner_eq_of_diag_norms_eq`: if two pairs of vectors realize the same four diagonal lengths $\\|x+y\\|,\\|x-y\\|,\\|x+iy\\|,\\|x-iy\\|$, their inner products coincide — polarization literally recovers $\\langle\\cdot,\\cdot\\rangle$ from $\\|\\cdot\\|$, proved by rewriting the split form under the four hypotheses. `inner_eq_zero_iff_diags`: the complex orthogonality-from-norms criterion $\\langle x,y\\rangle = 0 \\iff \\|x+y\\| = \\|x-y\\| \\wedge \\|x+iy\\| = \\|x-iy\\|$. Over $\\mathbb{R}$ perpendicularity is the single equal-diagonals condition $\\|x+y\\|=\\|x-y\\|$; the complex case needs the rotated diagonals to kill the imaginary part, upgrading $\\|a\\|^2=\\|b\\|^2$ to $\\|a\\|=\\|b\\|$ via nonnegativity of norms.",
+    "mathContext": "$\\langle x,y\\rangle = 0 \\iff \\|x+y\\| = \\|x-y\\| \\ \\wedge\\ \\|x+iy\\| = \\|x-iy\\|.$",
+    "significance": "key",
+    "relatedConcepts": ["norm determines inner product", "orthogonality", "complex vs real perpendicularity", "norm_nonneg"],
+    "prerequisites": ["the split form", "the separated re/im parts"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-07-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-07-oq-02/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "cauchy-schwarz-oq-07-oq-02",
+  "title": "The Full Complex Polarization Identity",
+  "slug": "cauchy-schwarz-oq-07-oq-02",
+  "description": "The second open question of the parallelogram-law entry (cauchy-schwarz-oq-07): extend the real polarization corollary ⟪x,y⟫_ℝ = (‖x+y‖²−‖x−y‖²)/4 to the full complex form recovering both real and imaginary parts of ⟪x,y⟫_ℂ from the norm. Packages the complex polarization identity in four equivalent shapes — the complex form, the real/imaginary split, the separated re/im parts, and a single cyclic sum over the four fourth-roots of unity ⟪x,y⟫ = ¼∑_{k<4}(−i)^k‖x+i^k·y‖² — and derives that the inner product is completely determined by the four diagonal norms, together with a complex orthogonality-from-norms criterion.",
+  "meta": {
+    "author": "Classical (polarization identity); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Polarization_identity",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "inner-product-spaces",
+      "cauchy-schwarz",
+      "parallelogram-law",
+      "polarization-identity",
+      "complex-analysis",
+      "roots-of-unity",
+      "orthogonality",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ07OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "inner_eq_sum_norm_sq_div_four",
+        "description": "The complex polarization identity in Mathlib: ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖² + (‖x−i·y‖² − ‖x+i·y‖²)·i)/4 over an RCLike inner-product space",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "re_inner_eq_norm_add_mul_self_sub_norm_sub_mul_self_div_four",
+        "description": "Real part of the inner product from the ordinary diagonals: re⟪x,y⟫ = (‖x+y‖·‖x+y‖ − ‖x−y‖·‖x−y‖)/4",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "im_inner_eq_norm_sub_i_smul_mul_self_sub_norm_add_i_smul_mul_self_div_four",
+        "description": "Imaginary part of the inner product from the rotated diagonals ‖x ± i·y‖",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "Complex.I_sq",
+        "description": "i² = −1, the fourth-root-of-unity arithmetic underlying the cyclic-sum form",
+        "module": "Mathlib.Data.Complex.Basic"
+      }
+    ],
+    "originalContributions": [
+      "inner_eq_polarization_complex: the ℂ specialization of Mathlib's inner_eq_sum_norm_sq_div_four with the imaginary unit written as Complex.I, the clean complex-form statement of full polarization",
+      "inner_eq_polarization_split: the real/imaginary split form ⟪x,y⟫ = (‖x+y‖²−‖x−y‖²)/4 + i·(‖x−i·y‖²−‖x+i·y‖²)/4, matching the parent's squared packaging with the real part reproducing the parent's real polarization formula verbatim",
+      "re_inner_eq_diag_sq_div_four / im_inner_eq_rot_diag_sq_div_four: the separated real and imaginary parts in the parent's ^2 style, exhibiting that the real part uses only the ordinary diagonals ‖x±y‖ while the imaginary part needs the rotated diagonals ‖x±i·y‖",
+      "inner_eq_sum_fourth_roots: the headline reformulation as a single cyclic sum over the four fourth-roots of unity, ⟪x,y⟫ = ¼∑_{k<4}(−i)^k‖x+i^k·y‖², proved by expanding the range-4 sum, reducing the coefficients (−i)^k = 1,−i,−1,i and the shifts i^k·y = y,i·y,−y,−i·y, and matching Mathlib's polarization identity — the discrete-Fourier / character-sum packaging not present in Mathlib",
+      "inner_eq_of_diag_norms_eq: the inner product is completely determined by the four diagonal norms ‖x±y‖, ‖x±i·y‖ — the precise sense in which polarization recovers ⟪·,·⟫ from ‖·‖ alone",
+      "inner_eq_zero_iff_diags: a complex orthogonality-from-norms criterion, ⟪x,y⟫ = 0 ↔ ‖x+y‖ = ‖x−y‖ ∧ ‖x+i·y‖ = ‖x−i·y‖, the complex refinement of the real fact that perpendicularity is the single equal-diagonals condition"
+    ],
+    "dateAdded": "2026-07-02",
+    "lineCount": 149,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The results are derived from Mathlib's verified inner_eq_sum_norm_sq_div_four and its re/im components; the roots-of-unity reformulation, the split/^2 packaging matching the parent entry, and the orthogonality criterion are original.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry (cauchy-schwarz-oq-07) proved the parallelogram law and, as its dual corollary, the *real* polarization identity ⟪x,y⟫_ℝ = (‖x+y‖²−‖x−y‖²)/4 — the inner product of a real space read off from the two diagonals of the parallelogram spanned by x and y. Over a complex space this is no longer enough: the diagonals ‖x±y‖ only recover the real part of ⟪x,y⟫, and the imaginary part is invisible to them. The classical remedy, going back to the polarization identity in its complex form, is to also probe the two *rotated* diagonals ‖x ± i·y‖, which capture the imaginary part. Assembling all four terms with the coefficients 1, −i, −1, i — the four fourth-roots of unity — reconstructs the complex inner product exactly. This is the exact analogue, for a sesquilinear form and its quadratic form, of recovering a bilinear form from a quadratic form.",
+    "problemStatement": "**Open Question (cauchy-schwarz-oq-07-oq-02)**: Extend the parent's real polarization corollary to the full complex form, recovering both the real and the imaginary part of the complex inner product ⟪x,y⟫_ℂ from the norm (Mathlib's inner_eq_sum_norm_sq_div_four).\n\n**Result**: The complex polarization identity is packaged in four equivalent shapes — the complex form, the real/imaginary split form, the separated re/im parts in the parent's squared style, and a single cyclic sum over the four fourth-roots of unity ⟪x,y⟫ = ¼∑_{k<4}(−i)^k‖x+i^k·y‖². Two corollaries record that the inner product is completely determined by the four diagonal norms and give a complex orthogonality criterion ⟪x,y⟫ = 0 ↔ ‖x+y‖ = ‖x−y‖ ∧ ‖x+i·y‖ = ‖x−i·y‖.",
+    "text": "The full complex polarization identity: the complex inner product ⟪x,y⟫ is recovered from the norm by combining the ordinary diagonals ‖x±y‖ (real part) with the rotated diagonals ‖x±i·y‖ (imaginary part). Presented as a cyclic sum over the four fourth-roots of unity, ⟪x,y⟫ = ¼∑_{k<4}(−i)^k‖x+i^k·y‖², with an orthogonality-from-norms corollary.",
+    "proofStrategy": "**Proof Strategy: one base identity, three reformulations, two corollaries.**\n\n1. **Base.** Specialize Mathlib's `inner_eq_sum_norm_sq_div_four` to 𝕜 = ℂ, replacing the abstract `RCLike.I` by `Complex.I` (equal by rfl), giving the complex-form identity.\n2. **Split.** Group the real and imaginary contributions, coercing each real quotient into ℂ; `push_cast` and `ring` verify the rearrangement.\n3. **Re / Im.** Take real and imaginary parts of the split form; `Complex.add_re/mul_re/I_re/I_im/ofReal_re/ofReal_im` collapse the imaginary unit and coercions, leaving the parent's squared diagonal formulas.\n4. **Roots of unity.** Expand ∑_{k∈range 4} (−i)^k‖x+i^k·y‖² with `Finset.sum_range_succ`, reduce the coefficients (−i)^k = 1, −i, −1, i and the shifts i^k·y = y, i·y, −y, −i·y (using i² = −1, i³ = −i), rewrite the resulting ±y and ±i·y arguments as ordinary/rotated diagonals, and match the base identity by `ring`.\n5. **Determination.** Rewriting the split form and substituting the four hypothesised norm equalities shows equal diagonal norms force equal inner products.\n6. **Orthogonality.** ⟪x,y⟫ = 0 iff its real and imaginary parts both vanish; each part is a difference of squared norms, and nonnegativity of norms upgrades ‖a‖² = ‖b‖² to ‖a‖ = ‖b‖.",
+    "keyInsights": [
+      "**The real diagonals only see the real part.** In a complex space ‖x+y‖ and ‖x−y‖ recover exactly re⟪x,y⟫; the imaginary part is orthogonal to what those two lengths measure. This is why the real polarization identity of the parent does not, by itself, extend to ℂ.",
+      "**The rotated diagonals supply the imaginary part.** Measuring ‖x ± i·y‖ probes x against the 90°-rotated copy of y; their squared difference is exactly 4·im⟪x,y⟫. The full inner product needs both pairs of diagonals.",
+      "**The coefficients are the fourth-roots of unity.** Writing polarization as ¼∑_{k<4}(−i)^k‖x+i^k·y‖² exposes the structure: the weights 1, −i, −1, i are the characters of the cyclic group of order four acting by multiplication by i. This is the discrete-Fourier packaging that generalizes to recovering any sesquilinear form from its quadratic form.",
+      "**Recovery is literal.** Because ⟪x,y⟫ is a fixed function of the four diagonal norms, two pairs of vectors with matching diagonals have equal inner products — polarization inverts the norm, not merely up to a constant.",
+      "**Complex orthogonality is a two-condition test.** Over ℝ, x ⟂ y iff ‖x+y‖ = ‖x−y‖ (equal diagonals). Over ℂ that only kills the real part; one must also demand ‖x+i·y‖ = ‖x−i·y‖ to kill the imaginary part, so complex perpendicularity is genuinely a pair of equal-diagonal conditions."
+    ],
+    "prerequisites": [
+      "Complex inner-product spaces (InnerProductSpace ℂ G in Mathlib)",
+      "The real polarization identity (parent entry cauchy-schwarz-oq-07)",
+      "The imaginary unit and its arithmetic (Complex.I, i² = −1)",
+      "Real and imaginary parts of complex numbers (Complex.re, Complex.im)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring stating the second open question (full complex polarization) and contrasting the ordinary diagonals ‖x±y‖ (real part) with the rotated diagonals ‖x±i·y‖ (imaginary part). Mathlib import, the CauchySchwarzOQ07OQ02 namespace, and the ambient complex inner-product space G.",
+      "mathContext": "Work over a complex inner-product space `[NormedAddCommGroup G] [InnerProductSpace ℂ G]`; the goal is to recover ⟪x,y⟫_ℂ from ‖·‖."
+    },
+    {
+      "id": "polarization-forms",
+      "title": "The Complex Polarization Identity: Complex and Split Forms",
+      "startLine": 49,
+      "endLine": 68,
+      "summary": "inner_eq_polarization_complex specializes Mathlib's inner_eq_sum_norm_sq_div_four to ℂ with Complex.I; inner_eq_polarization_split regroups it into the real/imaginary split form whose real part reproduces the parent's real polarization corollary and whose imaginary part carries the rotated-diagonal contribution.",
+      "mathContext": "$\\langle x,y\\rangle = \\tfrac14\\big(\\|x+y\\|^2-\\|x-y\\|^2\\big) + \\tfrac{i}{4}\\big(\\|x-iy\\|^2-\\|x+iy\\|^2\\big).$"
+    },
+    {
+      "id": "re-im-parts",
+      "title": "Separated Real and Imaginary Parts",
+      "startLine": 70,
+      "endLine": 88,
+      "summary": "re_inner_eq_diag_sq_div_four shows the real part uses only the ordinary diagonals, re⟪x,y⟫ = (‖x+y‖²−‖x−y‖²)/4 — verbatim the parent's real polarization formula; im_inner_eq_rot_diag_sq_div_four shows the imaginary part needs the rotated diagonals, im⟪x,y⟫ = (‖x−i·y‖²−‖x+i·y‖²)/4.",
+      "mathContext": "$\\operatorname{re}\\langle x,y\\rangle = \\tfrac14(\\|x+y\\|^2-\\|x-y\\|^2),\\quad \\operatorname{im}\\langle x,y\\rangle = \\tfrac14(\\|x-iy\\|^2-\\|x+iy\\|^2).$"
+    },
+    {
+      "id": "roots-of-unity",
+      "title": "The Roots-of-Unity Form",
+      "startLine": 90,
+      "endLine": 114,
+      "summary": "inner_eq_sum_fourth_roots packages the identity as a single cyclic sum over the four fourth-roots of unity, ⟪x,y⟫ = ¼∑_{k<4}(−i)^k‖x+i^k·y‖². The proof expands the range-4 sum, reduces the coefficients (−i)^k = 1,−i,−1,i and the shifts i^k·y = y,i·y,−y,−i·y, and matches the base identity by ring.",
+      "mathContext": "$\\langle x,y\\rangle = \\tfrac14\\sum_{k=0}^{3}(-i)^k\\,\\|x + i^k y\\|^2,$ the discrete-Fourier packaging over $\\mathbb{Z}/4$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Determination by Norms and Complex Orthogonality",
+      "startLine": 116,
+      "endLine": 146,
+      "summary": "inner_eq_of_diag_norms_eq: two pairs of vectors with the same four diagonal norms ‖x±y‖, ‖x±i·y‖ have equal inner products — polarization literally recovers ⟪·,·⟫ from ‖·‖. inner_eq_zero_iff_diags: the complex orthogonality criterion ⟪x,y⟫ = 0 ↔ ‖x+y‖ = ‖x−y‖ ∧ ‖x+i·y‖ = ‖x−i·y‖, refining the real single-condition test.",
+      "mathContext": "$\\langle x,y\\rangle = 0 \\iff \\|x+y\\| = \\|x-y\\| \\ \\wedge\\ \\|x+iy\\| = \\|x-iy\\|.$"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "cauchy-schwarz-oq-07",
+      "relationship": "extends",
+      "description": "The parent proves the real polarization corollary ⟪x,y⟫_ℝ = (‖x+y‖²−‖x−y‖²)/4; this entry answers its second open question by extending polarization to the full complex form, recovering the imaginary part via the rotated diagonals ‖x±i·y‖"
+    },
+    {
+      "proofId": "cauchy-schwarz-oq-07-oq-01",
+      "relationship": "related",
+      "description": "The sibling entry proves the Jordan–von Neumann converse (a norm satisfying the parallelogram law is induced by an inner product); this entry makes the recovering polarization formula fully explicit over ℂ, including the imaginary part the converse relies on"
+    },
+    {
+      "proofId": "cauchy-schwarz",
+      "relationship": "foundational",
+      "description": "Cauchy–Schwarz lives in an inner-product space; the complex polarization identity shows that inner product is not extra data beyond the norm but is fully recoverable from it"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the full complex polarization identity, recovering both parts of ⟪x,y⟫_ℂ from the norm. Presented in four equivalent shapes — complex form, real/imaginary split, separated re/im parts in the parent's squared style, and a single cyclic sum over the four fourth-roots of unity ⟪x,y⟫ = ¼∑_{k<4}(−i)^k‖x+i^k·y‖² — with corollaries that the inner product is determined by the four diagonal norms and a complex orthogonality-from-norms criterion.",
+    "implications": "Together with the parent's real polarization corollary, this closes the recovery of the inner product from the norm over both ℝ and ℂ. The rotated diagonals ‖x±i·y‖ are exactly the extra data the complex case needs; the roots-of-unity form exposes why four terms suffice and points to the general recovery of a sesquilinear form from its quadratic form. The orthogonality criterion turns complex perpendicularity into a pair of equal-diagonal length conditions, the direct complex analogue of the real single-condition test.",
+    "openQuestions": [
+      "Generalize the roots-of-unity form to the recovery of an arbitrary continuous sesquilinear form from its diagonal quadratic form, and to the p-th-root-of-unity averaging that recovers higher-degree forms.",
+      "Formalize the operator polarization identity recovering ⟪Tx,y⟫ (and hence a bounded operator T) from the quadratic form x ↦ ⟪Tx,x⟫ over a complex Hilbert space."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Conway, John B.",
+      "title": "A Course in Functional Analysis",
+      "year": "1990",
+      "venue": "Springer, Graduate Texts in Mathematics 96 (2nd edition)",
+      "note": "Chapter I: the polarization identity in real and complex inner-product spaces"
+    },
+    {
+      "authors": "Reed, Michael; Simon, Barry",
+      "title": "Methods of Modern Mathematical Physics I: Functional Analysis",
+      "year": "1980",
+      "venue": "Academic Press",
+      "note": "Section II.1: the complex polarization identity and recovery of the inner product from the norm"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of `cauchy-schwarz-oq-07` (The Parallelogram Law): *"extend the polarization corollary to the full complex form including the imaginary part (Mathlib's `inner_eq_sum_norm_sq_div_four`)."*

The parent recovered the **real** inner product from the norm via the two diagonals of a parallelogram, `⟪x,y⟫_ℝ = (‖x+y‖²−‖x−y‖²)/4`. Over ℂ those diagonals only see the real part; the imaginary part requires the two **rotated** diagonals `‖x ± i·y‖`. This entry assembles the full complex polarization identity in four equivalent shapes and derives two structural corollaries.

## New theorems (7, all 0-axiom, 0-sorry)

- `inner_eq_polarization_complex` — ℂ specialization of Mathlib's `inner_eq_sum_norm_sq_div_four` with `Complex.I`
- `inner_eq_polarization_split` — the real/imaginary split form (real part = the parent's formula verbatim)
- `re_inner_eq_diag_sq_div_four` / `im_inner_eq_rot_diag_sq_div_four` — separated re/im parts in the parent's squared style
- **`inner_eq_sum_fourth_roots`** — headline reformulation as a single cyclic sum over the four fourth-roots of unity: `⟪x,y⟫ = ¼ ∑_{k<4} (−i)^k ‖x + i^k·y‖²`. The discrete-Fourier / character-sum packaging, **not present in Mathlib**.
- `inner_eq_of_diag_norms_eq` — the inner product is completely determined by the four diagonal norms
- `inner_eq_zero_iff_diags` — complex **orthogonality-from-norms** criterion: `⟪x,y⟫ = 0 ↔ ‖x+y‖ = ‖x−y‖ ∧ ‖x+i·y‖ = ‖x−i·y‖`

## Files

- `proofs/Proofs/CauchySchwarzOQ07OQ02.lean` (149 lines)
- `src/data/proofs/cauchy-schwarz-oq-07-oq-02/{meta.json, annotations.json}`

## Verification

Typechecked with `lake env lean` against Mathlib 4.26.0. `#print axioms` on the headline theorems lists only `propext, Classical.choice, Quot.sound` (standard foundational — no `sorryAx`, no `Lean.ofReduceBool`). **0 axioms, 0 sorries, verified.**

## Status

**Outcome**: completed — closes parent open question 2. Badge `mathlib` (built on Mathlib's polarization identity; the roots-of-unity form, split/^2 packaging, and orthogonality criterion are original).

🤖 Generated by researcher-6