### PR TITLE
research(factor-remainder-theorem-oq-05-oq-02): existence of the Lagrange interpolating polynomial [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FactorRemainderTheoremOQ05OQ02.lean
+++ b/proofs/Proofs/FactorRemainderTheoremOQ05OQ02.lean
@@ -1,0 +1,159 @@
+import Mathlib
+
+/-
+# Factor/Remainder Theorem OQ-05-OQ-02: Existence of the Lagrange Interpolating Polynomial
+
+## Research Problem: factor-remainder-theorem-oq-05-oq-02
+
+The parent problem `factor-remainder-theorem-oq-05` proves the **uniqueness** half of
+polynomial interpolation over an integral domain: via the root-count bound
+`Polynomial.card_roots'`, a polynomial of degree `< n` that vanishes at `n` distinct points
+must be the zero polynomial, hence two such polynomials agreeing on `n` points are equal.
+
+This file supplies the complementary **existence** half over a *field*: for any finite set
+of `n` distinct nodes and any prescribed values, there *exists* a polynomial of degree `< n`
+taking those values. Combined with uniqueness this gives the classical
+
+  **Lagrange interpolation theorem**: through `n` distinct points there is one and only one
+  polynomial of degree `< n` with the prescribed values.
+
+## Mathematical Content
+
+The explicit witness is Lagrange's formula
+
+  L(x) = ∑_{i} r_i · ℓ_i(x),   ℓ_i(x) = ∏_{j ≠ i} (x − v_j)/(v_i − v_j),
+
+packaged in Mathlib as the linear map `Lagrange.interpolate s v`. Its two defining
+properties are that it reproduces the data at the nodes
+(`Lagrange.eval_interpolate_at_node`) and that its degree is `< #s`
+(`Lagrange.degree_interpolate_lt`). Feeding these into `ExistsUnique` yields the headline
+`∃!` statement.
+
+We give the result in two forms — an abstract indexed form (`v : ι → F` injective on a
+finset `s`) and the concrete classical form over a finite set of field points
+(`ι = F`, `v = id`) — then record two structural consequences:
+
+* **Superposition**: interpolation is `F`-linear in the prescribed values, because
+  `Lagrange.interpolate s v` is literally a `LinearMap` (`interpolate_add`, `interpolate_smul`).
+* **Evaluation is a linear isomorphism** `degreeLT F #s ≃ₗ[F] (s → F)`
+  (`Lagrange.funEquivDegreeLT`): evaluation at `n` distinct nodes is a bijection between
+  degree-`< n` polynomials and value tuples. This is the coordinate-free form of the
+  invertibility of the Vandermonde matrix, and is exactly the existence-and-uniqueness
+  statement upgraded to an `F`-linear equivalence.
+
+The field hypothesis is essential for *existence*: the denominators `v_i − v_j` in the
+Lagrange basis must be invertible. (Uniqueness, by contrast, only needs an integral domain,
+which is what the parent uses.)
+
+## References
+- Lagrange (1795): interpolation formula.
+- Mathlib: `Lagrange.interpolate`, `Lagrange.eval_interpolate_at_node`,
+  `Lagrange.degree_interpolate_lt`, `Lagrange.eq_interpolate_iff`,
+  `Lagrange.funEquivDegreeLT`.
+-/
+
+open Polynomial
+
+namespace FactorRemainderTheoremOQ05OQ02
+
+open scoped Finset
+
+variable {F : Type*} [Field F] {ι : Type*} [DecidableEq ι] {s : Finset ι} {v : ι → F}
+
+/-! ## Part I: Existence over a field (abstract indexed form)
+
+Given distinct nodes `v i` (`i ∈ s`) and any target values `r`, the Lagrange polynomial is a
+concrete witness of degree `< #s` taking the prescribed values. -/
+
+/-- **Existence of an interpolating polynomial.** Over a field, for any injective node map
+and any prescribed values there is a polynomial of degree `< #s` matching the data at every
+node. The witness is Lagrange's `interpolate`. -/
+theorem exists_interpolating (hvs : Set.InjOn v s) (r : ι → F) :
+    ∃ p : F[X], p.degree < s.card ∧ ∀ i ∈ s, p.eval (v i) = r i :=
+  ⟨Lagrange.interpolate s v r, Lagrange.degree_interpolate_lt r hvs,
+    fun _ hi => Lagrange.eval_interpolate_at_node r hvs hi⟩
+
+/-- The Lagrange polynomial has degree strictly below the number of interpolation nodes. -/
+theorem interpolate_degree_lt (hvs : Set.InjOn v s) (r : ι → F) :
+    (Lagrange.interpolate s v r).degree < s.card :=
+  Lagrange.degree_interpolate_lt r hvs
+
+/-- The Lagrange polynomial reproduces the data at each node. -/
+theorem interpolate_eval_node (hvs : Set.InjOn v s) (r : ι → F) {i : ι} (hi : i ∈ s) :
+    (Lagrange.interpolate s v r).eval (v i) = r i :=
+  Lagrange.eval_interpolate_at_node r hvs hi
+
+/-! ## Part II: Existence AND uniqueness — the Lagrange interpolation theorem -/
+
+omit [DecidableEq ι] in
+/-- **Uniqueness of the interpolant** (the parent's half, restated over a field). Two
+polynomials of degree `< #s` that agree at all `#s` distinct nodes are equal. Only an
+integral-domain structure is needed here — exactly the setting of the parent problem. -/
+theorem interpolate_unique (hvs : Set.InjOn v s) {p q : F[X]}
+    (hp : p.degree < s.card) (hq : q.degree < s.card)
+    (h : ∀ i ∈ s, p.eval (v i) = q.eval (v i)) : p = q :=
+  Polynomial.eq_of_degrees_lt_of_eval_index_eq s hvs hp hq h
+
+/-- **Lagrange interpolation theorem (existence + uniqueness).** Over a field, given `#s`
+distinct nodes and any target values, there is a *unique* polynomial of degree `< #s`
+realizing those values. -/
+theorem existsUnique_interpolating (hvs : Set.InjOn v s) (r : ι → F) :
+    ∃! p : F[X], p.degree < s.card ∧ ∀ i ∈ s, p.eval (v i) = r i := by
+  refine ⟨Lagrange.interpolate s v r,
+    ⟨Lagrange.degree_interpolate_lt r hvs,
+      fun _ hi => Lagrange.eval_interpolate_at_node r hvs hi⟩, ?_⟩
+  intro q hq
+  exact (Lagrange.eq_interpolate_iff r hvs).mp ⟨hq.1, hq.2⟩
+
+/-! ## Part III: The concrete classical statement over field points
+
+Specializing to `ι = F` and `v = id` recovers the textbook formulation: distinct
+`x`-coordinates drawn from a finset `S ⊆ F`, arbitrary `y`-values. -/
+
+/-- **Classical Lagrange interpolation.** For a finite set `S` of distinct points of a field
+`F` and any value function `y`, there is a unique polynomial of degree `< #S` passing through
+`(x, y x)` for every `x ∈ S`. -/
+theorem existsUnique_interpolating_points [DecidableEq F] (S : Finset F) (y : F → F) :
+    ∃! p : F[X], p.degree < S.card ∧ ∀ x ∈ S, p.eval x = y x := by
+  have hvs : Set.InjOn (id : F → F) (S : Set F) := Set.injOn_id _
+  simpa using existsUnique_interpolating (s := S) (v := id) hvs y
+
+/-- Existence form of the classical statement: a polynomial of degree `< #S` through any
+`#S` distinct field points with arbitrary prescribed values. -/
+theorem exists_interpolating_points [DecidableEq F] (S : Finset F) (y : F → F) :
+    ∃ p : F[X], p.degree < S.card ∧ ∀ x ∈ S, p.eval x = y x := by
+  have hvs : Set.InjOn (id : F → F) (S : Set F) := Set.injOn_id _
+  simpa using exists_interpolating (s := S) (v := id) hvs y
+
+/-- Uniqueness form of the classical statement (bridges to the parent's root-count proof):
+two polynomials of degree `< #S` agreeing on `#S` distinct field points coincide. -/
+theorem eq_of_degree_lt_of_eval_eq_points {S : Finset F} {p q : F[X]}
+    (hp : p.degree < S.card) (hq : q.degree < S.card)
+    (h : ∀ x ∈ S, p.eval x = q.eval x) : p = q :=
+  Polynomial.eq_of_degrees_lt_of_eval_finset_eq S hp hq h
+
+/-! ## Part IV: Structural consequences -/
+
+/-- **Superposition principle.** Interpolation is additive in the prescribed values: the
+interpolant of a sum of data is the sum of the interpolants. This is immediate because
+`Lagrange.interpolate s v` is an `F`-linear map. -/
+theorem interpolate_add (r r' : ι → F) :
+    Lagrange.interpolate s v (r + r') =
+      Lagrange.interpolate s v r + Lagrange.interpolate s v r' :=
+  map_add _ r r'
+
+/-- Interpolation commutes with scaling of the data. -/
+theorem interpolate_smul (c : F) (r : ι → F) :
+    Lagrange.interpolate s v (c • r) = c • Lagrange.interpolate s v r :=
+  map_smul _ c r
+
+/-- **Evaluation is a linear isomorphism.** Evaluation at `#s` distinct nodes is an
+`F`-linear bijection from degree-`< #s` polynomials onto value tuples `s → F`. This is the
+coordinate-free invertibility of the Vandermonde matrix, and packages existence and
+uniqueness simultaneously as a single equivalence. -/
+theorem eval_funEquivDegreeLT_bijective (hvs : Set.InjOn v s) :
+    Function.Bijective (Lagrange.funEquivDegreeLT hvs) :=
+  (Lagrange.funEquivDegreeLT hvs).bijective
+
+end FactorRemainderTheoremOQ05OQ02
+

--- a/src/data/proofs/factor-remainder-theorem-oq-05-oq-02/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-05-oq-02/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "factor-remainder-theorem-oq-05-oq-02",
+  "title": "Factor/Remainder Theorem OQ-05-OQ-02: Existence of the Lagrange Interpolating Polynomial",
+  "slug": "factor-remainder-theorem-oq-05-oq-02",
+  "description": "The existence half of polynomial interpolation over a field, complementing the parent problem's root-bound uniqueness: for any finite set of distinct nodes and prescribed values there is a polynomial of degree < |s| taking those values (Lagrange's formula). Combined with uniqueness this is the classical Lagrange interpolation theorem, packaged as an ∃! statement and upgraded to the F-linear evaluation isomorphism degreeLT ≃ (s → F) (coordinate-free Vandermonde invertibility).",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FactorRemainderTheoremOQ05OQ02.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "interpolation",
+      "lagrange",
+      "vandermonde",
+      "field"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Lagrange.interpolate",
+        "description": "The Lagrange interpolation linear map (ι → F) →ₗ[F] F[X] sending values r to ∑ᵢ C(rᵢ)·basisᵢ",
+        "module": "Mathlib.LinearAlgebra.Lagrange"
+      },
+      {
+        "theorem": "Lagrange.eval_interpolate_at_node",
+        "description": "eval (v i) (interpolate s v r) = r i: the interpolant reproduces the data at each node",
+        "module": "Mathlib.LinearAlgebra.Lagrange"
+      },
+      {
+        "theorem": "Lagrange.degree_interpolate_lt",
+        "description": "(interpolate s v r).degree < #s: the interpolant has degree below the node count",
+        "module": "Mathlib.LinearAlgebra.Lagrange"
+      },
+      {
+        "theorem": "Lagrange.eq_interpolate_iff",
+        "description": "Characteristic property: f.degree < #s ∧ (∀ i ∈ s, eval (v i) f = r i) ↔ f = interpolate s v r",
+        "module": "Mathlib.LinearAlgebra.Lagrange"
+      },
+      {
+        "theorem": "Lagrange.funEquivDegreeLT",
+        "description": "The F-linear equivalence degreeLT F #s ≃ₗ[F] (s → F) given by evaluation at the nodes",
+        "module": "Mathlib.LinearAlgebra.Lagrange"
+      },
+      {
+        "theorem": "Polynomial.eq_of_degrees_lt_of_eval_index_eq",
+        "description": "Two polynomials of degree < #s agreeing at #s distinct indexed points are equal (needs only an integral domain)",
+        "module": "Mathlib.LinearAlgebra.Lagrange"
+      },
+      {
+        "theorem": "Polynomial.eq_of_degrees_lt_of_eval_finset_eq",
+        "description": "Finset form of the same uniqueness bound over distinct field points",
+        "module": "Mathlib.LinearAlgebra.Lagrange"
+      },
+      {
+        "theorem": "Set.injOn_id",
+        "description": "The identity map is injective on any set (used to specialize v = id to concrete field points)",
+        "module": "Mathlib.Data.Set.Function"
+      }
+    ],
+    "originalContributions": [
+      "Packaging of the EXISTENCE half of interpolation as a first-class theorem (exists_interpolating): over a field, distinct nodes + arbitrary values admit a witnessing polynomial of degree < |s|",
+      "The full Lagrange interpolation theorem as a clean ∃! statement (existsUnique_interpolating), which Mathlib states only as the equality characterization eq_interpolate_iff — existence and uniqueness combined in the ExistsUnique form",
+      "The concrete classical formulation over a finite set of distinct field points (existsUnique_interpolating_points / exists_interpolating_points), specializing the abstract indexed API via v = id",
+      "A uniqueness restatement (eq_of_degree_lt_of_eval_eq_points) that bridges directly to the parent problem's integral-domain root-count argument",
+      "The superposition principle: interpolation is F-linear in the prescribed data (interpolate_add, interpolate_smul)",
+      "The structural statement that evaluation at |s| distinct nodes is an F-linear bijection degreeLT F #s ≃ₗ[F] (s → F) (eval_funEquivDegreeLT_bijective) — the coordinate-free invertibility of the Vandermonde matrix"
+    ],
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 159,
+    "assumptions": "0 axioms, 0 sorries; every theorem depends only on Lean's foundational propext / Classical.choice / Quot.sound. Existence and the ∃! statement wrap Mathlib's Lagrange.interpolate together with its node and degree properties; the field hypothesis is essential for existence (the Lagrange-basis denominators vᵢ − vⱼ must be invertible), while the uniqueness half needs only an integral domain — matching the parent problem.",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Lagrange's interpolation formula (1795) answers the existence question left open by the factor theorem's root bound: given n distinct abscissae and any prescribed ordinates, there is a polynomial of degree < n through those points, written explicitly as L(x) = ∑ᵢ yᵢ ∏_{j≠i}(x − xⱼ)/(xᵢ − xⱼ). The parent problem factor-remainder-theorem-oq-05 supplies the complementary uniqueness statement via the root-count bound card(roots p) ≤ deg(p): a low-degree polynomial cannot vanish at too many points, so at most one interpolant of degree < n exists. Together these are the two halves of the classical interpolation theorem, the well-definedness result underpinning numerical analysis, Reed–Solomon codes, secret sharing, and the Vandermonde determinant.",
+    "problemStatement": "**Open Question** (parent openQuestions[1]): Derive existence of the interpolating polynomial to complement uniqueness — full Lagrange interpolation over a field.\n\n**Answer**: For a finset s with node map v injective on s and any value function r, `Lagrange.interpolate s v r` is a polynomial of degree < #s with eval (v i) = r i for all i ∈ s (existence). With the parent's uniqueness this gives ∃! such polynomial, and the assignment values ↦ interpolant is an F-linear isomorphism degreeLT F #s ≃ₗ[F] (s → F).",
+    "text": "Over a field, distinct nodes and prescribed values determine a unique polynomial of degree < n; existence is witnessed by Lagrange's formula, uniqueness by the parent's root bound, and the two together form the F-linear evaluation isomorphism (coordinate-free Vandermonde invertibility).",
+    "proofStrategy": "Four parts:\n1. **Existence** (Part I): `exists_interpolating` exhibits `Lagrange.interpolate s v r` as the witness, using `degree_interpolate_lt` for the degree bound and `eval_interpolate_at_node` for value matching.\n2. **Existence + uniqueness** (Part II): `existsUnique_interpolating` supplies the interpolant as the witness and closes the uniqueness goal with `eq_interpolate_iff`; `interpolate_unique` restates the uniqueness half (integral domain only).\n3. **Concrete field points** (Part III): specialize ι = F, v = id (`Set.injOn_id`) to recover the textbook statement over a finset S ⊆ F; `eq_of_degree_lt_of_eval_eq_points` bridges to the parent's root-count uniqueness.\n4. **Structural** (Part IV): `interpolate_add` / `interpolate_smul` are `map_add` / `map_smul` of the linear map (superposition), and `eval_funEquivDegreeLT_bijective` records that evaluation at the nodes is an F-linear bijection degreeLT F #s ≃ₗ[F] (s → F).",
+    "keyInsights": [
+      "Existence is the field-only half: the Lagrange basis ℓᵢ requires dividing by vᵢ − vⱼ, so denominators must be invertible; uniqueness, by contrast, holds over any integral domain (the parent's setting)",
+      "Mathlib states interpolation only as the characterization eq_interpolate_iff (f = interpolate ↔ degree bound + node values); repackaging as ∃! makes the existence-and-uniqueness content explicit and matches the classical theorem statement",
+      "The whole theory is F-linear in the data: interpolate is a LinearMap, so superposition (interpolate of a sum is the sum of interpolants) is immediate — the basis for divide-and-conquer and incremental interpolation",
+      "Evaluation at n distinct nodes is a linear isomorphism degreeLT F n ≃ (nodes → F); this is exactly the invertibility of the n×n Vandermonde matrix stated without choosing the monomial basis, and simultaneously encodes existence (surjective) and uniqueness (injective)",
+      "Specializing the indexed API (v : ι → F) to ι = F, v = id turns the abstract statement into the classical one about distinct field points with no loss"
+    ],
+    "prerequisites": [
+      "Polynomials over a field and polynomial evaluation",
+      "The factor theorem and root bound (parent problem factor-remainder-theorem-oq-05)",
+      "Finite sets, injectivity on a set, and the degree filtration degreeLT",
+      "Linear maps and linear equivalences"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: existence complements the parent's uniqueness; Lagrange's explicit formula; the field hypothesis and its necessity for existence",
+      "startLine": 1,
+      "endLine": 62,
+      "mathContext": "Existence half of interpolation over a field, witnessed by Lagrange.interpolate; field needed for invertible basis denominators."
+    },
+    {
+      "id": "existence",
+      "title": "Part I: Existence over a Field (abstract indexed form)",
+      "summary": "exists_interpolating (a degree-<#s witness matching the data), plus interpolate_degree_lt and interpolate_eval_node exposing the witness's two defining properties",
+      "startLine": 63,
+      "endLine": 85,
+      "mathContext": "Lagrange.interpolate s v r has degree < #s and eval (v i) = r i for all i ∈ s."
+    },
+    {
+      "id": "exists-unique",
+      "title": "Part II: Existence AND Uniqueness — the Lagrange Interpolation Theorem",
+      "summary": "interpolate_unique (uniqueness half, integral domain only) and existsUnique_interpolating (the ∃! statement combining existence with uniqueness via eq_interpolate_iff)",
+      "startLine": 86,
+      "endLine": 106,
+      "mathContext": "∃! p, p.degree < #s ∧ ∀ i ∈ s, eval (v i) p = r i."
+    },
+    {
+      "id": "concrete-points",
+      "title": "Part III: The Concrete Classical Statement over Field Points",
+      "summary": "existsUnique_interpolating_points and exists_interpolating_points (ι = F, v = id), plus eq_of_degree_lt_of_eval_eq_points bridging to the parent's root-count uniqueness",
+      "startLine": 108,
+      "endLine": 133,
+      "mathContext": "For a finset S ⊆ F and values y, a unique polynomial of degree < #S passes through (x, y x) for all x ∈ S."
+    },
+    {
+      "id": "structural",
+      "title": "Part IV: Structural Consequences",
+      "summary": "interpolate_add / interpolate_smul (superposition: interpolation is F-linear in the data) and eval_funEquivDegreeLT_bijective (evaluation at the nodes is an F-linear bijection degreeLT ≃ (s → F), coordinate-free Vandermonde invertibility)",
+      "startLine": 135,
+      "endLine": 159,
+      "mathContext": "interpolate is a LinearMap; funEquivDegreeLT is an F-linear equivalence degreeLT F #s ≃ₗ[F] (s → F)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes the existence half of polynomial interpolation over a field, completing the classical Lagrange interpolation theorem begun by the parent problem's uniqueness result. Existence is witnessed by Mathlib's Lagrange.interpolate; combined with uniqueness it is packaged as a clean ∃! statement, given both in the abstract indexed form and in the concrete classical form over distinct field points. Two structural consequences are recorded: interpolation is F-linear in the prescribed values (superposition), and evaluation at the nodes is an F-linear isomorphism degreeLT F #s ≃ₗ[F] (s → F) — the coordinate-free invertibility of the Vandermonde matrix. All 11 theorems are verified with 0 sorries and 0 axioms beyond Lean's foundations.",
+    "implications": "With uniqueness (parent) and existence (here), the interpolating polynomial through n distinct points is well-defined — the foundation of Lagrange/Newton interpolation, Reed–Solomon codes, Shamir secret sharing, and Gaussian quadrature. The linear-isomorphism form is the abstract statement that the Vandermonde matrix is invertible, and it exhibits interpolation as a change of basis between the value representation and the coefficient representation of a degree-<n polynomial.",
+    "openQuestions": [
+      "Formalize the Newton divided-difference form of the interpolant and prove it equals the Lagrange form, giving an incremental O(n²) construction",
+      "Derive the explicit interpolation error / remainder term f(x) − p(x) = f⁽ⁿ⁾(ξ)/n! · ∏(x − xᵢ) for smooth real functions",
+      "Connect eval_funEquivDegreeLT_bijective to the nonvanishing of the Vandermonde determinant ∏_{i<j}(vⱼ − vᵢ)"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "factor-remainder-theorem-oq-05",
+      "relationship": "Parent problem: proves interpolation UNIQUENESS via the root bound card(roots p) ≤ deg(p); this entry answers its openQuestions[1] by supplying EXISTENCE"
+    },
+    {
+      "id": "factor-remainder-theorem",
+      "relationship": "Grandparent: the factor/remainder theorem (X − a) ∣ p ⟺ p(a) = 0"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "FactorRemainderTheoremOQ05OQ02",
+    "lineCount": 159,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/FactorRemainderTheoremOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Joseph-Louis Lagrange",
+      "title": "Leçons élémentaires sur les mathématiques (interpolation formula)",
+      "year": "1795",
+      "venue": "École Normale"
+    },
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra (polynomials over fields, interpolation)",
+      "year": "2002",
+      "venue": "Springer GTM 211"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "factor-remainder-theorem-oq-05",
+      "relationship": "extends",
+      "description": "Supplies the existence half of interpolation to complement the parent's root-bound uniqueness, completing the Lagrange interpolation theorem."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **factor-remainder-theorem-oq-05-oq-02** — the parent problem's `openQuestions[1]` verbatim: *"Derive existence of the interpolating polynomial to complement uniqueness (full Lagrange interpolation over a field)."*

The parent `factor-remainder-theorem-oq-05` proved interpolation **uniqueness** via the root bound `card(roots p) ≤ deg(p)`. This entry supplies the complementary **existence** half over a field, completing the classical Lagrange interpolation theorem.

## Content (11 theorems, 159 lines, 0 sorries, 0 axioms)

**Part I — Existence (abstract indexed form):** `exists_interpolating` exhibits `Lagrange.interpolate s v r` as a degree-`<#s` witness matching the data at every node; `interpolate_degree_lt`, `interpolate_eval_node` expose its two defining properties.

**Part II — Existence + uniqueness:** `existsUnique_interpolating` packages the classical theorem as a clean `∃!` statement (Mathlib states only the equality characterization `eq_interpolate_iff`); `interpolate_unique` restates the uniqueness half (integral domain only, matching the parent).

**Part III — Concrete classical statement:** `existsUnique_interpolating_points` / `exists_interpolating_points` specialize `ι = F, v = id` to the textbook statement over distinct field points; `eq_of_degree_lt_of_eval_eq_points` bridges to the parent's root-count uniqueness.

**Part IV — Structural:** `interpolate_add` / `interpolate_smul` give the superposition principle (interpolation is `F`-linear in the data); `eval_funEquivDegreeLT_bijective` records that evaluation at the nodes is an `F`-linear bijection `degreeLT F #s ≃ₗ[F] (s → F)` — the coordinate-free invertibility of the Vandermonde matrix.

## Verification

- `lake env lean` against **Mathlib 4.26.0**, clean compile, no warnings.
- `#print axioms` on the headline theorems: only `propext`, `Classical.choice`, `Quot.sound` — **0 custom axioms, no native_decide, 0 sorries** → `verified`.

The field hypothesis is essential for *existence* (the Lagrange-basis denominators `vᵢ − vⱼ` must be invertible); uniqueness needs only an integral domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)