### PR TITLE
research(sum-of-divisors-oq-03): add missing gallery entry for Robin's inequality proof [meta + annotations]

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-03/annotations.json
+++ b/src/data/proofs/sum-of-divisors-oq-03/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-sod-oq03-header",
+    "proofId": "sum-of-divisors-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "concept",
+    "title": "Honest Scope: Why 'native_decide on n ≤ 5040' Fails",
+    "content": "Robin's inequality σ(n) < e^γ·n·ln(ln n) is equivalent to the Riemann Hypothesis for n ≥ 5041 (Robin, 1984). The header documents why the tempting 'verify by native_decide on n ≤ 5040' framing is doubly wrong: (1) the inequality is actually FALSE on the bounded range — it fails on a finite exceptional set whose largest member is 5040 = 7! (under RH exactly 27 numbers), so there is no true '∀ n ≤ 5040' statement to decide; and (2) the comparison is transcendental — e^γ and ln(ln n) are irrational, so RobinInequality n is not a Decidable proposition and native_decide cannot touch it. Mathlib's only γ bounds are 1/2 < γ < 2/3, giving e^γ ∈ (1.6487, 1.9477), too loose to settle the delicate boundary near 5040. The entry therefore delivers three things honestly: the precise predicate, the verified structural facts, and the RH equivalence as an axiom.",
+    "mathContext": "$\\sigma(n) < e^{\\gamma} n \\ln\\ln n$ for all $n \\ge 5041$ iff RH; on $n \\le 5040$ there are 27 exceptions (largest $5040 = 7!$). $e^{\\gamma}, \\ln\\ln n$ transcendental $\\Rightarrow$ not Decidable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Robin's inequality",
+      "Riemann Hypothesis",
+      "sum-of-divisors function",
+      "Euler–Mascheroni constant",
+      "decidability"
+    ],
+    "prerequisites": [
+      "sum-of-divisors function",
+      "Riemann Hypothesis",
+      "transcendental numbers"
+    ]
+  },
+  {
+    "id": "ann-sod-oq03-predicate",
+    "proofId": "sum-of-divisors-oq-03",
+    "range": {
+      "startLine": 54,
+      "endLine": 61
+    },
+    "type": "definition",
+    "title": "The Robin Inequality Predicate",
+    "content": "RobinInequality n is the precise statement (σ 1 n : ℝ) < exp(γ) · n · ln(ln n), where σ 1 = ArithmeticFunction.sigma 1 is the sum-of-divisors function and γ = Real.eulerMascheroniConstant. This is the exact object the open question asks to formalize, phrased over the reals so the transcendental right-hand side is meaningful.",
+    "mathContext": "$\\mathrm{RobinInequality}(n) \\equiv \\sigma(n) < e^{\\gamma}\\, n\\, \\ln(\\ln n)$, with $\\sigma = $ `ArithmeticFunction.sigma 1` and $\\gamma = $ `Real.eulerMascheroniConstant`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ArithmeticFunction.sigma",
+      "Real.eulerMascheroniConstant",
+      "Real.log"
+    ],
+    "prerequisites": [
+      "sum-of-divisors function",
+      "Euler–Mascheroni constant"
+    ]
+  },
+  {
+    "id": "ann-sod-oq03-verified",
+    "proofId": "sum-of-divisors-oq-03",
+    "range": {
+      "startLine": 63,
+      "endLine": 93
+    },
+    "type": "theorem",
+    "title": "Verified Structural Facts (0 axioms)",
+    "content": "Three fully-verified facts. exp_eulerMascheroni_lower and exp_eulerMascheroni_upper transport Mathlib's γ bounds (one_half_lt_eulerMascheroniConstant, eulerMascheroniConstant_lt_two_thirds) through the monotonicity Real.exp_lt_exp to give e^{1/2} < e^γ < e^{2/3} — the sharpest e^γ enclosure obtainable from Mathlib today (≈ (1.6487, 1.9477)). log_log_pos shows ln(ln n) > 0 for n ≥ 3, by first bounding n > e (via Real.exp_one_lt_d9) so that ln n > 1. robin_rhs_pos then concludes the Robin bound e^γ·n·ln(ln n) is strictly positive for n ≥ 3, establishing that Robin's inequality is a well-posed comparison of two positive quantities on the relevant range.",
+    "mathContext": "$e^{1/2} < e^{\\gamma} < e^{2/3}$; for $n \\ge 3$: $n > e \\Rightarrow \\ln n > 1 \\Rightarrow \\ln(\\ln n) > 0$, and $e^{\\gamma} n \\ln\\ln n > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.exp_lt_exp",
+      "one_half_lt_eulerMascheroniConstant",
+      "Real.exp_one_lt_d9",
+      "Real.log_pos"
+    ],
+    "prerequisites": [
+      "monotonicity of exp",
+      "Mathlib's Euler–Mascheroni bounds",
+      "logarithm positivity"
+    ]
+  },
+  {
+    "id": "ann-sod-oq03-axiom",
+    "proofId": "sum-of-divisors-oq-03",
+    "range": {
+      "startLine": 95,
+      "endLine": 108
+    },
+    "type": "concept",
+    "title": "The RH Equivalence (Axiom)",
+    "content": "robin_iff_riemannHypothesis is the single axiom: (∀ n ≥ 5041, RobinInequality n) ↔ RiemannHypothesis. This is Robin's 1984 theorem — a deep analytic result far beyond current Mathlib, and RiemannHypothesis is itself an open Millennium Problem — so it is stated, not proved, exactly as the open question requested. It is the entry's bridge between the elementary divisor function σ and the Riemann Hypothesis. Its presence is why the entry's honest status is 'axiomatized' with axiomCount = 1; every other result is verified with 0 axioms.",
+    "mathContext": "$\\big(\\forall n \\ge 5041,\\ \\sigma(n) < e^{\\gamma} n \\ln\\ln n\\big) \\iff \\mathrm{RiemannHypothesis}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Robin's theorem",
+      "Riemann Hypothesis",
+      "axiomatized status",
+      "RiemannHypothesis"
+    ],
+    "prerequisites": [
+      "Riemann Hypothesis",
+      "analytic number theory"
+    ]
+  },
+  {
+    "id": "ann-sod-oq03-closing",
+    "proofId": "sum-of-divisors-oq-03",
+    "range": {
+      "startLine": 110,
+      "endLine": 118
+    },
+    "type": "concept",
+    "title": "What Is Not Here: The Tighter-Enclosure Blocker",
+    "content": "The closing remark records what the entry deliberately does not attempt: a decision procedure for RobinInequality at specific n. That is impossible with native_decide (transcendental constants) and indeterminate with Mathlib's current γ enclosure for the delicate n near 5040. Sharpening the e^γ enclosure to roughly (1.781, 1.782) — which would in principle let one prove the exceptionality of 5040 and verify Robin's inequality on the finite head — is the natural follow-up, but it requires substantially tighter Euler–Mascheroni bounds (more terms of eulerMascheroniSeq / eulerMascheroniSeq' with tight rational log bounds) than Mathlib provides today.",
+    "mathContext": "Verifying the finite head needs $e^{\\gamma} \\in (1.781, 1.782)$; Mathlib currently offers only $(e^{1/2}, e^{2/3})$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "eulerMascheroniSeq",
+      "numerical enclosure",
+      "blocker"
+    ],
+    "prerequisites": [
+      "Euler–Mascheroni approximation sequences"
+    ]
+  }
+]

