### PR TITLE
Enrich p-series-convergence-oq-01: keyInsights + conclusion + sections

### DIFF
--- a/src/data/proofs/p-series-convergence-oq-01/meta.json
+++ b/src/data/proofs/p-series-convergence-oq-01/meta.json
@@ -63,10 +63,12 @@
     "problemStatement": "**Theorem (p-series test).** For a real exponent p, the series\n\n$$\\sum_{n=1}^{\\infty} \\frac{1}{n^p}$$\n\nis summable **if and only if** $p > 1$.\n\nIn particular the harmonic series ($p = 1$) diverges, while every exponent strictly above $1$ — such as the Basel exponent $p = 2$ — yields a convergent series. The exponent $p = 1$ marks the sharp boundary of convergence.",
     "text": "This entry packages the classical p-series convergence dichotomy as a single coherent topic, drawing on Mathlib's p-series engine. The headline statement `pSeries_summable_iff_one_lt` uses the real power `Real.rpow` to give the sharp threshold: $\\sum 1/n^p$ is summable iff $1 < p$, delegating to `Real.summable_one_div_nat_rpow`. Two specializations follow — `pSeries_nat_summable_iff_one_lt` for a natural-number exponent (ordinary monoid power) and `pSeries_int_summable_iff_one_lt` for the two-sided $\\mathbb{Z}$-indexed series — each a thin wrapper over the corresponding Mathlib lemma. The convergence half is extracted as `pSeries_summable_of_one_lt`, and the boundary case is recorded twice: `harmonic_not_summable` shows the harmonic series $\\sum 1/n$ is *not* summable (so $1 < p$ cannot be relaxed to $1 \\le p$), and `harmonic_eq_pSeries_one` identifies it as the $p = 1$ instance. Finally `pSeries_basel_summable` specializes to the Basel exponent $p = 2$, confirming $\\sum 1/n^2$ converges. All seven results are fully machine-checked against Mathlib v4.26.0 with no additional axioms and no sorries.",
     "proofStrategy": "Every statement reduces to Mathlib's p-series library. The real-exponent threshold is `Real.summable_one_div_nat_rpow`; the natural- and integer-index forms are `Real.summable_one_div_nat_pow` and `Real.summable_one_div_int_pow`. These are themselves proved in Mathlib via the Cauchy condensation / integral test, which compares the dyadic blocks $[2^k, 2^{k+1})$ of the series against a geometric series with ratio $2^{1-p}$: the geometric series converges iff $2^{1-p} < 1$, i.e. iff $p > 1$. The harmonic divergence corollary rewrites `Real.not_summable_one_div_natCast` up to the definitional shape of $1/n$, and the Basel corollary applies the natural-exponent iff at $p = 2$ with a `norm_num` discharge of $1 < 2$.",
