### PR TITLE
Fix: create missing gallery entry for bell-numbers-oq-01

### DIFF
--- a/src/data/proofs/bell-numbers-oq-01/annotations.json
+++ b/src/data/proofs/bell-numbers-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header-bridge",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Bridging two disconnected Mathlib definitions",
+    "content": "The docstring states the goal and the obstruction. Mathlib defines the Bell numbers Nat.bell by the binomial recurrence B_{n+1} = Σᵢ C(n,i)·B_{n−i} and the Stirling numbers of the second kind Nat.stirlingSecond by the triangular recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k), but provides no lemma linking them. The classical row-sum identity Bₙ = Σₖ S(n,k) (group the partitions of an n-set by block count) therefore needs a fresh combinatorial bridge. The bridge is a 'horizontal' Stirling recurrence — also missing from Mathlib — obtained by conditioning a partition of {0,…,n} on how many points lie outside the block of the last element.",
+    "mathContext": "$B_n = \\sum_{k=0}^{n} S(n,k)$; the bridge is $S(n+1,k+1) = \\sum_{j=0}^{n} \\binom{n}{j} S(j,k)$.",
+    "significance": "context",
+    "relatedConcepts": ["Bell numbers", "Stirling numbers of the second kind", "set partitions", "OEIS A000110", "recurrence relations"],
+    "prerequisites": ["enumerative combinatorics", "set partitions"]
+  },
+  {
+    "id": "ann-horizontal-statement",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 38, "endLine": 46 },
+    "type": "insight",
+    "title": "The horizontal Stirling recurrence (main contribution)",
+    "content": "stirlingSecond_horizontal is the file's key new identity: S(n+1,k+1) = Σ_{j≤n} C(n,j)·S(j,k). Combinatorially, in a partition of {0,…,n} into k+1 blocks, condition on the set of j points lying outside the block containing the last point: C(n,j) chooses which j points are 'outside', and those j points must themselves form k blocks (S(j,k) ways), while the remaining n−j points plus the last point form the (k+1)-th block. Summing over j gives the recurrence. It is proved by induction on n with k generalized; the base case n=0 is dispatched by simp from the triangular recurrence and the boundary value stirlingSecond_zero_succ.",
+    "mathContext": "$S(n+1,k+1) = \\sum_{j=0}^{n} \\binom{n}{j} S(j,k)$ — condition on the $j$ points outside the last point's block.",
+    "significance": "key",
+    "relatedConcepts": ["horizontal recurrence", "conditioning argument", "block of the last point", "induction generalizing k"],
+    "prerequisites": ["Stirling recurrences", "binomial coefficients"]
+  },
+  {
+    "id": "ann-horizontal-pascal",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 47, "endLine": 63 },
+    "type": "technique",
+    "title": "Inductive step: peel j=0, then Pascal's rule",
+    "content": "The successor case rewrites the left side by the triangular recurrence and the right side by peeling the j=0 term with Finset.sum_range_succ'. Pascal's rule (Nat.choose_succ_succ', C(n+1,i+1) = C(n,i) + C(n,i+1)) with add_mul and sum_add_distrib splits the remaining sum into a 'shifted' block Σ C(n,i+1)·S(i+1,k) and an 'unshifted' block Σ C(n,i)·S(i+1,k). The lemma hshift re-glues the shifted block with its missing j=0 term (the top term vanishes via Nat.choose_succ_self, C(n,n+1)=0), and hS2 identifies that block with S(n+1,k+1) using the inductive hypothesis ih k.",
+    "mathContext": "$\\binom{n+1}{i+1} = \\binom{n}{i} + \\binom{n}{i+1}$ splits the sum into shifted and unshifted blocks.",
+    "significance": "supporting",
+    "relatedConcepts": ["Pascal's rule", "Nat.choose_succ_succ'", "Finset.sum_range_succ'", "sum_add_distrib"],
+    "prerequisites": ["binomial identities", "finite-sum manipulation"]
+  },
+  {
+    "id": "ann-horizontal-cases",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 64, "endLine": 82 },
+    "type": "technique",
+    "title": "Closing the unshifted block: cases on k, then omega",
+    "content": "The unshifted block Σ C(n,i)·S(i+1,k) is handled by cases on k. When k=0, every term S(i+1,0) = 0 (Nat.stirlingSecond_succ_zero), so hSum1zero collapses the whole sum and omega finishes. When k = k'+1, hSum1 expands S(i+1,k'+2) by the triangular recurrence and applies the inductive hypothesis twice (ih (k'+1) and ih k'), refolding via mul_sum and sum_add_distrib into (k'+1)·S(n+1,k'+2) + S(n+1,k'+1). In both branches omega combines hS2 and hSum1(zero) with the target's arithmetic to close the goal.",
+    "mathContext": "$k=0$: $S(i+1,0)=0$. $k=k'+1$: unshifted block $= (k'{+}1)S(n{+}1,k'{+}2) + S(n{+}1,k'{+}1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["case split", "Nat.stirlingSecond_succ_zero", "omega tactic", "Finset.mul_sum"],
+    "prerequisites": ["Stirling boundary values", "linear arithmetic"]
+  },
+  {
+    "id": "ann-bell-rowsum-statement",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 84, "endLine": 93 },
+    "type": "insight",
+    "title": "Bell = Stirling row sum, by strong induction",
+    "content": "bell_eq_sum_stirlingSecond is the headline result: Nat.bell n = Σ_{k≤n} Nat.stirlingSecond n k. It is proved by strong induction (Nat.strong_induction_on), pattern-matching on n. The n=0 case is simp (B₀ = 1 = S(0,0)). The successor case m+1 reduces the Bell recurrence to the summed horizontal recurrence, using the inductive hypothesis on all smaller j through the auxiliary hInner.",
+    "mathContext": "$B_n = \\sum_{k=0}^{n} S(n,k)$, proved by strong induction on $n$.",
+    "significance": "key",
+    "relatedConcepts": ["strong induction", "row sum", "Nat.strong_induction_on"],
+    "prerequisites": ["strong induction", "Bell and Stirling numbers"]
+  },
+  {
+    "id": "ann-bell-inner-tail",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 94, "endLine": 103 },
+    "type": "technique",
+    "title": "Padding the row sum: the Stirling tail vanishes",
+    "content": "hInner shows that for every j ≤ m, the padded row sum Σ_{k∈range(m+1)} S(j,k) already equals Nat.bell j. The point is that the exact range should be range(j+1), but the extra terms S(j,k) for k > j are all zero (Nat.stirlingSecond_eq_zero_of_lt, the Stirling triangle vanishes above the diagonal), so Finset.sum_subset lets the wider padded range range(m+1) stand in. Then the inductive hypothesis ih j (valid since j < m+1) gives bell j. Padding to a uniform range is what allows the later sum-swap to go through cleanly.",
+    "mathContext": "$S(j,k)=0$ for $k>j$, so $\\sum_{k=0}^{m} S(j,k) = \\sum_{k=0}^{j} S(j,k) = B_j$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.stirlingSecond_eq_zero_of_lt", "Finset.sum_subset", "vanishing above the diagonal", "padded range"],
+    "prerequisites": ["Finset.sum_subset", "Stirling triangle"]
+  },
+  {
+    "id": "ann-bell-recurrence-reflect",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 104, "endLine": 112 },
+    "type": "technique",
+    "title": "Reindexing the Bell recurrence via reflection and symmetry",
+    "content": "hbell recasts Mathlib's Bell recurrence into a shape matching the horizontal sum. Nat.bell_succ gives B_{m+1} = Σᵢ C(m,i)·B_{m−i} over Fin (m+1); Fin.sum_univ_eq_sum_range converts to a range sum, Finset.sum_range_reflect reverses the index j ↦ m−j, and the binomial symmetry Nat.choose_symm (C(m,i) = C(m,m−i)) turns the summand into C(m,j)·B_j. The result B_{m+1} = Σ_{j≤m} C(m,j)·B_j is exactly the form produced by summing the horizontal recurrence over k.",
+    "mathContext": "$B_{m+1} = \\sum_{i} \\binom{m}{i} B_{m-i} = \\sum_{j=0}^{m} \\binom{m}{j} B_j$ via reflection $j\\mapsto m-j$ and $\\binom{m}{i}=\\binom{m}{m-i}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.bell_succ", "Finset.sum_range_reflect", "Nat.choose_symm", "index reflection"],
+    "prerequisites": ["binomial symmetry", "sum reindexing"]
+  },
+  {
+    "id": "ann-bell-final-assembly",
+    "proofId": "bell-numbers-oq-01",
+    "range": { "startLine": 113, "endLine": 119 },
+    "type": "insight",
+    "title": "Final assembly: substitute, swap, refold",
+    "content": "The closing four lines fuse everything. After rewriting by hbell and peeling the k=0 term of the Stirling row sum (which is S(m+1,0) = 0), simp_rw [stirlingSecond_horizontal] replaces each S(m+1,k+1) by its horizontal sum Σ_j C(m,j)·S(j,k). Finset.sum_comm swaps the k- and j-summations, ← Finset.mul_sum factors out C(m,j), and the inner Σ_k S(j,k) is replaced by bell j through hInner — matching the C(m,j)·B_j terms of the Bell recurrence term by term. This is where the summed horizontal recurrence becomes the Bell binomial recurrence.",
+    "mathContext": "$\\sum_k \\sum_j \\binom{m}{j} S(j,k) \\xrightarrow{\\text{swap}} \\sum_j \\binom{m}{j}\\sum_k S(j,k) = \\sum_j \\binom{m}{j} B_j = B_{m+1}.$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_comm", "Finset.mul_sum", "double-sum swap", "recurrence matching"],
+    "prerequisites": ["double sums", "Fubini for finite sums"]
+  }
+]

