### PR TITLE
Enrich Bell Numbers as Stirling Row Sum: add 8 annotations

### DIFF
--- a/src/data/proofs/bell-numbers-oq-01/annotations.json
+++ b/src/data/proofs/bell-numbers-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header-bridge",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Bridging two disconnected Mathlib definitions",
+    "content": "The docstring states the goal and the obstruction. Mathlib defines the Bell numbers Nat.bell by the binomial recurrence B_{n+1} = Σᵢ C(n,i)·B_{n−i} and the Stirling numbers of the second kind Nat.stirlingSecond by the triangular recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k), but provides no lemma linking them. The classical row-sum identity Bₙ = Σₖ S(n,k) (group the partitions of an n-set by block count) therefore needs a fresh combinatorial bridge. The bridge is a 'horizontal' Stirling recurrence — also missing from Mathlib — obtained by conditioning a partition of {0,…,n} on how many points lie outside the block of the last element.",
+    "mathContext": "$B_n = \\sum_{k=0}^{n} S(n,k)$; the bridge is $S(n+1,k+1) = \\sum_{j=0}^{n} \\binom{n}{j} S(j,k)$.",
+    "significance": "context",
+    "relatedConcepts": ["Bell numbers", "Stirling numbers of the second kind", "set partitions", "OEIS A000110", "recurrence relations"],
+    "prerequisites": ["enumerative combinatorics", "set partitions"]
+  },
+  {
+    "id": "ann-horizontal-statement",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 38, "endLine": 46 },
+    "type": "insight",
+    "title": "The horizontal Stirling recurrence (main contribution)",
+    "content": "stirlingSecond_horizontal is the file's key new identity: S(n+1,k+1) = Σ_{j≤n} C(n,j)·S(j,k). Combinatorially, in a partition of {0,…,n} into k+1 blocks, condition on the set of j points lying outside the block containing the last point: C(n,j) chooses which j points are 'outside', and those j points must themselves form k blocks (S(j,k) ways), while the remaining n−j points plus the last point form the (k+1)-th block. Summing over j gives the recurrence. It is proved by induction on n with k generalized; the base case n=0 is dispatched by simp from the triangular recurrence and the boundary value stirlingSecond_zero_succ.",
+    "mathContext": "$S(n+1,k+1) = \\sum_{j=0}^{n} \\binom{n}{j} S(j,k)$ — condition on the $j$ points outside the last point's block.",
+    "significance": "key",
+    "relatedConcepts": ["horizontal recurrence", "conditioning argument", "block of the last point", "induction generalizing k"],
+    "prerequisites": ["Stirling recurrences", "binomial coefficients"]
+  },
+  {
+    "id": "ann-horizontal-pascal",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 47, "endLine": 63 },
+    "type": "technique",
+    "title": "Inductive step: peel j=0, then Pascal's rule",
+    "content": "The successor case rewrites the left side by the triangular recurrence and the right side by peeling the j=0 term with Finset.sum_range_succ'. Pascal's rule (Nat.choose_succ_succ', C(n+1,i+1) = C(n,i) + C(n,i+1)) with add_mul and sum_add_distrib splits the remaining sum into a 'shifted' block Σ C(n,i+1)·S(i+1,k) and an 'unshifted' block Σ C(n,i)·S(i+1,k). The lemma hshift re-glues the shifted block with its missing j=0 term (the top term vanishes via Nat.choose_succ_self, C(n,n+1)=0), and hS2 identifies that block with S(n+1,k+1) using the inductive hypothesis ih k.",
+    "mathContext": "$\\binom{n+1}{i+1} = \\binom{n}{i} + \\binom{n}{i+1}$ splits the sum into shifted and unshifted blocks.",
+    "significance": "supporting",
+    "relatedConcepts": ["Pascal's rule", "Nat.choose_succ_succ'", "Finset.sum_range_succ'", "sum_add_distrib"],
+    "prerequisites": ["binomial identities", "finite-sum manipulation"]
+  },
+  {
+    "id": "ann-horizontal-cases",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 64, "endLine": 82 },
+    "type": "technique",
+    "title": "Closing the unshifted block: cases on k, then omega",
+    "content": "The unshifted block Σ C(n,i)·S(i+1,k) is handled by cases on k. When k=0, every term S(i+1,0) = 0 (Nat.stirlingSecond_succ_zero), so hSum1zero collapses the whole sum and omega finishes. When k = k'+1, hSum1 expands S(i+1,k'+2) by the triangular recurrence and applies the inductive hypothesis twice (ih (k'+1) and ih k'), refolding via mul_sum and sum_add_distrib into (k'+1)·S(n+1,k'+2) + S(n+1,k'+1). In both branches omega combines hS2 and hSum1(zero) with the target's arithmetic to close the goal.",
+    "mathContext": "$k=0$: $S(i+1,0)=0$. $k=k'+1$: unshifted block $= (k'{+}1)S(n{+}1,k'{+}2) + S(n{+}1,k'{+}1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["case split", "Nat.stirlingSecond_succ_zero", "omega tactic", "Finset.mul_sum"],
+    "prerequisites": ["Stirling boundary values", "linear arithmetic"]
+  },
+  {
+    "id": "ann-bell-rowsum-statement",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 84, "endLine": 93 },
+    "type": "insight",
+    "title": "Bell = Stirling row sum, by strong induction",
+    "content": "bell_eq_sum_stirlingSecond is the headline result: Nat.bell n = Σ_{k≤n} Nat.stirlingSecond n k. It is proved by strong induction (Nat.strong_induction_on), pattern-matching on n. The n=0 case is simp (B₀ = 1 = S(0,0)). The successor case m+1 reduces the Bell recurrence to the summed horizontal recurrence, using the inductive hypothesis on all smaller j through the auxiliary hInner.",
+    "mathContext": "$B_n = \\sum_{k=0}^{n} S(n,k)$, proved by strong induction on $n$.",
+    "significance": "key",
+    "relatedConcepts": ["strong induction", "row sum", "Nat.strong_induction_on"],
+    "prerequisites": ["strong induction", "Bell and Stirling numbers"]
+  },
+  {
+    "id": "ann-bell-inner-tail",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 94, "endLine": 103 },
+    "type": "technique",
+    "title": "Padding the row sum: the Stirling tail vanishes",
+    "content": "hInner shows that for every j ≤ m, the padded row sum Σ_{k∈range(m+1)} S(j,k) already equals Nat.bell j. The point is that the exact range should be range(j+1), but the extra terms S(j,k) for k > j are all zero (Nat.stirlingSecond_eq_zero_of_lt, the Stirling triangle vanishes above the diagonal), so Finset.sum_subset lets the wider padded range range(m+1) stand in. Then the inductive hypothesis ih j (valid since j < m+1) gives bell j. Padding to a uniform range is what allows the later sum-swap to go through cleanly.",
+    "mathContext": "$S(j,k)=0$ for $k>j$, so $\\sum_{k=0}^{m} S(j,k) = \\sum_{k=0}^{j} S(j,k) = B_j$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.stirlingSecond_eq_zero_of_lt", "Finset.sum_subset", "vanishing above the diagonal", "padded range"],
+    "prerequisites": ["Finset.sum_subset", "Stirling triangle"]
+  },
+  {
+    "id": "ann-bell-recurrence-reflect",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 104, "endLine": 112 },
+    "type": "technique",
+    "title": "Reindexing the Bell recurrence via reflection and symmetry",
+    "content": "hbell recasts Mathlib's Bell recurrence into a shape matching the horizontal sum. Nat.bell_succ gives B_{m+1} = Σᵢ C(m,i)·B_{m−i} over Fin (m+1); Fin.sum_univ_eq_sum_range converts to a range sum, Finset.sum_range_reflect reverses the index j ↦ m−j, and the binomial symmetry Nat.choose_symm (C(m,i) = C(m,m−i)) turns the summand into C(m,j)·B_j. The result B_{m+1} = Σ_{j≤m} C(m,j)·B_j is exactly the form produced by summing the horizontal recurrence over k.",
+    "mathContext": "$B_{m+1} = \\sum_{i} \\binom{m}{i} B_{m-i} = \\sum_{j=0}^{m} \\binom{m}{j} B_j$ via reflection $j\\mapsto m-j$ and $\\binom{m}{i}=\\binom{m}{m-i}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.bell_succ", "Finset.sum_range_reflect", "Nat.choose_symm", "index reflection"],
+    "prerequisites": ["binomial symmetry", "sum reindexing"]
+  },
+  {
+    "id": "ann-bell-final-assembly",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 113, "endLine": 119 },
+    "type": "insight",
+    "title": "Final assembly: substitute, swap, refold",
+    "content": "The closing four lines fuse everything. After rewriting by hbell and peeling the k=0 term of the Stirling row sum (which is S(m+1,0) = 0), simp_rw [stirlingSecond_horizontal] replaces each S(m+1,k+1) by its horizontal sum Σ_j C(m,j)·S(j,k). Finset.sum_comm swaps the k- and j-summations, ← Finset.mul_sum factors out C(m,j), and the inner Σ_k S(j,k) is replaced by bell j through hInner — matching the C(m,j)·B_j terms of the Bell recurrence term by term. This is where the summed horizontal recurrence becomes the Bell binomial recurrence.",
+    "mathContext": "$\\sum_k \\sum_j \\binom{m}{j} S(j,k) \\xrightarrow{\\text{swap}} \\sum_j \\binom{m}{j}\\sum_k S(j,k) = \\sum_j \\binom{m}{j} B_j = B_{m+1}.$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_comm", "Finset.mul_sum", "double-sum swap", "recurrence matching"],
+    "prerequisites": ["double sums", "Fubini for finite sums"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `bell-numbers-oq-01` (was zero-annotation).

## Changes
- **Created `annotations.json`** with 8 substantive annotations covering the full Lean file (lines 1–119):
  - Docstring: bridging Mathlib's disconnected `Nat.bell` and `Nat.stirlingSecond`
  - `stirlingSecond_horizontal`: the new horizontal recurrence (conditioning on the last point's block) and its Pascal-rule inductive step + k-case split
  - `bell_eq_sum_stirlingSecond`: the strong-induction row sum, the tail-vanishing padding (`sum_subset`), the reflection/symmetry reindexing of the Bell recurrence, and the final substitute/`sum_comm`/refold assembly
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json unchanged (already rich, 11 KB, within caps). No claims altered.