### PR TITLE
Enrich The Cassini Defect Calculus (pell-equation-oq-07-oq-01-oq-02): add annotations (0→10)

### DIFF
--- a/src/data/proofs/pell-equation-oq-07-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-pe070102-overview",
+    "proofId": "pell-equation-oq-07-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 66 },
+    "type": "concept",
+    "title": "The Cassini defect as a recurrence invariant",
+    "content": "The sibling entry proves the Cassini/Catalan identities for the Pell coordinate sequences by explicit conjugate algebra in ℤ[√d]. This entry abstracts the structural theorem behind them — and behind the Fibonacci Cassini identity Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ — into a small calculus valid for ANY second-order linear recurrence over ANY commutative ring. The key object is the Cassini defect D(k) = u(k+2)·u(k) − u(k+1)²; the whole phenomenon reduces to the fact that D scales by a constant factor q each step, hence D(k) = qᵏ·D(0). This defect is exactly the determinant of the recurrence's 2×2 state matrix, so the identity is the specialization of det(Mⁿ) = (det M)ⁿ.",
+    "mathContext": "$D(k) = u(k{+}2)\\,u(k) - u(k{+}1)^2 = q^k D(0)$ for any recurrence $u(n{+}2) = p\\,u(n{+}1) - q\\,u(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Cassini identity", "Catalan identity", "second-order linear recurrence", "determinant of a matrix power"],
+    "prerequisites": ["linear recurrences", "commutative rings", "the sibling entry pell-equation-oq-07-oq-01-oq-01"]
+  },
+  {
+    "id": "ann-pe070102-def",
+    "proofId": "pell-equation-oq-07-oq-01-oq-02",
+    "range": { "startLine": 74, "endLine": 78 },
+    "type": "definition",
+    "title": "The Cassini defect D(k)",
+    "content": "The defect of a sequence u : ℕ → R at index k is the off-by-one product-minus-square u(k+2)·u(k) − u(k+1)². For the Fibonacci sequence this is the left side of Cassini's identity; the definition is stated for an arbitrary sequence over any commutative ring so that all downstream theorems are ring- and recurrence-agnostic and reusable for both Fibonacci and Pell.",
+    "mathContext": "$D(k) := u(k{+}2)\\,u(k) - u(k{+}1)^2$",
+    "significance": "key",
+    "relatedConcepts": ["Cassini defect", "sequence invariant"],
+    "prerequisites": ["commutative rings"]
+  },
+  {
+    "id": "ann-pe070102-succ",
+    "proofId": "pell-equation-oq-07-oq-01-oq-02",
+    "range": { "startLine": 80, "endLine": 91 },
+    "type": "insight",
+    "title": "One-step scaling law: D(k+1) = q·D(k)",
+    "content": "The heart of the calculus. If u satisfies u(n+2) = p·u(n+1) − q·u(n), then the second-order recurrence collapses the difference D(k+1) − q·D(k) to u(k+2)·(p·u(k+1) − q·u(k) − u(k+2)) = 0. In Lean this is a single linear_combination u(k+1)·h1 − u(k+2)·h2 against the two recurrence instances at k and k+1. Notice the defect obeys a FIRST-order recurrence of its own even though u is second-order — that drop in order is exactly why Cassini identities have closed forms.",
+    "mathContext": "$D(k{+}1) - q\\,D(k) = u(k{+}2)\\big(p\\,u(k{+}1) - q\\,u(k) - u(k{+}2)\\big) = 0.$",
+    "significance": "key",
+    "relatedConcepts": ["order reduction", "linear_combination", "telescoping"],
+    "prerequisites": ["second-order recurrence"]
+  },
+  {
+    "id": "ann-pe070102-eq",
+    "proofId": "pell-equation-oq-07-oq-01-oq-02",
+    "range": { "startLine": 93, "endLine": 101 },
+    "type": "technique",
+    "title": "Integrated identity: D(k) = qᵏ·D(0)",
+    "content": "Integrating the one-step scaling law by induction gives the closed form D(k) = qᵏ·D(0). This single equation is the abstract Cassini/Catalan theorem: u(k+2)·u(k) − u(k+1)² = qᵏ·(u₂u₀ − u₁²). The induction is one line — base case simp, successor step applies cassiniDefect_succ, the hypothesis, and pow_succ then closes with ring.",
+    "mathContext": "$D(k) = q^k D(0) = q^k\\big(u_2 u_0 - u_1^2\\big).$",
+    "significance": "key",
+    "relatedConcepts": ["induction", "geometric scaling", "closed form"],
+    "prerequisites": ["one-step scaling law", "mathematical induction"]
+  },
+  {
+    "id": "ann-pe070102-det",
+    "proofId": "pell-equation-oq-07-oq-01-oq-02",
+    "range": { "startLine": 103, "endLine": 109 },
+    "type": "insight",
+    "title": "The defect is a 2×2 determinant",
+    "content": "The defect equals the determinant of the state matrix W(k) = [[u(k+2), u(k+1)], [u(k+1), u(k)]], whose columns are the consecutive state vectors (u(k+2), u(k+1)) and (u(k+1), u(k)) of the recurrence. The proof is just det_fin_two_of followed by ring. This reframing is what connects the elementary Cassini identity to the matrix-power viewpoint of the grandparent entry.",
+    "mathContext": "$D(k) = \\det\\begin{pmatrix} u(k{+}2) & u(k{+}1)\\\\ u(k{+}1) & u(k)\\end{pmatrix}$",
+    "significance": "supporting",
+    "relatedConcepts": ["state matrix", "2×2 determinant", "Matrix.det_fin_two_of"],
+    "prerequisites": ["determinants", "companion matrix of a recurrence"]
+  },
+  {
+    "id": "ann-pe070102-detform",
+    "proofId": "pell-equation-oq-07-oq-01-oq-02",
+    "range": { "startLine": 111, "endLine": 119 },
+    "type": "insight",
+    "title": "Determinant form: det(W k) = qᵏ·det(W 0)",
+    "content": "Combining the determinant identity with the integrated scaling law gives det(W k) = qᵏ·det(W 0). Since the recurrence companion C = [[p, −q], [1, 0]] has det C = q and advances the state via W k = Cᵏ·W₀, this is precisely det(Cᵏ·W₀) = (det C)ᵏ·det(W₀) — the sharpest form of the multiplicativity of determinants det(Mⁿ) = (det M)ⁿ that the grandparent's companion matrix was pointing at.",
+    "mathContext": "$\\det(W_k) = q^k \\det(W_0) = (\\det C)^k \\det(W_0),\\quad C = \\begin{pmatrix} p & -q\\\\ 1 & 0\\end{pmatrix}.$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicativity of determinant", "companion matrix", "det(Mⁿ) = (det M)ⁿ"],
+    "prerequisites": ["determinant of a matrix power", "the integrated identity"]
+  },
+  {
+    "id": "ann-pe070102-fib",
+    "proofId": "pell-equation-oq-07-oq-01-oq-02",
+    "range": { "startLine": 121, "endLine": 134 },
+    "type": "context",
+    "title": "Fibonacci instantiation (p=1, q=−1)",
+    "content": "Setting p = 1, q = −1 makes the abstract identity read Fₖ₊₂·Fₖ − Fₖ₊₁² = (−1)ᵏ·(F₂F₀ − F₁²). For the standard seed F₀ = 0, F₁ = 1 the base defect is F₂F₀ − F₁² = −1, so this collapses to (−1)ᵏ⁺¹ — Cassini's classical 1680 identity Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ. The example feeds the additive recurrence into cassiniDefect_eq and simplifies.",
+    "mathContext": "$F_{k+2}F_k - F_{k+1}^2 = (-1)^k(F_2 F_0 - F_1^2) = (-1)^{k+1}.$",
+    "significance": "context",
+    "relatedConcepts": ["Cassini's identity", "Fibonacci numbers"],
+    "prerequisites": ["Fibonacci recurrence"]
+  },
+  {
+    "id": "ann-pe070102-pell-cassini",
+    "proofId": "pell-equation-oq-07-oq-01-oq-02",
+    "range": { "startLine": 136, "endLine": 150 },
+    "type": "context",
+    "title": "Pell instantiation recovers the sibling identity",
+    "content": "For the Pell real-coordinate sequence n ↦ re(aⁿ) with a ∈ ℤ[√d], the grandparent's re_recurrence supplies the recurrence with p = 2·re(a) and q = N(a) (the norm). Feeding this into cassiniDefect_eq immediately recovers the sibling's Pell Cassini identity re(aᵏ⁺²)·re(aᵏ) − re(aᵏ⁺¹)² = N(a)ᵏ·(base defect), demonstrating that the abstract calculus subsumes the hand-crafted conjugate-algebra proof.",
+    "mathContext": "$\\mathrm{re}(a^{k+2})\\,\\mathrm{re}(a^k) - \\mathrm{re}(a^{k+1})^2 = N(a)^k\\big(\\mathrm{re}(a^2)\\mathrm{re}(a^0) - \\mathrm{re}(a^1)^2\\big).$",
+    "significance": "supporting",
+    "relatedConcepts": ["Pell equation", "ℤ[√d] norm", "re_recurrence"],
+    "prerequisites": ["the grandparent entry pell-equation-oq-07", "quadratic integer rings"]
+  },
+  {
+    "id": "ann-pe070102-pell-unit",
+    "proofId": "pell-equation-oq-07-oq-01-oq-02",
+    "range": { "startLine": 152, "endLine": 162 },
+    "type": "insight",
+    "title": "A Pell unit has a constant Cassini invariant",
+    "content": "When a is a Pell unit, N(a) = 1, so the factor N(a)ᵏ = 1 disappears entirely and the defect becomes constant in k: re(aₖ₊₂)·re(aₖ) − re(aₖ₊₁)² = d·y₁², where y₁ = im(a). The proof simplifies away the norm power, then evaluates the base defect using re(a²) = re(a)² + d·im(a)² and re(a⁰) = 1. This is the arithmetic signature of solutions to Pell's equation x² − d·y² = 1.",
+    "mathContext": "$N(a)=1 \\implies \\mathrm{re}(a^{k+2})\\,\\mathrm{re}(a^k) - \\mathrm{re}(a^{k+1})^2 = d\\,y_1^2\\ (\\text{constant}).$",
+    "significance": "key",
+    "relatedConcepts": ["Pell unit", "fundamental solution", "norm-one elements"],
+    "prerequisites": ["Pell's equation", "units of ℤ[√d]"]
+  },
+  {
+    "id": "ann-pe070102-check",
+    "proofId": "pell-equation-oq-07-oq-01-oq-02",
+    "range": { "startLine": 164, "endLine": 168 },
+    "type": "context",
+    "title": "Numeric check for the fundamental unit 3 + 2√2",
+    "content": "A concrete decide-verified instance for the fundamental unit a = 3 + 2√2 of x² − 2y² = 1: the base defect is re(a²)·re(a⁰) − re(a¹)² = 17·1 − 9 = 8 = d·y₁² = 2·2². Because a is a Pell unit (q = N(a) = 1), the defect stays 8 at every index, illustrating the constant-invariant theorem above.",
+    "mathContext": "$a = 3 + 2\\sqrt2:\\ 17\\cdot 1 - 9 = 8 = 2\\cdot 2^2.$",
+    "significance": "context",
+    "relatedConcepts": ["fundamental unit", "decidable evaluation"],
+    "prerequisites": ["decide tactic"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-07-oq-01-oq-02` (was 0 annotations).

## What
Adds `annotations.json` with **10 line-anchored annotations** giving full coverage of the 176-line proof:

| Lines | Annotation |
|-------|-----------|
| 1–66 | Overview: the Cassini defect as a recurrence invariant |
| 74–78 | `cassiniDefect` definition |
| 80–91 | One-step scaling law D(k+1)=q·D(k) |
| 93–101 | Integrated identity D(k)=qᵏ·D(0) |
| 103–109 | The defect is a 2×2 determinant |
| 111–119 | Determinant form / det(Mⁿ)=(det M)ⁿ connection |
| 121–134 | Fibonacci instantiation |
| 136–150 | Pell instantiation recovers the sibling identity |
| 152–162 | Constant Cassini invariant of a Pell unit |
| 164–168 | Numeric check for 3+2√2 |

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Validation
`npx tsx scripts/annotations/resolver.ts validate` → **10 valid, 0 misaligned**.

Annotations only; no changes to the Lean source or meta.json.