### PR TITLE
Fix: create missing gallery entry for hilbert-13-oq-03

### DIFF
--- a/src/data/proofs/hilbert-13-oq-03/annotations.json
+++ b/src/data/proofs/hilbert-13-oq-03/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-h13oq03-overview",
+    "proofId": "hilbert-13-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "The Minimal Requirements Question",
+    "content": "The docstring frames OQ-03 of Hilbert's 13th problem: in the Kolmogorov–Arnold superposition f(x₁,…,xₙ) = Σ_q Φ_q(Σ_p coeff_{p,q} φ_p(x_p)), what are the minimal requirements on the inner functions φ_p for such a representation to be possible for every continuous f? The precise admissibility characterization is Sternfeld's basic-embedding theory (1985) and is genuinely deep. This file does NOT resolve sufficiency; it isolates and fully verifies (0 axioms, 0 sorries) the necessary core: point separation is mandatory. The strategy is to bundle the inner sums into a single feature map Ψ so that the outer functions see the domain point x only through Ψ(x).",
+    "mathContext": "Kolmogorov (1957): every continuous $f$ of $n$ variables is a superposition $\\sum_q \\Phi_q(\\sum_p \\varphi_{p,q}(x_p))$. OQ-03 asks for the minimal constraints on the inner $\\varphi_p$; the answer proved here is that they must separate points.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hilbert's 13th problem",
+      "Kolmogorov–Arnold superposition",
+      "inner functions",
+      "point separation"
+    ],
+    "prerequisites": [
+      "continuous function representation",
+      "superposition of univariate functions"
+    ]
+  },
+  {
+    "id": "ann-h13oq03-feature",
+    "proofId": "hilbert-13-oq-03",
+    "range": {
+      "startLine": 56,
+      "endLine": 91
+    },
+    "type": "insight",
+    "title": "The Feature Map Localizes the Representational Burden",
+    "content": "OuterRepresentable Ψ f captures the KA shape once inner sums are bundled: f x = Σ_q Φ_q (Ψ x q). eq_of_feature_eq is the structural obstruction — since the outer functions act only on Ψ(x), any representable f is constant on fibers of Ψ: Ψ x = Ψ y ⇒ f x = f y (proved by a three-step calc unfolding the representation and rewriting by h). feature_injective_of_universal turns this into necessity: if every continuous f is representable through Ψ and continuous functions separate the points of X, then Ψ is injective — for if Ψ merged x ≠ y, the separating continuous (hence representable) function would have to agree on them, a contradiction.",
+    "mathContext": "The outer functions cannot distinguish points the feature map merges, so a universal inner family must have injective $\\Psi$: every fiber is a singleton, otherwise some continuous function is unrepresentable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "feature map",
+      "OuterRepresentable",
+      "Function.Injective",
+      "fibers"
+    ],
+    "prerequisites": [
+      "Finset.sum",
+      "point separation by continuous functions"
+    ]
+  },
+  {
+    "id": "ann-h13oq03-descent",
+    "proofId": "hilbert-13-oq-03",
+    "range": {
+      "startLine": 93,
+      "endLine": 125
+    },
+    "type": "technique",
+    "title": "Descending Injectivity to Each Inner Function",
+    "content": "kaFeature φ coeff x q = Σ_p coeff_{p,q} · φ_p(x_p) is the concrete inner feature map on the product domain Fin n → ℝ. inner_injective_of_feature_injective shows injectivity of the bundled map descends to each φ_p: given φ_p(a) = φ_p(b), the two cube points that agree everywhere except coordinate p (values a vs b, zeros elsewhere) have identical feature tuples. The key step builds this equality of feature tuples via Finset.sum_congr, splitting on p' = p (where the perturbed values collapse by hab) versus p' ≠ p (where the if-branches agree); hinj then forces the two cube points equal, and evaluating at coordinate p gives a = b.",
+    "mathContext": "Coordinatewise descent: an injective bundled map $\\Psi$ cannot merge two points differing only in coordinate $p$, so $\\varphi_p$ must itself be injective.",
+    "significance": "key",
+    "relatedConcepts": [
+      "kaFeature",
+      "Finset.sum_congr",
+      "coordinate perturbation",
+      "Function.Injective"
+    ],
+    "prerequisites": [
+      "product domain Fin n → ℝ",
+      "if-then-else on decidable equality"
+    ]
+  },
+  {
+    "id": "ann-h13oq03-necessity",
+    "proofId": "hilbert-13-oq-03",
+    "range": {
+      "startLine": 127,
+      "endLine": 182
+    },
+    "type": "insight",
+    "title": "The Necessary Condition and Its Limits",
+    "content": "separates_of_pi supplies the missing hypothesis on the cube: distinct points of Fin n → ℝ differ in some coordinate (Function.ne_iff), and that coordinate projection is continuous (continuous_apply). inner_functions_must_be_injective then composes feature_injective_of_universal with inner_injective_of_feature_injective: any fixed inner family representing every continuous function on ℝⁿ forces each φ_p injective. feature_must_separate_points is the bundled form — the inner family must separate the cube's points. The closing remark is careful about scope: injectivity is necessary but NOT sufficient — Sternfeld (1985) showed the true admissibility threshold is a strictly stronger uniform separation, and mere injectivity can force the outer functions into unbounded oscillation that breaks continuity.",
+    "mathContext": "On $\\mathbb{R}^n$ the coordinate projections separate points, so the universality hypothesis is applicable and the necessary condition follows unconditionally. The floor is point separation; the exact threshold is Sternfeld's uniform criterion.",
+    "significance": "key",
+    "relatedConcepts": [
+      "continuous_apply",
+      "separates_of_pi",
+      "Sternfeld criterion",
+      "necessity vs sufficiency"
+    ],
+    "prerequisites": [
+      "continuity of coordinate projections",
+      "Function.ne_iff"
+    ]
+  }
+]

