### PR TITLE
research(erdos-841-oq-01): constructive definition of t_n, eliminating the parent's axiom [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos841OQ01.lean
+++ b/proofs/Proofs/Erdos841OQ01.lean
@@ -1,0 +1,227 @@
+/-
+Erdős Problem #841 — Open Question 01: A Constructive Definition of t_n
+
+Source: https://erdosproblems.com/841
+Parent entry: Proofs/Erdos841Problem.lean (axiomatizes `t` as an opaque function)
+
+Background:
+Let t_n be minimal such that {n+1,...,n+t_n} contains a subset S with
+n · ∏S a perfect square (with t_n = 0 if n is itself a square).
+
+The parent formalization declares `t` as an `axiom`, with the note:
+  "Axiomatized since the Nat.find formulation requires proving existence."
+The first open question of the parent entry asks precisely:
+
+  "Can the axioms be partially eliminated? The function t itself could
+   potentially be defined via Nat.find if the existence of square-completing
+   subsets were proved constructively — this would reduce the axiom count."
+
+This file answers that open question. We prove the existence of a
+square-completing subset for *every* n by exhibiting an explicit witness,
+and then **define** `t` via `Nat.find` — no axioms.
+
+Key constructive witness:
+  For n ≥ 1, the singleton {4n} ⊆ {n+1,...,n+3n} satisfies
+      n · 4n = 4n² = (2n)²,
+  a perfect square. Hence a square-completing subset always exists and
+      t_n ≤ 3n     for all n ≥ 1.
+  For n = 0 the empty subset works (0 is a square), giving t_0 = 0.
+
+This is a strictly weaker bound than Selfridge's t_n = O(√n) in the smooth
+regime, but it is *unconditional and elementary*, and — crucially — it makes
+`t` a genuine (computable) definition rather than an axiom.
+
+Results (all 0-axiom, machine-checked):
+- `exists_squareSubset`     : existence of a square-completing subset for every n
+- `t`                       : the minimal such interval length, defined via Nat.find
+- `hasSquareSubset_t`       : t n achieves a square-completing subset
+- `t_min`                   : minimality of t n
+- `t_le_three_mul`          : t n ≤ 3n  (universal linear upper bound)
+- `t_eq_zero_iff_isSquare`  : t n = 0 ↔ n is a perfect square
+- `t_six_le_six`            : t_6 ≤ 6, recovering the example 6·8·12 = 24²
+
+Tags: number-theory, square-products, constructive, erdos, axiom-elimination
+-/
+
+import Mathlib
+
+open Finset
+
+namespace Erdos841OQ01
+
+/-!
+## Part 1: Definitions
+
+We mirror the parent entry's setup, but formulate `HasSquareSubset` as a
+*bounded* existential over the powerset of the interval, so that it is
+decidable and `t` can be defined constructively.
+-/
+
+/-- The interval `{n+1, …, n+t}` as a `Finset`. -/
+def interval (n t : ℕ) : Finset ℕ := Finset.Ioc n (n + t)
+
+/-- `S` (a subset of some interval) completes `n` to a perfect square:
+`n · ∏_{s ∈ S} s` is a perfect square. The empty subset gives `n · 1 = n`. -/
+def HasSquareProduct (n : ℕ) (S : Finset ℕ) : Prop :=
+  IsSquare (n * ∏ s ∈ S, s)
+
+/-- Some subset of `{n+1,…,n+t}` completes `n` to a square.
+
+Phrased as a bounded existential over `(interval n t).powerset` so that the
+predicate `fun t => HasSquareSubset n t` is decidable — this is what allows
+`t` to be *defined* by `Nat.find` rather than axiomatized. -/
+def HasSquareSubset (n t : ℕ) : Prop :=
+  ∃ S ∈ (interval n t).powerset, HasSquareProduct n S
+
+instance (n : ℕ) : DecidablePred (HasSquareProduct n) := fun S =>
+  inferInstanceAs (Decidable (IsSquare (n * ∏ s ∈ S, s)))
+
+instance (n t : ℕ) : Decidable (HasSquareSubset n t) := by
+  unfold HasSquareSubset; infer_instance
+
+/-!
+## Part 2: Existence of a square-completing subset
+
+The heart of the axiom elimination: a square-completing subset always exists.
+-/
+
+/-- **Existence.** For every `n`, some interval `{n+1,…,n+t}` contains a
+square-completing subset.
+
+* If `n = 0`, the empty subset already works (`0` is a square).
+* If `n ≥ 1`, the singleton `{4n} ⊆ {n+1,…,n+3n}` works, since
+  `n · 4n = (2n)²`. -/
+theorem exists_squareSubset (n : ℕ) : ∃ t : ℕ, HasSquareSubset n t := by
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · -- n = 0: the empty subset, and 0 = 0² is a square.
+    refine ⟨0, ∅, ?_, ?_⟩
+    · simp
+    · simp [HasSquareProduct]
+  · -- n ≥ 1: the singleton {4n}.
+    refine ⟨3 * n, {4 * n}, ?_, ?_⟩
+    · -- {4n} ⊆ interval n (3n) = Ioc n (n + 3n)
+      simp only [Finset.mem_powerset, Finset.singleton_subset_iff, interval,
+        Finset.mem_Ioc]
+      omega
+    · -- n · 4n = (2n)²
+      simp only [HasSquareProduct, Finset.prod_singleton]
+      exact ⟨2 * n, by ring⟩
+
+/-!
+## Part 3: The constructive definition of `t`
+
+Because `HasSquareSubset n` is a decidable predicate on `ℕ` and
+`exists_squareSubset n` proves it is satisfied, `Nat.find` yields the minimal
+such `t`. This *is* the function the parent entry left as an axiom.
+-/
+
+/-- `t n` — the minimal interval length `t` such that `{n+1,…,n+t}` contains a
+square-completing subset. Defined constructively (no axioms) via `Nat.find`. -/
+def t (n : ℕ) : ℕ := Nat.find (exists_squareSubset n)
+
+/-- `t n` genuinely achieves a square-completing subset. -/
+theorem hasSquareSubset_t (n : ℕ) : HasSquareSubset n (t n) :=
+  Nat.find_spec (exists_squareSubset n)
+
+/-- Minimality: no shorter interval admits a square-completing subset. -/
+theorem t_min {n m : ℕ} (h : m < t n) : ¬ HasSquareSubset n m :=
+  Nat.find_min (exists_squareSubset n) h
+
+/-- `t n ≤ m` whenever `{n+1,…,n+m}` already contains a square-completing
+subset. -/
+theorem t_le_of_hasSquareSubset {n m : ℕ} (h : HasSquareSubset n m) : t n ≤ m :=
+  Nat.find_le h
+
+/-!
+## Part 4: The universal linear upper bound  t_n ≤ 3n
+-/
+
+/-- **Universal upper bound.** `t n ≤ 3n` for all `n ≥ 1`, via the witness
+`{4n}` (and trivially `t 0 = 0 ≤ 0`). In particular `t n` is finite for every
+`n`, so the square-completion process always terminates. -/
+theorem t_le_three_mul (n : ℕ) : t n ≤ 3 * n := by
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · simpa using t_le_of_hasSquareSubset (n := 0) (m := 0) (by
+      exact ⟨∅, by simp, by simp [HasSquareProduct]⟩)
+  · refine t_le_of_hasSquareSubset ?_
+    refine ⟨{4 * n}, ?_, ?_⟩
+    · simp only [Finset.mem_powerset, Finset.singleton_subset_iff, interval,
+        Finset.mem_Ioc]
+      omega
+    · simp only [HasSquareProduct, Finset.prod_singleton]
+      exact ⟨2 * n, by ring⟩
+
+/-!
+## Part 5: t_n = 0 ⟺ n is a perfect square
+-/
+
+/-- If `n` is a perfect square then `t n = 0`: the empty subset completes the
+square immediately. -/
+theorem t_eq_zero_of_isSquare {n : ℕ} (h : IsSquare n) : t n = 0 := by
+  refine Nat.le_zero.mp (t_le_of_hasSquareSubset ?_)
+  refine ⟨∅, by simp, ?_⟩
+  simpa [HasSquareProduct] using h
+
+/-- Conversely, `t n = 0` forces `n` to be a perfect square: an interval of
+length `0` is empty, so the only available subset is `∅`, giving `n · 1 = n`. -/
+theorem isSquare_of_t_eq_zero {n : ℕ} (h : t n = 0) : IsSquare n := by
+  have hspec := hasSquareSubset_t n
+  rw [h] at hspec
+  obtain ⟨S, hS, hsq⟩ := hspec
+  -- interval n 0 = Ioc n n = ∅, so S = ∅.
+  simp only [Finset.mem_powerset, interval, Nat.add_zero, Finset.Ioc_self,
+    Finset.subset_empty] at hS
+  subst hS
+  simpa [HasSquareProduct] using hsq
+
+/-- **Characterization of the base case.** `t n = 0 ↔ n` is a perfect square. -/
+theorem t_eq_zero_iff_isSquare (n : ℕ) : t n = 0 ↔ IsSquare n :=
+  ⟨isSquare_of_t_eq_zero, t_eq_zero_of_isSquare⟩
+
+/-!
+## Part 6: Recovering the example  t_6 ≤ 6
+
+The parent entry records `t_6 = 6` via `6 · 8 · 12 = 24²`. Our elementary
+bound only gives `t_6 ≤ 18`; here we recover the sharper `t_6 ≤ 6` directly
+from the documented subset `{8, 12} ⊆ {7,…,12}`.
+-/
+
+/-- The documented example: `6 · 8 · 12 = 576 = 24²`. -/
+theorem example_six : (6 * ∏ s ∈ ({8, 12} : Finset ℕ), s) = 24 * 24 := by
+  decide
+
+/-- `t 6 ≤ 6`, via the subset `{8, 12} ⊆ {7,8,9,10,11,12}`. -/
+theorem t_six_le_six : t 6 ≤ 6 := by
+  refine t_le_of_hasSquareSubset ?_
+  refine ⟨{8, 12}, ?_, ?_⟩
+  · decide
+  · show IsSquare (6 * ∏ s ∈ ({8, 12} : Finset ℕ), s)
+    rw [example_six]
+    exact ⟨24, rfl⟩
+
+/-!
+## Part 7: Summary
+
+The open question is answered: the existence of square-completing subsets is
+constructive, so `t` need not be axiomatized. We obtain, with **zero axioms**:
+
+* `t : ℕ → ℕ` defined by `Nat.find` (a total, computable function);
+* `t n ≤ 3n` for all `n` (unconditional termination bound);
+* `t n = 0 ↔ IsSquare n` (exact base-case characterization);
+* `t 6 ≤ 6` recovering the classical example.
+
+The deep estimates (`t_n ≥ P(n)`, Selfridge's dichotomy, Bui–Pratt–Zaharescu)
+remain axiomatized in the parent entry — those are genuine open/deep results,
+whereas the *definedness* of `t` was merely a formalization convenience that we
+have now discharged.
+-/
+
+/-- **Master theorem for OQ-01.** `t` is a genuine function (no axioms) with an
+explicit universal bound and exact base-case characterization. -/
+theorem erdos_841_oq01 :
+    (∀ n : ℕ, HasSquareSubset n (t n)) ∧
+    (∀ n : ℕ, t n ≤ 3 * n) ∧
+    (∀ n : ℕ, t n = 0 ↔ IsSquare n) :=
+  ⟨hasSquareSubset_t, t_le_three_mul, t_eq_zero_iff_isSquare⟩
+
+end Erdos841OQ01

--- a/src/data/proofs/erdos-841-oq-01/annotations.json
+++ b/src/data/proofs/erdos-841-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-e841oq01-header",
+    "proofId": "erdos-841-oq-01",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "concept",
+    "title": "The open question: turn the axiom `t` into a definition",
+    "content": "The parent entry erdos-841 declares `axiom t (n : ℕ) : ℕ` with the comment 'Axiomatized since the Nat.find formulation requires proving existence.' Its first open question asks whether t can instead be *defined* by Nat.find, given a constructive proof that a square-completing subset always exists. This file answers yes. The whole difficulty reduces to one elementary fact: n·(4n) = 4n² = (2n)² is always a perfect square, and for n ≥ 1 the element 4n sits inside {n+1,…,n+3n}. So a square-completing subset always exists, and the routine 'definedness' axiom evaporates — while the genuinely deep estimates (Selfridge, Bui–Pratt–Zaharescu) remain properly axiomatized in the parent.",
+    "mathContext": "$n\\cdot 4n = (2n)^2$, and $4n\\in\\{n+1,\\ldots,n+3n\\}$ for $n\\ge 1 \\Rightarrow$ existence for all $n$.",
+    "significance": "key",
+    "relatedConcepts": ["axiom elimination", "Nat.find", "Erdős–Selfridge square-product problem", "constructive existence"],
+    "prerequisites": ["the parent entry erdos-841 and its axiomatized t", "perfect squares"]
+  },
+  {
+    "id": "ann-e841oq01-decidable-setup",
+    "proofId": "erdos-841-oq-01",
+    "range": { "startLine": 53, "endLine": 80 },
+    "type": "technique",
+    "title": "Bounded existential ⇒ decidable predicate",
+    "content": "HasSquareSubset n t is phrased as a *bounded* existential ∃ S ∈ (interval n t).powerset, HasSquareProduct n S — quantifying over the finite powerset of the interval rather than over all Finsets. This is deliberate: a bounded existential over a Finset is decidable whenever the body is, and HasSquareProduct n S ≡ IsSquare (n·∏S) is decidable because Mathlib provides DecidablePred (IsSquare : ℕ → Prop) (via Nat.sqrt). The two instance declarations make `fun t => HasSquareSubset n t` a decidable predicate on ℕ — exactly the hypothesis Nat.find needs. Without the boundedness, the existential over the infinite type Finset ℕ would not be decidable and Nat.find would not apply.",
+    "mathContext": "$\\text{HasSquareSubset}(n,t)\\equiv\\exists S\\in\\mathcal P(\\{n+1,\\ldots,n+t\\}),\\ \\text{IsSquare}(n\\cdot\\textstyle\\prod S)$, a decidable proposition.",
+    "significance": "key",
+    "relatedConcepts": ["decidability", "bounded existential", "Finset.powerset", "IsSquare decidability", "Nat.sqrt"],
+    "prerequisites": ["decidable predicates", "Finset membership and powersets"]
+  },
+  {
+    "id": "ann-e841oq01-existence",
+    "proofId": "erdos-841-oq-01",
+    "range": { "startLine": 83, "endLine": 109 },
+    "type": "insight",
+    "title": "The witness {4n} — the heart of the axiom elimination",
+    "content": "exists_squareSubset is the theorem the parent lacked. Case n = 0: the empty subset works because 0 = 0² is a square (n·∏∅ = 0·1 = 0). Case n ≥ 1: take S = {4n}. Membership 4n ∈ Ioc n (n + 3n) unfolds to n < 4n ∧ 4n ≤ 4n, dispatched by omega using n ≥ 1. The square condition is IsSquare (n·∏{4n}) = IsSquare (n·4n), witnessed explicitly by ⟨2n, by ring⟩ since n·4n = (2n)·(2n). This elementary one-element witness is all that is needed to make t well-defined — no sieve theory, no smooth/rough dichotomy, no largest-prime-factor analysis.",
+    "mathContext": "$S=\\{4n\\}$: $n\\cdot 4n = 4n^2 = (2n)(2n)$, so $\\text{IsSquare}(n\\cdot 4n)$ with witness $2n$.",
+    "significance": "key",
+    "relatedConcepts": ["explicit witness", "IsSquare", "omega", "interval membership"],
+    "prerequisites": ["Finset.Ioc and Finset.mem_Ioc", "Finset.prod_singleton", "the definition of IsSquare as ∃ r, a = r*r"]
+  },
+  {
+    "id": "ann-e841oq01-def-t",
+    "proofId": "erdos-841-oq-01",
+    "range": { "startLine": 111, "endLine": 137 },
+    "type": "technique",
+    "title": "Defining t by Nat.find and reading off its API",
+    "content": "With the predicate decidable (from the instances above) and existence proved (exists_squareSubset), `t n := Nat.find (exists_squareSubset n)` is a genuine, total, computable function — this single line is what the parent could only write as an axiom. The rest of Part 3 exposes the standard Nat.find interface specialized to t: hasSquareSubset_t = Nat.find_spec (t n really does admit a square-completing subset), t_min = Nat.find_min (no strictly smaller interval works — minimality), and t_le_of_hasSquareSubset = Nat.find_le (any explicit witnessing interval bounds t from above). These three lemmas are the workhorses for everything downstream.",
+    "mathContext": "$t(n)=\\min\\{t:\\text{HasSquareSubset}(n,t)\\}$; $\\text{Nat.find\\_le}: \\text{HasSquareSubset}(n,m)\\Rightarrow t(n)\\le m$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.find", "Nat.find_spec", "Nat.find_min", "Nat.find_le", "least element of a decidable predicate"],
+    "prerequisites": ["the decidability instances", "exists_squareSubset"]
+  },
+  {
+    "id": "ann-e841oq01-bounds",
+    "proofId": "erdos-841-oq-01",
+    "range": { "startLine": 136, "endLine": 180 },
+    "type": "insight",
+    "title": "Universal bound t_n ≤ 3n and the base case t_n = 0 ⟺ n a square",
+    "content": "t_le_three_mul feeds the {4n} witness into t_le_of_hasSquareSubset, giving t_n ≤ 3n for all n (with n = 0 handled by the empty-subset witness). This is unconditional — far weaker than Selfridge's conditional O(√n), but it needs no hypotheses and certifies that the square-completion search always halts. t_eq_zero_iff_isSquare characterizes the base case in both directions: if n is a square, the empty subset realizes HasSquareSubset n 0 so t_n = 0; conversely if t_n = 0 then the achieving interval Ioc n n is empty, forcing S = ∅ and hence n·1 = n a square. This exact characterization is something the axiomatized parent could only assert as a comment.",
+    "mathContext": "$t_n\\le 3n$ for all $n$; $t_n = 0 \\iff \\exists m,\\ n=m^2$.",
+    "significance": "important",
+    "relatedConcepts": ["unconditional upper bound", "termination", "empty product", "perfect square characterization"],
+    "prerequisites": ["t_le_of_hasSquareSubset", "Finset.Ioc_self", "Finset.subset_empty"]
+  },
+  {
+    "id": "ann-e841oq01-example",
+    "proofId": "erdos-841-oq-01",
+    "range": { "startLine": 182, "endLine": 201 },
+    "type": "concept",
+    "title": "Recovering the classical example t_6 ≤ 6",
+    "content": "The parent records t_6 = 6 via 6·8·12 = 24². Our generic bound only gives t_6 ≤ 18, so this section sharpens it directly: example_six verifies 6·∏{8,12} = 24·24 by kernel `decide`, and t_six_le_six applies t_le_of_hasSquareSubset to the subset {8,12} ⊆ {7,…,12}, giving t_6 ≤ 6. Note the deliberate use of `decide` (kernel reduction) rather than `native_decide`: `native_decide` would introduce the `Lean.ofReduceBool` axiom, whereas `decide` keeps the file dependent only on the three foundational axioms — the whole entry stays genuinely axiom-free (`#print axioms` confirms [propext, Classical.choice, Quot.sound]).",
+    "mathContext": "$6\\cdot 8\\cdot 12 = 576 = 24^2$, with $\\{8,12\\}\\subseteq\\{7,\\ldots,12\\}\\Rightarrow t_6\\le 6$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide vs native_decide", "Lean.ofReduceBool", "axiom hygiene", "worked example"],
+    "prerequisites": ["kernel decidability", "Finset.prod over an explicit pair"]
+  }
+]

