### PR TITLE
Enrich Aperiodic Necklaces / Möbius companion to Fermat (burnside-counting-oq-06-oq-02)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-06-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-bc0602-overview",
+    "proofId": "burnside-counting-oq-06-oq-02",
+    "range": { "startLine": 4, "endLine": 45 },
+    "type": "concept",
+    "title": "Two closed forms for necklaces, one congruence",
+    "content": "There are two classical closed forms for counting k-colored necklaces of length n under cyclic rotation: the totient (Burnside) form N(n) = (1/n)∑_{d∣n} φ(n/d)·kᵈ for the total count, and the Möbius form L(n) = (1/n)∑_{d∣n} μ(d)·k^{n/d} for the aperiodic necklaces — those with no rotational symmetry, in bijection with Lyndon words. The two are linked by Möbius inversion of ∑_{d∣n} d·A(d) = kⁿ. The parent entry proved Fermat's little theorem from the totient form; this entry supplies the Möbius companion and shows both specialize at a prime p to k^p ≡ k (mod p). The necklace-counting proof of Fermat is credited to Golomb (1956); the Lyndon/Möbius refinement is the standard companion.",
+    "mathContext": "$N(n)=\\tfrac1n\\sum_{d\\mid n}\\varphi(n/d)k^{d},\\qquad L(n)=\\tfrac1n\\sum_{d\\mid n}\\mu(d)k^{n/d}.$",
+    "significance": "key",
+    "relatedConcepts": ["necklace counting", "Lyndon words", "aperiodic necklaces", "Möbius inversion", "Fermat's little theorem"],
+    "prerequisites": ["cyclic group action on colorings", "the parent totient necklace count", "Möbius and totient functions"]
+  },
+  {
+    "id": "ann-bc0602-mobius",
+    "proofId": "burnside-counting-oq-06-oq-02",
+    "range": { "startLine": 52, "endLine": 59 },
+    "type": "technique",
+    "title": "The Möbius companion collapses at a prime",
+    "content": "mobius_companion_prime evaluates the Möbius sum ∑_{d∣p} μ(d)·k^{p/d} at a prime p. The divisors of p are exactly {1, p} (Nat.Prime.divisors), so Finset.sum_pair reduces the sum to two terms: μ(1)·k^{p/1} = k^p and μ(p)·k^{p/p} = −k, using μ(1) = 1 (moebius_apply_one) and μ(p) = −1 (moebius_apply_prime). A final ring gives k^p − k. No general Möbius-inversion machinery is needed for the prime specialization — the whole content is that a prime has only two divisors.",
+    "mathContext": "$\\sum_{d\\mid p}\\mu(d)k^{p/d} = \\mu(1)k^{p} + \\mu(p)k = k^p - k.$",
+    "significance": "key",
+    "relatedConcepts": ["Möbius function", "divisors of a prime", "Finset.sum_pair", "two-term collapse"],
+    "prerequisites": ["μ(1)=1 and μ(p)=−1", "Nat.Prime.divisors = {1, p}"]
+  },
+  {
+    "id": "ann-bc0602-def",
+    "proofId": "burnside-counting-oq-06-oq-02",
+    "range": { "startLine": 61, "endLine": 65 },
+    "type": "definition",
+    "title": "The aperiodic (Lyndon) necklace count L(p) = N − k",
+    "content": "aperiodicNecklaces p k is defined as the total necklace count N = Nat.card of the orbit quotient of the rotation action Rot p on colorings (Rot p → Fin k), minus k. At prime length this is exactly the aperiodic count: a coloring of prime period p has period either 1 (constant — there are k such, the monochromatic necklaces) or full period p (aperiodic). So subtracting the k monochromatic necklaces from the total leaves precisely the aperiodic (Lyndon) ones. This makes the Möbius companion an honest cardinality difference rather than a purely formal expression. The definition is noncomputable because it uses Nat.card of a quotient.",
+    "mathContext": "$L(p) := N - k = \\#\\{\\text{necklaces}\\} - \\#\\{\\text{monochromatic}\\}.$",
+    "significance": "key",
+    "relatedConcepts": ["orbit quotient", "rotation action Rot", "monochromatic colorings", "period of a coloring"],
+    "prerequisites": ["the parent necklace framework", "Nat.card of an orbit quotient"]
+  },
+  {
+    "id": "ann-bc0602-key",
+    "proofId": "burnside-counting-oq-06-oq-02",
+    "range": { "startLine": 67, "endLine": 89 },
+    "type": "technique",
+    "title": "Auxiliary: N·p = (k^p − k) + k·p and k ≤ N",
+    "content": "necklaces_key does the ℤ-algebra that makes L(p) = N − k a genuine ℕ count. Starting from the parent's totient identity N·p = φ(p)·k + k^p (necklaces_mul_prime_eq, cast to ℤ) and substituting φ(p) = p − 1 (Nat.totient_prime), a linear_combination yields N·p = (k^p − k) + k·p. It then derives k ≤ N: since k ≤ k^p (Nat.le_self_pow), the identity forces k·p ≤ N·p, and cancelling the positive factor p (le_of_mul_le_mul_right) gives k ≤ N. This inequality is what lets the later ℕ-subtraction N − k be cast to ℤ faithfully.",
+    "mathContext": "$N\\cdot p = (p-1)k + k^p = (k^p - k) + k p,\\qquad k \\le N.$",
+    "significance": "supporting",
+    "relatedConcepts": ["totient of a prime", "linear_combination", "ℕ subtraction well-definedness", "cancellation"],
+    "prerequisites": ["the parent's necklaces_mul_prime_eq", "Nat.totient_prime", "Nat.le_self_pow"]
+  },
+  {
+    "id": "ann-bc0602-mulprime",
+    "proofId": "burnside-counting-oq-06-oq-02",
+    "range": { "startLine": 91, "endLine": 97 },
+    "type": "insight",
+    "title": "p·L(p) = k^p − k",
+    "content": "aperiodicNecklaces_mul_prime is the numerator identity of L(p) = (1/p)∑_{d∣p} μ(d)k^{p/d}. Unpacking L(p) = N − k, using k ≤ N (from necklaces_key) to justify Nat.cast_sub, and applying the auxiliary N·p = (k^p − k) + k·p, a single linear_combination gives (N − k)·p = k^p − k. This is the combinatorial half of the identity: the aperiodic necklace count, scaled by p, is exactly k^p − k.",
+    "mathContext": "$p\\,L(p) = (N-k)\\,p = k^p - k.$",
+    "significance": "key",
+    "relatedConcepts": ["aperiodic necklace count", "Nat.cast_sub", "linear_combination"],
+    "prerequisites": ["necklaces_key", "casting ℕ subtraction to ℤ"]
+  },
+  {
+    "id": "ann-bc0602-identify",
+    "proofId": "burnside-counting-oq-06-oq-02",
+    "range": { "startLine": 99, "endLine": 106 },
+    "type": "insight",
+    "title": "Identifying the count with the Möbius sum",
+    "content": "aperiodic_eq_mobius_companion is the pairing the open question requested: p·L(p) = ∑_{d∣p} μ(d)·k^{p/d}. It simply chains the two halves — the number-theoretic collapse mobius_companion_prime (Möbius sum = k^p − k) and the combinatorial identity aperiodicNecklaces_mul_prime (p·L(p) = k^p − k) — via linear_combination. The common value k^p − k is the bridge that identifies the combinatorial aperiodic count with the number-theoretic Lyndon-word closed form at prime length.",
+    "mathContext": "$p\\,L(p) = k^p - k = \\sum_{d\\mid p}\\mu(d)k^{p/d}.$",
+    "significance": "key",
+    "relatedConcepts": ["combinatorial vs number-theoretic count", "Lyndon words", "bridge identity"],
+    "prerequisites": ["mobius_companion_prime", "aperiodicNecklaces_mul_prime"]
+  },
+  {
+    "id": "ann-bc0602-fermat",
+    "proofId": "burnside-counting-oq-06-oq-02",
+    "range": { "startLine": 108, "endLine": 127 },
+    "type": "insight",
+    "title": "Fermat's little theorem with L(p) as witness",
+    "content": "The three Fermat theorems read off the identity with the aperiodic necklace count as the explicit witness. fermat_dvd: p ∣ k^p − k over ℤ, exhibiting the quotient directly as L(p) (k^p − k = p·L(p)). fermat_dvd_nat: the ℕ divisibility p ∣ k^p − k, obtained by casting back using k ≤ k^p (Nat.le_self_pow). fermat_modEq: the congruence k^p ≡ k [MOD p], via Nat.modEq_iff_dvd'. The novelty over the parent is that the witness is the honest aperiodic (Lyndon) count L(p), not merely the total necklace count — giving Fermat's theorem a clean combinatorial meaning: p divides k^p − k because k^p − k counts p copies of the aperiodic necklaces.",
+    "mathContext": "$p \\mid k^p - k = p\\,L(p),\\qquad k^p \\equiv k \\pmod p.$",
+    "significance": "key",
+    "relatedConcepts": ["Fermat's little theorem", "divisibility witness", "Nat.modEq_iff_dvd'", "combinatorial proof"],
+    "prerequisites": ["aperiodicNecklaces_mul_prime", "ℕ/ℤ casting", "modular congruence from divisibility"]
+  }
+]

