### PR TITLE
Enrich Cayley's Theorem (cayleys-theorem-oq-01)

### DIFF
--- a/src/data/proofs/cayleys-theorem-oq-01/annotations.json
+++ b/src/data/proofs/cayleys-theorem-oq-01/annotations.json
@@ -66,11 +66,31 @@
   {
     "id": "ann-cayley-embedding",
     "proofId": "cayleys-theorem-oq-01",
-    "range": { "startLine": 71, "endLine": 87 },
+    "range": { "startLine": 71, "endLine": 76 },
     "type": "insight",
-    "title": "Three Faces: Existence and the Subgroup-Embedding Isomorphism",
-    "content": "The final block records the theorem in its standard packagings. `cayley : ∃ f : G →* Equiv.Perm G, Function.Injective f` is the textbook existence form, assembled trivially as ⟨leftRegular G, leftRegular_injective G⟩. `cayleyEquivRange : G ≃* (leftRegular G).range` is the subgroup-embedding form — 'G is isomorphic to a subgroup of Sym(G)' — obtained by feeding the injective hom to `MonoidHom.ofInjective` (the multiplicative analogue of the first isomorphism theorem packaging: an injective hom yields an isomorphism onto its range). `cayleyEquivRange_apply` confirms the isomorphism still acts as g ↦ leftRegular g on elements. Injectivity, existence of an embedding, and isomorphism-onto-a-subgroup are three equivalent ways to state one theorem; the file makes the conversions explicit.",
-    "mathContext": "$\\exists\\, f : G \\to^* \\operatorname{Sym}(G)$ injective; equivalently $G \\cong \\operatorname{im}(\\lambda) \\le \\operatorname{Sym}(G)$ via $\\texttt{MonoidHom.ofInjective}$.",
+    "title": "Existence form: every group is a permutation group",
+    "content": "`cayley : ∃ f : G →* Equiv.Perm G, Function.Injective f` is the textbook existence form, assembled trivially as ⟨leftRegular G, leftRegular_injective G⟩. Stated this way it is the bare assertion that some faithful permutation representation of G exists — 'every group is (isomorphic to) a group of permutations' — the statement Cayley made in 1854 and the reason abstract group theory and concrete permutation-group theory coincide. The existential packaging deliberately forgets which representation is used, isolating the qualitative content from the specific left-regular construction.",
+    "mathContext": "$\\exists\\, f : G \\to^* \\operatorname{Sym}(G),\\ f \\text{ injective}$ — a faithful permutation representation of $G$ exists.",
+    "significance": "key",
+    "relatedConcepts": [
+      "permutation representation",
+      "faithful representation",
+      "abstract vs concrete groups",
+      "existential packaging in Lean"
+    ],
+    "prerequisites": [
+      "the left-regular representation and its injectivity",
+      "existential statements in Lean"
+    ]
+  },
+  {
+    "id": "ann-cayley-subgroup",
+    "proofId": "cayleys-theorem-oq-01",
+    "range": { "startLine": 77, "endLine": 89 },
+    "type": "insight",
+    "title": "Subgroup-embedding form: G ≅ a subgroup of Sym(G)",
+    "content": "`cayleyEquivRange : G ≃* (leftRegular G).range` is the sharpest packaging — 'G is isomorphic to a subgroup of Sym(G)' — obtained by feeding the injective hom to `MonoidHom.ofInjective`, the multiplicative analogue of the first-isomorphism-theorem fact that an injective hom is an isomorphism onto its range. `cayleyEquivRange_apply` confirms the isomorphism still acts as g ↦ leftRegular g, so the abstract iso is realised concretely by the permutations x ↦ g·x. Injectivity, existence, and isomorphism-onto-a-subgroup are three equivalent faces of one theorem; this form is the one that makes G literally a permutation group rather than merely mapping into one.",
+    "mathContext": "$G \\cong \\operatorname{im}(\\lambda) \\le \\operatorname{Sym}(G)$ via $\\texttt{MonoidHom.ofInjective}$, the iso acting by $g \\mapsto (x \\mapsto gx)$.",
     "significance": "key",
     "relatedConcepts": [
       "MonoidHom.ofInjective",
@@ -80,8 +100,7 @@
     ],
     "prerequisites": [
       "injective hom ↦ isomorphism onto range",
-      "subgroups and ranges of homomorphisms",
-      "existential packaging in Lean"
+      "subgroups and ranges of homomorphisms"
     ]
   }
 ]

