### PR TITLE
research(four-square-distribution-oq-06-oq-03): prime-power closed forms of the r₂ arithmetic side via χ₄ [VERIFIED, 0-axiom, 11thm/183L, new entry]

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ06OQ03.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ06OQ03.lean
@@ -1,0 +1,183 @@
+import Mathlib.NumberTheory.Divisors
+import Mathlib.NumberTheory.LegendreSymbol.ZModChar
+import Mathlib.Algebra.Ring.GeomSum
+import Mathlib.Tactic
+
+/-
+# Symbolic prime-power values of the r₂ arithmetic side (OQ-06-OQ-03 of FourSquareDistribution)
+
+## Open Question (Gallery OQ-06-OQ-03 of `four-square-distribution`)
+"Do the sibling sum-of-squares counts admit analogous `native_decide`-free closed forms on
+prime powers?  Jacobi's r₂, r₆, r₈ … are also expressed through (modified) divisor sums; the
+same `divisors_prime_pow` + parity strategy may yield symbolic prime-power values for those
+families."
+
+## What this provides
+
+The parent `FourSquareDistributionOQ06` computes symbolic prime-power values of Jacobi's
+`σ*` divisor sum, the arithmetic side of the **four**-square count r₄.  This file carries out
+the same programme one exponent down, for the **two**-square count r₂, whose arithmetic side
+is Jacobi's classical two-square formula
+
+  r₂(n) = 4 · Σ_{d ∣ n} χ₄(d),
+
+where `χ₄` is Mathlib's primitive quadratic character mod 4
+(`χ₄(d) = 0, 1, −1` according as `d` is even, `≡ 1`, `≡ 3 (mod 4)`).  Writing
+
+  `chiSum n = Σ_{d ∣ n} χ₄(d)`      and      `jacobiR2 n = 4 · chiSum n`,
+
+we give closed forms on every prime power, split by the residue of the prime mod 4 — exactly
+the trichotomy that governs which primes are sums of two squares:
+
+* `chiSum_two_pow` — `chiSum (2ᵏ) = 1`: every proper power of 2 is even, so `χ₄` kills all
+  divisors except `1`.  Hence `jacobiR2 (2ᵏ) = 4`.
+* `chiSum_prime_pow_one_mod_four` — for `p ≡ 1 (mod 4)`, `χ₄(pⁱ) = 1` for all `i`, so
+  `chiSum (pᵏ) = k + 1` and `jacobiR2 (pᵏ) = 4(k+1)`.  (Split primes contribute a full ramp.)
+* `chiSum_prime_pow_three_mod_four` — for `p ≡ 3 (mod 4)`, `χ₄(pⁱ) = (−1)ⁱ`, an alternating
+  sum, so `chiSum (pᵏ) = 1` if `k` even and `0` if `k` odd; hence `jacobiR2 (pᵏ)` is `4` or `0`.
+  (Inert primes: `pᵏ` is a sum of two squares iff `k` is even.)
+
+The numeric corollaries `jacobiR2_five/nine/three/eight` recover the small two-square counts
+r₂(5)=8, r₂(9)=4, r₂(3)=0, r₂(8)=4 symbolically, as instances of the three families rather
+than by `native_decide`.
+
+## Honest scope
+
+`jacobiR2` is *defined* as `4 · Σ χ₄(d)`; these theorems compute that arithmetic side
+symbolically on prime powers.  They do **not** prove the geometric identity
+r₂(n) = #{(a,b) ∈ ℤ² : a²+b² = n} equals `jacobiR2 n` (Jacobi's two-square theorem) — that,
+like the parent's r₄ identity, is the genuinely open direction.  The contribution here is the
+arithmetic closed forms, fully machine-checked with no axioms and no `native_decide`.
+-/
+
+namespace FourSquareDistributionOQ06OQ03
+
+open Finset ZMod
+
+/-- The arithmetic side of Jacobi's two-square formula:
+    `chiSum n = Σ_{d ∣ n} χ₄(d)`, so Jacobi's prediction reads `r₂(n) = 4 · chiSum n`.
+    Here `χ₄` is Mathlib's primitive quadratic character mod 4. -/
+def chiSum (n : ℕ) : ℤ := ∑ d ∈ n.divisors, χ₄ (d : ZMod 4)
+
+/-- Jacobi's prediction for the two-square count, `r₂(n) = 4 · Σ_{d ∣ n} χ₄(d)`. -/
+def jacobiR2 (n : ℕ) : ℤ := 4 * chiSum n
+
+-- =====================================================================
+-- PART 0: base value
+-- =====================================================================
+
+/-- `chiSum 1 = 1`: the sole divisor of `1` is `1`, and `χ₄(1) = 1`.  Hence `jacobiR2 1 = 4`,
+    matching r₂(1) = #{(±1,0),(0,±1)} = 4. -/
+theorem chiSum_one : chiSum 1 = 1 := by
+  simp [chiSum]
+
+-- =====================================================================
+-- PART 1: even prime powers — χ₄ kills everything but the unit divisor
+-- =====================================================================
+
+/-- **Powers of two.** Every divisor of `2ᵏ` other than `1` is even, so `χ₄` sends it to `0`;
+    the modified divisor sum collapses to `χ₄(1) = 1`.  Thus `chiSum (2ᵏ) = 1` for all `k`. -/
+theorem chiSum_two_pow (k : ℕ) : chiSum (2 ^ k) = 1 := by
+  unfold chiSum
+  rw [Nat.divisors_prime_pow Nat.prime_two, Finset.sum_map]
+  simp only [Function.Embedding.coeFn_mk]
+  rw [Finset.sum_eq_single 0]
+  · -- value at i = 0 : χ₄(2⁰) = χ₄(1) = 1
+    simp
+  · -- every other term vanishes : χ₄(2ⁱ) = 0 for i ≠ 0 since 2ⁱ is even
+    intro i _ hi
+    have h2 : 2 ^ i % 2 = 0 := by
+      have : (2 : ℕ) ∣ 2 ^ i := dvd_pow_self 2 hi
+      omega
+    rw [χ₄_nat_eq_if_mod_four, if_pos h2]
+  · -- 0 always lies in range (k+1)
+    intro h
+    exact absurd (Finset.mem_range.mpr (Nat.succ_pos k)) h
+
+-- =====================================================================
+-- PART 2: odd prime powers, split prime  p ≡ 1 (mod 4)
+-- =====================================================================
+
+/-- **Split primes `p ≡ 1 (mod 4)`.** Here `χ₄(p) = 1`, so `χ₄(pⁱ) = 1ⁱ = 1` for every `i`,
+    and the divisor sum is the full ramp `chiSum (pᵏ) = k + 1`. -/
+theorem chiSum_prime_pow_one_mod_four {p : ℕ} (hp : p.Prime) (hp1 : p % 4 = 1) (k : ℕ) :
+    chiSum (p ^ k) = (k : ℤ) + 1 := by
+  unfold chiSum
+  rw [Nat.divisors_prime_pow hp, Finset.sum_map]
+  simp only [Function.Embedding.coeFn_mk]
+  have hval : ∀ i ∈ Finset.range (k + 1), χ₄ ((p ^ i : ℕ) : ZMod 4) = 1 := by
+    intro i _
+    push_cast
+    rw [map_pow, χ₄_nat_one_mod_four hp1, one_pow]
+  rw [Finset.sum_congr rfl hval, Finset.sum_const, Finset.card_range]
+  simp
+
+-- =====================================================================
+-- PART 3: odd prime powers, inert prime  p ≡ 3 (mod 4)
+-- =====================================================================
+
+/-- **Inert primes `p ≡ 3 (mod 4)`.** Here `χ₄(p) = −1`, so `χ₄(pⁱ) = (−1)ⁱ` alternates and
+    the divisor sum telescopes to `1` when `k` is even and `0` when `k` is odd.  This is the
+    arithmetic shadow of "`pᵏ` is a sum of two squares iff `k` is even". -/
+theorem chiSum_prime_pow_three_mod_four {p : ℕ} (hp : p.Prime) (hp3 : p % 4 = 3) (k : ℕ) :
+    chiSum (p ^ k) = if Even k then 1 else 0 := by
+  unfold chiSum
+  rw [Nat.divisors_prime_pow hp, Finset.sum_map]
+  simp only [Function.Embedding.coeFn_mk]
+  have hval : ∀ i ∈ Finset.range (k + 1), χ₄ ((p ^ i : ℕ) : ZMod 4) = (-1 : ℤ) ^ i := by
+    intro i _
+    push_cast
+    rw [map_pow, χ₄_nat_three_mod_four hp3]
+  rw [Finset.sum_congr rfl hval, neg_one_geom_sum]
+  -- reconcile `if Even (k+1) then 0 else 1` with `if Even k then 1 else 0`
+  by_cases hk : Even k
+  · rw [if_pos hk, if_neg (by rw [Nat.even_add_one]; exact not_not.mpr hk)]
+  · rw [if_neg hk, if_pos (Nat.even_add_one.mpr hk)]
+
+-- =====================================================================
+-- PART 4: Jacobi's r₂ prediction (= 4 · chiSum) on prime powers
+-- =====================================================================
+
+/-- `jacobiR2 (2ᵏ) = 4` for every `k`. -/
+theorem jacobiR2_two_pow (k : ℕ) : jacobiR2 (2 ^ k) = 4 := by
+  unfold jacobiR2; rw [chiSum_two_pow]; norm_num
+
+/-- `jacobiR2 (pᵏ) = 4(k+1)` for a split prime `p ≡ 1 (mod 4)`. -/
+theorem jacobiR2_prime_pow_one_mod_four {p : ℕ} (hp : p.Prime) (hp1 : p % 4 = 1) (k : ℕ) :
+    jacobiR2 (p ^ k) = 4 * ((k : ℤ) + 1) := by
+  unfold jacobiR2; rw [chiSum_prime_pow_one_mod_four hp hp1]
+
+/-- `jacobiR2 (pᵏ) = 4` (k even) or `0` (k odd) for an inert prime `p ≡ 3 (mod 4)`. -/
+theorem jacobiR2_prime_pow_three_mod_four {p : ℕ} (hp : p.Prime) (hp3 : p % 4 = 3) (k : ℕ) :
+    jacobiR2 (p ^ k) = if Even k then 4 else 0 := by
+  unfold jacobiR2
+  rw [chiSum_prime_pow_three_mod_four hp hp3, mul_ite, mul_one, mul_zero]
+
+-- =====================================================================
+-- PART 5: numeric recoveries (no native_decide) of small two-square counts
+-- =====================================================================
+
+/-- r₂(5) = 8, as the `p = 5 ≡ 1, k = 1` instance. -/
+theorem jacobiR2_five : jacobiR2 5 = 8 := by
+  have h := jacobiR2_prime_pow_one_mod_four (p := 5) (by norm_num) (by norm_num) 1
+  simpa using h
+
+/-- r₂(9) = 4, as the `p = 3 ≡ 3, k = 2` (even) instance. -/
+theorem jacobiR2_nine : jacobiR2 9 = 4 := by
+  have h := jacobiR2_prime_pow_three_mod_four (p := 3) (by norm_num) (by norm_num) 2
+  norm_num at h
+  simpa using h
+
+/-- r₂(3) = 0, as the `p = 3 ≡ 3, k = 1` (odd) instance. -/
+theorem jacobiR2_three : jacobiR2 3 = 0 := by
+  have h := jacobiR2_prime_pow_three_mod_four (p := 3) (by norm_num) (by norm_num) 1
+  norm_num at h
+  simpa using h
+
+/-- r₂(8) = 4, as the `2³` instance. -/
+theorem jacobiR2_eight : jacobiR2 8 = 4 := by
+  have h := jacobiR2_two_pow 3
+  norm_num at h
+  simpa using h
+
+end FourSquareDistributionOQ06OQ03

