### PR TITLE
research(lucas-sum-oq-01-oq-01): even/odd-indexed + alternating Lucas partial sums

### DIFF
--- a/proofs/Proofs/LucasSumOQ01OQ01.lean
+++ b/proofs/Proofs/LucasSumOQ01OQ01.lean
@@ -1,0 +1,155 @@
+import Mathlib
+
+/-
+# Even/Odd-Indexed and Alternating Lucas Partial Sums
+
+## Open Question OQ-01-OQ-01 (extension of `lucas-sum-oq-01`)
+
+The parent entry `lucas-sum-oq-01` proves the full telescoping partial sum
+`∑_{k=1}^{n} L_k = L_{n+2} − 3` for the Lucas numbers `2, 1, 3, 4, 7, 11, 18, …`
+(the Fibonacci recurrence `L_{k+2} = L_k + L_{k+1}` with `L_0 = 2`, `L_1 = 1`).
+
+Splitting the sum by parity of the index gives two further telescoping identities, and
+alternating the signs gives a third.  All three are subtraction-free at heart:
+
+1. **Even-indexed.**  `∑_{k=1}^{n} L_{2k} = L_{2n+1} − 1`.
+   e.g. `L_2 + L_4 = 3 + 7 = 10 = L_5 − 1 = 11 − 1`.
+
+2. **Odd-indexed.**   `∑_{k=1}^{n} L_{2k−1} = L_{2n} − 2`.
+   e.g. `L_1 + L_3 = 1 + 4 = 5 = L_4 − 2 = 7 − 2`.
+
+3. **Alternating.**   `∑_{k=0}^{m} (−1)^k L_k = (−1)^m L_{m−1} + 3` (for `m ≥ 1`).
+   The closed form is again *Lucas-only* — no Fibonacci term is needed — because
+   `L_{m+1} − L_{m−1} = L_m` collapses the telescoping remainder.
+   e.g. `L_0 − L_1 + L_2 − L_3 + L_4 = 2 − 1 + 3 − 4 + 7 = 7 = L_3 + 3 = 4 + 3`.
+
+## What is proved here
+
+Each identity is proved in a subtraction-free "`+ c = L_j`" form by induction directly
+from the recurrence (the exact statement the telescoping argument produces, avoiding all
+`ℕ`-subtraction edge cases), then the headline subtracted form is read off.
+
+* `lucas_even_sum_add_one` / `lucas_even_sum` — even-indexed.
+* `lucas_odd_sum_add_two`  / `lucas_odd_sum`  — odd-indexed.
+* `lucas_alt_sum` — the alternating sum, stated over `ℤ` (signs force the integer setting),
+  in the subtraction-free shifted form `∑_{k<n+2} (−1)^k L_k = (−1)^{n+1} L_n + 3`.
+
+The 1-indexed sums `∑_{k=1}^{n} L_{2k}` and `∑_{k=1}^{n} L_{2k−1}` are encoded as
+`∑ k ∈ Finset.range n, lucas (2*k+2)` and `∑ k ∈ Finset.range n, lucas (2*k+1)`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace LucasSumOQ01OQ01
+
+open Finset
+
+/-- The Lucas numbers `2, 1, 3, 4, 7, 11, …` — the Fibonacci recurrence with the
+alternative initial data `L_0 = 2`, `L_1 = 1`.  (Self-contained copy of the definition
+from the parent entry `lucas-sum-oq-01`.) -/
+def lucas : ℕ → ℕ
+  | 0 => 2
+  | 1 => 1
+  | (n + 2) => lucas n + lucas (n + 1)
+
+@[simp] theorem lucas_zero : lucas 0 = 2 := rfl
+
+@[simp] theorem lucas_one : lucas 1 = 1 := rfl
+
+/-- The defining Lucas recurrence `L_{n+2} = L_n + L_{n+1}`. -/
+theorem lucas_add_two (n : ℕ) : lucas (n + 2) = lucas n + lucas (n + 1) := rfl
+
+/-! ### Even-indexed partial sum -/
+
+/-- **Even-indexed telescoping sum (subtraction-free).**
+`(∑_{k=1}^{n} L_{2k}) + 1 = L_{2n+1}`.
+
+Induction on `n`.  Base: `0 + 1 = L_1 = 1`.  Step: `Finset.sum_range_succ` peels off the
+new term `L_{2n+2}`; the Lucas recurrence `L_{2n+3} = L_{2n+1} + L_{2n+2}` lets `omega`
+combine it with the inductive hypothesis. -/
+theorem lucas_even_sum_add_one (n : ℕ) :
+    (∑ k ∈ Finset.range n, lucas (2 * k + 2)) + 1 = lucas (2 * n + 1) := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+    rw [Finset.sum_range_succ]
+    have hidx : 2 * (n + 1) + 1 = 2 * n + 3 := by ring
+    have hrec : lucas (2 * n + 3) = lucas (2 * n + 1) + lucas (2 * n + 2) :=
+      lucas_add_two (2 * n + 1)
+    rw [hidx]
+    omega
+
+/-- **Even-indexed Lucas partial sum** `∑_{k=1}^{n} L_{2k} = L_{2n+1} − 1`.
+Read off from `lucas_even_sum_add_one`; the `ℕ`-subtraction is exact since `L_{2n+1} ≥ 1`. -/
+theorem lucas_even_sum (n : ℕ) :
+    (∑ k ∈ Finset.range n, lucas (2 * k + 2)) = lucas (2 * n + 1) - 1 := by
+  have h := lucas_even_sum_add_one n
+  omega
+
+/-! ### Odd-indexed partial sum -/
+
+/-- **Odd-indexed telescoping sum (subtraction-free).**
+`(∑_{k=1}^{n} L_{2k−1}) + 2 = L_{2n}`.
+
+Induction on `n`.  Base: `0 + 2 = L_0 = 2`.  Step: the new term `L_{2n+1}` combines with
+the inductive hypothesis via `L_{2n+2} = L_{2n} + L_{2n+1}`. -/
+theorem lucas_odd_sum_add_two (n : ℕ) :
+    (∑ k ∈ Finset.range n, lucas (2 * k + 1)) + 2 = lucas (2 * n) := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+    rw [Finset.sum_range_succ]
+    have hidx : 2 * (n + 1) = 2 * n + 2 := by ring
+    have hrec : lucas (2 * n + 2) = lucas (2 * n) + lucas (2 * n + 1) :=
+      lucas_add_two (2 * n)
+    rw [hidx]
+    omega
+
+/-- **Odd-indexed Lucas partial sum** `∑_{k=1}^{n} L_{2k−1} = L_{2n} − 2`.
+Read off from `lucas_odd_sum_add_two`; the `ℕ`-subtraction is exact since `L_{2n} ≥ 2`. -/
+theorem lucas_odd_sum (n : ℕ) :
+    (∑ k ∈ Finset.range n, lucas (2 * k + 1)) = lucas (2 * n) - 2 := by
+  have h := lucas_odd_sum_add_two n
+  omega
+
+/-! ### Alternating partial sum -/
+
+/-- **Alternating Lucas partial sum** (over `ℤ`, since the signs force the integer setting).
+In subtraction-free shifted form:
+`∑_{k=0}^{n+1} (−1)^k L_k = (−1)^{n+1} L_n + 3`.
+
+Equivalently `∑_{k=0}^{m} (−1)^k L_k = (−1)^m L_{m−1} + 3` for `m = n + 1 ≥ 1`.  The closed
+form is Lucas-only: in the induction step the two new sign-weighted terms collapse via the
+recurrence `L_{n+2} − L_n = L_{n+1}`, leaving no Fibonacci remainder. -/
+theorem lucas_alt_sum (n : ℕ) :
+    (∑ k ∈ Finset.range (n + 2), (-1 : ℤ) ^ k * (lucas k : ℤ))
+      = (-1 : ℤ) ^ (n + 1) * (lucas n : ℤ) + 3 := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ih]
+    -- The two new sign-weighted terms collapse via the Lucas recurrence.
+    have hrec : ((lucas (n + 2) : ℤ)) = (lucas n : ℤ) + (lucas (n + 1) : ℤ) := by
+      have := lucas_add_two n
+      exact_mod_cast congrArg (Nat.cast : ℕ → ℤ) this
+    have hpow : (-1 : ℤ) ^ (n + 2) = (-1 : ℤ) ^ n := by
+      rw [pow_add]; ring
+    have hpow1 : (-1 : ℤ) ^ (n + 1) = -(-1 : ℤ) ^ n := by
+      rw [pow_succ]; ring
+    rw [hrec, hpow, hpow1]
+    ring
+
+/-! ### Sanity checks -/
+
+/-- `L_2 + L_4 = 3 + 7 = 10 = L_5 − 1`. -/
+example : (∑ k ∈ Finset.range 2, lucas (2 * k + 2)) = lucas 5 - 1 := by decide
+
+/-- `L_1 + L_3 = 1 + 4 = 5 = L_4 − 2`. -/
+example : (∑ k ∈ Finset.range 2, lucas (2 * k + 1)) = lucas 4 - 2 := by decide
+
+/-- `L_0 − L_1 + L_2 − L_3 + L_4 = 2 − 1 + 3 − 4 + 7 = 7 = L_3 + 3`. -/
+example :
+    (∑ k ∈ Finset.range 5, (-1 : ℤ) ^ k * (lucas k : ℤ)) = (lucas 3 : ℤ) + 3 := by
+  decide
+
+end LucasSumOQ01OQ01

