### PR TITLE
Enrich Algebraic Numbers Form a Perfect Field (algebraic-numbers-countable-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01-oq-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "algnum-perfect-ann-header",
+    "proofId": "algebraic-numbers-countable-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 48
+    },
+    "type": "context",
+    "title": "Roadmap: the separability half of ℚ̄",
+    "content": "The module docstring sets this file against its parent (AlgebraicNumbersCountableOQ01OQ01), which realized the algebraic numbers as algebraicNumbersField : IntermediateField ℚ ℂ and proved it algebraically closed. This file supplies the complementary separability picture and answers the parent's open question, in four steps: (1) ℚ is perfect, so its algebraic extensions are separable and minimal polynomials are squarefree; (2) ℚ̄ is perfect for two independent reasons (algebraic closedness, and being algebraic over the perfect field ℚ); (3) consequently ℚ̄ has no inseparable algebraic extension; (4) as an arithmetic payoff, a degree-n number field has exactly n embeddings. The imports pull in FieldTheory.Perfect and FieldTheory.SeparableDegree; everything is developed in the namespace AlgebraicNumbersCountableOQ01OQ01OQ01, reusing the parent's instances through open AlgebraicNumbersCountableOQ01OQ01.",
+    "mathContext": "Parent: $\\overline{\\mathbb{Q}}$ is algebraically closed. This file: $\\overline{\\mathbb{Q}}$ is perfect $\\Rightarrow$ every algebraic extension of $\\mathbb{Q}$ (and of $\\overline{\\mathbb{Q}}$) is separable.",
+    "significance": "context",
+    "relatedConcepts": [
+      "perfect field",
+      "separability",
+      "algebraic closure",
+      "number field embeddings"
+    ],
+    "prerequisites": [
+      "field extensions",
+      "algebraic closure of ℚ"
+    ]
+  },
+  {
     "id": "algnum-perfect-ann-rat",
     "proofId": "algebraic-numbers-countable-oq-01-oq-01-oq-01",
     "range": {
@@ -95,6 +118,29 @@
       "finite field extensions",
       "separable degree",
       "algebraic closure"
+    ]
+  },
+  {
+    "id": "algnum-perfect-ann-examples",
+    "proofId": "algebraic-numbers-countable-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 135,
+      "endLine": 144
+    },
+    "type": "context",
+    "title": "Worked examples: squarefree minimal polynomials and a separable extension",
+    "content": "The Examples section instantiates the abstract results on the concrete objects of interest. The first example takes any complex z algebraic over ℚ and, via minpoly_squarefree_rat applied to hz.isIntegral, concludes Squarefree (minpoly ℚ z) — every algebraic number's minimal polynomial has distinct roots. The second records Algebra.IsSeparable ℚ algebraicNumbersField by reusing isSeparable_rat_algebraicNumbers, confirming ℚ̄/ℚ is a separable (indeed perfect) extension. Both are one-liners that discharge directly from the named theorems, serving as executable sanity checks that the general statements specialise as intended.",
+    "mathContext": "For $z$ algebraic over $\\mathbb{Q}$: $\\operatorname{minpoly}_{\\mathbb{Q}}(z)$ is squarefree; and $\\overline{\\mathbb{Q}}/\\mathbb{Q}$ is separable.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "squarefree polynomial",
+      "minimal polynomial",
+      "separable extension",
+      "worked example"
+    ],
+    "prerequisites": [
+      "IsAlgebraic implies IsIntegral over a field",
+      "specialising a theorem"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-01-oq-01-oq-01`.

## Gap addressed
The entry already had a rich `meta.json` (20 KB, quality 91) and 4 substantive theorem-level annotations, but coverage spanned only lines **50–133** of the 146-line Lean file. The module header/roadmap and the `Examples` section were uncovered.

## Changes
Added **2 coverage annotations** to `annotations.json` (now 6 total, spanning the full file):
- **Roadmap (lines 1–48)**: the 4-step separability program — ℚ perfect ⇒ separable extensions; ℚ̄ perfect two ways; no inseparable extensions of ℚ̄; degree-n number field has n embeddings.
- **Examples (lines 135–144)**: the two worked examples (squarefree minimal polynomials; ℚ̄/ℚ separable).

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. No `meta.json` changes — coverage-only, well under all size caps.

Verified with `pnpm build`.