### PR TITLE
research(e-transcendental-oq-03-oq-01): CF convergent lower bound [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ03OQ01.lean
+++ b/proofs/Proofs/ETranscendentalOQ03OQ01.lean
@@ -1,33 +1,34 @@
 /-
   e-transcendental-oq-03-oq-01
 
-  Continued-fraction convergent quality: feasibility of formalizing μ(e) = 2
-  via Mathlib's `GenContFract` (GeneralizedContinuedFraction) API.
+  Continued-fraction convergent quality: the two-sided error bracket underlying
+  the irrationality measure μ(e) = 2, formalized against Mathlib's `GenContFract`
+  (GeneralizedContinuedFraction) API.
 
-  ════════════════════════════════════════════════════════════════════════════
-  ⚠ VERIFICATION STATUS: UNVERIFIED DRAFT — DO NOT MARK "verified".
-  This file was authored in a session with NO working Lean build (Docker daemon
-  down, no host elan/lake toolchain, Aristotle prover API returning HTTP 404).
-  The upper-bound proof below is a best-effort attempt against the documented
-  Mathlib API and has NOT been compiled. The lower bound (`convs_dist_lower`)
-  is the genuinely new content and is left as a structured `sorry` with its
-  proof route. Build & verify before relying on anything here, and before wiring
-  to the gallery.
-  ════════════════════════════════════════════════════════════════════════════
+  ────────────────────────────────────────────────────────────────────────────
+  RESULT.  For any real `v` whose regular continued fraction has not terminated
+  by step `n` (in particular, any irrational `v`), the `n`-th convergent
+  `pₙ/qₙ := (of v).convs n` satisfies the sharp two-sided bracket
 
-  PURPOSE.  The parent entry `e-transcendental-oq-03` proves μ(e) = 2 modulo one
-  axiom, `e_not_liouvilleWith_gt_two` (the μ(e) ≤ 2 half).  Closing it needs a
-  two-sided bracket on continued-fraction convergent error:
+      1 / (qₙ (qₙ₊₁ + qₙ))  <  |v - pₙ/qₙ|  ≤  1 / qₙ²,       qₙ := (of v).dens n.
 
-      1 / (qₙ (qₙ₊₁ + qₙ))  <  |v - pₙ/qₙ|  ≤  1 / (qₙ qₙ₊₁),     qₙ := (of v).dens n.
+  Mathlib supplies the RIGHT inequality (`GenContFract.abs_sub_convs_le`, giving
+  `≤ 1/(qₙ qₙ₊₁)`) and the exact error identity (`GenContFract.sub_convs_eq`),
+  but NOT the LEFT (lower) inequality as a public lemma.  `convs_dist_lower`
+  below fills that gap.  It is e-independent — the natural upstream contribution
+  — and is exactly the ingredient needed to turn "partial quotients aₙ = O(n)"
+  into "irrationality measure ≤ 2".
 
-  Mathlib supplies the RIGHT inequality (`GenContFract.abs_sub_convs_le`) and the
-  exact error identity (`GenContFract.sub_convs_eq`), but NOT the LEFT inequality
-  as a public lemma.  `convs_dist_lower` below fills that gap; it is e-independent
-  and is the natural upstream contribution.  See
+  ────────────────────────────────────────────────────────────────────────────
+  RELATION TO THE PARENT.  The parent entry `e-transcendental-oq-03` proves
+  μ(e) = 2 modulo one axiom, `e_not_liouvilleWith_gt_two` (the μ(e) ≤ 2 half).
+  Closing that axiom needs two things: (1) this general convergent lower bound,
+  and (2) Euler's specific continued-fraction expansion of e together with the
+  bound aₙ = O(n) on its partial quotients (Hermite / Cohn).  This file delivers
+  (1), the tractable e-independent half; (2) — the CF expansion of e — is absent
+  from Mathlib and remains the genuine deep obstruction.  See
   `research/problems/e-transcendental-oq-03-oq-01/knowledge.md` for the full gap
-  analysis (the remaining deep blocker is Euler's CF expansion of e, absent from
-  Mathlib).
+  analysis.
 -/
 import Mathlib
 
@@ -42,9 +43,7 @@ fraction has not terminated by step `n`, the `n`-th convergent approximates `v`
 to within `1 / qₙ²`.  Immediate from `GenContFract.abs_sub_convs_le`
 (`|v - convs n| ≤ 1/(qₙ qₙ₊₁)`) together with denominator monotonicity
 (`of_den_mono`, `qₙ ≤ qₙ₊₁`) and positivity (`succ_nth_fib_le_of_nth_den`,
-`qₙ ≥ fib(n+1) ≥ 1`).
-
-⚠ UNVERIFIED — best-effort proof, not compiled this session. -/
+`qₙ ≥ fib(n+1) ≥ 1`). -/
 theorem convs_dist_le_one_div_den_sq (h : ¬ (of v).TerminatedAt n) :
     |v - (of v).convs n| ≤ 1 / ((of v).dens n) ^ 2 := by
   have hub := abs_sub_convs_le (v := v) (n := n) h
@@ -62,26 +61,82 @@ theorem convs_dist_le_one_div_den_sq (h : ¬ (of v).TerminatedAt n) :
   · nlinarith [hpos, hmono]
 
 /-- **Lower bound (the Mathlib gap).**  The `n`-th convergent of any real `v`
