### PR TITLE
Fix: realign 22 stale meta.lineCount fields

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json
@@ -32,7 +32,7 @@
     "dateAdded": "2026-06-15",
     "axiomCount": 0,
     "assumptions": "No axioms or sorries. Fully machine-verified under Lean v4.26.0 / Mathlib for any commutative ring R, any index type ι, any Finset s, and every k ≥ 1. The core recurrence is obtained by transporting Mathlib's universal identity MvPolynomial.mul_esymm_eq_sum along the algebra map aeval — the combinatorial content lives in Mathlib; this entry contributes the concrete Finset/CommRing statement plus the bridge lemmas (psum_bridge, esymm_bridge, reindex_filter).",
-    "lineCount": 127,
+    "lineCount": 129,
     "theoremCount": 4,
     "definitionCount": 2,
     "originalContributions": [

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 385,
+    "lineCount": 387,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "historicalContext": "The formula |Gal(minpoly(cos(π/n))/ℚ)| = φ(2n)/2 connects classical angle trisection impossibility to cyclotomic field theory. Individual cases n=5 (|Gal|=2), n=7 (|Gal|=3), n=9 (|Gal|=3) were proved in earlier gallery entries. This file provides the general proof using IsCyclotomicExtension, answering the open question from AngleTrisectionCos20GalOQ01OQ02.",

--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -74,7 +74,7 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 112,
+    "lineCount": 114,
     "theoremCount": 3,
     "definitionCount": 0,
     "badge": "mathlib",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -54,7 +54,7 @@
     "dateAdded": "2026-06-27",
     "axiomCount": 0,
     "assumptions": "None. Axiom-free and sorry-free (depends only on propext, Classical.choice, Quot.sound). No native_decide.",
-    "lineCount": 224,
+    "lineCount": 222,
     "theoremCount": 6,
     "definitionCount": 1,
     "originalContributions": [

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
@@ -48,7 +48,7 @@
       "Ascending factorial",
       "Simplicial numbers"
     ],
-    "lineCount": 158,
+    "lineCount": 156,
     "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,

--- a/src/data/proofs/automorphic-number-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 249,
+    "lineCount": 251,
     "theoremCount": 14,
     "definitionCount": 1,
     "assumptions": "None. 0 axioms, 0 sorries, no native_decide. Results depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (Classical.choice / Quot.sound enter via Nat.card and the noncomputable equivalences built from Equiv.subtypeEquivRight / subtypePiEquivPi). Builds on the verified parent entries AutomorphicNumberOQ01 and AutomorphicNumberOQ01OQ01, reusing the latter's idempotent_count.",

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/meta.json
@@ -12,7 +12,7 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
-    "lineCount": 292,
+    "lineCount": 294,
     "theoremCount": 11,
     "definitionCount": 2,
     "difficulty": "advanced",

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
@@ -31,7 +31,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 310,
+    "lineCount": 312,
     "theoremCount": 8,
     "definitionCount": 2,
     "assumptions": "No axioms or sorries. Uses Mathlib's LinearMap.toMatrix / toMatrixAlgEquiv, minpoly.algEquiv_eq, Matrix charpoly API, FiniteDimensional bases, and (for the Section V span bridge) basisOfLinearIndependentOfCardEqFinrank, Fintype.linearIndependent_iff, and the Polynomial natDegree API. The span bridge also imports the registered module-theoretic file CayleyHamiltonMinpolyOQ05OQ01OQ03 (NonderogatoryModule.cyclicSubspace / finiteSpan_le_cyclicSubspace). Registered in Proofs.lean and verified by the aggregate fleet build; all Mathlib bearers checked against the pinned rev (v4.26.0), and the Section V Krylov-independence argument mirrors the compiled matrix proof CyclicCommutant.krylov_linearIndependent. The PID-module half of OQ-03 is now formalized in the registered companion CayleyHamiltonCyclicVectorAllFieldsOQ03PID.lean (0 sorry / 0 axiom; PRs #25497, #25552), listed in additionalFiles.",

--- a/src/data/proofs/derangements-convergence-oq-03-oq-03/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "No assumptions. Fully machine-checked with only Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). The error identity |D(n) - n!·e⁻¹| = n!·A(n+1) is derived from the parent file's exact tail decomposition; the two-sided bounds on the alternating tail A(m) follow from the parent's alt_partial_sum_nonneg / alt_partial_sum_le_first together with the newly proved alt_partial_sum_ge_first_sub_second.",
     "dateAdded": "2026-06-24",
-    "lineCount": 177,
+    "lineCount": 175,
     "theoremCount": 7,
     "definitionCount": 0,
     "originalContributions": [

--- a/src/data/proofs/erdos-1000-oq-03-oq-02/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-02/meta.json
@@ -123,7 +123,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 246,
+    "lineCount": 248,
     "theoremCount": 10,
     "definitionCount": 1,
     "assumptions": ""

--- a/src/data/proofs/erdos-1012-oq-02/meta.json
+++ b/src/data/proofs/erdos-1012-oq-02/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
     "assumptions": "2 axioms: bondy_vertex_pancyclic (Bondy 1971: n≥3, dense Hamiltonian graph → every vertex is on cycles of all lengths 3..n, unless bipartite), woodall_vertex_pancyclic (Woodall extension: dense graphs are vertex-pancyclic from 3 to n-k).",
-    "lineCount": 389,
+    "lineCount": 391,
     "theoremCount": 12,
     "definitionCount": 8,
     "originalContributions": [

--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -57,7 +57,7 @@
       "uniform_implies_spanning: ε-uniform ⟹ spanning"
     ],
     "axiomCount": 3,
-    "lineCount": 316,
+    "lineCount": 318,
     "assumptions": "3 axioms: gEps, basic_lower_bound, erdos_hall_upper. 0 sorries.",
     "theoremCount": 10,
     "definitionCount": 3

--- a/src/data/proofs/erdos-307-oq-02/meta.json
+++ b/src/data/proofs/erdos-307-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 298,
+    "lineCount": 296,
     "assumptions": "0 sorries, 0 axioms. Fully verified.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/euler-identity-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-02-oq-01/meta.json
@@ -53,7 +53,7 @@
       "euler_identity: e^{iπ} = −1, recovered within the series framework"
     ],
     "axiomCount": 0,
-    "lineCount": 128,
+    "lineCount": 130,
     "assumptions": "None. All theorems fully proved with 0 axioms and 0 sorries (no native_decide). #print axioms on euler_formula, hasSum_euler, and euler_identity reports only [propext, Classical.choice, Quot.sound]. The core derivation (hasSum_euler, euler_formula) uses only the exponential series and even/odd resummation; Complex.cos/sin are invoked solely in the closing identification lemmas, Pythagoras, and Euler's identity.",
     "theoremCount": 7,
     "definitionCount": 2,

--- a/src/data/proofs/euler-identity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-02/meta.json
@@ -51,7 +51,7 @@
       "euler_identity: e^{iπ} = −1"
     ],
     "axiomCount": 0,
