### PR TITLE
Enrich Fibre Counts for the Power Map x↦xᵏ: add 8 annotations

### DIFF
--- a/src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header-gcd-law",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-02",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "From character sums to the structural gcd law",
+    "content": "The docstring reframes the parent's quadratic-character count. The parent counts nonzero squares of ZMod p via the quadratic character χ and the vanishing sum ∑χ = 0, showing x ↦ x² is 2-to-1 on the units. This file answers the parent's open question for every exponent k and every finite field F by discarding the per-k character orthogonality and using its structural engine directly: on the cyclic group Fˣ the map x ↦ xᵏ is a monoid endomorphism whose kernel and range sizes are pinned by d = gcd(k, q−1). The whole higher-order theory (cubic, quartic, …) collapses into one gcd formula because Fˣ is cyclic.",
+    "mathContext": "With $q=|F|$, $d=\\gcd(k,q-1)$: $\\#\\{x^k=1\\}=d$, $\\#\\{x^k\\}=(q-1)/d$, and $x\\mapsto x^k$ is $d$-to-$1$ onto its image.",
+    "significance": "context",
+    "relatedConcepts": ["multiplicative characters", "character orthogonality", "cyclic group", "power map", "k-th power residues"],
+    "prerequisites": ["finite fields", "group theory"]
+  },
+  {
+    "id": "ann-powhom",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-02",
+    "range": { "startLine": 45, "endLine": 50 },
+    "type": "definition",
+    "title": "The power map as a monoid endomorphism",
+    "content": "The single definition of the file: powHom k is Mathlib's powMonoidHom k specialised to Fˣ, the group homomorphism x ↦ xᵏ. Because Fˣ is a finite cyclic group, packaging the power map as a MonoidHom (rather than a bare function) is precisely what turns the fibre count into pure arithmetic — kernel and range become subgroups whose orders obey Lagrange. The simp lemma powHom_apply : powHom k x = x^k, proved by rfl, lets later proofs move freely between the homomorphism and the raw power.",
+    "mathContext": "$\\mathrm{powHom}\\,k = \\mathrm{powMonoidHom}\\,k : F^\\times \\to F^\\times,\\ x \\mapsto x^k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monoid homomorphism", "powMonoidHom", "endomorphism of a group"],
+    "prerequisites": ["group homomorphisms", "units of a ring"]
+  },
+  {
+    "id": "ann-card-roots",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-02",
+    "range": { "startLine": 52, "endLine": 57 },
+    "type": "technique",
+    "title": "Kernel size = number of k-th roots of unity = gcd(k, q−1)",
+    "content": "card_kthRootsOfUnity computes the kernel of the power map: the k-th roots of unity in Fˣ number exactly gcd(q−1, k). The proof is a three-lemma rewrite — IsCyclic.card_powMonoidHom_ker (valid because Fˣ is cyclic) gives gcd(|Fˣ|, k), Nat.card_eq_fintype_card bridges Nat.card and Fintype.card, and Fintype.card_units converts |Fˣ| to |F| − 1 = q − 1. This is the higher-order kernel that the quadratic character sum silently computes at k = 2.",
+    "mathContext": "$\\#\\ker(x\\mapsto x^k) = \\#\\{x : x^k=1\\} = \\gcd(q-1,\\,k).$",
+    "significance": "key",
+    "relatedConcepts": ["IsCyclic.card_powMonoidHom_ker", "roots of unity", "kernel of a homomorphism", "Fintype.card_units"],
+    "prerequisites": ["cyclic groups", "kernel cardinality"]
+  },
+  {
+    "id": "ann-card-powers",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-02",
+    "range": { "startLine": 59, "endLine": 64 },
+    "type": "technique",
+    "title": "Range size = number of k-th powers = (q−1)/gcd(k, q−1)",
+    "content": "card_kthPowers is the dual of the kernel count: the image of the power map (the set of k-th powers) has cardinality (q−1)/gcd(q−1, k). The proof mirrors the kernel one, using IsCyclic.card_powMonoidHom_range in place of the kernel lemma. Together with card_kthRootsOfUnity this gives both halves of the first-isomorphism factorisation |Fˣ| = #range · #ker.",
+    "mathContext": "$\\#\\mathrm{range}(x\\mapsto x^k) = \\#\\{x^k\\} = (q-1)/\\gcd(q-1,\\,k).$",
+    "significance": "key",
+    "relatedConcepts": ["IsCyclic.card_powMonoidHom_range", "image of a homomorphism", "k-th powers", "quotient group"],
+    "prerequisites": ["cyclic groups", "first isomorphism theorem"]
+  },
+  {
+    "id": "ann-fibre-coset",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-02",
+    "range": { "startLine": 66, "endLine": 76 },
+    "type": "insight",
+    "title": "Every non-empty fibre is a coset of the kernel",
+    "content": "card_fibre_of_mem_range establishes the uniform fibre count: if a = xᵏ is a k-th power, the fibre {y : yᵏ = a} has exactly gcd(q−1, k) elements. The argument destructures the range-membership witness a = powHom k x, rewrites the fibre over a as the fibre over powHom k x, and applies MonoidHom.fiberEquivKer — the canonical bijection between a fibre and the kernel (the fibre is the coset x·ker). Its cardinality then reduces to card_kthRootsOfUnity. This is the higher-order generalisation of the parent's '2-to-1' statement: the map is gcd(q−1, k)-to-1 onto its image.",
+    "mathContext": "$a=x^k \\implies \\{y : y^k=a\\} = x\\cdot\\ker \\cong \\ker,\\ \\text{so } \\#\\{y:y^k=a\\}=\\gcd(q-1,k).$",
+    "significance": "key",
+    "relatedConcepts": ["MonoidHom.fiberEquivKer", "cosets", "fibres of a homomorphism", "uniform-to-1 map"],
+    "prerequisites": ["cosets", "quotient groups", "Lagrange's theorem"]
+  },
+  {
+    "id": "ann-card-fibre-dichotomy",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-02",
+    "range": { "startLine": 78, "endLine": 97 },
+    "type": "technique",
+    "title": "The full dichotomy: gcd(k, q−1) or 0",
+    "content": "fibre_empty_of_not_mem_range handles the complementary case — a value that is not a k-th power has an empty pre-image, shown by a direct ext/contradiction (a witness would place a in the range). card_fibre then assembles both cases into the clean dichotomy: #{x : xᵏ = a} equals gcd(q−1, k) when a is a k-th power and 0 otherwise. The `open Classical in` is used only to make range-membership decidable so the if-then-else can be stated; it introduces no computational axiom, keeping the file at 0 axioms.",
+    "mathContext": "$\\#\\{x : x^k=a\\} = \\begin{cases}\\gcd(q-1,k) & a\\in(F^\\times)^k\\\\ 0 & \\text{otherwise}\\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["case dichotomy", "classical decidability", "empty fibre", "if-then-else"],
+    "prerequisites": ["Set preimages", "classical logic in Lean"]
+  },
+  {
+    "id": "ann-counting-identity",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-02",
+    "range": { "startLine": 99, "endLine": 107 },
+    "type": "insight",
+    "title": "The product identity: Lagrange as a divisibility cancellation",
+    "content": "card_powers_mul_card_roots multiplies the two counts back together: (#k-th powers)·gcd(q−1, k) = q − 1. This is Lagrange / the first isomorphism theorem for the power endomorphism (|image|·|kernel| = |group|), but here it needs no fresh structural theorem — it follows from the two card formulas by Nat.div_mul_cancel, whose side goal gcd(q−1, k) ∣ q−1 is exactly Nat.gcd_dvd_left. The identity certifies that x ↦ xᵏ is a genuine uniform d-to-1 surjection onto its image.",
+    "mathContext": "$\\frac{q-1}{\\gcd(q-1,k)}\\cdot\\gcd(q-1,k) = q-1,\\quad \\gcd(q-1,k)\\mid q-1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Lagrange's theorem", "first isomorphism theorem", "Nat.div_mul_cancel", "divisibility"],
+    "prerequisites": ["Lagrange's theorem", "natural-number division"]
+  },
+  {
+    "id": "ann-quadratic-specialisation",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-02",
+    "range": { "startLine": 111, "endLine": 143 },
+    "type": "context",
+    "title": "k = 2 over ℤ/p recovers the parent's (p−1)/2 count",
+    "content": "The specialisation section closes the loop with the parent entry. gcd_two_pSub_one proves gcd(2, p−1) = 2 for an odd prime p: p odd makes p−1 even, so 2 ∣ p−1 (extracted by omega from the Odd witness) and Nat.gcd_eq_left finishes. card_squares_zmod then feeds gcd = 2 and ZMod.card (|ZMod p| = p) into card_kthPowers to get exactly (p−1)/2 nonzero squares — the parent's quadratic-character count re-derived as the k = 2 shadow of the uniform gcd law, with no character sum in sight.",
+    "mathContext": "$\\gcd(2,p-1)=2 \\implies \\#\\{\\text{nonzero squares in }\\mathbb{Z}/p\\} = (p-1)/2.$",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic residues", "ZMod.card", "Nat.gcd_eq_left", "specialisation to k=2"],
+    "prerequisites": ["quadratic residues mod p", "omega tactic"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `quadratic-gauss-sum-square-oq-02-oq-02` (was zero-annotation).

## Changes
- **Created `annotations.json`** with 8 substantive annotations covering the full Lean file (lines 1–143): docstring reframing, the `powHom` endomorphism, kernel/range gcd counts, the coset fibre count, the gcd-or-0 dichotomy, the Lagrange product identity, and the k=2 / ℤ/p specialisation recovering the parent's (p−1)/2 count.
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json unchanged (already rich, 16.8 KB, within caps). No claims altered.