### PR TITLE
Fix: remove dead r4 def and misleading jacobi_implies_lagrange (lagrange-four-squares)

### DIFF
--- a/proofs/Proofs/LagrangeFourSquares.lean
+++ b/proofs/Proofs/LagrangeFourSquares.lean
@@ -195,12 +195,6 @@ the number of representations of n as a sum of four squares:
 This connects to modular forms via the theta function θ(q)⁴.
 -/
 
-/-- r₄(n): number of ordered representations as sum of 4 squares (over ℤ) -/
-def r4 (_n : ℕ) : ℕ :=
-  -- Count (a,b,c,d) ∈ ℤ⁴ with a²+b²+c²+d² = n
-  -- Simplified placeholder; actual computation is over ℤ including negatives
-  0
-
 /-- Sum of divisors d of n where 4 does not divide d -/
 def sumDivisorsNot4 (n : ℕ) : ℕ :=
   (Finset.filter (fun d => d ∣ n ∧ ¬(4 ∣ d)) (Finset.range (n + 1))).sum id
@@ -224,15 +218,6 @@ theorem r4_prime_formula (p : ℕ) (hp : Nat.Prime p) (hp_odd : p % 2 = 1) :
       · exact ⟨by omega, dvd_refl _, h4_ndvd_p⟩
   rw [hfilt, Finset.sum_pair h1_ne_p]
   simp
-
-/-- Jacobi's formula gives r₄(n) > 0 for all n ≥ 1, providing an alternative
-    proof of Lagrange's theorem (four squares always suffice). -/
-theorem jacobi_implies_lagrange :
-    (∀ n : ℕ, n ≥ 1 → sumDivisorsNot4 n > 0) →
-    ∀ n : ℕ, n ≥ 1 → IsSumOfThreeSquares n ∨
-      ∃ a b c d : ℕ, a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 = n := by
-  intro h n _
-  right; exact lagrange_four_squares n
 
 /- ═══════════════════════════════════════════════════════════════════════════════
 PART IV: WARING'S PROBLEM AND g(k)

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -44,8 +44,8 @@
       "Waring's problem and additive number theory"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 15,
-    "definitionCount": 9,
+    "theoremCount": 14,
+    "definitionCount": 8,
     "additionalFiles": [
       "Proofs/FourSquareRepresentations.lean"
     ]
@@ -131,7 +131,7 @@
       "title": "Part III: Representation Counts and r₄(n)",
       "startLine": 188,
       "endLine": 234,
-      "summary": "Jacobi’s four-square count: r4 and sumDivisorsNot4 definitions, the prime formula r4(p)=8(p+1), and jacobi_implies_lagrange."
+      "summary": "Jacobi’s four-square count: the sumDivisorsNot4 definition and the prime formula r₄(p)=8(p+1), proved as sumDivisorsNot4 p = 1 + p."
     },
     {
       "id": "part4-waring",
@@ -214,10 +214,10 @@
     ],
     "opens": [],
     "namespace": "LagrangeFourSquares",
-    "lineCount": 424,
+    "lineCount": 409,
     "axiomCount": 5,
-    "theoremCount": 15,
-    "definitionCount": 9,
+    "theoremCount": 14,
+    "definitionCount": 8,
     "path": "Proofs/LagrangeFourSquares.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/lagrange-four-squares/review.json
+++ b/src/data/proofs/lagrange-four-squares/review.json
@@ -108,28 +108,32 @@
       "priority": "high",
       "target": "researcher",
       "description": "Fix lipschitz_norm_multiplicative (line 343): either prove actual norm multiplicativity for LipschitzQuaternion (define multiplication, prove N(q1*q2) = N(q1)*N(q2)), or remove the theorem and replace with an honest axiom or comment noting it as future work.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Already resolved by prior source rework: LipschitzQuaternion.mul is now a genuine Hamilton-product definition and lipschitz_norm_multiplicative proves N(q₁·q₂)=N(q₁)·N(q₂) via ring (not a vacuous stub)."
     },
     {
       "id": "ai-2",
       "priority": "high",
       "target": "researcher",
       "description": "Fix the 3 vacuous True axioms: jacobi_four_squares (line 213), hurwitz_quaternions_euclidean (line 357), hurwitz_representation_count (line 365). Either state the actual mathematical content in the type signature or remove and keep as commentary only.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Already resolved by prior source rework: the three vacuous True stubs (jacobi_four_squares, hurwitz_quaternions_euclidean, hurwitz_representation_count) have been removed from the source; no `: True` declarations remain."
     },
     {
       "id": "ai-3",
       "priority": "medium",
       "target": "researcher",
       "description": "Fix or remove the r4 definition (line 203) which unconditionally returns 0. Either implement the actual representation count or remove the dead definition.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Removed the dead r4 definition (returned 0 unconditionally, no callers, not in #check list). sumDivisorsNot4 and r4_prime_formula retained."
     },
     {
       "id": "ai-4",
       "priority": "medium",
       "target": "researcher",
       "description": "Fix jacobi_implies_lagrange (line 238): the proof ignores its hypothesis. Either derive Lagrange from sumDivisorsNot4 positivity or reframe honestly.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Removed jacobi_implies_lagrange: its proof ignored the sumDivisorsNot4-positivity hypothesis and simply invoked lagrange_four_squares. Honest reframing would make it a trivial duplicate of lagrange_four_squares, and the underlying Jacobi count is not formalized (its axiom stub was previously removed), so removal is the honest fix."
     },
     {
       "id": "ai-5",


### PR DESCRIPTION
## Fix

Resolves two open peer-review action items for `lagrange-four-squares` (Part III representation-count scaffolding).

## Evidence

**ai-3 — dead `r4` definition**
- **Before**: `def r4 (_n : ℕ) : ℕ := 0` — a placeholder returning 0 for all inputs, with no callers and not in the `#check` list, presented as part of the formalization.
- **After**: removed. `sumDivisorsNot4` and `r4_prime_formula` (which genuinely proves `sumDivisorsNot4 p = 1 + p` for odd primes) are retained.

**ai-4 — misleading `jacobi_implies_lagrange`**
- **Before**: took hypothesis `(∀ n ≥ 1, sumDivisorsNot4 n > 0)` but ignored it, proving its disjunction by simply calling `lagrange_four_squares`. Framed as an "alternative proof via Jacobi's formula" though it was the same proof with an unused hypothesis.
- **After**: removed. An honest reframe would make it a trivial duplicate of `lagrange_four_squares`, and the underlying Jacobi count (`jacobi_four_squares`) is not formalized (its stub was previously removed).

The change is **removal-only** of two unreferenced declarations; no remaining code references either (verified by grep, and neither appears in the `#check` verification block).

**Metadata sync**: `theoremCount` 15→14, `definitionCount` 9→8, `leanFile.lineCount` 424→409, Part III section summary updated to drop the removed decls.

**Bookkeeping**: ai-1 and ai-2 were already resolved by prior source rework (`LipschitzQuaternion.mul` is now a genuine Hamilton product and `lipschitz_norm_multiplicative` genuinely proves norm multiplicativity via `ring`; the three vacuous `True` stubs were removed). Marked resolved in `review.json`, which now has no open action items.

---
Automated fix by lean-mechanic agent.