### PR TITLE
Fix: create missing gallery entry for cyclotomic-polynomials-oq-01

### DIFF
--- a/src/data/proofs/cyclotomic-polynomials-oq-01/annotations.json
+++ b/src/data/proofs/cyclotomic-polynomials-oq-01/annotations.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "cyclotomic-polynomials-oq-01",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "Cyclotomic polynomials as a topic",
+    "content": "The n-th cyclotomic polynomial Φ_n is the minimal monic polynomial whose roots are the primitive n-th roots of unity. This file packages its three most fundamental structural facts — degree deg Φ_n = φ(n), the prime geometric-sum form Φ_p = 1 + X + ⋯ + X^{p-1}, and the divisor factorization ∏_{d∣n} Φ_d = Xⁿ − 1 — and from the last derives Gauss's totient-divisor-sum identity ∑_{d∣n} φ(d) = n. Everything is sorry-free and axiom-free. The gallery previously used `cyclotomic` only as machinery inside Galois and angle-trisection proofs; this entry treats it as a subject in its own right.",
+    "mathContext": "$\\deg\\Phi_n = \\varphi(n)$, $\\Phi_p = \\sum_{i<p}X^i$, $\\prod_{d\\mid n}\\Phi_d = X^n-1 \\Rightarrow \\sum_{d\\mid n}\\varphi(d)=n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cyclotomic polynomials",
+      "roots of unity",
+      "Euler's totient",
+      "Gauss's totient-divisor-sum identity"
+    ],
+    "prerequisites": [
+      "polynomials over a ring",
+      "divisors",
+      "Euler's totient function"
+    ]
+  },
+  {
+    "id": "ann-degree",
+    "proofId": "cyclotomic-polynomials-oq-01",
+    "range": { "startLine": 49, "endLine": 57 },
+    "type": "theorem",
+    "title": "deg Φ_n = φ(n), and deg Φ_p = p − 1 for prime p",
+    "content": "`cyclotomic_natDegree` records the headline degree fact deg Φ_n = φ(n) over any nontrivial ring, wrapping Mathlib's `natDegree_cyclotomic`. `cyclotomic_prime_natDegree` specializes it to a prime p: rewriting with `Nat.totient_prime` (φ(p) = p − 1) gives deg Φ_p = p − 1.",
+    "mathContext": "$\\deg\\Phi_n = \\varphi(n)$; $\\deg\\Phi_p = p-1$.",
+    "significance": "important",
+    "relatedConcepts": ["polynomial degree", "Euler's totient", "primes"],
+    "prerequisites": ["natDegree", "totient of a prime"]
+  },
+  {
+    "id": "ann-prime-form",
+    "proofId": "cyclotomic-polynomials-oq-01",
+    "range": { "startLine": 61, "endLine": 69 },
+    "type": "theorem",
+    "title": "Prime cyclotomics are geometric sums",
+    "content": "For a prime p, `cyclotomic_prime_geom_sum` gives Φ_p = ∑_{i<p} Xⁱ = 1 + X + ⋯ + X^{p−1}, the p-term geometric sum (Mathlib's `cyclotomic_prime`). Evaluating this at 1 sums p copies of 1, so `cyclotomic_prime_eval_one` yields Φ_p(1) = p.",
+    "mathContext": "$\\Phi_p = \\sum_{i<p}X^i$, so $\\Phi_p(1) = p$.",
+    "significance": "important",
+    "relatedConcepts": ["geometric sum", "polynomial evaluation", "primes"],
+    "prerequisites": ["Finset.range sums", "evaluation of polynomials"]
+  },
+  {
+    "id": "ann-divisor-product",
+    "proofId": "cyclotomic-polynomials-oq-01",
+    "range": { "startLine": 73, "endLine": 77 },
+    "type": "theorem",
+    "title": "The divisor factorization Xⁿ − 1 = ∏_{d∣n} Φ_d",
+    "content": "`prod_cyclotomic_divisors` states the factorization of Xⁿ − 1 into cyclotomic factors indexed by the divisors of n (Mathlib's `prod_cyclotomic_eq_X_pow_sub_one`), for n > 0 over any commutative ring. This is the identity that carries all the arithmetic content used to derive Gauss's identity next.",
+    "mathContext": "$\\prod_{d\\mid n}\\Phi_d = X^n - 1$ for $n > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["factorization", "roots of unity", "divisors"],
+    "prerequisites": ["products over Finset", "divisors of n"]
+  },
+  {
+    "id": "ann-gauss",
+    "proofId": "cyclotomic-polynomials-oq-01",
+    "range": { "startLine": 81, "endLine": 92 },
+    "type": "theorem",
+    "title": "Gauss's ∑_{d∣n} φ(d) = n via cyclotomic degrees",
+    "content": "`sum_totient_divisors` derives Gauss's totient-divisor-sum identity from the factorization ∏_{d∣n} Φ_d = Xⁿ − 1 over ℤ. Taking natDegree of both sides: on the left, `natDegree_prod` (each Φ_d ≠ 0 in the domain ℤ) turns the degree of the product into the sum of the factor degrees, and `natDegree_cyclotomic` rewrites each to φ(d); on the right, Xⁿ − 1 = Xⁿ − C 1 has degree n by `natDegree_X_pow_sub_C`. Equating gives ∑_{d∣n} φ(d) = n. A degree-count route to a classical counting identity.",
+    "mathContext": "$\\deg\\!\\big(\\prod_{d\\mid n}\\Phi_d\\big) = \\sum_{d\\mid n}\\varphi(d)$ and $\\deg(X^n-1)=n$, so $\\sum_{d\\mid n}\\varphi(d)=n$.",
+    "significance": "key",
+    "relatedConcepts": ["Gauss's identity", "degree of a product", "integral domain"],
+    "prerequisites": ["natDegree of a product", "nonvanishing of Φ_d over ℤ"]
+  },
+  {
+    "id": "ann-witnesses",
+    "proofId": "cyclotomic-polynomials-oq-01",
+    "range": { "startLine": 96, "endLine": 119 },
+    "type": "example",
+    "title": "Concrete witnesses and sample computations",
+    "content": "Explicit low-degree cases ground the abstract results: Φ₁ = X − 1, Φ₂ = X + 1, Φ₃ = 1 + X + X² (the last unfolded from the prime geometric-sum form at p = 3). Samples deg Φ₇ = 6 and Φ₅(1) = 5 instantiate the prime degree and evaluation results, and ∑_{d∣12} φ(d) = 12 instantiates Gauss's identity.",
+    "mathContext": "$\\Phi_1=X-1$, $\\Phi_2=X+1$, $\\Phi_3=1+X+X^2$; $\\deg\\Phi_7=6$, $\\Phi_5(1)=5$, $\\sum_{d\\mid 12}\\varphi(d)=12$.",
+    "significance": "supporting",
+    "relatedConcepts": ["low-degree cyclotomics", "worked examples"],
+    "prerequisites": ["the general results above"]
+  }
+]

