### PR TITLE
research(binomial-theorem-oq-06-oq-01): signed Vandermonde convolution + alternating squared-binomial sum [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ06OQ01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ06OQ01.lean
@@ -1,0 +1,173 @@
+import Mathlib
+
+/-
+# Signed Vandermonde Convolution and the Alternating Squared-Binomial Sum
+
+## Open Question OQ-06-OQ-01 (from `binomial-theorem-oq-06`)
+
+Mathlib records the *unsigned* Vandermonde identity
+`∑_{k} C(m,k)·C(n,r-k) = C(m+n,r)` (`Nat.add_choose_eq`) and the plain
+alternating row sum `∑_k (-1)^k C(n,k) = [n = 0]`
+(`Int.alternating_sum_range_choose`), but not the **signed Vandermonde
+convolution** that interpolates between them:
+
+  `∑_{k=0}^{r} (-1)^k C(m,k) C(n,r-k) = [x^r] (1-x)^m (1+x)^n`.
+
+This entry proves that generating-function identity and specialises it to the
+classical **alternating sum of squared binomial coefficients**:
+
+  `∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0`  if `n` is odd,
+  `∑_{k=0}^{n} (-1)^k C(n,k)^2 = (-1)^{n/2} C(n, n/2)`  if `n` is even,
+
+obtained by setting `m = n` and using `(1-x)(1+x) = 1 - x^2`.
+
+## Results
+
+* `coeff_one_sub_X_pow`      — `[x^k] (1-X)^m = (-1)^k C(m,k)` in `ℤ[X]`;
+* `signed_vandermonde`       — the signed convolution equals `[x^r] (1-X)^m (1+X)^n`;
+* `signed_vandermonde_diag`  — the `m = n` case equals `[x^r] (1-X^2)^n`;
+* `coeff_one_sub_X_sq_pow`   — `[x^r] (1-X^2)^n = [2∣r] (-1)^{r/2} C(n, r/2)`;
+* `alternating_choose_sq`    — `∑_k (-1)^k C(n,k)^2 = [x^n] (1-X^2)^n`;
+* `alternating_choose_sq_closed` — the closed form
+  `∑_k (-1)^k C(n,k)^2 = [2∣n] (-1)^{n/2} C(n, n/2)`;
+* `alternating_choose_sq_odd` — the vanishing statement for odd `n`.
+
+## Proof engine
+
+Everything runs through polynomial coefficient extraction over `ℤ[X]`.
+The convolution is `Polynomial.coeff_mul` on `(1-X)^m (1+X)^n`, rewritten from
+the antidiagonal to `range (r+1)`; the two factor coefficients are
+`coeff_one_sub_X_pow` (proved from `coeff_X_add_C_pow` with the sign
+identity `(-1)^m (-1)^{m-k} = (-1)^k`) and Mathlib's `coeff_one_add_X_pow`.
+The diagonal specialisation collapses the product via `(1-X)(1+X) = 1-X^2`,
+whose coefficients come from the binomial expansion
+`(1 - X^2)^n = ∑_j (-1)^j C(n,j) X^{2j}`.
+
+## References
+
+- Signed Vandermonde / Vandermonde–Chu convolution (standard generating-function identity).
+- Parent `binomial-theorem-oq-06`; sibling `binomial-theorem-oq-06-oq-02` (hockey-stick diagonals).
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace BinomialTheoremOQ06OQ01
+
+open Polynomial Finset
+
+/-! ## Coefficients of `(1 - X)^m` -/
+
+/-- The sign identity `(-1)^m · (-1)^{m-k} = (-1)^k` for `k ≤ m` (over `ℤ`). -/
+theorem neg_one_pow_mul_sub (m k : ℕ) (hk : k ≤ m) :
+    (-1 : ℤ) ^ m * (-1) ^ (m - k) = (-1) ^ k := by
+  rw [← pow_add, show m + (m - k) = k + 2 * (m - k) from by omega, pow_add, pow_mul]
+  simp
+
+/-- `[x^k] (1 - X)^m = (-1)^k · C(m, k)` in `ℤ[X]`. -/
+theorem coeff_one_sub_X_pow (m k : ℕ) :
+    ((1 - X : ℤ[X]) ^ m).coeff k = (-1) ^ k * (m.choose k : ℤ) := by
+  have h : (1 - X : ℤ[X]) = C (-1) * (X + C (-1)) := by
+    rw [C_neg, C_1]; ring
+  rw [h, mul_pow, ← C_pow, coeff_C_mul, coeff_X_add_C_pow]
+  rcases le_or_gt k m with hkm | hkm
+  · rw [← mul_assoc, neg_one_pow_mul_sub m k hkm]
+  · rw [Nat.choose_eq_zero_of_lt hkm]; simp
+
+/-! ## The signed Vandermonde convolution -/
+
+/-- **Signed Vandermonde convolution.** For all `m, n, r`,
+`∑_{k=0}^{r} (-1)^k C(m,k) C(n,r-k) = [x^r] (1-X)^m (1+X)^n`. -/
+theorem signed_vandermonde (m n r : ℕ) :
+    ∑ k ∈ range (r + 1), (-1) ^ k * (m.choose k : ℤ) * (n.choose (r - k) : ℤ)
+      = ((1 - X : ℤ[X]) ^ m * (1 + X) ^ n).coeff r := by
+  rw [coeff_mul,
+    Finset.Nat.sum_antidiagonal_eq_sum_range_succ
+      (fun i j => ((1 - X : ℤ[X]) ^ m).coeff i * ((1 + X : ℤ[X]) ^ n).coeff j)]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  rw [coeff_one_sub_X_pow, coeff_one_add_X_pow]
+
+/-- Diagonal case `m = n`: the convolution equals `[x^r] (1 - X^2)^n`. -/
+theorem signed_vandermonde_diag (n r : ℕ) :
+    ∑ k ∈ range (r + 1), (-1) ^ k * (n.choose k : ℤ) * (n.choose (r - k) : ℤ)
+      = ((1 - X ^ 2 : ℤ[X]) ^ n).coeff r := by
+  rw [signed_vandermonde n n r, ← mul_pow]
+  congr 2
+  ring
+
+/-! ## Coefficients of `(1 - X^2)^n` -/
+
+/-- `(1 - X^2)^n = ∑_{j=0}^{n} (-1)^j C(n,j) X^{2j}` in `ℤ[X]`. -/
+theorem one_sub_X_sq_pow_eq (n : ℕ) :
+    (1 - X ^ 2 : ℤ[X]) ^ n
+      = ∑ j ∈ range (n + 1), C ((-1) ^ j * (n.choose j : ℤ)) * X ^ (2 * j) := by
+  have h : (1 - X ^ 2 : ℤ[X]) = -X ^ 2 + 1 := by ring
+  rw [h, add_pow]
+  refine Finset.sum_congr rfl (fun j _ => ?_)
+  rw [one_pow, mul_one, neg_pow, ← pow_mul, C_mul, C_pow, C_neg, C_1, C_eq_natCast]
+  ring
+
+/-- **Closed form for `(1 - X^2)^n` coefficients.**
+`[x^r] (1 - X^2)^n = (-1)^{r/2} C(n, r/2)` when `2 ∣ r`, and `0` otherwise. -/
+theorem coeff_one_sub_X_sq_pow (n r : ℕ) :
+    ((1 - X ^ 2 : ℤ[X]) ^ n).coeff r
+      = if 2 ∣ r then (-1) ^ (r / 2) * (n.choose (r / 2) : ℤ) else 0 := by
+  rw [one_sub_X_sq_pow_eq, finset_sum_coeff]
+  simp only [coeff_C_mul, coeff_X_pow, mul_ite, mul_one, mul_zero]
+  by_cases hr : 2 ∣ r
+  · rw [if_pos hr]
+    obtain ⟨t, rfl⟩ := hr
+    rw [Nat.mul_div_cancel_left t (by norm_num)]
+    rw [Finset.sum_eq_single t]
+    · rw [if_pos rfl]
+    · intro j _ hj
+      rw [if_neg]; omega
+    · intro ht
+      rw [Finset.mem_range, not_lt] at ht
+      rw [if_pos rfl, Nat.choose_eq_zero_of_lt (by omega)]
+      simp
+  · rw [if_neg hr]
+    refine Finset.sum_eq_zero (fun j _ => ?_)
+    rw [if_neg]
+    intro h; exact hr ⟨j, h⟩
+
+/-! ## The alternating sum of squared binomial coefficients -/
+
+/-- The convolution at `r = n` is the alternating sum of squared binomials. -/
+theorem alternating_choose_sq (n : ℕ) :
+    ∑ k ∈ range (n + 1), (-1) ^ k * (n.choose k : ℤ) ^ 2
+      = ((1 - X ^ 2 : ℤ[X]) ^ n).coeff n := by
+  rw [← signed_vandermonde_diag n n]
+  refine Finset.sum_congr rfl (fun k hk => ?_)
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+  rw [Nat.choose_symm hk]
+  ring
+
+/-- **Closed form.** `∑_{k=0}^{n} (-1)^k C(n,k)^2 = (-1)^{n/2} C(n, n/2)` for even
+`n`, and `0` for odd `n`. -/
+theorem alternating_choose_sq_closed (n : ℕ) :
+    ∑ k ∈ range (n + 1), (-1) ^ k * (n.choose k : ℤ) ^ 2
+      = if 2 ∣ n then (-1) ^ (n / 2) * (n.choose (n / 2) : ℤ) else 0 := by
+  rw [alternating_choose_sq, coeff_one_sub_X_sq_pow]
+
+/-- **Vanishing for odd `n`.** `∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0` when `n` is odd. -/
+theorem alternating_choose_sq_odd (n : ℕ) (hn : Odd n) :
+    ∑ k ∈ range (n + 1), (-1) ^ k * (n.choose k : ℤ) ^ 2 = 0 := by
+  rw [alternating_choose_sq_closed, if_neg]
+  simpa [Nat.two_dvd_ne_zero, Nat.odd_iff] using hn
+
+/-! ## Numerical sanity checks -/
+
+/-- `∑_{k=0}^{4} (-1)^k C(4,k)^2 = 1 - 16 + 36 - 16 + 1 = 6 = (-1)^2 C(4,2)`. -/
+theorem check_four :
+    ∑ k ∈ range 5, (-1) ^ k * ((4).choose k : ℤ) ^ 2 = 6 := by decide
+
+/-- `∑_{k=0}^{3} (-1)^k C(3,k)^2 = 1 - 9 + 9 - 1 = 0` (odd case). -/
+theorem check_three :
+    ∑ k ∈ range 4, (-1) ^ k * ((3).choose k : ℤ) ^ 2 = 0 := by decide
+
+#print axioms signed_vandermonde
+#print axioms coeff_one_sub_X_sq_pow
+#print axioms alternating_choose_sq_closed
+#print axioms alternating_choose_sq_odd
+
+end BinomialTheoremOQ06OQ01

--- a/src/data/proofs/binomial-theorem-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-06-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-coeff-one-sub-X-pow",
+    "proofId": "binomial-theorem-oq-06-oq-01",
+    "range": { "startLine": 67, "endLine": 74 },
+    "type": "theorem",
+    "title": "Coefficients of (1 - X)^m",
+    "content": "The generating-function ingredient: [x^k](1-X)^m = (-1)^k C(m,k) in ℤ[X]. The proof rewrites 1 - X = C(-1)·(X + C(-1)), applies Mathlib's coeff_X_add_C_pow (which gives (-1)^{m-k} C(m,k)), and folds the leading (-1)^m into the sign via the elementary identity (-1)^m (-1)^{m-k} = (-1)^k for k ≤ m; for k > m both sides vanish since C(m,k) = 0.",
+    "mathContext": "$[x^k](1-X)^m = (-1)^k \\binom{m}{k}$",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial coefficients", "binomial theorem", "sign bookkeeping"],
+    "prerequisites": ["Polynomial.coeff_X_add_C_pow", "Nat.choose_eq_zero_of_lt"]
+  },
+  {
+    "id": "ann-signed-vandermonde",
+    "proofId": "binomial-theorem-oq-06-oq-01",
+    "range": { "startLine": 80, "endLine": 87 },
+    "type": "theorem",
+    "title": "The Signed Vandermonde Convolution",
+    "content": "The central result: ∑_{k=0}^{r} (-1)^k C(m,k) C(n,r-k) = [x^r] (1-X)^m (1+X)^n. Mathlib records the unsigned convolution (Nat.add_choose_eq) and the plain alternating row sum (Int.alternating_sum_range_choose) but not this signed interpolation. The proof is Polynomial.coeff_mul on the product, converting the antidiagonal to range (r+1) and rewriting the two factor coefficients via coeff_one_sub_X_pow and Mathlib's coeff_one_add_X_pow.",
+    "mathContext": "$\\sum_{k=0}^{r} (-1)^k \\binom{m}{k}\\binom{n}{r-k} = [x^r](1-x)^m(1+x)^n$",
+    "significance": "central",
+    "relatedConcepts": ["Vandermonde's identity", "generating functions", "convolution"],
+    "prerequisites": ["Polynomial.coeff_mul", "Finset.Nat.sum_antidiagonal_eq_sum_range_succ"]
+  },
+  {
+    "id": "ann-signed-vandermonde-diag",
+    "proofId": "binomial-theorem-oq-06-oq-01",
+    "range": { "startLine": 90, "endLine": 96 },
+    "type": "theorem",
+    "title": "Diagonal Specialisation m = n",
+    "content": "Setting m = n collapses the product (1-X)^n (1+X)^n to (1-X^2)^n via (1-X)(1+X) = 1-X^2, so the convolution becomes [x^r] (1-X^2)^n. This is the step that makes the alternating squared-binomial sum computable: only even-degree coefficients survive.",
+    "mathContext": "$\\sum_{k=0}^{r} (-1)^k \\binom{n}{k}\\binom{n}{r-k} = [x^r](1-x^2)^n$",
+    "significance": "supporting",
+    "relatedConcepts": ["difference of squares", "diagonal identity"],
+    "prerequisites": ["signed_vandermonde", "mul_pow"]
+  },
+  {
+    "id": "ann-one-sub-X-sq-pow-eq",
+    "proofId": "binomial-theorem-oq-06-oq-01",
+    "range": { "startLine": 100, "endLine": 108 },
+    "type": "theorem",
+    "title": "Binomial Expansion of (1 - X^2)^n",
+    "content": "(1 - X^2)^n = ∑_{j=0}^{n} (-1)^j C(n,j) X^{2j}, obtained from Mathlib's add_pow applied to (-X^2 + 1)^n and normalising the C-coefficients. This expansion — supported only on even degrees 2j — is what forces the odd-degree coefficients of (1-X^2)^n to vanish.",
+    "mathContext": "$(1-X^2)^n = \\sum_{j=0}^{n} (-1)^j \\binom{n}{j} X^{2j}$",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial theorem", "even-degree support"],
+    "prerequisites": ["add_pow", "Polynomial.C_pow", "Polynomial.C_eq_natCast"]
+  },
+  {
+    "id": "ann-coeff-one-sub-X-sq-pow",
+    "proofId": "binomial-theorem-oq-06-oq-01",
+    "range": { "startLine": 111, "endLine": 131 },
+    "type": "theorem",
+    "title": "Closed Form for (1 - X^2)^n Coefficients",
+    "content": "[x^r] (1-X^2)^n = (-1)^{r/2} C(n, r/2) when 2 ∣ r, and 0 otherwise. Extracting the coefficient from the even-degree expansion: coeff_X_pow selects the single index j with 2j = r, so the sum collapses to one term when r is even (via Finset.sum_eq_single at r/2) and is identically zero when r is odd.",
+    "mathContext": "$[x^r](1-X^2)^n = [\\,2 \\mid r\\,]\\, (-1)^{r/2} \\binom{n}{r/2}$",
+    "significance": "central",
+    "relatedConcepts": ["coefficient extraction", "parity", "central binomial coefficient"],
+    "prerequisites": ["Polynomial.coeff_X_pow", "Finset.sum_eq_single"]
+  },
+  {
+    "id": "ann-alternating-choose-sq-closed",
+    "proofId": "binomial-theorem-oq-06-oq-01",
+    "range": { "startLine": 147, "endLine": 151 },
+    "type": "theorem",
+    "title": "Closed Form of the Alternating Squared-Binomial Sum",
+    "content": "∑_{k=0}^{n} (-1)^k C(n,k)^2 = (-1)^{n/2} C(n, n/2) for even n and 0 for odd n. Combines the convolution at r = n (using C(n,n-k) = C(n,k) by symmetry, so the summand becomes (-1)^k C(n,k)^2) with the closed form of [x^n] (1-X^2)^n. This is the alternating companion of the parent entry's ∑ C(n,k)^2 = C(2n,n).",
+    "mathContext": "$\\sum_{k=0}^{n} (-1)^k \\binom{n}{k}^2 = \\begin{cases} (-1)^{n/2}\\binom{n}{n/2} & n \\text{ even} \\\\ 0 & n \\text{ odd}\\end{cases}$",
+    "significance": "central",
+    "relatedConcepts": ["alternating sums", "squared binomial coefficients", "symmetry of binomials"],
+    "prerequisites": ["alternating_choose_sq", "coeff_one_sub_X_sq_pow", "Nat.choose_symm"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-06-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-06-oq-01/meta.json
@@ -1,0 +1,90 @@
+{
+  "id": "binomial-theorem-oq-06-oq-01",
+  "slug": "binomial-theorem-oq-06-oq-01",
+  "title": "Signed Vandermonde Convolution and the Alternating Squared-Binomial Sum",
+  "description": "Proves the signed Vandermonde convolution ∑_{k=0}^{r} (-1)^k C(m,k) C(n,r-k) = [x^r] (1-x)^m (1+x)^n, the alternating analogue of the parent's Vandermonde identity, and specialises it (m=n, using (1-x)(1+x)=1-x^2) to the classical alternating sum of squared binomial coefficients: ∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0 for odd n and (-1)^{n/2} C(n, n/2) for even n. Mathlib has the unsigned Vandermonde (Nat.add_choose_eq) and the plain alternating row sum (Int.alternating_sum_range_choose) but not this signed convolution. Answers open question #1 of the parent entry.",
+  "leanFile": {
+    "namespace": "BinomialTheoremOQ06OQ01",
+    "lineCount": 173,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ06OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "vandermonde-identity",
+      "generating-functions",
+      "polynomials",
+      "alternating-sums"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified from the foundational axioms (propext, Classical.choice, Quot.sound). The named theorems use no native_decide; the two numerical checks use kernel decide, introducing no Lean.ofReduceBool.",
+    "lineCount": 173,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "originalContributions": [
+      "signed_vandermonde: the signed Vandermonde convolution ∑_{k=0}^{r} (-1)^k C(m,k) C(n,r-k) = [x^r] (1-X)^m (1+X)^n — the alternating analogue absent from Mathlib (which has only the unsigned Nat.add_choose_eq)",
+      "coeff_one_sub_X_pow: [x^k] (1-X)^m = (-1)^k C(m,k) in ℤ[X], with the supporting sign identity (-1)^m (-1)^{m-k} = (-1)^k",
+      "coeff_one_sub_X_sq_pow: closed form [x^r] (1-X^2)^n = [2∣r] (-1)^{r/2} C(n, r/2) via the binomial expansion (1-X^2)^n = ∑_j (-1)^j C(n,j) X^{2j}",
+      "alternating_choose_sq_closed: ∑_{k=0}^{n} (-1)^k C(n,k)^2 = (-1)^{n/2} C(n, n/2) for even n and 0 for odd n — the alternating companion of the parent's ∑ C(n,k)^2 = C(2n,n)",
+      "alternating_choose_sq_odd: the vanishing statement ∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0 for odd n"
+    ]
+  },
+  "conclusion": {
+    "summary": "Establishes the signed Vandermonde convolution by extracting the x^r coefficient of (1-X)^m (1+X)^n in ℤ[X]: Polynomial.coeff_mul turns the product coefficient into a range sum, whose factors are [x^k](1-X)^m = (-1)^k C(m,k) (from coeff_X_add_C_pow and the sign identity) and [x^{r-k}](1+X)^n = C(n,r-k). Setting m=n collapses the product to (1-X^2)^n via (1-X)(1+X)=1-X^2; its coefficients come from the binomial expansion (1-X^2)^n = ∑_j (-1)^j C(n,j) X^{2j}, giving the alternating squared-binomial sum in closed form. 11 theorems, 0 definitions, 0 axioms, 173 lines.",
+    "implications": "The parent entry proves the unsigned Vandermonde convolution and its diagonal corollary ∑ C(n,k)^2 = C(2n,n). This entry supplies the signed counterpart. The interpolating identity ∑ (-1)^k C(m,k) C(n,r-k) = [x^r](1-x)^m(1+x)^n unifies two facts Mathlib records only separately: the unsigned Vandermonde (r-th coefficient of (1+x)^{m+n}) and the alternating row sum (evaluate at the diagonal). Its diagonal specialisation recovers the classical dichotomy for ∑ (-1)^k C(n,k)^2 — zero in odd degree, a signed central binomial coefficient in even degree — the alternating analogue of the parent's central-binomial identity, and the coefficient extraction of (1-x^2)^n that underlies many hypergeometric evaluations.",
+    "openQuestions": [
+      "Give the general closed form of [x^r] (1-x)^m (1+x)^n for m ≠ n as a single (Jacobi-polynomial / hypergeometric ₂F₁) expression, rather than the unevaluated convolution.",
+      "Prove the odd-degree vanishing ∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0 directly by the involution k ↦ n-k, independently of the generating-function route, and compare the two proofs."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-06",
+      "relationship": "extends",
+      "description": "The parent proves Vandermonde's convolution ∑ C(m,k) C(n,r-k) = C(m+n,r) and its diagonal corollary ∑ C(n,k)^2 = C(2n,n). This entry answers its first open question with the signed convolution and the alternating squared-binomial sum."
+    },
+    {
+      "targetId": "binomial-theorem-oq-06-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling under the same parent, proving the hockey-stick diagonal sums and the Catalan / lattice-path connection of the central identity; this entry instead pursues the signed (alternating) branch."
+    }
+  ],
+  "sections": [
+    "Module Overview and References",
+    "Coefficients of (1 - X)^m",
+    "The Signed Vandermonde Convolution",
+    "Coefficients of (1 - X^2)^n",
+    "The Alternating Sum of Squared Binomial Coefficients",
+    "Numerical Sanity Checks"
+  ],
+  "sorries": [],
+  "overview": {
+    "historicalContext": "Vandermonde's convolution (Chu 1303, Vandermonde 1772) is one of the oldest binomial identities. Its signed variant, obtained by tracking coefficients of (1-x)^m(1+x)^n rather than (1+x)^{m+n}, is the natural bridge between the unsigned convolution and the alternating row sum ∑(-1)^k C(n,k) = 0. The diagonal case m=n produces the alternating sum of squares of binomial coefficients, whose value — zero in odd degree, a signed central binomial coefficient in even degree — is a standard exercise obtained from (1-x^2)^n = ((1-x)(1+x))^n.",
+    "problemStatement": "Formalize the signed Vandermonde convolution ∑_{k=0}^{r} (-1)^k C(m,k) C(n,r-k) = [x^r] (1-x)^m (1+x)^n and deduce the closed form of the alternating squared-binomial sum ∑_{k=0}^{n} (-1)^k C(n,k)^2, complementing the parent entry's unsigned Vandermonde identity and its diagonal corollary ∑ C(n,k)^2 = C(2n,n).",
+    "proofStrategy": "Work in ℤ[X]. First, [x^k](1-X)^m = (-1)^k C(m,k): write 1-X = C(-1)·(X + C(-1)), apply coeff_X_add_C_pow, and simplify the sign with (-1)^m(-1)^{m-k} = (-1)^k for k ≤ m (and the k>m case is zero on both sides). The convolution then follows from Polynomial.coeff_mul on (1-X)^m(1+X)^n, converting the antidiagonal to range (r+1) and rewriting the two factor coefficients (the second by Mathlib's coeff_one_add_X_pow). Setting m=n collapses the product to (1-X^2)^n through (1-X)(1+X)=1-X^2; expanding (1-X^2)^n = ∑_j (-1)^j C(n,j) X^{2j} by the binomial theorem and extracting the x^r coefficient gives the closed form, which at r=n yields the alternating squared-binomial sum.",
+    "keyInsights": [
+      "The signed convolution ∑ (-1)^k C(m,k) C(n,r-k) is exactly the x^r coefficient of (1-x)^m(1+x)^n, interpolating between Mathlib's unsigned Vandermonde (coefficient of (1+x)^{m+n}) and the alternating row sum.",
+      "The sign of [x^k](1-X)^m is handled by the elementary identity (-1)^m(-1)^{m-k}=(-1)^k, letting Mathlib's coeff_X_add_C_pow supply the magnitude C(m,k).",
+      "The diagonal m=n is where the identity becomes rigid: (1-x)(1+x)=1-x^2 kills all odd-degree coefficients, so ∑(-1)^k C(n,k)^2 vanishes in odd degree and equals (-1)^{n/2} C(n,n/2) in even degree.",
+      "The whole evaluation reduces to one binomial expansion (1-x^2)^n = ∑_j (-1)^j C(n,j) x^{2j} plus coefficient bookkeeping — no hypergeometric machinery is needed for the diagonal case.",
+      "This is the alternating companion of the parent's ∑ C(n,k)^2 = C(2n,n): the same diagonal, read off (1-x^2)^n instead of (1+x)^{2n}."
+    ]
+  },
+  "references": [
+    "Vandermonde, A.-T. (1772). Mémoire sur des irrationnelles de différents ordres.",
+    "Graham, Knuth, Patashnik, Concrete Mathematics, §5.1–5.3 (Vandermonde's convolution and its variants).",
+    "Parent entry binomial-theorem-oq-06 (unsigned Vandermonde and ∑ C(n,k)^2 = C(2n,n))."
+  ]
+}


### PR DESCRIPTION
## Summary

Answers open question #1 of `binomial-theorem-oq-06`. Proves the **signed Vandermonde convolution**
```
∑_{k=0}^{r} (-1)^k C(m,k) C(n,r-k) = [x^r] (1-x)^m (1+x)^n
```
the alternating analogue of the parent's Vandermonde identity. Mathlib has the *unsigned* convolution (`Nat.add_choose_eq`) and the plain alternating row sum (`Int.alternating_sum_range_choose`) but **not** this signed interpolation between them.

Specialising to `m = n` via `(1-x)(1+x) = 1-x²` gives the classical closed form for the **alternating sum of squared binomial coefficients**:
```
∑_{k=0}^{n} (-1)^k C(n,k)² = (-1)^{n/2} C(n, n/2)   (n even),   0   (n odd)
```
the alternating companion of the parent's `∑ C(n,k)² = C(2n,n)`.

## Method
Coefficient extraction in `ℤ[X]`: `Polynomial.coeff_mul` on `(1-X)^m (1+X)^n`, with `[x^k](1-X)^m = (-1)^k C(m,k)` (from `coeff_X_add_C_pow` + the sign identity `(-1)^m(-1)^{m-k}=(-1)^k`) and Mathlib's `coeff_one_add_X_pow`. The diagonal case reads the coefficients off the binomial expansion `(1-X²)^n = ∑_j (-1)^j C(n,j) X^{2j}`.

## Verification
- **0 axioms** (`propext`, `Classical.choice`, `Quot.sound` only — confirmed by `#print axioms`; no `native_decide`)
- 0 sorries, 11 theorems, 0 definitions, 173 lines
- Built with `lake env lean Proofs/BinomialTheoremOQ06OQ01.lean`

## Files
- `proofs/Proofs/BinomialTheoremOQ06OQ01.lean`
- `src/data/proofs/binomial-theorem-oq-06-oq-01/{meta.json,annotations.json}` (6 annotations, resolver-validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)