### PR TITLE
Fix: create missing gallery entry for cyclotomic-polynomials-oq-02

### DIFF
--- a/src/data/proofs/cyclotomic-polynomials-oq-02/annotations.json
+++ b/src/data/proofs/cyclotomic-polynomials-oq-02/annotations.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "cyclotomic-polynomials-oq-02",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "Prime-power cyclotomics and the eval-at-one law",
+    "content": "This companion to OQ-01 focuses on the prime-power case Φ_{p^k} and the value Φ_n(1). It proves the prime-power geometric form Φ_{p^{k+1}} = ∑_{i<p}(X^{p^k})^i, its degree φ(p^{k+1}) = p^k(p−1), and the eval-at-one dichotomy Φ_n(1) ∈ {p, 1}: value p on prime powers, value 1 as soon as n has ≥ 2 distinct prime factors. The dichotomy is the polynomial shadow of the von Mangoldt function: Φ_n(1) = e^{Λ(n)}. Sorry-free and axiom-free.",
+    "mathContext": "$\\Phi_{p^{k+1}} = \\sum_{i<p}(X^{p^k})^i$, $\\deg = p^k(p-1)$; $\\Phi_n(1) \\in \\{p, 1\\}$, i.e. $e^{\\Lambda(n)}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cyclotomic polynomials",
+      "prime powers",
+      "von Mangoldt function",
+      "Euler's totient"
+    ],
+    "prerequisites": [
+      "cyclotomic polynomials (OQ-01)",
+      "prime factorization",
+      "geometric sums"
+    ]
+  },
+  {
+    "id": "ann-prime-power-form",
+    "proofId": "cyclotomic-polynomials-oq-02",
+    "range": { "startLine": 46, "endLine": 51 },
+    "type": "theorem",
+    "title": "Prime-power cyclotomic as a geometric sum",
+    "content": "`cyclotomic_prime_pow_geom_sum` gives Φ_{p^{k+1}} = ∑_{i<p} (X^{p^k})^i for prime p — the p-term geometric sum in the variable X^{p^k}, so its exponents are the multiples 0, p^k, 2p^k, …, (p−1)p^k (Mathlib's `cyclotomic_prime_pow_eq_geom_sum`). This generalizes the prime form Φ_p = ∑_{i<p} Xⁱ from OQ-01 (the k = 0 case).",
+    "mathContext": "$\\Phi_{p^{k+1}} = \\sum_{i<p}(X^{p^k})^i$.",
+    "significance": "key",
+    "relatedConcepts": ["geometric sum", "prime powers", "substitution X ↦ X^{p^k}"],
+    "prerequisites": ["Finset.range sums", "prime form Φ_p"]
+  },
+  {
+    "id": "ann-prime-power-degree",
+    "proofId": "cyclotomic-polynomials-oq-02",
+    "range": { "startLine": 55, "endLine": 58 },
+    "type": "theorem",
+    "title": "Degree p^k(p−1) of the prime-power cyclotomic",
+    "content": "`cyclotomic_prime_pow_natDegree`: deg Φ_{p^{k+1}} = φ(p^{k+1}) = p^k(p−1), obtained by rewriting `natDegree_cyclotomic` (deg Φ_n = φ(n)) with the totient formula `totient_prime_pow_succ`.",
+    "mathContext": "$\\deg \\Phi_{p^{k+1}} = \\varphi(p^{k+1}) = p^k(p-1)$.",
+    "significance": "important",
+    "relatedConcepts": ["polynomial degree", "totient of a prime power"],
+    "prerequisites": ["deg Φ_n = φ(n)", "φ(p^{k+1}) = p^k(p−1)"]
+  },
+  {
+    "id": "ann-eval-one-prime-power",
+    "proofId": "cyclotomic-polynomials-oq-02",
+    "range": { "startLine": 62, "endLine": 65 },
+    "type": "theorem",
+    "title": "Prime powers evaluate to the prime: Φ_{p^{k+1}}(1) = p",
+    "content": "`cyclotomic_prime_pow_eval_one`: evaluating a prime-power cyclotomic at 1 gives the prime p (Mathlib's `eval_one_cyclotomic_prime_pow`). This is the prime-power end of the eval-at-one dichotomy.",
+    "mathContext": "$\\Phi_{p^{k+1}}(1) = p$.",
+    "significance": "important",
+    "relatedConcepts": ["polynomial evaluation", "von Mangoldt value"],
+    "prerequisites": ["prime-power geometric form"]
+  },
+  {
+    "id": "ann-eval-one-composite",
+    "proofId": "cyclotomic-polynomials-oq-02",
+    "range": { "startLine": 69, "endLine": 92 },
+    "type": "theorem",
+    "title": "Value 1 for ≥ 2 distinct prime factors",
+    "content": "`cyclotomic_eval_one_eq_one_of_two_le_primeFactors`: if n has at least two distinct prime factors then Φ_n(1) = 1. It applies `eval_one_cyclotomic_not_prime_pow` and discharges the not-a-prime-power obligation: assuming n = p^k, `primeFactors_prime_pow` shows n has exactly one prime factor, contradicting 2 ≤ card. The private helper `two_le_primeFactors_card` supplies 2 ≤ card n.primeFactors from any two distinct members via `Finset.card_pair`. Together with the prime-power case this closes the dichotomy Φ_n(1) ∈ {p, 1}.",
+    "mathContext": "$2 \\le |\\operatorname{primeFactors}(n)| \\Rightarrow \\Phi_n(1) = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["prime factors", "not a prime power", "Finset cardinality"],
+    "prerequisites": ["eval_one_cyclotomic_not_prime_pow", "primeFactors of a prime power"]
+  },
+  {
+    "id": "ann-witnesses",
+    "proofId": "cyclotomic-polynomials-oq-02",
+    "range": { "startLine": 96, "endLine": 142 },
+    "type": "example",
+    "title": "Concrete witnesses and both ends of the dichotomy",
+    "content": "Explicit cases: Φ₄ = X²+1 and Φ₉ = 1+X³+X⁶ (prime-power geometric form at p=2,3, k=1); degree samples deg Φ₈ = φ(8) = 4 and deg Φ₂₇ = φ(27) = 18; and both ends of the eval-at-one dichotomy — Φ₈(1) = 2 (prime power) versus Φ₁₅(1) = 1 (15 = 3·5) and Φ₆(1) = 1 (6 = 2·3), each two-distinct-prime case dispatched through the helper.",
+    "mathContext": "$\\Phi_4 = X^2+1$, $\\Phi_9 = 1+X^3+X^6$; $\\deg\\Phi_8=4$, $\\deg\\Phi_{27}=18$; $\\Phi_8(1)=2$, $\\Phi_{15}(1)=\\Phi_6(1)=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["low-degree cyclotomics", "worked examples", "prime power vs composite"],
+    "prerequisites": ["the general results above"]
+  }
+]

