### PR TITLE
research(denumerability-rationals-oq-04-oq-04): promote countable algebraic numbers to Denumerable (explicit Q̄ ≅ ℕ) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DenumerabilityRationalsOQ04OQ04.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ04OQ04.lean
@@ -1,0 +1,102 @@
+/-
+# Promoting Countability of the Algebraic Numbers to Denumerability
+
+Open question (denumerability family, `denumerability-rationals-oq-04-oq-04`),
+building on `denumerability-rationals-oq-04` (the algebraic numbers over ℚ are
+countable):
+
+  "Can this proof be promoted from `Countable` to `Denumerable` — an explicit
+   bijection `Q̄ ≅ ℕ` — without sacrificing constructiveness? The challenge is
+   computing the index of a given algebraic number in the enumeration."
+
+## What is proved
+
+Let `AlgQ := {x : ℂ // IsAlgebraic ℚ x}` be the field of complex algebraic
+numbers. We give it a `Denumerable` structure — the strongest countability
+notion in Mathlib, an *explicit bijection with ℕ* — obtained by combining:
+
+* **Countability** `Algebraic.countable ℚ ℂ` (already in Mathlib: the algebraic
+  elements of a `Countable` base ring are countable), and
+* **Infinitude** `Infinite AlgQ` (ℚ embeds into `AlgQ` via `algebraMap ℚ ℂ`),
+
+through `Denumerable.ofEncodableOfInfinite`. This yields
+`algebraicEquivNat : AlgQ ≃ ℕ`, the requested bijection `Q̄ ≅ ℕ`, together with
+the cardinality statement `#AlgQ = ℵ₀`.
+
+## The constructive caveat (the open part of the question)
+
+The `Denumerable` instance here is **classical / noncomputable**: it factors
+through `Encodable.ofCountable`, which uses `Classical.choice` to extract an
+encoding from a mere countability proof. So the bijection exists but does not
+*compute* — it does not give an algorithm mapping an algebraic number to its
+index. A genuinely *constructive* enumeration (the "without sacrificing
+constructiveness" of the question) would require effective root isolation
+(Sturm sequences / Vincent's theorem) to list the roots of each integer
+polynomial in a computable order; that remains open (it is open question 1 of
+the parent). The honest status: denumerability holds, an explicit `≃ ℕ` exists,
+but computing the index is the unresolved constructive challenge.
+
+`Classical.choice`, `propext`, and `Quot.sound` are the only axioms used — the
+standard foundational trio, none of which is `Lean.ofReduceBool` or `sorryAx`.
+So this file is verified (0 sorries, 0 `axiom` declarations); it is merely
+`noncomputable`.
+
+Axioms: 0 (Classical.choice / propext / Quot.sound only — the foundational trio)
+Sorries: 0
+-/
+
+import Mathlib
+
+open Cardinal
+
+namespace DenumerabilityRationalsOQ04OQ04
+
+/-- The complex algebraic numbers over ℚ. -/
+abbrev AlgQ : Type := {x : ℂ // IsAlgebraic ℚ x}
+
+/-- The algebraic numbers are countable — Mathlib's `Algebraic.countable`
+specialised to `ℚ ⊆ ℂ` (ℚ is a countable base ring). -/
+instance : Countable AlgQ :=
+  (Algebraic.countable ℚ ℂ).to_subtype
+
+/-- ℚ embeds into the algebraic numbers via `algebraMap ℚ ℂ` (every rational is
+algebraic), so there are infinitely many algebraic numbers. -/
+instance : Infinite AlgQ :=
+  Infinite.of_injective
+    (fun q : ℚ => (⟨algebraMap ℚ ℂ q, isAlgebraic_algebraMap q⟩ : AlgQ))
+    (fun a b h =>
+      FaithfulSMul.algebraMap_injective ℚ ℂ (Subtype.ext_iff.1 h))
+
+/-- **The Denumerable instance.** Countable + Infinite gives an explicit
+bijection with ℕ. Classical/noncomputable: the encoding is extracted from the
+countability proof via `Classical.choice`. -/
+noncomputable instance instDenumerableAlgQ : Denumerable AlgQ :=
+  haveI : Encodable AlgQ := Encodable.ofCountable AlgQ
+  Denumerable.ofEncodableOfInfinite AlgQ
+
+/-- **The explicit bijection `Q̄ ≅ ℕ`** requested by the open question. -/
+noncomputable def algebraicEquivNat : AlgQ ≃ ℕ :=
+  Denumerable.eqv AlgQ
+
+/-- A `Denumerable` structure on the algebraic numbers exists (the choiceless
+existence statement, independent of the chosen instance). -/
+theorem nonempty_denumerable_algQ : Nonempty (Denumerable AlgQ) :=
+  nonempty_denumerable AlgQ
+
+/-- An explicit bijection between the algebraic numbers and ℕ exists. -/
+theorem nonempty_equiv_nat : Nonempty (AlgQ ≃ ℕ) :=
+  ⟨algebraicEquivNat⟩
+
+/-- The algebraic numbers have cardinality `ℵ₀` — the cardinal-arithmetic form
+of denumerability (Mathlib's `cardinalMk_of_countable_of_charZero`). -/
+theorem cardinalMk_algQ : #AlgQ = ℵ₀ :=
+  Algebraic.cardinalMk_of_countable_of_charZero ℚ ℂ
+
+/-- Denumerability is equivalent to `#AlgQ = ℵ₀`: the bijection with ℕ and the
+cardinal statement carry the same information. -/
+theorem denumerable_iff_cardinal : Nonempty (Denumerable AlgQ) ↔ #AlgQ = ℵ₀ := by
+  constructor
+  · intro _; exact cardinalMk_algQ
+  · intro _; exact nonempty_denumerable_algQ
+
+end DenumerabilityRationalsOQ04OQ04

--- a/src/data/proofs/denumerability-rationals-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-04-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-denum0404-docstring",
+    "proofId": "denumerability-rationals-oq-04-oq-04",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "concept",
+    "title": "Countable → Denumerable, and the Constructive Caveat",
+    "content": "The docstring frames the promotion: the parent proves the algebraic numbers are `Countable`; here we upgrade to `Denumerable`, Mathlib's strongest countability notion — an explicit bijection with ℕ. The crucial honesty: the instance is **classical/noncomputable**, factoring through `Encodable.ofCountable` (which uses `Classical.choice`). So the bijection Q̄ ≅ ℕ exists but does not compute an index for a given algebraic number; a genuinely constructive enumeration (effective root isolation) is the parent's open question 1 and remains unresolved. `#print axioms` shows only propext/Classical.choice/Quot.sound — none counting — so the file is verified, merely noncomputable."
+  },
+  {
+    "id": "ann-denum0404-countable",
+    "proofId": "denumerability-rationals-oq-04-oq-04",
+    "range": { "startLine": 54, "endLine": 60 },
+    "type": "concept",
+    "title": "Countability from Mathlib",
+    "content": "AlgQ := {x : ℂ // IsAlgebraic ℚ x} is the field of complex algebraic numbers. Its `Countable` instance is Mathlib's `Algebraic.countable ℚ ℂ` (the algebraic elements over a countable base ring are countable), transported to the subtype by `.to_subtype`. This is Cantor's 1874 theorem, already in the library."
+  },
+  {
+    "id": "ann-denum0404-infinite",
+    "proofId": "denumerability-rationals-oq-04-oq-04",
+    "range": { "startLine": 62, "endLine": 68 },
+    "type": "proof-technique",
+    "title": "Infinitude via the Embedding of ℚ",
+    "content": "The `Infinite` instance embeds the (already infinite) rationals into the algebraic numbers: q ↦ ⟨algebraMap ℚ ℂ q, isAlgebraic_algebraMap q⟩ (every rational is algebraic). Injectivity follows from `FaithfulSMul.algebraMap_injective ℚ ℂ` applied through `Subtype.ext_iff`, so `Infinite.of_injective` gives `Infinite AlgQ`. Infinitude is the only ingredient beyond the parent's countability needed for the promotion."
+  },
+  {
+    "id": "ann-denum0404-denumerable",
+    "proofId": "denumerability-rationals-oq-04-oq-04",
+    "range": { "startLine": 70, "endLine": 79 },
+    "type": "key-insight",
+    "title": "The Denumerable Instance and the Bijection Q̄ ≅ ℕ",
+    "content": "`instDenumerableAlgQ` combines an `Encodable AlgQ` (obtained noncomputably from countability via `Encodable.ofCountable`) with the `Infinite` instance, feeding both to `Denumerable.ofEncodableOfInfinite`. `algebraicEquivNat := Denumerable.eqv AlgQ` is then the explicit bijection Q̄ ≅ ℕ requested by the open question. The `noncomputable` marker is the visible trace of the Classical.choice used inside `Encodable.ofCountable`."
+  },
+  {
+    "id": "ann-denum0404-existence",
+    "proofId": "denumerability-rationals-oq-04-oq-04",
+    "range": { "startLine": 81, "endLine": 88 },
+    "type": "concept",
+    "title": "Choiceless Existence Statements",
+    "content": "`nonempty_denumerable_algQ : Nonempty (Denumerable AlgQ)` (from Mathlib's `nonempty_denumerable`, requiring only Countable + Infinite) and `nonempty_equiv_nat : Nonempty (AlgQ ≃ ℕ)` record the existence of the structure and bijection independently of any particular chosen instance."
+  },
+  {
+    "id": "ann-denum0404-cardinal",
+    "proofId": "denumerability-rationals-oq-04-oq-04",
+    "range": { "startLine": 90, "endLine": 102 },
+    "type": "key-insight",
+    "title": "The Cardinality Form #AlgQ = ℵ₀",
+    "content": "`cardinalMk_algQ : #AlgQ = ℵ₀` is the cardinal-arithmetic form of denumerability, from Mathlib's `cardinalMk_of_countable_of_charZero` (ℚ countable, ℂ of characteristic zero). `denumerable_iff_cardinal` proves `Nonempty (Denumerable AlgQ) ↔ #AlgQ = ℵ₀`, confirming that the explicit bijection with ℕ and the statement 'cardinality ℵ₀' carry precisely the same information."
+  }
+]

--- a/src/data/proofs/denumerability-rationals-oq-04-oq-04/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-04-oq-04/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "denumerability-rationals-oq-04-oq-04",
+  "title": "Promoting Countability of the Algebraic Numbers to Denumerability",
+  "slug": "denumerability-rationals-oq-04-oq-04",
+  "description": "Promotes the countability of the complex algebraic numbers over ℚ (parent denumerability-rationals-oq-04) to a full Denumerable structure — an explicit bijection Q̄ ≅ ℕ — by combining Mathlib's Algebraic.countable with an Infinite instance (ℚ embeds). Yields algebraicEquivNat : {x : ℂ // IsAlgebraic ℚ x} ≃ ℕ and #AlgQ = ℵ₀. The instance is classical/noncomputable; a constructive index-computing enumeration remains open. 0 sorries, only the foundational axioms (Classical.choice/propext/Quot.sound).",
+  "meta": {
+    "author": "Cantor (countability of algebraic numbers, 1874); Denumerable promotion",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ04OQ04.lean",
+    "tags": [
+      "set-theory",
+      "countability",
+      "denumerable",
+      "algebraic-numbers",
+      "cardinality",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 102,
+    "assumptions": "None that count. 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms shows only [propext, Classical.choice, Quot.sound] — the standard foundational trio, none of which is Lean.ofReduceBool or sorryAx. The Denumerable instance is noncomputable (the encoding is extracted from the countability proof via Classical.choice); a genuinely constructive, index-computing enumeration is NOT provided and remains open (parent open question 1). Verified via lake env lean against Mathlib.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 5
+  },
+  "overview": {
+    "historicalContext": "Cantor's 1874 paper — the birth of set theory — proved that the algebraic numbers are countable, and used this to give the first proof that transcendental numbers exist (the reals being uncountable). In Lean/Mathlib the countability of the algebraic elements over a countable base ring is `Algebraic.countable`. Mathlib distinguishes several strengths of countability: `Countable` (a surjection from ℕ, or equivalently an injection into ℕ) is the weakest; `Encodable` adds a concrete encode/decode pair; and `Denumerable` is the strongest — an explicit bijection with ℕ, available exactly for the countably infinite types. The parent entry denumerability-rationals-oq-04 establishes `Countable`; this entry promotes it to `Denumerable`, the level at which one has a genuine enumeration Q̄ ≅ ℕ.",
+    "problemStatement": "Can the countability of the algebraic numbers be promoted from `Countable` to `Denumerable` — an explicit bijection Q̄ ≅ ℕ — and can this be done constructively (computing the index of a given algebraic number)?",
+    "text": "For AlgQ = {x : ℂ // IsAlgebraic ℚ x}, `Denumerable AlgQ` is obtained from two ingredients: countability (`Algebraic.countable ℚ ℂ`, since ℚ is a countable base ring) and infinitude (`Infinite AlgQ`, since ℚ embeds via `algebraMap ℚ ℂ` and every rational is algebraic). Mathlib's `Denumerable.ofEncodableOfInfinite` then produces the bijection.",
+    "proofStrategy": "Register `Countable AlgQ` from `Algebraic.countable ℚ ℂ |>.to_subtype`. Prove `Infinite AlgQ` by `Infinite.of_injective` applied to q ↦ ⟨algebraMap ℚ ℂ q, isAlgebraic_algebraMap q⟩, with injectivity from `FaithfulSMul.algebraMap_injective`. Obtain `Encodable AlgQ` via `Encodable.ofCountable` (noncomputable, uses Classical.choice) and feed it, with the Infinite instance, to `Denumerable.ofEncodableOfInfinite`. Expose the bijection as `algebraicEquivNat := Denumerable.eqv AlgQ`, and record `#AlgQ = ℵ₀` from Mathlib's `cardinalMk_of_countable_of_charZero`, plus the equivalence `Nonempty (Denumerable AlgQ) ↔ #AlgQ = ℵ₀`.",
+    "keyInsights": [
+      "**Countable + Infinite = Denumerable.** The only gap between the parent's countability result and a full bijection with ℕ is infinitude, which is immediate because ℚ (already infinite) embeds into the algebraic numbers.",
+      "**ℵ₀ is denumerability in cardinal form.** `#AlgQ = ℵ₀` and `Nonempty (Denumerable AlgQ)` carry exactly the same information; the file proves both and their equivalence.",
+      "**The classical/constructive divide is the real content of the question.** The `Denumerable` instance is noncomputable: `Encodable.ofCountable` uses `Classical.choice` to conjure an encoding from a bare countability proof. The bijection exists but does not compute an index for a given algebraic number.",
+      "**Constructive enumeration remains open.** A computable index would need effective root isolation (Sturm sequences / Vincent's theorem) to list the roots of each integer polynomial in computable order — this is the parent's open question 1 and is not resolved here.",
+      "**Axiom honesty.** #print axioms confirms only propext/Classical.choice/Quot.sound — the foundational trio — so the entry is verified (no Lean.ofReduceBool, no sorryAx); it is simply noncomputable."
+    ],
+    "prerequisites": [
+      "Countability hierarchy in Mathlib (Countable, Encodable, Denumerable)",
+      "Algebraic numbers and IsAlgebraic",
+      "Cardinal arithmetic (ℵ₀)",
+      "The role of Classical.choice and the notion of a noncomputable definition"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-denum0404-preamble",
+      "title": "Documentation and Imports",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring stating the promotion goal (Countable → Denumerable, an explicit Q̄ ≅ ℕ), the classical/noncomputable caveat (the constructive index-computing enumeration remains open), and the axiom disclosure (only the foundational trio). Imports Mathlib and opens the Cardinal namespace."
+    },
+    {
+      "id": "sec-denum0404-countable-infinite",
+      "title": "Countable and Infinite Instances",
+      "startLine": 54,
+      "endLine": 68,
+      "summary": "Defines AlgQ = {x : ℂ // IsAlgebraic ℚ x}. The Countable instance comes from Mathlib's Algebraic.countable ℚ ℂ (ℚ is a countable base ring). The Infinite instance embeds ℚ via q ↦ ⟨algebraMap ℚ ℂ q, isAlgebraic_algebraMap q⟩, injective by FaithfulSMul.algebraMap_injective."
+    },
+    {
+      "id": "sec-denum0404-denumerable",
+      "title": "The Denumerable Instance and the Bijection",
+      "startLine": 70,
+      "endLine": 88,
+      "summary": "instDenumerableAlgQ combines Encodable.ofCountable (noncomputable, Classical.choice) with the Infinite instance via Denumerable.ofEncodableOfInfinite. algebraicEquivNat := Denumerable.eqv AlgQ is the explicit bijection Q̄ ≅ ℕ; nonempty_denumerable_algQ and nonempty_equiv_nat give the choiceless existence statements."
+    },
+    {
+      "id": "sec-denum0404-cardinal",
+      "title": "Cardinality Form",
+      "startLine": 90,
+      "endLine": 102,
+      "summary": "cardinalMk_algQ proves #AlgQ = ℵ₀ from Mathlib's cardinalMk_of_countable_of_charZero, and denumerable_iff_cardinal records that Nonempty (Denumerable AlgQ) ↔ #AlgQ = ℵ₀ — the bijection and the cardinal statement are interchangeable."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers open question 4 of denumerability-rationals-oq-04: the countability of the complex algebraic numbers over ℚ is promoted to a full Denumerable structure — an explicit bijection algebraicEquivNat : {x : ℂ // IsAlgebraic ℚ x} ≃ ℕ — together with the cardinal statement #AlgQ = ℵ₀. All results are machine-checked with 0 sorries and depend only on the foundational axioms (propext/Classical.choice/Quot.sound).",
+    "implications": "Denumerability is the level at which countability becomes a genuine enumeration usable for indexing, diagonalization, and recursion. The promotion is a one-line consequence of countability plus infinitude, cleanly separating the (settled) existence of a bijection from the (open) problem of computing it. The remaining constructive challenge — an algorithm mapping an algebraic number to its index — is tied to effective root isolation and is documented as the parent's open question 1.",
+    "openQuestions": [
+      "Provide a genuinely constructive (computable) enumeration of the algebraic numbers via effective root isolation (Sturm sequences / Vincent's theorem), giving a Denumerable instance that actually computes indices — the parent's open question 1.",
+      "Decide algebraic membership constructively: given a description of a complex number, can Lean decide IsAlgebraic z? (parent open question 2)",
+      "Formalize Liouville's 1844 explicit transcendental construction as a witness for a specific number outside the enumeration (parent open question 3)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-04",
+      "relationship": "extends",
+      "description": "Promotes the parent's Countable result for the algebraic numbers to a full Denumerable structure (explicit bijection with ℕ), answering its open question 4."
+    },
+    {
+      "targetId": "denumerability-rationals",
+      "relationship": "related",
+      "description": "Part of the denumerability family; the algebraic numbers are the canonical countably-infinite field extending ℚ."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Cantor, G."
+      ],
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": 1874,
+      "venue": "Journal für die reine und angewandte Mathematik 77, pp. 258–262",
+      "note": "First proof that the algebraic numbers are countable and that transcendentals exist."
+    },
+    {
+      "authors": [
+        "The mathlib Community"
+      ],
+      "title": "Mathlib: Algebra.AlgebraicCard",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Algebraic.countable and cardinalMk_of_countable_of_charZero: countability and ℵ₀-cardinality of algebraic elements."
+    },
+    {
+      "authors": [
+        "Liouville, J."
+      ],
+      "title": "Sur des classes très étendues de quantités dont la valeur n'est ni algébrique...",
+      "year": 1844,
+      "venue": "Comptes Rendus de l'Académie des Sciences",
+      "note": "First explicit transcendental numbers (context for the constructive open questions)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ04OQ04",
+    "lineCount": 102,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 5,
+    "path": "Proofs/DenumerabilityRationalsOQ04OQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question 4** of `denumerability-rationals-oq-04`: promote the countability of the complex algebraic numbers over ℚ to a full `Denumerable` structure — an explicit bijection `Q̄ ≅ ℕ`.

For `AlgQ = {x : ℂ // IsAlgebraic ℚ x}`:
- **Countable** from Mathlib's `Algebraic.countable ℚ ℂ` (Cantor 1874).
- **Infinite**: ℚ embeds via `algebraMap ℚ ℂ` (every rational is algebraic).
- **Denumerable** via `Denumerable.ofEncodableOfInfinite`, giving the explicit bijection `algebraicEquivNat : AlgQ ≃ ℕ` and the cardinal form `#AlgQ = ℵ₀`, with `denumerable_iff_cardinal` tying them together.

## Honest scope (the open part)

The `Denumerable` instance is **classical / noncomputable**: `Encodable.ofCountable` uses `Classical.choice` to extract an encoding from a bare countability proof, so the bijection *exists* but does not *compute* an index for a given algebraic number. A genuinely constructive, index-computing enumeration (via effective root isolation — Sturm sequences / Vincent's theorem) is the parent's open question 1 and remains open; this is disclosed in the entry.

## Verification
- `#print axioms` shows only `[propext, Classical.choice, Quot.sound]` — the foundational trio, **none counting** (no `Lean.ofReduceBool`, no `sorryAx`). Verified, `noncomputable`.
- `lake env lean` — clean, **0 errors, 0 sorries, 0 axiom declarations**. 102 lines.
- **Self-contained on Mathlib**: the parent `.lean` is currently drift-broken (a `simp` now closes a goal; a doc-comment syntax error), so this file deliberately reuses Mathlib's own `Algebraic.countable` / `IsAlgebraic ℚ` rather than importing the parent.
- New gallery entry `src/data/proofs/denumerability-rationals-oq-04-oq-04/` (meta + 6 annotations), `status: verified`.

> Note for maintainers: `proofs/Proofs/DenumerabilityRationalsOQ04.lean` (the parent) no longer compiles under current Mathlib — worth a separate repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)