### PR TITLE
research(lucas-sum-oq-01-oq-02): weighted & squared Lucas partial sums + Fibonacci bridge [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LucasSumOQ01OQ02.lean
+++ b/proofs/Proofs/LucasSumOQ01OQ02.lean
@@ -1,0 +1,176 @@
+import Mathlib
+
+/-
+# Weighted and Squared Lucas Partial Sums: `∑ k·L_k` and `∑ L_k²`
+
+## Open Question OQ-01-OQ-02 (from `lucas-sum-oq-01`)
+
+The parent entry `lucas-sum-oq-01` proves the linear Lucas telescoping sum
+`∑_{k=1}^{n} L_k = L_{n+2} − 3` and records the Fibonacci bridge
+`L_{n+1} = F_n + F_{n+2}`.  Its second open question asks:
+
+> Derive a Lucas analogue of `∑ k·F_k` or `∑ F_k²` and relate it to the Fibonacci
+> versions through the bridge `L_{n+1} = F_n + F_{n+2}`.
+
+This entry answers it for **both** weighted and squared sums, over the companion
+sequence `L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}`:
+
+* `lucas_sq_sum`      —  `∑_{k=0}^{n} L_k² = L_n · L_{n+1} + 2`.
+* `weighted_lucas_sum` —  `∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4`.
+
+Both close under a **one-step induction** driven purely by the Lucas recurrence,
+stated in subtraction-free `(∑ …) + c = …` form so `omega`/`ring` finish each step.
+
+## The Fibonacci comparison and bridge
+
+For contrast we prove the classical Fibonacci square-sum
+
+* `fib_sq_sum`  —  `∑_{k=0}^{n} F_k² = F_n · F_{n+1}`
+
+by the same one-step telescoping, and then **relate the two** through the parent's
+bridge `L_{n+1} = F_n + F_{n+2}`:
+
+* `lucas_sq_sum_fib`  —  `∑_{k=0}^{n+1} L_k² = (F_n+F_{n+2})·(F_{n+1}+F_{n+3}) + 2`.
+
+The Lucas square-sum thus factors, via the bridge, into a product of *sums of two
+Fibonacci numbers* — the exact way the two sequences are tied together.
+
+## The telescoped constants
+
+The squared sum telescopes as `L_k² = L_k·L_{k+1} − L_{k−1}·L_k`, giving the
+closed constant `+2 = −L_{−1}·L_0 = −(−1)·2`.  The weighted sum uses the
+Abel-summation shape `k·L_k = k·(L_{k+2} − L_{k+1})`, producing the `n·L_{n+2}`
+head term and the `−L_{n+3} + 4` correction.  Both correction constants are
+recorded first in subtraction-free form so `ℕ`-subtraction never appears mid-proof.
+
+## References
+
+- The linear Lucas sum `∑ L_k = L_{n+2} − 3` and the bridge `L_{n+1} = F_n + F_{n+2}`
+  (parent family `lucas-sum-oq-01`).
+- `∑ F_k² = F_n·F_{n+1}` and `L_k² − 5F_k² = 4(−1)^k` (Vajda, *Fibonacci & Lucas
+  Numbers*, identities (11), (28)).
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace LucasSumOQ01OQ02
+
+open Finset
+
+/-- The Lucas numbers `2, 1, 3, 4, 7, 11, …` — the Fibonacci recurrence with the
+alternative initial data `L_0 = 2`, `L_1 = 1`.  Same self-contained definition as
+the parent `lucas-sum-oq-01`. -/
+def lucas : ℕ → ℕ
+  | 0 => 2
+  | 1 => 1
+  | (n + 2) => lucas n + lucas (n + 1)
+
+@[simp] theorem lucas_zero : lucas 0 = 2 := rfl
+
+@[simp] theorem lucas_one : lucas 1 = 1 := rfl
+
+/-- The defining Lucas recurrence `L_{n+2} = L_n + L_{n+1}`. -/
+theorem lucas_add_two (n : ℕ) : lucas (n + 2) = lucas n + lucas (n + 1) := rfl
+
+/-! ## Squared Lucas partial sum `∑_{k=0}^{n} L_k² = L_n · L_{n+1} + 2` -/
+
+/-- **Squared Lucas partial sum.** `∑_{k=0}^{n} L_k² = L_n · L_{n+1} + 2`.
+
+One-step induction.  Peeling `L_{n+1}²` and substituting the recurrence
+`L_{n+2} = L_n + L_{n+1}` reduces the step to
+`L_n·L_{n+1} + L_{n+1}² = L_{n+1}·(L_n + L_{n+1})`, closed by `ring`. -/
+theorem lucas_sq_sum (n : ℕ) :
+    (∑ k ∈ Finset.range (n + 1), lucas k ^ 2) = lucas n * lucas (n + 1) + 2 := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ih]
+    have hrec : lucas (n + 1 + 1) = lucas n + lucas (n + 1) := lucas_add_two n
+    rw [hrec]; ring
+
+/-! ## Weighted Lucas partial sum `∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4` -/
+
+/-- **Weighted Lucas partial sum (subtraction-free).**
+`(∑_{k=0}^{n} k·L_k) + L_{n+3} = n·L_{n+2} + 4`.
+
+One-step induction: peeling the new term `(n+1)·L_{n+1}` and expanding the two
+recurrences `L_{n+4} = L_{n+2}+L_{n+3}`, `L_{n+3} = L_{n+1}+L_{n+2}` lets `omega`
+combine everything with the inductive hypothesis. -/
+theorem weighted_lucas_sum_add (n : ℕ) :
+    (∑ k ∈ Finset.range (n + 1), k * lucas k) + lucas (n + 3) = n * lucas (n + 2) + 4 := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+    -- recurrences at the two indices the step needs, in canonical form
+    have h4 : lucas (n + 1 + 3) = lucas (n + 2) + lucas (n + 3) := lucas_add_two (n + 2)
+    have e2 : lucas (n + 1 + 2) = lucas (n + 3) := rfl
+    -- distribute `(n+1)` across the recurrence `L_{n+3} = L_{n+1} + L_{n+2}` so `omega`
+    -- can treat each `(n+1)·L`, `n·L` product as a consistent atom
+    have key : (n + 1) * lucas (n + 3)
+        = (n + 1) * lucas (n + 1) + (n + 1) * lucas (n + 2) := by
+      have h2 : lucas (n + 3) = lucas (n + 1) + lucas (n + 2) := lucas_add_two (n + 1)
+      rw [h2]; ring
+    have hd : (n + 1) * lucas (n + 2) = n * lucas (n + 2) + lucas (n + 2) := by ring
+    rw [Finset.sum_range_succ, h4, e2]
+    omega
+
+/-- **Weighted Lucas partial sum** `∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4`
+(truncated subtraction over `ℕ`; well-defined since `n·L_{n+2} + 4 ≥ L_{n+3}`). -/
+theorem weighted_lucas_sum (n : ℕ) :
+    (∑ k ∈ Finset.range (n + 1), k * lucas k) = n * lucas (n + 2) + 4 - lucas (n + 3) := by
+  have h := weighted_lucas_sum_add n
+  omega
+
+/-! ## The Fibonacci square-sum and the bridge -/
+
+/-- **Fibonacci square-sum.** `∑_{k=0}^{n} F_k² = F_n · F_{n+1}`, by the same
+one-step telescoping `F_n·F_{n+1} + F_{n+1}² = F_{n+1}·F_{n+2}`. -/
+theorem fib_sq_sum (n : ℕ) :
+    (∑ k ∈ Finset.range (n + 1), Nat.fib k ^ 2) = Nat.fib n * Nat.fib (n + 1) := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ih]
+    have hrec : Nat.fib (n + 1 + 1) = Nat.fib n + Nat.fib (n + 1) := Nat.fib_add_two
+    rw [hrec]; ring
+
+/-- **Lucas via Fibonacci.** `L_{n+1} = F_n + F_{n+2}` (parent's bridge, re-proved
+here so the file is self-contained).  Two-step induction on the shared recurrence. -/
+theorem lucas_succ_eq_fib_add_fib (n : ℕ) :
+    lucas (n + 1) = Nat.fib n + Nat.fib (n + 2) := by
+  induction n using Nat.twoStepInduction with
+  | zero => decide
+  | one => decide
+  | more n h0 h1 =>
+    have h0' : lucas (n + 1) = Nat.fib n + Nat.fib (n + 2) := h0
+    have h1' : lucas (n + 2) = Nat.fib (n + 1) + Nat.fib (n + 3) := h1
+    show lucas (n + 3) = Nat.fib (n + 2) + Nat.fib (n + 4)
+    have el : lucas (n + 3) = lucas (n + 1) + lucas (n + 2) := lucas_add_two (n + 1)
+    have f1 : Nat.fib (n + 2) = Nat.fib n + Nat.fib (n + 1) := Nat.fib_add_two
+    have f2 : Nat.fib (n + 4) = Nat.fib (n + 2) + Nat.fib (n + 3) := Nat.fib_add_two
+    rw [el, h0', h1']
+    omega
+
+/-- **The bridge corollary.** The squared Lucas partial sum factors, via
+`L_{m+1} = F_m + F_{m+2}`, into a product of sums of two Fibonacci numbers:
+`∑_{k=0}^{n+1} L_k² = (F_n+F_{n+2})·(F_{n+1}+F_{n+3}) + 2`. -/
+theorem lucas_sq_sum_fib (n : ℕ) :
+    (∑ k ∈ Finset.range (n + 2), lucas k ^ 2)
+      = (Nat.fib n + Nat.fib (n + 2)) * (Nat.fib (n + 1) + Nat.fib (n + 3)) + 2 := by
+  rw [lucas_sq_sum (n + 1), lucas_succ_eq_fib_add_fib n,
+      show lucas (n + 1 + 1) = Nat.fib (n + 1) + Nat.fib (n + 3) from
+        lucas_succ_eq_fib_add_fib (n + 1)]
+
+/-! ## Numerical sanity checks -/
+
+/-- `L₀² + L₁² + L₂² + L₃² = 4 + 1 + 9 + 16 = 30 = L₃·L₄ + 2 = 4·7 + 2`. -/
+theorem lucas_sq_sum_example : (∑ k ∈ Finset.range 4, lucas k ^ 2) = 30 := by decide
+
+/-- `0·L₀ + 1·L₁ + 2·L₂ + 3·L₃ = 0 + 1 + 6 + 12 = 19 = 3·L₅ − L₆ + 4 = 33 − 18 + 4`. -/
+theorem weighted_lucas_sum_example :
+    (∑ k ∈ Finset.range 4, k * lucas k) = 19 := by decide
+
+/-- `F₀² + … + F₄² = 0 + 1 + 1 + 4 + 9 = 15 = F₄·F₅ = 3·5`. -/
+theorem fib_sq_sum_example : (∑ k ∈ Finset.range 5, Nat.fib k ^ 2) = 15 := by decide
+
+end LucasSumOQ01OQ02

