### PR TITLE
research(derangements-convergence-oq-05-oq-03): all factorial moments of the fixed-point count = 1 (Poisson(1) hallmark) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ05OQ03.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ05OQ03.lean
@@ -1,0 +1,162 @@
+import Mathlib.Combinatorics.Derangements.Finite
+import Mathlib.Tactic
+
+/-
+# Factorial Moments of the Fixed-Point Count Are All 1 (Poisson(1) Hallmark)
+
+Let `X_n = #{fixed points of a uniformly random σ ∈ S_n}`. This file proves that
+every falling-factorial ("factorial") moment of `X_n` equals `1`:
+
+  E[(X_n)_r] = E[ X_n (X_n - 1) ⋯ (X_n - r + 1) ] = 1        for all 0 ≤ r ≤ n.
+
+This is the signature of the Poisson(1) distribution: a Poisson(λ) variable has
+`r`-th factorial moment `λ^r`, so `λ = 1` gives all factorial moments equal to `1`.
+It is the exact, finite-`n` analogue of the parent's asymptotic statement
+`D_k(n)/n! → e⁻¹/k!` (`derangements-convergence-oq-05`).
+
+## Proof
+
+Working with counts rather than measures, the expectation of a function `g` of
+`σ` is `(1/n!) ∑_{σ ∈ S_n} g(σ)`, so the claim `E[(X_n)_r] = 1` is the sum identity
+
+  `∑_{σ ∈ S_n} (X_n(σ))_r = n!`.                                     (★)
+
+The falling factorial counts ordered `r`-tuples of distinct fixed points, and
+`(X)_r = r! · C(X, r)`, where `C(X, r)` counts the `r`-element *subsets* of the
+fixed-point set. Summing over `σ` and swapping the order of summation,
+
+  `∑_σ (X_σ)_r = r! · ∑_{|S| = r} #{ σ : S ⊆ Fix σ }`,
+
+and a permutation fixes a given `r`-set `S` pointwise iff it restricts to an
+arbitrary permutation of the complement, of which there are `(n - r)!`
+(`card_perm_fixesPointwise`). Hence
+
+  `∑_σ (X_σ)_r = r! · C(n, r) · (n - r)! = n!`
+
+by `Nat.choose_mul_factorial_mul_factorial`.
+
+## Main results
+
+* `card_perm_fixesPointwise` : for a set `S`, `#{ σ ∈ S_n : σ fixes S pointwise } = (n - |S|)!`.
+* `sum_descFactorial_fixedPoints` : the sum identity (★), `∑_σ (X_σ)_r = n!` for `r ≤ n`.
+* `factorial_moment_eq_one` : the `r`-th factorial moment `E[(X_n)_r] = 1` (as a real).
+
+The `card_perm_fixesPointwise` counting lemma reuses Mathlib's
+`Equiv.Perm.subtypeEquivSubtypePerm` (permutations of a subtype ≃ permutations of
+the whole type fixing the rest pointwise); the factorial-moment identity is not in
+Mathlib.
+-/
+
+open Equiv Function Finset
+open scoped BigOperators
+
+namespace DerangementsFactorialMoments
+
+variable {n : ℕ}
+
+/-- The fixed-point set of `σ`, as a `Finset`. -/
+private abbrev fixedSet (σ : Perm (Fin n)) : Finset (Fin n) :=
+  univ.filter (fun i => σ i = i)
+
+/-- **Counting permutations that fix a set pointwise.** For any `S ⊆ Fin n`, the
+permutations of `Fin n` that fix every element of `S` are in bijection with the
+permutations of the complement `Sᶜ`; hence there are `(n - |S|)!` of them.
+
+A permutation fixing `S` pointwise necessarily permutes the complement, and
+conversely any permutation of the complement extends by the identity on `S`. -/
+theorem card_perm_fixesPointwise (S : Finset (Fin n)) :
+    (univ.filter (fun σ : Perm (Fin n) => ∀ i ∈ S, σ i = i)).card
+      = (n - S.card).factorial := by
+  classical
+  rw [← Fintype.card_subtype]
+  -- `Perm ↥Sᶜ ≃ {σ // σ fixes S pointwise}` via `subtypeEquivSubtypePerm (· ∉ S)`.
+  let e : Perm {a : Fin n // a ∉ S} ≃ {σ : Perm (Fin n) // ∀ i ∈ S, σ i = i} :=
+    (Equiv.Perm.subtypeEquivSubtypePerm (fun a : Fin n => a ∉ S)).trans
+      (Equiv.subtypeEquivRight (by intro σ; simp only [not_not]))
+  rw [← Fintype.card_congr e, Fintype.card_perm]
+  -- `card {a // a ∉ S} = n - |S|`.
+  have h1 : Fintype.card {a : Fin n // a ∈ S} = S.card := by simp
+  have hcard : Fintype.card {a : Fin n // a ∉ S} = n - S.card := by
+    rw [Fintype.card_subtype_compl, Fintype.card_fin, h1]
+  rw [hcard]
+
+/-- **The factorial-moment sum identity (★).** Summing the `r`-th falling factorial
+of the fixed-point count over all permutations of `Fin n` gives exactly `n!`, for
+every `r ≤ n`. Dividing by `n!` yields `E[(X_n)_r] = 1`. -/
+theorem sum_descFactorial_fixedPoints (n r : ℕ) (hr : r ≤ n) :
+    ∑ σ : Perm (Fin n), ((fixedSet σ).card).descFactorial r = n.factorial := by
+  classical
+  -- Rewrite each falling factorial as `r! · #{r-subsets of the fixed set}`, expressed
+  -- as a sum of indicators over the `r`-subsets `S` of `Fin n`.
+  have hterm : ∀ σ : Perm (Fin n),
+      ((fixedSet σ).card).descFactorial r
+        = r.factorial * ∑ S ∈ powersetCard r (univ : Finset (Fin n)),
+            (if S ⊆ fixedSet σ then 1 else 0) := by
+    intro σ
+    rw [Nat.descFactorial_eq_factorial_mul_choose]
+    congr 1
+    -- `C(|F|, r) = |powersetCard r F| = ∑_{|S|=r} [S ⊆ F]`.
+    rw [← Finset.card_powersetCard]
+    have hsub : powersetCard r (fixedSet σ)
+        = (powersetCard r (univ : Finset (Fin n))).filter (· ⊆ fixedSet σ) := by
+      ext T
+      simp only [mem_powersetCard, mem_filter, Finset.subset_univ, true_and]
+      tauto
+    rw [hsub, Finset.card_filter]
+  rw [Finset.sum_congr rfl (fun σ _ => hterm σ)]
+  -- Pull `r!` out and swap the order of summation.
+  rw [← Finset.mul_sum, Finset.sum_comm]
+  -- The inner sum over `σ` counts permutations fixing `S` pointwise: `(n - |S|)!`.
+  have hinner : ∀ S ∈ powersetCard r (univ : Finset (Fin n)),
+      ∑ σ : Perm (Fin n), (if S ⊆ fixedSet σ then 1 else 0) = (n - r).factorial := by
+    intro S hS
+    rw [Finset.mem_powersetCard] at hS
+    have hcard : (univ.filter (fun σ : Perm (Fin n) => S ⊆ fixedSet σ)).card
+        = (n - S.card).factorial := by
+      have : (univ.filter (fun σ : Perm (Fin n) => S ⊆ fixedSet σ))
+          = univ.filter (fun σ : Perm (Fin n) => ∀ i ∈ S, σ i = i) := by
+        apply Finset.filter_congr
+        intro σ _
+        constructor
+        · intro h i hi
+          have := h hi
+          simp only [fixedSet, mem_filter, mem_univ, true_and] at this
+          exact this
+        · intro h x hx
+          simp only [fixedSet, mem_filter, mem_univ, true_and]
+          exact h x hx
+      rw [this, card_perm_fixesPointwise]
+    rw [← Finset.card_filter]
+    rw [hcard, hS.2]
+  rw [Finset.sum_congr rfl hinner, Finset.sum_const, Finset.card_powersetCard,
+    Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+  -- `r! · C(n,r) · (n-r)! = n!`.
+  rw [← Nat.choose_mul_factorial_mul_factorial hr]
+  ring
+
+/-- **The factorial moments are all `1`.** For `r ≤ n`, the `r`-th factorial moment
+of the fixed-point count `X_n` of a uniform random permutation equals `1`:
+
+  `E[(X_n)_r] = (1/n!) ∑_{σ} (X_n(σ))_r = 1`.
+
+This is the defining property of a Poisson(1) variable (`λ^r` with `λ = 1`). -/
+theorem factorial_moment_eq_one (n r : ℕ) (hr : r ≤ n) :
+    (∑ σ : Perm (Fin n), ((fixedSet σ).card).descFactorial r : ℝ)
+        / (Fintype.card (Perm (Fin n)) : ℝ) = 1 := by
+  rw [Fintype.card_perm, Fintype.card_fin]
+  have h : (∑ σ : Perm (Fin n), ((fixedSet σ).card).descFactorial r : ℝ)
+      = (n.factorial : ℝ) := by
+    exact_mod_cast sum_descFactorial_fixedPoints n r hr
+  rw [h]
+  have hne : (n.factorial : ℝ) ≠ 0 := by
+    exact_mod_cast n.factorial_ne_zero
+  field_simp
+
+/-- **`r = 1`: the expected number of fixed points is `1`.** A specialization of the
+general identity (the mean of the Poisson(1) limit). -/
+theorem sum_card_fixedPoints (n : ℕ) (hn : 1 ≤ n) :
+    ∑ σ : Perm (Fin n), (fixedSet σ).card = n.factorial := by
+  have := sum_descFactorial_fixedPoints n 1 hn
+  simpa using this
+
+end DerangementsFactorialMoments

--- a/src/data/proofs/derangements-convergence-oq-05-oq-03/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-05-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-derangements-oq0503-header",
+    "proofId": "derangements-convergence-oq-05-oq-03",
+    "range": { "startLine": 4, "endLine": 48 },
+    "type": "concept",
+    "title": "The Poisson(1) hallmark: all factorial moments equal 1",
+    "content": "The module docstring frames the result. Let X_n count the fixed points of a uniform random permutation of an n-set. A Poisson(λ) variable is characterised by its factorial moments E[(X)_r] = λ^r; taking λ = 1 makes every factorial moment equal to 1. This entry proves exactly that for X_n, at every finite n with r ≤ n — the moment-side counterpart of the parent's asymptotic mass function D_k(n)/n! → e⁻¹/k!. Working with counts rather than measures, E[(X_n)_r] = 1 is the sum identity ∑_σ (X_σ)_r = n!, and the docstring lays out the double-counting route to it.",
+    "mathContext": "$\\mathbb{E}[(X_n)_r] = \\mathbb{E}[X_n(X_n-1)\\cdots(X_n-r+1)] = 1$ for all $0 \\le r \\le n$; equivalently $\\sum_{\\sigma \\in S_n}(X_\\sigma)_r = n!$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Poisson approximation",
+      "factorial moments",
+      "method of moments",
+      "fixed points of permutations"
+    ],
+    "prerequisites": [
+      "the parent fixed-point distribution entry",
+      "the falling (descending) factorial as a count of ordered tuples"
+    ]
+  },
+  {
+    "id": "ann-derangements-oq0503-fixedset",
+    "proofId": "derangements-convergence-oq-05-oq-03",
+    "range": { "startLine": 57, "endLine": 59 },
+    "type": "definition",
+    "title": "The fixed-point set and the random variable X_n",
+    "content": "fixedSet σ is the Finset {i : σ i = i} of fixed points of σ, defined as univ.filter (fun i => σ i = i). Its cardinality #(fixedSet σ) is the integer-valued random variable X_n whose moments the file studies. Phrasing fixed points as a Finset (rather than a Set) makes the cardinality, its binomial coefficients, and the subset double count all computable with Finset lemmas.",
+    "mathContext": "$X_\\sigma = |\\mathrm{Fix}\\,\\sigma| = |\\{i : \\sigma(i) = i\\}|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["fixed point", "cardinality", "Finset.filter"],
+    "prerequisites": ["permutations of a finite type"]
+  },
+  {
+    "id": "ann-derangements-oq0503-fixespointwise",
+    "proofId": "derangements-convergence-oq-05-oq-03",
+    "range": { "startLine": 61, "endLine": 81 },
+    "type": "technique",
+    "title": "Counting permutations that fix a set pointwise: (n − |S|)!",
+    "content": "card_perm_fixesPointwise is the one non-trivial combinatorial input. For any set S ⊆ Fin n, the permutations that fix every element of S are exactly the permutations of the complement Sᶜ extended by the identity on S — there are (n − |S|)! of them. The proof builds the bijection {σ : σ fixes S pointwise} ≃ Perm ↥Sᶜ from Mathlib's Equiv.Perm.subtypeEquivSubtypePerm applied to the predicate p := (· ∉ S): its codomain {f : Perm α // ∀ a, ¬p a → f a = a} unfolds (via not_not) to permutations fixing S. Then Fintype.card_perm gives (card ↥Sᶜ)! and Fintype.card_subtype_compl computes card ↥Sᶜ = n − |S|. This is the 'fix at least S' analogue of the parent's 'fix exactly S = derangement of the complement' lemma.",
+    "mathContext": "$\\#\\{\\sigma \\in S_n : \\forall i \\in S,\\ \\sigma(i) = i\\} = (n - |S|)!$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Equiv.Perm.subtypeEquivSubtypePerm",
+      "permutation of a complement",
+      "Fintype cardinality"
+    ],
+    "prerequisites": [
+      "permutations of a subtype extend by the identity",
+      "Fintype.card_perm and Fintype.card_subtype_compl"
+    ]
+  },
+  {
+    "id": "ann-derangements-oq0503-sumidentity",
+    "proofId": "derangements-convergence-oq-05-oq-03",
+    "range": { "startLine": 83, "endLine": 135 },
+    "type": "key-step",
+    "title": "The double count: ∑_σ (X_σ)_r = n!",
+    "content": "sum_descFactorial_fixedPoints is the combinatorial heart. First (hterm) each falling factorial is rewritten via Nat.descFactorial_eq_factorial_mul_choose as (X_σ)_r = r!·C(#Fix σ, r), and C(#Fix σ, r) is expanded as ∑ over the r-subsets S of Fin n of the indicator [S ⊆ Fix σ] (using powersetCard_r F = filter (· ⊆ F) over powersetCard_r univ, then Finset.card_filter). Pulling out r! and applying Finset.sum_comm swaps ∑_σ ∑_S for ∑_S ∑_σ. The inner sum (hinner) counts permutations with S ⊆ Fix σ; the condition S ⊆ Fix σ is exactly ∀ i ∈ S, σ i = i, so card_perm_fixesPointwise gives (n − |S|)! = (n − r)! for each r-subset S. Summing the constant over the C(n,r) subsets and simplifying yields r!·C(n,r)·(n−r)!, which Nat.choose_mul_factorial_mul_factorial collapses to n!.",
+    "mathContext": "$\\sum_{\\sigma} (X_\\sigma)_r = r!\\sum_{|S|=r}\\#\\{\\sigma : S \\subseteq \\mathrm{Fix}\\,\\sigma\\} = r!\\binom{n}{r}(n-r)! = n!$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "double counting",
+      "Finset.sum_comm",
+      "falling factorial as an r-tuple count",
+      "binomial coefficient as a subset count"
+    ],
+    "prerequisites": [
+      "card_perm_fixesPointwise",
+      "descFactorial = r!·choose",
+      "choose·r!·(n−r)! = n!"
+    ]
+  },
+  {
+    "id": "ann-derangements-oq0503-moment",
+    "proofId": "derangements-convergence-oq-05-oq-03",
+    "range": { "startLine": 137, "endLine": 154 },
+    "type": "key-step",
+    "title": "Dividing by |S_n|: the moment equals 1",
+    "content": "factorial_moment_eq_one turns the count identity into the probabilistic statement. The uniform expectation over S_n is the sum divided by |S_n| = Fintype.card (Perm (Fin n)) = n! (Fintype.card_perm, Fintype.card_fin). Casting the sum identity to ℝ gives numerator = n!, and since n! ≠ 0 the quotient n!/n! = 1 by field_simp. This is E[(X_n)_r] = 1 stated directly as a real ratio — the exact, error-free Poisson(1) fingerprint at finite n.",
+    "mathContext": "$\\mathbb{E}[(X_n)_r] = \\dfrac{\\sum_\\sigma (X_\\sigma)_r}{|S_n|} = \\dfrac{n!}{n!} = 1$.",
+    "significance": "important",
+    "relatedConcepts": ["uniform expectation", "Fintype.card_perm", "factorial nonzero"],
+    "prerequisites": ["the sum identity ∑_σ (X_σ)_r = n!", "|S_n| = n!"]
+  },
+  {
+    "id": "ann-derangements-oq0503-mean",
+    "proofId": "derangements-convergence-oq-05-oq-03",
+    "range": { "startLine": 155, "endLine": 162 },
+    "type": "concept",
+    "title": "The r = 1 case: a random permutation has one fixed point on average",
+    "content": "sum_card_fixedPoints specializes the general identity to r = 1: since (X)_1 = X, the sum identity reads ∑_σ #Fix σ = n!, i.e. the average number of fixed points of a uniform random permutation is exactly 1. This is the classical mean of the Poisson(1) limit, and here it drops out as a one-line corollary (simpa) of the r-th factorial moment result — a small sanity check that the general statement specialises correctly.",
+    "mathContext": "$\\sum_{\\sigma} |\\mathrm{Fix}\\,\\sigma| = n!$, so $\\mathbb{E}[X_n] = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["expected number of fixed points", "mean of Poisson(1)"],
+    "prerequisites": ["descFactorial · 1 = identity", "the general factorial-moment identity"]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-05-oq-03/index.ts
+++ b/src/data/proofs/derangements-convergence-oq-05-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DerangementsConvergenceOQ05OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const derangementsConvergenceOQ05OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const derangementsConvergenceOQ05OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const derangementsConvergenceOQ05OQ03Data: ProofData = {
+  proof: derangementsConvergenceOQ05OQ03Proof,
+  annotations: derangementsConvergenceOQ05OQ03Annotations,
+}

--- a/src/data/proofs/derangements-convergence-oq-05-oq-03/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-05-oq-03/meta.json
@@ -1,0 +1,230 @@
+{
+  "id": "derangements-convergence-oq-05-oq-03",
+  "title": "Factorial Moments of the Fixed-Point Count Are All 1 (Poisson(1) Hallmark)",
+  "slug": "derangements-convergence-oq-05-oq-03",
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Derangements.Finite",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Equiv",
+      "Function",
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "DerangementsFactorialMoments",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "substantiveTheoremCount": 4,
+    "duplicateTheorems": 0,
+    "definitionCount": 1,
+    "path": "Proofs/DerangementsConvergenceOQ05OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "factorial_moment_eq_one",
+      "type": "core",
+      "description": "For r ≤ n, the r-th factorial moment of the fixed-point count X_n of a uniform random permutation of Fin n equals 1: (∑_σ (X_σ)_r)/|S_n| = 1. The exact algebraic hallmark of the Poisson(1) limit at finite n.",
+      "leanType": "(n r : ℕ) → r ≤ n → (∑ σ : Perm (Fin n), ((fixedSet σ).card).descFactorial r : ℝ) / (Fintype.card (Perm (Fin n)) : ℝ) = 1"
+    },
+    {
+      "name": "sum_descFactorial_fixedPoints",
+      "type": "core",
+      "description": "The combinatorial core: ∑_{σ ∈ S_n} (X_σ)_r = n! for r ≤ n, where (X_σ)_r = descFactorial(#Fix σ, r).",
+      "leanType": "(n r : ℕ) → r ≤ n → ∑ σ : Perm (Fin n), ((fixedSet σ).card).descFactorial r = n.factorial"
+    },
+    {
+      "name": "card_perm_fixesPointwise",
+      "type": "supporting",
+      "description": "For any S ⊆ Fin n, the number of permutations fixing every element of S is (n − |S|)!.",
+      "leanType": "(S : Finset (Fin n)) → (univ.filter (fun σ : Perm (Fin n) => ∀ i ∈ S, σ i = i)).card = (n - S.card).factorial"
+    },
+    {
+      "name": "sum_card_fixedPoints",
+      "type": "supporting",
+      "description": "The r = 1 corollary: ∑_σ #Fix σ = n! for n ≥ 1, i.e. the expected number of fixed points is 1.",
+      "leanType": "(n : ℕ) → 1 ≤ n → ∑ σ : Perm (Fin n), (fixedSet σ).card = n.factorial"
+    }
+  ],
+  "description": "Let X_n count the fixed points of a uniformly random permutation of an n-element set. This entry proves that every falling-factorial moment of X_n equals 1: E[(X_n)_r] = E[X_n(X_n−1)⋯(X_n−r+1)] = 1 for all 0 ≤ r ≤ n. Since a Poisson(λ) variable has r-th factorial moment λ^r, having all factorial moments equal to 1 is the exact algebraic signature of Poisson(1) — the finite-n counterpart of the parent's asymptotic mass function D_k(n)/n! → e⁻¹/k!. The proof is a clean double count: the falling factorial (X_n)_r counts ordered r-tuples of distinct fixed points, so summing over all permutations counts pairs (σ, r-set S fixed pointwise by σ); a permutation fixing a given r-set restricts to an arbitrary permutation of the remaining n−r points, giving C(n,r) sets times r! orderings times (n−r)! completions = n!. Dividing by |S_n| = n! yields E[(X_n)_r] = 1.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ05OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "fixed-points",
+      "permutations",
+      "poisson",
+      "probability",
+      "factorial-moments",
+      "double-counting",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. All theorems are fully machine-checked, depending only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool). The counting lemma reuses Mathlib's Equiv.Perm.subtypeEquivSubtypePerm; the factorial-moment identity itself is not in Mathlib.",
+    "dateAdded": "2026-07-02",
+    "lineCount": 162,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "originalContributions": [
+      "factorial_moment_eq_one (PROVED, HEADLINE): for r ≤ n, the r-th factorial moment of the fixed-point count of a uniform random permutation is exactly 1: (∑_σ (X_σ)_r) / |S_n| = 1. This is the defining algebraic fingerprint of the Poisson(1) limit (a Poisson(λ) has r-th factorial moment λ^r; here λ = 1), stated at finite n with no asymptotics.",
+      "sum_descFactorial_fixedPoints (PROVED, COMBINATORIAL CORE): ∑_{σ ∈ S_n} (X_σ)_r = n! for r ≤ n, where (X_σ)_r = descFactorial(#Fix σ, r) is the r-th falling factorial of the number of fixed points. The sum identity from which the moment statement follows by dividing by n!.",
+      "card_perm_fixesPointwise (PROVED, COUNTING LEMMA): for any set S ⊆ Fin n, the number of permutations fixing every element of S is exactly (n − |S|)!. Built from Mathlib's Equiv.Perm.subtypeEquivSubtypePerm with predicate (· ∉ S), identifying such permutations with Perm ↥Sᶜ.",
+      "sum_card_fixedPoints (PROVED, r = 1 corollary): ∑_σ #Fix σ = n! for n ≥ 1 — the classical fact that the average number of fixed points of a random permutation is 1 (the mean of the Poisson(1) limit), recovered as the r = 1 instance."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Equiv.Perm.subtypeEquivSubtypePerm",
+        "description": "Perm (Subtype p) ≃ {f : Perm α // ∀ a, ¬p a → f a = a}: permutations of a subtype are equivalent to permutations of the whole type that fix the rest pointwise. Applied with p := (· ∉ S) to count permutations fixing a set S pointwise as (n − |S|)!.",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "Nat.descFactorial_eq_factorial_mul_choose",
+        "description": "n.descFactorial k = k! · n.choose k: the falling factorial equals k! times the binomial coefficient. Turns the r-tuple count (X_σ)_r into r! times the count of r-subsets of the fixed set, enabling the subset double count.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "For k ≤ n, choose n k · k! · (n−k)! = n!. The final arithmetic collapse assembling C(n,r) sets · r! orderings · (n−r)! completions into n!.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Fintype.card_perm",
+        "description": "Fintype.card (Perm α) = (Fintype.card α)!. Used both to size |S_n| = n! (the denominator of the expectation) and, for the complement subtype, to count Perm ↥Sᶜ = (n − |S|)!.",
+        "module": "Mathlib.GroupTheory.Perm.Fintype"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Swaps the order of a double Finset sum. The heart of the double count: exchange ∑_σ ∑_{r-set S} for ∑_{r-set S} ∑_σ, turning a sum over permutations of subset-counts into a sum over subsets of permutation-counts.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The number of fixed points of a random permutation is the archetypal example of Poisson approximation: as n → ∞ its distribution converges to Poisson(1), with masses e⁻¹/k!. The parent entry (derangements-convergence-oq-05) established that convergence pointwise in k, and a sibling (oq-05-oq-01) supplied its sharp rate. This entry attacks the same limit from the moment side. A distribution is pinned down by its moments, and for count variables the natural moments are the factorial (falling) moments E[(X)_r] = E[X(X−1)⋯(X−r+1)], because they linearise combinatorial counting: (X)_r is exactly the number of ordered r-tuples of distinct 'successes'. The Poisson(λ) law is the unique distribution whose r-th factorial moment is λ^r for all r, so proving that every factorial moment of the fixed-point count equals 1 is a direct, finite-n certificate that the limit is Poisson(1). The computation is a textbook application of the method of moments and inclusion-free double counting, going back to the rencontres problem of Montmort.",
+    "problemStatement": "**OQ-05-OQ-03 of derangements-convergence (an open question of the parent fixed-point-distribution entry).**\n\nLet X_n = #{fixed points of a uniform σ ∈ S_n}. Prove that all factorial moments are 1:\n\n  E[(X_n)_r] = E[X_n(X_n−1)⋯(X_n−r+1)] = 1,   for every 0 ≤ r ≤ n.\n\nThis is the Poisson(1) hallmark (r-th factorial moment λ^r with λ = 1), the moment-side counterpart of the parent's mass-function limit D_k(n)/n! → e⁻¹/k!.",
+    "text": "For X_n the fixed-point count of a uniform random permutation of Fin n, the r-th factorial moment E[(X_n)_r] equals 1 for all r ≤ n. Equivalently, ∑_{σ ∈ S_n} (X_σ)_r = n!.",
+    "proofStrategy": "**Work with counts, not measures.** The expectation of g(σ) over a uniform σ ∈ S_n is (1/n!)∑_σ g(σ), so E[(X_n)_r] = 1 is equivalent to the sum identity ∑_σ (X_σ)_r = n! (sum_descFactorial_fixedPoints), where (X_σ)_r = descFactorial(#Fix σ, r).\n\n**Falling factorial as an r-subset count.** By Nat.descFactorial_eq_factorial_mul_choose, (X_σ)_r = r!·C(#Fix σ, r), and C(#Fix σ, r) is the number of r-element subsets S of the fixed-point set — written as a sum of indicators [S ⊆ Fix σ] over all r-subsets S of Fin n.\n\n**Swap the order of summation (Finset.sum_comm).** Summing over σ first, ∑_σ (X_σ)_r = r!·∑_{|S|=r} #{σ : S ⊆ Fix σ}. Each term counts the permutations that fix the r-set S pointwise.\n\n**Count permutations fixing a set (card_perm_fixesPointwise).** A permutation fixing every point of S is exactly a permutation of the complement Sᶜ extended by the identity; via Mathlib's Equiv.Perm.subtypeEquivSubtypePerm there are (n − |S|)! = (n − r)! of them.\n\n**Assemble.** ∑_σ (X_σ)_r = r!·C(n,r)·(n−r)! = n! by Nat.choose_mul_factorial_mul_factorial. Dividing by |S_n| = n! gives E[(X_n)_r] = 1.",
+    "keyInsights": [
+      "The falling factorial is a counting device, not just an algebraic gadget: (X_σ)_r counts ordered r-tuples of distinct fixed points, so ∑_σ (X_σ)_r counts flagged configurations (σ, ordered r-tuple of points all fixed by σ). This is what makes the moment computable by pure double counting with no measure theory.",
+      "The r-dependence is entirely absorbed by the double count: summing the flag count the other way gives C(n,r) choices of which r points are fixed, times r! orderings, times (n−r)! ways to permute the rest — and these multiply back to n! independently of r. That is precisely why every factorial moment collapses to the same value 1.",
+      "Having all factorial moments equal to λ^r characterises Poisson(λ); the value 1 here is the finite-n fingerprint of the Poisson(1) limit. Unlike the mass-function statement D_k(n)/n! → e⁻¹/k!, the factorial-moment identity is exact at every finite n (for r ≤ n) — there is no error term to bound.",
+      "The single non-trivial combinatorial input is card_perm_fixesPointwise: permutations fixing a set S pointwise ≅ Perm(Sᶜ), hence (n − |S|)!. This is the 'fix at least S' companion to the parent's 'fix exactly S = derangement of the complement' lemma, and it is what the falling factorial (as opposed to the ordinary power) is tailored to exploit.",
+      "The r = 1 case (sum_card_fixedPoints) recovers the classical fact that a random permutation has on average exactly one fixed point — the mean of Poisson(1) — as a one-line corollary of the general identity."
+    ],
+    "prerequisites": [
+      "The definition of the fixed-point count as the cardinality of {i : σ i = i} and the falling factorial descFactorial",
+      "Mathlib's Equiv.Perm.subtypeEquivSubtypePerm identifying permutations that fix a subtype's complement pointwise with permutations of the subtype",
+      "Basic Finset double-counting (Finset.sum_comm) and the factorial identities descFactorial_eq_factorial_mul_choose and choose_mul_factorial_mul_factorial"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Module docstring stating the factorial-moment result E[(X_n)_r] = 1 as the Poisson(1) hallmark, with the double-counting strategy and the equivalent sum identity ∑_σ (X_σ)_r = n!. Imports the Mathlib derangement/finite module (for the permutation-counting infrastructure) and Mathlib.Tactic.",
+      "mathContext": "Sets up counting over Equiv.Perm (Fin n) and the reuse of Equiv.Perm.subtypeEquivSubtypePerm."
+    },
+    {
+      "id": "sec-fixedset",
+      "title": "The Fixed-Point Set",
+      "startLine": 57,
+      "endLine": 59,
+      "summary": "Defines fixedSet σ = univ.filter (fun i => σ i = i), the Finset of fixed points of σ; its cardinality is the random variable X_n whose moments are studied.",
+      "mathContext": "X_σ = #Fix σ = |{i : σ i = i}|."
+    },
+    {
+      "id": "sec-fixes-pointwise",
+      "title": "Counting Permutations that Fix a Set Pointwise",
+      "startLine": 61,
+      "endLine": 81,
+      "summary": "card_perm_fixesPointwise: for any S ⊆ Fin n, the number of permutations fixing every element of S equals (n − |S|)!. Proved by identifying such permutations with Perm ↥Sᶜ via Equiv.Perm.subtypeEquivSubtypePerm (predicate · ∉ S), then Fintype.card_perm and Fintype.card_subtype_compl.",
+      "mathContext": "#{σ : ∀ i ∈ S, σ i = i} = (n − |S|)!."
+    },
+    {
+      "id": "sec-sum-identity",
+      "title": "The Factorial-Moment Sum Identity",
+      "startLine": 83,
+      "endLine": 135,
+      "summary": "sum_descFactorial_fixedPoints: ∑_σ (X_σ)_r = n! for r ≤ n. Rewrites each falling factorial as r!·(number of r-subsets of the fixed set) expressed via indicators over r-subsets of Fin n, swaps the order of summation (Finset.sum_comm), applies card_perm_fixesPointwise to each inner sum, and collapses r!·C(n,r)·(n−r)! = n!.",
+      "mathContext": "∑_{σ ∈ S_n} descFactorial(#Fix σ, r) = n!."
+    },
+    {
+      "id": "sec-moment",
+      "title": "The Factorial Moments Are All 1",
+      "startLine": 137,
+      "endLine": 154,
+      "summary": "factorial_moment_eq_one: dividing the sum identity by |S_n| = n! gives E[(X_n)_r] = 1 as a real number, using Fintype.card_perm and n! ≠ 0.",
+      "mathContext": "(∑_σ (X_σ)_r) / |S_n| = n!/n! = 1."
+    },
+    {
+      "id": "sec-mean",
+      "title": "The r = 1 Corollary: Mean One",
+      "startLine": 155,
+      "endLine": 162,
+      "summary": "sum_card_fixedPoints: the r = 1 specialization ∑_σ #Fix σ = n! (n ≥ 1), the classical statement that the expected number of fixed points of a random permutation is 1 — the mean of the Poisson(1) limit.",
+      "mathContext": "∑_σ #Fix σ = n!, i.e. E[X_n] = 1."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-05",
+      "relationship": "parent",
+      "description": "Parent entry: proves the fixed-point count D_k(n) = C(n,k)·D(n−k) and the pointwise Poisson(1) limit D_k(n)/n! → e⁻¹/k!. This leaf certifies the same limit from the moment side, showing every factorial moment of the fixed-point count equals 1 (the Poisson(1) fingerprint) exactly at finite n."
+    },
+    {
+      "targetId": "derangements-convergence-oq-05-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling leaf: the sharp rate |D_k(n)/n! − e⁻¹/k!| ≤ 1/(k!(n−k+1)!) for the mass function. Complements this entry's moment-side certificate of the same Poisson(1) limit."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "foundational",
+      "description": "Grand-parent: the k = 0 derangement convergence D(n)/n! → e⁻¹, the origin of the Poisson(1) approximation whose moment structure is verified here."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "foundational",
+      "description": "Root derangement definitions and the permutation-counting infrastructure (Equiv.Perm (Fin n), fixed points) on which the double count is built."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Pierre de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris: Jacque Quillau (2nd ed. 1713)",
+      "note": "The rencontres problem: the origin of counting permutations by their number of fixed points, the combinatorics whose moments are computed here."
+    },
+    {
+      "authors": "Barbour, A. D.; Holst, L.; Janson, S.",
+      "title": "Poisson Approximation",
+      "year": "1992",
+      "venue": "Oxford Studies in Probability 2, Clarendon Press",
+      "note": "The method of moments for Poisson approximation: a nonnegative integer variable whose factorial moments all converge to λ^r converges to Poisson(λ). The fixed-point count, with all factorial moments exactly 1, is the canonical exact example."
+    },
+    {
+      "authors": "Flajolet, Philippe; Sedgewick, Robert",
+      "title": "Analytic Combinatorics",
+      "year": "2009",
+      "venue": "Cambridge University Press, §III.6",
+      "note": "Factorial moments and the exponential generating function of permutations by fixed-point count; derives E[(X_n)_r] = 1 for r ≤ n as the marker of the Poisson(1) limit."
+    }
+  ],
+  "conclusion": {
+    "summary": "Every falling-factorial moment of the fixed-point count of a uniform random permutation of Fin n equals 1 (for r ≤ n), the exact algebraic signature of the Poisson(1) distribution. The result is proved by a single double count — flagging permutations with ordered r-tuples of their fixed points — reducing to the counting lemma that (n−|S|)! permutations fix a given set S pointwise. It is a finite-n, error-free certificate of the same Poisson(1) limit the parent entry established asymptotically.",
+    "significance": "Supplies the moment-side companion to the parent's mass-function limit: where D_k(n)/n! → e⁻¹/k! is asymptotic, E[(X_n)_r] = 1 is exact at every finite n. Together they pin the Poisson(1) approximation from both the distribution and the moment directions. The counting lemma card_perm_fixesPointwise ('fix at least S') is reusable infrastructure alongside the parent's 'fix exactly S' lemma.",
+    "futureDirections": "The same double count computes ordinary moments E[X_n^r] via Stirling numbers (∑_j S(r,j)·(X)_j), and generalises to the joint factorial moments of the cycle-type counts, each of which is asymptotically an independent Poisson. A total-variation bound between X_n and Poisson(1) would combine these moment identities with the sibling's rate estimate."
+  }
+}


