### PR TITLE
research(sqrt2-examples-oq-01-oq-03): Cauchy–Schwarz from a sum of squares via Lagrange's identity

### DIFF
--- a/proofs/Proofs/Sqrt2OQ01OQ03.lean
+++ b/proofs/Proofs/Sqrt2OQ01OQ03.lean
@@ -1,0 +1,141 @@
+/-
+  Cauchy–Schwarz for finite sums from a sum-of-squares argument.
+
+  The `sqrt2-examples` family isolates the single fact `0 ≤ x²` (`sq_nonneg`,
+  the parent's `square_nonneg_general`) and traces its consequences.  Its parent
+  entry `sqrt2-examples-oq-01` asks, as its third open question, whether the
+  Cauchy–Schwarz inequality
+
+      (∑ᵢ aᵢ bᵢ)²  ≤  (∑ᵢ aᵢ²)(∑ᵢ bᵢ²)
+
+  can be obtained *directly* from square-positivity for finite sums in a
+  linearly ordered field.  This file answers that: yes, and via an exact
+  identity strictly stronger than the inequality — the **Lagrange identity**
+
+      2·[(∑ᵢ aᵢ²)(∑ⱼ bⱼ²) − (∑ᵢ aᵢ bᵢ)²]  =  ∑ᵢ ∑ⱼ (aᵢ bⱼ − aⱼ bᵢ)².
+
+  The right-hand side is a sum of squares, hence `≥ 0` by `sq_nonneg` applied
+  termwise, and Cauchy–Schwarz drops out by dividing by the positive constant 2.
+  The identity holds over any commutative ring; only the final inequality needs
+  the order.  Nothing here uses Mathlib's `Finset.sum_mul_sq_le_sq_mul_sq`; the
+  whole point is to expose the sum-of-squares certificate — the antisymmetric
+  Gram determinants `aᵢ bⱼ − aⱼ bᵢ` — that makes the inequality true.
+
+  Everything is 0-axiom.  (Order hypotheses are written in the current unbundled
+  Mathlib spelling `[Field α] [LinearOrder α] [IsStrictOrderedRing α]`, the
+  replacement for the former `LinearOrderedField`.)
+-/
+import Mathlib
+
+open scoped BigOperators
+open Finset
+
+namespace Sqrt2OQ01OQ03
+
+variable {ι : Type*}
+
+/-- The family's guiding fact, stated locally: a square is non-negative in any
+linearly ordered ring.  (This is `sq_nonneg`; the parent entry names it
+`square_nonneg_general`.) -/
+theorem square_nonneg_general {α : Type*} [Ring α] [LinearOrder α]
+    [IsStrictOrderedRing α] (x : α) : 0 ≤ x ^ 2 := sq_nonneg x
+
+/-- **Lagrange's identity** (doubled form), over an arbitrary commutative ring.
+The difference `(∑ aᵢ²)(∑ bⱼ²) − (∑ aᵢ bᵢ)²`, doubled, is the sum over all pairs
+`(i, j)` of the squares of the `2×2` "cross" determinants `aᵢ bⱼ − aⱼ bᵢ`.
+This is the algebraic heart of Cauchy–Schwarz: the defect is *literally* a sum
+of squares. -/
+theorem two_mul_lagrange {α : Type*} [CommRing α] (s : Finset ι) (a b : ι → α) :
+    2 * ((∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) - (∑ i ∈ s, a i * b i) ^ 2)
+      = ∑ i ∈ s, ∑ j ∈ s, (a i * b j - a j * b i) ^ 2 := by
+  have e : ∀ i j : ι, (a i * b j - a j * b i) ^ 2
+      = a i ^ 2 * b j ^ 2 + a j ^ 2 * b i ^ 2 - 2 * ((a i * b i) * (a j * b j)) :=
+    fun i j => by ring
+  have h1 : ∑ i ∈ s, ∑ j ∈ s, a i ^ 2 * b j ^ 2
+      = (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) := (sum_mul_sum s s _ _).symm
+  have h2 : ∑ i ∈ s, ∑ j ∈ s, a j ^ 2 * b i ^ 2
+      = (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) := by
+    rw [Finset.sum_comm]; exact (sum_mul_sum s s _ _).symm
+  have h3 : ∑ i ∈ s, ∑ j ∈ s, 2 * ((a i * b i) * (a j * b j))
+      = 2 * (∑ i ∈ s, a i * b i) ^ 2 := by
+    rw [sq, sum_mul_sum s s _ _, Finset.mul_sum]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [Finset.mul_sum]
+  symm
+  calc ∑ i ∈ s, ∑ j ∈ s, (a i * b j - a j * b i) ^ 2
+      = ∑ i ∈ s, ∑ j ∈ s,
+          (a i ^ 2 * b j ^ 2 + a j ^ 2 * b i ^ 2 - 2 * ((a i * b i) * (a j * b j))) :=
+        Finset.sum_congr rfl (fun i _ => Finset.sum_congr rfl (fun j _ => e i j))
+    _ = (∑ i ∈ s, ∑ j ∈ s, a i ^ 2 * b j ^ 2)
+          + (∑ i ∈ s, ∑ j ∈ s, a j ^ 2 * b i ^ 2)
+          - (∑ i ∈ s, ∑ j ∈ s, 2 * ((a i * b i) * (a j * b j))) := by
+        simp_rw [Finset.sum_sub_distrib, Finset.sum_add_distrib]
+    _ = 2 * ((∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) - (∑ i ∈ s, a i * b i) ^ 2) := by
+        rw [h1, h2, h3]; ring
+
+/-- The doubled Cauchy–Schwarz defect is non-negative in a linearly ordered
+field: it is a sum of squares, each `≥ 0` by `square_nonneg_general`. -/
+theorem two_mul_defect_nonneg {α : Type*} [Field α] [LinearOrder α]
+    [IsStrictOrderedRing α] (s : Finset ι) (a b : ι → α) :
+    0 ≤ 2 * ((∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) - (∑ i ∈ s, a i * b i) ^ 2) := by
+  rw [two_mul_lagrange]
+  exact Finset.sum_nonneg fun i _ =>
+    Finset.sum_nonneg fun j _ => square_nonneg_general _
+
+/-- **Cauchy–Schwarz inequality** for finite sums in a linearly ordered field,
+proved from the sum-of-squares Lagrange identity: dividing the non-negative
+doubled defect by `2 > 0` gives `(∑ aᵢ bᵢ)² ≤ (∑ aᵢ²)(∑ bᵢ²)`. -/
+theorem inner_sq_le_sum_sq_mul_sum_sq {α : Type*} [Field α] [LinearOrder α]
+    [IsStrictOrderedRing α] (s : Finset ι) (a b : ι → α) :
+    (∑ i ∈ s, a i * b i) ^ 2 ≤ (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) := by
+  have h := two_mul_defect_nonneg s a b
+  linarith
+
+/-- The defect `(∑ aᵢ²)(∑ bᵢ²) − (∑ aᵢ bᵢ)²` is itself non-negative — the same
+statement rearranged. -/
+theorem sum_sq_mul_sum_sq_sub_inner_sq_nonneg {α : Type*} [Field α] [LinearOrder α]
+    [IsStrictOrderedRing α] (s : Finset ι) (a b : ι → α) :
+    0 ≤ (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) - (∑ i ∈ s, a i * b i) ^ 2 := by
+  have := inner_sq_le_sum_sq_mul_sum_sq s a b
+  linarith
+
+/-- **Absolute-value form.** Since `|x|² = x²`, the squared Cauchy–Schwarz
+inequality is unchanged by taking the absolute value of the inner sum:
+`|∑ aᵢ bᵢ|² ≤ (∑ aᵢ²)(∑ bᵢ²)`. -/
+theorem abs_inner_sq_le {α : Type*} [Field α] [LinearOrder α]
+    [IsStrictOrderedRing α] (s : Finset ι) (a b : ι → α) :
+    |∑ i ∈ s, a i * b i| ^ 2 ≤ (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) := by
+  rw [sq_abs]
+  exact inner_sq_le_sum_sq_mul_sum_sq s a b
+
+end Sqrt2OQ01OQ03
+
+/-!
+### Concrete specialisations
+
+The inequality holds verbatim over `ℚ` and `ℝ`; and the parent's `x ↦ x²`
+motivation reappears as the two-term case `n = 2`, where the cross determinant is
+the single quantity `a₁ b₂ − a₂ b₁` and Lagrange's identity reads
+`(a₁² + a₂²)(b₁² + b₂²) − (a₁ b₁ + a₂ b₂)² = (a₁ b₂ − a₂ b₁)²`.
+-/
+
+namespace Sqrt2OQ01OQ03
+
+/-- Cauchy–Schwarz over the rationals. -/
+theorem cauchy_schwarz_rat (s : Finset ι) (a b : ι → ℚ) :
+    (∑ i ∈ s, a i * b i) ^ 2 ≤ (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) :=
+  inner_sq_le_sum_sq_mul_sum_sq s a b
+
+/-- Cauchy–Schwarz over the reals. -/
+theorem cauchy_schwarz_real (s : Finset ι) (a b : ι → ℝ) :
+    (∑ i ∈ s, a i * b i) ^ 2 ≤ (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) :=
+  inner_sq_le_sum_sq_mul_sum_sq s a b
+
+/-- The two-variable Lagrange identity, the `n = 2` shadow of `two_mul_lagrange`
+and the exact source of the classical `(a₁² + a₂²)(b₁² + b₂²) ≥ (a₁ b₁ + a₂ b₂)²`. -/
+theorem lagrange_two {α : Type*} [CommRing α] (a₁ a₂ b₁ b₂ : α) :
+    (a₁ ^ 2 + a₂ ^ 2) * (b₁ ^ 2 + b₂ ^ 2) - (a₁ * b₁ + a₂ * b₂) ^ 2
+      = (a₁ * b₂ - a₂ * b₁) ^ 2 := by
+  ring
+
+end Sqrt2OQ01OQ03

--- a/src/data/proofs/sqrt2-examples-oq-01-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-examples-oq-01-oq-03/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "sqrt2-examples-oq-01-oq-03",
+  "title": "Cauchy–Schwarz from a Sum of Squares: Lagrange's Identity as a Corollary of sq_nonneg",
+  "slug": "sqrt2-examples-oq-01-oq-03",
+  "description": "The sqrt2-examples family isolates the single fact 0 ≤ x² (sq_nonneg, the parent's square_nonneg_general) and traces its consequences. The parent entry sqrt2-examples-oq-01 asks, as its third open question, whether the Cauchy–Schwarz inequality (∑ᵢ aᵢbᵢ)² ≤ (∑ᵢ aᵢ²)(∑ᵢ bᵢ²) for finite sums follows directly from square-positivity in a linearly ordered field. This entry answers yes, via an exact identity strictly stronger than the inequality — the doubled Lagrange identity 2·[(∑ᵢ aᵢ²)(∑ⱼ bⱼ²) − (∑ᵢ aᵢbᵢ)²] = ∑ᵢ∑ⱼ (aᵢbⱼ − aⱼbᵢ)² (two_mul_lagrange), proved over an arbitrary commutative ring by expanding each cross term and refolding the three double sums into products via Finset.sum_mul_sum and Finset.sum_comm. The right-hand side is a sum of squares, non-negative termwise by square_nonneg_general (two_mul_defect_nonneg), so dividing by 2 > 0 yields Cauchy–Schwarz (inner_sq_le_sum_sq_mul_sum_sq), its rearrangement (sum_sq_mul_sum_sq_sub_inner_sq_nonneg), and the absolute-value form |∑ aᵢbᵢ|² ≤ (∑ aᵢ²)(∑ bᵢ²) (abs_inner_sq_le). Concrete corollaries over ℚ and ℝ, and the n = 2 shadow (a₁²+a₂²)(b₁²+b₂²) − (a₁b₁+a₂b₂)² = (a₁b₂−a₂b₁)² (lagrange_two), close the entry. The derivation deliberately avoids Mathlib's Finset.sum_mul_sq_le_sq_mul_sq, exposing the antisymmetric-Gram-determinant sum-of-squares certificate that makes the inequality true. Verified with 0 axioms, 0 sorries, no native_decide.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators",
+      "Finset"
+    ],
+    "namespace": "Sqrt2OQ01OQ03",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/Sqrt2OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "dateAdded": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Sqrt2OQ01OQ03.lean",
+    "tags": [
+      "algebra",
+      "ordered-rings",
+      "inequalities",
+      "cauchy-schwarz",
+      "lagrange-identity",
+      "sum-of-squares",
+      "finite-sums",
+      "generalization",
+      "pedagogical",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 141,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "assumptions": "",
+    "mathlib_version": "as vendored in proofs/.lake",
+    "mathlibDependencies": [
+      {
+        "theorem": "sq_nonneg",
+        "description": "0 ≤ x² in a linearly ordered ring — the family's guiding fact, re-exported locally as square_nonneg_general and applied termwise to the Lagrange sum of squares.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "Finset.sum_mul_sum",
+        "description": "(∑ i ∈ s, f i)·(∑ j ∈ t, g j) = ∑ i ∈ s, ∑ j ∈ t, f i · g j; the fold that turns each of the three products in the Lagrange identity into a double sum (and back).",
+        "module": "Mathlib.Algebra.BigOperators.Ring.Finset"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Swaps the order of a double sum; used to identify ∑ᵢ∑ⱼ aⱼ²bᵢ² with ∑ᵢ∑ⱼ aᵢ²bⱼ², the symmetrization that makes the doubled defect a symmetric sum of squares.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_nonneg",
+        "description": "A finite sum of non-negative terms is non-negative; applied to the inner and outer sums of squares to get two_mul_defect_nonneg.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_sub_distrib / Finset.sum_add_distrib",
+        "description": "Distributivity of finite sums over subtraction and addition, used to split the expanded Lagrange summand into three double sums.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "sq_abs",
+        "description": "|x|² = x²; converts the squared Cauchy–Schwarz bound into its absolute-value form abs_inner_sq_le.",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      }
+    ],
+    "originalContributions": [
+      "two_mul_lagrange: the doubled Lagrange identity 2·[(∑ aᵢ²)(∑ bⱼ²) − (∑ aᵢbᵢ)²] = ∑ᵢ∑ⱼ (aᵢbⱼ − aⱼbᵢ)² over an arbitrary commutative ring — an exact algebraic identity, strictly stronger than the Cauchy–Schwarz inequality, proved by termwise expansion plus a sum_mul_sum / sum_comm refolding of the three double sums.",
+      "inner_sq_le_sum_sq_mul_sum_sq: Cauchy–Schwarz for finite sums in a linearly ordered field obtained purely from the sum-of-squares certificate (each cross determinant squared is ≥ 0 by square_nonneg_general), with no appeal to Mathlib's Finset.sum_mul_sq_le_sq_mul_sq or to inner-product-space machinery — answering the parent's third open question in the requested 'direct corollary of square positivity' form.",
+      "two_mul_defect_nonneg and sum_sq_mul_sum_sq_sub_inner_sq_nonneg: the non-negativity of the (doubled) Cauchy–Schwarz defect exhibited as a manifest sum of squares, and its rearrangement; abs_inner_sq_le records the absolute-value form.",
+      "lagrange_two: the n = 2 shadow (a₁²+a₂²)(b₁²+b₂²) − (a₁b₁+a₂b₂)² = (a₁b₂−a₂b₁)², recovering the parent's x ↦ x² two-term motivation as the single-determinant case of the general identity, together with concrete cauchy_schwarz_rat / cauchy_schwarz_real specialisations."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cauchy's 1821 inequality for finite sums, later generalized by Bunyakovsky and Schwarz to integrals and inner products, is one of the most-used inequalities in mathematics. Among its many proofs, the sum-of-squares proof is the most elementary: it exhibits the difference $(\\sum a_i^2)(\\sum b_i^2) - (\\sum a_i b_i)^2$ as a manifestly non-negative sum of squares. That decomposition is Lagrange's identity, $\\left(\\sum a_i^2\\right)\\left(\\sum b_i^2\\right) - \\left(\\sum a_i b_i\\right)^2 = \\sum_{i<j}(a_i b_j - a_j b_i)^2$, whose summands are the $2\\times2$ minors of the matrix with rows $a$ and $b$. The inequality is thus a shadow of an exact algebraic identity valid over any commutative ring; only the very last step — 'a sum of squares is non-negative' — invokes the order, which is precisely the `sqrt2-examples` family's organizing fact `0 ≤ x²`.",
+    "problemStatement": "The parent entry sqrt2-examples-oq-01 poses: 'The Cauchy–Schwarz inequality $|\\sum_i a_i b_i|^2 \\le (\\sum_i a_i^2)(\\sum_i b_i^2)$ also follows from a sum-of-squares argument. Can it be formalized as a direct corollary of square positivity for finite sums in a linearly ordered field?' Formalize the doubled Lagrange identity over an arbitrary commutative ring, deduce from it — using only that squares are non-negative — the Cauchy–Schwarz inequality for finite sums in a linearly ordered field, and record the two-term specialisation and concrete $\\mathbb{Q}$/$\\mathbb{R}$ corollaries.",
+    "proofStrategy": "The core lemma `two_mul_lagrange` proves $2[(\\sum a_i^2)(\\sum b_j^2) - (\\sum a_i b_i)^2] = \\sum_i \\sum_j (a_i b_j - a_j b_i)^2$ over a `CommRing`. Each cross term expands (by `ring`) as $a_i^2 b_j^2 + a_j^2 b_i^2 - 2(a_i b_i)(a_j b_j)$; `Finset.sum_sub_distrib`/`sum_add_distrib` split the double sum into three, and `Finset.sum_mul_sum` refolds $\\sum_i\\sum_j a_i^2 b_j^2$ and $\\sum_i\\sum_j (a_ib_i)(a_jb_j)$ into the products $(\\sum a_i^2)(\\sum b_j^2)$ and $(\\sum a_i b_i)^2$, while `Finset.sum_comm` identifies the symmetric copy $\\sum_i\\sum_j a_j^2 b_i^2$ with the first product; `ring` finishes the numeric bookkeeping. `two_mul_defect_nonneg` then applies `Finset.sum_nonneg` twice with `square_nonneg_general` (= `sq_nonneg`) to the sum of squares, and `inner_sq_le_sum_sq_mul_sum_sq` divides the resulting $0 \\le 2(P - Q)$ by the positive constant $2$ with `linarith`. `sq_abs` gives the absolute-value form, and `lagrange_two`/`cauchy_schwarz_rat`/`cauchy_schwarz_real` are one-line specialisations.",
+    "keyInsights": [
+      "The Cauchy–Schwarz defect is not merely non-negative — it is *equal* to an explicit sum of squares (the squared antisymmetric minors $a_i b_j - a_j b_i$). Proving the identity, not just the inequality, isolates exactly where the order is used: nowhere until the final 'sum of squares ≥ 0'. The identity itself lives over any commutative ring.",
+      "Doubling the identity keeps the whole argument inside a commutative ring, avoiding division by 2 and any $i<j$ ordering of the index type. The symmetrization $\\sum_i\\sum_j a_j^2 b_i^2 = \\sum_i\\sum_j a_i^2 b_j^2$ (via `Finset.sum_comm`) is what lets the full double sum, rather than a triangular one, be a sum of squares.",
+      "The reduction to square-positivity is faithful to the family's thesis: the entire analytic content of Cauchy–Schwarz over an ordered field is `0 ≤ x²` applied termwise. No inner-product-space structure, completeness, or square roots are needed for the squared inequality.",
+      "The two-variable case `lagrange_two` — $(a_1^2+a_2^2)(b_1^2+b_2^2) - (a_1b_1+a_2b_2)^2 = (a_1b_2-a_2b_1)^2$ — is a single `ring` call and recovers the parent's $x \\mapsto x^2$ motivation as the one-minor case, making the general identity a direct generalization of the two-term AM-GM-style square already in the family."
+    ]
+  },
+  "conclusion": {
+    "summary": "Cauchy–Schwarz for finite sums in a linearly ordered field is machine-verified as a direct corollary of square positivity, through the exact doubled Lagrange identity $2[(\\sum a_i^2)(\\sum b_i^2) - (\\sum a_i b_i)^2] = \\sum_i\\sum_j (a_i b_j - a_j b_i)^2$ over an arbitrary commutative ring. The inequality, its rearrangement, the absolute-value form, the two-term identity, and $\\mathbb{Q}$/$\\mathbb{R}$ corollaries all follow. No axioms, no sorries, no native_decide, and no use of Mathlib's built-in Cauchy–Schwarz lemma — the sum-of-squares certificate is exhibited explicitly.",
+    "implications": "This answers the third open question of sqrt2-examples-oq-01 in exactly the requested form and completes the family's tour of `0 ≤ x²`: alongside AM-GM and the Artin–Schreier obstruction, Cauchy–Schwarz is now shown to reduce to termwise square positivity. The exact Lagrange identity — being ring-valued — is the natural launching point for the equality case (Cauchy–Schwarz is tight iff every minor $a_i b_j - a_j b_i$ vanishes, i.e. the sequences are proportional), for the Binet–Cauchy generalization to products of sums, and for Gram-determinant formulations in higher rank.",
+    "openQuestions": [
+      "Characterize the equality case from the identity: $(\\sum a_i b_i)^2 = (\\sum a_i^2)(\\sum b_i^2)$ iff $a_i b_j = a_j b_i$ for all $i, j$ (proportionality of $a$ and $b$), read directly off the vanishing of every squared minor in `two_mul_lagrange`.",
+      "Generalize to the Binet–Cauchy / Lagrange identity for $(\\sum a_i c_i)(\\sum b_i d_i) - (\\sum a_i d_i)(\\sum b_i c_i)$ and to the Gram-determinant form $\\det(\\langle v_i, v_j\\rangle) \\ge 0$ for finitely many vectors, still as a sum-of-squares certificate.",
+      "State and prove the weighted Cauchy–Schwarz $\\left(\\sum w_i a_i b_i\\right)^2 \\le \\left(\\sum w_i a_i^2\\right)\\left(\\sum w_i b_i^2\\right)$ for non-negative weights $w_i$ by the same doubled-identity route, absorbing $\\sqrt{w_i}$ into the sequences."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "sqrt2-examples-oq-01",
+      "relationship": "extends",
+      "description": "The parent, 'Generalized Non-Negativity of Squares', proves 0 ≤ x² and 2-variable AM-GM in a linearly ordered field and poses three open questions. This entry answers the third — Cauchy–Schwarz for finite sums as a direct corollary of square positivity — via the exact sum-of-squares Lagrange identity, recovering the parent's two-term square as the n = 2 case."
+    },
+    {
+      "proofId": "sqrt2-examples-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The sibling shows totality of the order is essential for 0 ≤ x² (the Artin–Schreier obstruction, with ℂ as witness). Together the two siblings map the boundary of the family's core fact: one shows what square-positivity yields (Cauchy–Schwarz), the other shows the exact hypothesis it requires (a total order)."
+    },
+    {
+      "proofId": "sqrt2-examples",
+      "relationship": "related",
+      "description": "The root entry collects elementary consequences of 0 ≤ x². This entry adds one of the most important: the Cauchy–Schwarz inequality, exhibited as a termwise sum of squares."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Sum-of-Squares Route to Cauchy–Schwarz",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Docstring framing: the family's fact 0 ≤ x² (square_nonneg_general, re-exported from sq_nonneg) is enough to prove Cauchy–Schwarz, via the exact doubled Lagrange identity whose right side is a sum of squares. Imports Mathlib, opens BigOperators/Finset, and notes the current unbundled order-typeclass spelling [Field α] [LinearOrder α] [IsStrictOrderedRing α]."
+    },
+    {
+      "id": "lagrange",
+      "title": "The Doubled Lagrange Identity",
+      "startLine": 43,
+      "endLine": 74,
+      "summary": "two_mul_lagrange: over an arbitrary CommRing, 2·[(∑ aᵢ²)(∑ bⱼ²) − (∑ aᵢbᵢ)²] = ∑ᵢ∑ⱼ (aᵢbⱼ − aⱼbᵢ)². Each cross term expands to aᵢ²bⱼ² + aⱼ²bᵢ² − 2(aᵢbᵢ)(aⱼbⱼ) by ring; the three resulting double sums are refolded into products by Finset.sum_mul_sum, with Finset.sum_comm identifying the symmetric copy, and ring closes the bookkeeping."
+    },
+    {
+      "id": "nonneg",
+      "title": "The Defect Is a Sum of Squares",
+      "startLine": 76,
+      "endLine": 100,
+      "summary": "two_mul_defect_nonneg: the doubled defect is ≥ 0 by applying Finset.sum_nonneg twice with square_nonneg_general to the Lagrange sum of squares. sum_sq_mul_sum_sq_sub_inner_sq_nonneg rearranges this to 0 ≤ (∑ aᵢ²)(∑ bᵢ²) − (∑ aᵢbᵢ)²."
+    },
+    {
+      "id": "cauchy-schwarz",
+      "title": "Cauchy–Schwarz and Its Absolute-Value Form",
+      "startLine": 85,
+      "endLine": 111,
+      "summary": "inner_sq_le_sum_sq_mul_sum_sq: dividing 0 ≤ 2·(P − Q) by 2 > 0 (linarith) yields (∑ aᵢbᵢ)² ≤ (∑ aᵢ²)(∑ bᵢ²). abs_inner_sq_le rewrites via sq_abs to |∑ aᵢbᵢ|² ≤ (∑ aᵢ²)(∑ bᵢ²)."
+    },
+    {
+      "id": "specialisations",
+      "title": "Concrete Fields and the n = 2 Shadow",
+      "startLine": 113,
+      "endLine": 141,
+      "summary": "cauchy_schwarz_rat / cauchy_schwarz_real: the inequality over ℚ and ℝ as one-line specialisations. lagrange_two: the two-variable identity (a₁²+a₂²)(b₁²+b₂²) − (a₁b₁+a₂b₂)² = (a₁b₂−a₂b₁)² by ring, the single-minor case recovering the parent's x ↦ x² motivation."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Steele, J. Michael",
+      "title": "The Cauchy–Schwarz Master Class",
+      "year": "2004",
+      "venue": "Cambridge University Press / MAA",
+      "note": "The sum-of-squares (Lagrange identity) proof of Cauchy–Schwarz and its variations"
+    },
+    {
+      "authors": "Lagrange, Joseph-Louis",
+      "title": "Solutions analytiques de quelques problèmes sur les pyramides triangulaires",
+      "year": "1773",
+      "venue": "Nouveaux mémoires de l'Académie de Berlin",
+      "note": "Origin of the identity (∑ aᵢ²)(∑ bᵢ²) − (∑ aᵢ bᵢ)² = ∑_{i<j}(aᵢ bⱼ − aⱼ bᵢ)²"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of the parent entry `sqrt2-examples-oq-01`: the Cauchy–Schwarz inequality

$$\left(\sum_i a_i b_i\right)^2 \le \left(\sum_i a_i^2\right)\left(\sum_i b_i^2\right)$$

for finite sums, obtained **directly from square positivity** (`0 ≤ x²`, the family's organizing fact) in a linearly ordered field — no appeal to Mathlib's `Finset.sum_mul_sq_le_sq_mul_sq` or inner-product-space machinery.

The engine is an **exact identity** strictly stronger than the inequality — the doubled **Lagrange identity** over an arbitrary commutative ring:

$$2\left[\left(\sum_i a_i^2\right)\left(\sum_j b_j^2\right) - \left(\sum_i a_i b_i\right)^2\right] = \sum_i \sum_j (a_i b_j - a_j b_i)^2.$$

The right-hand side is a manifest **sum of squares** (the squared antisymmetric Gram minors), non-negative termwise by `square_nonneg_general` (= `sq_nonneg`). Dividing by `2 > 0` gives Cauchy–Schwarz. The order is used *nowhere* until that final step.

## Contents

| theorem | statement |
|---|---|
| `two_mul_lagrange` | the doubled Lagrange identity over any `CommRing` |
| `two_mul_defect_nonneg` | the doubled defect is a sum of squares, hence `≥ 0` |
| `inner_sq_le_sum_sq_mul_sum_sq` | Cauchy–Schwarz for finite sums in a linearly ordered field |
| `sum_sq_mul_sum_sq_sub_inner_sq_nonneg` | defect `≥ 0` (rearranged) |
| `abs_inner_sq_le` | absolute-value form `\|∑ aᵢbᵢ\|² ≤ (∑ aᵢ²)(∑ bᵢ²)` |
| `cauchy_schwarz_rat` / `cauchy_schwarz_real` | ℚ / ℝ specialisations |
| `lagrange_two` | `(a₁²+a₂²)(b₁²+b₂²) − (a₁b₁+a₂b₂)² = (a₁b₂−a₂b₁)²` — the parent's `x↦x²` motivation as the single-minor case |

## Verification

- **0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`; `lagrange_two` needs only `propext`/`Quot.sound`), **0 sorries**, no `native_decide`.
- 9 theorems, 141 lines. Verified single-file via `lake env lean` against the cached Mathlib oleans.
- Uses the current unbundled order-typeclass spelling `[Field α] [LinearOrder α] [IsStrictOrderedRing α]` (the replacement for `LinearOrderedField`).

## Files

- `proofs/Proofs/Sqrt2OQ01OQ03.lean`
- `src/data/proofs/sqrt2-examples-oq-01-oq-03/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)