### PR TITLE
research(burnside-counting-oq-06-oq-01): totient necklace congruence at arbitrary modulus + prime-power form

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ06OQ01.lean
+++ b/proofs/Proofs/BurnsideCountingOQ06OQ01.lean
@@ -1,0 +1,116 @@
+import Mathlib
+import Proofs.BurnsideCountingOQ06
+import Proofs.BurnsideCountingOQ03OQ02OQ01OQ02
+
+/-
+# The totient necklace congruence at an arbitrary modulus
+
+The parent entry (`BurnsideCountingOQ06`, *Fermat's little theorem via necklace
+counting*) specializes the divisor-sum necklace count
+
+  `(#necklaces) · n = ∑_{d ∣ n} φ(n/d) · k^d`        (F)
+
+to a **prime** length `n = p`, where the sum collapses to `φ(p)·k + k^p` and yields
+Fermat's `p ∣ k^p − k`.  This companion pushes the same identity to an **arbitrary**
+modulus.
+
+## What is proved
+
+* `totient_divisor_sum_dvd` — the general divisibility that underlies the whole
+  necklace branch: for every `n ≥ 1` and every `k`,
+
+    `n ∣ ∑_{d ∣ n} φ(n/d) · k^d`,
+
+  with the necklace count `#necklaces` as the explicit quotient.  (F) records the
+  *equation*; this records the *congruence*, valid at every modulus, not just primes.
+* `totient_divisor_sum_modEq` — the same fact in `Nat.ModEq` form.
+* `sum_divisors_prime_pow_eq` — for a prime power `p^a` the divisor sum reindexes to a
+  clean single sum over exponents,
+  `∑_{i=0}^{a} φ(p^{a−i}) · k^{p^i}`.
+* `totient_prime_pow_sum_dvd` / `totient_prime_pow_sum_modEq` — the **prime-power
+  modulus** congruence `p^a ∣ ∑_{i=0}^{a} φ(p^{a−i}) · k^{p^i}`.
+* `totient_prime_pow_leading_dvd` — pulling out the top term gives the Fermat-shaped
+  statement `p^a ∣ (∑_{i<a} φ(p^{a−i}) k^{p^i}) + k^{p^a}`; at `a = 1` this is exactly
+  `p ∣ (p−1)k + k^p`, the parent's Fermat collapse.
+* `prime_pow_sum_one` — the `a = 1` consistency check: the exponent sum equals
+  `φ(p)·k + k^p`, matching `BurnsideCountingOQ06.necklaces_mul_prime_eq`.
+
+## Honesty note on "Euler's theorem"
+
+The congruence proved here, `n ∣ ∑_{d∣n} φ(n/d) k^d`, is the **totient (Gauss-type)
+necklace congruence**.  It is the genuine Fermat generalization that the *rotation*
+necklace count produces at an arbitrary modulus, and it is a *distinct* statement from
+Euler's theorem `k^{φ(n)} ≡ 1 (mod n)` (which requires `gcd(k,n)=1` and does not follow
+from the orbit count alone).  We therefore state and prove the congruence the necklace
+count actually yields, rather than overclaiming Euler.  No axioms, no `sorry`.
+-/
+
+open Finset MulAction
+open BurnsideCountingOQ03OQ02OQ01 (Rot)
+open BurnsideCountingOQ03OQ02OQ01OQ02 (card_necklaces_mul_eq_sum_divisors)
+
+namespace BurnsideCountingOQ06OQ01
+
+/-- **General totient necklace divisibility.**  For every `n ≥ 1` and `k`, the modulus
+`n` divides the totient-weighted divisor sum `∑_{d ∣ n} φ(n/d) · k^d`.  The witness is
+the number of `k`-colored `n`-bead necklaces, since `(#necklaces)·n` equals that sum by
+the parent's identity `(F)`.  This is the modulus-`n` congruence generalizing Fermat's
+prime case. -/
+theorem totient_divisor_sum_dvd (n k : ℕ) [NeZero n] :
+    n ∣ ∑ d ∈ n.divisors, Nat.totient (n / d) * k ^ d := by
+  refine ⟨Nat.card (orbitRel.Quotient (Rot n) (Rot n → Fin k)), ?_⟩
+  rw [← card_necklaces_mul_eq_sum_divisors (n := n) k, Nat.mul_comm]
+
+/-- **General totient necklace congruence, `ModEq` form.** `∑_{d∣n} φ(n/d) k^d ≡ 0 [MOD n]`. -/
+theorem totient_divisor_sum_modEq (n k : ℕ) [NeZero n] :
+    (∑ d ∈ n.divisors, Nat.totient (n / d) * k ^ d) ≡ 0 [MOD n] := by
+  rw [Nat.modEq_zero_iff_dvd]
+  exact totient_divisor_sum_dvd n k
+
+/-- **Prime-power reindexing.**  For a prime `p`, the totient divisor sum over the
+divisors of `p^a` becomes a single sum over exponents:
+`∑_{d ∣ p^a} φ(p^a/d) k^d = ∑_{i=0}^{a} φ(p^{a−i}) k^{p^i}`.  Each divisor `d = p^i`
+contributes `φ(p^{a−i}) · k^{p^i}`. -/
+theorem sum_divisors_prime_pow_eq (p a k : ℕ) (hp : p.Prime) :
+    (∑ d ∈ (p ^ a).divisors, Nat.totient (p ^ a / d) * k ^ d)
+      = ∑ i ∈ Finset.range (a + 1), Nat.totient (p ^ (a - i)) * k ^ (p ^ i) := by
+  rw [Nat.sum_divisors_prime_pow hp]
+  refine Finset.sum_congr rfl (fun i hi => ?_)
+  rw [Nat.pow_div (Nat.lt_succ_iff.mp (Finset.mem_range.mp hi)) hp.pos]
+
+/-- **Prime-power modulus congruence.**  For a prime `p` and any `a, k`,
+`p^a ∣ ∑_{i=0}^{a} φ(p^{a−i}) k^{p^i}`.  This is the prime-power specialization of the
+general necklace divisibility, with the divisor sum written explicitly over exponents. -/
+theorem totient_prime_pow_sum_dvd (p a k : ℕ) (hp : p.Prime) :
+    p ^ a ∣ ∑ i ∈ Finset.range (a + 1), Nat.totient (p ^ (a - i)) * k ^ (p ^ i) := by
+  haveI : NeZero (p ^ a) := ⟨pow_ne_zero a hp.pos.ne'⟩
+  rw [← sum_divisors_prime_pow_eq p a k hp]
+  exact totient_divisor_sum_dvd (p ^ a) k
+
+/-- **Prime-power modulus congruence, `ModEq` form.**
+`∑_{i=0}^{a} φ(p^{a−i}) k^{p^i} ≡ 0 [MOD p^a]`. -/
+theorem totient_prime_pow_sum_modEq (p a k : ℕ) (hp : p.Prime) :
+    (∑ i ∈ Finset.range (a + 1), Nat.totient (p ^ (a - i)) * k ^ (p ^ i)) ≡ 0 [MOD p ^ a] := by
+  rw [Nat.modEq_zero_iff_dvd]
+  exact totient_prime_pow_sum_dvd p a k hp
+
+/-- **Fermat-shaped prime-power congruence.**  Isolating the top term `k^{p^a}` (from the
+divisor `d = p^a`, where `φ(p^0) = 1`) exhibits
+`p^a ∣ (∑_{i<a} φ(p^{a−i}) k^{p^i}) + k^{p^a}`.  For `a = 1` the head sum is `φ(p)·k`, so
+this is Fermat's `p ∣ (p−1)k + k^p`; for `a ≥ 2` it is the higher-modulus analogue with a
+totient-weighted correction of lower `p`-power exponents. -/
+theorem totient_prime_pow_leading_dvd (p a k : ℕ) (hp : p.Prime) :
+    p ^ a ∣ (∑ i ∈ Finset.range a, Nat.totient (p ^ (a - i)) * k ^ (p ^ i)) + k ^ (p ^ a) := by
+  have h := totient_prime_pow_sum_dvd p a k hp
+  rwa [Finset.sum_range_succ, Nat.sub_self, pow_zero, Nat.totient_one, one_mul] at h
+
+/-- **Consistency with the parent's prime collapse.**  At `a = 1` the exponent sum equals
+`φ(p)·k + k^p`, exactly the right-hand side of
+`BurnsideCountingOQ06.necklaces_mul_prime_eq`.  Combined with
+`totient_prime_pow_sum_dvd p 1 k hp` this recovers `p ∣ φ(p)·k + k^p`. -/
+theorem prime_pow_sum_one (p k : ℕ) :
+    (∑ i ∈ Finset.range (1 + 1), Nat.totient (p ^ (1 - i)) * k ^ (p ^ i))
+      = Nat.totient p * k + k ^ p := by
+  simp [Finset.sum_range_succ, Nat.totient_one]
+
+end BurnsideCountingOQ06OQ01

