### PR TITLE
Enrich Alternating and Bisected Lucas Partial Sums (fibonacci-identities-oq-08-oq-01): add annotations (0→6)

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-08-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "fibonacci-identities-oq-08-oq-01",
+    "range": { "startLine": 4, "endLine": 46 },
+    "type": "concept",
+    "title": "Three Companion Lucas Partial Sums",
+    "content": "The parent entry `fibonacci-identities-oq-08` proved the Lucas telescoping sum `∑_{i≤n} Lᵢ = L_{n+2} − 1`; this follow-up answers that entry's open question by proving the three companion partial sums for the Lucas numbers `L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁`: the alternating sum, and the even- and odd-indexed (bisected) sums. The docstring records both the Binet-series derivation of the closed forms and the actual proof method used here — a one-step induction per identity, kept subtraction-free where possible so `omega` can finish.",
+    "mathContext": "$\\sum_{i=0}^n (-1)^i L_i = 3 + (-1)^n(L_{n+1}-L_n)$;\\ $\\sum_{i=0}^n L_{2i}=L_{2n+1}+1$;\\ $\\sum_{i=0}^n L_{2i+1}=L_{2n+2}-2$.",
+    "significance": "context",
+    "relatedConcepts": ["Lucas numbers", "partial sums", "telescoping", "Binet formula"],
+    "prerequisites": ["Lucas numbers", "finite sums", "induction"]
+  },
+  {
+    "id": "ann-lucas-def",
+    "proofId": "fibonacci-identities-oq-08-oq-01",
+    "range": { "startLine": 57, "endLine": 74 },
+    "type": "definition",
+    "title": "Self-Contained Lucas Numbers via a Pair Recursion",
+    "content": "`lucasPair n = (Lₙ, Lₙ₊₁)` carries both consecutive values so the recursion is structural (primitive) rather than two-step, and `lucas n := (lucasPair n).1` extracts `Lₙ`. Because the recursion is by-pattern, `lucas 0`, `lucas 1`, and the defining recurrence `lucas_add_two : L_{n+2} = Lₙ + Lₙ₊₁` all hold by `rfl`. `lucas_add_two_int` casts the recurrence into `ℤ`, which the alternating sum needs to carry the sign. Reproducing the definition here (rather than importing) keeps the file self-contained and lets every step reduce definitionally.",
+    "mathContext": "$L_0=2,\\ L_1=1,\\ L_{n+2}=L_n+L_{n+1}$; the pair $(L_n,L_{n+1})$ makes the recursion structural, so the recurrence is a definitional `rfl`.",
+    "significance": "supporting",
+    "relatedConcepts": ["pair recursion", "structural recursion", "definitional equality", "Lucas recurrence"],
+    "prerequisites": ["recursive definitions in Lean", "Nat.rec", "rfl proofs"]
+  },
+  {
+    "id": "ann-alt-sum",
+    "proofId": "fibonacci-identities-oq-08-oq-01",
+    "range": { "startLine": 78, "endLine": 89 },
+    "type": "technique",
+    "title": "The Alternating Sum over ℤ",
+    "content": "`alt_lucas_sum` proves `∑_{i=0}^{n} (−1)ⁱ Lᵢ = 3 + (−1)ⁿ(L_{n+1} − Lₙ)`, working over `ℤ` so the alternating sign and the difference `L_{n+1}−Lₙ` are honest (no truncated ℕ-subtraction). The proof is a one-step induction: `Finset.sum_range_succ` peels the top term, the hypothesis rewrites the head, `lucas_add_two_int` supplies `L_{k+2}=L_k+L_{k+1}`, and `pow_succ` exposes `(−1)^{k+1}=(−1)·(−1)ᵏ`; then `ring` closes because `(−1)ᵏ` is treated as an opaque atom. The subtraction-free right side `L_{n+1}−Lₙ` (equal to the classical `L_{n−1}`) avoids any negative index.",
+    "mathContext": "$\\sum_{i=0}^{n}(-1)^i L_i = 3 + (-1)^n\\big(L_{n+1}-L_n\\big)$, with $(-1)^{k+1}=-(-1)^k$ closing the inductive step by `ring`.",
+    "significance": "key",
+    "relatedConcepts": ["alternating sum", "geometric series", "Finset.sum_range_succ", "ring tactic"],
+    "prerequisites": ["induction on ℕ", "Finset.sum_range_succ", "pow_succ"]
+  },
+  {
+    "id": "ann-even-sum",
+    "proofId": "fibonacci-identities-oq-08-oq-01",
+    "range": { "startLine": 93, "endLine": 104 },
+    "type": "technique",
+    "title": "The Even-Indexed (Bisected) Sum",
+    "content": "`lucas_even_sum` proves `∑_{i=0}^{n} L_{2i} = L_{2n+1} + 1`. The bisection uses the two-step recurrence at odd base: the new term `L_{2k+2}` glues to the inductive `L_{2k+1}` via `L_{2k+3} = L_{2k+1} + L_{2k+2}`. After `sum_range_succ` and the hypothesis, the goal is a purely additive equation among the atoms `L_{2k+1}, L_{2k+2}, L_{2k+3}`, so `omega` finishes once the recurrence is provided as a linear fact. The constant `+1` originates from the base value `L₁ = 1`.",
+    "mathContext": "$\\sum_{i=0}^{n} L_{2i} = L_{2n+1} + 1$; inductive glue $L_{2k+3}=L_{2k+1}+L_{2k+2}$.",
+    "significance": "key",
+    "relatedConcepts": ["bisected sum", "two-step recurrence", "omega tactic", "Finset.sum_range_succ"],
+    "prerequisites": ["induction on ℕ", "linear arithmetic (omega)", "Lucas recurrence"]
+  },
+  {
+    "id": "ann-odd-sum",
+    "proofId": "fibonacci-identities-oq-08-oq-01",
+    "range": { "startLine": 108, "endLine": 127 },
+    "type": "technique",
+    "title": "The Odd-Indexed Sum via a Subtraction-Free Lemma",
+    "content": "The odd-indexed sum `∑_{i=0}^{n} L_{2i+1} = L_{2n+2} − 2` involves ℕ-subtraction, which is truncated and awkward for induction. The file first proves the subtraction-free `lucas_odd_sum_add_two : (∑ L_{2i+1}) + 2 = L_{2n+2}` by the same `sum_range_succ` + `omega` pattern (gluing `L_{2k+3}` via `L_{2k+4} = L_{2k+2} + L_{2k+3}`), then derives the stated form `lucas_odd_sum` in one line: `omega` rearranges `(∑) + 2 = L_{2n+2}` into `∑ = L_{2n+2} − 2`, valid because `L_{2n+2} ≥ 2`. The `−2` constant traces to the base value `L₀ = 2`.",
+    "mathContext": "$\\big(\\sum_{i=0}^{n} L_{2i+1}\\big) + 2 = L_{2n+2}$, hence $\\sum_{i=0}^{n} L_{2i+1} = L_{2n+2} - 2$ (truncated $\\mathbb{N}$-subtraction, well-defined as $L_{2n+2}\\ge 2$).",
+    "significance": "key",
+    "relatedConcepts": ["truncated subtraction", "subtraction-free reformulation", "omega tactic", "bisected sum"],
+    "prerequisites": ["ℕ truncated subtraction", "linear arithmetic (omega)", "induction on ℕ"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "fibonacci-identities-oq-08-oq-01",
+    "range": { "startLine": 131, "endLine": 140 },
+    "type": "context",
+    "title": "Numerical Sanity Checks",
+    "content": "Three `decide` checks confirm each closed form on a concrete instance: the alternating sum `L₀−L₁+L₂−L₃+L₄ = 2−1+3−4+7 = 7` matches `3+(−1)⁴(L₅−L₄)=3+(11−7)`; the even sum `L₀+L₂+L₄ = 12 = L₅+1`; and the odd sum `L₁+L₃+L₅ = 16 = L₆−2`. Because `lucas` reduces by `rfl`, these fully evaluate and `decide` discharges them without touching the general theorems.",
+    "mathContext": "$2-1+3-4+7=7$;\\ $2+3+7=12=L_5+1$;\\ $1+4+11=16=L_6-2$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "decide tactic", "computational reduction"],
+    "prerequisites": ["decidable equality", "evaluation of recursive definitions"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-08-oq-01` (quality 43, passes 0). Recently-merged researcher entry with rich `meta.json` but **no `annotations.json`** — this PR fills that gap.

## Changes
6 annotations covering the full 142-line Lean file, each with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`:
1. **Three Companion Lucas Partial Sums** — header, the parent OQ, and the three closed forms.
2. **Self-Contained Lucas Numbers** — the `lucasPair` structural recursion; recurrence as `rfl`.
3. **The Alternating Sum over ℤ** — `alt_lucas_sum`, one-step induction closed by `ring` with `(−1)ᵏ` opaque.
4. **The Even-Indexed Bisected Sum** — `lucas_even_sum`, `omega` from the two-step recurrence.
5. **The Odd-Indexed Sum** — the subtraction-free `lucas_odd_sum_add_two` lemma and its `−2` corollary.
6. **Numerical Sanity Checks** — the three `decide` instances.

## Validation
- Resolver: **6 valid, 0 misaligned** against the Lean source.
- `meta.json` unchanged; no content deleted. `status`/`badge`/`axiomCount` (verified/verified/0) untouched.
- Only `annotations.json` added (1 new file).