### PR TITLE
Enrich Gauss's q-Binomial Theorem (combinations-formula-oq-03-oq-02)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-cf0302-overview",
+    "proofId": "combinations-formula-oq-03-oq-02",
+    "range": { "startLine": 4, "endLine": 42 },
+    "type": "concept",
+    "title": "The identity the parent left unassembled",
+    "content": "Gauss's finite q-binomial theorem expands the product of linear factors (1 + qⁱx), i = 0,…,n−1, as a q-weighted sum of the Gaussian binomial coefficients [n,k]_q, with each term carrying the weight q^{C(k,2)} where C(k,2) = k(k−1)/2 is the k-th triangular number. It is the finite, single-variable heart of q-hypergeometric series and the q-analog of the ordinary binomial theorem, which it recovers at q = 1. The parent entry combinations-formula-oq-03 built the entire qBinom toolkit — the definition, both q-Pascal recurrences, the vanishing lemma, and the q=1 specialization — but never assembled them into this generating-function identity; this file supplies it plus two corollaries.",
+    "mathContext": "$\\prod_{i=0}^{n-1}(1 + q^i x) = \\sum_{k=0}^{n} \\binom{n}{k}_q q^{\\binom{k}{2}} x^k,\\quad \\binom{k}{2}=\\tfrac{k(k-1)}2.$",
+    "significance": "key",
+    "relatedConcepts": ["Gaussian binomial coefficient", "q-hypergeometric series", "generating functions", "binomial theorem", "triangular numbers"],
+    "prerequisites": ["Gaussian binomial coefficients (parent entry)", "finite products and sums over Finset.range"]
+  },
+  {
+    "id": "ann-cf0302-gauss-main",
+    "proofId": "combinations-formula-oq-03-oq-02",
+    "range": { "startLine": 54, "endLine": 66 },
+    "type": "technique",
+    "title": "The main theorem and its induction on n",
+    "content": "qBinom_gauss is stated over an arbitrary commutative ring R with parameters q x : R — no invertibility hypothesis on q, so q may be a zero divisor or 0 — because the parent's [n,k]_q is defined division-free by the q-Pascal recurrence rather than as a quotient of q-factorials. The proof is by induction on n. The base case n = 0 is closed by simp: the empty product is 1 and the right-hand sum has the single k = 0 term [0,0]_q·q⁰·x⁰ = 1.",
+    "mathContext": "$n=0:\\ \\prod_{i\\in\\varnothing}(\\cdots)=1=\\binom{0}{0}_q q^{0} x^{0}.$",
+    "significance": "key",
+    "relatedConcepts": ["mathematical induction", "commutative ring", "division-free definition", "empty product"],
+    "prerequisites": ["induction on ℕ", "Finset.prod over range"]
+  },
+  {
+    "id": "ann-cf0302-hkey",
+    "proofId": "combinations-formula-oq-03-oq-02",
+    "range": { "startLine": 68, "endLine": 81 },
+    "type": "insight",
+    "title": "The coefficient recurrence: second q-Pascal + triangular bookkeeping",
+    "content": "The engine of the inductive step. For k ≤ n, the (k+1)-st term at level n+1 splits into a q^n·x-shifted level-n term of index k plus the level-n term of index k+1. This is exactly the second q-Pascal recurrence [n+1,k+1]_q = q^{n−k}[n,k]_q + [n,k+1]_q (qBinom_pascal'), combined with the triangular-number identity C(k+1,2) = k + C(k,2). That identity is the crux: it lets the shift factor q^{n−k} coming from q-Pascal merge with q^{C(k+1,2)} to produce the clean q^n·q^{C(k,2)} (lemma hexp), after which linear_combination closes the goal. No exponent identity beyond C(k+1,2) = k + C(k,2) is needed.",
+    "mathContext": "$q^{n-k}\\,q^{\\binom{k+1}{2}} = q^{n}\\,q^{\\binom{k}{2}}\\quad\\text{since}\\quad \\binom{k+1}{2}=k+\\binom{k}{2}.$",
+    "significance": "key",
+    "relatedConcepts": ["q-Pascal recurrence", "triangular numbers", "linear_combination", "exponent arithmetic"],
+    "prerequisites": ["the second q-Pascal recurrence qBinom_pascal'", "Nat.choose_succ_succ"]
+  },
+  {
+    "id": "ann-cf0302-shift",
+    "proofId": "combinations-formula-oq-03-oq-02",
+    "range": { "startLine": 82, "endLine": 105 },
+    "type": "technique",
+    "title": "Vanishing top term, shift identity, and assembly",
+    "content": "Three bookkeeping steps finish the induction. hlast: the level-n term of index n+1 vanishes because qBinom_eq_zero_of_lt kills [n,n+1]_q (index exceeds n). hshift: re-folds the shifted sum ∑ g(k+1) + 1 = ∑ g(k) using Finset.sum_range_succ' and sum_range_succ against the vanishing top term and the fact that the k = 0 term equals 1. The main computation then multiplies the level-n expansion by the new factor (1 + q^n·x) via Finset.prod_range_succ, distributes with sum_add_distrib and mul_sum, and closes with ring. The whole step is pure rearrangement once the coefficient recurrence is in hand.",
+    "mathContext": "$\\sum_{k<n+1} g(k{+}1) + 1 = \\sum_{k<n+1} g(k),\\qquad \\binom{n}{n+1}_q = 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_range_succ'", "index shifting", "vanishing lemma", "distributivity of sums"],
+    "prerequisites": ["reindexing finite sums", "qBinom_eq_zero_of_lt"]
+  },
+  {
+    "id": "ann-cf0302-signed",
+    "proofId": "combinations-formula-oq-03-oq-02",
+    "range": { "startLine": 111, "endLine": 124 },
+    "type": "context",
+    "title": "Signed variant via x ↦ −x",
+    "content": "qBinom_gauss_neg gives the alternating product ∏(1 − qⁱx) = ∑ (−1)ᵏ[n,k]_q q^{C(k,2)} x^k for free by substituting x ↦ −x in the main theorem: each factor 1 + qⁱ(−x) becomes 1 − qⁱx, and each xᵏ picks up (−1)ᵏ via mul_pow. These alternating signs are exactly what appear in finite Jacobi-triple-product and q-series manipulations.",
+    "mathContext": "$\\prod_{i=0}^{n-1}(1 - q^i x) = \\sum_{k=0}^{n} (-1)^k \\binom{n}{k}_q q^{\\binom{k}{2}} x^k.$",
+    "significance": "context",
+    "relatedConcepts": ["substitution", "alternating signs", "Jacobi triple product", "q-series"],
+    "prerequisites": ["the main q-binomial theorem", "mul_pow"]
+  },
+  {
+    "id": "ann-cf0302-classical",
+    "proofId": "combinations-formula-oq-03-oq-02",
+    "range": { "startLine": 126, "endLine": 134 },
+    "type": "insight",
+    "title": "Recovering the classical binomial theorem at q = 1",
+    "content": "binom_theorem_of_qBinom specializes q = 1: every weight q^{C(k,2)} collapses to 1 (one_pow) and each Gaussian binomial [n,k]_1 becomes the ordinary C(n,k) (qBinom_at_one), while the product ∏(1 + x) over n factors becomes (1 + x)^n (Finset.prod_const, card_range). The classical binomial theorem (1+x)^n = ∑ C(n,k) xᵏ thus drops out as a one-line corollary — certifying the q-binomial theorem as a genuine q-deformation rather than an unrelated identity.",
+    "mathContext": "$q=1:\\ (1+x)^n = \\sum_{k=0}^{n} \\binom{n}{k} x^k.$",
+    "significance": "key",
+    "relatedConcepts": ["binomial theorem", "q=1 specialization", "qBinom_at_one", "Finset.prod_const"],
+    "prerequisites": ["the main q-binomial theorem", "q=1 value of Gaussian binomials"]
+  },
+  {
+    "id": "ann-cf0302-verify",
+    "proofId": "combinations-formula-oq-03-oq-02",
+    "range": { "startLine": 140, "endLine": 152 },
+    "type": "context",
+    "title": "Concrete check at n = 2",
+    "content": "Two examples pin down the identity at n = 2. First, the product (1 + x)(1 + qx) expands directly to 1 + (1+q)x + qx². Second, the q-binomial right-hand side ∑_{k<3} [2,k]_q q^{C(k,2)} xᵏ is computed and shown to equal the same polynomial, with the coefficients [2,0]_q = 1, [2,1]_q = 1+q, [2,2]_q·q^{C(2,2)} = 1·q. This makes the abstract identity tangible and guards against off-by-one or exponent-weight errors.",
+    "mathContext": "$(1+x)(1+qx) = 1 + (1+q)x + q x^2 = \\sum_{k=0}^{2}\\binom{2}{k}_q q^{\\binom{k}{2}} x^k.$",
+    "significance": "context",
+    "relatedConcepts": ["worked example", "polynomial expansion", "sanity check"],
+    "prerequisites": ["Finset.prod_range_succ", "the q-binomial theorem"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-03-oq-02`.

**Gap filled**: the entry had **no annotations.json** (annotations, mathContext, significance, crossRefs all scored 0). meta.json was already rich (overview, sections, conclusion, references, mainTheorems) and was left untouched.

**Added**: annotations.json with **7 substantive annotations**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
- overview / the identity the parent left unassembled
- the main theorem and its induction on n
- the coefficient recurrence (2nd q-Pascal + triangular identity C(k+1,2)=k+C(k,2))
- vanishing top term, shift identity, assembly
- signed variant via x↦−x
- classical binomial theorem recovered at q=1
- concrete n=2 check

Anchors validated against the 154-line Lean file (no anchor errors). Axiom status unchanged (verified, 0 axioms).