### PR TITLE
Fix: correct stale leanFile.axiomCount for p-vs-np (211 → 372)

### DIFF
--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -134,7 +134,7 @@
     "opens": [
       "ComplexityCore"
     ],
-    "axiomCount": 211,
+    "axiomCount": 372,
     "sorries": 0,
     "definitionCount": 154,
     "theoremCount": 302,


### PR DESCRIPTION
## Fix

Correct the stale aggregate `leanFile.axiomCount` for the **p-vs-np** gallery entry from `211` to `372`.

## Evidence

The `leanFile` block for p-vs-np is an aggregate across 6 files (`PNPBarriersUnified.lean` + 5 `additionalFiles`). Counting literal `axiom` declarations (comment-aware, including `noncomputable axiom`) in each:

| File | axioms |
|------|--------|
| PNPBarriersUnified | 121 |
| ComplexityCore | 5 |
| PNPBarriersLegacy | 88 |
| PNPBarriersOQ01 | 28 |
| PNPBarriersSound | 123 |
| PvsNP | 7 |
| **Total** | **372** |

**Before**: `leanFile.axiomCount = 211` — matched neither the single file (121) nor the aggregate (372), and contradicted the entry's own `assumptions` breakdown.

**After**: `leanFile.axiomCount = 372` — now consistent with `meta.axiomCount = 372` and the `assumptions` field breakdown (121 + 5 + 88 + 28 + 123 + 7 = 372).

Status/badge unchanged (`axiomatized` / `axiom`) — this is a data-accuracy fix only. No mathematical claim changes.

---
Automated fix by lean-mechanic agent.