### PR TITLE
Fix: realign angle-trisection-oq-02-oq-04-oq-01 leanFile counts (364→428L, 12→14thm)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -50,7 +50,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 364,
+    "lineCount": 428,
     "assumptions": "2 sorries: galois_two_group_implies_tower (~500 lines, Galois correspondence glue) and tower_implies_galois_two_group (~300 lines, splitting field degree). Newly proved this session: sqrt2_constructible_tower (concrete witness ℚ⟮√2⟯ is a height-1 quadratic tower containing √2; uses Sqrt2Minpoly.adjoin_sqrt_two_finrank + finrank tower formula). Companion Aristotle file now sorry-free (delegates to main).",
     "originalContributions": [
       "Proper inductive definition of QuadraticTower replacing the alias TowerCriterion = DegreeCriterion",
@@ -59,7 +59,7 @@
       "Proof that tower degree = 2^n by structural induction (modulo finrank multiplicativity)",
       "Key 2-group lemmas: existence of index-2 subgroups, trivial characterization"
     ],
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 1
   },
   "references": [
@@ -210,9 +210,9 @@
       "FiniteDimensional"
     ],
     "namespace": "AngleTrisectionOQ02OQ04OQ01",
-    "lineCount": 364,
+    "lineCount": 428,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Realign stale `lineCount` and `theoremCount` in `meta.json` to match the current Lean source.

## Evidence

The Lean file `Proofs/AngleTrisectionOQ02OQ04OQ01.lean` was reworked (Mathlib-drift repair plus two newly-proved theorems — `tower_ideg_pow_two` and `quadratic_tower_height_unique`), but `meta.json` was never updated.

**Before**: `lineCount: 364`, `theoremCount: 12` (in both the `meta` and `leanFile` blocks)
**After**: `lineCount: 428`, `theoremCount: 14`

Verified against the file on `main`:
- lines: **428**
- `theorem`/`lemma` decls: **14**
- `def`/`abbrev`: 1 (unchanged, correct)
- `axiom`: 0 (unchanged, correct)
- real sorries (comments stripped): 2 (unchanged, correct)

Integrity fields (`axiomCount: 0`, `sorries: 2`, `status: formalized`) are already accurate and left untouched.

---
Automated fix by lean-mechanic agent.