### PR TITLE
Enrich Raabe Multiplication Formula at m=3,4 (hermite-sawtooth-identity-oq-01-oq-03): add annotations (0→6)

### DIFF
--- a/src/data/proofs/hermite-sawtooth-identity-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-01-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "hermite-sawtooth-identity-oq-01-oq-03",
+    "range": { "startLine": 3, "endLine": 37 },
+    "type": "concept",
+    "title": "Open Question: How Far Does the Elementary Route Reach?",
+    "content": "The parent entry proved the Raabe multiplication theorem `∑_{k<n} Bₘ(x + k/n) = n^{1-m} Bₘ(nx)` for `m = 0,1,2` by a generating-function-free route: evaluate `Bₘ` to an explicit polynomial and close with Faulhaber power sums. Its open question asks how far this elementary method reaches. This file answers by proving `m = 3` (coefficient `n⁻²`) and `m = 4` (coefficient `n⁻³`), needing only the two extra power sums `∑k³` and `∑k⁴`. Verdict: the route extends cleanly to every fixed `m` — bounded only by availability of the Faulhaber sums, growing longer but never genuinely unwieldy.",
+    "mathContext": "$\\sum_{k=0}^{n-1} B_m\\!\\left(x + \\tfrac{k}{n}\\right) = n^{1-m} B_m(nx)$, proved here for $m = 3$ ($n^{-2}$) and $m = 4$ ($n^{-3}$).",
+    "significance": "context",
+    "relatedConcepts": ["Bernoulli polynomials", "Raabe multiplication formula", "Faulhaber sums", "generating functions"],
+    "prerequisites": ["Bernoulli polynomials", "finite power sums"]
+  },
+  {
+    "id": "ann-bernoulli-vals",
+    "proofId": "hermite-sawtooth-identity-oq-01-oq-03",
+    "range": { "startLine": 45, "endLine": 62 },
+    "type": "definition",
+    "title": "Explicit Evaluations of B₃ and B₄",
+    "content": "The proof needs the Bernoulli polynomials as concrete rational polynomials, not as Mathlib's abstract `Polynomial.bernoulli`. `bernoulli_three_val` and `bernoulli_four_val` first pin the Bernoulli numbers `b₃ = 0`, `b₄ = -1/30`, routed through `bernoulli'` via `bernoulli_eq_bernoulli'_of_ne_one` (Mathlib stores the `bernoulli'` convention). Then `bernoulli_eval_three'` and `bernoulli_eval_four'` unfold `Polynomial.bernoulli` through `Finset.sum_range_succ`, substitute those numbers, and `ring`-normalise to `B₃(x) = x³ - (3/2)x² + (1/2)x` and `B₄(x) = x⁴ - 2x³ + x² - 1/30`.",
+    "mathContext": "$b_3 = 0,\\ b_4 = -\\tfrac1{30}$; $B_3(x) = x^3 - \\tfrac32 x^2 + \\tfrac12 x$, $B_4(x) = x^4 - 2x^3 + x^2 - \\tfrac1{30}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Bernoulli numbers", "bernoulli' convention", "Polynomial.eval"],
+    "prerequisites": ["Bernoulli numbers", "Polynomial.bernoulli", "Finset.sum_range_succ"]
+  },
+  {
+    "id": "ann-power-sums",
+    "proofId": "hermite-sawtooth-identity-oq-01-oq-03",
+    "range": { "startLine": 66, "endLine": 94 },
+    "type": "technique",
+    "title": "Faulhaber Power Sums over ℚ (degrees 1–4)",
+    "content": "The four Faulhaber closed forms `∑_{k<n} kʲ` for `j = 1,2,3,4` are the entire analytic content: Gauss `n(n-1)/2`, sum-of-squares `n(n-1)(2n-1)/6`, Nicomachus cubes `(n(n-1)/2)²`, and the degree-4 sum `n(n-1)(2n-1)(3n²-3n-1)/30`. Each is proved over ℚ by the same rote one-step induction — `sum_range_succ` then `push_cast; ring` — so no generating function or Bernoulli machinery is invoked. Working over ℚ from the start (rather than ℕ with division) keeps every step subtraction- and truncation-free.",
+    "mathContext": "$\\sum_{k<n}k = \\tfrac{n(n-1)}2,\\ \\sum k^2=\\tfrac{n(n-1)(2n-1)}6,\\ \\sum k^3=\\big(\\tfrac{n(n-1)}2\\big)^2,\\ \\sum k^4=\\tfrac{n(n-1)(2n-1)(3n^2-3n-1)}{30}$.",
+    "significance": "key",
+    "relatedConcepts": ["Faulhaber's formula", "power sums", "Nicomachus's theorem", "induction"],
+    "prerequisites": ["induction on ℕ", "Finset.sum_range_succ", "push_cast", "ring"]
+  },
+  {
+    "id": "ann-raabe-three",
+    "proofId": "hermite-sawtooth-identity-oq-01-oq-03",
+    "range": { "startLine": 98, "endLine": 118 },
+    "type": "insight",
+    "title": "Raabe at m = 3",
+    "content": "`raabe_three` proves `∑_{k<n} B₃(x + k/n) = n⁻² · B₃(nx)` for `n ≥ 1`. The strategy is fully mechanical: `simp` rewrites each summand to the explicit `B₃`, the auxiliary `hexp` expands `B₃(x + k/n)` as a polynomial in `k` with coefficients in `x` and `1/n` (proved by `field_simp; ring`), then `Finset.sum_add_distrib`/`sum_const`/`← mul_sum` split the sum into the power sums `∑k, ∑k², ∑k³`, which are substituted from the Faulhaber lemmas. A closing `field_simp; ring` verifies the coefficient `n⁻²`. This is the m=3 instance of the method's one-shape template.",
+    "mathContext": "$\\sum_{k<n} B_3\\!\\left(x+\\tfrac{k}{n}\\right) = \\tfrac1{n^2} B_3(nx)$; the summand is a cubic in $k$ whose coefficients collapse via $\\sum k, \\sum k^2, \\sum k^3$.",
+    "significance": "key",
+    "relatedConcepts": ["Raabe formula", "Finset.sum_add_distrib", "Finset.mul_sum", "field_simp"],
+    "prerequisites": ["Faulhaber sums", "Finset sum manipulation", "field_simp", "ring"]
+  },
+  {
+    "id": "ann-raabe-four",
+    "proofId": "hermite-sawtooth-identity-oq-01-oq-03",
+    "range": { "startLine": 120, "endLine": 141 },
+    "type": "technique",
+    "title": "Raabe at m = 4",
+    "content": "`raabe_four` proves `∑_{k<n} B₄(x + k/n) = n⁻³ · B₄(nx)`, following exactly the same template as `raabe_three` but one degree higher: the summand expands to a quartic in `k`, so the closing step also consumes `∑k⁴` (`sum_range_quart_rat`). That the proof is a verbatim copy with one extra power-sum line is precisely the evidence for the file's verdict — the elementary route does not break down at higher `m`, it merely lengthens by one Faulhaber ingredient per order.",
+    "mathContext": "$\\sum_{k<n} B_4\\!\\left(x+\\tfrac{k}{n}\\right) = \\tfrac1{n^3} B_4(nx)$; identical shape to $m=3$ plus the $\\sum k^4$ term.",
+    "significance": "supporting",
+    "relatedConcepts": ["Raabe formula", "method scaling", "quartic power sum"],
+    "prerequisites": ["Faulhaber sums", "Finset sum manipulation", "field_simp", "ring"]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "hermite-sawtooth-identity-oq-01-oq-03",
+    "range": { "startLine": 145, "endLine": 157 },
+    "type": "context",
+    "title": "Sanity Checks at x = 0, n = 2",
+    "content": "Two examples instantiate the general theorems at `x = 0, n = 2`: `∑_{k<2} B₃(k/2) = (1/4)B₃(0) = 0` and `∑_{k<2} B₄(k/2) = (1/8)B₄(0) = -1/240`. Each is discharged by specialising `raabe_three`/`raabe_four` and `simpa`, confirming the closed forms compute correctly on a concrete instance rather than re-deriving them.",
+    "mathContext": "$\\sum_{k<2} B_3(k/2) = \\tfrac14 B_3(0) = 0$;\\ $\\sum_{k<2} B_4(k/2) = \\tfrac18 B_4(0) = -\\tfrac1{240}$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "specialisation", "simpa"],
+    "prerequisites": ["Polynomial.eval", "specialising universally quantified theorems"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `hermite-sawtooth-identity-oq-01-oq-03` (quality 43, passes 0). Recently-merged researcher entry with rich `meta.json` but **no `annotations.json`**.

## Changes
6 annotations covering the full 159-line Lean file, each with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`:
1. **Open Question header** — how far the generating-function-free route reaches, and the verdict.
2. **Explicit B₃/B₄ evaluations** — Bernoulli numbers `b₃=0, b₄=-1/30` via `bernoulli'`, then the polynomials.
3. **Faulhaber power sums (deg 1–4)** — Gauss, squares, Nicomachus cubes, degree-4; rote inductions over ℚ.
4. **Raabe at m=3** — the mechanical expand→split→substitute→`field_simp;ring` template (`n⁻²`).
5. **Raabe at m=4** — the same template one degree higher (`n⁻³`), evidencing the method scales.
6. **Sanity checks** — the two `x=0,n=2` instances.

## Validation
- Resolver: **6 valid, 0 misaligned**.
- `meta.json` unchanged; only `annotations.json` added. `status`/`badge`/`axiomCount` untouched.