### PR TITLE
research(pell-equation-oq-07-oq-01-oq-01): determinant norm identity + Cassini/Catalan identities [VERIFIED, 0-axiom, 12thm/228L]

### DIFF
--- a/proofs/Proofs/PellEquationOQ07OQ01OQ01.lean
+++ b/proofs/Proofs/PellEquationOQ07OQ01OQ01.lean
@@ -1,0 +1,228 @@
+/-
+Pell's Equation OQ-07 → OQ-01 → OQ-01: Determinant Norm Identity and the
+Cassini/Catalan Identities for Pell Coordinate Sequences
+
+The grandparent entry (`pell-equation-oq-07`) extracts the second-order recurrence
+`uₙ₊₂ = (2x₁)uₙ₊₁ − N(a)·uₙ` obeyed by each coordinate of the power sequence `aⁿ` of
+a generating quadratic integer `a = ⟨x₁, y₁⟩ ∈ ℤ√d`. The parent entry
+(`pell-equation-oq-07-oq-01`) supplies the *companion-matrix closed form*
+`Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)]` for `M = !![x₁, d·y₁; y₁, x₁]`, with
+`tr M = 2x₁` and `det M = N(a)`.
+
+This entry reads the **determinant** off that closed form. Because the determinant is
+multiplicative, `det(Mⁿ) = (det M)ⁿ = N(a)ⁿ`; on the other hand, evaluating the
+determinant of the explicit power matrix gives `re(aⁿ)² − d·im(aⁿ)²`. Equating the two
+recovers the fundamental **norm-power identity**
+
+    re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ,                         (`norm_pow_eq`)
+
+i.e. `N(aⁿ) = N(a)ⁿ`, obtained here purely from `det(Mⁿ) = (det M)ⁿ`. For a Pell
+generator (`N(a) = 1`) this is exactly the Pell equation `xₙ² − d·yₙ² = 1` for every
+power — the whole infinite family of Pell solutions in one determinant.
+
+From the same conjugate-symmetric decompositions the parent uses for Binet's formula,
+we also derive the **Cassini/Catalan identities** — the "second determinant" of three
+consecutive coordinates:
+
+    xₙ·xₙ₊₂ − xₙ₊₁² =  d·y₁²·N(a)ⁿ,                       (`cassini_re`)
+    d·(yₙ·yₙ₊₂ − yₙ₊₁²) = −d·y₁²·N(a)ⁿ,                   (`cassini_im`)
+
+where `xₖ = re(aᵏ)`, `yₖ = im(aᵏ)`. These are the two-by-two "consecutive-terms"
+determinants of the Pell sequence, and they are `√d`-free: every proof lives inside the
+ring `ℤ√d`, using only that conjugation `star` is a ring involution.
+
+## Mechanism
+
+Writing `α = a`, `β = star a`, the parent's isolation lemmas give
+`αᵏ + βᵏ = ⟨2xₖ, 0⟩` and `αᵏ − βᵏ = ⟨0, 2yₖ⟩`. The Cassini determinant is the pure
+commutative-ring identity
+
+    (αⁿ + βⁿ)(αⁿ⁺² + βⁿ⁺²) − (αⁿ⁺¹ + βⁿ⁺¹)² = (αβ)ⁿ (α − β)²,
+
+and dually with `−` in place of `+` on the left and an overall sign on the right. Since
+`αβ = a·star a = ⟨N(a), 0⟩` and `(α − β)² = ⟨4·d·y₁², 0⟩`, reading the rational
+coordinate turns each into the stated integer identity.
+
+## Main results
+
+* `mul_star_eq` — `a·star a = ⟨N(a), 0⟩` (Mathlib's `norm_eq_mul_conj`, restated).
+* `sub_star_mul_self` — `(a − star a)² = ⟨4·d·y₁², 0⟩`.
+* `det_companion_pow` — `det(Mⁿ) = N(a)ⁿ` via `Matrix.det_pow` and `det M = N(a)`.
+* `norm_pow_eq` — `re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ`: the norm-power identity, read off the
+  determinant of the companion power form.
+* `norm_pow` — the same as `(aⁿ).norm = a.norm ^ n` in Mathlib's `Zsqrtd.norm`.
+* `pell_pow` — for a Pell generator, `re(aⁿ)² − d·im(aⁿ)² = 1` for all `n`.
+* `cassini_re` / `cassini_im` — the Cassini/Catalan determinants of consecutive
+  coordinates.
+* Concrete `D = 2` checks against `(3 + 2√2)ⁿ = 1,3,17,99,… / 0,2,12,70,…`: the norm
+  identity is the Pell equation `xₙ² − 2yₙ² = 1`, and the Cassini constant is
+  `d·y₁² = 2·4 = 8`.
+
+All proofs are `sorry`-free and axiom-free (no `native_decide`).
+
+References:
+- Parent: `pell-equation-oq-07-oq-01` (companion-matrix closed form, isolation lemmas).
+- Mathlib `Mathlib/NumberTheory/Zsqrtd/Basic.lean` (`norm`, `norm_mul`,
+  `norm_eq_mul_conj`, `star`) and `Mathlib/LinearAlgebra/Matrix/Determinant`
+  (`Matrix.det_pow`, `Matrix.det_fin_two_of`).
+- The Cassini identity `Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ` is the `d = 5`, `a = ⟨1,1⟩/2` shadow of
+  this determinant; the general form is the Catalan identity for Lucas sequences.
+-/
+
+import Proofs.PellEquationOQ07OQ01
+
+namespace PellEquationOQ07OQ01OQ01
+
+open Zsqrtd Matrix
+open PellEquationOQ07OQ01
+
+variable {d : ℤ}
+
+/-
+## Two elementary `ℤ√d` identities
+
+The determinant identities all reduce, after using the parent's isolation lemmas, to two
+facts about the involution `star`: the product `a · star a` is the norm (a rational
+element), and the square of `a − star a` is `4·d·y₁²` (again rational).
+-/
+
+/-- **Product with conjugate is the norm.** `a · star a = ⟨N(a), 0⟩`. This is Mathlib's
+`Zsqrtd.norm_eq_mul_conj` read as a multiplication rule. -/
+theorem mul_star_eq (a : ℤ√d) : a * star a = ((a.norm : ℤ) : ℤ√d) :=
+  (Zsqrtd.norm_eq_mul_conj a).symm
+
+/-- **Square of the difference with the conjugate.** `(a − star a)² = ⟨4·d·y₁², 0⟩`:
+`a − star a = ⟨0, 2y₁⟩` is purely `√d`, so its square is the rational `d·(2y₁)²`. -/
+theorem sub_star_mul_self (a : ℤ√d) :
+    (a - star a) * (a - star a) = ((4 * d * a.im ^ 2 : ℤ) : ℤ√d) := by
+  refine Zsqrtd.ext ?_ ?_
+  · rw [re_mul, re_sub, im_sub, re_star, im_star, re_intCast]; ring
+  · rw [im_mul, re_sub, im_sub, re_star, im_star, im_intCast]; ring
+
+/-
+## The norm-power identity via the determinant
+
+`det` is multiplicative, so `det(Mⁿ) = (det M)ⁿ = N(a)ⁿ`. Evaluating `det` on the
+explicit companion power form `Mⁿ = !![xₙ, d·yₙ; yₙ, xₙ]` gives `xₙ² − d·yₙ²`.
+-/
+
+/-- **Determinant of the companion power.** `det(Mⁿ) = N(a)ⁿ`, by multiplicativity of the
+determinant (`det(Mⁿ) = (det M)ⁿ`) and `det M = N(a)`. -/
+theorem det_companion_pow (a : ℤ√d) (n : ℕ) :
+    ((companion a) ^ n).det = a.norm ^ n := by
+  rw [Matrix.det_pow, companion_det]
+
+/-- **The norm-power identity.** `re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ`. Read off by equating the
+two evaluations of `det(Mⁿ)`: the closed form `!![xₙ, d·yₙ; yₙ, xₙ]` has determinant
+`xₙ² − d·yₙ²`, while multiplicativity gives `N(a)ⁿ`. Equivalently `N(aⁿ) = N(a)ⁿ`. -/
+theorem norm_pow_eq (a : ℤ√d) (n : ℕ) :
+    (a ^ n).re ^ 2 - d * (a ^ n).im ^ 2 = a.norm ^ n := by
+  have hdet := det_companion_pow a n
+  rw [companion_pow, Matrix.det_fin_two_of] at hdet
+  linear_combination hdet
+
+/-- **Multiplicativity of the norm along powers**, `(aⁿ).norm = a.norm ^ n`, exhibited as
+a restatement of `norm_pow_eq` through `Zsqrtd.norm_def`. -/
+theorem norm_pow (a : ℤ√d) (n : ℕ) : (a ^ n).norm = a.norm ^ n := by
+  rw [Zsqrtd.norm_def]
+  have h := norm_pow_eq a n
+  linear_combination h
+
+/-- **The Pell equation for every power.** For a Pell generator (`N(a) = 1`), each power
+satisfies `re(aⁿ)² − d·im(aⁿ)² = 1`: the companion determinant `det(Mⁿ) = 1ⁿ = 1`
+produces the whole infinite family of Pell solutions at once. -/
+theorem pell_pow (a : ℤ√d) (h : a.norm = 1) (n : ℕ) :
+    (a ^ n).re ^ 2 - d * (a ^ n).im ^ 2 = 1 := by
+  rw [norm_pow_eq, h, one_pow]
+
+/-
+## The Cassini/Catalan identities
+
+The `2×2` determinant of three consecutive coordinates. Writing `α = a`, `β = star a`,
+the parent isolation lemmas turn `2xₖ` into `αᵏ + βᵏ` and `2yₖ` into the `√d`-part of
+`αᵏ − βᵏ`, and the identity becomes a pure ring computation whose right-hand side factors
+through `αβ = ⟨N(a), 0⟩` and `(α − β)² = ⟨4dy₁², 0⟩`.
+-/
+
+/-- Core `ℤ√d` determinant identity (real branch):
+`(αⁿ+βⁿ)(αⁿ⁺²+βⁿ⁺²) − (αⁿ⁺¹+βⁿ⁺¹)² = (αβ)ⁿ(α−β)²` with `β = star a`. -/
+private theorem cassini_re_elt (a : ℤ√d) (n : ℕ) :
+    (a ^ n + star a ^ n) * (a ^ (n + 2) + star a ^ (n + 2))
+      - (a ^ (n + 1) + star a ^ (n + 1)) * (a ^ (n + 1) + star a ^ (n + 1))
+      = (a * star a) ^ n * ((a - star a) * (a - star a)) := by
+  ring
+
+/-- Core `ℤ√d` determinant identity (imaginary branch):
+`(αⁿ−βⁿ)(αⁿ⁺²−βⁿ⁺²) − (αⁿ⁺¹−βⁿ⁺¹)² = −(αβ)ⁿ(α−β)²`. -/
+private theorem cassini_im_elt (a : ℤ√d) (n : ℕ) :
+    (a ^ n - star a ^ n) * (a ^ (n + 2) - star a ^ (n + 2))
+      - (a ^ (n + 1) - star a ^ (n + 1)) * (a ^ (n + 1) - star a ^ (n + 1))
+      = -((a * star a) ^ n * ((a - star a) * (a - star a))) := by
+  ring
+
+/-- **Cassini/Catalan identity, real coordinate.** For `xₖ = re(aᵏ)`,
+`xₙ·xₙ₊₂ − xₙ₊₁² = d·y₁²·N(a)ⁿ`. It is the `2×2` determinant `det !![xₙ₊₂, xₙ₊₁; xₙ₊₁, xₙ]`
+of consecutive coordinates, evaluated through the conjugate decomposition. -/
+theorem cassini_re (a : ℤ√d) (n : ℕ) :
+    (a ^ n).re * (a ^ (n + 2)).re - (a ^ (n + 1)).re ^ 2
+      = d * a.im ^ 2 * a.norm ^ n := by
+  have h := cassini_re_elt a n
+  rw [pow_add_star_pow a n, pow_add_star_pow a (n + 1), pow_add_star_pow a (n + 2),
+      mul_star_eq, sub_star_mul_self, ← Int.cast_pow] at h
+  have hint := congrArg Zsqrtd.re h
+  simp only [re_mul, re_sub, re_intCast, im_intCast, mul_zero, add_zero] at hint
+  have h4 : (4 : ℤ) * ((a ^ n).re * (a ^ (n + 2)).re - (a ^ (n + 1)).re ^ 2)
+      = 4 * (d * a.im ^ 2 * a.norm ^ n) := by linear_combination hint
+  exact mul_left_cancel₀ (by norm_num : (4 : ℤ) ≠ 0) h4
+
+/-- **Cassini/Catalan identity, `√d` coordinate.** For `yₖ = im(aᵏ)`,
+`d·(yₙ·yₙ₊₂ − yₙ₊₁²) = −d·y₁²·N(a)ⁿ`. (Stated with the `d` factor so it also holds at
+`d = 0`; for `d ≠ 0` it says `yₙyₙ₊₂ − yₙ₊₁² = −y₁²N(a)ⁿ`.) -/
+theorem cassini_im (a : ℤ√d) (n : ℕ) :
+    d * ((a ^ n).im * (a ^ (n + 2)).im - (a ^ (n + 1)).im ^ 2)
+      = -(d * a.im ^ 2 * a.norm ^ n) := by
+  have h := cassini_im_elt a n
+  rw [pow_sub_star_pow a n, pow_sub_star_pow a (n + 1), pow_sub_star_pow a (n + 2),
+      mul_star_eq, sub_star_mul_self, ← Int.cast_pow] at h
+  have hint := congrArg Zsqrtd.re h
+  simp only [re_mul, re_sub, re_neg, re_intCast, im_intCast,
+    mul_zero, add_zero, zero_add] at hint
+  have h4 : (4 : ℤ) * (d * ((a ^ n).im * (a ^ (n + 2)).im - (a ^ (n + 1)).im ^ 2))
+      = 4 * (-(d * a.im ^ 2 * a.norm ^ n)) := by linear_combination hint
+  exact mul_left_cancel₀ (by norm_num : (4 : ℤ) ≠ 0) h4
+
+/-
+## Concrete `D = 2` checks
+
+The norm-`1` generator `3 + 2√2 = ⟨3,2⟩ ∈ ℤ[√2]` has power sequence
+`x : 1, 3, 17, 99, …` and `y : 0, 2, 12, 70, …`. Here `d·y₁² = 2·2² = 8`.
+-/
+
+/-- For `(3+2√2)ⁿ` the norm identity is the **Pell equation** `xₙ² − 2yₙ² = 1`. -/
+theorem pell_pow_two (n : ℕ) :
+    ((⟨3, 2⟩ : ℤ√2) ^ n).re ^ 2 - 2 * ((⟨3, 2⟩ : ℤ√2) ^ n).im ^ 2 = 1 :=
+  pell_pow (⟨3, 2⟩ : ℤ√2) PellEquationOQ07.norm_three_two n
+
+/-- The Pell equation at `n = 2`: `17² − 2·12² = 289 − 288 = 1`. -/
+example : ((⟨3, 2⟩ : ℤ√2) ^ 2).re ^ 2 - 2 * ((⟨3, 2⟩ : ℤ√2) ^ 2).im ^ 2 = 1 := by decide
+
+/-- The Cassini constant for `⟨3,2⟩` is `d·y₁² = 8`, so `xₙxₙ₊₂ − xₙ₊₁² = 8` for all `n`. -/
+theorem cassini_re_two (n : ℕ) :
+    ((⟨3, 2⟩ : ℤ√2) ^ n).re * ((⟨3, 2⟩ : ℤ√2) ^ (n + 2)).re
+      - ((⟨3, 2⟩ : ℤ√2) ^ (n + 1)).re ^ 2 = 8 := by
+  have h := cassini_re (⟨3, 2⟩ : ℤ√2) n
+  rw [PellEquationOQ07.norm_three_two, one_pow] at h
+  rw [h]; norm_num
+
+/-- Cassini at `n = 0`: `x₀x₂ − x₁² = 1·17 − 3² = 17 − 9 = 8`. -/
+example : ((⟨3, 2⟩ : ℤ√2) ^ 0).re * ((⟨3, 2⟩ : ℤ√2) ^ 2).re
+    - ((⟨3, 2⟩ : ℤ√2) ^ 1).re ^ 2 = 8 := by decide
+
+#check @norm_pow_eq
+#check @norm_pow
+#check @pell_pow
+#check @cassini_re
+#check @cassini_im
+#check @det_companion_pow
+
+end PellEquationOQ07OQ01OQ01

--- a/src/data/proofs/pell-equation-oq-07-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01-oq-01/annotations.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": "ann-pell-oq070101-docstring",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 70 },
+    "type": "concept",
+    "title": "Reading the Determinant off the Companion Power Form",
+    "content": "The docstring answers the parent entry's first open question. The parent (pell-equation-oq-07-oq-01) proved the companion-matrix closed form Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)] with det M = N(a). This entry reads the determinant off that form two ways: multiplicatively det(Mⁿ) = (det M)ⁿ = N(a)ⁿ, and by direct 2×2 evaluation re(aⁿ)² − d·im(aⁿ)². Equating them gives the norm-power identity N(aⁿ) = N(a)ⁿ, which for a Pell generator is the Pell equation xₙ² − d·yₙ² = 1 for every power. The same conjugate decomposition then yields the Cassini/Catalan identities of three consecutive coordinates, proved √d-free inside ℤ[√d].",
+    "mathContext": "$\\det(M^n)=(\\det M)^n=N(a)^n=\\mathrm{re}(a^n)^2-d\\,\\mathrm{im}(a^n)^2.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Pell's equation",
+      "companion matrix",
+      "determinant multiplicativity",
+      "Cassini identity",
+      "Catalan identity",
+      "quadratic integers"
+    ],
+    "prerequisites": [
+      "the ring ℤ[√d] (Zsqrtd) with norm and conjugation star",
+      "the companion-matrix closed form Mⁿ (parent entry)",
+      "multiplicativity of the matrix determinant"
+    ]
+  },
+  {
+    "id": "ann-pell-oq070101-elementary",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 89, "endLine": 100 },
+    "type": "insight",
+    "title": "Two Elementary ℤ[√d] Identities",
+    "content": "mul_star_eq restates Mathlib's norm_eq_mul_conj as a product rule: a · star a = ⟨N(a), 0⟩, a purely rational element. sub_star_mul_self computes (a − star a)² = ⟨4·d·y₁², 0⟩, since a − star a = ⟨0, 2y₁⟩ is purely √d and squaring a purely-√d element ⟨0,p⟩ gives ⟨d·p², 0⟩. These two rational elements are exactly what the determinant right-hand sides factor through: the norm N(a) and the discriminant term 4dy₁².",
+    "mathContext": "$a\\cdot\\overline a=\\langle N(a),0\\rangle,\\qquad (a-\\overline a)^2=\\langle 4dy_1^2,0\\rangle.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "conjugation (star involution)",
+      "norm on ℤ[√d]",
+      "discriminant"
+    ],
+    "prerequisites": [
+      "Zsqrtd.norm_eq_mul_conj",
+      "Zsqrtd.ext and the re/im projections",
+      "re_mul / im_mul / re_sub / re_star"
+    ]
+  },
+  {
+    "id": "ann-pell-oq070101-normpower",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 109, "endLine": 136 },
+    "type": "concept",
+    "title": "The Norm-Power Identity via the Determinant",
+    "content": "det_companion_pow computes det(Mⁿ) = N(a)ⁿ using Matrix.det_pow (det(Mⁿ) = (det M)ⁿ) and the parent's companion_det (det M = N(a)). norm_pow_eq equates this with the direct 2×2 determinant of the explicit power form !![xₙ, d·yₙ; yₙ, xₙ], which is xₙ² − d·yₙ², giving re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ — the multiplicativity of the norm along powers, N(aⁿ) = N(a)ⁿ, obtained purely from the determinant. pell_pow specializes to a Pell generator (N(a) = 1): xₙ² − d·yₙ² = 1 for every power, the entire infinite family of Pell solutions from one determinant identity.",
+    "mathContext": "$\\mathrm{re}(a^n)^2-d\\,\\mathrm{im}(a^n)^2=N(a)^n;\\quad N(a)=1\\Rightarrow x_n^2-dy_n^2=1.$",
+    "significance": "central",
+    "relatedConcepts": [
+      "norm multiplicativity",
+      "Pell equation for every power",
+      "Matrix.det_pow",
+      "first integral of a recurrence"
+    ],
+    "prerequisites": [
+      "Matrix.det_pow and Matrix.det_fin_two_of",
+      "the parent's companion_pow and companion_det",
+      "linear_combination"
+    ]
+  },
+  {
+    "id": "ann-pell-oq070101-cassini",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 147, "endLine": 192 },
+    "type": "concept",
+    "title": "The Cassini/Catalan Identities of Consecutive Coordinates",
+    "content": "The core ring identities cassini_re_elt and cassini_im_elt — (αⁿ+βⁿ)(αⁿ⁺²+βⁿ⁺²) − (αⁿ⁺¹+βⁿ⁺¹)² = (αβ)ⁿ(α−β)² with β = star a, and its difference-branch dual carrying an overall minus sign — are pure commutative-ring facts proved by `ring` with symbolic exponents. Substituting the parent's isolation lemmas pow_add_star_pow / pow_sub_star_pow turns 2xₖ, 2yₖ into ℤ[√d] elements; rewriting mul_star_eq and sub_star_mul_self and reading the rational coordinate (congrArg Zsqrtd.re + simp, then cancelling the factor 4) gives cassini_re: xₙxₙ₊₂ − xₙ₊₁² = d·y₁²·N(a)ⁿ, and cassini_im: d·(yₙyₙ₊₂ − yₙ₊₁²) = −d·y₁²·N(a)ⁿ. The classical Fibonacci Cassini identity Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ is the D = 5 shadow.",
+    "mathContext": "$x_n x_{n+2}-x_{n+1}^2=d y_1^2 N(a)^n,\\qquad d\\,(y_n y_{n+2}-y_{n+1}^2)=-d y_1^2 N(a)^n.$",
+    "significance": "central",
+    "relatedConcepts": [
+      "Cassini identity",
+      "Catalan identity for Lucas sequences",
+      "conjugate decomposition (star)",
+      "consecutive-terms determinant"
+    ],
+    "prerequisites": [
+      "pow_add_star_pow / pow_sub_star_pow (parent isolation lemmas)",
+      "ring with symbolic exponents; mul_pow",
+      "mul_left_cancel₀"
+    ]
+  },
+  {
+    "id": "ann-pell-oq070101-d2",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 201, "endLine": 228 },
+    "type": "concept",
+    "title": "The D = 2 Instance: Pell Equation and Cassini Constant 8",
+    "content": "For the fundamental norm-1 unit 3 + 2√2 = ⟨3,2⟩ ∈ ℤ[√2], with power chain x : 1,3,17,99,… and y : 0,2,12,70,…: pell_pow_two instantiates the norm identity to the Pell equation xₙ² − 2yₙ² = 1 (e.g. 17² − 2·12² = 289 − 288 = 1), and cassini_re_two instantiates the Cassini identity to the constant d·y₁² = 2·2² = 8, so xₙxₙ₊₂ − xₙ₊₁² = 8 for all n (e.g. 1·17 − 3² = 8). Small cases are checked by kernel `decide`.",
+    "mathContext": "$3+2\\sqrt2:\\quad x_n^2-2y_n^2=1,\\qquad x_n x_{n+2}-x_{n+1}^2=8.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "fundamental unit of ℤ[√2]",
+      "Pell chain 1,3,17,99,577",
+      "concrete verification"
+    ],
+    "prerequisites": [
+      "PellEquationOQ07.norm_three_two",
+      "kernel decide vs native_decide"
+    ]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-07-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01-oq-01/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "pell-equation-oq-07-oq-01-oq-01",
+  "title": "Determinant Norm Identity and the Cassini/Catalan Identities for Pell Coordinate Sequences",
+  "slug": "pell-equation-oq-07-oq-01-oq-01",
+  "description": "The parent entry (pell-equation-oq-07-oq-01) supplies the companion-matrix closed form Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)] for the power sequence aⁿ of a generator a = ⟨x₁,y₁⟩ ∈ ℤ[√d], with M = !![x₁, d·y₁; y₁, x₁], trace 2x₁, and determinant N(a). This entry answers the parent's own first open question by reading the determinant off that closed form. Because the determinant is multiplicative, det(Mⁿ) = (det M)ⁿ = N(a)ⁿ; evaluating the determinant of the explicit power matrix instead gives re(aⁿ)² − d·im(aⁿ)². Equating the two recovers the norm-power identity re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ — that is, N(aⁿ) = N(a)ⁿ — obtained here purely from det(Mⁿ) = (det M)ⁿ. For a Pell generator (N(a) = 1) this is exactly the Pell equation xₙ² − d·yₙ² = 1 for every power, so the single determinant identity produces the entire infinite family of Pell solutions at once. From the same conjugate-symmetric decompositions the parent uses for Binet's formula, the entry then derives the Cassini/Catalan identities — the second determinant of three consecutive coordinates — xₙ·xₙ₊₂ − xₙ₊₁² = d·y₁²·N(a)ⁿ and d·(yₙ·yₙ₊₂ − yₙ₊₁²) = −d·y₁²·N(a)ⁿ, where xₖ = re(aᵏ), yₖ = im(aᵏ). The Cassini proofs are √d-free: writing α = a, β = star a, the isolation lemmas turn 2xₖ into αᵏ + βᵏ and 2yₖ into the √d-part of αᵏ − βᵏ, the identity becomes the pure commutative-ring fact (αⁿ+βⁿ)(αⁿ⁺²+βⁿ⁺²) − (αⁿ⁺¹+βⁿ⁺¹)² = (αβ)ⁿ(α−β)², and its right-hand side factors through αβ = ⟨N(a),0⟩ and (α−β)² = ⟨4dy₁²,0⟩. The classical Fibonacci Cassini identity Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ is the shadow of this general Catalan identity for Lucas sequences.",
+  "leanFile": {
+    "path": "Proofs/PellEquationOQ07OQ01OQ01.lean",
+    "lineCount": 228,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "sorryCount": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius (norm-power identity via det(Mⁿ) = (det M)ⁿ and √d-free Cassini/Catalan identities inside ℤ[√d]); Catalan/Cassini (classical consecutive-terms determinant for Lucas sequences)",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ07OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "pell-equation",
+      "quadratic-integers",
+      "zsqrtd",
+      "companion-matrix",
+      "determinant",
+      "cassini-identity",
+      "catalan-identity",
+      "norm-multiplicativity",
+      "conjugation",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-01",
+    "lineCount": 228,
+    "originalContributions": [
+      "norm_pow_eq: the norm-power identity re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ, read off by equating the two evaluations of det(Mⁿ) — the explicit companion power form !![xₙ, d·yₙ; yₙ, xₙ] has determinant xₙ² − d·yₙ², while multiplicativity of the determinant (Matrix.det_pow) with det M = N(a) gives N(a)ⁿ; this is N(aⁿ) = N(a)ⁿ derived from det(Mⁿ) = (det M)ⁿ",
+      "det_companion_pow: det(Mⁿ) = N(a)ⁿ via Matrix.det_pow and the parent's companion_det, the multiplicative half of the norm-power identity",
+      "pell_pow: for a Pell generator (N(a) = 1), re(aⁿ)² − d·im(aⁿ)² = 1 for every n — the single companion determinant produces the whole infinite family of Pell solutions xₙ² − d·yₙ² = 1",
+      "norm_pow: the same identity restated as (aⁿ).norm = a.norm ^ n through Zsqrtd.norm_def, matching Mathlib's multiplicativity of Zsqrtd.norm",
+      "cassini_re: the Cassini/Catalan identity for the real coordinate, xₙ·xₙ₊₂ − xₙ₊₁² = d·y₁²·N(a)ⁿ, the 2×2 determinant of consecutive coordinates — proved √d-free inside ℤ[√d] via the ring identity (αⁿ+βⁿ)(αⁿ⁺²+βⁿ⁺²) − (αⁿ⁺¹+βⁿ⁺¹)² = (αβ)ⁿ(α−β)² with β = star a, then reading the rational coordinate through αβ = ⟨N(a),0⟩ and (α−β)² = ⟨4dy₁²,0⟩",
+      "cassini_im: the dual Cassini identity for the √d coordinate, d·(yₙ·yₙ₊₂ − yₙ₊₁²) = −d·y₁²·N(a)ⁿ (stated with the d factor so it holds at d = 0; for d ≠ 0 it reads yₙyₙ₊₂ − yₙ₊₁² = −y₁²N(a)ⁿ), from the difference-branch ring identity with an overall sign",
+      "mul_star_eq / sub_star_mul_self: the two elementary ℤ[√d] facts underlying the determinant computations — a·star a = ⟨N(a),0⟩ (Mathlib's norm_eq_mul_conj) and (a − star a)² = ⟨4·d·y₁²,0⟩ (the square of the purely-√d element ⟨0,2y₁⟩)",
+      "pell_pow_two / cassini_re_two: the D = 2 instance for the fundamental unit 3 + 2√2 = ⟨3,2⟩ ∈ ℤ[√2] — the norm identity is the Pell equation xₙ² − 2yₙ² = 1 (e.g. 17² − 2·12² = 1) and the Cassini constant is d·y₁² = 2·2² = 8, so xₙxₙ₊₂ − xₙ₊₁² = 8 for all n (e.g. 1·17 − 3² = 8)"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide (the two `decide` uses are kernel `decide`, not `native_decide`, so no Lean.ofReduceBool). #print axioms reports only the standard triple [propext, Classical.choice, Quot.sound]. Uses Mathlib's Zsqrtd API (star, norm_def, norm_eq_mul_conj, re_mul/im_mul/re_sub/re_star), the 2×2 Matrix determinant API (det_pow, det_fin_two_of), the parent's companion / companion_pow / companion_det and pow_add_star_pow / pow_sub_star_pow isolation lemmas, and standard tactics (ring, linear_combination, simp, mul_left_cancel₀, decide).",
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pell-equation-oq-07-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the companion-matrix closed form Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)] with det M = N(a), and lists as its first open question the derivation of a Cassini/Catalan identity from det(Mⁿ) = (det M)ⁿ = N(a)ⁿ. This entry answers exactly that: the norm-power identity re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ via Matrix.det_pow, and the Cassini identities xₙxₙ₊₂ − xₙ₊₁² = d·y₁²·N(a)ⁿ and its √d-coordinate dual, reusing the parent's pow_add_star_pow / pow_sub_star_pow isolation lemmas."
+    },
+    {
+      "targetId": "pell-equation-oq-07",
+      "relationship": "related",
+      "description": "The grandparent derives the recurrence uₙ₊₂ = 2x₁·uₙ₊₁ − N(a)·uₙ that the Pell coordinate sequences satisfy. This entry supplies the two conserved quadratic quantities of that recurrence: the norm re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ (a first integral) and the Cassini determinant of consecutive terms."
+    },
+    {
+      "targetId": "pell-equation",
+      "relationship": "related",
+      "description": "The root entry classifies Pell solutions multiplicatively as powers of a fundamental unit. This entry shows the Pell equation xₙ² − d·yₙ² = 1 for every power is a single determinant identity det(Mⁿ) = (det M)ⁿ = 1, turning the multiplicative classification into one conserved determinant."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Two classical facts about Pell coordinate sequences flow from a single determinant. First, the norm of ℤ[√D] is multiplicative — N((x₁+y₁√D)ⁿ) = N(x₁+y₁√D)ⁿ — which for a Pell unit N = 1 says every power (xₙ, yₙ) is again a solution of xₙ² − D·yₙ² = 1. Second, the Cassini identity Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ for Fibonacci, and more generally the Catalan identity for Lucas sequences, express the 2×2 determinant of three consecutive terms as a constant times the n-th power of the recurrence's determinant. Both are instances of det(Mⁿ) = (det M)ⁿ for the transfer/companion matrix M whose determinant is the norm N(a): the norm identity is det of the coordinate matrix Mⁿ, and Cassini is det of the matrix of two consecutive coordinate vectors. This entry formalizes both inside Mathlib's ℤ[√d] for arbitrary d, deriving the norm identity from Matrix.det_pow and the Cassini identities √d-free from the ring structure of ℤ[√d].",
+    "problemStatement": "The parent proved the companion-matrix closed form Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)] but left as its first open question the Cassini/Catalan identity xₙ₋₁xₙ₊₁ − xₙ² = (constant)·N(a)ⁿ, to be derived from det(Mⁿ) = (det M)ⁿ = N(a)ⁿ. Can one read the norm-power identity off the determinant of the companion power form, and obtain the Cassini determinant of consecutive coordinates as a √d-free integer identity?",
+    "proofStrategy": "Work in Mathlib's ℤ√d = Zsqrtd d, importing the parent's companion, companion_pow, companion_det, pow_add_star_pow, pow_sub_star_pow. (1) det_companion_pow: rewrite det(Mⁿ) with Matrix.det_pow to (det M)ⁿ and companion_det to N(a)ⁿ. (2) norm_pow_eq: rewrite det(Mⁿ) instead through companion_pow and Matrix.det_fin_two_of to re(aⁿ)² − d·im(aⁿ)², then equate via linear_combination; specialize to Pell (N(a)=1) for pell_pow. (3) For Cassini, prove the pure ring identities cassini_re_elt/cassini_im_elt by `ring` (they hold for any commutative ring with symbolic exponents), substitute pow_add_star_pow / pow_sub_star_pow to turn 2xₖ, 2yₖ into ℤ√d elements, rewrite mul_star_eq (a·star a = ⟨N(a),0⟩) and sub_star_mul_self ((a−star a)² = ⟨4dy₁²,0⟩), then read the rational coordinate with congrArg Zsqrtd.re + simp and cancel the factor 4 with mul_left_cancel₀. (4) Instantiate at a = ⟨3,2⟩ ∈ ℤ[√2]: the norm identity becomes the Pell equation xₙ² − 2yₙ² = 1 and the Cassini constant is d·y₁² = 8, checked by decide at small n.",
+    "keyInsights": [
+      "The Pell equation xₙ² − d·yₙ² = 1 for every power n is not an infinite family of separate facts but a single determinant identity: det(Mⁿ) = (det M)ⁿ. Multiplicativity of the determinant (Matrix.det_pow) does all the work — the explicit power form !![xₙ, d·yₙ; yₙ, xₙ] has determinant xₙ² − d·yₙ², and det M = N(a) = 1 forces every one of these determinants to equal 1.",
+      "The same identity is the multiplicativity of the norm, N(aⁿ) = N(a)ⁿ, exhibited without Mathlib's norm_mul: the companion matrix converts the multiplicative norm into a matrix determinant, and det(Mⁿ) = (det M)ⁿ is exactly norm-multiplicativity along powers.",
+      "The Cassini/Catalan determinant of three consecutive coordinates is √d-free. Writing α = a, β = star a, the parent's isolation lemmas make 2xₖ = αᵏ + βᵏ a rational element, so the Cassini expression is the pure commutative-ring identity (αⁿ+βⁿ)(αⁿ⁺²+βⁿ⁺²) − (αⁿ⁺¹+βⁿ⁺¹)² = (αβ)ⁿ(α−β)², provable by `ring` with symbolic exponents — no analysis, no √d.",
+      "The right-hand side factors through two rational elements of ℤ[√d]: αβ = a·star a = ⟨N(a),0⟩ (the norm) and (α−β)² = (a − star a)² = ⟨4·d·y₁²,0⟩ (the square of the purely-irrational ⟨0,2y₁⟩). Reading the rational coordinate turns the ring identity into the integer Cassini identity xₙxₙ₊₂ − xₙ₊₁² = d·y₁²·N(a)ⁿ, with the Fibonacci constant (−1)ⁿ recovered as the D = 5 shadow.",
+      "For the D = 2 fundamental unit 3 + 2√2 = ⟨3,2⟩ the two identities specialize to the classical Pell chain: xₙ² − 2yₙ² = 1 on 1,3,17,99,… / 0,2,12,70,… (e.g. 17² − 2·12² = 289 − 288 = 1), and the Cassini constant d·y₁² = 2·2² = 8 gives xₙxₙ₊₂ − xₙ₊₁² = 8 for all n (e.g. 1·17 − 3² = 8)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-determinant",
+      "title": "Reading the Determinant off the Companion Power Form",
+      "startLine": 1,
+      "endLine": 74,
+      "summary": "Frames the goal: the parent's companion-matrix closed form Mⁿ = !![xₙ, d·yₙ; yₙ, xₙ] has a determinant that can be read two ways. Multiplicativity gives det(Mⁿ) = (det M)ⁿ = N(a)ⁿ; direct 2×2 evaluation gives xₙ² − d·yₙ². Equating them yields the norm-power identity and, for a Pell unit, the Pell equation for every power. The Cassini/Catalan determinant of consecutive coordinates follows from the same conjugate decomposition, √d-free.",
+      "mathContext": "$\\det(M^n)=(\\det M)^n=N(a)^n=\\mathrm{re}(a^n)^2-d\\,\\mathrm{im}(a^n)^2$."
+    },
+    {
+      "id": "elementary-identities",
+      "title": "Two Elementary ℤ[√d] Identities",
+      "startLine": 76,
+      "endLine": 100,
+      "summary": "mul_star_eq: a·star a = ⟨N(a),0⟩ (Mathlib's norm_eq_mul_conj read as a product rule). sub_star_mul_self: (a − star a)² = ⟨4·d·y₁²,0⟩, since a − star a = ⟨0,2y₁⟩ is purely √d. These are the two rational elements the determinant right-hand sides factor through.",
+      "mathContext": "$a\\cdot\\overline a=\\langle N(a),0\\rangle,\\quad (a-\\overline a)^2=\\langle 4dy_1^2,0\\rangle.$"
+    },
+    {
+      "id": "norm-power-identity",
+      "title": "The Norm-Power Identity via the Determinant",
+      "startLine": 102,
+      "endLine": 140,
+      "summary": "det_companion_pow: det(Mⁿ) = N(a)ⁿ via Matrix.det_pow and companion_det. norm_pow_eq: equating with the direct 2×2 determinant gives re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ. norm_pow restates it as (aⁿ).norm = a.norm ^ n; pell_pow specializes to xₙ² − d·yₙ² = 1 for a Pell generator, the whole family of Pell solutions from one determinant.",
+      "mathContext": "$\\mathrm{re}(a^n)^2-d\\,\\mathrm{im}(a^n)^2=N(a)^n;\\quad N(a)=1\\Rightarrow x_n^2-d y_n^2=1.$"
+    },
+    {
+      "id": "cassini-identities",
+      "title": "The Cassini/Catalan Identities of Consecutive Coordinates",
+      "startLine": 142,
+      "endLine": 200,
+      "summary": "The core ring identities cassini_re_elt / cassini_im_elt ((αⁿ+βⁿ)(αⁿ⁺²+βⁿ⁺²) − (αⁿ⁺¹+βⁿ⁺¹)² = (αβ)ⁿ(α−β)², and its difference-branch dual with a sign) are proved by `ring`. Substituting the isolation lemmas and reading the rational coordinate gives cassini_re: xₙxₙ₊₂ − xₙ₊₁² = d·y₁²·N(a)ⁿ, and cassini_im: d·(yₙyₙ₊₂ − yₙ₊₁²) = −d·y₁²·N(a)ⁿ.",
+      "mathContext": "$x_n x_{n+2}-x_{n+1}^2=d y_1^2 N(a)^n,\\quad d\\,(y_n y_{n+2}-y_{n+1}^2)=-d y_1^2 N(a)^n.$"
+    },
+    {
+      "id": "d2-instance",
+      "title": "The D = 2 Instance: Pell Equation and Cassini Constant 8",
+      "startLine": 202,
+      "endLine": 228,
+      "summary": "For the fundamental unit 3 + 2√2 = ⟨3,2⟩ ∈ ℤ[√2]: pell_pow_two gives the Pell equation xₙ² − 2yₙ² = 1 on the chain 1,3,17,99,… / 0,2,12,70,… (17² − 2·12² = 1), and cassini_re_two gives xₙxₙ₊₂ − xₙ₊₁² = 8 (constant d·y₁² = 2·2² = 8; e.g. 1·17 − 3² = 8), verified by decide at small n.",
+      "mathContext": "$3+2\\sqrt2:\\ x_n^2-2y_n^2=1,\\quad x_n x_{n+2}-x_{n+1}^2=8.$"
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 228-line file (0 sorries, 0 axioms, no native_decide) answers the parent entry's first open question. Reading the determinant off the companion power form two ways — multiplicatively det(Mⁿ) = (det M)ⁿ = N(a)ⁿ and by direct 2×2 evaluation re(aⁿ)² − d·im(aⁿ)² — yields the norm-power identity re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ (norm_pow_eq), which for a Pell generator is the Pell equation xₙ² − d·yₙ² = 1 for every power at once (pell_pow). From the parent's conjugate-symmetric isolation lemmas the entry then derives the Cassini/Catalan identities of three consecutive coordinates, xₙxₙ₊₂ − xₙ₊₁² = d·y₁²·N(a)ⁿ (cassini_re) and its √d-coordinate dual (cassini_im), √d-free via the ring identity (αⁿ+βⁿ)(αⁿ⁺²+βⁿ⁺²) − (αⁿ⁺¹+βⁿ⁺¹)² = (αβ)ⁿ(α−β)² with αβ = ⟨N(a),0⟩ and (α−β)² = ⟨4dy₁²,0⟩.",
+    "implications": "The two identities are the conserved quantities of the Pell recurrence: the norm N(aⁿ) = N(a)ⁿ is a first integral fixing every power to the same conic xₙ² − d·yₙ² = N(a)ⁿ, and the Cassini determinant records the second-order structure of consecutive terms. Both are one determinant identity det(Mⁿ) = (det M)ⁿ, so the technique — convert a multiplicative invariant into a matrix determinant, then use det_pow — transfers to any Lucas-type sequence (Fibonacci/Pell/Solution₁ generators, continued-fraction convergents). The Cassini computation is entirely √d-free, showing the identity lives at the level of the ring involution star, not the real embedding.",
+    "openQuestions": [
+      "Upgrade cassini_im to the divided form yₙyₙ₊₂ − yₙ₊₁² = −y₁²·N(a)ⁿ under d ≠ 0, and combine cassini_re, cassini_im into the full matrix Cassini det !![xₙ₊₁, xₙ; xₙ, xₙ₋₁] statement for the coordinate vector sequence.",
+      "Derive the addition/duplication formulas x_{m+n} = xₘxₙ + d·yₘyₙ, y_{m+n} = xₘyₙ + xₙyₘ from the same star-decomposition, giving the group law on Pell solutions in coordinate form and recovering Cassini as the m = 1 case.",
+      "Connect norm_pow to Mathlib's Pell.Solution₁: show the norm-power identity is the statement that the coordinate maps of a fundamental Solution₁ generator land in the Pell conic, closing the loop with the multiplicative classification."
+    ]
+  },
+  "references": [
+    {
+      "authors": "E. Catalan",
+      "title": "Note sur la théorie des nombres (Catalan's identity for Lucas sequences)",
+      "year": 1879,
+      "venue": "Mém. Soc. Roy. Sci. Liège",
+      "note": "The general identity uₙ₋ᵣuₙ₊ᵣ − uₙ² = (−1)ⁿ⁻ʳ⁺¹ uᵣ² for Lucas sequences, of which Cassini (r = 1) is the special case."
+    },
+    {
+      "authors": "E. J. Barbeau",
+      "title": "Pell's Equation",
+      "year": 2003,
+      "venue": "Springer",
+      "note": "Book-length treatment of Pell solutions, their recurrences, norm multiplicativity, and consecutive-term identities."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides the Zsqrtd (ℤ[√d]) norm/star API and the 2×2 Matrix determinant lemmas (det_pow, det_fin_two_of) underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New verified gallery entry answering the parent **pell-equation-oq-07-oq-01** `openQuestions[0]` **verbatim**: derive the Cassini/Catalan identity from `det(Mⁿ) = (det M)ⁿ = N(a)ⁿ` off the companion-matrix closed form.

The parent supplies `Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)]` for `M = !![x₁, d·y₁; y₁, x₁]` with `det M = N(a)`. Reading the determinant two ways gives the results below.

## Main results (`Proofs/PellEquationOQ07OQ01OQ01.lean`)

- **`norm_pow_eq`** — `re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ`, via `Matrix.det_pow` (det(Mⁿ)=(det M)ⁿ) + parent `companion_det`. This is `N(aⁿ) = N(a)ⁿ` read off the determinant.
- **`pell_pow`** — for a Pell generator (`N(a)=1`), `xₙ² − d·yₙ² = 1` for **every** power: the entire infinite Pell family from one determinant identity.
- **`cassini_re`** — `xₙ·xₙ₊₂ − xₙ₊₁² = d·y₁²·N(a)ⁿ`, proved **√d-free** inside ℤ[√d] via the pure ring identity `(αⁿ+βⁿ)(αⁿ⁺²+βⁿ⁺²) − (αⁿ⁺¹+βⁿ⁺¹)² = (αβ)ⁿ(α−β)²` (β = star a), with `αβ = ⟨N(a),0⟩`, `(α−β)² = ⟨4dy₁²,0⟩`.
- **`cassini_im`** — dual `√d`-coordinate identity `d·(yₙyₙ₊₂ − yₙ₊₁²) = −d·y₁²·N(a)ⁿ`.
- **D=2 checks** — for `3+2√2 = ⟨3,2⟩`: the norm identity is the Pell equation `xₙ²−2yₙ²=1` (e.g. 17²−2·12²=1), and the Cassini constant is `d·y₁²=8` (e.g. 1·17−3²=8).

The classical Fibonacci Cassini `Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ` is the D=5 shadow of `cassini_re`.

## Verification

- **0 sorries, 0 axioms.** `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`; the two `decide` uses are kernel decide (no `Lean.ofReduceBool`, no native_decide).
- Typechecked with `lake env lean` against the pinned Mathlib (v4.26.0).
- 228 lines, 12 theorems, 0 defs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)