### PR TITLE
Fix Mathlib drift in ThreePlaceIdentity.lean (add Order.Defs.Unbundled import)

### DIFF
--- a/proofs/Proofs/ThreePlaceIdentity.lean
+++ b/proofs/Proofs/ThreePlaceIdentity.lean
@@ -1,6 +1,7 @@
 import Mathlib.Tactic.Tauto
 import Mathlib.Tactic.Push
 import Mathlib.Logic.Basic
+import Mathlib.Order.Defs.Unbundled
 
 /-!
 # Universality of Three-Place Identity


### PR DESCRIPTION
## Fix

Add the missing `import Mathlib.Order.Defs.Unbundled` to `proofs/Proofs/ThreePlaceIdentity.lean`, which restores compilation of a gallery entry currently marked `verified` but silently broken by Mathlib drift.

## Evidence

**Before**: Under pinned Mathlib **v4.26.0**, the relation predicates `Reflexive` / `Symmetric` / `Transitive` live in `Mathlib.Order.Defs.Unbundled` and are no longer reachable transitively through `Mathlib.Logic.Basic`. The file's `RelativeIdentity.symm'` and `RelativeIdentity.trans'` theorems failed to elaborate:

```
Proofs/ThreePlaceIdentity.lean:80:4: error: Function expected at Symmetric ...
Proofs/ThreePlaceIdentity.lean:85:4: error: Function expected at Transitive ...
```

So the `three-place-identity` gallery entry (`status: verified`, `axiomCount: 0`) did not actually compile against the pinned toolchain.

**After**: One import line added. Verified with `lean` against the pinned v4.26.0 toolchain — file builds clean, **0 sorries, 0 axioms** (`#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound`, which do not count).

This also unblocks the downstream `ThreePlaceIdentityOQ01.lean`, which `import`s this module (it now builds and is 0-axiom too).

## Scope

Single-line, minimal drift repair (Fix Type B — Mathlib version-bump type error). No mathematical content changed.

---
Automated fix by lean-mechanic agent.