### PR TITLE
Enrich Dirichlet Lambda Values (basel-problem-oq-09-oq-01): expand annotations (5→8)

### DIFF
--- a/src/data/proofs/basel-problem-oq-09-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-09-oq-01/annotations.json
@@ -1,108 +1,98 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "basel-problem-oq-09-oq-01",
+    "range": { "startLine": 7, "endLine": 57 },
+    "type": "concept",
+    "title": "The Exponent-Uniform Parity Split and the Dirichlet Lambda Function",
+    "content": "The docstring states the entry's thesis: the parent (`basel-problem-oq-09`) split the Basel sum at the single exponent s = 2 to get ∑ 1/(2k+1)² = π²/8; this entry lifts that to an *exponent-uniform* law. For any convergent p-series with ∑ 1/nˢ = Z, the odd-index subseries is a fixed fraction of the whole: ∑ 1/(2k+1)ˢ = (1 − 2^{−s})·Z. Since the even part ∑ 1/(2k)ˢ = 2^{−s}·Z is just a rescaled copy of the full series, the fraction 1 − 2^{−s} is the *only* exponent-dependent quantity. Writing λ(s) := ∑ 1/(2k+1)ˢ for the Dirichlet lambda function, this is exactly λ(s) = (1 − 2^{−s})·ζ(s), specializing to λ(2) = π²/8, λ(4) = π⁴/96, and λ(2m) = (1 − 2^{−2m})·ζ(2m). Crucially, no new analytic input beyond the parent's toolkit is needed — the novelty is the abstraction and the s = 4 value.",
+    "mathContext": "$\\lambda(s) = \\sum_{k\\ge0}\\frac{1}{(2k+1)^s} = (1 - 2^{-s})\\,\\zeta(s)$",
+    "significance": "context",
+    "relatedConcepts": ["Dirichlet lambda function", "Riemann zeta at even integers", "Basel problem", "even/odd decomposition", "p-series"],
+    "prerequisites": ["infinite series", "Riemann zeta function", "HasSum API"]
+  },
+  {
     "id": "general-parity-split",
     "proofId": "basel-problem-oq-09-oq-01",
-    "range": {
-      "startLine": 72,
-      "endLine": 105
-    },
+    "range": { "startLine": 72, "endLine": 105 },
     "type": "theorem",
     "title": "hasSum_odd_pow — The Exponent-Uniform Parity Split",
     "content": "The single lemma that carries the whole entry. For any natural exponent s and any value Z with HasSum (fun n => 1/nˢ) Z, the odd-index subseries sums to (1 − 1/2ˢ)·Z. The proof has three moves and no analysis: (1) the even subseries fun k ↦ 1/(2k)ˢ equals (1/2ˢ)·(1/kˢ) termwise — mul_pow turns (2k)ˢ into 2ˢ·kˢ, and the rewrite is valid even at k = 0 where both sides are 1/0 = 0 in ℝ — so HasSum.mul_left evaluates it to (1/2ˢ)·Z; (2) the odd subseries is summable because k ↦ 2k+1 is injective (Summable.comp_injective); (3) HasSum.even_add_odd reassembles the full series and HasSum.unique forces (1/2ˢ)·Z + (odd) = Z, pinning the odd value to (1 − 1/2ˢ)·Z. This is exactly the reusable lemma the parent open question requested; the parent proved only the s = 2 instance by hand.",
     "mathContext": "$\\lambda(s) = \\sum_{k\\ge 0} \\dfrac{1}{(2k+1)^s} = \\left(1 - 2^{-s}\\right)\\zeta(s)$ for every convergent exponent.",
     "significance": "key",
-    "relatedConcepts": [
-      "Dirichlet lambda function",
-      "even/odd decomposition",
-      "uniqueness of sums",
-      "p-series"
-    ],
-    "prerequisites": [
-      "HasSum API",
-      "infinite series"
-    ]
+    "relatedConcepts": ["Dirichlet lambda function", "even/odd decomposition", "uniqueness of sums", "p-series"],
+    "prerequisites": ["HasSum API", "infinite series"]
+  },
+  {
+    "id": "ann-tsum-forms",
+    "proofId": "basel-problem-oq-09-oq-01",
+    "range": { "startLine": 108, "endLine": 111 },
+    "type": "technique",
+    "title": "tsum Companions: From HasSum to an Equation of Values",
+    "content": "`tsum_odd_pow` restates the parity split as a plain equation ∑' k, 1/(2k+1)ˢ = (1 − 1/2ˢ)·Z by applying `.tsum_eq` to `hasSum_odd_pow`. This is the pattern repeated throughout the file: each `HasSum`-valued theorem has a `tsum_`-prefixed corollary (`tsum_lambda_two`, `tsum_lambda_four`) giving the value as an ordinary `∑'` identity, plus `summable_lambda_four` and `lambda_four_pos` as convenience corollaries. The `HasSum` form is the stronger primitive (it packages summability *and* the value); `.tsum_eq` projects out just the value once summability is settled, which is the shape most consumers cite.",
+    "mathContext": "$\\text{HasSum } f\\ Z \\;\\Rightarrow\\; \\sum' f = Z$ via \\texttt{HasSum.tsum\\_eq}",
+    "significance": "supporting",
+    "relatedConcepts": ["HasSum vs tsum", "HasSum.tsum_eq", "Summable", "corollary pattern"],
+    "prerequisites": ["tsum notation", "HasSum API"]
   },
   {
     "id": "lambda-nat",
     "proofId": "basel-problem-oq-09-oq-01",
-    "range": {
-      "startLine": 121,
-      "endLine": 126
-    },
+    "range": { "startLine": 121, "endLine": 126 },
     "type": "theorem",
     "title": "hasSum_lambda_nat — λ(2m) = (1 − 2^{−2m})·ζ(2m)",
     "content": "The general even-exponent value, obtained by feeding Mathlib's hasSum_zeta_nat (the explicit Bernoulli closed form for ζ(2m)) into hasSum_odd_pow. No work beyond the specialization: the parity fraction 1 − 2^{−2m} multiplies whatever value ζ(2m) takes. This is the full Dirichlet lambda formula at even integers, stated for arbitrary m ≥ 1.",
     "mathContext": "$\\lambda(2m) = \\left(1 - 2^{-2m}\\right)\\zeta(2m)$, with $\\zeta(2m)$ the Bernoulli closed form.",
     "significance": "key",
-    "relatedConcepts": [
-      "Bernoulli numbers",
-      "zeta values at even integers",
-      "Dirichlet lambda function"
-    ],
-    "prerequisites": [
-      "hasSum_zeta_nat",
-      "Bernoulli numbers"
-    ]
-  },
-  {
-    "id": "lambda-four",
-    "proofId": "basel-problem-oq-09-oq-01",
-    "range": {
-      "startLine": 150,
-      "endLine": 154
-    },
-    "type": "theorem",
-    "title": "hasSum_lambda_four — λ(4) = π⁴/96 (the new value)",
-    "content": "The headline new result: ∑_{k≥0} 1/(2k+1)⁴ = 1 + 1/3⁴ + 1/5⁴ + ⋯ = π⁴/96. A one-line specialization of hasSum_odd_pow to Mathlib's hasSum_zeta_four (ζ(4) = π⁴/90) through the parity fraction 1 − 2^{−4} = 15/16: (15/16)·(π⁴/90) = π⁴/96. The 'no new analytic input' the open question asked for is literal — the only step is a norm_num/ring rewrite of the constant.",
-    "mathContext": "$\\sum_{k=0}^{\\infty} \\dfrac{1}{(2k+1)^4} = \\dfrac{15}{16}\\cdot\\dfrac{\\pi^4}{90} = \\dfrac{\\pi^4}{96}$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "Dirichlet lambda function",
-      "zeta of 4",
-      "odd fourth-power series"
-    ],
-    "prerequisites": [
-      "hasSum_zeta_four"
-    ]
+    "relatedConcepts": ["Bernoulli numbers", "zeta values at even integers", "Dirichlet lambda function"],
+    "prerequisites": ["hasSum_zeta_nat", "Bernoulli numbers"]
   },
   {
     "id": "lambda-two",
     "proofId": "basel-problem-oq-09-oq-01",
-    "range": {
-      "startLine": 132,
-      "endLine": 136
-    },
+    "range": { "startLine": 132, "endLine": 136 },
     "type": "theorem",
     "title": "hasSum_lambda_two — λ(2) = π²/8 (recovers the parent)",
     "content": "A consistency check: specializing the general lemma to hasSum_zeta_two through the fraction 1 − 2^{−2} = 3/4 reproduces the parent entry's odd-square value π²/8. That the exponent-uniform lemma reproduces the hand-built parent result confirms the abstraction is faithful.",
     "mathContext": "$\\sum_{k=0}^{\\infty} \\dfrac{1}{(2k+1)^2} = \\dfrac{3}{4}\\cdot\\dfrac{\\pi^2}{6} = \\dfrac{\\pi^2}{8}$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "Basel problem",
-      "odd-square series"
-    ],
-    "prerequisites": [
-      "hasSum_zeta_two"
-    ]
+    "relatedConcepts": ["Basel problem", "odd-square series"],
+    "prerequisites": ["hasSum_zeta_two"]
+  },
+  {
+    "id": "lambda-four",
+    "proofId": "basel-problem-oq-09-oq-01",
+    "range": { "startLine": 150, "endLine": 154 },
+    "type": "theorem",
+    "title": "hasSum_lambda_four — λ(4) = π⁴/96 (the new value)",
+    "content": "The headline new result: ∑_{k≥0} 1/(2k+1)⁴ = 1 + 1/3⁴ + 1/5⁴ + ⋯ = π⁴/96. A one-line specialization of hasSum_odd_pow to Mathlib's hasSum_zeta_four (ζ(4) = π⁴/90) through the parity fraction 1 − 2^{−4} = 15/16: (15/16)·(π⁴/90) = π⁴/96. The 'no new analytic input' the open question asked for is literal — the only step is a norm_num/ring rewrite of the constant.",
+    "mathContext": "$\\sum_{k=0}^{\\infty} \\dfrac{1}{(2k+1)^4} = \\dfrac{15}{16}\\cdot\\dfrac{\\pi^4}{90} = \\dfrac{\\pi^4}{96}$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet lambda function", "zeta of 4", "odd fourth-power series"],
+    "prerequisites": ["hasSum_zeta_four"]
+  },
+  {
+    "id": "ann-structural",
+    "proofId": "basel-problem-oq-09-oq-01",
+    "range": { "startLine": 169, "endLine": 178 },
+    "type": "insight",
+    "title": "Structural Consequences: How the Mass Splits Between Even and Odd Indices",
+    "content": "Two theorems make the even/odd mass distribution explicit at s = 4. `zeta_four_even_odd_decomposition` records that ζ(4) = π⁴/90 splits as (even part) + λ(4) = (π⁴/90 − π⁴/96) + π⁴/96 — the full Basel-4 value partitions in the ratio 2^{−4} : (1 − 2^{−4}), i.e. 1 : 15. `lambda_four_gt_even_part` then shows the odd part dominates: λ(4) = π⁴/96 exceeds the even part π⁴/90 − π⁴/96, since the odd indices carry 15/16 of the total. Together with `parity_fraction_mono` (the odd share grows with s), these give the qualitative picture behind the numerology: as the exponent increases, the series concentrates ever more on the odd terms.",
+    "mathContext": "$\\zeta(4) = \\underbrace{(\\tfrac{\\pi^4}{90}-\\tfrac{\\pi^4}{96})}_{\\text{even}, \\ 1/16} + \\underbrace{\\tfrac{\\pi^4}{96}}_{\\text{odd}, \\ 15/16}, \\qquad \\text{odd} > \\text{even}$",
+    "significance": "supporting",
+    "relatedConcepts": ["even/odd mass distribution", "ratio 2^{−s} : (1−2^{−s})", "monotonicity in the exponent"],
+    "prerequisites": ["the λ(4) value", "elementary inequalities", "positivity"]
   },
   {
     "id": "parity-fraction-mono",
     "proofId": "basel-problem-oq-09-oq-01",
-    "range": {
-      "startLine": 180,
-      "endLine": 182
-    },
+    "range": { "startLine": 180, "endLine": 182 },
     "type": "theorem",
     "title": "parity_fraction_mono — The Odd Share Grows with the Exponent",
     "content": "Records the structural fact behind the values: the parity fraction 1 − 2^{−s} increases in s, so a larger share of ζ(s) concentrates on the odd indices as the exponent grows — three quarters at s = 2, fifteen sixteenths at s = 4. Paired with lambda_four_gt_even_part (the odd part exceeds the even part at s = 4) and the ζ(4) decomposition.",
     "mathContext": "$1 - 2^{-2} = \\tfrac34 < \\tfrac{15}{16} = 1 - 2^{-4}$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "monotonicity",
-      "even/odd mass distribution"
-    ],
-    "prerequisites": [
-      "elementary inequalities"
-    ]
+    "relatedConcepts": ["monotonicity", "even/odd mass distribution"],
+    "prerequisites": ["elementary inequalities"]
   }
 ]


### PR DESCRIPTION
Enrichment (coverage-gap) pass for `basel-problem-oq-09-oq-01`. The 5 existing annotations covered ~28% of the 192-line Lean file, leaving the substantial docstring, the tsum companions, and the structural-consequences section unannotated.

Adds **3 annotations** (existing 5 preserved):
- **Overview** — the exponent-uniform parity split λ(s) = (1 − 2^{−s})·ζ(s), the Dirichlet lambda function, and the specializations λ(2)=π²/8, λ(4)=π⁴/96.
- **tsum companions** — the HasSum → `.tsum_eq` corollary pattern (`tsum_odd_pow`, `tsum_lambda_two/four`, `summable_lambda_four`, `lambda_four_pos`).
- **Structural consequences** — the even/odd mass decomposition of ζ(4) (ratio 1:15) and that the odd part dominates.

Coverage rises ~28% → ~61%. Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. All 8 line anchors validated via `validateLineAnnotations`. meta.json unchanged.