### PR TITLE
Fix: create missing gallery entry for perfect-numbers-oq-06

### DIFF
--- a/src/data/proofs/perfect-numbers-oq-06/annotations.json
+++ b/src/data/proofs/perfect-numbers-oq-06/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header-overview",
+    "proofId": "perfect-numbers-oq-06",
+    "range": { "startLine": 4, "endLine": 45 },
+    "type": "context",
+    "title": "Closing the form → triangular gap",
+    "content": "The docstring states the target and the gap it fills. Mathlib's Archive proves the Euclid–Euler *form* of even perfect numbers (n = 2^{p−1}(2^p − 1) with 2^p − 1 a Mersenne prime) but never the classical observation that such n are triangular numbers Tₘ = m(m+1)/2. This file supplies that consequence and pins down the triangulating index: it is exactly the Mersenne prime, so 6 = T₃, 28 = T₇, 496 = T₃₁, 8128 = T₁₂₇. The whole argument is kept division-free by working with the doubled value 2·n.",
+    "mathContext": "Even $n$ perfect $\\implies n = T_{2^p-1}$ where $2^p-1$ is the Mersenne prime.",
+    "significance": "context",
+    "relatedConcepts": ["perfect numbers", "triangular numbers", "Euclid–Euler theorem", "Mersenne primes"],
+    "prerequisites": ["perfect numbers", "triangular numbers"]
+  },
+  {
+    "id": "ann-doubled-form-certificate",
+    "proofId": "perfect-numbers-oq-06",
+    "range": { "startLine": 51, "endLine": 66 },
+    "type": "technique",
+    "title": "The division-free triangularity certificate",
+    "content": "IsTriangular is defined as ∃ m, n = m(m+1)/2, but reasoning about that truncating division directly is painful over ℕ. isTriangular_of_two_mul provides the working certificate: from 2·n = m(m+1) triangularity follows, because Nat.mul_div_cancel_left makes the division exact. Its converse two_mul_triangular records 2·Tₘ = m(m+1), using Nat.even_mul_succ_self (consecutive integers have an even product) so the division was exact all along. This doubled form is what the rest of the file uses.",
+    "mathContext": "$2n = m(m+1) \\implies n = m(m+1)/2$; and $2 \\cdot (m(m+1)/2) = m(m+1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["natural-number division", "Nat.mul_div_cancel_left", "even product of consecutive integers"],
+    "prerequisites": ["ℕ division", "divisibility"]
+  },
+  {
+    "id": "ann-core-identity",
+    "proofId": "perfect-numbers-oq-06",
+    "range": { "startLine": 68, "endLine": 77 },
+    "type": "insight",
+    "title": "The algebraic heart: 2·(2^k·m) = m(m+1)",
+    "content": "two_mul_euclid_factor is the arithmetic core. For the Euclid–Euler factor n = 2^k · mersenne(k+1) with m = mersenne(k+1) = 2^{k+1} − 1, it proves 2·n = m·(m+1). The single fact needed is m + 1 = 2^{k+1}, obtained by unfolding mersenne and Nat.sub_add_cancel Nat.one_le_two_pow. After rewriting with that and pow_succ, the goal 2·2^k·m = m·(2^{k+1}) closes by ring — crucially with m kept OPAQUE, so no reasoning about the size or primality of the Mersenne factor is required.",
+    "mathContext": "$2 \\cdot (2^k (2^{k+1}-1)) = 2^{k+1}(2^{k+1}-1) = m(m+1)$, $m = 2^{k+1}-1$.",
+    "significance": "key",
+    "relatedConcepts": ["Mersenne number", "pow_succ", "ring", "opaque rewriting"],
+    "prerequisites": ["exponent arithmetic", "mersenne"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "perfect-numbers-oq-06",
+    "range": { "startLine": 79, "endLine": 95 },
+    "type": "insight",
+    "title": "Main theorem and the Mersenne-prime strengthening",
+    "content": "even_perfect_isTriangular destructures Mathlib's Euclid–Euler theorem Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect, which returns n in the form 2^k · mersenne(k+1) together with the primality of that Mersenne number; feeding two_mul_euclid_factor into isTriangular_of_two_mul concludes triangularity. The strengthened even_perfect_triangular_mersenne_prime keeps the primality witness, exposing that the triangulating index m is itself a Mersenne prime — so an even perfect number is T_m for a *prime* m.",
+    "mathContext": "Destructure $n = 2^k \\cdot \\text{mersenne}(k{+}1)$, apply the doubled identity; retain $m.\\text{Prime}$.",
+    "significance": "key",
+    "relatedConcepts": ["Euclid–Euler theorem", "eq_two_pow_mul_prime_mersenne_of_even_perfect", "Mersenne prime"],
+    "prerequisites": ["even perfect numbers", "Mersenne primes"]
+  },
+  {
+    "id": "ann-concrete-examples",
+    "proofId": "perfect-numbers-oq-06",
+    "range": { "startLine": 97, "endLine": 102 },
+    "type": "context",
+    "title": "The first four perfect numbers, triangulated",
+    "content": "Four example checks confirm the general theorem numerically: 6 = T₃, 28 = T₇, 496 = T₃₁, 8128 = T₁₂₇, each discharged by exhibiting the index and a norm_num computation. The indices 3, 7, 31, 127 are precisely the Mersenne primes 2²−1, 2³−1, 2⁵−1, 2⁷−1 — a concrete illustration that the triangulating index is the Mersenne prime, not an arbitrary integer.",
+    "mathContext": "$6=T_3,\\ 28=T_7,\\ 496=T_{31},\\ 8128=T_{127}$.",
+    "significance": "context",
+    "relatedConcepts": ["triangular numbers", "Mersenne primes", "norm_num"],
+    "prerequisites": ["triangular numbers"]
+  }
+]

