### PR TITLE
Enrich Kummer in Digit-Sum Form: ν₂(C(2n,n))=popcount(n) (wilsons-theorem-oq-03-oq-03): add annotations.json (0→7)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-03-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-wt0303-overview",
+    "proofId": "wilsons-theorem-oq-03-oq-03",
+    "range": { "startLine": 2, "endLine": 45 },
+    "type": "concept",
+    "title": "From Legendre's formula to popcount of the central binomial",
+    "content": "The parent WilsonsTheoremOQ03 proves Legendre's formula in digit-sum form: (p−1)·ν_p(n!) = n − S_p(n). Applying it three times to n! = C(n,k)·k!·(n−k)! gives Kummer's theorem (p−1)·ν_p(C(n,k)) = S_p(k) + S_p(n−k) − S_p(n) — the number of carries when adding k and n−k in base p. Mathlib has that identity but not its consequences. This entry derives the sharp exact-valuation fact ν₂(C(2n,n)) = S₂(n) = popcount(n): the classical 'C(2n,n) is even' upgraded to knowing EXACTLY how even, plus a general-prime no-carry divisibility criterion.",
+    "mathContext": "$(p-1)\\,\\nu_p\\binom{n}{k} = S_p(k) + S_p(n-k) - S_p(n)$; in particular $\\nu_2\\binom{2n}{n} = S_2(n) = \\mathrm{popcount}(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Kummer's theorem", "Legendre's formula", "p-adic valuation", "central binomial coefficient", "popcount"],
+    "prerequisites": ["Legendre's formula (parent entry)", "base-p digit sum S_p", "p-adic valuation ν_p"]
+  },
+  {
+    "id": "ann-wt0303-shift",
+    "proofId": "wilsons-theorem-oq-03-oq-03",
+    "range": { "startLine": 57, "endLine": 64 },
+    "type": "theorem",
+    "title": "Binary left shift preserves digit sum",
+    "content": "The crux identity S₂(2n) = S₂(n): multiplying by 2 prepends a 0 bit in base 2, leaving the digit sum unchanged. Proved by peeling the lowest digit with Nat.digits_def': 2n has last digit 0 (2n % 2 = 0) and remainder 2n/2 = n, so the digit list of 2n is 0 :: digits(n) and the sums agree. This single shift lemma is what collapses the two-term Kummer expression for the central binomial.",
+    "mathContext": "$S_2(2n) = S_2(n)$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.digits_def'", "binary representation", "bit shift"],
+    "prerequisites": ["Nat.digits and its recursion"]
+  },
+  {
+    "id": "ann-wt0303-digit-facts",
+    "proofId": "wilsons-theorem-oq-03-oq-03",
+    "range": { "startLine": 68, "endLine": 85 },
+    "type": "theorem",
+    "title": "Digit-sum positivity and powers of two",
+    "content": "Two more base-2 facts. digit_two_sum_pos: S₂(n) > 0 for n ≥ 1, since the top (nonzero) digit is a member of the digit list, so it is ≤ the sum (List.single_le_sum). digit_sum_two_pow: S₂(2^m) = 1, since 2^m is a single 1-bit — an induction whose step is exactly the binary left shift digit_sum_two_mul. These feed the parity and sharpness corollaries below.",
+    "mathContext": "$n \\ge 1 \\Rightarrow S_2(n) > 0$;  $S_2(2^m) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["List.single_le_sum", "Nat.getLast_digit_ne_zero", "induction"],
+    "prerequisites": ["digit_sum_two_mul", "properties of Nat.digits"]
+  },
+  {
+    "id": "ann-wt0303-central",
+    "proofId": "wilsons-theorem-oq-03-oq-03",
+    "range": { "startLine": 96, "endLine": 104 },
+    "type": "theorem",
+    "title": "ν₂(C(2n,n)) = popcount(n) (headline)",
+    "content": "The main result: the 2-adic valuation of the central binomial coefficient equals the binary digit sum of n. Kummer's digit-sum identity for choose(2n) n gives (2−1)·ν₂ = S₂(n) + S₂(2n − n) − S₂(2n) = 2·S₂(n) − S₂(2n); the shift lemma S₂(2n) = S₂(n) collapses the right side to S₂(n). This is the sharp form of the folklore fact 'C(2n,n) is even' — Mathlib records no exact-valuation statement.",
+    "mathContext": "$\\nu_2\\binom{2n}{n} = S_2(n) = \\#\\{\\text{1-bits of } n\\}$",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficient", "Nat.centralBinom_eq_two_mul_choose", "sub_one_mul_padicValNat_choose_eq_sub_sum_digits"],
+    "prerequisites": ["Kummer's digit-sum identity", "digit_sum_two_mul"]
+  },
+  {
+    "id": "ann-wt0303-even",
+    "proofId": "wilsons-theorem-oq-03-oq-03",
+    "range": { "startLine": 110, "endLine": 123 },
+    "type": "theorem",
+    "title": "C(2n,n) is even except at n = 0",
+    "content": "An exact-parity corollary: 2 ∣ C(2n,n) ↔ n ≠ 0. The valuation is S₂(n), positive iff n ≠ 0 (digit_two_sum_pos), and a positive 2-adic valuation gives divisibility by 2 via pow_padicValNat_dvd. The n = 0 direction is the single exception C(0,0) = 1.",
+    "mathContext": "$2 \\mid \\binom{2n}{n} \\iff n \\neq 0$",
+    "significance": "supporting",
+    "relatedConcepts": ["pow_padicValNat_dvd", "parity", "Nat.centralBinom_zero"],
+    "prerequisites": ["padicValNat_centralBinom_two", "digit_two_sum_pos"]
+  },
+  {
+    "id": "ann-wt0303-sharp",
+    "proofId": "wilsons-theorem-oq-03-oq-03",
+    "range": { "startLine": 129, "endLine": 131 },
+    "type": "theorem",
+    "title": "Sharpness at powers of two",
+    "content": "The popcount bound is sharp: ν₂(C(2·2^m, 2^m)) = 1, since S₂(2^m) = 1. So at a power of two the central binomial is divisible by 2 exactly once — equivalently C(2^{m+1}, 2^m) ≡ 2 (mod 4). Powers of two are the minimizers of the valuation among all n of a given size.",
+    "mathContext": "$\\nu_2\\binom{2^{m+1}}{2^m} = 1$, i.e. $\\binom{2^{m+1}}{2^m} \\equiv 2 \\pmod 4$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sharpness", "digit_sum_two_pow"],
+    "prerequisites": ["padicValNat_centralBinom_two", "digit_sum_two_pow"]
+  },
+  {
+    "id": "ann-wt0303-nocarry",
+    "proofId": "wilsons-theorem-oq-03-oq-03",
+    "range": { "startLine": 145, "endLine": 163 },
+    "type": "theorem",
+    "title": "Kummer's no-carry criterion (general prime)",
+    "content": "The general-prime divisibility statement: for prime p and k ≤ n, p ∤ C(n,k) ↔ S_p(k) + S_p(n−k) ≤ S_p(n) — i.e. iff adding k and n−k in base p produces no carries. The proof reads off Kummer's identity: p ∤ C(n,k) ⟺ ν_p(C(n,k)) = 0 ⟺ (p−1)·ν_p = 0 ⟺ S_p(k) + S_p(n−k) − S_p(n) = 0 (using p − 1 > 0 and ℕ-subtraction), which omega finishes. Combined with the always-valid reverse inequality this is the classical equality of digit sums.",
+    "mathContext": "$p \\nmid \\binom{n}{k} \\iff S_p(k) + S_p(n-k) \\le S_p(n)$ (no carries in base $p$).",
+    "significance": "key",
+    "relatedConcepts": ["Kummer's theorem", "carries in base p", "padicValNat.eq_zero_of_not_dvd", "one_le_padicValNat_of_dvd"],
+    "prerequisites": ["Kummer's digit-sum identity", "p prime so p − 1 > 0"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-03-oq-03` (2-adic valuation of the central binomial coefficient = popcount, via Kummer's theorem).

**Gap:** the entry shipped with a rich meta.json but no `annotations.json`.

**Added:** 7 inline annotations, each with `content`, `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering:
- overview (Legendre → Kummer → popcount)
- `digit_sum_two_mul` (binary-shift digit-sum invariance)
- `digit_two_sum_pos` / `digit_sum_two_pow` (positivity, powers of two)
- `padicValNat_centralBinom_two` (ν₂(C(2n,n)) = popcount headline)
- `centralBinom_two_dvd_iff` (even except at n=0)
- `centralBinom_two_pow_valuation` (sharpness)
- `not_dvd_choose_iff` (Kummer's general-prime no-carry criterion)

All 7 validated by `validateLineAnnotations` (0 misaligned). No changes to meta.json or the Lean file.