### PR TITLE
research(newton-power-sum-identities-oq-01-oq-03): forward Girard–Waring determinant [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/NewtonPowerSumIdentitiesOQ01OQ03.lean
+++ b/proofs/Proofs/NewtonPowerSumIdentitiesOQ01OQ03.lean
@@ -1,0 +1,136 @@
+import Mathlib
+
+/-
+# The forward Girard–Waring determinant: power sums as determinants in the eₖ
+
+Parent: `newton-power-sum-identities-oq-01` (Newton's identities in low degree).
+
+Newton's identities relate the elementary symmetric polynomials `eₖ = esymm σ R k`
+and the power sums `pₖ = psum σ R k = ∑ᵢ Xᵢᵏ`.  The parent entry records the
+*forward* closed forms `p₁ = e₁`, `p₂ = e₁² − 2e₂`, `p₃ = e₁³ − 3e₁e₂ + 3e₃`, and
+the sibling entry `newton-power-sum-identities-oq-01-oq-02` records the **reverse**
+Toeplitz-determinant form `k!·eₖ = det Tₖ`, a determinant whose entries are the
+power sums.
+
+This entry proves the **dual determinant identity in the other direction**: each
+power sum `pₖ` is *itself* the determinant of a `k × k` lower-Hessenberg matrix
+whose entries are the elementary symmetric polynomials.  This is the classical
+**Girard–Waring determinant** (Wikipedia, *Newton's identities*, “Expressing power
+sums in terms of elementary symmetric polynomials”):
+
+* `p₁ = det [e₁]`                                              (`psum_one_det`)
+* `p₂ = det [[e₁, 1], [2e₂, e₁]]`                              (`psum_two_det`)
+* `p₃ = det [[e₁, 1, 0], [2e₂, e₁, 1], [3e₃, e₂, e₁]]`         (`psum_three_det`)
+
+The matrix `Mₖ` has the scaled elementary symmetric polynomials `1·e₁, 2·e₂, …,
+k·eₖ` down its first column, the `eⱼ` filling the diagonals below the super-diagonal,
+and constant `1`'s on the super-diagonal.  (Contrast the reverse form of
+`oq-01-oq-02`, where the super-diagonal instead carries the increasing integers
+`1, 2, …`; the asymmetry reflects the different coefficients on the two sides of
+the Newton recurrence.)
+
+Unlike a numeric statement these are identities in `MvPolynomial σ R` for **any**
+finite index type `σ` and **any** commutative ring `R`; when `card σ < k` the higher
+`eⱼ` vanish and the determinant degenerates correctly.  Mathlib records neither the
+explicit low-degree forward closed forms nor this determinant shape.
+
+We prove each determinant identity by expanding the small determinant with
+`Matrix.det_fin_one_of` / `Matrix.det_fin_two_of` / `Matrix.det_fin_three` and
+matching against the forward scalar identities, which we first reproduce by
+unrolling Mathlib's recurrence `MvPolynomial.psum_eq_mul_esymm_sub_sum`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+open Finset Matrix
+
+namespace NewtonForwardOQ0103
+
+open MvPolynomial
+
+variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
+
+/-! ## Forward scalar identities (stepping stones)
+
+These reproduce the parent's low-degree forward Newton identities, obtained by
+unrolling Mathlib's recurrence `psum_eq_mul_esymm_sub_sum`.  They are the scalar
+values that the determinants below must reproduce. -/
+
+/-- **Forward, degree 1:** `p₁ = e₁`. -/
+theorem psum_one_eq : psum σ R 1 = esymm σ R 1 := by
+  rw [psum_one, esymm_one]
+
+/-- **Forward, degree 2:** `p₂ = e₁² − 2 e₂`. -/
+theorem psum_two_eq :
+    psum σ R 2 = esymm σ R 1 ^ 2 - 2 * esymm σ R 2 := by
+  rw [psum_eq_mul_esymm_sub_sum σ R 2 (by norm_num)]
+  have hset : {a ∈ Finset.antidiagonal 2 | a.1 ∈ Set.Ioo 0 2} = {(1, 1)} := by
+    ext ⟨i, j⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo, Finset.mem_singleton,
+      Prod.mk.injEq]
+    omega
+  rw [hset, Finset.sum_singleton, psum_one_eq]
+  push_cast
+  ring
+
+/-- **Forward, degree 3:** `p₃ = e₁³ − 3 e₁ e₂ + 3 e₃`. -/
+theorem psum_three_eq :
+    psum σ R 3 =
+      esymm σ R 1 ^ 3 - 3 * esymm σ R 1 * esymm σ R 2 + 3 * esymm σ R 3 := by
+  rw [psum_eq_mul_esymm_sub_sum σ R 3 (by norm_num)]
+  have hset : {a ∈ Finset.antidiagonal 3 | a.1 ∈ Set.Ioo 0 3} = {(1, 2), (2, 1)} := by
+    ext ⟨i, j⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo, Finset.mem_insert,
+      Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  rw [hset, Finset.sum_pair (by decide), psum_two_eq, psum_one_eq]
+  push_cast
+  ring
+
+/-! ## Girard–Waring forward determinant closed form
+
+`pₖ = det Mₖ`, where `Mₖ` is the lower-Hessenberg matrix with the scaled
+elementary symmetric polynomials `1·e₁, 2·e₂, …, k·eₖ` down the first column, the
+`eⱼ` along the diagonals, and constant `1`'s on the super-diagonal. -/
+
+/-- **Determinant form, degree 1:** `p₁ = det [e₁]`. -/
+theorem psum_one_det :
+    psum σ R 1 = (!![esymm σ R 1] : Matrix (Fin 1) (Fin 1) (MvPolynomial σ R)).det := by
+  rw [Matrix.det_fin_one_of, psum_one_eq]
+
+/-- **Determinant form, degree 2:** `p₂ = det [[e₁, 1], [2e₂, e₁]]`. -/
+theorem psum_two_det :
+    psum σ R 2 =
+      (!![esymm σ R 1, 1; 2 * esymm σ R 2, esymm σ R 1] :
+        Matrix (Fin 2) (Fin 2) (MvPolynomial σ R)).det := by
+  rw [Matrix.det_fin_two_of]
+  linear_combination psum_two_eq σ R
+
+/-- **Determinant form, degree 3:**
+`p₃ = det [[e₁, 1, 0], [2e₂, e₁, 1], [3e₃, e₂, e₁]]`. -/
+theorem psum_three_det :
+    psum σ R 3 =
+      (!![esymm σ R 1, 1, 0; 2 * esymm σ R 2, esymm σ R 1, 1;
+            3 * esymm σ R 3, esymm σ R 2, esymm σ R 1] :
+        Matrix (Fin 3) (Fin 3) (MvPolynomial σ R)).det := by
+  rw [Matrix.det_fin_three]
+  simp only [Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.tail_cons, Matrix.head_fin_const, Matrix.cons_val',
+    Matrix.cons_val_fin_one, Matrix.empty_val']
+  linear_combination psum_three_eq σ R
+
+/-! ## Worked example
+
+Over `R = ℤ` with two variables `σ = Fin 2`, the determinant identities specialise
+to the familiar symmetric-function formulas.  For instance with variables `X₀, X₁`
+we have `p₂ = X₀² + X₁² = (X₀+X₁)² − 2 X₀X₁ = e₁² − 2e₂`, which is exactly the
+`2 × 2` determinant below. -/
+
+/-- Sanity check of the degree-2 determinant identity specialised to `Fin 2` over `ℤ`. -/
+example :
+    psum (Fin 2) ℤ 2 =
+      (!![esymm (Fin 2) ℤ 1, 1; 2 * esymm (Fin 2) ℤ 2, esymm (Fin 2) ℤ 1] :
+        Matrix (Fin 2) (Fin 2) (MvPolynomial (Fin 2) ℤ)).det :=
+  psum_two_det (Fin 2) ℤ
+
+end NewtonForwardOQ0103

--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-03/meta.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-03/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "newton-power-sum-identities-oq-01-oq-03",
+  "title": "The Forward Girard–Waring Determinant: Power Sums as Determinants in the eₖ",
+  "slug": "newton-power-sum-identities-oq-01-oq-03",
+  "description": "Newton's identities relate the elementary symmetric polynomials eₖ = esymm σ R k and the power sums pₖ = psum σ R k = ∑ᵢ Xᵢᵏ. The parent entry records the forward scalar closed forms p₁ = e₁, p₂ = e₁² − 2e₂, p₃ = e₁³ − 3e₁e₂ + 3e₃, and the sibling oq-01-oq-02 records the reverse Toeplitz form k!·eₖ = det Tₖ (a determinant in the power sums). This entry proves the dual determinant in the other direction — the classical Girard–Waring form — in which each power sum is itself a determinant in the elementary symmetric polynomials: p₁ = det[e₁], p₂ = det[[e₁,1],[2e₂,e₁]], p₃ = det[[e₁,1,0],[2e₂,e₁,1],[3e₃,e₂,e₁]]. The k×k matrix Mₖ carries the scaled elementary symmetric polynomials 1·e₁,2·e₂,…,k·eₖ down its first column, the eⱼ along the diagonals, and constant 1's on the super-diagonal (contrasting the reverse form of oq-01-oq-02, whose super-diagonal carries the increasing integers 1,2,…). These are identities in MvPolynomial σ R for any finite index type σ and any commutative ring R; Mathlib records neither the low-degree forward closed forms nor this determinant shape. Each determinant identity is proved by expanding with Matrix.det_fin_one_of / det_fin_two_of / det_fin_three and matching against the forward scalar identities, which are first reproduced by unrolling Mathlib's recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum.",
+  "meta": {
+    "author": "Albert Girard (1629) / Edward Waring (1762) / classical theory of symmetric functions; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_identities",
+    "date": "1629",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "symmetric-functions",
+      "newton-identities",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "girard-waring",
+      "determinant",
+      "mvpolynomial",
+      "commutative-ring",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/NewtonPowerSumIdentitiesOQ01OQ03.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+        "description": "The Newton recurrence pₖ = (-1)^{k+1}·k·eₖ - ∑_{0<i<k}(-1)^i·eᵢ·p_{k-i} (for 0 < k); unrolled at k = 2, 3 to reproduce the forward scalar identities that the determinants must match",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.NewtonIdentities"
+      },
+      {
+        "theorem": "MvPolynomial.psum_one / MvPolynomial.esymm_one",
+        "description": "psum σ R 1 = esymm σ R 1 = ∑ᵢ Xᵢ — the degree-1 base identity p₁ = e₁",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "Matrix.det_fin_one_of / Matrix.det_fin_two_of / Matrix.det_fin_three",
+        "description": "Closed-form expansions of the 1×1, 2×2 and 3×3 determinants, used to evaluate the Girard–Waring matrices Mₖ into polynomials in the eⱼ",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Finset.sum_singleton / Finset.sum_pair",
+        "description": "Evaluate the Newton recurrence's finite inner sums over the explicit one- and two-element index sets {(1,1)} and {(1,2),(2,1)}",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.mem_antidiagonal",
+        "description": "Membership in the ℕ-antidiagonal, reducing the inner index set {a ∈ antidiagonal k | 0 < a.1 < k} to a linear-arithmetic condition discharged by omega",
+        "module": "Mathlib.Algebra.Order.Antidiag.Nat"
+      }
+    ],
+    "originalContributions": [
+      "psum_one_det: p₁ = det[e₁] — the degree-1 Girard–Waring determinant",
+      "psum_two_det: p₂ = det[[e₁,1],[2e₂,e₁]] — the degree-2 forward determinant in the elementary symmetric polynomials",
+      "psum_three_det: p₃ = det[[e₁,1,0],[2e₂,e₁,1],[3e₃,e₂,e₁]] — the degree-3 forward determinant; this determinant shape (power sum as a determinant in the eⱼ) is absent from Mathlib and dual to the reverse Toeplitz form of oq-01-oq-02",
+      "psum_one_eq / psum_two_eq / psum_three_eq: self-contained restatement of the forward scalar identities used as the scalar targets for the determinants"
+    ],
+    "dateAdded": "2026-07-02",
+    "lineCount": 136,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). The single use of decide proves the pair inequality (1,2) ≠ (2,1) by kernel reduction, not native_decide, so no Lean.ofReduceBool is introduced. Verified via `lake env lean` against the prebuilt Mathlib olean cache (the Docker build wrapper was unavailable this session).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The determinant expressions for the Newton–Girard relations go back to Albert Girard (1629), who first tabulated the power sums of the roots of a polynomial in terms of its coefficients, and to Edward Waring (1762). They give a uniform, single-formula answer to 'what is pₖ as a function of the eⱼ (or vice versa)?' by packaging the recursive Newton identities as the determinant of a bidiagonal-plus-first-column (lower-Hessenberg) matrix. The two directions are dual: pₖ is a determinant in the eⱼ (this entry), while k!·eₖ is a determinant in the pᵢ (sibling oq-01-oq-02). These determinant forms are the computational shape used to convert between the traces of powers of a matrix and the coefficients of its characteristic polynomial.",
+    "problemStatement": "**Open Question (newton-power-sum-identities-oq-01-oq-03)**: Give a uniform *determinant* closed form for the low-degree power sums pₖ = ∑ᵢ Xᵢᵏ directly in terms of the elementary symmetric polynomials eⱼ (the forward Girard–Waring determinant), complementing the reverse Toeplitz-determinant form k!·eₖ = det Tₖ of sibling oq-01-oq-02.\n\n**Result**: psum_one_det (p₁ = det[e₁]), psum_two_det (p₂ = det[[e₁,1],[2e₂,e₁]]), and psum_three_det (p₃ = det[[e₁,1,0],[2e₂,e₁,1],[3e₃,e₂,e₁]]), identities in MvPolynomial σ R over an arbitrary commutative ring, absent from Mathlib.",
+    "text": "Let σ be a finite index type and R a commutative ring, with eⱼ = MvPolynomial.esymm σ R j and pₖ = MvPolynomial.psum σ R k. Then p₁ = det[e₁], p₂ = det of [[e₁,1],[2e₂,e₁]], and p₃ = det of [[e₁,1,0],[2e₂,e₁,1],[3e₃,e₂,e₁]]. The matrix Mₖ has the scaled polynomials 1·e₁,…,k·eₖ down the first column, the eⱼ on the diagonals, and 1's on the super-diagonal. These hold for every finite σ; when card σ < k the higher eⱼ vanish and the determinant degenerates correctly.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Reproduce the forward scalar identities p₁ = e₁ (psum_one_eq), p₂ = e₁² − 2e₂ (psum_two_eq), p₃ = e₁³ − 3e₁e₂ + 3e₃ (psum_three_eq) by unrolling Mathlib's recurrence psum_eq_mul_esymm_sub_sum over the omega-computed inner index sets {(1,1)} and {(1,2),(2,1)}, closing with push_cast; ring.\n\n2. **Degree 1** (psum_one_det): expand det[e₁] by Matrix.det_fin_one_of to e₁, then rewrite by psum_one_eq.\n\n3. **Degree 2** (psum_two_det): expand the 2×2 determinant by Matrix.det_fin_two_of to e₁·e₁ − 1·(2e₂); the goal is closed by linear_combination psum_two_eq.\n\n4. **Degree 3** (psum_three_det): expand by Matrix.det_fin_three, unfold the !![…] literal with simp (crucially including Matrix.of_apply, so the outer Matrix.of is peeled before the cons/head lemmas fire), and close with linear_combination psum_three_eq.",
+    "keyInsights": [
+      "**Two dual determinants.** The Newton recurrence can be packaged as a determinant in either direction: pₖ = det(matrix in the eⱼ) — this entry — or k!·eₖ = det(matrix in the pᵢ) — the sibling oq-01-oq-02. The forward matrix carries constant 1's on its super-diagonal while the reverse carries the integers 1,2,…; the asymmetry is exactly the asymmetry of the recurrence's coefficients.",
+      "**The super-diagonal 1's, first-column scaling.** In Mₖ the first column holds i·eᵢ (the derivative-like weights coming from the (-1)^{k+1}·k·eₖ term of the recurrence) while every other diagonal is a plain eⱼ — this is what makes the cofactor expansion telescope to the scalar identity.",
+      "**A simp trap in the 3×3 case.** Because !![…] elaborates to Matrix.of ![…], det_fin_three leaves entries of the form (Matrix.of M) i j; Matrix.of_apply must be in the simp set (before the cons/head lemmas) or simp 'makes no progress'. The 1×1 and 2×2 cases avoid this by using the *_of determinant lemmas.",
+      "**Identities over any commutative ring.** Living in MvPolynomial σ R, these are universal symmetric-function identities with no division by k! — the scaling sits inside the matrix, so the determinant form is valid over an arbitrary commutative ring, not just a ℚ-algebra."
+    ],
+    "prerequisites": [
+      "The definitions MvPolynomial.psum and MvPolynomial.esymm (Symmetric/Defs.lean)",
+      "The Newton recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum (Symmetric/NewtonIdentities.lean)",
+      "The small-determinant lemmas Matrix.det_fin_one_of, det_fin_two_of, det_fin_three and the !![…] matrix notation"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring stating the two dual determinant forms, the shape of the forward Girard–Waring matrix Mₖ (scaled eᵢ in the first column, eⱼ on the diagonals, 1's on the super-diagonal), and validity for any finite σ over any commutative ring. Mathlib import, open Finset Matrix / open MvPolynomial, namespace, and variables (σ finite, R a commutative ring).",
+      "mathContext": "$p_k = \\det M_k$, with $M_k$ lower-Hessenberg in the $e_j$."
+    },
+    {
+      "id": "scalar",
+      "title": "Forward scalar identities (stepping stones)",
+      "startLine": 53,
+      "endLine": 88,
+      "summary": "psum_one_eq (p₁ = e₁), psum_two_eq (p₂ = e₁² − 2e₂), psum_three_eq (p₃ = e₁³ − 3e₁e₂ + 3e₃): the parent's forward Newton identities, reproduced by unrolling the Mathlib recurrence over omega-computed inner index sets and closing with push_cast; ring. These are the scalar values the determinants must match.",
+      "mathContext": "$p_1=e_1,\\; p_2=e_1^2-2e_2,\\; p_3=e_1^3-3e_1e_2+3e_3$."
+    },
+    {
+      "id": "determinants",
+      "title": "Girard–Waring forward determinants",
+      "startLine": 90,
+      "endLine": 121,
+      "summary": "psum_one_det, psum_two_det, psum_three_det: each power sum expressed as the determinant of the lower-Hessenberg matrix in the eⱼ, proved by det_fin_one_of / det_fin_two_of / det_fin_three (with Matrix.of_apply in the 3×3 simp set) and linear_combination against the scalar identities.",
+      "mathContext": "$p_3=\\det\\begin{pmatrix} e_1&1&0\\\\ 2e_2&e_1&1\\\\ 3e_3&e_2&e_1\\end{pmatrix}$."
+    },
+    {
+      "id": "example",
+      "title": "Worked example",
+      "startLine": 122,
+      "endLine": 136,
+      "summary": "Specialisation of the degree-2 determinant identity to σ = Fin 2 over ℤ, recovering p₂ = X₀² + X₁² = e₁² − 2e₂ as a 2×2 determinant.",
+      "mathContext": "Over $\\mathbb{Z}$ with two variables, $p_2 = e_1^2 - 2e_2$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "newton-power-sum-identities-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry recording the forward scalar low-degree Newton identities p₁ = e₁, p₂ = e₁² − 2e₂, p₃ = e₁³ − 3e₁e₂ + 3e₃, which this entry packages as determinants."
+    },
+    {
+      "targetId": "newton-power-sum-identities-oq-01-oq-02",
+      "relationship": "dual",
+      "description": "Sibling entry proving the reverse Toeplitz-determinant form k!·eₖ = det Tₖ (each elementary symmetric polynomial as a determinant in the power sums). This entry proves the dual forward determinant pₖ = det Mₖ (each power sum as a determinant in the elementary symmetric polynomials)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) derivation of the forward Girard–Waring determinant identities p₁ = det[e₁], p₂ = det[[e₁,1],[2e₂,e₁]], p₃ = det[[e₁,1,0],[2e₂,e₁,1],[3e₃,e₂,e₁]] as universal identities in MvPolynomial σ R, packaging the low-degree Newton power sums as determinants in the elementary symmetric polynomials.",
+    "implications": "Supplies the determinant closed form for the forward direction of Newton's identities, dual to the reverse Toeplitz form of oq-01-oq-02, giving a uniform single-formula answer for pₖ in terms of the eⱼ over an arbitrary commutative ring — the shape used to convert between traces of matrix powers and characteristic-polynomial coefficients.",
+    "openQuestions": [
+      "Prove the general n×n Girard–Waring determinant pₙ = det Mₙ for all n by induction, matching Mathlib's recurrence to the cofactor expansion along the last row (this needs a general lower-Hessenberg determinant recurrence not yet in Mathlib).",
+      "Establish the mutual-inverse relationship between the forward matrix Mₖ (in the eⱼ) and the reverse Toeplitz matrix Tₖ (in the pᵢ) as a single statement over a ℚ-algebra, exhibiting the two determinant families as inverse changes of basis on the ring of symmetric functions."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Matrix",
+      "MvPolynomial"
+    ],
+    "namespace": "NewtonForwardOQ0103",
+    "lineCount": 136,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/NewtonPowerSumIdentitiesOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Girard, Albert",
+      "title": "Invention nouvelle en l'algèbre",
+      "year": "1629",
+      "venue": "Amsterdam",
+      "note": "Early tabulation of power sums of polynomial roots in terms of the coefficients"
+    },
+    {
+      "authors": "Waring, Edward",
+      "title": "Miscellanea Analytica de Aequationibus Algebraicis et Curvarum Proprietatibus",
+      "year": "1762",
+      "venue": "",
+      "note": "Classical source for the Waring formula expressing power sums via elementary symmetric functions"
+    },
+    {
+      "authors": "Mead, D. G.",
+      "title": "Newton's Identities",
+      "year": "1992",
+      "venue": "The American Mathematical Monthly 99(8), 749–751",
+      "note": "Modern exposition including the determinant (Hessenberg) forms of the Newton–Girard relations"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **newton-power-sum-identities-oq-01-oq-03**: the **forward Girard–Waring determinant** expressing each low-degree power sum as a determinant in the elementary symmetric polynomials — the dual of sibling `oq-01-oq-02`'s reverse Toeplitz form (`k!·eₖ = det Tₖ` in the power sums).

$$p_1 = \det[e_1],\quad p_2 = \det\begin{pmatrix}e_1&1\\ 2e_2&e_1\end{pmatrix},\quad p_3 = \det\begin{pmatrix}e_1&1&0\\ 2e_2&e_1&1\\ 3e_3&e_2&e_1\end{pmatrix}$$

The `k×k` lower-Hessenberg matrix `Mₖ` carries the scaled polynomials `1·e₁,…,k·eₖ` down the first column, the `eⱼ` on the diagonals, and constant `1`'s on the super-diagonal. These are identities in `MvPolynomial σ R` over an **arbitrary commutative ring** (no division by `k!`); the determinant shape is absent from Mathlib.

## Contributions
- `psum_one_det`, `psum_two_det`, `psum_three_det` — the forward determinants
- `psum_one_eq`, `psum_two_eq`, `psum_three_eq` — the forward scalar Newton identities (reproduced from Mathlib's `psum_eq_mul_esymm_sub_sum`), used as the scalar targets

Proved by expanding with `Matrix.det_fin_one_of` / `det_fin_two_of` / `det_fin_three` (with `Matrix.of_apply` in the 3×3 simp set) and closing via `linear_combination` against the scalar identities.

## Relation to existing work
- **Parent** `newton-power-sum-identities-oq-01` — forward scalar identities (packaged here as determinants)
- **Dual sibling** `newton-power-sum-identities-oq-01-oq-02` (PR #32851) — reverse Toeplitz determinant `k!·eₖ = det Tₖ`

Together they exhibit both directions of Newton's identities in determinant form. This directly answers the parent's open question requesting a uniform determinant closed form.

## Verification
- 6 theorems, 0 definitions, 136 lines, `import Mathlib` only
- **Verified via `lake env lean`** against the prebuilt Mathlib olean cache (the Docker build wrapper was unavailable this session due to a host containerd/disk issue). Single bounded elaboration (~15s), not `lake build`.
- `#print axioms` on all three determinant theorems reports only `propext, Classical.choice, Quot.sound` — **0 counted axioms, 0 sorries**. The one `decide` (proving `(1,2) ≠ (2,1)`) uses kernel reduction, not `native_decide`, so no `Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)