### PR TITLE
Enrich perfect-numbers-oq-06: add sections + conclusion

### DIFF
--- a/src/data/proofs/perfect-numbers-oq-06/meta.json
+++ b/src/data/proofs/perfect-numbers-oq-06/meta.json
@@ -109,5 +109,60 @@
       "leanType": "Even n → n.Perfect → ∃ m, m.Prime ∧ n = m * (m + 1) / 2"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Statement and Approach",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Imports Mathlib's Archive Euclid–Euler theorem and Mathlib.Tactic. The docstring states the result — every even perfect number is the triangular number T_{2^p−1} indexed by the Mersenne prime of its Euclid–Euler factorization — lists the first four examples (6=T₃, 28=T₇, 496=T₃₁, 8128=T₁₂₇), and sketches the division-free doubled-form approach.",
+      "mathContext": "$n$ even and perfect $\\Rightarrow n = T_{2^p-1}$ where $n = 2^{p-1}(2^p-1)$ is the Euclid–Euler form."
+    },
+    {
+      "id": "triangular-doubled-form",
+      "title": "Triangularity via the Doubled Form",
+      "startLine": 51,
+      "endLine": 66,
+      "summary": "Defines IsTriangular n := ∃ m, n = m(m+1)/2. isTriangular_of_two_mul turns the division-free hypothesis 2·n = m(m+1) into triangularity via Nat.mul_div_cancel_left. two_mul_triangular is the converse, 2·Tₘ = m(m+1), using that consecutive integers have an even product.",
+      "mathContext": "$2n = m(m+1) \\Rightarrow n = m(m+1)/2$, exact because $m(m+1)$ is even (Nat.even_mul_succ_self)."
+    },
+    {
+      "id": "core-identity",
+      "title": "The Core Algebraic Identity",
+      "startLine": 68,
+      "endLine": 77,
+      "summary": "two_mul_euclid_factor proves 2·(2^k·mersenne(k+1)) = mersenne(k+1)·(mersenne(k+1)+1). The only fact used is m+1 = 2^{k+1} (from mersenne unfolding + Nat.sub_add_cancel); rewriting with pow_succ and closing with ring keeps the Mersenne factor m opaque throughout.",
+      "mathContext": "With $m = 2^{k+1}-1$: $2\\cdot 2^k m = 2^{k+1} m = (m+1)m$, since $m+1 = 2^{k+1}$."
+    },
+    {
+      "id": "main-theorems",
+      "title": "Main Theorems",
+      "startLine": 79,
+      "endLine": 95,
+      "summary": "even_perfect_isTriangular destructures the Euclid–Euler theorem (n = 2^k·mersenne(k+1)) and feeds two_mul_euclid_factor into isTriangular_of_two_mul. even_perfect_triangular_mersenne_prime strengthens the conclusion by re-exposing the Mersenne prime witness, so the triangulating index m is certified prime.",
+      "mathContext": "$\\mathrm{Even}\\,n \\wedge n.\\mathrm{Perfect} \\Rightarrow \\exists m,\\ m.\\mathrm{Prime} \\wedge n = m(m+1)/2.$"
+    },
+    {
+      "id": "concrete-examples",
+      "title": "The First Four Perfect Numbers",
+      "startLine": 97,
+      "endLine": 104,
+      "summary": "Four example checks verifying 6 = T₃, 28 = T₇, 496 = T₃₁, 8128 = T₁₂₇ by exhibiting the triangulating index and discharging the arithmetic with norm_num — the concrete face of the general theorem, with the Mersenne primes 3, 7, 31, 127 as indices.",
+      "mathContext": "$6=T_3,\\ 28=T_7,\\ 496=T_{31},\\ 8128=T_{127}$ — indices are the Mersenne primes."
+    }
+  ],
+  "conclusion": {
+    "summary": "Every even perfect number is triangular, and the triangulating index is precisely the Mersenne prime of its Euclid–Euler factorization: n = 2^{p−1}(2^p−1) equals T_{2^p−1}. The formalization closes the form → triangular gap left open by Mathlib's Archive proof of Euclid–Euler, using a deliberately division-free strategy: triangularity is certified from the doubled identity 2·n = m(m+1), and the core computation keeps the Mersenne factor opaque so it reduces to pow_succ and ring. All 5 theorems verify with 0 sorries and 0 axioms.",
+    "implications": [
+      "Turns a piece of numerical folklore (6, 28, 496, 8128 are the 3rd, 7th, 31st, 127th triangular numbers) into a machine-checked theorem with an explicit, prime index — bridging Mathlib's Euclid–Euler form and elementary figurate-number lore.",
+      "The doubled-form technique (prove 2·n = m(m+1) and divide once, exactly) is a reusable pattern for stating figurate-number identities over ℕ without lossy division — applicable to pentagonal, hexagonal, and other polygonal characterizations.",
+      "Records that the triangulating index is not incidental but structurally the Mersenne prime, tightening the link between perfect numbers, Mersenne primes, and triangular numbers into a single statement."
+    ],
+    "openQuestions": [
+      "Can 'even' be dropped? Extending triangularity to all perfect numbers is equivalent to resolving whether any odd perfect number exists — an open problem since antiquity.",
+      "Every even perfect number beyond 6 is also a centered nonagonal number and a sum of consecutive odd cubes; can these companion figurate characterizations be formalized in the same division-free style?",
+      "Is the set of triangular indices {2^p − 1 : 2^p − 1 prime} infinite? This is exactly the open question of whether infinitely many Mersenne primes exist."
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for perfect-numbers-oq-06 (Every Even Perfect Number is Triangular).

## Gaps addressed
The entry already had a solid top-level overview and 5 depth-annotated annotations, but was **missing two required structural fields**:
- **`sections`** — added 5 sections covering the full 104-line Lean file (statement/approach, doubled-form triangularity, core algebraic identity, main theorems, concrete examples), each with a `mathContext`.
- **`conclusion`** — added `summary`, 3 `implications`, and 3 `openQuestions` (whether 'even' can be dropped ↔ odd perfect numbers; companion figurate characterizations; infinitude of Mersenne primes ↔ infinitude of triangular indices).

Section line ranges verified against `Proofs/PerfectNumbersOQ06.lean`. meta.json is 13.6 KB, well under the 60 KB cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)