### PR TITLE
research(hermite-sawtooth-identity-oq-01-oq-03): Raabe multiplication Bₘ at m=3,4 via elementary power-sum route [VERIFIED, 0-axiom, 10thm/159L, new entry]

### DIFF
--- a/proofs/Proofs/HermiteSawtoothIdentityOQ01OQ03.lean
+++ b/proofs/Proofs/HermiteSawtoothIdentityOQ01OQ03.lean
@@ -1,0 +1,159 @@
+import Mathlib
+
+/-
+# Raabe Multiplication Formula for Bernoulli Polynomials at m = 3, 4
+
+## Open Question (hermite-sawtooth-identity-oq-01-oq-03)
+
+The parent entry `HermiteSawtoothIdentityOQ01` proves the Raabe multiplication theorem
+
+    `∑_{k=0}^{n-1} Bₘ(x + k/n) = n^{1-m} · Bₘ(n x)`
+
+for the low orders `m = 0, 1, 2` by an elementary, generating-function-free route:
+evaluate `Bₘ` to its explicit polynomial and close the sum with the Gauss and
+sum-of-squares power-sum formulas.  Its stated open question asks how far this
+elementary route reaches:
+
+> *Extend the elementary power-sum route to m = 3, 4 (each a fixed Faulhaber
+> identity), charting how far the generating-function-free method reaches before
+> the algebra becomes unwieldy.*
+
+This file answers it, proving Raabe at `m = 3` (coefficient `n^{1-3} = n⁻²`) and
+`m = 4` (coefficient `n^{1-4} = n⁻³`).  The two new power-sum ingredients are
+
+* `∑_{k<n} k³ = (n(n-1)/2)²`                            (Nicomachus),
+* `∑_{k<n} k⁴ = n(n-1)(2n-1)(3n²-3n-1)/30`             (the degree-4 Faulhaber sum).
+
+Verdict on the open question: the elementary route extends cleanly to `m = 3, 4`.
+Each order needs exactly the power sums up to `∑ kᵐ⁻¹`, and the closing step is a
+single `field_simp; ring`; the only growth is the (mechanical) polynomial
+expansion of `Bₘ(x + k/n)` into a `k`-polynomial.  No new ideas are required — the
+method is bounded only by the availability of the Faulhaber power sums, so it
+reaches every fixed `m` (though the coefficients grow), never becoming genuinely
+unwieldy, only longer.
+
+Everything is over ℚ, fully machine-checked, `0`-axiom.  Mathlib provides the
+Bernoulli polynomials and `sum_bernoulli` but not the multiplication theorem.
+-/
+
+open Polynomial Finset
+
+namespace HermiteSawtoothIdentityOQ01OQ03
+
+/-! ### Explicit evaluations of `B₃` and `B₄` -/
+
+/-- Bernoulli number `b₃ = 0` (odd `> 1`), routed through `bernoulli'`. -/
+theorem bernoulli_three_val : (bernoulli 3 : ℚ) = 0 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by norm_num), bernoulli'_three]
+
+/-- Bernoulli number `b₄ = -1/30`, routed through `bernoulli'`. -/
+theorem bernoulli_four_val : (bernoulli 4 : ℚ) = -1 / 30 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by norm_num), bernoulli'_four]
+
+/-- `B₃(x) = x³ - (3/2)x² + (1/2)x`. -/
+theorem bernoulli_eval_three' (x : ℚ) :
+    (Polynomial.bernoulli 3).eval x = x ^ 3 - 3 / 2 * x ^ 2 + 1 / 2 * x := by
+  simp [Polynomial.bernoulli, Finset.sum_range_succ, bernoulli_three_val]; ring
+
+/-- `B₄(x) = x⁴ - 2x³ + x² - 1/30`. -/
+theorem bernoulli_eval_four' (x : ℚ) :
+    (Polynomial.bernoulli 4).eval x = x ^ 4 - 2 * x ^ 3 + x ^ 2 - 1 / 30 := by
+  simp [Polynomial.bernoulli, Finset.sum_range_succ, bernoulli_three_val,
+    bernoulli_four_val, Nat.choose]; ring
+
+/-! ### Power-sum lemmas over ℚ (Faulhaber, degrees 1–4) -/
+
+/-- Gauss sum over ℚ: `∑_{k<n} k = n(n-1)/2`. -/
+theorem sum_range_id_rat (n : ℕ) :
+    ∑ k ∈ range n, (k : ℚ) = (n : ℚ) * ((n : ℚ) - 1) / 2 := by
+  induction n with
+  | zero => simp
+  | succ m ih => rw [sum_range_succ, ih]; push_cast; ring
+
+/-- Sum of squares over ℚ: `∑_{k<n} k² = n(n-1)(2n-1)/6`. -/
+theorem sum_range_sq_rat (n : ℕ) :
+    ∑ k ∈ range n, (k : ℚ) ^ 2 = (n : ℚ) * ((n : ℚ) - 1) * (2 * (n : ℚ) - 1) / 6 := by
+  induction n with
+  | zero => simp
+  | succ m ih => rw [sum_range_succ, ih]; push_cast; ring
+
+/-- Sum of cubes over ℚ (Nicomachus): `∑_{k<n} k³ = (n(n-1)/2)²`. -/
+theorem sum_range_cube_rat (n : ℕ) :
+    ∑ k ∈ range n, (k : ℚ) ^ 3 = ((n : ℚ) * ((n : ℚ) - 1) / 2) ^ 2 := by
+  induction n with
+  | zero => simp
+  | succ m ih => rw [sum_range_succ, ih]; push_cast; ring
+
+/-- Sum of fourth powers over ℚ: `∑_{k<n} k⁴ = n(n-1)(2n-1)(3n²-3n-1)/30`. -/
+theorem sum_range_quart_rat (n : ℕ) :
+    ∑ k ∈ range n, (k : ℚ) ^ 4
+      = (n : ℚ) * ((n : ℚ) - 1) * (2 * (n : ℚ) - 1)
+          * (3 * (n : ℚ) ^ 2 - 3 * (n : ℚ) - 1) / 30 := by
+  induction n with
+  | zero => simp
+  | succ m ih => rw [sum_range_succ, ih]; push_cast; ring
+
+/-! ### The Raabe multiplication formula at `m = 3, 4` -/
+
+/-- **Raabe, `m = 3`.**  `∑_{k<n} B₃(x + k/n) = (1/n²) · B₃(n x)` (since
+`n^{1-3} = n⁻²`), for `n ≥ 1`.  Reduces to the power sums `∑k, ∑k², ∑k³`. -/
+theorem raabe_three (x : ℚ) (n : ℕ) (hn : 0 < n) :
+    ∑ k ∈ range n, (Polynomial.bernoulli 3).eval (x + (k : ℚ) / (n : ℚ))
+      = (1 / (n : ℚ) ^ 2) * (Polynomial.bernoulli 3).eval ((n : ℚ) * x) := by
+  have hn0 : (n : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  simp only [bernoulli_eval_three']
+  have hexp : ∀ k : ℕ,
+      (x + (k : ℚ) / (n : ℚ)) ^ 3 - 3 / 2 * (x + (k : ℚ) / (n : ℚ)) ^ 2
+          + 1 / 2 * (x + (k : ℚ) / (n : ℚ))
+        = (x ^ 3 - 3 / 2 * x ^ 2 + 1 / 2 * x)
+          + (3 * x ^ 2 - 3 * x + 1 / 2) / (n : ℚ) * (k : ℚ)
+          + (3 * x - 3 / 2) / (n : ℚ) ^ 2 * (k : ℚ) ^ 2
+          + (1 / (n : ℚ) ^ 3) * (k : ℚ) ^ 3 := by
+    intro k; field_simp; ring
+  rw [Finset.sum_congr rfl (fun k _ => hexp k)]
+  simp only [Finset.sum_add_distrib, Finset.sum_const, Finset.card_range,
+      nsmul_eq_mul, ← Finset.mul_sum]
+  rw [sum_range_id_rat, sum_range_sq_rat, sum_range_cube_rat]
+  field_simp
+  ring
+
+/-- **Raabe, `m = 4`.**  `∑_{k<n} B₄(x + k/n) = (1/n³) · B₄(n x)` (since
+`n^{1-4} = n⁻³`), for `n ≥ 1`.  Reduces to the power sums `∑k, ∑k², ∑k³, ∑k⁴`. -/
+theorem raabe_four (x : ℚ) (n : ℕ) (hn : 0 < n) :
+    ∑ k ∈ range n, (Polynomial.bernoulli 4).eval (x + (k : ℚ) / (n : ℚ))
+      = (1 / (n : ℚ) ^ 3) * (Polynomial.bernoulli 4).eval ((n : ℚ) * x) := by
+  have hn0 : (n : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  simp only [bernoulli_eval_four']
+  have hexp : ∀ k : ℕ,
+      (x + (k : ℚ) / (n : ℚ)) ^ 4 - 2 * (x + (k : ℚ) / (n : ℚ)) ^ 3
+          + (x + (k : ℚ) / (n : ℚ)) ^ 2 - 1 / 30
+        = (x ^ 4 - 2 * x ^ 3 + x ^ 2 - 1 / 30)
+          + (4 * x ^ 3 - 6 * x ^ 2 + 2 * x) / (n : ℚ) * (k : ℚ)
+          + (6 * x ^ 2 - 6 * x + 1) / (n : ℚ) ^ 2 * (k : ℚ) ^ 2
+          + (4 * x - 2) / (n : ℚ) ^ 3 * (k : ℚ) ^ 3
+          + (1 / (n : ℚ) ^ 4) * (k : ℚ) ^ 4 := by
+    intro k; field_simp; ring
+  rw [Finset.sum_congr rfl (fun k _ => hexp k)]
+  simp only [Finset.sum_add_distrib, Finset.sum_const, Finset.card_range,
+      nsmul_eq_mul, ← Finset.mul_sum]
+  rw [sum_range_id_rat, sum_range_sq_rat, sum_range_cube_rat, sum_range_quart_rat]
+  field_simp
+  ring
+
+/-! ### Sanity checks -/
+
+/-- Raabe `m = 3` at `x = 0`, `n = 2`:  `∑_{k<2} B₃(k/2) = (1/4)·B₃(0)`.
+Both sides equal `0`. -/
+example : ∑ k ∈ range 2, (Polynomial.bernoulli 3).eval ((k : ℚ) / 2)
+    = (1 / (2 : ℚ) ^ 2) * (Polynomial.bernoulli 3).eval 0 := by
+  have h := raabe_three 0 2 (by norm_num)
+  simpa using h
+
+/-- Raabe `m = 4` at `x = 0`, `n = 2`:  `∑_{k<2} B₄(k/2) = (1/8)·B₄(0)`.
+Both sides equal `-1/240`. -/
+example : ∑ k ∈ range 2, (Polynomial.bernoulli 4).eval ((k : ℚ) / 2)
+    = (1 / (2 : ℚ) ^ 3) * (Polynomial.bernoulli 4).eval 0 := by
+  have h := raabe_four 0 2 (by norm_num)
+  simpa using h
+
+end HermiteSawtoothIdentityOQ01OQ03

--- a/src/data/proofs/hermite-sawtooth-identity-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-01-oq-03/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "hermite-sawtooth-identity-oq-01-oq-03",
+  "title": "Raabe Multiplication Formula for Bernoulli Polynomials at m = 3, 4",
+  "slug": "hermite-sawtooth-identity-oq-01-oq-03",
+  "description": "Extends the elementary, generating-function-free power-sum route of the parent (Raabe at m = 0, 1, 2) to orders m = 3 and m = 4: ∑_{k<n} Bₘ(x + k/n) = n^{1-m} Bₘ(nx), with coefficients n⁻² (m=3) and n⁻³ (m=4). Each order reduces to the fixed Faulhaber power sums ∑k, ∑k², ∑k³ (and ∑k⁴), evaluated explicitly and closed by field_simp/ring.",
+  "meta": {
+    "author": "Classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bernoulli_polynomials#Multiplication_theorems",
+    "date": "Classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "bernoulli-polynomials",
+      "raabe-multiplication",
+      "power-sums",
+      "faulhaber",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/HermiteSawtoothIdentityOQ01OQ03.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. Depends only on the foundational axioms propext, Classical.choice, Quot.sound.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.bernoulli",
+        "description": "The m-th Bernoulli polynomial B_m(x)",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli'_three / bernoulli'_four",
+        "description": "The Bernoulli numbers b₃ = 0 and b₄ = -1/30 (via bernoulli_eq_bernoulli'_of_ne_one)",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the last term of a range sum, used to unfold the Bernoulli polynomial and run the power-sum inductions",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Raabe multiplication formula at m = 3: ∑_{k<n} B₃(x + k/n) = (1/n²) B₃(nx), for n ≥ 1",
+      "Raabe multiplication formula at m = 4: ∑_{k<n} B₄(x + k/n) = (1/n³) B₄(nx), for n ≥ 1",
+      "Sum of cubes over ℚ (Nicomachus): ∑_{k<n} k³ = (n(n-1)/2)²",
+      "Sum of fourth powers over ℚ (degree-4 Faulhaber): ∑_{k<n} k⁴ = n(n-1)(2n-1)(3n²-3n-1)/30",
+      "Explicit evaluations B₃(x) = x³ - (3/2)x² + (1/2)x and B₄(x) = x⁴ - 2x³ + x² - 1/30 over ℚ",
+      "Verdict on the parent open question: the generating-function-free power-sum route extends cleanly to every fixed m, bounded only by availability of the Faulhaber sums up to ∑kᵐ⁻¹"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 159,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Raabe's multiplication theorem (J. L. Raabe, 1851) states that the Bernoulli polynomials satisfy ∑_{k=0}^{n-1} B_m(x + k/n) = n^{1-m} B_m(nx). It is the polynomial shadow of the Hurwitz-zeta distribution relation and, at m = 1, of the classical sawtooth identity ∑_{k<n} {x + k/n} = {nx} + (n-1)/2. The general theorem is usually proved through the exponential generating function t·e^{xt}/(e^t - 1). The parent entry (hermite-sawtooth-identity-oq-01) instead pursued an elementary route: for small m the coefficient n^{1-m} is a concrete power of n and the identity collapses to a Faulhaber power-sum computation. It handled m = 0, 1, 2 and asked how far this elementary method reaches. This entry pushes it to m = 3 and m = 4.",
+    "problemStatement": "**Raabe multiplication at m = 3, 4** (over ℚ, for n ≥ 1):\n\n$$\\sum_{k=0}^{n-1} B_3\\!\\left(x + \\tfrac{k}{n}\\right) = \\frac{1}{n^{2}}\\,B_3(nx), \\qquad \\sum_{k=0}^{n-1} B_4\\!\\left(x + \\tfrac{k}{n}\\right) = \\frac{1}{n^{3}}\\,B_4(nx),$$\n\nwith $B_3(x) = x^3 - \\tfrac32 x^2 + \\tfrac12 x$ and $B_4(x) = x^4 - 2x^3 + x^2 - \\tfrac1{30}$.",
+    "text": "Extends the parent's elementary power-sum proof of Raabe's Bernoulli multiplication theorem from m = 0, 1, 2 to m = 3 (coefficient n⁻²) and m = 4 (coefficient n⁻³), using the sum-of-cubes and sum-of-fourth-powers Faulhaber formulas.",
+    "proofStrategy": "For each order, evaluate B_m to its explicit ℚ-polynomial (computing the Bernoulli numbers b₃ = 0, b₄ = -1/30 via bernoulli_eq_bernoulli'_of_ne_one). Expand B_m(x + k/n) into a polynomial in k whose coefficients are rational functions of x and n: B_m(x + k/n) = ∑_{j≤m} c_j(x,n)·kʲ. Distribute the finite sum ∑_{k<n} over these monomials, pull out the k-independent coefficients, and replace each ∑_{k<n} kʲ by its closed Faulhaber form (∑k, ∑k², ∑k³, and for m = 4 also ∑k⁴). A single field_simp; ring (using n ≠ 0) then verifies the resulting polynomial identity against n^{1-m} B_m(nx).",
+    "keyInsights": [
+      "The coefficient n^{1-m} is a genuine negative power of n for m ≥ 2 (n⁻² at m=3, n⁻³ at m=4); it lands exactly right because the highest power sum ∑k^{m-1} ~ nᵐ/m cancels the n^{-(m-1)} scaling of the leading kᵐ⁻¹ coefficient.",
+      "Order m needs precisely the power sums up to ∑k^{m-1}: m=3 uses ∑k, ∑k², ∑k³; m=4 additionally uses ∑k⁴. The sum of cubes is the Nicomachus square (∑k³ = (∑k)²) and ∑k⁴ is the first Faulhaber sum with an irreducible quadratic factor 3n²-3n-1.",
+      "The Bernoulli numbers enter only through the explicit polynomial B_m; b₃ = 0 makes B₃ lack a constant term, and b₄ = -1/30 is the only constant in B₄ — both are supplied by Mathlib's bernoulli'_three / bernoulli'_four routed through bernoulli_eq_bernoulli'_of_ne_one.",
+      "Answering the parent's open question: the elementary route never becomes genuinely unwieldy — it extends to every fixed m with no new idea, only a longer (mechanical) expansion and one more Faulhaber sum. The method is bounded solely by the availability of the power-sum formulas, all of which are one-line inductions.",
+      "The proof is entirely rational and axiom-free (0 axioms), in contrast to the generating-function proof of the general-m theorem, which would pull in the full exponential-generating-function machinery."
+    ],
+    "prerequisites": [
+      "Bernoulli polynomials and Bernoulli numbers (Polynomial.bernoulli, bernoulli')",
+      "Faulhaber / power-sum formulas ∑k, ∑k², ∑k³, ∑k⁴",
+      "Finite-sum manipulation (distributing sums over polynomial expansions)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "bernoulli-evals",
+      "title": "Explicit Evaluations of B₃ and B₄",
+      "startLine": 46,
+      "endLine": 62,
+      "summary": "Computes the Bernoulli numbers b₃ = 0 and b₄ = -1/30, then evaluates B₃(x) = x³ - (3/2)x² + (1/2)x and B₄(x) = x⁴ - 2x³ + x² - 1/30.",
+      "mathContext": "$B_3(x) = x^3 - \\tfrac32 x^2 + \\tfrac12 x$ and $B_4(x) = x^4 - 2x^3 + x^2 - \\tfrac1{30}$, obtained from the Bernoulli-number expansion with $b_3 = 0$, $b_4 = -\\tfrac1{30}$."
+    },
+    {
+      "id": "power-sums",
+      "title": "Faulhaber Power Sums (degrees 1–4)",
+      "startLine": 67,
+      "endLine": 94,
+      "summary": "Induction proofs of ∑_{k<n} k = n(n-1)/2, ∑ k² = n(n-1)(2n-1)/6, ∑ k³ = (n(n-1)/2)², and ∑ k⁴ = n(n-1)(2n-1)(3n²-3n-1)/30, all over ℚ.",
+      "mathContext": "The Faulhaber sums $\\sum_{k<n} k^j$ for $j = 1,2,3,4$; the cube sum is the Nicomachus identity $\\sum k^3 = (\\sum k)^2$ and the quartic sum carries the factor $3n^2 - 3n - 1$."
+    },
+    {
+      "id": "raabe-three",
+      "title": "Raabe at m = 3",
+      "startLine": 100,
+      "endLine": 120,
+      "summary": "Proves ∑_{k<n} B₃(x + k/n) = (1/n²) B₃(nx) by expanding B₃(x+k/n) into a k-polynomial and closing with ∑k, ∑k², ∑k³.",
+      "mathContext": "$\\sum_{k<n} B_3(x + k/n) = n^{-2} B_3(nx)$; the coefficient $n^{1-3} = n^{-2}$."
+    },
+    {
+      "id": "raabe-four",
+      "title": "Raabe at m = 4",
+      "startLine": 122,
+      "endLine": 142,
+      "summary": "Proves ∑_{k<n} B₄(x + k/n) = (1/n³) B₄(nx) by the same expansion, now using all four power sums ∑k, ∑k², ∑k³, ∑k⁴.",
+      "mathContext": "$\\sum_{k<n} B_4(x + k/n) = n^{-3} B_4(nx)$; the coefficient $n^{1-4} = n^{-3}$."
+    },
+    {
+      "id": "examples",
+      "title": "Sanity Checks",
+      "startLine": 147,
+      "endLine": 157,
+      "summary": "Numeric checks at x = 0, n = 2: ∑_{k<2} B₃(k/2) = (1/4)B₃(0) = 0 and ∑_{k<2} B₄(k/2) = (1/8)B₄(0) = -1/240.",
+      "mathContext": "Concrete instances confirming both multiplication identities at $x = 0$, $n = 2$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "hermite-sawtooth-identity-oq-01",
+      "relationship": "extends",
+      "description": "Directly answers the parent's open question by extending its elementary power-sum route for Raabe's Bernoulli multiplication theorem from m = 0, 1, 2 to m = 3, 4."
+    },
+    {
+      "targetId": "hermite-sawtooth-identity",
+      "relationship": "related",
+      "description": "The grandparent sawtooth identity ∑_{k<n} {x + k/n} = {nx} + (n-1)/2 is the fractional-part form of the m = 1 Raabe case; this entry pushes the Bernoulli-polynomial version to m = 3, 4."
+    }
+  ],
+  "conclusion": {
+    "summary": "Raabe's Bernoulli multiplication theorem ∑_{k<n} Bₘ(x + k/n) = n^{1-m} Bₘ(nx) is fully machine-verified with zero axioms at orders m = 3 (coefficient n⁻²) and m = 4 (coefficient n⁻³), extending the parent's elementary power-sum proofs for m = 0, 1, 2. Each order reduces to the Faulhaber power sums up to ∑kᵐ⁻¹ and a single field_simp/ring.",
+    "implications": "The elementary, generating-function-free method reaches every fixed m: order m requires only the power sums ∑k, …, ∑k^{m-1} (all one-line inductions) plus a mechanical polynomial expansion of Bₘ(x + k/n). It never becomes genuinely unwieldy, only longer, so the practical obstruction is bookkeeping, not mathematics. The general-m theorem still calls for the exponential generating function, but every concrete order is now within elementary reach.",
+    "openQuestions": [
+      "Automate the per-order expansion (a metaprogram producing the k-polynomial coefficients of Bₘ(x + k/n)) to discharge Raabe at arbitrary fixed m without hand-written coefficient lemmas.",
+      "Prove the general-m Raabe theorem ∑_{k<n} Bₘ(x + k/n) = n^{1-m} Bₘ(nx) via Mathlib's Bernoulli exponential generating function and a finite geometric-series summation, handling the real exponent n^{1-m}."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Finset"
+    ],
+    "namespace": "HermiteSawtoothIdentityOQ01OQ03",
+    "lineCount": 159,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/HermiteSawtoothIdentityOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **hermite-sawtooth-identity-oq-01-oq-03**, directly answering the open question posed by the parent entry (`hermite-sawtooth-identity-oq-01`):

> *Extend the elementary power-sum route to m = 3, 4 (each a fixed Faulhaber identity), charting how far the generating-function-free method reaches before the algebra becomes unwieldy.*

**Result.** For every `n ≥ 1`, over ℚ:
```
∑_{k<n} B₃(x + k/n) = (1/n²) · B₃(nx)      (coefficient n^{1-3} = n⁻²)
∑_{k<n} B₄(x + k/n) = (1/n³) · B₄(nx)      (coefficient n^{1-4} = n⁻³)
```
proved by the parent's elementary, generating-function-free method.

## Proof architecture
- Evaluate `B₃(x) = x³ − (3/2)x² + (1/2)x` and `B₄(x) = x⁴ − 2x³ + x² − 1/30` explicitly, computing the Bernoulli numbers `b₃ = 0`, `b₄ = −1/30` via `bernoulli_eq_bernoulli'_of_ne_one` + `bernoulli'_three`/`bernoulli'_four`.
- Expand `Bₘ(x + k/n)` into a polynomial in `k`; distribute `∑_{k<n}` over the monomials.
- Replace each `∑_{k<n} kʲ` by its closed Faulhaber form: `∑k`, `∑k²`, `∑k³ = (n(n−1)/2)²` (Nicomachus), and `∑k⁴ = n(n−1)(2n−1)(3n²−3n−1)/30` (m=4 only).
- Close with a single `field_simp; ring`.

## Verdict on the open question
The elementary route extends cleanly to **every fixed m**: order `m` needs only the power sums up to `∑k^{m−1}` (all one-line inductions) plus a mechanical polynomial expansion. It never becomes genuinely unwieldy — only longer.

## Verification
- **0 axioms** (`#print axioms` on `raabe_three`/`raabe_four` → `propext, Classical.choice, Quot.sound` only), **0 sorries**.
- 10 theorems / 159 lines, Mathlib 4.26.0.
- Typechecked via `lake env lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)