### PR TITLE
Enrich Abel's Theorem in the Regular Direction (geometric-series-oq-01-oq-03-oq-01): 4→5 annotations

### DIFF
--- a/src/data/proofs/geometric-series-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-03-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-gs-oq010301-header",
+    "proofId": "geometric-series-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 49
+    },
+    "type": "context",
+    "title": "Abel's Theorem (Regular Direction) and the Packaging Strategy",
+    "content": "Abel's theorem has two directions. The REGULAR direction proved here says every convergent series is Abel summable to its own sum: if ∑ₙ aₙ = L then A(x)=∑ₙ aₙxⁿ → L as x→1⁻. (The converse — a Tauberian theorem — needs an extra hypothesis such as aₙ=o(1/n) and is NOT claimed.) The parent entry proved only the geometric instance aₙ=rⁿ by hand; this entry generalises to ALL convergent series, answering the parent's open question oq-01. The header is explicit that this is a PACKAGING result: the hard analytic core (left-continuity of A at 1, proved in Mathlib by summation-by-parts on a Stolz sector) is imported, and the four-step contribution is (1) dominated-convergence summability on [0,1), (2) the left-limit, (3) synthesis into the parent's AbelSummableTo predicate, (4) reduction of the geometric boundary case to the general theorem.",
+    "mathContext": "Regular direction: $\\sum_n a_n = L \\Rightarrow \\lim_{x\\to 1^-}\\sum_n a_n x^n = L$. The proportional Tauberian converse requires $a_n=o(1/n)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Abel summability",
+      "Tauberian theorems",
+      "summation by parts",
+      "Stolz sector"
+    ],
+    "prerequisites": [
+      "convergent series",
+      "power series",
+      "one-sided limits"
+    ]
+  },
+  {
     "id": "ann-gsoq0301-summable-disc",
     "proofId": "geometric-series-oq-01-oq-03-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-01-oq-03-oq-01` ("Abel's Theorem in the Regular Direction, at Full Strength").

**Gap:** all four theorems were already annotated, but the 45-line module docstring (theorem statement, Abel-vs-Tauberian framing, honest-scope disclosure) was uncovered — coverage ~37%.

**Added 1 context annotation (4→5), coverage ~37%→~74%:**
- **Module docstring (context):** Abel's theorem in the regular direction (and why the Tauberian converse is *not* claimed), the packaging-over-Mathlib strategy, and the four-step contribution over the imported left-continuity core (`Real.tendsto_tsum_powerSeries_nhdsWithin_lt`).

Carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Focused, curation-minded addition (the four theorems were already well annotated).

**Validation:** `resolver.ts validate` → 5 valid, 0 misaligned. No meta.json or Lean changes.