### PR TITLE
research(vietas-formulas-oq-04-oq-01): cubic discriminant as squared root-gaps = −4p³−27q² [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/VietasFormulasOQ04OQ01.lean
+++ b/proofs/Proofs/VietasFormulasOQ04OQ01.lean
@@ -1,0 +1,140 @@
+/-
+  # The discriminant of a cubic via Vieta's formulas
+  # (vietas-formulas-oq-04-oq-01)
+
+  ## The Open Question
+
+  The parent entry `vietas-formulas-oq-04` treats the **quadratic** discriminant,
+  proving the identity `b² − 4ac = a²(r − s)²` and its consequences (repeated root
+  ⇔ `Δ = 0`, sign behaviour over an ordered field). This file answers the child
+  open question for the **cubic**:
+
+  > Express the cubic discriminant as `∏_{i<j} (rᵢ − rⱼ)²` and verify that it equals
+  > the classical `−4p³ − 27q²` for the depressed cubic `x³ + p·x + q`.
+
+  For a monic cubic with roots `r₁, r₂, r₃` the discriminant is, by definition,
+
+      Δ = (r₁ − r₂)² (r₁ − r₃)² (r₂ − r₃)².
+
+  The elementary symmetric functions of the roots are
+
+      e₁ = r₁ + r₂ + r₃,
+      e₂ = r₁r₂ + r₁r₃ + r₂r₃,
+      e₃ = r₁r₂r₃,
+
+  and the master identity (a pure polynomial identity, no hypotheses) is
+
+      Δ = e₁²e₂² − 4e₂³ − 4e₁³e₃ + 18 e₁e₂e₃ − 27 e₃².
+
+  Vieta's formulas for `x³ + b·x² + c·x + d` read `e₁ = −b, e₂ = c, e₃ = −d`, so the
+  identity specialises to the classical coefficient discriminant
+
+      Δ = b²c² − 4c³ − 4b³d + 18 b c d − 27 d².
+
+  For the **depressed** cubic `x³ + p·x + q` we have `b = 0`, i.e. `e₁ = 0`, and the
+  whole expression collapses to
+
+      Δ = −4p³ − 27q²        (since `p = e₂`,  `q = −e₃`).
+
+  We close the loop the same way the parent did for the quadratic: over an integral
+  domain `Δ = 0` holds **iff two of the roots coincide**, the cubic analogue of the
+  quadratic repeated-root criterion.
+
+  ## Axiom count: 0
+-/
+
+import Mathlib
+
+namespace CubicDiscriminant
+
+/-- **The master discriminant identity (over any commutative ring).**
+    The cubic discriminant `((r₁−r₂)(r₁−r₃)(r₂−r₃))²` equals the universal polynomial
+    in the elementary symmetric functions `e₁ = r₁+r₂+r₃`, `e₂ = r₁r₂+r₁r₃+r₂r₃`,
+    `e₃ = r₁r₂r₃`, namely `e₁²e₂² − 4e₂³ − 4e₁³e₃ + 18 e₁e₂e₃ − 27 e₃²`.
+    This is a pure `ring` identity requiring no hypotheses. -/
+theorem discriminant_eq_esymm {R : Type*} [CommRing R] (r₁ r₂ r₃ : R) :
+    ((r₁ - r₂) * (r₁ - r₃) * (r₂ - r₃)) ^ 2 =
+      (r₁ + r₂ + r₃) ^ 2 * (r₁ * r₂ + r₁ * r₃ + r₂ * r₃) ^ 2
+        - 4 * (r₁ * r₂ + r₁ * r₃ + r₂ * r₃) ^ 3
+        - 4 * (r₁ + r₂ + r₃) ^ 3 * (r₁ * r₂ * r₃)
+        + 18 * (r₁ + r₂ + r₃) * (r₁ * r₂ + r₁ * r₃ + r₂ * r₃) * (r₁ * r₂ * r₃)
+        - 27 * (r₁ * r₂ * r₃) ^ 2 := by
+  ring
+
+/-- **Discriminant in terms of the coefficients of a monic cubic.**
+    If `r₁, r₂, r₃` are the roots of `x³ + b·x² + c·x + d`, so that Vieta's formulas
+    give `b = -(r₁+r₂+r₃)`, `c = r₁r₂+r₁r₃+r₂r₃`, `d = -(r₁r₂r₃)`, then the
+    discriminant is the classical `b²c² − 4c³ − 4b³d + 18 b c d − 27 d²`. -/
+theorem discriminant_eq_coeffs {R : Type*} [CommRing R] (b c d r₁ r₂ r₃ : R)
+    (hb : b = -(r₁ + r₂ + r₃))
+    (hc : c = r₁ * r₂ + r₁ * r₃ + r₂ * r₃)
+    (hd : d = -(r₁ * r₂ * r₃)) :
+    ((r₁ - r₂) * (r₁ - r₃) * (r₂ - r₃)) ^ 2 =
+      b ^ 2 * c ^ 2 - 4 * c ^ 3 - 4 * b ^ 3 * d + 18 * b * c * d - 27 * d ^ 2 := by
+  subst hb hc hd; ring
+
+/-- **The depressed-cubic discriminant `Δ = −4p³ − 27q²`.**
+    A depressed cubic `x³ + p·x + q` has vanishing quadratic coefficient, i.e. the
+    roots satisfy `r₁ + r₂ + r₃ = 0`, together with `p = r₁r₂+r₁r₃+r₂r₃` and
+    `q = -(r₁r₂r₃)`. Under these Vieta relations the discriminant collapses to the
+    classical `−4p³ − 27q²`. -/
+theorem discriminant_depressed {R : Type*} [CommRing R] (p q r₁ r₂ r₃ : R)
+    (hsum : r₁ + r₂ + r₃ = 0)
+    (hp : p = r₁ * r₂ + r₁ * r₃ + r₂ * r₃)
+    (hq : q = -(r₁ * r₂ * r₃)) :
+    ((r₁ - r₂) * (r₁ - r₃) * (r₂ - r₃)) ^ 2 = -4 * p ^ 3 - 27 * q ^ 2 := by
+  -- Eliminate `r₃` via `r₃ = -(r₁ + r₂)`, then it is a pure ring computation.
+  have hr3 : r₃ = -(r₁ + r₂) := by linear_combination hsum
+  subst hr3 hp hq; ring
+
+/-- **Sum-of-roots-zero form (no `p, q` symbols).**
+    Purely in terms of the roots: when `r₁ + r₂ + r₃ = 0` the discriminant equals
+    `−4·e₂³ − 27·e₃²`. This is `discriminant_depressed` with `p, q` inlined and is
+    the cleanest statement of the depressed identity. -/
+theorem discriminant_of_sum_zero {R : Type*} [CommRing R] (r₁ r₂ r₃ : R)
+    (hsum : r₁ + r₂ + r₃ = 0) :
+    ((r₁ - r₂) * (r₁ - r₃) * (r₂ - r₃)) ^ 2 =
+      -4 * (r₁ * r₂ + r₁ * r₃ + r₂ * r₃) ^ 3 - 27 * (r₁ * r₂ * r₃) ^ 2 := by
+  have hr3 : r₃ = -(r₁ + r₂) := by linear_combination hsum
+  subst hr3; ring
+
+/-- **Sanity check: the depressed identity as a numerical instance.**
+    The roots `-1, 0, 1` of `x³ - x` (so `p = -1, q = 0`) give discriminant
+    `-4·(-1)³ - 27·0² = 4`, and indeed `((-1-0)(-1-1)(0-1))² = ((-1)(-2)(-1))² = 4`. -/
+example : ((((-1 : ℤ) - 0) * ((-1) - 1) * (0 - 1)) ^ 2)
+    = -4 * (-1 : ℤ) ^ 3 - 27 * (0 : ℤ) ^ 2 := by decide
+
+/-- **The discriminant vanishes iff two roots coincide (over an integral domain).**
+    The cubic analogue of the quadratic repeated-root criterion: since the
+    discriminant is a product of squared differences, over a domain it is zero
+    exactly when some pair of roots is equal. -/
+theorem discriminant_eq_zero_iff {R : Type*} [CommRing R] [IsDomain R]
+    (r₁ r₂ r₃ : R) :
+    ((r₁ - r₂) * (r₁ - r₃) * (r₂ - r₃)) ^ 2 = 0 ↔
+      r₁ = r₂ ∨ r₁ = r₃ ∨ r₂ = r₃ := by
+  rw [pow_eq_zero_iff (n := 2) (by norm_num), mul_eq_zero, mul_eq_zero,
+    sub_eq_zero, sub_eq_zero, sub_eq_zero, or_assoc]
+
+/-- **Distinct roots ⇒ nonzero discriminant (over an integral domain).**
+    Direct consequence of `discriminant_eq_zero_iff`: three pairwise-distinct roots
+    force the discriminant to be nonzero. -/
+theorem discriminant_ne_zero_of_distinct {R : Type*} [CommRing R] [IsDomain R]
+    {r₁ r₂ r₃ : R} (h₁₂ : r₁ ≠ r₂) (h₁₃ : r₁ ≠ r₃) (h₂₃ : r₂ ≠ r₃) :
+    ((r₁ - r₂) * (r₁ - r₃) * (r₂ - r₃)) ^ 2 ≠ 0 := by
+  rw [Ne, discriminant_eq_zero_iff]
+  push_neg
+  exact ⟨h₁₂, h₁₃, h₂₃⟩
+
+/-- **Depressed repeated-root criterion in `p, q` form (over an integral domain).**
+    Combining `discriminant_depressed` with `discriminant_eq_zero_iff`: for a
+    depressed cubic the classical quantity `-4p³ - 27q²` vanishes exactly when two
+    of the roots coincide. -/
+theorem depressed_discriminant_zero_iff {R : Type*} [CommRing R] [IsDomain R]
+    (p q r₁ r₂ r₃ : R)
+    (hsum : r₁ + r₂ + r₃ = 0)
+    (hp : p = r₁ * r₂ + r₁ * r₃ + r₂ * r₃)
+    (hq : q = -(r₁ * r₂ * r₃)) :
+    -4 * p ^ 3 - 27 * q ^ 2 = 0 ↔ r₁ = r₂ ∨ r₁ = r₃ ∨ r₂ = r₃ := by
+  rw [← discriminant_depressed p q r₁ r₂ r₃ hsum hp hq, discriminant_eq_zero_iff]
+
+end CubicDiscriminant

--- a/src/data/proofs/vietas-formulas-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/vietas-formulas-oq-04-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-vf-oq0401-esymm",
+    "proofId": "vietas-formulas-oq-04-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 65
+    },
+    "type": "theorem",
+    "title": "The Master Identity in Elementary Symmetric Functions",
+    "content": "The engine of the file. Expanding the squared root-gap product `((r₁−r₂)(r₁−r₃)(r₂−r₃))²` and rewriting in the elementary symmetric functions e₁ = r₁+r₂+r₃, e₂ = r₁r₂+r₁r₃+r₂r₃, e₃ = r₁r₂r₃ yields `e₁²e₂² − 4e₂³ − 4e₁³e₃ + 18e₁e₂e₃ − 27e₃²`. The proof is a single `ring` call with no hypotheses. Stated over an arbitrary `CommRing R`, so it holds over ℤ, finite fields, and matrix rings — no field, order, or characteristic assumptions.",
+    "mathContext": "Δ = ∏_{i<j}(rᵢ−rⱼ)² is a symmetric polynomial in the roots, hence expressible in e₁,e₂,e₃. The explicit expansion is the degree-3 discriminant-in-symmetric-functions formula.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "discriminant",
+      "elementary symmetric polynomials",
+      "Vieta's formulas",
+      "ring identity",
+      "CommRing"
+    ],
+    "prerequisites": [
+      "Commutative ring axioms",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-vf-oq0401-coeffs",
+    "proofId": "vietas-formulas-oq-04-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "The Classical Coefficient Discriminant",
+    "content": "Specialises the master identity to the coefficients of a monic cubic `x³ + b·x² + c·x + d`. Vieta's formulas give `b = −(r₁+r₂+r₃)`, `c = r₁r₂+r₁r₃+r₂r₃`, `d = −(r₁r₂r₃)`; substituting these (`subst hb hc hd`) and running `ring` produces the textbook `b²c² − 4c³ − 4b³d + 18bcd − 27d²`. This is the discriminant of the general monic cubic in its coefficient form.",
+    "mathContext": "With a = 1 the classical cubic discriminant Δ = 18bcd − 4b³d + b²c² − 4c³ − 27d² is exactly the e₁=−b, e₂=c, e₃=−d substitution into the master identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "discriminant",
+      "Vieta's formulas",
+      "monic cubic",
+      "polynomial coefficients"
+    ],
+    "prerequisites": [
+      "Vieta's formulas for the cubic",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-vf-oq0401-depressed",
+    "proofId": "vietas-formulas-oq-04-oq-01",
+    "range": {
+      "startLine": 81,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "The Depressed-Cubic Discriminant Δ = −4p³ − 27q²",
+    "content": "The headline result. A depressed cubic `x³ + p·x + q` has vanishing quadratic coefficient, so the roots satisfy `r₁ + r₂ + r₃ = 0`, with `p = r₁r₂+r₁r₃+r₂r₃` and `q = −(r₁r₂r₃)`. The proof eliminates the third root via `r₃ = −(r₁ + r₂)` (obtained by `linear_combination hsum`), then `subst hr3 hp hq; ring` collapses the whole expression to `−4p³ − 27q²`. This is the classical discriminant that governs the casus irreducibilis of the cubic.",
+    "mathContext": "When e₁ = 0 the four e₁-bearing terms of the master identity vanish, leaving −4e₂³ − 27e₃² = −4p³ − 27q² (since p = e₂, q = −e₃, so q² = e₃²).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "discriminant",
+      "depressed cubic",
+      "casus irreducibilis",
+      "Vieta's formulas"
+    ],
+    "prerequisites": [
+      "Vieta's formulas for the cubic",
+      "linear_combination tactic",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-vf-oq0401-repeated-root",
+    "proofId": "vietas-formulas-oq-04-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 119
+    },
+    "type": "theorem",
+    "title": "The Repeated-Root Criterion over an Integral Domain",
+    "content": "The cubic analogue of the quadratic repeated-root test. Because the discriminant is literally the square of the product `(r₁−r₂)(r₁−r₃)(r₂−r₃)`, over an integral domain it vanishes exactly when a factor does: `pow_eq_zero_iff` strips the square, `mul_eq_zero` splits the product, and `sub_eq_zero` turns each vanishing gap into a coincidence of roots, giving `Δ = 0 ↔ r₁=r₂ ∨ r₁=r₃ ∨ r₂=r₃`. The companions `discriminant_ne_zero_of_distinct` and `depressed_discriminant_zero_iff` deduce that distinct roots force Δ≠0 and rephrase the criterion in p,q form.",
+    "mathContext": "Δ = 0 ⇔ some pair of roots coincides. This is an exact equivalence over any domain, not an estimate — the structural reason √Δ detects a repeated root.",
+    "significance": "key",
+    "relatedConcepts": [
+      "discriminant",
+      "repeated roots",
+      "integral domain",
+      "no zero divisors"
+    ],
+    "prerequisites": [
+      "Integral domain (no zero divisors)",
+      "pow_eq_zero_iff",
+      "mul_eq_zero",
+      "sub_eq_zero"
+    ]
+  }
+]