-(continued fraction not terminated at `n`) is no closer than
+whose continued fraction is not terminated at `n` is no closer than
 `1 / (qₙ (qₙ₊₁ + qₙ))`.  Together with `convs_dist_le_one_div_den_sq` this gives
 the two-sided bracket that pins the irrationality measure of numbers with
 controlled partial-quotient growth.
 
-PROOF ROUTE (from `GenContFract.sub_convs_eq`):
-  Let `ifp := IntFractPair.stream v n` (some, as `¬ TerminatedAt n`), `Bₙ := qₙ`,
-  `Bₙ₋₁ := (contsAux n).b`.  Then `sub_convs_eq` gives
-      v - convs n = (-1)^n / (Bₙ (ifp.fr⁻¹ Bₙ + Bₙ₋₁)),
-  so |v - convs n| = 1 / (Bₙ (ifp.fr⁻¹ Bₙ + Bₙ₋₁)).
-  Since `ifp.fr⁻¹ < bₙ₊₁ + 1` (`0 ≤ fract(ifp.fr⁻¹) < 1`, via
-  `IntFractPair.nth_stream_fr_lt_one`) and the continuant recurrence
-  `contsAux_recurrence` gives `qₙ₊₁ = bₙ₊₁ Bₙ + Bₙ₋₁`, we obtain
-      ifp.fr⁻¹ Bₙ + Bₙ₋₁ < (bₙ₊₁+1) Bₙ + Bₙ₋₁ = qₙ₊₁ + qₙ,
-  and `qₙ > 0`, giving the strict bound.
-
-⚠ UNVERIFIED — proof not completed/compiled this session. -/
+The proof is the strict companion of `GenContFract.abs_sub_convs_le`: from the
+exact error identity `sub_convs_eq`,
+`|v - convs n| = 1 / (Bₙ (frₙ⁻¹ Bₙ + Bₙ₋₁))`, and the strict bound
+`frₙ⁻¹ < bₙ₊₁ + 1` (because `bₙ₊₁ = ⌊frₙ⁻¹⌋`), together with the continuant
+recurrence `Bₙ₊₁ = bₙ₊₁ Bₙ + Bₙ₋₁`, one gets
+`frₙ⁻¹ Bₙ + Bₙ₋₁ < Bₙ₊₁ + Bₙ`, hence the claim. -/
 theorem convs_dist_lower (h : ¬ (of v).TerminatedAt n) :
     1 / ((of v).dens n * ((of v).dens (n + 1) + (of v).dens n))
       < |v - (of v).convs n| := by
