### PR TITLE
Fix: create missing gallery entry for pell-equation-oq-05

### DIFF
--- a/src/data/proofs/pell-equation-oq-05/annotations.json
+++ b/src/data/proofs/pell-equation-oq-05/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-cnorm-det",
+    "proofId": "pell-equation-oq-05",
+    "range": { "startLine": 47, "endLine": 64 },
+    "type": "definition",
+    "title": "The Cubic Norm Form as a Determinant",
+    "content": "`cnorm a b c = a³ + 2b³ + 4c³ − 6abc` is the norm of $a + b\\sqrt[3]{2} + c\\sqrt[3]{4}$ in $\\mathbb{Z}[\\sqrt[3]{2}] = \\mathbb{Z}[t]/(t^3-2)$. `cnorm_eq_det` identifies it with the determinant of the matrix of multiplication-by-$(a+bt+ct^2)$ on the power basis $\\{1,t,t^2\\}$ (columns reduced by $t^3 = 2$), so this is the concrete `Algebra.norm` computed by hand — proved by `Matrix.det_fin_three` followed by `ring`, needing none of Mathlib's heavier field-theory machinery.",
+    "mathContext": "$N(a+b\\sqrt[3]2+c\\sqrt[3]4)=\\det\\begin{pmatrix}a&2c&2b\\\\ b&a&2c\\\\ c&b&a\\end{pmatrix}=a^3+2b^3+4c^3-6abc$",
+    "significance": "supporting",
+    "relatedConcepts": ["field norm", "cubic field ℚ(∛2)", "power basis", "determinant of a representation"],
+    "prerequisites": ["number fields", "the norm map N_{K/ℚ}", "determinants"]
+  },
+  {
+    "id": "ann-multiplicativity",
+    "proofId": "pell-equation-oq-05",
+    "range": { "startLine": 65, "endLine": 86 },
+    "type": "insight",
+    "title": "Multiplicativity of the Norm Form",
+    "content": "`cmul` is multiplication in $\\mathbb{Z}[t]/(t^3-2)$ — the product of two coordinate triples, reduced using $t^3 = 2$ — and `cnorm3` is the norm of a triple. `cnorm_cmul` is the key structural fact $N(\\xi\\cdot\\eta) = N(\\xi)\\cdot N(\\eta)$: after expanding `cmul`, it is a pure polynomial identity in the six coordinates, closed by `ring`. This is the higher-degree Brahmagupta composition law — the single engine that turns one unit into an infinite chain of solutions, exactly as multiplicativity of $x^2-Dy^2$ does for classical Pell.",
+    "mathContext": "$N(\\xi\\eta)=N(\\xi)N(\\eta)$ for $\\xi,\\eta\\in\\mathbb{Z}[\\sqrt[3]2]$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative norm", "Brahmagupta composition", "ring tactic", "polynomial identity"],
+    "prerequisites": ["norm multiplicativity", "quotient rings"]
+  },
+  {
+    "id": "ann-pell-chain",
+    "proofId": "pell-equation-oq-05",
+    "range": { "startLine": 87, "endLine": 121 },
+    "type": "insight",
+    "title": "The Fundamental Unit and the Higher-Degree Pell Chain",
+    "content": "`u = ∛2 − 1` (coordinate triple $(-1,1,0)$) is a unit: its inverse is $t^2+t+1$ since $(t-1)(t^2+t+1) = t^3-1 = 1$ (`cmul_u_uinv`, a finite `decide`), and it has norm 1 (`cnorm_u`). The chain `upow k = uᵏ` therefore consists entirely of norm-1 elements — `cnorm_upow` proves $N(u^k)=1$ by induction using multiplicativity and $N(u)=1$. The first terms $u^1=(-1,1,0),\\ u^2=(1,-2,1),\\ u^3=(1,3,-3),\\ u^4=(-7,-2,6)$ are the cubic counterpart of the Brahmagupta chain $(3,2)\\to(17,12)\\to\\cdots$ for $x^2-2y^2=1$.",
+    "mathContext": "$u=\\sqrt[3]2-1,\\ N(u)=1,\\ u^{-1}=\\sqrt[3]4+\\sqrt[3]2+1;\\quad N(u^k)=1\\ \\forall k$",
+    "significance": "key",
+    "relatedConcepts": ["fundamental unit", "unit group", "Pell chain", "Dirichlet unit theorem (rank 1)"],
+    "prerequisites": ["units of a ring of integers", "induction"]
+  },
+  {
+    "id": "ann-distinctness",
+    "proofId": "pell-equation-oq-05",
+    "range": { "startLine": 122, "endLine": 202 },
+    "type": "insight",
+    "title": "Distinctness of the Chain via a Real Embedding",
+    "content": "The subtle step — that the chain values are genuinely distinct (so there really are infinitely many solutions) — is handled with a single real embedding rather than Dirichlet's unit theorem. `phi τ` sends $(a,b,c)$ to $a + b\\tau + c\\tau^2$ with $\\tau = \\sqrt[3]2$; it is a ring homomorphism (`phi_cmul`, the residual multiple of $\\tau^3-2$ cleared by `linear_combination`), so $\\varphi(u^k) = \\varphi(u)^k$ (`phi_upow`). Since `tau_bounds`/`phi_u_mem` pin $\\varphi(u)=\\tau-1\\in(0,1)$, the powers $\\varphi(u)^k$ are strictly decreasing, hence `upow` is injective (`upow_injective`). `Set.infinite_of_injective_forall_mem` then gives `norm_one_solutions_infinite`: $N(\\xi)=1$ has infinitely many integral solutions.",
+    "mathContext": "$0<\\varphi(u)=\\tau-1<1\\Rightarrow \\varphi(u)^k$ strictly decreasing $\\Rightarrow k\\mapsto u^k$ injective",
+    "significance": "key",
+    "relatedConcepts": ["real embedding / infinite place", "geometric progression", "injectivity", "strict monotonicity of powers"],
+    "prerequisites": ["real analysis of xⁿ", "ring homomorphisms", "linear_combination tactic"]
+  },
+  {
+    "id": "ann-dichotomy",
+    "proofId": "pell-equation-oq-05",
+    "range": { "startLine": 203, "endLine": 285 },
+    "type": "insight",
+    "title": "Zero-or-Infinite Dichotomy for N(ξ) = m",
+    "content": "The $m=1$ infinitude upgrades to every nonzero $m$. `cnorm_eq_phi_mul` factors the norm at the real place as $N(\\xi)=\\varphi(\\xi)\\cdot\\varphi(\\xi^\\star)$ — the specialization of $x^3+y^3+z^3-3xyz=(x+y+z)(x^2+y^2+z^2-xy-yz-zx)$ to $(a,b\\tau,c\\tau^2)$ — so a nonzero norm forces $\\varphi(\\xi_0)\\neq 0$ (`phi_ne_zero_of_cnorm_ne_zero`). Then the shifted orbit $k\\mapsto \\xi_0\\cdot u^k$ has values $\\varphi(\\xi_0)\\varphi(u)^k$, still injective (`cmul_chain_injective`). Hence `norm_eq_solutions_infinite`: any solvable $N(\\xi)=m$ ($m\\neq 0$) has infinitely many solutions. `norm_two_solutions_infinite` instantiates it at $m=2$ with seed $\\sqrt[3]2 = (0,1,0)$.",
+    "mathContext": "$N(\\xi)=\\varphi(\\xi)\\varphi(\\xi^\\star)\\neq 0\\Rightarrow \\varphi(\\xi_0)\\neq 0\\Rightarrow \\{\\xi_0 u^k\\}$ infinite",
+    "significance": "key",
+    "relatedConcepts": ["unit-orbit of solutions", "norm-form factorization", "zero-or-infinite dichotomy"],
+    "prerequisites": ["group action on solution sets", "cancellation in ℝ"]
+  },
+  {
+    "id": "ann-non-surjective",
+    "proofId": "pell-equation-oq-05",
+    "range": { "startLine": 286, "endLine": 368 },
+    "type": "insight",
+    "title": "7 Is a Non-Norm: the Form Is Not Surjective",
+    "content": "Not every integer is a norm. `cnorm_anisotropic_mod7` checks — by a finite kernel `decide` over the $7^3=343$ residue triples — that the form's only zero over $\\mathbb{F}_7$ is $(0,0,0)$; equivalently $x^3-2$ is irreducible over $\\mathbb{F}_7$ (2 is a cubic non-residue), so 7 is **inert** in $\\mathbb{Q}(\\sqrt[3]2)$. Pulling back along $\\mathbb{Z}\\to\\mathbb{Z}/7$ gives `seven_dvd_cnorm_iff` (7 ∣ N ⟺ 7 divides each of $a,b,c$; the converse is homogeneity), so $7\\mid N$ forces $343\\mid N$. Since $343\\nmid 7$, we get `cnorm_ne_seven`/`cnorm_ne_neg_seven`, an empty solution set (`norm_eq_seven_no_solution`), and finally `cnorm3_not_surjective` — the empty counterpart to $N=2$'s infinitely many solutions. This uses only a finite check, no `native_decide`, so it remains axiom-free.",
+    "mathContext": "$x^3-2$ irreducible over $\\mathbb{F}_7$ ⇒ 7 inert ⇒ $7\\mid N\\Rightarrow 343\\mid N$ ⇒ 7 a non-norm",
+    "significance": "key",
+    "relatedConcepts": ["inert prime", "anisotropic form", "cubic reciprocity", "kernel decide (axiom-free)", "surjectivity"],
+    "prerequisites": ["primes in number fields", "ZMod arithmetic", "homogeneous forms"]
+  },
+  {
+    "id": "ann-recovering-pell",
+    "proofId": "pell-equation-oq-05",
+    "range": { "startLine": 369, "endLine": 386 },
+    "type": "definition",
+    "title": "Recovering Classical Pell",
+    "content": "For contrast, `qnorm p q = p² − 2q²` is the real-quadratic (degree-2) norm form. `qnorm_fundamental` records the classical fundamental solution $3^2-2\\cdot2^2=1$, and `qnorm_chain` its Brahmagupta iterates $(17,12),(99,70),(577,408)$. Because $\\mathbb{Q}(\\sqrt2)$ and $\\mathbb{Q}(\\sqrt[3]2)$ have the same unit rank 1, classical Pell is precisely the degree-2 shadow of the cubic picture developed above.",
+    "mathContext": "$x^2-2y^2=1$: $(3,2)\\to(17,12)\\to(99,70)\\to(577,408)$",
+    "significance": "supporting",
+    "relatedConcepts": ["classical Pell equation", "unit rank", "real-quadratic field"],
+    "prerequisites": ["Pell's equation"]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-05/index.ts
+++ b/src/data/proofs/pell-equation-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PellEquationOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pellEquationOq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pellEquationOq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pellEquationOq05Data: ProofData = {
+  proof: pellEquationOq05Proof,
+  annotations: pellEquationOq05Annotations,
+}

--- a/src/data/proofs/pell-equation-oq-05/meta.json
+++ b/src/data/proofs/pell-equation-oq-05/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "pell-equation-oq-05",
+  "slug": "pell-equation-oq-05",
+  "title": "Norm Equations in Degree > 2: The Cubic Pell Chain in ℤ[∛2] and a Non-Norm",
+  "sorries": 0,
+  "description": "Answers the parent's open question on norm equations in number fields of degree greater than 2, worked out concretely for the cubic field K = ℚ(∛2) = ℤ[t]/(t³−2). The cubic norm form N(a,b,c) = a³ + 2b³ + 4c³ − 6abc is shown to be a determinant and multiplicative; u = ∛2 − 1 is a fundamental unit of norm 1, generating a higher-degree Pell chain. Via the real embedding, the chain is injective, so N(ξ) = m has (for any solvable m ≠ 0) infinitely many integral solutions — a zero-or-infinite dichotomy. Finally, working mod 7, the form is anisotropic, so 7 is a non-norm and N is not surjective. All fully verified, 0 sorries, 0 axioms, kernel decide only (no native_decide).",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "PellEquationOQ05",
+    "lineCount": 421,
+    "axiomCount": 0,
+    "theoremCount": 29,
+    "definitionCount": 8,
+    "mainTheorems": [
+      {
+        "name": "cnorm_eq_det",
+        "type": "core",
+        "description": "The cubic norm form N(a,b,c) = a³ + 2b³ + 4c³ − 6abc equals the determinant of the matrix of multiplication-by-(a + bt + ct²) on the power basis {1, t, t²} (t³ = 2) — i.e. it is the concrete Algebra.norm of a + b∛2 + c∛4.",
+        "leanType": "(a b c : ℤ) → cnorm a b c = (!![a, 2*c, 2*b; b, a, 2*c; c, b, a]).det"
+      },
+      {
+        "name": "cnorm_cmul",
+        "type": "core",
+        "description": "The norm form is multiplicative: N(ξ·η) = N(ξ)·N(η). A polynomial identity in the six coordinates (closed by ring) — the engine that turns one unit into an infinite solution chain.",
+        "leanType": "(x y : ℤ × ℤ × ℤ) → cnorm3 (cmul x y) = cnorm3 x * cnorm3 y"
+      },
+      {
+        "name": "cnorm_upow",
+        "type": "key",
+        "description": "Every power uᵏ of the fundamental unit u = ∛2 − 1 has norm 1, giving integral solutions of N(ξ) = 1 — the cubic analogue of the Brahmagupta chain for x² − 2y² = 1.",
+        "leanType": "(k : ℕ) → cnorm3 (upow k) = 1"
+      },
+      {
+        "name": "norm_one_solutions_infinite",
+        "type": "key",
+        "description": "The set of integral solutions of N(ξ) = 1 in ℤ[∛2] is infinite. Via the real embedding φ, φ(uᵏ) = (τ−1)ᵏ is strictly decreasing (base in (0,1)), so k ↦ uᵏ is injective — closing the analytic distinctness gap with no signature/Dirichlet machinery.",
+        "leanType": "{p : ℤ × ℤ × ℤ | cnorm3 p = 1}.Infinite"
+      },
+      {
+        "name": "norm_eq_solutions_infinite",
+        "type": "key",
+        "description": "Zero-or-infinite dichotomy: if N(ξ) = m (m ≠ 0) has one integral solution ξ₀, it has infinitely many — the unit-orbit {ξ₀·uᵏ}. The factorization N(ξ) = φ(ξ)·φ(ξ⋆) forces φ(ξ₀) ≠ 0, keeping the shifted geometric chain injective.",
+        "leanType": "(m : ℤ) → m ≠ 0 → (p₀ : ℤ × ℤ × ℤ) → cnorm3 p₀ = m → {p : ℤ × ℤ × ℤ | cnorm3 p = m}.Infinite"
+      },
+      {
+        "name": "cnorm3_not_surjective",
+        "type": "key",
+        "description": "The cubic norm form is NOT surjective: 7 is never a norm. Since x³ − 2 is irreducible over 𝔽₇ (7 inert), the form is anisotropic mod 7, so 7 ∣ N forces 7 ∣ a,b,c and hence 343 ∣ N — impossible for N = ±7. The empty counterpart to N = 2 having infinitely many solutions.",
+        "leanType": "¬ Function.Surjective cnorm3"
+      }
+    ],
+    "path": "Proofs/PellEquationOQ05.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Dirichlet's unit theorem (degree > 2); formalized in Lean 4",
+    "date": "1846",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ05.lean",
+    "tags": [
+      "number-theory",
+      "pell-equation",
+      "norm-form",
+      "cubic-field",
+      "diophantine",
+      "units",
+      "dirichlet-unit-theorem"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 421,
+    "theoremCount": 29,
+    "definitionCount": 8,
+    "originalContributions": [
+      "cnorm_eq_det: the cubic norm form N(a,b,c) = a³ + 2b³ + 4c³ − 6abc realized as the determinant of the multiplication matrix on the power basis — the concrete Algebra.norm of a + b∛2 + c∛4, computed with no field-theory bearer.",
+      "cnorm_cmul: multiplicativity of the norm form as a single ring identity in six coordinates — the higher-degree analogue of Brahmagupta's composition law.",
+      "cnorm_upow: the higher-degree Pell chain — every power of the fundamental unit u = ∛2 − 1 has norm 1, giving infinitely many solutions of N(ξ) = 1.",
+      "norm_one_solutions_infinite / upow_injective: distinctness of the chain via the real embedding φ (φ(u) = τ − 1 ∈ (0,1)), closing the analytic gap without invoking the signature/Dirichlet machinery Mathlib does not ship for AdjoinRoot (X³−2).",
+      "norm_eq_solutions_infinite: the zero-or-infinite dichotomy for arbitrary m ≠ 0, via the norm-form factorization N(ξ) = φ(ξ)·φ(ξ⋆) (a specialization of x³+y³+z³−3xyz = (x+y+z)(x²+y²+z²−xy−yz−zx)) forcing φ(ξ₀) ≠ 0.",
+      "cnorm3_not_surjective: exhibiting a non-norm — 7 — from anisotropy of the form mod 7 (x³−2 irreducible over 𝔽₇, a finite kernel decide), so which integers are norms is governed by the splitting of primes."
+    ],
+    "problemStatement": "**Open Question (parent pell-equation, OQ-05)**: What happens to the norm equation N_{K/ℚ}(ξ) = m when K is a number field of degree greater than 2?\n\n**This entry**: works out the first genuinely-cubic case K = ℚ(∛2) concretely. Pell's equation x² − Dy² = 1 is the norm-one equation of the real-quadratic field ℚ(√D) and the rank-1 case of Dirichlet's unit theorem; the degree-3 field ℚ(∛2) has the same unit rank (r₁ + r₂ − 1 = 1 for signature (1,1)), so it too has a single fundamental unit and a Pell-like chain. The file formalizes the algebraic core: the cubic norm form, its multiplicativity, the fundamental unit u = ∛2 − 1, the infinitude of solutions of N(ξ) = m for solvable m ≠ 0, and the existence of a non-norm (7).",
+    "text": "A 421-line, fully verified (0 sorries, 0 axioms, kernel decide only — no native_decide) self-contained file over K = ℚ(∛2) = ℤ[t]/(t³−2). The cubic norm form cnorm a b c = a³ + 2b³ + 4c³ − 6abc is defined elementarily and identified with a 3×3 determinant (cnorm_eq_det); cmul is multiplication in the ring, and cnorm_cmul is its one-line multiplicativity. The fundamental unit u = ∛2 − 1 (cnorm_u = 1, inverse t²+t+1) generates the chain upow, all of norm 1 (cnorm_upow). The real embedding phi (a ring homomorphism, phi_cmul) sends uᵏ to (τ−1)ᵏ ∈ (0,1), strictly decreasing, so the chain is injective (upow_injective) and N(ξ) = 1 has infinitely many solutions (norm_one_solutions_infinite). The norm-form factorization cnorm_eq_phi_mul upgrades this to any solvable m ≠ 0 (norm_eq_solutions_infinite), with a worked N = 2 instance. Finally, anisotropy mod 7 (cnorm_anisotropic_mod7, a 7³-triple decide) shows 7 is a non-norm and the form is not surjective (cnorm3_not_surjective).",
+    "proofStrategy": "The norm form is packaged as a determinant (cnorm_eq_det, via Matrix.det_fin_three + ring) and shown multiplicative by expanding cmul and closing with ring (cnorm_cmul). The unit facts cmul_u_uinv, cnorm_u and the small chain values upow_one…upow_four are finite kernel decide. cnorm_upow is induction using multiplicativity and cnorm_u. Distinctness is analytic-at-the-real-place: phi is a ring hom (phi_cmul, cleared by linear_combination · (τ³−2)), so phi(uᵏ) = phi(u)ᵏ (phi_upow); tau_bounds/phi_u_mem pin phi(u) = τ − 1 ∈ (0,1) by nlinarith, and pow_lt_pow_right_of_lt_one₀ gives strict monotonicity, hence injectivity (upow_injective) and Set.infinite_of_injective_forall_mem finishes norm_one_solutions_infinite. For arbitrary m: cnorm_eq_phi_mul factors N(ξ) = φ(ξ)·φ(ξ⋆), so a nonzero norm keeps φ(ξ₀) ≠ 0 (phi_ne_zero_of_cnorm_ne_zero) and the shifted chain injective (cmul_chain_injective). Non-surjectivity: cnorm_anisotropic_mod7 is a finite decide, pulled back along ℤ → ZMod 7 to seven_dvd_cnorm_iff (converse by homogeneity), giving 343 ∣ N and cnorm_ne_seven, cnorm3_not_surjective.",
+    "keyInsights": [
+      "The unit rank of ℚ(∛2) equals that of a real-quadratic field (both are 1: signature (1,1) gives r₁+r₂−1 = 1), so the degree-3 case still has a single fundamental unit and a Pell-like solution chain — the right generalization of x² − Dy² = 1 to degree > 2 is the norm-one equation.",
+      "Multiplicativity of the cubic norm form is one polynomial identity in six coordinates (cnorm_cmul), exactly the higher-degree Brahmagupta composition: it is the whole engine turning a single unit into an infinite family of solutions.",
+      "Distinctness of the chain — the analytically subtle step Dirichlet's theorem normally supplies — is obtained cheaply here from a single real embedding: φ(u) = ∛2 − 1 lies in (0,1), so φ(uᵏ) is strictly decreasing and the powers are pairwise distinct. No signature/Dirichlet machinery is invoked.",
+      "The factorization N(ξ) = φ(ξ)·φ(ξ⋆) (the cubic identity x³+y³+z³−3xyz = (x+y+z)(x²+y²+z²−xy−yz−zx) specialized to (a, b∛2, c∛4)) shows a nonzero norm never vanishes at the real place, yielding the clean dichotomy: N(ξ) = m has zero or infinitely many solutions.",
+      "Which integers are norms is a local/splitting phenomenon: 7 is inert in ℚ(∛2) (x³−2 irreducible over 𝔽₇), so the form is anisotropic mod 7 and 7 enters norms only as a cube — hence 7 is a non-norm and the norm map is not surjective, in sharp contrast to N = 2."
+    ]
+  },
+  "sections": [
+    {
+      "id": "cubic-norm-form",
+      "title": "The Cubic Norm Form as a Determinant",
+      "startLine": 47,
+      "endLine": 64,
+      "summary": "cnorm a b c = a³ + 2b³ + 4c³ − 6abc, and cnorm_eq_det identifying it with the determinant of the multiplication-by-(a+bt+ct²) matrix on the power basis {1,t,t²}, t³ = 2.",
+      "mathContext": "The Algebra.norm of a + b∛2 + c∛4 in ℤ[∛2], computed concretely as a 3×3 determinant."
+    },
+    {
+      "id": "multiplicativity",
+      "title": "Ring Structure and Multiplicativity",
+      "startLine": 65,
+      "endLine": 86,
+      "summary": "cmul (multiplication in ℤ[t]/(t³−2), reducing by t³ = 2), cnorm3 (norm of a coordinate triple), and cnorm_cmul: N(ξ·η) = N(ξ)·N(η), a polynomial identity closed by ring.",
+      "mathContext": "The norm is multiplicative because it is a determinant of a ring representation — the higher-degree Brahmagupta composition law."
+    },
+    {
+      "id": "pell-chain",
+      "title": "The Fundamental Unit and the Higher-Degree Pell Chain",
+      "startLine": 87,
+      "endLine": 121,
+      "summary": "u = ∛2 − 1 with inverse t²+t+1 (cmul_u_uinv), cnorm_u = 1, the chain upow (uᵏ), cnorm_upow (every uᵏ has norm 1), and the first terms upow_one…upow_four.",
+      "mathContext": "A unit of norm 1 generates an infinite family of norm-1 elements — the cubic analogue of the Brahmagupta chain (3,2) → (17,12) → …"
+    },
+    {
+      "id": "distinctness-infinitude",
+      "title": "Distinctness via the Real Embedding, and Infinitude of N = 1",
+      "startLine": 122,
+      "endLine": 202,
+      "summary": "phi (the real embedding a + bτ + cτ²), phi_cmul (ring hom) and phi_upow, tau_bounds and phi_u_mem (φ(u) = τ−1 ∈ (0,1)), upow_injective (strictly decreasing chain), exists_real_cube_root_two, and norm_one_solutions_infinite.",
+      "mathContext": "0 < φ(u) < 1 makes φ(uᵏ) strictly decreasing, so the chain is injective — the analytic distinctness step, without signature/Dirichlet machinery."
+    },
+    {
+      "id": "dichotomy",
+      "title": "N(ξ) = m: Zero or Infinitely Many Solutions",
+      "startLine": 203,
+      "endLine": 285,
+      "summary": "cnorm_eq_phi_mul (norm-form factorization N = φ(ξ)·φ(ξ⋆)), phi_ne_zero_of_cnorm_ne_zero, cmul_chain_injective (the shifted orbit is injective), norm_eq_solutions_infinite (the dichotomy for any m ≠ 0), and the worked instance norm_two_solutions_infinite.",
+      "mathContext": "A nonzero norm cannot vanish at the real place, so a single seed generates an infinite unit-orbit of solutions."
+    },
+    {
+      "id": "non-surjectivity",
+      "title": "The Norm Form Is Not Surjective: 7 Is a Non-Norm",
+      "startLine": 286,
+      "endLine": 368,
+      "summary": "cnorm_anisotropic_mod7 (the form's only zero mod 7 is trivial — a finite kernel decide), seven_dvd_cnorm_iff (7 ∣ N iff 7 divides each coordinate), cnorm_ne_seven / cnorm_ne_neg_seven, norm_eq_seven_no_solution (empty solution set), and cnorm3_not_surjective.",
+      "mathContext": "7 is inert in ℚ(∛2) (x³−2 irreducible over 𝔽₇), so 7 enters norms only as a cube — it is never itself a norm."
+    },
+    {
+      "id": "recovering-pell",
+      "title": "Recovering Classical Pell (Rank-1 Special Case)",
+      "startLine": 369,
+      "endLine": 386,
+      "summary": "The quadratic (Pell) norm form qnorm p q = p² − 2q², its fundamental solution qnorm_fundamental (3² − 2·2² = 1), and the Brahmagupta chain qnorm_chain (17,12), (99,70), (577,408).",
+      "mathContext": "The classical Pell equation is the real-quadratic (degree-2, unit-rank-1) shadow of the same multiplicative picture."
+    }
+  ],
+  "conclusion": {
+    "summary": "For the cubic field K = ℚ(∛2), the norm equation N(ξ) = m is governed by the multiplicativity of the concrete cubic norm form a³ + 2b³ + 4c³ − 6abc together with a single fundamental unit u = ∛2 − 1. The unit powers give a higher-degree Pell chain; the real embedding makes the chain injective, so every solvable N = m (m ≠ 0) has infinitely many integral solutions — the zero-or-infinite dichotomy. Which m occur is a splitting question: 7 is inert, hence a non-norm, and the norm map is not surjective. Classical Pell (degree 2) is the unit-rank-1 shadow of the same structure.",
+    "implications": [
+      "Extends the gallery's Pell cluster from the real-quadratic case to a genuinely cubic field, exhibiting a fundamental unit and its Pell-like chain with only elementary (bearer-free) algebra plus one real embedding.",
+      "Isolates the analytic distinctness step — normally supplied by Dirichlet's unit theorem — as a one-line consequence of 0 < ∛2 − 1 < 1, reusable for other totally-real-place arguments.",
+      "Shows the norm map's image is constrained by prime splitting (7 inert ⇒ non-norm), the higher-degree face of the theory of which integers are represented by a form."
+    ],
+    "openQuestions": [
+      "Identify the unit rank r₁ + r₂ − 1 = 1 of 𝒪_K via the signature (r₁,r₂) = (1,1), i.e. prove card (InfinitePlace (AdjoinRoot (X³−2))) = 2 — the deferred step needing signature-from-minpoly support Mathlib does not ship.",
+      "Characterize exactly which integers are norms from K = ℚ(∛2) in terms of cubic reciprocity / the splitting of primes, generalizing the single non-norm witness 7."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Dirichlet, Peter Gustav Lejeune",
+      "title": "Zur Theorie der complexen Einheiten",
+      "year": "1846",
+      "venue": "Bericht über die Verhandlungen der Königlich Preußischen Akademie der Wissenschaften",
+      "note": "The unit theorem: 𝒪_K has unit rank r₁ + r₂ − 1; for ℚ(∛2) this is 1, hence a single fundamental unit and a Pell-like chain."
+    },
+    {
+      "authors": "Brahmagupta",
+      "title": "Brāhmasphuṭasiddhānta",
+      "year": "628",
+      "venue": "—",
+      "note": "The composition law for x² − Dy², generalized here to the multiplicativity of the cubic norm form."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pell-equation",
+      "relationship": "extends",
+      "description": "Parent: Pell's equation x² − Dy² = 1, the real-quadratic norm-one equation. This entry generalizes the norm equation to the cubic field ℚ(∛2)."
+    },
+    {
+      "targetId": "pell-equation-oq-04",
+      "relationship": "related",
+      "description": "The general quadratic norm form x² − Dy² = N: the degree-2 sibling of the dichotomy 'no solutions or infinitely many' proved here in degree 3."
+    }
+  ]
+}


