### PR TITLE
Fix: add missing gallery entry for abundant-number-oq-02-oq-01

### DIFF
--- a/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "abundant-number-oq-02-oq-01",
+  "title": "The Smallest Odd Abundant Number Coprime to 3 Is 5391411025",
+  "slug": "abundant-number-oq-02-oq-01",
+  "description": "A positive integer n is abundant when σ(n) > 2n. The smallest odd abundant number is 945 = 3³·5·7, but once the factor 3 is forbidden the smallest example jumps to 5391411025 = 5²·7·11·13·17·19·23·29. This entry proves, fully machine-checked with 0 axioms and 0 sorries, that 5391411025 is the least odd abundant number coprime to 3: it is itself odd, abundant and coprime to 3 (the witness / upper-bound half, via multiplicativity of σ — no native_decide, so no Lean.ofReduceBool), and every odd abundant number coprime to 3 is at least 5391411025 (the unconditional lower-bound half, odd_abundant_coprime_three_ge_witness). The lower bound is assembled from a chain of structural results developed across nine files: ω(n) ≥ 7 distinct prime factors, a radical magnitude bound n ≥ 37182145, sharpened exponent bounds (25 ∣ n, 49 ∣ n forced), and an exhaustive case analysis of the residual ω = 7 prime support. The squarefree sub-case is resolved exactly as well: IsLeast over squarefree odd numbers coprime to 3 is 33426748355 = 5·7·11·13·17·19·23·29·31.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abundant_number",
+    "date": "Classical; OEIS A005231 (odd abundant numbers), A047802 (least abundant coprime to first k primes)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbundantNumberOQ02OQ01.lean",
+    "badge": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-sum",
+      "abundant-numbers",
+      "abundancy-index",
+      "multiplicative-functions",
+      "advanced"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 2423,
+    "theoremCount": 94,
+    "definitionCount": 7,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "additionalFiles": [
+      "Proofs/AbundantNumberOQ02OQ01Unconditional.lean",
+      "Proofs/AbundantNumberOQ02OQ01ExponentBound.lean",
+      "Proofs/AbundantNumberOQ02OQ01OmegaSevenPrimes.lean",
+      "Proofs/AbundantNumberOQ02OQ01Minimality.lean",
+      "Proofs/AbundantNumberOQ02OQ01LowerBound.lean",
+      "Proofs/AbundantNumberOQ02OQ01GeneralBound.lean",
+      "Proofs/AbundantNumberOQ02OQ01SevenPrimeExponents.lean",
+      "Proofs/AbundantNumberOQ02OQ01Squarefree.lean"
+    ],
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries across all nine files. Abundance of the witness is established via multiplicativity of σ (isMultiplicative_sigma), splitting 5391411025 into its coprime prime-power factors so each σ-atom is a trivial divisor-sum computation — no native_decide is used anywhere, so the result carries no Lean.ofReduceBool axiom. Every #print axioms in the family reports only the standard foundational axioms propext / Classical.choice / Quot.sound. Small finite facts (e.g. σ of a prime power, oddness, non-divisibility by 3) use kernel decide, not native_decide.",
+    "originalContributions": [
+      "Proves the full resolution of the open question: 5391411025 = 5²·7·11·13·17·19·23·29 is the least odd abundant number coprime to 3. The upper-bound half (mem_odd_three_free_abundant) certifies membership; the lower-bound half (odd_abundant_coprime_three_ge_witness: Odd n → ¬ 3∣n → Abundant n → 5391411025 ≤ n) certifies minimality — together they pin the exact value axiom-free.",
+      "Establishes abundance of the ten-digit witness without any enumeration over its ≈5.4·10⁹ range: σ(5391411025) = 10799308800 is assembled from the eight tiny atoms σ(5²)=31, σ(7)=8, …, σ(29)=30 via multiplicativity of σ, giving 10799308800 > 10782822050 = 2·5391411025 (an abundance margin of only 16486750, ratio ≈ 2.00306).",
+      "Proves the structural lower bound ω(n) ≥ 7: every odd abundant number coprime to 3 has at least 7 distinct prime factors (odd_abundant_coprime_three_seven_primeFactors), because the abundancy index ∏ p/(p−1) over the six smallest admissible primes 5,7,11,13,17,19 stays below 2. This is upgraded to the radical magnitude bound n ≥ 37182145 = 5·7·11·13·17·19·23 (odd_abundant_coprime_three_ge).",
+      "Sharpens the exponent structure: forces 25 ∣ n and 49 ∣ n for the extremal shapes (five_sq_dvd, seven_sq_dvd in SevenPrimeExponents; omega_seven_imp_five_sq_dvd in ExponentBound) via sharp rational Euler-product inequalities, then closes the residual ω = 7 prime-support case by exhaustive analysis of four explicit prime sets (omega_seven_residual_ge_sharp), yielding the unconditional bound.",
+      "Resolves the squarefree sub-problem exactly: squarefree_odd_abundant_coprime_three_least proves IsLeast {n | Squarefree n ∧ Odd n ∧ ¬3∣n ∧ Nat.Abundant n} 33426748355. Forbidding repeated prime factors removes the exponent-boosting trick (index becomes ∏ (p+1)/p), forcing ≥ 9 distinct primes and the sharp squarefree minimum 5·7·11·13·17·19·23·29·31."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The classification of integers as deficient (σ(n) < 2n), perfect (σ(n) = 2n), or abundant (σ(n) > 2n) dates to Nicomachus of Gerasa (~100 CE). Odd abundant numbers are already rare — the smallest is 945 = 3³·5·7 (OEIS A005231) — and the rarity intensifies dramatically when small primes are excluded. The sequence A047802 records the least abundant number coprime to the first k primes; forbidding 2 gives 945, and additionally forbidding 3 gives 5391411025. The phenomenon is structural: to make the abundancy index σ(n)/n = ∏_{p^a ‖ n} (p^{a+1}−1)/(p^a(p−1)) exceed 2, a number must accumulate enough small-prime contributions. Removing 2 forfeits a factor as large as 2, and removing 3 forfeits another 3/2, so the surplus must be assembled from primes ≥ 5, which is expensive — the eight-prime witness 5²·7·11·13·17·19·23·29 clears 2 only by a hair (≈ 2.003).",
+    "problemStatement": "Working with Mathlib's Nat.Abundant n (n < ∑_{d ∈ properDivisors n} d), determine the least odd abundant number coprime to 3, i.e. the least element of {n | Odd n ∧ ¬ 3∣n ∧ Nat.Abundant n}, and prove the answer axiom-free — in particular without native_decide, whose Lean.ofReduceBool axiom would downgrade the result from verified to axiomatized. Brute force is hopeless: the witness is ≈ 5.4·10⁹ and even a kernel-reducible σ cannot enumerate that range.",
+    "text": "A Lean 4 / Mathlib formalization spanning nine files (2423 lines, 0 sorries, 0 axioms). Because the witness is a ten-digit number, the proof abandons enumeration entirely and works multiplicatively. The upper bound (parent file AbundantNumberOQ02OQ01.lean) certifies that 5391411025 is odd, coprime to 3, and abundant by computing σ from its coprime prime-power atoms. The lower bound is the hard direction and is built up across the companion files: an abundancy-index argument forces ω(n) ≥ 7 (Unconditional), a radical bound n ≥ 37182145 (LowerBound), a ×5 refinement to n ≥ 185910725 (GeneralBound), sharp exponent constraints 25 ∣ n and 49 ∣ n (ExponentBound, SevenPrimeExponents), a reduction of the residual ω = 7 case to four explicit prime sets (OmegaSevenPrimes, Minimality), and finally the assembly odd_abundant_coprime_three_ge_witness giving n ≥ 5391411025 unconditionally. Combined with the witness, this pins the least value exactly. The squarefree restriction is resolved independently and exactly (Squarefree).",
+    "proofStrategy": "1. **Upper bound (witness).** N = 5391411025 = 25·7·11·13·17·19·23·29. Repeated map_mul_of_coprime for isMultiplicative_sigma reduces σ(N) to the product of the eight atoms σ(25)=31, σ(7)=8, σ(11)=12, σ(13)=14, σ(17)=18, σ(19)=20, σ(23)=24, σ(29)=30 = 10799308800; abundant_iff_two_mul_lt_sigma turns Nat.Abundant N into 2N < σ(N), and 2·5391411025 = 10782822050 < 10799308800. Oddness and ¬3∣N are kernel decide.\n\n2. **ω ≥ 7.** Over primes p ≥ 5 the local Euler factor p/(p−1) is largest at p = 5,7,11,13,17,19; their product < 2, so any n with ≤ 6 such prime factors has σ(n)/n < 2 and is not abundant (odd_abundant_coprime_three_seven_primeFactors). Hence n has ≥ 7 distinct primes ≥ 5, giving the radical bound n ≥ 5·7·11·13·17·19·23 = 37182145 (odd_abundant_coprime_three_ge).\n\n3. **Exponent sharpening.** A refined rational Euler-product inequality (refined_euler_set, prod_primeFactors_f_lt_sharp) shows the minimal-exponent square-free skeleton on 7 primes falls short of 2, forcing extra multiplicity: 25 ∣ n (five_sq_dvd) and, in the tightest shapes, 49 ∣ n (seven_sq_dvd). GeneralBound turns the exponent gain into the magnitude bounds n ≥ 185910725 and the ω ≥ 8 shape bound n ≥ 5391411025.\n\n4. **Residual ω = 7.** The remaining ω = 7 support is pinned to four explicit prime sets (omega_seven_prime_support, exp_not_all_minimal); a finite check on each (omega_seven_residual_ge_sharp) shows every resulting n is ≥ 5391411025.\n\n5. **Assembly.** odd_abundant_coprime_three_ge_witness: an odd abundant n coprime to 3 below the witness would fall into one of the exhaustive shapes, each ≥ 5391411025 — contradiction (by_contra + omega). With the witness this gives the exact least value.\n\n6. **Squarefree case.** Without repeated primes the index is ∏ (p+1)/p; the eight smallest primes ≥ 5 give ≈ 1.938 < 2, forcing ≥ 9 distinct primes, so the squarefree minimum is exactly 5·7·11·13·17·19·23·29·31 = 33426748355 (squarefree_odd_abundant_coprime_three_least, an IsLeast).",
+    "keyInsights": [
+      "**Multiplicativity beats enumeration.** The witness is ≈ 5.4·10⁹, far beyond any kernel or compiled divisor enumeration. Splitting N into coprime prime powers and assembling σ(N) from eight one-line atoms via isMultiplicative_sigma settles abundance in a handful of arithmetic steps — and, crucially, without native_decide, keeping the result free of Lean.ofReduceBool.",
+      "**The lower bound is an abundancy-index inequality, not a search.** The abundancy index σ(n)/n = ∏_{p∣n} (local Euler factor) is monotone in the primes present. Bounding the product over the smallest admissible primes below 2 immediately forces more (or higher-power) primes, converting 'n is abundant' into hard combinatorial constraints on its prime support — the engine behind ω ≥ 7 and the exponent bounds.",
+      "**Forbidding 3 is expensive.** The smallest odd abundant number is 945 (three primes); forbidding the factor 3 as well raises the minimum by six orders of magnitude to 5391411025 (eight primes). Each excluded small prime removes a large chunk of the abundancy index that must then be recovered from many larger primes.",
+      "**Repeated primes buy abundancy cheaply.** The overall minimum 5²·7·11·13·17·19·23·29 is NOT squarefree: the repeated 5² contributes σ(25)/25 = 31/25 = 1.24, more than a fresh prime like 31 would (32/31 ≈ 1.032), so using 5² lets the witness get by with only 8 primes. The squarefree minimum, denied this trick, needs 9 primes and is over six times larger (33426748355).",
+      "**Axiom-free at scale means multiplicative structure, not a faster decide.** For the n < 945 problem a kernel-reducible σ made a bounded decide feasible. At ≈ 5.4·10⁹ no decide of any kind is viable, so axiom-freeness is achieved by replacing computation with the number theory of the multiplicative σ and the abundancy index — a template for pinning extremal values of arithmetic functions well beyond enumeration range."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ, its multiplicativity, and the abundancy index σ(n)/n",
+      "Abundant / deficient / perfect classification and Mathlib's Nat.Abundant / ArithmeticFunction.sigma",
+      "Prime factorizations, ω(n) = n.primeFactors.card, radicals, and squarefree numbers",
+      "Euler-product / rational inequality manipulation and finite case analysis over prime supports"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "odd_abundant_coprime_three_ge_witness",
+      "type": "core",
+      "description": "Unconditional exact lower bound: every odd abundant number coprime to 3 is at least 5391411025 = 5²·7·11·13·17·19·23·29. Assembled from the squarefree case (≥ 33426748355), the ω ≥ 8 case (≥ 5391411025), and the residual ω = 7 case (≥ 5391411025). Together with the witness's membership this makes 5391411025 the least such number. Axiom-free.",
+      "leanType": "Odd n → ¬ (3 ∣ n) → Nat.Abundant n → 5391411025 ≤ n"
+    },
+    {
+      "name": "mem_odd_three_free_abundant",
+      "type": "core",
+      "description": "Membership / upper-bound certificate: 5391411025 is odd, coprime to 3, and abundant, hence belongs to {n | Odd n ∧ ¬ 3∣n ∧ Nat.Abundant n}. Establishes the witness as an upper bound for the least such number.",
+      "leanType": "N ∈ {n : ℕ | Odd n ∧ ¬ (3 ∣ n) ∧ Nat.Abundant n}"
+    },
+    {
+      "name": "abundant_N",
+      "type": "supporting",
+      "description": "5391411025 is abundant. σ(N) = 10799308800 > 10782822050 = 2N, computed via multiplicativity of σ from the eight prime-power atoms — no enumeration, no native_decide.",
+      "leanType": "Nat.Abundant N"
+    },
+    {
+      "name": "odd_abundant_coprime_three_seven_primeFactors",
+      "type": "supporting",
+      "description": "Every odd abundant number coprime to 3 has at least 7 distinct prime factors, because the abundancy index over the six smallest admissible primes 5,7,11,13,17,19 stays below 2.",
+      "leanType": "Odd n → ¬ (3 ∣ n) → Nat.Abundant n → 7 ≤ n.primeFactors.card"
+    },
+    {
+      "name": "odd_abundant_coprime_three_ge",
+      "type": "supporting",
+      "description": "Radical magnitude bound: an odd abundant number coprime to 3 is at least 37182145 = 5·7·11·13·17·19·23, the product of the seven smallest admissible primes.",
+      "leanType": "Odd n → ¬ (3 ∣ n) → Nat.Abundant n → 37182145 ≤ n"
+    },
+    {
+      "name": "squarefree_odd_abundant_coprime_three_least",
+      "type": "supporting",
+      "description": "Exact resolution of the squarefree sub-problem: the least squarefree odd abundant number coprime to 3 is 33426748355 = 5·7·11·13·17·19·23·29·31. Without repeated primes the abundancy index ∏ (p+1)/p over the eight smallest admissible primes is < 2, forcing ≥ 9 distinct primes.",
+      "leanType": "IsLeast {n : ℕ | Squarefree n ∧ Odd n ∧ ¬ (3 ∣ n) ∧ Nat.Abundant n} 33426748355"
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry pins the least odd abundant number coprime to 3 at exactly 5391411025 = 5²·7·11·13·17·19·23·29, fully machine-checked with 0 axioms and 0 sorries across nine files. The upper bound computes σ(5391411025) = 10799308800 > 2·5391411025 via multiplicativity of σ (no enumeration, no native_decide); the lower bound odd_abundant_coprime_three_ge_witness is built from an abundancy-index chain — ω(n) ≥ 7, radical bound n ≥ 37182145, forced multiplicities 25 ∣ n and 49 ∣ n, and an exhaustive residual ω = 7 analysis. The squarefree sub-case is resolved exactly at 33426748355.",
+    "implications": "The proof answers the open follow-up recorded in abundant-number-oq-02 (smallest odd abundant is 945): forbidding the factor 3 as well pushes the minimum up by six orders of magnitude, and the answer is established axiom-free despite lying at ≈ 5.4·10⁹, entirely beyond enumeration. The technique — replace bounded computation with the multiplicative structure of σ and monotonicity of the abundancy index — is a reusable template for pinning extremal values of arithmetic functions (least k-fold abundant numbers, primitive abundant numbers, abundancy-threshold problems) far above any decide-feasible range.",
+    "openQuestions": [
+      "Extend the coprimality restriction one step further: determine the least odd abundant number coprime to 15 (i.e. to both 3 and 5), whose minimum is larger still and whose abundancy-index chain requires yet more primes.",
+      "Formalize a general lower-bound theorem for the least abundant number coprime to the first k primes (OEIS A047802), unifying the 945 and 5391411025 cases as instances of a single primorial-driven abundancy-index estimate.",
+      "Prove a density or counting statement for odd abundant numbers coprime to 3, or connect the extremal witness to the theory of primitive abundant numbers."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Nicomachus of Gerasa",
+      "title": "Introduction to Arithmetic",
+      "year": "~100 CE",
+      "venue": "—",
+      "note": "Earliest classification of numbers as deficient, perfect, and abundant."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A047802: Least abundant number not divisible by any of the first n primes",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "a(1) = 945 (odd abundant), a(2) = 5391411025 (odd abundant coprime to 3) — the witness proved least here."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A005231: Odd abundant numbers",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "The odd abundant numbers 945, 1575, 2205, … whose 3-free members this entry bounds below by 5391411025."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abundant-number-oq-02",
+      "relationship": "extends",
+      "description": "The oq-02 entry proves 945 = 3³·5·7 is the smallest odd abundant number and records as an open follow-up the much larger smallest odd abundant number NOT divisible by 3. This entry settles exactly that follow-up, proving the answer is 5391411025 axiom-free."
+    },
+    {
+      "targetId": "abundant-number-oq-01",
+      "relationship": "related",
+      "description": "The oq-01 entry proves 12 is the smallest abundant number and discusses the abundancy index σ(n)/n. This entry pushes the same abundancy-index viewpoint to the far harder 3-free odd setting, where enumeration is impossible and the bound is derived structurally."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AbundantNumberOQ02OQ01.lean",
+    "namespace": "AbundantNumberOQ02OQ01",
+    "imports": [
+      "Mathlib"
+    ],
+    "lineCount": 114,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 14,
+    "definitionCount": 1
+  }
+}


### PR DESCRIPTION
## Fix

Adds the missing `src/data/proofs/abundant-number-oq-02-oq-01/` gallery entry so the fully-resolved result becomes visible on the site.

## Evidence

**Before**: Nine files (`AbundantNumberOQ02OQ01.lean` + 8 companions, 2423 lines total, all merged and marked `[VERIFIED, 0-axiom]` — PRs #30378, #31116, #31175, #31350, #31518, #31583, #31595, plus the `Squarefree` file under a mislabeled erdos-1110 commit) proved that **5391411025 = 5²·7·11·13·17·19·23·29 is the smallest odd abundant number coprime to 3**, but there was no `src/data/proofs/abundant-number-oq-02-oq-01/` directory. The proof was completely invisible in the gallery.

**After**: `meta.json` created (`status: verified`, `badge: verified`, `axiomCount: 0`, `sorries: 0`), modeled on the sibling `abundant-number-oq-02` schema, with:
- `proofRepoPath` = the anchor witness file `Proofs/AbundantNumberOQ02OQ01.lean`
- all 8 companions listed under `meta.additionalFiles`
- `mainTheorems` for the upper bound (`mem_odd_three_free_abundant`), the unconditional lower bound (`odd_abundant_coprime_three_ge_witness`), and the supporting chain (ω ≥ 7, radical bound, squarefree `IsLeast`).

Verified 0-axiom / 0-sorry: every `sorry`/`native_decide` occurrence in the nine files is comment prose ("no native_decide, no sorry"); each file carries a `#print axioms` audit confirming only propext / Classical.choice / Quot.sound.

`pnpm annotations:build` parses the new entry with no errors.

---
Automated fix by lean-mechanic agent.