### PR TITLE
Fix: create missing gallery entry for continuum-hypothesis-oq-02-oq-01

### DIFF
--- a/src/data/proofs/continuum-hypothesis-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-choq0201-overview",
+    "proofId": "continuum-hypothesis-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 89
+    },
+    "type": "concept",
+    "title": "Discharging the Bounding-Number Axiom",
+    "content": "The module docstring sets the goal: the parent entry continuum-hypothesis-oq-02 left the lower bound ℵ₁ ≤ 𝔟 as an axiom (bounding_number_uncountable), remarking only that a proof 'requires constructing the diagonal function.' This file supplies exactly that, from Mathlib alone with no project-local axioms. Part 0 inlines the definitions to match the parent's conventions: eventuallyDominates f g (the ≤* preorder: f n ≤ g n for all large n), IsUnbounded F (no single g eventually dominates every member of F), and boundingNumber = ⨅_F (if IsUnbounded F then #F else 2^ℵ₀). The fallback continuum term in the infimum is what keeps 𝔟 ≤ 2^ℵ₀ and must be handled in the lower-bound proof.",
+    "mathContext": "The bounding number $\\mathfrak{b}$ is the least cardinality of a family in $(\\mathbb{N}\\to\\mathbb{N}, \\le^*)$ that no single function eventually dominates. The theorem $\\aleph_1 \\le \\mathfrak{b}$ asserts every such unbounded family is uncountable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "bounding number",
+      "eventual domination",
+      "cardinal characteristics",
+      "de-axiomatization"
+    ],
+    "prerequisites": [
+      "Cardinal.{0}",
+      "ℵ₀",
+      "ℵ₁",
+      "infimum of cardinals"
+    ]
+  },
+  {
+    "id": "ann-choq0201-konig",
+    "proofId": "continuum-hypothesis-oq-02-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 111
+    },
+    "type": "insight",
+    "title": "The General König Cofinality Constraint",
+    "content": "general_konig_cofinality proves κ < cf(2^κ) for every infinite cardinal κ, directly from Mathlib's Cardinal.lt_cof_power (König's theorem: ℵ₀ ≤ a → 1 < b → a < cf(bᵃ)), with the 1 < 2 side condition dispatched by norm_num. This generalizes the parent entry, which proved only the special case κ = ℵ₀ (recovered here as konig_cofinality_aleph0 by instantiating at le_rfl). The sharp statement shows 2^κ is never a cardinal of cofinality ≤ κ — in particular it is never singular of small cofinality.",
+    "mathContext": "König's theorem gives $\\kappa < \\mathrm{cf}(2^\\kappa)$. For $\\kappa = \\aleph_0$ this is $\\mathrm{cf}(2^{\\aleph_0}) > \\aleph_0$, ruling out $2^{\\aleph_0} = \\aleph_\\omega$; the general form rules out the analogous singular values at every infinite $\\kappa$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "König's theorem",
+      "cofinality",
+      "Cardinal.lt_cof_power",
+      "singular cardinals"
+    ],
+    "prerequisites": [
+      "cofinality cf",
+      "cardinal exponentiation"
+    ]
+  },
+  {
+    "id": "ann-choq0201-diagonal",
+    "proofId": "continuum-hypothesis-oq-02-oq-01",
+    "range": {
+      "startLine": 113,
+      "endLine": 156
+    },
+    "type": "insight",
+    "title": "Hausdorff Diagonalization: Countable Families Are Bounded",
+    "content": "The heart of the proof. diagonal_dominates shows the diagonal g(k) = (Finset.range (k+1)).sup (fun i => e i k) + 1 eventually dominates each enumerated member e j: for k ≥ j, j ∈ Finset.range (k+1), so Finset.le_sup gives e j k ≤ sup, and omega closes e j k ≤ sup + 1 = g k. unbounded_uncountable then proves ℵ₁ ≤ #F for any unbounded F. It rewrites ℵ₁ ≤ #F as ¬(#F < ℵ₁) = ¬F.Countable via countable_iff_lt_aleph_one, and derives a contradiction from countability: the empty family is not unbounded (witness g = 0 has no member to escape it), and a nonempty countable F = range e is dominated by its diagonal, contradicting IsUnbounded F applied to that diagonal.",
+    "mathContext": "A countable family $\\{f_0, f_1, \\dots\\}$ is eventually dominated by $g(k) = \\max_{i \\le k} f_i(k) + 1$: at coordinate $k$ only the first $k+1$ members are consulted, and $g(k)$ exceeds all of them. So no countable family is unbounded, hence unbounded families are uncountable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "diagonalization",
+      "Finset.le_sup",
+      "countable_iff_lt_aleph_one",
+      "Set.Countable.exists_eq_range"
+    ],
+    "prerequisites": [
+      "eventuallyDominates",
+      "IsUnbounded",
+      "Cardinal.mk"
+    ]
+  },
+  {
+    "id": "ann-choq0201-bounding",
+    "proofId": "continuum-hypothesis-oq-02-oq-01",
+    "range": {
+      "startLine": 158,
+      "endLine": 194
+    },
+    "type": "insight",
+    "title": "ℵ₁ ≤ 𝔟 by Term-wise Bounding of the Infimum",
+    "content": "aleph_one_le_two_pow_aleph0 proves ℵ₁ ≤ 2^ℵ₀ from Cantor: rewriting ℵ₁ = succ ℵ₀ (succ_aleph0), Order.succ_le_of_lt (Cardinal.cantor ℵ₀) gives the bound. bounding_number_uncountable then proves ℵ₁ ≤ 𝔟 by unfolding the infimum and applying le_ciInf: each term is either the unbounded branch #F (bounded below by unbounded_uncountable) or the fallback 2^ℵ₀ (bounded below by Cantor). Since ℵ₁ bounds every term, it bounds the infimum. This is precisely the parent's axiom bounding_number_uncountable, now a theorem. aleph0_lt_boundingNumber records the immediate corollary ℵ₀ < 𝔟.",
+    "mathContext": "$\\mathfrak{b} = \\bigsqcap_F (\\text{if IsUnbounded } F \\text{ then } \\#F \\text{ else } 2^{\\aleph_0})$. Both branches are $\\ge \\aleph_1$, so the infimum is $\\ge \\aleph_1$: the ZFC lower endpoint of the chain $\\aleph_1 \\le \\mathfrak{b} \\le \\mathfrak{d} \\le 2^{\\aleph_0}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "le_ciInf",
+      "Cardinal.cantor",
+      "succ_aleph0",
+      "bounding number"
+    ],
+    "prerequisites": [
+      "boundingNumber",
+      "unbounded_uncountable",
+      "infimum of cardinals"
+    ]
+  }
+]