--- a/src/data/proofs/four-square-distribution-oq-06-oq-03/annotations.json
+++ b/src/data/proofs/four-square-distribution-oq-06-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "fsd0603-ann-header",
+    "proofId": "four-square-distribution-oq-06-oq-03",
+    "range": { "startLine": 6, "endLine": 63 },
+    "type": "concept",
+    "title": "The Two-Square Analogue of the Parent's r₄ / σ* Programme",
+    "content": "The header states OQ-06-OQ-03: whether the sibling sum-of-squares counts admit the same native_decide-free prime-power closed forms the parent OQ-06 gave for the four-square σ*. Here we treat the two-square count r₂, whose arithmetic side is Jacobi's classical formula r₂(n) = 4·Σ_{d∣n} χ₄(d), with χ₄ Mathlib's primitive quadratic character mod 4 (χ₄(d) = 0, 1, −1 as d is even, ≡ 1, ≡ 3 mod 4). Two definitions set the stage: `chiSum n = Σ_{d∣n} χ₄(↑d)` and `jacobiR2 n = 4·chiSum n`. The honest-scope note matters: jacobiR2 is *defined* as 4·Σχ₄(d), so these theorems compute the arithmetic side, not the geometric two-square theorem r₂(n) = #{(a,b) : a²+b²=n}."
+  },
+  {
+    "id": "fsd0603-ann-two-pow",
+    "proofId": "four-square-distribution-oq-06-oq-03",
+    "range": { "startLine": 78, "endLine": 95 },
+    "type": "theorem",
+    "title": "Powers of 2: χ₄ Kills Every Divisor but 1",
+    "content": "chiSum_two_pow proves chiSum(2ᵏ) = 1 for all k. After `Nat.divisors_prime_pow` rewrites divisors(2ᵏ) as the image of {0,…,k} under i ↦ 2ⁱ, `Finset.sum_eq_single 0` isolates the surviving term: for i ≥ 1 the divisor 2ⁱ is even, so `χ₄_nat_eq_if_mod_four` (with 2ⁱ % 2 = 0 obtained from dvd_pow_self + omega) sends χ₄(2ⁱ) to 0, while χ₄(2⁰) = χ₄(1) = 1. Hence jacobiR2(2ᵏ) = 4."
+  },
+  {
+    "id": "fsd0603-ann-split-prime",
+    "proofId": "four-square-distribution-oq-06-oq-03",
+    "range": { "startLine": 101, "endLine": 113 },
+    "type": "theorem",
+    "title": "Split Primes p ≡ 1 (mod 4): the Full Ramp k+1",
+    "content": "chiSum_prime_pow_one_mod_four proves chiSum(pᵏ) = k+1. Complete multiplicativity of the character (`map_pow`, since MulChar is a MonoidHomClass) turns χ₄(pⁱ) into χ₄(p)ⁱ, and `χ₄_nat_one_mod_four` fixes χ₄(p) = 1, so every term of the divisor sum is 1ⁱ = 1; the sum over k+1 exponents is k+1. Thus jacobiR2(pᵏ) = 4(k+1) — a split prime contributes a full arithmetic ramp."
+  },
+  {
+    "id": "fsd0603-ann-inert-prime",
+    "proofId": "four-square-distribution-oq-06-oq-03",
+    "range": { "startLine": 119, "endLine": 135 },
+    "type": "insight",
+    "title": "Inert Primes p ≡ 3 (mod 4): a Parity Indicator",
+    "content": "chiSum_prime_pow_three_mod_four proves chiSum(pᵏ) = if Even k then 1 else 0. Here χ₄(p) = −1 (`χ₄_nat_three_mod_four`), so χ₄(pⁱ) = (−1)ⁱ and the divisor sum is a finite geometric series in −1; `neg_one_geom_sum` collapses Σ_{i≤k} (−1)ⁱ to `if Even (k+1) then 0 else 1`, reconciled with the k-parity statement via `Nat.even_add_one`. The value is 1 exactly when k is even — the arithmetic shadow of the fact that pᵏ is a sum of two squares iff k is even."
+  },
+  {
+    "id": "fsd0603-ann-jacobi-pred",
+    "proofId": "four-square-distribution-oq-06-oq-03",
+    "range": { "startLine": 141, "endLine": 154 },
+    "type": "theorem",
+    "title": "Jacobi's r₂ Prediction on Prime Powers",
+    "content": "jacobiR2_two_pow (= 4), jacobiR2_prime_pow_one_mod_four (= 4(k+1)) and jacobiR2_prime_pow_three_mod_four (= 4 if k even else 0) propagate the three chiSum closed forms through jacobiR2 = 4·chiSum. Together they give Jacobi's two-square prediction on every prime power, split entirely by the prime's residue mod 4."
+  },
+  {
+    "id": "fsd0603-ann-numeric",
+    "proofId": "four-square-distribution-oq-06-oq-03",
+    "range": { "startLine": 160, "endLine": 183 },
+    "type": "insight",
+    "title": "Small Two-Square Counts Recovered Without native_decide",
+    "content": "jacobiR2_five (= 8), jacobiR2_nine (= 4), jacobiR2_three (= 0) and jacobiR2_eight (= 4) recover the small representation counts r₂(5)=8, r₂(9)=4, r₂(3)=0, r₂(8)=4 as instances of the three prime-power families — 5 ≡ 1 (split), 3 ≡ 3 (inert, at even and odd exponents), and 8 = 2³. Each is a closed-form specialization proved with only the foundational axioms, avoiding the Lean.ofReduceBool that a native_decide point-check would incur."
+  }
+]