--- a/src/data/proofs/sum-of-divisors-oq-03/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-03/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "sum-of-divisors-oq-03",
+  "title": "Robin's Inequality and its Equivalence to the Riemann Hypothesis",
+  "slug": "sum-of-divisors-oq-03",
+  "description": "A follow-up to sum-of-divisors asking to formalize Robin's inequality σ(n) < e^γ·n·ln(ln n) and state its equivalence with the Riemann Hypothesis. The entry gives a precise Lean statement of the inequality (RobinInequality) built from Real.eulerMascheroniConstant and ArithmeticFunction.sigma 1, the sharpest e^γ enclosure available from Mathlib's γ bounds (e^{1/2} < e^γ < e^{2/3}, verified), the well-posedness facts ln(ln n) > 0 and positivity of the Robin bound for n ≥ 3 (verified), and Robin's 1984 theorem — (∀ n ≥ 5041, RobinInequality n) ↔ RiemannHypothesis — as a single clearly-labeled axiom. The entry is honest about scope: the candidate framing 'verify by native_decide on n ≤ 5040' fails on two counts, both documented — Robin's inequality is actually FALSE on the bounded range (it fails on a finite exceptional set, largest 5040 = 7!), and the comparison is transcendental (e^γ, ln ln n are not rational), so it is not Decidable. Status axiomatized (1 axiom: the RH equivalence), which is the correct status for any RH-linked result.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Robin%27s_theorem",
+    "date": "2026-07-02",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/SumOfDivisorsOQ03.lean",
+    "tags": [
+      "number-theory",
+      "sum-of-divisors",
+      "robin-inequality",
+      "riemann-hypothesis",
+      "euler-mascheroni",
+      "analytic-number-theory",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "assumptions": "One axiom, robin_iff_riemannHypothesis: (∀ n ≥ 5041, σ(n) < e^γ·n·ln(ln n)) ↔ RiemannHypothesis. This is Robin's deep 1984 theorem, far beyond current Mathlib, and RiemannHypothesis is itself an open Millennium Problem — so the equivalence is stated, not proved, exactly as the open question requested. It is the entry's bridge between the elementary divisor function σ and RH. All other results (the RobinInequality predicate, the e^{1/2} < e^γ < e^{2/3} enclosure, ln(ln n) > 0, and positivity of the Robin bound) are fully verified with 0 axioms and 0 sorries. No native_decide is used.",
+    "lineCount": 118,
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "**Robin's theorem and the Riemann Hypothesis**\n\nGronwall (1913) showed that the sum-of-divisors function satisfies limsup σ(n)/(n ln ln n) = e^γ, where γ is the Euler–Mascheroni constant. In 1984 Guy Robin sharpened this into a precise criterion: the Riemann Hypothesis is *equivalent* to the statement that σ(n) < e^γ·n·ln(ln n) holds for every n ≥ 5041. Below that threshold the inequality has exactly 27 exceptions (under RH), the largest being 5040 = 7!. Robin's criterion is one of the most striking elementary-looking reformulations of RH, turning a statement about the zeros of ζ into an inequality about divisor sums.\n\nThe parent gallery entry sum-of-divisors develops the σ function and its properties. This entry formalizes Robin's inequality precisely and records the RH equivalence as the open question requested.",
+    "problemStatement": "**Goal**\n\nFormalize Robin's inequality σ(n) < e^γ·n·ln(ln n) as a precise Lean predicate, and state its equivalence with the Riemann Hypothesis (as an axiom, since both directions are far beyond current formalization).\n\n**Result**: the predicate RobinInequality, a verified e^γ enclosure and well-posedness facts, and the axiom (∀ n ≥ 5041, RobinInequality n) ↔ RiemannHypothesis.",
+    "text": "Formalizes Robin's inequality σ(n) < e^γ·n·ln(ln n), the sharpest e^γ enclosure from Mathlib's γ bounds, and Robin's 1984 RH-equivalence as an axiom.",
+    "proofStrategy": "**Approach**\n\n1. `RobinInequality n`: the predicate (σ 1 n : ℝ) < exp γ · n · ln(ln n), using Real.eulerMascheroniConstant and ArithmeticFunction.sigma 1.\n2. `exp_eulerMascheroni_lower/_upper`: apply Real.exp_lt_exp monotonicity to Mathlib's one_half_lt_eulerMascheroniConstant and eulerMascheroniConstant_lt_two_thirds, giving e^{1/2} < e^γ < e^{2/3} — the sharpest enclosure Mathlib's γ bounds allow.\n3. `log_log_pos` (n ≥ 3): since n > e (via exp_one_lt_d9), ln n > 1, so ln(ln n) > 0.\n4. `robin_rhs_pos` (n ≥ 3): the Robin bound is a product of positive factors, so the inequality is a well-posed comparison of positive quantities.\n5. `robin_iff_riemannHypothesis`: Robin's theorem, stated as an axiom.",
+    "keyInsights": [
+      "**An elementary inequality equivalent to RH**: Robin's criterion recasts the Riemann Hypothesis — a statement about the nontrivial zeros of ζ — as the single inequality σ(n) < e^γ·n·ln(ln n) for all n ≥ 5041. Formalizing the predicate makes this bridge explicit in the gallery, with the deep equivalence carried by one clearly-labeled axiom.",
+      "**The bounded-range 'native_decide' framing is wrong, and the file says so**: Robin's inequality is FALSE on n ≤ 5040 (it has 27 exceptions, the largest 5040 = 7!), so there is no true '∀ n ≤ 5040' statement to decide; and e^γ, ln(ln n) are transcendental, so the comparison is not even Decidable. Documenting these two failure modes is part of the entry's value.",
+      "**Mathlib's γ bounds pin the enclosure — and its limits**: The sharpest e^γ enclosure derivable today is (e^{1/2}, e^{2/3}) ≈ (1.6487, 1.9477), from Mathlib's 1/2 < γ < 2/3. That is too loose to settle the boundary cases near 5040 (where σ(n)/n ≈ 3.838 vs e^γ·ln(ln 5040) ≈ 3.82), which is exactly why the computational half of the question is blocked pending tighter Euler–Mascheroni bounds.",
+      "**Honest status = axiomatized**: With RiemannHypothesis itself open and Robin's theorem far beyond Mathlib, the only faithful status is axiomatized with the equivalence exposed as an axiom. The surrounding structural facts are genuinely verified (0 axioms), so the axiom count is exactly 1 and its content is fully disclosed."
+    ],
+    "prerequisites": [
+      "the sum-of-divisors function σ and ArithmeticFunction.sigma",
+      "the Euler–Mascheroni constant and Mathlib's bounds on it",
+      "the Riemann Hypothesis statement",
+      "basic real-analytic facts about exp and log"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Honest Scope: Why 'native_decide on n ≤ 5040' Fails",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Documents that the candidate framing is doubly wrong — Robin's inequality is false on the bounded range (27 exceptions, largest 5040 = 7!) and the transcendental comparison is not Decidable — and lays out the three deliverables: the precise predicate, the verified structural facts, and the RH equivalence as an axiom.",
+      "mathContext": "$\\sigma(n) < e^{\\gamma} n \\ln\\ln n$ holds for all $n \\ge 5041$ iff RH; below 5040 there are 27 exceptions."
+    },
+    {
+      "id": "predicate",
+      "title": "The Robin Inequality Predicate",
+      "startLine": 54,
+      "endLine": 61,
+      "summary": "RobinInequality n := (σ 1 n : ℝ) < exp γ · n · ln(ln n), built from Real.eulerMascheroniConstant and ArithmeticFunction.sigma 1.",
+      "mathContext": "$\\mathrm{RobinInequality}(n) \\equiv \\sigma(n) < e^{\\gamma}\\, n\\, \\ln(\\ln n)$."
+    },
+    {
+      "id": "verified",
+      "title": "Verified Structural Facts (0 axioms)",
+      "startLine": 63,
+      "endLine": 93,
+      "summary": "exp_eulerMascheroni_lower/_upper (e^{1/2} < e^γ < e^{2/3}, the sharpest enclosure from Mathlib's γ bounds), log_log_pos (ln(ln n) > 0 for n ≥ 3), and robin_rhs_pos (the Robin bound is positive for n ≥ 3, so the comparison is well-posed).",
+      "mathContext": "$e^{1/2} < e^{\\gamma} < e^{2/3}$; $\\ln(\\ln n) > 0$ and $e^{\\gamma} n \\ln\\ln n > 0$ for $n \\ge 3$."
+    },
+    {
+      "id": "axiom",
+      "title": "The RH Equivalence (Axiom)",
+      "startLine": 95,
+      "endLine": 108,
+      "summary": "robin_iff_riemannHypothesis: Robin's 1984 theorem (∀ n ≥ 5041, RobinInequality n) ↔ RiemannHypothesis, stated as an axiom — a deep analytic result well beyond Mathlib, with RiemannHypothesis itself open.",
+      "mathContext": "$\\big(\\forall n \\ge 5041,\\ \\sigma(n) < e^{\\gamma} n \\ln\\ln n\\big) \\iff \\mathrm{RH}$."
+    },
+    {
+      "id": "closing",
+      "title": "What Is Not Here: The Tighter-Enclosure Blocker",
+      "startLine": 110,
+      "endLine": 118,
+      "summary": "Notes that a decision procedure for RobinInequality at specific n is impossible with native_decide and indeterminate with Mathlib's current γ enclosure; sharpening e^γ to ~(1.781, 1.782) via more terms of eulerMascheroniSeq is the natural but currently-blocked follow-up.",
+      "mathContext": "Verifying the finite head / proving 5040 exceptional needs $e^{\\gamma} \\in (1.781, 1.782)$, far tighter than Mathlib's $(e^{1/2}, e^{2/3})$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes Robin's inequality σ(n) < e^γ·n·ln(ln n) as a precise predicate, provides the sharpest e^γ enclosure available from Mathlib (e^{1/2} < e^γ < e^{2/3}) and the well-posedness facts, and states Robin's 1984 RH-equivalence as a single clearly-labeled axiom. The entry is explicit about why the bounded-range native_decide framing fails. Status: axiomatized (1 axiom, the RH equivalence).",
+    "implications": "Adds an RH bridge to the divisor-function corner of the gallery: any future tightening of Mathlib's Euler–Mascheroni bounds would immediately let the entry sharpen its e^γ enclosure and, in principle, verify Robin's inequality on the finite exceptional head and certify 5040 as the largest exception. The honest documentation of the two failure modes (falsity on the bounded range; non-decidability) prevents wasted effort on the native_decide route.",
+    "openQuestions": [
+      "Can Mathlib's Euler–Mascheroni enclosure be sharpened to e^γ ∈ (1.781, 1.782) by evaluating more terms of eulerMascheroniSeq / eulerMascheroniSeq' with tight rational bounds on the logarithms, enough to prove the exceptionality of 5040 and verify Robin's inequality on the finite head?",
+      "Can the related unconditional half of Robin's work — that if RH fails then σ(n) ≥ e^γ·n·ln(ln n) for infinitely many n — be stated as a companion axiom or partially formalized?"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "robin_iff_riemannHypothesis",
+      "type": "axiom",
+      "description": "Robin's theorem (1984): (∀ n ≥ 5041, Robin's inequality) ↔ RH — stated as an axiom",
+      "leanType": "(∀ n : ℕ, 5041 ≤ n → RobinInequality n) ↔ RiemannHypothesis"
+    },
+    {
+      "name": "exp_eulerMascheroni_lower",
+      "type": "core",
+      "description": "Sharpest lower enclosure of e^γ from Mathlib: e^{1/2} < e^γ",
+      "leanType": "Real.exp (1 / 2) < Real.exp eulerMascheroniConstant"
+    },
+    {
+      "name": "robin_rhs_pos",
+      "type": "core",
+      "description": "The Robin bound e^γ·n·ln(ln n) is positive for n ≥ 3 (well-posedness)",
+      "leanType": "∀ {n : ℕ}, 3 ≤ n → 0 < Real.exp eulerMascheroniConstant * (n : ℝ) * Real.log (Real.log n)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-divisors",
+      "relationship": "extends",
+      "description": "Parent entry develops the sum-of-divisors function σ; this follow-up formalizes Robin's inequality on σ and its RH equivalence"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "G. Robin"
+      ],
+      "title": "Grandes valeurs de la fonction somme des diviseurs et hypothèse de Riemann",
+      "year": "1984",
+      "note": "J. Math. Pures Appl. 63, 187–213 — the RH-equivalence criterion"
+    },
+    {
+      "authors": [
+        "T. H. Gronwall"
+      ],
+      "title": "Some asymptotic expressions in the theory of numbers",
+      "year": "1913",
+      "note": "limsup σ(n)/(n ln ln n) = e^γ"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "ArithmeticFunction",
+      "Real"
+    ],
+    "namespace": "SumOfDivisorsRobin",
+    "lineCount": 118,
+    "axiomCount": 1,
+    "theoremCount": 4,
+    "substantiveTheoremCount": 4,
+    "sorryTheorems": 0,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "robin_iff_riemannHypothesis",
+        "type": "axiom",
+        "description": "Robin's RH-equivalence, stated as an axiom"
+      },
+      {
+        "name": "exp_eulerMascheroni_lower",
+        "type": "proved",
+        "description": "e^{1/2} < e^γ"
+      },
+      {
+        "name": "exp_eulerMascheroni_upper",
+        "type": "proved",
+        "description": "e^γ < e^{2/3}"
+      },
+      {
+        "name": "robin_rhs_pos",
+        "type": "proved",
+        "description": "positivity of the Robin bound for n ≥ 3"
+      }
+    ],
+    "path": "Proofs/SumOfDivisorsOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The merged PR #30759 shipped `proofs/Proofs/SumOfDivisorsOQ03.lean` (Robin's inequality: verified structural facts + the RH-equivalence axiom) and its `knowledge.md`, but **never created the gallery entry** `src/data/proofs/sum-of-divisors-oq-03/`. The proof is therefore invisible in the gallery. This PR fills that gap with `meta.json` + `annotations.json` for the existing on-main Lean file — no changes to the proof itself.

## Status
- **axiomatized**, `axiomCount: 1`, badge `axiom`.
- The one axiom, `robin_iff_riemannHypothesis` — Robin's 1984 theorem `(∀ n ≥ 5041, σ(n) < e^γ·n·ln(ln n)) ↔ RiemannHypothesis` — is disclosed in `assumptions`. It is a deep analytic result far beyond Mathlib, and `RiemannHypothesis` is itself open, so the equivalence is stated as requested by the open question.
- All other results are verified 0-axiom: the `RobinInequality` predicate, the sharpest e^γ enclosure from Mathlib's γ bounds (`e^{1/2} < e^γ < e^{2/3}`), `log_log_pos`, and `robin_rhs_pos`. No `native_decide`.

## Notes
- The entry honestly documents why the candidate 'native_decide on n ≤ 5040' framing fails: Robin's inequality is **false** on the bounded range (27 exceptions, largest 5040 = 7!), and the transcendental comparison is not `Decidable`.
- Annotations validated against the source with `scripts/annotations/resolver.ts validate` (5/5 aligned).
- Line counts / theorem counts / namespace taken from the on-main file (118 lines, 1 def, 4 theorems, 1 axiom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)