### PR TITLE
Enrich Newton's Generalized Binomial / Negative Binomial Theorem (stars-and-bars-weak-compositions-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-sbnb-upper-negation",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-02",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "concept",
+    "title": "Upper negation with the sign as (−1)ⁿ",
+    "content": "ringChoose_neg_eq is the algebraic heart of the file: over any commutative binomial ring, Ring.choose (−r) n = (−1)ⁿ · Ring.choose (r+n−1) n. Mathlib's own Ring.choose_neg states this but carries the alternating sign as the group unit Int.negOnePow n ∈ ℤˣ — mathematically clean but awkward for ring arithmetic and norm_num. The proof discharges that unit to the plain ring element (−1)ⁿ by Units.smul_def, Int.coe_negOnePow_natCast, and zsmul_eq_mul, then finishes with push_cast; ring. This restores the textbook upper-negation identity in a form that composes with everything downstream. Newton's generalized binomial coefficient C(r,n) = r(r−1)⋯(r−n+1)/n! extends Nat.choose to arbitrary (in particular negative) upper index.",
+    "mathContext": "$\\binom{-r}{n} = (-1)^n \\binom{r+n-1}{n}$ over any binomial ring.",
+    "significance": "key",
+    "relatedConcepts": ["generalized binomial coefficient", "Ring.choose", "upper negation identity", "binomial ring", "Int.negOnePow"],
+    "prerequisites": ["Newton's generalized binomial coefficient", "units of ℤ and the smul action", "binomial rings"]
+  },
+  {
+    "id": "ann-sbnb-cast",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-02",
+    "range": { "startLine": 84, "endLine": 91 },
+    "type": "technique",
+    "title": "The upper index is a natural number when k ≥ 1",
+    "content": "cast_add_sub_one is the natural-number bookkeeping that lets the generalized identity land on the ordinary Nat.choose. The generalized coefficient C(−k, n) has an integer upper index, but the classical right-hand side C(n+k−1, n) needs a natural-number one. For k ≥ 1 the integer (k:ℤ)+n−1 is exactly the cast of the natural number n+k−1, proved by Nat.cast_sub after checking 1 ≤ n+k with omega. This hypothesis k ≥ 1 is only needed here on the ℤ side; the general upper-negation lemma ringChoose_neg_eq needs no positivity at all.",
+    "mathContext": "$(k:\\mathbb{Z}) + n - 1 = \\uparrow(n+k-1)\\quad\\text{for } k \\ge 1.$",
+    "significance": "technical",
+    "relatedConcepts": ["Nat.cast_sub", "ℕ/ℤ coercion", "omega", "natural subtraction"],
+    "prerequisites": ["casting subtraction between ℕ and ℤ"]
+  },
+  {
+    "id": "ann-sbnb-neg-natcast",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-02",
+    "range": { "startLine": 93, "endLine": 98 },
+    "type": "technique",
+    "title": "Specializing to integer upper index −k",
+    "content": "ringChoose_neg_natCast combines the general upper negation with the cast helper and Mathlib's Ring.choose_natCast (which says the generalized coefficient at a natural upper index is the ordinary Nat.choose). The result is Ring.choose (−k) n = (−1)ⁿ · C(n+k−1, n) over ℤ for k ≥ 1 — the generalized binomial coefficient at negative integer upper index expressed via an ordinary binomial coefficient.",
+    "mathContext": "$\\binom{-k}{n} = (-1)^n \\binom{n+k-1}{n}\\ (\\text{in } \\mathbb{Z},\\ k\\ge 1).$",
+    "significance": "supporting",
+    "relatedConcepts": ["Ring.choose_natCast", "generalized to ordinary binomial", "negative upper index"],
+    "prerequisites": ["ringChoose_neg_eq", "cast_add_sub_one", "Ring.choose_natCast"]
+  },
+  {
+    "id": "ann-sbnb-newton",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-02",
+    "range": { "startLine": 100, "endLine": 107 },
+    "type": "insight",
+    "title": "Newton's identity (−1)ⁿ C(−k,n) = C(n+k−1,n)",
+    "content": "negOnePow_mul_ringChoose_neg is the parent's explicitly stated open question: the classical upper-negation identity (−1)ⁿ · C(−k, n) = C(n+k−1, n) over ℤ for k ≥ 1. Starting from ringChoose_neg_natCast, multiplying by (−1)ⁿ folds the sign away because (−1)ⁿ · (−1)ⁿ = 1 (proved via ← mul_pow; norm_num). This is the bridge between the generalized (negative-index) binomial coefficient and the stars-and-bars count C(n+k−1, n): the two agree up to the alternating sign (−1)ⁿ.",
+    "mathContext": "$(-1)^n \\binom{-k}{n} = \\binom{n+k-1}{n}.$",
+    "significance": "key",
+    "relatedConcepts": ["Newton's generalized binomial theorem", "stars and bars", "sign cancellation", "negative binomial series"],
+    "prerequisites": ["ringChoose_neg_natCast", "(−1)ⁿ·(−1)ⁿ = 1"]
+  },
+  {
+    "id": "ann-sbnb-coeff",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-02",
+    "range": { "startLine": 109, "endLine": 117 },
+    "type": "insight",
+    "title": "Negative binomial reading of 1/(1−X)ᵏ",
+    "content": "coeff_invOneSubPow_eq_negOnePow_mul_ringChoose threads Newton's identity through the parent's coefficient formula. The parent's coeff_invOneSubPow_eq_choose gives the n-th coefficient of Mathlib's invOneSubPow ℤ k (= 1/(1−X)ᵏ) as C(n+k−1, n); rewriting by negOnePow_mul_ringChoose_neg reads it instead as (−1)ⁿ · C(−k, n). This is the coefficientwise form of the expansion 1/(1−X)ᵏ = ∑ₙ C(−k, n)(−X)ⁿ — the negative binomial theorem for the generating function of the weak-composition counts.",
+    "mathContext": "$[X^n]\\,\\tfrac{1}{(1-X)^k} = (-1)^n \\binom{-k}{n}.$",
+    "significance": "key",
+    "relatedConcepts": ["power series coefficients", "invOneSubPow", "generating functions", "negative binomial theorem"],
+    "prerequisites": ["parent's coeff_invOneSubPow_eq_choose", "Newton's identity"]
+  },
+  {
+    "id": "ann-sbnb-rescale",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-02",
+    "range": { "startLine": 119, "endLine": 124 },
+    "type": "insight",
+    "title": "The pure form: (1+X)⁻ᵏ = ∑ C(−k,n) Xⁿ",
+    "content": "coeff_rescale_invOneSubPow gives the sign-free reading. Mathlib's rescale_neg_one_invOneSubPow says the substitution X ↦ −X turns invOneSubPow ℤ k (= 1/(1−X)ᵏ) into the binomial series (1+X)⁻ᵏ, and binomialSeries_coeff reads its n-th coefficient directly as Ring.choose (−k) n. So the rescale interchanges the two readings — 1/(1−X)ᵏ carries the sign (−1)ⁿ, while (1+X)⁻ᵏ has coefficients exactly C(−k, n), giving the pure negative binomial theorem (1+X)⁻ᵏ = ∑ₙ C(−k, n) Xⁿ.",
+    "mathContext": "$[X^n]\\,(1+X)^{-k} = \\binom{-k}{n},\\qquad (1+X)^{-k} = \\sum_n \\binom{-k}{n} X^n.$",
+    "significance": "supporting",
+    "relatedConcepts": ["rescale of power series", "binomialSeries", "negative binomial theorem", "substitution X ↦ −X"],
+    "prerequisites": ["rescale_neg_one_invOneSubPow", "binomialSeries_coeff"]
+  },
+  {
+    "id": "ann-sbnb-weakcomp",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-02",
+    "range": { "startLine": 126, "endLine": 133 },
+    "type": "insight",
+    "title": "The coefficient counts weak compositions up to sign",
+    "content": "negOnePow_mul_ringChoose_eq_card_weakComposition closes the loop with the enumerative content. Composing Newton's identity with the grandparent's card_weakComposition (the number of weak compositions of n into k parts is C(n+k−1, n)) shows (−1)ⁿ · C(−k, n) is literally Fintype.card {f : Fin k → ℕ | ∑ f = n}. The analytic object C(−k, n) and the combinatorial object #{weak compositions} are the same sequence up to the alternating sign — the negative-binomial and stars-and-bars readings unified.",
+    "mathContext": "$(-1)^n \\binom{-k}{n} = \\#\\{f : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\textstyle\\sum_i f_i = n\\}.$",
+    "significance": "key",
+    "relatedConcepts": ["weak compositions", "stars and bars", "card_weakComposition", "enumerative combinatorics"],
+    "prerequisites": ["Newton's identity", "grandparent's card_weakComposition"]
+  },
+  {
+    "id": "ann-sbnb-examples",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-02",
+    "range": { "startLine": 135, "endLine": 144 },
+    "type": "context",
+    "title": "Numeric sanity checks",
+    "content": "Two examples ground the identity. C(−2, 3) = −4, consistent with (−1)³·C(4, 3) = −4; and C(−3, 2) = 6 = (−1)²·C(4, 2). Both are derived from ringChoose_neg_natCast and closed by norm_num, confirming the sign convention and the reduction to ordinary binomial coefficients on concrete inputs.",
+    "mathContext": "$\\binom{-2}{3} = -4,\\qquad \\binom{-3}{2} = 6 = (-1)^2\\binom{4}{2}.$",
+    "significance": "context",
+    "relatedConcepts": ["worked example", "norm_num", "sign convention"],
+    "prerequisites": ["ringChoose_neg_natCast"]
+  }
+]

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-01-oq-02/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-01-oq-02/meta.json
@@ -125,7 +125,15 @@
     ]
   },
   "crossReferences": [
-    "stars-and-bars-weak-compositions-oq-01",
-    "stars-and-bars-weak-compositions"
+    {
+      "proofId": "stars-and-bars-weak-compositions-oq-01",
+      "relationship": "parent",
+      "description": "Identifies the generating function of the weak-composition counts with Mathlib's invOneSubPow S k and reads its n-th coefficient as C(n+k−1, n) (coeff_invOneSubPow_eq_choose). This entry answers that entry's second open question by giving the negative binomial theorem reading of those coefficients as generalized binomial coefficients (−1)ⁿ C(−k, n)."
+    },
+    {
+      "proofId": "stars-and-bars-weak-compositions",
+      "relationship": "generalizes",
+      "description": "The grandparent counts weak compositions of n into k parts as C(n+k−1, n) via the bijection to size-n multisets (card_weakComposition); this entry shows the generalized binomial coefficient C(−k, n) reproduces that count up to the sign (−1)ⁿ."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `stars-and-bars-weak-compositions-oq-01-oq-02`.

**Gap filled**: no annotations.json (annotations, mathContext, significance, crossRefs all 0). meta.json already rich (overview, sections, conclusion).

**Added**: annotations.json with **8 substantive annotations** (each with `mathContext` LaTeX, `significance`, `relatedConcepts`, `prerequisites`):
- upper negation with the sign as (−1)ⁿ (ringChoose_neg_eq)
- the k≥1 cast helper
- specialization to integer upper index −k
- Newton's identity (−1)ⁿC(−k,n)=C(n+k−1,n)
- negative-binomial reading of 1/(1−X)ᵏ coefficients
- the pure (1+X)⁻ᵏ = ∑ C(−k,n)Xⁿ form
- the coefficient counts weak compositions up to sign
- numeric sanity checks

**Also fixed**: malformed `crossReferences` (bare string array → proper {proofId, relationship, description} objects per the CrossReference type).

Anchors validated against the 146-line Lean file (no anchor errors). Axiom status unchanged (verified, 0 axioms, no native_decide).