### PR TITLE
research(chebyshev-pnt-bridge-oq-04): prime-power strip → upper half of Mertens M1 for the honest prime sum

### DIFF
--- a/proofs/Proofs/ChebyshevPNTBridgeOQ04.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ04.lean
@@ -44,9 +44,20 @@
   axiom `chebyshevPsi_asymptotic`; Stirling's `O(log N)` form is real-analytic),
   so this entry is `axiomatized` with 2 structure-encoded assumptions.
 
-  The prime-power strip (Λ-sum → prime sum, M1) and the Abel-summation passage
-  M1 → M2 remain the open targets; Steps A–C are exactly the verified machinery
-  those steps build on.
+  ## Prime-power strip (this session, verified, no new axioms)
+
+  The Λ-sum is split exactly into the honest prime sum and a prime-power tail,
+  `Σ_{d≤N} Λ(d)/d = Σ_{p≤N} (log p)/p + R(N)` (`lambdaRecip_prime_split`), where
+  `R(N) := Σ_{d≤N, d not prime} Λ(d)/d ≥ 0` (`primePowerTail_nonneg`). Because the
+  tail is nonnegative, the conditional Λ-weighted estimate transfers directly to
+  the honest prime sum as an *upper* bound (`primeLogRecip_le`):
+
+    `Σ_{p≤N} (log p)/p ≤ log N + (1 + c_S + c_ψ)`   (N ≥ 2).
+
+  This is the upper half of Mertens' first theorem for the actual prime sum,
+  proved from the same 2 inputs (no new assumptions). The matching lower bound
+  needs a uniform tail bound `R(N) = Σ_{p^k≤N, k≥2} (log p)/p^k = O(1)`; that
+  geometric-series step and the Abel-summation passage M1 → M2 remain open.
 -/
 import Mathlib
 
@@ -246,5 +257,67 @@ theorem lambdaRecip_sub_log_le (h : MertensInputs) :
   constructor <;>
     linarith [habs.1, habs.2, hE_div_nonneg, hE_div_le,
       h.cChebyshev_nonneg, h.cStirling_nonneg]
