### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-02-oq-01): gallery entry — joint independence of disjoint blocks (PGF factorization) [VERIFIED, 0-axiom]

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-binjointpgf-header",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 55 },
+    "type": "concept",
+    "title": "Joint independence of disjoint blocks via PGF factorization",
+    "content": "The parent entry proved that marginals of a multinomial are binomial; its first open question asks whether the PGF method extends to JOINT independence of disjoint index subsets. In the binomial model — independent Bernoulli(p) indicators (Xᵢ) — the block-sums U = ∑_{i∈S} Xᵢ and V = ∑_{i∈T} Xᵢ over disjoint S, T should be jointly independent, each a Binomial. The certificate is generating-function factorization: for independent variables the joint PGF E[∏ tᵢ^{Xᵢ}] is the product of the per-index Bernoulli PGFs, and a joint PGF that separates into a function of u times a function of v certifies independence. Scope: the file proves this factorization rigorously; it does not re-derive the measure-theoretic PGF ⇒ independence equivalence."
+  },
+  {
+    "id": "ann-binjointpgf-setup",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 57, "endLine": 75 },
+    "type": "definition",
+    "title": "Bernoulli and joint generating functions",
+    "content": "bernoulliPGF p t = (1 − p) + p·t is the PGF of a single Bernoulli(p) indicator: E[t^X] = P(X=0)·t⁰ + P(X=1)·t¹ = (1−p) + p·t. jointPGF s p t = ∏_{i∈s} bernoulliPGF (p i) (t i) is the joint PGF of independent indicators (Xᵢ)_{i∈s} with per-index success probabilities p i, evaluated at formal variables t i. Because the indicators are independent, the joint transform E[∏ tᵢ^{Xᵢ}] is exactly this product — the modelling assumption is baked into the product form."
+  },
+  {
+    "id": "ann-binjointpgf-normalisation",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 77, "endLine": 89 },
+    "type": "proof",
+    "title": "These are genuine PGFs (total probability 1)",
+    "content": "bernoulliPGF_one: at t = 1, (1−p) + p·1 = 1 (by ring). jointPGF_one: evaluating every variable at 1 makes each factor 1, so the product is 1 — proved by Finset.prod_eq_one, reducing to the Bernoulli case factorwise. Evaluating a PGF at 1 recovers the total probability mass, so these lemmas confirm bernoulliPGF and jointPGF are honest generating functions rather than arbitrary polynomials."
+  },
+  {
+    "id": "ann-binjointpgf-union",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 91, "endLine": 104 },
+    "type": "proof",
+    "title": "jointPGF_union: the independence certificate",
+    "content": "The joint PGF over a disjoint union factors as jointPGF (S ∪ T) p t = jointPGF S p t · jointPGF T p t. After unfolding the definitions this is exactly Finset.prod_union h (a product over a disjoint union splits into the product over each part). This separation of the joint transform into an S-part and a T-part is the generating-function certificate that the two blocks are jointly independent."
+  },
+  {
+    "id": "ann-binjointpgf-const",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 106, "endLine": 117 },
+    "type": "proof",
+    "title": "jointPGF_const: a homogeneous block is a Binomial PGF",
+    "content": "With a common success probability p and a common formal variable u, the block PGF collapses: jointPGF s (fun _ => p) (fun _ => u) = bernoulliPGF p u ^ s.card = ((1−p) + p·u)^|s|. This is Finset.prod_const (a product of a constant over s equals that constant raised to s.card). The right-hand side is precisely the PGF of Binomial(|s|, p), exhibiting the block-sum as a Binomial directly from the factored form."
+  },
+  {
+    "id": "ann-binjointpgf-bivariate",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 119, "endLine": 144 },
+    "type": "proof",
+    "title": "disjoint_blocks_pgf: two disjoint block-sums are independent Binomials",
+    "content": "Assign variable u to block S and v to disjoint block T via the selector `if i ∈ S then u else v`. The bivariate PGF ∏_{i∈S∪T} bernoulliPGF p (if i∈S then u else v) factors as ((1−p)+p·u)^|S| · ((1−p)+p·v)^|T|. Proof: Finset.prod_union splits the product; then congr 1 handles each block. On S, every i satisfies i ∈ S so if_pos selects u and Finset.prod_const gives the |S| power. On T, disjointness (Finset.disjoint_right.mp h hi) gives i ∉ S so if_neg selects v, and Finset.prod_const gives the |T| power. The clean separation into a u-function times a v-function, each a Binomial PGF, is exactly the PGF independence criterion — answering the parent's open question in the binomial model."
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "binomial-theorem-oq-02-oq-01-oq-02-oq-01",
+  "title": "Joint Independence of Disjoint Blocks in the Binomial Model (PGF Factorization)",
+  "slug": "binomial-theorem-oq-02-oq-01-oq-02-oq-01",
+  "description": "Answers the open question of the parent entry (Marginal Distributions of Multinomial Are Binomial): in the binomial model — a family of independent Bernoulli indicators (Xᵢ)ᵢ — are the block-sums over DISJOINT index subsets jointly independent? Following the probability-generating-function (PGF) methodology of the parent, the file proves the generating-function certificate of independence: the joint PGF over a disjoint union S ∪ T factors as the product of the two block PGFs (jointPGF_union), and, specialising to a homogeneous success probability p with formal variable u on block S and v on block T, the bivariate PGF E[u^U v^V] separates as ((1−p)+p·u)^|S| · ((1−p)+p·v)^|T| = E[u^U]·E[v^V] (disjoint_blocks_pgf), each factor itself a Binomial PGF. Normalisation lemmas confirm these are genuine PGFs (evaluating all variables at 1 returns 1). Verified, axiom-free, sorry-free. Scope: the PGF factorization is the standard generating-function certificate of independence; the file proves the factorization rigorously and does not re-derive the measure-theoretic PGF ⇒ independence equivalence.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ02OQ01.lean",
+    "tags": [
+      "probability",
+      "binomial distribution",
+      "bernoulli",
+      "generating functions",
+      "independence",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 144,
+    "assumptions": "None. All 5 theorems are fully proved with 0 sorries, 0 axiom declarations, and no structure-encoded assumptions. Depends only on Lean's foundational axioms (propext, Classical.choice, Quot.sound); no native_decide, so Lean.ofReduceBool is not used.",
+    "theoremCount": 5,
+    "mathlib_version": "4.26.0",
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "That block-sums over disjoint index sets of independent indicators are themselves independent is a foundational fact of probability theory — it is what lets one treat non-overlapping groups of Bernoulli trials as separate experiments. The cleanest certificate is the factorization of the joint probability generating function: for independent variables the joint transform E[∏ tᵢ^{Xᵢ}] is the product of the per-variable PGFs, and conversely a joint PGF that separates into a product of single-variable functions certifies independence. This is the discrete analogue of the characteristic-function factorization criterion and underlies the additivity of the binomial family, Poisson thinning, and the independence of increments of Bernoulli processes. This entry answers the first open question posed by the parent entry ('Marginal Distributions of Multinomial Are Binomial'): can the PGF method be extended to joint independence of disjoint subsets?",
+    "problemStatement": "In the binomial model — independent Bernoulli(p) indicators (Xᵢ) — are the block-sums U = ∑_{i∈S} Xᵢ and V = ∑_{i∈T} Xᵢ over disjoint index sets S, T jointly independent, and is each a Binomial? Concretely: does the bivariate PGF E[u^U v^V] factor into a function of u times a function of v, each a Binomial PGF?",
+    "text": "Proves the PGF-factorization certificate of joint independence for disjoint block-sums in the binomial model: the joint PGF over a disjoint union factors as the product of block PGFs, and the bivariate PGF of two disjoint block-sums separates into ((1−p)+p·u)^|S| · ((1−p)+p·v)^|T|, each factor a Binomial PGF. Verified, axiom-free.",
+    "proofStrategy": "1. Define bernoulliPGF p t = (1−p) + p·t = E[t^X] for X ~ Bernoulli(p), and the joint PGF jointPGF s p t = ∏_{i∈s} bernoulliPGF (p i) (t i) of independent indicators. 2. Normalisation: bernoulliPGF_one and jointPGF_one show evaluating all variables at 1 gives 1, so these are genuine PGFs. 3. jointPGF_union: the joint PGF over a disjoint union S ∪ T factors as the product of block PGFs — a one-line application of Finset.prod_union — the separation of the joint transform that certifies joint independence. 4. jointPGF_const: with common parameter p and common variable u the block PGF collapses to the Binomial PGF ((1−p)+p·u)^|s| via Finset.prod_const. 5. disjoint_blocks_pgf: assigning u to block S and v to block T (via if i ∈ S then u else v), the bivariate PGF splits by Finset.prod_union, then Finset.prod_congr rewrites each block's indicator (if_pos on S, if_neg via Finset.disjoint_right on T) and Finset.prod_const collapses each to a Binomial PGF — the clean u-part × v-part separation that is exactly the PGF independence criterion.",
+    "keyInsights": [
+      "PGF factorization IS the independence certificate: for independent indicators the joint transform is a product, and a joint PGF that separates into a u-function times a v-function certifies the block-sums are independent — the discrete analogue of the characteristic-function criterion.",
+      "The whole argument is Finset bookkeeping: jointPGF_union is literally Finset.prod_union, and the bivariate factorization is Finset.prod_union followed by two Finset.prod_congr + Finset.prod_const collapses — no measure theory is invoked.",
+      "Disjointness enters exactly once, in the T-block: every i ∈ T lies outside S (Finset.disjoint_right), so the selector `if i ∈ S then u else v` picks v uniformly, letting the product collapse to a pure power of the v-PGF.",
+      "Homogeneity turns each block PGF into a Binomial PGF: with a common p and common variable, Finset.prod_const gives ((1−p)+p·t)^|s|, exhibiting each block-sum as Binomial(|s|, p) directly from the factored form.",
+      "This closes the loop with the parent's marginal-binomial result: the marginals are Binomial (parent), and disjoint block-sums are jointly independent Binomials (here) — both obtained from the same PGF machinery."
+    ],
+    "prerequisites": [
+      "probability generating functions and the factorization criterion for independence",
+      "the Bernoulli and Binomial distributions and their PGFs",
+      "finite products over Finsets: Finset.prod_union, Finset.prod_const, Finset.prod_congr",
+      "disjoint Finsets and Finset.disjoint_right"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Module Overview and Scope",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "States the open question inherited from the parent (are disjoint block-sums of independent Bernoulli indicators jointly independent?), the PGF factorization methodology, the two headline results (jointPGF_union and disjoint_blocks_pgf), the Mathlib dependencies, and the scope (the file proves the PGF factorization certificate, not the measure-theoretic PGF ⇒ independence equivalence)."
+    },
+    {
+      "id": "setup",
+      "title": "Setup: Bernoulli and Joint Generating Functions",
+      "startLine": 57,
+      "endLine": 75,
+      "summary": "Defines bernoulliPGF p t = (1−p) + p·t (the PGF E[t^X] of a Bernoulli(p) indicator) and jointPGF s p t = ∏_{i∈s} bernoulliPGF (p i) (t i) (the joint PGF of independent indicators evaluated at formal variables t i)."
+    },
+    {
+      "id": "normalisation",
+      "title": "Normalisation: These Are Genuine PGFs",
+      "startLine": 77,
+      "endLine": 89,
+      "summary": "bernoulliPGF_one (a Bernoulli PGF at t=1 equals 1) and jointPGF_one (the joint PGF at all variables = 1 equals 1, via Finset.prod_eq_one), confirming total probability 1."
+    },
+    {
+      "id": "part1-union",
+      "title": "Part I: Joint Independence via PGF Factorization",
+      "startLine": 91,
+      "endLine": 104,
+      "summary": "jointPGF_union: the joint PGF over a disjoint union S ∪ T factors as jointPGF S · jointPGF T (Finset.prod_union). This separation of the joint transform is the generating-function certificate of joint independence of the two blocks."
+    },
+    {
+      "id": "part2-const",
+      "title": "Part II: Each Block Is a Binomial PGF",
+      "startLine": 106,
+      "endLine": 117,
+      "summary": "jointPGF_const: with a common success probability p and a common formal variable u, the block PGF over s collapses to the Binomial PGF ((1−p)+p·u)^|s| via Finset.prod_const."
+    },
+    {
+      "id": "part3-bivariate",
+      "title": "Part III: Bivariate Block PGF Factorizes into Two Binomial PGFs",
+      "startLine": 119,
+      "endLine": 144,
+      "summary": "disjoint_blocks_pgf: assigning variable u to block S and v to disjoint block T, the bivariate PGF ∏_{i∈S∪T} bernoulliPGF p (if i∈S then u else v) factors as ((1−p)+p·u)^|S| · ((1−p)+p·v)^|T| — a u-function times a v-function, each a Binomial PGF. Proved by Finset.prod_union then Finset.prod_congr (if_pos on S; if_neg via Finset.disjoint_right on T) and Finset.prod_const."
+    }
+  ],
+  "conclusion": {
+    "summary": "The two headline theorems certify joint independence of disjoint block-sums in the binomial model through PGF factorization. jointPGF_union shows the joint PGF over a disjoint union factors as the product of block PGFs; disjoint_blocks_pgf shows the bivariate PGF of two disjoint block-sums separates into ((1−p)+p·u)^|S| · ((1−p)+p·v)^|T|, each factor a Binomial PGF. Normalisation lemmas confirm these are genuine PGFs. All 5 theorems machine-verified with 0 sorries and 0 axioms.",
+    "implications": "Answers the parent entry's first open question (extend the PGF method to joint independence of disjoint subsets) on the binomial model. Together with the parent's marginal-binomial result, this shows that disjoint groups of independent Bernoulli trials behave as independent Binomial experiments — the algebraic backbone of Poisson thinning, the additivity Binomial(m,p)+Binomial(n,p)=Binomial(m+n,p) for independent summands, and the independence of increments of a Bernoulli process. The factorization pattern (product over a disjoint union splits, homogeneous blocks collapse to powers) is reusable for any generating-function independence argument over finite index sets.",
+    "openQuestions": [
+      "Lift the PGF factorization to the measure-theoretic statement: formalize the PGF ⇒ independence equivalence for finitely-supported integer random variables, turning disjoint_blocks_pgf into a proof of ProbabilityTheory.IndepFun for the block-sums.",
+      "Generalize from two blocks to an arbitrary finite partition of the index set, showing the k-fold joint PGF factors as a product of k Binomial PGFs.",
+      "Extend to the genuinely multinomial setting (categories, not just success/failure), proving that disjoint category-groups give jointly independent collapsed multinomials — the full form of the parent's open question."
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/BinomialTheoremOQ02OQ01OQ02OQ01.lean",
+    "theorems": [
+      "bernoulliPGF_one",
+      "jointPGF_one",
+      "jointPGF_union",
+      "jointPGF_const",
+      "disjoint_blocks_pgf"
+    ],
+    "lineCount": 144,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 5
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry (marginals of multinomial are binomial) via the same PGF method; this file answers its first open question by proving joint independence of disjoint block-sums."
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Multinomial MGF/PGF formula — the generating-function tool underlying this factorization argument."
+    },
+    {
+      "targetId": "binomial-theorem-oq-02",
+      "relationship": "related",
+      "description": "The multinomial theorem, the algebraic engine behind the binomial-model PGF identities."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "related",
+      "description": "The original binomial theorem; the Binomial PGF ((1−p)+p·t)^n is its generating-function shadow."
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "W. Feller",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. 1",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Probability generating functions, independence via factorization of transforms, and the binomial/Bernoulli families."
+    },
+    {
+      "authors": "G. Grimmett, D. Stirzaker",
+      "title": "Probability and Random Processes",
+      "year": 2001,
+      "venue": "Oxford University Press",
+      "note": "3rd ed.; generating functions, the PGF factorization criterion for independence, and sums of independent random variables."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Finset.prod_union, Finset.prod_const, Finset.prod_congr, Finset.disjoint_right, and the BigOperators API underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fills a **missing-gallery-entry gap**: the verified proof `proofs/Proofs/BinomialTheoremOQ02OQ01OQ02OQ01.lean` is already merged on `main` but has no `src/data/proofs/` entry, so it renders nowhere in the gallery. This PR adds `meta.json` + `annotations.json` (no Lean changes).

## What the proof establishes

Answers the first open question of the parent entry *Marginal Distributions of Multinomial Are Binomial* (`binomial-theorem-oq-02-oq-01-oq-02`), in the binomial model: are block-sums over **disjoint** index subsets of independent Bernoulli indicators jointly independent? The certificate is **PGF factorization**:

- `jointPGF_union` — the joint PGF over a disjoint union $S \cup T$ factors as the product of the two block PGFs (the generating-function certificate of joint independence).
- `disjoint_blocks_pgf` — with homogeneous parameter $p$ and formal variables $u$ on $S$, $v$ on $T$, the bivariate PGF factors as $((1-p)+p u)^{|S|} \cdot ((1-p)+p v)^{|T|}$ — a $u$-part times a $v$-part, each a Binomial PGF.

Supporting: `bernoulliPGF_one`, `jointPGF_one` (normalisation — genuine PGFs), `jointPGF_const` (homogeneous block collapses to a Binomial PGF).

## Verification

- 144 lines, 5 theorems, 2 definitions, **0 sorries, 0 axiom declarations, 0 structure-encoded assumptions**. No `native_decide`, so `Lean.ofReduceBool` is not used.
- `status: verified`, `badge: original`, `axiomCount: 0`, `mathlib_version: 4.26.0`.
- The Lean file is unchanged and already on `main` (built there); this PR only adds gallery data.

## Scope (honest framing)

The file proves the PGF factorization — the standard generating-function *certificate* of independence — rigorously. It does **not** re-derive the measure-theoretic PGF ⇒ independence equivalence; this is stated in both the file docstring and the entry's `assumptions`/scope, and left as an open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)