### PR TITLE
research(triangular-reciprocals-oq-02-oq-03): closed form for the alternating gap-k reciprocal series [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/TriangularReciprocalsOQ02OQ03.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02OQ03.lean
@@ -1,0 +1,316 @@
+/-
+# Alternating gap-k reciprocal series: closed form via the alternating harmonic sibling
+
+For an integer gap `k ≥ 1` we evaluate the alternating series
+
+    ∑_{n≥1} (-1)^{n+1} / (n (n+k))
+
+in closed form.  The terms are dominated by `1/n²`, so the series is absolutely
+convergent and legitimately `HasSum`-able (unlike the *conditionally* convergent
+alternating harmonic series itself, which is **not** `HasSum` in Mathlib's
+unconditional sense).  Partial-fraction the *finite* partial sums
+
+    1/(n(n+k)) = (1/k)(1/n − 1/(n+k)),
+
+reindex the shifted piece `n ↦ n+k`, and pass to the limit.  Only one classical
+analytic fact enters: the alternating harmonic partial sums converge to `log 2`.
+
+Main result (`hasSum_alternating_gap_k`):
+
+    ∑_{n≥1} (-1)^{n+1} / (n(n+k))
+      = (1/k) · ( (1 − (−1)^k)·log 2  +  (−1)^k · A_k ),
+
+where `A_k = ∑_{m=1}^{k} (−1)^{m+1}/m` is the `k`-th alternating harmonic partial
+sum.  Equivalently
+
+  * `k` even :  ∑ = A_k / k
+  * `k` odd  :  ∑ = (2·log 2 − A_k) / k
+
+Special cases (checked against the sibling `TriangularReciprocalAlternatingOQ03`):
+  * `k = 1`:  ∑ (-1)^{n+1}/(n(n+1)) = 2·log 2 − 1
+  * `k = 2`:  ∑ (-1)^{n+1}/(n(n+2)) = 1/4
+
+The `log 2` limit is proved here **without axioms**: the alternating series test
+gives convergence, and Abel's limit theorem
+(`Real.tendsto_tsum_powerSeries_nhdsWithin_lt`) identifies the limit with the
+`x → 1⁻` boundary value of the Mercator series for `log(1+x)`.  This mirrors
+Mathlib's `Real.tendsto_sum_pi_div_four` (Leibniz's series for π) and upgrades the
+sibling entry, which took the boundary value as an (unsound-as-`HasSum`) axiom.
+-/
+import Mathlib
+
+namespace AlternatingGapKReciprocals
+
+open Finset Filter Topology Real
+
+/-- The `N`-th alternating harmonic partial sum, `1 − 1/2 + 1/3 − ⋯ ± 1/N`,
+written in range form `∑_{i<N} (-1)^i/(i+1)`. -/
+noncomputable def altH (N : ℕ) : ℝ := ∑ i ∈ Finset.range N, (-1 : ℝ) ^ i / ((i : ℝ) + 1)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Part I: the classical analytic input — alternating harmonic → log 2
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Alternating harmonic series.** The partial sums `∑_{i<N} (-1)^i/(i+1)`
+converge to `log 2`.  Proof: the alternating series test provides convergence to
+*some* limit `l`; Abel's limit theorem identifies `l` with the left-hand boundary
+value of the Mercator power series `∑ (-1)^n x^n/(n+1) = log(1+x)/x`, which tends
+to `log 2` as `x → 1⁻`. -/
+theorem tendsto_altH : Tendsto altH atTop (𝓝 (Real.log 2)) := by
+  show Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i / ((i : ℝ) + 1)) atTop (𝓝 (Real.log 2))
+  -- Convergence to some limit `l` via the alternating series test.
+  obtain ⟨l, hl⟩ :
+      ∃ l, Tendsto (fun n ↦ ∑ i ∈ range n, (-1 : ℝ) ^ i * (1 / ((i : ℝ) + 1)))
+        atTop (𝓝 l) := by
+    apply Antitone.tendsto_alternating_series_of_tendsto_zero
+    · intro a b hab
+      apply one_div_le_one_div_of_le (by positivity)
+      have : (a : ℝ) ≤ (b : ℝ) := by exact_mod_cast hab
+      linarith
+    · simpa using tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ)
+  -- Rewrite into `(-1)^i/(i+1)` form.
+  have hl' : Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i / ((i : ℝ) + 1)) atTop (𝓝 l) := by
+    refine hl.congr (fun n => ?_)
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [mul_one_div]
+  -- Abel's limit theorem.
+  have abel := Real.tendsto_tsum_powerSeries_nhdsWithin_lt hl'
+  -- The same tsum tends to `log 2`, since it equals `log(1+x)/x` near `1⁻`.
+  have key :
+      Tendsto (fun x : ℝ ↦ ∑' (n : ℕ), ((-1 : ℝ) ^ n / ((n : ℝ) + 1)) * x ^ n)
+        (𝓝[<] (1 : ℝ)) (𝓝 (Real.log 2)) := by
+    -- Pointwise identification for `0 < x < 1`.
+    have valLog : ∀ x : ℝ, 0 < x → |x| < 1 →
+        (∑' (n : ℕ), ((-1 : ℝ) ^ n / ((n : ℝ) + 1)) * x ^ n) = Real.log (1 + x) / x := by
+      intro x hx0 hxlt
+      have hxne : x ≠ 0 := ne_of_gt hx0
+      have base := Real.hasSum_pow_div_log_of_abs_lt_one
+        (x := -x) (by rwa [abs_neg])
+      have HS1 : HasSum (fun n : ℕ => (-1 : ℝ) ^ n * x ^ (n + 1) / ((n : ℝ) + 1))
+          (Real.log (1 + x)) := by
+        have hb := base.mul_left (-1)
+        have hval : (-1 : ℝ) * (-Real.log (1 - -x)) = Real.log (1 + x) := by
+          rw [sub_neg_eq_add]; ring
+        rw [hval] at hb
+        have hfun : (fun n : ℕ => (-1 : ℝ) ^ n * x ^ (n + 1) / ((n : ℝ) + 1))
+            = (fun n : ℕ => -1 * ((-x) ^ (n + 1) / ((n : ℝ) + 1))) := by
+          funext n
+          rw [neg_pow]
+          ring
+        rw [hfun]; exact hb
+      have hxT : x * (∑' (n : ℕ), ((-1 : ℝ) ^ n / ((n : ℝ) + 1)) * x ^ n)
+          = Real.log (1 + x) := by
+        rw [← HS1.tsum_eq, ← tsum_mul_left]
+        refine tsum_congr (fun n => ?_)
+        rw [pow_succ]; ring
+      rw [eq_div_iff hxne, mul_comm]; exact hxT
+    -- `log(1+x)/x → log 2` as `x → 1⁻`, by continuity at `1`.
+    have hcont : Tendsto (fun x : ℝ => Real.log (1 + x) / x)
+        (𝓝[<] (1 : ℝ)) (𝓝 (Real.log 2)) := by
+      have hca : ContinuousAt (fun x : ℝ => Real.log (1 + x) / x) 1 := by
+        apply ContinuousAt.div
+        · have h1 : ContinuousAt (fun x : ℝ => (1 : ℝ) + x) 1 := by fun_prop
+          have h2 : ContinuousAt Real.log (1 + 1 : ℝ) := Real.continuousAt_log (by norm_num)
+          exact h2.comp h1
+        · fun_prop
+        · norm_num
+      have htend := hca.tendsto
+      have hfe : Real.log (1 + 1) / 1 = Real.log 2 := by norm_num
+      rw [hfe] at htend
+      exact htend.mono_left nhdsWithin_le_nhds
+    -- Combine: `log(1+x)/x =ᶠ T` near `1⁻`, so `T` tends to `log 2`.
+    have heq : (fun x : ℝ => Real.log (1 + x) / x)
+        =ᶠ[𝓝[<] (1 : ℝ)] (fun x : ℝ ↦ ∑' (n : ℕ), ((-1 : ℝ) ^ n / ((n : ℝ) + 1)) * x ^ n) := by
+      have hlt : ∀ᶠ x in 𝓝[<] (1 : ℝ), x < 1 := by
+        filter_upwards [self_mem_nhdsWithin] with x hx using hx
+      have hpos : ∀ᶠ x in 𝓝[<] (1 : ℝ), (0 : ℝ) < x := by
+        have hmem : Set.Ioi (0 : ℝ) ∈ 𝓝[<] (1 : ℝ) :=
+          mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds (by norm_num))
+        filter_upwards [hmem] with x hx using hx
+      filter_upwards [hlt, hpos] with x hx1 hx0
+      have hxlt : |x| < 1 := by rw [abs_of_pos hx0]; exact hx1
+      exact (valLog x hx0 hxlt).symm
+    exact Tendsto.congr' heq hcont
+  have hleq : l = Real.log 2 := tendsto_nhds_unique abel key
+  rwa [hleq] at hl'
+
+/-- Shifted alternating harmonic partial sums `altH (N+k)` also converge to `log 2`. -/
+theorem tendsto_altH_shift (k : ℕ) :
+    Tendsto (fun N => altH (N + k)) atTop (𝓝 (Real.log 2)) :=
+  tendsto_altH.comp (tendsto_add_atTop_nat k)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Part II: finite algebra — partial fractions and reindexing
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Partial fraction decomposition `1/(n(n+k)) = (1/k)(1/n − 1/(n+k))`. -/
+theorem partial_fraction {n k : ℕ} (hn : n ≠ 0) (hk : k ≠ 0) :
+    (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) =
+      (1 / ↑k) * (1 / (n : ℝ) - 1 / ((n : ℝ) + ↑k)) := by
+  have hn' : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn
+  have hk' : (↑k : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hk
+  have hnk : (n : ℝ) + ↑k ≠ 0 := by positivity
+  field_simp
+  ring
+
+/-- The 1-based alternating harmonic partial sum equals `altH`. -/
+theorem altH_Icc_eq (N : ℕ) :
+    ∑ n ∈ Finset.Icc 1 N, (-1 : ℝ) ^ (n + 1) / (n : ℝ) = altH N := by
+  induction N with
+  | zero => simp [altH]
+  | succ M ih =>
+      rw [Finset.sum_Icc_succ_top (by omega), ih]
+      simp only [altH, Finset.sum_range_succ]
+      have hsign : (-1 : ℝ) ^ (M + 1 + 1) = (-1 : ℝ) ^ M := by
+        rw [pow_succ, pow_succ]; ring
+      rw [hsign]
+      push_cast
+      ring
+
+/-- Reindexing the shifted sum `∑_{n=1}^N (-1)^{n+1}/(n+k)` by `m = n+k`. -/
+theorem shifted_sum_eq (N k : ℕ) :
+    ∑ n ∈ Finset.Icc 1 N, (-1 : ℝ) ^ (n + 1) / ((n : ℝ) + ↑k) =
+      (-1 : ℝ) ^ k * (altH (N + k) - altH k) := by
+  induction N with
+  | zero => simp [altH]
+  | succ M ih =>
+      rw [Finset.sum_Icc_succ_top (by omega), ih]
+      have hstep : altH (M + 1 + k)
+          = altH (M + k) + (-1 : ℝ) ^ (M + k) / (((M : ℝ) + k) + 1) := by
+        have hEq : M + 1 + k = (M + k) + 1 := by omega
+        rw [hEq]
+        simp only [altH, Finset.sum_range_succ]
+        push_cast
+        ring
+      rw [hstep]
+      have hsign : (-1 : ℝ) ^ (M + 1 + 1) = (-1 : ℝ) ^ k * (-1 : ℝ) ^ (M + k) := by
+        rw [← pow_add]
+        rw [show M + 1 + 1 = M + 2 from rfl, show k + (M + k) = M + 2 * k from by ring]
+        rw [pow_add, pow_add, pow_mul]
+        norm_num
+      rw [hsign]
+      push_cast
+      ring
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Part III: the main HasSum
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Closed form for the alternating gap-`k` reciprocal series.**  For `k ≥ 1`,
+
+    ∑_{n≥1} (-1)^{n+1} / (n(n+k))
+      = (1/k) · ( (1 − (−1)^k)·log 2  +  (−1)^k · A_k ),
+
+with `A_k = altH k = ∑_{m=1}^k (−1)^{m+1}/m`. -/
+theorem hasSum_alternating_gap_k {k : ℕ} (hk : 1 ≤ k) :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / ((n : ℝ) * ((n : ℝ) + ↑k)))
+      ((1 / (k : ℝ)) * ((1 - (-1) ^ k) * Real.log 2 + (-1) ^ k * altH k)) := by
+  have hk0 : k ≠ 0 := by omega
+  set g : ℕ → ℝ := fun n => (-1 : ℝ) ^ (n + 1) / ((n : ℝ) * ((n : ℝ) + ↑k)) with hg
+  -- (1) Summability by comparison with the p = 2 series.
+  have hbound : ∀ n, ‖g n‖ ≤ 1 / (n : ℝ) ^ 2 := by
+    intro n
+    rcases Nat.eq_zero_or_pos n with hn | hn
+    · subst hn; simp [hg]
+    · have hnR : (0 : ℝ) < n := by exact_mod_cast hn
+      have hkR : (0 : ℝ) ≤ (k : ℝ) := by positivity
+      have hden : (0 : ℝ) < (n : ℝ) * ((n : ℝ) + ↑k) := by positivity
+      have hle : (n : ℝ) ^ 2 ≤ (n : ℝ) * ((n : ℝ) + ↑k) := by nlinarith [hnR, hkR]
+      have hnorm : ‖g n‖ = 1 / ((n : ℝ) * ((n : ℝ) + ↑k)) := by
+        simp only [hg, Real.norm_eq_abs, abs_div, abs_pow, abs_neg, abs_one, one_pow]
+        rw [abs_of_pos hden]
+      rw [hnorm]
+      exact one_div_le_one_div_of_le (by positivity) hle
+  have hsummable : Summable g :=
+    Summable.of_norm_bounded (g := fun n => 1 / (n : ℝ) ^ 2)
+      (summable_one_div_nat_pow.mpr (by norm_num)) hbound
+  -- (2) Partial-sum closed form over `Icc 1 N`.
+  have hPS : ∀ N, ∑ n ∈ Finset.Icc 1 N, g n
+      = (1 / (k : ℝ)) * (altH N - (-1) ^ k * (altH (N + k) - altH k)) := by
+    intro N
+    have step1 : ∑ n ∈ Finset.Icc 1 N, g n
+        = ∑ n ∈ Finset.Icc 1 N,
+            ((1 / (k : ℝ)) * ((-1 : ℝ) ^ (n + 1) / (n : ℝ))
+              - (1 / (k : ℝ)) * ((-1 : ℝ) ^ (n + 1) / ((n : ℝ) + ↑k))) := by
+      refine Finset.sum_congr rfl (fun n hn => ?_)
+      have hn1 : n ≠ 0 := by
+        rcases Finset.mem_Icc.mp hn with ⟨h, _⟩; omega
+      have hpf := partial_fraction (n := n) (k := k) hn1 hk0
+      simp only [hg]
+      have hrw : (-1 : ℝ) ^ (n + 1) / ((n : ℝ) * ((n : ℝ) + ↑k))
+          = (-1 : ℝ) ^ (n + 1) * (1 / ((n : ℝ) * ((n : ℝ) + ↑k))) := by
+        rw [mul_one_div]
+      rw [hrw, hpf]
+      ring
+    rw [step1, Finset.sum_sub_distrib, ← Finset.mul_sum, ← Finset.mul_sum,
+      altH_Icc_eq N, shifted_sum_eq N k]
+    ring
+  -- (3) Relate range partial sums to the `Icc` partial sums (drop the zero term).
+  have hEq_range : ∀ N, ∑ n ∈ Finset.range (N + 1), g n = ∑ n ∈ Finset.Icc 1 N, g n := by
+    intro N
+    induction N with
+    | zero => simp [hg]
+    | succ M ih =>
+        rw [Finset.sum_range_succ, ih, Finset.sum_Icc_succ_top (by omega)]
+  -- Limit of the closed form.
+  have hlim :
+      Tendsto (fun N => ∑ n ∈ Finset.Icc 1 N, g n) atTop
+        (𝓝 ((1 / (k : ℝ)) * (Real.log 2 - (-1) ^ k * (Real.log 2 - altH k)))) := by
+    have hbase :
+        Tendsto (fun N => (1 / (k : ℝ)) * (altH N - (-1) ^ k * (altH (N + k) - altH k)))
+          atTop (𝓝 ((1 / (k : ℝ)) * (Real.log 2 - (-1) ^ k * (Real.log 2 - altH k)))) := by
+      refine Tendsto.const_mul _ ?_
+      refine Tendsto.sub tendsto_altH ?_
+      refine Tendsto.const_mul _ ?_
+      exact (tendsto_altH_shift k).sub_const (altH k)
+    exact hbase.congr (fun N => (hPS N).symm)
+  -- Limit of the actual partial sums (to the tsum).
+  have hrange : Tendsto (fun M => ∑ n ∈ Finset.range M, g n) atTop (𝓝 (∑' n, g n)) :=
+    hsummable.hasSum.tendsto_sum_nat
+  have hrange' : Tendsto (fun N => ∑ n ∈ Finset.Icc 1 N, g n) atTop (𝓝 (∑' n, g n)) := by
+    have hcomp := hrange.comp (tendsto_add_atTop_nat 1)
+    simpa only [Function.comp_def, hEq_range] using hcomp
+  -- Identify the sum value and rewrite into the presented closed form.
+  have hval : (∑' n, g n)
+      = (1 / (k : ℝ)) * (Real.log 2 - (-1) ^ k * (Real.log 2 - altH k)) :=
+    tendsto_nhds_unique hrange' hlim
+  have hclosed :
+      (1 / (k : ℝ)) * (Real.log 2 - (-1) ^ k * (Real.log 2 - altH k))
+        = (1 / (k : ℝ)) * ((1 - (-1) ^ k) * Real.log 2 + (-1) ^ k * altH k) := by
+    ring
+  have hfin : HasSum g (∑' n, g n) := hsummable.hasSum
+  rw [hval, hclosed] at hfin
+  exact hfin
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Part IV: special cases
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- `k = 1`: `∑ (-1)^{n+1}/(n(n+1)) = 2·log 2 − 1`
+(matches the sibling `alternating_reciprocal_product_sum`). -/
+theorem hasSum_gap_one :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / ((n : ℝ) * ((n : ℝ) + 1)))
+      (2 * Real.log 2 - 1) := by
+  have h := hasSum_alternating_gap_k (k := 1) (le_refl 1)
+  have e : (1 / ((1 : ℕ) : ℝ)) * ((1 - (-1) ^ (1 : ℕ)) * Real.log 2 + (-1) ^ (1 : ℕ) * altH 1)
+      = 2 * Real.log 2 - 1 := by
+    have ha : altH 1 = 1 := by simp [altH]
+    rw [ha]; push_cast; ring
+  rw [e] at h
+  simpa using h
+
+/-- `k = 2`: `∑ (-1)^{n+1}/(n(n+2)) = 1/4`. -/
+theorem hasSum_gap_two :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / ((n : ℝ) * ((n : ℝ) + 2)))
+      (1 / 4) := by
+  have h := hasSum_alternating_gap_k (k := 2) (by norm_num)
+  have e : (1 / ((2 : ℕ) : ℝ)) * ((1 - (-1) ^ (2 : ℕ)) * Real.log 2 + (-1) ^ (2 : ℕ) * altH 2)
+      = 1 / 4 := by
+    have ha : altH 2 = 1 / 2 := by
+      simp [altH, Finset.sum_range_succ]
+      norm_num
+    rw [ha]; push_cast; ring
+  rw [e] at h
+  simpa using h
+
+end AlternatingGapKReciprocals

--- a/src/data/proofs/triangular-reciprocals-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/triangular-reciprocals-oq-02-oq-03/annotations.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "ann-scope",
+    "proofId": "triangular-reciprocals-oq-02-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "warning",
+    "title": "Scope and the Conditional-Convergence Trap",
+    "content": "This entry evaluates ∑_{n≥1} (-1)^{n+1}/(n(n+k)) in closed form for every k ≥ 1. The crucial subtlety is convergence type: the FULL alternating series is absolutely convergent (each term is bounded by 1/n²), so it legitimately HasSum in Mathlib's unconditional sense. But the two pieces it naively splits into — ∑ (-1)^{n+1}/n and its shift — are only CONDITIONALLY convergent and therefore do NOT HasSum. The sibling TriangularReciprocalAlternatingOQ03 postulated `HasSum (fun n => (-1)^{n+1}/n) (log 2)` as an axiom; that statement is unsound in Mathlib because unconditional summation forces absolute convergence. This proof avoids the trap: it splits only the FINITE partial sums, then takes limits, so no ill-defined object ever appears. 0 axioms, 0 sorries (#print axioms: propext, Classical.choice, Quot.sound).",
+    "mathContext": "$\\sum_{n\\ge1}\\frac{(-1)^{n+1}}{n(n+k)}$ is absolutely convergent; $\\sum\\frac{(-1)^{n+1}}{n}$ is only conditionally convergent (not `HasSum`).",
+    "significance": "major",
+    "relatedConcepts": ["absolute vs conditional convergence", "HasSum", "unconditional summation", "axiom integrity"],
+    "prerequisites": ["infinite series", "HasSum / tsum semantics"]
+  },
+  {
+    "id": "ann-alt-harmonic-log2",
+    "proofId": "triangular-reciprocals-oq-02-oq-03",
+    "range": {
+      "startLine": 59,
+      "endLine": 136
+    },
+    "type": "insight",
+    "title": "Alternating Harmonic Limit = log 2, Without Axioms",
+    "content": "The single transcendental input, proved rather than assumed. Step 1: the alternating series test (Antitone.tendsto_alternating_series_of_tendsto_zero) shows ∑_{i<N} (-1)^i/(i+1) converges to SOME limit l. Step 2: Abel's limit theorem (Real.tendsto_tsum_powerSeries_nhdsWithin_lt) turns l into lim_{x→1⁻} ∑' (-1)^n x^n/(n+1). Step 3: multiplying the tsum by x and matching Real.hasSum_pow_div_log_of_abs_lt_one at argument -x identifies ∑' (-1)^n x^{n+1}/(n+1) = log(1+x), so the tsum equals log(1+x)/x, which → log 2 by continuity at x=1. Uniqueness of limits gives l = log 2. This is exactly the recipe Mathlib uses for Leibniz's π/4 series (Real.tendsto_sum_pi_div_four), transplanted from arctan to log.",
+    "mathContext": "$\\sum_{i<N}\\frac{(-1)^i}{i+1}\\to\\log 2$ because $\\sum'\\frac{(-1)^n}{n+1}x^n=\\frac{\\log(1+x)}{x}\\xrightarrow{x\\to1^-}\\log 2$.",
+    "significance": "major",
+    "relatedConcepts": ["Abel's limit theorem", "Mercator series", "alternating series test", "Leibniz series for π", "boundary value of power series"],
+    "prerequisites": ["power series convergence", "Abel summation", "continuity of log"]
+  },
+  {
+    "id": "ann-partial-fraction-reindex",
+    "proofId": "triangular-reciprocals-oq-02-oq-03",
+    "range": {
+      "startLine": 147,
+      "endLine": 193
+    },
+    "type": "insight",
+    "title": "Finite Algebra: Partial Fraction and the n ↦ n+k Reindex",
+    "content": "All the non-analytic content is finite and exact. partial_fraction splits 1/(n(n+k)) = (1/k)(1/n - 1/(n+k)). altH_Icc_eq identifies the 1-based partial sum ∑_{n=1}^N (-1)^{n+1}/n with altH N (range form) by induction. shifted_sum_eq is the heart: reindexing m = n+k in ∑_{n=1}^N (-1)^{n+1}/(n+k) yields (-1)^k(altH(N+k) - altH k), where the factor (-1)^k comes from the sign identity (-1)^{n+k+1} = (-1)^k·(-1)^{n+1} (since (-1)^{2k} = 1). Both identities are proved by induction on N using Finset.sum_Icc_succ_top and Finset.sum_range_succ, keeping everything inside finite, well-defined sums.",
+    "mathContext": "$\\sum_{n=1}^{N}\\frac{(-1)^{n+1}}{n+k}=(-1)^k\\big(A_{N+k}-A_k\\big)$ via $m=n+k$, $(-1)^{m+1}=(-1)^k(-1)^{n+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["partial fractions", "index shift / reindexing", "sign bookkeeping", "induction on finite sums"],
+    "prerequisites": ["Finset sum manipulation", "parity of powers of -1"]
+  },
+  {
+    "id": "ann-main-hassum",
+    "proofId": "triangular-reciprocals-oq-02-oq-03",
+    "range": {
+      "startLine": 205,
+      "endLine": 283
+    },
+    "type": "insight",
+    "title": "Assembly: Summability + Finite Closed Form + Limit",
+    "content": "hasSum_alternating_gap_k glues the pieces. (1) Summability: ‖(-1)^{n+1}/(n(n+k))‖ ≤ 1/n² (since n(n+k) ≥ n²), so Summable.of_norm_bounded against the p=2 series gives Summable — hence HasSum. (2) Finite closed form: the partial fraction plus altH_Icc_eq and shifted_sum_eq give ∑_{n=1}^N term = (1/k)(altH N - (-1)^k(altH(N+k) - altH k)). (3) Limit: altH N → log 2 and altH(N+k) → log 2, so the finite closed form tends to (1/k)((1-(-1)^k)log 2 + (-1)^k altH k); relating the range partial sums (which tend to the tsum) to the Icc partial sums via a dropped zero-term and invoking tendsto_nhds_unique pins the tsum to this value.",
+    "mathContext": "$\\sum_{n\\ge1}\\frac{(-1)^{n+1}}{n(n+k)}=\\frac{1}{k}\\big((1-(-1)^k)\\log 2+(-1)^k A_k\\big)$.",
+    "significance": "major",
+    "relatedConcepts": ["comparison test", "p-series", "HasSum.tendsto_sum_nat", "uniqueness of limits"],
+    "prerequisites": ["Summable / HasSum", "limits of sequences", "partial sums of a summable series"]
+  },
+  {
+    "id": "ann-special-cases",
+    "proofId": "triangular-reciprocals-oq-02-oq-03",
+    "range": {
+      "startLine": 285,
+      "endLine": 316
+    },
+    "type": "note",
+    "title": "Parity and the Special Cases k = 1, k = 2",
+    "content": "The parity of k governs transcendence. For odd k the coefficient (1-(-1)^k) = 2 survives, so log 2 appears; for even k it vanishes and the sum is the rational A_k/k. hasSum_gap_one evaluates A_1 = 1 to get ∑ (-1)^{n+1}/(n(n+1)) = 2·log 2 - 1 (matching the sibling entry). hasSum_gap_two evaluates A_2 = 1 - 1/2 = 1/2 with the log 2 terms cancelling to get ∑ (-1)^{n+1}/(n(n+2)) = (1/2)·(1/2) = 1/4.",
+    "mathContext": "$k=1:\\ 2\\log 2 - 1$ (odd, transcendental);\\quad $k=2:\\ \\tfrac14$ (even, rational).",
+    "significance": "supporting",
+    "relatedConcepts": ["parity", "transcendence of log 2", "specialization"],
+    "prerequisites": ["evaluating small alternating harmonic sums"]
+  }
+]