--- a/src/data/proofs/continuum-hypothesis-oq-02-oq-01/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02-oq-01/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "continuum-hypothesis-oq-02-oq-01",
+  "title": "De-Axiomatizing the Bounding Number Lower Bound: ℵ₁ ≤ 𝔟",
+  "slug": "continuum-hypothesis-oq-02-oq-01",
+  "description": "Discharges the axiom bounding_number_uncountable from the parent entry continuum-hypothesis-oq-02 by giving the classical Hausdorff diagonalization: no countable family of functions ℕ → ℕ is unbounded in the eventual-domination preorder ≤*, because it is dominated by its diagonal g(k) = max_{i ≤ k} fᵢ(k) + 1. Hence every unbounded family is uncountable and the bounding number satisfies ℵ₁ ≤ 𝔟. Also records the sharp general König cofinality constraint κ < cf(2^κ) for every infinite κ. 7 theorems, 3 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cardinal_characteristic_of_the_continuum",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ContinuumHypothesisOQ02OQ01.lean",
+    "tags": [
+      "set-theory",
+      "foundations",
+      "cardinal-arithmetic",
+      "continuum-hypothesis",
+      "cardinal-characteristics",
+      "bounding-number",
+      "diagonalization"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.lt_cof_power",
+        "description": "König's theorem: ℵ₀ ≤ a → 1 < b → a < cf(bᵃ)",
+        "module": "Mathlib.SetTheory.Cardinal.Cofinality"
+      },
+      {
+        "theorem": "Cardinal.countable_iff_lt_aleph_one",
+        "description": "s.Countable ↔ #s < ℵ₁",
+        "module": "Mathlib.SetTheory.Cardinal.Aleph"
+      },
+      {
+        "theorem": "Set.Countable.exists_eq_range",
+        "description": "A nonempty countable set is the range of some ℕ → α",
+        "module": "Mathlib.Data.Set.Countable"
+      },
+      {
+        "theorem": "Cardinal.cantor",
+        "description": "Cantor's theorem: κ < 2^κ",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Finset.le_sup",
+        "description": "a ∈ s → f a ≤ s.sup f, used to bound the diagonal from below",
+        "module": "Mathlib.Order.Finset.Lattice"
+      }
+    ],
+    "originalContributions": [
+      "bounding_number_uncountable: ℵ₁ ≤ 𝔟 — proves the parent's axiom bounding_number_uncountable as a theorem",
+      "unbounded_uncountable: any unbounded family F in (ℕ → ℕ, ≤*) has ℵ₁ ≤ #F, via Hausdorff diagonalization",
+      "diagonal_dominates: the diagonal g(k) = max_{i ≤ k} e(i)(k) + 1 eventually dominates every member of an enumerated family",
+      "general_konig_cofinality: sharp form κ < cf(2^κ) for every infinite κ, generalizing the parent's κ = ℵ₀ case"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 194,
+    "assumptions": "None. #print axioms lists only propext, Classical.choice, Quot.sound (the standard Lean/Mathlib foundations). No axiom declarations and no structure-encoded assumptions; the parent's axiom bounding_number_uncountable is proved here.",
+    "theoremCount": 7,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The parent entry continuum-hypothesis-oq-02 develops the ZFC constraints on the continuum 2^ℵ₀ — Cantor's ℵ₁ ≤ 2^ℵ₀ and König's cofinality constraint cf(2^ℵ₀) > ℵ₀ — and introduces the combinatorial cardinal characteristics 𝔟 (bounding number) and 𝔡 (dominating number) with the ZFC chain ℵ₁ ≤ 𝔟 ≤ 𝔡 ≤ 2^ℵ₀. There the lower bound ℵ₁ ≤ 𝔟 was left as an axiom (bounding_number_uncountable), the docstring noting only that a formal proof 'requires constructing the diagonal function and showing it eventually dominates each element.' The bounding and dominating numbers are the founding invariants of the theory of cardinal characteristics of the continuum (Hausdorff's early diagonalization arguments; the modern survey is Blass 2010). This entry supplies the missing diagonalization and thereby removes the axiom.",
+    "problemStatement": "Prove, without axioms, the bounding-number lower bound ℵ₁ ≤ 𝔟 that the parent entry only axiomatized, and record the general König cofinality constraint κ < cf(2^κ).",
+    "text": "In (ℕ → ℕ, ≤*) with eventual domination f ≤* g meaning f n ≤ g n for all large n, a family F is unbounded if no single g eventually dominates every member. The bounding number 𝔟 is the least cardinality of an unbounded family. The theorem ℵ₁ ≤ 𝔟 says every unbounded family is uncountable. The proof is Hausdorff diagonalization: a countable family, written as a range e : ℕ → (ℕ → ℕ), is dominated by its diagonal g(k) = max_{i ≤ k} e(i)(k) + 1, which eventually dominates each e(j) (for k ≥ j, j ∈ {0,…,k} so e(j)(k) ≤ max < g(k)). Hence no countable family is unbounded, so an unbounded family has cardinality ≥ ℵ₁. The infimum defining 𝔟 is then bounded below by ℵ₁ term-by-term: unbounded terms by this result, the fallback continuum term by Cantor's ℵ₁ ≤ 2^ℵ₀.",
+    "proofStrategy": "Define eventual domination, unboundedness, and the bounding number matching the parent's conventions. Prove diagonal_dominates by Finset.le_sup and omega. Prove unbounded_uncountable by contradiction: countability gives an enumeration (Set.Countable.exists_eq_range), the diagonal contradicts unboundedness; the empty family is separately not unbounded. Prove ℵ₁ ≤ 2^ℵ₀ from Cantor via succ_aleph0. Combine with le_ciInf over the infimum's two branches to get ℵ₁ ≤ 𝔟. König's κ < cf(2^κ) follows directly from Cardinal.lt_cof_power.",
+    "keyInsights": [
+      "Diagonalization is the whole story: a countable family cannot be unbounded because its own diagonal dominates it",
+      "The diagonal g(k) = max_{i ≤ k} e(i)(k) + 1 only needs finitely many members at each coordinate, so Finset.sup suffices",
+      "Uncountability is ℵ₁ ≤ #F, i.e. the negation of #F < ℵ₁, which Mathlib's countable_iff_lt_aleph_one turns into ¬Countable",
+      "The infimum defining 𝔟 is bounded below term-by-term — the non-unbounded fallback branch is covered by Cantor's ℵ₁ ≤ 2^ℵ₀",
+      "König's cofinality constraint holds in sharp general form κ < cf(2^κ), not just for κ = ℵ₀"
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic: ℵ₀, ℵ₁, 2^κ, cofinality cf",
+      "Eventual-domination preorder ≤* on ℕ → ℕ and the bounding number 𝔟",
+      "Mathlib: Cardinal.lt_cof_power, countable_iff_lt_aleph_one, Set.Countable.exists_eq_range, Cardinal.cantor"
+    ]
+  },
+  "sections": [
+    {
+      "id": "ch-oq0201-defs",
+      "title": "Part 0: Eventual Domination and the Cardinal Characteristics",
+      "summary": "Inlines the definitions matching continuum-hypothesis-oq-02: eventuallyDominates f g (f ≤* g), IsUnbounded F (no g dominates every member), and the bounding number boundingNumber = ⨅_F (if IsUnbounded F then #F else 2^ℵ₀), whose fallback branch keeps 𝔟 ≤ 2^ℵ₀.",
+      "startLine": 70,
+      "endLine": 89,
+      "mathContext": "The eventual-domination preorder $f \\le^* g$ and the least cardinality $\\mathfrak{b}$ of an unbounded family, defined so that $\\mathfrak{b} \\le 2^{\\aleph_0}$ by construction."
+    },
+    {
+      "id": "ch-oq0201-konig",
+      "title": "Part 1: The General König Cofinality Constraint",
+      "summary": "general_konig_cofinality: for every infinite κ, κ < cf(2^κ), directly from Cardinal.lt_cof_power. konig_cofinality_aleph0 recovers the parent's special case cf(2^ℵ₀) > ℵ₀.",
+      "startLine": 91,
+      "endLine": 111,
+      "mathContext": "König's theorem $\\kappa < \\mathrm{cf}(2^\\kappa)$ — so $2^\\kappa$ is never singular of cofinality $\\le \\kappa$."
+    },
+    {
+      "id": "ch-oq0201-diagonal",
+      "title": "Part 2: The Diagonalization",
+      "summary": "diagonal_dominates: the diagonal g(k) = (Finset.range (k+1)).sup (fun i => e i k) + 1 eventually dominates each e j (for k ≥ j via Finset.le_sup + omega). unbounded_uncountable: an unbounded family is uncountable (ℵ₁ ≤ #F), by contradiction — countability yields an enumeration whose diagonal contradicts unboundedness, and the empty family is separately non-unbounded.",
+      "startLine": 113,
+      "endLine": 156,
+      "mathContext": "Hausdorff diagonalization: a countable $\\{f_0,f_1,\\dots\\}$ is dominated by $g(k)=\\max_{i\\le k} f_i(k)+1$, so no countable family is unbounded."
+    },
+    {
+      "id": "ch-oq0201-bounding",
+      "title": "Part 3: ℵ₁ ≤ 𝔟 (De-Axiomatized)",
+      "summary": "aleph_one_le_two_pow_aleph0: ℵ₁ ≤ 2^ℵ₀ from Cantor via succ_aleph0. bounding_number_uncountable: ℵ₁ ≤ 𝔟 by le_ciInf over the two branches of the infimum (unbounded_uncountable / Cantor) — the parent's axiom, now a theorem. aleph0_lt_boundingNumber: ℵ₀ < 𝔟 as an immediate corollary.",
+      "startLine": 158,
+      "endLine": 189,
+      "mathContext": "$\\mathfrak{b} = \\bigsqcap_F (\\cdots)$ is bounded below by $\\aleph_1$ term-by-term, giving $\\aleph_1 \\le \\mathfrak{b}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The bounding-number lower bound ℵ₁ ≤ 𝔟 is proved with 0 axioms and 0 sorries via Hausdorff diagonalization, discharging the parent entry's axiom bounding_number_uncountable. The sharp general König constraint κ < cf(2^κ) is also recorded. 7 theorems, 3 definitions, 194 lines.",
+    "implications": "Removing the axiom makes the ZFC chain ℵ₁ ≤ 𝔟 ≤ 𝔡 ≤ 2^ℵ₀ rest on a fully machine-checked lower endpoint, and packages the reusable Hausdorff diagonalization (a countable family is bounded) as a standalone Mathlib-only lemma. The generalized König statement clarifies that no power 2^κ is singular of small cofinality.",
+    "openQuestions": [
+      "De-axiomatize the remaining constraints in continuum-hypothesis-oq-02 (e.g. the dominating-number and continuum relationships)",
+      "Formalize 𝔟 ≤ 𝔡 and 𝔡 ≤ 2^ℵ₀ to complete the cardinal-characteristic chain in Lean",
+      "Prove additional Cichoń-diagram inequalities among cardinal characteristics"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.SetTheory.Cardinal.Cofinality",
+      "Mathlib.SetTheory.Cardinal.Aleph",
+      "Mathlib.SetTheory.Cardinal.Basic",
+      "Mathlib.Data.Set.Countable",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "ContinuumHypothesisOQ02OQ01",
+    "lineCount": 194,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "path": "Proofs/ContinuumHypothesisOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "continuum-hypothesis-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry that axiomatized bounding_number_uncountable (ℵ₁ ≤ 𝔟); this entry proves it as a theorem and sharpens the König constraint"
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "related",
+      "description": "The Hausdorff diagonalization here is the cardinal-characteristics analogue of Cantor's diagonal argument"
+    },
+    {
+      "targetId": "continuum-hypothesis",
+      "relationship": "related",
+      "description": "Cardinal characteristics 𝔟, 𝔡 refine the question of the size of the continuum addressed by CH"
+    }
+  ],
+  "references": [
+    {
+      "key": "Ha36",
+      "citation": "Hausdorff, F., Summen von ℵ₁ Mengen, Fundamenta Mathematicae 26 (1936), 241-255. Early use of diagonalization / gaps in the eventual-domination order underlying the bounding number.",
+      "type": "paper"
+    },
+    {
+      "key": "Ko05",
+      "citation": "König, J., Zum Kontinuumproblem, Mathematische Annalen 60 (1905), 177-180. Proved the cofinality constraint cf(2^κ) > κ.",
+      "type": "paper"
+    },
+    {
+      "key": "Bl10",
+      "citation": "Blass, A., Combinatorial cardinal characteristics of the continuum, in Handbook of Set Theory (Foreman and Kanamori, eds.), Springer (2010), 395-489. Comprehensive survey including 𝔟 and 𝔡.",
+      "type": "paper"
+    },
+    {
+      "key": "mathlib",
+      "citation": "The mathlib Community, Mathlib4: SetTheory.Cardinal.Cofinality (lt_cof_power), SetTheory.Cardinal.Aleph (countable_iff_lt_aleph_one), Data.Set.Countable. The cardinal-arithmetic infrastructure used throughout.",
+      "type": "software"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Fix

Create the missing gallery entry (`meta.json` + `annotations.json`) for **continuum-hypothesis-oq-02-oq-01**.

## Evidence

**Before**: `proofs/Proofs/ContinuumHypothesisOQ02OQ01.lean` (verified, 0-axiom, 0-sorry, 7 theorems, 3 definitions, 194 lines) was merged to `main` via a standalone `research(continuum-hypothesis-oq-02-oq-01)` PR, but no `src/data/proofs/continuum-hypothesis-oq-02-oq-01/` directory was ever created — the proof was invisible in the web gallery.

**After**: gallery entry added, modeled on the sibling parent `continuum-hypothesis-oq-02`. The proof **discharges the parent's axiom** `bounding_number_uncountable`:

`ℵ₁ ≤ 𝔟` (bounding number)

by the classical **Hausdorff diagonalization** — a countable family of functions ℕ → ℕ is eventually dominated by its diagonal `g(k) = max_{i ≤ k} fᵢ(k) + 1`, so no countable family is unbounded. It also records the sharp general König cofinality constraint `κ < cf(2^κ)` for every infinite κ.

- `status`: `verified`, `badge`: `original`, `axiomCount`: `0`
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`
- 4 annotations covering the full file; schema verified to match the sibling entry exactly

---
Automated fix by lean-mechanic agent.