### PR TITLE
Enrich exponent-governs-power-map: 4→6 annotations, +5th keyInsight

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01/annotations.json
@@ -24,6 +24,28 @@
     ]
   },
   {
+    "id": "ann-zpow-exponent",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 53
+    },
+    "type": "technique",
+    "title": "The ℤ-Power Bridge Lemma: x^(exp G) = 1 as an Integer Power",
+    "content": "zpow_exponent_eq_one restates the defining exponent property x^(exp G) = 1 (Monoid.pow_exponent_eq_one, a ℕ-power fact) as the integer-power equality x^(↑exp G : ℤ) = 1, proved by rw [zpow_natCast] and the ℕ-power lemma. This tiny repackaging is exactly what the image proof needs: Bézout writes gcd(n,e) = n·A + e·B over ℤ with A, B integers, so the exponent enters as the ℤ-coefficient of the product e·B. Having x raised to an integer multiple of e collapse to 1 is what lets the e·B term drop out; without the zpow form the integer arithmetic would not typecheck against the ℕ-power lemma.",
+    "mathContext": "$$x^{(\\uparrow\\!\\exp G\\,:\\,\\mathbb{Z})} = 1,\\qquad\\text{the }\\mathbb{Z}\\text{-power companion of } x^{\\exp G}=1.$$",
+    "significance": "technical",
+    "relatedConcepts": [
+      "monoid exponent",
+      "integer powers (zpow)",
+      "natural-to-integer cast of exponents"
+    ],
+    "prerequisites": [
+      "Monoid.pow_exponent_eq_one",
+      "zpow_natCast"
+    ]
+  },
+  {
     "id": "ann-kernel",
     "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
     "range": {
@@ -66,6 +88,30 @@
       "Nat.gcd_eq_gcd_ab",
       "zpow_mul",
       "zpow_add"
+    ]
+  },
+  {
+    "id": "ann-abelian-subgroups",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 133
+    },
+    "type": "theorem",
+    "title": "From Set Equalities to Subgroup Equalities (Abelian)",
+    "content": "In a commutative group the power map x ↦ xⁿ is a monoid homomorphism (powMonoidHom n), so its kernel and image are genuine subgroups rather than mere sets — this is the ONLY place commutativity is used. ker_powMonoidHom_eq_gcd_exponent unfolds MonoidHom.mem_ker via ext and powMonoidHom_apply and closes on the element-level pow_eq_one_iff_pow_gcd_exponent. range_powMonoidHom_eq_gcd_exponent transports the set-level range equality through MonoidHom.mem_range in both directions with ext y. Neither theorem assumes finiteness: the subgroup equalities of ker and range hold for every abelian group, finite or infinite.",
+    "mathContext": "$$\\ker(\\text{pow}_n)=\\ker(\\text{pow}_{\\gcd(n,\\exp G)}),\\qquad \\operatorname{range}(\\text{pow}_n)=\\operatorname{range}(\\text{pow}_{\\gcd(n,\\exp G)})\\ \\text{as subgroups.}$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "powMonoidHom",
+      "kernel and image subgroups",
+      "monoid homomorphism",
+      "commutativity as the sole hypothesis"
+    ],
+    "prerequisites": [
+      "MonoidHom.mem_ker",
+      "MonoidHom.mem_range",
+      "powMonoidHom"
     ]
   },
   {

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01/meta.json
@@ -131,7 +131,8 @@
       "The correct invariant for the power map's image is the group EXPONENT, not the order: range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) holds in every group, whereas the parent's order-based proof was confined to the cyclic case.",
       "The hard inclusion is a one-line Bézout identity: gcd(n, exp G) = n·A + exp G·B over ℤ, and x^exp G = 1 collapses the second term, so x^gcd(n,exp G) = (x^A)ⁿ is manifestly an n-th power.",
       "No commutativity or finiteness is needed for the set-level kernel and image equalities; commutativity enters only to phrase them as subgroup equalities, and finiteness only for the counting partition #range · #ker = |G|.",
-      "The partition analogue the parent asked for is first-isomorphism bookkeeping: in a finite abelian group the constant fibre size is #ker, and #range · #ker = |G|; the cyclic identity #(n-th powers) · gcd(n, m) = m is the special case #ker = gcd(n, m), exp G = m."
+      "The partition analogue the parent asked for is first-isomorphism bookkeeping: in a finite abelian group the constant fibre size is #ker, and #range · #ker = |G|; the cyclic identity #(n-th powers) · gcd(n, m) = m is the special case #ker = gcd(n, m), exp G = m.",
+      "The proof is cleanly stratified by hypothesis: the set-level kernel and image equalities need only a group; commutativity is spent solely to promote them to subgroup equalities of ker/range of powMonoidHom (where the power map becomes a homomorphism, so ker and range are subgroups at all — finite or infinite); and finiteness is spent solely on the last step, the counting partition #range · #ker = |G|."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01` (0 prior passes, 17.3 KB meta — comfortably under the 60 KB cap).

## Gaps addressed
The entry was already well-curated but had **annotation coverage gaps**: 4 annotations left two theorem blocks uncovered.

- **New `ann-zpow-exponent` (L47–53)** — the ℤ-power bridge lemma `zpow_exponent_eq_one`: x^(↑exp G : ℤ)=1, explaining why the integer-cast form is exactly what the Bézout computation needs (the e·B term is over ℤ).
- **New `ann-abelian-subgroups` (L105–133)** — the set→subgroup promotion: in a commutative group the power map is `powMonoidHom`, so ker/range become genuine subgroups; this is the *only* place commutativity is used, and no finiteness is needed.
- Annotations now cover **every theorem block** (6 total, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`).
- **+5th keyInsight** capturing the clean stratification of hypotheses: set-level equalities need only a group; commutativity buys subgroup equalities; finiteness buys only the counting partition.

## Verification
- Both JSON files parse; gallery data-build step completed for all entries.
- `check-meta-size.ts`: within caps (17.3 KB ≤ 60 KB).
- All existing content preserved; only additions.
- No changes to `status`/`badge`/`axiomCount` (verified, 0 axioms — accurate).