### PR TITLE
Fix: sync stale leanFile.lineCount across 93 gallery entries

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/meta.json
@@ -57,7 +57,7 @@
   },
   "leanFile": {
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01OQ01.lean",
-    "lineCount": 197,
+    "lineCount": 192,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 2,

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json
@@ -5,7 +5,7 @@
   "description": "Proves the general Newton-Girard recurrence for every k ≥ 1, relating power sums pₖ = Σ_{i∈s} (f i)^k and elementary symmetric functions eₖ = Σ_{T⊆s,|T|=k} ∏_{i∈T} f i for an arbitrary finite family f : ι → R indexed by a Finset s over any commutative ring R: Σ_{j=0}^{k-1} (-1)^j eⱼ p_{k-j} + (-1)^k k eₖ = 0. Mathlib provides Newton's identities only in the universal MvPolynomial form; this entry transports that universal identity to the directly usable Finset/CommRing layer via the algebra map aeval, closing the parent entry's open question for arbitrary k. 4 theorems, 2 definitions, 0 axioms.",
   "leanFile": {
     "namespace": "AmgmNewtonGirard",
-    "lineCount": 127,
+    "lineCount": 129,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 2,

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -139,7 +139,7 @@
       "AmgmInequalityOQ02"
     ],
     "namespace": "AmgmInequalityOQ02OQ03",
-    "lineCount": 226,
+    "lineCount": 238,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1,

--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -145,7 +145,7 @@
       "Real"
     ],
     "namespace": "AmgmInequalityOQ04OQ05",
-    "lineCount": 242,
+    "lineCount": 243,
     "axiomCount": 7,
     "theoremCount": 8,
     "definitionCount": 6,

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
@@ -55,7 +55,7 @@
       "Proofs.AngleTrisectionCos20GalOQ01OQ02"
     ],
     "namespace": "AngleTrisectionCos20GalOQ01OQ02OQ02",
-    "lineCount": 385,
+    "lineCount": 387,
     "axiomCount": 0,
     "theoremCount": 22,
     "definitionCount": 0,

--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-01/meta.json
@@ -197,7 +197,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 712,
+    "lineCount": 724,
     "path": "Proofs/AreaOfCircleOQ01OQ03OQ01.lean",
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -13,7 +13,7 @@
       "Finset"
     ],
     "namespace": "AreaOfCircleOQ07OQ04OQ01OQ01OQ02",
-    "lineCount": 112,
+    "lineCount": 114,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 0,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -105,7 +105,7 @@
       "BigOperators"
     ],
     "namespace": "qBinomialTheoremProof",
-    "lineCount": 224,
+    "lineCount": 222,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ01.lean",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
@@ -165,7 +165,7 @@
       "ArithmeticSeriesOQ02"
     ],
     "namespace": "ArithmeticSeriesOQ02OQ04",
-    "lineCount": 158,
+    "lineCount": 156,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 0,

--- a/src/data/proofs/automorphic-number-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01-oq-01/meta.json
@@ -89,7 +89,7 @@
       "Finset"
     ],
     "namespace": "AutomorphicNumberOQ01OQ01OQ01",
-    "lineCount": 249,
+    "lineCount": 251,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 1,

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-02/meta.json
@@ -157,7 +157,7 @@
       "BezoutCRTKFold"
     ],
     "namespace": "BezoutCRTCard",
-    "lineCount": 148,
+    "lineCount": 149,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
@@ -298,7 +298,7 @@
       "Topology"
     ],
     "namespace": "BorsukUlamTucker2D",
-    "lineCount": 2633,
+    "lineCount": 2640,
     "axiomCount": 1,
     "theoremCount": 123,
     "definitionCount": 36,

--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -133,7 +133,7 @@
       "Filter"
     ],
     "namespace": "BuffonCrossingAsymptotic",
-    "lineCount": 347,
+    "lineCount": 350,
     "axiomCount": 0,
     "theoremCount": 20,
     "definitionCount": 3,

--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -217,7 +217,7 @@
       "Topology"
     ],
     "namespace": "BuffonsNeedle",
-    "lineCount": 266,
+    "lineCount": 254,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 3,

