### PR TITLE
research(euler-totient-oq-07-oq-01): exact gcd(φm,φn)=2·gcd(φm/2,φn/2) factorisation [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ07OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ07OQ01.lean
@@ -1,0 +1,117 @@
+import Mathlib.Data.Nat.Totient
+import Mathlib.Tactic
+
+/-!
+# The exact shared power of two in `gcd(φ m, φ n)`
+
+**Open Question (`euler-totient-oq-07-oq-01`)**: sharpen the parent lower bound
+`2 ∣ gcd(φ m, φ n)` (for `m, n ≥ 3`) — when is the gcd *exactly* `2`, and when is
+it larger?  The seeker phrased a candidate strengthening:
+
+> is `gcd(φ m, φ n) ≥ 4` unless one of the arguments has totient exactly `2`
+> (i.e. lies in `{3, 4, 6}`)?
+
+This file settles the question.  The clean structural fact is that, once both
+totients are even, **the single factor of `2` splits off exactly**:
+
+  `gcd(φ m, φ n) = 2 · gcd(φ m / 2, φ n / 2)`   for `m, n ≥ 3`.
+
+Everything else is a one-line corollary of this identity together with `omega`:
+
+* the gcd equals `2` **iff** the halves `φ m / 2` and `φ n / 2` are coprime;
+* the gcd is `≥ 4` **iff** the halves share a common factor;
+* dividing the gcd by `2` gives the gcd of the halves on the nose.
+
+Crucially, the identity **refutes the seeker's candidate conjecture.**  Coprimality
+of the *halves* — not "one totient equals `2`" — is what controls equality.  The
+explicit witness `m = 5, n = 7` has `gcd(φ 5, φ 7) = gcd(4, 6) = 2` with **both**
+totients `≥ 4`, so neither argument lies in `{3, 4, 6}`.  The naive strengthening
+is false; the correct dividing line is the coprimality of the halved totients.
+
+The only Mathlib inputs are `Nat.totient_even` (`φ k` is even for `k > 2`) and
+`Nat.gcd_mul_left` (`gcd (k·a) (k·b) = k · gcd a b`).
+
+## Contents
+
+* `gcd_totient_eq_two_mul_gcd_half`    — the exact factorisation `= 2 · gcd(halves)`.
+* `gcd_totient_div_two`                — `gcd(φ m, φ n) / 2 = gcd(φ m / 2, φ n / 2)`.
+* `gcd_totient_eq_two_iff`             — `gcd = 2 ↔` the halves are coprime.
+* `four_le_gcd_totient_iff`            — `gcd ≥ 4 ↔` the halves share a factor.
+* `exists_gcd_two_with_large_totients` — the counterexample refuting the conjecture.
+
+Fully machine-checked: `0` sorries, `0` axioms (the `decide` calls are kernel
+reductions over concrete small naturals, not `native_decide`).
+-/
+
+namespace EulerTotientOQ07OQ01
+
+open Nat
+
+/-- **The exact factorisation.**  For `m, n ≥ 3` both totients are even, so the
+common factor of `2` splits off *cleanly*:
+`gcd(φ m, φ n) = 2 · gcd(φ m / 2, φ n / 2)`.
+
+This is the structural heart of the entry: it reduces every question about the
+shared factor `2` in `gcd(φ m, φ n)` to a question about the *halved* totients,
+where the parity obstruction has been removed. -/
+theorem gcd_totient_eq_two_mul_gcd_half {m n : ℕ} (hm : 3 ≤ m) (hn : 3 ≤ n) :
+    Nat.gcd (φ m) (φ n) = 2 * Nat.gcd (φ m / 2) (φ n / 2) := by
+  have em : 2 ∣ φ m := Even.two_dvd (totient_even (by omega))
+  have en : 2 ∣ φ n := Even.two_dvd (totient_even (by omega))
+  have key : Nat.gcd (φ m) (φ n)
+      = Nat.gcd (2 * (φ m / 2)) (2 * (φ n / 2)) := by
+    rw [Nat.mul_div_cancel' em, Nat.mul_div_cancel' en]
+  rw [key, Nat.gcd_mul_left]
+
+/-- Dividing the gcd of the totients by `2` recovers the gcd of the halves
+exactly (no rounding): `gcd(φ m, φ n) / 2 = gcd(φ m / 2, φ n / 2)`. -/
+theorem gcd_totient_div_two {m n : ℕ} (hm : 3 ≤ m) (hn : 3 ≤ n) :
+    Nat.gcd (φ m) (φ n) / 2 = Nat.gcd (φ m / 2) (φ n / 2) := by
+  rw [gcd_totient_eq_two_mul_gcd_half hm hn]; omega
+
+/-- **Characterisation of equality `gcd = 2`.**  For `m, n ≥ 3`,
+`gcd(φ m, φ n) = 2` holds *iff* the halved totients `φ m / 2` and `φ n / 2` are
+coprime.  This is the correct dividing line for the sharp lower bound — not the
+seeker's "one totient equals `2`" guess. -/
+theorem gcd_totient_eq_two_iff {m n : ℕ} (hm : 3 ≤ m) (hn : 3 ≤ n) :
+    Nat.gcd (φ m) (φ n) = 2 ↔ Nat.gcd (φ m / 2) (φ n / 2) = 1 := by
+  rw [gcd_totient_eq_two_mul_gcd_half hm hn]; omega
+
+/-- **Characterisation of `gcd ≥ 4`.**  For `m, n ≥ 3` the gcd exceeds the
+universal bound `2` (in fact reaches `≥ 4`) *iff* the halved totients share a
+common factor `≥ 2`. -/
+theorem four_le_gcd_totient_iff {m n : ℕ} (hm : 3 ≤ m) (hn : 3 ≤ n) :
+    4 ≤ Nat.gcd (φ m) (φ n) ↔ 2 ≤ Nat.gcd (φ m / 2) (φ n / 2) := by
+  rw [gcd_totient_eq_two_mul_gcd_half hm hn]; omega
+
+/-- **Refutation of the seeker's candidate conjecture.**  One might guess that
+`gcd(φ m, φ n) = 2` forces one of the totients to equal `2` (equivalently
+`m` or `n ∈ {3, 4, 6}`).  This is **false**: the pair `m = 5, n = 7` gives
+`gcd(φ 5, φ 7) = gcd(4, 6) = 2` while *both* totients are `≥ 4`.  What actually
+controls equality is the coprimality of the halves (`4/2 = 2` and `6/2 = 3` are
+coprime), exactly as `gcd_totient_eq_two_iff` predicts. -/
+theorem exists_gcd_two_with_large_totients :
+    ∃ m n : ℕ, 3 ≤ m ∧ 3 ≤ n ∧ Nat.gcd (φ m) (φ n) = 2 ∧ 4 ≤ φ m ∧ 4 ≤ φ n :=
+  ⟨5, 7, by norm_num, by norm_num, by decide, by decide, by decide⟩
+
+/-! ### Worked examples
+
+The factorisation `gcd(φ m, φ n) = 2 · gcd(φ m / 2, φ n / 2)` in action. -/
+
+-- Equality case, small: `φ 3 = φ 4 = 2`, halves `1, 1` coprime ⇒ `gcd = 2`.
+example : Nat.gcd (φ 3) (φ 4) = 2 := by decide
+example : Nat.gcd (φ 3 / 2) (φ 4 / 2) = 1 := by decide
+
+-- The refuting witness: `φ 5 = 4`, `φ 7 = 6`, halves `2, 3` coprime ⇒ `gcd = 2`.
+example : φ 5 = 4 := by decide
+example : φ 7 = 6 := by decide
+example : Nat.gcd (φ 5) (φ 7) = 2 := by decide
+
+-- Larger gcd, `= 4`: `φ 5 = φ 5 = 4`, halves `2, 2` share `2` ⇒ `gcd = 2·2 = 4`.
+example : Nat.gcd (φ 5) (φ 5) = 2 * Nat.gcd (φ 5 / 2) (φ 5 / 2) := by decide
+
+-- Larger gcd, `= 6`: `φ 7 = φ 9 = 6`, halves `3, 3` share `3` ⇒ `gcd = 2·3 = 6`.
+example : Nat.gcd (φ 7) (φ 9) = 6 := by decide
+example : Nat.gcd (φ 7) (φ 9) = 2 * Nat.gcd (φ 7 / 2) (φ 9 / 2) := by decide
+
+end EulerTotientOQ07OQ01

--- a/src/data/proofs/euler-totient-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header-overview",
+    "proofId": "euler-totient-oq-07-oq-01",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "overview",
+    "title": "Goal: Sharpen 2 ≤ gcd(φ m, φ n) into an Exact Factorisation",
+    "content": "The module docstring frames the sharpening. The parent proved only 2 ∣ gcd(φ m, φ n) for m, n ≥ 3. Here the key realisation is that this forced factor of 2 splits off *exactly*: gcd(φ m, φ n) = 2·gcd(φ m/2, φ n/2). Everything else — when the gcd equals 2, when it reaches 4 — becomes a trivial statement about the halved totients. The docstring also flags that the seeker's candidate conjecture (gcd = 2 forces a totient to equal 2) is false, with m = 5, n = 7 as the witness.",
+    "mathContext": "For $m,n\\ge 3$: $\\gcd(\\varphi(m),\\varphi(n)) = 2\\cdot\\gcd(\\varphi(m)/2,\\varphi(n)/2)$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's totient", "gcd", "parity of totient", "2-adic valuation"],
+    "prerequisites": ["Euler's totient function", "parity of φ", "gcd of naturals"]
+  },
+  {
+    "id": "ann-gcd-eq-two-mul-gcd-half",
+    "proofId": "euler-totient-oq-07-oq-01",
+    "range": { "startLine": 57, "endLine": 66 },
+    "type": "theorem",
+    "title": "The Exact Factorisation gcd(φ m, φ n) = 2·gcd(φ m/2, φ n/2)",
+    "content": "The structural heart of the entry. Since φ(m) and φ(n) are both even for m, n ≥ 3 (`Nat.totient_even`), each is rewritten as 2·(its half) via `Nat.mul_div_cancel'`, and the common factor 2 is pulled out of the gcd by `Nat.gcd_mul_left`. The result is an equality, not just the divisibility `2 ∣ gcd` of the parent: the factor of 2 is removed with nothing lost, so the residual gcd is exactly that of the parity-free halves φ(m)/2, φ(n)/2.",
+    "mathContext": "$\\gcd(2a,2b)=2\\gcd(a,b)$ applied with $a=\\varphi(m)/2$, $b=\\varphi(n)/2$.",
+    "significance": "key",
+    "relatedConcepts": ["gcd multiplicativity", "parity of totient", "clean factor extraction"],
+    "prerequisites": ["Nat.totient_even", "Nat.gcd_mul_left", "Nat.mul_div_cancel'"]
+  },
+  {
+    "id": "ann-gcd-div-two",
+    "proofId": "euler-totient-oq-07-oq-01",
+    "range": { "startLine": 68, "endLine": 71 },
+    "type": "theorem",
+    "title": "Halving the gcd Recovers the gcd of the Halves",
+    "content": "A direct consequence of the factorisation: gcd(φ m, φ n) / 2 = gcd(φ m/2, φ n/2). Because the factorisation writes the gcd as 2·G, integer division by 2 returns G exactly (no rounding). Discharged by `omega` after rewriting with the main identity.",
+    "mathContext": "$\\gcd(\\varphi(m),\\varphi(n))/2 = \\gcd(\\varphi(m)/2,\\varphi(n)/2)$.",
+    "significance": "standard",
+    "relatedConcepts": ["natural division", "gcd factorisation"],
+    "prerequisites": ["the exact factorisation", "omega"]
+  },
+  {
+    "id": "ann-gcd-eq-two-iff",
+    "proofId": "euler-totient-oq-07-oq-01",
+    "range": { "startLine": 76, "endLine": 81 },
+    "type": "theorem",
+    "title": "Equality gcd = 2 ⟺ the Halved Totients Are Coprime",
+    "content": "The correct characterisation of when the gcd hits the universal floor, answering the parent's open question. From gcd = 2·G, the equation 2·G = 2 is equivalent to G = 1, i.e. gcd(φ m/2, φ n/2) = 1. So gcd(φ m, φ n) = 2 precisely when the halves are coprime — this is the necessary-and-sufficient condition, superseding the seeker's guess about a totient equalling 2.",
+    "mathContext": "$\\gcd(\\varphi(m),\\varphi(n))=2 \\iff \\gcd(\\varphi(m)/2,\\varphi(n)/2)=1$.",
+    "significance": "key",
+    "relatedConcepts": ["coprimality", "sharp characterisation", "gcd = 2 case"],
+    "prerequisites": ["the exact factorisation", "coprimality as gcd = 1", "omega"]
+  },
+  {
+    "id": "ann-four-le-gcd-iff",
+    "proofId": "euler-totient-oq-07-oq-01",
+    "range": { "startLine": 83, "endLine": 91 },
+    "type": "theorem",
+    "title": "gcd ≥ 4 ⟺ the Halved Totients Share a Factor",
+    "content": "The complementary criterion: the gcd exceeds the parity minimum (reaching ≥ 4) exactly when φ(m)/2 and φ(n)/2 stop being coprime, i.e. gcd of the halves ≥ 2. From gcd = 2·G, the inequality 4 ≤ 2·G is equivalent to 2 ≤ G. This makes precise the jump from the guaranteed floor 2 to the next possible value.",
+    "mathContext": "$\\gcd(\\varphi(m),\\varphi(n))\\ge 4 \\iff \\gcd(\\varphi(m)/2,\\varphi(n)/2)\\ge 2$.",
+    "significance": "standard",
+    "relatedConcepts": ["gcd lower bound", "common factor of halves"],
+    "prerequisites": ["the exact factorisation", "omega"]
+  },
+  {
+    "id": "ann-counterexample",
+    "proofId": "euler-totient-oq-07-oq-01",
+    "range": { "startLine": 93, "endLine": 95 },
+    "type": "theorem",
+    "title": "Refutation: gcd = 2 Does Not Force a Totient to Equal 2",
+    "content": "The explicit counterexample to the seeker's candidate conjecture. m = 5, n = 7 gives φ(5) = 4, φ(7) = 6, so gcd(4, 6) = 2 — yet both totients are ≥ 4 and neither argument lies in {3, 4, 6}. Equality holds not because a totient is small but because the halves 2 and 3 are coprime, exactly as `gcd_totient_eq_two_iff` predicts. All conditions are checked by kernel `decide`.",
+    "mathContext": "$\\gcd(\\varphi(5),\\varphi(7))=\\gcd(4,6)=2$ with $\\varphi(5),\\varphi(7)\\ge 4$.",
+    "significance": "key",
+    "relatedConcepts": ["counterexample", "refuted conjecture", "coprime halves"],
+    "prerequisites": ["the equality characterisation", "kernel decide"]
+  },
+  {
+    "id": "ann-worked-examples",
+    "proofId": "euler-totient-oq-07-oq-01",
+    "range": { "startLine": 97, "endLine": 117 },
+    "type": "example",
+    "title": "Worked Examples of the Factorisation",
+    "content": "Concrete instances by kernel `decide`. The equality cases: (m,n) = (3,4) with halves 1, 1 (coprime ⇒ gcd = 2) and the counterexample (5,7) with halves 2, 3 (coprime ⇒ gcd = 2). The larger-gcd cases: (5,5) with halves 2, 2 sharing 2 ⇒ gcd = 2·2 = 4, and (7,9) with halves 3, 3 sharing 3 ⇒ gcd = 2·3 = 6. Each illustrates the factorisation gcd = 2·gcd(halves) directly.",
+    "mathContext": "$\\gcd(\\varphi(7),\\varphi(9))=6=2\\cdot 3=2\\cdot\\gcd(3,3)$.",
+    "significance": "standard",
+    "relatedConcepts": ["worked examples", "kernel decide", "factorisation instances"],
+    "prerequisites": ["Euler's totient values", "gcd computation"]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-07-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "euler-totient-oq-07-oq-01",
+  "slug": "euler-totient-oq-07-oq-01",
+  "title": "The Exact Shared Power of Two: $\\gcd(\\varphi(m),\\varphi(n)) = 2\\cdot\\gcd(\\varphi(m)/2,\\varphi(n)/2)$",
+  "description": "Sharpens the parent lower bound `2 ∣ gcd(φ m, φ n)` (for m, n ≥ 3) into an exact factorisation and settles the parent's open question on when the gcd equals exactly 2. Because φ(k) is even for every k > 2 (`Nat.totient_even`), the single guaranteed factor of 2 splits off cleanly: `gcd(φ m, φ n) = 2 · gcd(φ m / 2, φ n / 2)` (via `Nat.gcd_mul_left`). Every downstream question reduces to the halved totients and is discharged by `omega`: the gcd equals 2 iff the halves φ m / 2 and φ n / 2 are coprime; the gcd is ≥ 4 iff the halves share a common factor; and gcd(φ m, φ n) / 2 = gcd(φ m / 2, φ n / 2) exactly. This refutes the seeker's candidate conjecture that gcd = 2 forces one totient to equal 2 (arguments in {3,4,6}): the explicit witness m = 5, n = 7 gives gcd(φ 5, φ 7) = gcd(4, 6) = 2 with both totients ≥ 4, because the halves 2 and 3 are coprime. The correct dividing line is coprimality of the halved totients, not the size of either totient. Fully machine-checked: 0 sorries, 0 axioms (the `decide` calls are kernel reductions over concrete small naturals, not `native_decide`).",
+  "overview": {
+    "historicalContext": "The parent entry euler-totient-oq-07 records that for m, n ≥ 3 the totients φ(m), φ(n) are never coprime and satisfy the lower bound 2 ≤ gcd(φ(m), φ(n)), the shared factor coming from the parity fact φ(k) even for k > 2 (Euler's 1763 totient, whose unit group (ℤ/kℤ)ˣ contains the order-2 element −1). It left open how sharp that bound is: is the gcd forced above 2 except in a small exceptional set? A natural guess is that gcd = 2 only when one totient is itself 2 (i.e. an argument in {3, 4, 6}). This entry shows that guess is wrong and replaces it with the exact structural picture: the factor of 2 always splits off cleanly, and everything past that is governed by the arithmetic of the halved totients φ(m)/2, φ(n)/2 — objects with the parity obstruction removed.",
+    "problemStatement": "**Open Question (euler-totient-oq-07-oq-01):** sharpen `2 ≤ gcd(φ(m), φ(n))` for m, n ≥ 3. When does equality gcd = 2 hold, and is it true that gcd ≥ 4 unless some totient equals exactly 2?",
+    "text": "For m, n ≥ 3, gcd(φ(m), φ(n)) = 2 · gcd(φ(m)/2, φ(n)/2). Hence gcd = 2 exactly when the halves φ(m)/2 and φ(n)/2 are coprime, and gcd ≥ 4 exactly when they share a common factor. The guess 'gcd = 2 ⟹ some totient equals 2' is false: m = 5, n = 7 gives gcd(4, 6) = 2 with both totients ≥ 4.",
+    "proofStrategy": "The whole entry rests on one identity. For m, n ≥ 3 both totients are even (`Nat.totient_even`), so writing φ(m) = 2·(φ(m)/2) and φ(n) = 2·(φ(n)/2) via `Nat.mul_div_cancel'` and pulling the common factor out with `Nat.gcd_mul_left` gives `gcd(φ m, φ n) = 2 · gcd(φ m / 2, φ n / 2)` (`gcd_totient_eq_two_mul_gcd_half`). Each corollary is then a one-line `omega` on the resulting `2·G` expression: `2·G = 2 ↔ G = 1` (`gcd_totient_eq_two_iff`), `4 ≤ 2·G ↔ 2 ≤ G` (`four_le_gcd_totient_iff`), `2·G / 2 = G` (`gcd_totient_div_two`). The refutation `exists_gcd_two_with_large_totients` exhibits m = 5, n = 7 with all conditions checked by kernel `decide`.",
+    "keyInsights": [
+      "**The guaranteed factor of 2 splits off exactly.** Parity gives `2 ∣ gcd`; the identity `gcd(φ m, φ n) = 2 · gcd(φ m / 2, φ n / 2)` says nothing is lost or added by removing it — the residual gcd is precisely that of the halved totients. This reduces every sharpness question to a parity-free problem.",
+      "**Coprimality of the halves — not the size of a totient — controls equality.** gcd = 2 iff φ(m)/2 and φ(n)/2 are coprime. The seeker's guess that gcd = 2 forces a totient to equal 2 confuses a sufficient condition (φ(n) = 2 ⟹ φ(n)/2 = 1, trivially coprime) with the actual necessary-and-sufficient one.",
+      "**Explicit counterexample m = 5, n = 7.** φ(5) = 4, φ(7) = 6, both ≥ 4, yet gcd = 2 because the halves 2 and 3 are coprime. No argument here lies in {3, 4, 6}, so the naive strengthening of the parent bound is false.",
+      "**gcd ≥ 4 is the same as a common factor among the halves.** The jump from the universal floor 2 to 4 happens exactly when φ(m)/2 and φ(n)/2 stop being coprime, giving a clean criterion for the gcd exceeding the parity minimum."
+    ],
+    "prerequisites": [
+      "Euler's totient φ and the parity fact φ(n) even for n > 2",
+      "gcd of naturals and the multiplicativity `gcd(k·a, k·b) = k·gcd(a, b)`",
+      "Coprimality as gcd = 1",
+      "Natural-number division and linear arithmetic (omega)"
+    ]
+  },
+  "conclusion": {
+    "summary": "For m, n ≥ 3 the factor of 2 forced by parity splits off exactly: gcd(φ(m), φ(n)) = 2 · gcd(φ(m)/2, φ(n)/2). Consequently gcd = 2 iff the halved totients are coprime, gcd ≥ 4 iff they share a factor, and dividing the gcd by 2 returns the gcd of the halves on the nose. The parent's candidate strengthening (gcd ≥ 4 unless a totient equals 2) is refuted by m = 5, n = 7. 5 theorems, 117 lines, 0 sorries, 0 axioms; built on `Nat.totient_even` and `Nat.gcd_mul_left` plus `omega`.",
+    "implications": "The identity converts any question about the shared factor 2 in gcd(φ(m), φ(n)) into a question about the halved totients, where parity no longer interferes. This is the right tool for deciding equality gcd = 2 in concrete cases and for understanding when the gcd exceeds the parity minimum — the criterion is simply whether φ(m)/2 and φ(n)/2 have a common factor.",
+    "openQuestions": [
+      "Characterize coprimality of the halves φ(m)/2 and φ(n)/2 directly in terms of the factorizations of m and n, so that gcd(φ(m), φ(n)) = 2 becomes a condition read off from m, n without computing φ.",
+      "Iterate the splitting: peel off the full 2-adic valuation v₂(gcd(φ m, φ n)) = min(v₂ φ m, v₂ φ n) and relate it to the classification of n with φ(n) ≡ 2 (mod 4) (arguments 4, p^k, 2p^k with p ≡ 3 mod 4)."
+    ]
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "T. M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer",
+      "note": "Multiplicative arithmetic functions and the formula φ(n) = ∏ p^(k−1)(p−1) underlying the value of each totient."
+    },
+    {
+      "authors": "G. H. Hardy, E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press",
+      "note": "Standard reference for Euler's totient and its elementary parity and divisibility properties."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.totient, Nat.totient_even, and the gcd API (Nat.gcd_mul_left, Nat.mul_div_cancel') used throughout."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-07",
+      "relationship": "parent",
+      "description": "The parent establishes 2 ∣ gcd(φ m, φ n) and the floor 2 ≤ gcd for m, n ≥ 3. This entry sharpens that floor into the exact factorisation gcd = 2·gcd(halves), answers the parent's open question on when equality holds, and refutes its candidate 'gcd ≥ 4 unless a totient equals 2'."
+    },
+    {
+      "targetId": "euler-totient-oq-06",
+      "relationship": "related",
+      "description": "oq-06 classifies the parity of φ (even ⟺ n ∉ {1,2}) and the finer φ(n) ≡ 2 (mod 4) case. That 2-adic information is exactly what governs whether the halved totients here are both even, i.e. whether gcd(φ m, φ n) exceeds 2."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 117,
+    "path": "Proofs/EulerTotientOQ07OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 5
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring stating the goal — sharpen the parent's 2 ≤ gcd(φ m, φ n) floor — and the resolution: the factor of 2 splits off exactly, so gcd = 2·gcd(halves). Explains that the seeker's candidate conjecture is refuted by m = 5, n = 7, lists the contents, and imports `Mathlib.Data.Nat.Totient` and `Mathlib.Tactic`, opening the `Nat` namespace so `φ` denotes `Nat.totient`."
+    },
+    {
+      "id": "factorisation",
+      "title": "The Exact Factorisation and Its Corollaries",
+      "startLine": 54,
+      "endLine": 100,
+      "summary": "The structural heart: `gcd_totient_eq_two_mul_gcd_half` proves gcd(φ m, φ n) = 2·gcd(φ m/2, φ n/2) by rewriting each even totient as 2·(half) and pulling the factor out with `Nat.gcd_mul_left`. The corollaries `gcd_totient_div_two`, `gcd_totient_eq_two_iff`, and `four_le_gcd_totient_iff` follow by `omega`, and `exists_gcd_two_with_large_totients` exhibits the counterexample m = 5, n = 7 refuting the naive strengthening."
+    },
+    {
+      "id": "worked-examples",
+      "title": "Worked Examples",
+      "startLine": 101,
+      "endLine": 117,
+      "summary": "Kernel-`decide` evaluations illustrating the factorisation: the equality cases (m,n) = (3,4) and the counterexample (5,7) with gcd = 2 and coprime halves, and the larger cases (5,5) with gcd = 4 = 2·2 and (7,9) with gcd = 6 = 2·3 where the halves share a common factor."
+    }
+  ],
+  "meta": {
+    "author": "gcd factorisation of Euler totients formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_totient_function",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ07OQ01.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "gcd",
+      "parity",
+      "2-adic-valuation",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 117,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The factorisation uses `Nat.totient_even` (φ(k) even for k > 2) and `Nat.gcd_mul_left` (gcd(k·a, k·b) = k·gcd(a,b)); the corollaries are closed by `omega`. The `decide` calls evaluate φ at concrete small naturals (3, 4, 5, 7, 9) in the kernel, not `native_decide`, so the only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound` (confirmed by `#print axioms`).",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_even",
+        "description": "`2 < n → Even n.totient`. Supplies the factor 2 in each totient for m, n ≥ 3, letting each be written as 2·(half).",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.gcd_mul_left",
+        "description": "`gcd (k * a) (k * b) = k * gcd a b`. Pulls the common factor 2 out of gcd(2·(φ m/2), 2·(φ n/2)), giving the exact factorisation.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel'",
+        "description": "`a ∣ b → a * (b / a) = b`. Rewrites each even totient φ(k) as 2·(φ(k)/2) before applying `Nat.gcd_mul_left`.",
+        "module": "Mathlib.Algebra.Order.Group.Nat"
+      }
+    ],
+    "originalContributions": [
+      "`gcd_totient_eq_two_mul_gcd_half`: the exact factorisation gcd(φ m, φ n) = 2·gcd(φ m/2, φ n/2) for m, n ≥ 3 — sharpens the parent's `2 ∣ gcd` into an equality by showing the forced factor of 2 splits off cleanly.",
+      "`gcd_totient_eq_two_iff`: gcd(φ m, φ n) = 2 ⟺ gcd(φ m/2, φ n/2) = 1 — the correct necessary-and-sufficient condition for equality, answering the parent's open question.",
+      "`four_le_gcd_totient_iff`: gcd(φ m, φ n) ≥ 4 ⟺ gcd(φ m/2, φ n/2) ≥ 2 — the criterion for the gcd exceeding the parity minimum.",
+      "`gcd_totient_div_two`: gcd(φ m, φ n) / 2 = gcd(φ m/2, φ n/2) — halving the gcd recovers the gcd of the halves exactly.",
+      "`exists_gcd_two_with_large_totients`: the explicit witness m = 5, n = 7 with gcd(φ 5, φ 7) = 2 and both totients ≥ 4, refuting the seeker's candidate conjecture that gcd = 2 forces a totient to equal 2."
+    ],
+    "prerequisites": [
+      "Euler's totient function and the parity fact φ(n) even for n > 2",
+      "gcd of naturals and its multiplicativity gcd(k·a, k·b) = k·gcd(a, b)",
+      "Coprimality as gcd = 1",
+      "Natural-number division and linear arithmetic (omega)"
+    ],
+    "dateAdded": "2026-07-02",
+    "relatedProblems": [
+      {
+        "id": "euler-totient-oq-07",
+        "relationship": "Parent: proves 2 ∣ gcd(φ m, φ n) and the floor 2 ≤ gcd for m, n ≥ 3. This entry sharpens the floor into the exact factorisation, characterizes equality, and refutes the parent's candidate strengthening."
+      },
+      {
+        "id": "euler-totient-oq-06",
+        "relationship": "Related: oq-06's parity/2-adic classification of φ governs whether the halved totients are even, i.e. whether the gcd here exceeds the parity minimum of 2."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Sharpens the parent **euler-totient-oq-07** (which proved only `2 ∣ gcd(φ m, φ n)` and the floor `2 ≤ gcd` for `m, n ≥ 3`) into an **exact factorisation** and settles the parent's open question on when the gcd equals exactly 2.

**Main identity** (`gcd_totient_eq_two_mul_gcd_half`): for `m, n ≥ 3`,
```
gcd(φ m, φ n) = 2 · gcd(φ m / 2, φ n / 2).
```
Both totients are even (`Nat.totient_even`), so the parity-forced factor of 2 splits off cleanly via `Nat.gcd_mul_left`. Every downstream question then reduces to the halved totients and closes with `omega`:

- `gcd_totient_eq_two_iff`: `gcd = 2 ⟺ gcd(φ m/2, φ n/2) = 1` (halves coprime) — the correct characterisation.
- `four_le_gcd_totient_iff`: `gcd ≥ 4 ⟺ gcd(φ m/2, φ n/2) ≥ 2` (halves share a factor).
- `gcd_totient_div_two`: `gcd(φ m, φ n) / 2 = gcd(φ m/2, φ n/2)` exactly.

## Refutes the seeker's candidate conjecture

The parent's `openQuestions[0]` guessed `gcd ≥ 4` unless one totient equals 2 (argument in `{3,4,6}`). **This is false.** `exists_gcd_two_with_large_totients` exhibits **m = 5, n = 7**: `gcd(φ 5, φ 7) = gcd(4, 6) = 2` with *both* totients ≥ 4 — equality holds because the halves 2 and 3 are coprime, not because any totient is small. Coprimality of the halved totients is the true dividing line.

## Verification

- **5 theorems, 117 lines, 0 sorries, 0 axioms.**
- `#print axioms` on all five main results: `[propext, Classical.choice, Quot.sound]` only. The `decide` calls are **kernel** reductions over small naturals (not `native_decide`), so no `Lean.ofReduceBool`.
- Mathlib inputs: `Nat.totient_even`, `Nat.gcd_mul_left`, `Nat.mul_div_cancel'`.

## Files
- `proofs/Proofs/EulerTotientOQ07OQ01.lean`
- `src/data/proofs/euler-totient-oq-07-oq-01/{meta.json, annotations.json}` (new gallery entry, 7 annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)