### PR TITLE
research(four-square-distribution-oq-06-oq-02): multiplicativity of Jacobi's σ* + assembled closed form [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ06OQ02.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ06OQ02.lean
@@ -1,0 +1,245 @@
+import Mathlib
+
+/-
+# Multiplicativity of Jacobi's σ* and the assembled closed form (OQ-06-OQ-02)
+
+## Open Question (follow-up to `four-square-distribution-oq-06`)
+
+The parent `four-square-distribution-oq-06` computed Jacobi's modified divisor
+sum
+
+  σ*(n) = Σ_{d | n, 4 ∤ d} d
+
+on individual prime powers, and its child OQ-06-OQ-01 assembled the local values
+`σ*(2ᵃ·m) = 3·σ(m)` (a ≥ 1) and `σ*(n) = σ(n)` (4 ∤ n) by a hands-on divisor-sum
+computation. The parent's stated open target, however, was the *structural*
+reason those local pieces fit together into one formula:
+
+> Writing `n = 2ᵏ·m` with `m` odd, **multiplicativity of σ*** should give
+> `σ*(n) = 3·σ(m)` for `k ≥ 1` and `σ*(n) = σ(m)` for `k = 0`; formalizing the
+> multiplicativity of σ* would close the gap between the prime-power values and
+> arbitrary `n`.
+
+This entry proves exactly that multiplicativity — `σ*` **is a multiplicative
+arithmetic function** — and then re-derives the assembled closed form as a clean
+one-line corollary, replacing OQ-06-OQ-01's bespoke `ℕ`-subtraction argument.
+
+## What this provides
+
+* `weightedId` — the arithmetic function `g(d) = [4 ∤ d]·d` (the summand of σ*),
+  packaged as a `Mathlib` `ArithmeticFunction ℕ`.
+
+* `weightedId_isMultiplicative` — the heart: `g` is multiplicative,
+  `g(m·n) = g(m)·g(n)` for coprime `m, n`. The only content is the divisor
+  fact `4 ∤ m·n ⟸ 4 ∤ m ∧ 4 ∤ n` for coprime arguments (a factor `2` can live
+  in only one of them, so a factor `4` is confined to one side).
+
+* `sigmaStar_eq_zeta_mul` — `σ* = ζ ⋆ g` as a Dirichlet convolution, exhibiting
+  σ* as the divisor-summatory function of `g`.
+
+* `sigmaStar_isMultiplicative` / `sigmaStar_mul_coprime` — the **headline
+  result**: `σ*` is multiplicative, so `σ*(m·n) = σ*(m)·σ*(n)` whenever
+  `gcd(m, n) = 1`. This is the parent's open target.
+
+* `sigmaStar_two_pow` — `σ*(2ᵏ) = 1` for `k = 0` and `= 3` for `k ≥ 1` (only the
+  divisors `1, 2` escape being multiples of `4`).
+
+* `sigmaStar_assembled` — the parent's assembled formula, *derived from
+  multiplicativity*: for `m` odd, `σ*(2ᵏ·m) = (if k = 0 then 1 else 3)·σ(m)`.
+
+## Honest scope
+
+As in the parent family, `jacobiR4` is *defined* as `8·σ*`; nothing here touches
+the genuinely open geometric identity `r₄(n) = #{(a,b,c,d) : Σ = n}` (which needs
+the q-expansion of `jacobiTheta⁴`). The contribution is the structural
+multiplicativity of the arithmetic side, fully machine-checked and 0-axiom.
+-/
+
+namespace FourSquareDistributionOQ06OQ02
+
+open Finset Nat ArithmeticFunction
+open scoped ArithmeticFunction.zeta
+
+/-- Jacobi's modified divisor sum `σ*(n) = Σ_{d | n, 4 ∤ d} d`
+    (same definition as the parent family, restated for standalone checking). -/
+def sigmaStar (n : ℕ) : ℕ :=
+  ∑ d ∈ n.divisors, if 4 ∣ d then 0 else d
+
+/-- The summand of `σ*`, as an arithmetic function: `g(d) = [4 ∤ d]·d`.
+    `g 0 = 0` because `4 ∣ 0`, so this is a genuine `ArithmeticFunction`. -/
+def weightedId : ArithmeticFunction ℕ :=
+  ⟨fun d => if 4 ∣ d then 0 else d, by simp⟩
+
+@[simp] theorem weightedId_apply (d : ℕ) :
+    weightedId d = if 4 ∣ d then 0 else d := rfl
+
+-- =====================================================================
+-- PART 1: `g` is multiplicative
+-- =====================================================================
+
+/-- Coprimality confines a factor of `4` to one side: if `gcd(m, n) = 1`, then
+    `4 ∣ m·n` forces `4 ∣ m` or `4 ∣ n`. (A factor `2` can divide at most one of
+    two coprime numbers, so the two factors of `2` in `4` cannot be split.) -/
+theorem four_dvd_mul_of_coprime {m n : ℕ} (hmn : Nat.Coprime m n)
+    (h4 : 4 ∣ m * n) : 4 ∣ m ∨ 4 ∣ n := by
+  by_cases h2m : 2 ∣ m
+  · -- 2 ∣ m ⇒ (coprime) 2 ∤ n ⇒ Coprime 4 n ⇒ 4 ∣ m
+    have h2n : ¬ 2 ∣ n := by
+      intro h2n
+      have hd : (2 : ℕ) ∣ Nat.gcd m n := Nat.dvd_gcd h2m h2n
+      rw [Nat.Coprime] at hmn
+      rw [hmn] at hd
+      have := Nat.le_of_dvd (by norm_num) hd
+      omega
+    have hc4n : Nat.Coprime 4 n := by
+      have hc2n : Nat.Coprime 2 n := (Nat.prime_two.coprime_iff_not_dvd).mpr h2n
+      simpa [show (4 : ℕ) = 2 ^ 2 from rfl] using hc2n.pow_left 2
+    exact Or.inl (hc4n.dvd_of_dvd_mul_right h4)
+  · -- 2 ∤ m ⇒ Coprime 4 m ⇒ 4 ∣ n
+    have hc4m : Nat.Coprime 4 m := by
+      have hc2m : Nat.Coprime 2 m := (Nat.prime_two.coprime_iff_not_dvd).mpr h2m
+      simpa [show (4 : ℕ) = 2 ^ 2 from rfl] using hc2m.pow_left 2
+    exact Or.inr (hc4m.dvd_of_dvd_mul_left h4)
+
+/-- **The summand is multiplicative.** `g(d) = [4 ∤ d]·d` satisfies
+    `g 1 = 1` and `g(m·n) = g(m)·g(n)` for coprime `m, n`. -/
+theorem weightedId_isMultiplicative : weightedId.IsMultiplicative := by
+  refine ⟨by simp, ?_⟩
+  intro m n hmn
+  simp only [weightedId_apply]
+  by_cases hm : 4 ∣ m
+  · rw [if_pos hm, zero_mul, if_pos (hm.mul_right n)]
+  · by_cases hn : 4 ∣ n
+    · rw [if_pos hn, mul_zero, if_pos (hn.mul_left m)]
+    · rw [if_neg hm, if_neg hn, if_neg ?_]
+      intro h4
+      rcases four_dvd_mul_of_coprime hmn h4 with h | h
+      · exact hm h
+      · exact hn h
+
+-- =====================================================================
+-- PART 2: σ* = ζ ⋆ g, hence σ* is multiplicative
+-- =====================================================================
+
+/-- `σ*` is the divisor-summatory function of `g`, i.e. the Dirichlet
+    convolution `ζ ⋆ g`. -/
+theorem sigmaStar_eq_zeta_mul (n : ℕ) : sigmaStar n = (ζ * weightedId) n := by
+  rw [zeta_mul_apply]
+  simp only [sigmaStar, weightedId_apply]
+
+/-- **Headline result.** Jacobi's modified divisor sum `σ*` is a multiplicative
+    arithmetic function: it is `ζ ⋆ g` with both factors multiplicative. -/
+theorem sigmaStar_isMultiplicative : (ζ * weightedId).IsMultiplicative :=
+  isMultiplicative_zeta.mul weightedId_isMultiplicative
+
+/-- **Multiplicativity of σ*** (the parent's open target): for coprime `m, n`,
+
+      σ*(m·n) = σ*(m) · σ*(n). -/
+theorem sigmaStar_mul_coprime {m n : ℕ} (hmn : Nat.Coprime m n) :
+    sigmaStar (m * n) = sigmaStar m * sigmaStar n := by
+  rw [sigmaStar_eq_zeta_mul, sigmaStar_eq_zeta_mul, sigmaStar_eq_zeta_mul]
+  exact sigmaStar_isMultiplicative.2 hmn
+
+-- =====================================================================
+-- PART 3: local values, and the assembled closed form via multiplicativity
+-- =====================================================================
+
+/-- On numbers with `4 ∤ n`, `σ*` is the ordinary sum-of-divisors `σ`. In
+    particular this covers all odd `n`. -/
+theorem sigmaStar_eq_sigma_of_not_four_dvd {n : ℕ} (hn : ¬ 4 ∣ n) :
+    sigmaStar n = ∑ d ∈ n.divisors, d := by
+  unfold sigmaStar
+  refine Finset.sum_congr rfl ?_
+  intro d hd
+  rw [if_neg]
+  exact fun h4 => hn (dvd_trans h4 (Nat.dvd_of_mem_divisors hd))
+
+/-- `σ*(1) = 1`. -/
+@[simp] theorem sigmaStar_one : sigmaStar 1 = 1 := by decide
+
+/-- Power-of-two values: `σ*(2ᵏ⁺¹) = 3` — only the divisors `1` and `2` of `2ᵏ⁺¹`
+    escape being multiples of `4`. Proved by induction: passing from `2ᵏ⁺¹` to
+    `2ᵏ⁺²` adjoins the divisor `2ᵏ⁺²`, a multiple of `4`, contributing `0`. -/
+theorem sigmaStar_two_pow_succ (k : ℕ) : sigmaStar (2 ^ (k + 1)) = 3 := by
+  have key : ∀ a, sigmaStar (2 ^ a)
+      = ∑ i ∈ Finset.range (a + 1), weightedId (2 ^ i) := by
+    intro a
+    rw [sigmaStar_eq_zeta_mul, zeta_mul_apply, Nat.divisors_prime_pow Nat.prime_two,
+        Finset.sum_map]
+    simp only [Function.Embedding.coeFn_mk]
+  induction k with
+  | zero => decide
+  | succ j ih =>
+    rw [key] at ih ⊢
+    rw [Finset.sum_range_succ]
+    have htop : weightedId (2 ^ (j + 1 + 1)) = 0 := by
+      simp only [weightedId_apply]
+      rw [if_pos]
+      exact ⟨2 ^ j, by ring⟩
+    rw [htop, add_zero]
+    exact ih
+
+/-- Uniform statement of the power-of-two values: `σ*(2ᵏ) = if k = 0 then 1 else 3`. -/
+theorem sigmaStar_two_pow (k : ℕ) :
+    sigmaStar (2 ^ k) = if k = 0 then 1 else 3 := by
+  cases k with
+  | zero => simp
+  | succ j => simp [sigmaStar_two_pow_succ j]
+
+/-- **Assembled closed form, derived from multiplicativity.** Writing
+    `n = 2ᵏ·m` with `m` odd,
+
+      σ*(2ᵏ·m) = (if k = 0 then 1 else 3) · σ(m).
+
+    Contrast OQ-06-OQ-01, which proved this by a direct truncated-subtraction
+    computation; here it is a one-line consequence of `sigmaStar_mul_coprime`
+    together with the two local values `σ*(2ᵏ)` and `σ*(m) = σ(m)`. -/
+theorem sigmaStar_assembled {m : ℕ} (hm : Odd m) (k : ℕ) :
+    sigmaStar (2 ^ k * m) = (if k = 0 then 1 else 3) * ∑ d ∈ m.divisors, d := by
+  have hcop : Nat.Coprime (2 ^ k) m := by
+    have hc2 : Nat.Coprime 2 m :=
+      (Nat.prime_two.coprime_iff_not_dvd).mpr (by
+        rw [Nat.two_dvd_ne_zero]; exact Nat.odd_iff.mp hm)
+    exact hc2.pow_left k
+  have hmnot : ¬ (4 : ℕ) ∣ m := by
+    have hm2 : m % 2 = 1 := Nat.odd_iff.mp hm
+    omega
+  rw [sigmaStar_mul_coprime hcop, sigmaStar_two_pow,
+      sigmaStar_eq_sigma_of_not_four_dvd hmnot]
+
+-- =====================================================================
+-- PART 4: Jacobi's r₄ prediction, and sanity instances
+-- =====================================================================
+
+/-- Jacobi's prediction `r₄(n) = 8·σ*(n)`. -/
+def jacobiR4 (n : ℕ) : ℕ := 8 * sigmaStar n
+
+/-- For even arguments `n = 2ᵏ·m` (`m` odd, `k ≥ 1`), Jacobi's prediction depends
+    only on the odd part: `r₄(2ᵏ·m) = 24·σ(m)` — now via multiplicativity. -/
+theorem jacobiR4_two_pow_mul_odd {m : ℕ} (hm : Odd m) {k : ℕ} (hk : 1 ≤ k) :
+    jacobiR4 (2 ^ k * m) = 24 * ∑ d ∈ m.divisors, d := by
+  unfold jacobiR4
+  rw [sigmaStar_assembled hm k, if_neg (by omega : ¬ k = 0)]
+  ring
+
+/-- `σ*(12) = 3·σ(3) = 12`, as the `k = 2, m = 3` instance of the assembled form. -/
+theorem sigmaStar_twelve : sigmaStar 12 = 12 := by
+  have h := sigmaStar_assembled (show Odd 3 by decide) 2
+  norm_num [show ∑ d ∈ (3 : ℕ).divisors, d = 4 from by decide] at h
+  simpa using h
+
+/-- `r₄(12) = 24·σ(3) = 96`, recovered from the assembled form. -/
+theorem jacobiR4_twelve : jacobiR4 12 = 96 := by
+  unfold jacobiR4
+  rw [sigmaStar_twelve]
+
+/-- Multiplicativity in action: `σ*(45) = σ*(9)·σ*(5) = 13·6 = 78` (`45 = 9·5`,
+    both odd, so `σ* = σ` on each). -/
+theorem sigmaStar_fortyfive : sigmaStar 45 = 78 := by
+  have h : sigmaStar (9 * 5) = sigmaStar 9 * sigmaStar 5 :=
+    sigmaStar_mul_coprime (by decide)
+  norm_num at h
+  rw [h]
+  decide
+
+end FourSquareDistributionOQ06OQ02

--- a/src/data/proofs/four-square-distribution-oq-06-oq-02/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-06-oq-02/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "four-square-distribution-oq-06-oq-02",
+  "slug": "four-square-distribution-oq-06-oq-02",
+  "title": "Multiplicativity of Jacobi's σ* and the assembled closed form σ*(2ᵏ·m) = (1 or 3)·σ(m)",
+  "description": "The parent four-square-distribution-oq-06 computed Jacobi's modified divisor sum σ*(n) = Σ_{d∣n, 4∤d} d on individual prime powers, and its sibling OQ-06-OQ-01 assembled the local values σ*(2ᵃ·m)=3σ(m) (a≥1) and σ*(n)=σ(n) (4∤n) by a hands-on ℕ-subtraction computation. The parent's explicitly stated open target was the structural reason those pieces cohere: multiplicativity of σ*. This entry proves exactly that. Packaging the summand as an ArithmeticFunction weightedId d = [4∤d]·d, the crux is that g is multiplicative — g(m·n)=g(m)g(n) for coprime m,n — which reduces to the divisor fact that a factor of 4 cannot be split across two coprime numbers (a single factor of 2 lives in only one of them). Since σ* = ζ ⋆ g is then a Dirichlet convolution of two multiplicative functions, σ* is multiplicative: σ*(m·n)=σ*(m)·σ*(n) whenever gcd(m,n)=1. The assembled closed form σ*(2ᵏ·m) = (if k=0 then 1 else 3)·σ(m) for odd m is re-derived as a one-line corollary from multiplicativity together with σ*(2ᵏ)∈{1,3} and σ*(m)=σ(m). Honest scope: jacobiR4 is defined as 8·σ*; this is the arithmetic side, not the geometric identity r₄(n)=#{(a,b,c,d):Σ=n}.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FourSquareDistributionOQ06OQ02.lean",
+    "tags": [
+      "number-theory",
+      "sum-of-squares",
+      "jacobi",
+      "four-squares",
+      "arithmetic-function",
+      "multiplicative-function",
+      "dirichlet-convolution",
+      "divisor-function",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked with only Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound); no native_decide, so no Lean.ofReduceBool. Verified via #print axioms on sigmaStar_mul_coprime, sigmaStar_assembled, and weightedId_isMultiplicative. Uses Mathlib's ArithmeticFunction framework (ζ, IsMultiplicative, IsMultiplicative.mul, isMultiplicative_zeta, zeta_mul_apply).",
+    "dateAdded": "2026-07-02",
+    "lineCount": 245,
+    "theoremCount": 13,
+    "substantiveTheoremCount": 9,
+    "definitionCount": 3,
+    "originalContributions": [
+      "weightedId_isMultiplicative (PROVED): the summand g(d) = [4∤d]·d is a multiplicative arithmetic function. The content is four_dvd_mul_of_coprime — for coprime m,n, 4∣m·n forces 4∣m or 4∣n — proved by observing a factor of 2 divides at most one of two coprime numbers, so Coprime 4 (odd side) lets Coprime.dvd_of_dvd_mul push the whole 4 onto one factor.",
+      "sigmaStar_eq_zeta_mul (PROVED): σ* is the divisor-summatory function of g, i.e. the Dirichlet convolution ζ ⋆ g (via Mathlib's zeta_mul_apply).",
+      "sigmaStar_isMultiplicative / sigmaStar_mul_coprime (PROVED): the HEADLINE — σ* is multiplicative (isMultiplicative_zeta.mul weightedId_isMultiplicative), so σ*(m·n)=σ*(m)·σ*(n) for gcd(m,n)=1. This is the parent OQ-06's explicitly stated open target.",
+      "sigmaStar_two_pow (PROVED): σ*(2ᵏ) = 1 for k=0 and 3 for k≥1 — only the divisors 1 and 2 of 2ᵏ escape being multiples of 4 (induction: adjoining the divisor 2ᵏ⁺¹ ≥ 4 contributes 0).",
+      "sigmaStar_assembled (PROVED): the assembled closed form σ*(2ᵏ·m) = (if k=0 then 1 else 3)·σ(m) for odd m, derived in one line from multiplicativity + the two local values — replacing OQ-06-OQ-01's bespoke truncated-subtraction argument with the structural reason.",
+      "jacobiR4_two_pow_mul_odd (PROVED): r₄(2ᵏ·m) = 24·σ(m) for odd m and k≥1, propagated through jacobiR4 = 8·σ*.",
+      "sigmaStar_twelve / jacobiR4_twelve / sigmaStar_fortyfive (PROVED): numeric instances, including σ*(45)=σ*(9)·σ*(5)=13·6=78 as a direct display of multiplicativity, all native_decide-free."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.IsMultiplicative / IsMultiplicative.mul",
+        "description": "The multiplicativity predicate f 1 = 1 ∧ (∀ coprime m n, f(m·n)=f m · f n) and the fact that a Dirichlet convolution of two multiplicative functions is multiplicative — the engine that turns g multiplicative into σ* = ζ ⋆ g multiplicative."
+      },
+      {
+        "theorem": "ArithmeticFunction.isMultiplicative_zeta",
+        "description": "The zeta arithmetic function ζ is multiplicative; combined with weightedId_isMultiplicative via .mul."
+      },
+      {
+        "theorem": "ArithmeticFunction.zeta_mul_apply",
+        "description": "(ζ * f) x = Σ_{i∣x} f i — identifies σ* with the divisor-summatory function ζ ⋆ g."
+      },
+      {
+        "theorem": "Nat.Coprime.dvd_of_dvd_mul_right / dvd_of_dvd_mul_left",
+        "description": "For Coprime k n, k ∣ m·n → k ∣ m (and the left version): the mechanism pushing the whole factor 4 onto one coprime factor."
+      },
+      {
+        "theorem": "Nat.divisors_prime_pow",
+        "description": "divisors(2ᵏ) = (range (k+1)).map (2 ^ ·) — turns σ*(2ᵏ) into a sum over exponents for the power-of-two induction."
+      }
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Definitions",
+      "startLine": 1,
+      "endLine": 75,
+      "summary": "Docstring stating OQ-06-OQ-02 and quoting the parent's open target (multiplicativity of σ* to close the gap between prime-power values and arbitrary n). Defines sigmaStar n = Σ_{d∣n, 4∤d} d and packages the summand as an ArithmeticFunction weightedId d = if 4∣d then 0 else d (weightedId 0 = 0 since 4∣0).",
+      "mathContext": "σ*(n) = Σ_{d∣n} g(d) with g(d) = [4∤d]·d, the summand seen as an arithmetic function."
+    },
+    {
+      "id": "sec-summand-multiplicative",
+      "title": "The Summand g Is Multiplicative",
+      "startLine": 76,
+      "endLine": 119,
+      "summary": "four_dvd_mul_of_coprime: for coprime m,n, 4∣m·n → 4∣m ∨ 4∣n (a factor 2 divides at most one of two coprime numbers, so Coprime 4 to the odd side and Coprime.dvd_of_dvd_mul confine the 4). weightedId_isMultiplicative: g 1 = 1 and g(m·n)=g(m)g(n) for coprime m,n, by case analysis on 4∣m, 4∣n.",
+      "mathContext": "g(d)=[4∤d]·d is multiplicative because 4∤m·n ⟺ 4∤m ∧ 4∤n for coprime m,n."
+    },
+    {
+      "id": "sec-sigmastar-multiplicative",
+      "title": "σ* = ζ ⋆ g Is Multiplicative",
+      "startLine": 120,
+      "endLine": 142,
+      "summary": "sigmaStar_eq_zeta_mul: σ*(n) = (ζ * weightedId) n via zeta_mul_apply. sigmaStar_isMultiplicative: (ζ * g) is multiplicative by isMultiplicative_zeta.mul. sigmaStar_mul_coprime: the headline σ*(m·n)=σ*(m)·σ*(n) for gcd(m,n)=1.",
+      "mathContext": "A Dirichlet convolution of multiplicative functions is multiplicative; σ* = ζ ⋆ g inherits it."
+    },
+    {
+      "id": "sec-closed-form",
+      "title": "Local Values and the Assembled Closed Form",
+      "startLine": 143,
+      "endLine": 209,
+      "summary": "sigmaStar_eq_sigma_of_not_four_dvd: σ*(n)=σ(n) when 4∤n (covers all odd n). sigmaStar_two_pow: σ*(2ᵏ) = 1 (k=0) or 3 (k≥1), by induction adjoining the multiple-of-4 divisor 2ᵏ⁺¹. sigmaStar_assembled: σ*(2ᵏ·m) = (if k=0 then 1 else 3)·σ(m) for odd m, a one-line corollary of multiplicativity.",
+      "mathContext": "σ*(2ᵏ·m) = σ*(2ᵏ)·σ*(m) with σ*(2ᵏ)∈{1,3} and σ*(m)=σ(m) on the odd part."
+    },
+    {
+      "id": "sec-jacobi-instances",
+      "title": "Jacobi's r₄ Prediction and Numeric Instances",
+      "startLine": 210,
+      "endLine": 245,
+      "summary": "jacobiR4 n = 8·σ*(n); jacobiR4_two_pow_mul_odd: r₄(2ᵏ·m)=24·σ(m) for odd m, k≥1. Numeric instances σ*(12)=12, r₄(12)=96, and σ*(45)=σ*(9)·σ*(5)=78 — the last displaying multiplicativity directly — all native_decide-free.",
+      "mathContext": "jacobiR4 = 8·σ* propagates the closed forms; σ*(45)=13·6 shows multiplicativity in action."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sigmaStar_mul_coprime",
+      "type": "theorem",
+      "description": "Multiplicativity of Jacobi's modified divisor sum: σ*(m·n) = σ*(m)·σ*(n) for coprime m, n. The parent OQ-06's stated open target.",
+      "leanType": "{m n : ℕ} → Nat.Coprime m n → sigmaStar (m * n) = sigmaStar m * sigmaStar n"
+    },
+    {
+      "name": "weightedId_isMultiplicative",
+      "type": "theorem",
+      "description": "The summand g(d) = [4∤d]·d is a multiplicative arithmetic function.",
+      "leanType": "weightedId.IsMultiplicative"
+    },
+    {
+      "name": "sigmaStar_assembled",
+      "type": "theorem",
+      "description": "Assembled closed form via multiplicativity: for odd m, σ*(2ᵏ·m) = (if k = 0 then 1 else 3)·σ(m).",
+      "leanType": "{m : ℕ} → Odd m → (k : ℕ) → sigmaStar (2 ^ k * m) = (if k = 0 then 1 else 3) * ∑ d ∈ m.divisors, d"
+    },
+    {
+      "name": "sigmaStar_two_pow",
+      "type": "theorem",
+      "description": "Power-of-two values of σ*: 1 for k = 0, else 3 — only the divisors 1 and 2 escape being multiples of 4.",
+      "leanType": "(k : ℕ) → sigmaStar (2 ^ k) = if k = 0 then 1 else 3"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Jacobi's four-square theorem writes the representation count r₄(n) = #{(a,b,c,d) ∈ ℤ⁴ : a²+b²+c²+d² = n} as 8·σ*(n), where σ*(n) = Σ_{d∣n, 4∤d} d is the sum of divisors not divisible by 4. That σ* is a multiplicative arithmetic function is the structural fact that lets one compute it from its prime-power values; classically it follows because σ* is the Dirichlet convolution of the (completely multiplicative on coprime arguments) summand [4∤d]·d with the constant function 1. The parent OQ-06 computed σ* only on prime powers and flagged the multiplicativity as the missing piece needed to reach arbitrary n.",
+    "problemStatement": "**OQ-06-OQ-02 of four-square-distribution**\n\nWriting n = 2ᵏ·m with m odd, multiplicativity of σ* should give σ*(n) = 3·σ(m) for k ≥ 1 and σ*(n) = σ(m) for k = 0; formalize the multiplicativity of σ* to close the gap between the prime-power values and arbitrary n.",
+    "text": "Package the summand as an arithmetic function g(d) = [4∤d]·d. Then σ* = ζ ⋆ g. Prove g is multiplicative (the only content: 4∣m·n ⟺ 4∣m ∨ 4∣n for coprime m,n), whence σ* is multiplicative as a convolution of multiplicative functions. Re-derive σ*(2ᵏ·m) = (if k=0 then 1 else 3)·σ(m) for odd m in one line.",
+    "proofStrategy": "weightedId d = if 4∣d then 0 else d is an ArithmeticFunction (weightedId 0 = 0 since 4∣0). The key lemma four_dvd_mul_of_coprime splits on 2∣m: if 2∣m then coprimality gives 2∤n, hence Coprime 4 n (= 2² coprime to n), and Coprime.dvd_of_dvd_mul_right forces 4∣m; symmetrically if 2∤m then Coprime 4 m forces 4∣n. This yields g(m·n)=g(m)g(n) for coprime m,n by cases on 4∣m and 4∣n. Since σ*(n) = Σ_{d∣n} g(d) = (ζ * g)(n) (zeta_mul_apply) and both ζ and g are multiplicative, IsMultiplicative.mul gives σ* multiplicative. The power-of-two value σ*(2ᵏ)=3 (k≥1) is an induction over exponents (divisors_prime_pow) where the new top divisor 2ᵏ⁺¹ is a multiple of 4 and contributes 0; σ*(2⁰)=1. Combining with σ*(m)=σ(m) for odd m (no divisor of an odd number is a multiple of 4) and multiplicativity of the coprime factors 2ᵏ and m gives the assembled formula.",
+    "keyInsights": [
+      "Multiplicativity of σ* is not an accident of the '4' but a convolution phenomenon: σ* = ζ ⋆ g where g(d)=[4∤d]·d, and Dirichlet convolution preserves multiplicativity. Mathlib's ArithmeticFunction API (IsMultiplicative.mul, zeta_mul_apply) does the bookkeeping.",
+      "The entire arithmetic content collapses to one divisor fact: for coprime m,n a factor of 4 cannot be split, because a single factor of 2 lives in only one of two coprime numbers. Formally, whichever of m,n is odd is coprime to 4, so Coprime.dvd_of_dvd_mul pushes the whole 4 onto the other.",
+      "Given multiplicativity, the parent's assembled formula becomes a one-liner: σ*(2ᵏ·m) = σ*(2ᵏ)·σ*(m) with σ*(2ᵏ)∈{1,3} and σ*(m)=σ(m). This replaces OQ-06-OQ-01's hand-rolled truncated-subtraction computation with the structural reason it holds.",
+      "Working through Mathlib's ArithmeticFunction rather than raw Finset sums keeps the proof native_decide-free and 0-axiom, so the numeric instances (σ*(45)=78 via σ*(9)·σ*(5)) are genuine consequences of theorems proved for all coprime arguments."
+    ],
+    "prerequisites": [
+      "Jacobi's four-square formula r₄(n) = 8·σ*(n) and the modified divisor sum σ*(n) = Σ_{d∣n, 4∤d} d",
+      "Mathlib's ArithmeticFunction framework: the zeta function ζ, IsMultiplicative, IsMultiplicative.mul, zeta_mul_apply, and Nat.Coprime.dvd_of_dvd_mul"
+    ]
+  },
+  "conclusion": {
+    "summary": "Machine-verified, native_decide-free, 0-axiom proof that Jacobi's modified divisor sum σ*(n) = Σ_{d∣n, 4∤d} d is a multiplicative arithmetic function: σ*(m·n) = σ*(m)·σ*(n) for coprime m,n. Realized as the Dirichlet convolution σ* = ζ ⋆ g of the multiplicative summand g(d)=[4∤d]·d with ζ. The assembled closed form σ*(2ᵏ·m) = (if k=0 then 1 else 3)·σ(m) for odd m follows as a one-line corollary, and r₄(2ᵏ·m)=24·σ(m) (k≥1) via jacobiR4 = 8·σ*. Numeric instances σ*(12)=12, r₄(12)=96, σ*(45)=78 recovered as consequences.",
+    "implications": "Answers the parent OQ-06's explicitly stated open target — multiplicativity of σ* — and thereby closes the gap between its prime-power values and arbitrary n, giving a uniform, structural derivation of the assembled formula that OQ-06-OQ-01 proved by direct computation. The full geometric four-square identity r₄(n) = #{(a,b,c,d) : Σ = n} remains the open direction (it needs the q-expansion of jacobiTheta⁴); only the arithmetic side is treated here.",
+    "openQuestions": [
+      "With multiplicativity in hand, assemble σ* at every n from its prime-power factors σ*(2ᵏ) and σ*(pᵏ) = 1 + p + ⋯ + pᵏ (odd p), giving σ*(n) = 3^{[2∣n]}·σ(odd part of n) as a single evaluated formula, and package σ* itself as a named ArithmeticFunction with IsMultiplicative for reuse.",
+      "Transport the same convolution argument to the sibling arithmetic sides: chiSum (OQ-06-OQ-03, r₂) is multiplicative because χ₄ is completely multiplicative, and the modified divisor sums behind r₆, r₈ admit analogous ζ ⋆ g factorizations."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "four-square-distribution-oq-06",
+      "relationship": "parent",
+      "description": "Computed σ* on prime powers and stated multiplicativity of σ* as the open target needed to reach arbitrary n. This entry proves that multiplicativity and re-derives the assembled formula from it."
+    },
+    {
+      "targetId": "four-square-distribution-oq-06-oq-01",
+      "relationship": "sibling",
+      "description": "Proved the assembled formula σ*(2ᵃ·m)=3σ(m) (a≥1) and the bridge σ*(n)=σ(n)−4σ(n/4) by a direct ℕ-subtraction computation. This entry gives the structural reason via multiplicativity of σ* = ζ ⋆ g, reducing the assembled formula to a one-line corollary."
+    },
+    {
+      "targetId": "four-square-distribution-oq-06-oq-03",
+      "relationship": "sibling",
+      "description": "Computes the two-square arithmetic side chiSum = Σ χ₄(d) on prime powers and flags its multiplicativity as an open question; the same convolution technique used here (multiplicative summand ⋆ ζ) applies there."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Carl Gustav Jacob Jacobi",
+      "title": "Fundamenta nova theoriae functionum ellipticarum",
+      "year": "1829",
+      "venue": "Königsberg",
+      "note": "Source of the four-square formula r₄(n) = 8·σ*(n) with σ* the sum of divisors not divisible by 4."
+    },
+    {
+      "authors": "G. H. Hardy, E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed., §16.9–16.10, §17.10",
+      "note": "Multiplicative arithmetic functions, Dirichlet convolution, and the sum-of-squares divisor formulae."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **four-square-distribution-oq-06-oq-02**, answering the parent `four-square-distribution-oq-06`'s explicitly stated open target: **multiplicativity of Jacobi's modified divisor sum σ\***.

σ*(n) = Σ_{d∣n, 4∤d} d. Packaging the summand as an arithmetic function `g(d) = [4∤d]·d`, the entry proves:

- **`weightedId_isMultiplicative`** — `g` is multiplicative. The only content is `four_dvd_mul_of_coprime`: for coprime m,n, `4∣m·n → 4∣m ∨ 4∣n` (a factor of 2 lives in only one of two coprime numbers, so the whole 4 is confined to one side).
- **`sigmaStar_eq_zeta_mul`** — σ* = ζ ⋆ g as a Dirichlet convolution (`zeta_mul_apply`).
- **`sigmaStar_mul_coprime`** (headline) — σ*(m·n) = σ*(m)·σ*(n) for gcd(m,n)=1, via `isMultiplicative_zeta.mul`.
- **`sigmaStar_assembled`** — the parent's assembled formula σ*(2ᵏ·m) = (if k=0 then 1 else 3)·σ(m) for odd m, now a one-line corollary of multiplicativity (replacing OQ-06-OQ-01's bespoke ℕ-subtraction computation).
- `jacobiR4_two_pow_mul_odd`, and numeric instances σ*(12)=12, r₄(12)=96, σ*(45)=σ*(9)·σ*(5)=78.

## Verification

- **Status**: verified, **0 axioms** (propext / Classical.choice / Quot.sound only; **no** `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`).
- Confirmed via `lake env lean Proofs/FourSquareDistributionOQ06OQ02.lean` (clean) and `#print axioms` on `sigmaStar_mul_coprime`, `sigmaStar_assembled`, `weightedId_isMultiplicative`.
- 13 theorems, 3 defs, 245 lines.

## Honest scope

`jacobiR4` is *defined* as 8·σ*; this proves the arithmetic side only. The geometric identity r₄(n) = #{(a,b,c,d) : Σ = n} remains the open direction (needs the q-expansion of jacobiTheta⁴).

## Files

- `proofs/Proofs/FourSquareDistributionOQ06OQ02.lean` (new)
- `src/data/proofs/four-square-distribution-oq-06-oq-02/meta.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)