### PR TITLE
Enrich Surface Area of the Unit Sphere (area-of-circle-oq-02-oq-03): 4→8 annotations

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-03/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "ann-aoc-oq02-oq03-header",
+    "proofId": "area-of-circle-oq-02-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "context",
+    "title": "Geometric Provenance: Divergence Theorem and Shell Integration",
+    "content": "The identity Sₙ = n·Vₙ is the integral form of the divergence theorem applied to the radial vector field x ↦ x on the unit ball: ∫_ball div(x) dV = n·Vₙ equals the outward flux ∫_sphere x·n̂ dS = Sₙ. Equivalently, integrating in spherical shells, Vₙ(r) = ∫₀ʳ Sₙ tⁿ⁻¹ dt, so Sₙ = dVₙ(r)/dr at r=1 = n·Vₙ. This file does not reprove the geometry; it shows that the two independent Gamma closed forms are already in the ratio n:1, so the geometric scaling law is baked into the special-function formulas. The header also fixes the n=0 convention (Γ(0)=0 ⇒ S₀=0) that lets the theorem hold without a hypothesis n≥1.",
+    "mathContext": "$\\int_{B^n}\\operatorname{div}(x)\\,dV = n V_n = \\oint_{S^{n-1}} x\\cdot\\hat n\\,dS = S_n$; shells: $V_n=\\int_0^1 S_n\\,r^{n-1}\\,dr = S_n/n$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "divergence theorem",
+      "spherical shell integration",
+      "fundamental theorem of calculus"
+    ],
+    "prerequisites": [
+      "vector calculus",
+      "spherical coordinates"
+    ]
+  },
+  {
     "id": "ann-aoc-oq02-oq03-defs",
     "proofId": "area-of-circle-oq-02-oq-03",
     "range": {
@@ -19,6 +41,50 @@
     "prerequisites": [
       "Gamma function closed forms",
       "real powers (rpow)"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq02-oq03-gamma-half",
+    "proofId": "area-of-circle-oq-02-oq-03",
+    "range": {
+      "startLine": 66,
+      "endLine": 70
+    },
+    "type": "technique",
+    "title": "The Half-Integer Gamma Value Γ(3/2) = √π/2",
+    "content": "Every odd-dimensional special value ultimately rests on Γ(1/2) = √π. The helper gamma_three_div_two climbs one rung of the functional equation from there: Γ(3/2) = Γ(1/2 + 1) = (1/2)·Γ(1/2) = √π/2, formalized by rewriting 1/2 + 1 = 3/2 and chaining Real.Gamma_add_one (with 1/2 ≠ 0) with Real.Gamma_one_half_eq. Because Γ takes half-integer arguments at odd n, this single value is what makes V₁ and V₃ (and hence S₁, S₃) computable in closed form; even n instead lands on integer arguments where Γ is a factorial.",
+    "mathContext": "$\\Gamma\\!\\left(\\tfrac32\\right) = \\Gamma\\!\\left(\\tfrac12+1\\right) = \\tfrac12\\,\\Gamma\\!\\left(\\tfrac12\\right) = \\tfrac{\\sqrt\\pi}{2}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gamma functional equation",
+      "Gaussian integral",
+      "half-integer arguments"
+    ],
+    "prerequisites": [
+      "Real.Gamma_add_one",
+      "Real.Gamma_one_half_eq"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq02-oq03-positivity",
+    "proofId": "area-of-circle-oq-02-oq-03",
+    "range": {
+      "startLine": 74,
+      "endLine": 85
+    },
+    "type": "technique",
+    "title": "Positivity and the n = 0 Asymmetry",
+    "content": "Both closed forms are quotients of a positive power π^(n/2) > 0 by a Gamma value, so positivity reduces to Γ > 0 on the positive reals (Gamma_pos_of_pos). The two lemmas differ exactly at n = 0: the volume denominator is Γ(n/2+1), whose argument n/2+1 ≥ 1 > 0 for every n, so unitBallVolume_pos holds unconditionally; the surface denominator is Γ(n/2), whose argument n/2 is > 0 only when n ≥ 1, so unitSphereSurface_pos carries the hypothesis 1 ≤ n. This is the same n=0 boundary that forces the main identity to treat n=0 separately — there S₀ = 2/Γ(0) = 0, neither positive nor obtained from the functional equation.",
+    "mathContext": "$V_n>0$ for all $n$ (arg $\\tfrac n2+1\\ge 1$); $S_n>0$ iff $n\\ge 1$ (arg $\\tfrac n2>0$); $S_0=2/\\Gamma(0)=0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gamma positivity",
+      "junk-value convention",
+      "edge cases"
+    ],
+    "prerequisites": [
+      "Gamma_pos_of_pos",
+      "rpow_pos_of_pos"
     ]
   },
   {
@@ -61,6 +127,29 @@
       "originality framing"
     ],
     "prerequisites": []
+  },
+  {
+    "id": "ann-aoc-oq02-oq03-volume-values",
+    "proofId": "area-of-circle-oq-02-oq-03",
+    "range": {
+      "startLine": 115,
+      "endLine": 140
+    },
+    "type": "concept",
+    "title": "Volume Special Values V₁, V₂, V₃",
+    "content": "The three low-dimensional volumes are computed directly from the closed form and feed the surface values through the main identity. V₁ = 2 (length of [−1,1]) uses Γ(3/2) = √π/2 and π^(1/2) = √π, whose √π factors cancel. V₂ = π (area of the unit disk) is the cleanest case: the argument n/2+1 = 2 gives Γ(2) = 1 and π^1 = π. V₃ = 4π/3 (volume of the unit ball) again needs Γ(3/2), together with π^(3/2) = π·√π; the proof splits the exponent via rpow_add and closes with nlinarith using √π·√π = π. The even case bottoms out at an integer Gamma argument (a factorial); the odd cases carry the √π from Γ(1/2).",
+    "mathContext": "$V_1=\\dfrac{\\pi^{1/2}}{\\Gamma(3/2)}=\\dfrac{\\sqrt\\pi}{\\sqrt\\pi/2}=2,\\quad V_2=\\dfrac{\\pi}{\\Gamma(2)}=\\pi,\\quad V_3=\\dfrac{\\pi^{3/2}}{\\Gamma(5/2)}=\\dfrac{4\\pi}{3}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "n-ball volume",
+      "half-integer Gamma values",
+      "rpow arithmetic"
+    ],
+    "prerequisites": [
+      "Real.Gamma_two",
+      "rpow_add",
+      "sqrt manipulations"
+    ]
   },
   {
     "id": "ann-aoc-oq02-oq03-special",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-02-oq-03` ("Surface Area of the Unit Sphere: Sₙ = n·Vₙ").

**Gap:** entry had only 4 annotations covering ~29% of the 164-line Lean file — the module header, the Γ(3/2) helper, the positivity lemmas, and all volume special values were unannotated.

**Added 4 annotations (4→8), coverage ~29%→~75%:**
- **Module header (context):** divergence-theorem / spherical-shell provenance of Sₙ=n·Vₙ and the n=0 junk-value convention.
- **gamma_three_div_two (technique):** the half-integer value Γ(3/2)=√π/2 climbed from Γ(1/2)=√π via the functional equation — what makes odd-n special values computable.
- **Positivity lemmas (technique):** positivity via Γ>0 on the positive reals, and the n=0 asymmetry (Vₙ>0 unconditionally, Sₙ>0 only for n≥1).
- **Volume special values V₁,V₂,V₃ (concept):** the closed-form computations that feed the surface values through the main identity.

Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, matching the existing four.

**Validation:** `resolver.ts validate` → 8 valid, 0 misaligned. No meta.json or Lean changes.