### PR DESCRIPTION
## Summary
Research session for **derangements-convergence-oq-05-oq-03** — *Factorial Moments of the Fixed-Point Count Are All 1 (Poisson(1) Hallmark)*.

Let `X_n = #{fixed points of a uniform σ ∈ S_n}`. This entry proves every falling-factorial moment equals 1:

> **E[(X_n)_r] = E[X_n(X_n−1)⋯(X_n−r+1)] = 1** for all `0 ≤ r ≤ n`.

A Poisson(λ) variable has `r`-th factorial moment `λ^r`, so all factorial moments equal to 1 is the exact algebraic signature of **Poisson(1)** — the finite-`n`, error-free counterpart of the parent's asymptotic mass function `D_k(n)/n! → e⁻¹/k!`.

## Proof (double counting)
Working with counts, `E[(X_n)_r] = 1` is the sum identity `∑_{σ∈S_n} (X_σ)_r = n!`. The falling factorial `(X_σ)_r` counts ordered `r`-tuples of distinct fixed points, so summing over `σ` counts flagged pairs (σ, `r`-set fixed pointwise by σ). Counting the other way: `C(n,r)` choices of the fixed `r`-set × `r!` orderings × `(n−r)!` ways to permute the rest = `n!`, independent of `r`. Dividing by `|S_n| = n!` gives `E[(X_n)_r] = 1`.

## New results (`proofs/Proofs/DerangementsConvergenceOQ05OQ03.lean`, 162L)
- `sum_descFactorial_fixedPoints` — `∑_σ (X_σ)_r = n!` (combinatorial core; `Finset.sum_comm` double count).
- `card_perm_fixesPointwise` — `#{σ : σ fixes S pointwise} = (n−|S|)!`, via Mathlib's `Equiv.Perm.subtypeEquivSubtypePerm` with predicate `(· ∉ S)`. The *fix-at-least-S* companion to the parent's *fix-exactly-S = derangement of the complement* lemma.
- `factorial_moment_eq_one` — `(∑_σ (X_σ)_r)/|S_n| = 1` (headline).
- `sum_card_fixedPoints` — `r = 1` corollary: `∑_σ #Fix σ = n!`, the classical mean-one fact.

## Status
**Outcome**: completed. **VERIFIED, 0-axiom** — `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`); 0 sorries. Verified via `lake env lean`.

Gallery entry added: `src/data/proofs/derangements-convergence-oq-05-oq-03/` (meta.json, annotations.json, index.ts). Complements sibling oq-05-oq-01 (sharp rate) from the moment side.

🤖 Generated by researcher-16