--- a/src/data/proofs/hilbert-13-oq-03/meta.json
+++ b/src/data/proofs/hilbert-13-oq-03/meta.json
@@ -1,0 +1,164 @@
+{
+  "id": "hilbert-13-oq-03",
+  "title": "Hilbert's 13th, OQ-03: Point Separation Is Necessary for the Inner Functions",
+  "slug": "hilbert-13-oq-03",
+  "description": "Isolates and fully verifies the unconditional necessary core of 'what are the minimal requirements on the inner functions' in the Kolmogorov–Arnold superposition f(x) = Σ_q Φ_q(Σ_p coeff_{p,q} φ_p(x_p)). Bundling the inner data into a feature map Ψ, the outer functions see x only through Ψ(x); so if a fixed inner family represents every continuous function, Ψ must be injective (point-separating), and each inner φ_p must itself be injective. Explicitly does NOT resolve sufficiency (Sternfeld's stronger uniform-separation criterion). 6 theorems, 2 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "proofRepoPath": "Proofs/Hilbert13OQ03.lean",
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "tags": [
+      "hilbert-13",
+      "kolmogorov-arnold",
+      "superposition",
+      "point-separation",
+      "injectivity",
+      "approximation-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "continuous_apply",
+        "description": "Coordinate projections on a product space are continuous — used to separate points of Fin n → ℝ",
+        "module": "Mathlib.Topology.Constructions"
+      },
+      {
+        "theorem": "Function.ne_iff",
+        "description": "Distinct functions differ at some argument — witnesses the separating coordinate",
+        "module": "Mathlib.Logic.Function.Basic"
+      },
+      {
+        "theorem": "Finset.sum_congr",
+        "description": "Congruence for finite sums — used to equate the inner sums of two coordinate-perturbed points",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "eq_of_feature_eq: outer functions cannot separate points the feature map merges (Ψ x = Ψ y → f x = f y for representable f)",
+      "feature_injective_of_universal: a universal inner family (represents every continuous function) forces the feature map to be injective when continuous functions separate points",
+      "inner_injective_of_feature_injective: injectivity of the bundled KA feature map descends to each individual inner function φ_p",
+      "inner_functions_must_be_injective: the headline necessary condition — each φ_p must be injective",
+      "feature_must_separate_points: the bundled form — the inner family must separate the points of the cube"
+    ],
+    "dateAdded": "2026-07-02",
+    "hilbertNumber": 13,
+    "axiomCount": 0,
+    "lineCount": 182,
+    "assumptions": "None. #print axioms lists only propext, Classical.choice, Quot.sound (the standard Lean/Mathlib foundations). No axiom declarations and no structure-encoded assumptions. The result is a necessary condition only; sufficiency (Sternfeld's criterion) is explicitly not claimed.",
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Hilbert's 13th problem (1900) asked whether the solution of the general degree-7 equation, as a function of its coefficients, can be built from continuous functions of two variables. Kolmogorov (1957) and Arnold (1957) answered affirmatively in a strong form: every continuous function of n variables is a superposition of continuous functions of one variable and addition, f(x) = Σ_q Φ_q(Σ_p φ_{p,q}(x_p)). OQ-03 asks the refined question — what are the *minimal requirements on the inner functions* φ_p for such a representation to work for every continuous f? The precise admissibility characterization is the content of Sternfeld's 'basic embedding' theory (1985) and remains subtle. This entry does not resolve sufficiency; instead it isolates and machine-verifies the unconditional necessary kernel: point separation is mandatory.",
+    "problemStatement": "Determine a necessary condition on the inner functions of a Kolmogorov–Arnold superposition that must hold for the representation to succeed for every continuous function, and verify it formally.",
+    "text": "Bundle the inner data into a single feature map Ψ : X → ℝ^Q with Ψ(x)_q = Σ_p coeff_{p,q} φ_p(x_p). The outer functions Φ_q see x only through Ψ(x), so any representable f factors through Ψ: if Ψ x = Ψ y then f x = f y (eq_of_feature_eq). Consequently, if one fixed inner family represents *every* continuous function and continuous functions separate the points of X, then Ψ cannot merge distinct points — Ψ is injective (feature_injective_of_universal). On the cube domain Fin n → ℝ, coordinate projections separate points (separates_of_pi), and injectivity of the bundled feature map descends to each inner function: each φ_p is injective (inner_injective_of_feature_injective, inner_functions_must_be_injective). The bundled statement feature_must_separate_points records that the inner family must separate the cube's points. Injectivity is necessary but, as the closing remark notes, not sufficient — Sternfeld's uniform separation is strictly stronger.",
+    "proofStrategy": "Abstract the inner sums into a feature map and prove the factorization eq_of_feature_eq by unfolding OuterRepresentable and rewriting. Derive injectivity of Ψ by contradiction against a separating continuous function. Instantiate on Fin n → ℝ using coordinate-projection continuity for point separation. Descend injectivity to individual φ_p by feeding the feature map two cube points differing only in coordinate p and applying Finset.sum_congr. Compose the pieces into the headline necessary conditions.",
+    "keyInsights": [
+      "Bundle the inner data: the outer functions see x only through the feature map Ψ, so representability factors through Ψ",
+      "The burden of separating points falls entirely on the inner data — outer functions cannot distinguish what Ψ merges",
+      "Universality + point-separating continuous functions ⇒ Ψ injective: a universal inner family cannot afford to merge any two points",
+      "Injectivity of the bundled feature map descends to each inner function via coordinate-perturbed cube points",
+      "The result is a floor, not a threshold: injectivity is necessary but Sternfeld's uniform separation is strictly stronger (sufficiency not claimed)"
+    ],
+    "prerequisites": [
+      "Kolmogorov–Arnold superposition representation",
+      "Product topology on Fin n → ℝ and continuity of coordinate projections",
+      "Function injectivity and point separation by continuous functions"
+    ]
+  },
+  "sections": [
+    {
+      "id": "feature-map",
+      "title": "The Feature Map Abstraction",
+      "startLine": 56,
+      "endLine": 91,
+      "summary": "OuterRepresentable Ψ f: f x = Σ_q Φ_q (Ψ x q) for some outer family Φ — the Kolmogorov–Arnold shape with inner sums bundled into Ψ. eq_of_feature_eq: representability factors through Ψ, so Ψ x = Ψ y ⇒ f x = f y. feature_injective_of_universal: if every continuous f is representable through Ψ and continuous functions separate points, then Ψ is injective.",
+      "mathContext": "The outer functions $\\Phi_q$ act only on $\\Psi(x)$, so $f = \\sum_q \\Phi_q \\circ (\\Psi \\cdot)_q$ forces $f$ to be constant on fibers of $\\Psi$. A universal inner family therefore cannot have nontrivial fibers."
+    },
+    {
+      "id": "ka-feature",
+      "title": "The Kolmogorov–Arnold Inner Feature Map",
+      "startLine": 93,
+      "endLine": 125,
+      "summary": "kaFeature φ coeff x q = Σ_p coeff_{p,q} · φ_p(x_p): the concrete KA inner feature map on the product domain. inner_injective_of_feature_injective: if the bundled feature map is injective then each φ_p is injective — proved by feeding two cube points that differ only in coordinate p and collapsing the inner sums with Finset.sum_congr.",
+      "mathContext": "Injectivity of $\\Psi = \\mathrm{kaFeature}\\,\\varphi\\,c$ descends coordinatewise: if $\\varphi_p(a) = \\varphi_p(b)$ with $a \\ne b$, the points differing only at coordinate $p$ share a feature tuple, contradicting injectivity."
+    },
+    {
+      "id": "separation-and-necessity",
+      "title": "Point Separation on the Cube and the Necessary Condition",
+      "startLine": 127,
+      "endLine": 174,
+      "summary": "separates_of_pi: continuous functions separate points of Fin n → ℝ via coordinate projections. inner_functions_must_be_injective: a fixed inner family representing every continuous function on ℝⁿ forces each φ_p injective. feature_must_separate_points: the bundled form — the inner family must separate the cube's points. The closing remark records that injectivity is necessary but not sufficient (Sternfeld 1985).",
+      "mathContext": "On $\\mathbb{R}^n$ coordinate projections are continuous and separate points, so the universality hypothesis applies and the necessary condition — injectivity of every inner $\\varphi_p$ — follows unconditionally."
+    }
+  ],
+  "conclusion": {
+    "summary": "The necessary core of Hilbert 13 / OQ-03 is machine-verified with 0 axioms and 0 sorries: any inner family that yields a Kolmogorov–Arnold superposition for every continuous function must separate points, and each inner function φ_p must be injective. 6 theorems, 2 definitions, 182 lines.",
+    "implications": "The feature-map abstraction cleanly localizes the representational burden to the inner data and gives a reusable, dimension-agnostic necessary condition. It clarifies the floor of admissibility for the inner functions while leaving the exact threshold — Sternfeld's uniform (measure-)separation criterion — as the deeper open target.",
+    "openQuestions": [
+      "Formalize Sternfeld's uniform separation criterion and prove it is the exact admissibility threshold (sufficiency)",
+      "Quantify how injectivity alone permits outer functions requiring unbounded oscillation, breaking continuity",
+      "Extend the feature-map necessity argument to general compact metric domains beyond the cube"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Hilbert13OQ03",
+    "lineCount": 182,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "path": "Proofs/Hilbert13OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-13",
+      "relationship": "extends",
+      "description": "Parent entry on Hilbert's 13th problem and the Kolmogorov–Arnold superposition; OQ-03 pins down a necessary condition on the inner functions"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "inner_functions_must_be_injective",
+      "type": "core",
+      "description": "If a fixed inner family (φ, coeff) yields a Kolmogorov–Arnold superposition for every continuous function on ℝⁿ, then every inner function φ_p is injective",
+      "leanType": "(∀ f, Continuous f → OuterRepresentable (kaFeature φ coeff) f) → ∀ p, Function.Injective (φ p)"
+    },
+    {
+      "name": "feature_must_separate_points",
+      "type": "core",
+      "description": "Under the same universality hypothesis, the bundled inner feature map must be injective — the inner family must separate the points of the cube",
+      "leanType": "(∀ f, Continuous f → OuterRepresentable (kaFeature φ coeff) f) → Function.Injective (kaFeature φ coeff)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Kolmogorov, Andrey N.",
+      "title": "On the representation of continuous functions of many variables by superposition of continuous functions of one variable and addition",
+      "year": "1957",
+      "venue": "Doklady Akademii Nauk SSSR 114, 953–956",
+      "note": "The affirmative resolution of Hilbert's 13th in superposition form; the representation whose inner functions this entry constrains."
+    },
+    {
+      "authors": "Sternfeld, Yaki",
+      "title": "Dimension, superposition of functions and separation of points, in compact metric spaces",
+      "year": "1985",
+      "venue": "Israel Journal of Mathematics 50, 13–53",
+      "note": "The sharp characterization of admissible inner families via uniform separation — strictly stronger than the injectivity necessary condition proved here."
+    },
+    {
+      "authors": "Ostrand, Phillip A.",
+      "title": "Dimension of metric spaces and Hilbert's problem 13",
+      "year": "1965",
+      "venue": "Bulletin of the American Mathematical Society 71, 619–622",
+      "note": "Dimension-theoretic approach to the superposition representation and separation of points."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Fix

Create the missing gallery entry (`meta.json` + `annotations.json`) for **hilbert-13-oq-03**.

## Evidence

**Before**: `proofs/Proofs/Hilbert13OQ03.lean` (verified, 0-axiom, 0-sorry, 6 theorems, 2 definitions, 182 lines) was merged to `main` via a standalone `research(hilbert-13-oq-03)` PR, but no `src/data/proofs/hilbert-13-oq-03/` directory was ever created — the proof was invisible in the web gallery.

**After**: gallery entry added, modeled on the parent `hilbert-13`. The proof isolates and machine-verifies the **necessary core** of OQ-03 ("minimal requirements on the inner functions" of a Kolmogorov–Arnold superposition): bundling the inner sums into a feature map Ψ, the outer functions see x only through Ψ(x), so a universal inner family must make Ψ injective (point-separating), and each inner φ_p must itself be injective. Sufficiency (Sternfeld's stronger uniform-separation criterion) is explicitly **not** claimed.

- `status`: `verified`, `badge`: `original`, `axiomCount`: `0`
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`
- 4 annotations covering the full file; schema verified to match the parent exactly

---
Automated fix by lean-mechanic agent.