+
+/-!
+## Prime-power strip (Step 2 toward M1 for the honest prime sum)
+
+The Λ-weighted sum `Σ_{d≤N} Λ(d)/d` counts *all* prime powers. Mertens' first
+theorem is a statement about the prime sum `Σ_{p≤N} (log p)/p`. We split the
+Λ-sum exactly into its prime block and a prime-power tail, and use the tail's
+nonnegativity to transfer the *upper* half of the conditional estimate directly
+to the honest prime sum — with **no new assumptions** (still the 2 inputs of
+`MertensInputs`). The lower half needs a uniform upper bound on the tail
+`Σ_{p^k≤N, k≥2} (log p)/p^k = O(1)`, which remains the open analytic step.
+-/
+
+/-- The honest first-Mertens partial sum `Σ_{p ≤ N, p prime} (log p)/p`. -/
+noncomputable def primeLogRecip (N : ℕ) : ℝ :=
+  ∑ d ∈ (Finset.Icc 1 N).filter (fun d => Nat.Prime d), Real.log d / (d : ℝ)
+
+/-- The prime-power tail `R(N) := Σ_{d ≤ N, d not prime} Λ(d)/d`.
+    Its only nonzero terms are the higher prime powers `d = p^k` with `k ≥ 2`
+    (where `Λ(d) = log p ≠ 0` but `d` is not prime). -/
+noncomputable def primePowerTail (N : ℕ) : ℝ :=
+  ∑ d ∈ (Finset.Icc 1 N).filter (fun d => ¬ Nat.Prime d),
+    ArithmeticFunction.vonMangoldt d / (d : ℝ)
+
+/-- **Exact prime/prime-power split** of the Λ-weighted sum:
+    `Σ_{d≤N} Λ(d)/d = Σ_{p≤N} (log p)/p + R(N)`.
+    On the prime block `Λ(p) = log p` (`vonMangoldt_apply_prime`); the rest is
+    the tail `R(N)` by definition. -/
+theorem lambdaRecip_prime_split (N : ℕ) :
+    lambdaRecip N = primeLogRecip N + primePowerTail N := by
+  unfold lambdaRecip primeLogRecip primePowerTail
+  rw [← Finset.sum_filter_add_sum_filter_not (Finset.Icc 1 N)
+        (fun d => Nat.Prime d)
+        (fun d => ArithmeticFunction.vonMangoldt d / (d : ℝ))]
+  congr 1
+  refine Finset.sum_congr rfl (fun d hd => ?_)
+  simp only [Finset.mem_filter] at hd
+  rw [ArithmeticFunction.vonMangoldt_apply_prime hd.2]
+
+/-- **Tail nonnegativity**: `0 ≤ R(N)`. Each term `Λ(d)/d ≥ 0`. -/
+theorem primePowerTail_nonneg (N : ℕ) : 0 ≤ primePowerTail N := by
+  unfold primePowerTail
+  refine Finset.sum_nonneg (fun d _ => ?_)
+  exact div_nonneg ArithmeticFunction.vonMangoldt_nonneg (by positivity)
+
+/-- **Upper half of Mertens' first theorem for the honest prime sum**
+    (conditional, no new assumptions):
+    `Σ_{p ≤ N} (log p)/p ≤ log N + (1 + c_S + c_ψ)` for `N ≥ 2`.
+
+    Since `primeLogRecip N = lambdaRecip N − R(N)` and `R(N) ≥ 0`, the prime sum
+    is dominated by the Λ-sum, and the conditional Λ-weighted estimate
+    `lambdaRecip N ≤ log N + (1+c_S+c_ψ)` transfers directly. The matching lower
+    bound requires `R(N) = O(1)` (the prime-power tail bound), still open. -/
+theorem primeLogRecip_le (h : MertensInputs) :
+    ∀ N : ℕ, 2 ≤ N →
+      primeLogRecip N ≤ Real.log N + (1 + h.cStirling + h.cChebyshev) := by
+  intro N hN
+  have hsplit := lambdaRecip_prime_split N
+  have htail := primePowerTail_nonneg N
+  have hM1 := lambdaRecip_sub_log_le h N hN
+  have hupper := (abs_le.mp hM1).2
+  linarith [hsplit, htail, hupper]
 
 end ChebyshevPNTBridgeOQ04

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "chebyshev-pnt-bridge-oq-04",
   "title": "Mertens' First Theorem Backbone: the von Mangoldt Floor Identity Σ Λ(d)⌊N/d⌋ = Σ log n",
   "slug": "chebyshev-pnt-bridge-oq-04",
