### PR TITLE
research(inclusion-exclusion-oq-05-oq-01): Boole's inequality + second-order Bonferroni bound as named sieve corollaries [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/InclusionExclusionOQ05OQ01.lean
+++ b/proofs/Proofs/InclusionExclusionOQ05OQ01.lean
@@ -1,0 +1,222 @@
+/-
+# Boole's Inequality and the Second-Order Bonferroni Bound
+
+Open question (inclusion–exclusion family, `inclusion-exclusion-oq-05-oq-01`),
+building on the general Bonferroni inequalities of `inclusion-exclusion-oq-05`
+(`Proofs/BonferroniInequalities.lean`):
+
+  "Package the m = 1 and m = 2 cases as named corollaries (Boole's inequality and
+   the second-order Bonferroni bound) with the powerset sums expanded to
+   ∑ᵢ |Sᵢ| and ∑ᵢ |Sᵢ| − ∑_{i<j} |Sᵢ ∩ Sⱼ|."
+
+The parent file proves the general Bonferroni inequalities: truncating the
+inclusion–exclusion series for `#(⋃_{i∈s} Sᵢ)` at an **odd** number of terms
+overestimates the union, and at an **even** number underestimates it, where the
+truncated value is
+
+  `truncIE s S m = ∑_{k=1}^{m} (-1)^{k+1} ∑_{t ⊆ s, |t|=k} #(⋂_{i∈t} Sᵢ)`.
+
+Here we specialise to the two most-used cases and expand the abstract
+powerset-indexed sums into the concrete indexed forms practitioners quote:
+
+* **m = 1 — Boole's inequality.** The odd truncation at one term gives
+  `#(⋃ᵢ Sᵢ) ≤ ∑ᵢ #(Sᵢ)`, since `truncIE s S 1 = ∑_{i∈s} #(Sᵢ)`.
+
+* **m = 2 — second-order Bonferroni bound.** The even truncation at two terms
+  gives `∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ ∩ Sⱼ) ≤ #(⋃ᵢ Sᵢ)`, since
+  `truncIE s S 2 = ∑_{i∈s} #(Sᵢ) − ∑_{i<j} #(Sᵢ ∩ Sⱼ)`.
+
+The core work is expanding the truncated sums: `sum_interCard_one` rewrites the
+size-1 powerset sum as `∑_{i∈s} #(Sᵢ)` (each singleton `{i}` contributes
+`#(Sᵢ)`), and `sum_interCard_two` rewrites the size-2 powerset sum as the
+strict-pair sum `∑_{i<j} #(Sᵢ ∩ Sⱼ)` via a bijection between 2-element subsets
+and ordered pairs `i < j`.
+
+All results are proved with **0 axioms, 0 sorries**.
+
+Axioms: 0
+Sorries: 0
+
+Reference: Bonferroni, C. E. (1936); Comtet, *Advanced Combinatorics* (1974).
+-/
+
+import Mathlib
+import Proofs.BonferroniInequalities
+
+open Finset
+
+namespace Bonferroni
+
+variable {ι α : Type*} [DecidableEq ι] [DecidableEq α]
+
+/-! ## Expanding the size-1 and size-2 powerset sums -/
+
+/-- A single set contributes its full cardinality: for `i ∈ s`, the number of
+elements of the union lying in `S i` is just `#(S i)` (since `S i ⊆ ⋃_{i∈s} S i`).
+This is `interCard` on the singleton `{i}`. -/
+theorem interCard_singleton {s : Finset ι} {S : ι → Finset α} {i : ι}
+    (hi : i ∈ s) : interCard s S {i} = (S i).card := by
+  have hset : (s.biUnion S).filter (fun a => ∀ j ∈ ({i} : Finset ι), a ∈ S j)
+      = S i := by
+    ext a
+    rw [mem_filter]
+    constructor
+    · rintro ⟨_, h⟩; exact h i (mem_singleton_self i)
+    · intro ha
+      refine ⟨mem_biUnion.2 ⟨i, hi, ha⟩, ?_⟩
+      intro j hj
+      rw [mem_singleton] at hj; subst hj; exact ha
+  rw [interCard, hset]
+
+/-- A pair of sets contributes the cardinality of their intersection: for
+`i, j ∈ s`, the number of elements of the union lying in both `S i` and `S j` is
+`#(S i ∩ S j)`. This is `interCard` on the pair `{i, j}`. -/
+theorem interCard_pair {s : Finset ι} {S : ι → Finset α} {i j : ι}
+    (hi : i ∈ s) (hj : j ∈ s) :
+    interCard s S {i, j} = (S i ∩ S j).card := by
+  have hset : (s.biUnion S).filter (fun a => ∀ k ∈ ({i, j} : Finset ι), a ∈ S k)
+      = S i ∩ S j := by
+    ext a
+    rw [mem_filter, mem_inter]
+    constructor
+    · rintro ⟨_, h⟩
+      exact ⟨h i (by simp), h j (by simp)⟩
+    · rintro ⟨hai, haj⟩
+      refine ⟨mem_biUnion.2 ⟨i, hi, hai⟩, ?_⟩
+      intro k hk
+      rw [mem_insert, mem_singleton] at hk
+      rcases hk with rfl | rfl
+      · exact hai
+      · exact haj
+  rw [interCard, hset]
+
+/-- **Size-1 expansion.** The sum of `interCard` over all singletons `{i}`,
+`i ∈ s`, is `∑_{i∈s} #(S i)`. -/
+theorem sum_interCard_one (s : Finset ι) (S : ι → Finset α) :
+    ∑ t ∈ s.powersetCard 1, interCard s S t = ∑ i ∈ s, (S i).card := by
+  rw [powersetCard_one, Finset.sum_map]
+  apply Finset.sum_congr rfl
+  intro i hi
+  simp only [Function.Embedding.coeFn_mk]
+  exact interCard_singleton hi
+
+/-- **Size-2 expansion.** The sum of `interCard` over all 2-element subsets of `s`
+is the strict-pair sum `∑_{i<j} #(S i ∩ S j)`, where the pairs `i < j` range over
+`(s ×ˢ s)` filtered by `i < j`. Proved via the bijection `{i, j} ↦ (i, j)` (with
+`i < j`) between 2-element subsets and ordered pairs. -/
+theorem sum_interCard_two [LinearOrder ι] (s : Finset ι) (S : ι → Finset α) :
+    ∑ t ∈ s.powersetCard 2, interCard s S t
+      = ∑ p ∈ (s ×ˢ s).filter (fun p => p.1 < p.2), (S p.1 ∩ S p.2).card := by
+  -- 2-element subsets are exactly the images `{p.1, p.2}` of ordered pairs `p.1 < p.2`.
+  have hset : s.powersetCard 2
+      = ((s ×ˢ s).filter (fun p => p.1 < p.2)).image (fun p => {p.1, p.2}) := by
+    ext t
+    simp only [mem_powersetCard, mem_image, mem_filter, mem_product]
+    constructor
+    · rintro ⟨hsub, hcard⟩
+      obtain ⟨x, y, hxy, rfl⟩ := Finset.card_eq_two.1 hcard
+      rcases lt_or_gt_of_ne hxy with h | h
+      · exact ⟨(x, y), ⟨⟨hsub (by simp), hsub (by simp)⟩, h⟩, rfl⟩
+      · refine ⟨(y, x), ⟨⟨hsub (by simp), hsub (by simp)⟩, h⟩, ?_⟩
+        rw [Finset.pair_comm]
+    · rintro ⟨p, ⟨⟨hp1, hp2⟩, hlt⟩, rfl⟩
+      refine ⟨?_, Finset.card_pair (ne_of_lt hlt)⟩
+      intro a ha
+      simp only [mem_insert, mem_singleton] at ha
+      rcases ha with rfl | rfl <;> assumption
+  -- injectivity of `p ↦ {p.1, p.2}` on the strict pairs
+  have hinj : ∀ p ∈ (s ×ˢ s).filter (fun p => p.1 < p.2),
+      ∀ q ∈ (s ×ˢ s).filter (fun p => p.1 < p.2),
+      ({p.1, p.2} : Finset ι) = {q.1, q.2} → p = q := by
+    intro p hp q hq hpq
+    rw [mem_filter, mem_product] at hp hq
+    have hp' : p.1 < p.2 := hp.2
+    have hq' : q.1 < q.2 := hq.2
+    have hpp : p.1 ∈ ({q.1, q.2} : Finset ι) := by rw [← hpq]; simp
+    have hpp2 : p.2 ∈ ({q.1, q.2} : Finset ι) := by rw [← hpq]; simp
+    have hqq : q.1 ∈ ({p.1, p.2} : Finset ι) := by rw [hpq]; simp
+    have hqq2 : q.2 ∈ ({p.1, p.2} : Finset ι) := by rw [hpq]; simp
+    simp only [mem_insert, mem_singleton] at hpp hpp2 hqq hqq2
+    have h1 : p.1 = q.1 := by
+      apply le_antisymm
+      · rcases hqq with h | h
+        · exact le_of_eq h.symm
+        · rw [h]; exact hp'.le
+      · rcases hpp with h | h
+        · exact le_of_eq h.symm
+        · rw [h]; exact hq'.le
+    have h2 : p.2 = q.2 := by
+      apply le_antisymm
+      · rcases hpp2 with h | h
+        · rw [h]; exact hq'.le
+        · exact le_of_eq h
+      · rcases hqq2 with h | h
+        · rw [h]; exact hp'.le
+        · exact le_of_eq h
+    exact Prod.ext h1 h2
+  rw [hset, Finset.sum_image hinj]
+  apply Finset.sum_congr rfl
+  intro p hp
+  rw [mem_filter, mem_product] at hp
+  exact interCard_pair hp.1.1 hp.1.2
+
+/-! ## Casting the expansions to `ℤ` (to match `truncIE`) -/
+
+theorem sum_interCard_one_int (s : Finset ι) (S : ι → Finset α) :
+    ∑ t ∈ s.powersetCard 1, (interCard s S t : ℤ) = ∑ i ∈ s, ((S i).card : ℤ) := by
+  exact_mod_cast sum_interCard_one s S
+
+theorem sum_interCard_two_int [LinearOrder ι] (s : Finset ι) (S : ι → Finset α) :
+    ∑ t ∈ s.powersetCard 2, (interCard s S t : ℤ)
+      = ∑ p ∈ (s ×ˢ s).filter (fun p => p.1 < p.2), ((S p.1 ∩ S p.2).card : ℤ) := by
+  exact_mod_cast sum_interCard_two s S
+
+/-! ## The named corollaries -/
+
+/-- The truncated inclusion–exclusion value at `m = 1` is `∑_{i∈s} #(S i)`. -/
+theorem truncIE_one (s : Finset ι) (S : ι → Finset α) :
+    truncIE s S 1 = ∑ i ∈ s, ((S i).card : ℤ) := by
+  unfold truncIE
+  rw [Finset.Icc_self, Finset.sum_singleton, sum_interCard_one_int,
+    show ((-1 : ℤ)) ^ (1 + 1) = 1 by norm_num, one_mul]
+
+/-- The truncated inclusion–exclusion value at `m = 2` is
+`∑_{i∈s} #(S i) − ∑_{i<j} #(S i ∩ S j)`. -/
+theorem truncIE_two [LinearOrder ι] (s : Finset ι) (S : ι → Finset α) :
+    truncIE s S 2
+      = (∑ i ∈ s, ((S i).card : ℤ))
+        - ∑ p ∈ (s ×ˢ s).filter (fun p => p.1 < p.2), ((S p.1 ∩ S p.2).card : ℤ) := by
+  unfold truncIE
+  rw [show Finset.Icc 1 2 = ({1, 2} : Finset ℕ) by decide,
+    Finset.sum_pair (by norm_num : (1 : ℕ) ≠ 2), sum_interCard_one_int,
+    sum_interCard_two_int]
+  ring
+
+/-- **Boole's inequality** (the `m = 1` Bonferroni bound). The cardinality of a
+finite union is at most the sum of the cardinalities:
+`#(⋃_{i∈s} S i) ≤ ∑_{i∈s} #(S i)`. This is the odd (one-term) truncation of the
+inclusion–exclusion sieve. -/
+theorem boole_inequality (s : Finset ι) (S : ι → Finset α) :
+    ((s.biUnion S).card : ℤ) ≤ ∑ i ∈ s, ((S i).card : ℤ) := by
+  have h := card_biUnion_le_truncIE_odd s S (m := 1) odd_one
+  rwa [truncIE_one] at h
+
+/-- Boole's inequality in `ℕ` (no casts): `#(⋃_{i∈s} S i) ≤ ∑_{i∈s} #(S i)`. -/
+theorem boole_inequality_nat (s : Finset ι) (S : ι → Finset α) :
+    (s.biUnion S).card ≤ ∑ i ∈ s, (S i).card := by
+  have h := boole_inequality s S
+  exact_mod_cast h
+
+/-- **Second-order Bonferroni bound** (the `m = 2` Bonferroni inequality). The
+cardinality of a finite union is at least the first two inclusion–exclusion
+terms: `∑_{i∈s} #(S i) − ∑_{i<j} #(S i ∩ S j) ≤ #(⋃_{i∈s} S i)`. This is the even
+(two-term) truncation of the sieve, with the size-2 powerset sum written as the
+strict-pair sum over `i < j`. -/
+theorem bonferroni_second_order [LinearOrder ι] (s : Finset ι) (S : ι → Finset α) :
+    (∑ i ∈ s, ((S i).card : ℤ))
+      - ∑ p ∈ (s ×ˢ s).filter (fun p => p.1 < p.2), ((S p.1 ∩ S p.2).card : ℤ)
+      ≤ ((s.biUnion S).card : ℤ) := by
+  have h := truncIE_le_card_biUnion_even s S (m := 2) even_two
+  rwa [truncIE_two] at h
+
+end Bonferroni

