### PR TITLE
Enrich Unique Factorization in Polynomial Rings (bezout-identity-oq-02-oq-01-oq-01): expand annotations (5→11)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01/annotations.json
@@ -1,123 +1,134 @@
 [
   {
+    "id": "ann-bezout-poly-overview",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 21 },
+    "type": "concept",
+    "title": "The Bézout → Euclid → UFD Argument, Transplanted to Polynomials",
+    "content": "The module docstring states the guiding theme: the same abstract chain that proves the Fundamental Theorem of Arithmetic for ℤ — Bézout's identity ⟹ Euclid's lemma ⟹ unique factorization — carries over verbatim to polynomial rings. Over a field K, K[X] is a Euclidean domain (polynomial long division), hence a PID, hence a UFD; over an arbitrary UFD R, Gauss's Lemma lifts unique factorization to R[X]. The four headline results are: R[X] is a UFD when R is, K[X] is a Euclidean domain, the polynomial Bézout identity over a field, and irreducible ⟺ prime in polynomial UFDs. The proof leans entirely on Mathlib's algebraic hierarchy, so it is 0 sorries and 0 axioms.",
+    "mathContext": "$\\text{Bézout} \\Rightarrow \\text{Euclid's lemma} \\Rightarrow \\text{UFD}$, for both $\\mathbb{Z}$ and $K[X]$",
+    "significance": "context",
+    "relatedConcepts": ["Fundamental Theorem of Arithmetic", "Euclidean domain", "unique factorization", "Gauss's Lemma", "principal ideal domain"],
+    "prerequisites": ["ring theory hierarchy", "polynomial rings", "divisibility"]
+  },
+  {
+    "id": "ann-bezout-poly-ufd-structure",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01",
+    "range": { "startLine": 31, "endLine": 42 },
+    "type": "concept",
+    "title": "Section I — Polynomial Rings Inherit UFD and Euclidean Structure",
+    "content": "Three `inferInstance`/named-instance one-liners record the structural backbone. First, for any field K, `K[X]` is a `UniqueFactorizationMonoid` — resolved automatically by typeclass search through K[X] being a Euclidean domain. Second, `K[X]` is an `EuclideanDomain`, the polynomial division algorithm supplying the degree-decreasing remainder. Third, and most substantially, for any UFD R the ring `R[X]` is again a UFD via `Polynomial.uniqueFactorizationMonoid` — this is the formal content of Gauss's Lemma (the product of primitive polynomials is primitive). That these are available as instances is exactly what makes the downstream Bézout/Euclid arguments short.",
+    "mathContext": "$K \\text{ field} \\Rightarrow K[X] \\text{ Euclidean} \\Rightarrow K[X] \\text{ UFD}; \\quad R \\text{ UFD} \\Rightarrow R[X] \\text{ UFD (Gauss)}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Polynomial.uniqueFactorizationMonoid", "EuclideanDomain", "Gauss's Lemma", "typeclass inference"],
+    "prerequisites": ["Euclidean domains", "primitive polynomials", "typeclass resolution"]
+  },
+  {
     "id": "ann-bezout-poly-irred-prime",
     "proofId": "bezout-identity-oq-02-oq-01-oq-01",
-    "range": {
-      "startLine": 50,
-      "endLine": 53
-    },
+    "range": { "startLine": 50, "endLine": 53 },
     "type": "insight",
-    "title": "Irreducible \u2194 Prime in Polynomial UFDs",
-    "content": "`poly_irreducible_iff_prime` proves `Irreducible p \u2194 Prime p` for polynomials over any UFD, with a one-line proof delegating to `UniqueFactorizationMonoid.irreducible_iff_prime`. In a UFD, every irreducible element is prime \u2014 the converse (prime \u2192 irreducible) holds in any domain. For polynomials over a field K, this gives Euclid's lemma in full generality: irreducible polynomials are exactly the prime elements of K[X]. The equivalence characterizes UFDs among domains (in a non-UFD, irreducibles need not be prime, and unique factorization can fail). The proof is trivially short because Mathlib's `UniqueFactorizationMonoid` typeclass encodes this equivalence at the typeclass level.",
-    "mathContext": "In a UFD: `Irreducible p \u2194 Prime p`. Proof: prime \u2192 irreducible always (domain axiom); irreducible \u2192 prime is the UFD property. Over a PID: irreducible \u2194 prime \u2194 generates a maximal ideal. Over K[X]: irreducible = non-constant polynomial with no proper polynomial divisors.",
+    "title": "Irreducible ↔ Prime in Polynomial UFDs",
+    "content": "`poly_irreducible_iff_prime` proves `Irreducible p ↔ Prime p` for polynomials over any UFD, with a one-line proof delegating to `UniqueFactorizationMonoid.irreducible_iff_prime`. In a UFD, every irreducible element is prime — the converse (prime → irreducible) holds in any domain. For polynomials over a field K, this gives Euclid's lemma in full generality: irreducible polynomials are exactly the prime elements of K[X]. The equivalence characterizes UFDs among domains (in a non-UFD, irreducibles need not be prime, and unique factorization can fail). The proof is trivially short because Mathlib's `UniqueFactorizationMonoid` typeclass encodes this equivalence at the typeclass level.",
+    "mathContext": "In a UFD: `Irreducible p ↔ Prime p`. Proof: prime → irreducible always (domain axiom); irreducible → prime is the UFD property. Over a PID: irreducible ↔ prime ↔ generates a maximal ideal. Over K[X]: irreducible = non-constant polynomial with no proper polynomial divisors.",
     "significance": "key",
-    "relatedConcepts": [
-      "UniqueFactorizationMonoid",
-      "irreducible_iff_prime",
-      "Prime",
-      "Irreducible",
-      "UFD"
-    ],
-    "prerequisites": [
-      "UniqueFactorizationMonoid",
-      "CommRing",
-      "IsDomain"
-    ]
+    "relatedConcepts": ["UniqueFactorizationMonoid", "irreducible_iff_prime", "Prime", "Irreducible", "UFD"],
+    "prerequisites": ["UniqueFactorizationMonoid", "CommRing", "IsDomain"]
   },
   {
     "id": "ann-bezout-poly-euclid",
     "proofId": "bezout-identity-oq-02-oq-01-oq-01",
-    "range": {
-      "startLine": 57,
-      "endLine": 59
-    },
+    "range": { "startLine": 57, "endLine": 59 },
     "type": "insight",
-    "title": "Polynomial Euclid's Lemma: Irreducible p | f\u00b7g Implies p | f or p | g",
-    "content": "`poly_euclid_lemma` is Euclid's lemma for K[X]: if irreducible p divides f\u00b7g, then p | f or p | g. The proof is a two-step delegation: (1) `irreducible_iff_prime.mp hp` converts the irreducibility hypothesis to primeness using the UFD structure; (2) `.dvd_or_dvd hdvd` applies the defining property of prime elements. This mirrors the integer proof: p irreducible over \u2124 is prime (\u2124 is a UFD), so p | ab implies p | a or p | b. The `dvd_or_dvd` property is exactly what distinguishes prime elements from merely irreducible ones in non-UFDs.",
-    "mathContext": "Euclid's Lemma in K[X]: `Irreducible p \u2227 p | f\u00b7g \u2192 p | f \u2228 p | g`. Classical proof: p irreducible in K[X] implies gcd(p,f) \u2208 {1, up-to-unit p}; if p \u2224 f then gcd(p,f) = 1, so by B\u00e9zout \u2203 a b, a\u00b7p + b\u00b7f = 1, multiplying by g gives p | g.",
+    "title": "Polynomial Euclid's Lemma: Irreducible p | f·g Implies p | f or p | g",
+    "content": "`poly_euclid_lemma` is Euclid's lemma for K[X]: if irreducible p divides f·g, then p | f or p | g. The proof is a two-step delegation: (1) `irreducible_iff_prime.mp hp` converts the irreducibility hypothesis to primeness using the UFD structure; (2) `.dvd_or_dvd hdvd` applies the defining property of prime elements. This mirrors the integer proof: p irreducible over ℤ is prime (ℤ is a UFD), so p | ab implies p | a or p | b. The `dvd_or_dvd` property is exactly what distinguishes prime elements from merely irreducible ones in non-UFDs.",
+    "mathContext": "Euclid's Lemma in K[X]: `Irreducible p ∧ p | f·g → p | f ∨ p | g`. Classical proof: p irreducible in K[X] implies gcd(p,f) ∈ {1, up-to-unit p}; if p ∤ f then gcd(p,f) = 1, so by Bézout ∃ a b, a·p + b·f = 1, multiplying by g gives p | g.",
     "significance": "key",
-    "relatedConcepts": [
-      "irreducible_iff_prime",
-      "Prime.dvd_or_dvd",
-      "poly_irreducible_iff_prime",
-      "Euclid's lemma"
-    ],
-    "prerequisites": [
-      "poly_irreducible_iff_prime",
-      "Prime.dvd_or_dvd",
-      "Field"
-    ]
+    "relatedConcepts": ["irreducible_iff_prime", "Prime.dvd_or_dvd", "poly_irreducible_iff_prime", "Euclid's lemma"],
+    "prerequisites": ["poly_irreducible_iff_prime", "Prime.dvd_or_dvd", "Field"]
   },
   {
     "id": "ann-bezout-poly-bezout",
     "proofId": "bezout-identity-oq-02-oq-01-oq-01",
-    "range": {
-      "startLine": 68,
-      "endLine": 74
-    },
+    "range": { "startLine": 68, "endLine": 74 },
     "type": "insight",
-    "title": "Polynomial B\u00e9zout Identity: IsCoprime is Definitionally \u2203 a b, a\u00b7f + b\u00b7g = 1",
-    "content": "`poly_bezout` and `poly_isCoprime_iff` make explicit that `IsCoprime f g` is *definitionally* `\u2203 a b, a * f + b * g = 1`. The proof of `poly_bezout` is just `hcop` (the hypothesis itself), and `poly_isCoprime_iff` is proved by `Iff.rfl`. This definitional equality means polynomial coprimeness automatically carries B\u00e9zout coefficients \u2014 no separate proof needed. Over a field K, coprimeness holds when gcd(f,g) is a unit (a nonzero constant), and the extended Euclidean algorithm explicitly constructs a and b. The `IsCoprime` abstraction works for any commutative ring, making the B\u00e9zout identity universal.",
-    "mathContext": "In Mathlib: `IsCoprime f g := \u2203 a b, a * f + b * g = 1`. The type unfolds definitionally. Over K[X]: `IsCoprime f g \u2194 Polynomial.gcd f g \u223c 1 \u2194 gcd(f,g) is a nonzero constant`. Comparison: over \u2124, `IsCoprime a b \u2194 gcd(a,b) = 1`.",
+    "title": "Polynomial Bézout Identity: IsCoprime is Definitionally ∃ a b, a·f + b·g = 1",
+    "content": "`poly_bezout` and `poly_isCoprime_iff` make explicit that `IsCoprime f g` is *definitionally* `∃ a b, a * f + b * g = 1`. The proof of `poly_bezout` is just `hcop` (the hypothesis itself), and `poly_isCoprime_iff` is proved by `Iff.rfl`. This definitional equality means polynomial coprimeness automatically carries Bézout coefficients — no separate proof needed. Over a field K, coprimeness holds when gcd(f,g) is a unit (a nonzero constant), and the extended Euclidean algorithm explicitly constructs a and b. The `IsCoprime` abstraction works for any commutative ring, making the Bézout identity universal.",
+    "mathContext": "In Mathlib: `IsCoprime f g := ∃ a b, a * f + b * g = 1`. The type unfolds definitionally. Over K[X]: `IsCoprime f g ↔ Polynomial.gcd f g ∼ 1 ↔ gcd(f,g) is a nonzero constant`. Comparison: over ℤ, `IsCoprime a b ↔ gcd(a,b) = 1`.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "IsCoprime",
-      "EuclideanDomain.gcd_eq_gcd_ab",
-      "Iff.rfl",
-      "B\u00e9zout identity"
-    ],
-    "prerequisites": [
-      "IsCoprime",
-      "CommRing",
-      "Field"
-    ]
+    "relatedConcepts": ["IsCoprime", "EuclideanDomain.gcd_eq_gcd_ab", "Iff.rfl", "Bézout identity"],
+    "prerequisites": ["IsCoprime", "CommRing", "Field"]
+  },
+  {
+    "id": "ann-bezout-poly-existence",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 90 },
+    "type": "insight",
+    "title": "Section IV — Existence of Irreducible Factors and the UFD Package",
+    "content": "The existence half of unique factorization. `poly_has_irred_factor` states that every polynomial of positive degree over a field has an irreducible factor, via `Polynomial.exists_irreducible_of_natDegree_ne_zero` — the base case of the recursive factorization argument (peel off an irreducible factor, recurse on the strictly smaller quotient). `poly_ufd_structure` then names the full `UniqueFactorizationMonoid K[X]` instance, packaging both existence *and* uniqueness (up to units and reordering) of the factorization. Together with Section II's irreducible = prime, these deliver the polynomial Fundamental Theorem of Arithmetic.",
+    "mathContext": "Every $f \\in K[X]$ with $\\deg f \\ge 1$ has an irreducible factor; iterating gives $f = c\\prod_i p_i$ with $p_i$ irreducible, unique up to units and order.",
+    "significance": "key",
+    "relatedConcepts": ["Polynomial.exists_irreducible_of_natDegree_ne_zero", "existence of factorization", "well-founded recursion on degree", "UFD"],
+    "prerequisites": ["natDegree", "induction on degree", "UniqueFactorizationMonoid"]
+  },
+  {
+    "id": "ann-bezout-poly-examples",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01",
+    "range": { "startLine": 96, "endLine": 101 },
+    "type": "context",
+    "title": "Section V — Concrete Factorizations over ℚ",
+    "content": "Two concrete instances ground the abstract theory over ℚ[X]. The first `example` verifies the factorization $X^2 - 1 = (X-1)(X+1)$ purely by `ring`. `x_irreducible_Q` records that $X$ itself is irreducible in ℚ[X] via `Polynomial.irreducible_X` — a degree-1 monic polynomial cannot split into two non-units. These set up the contrast made precise in the next theorem: $X$ is a prime 'atom' of ℚ[X] while $X^2-1$ is composite, exactly paralleling primes versus composites in ℤ.",
+    "mathContext": "In $\\mathbb{Q}[X]$: $X$ irreducible (degree 1), $X^2 - 1 = (X-1)(X+1)$ reducible (degree 2 splitting into two linear factors).",
+    "significance": "context",
+    "relatedConcepts": ["Polynomial.irreducible_X", "linear factors", "concrete factorization", "ring tactic"],
+    "prerequisites": ["degree of a polynomial", "irreducibility of linear polynomials"]
   },
   {
     "id": "ann-bezout-poly-concrete",
     "proofId": "bezout-identity-oq-02-oq-01-oq-01",
-    "range": {
-      "startLine": 104,
-      "endLine": 114
-    },
+    "range": { "startLine": 104, "endLine": 114 },
     "type": "insight",
-    "title": "x\u00b2-1 is Reducible in \u211a[X]: Concrete Application of Irreducibility Criterion",
-    "content": "`x_sq_sub_one_reducible` proves `\u00ac Irreducible (X\u00b2 - 1 : \u211a[X])` by producing the factorization X\u00b2 - 1 = (X-1)(X+1) and showing neither factor is a unit. The proof uses `rcases hirr.isUnit_or_isUnit h` to split on which factor the assumed irreducibility forces to be a unit, then derives a contradiction using `Polynomial.irreducible_X_sub_C`: monic linear polynomials X - c are irreducible in K[X], hence non-units. The `have heq` steps normalize X \u00b1 1 into the X - C(\u00b11) form that `irreducible_X_sub_C` expects. This demonstrates that irreducibility is a property of the polynomial structure, not just the coefficient ring.",
-    "mathContext": "In K[X]: `Irreducible p` iff p is non-constant and cannot be written as a product of two non-units. Linear polynomials `X - c` are always irreducible (degree 1 implies one factor must be degree 0 = a unit). Degree 2+ polynomials may factor: X\u00b2 - 1 = (X-1)(X+1) over any ring containing \u00b11 with 1 \u2260 -1.",
+    "title": "x²-1 is Reducible in ℚ[X]: Concrete Application of Irreducibility Criterion",
+    "content": "`x_sq_sub_one_reducible` proves `¬ Irreducible (X² - 1 : ℚ[X])` by producing the factorization X² - 1 = (X-1)(X+1) and showing neither factor is a unit. The proof uses `rcases hirr.isUnit_or_isUnit h` to split on which factor the assumed irreducibility forces to be a unit, then derives a contradiction using `Polynomial.irreducible_X_sub_C`: monic linear polynomials X - c are irreducible in K[X], hence non-units. The `have heq` steps normalize X ± 1 into the X - C(±1) form that `irreducible_X_sub_C` expects. This demonstrates that irreducibility is a property of the polynomial structure, not just the coefficient ring.",
+    "mathContext": "In K[X]: `Irreducible p` iff p is non-constant and cannot be written as a product of two non-units. Linear polynomials `X - c` are always irreducible (degree 1 implies one factor must be degree 0 = a unit). Degree 2+ polynomials may factor: X² - 1 = (X-1)(X+1) over any ring containing ±1 with 1 ≠ -1.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "Polynomial.irreducible_X_sub_C",
-      "Irreducible.isUnit_or_isUnit",
-      "Polynomial.X",
-      "reducibility"
-    ],
-    "prerequisites": [
-      "Irreducible",
-      "Polynomial.irreducible_X_sub_C",
-      "ring tactic"
-    ]
+    "relatedConcepts": ["Polynomial.irreducible_X_sub_C", "Irreducible.isUnit_or_isUnit", "Polynomial.X", "reducibility"],
+    "prerequisites": ["Irreducible", "Polynomial.irreducible_X_sub_C", "ring tactic"]
+  },
+  {
+    "id": "ann-bezout-poly-parallel",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01",
+    "range": { "startLine": 120, "endLine": 132 },
+    "type": "concept",
+    "title": "Section VI — The Structural Parallel with the Integer FTA",
+    "content": "`bezout_parallel` restates Euclid's lemma for K[X] to underscore that it is *literally the same theorem* as the integer case (`BezoutIdentityOQ02OQ01`), only with the coefficient ring swapped. The docstring lays the two derivations side by side: over ℤ, `∃ x y, gcd(a,b) = ax + by` drives `p | ab → p | a ∨ p | b`, giving the FTA; over K[X], `∃ a b, af + bg = 1` drives `p | fg → p | f ∨ p | g`, giving polynomial unique factorization. In both, the engine is: the ring is a Euclidean domain ⟹ a GCDMonoid ⟹ a UFD. This is the payoff of the whole entry — one abstract argument, two classical theorems.",
+    "mathContext": "$\\mathbb{Z}$: Euclidean $\\Rightarrow$ GCDMonoid $\\Rightarrow$ UFD $\\Rightarrow$ FTA. $\\quad K[X]$: Euclidean $\\Rightarrow$ GCDMonoid $\\Rightarrow$ UFD $\\Rightarrow$ poly-FTA.",
+    "significance": "key",
+    "relatedConcepts": ["Fundamental Theorem of Arithmetic", "GCDMonoid", "structural analogy", "abstraction"],
+    "prerequisites": ["integer FTA", "Euclidean domains", "the sibling entry BezoutIdentityOQ02OQ01"]
+  },
+  {
+    "id": "ann-bezout-poly-gcd-dvd",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01",
+    "range": { "startLine": 138, "endLine": 141 },
+    "type": "technique",
+    "title": "Section VII — The GCD Divides Both Arguments",
+    "content": "`poly_gcd_dvd_both` records the defining divisibility property of the computable polynomial GCD: `EuclideanDomain.gcd f g` divides both f and g, packaged as a conjunction of `gcd_dvd_left` and `gcd_dvd_right`. The `[DecidableEq K]` instance is what makes `EuclideanDomain.gcd` an *explicit, computable* function (running the polynomial division algorithm) rather than an abstract GCDMonoid element. This lemma is the first of the two properties characterizing a GCD (divides both; is divisible by any common divisor) and sets up the Bézout-form theorem that follows.",
+    "mathContext": "$\\gcd(f,g) \\mid f \\ \\text{and}\\ \\gcd(f,g) \\mid g$; together with maximality among common divisors this characterizes the GCD.",
+    "significance": "supporting",
+    "relatedConcepts": ["EuclideanDomain.gcd", "gcd_dvd_left", "gcd_dvd_right", "DecidableEq", "computable GCD"],
+    "prerequisites": ["EuclideanDomain", "divisibility", "DecidableEq"]
   },
   {
     "id": "ann-bezout-poly-gcd-form",
     "proofId": "bezout-identity-oq-02-oq-01-oq-01",
-    "range": {
-      "startLine": 146,
-      "endLine": 151
-    },
+    "range": { "startLine": 146, "endLine": 151 },
     "type": "insight",
-    "title": "GCD B\u00e9zout Form: gcd(f,g) = a\u00b7f + b\u00b7g via Extended Euclidean Algorithm",
-    "content": "`poly_gcd_bezout_form` proves that the polynomial GCD has a B\u00e9zout representation: \u2203 a b, gcd(f,g) = a\u00b7f + b\u00b7g. The B\u00e9zout coefficients are `EuclideanDomain.gcdA f g` and `EuclideanDomain.gcdB f g` \u2014 Mathlib's computable extended Euclidean algorithm output. The key equation `EuclideanDomain.gcd_eq_gcd_ab` states `gcd f g = f * gcdA f g + g * gcdB f g`, and `ring` handles the commutativity. The `[DecidableEq K]` hypothesis is needed for the computable polynomial GCD; without it, only the abstract GCDMonoid structure is available. This is the constructive polynomial analogue of B\u00e9zout's theorem for integers.",
-    "mathContext": "B\u00e9zout's theorem for K[X]: \u2203 a b \u2208 K[X], gcd(f,g) = a\u00b7f + b\u00b7g. Constructive proof via extended Euclidean algorithm: run polynomial long division steps, tracking linear combinations. `EuclideanDomain.gcdA/gcdB` are the Lean 4 Mathlib computations. Specializing to gcd = 1: \u2203 a b, a\u00b7f + b\u00b7g = 1 (coprimeness case).",
+    "title": "GCD Bézout Form: gcd(f,g) = a·f + b·g via Extended Euclidean Algorithm",
+    "content": "`poly_gcd_bezout_form` proves that the polynomial GCD has a Bézout representation: ∃ a b, gcd(f,g) = a·f + b·g. The Bézout coefficients are `EuclideanDomain.gcdA f g` and `EuclideanDomain.gcdB f g` — Mathlib's computable extended Euclidean algorithm output. The key equation `EuclideanDomain.gcd_eq_gcd_ab` states `gcd f g = f * gcdA f g + g * gcdB f g`, and `ring` handles the commutativity. The `[DecidableEq K]` hypothesis is needed for the computable polynomial GCD; without it, only the abstract GCDMonoid structure is available. This is the constructive polynomial analogue of Bézout's theorem for integers.",
+    "mathContext": "Bézout's theorem for K[X]: ∃ a b ∈ K[X], gcd(f,g) = a·f + b·g. Constructive proof via extended Euclidean algorithm: run polynomial long division steps, tracking linear combinations. `EuclideanDomain.gcdA/gcdB` are the Lean 4 Mathlib computations. Specializing to gcd = 1: ∃ a b, a·f + b·g = 1 (coprimeness case).",
     "significance": "supporting",
-    "relatedConcepts": [
-      "EuclideanDomain.gcdA",
-      "EuclideanDomain.gcdB",
-      "EuclideanDomain.gcd_eq_gcd_ab",
-      "DecidableEq"
-    ],
-    "prerequisites": [
-      "EuclideanDomain",
-      "DecidableEq",
-      "Field"
-    ]
+    "relatedConcepts": ["EuclideanDomain.gcdA", "EuclideanDomain.gcdB", "EuclideanDomain.gcd_eq_gcd_ab", "DecidableEq"],
+    "prerequisites": ["EuclideanDomain", "DecidableEq", "Field"]
   }
 ]


### PR DESCRIPTION
Enrichment (coverage-gap) pass for `bezout-identity-oq-02-oq-01-oq-01`. The 5 existing annotations covered only ~20% of the 152-line Lean file, leaving the module overview and Sections I, IV, V, VI, VII unannotated.

Adds **6 annotations** for the uncovered sections (existing 5 preserved verbatim):
- **Overview** — the Bézout → Euclid's lemma → UFD chain, shared by ℤ and K[X].
- **Section I** — polynomial rings inherit UFD/Euclidean structure (K[X] Euclidean ⇒ UFD; R[X] UFD via Gauss's Lemma).
- **Section IV** — existence of irreducible factors + the full `UniqueFactorizationMonoid K[X]` package.
- **Section V** — concrete ℚ[X] examples (X irreducible; X²−1 = (X−1)(X+1)).
- **Section VI** — the structural parallel with the integer Fundamental Theorem of Arithmetic.
- **Section VII** — the GCD divides both arguments (computable `EuclideanDomain.gcd`).

Coverage of the Lean file rises from ~20% to ~62%. Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Validated against the Lean source via `scripts/annotations/build.ts` — all line anchors resolve to real constructs. meta.json unchanged; no axiom/status claims touched.