--- a/src/data/proofs/buffons-noodle/meta.json
+++ b/src/data/proofs/buffons-noodle/meta.json
@@ -181,7 +181,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 456,
+    "lineCount": 452,
     "namespace": "BuffonsNoodle",
     "opens": [
       "Real",

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -101,7 +101,7 @@
       "Mathlib.SetTheory.Cardinal.Cofinality"
     ],
     "namespace": "EastonSpectrum",
-    "lineCount": 206,
+    "lineCount": 207,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 1,

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/meta.json
@@ -65,7 +65,7 @@
       "CauchyInterlacing.Assembly"
     ],
     "namespace": "CauchyInterlacingOQ01OQ01OQ02",
-    "lineCount": 292,
+    "lineCount": 294,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 2,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -5,7 +5,7 @@
   "description": "Sigma-finite Lp Riesz representation theorem formalized in Lean 4: all three steps (A localization, B Lp truncation convergence, C density extension) with 0 sorries in this file. Step A (localization_existence, ~600 lines) was completed in PR #15581 via the Hölder extremizer construction; Step B uses Vitali's convergence theorem; Step C uses Lp.induction. NOTE (2026-06-24, #28788): this file transitively fails to compile against the pinned v4.26.0 toolchain because its imported foundation has 53 Mathlib-drift errors; status downgraded to formalized until the chain builds green.",
   "leanFile": {
     "namespace": "RieszSigmaFiniteComplete",
-    "lineCount": 952,
+    "lineCount": 1012,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 2,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -135,7 +135,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 208,
+    "lineCount": 213,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
@@ -88,7 +88,7 @@
       "Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ03"
     ],
     "namespace": "CyclicVectorOperator",
-    "lineCount": 310,
+    "lineCount": 312,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 2,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -197,7 +197,7 @@
       "Polynomial"
     ],
     "namespace": "NonderogatoryModule",
-    "lineCount": 345,
+    "lineCount": 350,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 6,

--- a/src/data/proofs/chebyshev-bounds-oq-03-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-03-oq-02/meta.json
@@ -145,7 +145,7 @@
       "Topology"
     ],
     "namespace": "ChebyshevBoundsOQ03OQ02",
-    "lineCount": 157,
+    "lineCount": 158,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json
@@ -14,7 +14,7 @@
       "BigOperators"
     ],
     "namespace": "ChebyshevBoundsOQ04OQ01",
-    "lineCount": 375,
+    "lineCount": 381,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 4,

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-04/meta.json
@@ -150,7 +150,7 @@
       "ArithmeticFunction"
     ],
     "namespace": "ChebyshevPNTBridgeOQ04",
-    "lineCount": 246,
+    "lineCount": 250,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 3,

--- a/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/meta.json
@@ -10,7 +10,7 @@
       "Metric"
     ],
     "namespace": "CompactnessFiniteSubcoverOq02Oq02",
-    "lineCount": 203,
+    "lineCount": 206,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 2,

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -165,7 +165,7 @@
       "Cardinal"
     ],
     "namespace": "ContinuumHypothesis",
-    "lineCount": 395,
+    "lineCount": 396,
     "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 12,

--- a/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
@@ -50,7 +50,7 @@
     "imports": ["Mathlib"],
     "opens": ["Polynomial", "Polynomial.Chebyshev"],
     "namespace": "DeMoivreOQ02OQ02OQ01",
-    "lineCount": 141,
+    "lineCount": 146,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,

--- a/src/data/proofs/de-moivre-oq-05-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02/meta.json
@@ -147,7 +147,7 @@
       "ArithmeticFunction.Moebius"
     ],
     "namespace": "DeMoivreOQ05OQ02",
-    "lineCount": 124,
+    "lineCount": 125,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 0,

--- a/src/data/proofs/derangements-convergence-oq-03-oq-03/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-03/meta.json
@@ -175,7 +175,7 @@
       "Topology"
     ],
     "namespace": "DerangementsConvergenceOQ03OQ03",
-    "lineCount": 177,
+    "lineCount": 175,
     "axiomCount": 0,
     "theoremCount": 7,
     "substantiveTheoremCount": 4,

--- a/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
@@ -166,7 +166,7 @@
       "Polynomial"
     ],
     "namespace": "DescartesRuleOQ01",
-    "lineCount": 1094,
+    "lineCount": 1099,
     "axiomCount": 0,
     "theoremCount": 49,
     "definitionCount": 1,

--- a/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-02/meta.json
@@ -143,7 +143,7 @@
       "Set"
     ],
     "namespace": "DilworthTheoremOQ01",
