### PR TITLE
Enrich Cassini/Catalan Identities for Pell Chains (pell-equation-oq-07-oq-01-oq-01): add annotations (0→7)

### DIFF
--- a/src/data/proofs/pell-equation-oq-07-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "concept",
+    "title": "Multiplicative Content of the Companion Form",
+    "content": "The parent supplied the companion-matrix power `Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)]` for a quadratic integer `a ∈ ℤ√d`, with `det M = N(a)`. This entry exploits multiplicativity of the determinant: `det(Mⁿ) = (det M)ⁿ = N(a)ⁿ`. Reading `det(Mⁿ)` off the explicit power form yields the quadratic Pell invariant `re(aⁿ)² − d·im(aⁿ)² = N(a)ⁿ` (Cassini for Pell chains); combined with the one-step coordinate recurrences it produces the three-term Cassini/Catalan identities. All of it is pure integer algebra in `ℤ√d` and `2×2` integer matrices — no passage to ℝ or √d.",
+    "mathContext": "$\\det(M^n) = N(a)^n$ gives $\\mathrm{re}(a^n)^2 - d\\,\\mathrm{im}(a^n)^2 = N(a)^n$, the Cassini invariant for the Pell power chain.",
+    "significance": "context",
+    "relatedConcepts": ["Pell's equation", "Cassini identity", "Catalan identity", "quadratic integers", "companion matrix"],
+    "prerequisites": ["ℤ√d arithmetic", "determinants", "matrix powers"]
+  },
+  {
+    "id": "ann-det",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 74 },
+    "type": "technique",
+    "title": "The Determinant Identity det(Mⁿ) = N(a)ⁿ",
+    "content": "`det_companion_pow` is the engine of the whole file: `det(Mⁿ) = N(a)ⁿ`. It is one line — `Matrix.det_pow` (determinant is a monoid homomorphism, so `det(Mⁿ) = (det M)ⁿ`) composed with the parent's `companion_det` (`det M = N(a)`). This purely multiplicative fact carries all the Cassini content once `det(Mⁿ)` is read off the explicit power form.",
+    "mathContext": "$\\det(M^n) = (\\det M)^n = N(a)^n$, since $\\det$ is multiplicative.",
+    "significance": "key",
+    "relatedConcepts": ["Matrix.det_pow", "multiplicativity of determinant", "monoid homomorphism"],
+    "prerequisites": ["Matrix.det_pow", "companion_det (parent)"]
+  },
+  {
+    "id": "ann-invariant",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 84, "endLine": 98 },
+    "type": "insight",
+    "title": "The Quadratic Pell Invariant",
+    "content": "`re_sq_sub_d_im_sq` evaluates `det(Mⁿ)` a second way — off the explicit power form via `Matrix.det_fin_two_of` — to get `re(aⁿ)² − d·im(aⁿ)²`, and equates it with `N(a)ⁿ` by `linear_combination`. This is the Cassini identity for Pell chains (equivalently `Zsqrtd.norm(aⁿ) = N(a)ⁿ`, recovered through the companion determinant). The corollary `pow_isPell` specialises to `N(a) = 1`: the norm-1 locus is closed under powers, so every power of a Pell solution is again a Pell solution.",
+    "mathContext": "$\\mathrm{re}(a^n)^2 - d\\,\\mathrm{im}(a^n)^2 = N(a)^n$; for $N(a) = 1$, $= 1$ for all $n$.",
+    "significance": "key",
+    "relatedConcepts": ["Cassini identity", "Zsqrtd.norm", "Matrix.det_fin_two_of", "Pell solutions"],
+    "prerequisites": ["Matrix.det_fin_two_of", "linear_combination", "companion_pow (parent)"]
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 109, "endLine": 117 },
+    "type": "technique",
+    "title": "The One-Step Coordinate Recurrences",
+    "content": "`re_succ` and `im_succ` are the shadow of `aⁿ⁺¹ = a·aⁿ` on coordinates: `re(aⁿ⁺¹) = re(a)·re(aⁿ) + d·im(a)·im(aⁿ)` and `im(aⁿ⁺¹) = re(a)·im(aⁿ) + im(a)·re(aⁿ)`. Each is proved by `pow_succ` then the `Zsqrtd` multiplication formulas `re_mul`/`im_mul` and `ring`. These private lemmas are the second ingredient (alongside the quadratic invariant) from which all three-term Cassini identities are derived by `linear_combination`.",
+    "mathContext": "$\\mathrm{re}(a^{n+1}) = \\mathrm{re}(a)\\,\\mathrm{re}(a^n) + d\\,\\mathrm{im}(a)\\,\\mathrm{im}(a^n)$;\\ $\\mathrm{im}(a^{n+1}) = \\mathrm{re}(a)\\,\\mathrm{im}(a^n) + \\mathrm{im}(a)\\,\\mathrm{re}(a^n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Zsqrtd.re_mul", "Zsqrtd.im_mul", "second-order recurrence", "pow_succ"],
+    "prerequisites": ["Zsqrtd multiplication", "pow_succ", "ring"]
+  },
+  {
+    "id": "ann-cross-cassini",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 119, "endLine": 128 },
+    "type": "insight",
+    "title": "The Mixed Two-Coordinate Cassini Invariant",
+    "content": "`cross_cassini` proves `re(aⁿ)·im(aⁿ⁺¹) − re(aⁿ⁺¹)·im(aⁿ) = im(a)·N(a)ⁿ`. The cross-term of the two coordinate sequences collapses: substituting the one-step recurrences and using the quadratic invariant, it reduces to `im(a)·(re(aⁿ)² − d·im(aⁿ)²) = im(a)·N(a)ⁿ`, closed by `linear_combination im(a)·hinv`. This is a Wronskian-style determinant of the coordinate pair, constant up to the geometric factor `N(a)ⁿ`.",
+    "mathContext": "$\\mathrm{re}(a^n)\\,\\mathrm{im}(a^{n+1}) - \\mathrm{re}(a^{n+1})\\,\\mathrm{im}(a^n) = \\mathrm{im}(a)\\,N(a)^n$.",
+    "significance": "key",
+    "relatedConcepts": ["Cassini identity", "Wronskian", "linear_combination", "coordinate sequences"],
+    "prerequisites": ["re_succ / im_succ", "quadratic invariant", "linear_combination"]
+  },
+  {
+    "id": "ann-three-term",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 130, "endLine": 146 },
+    "type": "technique",
+    "title": "The Three-Term Cassini / Catalan Identities",
+    "content": "`cassini_re` and `cassini_im` give the genuine three-term (Catalan-type) invariants for each coordinate sequence: `re(aⁿ)·re(aⁿ⁺²) − re(aⁿ⁺¹)² = d·im(a)²·N(a)ⁿ` and `im(aⁿ)·im(aⁿ⁺²) − im(aⁿ⁺¹)² = −im(a)²·N(a)ⁿ`. Each is proved by expanding `aⁿ⁺²` fully to level `n` (via `re_succ`/`im_succ` at `n+1` and `n`) and closing with `linear_combination` of the quadratic invariant scaled by the constant. These are `uₙ₋₁uₙ₊₁ − uₙ² = c·N(a)ⁿ⁻¹` (re-indexed), the constant `c` fixed by the seed `im(a)`.",
+    "mathContext": "$\\mathrm{re}(a^n)\\,\\mathrm{re}(a^{n+2}) - \\mathrm{re}(a^{n+1})^2 = d\\,\\mathrm{im}(a)^2 N(a)^n$;\\ $\\mathrm{im}(a^n)\\,\\mathrm{im}(a^{n+2}) - \\mathrm{im}(a^{n+1})^2 = -\\mathrm{im}(a)^2 N(a)^n$.",
+    "significance": "key",
+    "relatedConcepts": ["Catalan identity", "three-term recurrence invariant", "Cassini for Fibonacci-like sequences"],
+    "prerequisites": ["re_succ / im_succ", "quadratic invariant", "linear_combination"]
+  },
+  {
+    "id": "ann-checks",
+    "proofId": "pell-equation-oq-07-oq-01-oq-01",
+    "range": { "startLine": 157, "endLine": 174 },
+    "type": "context",
+    "title": "Concrete D = 2 Checks against (3+2√2)ⁿ",
+    "content": "The fundamental norm-1 unit of `ℤ[√2]` is `3 + 2√2 = ⟨3,2⟩`, with `re: 1,3,17,99,…`, `im: 0,2,12,70,…`, `N = 1`. Four `decide` checks confirm the identities on concrete powers: the quadratic invariant at `n=3` (`99² − 2·70² = 1`), the real three-term Cassini at `n=0` (`1·17 − 3² = 8 = 2·2²`), the √d three-term at `n=1` (`2·70 − 12² = −4`), and the mixed Cassini at `n=2` (`17·70 − 99·12 = 2 = im(a)·N³`).",
+    "mathContext": "$(3+2\\sqrt2)^n$: $99^2 - 2\\cdot 70^2 = 1$;\\ $1\\cdot17 - 3^2 = 8$;\\ $2\\cdot70 - 12^2 = -4$;\\ $17\\cdot70 - 99\\cdot12 = 2$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "decide tactic", "fundamental unit of ℤ[√2]"],
+    "prerequisites": ["decide", "evaluation of ℤ√d powers"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-07-oq-01-oq-01` (quality 43, passes 0). Recently-merged researcher entry with rich `meta.json` but **no `annotations.json`**.

## Changes
7 annotations covering the full 183-line Lean file, each with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`:
1. **Multiplicative Content of the Companion Form** — header, the `det(Mⁿ)=(det M)ⁿ` idea.
2. **The Determinant Identity** — `det_companion_pow`, `Matrix.det_pow` + `companion_det`.
3. **The Quadratic Pell Invariant** — `re(aⁿ)²−d·im(aⁿ)²=N(a)ⁿ` and `pow_isPell`.
4. **The One-Step Coordinate Recurrences** — `re_succ`/`im_succ` from `aⁿ⁺¹=a·aⁿ`.
5. **The Mixed Cross-Cassini** — `cross_cassini = im(a)·N(a)ⁿ`.
6. **The Three-Term Cassini/Catalan Identities** — `cassini_re`/`cassini_im`.
7. **Concrete D=2 Checks** — the four `decide` instances against `(3+2√2)ⁿ`.

## Validation
- Resolver: **7 valid, 0 misaligned**.
- `meta.json` unchanged; only `annotations.json` added. `status`/`badge`/`axiomCount` untouched.