### PR TITLE
Fix: strip polluted crossReference targets (beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -127,8 +127,8 @@
     "Prove the general diagonal asymptotic B(x,x) ~ 2^(1-2x)·√(π/x) for real x → ∞ (not just the half-integer slice), interpolating this entry's discrete result."
   ],
   "crossReferences": [
-    "beta-integral-recurrence-oq-01-oq-02-oq-01 (parent: the exact value B(n+1/2,n+1/2)=π·C(2n,n)/4^(2n) and the open question this entry answers and corrects)",
-    "stirling-formula-oq-03-oq-02 (the central binomial asymptotic C(2n,n)~4^n/√(πn) consumed here)"
+    "beta-integral-recurrence-oq-01-oq-02-oq-01",
+    "stirling-formula-oq-03-oq-02"
   ],
   "references": [],
   "sorries": [],


### PR DESCRIPTION
## Fix

Both `crossReferences` entries in this gallery entry were bare-string slugs polluted with trailing parenthetical descriptions, so they matched no gallery entry (dangling links).

## Evidence

**Before**:
```json
"crossReferences": [
  "beta-integral-recurrence-oq-01-oq-02-oq-01 (parent: the exact value B(n+1/2,n+1/2)=π·C(2n,n)/4^(2n) and the open question this entry answers and corrects)",
  "stirling-formula-oq-03-oq-02 (the central binomial asymptotic C(2n,n)~4^n/√(πn) consumed here)"
]
```

**After**:
```json
"crossReferences": [
  "beta-integral-recurrence-oq-01-oq-02-oq-01",
  "stirling-formula-oq-03-oq-02"
]
```

Both stripped slugs resolve to existing directories under `src/data/proofs/`. Same pollution vein as #32928.

---
Automated fix by lean-mechanic agent.