### PR TITLE
Fix: add missing leanFile metadata to compactness-finite-subcover-oq-01-oq-02-oq-01

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01/meta.json
@@ -139,5 +139,22 @@
         "module": "Mathlib.Analysis.SpecificLimits.Basic"
       }
     ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "CompactnessFiniteSubcoverOq01Oq02Oq01",
+    "lineCount": 100,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/CompactnessFiniteSubcoverOq01Oq02Oq01.lean",
+    "sorries": 0
   }
 }


### PR DESCRIPTION
## Fix

The gallery entry `compactness-finite-subcover-oq-01-oq-02-oq-01` ("Nested Closed Intervals Shrinking to a Point") is marked `status: verified` with a full write-up citing "100 lines, 2 theorems, 0 axioms, 0 sorries", but its `meta.json` was missing the `leanFile` key entirely — the sole verified gallery entry with no source pointer.

## Evidence

**Before**: `meta.json` had no `leanFile` field. A gallery-wide scan of all 102 `status: verified` entries found this was the only one whose source could not be resolved (`leanFile: null`).

**After**: Populated `leanFile` pointing to the real source `proofs/Proofs/CompactnessFiniteSubcoverOq01Oq02Oq01.lean`, which exists (shipped in #28029) and matches the claimed stats exactly:
- `wc -l` → 100 lines
- `grep -c "^axiom "` → 0 axioms
- `grep -c "\bsorry\b"` → 0 sorries
- 2 theorems (`nested_intervals_iInter_singleton`, `iInter_Icc_zero_one_div_eq_zero`)
- imports `Mathlib`, opens `Set Filter Topology`, namespace `CompactnessFiniteSubcoverOq01Oq02Oq01`

Schema mirrors the sibling entry `compactness-finite-subcover-oq-01-oq-02`. Pure additive 17-line metadata change; JSON validated.

---
Automated fix by lean-mechanic agent.