### PR TITLE
research(euler-totient-oq-03-oq-03-oq-01): closed form gcd/φ(gcd)=∏p/(p-1) [VERIFIED, 0-axiom, 8thm/167L, new entry]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ03OQ03OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ03OQ03OQ01.lean
@@ -1,0 +1,167 @@
+import Mathlib
+
+/-
+# Closed Form for the GCD–Totient Defect Factor
+
+## Open Question OQ-03-OQ-03-OQ-01
+
+The parent entry `EulerTotientOQ03OQ03` sharpens super-multiplicativity of Euler's totient
+to the exact identity
+
+  `φ(a) · φ(b) · gcd(a,b) / φ(gcd(a,b)) = φ(ab)`,
+
+identifying the **defect factor** `gcd(a,b) / φ(gcd(a,b)) ≥ 1` as the precise measure of the
+gap between `φ(a)·φ(b)` and `φ(ab)`.  Its open question asks:
+
+> Does the exact defect factor `gcd(a,b) / φ(gcd(a,b))` admit a clean closed form in terms
+> of the shared prime factors of `a` and `b` — e.g. `∏_{p | gcd} p/(p-1)` for squarefree
+> `gcd` — and can this be formalized?
+
+## The answer
+
+Yes, and in the *strongest* form: the closed form holds for **every** positive `n`, not just
+squarefree ones.  Working in `ℚ`,
+
+  `n / φ(n) = ∏_{p ∈ n.primeFactors} p / (p - 1)`.
+
+This is Euler's product formula `φ(n)/n = ∏ (1 - 1/p)` read as a statement about the
+reciprocal defect ratio.  Specialising `n := gcd(a,b)` gives the defect factor of the
+parent's identity in closed product form (`defect_factor_gcd`).
+
+For **squarefree** `d` — the case the open question singles out — there is the additional
+crisp fact that `φ(d)` is *itself* the product of `p - 1`:
+
+  `φ(d) = ∏_{p ∈ d.primeFactors} (p - 1)`   (`totient_squarefree`),
+
+because a squarefree number is exactly the product of its distinct prime factors
+(`Nat.prod_primeFactors_of_squarefree`).  Both the numerator `d = ∏ p` and the totient
+`φ(d) = ∏ (p-1)` are then products over the same prime set, and the ratio is `∏ p/(p-1)`.
+
+## Proof architecture
+
+The engine is Mathlib's `Nat.totient_mul_prod_primeFactors`:
+
+  `φ(n) · ∏_{p ∈ n.primeFactors} p = n · ∏_{p ∈ n.primeFactors} (p - 1)`.
+
+Casting this `ℕ`-identity into `ℚ` and dividing (both `φ(n)` and `∏ (p-1)` are nonzero for
+`n > 0`, since every prime factor is `≥ 2`) yields `n / φ(n) = (∏ p) / (∏ (p-1))`, and
+`Finset.prod_div_distrib` rewrites the right side as `∏ p/(p-1)`.  The squarefree totient
+formula cancels `∏ p` (positive) from the same identity after substituting `∏ p = d`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+open Nat Finset
+
+namespace EulerTotientOQ03OQ03OQ01
+
+/-! ### The engine (Mathlib's product form of Euler's formula) -/
+
+/-- Mathlib's product form of Euler's totient formula, restated as the foundation:
+`φ(n) · ∏_{p | n} p = n · ∏_{p | n} (p - 1)`. -/
+theorem totient_mul_prod (n : ℕ) :
+    φ n * ∏ p ∈ n.primeFactors, p = n * ∏ p ∈ n.primeFactors, (p - 1) :=
+  Nat.totient_mul_prod_primeFactors n
+
+/-! ### Auxiliary positivity facts over the prime factors -/
+
+/-- Every prime factor, cast to `ℚ`, has `p - 1 ≠ 0` (as `p ≥ 2`). -/
+theorem cast_sub_one_ne_zero {n p : ℕ} (hp : p ∈ n.primeFactors) :
+    (p : ℚ) - 1 ≠ 0 :=
+  sub_ne_zero.mpr (by exact_mod_cast (Nat.prime_of_mem_primeFactors hp).one_lt.ne')
+
+/-- The product `∏_{p | n} ((p : ℚ) - 1)` is nonzero. -/
+theorem prod_sub_one_ne_zero (n : ℕ) :
+    ∏ p ∈ n.primeFactors, ((p : ℚ) - 1) ≠ 0 :=
+  Finset.prod_ne_zero_iff.mpr fun _ hp => cast_sub_one_ne_zero hp
+
+/-- Casting `∏_{p | n} (p - 1)` from `ℕ` to `ℚ` distributes the truncated subtraction into
+the honest subtraction `(p : ℚ) - 1`, because each prime factor is `≥ 1`. -/
+theorem cast_prod_sub_one (n : ℕ) :
+    ((∏ p ∈ n.primeFactors, (p - 1) : ℕ) : ℚ) = ∏ p ∈ n.primeFactors, ((p : ℚ) - 1) := by
+  rw [Nat.cast_prod]
+  refine Finset.prod_congr rfl fun p hp => ?_
+  rw [Nat.cast_sub (Nat.prime_of_mem_primeFactors hp).one_lt.le, Nat.cast_one]
+
+/-! ### The closed form for the defect ratio (general `n`) -/
+
+/-- **The defect ratio in closed product form**, for every positive `n`:
+
+  `n / φ(n) = ∏_{p ∈ n.primeFactors} p / (p - 1)`.
+
+This is Euler's product formula, read as the reciprocal defect ratio.  It requires no
+squarefree hypothesis. -/
+theorem defect_ratio (n : ℕ) (hn : 0 < n) :
+    (n : ℚ) / φ n = ∏ p ∈ n.primeFactors, (p : ℚ) / ((p : ℚ) - 1) := by
+  have hφ : (φ n : ℚ) ≠ 0 := by
+    have : 0 < φ n := Nat.totient_pos.mpr hn
+    positivity
+  have hden : ∏ p ∈ n.primeFactors, ((p : ℚ) - 1) ≠ 0 := prod_sub_one_ne_zero n
+  -- cast the ℕ engine identity into ℚ
+  have keyQ : (φ n : ℚ) * ∏ p ∈ n.primeFactors, (p : ℚ)
+      = (n : ℚ) * ∏ p ∈ n.primeFactors, ((p : ℚ) - 1) := by
+    have h2 : ((φ n * ∏ p ∈ n.primeFactors, p : ℕ) : ℚ)
+        = ((n * ∏ p ∈ n.primeFactors, (p - 1) : ℕ) : ℚ) := by exact_mod_cast totient_mul_prod n
+    rwa [Nat.cast_mul, Nat.cast_mul, Nat.cast_prod, cast_prod_sub_one n] at h2
+  rw [Finset.prod_div_distrib, div_eq_div_iff hφ hden]
+  linear_combination -keyQ
+
+/-! ### The defect factor of the parent identity -/
+
+/-- **The parent's defect factor in closed form.**  For `a, b` not both zero, the exact
+super-multiplicativity defect factor `gcd(a,b) / φ(gcd(a,b))` of the parent identity is the
+product over the shared prime factors:
+
+  `gcd(a,b) / φ(gcd(a,b)) = ∏_{p ∈ (gcd a b).primeFactors} p / (p - 1)`. -/
+theorem defect_factor_gcd (a b : ℕ) (h : 0 < Nat.gcd a b) :
+    (Nat.gcd a b : ℚ) / φ (Nat.gcd a b)
+      = ∏ p ∈ (Nat.gcd a b).primeFactors, (p : ℚ) / ((p : ℚ) - 1) :=
+  defect_ratio (Nat.gcd a b) h
+
+/-! ### The squarefree case singled out by the open question -/
+
+/-- **Totient of a squarefree number.**  For squarefree `d`, the totient is exactly the
+product of `p - 1` over the prime factors: `φ(d) = ∏_{p | d} (p - 1)`.  (Mathlib provides
+this only implicitly through the general product formula; here it is the direct statement.)
+The proof cancels `∏ p = d` (positive) from the engine identity. -/
+theorem totient_squarefree {d : ℕ} (hd : Squarefree d) :
+    φ d = ∏ p ∈ d.primeFactors, (p - 1) := by
+  have key := totient_mul_prod d
+  rw [Nat.prod_primeFactors_of_squarefree hd] at key
+  have hd0 : 0 < d := Nat.pos_of_ne_zero hd.ne_zero
+  rw [mul_comm (φ d) d] at key
+  exact Nat.eq_of_mul_eq_mul_left hd0 key
+
+/-- **The squarefree defect ratio**, with both numerator and denominator displayed as
+products over the prime factors: for squarefree `d`,
+
+  `d / φ(d) = (∏_{p | d} p) / (∏_{p | d} (p - 1))`. -/
+theorem defect_ratio_squarefree {d : ℕ} (hd : Squarefree d) :
+    (d : ℚ) / φ d
+      = (∏ p ∈ d.primeFactors, (p : ℚ)) / (∏ p ∈ d.primeFactors, ((p : ℚ) - 1)) := by
+  rw [defect_ratio d (Nat.pos_of_ne_zero hd.ne_zero), Finset.prod_div_distrib]
+
+/-! ### Worked instances -/
+
+section Examples
+
+/-- `6 = 2·3` is squarefree: `6/φ(6) = 6/2 = 3 = (2/1)·(3/2)`. -/
+example : (6 : ℚ) / φ 6 = ∏ p ∈ (6 : ℕ).primeFactors, (p : ℚ) / ((p : ℚ) - 1) :=
+  defect_ratio 6 (by norm_num)
+
+/-- `φ(15) = (3-1)(5-1) = 8` for the squarefree `15 = 3·5`. -/
+example : φ 15 = ∏ p ∈ (15 : ℕ).primeFactors, (p - 1) := by
+  have h15 : Squarefree (15 : ℕ) := by
+    rw [(by norm_num : (15 : ℕ) = 3 * 5), Nat.squarefree_mul_iff]
+    exact ⟨by norm_num, Nat.prime_three.prime.squarefree,
+      (by norm_num : Nat.Prime 5).prime.squarefree⟩
+  exact totient_squarefree h15
+
+/-- The defect factor at `gcd(12, 18) = 6`: `6/φ(6) = 3`, matching `∏_{p | 6} p/(p-1)`. -/
+example : (Nat.gcd 12 18 : ℚ) / φ (Nat.gcd 12 18)
+    = ∏ p ∈ (Nat.gcd 12 18).primeFactors, (p : ℚ) / ((p : ℚ) - 1) :=
+  defect_factor_gcd 12 18 (by norm_num)
+
+end Examples
+
+end EulerTotientOQ03OQ03OQ01

--- a/src/data/proofs/euler-totient-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-03-oq-03-oq-01/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "euler-totient-oq-03-oq-03-oq-01",
+  "title": "Closed Form for the GCD–Totient Defect Factor: gcd/φ(gcd) = ∏ p/(p-1)",
+  "slug": "euler-totient-oq-03-oq-03-oq-01",
+  "description": "Answers the parent's open question OQ-03-OQ-03-OQ-01 — does the exact super-multiplicativity defect factor gcd(a,b)/φ(gcd(a,b)) admit a clean closed form in terms of the shared prime factors? — with the strongest possible answer. Working in ℚ, for EVERY positive n (not merely squarefree): n/φ(n) = ∏_{p ∈ n.primeFactors} p/(p-1). This is Euler's product formula φ(n)/n = ∏(1-1/p) read as the reciprocal defect ratio. Specialising n := gcd(a,b) yields the parent identity's defect factor in closed product form (defect_factor_gcd). For the squarefree case the open question singles out, there is the extra crisp fact φ(d) = ∏_{p|d}(p-1) (totient_squarefree), since a squarefree number is exactly the product of its distinct primes; then both numerator d = ∏p and totient φ(d) = ∏(p-1) are products over the same prime set. The engine is Mathlib's Nat.totient_mul_prod_primeFactors (φ(n)·∏p = n·∏(p-1)); casting to ℚ and dividing (both denominators nonzero since every prime factor is ≥ 2) gives the ratio, and Finset.prod_div_distrib collects it into ∏ p/(p-1).",
+  "meta": {
+    "author": "Lean Genius researcher-4",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ03OQ03OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 167,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "assumptions": "None. The general defect-ratio closed form requires only n > 0; the squarefree totient formula requires Squarefree d. Both are fully machine-checked. Verified via #print axioms to depend only on the foundational axioms propext, Classical.choice, Quot.sound; no native_decide and no Lean.ofReduceBool dependency.",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "multiplicative-functions",
+      "eulers-product-formula",
+      "squarefree",
+      "prime-factorization",
+      "gcd",
+      "closed-form",
+      "research"
+    ],
+    "dateAdded": "2026-07-01",
+    "originalContributions": [
+      "defect_ratio: the closed form n/φ(n) = ∏_{p ∈ n.primeFactors} p/(p-1) in ℚ for EVERY positive n — the reciprocal of Euler's product formula, answering the open question in stronger generality than the squarefree case it asked about (no squarefree hypothesis needed for the ratio)",
+      "defect_factor_gcd: the parent identity's exact super-multiplicativity defect factor gcd(a,b)/φ(gcd(a,b)) expressed as ∏_{p ∈ (gcd a b).primeFactors} p/(p-1), the literal closed form the open question requests, obtained by specialising defect_ratio at n = gcd(a,b)",
+      "totient_squarefree: for squarefree d, φ(d) = ∏_{p | d}(p-1) — the crisp squarefree totient formula (Mathlib supplies this only implicitly through the general factorization product), proved by cancelling ∏p = d from the engine identity",
+      "defect_ratio_squarefree: the squarefree defect ratio d/φ(d) = (∏_{p|d} p)/(∏_{p|d}(p-1)) with numerator and denominator each displayed as a product over the prime factors — the exact form of the ∏ p/(p-1) the open question names",
+      "Reusable ℚ-casting recipe: cast_prod_sub_one and prod_sub_one_ne_zero convert the ℕ engine identity Nat.totient_mul_prod_primeFactors into a rational quotient by distributing truncated subtraction (p-1) into honest subtraction (p:ℚ)-1 over the prime factors and certifying every denominator nonzero (each prime ≥ 2)"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/EulerTotientOQ03OQ03OQ01.lean",
+    "namespace": "EulerTotientOQ03OQ03OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 167,
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Euler's totient satisfies the product formula φ(n) = n·∏_{p|n}(1 - 1/p), equivalently φ(n)/n = ∏_{p|n}(p-1)/p, one of the oldest closed forms in analytic number theory. The parent chain isolates the factor gcd(a,b)/φ(gcd(a,b)) as the EXACT defect governing super-multiplicativity: φ(a)·φ(b)·gcd/φ(gcd) = φ(ab), with the defect factor ≥ 1 measuring the gap between φ(a)·φ(b) and φ(ab). The parent's open question asks whether that defect factor has a clean prime-factor closed form — guessing ∏_{p|gcd} p/(p-1) for squarefree gcd. The reciprocal of Euler's product formula answers this at once, and for arbitrary n: the ratio n/φ(n) is always the product of p/(p-1) over the distinct prime divisors.",
+    "problemStatement": "Open Question OQ-03-OQ-03-OQ-01: Does the exact defect factor gcd(a,b)/φ(gcd(a,b)) admit a clean closed form in terms of the shared prime factors of a and b — e.g. ∏_{p | gcd} p/(p-1) for squarefree gcd — and can this be formalized?",
+    "proofStrategy": "Take Mathlib's Nat.totient_mul_prod_primeFactors as the engine: φ(n)·∏_{p|n} p = n·∏_{p|n}(p-1) in ℕ, valid for all n. To read this as a rational ratio, cast into ℚ: the ∏ p term casts directly (Nat.cast_prod), while the ∏(p-1) term needs cast_prod_sub_one to turn truncated ℕ-subtraction into honest ℚ-subtraction (p:ℚ)-1, using that each prime factor is ≥ 1 (Nat.cast_sub). With φ(n) > 0 (Nat.totient_pos) and ∏((p:ℚ)-1) ≠ 0 (prod_sub_one_ne_zero, since each prime is ≥ 2 so (p:ℚ)-1 ≥ 1), div_eq_div_iff reduces the goal n/φ(n) = (∏p)/(∏(p-1)) to the cast engine identity, closed by linear_combination; Finset.prod_div_distrib then collects the right side into ∏ p/(p-1) (defect_ratio). Specialising n = gcd a b gives defect_factor_gcd. For squarefree d, Nat.prod_primeFactors_of_squarefree gives ∏p = d; substituting into the engine identity and cancelling the positive ∏p yields φ(d) = ∏(p-1) (totient_squarefree). Squarefree 15 is discharged via Nat.squarefree_mul_iff and Prime.squarefree.",
+    "keyInsights": [
+      "The defect factor's closed form is just the reciprocal of Euler's product formula, and it requires NO squarefree hypothesis: n/φ(n) = ∏_{p|n} p/(p-1) for every positive n. The open question guessed the squarefree case; the honest statement is more general, with squarefree merely the case where φ(d) itself equals ∏(p-1).",
+      "The whole content reduces to one Mathlib identity, Nat.totient_mul_prod_primeFactors: φ(n)·∏p = n·∏(p-1). Multiplicativity of the totient is already packaged there; the only real work is transporting it faithfully from ℕ (with truncated subtraction) into ℚ (with honest subtraction and division).",
+      "The ℕ→ℚ transport is the delicate step and is isolated into reusable lemmas: cast_prod_sub_one distributes the cast of ∏(p-1) into ∏((p:ℚ)-1) factorwise (each prime ≥ 1 licences Nat.cast_sub), and prod_sub_one_ne_zero certifies the denominator nonzero (each prime ≥ 2 makes (p:ℚ)-1 ≥ 1).",
+      "The squarefree fact φ(d) = ∏(p-1) drops out of the SAME engine identity: substituting ∏p = d (true exactly for squarefree d) turns φ(d)·d = d·∏(p-1) into φ(d) = ∏(p-1) after cancelling the positive d. So numerator and denominator of the defect ratio are, in the squarefree case, products over one shared prime set."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the Closed Form",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Header stating OQ-03-OQ-03-OQ-01 and the answer: n/φ(n) = ∏_{p|n} p/(p-1) for every positive n (the reciprocal of Euler's product formula), specialising to the parent's defect factor at n = gcd(a,b); plus the squarefree fact φ(d) = ∏(p-1). Describes the engine Nat.totient_mul_prod_primeFactors and the ℚ-casting architecture."
+    },
+    {
+      "id": "engine",
+      "title": "The Engine: Euler's Product Form",
+      "startLine": 58,
+      "endLine": 65,
+      "summary": "totient_mul_prod: Mathlib's Nat.totient_mul_prod_primeFactors restated as the foundation — φ(n)·∏_{p|n} p = n·∏_{p|n}(p-1) in ℕ, valid for all n."
+    },
+    {
+      "id": "casting",
+      "title": "ℚ-Casting and Positivity of the Prime Factors",
+      "startLine": 66,
+      "endLine": 85,
+      "summary": "cast_sub_one_ne_zero: (p:ℚ)-1 ≠ 0 for a prime factor (p ≥ 2); prod_sub_one_ne_zero: the denominator ∏((p:ℚ)-1) ≠ 0; cast_prod_sub_one: casting ∏(p-1) from ℕ distributes into ∏((p:ℚ)-1), turning truncated subtraction into honest subtraction via Nat.cast_sub."
+    },
+    {
+      "id": "defect-ratio",
+      "title": "The Closed Form for the Defect Ratio",
+      "startLine": 86,
+      "endLine": 108,
+      "summary": "defect_ratio: for every positive n, n/φ(n) = ∏_{p ∈ n.primeFactors} p/(p-1). Casts the engine identity into ℚ, applies div_eq_div_iff with both denominators nonzero, closes with linear_combination, and collects the product with Finset.prod_div_distrib."
+    },
+    {
+      "id": "defect-factor",
+      "title": "The Parent's Defect Factor in Closed Form",
+      "startLine": 109,
+      "endLine": 120,
+      "summary": "defect_factor_gcd: the parent identity's exact super-multiplicativity defect factor gcd(a,b)/φ(gcd(a,b)) = ∏_{p ∈ (gcd a b).primeFactors} p/(p-1) — the literal closed form the open question requests, by specialising defect_ratio at n = gcd(a,b)."
+    },
+    {
+      "id": "squarefree",
+      "title": "The Squarefree Case",
+      "startLine": 121,
+      "endLine": 143,
+      "summary": "totient_squarefree: for squarefree d, φ(d) = ∏_{p|d}(p-1), by cancelling ∏p = d (Nat.prod_primeFactors_of_squarefree) from the engine identity; defect_ratio_squarefree: d/φ(d) = (∏p)/(∏(p-1)) with numerator and denominator each a product over the prime factors."
+    },
+    {
+      "id": "examples",
+      "title": "Worked Instances",
+      "startLine": 144,
+      "endLine": 164,
+      "summary": "6/φ(6) = 3 = (2/1)(3/2); φ(15) = (3-1)(5-1) = 8 (Squarefree 15 via Nat.squarefree_mul_iff and Prime.squarefree); the defect factor at gcd(12,18) = 6 equals ∏_{p|6} p/(p-1)."
+    }
+  ],
+  "conclusion": {
+    "summary": "8 machine-checked theorems, 0 sorries, 0 axioms. For every positive n, the totient defect ratio has the closed form n/φ(n) = ∏_{p ∈ n.primeFactors} p/(p-1) (defect_ratio) — the reciprocal of Euler's product formula. Specialising to n = gcd(a,b) gives the exact super-multiplicativity defect factor gcd(a,b)/φ(gcd(a,b)) of the parent identity in closed product form (defect_factor_gcd). For squarefree d there is the additional crisp identity φ(d) = ∏_{p|d}(p-1) (totient_squarefree). The engine is Mathlib's Nat.totient_mul_prod_primeFactors, transported from ℕ to ℚ by dedicated casting/positivity lemmas.",
+    "implications": "The result confirms the open question's guessed form and strengthens it: the ∏ p/(p-1) closed form for the defect ratio is not special to squarefree gcd but universal, because it IS Euler's product formula in reciprocal. The squarefree hypothesis matters only for the auxiliary fact that φ(d) itself is ∏(p-1). The reusable takeaway is the ℕ→ℚ transport recipe: a multiplicative-function identity with truncated subtraction becomes a rational quotient by distributing casts factorwise (Nat.cast_sub) over the prime-factor set and certifying denominators nonzero. This is the standard bridge for turning Mathlib's integer product formulas into analytic-style rational identities.",
+    "openQuestions": [
+      "Can the closed form be pushed to the exact real value of the defect ratio as a function of the multiset of prime factors with multiplicity — i.e. an explicit formula for n/φ(n) when n is NOT squarefree, confirming the product is over distinct primes regardless of multiplicity?",
+      "Does the sibling formula φ(n^(k+1)) = n^k·φ(n) (parent OQ-03-OQ-03 OQ[1]) combine with this closed form to give the defect ratio of gcd(a^m, b^m) in terms of that of gcd(a,b)?",
+      "Can the product ∏_{p|n} p/(p-1) be bounded to recover classical growth estimates for n/φ(n) (e.g. the Mertens-type lower bound involving log log n), formalizing the extremal behaviour of the defect factor?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-03-oq-03",
+      "relationship": "parent — sharpens super-multiplicativity to the exact identity φ(a)·φ(b)·gcd/φ(gcd) = φ(ab), identifying gcd(a,b)/φ(gcd(a,b)) as the defect factor and posing this open question; this entry gives that defect factor's closed form ∏_{p|gcd} p/(p-1)"
+    },
+    {
+      "targetId": "euler-totient-oq-03",
+      "relationship": "ancestor — the GCD–totient identity φ(gcd(a,b))·φ(ab) = φ(a)·φ(b)·gcd(a,b) from which the defect factor arises"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's open question **OQ-03-OQ-03-OQ-01**: does the exact super-multiplicativity defect factor `gcd(a,b)/φ(gcd(a,b))` admit a clean closed form in terms of the shared prime factors?

**Yes — and in the strongest form.** Working in `ℚ`, for *every* positive `n`:
```
n / φ(n) = ∏_{p ∈ n.primeFactors} p / (p - 1)
```
This is Euler's product formula `φ(n)/n = ∏(1 - 1/p)` read as the reciprocal defect ratio — **no squarefree hypothesis needed**. Specialising `n := gcd(a,b)` gives the parent identity's defect factor in closed product form (`defect_factor_gcd`).

For the **squarefree** case the question singles out, there is the extra crisp fact
```
φ(d) = ∏_{p | d} (p - 1)     (totient_squarefree)
```
so numerator `d = ∏ p` and totient `φ(d) = ∏(p-1)` are products over the same prime set.

## Proof

The engine is Mathlib's `Nat.totient_mul_prod_primeFactors`: `φ(n)·∏p = n·∏(p-1)`. Casting this `ℕ`-identity into `ℚ` (distributing the truncated `(p-1)` into honest `(p:ℚ)-1` factorwise via `Nat.cast_sub`, with both `φ(n)` and `∏(p-1)` nonzero since every prime factor is `≥ 2`) and dividing gives `n/φ(n) = (∏p)/(∏(p-1))`; `Finset.prod_div_distrib` collects it into `∏ p/(p-1)`.

## Verification

- **8 theorems**, 0 defs, 167 lines
- **0 sorries, 0 axioms** — `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`
- Typechecks against Mathlib via `lake env lean`
- New gallery entry: `src/data/proofs/euler-totient-oq-03-oq-03-oq-01/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)