--- a/src/data/proofs/cyclotomic-polynomials-oq-01/meta.json
+++ b/src/data/proofs/cyclotomic-polynomials-oq-01/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "cyclotomic-polynomials-oq-01",
+  "title": "Cyclotomic Polynomials: Degree φ(n), Prime Form, and the Divisor Product Xⁿ−1 = ∏ Φ_d",
+  "slug": "cyclotomic-polynomials-oq-01",
+  "description": "A self-contained, fully machine-checked topic entry on the structural facts of the cyclotomic polynomials Φ_n — the minimal monic polynomials whose roots are the primitive n-th roots of unity. It packages four fundamental facts from Mathlib's cyclotomic library into one coherent entry: (1) deg Φ_n = φ(n) (Euler's totient) over any nontrivial ring; (2) for a prime p, Φ_p = 1 + X + X² + ⋯ + X^{p-1} is the p-term geometric sum, so deg Φ_p = p−1 and Φ_p(1) = p; (3) the divisor factorization ∏_{d ∣ n} Φ_d = Xⁿ − 1. From these it derives a genuine structural consequence — Gauss's totient-divisor-sum identity ∑_{d ∣ n} φ(d) = n — purely by taking degrees in the cyclotomic factorization of Xⁿ − 1 over ℤ. Concrete witnesses Φ₁ = X−1, Φ₂ = X+1, Φ₃ = 1+X+X² and sample degree/evaluation computations (deg Φ₇ = 6, Φ₅(1) = 5, ∑_{d∣12} φ(d) = 12) close the entry. The gallery previously used `cyclotomic` only as machinery inside Galois and angle-trisection proofs, never as a subject in its own right.",
+  "meta": {
+    "author": "Classical (Gauss); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cyclotomic_polynomial",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "algebra",
+      "polynomials",
+      "cyclotomic-polynomials",
+      "roots-of-unity",
+      "euler-totient",
+      "gauss-identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CyclotomicPolynomialsOQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.natDegree_cyclotomic",
+        "description": "deg Φ_n = φ(n): the degree of the n-th cyclotomic polynomial over any nontrivial ring is Euler's totient. The backbone of both the degree results and the Gauss derivation.",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic"
+      },
+      {
+        "theorem": "Polynomial.cyclotomic_prime",
+        "description": "For a prime p, Φ_p = ∑_{i<p} Xⁱ, the p-term geometric sum. Gives the prime cyclotomic its explicit closed form.",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic"
+      },
+      {
+        "theorem": "Polynomial.eval_one_cyclotomic_prime",
+        "description": "Φ_p(1) = p for prime p, obtained by evaluating the geometric-sum form at 1.",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Eval"
+      },
+      {
+        "theorem": "Polynomial.prod_cyclotomic_eq_X_pow_sub_one",
+        "description": "∏_{d ∣ n} Φ_d = Xⁿ − 1 for n > 0: the factorization of Xⁿ − 1 into cyclotomic factors indexed by the divisors of n. The source of the Gauss identity.",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic"
+      },
+      {
+        "theorem": "Polynomial.natDegree_prod",
+        "description": "Degree of a product of nonzero polynomials over a domain is the sum of the degrees. Applied to ∏_{d ∣ n} Φ_d over ℤ (each Φ_d ≠ 0) to convert the divisor product into ∑_{d∣n} φ(d).",
+        "module": "Mathlib.Algebra.Polynomial.BigOperators"
+      },
+      {
+        "theorem": "Nat.totient_prime",
+        "description": "φ(p) = p − 1 for prime p, used to specialize deg Φ_p = φ(p) to p − 1.",
+        "module": "Mathlib.NumberTheory.Divisors"
+      }
+    ],
+    "originalContributions": [
+      "A single coherent gallery topic entry for the cyclotomic polynomials Φ_n — degree, prime form, and divisor product — where the gallery previously used `cyclotomic` only as machinery inside Galois-theory and angle-trisection proofs, never as a subject in its own right",
+      "A degree-counting derivation of Gauss's totient-divisor-sum identity ∑_{d ∣ n} φ(d) = n obtained purely from the cyclotomic factorization ∏_{d∣n} Φ_d = Xⁿ − 1 (taking natDegree of both sides over ℤ), an alternative route to the classical identity that exposes its algebraic origin in the factorization of Xⁿ − 1",
+      "Machine-checked concrete witnesses Φ₁ = X−1, Φ₂ = X+1, Φ₃ = 1+X+X² together with sample computations deg Φ₇ = 6, Φ₅(1) = 5, and ∑_{d∣12} φ(d) = 12, grounding the abstract results in explicit low-degree cases"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 121,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. No native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext / Classical.choice / Quot.sound, none of which count as assumptions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "degree",
+      "title": "Degree of the cyclotomic polynomial",
+      "startLine": 47,
+      "endLine": 57,
+      "summary": "deg Φ_n = φ(n) over any nontrivial ring (`cyclotomic_natDegree`, a direct wrapper of Mathlib's `natDegree_cyclotomic`), specialized to deg Φ_p = p − 1 for prime p (`cyclotomic_prime_natDegree`) via `Nat.totient_prime`.",
+      "mathContext": "$\\deg \\Phi_n = \\varphi(n)$; for prime $p$, $\\deg \\Phi_p = p - 1$."
+    },
+    {
+      "id": "prime-form",
+      "title": "Prime cyclotomic polynomials are geometric sums",
+      "startLine": 59,
+      "endLine": 69,
+      "summary": "For a prime p, Φ_p = 1 + X + X² + ⋯ + X^{p-1} = ∑_{i<p} Xⁱ (`cyclotomic_prime_geom_sum`), and evaluating at 1 gives Φ_p(1) = p (`cyclotomic_prime_eval_one`).",
+      "mathContext": "$\\Phi_p = \\sum_{i<p} X^i$ and $\\Phi_p(1) = p$ for prime $p$."
+    },
+    {
+      "id": "divisor-product",
+      "title": "The divisor product Xⁿ − 1 = ∏_{d ∣ n} Φ_d",
+      "startLine": 71,
+      "endLine": 77,
+      "summary": "The factorization of Xⁿ − 1 into cyclotomic polynomials indexed by the divisors of n (`prod_cyclotomic_divisors`), for n > 0 over any commutative ring — the identity that powers Gauss's totient sum.",
+      "mathContext": "$\\prod_{d \\mid n} \\Phi_d = X^n - 1$ for $n > 0$."
+    },
+    {
+      "id": "gauss",
+      "title": "Gauss's totient-divisor-sum identity, via cyclotomic degrees",
+      "startLine": 79,
+      "endLine": 92,
+      "summary": "∑_{d ∣ n} φ(d) = n (`sum_totient_divisors`), derived by taking natDegree of both sides of ∏_{d∣n} Φ_d = Xⁿ − 1 over ℤ: the product degree is the sum of factor degrees (each Φ_d ≠ 0 in the domain ℤ), each contributing deg Φ_d = φ(d), while Xⁿ − 1 has degree n.",
+      "mathContext": "$\\sum_{d \\mid n} \\varphi(d) = n$, obtained from $\\deg\\!\\bigl(\\prod_{d\\mid n}\\Phi_d\\bigr) = \\deg(X^n-1) = n$."
+    },
+    {
+      "id": "witnesses",
+      "title": "Concrete witnesses and sample computations",
+      "startLine": 94,
+      "endLine": 119,
+      "summary": "Φ₁ = X−1, Φ₂ = X+1, Φ₃ = 1+X+X² and the samples deg Φ₇ = 6, Φ₅(1) = 5, ∑_{d∣12} φ(d) = 12, each discharged from the general results above.",
+      "mathContext": "$\\Phi_1 = X-1$, $\\Phi_2 = X+1$, $\\Phi_3 = 1+X+X^2$; $\\deg\\Phi_7 = 6$, $\\Phi_5(1)=5$, $\\sum_{d\\mid 12}\\varphi(d)=12$."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Roots of unity and the factorization of Xⁿ − 1**\n\nThe $n$-th cyclotomic polynomial $\\Phi_n$ is the minimal monic polynomial over $\\mathbb{Q}$ whose roots are exactly the primitive $n$-th roots of unity. Since every $n$-th root of unity is a primitive $d$-th root for a unique divisor $d \\mid n$, the polynomial $X^n - 1$ factors as $\\prod_{d \\mid n} \\Phi_d$. Gauss studied these polynomials in the *Disquisitiones Arithmeticae* (1801) in connection with the constructibility of regular polygons, and the degree relation $\\deg \\Phi_n = \\varphi(n)$ makes them the algebraic embodiment of Euler's totient. Comparing degrees on the two sides of $X^n - 1 = \\prod_{d\\mid n}\\Phi_d$ immediately yields Gauss's totient-divisor-sum identity $\\sum_{d\\mid n}\\varphi(d) = n$. Mathlib develops the cyclotomic polynomials in `RingTheory/Polynomial/Cyclotomic`, but the gallery had used them only as machinery inside Galois-theory and angle-trisection arguments; this entry gathers their basic structure into a subject in its own right.",
+    "problemStatement": "**Structural facts of the cyclotomic polynomials**\n\nAssemble and machine-check, over general (commutative / nontrivial) rings where possible, the fundamental facts:\n$$\\deg \\Phi_n = \\varphi(n), \\qquad \\Phi_p = \\sum_{i<p} X^i,\\qquad \\Phi_p(1) = p,\\qquad \\prod_{d\\mid n}\\Phi_d = X^n - 1,$$\nand derive Gauss's identity $\\sum_{d\\mid n}\\varphi(d) = n$ from the last of these by a degree count, with 0 axioms and 0 sorries.",
+    "keyInsights": [
+      "The degree of a cyclotomic polynomial is Euler's totient: $\\deg \\Phi_n = \\varphi(n)$. This single fact links the polynomial's shape to elementary number theory.",
+      "Prime cyclotomics are the simplest: $\\Phi_p = 1 + X + \\dots + X^{p-1}$ is a geometric sum, so $\\deg \\Phi_p = p-1$ and $\\Phi_p(1) = p$.",
+      "The divisor factorization $\\prod_{d\\mid n}\\Phi_d = X^n - 1$ carries all the arithmetic: taking degrees turns it into Gauss's $\\sum_{d\\mid n}\\varphi(d) = n$, since the product degree is the sum of factor degrees (each $\\Phi_d \\neq 0$ over the domain $\\mathbb{Z}$) and $X^n-1$ has degree $n$."
+    ]
+  },
+  "conclusion": {
+    "summary": "This entry collects the core structural facts of the cyclotomic polynomials — $\\deg \\Phi_n = \\varphi(n)$, the prime geometric-sum form $\\Phi_p = \\sum_{i<p}X^i$ with $\\Phi_p(1)=p$, and the divisor product $\\prod_{d\\mid n}\\Phi_d = X^n - 1$ — and derives Gauss's totient-divisor-sum identity $\\sum_{d\\mid n}\\varphi(d) = n$ by a single degree count over $\\mathbb{Z}$. Everything is machine-checked with 0 axioms and 0 sorries, and grounded in explicit witnesses $\\Phi_1,\\Phi_2,\\Phi_3$ and sample computations.",
+    "implications": [
+      "Establishes a standalone cyclotomic-polynomials topic in the gallery, reusable by Galois-theory, roots-of-unity, and constructibility entries that previously invoked cyclotomics only as unnamed machinery.",
+      "Exhibits Gauss's $\\sum_{d\\mid n}\\varphi(d) = n$ as a degree shadow of the factorization $X^n-1 = \\prod_{d\\mid n}\\Phi_d$, an algebraic route complementing the usual counting proof."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "venue": "Leipzig",
+      "note": "Introduces the cyclotomic polynomials in the study of the constructibility of regular polygons; the divisor factorization of Xⁿ − 1 and the totient-divisor-sum identity ∑_{d∣n} φ(d) = n originate here."
+    },
+    {
+      "authors": "Ireland, Kenneth; Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer GTM 84",
+      "note": "Standard treatment of cyclotomic polynomials, deg Φ_n = φ(n), and the factorization ∏_{d∣n} Φ_d = Xⁿ − 1."
+    }
+  ]
+}