--- a/src/data/proofs/burnside-counting-oq-06-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-06-oq-02/meta.json
@@ -126,7 +126,7 @@
   "crossReferences": [
     {
       "proofId": "burnside-counting-oq-06",
-      "relation": "parent",
+      "relationship": "parent",
       "description": "Parent entry deriving Fermat's little theorem from the totient form of the necklace count; this entry supplies the Möbius/Lyndon companion and shows both specialize to the Fermat congruence at a prime."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-06-oq-02`.

**Gap filled**: the entry had **no annotations.json** (annotations, mathContext, significance, crossRefs all 0). meta.json was already rich (overview, sections, conclusion, references).

**Added**: annotations.json with **7 substantive annotations** (each with `mathContext` LaTeX, `significance`, `relatedConcepts`, `prerequisites`):
- two closed forms / one congruence overview
- Möbius companion collapse at a prime
- the aperiodic (Lyndon) count L(p)=N−k definition
- the N·p=(k^p−k)+k·p auxiliary and k≤N
- p·L(p)=k^p−k
- identification with the Möbius sum
- the three Fermat theorems with L(p) as explicit witness

**Also fixed**: malformed `crossReferences` key `relation` → `relationship` (per the CrossReference type in src/types/proof.ts).

Anchors validated against the 129-line Lean file (no anchor errors). Axiom status unchanged (verified, 0 axioms, no native_decide).