-    "lineCount": 121,
+    "lineCount": 122,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1000-oq-03-oq-02/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-02/meta.json
@@ -98,7 +98,7 @@
       "Finset"
     ],
     "namespace": "Erdos1000OQ03OQ02",
-    "lineCount": 246,
+    "lineCount": 248,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 1,

--- a/src/data/proofs/erdos-1001-oq-02/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02/meta.json
@@ -190,7 +190,7 @@
       "Mathlib.NumberTheory.ArithmeticFunction"
     ],
     "namespace": "Erdos1001OQ02",
-    "lineCount": 315,
+    "lineCount": 308,
     "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-1001/meta.json
+++ b/src/data/proofs/erdos-1001/meta.json
@@ -235,7 +235,7 @@
       "Real"
     ],
     "namespace": "Erdos1001",
-    "lineCount": 249,
+    "lineCount": 242,
     "axiomCount": 2,
     "theoremCount": 10,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-1002/meta.json
+++ b/src/data/proofs/erdos-1002/meta.json
@@ -241,7 +241,7 @@
       "Int"
     ],
     "namespace": "Erdos1002",
-    "lineCount": 189,
+    "lineCount": 183,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-1011/meta.json
+++ b/src/data/proofs/erdos-1011/meta.json
@@ -221,7 +221,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 168,
+    "lineCount": 179,
     "axiomCount": 5,
     "theoremCount": 0,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-1012-oq-02/meta.json
+++ b/src/data/proofs/erdos-1012-oq-02/meta.json
@@ -61,7 +61,7 @@
   },
   "leanFile": {
     "namespace": "Erdos1012OQ02",
-    "lineCount": 389,
+    "lineCount": 391,
     "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -157,7 +157,7 @@
       "Proofs.Erdos1018OQ04"
     ],
     "namespace": "Erdos1018OQ04Completion",
-    "lineCount": 737,
+    "lineCount": 738,
     "axiomCount": 1,
     "theoremCount": 11,
     "path": "Proofs/Erdos1018OQ04Incomplete01.lean",

--- a/src/data/proofs/erdos-1040-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1040-oq-03-oq-01/meta.json
@@ -132,7 +132,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos1040OQ03OQ01",
-    "lineCount": 137,
+    "lineCount": 138,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-1042-oq-03/meta.json
+++ b/src/data/proofs/erdos-1042-oq-03/meta.json
@@ -132,7 +132,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos1042OQ03",
-    "lineCount": 113,
+    "lineCount": 114,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-105/meta.json
+++ b/src/data/proofs/erdos-105/meta.json
@@ -254,7 +254,7 @@
       "Finset"
     ],
     "namespace": "Erdos105",
-    "lineCount": 305,
+    "lineCount": 306,
     "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 19,

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -105,7 +105,7 @@
       "Finset"
     ],
     "namespace": "Erdos1090",
-    "lineCount": 513,
+    "lineCount": 614,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 17,

--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -229,7 +229,7 @@
       "Real"
     ],
     "namespace": "Erdos1179",
-    "lineCount": 316,
+    "lineCount": 318,
     "axiomCount": 3,
     "theoremCount": 10,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-307-oq-02/meta.json
+++ b/src/data/proofs/erdos-307-oq-02/meta.json
@@ -116,7 +116,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos307OQ02",
-    "lineCount": 298,
+    "lineCount": 296,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-31-primes-density/meta.json
+++ b/src/data/proofs/erdos-31-primes-density/meta.json
@@ -131,7 +131,7 @@
   ],
   "leanFile": {
     "path": "Proofs/Erdos31PrimesDensity.lean",
-    "lineCount": 234,
+    "lineCount": 239,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 5,

--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -125,7 +125,7 @@
   ],
   "leanFile": {
     "namespace": "Erdos476OQ05",
-    "lineCount": 885,
+    "lineCount": 890,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 1,

--- a/src/data/proofs/erdos-482/meta.json
+++ b/src/data/proofs/erdos-482/meta.json
@@ -131,7 +131,7 @@
       "Int"
     ],
     "namespace": "Erdos482",
-    "lineCount": 128,
+    "lineCount": 124,
     "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-606-oq-03-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03-oq-03/meta.json
@@ -155,7 +155,7 @@
       "Finset"
     ],
     "namespace": "SylvesterGallai",
