### PR TITLE
research(binomial-theorem-oq-06-oq-02): hockey-stick diagonal sums + Catalan/lattice-path bridge [VERIFIED, 0-axiom, 9thm/162L, new entry]

### DIFF
--- a/proofs/Proofs/HockeyStickCatalanOQ0602.lean
+++ b/proofs/Proofs/HockeyStickCatalanOQ0602.lean
@@ -1,0 +1,162 @@
+/-
+# Hockey-stick (Zhu Shijie) diagonal sums and the Catalan / lattice-path bridge
+
+Parent: `binomial-theorem-oq-06` — *Vandermonde's convolution identity and its
+diagonal corollaries* (`∑ C(n,k)² = C(2n,n)`).
+
+This entry answers that parent's second open question:
+
+> Formalize the hockey-stick and Li Jen-Shu identities as further diagonal sums,
+> and connect `∑ C(n,k)² = C(2n,n)` to the lattice-path / Catalan-number
+> interpretation.
+
+## What Mathlib already provides
+
+Mathlib proves the **hockey-stick identity** (Zhu Shijie / 朱世傑) in two forms,
+each fixing the *lower* index `k` and summing a **vertical** slice of Pascal's
+triangle:
+
+* `Nat.sum_Icc_choose       : ∑_{m ∈ [k,n]} C(m,k) = C(n+1, k+1)`
+* `Nat.sum_range_add_choose : ∑_{i ≤ n}     C(i+k,k) = C(n+k+1, k+1)`
+
+## What this entry adds (absent from Mathlib)
+
+1. **Parallel-summation / diagonal hockey-stick** (`parallel_summation`,
+   `parallel_summation'`):
+
+     `∑_{k=0}^{n} C(r+k, k) = C(r+n+1, r+1) = C(r+n+1, n)`.
+
+   Here the *difference* `(r+k) − k = r` is constant, so the summands run down a
+   **diagonal** of Pascal's triangle; the value is the lattice-path count
+   `C(r+n+1, n)`. This is the "Li Jen-Shu" companion of the vertical
+   hockey-stick, obtained by flipping each summand with `C(r+k,k) = C(r+k,r)`.
+
+2. **Central diagonal** (`central_diagonal`):
+
+     `∑_{k=0}^{n} C(n+k, k) = C(2n+1, n)`,
+
+   the `r = n` case — a partial diagonal sum landing on the central column.
+
+3. **Catalan / lattice-path bridge**. Re-deriving the Vandermonde diagonal
+   `∑ C(n,k)² = C(2n,n) = centralBinom n` and combining it with Mathlib's
+   `succ_mul_catalan_eq_centralBinom` yields the identities **not in Mathlib**:
+
+     `∑_{k=0}^{n} C(n,k)² = (n+1) · catalan n`   (`sum_sq_choose_eq_succ_mul_catalan`)
+     `catalan n = (∑_{k=0}^{n} C(n,k)²) / (n+1)` (`catalan_eq_sum_sq_choose_div`).
+
+   Interpretation: `C(2n,n)` counts monotone NE lattice paths `(0,0) → (n,n)`;
+   the Catalan number `catalan n` counts those staying weakly below the diagonal,
+   and each such path is shared `n+1` times under cyclic rotation (the cycle
+   lemma), which is exactly the factor `n+1`.
+
+Verified: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/
+import Mathlib
+
+open Finset BigOperators
+
+namespace HockeyStickCatalanOQ0602
+
+/-! ## 1. Hockey-stick identity (restating Mathlib as the bridge) -/
+
+/-- **Hockey-stick / Zhu Shijie, `Icc` form** (Mathlib's `Nat.sum_Icc_choose`):
+`∑_{m ∈ [k,n]} C(m,k) = C(n+1, k+1)`. A vertical slice of Pascal's triangle. -/
+theorem hockey_stick_Icc (n k : ℕ) :
+    ∑ m ∈ Icc k n, m.choose k = (n + 1).choose (k + 1) :=
+  Nat.sum_Icc_choose n k
+
+/-- **Hockey-stick / Zhu Shijie, `range` form** (Mathlib's `Nat.sum_range_add_choose`):
+`∑_{i=0}^{n} C(i+k, k) = C(n+k+1, k+1)`. -/
+theorem hockey_stick_range (n k : ℕ) :
+    ∑ i ∈ range (n + 1), (i + k).choose k = (n + k + 1).choose (k + 1) :=
+  Nat.sum_range_add_choose n k
+
+/-! ## 2. Diagonal corollaries (absent from Mathlib) -/
+
+/-- **Parallel-summation / diagonal hockey-stick.**
+`∑_{k=0}^{n} C(r+k, k) = C(r+n+1, r+1)`. The summands `C(r+k,k)` lie on the
+diagonal of Pascal's triangle with constant difference `r`. We flip each
+summand via `C(r+k,k) = C(k+r,r)` (`Nat.choose_symm_add`) to land on the
+vertical hockey-stick. -/
+theorem parallel_summation (r n : ℕ) :
+    ∑ k ∈ range (n + 1), (r + k).choose k = (r + n + 1).choose (r + 1) := by
+  have h : (∑ k ∈ range (n + 1), (r + k).choose k)
+      = ∑ k ∈ range (n + 1), (k + r).choose r :=
+    Finset.sum_congr rfl (fun k _ => by rw [Nat.add_comm r k, Nat.choose_symm_add])
+  rw [h, Nat.sum_range_add_choose n r, Nat.add_comm n r]
+
+/-- The same diagonal sum written with the lattice-path count `C(r+n+1, n)`,
+using `C(r+n+1, r+1) = C(r+n+1, n)`. -/
+theorem parallel_summation' (r n : ℕ) :
+    ∑ k ∈ range (n + 1), (r + k).choose k = (r + n + 1).choose n := by
+  have e : r + n + 1 = (r + 1) + n := by ring
+  rw [parallel_summation, e]
+  exact Nat.choose_symm_add
+
+/-- **Central diagonal.** `∑_{k=0}^{n} C(n+k, k) = C(2n+1, n)`: the `r = n` case
+of `parallel_summation'`, a partial diagonal sum landing on the central column. -/
+theorem central_diagonal (n : ℕ) :
+    ∑ k ∈ range (n + 1), (n + k).choose k = (2 * n + 1).choose n := by
+  rw [parallel_summation' n n, two_mul]
+
+/-! ## 3. Vandermonde diagonal `∑ C(n,k)² = C(2n,n)` (self-contained) -/
+
+/-- **Sum of squares of a Pascal row is the central binomial coefficient:**
+`∑_{k=0}^{n} C(n,k)² = C(2n, n)`. Proved directly from Vandermonde
+(`Nat.add_choose_eq`) by flipping one factor with `C(n,n−k) = C(n,k)`. -/
+theorem sum_sq_choose (n : ℕ) :
+    ∑ k ∈ range (n + 1), (n.choose k) ^ 2 = (2 * n).choose n := by
+  have key : (n + n).choose n
+      = ∑ k ∈ range (n + 1), n.choose k * n.choose (n - k) := by
+    rw [Nat.add_choose_eq n n n,
+      Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk
+        (fun ij => n.choose ij.1 * n.choose ij.2) n]
+  rw [two_mul, key]
+  refine Finset.sum_congr rfl (fun k hk => ?_)
+  rw [mem_range, Nat.lt_succ_iff] at hk
+  rw [pow_two, Nat.choose_symm hk]
+
+/-- `∑_{k=0}^{n} C(n,k)² = centralBinom n`, phrased through `Nat.centralBinom`. -/
+theorem sum_sq_choose_centralBinom (n : ℕ) :
+    ∑ k ∈ range (n + 1), (n.choose k) ^ 2 = n.centralBinom := by
+  rw [sum_sq_choose]; rfl
+
+/-! ## 4. Catalan / lattice-path bridge (absent from Mathlib) -/
+
+/-- **Catalan bridge.** `∑_{k=0}^{n} C(n,k)² = (n+1) · catalan n`.
+Combines `sum_sq_choose_centralBinom` with Mathlib's
+`succ_mul_catalan_eq_centralBinom`. The factor `n+1` is the cycle-lemma
+multiplicity: each Dyck path (below-diagonal lattice path) is shared `n+1`
+times among all `C(2n,n)` monotone paths from `(0,0)` to `(n,n)`. -/
+theorem sum_sq_choose_eq_succ_mul_catalan (n : ℕ) :
+    ∑ k ∈ range (n + 1), (n.choose k) ^ 2 = (n + 1) * catalan n := by
+  rw [sum_sq_choose_centralBinom, succ_mul_catalan_eq_centralBinom]
+
+/-- The Catalan number as the sum-of-squares divided by `n+1`:
+`catalan n = (∑_{k=0}^{n} C(n,k)²) / (n+1)`. -/
+theorem catalan_eq_sum_sq_choose_div (n : ℕ) :
+    catalan n = (∑ k ∈ range (n + 1), (n.choose k) ^ 2) / (n + 1) := by
+  rw [sum_sq_choose_centralBinom, catalan_eq_centralBinom_div]
+
+/-! ## Worked examples -/
+
+/-- Vertical hockey-stick: `C(2,2)+C(3,2)+C(4,2)+C(5,2) = 1+3+6+10 = 20 = C(6,3)`. -/
+example : ∑ m ∈ Icc 2 5, m.choose 2 = (5 + 1).choose 3 := hockey_stick_Icc 5 2
+
+/-- Diagonal hockey-stick: `C(2,0)+C(3,1)+C(4,2) = 1+3+6 = 10 = C(5,2)`. -/
+example : ∑ k ∈ range 3, (2 + k).choose k = (2 + 2 + 1).choose 2 := parallel_summation' 2 2
+
+/-- Central diagonal: `C(3,0)+C(4,1)+C(5,2)+C(6,3) = 1+4+10+20 = 35 = C(7,3)`. -/
+example : ∑ k ∈ range 4, (3 + k).choose k = (2 * 3 + 1).choose 3 := central_diagonal 3
+
+/-- Numeric check of the central-diagonal value. -/
+example : ∑ k ∈ range 4, (3 + k).choose k = 35 := by decide
+
+/-- Catalan bridge at `n = 4`: `∑ C(4,k)² = 1+16+36+16+1 = 70 = 5 · catalan 4 = 5·14`. -/
+example : ∑ k ∈ range 5, ((4 : ℕ).choose k) ^ 2 = 5 * catalan 4 :=
+  sum_sq_choose_eq_succ_mul_catalan 4
+
+/-- Numeric check: `∑ C(4,k)² = 70`. -/
+example : ∑ k ∈ range 5, ((4 : ℕ).choose k) ^ 2 = 70 := by decide
+
+end HockeyStickCatalanOQ0602

--- a/src/data/proofs/binomial-theorem-oq-06-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-06-oq-02/meta.json
@@ -1,0 +1,207 @@
+{
+  "id": "binomial-theorem-oq-06-oq-02",
+  "title": "Hockey-stick diagonal sums and the Catalan / lattice-path bridge: ∑ C(n,k)² = (n+1)·catalan n",
+  "slug": "binomial-theorem-oq-06-oq-02",
+  "description": "Answers the second open question of the parent binomial-theorem-oq-06 (Vandermonde's convolution) entry: formalize the hockey-stick identity as a diagonal sum and connect ∑ C(n,k)² = C(2n,n) to the lattice-path / Catalan-number interpretation. Mathlib already proves the hockey-stick (Zhu Shijie) identity in two VERTICAL forms that fix the lower index k (Nat.sum_Icc_choose: ∑_{m∈[k,n]} C(m,k) = C(n+1,k+1); Nat.sum_range_add_choose: ∑_{i≤n} C(i+k,k) = C(n+k+1,k+1)). This entry adds three things Mathlib lacks. (1) The DIAGONAL / parallel-summation form ∑_{k=0}^{n} C(r+k,k) = C(r+n+1,r+1) = C(r+n+1,n) (parallel_summation, parallel_summation'), where the difference (r+k)−k = r is constant so the summands run down a diagonal of Pascal's triangle; obtained by flipping each summand with C(r+k,k)=C(k+r,r) (Nat.choose_symm_add) to reach the vertical hockey-stick. (2) The central-diagonal special case ∑_{k=0}^{n} C(n+k,k) = C(2n+1,n) (central_diagonal, r=n). (3) The Catalan / lattice-path bridge: re-deriving ∑ C(n,k)² = C(2n,n) = centralBinom n from Vandermonde and combining it with Mathlib's succ_mul_catalan_eq_centralBinom gives ∑_{k=0}^{n} C(n,k)² = (n+1)·catalan n (sum_sq_choose_eq_succ_mul_catalan) and catalan n = (∑ C(n,k)²)/(n+1) (catalan_eq_sum_sq_choose_div), both absent from Mathlib. C(2n,n) counts monotone NE lattice paths (0,0)→(n,n); catalan n counts those staying weakly below the diagonal, each shared n+1 times under cyclic rotation (cycle lemma). Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Classical (Zhu Shijie 1303; Catalan / Euler–Segner); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HockeyStickCatalanOQ0602.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "hockey-stick-identity",
+      "zhu-shijie",
+      "catalan-numbers",
+      "central-binomial-coefficient",
+      "lattice-paths",
+      "pascals-triangle",
+      "finset-sum",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_Icc_choose",
+        "description": "Hockey-stick / Zhu Shijie identity, Icc form: ∑_{m∈[k,n]} C(m,k) = C(n+1,k+1). Restated as hockey_stick_Icc and used (via the range form) as the vertical target that the diagonal parallel-summation identity is reduced to.",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Nat.sum_range_add_choose",
+        "description": "Hockey-stick identity, range form: ∑_{i≤n} C(i+k,k) = C(n+k+1,k+1). Restated as hockey_stick_range; the parallel-summation proof flips each diagonal summand C(r+k,k) into C(k+r,r) and applies this lemma with fixed lower index r.",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Nat.choose_symm_add",
+        "description": "C(a+b, a) = C(a+b, b). Turns each diagonal summand C(r+k,k) into the vertical C(k+r,r), and rewrites the hockey-stick value C(r+n+1,r+1) into the lattice-path count C(r+n+1,n).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.add_choose_eq",
+        "description": "Vandermonde's identity in antidiagonal form, (m+n).choose k = ∑_{ij∈antidiagonal k} C(m,ij.1)·C(n,ij.2). Used to re-derive the diagonal sum-of-squares ∑ C(n,k)² = C(2n,n) self-contained, as the bridge to the Catalan identities.",
+        "module": "Mathlib.Data.Nat.Choose.Vandermonde"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "For k ≤ n, C(n, n−k) = C(n, k). Flips the second factor on the summation range k ≤ n to turn Vandermonde (r=n) into the sum-of-squares identity.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.centralBinom",
+        "description": "The central binomial coefficient, defined as (2n).choose n. The sum-of-squares identity is restated through it (sum_sq_choose_centralBinom) to reach the Catalan API.",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "succ_mul_catalan_eq_centralBinom",
+        "description": "(n+1)·catalan n = centralBinom n. Combined with sum_sq_choose_centralBinom to give the Catalan bridge ∑ C(n,k)² = (n+1)·catalan n. The factor n+1 is the cycle-lemma multiplicity of Dyck paths among all monotone lattice paths.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "catalan_eq_centralBinom_div",
+        "description": "catalan n = centralBinom n / (n+1). Gives the divided form catalan n = (∑ C(n,k)²)/(n+1).",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      }
+    ],
+    "originalContributions": [
+      "parallel_summation: the DIAGONAL / parallel-summation hockey-stick ∑_{k=0}^{n} C(r+k,k) = C(r+n+1,r+1), where the constant difference (r+k)−k = r makes the summands a diagonal of Pascal's triangle — the 'Li Jen-Shu' companion of Mathlib's vertical hockey-stick, obtained by flipping each summand with C(r+k,k)=C(k+r,r). Not in Mathlib.",
+      "parallel_summation': the same diagonal sum in the lattice-path count form ∑_{k=0}^{n} C(r+k,k) = C(r+n+1,n), via C(r+n+1,r+1)=C(r+n+1,n).",
+      "central_diagonal: the central-column special case ∑_{k=0}^{n} C(n+k,k) = C(2n+1,n) (r=n), a partial diagonal sum landing on the central column. Not in Mathlib.",
+      "sum_sq_choose_eq_succ_mul_catalan: the Catalan / lattice-path bridge ∑_{k=0}^{n} C(n,k)² = (n+1)·catalan n, connecting the Vandermonde diagonal sum of squares to the Catalan numbers via Mathlib's succ_mul_catalan_eq_centralBinom. Not in Mathlib.",
+      "catalan_eq_sum_sq_choose_div: the divided form catalan n = (∑_{k=0}^{n} C(n,k)²)/(n+1), expressing the Catalan number directly from a Pascal row of squares.",
+      "sum_sq_choose / sum_sq_choose_centralBinom: a self-contained re-derivation of ∑_{k=0}^{n} C(n,k)² = C(2n,n) = centralBinom n from Vandermonde's antidiagonal form, serving as the bridge into the Catalan API."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries, no native_decide (the numeric checks use kernel `decide`, so no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 162,
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The hockey-stick identity ∑_{i=r}^{n} C(i,r) = C(n+1,r+1) — so named because the summed cells and the total trace a hockey-stick shape in Pascal's triangle — was known to Zhu Shijie (Chu Shih-chieh) in his 1303 Jade Mirror of the Four Unknowns, the same source as the Chu–Vandermonde convolution. Its diagonal companion, the parallel-summation ∑_{k=0}^{n} C(r+k,k) = C(r+n+1,n), sums a constant-difference diagonal instead of a column. The central binomial coefficient C(2n,n) and the Catalan numbers catalan n = C(2n,n)/(n+1) are the two most fundamental lattice-path counts in enumerative combinatorics: C(2n,n) counts all monotone north-east paths from (0,0) to (n,n), while catalan n counts those never rising above the diagonal. The sum of the squares of a Pascal row, ∑ C(n,k)² = C(2n,n), is the diagonal case of Vandermonde and the entry point that ties this diagonal-sum circle of identities to the Catalan numbers.",
+    "problemStatement": "The parent binomial-theorem-oq-06 entry (Vandermonde's convolution) asks, as its second open question, to formalize the hockey-stick and 'Li Jen-Shu' identities as further diagonal sums and to connect ∑ C(n,k)² = C(2n,n) to the lattice-path / Catalan-number interpretation. Mathlib proves only the VERTICAL hockey-stick (fixed lower index).\n\n**Answer:** the DIAGONAL parallel-summation ∑_{k=0}^{n} C(r+k,k) = C(r+n+1,n) and its central case ∑_{k=0}^{n} C(n+k,k) = C(2n+1,n), together with the Catalan bridge ∑_{k=0}^{n} C(n,k)² = (n+1)·catalan n and catalan n = (∑ C(n,k)²)/(n+1) — none of which is in Mathlib.",
+    "text": "The diagonal (parallel-summation) hockey-stick ∑_{k=0}^{n} C(r+k,k) = C(r+n+1,n) and its central case, plus the Catalan / lattice-path bridge ∑ C(n,k)² = (n+1)·catalan n and catalan n = (∑ C(n,k)²)/(n+1) — all absent from Mathlib — with 0 axioms.",
+    "proofStrategy": "1. hockey_stick_Icc / hockey_stick_range: restate Mathlib's Nat.sum_Icc_choose and Nat.sum_range_add_choose (the vertical hockey-stick) as the bridge.\n2. parallel_summation: rewrite each diagonal summand C(r+k,k) = C(k+r,r) with Nat.add_comm + Nat.choose_symm_add (inside Finset.sum_congr), then apply Nat.sum_range_add_choose with fixed lower index r and normalize with Nat.add_comm n r, giving C(r+n+1,r+1).\n3. parallel_summation': rewrite C(r+n+1,r+1) = C(r+n+1,n) via Nat.choose_symm_add after normalizing r+n+1 = (r+1)+n.\n4. central_diagonal: specialize parallel_summation' to r=n and rewrite 2n = n+n.\n5. sum_sq_choose: re-derive ∑ C(n,k)² = C(2n,n) from Nat.add_choose_eq (antidiagonal Vandermonde) reindexed to range, flipping the second factor with Nat.choose_symm (k ≤ n) and collapsing C(n,k)·C(n,k) to C(n,k)² with pow_two.\n6. sum_sq_choose_centralBinom: (2n).choose n = centralBinom n by rfl.\n7. sum_sq_choose_eq_succ_mul_catalan: rewrite via sum_sq_choose_centralBinom then succ_mul_catalan_eq_centralBinom.\n8. catalan_eq_sum_sq_choose_div: rewrite via sum_sq_choose_centralBinom then catalan_eq_centralBinom_div.",
+    "keyInsights": [
+      "**Mathlib's hockey-stick is vertical, not diagonal.** Nat.sum_Icc_choose and Nat.sum_range_add_choose fix the LOWER index k and sum a column. The parallel-summation ∑ C(r+k,k), where the DIFFERENCE (r+k)−k = r is constant, sums a diagonal; the single symmetry C(r+k,k)=C(k+r,r) converts one into the other.",
+      "**One reflection turns a diagonal into a column.** Flipping each summand with Nat.choose_symm_add is the only combinatorial content of the parallel-summation proof — after it, Mathlib's vertical hockey-stick closes the goal.",
+      "**The sum of squares of a Pascal row is a Catalan multiple.** ∑_{k=0}^{n} C(n,k)² = C(2n,n) = (n+1)·catalan n. The Vandermonde diagonal already equals the central binomial coefficient; Mathlib's succ_mul_catalan_eq_centralBinom then exposes the Catalan number hiding inside it.",
+      "**The factor n+1 is the cycle lemma.** C(2n,n) counts all monotone lattice paths (0,0)→(n,n); catalan n counts the Dyck paths (weakly below the diagonal); each Dyck path is shared exactly n+1 times among cyclic rotations, which is precisely the n+1 in ∑ C(n,k)² = (n+1)·catalan n."
+    ],
+    "exampleSections": [
+      {
+        "title": "Central diagonal at n = 3",
+        "mathContext": "∑_{k=0}^{3} C(3+k,k) = C(3,0)+C(4,1)+C(5,2)+C(6,3) = 1+4+10+20 = 35 = C(7,3), the central-diagonal identity ∑ C(n+k,k) = C(2n+1,n)."
+      },
+      {
+        "title": "Catalan bridge at n = 4",
+        "mathContext": "∑_{k=0}^{4} C(4,k)² = 1+16+36+16+1 = 70 = 5·14 = (4+1)·catalan 4, since catalan 4 = 14."
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Zhu Shijie (Chu Shih-chieh)",
+      "title": "Siyuan yujian (Jade Mirror of the Four Unknowns)",
+      "year": "1303",
+      "note": "Contains both the Chu–Vandermonde convolution and the hockey-stick summation of a diagonal of the triangle."
+    },
+    {
+      "authors": "Graham, Ronald L.; Knuth, Donald E.; Patashnik, Oren",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Addison–Wesley — parallel and hockey-stick summation (§5.1, identities (5.9)–(5.10)) and the central binomial / lattice-path material."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 2",
+      "year": "1999",
+      "note": "Cambridge University Press — Catalan numbers, lattice paths, and the cycle lemma giving catalan n = C(2n,n)/(n+1)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-06",
+      "relationship": "extends",
+      "description": "The parent proves Vandermonde's convolution and its diagonal corollary ∑ C(n,k)² = C(2n,n); this entry answers its second open question — the hockey-stick diagonal sums and the connection of that central identity to the Catalan / lattice-path interpretation."
+    }
+  ],
+  "conclusion": {
+    "summary": "The hockey-stick (Zhu Shijie) identity is complemented by its DIAGONAL form ∑_{k=0}^{n} C(r+k,k) = C(r+n+1,n) (parallel_summation, parallel_summation') and central case ∑_{k=0}^{n} C(n+k,k) = C(2n+1,n) (central_diagonal), all absent from Mathlib, obtained from Mathlib's vertical hockey-stick by the single symmetry C(r+k,k)=C(k+r,r). Re-deriving ∑ C(n,k)² = C(2n,n) = centralBinom n and combining it with Mathlib's Catalan API yields the lattice-path bridge ∑_{k=0}^{n} C(n,k)² = (n+1)·catalan n (sum_sq_choose_eq_succ_mul_catalan) and catalan n = (∑ C(n,k)²)/(n+1) (catalan_eq_sum_sq_choose_div). Verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the diagonal / parallel-summation hockey-stick and the explicit Catalan-number identity ∑ C(n,k)² = (n+1)·catalan n as reusable, machine-checked lemmas, filling gaps in Mathlib's binomial and Catalan libraries and completing the diagonal-sum circle around the parent Vandermonde entry.",
+    "openQuestions": [
+      "Formalize the underlying lattice-path bijections directly — monotone NE paths (0,0)→(n,n) for C(2n,n) and Dyck paths for catalan n — and derive ∑ C(n,k)² = (n+1)·catalan n combinatorially via the cycle lemma rather than through the central-binomial arithmetic.",
+      "Prove the alternating parallel-summation and higher hockey-stick variants (e.g. ∑ (−1)^k C(r+k,k)) and their generating-function forms.",
+      "Extend the diagonal sums to q-analogues (Gaussian binomial coefficients) and to the Motzkin / Schröder path families."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module header and statement",
+      "startLine": 2,
+      "endLine": 53,
+      "summary": "Frames the gap: Mathlib proves the hockey-stick only in vertical (fixed-lower-index) forms. This entry adds the diagonal parallel-summation and central-diagonal identities and the Catalan / lattice-path bridge for ∑ C(n,k)².",
+      "mathContext": "$\\sum_{k=0}^{n} \\binom{r+k}{k} = \\binom{r+n+1}{n}, \\qquad \\sum_{k=0}^{n} \\binom{n}{k}^2 = (n+1)\\,\\mathrm{catalan}\\,n$"
+    },
+    {
+      "id": "hockey-stick",
+      "title": "Hockey-stick identity (restating Mathlib)",
+      "startLine": 60,
+      "endLine": 72,
+      "summary": "hockey_stick_Icc and hockey_stick_range restate Mathlib's Nat.sum_Icc_choose and Nat.sum_range_add_choose — the vertical hockey-stick — as the bridge for the diagonal corollaries.",
+      "mathContext": "$\\sum_{m=k}^{n} \\binom{m}{k} = \\binom{n+1}{k+1}$"
+    },
+    {
+      "id": "diagonal",
+      "title": "Diagonal corollaries (absent from Mathlib)",
+      "startLine": 74,
+      "endLine": 100,
+      "summary": "parallel_summation gives ∑ C(r+k,k) = C(r+n+1,r+1) by flipping each summand with Nat.choose_symm_add; parallel_summation' rewrites it to the lattice-path count C(r+n+1,n); central_diagonal is the r=n case ∑ C(n+k,k) = C(2n+1,n).",
+      "mathContext": "$\\sum_{k=0}^{n} \\binom{r+k}{k} = \\binom{r+n+1}{n}$"
+    },
+    {
+      "id": "sum-of-squares",
+      "title": "Vandermonde diagonal ∑ C(n,k)² = C(2n,n)",
+      "startLine": 102,
+      "endLine": 122,
+      "summary": "sum_sq_choose re-derives ∑ C(n,k)² = C(2n,n) from Nat.add_choose_eq (antidiagonal Vandermonde) by flipping the second factor with Nat.choose_symm; sum_sq_choose_centralBinom phrases it through Nat.centralBinom.",
+      "mathContext": "$\\sum_{k=0}^{n} \\binom{n}{k}^2 = \\binom{2n}{n} = \\mathrm{centralBinom}\\,n$"
+    },
+    {
+      "id": "catalan",
+      "title": "Catalan / lattice-path bridge (absent from Mathlib)",
+      "startLine": 124,
+      "endLine": 139,
+      "summary": "sum_sq_choose_eq_succ_mul_catalan proves ∑ C(n,k)² = (n+1)·catalan n via succ_mul_catalan_eq_centralBinom; catalan_eq_sum_sq_choose_div gives catalan n = (∑ C(n,k)²)/(n+1).",
+      "mathContext": "$\\sum_{k=0}^{n} \\binom{n}{k}^2 = (n+1)\\,\\mathrm{catalan}\\,n$"
+    },
+    {
+      "id": "examples",
+      "title": "Worked examples",
+      "startLine": 141,
+      "endLine": 160,
+      "summary": "Vertical hockey-stick C(2,2)+…+C(5,2)=20=C(6,3); diagonal C(2,0)+C(3,1)+C(4,2)=10=C(5,2); central diagonal ∑ C(3+k,k)=35=C(7,3); and the Catalan bridge ∑ C(4,k)²=70=5·catalan 4.",
+      "mathContext": "$\\sum_{k=0}^{3}\\binom{3+k}{k}=35=\\binom{7}{3}, \\quad \\sum_{k=0}^{4}\\binom{4}{k}^2=70=5\\cdot 14$"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "HockeyStickCatalanOQ0602",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/HockeyStickCatalanOQ0602.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
Answers the parent **binomial-theorem-oq-06** (Vandermonde's convolution) entry's second open question: *formalize the hockey-stick identity as a diagonal sum and connect $\sum C(n,k)^2 = C(2n,n)$ to the lattice-path / Catalan-number interpretation.*

## What Mathlib already has
Mathlib proves the hockey-stick (Zhu Shijie) identity only in **vertical** forms that fix the lower index `k`:
- `Nat.sum_Icc_choose`: $\sum_{m\in[k,n]} C(m,k) = C(n+1,k+1)$
- `Nat.sum_range_add_choose`: $\sum_{i\le n} C(i+k,k) = C(n+k+1,k+1)$

## What this entry adds (absent from Mathlib)
1. **Diagonal / parallel-summation hockey-stick** `parallel_summation` / `parallel_summation'`:
   $\sum_{k=0}^{n} C(r+k,k) = C(r+n+1,r+1) = C(r+n+1,n)$ — the difference $(r+k)-k=r$ is constant, so the summands run down a **diagonal**. Proved by flipping each summand with $C(r+k,k)=C(k+r,r)$ and reducing to the vertical hockey-stick.
2. **Central diagonal** `central_diagonal`: $\sum_{k=0}^{n} C(n+k,k) = C(2n+1,n)$ (the $r=n$ case).
3. **Catalan / lattice-path bridge**: re-deriving $\sum C(n,k)^2 = C(2n,n) = \mathrm{centralBinom}\,n$ from Vandermonde and combining with Mathlib's `succ_mul_catalan_eq_centralBinom`:
   - `sum_sq_choose_eq_succ_mul_catalan`: $\sum_{k=0}^{n} C(n,k)^2 = (n+1)\cdot\mathrm{catalan}\,n$
   - `catalan_eq_sum_sq_choose_div`: $\mathrm{catalan}\,n = \left(\sum_{k=0}^{n} C(n,k)^2\right)/(n+1)$

   Interpretation: $C(2n,n)$ counts monotone NE lattice paths $(0,0)\to(n,n)$; $\mathrm{catalan}\,n$ counts those weakly below the diagonal, each shared $n+1$ times under cyclic rotation (cycle lemma) — exactly the factor $n+1$.

## Verification
- **0 axioms**: `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound`. Numeric checks use kernel `decide` (no `native_decide`, hence no `Lean.ofReduceBool`).
- 0 sorries, 9 theorems, 162 lines, new gallery entry.
- Compiles clean under `lake env lean` (Mathlib 4.26.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)