--- a/src/data/proofs/cayleys-theorem-oq-01/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01/meta.json
@@ -67,7 +67,8 @@
       "**Faithfulness is the whole content.** Once the left-regular representation is recognised as a group action, Cayley's theorem reduces to a single fact: the regular self-action is faithful, i.e. g·1 = h·1 forces g = h. Mathlib packages this as RightCancelMonoid.faithfulSMul, found automatically by typeclass resolution.",
       "**Reuse the bundled action.** Rather than hand-build the homomorphism and check map_one/map_mul, the proof instantiates MulAction.toPermHom G G at the self-action, inheriting the homomorphism structure for free.",
       "**Three faces of one theorem.** Injectivity of a hom, existence of an embedding, and isomorphism onto a subgroup are equivalent packagings; MonoidHom.ofInjective converts the first into the last (G ≃* range), which is the form 'isomorphic to a subgroup of a permutation group'.",
-      "**Not Cayley–Hamilton.** The gallery has many Cayley–Hamilton (matrix) entries; the group-theoretic Cayley theorem — every group is a permutation group — is a distinct result and was absent."
+      "**Not Cayley–Hamilton.** The gallery has many Cayley–Hamilton (matrix) entries; the group-theoretic Cayley theorem — every group is a permutation group — is a distinct result and was absent.",
+      "**The embedding is faithful but far from minimal.** Cayley realises G inside Sym(G) = Equiv.Perm G, a symmetric group of order |G|! — enormous compared to G. The theorem guarantees a faithful permutation representation but not the smallest one; the minimal faithful degree μ(G) (e.g. μ(Cₙ)=n, μ(S₄)=4) is a subtler invariant that Cayley's construction only upper-bounds by |G|."
     ],
     "prerequisites": [
       "Group actions and the bundled permutation representation MulAction.toPermHom",
@@ -101,11 +102,19 @@
       "mathContext": "$\\lambda(g) = \\lambda(h) \\Rightarrow g = h$ (evaluate at the identity)."
     },
     {
+      "id": "existence",
+      "title": "Cayley's Theorem (Existence Form)",
+      "startLine": 71,
+      "endLine": 76,
+      "summary": "cayley: there exists an injective homomorphism f : G →* Equiv.Perm G — the bare existence statement that G is (isomorphic to) a permutation group, packaged from leftRegular and leftRegular_injective.",
+      "mathContext": "$\\exists\\, f : G \\to^* \\operatorname{Sym}(G),\\ f \\text{ injective}.$"
+    },
+    {
       "id": "embedding",
-      "title": "Existence and Subgroup-Embedding Forms",
-      "startLine": 80,
+      "title": "Subgroup-Embedding Form",
+      "startLine": 77,
       "endLine": 89,
-      "summary": "cayley: ∃ injective f : G →* Equiv.Perm G; cayleyEquivRange: G ≃* (leftRegular G).range via MonoidHom.ofInjective; cayleyEquivRange_apply records that the iso is still g ↦ leftRegular g.",
+      "summary": "cayleyEquivRange: G ≃* (leftRegular G).range via MonoidHom.ofInjective, exhibiting G as isomorphic to a subgroup of Sym(G); cayleyEquivRange_apply records that the iso still acts by g ↦ leftRegular g (left multiplication).",
       "mathContext": "$G \\cong \\operatorname{im}(\\lambda) \\le \\operatorname{Sym}(G)$."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `cayleys-theorem-oq-01` (quality 91 → 100).

- **Annotations 4 → 5**: split the lumped 'three faces' annotation into a dedicated existence-form annotation (every group is a permutation group) and a subgroup-embedding-form annotation (G ≅ a subgroup of Sym(G) via MonoidHom.ofInjective).
- **Sections 4 → 5**: split the 'existence and embedding' section into separate existence-form and subgroup-embedding-form sections.
- **keyInsights 4 → 5**: added an insight on the non-minimality of the Cayley embedding — G lands in Sym(G) of order |G|!, far above the minimal faithful permutation degree μ(G).

Anchors validated against the 89-line Lean file (no anchor errors for this entry). Axiom status unchanged (verified, 0 axioms).