### PR TITLE
Fix: create missing gallery entry for three-place-identity-oq-01

### DIFF
--- a/src/data/proofs/three-place-identity-oq-01/annotations.json
+++ b/src/data/proofs/three-place-identity-oq-01/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-tpioq01-overview",
+    "proofId": "three-place-identity-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "concept",
+    "title": "Making 'Foundation Is Essential' Precise",
+    "content": "The docstring states OQ-01: the parent file ThreePlaceIdentity.lean proves the Round-Trip Theorem under the Foundation axiom ∀ x, ¬ mem x x, and its prose asserts Foundation is 'essential' and the round-trip 'breaks down' without it — but never proves this. OQ-01 asks whether Foundation is necessary (not merely sufficient) and what exactly happens when it fails. The answer is a sharp characterization: writing D for the derived membership (mem →D2→ identity →D1→ mem'), the single identity D(mem) y x ↔ ¬(mem y x ↔ mem x x) yields sufficiency, necessity, inversion, and self-regularization. Everything is pure classical propositional logic (0 axioms, 0 sorries), reusing the parent's definitions unchanged.",
+    "mathContext": "The round-trip $D = D2 ; D1$ recovers membership under Foundation. OQ-01 pins down that Foundation is the exact hypothesis and that $D$ is a regularization operator.",
+    "significance": "key",
+    "relatedConcepts": [
+      "three-place identity",
+      "Foundation axiom",
+      "Round-Trip Theorem",
+      "regularization"
+    ],
+    "prerequisites": [
+      "relative identity bridges D1/D2",
+      "Regularity / Foundation axiom"
+    ]
+  },
+  {
+    "id": "ann-tpioq01-sharp",
+    "proofId": "three-place-identity-oq-01",
+    "range": {
+      "startLine": 52,
+      "endLine": 82
+    },
+    "type": "insight",
+    "title": "The Sharp Round-Trip Identity",
+    "content": "derivedMem mem y x is the composite bridge MemFromId (IdFromMem.toRelativeIdentity mem) y x, defined with no Foundation hypothesis. derivedMem_iff proves the governing identity derivedMem mem y x ↔ ¬(mem y x ↔ mem x x) by unfolding derivedMem, MemFromId, and the relative-identity construction, then closing with tauto — the whole behaviour reduces to propositional logic in the single bit mem x x. derivedMem_irrefl shows ¬ derivedMem mem x x always (Foundation holds for D(mem) regardless of mem), because the relative identity is reflexive so Id x x x holds and D(mem) x x = ¬ Id x x x is false. This irreflexivity is the engine of both necessity and self-regularization.",
+    "mathContext": "$D(\\mathrm{mem})\\,y\\,x \\leftrightarrow \\neg(\\mathrm{mem}\\,y\\,x \\leftrightarrow \\mathrm{mem}\\,x\\,x)$: $y$ is a derived-member of $x$ exactly when its membership-status differs from $x$'s self-membership.",
+    "significance": "key",
+    "relatedConcepts": [
+      "derivedMem",
+      "tauto",
+      "irreflexivity",
+      "relative identity"
+    ],
+    "prerequisites": [
+      "MemFromId / IdFromMem bridges",
+      "propositional logic"
+    ]
+  },
+  {
+    "id": "ann-tpioq01-suff-nec",
+    "proofId": "three-place-identity-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 113
+    },
+    "type": "insight",
+    "title": "Foundation Is Necessary and Sufficient",
+    "content": "derivedMem_of_foundation reads sufficiency off the sharp identity: if ¬ mem x x then derivedMem mem y x ↔ mem y x (simp on the false self-membership bit) — the pointwise content of the parent's roundtrip, obtained without a global WellFoundedMembership. roundtrip_iff_foundation is the necessity result: the round-trip holds at x for all y iff ¬ mem x x. Forward direction instantiates the universal hypothesis at y = x and uses derivedMem_irrefl — if mem x x held, (h x).mpr would produce derivedMem mem x x, contradicting irreflexivity. Backward direction is derivedMem_of_foundation. So Foundation is exactly the hypothesis the round-trip needs, not stronger.",
+    "mathContext": "$(\\forall y,\\ D\\,y\\,x \\leftrightarrow \\mathrm{mem}\\,y\\,x) \\leftrightarrow \\neg\\,\\mathrm{mem}\\,x\\,x$: irreflexivity of $D$ forces the self-membership bit off whenever the round-trip succeeds everywhere.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sufficiency",
+      "necessity",
+      "instantiation at y = x",
+      "derivedMem_irrefl"
+    ],
+    "prerequisites": [
+      "derivedMem_iff",
+      "universal instantiation"
+    ]
+  },
+  {
+    "id": "ann-tpioq01-inversion-idem",
+    "proofId": "three-place-identity-oq-01",
+    "range": {
+      "startLine": 115,
+      "endLine": 164
+    },
+    "type": "insight",
+    "title": "Inversion and Idempotent Regularization",
+    "content": "derivedMem_of_not_foundation shows that when Foundation fails (mem x x), the round-trip does not merely break but inverts: derivedMem mem y x ↔ ¬ mem y x (simp on the true self-membership bit). roundtrip_fails_example gives a concrete, non-vacuous witness — U = Unit with total membership (mem ≡ True) has derived membership everywhere False, disagreeing with mem. derivedWFM packages derivedMem mem as a WellFoundedMembership using derivedMem_irrefl for the foundation field. derivedMem_idempotent then applies the parent's roundtrip to derivedWFM to prove derivedMem (derivedMem mem) y x ↔ derivedMem mem y x: since D(mem) is already well-founded, a second round-trip changes nothing — D is an idempotent projection onto well-founded membership relations.",
+    "mathContext": "Failure of Foundation flips the round-trip to $\\neg\\,\\mathrm{mem}\\,y\\,x$; and because $D(\\mathrm{mem})$ is always well-founded, $D \\circ D = D$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "inversion",
+      "WellFoundedMembership",
+      "idempotence",
+      "regularization operator"
+    ],
+    "prerequisites": [
+      "derivedMem_iff",
+      "parent roundtrip theorem"
+    ]
+  }
+]