--- a/src/data/proofs/lucas-sum-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lucas-sum-oq-01-oq-02/annotations.json
@@ -1,0 +1,178 @@
+[
+  {
+    "id": "ann-programme",
+    "proofId": "lucas-sum-oq-01-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 54
+    },
+    "type": "concept",
+    "title": "Lucas Analogues of ∑ k·F_k and ∑ F_k², and the Fibonacci Bridge",
+    "content": "The docstring states the second open question of lucas-sum-oq-01: derive Lucas analogues of ∑ k·F_k or ∑ F_k² and relate them to the Fibonacci versions through the bridge L_{n+1} = F_n + F_{n+2}. This file answers both: the squared partial sum ∑_{k=0}^{n} L_k² = L_n·L_{n+1} + 2 and the weighted (first-moment) sum ∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4, plus the classical Fibonacci companion ∑_{k=0}^{n} F_k² = F_n·F_{n+1} and the bridge factorisation of the Lucas square-sum into Fibonacci terms. The additive constants +2 and +4 are fixed by the Lucas boundary data.",
+    "mathContext": "$\\sum_{k=0}^{n} L_k^2 = L_n L_{n+1} + 2$ and $\\sum_{k=0}^{n} k L_k = n L_{n+2} - L_{n+3} + 4$; compare $\\sum_{k=0}^{n} F_k^2 = F_n F_{n+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lucas numbers",
+      "Fibonacci numbers",
+      "squared partial sum",
+      "weighted partial sum",
+      "second-order linear recurrence"
+    ],
+    "prerequisites": [
+      "Fibonacci/Lucas recurrence",
+      "Finset.sum over range"
+    ]
+  },
+  {
+    "id": "ann-lucas-def",
+    "proofId": "lucas-sum-oq-01-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 73
+    },
+    "type": "concept",
+    "title": "A Self-Contained Lucas Sequence",
+    "content": "Mathlib provides Nat.fib but no Lucas sequence, so lucas : ℕ → ℕ is defined locally by the Fibonacci recurrence with boundary data L_0 = 2, L_1 = 1, giving 2, 1, 3, 4, 7, 11, 18, …. The boundary values are @[simp] lemmas and lucas_add_two : L_{n+2} = L_n + L_{n+1} holds by rfl. This single recurrence drives every induction below and the Fibonacci bridge, and matches the parent lucas-sum-oq-01 so the two entries share the same sequence.",
+    "mathContext": "$L_0 = 2,\\ L_1 = 1,\\ L_{n+2} = L_n + L_{n+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Lucas sequence definition",
+      "structural recursion on ℕ",
+      "@[simp] boundary lemmas"
+    ],
+    "prerequisites": [
+      "structural recursion",
+      "second-order recurrence"
+    ]
+  },
+  {
+    "id": "ann-squared-sum",
+    "proofId": "lucas-sum-oq-01-oq-02",
+    "range": {
+      "startLine": 77,
+      "endLine": 89
+    },
+    "type": "theorem",
+    "title": "The Squared Lucas Partial Sum",
+    "content": "lucas_sq_sum : ∑_{k=0}^{n} L_k² = L_n·L_{n+1} + 2. One-step induction: Finset.sum_range_succ peels L_{n+1}², and substituting the recurrence L_{n+2} = L_n + L_{n+1} turns the goal into the commutative-semiring identity L_n·L_{n+1} + L_{n+1}² = L_{n+1}·(L_n + L_{n+1}), closed by ring over ℕ. The offset +2 = L_{−1}·L_0 in the telescoping L_k² = L_k·L_{k+1} − L_{k−1}·L_k.",
+    "mathContext": "$\\sum_{k=0}^{n} L_k^2 = L_n L_{n+1} + 2$ (e.g. $L_0^2+\\dots+L_3^2 = 4+1+9+16 = 30 = L_3 L_4 + 2$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping sum of squares",
+      "Finset.sum_range_succ",
+      "ring over a commutative semiring"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "Lucas recurrence"
+    ]
+  },
+  {
+    "id": "ann-weighted-sum",
+    "proofId": "lucas-sum-oq-01-oq-02",
+    "range": {
+      "startLine": 93,
+      "endLine": 115
+    },
+    "type": "theorem",
+    "title": "The Weighted Lucas Partial Sum (subtraction-free engine)",
+    "content": "weighted_lucas_sum_add : (∑_{k=0}^{n} k·L_k) + L_{n+3} = n·L_{n+2} + 4, the ℕ-clean form of the first-moment identity. Peeling (n+1)·L_{n+1} with Finset.sum_range_succ, distributing (n+1) across the recurrence L_{n+3} = L_{n+1}+L_{n+2}, and expanding L_{n+4} = L_{n+2}+L_{n+3} supplies omega with matching product atoms so it can combine everything with the inductive hypothesis. This is the Lucas analogue of ∑ k·F_k = n·F_{n+2} − F_{n+3} + 2.",
+    "mathContext": "$\\left(\\sum_{k=0}^{n} k L_k\\right) + L_{n+3} = n L_{n+2} + 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "weighted/first-moment sum",
+      "subtraction-free formulation over ℕ",
+      "omega over opaque atoms"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "distributing products for omega"
+    ]
+  },
+  {
+    "id": "ann-weighted-headline",
+    "proofId": "lucas-sum-oq-01-oq-02",
+    "range": {
+      "startLine": 117,
+      "endLine": 122
+    },
+    "type": "theorem",
+    "title": "The Weighted Sum in ℕ-Subtraction Form",
+    "content": "weighted_lucas_sum : ∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4, read off from the subtraction-free engine by omega. The truncated ℕ-subtraction is exact because n·L_{n+2} + 4 ≥ L_{n+3} for all n.",
+    "mathContext": "$\\sum_{k=0}^{n} k L_k = n L_{n+2} - L_{n+3} + 4$ (e.g. $0+1+6+12 = 19 = 3 L_5 - L_6 + 4$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ℕ truncated subtraction",
+      "omega decision procedure"
+    ],
+    "prerequisites": [
+      "subtraction-free engine above"
+    ]
+  },
+  {
+    "id": "ann-fib-companion",
+    "proofId": "lucas-sum-oq-01-oq-02",
+    "range": {
+      "startLine": 124,
+      "endLine": 135
+    },
+    "type": "theorem",
+    "title": "The Fibonacci Companion ∑ F_k² = F_n·F_{n+1}",
+    "content": "fib_sq_sum : ∑_{k=0}^{n} F_k² = F_n·F_{n+1}, the classical Fibonacci square-sum, proved by the same one-step telescoping as the Lucas version (F_n·F_{n+1} + F_{n+1}² = F_{n+1}·F_{n+2} by ring). Unlike the Lucas case there is no additive constant because F_0 = 0. Mathlib packages Nat.fib and its recurrence but not this square-sum, so this fills a small gap and provides the Fibonacci side of the comparison.",
+    "mathContext": "$\\sum_{k=0}^{n} F_k^2 = F_n F_{n+1}$ (e.g. $F_0^2+\\dots+F_4^2 = 0+1+1+4+9 = 15 = F_4 F_5$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fibonacci sum of squares",
+      "Nat.fib_add_two",
+      "telescoping"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "Fibonacci recurrence"
+    ]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "lucas-sum-oq-01-oq-02",
+    "range": {
+      "startLine": 137,
+      "endLine": 152
+    },
+    "type": "theorem",
+    "title": "The Bridge L_{n+1} = F_n + F_{n+2}",
+    "content": "lucas_succ_eq_fib_add_fib : L_{n+1} = F_n + F_{n+2}, re-proved here (as in the parent) so the file is self-contained. Two-step induction (Nat.twoStepInduction): both sides obey x_{n+2} = x_n + x_{n+1} and agree at the two base indices, so the Fibonacci combination satisfies the Lucas recurrence; in the step every lucas is rewritten away and omega closes the goal from Nat.fib_add_two. This is the requested bridge relating the Lucas closed forms to the Fibonacci ones.",
+    "mathContext": "$L_{n+1} = F_n + F_{n+2}$, i.e. $L_m = F_{m-1} + F_{m+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lucas–Fibonacci bridge",
+      "Nat.twoStepInduction",
+      "Nat.fib_add_two"
+    ],
+    "prerequisites": [
+      "two-step induction",
+      "Fibonacci recurrence"
+    ]
+  },
+  {
+    "id": "ann-bridge-corollary",
+    "proofId": "lucas-sum-oq-01-oq-02",
+    "range": {
+      "startLine": 154,
+      "endLine": 162
+    },
+    "type": "theorem",
+    "title": "Factoring the Lucas Square-Sum Through the Bridge",
+    "content": "lucas_sq_sum_fib : ∑_{k=0}^{n+1} L_k² = (F_n + F_{n+2})·(F_{n+1} + F_{n+3}) + 2, obtained by substituting the bridge L_{m+1} = F_m + F_{m+2} into the closed form L_{n+1}·L_{n+2} + 2. The Lucas square-sum thus factors into a product of sums of two Fibonacci numbers — the concrete way the two sequences' closed forms are tied together, answering the 'relate to the Fibonacci versions' half of the open question.",
+    "mathContext": "$\\sum_{k=0}^{n+1} L_k^2 = (F_n + F_{n+2})(F_{n+1} + F_{n+3}) + 2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "bridge substitution",
+      "factorisation via Fibonacci",
+      "Lucas–Fibonacci relations"
+    ],
+    "prerequisites": [
+      "the bridge lemma",
+      "the squared Lucas sum"
+    ]
+  }
+]