-  "description": "Builds the exact elementary machinery behind Mertens' first theorem Σ_{p≤x} (log p)/p = log x + O(1), answering the parent bridge's fourth open question. The verified core is the von Mangoldt floor identity Σ_{d=1}^N Λ(d)·⌊N/d⌋ = Σ_{n=1}^N log n (the Λ-transport of the Möbius hyperbola identity in the sibling Mertens file), its floor decomposition N·Σ_{d=1}^N Λ(d)/d = Σ log n + E(N) with E(N) = Σ Λ(d)·fract(N/d), and the exact remainder sandwich 0 ≤ E(N) ≤ ψ(N) where ψ(N) = Σ_{d≤N} Λ(d). Feeding the two genuine analytic inputs — Chebyshev's ψ(N) = O(N) and Stirling's Σ_{n≤N} log n = N log N − N + O(log N), packaged as the hypotheses of a MertensInputs structure — yields the Λ-weighted first Mertens estimate Σ_{d=1}^N Λ(d)/d = log N + O(1) with the explicit constant 1 + c_S + c_ψ. Steps A–C are unconditional and axiom-free; the headline estimate is conditional on the two structure-encoded assumptions (axiomatized, axiomCount 2).",
+  "description": "Builds the exact elementary machinery behind Mertens' first theorem Σ_{p≤x} (log p)/p = log x + O(1), answering the parent bridge's fourth open question. The verified core is the von Mangoldt floor identity Σ_{d=1}^N Λ(d)·⌊N/d⌋ = Σ_{n=1}^N log n (the Λ-transport of the Möbius hyperbola identity in the sibling Mertens file), its floor decomposition N·Σ_{d=1}^N Λ(d)/d = Σ log n + E(N) with E(N) = Σ Λ(d)·fract(N/d), and the exact remainder sandwich 0 ≤ E(N) ≤ ψ(N) where ψ(N) = Σ_{d≤N} Λ(d). Feeding the two genuine analytic inputs — Chebyshev's ψ(N) = O(N) and Stirling's Σ_{n≤N} log n = N log N − N + O(log N), packaged as the hypotheses of a MertensInputs structure — yields the Λ-weighted first Mertens estimate Σ_{d=1}^N Λ(d)/d = log N + O(1) with the explicit constant 1 + c_S + c_ψ. A prime-power strip then splits the Λ-sum exactly into the honest prime sum and a nonnegative tail, Σ_{d≤N} Λ(d)/d = Σ_{p≤N} (log p)/p + R(N) with R(N) ≥ 0, and transfers the upper half of the estimate directly to the genuine prime sum: Σ_{p≤N} (log p)/p ≤ log N + (1 + c_S + c_ψ) — with no new assumptions. Steps A–C and the split are unconditional and axiom-free; the headline estimate is conditional on the two structure-encoded assumptions (axiomatized, axiomCount 2).",
   "meta": {
     "author": "Franz Mertens",
     "sourceUrl": "https://en.wikipedia.org/wiki/Mertens%27_theorems",
@@ -52,14 +52,17 @@
       "sum_vonMangoldt_mul_floor_eq_sum_log: the exact von Mangoldt floor identity Σ_{d=1}^N Λ(d)·⌊N/d⌋ = Σ_{n=1}^N log n, obtained by rewriting Λ(d)·⌊N/d⌋ as the count Σ_{n≤N}[d∣n]·Λ(d), swapping the double sum over d∣n (Finset.sum_comm), and collapsing the inner sum via vonMangoldt_sum. This is the Λ-transport of the Möbius identity Σ μ(d)⌊N/d⌋ = 1 in the sibling ChebyshevBoundsOQ04OQ01Mertens file",
       "mul_lambdaRecip_eq: the exact floor decomposition N·Σ_{d=1}^N Λ(d)/d = (Σ_{n≤N} log n) + E(N) with E(N) := Σ_{d=1}^N Λ(d)·fract(N/d), splitting ⌊N/d⌋ = N/d − fract(N/d) inside the floor identity",
       "lambdaFractRemainder_bounds: the exact remainder sandwich 0 ≤ E(N) ≤ ψ(N) = Σ_{d≤N} Λ(d), from Λ ≥ 0 and 0 ≤ fract < 1 term by term — pinning the second Chebyshev function ψ as the precise error scale",
-      "lambdaRecip_sub_log_le: the conditional Λ-weighted first Mertens estimate |Σ_{d=1}^N Λ(d)/d − log N| ≤ 1 + c_S + c_ψ for N ≥ 2, derived from Steps A–C plus the Chebyshev ψ(N) ≤ c_ψ·N and Stirling |Σ log n − (N log N − N)| ≤ c_S·log N hypotheses of the MertensInputs structure"
+      "lambdaRecip_sub_log_le: the conditional Λ-weighted first Mertens estimate |Σ_{d=1}^N Λ(d)/d − log N| ≤ 1 + c_S + c_ψ for N ≥ 2, derived from Steps A–C plus the Chebyshev ψ(N) ≤ c_ψ·N and Stirling |Σ log n − (N log N − N)| ≤ c_S·log N hypotheses of the MertensInputs structure",
+      "lambdaRecip_prime_split: the exact prime/prime-power decomposition Σ_{d≤N} Λ(d)/d = Σ_{p≤N} (log p)/p + R(N), splitting the Icc-sum by the Nat.Prime predicate (Finset.sum_filter_add_sum_filter_not) and rewriting the prime block via vonMangoldt_apply_prime (Λ(p) = log p); the tail R(N) := Σ_{d≤N, ¬prime} Λ(d)/d collects exactly the higher prime powers p^k (k≥2)",
+      "primePowerTail_nonneg: 0 ≤ R(N), from Λ ≥ 0 and 1/d ≥ 0 term by term — the sign fact that lets the Λ-sum dominate the honest prime sum",
+      "primeLogRecip_le: the upper half of Mertens' first theorem for the genuine prime sum, Σ_{p≤N} (log p)/p ≤ log N + (1 + c_S + c_ψ) for N ≥ 2, obtained with NO new assumptions by combining the exact split, tail nonnegativity, and the conditional Λ-weighted estimate (primeLogRecip N = lambdaRecip N − R(N) ≤ lambdaRecip N ≤ log N + (1+c_S+c_ψ))"
     ],
     "axiomCount": 2,
