### PR TITLE
Enrich Boole's inequality & 2nd-order Bonferroni bound: annotation depth fields

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/inclusion-exclusion-oq-05-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 41 },
     "type": "concept",
     "title": "From the General Sieve to Two Named Corollaries",
-    "content": "The docstring recalls the parent's truncated inclusion–exclusion value $\\mathrm{truncIE}\\,s\\,S\\,m = \\sum_{k=1}^{m} (-1)^{k+1} \\sum_{t \\subseteq s,\\,|t|=k} \\#(\\bigcap_{i\\in t} S_i)$ and states the goal: specialise the parent's odd/even Bonferroni inequalities to $m=1$ and $m=2$, and expand the abstract powerset-indexed sums into the indexed forms $\\sum_i \\#(S_i)$ and $\\sum_i \\#(S_i) - \\sum_{i<j} \\#(S_i \\cap S_j)$. This is open question 1 of the parent inclusion-exclusion-oq-05."
+    "content": "The docstring recalls the parent's truncated inclusion–exclusion value $\\mathrm{truncIE}\\,s\\,S\\,m = \\sum_{k=1}^{m} (-1)^{k+1} \\sum_{t \\subseteq s,\\,|t|=k} \\#(\\bigcap_{i\\in t} S_i)$ and states the goal: specialise the parent's odd/even Bonferroni inequalities to $m=1$ and $m=2$, and expand the abstract powerset-indexed sums into the indexed forms $\\sum_i \\#(S_i)$ and $\\sum_i \\#(S_i) - \\sum_{i<j} \\#(S_i \\cap S_j)$. This is open question 1 of the parent inclusion-exclusion-oq-05.",
+    "mathContext": "$\\mathrm{truncIE}\\,s\\,S\\,m = \\sum_{k=1}^{m} (-1)^{k+1} \\sum_{\\substack{t \\subseteq s \\\\ |t|=k}} \\#\\!\\left(\\bigcap_{i\\in t} S_i\\right)$; the $m$-th partial sum of the inclusion–exclusion series, whose odd truncations over- and even truncations under-estimate $\\#(\\bigcup_{i\\in s} S_i)$.",
+    "significance": "context",
+    "relatedConcepts": ["inclusion-exclusion principle", "Bonferroni inequalities", "sieve methods", "union bound"],
+    "prerequisites": ["Finset combinatorics", "inclusion–exclusion / sieve principle"]
   },
   {
     "id": "ann-ie0501-interCard-singleton",
@@ -13,7 +17,11 @@
     "range": { "startLine": 57, "endLine": 72 },
     "type": "proof-technique",
     "title": "A Singleton Contributes the Full Cardinality",
-    "content": "`interCard_singleton` shows `interCard s S {i} = #(S i)` for `i ∈ s`. Since `interCard` is defined as the number of elements of the union that lie in every set indexed by the subset, for the singleton `{i}` this is the number of union-elements in `S i` — and because `S i ⊆ ⋃_{i∈s} S i`, that is exactly `#(S i)`. The proof establishes the underlying finset equality `(⋃ S).filter (· ∈ S i) = S i` by extensionality, using `mem_biUnion` for the ⊇ direction."
+    "content": "`interCard_singleton` shows `interCard s S {i} = #(S i)` for `i ∈ s`. Since `interCard` is defined as the number of elements of the union that lie in every set indexed by the subset, for the singleton `{i}` this is the number of union-elements in `S i` — and because `S i ⊆ ⋃_{i∈s} S i`, that is exactly `#(S i)`. The proof establishes the underlying finset equality `(⋃ S).filter (· ∈ S i) = S i` by extensionality, using `mem_biUnion` for the ⊇ direction.",
+    "mathContext": "$\\mathrm{interCard}\\,s\\,S\\,\\{i\\} = \\#\\big(\\{x \\in \\bigcup_{j\\in s} S_j : x \\in S_i\\}\\big) = \\#(S_i)$, since $S_i \\subseteq \\bigcup_{j\\in s} S_j$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.filter", "subset of a union", "cardinality", "Finset extensionality"],
+    "prerequisites": ["Finset membership and extensionality", "Finset.biUnion / mem_biUnion"]
   },
   {
     "id": "ann-ie0501-interCard-pair",
@@ -21,7 +29,11 @@
     "range": { "startLine": 74, "endLine": 93 },
     "type": "proof-technique",
     "title": "A Pair Contributes the Intersection Cardinality",
-    "content": "`interCard_pair` shows `interCard s S {i,j} = #(S i ∩ S j)` for `i,j ∈ s`. The filter of the union by membership in every set of `{i,j}` — i.e. in both `S i` and `S j` — is `S i ∩ S j`, again because the intersection sits inside the union. The forall-over-`{i,j}` predicate is unfolded by `mem_insert`/`mem_singleton` and a two-case `rcases`."
+    "content": "`interCard_pair` shows `interCard s S {i,j} = #(S i ∩ S j)` for `i,j ∈ s`. The filter of the union by membership in every set of `{i,j}` — i.e. in both `S i` and `S j` — is `S i ∩ S j`, again because the intersection sits inside the union. The forall-over-`{i,j}` predicate is unfolded by `mem_insert`/`mem_singleton` and a two-case `rcases`.",
+    "mathContext": "$\\mathrm{interCard}\\,s\\,S\\,\\{i,j\\} = \\#\\big(\\{x \\in \\textstyle\\bigcup_k S_k : x \\in S_i \\wedge x \\in S_j\\}\\big) = \\#(S_i \\cap S_j)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset intersection", "mem_insert / mem_singleton", "subset of a union"],
+    "prerequisites": ["Finset membership", "case analysis on insert/singleton"]
   },
   {
     "id": "ann-ie0501-sum-one",
@@ -29,7 +41,11 @@
     "range": { "startLine": 95, "endLine": 105 },
     "type": "key-insight",
     "title": "Size-1 Expansion: ∑ over singletons = ∑ᵢ #(Sᵢ)",
-    "content": "`sum_interCard_one` rewrites `∑_{t ⊆ s, |t|=1} interCard s S t` as `∑_{i∈s} #(S i)`. The key lemma is `powersetCard_one`, which identifies the size-1 subsets of `s` with the singletons `{i}` (as the image of `s` under the singleton embedding); `Finset.sum_map` then reindexes the sum, and `interCard_singleton` evaluates each term. This is the closed form of the first sieve term."
+    "content": "`sum_interCard_one` rewrites `∑_{t ⊆ s, |t|=1} interCard s S t` as `∑_{i∈s} #(S i)`. The key lemma is `powersetCard_one`, which identifies the size-1 subsets of `s` with the singletons `{i}` (as the image of `s` under the singleton embedding); `Finset.sum_map` then reindexes the sum, and `interCard_singleton` evaluates each term. This is the closed form of the first sieve term.",
+    "mathContext": "$\\sum_{\\substack{t \\subseteq s \\\\ |t|=1}} \\mathrm{interCard}\\,s\\,S\\,t = \\sum_{i\\in s} \\#(S_i)$, using $\\mathcal{P}_1(s) = \\{\\{i\\} : i \\in s\\}$ (powersetCard_one).",
+    "significance": "key",
+    "relatedConcepts": ["powersetCard", "Finset.sum_map", "reindexing a sum", "singleton embedding"],
+    "prerequisites": ["powerset of a Finset", "sum over an image / map"]
   },
   {
     "id": "ann-ie0501-sum-two",
@@ -37,7 +53,11 @@
     "range": { "startLine": 107, "endLine": 161 },
     "type": "key-insight",
     "title": "Size-2 Expansion: ∑ over 2-subsets = ∑_{i<j} #(Sᵢ∩Sⱼ)",
-    "content": "`sum_interCard_two` is the crux: it rewrites `∑_{t ⊆ s, |t|=2} interCard s S t` as the strict-pair sum `∑_{(i,j) : i<j} #(S i ∩ S j)`. With a linear order on the index type, it proves `s.powersetCard 2` is the image of the strict pairs `{(i,j) ∈ s×s : i<j}` under `(i,j) ↦ {i,j}` (each 2-subset `{x,y}` arises from its ordered version), and that this map is injective — the two coordinates of a strict pair are precisely the minimum and maximum of the corresponding 2-element subset, recovered here by an `le_antisymm` argument on membership. `Finset.sum_image` then reindexes and `interCard_pair` evaluates each term. This subset-to-pairs bridge is the step that turns the abstract sieve into the textbook `∑_{i<j}` form."
+    "content": "`sum_interCard_two` is the crux: it rewrites `∑_{t ⊆ s, |t|=2} interCard s S t` as the strict-pair sum `∑_{(i,j) : i<j} #(S i ∩ S j)`. With a linear order on the index type, it proves `s.powersetCard 2` is the image of the strict pairs `{(i,j) ∈ s×s : i<j}` under `(i,j) ↦ {i,j}` (each 2-subset `{x,y}` arises from its ordered version), and that this map is injective — the two coordinates of a strict pair are precisely the minimum and maximum of the corresponding 2-element subset, recovered here by an `le_antisymm` argument on membership. `Finset.sum_image` then reindexes and `interCard_pair` evaluates each term. This subset-to-pairs bridge is the step that turns the abstract sieve into the textbook `∑_{i<j}` form.",
+    "mathContext": "$\\sum_{\\substack{t \\subseteq s \\\\ |t|=2}} \\mathrm{interCard}\\,s\\,S\\,t = \\sum_{\\substack{i,j\\in s \\\\ i<j}} \\#(S_i \\cap S_j)$; the bijection $\\{i,j\\} \\leftrightarrow (\\min,\\max)$ needs a linear order on the index type $\\iota$.",
+    "significance": "key",
+    "relatedConcepts": ["linear order", "min / max of a pair", "Finset.sum_image", "bijection between 2-subsets and strict pairs", "injectivity"],
+    "prerequisites": ["linear orders and antisymmetry", "sum over an injective image", "Finset products"]
   },
   {
     "id": "ann-ie0501-cast",
@@ -45,7 +65,11 @@
     "range": { "startLine": 163, "endLine": 173 },
     "type": "concept",
     "title": "Casting to ℤ to Match the Signed Sieve",
-    "content": "The parent's `truncIE` is an integer-valued alternating sum, so `sum_interCard_one_int` and `sum_interCard_two_int` restate the two expansions with summands cast to `ℤ`, discharged by `exact_mod_cast` from the natural-number versions. This lets the following corollaries rewrite inside `truncIE` directly."
+    "content": "The parent's `truncIE` is an integer-valued alternating sum, so `sum_interCard_one_int` and `sum_interCard_two_int` restate the two expansions with summands cast to `ℤ`, discharged by `exact_mod_cast` from the natural-number versions. This lets the following corollaries rewrite inside `truncIE` directly.",
+    "mathContext": "$\\sum_i (\\#(S_i) : \\mathbb{Z})$ and $\\sum_{i<j} (\\#(S_i\\cap S_j):\\mathbb{Z})$; needed because $\\mathrm{truncIE}$ carries the alternating signs $(-1)^{k+1}$ and so lives in $\\mathbb{Z}$, not $\\mathbb{N}$.",
+    "significance": "technical",
+    "relatedConcepts": ["Nat.cast ℕ→ℤ", "exact_mod_cast", "push_cast", "signed / alternating sums"],
+    "prerequisites": ["coercions between ℕ and ℤ", "cast lemmas for sums"]
   },
   {
     "id": "ann-ie0501-truncIE-values",
@@ -53,7 +77,11 @@
     "range": { "startLine": 177, "endLine": 197 },
     "type": "proof-technique",
     "title": "Computing truncIE at m = 1 and m = 2",
-    "content": "`truncIE_one` unfolds the sieve at `m=1`: the index set `Icc 1 1 = {1}`, the sign `(-1)^{1+1}=1`, giving `truncIE s S 1 = ∑ᵢ #(Sᵢ)`. `truncIE_two` unfolds at `m=2`: `Icc 1 2 = {1,2}` (by `decide`), and `Finset.sum_pair` splits the sum into the `k=1` term (sign `+1`) and the `k=2` term (sign `-1`), yielding `∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ)` after `ring`."
+    "content": "`truncIE_one` unfolds the sieve at `m=1`: the index set `Icc 1 1 = {1}`, the sign `(-1)^{1+1}=1`, giving `truncIE s S 1 = ∑ᵢ #(Sᵢ)`. `truncIE_two` unfolds at `m=2`: `Icc 1 2 = {1,2}` (by `decide`), and `Finset.sum_pair` splits the sum into the `k=1` term (sign `+1`) and the `k=2` term (sign `-1`), yielding `∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ)` after `ring`.",
+    "mathContext": "$\\mathrm{truncIE}\\,s\\,S\\,1 = \\sum_i \\#(S_i)$ and $\\mathrm{truncIE}\\,s\\,S\\,2 = \\sum_i \\#(S_i) - \\sum_{i<j} \\#(S_i\\cap S_j)$, from $\\mathrm{Icc}\\,1\\,2 = \\{1,2\\}$ and signs $(-1)^{2}=+1,\\,(-1)^{3}=-1$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.Icc", "Finset.sum_pair", "alternating sums", "decide (kernel)"],
+    "prerequisites": ["sums over integer intervals", "evaluating alternating signs"]
   },
   {
     "id": "ann-ie0501-boole",
@@ -61,7 +89,11 @@
     "range": { "startLine": 199, "endLine": 213 },
     "type": "key-insight",
     "title": "Boole's Inequality (m = 1)",
-    "content": "`boole_inequality` is the union bound `#(⋃ᵢ Sᵢ) ≤ ∑ᵢ #(Sᵢ)`: instantiate the parent's odd-truncation Bonferroni inequality at `m=1` (using `odd_one`) and rewrite with `truncIE_one`. `boole_inequality_nat` restates it in ℕ without casts. This is exactly the first-order sieve bound, recovered as a named corollary."
+    "content": "`boole_inequality` is the union bound `#(⋃ᵢ Sᵢ) ≤ ∑ᵢ #(Sᵢ)`: instantiate the parent's odd-truncation Bonferroni inequality at `m=1` (using `odd_one`) and rewrite with `truncIE_one`. `boole_inequality_nat` restates it in ℕ without casts. This is exactly the first-order sieve bound, recovered as a named corollary.",
+    "mathContext": "$\\#\\!\\left(\\bigcup_{i\\in s} S_i\\right) \\le \\sum_{i\\in s} \\#(S_i)$ — Boole's inequality, the odd (one-term) truncation of the sieve.",
+    "significance": "key",
+    "relatedConcepts": ["union bound", "first moment method", "odd truncation of the sieve", "probabilistic combinatorics"],
+    "prerequisites": ["general Bonferroni odd-truncation bound (parent)", "truncIE_one"]
   },
   {
     "id": "ann-ie0501-second-order",
@@ -69,6 +101,10 @@
     "range": { "startLine": 215, "endLine": 222 },
     "type": "key-insight",
     "title": "The Second-Order Bonferroni Bound (m = 2)",
-    "content": "`bonferroni_second_order` is the lower bound `∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ) ≤ #(⋃ᵢ Sᵢ)`: instantiate the parent's even-truncation Bonferroni inequality at `m=2` (using `even_two`) and rewrite with `truncIE_two`. This is the sharpest elementary lower bound on a union obtainable from single-set and pairwise-intersection data — the basis of the Bonferroni corrections in statistics."
+    "content": "`bonferroni_second_order` is the lower bound `∑ᵢ #(Sᵢ) − ∑_{i<j} #(Sᵢ∩Sⱼ) ≤ #(⋃ᵢ Sᵢ)`: instantiate the parent's even-truncation Bonferroni inequality at `m=2` (using `even_two`) and rewrite with `truncIE_two`. This is the sharpest elementary lower bound on a union obtainable from single-set and pairwise-intersection data — the basis of the Bonferroni corrections in statistics.",
+    "mathContext": "$\\sum_{i\\in s} \\#(S_i) - \\sum_{i<j} \\#(S_i\\cap S_j) \\le \\#\\!\\left(\\bigcup_{i\\in s} S_i\\right)$ — the even ($m=2$) truncation, a lower bound on the union.",
+    "significance": "key",
+    "relatedConcepts": ["Bonferroni correction", "even truncation of the sieve", "simultaneous statistical inference", "second moment / pairwise data"],
+    "prerequisites": ["general Bonferroni even-truncation bound (parent)", "truncIE_two"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `inclusion-exclusion-oq-05-oq-01` (0 prior passes).

## What changed
The meta.json was already rich (5 keyInsights, full conclusion, cross-references, references, sections), but **all 9 annotations lacked depth fields**. This pass adds them:

- **mathContext** — precise LaTeX formula each code section proves: the truncated sieve `truncIE`, `interCard` on singletons/pairs, the 2-subset ↔ strict-pair bijection, Boole's bound $\#(\bigcup S_i)\le\sum\#(S_i)$, and the second-order Bonferroni lower bound.
- **significance** — key / supporting / technical / context classification per annotation.
- **relatedConcepts** — Mathlib lemmas (powersetCard_one, Finset.sum_image, sum_pair) and broader theory (union bound, Bonferroni corrections, sieve methods).
- **prerequisites** — what a reader needs (linear orders, coercions ℕ→ℤ, powersets, the parent Bonferroni bounds).

## Safety
- Purely **additive**: id/proofId/type/title/content/range of all 9 annotations are byte-identical to `main` (verified programmatically).
- JSON valid; meta.json within all size caps (11.4 KB).
- The 4 pre-existing non-strict validator warnings (`type "key-insight"` on a theorem line) predate this PR and are unrelated to the added fields.

Now meets the enrichment quality target of ≥5 annotations with mathContext + significance + relatedConcepts (all 9 have them).