### PR TITLE
Enrich The Beta Integral: Recurrence and the Integer Closed Form (beta-integral-recurrence-oq-01): add overview annotation (4→5)

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01/annotations.json
@@ -1,50 +1,115 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "beta-integral-recurrence-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Beta integral: recurrence to the two-integer closed form",
+    "content": "The Euler Beta integral B(u,v) = ∫₀¹ t^(u−1)(1−t)^(v−1) dt satisfies the parameter recurrence u·B(u,v+1) = v·B(u+1,v). Combined with the Beta–Gamma relation B(u,v) = Γu·Γv/Γ(u+v), this pins down the Beta value on the integer lattice. The centerpiece is the symmetric two-integer closed form B(m+1,n+1) = m!·n!/(m+n+1)!, from which concrete values (B(1,1)=1, B(2,3)=1/12, B(3,3)=1/30) and the m↔n symmetry read off immediately. Mathlib supplies the recurrence, the Beta–Gamma division formula, and the ONE-sided evaluation B(u,n+1) = n!/∏_{j≤n}(u+j), but NOT the fully symmetric integer closed form — this file derives it by feeding both integer arguments through the Beta–Gamma relation and Gamma_nat_eq_factorial.",
+    "mathContext": "$B(m+1,n+1) = \\dfrac{m!\\,n!}{(m+n+1)!}$, from $u\\,B(u,v+1) = v\\,B(u+1,v)$ and $B(u,v) = \\dfrac{\\Gamma u\\,\\Gamma v}{\\Gamma(u+v)}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler Beta function",
+      "Gamma function",
+      "Beta–Gamma relation",
+      "factorials",
+      "binomial coefficients"
+    ],
+    "prerequisites": [
+      "improper integrals",
+      "the Gamma function",
+      "Complex.betaIntegral"
+    ]
+  },
+  {
     "id": "recurrence",
     "proofId": "beta-integral-recurrence-oq-01",
-    "range": { "startLine": 49, "endLine": 57 },
+    "range": {
+      "startLine": 49,
+      "endLine": 57
+    },
     "type": "concept",
     "title": "The Beta Parameter Recurrence",
     "content": "beta_recurrence re-exports Mathlib's Complex.betaIntegral_recurrence: u·B(u, v+1) = v·B(u+1, v) for Re u, Re v > 0. This functional equation is the Beta-function analogue of the Gamma recurrence Γ(z+1) = z·Γ(z) — it relates Beta values at neighbouring parameter points and, iterated from a base value, determines the Beta function on a lattice. It is the headline identity the entry advertises; the closed form is its destination.",
     "mathContext": "$u\\,B(u, v+1) = v\\,B(u+1, v)$ for $\\operatorname{Re} u, \\operatorname{Re} v > 0$.",
     "significance": "key",
-    "relatedConcepts": ["Beta function", "functional equation", "Gamma recurrence", "Euler integral"],
-    "prerequisites": ["Beta integral", "complex analysis"]
+    "relatedConcepts": [
+      "Beta function",
+      "functional equation",
+      "Gamma recurrence",
+      "Euler integral"
+    ],
+    "prerequisites": [
+      "Beta integral",
+      "complex analysis"
+    ]
   },
   {
     "id": "integer-closed-form",
     "proofId": "beta-integral-recurrence-oq-01",
-    "range": { "startLine": 59, "endLine": 77 },
+    "range": {
+      "startLine": 59,
+      "endLine": 77
+    },
     "type": "insight",
     "title": "The Symmetric Integer Closed Form",
     "content": "betaIntegral_nat_nat is the centerpiece: B(m+1, n+1) = m!·n!/(m+n+1)! for all m, n : ℕ. Mathlib records only the ASYMMETRIC one-sided evaluation B(u, n+1) = n!/∏(u+j); this symmetric two-integer value is not in Mathlib. The proof feeds both integer arguments through the Beta–Gamma relation B(u,v) = Γu·Γv/Γ(u+v), rewrites the denominator argument (m+1)+(n+1) as (m+n+1)+1, and collapses all three Gamma values to factorials via Complex.Gamma_nat_eq_factorial (Γ(k+1) = k!). The positivity side-conditions on the real parts are discharged by positivity.",
     "mathContext": "$B(m+1, n+1) = \\dfrac{m!\\,n!}{(m+n+1)!}$, from $B(u,v) = \\dfrac{\\Gamma u\\,\\Gamma v}{\\Gamma(u+v)}$ with $\\Gamma(k+1) = k!$.",
     "significance": "key",
-    "relatedConcepts": ["Beta–Gamma relation", "factorial", "Gamma function", "binomial coefficients"],
-    "prerequisites": ["Gamma function", "Beta–Gamma relation"]
+    "relatedConcepts": [
+      "Beta–Gamma relation",
+      "factorial",
+      "Gamma function",
+      "binomial coefficients"
+    ],
+    "prerequisites": [
+      "Gamma function",
+      "Beta–Gamma relation"
+    ]
   },
   {
     "id": "symmetry",
     "proofId": "beta-integral-recurrence-oq-01",
-    "range": { "startLine": 79, "endLine": 85 },
+    "range": {
+      "startLine": 79,
+      "endLine": 85
+    },
     "type": "tactic",
     "title": "Symmetry on the Integer Lattice",
     "content": "betaIntegral_nat_nat_symm reads off B(m+1, n+1) = B(n+1, m+1) directly from the closed form, whose right-hand side m!·n!/(m+n+1)! is manifestly symmetric under m ↔ n (using Nat.add_comm in the denominator). The Beta function's general symmetry B(u,v) = B(v,u) reflects the substitution t ↦ 1−t in the defining integral; here it becomes the visible algebraic symmetry of a factorial quotient.",
     "mathContext": "$B(m+1, n+1) = B(n+1, m+1)$, the $m \\leftrightarrow n$ symmetry of $m!\\,n!/(m+n+1)!$.",
     "significance": "supporting",
-    "relatedConcepts": ["symmetry of the Beta function", "substitution t ↦ 1−t", "factorial symmetry"],
-    "prerequisites": ["the integer closed form"]
+    "relatedConcepts": [
+      "symmetry of the Beta function",
+      "substitution t ↦ 1−t",
+      "factorial symmetry"
+    ],
+    "prerequisites": [
+      "the integer closed form"
+    ]
   },
   {
     "id": "concrete-values",
     "proofId": "beta-integral-recurrence-oq-01",
-    "range": { "startLine": 87, "endLine": 103 },
+    "range": {
+      "startLine": 87,
+      "endLine": 103
+    },
     "type": "concept",
     "title": "Concrete Evaluations",
     "content": "betaIntegral_one_one, betaIntegral_two_three, betaIntegral_three_three machine-check B(1,1) = 1, B(2,3) = 1/12, B(3,3) = 1/30 by instantiating the closed form at m,n ∈ {0,1,2} and simplifying with norm_num [Nat.factorial] + linear_combination. B(1,1) = 1 is the integral of the constant 1 over [0,1]; the others are exact rational areas under tᵐ(1−t)ⁿ. These ground the abstract closed form in checkable arithmetic.",
     "mathContext": "$B(1,1) = 1$, $B(2,3) = 1/12$, $B(3,3) = 1/30$ — instances of $m!\\,n!/(m+n+1)!$.",
     "significance": "supporting",
-    "relatedConcepts": ["definite integrals", "rational areas", "norm_num"],
-    "prerequisites": ["the integer closed form"]
+    "relatedConcepts": [
+      "definite integrals",
+      "rational areas",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "the integer closed form"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01`.

## What
The four existing annotations cover only the declarations; the 40-line header overview (lines 4–43) had **no annotation**. This adds one `concept` annotation:

- **Overview (lines 4–43):** the Beta integral, its parameter recurrence u·B(u,v+1)=v·B(u+1,v), the Beta–Gamma relation, the symmetric two-integer closed form B(m+1,n+1)=m!·n!/(m+n+1)! (not in Mathlib), and the derivation strategy.

The existing four annotations are preserved verbatim.

## Validation
`npx tsx scripts/annotations/resolver.ts validate` → **5 valid, 0 misaligned**.

Annotations only.