### PR TITLE
research(lucas-sequence-degree2-identities-oq-02-oq-01): sharp bound gcd(Uₙ,Vₙ) ∣ 2 for coprime parameters [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/LucasSequenceDegree2IdentitiesOQ02OQ01.lean
+++ b/proofs/Proofs/LucasSequenceDegree2IdentitiesOQ02OQ01.lean
@@ -1,0 +1,139 @@
+import Mathlib.Tactic
+import Proofs.LucasSequenceDegree2Identities
+
+/-
+# The Sharp Divisibility Bound `gcd(Uₙ, Vₙ) ∣ 2` for Coprime Parameters
+
+## Open Question (answered)
+
+For the two Lucas sequences of parameters `(P, Q)`
+
+  `Uₙ` : `U₀ = 0, U₁ = 1`,   `Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ`   (fundamental)
+  `Vₙ` : `V₀ = 2, V₁ = P`,   `Vₙ₊₂ = P·Vₙ₊₁ − Q·Vₙ`   (companion)
+
+the sibling entry `LucasSequenceDegree2IdentitiesOQ02` proves the *unconditional*
+divisibility core `gcd(Uₙ, Vₙ) ∣ 4·Qⁿ` (and its `Q = −1` corollary `∣ 4`), from the
+master identity `Vₙ² − D·Uₙ² = 4·Qⁿ`.  Its open question asks to **sharpen** this to
+
+  **`gcd(Uₙ, Vₙ) ∣ 2`  whenever `gcd(P, Q) = 1`.**
+
+This is the best possible constant: for the Fibonacci/Lucas case `(P,Q) = (1,−1)` one
+has `gcd(F₃, L₃) = gcd(2, 4) = 2`, so the `2` cannot be improved to `1`.
+
+## Results
+
+* `U_succ_coprime_Q`  — `IsCoprime Uₙ₊₁ Q`  (`Uₙ₊₁ ≡ Pⁿ (mod Q)`, so coprime to `Q`).
+* `U_coprime_succ`    — `IsCoprime Uₙ Uₙ₊₁`  (consecutive fundamental terms are coprime).
+* `gcd_dvd_two_of_coprime` — the sharp bound `gcd(Uₙ, Vₙ) ∣ 2` for `gcd(P,Q)=1`.
+* `fib_lucas_gcd_dvd_two` / `pell_gcd_dvd_two` — Fibonacci/Lucas and Pell instances.
+
+## Proof architecture
+
+The engine is the companion-from-fundamental relation `Vₙ = 2·Uₙ₊₁ − P·Uₙ` (`V_eq`,
+proved in the base file).  Writing `g = gcd(Uₙ, Vₙ)`:
+
+* `g ∣ Uₙ` and `g ∣ Vₙ`, so `g ∣ Vₙ + P·Uₙ = 2·Uₙ₊₁`.
+* Under `gcd(P,Q) = 1`, consecutive terms `Uₙ, Uₙ₊₁` are coprime (`U_coprime_succ`),
+  hence `IsCoprime g Uₙ₊₁` (as `g ∣ Uₙ`).
+* From `g ∣ 2·Uₙ₊₁` and `IsCoprime g Uₙ₊₁` we cancel `Uₙ₊₁` (`IsCoprime.dvd_of_dvd_mul_right`)
+  to get `g ∣ 2`.
+
+The coprimality `U_coprime_succ` is itself an induction, and needs the auxiliary
+`U_succ_coprime_Q` (`Uₙ₊₁` is coprime to `Q`) so that the step
+`Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ` can be reduced modulo `Uₙ₊₁` to `−Q·Uₙ` and split by
+`IsCoprime.mul_right`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace LucasSequenceDegree2IdentitiesOQ02OQ01
+
+open LucasSequenceDegree2Identities
+
+/-- **`Uₙ₊₁` is coprime to `Q`** when `gcd(P,Q) = 1`.  Modulo `Q` the recurrence reads
+`Uₙ₊₂ ≡ P·Uₙ₊₁`, so `Uₙ₊₁ ≡ Pⁿ`; the induction step drops the `Q·Uₙ` term and splits the
+product `P·Uₙ₊₁` via `IsCoprime.mul_left`. -/
+theorem U_succ_coprime_Q (P Q : ℤ) (hPQ : IsCoprime P Q) :
+    ∀ n : ℕ, IsCoprime (U P Q (n + 1)) Q := by
+  intro n
+  induction n with
+  | zero =>
+      -- U₁ = 1
+      simpa [U_one] using (isCoprime_one_left : IsCoprime (1 : ℤ) Q)
+  | succ k ih =>
+      -- U_{k+2} = P·U_{k+1} − Q·U_k = (P·U_{k+1}) + Q·(−U_k)
+      have hrec : U P Q (k + 1 + 1) = P * U P Q (k + 1) - Q * U P Q k := U_add_two P Q k
+      have hbase : IsCoprime (P * U P Q (k + 1)) Q := hPQ.mul_left ih
+      have hshift : IsCoprime (P * U P Q (k + 1) + Q * (-U P Q k)) Q :=
+        hbase.add_mul_left_left (-U P Q k)
+      have he : P * U P Q (k + 1) + Q * (-U P Q k) = U P Q (k + 1 + 1) := by
+        rw [hrec]; ring
+      rwa [he] at hshift
+
+/-- **Consecutive fundamental terms are coprime:** `IsCoprime Uₙ Uₙ₊₁` when
+`gcd(P,Q) = 1`.  Induction on `n`; the step rewrites `Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ`, reduces it
+modulo `Uₙ₊₁` to `−Q·Uₙ`, and splits `Q·Uₙ` using `U_succ_coprime_Q` and the symmetric
+inductive hypothesis. -/
+theorem U_coprime_succ (P Q : ℤ) (hPQ : IsCoprime P Q) :
+    ∀ n : ℕ, IsCoprime (U P Q n) (U P Q (n + 1)) := by
+  intro n
+  induction n with
+  | zero =>
+      -- U₀ = 0, U₁ = 1 : IsCoprime 0 1
+      simpa [U_zero, U_one] using (isCoprime_one_right : IsCoprime (0 : ℤ) 1)
+  | succ k ih =>
+      have hrec : U P Q (k + 1 + 1) = P * U P Q (k + 1) - Q * U P Q k := U_add_two P Q k
+      -- IsCoprime U_{k+1} (Q · U_k):  U_{k+1} ⟂ Q  and  U_{k+1} ⟂ U_k
+      have hQ : IsCoprime (U P Q (k + 1)) Q := U_succ_coprime_Q P Q hPQ k
+      have hUk : IsCoprime (U P Q (k + 1)) (U P Q k) := ih.symm
+      have hmul : IsCoprime (U P Q (k + 1)) (Q * U P Q k) := hQ.mul_right hUk
+      -- push through the sign, then add the multiple `U_{k+1} · P`
+      have hneg : IsCoprime (U P Q (k + 1)) (-(Q * U P Q k)) := hmul.neg_right
+      have hadd : IsCoprime (U P Q (k + 1)) (-(Q * U P Q k) + U P Q (k + 1) * P) :=
+        hneg.add_mul_left_right P
+      have he : -(Q * U P Q k) + U P Q (k + 1) * P = U P Q (k + 1 + 1) := by
+        rw [hrec]; ring
+      rwa [he] at hadd
+
+/-- **The sharp divisibility bound.** For coprime parameters `gcd(P,Q) = 1`,
+`gcd(Uₙ, Vₙ) ∣ 2`.  This improves the sibling entry's unconditional `gcd(Uₙ, Vₙ) ∣ 4·Qⁿ`
+and is sharp (`gcd(F₃, L₃) = 2`). -/
+theorem gcd_dvd_two_of_coprime (P Q : ℤ) (hPQ : IsCoprime P Q) (n : ℕ) :
+    (Int.gcd (U P Q n) (V P Q n) : ℤ) ∣ 2 := by
+  set g : ℤ := (Int.gcd (U P Q n) (V P Q n) : ℤ) with hg
+  have hUdvd : g ∣ U P Q n := by rw [hg]; exact Int.gcd_dvd_left _ _
+  have hVdvd : g ∣ V P Q n := by rw [hg]; exact Int.gcd_dvd_right _ _
+  -- g divides V_n + P·U_n = 2·U_{n+1}
+  have h2U : g ∣ 2 * U P Q (n + 1) := by
+    have hsum : g ∣ V P Q n + P * U P Q n := dvd_add hVdvd (hUdvd.mul_left P)
+    have he : V P Q n + P * U P Q n = 2 * U P Q (n + 1) := by rw [V_eq]; ring
+    rwa [he] at hsum
+  -- g is coprime to U_{n+1} since g ∣ U_n and U_n ⟂ U_{n+1}
+  have hcop : IsCoprime g (U P Q (n + 1)) :=
+    (U_coprime_succ P Q hPQ n).of_isCoprime_of_dvd_left hUdvd
+  -- cancel the U_{n+1} factor
+  exact hcop.dvd_of_dvd_mul_right h2U
+
+/-- **Fibonacci/Lucas instance** `(P,Q) = (1,−1)`: `gcd(Fₙ, Lₙ) ∣ 2`.  Sharp, since
+`gcd(F₃, L₃) = gcd(2, 4) = 2`. -/
+theorem fib_lucas_gcd_dvd_two (n : ℕ) :
+    (Int.gcd (U 1 (-1) n) (V 1 (-1) n) : ℤ) ∣ 2 :=
+  gcd_dvd_two_of_coprime 1 (-1) (by norm_num) n
+
+/-- **Pell instance** `(P,Q) = (2,−1)`: `gcd(Pₙ, Qₙ) ∣ 2`. -/
+theorem pell_gcd_dvd_two (n : ℕ) :
+    (Int.gcd (U 2 (-1) n) (V 2 (-1) n) : ℤ) ∣ 2 :=
+  gcd_dvd_two_of_coprime 2 (-1) (by norm_num) n
+
+/-! ## Numerical sanity checks -/
+
+/-- `gcd(F₃, L₃) = gcd(2, 4) = 2` : the bound is attained (equals 2). -/
+theorem fib_lucas_gcd_three : Int.gcd (U 1 (-1) 3) (V 1 (-1) 3) = 2 := by decide
+
+/-- `gcd(F₄, L₄) = gcd(3, 7) = 1` : the bound can also be strict. -/
+theorem fib_lucas_gcd_four : Int.gcd (U 1 (-1) 4) (V 1 (-1) 4) = 1 := by decide
+
+/-- `gcd(P₂, Q₂) = gcd(2, 6) = 2` for the Pell parameters `(2,−1)`. -/
+theorem pell_gcd_two : Int.gcd (U 2 (-1) 2) (V 2 (-1) 2) = 2 := by decide
+
+end LucasSequenceDegree2IdentitiesOQ02OQ01

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-coprime-Q",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01",
+    "range": { "startLine": 53, "endLine": 71 },
+    "type": "technique",
+    "title": "Auxiliary Coprimality Uₙ₊₁ ⟂ Q",
+    "content": "`U_succ_coprime_Q` proves IsCoprime Uₙ₊₁ Q by induction on n. The base case is U₁ = 1, coprime to everything (`isCoprime_one_left`). The step rewrites Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ = (P·Uₙ₊₁) + Q·(−Uₙ): the term Q·(−Uₙ) is a multiple of Q, so `IsCoprime.add_mul_left_left` drops it, and `IsCoprime.mul_left` splits the remaining P·Uₙ₊₁ into the hypothesis gcd(P,Q)=1 and the inductive Uₙ₊₁ ⟂ Q. Modulo Q the recurrence is Uₙ₊₂ ≡ P·Uₙ₊₁, i.e. Uₙ₊₁ ≡ Pⁿ, which is why coprimality of P and Q propagates.",
+    "mathContext": "$U_{n+1} \\equiv P^n \\pmod Q$, so $\\gcd(U_{n+1}, Q) = \\gcd(P^n, Q) = 1$ when $\\gcd(P,Q)=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["coprimality", "Lucas sequence recurrence", "IsCoprime.mul_left"],
+    "prerequisites": ["IsCoprime API", "induction over ℕ"]
+  },
+  {
+    "id": "ann-coprime-succ",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01",
+    "range": { "startLine": 73, "endLine": 96 },
+    "type": "concept",
+    "title": "Consecutive Fundamental Terms are Coprime",
+    "content": "`U_coprime_succ` proves IsCoprime Uₙ Uₙ₊₁ by induction. Base: IsCoprime 0 1 (U₀=0, U₁=1). Step: rewrite Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ = −(Q·Uₙ) + Uₙ₊₁·P. The multiple Uₙ₊₁·P is removed by `IsCoprime.add_mul_left_right`, leaving IsCoprime Uₙ₊₁ (Q·Uₙ); this splits by `IsCoprime.mul_right` into Uₙ₊₁ ⟂ Q (from `U_succ_coprime_Q`) and Uₙ₊₁ ⟂ Uₙ (the symmetric inductive hypothesis). This is the general-parameter analogue of consecutive Fibonacci numbers being coprime.",
+    "mathContext": "$\\gcd(U_n, U_{n+1}) = 1$ for $\\gcd(P,Q)=1$; e.g. consecutive Fibonacci numbers are always coprime.",
+    "significance": "key",
+    "relatedConcepts": ["consecutive coprimality", "Lucas sequence", "strong divisibility"],
+    "prerequisites": ["IsCoprime.mul_right", "U_succ_coprime_Q"]
+  },
+  {
+    "id": "ann-main-bound",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01",
+    "range": { "startLine": 98, "endLine": 116 },
+    "type": "insight",
+    "title": "The Sharp Bound gcd(Uₙ, Vₙ) ∣ 2",
+    "content": "`gcd_dvd_two_of_coprime` sets g = gcd(Uₙ, Vₙ). From g ∣ Uₙ and g ∣ Vₙ we get g ∣ Vₙ + P·Uₙ, and the companion relation `V_eq` (Vₙ = 2·Uₙ₊₁ − P·Uₙ) makes that sum exactly 2·Uₙ₊₁, so g ∣ 2·Uₙ₊₁. Because g ∣ Uₙ and Uₙ ⟂ Uₙ₊₁ (`U_coprime_succ`), coprimality transports along the divisor (`IsCoprime.of_isCoprime_of_dvd_left`) to give IsCoprime g Uₙ₊₁. Then `IsCoprime.dvd_of_dvd_mul_right` cancels the Uₙ₊₁ factor, leaving g ∣ 2. The constant 2 (not 4) is forced precisely because g is coprime to Uₙ₊₁, so it cannot absorb any of that factor.",
+    "mathContext": "$\\gcd(U_n, V_n) \\mid 2$ when $\\gcd(P,Q)=1$, improving the unconditional $\\gcd(U_n,V_n) \\mid 4Q^n$; sharp since $\\gcd(F_3,L_3)=2$.",
+    "significance": "key",
+    "relatedConcepts": ["gcd divisibility", "companion relation", "coprime cancellation"],
+    "prerequisites": ["V_eq", "U_coprime_succ", "IsCoprime.dvd_of_dvd_mul_right"]
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01",
+    "range": { "startLine": 117, "endLine": 126 },
+    "type": "concept",
+    "title": "Fibonacci/Lucas and Pell Instances",
+    "content": "`fib_lucas_gcd_dvd_two` specializes the bound to (P,Q)=(1,−1), recovering the classical gcd(Fₙ, Lₙ) ∣ 2, and `pell_gcd_dvd_two` to (2,−1) for the Pell pair gcd(Pₙ, Qₙ) ∣ 2. In both the coprimality hypothesis gcd(P,Q)=1 is discharged automatically by `norm_num` on IsCoprime 1 (-1) / IsCoprime 2 (-1).",
+    "mathContext": "Classical corollary $\\gcd(F_n, L_n) \\in \\{1,2\\}$ and the Pell analogue.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fibonacci", "Lucas numbers", "Pell numbers", "specialization"],
+    "prerequisites": ["gcd_dvd_two_of_coprime"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01",
+    "range": { "startLine": 128, "endLine": 139 },
+    "type": "concept",
+    "title": "Numerical Sanity Checks",
+    "content": "Three decidable checks confirm the bound is meaningful: gcd(F₃, L₃) = gcd(2, 4) = 2 (the bound is attained), gcd(F₄, L₄) = gcd(3, 7) = 1 (the gcd can also be 1), and gcd(P₂, Q₂) = gcd(2, 6) = 2 for the Pell parameters. All are closed by kernel `decide`, so no `native_decide` and no `Lean.ofReduceBool` dependency is introduced.",
+    "mathContext": "The gcd oscillates between 1 and 2, so 2 is a genuine (attained, non-vacuous) ceiling.",
+    "significance": "supporting",
+    "relatedConcepts": ["decidability", "kernel decide", "sharpness"],
+    "prerequisites": ["decide tactic"]
+  }
+]

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01/meta.json
@@ -1,0 +1,88 @@
+{
+  "id": "lucas-sequence-degree2-identities-oq-02-oq-01",
+  "title": "The Sharp Divisibility Bound gcd(Uₙ, Vₙ) ∣ 2 for Coprime Parameters",
+  "slug": "lucas-sequence-degree2-identities-oq-02-oq-01",
+  "description": "Sharpening of the Lucas-sequence divisibility core: for the fundamental/companion pair Uₙ, Vₙ of parameters (P,Q), the sibling entry proves gcd(Uₙ,Vₙ) ∣ 4·Qⁿ unconditionally. This entry proves the sharp bound gcd(Uₙ,Vₙ) ∣ 2 whenever gcd(P,Q)=1, via the companion relation Vₙ = 2·Uₙ₊₁ − P·Uₙ and the coprimality of consecutive fundamental terms Uₙ, Uₙ₊₁. The constant 2 is best possible (gcd(F₃,L₃)=2). Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lucas (1878) (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_sequence",
+    "date": "1878",
+    "status": "verified",
+    "tags": ["number-theory", "lucas-sequences", "divisibility", "coprimality", "gcd", "induction", "research"],
+    "proofRepoPath": "Proofs/LucasSequenceDegree2IdentitiesOQ02OQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {"theorem": "IsCoprime.dvd_of_dvd_mul_right", "description": "From IsCoprime k n and k ∣ m·n conclude k ∣ m — cancels the Uₙ₊₁ factor to reach g ∣ 2", "module": "Mathlib.RingTheory.Coprime.Basic"},
+      {"theorem": "IsCoprime.of_isCoprime_of_dvd_left", "description": "Transports coprimality along a left divisor: g ∣ Uₙ and IsCoprime Uₙ Uₙ₊₁ give IsCoprime g Uₙ₊₁", "module": "Mathlib.RingTheory.Coprime.Basic"},
+      {"theorem": "IsCoprime.mul_left / IsCoprime.mul_right", "description": "Split coprimality across products (P·Uₙ₊₁ ⟂ Q, and Uₙ₊₁ ⟂ Q·Uₙ) in the two coprimality inductions", "module": "Mathlib.RingTheory.Coprime.Basic"},
+      {"theorem": "IsCoprime.add_mul_left_left / IsCoprime.add_mul_left_right", "description": "Coprimality is invariant under adding a multiple of one argument — reduces the recurrence Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ modulo Uₙ₊₁ (resp. Q)", "module": "Mathlib.RingTheory.Coprime.Basic"},
+      {"theorem": "Int.gcd_dvd_left / Int.gcd_dvd_right", "description": "The integer gcd divides each argument — gives g ∣ Uₙ and g ∣ Vₙ", "module": "Mathlib.Algebra.Order.Ring.Int"}
+    ],
+    "originalContributions": [
+      "gcd_dvd_two_of_coprime: the sharp bound gcd(Uₙ, Vₙ) ∣ 2 for gcd(P,Q)=1, improving the sibling entry's unconditional gcd(Uₙ, Vₙ) ∣ 4·Qⁿ",
+      "U_coprime_succ: consecutive fundamental Lucas-sequence terms Uₙ, Uₙ₊₁ are coprime when gcd(P,Q)=1, by induction",
+      "U_succ_coprime_Q: the auxiliary fact IsCoprime Uₙ₊₁ Q (Uₙ₊₁ ≡ Pⁿ mod Q), the engine of the consecutive-coprimality step",
+      "fib_lucas_gcd_dvd_two / pell_gcd_dvd_two: Fibonacci/Lucas (P,Q)=(1,−1) and Pell (2,−1) instances gcd(Fₙ,Lₙ) ∣ 2 and gcd(Pₙ,Qₙ) ∣ 2",
+      "Numerical checks showing both endpoints occur: gcd(F₃,L₃)=2 (sharpness) and gcd(F₄,L₄)=1 (strictness)"
+    ],
+    "dateAdded": "2026-07-02",
+    "lineCount": 139,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms); no sorryAx and no Lean.ofReduceBool — the three numerical examples use kernel `decide`, not `native_decide`. Builds on the base entry LucasSequenceDegree2Identities (definitions of U, V and the relations V_eq, U_add_two).",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "For fixed integer parameters (P, Q) the Lucas sequences Uₙ(P,Q) (fundamental, U₀=0, U₁=1) and Vₙ(P,Q) (companion, V₀=2, V₁=P) satisfy the common recurrence Xₙ₊₂ = P·Xₙ₊₁ − Q·Xₙ and the master identity Vₙ² − D·Uₙ² = 4·Qⁿ with D = P²−4Q. The Fibonacci/Lucas pair is (P,Q)=(1,−1) and the Pell pair is (2,−1). A classical fact is that gcd(Fₙ, Lₙ) is always 1 or 2; the general statement is that gcd(Uₙ, Vₙ) divides 2 as soon as the parameters are coprime.",
+    "problemStatement": "**Open question (lucas-sequence-degree2-identities-oq-02)**: The sibling entry proves the unconditional divisibility core gcd(Uₙ, Vₙ) ∣ 4·Qⁿ. Sharpen it to gcd(Uₙ, Vₙ) ∣ 2 under the coprimality hypothesis gcd(P,Q)=1, using that consecutive fundamental terms Uₙ, Uₙ₊₁ are coprime together with Vₙ = 2·Uₙ₊₁ − P·Uₙ.\n\n**Result**: A fully verified (0 sorries, 0 axioms) proof of gcd(Uₙ, Vₙ) ∣ 2 for gcd(P,Q)=1, with the required consecutive-coprimality lemma and Fibonacci/Lucas and Pell instances. The bound is sharp: gcd(F₃, L₃) = 2.",
+    "text": "The sharp bound gcd(Uₙ, Vₙ) ∣ 2 for coprime Lucas-sequence parameters, proved by combining the companion relation Vₙ = 2·Uₙ₊₁ − P·Uₙ with the coprimality of consecutive fundamental terms Uₙ, Uₙ₊₁.",
+    "proofStrategy": "**Proof Strategy:**\n\n1. **Auxiliary coprimality Uₙ₊₁ ⟂ Q** (`U_succ_coprime_Q`): induction on n. Base U₁=1 is coprime to everything; the step reduces Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ modulo Q (drop the Q·Uₙ term via `IsCoprime.add_mul_left_left`) and splits P·Uₙ₊₁ by `IsCoprime.mul_left` using gcd(P,Q)=1.\n\n2. **Consecutive coprimality Uₙ ⟂ Uₙ₊₁** (`U_coprime_succ`): induction on n. Base IsCoprime 0 1; the step reduces Uₙ₊₂ modulo Uₙ₊₁ to −Q·Uₙ, then splits Q·Uₙ by `IsCoprime.mul_right` using step 1 (Uₙ₊₁ ⟂ Q) and the symmetric inductive hypothesis (Uₙ₊₁ ⟂ Uₙ).\n\n3. **The bound** (`gcd_dvd_two_of_coprime`): set g = gcd(Uₙ, Vₙ). Then g ∣ Uₙ, g ∣ Vₙ, so g ∣ Vₙ + P·Uₙ = 2·Uₙ₊₁ (via `V_eq`). Since g ∣ Uₙ and Uₙ ⟂ Uₙ₊₁, we have IsCoprime g Uₙ₊₁ (`IsCoprime.of_isCoprime_of_dvd_left`). Cancelling the Uₙ₊₁ factor from g ∣ 2·Uₙ₊₁ (`IsCoprime.dvd_of_dvd_mul_right`) gives g ∣ 2.",
+    "keyInsights": [
+      "**The companion relation is the whole engine**: Vₙ = 2·Uₙ₊₁ − P·Uₙ turns a common divisor of Uₙ and Vₙ into a divisor of 2·Uₙ₊₁, moving the problem from the (Uₙ, Vₙ) pair to the (Uₙ, Uₙ₊₁) pair where coprimality is available.",
+      "**Coprimality cancels the odd part**: because Uₙ and Uₙ₊₁ are coprime under gcd(P,Q)=1, the gcd g inherits coprimality with Uₙ₊₁, so the only surviving factor of 2·Uₙ₊₁ that g can divide is the 2. This is exactly why the sharp constant is 2 and not 4.",
+      "**Sharp and strict both occur**: gcd(F₃, L₃) = gcd(2, 4) = 2 shows the 2 is attained, while gcd(F₄, L₄) = gcd(3, 7) = 1 shows the gcd can also be 1 — so the value oscillates and 2 is a genuine (not vacuous) ceiling.",
+      "**Coprimality bookkeeping replaces number-theoretic case analysis**: the whole argument is carried by Mathlib's IsCoprime algebra (mul_left/mul_right, add_mul_left, dvd_of_dvd_mul_right), avoiding any explicit modular or parity case split."
+    ],
+    "prerequisites": [
+      "Lucas sequences Uₙ, Vₙ and their common recurrence",
+      "The companion-from-fundamental relation Vₙ = 2·Uₙ₊₁ − P·Uₙ",
+      "The IsCoprime API over a commutative ring (products, adding multiples, cancellation)"
+    ]
+  },
+  "sections": [
+    {"id": "coprime-Q", "title": "Auxiliary Coprimality Uₙ₊₁ ⟂ Q", "startLine": 1, "endLine": 71, "summary": "Module docstring and imports (Mathlib.Tactic, the base entry Proofs.LucasSequenceDegree2Identities). U_succ_coprime_Q proves IsCoprime Uₙ₊₁ Q by induction: the base U₁=1 is coprime to Q, and the step reduces Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ modulo Q and splits P·Uₙ₊₁ using gcd(P,Q)=1.", "mathContext": "$U_{n+1} \\equiv P^n \\pmod Q$, so $\\gcd(U_{n+1}, Q) = \\gcd(P^n, Q) = 1$ when $\\gcd(P,Q)=1$."},
+    {"id": "coprime-succ", "title": "Consecutive Fundamental Terms are Coprime", "startLine": 73, "endLine": 96, "summary": "U_coprime_succ proves IsCoprime Uₙ Uₙ₊₁ by induction. Base IsCoprime 0 1; the step reduces Uₙ₊₂ modulo Uₙ₊₁ to −Q·Uₙ and splits Q·Uₙ via U_succ_coprime_Q (Uₙ₊₁ ⟂ Q) and the symmetric inductive hypothesis (Uₙ₊₁ ⟂ Uₙ).", "mathContext": "$\\gcd(U_n, U_{n+1}) = 1$ for $\\gcd(P,Q)=1$ — the general analogue of consecutive Fibonacci numbers being coprime."},
+    {"id": "main-bound", "title": "The Sharp Bound gcd(Uₙ, Vₙ) ∣ 2", "startLine": 98, "endLine": 116, "summary": "gcd_dvd_two_of_coprime: with g = gcd(Uₙ, Vₙ), g ∣ Vₙ + P·Uₙ = 2·Uₙ₊₁ (via V_eq); since g ∣ Uₙ and Uₙ ⟂ Uₙ₊₁, IsCoprime g Uₙ₊₁; cancelling Uₙ₊₁ from g ∣ 2·Uₙ₊₁ yields g ∣ 2.", "mathContext": "$\\gcd(U_n, V_n) \\mid 2$ when $\\gcd(P,Q)=1$; the companion relation $V_n = 2U_{n+1} - P U_n$ moves the divisor onto $2U_{n+1}$."},
+    {"id": "instances", "title": "Fibonacci/Lucas and Pell Instances", "startLine": 117, "endLine": 126, "summary": "fib_lucas_gcd_dvd_two specializes to (P,Q)=(1,−1): gcd(Fₙ, Lₙ) ∣ 2; pell_gcd_dvd_two to (2,−1): gcd(Pₙ, Qₙ) ∣ 2. The coprimality hypothesis is discharged by norm_num.", "mathContext": "Classical corollary $\\gcd(F_n, L_n) \\in \\{1, 2\\}$ and its Pell analogue."},
+    {"id": "examples", "title": "Numerical Sanity Checks", "startLine": 128, "endLine": 139, "summary": "Three decidable checks: gcd(F₃, L₃) = 2 (the bound is attained), gcd(F₄, L₄) = 1 (the bound can be strict), gcd(P₂, Q₂) = 2. All by kernel `decide` (no native_decide, so no Lean.ofReduceBool).", "mathContext": "Concrete gcd values confirming both that 2 is attained and that the gcd is not always 2."}
+  ],
+  "crossReferences": [
+    {"targetId": "lucas-sequence-degree2-identities-oq-02", "relationship": "extends", "description": "Sharpens the sibling entry's unconditional divisibility core gcd(Uₙ, Vₙ) ∣ 4·Qⁿ to the coprime-parameter bound gcd(Uₙ, Vₙ) ∣ 2, exactly the open question stated there; reuses its companion relation V_eq and recurrence U_add_two."},
+    {"targetId": "lucas-sequence-degree2-identities", "relationship": "depends-on", "description": "Imports the base entry's definitions of the fundamental and companion Lucas sequences U, V and the relations V_eq (Vₙ = 2Uₙ₊₁ − P Uₙ) and U_add_two used throughout."}
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) proof of the sharp divisibility bound gcd(Uₙ, Vₙ) ∣ 2 for Lucas sequences with coprime parameters gcd(P,Q)=1, together with the enabling coprimality of consecutive fundamental terms Uₙ, Uₙ₊₁, Fibonacci/Lucas and Pell instances, and numerical checks showing both gcd=2 (sharpness) and gcd=1 occur.",
+    "implications": "**Theoretical Significance**: This is the best-possible strengthening of the sibling entry's gcd(Uₙ, Vₙ) ∣ 4·Qⁿ: the coprimality hypothesis removes the Qⁿ factor and halves the constant from 4 to 2. Methodologically the proof shows how a single algebraic relation (the companion relation Vₙ = 2Uₙ₊₁ − P Uₙ) plus Mathlib's IsCoprime cancellation API replaces the usual modular/parity case analysis, keeping the whole argument to a handful of coprimality manipulations.",
+    "openQuestions": [
+      "Determine exactly when gcd(Uₙ, Vₙ) = 2 versus = 1 (for Fibonacci this is governed by n mod 3); formalize the periodic characterization.",
+      "Prove the multiplication-by-index divisibility Uₘ ∣ Uₘₙ and the strong divisibility gcd(Uₘ, Uₙ) = U_{gcd(m,n)} for the general Lucas sequence, extending the consecutive-coprimality result proved here."
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib.Tactic", "Proofs.LucasSequenceDegree2Identities"],
+    "opens": ["LucasSequenceDegree2Identities"],
+    "namespace": "LucasSequenceDegree2IdentitiesOQ02OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/LucasSequenceDegree2IdentitiesOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {"authors": "Édouard Lucas", "title": "Théorie des fonctions numériques simplement périodiques", "year": "1878", "venue": "American Journal of Mathematics", "note": "Introduction of the general Lucas sequences Uₙ, Vₙ and their divisibility theory"},
+    {"authors": "Paulo Ribenboim", "title": "The New Book of Prime Number Records", "year": "1996", "venue": "Springer", "note": "Divisibility properties of Lucas sequences, including gcd relations for Uₙ, Vₙ"}
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **lucas-sequence-degree2-identities-oq-02** openQuestions[0] verbatim: sharpen the sibling entry's *unconditional* divisibility core `gcd(Uₙ, Vₙ) ∣ 4·Qⁿ` to the **best-possible** bound

> **`gcd(Uₙ, Vₙ) ∣ 2` whenever `gcd(P, Q) = 1`.**

for the fundamental/companion Lucas sequences `Uₙ, Vₙ` of parameters `(P,Q)`. The constant 2 is sharp: `gcd(F₃, L₃) = gcd(2,4) = 2`.

## Proof

With `g = gcd(Uₙ, Vₙ)`:
- `g ∣ Uₙ`, `g ∣ Vₙ` ⟹ `g ∣ Vₙ + P·Uₙ = 2·Uₙ₊₁` (companion relation `V_eq`).
- Consecutive fundamental terms are coprime — `U_coprime_succ : IsCoprime Uₙ Uₙ₊₁` (induction, needing the auxiliary `U_succ_coprime_Q : IsCoprime Uₙ₊₁ Q`).
- Hence `IsCoprime g Uₙ₊₁` (since `g ∣ Uₙ`), and cancelling the `Uₙ₊₁` factor from `g ∣ 2·Uₙ₊₁` gives `g ∣ 2`.

The whole argument runs on Mathlib's `IsCoprime` algebra (`mul_left`/`mul_right`, `add_mul_left_*`, `dvd_of_dvd_mul_right`), no modular case analysis.

## Contents
- `gcd_dvd_two_of_coprime` — the sharp bound.
- `U_coprime_succ`, `U_succ_coprime_Q` — the enabling coprimality lemmas.
- `fib_lucas_gcd_dvd_two`, `pell_gcd_dvd_two` — Fibonacci/Lucas and Pell instances.
- Numerical checks: `gcd(F₃,L₃)=2` (attained), `gcd(F₄,L₄)=1` (strict), `gcd(P₂,Q₂)=2`.

## Verification
- **0 axioms, 0 sorries** — `#print axioms` shows only `propext, Classical.choice, Quot.sound`; no `sorryAx`, no `Lean.ofReduceBool` (examples use kernel `decide`, not `native_decide`).
- 8 theorems, 139 lines. Builds on base entry `LucasSequenceDegree2Identities`.
- Gallery data: `meta.json` + `annotations.json` (5/5 annotations validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)