### PR TITLE
Enrich energy seminorm (cauchy-schwarz-oq-02-oq-04-oq-02): annotations 4→7

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-02/annotations.json
@@ -91,5 +91,73 @@
       "energyNorm_sq",
       "sesquilinearity (inner_add/sub_left/right)"
     ]
+  },
+  {
+    "id": "csq020402-ann-overview",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-02",
+    "range": {
+      "startLine": 5,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "Promoting the Kadison–Schwarz inequality to a seminorm structure",
+    "content": "The parent entry proves the positive-operator (Kadison–Schwarz) Cauchy-Schwarz inequality ⟪Tx,y⟫² ≤ ⟪Tx,x⟫·⟪Ty,y⟫ for a positive symmetric operator T — precisely Cauchy-Schwarz for the positive semidefinite bilinear form (x,y) ↦ ⟪Tx,y⟫. This entry turns that inequality into a structure: the induced energy seminorm ‖x‖_T := √⟪Tx,x⟫ is nonnegative, absolutely homogeneous, and satisfies the triangle inequality, so every positive symmetric T equips the space with a seminorm (a norm exactly when T is positive definite). Positivity (hpos) and symmetry (hsymm) are carried as explicit hypotheses, not structure-encoded assumptions, and the parallelogram law holds with no positivity at all — it is a purely bilinear identity.",
+    "mathContext": "$\\|x\\|_T := \\sqrt{\\langle Tx,x\\rangle}$; the substantive axiom is $\\|x+y\\|_T \\le \\|x\\|_T + \\|y\\|_T$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kadison–Schwarz inequality",
+      "positive semidefinite bilinear form",
+      "seminorm",
+      "energy norm"
+    ],
+    "prerequisites": [
+      "real inner product spaces",
+      "the parent entry cauchy-schwarz-oq-02-oq-04",
+      "positive symmetric operators"
+    ]
+  },
+  {
+    "id": "csq020402-ann-basic",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-02",
+    "range": {
+      "startLine": 87,
+      "endLine": 109
+    },
+    "type": "technique",
+    "title": "The easy seminorm axioms: nonnegativity, square, zero, homogeneity",
+    "content": "Three of the four seminorm properties are elementary and need little of T's structure. energyNorm_nonneg is immediate from √ ≥ 0 (no hypotheses at all). energyNorm_sq recovers the diagonal form ‖x‖_T² = ⟪Tx,x⟫, valid because positivity lets √ and squaring be mutual inverses (Real.sq_sqrt). energyNorm_zero follows from map_zero + inner_zero_left. energyNorm_smul is absolute homogeneity ‖c•x‖_T = |c|·‖x‖_T: bilinearity gives ⟪T(c•x),c•x⟫ = c²⟪Tx,x⟫, and Real.sqrt_mul with Real.sqrt_sq_eq_abs extracts |c|. Only the triangle inequality below actually consumes Cauchy-Schwarz.",
+    "mathContext": "$\\|x\\|_T^2 = \\langle Tx,x\\rangle,\\quad \\|c\\bullet x\\|_T = |c|\\,\\|x\\|_T,\\quad \\|0\\|_T = 0.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "absolute homogeneity",
+      "bilinearity",
+      "Real.sqrt properties"
+    ],
+    "prerequisites": [
+      "properties of the real square root",
+      "bilinearity of the inner product"
+    ]
+  },
+  {
+    "id": "csq020402-ann-sqrtcs",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-02",
+    "range": {
+      "startLine": 111,
+      "endLine": 122
+    },
+    "type": "technique",
+    "title": "Square-root form of Cauchy-Schwarz: |⟪Tx,y⟫| ≤ ‖x‖_T ‖y‖_T",
+    "content": "energyNorm_cauchy_schwarz repackages the squared inequality ⟪Tx,y⟫² ≤ ⟪Tx,x⟫·⟪Ty,y⟫ into the √-form |⟪Tx,y⟫| ≤ ‖x‖_T·‖y‖_T that the triangle inequality actually uses. The proof monotonicity of √ (Real.sqrt_le_sqrt): write the right side as √(⟪Tx,x⟫·⟪Ty,y⟫) via Real.sqrt_mul, write |⟪Tx,y⟫| as √(⟪Tx,y⟫²) via Real.sqrt_sq + sq_abs, then reduce to the squared inequality. This is the bridge lemma feeding the cross-term bound in energyNorm_triangle.",
+    "mathContext": "$|\\langle Tx,y\\rangle| \\le \\|x\\|_T\\,\\|y\\|_T$, from $\\langle Tx,y\\rangle^2 \\le \\langle Tx,x\\rangle\\langle Ty,y\\rangle$ by monotonicity of $\\sqrt{\\cdot}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cauchy-Schwarz inequality",
+      "monotonicity of the square root",
+      "absolute value"
+    ],
+    "prerequisites": [
+      "Real.sqrt monotonicity",
+      "the squared Cauchy-Schwarz inequality"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-02-oq-04-oq-02` (the energy seminorm ‖x‖_T = √⟪Tx,x⟫ of a positive symmetric operator).

**Gap:** 4 annotations covering ~32% of the 161-line file — the module overview and the middle block of seminorm lemmas were unannotated.

**Change:** added 3 annotations (→7 total), coverage ~85%:
- **Overview**: promoting the parent's Kadison–Schwarz inequality into a seminorm structure
- **Elementary seminorm axioms** (nonneg / sq / zero / absolute homogeneity) — the properties that don't need Cauchy-Schwarz
- **√-form Cauchy-Schwarz** bridge lemma feeding the triangle inequality

Existing 4 annotations preserved. **Validation:** 7/7 resolve, 0 misaligned. No meta.json change.