### PR TITLE
Fix: create missing gallery entry for cayley-hamilton-minpoly-oq-01-oq-01

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-01/annotations.json
@@ -1,0 +1,127 @@
+[
+  {
+    "id": "ann-jcfoq01-overview",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 58
+    },
+    "type": "concept",
+    "title": "Closing the JCF Product-Formula Axiom",
+    "content": "The module docstring frames the goal: the parent entry cayley-hamilton-minpoly-oq-01 axiomatized the Jordan-canonical-form identity minpoly K f = ∏_{μ} (X − μ)^{e_μ} (e_μ = maxGenEigenspaceIndex f μ) because Mathlib 4.26.0 lacks an explicit Jordan block matrix decomposition. This file proves it as a theorem with no Jordan block infrastructure, purely from generalized-eigenspace theory. The plan: (1) forward divisibility minpoly ∣ ∏ from the spanning of maximal generalized eigenspaces (Axler 8.21 = iSup_maxGenEigenspace_eq_top); (2) index exactness — maxGenEigenspaceIndex is the exact nilpotency index of f − μ — supplying a witness (f − μ)^{e−1} v ≠ 0; (3) per-factor reverse divisibility (X − μ)^{e_μ} ∣ minpoly, needing only FiniteDimensional; (4) the two divisibilities plus monicity give equality. Status: 0 sorries, 0 axioms; #print axioms lists only propext, Classical.choice, Quot.sound.",
+    "mathContext": "For $f : \\mathrm{End}_K V$ over an algebraically closed $K$ in finite dimension, the minimal polynomial records the largest Jordan block size per eigenvalue: $\\mathrm{minpoly}_K f = \\prod_{\\mu} (X-\\mu)^{e_\\mu}$, $e_\\mu = \\max$ block size $= \\mathrm{maxGenEigenspaceIndex}\\, f\\, \\mu$. The classical proof goes through Jordan blocks; here the exponent is characterized spectrally as the exact nilpotency index of $f-\\mu$ on the maximal generalized eigenspace.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Jordan canonical form",
+      "minimal polynomial",
+      "maxGenEigenspaceIndex",
+      "generalized eigenspace",
+      "de-axiomatization"
+    ],
+    "prerequisites": [
+      "Module.End",
+      "minpoly K f",
+      "genEigenspace",
+      "IsAlgClosed",
+      "FiniteDimensional"
+    ]
+  },
+  {
+    "id": "ann-jcfoq01-factor-eval",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 86
+    },
+    "type": "technique",
+    "title": "Evaluating the Linear Factor as an Endomorphism Power",
+    "content": "Two setup lemmas. maxGenEigenspace_eq_bot_of_not_hasEigenvalue: if ν is not an eigenvalue then f.maxGenEigenspace ν = ⊥ (contrapositive: a nonzero generalized eigenvector forces an eigenvalue), which lets the forward-divisibility proof discard off-spectrum summands. aeval_linear_factor_pow: aeval f ((X − C ν)^k) = (f − ν • 1)^k, obtained by pushing aeval through map_pow/map_sub and rewriting the scalar via Algebra.algebraMap_eq_smul_one. This bridge is used throughout: it converts polynomial factors into the endomorphism powers whose kernels are exactly the generalized eigenspaces (genEigenspace_nat).",
+    "mathContext": "The identity $\\mathrm{aeval}_f((X-\\nu)^k) = (f - \\nu\\,\\mathrm{id})^k$ is what ties the polynomial side to the operator side: $\\ker (f-\\nu\\,\\mathrm{id})^k = \\mathrm{genEigenspace}\\,\\nu\\,k$, so vanishing of a polynomial factor on a vector is membership in a generalized eigenspace.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "aeval",
+      "algebraMap_eq_smul_one",
+      "maxGenEigenspace",
+      "genEigenspace_nat"
+    ],
+    "prerequisites": [
+      "Polynomial.aeval",
+      "map_pow",
+      "map_sub"
+    ]
+  },
+  {
+    "id": "ann-jcfoq01-forward",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-01",
+    "range": {
+      "startLine": 88,
+      "endLine": 129
+    },
+    "type": "insight",
+    "title": "Forward Divisibility Is Spanning",
+    "content": "minpoly_dvd_maxGenEigenspace_product proves minpoly K f ∣ ∏_{μ eigenvalue} (X − μ)^{e_μ} over an algebraically closed field. The strategy: by minpoly.dvd it suffices that the product annihilates f, i.e. its aeval-kernel is ⊤. Rewriting ⊤ = ⨆ maxGenEigenspace via iSup_maxGenEigenspace_eq_top reduces to checking each maximal generalized eigenspace. For an eigenvalue ν in the spectrum, Finset.prod_erase_mul pulls the factor (X − ν)^{e_ν} out front; genEigenspace_nat shows it already annihilates every v in the ν-summand, and the commuting remaining factors map 0 to 0. For ν off the spectrum the summand is ⊥, so v = 0. No Jordan blocks appear anywhere.",
+    "mathContext": "Axler's Lemma 8.21: over $\\overline{K}$, $V = \\bigoplus_\\mu G_\\mu$ where $G_\\mu$ is the maximal generalized eigenspace. On $G_\\mu$, $(f-\\mu)^{e_\\mu} = 0$, so $\\prod_\\nu (f-\\nu)^{e_\\nu}$ kills each summand and hence all of $V$. A polynomial that annihilates $f$ is a multiple of $\\mathrm{minpoly}_K f$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "iSup_maxGenEigenspace_eq_top",
+      "minpoly.dvd",
+      "Finset.prod_erase_mul",
+      "genEigenspace_nat"
+    ],
+    "prerequisites": [
+      "LinearMap.ker_eq_top",
+      "Module.End.mul_apply",
+      "maxGenEigenspace_eq"
+    ]
+  },
+  {
+    "id": "ann-jcfoq01-exactness",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-01",
+    "range": {
+      "startLine": 131,
+      "endLine": 206
+    },
+    "type": "insight",
+    "title": "Index Exactness: the Missing Ingredient",
+    "content": "The reverse divisibility hinges on maxGenEigenspaceIndex being the EXACT nilpotency index, not merely an upper bound. genEigenspace_lt_succ_of_lt_maxGenEigenspaceIndex proves that for k < e the chain grows strictly: genEigenspace μ k < genEigenspace μ (k+1). If it were constant at step k, then via genEigenspace_nat the kernels ker (f − μ)^k and ker (f − μ)^{k+1} coincide, and Module.End.ker_pow_constant propagates constancy for all larger d; but maxGenEigenspaceIndex is the LEAST stabilization index (Nat.sInf_le on the defining monotone sequence), contradicting k < e. exists_mem_maxGenEigenspace_pow_pred_ne_zero then extracts the concrete witness: a v in the maximal generalized eigenspace with (f − μ)^{e−1} v ≠ 0. This witness is precisely what distinguishes the exact product formula from mere forward divisibility.",
+    "mathContext": "The generalized-eigenspace chain $\\ker(f-\\mu)^0 \\subsetneq \\ker(f-\\mu)^1 \\subsetneq \\cdots$ is strictly increasing until it stabilizes at index $e_\\mu$, after which it is constant. Exactness says the first stabilization is at $e_\\mu$ itself, so $(f-\\mu)^{e_\\mu-1}$ does not vanish on all of $G_\\mu$ — there is a vector of nilpotency degree exactly $e_\\mu$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Module.End.ker_pow_constant",
+      "maxGenEigenspaceIndex",
+      "monotonicSequenceLimitIndex",
+      "Nat.sInf_le"
+    ],
+    "prerequisites": [
+      "genEigenspace_nat",
+      "SetLike.exists_of_lt",
+      "WithTop.coeOrderHom"
+    ]
+  },
+  {
+    "id": "ann-jcfoq01-reverse-and-formula",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-01",
+    "range": {
+      "startLine": 208,
+      "endLine": 328
+    },
+    "type": "insight",
+    "title": "Reverse Divisibility and the Final Identity",
+    "content": "pow_maxGenEigenspaceIndex_dvd_minpoly proves (X − μ)^{e_μ} ∣ minpoly using ONLY FiniteDimensional (no algebraic closure), one eigenvalue at a time. Write minpoly = (X − μ)^m · g with m = rootMultiplicity μ (minpoly) and (X − μ) ∤ g. Then (X − μ)^{e_μ} and g are coprime (prime_X_sub_C, coprime_iff_not_dvd, pow_left), giving Bézout coefficients a·(X−μ)^{e_μ} + b·g = 1. Evaluate at the exactness witness v: since (f − μ)^{e_μ} v = 0, the first term dies and v = b(f)(g(f) v). Because minpoly annihilates f, (f − μ)^m (g(f) v) = 0, and b(f) commutes with (f − μ)^m, so (f − μ)^m v = 0. Exactness ((f − μ)^{e_μ−1} v ≠ 0) forces e_μ ≤ m, whence (X − μ)^{e_μ} ∣ (X − μ)^m ∣ minpoly. prod_pow_maxGenEigenspaceIndex_dvd_minpoly lifts to the product via pairwise coprimality of distinct linear powers (Finset.prod_dvd_of_coprime, pairwise_coprime_X_sub_C). Finally minpoly_eq_prod_pow_maxGenEigenspaceIndex combines both divisibilities with monicity of both sides (eq_of_monic_of_associated, associated_of_dvd_dvd) to yield the exact identity — the parent's axiom, now proved.",
+    "mathContext": "Coprimality turns the geometric exactness witness into an arithmetic bound on root multiplicity: $e_\\mu \\le \\mathrm{rootMult}_\\mu(\\mathrm{minpoly})$. Distinct linear factors $(X-\\mu)$ are pairwise coprime, so per-factor divisibility multiplies up to $\\prod \\mid \\mathrm{minpoly}$. Two monic polynomials dividing each other are equal — the associate-to-identity upgrade.",
+    "significance": "key",
+    "relatedConcepts": [
+      "rootMultiplicity",
+      "IsCoprime",
+      "prime_X_sub_C",
+      "pairwise_coprime_X_sub_C",
+      "eq_of_monic_of_associated",
+      "associated_of_dvd_dvd"
+    ],
+    "prerequisites": [
+      "exists_eq_pow_rootMultiplicity_mul_and_not_dvd",
+      "Finset.prod_dvd_of_coprime",
+      "minpoly.aeval"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-01/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-01-oq-01",
+  "title": "De-Axiomatizing the JCF Product Formula: minpoly = Π (X−μ)^{e_μ}",
+  "slug": "cayley-hamilton-minpoly-oq-01-oq-01",
+  "description": "Fully proves the Jordan-canonical-form minimal-polynomial product formula minpoly K f = ∏_{μ eigenvalue} (X − μ)^{maxGenEigenspaceIndex f μ}, which the parent entry (cayley-hamilton-minpoly-oq-01) only axiomatized. Both divisibilities are established with no Jordan block matrix infrastructure: forward (minpoly ∣ ∏) from iSup_maxGenEigenspace_eq_top, reverse (∏ ∣ minpoly) from exactness of the generalized-eigenspace index — the reverse direction needing only FiniteDimensional, no algebraic closure. 8 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "references": [
+    {
+      "authors": "Sheldon Axler",
+      "title": "Linear Algebra Done Right (3rd ed.)",
+      "year": 2015,
+      "note": "Springer. Lemma 8.21: the maximal generalized eigenspaces span V over an algebraically closed field — the forward-divisibility ingredient (Mathlib: iSup_maxGenEigenspace_eq_top)."
+    },
+    {
+      "authors": "Camille Jordan",
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": 1870,
+      "note": "Gauthier-Villars. The Jordan canonical form; the exponent e_μ is the size of the largest Jordan block for μ, here realized as maxGenEigenspaceIndex f μ without block matrices."
+    },
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra (Revised 3rd ed.), GTM 211",
+      "year": 2002,
+      "note": "Springer. Minimal polynomial, root multiplicity, and the primary-decomposition viewpoint underlying the per-eigenvalue reverse divisibility."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: LinearAlgebra.Eigenspace.{Basic, Triangularizable, Minpoly} and Module.End.ker_pow_constant",
+      "year": 2024,
+      "note": "Generalized eigenspaces, maxGenEigenspaceIndex, genEigenspace_nat, and one-step kernel stabilization — the machinery replacing explicit Jordan blocks."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ01OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "minimal-polynomial",
+      "jordan-canonical-form",
+      "generalized-eigenspace",
+      "eigenvalues"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "None. #print axioms lists only propext, Classical.choice, Quot.sound (the standard Lean/Mathlib foundations). No axiom declarations and no structure-encoded assumptions.",
+    "lineCount": 328,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "originalContributions": [
+      "minpoly_eq_prod_pow_maxGenEigenspaceIndex: proves the parent's axiomatized minpoly_product_formula as a theorem — minpoly K f = ∏ (X − μ)^{maxGenEigenspaceIndex f μ}",
+      "minpoly_dvd_maxGenEigenspace_product: forward divisibility from iSup_maxGenEigenspace_eq_top, no Jordan blocks",
+      "genEigenspace_lt_succ_of_lt_maxGenEigenspaceIndex: strict growth of the generalized-eigenspace chain below the limit index (index exactness) via Module.End.ker_pow_constant",
+      "exists_mem_maxGenEigenspace_pow_pred_ne_zero: the concrete exactness witness (f − μ)^{e−1} v ≠ 0",
+      "pow_maxGenEigenspaceIndex_dvd_minpoly: per-factor reverse divisibility (X − μ)^{e_μ} ∣ minpoly, needing only FiniteDimensional (no algebraic closure)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry (cayley-hamilton-minpoly-oq-01) formalizes the Jordan-canonical-form relationship between an endomorphism and its minimal polynomial, but had to axiomatize the central product formula minpoly = Π (X−μ)^{e_μ} together with an exactness statement, noting that Mathlib 4.26.0 provides triangularizability, the Jordan–Chevalley decomposition, and generalized-eigenspace theory, yet not the explicit Jordan block matrix with a labeled basis. This entry closes that gap: it proves the product formula outright from generalized-eigenspace theory alone, sidestepping Jordan blocks entirely. The key classical input is Axler's Lemma 8.21 (maximal generalized eigenspaces span V over an algebraically closed field), and the decisive new observation is that maxGenEigenspaceIndex is the *exact* nilpotency index of f − μ, extracted from Mathlib's one-step kernel-stabilization lemma.",
+    "problemStatement": "Prove, without axioms, the Jordan-canonical-form minimal-polynomial product formula minpoly K f = ∏_{μ eigenvalue} (X − μ)^{maxGenEigenspaceIndex f μ} that the parent file only axiomatized.",
+    "text": "For f : Module.End K V with K algebraically closed and V finite-dimensional, the minimal polynomial factors as ∏_{μ} (X − μ)^{e_μ} where e_μ = maxGenEigenspaceIndex f μ. The proof splits into two divisibilities. Forward: the product annihilates f because the maximal generalized eigenspaces span V and on each μ-summand the factor (X − μ)^{e_μ} already vanishes; minpoly.dvd then gives minpoly ∣ ∏. Reverse: proved one eigenvalue at a time and needing only FiniteDimensional — the index exactness produces a witness v with (f − μ)^{e_μ−1} v ≠ 0, and a Bézout/coprimality argument against the root-multiplicity factorisation forces e_μ ≤ rootMultiplicity μ (minpoly), hence (X − μ)^{e_μ} ∣ minpoly; pairwise coprimality of distinct linear powers lifts this to the whole product. Both sides are monic, so the two divisibilities upgrade to equality.",
+    "proofStrategy": "Establish forward divisibility via the spanning of maximal generalized eigenspaces (iSup_maxGenEigenspace_eq_top) and factor extraction on each summand. Establish index exactness: below maxGenEigenspaceIndex the generalized-eigenspace chain grows strictly (from Module.End.ker_pow_constant plus the least-index characterization of the limit), yielding a nonzero witness under (f − μ)^{e−1}. Convert per-eigenvalue exactness into reverse divisibility through the root-multiplicity factorisation minpoly = (X − μ)^m · g with (X − μ) ∤ g, Bézout coprimality, and commutation of aeval-images. Combine via monicity and associated_of_dvd_dvd.",
+    "keyInsights": [
+      "The Jordan product formula needs no Jordan block matrices — generalized-eigenspace theory alone suffices",
+      "Forward divisibility is spanning: the maximal generalized eigenspaces fill V, and each factor kills its own summand",
+      "maxGenEigenspaceIndex is the *exact* nilpotency index, not just an upper bound — the missing ingredient for the reverse direction",
+      "The reverse divisibility argues one eigenvalue at a time and requires only FiniteDimensional, not algebraic closure",
+      "Bézout coprimality of (X − μ)^{e_μ} and the non-(X − μ) cofactor g converts the exactness witness into e_μ ≤ rootMultiplicity μ (minpoly)",
+      "Two monic polynomials that divide each other are equal — the final upgrade from associate to identity"
+    ],
+    "prerequisites": [
+      "Generalized eigenspaces: Module.End.genEigenspace, maxGenEigenspace, maxGenEigenspaceIndex, genEigenspace_nat",
+      "iSup_maxGenEigenspace_eq_top over an algebraically closed field",
+      "Root multiplicity and the factorisation minpoly = (X − μ)^m · g with (X − μ) ∤ g",
+      "Coprimality and Bézout in K[X]; prime_X_sub_C and pairwise_coprime_X_sub_C"
+    ]
+  },
+  "conclusion": {
+    "summary": "The JCF minimal-polynomial product formula minpoly K f = ∏ (X − μ)^{maxGenEigenspaceIndex f μ} is proved with 0 axioms and 0 sorries, discharging the parent entry's axiomatized minpoly_product_formula and its exactness companion. 8 theorems, 328 lines. Forward divisibility comes from spanning of maximal generalized eigenspaces; reverse divisibility from exactness of the generalized-eigenspace index, requiring only FiniteDimensional.",
+    "implications": "Removing the axiom converts the parent's account of the Jordan/minpoly relationship into a fully machine-checked identity, and isolates the reusable, e-independent ingredients (index exactness, per-factor reverse divisibility) that are natural upstream Mathlib contributions. It also demonstrates that the coarsest Jordan invariant — the largest block size per eigenvalue — is recoverable purely spectrally, without constructing the block matrix.",
+    "openQuestions": [
+      "Upstream genEigenspace_lt_succ_of_lt_maxGenEigenspaceIndex and pow_maxGenEigenspaceIndex_dvd_minpoly to Mathlib",
+      "Recover the full Jordan block count per size, dim(genEigenspace μ k) − dim(genEigenspace μ (k−1)), from the same generalized-eigenspace tower",
+      "Extend the reverse-divisibility technique to the rational canonical form over non-algebraically-closed fields via invariant factors"
+    ]
+  },
+  "leanFile": {
+    "namespace": "JordanMinpolyOQ01OQ01",
+    "lineCount": 328,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry that axiomatized the JCF product formula (minpoly_product_formula) and its exactness; this entry proves both as theorems"
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The Cayley–Hamilton theorem; here the minimal polynomial's factorisation is characterized via generalized-eigenspace indices"
+    }
+  ],
+  "sections": [
+    {
+      "title": "Setup and Factor Evaluation",
+      "startLine": 60,
+      "endLine": 86,
+      "summary": "Imports (generalized-eigenspace and minpoly infrastructure only) and namespace JordanMinpolyOQ01OQ01. maxGenEigenspace_eq_bot_of_not_hasEigenvalue: a non-eigenvalue has trivial maximal generalized eigenspace. aeval_linear_factor_pow: aeval f ((X − C ν)^k) = (f − ν • 1)^k, matching the form used by genEigenspace_nat."
+    },
+    {
+      "title": "Forward Divisibility: minpoly ∣ ∏",
+      "startLine": 88,
+      "endLine": 129,
+      "summary": "minpoly_dvd_maxGenEigenspace_product (IsAlgClosed, FiniteDimensional): the product over eigenvalues of (X − μ)^{e_μ} annihilates f. Proof rewrites ker = ⊤ via iSup_maxGenEigenspace_eq_top; on each μ-summand the matching factor kills v; off the eigenvalue set the summand is trivial. minpoly.dvd closes."
+    },
+    {
+      "title": "Index Exactness and the Witness",
+      "startLine": 131,
+      "endLine": 206,
+      "summary": "genEigenspace_lt_succ_of_lt_maxGenEigenspaceIndex: below the limit index the chain grows strictly, via Module.End.ker_pow_constant and the least-stabilization-index characterization. exists_mem_maxGenEigenspace_pow_pred_ne_zero: a concrete v in the maximal generalized eigenspace with (f − μ)^{e−1} v ≠ 0."
+    },
+    {
+      "title": "Reverse Divisibility: ∏ ∣ minpoly",
+      "startLine": 208,
+      "endLine": 300,
+      "summary": "pow_maxGenEigenspaceIndex_dvd_minpoly (FiniteDimensional only): (X − μ)^{e_μ} ∣ minpoly via the root-multiplicity factorisation minpoly = (X − μ)^m · g, Bézout coprimality of (X − μ)^{e_μ} and g, the exactness witness, and commutation of aeval-images, forcing e_μ ≤ m. prod_pow_maxGenEigenspaceIndex_dvd_minpoly lifts to the product via pairwise coprimality of distinct linear powers."
+    },
+    {
+      "title": "The Product Formula",
+      "startLine": 302,
+      "endLine": 328,
+      "summary": "minpoly_eq_prod_pow_maxGenEigenspaceIndex (IsAlgClosed, FiniteDimensional): both divisibilities plus monicity of both sides give the exact identity minpoly K f = ∏ (X − μ)^{maxGenEigenspaceIndex f μ}, via eq_of_monic_of_associated and associated_of_dvd_dvd. This is the parent's axiomatized minpoly_product_formula, now a theorem."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Fix

Create the missing gallery entry (`meta.json` + `annotations.json`) for **cayley-hamilton-minpoly-oq-01-oq-01**.

## Evidence

**Before**: `proofs/Proofs/CayleyHamiltonMinpolyOQ01OQ01.lean` (verified, 0-axiom, 0-sorry, 8 theorems, 328 lines) was merged to `main` via a standalone `research(cayley-hamilton-minpoly-oq-01-oq-01)` PR, but no `src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-01/` directory was ever created — the proof was invisible in the web gallery.

**After**: gallery entry added, modeled field-for-field on the parent `cayley-hamilton-minpoly-oq-01`. The proof **de-axiomatizes the parent's central axiom** `minpoly_product_formula`: it proves

`minpoly K f = ∏_{μ eigenvalue} (X − μ)^{maxGenEigenspaceIndex f μ}`

with **0 axioms / 0 sorries**, purely from generalized-eigenspace theory (no Jordan-block matrices). Forward divisibility from `iSup_maxGenEigenspace_eq_top`; reverse divisibility from exactness of the generalized-eigenspace index (needs only `FiniteDimensional`, no algebraic closure).

- `status`: `verified`, `badge`: `original`, `axiomCount`: `0`
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`
- 5 annotations covering the full file; schema verified to match the parent exactly

---
Automated fix by lean-mechanic agent.