--- a/src/data/proofs/inclusion-exclusion-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/inclusion-exclusion-oq-05-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-ie0501-docstring",
+    "proofId": "inclusion-exclusion-oq-05-oq-01",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "From the General Sieve to Two Named Corollaries",
+    "content": "The docstring recalls the parent's truncated inclusion–exclusion value $\\mathrm{truncIE}\\,s\\,S\\,m = \\sum_{k=1}^{m} (-1)^{k+1} \\sum_{t \\subseteq s,\\,|t|=k} \\#(\\bigcap_{i\\in t} S_i)$ and states the goal: specialise the parent's odd/even Bonferroni inequalities to $m=1$ and $m=2$, and expand the abstract powerset-indexed sums into the indexed forms $\\sum_i \\#(S_i)$ and $\\sum_i \\#(S_i) - \\sum_{i<j} \\#(S_i \\cap S_j)$. This is open question 1 of the parent inclusion-exclusion-oq-05."
+  },
+  {
+    "id": "ann-ie0501-interCard-singleton",
+    "proofId": "inclusion-exclusion-oq-05-oq-01",
+    "range": { "startLine": 57, "endLine": 72 },
+    "type": "proof-technique",
+    "title": "A Singleton Contributes the Full Cardinality",
+    "content": "`interCard_singleton` shows `interCard s S {i} = #(S i)` for `i ∈ s`. Since `interCard` is defined as the number of elements of the union that lie in every set indexed by the subset, for the singleton `{i}` this is the number of union-elements in `S i` — and because `S i ⊆ ⋃_{i∈s} S i`, that is exactly `#(S i)`. The proof establishes the underlying finset equality `(⋃ S).filter (· ∈ S i) = S i` by extensionality, using `mem_biUnion` for the ⊇ direction."
+  },
+  {
+    "id": "ann-ie0501-interCard-pair",
+    "proofId": "inclusion-exclusion-oq-05-oq-01",
+    "range": { "startLine": 74, "endLine": 93 },
+    "type": "proof-technique",
+    "title": "A Pair Contributes the Intersection Cardinality",
+    "content": "`interCard_pair` shows `interCard s S {i,j} = #(S i ∩ S j)` for `i,j ∈ s`. The filter of the union by membership in every set of `{i,j}` — i.e. in both `S i` and `S j` — is `S i ∩ S j`, again because the intersection sits inside the union. The forall-over-`{i,j}` predicate is unfolded by `mem_insert`/`mem_singleton` and a two-case `rcases`."
+  },
+  {
+    "id": "ann-ie0501-sum-one",
+    "proofId": "inclusion-exclusion-oq-05-oq-01",
+    "range": { "startLine": 95, "endLine": 105 },
+    "type": "key-insight",
+    "title": "Size-1 Expansion: ∑ over singletons = ∑ᵢ #(Sᵢ)",
+    "content": "`sum_interCard_one` rewrites `∑_{t ⊆ s, |t|=1} interCard s S t` as `∑_{i∈s} #(S i)`. The key lemma is `powersetCard_one`, which identifies the size-1 subsets of `s` with the singletons `{i}` (as the image of `s` under the singleton embedding); `Finset.sum_map` then reindexes the sum, and `interCard_singleton` evaluates each term. This is the closed form of the first sieve term."
+  },
+  {
+    "id": "ann-ie0501-sum-two",
+    "proofId": "inclusion-exclusion-oq-05-oq-01",
+    "range": { "startLine": 107, "endLine": 161 },
+    "type": "key-insight",
+    "title": "Size-2 Expansion: ∑ over 2-subsets = ∑_{i<j} #(Sᵢ∩Sⱼ)",
+    "content": "`sum_interCard_two` is the crux: it rewrites `∑_{t ⊆ s, |t|=2} interCard s S t` as the strict-pair sum `∑_{(i,j) : i<j} #(S i ∩ S j)`. With a linear order on the index type, it proves `s.powersetCard 2` is the image of the strict pairs `{(i,j) ∈ s×s : i<j}` under `(i,j) ↦ {i,j}` (each 2-subset `{x,y}` arises from its ordered version), and that this map is injective — the two coordinates of a strict pair are precisely the minimum and maximum of the corresponding 2-element subset, recovered here by an `le_antisymm` argument on membership. `Finset.sum_image` then reindexes and `interCard_pair` evaluates each term. This subset-to-pairs bridge is the step that turns the abstract sieve into the textbook `∑_{i<j}` form."
+  },
+  {
+    "id": "ann-ie0501-cast",
+    "proofId": "inclusion-exclusion-oq-05-oq-01",
+    "range": { "startLine": 163, "endLine": 173 },
+    "type": "concept",
+    "title": "Casting to ℤ to Match the Signed Sieve",
+    "content": "The parent's `truncIE` is an integer-valued alternating sum, so `sum_interCard_one_int` and `sum_interCard_two_int` restate the two expansions with summands cast to `ℤ`, discharged by `exact_mod_cast` from the natural-number versions. This lets the following corollaries rewrite inside `truncIE` directly."
+  },
+  {
+    "id": "ann-ie0501-truncIE-values",
+    "proofId": "inclusion-exclusion-oq-05-oq-01",
+    "range": { "startLine": 177, "endLine": 197 },
+    "type": "proof-technique",
+    "title": "Computing truncIE at m = 1 and m = 2",
+    "content": "`truncIE_one` unfolds the sieve at `m=1`: the index set `Icc 1 1 = {1}`, the sign `(-1)^{1+1}=1`, giving `truncIE s S 1 = ∑ᵢ #(Sᵢ)`. `truncIE_two` unfolds at `m=2`: `Icc 1 2 = {1,2}` (by `decide`), and `Finset.sum_pair` splits the sum into the `k=1` term (sign `+1`) and the `k=2` term (sign `-1`), yielding `∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ)` after `ring`."
+  },
+  {
+    "id": "ann-ie0501-boole",
+    "proofId": "inclusion-exclusion-oq-05-oq-01",
+    "range": { "startLine": 199, "endLine": 213 },
+    "type": "key-insight",
+    "title": "Boole's Inequality (m = 1)",
+    "content": "`boole_inequality` is the union bound `#(⋃ᵢ Sᵢ) ≤ ∑ᵢ #(Sᵢ)`: instantiate the parent's odd-truncation Bonferroni inequality at `m=1` (using `odd_one`) and rewrite with `truncIE_one`. `boole_inequality_nat` restates it in ℕ without casts. This is exactly the first-order sieve bound, recovered as a named corollary."
+  },
+  {
+    "id": "ann-ie0501-second-order",
+    "proofId": "inclusion-exclusion-oq-05-oq-01",
+    "range": { "startLine": 215, "endLine": 222 },
+    "type": "key-insight",
+    "title": "The Second-Order Bonferroni Bound (m = 2)",
+    "content": "`bonferroni_second_order` is the lower bound `∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ) ≤ #(⋃ᵢ Sᵢ)`: instantiate the parent's even-truncation Bonferroni inequality at `m=2` (using `even_two`) and rewrite with `truncIE_two`. This is the sharpest elementary lower bound on a union obtainable from single-set and pairwise-intersection data — the basis of the Bonferroni corrections in statistics."
+  }
+]

