### PR TITLE
Enrich Cauchy–Schwarz from a Sum of Squares: add 7 annotations

### DIFF
--- a/src/data/proofs/sqrt2-examples-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/sqrt2-examples-oq-01-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-square-nonneg",
+    "proofId": "sqrt2-examples-oq-01-oq-03",
+    "range": { "startLine": 37, "endLine": 41 },
+    "type": "concept",
+    "title": "The guiding fact: a square is non-negative",
+    "content": "The whole sqrt2-examples family is built on the single order fact 0 ≤ x², restated locally as square_nonneg_general (Mathlib's sq_nonneg, the parent's name). Everything in this file is a consequence of applying it termwise to a carefully chosen sum of squares. Order is supplied by the unbundled hypotheses [Ring α] [LinearOrder α] [IsStrictOrderedRing α], the modern replacement for LinearOrderedRing.",
+    "mathContext": "$0 \\le x^2$",
+    "significance": "supporting",
+    "relatedConcepts": ["sq_nonneg", "ordered ring", "square-positivity"],
+    "prerequisites": ["linearly ordered ring"]
+  },
+  {
+    "id": "ann-two-mul-lagrange",
+    "proofId": "sqrt2-examples-oq-01-oq-03",
+    "range": { "startLine": 43, "endLine": 74 },
+    "type": "insight",
+    "title": "Lagrange's identity: the defect is literally a sum of squares",
+    "content": "The algebraic heart of the file. Over an arbitrary commutative ring, twice the Cauchy–Schwarz defect equals the double sum of squared 2×2 cross determinants (aᵢbⱼ − aⱼbᵢ). The proof expands each squared determinant via ring into aᵢ²bⱼ² + aⱼ²bᵢ² − 2(aᵢbᵢ)(aⱼbⱼ), then evaluates the three resulting double sums with sum_mul_sum (and Finset.sum_comm for the symmetric second term). No order is used here — this is a pure ring identity that is strictly stronger than the inequality.",
+    "mathContext": "$2\\left[\\left(\\sum_i a_i^2\\right)\\left(\\sum_i b_i^2\\right) - \\left(\\sum_i a_i b_i\\right)^2\\right] = \\sum_i\\sum_j (a_i b_j - a_j b_i)^2$",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange's identity", "sum of squares certificate", "Gram determinant", "Finset.sum_mul_sum"],
+    "prerequisites": ["double Finset sums", "ring tactic", "sum_mul_sum"]
+  },
+  {
+    "id": "ann-defect-nonneg",
+    "proofId": "sqrt2-examples-oq-01-oq-03",
+    "range": { "startLine": 76, "endLine": 83 },
+    "type": "technique",
+    "title": "The doubled defect is non-negative",
+    "content": "Rewriting the doubled defect by the Lagrange identity turns it into a double sum of squares, each summand ≥ 0 by square_nonneg_general. Two nested applications of Finset.sum_nonneg then give 0 ≤ 2·[(∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)²]. This is the exact point where the order hypothesis enters.",
+    "mathContext": "$0 \\le \\sum_i\\sum_j (a_i b_j - a_j b_i)^2$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_nonneg", "non-negativity", "sum of squares"],
+    "prerequisites": ["two_mul_lagrange", "sum of non-negative terms is non-negative"]
+  },
+  {
+    "id": "ann-cauchy-schwarz",
+    "proofId": "sqrt2-examples-oq-01-oq-03",
+    "range": { "startLine": 85, "endLine": 100 },
+    "type": "concept",
+    "title": "Cauchy–Schwarz for finite sums",
+    "content": "Dividing the non-negative doubled defect by 2 > 0 (linarith) yields the Cauchy–Schwarz inequality (∑aᵢbᵢ)² ≤ (∑aᵢ²)(∑bᵢ²). The companion sum_sq_mul_sum_sq_sub_inner_sq_nonneg is the same statement written as 0 ≤ (∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)². Notably this route never invokes Mathlib's Finset.sum_mul_sq_le_sq_mul_sq — the whole point is to expose the antisymmetric sum-of-squares certificate that makes the inequality true.",
+    "mathContext": "$\\left(\\sum_i a_i b_i\\right)^2 \\le \\left(\\sum_i a_i^2\\right)\\left(\\sum_i b_i^2\\right)$",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy–Schwarz inequality", "inner product", "linarith"],
+    "prerequisites": ["two_mul_defect_nonneg"]
+  },
+  {
+    "id": "ann-abs-form",
+    "proofId": "sqrt2-examples-oq-01-oq-03",
+    "range": { "startLine": 102, "endLine": 109 },
+    "type": "technique",
+    "title": "Absolute-value form",
+    "content": "Because |x|² = x² (sq_abs), the squared inequality is unchanged by taking the absolute value of the inner sum, giving |∑aᵢbᵢ|² ≤ (∑aᵢ²)(∑bᵢ²). This is the form most often quoted, and it follows in one rewrite from the squared version.",
+    "mathContext": "$\\left|\\sum_i a_i b_i\\right|^2 \\le \\left(\\sum_i a_i^2\\right)\\left(\\sum_i b_i^2\\right)$",
+    "significance": "technical",
+    "relatedConcepts": ["absolute value", "sq_abs"],
+    "prerequisites": ["inner_sq_le_sum_sq_mul_sum_sq"]
+  },
+  {
+    "id": "ann-concrete-fields",
+    "proofId": "sqrt2-examples-oq-01-oq-03",
+    "range": { "startLine": 122, "endLine": 132 },
+    "type": "context",
+    "title": "Concrete specialisations over ℚ and ℝ",
+    "content": "The inequality holds verbatim over the rationals and the reals — cauchy_schwarz_rat and cauchy_schwarz_real are direct instantiations of the general theorem, since both ℚ and ℝ are linearly ordered fields. These pin down the abstract result to the two fields where Cauchy–Schwarz is most used.",
+    "mathContext": "Cauchy–Schwarz over $\\mathbb{Q}$ and $\\mathbb{R}$",
+    "significance": "context",
+    "relatedConcepts": ["rational numbers", "real numbers", "specialization"],
+    "prerequisites": ["inner_sq_le_sum_sq_mul_sum_sq"]
+  },
+  {
+    "id": "ann-lagrange-two",
+    "proofId": "sqrt2-examples-oq-01-oq-03",
+    "range": { "startLine": 134, "endLine": 139 },
+    "type": "insight",
+    "title": "The n = 2 shadow: two-variable Lagrange identity",
+    "content": "Specializing to two terms recovers the classical identity (a₁²+a₂²)(b₁²+b₂²) − (a₁b₁+a₂b₂)² = (a₁b₂ − a₂b₁)², closed by a single ring call. Here the double sum collapses to the single cross determinant a₁b₂ − a₂b₁, making transparent why the two-term Cauchy–Schwarz (a₁²+a₂²)(b₁²+b₂²) ≥ (a₁b₁+a₂b₂)² holds — the defect is one square. This is the parent's x ↦ x² motivation reappearing.",
+    "mathContext": "$(a_1^2+a_2^2)(b_1^2+b_2^2) - (a_1 b_1 + a_2 b_2)^2 = (a_1 b_2 - a_2 b_1)^2$",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange's identity", "Brahmagupta–Fibonacci identity", "cross determinant"],
+    "prerequisites": ["ring tactic"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `sqrt2-examples-oq-01-oq-03` (Cauchy–Schwarz from a sum-of-squares / Lagrange identity).

**Gap addressed:** rich meta.json (5 sections, keyInsights, conclusion, cross-references) but **no annotations.json**. Adds 7 inline annotations covering the full Lean proof.

**Annotations (0 → 7):**
- The guiding fact 0 ≤ x² (`square_nonneg_general`)
- Lagrange's identity: doubled defect = ∑∑ (aᵢbⱼ − aⱼbᵢ)² (pure ring identity)
- The doubled defect is non-negative (termwise `sq_nonneg` + `Finset.sum_nonneg`)
- Cauchy–Schwarz inequality + absolute-value form
- Concrete specialisations over ℚ and ℝ
- The n=2 two-variable Lagrange identity shadow

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. JSON validates; pushed via git plumbing (worktrees reaped mid-session). meta.json unchanged, under the 60 KB cap.