-    "lineCount": 508,
+    "lineCount": 516,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-606-oq-03-wip-01/meta.json
+++ b/src/data/proofs/erdos-606-oq-03-wip-01/meta.json
@@ -136,7 +136,7 @@
       "Finset"
     ],
     "namespace": "Erdos606OQ03WIP01",
-    "lineCount": 114,
+    "lineCount": 117,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -180,7 +180,7 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 421,
+    "lineCount": 424,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-798/meta.json
+++ b/src/data/proofs/erdos-798/meta.json
@@ -186,7 +186,7 @@
       "Asymptotics"
     ],
     "namespace": "Erdos798",
-    "lineCount": 345,
+    "lineCount": 353,
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-8-oq-02/meta.json
+++ b/src/data/proofs/erdos-8-oq-02/meta.json
@@ -93,7 +93,7 @@
   },
   "leanFile": {
     "namespace": "Erdos8OQ02",
-    "lineCount": 296,
+    "lineCount": 299,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
+++ b/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
@@ -166,7 +166,7 @@
       "EuclideanGeometry"
     ],
     "namespace": "ErdosMordellOQ01",
-    "lineCount": 399,
+    "lineCount": 405,
     "axiomCount": 0,
     "theoremCount": 12,
     "substantiveTheoremCount": 6,

--- a/src/data/proofs/euler-identity-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-02-oq-01/meta.json
@@ -143,7 +143,7 @@
       "NormedSpace"
     ],
     "namespace": "EulerIdentityOQ01OQ02OQ01",
-    "lineCount": 128,
+    "lineCount": 130,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 2,

--- a/src/data/proofs/euler-identity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-02/meta.json
@@ -132,7 +132,7 @@
       "Complex"
     ],
     "namespace": "EulerIdentityOQ01OQ02",
-    "lineCount": 77,
+    "lineCount": 75,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/euler-totient-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01/meta.json
@@ -168,7 +168,7 @@
   ],
   "leanFile": {
     "namespace": "CarmichaelFunction",
-    "lineCount": 83,
+    "lineCount": 87,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,

--- a/src/data/proofs/fatou-lemma-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fatou-lemma-oq-01-oq-01/meta.json
@@ -15,7 +15,7 @@
       "Topology"
     ],
     "namespace": "FatouLemmaOQ01OQ01",
-    "lineCount": 177,
+    "lineCount": 180,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -286,7 +286,7 @@
     ],
     "opens": [],
     "namespace": "FermatsLastTheorem",
-    "lineCount": 201,
+    "lineCount": 202,
     "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/frobenius-number-oq-01-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01-oq-01/meta.json
@@ -164,7 +164,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "FrobeniusMultiGenerator",
-    "lineCount": 178,
+    "lineCount": 179,
     "theoremCount": 6,
     "axiomCount": 0,
     "definitionCount": 0,

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -215,7 +215,7 @@
       "Complex"
     ],
     "namespace": "GeneralQuartic",
-    "lineCount": 814,
+    "lineCount": 816,
     "axiomCount": 0,
     "theoremCount": 24,
     "definitionCount": 5,

--- a/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/meta.json
@@ -146,7 +146,7 @@
       "Topology"
     ],
     "namespace": "GeometricSeriesOQ01OQ01OQ02",
-    "lineCount": 107,
+    "lineCount": 101,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -13,7 +13,7 @@
       "InnerProductSpace"
     ],
     "namespace": "GramLinearIndependenceOQ01OQ01OQ02OQ01",
-    "lineCount": 124,
+    "lineCount": 130,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1,

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -77,7 +77,7 @@
       "Topology"
     ],
     "namespace": "GreensTheoremOQ01OQ01OQ01OQ01",
-    "lineCount": 537,
+    "lineCount": 538,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/greens-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02-oq-04/meta.json
@@ -173,7 +173,7 @@
       "GreensTheoremOQ02",
       "GeneralizedStokes"
     ],
-    "lineCount": 259,
+    "lineCount": 267,
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 9,

--- a/src/data/proofs/hilbert-14/meta.json
+++ b/src/data/proofs/hilbert-14/meta.json
@@ -135,7 +135,7 @@
     ],
     "opens": [],
     "namespace": "Hilbert14Invariants",
-    "lineCount": 364,
+    "lineCount": 368,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 2,