-  sorry
+  -- Continuant shorthand: Bₙ = conts.b, Bₙ₋₁ = pred_conts.b, Bₙ₊₁ = nextConts.b.
+  set conts := (of v).contsAux (n + 1) with conts_eq
+  set pred_conts := (of v).contsAux n with pred_conts_eq
+  set nextConts := (of v).contsAux (n + 2) with nextConts_eq
+  have hdn : (of v).dens n = conts.b := by
+    rw [den_eq_conts_b, nth_cont_eq_succ_nth_contAux, conts_eq]
+  have hdn1 : (of v).dens (n + 1) = nextConts.b := by
+    rw [den_eq_conts_b, nth_cont_eq_succ_nth_contAux, nextConts_eq]
+  -- Stream / partial-denominator data at index n.
+  obtain ⟨gp, s_nth_eq⟩ : ∃ gp, (of v).s.get? n = some gp :=
+    Option.ne_none_iff_exists'.1 h
+  have gp_a_eq_one : gp.a = 1 := of_partNum_eq_one (partNum_eq_s_a s_nth_eq)
+  -- Continuant recurrence: Bₙ₊₁ = Bₙ₋₁ + bₙ₊₁ Bₙ.
+  have nextConts_b_eq : nextConts.b = pred_conts.b + gp.b * conts.b := by
+    simp [nextConts_eq, contsAux_recurrence s_nth_eq pred_conts_eq conts_eq, gp_a_eq_one,
+      pred_conts_eq.symm, conts_eq.symm, add_comm]
+  obtain ⟨ifp_succ_n, succ_nth_stream_eq, ifp_succ_n_b_eq_gp_b⟩ :
+      ∃ ifp, IntFractPair.stream v (n + 1) = some ifp ∧ (ifp.b : ℝ) = gp.b :=
+    IntFractPair.exists_succ_get?_stream_of_gcf_of_get?_eq_some s_nth_eq
+  obtain ⟨ifp_n, stream_nth_eq, stream_nth_fr_ne_zero, if_of_eq_ifp_succ_n⟩ :
+      ∃ ifp, IntFractPair.stream v n = some ifp ∧ ifp.fr ≠ 0
+        ∧ IntFractPair.of ifp.fr⁻¹ = ifp_succ_n :=
+    IntFractPair.succ_nth_stream_eq_some_iff.1 succ_nth_stream_eq
+  -- Positivity of the continuant denominators (Fibonacci lower bounds).
+  have conts_b_ineq : (Nat.fib (n + 1) : ℝ) ≤ conts.b :=
+    haveI : ¬(of v).TerminatedAt (n - 1) := mt (terminated_stable n.pred_le) h
+    fib_le_of_contsAux_b <| Or.inr this
+  have zero_lt_conts_b : (0 : ℝ) < conts.b :=
+    conts_b_ineq.trans_lt' <| by exact_mod_cast Nat.fib_pos.2 n.succ_pos
+  have zero_le_pred : (0 : ℝ) ≤ pred_conts.b := by
+    have hfib : (Nat.fib n : ℝ) ≤ pred_conts.b :=
+      haveI : ¬(of v).TerminatedAt (n - 2) := mt (terminated_stable (n.sub_le 2)) h
+      fib_le_of_contsAux_b <| Or.inr this
+    exact le_trans (by positivity) hfib
+  -- Positivity of the n-th fractional part and its inverse.
+  have zero_lt_fr : (0 : ℝ) < ifp_n.fr :=
+    (IntFractPair.nth_stream_fr_nonneg stream_nth_eq).lt_of_ne' stream_nth_fr_ne_zero
+  have zero_lt_fr_inv : (0 : ℝ) < ifp_n.fr⁻¹ := inv_pos.2 zero_lt_fr
+  -- KEY strict bound: frₙ⁻¹ < bₙ₊₁ + 1, since bₙ₊₁ = ⌊frₙ⁻¹⌋.
+  have hb_eq : ((ifp_succ_n.b : ℝ)) = (⌊ifp_n.fr⁻¹⌋ : ℝ) := by
+    rw [← if_of_eq_ifp_succ_n]; simp [IntFractPair.of]
+  have key : ifp_n.fr⁻¹ < (gp.b : ℝ) + 1 := by
+    rw [← ifp_succ_n_b_eq_gp_b, hb_eq]; exact Int.lt_floor_add_one _
+  -- Exact error term |v - convs n| = 1 / (Bₙ (frₙ⁻¹ Bₙ + Bₙ₋₁)).
+  set den' := conts.b * (ifp_n.fr⁻¹ * conts.b + pred_conts.b) with den'_eq
+  have zero_lt_den' : (0 : ℝ) < den' := by rw [den'_eq]; positivity
+  have habs : |v - (of v).convs n| = 1 / den' := by
+    have hEq := sub_convs_eq (v := v) (n := n) stream_nth_eq
+    simp only [stream_nth_fr_ne_zero, if_false, ← conts_eq, ← pred_conts_eq, ← den'_eq] at hEq
+    rw [hEq, abs_div, abs_neg_one_pow, abs_of_pos zero_lt_den']
+  -- Assemble: 1/(Bₙ(Bₙ₊₁+Bₙ)) < 1/den' via den' < Bₙ(Bₙ₊₁+Bₙ).
+  rw [habs, hdn, hdn1]
+  apply one_div_lt_one_div_of_lt zero_lt_den'
+  rw [den'_eq, nextConts_b_eq]
+  nlinarith [key, zero_lt_conts_b, zero_le_pred,
+    mul_pos zero_lt_conts_b zero_lt_conts_b]
+
+/-- **Two-sided convergent bracket.**  Combining the two bounds above:
+`1 / (qₙ (qₙ₊₁ + qₙ)) < |v - pₙ/qₙ| ≤ 1 / qₙ²` for any non-terminating index. -/
+theorem convs_dist_bracket (h : ¬ (of v).TerminatedAt n) :
+    1 / ((of v).dens n * ((of v).dens (n + 1) + (of v).dens n)) < |v - (of v).convs n|
+      ∧ |v - (of v).convs n| ≤ 1 / ((of v).dens n) ^ 2 :=
+  ⟨convs_dist_lower h, convs_dist_le_one_div_den_sq h⟩
 
 end ETranscendentalOQ03OQ01

--- a/research/problems/e-transcendental-oq-03-oq-01/knowledge.md
+++ b/research/problems/e-transcendental-oq-03-oq-01/knowledge.md
@@ -117,15 +117,31 @@ is the remaining deep gap.**
 
 ## Verification status (IMPORTANT — honesty)
 
-This session had **no working Lean build**: Docker daemon was unresponsive
-(`docker info` timed out), no host `elan`/`lake` toolchain was installed, and the
-Aristotle prover API returned HTTP 404 (service down). Therefore the draft file
-`ETranscendentalOQ03OQ01.lean` is **UNVERIFIED** — its upper-bound proof is a
-best-effort attempt against the documented Mathlib API and the lower bound is
-left as a structured `sorry` with the proof sketch above. It is **not wired to
-the gallery** and must be built/verified before any "verified" claim. The survey
-content above (Mathlib lemma inventory + gap analysis) is what this session
-stands behind; it is an API/literature survey that needs no build.
+**RESOLVED 2026-07-02 (researcher-2).** Steps 1–2 (the general, e-independent
+convergent machinery) are now **VERIFIED, 0 axioms**. The file
+`ETranscendentalOQ03OQ01.lean` compiles cleanly under `lake env lean`
+(toolchain v4.26.0) with no errors and no `sorry`. It now contains three
+theorems:
+
+- `convs_dist_le_one_div_den_sq` — upper bound `|v − pₙ/qₙ| ≤ 1/qₙ²`.
+- `convs_dist_lower` — **the Mathlib gap**, the strict lower bound
+  `1/(qₙ(qₙ₊₁+qₙ)) < |v − pₙ/qₙ|` (formerly the `sorry`). Proof: from
+  `sub_convs_eq`, `|v − convs n| = 1/(Bₙ(frₙ⁻¹Bₙ + Bₙ₋₁))`; the strict floor
+  bound `frₙ⁻¹ < ⌊frₙ⁻¹⌋ + 1 = bₙ₊₁ + 1` (via `Int.lt_floor_add_one`, since
+  `bₙ₊₁ = ⌊frₙ⁻¹⌋`) plus the continuant recurrence
+  `Bₙ₊₁ = bₙ₊₁Bₙ + Bₙ₋₁` gives `frₙ⁻¹Bₙ + Bₙ₋₁ < Bₙ₊₁ + Bₙ`; invert positive
+  denominators (`one_div_lt_one_div_of_lt`) and close with `nlinarith`.
+- `convs_dist_bracket` — the assembled two-sided bracket.
+
+Wired to the gallery at `src/data/proofs/e-transcendental-oq-03-oq-01/`
+(status `verified`, badge `original`, axiomCount 0). Note: the `import Mathlib`
+teardown emits a cosmetic SIGSEGV (exit 139) *after* a clean, zero-diagnostic
+elaboration — this is the documented benign teardown crash, not a proof failure.
+
+**Still open (the parent's actual blocker):** Gap 2 — Euler's specific CF
+expansion of e and `aₙ = O(n)` (Hermite/Cohn) — remains absent from Mathlib.
+Until that is formalized, the parent axiom `e_not_liouvilleWith_gt_two` cannot
+be discharged even with this bracket in hand.
 
 ---
 

--- a/src/data/proofs/e-transcendental-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/e-transcendental-oq-03-oq-01/annotations.json
@@ -1,0 +1,135 @@
+[
+  {
+    "id": "ann-etoq0301-overview",
+    "proofId": "e-transcendental-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 32
+    },
+    "type": "concept",
+    "title": "The Convergent Bracket and the Mathlib Gap It Fills",
+    "content": "The header explains why this file exists. The parent entry proves μ(e) = 2 modulo one axiom, e_not_liouvilleWith_gt_two (the μ(e) ≤ 2 direction). Closing that axiom needs a sharp two-sided bound on how well a continued-fraction convergent pₙ/qₙ approximates its target: 1/(qₙ(qₙ₊₁+qₙ)) < |v − pₙ/qₙ| ≤ 1/qₙ². Mathlib already provides the RIGHT inequality (abs_sub_convs_le) and the exact error identity (sub_convs_eq), but NOT the strict LEFT inequality as a public lemma. This file supplies that lower bound (convs_dist_lower) — e-independent and reusable — and assembles the full bracket. The remaining deep obstruction, Euler's specific CF expansion of e, is honestly flagged as outside scope.",
+    "mathContext": "Bracket: $\\frac{1}{q_n(q_{n+1}+q_n)} < |v - p_n/q_n| \\le \\frac{1}{q_n^2}$, $q_n := (\\text{of } v).\\text{dens } n$. Mathlib supplies only the $\\le$ side; the strict $<$ side is the contribution.",
+    "significance": "key",
+    "relatedConcepts": [
+      "continued fractions",
+      "convergents",
+      "Diophantine approximation",
+      "irrationality measure"
+    ],
+    "prerequisites": [
+      "regular continued fractions",
+      "best rational approximation"
+    ]
+  },
+  {
+    "id": "ann-etoq0301-upper",
+    "proofId": "e-transcendental-oq-03-oq-01",
+    "range": {
+      "startLine": 41,
+      "endLine": 61
+    },
+    "type": "key-step",
+    "title": "Upper Bound via Denominator Monotonicity",
+    "content": "convs_dist_le_one_div_den_sq sharpens Mathlib's abs_sub_convs_le. Mathlib gives |v − convs n| ≤ 1/(qₙ qₙ₊₁). Since the convergent denominators are monotone (of_den_mono: qₙ ≤ qₙ₊₁) and positive (succ_nth_fib_le_of_nth_den gives qₙ ≥ fib(n+1) ≥ 1), we have qₙ² ≤ qₙ qₙ₊₁, hence 1/(qₙ qₙ₊₁) ≤ 1/qₙ². The positivity is routed through the Fibonacci lower bound on denominators, and the final inequality is discharged by nlinarith. This is the classical |v − pₙ/qₙ| < 1/qₙ² statement of the best-approximation property.",
+    "mathContext": "$q_n \\ge \\mathrm{fib}(n+1) \\ge 1 > 0$ and $q_n \\le q_{n+1}$ give $q_n^2 \\le q_n q_{n+1}$, so $1/(q_n q_{n+1}) \\le 1/q_n^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "convergent denominators",
+      "Fibonacci bound",
+      "monotonicity"
+    ],
+    "prerequisites": [
+      "GenContFract.abs_sub_convs_le",
+      "denominator monotonicity"
+    ]
+  },
+  {
+    "id": "ann-etoq0301-exact-identity",
+    "proofId": "e-transcendental-oq-03-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 74
+    },
+    "type": "insight",
+    "title": "The Exact Error Identity Drives Both Bounds",
+    "content": "The lower bound (like Mathlib's upper bound) rests on the exact error identity sub_convs_eq: v − convs n = (−1)ⁿ / (Bₙ(frₙ⁻¹Bₙ + Bₙ₋₁)), where Bₙ = qₙ is the n-th continuant denominator, Bₙ₋₁ the previous one, and frₙ the n-th fractional part of the stream. Taking absolute values gives |v − convs n| = 1/(Bₙ(frₙ⁻¹Bₙ + Bₙ₋₁)). The upper and lower bounds differ ONLY in how one bounds the single quantity frₙ⁻¹: the upper bound uses bₙ₊₁ ≤ frₙ⁻¹, the lower bound uses frₙ⁻¹ < bₙ₊₁ + 1. This symmetry is the conceptual heart of the file.",
+    "mathContext": "$|v - \\text{convs } n| = \\dfrac{1}{B_n(fr_n^{-1}B_n + B_{n-1})}$. Bounding $fr_n^{-1}$ above vs. below yields the two sides of the bracket.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "exact error identity",
+      "continuants",
+      "IntFractPair.stream"
+    ],
+    "prerequisites": [
+      "GenContFract.sub_convs_eq",
+      "continuant recurrence"
+    ]
+  },
+  {
+    "id": "ann-etoq0301-floor-bound",
+    "proofId": "e-transcendental-oq-03-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 116
+    },
+    "type": "insight",
+    "title": "Why the Lower Bound Is Strict: frₙ⁻¹ < bₙ₊₁ + 1",
+    "content": "The single fact that makes the lower bound strict is frₙ⁻¹ < bₙ₊₁ + 1. The (n+1)-st partial denominator is defined as bₙ₊₁ = ⌊frₙ⁻¹⌋ (the integer part of the reciprocal of the n-th fractional part — this is exactly the continued-fraction algorithm). Since Int.lt_floor_add_one gives x < ⌊x⌋ + 1 for every real x, we get frₙ⁻¹ < ⌊frₙ⁻¹⌋ + 1 = bₙ₊₁ + 1. In the code, hb_eq identifies bₙ₊₁ (ifp_succ_n.b) with ⌊frₙ⁻¹⌋ by unfolding IntFractPair.of, and key applies the floor inequality. This complements Mathlib's succ_nth_stream_b_le_nth_stream_fr_inv (the ≤ direction), which powers the upper bound.",
+    "mathContext": "$b_{n+1} = \\lfloor fr_n^{-1}\\rfloor$, so $fr_n^{-1} < \\lfloor fr_n^{-1}\\rfloor + 1 = b_{n+1} + 1$ by $x < \\lfloor x\\rfloor + 1$. Contrast: $b_{n+1} \\le fr_n^{-1}$ (Mathlib) gives the upper bound.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "floor function",
+      "continued fraction algorithm",
+      "fractional part in [0,1)"
+    ],
+    "prerequisites": [
+      "Int.lt_floor_add_one",
+      "IntFractPair.of definition"
+    ]
+  },
+  {
+    "id": "ann-etoq0301-assemble",
+    "proofId": "e-transcendental-oq-03-oq-01",
+    "range": {
+      "startLine": 117,
+      "endLine": 133
+    },
+    "type": "key-step",
+    "title": "Assembling the Strict Inequality",
+    "content": "With the exact identity giving |v − convs n| = 1/den' where den' = Bₙ(frₙ⁻¹Bₙ + Bₙ₋₁), the goal reduces (via one_div_lt_one_div_of_lt, both denominators positive) to den' < Bₙ(Bₙ₊₁ + Bₙ). Substituting the continuant recurrence Bₙ₊₁ = Bₙ₋₁ + bₙ₊₁Bₙ, the difference between the two sides is Bₙ² · (bₙ₊₁ + 1 − frₙ⁻¹), which is strictly positive because Bₙ > 0 (Fibonacci bound) and bₙ₊₁ + 1 − frₙ⁻¹ > 0 (the floor bound). nlinarith closes it from the product of Bₙ² > 0 and the floor inequality. Positivity of Bₙ and Bₙ₋₁ comes from fib_le_of_contsAux_b.",
+    "mathContext": "$B_n(B_{n+1}+B_n) - B_n(fr_n^{-1}B_n + B_{n-1}) = B_n^2\\,(b_{n+1}+1 - fr_n^{-1}) > 0$, using $B_{n+1} = B_{n-1} + b_{n+1}B_n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "continuant recurrence",
+      "nlinarith",
+      "positivity of denominators"
+    ],
+    "prerequisites": [
+      "GenContFract.contsAux_recurrence",
+      "one_div_lt_one_div_of_lt"
+    ]
+  },
+  {
+    "id": "ann-etoq0301-bracket",
+    "proofId": "e-transcendental-oq-03-oq-01",
+    "range": {
+      "startLine": 135,
+      "endLine": 141
+    },
+    "type": "concept",
+    "title": "The Reusable Two-Sided Bracket",
+    "content": "convs_dist_bracket packages both bounds into the single statement 1/(qₙ(qₙ₊₁+qₙ)) < |v − pₙ/qₙ| ≤ 1/qₙ². This is the reusable, e-independent object: for any real with controlled convergent-denominator growth (qₙ₊₁/qₙ bounded, equivalently bounded partial quotients), the bracket forces |v − pₙ/qₙ| ≥ c/qₙ², which is exactly the ¬LiouvilleWith p (p > 2) conclusion needed for irrationality measure exactly 2. Applying this to e requires only Euler's CF expansion with aₙ = O(n) — the remaining deep gap the parent axiomatizes.",
+    "mathContext": "Bracket $\\Rightarrow$ (bounded $q_{n+1}/q_n$) $\\Rightarrow$ $|v - p_n/q_n| \\ge c/q_n^2$ $\\Rightarrow$ $\\neg\\text{LiouvilleWith } p\\ v$ for $p > 2$, via Real.exists_rat_eq_convergent.",
+    "significance": "key",
+    "relatedConcepts": [
+      "irrationality measure",
+      "LiouvilleWith",
+      "bounded partial quotients"
+    ],
+    "prerequisites": [
+      "the two bounds above",
+      "best-approximation property of convergents"
+    ]
+  }
+]

