### PR TITLE
Enrich Faulhaber p=4 power sum (nicomachus-sum-of-cubes-oq-02): annotations 4→6

### DIFF
--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-02/annotations.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-02/annotations.json
@@ -2,47 +2,124 @@
   {
     "id": "ann-subtraction-free",
     "proofId": "nicomachus-sum-of-cubes-oq-02",
-    "range": { "startLine": 59, "endLine": 69 },
+    "range": {
+      "startLine": 59,
+      "endLine": 69
+    },
     "type": "theorem",
     "title": "Subtraction-free, division-free core: 30·∑k⁴ + n = 6n⁵+15n⁴+10n³",
     "content": "The whole development is built on this lemma. The target closed form $n(n+1)(2n+1)(3n^2+3n-1)/30$ has a division by 30 and, once cleared, a subtraction: $30\\sum k^4 = 6n^5 + 15n^4 + 10n^3 - n$. Both are hostile to `ring` over $\\mathbb{N}$ (no division; truncated subtraction is not a ring operation). Multiplying by 30 and moving the $-n$ to the left gives $30\\sum_{k\\le n} k^4 + n = 6n^5 + 15n^4 + 10n^3$, where every term is a genuine natural number. The induction's base case is `simp` (the $k=0$ term vanishes); the step uses `sum_range_succ` to expose the top fourth power $(m+1)^4$, then leans on the standalone polynomial identity proved on the next line.",
     "mathContext": "$30\\sum_{k\\le n} k^4 + n = 6n^5 + 15n^4 + 10n^3$.",
     "significance": "critical",
-    "prerequisites": ["Mathematical induction", "Finset.sum_range_succ"],
-    "relatedConcepts": ["Truncated natural subtraction", "Power sums", "Faulhaber's formula"]
+    "prerequisites": [
+      "Mathematical induction",
+      "Finset.sum_range_succ"
+    ],
+    "relatedConcepts": [
+      "Truncated natural subtraction",
+      "Power sums",
+      "Faulhaber's formula"
+    ]
   },
   {
     "id": "ann-ring-omega-step",
     "proofId": "nicomachus-sum-of-cubes-oq-02",
-    "range": { "startLine": 64, "endLine": 69 },
+    "range": {
+      "startLine": 64,
+      "endLine": 69
+    },
     "type": "insight",
     "title": "ring for the algebra, omega for the splice",
     "content": "The inductive step is closed by a clean division of labor. The `key` hypothesis $6m^5 + 15m^4 + 10m^3 + 30(m+1)^4 + 1 = 6(m+1)^5 + 15(m+1)^4 + 10(m+1)^3$ is a fixed, subtraction-free degree-5 polynomial identity that `ring` verifies outright. Then `omega` finishes: it treats the nonlinear terms $m^5, m^4, m^3, (m+1)^5, (m+1)^4, (m+1)^3$ and the sum as opaque atoms and does the purely *linear* algebra needed to combine `key` with the inductive hypothesis $30\\sum_{k\\le m} k^4 + m = 6m^5 + 15m^4 + 10m^3$. Neither tactic does the other's job — `ring` cannot use the hypothesis, `omega` cannot expand the polynomials.",
     "mathContext": "$6m^5 + 15m^4 + 10m^3 + 30(m+1)^4 + 1 = 6(m+1)^5 + 15(m+1)^4 + 10(m+1)^3$.",
     "significance": "key",
-    "relatedConcepts": ["ring tactic", "omega tactic", "Atomization of nonlinear terms"]
+    "relatedConcepts": [
+      "ring tactic",
+      "omega tactic",
+      "Atomization of nonlinear terms"
+    ]
   },
   {
     "id": "ann-factored-int",
     "proofId": "nicomachus-sum-of-cubes-oq-02",
-    "range": { "startLine": 77, "endLine": 87 },
+    "range": {
+      "startLine": 77,
+      "endLine": 87
+    },
     "type": "theorem",
     "title": "Factored form over ℤ: 30·∑k⁴ = n(n+1)(2n+1)(3n²+3n−1)",
     "content": "The classical factored product is stated over $\\mathbb{Z}$ so the factor $3n^2+3n-1$ uses honest subtraction. `congrArg Nat.cast` lifts the $\\mathbb{N}$ identity, `push_cast` distributes the cast through the sum and powers, and `linarith` isolates $30\\sum_{k\\le n} k^4 = 6n^5 + 15n^4 + 10n^3 - n$. A final `ring` recognizes that the product $n(n+1)(2n+1)(3n^2+3n-1)$ equals $6n^5+15n^4+10n^3-n$, closing the goal. The integers are used only to *state* the result — all the inductive work happened in $\\mathbb{N}$.",
     "mathContext": "$30\\sum_{k\\le n} k^4 = n(n+1)(2n+1)(3n^2+3n-1)$ over $\\mathbb{Z}$.",
     "significance": "critical",
-    "prerequisites": ["Integer casts (push_cast)"],
-    "relatedConcepts": ["Nat.cast", "push_cast", "Closed-form power sums"]
+    "prerequisites": [
+      "Integer casts (push_cast)"
+    ],
+    "relatedConcepts": [
+      "Nat.cast",
+      "push_cast",
+      "Closed-form power sums"
+    ]
   },
   {
     "id": "ann-headline-rat",
     "proofId": "nicomachus-sum-of-cubes-oq-02",
-    "range": { "startLine": 93, "endLine": 103 },
+    "range": {
+      "startLine": 93,
+      "endLine": 103
+    },
     "type": "theorem",
     "title": "Headline form over ℚ: ∑k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30",
     "content": "The headline divided form lives over $\\mathbb{Q}$, where the $/30$ is a genuine division. The same $\\mathbb{N}$ core is cast with `push_cast`, `linarith` isolates the sum as $(6n^5+15n^4+10n^3-n)/30$, and `ring` clears the product against the $/30$ to recognize the factored numerator. This is the form a reader recognizes as Faulhaber's $p=4$ identity; the rationals are used only for the final statement.",
     "mathContext": "$\\sum_{k\\le n} k^4 = \\dfrac{n(n+1)(2n+1)(3n^2+3n-1)}{30}$ over $\\mathbb{Q}$.",
     "significance": "supporting",
-    "relatedConcepts": ["Rational casts", "Division in fields", "Closed-form power sums"]
+    "relatedConcepts": [
+      "Rational casts",
+      "Division in fields",
+      "Closed-form power sums"
+    ]
+  },
+  {
+    "id": "ann-nico4-overview",
+    "proofId": "nicomachus-sum-of-cubes-oq-02",
+    "range": {
+      "startLine": 4,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "Faulhaber's p = 4 power sum and the additive clear-denominator strategy",
+    "content": "This entry supplies the fourth-power member of the Faulhaber family, extending the parent Nicomachus sum-of-cubes identity ∑k³ = (∑k)². The classical closed form ∑_{k≤n} k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30 carries two features hostile to a natural-number induction: a division by 30 and, once cleared, a genuine subtraction (30·∑k⁴ = 6n⁵+15n⁴+10n³ − n). Truncated ℕ-subtraction breaks `ring`, so the file's design move is to prove instead the fully subtraction-free, division-free equivalent 30·∑k⁴ + n = 6n⁵+15n⁴+10n³ (adding n to both sides), which lives cleanly in ℕ. The honest factored form over ℤ and the divided form over ℚ are then recovered by casting. Mathlib has the Gauss triangular identity and (via this gallery) the cube and odd-cube sums, but not the p=4 Faulhaber form; this file adds it, mirroring the additive technique of the sibling power-sum entries.",
+    "mathContext": "$\\sum_{k\\le n} k^4 = \\dfrac{n(n+1)(2n+1)(3n^2+3n-1)}{30}$; cleared and shifted: $30\\sum_{k\\le n}k^4 + n = 6n^5+15n^4+10n^3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Faulhaber's formula",
+      "power sums",
+      "Nicomachus's identity",
+      "truncated natural subtraction"
+    ],
+    "prerequisites": [
+      "finite sums over Finset.range",
+      "mathematical induction",
+      "the parent Nicomachus sum-of-cubes entry"
+    ]
+  },
+  {
+    "id": "ann-nico4-checks",
+    "proofId": "nicomachus-sum-of-cubes-oq-02",
+    "range": {
+      "startLine": 105,
+      "endLine": 109
+    },
+    "type": "context",
+    "title": "Numeric sanity checks",
+    "content": "Two concrete evaluations at n = 3 confirm the identity: the raw sum ∑_{k≤3} k⁴ = 1+16+81 = 98, and its cleared form 30·∑_{k≤3} k⁴ = 3·4·7·35 = 2940 = 30·98, matching the factored product n(n+1)(2n+1)(3n²+3n−1) at n = 3. Both are discharged by kernel `decide`, so they add no axioms (no native_decide, hence no Lean.ofReduceBool).",
+    "mathContext": "$\\sum_{k\\le 3} k^4 = 98,\\qquad 30\\cdot 98 = 2940 = 3\\cdot 4\\cdot 7\\cdot 35.$",
+    "significance": "context",
+    "relatedConcepts": [
+      "numeric verification",
+      "kernel decide"
+    ],
+    "prerequisites": [
+      "evaluating finite sums"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `nicomachus-sum-of-cubes-oq-02` (Faulhaber's fourth-power sum ∑k⁴).

**Gap:** 4 annotations covering only ~30% of the 111-line Lean file — the module header/overview and the numeric sanity checks were unannotated.

**Change:** added 2 annotations (→6 total), raising coverage to ~80%:
- **Overview** (module header): the Faulhaber p=4 identity and the additive clear-denominator strategy (why the proof works over ℕ subtraction-free before casting to ℤ/ℚ)
- **Numeric sanity checks**: the n=3 evaluations and their kernel-`decide` (axiom-free) discharge

Existing 4 theorem/insight annotations preserved unchanged, each already has mathContext/significance/relatedConcepts.

**Validation:** `resolver.ts validate` → 6/6 resolve, 0 misaligned. No meta.json change.