### PR TITLE
Enrich van Aubel's theorem (van-aubel-theorem-oq-01): annotations 4→5

### DIFF
--- a/src/data/proofs/van-aubel-theorem-oq-01/annotations.json
+++ b/src/data/proofs/van-aubel-theorem-oq-01/annotations.json
@@ -2,49 +2,114 @@
   {
     "id": "ann-square-center",
     "proofId": "van-aubel-theorem-oq-01",
-    "range": { "startLine": 37, "endLine": 39 },
+    "range": {
+      "startLine": 37,
+      "endLine": 39
+    },
     "type": "definition",
     "title": "squareCenter: center of the externally erected square",
     "content": "On the directed edge u → v, the square erected outward has its center at the edge midpoint (u+v)/2 displaced by the outward normal i·(v-u)/2. Multiplication by i rotates the edge vector v-u by +90°, and dividing by 2 makes the displacement half the edge length — exactly the offset from a side's midpoint to the center of the square built on it. Encoding the plane as ℂ lets a single closed-form expression replace any synthetic construction.",
     "mathContext": "$\\mathrm{squareCenter}(u,v) = \\dfrac{u+v}{2} + i\\,\\dfrac{v-u}{2}$. The outward normal direction is $i(v-u)$ and the square's center sits at distance $\\tfrac12\\lvert v-u\\rvert$ from the midpoint along it.",
     "significance": "supporting",
-    "relatedConcepts": ["complex plane as ℝ²", "90° rotation via multiplication by i", "midpoint and normal offset"],
-    "prerequisites": ["complex numbers", "geometric meaning of i"]
+    "relatedConcepts": [
+      "complex plane as ℝ²",
+      "90° rotation via multiplication by i",
+      "midpoint and normal offset"
+    ],
+    "prerequisites": [
+      "complex numbers",
+      "geometric meaning of i"
+    ]
   },
   {
     "id": "ann-key-identity",
     "proofId": "van-aubel-theorem-oq-01",
-    "range": { "startLine": 41, "endLine": 48 },
+    "range": {
+      "startLine": 41,
+      "endLine": 48
+    },
     "type": "theorem",
     "title": "vanAubel_key: R - P = i·(S - Q)",
     "content": "This is the heart of the entire proof. Expanding the four square centers P, Q, R, S and simplifying, the diagonal vector R - P equals exactly i times the other diagonal vector S - Q. The proof is `linear_combination (-(a+b-c-d)/2) * Complex.I_sq`: every term is a polynomial in a,b,c,d except for a single occurrence of i², which the linear_combination absorbs using Complex.I_sq (i² = -1). Both named consequences of van Aubel's theorem are one-line corollaries of this identity.",
     "mathContext": "With $P=\\mathrm{sc}(a,b),Q=\\mathrm{sc}(b,c),R=\\mathrm{sc}(c,d),S=\\mathrm{sc}(d,a)$: $R-P = -\\tfrac{a+b-c-d}{2} + i\\,\\tfrac{a-b-c+d}{2}$ and $i(S-Q)$ equals the same, using $i^2=-1$.",
     "significance": "key",
-    "relatedConcepts": ["linear_combination tactic", "i² = -1", "complex rotation of diagonals"],
-    "prerequisites": ["complex arithmetic", "linear_combination in Mathlib"]
+    "relatedConcepts": [
+      "linear_combination tactic",
+      "i² = -1",
+      "complex rotation of diagonals"
+    ],
+    "prerequisites": [
+      "complex arithmetic",
+      "linear_combination in Mathlib"
+    ]
   },
   {
     "id": "ann-equal-diagonals",
     "proofId": "van-aubel-theorem-oq-01",
-    "range": { "startLine": 50, "endLine": 54 },
+    "range": {
+      "startLine": 50,
+      "endLine": 54
+    },
     "type": "theorem",
     "title": "vanAubel_equal_diagonals: |R - P| = |S - Q|",
     "content": "The segments PR and QS joining opposite square centers have equal length. After rewriting with the key identity, the goal is |i·(S-Q)| = |S-Q|, which follows from norm_mul and |i| = 1. Multiplication by i is a rotation, hence an isometry, so it cannot change the length of S - Q.",
     "mathContext": "$\\lVert R-P\\rVert = \\lVert i(S-Q)\\rVert = \\lvert i\\rvert\\,\\lVert S-Q\\rVert = 1\\cdot\\lVert S-Q\\rVert$.",
     "significance": "key",
-    "relatedConcepts": ["norm_mul", "Complex.norm_I", "isometry of rotation"],
-    "prerequisites": ["complex modulus", "|zw| = |z||w|"]
+    "relatedConcepts": [
+      "norm_mul",
+      "Complex.norm_I",
+      "isometry of rotation"
+    ],
+    "prerequisites": [
+      "complex modulus",
+      "|zw| = |z||w|"
+    ]
   },
   {
     "id": "ann-perp-diagonals",
     "proofId": "van-aubel-theorem-oq-01",
-    "range": { "startLine": 56, "endLine": 63 },
+    "range": {
+      "startLine": 56,
+      "endLine": 63
+    },
     "type": "theorem",
     "title": "vanAubel_perp_diagonals: PR ⟂ QS",
     "content": "Perpendicularity is encoded as the vanishing of the real part of (R-P)·conj(S-Q) — the Euclidean inner product of the two diagonal vectors. Rewriting with the key identity and Complex.mul_conj turns the product into i·|S-Q|², which is purely imaginary, so its real part is 0. Thus the diagonals meet at a right angle.",
     "mathContext": "$\\big((R-P)\\,\\overline{(S-Q)}\\big)_{\\mathrm{re}} = \\big(i\\,(S-Q)\\overline{(S-Q)}\\big)_{\\mathrm{re}} = \\big(i\\,\\lvert S-Q\\rvert^2\\big)_{\\mathrm{re}} = 0$.",
     "significance": "key",
-    "relatedConcepts": ["Complex.mul_conj", "Complex.I_mul_re", "Euclidean inner product as Re(z·conj w)"],
-    "prerequisites": ["complex conjugate", "z·conj z = |z|²", "real part of a purely imaginary number"]
+    "relatedConcepts": [
+      "Complex.mul_conj",
+      "Complex.I_mul_re",
+      "Euclidean inner product as Re(z·conj w)"
+    ],
+    "prerequisites": [
+      "complex conjugate",
+      "z·conj z = |z|²",
+      "real part of a purely imaginary number"
+    ]
+  },
+  {
+    "id": "ann-vanaubel-overview",
+    "proofId": "van-aubel-theorem-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 31
+    },
+    "type": "concept",
+    "title": "van Aubel's theorem as a single complex identity",
+    "content": "van Aubel's theorem: erect a square externally on each side of an arbitrary planar quadrilateral a,b,c,d, and let P,Q,R,S be the four square centers (one per directed side). Then the two 'diagonals' PR and QS of the square-center quadrilateral are equal in length and perpendicular. Modelling the plane as ℂ, the whole statement collapses to one algebraic identity R − P = i·(S − Q) (vanAubel_key). Since multiplication by i is a 90° rotation preserving length, this single equation yields both ‖PR‖ = ‖QS‖ (equal diagonals) and PR ⟂ QS (perpendicular diagonals, encoded as the vanishing real part of (R−P)·conj(S−Q)). The key identity is a pure `ring` computation once Complex.I_sq (i² = −1) is supplied, so the proof is fully machine-checked, axiom-free, and is not a named Mathlib result.",
+    "mathContext": "$R - P = i\\,(S - Q)$, whence $\\|PR\\| = \\|QS\\|$ and $\\mathrm{Re}\\big((R-P)\\overline{(S-Q)}\\big) = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complex numbers as the plane",
+      "rotation by multiplication by i",
+      "van Aubel's theorem",
+      "Napoleon-type configurations"
+    ],
+    "prerequisites": [
+      "complex arithmetic",
+      "norm and conjugate on ℂ",
+      "the geometry of squares on a quadrilateral"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `van-aubel-theorem-oq-01`.

**Gap:** 4 annotations covering ~37% of the 65-line file — the definition and three theorems were annotated but the module header/overview was not.

**Change:** added 1 overview annotation (→5 total), coverage ~80%, explaining how the full theorem (equal + perpendicular diagonals of the square-center quadrilateral) collapses to the single complex identity R − P = i(S − Q).

Existing 4 annotations preserved. **Validation:** 5/5 resolve, 0 misaligned. No meta.json change.