--- a/src/data/proofs/lucas-sum-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lucas-sum-oq-01-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-programme",
+    "proofId": "lucas-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 41
+    },
+    "type": "concept",
+    "title": "Parity-Split and Alternating Lucas Partial Sums",
+    "content": "The docstring frames three extensions of the parent telescoping sum ∑_{k=1}^{n} L_k = L_{n+2} − 3. Splitting the sum by the parity of the index gives the even-indexed identity ∑_{k=1}^{n} L_{2k} = L_{2n+1} − 1 and the odd-indexed identity ∑_{k=1}^{n} L_{2k−1} = L_{2n} − 2, and alternating the signs gives ∑_{k=0}^{m} (−1)^k L_k = (−1)^m L_{m−1} + 3. All three are subtraction-free at heart and are proved from the recurrence L_{n+2} = L_n + L_{n+1}. The alternating closed form is notable for being Lucas-only: no Fibonacci term is needed because the telescoping remainder L_{m+1} − L_{m−1} equals L_m.",
+    "mathContext": "$\\sum_{k=1}^n L_{2k} = L_{2n+1}-1$, $\\sum_{k=1}^n L_{2k-1} = L_{2n}-2$, $\\sum_{k=0}^m (-1)^k L_k = (-1)^m L_{m-1}+3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lucas numbers",
+      "telescoping partial sum",
+      "parity splitting",
+      "alternating sum",
+      "second-order linear recurrence"
+    ]
+  },
+  {
+    "id": "ann-lucas-def",
+    "proofId": "lucas-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 48,
+      "endLine": 60
+    },
+    "type": "definition",
+    "title": "The Lucas Numbers and Their Recurrence",
+    "content": "A self-contained copy of the parent entry's Lucas definition: lucas 0 = 2, lucas 1 = 1, and lucas (n+2) = lucas n + lucas (n+1). Mathlib centers on Nat.fib and packages no Lucas sequence, so the sequence is defined locally. The boundary values are recorded as simp lemmas, and lucas_add_two : L_{n+2} = L_n + L_{n+1} is the definitional (rfl) recurrence that drives all three telescoping inductions below.",
+    "mathContext": "$L_0=2,\\ L_1=1,\\ L_{n+2}=L_n+L_{n+1}$; sequence $2,1,3,4,7,11,18,\\dots$ (OEIS A000032).",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Lucas numbers",
+      "recursive definition",
+      "second-order recurrence"
+    ]
+  },
+  {
+    "id": "ann-even",
+    "proofId": "lucas-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 87
+    },
+    "type": "proof-technique",
+    "title": "Even-Indexed Sum via a Subtraction-Free Engine",
+    "content": "lucas_even_sum_add_one proves (∑_{k=1}^{n} L_{2k}) + 1 = L_{2n+1} by induction on n. The base case is 0 + 1 = L_1 = 1 (decide). In the step, Finset.sum_range_succ peels off the new term L_{2n+2}; the index 2*(n+1)+1 is rewritten to 2*n+3 so the opaque lucas atoms line up, and the recurrence L_{2n+3} = L_{2n+1} + L_{2n+2} lets omega combine the new term with the inductive hypothesis. The headline lucas_even_sum : ∑ L_{2k} = L_{2n+1} − 1 is then read off by omega, the ℕ truncated subtraction being exact since L_{2n+1} ≥ 1.",
+    "mathContext": "$\\left(\\sum_{k=1}^n L_{2k}\\right)+1 = L_{2n+1}$, hence $\\sum_{k=1}^n L_{2k} = L_{2n+1}-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "mathematical induction",
+      "Finset.sum_range_succ",
+      "telescoping",
+      "truncated subtraction",
+      "omega"
+    ]
+  },
+  {
+    "id": "ann-odd",
+    "proofId": "lucas-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 114
+    },
+    "type": "proof-technique",
+    "title": "Odd-Indexed Sum via the Same Engine",
+    "content": "lucas_odd_sum_add_two proves (∑_{k=1}^{n} L_{2k−1}) + 2 = L_{2n} by the same induction, base 0 + 2 = L_0 = 2. In the step the new term L_{2n+1} combines with the inductive hypothesis via L_{2n+2} = L_{2n} + L_{2n+1} (after rewriting 2*(n+1) to 2*n+2). The headline lucas_odd_sum : ∑ L_{2k−1} = L_{2n} − 2 follows by omega, exact since L_{2n} ≥ 2. The boundary constants 1 (even) and 2 (odd) are precisely the Lucas values L_1 and L_0 that the two partial sums leave behind.",
+    "mathContext": "$\\left(\\sum_{k=1}^n L_{2k-1}\\right)+2 = L_{2n}$, hence $\\sum_{k=1}^n L_{2k-1} = L_{2n}-2$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "mathematical induction",
+      "Finset.sum_range_succ",
+      "telescoping",
+      "truncated subtraction"
+    ]
+  },
+  {
+    "id": "ann-alternating",
+    "proofId": "lucas-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 116,
+      "endLine": 140
+    },
+    "type": "key-insight",
+    "title": "The Alternating Sum Closes in Lucas Terms Alone",
+    "content": "lucas_alt_sum proves ∑_{k=0}^{n+1} (−1)^k L_k = (−1)^{n+1} L_n + 3 over ℤ — the subtraction-free shifted form of ∑_{k=0}^{m} (−1)^k L_k = (−1)^m L_{m−1} + 3. The signs force the integer setting. In the induction step the two new sign-weighted terms collapse via the cast recurrence L_{n+2} = L_n + L_{n+1} together with (−1)^{n+2} = (−1)^n and (−1)^{n+1} = −(−1)^n; after these rewrites ring closes the goal. The striking feature is that the closed form is Lucas-only: no Fibonacci remainder survives, because the telescoping tail L_{n+2} − L_n equals L_{n+1}.",
+    "mathContext": "$\\sum_{k=0}^m (-1)^k L_k = (-1)^m L_{m-1}+3$; e.g. $2-1+3-4+7 = 7 = L_3+3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "alternating sum",
+      "integer casting",
+      "sign manipulation",
+      "ring tactic",
+      "telescoping"
+    ]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "lucas-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 142,
+      "endLine": 154
+    },
+    "type": "concept",
+    "title": "Kernel-Checked Sanity Values",
+    "content": "Three example lemmas verify the identities at small indices with kernel decide (not native_decide, keeping the file axiom-free): L_2 + L_4 = 10 = L_5 − 1, L_1 + L_3 = 5 = L_4 − 2, and L_0 − L_1 + L_2 − L_3 + L_4 = 7 = L_3 + 3. These pin the general theorems to concrete arithmetic.",
+    "mathContext": "$3+7=10=L_5-1$; $1+4=5=L_4-2$; $2-1+3-4+7=7=L_3+3$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "decidability",
+      "kernel computation",
+      "sanity check"
+    ]
+  }
+]

