### PR TITLE
Enrich Every Odd-Degree Real Polynomial Has a Real Root

### DIFF
--- a/src/data/proofs/fundamental-theorem-algebra-oq-06/annotations.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-06/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["polynomial evaluation", "Lean 4 module system"]
   },
   {
+    "id": "ann-statement-both-signs",
+    "proofId": "fundamental-theorem-algebra-oq-06",
+    "range": { "startLine": 45, "endLine": 52 },
+    "type": "concept",
+    "title": "Statement and Reduction to Positive Degree",
+    "content": "The workhorse lemma `exists_neg_and_pos_eval` claims an odd-degree `P` attains both a strictly negative and a strictly positive value; the root theorem then follows by the IVT. The proof opens by unpacking the hypothesis `Odd P.natDegree` as `natDegree P = 2m + 1`, from which `omega` derives `0 < P.natDegree`, and `natDegree_pos_iff_degree_pos` upgrades this to `0 < P.degree`. Positive degree — not oddness directly — is what the end-behaviour lemmas require: a constant polynomial has no limit at infinity, so the argument would collapse without it. Oddness re-enters only later, through the sign of `(-1)^(natDegree P)`.",
+    "mathContext": "$\\mathrm{Odd}(\\deg P) \\Rightarrow \\deg P = 2m+1 \\Rightarrow 0 < \\deg P$; the `natDegree`/`degree` distinction matters because `degree 0 = -\\infty` while `natDegree 0 = 0`.",
+    "significance": "supporting",
+    "relatedConcepts": ["parity", "polynomial degree", "natDegree versus degree"],
+    "prerequisites": ["Odd", "natDegree_pos_iff_degree_pos", "omega"]
+  },
+  {
     "id": "ann-reflected-polynomial",
     "proofId": "fundamental-theorem-algebra-oq-06",
     "range": { "startLine": 53, "endLine": 67 },

--- a/src/data/proofs/fundamental-theorem-algebra-oq-06/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-06/meta.json
@@ -124,7 +124,8 @@
       "Oddness of the degree is exactly what makes the leading term flip sign between $+\\infty$ and $-\\infty$ — this is the entire content of the theorem.",
       "The sign flip at $-\\infty$ need not be proved by a separate atBot argument: composing with $-X$ converts $-\\infty$ behaviour into $+\\infty$ behaviour, and $\\mathrm{leadingCoeff}(P\\circ(-X)) = (-1)^{\\deg P}\\,\\mathrm{leadingCoeff}(P)$.",
       "Using the unordered interval `[[a,b]]` and `intermediate_value_uIcc` removes any need to track whether $a \\le b$ or $b \\le a$.",
-      "The result explains the asymmetry in ℝ: odd-degree polynomials always have roots, so the obstruction to ℝ being algebraically closed lives entirely in even degree (e.g. $X^2+1$)."
+      "The result explains the asymmetry in ℝ: odd-degree polynomials always have roots, so the obstruction to ℝ being algebraically closed lives entirely in even degree (e.g. $X^2+1$).",
+      "The argument is purely qualitative: it never bounds or locates the root, converting end behaviour directly into existence through the IVT. This is exactly why it transposes verbatim to any real-closed field once an order-topology intermediate value property is available — the ℝ-specific analysis is confined to Mathlib's `tendsto` end-behaviour lemmas."
     ],
     "historicalContext": "Gauss gave several proofs of the Fundamental Theorem of Algebra. His 1849 proof is the most algebraic, isolating the order structure of ℝ to two ingredients: the intermediate value property for odd-degree polynomials (proved here) and the existence of complex square roots. The general order-theoretic version — every odd-degree polynomial over a real-closed field has a root — is part of the Artin–Schreier theory of real-closed fields (1927).",
     "prerequisites": [


### PR DESCRIPTION
Enrichment pass for `fundamental-theorem-algebra-oq-06` (quality 38, passes 0).

The entry already had rich meta and 5 fully-detailed annotations; the genuine gap was annotation **coverage**, not depth.

## Changes
- **Annotation coverage gap closed (5→6):** added `ann-statement-both-signs` for lines 45–52 — the main lemma `exists_neg_and_pos_eval`'s statement and the `Odd P.natDegree → 0 < P.degree` reduction, including why positive degree (not oddness directly) is what the end-behaviour lemmas require and the `natDegree`-vs-`degree` distinction. This was the only uncovered stretch of the file. All 6 annotations carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites` and validate against the Lean source (resolver: 6 valid, 0 misaligned).
- **keyInsight added (4→5):** the proof is purely qualitative — it never bounds or locates the root, converting end behaviour directly into existence via the IVT, which is exactly why it transposes verbatim to any real-closed field.

## Guardrails
- meta.json 13.5 KB → 13.9 KB — well under the ~60 KB cap; keyInsights 5 (cap 12); all collections under caps.
- No content deleted; `status`/`badge`/`axiomCount` (verified/original/0) unchanged and consistent with the Lean file.

Content validated: JSON parses, annotation build emitted cleanly, resolver anchoring 6/6.