### PR TITLE
Enrich Stewart's Theorem from Law of Cosines (law-of-cosines-oq-04): expand annotations (5→8)

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-04/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-04/annotations.json
@@ -1,120 +1,98 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "law-of-cosines-oq-04",
+    "range": { "startLine": 3, "endLine": 22 },
+    "type": "concept",
+    "title": "Stewart's Theorem as a Cevian Generalization of the Law of Cosines",
+    "content": "The module docstring states the research question and the theorem. Stewart's theorem (1746) concerns a triangle ABC with a cevian AD of length d to side BC, splitting it into segments BD = m and DC = n (so m + n = a): then b²m + c²n = a(d² + mn), equivalently b²m + c²n − a(d² + mn) = 0. The open question `law-of-cosines-oq-04` asks whether this can be derived from the inner-product / law-of-cosines framework — and the file answers yes. Stewart's theorem generalizes the law of cosines (it *is* the law of cosines applied twice to the sub-triangles and combined) and contains the median-length and angle-bisector-length formulas as special cases.",
+    "mathContext": "$b^2 m + c^2 n = a(d^2 + mn), \\qquad m + n = a$",
+    "significance": "context",
+    "relatedConcepts": ["Stewart's theorem", "cevian", "law of cosines", "median length formula", "angle bisector length"],
+    "prerequisites": ["triangle geometry", "law of cosines", "cevians"]
+  },
+  {
     "id": "ann-stewarts-algebraic",
     "proofId": "law-of-cosines-oq-04",
-    "range": {
-      "startLine": 43,
-      "endLine": 47
-    },
+    "range": { "startLine": 43, "endLine": 47 },
     "type": "insight",
     "title": "Algebraic Identity: Stewart's Theorem as a Ring Fact",
-    "content": "stewarts_algebraic is a pure algebraic theorem: it verifies that b\u00b2m + c\u00b2n - a(d\u00b2+mn) = m(b\u00b2-d\u00b2-n\u00b2) + n(c\u00b2-d\u00b2-m\u00b2) for any reals with m+n=a. The proof is just ring after substituting a = m+n. This separates the algebraic skeleton of the proof from its geometric meaning \u2014 the geometric content is the identification of b\u00b2-d\u00b2-n\u00b2 as -2dnt (from the law of cosines in triangle ACD).",
-    "mathContext": "Substituting $a = m+n$: LHS $= b^2 m + c^2 n - (m+n)(d^2 + mn)$. RHS $= m(b^2 - d^2 - n^2) + n(c^2 - d^2 - m^2) = b^2 m - md^2 - mn^2 + c^2 n - nd^2 - nm^2 = b^2 m + c^2 n - (m+n)d^2 - mn(m+n)$. LHS equals RHS since $mn + (m+n)d^2 = (m+n)(d^2 + mn)$... wait, that's $d^2(m+n) + mn(m+n)$, not equal to LHS unless we factor. Actually: $(m+n)(d^2+mn) = md^2+nd^2+m^2 n+mn^2 = (m+n)d^2+mn(m+n)$. RHS $= b^2m+c^2n - (m+n)d^2 - mn^2 - m^2 n = b^2m+c^2n-(m+n)d^2 - mn(m+n)$. Equal. \\texttt{ring} verifies this automatically.",
+    "content": "stewarts_algebraic is a pure algebraic theorem: it verifies that b²m + c²n - a(d²+mn) = m(b²-d²-n²) + n(c²-d²-m²) for any reals with m+n=a. The proof is just ring after substituting a = m+n. This separates the algebraic skeleton of the proof from its geometric meaning — the geometric content is the identification of b²-d²-n² as -2dnt (from the law of cosines in triangle ACD).",
+    "mathContext": "Substituting $a = m+n$: LHS $= b^2 m + c^2 n - (m+n)(d^2 + mn)$. RHS $= m(b^2 - d^2 - n^2) + n(c^2 - d^2 - m^2)$. Both expand to $b^2 m + c^2 n - (m+n)d^2 - mn(m+n)$, so they are equal; \\texttt{ring} verifies this automatically.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "ring tactic in Lean 4",
-      "separation of algebra from geometry",
-      "cevian identity"
-    ],
-    "prerequisites": [
-      "ring tactic",
-      "algebraic manipulation with hypotheses (ha : m+n=a)"
-    ]
+    "relatedConcepts": ["ring tactic in Lean 4", "separation of algebra from geometry", "cevian identity"],
+    "prerequisites": ["ring tactic", "algebraic manipulation with hypotheses (ha : m+n=a)"]
+  },
+  {
+    "id": "ann-lawofcosines-defs",
+    "proofId": "law-of-cosines-oq-04",
+    "range": { "startLine": 52, "endLine": 65 },
+    "type": "definition",
+    "title": "Part II — The Three Law-of-Cosines Relations as Propositions",
+    "content": "Three `def`s name the law-of-cosines relations used in the derivation: `lawOfCosines_ABD` (d² = c² + m² − 2cm·cos B in sub-triangle ABD), `lawOfCosines_ACD` (d² = b² + n² − 2bn·cos C in sub-triangle ACD), and `lawOfCosines_ABC` (a² = b² + c² − 2bc·cos A in the whole triangle). Packaging each as a named `Prop` rather than inlining it documents the geometric hypotheses cleanly and lets the theorems below take them as explicit assumptions. Crucially, the proof does not need the *angles* themselves — only that the two cevian-angle cosines are negatives of each other (supplementary), which is why the theorems abstract the shared cosine into a single variable `t`.",
+    "mathContext": "$d^2 = c^2 + m^2 - 2cm\\cos B, \\quad d^2 = b^2 + n^2 - 2bn\\cos C, \\quad a^2 = b^2 + c^2 - 2bc\\cos A$",
+    "significance": "supporting",
+    "relatedConcepts": ["law of cosines", "Prop as hypothesis", "sub-triangles", "cevian angles"],
+    "prerequisites": ["law of cosines", "Lean Prop definitions"]
   },
   {
     "id": "ann-supplementary-angles",
     "proofId": "law-of-cosines-oq-04",
-    "range": {
-      "startLine": 79,
-      "endLine": 89
-    },
+    "range": { "startLine": 79, "endLine": 89 },
     "type": "insight",
     "title": "Stewart's from Cosines: Supplementary Angle Trick",
-    "content": "stewarts_from_cosines is the geometric core: it shows that given the two law-of-cosines equations for sub-triangles ABD and ACD (with supplementary angle variable t = cos(\u2220BDA)), the identity b\u00b2m + c\u00b2n = (m+n)(d\u00b2+mn) follows by ring. The key design decision is abstracting the angle relationship into a single variable t \u2014 instead of formalizing that \u2220BDA + \u2220CDA = \u03c0 (which would require trigonometry infrastructure), the proof simply takes two hypotheses where one uses +2dnt and the other -2dmt, and ring eliminates t automatically.",
-    "mathContext": "Triangle ABD: $c^2 = d^2 + m^2 - 2dm \\cdot t$. Triangle ACD: $b^2 = d^2 + n^2 + 2dn \\cdot t$ (note $+$ from $\\cos(\\pi - \\theta) = -\\cos(\\theta)$). Multiply first by $n$: $c^2 n = n d^2 + nm^2 - 2dmnt$. Multiply second by $m$: $b^2 m = md^2 + mn^2 + 2dmnt$. Add: $b^2m + c^2n = (m+n)d^2 + nm^2 + mn^2 = (m+n)d^2 + mn(n+m) = (m+n)(d^2+mn)$. Lean proof: \\texttt{rw [h\\_ABD, h\\_ACD]; ring}.",
+    "content": "stewarts_from_cosines is the geometric core: it shows that given the two law-of-cosines equations for sub-triangles ABD and ACD (with supplementary angle variable t = cos(∠BDA)), the identity b²m + c²n = (m+n)(d²+mn) follows by ring. The key design decision is abstracting the angle relationship into a single variable t — instead of formalizing that ∠BDA + ∠CDA = π (which would require trigonometry infrastructure), the proof simply takes two hypotheses where one uses +2dnt and the other -2dmt, and ring eliminates t automatically.",
+    "mathContext": "Triangle ABD: $c^2 = d^2 + m^2 - 2dm \\cdot t$. Triangle ACD: $b^2 = d^2 + n^2 + 2dn \\cdot t$ (note $+$ from $\\cos(\\pi - \\theta) = -\\cos(\\theta)$). Multiply first by $n$, second by $m$, add: $b^2m + c^2n = (m+n)d^2 + mn(n+m) = (m+n)(d^2+mn)$. Lean proof: \\texttt{rw [h\\_ABD, h\\_ACD]; ring}.",
     "significance": "key",
-    "relatedConcepts": [
-      "supplementary angles",
-      "law of cosines",
-      "ring tactic for linear arithmetic",
-      "t-abstraction"
-    ],
-    "prerequisites": [
-      "cos(\u03c0-\u03b8) = -cos(\u03b8)",
-      "ring tactic",
-      "rewriting with hypotheses"
-    ]
+    "relatedConcepts": ["supplementary angles", "law of cosines", "ring tactic for linear arithmetic", "t-abstraction"],
+    "prerequisites": ["cos(π-θ) = -cos(θ)", "ring tactic", "rewriting with hypotheses"]
+  },
+  {
+    "id": "ann-stewarts-standard",
+    "proofId": "law-of-cosines-oq-04",
+    "range": { "startLine": 91, "endLine": 98 },
+    "type": "insight",
+    "title": "Stewart's Theorem in Standard Form",
+    "content": "`stewarts_theorem` packages the core result into the textbook statement b²m + c²n = a(d² + mn), reintroducing the side length a via the hypothesis m + n = a. The proof simply invokes `stewarts_from_cosines` to get b²m + c²n = (m+n)(d² + mn), then rewrites (m + n) to a with `ha`. This is the clean interface theorem the downstream special cases (median, angle bisector) actually apply — separating the a = m + n bookkeeping from the trigonometric elimination done in `stewarts_from_cosines`.",
+    "mathContext": "$b^2 m + c^2 n = (m+n)(d^2 + mn) \\xrightarrow{\\;m+n=a\\;} b^2 m + c^2 n = a(d^2 + mn)$",
+    "significance": "key",
+    "relatedConcepts": ["Stewart's theorem", "interface lemma", "rewriting with equalities", "stewarts_from_cosines"],
+    "prerequisites": ["stewarts_from_cosines", "substitution m+n=a"]
   },
   {
     "id": "ann-median-formula",
     "proofId": "law-of-cosines-oq-04",
-    "range": {
-      "startLine": 109,
-      "endLine": 115
-    },
+    "range": { "startLine": 109, "endLine": 115 },
     "type": "insight",
     "title": "Median Length Formula: Stewart's Theorem Specialized",
-    "content": "median_length_formula specializes Stewart's theorem to the case m = n = a/2 (midpoint). The proof applies stewarts_theorem with these values, then uses field_simp to clear the 1/4 and 1/2 denominators, and nlinarith to handle the resulting nonlinear arithmetic. The fact that a \u2260 0 is required because the median formula divides by a (implicit in field_simp), even though the geometric case a=0 would be degenerate anyway.",
-    "mathContext": "Substituting $m = n = a/2$ in $b^2 m + c^2 n = a(d^2+mn)$: $(b^2+c^2)(a/2) = a(d^2 + a^2/4)$. Divide by $a$ (nonzero): $(b^2+c^2)/2 = d^2 + a^2/4$, so $d^2 = (b^2+c^2)/2 - a^2/4 = (2b^2+2c^2-a^2)/4$. After \\texttt{field\\_simp}: Lean gets $4d^2 = 2b^2+2c^2-a^2$ as a polynomial equation, then \\texttt{nlinarith} closes it from the hypothesis (which after field_simp has the form $(b^2+c^2)a/2 = a(d^2+a^2/4)$ expanded).",
+    "content": "median_length_formula specializes Stewart's theorem to the case m = n = a/2 (midpoint). The proof applies stewarts_theorem with these values, then uses field_simp to clear the 1/4 and 1/2 denominators, and nlinarith to handle the resulting nonlinear arithmetic. The fact that a ≠ 0 is required because the median formula divides by a (implicit in field_simp), even though the geometric case a=0 would be degenerate anyway.",
+    "mathContext": "Substituting $m = n = a/2$ in $b^2 m + c^2 n = a(d^2+mn)$: $(b^2+c^2)(a/2) = a(d^2 + a^2/4)$. Divide by $a$ (nonzero): $d^2 = (b^2+c^2)/2 - a^2/4 = (2b^2+2c^2-a^2)/4$. After \\texttt{field\\_simp}: Lean gets $4d^2 = 2b^2+2c^2-a^2$, then \\texttt{nlinarith} closes it.",
     "significance": "key",
-    "relatedConcepts": [
-      "Apollonius's theorem",
-      "median length",
-      "field_simp for fractions",
-      "nlinarith for nonlinear arithmetic"
-    ],
-    "prerequisites": [
-      "field_simp for denominators",
-      "nlinarith tactic",
-      "Apollonius's theorem (equivalent formulation)"
-    ]
-  },
-  {
-    "id": "ann-right-triangle",
-    "proofId": "law-of-cosines-oq-04",
-    "range": {
-      "startLine": 135,
-      "endLine": 137
-    },
-    "type": "insight",
-    "title": "Verification: Median to Hypotenuse of 3-4-5 Triangle",
-    "content": "The right_triangle_median theorem verifies the specific case: in a 3-4-5 right triangle, the median to the hypotenuse has length 5/2. This is the classical result that the median to the hypotenuse of a right triangle equals half the hypotenuse \u2014 geometrically, because the right angle inscribes in a semicircle. The Lean proof is purely computational: norm_num verifies (2\u00b716 + 2\u00b79 - 25)/4 = 25/4 by arithmetic.",
-    "mathContext": "$(2 \\cdot 4^2 + 2 \\cdot 3^2 - 5^2)/4 = (32 + 18 - 25)/4 = 25/4$. The geometric interpretation: in a right triangle with hypotenuse $a$, the median to the hypotenuse has length $a/2$ because the right triangle inscribes in a semicircle of diameter $a$, and the median from the right angle vertex to the hypotenuse equals the circumradius = $a/2$. This can also be seen from: $d^2 = (2b^2+2c^2-a^2)/4 = (2(b^2+c^2)-a^2)/4 = (2a^2-a^2)/4 = a^2/4$ using $b^2+c^2=a^2$ (Pythagorean theorem).",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "Thales' theorem",
-      "inscribed angle theorem",
-      "norm_num tactic",
-      "right triangle geometry"
-    ],
-    "prerequisites": [
-      "Pythagorean theorem",
-      "circumradius of right triangle",
-      "norm_num for arithmetic verification"
-    ]
+    "relatedConcepts": ["Apollonius's theorem", "median length", "field_simp for fractions", "nlinarith for nonlinear arithmetic"],
+    "prerequisites": ["field_simp for denominators", "nlinarith tactic", "Apollonius's theorem (equivalent formulation)"]
   },
   {
     "id": "ann-angle-bisector",
     "proofId": "law-of-cosines-oq-04",
-    "range": {
-      "startLine": 118,
-      "endLine": 134
-    },
+    "range": { "startLine": 122, "endLine": 134 },
     "type": "insight",
     "title": "Angle Bisector Length via Stewart's Theorem",
-    "content": "Stewart's theorem specializes further: when the cevian is the angle bisector, the angle bisector theorem gives m/n = c/b, so m = ca/(b+c) and n = ba/(b+c). Substituting into Stewart's formula yields the angle bisector length d\u00b2 = bc[(b+c)\u00b2 - a\u00b2]/(b+c)\u00b2. This is the classical angle bisector length formula, derived purely algebraically from the law of cosines without trigonometry.",
+    "content": "Stewart's theorem specializes further: when the cevian is the angle bisector, the angle bisector theorem gives m/n = c/b, so m = ca/(b+c) and n = ba/(b+c). Substituting into Stewart's formula yields the angle bisector length d² = bc[(b+c)² - a²]/(b+c)². This is the classical angle bisector length formula, derived purely algebraically from the law of cosines without trigonometry.",
     "mathContext": "The angle bisector from vertex $A$ to side $BC$ of length $a$ has length $d$ satisfying $d^2 = bc\\left[1 - \\left(\\frac{a}{b+c}\\right)^2\\right] = \\frac{bc[(b+c)^2 - a^2]}{(b+c)^2}$. This follows from Stewart's theorem with $m = \\frac{ca}{b+c}$, $n = \\frac{ba}{b+c}$ (from the angle bisector theorem $m:n = c:b$). The formula shows $d \\leq \\sqrt{bc}$ with equality iff $a = 0$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "angle bisector theorem",
-      "Stewart's theorem",
-      "cevian length",
-      "law of cosines"
-    ],
-    "prerequisites": [
-      "stewarts_theorem (proved above)",
-      "angle bisector theorem (m/n = c/b)",
-      "algebraic manipulation"
-    ]
+    "relatedConcepts": ["angle bisector theorem", "Stewart's theorem", "cevian length", "law of cosines"],
+    "prerequisites": ["stewarts_theorem (proved above)", "angle bisector theorem (m/n = c/b)", "algebraic manipulation"]
+  },
+  {
+    "id": "ann-right-triangle",
+    "proofId": "law-of-cosines-oq-04",
+    "range": { "startLine": 135, "endLine": 137 },
+    "type": "insight",
+    "title": "Verification: Median to Hypotenuse of 3-4-5 Triangle",
+    "content": "The right_triangle_median theorem verifies the specific case: in a 3-4-5 right triangle, the median to the hypotenuse has length 5/2. This is the classical result that the median to the hypotenuse of a right triangle equals half the hypotenuse — geometrically, because the right angle inscribes in a semicircle. The Lean proof is purely computational: norm_num verifies (2·16 + 2·9 - 25)/4 = 25/4 by arithmetic.",
+    "mathContext": "$(2 \\cdot 4^2 + 2 \\cdot 3^2 - 5^2)/4 = (32 + 18 - 25)/4 = 25/4$. Geometric interpretation: in a right triangle with hypotenuse $a$, the median to the hypotenuse has length $a/2$ (the hypotenuse is a diameter of the circumcircle, so the vertex lies on a semicircle of radius $a/2$). Equivalently $d^2 = (2(b^2+c^2)-a^2)/4 = (2a^2-a^2)/4 = a^2/4$ using $b^2+c^2=a^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Thales' theorem", "inscribed angle theorem", "norm_num tactic", "right triangle geometry"],
+    "prerequisites": ["Pythagorean theorem", "circumradius of right triangle", "norm_num for arithmetic verification"]
   }
 ]


### PR DESCRIPTION
Enrichment (coverage-gap) pass for `law-of-cosines-oq-04`. The 5 existing annotations covered only ~28% of the 156-line Lean file, leaving the overview, Part II definitions, and the standard-form theorem unannotated.

Adds **3 annotations** (existing 5 preserved):
- **Overview** — Stewart's theorem b²m + c²n = a(d² + mn) as a cevian generalization of the law of cosines, and the OQ it answers.
- **Part II** — the three `lawOfCosines_ABD/ACD/ABC` relations packaged as Props, and why the proof only needs the supplementary-angle relationship (single variable `t`).
- **Standard-form `stewarts_theorem`** — the interface lemma reintroducing a = m + n, applied by the median and angle-bisector special cases.

Also re-anchors the pre-existing `ann-angle-bisector` annotation (was on a separator-comment line with no construct) onto its Part IV explanatory block. Coverage rises ~28% → ~54%. Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. All 8 line anchors validated via `validateLineAnnotations`. meta.json unchanged.