### PR TITLE
research(combinations-formula-oq-10-oq-01): weighted Vandermonde diagonal ∑ k·C(n,k)²=n·C(2n-1,n-1) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ10OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ10OQ01.lean
@@ -1,0 +1,132 @@
+import Mathlib
+
+/-
+# The Weighted Diagonal of Vandermonde: a Closed Form for ∑ k·C(n,k)²
+
+## Open Question OQ-10-OQ-01
+
+The parent file (`CombinationsFormulaOQ10`) proves the **unweighted** diagonal
+of Vandermonde, the sum of the squares of a Pascal row,
+
+        ∑_{k=0}^{n} C(n,k)² = C(2n, n).
+
+This file proves the **first-moment** (weighted) refinement, the closed form
+
+        ∑_{k=0}^{n} k · C(n,k)² = n · C(2n-1, n-1),
+
+which the parent's open questions ask for.  The right-hand side is the standard
+"weighted central binomial": the number of ways to pick a committee of `n` from
+`2n-1` people together with a designated chair among a distinguished half.
+
+## Method
+
+The engine is the **absorption identity**
+`(k+1)·C(n+1,k+1) = (n+1)·C(n,k)` (Mathlib's `Nat.succ_mul_choose_eq`),
+which turns the weight `k` into a shift of the binomial row.  Writing every
+subtraction-free statement over `n+1`:
+
+1. Peel the vanishing `k = 0` term with `Finset.sum_range_succ'` and reindex to
+   `∑_{j=0}^{n} (j+1)·C(n+1,j+1)²`.
+2. Apply absorption to one factor: each term becomes
+   `(n+1)·C(n,j)·C(n+1,j+1)`, so `(n+1)` factors out of the whole sum.
+3. The residual sum `∑_{j=0}^{n} C(n,j)·C(n+1,j+1)` is a genuine (unequal-row)
+   Vandermonde convolution; folding `C(n+1,j+1) = C(n+1,n-j)` by symmetry and
+   applying `Nat.add_choose_eq` collapses it to `C(2n+1, n)`.
+
+Everything is proved over `ℕ` with no truncated-subtraction pitfalls; the
+`n·C(2n-1,n-1)` form is recovered from the `n+1` form by `omega` arithmetic on
+the indices.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ10OQ01
+
+open Nat Finset
+
+/-- **Unequal-row Vandermonde convolution** feeding the weighted diagonal:
+
+        ∑_{j=0}^{n} C(n,j) · C(n+1, j+1) = C(2n+1, n).
+
+Rows `n` and `n+1` are convolved; folding `C(n+1,j+1) = C(n+1,n-j)` by symmetry
+reduces this to `Nat.add_choose_eq` at `m = n`, `n' = n+1`, `r = n`. -/
+theorem sum_choose_mul_choose_succ_shift (n : ℕ) :
+    ∑ j ∈ range (n + 1), n.choose j * (n + 1).choose (j + 1)
+      = (2 * n + 1).choose n := by
+  -- Vandermonde with rows `n` and `n+1`, evaluated at `r = n`.
+  have hv : (n + (n + 1)).choose n
+      = ∑ j ∈ range (n + 1), n.choose j * (n + 1).choose (n - j) := by
+    rw [Nat.add_choose_eq]
+    exact Finset.Nat.sum_antidiagonal_eq_sum_range_succ
+      (fun i j => n.choose i * (n + 1).choose j) n
+  -- Fold the inner coefficient `C(n+1, n-j)` back to `C(n+1, j+1)`.
+  have hsum : ∑ j ∈ range (n + 1), n.choose j * (n + 1).choose (j + 1)
+      = (n + (n + 1)).choose n := by
+    rw [hv]
+    apply Finset.sum_congr rfl
+    intro j hj
+    rw [Finset.mem_range, Nat.lt_succ_iff] at hj
+    have hsplit : n + 1 = (j + 1) + (n - j) := by omega
+    rw [Nat.choose_symm_of_eq_add hsplit]
+  rw [hsum]
+  congr 1
+  omega
+
+/-- **Weighted diagonal, subtraction-free form.**
+
+        ∑_{k=0}^{n+1} k · C(n+1,k)² = (n+1) · C(2n+1, n).
+
+The `k = 0` term vanishes; absorption `(k)·C(n+1,k) = (n+1)·C(n,k-1)` converts
+each remaining term into `(n+1)·C(n,j)·C(n+1,j+1)`, and the residual convolution
+collapses via `sum_choose_mul_choose_succ_shift`. -/
+theorem sum_weighted_sq_choose_succ (n : ℕ) :
+    ∑ k ∈ range (n + 2), k * ((n + 1).choose k) ^ 2
+      = (n + 1) * (2 * n + 1).choose n := by
+  -- Peel the vanishing `k = 0` term and reindex `k = j + 1`.
+  rw [Finset.sum_range_succ' (fun k => k * ((n + 1).choose k) ^ 2) (n + 1)]
+  simp only [Nat.zero_mul, add_zero]
+  -- Each term: `(j+1)·C(n+1,j+1)² = (n+1)·(C(n,j)·C(n+1,j+1))`.
+  have hterm : ∀ j ∈ range (n + 1),
+      (j + 1) * ((n + 1).choose (j + 1)) ^ 2
+        = (n + 1) * (n.choose j * (n + 1).choose (j + 1)) := by
+    intro j _
+    have habsorb : (n + 1) * n.choose j = (n + 1).choose (j + 1) * (j + 1) :=
+      Nat.add_one_mul_choose_eq n j
+    have : (j + 1) * (n + 1).choose (j + 1) = (n + 1) * n.choose j := by
+      rw [habsorb]; ring
+    calc (j + 1) * ((n + 1).choose (j + 1)) ^ 2
+        = ((j + 1) * (n + 1).choose (j + 1)) * (n + 1).choose (j + 1) := by ring
+      _ = ((n + 1) * n.choose j) * (n + 1).choose (j + 1) := by rw [this]
+      _ = (n + 1) * (n.choose j * (n + 1).choose (j + 1)) := by ring
+  rw [Finset.sum_congr rfl hterm, ← Finset.mul_sum,
+    sum_choose_mul_choose_succ_shift]
+
+/-- **Weighted diagonal of Vandermonde** (the headline closed form):
+
+        ∑_{k=0}^{n} k · C(n,k)² = n · C(2n-1, n-1).
+
+The first-moment refinement of `∑ C(n,k)² = C(2n,n)`.  Recovered from the
+subtraction-free `sum_weighted_sq_choose_succ` by `omega` arithmetic on the
+indices; the `n = 0` degenerate case (both sides `0`) is handled uniformly. -/
+theorem sum_weighted_sq_choose (n : ℕ) :
+    ∑ k ∈ range (n + 1), k * (n.choose k) ^ 2
+      = n * (2 * n - 1).choose (n - 1) := by
+  cases n with
+  | zero => decide
+  | succ m =>
+      have h := sum_weighted_sq_choose_succ m
+      -- `2*(m+1)-1 = 2*m+1` and `(m+1)-1 = m`.
+      have e1 : 2 * (m + 1) - 1 = 2 * m + 1 := by omega
+      have e2 : (m + 1) - 1 = m := by omega
+      rw [e1, e2]
+      simpa using h
+
+-- Concrete verifications (axiom-free `decide`).
+-- ∑ k·C(3,k)² = 1·9 + 2·9 + 3·1 = 9+18+3 = 30 = 3·C(5,2) = 3·10.
+example : ∑ k ∈ range 4, k * (Nat.choose 3 k) ^ 2 = 3 * Nat.choose 5 2 := by decide
+-- ∑ k·C(4,k)² = 4·C(7,3) = 4·35 = 140.
+example : ∑ k ∈ range 5, k * (Nat.choose 4 k) ^ 2 = 4 * Nat.choose 7 3 := by decide
+-- ∑ k·C(5,k)² = 5·C(9,4) = 5·126 = 630.
+example : ∑ k ∈ range 6, k * (Nat.choose 5 k) ^ 2 = 5 * Nat.choose 9 4 := by decide
+
+end CombinationsFormulaOQ10OQ01

--- a/src/data/proofs/combinations-formula-oq-10-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-10-oq-01/annotations.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": "ann-combo1001-header",
+    "proofId": "combinations-formula-oq-10-oq-01",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "concept",
+    "title": "The Weighted Diagonal of Vandermonde",
+    "content": "The header frames OQ-10-OQ-01, the first-moment refinement of the parent OQ-10. The parent proves the unweighted diagonal ∑_{k=0}^{n} C(n,k)² = C(2n,n) (the sum of the squares of a Pascal row is the central binomial coefficient). This file weights each term by k and proves the closed form ∑_{k=0}^{n} k·C(n,k)² = n·C(2n-1,n-1).\n\nThe strategy is announced up front: the absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k) trades the linear weight k for a decrement of the binomial row, turning a weighted self-convolution into an ordinary unequal-row Vandermonde convolution. Everything is phrased over n+1 to stay free of truncated ℕ-subtraction; subtraction survives only cosmetically in the RHS index C(2n-1,n-1) of the final statement. `import Mathlib` supplies Nat.add_one_mul_choose_eq (absorption), Nat.add_choose_eq (Vandermonde), the antidiagonal-to-range converter, and Nat.choose_symm_of_eq_add.",
+    "mathContext": "Weighted diagonal: $\\sum_{k=0}^{n} k\\binom{n}{k}^2 = n\\binom{2n-1}{n-1}$. Equivalently $\\tfrac{n}{2}\\binom{2n}{n}$, i.e. $\\tfrac{n}{2}$ times the parent's total mass $\\sum \\binom{n}{k}^2 = \\binom{2n}{n}$, reflecting the symmetry of the squared Pascal row about its center. Absorption: $k\\binom{n}{k} = n\\binom{n-1}{k-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "weighted binomial moments",
+      "absorption identity k·C(n,k) = n·C(n-1,k-1)",
+      "central binomial coefficient",
+      "self-convolution of a sequence",
+      "first moment of a hypergeometric distribution"
+    ],
+    "prerequisites": [
+      "binomial coefficients C(n,k) = Nat.choose",
+      "the unweighted diagonal ∑ C(n,k)² = C(2n,n) (parent OQ-10)",
+      "the symmetry C(n,k) = C(n,n-k)",
+      "finite sums over Finset.range"
+    ]
+  },
+  {
+    "id": "ann-combo1001-vandermonde-convolution",
+    "proofId": "combinations-formula-oq-10-oq-01",
+    "range": { "startLine": 47, "endLine": 73 },
+    "type": "insight",
+    "title": "Unequal-Row Convolution: ∑ C(n,j)·C(n+1,j+1) = C(2n+1,n)",
+    "content": "sum_choose_mul_choose_succ_shift proves ∑_{j=0}^{n} C(n,j)·C(n+1,j+1) = C(2n+1,n). Unlike the parent's diagonal, the two binomial rows here differ by 1 (n and n+1), so this is a genuine unequal-row Vandermonde convolution. The proof has two moves.\n\n1. **Specialize Vandermonde.** Nat.add_choose_eq gives C(n+(n+1),n) as a sum over the antidiagonal of n; Finset.Nat.sum_antidiagonal_eq_sum_range_succ rewrites that as the range sum ∑_{j=0}^{n} C(n,j)·C(n+1,n-j) (lemma hv).\n\n2. **Fold the inner coefficient.** For each j ≤ n the index split n+1 = (j+1)+(n-j) holds — a one-line omega fact. Nat.choose_symm_of_eq_add turns C(n+1,n-j) into C(n+1,j+1), matching the target sum (lemma hsum). A final congr/omega step normalizes C(n+(n+1),n) to C(2n+1,n).",
+    "mathContext": "From $\\binom{n+(n+1)}{n} = \\sum_{j=0}^{n}\\binom{n}{j}\\binom{n+1}{n-j}$ and $\\binom{n+1}{n-j} = \\binom{n+1}{j+1}$ (because $n+1 = (j+1)+(n-j)$), the sum equals $\\binom{2n+1}{n}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.add_choose_eq (Vandermonde)",
+      "unequal-row convolution",
+      "antidiagonal to range conversion",
+      "Nat.choose_symm_of_eq_add",
+      "subtraction-free ℕ arithmetic via omega"
+    ],
+    "prerequisites": [
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ",
+      "Finset.sum_congr",
+      "Pascal symmetry as an index split n+1 = a + b"
+    ]
+  },
+  {
+    "id": "ann-combo1001-weighted-diagonal-succ",
+    "proofId": "combinations-formula-oq-10-oq-01",
+    "range": { "startLine": 75, "endLine": 102 },
+    "type": "insight",
+    "title": "Absorption Engine: ∑ k·C(n+1,k)² = (n+1)·C(2n+1,n)",
+    "content": "sum_weighted_sq_choose_succ is the subtraction-free workhorse: ∑_{k=0}^{n+1} k·C(n+1,k)² = (n+1)·C(2n+1,n). Three moves.\n\n1. **Peel the zero term.** Finset.sum_range_succ' splits off the k=0 summand (which is 0·C(n+1,0)² = 0) and reindexes the rest to ∑_{j=0}^{n} (j+1)·C(n+1,j+1)².\n\n2. **Absorb.** The per-term lemma hterm applies Nat.add_one_mul_choose_eq — (n+1)·C(n,j) = C(n+1,j+1)·(j+1) — to ONE of the two C(n+1,j+1) factors. Splitting the square as ((j+1)·C(n+1,j+1))·C(n+1,j+1) and rewriting the first factor gives (n+1)·C(n,j)·C(n+1,j+1). Applying absorption to only one factor is the crux: it leaves a clean two-row product ready for Vandermonde.\n\n3. **Factor and collapse.** Finset.mul_sum pulls the constant (n+1) out of the sum, and sum_choose_mul_choose_succ_shift collapses the residual convolution to C(2n+1,n).",
+    "mathContext": "$\\sum_{k=0}^{n+1} k\\binom{n+1}{k}^2 = \\sum_{j=0}^{n}(j+1)\\binom{n+1}{j+1}^2 = (n+1)\\sum_{j=0}^{n}\\binom{n}{j}\\binom{n+1}{j+1} = (n+1)\\binom{2n+1}{n}$, using $(j+1)\\binom{n+1}{j+1} = (n+1)\\binom{n}{j}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.add_one_mul_choose_eq (absorption)",
+      "Finset.sum_range_succ' (peeling the first term)",
+      "Finset.mul_sum (factoring a constant)",
+      "reindexing a sum by k = j+1"
+    ],
+    "prerequisites": [
+      "the absorption identity in Mathlib",
+      "splitting a square into a product to expose one factor",
+      "sum_choose_mul_choose_succ_shift (the convolution lemma above)"
+    ]
+  },
+  {
+    "id": "ann-combo1001-weighted-diagonal",
+    "proofId": "combinations-formula-oq-10-oq-01",
+    "range": { "startLine": 104, "endLine": 122 },
+    "type": "insight",
+    "title": "The Closed Form: ∑ k·C(n,k)² = n·C(2n-1,n-1)",
+    "content": "sum_weighted_sq_choose is the headline result: ∑_{k=0}^{n} k·C(n,k)² = n·C(2n-1,n-1). It is recovered from the n+1 workhorse by a case split on n.\n\nFor n = 0 both sides are 0 (the only term is 0·C(0,0)² = 0, and the RHS is 0·anything), discharged by decide. For n = m+1, sum_weighted_sq_choose_succ m gives the value (m+1)·C(2m+1,m); the two index rewrites 2(m+1)-1 = 2m+1 and (m+1)-1 = m (both one-line omega facts) align it with the target n·C(2n-1,n-1). This is where the only truncated ℕ-subtraction in the file appears — confined to the cosmetic RHS index and neutralized by omega, so no subtraction reasoning contaminates the actual derivation.",
+    "mathContext": "$\\sum_{k=0}^{n} k\\binom{n}{k}^2 = n\\binom{2n-1}{n-1}$. For $n=m+1$: RHS $= (m+1)\\binom{2m+1}{m}$, matching the workhorse. For $n=0$: both sides vanish.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "first moment of the squared Pascal row",
+      "closed form n·C(2n-1,n-1)",
+      "recovering a general statement from a subtraction-free special form",
+      "omega for index normalization"
+    ],
+    "prerequisites": [
+      "sum_weighted_sq_choose_succ (the n+1 workhorse)",
+      "case analysis on ℕ (zero vs. succ)",
+      "omega for the index identities"
+    ]
+  },
+  {
+    "id": "ann-combo1001-checks",
+    "proofId": "combinations-formula-oq-10-oq-01",
+    "range": { "startLine": 124, "endLine": 132 },
+    "type": "observation",
+    "title": "Sanity Checks",
+    "content": "Three axiom-free decide verifications confirm the closed form on small cases: ∑_{k} k·C(3,k)² = 1·9 + 2·9 + 3·1 = 9+18+3 = 30 = 3·C(5,2) = 3·10; ∑_{k} k·C(4,k)² = 140 = 4·C(7,3) = 4·35; ∑_{k} k·C(5,k)² = 630 = 5·C(9,4) = 5·126. Using decide (kernel reduction) rather than native_decide keeps these checks free of the Lean.ofReduceBool axiom.",
+    "mathContext": "$\\sum_k k\\binom{3}{k}^2 = 30 = 3\\binom{5}{2}$, $\\sum_k k\\binom{4}{k}^2 = 140 = 4\\binom{7}{3}$, $\\sum_k k\\binom{5}{k}^2 = 630 = 5\\binom{9}{4}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide vs native_decide",
+      "axiom-free numerical verification"
+    ],
+    "prerequisites": [
+      "kernel evaluation of Nat.choose and Finset.sum"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-10-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-10-oq-01/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "combinations-formula-oq-10-oq-01",
+  "title": "The Weighted Diagonal of Vandermonde: a Closed Form for ∑ k·C(n,k)²",
+  "slug": "combinations-formula-oq-10-oq-01",
+  "description": "Proves the first-moment (weighted) refinement of the sum-of-squares diagonal from the parent OQ-10. Where the parent gives ∑_{k=0}^{n} C(n,k)² = C(2n,n), this entry supplies the weighted closed form ∑_{k=0}^{n} k·C(n,k)² = n·C(2n-1,n-1). The engine is the absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k) (Mathlib's Nat.add_one_mul_choose_eq), which turns the weight k into a row shift; the residual sum is an unequal-row Vandermonde convolution ∑ C(n,j)·C(n+1,j+1) = C(2n+1,n) collapsed via Nat.add_choose_eq. Fully machine-checked in ℕ with no truncated-subtraction pitfalls.",
+  "meta": {
+    "author": "Lean Genius researcher-16",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ10OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 132,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None. Every result holds for all natural numbers with no side conditions; the n·C(2n-1,n-1) form uses truncated ℕ-subtraction only in the index of the RHS, and its n=0 degenerate case (both sides 0) is discharged uniformly. Fully machine-checked, depending only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms — no Lean.ofReduceBool, since the numerical checks use decide rather than native_decide).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "vandermonde-identity",
+      "central-binomial-coefficient",
+      "weighted-sum",
+      "absorption-identity",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-07-02",
+    "originalContributions": [
+      "sum_weighted_sq_choose: the weighted diagonal closed form ∑_{k=0}^{n} k·C(n,k)² = n·C(2n-1,n-1), the first-moment refinement of the parent's ∑ C(n,k)² = C(2n,n) — absent elsewhere in the gallery",
+      "sum_weighted_sq_choose_succ: the subtraction-free workhorse ∑_{k=0}^{n+1} k·C(n+1,k)² = (n+1)·C(2n+1,n), proved by peeling the vanishing k=0 term, applying the absorption identity to one binomial factor, and factoring out (n+1)",
+      "sum_choose_mul_choose_succ_shift: the unequal-row Vandermonde convolution ∑_{j=0}^{n} C(n,j)·C(n+1,j+1) = C(2n+1,n), obtained by folding C(n+1,j+1) = C(n+1,n-j) and specializing Nat.add_choose_eq at rows n and n+1",
+      "Worked verifications: ∑ k·C(3,k)² = 30 = 3·C(5,2), ∑ k·C(4,k)² = 140 = 4·C(7,3), ∑ k·C(5,k)² = 630 = 5·C(9,4), all by axiom-free decide"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ10OQ01.lean",
+    "namespace": "CombinationsFormulaOQ10OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 132,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The unweighted diagonal ∑_{k=0}^{n} C(n,k)² = C(2n,n) (Vandermonde's most famous corollary) has a standard family of moment refinements. The first moment ∑_{k=0}^{n} k·C(n,k)² = n·C(2n-1,n-1) is the archetype: it counts committees of size n chosen from 2n-1 people together with a designated chair drawn from a distinguished half, and appears in Riordan's and Gould's combinatorial-identity tables. It is the coefficient-of-x^{n-1} reading of the derivative of (1+x)^{2n}, and is the n-th moment analogue of the mean value of a hypergeometric distribution. Together with the parent's zeroth-moment identity it fixes the first two terms of the moment sequence of the squared Pascal row.",
+    "problemStatement": "Open Question OQ-10-OQ-01 (parent OQ-10, open question 1): does the weighted diagonal ∑_{k=0}^{n} k·C(n,k)² admit a short closed form n·C(2n-1,n-1) by combining the self-convolution (parent OQ-10) with the first-moment absorption identity k·C(n,k) = n·C(n-1,k-1)? Reindex, then apply Vandermonde once.",
+    "proofStrategy": "Work over n+1 to stay subtraction-free. (1) Peel the vanishing k=0 term with Finset.sum_range_succ' and reindex to ∑_{j=0}^{n} (j+1)·C(n+1,j+1)². (2) Apply the absorption identity Nat.add_one_mul_choose_eq, (n+1)·C(n,j) = C(n+1,j+1)·(j+1), to one of the two binomial factors: each term becomes (n+1)·C(n,j)·C(n+1,j+1), so (n+1) factors out via Finset.mul_sum. (3) The residual sum ∑_{j=0}^{n} C(n,j)·C(n+1,j+1) is an unequal-row Vandermonde convolution: fold C(n+1,j+1) = C(n+1,n-j) by Nat.choose_symm_of_eq_add (using n+1 = (j+1)+(n-j)), then apply Nat.add_choose_eq at rows n and n+1, r=n, converting the antidiagonal to a range sum; this collapses to C(2n+1,n). The headline n·C(2n-1,n-1) form is recovered from the n+1 workhorse by omega arithmetic on the indices (2(m+1)-1 = 2m+1, (m+1)-1 = m), with the n=0 case decided directly.",
+    "keyInsights": [
+      "The weight k is not an obstruction but a signal to shift the row: absorption k·C(n,k) = n·C(n-1,k-1) trades the linear weight for a decrement of both the upper and lower index, converting a weighted self-convolution into an ordinary (unequal-row) Vandermonde convolution.",
+      "Applying absorption to only one of the two C(n+1,j+1) factors is the crux: it leaves a clean product C(n,j)·C(n+1,j+1) whose two rows differ by exactly 1, which is precisely the shape Nat.add_choose_eq collapses.",
+      "Phrasing the workhorse over n+1 eliminates every truncated ℕ-subtraction in the derivation; subtraction survives only in the cosmetic RHS index C(2n-1,n-1) of the final statement, where a single omega step and the n=0 base case suffice.",
+      "The closed form n·C(2n-1,n-1) is exactly (n/2)·C(2n,n): the first moment is half the total mass ∑ C(n,k)² = C(2n,n) times n, matching the symmetry of the squared Pascal row about its center."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Header stating OQ-10-OQ-01: the weighted (first-moment) refinement of the parent's sum-of-squares diagonal. Explains the absorption-identity strategy and the subtraction-free n+1 phrasing."
+    },
+    {
+      "id": "vandermonde-convolution",
+      "title": "Unequal-Row Vandermonde Convolution",
+      "startLine": 47,
+      "endLine": 73,
+      "summary": "sum_choose_mul_choose_succ_shift: ∑_{j=0}^{n} C(n,j)·C(n+1,j+1) = C(2n+1,n). Folds C(n+1,j+1) = C(n+1,n-j) by symmetry and specializes Nat.add_choose_eq at rows n and n+1, converting the antidiagonal to a range sum."
+    },
+    {
+      "id": "weighted-diagonal-succ",
+      "title": "Weighted Diagonal (Subtraction-Free Form)",
+      "startLine": 75,
+      "endLine": 102,
+      "summary": "sum_weighted_sq_choose_succ: ∑_{k=0}^{n+1} k·C(n+1,k)² = (n+1)·C(2n+1,n). Peels the k=0 term, applies absorption Nat.add_one_mul_choose_eq to one factor of each term, factors out (n+1), and closes with the convolution lemma."
+    },
+    {
+      "id": "weighted-diagonal",
+      "title": "Weighted Diagonal Closed Form",
+      "startLine": 104,
+      "endLine": 122,
+      "summary": "sum_weighted_sq_choose: the headline ∑_{k=0}^{n} k·C(n,k)² = n·C(2n-1,n-1). Recovered from the n+1 workhorse by omega arithmetic on the indices, with the n=0 degenerate case decided directly."
+    },
+    {
+      "id": "checks",
+      "title": "Sanity Checks",
+      "startLine": 124,
+      "endLine": 132,
+      "summary": "Axiom-free decide verifications: ∑ k·C(3,k)² = 48 = 3·C(5,2), ∑ k·C(4,k)² = 140 = 4·C(7,3), ∑ k·C(5,k)² = 630 = 5·C(9,4)."
+    }
+  ],
+  "conclusion": {
+    "summary": "3 theorems, 0 sorries, 0 axioms. The weighted (first-moment) diagonal of Vandermonde is formalized in ℕ: ∑_{k=0}^{n} k·C(n,k)² = n·C(2n-1,n-1), together with its subtraction-free workhorse over n+1 and the unequal-row Vandermonde convolution ∑ C(n,j)·C(n+1,j+1) = C(2n+1,n) that drives it.",
+    "implications": "This answers the parent OQ-10's first open question in the affirmative and with the predicted closed form, extending the elementary Vandermonde suite from the zeroth moment (∑ C(n,k)² = C(2n,n)) to the first. The absorption-then-Vandermonde pattern — trade a linear weight for a row decrement, then collapse the resulting unequal-row convolution — is reusable for higher weighted moments and for other weighted binomial-square sums.",
+    "openQuestions": [
+      "Does the second moment ∑_{k=0}^{n} k²·C(n,k)² admit a closed form (a linear combination of C(2n-1,n-1) and C(2n-2,n-1)) by applying absorption to both factors, or by combining the zeroth and first moments proved here?",
+      "Can the weighted diagonal be lifted to a polynomial/generating-function identity ∑_k k·C(n,k)² x^k, recovering the integer statement at x=1, in the manner of the Chu–Vandermonde polynomial entry?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-10",
+      "relationship": "parent — provides the unweighted diagonal ∑ C(n,k)² = C(2n,n); this entry proves the first-moment refinement its open questions requested"
+    },
+    {
+      "targetId": "combinations-formula-oq-01",
+      "relationship": "ancestor — the general Vandermonde convolution C(m+n,r) = ∑ C(m,k)·C(n,r-k) that the unequal-row convolution here specializes"
+    },
+    {
+      "targetId": "combinations-formula-oq-09",
+      "relationship": "sibling — weighted binomial row moments; shares the absorption identity k·C(n,k) = n·C(n-1,k-1) and the subtraction-free ℕ proof style"
+    }
+  ],
+  "references": [
+    {
+      "authors": "A.-T. Vandermonde",
+      "title": "Mémoire sur des irrationnelles de différens ordres avec une application au cercle",
+      "year": 1772,
+      "venue": "Hist. Acad. Roy. Sci.",
+      "note": "Vandermonde's convolution identity for binomial coefficients."
+    },
+    {
+      "authors": "H. W. Gould",
+      "title": "Combinatorial Identities: A Standardized Set of Tables Listing 500 Binomial Coefficient Summations",
+      "year": 1972,
+      "venue": "Morgantown, WV",
+      "note": "Tabulates weighted binomial-square moment identities including ∑ k·C(n,k)² = n·C(2n-1,n-1)."
+    },
+    {
+      "authors": "R. L. Graham, D. E. Knuth, O. Patashnik",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "venue": "Addison-Wesley",
+      "note": "Standard reference for the absorption identity k·C(n,k) = n·C(n-1,k-1) and binomial moment computations."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.choose, Nat.add_choose_eq, Nat.add_one_mul_choose_eq, and the antidiagonal/binomial API underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **first-moment (weighted) refinement** of the parent OQ-10 sum-of-squares diagonal — answering that entry's first open question with the predicted closed form:

92920\sum_{k=0}^{n} k\binom{n}{k}^2 = n\binom{2n-1}{n-1}.92920

Where the parent gives the zeroth moment $\sum \binom{n}{k}^2 = \binom{2n}{n}$, this entry supplies the first moment (equivalently $\tfrac{n}{2}\binom{2n}{n}$).

## Method

- **Absorption engine:** `Nat.add_one_mul_choose_eq`, $(k{+}1)\binom{n+1}{k+1} = (n{+}1)\binom{n}{k}$, trades the linear weight $k$ for a decrement of the binomial row.
- Applied to **one** of the two squared factors, each term becomes $(n{+}1)\binom{n}{j}\binom{n+1}{j+1}$, so $(n{+}1)$ factors out.
- The residual is an **unequal-row Vandermonde convolution** $\sum \binom{n}{j}\binom{n+1}{j+1} = \binom{2n+1}{n}$, collapsed via `Nat.add_choose_eq`.
- The workhorse is phrased over `n+1` to stay subtraction-free; the headline $\binom{2n-1}{n-1}$ form is recovered by `omega` on the indices, with `n=0` decided directly.

## Verification

- **3 theorems, 0 sorries, 0 axioms.** `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` — no `Lean.ofReduceBool` (numerical checks use `decide`, not `native_decide`).
- Verified via `lake env lean`.
- Worked checks: $\sum k\binom{3}{k}^2 = 30 = 3\binom{5}{2}$, $\sum k\binom{4}{k}^2 = 140 = 4\binom{7}{3}$, $\sum k\binom{5}{k}^2 = 630 = 5\binom{9}{4}$.

## Files

- `proofs/Proofs/CombinationsFormulaOQ10OQ01.lean` (132 lines)
- `src/data/proofs/combinations-formula-oq-10-oq-01/` (meta.json + 5 annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)