### PR TITLE
Fix: realign stale meta.lineCount for 30 gallery entries

### DIFF
--- a/src/data/proofs/abel-ruffini-obstruction-oq-06/meta.json
+++ b/src/data/proofs/abel-ruffini-obstruction-oq-06/meta.json
@@ -51,7 +51,7 @@
     ],
     "dateAdded": "2026-06-25",
     "axiomCount": 0,
-    "lineCount": 121,
+    "lineCount": 215,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for all four results (none of which count as assumptions). The single `decide` (for S₂ commutativity) is kernel decidability, not native_decide, so it does not introduce Lean.ofReduceBool. No structure-encoded hypotheses. Scope note: this is the characteristic-independent core; the characteristic-p Abhyankar-conjecture refinements are not formalized.",
     "mathlib_version": "4.26.0",
     "theoremCount": 5,

--- a/src/data/proofs/abel-ruffini-oq-06/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-06/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-06-27",
     "axiomCount": 0,
-    "lineCount": 142,
+    "lineCount": 94,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (single-file checked with `lake env lean`). #print axioms reports only the foundational propext / Classical.choice / Quot.sound (none of which count). No native_decide, so no Lean.ofReduceBool. No structure-encoded hypotheses. Scope note: this is the characteristic-independent core; the characteristic-p Abhyankar refinements are not formalized. The remaining threshold case S₄ (needing A₄ solvable) is deferred to a companion file and is NOT claimed here.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,

--- a/src/data/proofs/abundant-number-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-01/meta.json
@@ -20,7 +20,7 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 236,
+    "lineCount": 197,
     "theoremCount": 13,
     "definitionCount": 0,
     "dateAdded": "2026-06-18",

--- a/src/data/proofs/algebraic-reals-meager-oq-02/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02/meta.json
@@ -74,7 +74,7 @@
       "Liouville numbers: residual, dense, and Lebesgue-null",
       "Countability of the algebraic reals (Algebraic.countable)"
     ],
