### PR TITLE
Fix: render string-format cross-references and prune dead cross-reference links

### DIFF
--- a/src/data/proofs/index.ts
+++ b/src/data/proofs/index.ts
@@ -87,6 +87,30 @@ function normalizeAnnotations(annotations: Annotation[]): Annotation[] {
 }
 
 /**
+ * Normalize cross-references. Two data shapes exist across meta.json files:
+ *   - object form: { proofId | targetId, relationship, description? }
+ *   - legacy string form: a bare slug string (~29 files)
+ * The string form never rendered because ProofOverview/ProofConclusion read
+ * `ref.proofId ?? ref.targetId`, both undefined on a string. Coerce strings to
+ * the object form so those links display. Additionally, drop any reference
+ * whose target slug is not a real proof (absent from the data manifest) — this
+ * prunes dead links to proofs that do not exist (e.g. skipped OQ numbers).
+ */
+function normalizeCrossReferences(
+  refs: (CrossReference | string)[] | undefined
+): CrossReference[] | undefined {
+  if (!refs) return refs
+  return refs
+    .map((ref): CrossReference =>
+      typeof ref === 'string' ? { proofId: ref, relationship: 'related' } : ref
+    )
+    .filter((ref) => {
+      const slug = ref.proofId ?? ref.targetId
+      return slug != null && DATA_MANIFEST[slug] != null
+    })
+}
+
+/**
  * Asynchronously load proof data for a given slug.
  *
  * Public signature preserved from phase 1: `(slug) => Promise<ProofData | undefined>`.
@@ -130,7 +154,7 @@ export async function getProofAsync(slug: string): Promise<ProofData | undefined
         sections: meta.sections ?? [],
         overview: meta.overview,
         conclusion: meta.conclusion,
-        crossReferences: meta.crossReferences,
+        crossReferences: normalizeCrossReferences(meta.crossReferences),
         references: meta.references,
         source: '',
       },


### PR DESCRIPTION
## Fix

The proof loader (`src/data/proofs/index.ts`) now normalizes `crossReferences` before handing them to the UI: legacy bare-slug **string** entries are coerced to object form, and any reference whose target slug is absent from the data manifest (a proof that does not exist) is dropped.

## Evidence

**Before**:
- ~29 gallery entries store `crossReferences` as plain slug strings (e.g. `["triangle-angle-sum-oq-04"]`). `ProofOverview.tsx` / `ProofConclusion.tsx` read `ref.proofId ?? ref.targetId`, both `undefined` on a string → `return null`, so these "Related Proofs" links **never rendered**.
- `triangle-angle-sum-oq-04` and `triangle-angle-sum-oq-06` both cross-reference `triangle-angle-sum-oq-05`, which **does not exist** (the OQ-05 number was skipped — no gallery entry, no Lean file, not in git history). That is a dead `/proof/...` link.

**After**:
- String cross-references are coerced to `{ proofId, relationship: "related" }` so they render as proper links.
- References to non-existent proofs (not in `DATA_MANIFEST`) are filtered out, eliminating dead links such as `triangle-angle-sum-oq-05`.
- Centralized loader fix — no per-entry data churn; object-form cross-references are unaffected.
- `tsc --noEmit` passes.

---
Automated fix by lean-mechanic agent.