### PR TITLE
Enrich Erdős #823 OQ-05: openQuestions + cross-references

### DIFF
--- a/src/data/proofs/erdos-823-oq-05/meta.json
+++ b/src/data/proofs/erdos-823-oq-05/meta.json
@@ -94,11 +94,26 @@
       "targetId": "erdos-823",
       "relationship": "extends",
       "description": "The parent formalizes Pollack's theorem and illustrates it with σ-values computed by native_decide (hence depending on Lean.ofReduceBool). This entry reproves those values symbolically and axiom-free, and documents that the parent's sigma_206_210 (σ206=σ210) is false."
+    },
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "related",
+      "description": "Perfect numbers are exactly the fixed points σ(n)=2n; the same multiplicativity-and-prime-values evaluation of σ used here underlies that theorem."
+    },
+    {
+      "targetId": "sum-of-divisors-oq-03",
+      "relationship": "related",
+      "description": "Robin's inequality is a deep growth statement about the same σ function whose concrete values this entry certifies axiom-free."
     }
   ],
   "conclusion": {
     "summary": "The concrete sum-of-divisors values behind Erdős #823 — σ(14)=σ(15)=24, σ(957)=σ(958)=1440, σ(6)=12, σ(28)=56 — are reproved symbolically from σ's multiplicativity and its value on primes, replacing the parent's native_decide computations with kernel-checked, genuinely axiom-free proofs (#print axioms shows only propext/Classical.choice/Quot.sound).",
-    "implications": "Beyond removing an axiom dependency, the entry gives a reusable recipe for evaluating any multiplicative arithmetic function at an explicit integer from its factorization, and it underscores a methodological point: native_decide can silently certify even false statements (the parent's σ206=σ210), whereas symbolic proof cannot. The verified σ-pairs are the elementary base of the value-collision phenomenon Pollack's theorem generalizes."
+    "implications": "Beyond removing an axiom dependency, the entry gives a reusable recipe for evaluating any multiplicative arithmetic function at an explicit integer from its factorization, and it underscores a methodological point: native_decide can silently certify even false statements (the parent's σ206=σ210), whereas symbolic proof cannot. The verified σ-pairs are the elementary base of the value-collision phenomenon Pollack's theorem generalizes.",
+    "openQuestions": [
+      "Can the symbolic multiplicative-evaluation recipe be packaged as a general Lean tactic/procedure that evaluates any multiplicative arithmetic function (σ, τ, φ, …) at an explicit integer from its factorization, replacing native_decide throughout the gallery?",
+      "How many other gallery entries certify concrete arithmetic-function values via native_decide (and thus depend on Lean.ofReduceBool), and could they be systematically de-axiomatized the same way?",
+      "Can the σ(m)=σ(m+1) value-collision phenomenon underlying Pollack's theorem be pushed from these verified base cases toward a formalized infinitude statement, or is that genuinely beyond current Mathlib?"
+    ]
   },
   "leanFile": {
     "imports": [


### PR DESCRIPTION
Enrichment pass for `erdos-823-oq-05` ("σ Values from Mathlib, Axiom-Free"; quality 91, pass 0).

Annotations already carry full depth fields. Two gaps addressed:

- `conclusion.openQuestions` was empty → added 3 (a general multiplicative-function evaluation tactic to replace native_decide, a systematic audit/de-axiomatization of native_decide value certifications across the gallery, and formalizing the σ(m)=σ(m+1) collision infinitude behind Pollack's theorem)
- `crossReferences` had only the parent → added `perfect-numbers` (σ(n)=2n fixed points) and `sum-of-divisors-oq-03` (Robin's inequality), both σ-based

meta.json stays well under the size cap. No annotations or Lean source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)