### PR TITLE
Enrich General-Cubic Discriminant (solution-of-cubic-oq-01-oq-01): 4→7 annotations, full coverage

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-soc-oq0101-overview",
+    "proofId": "solution-of-cubic-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 52 },
+    "type": "context",
+    "title": "The Open Question: The General Cubic's Discriminant",
+    "content": "The parent proved the Tschirnhaus shift x = t − b/(3a) depresses a x³ + b x² + c x + d to a(t³ + p t + q), and left open formalizing the discriminant of the general cubic and relating it to the depressed one. This file defines Δ(a,b,c,d) = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² and proves the headline Δ = a⁴·(−4p³ − 27q²): the discriminant scales by a^(2n−2) = a⁴ under a leading factor and is invariant under the translation. It then bridges to the parent's Cardano radicand (Δ = −108·a⁴·Δ_C), shows Δ = 0 characterises repeated roots, and gives the symmetric root form a⁴·∏(xᵢ−xⱼ)². Everything is over ℂ and 0-axiom.",
+    "mathContext": "$\\Delta(a,b,c,d) = a^{4}(-4p^{3}-27q^{2}) = -108\\,a^{4}\\Delta_{C} = a^{4}\\!\\!\\prod_{i<j}(x_i-x_j)^{2}$",
+    "significance": "context",
+    "relatedConcepts": ["cubic discriminant", "Tschirnhaus transformation", "Cardano's formula", "repeated roots"],
+    "prerequisites": ["general and depressed cubics", "the parent's shift parameters p, q"]
+  },
+  {
+    "id": "ann-soc-oq0101-defs",
+    "proofId": "solution-of-cubic-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 70 },
+    "type": "definition",
+    "title": "The Two Discriminants, as Polynomials in the Coefficients",
+    "content": "generalDiscriminant a b c d = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² is the discriminant of the general cubic, a polynomial in its four coefficients. depressedDisc p q = −4p³ − 27q² is the standard (monic) discriminant of the depressed cubic t³ + p t + q. The whole file relates the two: the shift identity ties Δ to a⁴·depressedDisc, and depressedDisc is in turn −108× the parent's Cardano radicand q²/4 + p³/27. Crucially both are ordinary polynomials — no roots and no radicals appear — so every downstream identity reduces to a ring or field computation.",
+    "mathContext": "$\\Delta = 18abcd - 4b^{3}d + b^{2}c^{2} - 4ac^{3} - 27a^{2}d^{2}$;\\quad $\\operatorname{disc}(t^{3}+pt+q) = -4p^{3} - 27q^{2}$",
+    "significance": "supporting",
+    "relatedConcepts": ["discriminant of a polynomial", "cubic coefficients", "depressed cubic", "symmetric functions of roots"],
+    "prerequisites": ["polynomials over ℂ", "coefficients of a cubic"]
+  },
+  {
     "id": "ann-soc-oq0101-shift",
     "proofId": "solution-of-cubic-oq-01-oq-01",
     "range": { "startLine": 85, "endLine": 90 },
@@ -46,5 +70,17 @@
     "significance": "key",
     "relatedConcepts": ["Vieta's formulas", "symmetric polynomials", "discriminant as squared Vandermonde", "repeated roots"],
     "prerequisites": ["Vieta root-coefficient relations", "sq_eq_zero_iff over ℂ"]
+  },
+  {
+    "id": "ann-soc-oq0101-sanity",
+    "proofId": "solution-of-cubic-oq-01-oq-01",
+    "range": { "startLine": 180, "endLine": 192 },
+    "type": "context",
+    "title": "Sanity Checks: Depressed Case and Worked Examples",
+    "content": "Three decidable checks anchor the abstract identities. With a = 1, b = 0 the cubic is already depressed, so Δ reduces to −4c³ − 27d² (pure ring). The parent's worked example t³ − 6t − 40 (root t = 4) has Δ = 864 − 43200 = −42336 ≠ 0, confirming its roots are distinct (norm_num). The perfect cube (x − 2)³ = x³ − 6x² + 12x − 8 has Δ = 0, matching its triple root. Each evaluates the polynomial Δ numerically and needs nothing beyond unfolding and norm_num — a concrete cross-check of the symbolic theorems above.",
+    "mathContext": "$\\Delta(1,0,-6,-40) = -42336 \\neq 0$;\\quad $\\Delta(1,-6,12,-8) = 0$",
+    "significance": "context",
+    "relatedConcepts": ["worked example", "norm_num", "repeated roots", "depressed cubic"],
+    "prerequisites": ["evaluating polynomials at numeric coefficients", "norm_num"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-01-oq-01` (Discriminant of the General Cubic and its invariance under the Tschirnhaus shift).

Shipped with 4 rich annotations covering ~31% of the 201-line file. This pass annotates the remaining major declarations, 4→7, all validating against the canonical Lean source (7 valid, 0 misaligned).

**Added:**
- **Overview / OQ** (lines 4–52, context): the parent's shift and this file's discriminant answer Δ = a⁴(−4p³−27q²) = −108a⁴Δ_C = a⁴∏(xᵢ−xⱼ)².
- **Definitions** (62–70, definition): `generalDiscriminant` and `depressedDisc` as polynomials in the coefficients.
- **Sanity checks** (180–192, context): the depressed reduction and the t³−6t−40 / (x−2)³ worked examples.

All existing annotations preserved byte-for-byte. No meta.json change.