--- a/src/data/proofs/lucas-sum-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lucas-sum-oq-01-oq-02/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "lucas-sum-oq-01-oq-02",
+  "slug": "lucas-sum-oq-01-oq-02",
+  "title": "Weighted and Squared Lucas Partial Sums: ∑ k·L_k and ∑ L_k², with the Fibonacci bridge",
+  "status": "verified",
+  "badge": "original",
+  "description": "Answers the second open question of lucas-sum-oq-01: derive Lucas analogues of ∑ k·F_k and ∑ F_k² and relate them to the Fibonacci versions through the bridge L_{n+1} = F_n + F_{n+2}. Over the self-contained Lucas sequence L_0=2, L_1=1, L_{n+2}=L_n+L_{n+1}, this entry proves the squared partial sum ∑_{k=0}^{n} L_k² = L_n·L_{n+1} + 2 and the weighted partial sum ∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4 (via the subtraction-free form (∑ k·L_k)+L_{n+3} = n·L_{n+2}+4). It also proves the classical Fibonacci companion ∑_{k=0}^{n} F_k² = F_n·F_{n+1} (not packaged in Mathlib) and, via the parent's bridge, the factorisation ∑_{k=0}^{n+1} L_k² = (F_n+F_{n+2})·(F_{n+1}+F_{n+3}) + 2. Fully verified: 12 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "overview": {
+    "historicalContext": "The Lucas numbers 2, 1, 3, 4, 7, 11, 18, … (OEIS A000032) obey the Fibonacci recurrence with initial data L_0 = 2, L_1 = 1. Alongside the linear telescoping sum ∑ L_k = L_{n+2} − 3 (parent entry lucas-sum-oq-01), two further partial sums are classical: the squared sum, whose Fibonacci counterpart ∑_{k=0}^{n} F_k² = F_n·F_{n+1} is a staple of the Fibonacci literature, and the weighted (first-moment) sum ∑ k·L_k. Both are second-order-recurrence exercises in the Fibonacci–Lucas family, and both admit clean closed forms with additive constants (2 and 4) fixed by the Lucas boundary data.",
+    "problemStatement": "For every natural number n, prove over ℕ: (i) ∑_{k=0}^{n} L_k² = L_n·L_{n+1} + 2; (ii) ∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4; (iii) the Fibonacci companion ∑_{k=0}^{n} F_k² = F_n·F_{n+1}; and (iv) the bridge form ∑_{k=0}^{n+1} L_k² = (F_n+F_{n+2})·(F_{n+1}+F_{n+3}) + 2 obtained from L_{m+1} = F_m + F_{m+2}. The Lucas sequence is defined locally (Mathlib has only Nat.fib) and bridged to Nat.fib.",
+    "proofStrategy": "Each closed form is proved by a one-step induction driven purely by the Lucas (resp. Fibonacci) recurrence. For the squared sum, Finset.sum_range_succ peels L_{n+1}² and the recurrence L_{n+2} = L_n + L_{n+1} reduces the step to L_n·L_{n+1} + L_{n+1}² = L_{n+1}·(L_n+L_{n+1}), closed by ring. The weighted sum is stated first in subtraction-free form (∑ k·L_k)+L_{n+3} = n·L_{n+2}+4; peeling (n+1)·L_{n+1}, distributing (n+1) across the recurrence for L_{n+3}, and expanding L_{n+4} = L_{n+2}+L_{n+3} lets omega combine each product atom with the inductive hypothesis. The Fibonacci square-sum telescopes identically (no additive constant since F_0 = 0). The bridge L_{n+1} = F_n + F_{n+2} is proved by two-step induction and substituted term-by-term to factor the Lucas square-sum into Fibonacci form.",
+    "keyInsights": [
+      "The squared sum telescopes as L_k² = L_k·L_{k+1} − L_{k−1}·L_k, so ∑_{k=0}^{n} L_k² = L_n·L_{n+1} − L_{−1}·L_0; the boundary term evaluates to +2, giving the clean +2 offset that the Fibonacci version (with F_0 = 0) does not carry.",
+      "Over ℕ the weighted sum needs truncated subtraction; proving the subtraction-free form (∑ k·L_k)+L_{n+3} = n·L_{n+2}+4 first keeps the induction honest and lets omega discharge the final subtraction.",
+      "omega treats lucas(·) and fib(·) as opaque atoms and does not rewrite their arguments or distribute products, so the recurrence must be stated in the goal's exact index form and each (n+1)·L / n·L product supplied as a matching atom.",
+      "The parent bridge L_{m+1} = F_m + F_{m+2} factors the Lucas square-sum into a product of sums of two Fibonacci numbers — the concrete way the two closed forms L_n·L_{n+1}+2 and F_n·F_{n+1} are tied together."
+    ],
+    "prerequisites": [
+      "Second-order linear recurrences and the Lucas/Fibonacci initial data",
+      "Finite sums over Finset.range with Finset.sum_range_succ",
+      "ℕ truncated subtraction and the omega decision procedure over opaque atoms",
+      "ring over ℕ (commutative semiring); Nat.fib and Nat.fib_add_two; Nat.twoStepInduction"
+    ]
+  },
+  "sections": [
+    {
+      "id": "lucas-def",
+      "title": "Section I: The Lucas Numbers and Their Recurrence",
+      "startLine": 60,
+      "endLine": 73,
+      "summary": "lucas: ℕ → ℕ with L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}, the boundary simp lemmas, and the rfl-recurrence lucas_add_two.",
+      "mathContext": "The same self-contained definition as the parent lucas-sum-oq-01; lucas_add_two : L_{n+2} = L_n + L_{n+1} drives every induction and the Fibonacci bridge."
+    },
+    {
+      "id": "squared-sum",
+      "title": "Section II: The Squared Lucas Partial Sum",
+      "startLine": 75,
+      "endLine": 89,
+      "summary": "lucas_sq_sum: ∑_{k=0}^{n} L_k² = L_n·L_{n+1} + 2, by one-step induction closed with ring after substituting the recurrence.",
+      "mathContext": "Finset.sum_range_succ peels L_{n+1}²; the step L_n·L_{n+1} + L_{n+1}² = L_{n+1}·(L_n+L_{n+1}) is a commutative-semiring identity, closed by ring over ℕ."
+    },
+    {
+      "id": "weighted-sum",
+      "title": "Section III: The Weighted Lucas Partial Sum",
+      "startLine": 91,
+      "endLine": 122,
+      "summary": "weighted_lucas_sum_add: the subtraction-free (∑ k·L_k)+L_{n+3} = n·L_{n+2}+4, and weighted_lucas_sum: ∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4.",
+      "mathContext": "Peeling (n+1)·L_{n+1}, distributing (n+1) across L_{n+3} = L_{n+1}+L_{n+2}, and expanding L_{n+4} = L_{n+2}+L_{n+3} lets omega combine the product atoms with the inductive hypothesis; the headline subtraction form follows by omega."
+    },
+    {
+      "id": "fib-companion-bridge",
+      "title": "Section IV: The Fibonacci Companion and the Bridge",
+      "startLine": 124,
+      "endLine": 162,
+      "summary": "fib_sq_sum: ∑_{k=0}^{n} F_k² = F_n·F_{n+1}; lucas_succ_eq_fib_add_fib: L_{n+1} = F_n + F_{n+2}; lucas_sq_sum_fib: ∑_{k=0}^{n+1} L_k² = (F_n+F_{n+2})·(F_{n+1}+F_{n+3}) + 2.",
+      "mathContext": "The Fibonacci square-sum telescopes exactly like the Lucas one but with no additive constant (F_0 = 0). Two-step induction proves the bridge, which is then substituted to factor the Lucas square-sum into Fibonacci form."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 176 lines, 12 theorems and 1 definition answering the second open question of lucas-sum-oq-01. It establishes the squared Lucas partial sum ∑_{k=0}^{n} L_k² = L_n·L_{n+1} + 2 and the weighted sum ∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4, proves the classical Fibonacci companion ∑_{k=0}^{n} F_k² = F_n·F_{n+1} (absent from Mathlib), and factors the Lucas square-sum through the bridge L_{n+1} = F_n + F_{n+2}. #print axioms reports only [propext, Classical.choice, Quot.sound] for the sum theorems (and [propext, Quot.sound] for the bridge).",
+    "implications": "An elementary but cleanly formalized entry that completes the Lucas partial-sum family (linear, squared, weighted) and supplies the ∑ F_k² = F_n·F_{n+1} companion as a reusable Mathlib gap-filler. Its value is a tidy, axiom-free treatment tying the Lucas and Fibonacci closed forms together through the parent's bridge; the results are routine in difficulty rather than a new mathematical contribution.",
+    "openQuestions": [
+      "Prove the mixed first-moment ∑ k·L_k² and the alternating squared sum ∑ (−1)^k L_k² by the same subtraction-free engine.",
+      "Establish the Lucas–Fibonacci identity L_k² − 5·F_k² = 4·(−1)^k directly and use it to relate ∑ L_k² and ∑ F_k² over ℤ without the product bridge."
+    ]
+  },
+  "references": [
+    {
+      "key": "OEIS_A000032",
+      "citation": "OEIS Foundation, The On-Line Encyclopedia of Integer Sequences, sequence A000032 (Lucas numbers).",
+      "type": "web"
+    },
+    {
+      "key": "Vajda",
+      "citation": "Vajda, S., Fibonacci and Lucas Numbers, and the Golden Section, Ellis Horwood (1989), identities for ∑ F_k², ∑ L_k² and L_k² − 5F_k² = 4(−1)^k.",
+      "type": "book"
+    },
+    {
+      "key": "Koshy",
+      "citation": "Koshy, T., Fibonacci and Lucas Numbers with Applications, Wiley (2001), Ch. on Lucas-number summation identities.",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "lucas-sum-oq-01",
+      "relationship": "Parent problem",
+      "description": "Directly answers the second open question of lucas-sum-oq-01 (Lucas analogue of ∑ k·F_k or ∑ F_k², related to Fibonacci via L_{n+1} = F_n + F_{n+2}); reuses its self-contained Lucas definition and bridge."
+    },
+    {
+      "proofId": "fibonacci-identities",
+      "relationship": "Fibonacci analogue",
+      "description": "The Fibonacci companions ∑ F_k² = F_n·F_{n+1} and the bridge L_{n+1} = F_n + F_{n+2} tie the Lucas closed forms here to the standard Fibonacci identities."
+    },
+    {
+      "proofId": "factorial-telescoping-sum-oq-01",
+      "relationship": "Shared technique",
+      "description": "Shares the ℕ subtraction-free telescoping technique (prove the additive form (∑)+c = boundary first, then read off the subtraction by omega)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "LucasSumOQ01OQ02",
+    "lineCount": 176,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "path": "Proofs/LucasSumOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://oeis.org/A000032",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LucasSumOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "lucas-numbers",
+      "fibonacci",
+      "recurrence",
+      "telescoping",
+      "induction",
+      "finite-sums",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{k ∈ range (n+1)} f k = (∑_{k ∈ range n} f k) + f n — peels the new term in each induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n+2) = fib n + fib (n+1) — the Fibonacci recurrence used for ∑ F_k² and the bridge",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.twoStepInduction",
+        "description": "Two-step (second-order) induction principle matching the Lucas/Fibonacci recurrence",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "lucas_sq_sum: the squared Lucas partial sum ∑_{k=0}^{n} L_k² = L_n·L_{n+1} + 2",
+      "weighted_lucas_sum_add / weighted_lucas_sum: the weighted (first-moment) sum ∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4, via its subtraction-free form",
+      "fib_sq_sum: the classical Fibonacci companion ∑_{k=0}^{n} F_k² = F_n·F_{n+1}, filling a Mathlib gap",
+      "lucas_sq_sum_fib: the bridge factorisation ∑_{k=0}^{n+1} L_k² = (F_n+F_{n+2})·(F_{n+1}+F_{n+3}) + 2 via L_{m+1} = F_m + F_{m+2}"
+    ],
+    "axiomCount": 0,
+    "lineCount": 176,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for lucas_sq_sum, weighted_lucas_sum, fib_sq_sum, and lucas_sq_sum_fib, and [propext, Quot.sound] for lucas_succ_eq_fib_add_fib. The three `theorem` sanity checks (∑_{k<4} L_k² = 30, ∑_{k<4} k·L_k = 19, ∑_{k<5} F_k² = 15) use kernel `decide`, not `native_decide`. Compiled against Mathlib v4.26.0. The identities are elementary/classical; Mathlib has no packaged Lucas partial-sum or Fibonacci square-sum lemma, so the Lucas sequence is defined locally and bridged to Nat.fib.",
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "prerequisites": [
+      "Second-order linear recurrences and Lucas/Fibonacci initial data",
+      "Finite sums over Finset.range with Finset.sum_range_succ",
+      "ℕ truncated subtraction, ring over ℕ, and omega over opaque atoms",
+      "Nat.fib, Nat.fib_add_two, and Nat.twoStepInduction"
+    ],
+    "relatedProblems": [
+      "lucas-sum-oq-01",
+      "fibonacci-identities",
+      "factorial-telescoping-sum-oq-01"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of `lucas-sum-oq-01`:

> Derive a Lucas analogue of ∑ k·F_k or ∑ F_k² and relate it to the Fibonacci versions through the bridge L_{n+1} = F_n + F_{n+2}.

New gallery entry `lucas-sum-oq-01-oq-02` over the self-contained Lucas sequence `L_0=2, L_1=1, L_{n+2}=L_n+L_{n+1}`:

| Theorem | Statement |
|---|---|
| `lucas_sq_sum` | ∑_{k=0}^{n} L_k² = L_n·L_{n+1} + 2 |
| `weighted_lucas_sum` | ∑_{k=0}^{n} k·L_k = n·L_{n+2} − L_{n+3} + 4 (via subtraction-free `(∑)+L_{n+3} = n·L_{n+2}+4`) |
| `fib_sq_sum` | ∑_{k=0}^{n} F_k² = F_n·F_{n+1} (classical companion; not packaged in Mathlib) |
| `lucas_succ_eq_fib_add_fib` | the bridge L_{n+1} = F_n + F_{n+2} |
| `lucas_sq_sum_fib` | ∑_{k=0}^{n+1} L_k² = (F_n+F_{n+2})·(F_{n+1}+F_{n+3}) + 2 |

## Method

Each closed form is a one-step induction driven by the recurrence: `Finset.sum_range_succ` peels the new term, then `ring` (squared sums) or `omega` (weighted sum, after distributing products across the recurrence) closes the step. The additive constants +2 and +4 are the Lucas boundary data. The parent's two-step-induction bridge is substituted term-by-term to factor the Lucas square-sum into Fibonacci form.

## Verification

- **12 theorems, 1 definition, 176 lines, 0 sorries, 0 axioms, no `native_decide`.**
- `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for `lucas_sq_sum`, `weighted_lucas_sum`, `fib_sq_sum`, `lucas_sq_sum_fib`, and `[propext, Quot.sound]` for the bridge.
- The three sanity `theorem`s use kernel `decide` (not `native_decide`).
- Compiled clean via `lake env lean Proofs/LucasSumOQ01OQ02.lean` (exit 0) against Mathlib v4.26.0.
- Annotations validated: 8/8 valid, 0 misaligned.

## ⚠️ Infra note

During this session the **host disk hit 100% full** (~44 GB of non-lean-genius `vibesql_tcl_securedel2_*-checkpoints` dirs in `/private/tmp`), which corrupted the shared Mathlib olean cache and the Docker daemon metadata, causing intermittent `139`/`invalid header` build failures for all agents. Verification above was obtained in a clean window; a full `docker-build.sh` currently fails on Mathlib rebuild due to the disk state. Someone with authority may want to reclaim that space.

Closes the second open question of `lucas-sum-oq-01`.