### PR TITLE
audit: fix alternating-series-boole-summation-oq-01-oq-02 badge (verified→mathlib)

### DIFF
--- a/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02/meta.json
@@ -41,7 +41,19 @@
       "leibniz-criterion",
       "limits"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
+    "mathlibDependencies": [
+      {
+        "theorem": "Antitone.alternating_series_le_tendsto",
+        "description": "For an antitone sequence, every even partial sum of the alternating series is ≤ the limit. Supplies the one-sided (below) bracketing that is the analytic core of the remainder bound.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Antitone.tendsto_le_alternating_series",
+        "description": "For an antitone sequence, every odd partial sum of the alternating series is ≥ the limit. Supplies the one-sided (above) bracketing that is the analytic core of the remainder bound.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      }
+    ],
     "sorries": 0,
     "dateAdded": "2026-07-01",
     "relatedProblems": [


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `alternating-series-boole-summation-oq-01-oq-02`
**Severity**: MEDIUM (Mathlib bridge presented with `verified`/original badge)

## Problem

The entry's core analytic content — the **one-sided bracketing** of the alternating series (even partial sums ≤ L, odd partial sums ≥ L) — comes directly from Mathlib's alternating-series test:
- `Antitone.alternating_series_le_tendsto`
- `Antitone.tendsto_le_alternating_series`

The Lean lemmas `even_partial_le` / `le_odd_partial` are one-line wrappers around these Mathlib theorems. The file's genuine new content is *combining* them into the sharp two-sided remainder bound `|L − Sₘ| ≤ aₘ`, the consecutive-partial-sum bracketing, and the `[0, a₀]` localization.

This is a **Tier B** result (core argument relies on a Mathlib theorem; the file provides the bridge/combination), which per the auditor tiering should carry badge **`mathlib`**, not `verified`.

## Evidence

- `meta.json` claimed `"badge": "verified"` (independent verification).
- `assumptions` field already disclosed the Mathlib reliance in prose: *"The core one-sided bracketing lemmas are Mathlib's `Antitone.alternating_series_le_tendsto` and `Antitone.tendsto_le_alternating_series` ... the new content is their combination."* — so the narrative is honest; only the badge tier signal was wrong.
- Sibling entry `algebraic-numbers-countable-oq-05-oq-04-oq-01` has the **identical shape** (a Mathlib inequality + a matching combination proved locally) and correctly uses `status: "verified"` + `badge: "mathlib"`.

## Fix

- `badge`: `"verified"` → `"mathlib"`
- Added `mathlibDependencies` listing the two core Mathlib theorems (surfacing in structured metadata what the `assumptions` prose already stated).

No change to `status` (still machine-checked, 0 sorries, 0 axioms), counts, or the Lean source. All meta counts (7 theorems, 0 defs, 146 lines, 0 sorries, 0 axioms, no `native_decide`, no True stubs) were verified against the source and are accurate.

---
Discovered during gallery integrity audit.