-    "lineCount": 175,
+    "lineCount": 177,
     "relatedProblems": [
       {
         "id": "algebraic-reals-meager",

--- a/src/data/proofs/algebraic-reals-meager/meta.json
+++ b/src/data/proofs/algebraic-reals-meager/meta.json
@@ -75,7 +75,7 @@
       "ℝ is a perfect, T1, Baire space",
       "Countability of the algebraic reals (Algebraic.countable)"
     ],
-    "lineCount": 165,
+    "lineCount": 226,
     "relatedProblems": [
       {
         "id": "algebraic-numbers-countable-oq-02-oq-02",

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
@@ -68,7 +68,7 @@
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
     "assumptions": "Fully verified: 0 axioms, 0 sorries remain.",
-    "lineCount": 329,
+    "lineCount": 386,
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 1

--- a/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 172,
+    "lineCount": 218,
     "mathlibDependencies": [
       {
         "theorem": "GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I",

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -60,7 +60,7 @@
       "isBundledRegularRepresentation: the parent's isExplicitRegularRepresentation upgraded from a pair of pointwise identities to a single group isomorphism φ : H ≃* (regularRepHom H).range with (φ σ : Perm H) = e.symm.permCongr (σ : Perm α)"
     ],
     "dateAdded": "2026-06-23",
-    "lineCount": 156,
+    "lineCount": 143,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries; the headline theorems depend only on Mathlib's foundational propext/Classical.choice/Quot.sound (Classical.choice/arbitrary supplies a basepoint and underlies MulEquiv.ofInjective via codRestrict; Classical.arbitrary picks the basepoint in the geometric section). No decide/native_decide, so no Lean.ofReduceBool. regularRepHom, regularRepHom_injective, regularRep and cayley hold for an arbitrary group G with no finiteness; the geometric tie-in additionally assumes α nonempty (for the orbit basepoint) but no finiteness.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,

--- a/src/data/proofs/erdos-1002-oq-03/meta.json
+++ b/src/data/proofs/erdos-1002-oq-03/meta.json
@@ -28,7 +28,7 @@
       "erdos-1002-oq-01"
     ],
     "axiomCount": 0,
-    "lineCount": 212,
+    "lineCount": 258,
     "assumptions": "No axioms. Both main theorems depend only on Lean's standard foundational axioms (propext, Classical.choice, Quot.sound); #print axioms reports no sorryAx and no Lean.ofReduceBool. No native_decide is used. The parent Erdős #1002 (Kesten's Cauchy-limit theorem for irrational α) remains open; this file resolves only the elementary rational case, which is itself a complete, axiom-free theorem.",
     "theoremCount": 10,
     "definitionCount": 2

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -29,7 +29,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-25",
-    "lineCount": 2936,
+    "lineCount": 3112,
     "originalContributions": [
       "denom_ge_of_between: the headline lower bound — if a/b < p/q < c/d and the outer pair is unimodular (bc − ad = 1), then q ≥ b + d. Proved from the identity q = b·(cq − pd) + d·(pb − aq) by reading off pb − aq ≥ 1 and cq − pd ≥ 1 from the strict orders, with no Farey enumeration. The mediant therefore has the smallest denominator of any fraction in the open gap (a/b, c/d)",
       "eq_mediant_of_denom_eq: uniqueness — a strictly-in-gap fraction p/q that attains the minimal denominator q = b + d must be the mediant itself, p = a + c. The two cross-differences pb − aq and cq − pd are each pinned to exactly 1, forcing p·b = (a+c)·b and cancelling b",

--- a/src/data/proofs/erdos-1023-oq-01/meta.json
+++ b/src/data/proofs/erdos-1023-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
     "assumptions": "2 axioms: problem_447_solution (Erdős-Kleitman: max union-free family in 2^[n] has size C(n,⌊n/2⌋)), stirling_central_approx (Stirling: C(n,n/2) ~ √(2/π) · 2^n / √n).",
-    "lineCount": 458,
+    "lineCount": 660,
     "theoremCount": 36,
     "definitionCount": 20,
     "originalContributions": [

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -74,7 +74,7 @@
       "productSet_eq_image: productSet A B = image of product map on A×ˢB"
     ],
     "axiomCount": 3,
-    "lineCount": 506,
+    "lineCount": 557,
     "assumptions": "3 axioms, 0 sorries. Axioms: szemeredi_theorem (Szemerédi 1976 upper bound, deep); optimal_has_distinct_products (the optimal example has distinct products, deep); primes_upper_half_lower_bound (Chebyshev-type lower bound — the count of primes in (N/2,N] is ≳ N/log N; isolated as an axiom because Mathlib's Nat.primeCounting provides only an upper bound, no lower bound on π(N)−π(N/2); the bridge lemma optimalB_card_eq_primeCounting now proves |optimalB N| = π(N)−π(N/2) in Mathlib's API, 0-axiom, so the axiom is reduced to exactly a Chebyshev lower bound for π(N)−π(N/2)). Progression: researcher-8 (2026-06-28) repaired the build against the current Mathlib pin and eliminated 4 sorries with 0-axiom proofs (optimal_works_because_primes, the two IsSubsetUpTo subgoals, primes_products_determine_pair). researcher-3 (2026-06-28) then proved distinct_minimal_energy (HasDistinctProducts ↔ multiplicative energy = |A||B|) 0-axiom via the diagonal-subset argument, and in a follow-up session eliminated the last sorry: proved optimalA_card (|optimalA N| = ⌊N/2⌋, 0-axiom) and discharged the bound_is_optimal lower bound from the isolated Chebyshev axiom (note: the previously hardcoded constant 1/3 was false at small N, e.g. N=10 where the product ratio dips to ≈0.115, so the theorem is now in its honest ∃c>0 form).",
     "theoremCount": 14,
     "definitionCount": 15,

--- a/src/data/proofs/erdos-565/meta.json
+++ b/src/data/proofs/erdos-565/meta.json
@@ -53,7 +53,7 @@
       "Lower bound showing tightness"
     ],
     "axiomCount": 3,
-    "lineCount": 286,
+    "lineCount": 323,
     "assumptions": "3 axioms: induced_ramsey_exists, aragao_et_al_theorem, exponential_lower_bound. 1 sorry.",
     "theoremCount": 5,
     "definitionCount": 10

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "0 axioms, 0 sorries. The headline Erdős–Simonovits conjecture (#574) remains OPEN and is stated only as commentary, not as a proven theorem — hence the 'axiomatized' status. The file now contributes three machine-checked theorems formalizing the unconditional lower-bound core: a bipartite graph has no cycle of odd length (bipartite_not_hasCycle_odd), hence contains no C_{2k−1} (bipartite_no_odd_consecutive), hence a bipartite C_{2k}-free graph is automatically {C_{2k−1}, C_{2k}}-free (bipartite_evenFree_consecutiveFree). This is the structural reason the lower bound for ex(n; {C_{2k−1}, C_{2k}}) transfers with no loss from ex(n; C_{2k}); the only open content is the matching upper bound.",
     "proofRepoPath": "Proofs/Erdos574Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 188,
+    "lineCount": 220,
     "theoremCount": 3,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-606-oq-01/meta.json
+++ b/src/data/proofs/erdos-606-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 204,
+    "lineCount": 255,
     "assumptions": "Fully machine-checked, 0 sorries, 0 axiom declarations; all theorems depend only on the foundational axioms propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool — kernel-verified). Honest scope: this file proves the NUMBER-THEORETIC core that explains why the Erdős–Salamon forbidden set is exactly {C(n,2)−1, C(n,2)−3}, namely that the gap set of the numerical semigroup ⟨2,5⟩ is exactly {1,3}. It does NOT prove geometric realizability (that disjoint collinear triples/quadruples can be embedded in the plane — the geometric content carried by the parent file's axioms), nor the open Erdős–Salamon threshold N₀ (OQ-01's literal question).",
     "dateAdded": "2026-06-22",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-895-counterexample-fin18/meta.json
+++ b/src/data/proofs/erdos-895-counterexample-fin18/meta.json
@@ -21,7 +21,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 111,
+    "lineCount": 120,
     "dateAdded": "06/25/26",
     "erdosNumber": 895,
     "erdosUrl": "https://erdosproblems.com/895",

--- a/src/data/proofs/factor-remainder-hasse-derivative-fq/meta.json
+++ b/src/data/proofs/factor-remainder-hasse-derivative-fq/meta.json
@@ -64,7 +64,7 @@
       "Supporting concrete results: rootMultiplicity_X_pow (rootMultiplicity 0 (X^n) = n), derivative_X_pow_char (first ordinary derivative of X^{p^e} is 0), iterate_derivative_X_pow_char_eq_zero (all positive-order ordinary derivatives vanish)."
     ],
     "axiomCount": 0,
-    "lineCount": 150,
+    "lineCount": 280,
     "assumptions": "None. All 8 theorems fully proved with 0 axioms and 0 sorries (no native_decide); #print axioms reports only [propext, Classical.choice, Quot.sound]. Results assume the standard CharP F p with p prime (Part I/II hold over an arbitrary characteristic-p commutative ring; the agreement and X^{p^e} multiplicity results specialize to a field, which every 𝔽_q is). No assumption is encoded in any structure or typeclass beyond Mathlib's CharP.",
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/fibonacci-divisibility-oq-07/meta.json
+++ b/src/data/proofs/fibonacci-divisibility-oq-07/meta.json
@@ -57,7 +57,7 @@
       "fib_two_exception: fib 2 ∣ fib 1 ∧ ¬ (2 ∣ 1) — the concrete sharpness witness at m = 2"
     ],
     "dateAdded": "2026-07-01",
-    "lineCount": 106,
+    "lineCount": 108,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). The tactic `decide` is used only to evaluate the closed numerals fib 2 = 1, fib 3 = 2, fib 4 = 3 and the ground fact ¬(2 ∣ 1); these reduce in the kernel (fib_zero/one/two are rfl) and introduce no `Lean.ofReduceBool` — no `native_decide` appears.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,

