### PR TITLE
Enrich Kummer's Theorem OQ-03 (kummer-theorem-oq-03): expand annotations (5→7)

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-03/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-03/annotations.json
@@ -1,122 +1,86 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "kummer-theorem-oq-03",
+    "range": { "startLine": 1, "endLine": 17 },
+    "type": "concept",
+    "title": "Divisibility of Binomial Coefficients by Higher Prime Powers",
+    "content": "The docstring frames the entry as a strengthening of the parent's Kummer theorem (which computes the p-adic valuation of a binomial coefficient as a count of base-p carries). Here the goal is the full divisibility characterization by higher prime powers p^m, together with the classical 'prime row' consequences. Three results are promised: (1) p^m ∣ C(n,k) iff there are at least m carries in the base-p addition of k + (n−k); (2) p ∣ C(pⁿ,k) for every interior 0 < k < pⁿ; (3) p-adic patterns for specific rows. All follow from Mathlib plus the parent file, 0 axioms and 0 sorries. The historical arc runs from Kummer (1852, the carry theorem) to Granville (1997, prime-power generalizations).",
+    "mathContext": "$p^m \\mid \\binom{n}{k} \\iff \\#\\{\\text{base-}p\\text{ carries in } k+(n-k)\\} \\ge m$",
+    "significance": "context",
+    "relatedConcepts": ["Kummer's theorem", "p-adic valuation", "base-p carries", "Pascal's triangle mod p", "Lucas' theorem"],
+    "prerequisites": ["binomial coefficients", "base-p representation", "prime powers"]
+  },
+  {
     "id": "ann-kummer-oq03-carry-count",
     "proofId": "kummer-theorem-oq-03",
-    "range": {
-      "startLine": 30,
-      "endLine": 31
-    },
+    "range": { "startLine": 30, "endLine": 31 },
     "type": "definition",
     "title": "carryCount: Number of Base-p Carries in k + (n-k)",
-    "content": "`carryCount p n k b` counts the positions $i \\in \\{1, \\ldots, b-1\\}$ where a carry occurs when adding $k$ and $n-k$ in base $p$. The predicate `p^i \u2264 k % p^i + (n-k) % p^i` captures a carry at position $i$: the sum of the $i$-th digit contributions of $k$ and $n-k$ overflows the $p^i$ threshold. The bound `b = Nat.log p n + 1` is sufficient since carries above the top digit are impossible. The `noncomputable` qualifier is needed since `Finset.card` of a `filter` over `Ico` requires decidability of the predicate \u2014 in Lean 4 with `ENNReal`-like real arithmetic this is classical. This definition is the discrete encoding of Kummer's 1852 carry count.",
+    "content": "`carryCount p n k b` counts the positions $i \\in \\{1, \\ldots, b-1\\}$ where a carry occurs when adding $k$ and $n-k$ in base $p$. The predicate `p^i ≤ k % p^i + (n-k) % p^i` captures a carry at position $i$: the sum of the $i$-th digit contributions of $k$ and $n-k$ overflows the $p^i$ threshold. The bound `b = Nat.log p n + 1` is sufficient since carries above the top digit are impossible. The `noncomputable` qualifier is needed since `Finset.card` of a `filter` over `Ico` requires decidability of the predicate — in Lean 4 with `ENNReal`-like real arithmetic this is classical. This definition is the discrete encoding of Kummer's 1852 carry count.",
     "mathContext": "A carry occurs at position $i$ when $\\lfloor k/p^i \\rfloor + \\lfloor (n-k)/p^i \\rfloor > \\lfloor n/p^i \\rfloor$, equivalently when $(k \\bmod p^i) + ((n-k) \\bmod p^i) \\geq p^i$. The carryCount is $|\\{i : 1 \\leq i < b,\\; p^i \\leq (k \\bmod p^i) + ((n-k) \\bmod p^i)\\}|$.",
     "significance": "key",
-    "relatedConcepts": [
-      "base-p representation",
-      "carries in addition",
-      "Kummer's theorem",
-      "Finset.filter",
-      "Nat.log"
-    ],
-    "prerequisites": [
-      "Nat.log",
-      "Finset.Ico",
-      "Finset.card",
-      "Finset.filter"
-    ]
+    "relatedConcepts": ["base-p representation", "carries in addition", "Kummer's theorem", "Finset.filter", "Nat.log"],
+    "prerequisites": ["Nat.log", "Finset.Ico", "Finset.card", "Finset.filter"]
   },
   {
     "id": "ann-kummer-oq03-dvd-iff",
     "proofId": "kummer-theorem-oq-03",
-    "range": {
-      "startLine": 38,
-      "endLine": 44
-    },
+    "range": { "startLine": 38, "endLine": 44 },
     "type": "insight",
-    "title": "Kummer's Criterion for p^m: Divisibility \u2194 Carry Count \u2265 m",
-    "content": "`choose_dvd_prime_pow_iff` is the main theorem: $m \\leq \\text{carryCount}(p,n,k,b)$ iff $p^m \\mid \\binom{n}{k}$. The proof bridges three levels: (1) unfold `carryCount` to expose the Finset definition; (2) use `PartENat.coe_le_coe` to convert the \u2115 inequality $m \\leq |\\{\\text{carries}\\}|$ to a PartENat inequality $m \\leq v_p(\\binom{n}{k})$ via the parent's `kummer` theorem; (3) apply `multiplicity.pow_dvd_iff_le_multiplicity` to convert $p^m \\mid \\binom{n}{k}$ into $m \\leq v_p(\\binom{n}{k})$. The `.symm` at the end reverses the direction. The hypothesis `hnb : Nat.log p n < b` ensures the carry bound is sufficient.",
+    "title": "Kummer's Criterion for p^m: Divisibility ↔ Carry Count ≥ m",
+    "content": "`choose_dvd_prime_pow_iff` is the main theorem: $m \\leq \\text{carryCount}(p,n,k,b)$ iff $p^m \\mid \\binom{n}{k}$. The proof bridges three levels: (1) unfold `carryCount` to expose the Finset definition; (2) use `PartENat.coe_le_coe` to convert the ℕ inequality $m \\leq |\\{\\text{carries}\\}|$ to a PartENat inequality $m \\leq v_p(\\binom{n}{k})$ via the parent's `kummer` theorem; (3) apply `multiplicity.pow_dvd_iff_le_multiplicity` to convert $p^m \\mid \\binom{n}{k}$ into $m \\leq v_p(\\binom{n}{k})$. The `.symm` at the end reverses the direction. The hypothesis `hnb : Nat.log p n < b` ensures the carry bound is sufficient.",
     "mathContext": "$v_p(\\binom{n}{k}) = \\text{carryCount}(p,n,k)$ (Kummer 1852). Then: $p^m \\mid \\binom{n}{k} \\iff m \\leq v_p(\\binom{n}{k}) \\iff m \\leq \\text{carryCount}(p,n,k)$. Key Mathlib bridge: `multiplicity.pow_dvd_iff_le_multiplicity`: $p^m \\mid n \\iff m \\leq \\text{multiplicity}(p, n)$ (as PartENat values).",
     "significance": "key",
-    "relatedConcepts": [
-      "multiplicity.pow_dvd_iff_le_multiplicity",
-      "PartENat.coe_le_coe",
-      "kummer theorem",
-      "p-adic valuation"
-    ],
-    "prerequisites": [
-      "KummerTheorem (parent)",
-      "PartENat arithmetic",
-      "multiplicity in Mathlib"
-    ]
+    "relatedConcepts": ["multiplicity.pow_dvd_iff_le_multiplicity", "PartENat.coe_le_coe", "kummer theorem", "p-adic valuation"],
+    "prerequisites": ["KummerTheorem (parent)", "PartENat arithmetic", "multiplicity in Mathlib"]
   },
   {
     "id": "ann-kummer-oq03-pascal-row",
     "proofId": "kummer-theorem-oq-03",
-    "range": {
-      "startLine": 55,
-      "endLine": 58
-    },
+    "range": { "startLine": 55, "endLine": 58 },
     "type": "insight",
     "title": "Pascal's p^n-th Row: All Interior Entries Divisible by p",
-    "content": "`pascal_row_prime_power_div` proves $p \\mid \\binom{p^n}{k}$ for all $0 < k < p^n$. The proof is a one-line delegation to `prime_dvd_choose_prime_pow` from the parent file (`Proofs.KummerTheorem`). The key geometric insight, proved in the parent, is that when the top index is a pure prime power $p^n$, adding any interior $k$ and $p^n - k$ in base $p$ must produce at least one carry \u2014 because $p^n$ has a single non-zero base-$p$ digit (a 1 in position $n$), so the $n$-th digit sum must overflow. This is the Kummer-based proof of the classical 'prime row' property that underlies the primality test $p \\mid \\binom{p}{k}$ for all $0 < k < p$.",
+    "content": "`pascal_row_prime_power_div` proves $p \\mid \\binom{p^n}{k}$ for all $0 < k < p^n$. The proof is a one-line delegation to `prime_dvd_choose_prime_pow` from the parent file (`Proofs.KummerTheorem`). The key geometric insight, proved in the parent, is that when the top index is a pure prime power $p^n$, adding any interior $k$ and $p^n - k$ in base $p$ must produce at least one carry — because $p^n$ has a single non-zero base-$p$ digit (a 1 in position $n$), so the $n$-th digit sum must overflow. This is the Kummer-based proof of the classical 'prime row' property that underlies the primality test $p \\mid \\binom{p}{k}$ for all $0 < k < p$.",
     "mathContext": "$p^n$ in base $p$ is $1\\underbrace{00\\cdots0}_{n}$. For $0 < k < p^n$, the base-$p$ addition $k + (p^n - k)$ must produce a carry at position $n$ (since $k$ has nonzero contribution at some position $< n$ while $p^n - k$ must supply the complementary digits to reach $p^n$). Hence carryCount $\\geq 1$ and $p \\mid \\binom{p^n}{k}$.",
     "significance": "key",
-    "relatedConcepts": [
-      "prime_dvd_choose_prime_pow",
-      "Sierpi\u0144ski triangle",
-      "Pascal triangle fractal",
-      "carry at pure power"
-    ],
-    "prerequisites": [
-      "KummerTheorem (parent)",
-      "choose_dvd_prime_pow_iff"
-    ]
+    "relatedConcepts": ["prime_dvd_choose_prime_pow", "Sierpiński triangle", "Pascal triangle fractal", "carry at pure power"],
+    "prerequisites": ["KummerTheorem (parent)", "choose_dvd_prime_pow_iff"]
   },
   {
     "id": "ann-kummer-oq03-specific-rows",
     "proofId": "kummer-theorem-oq-03",
-    "range": {
-      "startLine": 64,
-      "endLine": 75
-    },
+    "range": { "startLine": 64, "endLine": 75 },
     "type": "concept",
     "title": "Classical Instances: Prime Row and Prime-Square Row",
     "content": "`choose_prime_div` proves the classical result $p \\mid \\binom{p}{k}$ for $0 < k < p$. This is obtained as the $n=1$ special case of `pascal_row_prime_power_div`, with a short `simp; omega` step to verify $k \\neq p^1$. `choose_prime_sq_div` handles the $n=2$ case $p \\mid \\binom{p^2}{k}$ for $0 < k < p^2$, again a one-line delegation with `omega`-closed side conditions. The classical $p \\mid \\binom{p}{k}$ result is the foundation of the most common proof of Fermat's little theorem via the binomial theorem: $(a+1)^p \\equiv a^p + 1 \\pmod{p}$ follows by induction, since all intermediate binomial coefficients $\\binom{p}{k}$ vanish mod $p$. The $p^2$ generalization appears in more refined number-theoretic arguments, for instance in the study of Wieferich primes.",
     "mathContext": "$p \\mid \\binom{p}{k}$ for $0 < k < p$: the classical 'primality lemma'. $p \\mid \\binom{p^2}{k}$ for $0 < k < p^2$: the $n=2$ generalization. Both follow from carryCount $\\geq 1$ when the top index is a pure prime power.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "Fermat's little theorem",
-      "primality via binomial theorem",
-      "Wieferich primes",
-      "pascal_row_prime_power_div"
-    ],
-    "prerequisites": [
-      "pascal_row_prime_power_div",
-      "omega tactic for arithmetic goals"
-    ]
+    "relatedConcepts": ["Fermat's little theorem", "primality via binomial theorem", "Wieferich primes", "pascal_row_prime_power_div"],
+    "prerequisites": ["pascal_row_prime_power_div", "omega tactic for arithmetic goals"]
   },
   {
     "id": "ann-kummer-oq03-carry-free",
     "proofId": "kummer-theorem-oq-03",
-    "range": {
-      "startLine": 83,
-      "endLine": 90
-    },
+    "range": { "startLine": 83, "endLine": 90 },
     "type": "insight",
-    "title": "Carry-Free \u2194 Coprime to p (Lucas' Criterion)",
+    "title": "Carry-Free ↔ Coprime to p (Lucas' Criterion)",
     "content": "`choose_coprime_of_no_carries` proves the contrapositive: if carryCount = 0 (no carries), then $p \\nmid \\binom{n}{k}$. The proof: assume $p \\mid \\binom{n}{k}$; by `choose_dvd_prime_pow_iff` (with $m = 1$), $1 \\leq \\text{carryCount}$; but carryCount = 0 by hypothesis, contradiction via `omega`. This is the carry-free direction of Lucas' theorem: $k$ and $n-k$ written in base $p$ have no position where their digits sum to $\\geq p$ (no carry), which by Kummer means $v_p(\\binom{n}{k}) = 0$, i.e., $\\gcd(\\binom{n}{k}, p) = 1$. Lucas' theorem further says $\\binom{n}{k} \\equiv \\prod_i \\binom{n_i}{k_i} \\pmod{p}$, which is nonzero mod $p$ precisely when no digit of $k$ exceeds the corresponding digit of $n$.",
     "mathContext": "carryCount = 0 $\\Rightarrow$ $v_p(\\binom{n}{k}) = 0$ (Kummer) $\\Rightarrow$ $p \\nmid \\binom{n}{k}$. Lucas' theorem (congruence version): $\\binom{n}{k} \\equiv \\prod_{i=0}^r \\binom{n_i}{k_i} \\pmod{p}$ where $n = \\sum n_i p^i$, $k = \\sum k_i p^i$. No carries iff $k_i \\leq n_i$ for all $i$, iff each factor is nonzero mod $p$.",
     "significance": "key",
-    "relatedConcepts": [
-      "Lucas' theorem",
-      "carry-free addition",
-      "p-adic valuation zero",
-      "choose_dvd_prime_pow_iff"
-    ],
-    "prerequisites": [
-      "choose_dvd_prime_pow_iff",
-      "carryCount definition",
-      "omega tactic"
-    ]
+    "relatedConcepts": ["Lucas' theorem", "carry-free addition", "p-adic valuation zero", "choose_dvd_prime_pow_iff"],
+    "prerequisites": ["choose_dvd_prime_pow_iff", "carryCount definition", "omega tactic"]
+  },
+  {
+    "id": "ann-summary-fractal",
+    "proofId": "kummer-theorem-oq-03",
+    "range": { "startLine": 96, "endLine": 114 },
+    "type": "insight",
+    "title": "The Fractal Structure of Pascal's Triangle mod Prime Powers",
+    "content": "The closing summary synthesizes the results into the qualitative picture. Because p-adic divisibility of C(n,k) is controlled entirely by the base-p carry pattern, the divisibility layers stack: C(n,k) ≡ 0 mod p iff ≥ 1 carry (Lucas), mod p² iff ≥ 2 carries, ..., mod pᵐ iff ≥ m carries. This is exactly why Pascal's triangle mod p exhibits self-similar fractal structure — for p = 2 the pattern of odd entries is the Sierpiński triangle, and in general the divisibility pattern reproduces itself at scale p because a digit of the index either does or does not force a carry. The special rows pⁿ (all interior entries divisible by p) are the 'blank rows' that separate the self-similar blocks. The mathematical content of the fractal is thus purely the arithmetic of base-p digits.",
+    "mathContext": "For $p=2$: $\\binom{n}{k}$ odd $\\iff$ $k$'s binary digits are $\\le$ $n$'s (Lucas), giving the Sierpiński triangle. General $p$: the mod-$p$ pattern is self-similar at scale $p$; rows $p^n$ are fully $p$-divisible in the interior.",
+    "significance": "supporting",
+    "relatedConcepts": ["Sierpiński triangle", "self-similarity", "fractal structure", "Lucas' theorem", "base-p digits"],
+    "prerequisites": ["Kummer's carry criterion", "Lucas' theorem", "self-similar patterns"]
   }
 ]


### PR DESCRIPTION
Enrichment (coverage-gap) pass for `kummer-theorem-oq-03`. The 5 existing annotations covered ~28% of the 116-line Lean file, leaving the docstring and the Summary block unannotated.

Adds **2 annotations** (existing 5 preserved):
- **Overview** — the goal of characterizing p^m ∣ C(n,k) via base-p carries, and the classical prime-row consequences (Kummer 1852 → Granville 1997).
- **Fractal structure** — how the stacking carry criterion produces the self-similar (Sierpiński, for p=2) structure of Pascal's triangle mod prime powers, with rows pⁿ as the separating blank rows.

Coverage rises ~28% → ~59%. Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. All 7 line anchors validated via `validateLineAnnotations`. meta.json unchanged.