### PR TITLE
Enrich n·log n Lower Bound on the n-th Prime (chebyshev-pnt-bridge-oq-06-oq-02)

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/annotations.json
@@ -93,5 +93,27 @@
       "the bridge identity π(nth Prime n) = n + 1",
       "the Nat.sqrt logarithm bracket"
     ]
+  },
+  {
+    "id": "ann-checks",
+    "proofId": "chebyshev-pnt-bridge-oq-06-oq-02",
+    "range": {
+      "startLine": 155,
+      "endLine": 157
+    },
+    "type": "context",
+    "title": "Verification: type-signature sanity checks",
+    "content": "Two #check commands record the two exported results at the type level, serving as a compile-time contract for readers: primeCounting_nth_prime has type π(nth Prime n) = n + 1 (the bridge identity of Part I), and nth_prime_lower_bound states (n+1)·(½·log(n+2) − log 2) ≤ 2·log 4·pₙ (the n·log n lower bound of Part II). Because #check elaborates the statements without proving anything new, the fact that the file compiles confirms both theorems have exactly the claimed signatures — a lightweight guard against silent statement drift, and a quick index of the file's two deliverables.",
+    "mathContext": "$\\pi(p_n) = n+1$ and $(n+1)\\left(\\tfrac12\\log(n+2) - \\log 2\\right) \\le 2\\log 4 \\cdot p_n$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "type-level verification",
+      "#check command",
+      "statement drift",
+      "prime counting"
+    ],
+    "prerequisites": [
+      "reading Lean type signatures"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `chebyshev-pnt-bridge-oq-06-oq-02`.

## Gap addressed
The entry is already high quality (14 KB `meta.json`, quality 91, 4 substantive annotations covering lines 1–153). The only uncovered content was the tail `#check` verification block.

## Changes
Added **1 annotation** (now 5 total) for the `#check` lines (155–157): documents the two type-level sanity checks — `primeCounting_nth_prime : π(nth Prime n) = n + 1` and `nth_prime_lower_bound` — as a compile-time contract / index of the file's two deliverables. Carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

No `meta.json` changes — it already meets all quality targets. Coverage-only, well under size caps.

Verified with `pnpm build`.