### PR TITLE
research(basel-problem-oq-06): ζ(4)=π⁴/90 + even/odd fourth-power sums [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/BaselProblemOQ06.lean
+++ b/proofs/Proofs/BaselProblemOQ06.lean
@@ -1,0 +1,128 @@
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.NumberTheory.LSeries.HurwitzZetaValues
+import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Topology.Algebra.InfiniteSum.NatInt
+import Mathlib.Analysis.PSeries
+import Mathlib.Tactic
+
+/-!
+# Riemann Zeta at Four: ζ(4) = π⁴/90
+
+## What This Proves
+Euler's evaluation of the Riemann zeta function at `s = 4`:
+
+  ζ(4) = ∑_{n=1}^∞ 1/n⁴ = π⁴/90,
+
+recorded both as a real series (`HasSum` / `tsum`) and as the value of the
+complex `riemannZeta 4`.  This is the fourth-power companion of the Basel
+problem ζ(2) = π²/6.
+
+## Original corollaries (not in Mathlib)
+Mathlib already supplies the headline value (`hasSum_zeta_four`,
+`riemannZeta_four`).  The new mathematical content of this entry is the
+even/odd decomposition of the ζ(4) series, exactly parallel to the ζ(2) →
+π²/8 odd-squares result:
+
+  * **Sum of reciprocal even fourth powers**  ∑_{k} 1/(2k)⁴ = π⁴/1440
+    (the ζ(4) series scaled by 1/16).
+  * **Sum of reciprocal odd fourth powers**   ∑_{k} 1/(2k+1)⁴ = π⁴/96
+    (the "odd zeta value" λ(4); obtained as π⁴/90 − π⁴/1440).
+
+## Approach
+No new analysis beyond Mathlib's `hasSum_zeta_four`.  The even subsequence
+`k ↦ 1/(2k)⁴ = (1/16)·(1/k⁴)` is the original series scaled by `1/16`; the
+`HasSum.even_add_odd` decomposition then pins the odd tail by uniqueness of
+infinite sums:  π⁴/1440 + (odd) = π⁴/90, so the odd sum is π⁴/96.
+
+## Status
+- [x] Complete proof (0 sorries, 0 axioms)
+- [x] Uses Mathlib for the underlying ζ(4) identity
+
+## Mathlib Dependencies
+- `hasSum_zeta_four` : ∑ 1/n⁴ = π⁴/90
+- `riemannZeta_four` : riemannZeta 4 = π⁴/90
+- `HasSum.even_add_odd`, `HasSum.mul_left`, `HasSum.unique`
+
+Original formalization for Lean Genius.
+-/
+
+namespace BaselProblemOQ06
+
+open Filter Topology Real
+
+/-- The base summand `f n = 1/n⁴`. -/
+private noncomputable def f (n : ℕ) : ℝ := 1 / (n : ℝ) ^ 4
+
+/-- **ζ(4) as a real series** (Mathlib): `∑ 1/n⁴ = π⁴/90`. -/
+theorem zeta_four_hasSum : HasSum f (π ^ 4 / 90) := hasSum_zeta_four
+
+/-- **ζ(4) as a `tsum`**: `∑' n, 1/n⁴ = π⁴/90`. -/
+theorem zeta_four_tsum : ∑' n : ℕ, f n = π ^ 4 / 90 :=
+  zeta_four_hasSum.tsum_eq
+
+/-- **ζ(4) as a value of the complex zeta function** (Mathlib):
+`riemannZeta 4 = π⁴/90`. -/
+theorem riemannZeta_four_value : riemannZeta 4 = (π : ℂ) ^ 4 / 90 :=
+  riemannZeta_four
+
+/-- **Sum of reciprocal even fourth powers**: `∑_{k} 1/(2k)⁴ = π⁴/1440`.
+
+Each even-indexed term is `1/(2k)⁴ = (1/16)·(1/k⁴)`, so the even subsequence
+is the ζ(4) series scaled by `1/16`, giving `(1/16)·(π⁴/90) = π⁴/1440`. -/
+theorem hasSum_even_fourth : HasSum (fun k : ℕ => f (2 * k)) (π ^ 4 / 1440) := by
+  have h : HasSum (fun n : ℕ => (1 / 16 : ℝ) * f n) ((1 / 16) * (π ^ 4 / 90)) :=
+    zeta_four_hasSum.mul_left (1 / 16)
+  have hval : (1 / 16 : ℝ) * (π ^ 4 / 90) = π ^ 4 / 1440 := by ring
+  rw [hval] at h
+  refine h.congr_fun ?_
+  intro k
+  show f (2 * k) = (1 / 16 : ℝ) * f k
+  unfold f
+  push_cast
+  rw [show (2 * (k : ℝ)) ^ 4 = 16 * (k : ℝ) ^ 4 from by ring, one_div_mul_one_div]
+
+/-- The odd subsequence `k ↦ 1/(2k+1)⁴` is summable (a subseries of a summable
+series, via injective reindexing). -/
+theorem summable_odd_fourth : Summable (fun k : ℕ => f (2 * k + 1)) := by
+  have hi : Function.Injective (fun k : ℕ => 2 * k + 1) := by
+    intro a b hab
+    have hab' : 2 * a + 1 = 2 * b + 1 := hab
+    omega
+  exact zeta_four_hasSum.summable.comp_injective hi
+
+/-- **Sum of reciprocal odd fourth powers**: `∑_{k} 1/(2k+1)⁴ = π⁴/96`.
+
+The even part (π⁴/1440) plus the odd part recovers the full ζ(4) sum (π⁴/90),
+so the odd part equals `π⁴/90 − π⁴/1440 = π⁴/96`. -/
+theorem hasSum_odd_fourth : HasSum (fun k : ℕ => f (2 * k + 1)) (π ^ 4 / 96) := by
+  obtain ⟨b, hb⟩ := summable_odd_fourth
+  have hcombined : HasSum f (π ^ 4 / 1440 + b) := hasSum_even_fourth.even_add_odd hb
+  have heq : π ^ 4 / 90 = π ^ 4 / 1440 + b := zeta_four_hasSum.unique hcombined
+  have hb_val : b = π ^ 4 / 96 := by linarith
+  rwa [hb_val] at hb
+
+/-- **Main odd-fourth-power identity** in the natural `(2k+1 : ℝ)` form:
+`∑_{k=0}^∞ 1/(2k+1)⁴ = π⁴/96`. -/
+theorem odd_fourth_hasSum :
+    HasSum (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 4) (π ^ 4 / 96) := by
+  have h := hasSum_odd_fourth
+  refine h.congr_fun ?_
+  intro k
+  show 1 / (2 * (k : ℝ) + 1) ^ 4 = f (2 * k + 1)
+  unfold f
+  push_cast
+  ring
+
+/-- The `tsum` form of the odd-fourth-power identity: `∑' k, 1/(2k+1)⁴ = π⁴/96`. -/
+theorem odd_fourth_tsum :
+    ∑' k : ℕ, 1 / (2 * (k : ℝ) + 1) ^ 4 = π ^ 4 / 96 :=
+  odd_fourth_hasSum.tsum_eq
+
+/-- Consistency: even part + odd part = full ζ(4) sum. -/
+theorem even_add_odd_eq_zeta_four : π ^ 4 / 1440 + π ^ 4 / 96 = π ^ 4 / 90 := by
+  ring
+
+/-- Sanity check: the odd-fourth-power sum is positive. -/
+theorem odd_fourth_pos : (0 : ℝ) < π ^ 4 / 96 := by positivity
+
+end BaselProblemOQ06

--- a/src/data/proofs/basel-problem-oq-06/annotations.json
+++ b/src/data/proofs/basel-problem-oq-06/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-zeta-four-context",
+    "proofId": "basel-problem-oq-06",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "concept",
+    "title": "ζ(4) and Euler's Even-Argument Values",
+    "content": "Euler's 1735 solution of the Basel problem ($\\zeta(2)=\\pi^2/6$) generalizes to all even arguments: $\\zeta(2k)$ is a rational multiple of $\\pi^{2k}$, given by $\\zeta(2k)=(-1)^{k+1}B_{2k}(2\\pi)^{2k}/(2(2k)!)$. For $k=2$, $B_4=-1/30$ yields $\\zeta(4)=\\pi^4/90$. Mathlib records this as `hasSum_zeta_four` (real series) and `riemannZeta_four` (complex zeta). The odd values $\\zeta(3),\\zeta(5),\\dots$ have no known closed form, making the even values a special, fully-computable family.",
+    "mathContext": "$\\zeta(4)=\\sum_{n\\geq 1} 1/n^4 = \\pi^4/90$; general even formula via Bernoulli numbers, $B_4=-1/30$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Riemann zeta function", "Bernoulli numbers", "Basel problem", "even zeta values"],
+    "prerequisites": ["infinite series", "Riemann zeta function"]
+  },
+  {
+    "id": "ann-zeta-four-forms",
+    "proofId": "basel-problem-oq-06",
+    "range": { "startLine": 54, "endLine": 67 },
+    "type": "key-step",
+    "title": "ζ(4) = π⁴/90 in Three Equivalent Forms",
+    "content": "With the summand `f n = 1/n⁴`, the value is recorded as a `HasSum` (`zeta_four_hasSum := hasSum_zeta_four`), as a `tsum` (`zeta_four_tsum` via `HasSum.tsum_eq`), and as the value of the complex zeta function (`riemannZeta_four_value : riemannZeta 4 = (π:ℂ)^4/90`, from Mathlib's `riemannZeta_four`). Recording all three forms makes the entry usable both by real-analysis consumers (series) and by complex-analytic ones (`riemannZeta`).",
+    "mathContext": "$\\sum 1/n^4 = \\pi^4/90$ (real HasSum & tsum); $\\texttt{riemannZeta}\\,4 = \\pi^4/90$ (complex).",
+    "significance": "major",
+    "relatedConcepts": ["HasSum", "tsum", "riemannZeta"],
+    "prerequisites": ["HasSum.tsum_eq", "Riemann zeta special values"]
+  },
+  {
+    "id": "ann-even-fourth",
+    "proofId": "basel-problem-oq-06",
+    "range": { "startLine": 68, "endLine": 84 },
+    "type": "key-step",
+    "title": "Even Fourth Powers: the Series Scaled by 1/16",
+    "content": "`hasSum_even_fourth` shows $\\sum_k 1/(2k)^4 = \\pi^4/1440$. The key observation is $1/(2k)^4 = (1/16)\\cdot 1/k^4$, so the even subsequence is the ζ(4) series scaled by $1/16$ (`HasSum.mul_left`), giving $(1/16)(\\pi^4/90)=\\pi^4/1440$. The pointwise identity is closed with `one_div_mul_one_div` — which holds unconditionally, including the $k=0$ term where Lean's convention $1/0=0$ makes both sides vanish — rather than `field_simp`, which would demand $k\\neq 0$.",
+    "mathContext": "$1/(2k)^4=(1/16)/k^4 \\Rightarrow \\sum_k 1/(2k)^4=(1/16)\\zeta(4)=\\pi^4/1440$; $1/16=1/2^4$.",
+    "significance": "major",
+    "relatedConcepts": ["HasSum.mul_left", "one_div_mul_one_div", "subseries rescaling"],
+    "prerequisites": ["HasSum scaling", "the 1/0 = 0 convention"]
+  },
+  {
+    "id": "ann-odd-fourth",
+    "proofId": "basel-problem-oq-06",
+    "range": { "startLine": 85, "endLine": 121 },
+    "type": "key-step",
+    "title": "Odd Fourth Powers = π⁴/96 by Even/Odd Decomposition",
+    "content": "`hasSum_odd_fourth` proves $\\sum_k 1/(2k+1)^4=\\pi^4/96$. First `summable_odd_fourth` establishes summability by injective reindexing ($k\\mapsto 2k+1$) of the summable ζ(4) series. Then `HasSum.even_add_odd` reconstructs the whole series from its even and odd parts: $\\pi^4/1440 + b = \\pi^4/90$ where $b$ is the (a priori unknown) odd sum. `HasSum.unique` against the ζ(4) value forces $b = \\pi^4/90 - \\pi^4/1440 = \\pi^4/96$ (closed by `linarith`, treating $\\pi^4$ as an atom). `odd_fourth_hasSum` / `odd_fourth_tsum` restate the result in the natural $(2k+1:\\mathbb{R})$ form via `HasSum.congr_fun`.",
+    "mathContext": "$\\lambda(4)=\\sum 1/(2k+1)^4 = (1-1/16)\\zeta(4) = (15/16)(\\pi^4/90) = \\pi^4/96$.",
+    "significance": "critical",
+    "relatedConcepts": ["HasSum.even_add_odd", "HasSum.unique", "Summable.comp_injective", "Dirichlet lambda function"],
+    "prerequisites": ["even/odd series splitting", "uniqueness of infinite sums"]
+  },
+  {
+    "id": "ann-consistency",
+    "proofId": "basel-problem-oq-06",
+    "range": { "startLine": 122, "endLine": 128 },
+    "type": "observation",
+    "title": "Consistency and Positivity Checks",
+    "content": "`even_add_odd_eq_zeta_four` verifies the arithmetic $\\pi^4/1440 + \\pi^4/96 = \\pi^4/90$ (by `ring`), confirming the even and odd parts reconstitute ζ(4). `odd_fourth_pos` records that the odd-fourth-power sum is positive (by `positivity`). These are lightweight sanity checks certifying the derived constants are mutually consistent.",
+    "mathContext": "$\\pi^4/1440 + \\pi^4/96 = \\pi^4/90$; $\\pi^4/96 > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ring", "positivity", "consistency check"],
+    "prerequisites": ["field arithmetic"]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-06/meta.json
+++ b/src/data/proofs/basel-problem-oq-06/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "basel-problem-oq-06",
+  "title": "Riemann Zeta at Four: ζ(4) = π⁴/90",
+  "slug": "basel-problem-oq-06",
+  "description": "Euler's evaluation ζ(4) = ∑ 1/n⁴ = π⁴/90, the fourth-power companion of the Basel problem ζ(2)=π²/6, recorded both as a real series (HasSum/tsum) and as the complex value riemannZeta 4 = π⁴/90. Building on Mathlib's hasSum_zeta_four and riemannZeta_four, the entry derives — with 0 axioms and 0 sorries — the even/odd decomposition of the ζ(4) series: the sum of reciprocal even fourth powers ∑ 1/(2k)⁴ = π⁴/1440 (the series scaled by 1/16), and, by uniqueness of infinite sums, the sum of reciprocal odd fourth powers ∑ 1/(2k+1)⁴ = π⁴/96 (the value λ(4)). This mirrors the sibling ζ(2)→π²/8 odd-squares result at the fourth power.",
+  "meta": {
+    "author": "Leonhard Euler (1735/1741); Robb Walters (formalization)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Riemann_zeta_function",
+    "date": "1741",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ06.lean",
+    "tags": [
+      "analysis",
+      "number-theory",
+      "riemann-zeta",
+      "basel-problem",
+      "special-values",
+      "euler",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": [],
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      "hasSum_zeta_four",
+      "riemannZeta_four",
+      "HasSum.even_add_odd",
+      "HasSum.mul_left",
+      "HasSum.unique"
+    ],
+    "parentProof": "basel-problem",
+    "openQuestionType": "extension",
+    "openQuestionOf": "basel-problem",
+    "lineCount": 128,
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "In 1735 Euler solved the **Basel problem**, showing $\\sum_{n\\geq 1} 1/n^2 = \\pi^2/6$, and quickly extended his method to all even arguments: $\\zeta(2k)$ is a rational multiple of $\\pi^{2k}$. The next case, $\\zeta(4) = \\sum 1/n^4 = \\pi^4/90$, follows from the same product/partial-fraction machinery for $\\sin$, and in modern form from the Bernoulli-number formula $\\zeta(2k) = (-1)^{k+1} B_{2k} (2\\pi)^{2k} / (2\\,(2k)!)$ with $B_4 = -1/30$. In stark contrast, the odd values $\\zeta(3), \\zeta(5), \\dots$ have no known closed form ($\\zeta(3)$ is merely known to be irrational, by Apéry 1978). Mathlib formalizes the even-value formula and records $\\zeta(4) = \\pi^4/90$ explicitly as `hasSum_zeta_four` (real series) and `riemannZeta_four` (complex zeta).",
+    "problemStatement": "Formalize $\\zeta(4) = \\pi^4/90$ in Lean and extract its immediate structural consequences. Concretely: (1) state $\\sum_{n\\geq 1} 1/n^4 = \\pi^4/90$ as both a `HasSum` and a `tsum`, and record the complex identity $\\texttt{riemannZeta}\\,4 = \\pi^4/90$; (2) decompose the series into even- and odd-indexed subseries to obtain $\\sum_k 1/(2k)^4 = \\pi^4/1440$ and the odd-fourth-power value $\\sum_k 1/(2k+1)^4 = \\pi^4/96$.",
+    "proofStrategy": "The headline value is taken from Mathlib (`hasSum_zeta_four`, `riemannZeta_four`). The original content is the even/odd split, parallel to the ζ(2)→π²/8 sibling. The even subsequence satisfies $1/(2k)^4 = (1/16)\\cdot 1/k^4$, so it is the ζ(4) series scaled by $1/16$ (`HasSum.mul_left`), summing to $(1/16)(\\pi^4/90) = \\pi^4/1440$. The odd subsequence is summable (an injective reindexing of a summable series), and `HasSum.even_add_odd` reconstructs the whole series: $\\pi^4/1440 + (\\text{odd}) = \\pi^4/90$. Uniqueness of infinite sums (`HasSum.unique`) then pins the odd value at $\\pi^4/90 - \\pi^4/1440 = \\pi^4/96$. The pointwise scaling identity is discharged unconditionally with `one_div_mul_one_div` (valid even at the $k=0$ term where $1/0 = 0$).",
+    "keyInsights": [
+      "ζ(4) = π⁴/90 is the even-argument neighbour of the Basel problem: both are rational multiples of a power of π, unlike the odd values ζ(3), ζ(5), … which have no known closed form. Here $B_4 = -1/30$ yields the coefficient $1/90$.",
+      "The even-indexed subseries is a rescaled copy of the whole: $1/(2k)^4 = (1/16)/k^4$, so it sums to $(1/16)\\zeta(4) = \\pi^4/1440$. The factor $1/16 = 1/2^4$ is the fourth-power analogue of the $1/4$ that appears in the ζ(2) decomposition.",
+      "The odd value $\\lambda(4) = \\sum 1/(2k+1)^4 = \\pi^4/96$ is obtained purely by subtraction — $\\zeta(4) - 2^{-4}\\zeta(4) = (1 - 1/16)\\zeta(4) = (15/16)(\\pi^4/90) = \\pi^4/96$ — with no independent analysis, exactly mirroring $\\lambda(2) = \\pi^2/8$ for the squares.",
+      "The pointwise identity $1/(2k)^4 = (1/16)/k^4$ is proved with `one_div_mul_one_div` rather than `field_simp`, so it holds unconditionally including the $k=0$ term (where Lean's $1/0 = 0$ makes both sides $0$); this avoids any nonzero-denominator side condition.",
+      "The same `HasSum.even_add_odd` + `HasSum.unique` template that pins $\\lambda(2) = \\pi^2/8$ from ζ(2) transfers verbatim to the fourth power, indicating a general recipe: from any known $\\zeta(2m) = c\\,\\pi^{2m}$ one obtains $\\lambda(2m) = (1 - 4^{-m})\\,\\zeta(2m)$ mechanically."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Approach",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "States the goal ζ(4)=π⁴/90 and its fourth-power-companion status to the Basel problem, lists the original corollaries (even/odd fourth-power sums), and records the Mathlib dependencies (`hasSum_zeta_four`, `riemannZeta_four`, `HasSum.even_add_odd`)."
+    },
+    {
+      "id": "zeta-four-value",
+      "title": "ζ(4) = π⁴/90 in Three Forms",
+      "startLine": 54,
+      "endLine": 67,
+      "summary": "Defines the summand `f n = 1/n⁴` and records ζ(4) as a `HasSum` (`zeta_four_hasSum := hasSum_zeta_four`), as a `tsum` (`zeta_four_tsum`), and as the complex value (`riemannZeta_four_value : riemannZeta 4 = π⁴/90`)."
+    },
+    {
+      "id": "even-fourth",
+      "title": "Sum of Reciprocal Even Fourth Powers = π⁴/1440",
+      "startLine": 68,
+      "endLine": 84,
+      "summary": "`hasSum_even_fourth`: since $1/(2k)^4 = (1/16)/k^4$, the even subseries is the ζ(4) series scaled by $1/16$ (`HasSum.mul_left`), summing to $(1/16)(\\pi^4/90)=\\pi^4/1440$. The pointwise identity uses `one_div_mul_one_div` to stay valid at $k=0$."
+    },
+    {
+      "id": "odd-fourth",
+      "title": "Sum of Reciprocal Odd Fourth Powers = π⁴/96",
+      "startLine": 85,
+      "endLine": 121,
+      "summary": "`summable_odd_fourth` (injective reindexing), then `hasSum_odd_fourth`: `HasSum.even_add_odd` gives $\\pi^4/1440 + (\\text{odd}) = \\pi^4/90$, and `HasSum.unique` + `linarith` pin the odd sum at $\\pi^4/96$. `odd_fourth_hasSum` / `odd_fourth_tsum` restate it in the natural $(2k+1:\\mathbb{R})$ form."
+    },
+    {
+      "id": "consistency",
+      "title": "Consistency and Sanity Checks",
+      "startLine": 122,
+      "endLine": 128,
+      "summary": "`even_add_odd_eq_zeta_four`: π⁴/1440 + π⁴/96 = π⁴/90 (by `ring`); `odd_fourth_pos`: the odd-fourth sum is positive (by `positivity`)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes Euler's value ζ(4) = π⁴/90 in three equivalent forms and, with 0 axioms and 0 sorries, derives the even/odd decomposition of the series: ∑ 1/(2k)⁴ = π⁴/1440 and the odd-fourth-power value ∑ 1/(2k+1)⁴ = π⁴/96. It is the fourth-power analogue of the ζ(2) → π²/8 odd-squares entry, reusing the same `even_add_odd` + `unique` template.",
+    "implications": "The decomposition exhibits the general mechanism λ(2m) = (1 − 4⁻ᵐ)ζ(2m) relating the full even-zeta value to its odd-integer restriction, here yielding π⁴/96 = (15/16)(π⁴/90). Because ζ(4) is a rational multiple of π⁴ (via B₄ = −1/30), every derived constant is exactly computable — a sharp contrast with the odd zeta values ζ(3), ζ(5), … which resist closed evaluation and remain a central open theme in analytic number theory.",
+    "openQuestions": [
+      "Does the same even/odd template mechanically produce ζ(6) = π⁶/945 and λ(6) = ∑ 1/(2k+1)⁶, and can a single Lean lemma parameterize λ(2m) = (1−4⁻ᵐ)ζ(2m) over all m?",
+      "Can the Dirichlet eta value η(4) = ∑ (−1)ⁿ⁻¹/n⁴ = 7π⁴/720 be assembled from the even and odd subseries proved here (η(4) = λ(4) − ∑ 1/(2k)⁴ = π⁴/96 − π⁴/1440)?",
+      "Is there a Lean-formalizable elementary route to ζ(4) = π⁴/90 (e.g. via ∑ 1/n² squared and the Cauchy product, or Parseval on a Fourier series) that does not go through the general Bernoulli formula?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem",
+      "relationship": "extends",
+      "description": "Parent: the Basel problem ζ(2) = π²/6. This entry is the fourth-power companion, ζ(4) = π⁴/90, with the analogous even/odd series decomposition."
+    },
+    {
+      "targetId": "basel-problem-oq-06-oq-01",
+      "relationship": "related",
+      "description": "Sibling technique: derives ∑ 1/(2k+1)² = π²/8 from ζ(2) by the same even/odd `HasSum` decomposition used here at the fourth power."
+    }
+  ],
+  "leanFile": {
+    "axiomCount": 0,
+    "lineCount": 128,
+    "path": "Proofs/BaselProblemOQ06.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 10
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry `basel-problem-oq-06` formalizing **Euler's ζ(4) = ∑ 1/n⁴ = π⁴/90** — the fourth-power companion of the Basel problem — and deriving its even/odd series decomposition. **Verified, 0 axioms, 0 sorries** (10 theorems / 1 def / 128 lines).

The slug `basel-problem-oq-06` previously had a child (`-oq-01`) but no entry or Lean file of its own — this fills that gap.

## What is proved

**ζ(4) in three forms** (anchored on Mathlib):
- `zeta_four_hasSum` — `HasSum (1/n⁴) (π⁴/90)` (= `hasSum_zeta_four`)
- `zeta_four_tsum` — `∑' n, 1/n⁴ = π⁴/90`
- `riemannZeta_four_value` — `riemannZeta 4 = π⁴/90` (= `riemannZeta_four`)

**Original corollaries** (not in Mathlib), via the same `HasSum.even_add_odd` + `HasSum.unique` template as the sibling ζ(2)→π²/8 entry:
- `hasSum_even_fourth` — `∑ 1/(2k)⁴ = π⁴/1440` (the ζ(4) series scaled by 1/16)
- `hasSum_odd_fourth` — `∑ 1/(2k+1)⁴ = π⁴/96` (the odd value λ(4) = (1−1/16)ζ(4))
- `odd_fourth_hasSum` / `odd_fourth_tsum` — natural `(2k+1:ℝ)` form
- consistency (`π⁴/1440 + π⁴/96 = π⁴/90`) and positivity checks

## Verification

- Canonical `./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ06` → **Build completed successfully (3271 jobs), exit 0**.
- No `sorry`, no `native_decide`, no `axiom`; every theorem is a Mathlib re-export or an elementary `ring`/`omega`/`linarith`/`positivity`/`HasSum`-lemma derivation → **0 real axioms**. Same status basis as the verified sibling `basel-problem-oq-06-oq-01`.

## Files
- `proofs/Proofs/BaselProblemOQ06.lean`
- `src/data/proofs/basel-problem-oq-06/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)