### PR TITLE
research(fibonacci-identities-oq-08-oq-01): alternating & bisected Lucas partial sums [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ08OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ08OQ01.lean
@@ -1,0 +1,142 @@
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.Tactic
+
+/-
+# Alternating and Bisected Lucas Partial Sums
+
+## What This Proves
+
+The parent entry `fibonacci-identities-oq-08` establishes the Lucas telescoping
+sum `∑_{i≤n} Lᵢ = L_{n+2} − 1`. This follow-up entry proves the three companion
+partial-sum identities requested by that entry's open question, for the Lucas
+numbers `L₀ = 2, L₁ = 1, Lₙ₊₂ = Lₙ + Lₙ₊₁`:
+
+* `alt_lucas_sum` — the **alternating sum**
+  `∑_{i=0}^{n} (−1)ⁱ Lᵢ = 3 + (−1)ⁿ (L_{n+1} − Lₙ)`, over `ℤ` to carry the sign.
+* `lucas_even_sum` — the **even-indexed** (bisected) sum
+  `∑_{i=0}^{n} L_{2i} = L_{2n+1} + 1`.
+* `lucas_odd_sum` — the **odd-indexed** (bisected) sum
+  `∑_{i=0}^{n} L_{2i+1} = L_{2n+2} − 2`.
+
+## The closed forms
+
+**Alternating.** From Binet `Lₙ = φⁿ + ψⁿ` with `φψ = −1` and `1 + φ = φ²`,
+the geometric series `∑ (−φ)ⁱ + ∑ (−ψ)ⁱ` telescopes to
+`L₂ + (−1)ⁿ L_{n−1} = 3 + (−1)ⁿ L_{n−1}`. Writing `L_{n−1} = L_{n+1} − Lₙ`
+gives the subtraction-free `3 + (−1)ⁿ (L_{n+1} − Lₙ)` used here, valid for all
+`n` without a negative index.
+
+**Bisections.** Both even- and odd-indexed sums telescope with the two-step
+recurrence `L_{k+2} = L_k + L_{k+1}`: the even sum accumulates a `+1` constant
+(from `L₁ = 1` shifting the base), the odd sum a `−2` (from `L₀ = 2`).
+
+## How It's Proved
+
+Each identity is a **one-step induction** on `n` using `Finset.sum_range_succ`.
+The bisected sums are stated (or reduced to) a subtraction-free `(∑ …) + c = …`
+form so `omega` can finish each step from the Lucas recurrence read as a linear
+fact over the atoms `L_{2k+1}, L_{2k+2}, L_{2k+3}`. The alternating step keeps
+`(−1)ᵏ` as an opaque atom and closes by `ring` after rewriting the recurrence
+and `(−1)^{k+1} = −(−1)ᵏ`.
+
+## References
+
+- Parent family: the Lucas telescoping sum `∑_{i≤n} Lᵢ = L_{n+2} − 1`.
+- Vajda, *Fibonacci & Lucas Numbers*, bisection and alternating-sum identities.
+-/
+
+namespace FibonacciIdentitiesOQ08OQ01
+
+open Nat Finset
+
+/-! ## Definition of the Lucas numbers
+
+Same structural pair recursion as the parent and sibling Lucas entries so this
+file is self-contained; `lucas` reduces by `rfl`. -/
+
+/-- The pair `(Lₙ, Lₙ₊₁)`. -/
+def lucasPair : ℕ → ℕ × ℕ
+  | 0 => (2, 1)
+  | n + 1 => ((lucasPair n).2, (lucasPair n).1 + (lucasPair n).2)
+
+/-- The Lucas numbers `Lₙ`: `L₀ = 2`, `L₁ = 1`, `Lₙ₊₂ = Lₙ + Lₙ₊₁`. -/
+def lucas (n : ℕ) : ℕ := (lucasPair n).1
+
+@[simp] theorem lucas_zero : lucas 0 = 2 := rfl
+@[simp] theorem lucas_one : lucas 1 = 1 := rfl
+
+/-- The defining recurrence `Lₙ₊₂ = Lₙ + Lₙ₊₁`. -/
+theorem lucas_add_two (n : ℕ) : lucas (n + 2) = lucas n + lucas (n + 1) := rfl
+
+/-- Integer-cast form of the recurrence, convenient for the alternating sum. -/
+theorem lucas_add_two_int (n : ℕ) :
+    (lucas (n + 2) : ℤ) = (lucas n : ℤ) + (lucas (n + 1) : ℤ) := by
+  exact_mod_cast lucas_add_two n
+
+/-! ## The alternating Lucas sum `∑_{i≤n} (−1)ⁱ Lᵢ = 3 + (−1)ⁿ (L_{n+1} − Lₙ)` -/
+
+/-- **Alternating Lucas partial sum.** `∑_{i=0}^{n} (−1)ⁱ Lᵢ =
+3 + (−1)ⁿ (L_{n+1} − Lₙ)`, over `ℤ`. One-step induction: the closed form
+`g(n) = 3 + (−1)ⁿ(L_{n+1} − Lₙ)` satisfies `g(n+1) = g(n) + (−1)^{n+1} L_{n+1}`
+using `L_{n+2} = L_n + L_{n+1}` and `(−1)^{n+1} = −(−1)ⁿ`. -/
+theorem alt_lucas_sum (n : ℕ) :
+    (∑ i ∈ range (n + 1), (-1 : ℤ) ^ i * (lucas i : ℤ))
+      = 3 + (-1) ^ n * ((lucas (n + 1) : ℤ) - (lucas n : ℤ)) := by
+  induction n with
+  | zero => rw [Finset.sum_range_one]; norm_num
+  | succ k ih =>
+      rw [Finset.sum_range_succ, ih, lucas_add_two_int k, pow_succ]
+      ring
+
+/-! ## The even-indexed (bisected) sum `∑_{i≤n} L_{2i} = L_{2n+1} + 1` -/
+
+/-- **Even-indexed Lucas sum.** `∑_{i=0}^{n} L_{2i} = L_{2n+1} + 1`. The new term
+`L_{2k+2}` glues to the inductive `L_{2k+1}` via `L_{2k+3} = L_{2k+1} + L_{2k+2}`. -/
+theorem lucas_even_sum (n : ℕ) :
+    (∑ i ∈ range (n + 1), lucas (2 * i)) = lucas (2 * n + 1) + 1 := by
+  induction n with
+  | zero => decide
+  | succ k ih =>
+      rw [Finset.sum_range_succ, ih]
+      have hrec : lucas (2 * k + 3) = lucas (2 * k + 1) + lucas (2 * k + 2) :=
+        lucas_add_two (2 * k + 1)
+      show lucas (2 * k + 1) + 1 + lucas (2 * k + 2) = lucas (2 * k + 3) + 1
+      omega
+
+/-! ## The odd-indexed (bisected) sum `∑_{i≤n} L_{2i+1} = L_{2n+2} − 2` -/
+
+/-- **Subtraction-free odd-indexed sum:** `(∑_{i=0}^{n} L_{2i+1}) + 2 = L_{2n+2}`.
+The new term `L_{2k+3}` glues to `L_{2k+2}` via `L_{2k+4} = L_{2k+2} + L_{2k+3}`. -/
+theorem lucas_odd_sum_add_two (n : ℕ) :
+    (∑ i ∈ range (n + 1), lucas (2 * i + 1)) + 2 = lucas (2 * n + 2) := by
+  induction n with
+  | zero => decide
+  | succ k ih =>
+      rw [Finset.sum_range_succ]
+      have hrec : lucas (2 * k + 4) = lucas (2 * k + 2) + lucas (2 * k + 3) :=
+        lucas_add_two (2 * k + 2)
+      show (∑ i ∈ range (k + 1), lucas (2 * i + 1)) + lucas (2 * k + 3) + 2
+          = lucas (2 * k + 4)
+      omega
+
+/-- **Odd-indexed Lucas sum:** `∑_{i=0}^{n} L_{2i+1} = L_{2n+2} − 2`
+(truncated subtraction over `ℕ`; well-defined since `L_{2n+2} ≥ 2`). -/
+theorem lucas_odd_sum (n : ℕ) :
+    (∑ i ∈ range (n + 1), lucas (2 * i + 1)) = lucas (2 * n + 2) - 2 := by
+  have h := lucas_odd_sum_add_two n
+  omega
+
+/-! ## Numerical sanity checks -/
+
+/-- Alternating: `L₀ − L₁ + L₂ − L₃ + L₄ = 2 − 1 + 3 − 4 + 7 = 7`,
+matching `3 + (−1)⁴(L₅ − L₄) = 3 + (11 − 7) = 7`. -/
+theorem alt_lucas_sum_example :
+    (∑ i ∈ range 5, (-1 : ℤ) ^ i * (lucas i : ℤ)) = 7 := by decide
+
+/-- Even-indexed: `L₀ + L₂ + L₄ = 2 + 3 + 7 = 12 = L₅ + 1 = 11 + 1`. -/
+theorem lucas_even_sum_example : (∑ i ∈ range 3, lucas (2 * i)) = 12 := by decide
+
+/-- Odd-indexed: `L₁ + L₃ + L₅ = 1 + 4 + 11 = 16 = L₆ − 2 = 18 − 2`. -/
+theorem lucas_odd_sum_example : (∑ i ∈ range 3, lucas (2 * i + 1)) = 16 := by decide
+
+end FibonacciIdentitiesOQ08OQ01

--- a/src/data/proofs/fibonacci-identities-oq-08-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-08-oq-01/meta.json
@@ -1,0 +1,85 @@
+{
+  "id": "fibonacci-identities-oq-08-oq-01",
+  "title": "Alternating and Bisected Lucas Partial Sums",
+  "slug": "fibonacci-identities-oq-08-oq-01",
+  "description": "The three companion partial-sum identities for the Lucas numbers requested by the parent entry's open question: the alternating sum ∑_{i≤n} (−1)ⁱ Lᵢ = 3 + (−1)ⁿ (L_{n+1} − Lₙ) (over ℤ), the even-indexed sum ∑_{i≤n} L_{2i} = L_{2n+1} + 1, and the odd-indexed sum ∑_{i≤n} L_{2i+1} = L_{2n+2} − 2. Each is a one-step telescoping induction; the bisected sums are kept subtraction-free so omega closes them, the alternating step closes by ring keeping (−1)ⁿ as an opaque atom. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lucas (1878) / Vajda (1989) (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_number",
+    "date": "1878",
+    "status": "verified",
+    "tags": ["number-theory", "fibonacci", "lucas-numbers", "telescoping-sum", "alternating-sum", "bisection", "induction", "research"],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ08OQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {"theorem": "Finset.sum_range_succ", "description": "Peeling the last term of a range sum — the engine of all three telescoping inductions", "module": "Mathlib.Algebra.BigOperators.Basic"},
+      {"theorem": "Finset.sum_range_one", "description": "Evaluating the singleton base sum ∑_{i<1} f i = f 0 in the alternating-sum base case", "module": "Mathlib.Algebra.BigOperators.Basic"}
+    ],
+    "originalContributions": [
+      "alt_lucas_sum: the alternating Lucas sum ∑_{i=0}^{n} (−1)ⁱ Lᵢ = 3 + (−1)ⁿ (L_{n+1} − Lₙ), stated over ℤ in a subtraction-free closed form that avoids the negative index L_{n−1}",
+      "lucas_even_sum: the even-indexed (bisected) sum ∑_{i=0}^{n} L_{2i} = L_{2n+1} + 1",
+      "lucas_odd_sum_add_two / lucas_odd_sum: the odd-indexed (bisected) sum ∑_{i=0}^{n} L_{2i+1} = L_{2n+2} − 2, in subtraction-free and truncated-subtraction forms",
+      "lucas_add_two_int: the integer-cast Lucas recurrence, keeping the alternating-sum induction in ℤ",
+      "Self-contained Lucas-number definition via pair recursion (reducing by rfl), reused from the parent and sibling Lucas entries"
+    ],
+    "dateAdded": "2026-07-01",
+    "lineCount": 142,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms on alt_lucas_sum, lucas_even_sum, lucas_odd_sum); no sorryAx and no Lean.ofReduceBool — the three numerical examples use kernel `decide`, not `native_decide`. All identities are established by ordinary one-step induction via Finset.sum_range_succ.",
+    "theoremCount": 11,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Lucas numbers Lₙ (L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁, introduced by Édouard Lucas in the 1870s) are the companion sequence to the Fibonacci numbers and satisfy the same web of summation identities. Beyond the plain telescoping sum ∑_{i≤n} Lᵢ = L_{n+2} − 1 (parent entry), three variants are standard: the alternating sum ∑ (−1)ⁱ Lᵢ, and the two bisected (even- and odd-indexed) sums ∑ L_{2i} and ∑ L_{2i+1}. The alternating sum requires working over ℤ to carry the sign; the bisected sums stay in ℕ and telescope with the two-step recurrence.",
+    "problemStatement": "**Open question (fibonacci-identities-oq-08, openQuestions[0])**: Prove the alternating Lucas sum ∑_{i≤n} (−1)ⁱ Lᵢ and the odd/even-indexed partial sums (∑ L_{2i}, ∑ L_{2i+1}) in closed form, over ℤ to handle sign alternation.\n\n**Result**: A fully verified (0 sorries, 0 axioms) development of all three: ∑_{i≤n} (−1)ⁱ Lᵢ = 3 + (−1)ⁿ (L_{n+1} − Lₙ), ∑_{i≤n} L_{2i} = L_{2n+1} + 1, and ∑_{i≤n} L_{2i+1} = L_{2n+2} − 2.",
+    "text": "Three Lucas partial-sum identities — the alternating sum ∑ (−1)ⁱ Lᵢ = 3 + (−1)ⁿ(L_{n+1} − Lₙ) over ℤ, and the bisected sums ∑ L_{2i} = L_{2n+1} + 1 and ∑ L_{2i+1} = L_{2n+2} − 2 — each proved by a one-step telescoping induction.",
+    "proofStrategy": "**Proof Strategy:**\n\n1. **Alternating sum (over ℤ)**: The Binet computation ∑ (−φ)ⁱ + ∑ (−ψ)ⁱ telescopes to L₂ + (−1)ⁿ L_{n−1} = 3 + (−1)ⁿ L_{n−1}; writing L_{n−1} = L_{n+1} − Lₙ gives the subtraction-free closed form 3 + (−1)ⁿ (L_{n+1} − Lₙ), valid for all n with no negative index. The induction step keeps (−1)ᵏ as an opaque atom, rewrites the integer-cast recurrence L_{k+2} = L_k + L_{k+1} and (−1)^{k+1} = −(−1)ᵏ (via `pow_succ`), and closes by `ring`.\n\n2. **Even-indexed sum**: Stated directly as ∑_{i≤n} L_{2i} = L_{2n+1} + 1; the induction step glues the new term L_{2k+2} to the inductive L_{2k+1} via L_{2k+3} = L_{2k+1} + L_{2k+2}, closed by `omega` after normalising indices by defeq.\n\n3. **Odd-indexed sum**: Stated subtraction-free as (∑_{i≤n} L_{2i+1}) + 2 = L_{2n+2} (`lucas_odd_sum_add_two`), so `omega` finishes from L_{2k+4} = L_{2k+2} + L_{2k+3}; the truncated-subtraction form `lucas_odd_sum` follows by `omega`.",
+    "keyInsights": [
+      "**The alternating sum has a Binet-derived closed form 3 + (−1)ⁿ L_{n−1}**: The geometric series ∑ (−φ)ⁱ + ∑ (−ψ)ⁱ telescopes using 1 + φ = φ², φψ = −1, leaving the constant L₂ = 3 plus a signed shifted Lucas term. Rewriting L_{n−1} = L_{n+1} − Lₙ eliminates the negative index so the identity holds for every n ∈ ℕ.",
+      "**Sign handling forces ℤ but not much else**: Only the alternating sum needs ℤ; the (−1)ⁿ factor is treated as an opaque atom, so the inductive step is a single `ring` call after `pow_succ` turns (−1)^{k+1} into −(−1)ᵏ. The recurrence enters as its integer cast lucas_add_two_int.",
+      "**The two bisections carry different constants for the same reason as the plain sum**: The even sum picks up +1 and the odd sum −2, mirroring L₁ = 1 and L₀ = 2 as the boundary terms of the two interleaved subsequences; both telescope with the two-step recurrence L_{k+2} = L_k + L_{k+1}.",
+      "**Subtraction-free framing keeps `omega` in charge**: The odd sum is proved in the form (∑ …) + 2 = L_{2n+2}, and index arithmetic like 2·(k+1)+1 = 2k+3 is discharged by definitional equality, so `omega` sees the Lucas recurrence as a linear fact over atoms."
+    ],
+    "prerequisites": [
+      "Lucas number recurrence L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁",
+      "Induction over ℕ and Finset range sums (Finset.sum_range_succ)",
+      "Binet's formula Lₙ = φⁿ + ψⁿ (motivation for the alternating closed form)"
+    ]
+  },
+  "sections": [
+    {"id": "setup", "title": "Imports, Docstring, and Lucas Definition", "startLine": 1, "endLine": 74, "summary": "Module docstring framing the three partial-sum variants; imports Mathlib.Data.Nat.Fib.Basic and Mathlib.Tactic; opens namespace FibonacciIdentitiesOQ08OQ01. Defines the Lucas numbers via pair recursion (lucasPair / lucas) with base facts lucas_zero, lucas_one, the recurrence lucas_add_two, and its integer cast lucas_add_two_int.", "mathContext": "Lucas numbers L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁, the companion sequence to the Fibonacci numbers."},
+    {"id": "alternating", "title": "The Alternating Lucas Sum ∑ (−1)ⁱ Lᵢ", "startLine": 76, "endLine": 89, "summary": "alt_lucas_sum proves ∑_{i≤n} (−1)ⁱ Lᵢ = 3 + (−1)ⁿ (L_{n+1} − Lₙ) over ℤ by one-step induction: rewrite Finset.sum_range_succ, the inductive hypothesis, the integer-cast recurrence, and pow_succ, then close by ring with (−1)ⁿ kept as an atom.", "mathContext": "The alternating (signed) Lucas partial sum, with Binet-derived closed form avoiding the negative index L_{n−1}."},
+    {"id": "even", "title": "The Even-Indexed Sum ∑ L_{2i} = L_{2n+1} + 1", "startLine": 91, "endLine": 104, "summary": "lucas_even_sum proves ∑_{i≤n} L_{2i} = L_{2n+1} + 1 by one-step induction; the new term L_{2k+2} glues to L_{2k+1} via L_{2k+3} = L_{2k+1} + L_{2k+2}, closed by omega after a defeq `show` normalises the indices.", "mathContext": "The bisected even-indexed Lucas sum; constant +1 from the L₁ boundary term."},
+    {"id": "odd", "title": "The Odd-Indexed Sum ∑ L_{2i+1} = L_{2n+2} − 2", "startLine": 106, "endLine": 127, "summary": "lucas_odd_sum_add_two proves the subtraction-free (∑_{i≤n} L_{2i+1}) + 2 = L_{2n+2} by induction using L_{2k+4} = L_{2k+2} + L_{2k+3}; lucas_odd_sum gives the truncated-subtraction form ∑ L_{2i+1} = L_{2n+2} − 2 by omega.", "mathContext": "The bisected odd-indexed Lucas sum; constant −2 from the L₀ = 2 boundary term."},
+    {"id": "examples", "title": "Numerical Sanity Checks", "startLine": 129, "endLine": 142, "summary": "Three decidable checks: ∑_{i<5} (−1)ⁱ Lᵢ = 7 (= 3 + (L₅ − L₄)), ∑_{i<3} L_{2i} = 12 (= L₅ + 1), and ∑_{i<3} L_{2i+1} = 16 (= L₆ − 2). All by kernel `decide` (no native_decide, so no Lean.ofReduceBool).", "mathContext": "Concrete instances confirming the three closed forms."}
+  ],
+  "crossReferences": [
+    {"targetId": "fibonacci-identities-oq-08", "relationship": "extends", "description": "Answers openQuestions[0] of the parent Lucas partial-sum entry: the alternating and bisected (even/odd-indexed) Lucas sums, complementing the parent's plain telescoping sum ∑ Lᵢ = L_{n+2} − 1 and mixed sum ∑ Fᵢ·Lᵢ."},
+    {"targetId": "fibonacci-identities", "relationship": "related", "description": "The Lucas-number counterparts of the classical Fibonacci alternating and bisected partial sums, built on the same telescoping-induction template."}
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) formalization of the three companion Lucas partial-sum identities: the alternating sum ∑_{i≤n} (−1)ⁱ Lᵢ = 3 + (−1)ⁿ (L_{n+1} − Lₙ) over ℤ, the even-indexed sum ∑_{i≤n} L_{2i} = L_{2n+1} + 1, and the odd-indexed sum ∑_{i≤n} L_{2i+1} = L_{2n+2} − 2, together with three decidable numerical checks.",
+    "implications": "**Theoretical Significance**: These are the exact Lucas-number counterparts of the classical alternating and bisected Fibonacci summation identities, and they answer the parent entry's open question in full. The development highlights two reusable techniques: (i) deriving a subtraction-free closed form for a signed (alternating) sum via Binet and eliminating the negative index by the recurrence, so the inductive step closes by a single `ring` with (−1)ⁿ as an opaque atom; and (ii) proving bisected sums in subtraction-free `(∑ …) + c = …` form so `omega` discharges each step over ℕ from the two-step Lucas recurrence.",
+    "openQuestions": [
+      "Unify the three identities and the parent's plain sum as specialisations of a single generating-function identity ∑ Lᵢ xⁱ = (2 − x)/(1 − x − x²), reading off x = 1, x = −1, and the even/odd parts by partial fractions.",
+      "Prove the analogous alternating and bisected sums for the mixed products ∑ (−1)ⁱ Fᵢ·Lᵢ and ∑ F_{2i}·L_{2i}, using the product identity Fₙ·Lₙ = F_{2n} to reduce them to (bisected) Fibonacci sums."
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib.Data.Nat.Fib.Basic", "Mathlib.Tactic"],
+    "opens": ["Nat", "Finset"],
+    "namespace": "FibonacciIdentitiesOQ08OQ01",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 2,
+    "path": "Proofs/FibonacciIdentitiesOQ08OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {"authors": "Édouard Lucas", "title": "Théorie des fonctions numériques simplement périodiques", "year": "1878", "venue": "American Journal of Mathematics", "note": "Introduction and systematic study of the Lucas numbers Lₙ"},
+    {"authors": "Steven Vajda", "title": "Fibonacci and Lucas Numbers, and the Golden Section", "year": "1989", "venue": "Ellis Horwood", "note": "Catalogue of Fibonacci–Lucas identities including the alternating and bisected partial-sum formulas"}
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry answering **openQuestions[0]** of parent `fibonacci-identities-oq-08`: the three companion Lucas partial-sum identities.

| Identity | Closed form |
|----------|-------------|
| Alternating (over ℤ) | `∑_{i≤n} (−1)ⁱ Lᵢ = 3 + (−1)ⁿ (L_{n+1} − Lₙ)` |
| Even-indexed | `∑_{i≤n} L_{2i} = L_{2n+1} + 1` |
| Odd-indexed | `∑_{i≤n} L_{2i+1} = L_{2n+2} − 2` |

## Approach
- Each is a **one-step telescoping induction** via `Finset.sum_range_succ`.
- The bisected sums are kept **subtraction-free** so `omega` closes each step from the Lucas recurrence `L_{k+2}=L_k+L_{k+1}`.
- The alternating step works over ℤ, keeps `(−1)ⁿ` as an opaque atom, and closes by `ring` after `pow_succ` and the integer-cast recurrence. The closed form `3 + (−1)ⁿ(L_{n+1}−Lₙ)` is Binet-derived and avoids the negative index `L_{n−1}`.

## Verification
- **0 sorries, 0 axioms** — `#print axioms` on all three main theorems lists only `propext, Classical.choice, Quot.sound`; no `sorryAx`, no `Lean.ofReduceBool` (examples use kernel `decide`).
- Compiles cleanly under `lake env lean` (no errors/warnings).
- 11 theorems, 2 defs, 142 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)