### PR TITLE
research(derangements-convergence-oq-04-oq-02): combined modulus n(n−1) via CRT [VERIFIED, 0-axiom, 10thm/1def/203L, new entry]

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ04OQ02.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ04OQ02.lean
@@ -1,0 +1,203 @@
+/-
+  Derangements: the combined modulus n(n−1) and its explicit CRT residue
+  Open Question: derangements-convergence-oq-04-oq-02
+  (parent `derangements-convergence-oq-04`, open question 2)
+
+  The parent entry proves two divisibility facts for the derangement numbers
+  `D(n) = numDerangements n`:
+
+    (A)  (n − 1) ∣ D(n)              for n ≥ 2      [additive recurrence]
+    (B)  n ∣ (D(n) − (−1)^n)         for all n      [multiplicative recurrence]
+
+  Its open question asks: *for which n does n(n−1) ∣ (D(n) − c) for an explicit
+  residue c, combining the two facts via CRT?*  Because `n` and `n − 1` are
+  coprime, the Chinese Remainder Theorem fuses (A) and (B) into a single
+  congruence modulo `n(n−1)`.  The key observation is that a **single closed
+  form** solves the CRT system for every parity at once:
+
+    c(n) = (−1)^n · (n − 1)².
+
+  Indeed `(n − 1)² ≡ 0 (mod n−1)` recovers (A) and `(n − 1)² ≡ 1 (mod n)`
+  (as `n − 1 ≡ −1`) recovers (B).  Hence:
+
+  ## Main Result
+
+  `mul_dvd_sub_crt` (PROVED): for all n,
+    (n * (n − 1) : ℤ) ∣ (D(n) − (−1)^n · (n − 1)²).
+
+  Equivalently `D(n) ≡ (−1)^n (n−1)²  (mod n(n−1))`.
+
+  ## Canonical reduced residue
+
+  The closed form `(−1)^n (n−1)²` is not reduced for odd `n` (it is negative).
+  Reducing modulo `n(n−1)` gives the canonical representative
+
+    r(n) = (n − 1)²   if n is even,
+    r(n) = (n − 1)    if n is odd,
+
+  with `0 ≤ r(n) < n(n−1)` for n ≥ 2 (`reduced_residue_lt`), and
+  `D(n) ≡ r(n) (mod n(n−1))` (`numDerangements_sub_reduced_dvd`).
+
+  Sample values (checked below): D(4)=9 ≡ 9 (mod 12), D(5)=44 ≡ 4 (mod 20),
+  D(6)=265 ≡ 25 (mod 30).
+
+  Everything is read off the two standard Mathlib recurrences for
+  `numDerangements`; the proofs are fully machine-checked with no extra axioms.
+-/
+
+import Mathlib
+
+open Nat
+
+namespace DerangementsConvergenceOQ04OQ02
+
+/-! ### The two parent divisibility facts (reproduced, self-contained) -/
+
+/-- Fact (A): for n ≥ 2, `(n − 1)` divides `D(n)`. Read off the additive
+    recurrence `numDerangements_add_two`. -/
+theorem sub_one_dvd_numDerangements (n : ℕ) (hn : 2 ≤ n) :
+    (n - 1) ∣ numDerangements n := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 2 := ⟨n - 2, by omega⟩
+  refine ⟨numDerangements m + numDerangements (m + 1), ?_⟩
+  simpa using numDerangements_add_two m
+
+/-- Fact (B) over ℤ: for all n, `n ∣ (D(n) − (−1)^n)`. Read off the
+    multiplicative recurrence `numDerangements_succ`. -/
+theorem dvd_numDerangements_sub_neg_one_pow (n : ℕ) :
+    (n : ℤ) ∣ ((numDerangements n : ℤ) - (-1) ^ n) := by
+  cases n with
+  | zero => simp
+  | succ k =>
+    refine ⟨numDerangements k, ?_⟩
+    rw [numDerangements_succ k, pow_succ]
+    push_cast
+    ring
+
+/-! ### Coprimality of consecutive integers -/
+
+/-- `n` and `n − 1` are coprime as integers: `1·n + (−1)·(n−1) = 1`. -/
+theorem isCoprime_self_sub_one (n : ℕ) :
+    IsCoprime (n : ℤ) ((n : ℤ) - 1) :=
+  ⟨1, -1, by ring⟩
+
+/-! ### The combined modulus via CRT -/
+
+/-- The `(n−1)`-component divisibility of the CRT residue `(−1)^n (n−1)²`. -/
+private theorem sub_one_dvd_shift (n : ℕ) :
+    ((n : ℤ) - 1) ∣ ((numDerangements n : ℤ) - (-1) ^ n * ((n : ℤ) - 1) ^ 2) := by
+  -- (n−1) ∣ (−1)^n (n−1)² always; (n−1) ∣ D(n) for n ≥ 2 (fact A).
+  have hsq : ((n : ℤ) - 1) ∣ (-1) ^ n * ((n : ℤ) - 1) ^ 2 :=
+    (dvd_pow_self ((n : ℤ) - 1) (by norm_num : (2 : ℕ) ≠ 0)).mul_left _
+  rcases Nat.lt_or_ge n 2 with h | h
+  · -- n = 0 or 1: evaluate directly
+    interval_cases n <;> simp [numDerangements_zero, numDerangements_one]
+  · have hnat := sub_one_dvd_numDerangements n h
+    have hA : ((n : ℤ) - 1) ∣ (numDerangements n : ℤ) := by
+      have hc := Int.natCast_dvd_natCast.mpr hnat
+      rwa [Nat.cast_sub (by omega : 1 ≤ n), Nat.cast_one] at hc
+    exact dvd_sub hA hsq
+
+/-- The `n`-component divisibility of the CRT residue `(−1)^n (n−1)²`. -/
+private theorem cast_dvd_shift (n : ℕ) :
+    (n : ℤ) ∣ ((numDerangements n : ℤ) - (-1) ^ n * ((n : ℤ) - 1) ^ 2) := by
+  -- D(n) − (−1)^n (n−1)² = (D(n) − (−1)^n) + (−1)^n · (1 − (n−1)²),
+  -- and 1 − (n−1)² = n(2 − n), so n divides both summands.
+  have hB := dvd_numDerangements_sub_neg_one_pow n
+  have hterm : (n : ℤ) ∣ (-1) ^ n * (1 - ((n : ℤ) - 1) ^ 2) := by
+    refine Dvd.dvd.mul_left ?_ _
+    exact ⟨2 - (n : ℤ), by ring⟩
+  have := dvd_add hB hterm
+  have hrw : ((numDerangements n : ℤ) - (-1) ^ n)
+      + (-1) ^ n * (1 - ((n : ℤ) - 1) ^ 2)
+      = (numDerangements n : ℤ) - (-1) ^ n * ((n : ℤ) - 1) ^ 2 := by ring
+  rwa [hrw] at this
+
+/-- **Main result (CRT combination).** For every `n`,
+    `n(n−1)` divides `D(n) − (−1)^n (n−1)²`.  Equivalently
+    `D(n) ≡ (−1)^n (n−1)²  (mod n(n−1))`.
+
+    Proof: `n − 1 ∣ ·` is fact (A) plus `n−1 ∣ (n−1)²`; `n ∣ ·` is fact (B)
+    plus `(n−1)² ≡ 1 (mod n)`. Since `n` and `n−1` are coprime, their product
+    divides the common multiple. -/
+theorem mul_dvd_sub_crt (n : ℕ) :
+    ((n : ℤ) * ((n : ℤ) - 1)) ∣
+      ((numDerangements n : ℤ) - (-1) ^ n * ((n : ℤ) - 1) ^ 2) :=
+  (isCoprime_self_sub_one n).mul_dvd (cast_dvd_shift n) (sub_one_dvd_shift n)
+
+/-- Restatement of the main result as a `ZMod` equality over the combined
+    modulus `n(n−1)`:  `D(n) = (−1)^n (n−1)²` in `ℤ/n(n−1)ℤ`. -/
+theorem numDerangements_zmod_mul_eq (n : ℕ) :
+    (numDerangements n : ZMod (n * (n - 1)))
+      = (-1) ^ n * ((n : ZMod (n * (n - 1))) - 1) ^ 2 := by
+  have h := mul_dvd_sub_crt n
+  have hz : ((n : ℤ) * ((n : ℤ) - 1)) = (((n * (n - 1) : ℕ)) : ℤ) := by
+    rcases n with _ | k
+    · simp
+    · push_cast [Nat.succ_sub_one]; ring
+  rw [hz] at h
+  have := (ZMod.intCast_zmod_eq_zero_iff_dvd _ (n * (n - 1))).mpr h
+  push_cast at this
+  linear_combination this
+
+/-! ### Canonical reduced residue -/
+
+/-- The canonical representative of `D(n) mod n(n−1)`:
+    `(n−1)²` for even `n`, `(n−1)` for odd `n`. -/
+def reducedResidue (n : ℕ) : ℤ :=
+  if Even n then ((n : ℤ) - 1) ^ 2 else ((n : ℤ) - 1)
+
+/-- For `n ≥ 2` the canonical residue lies in the fundamental domain
+    `0 ≤ r(n) < n(n−1)`. -/
+theorem reduced_residue_lt (n : ℕ) (hn : 2 ≤ n) :
+    0 ≤ reducedResidue n ∧ reducedResidue n < (n : ℤ) * ((n : ℤ) - 1) := by
+  have h1 : (1 : ℤ) ≤ (n : ℤ) - 1 := by
+    have : (2 : ℤ) ≤ (n : ℤ) := by exact_mod_cast hn
+    linarith
+  unfold reducedResidue
+  by_cases he : Even n
+  · simp only [he, if_true]
+    refine ⟨by positivity, ?_⟩
+    nlinarith [h1]
+  · simp only [he, if_false]
+    exact ⟨by linarith, by nlinarith [h1]⟩
+
+/-- The closed form `(−1)^n (n−1)²` agrees with the reduced residue modulo
+    `n(n−1)`. -/
+theorem closedForm_sub_reduced_dvd (n : ℕ) :
+    ((n : ℤ) * ((n : ℤ) - 1)) ∣
+      ((-1) ^ n * ((n : ℤ) - 1) ^ 2 - reducedResidue n) := by
+  rw [reducedResidue]
+  by_cases he : Even n
+  · simp only [if_pos he, he.neg_one_pow, one_mul, sub_self]
+    exact dvd_zero _
+  · have hodd : Odd n := Nat.not_even_iff_odd.mp he
+    simp only [if_neg he, hodd.neg_one_pow]
+    -- −(n−1)² − (n−1) = −(n−1)·n
+    exact ⟨-(1 : ℤ), by ring⟩
+
+/-- **Canonical congruence.** `D(n) ≡ r(n)  (mod n(n−1))`, where `r(n)` is the
+    reduced residue `(n−1)²` (n even) or `(n−1)` (n odd). -/
+theorem numDerangements_sub_reduced_dvd (n : ℕ) :
+    ((n : ℤ) * ((n : ℤ) - 1)) ∣ ((numDerangements n : ℤ) - reducedResidue n) := by
+  have h1 := mul_dvd_sub_crt n
+  have h2 := closedForm_sub_reduced_dvd n
+  have := dvd_add h1 h2
+  have hrw : ((numDerangements n : ℤ) - (-1) ^ n * ((n : ℤ) - 1) ^ 2)
+      + ((-1) ^ n * ((n : ℤ) - 1) ^ 2 - reducedResidue n)
+      = (numDerangements n : ℤ) - reducedResidue n := by ring
+  rwa [hrw] at this
+
+/-! ### Concrete sanity checks -/
+
+-- D(2)=1, modulus 2·1=2, residue 1²=1 (even): 2 ∣ (1 − 1).
+example : ((2 : ℤ) * (2 - 1)) ∣ ((numDerangements 2 : ℤ) - (-1) ^ 2 * ((2 : ℤ) - 1) ^ 2) :=
+  mul_dvd_sub_crt 2
+-- D(5)=44, modulus 20, closed form (−1)^5·16 = −16, 44 − (−16) = 60 = 3·20.
+example : numDerangements 5 = 44 := by decide
+example : ((numDerangements 5 : ℤ) - (-1) ^ 5 * ((5 : ℤ) - 1) ^ 2) = 60 := by decide
+-- D(6)=265, modulus 30, reduced residue (even) 5²=25, 265 − 25 = 240 = 8·30.
+example : numDerangements 6 = 265 := by decide
+example : reducedResidue 6 = 25 := by decide
+example : reducedResidue 5 = 4 := by decide
+
+end DerangementsConvergenceOQ04OQ02

