### PR TITLE
Enrich subordinate finite ε-nets (compactness-finite-subcover-oq-02): annotations 4→5

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-02/annotations.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02/annotations.json
@@ -2,49 +2,118 @@
   {
     "id": "subordinate-net",
     "proofId": "compactness-finite-subcover-oq-02",
-    "range": { "startLine": 60, "endLine": 73 },
+    "range": {
+      "startLine": 60,
+      "endLine": 73
+    },
     "type": "insight",
     "title": "The Subordinate Net: Two Lemmas at One Radius",
     "content": "`exists_subordinate_finite_ball_cover` is the headline and the conceptual heart. It first extracts a Lebesgue radius δ for the cover from `lebesgue_number_lemma_of_metric` (applied to the compact `univ`), so that every δ-ball lands inside some cover member U i. It then runs `exists_finite_cover_balls_of_isCompact_closure` at THAT SAME δ to get finitely many centers t whose δ-balls cover X. The two facts are compatible precisely because they share the radius δ: the balls both cover X (total boundedness) and refine the cover (Lebesgue). No single Mathlib lemma states this conjunction — the assembly is the content.",
     "mathContext": "$\\exists\\,\\delta>0,\\ t$ finite: $\\bigcup_{x\\in t}B(x,\\delta)=X$ and $\\forall x\\in t,\\ \\exists i,\\ B(x,\\delta)\\subseteq U_i$.",
     "significance": "key",
-    "relatedConcepts": ["Lebesgue number lemma", "total boundedness", "ε-net", "subordinate cover"],
-    "prerequisites": ["compact metric spaces", "open covers", "metric balls"]
+    "relatedConcepts": [
+      "Lebesgue number lemma",
+      "total boundedness",
+      "ε-net",
+      "subordinate cover"
+    ],
+    "prerequisites": [
+      "compact metric spaces",
+      "open covers",
+      "metric balls"
+    ]
   },
   {
     "id": "lebesgue-extract",
     "proofId": "compactness-finite-subcover-oq-02",
-    "range": { "startLine": 66, "endLine": 73 },
+    "range": {
+      "startLine": 66,
+      "endLine": 73
+    },
     "type": "tactic",
     "title": "Extracting δ and the Finite Net",
     "content": "The proof body is a tight two-step. `lebesgue_number_lemma_of_metric isCompact_univ hU hsub` yields δ > 0 and the subordination witness `hlb`. Then `exists_finite_cover_balls_of_isCompact_closure` is invoked on `univ` (with `closure_univ` rewriting closure univ = univ so the relative-compactness hypothesis is just `isCompact_univ`) at radius δ, producing the finite center set t with htfin and htcov. The final term packages δ, t, positivity, finiteness, the cover equality (`univ_subset_iff.mp htcov`), and subordination (`fun x _ => hlb x (mem_univ x)`).",
     "mathContext": "Lebesgue: $\\forall x,\\ \\exists i,\\ B(x,\\delta)\\subseteq U_i$. Total boundedness at $\\delta$: finite $t$ with $\\bigcup_{x\\in t}B(x,\\delta)\\supseteq X$.",
     "significance": "supporting",
-    "relatedConcepts": ["closure_univ", "isCompact_univ", "univ_subset_iff"],
-    "prerequisites": ["Mathlib metric API", "relative compactness"]
+    "relatedConcepts": [
+      "closure_univ",
+      "isCompact_univ",
+      "univ_subset_iff"
+    ],
+    "prerequisites": [
+      "Mathlib metric API",
+      "relative compactness"
+    ]
   },
   {
     "id": "finite-subcover",
     "proofId": "compactness-finite-subcover-oq-02",
-    "range": { "startLine": 79, "endLine": 93 },
+    "range": {
+      "startLine": 79,
+      "endLine": 93
+    },
     "type": "tactic",
     "title": "Constructive Heine–Borel from the Net",
     "content": "`exists_finite_subcover_via_net` recovers the finite subcover constructively. After making t a Finite subtype (`htfin.to_subtype`), `choose g hg` selects, for each center x ∈ t, a cover index g x with ball x δ ⊆ U (g x). The finite subfamily is then `range g` (finite since t is finite, via `Set.finite_range`). Covering is checked pointwise: any y lands in some net ball `ball x δ` (from htcov), which is inside U (g ⟨x,hx⟩), so y is covered. This derives Heine–Borel from the Lebesgue number rather than from abstract compactness — complementing the by-hand general-topology derivation in the sibling oq-01.",
     "mathContext": "$\\exists\\,s\\subseteq\\iota$ finite: $\\bigcup_{i\\in s}U_i = X$, with $s=\\operatorname{range}g$ and $g$ chosen so $B(x,\\delta)\\subseteq U_{g(x)}$.",
     "significance": "key",
-    "relatedConcepts": ["Heine–Borel theorem", "choice function", "finite subcover", "range of a map"],
-    "prerequisites": ["axiom of choice (choose)", "finite types"]
+    "relatedConcepts": [
+      "Heine–Borel theorem",
+      "choice function",
+      "finite subcover",
+      "range of a map"
+    ],
+    "prerequisites": [
+      "axiom of choice (choose)",
+      "finite types"
+    ]
   },
   {
     "id": "fineness",
     "proofId": "compactness-finite-subcover-oq-02",
-    "range": { "startLine": 99, "endLine": 107 },
+    "range": {
+      "startLine": 99,
+      "endLine": 107
+    },
     "type": "concept",
     "title": "Fineness: Controlled Diameters",
     "content": "`exists_subordinate_fine_cover` reuses the same net and adds a diameter bound: `Metric.diam_ball` gives diam (ball x δ) ≤ 2δ for each member. So an arbitrary open cover refines to a finite cover by sets of uniformly small, controlled diameter, each still inside one cover element. This 'fineness' is the metric analogue of refining to an arbitrarily fine cover, and is the precise structure needed for Heine–Cantor uniform continuity (take the Lebesgue number of the cover by preimages of ε/2-balls) and for localizing bump functions in a partition of unity.",
     "mathContext": "Each net member satisfies $\\operatorname{diam}\\,B(x,\\delta)\\le 2\\delta$ in addition to $B(x,\\delta)\\subseteq U_i$.",
     "significance": "supporting",
-    "relatedConcepts": ["diameter", "fine cover", "Heine–Cantor theorem", "partition of unity"],
-    "prerequisites": ["diameter of a set", "metric balls"]
+    "relatedConcepts": [
+      "diameter",
+      "fine cover",
+      "Heine–Cantor theorem",
+      "partition of unity"
+    ],
+    "prerequisites": [
+      "diameter of a set",
+      "metric balls"
+    ]
+  },
+  {
+    "id": "csfs02-ann-overview",
+    "proofId": "compactness-finite-subcover-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 48
+    },
+    "type": "concept",
+    "title": "Subordinate finite ε-nets: the Lebesgue number meets total boundedness",
+    "content": "This entry refines the finite-subcover characterization of compactness in the metric setting. Given an open cover U of a compact metric space it produces a single uniform radius δ > 0 (a Lebesgue number) together with a finite set of centers whose δ-balls cover X and are subordinate to the cover: each ball ball x δ sits inside some single member U i. The content is genuinely a combination of two Mathlib ingredients, neither sufficient alone: lebesgue_number_lemma_of_metric supplies the radius δ at which every δ-ball lands in a cover member, and exists_finite_cover_balls_of_isCompact_closure supplies finitely many balls of that same radius covering X. Running total boundedness at exactly the Lebesgue radius makes the two compatible. Two corollaries are read off: exists_finite_subcover_via_net re-derives the Heine–Borel finite subcover constructively from the Lebesgue number (rather than from abstract compactness), and exists_subordinate_fine_cover adds diameter control (≤ 2δ), refining an arbitrary cover to one by small, controlled-diameter sets. This structure underlies Heine–Cantor uniform continuity and partitions of unity.",
+    "mathContext": "For an open cover $U$ of compact metric $X$: $\\exists\\,\\delta>0,\\ t$ finite with $\\bigcup_{x\\in t}\\mathrm{ball}(x,\\delta)=X$ and $\\forall x\\in t,\\ \\exists i,\\ \\mathrm{ball}(x,\\delta)\\subseteq U_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lebesgue number lemma",
+      "total boundedness",
+      "Heine–Borel theorem",
+      "finite ε-net",
+      "partitions of unity"
+    ],
+    "prerequisites": [
+      "compact metric spaces",
+      "open covers",
+      "metric balls"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `compactness-finite-subcover-oq-02` (subordinate finite ε-nets on compact metric spaces).

**Gap:** 4 annotations covering ~35% of the 109-line file — the three theorems were annotated but the module header/overview was not.

**Change:** added 1 overview annotation (→5 total), coverage ~78%, explaining the core combination (Lebesgue number × total boundedness at the same radius) and the two corollaries (constructive Heine–Borel finite subcover; diameter-controlled fineness refinement).

Existing 4 annotations preserved. **Validation:** 5/5 resolve, 0 misaligned. No meta.json change.