### PR TITLE
Enrich Forward Girard–Waring Determinant: add 8 annotations

### DIFF
--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header-duality",
+    "proofId": "newton-power-sum-identities-oq-01-oq-03",
+    "range": { "startLine": 3, "endLine": 43 },
+    "type": "context",
+    "title": "Two dual determinant forms of Newton's identities",
+    "content": "The module docstring frames the result as the dual of sibling oq-01-oq-02. Newton's identities relate the elementary symmetric polynomials eₖ = esymm σ R k and the power sums pₖ = psum σ R k = ∑ᵢ Xᵢᵏ. There are two determinant packagings of the same recurrence: the reverse form expresses k!·eₖ as a determinant in the pᵢ (oq-01-oq-02), while this entry proves the forward Girard–Waring form expressing each pₖ as a determinant of a k×k lower-Hessenberg matrix Mₖ whose entries are the eⱼ. In Mₖ the scaled polynomials 1·e₁, 2·e₂, …, k·eₖ run down the first column, the eⱼ fill the diagonals, and constant 1's sit on the super-diagonal — the constant super-diagonal (versus the increasing integers of the reverse form) mirrors the asymmetric coefficients of the two sides of the Newton recurrence.",
+    "mathContext": "$p_k = \\det M_k$ where $M_k$ is lower-Hessenberg in the $e_j$; dually $k!\\,e_k = \\det T_k$ is Toeplitz in the $p_i$.",
+    "significance": "context",
+    "relatedConcepts": ["Newton's identities", "elementary symmetric polynomials", "power sums", "lower-Hessenberg matrix", "Girard–Waring formula"],
+    "prerequisites": ["symmetric polynomials", "determinants"]
+  },
+  {
+    "id": "ann-setup-variables",
+    "proofId": "newton-power-sum-identities-oq-01-oq-03",
+    "range": { "startLine": 45, "endLine": 51 },
+    "type": "definition",
+    "title": "Ambient setting: any finite σ over any commutative ring",
+    "content": "The proof opens Finset, Matrix and MvPolynomial and fixes a finite index type σ and a commutative ring R. Because everything lives in MvPolynomial σ R, the identities are universal symmetric-function statements: they hold for every finite σ and every commutative ring R, with no division by k!. When card σ < k the higher eⱼ vanish and the determinant degenerates to the correct value automatically. The [CommRing R] hypothesis (not [Field] or [CommRing R] with a ℚ-algebra structure) is the strongest possible generality for these identities.",
+    "mathContext": "$e_j = \\mathrm{esymm}\\,\\sigma\\,R\\,j,\\quad p_k = \\mathrm{psum}\\,\\sigma\\,R\\,k = \\sum_i X_i^k$, for $\\sigma$ finite and $R$ commutative.",
+    "significance": "supporting",
+    "relatedConcepts": ["MvPolynomial", "commutative ring", "generality of symmetric-function identities"],
+    "prerequisites": ["Lean typeclasses", "multivariate polynomials"]
+  },
+  {
+    "id": "ann-psum-one-eq",
+    "proofId": "newton-power-sum-identities-oq-01-oq-03",
+    "range": { "startLine": 59, "endLine": 61 },
+    "type": "technique",
+    "title": "Degree-1 base case p₁ = e₁",
+    "content": "The degree-1 identity is immediate: both the first power sum and the first elementary symmetric polynomial equal ∑ᵢ Xᵢ. The proof is a two-step rewrite by Mathlib's psum_one and esymm_one. This is the anchor of the recursive unrolling — every higher forward identity ultimately reduces to this base plus the Newton recurrence.",
+    "mathContext": "$p_1 = \\sum_i X_i = e_1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["power sums", "elementary symmetric polynomials", "base case"],
+    "prerequisites": ["MvPolynomial.psum", "MvPolynomial.esymm"]
+  },
+  {
+    "id": "ann-psum-two-eq",
+    "proofId": "newton-power-sum-identities-oq-01-oq-03",
+    "range": { "startLine": 63, "endLine": 74 },
+    "type": "technique",
+    "title": "Unrolling the Newton recurrence at degree 2",
+    "content": "p₂ = e₁² − 2e₂ is obtained by instantiating Mathlib's recurrence psum_eq_mul_esymm_sub_sum at k = 2. The recurrence's inner sum ranges over the filtered antidiagonal {a ∈ antidiagonal 2 | 0 < a.1 < 2}, which is shown to be the single pair {(1,1)} by an ext/simp/omega argument — the set is characterised by a linear-arithmetic condition that omega discharges. Finset.sum_singleton collapses the sum, psum_one_eq substitutes the base case, and push_cast; ring finish by clearing the ℕ→R casts on the coefficient 2·e₂ and normalising the ring expression.",
+    "mathContext": "$p_2 = (-1)^{3}\\cdot 2 e_2 - \\sum_{0<i<2}(-1)^i e_i p_{2-i} = 2e_2 \\cdot(-1) + e_1 p_1 = e_1^2 - 2e_2.$",
+    "significance": "key",
+    "relatedConcepts": ["Newton recurrence", "antidiagonal", "omega tactic", "push_cast"],
+    "prerequisites": ["MvPolynomial.psum_eq_mul_esymm_sub_sum", "Finset.antidiagonal", "finite sums"]
+  },
+  {
+    "id": "ann-psum-three-eq",
+    "proofId": "newton-power-sum-identities-oq-01-oq-03",
+    "range": { "startLine": 76, "endLine": 88 },
+    "type": "technique",
+    "title": "Unrolling the Newton recurrence at degree 3",
+    "content": "p₃ = e₁³ − 3e₁e₂ + 3e₃ follows the same pattern one degree higher. Now the filtered antidiagonal {a ∈ antidiagonal 3 | 0 < a.1 < 3} equals the two-element set {(1,2), (2,1)}, again pinned down by omega. Finset.sum_pair (with the pair-distinctness (1,2) ≠ (2,1) discharged by kernel decide — not native_decide, so no Lean.ofReduceBool axiom is introduced) expands the inner sum; substituting the already-proved degree-2 and degree-1 identities and closing with push_cast; ring yields the closed form. These scalar identities are the exact targets the determinants must match.",
+    "mathContext": "$p_3 = 3e_3 - \\big(-e_1 p_2 + e_2 p_1\\big) = e_1^3 - 3e_1 e_2 + 3e_3.$",
+    "significance": "key",
+    "relatedConcepts": ["Newton recurrence", "Finset.sum_pair", "decide vs native_decide", "axiom hygiene"],
+    "prerequisites": ["MvPolynomial.psum_eq_mul_esymm_sub_sum", "induction on prior identities"]
+  },
+  {
+    "id": "ann-psum-one-two-det",
+    "proofId": "newton-power-sum-identities-oq-01-oq-03",
+    "range": { "startLine": 96, "endLine": 107 },
+    "type": "insight",
+    "title": "Power sums as 1×1 and 2×2 determinants",
+    "content": "The forward Girard–Waring determinants for degrees 1 and 2. psum_one_det reads p₁ = det[e₁] and closes by Matrix.det_fin_one_of followed by psum_one_eq. psum_two_det reads p₂ = det[[e₁, 1], [2e₂, e₁]]; Matrix.det_fin_two_of expands it to e₁·e₁ − 1·(2e₂) = e₁² − 2e₂, and linear_combination psum_two_eq closes the gap against the scalar identity. The first column carries the derivative-like weights i·eᵢ (here 1·e₁ and 2·e₂) coming from the (-1)^{k+1}·k·eₖ term of the recurrence, while the constant 1 on the super-diagonal makes the cofactor expansion telescope into exactly the scalar Newton identity.",
+    "mathContext": "$p_2 = \\det\\begin{pmatrix} e_1 & 1 \\\\ 2e_2 & e_1\\end{pmatrix} = e_1^2 - 2e_2.$",
+    "significance": "key",
+    "relatedConcepts": ["determinant expansion", "cofactor expansion", "linear_combination tactic", "lower-Hessenberg matrix"],
+    "prerequisites": ["Matrix.det_fin_two_of", "small determinants"]
+  },
+  {
+    "id": "ann-psum-three-det",
+    "proofId": "newton-power-sum-identities-oq-01-oq-03",
+    "range": { "startLine": 109, "endLine": 120 },
+    "type": "insight",
+    "title": "The 3×3 determinant and the Matrix.of_apply simp trap",
+    "content": "psum_three_det packages p₃ as the 3×3 lower-Hessenberg determinant det[[e₁,1,0],[2e₂,e₁,1],[3e₃,e₂,e₁]]. Matrix.det_fin_three expands it, but a subtlety appears: the !![…] literal elaborates to Matrix.of ![…], so det_fin_three leaves entries of the form (Matrix.of M) i j. Matrix.of_apply must be included in the simp set — and fire before the cons/head lemmas — to peel the outer Matrix.of, otherwise simp reports 'no progress'. (The 1×1 and 2×2 cases sidestep this by using the *_of determinant lemmas which take the raw entries directly.) Once unfolded, linear_combination psum_three_eq matches the expansion against the scalar identity e₁³ − 3e₁e₂ + 3e₃.",
+    "mathContext": "$p_3 = \\det\\begin{pmatrix} e_1 & 1 & 0 \\\\ 2e_2 & e_1 & 1 \\\\ 3e_3 & e_2 & e_1\\end{pmatrix} = e_1^3 - 3e_1 e_2 + 3e_3.$",
+    "significance": "key",
+    "relatedConcepts": ["Matrix.det_fin_three", "Matrix.of_apply", "simp normal form", "matrix notation !![…]"],
+    "prerequisites": ["3×3 determinant expansion", "Lean simp internals"]
+  },
+  {
+    "id": "ann-example-fin2",
+    "proofId": "newton-power-sum-identities-oq-01-oq-03",
+    "range": { "startLine": 122, "endLine": 135 },
+    "type": "context",
+    "title": "Worked example: two variables over ℤ",
+    "content": "The closing example specialises the degree-2 determinant identity to σ = Fin 2 over ℤ, recovering the familiar p₂ = X₀² + X₁² = (X₀+X₁)² − 2X₀X₁ = e₁² − 2e₂ as a 2×2 determinant. It is a one-line application psum_two_det (Fin 2) ℤ, confirming that the abstract MvPolynomial identity instantiates correctly to concrete variable sets. This grounds the universal statement in the smallest nontrivial case a reader can verify by hand.",
+    "mathContext": "Over $\\mathbb{Z}$ with $X_0, X_1$: $p_2 = X_0^2 + X_1^2 = e_1^2 - 2e_2 = \\det\\begin{pmatrix} X_0+X_1 & 1 \\\\ 2X_0X_1 & X_0+X_1\\end{pmatrix}.$",
+    "significance": "context",
+    "relatedConcepts": ["specialisation", "concrete instances", "Fin 2"],
+    "prerequisites": ["MvPolynomial over ℤ"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `newton-power-sum-identities-oq-01-oq-03` (was zero-annotation).

## Changes
- **Created `annotations.json`** with 8 substantive annotations covering the entire Lean file (lines 3–135):
  - Docstring: the two dual determinant forms of Newton's identities
  - Ambient setup: universality over any finite σ and any commutative ring
  - The three forward scalar stepping-stones (p₁=e₁, p₂=e₁²−2e₂, p₃=e₁³−3e₁e₂+3e₃) via the unrolled Newton recurrence
  - The 1×1/2×2 and 3×3 Girard–Waring determinant identities
  - Worked Fin 2 / ℤ example
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- Notes two proof-craft points: the `Matrix.of_apply` simp trap in the 3×3 case and the kernel-`decide` (not `native_decide`) axiom hygiene, consistent with the entry's `axiomCount: 0`.

meta.json unchanged (already rich, 15 KB, within all size caps). No claims altered.