--- a/src/data/proofs/derangements-convergence-oq-04-oq-02/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-04-oq-02/meta.json
@@ -1,0 +1,200 @@
+{
+  "id": "derangements-convergence-oq-04-oq-02",
+  "title": "The combined modulus n(n−1) for derangements",
+  "slug": "derangements-convergence-oq-04-oq-02",
+  "description": "Fuses the two divisibility facts of the parent entry — (n−1) ∣ D(n) and n ∣ (D(n) − (−1)^n) — into a single congruence modulo n(n−1), using that n and n−1 are coprime (CRT). The key observation is that one closed form solves the CRT system for every parity simultaneously: D(n) ≡ (−1)^n·(n−1)² (mod n(n−1)), because (n−1)² ≡ 0 (mod n−1) and (n−1)² ≡ 1 (mod n). Reducing to the fundamental domain 0 ≤ r < n(n−1) gives the canonical residue r(n) = (n−1)² for even n and r(n) = n−1 for odd n.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ04OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "divisibility",
+      "chinese-remainder-theorem",
+      "congruence",
+      "number-theory",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. All theorems are fully machine-checked. The two component divisibilities are reproduced self-contained from Mathlib's numDerangements_add_two (additive recurrence, giving (n−1) ∣ D(n)) and numDerangements_succ (multiplicative recurrence, giving n ∣ (D(n) − (−1)^n)). The CRT fusion uses IsCoprime.mul_dvd on the coprime pair (n, n−1). Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms).",
+    "dateAdded": "2026-07-01",
+    "lineCount": 203,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "originalContributions": [
+      "mul_dvd_sub_crt (PROVED, MAIN): for all n, (n·(n−1) : ℤ) ∣ (D(n) − (−1)^n·(n−1)²), i.e. D(n) ≡ (−1)^n·(n−1)² (mod n(n−1)) — the CRT fusion of the parent's two divisibility facts with a single parity-independent residue",
+      "numDerangements_zmod_mul_eq (PROVED): the ZMod restatement (D(n) : ZMod (n(n−1))) = (−1)^n·((n : ZMod (n(n−1))) − 1)²",
+      "reducedResidue (DEF): the canonical residue r(n) = (n−1)² if n even, (n−1) if n odd",
+      "reduced_residue_lt (PROVED): for n ≥ 2, 0 ≤ r(n) < n(n−1) — r(n) is the representative in the fundamental domain",
+      "numDerangements_sub_reduced_dvd (PROVED): D(n) ≡ r(n) (mod n(n−1)) with the reduced residue",
+      "isCoprime_self_sub_one (PROVED, helper): IsCoprime (n : ℤ) (n − 1) via 1·n + (−1)·(n−1) = 1",
+      "sub_one_dvd_numDerangements / dvd_numDerangements_sub_neg_one_pow (PROVED, reproduced parent facts A and B, self-contained)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "numDerangements_add_two",
+        "description": "Additive recurrence D(n+2) = (n+1)·(D(n) + D(n+1)) — source of fact (A): (n−1) ∣ D(n)",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "numDerangements_succ",
+        "description": "Multiplicative recurrence (D(n+1) : ℤ) = (n+1)·D(n) − (−1)^n — source of fact (B): n ∣ (D(n) − (−1)^n)",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "IsCoprime.mul_dvd",
+        "description": "If a, b coprime and a ∣ c and b ∣ c then a·b ∣ c — the CRT fusion step",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      },
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "(a : ZMod m) = 0 ↔ (m : ℤ) ∣ a — bridges the integer divisibility to the ZMod restatement over modulus n(n−1)",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The derangement numbers D(n) satisfy two folklore recurrences: the symmetric additive D(n) = (n−1)(D(n−1)+D(n−2)) and the asymmetric multiplicative D(n) = n·D(n−1) + (−1)^n. Each encodes one elementary divisibility fact — respectively (n−1) ∣ D(n) and D(n) ≡ (−1)^n (mod n) — proved in the parent entry. Because consecutive integers are coprime, the Chinese Remainder Theorem determines D(n) modulo the product n(n−1). This entry answers the parent's second open question by pinning down the combined residue explicitly and reducing it to canonical form.",
+    "problemStatement": "**OQ-02 of derangements-convergence-oq-04**\n\nSharpen the modulus: for which n does n(n−1) ∣ (D(n) − c) for an explicit residue c, combining the two divisibility facts via CRT?",
+    "text": "For all n, n(n−1) ∣ (D(n) − (−1)^n·(n−1)²); equivalently D(n) ≡ (−1)^n·(n−1)² (mod n(n−1)).",
+    "proofStrategy": "**Two components.** From the parent: (A) (n−1) ∣ D(n) (for n ≥ 2) and (B) n ∣ (D(n) − (−1)^n) (all n), both reproduced self-contained here from the Mathlib recurrences.\n\n**A single closed form for both parities.** Consider c(n) = (−1)^n·(n−1)². Modulo n−1: (n−1)² ≡ 0, and D(n) ≡ 0 by (A), so (n−1) ∣ (D(n) − c(n)). Modulo n: (n−1) ≡ −1 so (n−1)² ≡ 1, hence c(n) ≡ (−1)^n; combined with (B), D(n) ≡ (−1)^n ≡ c(n), so n ∣ (D(n) − c(n)). Algebraically, D(n) − c(n) = (D(n) − (−1)^n) + (−1)^n(1 − (n−1)²) and 1 − (n−1)² = n(2−n), which makes the n-divisibility of the second term transparent.\n\n**CRT fusion.** Since 1·n + (−1)·(n−1) = 1, n and n−1 are coprime; IsCoprime.mul_dvd upgrades the two component divisibilities to n(n−1) ∣ (D(n) − c(n)).\n\n**Reduction.** c(n) is negative for odd n; reducing modulo n(n−1) gives the canonical residue r(n) = (n−1)² (n even) or n−1 (n odd), with 0 ≤ r(n) < n(n−1) for n ≥ 2. The difference c(n) − r(n) is a multiple of n(n−1) (for odd n it equals −n(n−1)), so D(n) ≡ r(n) as well.",
+    "keyInsights": [
+      "A single closed form c(n) = (−1)^n·(n−1)² solves the CRT system for both parities at once. This works because (n−1)² is simultaneously ≡ 0 (mod n−1) and ≡ 1 (mod n) — it is its own inverse mod n since n−1 ≡ −1.",
+      "The general CRT recipe would produce c = (−1)^n·(n−1)·[(n−1)⁻¹ mod n]; the self-inverse property (n−1)⁻¹ ≡ n−1 (mod n) collapses this to (−1)^n(n−1)², avoiding any explicit inverse computation.",
+      "The identity 1 − (n−1)² = n(2 − n) is what makes the n-component divisibility elementary: the correction term (−1)^n(1 − (n−1)²) is manifestly a multiple of n.",
+      "Reducing to the fundamental domain exposes the genuine parity split hidden in the uniform closed form: the canonical residue is (n−1)² for even n but only n−1 for odd n (since −(n−1)² ≡ n−1 mod n(n−1)).",
+      "Coprimality of consecutive integers (1·n + (−1)·(n−1) = 1) is the entire content of the CRT step; no primality or factorisation of n is needed."
+    ],
+    "prerequisites": [
+      "The parent entry's two divisibility facts (n−1) ∣ D(n) and n ∣ (D(n) − (−1)^n)",
+      "IsCoprime and IsCoprime.mul_dvd from Mathlib's coprimality API",
+      "The ZMod ↔ integer-divisibility bridge ZMod.intCast_zmod_eq_zero_iff_dvd"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring deriving the CRT residue c(n) = (−1)^n(n−1)² and the canonical reduced residue r(n), with sample values D(4)=9, D(5)=44, D(6)=265. Imports Mathlib, opens Nat, namespace DerangementsConvergenceOQ04OQ02.",
+      "mathContext": "The CRT system: D(n) ≡ 0 (mod n−1) and D(n) ≡ (−1)^n (mod n), fused over the coprime pair (n, n−1)."
+    },
+    {
+      "id": "sec-parent-facts",
+      "title": "The Two Parent Divisibility Facts",
+      "startLine": 54,
+      "endLine": 74,
+      "summary": "sub_one_dvd_numDerangements: (n−1) ∣ D(n) for n ≥ 2 (fact A, from numDerangements_add_two). dvd_numDerangements_sub_neg_one_pow: n ∣ (D(n) − (−1)^n) over ℤ (fact B, from numDerangements_succ).",
+      "mathContext": "$(n-1)\\mid D(n)$ and $n \\mid (D(n) - (-1)^n)$ — the two coprime-modulus constraints."
+    },
+    {
+      "id": "sec-coprime",
+      "title": "Coprimality of Consecutive Integers",
+      "startLine": 76,
+      "endLine": 83,
+      "summary": "isCoprime_self_sub_one: IsCoprime (n : ℤ) (n − 1), witnessed by 1·n + (−1)·(n−1) = 1.",
+      "mathContext": "$\\gcd(n, n-1) = 1$ via the Bézout identity $1\\cdot n + (-1)(n-1) = 1$."
+    },
+    {
+      "id": "sec-crt",
+      "title": "The Combined Modulus via CRT",
+      "startLine": 85,
+      "endLine": 143,
+      "summary": "sub_one_dvd_shift and cast_dvd_shift establish the two component divisibilities of D(n) − (−1)^n(n−1)². mul_dvd_sub_crt (MAIN) fuses them via IsCoprime.mul_dvd. numDerangements_zmod_mul_eq restates the result in ZMod (n(n−1)).",
+      "mathContext": "$n(n-1) \\mid (D(n) - (-1)^n(n-1)^2)$, using $1 - (n-1)^2 = n(2-n)$ for the $n$-component."
+    },
+    {
+      "id": "sec-reduced",
+      "title": "Canonical Reduced Residue",
+      "startLine": 145,
+      "endLine": 203,
+      "summary": "reducedResidue r(n) = (n−1)² (even) / (n−1) (odd). reduced_residue_lt: 0 ≤ r(n) < n(n−1) for n ≥ 2. closedForm_sub_reduced_dvd: c(n) ≡ r(n) mod n(n−1). numDerangements_sub_reduced_dvd: D(n) ≡ r(n) (mod n(n−1)). Closing sanity checks on n = 2, 5, 6.",
+      "mathContext": "The canonical representative in $[0, n(n-1))$: $r(n) = (n-1)^2$ for even $n$, $r(n) = n-1$ for odd $n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-04",
+      "relationship": "sibling",
+      "description": "Parent entry: proves the two divisibility facts (n−1) ∣ D(n) and n ∣ (D(n) − (−1)^n) separately. This entry answers its open question OQ-02 by fusing them via CRT."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "foundational",
+      "description": "Root: derangement definitions and the recurrences numDerangements_add_two / numDerangements_succ underlying both component facts."
+    },
+    {
+      "targetId": "chinese-remainder-theorem",
+      "relationship": "foundational",
+      "description": "The fusion of the two coprime-modulus congruences into one modulo n(n−1) is a direct application of the CRT (here via IsCoprime.mul_dvd)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified: for all n, n(n−1) ∣ (D(n) − (−1)^n·(n−1)²), i.e. D(n) ≡ (−1)^n·(n−1)² (mod n(n−1)). This fuses the parent's two divisibility facts via CRT with a single parity-independent residue. Reducing to the fundamental domain gives the canonical residue r(n) = (n−1)² (n even) / n−1 (n odd), with D(n) ≡ r(n) (mod n(n−1)). Zero sorries, zero extra axioms.",
+    "implications": "**Complete residue mod n(n−1)**: The parent left D(n) determined modulo n and modulo n−1 separately; this entry gives the single sharp congruence modulo their product, the finest modulus obtainable from the two standard recurrences alone.\n\n**Parity dichotomy**: The uniform closed form (−1)^n(n−1)² conceals a genuine parity split visible only after reduction — even n contributes (n−1)², odd n only n−1.",
+    "openQuestions": [
+      "Does a third independent recurrence or identity sharpen the modulus beyond n(n−1) — e.g. to n(n−1)(n−2) via a mod-(n−2) constraint on D(n)?",
+      "Express the canonical residue r(n) without the parity case split, e.g. as a single polynomial-in-n formula valid mod n(n−1)."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "mul_dvd_sub_crt",
+      "type": "core",
+      "description": "For all n, n(n−1) divides D(n) − (−1)^n·(n−1)²; the CRT fusion of the two parent divisibility facts.",
+      "leanType": "(n : ℕ) → ((n : ℤ) * ((n : ℤ) - 1)) ∣ ((numDerangements n : ℤ) - (-1) ^ n * ((n : ℤ) - 1) ^ 2)"
+    },
+    {
+      "name": "numDerangements_sub_reduced_dvd",
+      "type": "core",
+      "description": "D(n) ≡ r(n) (mod n(n−1)) with the canonical reduced residue r(n) = (n−1)² (even) / n−1 (odd).",
+      "leanType": "(n : ℕ) → ((n : ℤ) * ((n : ℤ) - 1)) ∣ ((numDerangements n : ℤ) - reducedResidue n)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "DerangementsConvergenceOQ04OQ02",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "substantiveTheoremCount": 4,
+    "duplicateTheorems": 0,
+    "definitionCount": 1,
+    "path": "Proofs/DerangementsConvergenceOQ04OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Riordan, John",
+      "title": "An Introduction to Combinatorial Analysis",
+      "year": "1958",
+      "venue": "Wiley, Chapter 3",
+      "note": "Standard reference for the two derangement recurrences from which the component divisibility facts (n−1) ∣ D(n) and D(n) ≡ (−1)^n (mod n) follow."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "venue": "Cambridge Studies in Advanced Mathematics 49, 2nd edition, §2.2",
+      "note": "Derangement generating function and recurrences; elementary divisibility properties are standard exercises."
+    },
+    {
+      "authors": "Ireland, Kenneth and Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer GTM 84, Chapter 3",
+      "note": "The Chinese Remainder Theorem for coprime moduli, used here to fuse the mod-n and mod-(n−1) congruences into a single congruence mod n(n−1)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry answering **open question 2** of `derangements-convergence-oq-04` (verbatim: *"Sharpen the modulus: for which n does n(n−1) ∣ (D(n) − c) for an explicit residue c, combining the two divisibility facts via CRT?"*).

The parent proves two separate divisibility facts for the derangement numbers `D(n) = numDerangements n`:
- **(A)** `(n−1) ∣ D(n)` (n ≥ 2), from the additive recurrence
- **(B)** `n ∣ (D(n) − (−1)ⁿ)` (all n), from the multiplicative recurrence

Since `n` and `n−1` are coprime, CRT fuses these into one congruence modulo `n(n−1)`. The key observation: a **single closed form solves the CRT system for both parities at once**, because `(n−1)²` is simultaneously `≡ 0 (mod n−1)` and `≡ 1 (mod n)` (as `n−1 ≡ −1`, so `(n−1)²` is self-inverse mod n):

$$D(n) \equiv (-1)^n (n-1)^2 \pmod{n(n-1)}.$$

Reducing to the fundamental domain `[0, n(n−1))` exposes the parity split hidden in the uniform form: the canonical residue is `r(n) = (n−1)²` for even `n` and `r(n) = n−1` for odd `n`.

## Main results
- `mul_dvd_sub_crt` (**MAIN**): `n(n−1) ∣ (D(n) − (−1)ⁿ(n−1)²)`
- `numDerangements_zmod_mul_eq`: ZMod restatement over modulus `n(n−1)`
- `reducedResidue` (def) + `reduced_residue_lt`: `0 ≤ r(n) < n(n−1)` for n ≥ 2
- `numDerangements_sub_reduced_dvd`: `D(n) ≡ r(n) (mod n(n−1))`
- `isCoprime_self_sub_one`: `IsCoprime (n:ℤ) (n−1)` via Bézout `1·n + (−1)(n−1) = 1`

Verified numerically: D(4)=9≡9 (mod 12), D(5)=44≡4 (mod 20), D(6)=265≡25 (mod 30).

## Verification
- **0 sorries, 0 axioms** — `#print axioms` on the main theorems shows only `propext, Classical.choice, Quot.sound`
- Type-checked with `lake env lean` against the pinned Mathlib (exit 0)
- 10 theorems (2 private helpers) + 1 definition, 203 lines, self-contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)