### PR TITLE
Fix: remove stray Kuratowski axiom-file from euler-polyhedral-formula-oq-01 file set

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01/meta.json
@@ -206,9 +206,7 @@
     "definitionCount": 16,
     "path": "Proofs/EulerPolyhedralOQ01.lean",
     "sorries": 0,
-    "additionalFiles": [
-      "Proofs/EulerPolyhedralOQ01OQ04.lean"
-    ]
+    "additionalFiles": []
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

`leanFile.additionalFiles` for **euler-polyhedral-formula-oq-01** listed `Proofs/EulerPolyhedralOQ01OQ04.lean`, which is not part of this entry. Set it to `[]`.

## Evidence

**Before**: The entry claims `status: "verified"`, `axiomCount: 0`, assumptions "Fully verified. 0 axioms, 0 sorries." — accurate for its actual content, the primary file `EulerPolyhedralOQ01.lean` (903 lines, 60 theorems, **0 axioms**, namespaces `EulerOQ01`/`SixColorTheorem`). But `additionalFiles` also listed `EulerPolyhedralOQ01OQ04.lean`, an **unrelated** file (namespace `KuratowskiTheorem`, 401 lines, **12 axiom declarations** including `four_color_theorem`, `kuratowski_hard`, `five_color_theorem`, `euler_formula` stated as axioms).

Key facts establishing the file does not belong:
- The primary file `EulerPolyhedralOQ01.lean` does **not** import `EulerPolyhedralOQ01OQ04.lean` (and vice-versa).
- The entry **explicitly disclaims** this content: `conclusion.openQuestions` lists the Four Color Theorem ("Gonthier 2005 Coq proof … re-formalized in Lean 4?") and Kuratowski's theorem ("Can Kuratowski's theorem … be formalized?") as *unsolved*. The bibliography notes Kuratowski "Generalizes the explicit non-planarity certificates proved here."
- `EulerPolyhedralOQ01OQ04.lean` is nobody's primary file; it appears only as a stray `additionalFiles` entry.

The stray listing falsely injected 12 axioms into a genuinely 0-axiom, verified entry's file set — the kind of mismatch gallery-integrity scanners flag as a hidden-axiom overclaim.

**After**: `additionalFiles: []`. The entry's file set now matches its content, and `status: "verified"` / `axiomCount: 0` is consistent with the actual (axiom-free) proof.

Minimal diff: 3 lines → 1 line, valid JSON, no other fields touched.

---
Automated fix by lean-mechanic agent.