### PR TITLE
research(alternating-series-boole-summation-oq-01-oq-02): sharp two-sided remainder estimates [VERIFIED, 0-axiom, 7thm/146L]

### DIFF
--- a/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ02.lean
+++ b/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ02.lean
@@ -1,0 +1,146 @@
+/-
+# Alternating-Series Boole Summation — OQ-01-OQ-02
+## Sharp two-sided remainder estimates for the convergent tail
+
+The parent entry (`AlternatingSeriesBooleSummationOQ01.lean`) passes the finite Boole
+identity to the limit `m → ∞`, showing that for an antitone null sequence `a` the
+alternating partial sums `altSum a 0 m = ∑_{j<m} (-1)^j a_j` converge to some `L`.
+It leaves the *quantitative* question open: how far is the `m`-th partial sum from `L`?
+
+This entry answers that with the classical **sharp alternating-series remainder bound**
+
+  `|L − altSum a 0 m| ≤ a_m`   for every `m`,
+
+together with the two-sided bracketing that makes it sharp: consecutive partial sums lie
+on opposite sides of `L` (`partial_bracket`), so `L` is trapped between `altSum a 0 m`
+and `altSum a 0 (m+1)`, and the gap between those is exactly `a_m`. Specializing to
+`m = 0` gives the whole-series localization `L ∈ [0, a_0]` (`sum_mem_Icc`).
+
+## The argument
+
+Mathlib's alternating-series test supplies the *one-sided* bracketing for the series
+from `0`: even partial sums are `≤ L` (`Antitone.alternating_series_le_tendsto`) and odd
+partial sums are `≥ L` (`Antitone.tendsto_le_alternating_series`). Splitting `m` into even
+and odd and using the successor identity `altSum a 0 (m+1) = altSum a 0 m + (-1)^m a_m`
+(the parent's `altSum_succ`) turns each one-sided bound into a two-sided sandwich of width
+`a_m`, from which `|L − altSum a 0 m| ≤ a_m` follows. Antitonicity together with `a → 0`
+also forces `a_m ≥ 0`, which is what makes the bound an honest absolute-value estimate.
+
+## What Mathlib has — and what this adds
+
+Mathlib has the convergence test and the even/odd one-sided bracketing. This entry
+combines them into the single sharp remainder bound `|L − Sₘ| ≤ aₘ`, the alternating
+bracketing `(Sₘ − L)(Sₘ₊₁ − L) ≤ 0`, and the localization `L ∈ [0, a₀]` — the concrete
+error control that the parent's qualitative convergence statement leaves open.
+
+**Sorry count**: 0. **Axiom count**: 0 (only Lean/Mathlib foundational axioms).
+-/
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecificLimits.Normed
+import Proofs.AlternatingSeriesBooleSummationOQ01
+
+namespace AlternatingSeriesBooleSummationOQ01OQ02
+
+open AlternatingSeriesBooleSummationOQ01 Finset Filter Topology
+
+variable {a : ℕ → ℝ}
+
+/-- For an antitone null sequence every term is nonnegative: each `a m` bounds the tail,
+which tends to `0`. -/
+theorem term_nonneg (ha : Antitone a) (ha0 : Tendsto a atTop (𝓝 0)) (m : ℕ) :
+    0 ≤ a m := by
+  refine le_of_tendsto ha0 ?_
+  filter_upwards [eventually_ge_atTop m] with j hj
+  exact ha hj
+
+/-- `altSum a 0 m` is Mathlib's `range`-form alternating partial sum. -/
+theorem altSum_eq_range (m : ℕ) :
+    altSum a 0 m = ∑ i ∈ range m, (-1 : ℝ) ^ i * a i := by
+  rw [altSum, Finset.range_eq_Ico]
+
+/-- Even partial sums lie below the limit: `altSum a 0 (2k) ≤ L`. -/
+theorem even_partial_le (ha : Antitone a) {L : ℝ}
+    (hL : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L)) (k : ℕ) :
+    altSum a 0 (2 * k) ≤ L := by
+  have hL' : Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i * a i) atTop (𝓝 L) := by
+    simpa [altSum_eq_range] using hL
+  rw [altSum_eq_range]
+  exact ha.alternating_series_le_tendsto hL' k
+
+/-- Odd partial sums lie above the limit: `L ≤ altSum a 0 (2k+1)`. -/
+theorem le_odd_partial (ha : Antitone a) {L : ℝ}
+    (hL : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L)) (k : ℕ) :
+    L ≤ altSum a 0 (2 * k + 1) := by
+  have hL' : Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i * a i) atTop (𝓝 L) := by
+    simpa [altSum_eq_range] using hL
+  rw [altSum_eq_range]
+  exact ha.tendsto_le_alternating_series hL' k
+
+/-- **Sharp alternating-series remainder bound.**  For an antitone null sequence with
+alternating sum `L`, the `m`-th partial sum approximates `L` to within the `m`-th term:
+`|L − altSum a 0 m| ≤ a_m`.  This is the best possible bound: the error is squeezed
+between `0` and `a_m` by the bracketing of consecutive partial sums. -/
+theorem remainder_bound (ha : Antitone a) (ha0 : Tendsto a atTop (𝓝 0)) {L : ℝ}
+    (hL : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L)) (m : ℕ) :
+    |L - altSum a 0 m| ≤ a m := by
+  rcases Nat.even_or_odd m with ⟨k, hk⟩ | ⟨k, hk⟩
+  · -- m = 2k : altSum ≤ L ≤ altSum + a m
+    have hkk : m = 2 * k := by omega
+    subst hkk
+    have h1 : altSum a 0 (2 * k) ≤ L := even_partial_le ha hL k
+    have h2 : L ≤ altSum a 0 (2 * k + 1) := le_odd_partial ha hL k
+    have hs : altSum a 0 (2 * k + 1) = altSum a 0 (2 * k) + a (2 * k) := by
+      rw [altSum_succ a (Nat.zero_le _), pow_mul]; norm_num
+    rw [hs] at h2
+    have hnn : 0 ≤ a (2 * k) := term_nonneg ha ha0 (2 * k)
+    rw [abs_le]; constructor <;> linarith
+  · -- m = 2k+1 : altSum - a m ≤ L ≤ altSum
+    have hkk : m = 2 * k + 1 := by omega
+    subst hkk
+    have h2 : L ≤ altSum a 0 (2 * k + 1) := le_odd_partial ha hL k
+    have h1 : altSum a 0 (2 * k + 1 + 1) ≤ L := by
+      have := even_partial_le ha hL (k + 1)
+      rwa [(by ring : 2 * (k + 1) = 2 * k + 1 + 1)] at this
+    have hs : altSum a 0 (2 * k + 1 + 1) = altSum a 0 (2 * k + 1) - a (2 * k + 1) := by
+      have hp : ((-1 : ℝ) ^ (2 * k + 1)) = -1 := by rw [pow_succ, pow_mul]; norm_num
+      rw [altSum_succ a (Nat.zero_le _), hp]; ring
+    rw [hs] at h1
+    have hnn : 0 ≤ a (2 * k + 1) := term_nonneg ha ha0 (2 * k + 1)
+    rw [abs_le]; constructor <;> linarith
+
+/-- **Two-sided bracketing.**  Consecutive partial sums straddle the limit: the products
+`(altSum a 0 m − L)` and `(altSum a 0 (m+1) − L)` have opposite signs (their product is
+`≤ 0`).  This is what makes the remainder bound sharp — `L` is trapped in the interval
+whose endpoints are consecutive partial sums, of width `a_m`. -/
+theorem partial_bracket (ha : Antitone a) {L : ℝ}
+    (hL : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L)) (m : ℕ) :
+    (altSum a 0 m - L) * (altSum a 0 (m + 1) - L) ≤ 0 := by
+  rcases Nat.even_or_odd m with ⟨k, hk⟩ | ⟨k, hk⟩
+  · have hkk : m = 2 * k := by omega
+    subst hkk
+    have h1 : altSum a 0 (2 * k) ≤ L := even_partial_le ha hL k
+    have h2 : L ≤ altSum a 0 (2 * k + 1) := le_odd_partial ha hL k
+    exact mul_nonpos_iff.mpr (Or.inr ⟨by linarith, by linarith⟩)
+  · have hkk : m = 2 * k + 1 := by omega
+    subst hkk
+    have h2 : L ≤ altSum a 0 (2 * k + 1) := le_odd_partial ha hL k
+    have h1 : altSum a 0 (2 * k + 1 + 1) ≤ L := by
+      have := even_partial_le ha hL (k + 1)
+      rwa [(by ring : 2 * (k + 1) = 2 * k + 1 + 1)] at this
+    exact mul_nonpos_iff.mpr (Or.inl ⟨by linarith, by linarith⟩)
+
+/-- **Localization of the full alternating sum.**  Taking `m = 0` in the remainder bound
+(where `altSum a 0 0 = 0`) traps the whole alternating series in `[0, a_0]`. -/
+theorem sum_mem_Icc (ha : Antitone a) {L : ℝ}
+    (hL : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L)) :
+    L ∈ Set.Icc (0 : ℝ) (a 0) := by
+  have h0 : altSum a 0 0 = 0 := by simp [altSum]
+  have hlow : altSum a 0 (2 * 0) ≤ L := even_partial_le ha hL 0
+  have hup : L ≤ altSum a 0 (2 * 0 + 1) := le_odd_partial ha hL 0
+  have hup' : altSum a 0 (2 * 0 + 1) = a 0 := by
+    rw [altSum_succ a (Nat.zero_le _), h0]; norm_num
+  rw [show 2 * 0 = 0 from rfl, h0] at hlow
+  rw [hup'] at hup
+  exact ⟨hlow, hup⟩
+
+end AlternatingSeriesBooleSummationOQ01OQ02

--- a/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "alternating-series-boole-summation-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "Sharp remainder bound and its bracketing",
+    "content": "The header recalls the parent's qualitative convergence of the alternating partial sums altSum a 0 m → L and states the quantitative gap it leaves open. The deliverables: the sharp remainder bound |L − altSum a 0 m| ≤ a_m (error never exceeds the first omitted term), the bracketing (S_m − L)(S_{m+1} − L) ≤ 0 that makes it sharp, and the localization L ∈ [0, a_0]. The strategy splits m by parity over Mathlib's one-sided brackets; nonnegativity of the terms is derived from antitonicity plus a → 0.",
+    "mathContext": "$|L - S_m| \\le a_m$, $L$ trapped between $S_m$ and $S_{m+1}$ of gap $a_m$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "alternating series (Leibniz) criterion",
+      "remainder / truncation error",
+      "Boole summation (parent)",
+      "conditional convergence"
+    ],
+    "prerequisites": [
+      "convergence of alternating partial sums (parent entry)",
+      "antitone null sequence"
+    ]
+  },
+  {
+    "id": "ann-term-nonneg",
+    "proofId": "alternating-series-boole-summation-oq-01-oq-02",
+    "range": {
+      "startLine": 48,
+      "endLine": 54
+    },
+    "type": "insight",
+    "title": "Antitone null sequences are nonnegative",
+    "content": "term_nonneg shows 0 ≤ a m for every m: for j ≥ m antitonicity gives a j ≤ a m, and since a j → 0, le_of_tendsto yields 0 ≤ a m. This is not an assumption but a consequence of the hypotheses, and it is exactly what makes the remainder bound |L − S_m| ≤ a_m an honest absolute-value estimate rather than a one-sided inequality.",
+    "mathContext": "$a_j \\le a_m$ for $j \\ge m$ and $a_j \\to 0 \\Rightarrow 0 \\le a_m$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Antitone",
+      "le_of_tendsto",
+      "order limits"
+    ],
+    "prerequisites": [
+      "limits of monotone sequences",
+      "eventually_ge_atTop"
+    ]
+  },
+  {
+    "id": "ann-one-sided",
+    "proofId": "alternating-series-boole-summation-oq-01-oq-02",
+    "range": {
+      "startLine": 61,
+      "endLine": 77
+    },
+    "type": "insight",
+    "title": "Even/odd one-sided brackets",
+    "content": "altSum_eq_range identifies the parent's altSum a 0 m with Mathlib's range-form ∑_{i<m} (-1)^i a i. even_partial_le and le_odd_partial then transport Mathlib's alternating-series brackets: even partial sums lie below the limit (Antitone.alternating_series_le_tendsto: S_{2k} ≤ L) and odd partial sums lie above it (Antitone.tendsto_le_alternating_series: L ≤ S_{2k+1}). These two one-sided inequalities are all Mathlib supplies; the parity split combines them.",
+    "mathContext": "$S_{2k} \\le L \\le S_{2k+1}$.",
+    "significance": "major",
+    "relatedConcepts": [
+      "Antitone.alternating_series_le_tendsto",
+      "Antitone.tendsto_le_alternating_series",
+      "range vs Ico partial sums"
+    ],
+    "prerequisites": [
+      "Mathlib alternating-series test",
+      "monotone subsequences of partial sums"
+    ]
+  },
+  {
+    "id": "ann-remainder-bound",
+    "proofId": "alternating-series-boole-summation-oq-01-oq-02",
+    "range": {
+      "startLine": 79,
+      "endLine": 108
+    },
+    "type": "insight",
+    "title": "The sharp remainder bound",
+    "content": "remainder_bound is the headline estimate |L − altSum a 0 m| ≤ a_m. Casing on m even or odd and using the successor identity altSum_succ with (-1)^{2k} = 1 and (-1)^{2k+1} = -1: the even case gives L − S_m ∈ [0, a_m] and the odd case gives S_m − L ∈ [0, a_m]. term_nonneg supplies a_m ≥ 0, and abs_le + linarith close both branches. No new limit argument is needed beyond the parent's convergence.",
+    "mathContext": "$|L - S_m| \\le a_m$ for all $m$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Leibniz remainder estimate",
+      "parity case analysis",
+      "abs_le"
+    ],
+    "prerequisites": [
+      "altSum_succ (parent)",
+      "even/odd brackets",
+      "term_nonneg"
+    ]
+  },
+  {
+    "id": "ann-bracket-localization",
+    "proofId": "alternating-series-boole-summation-oq-01-oq-02",
+    "range": {
+      "startLine": 109,
+      "endLine": 142
+    },
+    "type": "insight",
+    "title": "Bracketing sharpness and [0, a₀] localization",
+    "content": "partial_bracket packages the sandwich as (altSum a 0 m − L)(altSum a 0 (m+1) − L) ≤ 0 via mul_nonpos_iff, showing consecutive partial sums straddle L — this is the sharpness statement, since the two endpoints differ by exactly a_m. sum_mem_Icc specializes the k = 0 brackets (S_0 = 0, S_1 = a_0) to localize the entire alternating series in the interval [0, a_0].",
+    "mathContext": "$(S_m - L)(S_{m+1} - L) \\le 0$; $\\;L \\in [0, a_0]$.",
+    "significance": "major",
+    "relatedConcepts": [
+      "mul_nonpos_iff",
+      "interval localization",
+      "sharpness of the bound"
+    ],
+    "prerequisites": [
+      "sign of a product",
+      "even/odd brackets at k = 0"
+    ]
+  }
+]

