### PR TITLE
Enrich The Exact Cardinality of the Algebraic Elements (algebraic-numbers-countable-oq-05-oq-04-oq-01): add annotations (0→6)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05-oq-04-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04-oq-01",
+    "range": { "startLine": 3, "endLine": 65 },
+    "type": "concept",
+    "title": "From Countability Dichotomy to Exact Cardinal",
+    "content": "The parent entry characterized when `{x : L | IsAlgebraic K x}` is countable (iff `K` is countable). This entry upgrades that coarse dichotomy to an exact cardinal formula: `#{x : L | IsAlgebraic K x} = max(#K, ℵ₀)`, under the natural hypothesis that the ambient `L` is algebraically closed (`IsAlgClosed L`) — precisely the statement that `L` contains an algebraic closure of `K`. The hypothesis is genuinely needed: for `L = K` a finite field the algebraic set is just `K` (finite), while `max(#K, ℵ₀) = ℵ₀`. Both the countable regime (`max = ℵ₀`) and the uncountable regime (`max = #K`) are the two cases of the one formula.",
+    "mathContext": "$\\#\\{x \\in L : x\\ \\text{algebraic}/K\\} = \\max(\\#K, \\aleph_0)$ when $L$ is algebraically closed.",
+    "significance": "context",
+    "relatedConcepts": ["cardinal arithmetic", "algebraic closure", "algebraic numbers", "countability"],
+    "prerequisites": ["cardinality", "algebraic elements", "field extensions"]
+  },
+  {
+    "id": "ann-upper",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04-oq-01",
+    "range": { "startLine": 77, "endLine": 83 },
+    "type": "technique",
+    "title": "Upper Bound from Mathlib",
+    "content": "`cardinalMk_algebraicClosure_le` gives `#(algebraicClosure K L) ≤ max(#K, ℵ₀)`. The algebraic elements form the *relative algebraic closure* `algebraicClosure K L`, an intermediate field whose carrier is exactly `{x : L | IsAlgebraic K x}`. Since that field is algebraic over `K`, the bound is directly Mathlib's `Algebra.IsAlgebraic.cardinalMk_le_max` — the one inequality the open question already had in hand. All the new work is the matching lower bound.",
+    "mathContext": "$\\#(\\overline{K}^L) \\le \\max(\\#K, \\aleph_0)$, where $\\overline{K}^L = \\text{algebraicClosure}\\ K\\ L$.",
+    "significance": "supporting",
+    "relatedConcepts": ["relative algebraic closure", "IntermediateField", "cardinalMk_le_max"],
+    "prerequisites": ["Algebra.IsAlgebraic.cardinalMk_le_max", "algebraicClosure"]
+  },
+  {
+    "id": "ann-lower",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04-oq-01",
+    "range": { "startLine": 87, "endLine": 102 },
+    "type": "technique",
+    "title": "The Two Lower Bounds",
+    "content": "The lower bound `max(#K, ℵ₀) ≤ #A` splits into two. `cardinalMk_le_algebraicClosure`: `#K ≤ #A`, because the base field embeds into its relative algebraic closure via the injective `algebraMap` (`FaithfulSMul.algebraMap_injective`) and `Cardinal.mk_le_of_injective`. `aleph0_le_cardinalMk_algebraicClosure`: `ℵ₀ ≤ #A`, because when `L` is algebraically closed, `A` is an *absolute* algebraic closure of `K` (the local instance `IsAlgClosure.isAlgClosed`), hence itself algebraically closed, hence infinite — an algebraically closed field is never finite.",
+    "mathContext": "$\\#K \\le \\#A$ (via injective $\\text{algebraMap}$) and $\\aleph_0 \\le \\#A$ (an algebraically closed field is infinite).",
+    "significance": "key",
+    "relatedConcepts": ["injective algebraMap", "algebraically closed fields are infinite", "IsAlgClosure"],
+    "prerequisites": ["Cardinal.mk_le_of_injective", "FaithfulSMul.algebraMap_injective", "Cardinal.aleph0_le_mk"]
+  },
+  {
+    "id": "ann-exact",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04-oq-01",
+    "range": { "startLine": 106, "endLine": 129 },
+    "type": "insight",
+    "title": "The Exact Cardinal Formula",
+    "content": "`cardinalMk_algebraicClosure_eq_max` assembles the exact formula on the relative closure by `le_antisymm` of the upper bound and `max_le` of the two lower bounds. `cardinalMk_setOf_eq_algebraicClosure` then transports it from the intermediate field `algebraicClosure K L` to the raw set `{x : L | IsAlgebraic K x}` via `Equiv.subtypeEquivRight` and `mem_algebraicClosure_iff` (same elements ⇒ same cardinal). The main theorem `cardinalMk_setOf_isAlgebraic_eq_max` is the one-line composition: `#{x : L | IsAlgebraic K x} = max(#K, ℵ₀)`.",
+    "mathContext": "$\\#\\{x : L \\mid \\text{IsAlgebraic}\\ K\\ x\\} = \\#(\\text{algebraicClosure}\\ K\\ L) = \\max(\\#K, \\aleph_0)$.",
+    "significance": "key",
+    "relatedConcepts": ["le_antisymm", "Cardinal.mk_congr", "subtypeEquivRight", "mem_algebraicClosure_iff"],
+    "prerequisites": ["le_antisymm", "max_le", "Equiv.subtypeEquivRight"]
+  },
+  {
+    "id": "ann-absolute",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04-oq-01",
+    "range": { "startLine": 136, "endLine": 143 },
+    "type": "concept",
+    "title": "The Absolute Algebraic Closure",
+    "content": "`cardinalMk_algebraicClosure_type_eq_max` states the same formula for Mathlib's absolute construction `AlgebraicClosure K`: `#(AlgebraicClosure K) = max(#K, ℵ₀)`. This is the special case `L = AlgebraicClosure K` of the main result — the whole type is algebraic over `K`, so the algebraic set is everything — and it is proved directly by the same `le_antisymm`/`max_le` pattern applied to `AlgebraicClosure K`.",
+    "mathContext": "$\\#(\\overline{K}) = \\max(\\#K, \\aleph_0)$ for the absolute algebraic closure $\\overline{K} = \\text{AlgebraicClosure}\\ K$.",
+    "significance": "supporting",
+    "relatedConcepts": ["AlgebraicClosure", "absolute vs relative closure"],
+    "prerequisites": ["AlgebraicClosure K", "Algebra.IsAlgebraic.cardinalMk_le_max"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04-oq-01",
+    "range": { "startLine": 149, "endLine": 162 },
+    "type": "context",
+    "title": "Both Regimes as Instances",
+    "content": "Two examples realise the two cases of the single formula. Countable regime: the algebraic numbers `{x : ℂ | IsAlgebraic ℚ x}` have cardinality `max(#ℚ, ℵ₀) = ℵ₀` (via `Cardinal.mkRat` and `max_self`) — the classical countability of the algebraic numbers, now as an exact count. Uncountable regime: `{x : ℂ | IsAlgebraic ℝ x}` has cardinality `max(#ℝ, ℵ₀) = 𝔠` (via `Cardinal.mk_real` and `aleph0_le_continuum`), since every element of ℂ is algebraic over ℝ of degree ≤ 2.",
+    "mathContext": "$\\#\\{x \\in \\mathbb{C} : x\\ \\text{alg}/\\mathbb{Q}\\} = \\aleph_0$;\\ $\\#\\{x \\in \\mathbb{C} : x\\ \\text{alg}/\\mathbb{R}\\} = \\mathfrak{c}$.",
+    "significance": "context",
+    "relatedConcepts": ["algebraic numbers", "continuum", "Cardinal.mkRat", "Cardinal.mk_real"],
+    "prerequisites": ["cardinality of ℚ and ℝ", "aleph0_le_continuum"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-05-oq-04-oq-01` (quality 43, passes 0). Recently-merged researcher entry with rich `meta.json` but **no `annotations.json`**.

## Changes
6 annotations covering the full 165-line Lean file, each with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`:
1. **From Countability Dichotomy to Exact Cardinal** — the OQ, sharp answer, and why `IsAlgClosed L` is needed.
2. **Upper Bound from Mathlib** — `Algebra.IsAlgebraic.cardinalMk_le_max` on the relative closure.
3. **The Two Lower Bounds** — base-field embedding (`#K ≤ #A`) and infinitude (`ℵ₀ ≤ #A`).
4. **The Exact Cardinal Formula** — `le_antisymm` assembly + transport to the raw algebraic set.
5. **The Absolute Algebraic Closure** — the `AlgebraicClosure K` special case.
6. **Both Regimes as Instances** — `ℚ→ℂ` (`ℵ₀`) and `ℝ→ℂ` (`𝔠`).

## Validation
- Resolver: **6 valid, 0 misaligned**.
- `meta.json` unchanged; only `annotations.json` added. `status`/`badge`/`axiomCount` untouched.