### PR TITLE
Enrich Lagrange interpolation existence (factor-remainder-oq-05-oq-02): add annotations.json (0→5)

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-05-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "frt-oq0502-ann-preamble",
+    "proofId": "factor-remainder-theorem-oq-05-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 53
+    },
+    "type": "context",
+    "title": "The existence half of Lagrange interpolation",
+    "content": "The parent problem factor-remainder-theorem-oq-05 proved the uniqueness half of polynomial interpolation over an integral domain: via the root-count bound Polynomial.card_roots', a degree-< n polynomial vanishing at n distinct points is zero, so two such polynomials agreeing on n points coincide. This file supplies the complementary existence half over a field: an explicit witness, Lagrange's interpolating polynomial, of degree < n taking any prescribed values at n distinct nodes. Existence genuinely needs a field — the denominators v_i − v_j in the Lagrange basis must be invertible — whereas uniqueness needs only an integral domain. Combined, they give the classical Lagrange interpolation theorem in ∃! form.",
+    "mathContext": "$$L(x)=\\sum_i r_i\\,\\ell_i(x),\\qquad \\ell_i(x)=\\prod_{j\\neq i}\\frac{x-v_j}{v_i-v_j}.$$ Existence requires the field so that each $v_i-v_j$ is invertible; uniqueness requires only an integral domain.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lagrange interpolation",
+      "existence vs uniqueness",
+      "polynomial interpolation",
+      "field vs integral domain"
+    ],
+    "prerequisites": [
+      "polynomials over a field",
+      "polynomial evaluation",
+      "finite sets of nodes"
+    ]
+  },
+  {
+    "id": "frt-oq0502-ann-existence",
+    "proofId": "factor-remainder-theorem-oq-05-oq-02",
+    "range": {
+      "startLine": 63,
+      "endLine": 85
+    },
+    "type": "theorem",
+    "title": "Part I — Existence over a field (abstract indexed form)",
+    "content": "exists_interpolating packages Mathlib's Lagrange.interpolate s v r as an explicit witness: given an injective node map (Set.InjOn v s) and arbitrary values r, it produces p : F[X] with p.degree < #s and p.eval (v i) = r i for every node. The two defining properties of interpolate are used directly — Lagrange.degree_interpolate_lt for the degree bound and Lagrange.eval_interpolate_at_node for the value-matching. interpolate_degree_lt and interpolate_eval_node expose these two facts as standalone lemmas. This is the abstract form: nodes are indexed by an arbitrary ι with v injective on the finset s.",
+    "mathContext": "For distinct nodes $v(i)$, $i\\in s$, and values $r_i$, the witness $L=\\mathrm{interpolate}\\,s\\,v\\,r$ satisfies $\\deg L<\\#s$ and $L(v_i)=r_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lagrange.interpolate",
+      "degree bound",
+      "injective node map",
+      "existence proof by explicit witness"
+    ],
+    "prerequisites": [
+      "Lagrange basis polynomials",
+      "Finset.card",
+      "Set.InjOn"
+    ]
+  },
+  {
+    "id": "frt-oq0502-ann-existsunique",
+    "proofId": "factor-remainder-theorem-oq-05-oq-02",
+    "range": {
+      "startLine": 86,
+      "endLine": 106
+    },
+    "type": "theorem",
+    "title": "Part II — The Lagrange interpolation theorem (∃!)",
+    "content": "interpolate_unique restates the parent's uniqueness over a field via Polynomial.eq_of_degrees_lt_of_eval_index_eq: two degree-< #s polynomials agreeing at all nodes are equal (only integral-domain structure is used, exactly the parent's setting). existsUnique_interpolating then assembles existence and uniqueness into the headline ∃! statement: the Lagrange polynomial is the witness, and any other q satisfying the same constraints equals it by Lagrange.eq_interpolate_iff. This is the classical 'through n distinct points there is one and only one polynomial of degree < n with the prescribed values.'",
+    "mathContext": "$$\\exists!\\,p\\in F[X]:\\ \\deg p<\\#s\\ \\wedge\\ \\forall i\\in s,\\ p(v_i)=r_i.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "ExistsUnique",
+      "uniqueness of interpolant",
+      "Lagrange.eq_interpolate_iff",
+      "existence and uniqueness"
+    ],
+    "prerequisites": [
+      "ExistsUnique in Lean",
+      "root-count bound",
+      "integral domains"
+    ]
+  },
+  {
+    "id": "frt-oq0502-ann-classical",
+    "proofId": "factor-remainder-theorem-oq-05-oq-02",
+    "range": {
+      "startLine": 108,
+      "endLine": 133
+    },
+    "type": "theorem",
+    "title": "Part III — The concrete classical statement over field points",
+    "content": "Specializing the abstract form to ι = F and v = id recovers the textbook picture: distinct x-coordinates drawn from a finset S ⊆ F, arbitrary y-values. existsUnique_interpolating_points obtains the ∃! statement by feeding Set.injOn_id into existsUnique_interpolating and discharging the id-substitution with simpa; exists_interpolating_points is the existence-only form. eq_of_degree_lt_of_eval_eq_points gives the matching uniqueness through Polynomial.eq_of_degrees_lt_of_eval_finset_eq, bridging back to the parent's root-count proof phrased directly on field points.",
+    "mathContext": "For $S\\subseteq F$ finite and $y:F\\to F$: a unique $p$ with $\\deg p<\\#S$ and $p(x)=y(x)$ for all $x\\in S$. The case $v=\\mathrm{id}$ of the indexed form.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialization to identity nodes",
+      "textbook interpolation",
+      "Set.injOn_id",
+      "simpa"
+    ],
+    "prerequisites": [
+      "Finset over a field",
+      "identity map",
+      "the abstract indexed form"
+    ]
+  },
+  {
+    "id": "frt-oq0502-ann-structural",
+    "proofId": "factor-remainder-theorem-oq-05-oq-02",
+    "range": {
+      "startLine": 135,
+      "endLine": 158
+    },
+    "type": "insight",
+    "title": "Part IV — Superposition and the Vandermonde isomorphism",
+    "content": "Two structural consequences flow from interpolate being a LinearMap. interpolate_add and interpolate_smul (via map_add, map_smul) are the superposition principle: interpolation is F-linear in the prescribed values, so the interpolant of a sum/scaling of data is the sum/scaling of interpolants. eval_funEquivDegreeLT_bijective records that Lagrange.funEquivDegreeLT is a bijection — evaluation at #s distinct nodes is an F-linear isomorphism degreeLT F #s ≃ₗ[F] (s → F). This is the coordinate-free invertibility of the Vandermonde matrix, packaging existence (surjectivity) and uniqueness (injectivity) simultaneously as one equivalence.",
+    "mathContext": "Evaluation $\\mathrm{ev}:\\{p:\\deg p<n\\}\\xrightarrow{\\ \\sim\\ }F^{s}$ is an $F$-linear isomorphism; its matrix in the monomial/tuple bases is the Vandermonde matrix $V_{ij}=v_i^{\\,j}$, invertible exactly when the $v_i$ are distinct.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "linear map",
+      "superposition principle",
+      "Vandermonde matrix",
+      "linear isomorphism degreeLT ≃ tuples"
+    ],
+    "prerequisites": [
+      "linear maps",
+      "Vandermonde determinant",
+      "bijections and equivalences"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-05-oq-02` (0 prior passes, quality score 45). This entry had **no `annotations.json` at all** — the highest-value gap.

## What was added
Created `annotations.json` from scratch: **5 annotations covering the full 159-line file**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

| Range | Annotation |
|-------|-----------|
| 1–53 | Preamble — the existence half; why existence needs a field (invertible denominators `v_i − v_j`) while uniqueness needs only an integral domain |
| 63–85 | Part I — `exists_interpolating`: the explicit Lagrange witness, abstract indexed form |
| 86–106 | Part II — `existsUnique_interpolating`: the ∃! Lagrange interpolation theorem |
| 108–133 | Part III — concrete classical statement over field points (ι=F, v=id) |
| 135–158 | Part IV — superposition (LinearMap) + the Vandermonde linear isomorphism `degreeLT F #s ≃ₗ (s → F)` |

## Verification
- JSON well-formed; all annotations carry the required fields and correct `proofId`.
- Ranges align with the meta `sections` and cover the whole file.
- `check-meta-size.ts`: within caps (meta unchanged at 14.5 KB).
- meta.json untouched; `status: verified`, `axiomCount: 0` accurate.