### PR TITLE
Enrich Gauss sum bound |τ(χ)|=√p (bounded-prime-gaps-oq-04-oq-03)

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/annotations.json
@@ -58,5 +58,20 @@
     "mathContext": "$z\\overline{z} = \\mathrm{normSq}(z)$ as a real number, and $\\|z\\| = \\sqrt{\\mathrm{normSq}(z)}$; with $\\mathrm{normSq}(\\tau(\\chi)) = p$ this yields $\\|\\tau(\\chi)\\| = \\sqrt{p}$.",
     "relatedConcepts": ["axiom auditing (#print axioms)", "Complex.normSq", "verified vs axiomatized status", "gaussSum_ne_zero"],
     "prerequisites": ["Complex.normSq and Complex.norm_def", "z·conj z = normSq z", "#print axioms discipline", "√p > 0"]
+  },
+  {
+    "id": "ann-bpg-oq0403-nonvanishing",
+    "proofId": "bounded-prime-gaps-oq-04-oq-03",
+    "range": {
+      "startLine": 122,
+      "endLine": 131
+    },
+    "type": "context",
+    "title": "Nonvanishing corollary: τ(χ) ≠ 0",
+    "significance": "supporting",
+    "content": "gaussSum_ne_zero records the immediate but useful consequence that the Gauss sum of a nontrivial character mod a prime never vanishes. The proof is purely order-theoretic: from norm_gaussSum_eq_sqrt the norm is √p, and √p > 0 because p > 0 (Real.sqrt_pos on the primality-derived positivity Fact p.Prime → p.pos); a zero Gauss sum would force √p = ‖0‖ = 0, contradicting √p > 0. Nonvanishing of Gauss sums is what makes them invertible normalizing factors in the functional equation of Dirichlet L-functions and in the reduction of character sums, so the corollary is the natural downstream hook for the √p bound rather than a mere afterthought.",
+    "mathContext": "$\\|\\tau(\\chi)\\| = \\sqrt{p} > 0$, and $\\tau(\\chi) = 0$ would give $\\sqrt{p} = \\|0\\| = 0$, a contradiction; hence $\\tau(\\chi) \\neq 0$.",
+    "relatedConcepts": ["nonvanishing of Gauss sums", "Real.sqrt_pos", "functional equation of L-functions", "normalizing factor"],
+    "prerequisites": ["norm_gaussSum_eq_sqrt", "√p > 0 for p prime", "‖z‖ = 0 ⟺ z = 0"]
   }
 ]

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/meta.json
@@ -64,20 +64,44 @@
       "mathContext": "For a nontrivial Dirichlet character $\\chi \\bmod p$ with $p$ prime, $|\\tau(\\chi)| = \\sqrt{p}$ where $\\tau(\\chi) = \\sum_{a} \\chi(a) e(a/p)$. The proof rests on $\\tau(\\chi)\\overline{\\tau(\\chi)} = \\#(\\mathbb{Z}/p) = p$."
     },
     {
-      "id": "conjugation",
-      "title": "Conjugation identities",
+      "id": "conj-addchar",
+      "title": "Conjugating the standard additive character",
       "startLine": 69,
-      "endLine": 95,
-      "summary": "conj_stdAddChar: conj(stdAddChar a) = stdAddChar⁻¹ a, since the standard additive character takes values on the unit circle (Circle.coe_inv_eq_conj, AddChar.map_neg_eq_inv). conj_gaussSum: conj(gaussSum χ stdAddChar) = gaussSum χ⁻¹ stdAddChar⁻¹, obtained termwise from map_sum, map_mul, MulChar.star_apply', and conj_stdAddChar.",
-      "mathContext": "$\\overline{e(a/N)} = e(-a/N)$ and $\\overline{\\chi(a)} = \\chi^{-1}(a)$ give $\\overline{\\tau(\\chi)} = \\sum_a \\chi^{-1}(a) e(-a/N) = \\mathrm{gaussSum}\\ \\chi^{-1}\\ \\psi^{-1}$. This holds for every modulus."
+      "endLine": 77,
+      "summary": "conj_stdAddChar: conj(stdAddChar a) = stdAddChar⁻¹ a, since the standard additive character takes values on the unit circle (Circle.coe_inv_eq_conj, AddChar.map_neg_eq_inv). Holds for every modulus.",
+      "mathContext": "$\\overline{e(a/N)} = e(-a/N) = e(a/N)^{-1}$, conjugation equals inversion on the unit circle."
     },
     {
-      "id": "product-and-norm",
-      "title": "Product formula and the √p bound",
-      "startLine": 96,
+      "id": "conj-gausssum",
+      "title": "Conjugating the Gauss sum",
+      "startLine": 78,
+      "endLine": 88,
+      "summary": "conj_gaussSum: conj(gaussSum χ stdAddChar) = gaussSum χ⁻¹ stdAddChar⁻¹, obtained termwise from map_sum, map_mul, MulChar.star_apply', and conj_stdAddChar. Also modulus-agnostic.",
+      "mathContext": "$\\overline{\\chi(a)} = \\chi^{-1}(a)$ gives $\\overline{\\tau(\\chi)} = \\sum_a \\chi^{-1}(a) e(-a/N) = \\mathrm{gaussSum}\\ \\chi^{-1}\\ \\psi^{-1}$."
+    },
+    {
+      "id": "product-formula",
+      "title": "Product formula τ(χ)·conj τ(χ) = p (the field step)",
+      "startLine": 89,
+      "endLine": 101,
+      "summary": "gaussSum_mul_conj: for a nontrivial χ mod prime p, τ(χ)·conj τ(χ) = p, via gaussSum_mul_gaussSum_eq_card (which needs ZMod p to be a field — the single place the prime hypothesis enters) rewritten by conj_gaussSum, then ZMod.card.",
+      "mathContext": "$\\tau(\\chi)\\,\\overline{\\tau(\\chi)} = \\mathrm{gaussSum}\\,\\chi\\,\\psi \\cdot \\mathrm{gaussSum}\\,\\chi^{-1}\\,\\psi^{-1} = \\#(\\mathbb{Z}/p) = p$."
+    },
+    {
+      "id": "norm-bound",
+      "title": "Squared norm and the √p bound",
+      "startLine": 102,
+      "endLine": 120,
+      "summary": "normSq_gaussSum: normSq τ(χ) = p (cast from the complex product via normSq_eq_conj_mul_self). norm_gaussSum_eq_sqrt: |τ(χ)| = √p via Complex.norm_def — the headline result, axiom-free.",
+      "mathContext": "$z\\bar z = \\mathrm{normSq}(z) = p$ so $\\|z\\| = \\sqrt{\\mathrm{normSq}(z)} = \\sqrt{p}$."
+    },
+    {
+      "id": "nonvanishing",
+      "title": "Nonvanishing corollary",
+      "startLine": 121,
       "endLine": 135,
-      "summary": "gaussSum_mul_conj: τ(χ)·conj τ(χ) = p via gaussSum_mul_gaussSum_eq_card and ZMod.card. normSq_gaussSum: normSq τ(χ) = p (cast from the complex product). norm_gaussSum_eq_sqrt: |τ(χ)| = √p via Complex.norm_def. gaussSum_ne_zero: τ(χ) ≠ 0 since √p > 0.",
-      "mathContext": "$z\\bar z = \\mathrm{normSq}(z) = p$ so $|z| = \\sqrt{\\mathrm{normSq}(z)} = \\sqrt{p}$. The field hypothesis of gaussSum_mul_gaussSum_eq_card is met because $\\mathbb{Z}/p$ is a field for prime $p$."
+      "summary": "gaussSum_ne_zero: the Gauss sum of a nontrivial character mod a prime is nonzero, since its norm √p is strictly positive (Real.sqrt_pos on p > 0).",
+      "mathContext": "$\\|\\tau(\\chi)\\| = \\sqrt{p} > 0 \\implies \\tau(\\chi) \\neq 0$."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-04-oq-03` (quality 91 → 100).

- **Annotations 4 → 5**: added a focused annotation on the nonvanishing corollary `gaussSum_ne_zero` (was un-annotated), with its role as a normalizing factor in L-function functional equations.
- **Sections 3 → 6**: split the coarse 'Product formula and the √p bound' section into finer sections — additive-character conjugation, Gauss-sum conjugation, the field product step (where the prime hypothesis enters), the √p norm bound, and the nonvanishing corollary.

Anchors validated against the 135-line Lean file (no anchor errors). Axiom status unchanged (verified, 0 axioms).