--- a/src/data/proofs/inclusion-exclusion-oq-05-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-05-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "inclusion-exclusion-oq-05-oq-01",
+  "title": "Boole's Inequality and the Second-Order Bonferroni Bound",
+  "slug": "inclusion-exclusion-oq-05-oq-01",
+  "description": "Packages the m = 1 and m = 2 cases of the general Bonferroni inequalities as named corollaries: Boole's inequality #(⋃ᵢ Sᵢ) ≤ ∑ᵢ|Sᵢ| and the second-order Bonferroni bound ∑ᵢ|Sᵢ| − ∑_{i<j}|Sᵢ∩Sⱼ| ≤ #(⋃ᵢ Sᵢ), with the abstract powerset-indexed truncated inclusion–exclusion sums expanded into the concrete indexed forms. Builds on inclusion-exclusion-oq-05 (BonferroniInequalities.lean). 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Bonferroni (1936); Boole; indexed-form formalization",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InclusionExclusionOQ05OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "inclusion-exclusion",
+      "bonferroni",
+      "boole-inequality",
+      "finset",
+      "cardinality",
+      "union-bound"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 222,
+    "assumptions": "None. 0 axiom declarations, 0 sorries, 0 structure-encoded assumptions. Proofs use only kernel-checked tactics (decide is kernel Decidable-reduction, not native_decide; plus le_antisymm, simp, ring, exact_mod_cast). Imports and extends the verified parent Proofs/BonferroniInequalities.lean. Elaborates cleanly against Mathlib.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The inclusion–exclusion principle expresses the cardinality (or probability) of a union as an alternating sum over intersections. George Boole (1854) recorded the first-order bound #(⋃ᵢ Sᵢ) ≤ ∑ᵢ #(Sᵢ) — 'Boole's inequality', the union bound ubiquitous in probability and combinatorics. Carlo Emilio Bonferroni (1936) generalised this to a family of two-sided bounds: truncating the inclusion–exclusion series after an odd number of terms overestimates the union, and after an even number underestimates it. The second-order lower bound ∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ) ≤ #(⋃ᵢ Sᵢ) underlies the Bonferroni corrections for simultaneous statistical inference. The parent entry inclusion-exclusion-oq-05 formalizes the general Bonferroni inequalities via a pointwise binomial argument; this entry extracts the two classical named corollaries and expands the abstract powerset sums into the indexed forms that appear in textbooks.",
+    "problemStatement": "Package the m = 1 and m = 2 cases of the general Bonferroni inequalities as named corollaries — Boole's inequality and the second-order Bonferroni bound — with the powerset-indexed truncated inclusion–exclusion sums expanded to ∑ᵢ |Sᵢ| and ∑ᵢ |Sᵢ| − ∑_{i<j} |Sᵢ ∩ Sⱼ|.",
+    "text": "The parent file's truncated sieve value is truncIE s S m = ∑_{k=1}^{m} (-1)^{k+1} ∑_{t ⊆ s, |t|=k} #(⋂_{i∈t} Sᵢ). The task is to compute this at m = 1 and m = 2 in closed indexed form and combine with the parent's odd/even Bonferroni inequalities to obtain the two named classical bounds.",
+    "proofStrategy": "Two expansion lemmas do the real work. `sum_interCard_one` rewrites the size-1 powerset sum ∑_{|t|=1} #(⋂_{i∈t} Sᵢ) as ∑_{i∈s} #(Sᵢ), using powersetCard_one (size-1 subsets are the singletons) and interCard_singleton (each singleton {i} contributes #(Sᵢ), since Sᵢ ⊆ ⋃ᵢ Sᵢ). `sum_interCard_two` rewrites the size-2 powerset sum as the strict-pair sum ∑_{i<j} #(Sᵢ∩Sⱼ): assuming a linear order on the index type, 2-element subsets biject with ordered pairs (i,j), i<j, via {i,j} ↦ (i,j); the bijection is established by expressing powersetCard 2 as an image and proving injectivity of {p₁,p₂} ↦ p (each coordinate recovered as the min/max of the pair by antisymmetry). Casting to ℤ, truncIE_one and truncIE_two compute the truncated values, and the named corollaries follow by rewriting the parent's card_biUnion_le_truncIE_odd (at m=1) and truncIE_le_card_biUnion_even (at m=2).",
+    "keyInsights": [
+      "**Boole = first Bonferroni term.** Boole's inequality is exactly the odd (one-term) truncation of the inclusion–exclusion sieve: the parent's odd bound at m = 1 with truncIE s S 1 = ∑ᵢ #(Sᵢ).",
+      "**The second-order bound is the even truncation at m = 2**, giving the sharpest elementary lower bound on a union from single and pairwise data: ∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ).",
+      "**Singleton and pair evaluation.** interCard on a singleton {i} is #(Sᵢ) and on a pair {i,j} is #(Sᵢ∩Sⱼ); the phrasing of interCard as a filter over the union (rather than an Finset.inf') makes both immediate from Sᵢ ⊆ ⋃ᵢ Sᵢ.",
+      "**2-subsets ↔ ordered pairs.** The step from the powerset-indexed sum to the practitioner's ∑_{i<j} requires a linear order on indices and a bijection between 2-element subsets and strict pairs; injectivity is the observation that the two coordinates of a strict pair are the min and max of the corresponding 2-subset.",
+      "**Reuse over re-proof.** The heavy pointwise binomial inequality lives in the parent; this entry only performs the algebraic expansion, illustrating how a general theorem specialises to its famous named cases."
+    ],
+    "prerequisites": [
+      "Finset combinatorics (biUnion, powersetCard, filter, products)",
+      "The inclusion–exclusion / sieve principle",
+      "Basic order theory (linear orders, min/max, antisymmetry)",
+      "The general Bonferroni inequalities (parent entry inclusion-exclusion-oq-05)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-ie0501-preamble",
+      "title": "Documentation and Imports",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Module docstring recalling the parent's truncated inclusion–exclusion value truncIE and stating the two target corollaries with their expanded indexed sums. Imports Mathlib and the parent BonferroniInequalities module, and reopens the Bonferroni namespace to reuse interCard, truncIE, and the odd/even Bonferroni inequalities."
+    },
+    {
+      "id": "sec-ie0501-eval",
+      "title": "Evaluating interCard on Singletons and Pairs",
+      "startLine": 52,
+      "endLine": 93,
+      "summary": "interCard_singleton proves interCard s S {i} = #(S i) for i ∈ s (the filter of the union by membership in S i is S i itself). interCard_pair proves interCard s S {i,j} = #(S i ∩ S j) for i,j ∈ s (the filter by membership in both is the intersection)."
+    },
+    {
+      "id": "sec-ie0501-expand",
+      "title": "Expanding the Size-1 and Size-2 Powerset Sums",
+      "startLine": 95,
+      "endLine": 162,
+      "summary": "sum_interCard_one rewrites the size-1 powerset sum as ∑_{i∈s} #(S i) via powersetCard_one. sum_interCard_two rewrites the size-2 powerset sum as the strict-pair sum ∑_{i<j} #(S i ∩ S j), proving powersetCard 2 equals the image of strict pairs under {·,·} and that this map is injective (each coordinate is the min/max of the 2-subset)."
+    },
+    {
+      "id": "sec-ie0501-cast",
+      "title": "Casting the Expansions to ℤ",
+      "startLine": 163,
+      "endLine": 173,
+      "summary": "sum_interCard_one_int and sum_interCard_two_int restate the two expansions with the summands cast to ℤ (via exact_mod_cast), matching the signed integer form of the parent's truncIE."
+    },
+    {
+      "id": "sec-ie0501-corollaries",
+      "title": "The Named Corollaries",
+      "startLine": 174,
+      "endLine": 222,
+      "summary": "truncIE_one and truncIE_two compute truncIE s S 1 = ∑ᵢ#(Sᵢ) and truncIE s S 2 = ∑ᵢ#(Sᵢ) − ∑_{i<j}#(Sᵢ∩Sⱼ). boole_inequality (with boole_inequality_nat) and bonferroni_second_order then follow by rewriting the parent's odd/even Bonferroni inequalities at m = 1 and m = 2."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers open question 1 of inclusion-exclusion-oq-05: the general Bonferroni inequalities are specialised to their two classical named cases — Boole's inequality (m = 1) and the second-order Bonferroni bound (m = 2) — with the abstract powerset-indexed sieve sums expanded into the concrete indexed forms ∑ᵢ #(Sᵢ) and ∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ). All results are machine-checked with 0 axioms and 0 sorries, reusing the parent's pointwise machinery.",
+    "implications": "Boole's inequality is the union bound at the heart of probabilistic combinatorics and the first moment method; the second-order Bonferroni bound is the basis of Bonferroni corrections in simultaneous statistical inference. Having them as named, indexed-form corollaries of a single verified sieve makes them directly reusable. The powerset-to-pairs bijection (sum_interCard_two) is a reusable bridge between subset-indexed and coordinate-indexed sums that recurs throughout enumerative combinatorics.",
+    "openQuestions": [
+      "Transport the inequalities to the dual sieve form #(none of Sᵢ) via the bridge #(none) = |α| − |⋃ Sᵢ| of inclusion-exclusion-oq-04 (parent open question 2).",
+      "State the measure-theoretic Bonferroni inequalities for a finite measure (probabilities of unions of events) by replacing cardinality with measure and reusing the same pointwise argument (parent open question 3).",
+      "Provide the higher named cases (third- and fourth-order Bonferroni bounds) with their triple- and quadruple-intersection sums."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "inclusion-exclusion-oq-05",
+      "relationship": "extends",
+      "description": "Specialises the general Bonferroni inequalities (card_biUnion_le_truncIE_odd / truncIE_le_card_biUnion_even) to m = 1 and m = 2, reusing interCard and truncIE directly by reopening the Bonferroni namespace."
+    },
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "related",
+      "description": "Boole's inequality and the second-order Bonferroni bound are the first truncations of the inclusion–exclusion sieve."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Bonferroni, C. E."
+      ],
+      "title": "Teoria statistica delle classi e calcolo delle probabilità",
+      "year": 1936,
+      "venue": "Pubblicazioni del R. Istituto Superiore di Scienze Economiche e Commerciali di Firenze 8, pp. 3–62",
+      "note": "Original two-sided Bonferroni inequalities generalising Boole's bound."
+    },
+    {
+      "authors": [
+        "Boole, G."
+      ],
+      "title": "An Investigation of the Laws of Thought",
+      "year": 1854,
+      "venue": "Walton and Maberly, London",
+      "note": "Source of the first-order union bound (Boole's inequality)."
+    },
+    {
+      "authors": [
+        "Comtet, L."
+      ],
+      "title": "Advanced Combinatorics: The Art of Finite and Infinite Expansions",
+      "year": 1974,
+      "venue": "D. Reidel Publishing Company",
+      "note": "Inclusion–exclusion, Bonferroni inequalities, and sieve methods."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BonferroniInequalities"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Bonferroni",
+    "lineCount": 222,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/InclusionExclusionOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question 1** of `inclusion-exclusion-oq-05`: package the `m = 1` and `m = 2` cases of the general Bonferroni inequalities as named corollaries, with the abstract powerset-indexed truncated inclusion–exclusion sums expanded into the concrete indexed forms.

- **Boole's inequality** (`m = 1`): `#(⋃ᵢ Sᵢ) ≤ ∑ᵢ #(Sᵢ)`, since `truncIE s S 1 = ∑ᵢ #(Sᵢ)`.
- **Second-order Bonferroni bound** (`m = 2`): `∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ) ≤ #(⋃ᵢ Sᵢ)`, since `truncIE s S 2 = ∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ)`.

## Approach

The heavy pointwise binomial argument already lives in the verified parent `Proofs/BonferroniInequalities.lean`. This entry reopens the `Bonferroni` namespace and performs the algebraic expansion:

- `interCard_singleton` / `interCard_pair` — a size-1 subset `{i}` contributes `#(Sᵢ)` and a size-2 subset `{i,j}` contributes `#(Sᵢ∩Sⱼ)` (both immediate from `Sᵢ ⊆ ⋃ Sᵢ`).
- `sum_interCard_one` — the size-1 powerset sum equals `∑ᵢ #(Sᵢ)` via `powersetCard_one`.
- `sum_interCard_two` — the size-2 powerset sum equals the strict-pair sum `∑_{i<j} #(Sᵢ∩Sⱼ)` via a bijection between 2-element subsets and ordered pairs `i<j` (injectivity: each coordinate is the min/max of the 2-subset, by `le_antisymm`).
- `truncIE_one` / `truncIE_two` compute the truncated values; the named corollaries follow by rewriting the parent's `card_biUnion_le_truncIE_odd` (`m=1`) and `truncIE_le_card_biUnion_even` (`m=2`).

## Verification
- `lake env lean proofs/Proofs/InclusionExclusionOQ05OQ01.lean` — clean elaboration, **0 errors, 0 sorries** (teardown SIGSEGV from `import Mathlib` is the known cosmetic issue; elaboration succeeds).
- **0 axioms**, no `native_decide` (`decide` here is kernel `Decidable`-reduction). 11 theorems, 222 lines.
- New gallery entry `src/data/proofs/inclusion-exclusion-oq-05-oq-01/` (meta + 9 annotations), `status: verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)