--- a/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
@@ -176,7 +176,7 @@
   "leanFile": {
     "path": "Proofs/Hilbert15OQ02OQ03.lean",
     "axiomCount": 3,
-    "lineCount": 249,
+    "lineCount": 256,
     "theoremCount": 8,
     "definitionCount": 5,
     "sorries": 0,

--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -139,7 +139,7 @@
     ],
     "opens": [],
     "namespace": "LRComplexity",
-    "lineCount": 533,
+    "lineCount": 537,
     "axiomCount": 0,
     "theoremCount": 27,
     "definitionCount": 6,

--- a/src/data/proofs/infinitude-primes-4k1/meta.json
+++ b/src/data/proofs/infinitude-primes-4k1/meta.json
@@ -60,7 +60,7 @@
   },
   "leanFile": {
     "namespace": "InfinitudePrimes4k1",
-    "lineCount": 177,
+    "lineCount": 181,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/infinitude-primes-4k3-oq-02/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-02/meta.json
@@ -248,7 +248,7 @@
   ],
   "leanFile": {
     "namespace": "InfinitudePrimes4k3OQ02",
-    "lineCount": 264,
+    "lineCount": 273,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/intermediate-value-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-01-oq-01/meta.json
@@ -187,7 +187,7 @@
       "Real"
     ],
     "namespace": "BisectionMethod",
-    "lineCount": 153,
+    "lineCount": 155,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/isoperimetric-theorem-oq-02/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-02/meta.json
@@ -163,7 +163,7 @@
     ],
     "opens": [],
     "namespace": "DiscreteIsoperimetric1D",
-    "lineCount": 136,
+    "lineCount": 138,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 1,

--- a/src/data/proofs/isoperimetric-theorem-oq-03/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-03/meta.json
@@ -178,7 +178,7 @@
       "Finset"
     ],
     "namespace": "IsoperimetricCycle",
-    "lineCount": 210,
+    "lineCount": 212,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 3,

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-04/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-04/meta.json
@@ -7,7 +7,7 @@
     ],
     "opens": [],
     "namespace": "LagrangeFourSquaresWaringG2OQ03OQ04",
-    "lineCount": 155,
+    "lineCount": 156,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 2,

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
@@ -61,7 +61,7 @@
       "Fintype"
     ],
     "namespace": "LagrangeOQ01OQ03",
-    "lineCount": 211,
+    "lineCount": 217,
     "axiomCount": 2,
     "sorries": 0,
     "definitionCount": 2,

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01/meta.json
@@ -169,7 +169,7 @@
       "Finset",
       "BigOperators"
     ],
-    "lineCount": 226,
+    "lineCount": 230,
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 6,

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -132,7 +132,7 @@
     "opens": [
       "MulAction"
     ],
-    "lineCount": 101,
+    "lineCount": 109,
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 2,

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01/meta.json
@@ -37,7 +37,7 @@
     "path": "Proofs/LawOfCosinesOQ01OQ01.lean",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 334,
+    "lineCount": 337,
     "theoremCount": 22,
     "definitionCount": 3
   },

--- a/src/data/proofs/lhopital-oq-04-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-04-oq-01/meta.json
@@ -138,7 +138,7 @@
       "Nat"
     ],
     "namespace": "LHopitalOQ04OQ01",