-    "lineCount": 250,
-    "assumptions": "The unconditional results — the floor identity (Step A), its decomposition (Step B), the remainder sandwich (Step C), and the rearrangement lambdaRecip_eq — are fully verified, 0 axioms and 0 sorries (only propext / Classical.choice / Quot.sound), no native_decide. The headline Λ-weighted first Mertens estimate lambdaRecip_sub_log_le is CONDITIONAL: it is a verified implication taking the two analytic inputs as the hypotheses of the MertensInputs structure — (1) Chebyshev's bound ψ(N) ≤ c_ψ·N (the gallery's standing open chebyshevPsi_asymptotic, upper half) and (2) Stirling's estimate |Σ_{n≤N} log n − (N log N − N)| ≤ c_S·log N. These two structure-encoded assumptions are counted as axiomCount = 2 per the project's axiom-integrity policy (leanFile.axiomCount = 0 since there are no literal `axiom` declarations). Neither input is proved here. The prime-power strip from the Λ-sum to the genuine prime sum Σ_{p≤x}(log p)/p, and the Abel partial-summation passage to Mertens' second theorem Σ_{p≤x} 1/p = log log x + M + O(1/log x), remain the open targets.",
+    "lineCount": 323,
+    "assumptions": "The unconditional results — the floor identity (Step A), its decomposition (Step B), the remainder sandwich (Step C), and the rearrangement lambdaRecip_eq — are fully verified, 0 axioms and 0 sorries (only propext / Classical.choice / Quot.sound), no native_decide. The headline Λ-weighted first Mertens estimate lambdaRecip_sub_log_le is CONDITIONAL: it is a verified implication taking the two analytic inputs as the hypotheses of the MertensInputs structure — (1) Chebyshev's bound ψ(N) ≤ c_ψ·N (the gallery's standing open chebyshevPsi_asymptotic, upper half) and (2) Stirling's estimate |Σ_{n≤N} log n − (N log N − N)| ≤ c_S·log N. These two structure-encoded assumptions are counted as axiomCount = 2 per the project's axiom-integrity policy (leanFile.axiomCount = 0 since there are no literal `axiom` declarations). Neither input is proved here. The prime-power strip is now performed exactly and axiom-free: lambdaRecip_prime_split gives Σ_{d≤N} Λ(d)/d = Σ_{p≤N} (log p)/p + R(N), primePowerTail_nonneg gives R(N) ≥ 0, and primeLogRecip_le transfers the UPPER half of the estimate to the genuine prime sum, Σ_{p≤N} (log p)/p ≤ log N + (1 + c_S + c_ψ), with no new assumptions (still axiomCount 2). The matching LOWER bound needs a uniform tail bound R(N) = Σ_{p^k≤N, k≥2} (log p)/p^k = O(1) (a convergent geometric-series estimate), and the Abel partial-summation passage to Mertens' second theorem Σ_{p≤x} 1/p = log log x + M + O(1/log x) remains the open target.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
-    "definitionCount": 3
+    "theoremCount": 9,
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "Mertens proved his three theorems in 1874, two decades after Chebyshev's 1852 bounds and two decades before the Prime Number Theorem. The first theorem Σ_{p≤x} (log p)/p = log x + O(1) is the elementary heart: it is provable from Chebyshev-strength bounds plus Stirling's approximation, without the analytic machinery PNT requires. The classical route runs through the von Mangoldt function Λ — the prime-power weight satisfying Σ_{d∣n} Λ(d) = log n — because summing that divisor identity over n ≤ N and swapping the order of summation turns the difficult prime sum into a tractable floor sum Σ_d Λ(d)⌊N/d⌋. This is the same Dirichlet-hyperbola swap that the sibling Möbius file uses for Σ μ(d)⌊N/d⌋ = 1.",
@@ -84,47 +87,55 @@
       "id": "header",
       "title": "Overview",
       "startLine": 1,