--- a/src/data/proofs/triangular-reciprocals-oq-02-oq-03/index.ts
+++ b/src/data/proofs/triangular-reciprocals-oq-02-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/TriangularReciprocalsOQ02OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const triangularReciprocalsOq02Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const triangularReciprocalsOq02Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const triangularReciprocalsOq02Oq03Data: ProofData = {
+  proof: triangularReciprocalsOq02Oq03Proof,
+  annotations: triangularReciprocalsOq02Oq03Annotations,
+}

--- a/src/data/proofs/triangular-reciprocals-oq-02-oq-03/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-02-oq-03/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "triangular-reciprocals-oq-02-oq-03",
+  "title": "Closed Form for the Alternating Gap-k Reciprocal Series",
+  "slug": "triangular-reciprocals-oq-02-oq-03",
+  "description": "For every integer k ≥ 1, the alternating series ∑_{n≥1} (-1)^{n+1}/(n(n+k)) is evaluated in closed form as (1/k)((1-(-1)^k)·log 2 + (-1)^k·A_k), where A_k = ∑_{m=1}^k (-1)^{m+1}/m is the k-th alternating harmonic partial sum. Specializes to 2·log 2 - 1 at k=1 and 1/4 at k=2. The alternating harmonic limit A_∞ = log 2 is proved without axioms via the alternating series test and Abel's limit theorem, upgrading the sibling entry's axiomatized (and unsound-as-HasSum) treatment.",
+  "meta": {
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/List_of_mathematical_series",
+    "date": "2026-07-02",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "series",
+      "alternating-series",
+      "harmonic-numbers",
+      "partial-fractions",
+      "abel-summation",
+      "logarithm",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/TriangularReciprocalsOQ02OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Antitone.tendsto_alternating_series_of_tendsto_zero",
+        "description": "Alternating series test: for antitone f → 0, the partial sums ∑ (-1)^i f i converge; supplies convergence of the alternating harmonic series to some limit",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Real.tendsto_tsum_powerSeries_nhdsWithin_lt",
+        "description": "Abel's limit theorem for real power series: a series converging at 1 equals the x → 1⁻ boundary limit of its power series; identifies the alternating harmonic limit with log 2",
+        "module": "Mathlib.Analysis.Complex.AbelLimit"
+      },
+      {
+        "theorem": "Real.hasSum_pow_div_log_of_abs_lt_one",
+        "description": "Mercator series ∑ x^{n+1}/(n+1) = -log(1-x) for |x| < 1; at argument -x gives the log(1+x) power series matched inside the tsum",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Deriv"
+      },
+      {
+        "theorem": "Summable.of_norm_bounded",
+        "description": "Comparison test: absolute convergence via a summable dominating series; the gap-k terms are bounded by 1/n²",
+        "module": "Mathlib.Analysis.Normed.Group.InfiniteSum"
+      },
+      {
+        "theorem": "summable_one_div_nat_pow",
+        "description": "The p-series ∑ 1/n^p converges iff p > 1; the p = 2 case is the dominating series",
+        "module": "Mathlib.Analysis.PSeries"
+      },
+      {
+        "theorem": "HasSum.tendsto_sum_nat",
+        "description": "For a summable sequence, the range-N partial sums converge to the tsum; bridges the finite closed form to the infinite sum's value",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Nat"
+      },
+      {
+        "theorem": "Finset.sum_Icc_succ_top",
+        "description": "Peels the top term off an Icc sum; drives the inductions establishing the partial-sum closed form and the reindexing identity",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "tendsto_nhds_unique",
+        "description": "Uniqueness of limits in a Hausdorff space; identifies the tsum value with the limit of the finite closed form",
+        "module": "Mathlib.Topology.Separation.Basic"
+      }
+    ],
+    "originalContributions": [
+      "First Lean 4 formalization of the closed form ∑_{n≥1} (-1)^{n+1}/(n(n+k)) = (1/k)((1-(-1)^k)·log 2 + (-1)^k·A_k) for arbitrary gap k ≥ 1",
+      "Axiom-free proof of the alternating harmonic limit ∑ (-1)^{i}/(i+1) = log 2, via the alternating series test (convergence) plus Abel's limit theorem matched against the Mercator series (value), mirroring Mathlib's Leibniz-series construction for π",
+      "Corrects the sibling TriangularReciprocalAlternatingOQ03, which axiomatized the alternating harmonic value as a HasSum — a statement that is unsound in Mathlib's unconditional-summation sense (the series is only conditionally convergent)",
+      "Reduces the whole evaluation to a finite partial-fraction split plus a single reindexing n ↦ n+k, so no conditionally-convergent series is ever split — only the absolutely convergent full series is summed",
+      "Verified special cases 2·log 2 - 1 (k=1, matching the sibling) and 1/4 (k=2), recovered from the general formula by evaluating A_1 = 1 and A_2 = 1/2"
+    ],
+    "dateAdded": "2026-07-02",
+    "lineCount": 316,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The parent entry (triangular-reciprocals-oq-02) evaluates the positive gap-k series ∑_{n≥1} 1/(n(n+k)) = H_k/k, generalizing Leibniz's 1673 telescoping sum (k=1). Attaching alternating signs changes the arithmetic completely: the telescoping collapse is replaced by two shifted copies of the alternating harmonic series, whose boundary value ∑ (-1)^{n+1}/n = log 2 is the Mercator series (1668) evaluated at the edge of its disk of convergence. The sibling TriangularReciprocalAlternatingOQ03 handled only k=1 and postulated the log 2 value as an axiom, remarking that its justification (Abel's theorem) was 'not yet available in Mathlib.' Abel's limit theorem has since landed in Mathlib (used there for Leibniz's series for π), so this entry proves the alternating harmonic value outright and evaluates the entire gap-k family.",
+    "problemStatement": "**Alternating gap-k reciprocals.** For every integer $k \\ge 1$,\n\n$$\\sum_{n=1}^{\\infty} \\frac{(-1)^{n+1}}{n(n+k)} = \\frac{1}{k}\\Big( \\big(1-(-1)^k\\big)\\log 2 + (-1)^k A_k \\Big), \\qquad A_k = \\sum_{m=1}^{k}\\frac{(-1)^{m+1}}{m}.$$\n\nEquivalently the sum is $A_k/k$ when $k$ is even and $(2\\log 2 - A_k)/k$ when $k$ is odd.",
+    "text": "Evaluates the alternating cousin of the parent's gap-k reciprocal series. Unlike the positive series (which telescopes to a rational multiple of a harmonic number), the alternating series converges to a combination of log 2 and a finite alternating harmonic sum. The transcendental log 2 enters exactly when k is odd.",
+    "proofStrategy": "1. **Analytic input (axiom-free).** Prove ∑_{i<N} (-1)^i/(i+1) → log 2: the alternating series test gives convergence to some l; Abel's limit theorem turns l into lim_{x→1⁻} ∑' (-1)^n x^n/(n+1), which equals lim_{x→1⁻} log(1+x)/x = log 2 by matching the Mercator series and using continuity. 2. **Absolute convergence.** |(-1)^{n+1}/(n(n+k))| ≤ 1/n², so the full series is Summable by comparison with the p=2 series — hence legitimately HasSum. 3. **Finite closed form.** Partial-fraction each finite partial sum: 1/(n(n+k)) = (1/k)(1/n - 1/(n+k)); the 1/n piece gives A_N, and the 1/(n+k) piece reindexes (m = n+k, sign shift (-1)^k) to (-1)^k(A_{N+k} - A_k). 4. **Pass to the limit.** A_N → log 2 and A_{N+k} → log 2, so the finite closed form converges to the stated value; uniqueness of limits identifies it with the tsum.",
+    "keyInsights": [
+      "The alternating series is *absolutely* convergent (dominated by 1/n²), so it genuinely HasSum in Mathlib — but the two pieces it splits into (∑ (-1)^{n+1}/n and its shift) are only conditionally convergent and do NOT HasSum. The proof therefore splits only the finite partial sums, never the infinite series, sidestepping the trap the sibling entry fell into",
+      "Only one transcendental fact is needed: the alternating harmonic limit A_∞ = log 2. Everything else is finite algebra (a partial fraction, an index shift, sign bookkeeping (-1)^{n+k+1} = (-1)^k(-1)^{n+1}) plus limit arithmetic",
+      "A_∞ = log 2 is proved by the same recipe Mathlib uses for Leibniz's π/4 series: alternating series test for convergence, then Abel's limit theorem to evaluate the boundary of the Mercator power series log(1+x) = ∑ (-1)^n x^{n+1}/(n+1)",
+      "The parity of k controls transcendence: for even k the log 2 terms cancel ((1-(-1)^k) = 0) leaving the rational A_k/k, while for odd k a surviving 2 log 2 makes the sum transcendental",
+      "Reindexing by m = n+k on finite Icc sums (via induction and Finset.sum_Icc_succ_top) is more robust than manipulating infinite tsums and keeps the argument entirely within convergent, well-defined objects"
+    ],
+    "prerequisites": [
+      "Real analysis: absolute vs conditional convergence, HasSum/tsum, partial sums",
+      "The Mercator series and Abel's limit theorem",
+      "Alternating harmonic series and the alternating series test",
+      "Partial fractions and finite sum reindexing in Lean 4 Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "alt-harmonic-log2",
+      "title": "The Alternating Harmonic Limit is log 2 (Axiom-Free)",
+      "startLine": 50,
+      "endLine": 140,
+      "summary": "tendsto_altH proves ∑_{i<N} (-1)^i/(i+1) → log 2. The alternating series test (Antitone.tendsto_alternating_series_of_tendsto_zero) gives convergence to some l; Abel's limit theorem (Real.tendsto_tsum_powerSeries_nhdsWithin_lt) rewrites l as the x → 1⁻ limit of the power series, which is matched against the Mercator series Real.hasSum_pow_div_log_of_abs_lt_one to equal log(1+x)/x, tending to log 2 by continuity. tendsto_altH_shift transports the limit along N ↦ N+k.",
+      "mathContext": "$\\sum_{i<N}\\frac{(-1)^i}{i+1} \\to \\log 2$, since $\\sum' \\frac{(-1)^n}{n+1}x^n = \\frac{\\log(1+x)}{x} \\to \\log 2$ as $x \\to 1^-$."
+    },
+    {
+      "id": "finite-algebra",
+      "title": "Partial Fractions and the Reindexing Identity",
+      "startLine": 142,
+      "endLine": 194,
+      "summary": "partial_fraction gives 1/(n(n+k)) = (1/k)(1/n - 1/(n+k)). altH_Icc_eq identifies the 1-based partial sum ∑_{n=1}^N (-1)^{n+1}/n with altH N by induction. shifted_sum_eq reindexes ∑_{n=1}^N (-1)^{n+1}/(n+k) = (-1)^k(altH(N+k) - altH k) by induction on N, with the sign identity (-1)^{n+k+1} = (-1)^k(-1)^{n+1}.",
+      "mathContext": "$\\sum_{n=1}^{N}\\frac{(-1)^{n+1}}{n+k} = (-1)^k\\big(A_{N+k} - A_k\\big)$, where $A_M = \\sum_{i<M}\\frac{(-1)^i}{i+1}$."
+    },
+    {
+      "id": "main-hassum",
+      "title": "Summability and the Closed-Form HasSum",
+      "startLine": 195,
+      "endLine": 284,
+      "summary": "hasSum_alternating_gap_k assembles the result: the terms are bounded by 1/n² (Summable.of_norm_bounded against the p=2 series), the finite partial-sum closed form (1/k)(altH N - (-1)^k(altH(N+k) - altH k)) follows from the partial fraction plus the two Part-II lemmas, and passing N → ∞ (using altH N, altH(N+k) → log 2) together with uniqueness of limits identifies the tsum with the stated closed form.",
+      "mathContext": "$\\sum_{n\\ge1}\\frac{(-1)^{n+1}}{n(n+k)} = \\frac{1}{k}\\big((1-(-1)^k)\\log 2 + (-1)^k A_k\\big)$."
+    },
+    {
+      "id": "special-cases",
+      "title": "Special Cases k = 1 and k = 2",
+      "startLine": 285,
+      "endLine": 316,
+      "summary": "hasSum_gap_one recovers ∑ (-1)^{n+1}/(n(n+1)) = 2·log 2 - 1 (A_1 = 1), matching the sibling's alternating_reciprocal_product_sum. hasSum_gap_two recovers ∑ (-1)^{n+1}/(n(n+2)) = 1/4 (A_2 = 1/2, and the log 2 terms cancel for even k).",
+      "mathContext": "$k=1:\\ 2\\log 2 - 1$;\\quad $k=2:\\ \\tfrac14$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "triangular-reciprocals-oq-02",
+      "relationship": "extends",
+      "description": "The alternating counterpart of the parent's positive gap-k identity ∑ 1/(n(n+k)) = H_k/k. Reuses the same partial-fraction decomposition, but where the parent telescopes to a harmonic number, the alternating signs produce a log 2 / alternating-harmonic combination."
+    },
+    {
+      "targetId": "triangular-reciprocals-oq-02-oq-04",
+      "relationship": "related",
+      "description": "Sibling child of the same parent: oq-02-oq-04 quantifies the truncation error of the positive series, while this entry evaluates the alternating series in closed form. Both hinge on reindexing the shifted partial sum n ↦ n+k."
+    },
+    {
+      "targetId": "triangular-reciprocals",
+      "relationship": "related",
+      "description": "Generalizes the alternating analogue of the classical k=1 triangular reciprocal sum: at k=1 the value is 2·log 2 - 1, the alternating cousin of the classical ∑ 2/(n(n+1)) = 2."
+    }
+  ],
+  "conclusion": {
+    "summary": "The closed form ∑_{n≥1} (-1)^{n+1}/(n(n+k)) = (1/k)((1-(-1)^k)·log 2 + (-1)^k·A_k) is fully verified in Lean 4 (Mathlib v4.26.0) with 0 sorries and 0 axioms (only propext, Classical.choice, Quot.sound). The alternating harmonic value log 2 is proved from Abel's limit theorem rather than assumed.",
+    "implications": "Completes the alternating branch of the gap-k reciprocal family and demonstrates the correct HasSum-safe way to evaluate a conditionally-flavoured series: split only the absolutely convergent whole, never its conditionally convergent parts. The axiom-free treatment of ∑ (-1)^{n+1}/n = log 2 supersedes the sibling's axiom and provides a reusable template for boundary evaluations of power series (log, arctan) via Abel's theorem.",
+    "openQuestions": [
+      "Evaluate the gap-k alternating series with a general phase, ∑ (-1)^{n+1}/((n+a)(n+a+k)) or ∑ ζ^n/(n(n+k)) for a root of unity ζ, tying the value to polylogarithms Li_1 at roots of unity",
+      "Give the asymptotic of the closed form as k → ∞: since A_k → log 2, the sum behaves like ((1-(-1)^k)log 2 + (-1)^k log 2)/k = (log 2)/k + o(1/k) — make the error term explicit"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Filter",
+      "Topology",
+      "Real"
+    ],
+    "namespace": "AlternatingGapKReciprocals",
+    "lineCount": 316,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/TriangularReciprocalsOQ02OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry: a closed form for the **alternating gap-k reciprocal series**. For every integer $k \ge 1$,

$$\sum_{n=1}^{\infty} \frac{(-1)^{n+1}}{n(n+k)} = \frac{1}{k}\Big( (1-(-1)^k)\log 2 + (-1)^k A_k \Big), \qquad A_k = \sum_{m=1}^{k}\frac{(-1)^{m+1}}{m}.$$

Specializes to $2\log 2 - 1$ at $k=1$ and $1/4$ at $k=2$.

This is the alternating counterpart of the parent `triangular-reciprocals-oq-02` (which telescopes the *positive* series to $H_k/k$).

## Why it matters

- **Axiom-free `log 2`.** The alternating harmonic limit $\sum \frac{(-1)^i}{i+1} = \log 2$ is *proved*, not assumed — via the alternating series test (convergence) + **Abel's limit theorem** matched against the Mercator series (value), mirroring Mathlib's `Real.tendsto_sum_pi_div_four` (Leibniz's series for π).
- **Corrects the sibling.** `TriangularReciprocalAlternatingOQ03` axiomatized the value as `HasSum (fun n => (-1)^{n+1}/n) (log 2)` — which is **unsound** in Mathlib, since that series is only *conditionally* convergent and `HasSum` demands unconditional (absolute) convergence. This entry sidesteps the trap: the full gap-k series *is* absolutely convergent (dominated by $1/n^2$), and the proof splits only the **finite** partial sums before taking limits.

## Verification

- Built against Mathlib v4.26.0 (single-file build against the prebuilt olean cache; Docker containerd store was corrupted this session).
- `0` sorries, `0` axioms. `#print axioms hasSum_alternating_gap_k` → `[propext, Classical.choice, Quot.sound]` only.
- 8 theorems, 1 definition, 316 lines.

## Files

- `proofs/Proofs/TriangularReciprocalsOQ02OQ03.lean`
- `src/data/proofs/triangular-reciprocals-oq-02-oq-03/{meta.json,annotations.json,index.ts}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)