### PR DESCRIPTION
## Fix

Creates the missing gallery entry for **pell-equation-oq-05** — a verified, 0-axiom Lean proof that was merged to `proofs/Proofs/` but never given a `src/data/proofs/<slug>/` directory, so it was invisible in the web gallery.

## Evidence

**Before**: `proofs/Proofs/PellEquationOQ05.lean` (421 lines, 29 theorems, 8 defs, 0 sorry, 0 axiom, kernel `decide` only) existed on `origin/main` — merged via #31655 and predecessor research PRs — but `src/data/proofs/pell-equation-oq-05/` did not exist and no gallery `meta.json` referenced the file. The proof did not appear in the gallery.

**After**: adds `meta.json` (7 sections, 6 mainTheorems, 6 keyInsights, 6 originalContributions), `annotations.json` (7 line-aligned annotations), and `index.ts`. `pnpm annotations:build` processes the entry with **zero warnings** (all annotations resolve to Lean constructs) and emits it into `listings.json` + `public/data/proofs/pell-equation-oq-05/`.

The proof itself: over the cubic field K = ℚ(∛2) = ℤ[t]/(t³−2), the norm form N(a,b,c) = a³ + 2b³ + 4c³ − 6abc is a determinant and multiplicative; u = ∛2 − 1 is a fundamental unit of norm 1 generating a higher-degree Pell chain; via the real embedding the chain is injective, giving a zero-or-infinite dichotomy for N(ξ) = m; and mod-7 anisotropy exhibits 7 as a non-norm. Status `verified`, badge `verified`, axiomCount 0.

---
Automated fix by lean-mechanic agent.