--- a/src/data/proofs/lucas-sum-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lucas-sum-oq-01-oq-01/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "lucas-sum-oq-01-oq-01",
+  "slug": "lucas-sum-oq-01-oq-01",
+  "title": "Even/Odd-Indexed and Alternating Lucas Partial Sums",
+  "status": "verified",
+  "badge": "original",
+  "description": "Three parity-split telescoping identities for the Lucas numbers (L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}), answering the parent entry's first open question. Even-indexed: ∑_{k=1}^{n} L_{2k} = L_{2n+1} − 1. Odd-indexed: ∑_{k=1}^{n} L_{2k−1} = L_{2n} − 2. Alternating: ∑_{k=0}^{m} (−1)^k L_k = (−1)^m L_{m−1} + 3, whose closed form is Lucas-only (no Fibonacci remainder) because L_{m+1} − L_{m−1} = L_m collapses the telescoping tail. Each identity is proved in a subtraction-free additive form by a one-line induction from the recurrence; the ℕ-subtraction headline forms are read off by omega, and the alternating sum is stated over ℤ since the signs force the integer setting. Fully verified: 8 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "overview": {
+    "historicalContext": "The Lucas numbers 2, 1, 3, 4, 7, 11, 18, … (OEIS A000032) obey the Fibonacci recurrence from the alternative initial data L_0 = 2, L_1 = 1. The parent entry lucas-sum-oq-01 formalizes the full telescoping partial sum ∑_{k=1}^{n} L_k = L_{n+2} − 3. Splitting that sum by the parity of the index yields two further textbook telescoping identities — ∑ L_{2k} = L_{2n+1} − 1 and ∑ L_{2k−1} = L_{2n} − 2 — and alternating the signs yields a third. All are standard consequences of the second-order linear recurrence and appear as exercises in the Fibonacci–Lucas literature (e.g. Koshy).",
+    "problemStatement": "Prove, for every natural number n (resp. m), the even-indexed sum ∑_{k=1}^{n} L_{2k} = L_{2n+1} − 1, the odd-indexed sum ∑_{k=1}^{n} L_{2k−1} = L_{2n} − 2 over ℕ (handling truncated subtraction honestly), and the alternating sum ∑_{k=0}^{m} (−1)^k L_k = (−1)^m L_{m−1} + 3 over ℤ, with L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}. Mathlib provides Nat.fib but no packaged Lucas sequence, so the Lucas numbers are defined locally.",
+    "proofStrategy": "For each identity, prove a subtraction-free additive form by induction on the range bound, using the same engine as the parent entry. Even-indexed: (∑_{k=1}^{n} L_{2k}) + 1 = L_{2n+1}; base 0 + 1 = L_1, and in the step Finset.sum_range_succ peels L_{2n+2} while the recurrence L_{2n+3} = L_{2n+1} + L_{2n+2} lets omega combine it with the inductive hypothesis (the index 2*(n+1)+1 is first normalized to 2*n+3 by rw so the opaque lucas atoms match). Odd-indexed: (∑_{k=1}^{n} L_{2k−1}) + 2 = L_{2n}, analogously. The ℕ-subtraction headlines follow by omega (valid since L_{2n+1} ≥ 1 and L_{2n} ≥ 2). Alternating: over ℤ, prove ∑_{k<n+2} (−1)^k L_k = (−1)^{n+1} L_n + 3 by induction; in the step the two new sign-weighted terms collapse via the cast recurrence L_{n+2} = L_n + L_{n+1} together with (−1)^{n+2} = (−1)^n and (−1)^{n+1} = −(−1)^n, after which ring closes the goal.",
+    "keyInsights": [
+      "Parity splitting of ∑ L_k gives two telescoping sums with different boundary constants: the even part collapses to L_{2n+1} − 1 and the odd part to L_{2n} − 2, the constants 1 and 2 being the boundary Lucas values.",
+      "The alternating sum has a purely Lucas-only closed form (−1)^m L_{m−1} + 3 — no Fibonacci term appears — because the telescoping remainder L_{m+1} − L_{m−1} equals L_m and cancels.",
+      "As in the parent, proving the subtraction-free additive form first makes each induction a one-liner and lets omega discharge the ℕ truncated subtraction of the headline form.",
+      "omega and ring treat lucas (·) as an opaque atom and do not normalize its argument, so the doubled indices (2*(n+1)+1 vs 2*n+3, 2*(n+1) vs 2*n+2) must be rewritten to the goal's exact form before the recurrence is applied.",
+      "Signs force the alternating identity into ℤ; casting the ℕ recurrence and expanding (−1)^{n+1}, (−1)^{n+2} in terms of (−1)^n reduces the step to a ring identity."
+    ],
+    "prerequisites": [
+      "Second-order linear recurrences and the Lucas/Fibonacci initial data",
+      "Finite sums over Finset.range with Finset.sum_range_succ",
+      "ℕ truncated subtraction and the omega decision procedure over opaque atoms",
+      "Casting ℕ to ℤ and manipulating (−1)^k via pow_add / pow_succ; the ring tactic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "lucas-def",
+      "title": "Section I: The Lucas Numbers and Their Recurrence",
+      "startLine": 43,
+      "endLine": 60,
+      "summary": "lucas: ℕ → ℕ with L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}, the boundary simp lemmas, and the recurrence lucas_add_two (a self-contained copy of the parent's definition).",
+      "mathContext": "Mathlib has no Lucas sequence, so the sequence is defined locally; lucas_add_two : L_{n+2} = L_n + L_{n+1} is the rfl-recurrence driving all three telescoping inductions."
+    },
+    {
+      "id": "even-indexed",
+      "title": "Section II: The Even-Indexed Sum",
+      "startLine": 62,
+      "endLine": 87,
+      "summary": "lucas_even_sum_add_one: (∑_{k=1}^{n} L_{2k}) + 1 = L_{2n+1} by induction, and the headline lucas_even_sum: ∑_{k=1}^{n} L_{2k} = L_{2n+1} − 1.",
+      "mathContext": "Finset.sum_range_succ peels L_{2n+2}; after rewriting 2*(n+1)+1 to 2*n+3 the recurrence L_{2n+3} = L_{2n+1} + L_{2n+2} lets omega finish. The ℕ subtraction is exact because L_{2n+1} ≥ 1."
+    },
+    {
+      "id": "odd-indexed",
+      "title": "Section III: The Odd-Indexed Sum",
+      "startLine": 89,
+      "endLine": 114,
+      "summary": "lucas_odd_sum_add_two: (∑_{k=1}^{n} L_{2k−1}) + 2 = L_{2n} by induction, and the headline lucas_odd_sum: ∑_{k=1}^{n} L_{2k−1} = L_{2n} − 2.",
+      "mathContext": "Analogous to the even case: the new term L_{2n+1} combines with the inductive hypothesis via L_{2n+2} = L_{2n} + L_{2n+1}; the ℕ subtraction is exact because L_{2n} ≥ 2."
+    },
+    {
+      "id": "alternating",
+      "title": "Section IV: The Alternating Sum",
+      "startLine": 116,
+      "endLine": 149,
+      "summary": "lucas_alt_sum: ∑_{k=0}^{n+1} (−1)^k L_k = (−1)^{n+1} L_n + 3 over ℤ, the subtraction-free shifted form of ∑_{k=0}^{m} (−1)^k L_k = (−1)^m L_{m−1} + 3.",
+      "mathContext": "Over ℤ (signs preclude ℕ). In the induction step the cast recurrence L_{n+2} = L_n + L_{n+1} and the identities (−1)^{n+2} = (−1)^n, (−1)^{n+1} = −(−1)^n reduce the goal to a ring identity — the Lucas-only closed form emerges with no Fibonacci remainder."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 155 lines, 8 theorems and 1 definition establishing the even-indexed sum ∑ L_{2k} = L_{2n+1} − 1, the odd-indexed sum ∑ L_{2k−1} = L_{2n} − 2, and the alternating sum ∑_{k=0}^{m} (−1)^k L_k = (−1)^m L_{m−1} + 3. Each rests on a subtraction-free additive form proved by a one-line induction; the alternating one is stated over ℤ. #print axioms reports only [propext, Classical.choice, Quot.sound] for the headline theorems. This answers the first open question of the parent entry lucas-sum-oq-01.",
+    "implications": "Elementary but cleanly formalized: parity-split and alternating analogues of the Lucas telescoping sum, reusing the parent's subtraction-free engine. The mathematically noteworthy point is that the alternating sum closes in Lucas terms alone (via L_{m+1} − L_{m−1} = L_m), needing no Fibonacci bridge. The results are routine in difficulty rather than new mathematics.",
+    "openQuestions": [
+      "Prove the corresponding Fibonacci parity-split sums ∑ F_{2k} = F_{2n+1} − 1 and ∑ F_{2k−1} = F_{2n}, and relate them to these Lucas identities through the bridge L_{n+1} = F_n + F_{n+2}.",
+      "Establish a weighted or squared Lucas partial sum (e.g. ∑ k·L_k or ∑ L_k²) by the same subtraction-free telescoping engine."
+    ]
+  },
+  "references": [
+    {
+      "key": "OEIS_A000032",
+      "citation": "OEIS Foundation, The On-Line Encyclopedia of Integer Sequences, sequence A000032 (Lucas numbers) and its partial-sum relations.",
+      "type": "web"
+    },
+    {
+      "key": "Koshy",
+      "citation": "Koshy, T., Fibonacci and Lucas Numbers with Applications, Wiley (2001), chapters on Lucas-number summation identities.",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "lucas-sum-oq-01",
+      "relationship": "Parent problem",
+      "description": "Parent entry proving the full telescoping sum ∑_{k=1}^{n} L_k = L_{n+2} − 3. This entry answers its first open question by splitting that sum by parity and alternating the signs, reusing the same subtraction-free additive engine and self-contained Lucas definition."
+    },
+    {
+      "proofId": "fibonacci-identities-oq-06",
+      "relationship": "Fibonacci analogue",
+      "description": "Fibonacci counterpart of the parent telescoping sum ∑_{i≤n} F_i = F_{n+2} − 1; the parity-split Fibonacci sums are the natural analogues of the even/odd identities proved here."
+    },
+    {
+      "proofId": "factorial-telescoping-sum-oq-01",
+      "relationship": "Shared technique",
+      "description": "Shares the ℕ subtraction-free telescoping technique: prove (∑) + c = boundary term first, then read off the subtracted form by omega."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "LucasSumOQ01OQ01",
+    "lineCount": 155,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/LucasSumOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://oeis.org/A000032",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LucasSumOQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "lucas-numbers",
+      "fibonacci",
+      "recurrence",
+      "telescoping",
+      "alternating-sum",
+      "induction",
+      "finite-sums",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{k ∈ range (n+1)} f k = (∑_{k ∈ range n} f k) + f n — peels the new term in each telescoping induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "pow_succ",
+        "description": "a^(n+1) = a^n * a — used to expand (−1)^{n+1} = −(−1)^n in the alternating-sum step",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "lucas_even_sum_add_one / lucas_even_sum: the even-indexed identity ∑_{k=1}^{n} L_{2k} = L_{2n+1} − 1, via the subtraction-free form (∑) + 1 = L_{2n+1}",
+      "lucas_odd_sum_add_two / lucas_odd_sum: the odd-indexed identity ∑_{k=1}^{n} L_{2k−1} = L_{2n} − 2, via (∑) + 2 = L_{2n}",
+      "lucas_alt_sum: the alternating identity ∑_{k=0}^{m} (−1)^k L_k = (−1)^m L_{m−1} + 3 over ℤ, with a Lucas-only closed form (no Fibonacci remainder)",
+      "Answers the first open question of lucas-sum-oq-01 by parity-splitting and alternating the Lucas telescoping sum with the same engine"
+    ],
+    "axiomCount": 0,
+    "lineCount": 155,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for lucas_even_sum, lucas_odd_sum, and lucas_alt_sum. The three example sanity checks use kernel `decide`, not `native_decide`. Compiled against Mathlib v4.26.0. The identities are elementary/classical; Mathlib has no packaged Lucas sequence, so it is defined locally (a self-contained copy of the parent entry's definition).",
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "prerequisites": [
+      "Second-order linear recurrences and Lucas/Fibonacci initial data",
+      "Finite sums over Finset.range with Finset.sum_range_succ",
+      "ℕ truncated subtraction and omega over opaque atoms",
+      "Casting ℕ to ℤ and manipulating (−1)^k; the ring tactic"
+    ],
+    "relatedProblems": [
+      "lucas-sum-oq-01",
+      "fibonacci-identities-oq-06",
+      "factorial-telescoping-sum-oq-01"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the first open question of the parent entry **lucas-sum-oq-01** by parity-splitting and alternating its Lucas telescoping sum `∑_{k=1}^{n} L_k = L_{n+2} − 3`, reusing the same subtraction-free engine.

Three new identities for the Lucas numbers (`L_0=2, L_1=1, L_{n+2}=L_n+L_{n+1}`):

| Identity | Closed form |
|----------|-------------|
| Even-indexed | `∑_{k=1}^{n} L_{2k} = L_{2n+1} − 1` |
| Odd-indexed  | `∑_{k=1}^{n} L_{2k−1} = L_{2n} − 2` |
| Alternating  | `∑_{k=0}^{m} (−1)^k L_k = (−1)^m L_{m−1} + 3` |

**Mathematical note:** the alternating sum has a *Lucas-only* closed form — no Fibonacci remainder — because the telescoping tail `L_{m+1} − L_{m−1} = L_m` cancels. The alternating identity is stated over ℤ (signs force the integer setting); the even/odd ones are over ℕ with the subtraction-free additive form as the inductive engine.

## Verification

- **8 theorems, 1 definition, 155 lines, 0 sorries, 0 axioms, no `native_decide`.**
- `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for the three headline theorems — these do not count under the axiom policy.
- Verified via single-file `lake env lean` against cached Mathlib oleans (v4.26.0). The docker wrapper failed with a containerd I/O error, so the sanctioned single-file elaboration path was used; no full `lake build` was run.

## Files
- `proofs/Proofs/LucasSumOQ01OQ01.lean`
- `src/data/proofs/lucas-sum-oq-01-oq-01/meta.json`
- `src/data/proofs/lucas-sum-oq-01-oq-01/annotations.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)