--- a/src/data/proofs/burnside-counting-oq-06-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-06-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "burnside-counting-oq-06-oq-01",
+  "slug": "burnside-counting-oq-06-oq-01",
+  "title": "The Totient Necklace Congruence at Arbitrary Modulus: n ∣ ∑_{d∣n} φ(n/d)·kᵈ and its Prime-Power Form",
+  "description": "Extends the parent's prime specialization of the cyclic necklace count (burnside-counting-oq-06, Fermat's little theorem) to an arbitrary modulus. Because the gallery's divisor-form count (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d holds for every n, the number of necklaces being an integer forces the totient (Gauss-type) congruence n ∣ ∑_{d∣n} φ(n/d)·k^d for every n ≥ 1 and every k (totient_divisor_sum_dvd), with the necklace count as an explicit quotient. Specializing to a prime power p^a and reindexing the divisor sum over exponents (Nat.sum_divisors_prime_pow, Nat.pow_div) yields the clean single sum ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i} and the prime-power modulus congruence p^a ∣ ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i} (totient_prime_pow_sum_dvd). Isolating the top term gives the Fermat-shaped p^a ∣ (∑_{i<a} φ(p^{a−i}) k^{p^i}) + k^{p^a} (totient_prime_pow_leading_dvd), which at a = 1 is exactly the parent's p ∣ (p−1)·k + k^p. This is the totient/Gauss congruence the rotation orbit count actually produces at general modulus — a genuine Fermat generalization, distinct from (and not overclaiming) Euler's theorem k^{φ(n)} ≡ 1.",
+  "leanFile": {
+    "lineCount": 116,
+    "path": "Proofs/BurnsideCountingOQ06OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 7
+  },
+  "meta": {
+    "author": "Classical (Gauss/totient necklace congruence; cf. Golomb 1956, Stanley EC1); formalized via Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Necklace_(combinatorics)",
+    "date": "1956",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ06OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "group-theory",
+      "number-theory",
+      "necklaces",
+      "burnside",
+      "orbit-counting",
+      "cyclic-group",
+      "totient",
+      "divisor-sum",
+      "congruence",
+      "prime-power",
+      "fermat-little-theorem",
+      "research",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 sorries, 0 literal `axiom` declarations, 0 structure-encoded assumptions. Fully machine-checked: all seven theorems (totient_divisor_sum_dvd, totient_divisor_sum_modEq, sum_divisors_prime_pow_eq, totient_prime_pow_sum_dvd, totient_prime_pow_sum_modEq, totient_prime_pow_leading_dvd, prime_pow_sum_one) depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). No native_decide is used.",
+    "dateAdded": "2026-07-02",
+    "lineCount": 116,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_divisors_prime_pow",
+        "description": "∑_{x ∈ (p^a).divisors} f x = ∑_{i ∈ range(a+1)} f (p^i) for prime p — reindexes the divisor sum over the prime power p^a to a sum over exponents i = 0,…,a",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Nat.pow_div",
+        "description": "p^a / p^i = p^(a−i) for i ≤ a and 0 < p — evaluates the complementary divisor p^a/p^i = p^{a−i} inside the reindexed sum, turning φ(p^a/p^i) into φ(p^{a−i})",
+        "module": "Mathlib.Data.Nat.Basic"
+      },
+      {
+        "theorem": "Nat.totient_one",
+        "description": "φ(1) = 1 — makes the top term of the prime-power sum (divisor d = p^a, i.e. φ(p^0)·k^{p^a}) equal to k^{p^a}, exposing the Fermat-shaped leading term",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{i ∈ range(n+1)} f i = (∑_{i ∈ range n} f i) + f n — splits off the top exponent i = a to expose k^{p^a} and to collapse the a = 1 sum to φ(p)·k + k^p",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.modEq_zero_iff_dvd",
+        "description": "a ≡ 0 [MOD n] ↔ n ∣ a — packages the divisibilities as Nat.ModEq congruences",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "BurnsideCountingOQ03OQ02OQ01OQ02.card_necklaces_mul_eq_sum_divisors",
+        "description": "(#necklaces up to rotation)·n = ∑_{d∣n} φ(n/d)·k^d — the gallery's divisor-form cyclic necklace count, whose integer left factor gives the modulus-n divisibility at every n",
+        "module": "Proofs.BurnsideCountingOQ03OQ02OQ01OQ02"
+      }
+    ],
+    "originalContributions": [
+      "totient_divisor_sum_dvd: n ∣ ∑_{d∣n} φ(n/d)·k^d for every n ≥ 1 and k — the general totient (Gauss-type) necklace congruence, obtained by reading the parent equation (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d as a divisibility with the necklace count as the explicit quotient. The parent recorded only the prime case; this holds at every modulus.",
+      "totient_divisor_sum_modEq: ∑_{d∣n} φ(n/d)·k^d ≡ 0 [MOD n] — the same fact in Nat.ModEq form.",
+      "sum_divisors_prime_pow_eq: ∑_{d∣p^a} φ(p^a/d)·k^d = ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i} for prime p — reindexes the prime-power divisor sum to a single clean sum over exponents (Nat.sum_divisors_prime_pow, then Nat.pow_div evaluates p^a/p^i = p^{a−i} termwise).",
+      "totient_prime_pow_sum_dvd: p^a ∣ ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i} for prime p — the prime-power modulus specialization of the general congruence, with the divisor sum written explicitly over exponents.",
+      "totient_prime_pow_sum_modEq: ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i} ≡ 0 [MOD p^a] — its Nat.ModEq form.",
+      "totient_prime_pow_leading_dvd: p^a ∣ (∑_{i<a} φ(p^{a−i})·k^{p^i}) + k^{p^a} — pulling out the top term k^{p^a} (φ(p^0) = 1) gives the Fermat-shaped statement; at a = 1 the head sum is φ(p)·k, recovering the parent's p ∣ (p−1)·k + k^p.",
+      "prime_pow_sum_one: ∑_{i=0}^{1} φ(p^{1−i})·k^{p^i} = φ(p)·k + k^p — the a = 1 consistency check, matching the right-hand side of BurnsideCountingOQ06.necklaces_mul_prime_eq and confirming the general prime-power sum degenerates to the parent's prime collapse."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The number of k-colored n-bead necklaces up to rotation is the classical closed form (1/n)·∑_{d∣n} φ(n/d)·k^d (Gauss; see Stanley, Enumerative Combinatorics I). Its most famous by-product is the necklace proof of Fermat's little theorem (Golomb 1956), which the parent entry burnside-counting-oq-06 formalizes by specializing the bead count to a prime length p. But the same count carries information at every modulus: because it is an integer, n divides the totient-weighted divisor sum for all n, not just primes. This entry records that general congruence and its prime-power specialization, closing the parent's own open question of pushing the prime case to a prime-power or square-free modulus.",
+    "problemStatement": "Extend the prime-length necklace collapse to an arbitrary modulus. Prove the general totient congruence n ∣ ∑_{d∣n} φ(n/d)·k^d for every n ≥ 1 and every k, then specialize to a prime power p^a: reindex the divisor sum over exponents to ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i}, deduce p^a ∣ ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i}, and pull out the top term to exhibit the Fermat-shaped p^a ∣ (∑_{i<a} φ(p^{a−i}) k^{p^i}) + k^{p^a} that degenerates to the parent's p ∣ (p−1)·k + k^p at a = 1.",
+    "proofStrategy": "**General congruence (totient_divisor_sum_dvd).** The parent's card_necklaces_mul_eq_sum_divisors gives (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d for any n with NeZero n. Reading the left side as n·(#necklaces) exhibits the necklace count as an explicit quotient, so n ∣ ∑_{d∣n} φ(n/d)·k^d; totient_divisor_sum_modEq is the Nat.ModEq restatement via Nat.modEq_zero_iff_dvd.\n\n**Prime-power reindexing (sum_divisors_prime_pow_eq).** For a prime p, Nat.sum_divisors_prime_pow rewrites the sum over (p^a).divisors as a sum over exponents i ∈ range(a+1) of f(p^i) with f d = φ(p^a/d)·k^d. A termwise Finset.sum_congr then uses Nat.pow_div (valid since i ≤ a on range(a+1)) to replace p^a/p^i by p^{a−i}, giving ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i}.\n\n**Prime-power modulus congruence (totient_prime_pow_sum_dvd).** Instantiate the general congruence at n = p^a (NeZero p^a from p prime) and rewrite the divisor sum by sum_divisors_prime_pow_eq.\n\n**Fermat-shaped leading form (totient_prime_pow_leading_dvd).** Finset.sum_range_succ splits off the top exponent i = a, whose term is φ(p^{a−a})·k^{p^a} = φ(1)·k^{p^a} = k^{p^a} (Nat.sub_self, pow_zero, Nat.totient_one), leaving p^a ∣ (∑_{i<a} φ(p^{a−i}) k^{p^i}) + k^{p^a}.\n\n**Consistency (prime_pow_sum_one).** At a = 1, sum_range_succ and totient_one evaluate ∑_{i=0}^{1} φ(p^{1−i})·k^{p^i} to φ(p)·k + k^p, the exact right-hand side of the parent's necklaces_mul_prime_eq.",
+    "keyInsights": [
+      "**Fermat's prime collapse is one point of a modulus-n congruence.** The parent evaluated (#necklaces)·n = ∑_{d∣n} φ(n/d) k^d only at n = p; the divisor sum is congruent to 0 modulo n for every n, and Fermat is the two-term n = p case.",
+      "**Integrality of an orbit count is the whole content.** The congruence n ∣ ∑_{d∣n} φ(n/d) k^d says nothing more than that the number of necklaces — the quotient of the divisor sum by n — is a whole number; the necklace count is the explicit witness.",
+      "**A prime power gives a clean single sum.** Over p^a the divisor lattice is a chain, so the sum reindexes to ∑_{i=0}^{a} φ(p^{a−i}) k^{p^i}; the top exponent contributes the bare k^{p^a}, making the Fermat shape p^a ∣ (lower terms) + k^{p^a} explicit.",
+      "**It is the Gauss/totient congruence, not Euler.** What the rotation orbit count yields at arbitrary modulus is the totient-weighted divisor congruence, a genuine Fermat generalization that is distinct from Euler's k^{φ(n)} ≡ 1 (which needs gcd(k,n) = 1 and a different argument). Stating the congruence the count actually produces keeps the entry honest."
+    ],
+    "prerequisites": [
+      "The parent's prime specialization burnside-counting-oq-06 (Fermat via necklaces) and the gallery's divisor-form count card_necklaces_mul_eq_sum_divisors (burnside-counting-oq-03-oq-02-oq-01-oq-02)",
+      "Divisors of a prime power: Nat.sum_divisors_prime_pow and Nat.pow_div (p^a/p^i = p^{a−i})",
+      "Elementary totient values: Nat.totient_one (φ(1) = 1)",
+      "The dictionary between Nat divisibility and Nat.ModEq (Nat.modEq_zero_iff_dvd) and finite-sum manipulation (Finset.sum_range_succ, Finset.sum_congr)"
+    ],
+    "what": "For every n ≥ 1 and k: n ∣ ∑_{d∣n} φ(n/d)·k^d (the totient/Gauss necklace congruence), with the necklace count as explicit quotient. For a prime power p^a the divisor sum reindexes to ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i}, giving p^a ∣ ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i} and the Fermat-shaped p^a ∣ (∑_{i<a} φ(p^{a−i}) k^{p^i}) + k^{p^a}, which at a = 1 is the parent's p ∣ (p−1)·k + k^p. 7 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "how": "Read the parent equation (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d as a divisibility (integer necklace count = quotient); then for n = p^a reindex the divisor sum over exponents with Nat.sum_divisors_prime_pow and Nat.pow_div, and split off the top exponent with Finset.sum_range_succ and Nat.totient_one to expose k^{p^a}.",
+    "significance": "Answers the parent entry's own open question — pushing the prime-length Fermat collapse to a prime-power/arbitrary modulus — with a fully machine-checked, axiom-free congruence. It isolates the general fact behind the whole necklace branch (integrality of the orbit count ⇒ n ∣ ∑_{d∣n} φ(n/d) k^d), gives the prime-power case as an explicit exponent sum with the Fermat shape p^a ∣ (⋯) + k^{p^a}, and is careful to state the totient/Gauss congruence the count actually yields rather than overclaiming Euler's theorem."
+  },
+  "references": [
+    {
+      "authors": "Solomon W. Golomb",
+      "title": "Combinatorial Proof of Fermat's 'Little' Theorem (American Mathematical Monthly 63)",
+      "year": 1956,
+      "note": "The necklace-counting proof of the prime case, generalized here to arbitrary modulus."
+    },
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Enumerative Combinatorics, Volume 1 (2nd ed.)",
+      "year": 2011,
+      "note": "Cambridge University Press. The totient-weighted divisor-sum necklace count (1/n)∑_{d∣n} φ(n/d) k^d and cyclic orbit counting."
+    },
+    {
+      "authors": "Carl Friedrich Gauss",
+      "title": "Disquisitiones Arithmeticae",
+      "year": 1801,
+      "note": "The totient identity ∑_{d∣n} φ(d) = n and the arithmetic of divisor sums underlying the necklace count and its congruence."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.divisors, Nat.totient, and cyclic-group action infrastructure",
+      "year": 2024,
+      "note": "Nat.sum_divisors_prime_pow, Nat.pow_div, Nat.totient_one, and the φ-weighted divisor sum machinery reused from the parent Burnside branch."
+    }
+  ],
+  "conclusion": {
+    "summary": "Generalizes the parent's prime specialization of the cyclic necklace count to an arbitrary modulus. Since (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d holds for every n and the necklace count is an integer, one gets the totient (Gauss-type) congruence n ∣ ∑_{d∣n} φ(n/d)·k^d for all n ≥ 1 and k (totient_divisor_sum_dvd), with the necklace count as explicit witness. For a prime power p^a the divisor sum reindexes over exponents to ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i} (sum_divisors_prime_pow_eq), giving p^a ∣ ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i} (totient_prime_pow_sum_dvd) and, after isolating the top term, the Fermat-shaped p^a ∣ (∑_{i<a} φ(p^{a−i}) k^{p^i}) + k^{p^a} (totient_prime_pow_leading_dvd) — which at a = 1 reproduces the parent's p ∣ (p−1)·k + k^p (prime_pow_sum_one). Fully verified with 0 sorries and 0 axioms.",
+    "implications": "Turns the parent's one-off prime collapse into a modulus-n congruence, exposing that the entire necklace branch rests on the integrality of a single orbit count. The prime-power form ∑_{i=0}^{a} φ(p^{a−i}) k^{p^i} ≡ 0 (mod p^a) is a concrete higher-modulus Gauss congruence with the bare k^{p^a} as its leading term, and the entry deliberately proves the totient congruence the count yields rather than overstating it as Euler's theorem.",
+    "openQuestions": [
+      "Make the square-free modulus n = p·q explicit: enumerate the four divisors {1, p, q, pq} to write ∑_{d∣pq} φ(pq/d) k^d = (p−1)(q−1)k + (q−1)k^p + (p−1)k^q + k^{pq} and read off pq ∣ that four-term sum directly.",
+      "Determine precisely when the totient necklace congruence n ∣ ∑_{d∣n} φ(n/d) k^d does and does not imply Euler's theorem k^{φ(n)} ≡ 1 (gcd(k,n)=1), and whether a Korselt/Carmichael criterion can be read off the same divisor-sum data."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "From the prime case to an arbitrary modulus",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring. Recalls the parent's prime specialization of the divisor-form necklace count (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d and states the plan: the count is an integer at every n, so n divides the totient-weighted divisor sum for all n; the prime-power case reindexes to ∑_{i=0}^{a} φ(p^{a−i}) k^{p^i}. Includes an honesty note distinguishing this totient/Gauss congruence from Euler's theorem.",
+      "mathContext": "$n \\mid \\sum_{d\\mid n}\\varphi(n/d)\\,k^{d}$"
+    },
+    {
+      "id": "general",
+      "title": "The general totient necklace congruence",
+      "startLine": 49,
+      "endLine": 72,
+      "summary": "totient_divisor_sum_dvd and totient_divisor_sum_modEq: for every n ≥ 1 and k, n ∣ ∑_{d∣n} φ(n/d)·k^d, with the necklace count Nat.card(orbits) as explicit quotient, read off the parent's equation card_necklaces_mul_eq_sum_divisors.",
+      "mathContext": "$\\sum_{d\\mid n}\\varphi(n/d)\\,k^{d}\\equiv 0 \\pmod n$"
+    },
+    {
+      "id": "prime-power",
+      "title": "Prime-power reindexing and congruence",
+      "startLine": 73,
+      "endLine": 100,
+      "summary": "sum_divisors_prime_pow_eq reindexes ∑_{d∣p^a} φ(p^a/d) k^d = ∑_{i=0}^{a} φ(p^{a−i}) k^{p^i} (Nat.sum_divisors_prime_pow + termwise Nat.pow_div); totient_prime_pow_sum_dvd and totient_prime_pow_sum_modEq give p^a ∣ ∑_{i=0}^{a} φ(p^{a−i}) k^{p^i}.",
+      "mathContext": "$p^{a}\\mid \\sum_{i=0}^{a}\\varphi(p^{a-i})\\,k^{p^{i}}$"
+    },
+    {
+      "id": "fermat-shape",
+      "title": "Fermat-shaped leading form and consistency",
+      "startLine": 101,
+      "endLine": 116,
+      "summary": "totient_prime_pow_leading_dvd isolates the top exponent (φ(p^0)=1) to give p^a ∣ (∑_{i<a} φ(p^{a−i}) k^{p^i}) + k^{p^a}; prime_pow_sum_one checks the a = 1 sum equals φ(p)·k + k^p, matching the parent's necklaces_mul_prime_eq.",
+      "mathContext": "$p^{a}\\mid \\Big(\\sum_{i<a}\\varphi(p^{a-i})k^{p^{i}}\\Big)+k^{p^{a}}$"
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "xref-burnside-oq06-fermat-prime",
+      "targetId": "burnside-counting-oq-06",
+      "relationship": "extends",
+      "description": "Generalizes that entry's prime-length collapse (#necklaces)·p = (p−1)k + k^p ⇒ p ∣ k^p − k to an arbitrary modulus: n ∣ ∑_{d∣n} φ(n/d)·k^d for all n, with the prime-power case p^a ∣ ∑_{i=0}^{a} φ(p^{a−i}) k^{p^i} degenerating to the parent's two-term Fermat form at a = 1."
+    },
+    {
+      "id": "xref-burnside-oq0302010102-divisor-count",
+      "targetId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Reads that entry's divisor-form cyclic necklace count (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d as a divisibility for every n, extracting the modulus-n totient congruence directly from the integrality of the orbit count."
+    },
+    {
+      "id": "xref-burnside-root",
+      "targetId": "burnside-counting",
+      "relationship": "extends",
+      "description": "Delivers the number-theoretic payoff of the root Burnside/necklace framework at general modulus: the totient (Gauss-type) congruence n ∣ ∑_{d∣n} φ(n/d) k^d generalizing the prime-length Fermat case."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's own open question (`burnside-counting-oq-06`, *Fermat via necklace counting*, openQuestions[0]): **extend the prime-length specialization to a prime-power / arbitrary modulus.**

Because the gallery's divisor-form count `(#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d` holds for **every** `n` and the necklace count is an integer, we get the **totient (Gauss-type) necklace congruence**
```
n ∣ ∑_{d∣n} φ(n/d)·k^d      for all n ≥ 1, k
```
with the necklace count as the explicit quotient. Specializing to a prime power `p^a` reindexes the divisor sum over exponents:
```
∑_{d∣p^a} φ(p^a/d) k^d = ∑_{i=0}^{a} φ(p^{a−i}) k^{p^i}
p^a ∣ ∑_{i=0}^{a} φ(p^{a−i}) k^{p^i}
p^a ∣ (∑_{i<a} φ(p^{a−i}) k^{p^i}) + k^{p^a}      (Fermat-shaped leading term)
```
which at `a = 1` degenerates to the parent's `p ∣ (p−1)·k + k^p`.

## Theorems (7, 0 defs)
- `totient_divisor_sum_dvd` — general `n ∣ ∑_{d∣n} φ(n/d) k^d`
- `totient_divisor_sum_modEq` — `Nat.ModEq` form
- `sum_divisors_prime_pow_eq` — reindex over exponents (`Nat.sum_divisors_prime_pow`, `Nat.pow_div`)
- `totient_prime_pow_sum_dvd` / `totient_prime_pow_sum_modEq` — prime-power modulus congruence
- `totient_prime_pow_leading_dvd` — Fermat-shaped leading form
- `prime_pow_sum_one` — a = 1 consistency with parent's `necklaces_mul_prime_eq`

## Honesty note
This is the totient/Gauss congruence the rotation orbit count **actually** produces at general modulus — a genuine Fermat generalization, **distinct from** Euler's `k^{φ(n)} ≡ 1` (which needs `gcd(k,n)=1` and a different argument). The entry does not overclaim Euler.

## Verification
- Built with `lake env lean Proofs/BurnsideCountingOQ06OQ01.lean` (single-file elab against prebuilt Mathlib oleans).
- `#print axioms`: `propext, Classical.choice, Quot.sound` only. **0 axioms, 0 sorries.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)