### PR TITLE
research(euler-totient-oq-02-oq-04): Gauss divisor-sum identity characterizes φ uniquely [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ02OQ04.lean
+++ b/proofs/Proofs/EulerTotientOQ02OQ04.lean
@@ -1,0 +1,118 @@
+/-
+# Characterizing the Totient: the Gauss Divisor-Sum Determines φ Uniquely
+
+## What This Proves
+Euler's totient satisfies two structural properties:
+
+  * **Gauss's divisor-sum identity**:  `Σ_{d | n} φ(d) = n`   (i.e. `φ ∗ ζ = id`);
+  * **multiplicativity**:  `φ(mn) = φ(m)·φ(n)` for `gcd(m,n) = 1`.
+
+The open question asks how these two properties *together* characterize φ among all
+multiplicative arithmetic functions. The answer is sharp, and stronger than the question:
+
+  **the divisor-sum identity ALONE pins the function down.**
+
+Any function `f : ℕ → ℤ` with `Σ_{d | n} f(d) = n` for all `n > 0` must equal `φ` on the
+positive integers — multiplicativity is not even needed for uniqueness. Consequently φ is the
+UNIQUE multiplicative function satisfying Gauss's identity, and it is *a fortiori* the unique
+function of any kind satisfying it.
+
+## Where this sits
+The sibling `euler-totient-oq-04-oq-02` proves the inversion `φ = μ ∗ id` (solving Gauss's
+identity FOR φ). This leaf proves the dual *uniqueness*: the identity has only one solution,
+so it characterizes φ. Both rest on the invertibility of `ζ` in the Dirichlet ring
+(`μ ∗ ζ = ε`), packaged by Mathlib as Möbius inversion.
+
+## Proof
+`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` says, for `f g : ℕ → ℤ`,
+
+    (∀ n>0, Σ_{d|n} f d = g n)  ↔  (∀ n>0, Σ_{(a,b)} μ(a)·g(b) = f n).
+
+Instantiate `g = id`. Both `f` (by hypothesis) and `φ` (by Gauss's identity `Nat.sum_totient`)
+have the same divisor-sum `g = id`, so the RIGHT-hand side — a single expression depending only
+on `g` — equals both `f n` and `φ n`. Hence `f n = φ n` for `n > 0`.
+
+## Why this isn't just a Mathlib wrapper
+Mathlib has the abstract inversion machine and `Nat.sum_totient`, but no statement that the
+Gauss identity *characterizes* φ. This file supplies that uniqueness theorem, its multiplicative
+corollary (the exact form the open question asks for), and the witness that φ satisfies both
+properties — so the characterization is non-vacuous.
+
+## Status
+**Verified** — zero `sorry`, zero `axiom` (only propext / Classical.choice / Quot.sound).
+
+## Mathlib Dependencies
+- `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` : Möbius inversion over a ring
+- `Nat.sum_totient` : `Σ_{d|n} φ(d) = n`
+- `Nat.totient_mul` : multiplicativity of φ on coprime arguments
+-/
+import Mathlib.NumberTheory.ArithmeticFunction.Moebius
+import Mathlib.Data.Nat.Totient
+
+open Nat ArithmeticFunction
+open scoped BigOperators ArithmeticFunction.Moebius
+
+namespace EulerTotientOQ02OQ04
+
+/-- Gauss's divisor-sum identity for φ, cast to `ℤ`: `Σ_{d | n} φ(d) = n`.
+This is the property whose *uniqueness* we establish. -/
+theorem totient_sum_eq (n : ℕ) :
+    ∑ d ∈ n.divisors, (φ d : ℤ) = (n : ℤ) := by
+  exact_mod_cast Nat.sum_totient n
+
+/-- φ is multiplicative: `φ(m·n) = φ(m)·φ(n)` for coprime `m, n`.
+The second of the two characterizing properties. -/
+theorem totient_multiplicative {m n : ℕ} (h : m.Coprime n) :
+    φ (m * n) = φ m * φ n :=
+  Nat.totient_mul h
+
+/-- **Uniqueness of the Gauss divisor-sum identity.**
+If `f : ℕ → ℤ` satisfies `Σ_{d | n} f(d) = n` for every `n > 0`, then `f` agrees with the
+totient on the positive integers. The divisor-sum identity has a *single* solution — φ —
+so it characterizes the totient with no further hypotheses (multiplicativity is not needed). -/
+theorem eq_totient_of_sum_eq (f : ℕ → ℤ)
+    (hf : ∀ n : ℕ, 0 < n → ∑ d ∈ n.divisors, f d = (n : ℤ)) :
+    ∀ n > 0, f n = (φ n : ℤ) := by
+  -- Both `f` and `d ↦ φ d` have the same divisor-sum `g = id`, so Möbius inversion
+  -- forces them to share the same inverse expression, hence to be equal on `n > 0`.
+  have key_f :=
+    (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (R := ℤ)
+      (f := f) (g := fun n => (n : ℤ))).mp hf
+  have key_φ :=
+    (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (R := ℤ)
+      (f := fun d => (φ d : ℤ)) (g := fun n => (n : ℤ))).mp
+      (fun m _ => totient_sum_eq m)
+  intro n hn
+  exact (key_f n hn).symm.trans (key_φ n hn)
+
+/-- **Characterization among multiplicative functions (the open question's form).**
+φ is the unique multiplicative function satisfying Gauss's divisor-sum identity:
+if `f` is multiplicative (in the sense `f(1) = 1` and `f(m·n) = f(m)·f(n)` for coprime `m, n`)
+and `Σ_{d | n} f(d) = n` for all `n > 0`, then `f = φ` on the positive integers. The
+multiplicativity hypothesis is displayed for faithfulness to the question, but is redundant:
+`eq_totient_of_sum_eq` already gives the conclusion from the divisor-sum alone. -/
+theorem eq_totient_of_multiplicative_of_sum_eq (f : ℕ → ℤ)
+    (_hmul : f 1 = 1 ∧ ∀ {m n : ℕ}, m.Coprime n → f (m * n) = f m * f n)
+    (hf : ∀ n : ℕ, 0 < n → ∑ d ∈ n.divisors, f d = (n : ℤ)) :
+    ∀ n > 0, f n = (φ n : ℤ) :=
+  eq_totient_of_sum_eq f hf
+
+/-- **The two properties together are realized by φ and by nothing else.**
+For any `f : ℕ → ℤ`, `f` agrees with φ on the positive integers **iff** it satisfies Gauss's
+divisor-sum identity there. This is the precise sense in which the divisor-sum identity
+characterizes the totient: the solution set of the identity is exactly `{φ}`. -/
+theorem sum_eq_iff_eq_totient (f : ℕ → ℤ) :
+    (∀ n : ℕ, 0 < n → ∑ d ∈ n.divisors, f d = (n : ℤ)) ↔ (∀ n > 0, f n = (φ n : ℤ)) := by
+  constructor
+  · exact eq_totient_of_sum_eq f
+  · intro hfφ n hn
+    calc ∑ d ∈ n.divisors, f d
+        = ∑ d ∈ n.divisors, (φ d : ℤ) :=
+          Finset.sum_congr rfl fun d hd => hfφ d (Nat.pos_of_mem_divisors hd)
+      _ = (n : ℤ) := totient_sum_eq n
+
+#check @eq_totient_of_sum_eq
+#check @eq_totient_of_multiplicative_of_sum_eq
+#check @sum_eq_iff_eq_totient
+
+end EulerTotientOQ02OQ04

--- a/src/data/proofs/euler-totient-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "euler-totient-oq-02-oq-04",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "concept",
+    "title": "Characterizing φ by Its Structural Properties",
+    "content": "The totient is pinned down by two classical facts: multiplicativity (φ(mn)=φ(m)φ(n) for coprime m,n) and Gauss's divisor-sum identity Σ_{d|n} φ(d)=n. In Dirichlet-convolution terms these are 'φ multiplicative' and 'φ ∗ ζ = id'. The parent entry asks how the two together characterize φ. The answer proved here is sharper than asked: because ζ is a unit in the Dirichlet ring with inverse μ (μ ∗ ζ = ε), the equation f ∗ ζ = id has the UNIQUE solution f = μ ∗ id = φ — so the divisor-sum identity alone determines the function, and multiplicativity is not needed for uniqueness.",
+    "mathContext": "$f \\ast \\zeta = \\mathrm{id},\\ \\ \\mu \\ast \\zeta = \\varepsilon\\ \\Rightarrow\\ f = \\mu \\ast \\mathrm{id} = \\varphi.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Dirichlet convolution", "Möbius inversion", "multiplicative functions", "Euler's totient", "Gauss divisor-sum identity"],
+    "prerequisites": ["arithmetic functions", "divisor sums"]
+  },
+  {
+    "id": "ann-witness",
+    "proofId": "euler-totient-oq-02-oq-04",
+    "range": { "startLine": 57, "endLine": 67 },
+    "type": "theorem",
+    "title": "φ Realizes Both Characterizing Properties",
+    "content": "totient_sum_eq casts Nat.sum_totient into ℤ, recording Gauss's divisor-sum identity Σ_{d|n} φ(d) = n — the property whose uniqueness of solution is the point of this entry. totient_multiplicative is Nat.totient_mul, the multiplicativity φ(m·n) = φ(m)·φ(n) for coprime m, n. Together they witness that φ actually satisfies the two properties in question, so the characterization theorems below are non-vacuous.",
+    "mathContext": "$\\sum_{d\\mid n}\\varphi(d) = n,\\qquad \\gcd(m,n)=1 \\Rightarrow \\varphi(mn)=\\varphi(m)\\varphi(n).$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.sum_totient", "Nat.totient_mul", "multiplicativity"],
+    "prerequisites": ["totient basics"]
+  },
+  {
+    "id": "ann-uniqueness",
+    "proofId": "euler-totient-oq-02-oq-04",
+    "range": { "startLine": 69, "endLine": 92 },
+    "type": "insight",
+    "title": "Uniqueness from the Divisor-Sum Alone",
+    "content": "eq_totient_of_sum_eq is the heart of the entry: any f : ℕ → ℤ with Σ_{d|n} f(d) = n for all n > 0 equals φ on the positive integers. Mathlib's sum_eq_iff_sum_mul_moebius_eq turns a divisor-sum equation with target g = id into the pointwise formula f(n) = Σ_{(a,b)∈antidiagonal n} μ(a)·b. Applying it to f (from the hypothesis) and to φ (whose divisor sum is n by totient_sum_eq) yields the SAME right-hand side for both; transitivity gives f(n) = φ(n). No multiplicativity is used — the divisor-sum identity is an invertible equation and its solution is unique.",
+    "mathContext": "$f(n)=\\!\\!\\sum_{(a,b)}\\!\\mu(a)\\,b = \\varphi(n)\\quad (n>0).$",
+    "significance": "key",
+    "relatedConcepts": ["Möbius inversion", "uniqueness", "sum_eq_iff_sum_mul_moebius_eq", "Dirichlet inverse of ζ"],
+    "prerequisites": ["Möbius inversion", "divisorsAntidiagonal"]
+  },
+  {
+    "id": "ann-characterization",
+    "proofId": "euler-totient-oq-02-oq-04",
+    "range": { "startLine": 94, "endLine": 116 },
+    "type": "theorem",
+    "title": "Multiplicative Corollary and the {φ} Solution Set",
+    "content": "eq_totient_of_multiplicative_of_sum_eq answers the open question in its literal wording — φ is the unique multiplicative function satisfying Gauss's identity — obtained immediately from the stronger uniqueness (the multiplicativity hypothesis is displayed but never used). sum_eq_iff_eq_totient sharpens this to an iff: a function satisfies the divisor-sum identity iff it equals φ on the positive integers, so the solution set of Gauss's identity is exactly the singleton {φ}. The reverse direction folds f = φ back through sum congruence and Gauss's identity.",
+    "mathContext": "$\\{\\,f : \\sum_{d\\mid n} f(d) = n\\ \\forall n>0\\,\\} = \\{\\varphi\\}.$",
+    "significance": "key",
+    "relatedConcepts": ["characterization", "unique multiplicative function", "Finset.sum_congr", "solution set"],
+    "prerequisites": ["the uniqueness theorem", "sum congruence"]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-02-oq-04/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-04/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "euler-totient-oq-02-oq-04",
+  "slug": "euler-totient-oq-02-oq-04",
+  "title": "The Gauss Divisor-Sum Identity Characterizes φ Uniquely",
+  "description": "Answers the open question of euler-totient-oq-02 — 'the divisor sum n = Σ_{d|n} φ(d) is dual to multiplicativity; how do these two properties together characterize the totient among multiplicative functions?' — with a sharp, fully verified result that is stronger than asked: the divisor-sum identity ALONE characterizes φ. We prove that any function f : ℕ → ℤ satisfying Σ_{d|n} f(d) = n for all n > 0 must agree with the totient on the positive integers (eq_totient_of_sum_eq); multiplicativity is not even needed for uniqueness. Consequently φ is the unique multiplicative function satisfying Gauss's identity (eq_totient_of_multiplicative_of_sum_eq, the exact form the question asks for), and more precisely the solution set of the identity is exactly {φ}: for any f, the divisor-sum identity holds iff f = φ on the positive integers (sum_eq_iff_eq_totient). The witness that the characterization is non-vacuous is included — φ satisfies both the divisor-sum identity (totient_sum_eq, from Nat.sum_totient) and multiplicativity (totient_multiplicative, from Nat.totient_mul). The uniqueness rests on the invertibility of ζ in the Dirichlet ring (μ ∗ ζ = ε), packaged by Mathlib as Möbius inversion (sum_eq_iff_sum_mul_moebius_eq): both f and φ have the same divisor-sum g = id, so they share the same Möbius-inverse expression and hence coincide. Machine-checked, 0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound).",
+  "leanFile": {
+    "imports": ["Mathlib.NumberTheory.ArithmeticFunction.Moebius", "Mathlib.Data.Nat.Totient"],
+    "opens": ["Nat", "ArithmeticFunction"],
+    "namespace": "EulerTotientOQ02OQ04",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 3,
+    "trivialSpecializations": 2,
+    "definitionCount": 0,
+    "path": "Proofs/EulerTotientOQ02OQ04.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "researcher-2",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_totient_function#Divisor_sum",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ02OQ04.lean",
+    "tags": [
+      "number-theory",
+      "arithmetic-functions",
+      "euler-totient",
+      "dirichlet-convolution",
+      "moebius-inversion",
+      "multiplicative-functions",
+      "uniqueness"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None beyond Mathlib's foundations. Uniqueness follows from ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (Möbius inversion over a ring) applied to f and to φ, both sharing the divisor-sum g = id; the witness uses Nat.sum_totient and Nat.totient_mul. #print axioms reports only propext / Classical.choice / Quot.sound for every public declaration — no sorryAx, no Lean.ofReduceBool.",
+    "dateAdded": "2026-07-02",
+    "mathlibDependencies": [
+      "ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq",
+      "Nat.sum_totient",
+      "Nat.totient_mul",
+      "Nat.pos_of_mem_divisors"
+    ],
+    "originalContributions": [
+      "eq_totient_of_sum_eq: the divisor-sum identity Σ_{d|n} f(d) = n ALONE forces f = φ on the positive integers — uniqueness with no multiplicativity hypothesis",
+      "eq_totient_of_multiplicative_of_sum_eq: φ is the unique multiplicative function satisfying Gauss's identity, the exact characterization the open question requests (with multiplicativity displayed but shown redundant)",
+      "sum_eq_iff_eq_totient: the solution set of the Gauss identity is exactly {φ} — f satisfies Σ_{d|n} f(d) = n iff f = φ on positive integers",
+      "totient_sum_eq and totient_multiplicative: the witness that φ realizes both characterizing properties, so the characterization is non-vacuous"
+    ],
+    "prerequisites": [
+      "Dirichlet convolution and the arithmetic-function ring (ζ, μ, ε = μ ∗ ζ)",
+      "Möbius inversion: Σ_{d|n} f(d) = g(n) ⟺ f(n) = Σ_{(a,b)} μ(a)·g(b)",
+      "Gauss's divisor-sum identity Σ_{d|n} φ(d) = n",
+      "Multiplicativity of the totient on coprime arguments"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 118,
+    "relatedProblems": ["euler-totient", "euler-totient-oq-02", "euler-totient-oq-04", "euler-totient-oq-04-oq-02"],
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Among arithmetic functions, Euler's totient is pinned down by two classical structural properties: it is multiplicative (Euler), and it satisfies Gauss's divisor-sum identity Σ_{d|n} φ(d) = n (Gauss). In the language of Dirichlet convolution these read φ multiplicative and φ ∗ ζ = id. The parent entry euler-totient-oq-02 establishes multiplicativity and closes by asking how these two properties TOGETHER characterize φ. The clean modern answer comes from the fact that ζ is a unit in the Dirichlet ring, with inverse the Möbius function μ (μ ∗ ζ = ε): the equation f ∗ ζ = id therefore has the unique solution f = id ∗ μ = φ. So the divisor-sum identity by itself already determines the function, and multiplicativity — while true of φ — is not required for uniqueness.",
+    "problemStatement": "Make precise and prove the sense in which the totient is characterized by its structural properties. Show that any f : ℕ → ℤ with Σ_{d|n} f(d) = n for all n > 0 equals φ on the positive integers; deduce that φ is the unique multiplicative function satisfying Gauss's identity; and exhibit that φ itself satisfies both the divisor-sum identity and multiplicativity, so the characterization is realized.",
+    "proofStrategy": "Mathlib's ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq states, for f g : ℕ → ℤ, that (∀ n > 0, Σ_{d|n} f(d) = g(n)) ⟺ (∀ n > 0, Σ_{(a,b)∈antidiagonal n} μ(a)·g(b) = f(n)). Fix g = id. The right-hand side is a single expression depending only on g. Applying the equivalence to the hypothesis for f gives that expression equals f(n); applying it to φ — whose divisor sum is n by Nat.sum_totient — gives the same expression equals φ(n). Transitivity yields f(n) = φ(n) for n > 0. The iff-characterization adds the converse: if f = φ on positive divisors then Σ_{d|n} f(d) = Σ_{d|n} φ(d) = n by congruence and Gauss's identity.",
+    "keyInsights": [
+      "The divisor-sum identity is an equation f ∗ ζ = id in the Dirichlet ring, and ζ is invertible (μ ∗ ζ = ε), so the equation has a unique solution — this is why the totient is determined WITHOUT invoking multiplicativity.",
+      "Uniqueness is cleanest at the level of the shared Möbius-inverse expression: two functions with the same divisor-sum have the same inverse, hence are equal.",
+      "The multiplicative hypothesis requested by the open question is genuinely redundant for uniqueness; we display it in eq_totient_of_multiplicative_of_sum_eq only to answer the question in its literal form.",
+      "The characterization is non-vacuous precisely because φ satisfies both properties: Nat.sum_totient gives the divisor sum and Nat.totient_mul gives multiplicativity.",
+      "sum_eq_iff_eq_totient states the sharpest form: the solution set of Gauss's identity is exactly the singleton {φ}."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "eq_totient_of_sum_eq",
+      "statement": "(∀ n > 0, Σ_{d ∈ n.divisors} f d = n) → ∀ n > 0, f n = φ n   (f : ℕ → ℤ)",
+      "description": "The divisor-sum identity alone determines the totient: any f with Σ_{d|n} f(d) = n equals φ on the positive integers, with no multiplicativity hypothesis."
+    },
+    {
+      "name": "eq_totient_of_multiplicative_of_sum_eq",
+      "statement": "f multiplicative → (∀ n > 0, Σ_{d ∈ n.divisors} f d = n) → ∀ n > 0, f n = φ n",
+      "description": "φ is the unique multiplicative function satisfying Gauss's divisor-sum identity — the exact characterization the open question requests. Multiplicativity is displayed but redundant."
+    },
+    {
+      "name": "sum_eq_iff_eq_totient",
+      "statement": "(∀ n > 0, Σ_{d ∈ n.divisors} f d = n) ↔ (∀ n > 0, f n = φ n)   (f : ℕ → ℤ)",
+      "description": "The solution set of Gauss's identity is exactly {φ}: a function satisfies the divisor-sum identity iff it equals the totient on the positive integers."
+    }
+  ],
+  "sections": [
+    {
+      "id": "witness",
+      "title": "φ Realizes Both Characterizing Properties",
+      "startLine": 57,
+      "endLine": 67,
+      "summary": "totient_sum_eq casts Nat.sum_totient to ℤ, giving Gauss's divisor-sum identity Σ_{d|n} φ(d) = n. totient_multiplicative is Nat.totient_mul: φ(m·n) = φ(m)·φ(n) for coprime m, n. Together they witness that φ satisfies the two properties whose joint characterizing power is at issue.",
+      "mathContext": "$\\sum_{d\\mid n}\\varphi(d) = n,\\qquad \\varphi(mn) = \\varphi(m)\\varphi(n)\\ (\\gcd(m,n)=1).$"
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness from the Divisor-Sum Alone",
+      "startLine": 69,
+      "endLine": 92,
+      "summary": "eq_totient_of_sum_eq. Applying Möbius inversion (sum_eq_iff_sum_mul_moebius_eq) to f and to φ, both with divisor-sum g = id, yields the same antidiagonal Möbius-inverse expression for each; transitivity gives f(n) = φ(n) for n > 0. No multiplicativity is used.",
+      "mathContext": "$f \\ast \\zeta = \\mathrm{id} = \\varphi \\ast \\zeta \\ \\Rightarrow\\ f = \\mathrm{id}\\ast\\mu = \\varphi.$"
+    },
+    {
+      "id": "characterization",
+      "title": "Multiplicative Corollary and the {φ} Solution Set",
+      "startLine": 94,
+      "endLine": 116,
+      "summary": "eq_totient_of_multiplicative_of_sum_eq answers the open question in its literal form (φ is the unique multiplicative solution), immediately from the stronger uniqueness. sum_eq_iff_eq_totient adds the converse via sum congruence and Gauss's identity, showing the Gauss identity's solution set is exactly {φ}.",
+      "mathContext": "$\\{\\,f : \\textstyle\\sum_{d\\mid n} f(d) = n\\,\\} = \\{\\varphi\\}.$"
+    }
+  ],
+  "references": [
+    {
+      "title": "Euler's totient function — Divisor sum",
+      "url": "https://en.wikipedia.org/wiki/Euler%27s_totient_function#Divisor_sum"
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Undergraduate Texts in Mathematics, Springer",
+      "note": "Chapter 2 develops Dirichlet convolution, Möbius inversion, and the characterization φ = μ ∗ id together with the uniqueness of solutions to f ∗ ζ = id."
+    },
+    {
+      "title": "Möbius inversion formula",
+      "url": "https://en.wikipedia.org/wiki/M%C3%B6bius_inversion_formula"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "euler-totient-oq-02",
+      "relationship": "Answers an open question of the parent",
+      "description": "The parent entry (multiplicativity of φ) closes by asking how multiplicativity and the divisor-sum identity together characterize the totient. This leaf shows the divisor-sum identity alone characterizes φ, so φ is a fortiori the unique multiplicative function satisfying it."
+    },
+    {
+      "proofId": "euler-totient-oq-04-oq-02",
+      "relationship": "Dual result",
+      "description": "The sibling proves Möbius inversion φ = μ ∗ id (solving Gauss's identity FOR φ). This entry proves the dual uniqueness: Gauss's identity has only the one solution φ, so it characterizes the totient."
+    },
+    {
+      "proofId": "euler-totient-oq-04",
+      "relationship": "Uses the forward identity",
+      "description": "euler-totient-oq-04 formalizes Gauss's forward divisor-sum n = Σ_{d|n} φ(d); that identity is exactly the property whose uniqueness of solution is established here."
+    }
+  ],
+  "conclusion": {
+    "summary": "Euler's totient is the unique function f : ℕ → ℤ satisfying Gauss's divisor-sum identity Σ_{d|n} f(d) = n on the positive integers; multiplicativity, though true of φ, is not needed for uniqueness. Equivalently the solution set of the identity is exactly {φ}. This answers the parent's open question — sharpened — on how the structural properties characterize the totient, and is machine-checked with zero sorries and zero axioms.",
+    "implications": "The result explains why the totient is 'rigid': its defining divisor-sum relation is an invertible equation in the Dirichlet ring, so no other arithmetic function can share it. This is the abstract reason multiplicativity and the divisor sum are 'dual' — each determines φ within its own world (multiplicative functions are fixed by their prime-power values; the divisor-sum fixes any function via Möbius inversion), and the two descriptions agree on φ.",
+    "openQuestions": [
+      "Can the uniqueness be stated at the ArithmeticFunction level as: the only g with g ∗ ζ = id is φ (cast to an arithmetic function), directly from ζ being a unit?",
+      "Does an analogous 'divisor-sum determines the function' uniqueness hold for other classical identities, e.g. characterizing the identity function id by Σ_{d|n} σ_?(d)-type relations, or the constant 1 by Σ_{d|n} μ(d) = [n=1]?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question of `euler-totient-oq-02` — *'the divisor sum n = Σ_{d|n} φ(d) is dual to multiplicativity; how do these two properties together characterize the totient among multiplicative functions?'* — with a result **sharper than asked**:

> **The divisor-sum identity ALONE characterizes φ.**

Any `f : ℕ → ℤ` with `Σ_{d|n} f(d) = n` for all `n > 0` must equal φ on the positive integers — multiplicativity is not even needed for uniqueness.

## Results (5 theorems, 118 lines)

| Declaration | Statement |
|---|---|
| `eq_totient_of_sum_eq` | divisor-sum `Σ_{d\|n} f(d)=n` ⟹ `f=φ` (no multiplicativity) |
| `eq_totient_of_multiplicative_of_sum_eq` | φ is **the** unique multiplicative solution (OQ's literal form; multiplicativity shown redundant) |
| `sum_eq_iff_eq_totient` | solution set of Gauss's identity is exactly `{φ}` |
| `totient_sum_eq`, `totient_multiplicative` | witness that φ satisfies both properties |

## Proof

Möbius inversion (`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`) turns the divisor-sum equation with target `g = id` into a pointwise formula. Both `f` (hypothesis) and `φ` (by `Nat.sum_totient`) share divisor-sum `g = id`, hence share the same Möbius-inverse expression ⇒ `f = φ`. The abstract reason: `ζ` is a unit in the Dirichlet ring (`μ ∗ ζ = ε`), so `f ∗ ζ = id` has the unique solution `f = μ ∗ id = φ`.

## Where it sits

Dual to the sibling `euler-totient-oq-04-oq-02` (which proves the inversion `φ = μ ∗ id`, *solving* Gauss's identity for φ); this entry proves that identity has **only one** solution.

## Verification

`lake env lean` clean (EXIT 0). `#print axioms` on all public declarations reports only `propext / Classical.choice / Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. `status: verified`, `badge: original`, `axiomCount: 0`.

New gallery entry `src/data/proofs/euler-totient-oq-02-oq-04/` (meta.json + 4 annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)