-      "endLine": 59,
-      "summary": "Module docstring framing OQ#4: Mertens' first theorem via the von Mangoldt floor identity, listing the three verified steps and the two analytic inputs."
+      "endLine": 61,
+      "summary": "Module docstring framing OQ#4: Mertens' first theorem via the von Mangoldt floor identity, listing the three verified steps, the two analytic inputs, and the prime-power strip to the honest prime sum."
     },
     {
       "id": "floor-identity",
       "title": "Step A — The von Mangoldt Floor Identity",
-      "startLine": 61,
-      "endLine": 107,
+      "startLine": 69,
+      "endLine": 118,
       "summary": "card_multiples_Icc identifies ⌊N/d⌋ with #{n≤N : d∣n}; sum_vonMangoldt_mul_floor_eq_sum_log proves the exact identity Σ_{d≤N} Λ(d)·⌊N/d⌋ = Σ_{n≤N} log n by the hyperbola swap and vonMangoldt_sum.",
       "mathContext": "Σ_{d=1}^N Λ(d)·⌊N/d⌋ = Σ_{n=1}^N log n, exact for all N."
     },
     {
       "id": "decomposition",
       "title": "Step B — Floor Decomposition",
-      "startLine": 109,
-      "endLine": 147,
+      "startLine": 119,
+      "endLine": 156,
       "summary": "Definitions of lambdaRecip (Σ Λ(d)/d), lambdaFractRemainder (E(N)), chebyshevPsi (ψ(N)); mul_lambdaRecip_eq gives N·Σ Λ(d)/d = Σ log n + E(N) by ⌊N/d⌋ = N/d − fract(N/d).",
       "mathContext": "N·Σ_{d=1}^N Λ(d)/d = (Σ_{n≤N} log n) + Σ_{d=1}^N Λ(d)·fract(N/d)."
     },
     {
       "id": "remainder-bound",
       "title": "Step C — Remainder Sandwich",
-      "startLine": 149,
-      "endLine": 177,
+      "startLine": 157,
+      "endLine": 181,
       "summary": "lambdaFractRemainder_bounds proves 0 ≤ E(N) ≤ ψ(N) from Λ ≥ 0 and 0 ≤ fract < 1; lambdaRecip_eq rearranges Step B to Σ Λ(d)/d = (Σ log n)/N + E(N)/N for N ≥ 1.",
       "mathContext": "0 ≤ E(N) ≤ ψ(N); the fractional remainder is controlled by the second Chebyshev function."
     },
     {
       "id": "conditional-mertens",
       "title": "Conditional First Mertens Estimate",
-      "startLine": 179,
-      "endLine": 246,
+      "startLine": 182,
+      "endLine": 260,
       "summary": "MertensInputs packages Chebyshev's ψ(N) ≤ c_ψ·N and Stirling's |Σ log n − (N log N − N)| ≤ c_S·log N; lambdaRecip_sub_log_le derives |Σ_{d≤N} Λ(d)/d − log N| ≤ 1 + c_S + c_ψ for N ≥ 2.",
       "mathContext": "Σ_{d=1}^N Λ(d)/d = log N + O(1), conditional on the two structure-encoded analytic inputs."
+    },
+    {
+      "id": "prime-power-strip",
+      "title": "Prime-Power Strip — Upper Bound for the Honest Prime Sum",
+      "startLine": 261,
+      "endLine": 322,
+      "summary": "primeLogRecip (Σ_{p≤N} (log p)/p) and primePowerTail (R(N) = Σ_{d≤N, ¬prime} Λ(d)/d) are defined; lambdaRecip_prime_split proves the exact decomposition Σ Λ(d)/d = Σ_{p≤N}(log p)/p + R(N) via Finset.sum_filter_add_sum_filter_not and vonMangoldt_apply_prime; primePowerTail_nonneg gives R(N) ≥ 0; primeLogRecip_le transfers the upper half Σ_{p≤N}(log p)/p ≤ log N + (1+c_S+c_ψ) with no new assumptions.",
+      "mathContext": "Σ_{p≤N} (log p)/p ≤ log N + (1 + c_S + c_ψ) for N ≥ 2 — the upper half of Mertens' first theorem for the genuine prime sum."
     }
   ],
   "conclusion": {
     "summary": "Establishes the exact, axiom-free elementary backbone of Mertens' first theorem: the von Mangoldt floor identity Σ_{d≤N} Λ(d)⌊N/d⌋ = Σ_{n≤N} log n, its main-term/fractional-remainder decomposition, and the sandwich 0 ≤ E(N) ≤ ψ(N) pinning the error to the second Chebyshev function. Combined with Chebyshev's ψ = O(N) and Stirling (the two MertensInputs hypotheses), these give the Λ-weighted first Mertens estimate Σ_{d≤N} Λ(d)/d = log N + O(1). The three structural lemmas are unconditional; the final estimate is a verified implication conditional on the two analytic inputs (axiomatized, axiomCount 2).",
-    "implications": "Reduces Mertens' first theorem to exactly two named analytic inputs, both of which the gallery already treats as standing targets (Chebyshev's ψ = O(N) is the parent's chebyshevPsi_asymptotic). The floor identity and remainder sandwich are reusable for any Dirichlet-convolution partial sum, and the isolated E(N) ≤ ψ(N) bound is the precise hinge on which a fully-unconditional Mertens would turn once Chebyshev's bound is discharged in Lean.",
+    "implications": "Reduces Mertens' first theorem to exactly two named analytic inputs, both of which the gallery already treats as standing targets (Chebyshev's ψ = O(N) is the parent's chebyshevPsi_asymptotic). The floor identity and remainder sandwich are reusable for any Dirichlet-convolution partial sum, and the isolated E(N) ≤ ψ(N) bound is the precise hinge on which a fully-unconditional Mertens would turn once Chebyshev's bound is discharged in Lean. The prime-power strip now delivers the upper half of Mertens' first theorem for the genuine prime sum Σ_{p≤N} (log p)/p ≤ log N + O(1) with no extra assumptions, leaving only the convergent prime-power tail bound R(N) = O(1) for the matching lower half.",
     "openQuestions": [
-      "Strip the prime-power tail: pass from the Λ-weighted sum Σ_{d≤N} Λ(d)/d to the genuine prime sum Σ_{p≤N} (log p)/p, controlling the convergent Σ_{p, k≥2} (log p)/p^k correction, to obtain the unconditional shape of Mertens' first theorem.",
+      "Bound the prime-power tail R(N) = Σ_{p^k≤N, k≥2} (log p)/p^k = O(1) uniformly (per-prime geometric series Σ_{k≥2} p^{-k} = 1/(p(p−1))), to upgrade primeLogRecip_le to the full two-sided Mertens' first theorem Σ_{p≤N} (log p)/p = log N + O(1) for the genuine prime sum. The exact split (lambdaRecip_prime_split) and the upper half (primeLogRecip_le) are now done; only this lower-bound tail estimate remains.",
       "Feed the first theorem into Mathlib's Abel summation (sum_mul_eq_sub_sub_integral_mul) to derive Mertens' second theorem Σ_{p≤x} 1/p = log log x + M + O(1/log x), including the Mertens constant M.",
       "Discharge the MertensInputs hypotheses inside Lean by proving Chebyshev's ψ(N) = O(N) and an elementary Stirling bound Σ_{n≤N} log n = N log N − N + O(log N), upgrading the conditional estimate to a fully verified one."
     ]
@@ -150,10 +161,10 @@
       "ArithmeticFunction"
     ],
     "namespace": "ChebyshevPNTBridgeOQ04",