--- a/src/data/proofs/erdos-841-oq-01/meta.json
+++ b/src/data/proofs/erdos-841-oq-01/meta.json
@@ -1,0 +1,216 @@
+{
+  "id": "erdos-841-oq-01",
+  "slug": "erdos-841-oq-01",
+  "title": "Erdős #841 — A Constructive Definition of t_n (Axiom Elimination)",
+  "description": "The parent entry erdos-841 declares the square-completion function t_n as an axiom, noting 'the Nat.find formulation requires proving existence.' Its first open question asks whether t could instead be *defined* via Nat.find by proving constructively that a square-completing subset always exists — reducing the axiom count. This entry answers that question. We prove that for every n there is a subset S of some interval {n+1,…,n+t} with n·∏S a perfect square, via the explicit witness {4n}: n·4n = (2n)². We then define t : ℕ → ℕ by Nat.find (no axioms), and derive the universal linear bound t_n ≤ 3n, the exact base-case characterization t_n = 0 ↔ n is a perfect square, and t_6 ≤ 6 recovering the classical example 6·8·12 = 24². Verified, axiom-free, sorry-free.",
+  "overview": {
+    "historicalContext": "**From axiom to definition.** Erdős Problem #841 asks to estimate $t_n$, the least $t$ such that $\\{n+1,\\ldots,n+t\\}$ contains a subset $S$ with $n\\cdot\\prod S$ a perfect square (with $t_n=0$ when $n$ is itself a square). The deep answer — Selfridge's dichotomy $t_n = P(n)$ for rough $n$ versus $t_n = O(\\sqrt n)$ for smooth $n$, refined by Bui–Pratt–Zaharescu (2024) to a full distributional equivalence with the largest prime factor — is captured in the parent gallery entry erdos-841 through four axioms.\n\nOne of those four axioms, however, is not a deep theorem but a *formalization convenience*: the function $t$ itself is declared `axiom t (n : ℕ) : ℕ`, with the source comment 'Axiomatized since the Nat.find formulation requires proving existence.' The very existence of a finite square-completing interval was left unproved, so $t$ could not be defined by `Nat.find`. The parent's first open question asks whether this can be repaired.\n\nThis entry repairs it. The key observation is elementary: $n\\cdot(4n) = 4n^2 = (2n)^2$ is always a perfect square, and for $n\\ge 1$ the single element $4n$ lies in the interval $\\{n+1,\\ldots,n+3n\\}$. So a square-completing subset always exists, $t$ is a genuine total function, and the (routine) axiom disappears.",
+    "problemStatement": "**Goal (parent open question OQ-01).** Eliminate the axiomatization of $t$ in Erdős #841 by proving constructively that a square-completing subset exists for every $n$, so that $t$ can be *defined* via `Nat.find`.\n\n**Delivered:** a self-contained, axiom-free development that (i) proves existence via the witness $\\{4n\\}$, (ii) defines $t : \\mathbb{N}\\to\\mathbb{N}$ by `Nat.find`, and (iii) establishes $t_n \\le 3n$ and $t_n = 0 \\iff n$ is a perfect square.",
+    "text": "Answers the first open question of Erdős #841: proves that a square-completing subset always exists (witness {4n}, since n·4n=(2n)²), defines t via Nat.find with zero axioms, and derives t_n ≤ 3n and t_n = 0 ↔ IsSquare n.",
+    "proofStrategy": "**Approach**\n\n1. Formulate `HasSquareSubset n t` as a *bounded* existential over `(interval n t).powerset`, making the predicate `fun t => HasSquareSubset n t` decidable — the precondition for `Nat.find`.\n2. Prove `exists_squareSubset n : ∃ t, HasSquareSubset n t`. For n = 0 the empty subset works (0 is a square); for n ≥ 1 the singleton {4n} ⊆ Ioc n (n+3n) works because n·4n = (2n)². Membership 4n ∈ Ioc n (4n) is `omega`; the square is the explicit witness ⟨2n, by ring⟩.\n3. Define `t n := Nat.find (exists_squareSubset n)` — a total, computable function, no axioms.\n4. Read off the Nat.find API: `hasSquareSubset_t` (t achieves a subset), `t_min` (minimality), `t_le_of_hasSquareSubset` (upper bounds from witnesses).\n5. `t_le_three_mul`: apply `t_le_of_hasSquareSubset` to the {4n} witness, giving t_n ≤ 3n.\n6. `t_eq_zero_iff_isSquare`: forward, an interval of length 0 is empty so the only subset is ∅, giving n·1 = n a square; backward, ∅ realizes HasSquareSubset n 0 when n is a square.\n7. `t_six_le_six`: the documented subset {8,12} ⊆ {7,…,12} with 6·8·12 = 576 = 24² (kernel `decide`, not `native_decide`, so no `Lean.ofReduceBool`).",
+    "keyInsights": [
+      "**A one-element witness kills the existence problem.** The identity n·(4n) = (2n)² means the singleton {4n} always completes n to a square. Because 4n lies within {n+1,…,n+3n} for every n ≥ 1, existence is immediate and completely elementary — no sieve theory, no smooth/rough dichotomy.",
+      "**Definedness was never the hard part.** The parent axiomatized t because it never proved existence, not because existence is deep. Separating the *definedness* of t (routine, discharged here) from the deep *estimates* on t (Selfridge, Bui–Pratt–Zaharescu, which remain axiomatized) is the right conceptual split; this entry removes exactly the routine axiom.",
+      "**Bounded existential ⇒ decidable ⇒ Nat.find.** Phrasing 'some subset of the interval works' as a bounded existential over the finite powerset makes the predicate decidable (IsSquare is decidable on ℕ), which is precisely what lets Nat.find turn the existence proof into a computable, total t.",
+      "**t_n ≤ 3n is unconditional.** Selfridge's O(√n) bound is far sharper but conditional on smoothness; the linear bound t_n ≤ 3n holds for every n with a two-line proof and certifies that the square-completion search always terminates.",
+      "**The base case is exactly the squares.** t_n = 0 ⟺ n is a perfect square, proved in both directions from the empty-subset convention — a clean, total characterization that the axiomatized parent could only assert."
+    ],
+    "prerequisites": [
+      "The definition of t_n and the setup of Erdős #841 (parent entry erdos-841)",
+      "Nat.find and its API (find_spec, find_le, find_min) for decidable predicates on ℕ",
+      "IsSquare on ℕ and its decidability instance",
+      "Finset intervals (Finset.Ioc) and powersets, and bounded existentials over Finsets"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "exists_squareSubset",
+      "type": "core",
+      "description": "For every n, some interval {n+1,…,n+t} contains a subset S with n·∏S a perfect square — the existence that the parent left unproved. Witness: {4n} for n≥1 (n·4n=(2n)²), ∅ for n=0.",
+      "leanType": "∀ (n : ℕ), ∃ t : ℕ, HasSquareSubset n t"
+    },
+    {
+      "name": "t",
+      "type": "core",
+      "description": "The square-completion function t_n, DEFINED via Nat.find (no axiom). Total and computable.",
+      "leanType": "ℕ → ℕ"
+    },
+    {
+      "name": "t_le_three_mul",
+      "type": "core",
+      "description": "Universal linear upper bound: t_n ≤ 3n for all n (via the witness {4n}), so the process always terminates.",
+      "leanType": "∀ (n : ℕ), t n ≤ 3 * n"
+    },
+    {
+      "name": "t_eq_zero_iff_isSquare",
+      "type": "core",
+      "description": "Exact base-case characterization: t_n = 0 if and only if n is a perfect square.",
+      "leanType": "∀ (n : ℕ), t n = 0 ↔ IsSquare n"
+    },
+    {
+      "name": "t_six_le_six",
+      "type": "corollary",
+      "description": "Recovers the classical example: t_6 ≤ 6 via {8,12} ⊆ {7,…,12} with 6·8·12 = 24².",
+      "leanType": "t 6 ≤ 6"
+    }
+  ],
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions: interval, HasSquareProduct, HasSquareSubset",
+      "startLine": 53,
+      "endLine": 80,
+      "summary": "Mirrors the parent's setup but phrases HasSquareSubset as a bounded existential over (interval n t).powerset, and supplies the decidability instances (IsSquare on ℕ is decidable), so the predicate fun t => HasSquareSubset n t is decidable.",
+      "mathContext": "$\\text{interval}(n,t)=\\{n+1,\\ldots,n+t\\}$; $\\text{HasSquareSubset}(n,t)\\equiv\\exists S\\subseteq\\text{interval}(n,t),\\ \\text{IsSquare}(n\\cdot\\textstyle\\prod S)$."
+    },
+    {
+      "id": "existence",
+      "title": "Existence of a Square-Completing Subset",
+      "startLine": 83,
+      "endLine": 109,
+      "summary": "exists_squareSubset: for n=0 the empty subset works (0 is a square); for n≥1 the singleton {4n} ⊆ Ioc n (n+3n) works since n·4n = (2n)². This is the crux that removes the parent's axiom.",
+      "mathContext": "$n\\cdot 4n = 4n^2 = (2n)^2$, and $4n\\in\\{n+1,\\ldots,n+3n\\}$ for $n\\ge 1$."
+    },
+    {
+      "id": "definition-of-t",
+      "title": "The Constructive Definition of t",
+      "startLine": 111,
+      "endLine": 137,
+      "summary": "t n := Nat.find (exists_squareSubset n) — a total, computable function, no axioms. Records the Nat.find API: hasSquareSubset_t (achievability), t_min (minimality), t_le_of_hasSquareSubset (upper bounds from witnesses).",
+      "mathContext": "$t(n) = \\min\\{t : \\text{HasSquareSubset}(n,t)\\}$, well-defined by the existence proof."
+    },
+    {
+      "id": "upper-bound",
+      "title": "The Universal Linear Upper Bound t_n ≤ 3n",
+      "startLine": 136,
+      "endLine": 154,
+      "summary": "t_le_three_mul: applying t_le_of_hasSquareSubset to the {4n} witness gives t_n ≤ 3n for all n. Unconditional (unlike Selfridge's sharper O(√n)), and certifies termination.",
+      "mathContext": "$t_n \\le 3n$ for all $n$."
+    },
+    {
+      "id": "base-case",
+      "title": "Base Case: t_n = 0 ⟺ n is a Perfect Square",
+      "startLine": 155,
+      "endLine": 180,
+      "summary": "t_eq_zero_of_isSquare and isSquare_of_t_eq_zero combine into t_eq_zero_iff_isSquare. Forward: interval of length 0 is empty, only subset ∅, giving n·1 = n a square. Backward: ∅ realizes HasSquareSubset n 0.",
+      "mathContext": "$t_n = 0 \\iff \\exists m,\\ n = m^2$."
+    },
+    {
+      "id": "example",
+      "title": "Recovering the Example t_6 ≤ 6",
+      "startLine": 182,
+      "endLine": 201,
+      "summary": "example_six (6·8·12 = 24²) and t_six_le_six via {8,12} ⊆ {7,…,12}. Uses kernel decide (not native_decide), so no Lean.ofReduceBool axiom is introduced.",
+      "mathContext": "$6\\cdot 8\\cdot 12 = 576 = 24^2$; $\\{8,12\\}\\subseteq\\{7,\\ldots,12\\}$, so $t_6\\le 6$."
+    },
+    {
+      "id": "summary",
+      "title": "Master Theorem",
+      "startLine": 203,
+      "endLine": 227,
+      "summary": "erdos_841_oq01 bundles the three headline facts: t achieves a square-completing subset everywhere, t_n ≤ 3n, and t_n = 0 ↔ IsSquare n — all with zero axioms.",
+      "mathContext": "$t$ is a genuine (axiom-free) function with $t_n\\le 3n$ and $t_n=0\\iff n$ a square."
+    }
+  ],
+  "conclusion": {
+    "summary": "Answers the first open question of Erdős #841: the existence of a square-completing subset is proved constructively (witness {4n}, since n·4n = (2n)²), so the parent's `axiom t` is replaced by a genuine, computable definition t := Nat.find. Along the way we obtain the unconditional bound t_n ≤ 3n and the exact base-case characterization t_n = 0 ↔ n is a perfect square, and we recover the classical example t_6 ≤ 6. Fully verified, axiom-free, sorry-free.",
+    "implications": "Reduces the assumption footprint of the Erdős #841 formalization by discharging its one *routine* axiom (the definedness of t) while leaving the genuinely deep estimates — Selfridge's dichotomy and the Bui–Pratt–Zaharescu distributional theorem — clearly separated as the content still worth axiomatizing. It demonstrates the general principle that a Nat.find-defined extremal quantity only needs an existence witness to become a first-class definition, and that a trivial algebraic witness (n·4n = (2n)²) can suffice even when the sharp value is governed by deep number theory.",
+    "openQuestions": [
+      "Can the sharp value t_6 = 6 (equality, not just ≤ 6) be proved by evaluating the now-computable t at 6, i.e. by `decide`/`Nat.find` reduction, without a separate lower-bound argument?",
+      "Prove the trivial lower bound t_n ≥ P(n) constructively for the DEFINED t (the parent axiomatizes it): if p = P(n) divides n to an odd power, any square-completing subset must contain a multiple of p, forcing t_n ≥ p.",
+      "Extend the constructive definition to the k-th-power analog t_n^{(k)} (least interval whose subset makes n·∏S a perfect k-th power); the witness (k^k · n^{k-1})·n = (k n)^k generalizes {4n}.",
+      "Sharpen the universal upper bound from the crude t_n ≤ 3n toward Selfridge's O(√n) in the smooth regime, staying axiom-free for explicit smoothness hypotheses."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-841",
+      "relationship": "completes",
+      "description": "Answers the parent's first open question by replacing its `axiom t` with a constructive Nat.find definition, proving the existence the parent left unproved and adding the unconditional bound t_n ≤ 3n."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "R. K. Guy"
+      ],
+      "title": "Unsolved Problems in Number Theory (Section B30)",
+      "year": "2004",
+      "note": "Erdős–Selfridge square-product problem and the role of the largest prime factor P(n)"
+    },
+    {
+      "authors": [
+        "H. M. Bui",
+        "K. Pratt",
+        "A. Zaharescu"
+      ],
+      "title": "On the distribution of t_n",
+      "year": "2024",
+      "note": "Distributional equivalence of t_n with the largest prime factor; the deep results axiomatized in the parent entry"
+    }
+  ],
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/841",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos841OQ01.lean",
+    "tags": [
+      "number-theory",
+      "square-products",
+      "constructive",
+      "axiom-elimination",
+      "erdos",
+      "nat-find",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All results depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound); there are no axiom declarations, no sorries, and no structure-encoded assumptions. The example t_6 ≤ 6 is closed by kernel `decide` (not `native_decide`), so no `Lean.ofReduceBool` is introduced (`#print axioms` confirms only the three foundational axioms). This entry is self-contained (it re-declares the interval/HasSquareProduct/HasSquareSubset setup rather than importing the parent's axiomatized file) and depends only on Mathlib.",
+    "erdosNumber": 841,
+    "erdosUrl": "https://erdosproblems.com/841",
+    "lineCount": 227,
+    "theoremCount": 11,
+    "definitionCount": 4
+  },
+  "leanFile": {
+    "path": "Proofs/Erdos841OQ01.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos841OQ01",
+    "lineCount": 227,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 4,
+    "sorries": 0,
+    "mainTheorems": [
+      {
+        "name": "exists_squareSubset",
+        "type": "core",
+        "statement": "∀ (n : ℕ), ∃ t : ℕ, HasSquareSubset n t",
+        "description": "A square-completing subset exists for every n — the existence the parent axiomatized around.",
+        "significance": "Removes the parent's `axiom t` by making Nat.find applicable; witness {4n} since n·4n = (2n)²"
+      },
+      {
+        "name": "t_le_three_mul",
+        "type": "core",
+        "statement": "∀ (n : ℕ), t n ≤ 3 * n",
+        "description": "Universal, unconditional linear upper bound on the square-completion length.",
+        "significance": "Certifies termination of the search; sharper than nothing, weaker than Selfridge's conditional O(√n)"
+      },
+      {
+        "name": "t_eq_zero_iff_isSquare",
+        "type": "core",
+        "statement": "∀ (n : ℕ), t n = 0 ↔ IsSquare n",
+        "description": "The base case is exactly the perfect squares.",
+        "significance": "Exact characterization the axiomatized parent could only assert as a comment"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the Erdős #841 gallery entry. The parent (`erdos-841`) declares the square-completion function `t_n` as an `axiom`, with the note *"Axiomatized since the Nat.find formulation requires proving existence."* Its open question asks:

> *Can the axioms be partially eliminated? The function `t` itself could potentially be defined via `Nat.find` if the existence of square-completing subsets were proved constructively — this would reduce the axiom count.*

This entry does exactly that. The whole difficulty reduces to one elementary fact: **n · 4n = 4n² = (2n)²** is always a perfect square, and for n ≥ 1 the element 4n lies in {n+1, …, n+3n}. So a square-completing subset always exists, and `t` becomes a genuine (computable) definition instead of an axiom.

## Results (all 0-axiom, sorry-free)

| Theorem | Statement |
|---|---|
| `exists_squareSubset` | ∀ n, ∃ t, HasSquareSubset n t — the existence the parent left unproved |
| `t` | ℕ → ℕ, **defined** via `Nat.find` (no axiom) |
| `t_le_three_mul` | t n ≤ 3n — universal, unconditional bound |
| `t_eq_zero_iff_isSquare` | t n = 0 ↔ n is a perfect square |
| `t_six_le_six` | recovers the classical example 6·8·12 = 24² |

## Verification

- `#print axioms erdos_841_oq01` = `[propext, Classical.choice, Quot.sound]` — the three foundational axioms only.
- The example `t_6 ≤ 6` uses **kernel `decide`**, not `native_decide`, so **no `Lean.ofReduceBool`** is introduced.
- Verified via `lake env lean` against the built Mathlib (docker unavailable; disk-constrained host).
- 11 theorems, 4 definitions, 227 lines; self-contained (re-declares the interval/HasSquareProduct setup rather than importing the parent's axiomatized file).

## Scope

Only the **routine** 'definedness' axiom is discharged. The genuinely deep estimates — Selfridge's dichotomy and the Bui–Pratt–Zaharescu distributional theorem — remain axiomatized in the parent, which is the correct place for them.

New gallery entry: `src/data/proofs/erdos-841-oq-01/` (meta.json + 6 annotations).