### PR DESCRIPTION
## Fix

Creates the missing gallery entry (`meta.json` + `annotations.json`) for `cyclotomic-polynomials-oq-01`, whose verified Lean proof was already on `main` but had no `src/data/proofs/` directory — so the proof rendered nowhere in the gallery.

## Evidence

**Before**: `proofs/Proofs/CyclotomicPolynomialsOQ01.lean` (merged via #27046 — verified, 0-axiom, 0-sorry, 10 theorems / 121 lines) was referenced by no `meta.json`, and `src/data/proofs/cyclotomic-polynomials-oq-01/` did not exist. The topic had zero gallery presence (`cyclotomic` was previously used only as machinery inside Galois/trisection proofs).

**After**: New gallery entry added:
- `status: verified`, `badge: verified`, `axiomCount: 0`, `sorries: 0`, `lineCount: 121`, `theoremCount: 10`
- 5 sections (degree, prime-form, divisor-product, Gauss identity, witnesses)
- 6 annotations, overview, conclusion, references
- Content: deg Φ_n = φ(n); Φ_p = ∑_{i<p} Xⁱ, Φ_p(1) = p; ∏_{d∣n} Φ_d = Xⁿ−1; and Gauss's ∑_{d∣n} φ(d) = n derived by a degree count.

JSON validated; schema modeled on the merged `centered-hexagonal-sum-oq-01` entry. Lean source unchanged.

---
Automated fix by lean-mechanic agent.