### PR TITLE
Enrich Multiplicativity of Jacobi's σ* (four-square-distribution-oq-06-oq-02): add annotations.json (0→6)

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/four-square-distribution-oq-06-oq-02/annotations.json
@@ -1,0 +1,152 @@
+[
+  {
+    "id": "ann-4sq-oq0602-header",
+    "proofId": "four-square-distribution-oq-06-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 74
+    },
+    "type": "context",
+    "title": "Repackaging σ*'s summand as an arithmetic function",
+    "content": "The setup makes one decisive modelling choice. Jacobi's modified divisor sum σ*(n) = Σ_{d∣n, 4∤d} d is defined directly (sigmaStar), but the summand [4∤d]·d is ALSO packaged as a Mathlib ArithmeticFunction weightedId. An ArithmeticFunction ℕ is a function ℕ→ℕ required to vanish at 0; here weightedId 0 = 0 holds automatically because 4∣0, so the packaging is legitimate. This is the pivot of the whole proof: once the summand is an ArithmeticFunction, σ* becomes a Dirichlet convolution ζ ⋆ g and multiplicativity follows from Mathlib's convolution machinery rather than from any hand computation.",
+    "mathContext": "$\\sigma^*(n)=\\sum_{d\\mid n}g(d)$ with $g(d)=[4\\nmid d]\\cdot d$; $g(0)=0$ since $4\\mid 0$, so $g$ is a valid ArithmeticFunction.",
+    "significance": "context",
+    "relatedConcepts": [
+      "arithmetic functions",
+      "divisor sums",
+      "Jacobi four-square theorem",
+      "sum of divisors",
+      "Iverson bracket"
+    ],
+    "prerequisites": [
+      "divisors of a natural number",
+      "sum-of-divisors function σ",
+      "arithmetic functions"
+    ]
+  },
+  {
+    "id": "ann-4sq-oq0602-4dvd",
+    "proofId": "four-square-distribution-oq-06-oq-02",
+    "range": {
+      "startLine": 80,
+      "endLine": 102
+    },
+    "type": "insight",
+    "title": "The one divisor fact: a factor of 4 cannot be split across coprime numbers",
+    "content": "four_dvd_mul_of_coprime carries the entire arithmetic content of the proof. For coprime m,n it shows 4∣m·n forces 4∣m or 4∣n. The reason: the two factors of 2 inside 4 cannot be distributed — a single 2 can divide at most one of two coprime numbers. The Lean argument case-splits on 2∣m. If 2∣m, coprimality forbids 2∣n (else 2∣gcd(m,n)=1), so n is coprime to 2 and hence to 4 = 2², and Coprime.dvd_of_dvd_mul_right pushes the whole 4 onto m. If 2∤m, then m is coprime to 4 and the 4 lands on n. Note the direction that matters combinatorially is the contrapositive 4∤m ∧ 4∤n ⟹ 4∤m·n, which is what makes the Iverson weight [4∤·] multiplicative.",
+    "mathContext": "For $\\gcd(m,n)=1$: $4\\mid mn \\Rightarrow 4\\mid m \\lor 4\\mid n$, because $2\\mid\\gcd(m,n)=1$ is impossible, so whichever side is odd is coprime to $4=2^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "coprimality",
+      "prime factorization",
+      "Coprime.dvd_of_dvd_mul",
+      "p-adic valuation",
+      "Euclid's lemma"
+    ],
+    "prerequisites": [
+      "coprimality and gcd",
+      "divisibility of products",
+      "prime two"
+    ]
+  },
+  {
+    "id": "ann-4sq-oq0602-gmult",
+    "proofId": "four-square-distribution-oq-06-oq-02",
+    "range": {
+      "startLine": 104,
+      "endLine": 118
+    },
+    "type": "insight",
+    "title": "The summand g is a multiplicative arithmetic function",
+    "content": "weightedId_isMultiplicative discharges the IsMultiplicative predicate for g: g(1)=1 (immediate, since 4∤1) and g(m·n)=g(m)·g(n) for coprime m,n. The proof is a clean case analysis on 4∣m and 4∣n. If 4∣m then g(m)=0 and 4∣m·n so g(m·n)=0=0·g(n); symmetrically if 4∣n. In the remaining case 4∤m and 4∤n, we need g(m·n)=m·n, i.e. 4∤m·n — which is exactly the contrapositive of four_dvd_mul_of_coprime. So the multiplicativity of the weight reduces entirely to the previous divisor fact; the numeric factor d·(m·n)=(d·m)(d·n) is automatic once the [4∤·] indicator is shown multiplicative.",
+    "mathContext": "$g(mn)=[4\\nmid mn]\\,mn=[4\\nmid m][4\\nmid n]\\,mn=g(m)g(n)$ for $\\gcd(m,n)=1$; the indicator is multiplicative by the coprime-splitting lemma.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multiplicative functions",
+      "IsMultiplicative predicate",
+      "completely multiplicative",
+      "case analysis",
+      "arithmetic functions"
+    ],
+    "prerequisites": [
+      "multiplicative arithmetic functions",
+      "coprimality",
+      "divisibility"
+    ]
+  },
+  {
+    "id": "ann-4sq-oq0602-conv",
+    "proofId": "four-square-distribution-oq-06-oq-02",
+    "range": {
+      "startLine": 120,
+      "endLine": 142
+    },
+    "type": "insight",
+    "title": "σ* = ζ ⋆ g, so multiplicativity is inherited from the convolution",
+    "content": "This is the headline. sigmaStar_eq_zeta_mul identifies σ* with the Dirichlet convolution (ζ * weightedId) via Mathlib's zeta_mul_apply, which unfolds (ζ*f)(n) = Σ_{d∣n} f(d) — precisely σ*'s definition. Then sigmaStar_isMultiplicative applies the general theorem IsMultiplicative.mul: the Dirichlet convolution of two multiplicative arithmetic functions is multiplicative. Since ζ is multiplicative (isMultiplicative_zeta) and g is multiplicative (just proved), σ* = ζ ⋆ g is multiplicative, giving sigmaStar_mul_coprime: σ*(m·n)=σ*(m)·σ*(n) for gcd(m,n)=1. This answers the parent OQ-06's explicitly stated open target, and it exposes multiplicativity as a convolution phenomenon rather than a coincidence of the number 4.",
+    "mathContext": "$\\sigma^*=\\zeta\\star g$ and $(\\zeta\\star g)$ multiplicative because Dirichlet convolution preserves multiplicativity: $\\sigma^*(mn)=\\sigma^*(m)\\sigma^*(n)$ for $\\gcd(m,n)=1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Dirichlet convolution",
+      "multiplicative functions",
+      "zeta arithmetic function",
+      "divisor-summatory function",
+      "IsMultiplicative.mul"
+    ],
+    "prerequisites": [
+      "Dirichlet convolution",
+      "multiplicative functions",
+      "zeta function ζ ⋆ f = divisor sum"
+    ]
+  },
+  {
+    "id": "ann-4sq-oq0602-assembled",
+    "proofId": "four-square-distribution-oq-06-oq-02",
+    "range": {
+      "startLine": 143,
+      "endLine": 208
+    },
+    "type": "insight",
+    "title": "The assembled closed form as a one-line corollary",
+    "content": "With multiplicativity in hand, the parent's assembled formula collapses. Two local values feed it: sigmaStar_eq_sigma_of_not_four_dvd shows σ*(n)=σ(n) whenever 4∤n (covering all odd n, since no divisor of an odd number is a multiple of 4), and sigmaStar_two_pow gives σ*(2ᵏ)=1 for k=0, else 3. The power-of-two value is an induction over the exponent using divisors_prime_pow: passing from 2ᵏ to 2ᵏ⁺¹ adjoins the single new divisor 2ᵏ⁺¹, which for k≥1 is a multiple of 4 and so contributes 0 to the weighted sum — the sum stabilizes at 1+2=3. Then sigmaStar_assembled writes n=2ᵏ·m (m odd, so 2ᵏ and m coprime) and applies sigmaStar_mul_coprime to get σ*(2ᵏ·m)=σ*(2ᵏ)·σ*(m)=(if k=0 then 1 else 3)·σ(m) in one line, replacing OQ-06-OQ-01's bespoke ℕ-truncated-subtraction argument with the structural reason.",
+    "mathContext": "$\\sigma^*(2^k m)=\\sigma^*(2^k)\\,\\sigma^*(m)=\\bigl(\\text{if }k=0\\text{ then }1\\text{ else }3\\bigr)\\cdot\\sigma(m)$ for odd $m$; $\\sigma^*(2^k)\\in\\{1,3\\}$ as only $1,2$ avoid $4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "prime power values",
+      "induction on exponent",
+      "divisors_prime_pow",
+      "sum-of-divisors function",
+      "closed form"
+    ],
+    "prerequisites": [
+      "multiplicativity of σ*",
+      "divisors of prime powers",
+      "induction"
+    ]
+  },
+  {
+    "id": "ann-4sq-oq0602-instances",
+    "proofId": "four-square-distribution-oq-06-oq-02",
+    "range": {
+      "startLine": 210,
+      "endLine": 245
+    },
+    "type": "context",
+    "title": "Jacobi's r₄ prediction and multiplicativity in action",
+    "content": "jacobiR4 n is DEFINED as 8·σ*(n) — the arithmetic side of Jacobi's four-square formula, not the geometric representation count (that would need the q-expansion of jacobiTheta⁴ and remains open). jacobiR4_two_pow_mul_odd propagates the closed form: for odd m and k≥1, r₄(2ᵏ·m)=24·σ(m), since 8·3=24. The numeric instances are genuine consequences of the general theorems, not separate calculations: σ*(12)=12 (k=2,m=3), r₄(12)=96, and most tellingly σ*(45)=σ*(9)·σ*(5)=13·6=78 displays multiplicativity directly on 45=9·5. All are proved with kernel `decide`, never native_decide, so the entry stays fully 0-axiom.",
+    "mathContext": "$r_4(2^k m)=8\\cdot\\sigma^*(2^k m)=24\\,\\sigma(m)$ for odd $m$, $k\\ge1$; e.g. $\\sigma^*(45)=\\sigma^*(9)\\sigma^*(5)=13\\cdot6=78$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Jacobi four-square theorem",
+      "representation numbers r₄",
+      "theta functions",
+      "kernel decide",
+      "sum of divisors"
+    ],
+    "prerequisites": [
+      "Jacobi's formula r₄ = 8σ*",
+      "sum-of-divisors function",
+      "multiplicativity of σ*"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment pass — `four-square-distribution-oq-06-oq-02`

Quality **43 → 98**. The entry had a rich `meta.json` but no `annotations.json`; this adds one with full line-range coverage.

### Changes
- **New `annotations.json`** with 6 annotations, one per Lean section, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`:
  1. Repackaging σ*'s summand as an ArithmeticFunction (`weightedId`)
  2. The crux divisor fact — a factor of 4 can't be split across coprimes (`four_dvd_mul_of_coprime`)
  3. `g` is a multiplicative arithmetic function
  4. **Headline**: σ* = ζ ⋆ g, so multiplicativity is inherited from the convolution
  5. The assembled closed form σ*(2ᵏ·m) = (1 or 3)·σ(m) as a one-line corollary
  6. Jacobi's r₄ prediction and numeric instances (σ*(45)=13·6=78)

All line ranges verified against the 245-line Lean source; mathematically checked against the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)