-    "openQuestions": [
-      "The convergent values ∑ 1/n^{2k} are rational multiples of π^{2k} (Euler); the odd zeta values ∑ 1/n^{2k+1} are far more mysterious — is ζ(5) irrational? (ζ(3) irrational is Apéry, 1979.)",
-      "How slowly does the p-series diverge as p → 1⁺? The sum behaves like 1/(p−1), linking the boundary to the simple pole of the Riemann zeta function at s = 1.",
-      "Can the sharp threshold be refined along the boundary itself, e.g. ∑ 1/(n (ln n)^q) converging iff q > 1 (the logarithmic p-series)?"
+    "keyInsights": [
+      "**A sharp phase transition at p = 1.** The p-series test is the cleanest example of a convergence threshold: ∑ 1/nᵖ converges for every p > 1 and diverges for every p ≤ 1, with no gap and no ambiguity. The boundary p = 1 belongs to the divergent side, so the theorem is genuinely an iff, not a one-sided bound.",
+      "**The real-exponent (rpow) form is the master statement.** Phrasing the threshold with Real.rpow (pSeries_summable_iff_one_lt) covers all real p at once; the natural- and integer-exponent versions are thin specializations. This is why the entry leads with the rpow form and derives the others.",
+      "**The engine is Cauchy condensation / the integral test.** Mathlib proves these lemmas by comparing the dyadic blocks [2^k, 2^{k+1}) of ∑ 1/nᵖ against a geometric series of ratio 2^{1−p}; that geometric series converges iff 2^{1−p} < 1, i.e. iff p > 1. The sharp threshold is thus the geometric-series threshold in disguise.",
+      "**The harmonic series is the load-bearing boundary witness.** harmonic_not_summable (p = 1 diverges) is exactly what forbids relaxing 1 < p to 1 ≤ p. harmonic_eq_pSeries_one pins it as the p = 1 instance, making the boundary case explicit rather than folklore.",
+      "**Basel is the first convergent instance.** p = 2 lies just above the threshold, so ∑ 1/n² converges — and its value π²/6 (Euler, 1735) is the historical seed of the whole zeta-function story. The entry records convergence; the exact value is the sibling Basel entry."
     ]
   },
   "references": [
@@ -120,5 +122,52 @@
       "leanType": "Summable (fun n : ℕ => 1 / (n : ℝ) ^ p) ↔ 1 < p"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The p-series ∑ 1/nᵖ converges if and only if p > 1. This entry packages that dichotomy from Mathlib's p-series engine: the sharp real-exponent (rpow) threshold pSeries_summable_iff_one_lt, its natural- and integer-index specializations, the convergence half pSeries_summable_of_one_lt, the harmonic boundary case (harmonic_not_summable, identified as the p = 1 instance), and the Basel exponent p = 2 as a convergent corollary. All 7 results are machine-checked against Mathlib v4.26.0 with 0 axioms and 0 sorries.",
+    "implications": [
+      "Provides the canonical convergence-threshold reference in the gallery, unifying the harmonic-divergence and Basel-problem entries under a single iff with the boundary case made explicit.",
+      "Exhibits the sharp geometric-series mechanism behind figurate convergence tests: the dyadic comparison ratio 2^{1−p} crosses 1 exactly at p = 1, which is why the threshold is sharp and the boundary divergent.",
+      "Anchors the analytic continuation story of the Riemann zeta function ζ(s) = ∑ 1/nˢ: the p-series test is precisely the statement that ζ converges on the real axis for s > 1, with the pole at s = 1 shadowed by the harmonic divergence."
+    ],
+    "openQuestions": [
+      "The convergent values ∑ 1/n^{2k} are rational multiples of π^{2k} (Euler); the odd zeta values ∑ 1/n^{2k+1} are far more mysterious — is ζ(5) irrational? (ζ(3) irrational is Apéry, 1979.)",
+      "How slowly does the p-series diverge as p → 1⁺? The sum behaves like 1/(p−1), linking the boundary to the simple pole of the Riemann zeta function at s = 1.",
+      "Can the sharp threshold be refined along the boundary itself, e.g. ∑ 1/(n (ln n)^q) converging iff q > 1 (the logarithmic p-series)?"
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "The Dichotomy and Main Results",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Module docstring stating the p-series convergence dichotomy (∑ 1/nᵖ converges iff 1 < p), noting the harmonic series as the p = 1 boundary and Basel p = 2 as a convergent instance, and listing the seven main results. All reduce to Mathlib's p-series engine.",
+      "mathContext": "$\\sum_{n=1}^{\\infty} 1/n^p$ summable $\\iff p > 1$."
+    },
+    {
+      "id": "sharp-threshold",
+      "title": "The Sharp Threshold and Its Index Variants",
+      "startLine": 33,
+      "endLine": 56,
+      "summary": "The headline pSeries_summable_iff_one_lt uses Real.rpow for a real exponent (delegating to Real.summable_one_div_nat_rpow), then pSeries_nat_summable_iff_one_lt (natural exponent, monoid power) and pSeries_int_summable_iff_one_lt (two-sided ℤ-indexed) specialize it via the corresponding Mathlib lemmas.",
+      "mathContext": "Real form $\\mathrm{Summable}(n \\mapsto 1/n^p) \\iff 1 < p$; ℕ- and ℤ-indexed variants are specializations."
+    },
+    {
+      "id": "convergence-and-boundary",
+      "title": "Convergence Half and the Harmonic Boundary",
+      "startLine": 58,
+      "endLine": 74,
+      "summary": "pSeries_summable_of_one_lt extracts the usable convergence direction (1 < p ⇒ summable). harmonic_not_summable shows the harmonic series ∑ 1/n diverges — the p = 1 boundary — so 1 < p cannot relax to 1 ≤ p; harmonic_eq_pSeries_one identifies ∑ 1/n as the p = 1 instance.",
+      "mathContext": "$\\sum 1/n$ not summable: the boundary $p = 1$ lies on the divergent side."
+    },
+    {
+      "id": "basel",
+      "title": "The Basel Exponent",
+      "startLine": 76,
+      "endLine": 82,
+      "summary": "pSeries_basel_summable specializes the natural-exponent threshold to p = 2 (discharging 1 < 2 by norm_num), confirming ∑ 1/n² converges — the convergence claim behind Euler's Basel evaluation π²/6.",
+      "mathContext": "$p = 2 > 1 \\Rightarrow \\sum 1/n^2$ converges (Basel; value $\\pi^2/6$)."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for p-series-convergence-oq-01 (The p-Series Convergence Test).

## Gaps addressed
- **`overview.keyInsights` was empty** (the Key Insights panel rendered nothing) → added 5 substantive insights: the sharp phase transition at p=1, why the rpow real-exponent form is the master statement, the Cauchy-condensation/integral-test mechanism (dyadic ratio 2^{1−p}), the harmonic series as the load-bearing boundary witness, and Basel p=2 as the first convergent instance.
- **`openQuestions` lived under `overview`**, where `ProofOverview` never renders them → moved into a new **`conclusion`** object (summary + 3 implications + the 3 openQuestions), which `ProofConclusion` renders.
- **No `sections`** → added 4 sections mapping the full 82-line Lean file, each with a `mathContext`.

Overview prose (historicalContext, problemStatement, proofStrategy, text) and the 6 annotations were already well-enriched. Section line ranges verified against `Proofs/PSeriesConvergenceOQ01.lean`. meta.json 12.9 KB, under the 60 KB cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)