--- a/src/data/proofs/cyclotomic-polynomials-oq-02/meta.json
+++ b/src/data/proofs/cyclotomic-polynomials-oq-02/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "cyclotomic-polynomials-oq-02",
+  "title": "Prime-Power Cyclotomics and the Eval-at-One Law Φ_n(1) ∈ {p, 1}",
+  "slug": "cyclotomic-polynomials-oq-02",
+  "description": "A self-contained, fully machine-checked companion to the cyclotomic-polynomials topic (OQ-01), zooming in on the prime-power case Φ_{p^k} and the value Φ_n(1). Three results: (1) the prime-power geometric form Φ_{p^{k+1}} = ∑_{i<p} (X^{p^k})^i (the p-term geometric sum in the variable X^{p^k}); (2) its degree deg Φ_{p^{k+1}} = φ(p^{k+1}) = p^k(p−1); and (3) the eval-at-one dichotomy: Φ_{p^{k+1}}(1) = p, whereas Φ_n(1) = 1 as soon as n has at least two distinct prime factors. This dichotomy Φ_n(1) ∈ {p, 1} is the polynomial shadow of the von Mangoldt function — Φ_n(1) = e^{Λ(n)}, equal to the prime p exactly when n is a prime power and 1 otherwise. Concrete witnesses Φ₄ = X²+1, Φ₉ = 1+X³+X⁶ and sample computations (deg Φ₈ = 4, deg Φ₂₇ = 18, Φ₈(1) = 2 vs Φ₁₅(1) = Φ₆(1) = 1) illustrate both ends. Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Classical (von Mangoldt / cyclotomic theory); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cyclotomic_polynomial",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "algebra",
+      "polynomials",
+      "cyclotomic-polynomials",
+      "prime-powers",
+      "von-mangoldt",
+      "euler-totient",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CyclotomicPolynomialsOQ02.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.cyclotomic_prime_pow_eq_geom_sum",
+        "description": "Φ_{p^{k+1}} = ∑_{i<p} (X^{p^k})^i for prime p: the prime-power cyclotomic is a geometric sum in the variable X^{p^k}. Source of the prime-power form.",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic"
+      },
+      {
+        "theorem": "Polynomial.natDegree_cyclotomic",
+        "description": "deg Φ_n = φ(n) over any nontrivial ring; combined with totient_prime_pow_succ to give deg Φ_{p^{k+1}} = p^k(p−1).",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic"
+      },
+      {
+        "theorem": "Nat.totient_prime_pow_succ",
+        "description": "φ(p^{k+1}) = p^k(p−1) for prime p. Converts the cyclotomic degree into a closed form in p and k.",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Polynomial.eval_one_cyclotomic_prime_pow",
+        "description": "Φ_{p^{k+1}}(1) = p for prime p: the prime-power end of the eval-at-one dichotomy.",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Eval"
+      },
+      {
+        "theorem": "Polynomial.eval_one_cyclotomic_not_prime_pow",
+        "description": "Φ_n(1) = 1 when n is not a prime power. Drives the composite end of the dichotomy once ≥2 distinct prime factors are shown to preclude n = p^k.",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Eval"
+      },
+      {
+        "theorem": "Nat.primeFactors_prime_pow",
+        "description": "primeFactors(p^k) = {p} for k ≥ 1, giving card 1 — used to contradict the hypothesis 2 ≤ card primeFactors when assuming n = p^k.",
+        "module": "Mathlib.NumberTheory.Divisors"
+      }
+    ],
+    "originalContributions": [
+      "A gallery entry packaging the prime-power cyclotomic facts — geometric form Φ_{p^{k+1}} = ∑_{i<p}(X^{p^k})^i and degree φ(p^{k+1}) = p^k(p−1) — as a companion to the basic-structure entry OQ-01",
+      "A machine-checked proof of the composite end of the eval-at-one dichotomy: Φ_n(1) = 1 whenever n has at least two distinct prime factors, via `eval_one_cyclotomic_not_prime_pow` together with a `primeFactors`-cardinality argument (a prime power has exactly one prime factor)",
+      "The self-contained helper `two_le_primeFactors_card` witnessing 2 ≤ card n.primeFactors from two distinct members, plus concrete witnesses Φ₄, Φ₉ and both ends of the dichotomy (Φ₈(1) = 2 vs Φ₁₅(1) = Φ₆(1) = 1) exhibiting the von-Mangoldt shadow Φ_n(1) = e^{Λ(n)}"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 144,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. No native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext / Classical.choice / Quot.sound, none of which count as assumptions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "prime-power-form",
+      "title": "The prime-power cyclotomic as a geometric sum",
+      "startLine": 44,
+      "endLine": 51,
+      "summary": "For a prime p, `cyclotomic_prime_pow_geom_sum` gives Φ_{p^{k+1}} = ∑_{i<p} (X^{p^k})^i — the p-term geometric sum in the variable X^{p^k}, with exponents 0, p^k, 2p^k, …, (p−1)p^k (Mathlib's `cyclotomic_prime_pow_eq_geom_sum`).",
+      "mathContext": "$\\Phi_{p^{k+1}} = \\sum_{i<p} (X^{p^k})^i$."
+    },
+    {
+      "id": "prime-power-degree",
+      "title": "Degree of the prime-power cyclotomic",
+      "startLine": 53,
+      "endLine": 58,
+      "summary": "`cyclotomic_prime_pow_natDegree`: deg Φ_{p^{k+1}} = φ(p^{k+1}) = p^k(p−1), by rewriting `natDegree_cyclotomic` with `totient_prime_pow_succ`.",
+      "mathContext": "$\\deg \\Phi_{p^{k+1}} = \\varphi(p^{k+1}) = p^{k}(p-1)$."
+    },
+    {
+      "id": "eval-one-prime-power",
+      "title": "Eval-at-one: prime powers evaluate to the prime",
+      "startLine": 60,
+      "endLine": 65,
+      "summary": "`cyclotomic_prime_pow_eval_one`: Φ_{p^{k+1}}(1) = p (Mathlib's `eval_one_cyclotomic_prime_pow`) — the prime-power end of the dichotomy.",
+      "mathContext": "$\\Phi_{p^{k+1}}(1) = p$."
+    },
+    {
+      "id": "eval-one-composite",
+      "title": "Eval-at-one: value 1 for ≥ 2 distinct prime factors",
+      "startLine": 67,
+      "endLine": 92,
+      "summary": "`cyclotomic_eval_one_eq_one_of_two_le_primeFactors`: if 2 ≤ card n.primeFactors then Φ_n(1) = 1. Uses `eval_one_cyclotomic_not_prime_pow`; assuming n = p^k contradicts the hypothesis since `primeFactors_prime_pow` gives card 1. The helper `two_le_primeFactors_card` builds 2 ≤ card from two distinct prime members.",
+      "mathContext": "$2 \\le |\\{\\text{prime factors of } n\\}| \\Rightarrow \\Phi_n(1) = 1$, completing $\\Phi_n(1) \\in \\{p, 1\\}$."
+    },
+    {
+      "id": "witnesses",
+      "title": "Concrete witnesses and both ends of the dichotomy",
+      "startLine": 94,
+      "endLine": 142,
+      "summary": "Φ₄ = X²+1, Φ₉ = 1+X³+X⁶ (prime-power geometric form); deg Φ₈ = 4, deg Φ₂₇ = 18 (degree); and the dichotomy ends Φ₈(1) = 2 vs Φ₁₅(1) = Φ₆(1) = 1.",
+      "mathContext": "$\\Phi_4 = X^2+1$, $\\Phi_9 = 1+X^3+X^6$; $\\deg\\Phi_8=4$, $\\deg\\Phi_{27}=18$; $\\Phi_8(1)=2$, $\\Phi_{15}(1)=\\Phi_6(1)=1$."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Φ_n(1) and the von Mangoldt function**\n\nThe value of a cyclotomic polynomial at $1$ encodes a clean arithmetic dichotomy. Writing $X^n - 1 = \\prod_{d\\mid n}\\Phi_d(X)$ and differentiating the divisor structure, one finds $\\Phi_n(1) = e^{\\Lambda(n)}$, where $\\Lambda$ is the von Mangoldt function: $\\Phi_n(1) = p$ exactly when $n = p^k$ is a prime power ($k \\ge 1$), and $\\Phi_n(1) = 1$ otherwise. The prime-power cyclotomics themselves have a particularly transparent shape — $\\Phi_{p^{k+1}}$ is just the $p$-term geometric sum $1 + Y + \\dots + Y^{p-1}$ in the variable $Y = X^{p^k}$ — so their degree is $\\varphi(p^{k+1}) = p^k(p-1)$ and their value at $1$ is $p$. This entry, a companion to the basic-structure entry OQ-01, formalizes both ends of the dichotomy.",
+    "problemStatement": "**Prime-power cyclotomics and Φ_n(1)**\n\nMachine-check the prime-power form $\\Phi_{p^{k+1}} = \\sum_{i<p}(X^{p^k})^i$, its degree $p^k(p-1)$, and the eval-at-one dichotomy:\n$$\\Phi_{p^{k+1}}(1) = p, \\qquad \\Phi_n(1) = 1 \\text{ when } n \\text{ has} \\ge 2 \\text{ distinct prime factors},$$\nwith 0 axioms and 0 sorries.",
+    "keyInsights": [
+      "A prime-power cyclotomic is a disguised geometric sum: $\\Phi_{p^{k+1}} = \\sum_{i<p}(X^{p^k})^i$, so its degree is $\\varphi(p^{k+1}) = p^{k}(p-1)$.",
+      "Evaluating at $1$ produces a two-valued invariant: $\\Phi_n(1) = p$ on prime powers and $1$ otherwise — the polynomial shadow of the von Mangoldt function, $\\Phi_n(1) = e^{\\Lambda(n)}$.",
+      "The composite end is a cardinality argument: a prime power has exactly one prime factor, so $2 \\le |\\text{primeFactors}(n)|$ rules out $n = p^k$ and forces $\\Phi_n(1) = 1$."
+    ]
+  },
+  "conclusion": {
+    "summary": "This companion entry establishes the prime-power cyclotomic form $\\Phi_{p^{k+1}} = \\sum_{i<p}(X^{p^k})^i$ with degree $p^k(p-1)$, and both ends of the eval-at-one dichotomy $\\Phi_n(1) \\in \\{p, 1\\}$: value $p$ on prime powers and $1$ on any $n$ with $\\ge 2$ distinct prime factors. All results are machine-checked with 0 axioms and 0 sorries and grounded in explicit witnesses.",
+    "implications": [
+      "Completes the cyclotomic-polynomials topic with the prime-power case and the von-Mangoldt-shadow value $\\Phi_n(1) = e^{\\Lambda(n)}$, complementing the basic-structure entry OQ-01.",
+      "Provides reusable named lemmas for the prime-power geometric form, its degree, and the eval-at-one dichotomy that other number-theory entries can invoke directly."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Ireland, Kenneth; Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer GTM 84",
+      "note": "Cyclotomic polynomials, the prime-power form Φ_{p^k}, and the divisor factorization underlying the eval-at-one behaviour."
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer UTM",
+      "note": "The von Mangoldt function Λ(n) and its relation to prime powers, of which Φ_n(1) = e^{Λ(n)} is the cyclotomic shadow."
+    }
+  ]
+}


