### PR TITLE
Enrich Closed Form for the GCD-Totient Defect Factor (euler-totient-oq-03-oq-03-oq-01): add annotations (0→7)

### DIFF
--- a/src/data/proofs/euler-totient-oq-03-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-03-oq-03-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "euler-totient-oq-03-oq-03-oq-01",
+    "range": { "startLine": 3, "endLine": 52 },
+    "type": "concept",
+    "title": "Open Question and the Closed Form",
+    "content": "The header states the parent's open question OQ-03-OQ-03-OQ-01 — does the exact super-multiplicativity defect factor `gcd(a,b)/φ(gcd(a,b))` admit a clean prime-factor closed form — and gives the answer in its strongest form: for EVERY positive `n` (not just squarefree), `n/φ(n) = ∏_{p ∈ n.primeFactors} p/(p-1)`. This is simply Euler's product formula `φ(n)/n = ∏(1 - 1/p)` read as the reciprocal defect ratio. Specialising `n := gcd(a,b)` produces the parent's defect factor in closed product form. The docstring also previews the proof engine, `Nat.totient_mul_prod_primeFactors`, and the ℕ→ℚ casting architecture.",
+    "mathContext": "$\\dfrac{n}{\\varphi(n)} = \\prod_{p \\mid n} \\dfrac{p}{p-1}$, the reciprocal of $\\dfrac{\\varphi(n)}{n} = \\prod_{p \\mid n}\\left(1 - \\dfrac1p\\right)$.",
+    "significance": "context",
+    "relatedConcepts": ["Euler's totient", "Euler product formula", "super-multiplicativity defect", "prime factorization"],
+    "prerequisites": ["Euler's totient function", "greatest common divisor", "prime factors"]
+  },
+  {
+    "id": "ann-engine",
+    "proofId": "euler-totient-oq-03-oq-03-oq-01",
+    "range": { "startLine": 60, "endLine": 64 },
+    "type": "technique",
+    "title": "The Engine: Euler's Product Form over ℕ",
+    "content": "`totient_mul_prod` restates Mathlib's `Nat.totient_mul_prod_primeFactors` as the single foundation of the whole file: `φ(n) · ∏_{p|n} p = n · ∏_{p|n} (p-1)`, valid for every `n` with no squarefree hypothesis. Multiplicativity of the totient is already packaged inside this identity; every subsequent theorem is obtained by transporting it faithfully into ℚ and rearranging. Keeping it as a named local theorem makes the dependency explicit and gives the later proofs a stable handle.",
+    "mathContext": "$\\varphi(n)\\,\\prod_{p \\mid n} p = n\\,\\prod_{p \\mid n}(p-1)$ in $\\mathbb{N}$ (truncated subtraction $p-1$).",
+    "significance": "key",
+    "relatedConcepts": ["Euler product formula", "primeFactors", "Finset.prod"],
+    "prerequisites": ["Nat.totient_mul_prod_primeFactors", "Finset products over prime factors"]
+  },
+  {
+    "id": "ann-casting",
+    "proofId": "euler-totient-oq-03-oq-03-oq-01",
+    "range": { "startLine": 68, "endLine": 84 },
+    "type": "technique",
+    "title": "Transporting the ℕ Identity into ℚ",
+    "content": "The delicate step is moving from ℕ (with truncated subtraction) to ℚ (with honest subtraction and division). Three lemmas isolate it: `cast_sub_one_ne_zero` shows `(p:ℚ) - 1 ≠ 0` for a prime factor (every prime is ≥ 2, so `p - 1 ≥ 1`); `prod_sub_one_ne_zero` lifts this to the whole denominator `∏((p:ℚ)-1) ≠ 0` via `Finset.prod_ne_zero_iff`; and `cast_prod_sub_one` proves `((∏(p-1):ℕ):ℚ) = ∏((p:ℚ)-1)`, distributing the cast factorwise with `Nat.cast_sub` (licensed because each prime factor is ≥ 1). These are the reusable bridge for turning any Mathlib integer product formula into a rational quotient.",
+    "mathContext": "Each prime factor $p \\ge 2 \\Rightarrow (p:\\mathbb{Q}) - 1 \\ge 1 \\ne 0$; and $\\overline{\\prod_{p\\mid n}(p-1)} = \\prod_{p\\mid n}\\big((p:\\mathbb{Q}) - 1\\big)$ since $\\mathbb{N}$-subtraction is honest when $p \\ge 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.cast_sub", "truncated subtraction", "Finset.prod_ne_zero_iff", "coercion ℕ→ℚ"],
+    "prerequisites": ["Nat.cast_sub", "Nat.prime_of_mem_primeFactors", "Finset.prod_ne_zero_iff"]
+  },
+  {
+    "id": "ann-defect-ratio",
+    "proofId": "euler-totient-oq-03-oq-03-oq-01",
+    "range": { "startLine": 88, "endLine": 107 },
+    "type": "insight",
+    "title": "The Closed-Form Defect Ratio (general n)",
+    "content": "`defect_ratio` is the main result: for every positive `n`, `n/φ(n) = ∏_{p ∈ n.primeFactors} p/(p-1)`, with no squarefree hypothesis. The proof casts `totient_mul_prod` into ℚ (using `cast_prod_sub_one`), notes `φ(n) > 0` (`Nat.totient_pos`) and the denominator nonzero, then applies `div_eq_div_iff` to reduce the goal `n/φ(n) = (∏p)/(∏(p-1))` to the cast engine identity, closed by `linear_combination`. Finally `Finset.prod_div_distrib` collects the right-hand side from `(∏p)/(∏(p-1))` into the single product `∏ p/(p-1)`.",
+    "mathContext": "$\\dfrac{n}{\\varphi(n)} = \\dfrac{\\prod_{p\\mid n} p}{\\prod_{p\\mid n}(p-1)} = \\prod_{p\\mid n}\\dfrac{p}{p-1}$ for $n > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["div_eq_div_iff", "linear_combination", "Finset.prod_div_distrib", "reciprocal Euler product"],
+    "prerequisites": ["Nat.totient_pos", "division in ℚ", "Finset.prod_div_distrib"]
+  },
+  {
+    "id": "ann-defect-factor-gcd",
+    "proofId": "euler-totient-oq-03-oq-03-oq-01",
+    "range": { "startLine": 111, "endLine": 119 },
+    "type": "concept",
+    "title": "The Parent's Defect Factor in Closed Form",
+    "content": "`defect_factor_gcd` delivers exactly what the open question asks: for `a, b` with `gcd(a,b) > 0`, the parent identity's super-multiplicativity defect factor is `gcd(a,b)/φ(gcd(a,b)) = ∏_{p ∈ (gcd a b).primeFactors} p/(p-1)`. It is a one-line specialisation of `defect_ratio` at `n = gcd a b` — showing that the closed form the parent conjectured for squarefree `gcd` in fact holds for arbitrary `gcd`, because the defect ratio is universal.",
+    "mathContext": "$\\dfrac{\\gcd(a,b)}{\\varphi(\\gcd(a,b))} = \\prod_{p \\mid \\gcd(a,b)} \\dfrac{p}{p-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["gcd", "super-multiplicativity defect", "specialisation"],
+    "prerequisites": ["greatest common divisor", "Euler's totient"]
+  },
+  {
+    "id": "ann-squarefree",
+    "proofId": "euler-totient-oq-03-oq-03-oq-01",
+    "range": { "startLine": 121, "endLine": 142 },
+    "type": "concept",
+    "title": "The Squarefree Case Singled Out by the Question",
+    "content": "For the squarefree case the open question named, `totient_squarefree` gives the crisp fact `φ(d) = ∏_{p|d}(p-1)`: substitute `∏p = d` (true exactly for squarefree `d`, via `Nat.prod_primeFactors_of_squarefree`) into the engine identity `φ(d)·d = d·∏(p-1)` and cancel the positive `d`. `defect_ratio_squarefree` then displays `d/φ(d) = (∏p)/(∏(p-1))` with numerator and denominator each a product over the same prime set. So squarefree is not needed for the *ratio*, only for the auxiliary fact that φ(d) itself is `∏(p-1)`.",
+    "mathContext": "Squarefree $d \\Rightarrow d = \\prod_{p\\mid d} p$ and $\\varphi(d) = \\prod_{p\\mid d}(p-1)$, hence $\\dfrac{d}{\\varphi(d)} = \\dfrac{\\prod_{p\\mid d} p}{\\prod_{p\\mid d}(p-1)}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["squarefree number", "Nat.prod_primeFactors_of_squarefree", "cancellation"],
+    "prerequisites": ["Squarefree", "Nat.eq_of_mul_eq_mul_left"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "euler-totient-oq-03-oq-03-oq-01",
+    "range": { "startLine": 148, "endLine": 165 },
+    "type": "context",
+    "title": "Worked Instances",
+    "content": "Three concrete checks ground the abstract identities: `6/φ(6) = 3 = (2/1)·(3/2)` for the squarefree `6 = 2·3`; `φ(15) = (3-1)(5-1) = 8`, where `Squarefree 15` is discharged via `Nat.squarefree_mul_iff` and `Prime.squarefree`; and the defect factor at `gcd(12,18) = 6` equals `∏_{p|6} p/(p-1)`, exhibiting `defect_factor_gcd` on a genuine pair.",
+    "mathContext": "$\\tfrac{6}{\\varphi(6)} = 3 = \\tfrac21\\cdot\\tfrac32$; $\\varphi(15) = 2\\cdot 4 = 8$; $\\tfrac{\\gcd(12,18)}{\\varphi(\\gcd(12,18))} = \\tfrac{6}{2} = 3$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "Nat.squarefree_mul_iff", "Prime.squarefree"],
+    "prerequisites": ["evaluation of φ on small numbers", "Finset.prod over explicit primeFactors"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-03-oq-03-oq-01` (quality 43, passes 0). This recently-merged researcher entry had a rich `meta.json` but **no `annotations.json`** — this PR fills that gap.

## Changes
Adds 7 annotations covering the full 167-line Lean file, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`:
1. **Open Question and the Closed Form** — the OQ and the answer `n/φ(n) = ∏ p/(p-1)`.
2. **The Engine** — `Nat.totient_mul_prod_primeFactors`, `φ(n)·∏p = n·∏(p-1)`.
3. **Transporting ℕ→ℚ** — the casting/positivity bridge (`cast_prod_sub_one`, `prod_sub_one_ne_zero`, truncated vs honest subtraction).
4. **The Closed-Form Defect Ratio** — the main `defect_ratio` theorem (`div_eq_div_iff` + `linear_combination` + `Finset.prod_div_distrib`).
5. **The Parent's Defect Factor** — `defect_factor_gcd` as a specialisation at `n = gcd(a,b)`.
6. **The Squarefree Case** — `totient_squarefree` (`φ(d) = ∏(p-1)`) and `defect_ratio_squarefree`.
7. **Worked Instances** — `6/φ(6)=3`, `φ(15)=8`, `gcd(12,18)=6`.

## Validation
- Resolver: **7 valid, 0 misaligned** against the Lean source.
- `meta.json` unchanged; no content deleted. `status`/`badge`/`axiomCount` (verified/mathlib/0) untouched.
- Only `annotations.json` added (1 new file).