### PR TITLE
Enrich Negative-Pell Solution₁ Promotion: add 8 annotations

### DIFF
--- a/src/data/proofs/pell-equation-oq-06-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header-promotion",
+    "proofId": "pell-equation-oq-06-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "context",
+    "title": "From a bare identity to a Mathlib-typed object",
+    "content": "The docstring states the mission. The parent entry recorded only the arithmetic squaring identity x² − 2y² = −1 ⟹ (x²+2y²)² − 2(2xy)² = 1, remarking informally that it 'connects to Mathlib's Pell.Solution₁' but never building an element of that type. Mathlib defines Pell.Solution₁ d := ↥(unitary (ℤ√d)) — the group of norm +1 elements — and provides nothing for the norm −1 (negative Pell) equation. This entry promotes the parent's identity into an actual inhabitant of Solution₁ d, using the multiplicativity of the Zsqrtd norm (packaged as the monoid hom normMonoidHom) as the whole engine.",
+    "mathContext": "$\\texttt{Pell.Solution}_1\\,d := \\uparrow(\\mathrm{unitary}\\,(\\mathbb{Z}\\sqrt d))$, the norm $+1$ group; $N(a) = a_{re}^2 - d\\,a_{im}^2$ is multiplicative.",
+    "significance": "context",
+    "relatedConcepts": ["Pell equation", "negative Pell", "quadratic integer ring ℤ√d", "unit group", "Brahmagupta composition"],
+    "prerequisites": ["Pell's equation", "quadratic integer rings"]
+  },
+  {
+    "id": "ann-unit-dichotomy",
+    "proofId": "pell-equation-oq-06-oq-01-oq-02",
+    "range": { "startLine": 62, "endLine": 75 },
+    "type": "insight",
+    "title": "Units of ℤ√d are exactly the norm ±1 elements",
+    "content": "isUnit_iff_norm_eq_pm_one is the dichotomy that organises everything: a ∈ ℤ√d is a unit iff its norm is +1 or −1. The proof rewrites via Zsqrtd.norm_eq_one_iff (|N(a)| = 1 ↔ IsUnit a) and Int.natAbs_eq_iff (|N(a)| = 1 ↔ N(a) = 1 ∨ N(a) = −1), closed by norm_num. Because the norm is a monoid hom into ℤ whose only units are ±1, unit-ness pulls back to the norm being a unit of ℤ — separating the positive-Pell (norm +1) from the negative-Pell (norm −1) solutions.",
+    "mathContext": "$\\mathrm{IsUnit}\\,a \\iff N(a)=1 \\lor N(a)=-1$, since the units of $\\mathbb{Z}$ are exactly $\\pm 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Zsqrtd.norm_eq_one_iff", "units of ℤ", "monoid homomorphism", "norm form"],
+    "prerequisites": ["units of a ring", "integer norm forms"]
+  },
+  {
+    "id": "ann-pos-neg-classes",
+    "proofId": "pell-equation-oq-06-oq-01-oq-02",
+    "range": { "startLine": 77, "endLine": 98 },
+    "type": "definition",
+    "title": "The positive- and negative-Pell classes",
+    "content": "IsPosPell a := a.norm = 1 and IsNegPell a := a.norm = −1 name the two unit classes. Both are units (IsNegPell.isUnit, IsPosPell.isUnit) via the dichotomy. Crucially, isPosPell_iff_mem_unitary identifies the positive-Pell elements with membership in unitary (ℤ√d) — i.e. the underlying set of Mathlib's Solution₁ d — through Zsqrtd.norm_eq_one_iff_mem_unitary. This is the hook that lets norm +1 elements be re-typed as library Solution₁ objects.",
+    "mathContext": "$\\mathrm{IsPosPell}\\,a \\iff a \\in \\mathrm{unitary}(\\mathbb{Z}\\sqrt d) = \\texttt{Solution}_1\\,d$; $\\mathrm{IsNegPell}\\,a \\iff N(a) = -1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["unitary submonoid", "Solution₁", "Zsqrtd.norm_eq_one_iff_mem_unitary"],
+    "prerequisites": ["subgroups", "predicate definitions in Lean"]
+  },
+  {
+    "id": "ann-coset-signlaws",
+    "proofId": "pell-equation-oq-06-oq-01-oq-02",
+    "range": { "startLine": 100, "endLine": 133 },
+    "type": "insight",
+    "title": "Negative-Pell is a single coset of the norm +1 subgroup",
+    "content": "Multiplicativity of the norm gives the sign laws: IsNegPell.mul shows (−1)·(−1) = +1 (product of two negative-Pell elements is positive-Pell), and IsPosPell.mul_isNegPell shows (+1)·(−1) = −1. Both proofs are rw [Zsqrtd.norm_mul, ...]; norm_num. These assemble into isNegPell_mul_iff_norm_one: fixing one negative-Pell a₀, the product a₀·a is negative-Pell iff a is positive-Pell — so left multiplication by a₀ is a bijection Solution₁ d ≅ {negative-Pell elements}. The negative-Pell set is precisely the coset a₀·(Solution₁ d); positive and negative Pell together form the full unit group, with Solution₁ index 2 inside it when a norm −1 solution exists.",
+    "mathContext": "Sign law $(-1)(-1)=+1,\\ (+1)(-1)=-1$; negative-Pell set $= a_0\\cdot\\texttt{Solution}_1\\,d$, a coset of the norm $+1$ subgroup.",
+    "significance": "key",
+    "relatedConcepts": ["cosets", "Zsqrtd.norm_mul", "index-2 subgroup", "torsor"],
+    "prerequisites": ["coset structure", "multiplicative norm"]
+  },
+  {
+    "id": "ann-promotion",
+    "proofId": "pell-equation-oq-06-oq-01-oq-02",
+    "range": { "startLine": 135, "endLine": 150 },
+    "type": "insight",
+    "title": "The promotion: squaring into Solution₁ d",
+    "content": "IsNegPell.toSolution₁ is the structural upgrade. Since the norm is multiplicative, the square of a negative-Pell element has norm (−1)² = +1 (IsNegPell.sq = h.mul h). Zsqrtd.norm_eq_one_iff_mem_unitary converts '(a·a).norm = 1' into the membership proof 'a·a ∈ unitary (ℤ√d)', exactly what is needed to build the dependent pair ⟨a·a, _⟩ : Solution₁ d. This is a type-level upgrade, not merely an equation: the parent's polynomial identity (x²+2y²)² − 2(2xy)² = 1 becomes an actual inhabitant of Mathlib's Solution₁ type, on which the full group API then applies.",
+    "mathContext": "$N(a^2) = N(a)^2 = (-1)^2 = 1 \\Rightarrow a^2 \\in \\mathrm{unitary}(\\mathbb{Z}\\sqrt d) = \\texttt{Solution}_1\\,d.$",
+    "significance": "key",
+    "relatedConcepts": ["type-level promotion", "dependent pair", "subtype membership", "Solution₁ constructor"],
+    "prerequisites": ["dependent types", "subtypes in Lean"]
+  },
+  {
+    "id": "ann-components",
+    "proofId": "pell-equation-oq-06-oq-01-oq-02",
+    "range": { "startLine": 152, "endLine": 162 },
+    "type": "technique",
+    "title": "Explicit components of the promoted solution",
+    "content": "toSolution₁_x and toSolution₁_y read off the coordinates of the promoted square from the ℤ√d multiplication formulas. Each proof uses `show` to unfold the Solution₁ projection to the underlying (a·a).re / (a·a).im, then Zsqrtd.re_mul / im_mul give (a·a).re = a.re² + d·a.im² and (a·a).im = 2·a.re·a.im, closed by ring. These are marked @[simp], so downstream the promoted x and y compute automatically. They realise the parent's (x²+2y², 2xy) formula as the concrete Solution₁ components.",
+    "mathContext": "$x = a_{re}^2 + d\\,a_{im}^2,\\quad y = 2\\,a_{re}\\,a_{im}$ from $\\texttt{Zsqrtd.re\\_mul}/\\texttt{im\\_mul}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Zsqrtd.re_mul", "Zsqrtd.im_mul", "simp lemmas", "coordinate extraction"],
+    "prerequisites": ["ring multiplication in ℤ√d"]
+  },
+  {
+    "id": "ann-chain-lift",
+    "proofId": "pell-equation-oq-06-oq-01-oq-02",
+    "range": { "startLine": 164, "endLine": 201 },
+    "type": "technique",
+    "title": "Lifting the d = 2 chain into Solution₁ 2",
+    "content": "The specialisation makes the payoff concrete. negPellElt turns each grandparent chain term (negPellSeq n) into a ℤ√2 element; isNegPell_negPellElt proves it has norm −1 by rewriting Zsqrtd.norm_def and closing with linear_combination against the grandparent's negPellSeq_norm. negPellChainSolution n = (isNegPell_negPellElt n).toSolution₁ promotes it into Solution₁ 2, with x/y components matching the parent's arithmetic form. The centrepiece is negPellChainSolution_prop: the Pell equation x² − 2y² = 1 is now delivered as Mathlib's own Solution₁.prop — a library-level fact rather than a hand-written identity.",
+    "mathContext": "$(x_n, y_n)$ with $N=-1$ squares to $(x_n^2 + 2y_n^2,\\ 2x_ny_n) \\in \\texttt{Solution}_1\\,2$, satisfying $x^2 - 2y^2 = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["negPellSeq", "linear_combination", "Solution₁.prop", "chain lifting"],
+    "prerequisites": ["parent negative-Pell chain", "Zsqrtd.norm_def"]
+  },
+  {
+    "id": "ann-fundamental-case",
+    "proofId": "pell-equation-oq-06-oq-01-oq-02",
+    "range": { "startLine": 203, "endLine": 218 },
+    "type": "context",
+    "title": "Fundamental case: 1+√2 squares to 3+2√2",
+    "content": "negPellChainSolution_zero pins the fundamental correspondence: the fundamental negative solution 1+√2 (norm −1) squares to the fundamental positive solution 3+2√2 = Solution₁.mk 3 2, the fundamental unit of norm +1 for ℤ√2. The proof is Solution₁.ext on the x and y components using negPellSeq_zero and norm_num. The trailing example gives a second data point: the chain term (7,5) squares to (99,70), with 99² − 2·70² = 1. Together these ground the abstract promotion in the smallest explicit cases.",
+    "mathContext": "$(1+\\sqrt2)^2 = 3+2\\sqrt2 = \\texttt{Solution}_1.\\mathrm{mk}\\,3\\,2$; $(7,5)^2 = (99,70),\\ 99^2 - 2\\cdot70^2 = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["fundamental solution", "Solution₁.ext", "fundamental unit of ℤ√2"],
+    "prerequisites": ["fundamental unit theory"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-06-oq-01-oq-02` (was zero-annotation).

## Changes
- **Created `annotations.json`** with 8 substantive annotations covering the full Lean file (lines 1–218):
  - Docstring: promoting the parent's bare identity into a Mathlib-typed `Solution₁` object
  - `isUnit_iff_norm_eq_pm_one`: units of ℤ√d ⟺ norm ±1
  - The `IsPosPell`/`IsNegPell` classes and their identification with `unitary (ℤ√d)`
  - The coset sign-laws (`isNegPell_mul_iff_norm_one`): negative-Pell as the other half of the unit group
  - `IsNegPell.toSolution₁`: the squaring promotion and its explicit components
  - The d=2 chain lift and the fundamental 1+√2 ↦ 3+2√2 case
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json unchanged (already rich, 14 KB, within caps). No claims altered.