### PR TITLE
research(erdos-695): complete Aristotle supporting lemmas + repair Mathlib v4.26.0 bitrot

### DIFF
--- a/proofs/Proofs/Erdos695Aristotle.lean
+++ b/proofs/Proofs/Erdos695Aristotle.lean
@@ -41,7 +41,7 @@ lemma primeChain_next_gt (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) : p (i
 /-- p(i+1) ≥ p(i) + 1 in a prime chain (StrictMono) -/
 lemma primeChain_next_ge_double (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) :
     p (i + 1) ≥ p i + 1 := by
-  have := h.1 (Nat.lt_succ_self i)
+  have := h.1 (show i < i + 1 by omega)
   omega
 
 /-
@@ -53,26 +53,65 @@ def ChainDivisibility (p : ℕ → ℕ) : Prop :=
 
 /-- If p(i+1) % p(i) = 1 then p(i) | p(i+1) - 1 -/
 lemma mod_one_implies_dvd (p q : ℕ) (h : q % p = 1) (hq : q ≥ 1) : p ∣ q - 1 := by
-  refine ⟨q / p, ?_⟩
-  have h1 : q / p * p + 1 = q := by
-    have := Nat.div_add_mod q p; omega
-  have h2 : q / p * p = p * (q / p) := mul_comm _ _
-  omega
+  -- Keep the nonlinear product `p * (q / p)` as a single atom so `omega` stays linear.
+  have hdm : p * (q / p) + q % p = q := Nat.div_add_mod q p
+  rw [h] at hdm
+  exact ⟨q / p, by omega⟩
 
 /-- Chain congruence implies divisibility -/
 lemma chain_cong_to_dvd (p : ℕ → ℕ) (hprime : ∀ i, (p i).Prime)
     (hcong : ∀ i, p (i + 1) % p i = 1) : ChainDivisibility p := fun i =>
-  mod_one_implies_dvd _ _ (hcong i) (hprime (i + 1)).pos.le
+  mod_one_implies_dvd _ _ (hcong i) (hprime (i + 1)).pos
 
 /-
   ## Section 3: Real.rpow Helpers for Growth Rate
 -/
 
-/-- p^(1/k) → ∞ iff p grows super-exponentially -/
+/-- p^(1/k) → ∞ iff p grows super-exponentially.
+    Both directions use the rpow identity ((p k)^(1/k))^k = p k for k ≥ 1. -/
 lemma rpow_tendsto_atTop_iff (p : ℕ → ℕ) :
     Filter.Tendsto (fun k => (p k : ℝ) ^ (1 / (k : ℝ))) Filter.atTop Filter.atTop ↔
     ∀ c : ℝ, c > 1 → ∀ᶠ k in Filter.atTop, (p k : ℝ) > c ^ k := by
-  sorry
+  -- Helper: ((p k)^{1/k})^k = p k for k ≥ 1 (rpow identity)
+  have rpow_inv_pow (x : ℝ) (hx : 0 ≤ x) (k : ℕ) (hk : k ≠ 0) :
+      (x ^ ((1 : ℝ) / (k : ℝ))) ^ k = x := by
+    rw [← Real.rpow_natCast (x ^ _) k, ← Real.rpow_mul hx,
+        one_div, inv_mul_cancel₀ (Nat.cast_ne_zero.mpr hk), Real.rpow_one]
+  constructor
+  · -- (→) tendsto to ∞ implies p k > c^k eventually, for each c > 1
+    intro htend c hc
+    rw [Filter.tendsto_atTop_atTop] at htend
+    obtain ⟨k₀, hk₀⟩ := htend (c + 1)
+    rw [Filter.eventually_atTop]
+    refine ⟨max k₀ 1, fun k hk => ?_⟩
+    have hkne : k ≠ 0 := by omega
+    have hpk_pos : (0 : ℝ) ≤ (p k : ℝ) := Nat.cast_nonneg _
+    have hc0 : (0 : ℝ) ≤ c := le_of_lt (lt_trans one_pos hc)
+    -- (p k)^(1/k) ≥ c + 1 > c
+    have hkth : c < (p k : ℝ) ^ (1 / (k : ℝ)) := by
+      have := hk₀ k (by omega : k₀ ≤ k); linarith
+    calc (c : ℝ) ^ k < ((p k : ℝ) ^ (1 / (k : ℝ))) ^ k :=
+          pow_lt_pow_left₀ hkth hc0 hkne
+      _ = (p k : ℝ) := rpow_inv_pow _ hpk_pos k hkne
+  · -- (←) p k > c^k eventually (each c > 1) implies kthRoot tends to ∞
+    intro h
+    rw [Filter.tendsto_atTop_atTop]
+    intro b
+    have hc2 : (max b 2 : ℝ) > 1 := lt_of_lt_of_le (by norm_num) (le_max_right _ _)
+    obtain ⟨k₀, hk₀⟩ := Filter.eventually_atTop.mp (h (max b 2) hc2)
+    refine ⟨max k₀ 1, fun k hk => ?_⟩
+    have hkne : (k : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+    have hgt := hk₀ k (by omega)
+    calc (p k : ℝ) ^ ((1 : ℝ) / (k : ℝ))
+        ≥ ((max b 2 : ℝ) ^ (k : ℕ)) ^ ((1 : ℝ) / (k : ℝ)) := by
+          apply Real.rpow_le_rpow (by positivity) (le_of_lt hgt)
+          positivity
+      _ = max b 2 := by
+          rw [← Real.rpow_natCast (max b 2 : ℝ) k,
+              ← Real.rpow_mul (by positivity : (0 : ℝ) ≤ max b 2),
+              show (↑k : ℝ) * ((1 : ℝ) / (k : ℝ)) = 1 from mul_one_div_cancel hkne,
+              Real.rpow_one]
+      _ ≥ b := le_max_left _ _
 
 /-- For c > 1, c^k → ∞ -/
 lemma pow_tendsto_atTop (c : ℝ) (hc : c > 1) :
@@ -100,9 +139,18 @@ lemma rpow_ge_two_of_exp_bound (p : ℕ → ℕ) (k : ℕ) (hk : k ≥ 1)
   ## Section 4: Dirichlet Consequence
 -/
 
-/-- For any prime p, there exists a prime q with q ≡ 1 (mod p) -/
+/-- For any prime p, there exists a prime q with q ≡ 1 (mod p).
+    This is a consequence of Dirichlet's theorem: since gcd(1, p) = 1, there are
+    infinitely many primes q ≡ 1 (mod p). We extract one via
+    `Nat.forall_exists_prime_gt_and_modEq`. -/
 lemma prime_cong_one_exists (p : ℕ) (hp : p.Prime) : ∃ q : ℕ, q.Prime ∧ q % p = 1 := by
-  sorry
+  have hcop : Nat.Coprime 1 p := Nat.coprime_one_left p
+  -- `forall_exists_prime_gt_and_modEq 0 hp.ne_zero hcop : ∃ q > 0, q.Prime ∧ q ≡ 1 [MOD p]`
+  obtain ⟨q, -, hq_prime, hq_mod⟩ := Nat.forall_exists_prime_gt_and_modEq 0 hp.ne_zero hcop
+  refine ⟨q, hq_prime, ?_⟩
+  -- `Nat.ModEq p q 1` is defeq to `q % p = 1 % p`; reduce `1 % p` using `p > 1`
+  have hmod : q % p = 1 % p := hq_mod
+  rwa [Nat.mod_eq_of_lt hp.one_lt] at hmod
 
 /-- Any prime q ≡ 1 (mod p) satisfies q > p -/
 lemma smallest_cong_prime_gt (p : ℕ) (hp : p.Prime) (q : ℕ) (hq : q.Prime)
@@ -111,9 +159,11 @@ lemma smallest_cong_prime_gt (p : ℕ) (hp : p.Prime) (q : ℕ) (hq : q.Prime)
   · -- q < p → q % p = q → q = 1, not prime
     rw [Nat.mod_eq_of_lt hlt] at hmod
     exact absurd hmod hq.one_lt.ne'
-  · -- q ≥ p: need q ≠ p
-    rcases Nat.eq_or_gt_of_le hge with rfl | hgt
-    · simp [Nat.mod_self] at hmod
+  · -- q ≥ p: rule out q = p, so q > p
+    rcases eq_or_lt_of_le hge with heq | hgt
+    · -- heq : p = q, then q % p = p % p = 0 ≠ 1
+      rw [← heq, Nat.mod_self] at hmod
+      exact absurd hmod (by decide)
     · exact hgt
 
 end Erdos695.Aristotle

--- a/proofs/Proofs/Erdos695Problem.lean
+++ b/proofs/Proofs/Erdos695Problem.lean
@@ -49,11 +49,17 @@ theorem chain_equiv (p : ℕ → ℕ) (hp : ∀ i, (p i).Prime) :
     (∀ i, p (i + 1) % p i = 1) ↔ ChainDivisibility p := by
   constructor
   · intro h i
-    have := h i
-    exact Nat.dvd_sub' (Nat.dvd_of_mod_eq_zero (by omega)) (Nat.dvd_refl _)
+    -- p(i+1) % p i = 1 ⟹ p i ∣ p(i+1) - 1; keep `p i * (p(i+1)/p i)` as one atom for omega
+    have hdm : p i * (p (i + 1) / p i) + p (i + 1) % p i = p (i + 1) := Nat.div_add_mod _ _
+    rw [h i] at hdm
+    exact ⟨p (i + 1) / p i, by omega⟩
   · intro h i
-    have := h i
-    omega
+    -- p i ∣ p(i+1) - 1 ⟹ p(i+1) = 1 + p i * c ⟹ p(i+1) % p i = 1
+    obtain ⟨c, hc⟩ := h i
+    have hpi : 1 < p i := (hp i).one_lt
+    have hpi1 : 1 ≤ p (i + 1) := (hp (i + 1)).pos
+    have heq : p (i + 1) = 1 + p i * c := by omega
+    rw [heq, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hpi]
 
 /-
 # Part 2: Growth Questions
@@ -102,7 +108,7 @@ theorem question1_equiv :
     have hkth : c < kthRoot p k := by linarith [hk₀ k (by omega : k₀ ≤ k)]
     -- c^k < (kthRoot p k)^k = p k
     calc (c : ℝ) ^ k < (kthRoot p k) ^ k :=
-          pow_lt_pow_left hkth (le_of_lt hc) hkne
+          pow_lt_pow_left₀ hkth (le_of_lt hc) hkne
       _ = (p k : ℝ) := by
           exact rpow_inv_pow _ hpk_pos k hkne
   · -- (←) p_k > c^k eventually implies kthRoot tends to ∞
@@ -162,10 +168,11 @@ Prime chains connect to OEIS A061092 and Cunningham chains.
 noncomputable def smallestPrimeCongruentOne (p : ℕ) (hp : p.Prime) : ℕ :=
   Nat.find (show ∃ q, q.Prime ∧ q % p = 1 from by
     have hcop : Nat.Coprime 1 p := Nat.coprime_one_left p
-    obtain ⟨q, hq_prime, -, hq_mod⟩ := Nat.forall_exists_prime_gt_and_modEq hp.ne_zero hcop 0
+    obtain ⟨q, -, hq_prime, hq_mod⟩ := Nat.forall_exists_prime_gt_and_modEq 0 hp.ne_zero hcop
     refine ⟨q, hq_prime, ?_⟩
-    have := hq_mod  -- q ≡ 1 [MOD p] i.e. q % p = 1 % p
-    rwa [Nat.mod_eq_of_lt hp.one_lt] at this)
+    -- `Nat.ModEq p q 1` is defeq to `q % p = 1 % p`; reduce `1 % p` via `p > 1`
+    have hmod : q % p = 1 % p := hq_mod
+    rwa [Nat.mod_eq_of_lt hp.one_lt] at hmod)
 
 -- Cunningham chain of the first kind: p, 2p+1, 4p+3, ...
 def IsCunninghamChainFirst (p : ℕ → ℕ) : Prop :=
@@ -196,20 +203,24 @@ This gives exponential growth: p(k) ≥ 2^k for any prime chain.
     q = p₀ + 1 is even and ≥ 4 (not prime since p₀ is odd). So k ≥ 2. -/
 theorem chain_step_ge {p₀ q : ℕ} (hp₀ : p₀.Prime) (hq : q.Prime)
     (hp₀3 : 3 ≤ p₀) (hmod : q % p₀ = 1) : 2 * p₀ + 1 ≤ q := by
-  suffices 2 ≤ q / p₀ by
-    have := Nat.div_mul_le_self q p₀
+  suffices h2 : 2 ≤ q / p₀ by
+    have hdm := Nat.div_add_mod q p₀            -- p₀ * (q/p₀) + q % p₀ = q
+    rw [hmod] at hdm                            -- p₀ * (q/p₀) + 1 = q
+    have hm2 : p₀ * 2 ≤ p₀ * (q / p₀) := Nat.mul_le_mul (le_refl p₀) h2
     omega
   by_contra hlt
   push_neg at hlt
   have hlt1 : q / p₀ ≤ 1 := by omega
-  rcases Nat.le_one_iff_eq_zero_or_eq_one.mp hlt1 with rfl | rfl
+  rcases Nat.le_one_iff_eq_zero_or_eq_one.mp hlt1 with h0 | h1
   · -- k = 0: q = 0·p₀ + 1 = 1, not prime
-    have : q < p₀ := Nat.div_eq_zero_iff hp₀.pos |>.mp rfl
-    have : q = 1 := by omega
-    subst this; exact absurd hq (by decide)
+    have hdm := Nat.div_add_mod q p₀            -- p₀ * (q/p₀) + q % p₀ = q
+    rw [h0, hmod] at hdm                        -- p₀ * 0 + 1 = q
+    have hq1 : q = 1 := by omega
+    rw [hq1] at hq; exact absurd hq (by decide)
   · -- k = 1: q = p₀ + 1, which is even (p₀ odd) and ≥ 4, not prime
     have hqeq : q = p₀ + 1 := by
-      have := Nat.div_add_mod q p₀; omega
+      have hdm := Nat.div_add_mod q p₀          -- p₀ * (q/p₀) + q % p₀ = q
+      rw [h1, hmod] at hdm; omega
     subst hqeq
     have hdvd : 2 ∣ (p₀ + 1) := by
       obtain ⟨k, rfl⟩ := hp₀.odd_of_ne_two (by omega)
@@ -226,7 +237,7 @@ theorem exponential_lower_bound : ∃ c : ℝ, c > 1 ∧
     intro k
     induction k with
     | zero => exact (hp 0).two_le
-    | succ n ih => exact Nat.succ_le_of_lt (lt_of_le_of_lt ih (hm (Nat.lt.base n)))
+    | succ n ih => exact Nat.succ_le_of_lt (lt_of_le_of_lt ih (hm (Nat.lt_add_one n)))
   -- Main: p(k) ≥ 2^k (in ℕ, then cast to ℝ)
   suffices hnat : ∀ k, 2 ^ k ≤ p k from
     fun k => by exact_mod_cast hnat k
@@ -277,16 +288,12 @@ The following are the precise formal statements.
 -/
 
 -- Part 1: Does the k-th root tend to infinity?
+-- `Question1` says exactly this for every prime chain, so the two are definitionally equal
+-- (note `→` binds tighter than `↔`, so the quantified statement needs explicit parentheses).
 theorem erdos_695_main :
-    ∀ p : ℕ → ℕ, IsPrimeChain p →
-      Tendsto (fun k => (p k : ℝ) ^ (1 / k : ℝ)) atTop atTop ↔
-      Question1 := by
-  intro p hp
-  simp only [Question1]
-  constructor <;> intro h
-  · intro q hq
-    exact h
-  · exact h p hp
+    (∀ p : ℕ → ℕ, IsPrimeChain p →
+      Tendsto (fun k => (p k : ℝ) ^ (1 / k : ℝ)) atTop atTop) ↔
+      Question1 := Iff.rfl
 
 -- Part 2: Does there exist a chain with the bound?
 theorem erdos_695_variant :

--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -66,8 +66,8 @@
       "Asymptotic notation (big-O, little-o)",
       "Lean 4 / Mathlib (Filter.Tendsto, Asymptotics.IsLittleO, Nat.Prime)"
     ],
