### PR TITLE
Enrich bijective derangement recurrence (derangements-convergence-oq-04-oq-04)

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-04-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-der0404-natural-order",
+    "proofId": "derangements-convergence-oq-04-oq-04",
+    "range": { "startLine": 56, "endLine": 62 },
+    "type": "concept",
+    "title": "The additive derangement recurrence",
+    "content": "A derangement is a permutation with no fixed point; D(n) (the subfactorial !n) counts derangements of an n-element set. The classical additive recurrence D(n) = (n−1)(D(n−1)+D(n−2)) was found by Pierre Rémond de Montmort (1708) in his study of the problème des rencontres and is the standard companion to the closed form D(n) = n!∑_{k=0}^{n}(−1)ᵏ/k!. Mathlib states the recurrence only in the shifted, computation-friendly form numDerangements_add_two: D(n+2) = (n+1)(D(n)+D(n+1)). numDerangements_add_two' simply commutes the inner sum to the natural descending order D(n+1)+D(n), the shape used everywhere below.",
+    "mathContext": "$D(n+2) = (n+1)\\bigl(D(n+1)+D(n)\\bigr).$",
+    "significance": "supporting",
+    "relatedConcepts": ["derangement", "subfactorial", "problème des rencontres", "numDerangements", "recurrence relation"],
+    "prerequisites": ["derangements of a finite set", "Mathlib's numDerangements"]
+  },
+  {
+    "id": "ann-der0404-subtracted",
+    "proofId": "derangements-convergence-oq-04-oq-04",
+    "range": { "startLine": 64, "endLine": 73 },
+    "type": "technique",
+    "title": "The classical subtracted form for n ≥ 2",
+    "content": "numDerangements_recurrence states the recurrence in its textbook form D(n) = (n−1)(D(n−1)+D(n−2)) directly, with truncated ℕ subtraction, valid for every n ≥ 2 — a form Mathlib does not provide. The proof writes n = m+2 (justified by omega from n ≥ 2), rewrites the subtractions m+2−1 = m+1 and m+2−2 = m, and applies the natural-order recurrence. This subtracted form is the one usable in divisibility arguments like the parent's (n−1) ∣ D(n).",
+    "mathContext": "$D(n) = (n-1)\\bigl(D(n-1)+D(n-2)\\bigr),\\quad n \\ge 2.$",
+    "significance": "key",
+    "relatedConcepts": ["truncated subtraction", "omega", "index shifting", "divisibility of derangements"],
+    "prerequisites": ["numDerangements_add_two'", "ℕ subtraction"]
+  },
+  {
+    "id": "ann-der0404-fintype",
+    "proofId": "derangements-convergence-oq-04-oq-04",
+    "range": { "startLine": 75, "endLine": 82 },
+    "type": "technique",
+    "title": "Lifting the recurrence to an arbitrary fintype",
+    "content": "card_derangements_recurrence lifts the subtracted form from the numeric D(n) to the cardinality of the derangement set of an arbitrary fintype α with 2 ≤ card α: card(derangements α) = (card α − 1)(D(card α − 1) + D(card α − 2)). It bridges via card_derangements_eq_numDerangements (the set of derangements of α has cardinality D(card α)) and then applies numDerangements_recurrence. This makes the recurrence a statement about actual derangement sets, not just the counting sequence.",
+    "mathContext": "$\\#\\,\\mathrm{derangements}(\\alpha) = (|\\alpha|-1)\\bigl(D(|\\alpha|-1)+D(|\\alpha|-2)\\bigr).$",
+    "significance": "supporting",
+    "relatedConcepts": ["fintype cardinality", "derangement set", "card_derangements_eq_numDerangements"],
+    "prerequisites": ["numDerangements_recurrence", "Fintype.card"]
+  },
+  {
+    "id": "ann-der0404-bijective",
+    "proofId": "derangements-convergence-oq-04-oq-04",
+    "range": { "startLine": 84, "endLine": 105 },
+    "type": "insight",
+    "title": "The bijective heart: counting the Option recursion equivalence",
+    "content": "This is the entry's main contribution — a bijective derivation answering the parent's open question. Mathlib provides the recursion equivalence derangements(Option α) ≃ Σ a : α, derangements({a}ᶜ) ⊕ derangements α. card_derangements_option counts both sides: card_sigma turns the total into a sum over the card α fibres, and for each fibre card_sum plus card({a}ᶜ) = card α − 1 (Fintype.card_compl_set, Set.card_singleton) gives D(card α − 1) + D(card α). Since every fibre contributes the same value, Finset.sum_const collapses the sum to card α · (D(card α − 1) + D(card α)). This replaces Mathlib's Fin-indexed strong induction with a direct count of the bijection.",
+    "mathContext": "$\\mathrm{derangements}(\\mathrm{Option}\\,\\alpha) \\simeq \\textstyle\\sum_{a:\\alpha}\\bigl(\\mathrm{derangements}(\\{a\\}^{c}) \\oplus \\mathrm{derangements}\\,\\alpha\\bigr).$",
+    "significance": "key",
+    "relatedConcepts": ["bijective proof", "recursion equivalence", "card_sigma", "card_sum", "Option type"],
+    "prerequisites": ["derangements.derangementsRecursionEquiv", "counting sigma and sum types"]
+  },
+  {
+    "id": "ann-der0404-succ",
+    "proofId": "derangements-convergence-oq-04-oq-04",
+    "range": { "startLine": 107, "endLine": 116 },
+    "type": "technique",
+    "title": "Reading off the succ-form recurrence",
+    "content": "numDerangements_succ_recurrence converts the bijective count into the recurrence D(card α + 1) = card α·(D(card α − 1) + D(card α)). It rewrites card(derangements(Option α)) via card_derangements_eq_numDerangements as D(card(Option α)) and uses card_option: card(Option α) = card α + 1. So the left side of card_derangements_option becomes D(card α + 1), yielding the shifted additive recurrence directly from the bijection.",
+    "mathContext": "$D(|\\alpha|+1) = |\\alpha|\\bigl(D(|\\alpha|-1)+D(|\\alpha|)\\bigr).$",
+    "significance": "supporting",
+    "relatedConcepts": ["card_option", "shifted recurrence", "derangement count"],
+    "prerequisites": ["card_derangements_option", "card_derangements_eq_numDerangements"]
+  },
+  {
+    "id": "ann-der0404-numeric-form",
+    "proofId": "derangements-convergence-oq-04-oq-04",
+    "range": { "startLine": 118, "endLine": 126 },
+    "type": "insight",
+    "title": "The numerical recurrence, bijectively obtained",
+    "content": "numDerangements_succ_eq specializes the fintype version at α = Fin n (using card_fin: card(Fin n) = n) to obtain, for every n, D(n+1) = n·(D(n−1) + D(n)) — the additive derangement recurrence derived purely from the recursion bijection rather than by induction. At n = 0 both sides are 0; for n ≥ 1 it is the shifted form of the classical recurrence. This is the payoff: a self-contained bijective proof of the recurrence over ℕ.",
+    "mathContext": "$D(n+1) = n\\bigl(D(n-1)+D(n)\\bigr)\\quad\\text{for all } n.$",
+    "significance": "key",
+    "relatedConcepts": ["Fin n", "card_fin", "bijective vs inductive proof", "derangement recurrence"],
+    "prerequisites": ["numDerangements_succ_recurrence", "specialization to Fin n"]
+  },
+  {
+    "id": "ann-der0404-checks",
+    "proofId": "derangements-convergence-oq-04-oq-04",
+    "range": { "startLine": 128, "endLine": 145 },
+    "type": "context",
+    "title": "Numerical sanity checks",
+    "content": "Kernel-decide checks pin down the sequence D(2..6) = 1, 2, 9, 44, 265 (the subfactorials / OEIS A000166), plus the subtracted recurrence at n = 6 (265 = 5·(44+9)) and the bijective recurrence at n = 5 (265 = 5·(9+44)). Because these use plain decide (not native_decide), they introduce no Lean.ofReduceBool and keep the entry 0-axiom while making the identities concrete.",
+    "mathContext": "$D_2,\\dots,D_6 = 1,2,9,44,265;\\quad 265 = 5\\cdot(44+9).$",
+    "significance": "context",
+    "relatedConcepts": ["subfactorial values", "OEIS A000166", "kernel decide", "sanity check"],
+    "prerequisites": ["the additive recurrence", "decidable evaluation"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `derangements-convergence-oq-04-oq-04`.

**Gap filled**: no annotations.json (annotations, mathContext, significance, crossRefs all 0). meta.json already rich (overview, sections, conclusion, well-formed crossReferences).

**Added**: annotations.json with **7 substantive annotations** (each with `mathContext` LaTeX, `significance`, `relatedConcepts`, `prerequisites`):
- the additive derangement recurrence (Montmort 1708)
- the classical subtracted form for n≥2
- lifting to an arbitrary fintype
- the bijective heart: counting the Option recursion equivalence
- the succ-form recurrence
- the numerical recurrence, bijectively obtained
- decide sanity checks (D(2..6)=1,2,9,44,265)

Anchors validated against the 147-line Lean file (no anchor errors). Axiom status unchanged (verified, 0 axioms).