### PR TITLE
Enrich Centered Hexagonal Numbers Sum to Cubes (centered-hexagonal-sum-oq-01): add overview annotation (4→5)

### DIFF
--- a/src/data/proofs/centered-hexagonal-sum-oq-01/annotations.json
+++ b/src/data/proofs/centered-hexagonal-sum-oq-01/annotations.json
@@ -1,48 +1,108 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "centered-hexagonal-sum-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 40
+    },
+    "type": "concept",
+    "title": "Centered hexagonal numbers sum to cubes",
+    "content": "The k-th centered hexagonal number Hₖ = 3k(k−1)+1 counts the dots in k nested hexagonal rings: 1, 7, 19, 37, 61, … The classical figurate identity proved here is that the first n of them always sum to the perfect cube n³ (e.g. 1+7+19 = 27 = 3³). The file gives two equivalent machine-checked forms — the reindexed ∑_{k<n} H_{k+1} = n³ (whose inductive step is a single ring call) and the classical 1-indexed ∑_{k=1}^{n} Hₖ = n³ over the interval [1,n]. The conceptual heart is the cube-shell identity Hₖ = k³ − (k−1)³: each hexagonal number is the gap between consecutive cubes, so the partial sums telescope. Novelty: Mathlib has Gauss's triangular identity and Nicomachus's ∑k³ = (∑k)², but no named centered-hexagonal partial-sum lemma; this supplies it, with the headline result living entirely in ℕ.",
+    "mathContext": "$\\sum_{k=1}^{n}\\big(3k(k-1)+1\\big) = n^3$, telescoping via $H_k = k^3 - (k-1)^3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "figurate numbers",
+      "centered hexagonal numbers",
+      "telescoping sums",
+      "Nicomachus's identity",
+      "OEIS A003215"
+    ],
+    "prerequisites": [
+      "finite sums",
+      "mathematical induction",
+      "perfect cubes"
+    ]
+  },
+  {
     "id": "ann-definition",
     "proofId": "centered-hexagonal-sum-oq-01",
-    "range": { "startLine": 48, "endLine": 54 },
+    "range": {
+      "startLine": 48,
+      "endLine": 54
+    },
     "type": "definition",
     "title": "Centered Hexagonal Number Hₖ = 3k(k−1)+1",
     "content": "The $k$-th centered hexagonal number counts dots in $k$ nested hexagonal rings: $1, 7, 19, 37, 61, \\dots$ (OEIS A003215). The companion lemma `centeredHex_succ` rewrites $H_{k+1} = 3(k+1)k + 1$: shifting the index by one turns the truncated $\\mathbb{N}$ subtraction $(k+1)-1$ into the honest $k$, so the summand becomes a plain polynomial that `ring` can manipulate. This reindexing is what keeps the headline result inside $\\mathbb{N}$.",
     "mathContext": "$H_k = 3k(k-1)+1$, and $H_{k+1} = 3(k+1)k + 1$.",
     "significance": "supporting",
-    "relatedConcepts": ["Figurate numbers", "Truncated natural subtraction", "Reindexing"]
+    "relatedConcepts": [
+      "Figurate numbers",
+      "Truncated natural subtraction",
+      "Reindexing"
+    ]
   },
   {
     "id": "ann-cube-shell",
     "proofId": "centered-hexagonal-sum-oq-01",
-    "range": { "startLine": 61, "endLine": 68 },
-    "type": "lemma",
+    "range": {
+      "startLine": 61,
+      "endLine": 68
+    },
+    "type": "theorem",
     "title": "Cube-Shell Identity: Hₖ = k³ − (k−1)³",
     "content": "Each centered hexagonal number is the difference of consecutive cubes — the layer added when growing a $(k-1)^3$ cube to a $k^3$ cube. Stated over $\\mathbb{Z}$ because the subtraction is genuine: e.g. $H_0 = 0^3 - (-1)^3 = 1$. A `cases k` split closes the zero case by `norm_num` and the successor case by `simp only [..., Nat.succ_sub_one]`, `push_cast`, `ring`. This identity is the geometric reason the partial sums telescope to $n^3$: summing the $n$ hexagonal shells is summing the $n$ cubic shells $k^3 - (k-1)^3$.",
     "mathContext": "$H_k = k^3 - (k-1)^3$ over $\\mathbb{Z}$.",
     "significance": "key",
-    "relatedConcepts": ["Telescoping sums", "Cube differences", "push_cast", "Case analysis"]
+    "relatedConcepts": [
+      "Telescoping sums",
+      "Cube differences",
+      "push_cast",
+      "Case analysis"
+    ]
   },
   {
     "id": "ann-main-range",
     "proofId": "centered-hexagonal-sum-oq-01",
-    "range": { "startLine": 78, "endLine": 84 },
+    "range": {
+      "startLine": 78,
+      "endLine": 84
+    },
     "type": "theorem",
     "title": "Main Identity (reindexed range form)",
     "content": "$\\sum_{k<n} H_{k+1} = n^3$. The base case is `simp` (empty sum). In the step, `Finset.sum_range_succ` peels the top term, the inductive hypothesis rewrites the remaining sum to $m^3$, and `centeredHex_succ` expands $H_{m+1}$, leaving $m^3 + (3(m+1)m + 1) = (m+1)^3$ — a single-number identity closed by `ring`. Because the summand was reindexed, no truncated subtraction ever reaches `ring`, so the whole proof lives in $\\mathbb{N}$.",
     "mathContext": "$\\sum_{k<n} H_{k+1} = n^3$.",
     "significance": "critical",
-    "prerequisites": ["Mathematical induction", "Finset.sum_range_succ"],
-    "relatedConcepts": ["Power sums", "Figurate numbers", "Induction"]
+    "prerequisites": [
+      "Mathematical induction",
+      "Finset.sum_range_succ"
+    ],
+    "relatedConcepts": [
+      "Power sums",
+      "Figurate numbers",
+      "Induction"
+    ]
   },
   {
     "id": "ann-main-icc",
     "proofId": "centered-hexagonal-sum-oq-01",
-    "range": { "startLine": 93, "endLine": 99 },
+    "range": {
+      "startLine": 93,
+      "endLine": 99
+    },
     "type": "theorem",
     "title": "Main Identity (classical 1-indexed form)",
     "content": "$\\sum_{k \\in [1,n]} H_k = n^3$, the statement exactly as figurate identities are usually phrased. The proof mirrors the range form: base case `simp` (empty interval), step peels the top term with `Finset.sum_Icc_succ_top` (whose side condition $1 \\le m+1$ is discharged by `omega`), applies the hypothesis and `centeredHex_succ`, then closes with `ring`. The two forms agree because the $k=0$ term of $H_k$ contributes the same constant in either indexing.",
     "mathContext": "$\\sum_{k=1}^{n} H_k = n^3$.",
     "significance": "critical",
-    "prerequisites": ["Mathematical induction", "Finset.sum_Icc_succ_top"],
-    "relatedConcepts": ["Interval sums", "Figurate numbers", "Induction"]
+    "prerequisites": [
+      "Mathematical induction",
+      "Finset.sum_Icc_succ_top"
+    ],
+    "relatedConcepts": [
+      "Interval sums",
+      "Figurate numbers",
+      "Induction"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `centered-hexagonal-sum-oq-01`.

## What
The four existing annotations (already high quality, with `mathContext`/`significance`/`relatedConcepts`) cover only the declarations — the 38-line header overview (lines 3–40) had **no annotation**. This adds one `concept` annotation for it:

- **Overview (lines 3–40):** the classical figurate identity ∑(3k(k−1)+1) = n³, the two equivalent proof forms (reindexed range vs 1-indexed Icc), the cube-shell telescoping intuition Hₖ = k³ − (k−1)³, and the novelty vs Mathlib's Gauss / Nicomachus identities.

Also fixes a **pre-existing validation error**: `ann-cube-shell` was typed `"lemma"` but anchors a `theorem` at line 61 — retyped `"theorem"` to match its siblings. The existing four annotations are otherwise preserved verbatim.

## Validation
`npx tsx scripts/annotations/resolver.ts validate` → **5 valid, 0 misaligned** (was 4 valid / 1 misaligned on `main`).

Annotations only.