--- a/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "alternating-series-boole-summation-oq-01-oq-02",
+  "title": "Sharp Two-Sided Remainder Estimates for Alternating Series",
+  "slug": "alternating-series-boole-summation-oq-01-oq-02",
+  "description": "The parent entry passes the finite Boole summation identity to the limit m → ∞, showing that for an antitone null sequence a the alternating partial sums altSum a 0 m = ∑_{j<m} (-1)^j a_j converge to some L, but leaves the quantitative question open: how far is the m-th partial sum from L? This entry supplies the classical sharp alternating-series remainder bound |L − altSum a 0 m| ≤ a_m for every m, together with the two-sided bracketing that makes it sharp: consecutive partial sums lie on opposite sides of L (partial_bracket: (S_m − L)(S_{m+1} − L) ≤ 0), so L is trapped between altSum a 0 m and altSum a 0 (m+1), whose gap is exactly a_m. Specializing to m = 0 (where altSum a 0 0 = 0) localizes the whole series to L ∈ [0, a_0] (sum_mem_Icc). The proof combines Mathlib's one-sided bracketing from the alternating-series test — even partial sums ≤ L (Antitone.alternating_series_le_tendsto) and odd partial sums ≥ L (Antitone.tendsto_le_alternating_series) — with the parent's successor identity altSum_succ, splitting m into even and odd to turn each one-sided bound into a two-sided sandwich of width a_m. Antitonicity together with a → 0 forces a_m ≥ 0 (term_nonneg), which is what makes the estimate an honest absolute-value bound. This answers the parent's open question of pinning down the limit S = ½(-1)^n a_n − ½T with sharp two-sided error control.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Proofs.AlternatingSeriesBooleSummationOQ01"
+    ],
+    "opens": [
+      "AlternatingSeriesBooleSummationOQ01",
+      "Finset",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "AlternatingSeriesBooleSummationOQ01OQ02",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/AlternatingSeriesBooleSummationOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Alternating_series#Alternating_series_test",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlternatingSeriesBooleSummationOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "alternating-series",
+      "boole-summation",
+      "remainder-bound",
+      "error-estimate",
+      "convergence",
+      "leibniz-criterion",
+      "limits"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-01",
+    "relatedProblems": [
+      {
+        "id": "alternating-series-boole-summation-oq-01",
+        "relationship": "Direct parent. That entry passes the finite Boole identity to the limit m → ∞, proving that the alternating partial sums altSum a 0 m of an antitone null sequence converge to some L (altSum_tendsto_of_antitone) and satisfy the limit-form Boole identity S = ½(-1)^n a_n − ½T. It leaves the quantitative rate open. This entry supplies the sharp remainder bound |L − altSum a 0 m| ≤ a_m and the two-sided bracketing, reusing the parent's altSum, altSum_succ, and altSum_tendsto_of_antitone. This directly answers the parent's open question of nailing the limit with sharp two-sided estimates."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 146,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All seven theorems (term_nonneg, altSum_eq_range, even_partial_le, le_odd_partial, remainder_bound, partial_bracket, sum_mem_Icc) were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The results hold over ℝ for any antitone sequence a : ℕ → ℝ with a → 0 (Tendsto a atTop (𝓝 0)) whose alternating partial sums converge to L; convergence itself is guaranteed by the parent's altSum_tendsto_of_antitone (Mathlib's alternating-series test), so the hypotheses are satisfiable and not vacuous. The core one-sided bracketing lemmas are Mathlib's Antitone.alternating_series_le_tendsto and Antitone.tendsto_le_alternating_series (stated for the range-form partial sums); the new content is their combination into the sharp two-sided remainder bound, the alternating bracketing of consecutive partial sums, and the [0, a_0] localization, together with the nonnegativity term_nonneg derived from antitonicity and a → 0. The limit object is the limit of partial sums (Filter.Tendsto), not HasSum/tsum, since alternating series such as ∑ (-1)^j/(j+1) converge conditionally but are not summable.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The alternating-series (Leibniz) criterion is usually stated in two parts: convergence, and the remainder estimate that the truncation error never exceeds the first omitted term. The second part is what makes alternating series so useful numerically — one gets a guaranteed error bound for free at every truncation, with the true value bracketed between consecutive partial sums. In the Boole/Euler–Maclaurin framework of the parent entries the alternating series arises as the m → ∞ limit of a finite summation identity; the qualitative convergence is established there, and the natural next step is the quantitative rate. This entry formalizes exactly that classical remainder estimate and the underlying bracketing.",
+    "problemStatement": "Let a : ℕ → ℝ be antitone with a → 0, and let L be the limit of the alternating partial sums altSum a 0 m = ∑_{j<m} (-1)^j a_j. Prove the sharp remainder bound |L − altSum a 0 m| ≤ a_m for all m, show that consecutive partial sums bracket L (so the bound is sharp), and deduce L ∈ [0, a_0].",
+    "text": "The parent entry (alternating-series-boole-summation-oq-01) establishes that the alternating partial sums of an antitone null sequence converge. This entry adds the quantitative content: an explicit, sharp error bound at every truncation. It reuses the parent's altSum definition and successor identity and Mathlib's alternating-series test to bracket the limit between consecutive partial sums.",
+    "proofStrategy": "term_nonneg first records that an antitone null sequence is nonnegative (each a m dominates the tail, which tends to 0; via le_of_tendsto on the eventual bound a j ≤ a m). altSum_eq_range identifies the parent's altSum a 0 m with Mathlib's range-form ∑_{i<m} (-1)^i a i. even_partial_le and le_odd_partial then transport Mathlib's one-sided brackets — Antitone.alternating_series_le_tendsto (even partials ≤ L) and Antitone.tendsto_le_alternating_series (odd partials ≥ L) — to the altSum form. The main theorem remainder_bound splits m by parity: for m = 2k, altSum a 0 (2k) ≤ L ≤ altSum a 0 (2k+1) = altSum a 0 (2k) + a_{2k} (successor identity altSum_succ with (-1)^{2k} = 1), so the error L − altSum lies in [0, a_{2k}]; for m = 2k+1, altSum a 0 (2k+2) = altSum a 0 (2k+1) − a_{2k+1} ≤ L ≤ altSum a 0 (2k+1), so altSum − L ∈ [0, a_{2k+1}]. In both cases term_nonneg supplies a_m ≥ 0 and the two-sided bound |L − altSum a 0 m| ≤ a_m follows by linarith after abs_le. partial_bracket packages the same sandwich as (altSum a 0 m − L)(altSum a 0 (m+1) − L) ≤ 0 via mul_nonpos_iff, and sum_mem_Icc specializes the even/odd brackets at k = 0 (altSum a 0 0 = 0, altSum a 0 1 = a_0) to locate L in [0, a_0].",
+    "keyInsights": [
+      "**The error never exceeds the first omitted term**: |L − S_m| ≤ a_m is the sharp, classical alternating-series remainder bound. It is what makes alternating series numerically self-certifying — every partial sum comes with a free, tight error estimate equal to the size of the next term.",
+      "**Bracketing is what makes the bound sharp**: even partial sums approach L from below and odd ones from above, so L is trapped between any two consecutive partial sums (partial_bracket). Since those two differ by exactly a_m, the trap has width a_m and the remainder bound cannot be improved.",
+      "**Parity is the whole proof**: Mathlib provides only the two one-sided inequalities (even ≤ L, L ≤ odd). Casing on whether m is even or odd, and using the single successor step altSum a 0 (m+1) = altSum a 0 m + (-1)^m a_m, converts each one-sided bound into the two-sided sandwich. No new limit argument is needed beyond the parent's convergence.",
+      "**Nonnegativity is not free and must be derived**: |L − S_m| ≤ a_m only makes sense with a_m ≥ 0, which is not assumed but follows from antitonicity plus a → 0 (term_nonneg). A decreasing sequence with limit 0 has all terms above its limit, hence nonnegative.",
+      "**Convergence is Tendsto, not HasSum**: the alternating harmonic series converges conditionally but is not summable, so the natural limit object is the limit of partial sums, and the remainder bound is phrased against altSum … atTop rather than a tsum — matching the parent entry's deliberate choice."
+    ],
+    "prerequisites": [
+      "The parent entry's altSum definition, successor identity altSum_succ, and convergence result altSum_tendsto_of_antitone (Proofs/AlternatingSeriesBooleSummationOQ01.lean)",
+      "Mathlib's alternating-series brackets: Antitone.alternating_series_le_tendsto and Antitone.tendsto_le_alternating_series for the range-form partial sums",
+      "Order limits of sequences: le_of_tendsto with eventual bounds, and the abs_le characterization of two-sided estimates",
+      "Sign of a product via mul_nonpos_iff, and parity case analysis Nat.even_or_odd with the evaluation (-1)^{2k} = 1, (-1)^{2k+1} = -1"
+    ]
+  },
+  "sections": [
+    {
+      "id": "statement-and-strategy",
+      "title": "The Sharp Remainder Bound and Its Bracketing",
+      "startLine": 1,
+      "endLine": 37,
+      "mathContext": "$|L - S_m| \\le a_m$, with $L$ trapped between consecutive partial sums $S_m, S_{m+1}$ of width $a_m$.",
+      "summary": "The module docstring recalls the parent's qualitative convergence, states the quantitative gap it leaves open, and gives the deliverables: the sharp remainder bound |L − altSum a 0 m| ≤ a_m, the bracketing that makes it sharp, and the [0, a_0] localization. It describes the parity-splitting strategy over Mathlib's one-sided brackets and notes that nonnegativity of the terms is derived, not assumed."
+    },
+    {
+      "id": "term-nonneg-and-range",
+      "title": "Nonnegativity and the Range Form",
+      "startLine": 48,
+      "endLine": 59,
+      "mathContext": "$0 \\le a_m$ for antitone $a \\to 0$; $\\;\\mathrm{altSum}\\,a\\,0\\,m = \\sum_{i<m} (-1)^i a_i$.",
+      "summary": "term_nonneg proves an antitone null sequence is nonnegative: each a m bounds the tail a j (j ≥ m), which tends to 0, so 0 ≤ a m by le_of_tendsto. altSum_eq_range identifies the parent's altSum a 0 m with Mathlib's range-form partial sum, the shape in which the alternating-series brackets are stated."
+    },
+    {
+      "id": "one-sided-brackets",
+      "title": "Even and Odd One-Sided Brackets",
+      "startLine": 61,
+      "endLine": 77,
+      "mathContext": "$S_{2k} \\le L \\le S_{2k+1}$.",
+      "summary": "even_partial_le and le_odd_partial transport Mathlib's alternating-series brackets to the altSum form: even partial sums lie below the limit L (Antitone.alternating_series_le_tendsto) and odd partial sums lie above it (Antitone.tendsto_le_alternating_series). These are the two one-sided inequalities that the parity split will combine."
+    },
+    {
+      "id": "remainder-bound",
+      "title": "The Sharp Remainder Bound",
+      "startLine": 79,
+      "endLine": 108,
+      "mathContext": "$|L - S_m| \\le a_m$.",
+      "summary": "remainder_bound is the headline estimate. Splitting m by parity and using the successor identity altSum_succ (with (-1)^{2k} = 1, (-1)^{2k+1} = -1), the even case gives L − S_m ∈ [0, a_m] and the odd case gives S_m − L ∈ [0, a_m]; term_nonneg supplies a_m ≥ 0 so abs_le and linarith close both to |L − S_m| ≤ a_m."
+    },
+    {
+      "id": "bracket-and-localization",
+      "title": "Bracketing and Localization",
+      "startLine": 109,
+      "endLine": 146,
+      "mathContext": "$(S_m - L)(S_{m+1} - L) \\le 0$; $\\;L \\in [0, a_0]$.",
+      "summary": "partial_bracket packages the sandwich as (S_m − L)(S_{m+1} − L) ≤ 0 via mul_nonpos_iff, showing consecutive partial sums straddle L — the sharpness statement. sum_mem_Icc specializes the k = 0 brackets (S_0 = 0, S_1 = a_0) to localize the full alternating series in [0, a_0]."
+    }
+  ],
+  "conclusion": {
+    "summary": "The classical sharp alternating-series remainder bound is formalized sorry-free and axiom-free: for an antitone null sequence a with alternating sum L, every partial sum satisfies |L − altSum a 0 m| ≤ a_m, consecutive partial sums bracket L (making the bound sharp), and the full series is localized to L ∈ [0, a_0]. Building on the parent's convergence result and Mathlib's one-sided alternating-series brackets, this supplies the quantitative error control the parent left open, answering its open question about pinning the limit with sharp two-sided estimates.",
+    "implications": "The remainder bound turns the parent's qualitative convergence into a usable numerical guarantee: any truncation of an alternating series of an antitone null sequence has error at most the first omitted term, with the true value bracketed between consecutive partial sums. This is the standard tool for certified evaluation of alternating series (e.g. Leibniz's π/4, log 2). The bracketing lemma partial_bracket is also the natural ingredient for monotone-convergence-style arguments about the even and odd subsequences of partial sums.",
+    "openQuestions": [
+      "Sharpen the localization to the strict interior when a is strictly antitone: show L ∈ (altSum a 0 (m+1), altSum a 0 m) (or the reversed open interval) with strict inequalities, quantifying that the remainder bound is attained only in the limit of constant sequences.",
+      "Combine the remainder bound with the parent's limit-form Boole identity S = ½(-1)^n a_n − ½T to obtain an explicit error estimate for the Boole/Euler summation acceleration itself, bounding how fast the accelerated series approaches its limit."
+    ]
+  },
+  "crossReferences": [
+    "alternating-series-boole-summation-oq-01",
+    "alternating-series-boole-summation"
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **open question** posed by the parent entry `alternating-series-boole-summation-oq-01`: pin down the alternating-series limit with **sharp two-sided error control**.

For an antitone null sequence `a` (`Antitone a`, `a → 0`) whose alternating partial sums `altSum a 0 m = ∑_{j<m} (-1)^j a_j` converge to `L`, this entry proves:

- **`remainder_bound`** (headline): `|L − altSum a 0 m| ≤ a_m` — the classical Leibniz estimate: the truncation error never exceeds the first omitted term.
- **`partial_bracket`**: `(S_m − L)(S_{m+1} − L) ≤ 0` — consecutive partial sums straddle `L`, so the bound is **sharp** (the trap has width exactly `a_m`).
- **`sum_mem_Icc`**: `L ∈ [0, a_0]` — localization of the full alternating series.

## Approach

Mathlib supplies only the one-sided brackets (`Antitone.alternating_series_le_tendsto`: even partials ≤ L; `Antitone.tendsto_le_alternating_series`: L ≤ odd partials). Splitting `m` by parity and using the parent's successor identity `altSum_succ` turns each one-sided bound into a two-sided sandwich of width `a_m`. Nonnegativity `a_m ≥ 0` is **derived** from antitonicity + `a → 0` (`term_nonneg`), not assumed. Reuses the parent's `altSum`, `altSum_succ`, and `altSum_tendsto_of_antitone`.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` on all results shows only `propext / Classical.choice / Quot.sound`
- Typechecked against Mathlib 4.26.0 via `lake env lean`
- 7 theorems, 0 definitions, 146 lines
- New gallery entry (meta.json + annotations.json)

## Files
- `proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ02.lean`
- `src/data/proofs/alternating-series-boole-summation-oq-01-oq-02/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)