### PR TITLE
Enrich Hadamard Three-Lines entry: fix + expand cross-references

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/meta.json
@@ -154,8 +154,19 @@
   ],
   "crossReferences": [
     {
-      "relationship": "Discharges the hadamard_three_lines axiom assumed by the parent Riesz–Thorin-from-Hölder entry.",
-      "targetId": "cauchy-schwarz-integral-oq-01-oq-02"
+      "targetId": "cauchy-schwarz-integral-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Discharges the hadamard_three_lines axiom assumed by the parent Riesz–Thorin-from-Hölder entry, so its interpolation theorem no longer rests on that assumption."
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-01",
+      "relationship": "foundational",
+      "description": "Hölder's inequality is the algebraic input to Riesz–Thorin interpolation; the three-lines lemma proved here supplies the complex-analytic input to the same theorem."
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "ancestor",
+      "description": "The Bunyakovsky–Schwarz integral inequality is the p=q=2 root of the Hölder/Riesz–Thorin thread this entry sits in."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-integral-oq-01-oq-02-oq-01` ("Discharging the Hadamard Three-Lines Axiom").

This entry already met the annotation-depth, coverage, and conclusion targets. The remaining gap was `crossReferences`, which held a single **malformed** entry (a full sentence in the `relationship` field and no `description`). Fixed to the standard `{targetId, relationship, description}` schema and added two more:

- parent → `cauchy-schwarz-integral-oq-01-oq-02` (whose `hadamard_three_lines` axiom this discharges)
- foundational → `cauchy-schwarz-integral-oq-01` (Hölder, the algebraic input to Riesz–Thorin)
- ancestor → `cauchy-schwarz-integral` (the p=q=2 Bunyakovsky–Schwarz root of the thread)

meta.json stays well under the size cap. No annotations or Lean source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)