-    "lineCount": 299,
-    "assumptions": "1 axiom: small_prime_conjecture (conjectured). 1 sorry: conjecture_implies_question2. Proved question1_equiv (rpow/tendsto equivalence) and fixed smallestPrimeCongruentOne (Dirichlet's theorem from Mathlib).",
+    "lineCount": 306,
+    "assumptions": "1 axiom: small_prime_conjecture (conjectured polynomial bound on the least prime ≡ 1 mod p). 1 sorry: conjecture_implies_question2 (the hard asymptotic chain construction). All other results are fully machine-checked, including chain_equiv, question1_equiv (rpow/tendsto growth equivalence), chain_step_ge and exponential_lower_bound (p_k ≥ 2^k), and the Dirichlet-based smallestPrimeCongruentOne. The companion Erdos695Aristotle.lean is now sorry-free (prime_cong_one_exists and rpow_tendsto_atTop_iff proved). Both files updated for Mathlib v4.26.0 API (pow_lt_pow_left₀, forall_exists_prime_gt_and_modEq new signature, etc.).",
     "theoremCount": 8,
     "definitionCount": 10
   },
@@ -184,7 +184,7 @@
       "Real"
     ],
     "namespace": "Erdos695",
-    "lineCount": 299,
+    "lineCount": 306,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 10,