--- a/src/data/proofs/three-place-identity-oq-01/meta.json
+++ b/src/data/proofs/three-place-identity-oq-01/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "three-place-identity-oq-01",
+  "title": "Three-Place Identity, OQ-01: Foundation Is Exactly the Round-Trip Hypothesis",
+  "slug": "three-place-identity-oq-01",
+  "description": "Makes precise the parent entry's asserted-but-unproved claim that Foundation is 'essential' for the Round-Trip Theorem. Proves the sharp identity derivedMem mem y x ↔ ¬(mem y x ↔ mem x x), from which everything follows: Foundation at x is sufficient (recovers roundtrip), necessary (round-trip holds for all y iff ¬ mem x x), and when it fails the round-trip inverts (↔ ¬ mem y x). The derived membership always satisfies Foundation, so the derivation is an idempotent regularization. Pure classical propositional logic. 7 theorems, 2 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://spasim.org/docs/UniversalityOfThreePlaceIdentity.pdf",
+    "date": "2026-07-02",
+    "status": "verified",
+    "tags": [
+      "foundations",
+      "set-theory",
+      "logic",
+      "identity",
+      "regularity-axiom",
+      "philosophy"
+    ],
+    "proofRepoPath": "Proofs/ThreePlaceIdentityOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "tauto",
+        "description": "Propositional tautology solver — discharges the sharp Round-Trip Identity after unfolding the bridges",
+        "module": "Mathlib.Tactic.Tauto"
+      }
+    ],
+    "originalContributions": [
+      "derivedMem_iff: the sharp Round-Trip Identity derivedMem mem y x ↔ ¬(mem y x ↔ mem x x), unconditional (no Foundation assumed)",
+      "roundtrip_iff_foundation: the round-trip holds at x for all y iff Foundation holds at x (¬ mem x x) — necessity, not just sufficiency",
+      "derivedMem_of_not_foundation: when Foundation fails, the round-trip inverts to derivedMem mem y x ↔ ¬ mem y x",
+      "derivedMem_irrefl / derivedWFM / derivedMem_idempotent: the derived membership always satisfies Foundation, making the derivation an idempotent regularization operator"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 164,
+    "assumptions": "None. #print axioms lists only propext, Classical.choice, Quot.sound (the standard Lean/Mathlib foundations). No axiom declarations and no structure-encoded assumptions; the reasoning is pure classical propositional logic reusing the parent's definitions unchanged.",
+    "theoremCount": 7,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Tom Etter's three-place identity (Boundary Institute, 2006) proposes relative identity as a foundation for mathematics, with bridges D1 (identity → membership) and D2 (membership → identity). The parent entry three-place-identity formalizes the Universality Theorem and the Round-Trip Theorem, the latter proved under the Foundation (Regularity) axiom ∀ x, ¬ mem x x. The parent prose asserts Foundation is 'essential' and that 'without it the round-trip breaks down,' but never proves this. OQ-01 makes the claim precise, asking whether Foundation is genuinely necessary (not merely sufficient) and what exactly happens to the round-trip when Foundation fails.",
+    "problemStatement": "Determine whether the Foundation axiom is necessary or merely sufficient for the Three-Place Identity Round-Trip Theorem, and characterize the round-trip's behaviour when Foundation fails.",
+    "text": "Let D = D2 ; D1 be the derived membership: start from raw membership mem, build the relative identity via D2, and read membership back via D1. The single sharp identity derivedMem mem y x ↔ ¬(mem y x ↔ mem x x) governs everything: y is a derived-member of x exactly when y and x have different membership-status in x, controlled by the one bit mem x x. Sufficiency: if ¬ mem x x then derivedMem mem y x ↔ mem y x (recovers the parent's roundtrip pointwise). Necessity: the round-trip holds at x for all y iff ¬ mem x x — instantiating at y = x and using that derived membership is always irreflexive forces mem x x false. Inversion: if mem x x then derivedMem mem y x ↔ ¬ mem y x (a concrete Unit-model witness shows this genuinely fails the round-trip). Self-regularization: derivedMem mem always satisfies Foundation, packaged as derivedWFM, so applying the round-trip twice changes nothing — the derivation is an idempotent projection onto well-founded membership relations.",
+    "proofStrategy": "Unfold the D2/D1 bridge composite and discharge the sharp identity derivedMem_iff by tauto. Read sufficiency and inversion off the identity by simp on the value of mem x x. Prove necessity by instantiating the universally-quantified round-trip at y = x against derivedMem_irrefl. Package derived membership as a WellFoundedMembership (derivedWFM) using irreflexivity, then obtain idempotence from the parent's roundtrip applied to derivedWFM.",
+    "keyInsights": [
+      "One bit governs everything: derivedMem mem y x ↔ ¬(mem y x ↔ mem x x), controlled by mem x x",
+      "Foundation is exactly the right hypothesis — necessary and sufficient, not stronger than needed",
+      "Without Foundation the round-trip does not merely break; it inverts to the negation of membership",
+      "The derived membership is always irreflexive, so the derivation is an idempotent regularization onto well-founded relations",
+      "A concrete Unit-model with total membership is a non-vacuous witness that the round-trip fails without Foundation"
+    ],
+    "prerequisites": [
+      "The three-place identity bridges D1 (MemFromId) and D2 (IdFromMem)",
+      "The parent Round-Trip Theorem ThreePlaceIdentity.roundtrip and WellFoundedMembership",
+      "The Foundation (Regularity) axiom ∀ x, ¬ mem x x"
+    ]
+  },
+  "sections": [
+    {
+      "id": "tpi-oq01-sharp",
+      "title": "Part I: The Sharp Round-Trip Identity",
+      "startLine": 52,
+      "endLine": 82,
+      "summary": "derivedMem: the composite D2 ; D1, with no Foundation hypothesis. derivedMem_iff: unconditionally derivedMem mem y x ↔ ¬(mem y x ↔ mem x x), by unfolding the bridges and tauto. derivedMem_irrefl: the derived membership is always irreflexive (Foundation holds for D(mem) regardless of mem).",
+      "mathContext": "The derived membership is a Boolean function of the single bit $\\mathrm{mem}\\,x\\,x$: $D(\\mathrm{mem})\\,y\\,x \\leftrightarrow \\neg(\\mathrm{mem}\\,y\\,x \\leftrightarrow \\mathrm{mem}\\,x\\,x)$."
+    },
+    {
+      "id": "tpi-oq01-suff-nec",
+      "title": "Parts II–III: Sufficiency and Necessity",
+      "startLine": 84,
+      "endLine": 113,
+      "summary": "derivedMem_of_foundation: ¬ mem x x ⇒ derivedMem mem y x ↔ mem y x (the pointwise content of the parent's roundtrip). roundtrip_iff_foundation: the round-trip holds at x for all y iff ¬ mem x x — necessity via instantiation at y = x against derivedMem_irrefl, sufficiency via derivedMem_of_foundation.",
+      "mathContext": "Foundation at $x$ is both sufficient (recovers membership) and necessary (irreflexivity of $D$ forces $\\neg\\,\\mathrm{mem}\\,x\\,x$ whenever the round-trip holds for all $y$)."
+    },
+    {
+      "id": "tpi-oq01-inversion-idem",
+      "title": "Parts IV–V: Inversion and Self-Regularization",
+      "startLine": 115,
+      "endLine": 164,
+      "summary": "derivedMem_of_not_foundation: mem x x ⇒ derivedMem mem y x ↔ ¬ mem y x (the round-trip inverts). roundtrip_fails_example: a concrete Unit model with total membership witnesses genuine failure. derivedWFM packages the derived membership as a WellFoundedMembership; derivedMem_idempotent: applying the round-trip twice changes nothing (idempotent regularization), from the parent's roundtrip on derivedWFM.",
+      "mathContext": "When Foundation fails the round-trip flips to $\\neg\\,\\mathrm{mem}\\,y\\,x$; since $D(\\mathrm{mem})$ is always well-founded, $D \\circ D = D$ — an idempotent projection onto well-founded membership."
+    }
+  ],
+  "conclusion": {
+    "summary": "OQ-01 is resolved with a sharp, fully machine-verified (0 axioms, 0 sorries) characterization: Foundation is exactly the hypothesis the Three-Place Identity round-trip requires — necessary and sufficient — and when it fails the round-trip inverts to the negation of membership. The derivation is an idempotent regularization onto well-founded membership relations. 7 theorems, 2 definitions, 164 lines.",
+    "implications": "The result upgrades the parent entry's informal 'Foundation is essential' remark to a precise theorem, and reveals additional structure: the D2 ; D1 composite is a regularization operator whose fixed points are exactly the well-founded membership relations. The inversion phenomenon gives a clean logical account of what non-well-founded membership does to the identity round-trip.",
+    "openQuestions": [
+      "Characterize the round-trip behaviour for partial or many-valued membership relations",
+      "Relate the regularization operator D2 ; D1 to the standard rank/Mostowski-collapse constructions on well-founded relations",
+      "Explore whether the sharp identity extends to Etter's stereo-equality development (ThreePlaceIdentityOQ02)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.ThreePlaceIdentity"
+    ],
+    "opens": [
+      "ThreePlaceIdentity"
+    ],
+    "namespace": "ThreePlaceIdentity.OQ01",
+    "lineCount": 164,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "path": "Proofs/ThreePlaceIdentityOQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "three-place-identity",
+      "relationship": "extends",
+      "description": "Parent entry proving the Round-Trip Theorem under Foundation; OQ-01 shows Foundation is exactly necessary and characterizes failure"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "derivedMem_iff",
+      "type": "core",
+      "description": "The sharp Round-Trip Identity: derived membership equals disagreement with the self-membership bit, unconditionally.",
+      "leanType": "(mem : U → U → Prop) (y x : U) : derivedMem mem y x ↔ ¬ (mem y x ↔ mem x x)"
+    },
+    {
+      "name": "roundtrip_iff_foundation",
+      "type": "core",
+      "description": "Foundation is exactly the round-trip hypothesis: the round-trip holds at x for all y iff ¬ mem x x.",
+      "leanType": "(mem : U → U → Prop) (x : U) : (∀ y, derivedMem mem y x ↔ mem y x) ↔ ¬ mem x x"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Etter, Tom",
+      "title": "Three-Place Identity",
+      "year": "2006",
+      "venue": "Boundary Institute Working Paper",
+      "note": "The original paper proposing three-place relative identity as a foundation for mathematics, with the universality theorem and the D1/D2 bridges whose round-trip this entry analyzes."
+    },
+    {
+      "authors": "Benacerraf, Paul",
+      "title": "What Numbers Could Not Be",
+      "year": "1965",
+      "venue": "The Philosophical Review 74(1), 47–73",
+      "note": "The classic paper questioning whether numbers are sets — motivates the search for an identity-based alternative to set-theoretic foundations."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Fix

Create the missing gallery entry (`meta.json` + `annotations.json`) for **three-place-identity-oq-01**.

## Evidence

**Before**: `proofs/Proofs/ThreePlaceIdentityOQ01.lean` (verified, 0-axiom, 0-sorry, 7 theorems, 2 definitions, 164 lines) was merged to `main` via a standalone `research(three-place-identity-oq-01)` PR, but no `src/data/proofs/three-place-identity-oq-01/` directory was ever created — the proof was invisible in the web gallery.

**After**: gallery entry added, modeled on the parent `three-place-identity`. The proof makes the parent's asserted-but-unproved claim ("Foundation is essential") precise via the sharp identity `derivedMem mem y x ↔ ¬(mem y x ↔ mem x x)`: Foundation is **exactly** the round-trip hypothesis (necessary **and** sufficient), the round-trip **inverts** when Foundation fails, and the derivation is an **idempotent regularization** onto well-founded membership. Pure classical propositional logic.

- `status`: `verified`, `badge`: `original`, `axiomCount`: `0`
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`
- 4 annotations covering the full file; schema verified to match the parent exactly

---
Automated fix by lean-mechanic agent.