--- a/src/data/proofs/hermite-lindemann/meta.json
+++ b/src/data/proofs/hermite-lindemann/meta.json
@@ -39,7 +39,7 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 1,
-    "lineCount": 390,
+    "lineCount": 373,
     "assumptions": "1 axiom: hermite_lindemann (deep analytic number theory, not in Mathlib). All corollaries (e transcendence, π transcendence) are now proved from this single axiom via Euler's identity and algebraic closure properties.",
     "mathlib_version": "4.26.0",
     "theoremCount": 5,

--- a/src/data/proofs/hermite-sawtooth-identity-oq-02/meta.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-02/meta.json
@@ -49,7 +49,7 @@
     ],
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
-    "lineCount": 101,
+    "lineCount": 135,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for all results. No native_decide, no sorryAx, no structure-encoded hypotheses. The hypotheses (0 < q and Nat.Coprime p q) are explicit arguments of the theorems, not assumptions about the ambient theory.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,

--- a/src/data/proofs/hilbert-14-oq-02-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-02-oq-01/meta.json
@@ -59,7 +59,7 @@
       "esymm_algebraicIndependent / esymm_isHomogeneous: self-contained re-proofs of the two parent facts the argument rests on, so the entry stands alone"
     ],
     "axiomCount": 0,
-    "lineCount": 130,
+    "lineCount": 136,
     "assumptions": "None. All theorems fully proved with 0 axioms and 0 sorries (no native_decide). #print axioms reports only [propext, Classical.choice, Quot.sound]. SCOPE: this proves the SHARPNESS (lower bound β(Sₙ) ≥ n) for the symmetric group Sₙ, complementing the parent's upper bound β(Sₙ) ≤ n. The non-membership is stated for the lower ELEMENTARY symmetric family; a fully general 'no generating set in degrees < n' statement (over ALL degree-<n invariants) would additionally require that every invariant of degree < n is a polynomial in e₁,…,e_{n-1}, which is true but not formalized here — see open questions.",
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/hilbert-17-oq-03-oq-03/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-03/meta.json
@@ -54,7 +54,7 @@
       "Homogeneous decomposition of multivariate polynomials and the leading form.",
       "Coefficient extraction via MvPolynomial.coeff_mul over the Finsupp antidiagonal."
     ],
