### PR TITLE
Fix: create missing gallery entry for schroeder-bernstein-oq-05

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-05/annotations.json
+++ b/src/data/proofs/schroeder-bernstein-oq-05/annotations.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "ann-cbs-oq05-section",
+    "proofId": "schroeder-bernstein-oq-05",
+    "range": {
+      "startLine": 33,
+      "endLine": 42
+    },
+    "type": "insight",
+    "title": "Splitting a Surjection — Where Choice Enters",
+    "content": "exists_injective_section proves that every surjection f : A → B admits a right inverse f' : B → A (a section) which is injective. Mathlib's Surjective.hasRightInverse produces the section, and RightInverse.injective shows it is injective. This is the single point at which the Axiom of Choice is used in the entire dual theorem: choosing one preimage for each element of the codomain. Everything downstream is choice-free.",
+    "mathContext": "For a surjection $f$, `hasRightInverse` gives $f'$ with $f \\circ f' = \\mathrm{id}_B$; a right inverse is always injective.",
+    "significance": "key",
+    "relatedConcepts": [
+      "axiom of choice",
+      "right inverse",
+      "section of a surjection",
+      "injectivity"
+    ],
+    "prerequisites": [
+      "Function.Surjective.hasRightInverse",
+      "Function.RightInverse.injective"
+    ]
+  },
+  {
+    "id": "ann-cbs-oq05-bijection",
+    "proofId": "schroeder-bernstein-oq-05",
+    "range": {
+      "startLine": 44,
+      "endLine": 52
+    },
+    "type": "concept",
+    "title": "Reduction to Classical Schroeder-Bernstein",
+    "content": "exists_bijective_of_surjective₂ is the crux: given surjections both ways, split each into an injective section, then feed the two injections to the classical Schroeder-Bernstein theorem (Embedding.schroeder_bernstein). The duality is realized by turning mutual surjections into mutual injections. Note the direction bookkeeping — the section of f : A → B is an injection B → A, and the section of g : B → A is an injection A → B.",
+    "mathContext": "From $f : A \\twoheadrightarrow B$, $g : B \\twoheadrightarrow A$ obtain injections $f' : B \\hookrightarrow A$, $g' : A \\hookrightarrow B$; `Embedding.schroeder_bernstein` yields a bijection $A \\to B$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Schroeder-Bernstein theorem",
+      "duality",
+      "mutual injections",
+      "function embeddings"
+    ],
+    "prerequisites": [
+      "Function.Embedding.schroeder_bernstein"
+    ]
+  },
+  {
+    "id": "ann-cbs-oq05-equiv",
+    "proofId": "schroeder-bernstein-oq-05",
+    "range": {
+      "startLine": 54,
+      "endLine": 63
+    },
+    "type": "definition",
+    "title": "Explicit Equivalence Witness",
+    "content": "equivOfSurjective₂ packages the bijection as an explicit A ≃ B via Equiv.ofBijective, and nonempty_equiv_of_surjective₂ exposes the propositional equinumerosity Nonempty (A ≃ B). The definition is noncomputable because the underlying sections are chosen — the noncomputability is inherited entirely from the single use of choice in the section step, not introduced by any later construction.",
+    "mathContext": "`Equiv.ofBijective` converts the bijection into $A \\simeq B$; wrapping in `Nonempty` gives the equinumerosity predicate.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "equivalence of types",
+      "noncomputable definitions",
+      "equinumerosity"
+    ],
+    "prerequisites": [
+      "Equiv.ofBijective"
+    ]
+  },
+  {
+    "id": "ann-cbs-oq05-cardinal",
+    "proofId": "schroeder-bernstein-oq-05",
+    "range": {
+      "startLine": 65,
+      "endLine": 76
+    },
+    "type": "concept",
+    "title": "Cardinal Equality and Sanity Check",
+    "content": "cardinal_eq_of_surjective₂ lifts the equivalence to the cardinal identity #A = #B using Cardinal.eq.mpr, connecting the pointwise bijection to Mathlib's cardinal-arithmetic framework. equivOfSurjective₂_bijective is a sanity check confirming the produced equivalence is genuinely bijective. Together these give the theorem in its most usable forms: as a bijection, as an equinumerosity statement, and as a cardinal equation.",
+    "mathContext": "`Cardinal.eq.mpr` turns a nonempty equivalence into $\\#A = \\#B$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cardinal arithmetic",
+      "equinumerosity",
+      "bijection"
+    ],
+    "prerequisites": [
+      "Cardinal.eq",
+      "Equiv.bijective"
+    ]
+  }
+]