-    "lineCount": 200,
+    "lineCount": 201,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/minkowski-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-02/meta.json
@@ -164,7 +164,7 @@
     "namespace": "BlichfeldtTheorem",
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 206,
+    "lineCount": 211,
     "theoremCount": 8,
     "definitionCount": 0,
     "mainTheorems": [

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -253,7 +253,7 @@
       "Mathlib.Data.List.Sort"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 1260,
+    "lineCount": 1429,
     "axiomCount": 0,
     "theoremCount": 66,
     "definitionCount": 11,

--- a/src/data/proofs/quadratic-gauss-sum-square/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square/meta.json
@@ -76,7 +76,7 @@
   "leanFile": {
     "path": "Proofs/QuadraticGaussSumSquare.lean",
     "axiomCount": 0,
-    "lineCount": 75,
+    "lineCount": 77,
     "theoremCount": 4,
     "definitionCount": 1,
     "sorries": 0

--- a/src/data/proofs/randomized-maxcut/meta.json
+++ b/src/data/proofs/randomized-maxcut/meta.json
@@ -208,7 +208,7 @@
     ],
     "opens": [],
     "namespace": "Cut",
-    "lineCount": 324,
+    "lineCount": 326,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 7,

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -247,7 +247,7 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 729,
+    "lineCount": 796,
     "axiomCount": 0,
     "theoremCount": 50,
     "definitionCount": 12,

--- a/src/data/proofs/shannon-channel-coding-bec-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-01/meta.json
@@ -180,7 +180,7 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 276,
+    "lineCount": 277,
     "path": "Proofs/ShannonChannelCodingBECOQ01.lean",
     "sorries": 0,
     "definitionCount": 2,

--- a/src/data/proofs/shannon-channel-coding-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02/meta.json
@@ -177,7 +177,7 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 294,
+    "lineCount": 298,
     "path": "Proofs/ShannonChannelCodingOQ02.lean",
     "sorries": 0,
     "definitionCount": 1,

--- a/src/data/proofs/shannon-entropy-oq-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01-oq-01/meta.json
@@ -124,7 +124,7 @@
   ],
   "leanFile": {
     "namespace": "DifferentialEntropy",
-    "lineCount": 88,
+    "lineCount": 89,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 1,

--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
@@ -146,7 +146,7 @@
       "Finset"
     ],
     "namespace": "InformationTheory",
-    "lineCount": 443,
+    "lineCount": 448,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01/meta.json
@@ -156,7 +156,7 @@
       "Polynomial"
     ],
     "namespace": "SpectralTraceDetEigenvaluesOQ01",
-    "lineCount": 126,
+    "lineCount": 132,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 1,

--- a/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
@@ -154,7 +154,7 @@
       "Finset"
     ],
     "namespace": "SumOfKthPowersOQ03",
-    "lineCount": 155,
+    "lineCount": 158,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 1,

--- a/src/data/proofs/sum-of-kth-powers-oq-05/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-05/meta.json
@@ -144,7 +144,7 @@
       "Finset"
     ],
     "namespace": "SumOfKthPowersOQ05",
-    "lineCount": 109,
+    "lineCount": 110,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/sylvester-sequence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sylvester-sequence-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "imports": ["Mathlib", "Proofs.SylvesterSequenceOQ01"],
     "opens": ["SylvesterSequenceOQ01", "Filter", "Topology"],
     "namespace": "SylvesterSequenceOQ01OQ01",
-    "lineCount": 127,
+    "lineCount": 123,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 5,

--- a/src/data/proofs/thue-morse-oq-01/meta.json
+++ b/src/data/proofs/thue-morse-oq-01/meta.json
@@ -12,7 +12,7 @@
       "BigOperators"
     ],
     "namespace": "ThueMorse",
-    "lineCount": 144,
+    "lineCount": 146,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 1,

--- a/src/data/proofs/unit-distance-independence/meta.json
+++ b/src/data/proofs/unit-distance-independence/meta.json
@@ -75,7 +75,7 @@
   },
   "leanFile": {
     "namespace": "UnitDistanceIndependence",
-    "lineCount": 948,
+    "lineCount": 959,
     "axiomCount": 1,
     "theoremCount": 66,
     "definitionCount": 12,


### PR DESCRIPTION
## Fix

Metadata integrity sweep: `leanFile.lineCount` had drifted from the actual Lean source in 93 gallery entries. The gallery convention is `lineCount = file newline count` (`wc -l`); these entries went stale after their `.lean` files were edited following the metadata write.

## Evidence

**Before**: 93 entries reported a `leanFile.lineCount` matching neither the newline count nor the split-line count of the source file. Several drifts were substantial:
- `erdos-1090`: 513 → 614
- `puiseux-theorem-oq-03`: 1260 → 1429
- `schroeder-bernstein-oq-03`: 729 → 796
- `cauchy-schwarz-integral-...-incomplete-01`: 952 → 1012
- `buffons-needle`: 266 → 254

**After**: Every changed `leanFile.lineCount` matches the source file's newline count. Re-scan reports 0 lineCount drift, 0 under-reported sorries, 0 under-reported axioms.

A guarded regex updated only the `leanFile.lineCount` value; no other fields were touched (93 files, +93/−93). The lone entry with a top-level `lineCount` (`isoperimetric-theorem-oq-01-oq-01`) was left untouched to avoid conflating it with a possible aggregate semantic.

---
Automated fix by lean-mechanic agent.