-    "lineCount": 77,
+    "lineCount": 75,
     "assumptions": "None. All theorems fully proved with 0 axioms and 0 sorries (no native_decide). #print axioms reports only [propext, Classical.choice, Quot.sound]. The power series and Euler's formula/identity are invoked from Mathlib; the exponential-form lemmas are short derivations.",
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -42,7 +42,7 @@
     "dateAdded": "2025-12-28",
     "wiedijkNumber": 46,
     "axiomCount": 0,
-    "lineCount": 814,
+    "lineCount": 816,
     "prerequisites": [
       "Complex numbers and polynomial evaluation",
       "Cubic equation solution (Cardano's formula)",

--- a/src/data/proofs/intermediate-value-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-01-oq-01/meta.json
@@ -74,7 +74,7 @@
     ],
     "dateAdded": "2026-06-22",
     "axiomCount": 0,
-    "lineCount": 153,
+    "lineCount": 155,
     "mathlib_version": "4.26.0",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound).",
     "theoremCount": 8,

--- a/src/data/proofs/isoperimetric-theorem-oq-02/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-02/meta.json
@@ -45,7 +45,7 @@
       "discrete_isoperimetric_1d: combined statement of bound and equality case"
     ],
     "axiomCount": 0,
-    "lineCount": 136,
+    "lineCount": 138,
     "assumptions": "0 axioms, 0 sorries — fully verified.",
     "theoremCount": 5,
     "definitionCount": 1

--- a/src/data/proofs/isoperimetric-theorem-oq-03/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-03/meta.json
@@ -58,7 +58,7 @@
       "cycle_isoperimetric: packaged statement combining the sharp bound and its achievability, identifying 2 as the best isoperimetric constant on the discrete circle."
     ],
     "axiomCount": 0,
-    "lineCount": 210,
+    "lineCount": 212,
     "assumptions": "0 axioms, 0 sorries — fully verified (depends only on propext, Classical.choice, Quot.sound).",
     "theoremCount": 9,
     "definitionCount": 3

--- a/src/data/proofs/quadratic-gauss-sum-square/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square/meta.json
@@ -19,7 +19,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 75,
+    "lineCount": 77,
     "theoremCount": 4,
     "definitionCount": 1,
     "assumptions": ""

--- a/src/data/proofs/randomized-maxcut/meta.json
+++ b/src/data/proofs/randomized-maxcut/meta.json
@@ -61,7 +61,7 @@
     ],
     "dateAdded": "2025-12-24",
     "axiomCount": 0,
-    "lineCount": 324,
+    "lineCount": 326,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "theoremCount": 6,
     "definitionCount": 7

--- a/src/data/proofs/thue-morse-oq-01/meta.json
+++ b/src/data/proofs/thue-morse-oq-01/meta.json
@@ -95,7 +95,7 @@
     ],
     "dateAdded": "2026-06-16",
     "axiomCount": 0,
-    "lineCount": 144,
+    "lineCount": 146,
     "assumptions": "None. Fully machine-checked with no axioms and no sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 14,


### PR DESCRIPTION
## Fix

22 gallery entries had a stale `meta.lineCount` that no longer matched their Lean source file's actual line count (all off by a small amount from routine edits). Each `meta.lineCount` is realigned to the main-file line count — which already agrees with the entry's correct `leanFile.lineCount`.

## Evidence

Scan resolved each entry's main Lean file (`leanFile.path`), counted newlines, and compared against `meta.lineCount`. For every entry fixed, `leanFile.lineCount` already equalled the true count while `meta.lineCount` had drifted (e.g. `thue-morse-oq-01`: 144 → 146; `general-quartic`: 814 → 816).

The 5 multi-file erdős entries whose `meta.lineCount` is a **correct aggregate** of main + `additionalFiles` (erdos-10-oq-02, erdos-1047, erdos-12, erdos-26, erdos-741) were verified as sum-of-all-files and deliberately left untouched.

Edits target only the field inside the `"meta": {` object; `leanFile.lineCount` and any top-level `lineCount` are untouched. All 22 files re-validated as parseable JSON after the change.

Disjoint from open PR #32886 (leanFile.lineCount) — this touches the separate `meta.lineCount` field.

---
Automated fix by lean-mechanic agent.