-    "lineCount": 427,
+    "lineCount": 423,
     "relatedProblems": [
       {
         "id": "hilbert-17",

--- a/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/meta.json
@@ -80,7 +80,7 @@
     ],
     "dateAdded": "2026-06-25",
     "axiomCount": 0,
-    "lineCount": 221,
+    "lineCount": 272,
     "mathlib_version": "4.26.0",
     "assumptions": "0 axioms and 0 sorries by construction over ℝ. BUILD-CONFIRMED: machine-checked with `lake env lean` against the prebuilt Mathlib 4.26.0 olean cache (Docker engine was down fleet-wide, so docker-build.sh could not be used; the single file imports only Mathlib and has no sibling-proof dependencies, so a standalone compile is a complete check). Exit 0, no errors; `#print axioms` on isoperimetric_fourier / wirtinger / equality_implies_circle / hurwitzTerm_eq_zero reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool. Status promoted to 'verified'. The proof uses only elementary ℝ-algebra tactics (ring, nlinarith, linarith, le_antisymm, Finset.sum_nonneg). The Parseval bridge from the L²-integrals ∮(x'²+y'²) and ∮x dy to the coefficient sums E and Ar is the standard textbook reduction (Stein–Shakarchi, Ch. 4); it is documented, not re-derived — the formalized objects are the Fourier coefficients and the coefficient-level inequality, which is the mathematical heart of the method.",
     "theoremCount": 7,

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -35,7 +35,7 @@
     "dateAdded": "2025-12-26",
     "axiomCount": 7,
     "assumptions": "7 axioms across the chain (main 5 + FourSquareRepresentations.lean 2): main file declares legendre_three_squares (3-square obstruction criterion), hilbert_waring (g(k) exists for all k), wieferich_nine_cubes (g(3)=9), waring_general_formula (g(k) general formula), vinogradov_waring_bound (G(k) upper bound); FourSquareRepresentations.lean declares jacobi_four_square (r₄(n) = 8·σ*(n)) and r₄_zero (r₄ 0 = 1). fermat_two_squares has been formally proved. hurwitz_quaternions_euclidean and hurwitz_representation_count True stubs removed — Hurwitz quaternion results are not formalized.",
-    "lineCount": 392,
+    "lineCount": 409,
     "prerequisites": [
       "Quaternion algebra and norm multiplicativity",
       "Euler's four-square identity",

--- a/src/data/proofs/prob-method-second-moment-oq-04/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-04/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "axiomCount": 0,
-    "lineCount": 171,
+    "lineCount": 179,
     "theoremCount": 4,
     "definitionCount": 1,
     "assumptions": "None. 0 axioms, 0 sorries. Fully verified in Lean 4 with Mathlib. Reuses mean / variance from the sibling ProbMethodSecondMomentOQ02.lean (counting-measure formalism).",

--- a/src/data/proofs/schauder-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-04/meta.json
@@ -50,7 +50,7 @@
     ],
     "dateAdded": "2026-06-25",
     "axiomCount": 0,
-    "lineCount": 80,
+    "lineCount": 78,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms on fixedPoints_Icc_nonempty_isCompact and exists_fixedPoint_Icc reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide, no structure-encoded hypotheses. Imports only Mathlib — deliberately NOT the axiom-bearing base file SchauderFixedPoint.lean (which carries brouwer/mazur axioms).",
     "mathlib_version": "4.26.0",
     "theoremCount": 5,

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     "assumptions": "0 axioms in this file. 4 sorries (aggregate): 0 in the main bridge file ShannonChannelCodingOQ02OQ01.lean + 4 in the Aristotle companion ShannonChannelCodingOQ02OQ01Aristotle.lean (workbench targets for automated proof search). Removed the unused `axiom import_shannon_entropy_blocked : False` placeholder (asserting False is logically unsound — even an unused declaration is a footgun). The blocker explanation is preserved as a comment block. The target axiom `fano_inequality` (in ShannonChannelCoding.lean) is now DISCHARGED: it is a `theorem` (ShannonChannelCoding.lean line 199) defined as `:= FanoFromConditionalEntropy.fano_inequality_proved pXY hp hsum`, routing through this file's `fano_inequality_proved` (which dispatches on `Fintype.card α` to `fano_singleton_card_one` and `fano_from_oq03_std`, the latter built on OQ-03's `fano_theorem`). This route bypasses the earlier ShannonEntropy.lean strong_subadditivity blocker entirely. The parent gallery entry's axiomCount dropped 4 → 3 accordingly (and later 3 → 2 when the bsc_capacity_eq axiom was removed); the parent file's own header now lists Axioms: 2 (channel_coding_achievability, channel_coding_converse), with `fano_inequality` among its 18 theorems.",
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 312,
+    "lineCount": 318,
     "prerequisites": [
       "Fano's inequality (OQ-03): H(X|Y) ≤ h(P_e) + P_e·log(|X|-1)",
       "Binary entropy function and concavity (OQ-04)",

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-04/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-04/meta.json
@@ -54,7 +54,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 131,
+    "lineCount": 203,
     "assumptions": "0 axioms, 0 sorries, no native_decide. All seven named theorems (weakCompositionGenFun_zero, weakCompositionGenFun_eq_invOneSubPow_val, weakCompositionGenFun_mul, vandermonde_negBinomial, card_weakComposition_recurrence, card_weakComposition_partial_sum, negBinomial_hockey_stick) were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The multiplicativity weakCompositionGenFun_mul and the unit weakCompositionGenFun_zero hold for all k₁, k₂, k ≥ 0. The convolution vandermonde_negBinomial is stated without positivity hypotheses: for k₁, k₂ ≥ 1 it is the genuine negative-binomial Vandermonde identity, while at k = 0 the term C(·−1,·) collapses to the indicator of 0 (matching W(0)=1), so the stated identity remains true. The ℕ identity is obtained from the ℤ-coefficient identity by exact_mod_cast (injectivity of ℕ → ℤ).",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-05/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-05/meta.json
@@ -52,7 +52,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 176,
+    "lineCount": 181,
     "assumptions": "0 axioms, 0 sorries, no native_decide. Both named theorems (card_weakComposition_first_eq, sum_marginals_eq_total) and the bijection dropFirstEquiv were verified to depend only on the foundational propext / Classical.choice / Quot.sound. The marginal count card_weakComposition_first_eq holds for every k ≥ 1 and d ≤ n; the d ≤ n hypothesis is essential, since for d > n the set is empty (count 0) while the closed form would read C(n−d+k−2, 0) = 1. The summation consistency sum_marginals_eq_total holds for all k ≥ 1, with the k = 1 (single-part) boundary handled separately: only the d = n term survives. The worked examples are discharged by kernel evaluation of Nat.choose on literals (decide), not native_decide.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -48,7 +48,7 @@
       "stirling_first_correction (fully proved): combines the partial-sum bounds with two limits (htend_diff for L = log(stirlingSeq n) \u2212 log(\u221a\u03c0), htend_Gn for the lower-tail residual via Tendsto.div_atTop on each tail term), Real.exp_bound at degree 2 for the upper-half Taylor remainder |exp L \u2212 (1+L)| \u2264 3\u00b7L\u00b2/4, and the algebraic comparisons (n\u22122)(4n\u22123) \u2265 0 (for L \u2212 1/(12n) \u2264 1/(2n\u00b2)) and (12(n\u22121)\u00b3 \u2212 n\u00b3) \u2265 0 (for the lower half). Yields C = 2.",
       "stirling_two_term_expansion (fully proved from stirling_first_correction via the \u221a(2\u03c0n) = \u221a(2n)\u00b7\u221a\u03c0 split)"
     ],
-    "lineCount": 915,
+    "lineCount": 993,
     "theoremCount": 21,
     "definitionCount": 2,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Realigns the stale top-level `meta.lineCount` field for 30 gallery entries to match the actual line count of the main Lean source file (`file.count('\n')` convention).

## Evidence

**Before**: `meta.lineCount` had drifted from the source (e.g. `abundant-number-oq-01` claimed 236 lines for a 197-line file; `stirling-formula-oq-01` claimed 915 for 993).

**After**: `meta.lineCount` matches the main source file. In every case where the entry also carries a `leanFile.lineCount`, that field was **already correct** — only the separate `meta.lineCount` field was stale, so this brings the two into agreement.

## Scope notes

- Distinct field from `leanFile.lineCount` (addressed separately in #32886); the two PRs edit disjoint entries — no overlap with #32886's 74-entry set.
- Entries with `additionalFiles` were verified: their `meta.lineCount` tracks the main file (matching `leanFile.lineCount`), not an aggregate, so main-file count is the correct target.
- `isoperimetric-theorem-oq-01-oq-01`'s lone top-level `lineCount` was left untouched by convention; only its `meta.lineCount` was corrected.
- Pure numeric metadata sync: 30 files, +30/-30 lines, all JSON revalidated.

---
Automated fix by lean-mechanic agent.