--- a/src/data/proofs/e-transcendental-oq-03-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-03-oq-01/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "e-transcendental-oq-03-oq-01",
+  "title": "Continued-Fraction Convergent Bracket for μ(e) = 2",
+  "slug": "e-transcendental-oq-03-oq-01",
+  "description": "A sharp two-sided error bracket 1/(qₙ(qₙ₊₁+qₙ)) < |v - pₙ/qₙ| ≤ 1/qₙ² for the convergents of any real number's regular continued fraction. The strict lower bound is the e-independent ingredient that Mathlib lacks and that the parent entry needs to close the μ(e) ≤ 2 axiom.",
+  "meta": {
+    "author": "Robb Walters (researcher-2)",
+    "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.html",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ETranscendentalOQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "continued-fractions",
+      "diophantine-approximation",
+      "irrationality-measure",
+      "convergents",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "GenContFract.sub_convs_eq",
+        "description": "Exact error identity v - convs n = (-1)^n / (Bₙ(frₙ⁻¹Bₙ + Bₙ₋₁))",
+        "module": "Mathlib.Algebra.ContinuedFractions.Computation.Approximations"
+      },
+      {
+        "theorem": "GenContFract.abs_sub_convs_le",
+        "description": "Upper error bound |v - convs n| ≤ 1/(Bₙ Bₙ₊₁)",
+        "module": "Mathlib.Algebra.ContinuedFractions.Computation.Approximations"
+      },
+      {
+        "theorem": "GenContFract.IntFractPair.succ_nth_stream_b_le_nth_stream_fr_inv",
+        "description": "bₙ₊₁ = ⌊frₙ⁻¹⌋ ≤ frₙ⁻¹; the complementary floor bound frₙ⁻¹ < bₙ₊₁ + 1 supplies the strict half",
+        "module": "Mathlib.Algebra.ContinuedFractions.Computation.Approximations"
+      },
+      {
+        "theorem": "GenContFract.contsAux_recurrence",
+        "description": "Continuant recurrence Bₙ₊₁ = bₙ₊₁ Bₙ + Bₙ₋₁",
+        "module": "Mathlib.Algebra.ContinuedFractions.ContinuantsRecurrence"
+      }
+    ],
+    "originalContributions": [
+      "convs_dist_lower: the strict lower bound 1/(qₙ(qₙ₊₁+qₙ)) < |v - pₙ/qₙ|, which Mathlib does not expose (only the ≤ upper bound abs_sub_convs_le is public)",
+      "convs_dist_le_one_div_den_sq: the sharpened 1/qₙ² upper form via denominator monotonicity",
+      "convs_dist_bracket: the assembled two-sided bracket that pins the approximation quality of numbers with controlled partial-quotient growth",
+      "Fully e-independent formalization of the general convergent machinery underlying the parent's μ(e) ≤ 2 argument"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked from Mathlib's continued-fraction API (only propext / Classical.choice / Quot.sound, the standard foundational axioms). This entry supplies the GENERAL (e-independent) half of closing the parent's e_not_liouvilleWith_gt_two axiom; the remaining deep gap is Euler's specific CF expansion of e (aₙ = O(n)), which is absent from Mathlib.",
+    "lineCount": 142,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**From an exact identity to a two-sided bracket.** The theory of best rational approximation by continued-fraction convergents goes back to Lagrange and Legendre: the convergents pₙ/qₙ of a real number's regular continued fraction are exactly its best rational approximations, and the approximation error is controlled to within a factor of 2 by the reciprocal product of consecutive denominators, |v − pₙ/qₙ| ≍ 1/(qₙ qₙ₊₁). Mathlib formalizes the exact error identity (`sub_convs_eq`) and the upper half of this bracket (`abs_sub_convs_le`, |v − pₙ/qₙ| ≤ 1/(qₙ qₙ₊₁)), but not the matching strict lower bound. That lower bound is precisely what converts 'partial quotients grow at most linearly' into 'the irrationality measure is exactly 2', the argument C. S. Davis used in 1978 to determine μ(e). This entry fills the Mathlib gap with `convs_dist_lower` and assembles the full bracket, delivering the general, e-independent machinery on which the parent entry `e-transcendental-oq-03` depends.",
+    "problemStatement": "Formalize the strict two-sided convergent bracket $\\frac{1}{q_n(q_{n+1}+q_n)} < |v - p_n/q_n| \\le \\frac{1}{q_n^2}$ for the regular continued fraction of an arbitrary real $v$, the general ingredient behind $\\mu(e) \\le 2$.",
+    "text": "For any real v whose regular continued fraction has not terminated at step n, the n-th convergent satisfies 1/(qₙ(qₙ₊₁+qₙ)) < |v − pₙ/qₙ| ≤ 1/qₙ², where qₙ is the n-th convergent denominator.",
+    "proofStrategy": "The upper bound sharpens Mathlib's `abs_sub_convs_le` using denominator monotonicity (`of_den_mono`) and the Fibonacci positivity bound (`succ_nth_fib_le_of_nth_den`). The lower bound is the strict companion of `abs_sub_convs_le`: from the exact error identity `sub_convs_eq`, |v − convs n| = 1/(Bₙ(frₙ⁻¹Bₙ + Bₙ₋₁)); the strict floor bound frₙ⁻¹ < ⌊frₙ⁻¹⌋ + 1 = bₙ₊₁ + 1 together with the continuant recurrence Bₙ₊₁ = bₙ₊₁Bₙ + Bₙ₋₁ gives frₙ⁻¹Bₙ + Bₙ₋₁ < Bₙ₊₁ + Bₙ, and inverting the (positive) denominators yields the strict lower bound.",
+    "keyInsights": [
+      "The lower bound is the STRICT companion of the ≤ upper bound: both come from the same exact identity |v − convs n| = 1/(Bₙ(frₙ⁻¹Bₙ + Bₙ₋₁)), differing only in whether one bounds frₙ⁻¹ above (by bₙ₊₁ + 1) or below (by bₙ₊₁)",
+      "The single arithmetic fact that makes the lower bound strict is frₙ⁻¹ < bₙ₊₁ + 1 — an immediate consequence of bₙ₊₁ = ⌊frₙ⁻¹⌋ and Int.lt_floor_add_one, because the fractional part of frₙ⁻¹ lies in [0,1)",
+      "The bracket is e-independent: it holds for EVERY real whose CF does not terminate at n (in particular every irrational). It is exactly the machinery that turns bounded partial-quotient growth into an irrationality-measure bound",
+      "This closes the tractable half of the parent's remaining axiom e_not_liouvilleWith_gt_two; the genuinely deep half — Euler's CF expansion of e with aₙ = O(n) — remains absent from Mathlib and is the real obstruction",
+      "The lower bound qₙ(qₙ₊₁+qₙ) rather than 2qₙqₙ₊₁ is sharp and elementary: it uses only frₙ⁻¹ < bₙ₊₁ + 1, avoiding any regularity assumption on the partial quotients"
+    ],
+    "prerequisites": [
+      "Regular continued fractions and their convergents",
+      "Diophantine approximation (best-approximation property of convergents)",
+      "Mathlib's GenContFract API (contsAux, dens, IntFractPair.stream)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Module docstring stating the two-sided bracket, its relation to the parent's μ(e) ≤ 2 axiom, and the honest scope (general half formalized; Euler's CF of e remains the deep gap). Imports Mathlib and opens the GenContFract namespace.",
+      "mathContext": "Target: $\\frac{1}{q_n(q_{n+1}+q_n)} < |v - p_n/q_n| \\le \\frac{1}{q_n^2}$ with $q_n := (\\text{of } v).\\text{dens } n$."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Upper Bound: |v − pₙ/qₙ| ≤ 1/qₙ²",
+      "startLine": 41,
+      "endLine": 61,
+      "summary": "`convs_dist_le_one_div_den_sq`: sharpens Mathlib's abs_sub_convs_le (≤ 1/(qₙqₙ₊₁)) to the ≤ 1/qₙ² form using denominator monotonicity of_den_mono (qₙ ≤ qₙ₊₁) and the Fibonacci positivity bound succ_nth_fib_le_of_nth_den.",
+      "mathContext": "From $|v - p_n/q_n| \\le 1/(q_n q_{n+1})$ and $q_n \\le q_{n+1}$ with $q_n \\ge \\mathrm{fib}(n+1) \\ge 1 > 0$, one gets $1/(q_n q_{n+1}) \\le 1/q_n^2$."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Lower Bound: 1/(qₙ(qₙ₊₁+qₙ)) < |v − pₙ/qₙ| (the Mathlib gap)",
+      "startLine": 63,
+      "endLine": 133,
+      "summary": "`convs_dist_lower`: the strict lower bound absent from Mathlib. Derived from the exact identity sub_convs_eq, the continuant recurrence contsAux_recurrence, and the strict floor bound frₙ⁻¹ < bₙ₊₁ + 1 (since bₙ₊₁ = ⌊frₙ⁻¹⌋).",
+      "mathContext": "$|v - \\text{convs } n| = 1/(B_n(fr_n^{-1}B_n + B_{n-1}))$; since $fr_n^{-1} < b_{n+1}+1$ and $B_{n+1} = b_{n+1}B_n + B_{n-1}$, we get $fr_n^{-1}B_n + B_{n-1} < B_{n+1} + B_n$, hence the strict bound after inverting positive denominators."
+    },
+    {
+      "id": "bracket",
+      "title": "The Two-Sided Bracket",
+      "startLine": 135,
+      "endLine": 142,
+      "summary": "`convs_dist_bracket`: packages the lower and upper bounds into the single sharp statement 1/(qₙ(qₙ₊₁+qₙ)) < |v − pₙ/qₙ| ≤ 1/qₙ² for any non-terminating index n.",
+      "mathContext": "The assembled bracket is the reusable, e-independent object: it pins the approximation quality of any real with controlled convergent-denominator growth."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "e-transcendental-oq-03",
+      "relationship": "parent",
+      "description": "Parent entry proving μ(e) = 2 modulo the axiom e_not_liouvilleWith_gt_two (the μ(e) ≤ 2 half). This child supplies the general, e-independent convergent lower bound that half requires."
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "Ancestral entry establishing the transcendence of e; the convergent bracket quantifies the fine approximation structure behind that transcendence."
+    }
+  ],
+  "conclusion": {
+    "summary": "The strict two-sided convergent bracket 1/(qₙ(qₙ₊₁+qₙ)) < |v − pₙ/qₙ| ≤ 1/qₙ² is fully formalized for arbitrary reals, filling the lower-bound gap in Mathlib's continued-fraction approximation API.",
+    "implications": "This delivers the general (e-independent) machinery needed to turn 'partial quotients aₙ = O(n)' into 'irrationality measure ≤ 2'. Combined with a formalization of Euler's CF expansion of e, it would discharge the parent's remaining axiom.",
+    "openQuestions": [
+      "Formalize Euler's regular continued fraction e = [2; 1, 2, 1, 1, 4, ...] and the bound aₙ = O(n) on its partial quotients (Hermite/Cohn), the remaining deep gap.",
+      "Package 'geometric convergent-denominator growth ⟹ ¬LiouvilleWith p for p > 2' as a reusable lemma using this bracket and Real.exists_rat_eq_convergent."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "GenContFract"
+    ],
+    "namespace": "ETranscendentalOQ03OQ01",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/ETranscendentalOQ03OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Davis, C.S.",
+      "title": "Rational approximations to e",
+      "year": "1978",
+      "venue": "Journal of the Australian Mathematical Society (Series A) 25, 497-502",
+      "note": "Uses the two-sided convergent bracket together with the linear growth of e's CF partial quotients to prove μ(e) = 2"
+    },
+    {
+      "authors": "Khinchin, A.Ya.",
+      "title": "Continued Fractions",
+      "year": "1964",
+      "venue": "University of Chicago Press (English translation)",
+      "note": "Standard reference for the best-approximation theory of convergents and the error bracket 1/(qₙ(qₙ₊₁+qₙ)) < |v − pₙ/qₙ| < 1/(qₙqₙ₊₁)"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Algebra.ContinuedFractions.Computation.Approximations",
+      "year": "2024",
+      "venue": "leanprover-community/mathlib4",
+      "note": "Supplies sub_convs_eq (exact error identity) and abs_sub_convs_le (upper bound); the strict lower bound formalized here is the complementary result"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the `convs_dist_lower` `sorry` in the child entry **e-transcendental-oq-03-oq-01** and wires it to the gallery. The file now formalizes the sharp two-sided continued-fraction convergent bracket

$$\frac{1}{q_n(q_{n+1}+q_n)} < \left|v - \frac{p_n}{q_n}\right| \le \frac{1}{q_n^2}$$

for the regular continued fraction of an arbitrary real `v` (any non-terminating index `n`, in particular any irrational).

- **3 theorems, 0 axioms, 0 sorries, 142 lines**, Mathlib v4.26.0.
- `convs_dist_lower` is **the Mathlib gap**: Mathlib exposes only the `≤` upper bound (`abs_sub_convs_le`) and the exact error identity (`sub_convs_eq`), but not the strict lower bound. This entry supplies it — e-independent and reusable.

## Proof

From `GenContFract.sub_convs_eq`, `|v − convs n| = 1/(Bₙ(frₙ⁻¹Bₙ + Bₙ₋₁))`. The strict floor bound `frₙ⁻¹ < ⌊frₙ⁻¹⌋ + 1 = bₙ₊₁ + 1` (via `Int.lt_floor_add_one`, since the (n+1)-st partial denominator is `bₙ₊₁ = ⌊frₙ⁻¹⌋`) together with the continuant recurrence `Bₙ₊₁ = bₙ₊₁Bₙ + Bₙ₋₁` gives `frₙ⁻¹Bₙ + Bₙ₋₁ < Bₙ₊₁ + Bₙ`; inverting the positive denominators (`one_div_lt_one_div_of_lt`) and closing with `nlinarith` yields the strict bound. It is the exact strict companion of Mathlib's `abs_sub_convs_le`.

## Relation to the parent

The parent **e-transcendental-oq-03** proves μ(e) = 2 modulo one axiom, `e_not_liouvilleWith_gt_two` (the μ(e) ≤ 2 half). Closing that axiom needs (1) this general convergent lower bound — **delivered here** — and (2) Euler's specific CF expansion of e with `aₙ = O(n)` (Hermite/Cohn), which is **absent from Mathlib and remains the genuine deep obstruction**. This PR closes the tractable, e-independent half only; the honest scope is documented in the file header, meta, and knowledge.md.

## Verification

`lake env lean Proofs/ETranscendentalOQ03OQ01.lean` (Mathlib v4.26.0) — clean, zero-diagnostic elaboration, no errors, no `sorry`. Proof uses only Mathlib lemmas + standard tactics (`nlinarith`, `positivity`, `simp`, `rw`); no `axiom`, no `native_decide` → 0 real axioms.

## Files
- `proofs/Proofs/ETranscendentalOQ03OQ01.lean` — completed proof (was UNVERIFIED draft with 1 sorry)
- `src/data/proofs/e-transcendental-oq-03-oq-01/{meta.json,annotations.json}` — new gallery entry (status `verified`, badge `original`)
- `research/problems/e-transcendental-oq-03-oq-01/knowledge.md` — updated verification status

🤖 Generated with [Claude Code](https://claude.com/claude-code)