### PR TITLE
Enrich Pell OQ-05: header overview annotation

### DIFF
--- a/src/data/proofs/pell-equation-oq-05/annotations.json
+++ b/src/data/proofs/pell-equation-oq-05/annotations.json
@@ -1,86 +1,190 @@
 [
   {
+    "id": "ann-pell-oq05-overview",
+    "proofId": "pell-equation-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "concept",
+    "title": "Pell in Higher Degree: Norm Equations over ℚ(∛2)",
+    "content": "Classical Pell $x^2 - Dy^2 = 1$ is the norm-one equation $N_{\\mathbb{Q}(\\sqrt D)/\\mathbb{Q}}(x+y\\sqrt D)=1$ — the rank-1 case of Dirichlet's unit theorem. This entry pushes the same idea into degree 3 over the cubic field $K=\\mathbb{Q}(\\sqrt[3]2)=\\mathbb{Z}[t]/(t^3-2)$, studying the integral solutions of the cubic norm form $N(a,b,c)=a^3+2b^3+4c^3-6abc$.\n\nThe docstring lays out the *concrete algebraic core* the file formalizes without invoking Mathlib's (bearer-less) signature/Dirichlet machinery: (1) $N$ is a determinant, (2) $N$ is multiplicative, (3) $u=\\sqrt[3]2-1$ is a norm-1 unit, (4) every $u^k$ has norm 1 (the higher Pell chain), (5) the chain is strictly decreasing under the real embedding hence injective, giving **infinitely many** solutions of $N(\\xi)=1$ — closing the distinctness gap that session S4 left open. What stays deferred is the unit *rank* $r_1+r_2-1=1$ via the signature $(r_1,r_2)=(1,1)$, which needs a place count Mathlib ships no procedure for. The whole file is 0-axiom, 0-sorry.",
+    "mathContext": "$x^2-Dy^2=1 \\iff N_{\\mathbb{Q}(\\sqrt D)/\\mathbb{Q}}(x+y\\sqrt D)=1$; degree-3 analogue $N(a,b,c)=a^3+2b^3+4c^3-6abc$ over $K=\\mathbb{Q}(\\sqrt[3]2)$, unit rank $r_1+r_2-1=1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pell's equation",
+      "Dirichlet unit theorem",
+      "cubic field ℚ(∛2)",
+      "norm form",
+      "unit rank",
+      "real embedding"
+    ],
+    "prerequisites": [
+      "algebraic number theory",
+      "norm map N_{K/ℚ}",
+      "units of a ring of integers"
+    ]
+  },
+  {
     "id": "ann-cnorm-det",
     "proofId": "pell-equation-oq-05",
-    "range": { "startLine": 47, "endLine": 64 },
+    "range": {
+      "startLine": 47,
+      "endLine": 64
+    },
     "type": "definition",
     "title": "The Cubic Norm Form as a Determinant",
     "content": "`cnorm a b c = a³ + 2b³ + 4c³ − 6abc` is the norm of $a + b\\sqrt[3]{2} + c\\sqrt[3]{4}$ in $\\mathbb{Z}[\\sqrt[3]{2}] = \\mathbb{Z}[t]/(t^3-2)$. `cnorm_eq_det` identifies it with the determinant of the matrix of multiplication-by-$(a+bt+ct^2)$ on the power basis $\\{1,t,t^2\\}$ (columns reduced by $t^3 = 2$), so this is the concrete `Algebra.norm` computed by hand — proved by `Matrix.det_fin_three` followed by `ring`, needing none of Mathlib's heavier field-theory machinery.",
     "mathContext": "$N(a+b\\sqrt[3]2+c\\sqrt[3]4)=\\det\\begin{pmatrix}a&2c&2b\\\\ b&a&2c\\\\ c&b&a\\end{pmatrix}=a^3+2b^3+4c^3-6abc$",
     "significance": "supporting",
-    "relatedConcepts": ["field norm", "cubic field ℚ(∛2)", "power basis", "determinant of a representation"],
-    "prerequisites": ["number fields", "the norm map N_{K/ℚ}", "determinants"]
+    "relatedConcepts": [
+      "field norm",
+      "cubic field ℚ(∛2)",
+      "power basis",
+      "determinant of a representation"
+    ],
+    "prerequisites": [
+      "number fields",
+      "the norm map N_{K/ℚ}",
+      "determinants"
+    ]
   },
   {
     "id": "ann-multiplicativity",
     "proofId": "pell-equation-oq-05",
-    "range": { "startLine": 65, "endLine": 86 },
+    "range": {
+      "startLine": 65,
+      "endLine": 86
+    },
     "type": "insight",
     "title": "Multiplicativity of the Norm Form",
     "content": "`cmul` is multiplication in $\\mathbb{Z}[t]/(t^3-2)$ — the product of two coordinate triples, reduced using $t^3 = 2$ — and `cnorm3` is the norm of a triple. `cnorm_cmul` is the key structural fact $N(\\xi\\cdot\\eta) = N(\\xi)\\cdot N(\\eta)$: after expanding `cmul`, it is a pure polynomial identity in the six coordinates, closed by `ring`. This is the higher-degree Brahmagupta composition law — the single engine that turns one unit into an infinite chain of solutions, exactly as multiplicativity of $x^2-Dy^2$ does for classical Pell.",
     "mathContext": "$N(\\xi\\eta)=N(\\xi)N(\\eta)$ for $\\xi,\\eta\\in\\mathbb{Z}[\\sqrt[3]2]$",
     "significance": "key",
-    "relatedConcepts": ["multiplicative norm", "Brahmagupta composition", "ring tactic", "polynomial identity"],
-    "prerequisites": ["norm multiplicativity", "quotient rings"]
+    "relatedConcepts": [
+      "multiplicative norm",
+      "Brahmagupta composition",
+      "ring tactic",
+      "polynomial identity"
+    ],
+    "prerequisites": [
+      "norm multiplicativity",
+      "quotient rings"
+    ]
   },
   {
     "id": "ann-pell-chain",
     "proofId": "pell-equation-oq-05",
-    "range": { "startLine": 87, "endLine": 121 },
+    "range": {
+      "startLine": 87,
+      "endLine": 121
+    },
     "type": "insight",
     "title": "The Fundamental Unit and the Higher-Degree Pell Chain",
     "content": "`u = ∛2 − 1` (coordinate triple $(-1,1,0)$) is a unit: its inverse is $t^2+t+1$ since $(t-1)(t^2+t+1) = t^3-1 = 1$ (`cmul_u_uinv`, a finite `decide`), and it has norm 1 (`cnorm_u`). The chain `upow k = uᵏ` therefore consists entirely of norm-1 elements — `cnorm_upow` proves $N(u^k)=1$ by induction using multiplicativity and $N(u)=1$. The first terms $u^1=(-1,1,0),\\ u^2=(1,-2,1),\\ u^3=(1,3,-3),\\ u^4=(-7,-2,6)$ are the cubic counterpart of the Brahmagupta chain $(3,2)\\to(17,12)\\to\\cdots$ for $x^2-2y^2=1$.",
     "mathContext": "$u=\\sqrt[3]2-1,\\ N(u)=1,\\ u^{-1}=\\sqrt[3]4+\\sqrt[3]2+1;\\quad N(u^k)=1\\ \\forall k$",
     "significance": "key",
-    "relatedConcepts": ["fundamental unit", "unit group", "Pell chain", "Dirichlet unit theorem (rank 1)"],
-    "prerequisites": ["units of a ring of integers", "induction"]
+    "relatedConcepts": [
+      "fundamental unit",
+      "unit group",
+      "Pell chain",
+      "Dirichlet unit theorem (rank 1)"
+    ],
+    "prerequisites": [
+      "units of a ring of integers",
+      "induction"
+    ]
   },
   {
     "id": "ann-distinctness",
     "proofId": "pell-equation-oq-05",
-    "range": { "startLine": 122, "endLine": 202 },
+    "range": {
+      "startLine": 122,
+      "endLine": 202
+    },
     "type": "insight",
     "title": "Distinctness of the Chain via a Real Embedding",
     "content": "The subtle step — that the chain values are genuinely distinct (so there really are infinitely many solutions) — is handled with a single real embedding rather than Dirichlet's unit theorem. `phi τ` sends $(a,b,c)$ to $a + b\\tau + c\\tau^2$ with $\\tau = \\sqrt[3]2$; it is a ring homomorphism (`phi_cmul`, the residual multiple of $\\tau^3-2$ cleared by `linear_combination`), so $\\varphi(u^k) = \\varphi(u)^k$ (`phi_upow`). Since `tau_bounds`/`phi_u_mem` pin $\\varphi(u)=\\tau-1\\in(0,1)$, the powers $\\varphi(u)^k$ are strictly decreasing, hence `upow` is injective (`upow_injective`). `Set.infinite_of_injective_forall_mem` then gives `norm_one_solutions_infinite`: $N(\\xi)=1$ has infinitely many integral solutions.",
     "mathContext": "$0<\\varphi(u)=\\tau-1<1\\Rightarrow \\varphi(u)^k$ strictly decreasing $\\Rightarrow k\\mapsto u^k$ injective",
     "significance": "key",
-    "relatedConcepts": ["real embedding / infinite place", "geometric progression", "injectivity", "strict monotonicity of powers"],
-    "prerequisites": ["real analysis of xⁿ", "ring homomorphisms", "linear_combination tactic"]
+    "relatedConcepts": [
+      "real embedding / infinite place",
+      "geometric progression",
+      "injectivity",
+      "strict monotonicity of powers"
+    ],
+    "prerequisites": [
+      "real analysis of xⁿ",
+      "ring homomorphisms",
+      "linear_combination tactic"
+    ]
   },
   {
     "id": "ann-dichotomy",
     "proofId": "pell-equation-oq-05",
-    "range": { "startLine": 203, "endLine": 285 },
+    "range": {
+      "startLine": 203,
+      "endLine": 285
+    },
     "type": "insight",
     "title": "Zero-or-Infinite Dichotomy for N(ξ) = m",
     "content": "The $m=1$ infinitude upgrades to every nonzero $m$. `cnorm_eq_phi_mul` factors the norm at the real place as $N(\\xi)=\\varphi(\\xi)\\cdot\\varphi(\\xi^\\star)$ — the specialization of $x^3+y^3+z^3-3xyz=(x+y+z)(x^2+y^2+z^2-xy-yz-zx)$ to $(a,b\\tau,c\\tau^2)$ — so a nonzero norm forces $\\varphi(\\xi_0)\\neq 0$ (`phi_ne_zero_of_cnorm_ne_zero`). Then the shifted orbit $k\\mapsto \\xi_0\\cdot u^k$ has values $\\varphi(\\xi_0)\\varphi(u)^k$, still injective (`cmul_chain_injective`). Hence `norm_eq_solutions_infinite`: any solvable $N(\\xi)=m$ ($m\\neq 0$) has infinitely many solutions. `norm_two_solutions_infinite` instantiates it at $m=2$ with seed $\\sqrt[3]2 = (0,1,0)$.",
     "mathContext": "$N(\\xi)=\\varphi(\\xi)\\varphi(\\xi^\\star)\\neq 0\\Rightarrow \\varphi(\\xi_0)\\neq 0\\Rightarrow \\{\\xi_0 u^k\\}$ infinite",
     "significance": "key",
-    "relatedConcepts": ["unit-orbit of solutions", "norm-form factorization", "zero-or-infinite dichotomy"],
-    "prerequisites": ["group action on solution sets", "cancellation in ℝ"]
+    "relatedConcepts": [
+      "unit-orbit of solutions",
+      "norm-form factorization",
+      "zero-or-infinite dichotomy"
+    ],
+    "prerequisites": [
+      "group action on solution sets",
+      "cancellation in ℝ"
+    ]
   },
   {
     "id": "ann-non-surjective",
     "proofId": "pell-equation-oq-05",
-    "range": { "startLine": 286, "endLine": 368 },
+    "range": {
+      "startLine": 286,
+      "endLine": 368
+    },
     "type": "insight",
     "title": "7 Is a Non-Norm: the Form Is Not Surjective",
     "content": "Not every integer is a norm. `cnorm_anisotropic_mod7` checks — by a finite kernel `decide` over the $7^3=343$ residue triples — that the form's only zero over $\\mathbb{F}_7$ is $(0,0,0)$; equivalently $x^3-2$ is irreducible over $\\mathbb{F}_7$ (2 is a cubic non-residue), so 7 is **inert** in $\\mathbb{Q}(\\sqrt[3]2)$. Pulling back along $\\mathbb{Z}\\to\\mathbb{Z}/7$ gives `seven_dvd_cnorm_iff` (7 ∣ N ⟺ 7 divides each of $a,b,c$; the converse is homogeneity), so $7\\mid N$ forces $343\\mid N$. Since $343\\nmid 7$, we get `cnorm_ne_seven`/`cnorm_ne_neg_seven`, an empty solution set (`norm_eq_seven_no_solution`), and finally `cnorm3_not_surjective` — the empty counterpart to $N=2$'s infinitely many solutions. This uses only a finite check, no `native_decide`, so it remains axiom-free.",
     "mathContext": "$x^3-2$ irreducible over $\\mathbb{F}_7$ ⇒ 7 inert ⇒ $7\\mid N\\Rightarrow 343\\mid N$ ⇒ 7 a non-norm",
     "significance": "key",
-    "relatedConcepts": ["inert prime", "anisotropic form", "cubic reciprocity", "kernel decide (axiom-free)", "surjectivity"],
-    "prerequisites": ["primes in number fields", "ZMod arithmetic", "homogeneous forms"]
+    "relatedConcepts": [
+      "inert prime",
+      "anisotropic form",
+      "cubic reciprocity",
+      "kernel decide (axiom-free)",
+      "surjectivity"
+    ],
+    "prerequisites": [
+      "primes in number fields",
+      "ZMod arithmetic",
+      "homogeneous forms"
+    ]
   },
   {
     "id": "ann-recovering-pell",
     "proofId": "pell-equation-oq-05",
-    "range": { "startLine": 369, "endLine": 386 },
+    "range": {
+      "startLine": 369,
+      "endLine": 386
+    },
     "type": "definition",
     "title": "Recovering Classical Pell",
     "content": "For contrast, `qnorm p q = p² − 2q²` is the real-quadratic (degree-2) norm form. `qnorm_fundamental` records the classical fundamental solution $3^2-2\\cdot2^2=1$, and `qnorm_chain` its Brahmagupta iterates $(17,12),(99,70),(577,408)$. Because $\\mathbb{Q}(\\sqrt2)$ and $\\mathbb{Q}(\\sqrt[3]2)$ have the same unit rank 1, classical Pell is precisely the degree-2 shadow of the cubic picture developed above.",
     "mathContext": "$x^2-2y^2=1$: $(3,2)\\to(17,12)\\to(99,70)\\to(577,408)$",
     "significance": "supporting",
-    "relatedConcepts": ["classical Pell equation", "unit rank", "real-quadratic field"],
-    "prerequisites": ["Pell's equation"]
+    "relatedConcepts": [
+      "classical Pell equation",
+      "unit rank",
+      "real-quadratic field"
+    ],
+    "prerequisites": [
+      "Pell's equation"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-05` (quality 80, pass 0).

All 7 existing annotations already carried full depth fields, so the gap was **coverage**: the rich header docstring (lines 1-46) had no annotation. Added `ann-pell-oq05-overview` framing the whole entry — classical Pell as the norm-one equation, its degree-3 analogue over $\mathbb{Q}(\sqrt[3]2)$, the five-item concrete algebraic core, the S4 distinctness closure (infinitely many solutions via the real embedding), and the deferred unit-rank/signature step. Full depth fields included (`mathContext`, `significance: key`, `relatedConcepts`, `prerequisites`).

meta.json unchanged (already meets targets, under size cap). No Lean source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)