### PR TITLE
Enrich Erdős #1012 OQ-05: decidability of cycle detection (erdos-1012-oq-05)

### DIFF
--- a/src/data/proofs/erdos-1012-oq-05/annotations.json
+++ b/src/data/proofs/erdos-1012-oq-05/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-e1012oq05-header",
+    "proofId": "erdos-1012-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 58
+    },
+    "type": "context",
+    "title": "Scope: the decidable, finitely-searchable core of OQ-05",
+    "content": "The module docstring is unusually careful about what is and is not claimed. Erdős #1012's fifth open question asks for the computational complexity of detecting an (n−k)-cycle in a graph with T(n,k)−1 edges — a question whose full answer (a polynomial algorithm, or an NP-hardness reduction) is out of reach of current Mathlib. This file instead pins down the honest computational core the question presupposes: for a fixed finite graph, cycle detection is Decidable (a decision procedure provably exists), it is realised by an explicit finite brute-force search, and that search space has exactly |V|^ℓ candidates. The docstring's explicit 'What This File Does NOT Claim' section stresses that the |V|^ℓ bound is exponential and no hardness result is proved — the file delimits the decidable skeleton on which any future complexity analysis rests. Setup: import Mathlib and the parent Erdos1012Problem, namespace Erdos1012OQ05, open Erdos1012, and a fixed finite decidable-eq vertex type V.",
+    "mathContext": "For fixed finite $G$: 'contains an $\\ell$-cycle' is $\\mathrm{Decidable}$, equivalent to a search over $\\{c : \\mathrm{Fin}\\,\\ell \\to V\\}$ of size $|V|^{\\ell}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "decidability",
+      "brute-force search",
+      "computational complexity",
+      "cycle detection",
+      "Erdős #1012"
+    ],
+    "prerequisites": [
+      "Decidable instances",
+      "Fintype cardinality",
+      "SimpleGraph cycles"
+    ]
+  },
+  {
     "id": "ann-e1012oq05-basecase",
     "proofId": "erdos-1012-oq-05",
     "range": {


### PR DESCRIPTION
Enrichment pass for `erdos-1012-oq-05`.

## Gap addressed
Annotation coverage was **45%** (65/145 lines) — the entire module docstring / scope statement (lines 1–58) was uncovered; the 5 existing annotations covered only the theorems (60–145).

## Changes
Added **1 header/scope annotation** (now 6 total), covering lines 1–58: the OQ-05 open question, the decidable finitely-searchable core that IS proved (`Decidable` cycle detection, explicit `|V|^ℓ` search space), and the docstring's careful 'what is NOT claimed' (no polynomial algorithm, no hardness result). Coverage now ~85%.

Carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. No `meta.json` changes. Well under size caps.

Verified with `pnpm build`.