### PR TITLE
research(combinations-formula-oq-03-oq-02): Gauss's q-binomial theorem [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ0302.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ0302.lean
@@ -1,0 +1,154 @@
+import Proofs.CombinationsFormulaOQ03
+import Mathlib.Tactic
+
+/-
+# The q-Binomial Theorem (Gauss's q-Analog of the Binomial Theorem)
+
+## What This Proves
+Gauss's finite q-binomial theorem: the product of the linear factors
+`(1 + q^i x)` for `i = 0, …, n-1` expands as a q-weighted sum of the
+Gaussian binomial coefficients,
+
+    ∏_{i=0}^{n-1} (1 + q^i · x) = ∑_{k=0}^{n} [n choose k]_q · q^{C(k,2)} · x^k,
+
+where `C(k,2) = k(k-1)/2 = Nat.choose k 2` is the k-th triangular number.
+This is the fundamental identity of the theory of q-hypergeometric series and
+the q-analog of the classical binomial theorem `(1 + x)^n = ∑ C(n,k) x^k`
+(recovered here by setting `q = 1`).
+
+## Approach
+- Reuse the q-binomial framework from `CombinationsFormulaOQ03` (namespace
+  `QBinomialCoefficients`): the definition `qBinom`, the two q-Pascal
+  recurrences, the vanishing lemma, and the `q = 1` specialization.
+- Prove the main identity by induction on `n`. The inductive step multiplies
+  the level-`n` expansion by `(1 + q^n x)`, re-indexes, and matches
+  coefficients using the *second* q-Pascal recurrence
+  `[n+1,k+1]_q = q^{n-k}·[n,k]_q + [n,k+1]_q`
+  together with the triangular-number identity `C(k+1,2) = k + C(k,2)`.
+- Derive corollaries: the signed form `∏ (1 - q^i x)` (substitute `x ↦ -x`)
+  and the classical binomial theorem (`q = 1`).
+
+## Status
+- [x] q-binomial theorem `∏ (1 + q^i x) = ∑ [n,k]_q q^{C(k,2)} x^k`
+- [x] Signed variant `∏ (1 - q^i x) = ∑ (-1)^k [n,k]_q q^{C(k,2)} x^k`
+- [x] Classical binomial theorem recovered at `q = 1`
+- [x] Concrete verification at `n = 2`
+
+## Provenance
+Answers `combinations-formula-oq-03-oq-02`: the q-analog of the binomial theorem
+as a polynomial identity, foundational identity of q-hypergeometric series.
+The parent entry (`combinations-formula-oq-03`) built the `qBinom` machinery but
+stopped short of this generating-function identity.
+-/
+
+namespace QBinomialCoefficients
+
+open Finset
+
+variable {R : Type*} [CommRing R]
+
+-- ============================================================
+-- The q-Binomial Theorem
+-- ============================================================
+
+/-- **Gauss's q-Binomial Theorem** (finite form).
+
+    `∏_{i=0}^{n-1} (1 + q^i · x) = ∑_{k=0}^{n} [n choose k]_q · q^{C(k,2)} · x^k`.
+
+    The exponent `C(k,2) = Nat.choose k 2 = k(k-1)/2` is the k-th triangular
+    number. At `q = 1` every `q^{C(k,2)}` collapses to `1` and each `[n,k]_1`
+    becomes `C(n,k)`, recovering the ordinary binomial theorem. -/
+theorem qBinom_gauss (q x : R) : ∀ n : ℕ,
+    ∏ i ∈ Finset.range n, (1 + q ^ i * x)
+      = ∑ k ∈ Finset.range (n + 1), qBinom q n k * q ^ (Nat.choose k 2) * x ^ k := by
+  intro n
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    -- Coefficient recurrence: the (k+1)-st level-(n+1) term splits into a
+    -- `q^n x`-shifted level-n term plus the level-n term of the same index.
+    have hkey : ∀ k, k ≤ n →
+        qBinom q (n + 1) (k + 1) * q ^ (Nat.choose (k + 1) 2) * x ^ (k + 1)
+          = q ^ n * x * (qBinom q n k * q ^ (Nat.choose k 2) * x ^ k)
+            + qBinom q n (k + 1) * q ^ (Nat.choose (k + 1) 2) * x ^ (k + 1) := by
+      intro k hk
+      have hc : Nat.choose (k + 1) 2 = k + Nat.choose k 2 := by
+        rw [Nat.choose_succ_succ k 1, Nat.choose_one_right]
+      have hexp : q ^ (n - k) * q ^ (Nat.choose (k + 1) 2)
+          = q ^ n * q ^ (Nat.choose k 2) := by
+        rw [← pow_add, ← pow_add, hc]; congr 1; omega
+      rw [qBinom_pascal' q n k (by omega)]
+      linear_combination (qBinom q n k * x ^ (k + 1)) * hexp
+    -- The `k = n+1` term of the level-n family vanishes (index exceeds `n`).
+    have hlast : qBinom q n (n + 1) * q ^ (Nat.choose (n + 1) 2) * x ^ (n + 1) = 0 := by
+      rw [qBinom_eq_zero_of_lt q n (n + 1) (by omega)]; ring
+    -- `1` equals the `k = 0` level-n term, used to re-fold the shifted sum.
+    have hg0 : qBinom q n 0 * q ^ (Nat.choose 0 2) * x ^ 0 = 1 := by simp
+    -- Shift identity: ∑_{k<n+1} g(k+1) + 1 = ∑_{k<n+1} g(k).
+    have hshift :
+        (∑ k ∈ Finset.range (n + 1),
+            qBinom q n (k + 1) * q ^ (Nat.choose (k + 1) 2) * x ^ (k + 1)) + 1
+          = ∑ k ∈ Finset.range (n + 1), qBinom q n k * q ^ (Nat.choose k 2) * x ^ k := by
+      rw [← hg0,
+          ← Finset.sum_range_succ' (fun k => qBinom q n k * q ^ (Nat.choose k 2) * x ^ k) (n + 1),
+          Finset.sum_range_succ (fun k => qBinom q n k * q ^ (Nat.choose k 2) * x ^ k) (n + 1),
+          hlast, add_zero]
+    -- Main computation.
+    rw [Finset.prod_range_succ, ih,
+        Finset.sum_range_succ' (fun k => qBinom q (n + 1) k * q ^ (Nat.choose k 2) * x ^ k) (n + 1),
+        Finset.sum_congr rfl
+          (fun k hk => hkey k (Nat.lt_succ_iff.mp (Finset.mem_range.mp hk))),
+        Finset.sum_add_distrib, ← Finset.mul_sum]
+    -- Goal: (∑ g) * (1 + q^n x) = (q^n x * ∑ g + ∑ g(k+1)) + G 0
+    have hG0 : qBinom q (n + 1) 0 * q ^ (Nat.choose 0 2) * x ^ 0 = 1 := by simp
+    rw [hG0, add_assoc, hshift]
+    ring
+
+-- ============================================================
+-- Corollaries
+-- ============================================================
+
+/-- **Signed q-Binomial Theorem**: substituting `x ↦ -x` gives the alternating
+    product `∏ (1 - q^i x)` expanded with signs `(-1)^k`. -/
+theorem qBinom_gauss_neg (q x : R) (n : ℕ) :
+    ∏ i ∈ Finset.range n, (1 - q ^ i * x)
+      = ∑ k ∈ Finset.range (n + 1),
+          (-1) ^ k * qBinom q n k * q ^ (Nat.choose k 2) * x ^ k := by
+  have h := qBinom_gauss q (-x) n
+  rw [Finset.prod_congr rfl
+        (fun i _ => by ring :
+          ∀ i ∈ Finset.range n, 1 + q ^ i * (-x) = 1 - q ^ i * x)] at h
+  rw [h]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  rw [show (-x) = (-1 : R) * x by ring, mul_pow]
+  ring
+
+/-- **Classical Binomial Theorem, recovered at `q = 1`**:
+    `(1 + x)^n = ∑_{k=0}^{n} C(n,k) · x^k`.
+    This exhibits the q-binomial theorem as a genuine generalization. -/
+theorem binom_theorem_of_qBinom (x : R) (n : ℕ) :
+    (1 + x) ^ n = ∑ k ∈ Finset.range (n + 1), (Nat.choose n k : R) * x ^ k := by
+  have h := qBinom_gauss (1 : R) x n
+  simp only [one_pow, one_mul, mul_one, qBinom_at_one] at h
+  rw [Finset.prod_const, Finset.card_range] at h
+  exact h
+
+-- ============================================================
+-- Concrete verification
+-- ============================================================
+
+/-- At `n = 2`: `(1 + x)(1 + q x) = 1 + (1 + q) x + q x^2`. -/
+example (q x : R) :
+    ∏ i ∈ Finset.range 2, (1 + q ^ i * x) = 1 + (1 + q) * x + q * x ^ 2 := by
+  rw [Finset.prod_range_succ, Finset.prod_range_succ, Finset.prod_range_zero]
+  ring
+
+/-- The n = 2 expansion matches the q-binomial theorem's right-hand side. -/
+example (q x : R) :
+    (∑ k ∈ Finset.range 3, qBinom q 2 k * q ^ (Nat.choose k 2) * x ^ k)
+      = 1 + (1 + q) * x + q * x ^ 2 := by
+  rw [Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_succ,
+      Finset.sum_range_zero]
+  simp [qBinom]
+
+end QBinomialCoefficients

--- a/src/data/proofs/combinations-formula-oq-03-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-02/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "combinations-formula-oq-03-oq-02",
+  "slug": "combinations-formula-oq-03-oq-02",
+  "title": "Gauss's q-Binomial Theorem (Finite Form)",
+  "description": "A follow-up to combinations-formula-oq-03 (Gaussian binomial coefficients). The parent builds the division-free q-binomial machinery — qNumber, qBinom, the two q-Pascal recurrences, the vanishing lemma, and the q=1 specialization — but stops short of the generating-function identity that ties them together. This entry proves Gauss's finite q-binomial theorem, ∏_{i=0}^{n-1}(1 + q^i·x) = ∑_{k=0}^{n} [n,k]_q · q^{C(k,2)} · x^k, over an arbitrary commutative ring, by induction on n using the second q-Pascal recurrence and the triangular-number identity C(k+1,2) = k + C(k,2). It then derives the signed variant ∏(1 − q^i·x) = ∑(−1)^k [n,k]_q q^{C(k,2)} x^k (substitute x ↦ −x) and recovers the classical binomial theorem (1+x)^n = ∑ C(n,k) x^k by specializing to q=1. Verified, axiom-free, sorry-free.",
+  "overview": {
+    "historicalContext": "**Gauss and the q-Binomial Theorem**\n\nThe q-binomial theorem — the identity ∏_{i=0}^{n-1}(1 + q^i x) = ∑_k [n,k]_q q^{C(k,2)} x^k — is the finite, single-variable heart of the theory of q-hypergeometric (basic hypergeometric) series developed by Gauss, Heine, and later Rogers and Ramanujan. Setting q = 1 collapses every q-weight to 1 and every Gaussian binomial [n,k]_q to the ordinary C(n,k), recovering the classical binomial theorem; so the identity exhibits the Gaussian binomials as the natural coefficients of a q-deformed product. The finite form is the springboard for the infinite q-binomial series and the Jacobi triple product.\n\nThe parent gallery entry combinations-formula-oq-03 formalizes the Gaussian binomial coefficients division-free over an arbitrary commutative ring — q-numbers, q-Pascal recurrences, symmetry, the q-hockey-stick and q-Vandermonde identities — but never assembles them into this generating-function identity. This entry closes that gap.",
+    "problemStatement": "**Goal**\n\nProve Gauss's finite q-binomial theorem as a polynomial identity over an arbitrary commutative ring, and derive its signed variant and its q=1 specialization.\n\n**Result**: ∏_{i=0}^{n-1}(1 + q^i·x) = ∑_{k=0}^{n} [n,k]_q · q^{C(k,2)} · x^k, where C(k,2) = k(k−1)/2 is the k-th triangular number.",
+    "text": "Proves Gauss's finite q-binomial theorem ∏(1 + q^i x) = ∑ [n,k]_q q^{C(k,2)} x^k over an arbitrary CommRing, with the signed variant and the classical binomial theorem as corollaries.",
+    "proofStrategy": "**Approach**\n\n1. Induct on n. The base case n = 0 is `simp` (empty product = 1 = single k=0 term).\n2. Inductive step: multiply the level-n expansion by the new factor (1 + q^n·x) via `Finset.prod_range_succ` and the hypothesis.\n3. The coefficient recurrence `hkey`: for k ≤ n, the (k+1)-st level-(n+1) term splits into a q^n·x-shifted level-n term of index k plus the level-n term of index k+1. This is exactly the second q-Pascal recurrence `qBinom_pascal'`, combined with the exponent bookkeeping q^{n−k}·q^{C(k+1,2)} = q^n·q^{C(k,2)} (using C(k+1,2) = k + C(k,2)); closed by `linear_combination`.\n4. The top level-n term of index n+1 vanishes (`qBinom_eq_zero_of_lt`), and the constant terms match (both k=0 terms equal 1), giving a shift identity `hshift` that re-folds the shifted sum.\n5. Assemble with `Finset.sum_add_distrib`, `Finset.mul_sum`, and `ring`.\n6. Corollaries: substitute x ↦ −x for the signed form; specialize q = 1 (`qBinom_at_one`, `one_pow`, product of constants) for the classical binomial theorem.",
+    "keyInsights": [
+      "**One recurrence drives the whole induction**: The entire inductive step is powered by the second q-Pascal recurrence [n+1,k+1]_q = q^{n−k}[n,k]_q + [n,k+1]_q. The q-weights q^{C(k,2)} are precisely what makes this recurrence collapse the product-times-(1+q^n x) into the next-level sum.",
+      "**Triangular-number exponent bookkeeping is the crux**: The identity C(k+1,2) = k + C(k,2) is what lets the shift factor q^{n−k} from q-Pascal combine with q^{C(k+1,2)} to give the clean q^n·q^{C(k,2)} needed to match the shifted term — no other exponent identity is required.",
+      "**Division-free over any CommRing**: Because the parent's [n,k]_q is defined by the division-free q-Pascal recurrence (not as a quotient of q-factorials), the whole theorem holds over an arbitrary commutative ring with no invertibility hypothesis on q — q can even be a zero divisor or 0.",
+      "**q=1 is a genuine generalization, not a coincidence**: Specializing q=1 sends q^{C(k,2)} ↦ 1 and [n,k]_1 ↦ C(n,k), and the product ∏(1 + x) becomes (1+x)^n — so the classical binomial theorem drops out as a one-line corollary, certifying the q-analog.",
+      "**Signed form for free**: The alternating product ∏(1 − q^i x) is just the x ↦ −x substitution, giving the (−1)^k signs used in the finite Jacobi-triple-product and q-series manipulations."
+    ],
+    "prerequisites": [
+      "Gaussian binomial coefficients and the division-free q-Pascal recurrences (parent entry combinations-formula-oq-03)",
+      "Finite products and sums over Finset.range (Finset.prod_range_succ, Finset.sum_range_succ')",
+      "The triangular-number identity C(k+1,2) = k + C(k,2)",
+      "Induction and polynomial identities over a commutative ring (linear_combination, ring)"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "qBinom_gauss",
+      "type": "core",
+      "description": "Gauss's finite q-binomial theorem: ∏_{i<n}(1 + q^i·x) = ∑_{k≤n} [n,k]_q · q^{C(k,2)} · x^k",
+      "leanType": "∀ (q x : R) (n : ℕ), ∏ i ∈ Finset.range n, (1 + q ^ i * x) = ∑ k ∈ Finset.range (n + 1), qBinom q n k * q ^ (Nat.choose k 2) * x ^ k"
+    },
+    {
+      "name": "qBinom_gauss_neg",
+      "type": "corollary",
+      "description": "Signed variant: ∏_{i<n}(1 − q^i·x) = ∑_{k≤n} (−1)^k [n,k]_q q^{C(k,2)} x^k (substitute x ↦ −x)",
+      "leanType": "∀ (q x : R) (n : ℕ), ∏ i ∈ Finset.range n, (1 - q ^ i * x) = ∑ k ∈ Finset.range (n + 1), (-1) ^ k * qBinom q n k * q ^ (Nat.choose k 2) * x ^ k"
+    },
+    {
+      "name": "binom_theorem_of_qBinom",
+      "type": "corollary",
+      "description": "Classical binomial theorem recovered at q=1: (1+x)^n = ∑_{k≤n} C(n,k) x^k",
+      "leanType": "∀ (x : R) (n : ℕ), (1 + x) ^ n = ∑ k ∈ Finset.range (n + 1), (Nat.choose n k : R) * x ^ k"
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Motivation: The Identity the Parent Left Unassembled",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Explains that the parent builds the q-binomial machinery (qBinom, q-Pascal recurrences, vanishing, q=1) but never proves the generating-function identity; this entry supplies it plus two corollaries.",
+      "mathContext": "$\\prod_{i=0}^{n-1}(1 + q^i x) = \\sum_{k=0}^{n} \\binom{n}{k}_q q^{\\binom{k}{2}} x^k$."
+    },
+    {
+      "id": "main",
+      "title": "Gauss's q-Binomial Theorem",
+      "startLine": 44,
+      "endLine": 105,
+      "summary": "qBinom_gauss by induction on n: multiply by (1 + q^n x), split via the coefficient recurrence hkey (second q-Pascal + C(k+1,2)=k+C(k,2)), vanish the top term, re-fold with the shift identity, close by ring.",
+      "mathContext": "Inductive step uses $\\binom{n+1}{k+1}_q = q^{n-k}\\binom{n}{k}_q + \\binom{n}{k+1}_q$ and $q^{n-k}q^{\\binom{k+1}{2}} = q^n q^{\\binom{k}{2}}$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Signed Variant and the Classical Binomial Theorem",
+      "startLine": 107,
+      "endLine": 134,
+      "summary": "qBinom_gauss_neg (x ↦ −x gives the alternating product with (−1)^k signs) and binom_theorem_of_qBinom (q=1 collapses q^{C(k,2)} to 1 and [n,k]_1 to C(n,k), recovering (1+x)^n).",
+      "mathContext": "$\\prod(1 - q^i x) = \\sum (-1)^k \\binom{n}{k}_q q^{\\binom{k}{2}} x^k$; at $q=1$, $(1+x)^n = \\sum \\binom{n}{k} x^k$."
+    },
+    {
+      "id": "verification",
+      "title": "Concrete Verification at n = 2",
+      "startLine": 136,
+      "endLine": 153,
+      "summary": "Two examples: the product (1+x)(1+qx) expands to 1 + (1+q)x + qx², and the q-binomial right-hand side at n=2 matches it.",
+      "mathContext": "$(1+x)(1+qx) = 1 + (1+q)x + qx^2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves Gauss's finite q-binomial theorem ∏_{i<n}(1 + q^i·x) = ∑_{k≤n} [n,k]_q q^{C(k,2)} x^k over an arbitrary commutative ring — the generating-function identity the parent's machinery was built for but never assembled — together with the signed variant and the classical binomial theorem at q=1. Fully verified, axiom-free.",
+    "implications": "Completes the parent's q-binomial development by delivering its central generating-function identity, exhibits the Gaussian binomials as the natural coefficients of a q-deformed product, and certifies the whole q-analog by recovering the classical binomial theorem at q=1. The division-free, arbitrary-CommRing formulation is the finite springboard for the infinite q-binomial series and finite Jacobi-triple-product manipulations.",
+    "openQuestions": [
+      "Can the q-Vandermonde convolution (proved in the parent) be re-derived as a coefficient identity by expanding ∏_{i<m+n}(1 + q^i x) two ways, giving a generating-function proof independent of the subspace-counting argument?",
+      "Does the finite identity pass to the infinite q-binomial series ∏_{i≥0}(1 + q^i x) = ∑_k q^{C(k,2)} x^k / ((1−q)⋯(1−q^k)) under a formal-power-series or |q|<1 analytic hypothesis in Lean?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-03",
+      "relationship": "completes",
+      "description": "Assembles the parent's qBinom machinery (qBinom, qBinom_pascal', qBinom_eq_zero_of_lt, qBinom_at_one) into the generating-function identity the parent built toward but never proved"
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "generalizes",
+      "description": "Recovers the classical binomial theorem (1+x)^n = ∑ C(n,k) x^k as the q=1 specialization"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "G. E. Andrews"
+      ],
+      "title": "The Theory of Partitions",
+      "year": "1976",
+      "note": "Standard reference for the finite and infinite q-binomial theorems and q-series"
+    },
+    {
+      "authors": [
+        "V. Kac",
+        "P. Cheung"
+      ],
+      "title": "Quantum Calculus",
+      "year": "2002",
+      "note": "Gauss's q-binomial theorem and the C(k,2) exponent weighting"
+    }
+  ],
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ0302.lean",
+    "tags": [
+      "combinatorics",
+      "q-analogs",
+      "gaussian-binomial",
+      "q-binomial-theorem",
+      "generating-functions",
+      "algebra",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All results depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound); there are no axiom declarations, no sorries, and no structure-encoded assumptions. Proved over an arbitrary commutative ring R with parameters q x : R and no invertibility hypothesis. Built on the parent's division-free q-binomial API (qBinom, qBinom_pascal', qBinom_eq_zero_of_lt, qBinom_at_one) and Mathlib's Nat.choose and Finset product/sum lemmas.",
+    "lineCount": 154,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ0302.lean",
+    "imports": [
+      "Proofs.CombinationsFormulaOQ03",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "QBinomialCoefficients",
+    "lineCount": 154,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "sorries": 0,
+    "mainTheorems": [
+      {
+        "name": "qBinom_gauss",
+        "type": "core",
+        "statement": "∀ (q x : R) (n : ℕ), ∏ i ∈ Finset.range n, (1 + q ^ i * x) = ∑ k ∈ Finset.range (n + 1), qBinom q n k * q ^ (Nat.choose k 2) * x ^ k",
+        "description": "Gauss's finite q-binomial theorem over an arbitrary commutative ring.",
+        "significance": "The central generating-function identity of the q-binomial theory; the parent's machinery was built for this but never assembled it"
+      },
+      {
+        "name": "binom_theorem_of_qBinom",
+        "type": "corollary",
+        "statement": "∀ (x : R) (n : ℕ), (1 + x) ^ n = ∑ k ∈ Finset.range (n + 1), (Nat.choose n k : R) * x ^ k",
+        "description": "Classical binomial theorem recovered by setting q = 1.",
+        "significance": "Certifies the q-analog as a genuine generalization of the ordinary binomial theorem"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves **Gauss's finite q-binomial theorem** over an arbitrary commutative ring:

$$\prod_{i=0}^{n-1}(1 + q^i x) = \sum_{k=0}^{n} \binom{n}{k}_q \, q^{\binom{k}{2}} \, x^k$$

where $\binom{k}{2} = $ `Nat.choose k 2` is the $k$-th triangular number. Answers `combinations-formula-oq-03-oq-02`.

The parent entry `combinations-formula-oq-03` builds the division-free q-binomial machinery (`qBinom`, both q-Pascal recurrences, the vanishing lemma, the $q=1$ specialization) but never assembles it into this generating-function identity. This entry supplies it.

## Theorems (3, 154 lines, 0 axioms, 0 sorries)

- **`qBinom_gauss`** — the theorem, by induction on $n$: the inductive step multiplies by $(1 + q^n x)$ and matches coefficients via the second q-Pascal recurrence $\binom{n+1}{k+1}_q = q^{n-k}\binom{n}{k}_q + \binom{n}{k+1}_q$ together with $\binom{k+1}{2} = k + \binom{k}{2}$.
- **`qBinom_gauss_neg`** — signed variant $\prod(1 - q^i x) = \sum (-1)^k \binom{n}{k}_q q^{\binom{k}{2}} x^k$ (substitute $x \mapsto -x$).
- **`binom_theorem_of_qBinom`** — the classical binomial theorem $(1+x)^n = \sum \binom{n}{k} x^k$ recovered at $q=1$, certifying the q-analog as a genuine generalization.

Plus two concrete $n=2$ verification examples.

## Verification

Built with `lake env lean` against prebuilt Mathlib + parent oleans. `#print axioms` on all three theorems shows only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms, 0 sorries, verified**. Division-free over any `CommRing`, no invertibility hypothesis on `q`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)