### PR TITLE
Enrich Collatz Structured OQ-02-OQ-03: fix stale ranges + full-file coverage (4→13 annotations)

### DIFF
--- a/src/data/proofs/collatz-structured-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/annotations.json
@@ -2,89 +2,157 @@
   {
     "id": "collatz-two-mul",
     "proofId": "collatz-structured-oq-02-oq-03",
-    "range": {
-      "startLine": 68,
-      "endLine": 70
-    },
+    "range": { "startLine": 84, "endLine": 88 },
     "type": "insight",
     "title": "The Single Dynamical Fact: collatz(2m) = m",
     "content": "Because 2m is even, one Collatz step halves it: collatz (2*m) = (2*m)/2 = m. This one identity is the engine behind the dyadic collapse. Iterating it, a power of two is peeled one factor of 2 at a time until nothing but 1 remains, which is why collatz^[k] (2^k) = 1 falls out of a clean induction.",
-    "mathContext": "$$\\mathrm{collatz}(2m) = m.$$",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "Collatz map",
-      "even step",
-      "Nat.mul_mod_right"
-    ],
-    "prerequisites": [
-      "n / 2 for even n",
-      "Nat.mul_div_cancel_left"
-    ]
+    "mathContext": "$T(2m) = m$ since $2m$ is even and $T(n) = n/2$ there. Iterating peels one factor of two per step.",
+    "significance": "key",
+    "relatedConcepts": ["Collatz map", "even step", "dyadic collapse"],
+    "prerequisites": ["Collatz function definition", "Nat division"]
   },
   {
-    "id": "even-attains-below",
+    "id": "attains-below-def",
     "proofId": "collatz-structured-oq-02-oq-03",
-    "range": {
-      "startLine": 82,
-      "endLine": 86
-    },
-    "type": "insight",
-    "title": "Half of All Starting Values Drop Immediately",
-    "content": "For any positive even n, a single Collatz step sends n to n/2 < n. So the entire arithmetic progression of even numbers — natural density 1/2 — satisfies the 'attains a value below itself' conclusion with no analysis whatsoever. The almost-all phenomenon is only interesting on the odd numbers; the even half is elementary.",
-    "mathContext": "$$n \\text{ even}, n \\ge 1 \\;\\Rightarrow\\; \\mathrm{collatz}(n) = n/2 < n.$$",
+    "range": { "startLine": 112, "endLine": 121 },
+    "type": "definition",
+    "title": "AttainsBelow and the Even Half of ℕ",
+    "content": "AttainsBelow n := ∃ k > 0, collatz^[k] n < n is the elementary conclusion of Tao's almost-all theorem: the orbit eventually dips below its start. even_attainsBelow proves it instantly for every positive even n (one step sends n ↦ n/2 < n via Nat.div_lt_self). So the entire even progression — natural density 1/2 — satisfies the drop-below property with no analysis; the almost-all phenomenon is only interesting on the odds.",
+    "mathContext": "$\\mathrm{AttainsBelow}(n) :\\Leftrightarrow \\exists k>0,\\ T^{[k]}(n) < n$. For even $n$: $T(n) = n/2 < n$, so density-$\\tfrac12$ of ℕ drops in one step.",
     "significance": "key",
-    "relatedConcepts": [
-      "stopping time",
-      "Nat.div_lt_self",
-      "natural density"
-    ],
-    "prerequisites": [
-      "Collatz map on even inputs"
-    ]
+    "relatedConcepts": ["orbit descent", "natural density", "Nat.div_lt_self"],
+    "prerequisites": ["function iteration", "even/odd cases"]
   },
   {
     "id": "pow-two-collapse",
     "proofId": "collatz-structured-oq-02-oq-03",
-    "range": {
-      "startLine": 90,
-      "endLine": 98
-    },
+    "range": { "startLine": 122, "endLine": 137 },
     "type": "insight",
     "title": "Powers of Two Collapse All the Way to 1",
-    "content": "collatz^[k] (2^k) = 1, by induction on k: the successor step writes 2^(k+1) = 2·2^k, applies collatz(2·m) = m to reach 2^k, and finishes by the inductive hypothesis. Hence every dyadic starting value not only drops below itself but reaches the global minimum 1 — a concrete witness that colMin(2^k) ≤ 1.",
-    "mathContext": "$$\\mathrm{collatz}^{[k]}(2^k) = 1.$$",
+    "content": "collatz^[k] (2^k) = 1, by induction on k: the successor step writes 2^(k+1) = 2·2^k, applies collatz(2·m) = m to reach 2^k, and finishes by the inductive hypothesis. pow_two_attainsBelow then gives the drop for every dyadic start with k ≥ 1. Hence every power of two not only drops below itself but reaches the global minimum 1 — a concrete witness that colMin(2^k) = 1.",
+    "mathContext": "$T^{[k]}(2^k) = 1$ by induction using $T(2m)=m$; so $2^k$ reaches the fixed cycle's minimum and $\\mathrm{colMin}(2^k)=1$.",
     "significance": "key",
-    "relatedConcepts": [
-      "Function.iterate_succ_apply",
-      "pow_succ'",
-      "orbit minimum"
-    ],
-    "prerequisites": [
-      "Function iteration",
-      "induction on ℕ"
-    ]
+    "relatedConcepts": ["dyadic starting values", "induction on exponent", "global minimum 1"],
+    "prerequisites": ["induction", "pow_succ", "collatz_two_mul"]
+  },
+  {
+    "id": "mod-four-one",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": { "startLine": 140, "endLine": 158 },
+    "type": "insight",
+    "title": "First Odd Family: n ≡ 1 (mod 4) Drops in Three Steps",
+    "content": "mod_four_one_attainsBelow handles the first genuinely-odd positive-density family. Writing n = 4m+1, the trajectory is 4m+1 ↦ 12m+4 ↦ 6m+2 ↦ 3m+1 (one 3n+1 step then two halvings), and 3m+1 < 4m+1 once m ≥ 1 (i.e. n ≥ 5). Unlike the evens and powers of two, the first step here is the non-trivial 3n+1 branch, so this adds unconditional content on the odd numbers — the only place the almost-all problem is interesting.",
+    "mathContext": "$4m+1 \\xrightarrow{3n+1} 12m+4 \\xrightarrow{/2} 6m+2 \\xrightarrow{/2} 3m+1 < 4m+1$ for $m \\ge 1$. Leading coefficient $3 < 4$ = modulus.",
+    "significance": "key",
+    "relatedConcepts": ["odd residue class", "trajectory chase", "positive density 1/4"],
+    "prerequisites": ["collatz_odd / collatz_even", "Function.iterate_succ_apply'", "omega"]
+  },
+  {
+    "id": "affine-residue-engine",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": { "startLine": 160, "endLine": 192 },
+    "type": "insight",
+    "title": "The General Residue-Determined Drop",
+    "content": "affine_residue_attainsBelow packages the common shape of every residue-class family: if on n ≡ r (mod M) the k-step iterate is the affine value c·m + d (with n = M·m + r), and the leading coefficient c < M while the constant d < r, then every member drops within k steps. The leading coefficient is always c = 3^a · M / 2^b (a = #odd steps, b = #halvings), so the criterion c < M is exactly 3^a < 2^b — enough halvings to overcome the triplings. Only the class-specific trajectory identity is supplied by the caller; the descent bookkeeping is shared.",
+    "mathContext": "$n \\equiv r \\pmod M$, $T^{[k]}(Mm+r) = cm+d$ with $c<M$, $d<r$ $\\Rightarrow$ $T^{[k]}(n)<n$. Here $c = 3^a M / 2^b$, so $c<M \\Leftrightarrow 3^a < 2^b$.",
+    "significance": "key",
+    "relatedConcepts": ["affine trajectory", "Terras 3^a < 2^b criterion", "residue class", "leading coefficient"],
+    "prerequisites": ["modular arithmetic", "Nat.mul_le_mul", "the drop criterion"]
+  },
+  {
+    "id": "affine-step-lemmas",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": { "startLine": 193, "endLine": 246 },
+    "type": "tactic",
+    "title": "Reusable Affine Step-Composition (Terras Law)",
+    "content": "affine_step_even and affine_step_odd turn the hand-written collatz_odd/collatz_even boilerplate into reusable composition primitives. The trick: keep the leading coefficient c EVEN, so the parity of c·m + d is d mod 2, independent of m. An even step maps (c,d) ↦ (c/2, d/2); an odd step maps (c,d) ↦ (3c, 3d+1). Composing these along a step schedule realizes the Terras affine recurrence collatz^[b] n = (3^a·n + C_v)/2^b, and the window drops when the accumulated c < M.",
+    "mathContext": "Even step: $(c,d) \\mapsto (c/2, d/2)$; odd step: $(c,d) \\mapsto (3c, 3d+1)$. With $c$ even, parity of $cm+d$ is $d \\bmod 2$, uniform in $m$ — the Terras parity vector.",
+    "significance": "supporting",
+    "relatedConcepts": ["Terras parity vector", "affine recurrence", "step composition", "parity independence"],
+    "prerequisites": ["affine functions", "even leading coefficient trick"]
+  },
+  {
+    "id": "residue-families",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": { "startLine": 247, "endLine": 477 },
+    "type": "tactic",
+    "title": "The Residue-Class Families and Their Union",
+    "content": "A cascade of explicit residue classes proven to drop below themselves via trajectory chases: n ≡ 3 (mod 16), n ≡ 11 and 23 (mod 32), and n ≡ 7, 15, 59 (mod 128). Each is a mod_*_attainsBelow theorem whose parity vector satisfies 3^a < 2^b. The even_or_mod_four_one_or_* union theorems then combine them by case analysis into progressively larger covered sets — culminating in even_or_mod_four_one_or_mod_onetwentyeight_attainsBelow, all axiom-free and independent of Tao's deep theorem.",
+    "mathContext": "Covered classes: even, $1\\!\\!\\pmod 4$, $3\\!\\!\\pmod{16}$, $11,23\\!\\!\\pmod{32}$, $7,15,59\\!\\!\\pmod{128}$; unions accumulate the drop-below set by residue case-split.",
+    "significance": "supporting",
+    "relatedConcepts": ["residue coverage", "case analysis", "parity vectors", "unconditional families"],
+    "prerequisites": ["modular arithmetic", "affine_residue_attainsBelow"]
+  },
+  {
+    "id": "density-floor",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": { "startLine": 478, "endLine": 977 },
+    "type": "insight",
+    "title": "A Quantitative Density Floor: 3/4 → 13/16 → …",
+    "content": "The prose 'these families cover three-quarters of the integers' is upgraded to machine-checked counting bounds. attainsBelow_density_lower shows at least 3N−1 of [1,4N] already drop (2N evens as an injective image of [1,2N], plus N−1 members of 1+4ℕ that are ≥5, disjoint by parity), giving lower natural density ≥ 3/4. Sharpened versions adjoin further residue classes: attainsBelow_density_lower_16 reaches 13/16, and the mod-32 / mod-128 variants push the unconditional, axiom-free floor still higher — the concrete floor underneath Tao's density-one theorem.",
+    "mathContext": "$\\#\\{n \\le 4N : \\mathrm{AttainsBelow}(n)\\} \\ge 3N-1$, so lower density $\\ge \\tfrac34$; adjoining $3\\!\\!\\pmod{16}$ gives $\\ge \\tfrac{13}{16}$, etc. Disjointness of the residue families is by parity/residue.",
+    "significance": "key",
+    "relatedConcepts": ["lower natural density", "Finset.card_union_of_disjoint", "injective image count", "density floor under Tao"],
+    "prerequisites": ["Finset cardinality", "disjoint unions", "card_image_of_injective"]
+  },
+  {
+    "id": "colmin",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": { "startLine": 978, "endLine": 1119 },
+    "type": "definition",
+    "title": "The Orbit Minimum colMin and Its Properties",
+    "content": "colMin n = sInf {m | ∃ k, collatz^[k] n = m} is the least value visited by the orbit of n. Key facts: colMin_le_self (k=0 visits n), colMin_pos (positivity propagates), colMin_mem_orbit (the infimum is attained — the value set has a least element in ℕ), and the recursive colMin_eq_min_collatz: colMin n = min n (colMin (collatz n)). attainsBelow_colMin_lt converts every drop-below result into colMin n < n, so all the residue families and the density floor transfer directly to statements about the orbit minimum.",
+    "mathContext": "$\\mathrm{colMin}(n) = \\inf\\{m : \\exists k,\\ T^{[k]}(n)=m\\}$; $\\mathrm{colMin}(n) = \\min(n, \\mathrm{colMin}(T(n)))$ and $\\mathrm{AttainsBelow}(n) \\Rightarrow \\mathrm{colMin}(n) < n$.",
+    "significance": "key",
+    "relatedConcepts": ["orbit minimum", "sInf on ℕ", "well-ordering", "recursive minimum"],
+    "prerequisites": ["infimum of a set of naturals", "Nat.sInf", "orbit value set"]
   },
   {
     "id": "tao-statement",
     "proofId": "collatz-structured-oq-02-oq-03",
-    "range": {
-      "startLine": 138,
-      "endLine": 145
-    },
-    "type": "warning",
+    "range": { "startLine": 1120, "endLine": 1143 },
+    "type": "concept",
     "title": "Tao's Theorem Is Stated, Not Proved (and Why)",
-    "content": "tao_2019 records Tao's 2019 result precisely: for every f → ∞, the orbit-minimum sublevel set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. It is an axiom, not a theorem, because the proof is genuinely analytic — Tao evolves tuned measures on the 3-adics and controls their concentration (a transport estimate) together with a Fourier-analytic input, machinery Mathlib does not yet have. So the answer to OQ-03 is: the STATEMENT formalizes cleanly as a Tendsto predicate, but the PROOF is BLOCKED (>> 1000 lines). Crucially, no other theorem in this file depends on this axiom.",
-    "mathContext": "$$\\forall f \\to \\infty:\\quad \\mathrm{logdens}\\{n : \\mathrm{Col\\_min}(n) < f(n)\\} = 1.$$",
+    "content": "logDensity and HasLogDensityOne set up the notion of logarithmic density one, and tao_2019 records Tao's 2019 result precisely: for every f → ∞, the orbit-minimum sublevel set {n : 0 < n ∧ colMin(n) < f n} has logarithmic density one. It is an axiom, not a theorem, because the proof is genuinely analytic — Tao evolves tuned measures on the 3-adics and controls their concentration — far beyond current Mathlib. This entry is a feasibility anchor: it pins the open question with a machine-checkable statement while proving the elementary drop-below conclusion unconditionally for explicit families.",
+    "mathContext": "$\\mathrm{HasLogDensityOne}(S) :\\Leftrightarrow \\frac{\\sum_{n\\le N,\\,n\\in S} 1/n}{\\sum_{n\\le N} 1/n} \\to 1$. Axiom: $\\forall f \\to \\infty,\\ \\mathrm{HasLogDensityOne}\\{n>0 : \\mathrm{colMin}(n) < f(n)\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["logarithmic density", "Tao 2019", "axiomatized deep theorem", "3-adic concentration"],
+    "prerequisites": ["Filter.Tendsto", "logarithmic density", "why an axiom (proof out of reach)"]
+  },
+  {
+    "id": "terras-leadcoeff",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": { "startLine": 1145, "endLine": 1227 },
+    "type": "insight",
+    "title": "The Terras Leading-Coefficient Law",
+    "content": "leadCoeff folds a parity vector v : List Bool onto the leading coefficient (odd bit triples, even bit halves). leadCoeff_mul is the general multiplicative form: folding from 3^p·2^q with enough powers of two yields 3^(p+#odd)·2^(q−#even). Its specialization leadCoeff_two_pow is the Terras 3^a/2^b law: from modulus M = 2^b whose b halvings are spread through v, the window ends at exactly 3^a with a = #odd steps. The drop criterion c < M becomes literally 3^a < 2^b — enough halvings to beat the triplings.",
+    "mathContext": "$\\mathrm{leadCoeff}(v, 2^{\\#\\mathrm{false}}) = 3^{\\#\\mathrm{true}}$; general form $\\mathrm{leadCoeff}(v, 3^p 2^q) = 3^{p+\\#\\mathrm{true}} 2^{q-\\#\\mathrm{false}}$. Drop $\\Leftrightarrow 3^a < 2^b$.",
     "significance": "key",
-    "relatedConcepts": [
-      "logarithmic density",
-      "3-adic measures",
-      "concentration of measure",
-      "Tendsto"
-    ],
-    "prerequisites": [
-      "Filters and Tendsto",
-      "logarithmic vs natural density"
-    ]
+    "relatedConcepts": ["Terras 3^a/2^b law", "parity vector fold", "list count", "leading coefficient"],
+    "prerequisites": ["List induction", "pow_succ", "List.count"]
+  },
+  {
+    "id": "affine-orbit-engine",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": { "startLine": 1228, "endLine": 1356 },
+    "type": "insight",
+    "title": "The Affine-Orbit Engine and parityVector_attainsBelow",
+    "content": "affStep / affOrbit run the affine (c,d) recurrence along a parity vector, and affOrbit_realize discharges the orbit identity collatz^[k] (c·m+d) = c_k·m + d_k from a step-by-step certificate AffValid — so a new residue family needs only that certificate, no bespoke iterate bookkeeping. affOrbit_fst shows the leading coefficient evolves independently of d (it is the pure leadCoeff fold). parityVector_attainsBelow and terras_attainsBelow package all of this with affine_residue_attainsBelow: a class drops below itself as soon as one exhibits a valid parity-vector certificate with c_k < M and d_k < r. terras_drop_iff gives the clean 3^a < 2^b characterization.",
+    "mathContext": "$\\mathrm{affOrbit}(v)(c,d) = (c_k, d_k)$ realizes $T^{[|v|]}(cm+d) = c_k m + d_k$ given $\\mathrm{AffValid}\\,v\\,c\\,d$; drop $\\Leftrightarrow c_k < M \\wedge d_k < r$.",
+    "significance": "key",
+    "relatedConcepts": ["affine orbit", "AffValid certificate", "parity-vector realization", "Terras engine"],
+    "prerequisites": ["inductive predicates", "affine recurrence", "affine_residue_attainsBelow"]
+  },
+  {
+    "id": "decidable-certificates",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": { "startLine": 1357, "endLine": 1454 },
+    "type": "tactic",
+    "title": "Decidable Certificates: A Residue Family in One `by decide`",
+    "content": "AffValid is Prop-valued, so a certificate normally means a hand-built nested term. affValidB reflects the validity condition into a Bool decision procedure and affValidB_sound transports true back to the Prop. dropCert M r v bundles non-emptiness, Boolean validity, and the two drop inequalities c_k < M, d_k < r into a single Bool. dropCert_attainsBelow then reduces adding a new residue family to one line: dropCert_attainsBelow v (by decide) h — no trajectory chase, no hand-built certificate. Validation examples confirm the engine reproduces the Part II leading coefficients (9 = 3² for mod 16, 27 = 3³ for mod 32).",
+    "mathContext": "$\\mathrm{dropCert}\\,M\\,r\\,v = (0<|v|) \\wedge \\mathrm{affValidB}\\,v\\,M\\,r \\wedge (c_k<M) \\wedge (d_k<r)$, a finite Boolean checked by `decide`; soundness gives AttainsBelow for the class.",
+    "significance": "supporting",
+    "relatedConcepts": ["decidability reflection", "Bool ↔ Prop soundness", "by decide", "one-shot certificate"],
+    "prerequisites": ["DecidablePred", "Bool.and_eq_true", "kernel decide"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `collatz-structured-oq-02-oq-03` (Tao's 2019 almost-all bound feasibility anchor, 1761-line Lean file).

## Problems found
1. **Stale ranges**: the 4 existing annotations were written against an older ~145-line version. The file has since grown to **1761 lines** (imports added at the top pushed everything down, plus large new Parts II.5 and V). Every existing range was misaligned — e.g. `collatz-two-mul` landed on `open Filter`, `tao-statement` landed on `mod_four_one_attainsBelow`.
2. **Severe undercoverage**: 4 annotations covered ~1% of the file.

## Changes (4 → 13 annotations)
- **Remapped** the 4 existing annotations to their correct current constructs.
- **Added 9** covering the previously-uncovered majority:
  - the general affine residue-drop engine (`affine_residue_attainsBelow`, the 3ᵃ < 2ᵇ criterion)
  - Terras affine step-composition lemmas
  - the mod-16/32/128 residue families and their union theorems
  - the quantitative **3/4 → 13/16 → …** density floor
  - the orbit minimum `colMin` and its recursive/lattice properties
  - Tao's **axiomatized** theorem (logarithmic density one) with the why-an-axiom framing
  - the **Terras leading-coefficient law** (`leadCoeff`, `leadCoeff_two_pow`)
  - the affine-orbit engine (`parityVector_attainsBelow`, `AffValid`)
  - the **decidable `dropCert`** one-shot `by decide` certificates
- All 13 have mathContext (LaTeX), significance, relatedConcepts, prerequisites.

## Validation
- `annotations:build`: no errors (ranges non-overlapping, each lands on a Lean construct).
- `gallery:check-size`: within caps.