--- a/src/data/proofs/perfect-numbers-oq-06/meta.json
+++ b/src/data/proofs/perfect-numbers-oq-06/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "perfect-numbers-oq-06",
+  "title": "Every Even Perfect Number is Triangular",
+  "slug": "perfect-numbers-oq-06",
+  "description": "Every even perfect number is a triangular number Tₘ = m(m+1)/2, and the triangulating index m is precisely the Mersenne prime from its Euclid–Euler factorization: 6 = T₃, 28 = T₇, 496 = T₃₁, 8128 = T₁₂₇. Built on Mathlib's Euclid–Euler theorem via a division-free doubled identity. 5 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Perfect_number",
+    "date": "Classical (Euclid–Euler; triangular consequence folklore)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PerfectNumbersOQ06.lean",
+    "tags": [
+      "number-theory",
+      "perfect-numbers",
+      "triangular-numbers",
+      "mersenne-primes",
+      "euclid-euler"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 5 theorems fully verified with 0 sorries and 0 axioms (beyond Mathlib's foundational set). Builds on Mathlib's Archive Euclid–Euler theorem.",
+    "originalContributions": [
+      "even_perfect_isTriangular: every even perfect number is triangular (the form → triangular gap not covered in Mathlib's PerfectNumbers)",
+      "even_perfect_triangular_mersenne_prime: strengthened form — the triangulating index m is itself a Mersenne prime",
+      "two_mul_euclid_factor: the division-free core identity 2·(2^k·(2^{k+1}−1)) = m·(m+1) with m = 2^{k+1}−1",
+      "isTriangular_of_two_mul / two_mul_triangular: the doubled-form certificate of triangularity, avoiding natural-number division",
+      "Concrete checks 6 = T₃, 28 = T₇, 496 = T₃₁, 8128 = T₁₂₇"
+    ],
+    "dateAdded": "2026-07-02",
+    "prerequisites": [
+      "The Euclid–Euler theorem (even perfect ↔ 2^{p−1}(2^p−1) with 2^p−1 a Mersenne prime)",
+      "Triangular numbers Tₘ = m(m+1)/2",
+      "Mersenne numbers and mersenne (k+1) = 2^{k+1} − 1 in Mathlib",
+      "Division-free reasoning over ℕ (working with 2·n)"
+    ],
+    "lineCount": 104,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Perfect numbers — equal to the sum of their proper divisors (6 = 1+2+3, 28 = 1+2+4+7+14) — are among the oldest objects in number theory. Euclid (c. 300 BCE) showed that if 2^p − 1 is prime then 2^{p−1}(2^p − 1) is perfect; Euler proved the converse for even numbers two millennia later, giving the Euclid–Euler characterization. A charming further observation, known since antiquity in numerical form, is that every even perfect number is also *triangular*: 6, 28, 496, 8128 are the 3rd, 7th, 31st, and 127th triangular numbers. The triangulating index is not arbitrary — it is exactly the Mersenne prime 2^p − 1 appearing in the factorization. Whether any odd perfect number exists remains one of the oldest open problems in mathematics, so 'even' cannot presently be dropped.",
+    "problemStatement": "**Theorem.** If n is even and perfect, then n is a triangular number: n = T_m = m(m+1)/2 for some m. More precisely, n = T_{2^p − 1} where 2^p − 1 is the Mersenne prime in the Euclid–Euler factorization n = 2^{p−1}(2^p − 1).\n\nExamples: 6 = T₃, 28 = T₇, 496 = T₃₁, 8128 = T₁₂₇ — the triangulating indices 3, 7, 31, 127 are exactly the Mersenne primes.",
+    "text": "This 104-line entry closes the form → triangular gap left by Mathlib's `Archive.Wiedijk100Theorems.PerfectNumbers`, which proves the Euclid–Euler *form* of even perfect numbers but not their triangularity. The argument is deliberately division-free. Triangularity is captured by `IsTriangular n := ∃ m, n = m(m+1)/2`, but the working certificate is the doubled form: `isTriangular_of_two_mul` shows `2·n = m(m+1)` already forces triangularity (dividing an even product by 2 is exact via `Nat.mul_div_cancel_left`). The core identity `two_mul_euclid_factor` computes, for the Euclid–Euler factor n = 2^k·(2^{k+1}−1) with m = 2^{k+1}−1, that `2·n = 2^{k+1}·(2^{k+1}−1) = m(m+1)` — keeping `mersenne (k+1)` opaque and using only `m + 1 = 2^{k+1}`, so the whole step reduces to `pow_succ` and `ring`. The main theorem `even_perfect_isTriangular` then destructures `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect` and applies the identity; the strengthened `even_perfect_triangular_mersenne_prime` additionally exposes that the index m is a Mersenne *prime*. Four `example`s verify the first four perfect numbers concretely. All 5 theorems compile with 0 sorries and 0 axioms.",
+    "proofStrategy": "**Reduce to the doubled form.** Rather than reasoning about m(m+1)/2 directly, prove triangularity from `2·n = m(m+1)`: since m(m+1) is a product of consecutive integers it is even, so `Nat.mul_div_cancel_left n (by norm_num)` recovers n = m(m+1)/2 without any lossy natural-number division.\n\n**The algebraic heart (two_mul_euclid_factor).** Set m = mersenne (k+1) = 2^{k+1} − 1. The only fact needed is m + 1 = 2^{k+1}, discharged by `mersenne` unfolding and `Nat.sub_add_cancel Nat.one_le_two_pow`. Rewriting with `pow_succ` turns 2·2^k·m into 2^{k+1}·m = m·(m+1), closed by `ring` — m itself stays opaque throughout.\n\n**Assemble.** `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect hev hperf` gives n = 2^k · mersenne (k+1) with the Mersenne prime witness; feeding `two_mul_euclid_factor k` into `isTriangular_of_two_mul` finishes, and re-exposing the prime witness gives the strengthened form.",
+    "keyInsights": [
+      "**Doubled-form trick.** Working with 2·n = m(m+1) instead of n = m(m+1)/2 sidesteps every natural-number division subtlety; exactness comes for free from the evenness of consecutive-integer products (`Nat.even_mul_succ_self`).",
+      "**Keep the Mersenne factor opaque.** The core identity never needs to know m = 2^{k+1} − 1 as a number — only the single relation m + 1 = 2^{k+1}. This keeps the `ring` step trivial and the proof robust.",
+      "**The index is the Mersenne prime.** The triangulating index m is not incidental: it equals the Mersenne prime 2^p − 1 of the Euclid–Euler factorization, so the strengthened theorem records m.Prime alongside n = T_m.",
+      "**'Even' is load-bearing.** The result rests on Euler's converse, which is only known for even perfect numbers; extending triangularity to all perfect numbers is equivalent to resolving the existence of odd perfect numbers, an ancient open problem."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Euclid",
+      "title": "Elements, Book IX, Proposition 36",
+      "year": "c. 300 BCE",
+      "venue": "Classical mathematics",
+      "note": "If 2^p − 1 is prime then 2^{p−1}(2^p − 1) is perfect — the constructive half of the Euclid–Euler theorem."
+    },
+    {
+      "authors": "Euler, Leonhard",
+      "title": "Tractatus de numerorum doctrina",
+      "year": "c. 1747",
+      "venue": "Posthumously published",
+      "note": "Proved the converse: every even perfect number has the Euclidean form 2^{p−1}(2^p − 1) with 2^p − 1 prime."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "extends",
+      "description": "The base entry proves the Euclid–Euler characterization (the Mersenne form of even perfect numbers); this entry derives the triangular consequence n = T_{2^p−1} from that form."
+    },
+    {
+      "targetId": "perfect-numbers-oq-03",
+      "relationship": "related",
+      "description": "Studies the Mersenne primes 2^p − 1 themselves (necessity of prime exponent, Lucas congruence); here those same Mersenne primes reappear as the triangulating indices of the perfect numbers."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Archive.Wiedijk100Theorems.PerfectNumbers",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "scoped ArithmeticFunction"
+    ],
+    "namespace": "PerfectNumbersOQ06",
+    "lineCount": 104,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/PerfectNumbersOQ06.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "even_perfect_isTriangular",
+      "type": "core",
+      "description": "Every even perfect number is a triangular number, triangulated by the Mersenne prime of its Euclid–Euler factorization.",
+      "leanType": "Even n → n.Perfect → IsTriangular n"
+    },
+    {
+      "name": "even_perfect_triangular_mersenne_prime",
+      "type": "core",
+      "description": "Strengthened form: an even perfect number equals T_m for a Mersenne prime m.",
+      "leanType": "Even n → n.Perfect → ∃ m, m.Prime ∧ n = m * (m + 1) / 2"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Fix

`proofs/Proofs/PerfectNumbersOQ06.lean` was merged to `main` but never received a `src/data/proofs/<slug>/` directory, so the proof was **invisible** in the gallery. This creates the missing entry.

## Evidence

**Before**: `PerfectNumbersOQ06.lean` exists on `main` (5 theorems, 1 def, 0 sorries, 0 axioms) with no `src/data/proofs/perfect-numbers-oq-06/` directory → not rendered anywhere.

**After**: gallery entry added:
- `meta.json` — `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`, `theoremCount: 5`, `definitionCount: 1`; cross-references to `perfect-numbers` (extends the Euclid–Euler form) and `perfect-numbers-oq-03` (the Mersenne primes involved).
- `annotations.json` — 5 annotations covering the header, the division-free triangularity certificate, the core algebraic identity, the main theorem + Mersenne-prime strengthening, and the concrete examples.

**Validation**:
- Both JSON files parse; `pnpm annotations:validate` reports **zero errors for this entry** (all annotation ranges resolve to real Lean constructs).
- The `.lean` builds on Mathlib's `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect` (Archive Euclid–Euler theorem); the added lemmas are short algebraic derivations with 0 sorries / 0 axioms.

The result: every even perfect number is a triangular number T_m, and the triangulating index m is exactly the Mersenne prime from its Euclid–Euler factorization (6 = T₃, 28 = T₇, 496 = T₃₁, 8128 = T₁₂₇).

---
Automated fix by lean-mechanic agent.