### PR TITLE
Enrich burnside-counting-oq-06-oq-01: add annotations (0→8)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-06-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header-overview",
+    "proofId": "burnside-counting-oq-06-oq-01",
+    "range": { "startLine": 5, "endLine": 46 },
+    "type": "context",
+    "title": "From the prime case to an arbitrary modulus",
+    "content": "The module docstring frames the whole file. The parent entry specializes the divisor-form necklace count (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d to a prime length n = p, where the sum collapses to φ(p)·k + k^p and yields Fermat's p ∣ k^p − k. This companion reads the same equation as a congruence at every modulus. The final paragraph is an honesty note: the congruence proved here is the totient (Gauss-type) necklace congruence, a genuine Fermat generalization that the rotation orbit count actually produces — deliberately not overclaimed as Euler's theorem k^{φ(n)} ≡ 1, which needs gcd(k,n) = 1 and does not follow from the orbit count alone.",
+    "mathContext": "$(\\#\\text{necklaces})\\cdot n = \\sum_{d\\mid n}\\varphi(n/d)\\,k^{d}\\ \\Longrightarrow\\ n \\mid \\sum_{d\\mid n}\\varphi(n/d)\\,k^{d}$",
+    "significance": "context",
+    "relatedConcepts": ["necklace counting", "Fermat's little theorem", "Euler's theorem", "Gauss totient congruence", "orbit counting"],
+    "prerequisites": ["cyclic group actions", "Burnside's lemma", "Euler totient function"]
+  },
+  {
+    "id": "ann-imports-opens",
+    "proofId": "burnside-counting-oq-06-oq-01",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "technique",
+    "title": "Reusing the parent Burnside branch",
+    "content": "The file imports the parent BurnsideCountingOQ06 (the prime Fermat collapse) and BurnsideCountingOQ03OQ02OQ01OQ02 (which supplies the divisor-form count card_necklaces_mul_eq_sum_divisors). The `open ... (Rot)` and `open ... (card_necklaces_mul_eq_sum_divisors)` selectively bring in exactly the rotation-action type and the one equation this file leverages, keeping the namespace clean. No new combinatorial machinery is built here — the entire number-theoretic payoff is extracted from an already-proven equation between an integer product and a divisor sum.",
+    "mathContext": "$\\text{Rot}\\,n \\curvearrowright (\\text{Rot}\\,n \\to \\mathrm{Fin}\\,k)$",
+    "significance": "technical",
+    "relatedConcepts": ["cyclic rotation action", "necklace = colouring up to rotation", "module reuse"],
+    "prerequisites": ["Lean namespaces and selective open", "MulAction"]
+  },
+  {
+    "id": "ann-totient-divisor-sum-dvd",
+    "proofId": "burnside-counting-oq-06-oq-01",
+    "range": { "startLine": 54, "endLine": 62 },
+    "type": "insight",
+    "title": "The general totient necklace divisibility",
+    "content": "The keystone result. For every n ≥ 1 and k, n divides the totient-weighted divisor sum ∑_{d∣n} φ(n/d)·k^d. The proof is a single move: exhibit the number of necklaces Nat.card(orbitRel.Quotient …) as the explicit quotient, since the parent's identity says (#necklaces)·n equals that sum. `refine ⟨Nat.card …, ?_⟩` provides the witness, then rewriting by the parent equation and Nat.mul_comm discharges the goal. The whole content is that an orbit count is an integer — everything downstream is specialization.",
+    "mathContext": "$n \\mid \\sum_{d\\mid n}\\varphi(n/d)\\,k^{d},\\quad \\text{witness } = \\#\\{k\\text{-colored }n\\text{-necklaces}\\}$",
+    "significance": "key",
+    "relatedConcepts": ["divisibility as existence of quotient", "orbit-counting theorem", "integrality argument"],
+    "prerequisites": ["Nat.card of a quotient by a group action", "Dvd.intro / anonymous constructor for divisibility"]
+  },
+  {
+    "id": "ann-totient-divisor-sum-modeq",
+    "proofId": "burnside-counting-oq-06-oq-01",
+    "range": { "startLine": 64, "endLine": 68 },
+    "type": "technique",
+    "title": "Repackaging as a ModEq congruence",
+    "content": "Restates the divisibility in Nat.ModEq form: ∑_{d∣n} φ(n/d)·k^d ≡ 0 [MOD n]. The bridge is Nat.modEq_zero_iff_dvd (a ≡ 0 [MOD n] ↔ n ∣ a), after which the previous theorem closes the goal directly. This ModEq phrasing is the shape that composes with congruence arithmetic and matches how the classical Gauss/Fermat statements are usually written.",
+    "mathContext": "$\\sum_{d\\mid n}\\varphi(n/d)\\,k^{d}\\equiv 0 \\pmod n$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.ModEq", "divisibility ↔ congruence to zero"],
+    "prerequisites": ["modular arithmetic in ℕ"]
+  },
+  {
+    "id": "ann-sum-divisors-prime-pow-eq",
+    "proofId": "burnside-counting-oq-06-oq-01",
+    "range": { "startLine": 70, "endLine": 79 },
+    "type": "insight",
+    "title": "Reindexing the prime-power divisor sum over exponents",
+    "content": "For a prime power p^a the divisor lattice is a chain 1 ∣ p ∣ p² ∣ … ∣ p^a, so the sum over divisors becomes a sum over exponents. Nat.sum_divisors_prime_pow rewrites ∑_{d∣p^a} f(d) as ∑_{i=0}^{a} f(p^i); then a termwise Finset.sum_congr applies Nat.pow_div to evaluate the complementary divisor p^a / p^i = p^{a−i} (valid because i ≤ a on range(a+1), extracted via Nat.lt_succ_iff and Finset.mem_range). The result is the clean single sum ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i}.",
+    "mathContext": "$\\sum_{d\\mid p^{a}}\\varphi(p^{a}/d)\\,k^{d}=\\sum_{i=0}^{a}\\varphi(p^{a-i})\\,k^{p^{i}}$",
+    "significance": "key",
+    "relatedConcepts": ["divisors of a prime power", "chain of divisors", "reindexing a finite sum"],
+    "prerequisites": ["Nat.sum_divisors_prime_pow", "Nat.pow_div", "Finset.sum_congr"]
+  },
+  {
+    "id": "ann-totient-prime-pow-sum-dvd",
+    "proofId": "burnside-counting-oq-06-oq-01",
+    "range": { "startLine": 81, "endLine": 95 },
+    "type": "concept",
+    "title": "The prime-power modulus congruence",
+    "content": "Instantiating the general congruence at n = p^a (with NeZero p^a supplied from p prime via pow_ne_zero) and rewriting the divisor sum by the reindexing lemma gives p^a ∣ ∑_{i=0}^{a} φ(p^{a−i})·k^{p^i}. The companion totient_prime_pow_sum_modEq states the same fact in Nat.ModEq form. This is a concrete higher-modulus Gauss congruence expressed purely in terms of exponents of p.",
+    "mathContext": "$p^{a}\\mid \\sum_{i=0}^{a}\\varphi(p^{a-i})\\,k^{p^{i}}$",
+    "significance": "key",
+    "relatedConcepts": ["prime-power modulus", "specialization of a general congruence", "NeZero instance"],
+    "prerequisites": ["pow_ne_zero", "typeclass instance for NeZero (p^a)"]
+  },
+  {
+    "id": "ann-totient-prime-pow-leading-dvd",
+    "proofId": "burnside-counting-oq-06-oq-01",
+    "range": { "startLine": 97, "endLine": 105 },
+    "type": "insight",
+    "title": "Isolating the leading term: the Fermat shape",
+    "content": "Finset.sum_range_succ splits off the top exponent i = a. Its term is φ(p^{a−a})·k^{p^a} = φ(p^0)·k^{p^a} = φ(1)·k^{p^a} = k^{p^a}, simplified via Nat.sub_self, pow_zero, Nat.totient_one, and one_mul. What remains is the Fermat-shaped p^a ∣ (∑_{i<a} φ(p^{a−i})·k^{p^i}) + k^{p^a}. At a = 1 the head sum is φ(p)·k, so this is exactly Fermat's p ∣ (p−1)k + k^p; for a ≥ 2 it is the higher-modulus analogue with a totient-weighted correction over the lower p-power exponents.",
+    "mathContext": "$p^{a}\\mid \\Big(\\sum_{i<a}\\varphi(p^{a-i})\\,k^{p^{i}}\\Big)+k^{p^{a}}$",
+    "significance": "key",
+    "relatedConcepts": ["Fermat's little theorem", "leading term isolation", "φ(1) = 1"],
+    "prerequisites": ["Finset.sum_range_succ", "Nat.totient_one", "pow_zero"]
+  },
+  {
+    "id": "ann-prime-pow-sum-one",
+    "proofId": "burnside-counting-oq-06-oq-01",
+    "range": { "startLine": 107, "endLine": 114 },
+    "type": "context",
+    "title": "Consistency check at a = 1",
+    "content": "A degeneration test: at a = 1 the exponent sum ∑_{i=0}^{1} φ(p^{1−i})·k^{p^i} evaluates to φ(p)·k + k^p, the exact right-hand side of the parent's BurnsideCountingOQ06.necklaces_mul_prime_eq. The proof is a one-line `simp [Finset.sum_range_succ, Nat.totient_one]`. Combined with totient_prime_pow_sum_dvd p 1 k hp this recovers p ∣ φ(p)·k + k^p, confirming the general prime-power machinery collapses correctly to the parent's prime case.",
+    "mathContext": "$\\sum_{i=0}^{1}\\varphi(p^{1-i})\\,k^{p^{i}}=\\varphi(p)\\cdot k + k^{p}$",
+    "significance": "supporting",
+    "relatedConcepts": ["degeneration / sanity check", "consistency with parent theorem"],
+    "prerequisites": ["Finset.sum_range_succ", "simp normalization"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-06-oq-01` (The Totient Necklace Congruence at Arbitrary Modulus).

## Gap
The entry had a rich `meta.json` (18.6 KB — full overview, sections, references, conclusion) but **no `annotations.json`** — zero inline annotation coverage.

## Change
Adds `annotations.json` with **8 annotations** covering the full 116-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. Header + honesty note (prime case → arbitrary modulus; totient/Gauss vs Euler)
2. Imports/opens (reuse of the parent Burnside branch)
3. `totient_divisor_sum_dvd` — the general totient necklace divisibility (keystone)
4. `totient_divisor_sum_modEq` — ModEq form
5. `sum_divisors_prime_pow_eq` — reindexing over exponents
6. `totient_prime_pow_sum_dvd` — prime-power modulus congruence
7. `totient_prime_pow_leading_dvd` — Fermat-shaped leading term
8. `prime_pow_sum_one` — a = 1 consistency check

Annotation ranges verified against the Lean source (max endLine 114 ≤ 116). Content cross-checked against theorem statements and proof tactics.

## Note on verification
Local `pnpm build` could not complete due to a host disk-full condition (ENOSPC at the final listings write, after all 4454 proofs were discovered and annotations processed). JSON validated independently (parses cleanly, 8 annotations, schema matches gallery convention).