--- a/src/data/proofs/vietas-formulas-oq-04-oq-01/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-04-oq-01/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "vietas-formulas-oq-04-oq-01",
+  "title": "The Cubic Discriminant via Vieta's Formulas",
+  "slug": "vietas-formulas-oq-04-oq-01",
+  "description": "Expresses the discriminant of a monic cubic as the product of squared root-gaps Δ = (r₁−r₂)²(r₁−r₃)²(r₂−r₃)² and identifies it with the classical coefficient formulas. A single universal ring identity gives Δ = e₁²e₂² − 4e₂³ − 4e₁³e₃ + 18e₁e₂e₃ − 27e₃² in the elementary symmetric functions; specialising via Vieta yields b²c² − 4c³ − 4b³d + 18bcd − 27d² for x³+bx²+cx+d, and collapses to the textbook Δ = −4p³ − 27q² for the depressed cubic x³+px+q. Over an integral domain Δ = 0 exactly when two roots coincide — the cubic repeated-root criterion.",
+  "meta": {
+    "author": "Francois Viete (1615); formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Discriminant",
+    "date": "1615",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VietasFormulasOQ04OQ01.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "vietas-formulas",
+      "discriminant",
+      "cubic",
+      "symmetric-functions",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "defCount": 0,
+    "lineCount": 140,
+    "mathlibDependencies": [
+      {
+        "theorem": "pow_eq_zero_iff",
+        "description": "xⁿ = 0 ↔ x = 0 (n ≠ 0) over a monoid with no zero divisors — reduces the squared discriminant to the product of root-gaps",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "mul_eq_zero",
+        "description": "In a domain, a product is zero iff a factor is zero — reads off which pair of roots coincides",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      },
+      {
+        "theorem": "sub_eq_zero",
+        "description": "a − b = 0 ↔ a = b — translates a vanishing root-gap into a coincidence of roots",
+        "module": "Mathlib.Algebra.Group.Basic"
+      }
+    ],
+    "originalContributions": [
+      "discriminant_eq_esymm: the master identity Δ = e₁²e₂² − 4e₂³ − 4e₁³e₃ + 18e₁e₂e₃ − 27e₃² as a pure `ring` identity over any commutative ring, with no hypotheses",
+      "discriminant_eq_coeffs: the classical coefficient discriminant b²c² − 4c³ − 4b³d + 18bcd − 27d² of a monic cubic x³+bx²+cx+d, obtained by Vieta substitution e₁=−b, e₂=c, e₃=−d",
+      "discriminant_depressed: Δ = −4p³ − 27q² for the depressed cubic, proved by eliminating r₃ = −(r₁+r₂) and a single ring computation",
+      "discriminant_of_sum_zero: the depressed identity in pure root form (−4e₂³ − 27e₃² when e₁ = 0)",
+      "discriminant_eq_zero_iff: over an integral domain Δ = 0 ⇔ r₁=r₂ ∨ r₁=r₃ ∨ r₂=r₃, the cubic repeated-root criterion",
+      "depressed_discriminant_zero_iff: the repeated-root criterion in p,q form — −4p³ − 27q² = 0 ⇔ two roots coincide"
+    ],
+    "dateAdded": "2026-07-02",
+    "prerequisites": [
+      "Vieta's formulas for the cubic (elementary symmetric functions of the roots)",
+      "Commutative ring axioms and the `ring` tactic",
+      "No-zero-divisor cancellation over an integral domain"
+    ],
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The discriminant of a polynomial is the classical quantity that detects repeated roots. For the cubic it dates to the Renaissance algebraists (Cardano, Viete) and governs the casus irreducibilis: over the reals a depressed cubic x³+px+q has three distinct real roots exactly when −4p³−27q² > 0. Vieta's formulas (Francois Viete, 1615) relate coefficients to symmetric functions of the roots. This entry is the cubic sequel to the quadratic discriminant entry, connecting the root-gap definition Δ = ∏_{i<j}(rᵢ−rⱼ)² to the familiar coefficient formulas.",
+    "problemStatement": "Express the cubic discriminant as the product of squared root-gaps (r₁−r₂)²(r₁−r₃)²(r₂−r₃)² and verify that it equals the classical −4p³−27q² for the depressed cubic x³+px+q, together with the general monic-coefficient form and the repeated-root criterion.",
+    "text": "Proves the master symmetric-function identity for the cubic discriminant, specialises it to the coefficient discriminant of a monic cubic and to the depressed-cubic form −4p³−27q², and derives the repeated-root criterion Δ=0 ⇔ two roots coincide over an integral domain.",
+    "proofStrategy": "The engine is one universal polynomial identity: expanding ((r₁−r₂)(r₁−r₃)(r₂−r₃))² and rewriting in the elementary symmetric functions e₁,e₂,e₃ gives Δ = e₁²e₂² − 4e₂³ − 4e₁³e₃ + 18e₁e₂e₃ − 27e₃², a single `ring` call with no hypotheses (discriminant_eq_esymm).\n\nEverything else is substitution. Vieta's formulas for x³+bx²+cx+d read e₁=−b, e₂=c, e₃=−d; substituting and expanding gives the classical b²c²−4c³−4b³d+18bcd−27d² (discriminant_eq_coeffs). For the depressed cubic the quadratic coefficient vanishes, i.e. r₁+r₂+r₃=0; eliminating r₃=−(r₁+r₂) reduces the identity to a two-variable ring computation yielding −4p³−27q² with p=e₂, q=−e₃ (discriminant_depressed, and its symbol-free cousin discriminant_of_sum_zero).\n\nThe structural corollaries come from the product form. Over an integral domain a squared product vanishes iff a factor does, so pow_eq_zero_iff, mul_eq_zero, and sub_eq_zero give Δ=0 ⇔ some pair of roots coincides (discriminant_eq_zero_iff), whence distinct roots force Δ≠0 (discriminant_ne_zero_of_distinct) and the p,q form of the criterion (depressed_discriminant_zero_iff).",
+    "keyInsights": [
+      "**One symmetric identity, every corollary**: The coefficient discriminant, the depressed −4p³−27q², and the repeated-root test are all readings of a single ring identity Δ = e₁²e₂² − 4e₂³ − 4e₁³e₃ + 18e₁e₂e₃ − 27e₃². Proving it once makes the rest pure substitution.",
+      "**Maximal generality for free**: The master identity needs only a commutative ring, so it holds over ℤ, finite fields, and matrix entries — not just ℝ or ℂ. The integral-domain hypothesis is invoked only for the repeated-root iff, where cancellation is genuinely required.",
+      "**Depression is just e₁ = 0**: The textbook collapse to −4p³−27q² is not a separate theorem but the e₁=0 slice of the master identity; the four e₁-bearing terms simply drop out, and eliminating r₃=−(r₁+r₂) makes this mechanical.",
+      "**The root-gap product is the source of the criterion**: Because Δ is literally the square of the Vandermonde-style product (r₁−r₂)(r₁−r₃)(r₂−r₃), the repeated-root criterion is not an estimate but an equivalence over any domain — the same structural reason the quadratic Δ=a²(r−s)² detects equal roots."
+    ],
+    "prerequisites": [
+      "Vieta's formulas for the cubic",
+      "Commutative ring axioms and the `ring` tactic",
+      "No-zero-divisor cancellation over an integral domain"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "The Open Question and the Master Identity",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "States the follow-up to the quadratic discriminant entry: express the cubic discriminant as ∏_{i<j}(rᵢ−rⱼ)² and verify it equals −4p³−27q² for the depressed cubic. Announces the master symmetric-function identity Δ = e₁²e₂² − 4e₂³ − 4e₁³e₃ + 18e₁e₂e₃ − 27e₃², records the Vieta specialisations, and declares 0 axioms.",
+      "mathContext": "$\\Delta = e_1^2 e_2^2 - 4e_2^3 - 4e_1^3 e_3 + 18 e_1 e_2 e_3 - 27 e_3^2$."
+    },
+    {
+      "id": "master-identity",
+      "title": "discriminant_eq_esymm: the identity in symmetric functions",
+      "startLine": 55,
+      "endLine": 66,
+      "summary": "discriminant_eq_esymm expands ((r₁−r₂)(r₁−r₃)(r₂−r₃))² and rewrites it in the elementary symmetric functions e₁,e₂,e₃ by a single `ring` call. Stated over an arbitrary CommRing with no hypotheses, so it holds over ℤ, finite fields, and matrix rings.",
+      "mathContext": "$((r_1-r_2)(r_1-r_3)(r_2-r_3))^2 = e_1^2 e_2^2 - 4e_2^3 - 4e_1^3 e_3 + 18 e_1 e_2 e_3 - 27 e_3^2.$"
+    },
+    {
+      "id": "coefficient-form",
+      "title": "discriminant_eq_coeffs: the classical coefficient discriminant",
+      "startLine": 68,
+      "endLine": 79,
+      "summary": "discriminant_eq_coeffs substitutes the Vieta relations b=−(r₁+r₂+r₃), c=r₁r₂+r₁r₃+r₂r₃, d=−(r₁r₂r₃) into the master identity and expands to the classical b²c²−4c³−4b³d+18bcd−27d² for a monic cubic x³+bx²+cx+d, by `subst` + `ring`.",
+      "mathContext": "$\\Delta = b^2 c^2 - 4c^3 - 4b^3 d + 18 b c d - 27 d^2.$"
+    },
+    {
+      "id": "depressed",
+      "title": "discriminant_depressed and discriminant_of_sum_zero: Δ = −4p³ − 27q²",
+      "startLine": 81,
+      "endLine": 109,
+      "summary": "discriminant_depressed handles the depressed cubic x³+px+q: the vanishing quadratic coefficient means r₁+r₂+r₃=0, so eliminating r₃=−(r₁+r₂) reduces the master identity to −4p³−27q² (with p=e₂, q=−e₃) via `linear_combination` + `ring`. discriminant_of_sum_zero states the same collapse purely in the roots as −4e₂³−27e₃², and a numerical `decide` example checks the roots −1,0,1 of x³−x give Δ=4.",
+      "mathContext": "$r_1+r_2+r_3=0 \\Rightarrow \\Delta = -4p^3 - 27q^2 = -4e_2^3 - 27 e_3^2.$"
+    },
+    {
+      "id": "repeated-root",
+      "title": "The repeated-root criterion over an integral domain",
+      "startLine": 111,
+      "endLine": 140,
+      "summary": "discriminant_eq_zero_iff shows Δ=0 ⇔ r₁=r₂ ∨ r₁=r₃ ∨ r₂=r₃ over an integral domain: a squared product vanishes iff a factor does (pow_eq_zero_iff, mul_eq_zero, sub_eq_zero). discriminant_ne_zero_of_distinct deduces that pairwise-distinct roots force Δ≠0, and depressed_discriminant_zero_iff rephrases the criterion in p,q form: −4p³−27q²=0 ⇔ two roots coincide.",
+      "mathContext": "$\\Delta = 0 \\iff r_1=r_2 \\lor r_1=r_3 \\lor r_2=r_3$ over an integral domain."
+    }
+  ],
+  "conclusion": {
+    "summary": "The cubic discriminant (r₁−r₂)²(r₁−r₃)²(r₂−r₃)² equals the universal symmetric-function polynomial e₁²e₂²−4e₂³−4e₁³e₃+18e₁e₂e₃−27e₃², which specialises to the coefficient discriminant b²c²−4c³−4b³d+18bcd−27d² and, for the depressed cubic, to the classical −4p³−27q². Over an integral domain the discriminant vanishes exactly when two roots coincide. 7 theorems, 0 sorries, 0 axioms.",
+    "implications": "Reducing every form of the cubic discriminant to one ring identity makes the casus irreducibilis and the repeated-root test characteristic-independent and transparent. The root-gap-squared pattern (r₁−r₂)²(r₁−r₃)²(r₂−r₃)² is the degree-3 instance of the squared Vandermonde, the bridge to the general degree-n discriminant.",
+    "openQuestions": [
+      "Connect this concrete cubic discriminant to Mathlib's general Polynomial.discriminant and the squared Vandermonde determinant of the roots for arbitrary degree.",
+      "Prove the casus irreducibilis over ℝ: a depressed cubic has three distinct real roots iff −4p³−27q² > 0, one real and two complex-conjugate roots iff < 0."
+    ]
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Viete, Francois",
+      "title": "De aequationum recognitione et emendatione",
+      "year": "1615",
+      "venue": "",
+      "note": "Origin of the coefficient-root relations now called Vieta's formulas"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "vietas-formulas-oq-04",
+      "relationship": "extends",
+      "description": "The cubic sequel to the quadratic discriminant entry: the same root-gap-squared pattern one degree higher, answering that entry's first open question."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "CubicDiscriminant",
+    "lineCount": 140,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/VietasFormulasOQ04OQ01.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Answers the first open question of the verified parent `vietas-formulas-oq-04` (quadratic discriminant): **express the cubic discriminant as the product of squared root-gaps `∏_{i<j}(rᵢ−rⱼ)²` and verify it equals the classical `−4p³−27q²` for the depressed cubic** `x³+px+q`.

## Results (7 theorems, 0 sorries, 0 axioms)

- `discriminant_eq_esymm` — the master identity `Δ = e₁²e₂² − 4e₂³ − 4e₁³e₃ + 18e₁e₂e₃ − 27e₃²` as a pure `ring` identity over any `CommRing` (no hypotheses).
- `discriminant_eq_coeffs` — the classical coefficient discriminant `b²c² − 4c³ − 4b³d + 18bcd − 27d²` for a monic cubic `x³+bx²+cx+d`, via Vieta substitution.
- `discriminant_depressed` — the headline `Δ = −4p³ − 27q²` for the depressed cubic (eliminate `r₃ = −(r₁+r₂)`, then `ring`).
- `discriminant_of_sum_zero` — the depressed identity in pure root form `−4e₂³ − 27e₃²`.
- `discriminant_eq_zero_iff` — repeated-root criterion over an integral domain: `Δ = 0 ↔` two roots coincide.
- `discriminant_ne_zero_of_distinct`, `depressed_discriminant_zero_iff` — corollaries.

## Verification

Verified with `lake env lean` against Mathlib v4.26.0 (clean elaboration; process segfaults only on `import Mathlib` teardown, a known harness quirk). `#print axioms` reports only `propext`, `Quot.sound`, `Classical.choice` — genuine 0-axiom. All ring identities independently cross-checked with sympy.

## Relation to existing gallery

Distinct from the `solution-of-cubic` discriminant entries (resultant / Tschirnhaus-invariance framing): this is the **Vieta / root-gap-squared → elementary-symmetric-functions** framing, the direct child of `vietas-formulas-oq-04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)