### PR TITLE
Enrich The Cassini Defect Calculus (pell-equation-oq-07-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/pell-equation-oq-07-oq-01-oq-02/meta.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01-oq-02/meta.json
@@ -68,5 +68,94 @@
       "relationship": "related",
       "description": "That entry proves the Fibonacci Cassini identity Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ via det(Qⁿ) = (−1)ⁿ. Here it is the p = 1, q = −1 instantiation of a single abstract theorem (cassiniDefect_eq) that also yields the Pell Cassini identity — making explicit that Fibonacci's alternating sign and Pell's constant invariant are the two faces of D(k) = qᵏ·D(0)."
     }
-  ]
+  ],
+  "overview": {
+    "historicalContext": "Cassini's identity Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ was published in 1680 by the Italian-French astronomer Giovanni Domenico (Jean-Dominique) Cassini and rediscovered by Robert Simson in 1753 (hence the alternative name Simson's identity). Eugène Charles Catalan generalized it in the 19th century to Fₙ² − Fₙ₋ᵣFₙ₊ᵣ = (−1)ⁿ⁻ʳFᵣ². The modern viewpoint recognizes both as instances of the multiplicativity of the determinant applied to the Fibonacci Q-matrix !![1,1;1,0], whose n-th power carries consecutive Fibonacci numbers and whose determinant −1 raised to the n-th power reproduces the alternating sign. The parallel phenomenon for Pell's equation x² − d·y² = 1 — studied by Brahmagupta (628), Bhāskara II's chakravala method (1150), and completed in Europe by Lagrange (1768) — arises because the Pell coordinate sequences re(aⁿ), im(aⁿ) of a quadratic integer a ∈ ℤ[√d] satisfy their own second-order recurrence whose companion matrix has determinant N(a). This entry unifies the two stories: it isolates the single ring-theoretic mechanism, the scaling law D(k+1) = q·D(k) of the Cassini defect, that makes Fibonacci's (−1)ⁿ and Pell's norm-power invariant the same theorem.",
+    "problemStatement": "For a sequence $u : \\mathbb{N} \\to R$ over a commutative ring $R$, define the Cassini defect $D(k) = u(k{+}2)\\,u(k) - u(k{+}1)^2$. If $u$ satisfies the second-order linear recurrence $u(n{+}2) = p\\,u(n{+}1) - q\\,u(n)$, prove that $D$ satisfies the first-order recurrence $D(k{+}1) = q\\,D(k)$, hence $D(k) = q^k D(0)$; and identify $D(k)$ as the determinant of the $2\\times2$ state matrix $\\begin{pmatrix} u(k{+}2) & u(k{+}1)\\\\ u(k{+}1) & u(k)\\end{pmatrix}$, so that $D(k) = q^k D(0)$ is the identity $\\det(C^k W_0) = (\\det C)^k \\det(W_0)$ for the companion $C = \\begin{pmatrix} p & -q\\\\ 1 & 0\\end{pmatrix}$.",
+    "proofStrategy": "The proof is a four-step tower over an arbitrary commutative ring. (1) Define the Cassini defect for an arbitrary sequence, deferring all recurrence and ring specialization. (2) Prove the one-step scaling law cassiniDefect_succ by a single linear_combination: substituting the two top recurrence instances (at k and k+1) into D(k+1) − q·D(k) collapses it to u(k+2)·(p·u(k+1) − q·u(k) − u(k+2)) = 0; the p-dependence cancels and only q survives. (3) Integrate the scaling law by a one-line induction to get cassiniDefect_eq: D(k) = qᵏ·D(0). (4) Reframe the defect as a determinant via Matrix.det_fin_two_of (cassiniDefect_eq_det), then combine to obtain the determinant form cassini_det_eq. Finally, instantiate: p=1, q=−1 recovers Fibonacci Cassini; p=2·re(a), q=N(a) via the grandparent's re_recurrence recovers the Pell identity, with the Pell-unit case (N(a)=1) collapsing to a constant, checked numerically for 3+2√2 by kernel decide.",
+    "keyInsights": [
+      "The Cassini defect of a *second*-order recurrence obeys a *first*-order recurrence D(k+1) = q·D(k). This drop in order — from two-term to one-term — is precisely why Cassini/Catalan identities have simple closed forms: a first-order linear recurrence integrates to a pure geometric term qᵏ.",
+      "Only q survives, p vanishes. In the scaling law the coefficient p of the recurrence cancels completely; the defect's growth factor is entirely the constant term q = det of the companion matrix. This is the algebraic shadow of det(C) depending only on the bottom coefficient for a companion matrix.",
+      "The Cassini defect IS a determinant. D(k) = det !![u(k+2),u(k+1);u(k+1),u k] exhibits the elementary product-minus-square as the determinant of the recurrence's state matrix, turning the identity into a statement about determinants of matrix powers.",
+      "D(k) = qᵏ·D(0) is exactly det(Cᵏ·W₀) = (det C)ᵏ·det(W₀). The abstract Cassini theorem is the sharpest form of the multiplicativity law det(Mⁿ) = (det M)ⁿ, specialized to the companion matrix C = !![p,−q;1,0] with det C = q.",
+      "Fibonacci's alternating sign and Pell's norm invariant are one theorem. Setting q = −1 gives Cassini's (−1)ⁿ; setting q = N(a) gives the Pell coordinate identity. The single parameter q in D(k) = qᵏ·D(0) interpolates between the two classical results.",
+      "A Pell unit has a *constant* Cassini invariant. When N(a) = 1 the factor N(a)ᵏ = 1 disappears entirely, so re(aᵏ⁺²)·re(aᵏ) − re(aᵏ⁺¹)² = d·y₁² is independent of k — the arithmetic fingerprint of a solution to x² − d·y² = 1.",
+      "The result is ring-agnostic. Stating everything over an arbitrary CommRing R means one proof serves ℤ (Fibonacci), ℤ[√d] coordinates (Pell), and any other second-order recurrence, so the classical case-by-case proofs become instantiations of a single lemma."
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-header",
+      "title": "The Cassini defect calculus",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "Module docstring motivating the abstraction: the Cassini defect D(k) = u(k+2)·u(k) − u(k+1)² of any second-order recurrence over any commutative ring, its scaling law D(k+1) = q·D(k), the integrated form D(k) = qᵏ·D(0), the determinant identification, and the Fibonacci/Pell instantiations."
+    },
+    {
+      "id": "imports-setup",
+      "title": "Imports and namespace",
+      "startLine": 68,
+      "endLine": 72,
+      "summary": "Imports the grandparent Pell file (for Zsqrtd.re_recurrence) and opens the Zsqrtd namespace; all subsequent results live in namespace PellEquationOQ07OQ01OQ02."
+    },
+    {
+      "id": "def-cassini-defect",
+      "title": "Definition: the Cassini defect",
+      "startLine": 74,
+      "endLine": 78,
+      "summary": "Defines cassiniDefect u k = u(k+2)·u(k) − u(k+1)² for an arbitrary sequence u : ℕ → R over a commutative ring, deliberately independent of any recurrence so downstream theorems are reusable."
+    },
+    {
+      "id": "scaling-law",
+      "title": "One-step scaling law D(k+1) = q·D(k)",
+      "startLine": 80,
+      "endLine": 91,
+      "summary": "cassiniDefect_succ: from u(n+2) = p·u(n+1) − q·u(n), the defect scales by q each step. Proved by a single linear_combination against the recurrence at k and k+1, collapsing D(k+1) − q·D(k) to u(k+2)·(p·u(k+1) − q·u(k) − u(k+2)) = 0."
+    },
+    {
+      "id": "integrated-identity",
+      "title": "Integrated identity D(k) = qᵏ·D(0)",
+      "startLine": 93,
+      "endLine": 101,
+      "summary": "cassiniDefect_eq: integrating the scaling law by induction gives the closed form D(k) = qᵏ·D(0), the abstract Cassini/Catalan theorem u(k+2)·u(k) − u(k+1)² = qᵏ·(u₂u₀ − u₁²)."
+    },
+    {
+      "id": "determinant-form",
+      "title": "The defect as a state-matrix determinant",
+      "startLine": 103,
+      "endLine": 119,
+      "summary": "cassiniDefect_eq_det identifies D(k) with det !![u(k+2),u(k+1);u(k+1),u k] via Matrix.det_fin_two_of; cassini_det_eq combines this with the integrated identity to give det(W k) = qᵏ·det(W 0) = det(Cᵏ·W₀) = (det C)ᵏ·det(W₀)."
+    },
+    {
+      "id": "fibonacci-instantiation",
+      "title": "Fibonacci instantiation (p=1, q=−1)",
+      "startLine": 121,
+      "endLine": 134,
+      "summary": "Specializing to the additive recurrence F(n+2) = F(n+1) + F(n) yields Fₖ₊₂·Fₖ − Fₖ₊₁² = (−1)ᵏ·(F₂F₀ − F₁²), i.e. Cassini's 1680 identity (−1)ᵏ⁺¹ for the standard seed."
+    },
+    {
+      "id": "pell-instantiation",
+      "title": "Pell instantiations and the Pell-unit constant",
+      "startLine": 136,
+      "endLine": 162,
+      "summary": "Feeding the grandparent's re_recurrence (p = 2·re a, q = N(a)) into cassiniDefect_eq recovers the sibling's Pell coordinate Cassini identity; for a Pell unit (N(a) = 1) the norm power vanishes and the defect is the constant d·y₁²."
+    },
+    {
+      "id": "numeric-check",
+      "title": "Numeric verification and signatures",
+      "startLine": 164,
+      "endLine": 176,
+      "summary": "A kernel-decide check that the base defect of the fundamental unit 3 + 2√2 of x² − 2y² = 1 equals 8 = 2·2², plus #check signatures of the five main declarations."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry distills the Cassini and Catalan identities down to a single ring-theoretic mechanism: the Cassini defect D(k) = u(k+2)·u(k) − u(k+1)² of any second-order linear recurrence over any commutative ring satisfies the first-order scaling law D(k+1) = q·D(k), hence the closed form D(k) = qᵏ·D(0). Because the defect is the determinant of the recurrence's 2×2 state matrix, this closed form is exactly the multiplicativity identity det(Cᵏ·W₀) = (det C)ᵏ·det(W₀) for the companion matrix C = !![p,−q;1,0] with det C = q. Fibonacci's Cassini identity (q = −1, alternating sign) and the Pell coordinate identity (q = N(a), norm-power invariant, constant for a Pell unit) both fall out as one-line instantiations.",
+    "implications": "Abstracting the identity over an arbitrary CommRing turns a family of case-by-case classical proofs into instances of a single four-line lemma tower, and makes explicit that the alternating sign of Cassini and the norm invariant of Pell are the same phenomenon read at different values of the parameter q. The determinant reframing connects the elementary product-minus-square to the linear-algebra viewpoint (companion matrix, det of a matrix power) that also governs Binet-type formulas and the eigenvalue structure of the recurrence, and the whole development is machine-checked with 0 axioms and 0 sorries.",
+    "openQuestions": [
+      "Does the analogous r-step defect u(k+r)·u(k) − (mixed products) admit a clean scaling law recovering Catalan's identity Fₙ² − Fₙ₋ᵣFₙ₊ᵣ = (−1)ⁿ⁻ʳFᵣ² in the same abstract framework?",
+      "Can the state-matrix determinant argument be lifted to higher-order (m-th order) linear recurrences, where the invariant becomes the determinant of an m×m Casoratian-type matrix and scales by the product of the companion matrix's determinant?",
+      "For Pell units, is the constant invariant d·y₁² the boundary case of a more refined identity tracking the full state matrix Cᵏ, giving a matrix-valued strengthening of the constancy?",
+      "What is the precise relationship between the Cassini defect calculus and the theory of the Casoratian (the discrete Wronskian) for linear difference equations, and does the qᵏ scaling generalize Abel's identity to that setting?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-07-oq-01-oq-02`.

**Gaps filled** (all four scored 0 in find-targets quality breakdown):
- **overview**: added `historicalContext` (Cassini 1680 / Simson 1753 / Catalan; Pell via Brahmagupta to Bhaskara II to Lagrange; Q-matrix determinant viewpoint), `problemStatement` (LaTeX), `proofStrategy`, and **7 keyInsights**
- **sections**: **9 sections** covering the full 176-line Lean file with correct line ranges
- **conclusion**: `summary`, `implications`, and **4 openQuestions**

Annotations (11, already rich) and crossReferences (4) left intact. meta.json 7KB to 17.7KB, within 60KB cap; JSON + schema validated, no anchor errors. Axiom status unchanged (verified, 0 axioms; single decide is kernel decide, not native_decide).