### PR TITLE
Enrich Symbolic prime-power r₂ values (four-square-distribution-oq-06-oq-03): add depth fields + coverage (6→8)

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-06-oq-03/annotations.json
+++ b/src/data/proofs/four-square-distribution-oq-06-oq-03/annotations.json
@@ -5,7 +5,35 @@
     "range": { "startLine": 6, "endLine": 63 },
     "type": "concept",
     "title": "The Two-Square Analogue of the Parent's r₄ / σ* Programme",
-    "content": "The header states OQ-06-OQ-03: whether the sibling sum-of-squares counts admit the same native_decide-free prime-power closed forms the parent OQ-06 gave for the four-square σ*. Here we treat the two-square count r₂, whose arithmetic side is Jacobi's classical formula r₂(n) = 4·Σ_{d∣n} χ₄(d), with χ₄ Mathlib's primitive quadratic character mod 4 (χ₄(d) = 0, 1, −1 as d is even, ≡ 1, ≡ 3 mod 4). Two definitions set the stage: `chiSum n = Σ_{d∣n} χ₄(↑d)` and `jacobiR2 n = 4·chiSum n`. The honest-scope note matters: jacobiR2 is *defined* as 4·Σχ₄(d), so these theorems compute the arithmetic side, not the geometric two-square theorem r₂(n) = #{(a,b) : a²+b²=n}."
+    "content": "The header states OQ-06-OQ-03: whether the sibling sum-of-squares counts admit the same native_decide-free prime-power closed forms the parent OQ-06 gave for the four-square σ*. Here we treat the two-square count r₂, whose arithmetic side is Jacobi's classical formula r₂(n) = 4·Σ_{d∣n} χ₄(d), with χ₄ Mathlib's primitive quadratic character mod 4 (χ₄(d) = 0, 1, −1 as d is even, ≡ 1, ≡ 3 mod 4). Two definitions set the stage: `chiSum n = Σ_{d∣n} χ₄(↑d)` and `jacobiR2 n = 4·chiSum n`. The honest-scope note matters: jacobiR2 is *defined* as 4·Σχ₄(d), so these theorems compute the arithmetic side, not the geometric two-square theorem r₂(n) = #{(a,b) : a²+b²=n}.",
+    "mathContext": "$r_2(n) = 4\\sum_{d\\mid n}\\chi_4(d)$, where $\\chi_4$ is the non-principal character mod 4: $\\chi_4(d)=0,1,-1$ as $d\\equiv 0,\\,1,\\,3\\pmod 4$.",
+    "significance": "context",
+    "relatedConcepts": ["sum of two squares", "Jacobi two-square theorem", "Dirichlet character mod 4", "divisor sums", "arithmetic functions"],
+    "prerequisites": ["Dirichlet characters", "divisor functions", "modular arithmetic"]
+  },
+  {
+    "id": "fsd0603-ann-defs",
+    "proofId": "four-square-distribution-oq-06-oq-03",
+    "range": { "startLine": 57, "endLine": 63 },
+    "type": "definition",
+    "title": "The Two Arithmetic Definitions: chiSum and jacobiR2",
+    "content": "chiSum n := Σ_{d ∈ n.divisors} χ₄(↑d) is the modified divisor sum over Mathlib's primitive quadratic character mod 4 (ZMod.χ₄), and jacobiR2 n := 4·chiSum n is Jacobi's predicted two-square count. Casting each natural divisor d into ZMod 4 before applying χ₄ is what lets the residue-mod-4 trichotomy drive every subsequent closed form. Keeping jacobiR2 a thin 4·chiSum wrapper means each r₂ theorem is a one-line propagation of the corresponding chiSum result.",
+    "mathContext": "$\\mathrm{chiSum}(n)=\\sum_{d\\mid n}\\chi_4(d)\\in\\mathbb{Z},\\qquad \\mathrm{jacobiR2}(n)=4\\cdot\\mathrm{chiSum}(n).$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative characters", "ZMod 4", "divisor sum", "quadratic character"],
+    "prerequisites": ["Finset.sum", "Nat.divisors", "ZMod"]
+  },
+  {
+    "id": "fsd0603-ann-base",
+    "proofId": "four-square-distribution-oq-06-oq-03",
+    "range": { "startLine": 69, "endLine": 73 },
+    "type": "theorem",
+    "title": "Base Value: chiSum 1 = 1",
+    "content": "chiSum_one anchors the whole family at n = 1: the sole divisor of 1 is 1 and χ₄(1) = 1, so the divisor sum is 1 and `simp [chiSum]` closes it. Correspondingly jacobiR2 1 = 4, matching r₂(1) = #{(±1,0),(0,±1)} = 4. This is the k = 0 boundary case shared by all three prime-power ramps (2⁰, p⁰) and confirms the normalization of χ₄.",
+    "mathContext": "$\\mathrm{chiSum}(1)=\\chi_4(1)=1$, so $\\mathrm{jacobiR2}(1)=4=r_2(1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["multiplicative identity", "boundary case", "character normalization"],
+    "prerequisites": ["Nat.divisors", "character values"]
   },
   {
     "id": "fsd0603-ann-two-pow",
@@ -13,7 +41,11 @@
     "range": { "startLine": 78, "endLine": 95 },
     "type": "theorem",
     "title": "Powers of 2: χ₄ Kills Every Divisor but 1",
-    "content": "chiSum_two_pow proves chiSum(2ᵏ) = 1 for all k. After `Nat.divisors_prime_pow` rewrites divisors(2ᵏ) as the image of {0,…,k} under i ↦ 2ⁱ, `Finset.sum_eq_single 0` isolates the surviving term: for i ≥ 1 the divisor 2ⁱ is even, so `χ₄_nat_eq_if_mod_four` (with 2ⁱ % 2 = 0 obtained from dvd_pow_self + omega) sends χ₄(2ⁱ) to 0, while χ₄(2⁰) = χ₄(1) = 1. Hence jacobiR2(2ᵏ) = 4."
+    "content": "chiSum_two_pow proves chiSum(2ᵏ) = 1 for all k. After `Nat.divisors_prime_pow` rewrites divisors(2ᵏ) as the image of {0,…,k} under i ↦ 2ⁱ, `Finset.sum_eq_single 0` isolates the surviving term: for i ≥ 1 the divisor 2ⁱ is even, so `χ₄_nat_eq_if_mod_four` (with 2ⁱ % 2 = 0 obtained from dvd_pow_self + omega) sends χ₄(2ⁱ) to 0, while χ₄(2⁰) = χ₄(1) = 1. Hence jacobiR2(2ᵏ) = 4.",
+    "mathContext": "$\\mathrm{chiSum}(2^k)=\\sum_{i=0}^{k}\\chi_4(2^i)=\\chi_4(1)=1$, since $\\chi_4(2^i)=0$ for $i\\ge 1$ (even).",
+    "significance": "key",
+    "relatedConcepts": ["prime power divisors", "even divisors", "vanishing character", "Finset.sum_eq_single"],
+    "prerequisites": ["Nat.divisors_prime_pow", "character mod 4", "divisibility"]
   },
   {
     "id": "fsd0603-ann-split-prime",
@@ -21,7 +53,11 @@
     "range": { "startLine": 101, "endLine": 113 },
     "type": "theorem",
     "title": "Split Primes p ≡ 1 (mod 4): the Full Ramp k+1",
-    "content": "chiSum_prime_pow_one_mod_four proves chiSum(pᵏ) = k+1. Complete multiplicativity of the character (`map_pow`, since MulChar is a MonoidHomClass) turns χ₄(pⁱ) into χ₄(p)ⁱ, and `χ₄_nat_one_mod_four` fixes χ₄(p) = 1, so every term of the divisor sum is 1ⁱ = 1; the sum over k+1 exponents is k+1. Thus jacobiR2(pᵏ) = 4(k+1) — a split prime contributes a full arithmetic ramp."
+    "content": "chiSum_prime_pow_one_mod_four proves chiSum(pᵏ) = k+1. Complete multiplicativity of the character (`map_pow`, since MulChar is a MonoidHomClass) turns χ₄(pⁱ) into χ₄(p)ⁱ, and `χ₄_nat_one_mod_four` fixes χ₄(p) = 1, so every term of the divisor sum is 1ⁱ = 1; the sum over k+1 exponents is k+1. Thus jacobiR2(pᵏ) = 4(k+1) — a split prime contributes a full arithmetic ramp.",
+    "mathContext": "$p\\equiv 1\\!\\!\\pmod 4\\Rightarrow\\chi_4(p)=1\\Rightarrow\\mathrm{chiSum}(p^k)=\\sum_{i=0}^{k}1=k+1.$",
+    "significance": "key",
+    "relatedConcepts": ["split primes", "completely multiplicative character", "Fermat two-square theorem", "geometric ramp"],
+    "prerequisites": ["multiplicative characters", "map_pow", "prime power divisors"]
   },
   {
     "id": "fsd0603-ann-inert-prime",
@@ -29,7 +65,11 @@
     "range": { "startLine": 119, "endLine": 135 },
     "type": "insight",
     "title": "Inert Primes p ≡ 3 (mod 4): a Parity Indicator",
-    "content": "chiSum_prime_pow_three_mod_four proves chiSum(pᵏ) = if Even k then 1 else 0. Here χ₄(p) = −1 (`χ₄_nat_three_mod_four`), so χ₄(pⁱ) = (−1)ⁱ and the divisor sum is a finite geometric series in −1; `neg_one_geom_sum` collapses Σ_{i≤k} (−1)ⁱ to `if Even (k+1) then 0 else 1`, reconciled with the k-parity statement via `Nat.even_add_one`. The value is 1 exactly when k is even — the arithmetic shadow of the fact that pᵏ is a sum of two squares iff k is even."
+    "content": "chiSum_prime_pow_three_mod_four proves chiSum(pᵏ) = if Even k then 1 else 0. Here χ₄(p) = −1 (`χ₄_nat_three_mod_four`), so χ₄(pⁱ) = (−1)ⁱ and the divisor sum is a finite geometric series in −1; `neg_one_geom_sum` collapses Σ_{i≤k} (−1)ⁱ to `if Even (k+1) then 0 else 1`, reconciled with the k-parity statement via `Nat.even_add_one`. The value is 1 exactly when k is even — the arithmetic shadow of the fact that pᵏ is a sum of two squares iff k is even.",
+    "mathContext": "$p\\equiv 3\\!\\!\\pmod 4\\Rightarrow\\chi_4(p^i)=(-1)^i\\Rightarrow\\sum_{i=0}^{k}(-1)^i=\\begin{cases}1&k\\text{ even}\\\\0&k\\text{ odd}\\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["inert primes", "alternating geometric sum", "sum of two squares criterion", "parity"],
+    "prerequisites": ["neg_one_geom_sum", "character mod 4", "parity of exponents"]
   },
   {
     "id": "fsd0603-ann-jacobi-pred",
@@ -37,7 +77,11 @@
     "range": { "startLine": 141, "endLine": 154 },
     "type": "theorem",
     "title": "Jacobi's r₂ Prediction on Prime Powers",
-    "content": "jacobiR2_two_pow (= 4), jacobiR2_prime_pow_one_mod_four (= 4(k+1)) and jacobiR2_prime_pow_three_mod_four (= 4 if k even else 0) propagate the three chiSum closed forms through jacobiR2 = 4·chiSum. Together they give Jacobi's two-square prediction on every prime power, split entirely by the prime's residue mod 4."
+    "content": "jacobiR2_two_pow (= 4), jacobiR2_prime_pow_one_mod_four (= 4(k+1)) and jacobiR2_prime_pow_three_mod_four (= 4 if k even else 0) propagate the three chiSum closed forms through jacobiR2 = 4·chiSum. Together they give Jacobi's two-square prediction on every prime power, split entirely by the prime's residue mod 4.",
+    "mathContext": "$\\mathrm{jacobiR2}(p^k)=\\begin{cases}4&p=2\\\\4(k+1)&p\\equiv 1\\\\4\\,[2\\mid k]&p\\equiv 3\\end{cases}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Jacobi two-square formula", "prime factorization", "residue trichotomy"],
+    "prerequisites": ["the three chiSum closed forms", "definition of jacobiR2"]
   },
   {
     "id": "fsd0603-ann-numeric",
@@ -45,6 +89,10 @@
     "range": { "startLine": 160, "endLine": 183 },
     "type": "insight",
     "title": "Small Two-Square Counts Recovered Without native_decide",
-    "content": "jacobiR2_five (= 8), jacobiR2_nine (= 4), jacobiR2_three (= 0) and jacobiR2_eight (= 4) recover the small representation counts r₂(5)=8, r₂(9)=4, r₂(3)=0, r₂(8)=4 as instances of the three prime-power families — 5 ≡ 1 (split), 3 ≡ 3 (inert, at even and odd exponents), and 8 = 2³. Each is a closed-form specialization proved with only the foundational axioms, avoiding the Lean.ofReduceBool that a native_decide point-check would incur."
+    "content": "jacobiR2_five (= 8), jacobiR2_nine (= 4), jacobiR2_three (= 0) and jacobiR2_eight (= 4) recover the small representation counts r₂(5)=8, r₂(9)=4, r₂(3)=0, r₂(8)=4 as instances of the three prime-power families — 5 ≡ 1 (split), 3 ≡ 3 (inert, at even and odd exponents), and 8 = 2³. Each is a closed-form specialization proved with only the foundational axioms, avoiding the Lean.ofReduceBool that a native_decide point-check would incur.",
+    "mathContext": "$r_2(5)=8,\\ r_2(9)=4,\\ r_2(3)=0,\\ r_2(8)=4$ — instances of the split / inert / power-of-2 families.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "kernel decide vs native_decide", "Lean.ofReduceBool", "axiom hygiene"],
+    "prerequisites": ["the prime-power closed forms", "specialization of theorems"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `four-square-distribution-oq-06-oq-03`

The entry had 6 annotations but each was bare (only `id`/`type`/`title`/`content` — no depth fields), and two constructs were uncovered.

**Depth fields added** to all 6 existing annotations: `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Existing `content` preserved verbatim.

**Coverage gaps closed** (2 new annotations, 6→8):
- `fsd0603-ann-defs` — the two arithmetic definitions `chiSum` / `jacobiR2` (lines 57–63).
- `fsd0603-ann-base` — the PART-0 base-value theorem `chiSum_one` (lines 69–73), previously unannotated.

**Validation:** `resolver.ts validate` → 8 valid, 0 misaligned; JSON parses; all 8 have full depth fields. `meta.json` unchanged (already rich).

> Note: `pnpm build` could not complete in this environment due to host disk exhaustion (100% full from unrelated `/tmp` scratch, ENOSPC on manifest write) — but the annotation build phase emitted successfully and the authoritative resolver validation passed. No content-level failure.