-    "lineCount": 250,
+    "lineCount": 323,
     "axiomCount": 0,
-    "theoremCount": 6,
-    "definitionCount": 3,
+    "theoremCount": 9,
+    "definitionCount": 5,
     "path": "Proofs/ChebyshevPNTBridgeOQ04.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Extends the existing verified Mertens' first-theorem backbone (`ChebyshevPNTBridgeOQ04.lean`) with the **prime-power strip** — the step the knowledge log flagged as the next target — carrying the Λ-weighted estimate over to the *genuine* prime sum `Σ_{p≤N} (log p)/p`.

Three new results (all axiom-free; the headline still rests only on the 2 pre-existing `MertensInputs` assumptions):

- **`lambdaRecip_prime_split`** — exact decomposition `Σ_{d≤N} Λ(d)/d = Σ_{p≤N} (log p)/p + R(N)`, splitting the `Icc 1 N` sum by the `Nat.Prime` predicate (`Finset.sum_filter_add_sum_filter_not`) and rewriting the prime block with `vonMangoldt_apply_prime` (Λ(p) = log p). The tail `R(N) := Σ_{d≤N, ¬prime} Λ(d)/d` collects exactly the higher prime powers p^k (k≥2).
- **`primePowerTail_nonneg`** — `0 ≤ R(N)`, from Λ ≥ 0 and 1/d ≥ 0.
- **`primeLogRecip_le`** — the **upper half of Mertens' first theorem for the honest prime sum**: `Σ_{p≤N} (log p)/p ≤ log N + (1 + c_S + c_ψ)` for N ≥ 2. Since `primeLogRecip N = lambdaRecip N − R(N) ≤ lambdaRecip N`, the conditional Λ-weighted upper bound transfers directly — **no new assumptions**.

The matching lower bound needs a uniform tail bound `R(N) = Σ_{p^k≤N,k≥2}(log p)/p^k = O(1)` (per-prime geometric series), which remains the open analytic step; the exact split and upper half are now done.

## Status
- `axiomatized`, `axiomCount 2` (unchanged — the two structure-encoded analytic inputs; no literal axioms, `leanFile.axiomCount 0`).
- 9 theorems / 5 defs / 323 lines. Gallery meta updated (counts, contributions, new section, open questions).

## Verification
Single-file elaboration via `lake env lean` against the pinned Mathlib 4.26.0 build: **exit 0, no errors/warnings** over the full file (existing steps A–C + conditional M1 + the three new lemmas). `#print axioms` on the new theorems shows only `propext / Classical.choice / Quot.sound` (`primeLogRecip_le` additionally carries the `MertensInputs` hypothesis as an argument, i.e. it is a verified implication — no new global assumption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)