### PR TITLE
research(algebraic-numbers-countable-oq-05-oq-04-oq-01): exact cardinality #{x:L|IsAlgebraic K x}=max(#K,ℵ₀) [VERIFIED, 0-axiom, 8thm/165L, new entry]

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ05OQ04OQ01.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ05OQ04OQ01.lean
@@ -1,0 +1,165 @@
+import Mathlib
+
+/-
+# The Exact Cardinality of the Algebraic Elements is `max #K ℵ₀`
+
+## Open Question OQ-05-OQ-04-OQ-01
+
+The parent entry `AlgebraicNumbersCountableOQ05OQ04` proves the sharp *countability*
+characterization for a field extension `L / K`:
+
+  `{x : L | IsAlgebraic K x}` is countable  ↔  the base field `K` is countable.
+
+Its open question asks whether this coarse (countable / uncountable) dichotomy can be
+upgraded to an **exact cardinal formula**:
+
+> Can the characterization be upgraded to exact cardinality —
+> `#{x : L | IsAlgebraic K x} = max (#K) ℵ₀` whenever `L` contains the algebraic
+> closure of `K` — recovering both the countable and uncountable regimes as the two
+> cases of a single cardinal formula?  (Mathlib's `Algebra.IsAlgebraic.cardinalMk_le_max`
+> gives one inequality.)
+
+## The sharp answer
+
+The answer is **yes**, with the natural hypothesis pinned down: it is enough that the
+ambient field `L` be **algebraically closed** (`IsAlgClosed L`), which is exactly the
+statement that `L` contains an algebraic closure of `K`.  Under this hypothesis
+
+  `#{x : L | IsAlgebraic K x} = max (#K) ℵ₀`.
+
+Note the hypothesis is genuinely needed: with `L = K` a finite field the algebraic set is
+just `K`, of finite cardinality `#K`, whereas `max (#K) ℵ₀ = ℵ₀`.  The formula only holds
+once `L` is large enough to hold the whole (infinite) algebraic closure — which
+`IsAlgClosed L` guarantees.
+
+## Proof architecture
+
+The algebraic elements form the *relative algebraic closure* `algebraicClosure K L`, an
+intermediate field whose carrier is exactly `{x : L | IsAlgebraic K x}`
+(`mem_algebraicClosure_iff`).  Write `A := algebraicClosure K L`.
+
+* **Upper bound** `#A ≤ max (#K) ℵ₀`:  `A` is algebraic over `K`
+  (`algebraicClosure.isAlgebraic`), so this is Mathlib's
+  `Algebra.IsAlgebraic.cardinalMk_le_max` — the one inequality the open question already
+  had in hand.
+
+* **Lower bound** `max (#K) ℵ₀ ≤ #A`, split into two:
+  * `#K ≤ #A`:  the base field embeds into `A` through the injective `algebraMap`.
+  * `ℵ₀ ≤ #A`:  when `L` is algebraically closed, `A` is an *absolute* algebraic closure
+    of `K` (`algebraicClosure.isAlgClosure`), hence itself algebraically closed, hence
+    **infinite** — an algebraically closed field is never finite.
+
+`le_antisymm` assembles the two bounds into the exact formula.
+
+## Recovering both regimes, and the parent
+
+* Countable regime: `K = ℚ` (or any countable field) gives `#K = ℵ₀`, so the algebraic
+  numbers in `ℂ` have cardinality `max ℵ₀ ℵ₀ = ℵ₀` — the classical countability of the
+  algebraic numbers, now as an *exact* count.
+* Uncountable regime: `K = ℝ` gives `#K = 𝔠 > ℵ₀`, so the elements of `ℂ` algebraic over
+  `ℝ` number exactly `𝔠` — the sharp form of the parent's `p`-adic-style obstruction.
+
+Both are the two cases `max (#K) ℵ₀ = #K` and `= ℵ₀` of one formula.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace AlgebraicNumbersCountableOQ05OQ04OQ01
+
+open Cardinal
+
+universe u
+
+variable {K L : Type u} [Field K] [Field L] [Algebra K L]
+
+/-! ### Upper bound (Mathlib's inequality, restated on the algebraic set) -/
+
+/-- **Upper bound.**  The algebraic elements of any field extension `L / K` number at most
+`max (#K) ℵ₀`.  This is Mathlib's `Algebra.IsAlgebraic.cardinalMk_le_max` applied to the
+relative algebraic closure `algebraicClosure K L`, whose carrier is exactly the algebraic
+set.  It is the single inequality the open question already had available. -/
+theorem cardinalMk_algebraicClosure_le :
+    #(algebraicClosure K L) ≤ max (#K) ℵ₀ :=
+  Algebra.IsAlgebraic.cardinalMk_le_max K (algebraicClosure K L)
+
+/-! ### Lower bounds -/
+
+/-- The base field embeds into its relative algebraic closure via the (injective)
+`algebraMap`, so `#K ≤ #(algebraicClosure K L)`. -/
+theorem cardinalMk_le_algebraicClosure :
+    #K ≤ #(algebraicClosure K L) :=
+  Cardinal.mk_le_of_injective
+    (FaithfulSMul.algebraMap_injective K (algebraicClosure K L))
+
+/-- **Infinitude of the algebraic set.**  When `L` is algebraically closed, the relative
+algebraic closure `algebraicClosure K L` is an *absolute* algebraic closure of `K`
+(`algebraicClosure.isAlgClosure`), hence itself algebraically closed, hence infinite. -/
+instance [IsAlgClosed L] : IsAlgClosed (algebraicClosure K L) :=
+  IsAlgClosure.isAlgClosed K
+
+theorem aleph0_le_cardinalMk_algebraicClosure [IsAlgClosed L] :
+    ℵ₀ ≤ #(algebraicClosure K L) :=
+  Cardinal.aleph0_le_mk (algebraicClosure K L)
+
+/-! ### The exact cardinal formula -/
+
+/-- **The exact cardinality, on the relative algebraic closure.**  If `L` is algebraically
+closed then the relative algebraic closure of `K` in `L` has cardinality exactly
+`max (#K) ℵ₀`. -/
+theorem cardinalMk_algebraicClosure_eq_max [IsAlgClosed L] :
+    #(algebraicClosure K L) = max (#K) ℵ₀ :=
+  le_antisymm cardinalMk_algebraicClosure_le
+    (max_le cardinalMk_le_algebraicClosure aleph0_le_cardinalMk_algebraicClosure)
+
+/-- The relative algebraic closure and the algebraic set have the same elements, hence the
+same cardinality. -/
+theorem cardinalMk_setOf_eq_algebraicClosure :
+    #{x : L | IsAlgebraic K x} = #(algebraicClosure K L) :=
+  Cardinal.mk_congr (Equiv.subtypeEquivRight fun _ => (mem_algebraicClosure_iff).symm)
+
+/-- **Main result (OQ-05-OQ-04-OQ-01).**  For a field extension `L / K` with `L`
+algebraically closed, the set of elements of `L` algebraic over `K` has cardinality exactly
+
+  `#{x : L | IsAlgebraic K x} = max (#K) ℵ₀`.
+
+This upgrades the parent's countable/uncountable dichotomy to a single exact cardinal
+formula, with the two regimes appearing as `max (#K) ℵ₀ = #K` and `= ℵ₀`. -/
+theorem cardinalMk_setOf_isAlgebraic_eq_max [IsAlgClosed L] :
+    #{x : L | IsAlgebraic K x} = max (#K) ℵ₀ := by
+  rw [cardinalMk_setOf_eq_algebraicClosure, cardinalMk_algebraicClosure_eq_max]
+
+/-! ### The absolute algebraic closure
+
+The same formula for Mathlib's absolute construction `AlgebraicClosure K` — the whole type
+is algebraic over `K`, so the algebraic set is everything. -/
+
+/-- **Absolute form.**  The (absolute) algebraic closure of `K` has cardinality exactly
+`max (#K) ℵ₀`.  This is the special case `L = AlgebraicClosure K` of the main result. -/
+theorem cardinalMk_algebraicClosure_type_eq_max :
+    #(AlgebraicClosure K) = max (#K) ℵ₀ :=
+  le_antisymm (Algebra.IsAlgebraic.cardinalMk_le_max K (AlgebraicClosure K))
+    (max_le
+      (Cardinal.mk_le_of_injective (FaithfulSMul.algebraMap_injective K (AlgebraicClosure K)))
+      (Cardinal.aleph0_le_mk (AlgebraicClosure K)))
+
+/-! ### Worked instances: both regimes of the single formula -/
+
+section Examples
+
+/-- **Countable regime.**  The algebraic numbers (elements of `ℂ` algebraic over `ℚ`) number
+exactly `ℵ₀`: here `max (#ℚ) ℵ₀ = max ℵ₀ ℵ₀ = ℵ₀`.  This is the classical countability of
+the algebraic numbers, sharpened to an exact count. -/
+example : #{x : ℂ | IsAlgebraic ℚ x} = ℵ₀ := by
+  rw [cardinalMk_setOf_isAlgebraic_eq_max, Cardinal.mkRat, max_self]
+
+/-- **Uncountable regime.**  The elements of `ℂ` algebraic over `ℝ` number exactly the
+continuum `𝔠`: here `#ℝ = 𝔠 ≥ ℵ₀`, so `max (#ℝ) ℵ₀ = 𝔠`.  (Indeed every element of `ℂ` is
+algebraic over `ℝ`, of degree at most `2`.)  This is the sharp form of the parent's
+uncountable obstruction. -/
+example : #{x : ℂ | IsAlgebraic ℝ x} = 𝔠 := by
+  rw [cardinalMk_setOf_isAlgebraic_eq_max, Cardinal.mk_real,
+    max_eq_left (Cardinal.aleph0_le_continuum)]
+
+end Examples
+
+end AlgebraicNumbersCountableOQ05OQ04OQ01

