### PR TITLE
research(quadratic-gauss-sum-square-oq-02-oq-02): fibre counts for x↦xᵏ over F_q via the gcd law

### DIFF
--- a/proofs/Proofs/QuadraticGaussSumSquareOQ02OQ02.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquareOQ02OQ02.lean
@@ -1,0 +1,144 @@
+/-
+  Fibre counts for the power map `x ↦ xᵏ` over a finite field.
+
+  The parent entry `quadratic-gauss-sum-square-oq-02` counts the nonzero
+  squares of `ZMod p` using the *quadratic* character `χ` and the vanishing
+  character sum `∑ χ = 0`: the map `x ↦ x²` is exactly 2-to-1 on the units, so
+  there are `(p-1)/2` squares.  Its open question asks whether the same fibre
+  count generalises to higher-order maps `x ↦ xᵏ` — the quadratic case being
+  `k = 2` and the character-sum decomposition being the `k`-th order analogue of
+  character orthogonality.
+
+  This file answers that question *exactly*, and for an arbitrary finite field
+  `F` (not just `ZMod p`).  Rather than routing through the `k` multiplicative
+  characters of order dividing `k` and their orthogonality relations, we use the
+  structural fact underlying that computation: on the cyclic group `Fˣ` the map
+  `x ↦ xᵏ` is the monoid endomorphism `powMonoidHom k`, whose kernel and range
+  cardinalities are pinned by `gcd(k, |Fˣ|)`.  Concretely, with `q = |F|` and
+  `d = gcd(k, q-1)`:
+
+    * the number of `k`-th roots of unity `#{x : xᵏ = 1}` is `d`;
+    * the number of `k`-th powers `#{xᵏ : x}` is `(q-1)/d`;
+    * every nonempty fibre `#{x : xᵏ = a}` has exactly `d` elements, because it
+      is a coset of the kernel (`MonoidHom.fiberEquivKer`);
+    * so `x ↦ xᵏ` is a `d`-to-`1` map onto its image.
+
+  Specialising to `k = 2` and `F = ZMod p` (`p` an odd prime) recovers the
+  parent's count: `d = gcd(2, p-1) = 2`, giving `(p-1)/2` squares, each with two
+  square roots.  So the parent's quadratic-character count is the `k = 2` shadow
+  of this uniform gcd law.
+
+  Everything is 0-axiom: the arithmetic comes from
+  `IsCyclic.card_powMonoidHom_ker` / `IsCyclic.card_powMonoidHom_range` (the
+  units of a finite field are cyclic) and the fibre count from the coset
+  equivalence `MonoidHom.fiberEquivKer`.
+-/
+import Mathlib
+
+open scoped BigOperators
+open Finset
+
+namespace QuadraticGaussSumSquareOQ02OQ02
+
+variable {F : Type*} [Field F] [Fintype F] [DecidableEq F]
+
+/-- The `k`-th power map on the units of `F`, as a monoid endomorphism
+`x ↦ xᵏ`.  `Fˣ` is a finite commutative — indeed cyclic — group, which is what
+makes the fibre count purely arithmetic. -/
+noncomputable abbrev powHom (k : ℕ) : Fˣ →* Fˣ := powMonoidHom k
+
+@[simp] theorem powHom_apply (k : ℕ) (x : Fˣ) : powHom k x = x ^ k := rfl
+
+/-- The number of `k`-th roots of unity in `Fˣ`, i.e. the kernel of `x ↦ xᵏ`,
+is `gcd(k, q-1)` where `q = |F|`.  This is `IsCyclic.card_powMonoidHom_ker`
+specialised to the cyclic group `Fˣ`, with `|Fˣ| = q - 1`. -/
+theorem card_kthRootsOfUnity (k : ℕ) :
+    Nat.card (powHom (F := F) k).ker = (Fintype.card F - 1).gcd k := by
+  rw [IsCyclic.card_powMonoidHom_ker, Nat.card_eq_fintype_card, Fintype.card_units]
+
+/-- The number of `k`-th powers in `Fˣ`, i.e. the range of `x ↦ xᵏ`, is
+`(q-1)/gcd(k, q-1)`.  This is `IsCyclic.card_powMonoidHom_range` on `Fˣ`. -/
+theorem card_kthPowers (k : ℕ) :
+    Nat.card (powHom (F := F) k).range
+      = (Fintype.card F - 1) / (Fintype.card F - 1).gcd k := by
+  rw [IsCyclic.card_powMonoidHom_range, Nat.card_eq_fintype_card, Fintype.card_units]
+
+/-- **Uniform fibre count.** Every value `a` that *is* a `k`-th power has exactly
+`gcd(k, q-1)` pre-images under `x ↦ xᵏ`: the fibre is a coset of the kernel, so
+has the same cardinality as the kernel (`MonoidHom.fiberEquivKer`). -/
+theorem card_fibre_of_mem_range (k : ℕ) (a : Fˣ)
+    (ha : a ∈ (powHom (F := F) k).range) :
+    Nat.card ((powHom (F := F) k) ⁻¹' {a}) = (Fintype.card F - 1).gcd k := by
+  obtain ⟨x, hx⟩ := ha
+  have hfib : (powHom (F := F) k) ⁻¹' {a} = (powHom (F := F) k) ⁻¹' {powHom k x} := by
+    rw [hx]
+  rw [hfib, Nat.card_congr (MonoidHom.fiberEquivKer (powHom (F := F) k) x),
+    card_kthRootsOfUnity]
+
+/-- A value that is **not** a `k`-th power has an empty fibre — there is no `x`
+with `xᵏ = a`. -/
+theorem fibre_empty_of_not_mem_range (k : ℕ) (a : Fˣ)
+    (ha : a ∉ (powHom (F := F) k).range) :
+    (powHom (F := F) k) ⁻¹' {a} = (∅ : Set Fˣ) := by
+  ext x
+  simp only [Set.mem_preimage, Set.mem_singleton_iff, Set.mem_empty_iff_false, iff_false]
+  intro hx
+  exact ha ⟨x, hx⟩
+
+/- The full dichotomy: the fibre of `x ↦ xᵏ` over any `a : Fˣ` has cardinality
+`gcd(k, q-1)` if `a` is a `k`-th power and `0` otherwise. -/
+open Classical in
+theorem card_fibre (k : ℕ) (a : Fˣ) :
+    Nat.card ((powHom (F := F) k) ⁻¹' {a})
+      = if a ∈ (powHom (F := F) k).range then (Fintype.card F - 1).gcd k else 0 := by
+  by_cases ha : a ∈ (powHom (F := F) k).range
+  · rw [if_pos ha, card_fibre_of_mem_range k a ha]
+  · rw [if_neg ha, fibre_empty_of_not_mem_range k a ha, Nat.card_eq_fintype_card,
+      Fintype.card_of_isEmpty]
+
+/-- **Counting identity.** `(number of `k`-th powers) · (fibre size) = q - 1`:
+the `k`-th power map is a `gcd(k, q-1)`-to-`1` surjection onto the `k`-th powers,
+so the two counts multiply back to `|Fˣ| = q - 1`.  This is Lagrange /
+first-isomorphism for `powMonoidHom k`, read off from the two card formulas. -/
+theorem card_powers_mul_card_roots (k : ℕ) :
+    Nat.card (powHom (F := F) k).range * (Fintype.card F - 1).gcd k
+      = Fintype.card F - 1 := by
+  rw [card_kthPowers, Nat.div_mul_cancel]
+  exact Nat.gcd_dvd_left _ _
+
+end QuadraticGaussSumSquareOQ02OQ02
+
+/-!
+### Specialisation: the quadratic case recovers the parent count
+
+Over `ZMod p` with `p` an odd prime, `q - 1 = p - 1` and `gcd(2, p-1) = 2`, so
+the map `x ↦ x²` is exactly 2-to-1 on `(ZMod p)ˣ` and there are `(p-1)/2`
+nonzero squares — precisely the equidistribution count that the parent entry
+obtained from the quadratic character sum `∑ χ = 0`.
+-/
+
+namespace QuadraticGaussSumSquareOQ02OQ02
+
+/-- Over an odd prime field, `gcd(2, p-1) = 2`: every nonzero square has exactly
+two square roots.  (`p` odd ⇒ `p - 1` even.) -/
+theorem gcd_two_pSub_one (p : ℕ) [Fact p.Prime] (hp : p ≠ 2) :
+    (Fintype.card (ZMod p) - 1).gcd 2 = 2 := by
+  have hodd : Odd p := (Nat.Prime.odd_of_ne_two Fact.out hp)
+  have hcard : Fintype.card (ZMod p) = p := ZMod.card p
+  rw [hcard]
+  -- `p` odd ⇒ `2 ∣ p - 1`, so `gcd (p-1) 2 = 2`
+  have hdvd : 2 ∣ (p - 1) := by
+    obtain ⟨m, hm⟩ := hodd
+    omega
+  rw [Nat.gcd_comm]
+  exact Nat.gcd_eq_left hdvd
+
+/-- The number of nonzero squares in `ZMod p` (`p` odd prime) is `(p-1)/2`,
+matching the parent's quadratic-character count — now read off as the `k = 2`
+case of the uniform fibre law. -/
+theorem card_squares_zmod (p : ℕ) [Fact p.Prime] (hp : p ≠ 2) :
+    Nat.card (powHom (F := ZMod p) 2).range = (p - 1) / 2 := by
+  have hcard : Fintype.card (ZMod p) = p := ZMod.card p
+  rw [card_kthPowers, gcd_two_pSub_one p hp, hcard]
+
+end QuadraticGaussSumSquareOQ02OQ02

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-02/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-02/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "quadratic-gauss-sum-square-oq-02-oq-02",
+  "title": "Fibre Counts for the Power Map x ↦ xᵏ over a Finite Field: the gcd Law behind Higher-Order Character Sums",
+  "slug": "quadratic-gauss-sum-square-oq-02-oq-02",
+  "description": "The parent family counts the nonzero squares of a finite field via the quadratic character and its vanishing sum ∑ χ = 0 — the squaring map x ↦ x² being 2-to-1 on the units. The sibling entry (quadratic-gauss-sum-square-oq-02-oq-01) generalized the equidistribution to any odd-order finite field and asked, as its two open questions, (1) whether the signed-indicator decomposition extends to higher-order (cubic, quartic) characters to count the fibres of x ↦ xᵏ over F_q, and (2) whether the squaring-map kernel picture #squares = (q−1)/gcd(2, q−1) can be unified into a single statement valid for every k. This entry answers both, for an arbitrary finite field F (not just ZMod p) and every exponent k, by the structural route the character computation secretly runs on: on the cyclic group Fˣ the map x ↦ xᵏ is the monoid endomorphism powMonoidHom k, whose kernel and range cardinalities are pinned by d = gcd(k, q−1). Concretely (q = |F|): the number of k-th roots of unity #{x : xᵏ = 1} is d (card_kthRootsOfUnity, from IsCyclic.card_powMonoidHom_ker); the number of k-th powers #{xᵏ} is (q−1)/d (card_kthPowers, from IsCyclic.card_powMonoidHom_range); every nonempty fibre #{x : xᵏ = a} has exactly d elements, being a coset of the kernel (card_fibre_of_mem_range, via MonoidHom.fiberEquivKer), while a non-power has an empty fibre (fibre_empty_of_not_mem_range) — giving the full dichotomy card_fibre; and the two counts multiply back to |Fˣ| = q−1 (card_powers_mul_card_roots), so x ↦ xᵏ is a uniform d-to-1 surjection onto its image. Specialising k = 2, F = ZMod p (gcd_two_pSub_one: gcd(2, p−1) = 2) recovers the parent's (p−1)/2 count (card_squares_zmod). Verified with 0 axioms, 0 sorries, no native_decide.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators",
+      "Finset"
+    ],
+    "namespace": "QuadraticGaussSumSquareOQ02OQ02",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/QuadraticGaussSumSquareOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "dateAdded": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticGaussSumSquareOQ02OQ02.lean",
+    "tags": [
+      "number-theory",
+      "finite-fields",
+      "characters",
+      "gauss-sums",
+      "power-map",
+      "cyclic-group",
+      "fibre-count",
+      "gcd",
+      "monoid-hom",
+      "counting",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 144,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "assumptions": "",
+    "mathlib_version": "as vendored in proofs/.lake",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsCyclic.card_powMonoidHom_ker",
+        "description": "For a finite cyclic group G, the kernel of x ↦ xᵏ has cardinality gcd(|G|, k). Applied to Fˣ (cyclic, order q−1) this gives #{k-th roots of unity} = gcd(q−1, k).",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "IsCyclic.card_powMonoidHom_range",
+        "description": "For a finite cyclic group G, the range of x ↦ xᵏ has cardinality |G|/gcd(|G|, k). Applied to Fˣ this gives #{k-th powers} = (q−1)/gcd(q−1, k).",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "MonoidHom.fiberEquivKer",
+        "description": "The fibre of a monoid homomorphism over f(x) is in bijection with the kernel (it is the coset x·ker). This forces every nonempty fibre of x ↦ xᵏ to have exactly gcd(q−1, k) elements.",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      },
+      {
+        "theorem": "Fintype.card_units",
+        "description": "|Fˣ| = |F| − 1 for a finite field F (the units are exactly the nonzero elements). Converts the group-order gcd formulas into the field count q − 1.",
+        "module": "Mathlib.Algebra.GroupWithZero.Units.Basic"
+      },
+      {
+        "theorem": "Nat.div_mul_cancel",
+        "description": "d ∣ n → (n/d)·d = n. With d = gcd(q−1, k) ∣ q−1 this yields the counting identity (#k-th powers)·(fibre size) = q − 1.",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "ZMod.card",
+        "description": "|ZMod p| = p, used to specialise the field count to the prime case and recover the parent's (p−1)/2 square count.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "card_kthRootsOfUnity / card_kthPowers: for an arbitrary finite field F (not just ZMod p) and every exponent k, #{k-th roots of unity} = gcd(q−1, k) and #{k-th powers} = (q−1)/gcd(q−1, k), read off the cyclic structure of Fˣ — the structural content that the quadratic character sum computes in the k = 2 case.",
+      "card_fibre_of_mem_range and card_fibre: the uniform fibre count — every value that is a k-th power has exactly gcd(q−1, k) pre-images (its fibre is a coset of the kernel), with the full dichotomy (gcd(q−1,k) if a is a k-th power, else 0) packaged in card_fibre. This is the higher-order analogue of the parent's '2-to-1 squaring map', answering the sibling's open question about counting the fibres of x ↦ xᵏ.",
+      "card_powers_mul_card_roots: the Lagrange/first-isomorphism identity (#k-th powers)·(fibre size) = q − 1, exhibiting x ↦ xᵏ as a uniform gcd(q−1, k)-to-1 surjection onto its image.",
+      "gcd_two_pSub_one and card_squares_zmod: the k = 2, F = ZMod p specialisation, showing gcd(2, p−1) = 2 for odd p and recovering the parent's (p−1)/2 nonzero-square count as the shadow of the uniform gcd law — the requested unification of the squaring-map kernel picture with a single all-k statement."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Counting the image and fibres of the power map $x \\mapsto x^k$ on a finite field is a classical piece of finite-field arithmetic, usually deduced from multiplicative character orthogonality: the number of solutions of $x^k = a$ is $\\sum_{\\chi^k = 1} \\chi(a)$, summed over the $\\gcd(k, q-1)$ multiplicative characters whose order divides $k$. Summing over $a$ recovers the count of $k$-th powers, and the quadratic case $k = 2$ is exactly the vanishing-sum argument of the parent entries. But the orthogonality computation is powered by a purely structural fact: $\\mathbb{F}_q^\\times$ is cyclic of order $q-1$, so $x \\mapsto x^k$ is a group endomorphism with kernel of size $\\gcd(k, q-1)$. This entry isolates that structural core, so the fibre count for every $k$ falls out of Lagrange's theorem rather than a separate character sum per exponent.",
+    "problemStatement": "Let $F$ be a finite field with $q = |F|$ and let $k \\in \\mathbb{N}$. Writing $d = \\gcd(k, q-1)$, prove that the power map $x \\mapsto x^k$ on $F^\\times$ has exactly $d$ many $k$-th roots of unity, image of size $(q-1)/d$, and that every non-empty fibre $\\{x : x^k = a\\}$ has exactly $d$ elements while every other value has empty fibre — so $x \\mapsto x^k$ is a uniform $d$-to-$1$ surjection onto the $k$-th powers, with $(q-1)/d \\cdot d = q-1$. Recover the parent's count of $(q-1)/2$ nonzero squares as the case $k = 2$ over $\\mathbb{Z}/p$.",
+    "proofStrategy": "The power map is treated as the monoid endomorphism `powHom k := powMonoidHom k` on $F^\\times$. (1) `card_kthRootsOfUnity` rewrites $\\mathrm{Nat.card}\\,(\\ker)$ via `IsCyclic.card_powMonoidHom_ker` (valid because $F^\\times$ is cyclic) and `Fintype.card_units` to get $\\gcd(q-1, k)$. (2) `card_kthPowers` does the same for the range via `IsCyclic.card_powMonoidHom_range`, giving $(q-1)/\\gcd(q-1, k)$. (3) `card_fibre_of_mem_range` takes a value $a = x^k$ in the range, rewrites the fibre over $a$ as the fibre over $\\mathrm{powHom}\\,k\\,x$, and applies `MonoidHom.fiberEquivKer` (the coset bijection with the kernel) plus `card_kthRootsOfUnity`. (4) `fibre_empty_of_not_mem_range` shows a non-power has empty fibre by unfolding membership, and `card_fibre` assembles the two cases into the dichotomy (using classical decidability of range membership only to state the `if`). (5) `card_powers_mul_card_roots` multiplies the two counts and cancels via `Nat.div_mul_cancel` and `Nat.gcd_dvd_left`. (6) `gcd_two_pSub_one` computes $\\gcd(2, p-1) = 2$ for odd $p$ (via `Nat.Prime.odd_of_ne_two` and `Nat.gcd_eq_left`), and `card_squares_zmod` feeds it into `card_kthPowers` with `ZMod.card` to obtain $(p-1)/2$.",
+    "keyInsights": [
+      "The quadratic-character count of squares is the $k = 2$ shadow of a single gcd law. What the vanishing sum $\\sum \\chi = 0$ verifies for $k = 2$, and what a sum over the $\\gcd(k, q-1)$ order-dividing-$k$ characters verifies for general $k$, is exactly the cardinality of the kernel of $x \\mapsto x^k$ on the cyclic group $\\mathbb{F}_q^\\times$ — namely $\\gcd(k, q-1)$. Routing through the endomorphism makes every exponent uniform and removes the per-$k$ character bookkeeping.",
+      "Every non-empty fibre has the same size. Because $x \\mapsto x^k$ is a group homomorphism, its fibres are cosets of the kernel, so they are either empty or in bijection with the kernel — `MonoidHom.fiberEquivKer`. This is the higher-order analogue of the parent's '2-to-1' statement: the map is $\\gcd(k, q-1)$-to-1 onto its image.",
+      "The result is field-agnostic. Nothing uses primality or $\\mathbb{Z}/p$; the only inputs are that $F^\\times$ is finite cyclic of order $q-1$, which holds for every finite field. Replacing $\\mathrm{ZMod}\\,p$ by an arbitrary $F$ and $|(\\mathrm{ZMod}\\,p)^\\times|$ by $\\mathrm{Fintype.card}\\,F - 1$ is the whole generalization.",
+      "The counting identity $(q-1)/d \\cdot d = q-1$ is Lagrange / the first isomorphism theorem for $\\mathrm{powMonoidHom}\\,k$, read off from the kernel and range cardinalities rather than proved separately — a single divisibility cancellation."
+    ]
+  },
+  "conclusion": {
+    "summary": "For every finite field $F$ of order $q$ and every exponent $k$, the power map $x \\mapsto x^k$ on $F^\\times$ is machine-verified to be a uniform $\\gcd(k, q-1)$-to-$1$ surjection onto the $k$-th powers: $\\gcd(k, q-1)$ many $k$-th roots of unity, $(q-1)/\\gcd(k, q-1)$ many $k$-th powers, every non-empty fibre of size $\\gcd(k, q-1)$, and the product identity $q-1$. The parent's count of $(q-1)/2$ nonzero squares over $\\mathbb{Z}/p$ is recovered as the case $k = 2$. No axioms, no sorries, no native_decide.",
+    "implications": "This settles the sibling entry's two open questions on the structural side: the fibre count for $x \\mapsto x^k$ over $\\mathbb{F}_q$ (open question 1) and the unification of the squaring-map kernel picture into a single all-$k$ statement (open question 2). The gcd law is the arithmetic backbone of Gauss- and Jacobi-sum evaluations, of counting points on diagonal equations $x^k = a$ and Fermat curves over finite fields, and of the theory of $k$-th power residues; deriving it uniformly from the cyclic structure complements the character-orthogonality route used for individual exponents.",
+    "openQuestions": [
+      "Reconnect the structural count to the character side explicitly: prove $\\#\\{x : x^k = a\\} = \\sum_{\\chi^k = 1} \\chi(a)$ by identifying the $\\gcd(k, q-1)$ order-dividing-$k$ multiplicative characters with the dual of the cyclic quotient $F^\\times / (F^\\times)^k$, so the two derivations of the fibre count meet.",
+      "Extend the fibre count to the additive question $\\#\\{(x_1, \\dots, x_n) : x_1^k + \\dots + x_n^k = b\\}$, where the uniform gcd law feeds into Jacobi-sum and Weil-bound estimates for diagonal hypersurfaces over $\\mathbb{F}_q$.",
+      "Handle the characteristic-$p$ exponent case $p \\mid k$ where the Frobenius part of $x \\mapsto x^k$ is a bijection, and state the combined count for arbitrary $k$ (not just $k$ coprime to $p$)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "quadratic-gauss-sum-square-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "The sibling proves equidistribution of squares/non-squares over an arbitrary odd-order finite field from the vanishing quadratic-character sum, and poses as open questions (1) extending the signed-indicator decomposition to higher-order characters to count fibres of x ↦ xᵏ and (2) unifying the squaring-map kernel picture across all k. This entry answers both via the structural gcd law on the cyclic group Fˣ, valid for every k, and recovers the sibling's (q−1)/2 count at k = 2."
+    },
+    {
+      "proofId": "quadratic-gauss-sum-square-oq-02",
+      "relationship": "specializes",
+      "description": "The parent counts nonzero quadratic residues mod an odd prime p via the quadratic character. Its count is the k = 2, F = ZMod p case of the uniform gcd(k, q−1)-to-1 fibre law proved here (gcd(2, p−1) = 2, giving (p−1)/2 squares)."
+    },
+    {
+      "proofId": "quadratic-gauss-sum-square",
+      "relationship": "related",
+      "description": "The grandparent establishes the algebraic square identity g² = (−1)^((p−1)/2)·p for the quadratic Gauss sum. This entry develops the complementary counting side — the fibre structure of the power map — over a general finite field, independently of the square identity."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "The Power Map as a Cyclic-Group Endomorphism",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Docstring framing: the parent counts squares via the quadratic character and ∑ χ = 0; here the map x ↦ xᵏ on Fˣ is treated as the monoid endomorphism powMonoidHom k (powHom), whose kernel and range cardinalities are pinned by d = gcd(k, q−1) because Fˣ is cyclic. Imports Mathlib, opens BigOperators/Finset, sets F a finite field with DecidableEq. powHom and its simp lemma powHom_apply : powHom k x = x ^ k."
+    },
+    {
+      "id": "kernel-range",
+      "title": "Kernel and Range: the gcd and its Cofactor",
+      "startLine": 52,
+      "endLine": 64,
+      "summary": "card_kthRootsOfUnity: #ker(powHom k) = gcd(q−1, k) via IsCyclic.card_powMonoidHom_ker and Fintype.card_units — the number of k-th roots of unity. card_kthPowers: #range(powHom k) = (q−1)/gcd(q−1, k) via IsCyclic.card_powMonoidHom_range — the number of k-th powers."
+    },
+    {
+      "id": "fibres",
+      "title": "Uniform Fibre Count and the Dichotomy",
+      "startLine": 66,
+      "endLine": 97,
+      "summary": "card_fibre_of_mem_range: a value a = x^k that lies in the range has exactly gcd(q−1, k) pre-images, its fibre being a coset of the kernel via MonoidHom.fiberEquivKer. fibre_empty_of_not_mem_range: a non-power has empty fibre. card_fibre packages both into the dichotomy #{x : xᵏ = a} = gcd(q−1, k) if a is a k-th power, else 0 (classical decidability only to state the if)."
+    },
+    {
+      "id": "counting-identity",
+      "title": "The Product Identity (#powers)·(fibre size) = q − 1",
+      "startLine": 98,
+      "endLine": 109,
+      "summary": "card_powers_mul_card_roots: (#k-th powers)·gcd(q−1, k) = q − 1 by Nat.div_mul_cancel with gcd ∣ q−1 — Lagrange / first-isomorphism for powMonoidHom k, exhibiting x ↦ xᵏ as a uniform gcd(q−1, k)-to-1 surjection onto its image."
+    },
+    {
+      "id": "quadratic-specialisation",
+      "title": "The Quadratic Case Recovers the Parent",
+      "startLine": 110,
+      "endLine": 144,
+      "summary": "gcd_two_pSub_one: gcd(2, p−1) = 2 for an odd prime p (via Nat.Prime.odd_of_ne_two and Nat.gcd_eq_left). card_squares_zmod: #{nonzero squares in ZMod p} = (p−1)/2, obtained by feeding gcd = 2 and ZMod.card into card_kthPowers — the parent's quadratic count as the k = 2 shadow of the uniform gcd law."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lidl, Rudolf; Niederreiter, Harald",
+      "title": "Finite Fields",
+      "year": "1997",
+      "venue": "Encyclopedia of Mathematics and its Applications 20, Cambridge University Press",
+      "note": "Cyclic structure of the multiplicative group and the power map x ↦ xᵏ over F_q"
+    },
+    {
+      "authors": "Ireland, Kenneth; Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Graduate Texts in Mathematics 84, Springer",
+      "note": "k-th power residues, character sums, and the fibre count #{x : xᵏ = a} = ∑_{χᵏ=1} χ(a)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the two open questions posed by the sibling entry **quadratic-gauss-sum-square-oq-02-oq-01** on the structural side:

1. counting the fibres of the power map `x ↦ xᵏ` over an arbitrary finite field `F` (not just `ZMod p`), and
2. unifying the squaring-map kernel picture `#squares = (q−1)/gcd(2, q−1)` into a single statement valid for **every** exponent `k`.

Rather than routing through a separate multiplicative-character sum per exponent, the proof isolates the structural fact those sums secretly compute: on the cyclic group `Fˣ`, `x ↦ xᵏ` is the monoid endomorphism `powMonoidHom k`, whose kernel and range cardinalities are pinned by `d = gcd(k, q−1)` (`q = |F|`):

| quantity | value | Mathlib engine |
|---|---|---|
| `#{x : xᵏ = 1}` (k-th roots of unity) | `d` | `IsCyclic.card_powMonoidHom_ker` |
| `#{xᵏ}` (k-th powers) | `(q−1)/d` | `IsCyclic.card_powMonoidHom_range` |
| every nonempty fibre `#{x : xᵏ = a}` | `d` | `MonoidHom.fiberEquivKer` (coset bijection) |
| `(#powers)·d` | `q−1` | Lagrange / first isomorphism |

So `x ↦ xᵏ` is a uniform `d`-to-`1` surjection onto the k-th powers. Specialising `k = 2`, `F = ZMod p` (`gcd(2, p−1) = 2`) recovers the parent's `(p−1)/2` nonzero-square count — the quadratic-character count as the `k = 2` shadow of the gcd law.

## Verification

- **0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`; no `Lean.ofReduceBool`, no `sorryAx`), **0 sorries**, no `native_decide`.
- 9 theorems, 1 definition, 144 lines.
- Verified single-file via `lake env lean` against the cached Mathlib oleans.

## Files

- `proofs/Proofs/QuadraticGaussSumSquareOQ02OQ02.lean`
- `src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-02/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)