### PR TITLE
Fix: strip embedded description from beta-integral crossReference targets

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -127,8 +127,8 @@
     "Prove the general diagonal asymptotic B(x,x) ~ 2^(1-2x)·√(π/x) for real x → ∞ (not just the half-integer slice), interpolating this entry's discrete result."
   ],
   "crossReferences": [
-    "beta-integral-recurrence-oq-01-oq-02-oq-01 (parent: the exact value B(n+1/2,n+1/2)=π·C(2n,n)/4^(2n) and the open question this entry answers and corrects)",
-    "stirling-formula-oq-03-oq-02 (the central binomial asymptotic C(2n,n)~4^n/√(πn) consumed here)"
+    "beta-integral-recurrence-oq-01-oq-02-oq-01",
+    "stirling-formula-oq-03-oq-02"
   ],
   "references": [],
   "sorries": [],


### PR DESCRIPTION
## Fix

The gallery entry `beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01` had two string cross-references whose slug field was polluted with trailing parenthetical description text, so neither link resolved to a gallery entry.

## Evidence

**Before** (`crossReferences`):
```
"beta-integral-recurrence-oq-01-oq-02-oq-01 (parent: the exact value B(n+1/2,n+1/2)=π·C(2n,n)/4^(2n) and the open question this entry answers and corrects)",
"stirling-formula-oq-03-oq-02 (the central binomial asymptotic C(2n,n)~4^n/√(πn) consumed here)"
```

**After**:
```
"beta-integral-recurrence-oq-01-oq-02-oq-01",
"stirling-formula-oq-03-oq-02"
```

Both target slugs exist as gallery directories (`src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01/` and `src/data/proofs/stirling-formula-oq-03-oq-02/`), so the cross-references now resolve. This was the only entry in the gallery whose string cross-references contained embedded prose; the descriptive text is already captured in the entry's `historicalContext`, `proofStrategy`, and `implications` fields.

JSON validated with `JSON.parse`.

---
Automated fix by lean-mechanic agent.