--- a/src/data/proofs/algebraic-numbers-countable-oq-05-oq-04-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05-oq-04-oq-01/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "algebraic-numbers-countable-oq-05-oq-04-oq-01",
+  "title": "The Exact Cardinality of the Algebraic Elements is max(#K, ℵ₀)",
+  "slug": "algebraic-numbers-countable-oq-05-oq-04-oq-01",
+  "description": "Answers the parent's open question OQ-05-OQ-04-OQ-01 — can the countable/uncountable dichotomy be upgraded to an exact cardinal formula? — with a single sharp equation. For a field extension L/K with L algebraically closed, #{x : L | IsAlgebraic K x} = max(#K, ℵ₀). The algebraic elements form the relative algebraic closure algebraicClosure K L (an intermediate field whose carrier is exactly the algebraic set). The upper bound #A ≤ max(#K, ℵ₀) is Mathlib's Algebra.IsAlgebraic.cardinalMk_le_max — the one inequality the open question already had. The matching lower bound is new: K embeds into A via the injective algebraMap (giving #K ≤ #A), and when L is algebraically closed A is itself an absolute algebraic closure of K, hence algebraically closed, hence infinite (giving ℵ₀ ≤ #A). le_antisymm assembles them. The algebraic-closure hypothesis is genuinely needed (with L = K a finite field the algebraic set is just K, of finite cardinality). Both regimes of the parent — countable (K = ℚ, count ℵ₀) and uncountable (K = ℝ, count 𝔠) — appear as the two cases max(#K, ℵ₀) = ℵ₀ and = #K of one formula.",
+  "meta": {
+    "author": "Lean Genius researcher-4",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ05OQ04OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 165,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "assumptions": "None. The main theorem requires the ambient field L to be algebraically closed (IsAlgClosed L) — the formalization of 'L contains the algebraic closure of K', which is exactly the hypothesis the open question states and is genuinely necessary for the formula. The result is fully machine-checked. Verified via #print axioms to depend only on the foundational axioms propext, Classical.choice, Quot.sound; no native_decide and no Lean.ofReduceBool dependency.",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "cardinal-arithmetic",
+      "algebraic-numbers",
+      "algebraic-closure",
+      "field-theory",
+      "field-extensions",
+      "sharp-boundary",
+      "research"
+    ],
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "cardinalMk_setOf_isAlgebraic_eq_max: the exact cardinal formula #{x : L | IsAlgebraic K x} = max(#K, ℵ₀) for a field extension L/K with L algebraically closed — upgrading the parent's coarse countable/uncountable dichotomy to a single equation whose two cases (max(#K, ℵ₀) = ℵ₀ and = #K) recover both regimes",
+      "cardinalMk_algebraicClosure_eq_max: the same exact cardinality on the relative algebraic closure algebraicClosure K L (the intermediate field of algebraic elements), the structural form of the result before transferring to the set {x : L | IsAlgebraic K x}",
+      "The matching lower bound max(#K, ℵ₀) ≤ #A, the half the open question did NOT have: #K ≤ #A by embedding the base field through the injective algebraMap (cardinalMk_le_algebraicClosure), and ℵ₀ ≤ #A because when L is algebraically closed the relative algebraic closure is an absolute algebraic closure of K (algebraicClosure.isAlgClosure), hence itself algebraically closed, hence infinite (aleph0_le_cardinalMk_algebraicClosure)",
+      "cardinalMk_algebraicClosure_type_eq_max: the absolute form #(AlgebraicClosure K) = max(#K, ℵ₀) for Mathlib's absolute algebraic-closure construction, the special case L = AlgebraicClosure K",
+      "Worked instances on both regimes of the single formula: the algebraic numbers (ℂ over ℚ) number exactly ℵ₀ = max(ℵ₀, ℵ₀), while the elements of ℂ algebraic over ℝ number exactly the continuum 𝔠 = max(𝔠, ℵ₀) — the sharp cardinal form of the parent's countable and uncountable examples"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/AlgebraicNumbersCountableOQ05OQ04OQ01.lean",
+    "namespace": "AlgebraicNumbersCountableOQ05OQ04OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 165,
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Cantor's 1874 count of the real algebraic numbers gives ℵ₀ many, the first proof that transcendentals exist. The parent chain sharpens this to a base-field biconditional: the algebraic elements over K are countable iff K is. That is a coarse (countable / uncountable) statement, and its own open question asks for the exact count. The natural guess — max(#K, ℵ₀) — is the cardinality of an algebraic closure of K: countably many polynomials over K when K is countable (ℵ₀ roots total), and #K·ℵ₀ = #K when K is uncountable. Mathlib supplies the upper half (Algebra.IsAlgebraic.cardinalMk_le_max) as a Stacks-tagged lemma; the missing half is a lower bound, which is where the algebraic-closure hypothesis enters: only once L is large enough to contain the whole (infinite) algebraic closure does the count reach ℵ₀.",
+    "problemStatement": "Open Question OQ-05-OQ-04-OQ-01: Can the countable/uncountable characterization be upgraded to exact cardinality — #{x : L | IsAlgebraic K x} = max(#K, ℵ₀) whenever L contains the algebraic closure of K — recovering both regimes as the two cases of a single cardinal formula? (Mathlib's Algebra.IsAlgebraic.cardinalMk_le_max gives one inequality.)",
+    "proofStrategy": "Identify the algebraic set with the relative algebraic closure A := algebraicClosure K L, an IntermediateField whose carrier is exactly {x : L | IsAlgebraic K x} (mem_algebraicClosure_iff). Prove #A = max(#K, ℵ₀) by le_antisymm. Upper bound: A is algebraic over K (algebraicClosure.isAlgebraic), so Algebra.IsAlgebraic.cardinalMk_le_max K A gives #A ≤ max(#K, ℵ₀) — the inequality the open question already had. Lower bound max(#K, ℵ₀) ≤ #A via max_le of two parts: (i) #K ≤ #A from Cardinal.mk_le_of_injective applied to the injective algebraMap K A (FaithfulSMul.algebraMap_injective); (ii) ℵ₀ ≤ #A from Cardinal.aleph0_le_mk once A is Infinite — and A IS infinite because, when L is algebraically closed, algebraicClosure.isAlgClosure makes A an absolute algebraic closure of K (IsAlgClosure K A), whose isAlgClosed projection plus Mathlib's 'algebraically closed ⟹ infinite' instance forces Infinite A. Transfer from A to the set via Equiv.subtypeEquivRight and Cardinal.mk_congr (cardinalMk_setOf_eq_algebraicClosure). The absolute form #(AlgebraicClosure K) = max(#K, ℵ₀) is the same three-step argument on Mathlib's absolute construction.",
+    "keyInsights": [
+      "The exact count is max(#K, ℵ₀), the cardinality of an algebraic closure of K — and this is precisely why the ambient L must be algebraically closed: the formula is a statement about how big the algebraic closure is, so L must be big enough to hold it. With L = K a finite field the algebraic set is finite, and the formula fails; IsAlgClosed L is the sharp hypothesis.",
+      "The open question already had the upper bound (Mathlib's cardinalMk_le_max). The whole content of the answer is the LOWER bound, and it factors cleanly: #K ≤ #A is a one-line embedding, and ℵ₀ ≤ #A is 'an algebraically closed field is infinite' applied to the relative algebraic closure once it is recognized (via IsAlgClosure) as an absolute algebraic closure of K.",
+      "Working with the intermediate field algebraicClosure K L rather than the raw set {x : L | IsAlgebraic K x} is what unlocks the Mathlib API: it carries the Algebra.IsAlgebraic, NoZeroSMulDivisors, and (under IsAlgClosed L) IsAlgClosure instances that the cardinal lemmas need. The transfer back to the set is a pure Equiv.subtypeEquivRight, since the two subtypes have equivalent membership predicates.",
+      "Both parent regimes are the two branches of max: over ℚ, max(ℵ₀, ℵ₀) = ℵ₀ gives the classical countable algebraic numbers as an EXACT count; over ℝ, max(𝔠, ℵ₀) = 𝔠 gives exactly continuum-many elements of ℂ algebraic over ℝ. One equation, two cases."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the Sharp Answer",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Header stating OQ-05-OQ-04-OQ-01 and the resolution: the exact count is max(#K, ℵ₀) under the hypothesis that L is algebraically closed (the formalization of 'L contains the algebraic closure of K'), genuinely needed since L = K finite fails. Describes the algebraicClosure-based architecture: Mathlib's upper bound plus a two-part lower bound."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Upper Bound (Mathlib's Inequality)",
+      "startLine": 75,
+      "endLine": 83,
+      "summary": "cardinalMk_algebraicClosure_le: #(algebraicClosure K L) ≤ max(#K, ℵ₀), Mathlib's Algebra.IsAlgebraic.cardinalMk_le_max applied to the relative algebraic closure — the single inequality the open question already had available."
+    },
+    {
+      "id": "lower-bounds",
+      "title": "Lower Bounds: Base Embedding and Infinitude",
+      "startLine": 85,
+      "endLine": 102,
+      "summary": "cardinalMk_le_algebraicClosure: #K ≤ #A via the injective algebraMap (FaithfulSMul.algebraMap_injective). The instance IsAlgClosed (algebraicClosure K L) under IsAlgClosed L, from algebraicClosure.isAlgClosure. aleph0_le_cardinalMk_algebraicClosure: ℵ₀ ≤ #A because an algebraically closed field is infinite."
+    },
+    {
+      "id": "exact-formula",
+      "title": "The Exact Cardinal Formula",
+      "startLine": 104,
+      "endLine": 129,
+      "summary": "cardinalMk_algebraicClosure_eq_max: #(algebraicClosure K L) = max(#K, ℵ₀) by le_antisymm. cardinalMk_setOf_eq_algebraicClosure: the set and the relative closure are equinumerous (Equiv.subtypeEquivRight). cardinalMk_setOf_isAlgebraic_eq_max: the main result #{x : L | IsAlgebraic K x} = max(#K, ℵ₀)."
+    },
+    {
+      "id": "absolute",
+      "title": "The Absolute Algebraic Closure",
+      "startLine": 131,
+      "endLine": 143,
+      "summary": "cardinalMk_algebraicClosure_type_eq_max: #(AlgebraicClosure K) = max(#K, ℵ₀) for Mathlib's absolute construction — the special case L = AlgebraicClosure K, proved by the same three-step argument (Mathlib upper bound, algebraMap embedding, infinitude)."
+    },
+    {
+      "id": "examples",
+      "title": "Worked Instances: Both Regimes",
+      "startLine": 145,
+      "endLine": 162,
+      "summary": "The algebraic numbers (ℂ over ℚ) number exactly ℵ₀ = max(ℵ₀, ℵ₀) via Cardinal.mkRat; the elements of ℂ algebraic over ℝ number exactly the continuum 𝔠 = max(𝔠, ℵ₀) via Cardinal.mk_real and aleph0_le_continuum — the sharp cardinal form of the parent's countable and uncountable examples."
+    }
+  ],
+  "conclusion": {
+    "summary": "8 machine-checked results, 0 sorries, 0 axioms. For a field extension L/K with L algebraically closed, #{x : L | IsAlgebraic K x} = max(#K, ℵ₀). The algebraic elements are the relative algebraic closure algebraicClosure K L; its cardinality is squeezed between Mathlib's upper bound (Algebra.IsAlgebraic.cardinalMk_le_max) and a matching lower bound assembled from the algebraMap embedding (#K ≤ #A) and the infinitude of an algebraically closed field (ℵ₀ ≤ #A). The absolute form #(AlgebraicClosure K) = max(#K, ℵ₀) follows identically. Worked instances give exactly ℵ₀ over ℚ and exactly 𝔠 over ℝ.",
+    "implications": "The result upgrades the parent's countable/uncountable dichotomy to a single exact cardinal formula, with the two regimes recovered as the two branches of the max. It pins down the precise hypothesis under which the formula holds — L algebraically closed — and shows why it is needed (a small L truncates the algebraic set below ℵ₀). The reusable idiom: to turn a one-directional cardinality bound into an equality, supply the reverse bound by embedding the base and exhibiting an infinite subobject, working through the relative algebraic closure so the Mathlib Algebra.IsAlgebraic / IsAlgClosure API is available.",
+    "openQuestions": [
+      "Does an analogous exact cardinal formula hold for the set of TRANSCENDENTAL elements {x : L | ¬ IsAlgebraic K x}, whose size should be governed by #L (the ambient field) rather than #K, giving #{transcendental} = #L when #L > max(#K, ℵ₀)?",
+      "Can the transcendence degree trdeg K L be given an exact cardinal formula in terms of #K and #L, completing the cardinal picture of a field extension alongside the algebraic count established here?",
+      "Does the formula extend beyond algebraically closed L to any L containing a copy of the algebraic closure of K but not itself algebraically closed — i.e. is the sharp hypothesis 'AlgebraicClosure K embeds into L' rather than 'IsAlgClosed L'?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "algebraic-numbers-countable-oq-05-oq-04",
+      "relationship": "parent — proves the sharp countable/uncountable dichotomy (algebraic set countable ↔ base field countable) and poses this open question asking for the exact cardinality; this entry supplies the formula #{x : L | IsAlgebraic K x} = max(#K, ℵ₀) and the lower bound the parent lacked"
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-05",
+      "relationship": "ancestor — proves the real algebraic numbers over ℚ countable via Cantor's 1874 height function"
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "ancestor — the core entry establishing countability of the algebraic numbers over ℚ"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's open question **OQ-05-OQ-04-OQ-01** verbatim: upgrades the parent's coarse countable/uncountable dichotomy to a single **exact cardinal formula**.

For a field extension `L / K` with `L` algebraically closed:
```
#{x : L | IsAlgebraic K x} = max (#K) ℵ₀
```

## The answer

The algebraic elements form the relative algebraic closure `algebraicClosure K L` (an `IntermediateField` whose carrier is exactly the algebraic set, via `mem_algebraicClosure_iff`). Its cardinality is pinned by `le_antisymm`:

- **Upper bound** `#A ≤ max(#K, ℵ₀)`: Mathlib's `Algebra.IsAlgebraic.cardinalMk_le_max` — *the one inequality the open question already had in hand.*
- **Lower bound** `max(#K, ℵ₀) ≤ #A` (new): `#K ≤ #A` by embedding the base field through the injective `algebraMap`; `ℵ₀ ≤ #A` because when `L` is algebraically closed the relative algebraic closure is an *absolute* algebraic closure of `K` (`algebraicClosure.isAlgClosure`), hence itself algebraically closed, hence **infinite**.

The `IsAlgClosed L` hypothesis (the formalization of *'L contains the algebraic closure of K'*) is genuinely necessary: with `L = K` a finite field the algebraic set is just `K`, of finite cardinality, while `max(#K, ℵ₀) = ℵ₀`.

## Both regimes of one formula

- **Countable**: `#{x : ℂ | IsAlgebraic ℚ x} = ℵ₀` (= `max(ℵ₀, ℵ₀)`) — the classical algebraic numbers, as an exact count.
- **Uncountable**: `#{x : ℂ | IsAlgebraic ℝ x} = 𝔠` (= `max(𝔠, ℵ₀)`) — the sharp cardinal form of the parent's obstruction.

Also includes the absolute form `#(AlgebraicClosure K) = max(#K, ℵ₀)`.

## Verification

- **8 declarations** (7 theorems + 1 instance), 0 defs, 165 lines
- **0 sorries, 0 axioms** — `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`
- Typechecks against Mathlib via `lake env lean`
- New gallery entry: `src/data/proofs/algebraic-numbers-countable-oq-05-oq-04-oq-01/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)