### PR TITLE
research(stars-and-bars-oq-01-oq-02): Newton's generalized binomial coefficient & negative binomial theorem

### DIFF
--- a/proofs/Proofs/StarsAndBarsWeakCompositionsOQ01OQ02.lean
+++ b/proofs/Proofs/StarsAndBarsWeakCompositionsOQ01OQ02.lean
@@ -1,0 +1,146 @@
+import Mathlib.RingTheory.Binomial
+import Mathlib.RingTheory.PowerSeries.WellKnown
+import Mathlib.RingTheory.PowerSeries.Binomial
+import Mathlib.Tactic
+import Proofs.StarsAndBarsWeakCompositionsOQ01
+
+/-
+# Newton's Generalized Binomial Coefficient and the Negative Binomial Theorem
+
+## What This Proves
+
+The parent entry (`StarsAndBarsWeakCompositionsOQ01.lean`) identifies the ordinary
+generating function of the weak-composition counts with Mathlib's `invOneSubPow S k`,
+the algebraic power series `1/(1 − X)ᵏ`, and reads off its coefficients as the
+stars-and-bars count
+
+  `coeff n (invOneSubPow S k) = C(n + k − 1, n)`   (`coeff_invOneSubPow_eq_choose`).
+
+This entry supplies the **negative binomial theorem** reading of the very same
+coefficients, answering the parent's second open question. Newton's generalized
+binomial coefficient `C(r, n)` — Mathlib's `Ring.choose r n`, defined over any
+binomial ring by dividing a descending Pochhammer product by `n!` — extends
+`Nat.choose` to negative (indeed arbitrary ring) upper index. The classical
+*upper-negation* / negative-binomial identity is
+
+  `(−1)ⁿ · C(−k, n) = C(n + k − 1, n)`,
+
+which says the coefficients `C(n + k − 1, n)` of `1/(1 − X)ᵏ` are, up to the sign
+`(−1)ⁿ`, the generalized binomial coefficients `C(−k, n)`. Equivalently
+`1/(1 − X)ᵏ = ∑ₙ C(−k, n) (−X)ⁿ`, the negative-binomial expansion of `(1 − X)⁻ᵏ`.
+
+## The argument
+
+Mathlib already provides the analytic backbone:
+
+* `Ring.choose_neg : choose (−r) n = Int.negOnePow n • choose (r + n − 1) n`
+  — upper negation for the generalized binomial coefficient, with the sign carried
+  by the unit `Int.negOnePow n = (−1)ⁿ ∈ ℤˣ`.
+* `Ring.choose_natCast : choose (↑m) n = ↑(Nat.choose m n)` — on natural upper index
+  the generalized coefficient is the ordinary one.
+* `PowerSeries.rescale_neg_one_invOneSubPow :
+  rescale (−1) (invOneSubPow A d) = binomialSeries A (−d)` — substituting `X ↦ −X`
+  turns `1/(1 − X)ᵈ` into the binomial series `(1 + X)⁻ᵈ` whose coefficients are
+  `Ring.choose (−d) n`.
+
+The content added here is the *bridge*: rewriting the unit `Int.negOnePow n` as the
+plain ring element `(−1)ⁿ`, specializing to `r = k : ℤ` (with `k ≥ 1`, so that
+`k + n − 1` is a genuine natural number), and threading the resulting elementary
+identity through the parent's coefficient formula and the stars-and-bars count. The
+upshot is that the generalized binomial coefficient `C(−k, n)` *counts weak
+compositions up to sign*.
+
+## What Mathlib has — and what this adds
+
+Mathlib has `Ring.choose` and its upper-negation `Ring.choose_neg` (sign as a unit),
+the binomial power series `binomialSeries`, and the rescale relation
+`rescale_neg_one_invOneSubPow`. It does **not** record the clean elementary identity
+`(−1)ⁿ C(−k, n) = C(n + k − 1, n)` with the sign as `(−1)ⁿ`, nor its connection to
+the enumerative content of the parent entry. The new results are:
+`ringChoose_neg_eq` (upper negation in `(−1)ⁿ` form over any binomial ring),
+`ringChoose_neg_natCast` and `negOnePow_mul_ringChoose_neg` (the negative-binomial
+identity over ℤ), `coeff_invOneSubPow_eq_negOnePow_mul_ringChoose` (the negative
+binomial reading of `invOneSubPow`'s coefficients), `coeff_rescale_invOneSubPow`
+(coefficient of `(1 + X)⁻ᵏ` is exactly `C(−k, n)`), and
+`negOnePow_mul_ringChoose_eq_card_weakComposition` (the generalized binomial
+coefficient counts weak compositions up to sign).
+-/
+
+open PowerSeries
+
+namespace StarsAndBarsNegBinom
+
+/-- **Upper negation for the generalized binomial coefficient.** Over any commutative
+binomial ring, `Ring.choose (−r) n = (−1)ⁿ · Ring.choose (r + n − 1) n`.
+
+This is Mathlib's `Ring.choose_neg` with the unit `Int.negOnePow n ∈ ℤˣ` rewritten as
+the plain ring element `(−1)ⁿ`. -/
+theorem ringChoose_neg_eq {R : Type*} [CommRing R] [BinomialRing R] (r : R) (n : ℕ) :
+    Ring.choose (-r) n = (-1) ^ n * Ring.choose (r + n - 1) n := by
+  rw [Ring.choose_neg, Units.smul_def, Int.coe_negOnePow_natCast, zsmul_eq_mul]
+  push_cast
+  ring
+
+/-- The nonnegative upper index `k + n − 1` is a genuine natural number when `k ≥ 1`:
+`(k : ℤ) + n − 1 = ↑(n + k − 1)`. -/
+private theorem cast_add_sub_one (k n : ℕ) (hk : 0 < k) :
+    (k : ℤ) + n - 1 = ((n + k - 1 : ℕ) : ℤ) := by
+  have h : 1 ≤ n + k := by omega
+  rw [Nat.cast_sub h]
+  push_cast
+  ring
+
+/-- **Negative binomial identity, `Ring.choose` form.** Over ℤ, for `k ≥ 1`,
+`Ring.choose (−k, n) = (−1)ⁿ · C(n + k − 1, n)`, where the right-hand `C` is the
+ordinary `Nat.choose`. -/
+theorem ringChoose_neg_natCast (k n : ℕ) (hk : 0 < k) :
+    Ring.choose (-(k : ℤ)) n = (-1) ^ n * ((n + k - 1).choose n : ℤ) := by
+  rw [ringChoose_neg_eq, cast_add_sub_one k n hk, Ring.choose_natCast]
+
+/-- **Newton's generalized binomial coefficient identity** (the parent's open
+question): `(−1)ⁿ · C(−k, n) = C(n + k − 1, n)` over ℤ, for `k ≥ 1`. The sign folds
+in because `(−1)ⁿ · (−1)ⁿ = 1`. -/
+theorem negOnePow_mul_ringChoose_neg (k n : ℕ) (hk : 0 < k) :
+    (-1) ^ n * Ring.choose (-(k : ℤ)) n = ((n + k - 1).choose n : ℤ) := by
+  have hsign : ((-1 : ℤ)) ^ n * (-1) ^ n = 1 := by
+    rw [← mul_pow]; norm_num
+  rw [ringChoose_neg_natCast k n hk, ← mul_assoc, hsign, one_mul]
+
+/-- **Negative binomial reading of the coefficients of `1/(1 − X)ᵏ`.** Over ℤ, the
+`n`-th coefficient of Mathlib's `invOneSubPow ℤ k` is `(−1)ⁿ · C(−k, n)`, the
+generalized binomial coefficient of `(1 − X)⁻ᵏ`. Combined with the parent's
+`coeff_invOneSubPow_eq_choose` this is the identity `1/(1 − X)ᵏ = ∑ₙ C(−k, n) (−X)ⁿ`
+read coefficientwise. -/
+theorem coeff_invOneSubPow_eq_negOnePow_mul_ringChoose (k n : ℕ) (hk : 0 < k) :
+    coeff n (invOneSubPow ℤ k).val = (-1) ^ n * Ring.choose (-(k : ℤ)) n := by
+  rw [StarsAndBarsGenFun.coeff_invOneSubPow_eq_choose ℤ k n hk,
+    negOnePow_mul_ringChoose_neg k n hk]
+
+/-- **The negative binomial theorem, coefficient form.** Rescaling `X ↦ −X` sends
+`1/(1 − X)ᵏ` to the binomial series `(1 + X)⁻ᵏ`, and its `n`-th coefficient is exactly
+the generalized binomial coefficient `C(−k, n)`. -/
+theorem coeff_rescale_invOneSubPow (k n : ℕ) :
+    coeff n (rescale (-1 : ℤ) (invOneSubPow ℤ k)) = Ring.choose (-(k : ℤ)) n := by
+  rw [rescale_neg_one_invOneSubPow, binomialSeries_coeff, smul_eq_mul, mul_one]
+
+/-- **The generalized binomial coefficient counts weak compositions up to sign.**
+`(−1)ⁿ · C(−k, n)` equals the number of weak compositions of `n` into `k` parts —
+the enumerative content of the parent entry, now read off the negative-binomial
+coefficient. -/
+theorem negOnePow_mul_ringChoose_eq_card_weakComposition (k n : ℕ) (hk : 0 < k) :
+    (-1) ^ n * Ring.choose (-(k : ℤ)) n
+      = (Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} : ℤ) := by
+  rw [negOnePow_mul_ringChoose_neg k n hk, StarsAndBars.card_weakComposition]
+
+/-- Sanity check: `C(−2, 3) = −4` while `C(4, 3) = 4`, and `(−1)³ · (−4) = 4`. -/
+example : Ring.choose (-((2 : ℕ) : ℤ)) 3 = -4 := by
+  rw [ringChoose_neg_natCast 2 3 (by norm_num)]
+  norm_num
+
+/-- Sanity check on the generalized coefficient at `k = 3, n = 2`:
+`C(−3, 2) = (−1)² C(4, 2) = 6`. -/
+example : Ring.choose (-((3 : ℕ) : ℤ)) 2 = 6 := by
+  rw [ringChoose_neg_natCast 3 2 (by norm_num)]
+  norm_num [Nat.choose]
+
+end StarsAndBarsNegBinom

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-01-oq-02/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-01-oq-02/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "stars-and-bars-weak-compositions-oq-01-oq-02",
+  "title": "Newton's Generalized Binomial Coefficient and the Negative Binomial Theorem: (−1)ⁿ C(−k, n) = C(n+k−1, n)",
+  "slug": "stars-and-bars-weak-compositions-oq-01-oq-02",
+  "description": "The parent entry identifies the ordinary generating function of the weak-composition counts with Mathlib's invOneSubPow S k = 1/(1−X)ᵏ and reads off its coefficients as the stars-and-bars count C(n+k−1, n) (coeff_invOneSubPow_eq_choose). This entry answers the parent's second open question by supplying the negative binomial theorem reading of those coefficients. Newton's generalized binomial coefficient C(r, n) — Mathlib's Ring.choose r n, defined over any binomial ring by dividing a descending Pochhammer product by n! — extends Nat.choose to arbitrary (in particular negative) upper index. The classical upper-negation identity is (−1)ⁿ · C(−k, n) = C(n+k−1, n) (negOnePow_mul_ringChoose_neg): the coefficients C(n+k−1, n) of 1/(1−X)ᵏ are, up to the sign (−1)ⁿ, the generalized binomial coefficients C(−k, n), so 1/(1−X)ᵏ = ∑ₙ C(−k, n) (−X)ⁿ. Mathlib supplies the analytic backbone — Ring.choose_neg (upper negation with the sign as the unit Int.negOnePow n ∈ ℤˣ), Ring.choose_natCast (on natural upper index the generalized coefficient is the ordinary one), and rescale_neg_one_invOneSubPow (X ↦ −X turns 1/(1−X)ᵈ into the binomial series (1+X)⁻ᵈ). The new content is the bridge: rewriting the unit Int.negOnePow n as the plain ring element (−1)ⁿ (ringChoose_neg_eq), specializing to integer −k with k ≥ 1, threading the resulting elementary identity through the parent's coefficient formula (coeff_invOneSubPow_eq_negOnePow_mul_ringChoose), reading the coefficient of (1+X)⁻ᵏ as exactly C(−k, n) (coeff_rescale_invOneSubPow), and exhibiting that C(−k, n) counts weak compositions up to sign (negOnePow_mul_ringChoose_eq_card_weakComposition).",
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Binomial",
+      "Mathlib.RingTheory.PowerSeries.WellKnown",
+      "Mathlib.RingTheory.PowerSeries.Binomial",
+      "Mathlib.Tactic",
+      "Proofs.StarsAndBarsWeakCompositionsOQ01"
+    ],
+    "opens": [
+      "PowerSeries"
+    ],
+    "namespace": "StarsAndBarsNegBinom",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/StarsAndBarsWeakCompositionsOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binomial_series#Special_cases",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StarsAndBarsWeakCompositionsOQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "generating-functions",
+      "binomial-coefficients",
+      "generalized-binomial-coefficient",
+      "negative-binomial-series",
+      "newtons-binomial-theorem",
+      "power-series",
+      "stars-and-bars",
+      "weak-compositions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "relatedProblems": [
+      {
+        "id": "stars-and-bars-weak-compositions-oq-01",
+        "relationship": "Direct parent. That entry identifies the ordinary generating function of the weak-composition counts with Mathlib's invOneSubPow S k (the inverse unit of (1−X)ᵏ) and reads its n-th coefficient off as C(n+k−1, n) (coeff_invOneSubPow_eq_choose). This entry answers that entry's second listed open question: it derives Newton's generalized binomial coefficient identity (−1)ⁿ C(−k, n) = C(n+k−1, n) and reuses coeff_invOneSubPow_eq_choose to read those coefficients as generalized binomial coefficients — the negative binomial theorem reading."
+      },
+      {
+        "id": "stars-and-bars-weak-compositions",
+        "relationship": "Grandparent. That entry counts weak compositions of n into k parts as C(n+k−1, n) via the bijection to size-n multisets (card_weakComposition), the count this entry shows the generalized binomial coefficient C(−k, n) reproduces up to sign (negOnePow_mul_ringChoose_eq_card_weakComposition)."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 146,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All results were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The identities over ℤ require k ≥ 1 so that k+n−1 is a genuine natural number (Nat.choose upper index); the general upper-negation lemma ringChoose_neg_eq holds over any commutative binomial ring with no positivity hypothesis. The new content beyond Mathlib is the elementary form of the negative-binomial identity — the sign carried as the plain ring element (−1)ⁿ rather than the unit Int.negOnePow n ∈ ℤˣ — and its connection to the parent entry's coefficient formula and the stars-and-bars count. Mathlib supplies Ring.choose with its upper negation Ring.choose_neg and natural-index specialization Ring.choose_natCast, the binomial power series binomialSeries, and the rescale relation rescale_neg_one_invOneSubPow; the imported parent supplies coeff_invOneSubPow_eq_choose and the count card_weakComposition. Sanity checks compiled: C(−2, 3) = −4 (while C(4, 3) = 4, and (−1)³·(−4) = 4), and (−1)²·C(−3, 2) = C(4, 2) = 6.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Newton's generalized binomial theorem extends the finite binomial expansion (1+x)ᵐ to an arbitrary exponent r, giving the infinite series (1+x)ʳ = ∑ₙ C(r, n) xⁿ with the generalized binomial coefficient C(r, n) = r(r−1)⋯(r−n+1)/n!. For a negative integer exponent −k this specializes to the negative binomial series (1−x)⁻ᵏ = ∑ₙ C(n+k−1, n) xⁿ, and the two expansions are reconciled by the upper-negation identity C(−k, n) = (−1)ⁿ C(n+k−1, n). This is the analytic face of stars and bars: the coefficients of (1−x)⁻ᵏ are the counts of weak compositions of n into k parts. Mathlib formalizes the generalized coefficient as Ring.choose over any binomial ring — a commutative ring in which every descending Pochhammer product is divisible by the corresponding factorial — and proves the upper negation Ring.choose_neg with the alternating sign packaged as the unit Int.negOnePow n. The classical identity in its familiar (−1)ⁿ form, and its tie to the enumerative content of the parent entry, is what this entry records.",
+    "problemStatement": "Derive Newton's generalized binomial coefficient identity (−1)ⁿ C(−k, n) = C(n+k−1, n) in Lean, with the sign as the ring element (−1)ⁿ, and connect it to the parent entry's coeff_invOneSubPow_eq_choose to give the negative binomial theorem reading of the coefficients of 1/(1−X)ᵏ: coeff n (invOneSubPow ℤ k) = (−1)ⁿ C(−k, n), and coeff n ((1+X)⁻ᵏ) = C(−k, n), with C(−k, n) counting weak compositions of n into k parts up to sign.",
+    "text": "The parent entry (stars-and-bars-weak-compositions-oq-01) identifies the generating function of weak-composition counts with Mathlib's invOneSubPow S k and reads its coefficients as C(n+k−1, n). This entry supplies the negative binomial theorem reading. Mathlib's Ring.choose r n is the generalized binomial coefficient over a binomial ring, and Ring.choose_neg gives the upper negation choose (−r) n = Int.negOnePow n • choose (r+n−1) n with the sign as a unit in ℤˣ. The task is to convert that unit to the plain ring element (−1)ⁿ, specialize to the integer upper index −k (k ≥ 1) using Ring.choose_natCast, and thread the elementary identity (−1)ⁿ C(−k, n) = C(n+k−1, n) through the parent's coefficient formula and the stars-and-bars count. The binomial series (1+X)ʳ is Mathlib's binomialSeries, and rescale_neg_one_invOneSubPow identifies rescale (−1) (invOneSubPow ℤ k) with binomialSeries ℤ (−k), whose n-th coefficient is exactly Ring.choose (−k) n.",
+    "proofStrategy": "ringChoose_neg_eq rewrites Mathlib's Ring.choose_neg into the (−1)ⁿ form over any commutative binomial ring: after choose_neg the sign is the unit Int.negOnePow n, converted to the ring element (−1)ⁿ by Units.smul_def, Int.coe_negOnePow_natCast, and zsmul_eq_mul, then push_cast; ring. The private lemma cast_add_sub_one shows (k:ℤ)+n−1 = ↑(n+k−1) for k ≥ 1 (Nat.cast_sub with 1 ≤ n+k by omega). ringChoose_neg_natCast combines these with Ring.choose_natCast to get Ring.choose (−k) n = (−1)ⁿ C(n+k−1, n) over ℤ, and negOnePow_mul_ringChoose_neg multiplies by (−1)ⁿ (using (−1)ⁿ·(−1)ⁿ = 1 via ← mul_pow; norm_num) to reach the parent's open-question form (−1)ⁿ C(−k, n) = C(n+k−1, n). coeff_invOneSubPow_eq_negOnePow_mul_ringChoose rewrites the parent's coeff_invOneSubPow_eq_choose by this identity, giving coeff n (invOneSubPow ℤ k) = (−1)ⁿ C(−k, n). coeff_rescale_invOneSubPow reads the coefficient of the rescaled series directly: rescale_neg_one_invOneSubPow turns rescale (−1) (invOneSubPow ℤ k) into binomialSeries ℤ (−k), whose coefficient (binomialSeries_coeff) is Ring.choose (−k) n • 1 = Ring.choose (−k) n. negOnePow_mul_ringChoose_eq_card_weakComposition rewrites the identity by the grandparent's card_weakComposition to exhibit (−1)ⁿ C(−k, n) as the number of weak compositions of n into k parts. Two numeric examples (C(−2,3) = −4 and (−1)²C(−3,2) = 6) close the file.",
+    "keyInsights": [
+      "**The sign is (−1)ⁿ, not a unit**: Mathlib's Ring.choose_neg carries the alternating sign as the group unit Int.negOnePow n ∈ ℤˣ, mathematically clean but awkward to use in ring arithmetic. The core move (ringChoose_neg_eq) is to discharge the unit to the plain ring element (−1)ⁿ via Units.smul_def / Int.coe_negOnePow_natCast / zsmul_eq_mul, restoring the textbook form (−1)ⁿ C(−k, n) = C(n+k−1, n) that composes with norm_num and the parent's coefficient formula.",
+      "**k ≥ 1 makes the upper index a natural number**: the identity relates a generalized coefficient C(−k, n) (upper index in ℤ) to an ordinary one C(n+k−1, n) (upper index in ℕ). For k ≥ 1 the integer k+n−1 is a genuine natural number (cast_add_sub_one), so Ring.choose_natCast applies and the right-hand side is Nat.choose. The general upper-negation lemma ringChoose_neg_eq needs no such hypothesis — it lives entirely over the ring.",
+      "**Two faces of the negative binomial theorem**: coeff_invOneSubPow_eq_negOnePow_mul_ringChoose reads the coefficients of 1/(1−X)ᵏ as (−1)ⁿ C(−k, n) — the expansion 1/(1−X)ᵏ = ∑ₙ C(−k, n)(−X)ⁿ. coeff_rescale_invOneSubPow reads the coefficients of the rescaled series (1+X)⁻ᵏ as C(−k, n) directly — the expansion (1+X)⁻ᵏ = ∑ₙ C(−k, n) Xⁿ. The rescale X ↦ −X interchanges them, absorbing the sign.",
+      "**The generalized coefficient counts weak compositions up to sign**: composing the identity with the grandparent's card_weakComposition (negOnePow_mul_ringChoose_eq_card_weakComposition) shows (−1)ⁿ C(−k, n) is literally the number of weak compositions of n into k parts. The analytic object C(−k, n) and the combinatorial object #{f : Fin k → ℕ | ∑ f = n} are the same up to the alternating sign — the negative-binomial and stars-and-bars readings of one sequence.",
+      "**Mathlib did the hard analysis; this is the bridge**: Ring.choose_neg, Ring.choose_natCast, binomialSeries, and rescale_neg_one_invOneSubPow are all Mathlib's, and coeff_invOneSubPow_eq_choose and card_weakComposition come from the parent chain. The genuinely new content is the elementary (−1)ⁿ restatement and the plumbing that ties the generalized binomial coefficient to the parent entry's enumerative generating function."
+    ],
+    "prerequisites": [
+      "Mathlib's generalized binomial coefficient Ring.choose r n over a binomial ring, with the upper negation Ring.choose_neg (sign as the unit Int.negOnePow n) and the natural-index specialization Ring.choose_natCast",
+      "The unit Int.negOnePow : ℤ → ℤˣ with Int.coe_negOnePow_natCast (its ℤ-value is (−1)ⁿ), and Units.smul_def / zsmul_eq_mul for converting the unit action to ring multiplication",
+      "The binomial power series PowerSeries.binomialSeries A r (coefficients Ring.choose r n • 1) and rescale_neg_one_invOneSubPow (rescale (−1) (invOneSubPow A d) = binomialSeries A (−d))",
+      "The parent entry's coeff_invOneSubPow_eq_choose (coefficient of 1/(1−X)ᵏ is C(n+k−1, n)) and the grandparent's card_weakComposition (weak-composition count as C(n+k−1, n))",
+      "Nat.cast_sub and omega for the natural-number bookkeeping (k:ℤ)+n−1 = ↑(n+k−1) when k ≥ 1"
+    ]
+  },
+  "sections": [
+    {
+      "id": "upper-negation",
+      "title": "Upper Negation in (−1)ⁿ Form",
+      "startLine": 74,
+      "endLine": 96,
+      "mathContext": "$\\binom{-r}{n} = (-1)^n \\binom{r+n-1}{n}$ over any binomial ring.",
+      "summary": "ringChoose_neg_eq is the core algebraic step: it rewrites Mathlib's Ring.choose_neg — which carries the sign as the unit Int.negOnePow n ∈ ℤˣ — into the plain ring form Ring.choose (−r) n = (−1)ⁿ Ring.choose (r+n−1) n over an arbitrary commutative binomial ring. The unit action is discharged to ring multiplication by Units.smul_def, Int.coe_negOnePow_natCast, and zsmul_eq_mul, then push_cast; ring. The private helper cast_add_sub_one records that (k:ℤ)+n−1 is the cast of the natural number n+k−1 when k ≥ 1."
+    },
+    {
+      "id": "negative-binomial-identity",
+      "title": "The Negative Binomial Identity over ℤ",
+      "startLine": 98,
+      "endLine": 116,
+      "mathContext": "$(-1)^n \\binom{-k}{n} = \\binom{n+k-1}{n}$ for $k \\ge 1$.",
+      "summary": "ringChoose_neg_natCast specializes ringChoose_neg_eq to the integer upper index −k, using cast_add_sub_one and Ring.choose_natCast to land the right-hand side on the ordinary Nat.choose: Ring.choose (−k) n = (−1)ⁿ C(n+k−1, n). negOnePow_mul_ringChoose_neg then multiplies through by (−1)ⁿ and cancels the sign ((−1)ⁿ·(−1)ⁿ = 1 via ← mul_pow; norm_num) to reach the parent's open-question form (−1)ⁿ C(−k, n) = C(n+k−1, n)."
+    },
+    {
+      "id": "power-series-reading",
+      "title": "The Negative Binomial Theorem for the Coefficients",
+      "startLine": 118,
+      "endLine": 140,
+      "mathContext": "$[X^n]\\,(1-X)^{-k} = (-1)^n\\binom{-k}{n}, \\quad [X^n]\\,(1+X)^{-k} = \\binom{-k}{n}$.",
+      "summary": "coeff_invOneSubPow_eq_negOnePow_mul_ringChoose rewrites the parent's coeff_invOneSubPow_eq_choose by the negative binomial identity, reading the n-th coefficient of 1/(1−X)ᵏ as (−1)ⁿ C(−k, n). coeff_rescale_invOneSubPow uses Mathlib's rescale_neg_one_invOneSubPow to turn rescale (−1) (invOneSubPow ℤ k) into the binomial series (1+X)⁻ᵏ and reads its coefficient directly as C(−k, n). negOnePow_mul_ringChoose_eq_card_weakComposition composes the identity with the grandparent's card_weakComposition, exhibiting (−1)ⁿ C(−k, n) as the number of weak compositions of n into k parts."
+    },
+    {
+      "id": "examples",
+      "title": "Numeric Sanity Checks",
+      "startLine": 142,
+      "endLine": 146,
+      "mathContext": "$\\binom{-2}{3} = -4, \\quad (-1)^2\\binom{-3}{2} = \\binom{4}{2} = 6$.",
+      "summary": "Two examples ground the identity: C(−2, 3) = −4 (derived from ringChoose_neg_natCast, matching (−1)³ C(4, 3) = −4), and (−1)² C(−3, 2) = C(4, 2) = 6 (from negOnePow_mul_ringChoose_neg)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Newton's generalized binomial coefficient identity is formalized sorry-free and axiom-free: over any commutative binomial ring Ring.choose (−r) n = (−1)ⁿ Ring.choose (r+n−1) n (ringChoose_neg_eq), and over ℤ for k ≥ 1 this is the classical (−1)ⁿ C(−k, n) = C(n+k−1, n) (negOnePow_mul_ringChoose_neg), answering the parent's second open question. The identity is threaded through the parent's coefficient formula (coeff_invOneSubPow_eq_negOnePow_mul_ringChoose: coeff n (1/(1−X)ᵏ) = (−1)ⁿ C(−k, n)) and Mathlib's rescale relation (coeff_rescale_invOneSubPow: coeff n ((1+X)⁻ᵏ) = C(−k, n)), and connected to the enumerative count (negOnePow_mul_ringChoose_eq_card_weakComposition: (−1)ⁿ C(−k, n) counts weak compositions of n into k parts). The content beyond Mathlib is the elementary (−1)ⁿ restatement of Ring.choose_neg and its bridge to the parent entry.",
+    "implications": "Casting the sign of the upper-negation identity as the plain ring element (−1)ⁿ makes the generalized binomial coefficient usable in ordinary ring arithmetic and norm_num computations, and closes the loop with the parent's generating-function view: the coefficients of 1/(1−X)ᵏ have three coequal readings — the stars-and-bars count C(n+k−1, n), the generalized binomial coefficient (−1)ⁿ C(−k, n), and the number of weak compositions of n into k parts. The rescaled statement gives the pure negative binomial theorem (1+X)⁻ᵏ = ∑ₙ C(−k, n) Xⁿ. These are the coefficient-level engine behind the whole composition family of entries.",
+    "openQuestions": [
+      "Prove the general negative binomial theorem as a power-series identity binomialSeries ℤ (−k) = ∑' pointwise, i.e. lift the coefficientwise statement to an equality (1+X)⁻ᵏ · (1+X)ᵏ = 1 combining rescale_neg_one_invOneSubPow with the unit structure of invOneSubPow.",
+      "Extend the upper-negation identity to the two-variable Vandermonde form C(−k, n) via Ring.add_choose (the generalized Vandermonde convolution) and connect it to the multiplicativity invOneSubPow_add of the parent's series.",
+      "Formalize the generalized binomial theorem over ℚ or ℝ for a non-integer exponent r using Ring.choose r n and relate C(1/2, n) to the central binomial coefficients / Catalan numbers."
+    ]
+  },
+  "crossReferences": [
+    "stars-and-bars-weak-compositions-oq-01",
+    "stars-and-bars-weak-compositions"
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the second open question of `stars-and-bars-weak-compositions-oq-01`: **derive Newton's generalized binomial coefficient identity `(−1)ⁿ C(−k, n) = C(n+k−1, n)` and connect it to `coeff_invOneSubPow_eq_choose`**, giving the *negative binomial theorem* reading of the coefficients of `1/(1−X)ᵏ`.

Newton's generalized binomial coefficient `C(r, n)` is Mathlib's `Ring.choose r n` (a descending Pochhammer product over `n!`, defined on any binomial ring). The classical upper-negation identity says the stars-and-bars coefficients `C(n+k−1, n)` of `1/(1−X)ᵏ` are, up to sign `(−1)ⁿ`, the generalized coefficients `C(−k, n)` — i.e. `1/(1−X)ᵏ = ∑ₙ C(−k, n)(−X)ⁿ`.

## Results (7 theorems, 146 lines)

- `ringChoose_neg_eq` — upper negation over any commutative binomial ring, with the sign as the plain ring element `(−1)ⁿ` (Mathlib's `Ring.choose_neg` carries it as the unit `Int.negOnePow n ∈ ℤˣ`).
- `ringChoose_neg_natCast` / `negOnePow_mul_ringChoose_neg` — the identity over ℤ for `k ≥ 1`: `(−1)ⁿ C(−k, n) = C(n+k−1, n)`.
- `coeff_invOneSubPow_eq_negOnePow_mul_ringChoose` — `coeff n (invOneSubPow ℤ k) = (−1)ⁿ C(−k, n)`, threading the parent's coefficient formula.
- `coeff_rescale_invOneSubPow` — the pure negative binomial theorem: `coeff n ((1+X)⁻ᵏ) = C(−k, n)` (via Mathlib's `rescale_neg_one_invOneSubPow`).
- `negOnePow_mul_ringChoose_eq_card_weakComposition` — `(−1)ⁿ C(−k, n)` equals the number of weak compositions of `n` into `k` parts.

## What's new vs Mathlib

Mathlib has `Ring.choose_neg` (sign as a unit), `binomialSeries`, and `rescale_neg_one_invOneSubPow`; the parent chain supplies `coeff_invOneSubPow_eq_choose` and `card_weakComposition`. New here: the elementary `(−1)ⁿ` restatement and the bridge tying the generalized binomial coefficient to the parent entry's enumerative generating function.

## Verification

- `#print axioms` on all main results: only `propext / Classical.choice / Quot.sound` — **0-axiom, 0 sorries, no native_decide**.
- Built with the Docker wrapper / `lake env lean` against Mathlib 4.26.0.
- Numeric sanity checks compiled: `C(−2,3) = −4`, `C(−3,2) = 6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)