--- a/src/data/proofs/bell-numbers-oq-01/meta.json
+++ b/src/data/proofs/bell-numbers-oq-01/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "bell-numbers-oq-01",
+  "slug": "bell-numbers-oq-01",
+  "title": "Bell Numbers as the Row Sum of Stirling Numbers of the Second Kind",
+  "status": "verified",
+  "badge": "original",
+  "description": "A machine-checked bridge between Mathlib's two independent combinatorial definitions Nat.bell and Nat.stirlingSecond: the classical identity Bₙ = Σ_{k=0}^{n} S(n,k), obtained by grouping the partitions of an n-element set by their number of blocks. Pinned Mathlib defines the Bell numbers by the binomial recurrence B_{n+1} = Σ_i C(n,i)·B_{n-i} and the Stirling numbers of the second kind by the triangular recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k), but does not connect them. The link is a second, 'horizontal' Stirling recurrence — also absent from Mathlib — S(n+1,k+1) = Σ_{j≤n} C(n,j)·S(j,k), proved by conditioning a partition of {0,…,n} into k+1 blocks on the j points lying outside the block of the last element; summing it over k turns the Stirling row sum into the Bell binomial recurrence. Fully verified: 2 theorems, 0 definitions, 0 sorries, 0 axioms, no native_decide.",
+  "overview": {
+    "historicalContext": "The Bell numbers 1, 1, 2, 5, 15, 52, … (OEIS A000110) count the partitions of a finite set; the Stirling numbers of the second kind S(n,k) count partitions into exactly k nonempty blocks. That Bₙ is the row sum Σ_k S(n,k) is one of the oldest identities in enumerative combinatorics, immediate from the definitions once one groups partitions by their block count. Mathlib carries both sequences (Nat.bell via a binomial recurrence, Nat.stirlingSecond via the triangular recurrence) with their boundary values, but — as of the pinned version — leaves the two developments disconnected.",
+    "problemStatement": "Prove, for every natural number n, that Nat.bell n = Σ_{k ∈ range (n+1)} Nat.stirlingSecond n k, connecting Mathlib's Nat.bell (binomial recurrence) and Nat.stirlingSecond (triangular recurrence). Mathlib provides no lemma relating the two, so a fresh combinatorial bridge is required.",
+    "proofStrategy": "The proof rests on a 'horizontal' Stirling recurrence S(n+1,k+1) = Σ_{j≤n} C(n,j)·S(j,k), established by induction on n from the triangular recurrence: the j=0 term is peeled with Finset.sum_range_succ', the remaining sum is re-indexed via Pascal's rule (Nat.choose_succ_succ'), and the two resulting blocks are matched against the inductive hypothesis (the shifted block collapses via Nat.choose_succ_self, the unshifted one via the triangular recurrence), with omega closing the arithmetic. The Bell identity is then proved by strong induction: the padded Stirling row sum equals bell j for every j ≤ m (tail terms vanish by Nat.stirlingSecond_eq_zero_of_lt), the Bell binomial recurrence is rewritten as Σ_j C(m,j)·bell j (using Nat.bell_succ, Fin.sum_univ_eq_sum_range, sum_range_reflect and Nat.choose_symm), and substituting the horizontal recurrence, swapping the order of summation (Finset.sum_comm), and folding C(m,j) back in identifies the two.",
+    "keyInsights": [
+      "The row-sum identity Bₙ = Σ_k S(n,k) reduces to matching two different recurrences Mathlib already knows about: the Bell binomial recurrence and the Stirling triangular recurrence.",
+      "The missing link is the horizontal Stirling recurrence S(n+1,k+1) = Σ_{j≤n} C(n,j)·S(j,k), which comes from conditioning on the block of the last point; it is not in pinned Mathlib and is the file's main combinatorial contribution.",
+      "Summing the horizontal recurrence over k and swapping the order of summation converts a sum of Stirling row sums into the Bell binomial recurrence — the two definitions then agree by induction.",
+      "The Stirling tail vanishes above the diagonal (S(n,k) = 0 for k > n), so a padded range (n+1 terms) can stand in for the exact range (j+1 terms) via Finset.sum_subset."
+    ],
+    "prerequisites": [
+      "Set partitions, Bell numbers and Stirling numbers of the second kind",
+      "The triangular and binomial recurrences for these sequences (Mathlib's Nat.stirlingSecond and Nat.bell)",
+      "Finite sums over Finset.range: sum_range_succ / sum_range_succ', sum_comm, sum_subset, sum_range_reflect",
+      "Pascal's rule and binomial symmetry (Nat.choose_succ_succ', Nat.choose_symm); strong induction and omega"
+    ]
+  },
+  "sections": [
+    {
+      "id": "horizontal-recurrence",
+      "title": "Section I: The Horizontal Stirling Recurrence",
+      "startLine": 38,
+      "endLine": 82,
+      "summary": "stirlingSecond_horizontal: S(n+1,k+1) = Σ_{j∈range(n+1)} C(n,j)·S(j,k), proved by induction on n (generalizing k) from the triangular recurrence.",
+      "mathContext": "Absent from pinned Mathlib. The induction peels the j=0 term with Finset.sum_range_succ', applies Pascal's rule to split the remainder into a shifted and an unshifted block, and matches each against the inductive hypothesis; omega discharges the residual arithmetic in the k=0 and k=k'+1 cases."
+    },
+    {
+      "id": "bell-row-sum",
+      "title": "Section II: Bell Numbers as the Stirling Row Sum",
+      "startLine": 84,
+      "endLine": 118,
+      "summary": "bell_eq_sum_stirlingSecond: Nat.bell n = Σ_{k∈range(n+1)} Nat.stirlingSecond n k, by strong induction using the horizontal recurrence and the Bell binomial recurrence.",
+      "mathContext": "The padded Stirling row sum equals bell j for j ≤ m (tail terms vanish by Nat.stirlingSecond_eq_zero_of_lt); rewriting Nat.bell_succ as Σ_j C(m,j)·bell j, substituting the horizontal recurrence, and swapping the summation order (Finset.sum_comm) identifies the two sides."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 120 lines with 2 theorems establishing the horizontal Stirling recurrence S(n+1,k+1) = Σ_{j≤n} C(n,j)·S(j,k) and the Bell row-sum identity Bₙ = Σ_{k≤n} S(n,k). #print axioms reports only [propext, Classical.choice, Quot.sound] for the headline theorem. The result connects Mathlib's otherwise disconnected Nat.bell and Nat.stirlingSecond developments.",
+    "implications": "Supplies a bridge Mathlib lacks between its two combinatorial partition-count sequences. The horizontal Stirling recurrence proved en route is itself a reusable identity absent from the library. The mathematics is classical; the contribution is the clean formalized connection and the auxiliary recurrence.",
+    "openQuestions": [
+      "Formalize the exponential generating function identity Σ Bₙ xⁿ/n! = exp(eˣ − 1) and derive the row-sum identity from it.",
+      "Prove Dobinski's formula Bₙ = e⁻¹ Σ_{k≥0} kⁿ/k! and relate it to the Stirling row sum.",
+      "Establish the companion identity for the Stirling numbers of the first kind (row sums giving n!) by the analogous conditioning argument."
+    ]
+  },
+  "references": [
+    {
+      "key": "OEIS_A000110",
+      "citation": "OEIS Foundation, The On-Line Encyclopedia of Integer Sequences, sequence A000110 (Bell numbers).",
+      "type": "web"
+    },
+    {
+      "key": "OEIS_A008277",
+      "citation": "OEIS Foundation, The On-Line Encyclopedia of Integer Sequences, sequence A008277 (Stirling numbers of the second kind).",
+      "type": "web"
+    },
+    {
+      "key": "Stanley_EC1",
+      "citation": "Stanley, R. P., Enumerative Combinatorics, Volume 1, 2nd ed., Cambridge University Press (2011), Chapter 1 (set partitions, Bell and Stirling numbers).",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "uniformbell-multinomial-oq-01",
+      "relationship": "Related Bell-number result",
+      "description": "Companion formalization studying uniform Bell numbers and the multinomial structure of equal-block partitions; shares the set-partition setting and Mathlib's Nat.bell."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Enumerative.Stirling",
+      "Mathlib.Combinatorics.Enumerative.Bell",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "BellNumbersOQ01",
+    "lineCount": 120,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/BellNumbersOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://oeis.org/A000110",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BellNumbersOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "bell-numbers",
+      "stirling-numbers",
+      "set-partitions",
+      "recurrence",
+      "finite-sums",
+      "induction",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.stirlingSecond_succ_succ",
+        "description": "The triangular recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k) — the sole recurrence Mathlib provides for the Stirling numbers of the second kind, driving the horizontal recurrence's induction.",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.bell_succ",
+        "description": "The Bell binomial recurrence B_{n+1} = Σ_i C(n,i)·B_{n-i}, rewritten (via sum_range_reflect and Nat.choose_symm) as Σ_j C(n,j)·B_j to match the summed horizontal recurrence.",
+        "module": "Mathlib.Combinatorics.Enumerative.Bell"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Swaps the order of a double sum — turns Σ_k Σ_j into Σ_j Σ_k so the C(m,j) factor can be folded back in against the Bell recurrence.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.stirlingSecond_eq_zero_of_lt",
+        "description": "S(n,k) = 0 for k > n — lets a padded range replace the exact range in the row sum via Finset.sum_subset.",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      }
+    ],
+    "originalContributions": [
+      "stirlingSecond_horizontal: the horizontal Stirling recurrence S(n+1,k+1) = Σ_{j≤n} C(n,j)·S(j,k), absent from pinned Mathlib",
+      "bell_eq_sum_stirlingSecond: the row-sum identity Bₙ = Σ_{k≤n} S(n,k), connecting Mathlib's Nat.bell and Nat.stirlingSecond",
+      "A fully machine-checked bridge between Mathlib's two disconnected partition-count sequences, obtained by conditioning on the block of the last point"
+    ],
+    "axiomCount": 0,
+    "lineCount": 120,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for stirlingSecond_horizontal and bell_eq_sum_stirlingSecond. Compiled against Mathlib v4.26.0. The row-sum identity is classical; the horizontal Stirling recurrence used as the bridge is not present in pinned Mathlib and is proved from scratch.",
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "prerequisites": [
+      "Set partitions, Bell and Stirling (second kind) numbers",
+      "The triangular and binomial recurrences (Nat.stirlingSecond, Nat.bell)",
+      "Finite sums over Finset.range: sum_range_succ', sum_comm, sum_subset, sum_range_reflect",
+      "Pascal's rule, binomial symmetry, strong induction and omega"
+    ],
+    "relatedProblems": [
+      "uniformbell-multinomial-oq-01"
+    ]
+  }
+}


### PR DESCRIPTION
## Fix

The verified, 0-axiom proof `proofs/Proofs/BellNumbersOQ01.lean` (Bell numbers as the row sum of Stirling numbers of the second kind, merged in #27098) had **no** `src/data/proofs/` gallery directory, so the result was invisible in the gallery. This PR creates the entry.

## Evidence

**Before**: `git cat-file -e origin/main:proofs/Proofs/BellNumbersOQ01.lean` succeeds, but `src/data/proofs/bell-numbers-oq-01/` did not exist — no gallery entry ever created for this merged research result. (Same GAP pattern as sum-of-divisors-oq-03 → #32878.)

**After**: adds `bell-numbers-oq-01/meta.json` (status `verified`, badge `original`, 2 theorems, 0 definitions, 0 sorries, 0 axioms, no `native_decide`, 120 lines — all confirmed against the Lean source) plus `annotations.json` (8 annotations, authored by the enricher on this branch). `pnpm build` passes.

Fixes the invisibility of a completed proof. `axiomCount` is 0: `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for the two headline theorems.

---
Automated fix by lean-mechanic agent.