--- a/src/data/proofs/schroeder-bernstein-oq-05/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-05/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "schroeder-bernstein-oq-05",
+  "title": "Dual Schroeder-Bernstein: Mutual Surjections Imply Equinumerosity",
+  "slug": "schroeder-bernstein-oq-05",
+  "description": "The dual of the classical Cantor-Schroeder-Bernstein theorem: if there exist surjections both ways between two types, then they are equinumerous. Each surjection is split by a right inverse (an injection via the Axiom of Choice), and the classical Schroeder-Bernstein theorem is applied to the two resulting injections.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026-06-27",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SchroederBernsteinOQ05.lean",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "axiom-of-choice",
+      "surjections",
+      "bijections",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Function.Surjective.hasRightInverse",
+        "description": "Every surjection admits a right inverse (section)",
+        "module": "Mathlib.Logic.Function.Basic"
+      },
+      {
+        "theorem": "Function.RightInverse.injective",
+        "description": "A right inverse of a function is injective",
+        "module": "Mathlib.Logic.Function.Basic"
+      },
+      {
+        "theorem": "Function.Embedding.schroeder_bernstein",
+        "description": "Classical Schroeder-Bernstein: mutual injections yield a bijection",
+        "module": "Mathlib.SetTheory.Cardinal.SchroederBernstein"
+      },
+      {
+        "theorem": "Equiv.ofBijective",
+        "description": "Construct an equivalence from a bijective function",
+        "module": "Mathlib.Logic.Equiv.Defs"
+      },
+      {
+        "theorem": "Cardinal.eq",
+        "description": "Equality of cardinals is equivalent to the existence of an equivalence",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Formalization of the surjective (dual) form of Schroeder-Bernstein",
+      "Right-inverse splitting reduces mutual surjections to mutual injections",
+      "Explicit A ≃ B equivalence witness (equivOfSurjective₂)",
+      "Cardinal-equality corollary #A = #B from mutual surjections",
+      "Isolation of the single point where the Axiom of Choice enters"
+    ],
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 76,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None beyond Lean/Mathlib's standard foundational axioms (propext, Classical.choice, Quot.sound). Fully verified with 0 custom axioms and 0 sorries. The surjective form genuinely uses Classical.choice to split each surjection into a section.",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Schroeder-Bernstein theorem (1887-1898), independently established by Dedekind, Schroeder, and Bernstein, states that mutual injections between two sets imply the existence of a bijection. This injective form is choice-free: the classical back-and-forth construction proceeds without any appeal to the Axiom of Choice.\n\nThe *dual* statement replaces injections with surjections: if there exist surjections both ways, are the sets equinumerous? Unlike the injective form, the dual is not choice-free — for arbitrary sets it is in fact *equivalent* to the Axiom of Choice. The obstruction is precisely that splitting a surjection into a section requires choosing a preimage for each element of the codomain.",
+    "problemStatement": "**Open Question (OQ-05)**: Does the surjective analogue of Schroeder-Bernstein hold — do mutual surjections imply equinumerosity — and what is its logical strength?\n\n**Answer**: Yes, under the Axiom of Choice. Given surjections $f : A \\twoheadrightarrow B$ and $g : B \\twoheadrightarrow A$, each admits a right inverse (a section), which is an injection. Feeding the two injections $g' : A \\hookrightarrow B$ and $f' : B \\hookrightarrow A$ into the classical Schroeder-Bernstein theorem produces a bijection $A \\simeq B$, hence $\\#A = \\#B$.",
+    "proofStrategy": "The proof is a clean two-step reduction:\n\n1. **Split each surjection.** By `Function.Surjective.hasRightInverse`, a surjection $f$ has a right inverse $f'$ with $f \\circ f' = \\mathrm{id}$. Any such section is injective (`RightInverse.injective`). This is the *only* place the Axiom of Choice is used.\n\n2. **Apply classical Schroeder-Bernstein.** The two sections give injections in both directions; `Function.Embedding.schroeder_bernstein` upgrades them to a bijection. `Equiv.ofBijective` packages it as an `A ≃ B`, and `Cardinal.eq` yields the cardinal identity $\\#A = \\#B$.",
+    "keyInsights": [
+      "**Duality via sections**: The surjective form reduces to the injective form by splitting each surjection into an injective section. This is the conceptual heart — mutual surjections become mutual injections once every surjection is right-inverted.",
+      "**Choice enters exactly once**: The entire non-constructive content is concentrated in `hasRightInverse`. Everything downstream (Schroeder-Bernstein, `ofBijective`) is choice-free given the two injections, making the dependence on the Axiom of Choice transparent.",
+      "**Equivalent to AC in general**: For arbitrary sets the dual statement is equivalent to the Axiom of Choice, so the appeal to choice is not an artifact of the proof but a genuine feature of the theorem.",
+      "**Noncomputability is inherited**: `equivOfSurjective₂` is `noncomputable` precisely because the chosen sections are noncomputable; the surrounding logic adds no further obstruction."
+    ],
+    "prerequisites": [
+      "Set theory (injections, surjections, bijections)",
+      "The Axiom of Choice and right inverses of surjections",
+      "The classical Schroeder-Bernstein theorem",
+      "Cardinal arithmetic (equinumerosity)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "section",
+      "title": "Splitting a Surjection into an Injective Section",
+      "startLine": 33,
+      "endLine": 42,
+      "summary": "Proves `exists_injective_section`: every surjection `f : A → B` admits a right inverse `f' : B → A` that is injective. This is the one place the Axiom of Choice enters the dual theorem.",
+      "mathContext": "For a surjection $f$, `hasRightInverse` provides $f'$ with $f \\circ f' = \\mathrm{id}_B$; such a section is automatically injective. The choice of preimage per element is the Axiom of Choice."
+    },
+    {
+      "id": "bijection",
+      "title": "Dual Schroeder-Bernstein (Bijection Form)",
+      "startLine": 44,
+      "endLine": 52,
+      "summary": "Proves `exists_bijective_of_surjective₂`: surjections both ways yield a bijection `A → B`, by splitting each surjection into an injective section and applying the classical Schroeder-Bernstein theorem to the two injections.",
+      "mathContext": "From $f : A \\twoheadrightarrow B$ and $g : B \\twoheadrightarrow A$ obtain injective sections $f' : B \\hookrightarrow A$ and $g' : A \\hookrightarrow B$; then `Embedding.schroeder_bernstein` yields a bijection $A \\to B$."
+    },
+    {
+      "id": "equiv",
+      "title": "Explicit Equivalence and Nonempty Form",
+      "startLine": 54,
+      "endLine": 63,
+      "summary": "Defines `equivOfSurjective₂`, the explicit `A ≃ B` witness (noncomputable, since the sections are chosen), and `nonempty_equiv_of_surjective₂`, the propositional equinumerosity statement.",
+      "mathContext": "`Equiv.ofBijective` turns the bijection into $A \\simeq B$; wrapping it in `Nonempty` gives the equinumerosity predicate used by cardinal arithmetic."
+    },
+    {
+      "id": "cardinal",
+      "title": "Cardinal Form and Sanity Check",
+      "startLine": 65,
+      "endLine": 76,
+      "summary": "Proves `cardinal_eq_of_surjective₂` (mutual surjections force `#A = #B` via `Cardinal.eq`) and `equivOfSurjective₂_bijective`, verifying the produced equivalence really is bijective.",
+      "mathContext": "`Cardinal.eq.mpr` converts the nonempty equivalence into $\\#A = \\#B$; the sanity check confirms `equivOfSurjective₂` is a genuine bijection."
+    }
+  ],
+  "conclusion": {
+    "summary": "We answer OQ-05 affirmatively under the Axiom of Choice: mutual surjections between two types imply equinumerosity. The proof splits each surjection into an injective section and reduces to the classical Schroeder-Bernstein theorem, isolating the single use of choice.",
+    "implications": "**Sharp localization of choice**: By concentrating all non-constructive content in the right-inverse step, the formalization makes precise where and why the dual theorem departs from the choice-free injective form. This mirrors the general fact that the dual statement is equivalent to the Axiom of Choice for arbitrary sets.\n\n**Reusable reduction pattern**: The 'split each surjection into a section, then apply the injective theorem' pattern is a reusable device for transporting results about injections to results about surjections whenever choice is available.\n\n**Cardinal-arithmetic payoff**: The cardinal-equality corollary $\\#A = \\#B$ connects the pointwise bijection to Mathlib's cardinal framework, allowing the result to be used wherever cardinal identities are needed.",
+    "openQuestions": [
+      "Which restricted classes of sets admit a choice-free dual Schroeder-Bernstein (e.g. finite or well-orderable types)?",
+      "Can the exact logical strength of the dual statement over weak set theories be formalized (equivalence with AC)?",
+      "Is there a canonical bijection when the surjections carry extra structure, avoiding the noncomputable section?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "schroeder-bernstein",
+      "relationship": "extends",
+      "description": "The classical (injective) Schroeder-Bernstein theorem: mutual injections yield a bijection. This entry proves the dual surjective form by splitting surjections into injective sections and invoking the classical theorem."
+    },
+    {
+      "targetId": "schroeder-bernstein-oq-04",
+      "relationship": "related",
+      "description": "A constructive Schroeder-Bernstein for finite types that isolates where excluded middle enters the injective proof; this entry instead isolates where the Axiom of Choice enters the surjective (dual) proof."
+    }
+  ],
+  "references": [
+    {
+      "text": "Bernstein, F. (1898). Untersuchungen aus der Mengenlehre. PhD thesis, Georg-August-Universitaet Goettingen.",
+      "url": "https://en.wikipedia.org/wiki/Schr%C3%B6der%E2%80%93Bernstein_theorem"
+    },
+    {
+      "text": "Schroeder-Bernstein theorem (dual / surjective form).",
+      "url": "https://en.wikipedia.org/wiki/Schr%C3%B6der%E2%80%93Bernstein_theorem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.SetTheory.Cardinal.SchroederBernstein",
+      "Mathlib.SetTheory.Cardinal.Basic",
+      "Mathlib.Logic.Equiv.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Function"
+    ],
+    "namespace": "SchroederBernsteinOQ05",
+    "lineCount": 76,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/SchroederBernsteinOQ05.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Fix

The dual Schroeder–Bernstein proof was merged but never made it into the web gallery — no `src/data/proofs/` directory was created, so the entry is invisible.

## Evidence

**Before**: `proofs/Proofs/SchroederBernsteinOQ05.lean` was merged in #32112 (`research(schroeder-bernstein-oq-05): dual Schröder–Bernstein (mutual surjections ⇒ equinumerosity) [VERIFIED, 0-axiom, original]`) but `src/data/proofs/schroeder-bernstein-oq-05/` did not exist and no `meta.json` referenced the file — it appeared in no gallery view.

**After**: Adds `meta.json` + `annotations.json`. The Lean file is 76 lines, 5 theorems / 1 definition, 0 sorries, 0 custom axioms (uses only the standard `propext`/`Classical.choice`/`Quot.sound`; the surjective form genuinely uses choice to split each surjection into a section). Status `verified`, badge `original`.

`pnpm annotations:build` resolves all four annotations to Lean constructs with no warnings for this entry; cross-reference targets (`schroeder-bernstein`, `schroeder-bernstein-oq-04`) both exist.

---
Automated fix by lean-mechanic agent.