### PR DESCRIPTION
## Erdős Problem #695 — Prime Chain Growth (`erdos-695-incomplete-01`)

Completes the two supporting sorries in `Erdos695Aristotle.lean` **and** repairs
Mathlib-API bitrot that had left the whole entry uncompilable against the pinned
Mathlib `v4.26.0`. Verified with `lake env lean` against the pinned Mathlib cache
(both files `RC=0`; the only remaining warning is the single intentional `sorry` in
`conjecture_implies_question2`).

### Completed proofs (`Erdos695Aristotle.lean`, 2 sorries → 0)
- **`prime_cong_one_exists`** — for any prime `p`, there is a prime `q ≡ 1 (mod p)`
  (Dirichlet, via `Nat.forall_exists_prime_gt_and_modEq`).
- **`rpow_tendsto_atTop_iff`** — `p_k^{1/k} → ∞` iff `p` grows super-exponentially
  (`∀ c>1, eventually p_k > c^k`), via the `((p_k)^{1/k})^k = p_k` rpow identity.

The companion file is now **sorry-free and axiom-free**.

### Bitrot repair (both files, Mathlib v4.26.0)
- `pow_lt_pow_left` → `pow_lt_pow_left₀`
- `Nat.forall_exists_prime_gt_and_modEq` — new signature `(n) (hq) (coprime)`
- `Nat.dvd_sub'` removed → direct `Nat.div_add_mod` proof of `chain_equiv` (both directions)
- `Nat.eq_or_gt_of_le` → `eq_or_lt_of_le`; `Nat.lt.base` → `Nat.lt_add_one`
- `chain_step_ge`: fixed nonlinear-`omega` atom splits (keep `p₀ * (q/p₀)` as one atom)
  and `rcases … with rfl | rfl` on non-variables
- `Nat.Prime.pos.le` (`0 ≤`) → `.pos` (`≥ 1`)
- **`erdos_695_main`**: fixed a `→`/`↔` precedence bug that made the statement false as
  parsed; restated as the clean, true `(∀ chain, Tendsto …) ↔ Question1` (`Iff.rfl`)

### Status (unchanged, per axiom-integrity policy)
`Erdos695Problem.lean` retains its **1 axiom** (`small_prime_conjecture`, a genuine open
conjecture) and **1 sorry** (`conjecture_implies_question2`, the hard asymptotic chain
construction). Entry stays `axiomatized` / badge `axiom`. `meta.json` `lineCount` and
`assumptions` refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)