### PR DESCRIPTION
## Fix

Creates the missing gallery entry (`meta.json` + `annotations.json`) for `cyclotomic-polynomials-oq-02`, whose verified Lean proof was already on `main` but had no `src/data/proofs/` directory — so the proof rendered nowhere in the gallery.

## Evidence

**Before**: `proofs/Proofs/CyclotomicPolynomialsOQ02.lean` (merged via #27058 — verified, 0-axiom, 0-sorry, 12 theorems / 144 lines) was referenced by no `meta.json`, and `src/data/proofs/cyclotomic-polynomials-oq-02/` did not exist.

**After**: New gallery entry added:
- `status: verified`, `badge: verified`, `axiomCount: 0`, `sorries: 0`, `lineCount: 144`, `theoremCount: 12`
- 5 sections (prime-power form, degree, eval-at-one prime-power, eval-at-one composite, witnesses)
- 6 annotations, overview, conclusion, references
- Content: Φ_{p^{k+1}} = ∑_{i<p}(X^{p^k})^i; deg = p^k(p−1); eval-at-one dichotomy Φ_n(1) ∈ {p, 1} (the von-Mangoldt shadow Φ_n(1) = e^{Λ(n)}).

Companion to `cyclotomic-polynomials-oq-01` (PR #32958). JSON validated; schema modeled on the merged `centered-hexagonal-sum-oq-01` entry. Lean source unchanged.

---
Automated fix by lean-mechanic agent.