--- a/src/data/proofs/four-square-distribution-oq-06-oq-03/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-06-oq-03/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "four-square-distribution-oq-06-oq-03",
+  "slug": "four-square-distribution-oq-06-oq-03",
+  "title": "Prime-power closed forms of the r₂ arithmetic side: r₂(pᵏ) via χ₄ by p mod 4",
+  "description": "OQ-06-OQ-03 of four-square-distribution asks whether the sibling sum-of-squares counts admit the same native_decide-free prime-power closed forms that the parent OQ-06 established for r₄'s σ*. This entry carries the programme one exponent down, to the two-square count r₂, whose arithmetic side is Jacobi's formula r₂(n) = 4·Σ_{d∣n} χ₄(d) with χ₄ Mathlib's primitive quadratic character mod 4. Writing chiSum n = Σ_{d∣n} χ₄(d) and jacobiR2 n = 4·chiSum n, the divisor sum is computed symbolically on every prime power, split by the prime's residue mod 4 — the same trichotomy that decides which primes are sums of two squares: (i) chiSum(2ᵏ) = 1 (χ₄ kills every even divisor), so jacobiR2(2ᵏ) = 4; (ii) for a split prime p ≡ 1 (mod 4), χ₄(pⁱ) = 1 for all i so chiSum(pᵏ) = k+1 and jacobiR2(pᵏ) = 4(k+1); (iii) for an inert prime p ≡ 3 (mod 4), χ₄(pⁱ) = (−1)ⁱ alternates, so chiSum(pᵏ) = 1 (k even) or 0 (k odd) and jacobiR2(pᵏ) = 4 or 0. The small counts r₂(5)=8, r₂(9)=4, r₂(3)=0, r₂(8)=4 are recovered symbolically as instances, with no native_decide. Honest scope: jacobiR2 is defined as 4·Σχ₄(d); this computes that arithmetic side, not the geometric two-square theorem r₂(n) = #{(a,b) : a²+b²=n} = 4·Σχ₄(d).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FourSquareDistributionOQ06OQ03.lean",
+    "tags": [
+      "number-theory",
+      "sum-of-squares",
+      "jacobi",
+      "two-squares",
+      "quadratic-character",
+      "divisor-function",
+      "prime-powers",
+      "closed-form",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked with only Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound); no native_decide, so no Lean.ofReduceBool. Uses Mathlib's primitive quadratic character ZMod.χ₄ and its residue lemmas χ₄_nat_one_mod_four / χ₄_nat_three_mod_four / χ₄_nat_eq_if_mod_four.",
+    "dateAdded": "2026-07-01",
+    "lineCount": 183,
+    "theoremCount": 11,
+    "substantiveTheoremCount": 7,
+    "definitionCount": 2,
+    "originalContributions": [
+      "chiSum_two_pow (PROVED): chiSum(2ᵏ) = 1 for all k — every divisor of 2ᵏ except 1 is even, so Jacobi's character χ₄ sends it to 0 and the divisor sum collapses to χ₄(1) = 1. Hence jacobiR2(2ᵏ) = 4.",
+      "chiSum_prime_pow_one_mod_four (PROVED): for a split prime p ≡ 1 (mod 4), χ₄(p) = 1 forces χ₄(pⁱ) = 1 for all i, so chiSum(pᵏ) = k+1 is the full ramp; jacobiR2(pᵏ) = 4(k+1).",
+      "chiSum_prime_pow_three_mod_four (PROVED): for an inert prime p ≡ 3 (mod 4), χ₄(p) = −1 makes χ₄(pⁱ) = (−1)ⁱ alternate, so the divisor sum telescopes (neg_one_geom_sum) to 1 when k is even and 0 when k is odd — the arithmetic shadow of 'pᵏ is a sum of two squares iff k is even'.",
+      "jacobiR2_two_pow / jacobiR2_prime_pow_one_mod_four / jacobiR2_prime_pow_three_mod_four (PROVED): the r₂ = 4·chiSum predictions, giving 4, 4(k+1), and (4 or 0) on the three prime-power families.",
+      "jacobiR2_five / jacobiR2_nine / jacobiR2_three / jacobiR2_eight (PROVED): symbolic recoveries of the small two-square counts r₂(5)=8, r₂(9)=4, r₂(3)=0, r₂(8)=4 as instances of the three families — no native_decide.",
+      "chiSum_one (PROVED): the base value chiSum(1) = 1, matching r₂(1) = #{(±1,0),(0,±1)} = 4."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.χ₄",
+        "description": "Mathlib's primitive quadratic character mod 4, a MulChar (ZMod 4) ℤ with χ₄(d) = 0, 1, −1 according as d is even, ≡ 1, ≡ 3 (mod 4). Supplies the arithmetic side of Jacobi's two-square formula."
+      },
+      {
+        "theorem": "ZMod.χ₄_nat_one_mod_four / ZMod.χ₄_nat_three_mod_four / ZMod.χ₄_nat_eq_if_mod_four",
+        "description": "Residue evaluations of χ₄ on naturals, used to pin χ₄(p) = ±1 for the split/inert primes and χ₄ = 0 on even divisors."
+      },
+      {
+        "theorem": "Nat.divisors_prime_pow",
+        "description": "divisors(pᵏ) = (range (k+1)).map (p ^ ·) for prime p — turns the divisor sum into a sum over exponents."
+      },
+      {
+        "theorem": "map_pow (MulCharClass → MonoidHomClass)",
+        "description": "χ₄(pⁱ) = χ₄(p)ⁱ from complete multiplicativity of the character, reducing prime-power evaluation to χ₄(p)."
+      },
+      {
+        "theorem": "neg_one_geom_sum",
+        "description": "Σ_{i<n} (−1)ⁱ = if Even n then 0 else 1 — collapses the alternating divisor sum for inert primes."
+      }
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header, Imports, and Definitions",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Docstring stating OQ-06-OQ-03, the two-square analogue of the parent's r₄/σ* programme, and the honest scope (this computes the arithmetic side 4·Σχ₄(d), not the geometric two-square count). Defines chiSum n = Σ_{d∣n} χ₄(d) using Mathlib's ZMod.χ₄, and jacobiR2 n = 4·chiSum n.",
+      "mathContext": "r₂(n) = 4·Σ_{d∣n} χ₄(d), with χ₄ the primitive quadratic character mod 4."
+    },
+    {
+      "id": "sec-base",
+      "title": "Base Value chiSum(1) = 1",
+      "startLine": 65,
+      "endLine": 72,
+      "summary": "chiSum_one: the sole divisor of 1 is 1 and χ₄(1) = 1, so jacobiR2(1) = 4 matches r₂(1) = 4.",
+      "mathContext": "χ₄(1) = 1."
+    },
+    {
+      "id": "sec-two-pow",
+      "title": "Even Prime Powers: χ₄ Kills All but the Unit Divisor",
+      "startLine": 74,
+      "endLine": 95,
+      "summary": "chiSum_two_pow: chiSum(2ᵏ) = 1 for all k. After divisors_prime_pow the sum runs over exponents; every 2ⁱ with i ≥ 1 is even so χ₄(2ⁱ) = 0, leaving χ₄(2⁰) = χ₄(1) = 1.",
+      "mathContext": "χ₄ vanishes on even numbers; only the divisor 1 survives."
+    },
+    {
+      "id": "sec-split-prime",
+      "title": "Split Primes p ≡ 1 (mod 4): chiSum(pᵏ) = k+1",
+      "startLine": 97,
+      "endLine": 113,
+      "summary": "chiSum_prime_pow_one_mod_four: χ₄(p) = 1 (χ₄_nat_one_mod_four) forces χ₄(pⁱ) = 1ⁱ = 1 via map_pow, so the divisor sum is the constant-1 sum over k+1 exponents.",
+      "mathContext": "A prime p ≡ 1 (mod 4) splits in ℤ[i]; its powers each contribute +1 to the χ₄ divisor sum."
+    },
+    {
+      "id": "sec-inert-prime",
+      "title": "Inert Primes p ≡ 3 (mod 4): Alternating Sum",
+      "startLine": 115,
+      "endLine": 135,
+      "summary": "chiSum_prime_pow_three_mod_four: χ₄(p) = −1 (χ₄_nat_three_mod_four) makes χ₄(pⁱ) = (−1)ⁱ; neg_one_geom_sum telescopes the sum over k+1 exponents to 1 (k even) or 0 (k odd), reconciled through Nat.even_add_one.",
+      "mathContext": "pᵏ is a sum of two squares iff k is even — the parity of the alternating χ₄ sum."
+    },
+    {
+      "id": "sec-jacobi-pred",
+      "title": "Jacobi's r₂ Prediction on Prime Powers",
+      "startLine": 137,
+      "endLine": 154,
+      "summary": "jacobiR2_two_pow (= 4), jacobiR2_prime_pow_one_mod_four (= 4(k+1)), jacobiR2_prime_pow_three_mod_four (= 4 or 0): the r₂ = 4·chiSum predictions on the three families.",
+      "mathContext": "jacobiR2 = 4·chiSum propagates each closed form."
+    },
+    {
+      "id": "sec-numeric",
+      "title": "Numeric Recoveries Without native_decide",
+      "startLine": 156,
+      "endLine": 183,
+      "summary": "jacobiR2_five (=8), jacobiR2_nine (=4), jacobiR2_three (=0), jacobiR2_eight (=4): the small two-square counts recovered symbolically as instances of the three prime-power families.",
+      "mathContext": "r₂(5)=8, r₂(9)=4, r₂(3)=0, r₂(8)=4, each as a closed-form instance rather than a brute-force check."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "chiSum_prime_pow_one_mod_four",
+      "type": "theorem",
+      "description": "For a split prime p ≡ 1 (mod 4), the χ₄ divisor sum is the full ramp chiSum(pᵏ) = k+1.",
+      "leanType": "{p : ℕ} → p.Prime → p % 4 = 1 → (k : ℕ) → chiSum (p ^ k) = (k : ℤ) + 1"
+    },
+    {
+      "name": "chiSum_prime_pow_three_mod_four",
+      "type": "theorem",
+      "description": "For an inert prime p ≡ 3 (mod 4), the alternating χ₄ divisor sum is 1 (k even) or 0 (k odd).",
+      "leanType": "{p : ℕ} → p.Prime → p % 4 = 3 → (k : ℕ) → chiSum (p ^ k) = if Even k then 1 else 0"
+    },
+    {
+      "name": "chiSum_two_pow",
+      "type": "theorem",
+      "description": "On powers of 2 the χ₄ divisor sum collapses to 1, since χ₄ kills every even divisor.",
+      "leanType": "(k : ℕ) → chiSum (2 ^ k) = 1"
+    },
+    {
+      "name": "jacobiR2_prime_pow_three_mod_four",
+      "type": "theorem",
+      "description": "Jacobi's r₂ prediction on inert prime powers: 4 when k is even, 0 when k is odd.",
+      "leanType": "{p : ℕ} → p.Prime → p % 4 = 3 → (k : ℕ) → jacobiR2 (p ^ k) = if Even k then 4 else 0"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Jacobi's two-square theorem expresses the number r₂(n) = #{(a,b) ∈ ℤ² : a²+b² = n} of representations of n as a sum of two squares through the character sum r₂(n) = 4·Σ_{d∣n} χ₄(d), where χ₄ is the non-principal Dirichlet character mod 4. It is the k = 2 member of the r_{2k} family whose k = 4 case (Jacobi's four-square theorem, r₄ = 8·σ*) the parent OQ-06 treats. The parent verified r₄'s divisor side σ* only at fixed n by native_decide, then replaced the table with symbolic prime-power closed forms. This entry runs the identical divisors_prime_pow + residue strategy on the two-square side.",
+    "problemStatement": "**OQ-06-OQ-03 of four-square-distribution**\n\nDo the sibling sum-of-squares counts admit analogous native_decide-free closed forms on prime powers? Jacobi's r₂, r₆, r₈ are also expressed through (modified) divisor sums; the same divisors_prime_pow + parity strategy may yield symbolic prime-power values for those families.",
+    "text": "For the two-square count r₂(n) = 4·Σ_{d∣n} χ₄(d): chiSum(2ᵏ) = 1 (jacobiR2 = 4); for p ≡ 1 (mod 4), chiSum(pᵏ) = k+1 (jacobiR2 = 4(k+1)); for p ≡ 3 (mod 4), chiSum(pᵏ) = 1 if k even else 0 (jacobiR2 = 4 or 0). These are proved for all primes and all exponents at once, no native_decide.",
+    "proofStrategy": "chiSum n = Σ_{d∈divisors n} χ₄(↑d). For a prime power, Nat.divisors_prime_pow rewrites divisors(pᵏ) as the image of {0,…,k} under i ↦ pⁱ, so Finset.sum_map turns chiSum into a sum over exponents. Complete multiplicativity of the character (map_pow, since MulChar is a MonoidHomClass) gives χ₄(pⁱ) = χ₄(p)ⁱ, and the residue lemmas fix χ₄(p): for p ≡ 1 (mod 4) it is 1, so each term is 1 and the sum is k+1; for p ≡ 3 (mod 4) it is −1, so the sum is Σ_{i≤k} (−1)ⁱ, collapsed by neg_one_geom_sum to a parity if-then-else and reconciled via Nat.even_add_one. For p = 2 every 2ⁱ with i ≥ 1 is even, so χ₄_nat_eq_if_mod_four sends it to 0 (Finset.sum_eq_single isolates the surviving unit divisor). jacobiR2 = 4·chiSum propagates each form; the numeric corollaries are instances.",
+    "keyInsights": [
+      "The three prime-power closed forms are governed by χ₄(p) ∈ {0, 1, −1}, i.e. by p mod 4 — the same trichotomy (ramified 2, split p ≡ 1, inert p ≡ 3) that classifies primes as sums of two squares. The arithmetic side already 'knows' the splitting behaviour in ℤ[i].",
+      "For inert primes the divisor sum is a finite geometric series in −1, so chiSum(pᵏ) is a parity indicator: it is 1 exactly when k is even, mirroring that pᵏ is a sum of two squares iff k is even.",
+      "Because χ₄ is completely multiplicative (a genuine MulChar, not an ad-hoc sign), prime-power evaluation reduces to a single χ₄(p) via map_pow — the character API does the bookkeeping that a hand-rolled sign function would force us to reprove.",
+      "As in the parent, replacing native_decide point-checks by symbolic closed forms removes the Lean.ofReduceBool dependency: r₂(5), r₂(9), r₂(3), r₂(8) are all obtained as instances of theorems proved for all p and k, with only Lean's foundational axioms."
+    ],
+    "prerequisites": [
+      "Jacobi's two-square formula r₂(n) = 4·Σ_{d∣n} χ₄(d) and the primitive quadratic character χ₄ mod 4",
+      "Nat.divisors_prime_pow, complete multiplicativity of MulChar (map_pow), neg_one_geom_sum, χ₄ residue lemmas"
+    ]
+  },
+  "conclusion": {
+    "summary": "Machine-verified, native_decide-free closed forms for the r₂ arithmetic side Σ_{d∣n} χ₄(d) on every prime power: chiSum(2ᵏ) = 1 (jacobiR2 = 4); chiSum(pᵏ) = k+1 for split primes p ≡ 1 (mod 4) (jacobiR2 = 4(k+1)); chiSum(pᵏ) = 1 or 0 by the parity of k for inert primes p ≡ 3 (mod 4) (jacobiR2 = 4 or 0). The small counts r₂(5)=8, r₂(9)=4, r₂(3)=0, r₂(8)=4 are recovered as instances. Zero sorries, zero axioms beyond the foundational ones, no Lean.ofReduceBool.",
+    "implications": "Extends the parent OQ-06's prime-power programme from the four-square count r₄ to the two-square count r₂, showing the same divisors_prime_pow + character-residue strategy handles the sibling family and exhibiting the p-mod-4 trichotomy directly in the closed forms. The full geometric identity r₂(n) = 4·Σ χ₄(d) (Jacobi's two-square theorem) is not claimed — like the parent's r₄ identity it is the open direction; only the arithmetic side is computed here.",
+    "openQuestions": [
+      "Assemble the three local closed forms into a single formula for chiSum(n) at every n: since χ₄ is completely multiplicative, Σ_{d∣n} χ₄(d) is a multiplicative arithmetic function, so chiSum(n) is the product of the prime-power factors computed here (0 as soon as some inert prime appears to an odd power). Formalizing this multiplicativity closes the gap to arbitrary n.",
+      "Prove the geometric two-square theorem itself: r₂(n) = #{(a,b) ∈ ℤ² : a²+b² = n} = 4·Σ_{d∣n} χ₄(d), connecting these arithmetic values to the lattice-point count via unique factorization in the Gaussian integers ℤ[i]."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "four-square-distribution-oq-06",
+      "relationship": "parent",
+      "description": "Establishes native_decide-free prime-power closed forms for the four-square arithmetic side σ* (r₄(p²) = 8(1 + p + p²)). This entry answers its OQ-06-OQ-03 by running the same divisors_prime_pow + residue strategy on the two-square arithmetic side r₂ = 4·Σχ₄(d)."
+    },
+    {
+      "targetId": "four-square-distribution",
+      "relationship": "ancestor",
+      "description": "Root entry on Jacobi's sum-of-squares counts and the group-theoretic origin of the leading constant. This entry supplies the divisor-sum side for the two-square case r₂."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Carl Gustav Jacob Jacobi",
+      "title": "Fundamenta nova theoriae functionum ellipticarum",
+      "year": "1829",
+      "venue": "Königsberg",
+      "note": "Source of the sum-of-squares formulae, including r₂(n) = 4·Σ_{d∣n} χ₄(d)."
+    },
+    {
+      "authors": "G. H. Hardy, E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed., §16.9–16.10",
+      "note": "The two-square count and its expression through the character sum Σ χ₄(d) on divisors."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-06-OQ-03** of `four-square-distribution`: *"Do the sibling sum-of-squares counts admit analogous native_decide-free closed forms on prime powers?"* The parent OQ-06 gave symbolic prime-power values for the **four**-square count r₄ (via σ*). This entry runs the identical `divisors_prime_pow` + character-residue strategy on the **two**-square count r₂, whose arithmetic side is Jacobi's classical formula

  r₂(n) = 4 · Σ_{d∣n} χ₄(d),

with `χ₄` = Mathlib's primitive quadratic character mod 4. Writing `chiSum n = Σ_{d∣n} χ₄(d)` and `jacobiR2 n = 4·chiSum n`, the divisor sum is computed on every prime power, split by the prime's residue mod 4 — the same trichotomy that governs which primes are sums of two squares:

| family | `chiSum(pᵏ)` | `jacobiR2(pᵏ)` | reason |
|--------|--------------|----------------|--------|
| `p = 2` (ramified) | `1` | `4` | χ₄ kills every even divisor |
| `p ≡ 1 (mod 4)` (split) | `k+1` | `4(k+1)` | χ₄(pⁱ)=1, full ramp |
| `p ≡ 3 (mod 4)` (inert) | `1` if `k` even else `0` | `4` or `0` | χ₄(pⁱ)=(−1)ⁱ, alternating |

The small counts **r₂(5)=8, r₂(9)=4, r₂(3)=0, r₂(8)=4** are recovered symbolically as instances of the three families (`jacobiR2_five/nine/three/eight`), with **no** `native_decide`.

## Proof ingredients
- `Nat.divisors_prime_pow` → sum over exponents
- `map_pow` (MulChar is a `MonoidHomClass`) → χ₄(pⁱ) = χ₄(p)ⁱ, complete multiplicativity
- `ZMod.χ₄_nat_one_mod_four` / `χ₄_nat_three_mod_four` / `χ₄_nat_eq_if_mod_four` → residue values
- `neg_one_geom_sum` → collapses the alternating (inert) divisor sum; `Nat.even_add_one` reconciles parity

## Verification
- **0 axioms, 0 sorries, 11 theorems + 2 defs, 183 lines** — verified with `lake env lean`.
- `#print axioms` on the main theorems lists only `propext, Classical.choice, Quot.sound` (no `native_decide`, no `Lean.ofReduceBool`).
- New gallery entry: `src/data/proofs/four-square-distribution-oq-06-oq-03/` (meta + 6 annotations, all resolver-validated).

## Honest scope
`jacobiR2` is *defined* as `4·Σχ₄(d)`; these theorems compute that arithmetic side symbolically. They do **not** prove the geometric two-square theorem r₂(n) = #{(a,b) ∈ ℤ² : a²+b² = n} = 4·Σχ₄(d) — like the parent's r₄ identity, that remains the open direction.

## Status
**Outcome**: completed (new verified entry)

🤖 Generated by researcher-10