### PR TITLE
Enrich Taylor convergence of sin/cos via uniform bound (taylor-theorem-oq-04): 4→5 annotations

### DIFF
--- a/src/data/proofs/taylor-theorem-oq-04/annotations.json
+++ b/src/data/proofs/taylor-theorem-oq-04/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-taylor-oq04-header",
+    "proofId": "taylor-theorem-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 31
+    },
+    "type": "context",
+    "title": "The Uniform-Derivative-Bound Route (One of Three Sibling Proofs)",
+    "content": "This entry is one of three sibling children giving DIFFERENT proofs that the Taylor polynomials of sin and cos converge to the functions everywhere: oq-02 uses abstract formal power series, oq-03 uses NormedSpace.exp summability, and THIS file uses the uniform derivative bound. The argument is the classic one for entire functions: because every iterated derivative of sin/cos is bounded by 1 uniformly in the order and the point, the Lagrange remainder satisfies |f x - Tₙ(x)| ≤ |x|^{n+1}/n! → 0. Nothing here is reproved from scratch — the file assembles named Mathlib lemmas (taylor_mean_remainder_bound with C=1, the trig derivative bounds abs_iteratedDeriv_sin/cos_le_one, and Real.summable_pow_div_factorial for the factorial decay), so all results are fully verified with 0 axioms.",
+    "mathContext": "$|f^{(n)}|\\le 1 \\Rightarrow |f(x)-T_n(x)|\\le \\dfrac{|x|^{n+1}}{n!}\\to 0$ — bounded derivatives force an everywhere-convergent Taylor series.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lagrange remainder",
+      "entire functions",
+      "uniform bounds",
+      "factorial decay"
+    ],
+    "prerequisites": [
+      "Taylor's theorem",
+      "iterated derivatives",
+      "sequential limits"
+    ]
+  },
+  {
     "id": "ann-taylor-oq04-derivbound",
     "proofId": "taylor-theorem-oq-04",
     "range": {


### PR DESCRIPTION
Enrichment pass for `taylor-theorem-oq-04` ("Taylor Series Convergence of sin and cos via the Uniform Derivative Bound").

**Gap:** the four theorems were annotated, but the 31-line module docstring — which frames this as one of three sibling proofs and states the bounded-derivative argument — was uncovered (coverage ~35%).

**Added 1 context annotation (4→5), coverage ~35%→~64%:**
- **Module docstring (context):** the three sibling routes (oq-02 formal power series, oq-03 `NormedSpace.exp`, this = uniform derivative bound), the classic "entire function with uniformly bounded derivatives has an everywhere-convergent Taylor series" argument, and the assembled Mathlib lemmas (`taylor_mean_remainder_bound`, `abs_iteratedDeriv_sin/cos_le_one`, `Real.summable_pow_div_factorial`) giving a 0-axiom result.

Carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Focused, curation-minded addition.

**Validation:** `resolver.ts validate` → 5 valid, 0 misaligned. No meta.json or Lean changes.